### PR TITLE
fix: replace hardcoded XMPP domains with ConfigMap refs

### DIFF
--- a/k3d/jitsi-jicofo.yaml
+++ b/k3d/jitsi-jicofo.yaml
@@ -25,10 +25,15 @@ spec:
                 configMapKeyRef:
                   name: domain-config
                   key: JITSI_DOMAIN
+            - name: JITSI_XMPP_SUFFIX
+              valueFrom:
+                configMapKeyRef:
+                  name: domain-config
+                  key: JITSI_XMPP_SUFFIX
             - name: XMPP_AUTH_DOMAIN
-              value: "auth.meet.meet.localhost"
+              value: "auth.meet.$(JITSI_XMPP_SUFFIX)"
             - name: XMPP_INTERNAL_MUC_DOMAIN
-              value: "internal-muc.meet.meet.localhost"
+              value: "internal-muc.meet.$(JITSI_XMPP_SUFFIX)"
             - name: JICOFO_AUTH_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/k3d/jitsi-jvb.yaml
+++ b/k3d/jitsi-jvb.yaml
@@ -25,10 +25,15 @@ spec:
                 configMapKeyRef:
                   name: domain-config
                   key: JITSI_DOMAIN
+            - name: JITSI_XMPP_SUFFIX
+              valueFrom:
+                configMapKeyRef:
+                  name: domain-config
+                  key: JITSI_XMPP_SUFFIX
             - name: XMPP_AUTH_DOMAIN
-              value: "auth.meet.meet.localhost"
+              value: "auth.meet.$(JITSI_XMPP_SUFFIX)"
             - name: XMPP_INTERNAL_MUC_DOMAIN
-              value: "internal-muc.meet.meet.localhost"
+              value: "internal-muc.meet.$(JITSI_XMPP_SUFFIX)"
             - name: JVB_AUTH_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/k3d/jitsi-keycloak-adapter.yaml
+++ b/k3d/jitsi-keycloak-adapter.yaml
@@ -18,9 +18,14 @@ spec:
         - name: adapter
           image: ghcr.io/nordeck/jitsi-keycloak-adapter-v2:latest
           env:
+            - name: KC_DOMAIN
+              valueFrom:
+                configMapKeyRef:
+                  name: domain-config
+                  key: KC_DOMAIN
             # Browser-seitige Keycloak-URL (extern)
             - name: KEYCLOAK_ORIGIN
-              value: "http://auth.localhost"
+              value: "http://$(KC_DOMAIN)"
             # Server-seitige Keycloak-URL (intern)
             - name: KEYCLOAK_ORIGIN_INTERNAL
               value: "http://keycloak:8080"

--- a/k3d/jitsi-prosody.yaml
+++ b/k3d/jitsi-prosody.yaml
@@ -23,12 +23,17 @@ spec:
                 configMapKeyRef:
                   name: domain-config
                   key: JITSI_DOMAIN
+            - name: JITSI_XMPP_SUFFIX
+              valueFrom:
+                configMapKeyRef:
+                  name: domain-config
+                  key: JITSI_XMPP_SUFFIX
             - name: XMPP_AUTH_DOMAIN
-              value: "auth.meet.meet.localhost"
+              value: "auth.meet.$(JITSI_XMPP_SUFFIX)"
             - name: XMPP_MUC_DOMAIN
-              value: "muc.meet.meet.localhost"
+              value: "muc.meet.$(JITSI_XMPP_SUFFIX)"
             - name: XMPP_INTERNAL_MUC_DOMAIN
-              value: "internal-muc.meet.meet.localhost"
+              value: "internal-muc.meet.$(JITSI_XMPP_SUFFIX)"
             - name: JICOFO_AUTH_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/k3d/jitsi-web.yaml
+++ b/k3d/jitsi-web.yaml
@@ -18,19 +18,26 @@ spec:
         - name: web
           image: jitsi/web:stable-9111
           env:
-            - name: PUBLIC_URL
-              value: "http://meet.localhost"
-            - name: XMPP_DOMAIN
+            - name: JITSI_DOMAIN
               valueFrom:
                 configMapKeyRef:
                   name: domain-config
                   key: JITSI_DOMAIN
+            - name: JITSI_XMPP_SUFFIX
+              valueFrom:
+                configMapKeyRef:
+                  name: domain-config
+                  key: JITSI_XMPP_SUFFIX
+            - name: PUBLIC_URL
+              value: "http://$(JITSI_DOMAIN)"
+            - name: XMPP_DOMAIN
+              value: "$(JITSI_DOMAIN)"
             - name: XMPP_AUTH_DOMAIN
-              value: "auth.meet.meet.localhost"
+              value: "auth.meet.$(JITSI_XMPP_SUFFIX)"
             - name: XMPP_BOSH_URL_BASE
               value: "http://prosody:5280"
             - name: XMPP_MUC_DOMAIN
-              value: "muc.meet.meet.localhost"
+              value: "muc.meet.$(JITSI_XMPP_SUFFIX)"
             - name: ENABLE_AUTH
               value: "1"
             - name: AUTH_TYPE
@@ -48,7 +55,7 @@ spec:
               value: jitsi
             # TOKEN_AUTH_URL: Leitet nicht-authentifizierte Nutzer zum OIDC-Adapter
             - name: TOKEN_AUTH_URL
-              value: "http://meet.localhost/oidc/auth?state={state}"
+              value: "http://$(JITSI_DOMAIN)/oidc/auth?state={state}"
             - name: ENABLE_GUESTS
               value: "1"
             - name: ENABLE_AUTO_LOGIN


### PR DESCRIPTION
## Summary

All Jitsi K8s manifests had XMPP sub-domains (auth, muc, internal-muc) hardcoded as `*.meet.meet.localhost` instead of reading from the `domain-config` ConfigMap. This would break any non-localhost deployment (e.g. production with DuckDNS domains). Now all values are dynamically constructed using Kubernetes `$(VAR)` env var interpolation from `JITSI_XMPP_SUFFIX`.

Also fixes hardcoded `PUBLIC_URL`, `TOKEN_AUTH_URL` (jitsi-web), and `KEYCLOAK_ORIGIN` (jitsi-keycloak-adapter).

## Type of Change

- [ ] Feature (`feature/*` branch)
- [x] Bug fix (`fix/*` branch)
- [ ] Refactor / chore (`chore/*` branch)
- [ ] Documentation
- [x] Infrastructure / k8s manifests

## Checklist

### Required for all PRs
- [x] Branch follows naming convention (`feature/`, `fix/`, `chore/`)
- [x] Changes are scoped to a single concern
- [x] No secrets or credentials committed (dev secrets in `k3d/secrets.yaml` are OK)

### If modifying Kubernetes manifests (`k3d/`)
- [x] `kubectl kustomize k3d/` succeeds locally
- [ ] Deployed to local k3d cluster and verified (`task homeoffice:deploy`)
- [x] Resource requests/limits are set for new containers
- [x] Health probes configured for new services

### If modifying authentication (Keycloak / OIDC)
- [x] `realm-homeoffice.json` and `k3d/realm-homeoffice-dev.json` are in sync
- [ ] SSO login tested for all affected services

## Requirements Traceability

- [x] **Checked** whether a matching requirement entry exists

**Requirement ID:** N/A — this is a correctness fix for existing infrastructure, not a new requirement.

## Test Plan

**Tests implemented:**
- [ ] Verify `kubectl kustomize k3d/` renders correct XMPP domain values
- [ ] Deploy to k3d and confirm Jitsi video calls work with OIDC auth
- [ ] Verify all 4 Jitsi pods start without XMPP connection errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)