### PR TITLE
fix(argocd,cmp): whitelist envsubst, optional stripe secret

### DIFF
--- a/argocd/install/cmp-plugin.yaml
+++ b/argocd/install/cmp-plugin.yaml
@@ -21,10 +21,17 @@ data:
         command: [sh, -c]
         args:
           - |
-            # Export all ARGOCD_ENV_* vars without the prefix
+            # Export all ARGOCD_ENV_* vars without the prefix and build a
+            # whitelist for envsubst. The whitelist is essential: bare
+            # `envsubst` would also replace shell variables that legitimately
+            # appear in manifests (e.g. `${ARCH}` inside an inline pod
+            # script), substituting them with empty string and breaking
+            # the affected workloads.
+            WHITELIST=""
             for var in $(env | grep ^ARGOCD_ENV_ | cut -d= -f1); do
               name="${var#ARGOCD_ENV_}"
               export "$name=$(printenv "$var")"
+              WHITELIST="$WHITELIST \${$name}"
             done
-            kustomize build . | envsubst
+            kustomize build . | envsubst "$WHITELIST"
       lockRepo: false

--- a/k3d/claude-code-mcp-stripe.yaml
+++ b/k3d/claude-code-mcp-stripe.yaml
@@ -31,11 +31,14 @@ spec:
                 --streamableHttpPath /mcp \
                 --healthEndpoint /health
           env:
+            # Optional: deployments without a Stripe account (e.g. mentolder)
+            # leave this unset and the MCP server logs but stays up.
             - name: STRIPE_SECRET_KEY
               valueFrom:
                 secretKeyRef:
                   name: workspace-secrets
                   key: STRIPE_SECRET_KEY
+                  optional: true
           ports:
             - containerPort: 3003
           readinessProbe:


### PR DESCRIPTION
## Summary
Two surgical fixes that surfaced after #63 was deployed.

1. **CMP plugin envsubst was too aggressive** — it replaced ALL `\${VAR}` patterns including legit shell variables like `\${ARCH}` in inline pod scripts. The kubernetes MCP container ended up downloading `mcp-k8s-go_Linux_.tar.gz` (no arch, 404). Fixed by building a whitelist from `ARGOCD_ENV_*` vars and passing it to envsubst.
2. **mcp-stripe** got stuck in `CreateContainerConfigError` on mentolder because that cluster doesn't have `STRIPE_SECRET_KEY` in `workspace-secrets`. Marked the env reference as `optional: true`.

## Test plan
- [x] Live: cmp ConfigMap updated, repo-server restarted, the new pod has the whitelist version
- [ ] After merge: re-sync workspace-mentolder app at the new revision and verify mcp-ops + mcp-stripe pods become Ready

🤖 Generated with [Claude Code](https://claude.com/claude-code)