### PR TITLE
fix: replace kubectl dry-run with kubeconform in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,15 +16,23 @@ jobs:
       - name: Install kubectl
         uses: azure/setup-kubectl@v4
 
+      - name: Install kubeconform
+        run: |
+          curl -sSL https://github.com/yannh/kubeconform/releases/latest/download/kubeconform-linux-amd64.tar.gz \
+            | sudo tar xz -C /usr/local/bin kubeconform
+
       - name: Validate kustomize output
         run: |
           kubectl kustomize k3d/ > /dev/null
           echo "Kustomize build succeeded"
 
-      - name: Dry-run apply
+      - name: Validate manifests with kubeconform
         run: |
-          kubectl kustomize k3d/ | kubectl apply --dry-run=client -f - 2>&1
-          echo "Dry-run apply passed"
+          kubectl kustomize k3d/ | kubeconform -strict -summary \
+            -kubernetes-version 1.31.0 \
+            -schema-location default \
+            -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json'
+          echo "Manifest validation passed"
 
   lint-yaml:
     name: Lint YAML


### PR DESCRIPTION
## Summary

The CI "Validate Kubernetes Manifests" job always failed because `kubectl apply --dry-run=client` needs a running K8s API server to download the OpenAPI schema — which GitHub Actions runners don't have. This also caused the `test-configs` job to be permanently skipped (it had `needs: [validate-manifests]`).

Replaced with [kubeconform](https://github.com/yannh/kubeconform) — a standalone manifest validator that downloads K8s JSON schemas and validates offline. Configured for K8s 1.31.0 (matching our k3d cluster version) with CRD schema support.

## Type of Change

- [ ] Feature (`feature/*` branch)
- [x] Bug fix (`fix/*` branch)
- [ ] Refactor / chore (`chore/*` branch)
- [ ] Documentation
- [x] Infrastructure / k8s manifests

## Checklist

### Required for all PRs
- [x] Branch follows naming convention (`feature/`, `fix/`, `chore/`)
- [x] Changes are scoped to a single concern
- [x] No secrets or credentials committed

## Requirements Traceability

- [x] **Checked** whether a matching requirement entry exists

**Requirement ID:** N/A — CI infrastructure fix, not a functional requirement.

## Test Plan

- [ ] CI pipeline runs on this PR and the validate-manifests job passes
- [ ] test-configs job is no longer skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)