### PR TITLE
fix(docs): include index.html with mermaid renderer in docs-content CM

### DIFF
--- a/k3d/docs-content/index.html
+++ b/k3d/docs-content/index.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8">
+  <title>Workspace MVP Documentation</title>
+  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
+  <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+  <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/docsify/lib/themes/vue.css">
+</head>
+<body>
+  <div id="app"></div>
+  <script>
+    window.$docsify = {
+      name: 'Workspace MVP',
+      repo: '',
+      loadSidebar: true,
+      subMaxLevel: 2,
+      markdown: {
+        renderer: {
+          code: function(code, lang) {
+            if (lang === 'mermaid') {
+              return '<div class="mermaid">' + code + '</div>';
+            }
+            return this.origin.code.apply(this, arguments);
+          }
+        }
+      }
+    }
+  </script>
+  <script src="//cdn.jsdelivr.net/npm/docsify/lib/docsify.min.js"></script>
+  <script src="//cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"></script>
+  <script>
+    mermaid.initialize({ startOnLoad: false, securityLevel: 'loose' });
+    window.$docsify.plugins = [].concat(function(hook) {
+      hook.doneEach(function() {
+        mermaid.run({ querySelector: '.mermaid' });
+      });
+    }, window.$docsify.plugins || []);
+  </script>
+</body>
+</html>

--- a/k3d/kustomization.yaml
+++ b/k3d/kustomization.yaml
@@ -90,6 +90,7 @@ configMapGenerator:
       - default.conf=mattermost-userinfo-proxy.conf
   - name: docs-content
     files:
+      - docs-content/index.html
       - docs-content/README.md
       - docs-content/_sidebar.md
       - docs-content/architecture.md


### PR DESCRIPTION
## Summary

Fix Mermaid rendering on docs.korczewski.de (currently broken — blocks shown as raw code) and lock both clusters to the same canonical index.html.

## Root cause

`docs-site/index.html` lived in the repo but was **not** in the `configMapGenerator` files list for `docs-content` in `k3d/kustomization.yaml`. At some point the ConfigMap was created manually (`kubectl create cm --from-file=...`) and the live state diverged:

| Cluster | Live index.html | Mermaid diagrams |
|---|---|---|
| docs.mentolder.de | Workspace MVP Documentation title, Mermaid hook present | ✓ 3/3 render as SVG |
| docs.korczewski.de | Workspace Docs title, docsify-themeable theme, **no mermaid** | ✗ 9/9 shown as raw code |

Verified by port-forwarding `svc/docs` on both clusters and inspecting the rendered DOM + fetching `/index.html` from each pod.

## Fix

- Copy `docs-site/index.html` → `k3d/docs-content/index.html` (same file, now under the generator root)
- Add `- docs-content/index.html` to the `docs-content` configMapGenerator in `k3d/kustomization.yaml`

Verified locally with `kustomize build k3d`: the generated `docs-content` ConfigMap now has **17 keys** (previously 16), the new `index.html` key is present, and it contains both the `class="mermaid"` custom renderer and the `mermaid.min.js` script tag.

## Test plan

- [ ] CI: `task workspace:validate` green (already verified locally)
- [ ] After merge + ArgoCD sync on **korczewski**: visit docs.korczewski.de/#/architecture, verify mermaid diagrams render as SVG (currently raw code blocks)
- [ ] After merge + ArgoCD sync on **mentolder**: visit docs.mentolder.de/#/architecture, verify still renders (sanity check — should pick up the slightly newer `securityLevel: 'loose'` setting)
- [ ] Confirm docs-content ConfigMap now has 17 keys on both clusters (`kubectl get cm docs-content -o json | jq '.data | keys | length'`)

## Note

`docs-site/index.html` is now duplicated in `k3d/docs-content/index.html`. Future cleanup could remove the `docs-site/` directory entirely, since the canonical copy lives under the generator root. Left out of this PR to keep scope tight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)