### PR TITLE
fix(cert-manager): force podDnsPolicy=Default to bypass cluster DNS

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1663,14 +1663,31 @@ tasks:
       - sh: kubectl cluster-info > /dev/null 2>&1
         msg: "No cluster running. Run 'task cluster:create' first."
     cmds:
-      # Install cert-manager
+      # Install cert-manager.
+      #
+      # podDnsPolicy=Default forces the cert-manager controller to use the
+      # node's /etc/resolv.conf instead of the cluster's CoreDNS service.
+      # On hybrid clusters where the only public-IP node (e.g. korczewski's
+      # pk-hetzner) cannot reach pods on private home nodes via the CNI
+      # overlay, the in-cluster CoreDNS Service is unreachable and ACME
+      # registration fails with `dial tcp: lookup acme-v02.api.letsencrypt.org:
+      # i/o timeout`. Default DNS policy bypasses this entirely. Harmless
+      # on single-network clusters.
       - helm repo add jetstack https://charts.jetstack.io --force-update
       - helm repo update
       - |
         helm upgrade --install cert-manager jetstack/cert-manager \
           --namespace cert-manager --create-namespace \
           --set crds.enabled=true \
+          --set podDnsPolicy=Default \
           --wait --timeout=180s
+      # If cert-manager was installed before this fix landed, the running
+      # Deployment still has dnsPolicy=ClusterFirst. Patch it idempotently
+      # so reruns of cert:install also fix existing installations.
+      - |
+        kubectl patch deploy -n cert-manager cert-manager \
+          --type=merge -p '{"spec":{"template":{"spec":{"dnsPolicy":"Default"}}}}' \
+          2>/dev/null || true
       # Install cert-manager-lego-webhook
       - helm repo add cert-manager-lego-webhook https://yxwuxuanl.github.io/cert-manager-lego-webhook/ --force-update
       - helm repo update


### PR DESCRIPTION
## Summary
Persists the live workaround applied during the post-#63 cleanup to git.

On hybrid clusters where only one node has a public IP (korczewski's `pk-hetzner`) and the rest are home nodes behind NAT, pods on the public node cannot reach the in-cluster CoreDNS Service via the CNI overlay. cert-manager — pinned to `pk-hetzner` to be reachable for ACME HTTP-01 — therefore couldn't resolve `acme-v02.api.letsencrypt.org` and the `letsencrypt-prod` ClusterIssuer was stuck on:

\`\`\`
Failed to register ACME account: Get "https://acme-v02.api.letsencrypt.org/directory":
dial tcp: lookup acme-v02.api.letsencrypt.org: i/o timeout
\`\`\`

## Changes
- `task cert:install` now passes `--set podDnsPolicy=Default` to the jetstack/cert-manager Helm chart, so the controller pod inherits the node's `/etc/resolv.conf` instead of using cluster DNS.
- Adds an idempotent `kubectl patch` post-install step so reruns of `task cert:install` also repair existing installations that pre-date this fix.

## Test plan
- [x] Live korczewski: `dnsPolicy: Default` already applied via direct kubectl patch (in the post-#63 cleanup), letsencrypt-prod is `Ready=True`, ACME account verified.
- [ ] Run `task cert:install` on a fresh cluster to verify the helm value is honored.
- [ ] Run `task cert:install` on an existing install to verify the post-patch step idempotently fixes drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)