### PR TITLE
feat(website): role-based post-login redirect + restore missing config

### DIFF
--- a/website/src/components/Navigation.svelte
+++ b/website/src/components/Navigation.svelte
@@ -2,7 +2,7 @@
   let { siteTitle = '' } = $props();
   let mobileOpen = $state(false);
   let scrolled = $state(false);
-  let user = $state<{ name: string; email: string } | null>(null);
+  let user = $state<{ name: string; email: string; isAdmin?: boolean } | null>(null);
   let authChecked = $state(false);
 
   if (typeof window !== 'undefined') {
@@ -39,6 +39,13 @@
 
       {#if authChecked}
         {#if user}
+          <a
+            href={user.isAdmin ? '/admin' : '/portal'}
+            class="text-gold hover:text-gold-light font-medium transition-colors"
+            data-testid="nav-user-area"
+          >
+            {user.isAdmin ? 'Admin' : 'Mein Portal'}
+          </a>
           <span class="text-muted text-sm">{user.name}</span>
           <a
             href="/api/auth/logout"
@@ -91,6 +98,13 @@
       {#if authChecked}
         {#if user}
           <div class="py-2 text-muted text-sm border-t border-dark-lighter pt-4">Angemeldet als {user.name}</div>
+          <a
+            href={user.isAdmin ? '/admin' : '/portal'}
+            class="block text-gold hover:text-gold-light font-medium py-2"
+            onclick={() => (mobileOpen = false)}
+          >
+            {user.isAdmin ? 'Admin' : 'Mein Portal'}
+          </a>
           <a href="/api/auth/logout" class="block text-muted hover:text-gold font-medium py-2" onclick={() => (mobileOpen = false)}>Abmelden</a>
         {:else}
           <a href="/registrieren" class="block text-muted hover:text-gold font-medium py-2" onclick={() => (mobileOpen = false)}>Registrieren</a>

--- a/website/src/config/brands/korczewski.ts
+++ b/website/src/config/brands/korczewski.ts
@@ -1,0 +1,320 @@
+import type { BrandConfig } from '../types';
+
+export const korczewskiConfig: BrandConfig = {
+  brand: 'korczewski',
+  meta: {
+    siteTitle: 'korczewski.de',
+    siteDescription: 'Software Engineering & IT-Security-Beratung – KI-Beratung, Software-Entwicklung, Kubernetes-Deployment',
+  },
+  contact: {
+    name: 'Patrick Korczewski',
+    email: 'info@korczewski.de',
+    phone: '',
+    city: 'Luneburg',
+  },
+  legal: {
+    street: 'In der Twiet 4',
+    zip: '21360',
+    jobtitle: 'Software Engineer, IT-Security-Berater',
+    chamber: 'Entfallt',
+    ustId: 'Kleinunternehmer gem. § 19 Abs. 1 UStG',
+    website: 'korczewski.de',
+    tagline: 'Software Engineering & IT-Security-Beratung',
+  },
+  homepage: {
+    stats: [
+      { value: 'B.Sc.', label: 'IT-Sicherheit' },
+      { value: '10+', label: 'Jahre IT-Management' },
+      { value: 'KI', label: 'Seit Tag 1 dabei' },
+      { value: 'K8s', label: 'Kubernetes & Open Source' },
+    ],
+    servicesHeadline: 'Was ich fur Sie tun kann',
+    servicesSubheadline: 'Technologie soll Ihnen das Leben leichter machen – nicht komplizierter. Ich sorge dafur, dass es so bleibt.',
+    whyMeHeadline: 'Warum ich?',
+    whyMeIntro: 'Ich komme nicht aus der Theorie. Ich habe jahrelang die IT von Unternehmen gemanaged, bevor ich angefangen habe, selbst zu entwickeln. Und seit GPT-3 auf dem Markt ist, habe ich jeden Tag damit verbracht, aus meiner Intuition solides Architekturwissen zu machen.',
+    whyMePoints: [
+      {
+        iconPath: 'M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z',
+        title: 'IT-Sicherheit im Blut',
+        text: 'Bachelor in IT-Sicherheit. Ich denke Security-first, nicht als Afterthought.',
+      },
+      {
+        iconPath: 'M13 10V3L4 14h7v7l9-11h-7z',
+        title: 'KI-Native seit der ersten Stunde',
+        text: 'Seit dem Launch von ChatGPT 3 arbeite ich taglich mit KI. Nicht als Spielerei – als Werkzeug.',
+      },
+      {
+        iconPath: 'M19.428 15.428a2 2 0 00-1.022-.547l-2.387-.477a6 6 0 00-3.86.517l-.318.158a6 6 0 01-3.86.517L6.05 15.21a2 2 0 00-1.806.547M8 4h8l-1 1v5.172a2 2 0 00.586 1.414l5 5c1.26 1.26.367 3.414-1.415 3.414H4.828c-1.782 0-2.674-2.154-1.414-3.414l5-5A2 2 0 009 10.172V5L8 4z',
+        title: 'Praxis schlagt Theorie',
+        text: 'Jahre in der IT grosser und kleiner Unternehmen. Ich kenne die echten Probleme, nicht nur die Lehrbuch-Probleme.',
+      },
+    ],
+    avatarType: 'initials',
+    avatarInitials: 'PK',
+    quote: 'Ich habe meine Vibes in Architekturwissen verwandelt – und jetzt helfe ich Ihnen, dasselbe zu tun. Nur schneller, weil ich die Sackgassen schon kenne.',
+    quoteName: 'Patrick Korczewski',
+  },
+  services: [
+    {
+      slug: 'ki-beratung',
+      title: 'KI-Beratung',
+      description: 'KI sicher, sinnvoll und kosteneffizient einsetzen – privat oder geschaftlich. Kein Hype, sondern das, was wirklich funktioniert.',
+      icon: '🧠',
+      features: [
+        'ChatGPT, Claude & Co. produktiv nutzen',
+        'Datenschutzkonformer KI-Einsatz im Unternehmen',
+        'Automatisierung von Routineaufgaben',
+        'Kosten-Nutzen-Analyse verschiedener KI-Tools',
+      ],
+      price: '50 € / Stunde',
+      pageContent: {
+        headline: 'KI sicher und produktiv einsetzen',
+        intro: 'KI ist kein Hexenwerk. Aber es gibt einen grossen Unterschied zwischen "mal ChatGPT ausprobiert" und "KI systematisch und sicher einsetzen". Ich zeige Ihnen den Unterschied.',
+        forWhom: [
+          'KI fur den personlichen Alltag nutzen mochten',
+          'KI datenschutzkonform im Unternehmen einfuhren wollen',
+          'Routineaufgaben automatisieren mochten',
+          'Den Uberblick uber Tools und Kosten behalten wollen',
+        ],
+        sections: [
+          {
+            title: 'KI-Einfuhrung Privat',
+            items: ['ChatGPT, Claude, lokale Modelle – was gibt es, was kostet es, was ist sicher?', 'Praxisnahe Einfuhrung fur den Alltag'],
+          },
+          {
+            title: 'KI-Strategie Geschaftlich',
+            items: ['Welche Prozesse lassen sich automatisieren?', 'Wo lohnt sich KI, wo nicht?', 'Datenschutzkonformer Einsatz im Unternehmen'],
+          },
+          {
+            title: 'Prompt Engineering',
+            items: ['Die Kunst, KI die richtigen Fragen zu stellen', 'Fur Teams oder Einzelpersonen'],
+          },
+          {
+            title: 'Kennenlerngesprach',
+            items: ['Wir sprechen uber Ihre Situation', 'Ich finde heraus, wo KI Ihnen wirklich helfen kann', 'Keine Verkaufsshow'],
+          },
+        ],
+        pricing: [
+          { label: 'Kennenlerngesprach', price: '20 €', unit: '/ 45 Min' },
+          { label: 'KI-Einfuhrung Privat', price: '50 €', unit: '/ Stunde' },
+          { label: 'KI-Strategie Geschaftlich', price: '50 €', unit: '/ Stunde', highlight: true },
+          { label: 'Prompt Engineering Workshop', price: '50 €', unit: '/ Stunde' },
+        ],
+        faq: [
+          { question: 'Fur wen ist die KI-Beratung gedacht?', answer: 'Fur alle, die KI sinnvoll nutzen wollen – ob Privatperson, Selbstandiger oder Unternehmen. Ich hole Sie dort ab, wo Sie stehen, und zeige Ihnen, was heute schon funktioniert.' },
+          { question: 'Brauche ich Programmierkenntnisse fur die KI-Beratung?', answer: 'Nein. Fur die KI-Beratung und grundlegende Automatisierung brauchen Sie null Vorkenntnisse.' },
+        ],
+      },
+    },
+    {
+      slug: 'software-dev',
+      title: 'Software-Entwicklung mit KI',
+      description: 'Vom ersten Prompt bis zum fertigen Produkt. Ich zeige Ihnen, wie KI-gestutzte Entwicklung funktioniert – auch wenn Sie kein Informatiker sind.',
+      icon: '💻',
+      features: [
+        'Einfuhrung in KI-gestutzte Entwicklung',
+        'Architekturentscheidungen mit KI treffen',
+        'Code-Qualitat und Testing mit KI',
+        'Von der Idee zum produktionsreifen Code',
+      ],
+      price: '50 € / Stunde',
+      pageContent: {
+        headline: 'Software entwickeln – mit KI als Co-Pilot',
+        intro: 'Sie mussen kein Informatiker sein, um mit KI Software zu bauen. Aber es hilft, jemanden an der Seite zu haben, der die Fallstricke kennt.',
+        forWhom: [
+          'Von der Idee zu einem funktionierenden Prototyp kommen wollen',
+          'KI-gestutzte Entwicklung erlernen mochten',
+          'Architekturentscheidungen richtig treffen wollen',
+          'Bestehenden Code verbessern mochten',
+        ],
+        sections: [
+          {
+            title: 'Einstieg in KI-Entwicklung',
+            items: ['Wie man mit Claude Code, Cursor oder Copilot startet', 'Von der Idee zum funktionierenden Prototyp'],
+          },
+          {
+            title: 'Architektur-Beratung',
+            items: ['Die richtigen Entscheidungen treffen, bevor man Code schreibt', 'Technologie-Stack, Struktur, Skalierbarkeit'],
+          },
+          {
+            title: 'Code-Review & Qualitat',
+            items: ['Bestehenden Code gemeinsam durchgehen', 'Testing, Security, Performance – die Dinge, die KI gerne ubersieht'],
+          },
+          {
+            title: 'Pair Programming mit KI',
+            items: ['Wir entwickeln gemeinsam', 'Sie lernen, wie man KI als Co-Pilot effektiv einsetzt'],
+          },
+        ],
+        pricing: [
+          { label: 'Kennenlerngesprach', price: '20 €', unit: '/ 45 Min', highlight: true },
+          { label: 'Stundensatz', price: '50 €', unit: '/ Stunde' },
+        ],
+        faq: [
+          { question: 'Brauche ich Programmierkenntnisse?', answer: 'Fur Software-Entwicklung mit KI starten wir bei den Basics – KI ubernimmt den Grossteil der schweren Arbeit.' },
+          { question: 'Wie lauft ein Kennenlerngesprach ab?', answer: '45 Minuten, 20 Euro. Wir sprechen uber Ihre Situation, ich stelle Fragen, Sie stellen Fragen. Am Ende wissen wir beide, ob eine Zusammenarbeit Sinn macht.' },
+        ],
+      },
+    },
+    {
+      slug: 'deployment',
+      title: 'Deployment & Infrastruktur',
+      description: 'Kubernetes, Open-Source-Losungen, Wartung – ich bringe Ihre Software sicher in Produktion und halte sie am Laufen.',
+      icon: '☁️',
+      features: [
+        'Kubernetes-Deployment von A bis Z',
+        'Open-Source-Alternativen zu teurer Software',
+        'Monitoring, Wartung & Updates',
+        'DSGVO-konforme Self-Hosted-Losungen',
+      ],
+      price: '50 € / Stunde',
+      pageContent: {
+        headline: 'Ihre Software sicher in Produktion bringen',
+        intro: 'Code schreiben ist die halbe Miete. Ihn zuverlassig in Produktion zu bringen und dort zu halten – das ist die andere Halfte.',
+        forWhom: [
+          'Kubernetes neu einrichten oder migrieren mochten',
+          'Self-Hosted Open-Source-Losungen aufsetzen wollen',
+          'Monitoring und Wartung outsourcen mochten',
+          'Daten sicher migrieren mochten',
+        ],
+        sections: [
+          {
+            title: 'Kubernetes-Deployment',
+            items: ['Von Docker-Compose zu Kubernetes', 'Manifeste, Ingress, TLS, Monitoring – der ganze Stack'],
+          },
+          {
+            title: 'Open-Source-Setup',
+            items: ['Nextcloud, Mattermost, Vaultwarden, Keycloak & mehr', 'Self-hosted, DSGVO-konform, unter Ihrer Kontrolle'],
+          },
+          {
+            title: 'Wartung & Monitoring',
+            items: ['Updates, Backups, Alerting', 'Damit Sie ruhig schlafen konnen, wahrend Ihre Infrastruktur lauft'],
+          },
+          {
+            title: 'Migration & Umzug',
+            items: ['Von der Cloud zum eigenen Server oder umgekehrt', 'Daten sicher migrieren, Downtime minimieren'],
+          },
+        ],
+        pricing: [
+          { label: 'Kennenlerngesprach', price: '20 €', unit: '/ 45 Min', highlight: true },
+          { label: 'Stundensatz', price: '50 €', unit: '/ Stunde' },
+        ],
+        faq: [
+          { question: 'Warum Open Source statt Standardsoftware?', answer: 'Weil Sie damit unabhangig bleiben: keine Vendor-Lock-ins, keine steigenden Lizenzkosten, volle Kontrolle uber Ihre Daten. Und oft ist die Open-Source-Losung auch die bessere.' },
+          { question: 'Arbeiten Sie remote oder vor Ort?', answer: 'Beides. Die meisten Projekte lassen sich hervorragend remote umsetzen. Fur intensivere Zusammenarbeit komme ich auch gerne nach Luneburg und Umgebung.' },
+        ],
+      },
+    },
+  ],
+  leistungen: [
+    {
+      id: 'ki-beratung',
+      title: 'KI-Beratung',
+      icon: '🧠',
+      description: 'KI ist kein Hexenwerk. Aber es gibt einen grossen Unterschied zwischen "mal ChatGPT ausprobiert" und "KI systematisch und sicher einsetzen". Ich zeige Ihnen den Unterschied.',
+      services: [
+        { key: 'ki-kennenlern', name: 'Kennenlerngesprach', price: '20 €', unit: '/ 45 Min', desc: 'Wir sprechen uber Ihre Situation und finden heraus, wo KI Ihnen wirklich helfen kann. Keine Verkaufsshow.' },
+        { key: 'ki-privat', name: 'KI-Einfuhrung Privat', price: '50 €', unit: '/ Stunde', desc: 'ChatGPT, Claude, lokale Modelle – was gibt es, was kostet es, was ist sicher? Praxisnahe Einfuhrung fur den Alltag.' },
+        { key: 'ki-geschaeft', name: 'KI-Strategie Geschaftlich', price: '50 €', unit: '/ Stunde', desc: 'Welche Prozesse lassen sich automatisieren? Wo lohnt sich KI, wo nicht? Datenschutzkonformer Einsatz im Unternehmen.', highlight: true },
+        { key: 'ki-prompt', name: 'Prompt Engineering Workshop', price: '50 €', unit: '/ Stunde', desc: 'Die Kunst, KI die richtigen Fragen zu stellen. Fur Teams oder Einzelpersonen.' },
+      ],
+    },
+    {
+      id: 'software-dev',
+      title: 'Software-Entwicklung mit KI',
+      icon: '💻',
+      description: 'Sie mussen kein Informatiker sein, um mit KI Software zu bauen. Aber es hilft, jemanden an der Seite zu haben, der die Fallstricke kennt.',
+      services: [
+        { key: 'sw-einstieg', name: 'Einstieg in KI-gestutzte Entwicklung', price: '50 €', unit: '/ Stunde', desc: 'Wie man mit Claude Code, Cursor oder Copilot von der Idee zum funktionierenden Prototyp kommt.' },
+        { key: 'sw-architektur', name: 'Architektur-Beratung', price: '50 €', unit: '/ Stunde', desc: 'Die richtigen Entscheidungen treffen, bevor man Code schreibt. Technologie-Stack, Struktur, Skalierbarkeit.' },
+        { key: 'sw-review', name: 'Code-Review & Qualitat', price: '50 €', unit: '/ Stunde', desc: 'Bestehenden Code gemeinsam durchgehen. Testing, Security, Performance – die Dinge, die KI gerne ubersieht.' },
+        { key: 'sw-pair', name: 'Pair Programming mit KI', price: '50 €', unit: '/ Stunde', desc: 'Wir entwickeln gemeinsam. Sie lernen dabei, wie man KI als Co-Pilot effektiv einsetzt.' },
+      ],
+    },
+    {
+      id: 'deployment',
+      title: 'Deployment & Infrastruktur',
+      icon: '☁️',
+      description: 'Code schreiben ist die halbe Miete. Ihn zuverlassig in Produktion zu bringen und dort zu halten – das ist die andere Halfte.',
+      services: [
+        { key: 'dep-kubernetes', name: 'Kubernetes-Deployment', price: '50 €', unit: '/ Stunde', desc: 'Von Docker-Compose zu Kubernetes. Manifeste, Ingress, TLS, Monitoring – der ganze Stack.' },
+        { key: 'dep-opensource', name: 'Open-Source-Setup', price: '50 €', unit: '/ Stunde', desc: 'Nextcloud, Mattermost, Vaultwarden, Keycloak & mehr. Self-hosted, DSGVO-konform, unter Ihrer Kontrolle.' },
+        { key: 'dep-wartung', name: 'Wartung & Monitoring', price: '50 €', unit: '/ Stunde', desc: 'Updates, Backups, Alerting. Damit Sie ruhig schlafen konnen, wahrend Ihre Infrastruktur lauft.' },
+        { key: 'dep-migration', name: 'Migration & Umzug', price: '50 €', unit: '/ Stunde', desc: 'Von der Cloud zum eigenen Server oder umgekehrt. Daten sicher migrieren, Downtime minimieren.' },
+      ],
+    },
+  ],
+  leistungenPricingHighlight: [
+    { label: 'Kennenlerngesprach', price: '20 €', note: '45 Minuten · Bedarf erfassen & eingrenzen' },
+    { label: 'Stundensatz', price: '50 €', note: 'Alle Leistungen · Fair & transparent', highlight: true },
+  ],
+  uebermich: {
+    pageHeadline: 'Von der IT-Abteilung zur KI-Beratung',
+    subheadline: 'Uber mich',
+    introParagraphs: [
+      'Manche Leute finden ihren Weg geradlinig. Ich habe meinen eher im Zickzack gefunden – und bin der Meinung, dass genau das der Grund ist, warum ich heute gute Beratung machen kann.',
+      'Angefangen hat alles in der IT-Abteilung. Nicht in einem hippen Startup, sondern dort, wo Technik wirklich funktionieren muss: in Unternehmen, die darauf angewiesen sind, dass morgens um acht alles lauft. Grosse Firmen, kleine Firmen – ich habe ihre Server gewartet, ihre Netzwerke aufgebaut, ihre Mitarbeiter supportet und dabei gelernt, dass die grosste Herausforderung in der IT selten die Technik ist. Es sind die Menschen, die Prozesse und die Frage "Warum machen wir das eigentlich so?".',
+    ],
+    sections: [
+      {
+        title: 'Der Security-Hintergrund',
+        content: 'Irgendwann wollte ich es genauer wissen und habe IT-Sicherheit im Bachelor studiert. Penetration Testing, Kryptographie, sichere Architekturen – das volle Programm. Was dabei hangengeblieben ist: ein tiefes Misstrauen gegenuber "das haben wir schon immer so gemacht" und die Uberzeugung, dass Security keine Checkbox ist, sondern eine Denkweise.',
+      },
+      {
+        title: 'Die KI-Revolution – live dabei',
+        content: 'Als im November 2022 ChatGPT 3 erschien, hat sich fur mich alles verandert. Nicht weil ich dachte "cool, ein Chatbot" – sondern weil ich sofort verstanden habe, dass sich die Art, wie wir Software bauen, grundlegend andern wurde. Seitdem habe ich praktisch jeden Tag mit KI gearbeitet. Tausende Stunden Prompting, Architektur-Entscheidungen, Trial and Error. Was als "Vibes-based Development" angefangen hat – also die intuitive Arbeit mit KI, bei der man mehr fuhlt als versteht – habe ich systematisch in solides Software-Architekturwissen verwandelt.',
+      },
+    ],
+    milestones: [
+      { year: 'Fruher', title: 'IT-Management', desc: 'Die IT grosser und kleiner Unternehmen gemanaged und supportet. Server, Netzwerke, Helpdesk, Strategie – der ganze Spass.' },
+      { year: 'Studium', title: 'B.Sc. IT-Sicherheit', desc: 'Informatik studiert mit Schwerpunkt IT-Sicherheit. Penetration Testing, Kryptographie, sichere Systeme.' },
+      { year: 'Nov 2022', title: 'GPT-3 & der Wendepunkt', desc: 'ChatGPT erscheint. Ab diesem Tag: jeden Tag KI. Prompts, Pipelines, Architektur. Aus Vibes wurde Wissen.' },
+      { year: 'Heute', title: 'Beratung & Entwicklung', desc: 'Software-Architektur, KI-Beratung, Kubernetes-Deployments. Und endlich bereit, dieses Wissen weiterzugeben.' },
+    ],
+    notDoing: [
+      { title: 'Kein Webdesign', text: 'Ich baue Infrastruktur und Architektur. Fur schicke Pixel-perfekte Designs gibt es bessere Leute.' },
+      { title: 'Keine leeren Versprechen', text: '"KI lost alles" ist Unsinn. Ich sage Ihnen ehrlich, was geht und was nicht. Auch wenn das bedeutet, dass Sie mich nicht buchen.' },
+      { title: 'Keine 24/7-Erreichbarkeit', text: 'Gute Arbeit braucht Fokus. Ich arbeite grundlich, nicht hektisch.' },
+    ],
+    privateText: 'Ich lebe in {city}. Wenn ich nicht gerade Kubernetes-Cluster debugge oder mit Claude uber Architekturentscheidungen diskutiere, bin ich wahrscheinlich draussen unterwegs oder experimentiere mit dem nachsten Open-Source-Tool, das mir uber den Weg lauft.',
+  },
+  kontakt: {
+    intro: 'Egal ob Frage, Kennenlerngesprach oder konkretes Projekt – schreiben Sie mir. Ich antworte in der Regel innerhalb von 24 Stunden.',
+    sidebarTitle: 'Kennenlerngesprach',
+    sidebarText: '45 Minuten, 20 Euro. Wir sprechen uber Ihre Situation, ich stelle die richtigen Fragen, und am Ende wissen wir beide, ob und wie ich Ihnen helfen kann.',
+    sidebarCta: 'Kein Verkaufsgesprach. Nur Klarheit.',
+    showPhone: false,
+    showSteps: true,
+  },
+  faq: [
+    {
+      question: 'Fur wen ist die KI-Beratung gedacht?',
+      answer: 'Fur alle, die KI sinnvoll nutzen wollen – ob Privatperson, Selbstandiger oder Unternehmen. Ich hole Sie dort ab, wo Sie stehen, und zeige Ihnen, was heute schon funktioniert.',
+    },
+    {
+      question: 'Brauche ich Programmierkenntnisse?',
+      answer: 'Nein. Fur die KI-Beratung und grundlegende Automatisierung brauchen Sie null Vorkenntnisse. Fur Software-Entwicklung mit KI starten wir bei den Basics – KI ubernimmt den Grossteil der schweren Arbeit.',
+    },
+    {
+      question: 'Wie lauft ein Kennenlerngesprach ab?',
+      answer: '45 Minuten, 20 Euro. Wir sprechen uber Ihre Situation, ich stelle Fragen, Sie stellen Fragen. Am Ende wissen wir beide, ob eine Zusammenarbeit Sinn macht – und wenn ja, wie.',
+    },
+    {
+      question: 'Warum Open Source statt Standardsoftware?',
+      answer: 'Weil Sie damit unabhangig bleiben: keine Vendor-Lock-ins, keine steigenden Lizenzkosten, volle Kontrolle uber Ihre Daten. Und oft ist die Open-Source-Losung auch die bessere.',
+    },
+    {
+      question: 'Arbeiten Sie remote oder vor Ort?',
+      answer: 'Beides. Die meisten Projekte lassen sich hervorragend remote umsetzen. Fur intensivere Zusammenarbeit komme ich auch gerne nach Luneburg und Umgebung.',
+    },
+  ],
+  leistungenCta: {
+    href: '/kontakt',
+    text: 'Anfragen',
+  },
+  features: {
+    hasBooking: true,
+    hasRegistration: true,
+    hasOIDC: true,
+    hasBilling: true,
+  },
+};

--- a/website/src/config/brands/mentolder.ts
+++ b/website/src/config/brands/mentolder.ts
@@ -1,0 +1,343 @@
+import type { BrandConfig } from '../types';
+
+export const mentolderConfig: BrandConfig = {
+  brand: 'mentolder',
+  meta: {
+    siteTitle: 'Mentolder',
+    siteDescription: 'Digital Coaching & Fuhrungskrafte-Beratung - Ihr Partner fur digitale Kompetenz und personliche Entwicklung',
+  },
+  contact: {
+    name: 'Gerald Korczewski',
+    email: 'info@mentolder.de',
+    phone: '+49 151 508 32 601',
+    city: 'Luneburg',
+  },
+  legal: {
+    street: '',
+    zip: '',
+    jobtitle: 'Coach und digitaler Begleiter',
+    chamber: 'Entfallt',
+    ustId: 'Kleinunternehmer gem. § 19 Abs. 1 UStG',
+    website: 'mentolder.de',
+    tagline: 'Digital Coaching & Fuhrungskrafte-Beratung',
+  },
+  homepage: {
+    stats: [
+      { value: '30+', label: 'Jahre Fuhrungserfahrung' },
+      { value: '50+', label: 'Begleitete Teilnehmer' },
+      { value: '40', label: 'Jahre Praxis in IT & Sicherheit' },
+      { value: 'KI', label: 'Pionier der ersten Stunde' },
+    ],
+    servicesHeadline: 'Meine Angebote',
+    servicesSubheadline: 'Sie suchen jemanden, der Menschen, Prozesse und Technik verbindet? Der Fuhrungserfahrung mit Empathie vereint?',
+    whyMeHeadline: 'Warum ich?',
+    whyMeIntro: 'Ich kenne beide Welten: 40 Jahre etablierte Strukturen UND modernste KI-Tools. Ich weiss, wie Veranderung in komplexen Organisationen wirklich funktioniert.',
+    whyMePoints: [
+      {
+        iconPath: 'M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z',
+        title: 'Erste deutsche Polizeibehorde mit KI',
+        text: 'Pionier, nicht Nachahmer. Gesichtserkennung, BOS-Digitalfunk, bundesweit fuhrend.',
+      },
+      {
+        iconPath: 'M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z',
+        title: 'Systemischer Coach',
+        text: 'Nicht nur IT, sondern auch Menschen. Ich verbinde technologisches Verstandnis mit Empathie.',
+      },
+      {
+        iconPath: 'M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z',
+        title: 'Selbst Generation 50+',
+        text: '65 Jahre. Ich kenne die Herausforderungen aus eigener Erfahrung und spreche Ihre Sprache.',
+      },
+    ],
+    avatarType: 'image',
+    avatarSrc: '/gerald.webp',
+    quote: 'Ich stelle unbequeme Fragen – weil echte Losungen manchmal unbequeme Wahrheiten brauchen.',
+    quoteName: 'Gerald Korczewski',
+  },
+  services: [
+    {
+      slug: 'digital-cafe',
+      title: 'Digital Cafe 50+',
+      description: 'Ihr sicherer Einstieg in die digitale Welt. Ich begleite Sie Schritt fur Schritt – in Ihrem Tempo, ohne Fachchinesisch.',
+      icon: '💻',
+      features: [
+        'Smartphone, Tablet & Computer Grundlagen',
+        'WhatsApp, Email & Videocalls',
+        'Online-Banking & Shopping sicher nutzen',
+        'Datenschutz & Sicherheit verstehen',
+      ],
+      price: 'Ab 60 € / Stunde',
+      pageContent: {
+        headline: 'Ihr sicherer Einstieg in die digitale Welt',
+        intro: 'Sie mochten WhatsApp nutzen, Online-Banking verstehen, oder einfach sicherer im Umgang mit Smartphone und Computer werden? Ich begleite Sie Schritt fur Schritt – in Ihrem Tempo, ohne Fachchinesisch.',
+        forWhom: [
+          'Sich mehr Unabhangigkeit im digitalen Alltag wunschen',
+          'Konkrete Fragen zu Smartphone, Tablet oder Computer haben',
+          'Sicher mit Email, WhatsApp und Online-Diensten umgehen mochten',
+          'Einen geduldigen Begleiter suchen, der Ihre Fragen ernst nimmt',
+        ],
+        sections: [
+          {
+            title: 'Grundlagen',
+            items: [
+              'Smartphone & Tablet Bedienung',
+              'Apps installieren und nutzen',
+              'Fotos und Videos verwalten',
+              'Windows/Mac Grundlagen',
+              'Dateien organisieren',
+              'Cloud-Dienste verstehen',
+            ],
+          },
+          {
+            title: 'Kommunikation',
+            items: [
+              'Email-Programme einrichten',
+              'WhatsApp sicher nutzen',
+              'Videocalls (Zoom, Skype)',
+              'Sichere Passworter',
+              'Betrugsmaschen erkennen',
+              'Privatsphare schutzen',
+            ],
+          },
+          {
+            title: 'Dienste',
+            items: [
+              'Online-Banking sicher nutzen',
+              'Sicher online einkaufen',
+              'Bezahldienste verstehen',
+              'Gesundheits-Apps',
+              'Online-Termine buchen',
+              'Elektronische Patientenakte',
+            ],
+          },
+        ],
+        pricing: [
+          { label: 'Einzelbegleitung', price: '60 €', unit: 'pro Stunde' },
+          { label: '5er-Paket', price: '270 €', unit: 'statt 300 €', highlight: true },
+          { label: 'Kleine Gruppe', price: '40 €', unit: 'pro Person / Stunde' },
+        ],
+        faq: [
+          { question: 'Ich habe gar keine Vorkenntnisse – ist das ein Problem?', answer: 'Nein, uberhaupt nicht! Wir fangen genau da an, wo Sie stehen. Viele meiner Teilnehmer*innen hatten vorher kaum Erfahrung – und haben es trotzdem gelernt.' },
+          { question: 'Muss ich meine Gerate mitbringen?', answer: 'Ja, am besten schon! Wir arbeiten mit IHREN Geraten – dann konnen Sie das Gelernte sofort zuhause umsetzen.' },
+          { question: 'Wie lange dauert es, bis ich sicher bin?', answer: 'Das ist sehr individuell. Manche brauchen 3-4 Sessions, andere 10. Sie bestimmen das Tempo.' },
+          { question: 'Was kostet das?', answer: 'Ein Erstgesprach (30 Min.) ist kostenlos. Danach arbeiten wir stundenweise (60 €) oder als Paket. Kleine Gruppen sind gunstiger.' },
+        ],
+      },
+    },
+    {
+      slug: 'coaching',
+      title: 'Fuhrungskrafte-Coaching',
+      description: 'Ihre Karriere strategisch gestalten. Ich unterstutze erfahrene Fuhrungskrafte bei der beruflichen Neuorientierung.',
+      icon: '🎯',
+      features: [
+        'Profil-Scharfung & Positionierung',
+        'Karriere-Strategie entwickeln',
+        'Gesprachsvorbereitung (Headhunter, Vorstellungsgesprache)',
+        'Sparring auf Augenhohe',
+      ],
+      price: 'Ab 150 € / Session',
+      pageContent: {
+        headline: 'Ihre Karriere strategisch gestalten',
+        intro: 'Sie sind erfahrene Fuhrungskraft und stehen vor einer beruflichen Neuorientierung? Ich begleite Sie dabei, Ihre Starken zu scharfen und sich optimal zu positionieren.',
+        forWhom: [
+          'Als erfahrene Fuhrungskraft Ihre Karriere neu ausrichten mochten',
+          'Sich auf wichtige Gesprache mit Headhuntern vorbereiten',
+          'Ihr Profil scharfen und Ihre USPs herausarbeiten wollen',
+          'Einen Sparring-Partner auf Augenhohe suchen',
+        ],
+        sections: [
+          {
+            title: 'Profil-Scharfung',
+            items: [
+              'Starken-Analyse und Positionierung',
+              'USPs herausarbeiten',
+              'CV-Optimierung',
+              'LinkedIn/XING-Profil strategisch aufbauen',
+            ],
+          },
+          {
+            title: 'Karriere-Strategie',
+            items: [
+              'Zielpositionen definieren',
+              'Branchen und Unternehmen identifizieren',
+              'Netzwerk-Strategie entwickeln',
+              'Timing und Vorgehensweise planen',
+            ],
+          },
+          {
+            title: 'Gesprachsvorbereitung',
+            items: [
+              'Headhunter-Gesprache',
+              'Vorstellungsgesprache',
+              'Gehaltsverhandlungen',
+              'Assessment Center',
+            ],
+          },
+          {
+            title: 'Markt-Positionierung',
+            items: [
+              'Marktanalyse',
+              'Zielunternehmen recherchieren',
+              'Anforderungsprofile verstehen',
+              'Ihr Profil passgenau ausrichten',
+            ],
+          },
+        ],
+        pricing: [
+          { label: 'Einzelsession (90 Min.)', price: '150 €' },
+          { label: 'Paket 6 Sessions', price: '800 €', unit: 'statt 900 €', highlight: true },
+          { label: 'Intensiv-Tag (6 Std.)', price: '500 €' },
+        ],
+        faq: [
+          { question: 'Wie lange dauert ein Coaching?', answer: 'Das hangt von Ihrer Situation ab. Manche brauchen nur 2-3 Sessions zur Vorbereitung auf ein Gesprach. Andere buchen ein 6er-Paket fur eine komplette Neuausrichtung.' },
+          { question: 'Ist das auch fur Fuhrungskrafte ausserhalb Luneburgs?', answer: 'Ja! Coaching lauft meist online via Video – das funktioniert hervorragend. Wenn Sie in der Nahe sind, konnen wir auch personlich arbeiten.' },
+          { question: 'Was unterscheidet Sie von anderen Coaches?', answer: 'Ich komme aus 30+ Jahren Fuhrungspraxis. Ich kenne beide Seiten des Tisches. Und: Ich bin direkt und ehrlich – kein "Coaching-Sprech".' },
+        ],
+      },
+    },
+    {
+      slug: 'beratung',
+      title: 'Unternehmensberatung',
+      description: 'Digitale Transformation fur Mittelstand, Verwaltung und kritische Infrastrukturen. 40 Jahre Praxis aus komplexen Strukturen.',
+      icon: '🏢',
+      features: [
+        'Analyse & digitale Strategie',
+        'Change Management & Teamschulungen',
+        'Umsetzungsbegleitung & Prozessoptimierung',
+        'Nachhaltige interne Kompetenz aufbauen',
+      ],
+      price: 'nach Vereinbarung',
+      pageContent: {
+        headline: 'Digitale Transformation mit Erfahrung',
+        intro: 'Ich begleite Organisationen bei der digitalen Transformation – nicht mit theoretischen Konzepten, sondern mit 40 Jahren Praxis aus komplexen IT- und Sicherheitsstrukturen.',
+        forWhom: [
+          'Mittelstandische Unternehmen (50-500 Mitarbeiter)',
+          'Offentliche Verwaltung (Behorden & Verwaltung)',
+          'Kritische Infrastrukturen (Energie, Kommunikation, Verkehr)',
+        ],
+        sections: [
+          {
+            title: 'Analyse',
+            items: ['Wo stehen Sie heute?', 'Was sind die konkreten Bedarfe?', 'Welche Ziele verfolgen Sie?'],
+          },
+          {
+            title: 'Strategie',
+            items: ['Entwicklung einer klaren Roadmap', 'Prioritaten & Ressourcenplanung', 'Meilensteine definieren'],
+          },
+          {
+            title: 'Change Management',
+            items: ['Ihr Team mitnehmen', 'Schulungen & Kommunikation', 'Motivation – damit Veranderung gelebt wird'],
+          },
+          {
+            title: 'Umsetzungsbegleitung',
+            items: ['Implementation begleiten', 'Prozesse optimieren', 'Nachhaltigkeit sichern'],
+          },
+        ],
+        pricing: [
+          { label: 'Tagessatz', price: 'nach Vereinbarung', unit: 'Projektumfang individuell, Dauer: 3-12 Monate', highlight: true },
+        ],
+        faq: [],
+      },
+    },
+  ],
+  leistungen: [
+    {
+      id: 'digital-cafe',
+      title: 'Digital Cafe 50+',
+      icon: '💻',
+      services: [
+        { key: 'digital-cafe-einzel', name: 'Einzelbegleitung', price: '60 €', unit: '/ Stunde', desc: 'Individuelle 1:1 Begleitung bei Ihnen zuhause oder in ruhiger Umgebung.' },
+        { key: 'digital-cafe-gruppe', name: 'Kleine Gruppe (2-4)', price: '40 €', unit: '/ Person / Stunde', desc: 'Gemeinsam lernen in kleiner Runde. Ideal fur Freundeskreise oder Nachbarn.' },
+        { key: 'digital-cafe-5er', name: '5er-Paket', price: '270 €', unit: 'statt 300 €', desc: '5 Einzelstunden zum Vorteilspreis. Flexible Terminwahl.', highlight: true },
+        { key: 'digital-cafe-10er', name: '10er-Paket', price: '500 €', unit: 'statt 600 €', desc: '10 Einzelstunden. Fur langfristige Begleitung.' },
+      ],
+    },
+    {
+      id: 'coaching',
+      title: 'Fuhrungskrafte-Coaching',
+      icon: '🎯',
+      services: [
+        { key: 'coaching-session', name: 'Einzelsession (90 Min.)', price: '150 €', unit: '/ Session', desc: 'Intensive Einzelsession fur Profilscharfung, Gesprachsvorbereitung oder Strategie.' },
+        { key: 'coaching-6er', name: '6er-Paket', price: '800 €', unit: 'statt 900 €', desc: 'Komplette Neuausrichtung in 6 Sessions. Der beliebteste Weg.', highlight: true },
+        { key: 'coaching-intensiv', name: 'Intensiv-Tag (6 Std.)', price: '500 €', unit: '/ Tag', desc: 'Ein ganzer Tag fokussiert auf Ihre Karrierestrategie.' },
+      ],
+    },
+    {
+      id: 'beratung',
+      title: 'Unternehmensberatung',
+      icon: '🏢',
+      services: [
+        { key: 'beratung-tag', name: 'Tagessatz', price: 'nach Vereinbarung', unit: '', desc: 'Digitale Transformation, Change Management, Strategie. Projektumfang individuell.' },
+      ],
+    },
+  ],
+  uebermich: {
+    pageHeadline: 'Von der Polizei Hamburg in die digitale Begleitung',
+    subheadline: 'Uber mich',
+    introParagraphs: [
+      'Nach uber 30 Jahren bei der Polizei Hamburg – davon viele Jahre in Fuhrungspositionen – habe ich 2023 einen neuen Weg eingeschlagen.',
+      'Was ich in all den Jahren gelernt habe? Menschen fuhren bedeutet vor allem: Menschen verstehen, Geduld haben, und Wissen so vermitteln, dass es ankommt.',
+    ],
+    sections: [
+      {
+        title: 'Warum Digital Cafe 50+?',
+        content: 'Als ich im Altenheim ein halbes Jahr lang ein Digital Cafe leitete, merkte ich: Hier kann ich genau diese Fahigkeiten einsetzen. Menschen der Generation 50+ stehen vor echten Herausforderungen in der digitalen Welt. Nicht weil sie "zu alt" sind – sondern weil niemand sich die Zeit nimmt, es in Ruhe und verstandlich zu erklaren.',
+      },
+      {
+        title: 'Warum Fuhrungskrafte-Coaching?',
+        content: '30+ Jahre Fuhrungserfahrung bedeutet auch: Ich kenne beide Seiten. Ich habe hunderte Fuhrungskrafte eingestellt, entwickelt, befordert. Ich weiss, worauf es ankommt. Diese Erfahrung gebe ich heute weiter.',
+      },
+    ],
+    milestones: [
+      { year: '1980-2023', title: 'Polizei Hamburg', desc: 'Uber 30 Jahre in Fuhrungspositionen. Personalfuhrung, Organisationsentwicklung, Strategie.' },
+      { year: 'Highlight', title: 'KI-Pionier', desc: 'Erste deutsche Polizeibehorde mit KI/Gesichtserkennung. BOS-Digitalfunk bundesweit fuhrend gemacht.' },
+      { year: '2023', title: 'Digital Cafe', desc: '6 Monate intensives Digital Cafe im Altenheim. Uber 50 Teilnehmer individuell begleitet.' },
+      { year: 'Seit 2024', title: 'Selbststandig', desc: 'Coach und Digitaler Begleiter. Fuhrungskrafte-Coaching und Unternehmensberatung.' },
+    ],
+    notDoing: [
+      { title: 'Keine technische Umsetzung', text: 'Ich berate, entwickle Strategien und begleite Change-Prozesse. Programmierung uberlasse ich Spezialisten.' },
+      { title: 'Keine Online-Kurse', text: 'Ich glaube an personliche Begleitung statt standardisierte, skalierbare Produkte.' },
+    ],
+    privateText: 'Ich lebe in {city}, bin verheiratet, habe zwei erwachsene Kinder. In meiner Freizeit bin ich viel zu Fuss unterwegs – Bewegung ist fur mich Meditation. Und ja, ich bin selbst Teil der Generation 50+ (65 Jahre) – ich weiss also aus eigener Erfahrung, wovon ich spreche.',
+  },
+  kontakt: {
+    intro: 'Egal ob Frage, Erstgesprach oder Feedback – ich freue mich, von Ihnen zu horen.',
+    sidebarTitle: 'Kostenloses Erstgesprach',
+    sidebarText: 'In 30 Minuten klaren wir: Wo stehen Sie? Was ist Ihre grosste Herausforderung? Wie konnte eine Zusammenarbeit aussehen?',
+    sidebarCta: 'Kein Verkaufsgesprach. Kein Druck. Nur Klarheit.',
+    showPhone: true,
+    showSteps: false,
+  },
+  faq: [
+    {
+      question: 'Fur wen ist das Digital Cafe geeignet?',
+      answer: 'Fur alle Menschen 50+, die digital selbststandiger werden mochten. Keine Vorkenntnisse notig – wir fangen genau da an, wo Sie stehen.',
+    },
+    {
+      question: 'Wie lauft ein Coaching ab?',
+      answer: 'Wir starten mit einem kostenlosen Erstgesprach (30-45 Min.), um Ihre Situation zu verstehen. Danach arbeiten wir in individuellen Sessions an Ihren Zielen – online oder vor Ort.',
+    },
+    {
+      question: 'Arbeiten Sie auch online?',
+      answer: 'Ja! Coaching und Beratung funktionieren hervorragend online per Video. Das Digital Cafe biete ich bevorzugt vor Ort in {city} und Umgebung an.',
+    },
+    {
+      question: 'Was kostet ein Erstgesprach?',
+      answer: 'Nichts. Das Erstgesprach ist kostenlos und unverbindlich. Wir lernen uns kennen und klaren, ob eine Zusammenarbeit passt.',
+    },
+    {
+      question: 'Was unterscheidet Sie von anderen Coaches?',
+      answer: 'Ich komme aus 30+ Jahren Fuhrungspraxis bei der Polizei Hamburg. Ich kenne beide Seiten des Tisches, bin direkt und ehrlich – und verstehe die Herausforderungen der Generation 50+ aus eigener Erfahrung.',
+    },
+  ],
+  leistungenCta: {
+    href: '/termin',
+    text: 'Termin buchen',
+  },
+  features: {
+    hasBooking: true,
+    hasRegistration: true,
+    hasOIDC: true,
+    hasBilling: true,
+  },
+};

--- a/website/src/config/index.ts
+++ b/website/src/config/index.ts
@@ -1,0 +1,6 @@
+import type { BrandConfig } from './types';
+import { mentolderConfig } from './brands/mentolder';
+import { korczewskiConfig } from './brands/korczewski';
+
+const brand = process.env.BRAND ?? 'mentolder';
+export const config: BrandConfig = brand === 'korczewski' ? korczewskiConfig : mentolderConfig;

--- a/website/src/config/types.ts
+++ b/website/src/config/types.ts
@@ -1,0 +1,121 @@
+export interface ServicePageSection {
+  title: string;
+  items: string[];
+}
+
+export interface ServicePagePricing {
+  label: string;
+  price: string;
+  unit?: string;
+  highlight?: boolean;
+}
+
+export interface ServicePageContent {
+  headline: string;
+  intro: string;
+  forWhom: string[];
+  sections: ServicePageSection[];
+  pricing: ServicePagePricing[];
+  faq?: Array<{ question: string; answer: string }>;
+}
+
+export interface HomepageService {
+  slug: string;
+  title: string;
+  description: string;
+  icon: string;
+  features: string[];
+  price: string;
+  pageContent: ServicePageContent;
+}
+
+export interface LeistungService {
+  key: string;
+  name: string;
+  price: string;
+  unit: string;
+  desc: string;
+  highlight?: boolean;
+}
+
+export interface LeistungCategory {
+  id: string;
+  title: string;
+  icon: string;
+  description?: string;
+  services: LeistungService[];
+}
+
+export interface LeistungPricingHighlight {
+  label: string;
+  price: string;
+  note: string;
+  highlight?: boolean;
+}
+
+export interface BrandConfig {
+  brand: 'mentolder' | 'korczewski';
+  meta: {
+    siteTitle: string;
+    siteDescription: string;
+  };
+  contact: {
+    name: string;
+    email: string;
+    phone: string;
+    city: string;
+  };
+  legal: {
+    street: string;
+    zip: string;
+    jobtitle: string;
+    chamber: string;
+    ustId: string;
+    website: string;
+    tagline: string;
+  };
+  homepage: {
+    stats: Array<{ value: string; label: string }>;
+    servicesHeadline: string;
+    servicesSubheadline: string;
+    whyMeHeadline: string;
+    whyMeIntro: string;
+    whyMePoints: Array<{ iconPath: string; title: string; text: string }>;
+    avatarType: 'image' | 'initials';
+    avatarSrc?: string;
+    avatarInitials?: string;
+    quote: string;
+    quoteName: string;
+  };
+  services: HomepageService[];
+  leistungen: LeistungCategory[];
+  leistungenPricingHighlight?: LeistungPricingHighlight[];
+  uebermich: {
+    pageHeadline: string;
+    subheadline: string;
+    introParagraphs: string[];
+    sections: Array<{ title: string; content: string }>;
+    milestones: Array<{ year: string; title: string; desc: string }>;
+    notDoing: Array<{ title: string; text: string }>;
+    privateText: string;
+  };
+  kontakt: {
+    intro: string;
+    sidebarTitle: string;
+    sidebarText: string;
+    sidebarCta: string;
+    showPhone: boolean;
+    showSteps?: boolean;
+  };
+  faq: Array<{ question: string; answer: string }>;
+  leistungenCta: {
+    href: string;
+    text: string;
+  };
+  features: {
+    hasBooking: boolean;
+    hasRegistration: boolean;
+    hasOIDC: boolean;
+    hasBilling: boolean;
+  };
+}

--- a/website/src/pages/api/auth/callback.ts
+++ b/website/src/pages/api/auth/callback.ts
@@ -1,5 +1,5 @@
 import type { APIRoute } from 'astro';
-import { exchangeCode, setSessionCookie } from '../../../lib/auth';
+import { exchangeCode, isAdmin, setSessionCookie } from '../../../lib/auth';
 
 // Keycloak redirects here after successful login.
 // Exchanges the authorization code for tokens and creates a session.
@@ -32,11 +32,16 @@ export const GET: APIRoute = async ({ url }) => {
     });
   }
 
-  // Set session cookie and redirect to original page
+  // If the caller requested a specific deep link (state !== '/'), honor it.
+  // Otherwise land admins on /admin and regular users on /portal.
+  const destination = state && state !== '/'
+    ? state
+    : (isAdmin(result.user) ? '/admin' : '/portal');
+
   return new Response(null, {
     status: 302,
     headers: {
-      Location: state,
+      Location: destination,
       'Set-Cookie': setSessionCookie(result.sessionId),
     },
   });

--- a/website/src/pages/api/auth/me.ts
+++ b/website/src/pages/api/auth/me.ts
@@ -1,5 +1,5 @@
 import type { APIRoute } from 'astro';
-import { getSession } from '../../../lib/auth';
+import { getSession, isAdmin } from '../../../lib/auth';
 
 // Returns the current user's session info as JSON.
 // Used by client-side Svelte components to check auth state.
@@ -22,6 +22,7 @@ export const GET: APIRoute = async ({ request }) => {
         username: session.preferred_username,
         givenName: session.given_name,
         familyName: session.family_name,
+        isAdmin: isAdmin(session),
       },
     }),
     {


### PR DESCRIPTION
## Summary

- **Admin/Portal auto-redirect:** Nach erfolgreichem Keycloak-Login landen Admins automatisch auf `/admin`, reguläre User auf `/portal`. Explizite Deep-Links via `state` werden weiter respektiert.
- **Nav-Link:** Eingeloggte Nutzer sehen jetzt einen goldenen Link „Admin" bzw. „Mein Portal" in der Top-Navigation (Desktop + Mobile), statt manuell `/admin` oder `/portal` ansurfen zu müssen.
- **Build-Blocker-Fix:** Stellt `website/src/config/{index,types}.ts` und `website/src/config/brands/{mentolder,korczewski}.ts` wieder her. Diese Dateien wurden in Commit `80b3a3b` aus mehreren Seiten (`registrieren.astro`, `ueber-mich.astro`, `leistungen.astro`, `impressum.astro`, `kontakt.astro`, `index.astro`, `layouts/Layout.astro`) importiert, aber nie mitgecommited — der Production-Build auf `main` war seither gebrochen (`Could not resolve "../config/index"`). Dateien cherry-picked aus `2355da0` auf Branch `feature/website-gaps`.

## Geänderte Dateien

- `website/src/pages/api/auth/callback.ts` — rollenbasierter Redirect nach Token-Exchange
- `website/src/pages/api/auth/me.ts` — liefert neues `isAdmin`-Feld
- `website/src/components/Navigation.svelte` — Portal/Admin-Link in Desktop + Mobile Nav
- `website/src/config/**` — 4 wiederhergestellte Dateien (Brand-Configs für mentolder + korczewski)

## Test plan

- [ ] `npx astro check` zeigt keine *neuen* Errors (vorherige 21 Config-Import-Errors sind weg; 2 pre-existing Buffer/Blob-Errors in `whisper.ts` bleiben)
- [ ] `npm run build` auf CI läuft durch (vorher blockiert)
- [ ] Login als `admin`-User → landet auf `/admin`
- [ ] Login als normaler User → landet auf `/portal`
- [ ] Top-Nav zeigt für Admin Link „Admin", für User „Mein Portal"
- [ ] Nach ArgoCD-Sync: beide Sites (`web.mentolder.de`, `web.korczewski.de`) zeigen Änderung

🤖 Generated with [Claude Code](https://claude.com/claude-code)