### PR TITLE
fix(hpb,keycloak): public TURN+SFU stack and complete realm import

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -540,7 +540,9 @@ tasks:
             {\"op\":\"add\",\"path\":\"/metadata/annotations/workspace-email\",\"value\":\"${CONTACT_EMAIL}\"},
             {\"op\":\"add\",\"path\":\"/metadata/annotations/workspace-infra-namespace\",\"value\":\"workspace-infra\"},
             {\"op\":\"add\",\"path\":\"/metadata/annotations/workspace-tls-secret\",\"value\":\"workspace-wildcard-tls\"},
-            {\"op\":\"add\",\"path\":\"/metadata/annotations/workspace-smtp-from\",\"value\":\"${SMTP_FROM}\"}
+            {\"op\":\"add\",\"path\":\"/metadata/annotations/workspace-smtp-from\",\"value\":\"${SMTP_FROM}\"},
+            {\"op\":\"add\",\"path\":\"/metadata/annotations/workspace-turn-ip\",\"value\":\"${TURN_PUBLIC_IP}\"},
+            {\"op\":\"add\",\"path\":\"/metadata/annotations/workspace-turn-node\",\"value\":\"${TURN_NODE}\"}
           ]" 2>/dev/null || echo "  (patch skipped — annotations may already exist)"
           echo "  ✓ hetzner registered and annotated"
         else
@@ -564,7 +566,9 @@ tasks:
             {\"op\":\"add\",\"path\":\"/metadata/annotations/workspace-email\",\"value\":\"${CONTACT_EMAIL}\"},
             {\"op\":\"add\",\"path\":\"/metadata/annotations/workspace-infra-namespace\",\"value\":\"workspace-infra\"},
             {\"op\":\"add\",\"path\":\"/metadata/annotations/workspace-tls-secret\",\"value\":\"workspace-wildcard-tls\"},
-            {\"op\":\"add\",\"path\":\"/metadata/annotations/workspace-smtp-from\",\"value\":\"${SMTP_FROM}\"}
+            {\"op\":\"add\",\"path\":\"/metadata/annotations/workspace-smtp-from\",\"value\":\"${SMTP_FROM}\"},
+            {\"op\":\"add\",\"path\":\"/metadata/annotations/workspace-turn-ip\",\"value\":\"${TURN_PUBLIC_IP}\"},
+            {\"op\":\"add\",\"path\":\"/metadata/annotations/workspace-turn-node\",\"value\":\"${TURN_NODE}\"}
           ]" 2>/dev/null || echo "  (patch skipped — annotations may already exist)"
           echo "  ✓ korczewski registered and annotated"
         else
@@ -584,6 +588,7 @@ tasks:
     cmds:
       - kubectl --context mentolder apply -f argocd/project.yaml
       - kubectl --context mentolder apply -f argocd/applicationset.yaml
+      - kubectl --context mentolder apply -f argocd/applicationset-coturn.yaml
       - echo ""
       - echo "✓ AppProject 'workspace' and ApplicationSet applied"
       - |

--- a/argocd/applicationset-coturn.yaml
+++ b/argocd/applicationset-coturn.yaml
@@ -1,0 +1,57 @@
+# Separate ApplicationSet for the coturn-stack (TURN + Janus SFU).
+#
+# Lives in its own ArgoCD Application because the coturn-stack manifests
+# install into the privileged `coturn` namespace, which is incompatible
+# with the workspace AppSet's `namespace: workspace` kustomize directive
+# (the namespace transformer would rename the cluster-scoped Namespace
+# resource and produce a name conflict).
+#
+# Cluster targeting and per-cluster substitutions reuse the same
+# annotations as the main `workspace` ApplicationSet.
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: workspace-coturn
+  namespace: argocd
+spec:
+  generators:
+    - clusters:
+        selector:
+          matchLabels:
+            workspace: "true"
+
+  template:
+    metadata:
+      name: "workspace-coturn-{{name}}"
+      annotations:
+        argocd.argoproj.io/sync-wave: "0"
+    spec:
+      project: workspace
+
+      source:
+        repoURL: https://github.com/Paddione/Bachelorprojekt
+        targetRevision: main
+        path: k3d/coturn-stack
+
+        plugin:
+          name: kustomize-envsubst
+          env:
+            - name: PROD_DOMAIN
+              value: "{{metadata.annotations.workspace-domain}}"
+            - name: TURN_PUBLIC_IP
+              value: "{{metadata.annotations.workspace-turn-ip}}"
+            - name: TURN_NODE
+              value: "{{metadata.annotations.workspace-turn-node}}"
+
+      destination:
+        server: "{{server}}"
+        namespace: coturn
+
+      syncPolicy:
+        automated:
+          prune: false
+          selfHeal: true
+        syncOptions:
+          - CreateNamespace=true
+          - ServerSideApply=true
+          - RespectIgnoreDifferences=true

--- a/argocd/applicationset.yaml
+++ b/argocd/applicationset.yaml
@@ -60,6 +60,10 @@ spec:
               value: "{{metadata.annotations.workspace-tls-secret}}"
             - name: SMTP_FROM
               value: "{{metadata.annotations.workspace-smtp-from}}"
+            - name: TURN_PUBLIC_IP
+              value: "{{metadata.annotations.workspace-turn-ip}}"
+            - name: TURN_NODE
+              value: "{{metadata.annotations.workspace-turn-node}}"
 
       destination:
         server: "{{server}}"

--- a/argocd/project.yaml
+++ b/argocd/project.yaml
@@ -16,6 +16,8 @@ spec:
   destinations:
     - namespace: workspace
       server: "*"
+    - namespace: coturn
+      server: "*"
     - namespace: website
       server: "*"
     - namespace: monitoring

--- a/environments/korczewski.yaml
+++ b/environments/korczewski.yaml
@@ -20,6 +20,8 @@ env_vars:
   INFRA_NAMESPACE: korczewski-infra
   TLS_SECRET_NAME: korczewski-tls
   SMTP_FROM: korczewski@mailbox.org
+  TURN_PUBLIC_IP: "62.238.9.39"
+  TURN_NODE: "pk-hetzner"
 
 overlay: prod-korczewski
 secrets_ref: sealed-secrets/korczewski.yaml

--- a/environments/mentolder.yaml
+++ b/environments/mentolder.yaml
@@ -20,6 +20,8 @@ env_vars:
   INFRA_NAMESPACE: mentolder-infra
   TLS_SECRET_NAME: mentolder-tls
   SMTP_FROM: mentolder@mailbox.org
+  TURN_PUBLIC_IP: "178.104.169.206"
+  TURN_NODE: "gekko-hetzner-2"
 
 overlay: prod
 secrets_ref: sealed-secrets/mentolder.yaml

--- a/environments/schema.yaml
+++ b/environments/schema.yaml
@@ -70,6 +70,14 @@ env_vars:
     required: true
     default_dev: "noreply@localhost"
 
+  - name: TURN_PUBLIC_IP
+    required: true
+    default_dev: "127.0.0.1"
+
+  - name: TURN_NODE
+    required: true
+    default_dev: "k3d-dev-server-0"
+
 secrets:
   - name: SHARED_DB_PASSWORD
     required: true

--- a/k3d/coturn-stack/coturn.yaml
+++ b/k3d/coturn-stack/coturn.yaml
@@ -1,10 +1,19 @@
 # ═══════════════════════════════════════════════════════════════════
 # coturn — TURN/STUN server for NAT traversal
 # ═══════════════════════════════════════════════════════════════════
+# Runs on hostNetwork on a single public node so that browsers can
+# reach it directly via UDP. Uses the REST API auth mechanism
+# (Nextcloud Talk's preferred method).
+#
+# Required environment substitutions (kustomize-envsubst):
+#   ${TURN_NODE}      — kubernetes.io/hostname of the public node
+#   ${TURN_PUBLIC_IP} — public IP of that node (used as external-ip)
+#   ${PROD_DOMAIN}    — used for the realm (turn.${PROD_DOMAIN})
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: coturn
+  namespace: coturn
   labels:
     app: coturn
 spec:
@@ -12,11 +21,17 @@ spec:
   selector:
     matchLabels:
       app: coturn
+  strategy:
+    type: Recreate
   template:
     metadata:
       labels:
         app: coturn
     spec:
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      nodeSelector:
+        kubernetes.io/hostname: ${TURN_NODE}
       containers:
         - name: coturn
           image: coturn/coturn:4.9-alpine
@@ -24,38 +39,30 @@ spec:
             - "--no-tls"
             - "--no-dtls"
             - "--listening-port=3478"
-            - "--realm=workspace.local"
-            - "--user=talk:devturnpassword1234"
-            - "--lt-cred-mech"
+            - "--min-port=49152"
+            - "--max-port=49252"
+            - "--realm=turn.${PROD_DOMAIN}"
+            - "--use-auth-secret"
+            - "--static-auth-secret=devturnpassword1234"
+            - "--external-ip=${TURN_PUBLIC_IP}"
+            - "--listening-ip=0.0.0.0"
+            - "--no-multicast-peers"
+            - "--no-cli"
             - "--fingerprint"
             - "--log-file=stdout"
             - "--no-stdout-log"
             - "--simple-log"
           ports:
             - containerPort: 3478
+              hostPort: 3478
               protocol: TCP
             - containerPort: 3478
+              hostPort: 3478
               protocol: UDP
           resources:
             requests:
-              memory: 32Mi
-              cpu: 50m
+              memory: 64Mi
+              cpu: "100m"
             limits:
-              memory: 128Mi
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: coturn
-spec:
-  selector:
-    app: coturn
-  ports:
-    - name: turn-tcp
-      port: 3478
-      targetPort: 3478
-      protocol: TCP
-    - name: turn-udp
-      port: 3478
-      targetPort: 3478
-      protocol: UDP
+              memory: 256Mi
+              cpu: "500m"

--- a/k3d/coturn-stack/janus.yaml
+++ b/k3d/coturn-stack/janus.yaml
@@ -1,0 +1,116 @@
+# ═══════════════════════════════════════════════════════════════════
+# Janus WebRTC Gateway (SFU) — Nextcloud Talk High-Performance Backend
+# ═══════════════════════════════════════════════════════════════════
+# Runs on hostNetwork, pinned to the same public node as coturn so the
+# RTP/RTCP UDP range and the WS admin port land directly on a routable
+# IP. Uses ICE-Lite + nat_1_1_mapping to advertise that public IP in
+# the candidates it returns to clients via spreed-signaling.
+#
+# Required environment substitutions (kustomize-envsubst):
+#   ${TURN_NODE}      — kubernetes.io/hostname of the public node
+#   ${TURN_PUBLIC_IP} — public IP of that node (for nat_1_1_mapping)
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: janus-config
+  namespace: coturn
+data:
+  janus.jcfg: |
+    general: {
+      configs_folder = "/etc/janus"
+      log_to_stdout = true
+      debug_level = 4
+      admin_secret = "devjanusadmin"
+    }
+    nat: {
+      nice_debug = false
+      full_trickle = true
+      ice_lite = true
+      nat_1_1_mapping = "${TURN_PUBLIC_IP}"
+      keep_private_host = false
+    }
+    media: {
+      rtp_port_range = "20000-20200"
+    }
+    transports: {
+      disable = "libjanus_transport.so"
+    }
+  janus.transport.websockets.jcfg: |
+    general: {
+      ws = true
+      ws_port = 8188
+      ws_logging = "err,warn"
+    }
+  janus.plugin.videoroom.jcfg: |
+    general: {
+      admin_key = "devvideoroomadmin"
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: janus
+  namespace: coturn
+  labels:
+    app: janus
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: janus
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: janus
+    spec:
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      nodeSelector:
+        kubernetes.io/hostname: ${TURN_NODE}
+      containers:
+        - name: janus
+          image: canyan/janus-gateway:master_cefca79700bdadd32d759ce65ba3805552a4d312
+          ports:
+            - containerPort: 8188
+              hostPort: 8188
+              name: ws
+              protocol: TCP
+          volumeMounts:
+            - name: config
+              mountPath: /etc/janus/janus.jcfg
+              subPath: janus.jcfg
+            - name: config
+              mountPath: /etc/janus/janus.transport.websockets.jcfg
+              subPath: janus.transport.websockets.jcfg
+            - name: config
+              mountPath: /etc/janus/janus.plugin.videoroom.jcfg
+              subPath: janus.plugin.videoroom.jcfg
+          resources:
+            requests:
+              memory: 128Mi
+              cpu: "100m"
+            limits:
+              memory: 512Mi
+              cpu: "1"
+      volumes:
+        - name: config
+          configMap:
+            name: janus-config
+---
+# Cross-namespace service so spreed-signaling can reach Janus as
+# `janus.coturn:8188` from the workspace namespace. Endpoints will
+# resolve to the host network pod IP (== TURN_PUBLIC_IP).
+apiVersion: v1
+kind: Service
+metadata:
+  name: janus
+  namespace: coturn
+spec:
+  selector:
+    app: janus
+  ports:
+    - port: 8188
+      targetPort: 8188
+      name: ws

--- a/k3d/coturn-stack/kustomization.yaml
+++ b/k3d/coturn-stack/kustomization.yaml
@@ -1,0 +1,15 @@
+# ═══════════════════════════════════════════════════════════════════
+# coturn-stack — TURN/STUN + Janus SFU in dedicated privileged ns
+# ═══════════════════════════════════════════════════════════════════
+# Lives in its own namespace `coturn` because both pods need
+# hostNetwork + hostPort, which violate the workspace namespace's
+# baseline PodSecurity policy. Pinned to a single public node via
+# the ${TURN_NODE} envsubst variable so RTP/ICE traffic lands on a
+# routable IP.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - namespace.yaml
+  - coturn.yaml
+  - janus.yaml

--- a/k3d/coturn-stack/namespace.yaml
+++ b/k3d/coturn-stack/namespace.yaml
@@ -1,0 +1,15 @@
+# ═══════════════════════════════════════════════════════════════════
+# coturn namespace — privileged PSA for hostNetwork TURN/SFU pods
+# ═══════════════════════════════════════════════════════════════════
+# coturn and janus need hostNetwork + hostPort, which are forbidden
+# under the baseline PSA enforced on the workspace namespace.
+# Isolating them in a dedicated privileged namespace keeps the
+# privilege escalation surface minimal.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: coturn
+  labels:
+    app.kubernetes.io/part-of: workspace-mvp
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/warn: privileged

--- a/k3d/kustomization.yaml
+++ b/k3d/kustomization.yaml
@@ -16,8 +16,11 @@ resources:
   - mattermost-hpa.yaml
   - nextcloud.yaml
   # Nextcloud Talk HPB + Collabora + Whiteboard
+  # NB: coturn + janus live in their own ArgoCD Application
+  # (k3d/coturn-stack) because they need a dedicated privileged
+  # namespace and can't be transformed by this kustomization's
+  # `namespace: workspace` directive.
   - talk-hpb.yaml
-  - coturn.yaml
   - collabora.yaml
   - whiteboard.yaml
   - talk-recording.yaml

--- a/k3d/talk-hpb.yaml
+++ b/k3d/talk-hpb.yaml
@@ -1,8 +1,9 @@
 # ═══════════════════════════════════════════════════════════════════
 # Nextcloud Talk — High Performance Backend (HPB)
 # ═══════════════════════════════════════════════════════════════════
-# Components: NATS (message bus), Janus (WebRTC SFU),
-#             spreed-signaling (coordination)
+# Components: NATS (message bus), spreed-signaling (coordination)
+# Janus (the SFU) lives in k3d/janus.yaml inside the privileged
+# `coturn` namespace because it requires hostNetwork.
 # ═══════════════════════════════════════════════════════════════════
 
 # ── NATS (internal message bus) ─────────────────────────────────
@@ -29,10 +30,11 @@ spec:
             - containerPort: 4222
           resources:
             requests:
-              memory: 32Mi
-              cpu: 50m
+              memory: 64Mi
+              cpu: "100m"
             limits:
-              memory: 128Mi
+              memory: 256Mi
+              cpu: "500m"
 ---
 apiVersion: v1
 kind: Service
@@ -46,105 +48,9 @@ spec:
       targetPort: 4222
 
 ---
-# ── Janus WebRTC Gateway (SFU) ──────────────────────────────────
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: janus-config
-data:
-  janus.jcfg: |
-    general: {
-      configs_folder = "/etc/janus"
-      log_to_stdout = true
-      debug_level = 4
-      admin_secret = "devjanusadmin"
-    }
-    nat: {
-      nice_debug = false
-      full_trickle = true
-      ice_lite = true
-      stun_server = "coturn"
-      stun_port = 3478
-      turn_server = "coturn"
-      turn_port = 3478
-      turn_type = "udp"
-      turn_user = "talk"
-      turn_pwd = "devturnpassword1234"
-    }
-    media: {
-      rtp_port_range = "20000-40000"
-    }
-    transports: {
-      disable = "libjanus_transport.so"
-    }
-  janus.transport.websockets.jcfg: |
-    general: {
-      ws = true
-      ws_port = 8188
-      ws_logging = "err,warn"
-    }
-  janus.plugin.videoroom.jcfg: |
-    general: {
-      admin_key = "devvideoroomadmin"
-    }
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: janus
-  labels:
-    app: janus
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: janus
-  template:
-    metadata:
-      labels:
-        app: janus
-    spec:
-      containers:
-        - name: janus
-          image: canyan/janus-gateway:master_cefca79700bdadd32d759ce65ba3805552a4d312
-          ports:
-            - containerPort: 8188
-              name: ws
-          volumeMounts:
-            - name: config
-              mountPath: /etc/janus/janus.jcfg
-              subPath: janus.jcfg
-            - name: config
-              mountPath: /etc/janus/janus.transport.websockets.jcfg
-              subPath: janus.transport.websockets.jcfg
-            - name: config
-              mountPath: /etc/janus/janus.plugin.videoroom.jcfg
-              subPath: janus.plugin.videoroom.jcfg
-          resources:
-            requests:
-              memory: 128Mi
-              cpu: 200m
-            limits:
-              memory: 512Mi
-      volumes:
-        - name: config
-          configMap:
-            name: janus-config
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: janus
-spec:
-  selector:
-    app: janus
-  ports:
-    - port: 8188
-      targetPort: 8188
-      name: ws
-
----
 # ── spreed-signaling (HPB coordination) ─────────────────────────
+# Required environment substitutions (kustomize-envsubst):
+#   ${PROD_DOMAIN} — backend URL + TURN hostname (turn.${PROD_DOMAIN})
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -171,7 +77,7 @@ data:
     connectionsperhost = 8
 
     [backend-1]
-    url = http://nextcloud:80
+    url = https://files.${PROD_DOMAIN}
     secret = devsignalingsecret1234567890abcdef
     maxstreambitrate = 0
     maxscreenbitrate = 0
@@ -181,12 +87,12 @@ data:
 
     [mcu]
     type = janus
-    url = ws://janus:8188
+    url = ws://janus.coturn:8188
 
     [turn]
     apikey = devturnapikey1234567890
     secret = devturnpassword1234
-    servers = turn:coturn:3478?transport=udp,turn:coturn:3478?transport=tcp
+    servers = turn:turn.${PROD_DOMAIN}:3478?transport=udp,turn:turn.${PROD_DOMAIN}:3478?transport=tcp
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -225,10 +131,11 @@ spec:
             periodSeconds: 10
           resources:
             requests:
-              memory: 64Mi
-              cpu: 100m
+              memory: 128Mi
+              cpu: "200m"
             limits:
-              memory: 256Mi
+              memory: 512Mi
+              cpu: "1"
       volumes:
         - name: config
           configMap:

--- a/prod/import-entrypoint.sh
+++ b/prod/import-entrypoint.sh
@@ -2,7 +2,12 @@
 # Substituiert Umgebungsvariablen in realm-workspace.json
 # und startet Keycloak mit --import-realm
 #
-# Production-Variante: substituiert auch SMTP_PASSWORD
+# Production-Variante: substituiert alle ${VAR} Platzhalter, die das
+# Realm-Template referenziert. Die Liste muss vollständig sein, weil
+# kc.sh start --import-realm den Realm nur beim ersten Start einliest.
+# Wenn hier eine Variable fehlt, landet ihr literaler ${VAR}-String in
+# der KC-Datenbank und Auth-Flows scheitern später mit
+# "Invalid client credentials".
 set -e
 
 TEMPLATE="/opt/keycloak/realm-template/realm-workspace.json"
@@ -12,8 +17,21 @@ mkdir -p "$(dirname "$OUTPUT")"
 
 # Alle ${VAR} Referenzen im JSON durch aktuelle Env-Werte ersetzen (sed-basiert)
 cp "$TEMPLATE" "$OUTPUT"
-for var in MATTERMOST_OIDC_SECRET NEXTCLOUD_OIDC_SECRET \
-           MM_DOMAIN NC_DOMAIN SMTP_PASSWORD; do
+for var in \
+    MATTERMOST_OIDC_SECRET \
+    NEXTCLOUD_OIDC_SECRET \
+    INVOICENINJA_OIDC_SECRET \
+    VAULTWARDEN_OIDC_SECRET \
+    CLAUDE_CODE_OIDC_SECRET \
+    WEBSITE_OIDC_SECRET \
+    OUTLINE_OIDC_SECRET \
+    MM_DOMAIN \
+    NC_DOMAIN \
+    BILLING_DOMAIN \
+    VAULT_DOMAIN \
+    AI_DOMAIN \
+    WEB_DOMAIN \
+    PROD_DOMAIN; do
   eval val="\${${var}:-}"
   if [ -z "$val" ]; then
     echo "[import-entrypoint] WARNUNG: ${var} ist nicht gesetzt!"
@@ -21,6 +39,13 @@ for var in MATTERMOST_OIDC_SECRET NEXTCLOUD_OIDC_SECRET \
     sed -i "s|\${${var}}|${val}|g" "$OUTPUT"
   fi
 done
+
+# Sanity check: keine unaufgelösten ${...} Platzhalter mehr im Output
+if grep -q '\${[A-Z_]*}' "$OUTPUT"; then
+  echo "[import-entrypoint] FEHLER: Unaufgelöste Platzhalter im Realm-JSON:" >&2
+  grep -o '\${[A-Z_]*}' "$OUTPUT" | sort -u >&2
+  exit 1
+fi
 
 echo "[import-entrypoint] Realm JSON generiert: $OUTPUT"
 

--- a/prod/patch-amd64-only.yaml
+++ b/prod/patch-amd64-only.yaml
@@ -1,16 +1,7 @@
 # Pin amd64-only images to amd64 nodes.
-# janus-gateway has no arm64 build.
 # faster-whisper-server has no arm64 build for CPU variant.
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: janus
-spec:
-  template:
-    spec:
-      nodeSelector:
-        kubernetes.io/arch: amd64
+# (janus is also amd64-only but it's pinned via nodeSelector to a
+#  specific public node in k3d/coturn-stack/janus.yaml — no patch needed)
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/prod/patch-keycloak.yaml
+++ b/prod/patch-keycloak.yaml
@@ -8,11 +8,8 @@ spec:
       containers:
         - name: keycloak
           env:
-            - name: SMTP_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: workspace-secrets
-                  key: SMTP_PASSWORD
+            - name: PROD_DOMAIN
+              value: "${PROD_DOMAIN}"
             - name: KC_HOSTNAME
               value: "https://auth.${PROD_DOMAIN}"
             - name: KC_HOSTNAME_STRICT

--- a/scripts/import-entrypoint.sh
+++ b/scripts/import-entrypoint.sh
@@ -4,6 +4,12 @@
 #
 # Hinweis: envsubst ist im Keycloak-Image (RHEL UBI9-micro) nicht
 # verfügbar, daher werden die Variablen per sed ersetzt.
+#
+# Wichtig: Wenn hier eine Variable fehlt, landet ihr literaler ${VAR}-
+# String in der KC-Datenbank, weil kc.sh start --import-realm den
+# Realm nur einmalig importiert. Spätere Auth-Flows scheitern dann
+# mit "Invalid client credentials". Die Sanity-Prüfung am Ende lässt
+# das Pod failen, statt einen kaputten Realm zu produzieren.
 set -e
 
 TEMPLATE="/opt/keycloak/realm-template/realm-workspace.json"
@@ -24,6 +30,13 @@ for var in MATTERMOST_OIDC_SECRET NEXTCLOUD_OIDC_SECRET INVOICENINJA_OIDC_SECRET
     sed -i "s|\${${var}}|${val}|g" "$OUTPUT"
   fi
 done
+
+# Sanity check: keine unaufgelösten ${...} Platzhalter mehr im Output
+if grep -q '\${[A-Z_]*}' "$OUTPUT"; then
+  echo "[import-entrypoint] FEHLER: Unaufgelöste Platzhalter im Realm-JSON:" >&2
+  grep -o '\${[A-Z_]*}' "$OUTPUT" | sort -u >&2
+  exit 1
+fi
 
 echo "[import-entrypoint] Realm JSON generiert: $OUTPUT"
 

--- a/scripts/mattermost-connectors-setup.sh
+++ b/scripts/mattermost-connectors-setup.sh
@@ -143,10 +143,10 @@ $(echo -e "${TABLE_ROWS}")
 **Hilfe:** Bei Fragen den Kanal \`claude-code\` nutzen oder die [Dokumentation](${SCHEME}://${DOCS_DOMAIN}) lesen."
 
 # ── Town Square header with quick-links ───────────────────────────────────
-TOWN_SQUARE_HEADER=":file_folder: [Dateien](${SCHEME}://${NC_DOMAIN}) | :key: [SSO](${SCHEME}://${KC_DOMAIN}) | :receipt: [Rechnungen](${SCHEME}://${BILLING_DOMAIN}) | :lock: [Passwoerter](${SCHEME}://${VAULT_DOMAIN}) | :books: [Docs](${SCHEME}://${DOCS_DOMAIN}) | :globe_with_meridians: [Website](${SCHEME}://${WEB_DOMAIN})"
+TOWN_SQUARE_HEADER=":file_folder: [Dateien](${SCHEME}://${NC_DOMAIN}) | :movie_camera: [Talk](${SCHEME}://${NC_DOMAIN}/apps/spreed) | :key: [SSO](${SCHEME}://${KC_DOMAIN}) | :receipt: [Rechnungen](${SCHEME}://${BILLING_DOMAIN}) | :lock: [Passwoerter](${SCHEME}://${VAULT_DOMAIN}) | :books: [Docs](${SCHEME}://${DOCS_DOMAIN}) | :globe_with_meridians: [Website](${SCHEME}://${WEB_DOMAIN})"
 
 # ── workspace-services channel header ─────────────────────────────────────
-SVC_CHANNEL_HEADER=":file_folder: [Dateien](${SCHEME}://${NC_DOMAIN}) | :pencil: [Office](${SCHEME}://${COLLABORA_DOMAIN}) | :key: [SSO](${SCHEME}://${KC_DOMAIN}) | :receipt: [Rechnungen](${SCHEME}://${BILLING_DOMAIN}) | :lock: [Passwoerter](${SCHEME}://${VAULT_DOMAIN}) | :books: [Docs](${SCHEME}://${DOCS_DOMAIN}) | :art: [Whiteboard](${SCHEME}://${WHITEBOARD_DOMAIN}) | :robot_face: [KI](${SCHEME}://${AI_DOMAIN})"
+SVC_CHANNEL_HEADER=":file_folder: [Dateien](${SCHEME}://${NC_DOMAIN}) | :movie_camera: [Talk](${SCHEME}://${NC_DOMAIN}/apps/spreed) | :pencil: [Office](${SCHEME}://${COLLABORA_DOMAIN}) | :key: [SSO](${SCHEME}://${KC_DOMAIN}) | :receipt: [Rechnungen](${SCHEME}://${BILLING_DOMAIN}) | :lock: [Passwoerter](${SCHEME}://${VAULT_DOMAIN}) | :books: [Docs](${SCHEME}://${DOCS_DOMAIN}) | :art: [Whiteboard](${SCHEME}://${WHITEBOARD_DOMAIN}) | :robot_face: [KI](${SCHEME}://${AI_DOMAIN})"
 
 # ── Process each team ─────────────────────────────────────────────────────
 echo "${TEAMS_JSON}" | python3 -c "


### PR DESCRIPTION
## Summary
- Reorganises the Talk High-Performance Backend (coturn + janus) into a dedicated privileged `coturn` namespace with `hostNetwork`, pinned per-cluster, so browsers can actually establish a media path.
- Closes the realm-import gap that left several Keycloak client secrets stuck on either unresolved `${VAR}` placeholders or auto-generated random values on a fresh bootstrap.
- Adds a Talk quick-link to the Mattermost service-directory channel headers.

## What's in here
**HPB / coturn / janus**
- New `k3d/coturn-stack/` (Namespace + coturn + janus). hostNetwork, hostPort, parameterised per cluster via `${TURN_NODE}` / `${TURN_PUBLIC_IP}`.
- coturn switched from `--lt-cred-mech` to `--use-auth-secret` (the REST mechanism Talk actually uses), relay range narrowed to 49152–49252.
- janus now uses `nat_1_1_mapping=${TURN_PUBLIC_IP}`, drops the unused STUN/TURN client config (ICE-Lite responder), shrinks RTP range to 20000–20200.
- spreed-signaling: `[backend-1] url` → `https://files.${PROD_DOMAIN}` (was hardcoded `http://nextcloud:80`, breaking HMAC backend lookup), `[mcu] url` → `ws://janus.coturn:8188`, `[turn] servers` → `turn.${PROD_DOMAIN}`.
- New `argocd/applicationset-coturn.yaml` deploys coturn-stack as its own ArgoCD app per cluster (separate from the workspace AppSet because the cluster-scoped Namespace resource conflicts with the workspace AppSet's `namespace: workspace` kustomize directive).
- New env vars `TURN_PUBLIC_IP` / `TURN_NODE` wired through env schema, both env files, ApplicationSet env block, and the cluster-register Task.
- AppProject whitelists the new `coturn` destination namespace.

**Realm import (root cause for Mattermost / Invoiceninja login failures)**
- `prod/import-entrypoint.sh` substituted only 5 of the 14 `${VAR}` placeholders. On a fresh bootstrap several client secrets ended up as literal `${SECRET}` strings (or random values when Keycloak rejected the literal). Add the missing variables (`INVOICENINJA_OIDC_SECRET`, `VAULTWARDEN_OIDC_SECRET`, `CLAUDE_CODE_OIDC_SECRET`, `WEBSITE_OIDC_SECRET`, `OUTLINE_OIDC_SECRET`, `BILLING_DOMAIN`, `VAULT_DOMAIN`, `AI_DOMAIN`, `WEB_DOMAIN`, `PROD_DOMAIN`).
- Both dev and prod scripts now fail-fast if any `${VAR}` survives the sed pass — the next fresh install can never silently regress.
- `prod/patch-keycloak.yaml`: expose `PROD_DOMAIN` to the keycloak container (referenced by the realm template), drop the dead `SMTP_PASSWORD` env (the realm template no longer references it).

**Other**
- `scripts/mattermost-connectors-setup.sh`: add `:movie_camera: [Talk]` link to both the Town Square header and the workspace-services channel header.
- `prod/patch-amd64-only.yaml`: drop the obsolete janus `nodeSelector` patch — janus is now pinned via the coturn-stack manifests directly.

## Test plan
- [x] `kustomize build` succeeds for all four roots: `k3d`, `k3d/coturn-stack`, `prod`, `prod-korczewski`
- [x] envsubst-rendered `coturn-stack` produces correct `external-ip`, `nodeSelector`, `nat_1_1_mapping`, `realm` for both clusters
- [x] Live cluster: coturn + janus pods running on `gekko-hetzner-2` (mentolder) and `pk-hetzner` (korczewski)
- [x] Live cluster: spreed-signaling logs show backend `https://files.<domain>/`, MCU `ws://janus.coturn:8188`, TURN `turn.<domain>`
- [x] Live cluster: Talk-Anruf zwischen 2 Geräten funktioniert (user-confirmed)
- [x] Live cluster: Keycloak master admin password reset on both clusters (admin/devadmin)
- [x] Live cluster: korczewski mattermost/nextcloud/invoiceninja/vaultwarden client secrets aligned with `workspace-secrets`
- [x] Live cluster: mentolder `openclaw` client deleted, `claude-code` client recreated with the secret from `workspace-secrets`
- [ ] After merge: ArgoCD picks up the changes without drift; `task argocd:status` shows all four apps Synced/Healthy
- [ ] After merge: re-running `task argocd:cluster:register` populates the new `workspace-turn-ip` / `workspace-turn-node` annotations on both cluster Secrets

## Follow-ups (out of scope)
- Rotate the dev TURN secret (`devturnpassword1234`) to a real random value, propagated through `workspace-secrets`, the coturn args, and `talk:turn:edit`.
- Old `spreed-signaling`, `nats`, `signaling-config` resources still live in `workspace`. They're now correctly wired but the secret is still a dev placeholder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)