### PR TITLE
refactor(bugs): DB as sole source of truth for bug tracking

### DIFF
--- a/website/src/pages/api/bug-report.ts
+++ b/website/src/pages/api/bug-report.ts
@@ -1,17 +1,8 @@
 import type { APIRoute } from 'astro';
-import {
-  postWebhook,
-  postInteractiveMessage,
-  getFirstTeamId,
-  getChannelByName,
-  uploadFile,
-} from '../../lib/mattermost';
 import { insertBugTicket } from '../../lib/meetings-db';
 
 const MAX_BYTES = 5 * 1024 * 1024;
 const ALLOWED_MIME = new Set(['image/png', 'image/jpeg', 'image/webp']);
-const DEFAULT_CHANNEL = process.env.BUG_REPORT_CHANNEL || 'bugs';
-const FALLBACK_CHANNEL = 'anfragen';
 const BRAND = process.env.BRAND || 'mentolder';
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
@@ -19,11 +10,6 @@ const CATEGORY_LABELS: Record<string, string> = {
   fehler: 'Fehler',
   verbesserung: 'Verbesserung',
   erweiterungswunsch: 'Erweiterungswunsch',
-};
-const CATEGORY_EMOJI: Record<string, string> = {
-  fehler: ':red_circle:',
-  verbesserung: ':bulb:',
-  erweiterungswunsch: ':sparkles:',
 };
 
 function jsonError(message: string, status: number): Response {
@@ -47,8 +33,7 @@ export const POST: APIRoute = async ({ request }) => {
     const email = (formData.get('email')?.toString() ?? '').trim().slice(0, 200);
     const category = (formData.get('category')?.toString() ?? '').trim();
     const url = (formData.get('url')?.toString() ?? 'unbekannt').slice(0, 500).replace(/[\r\n]/g, ' ');
-    const userAgent = (formData.get('userAgent')?.toString() ?? 'unbekannt').slice(0, 500).replace(/[\r\n]/g, ' ');
-    const viewport = (formData.get('viewport')?.toString() ?? 'unbekannt').slice(0, 40).replace(/[\r\n]/g, ' ');
+
     if (!description) {
       return jsonError('Bitte beschreiben Sie das Problem.', 400);
     }
@@ -62,9 +47,8 @@ export const POST: APIRoute = async ({ request }) => {
       return jsonError('Bitte wählen Sie eine Kategorie.', 400);
     }
 
+    // Validate screenshots (accepted but not stored yet)
     const screenshots = formData.getAll('screenshot');
-
-    const validFiles: File[] = [];
     for (const item of screenshots) {
       if (!(item instanceof File) || item.size === 0) continue;
       if (item.size > MAX_BYTES) {
@@ -73,112 +57,21 @@ export const POST: APIRoute = async ({ request }) => {
       if (!ALLOWED_MIME.has(item.type)) {
         return jsonError(`"${item.name}": Dateiformat nicht unterstützt. Erlaubt: PNG, JPEG, WEBP.`, 400);
       }
-      validFiles.push(item);
     }
-    if (validFiles.length > 3) {
+    if (screenshots.filter(s => s instanceof File && s.size > 0).length > 3) {
       return jsonError('Maximal 3 Screenshots erlaubt.', 400);
     }
 
     const ticketId = generateTicketId();
-    const categoryLabel = CATEGORY_LABELS[category];
-    const categoryEmoji = CATEGORY_EMOJI[category];
 
-    // Resolve Mattermost team + channel (fall back to anfragen if bugs missing)
-    const teamId = await getFirstTeamId();
-    let channelName = DEFAULT_CHANNEL;
-    let channelId: string | null = teamId ? await getChannelByName(teamId, DEFAULT_CHANNEL) : null;
-    let fallbackPrefix = '';
-    if (!channelId && teamId) {
-      channelId = await getChannelByName(teamId, FALLBACK_CHANNEL);
-      if (channelId) {
-        channelName = FALLBACK_CHANNEL;
-        fallbackPrefix = '[BUG] ';
-        console.warn(`[bug-report] Channel "${DEFAULT_CHANNEL}" missing, falling back to "${FALLBACK_CHANNEL}"`);
-      }
-    }
-
-    // Upload screenshots — best-effort, partial failure is a soft warning
-    const fileIds: string[] = [];
-    let uploadWarning = '';
-    if (validFiles.length > 0 && channelId) {
-      for (const f of validFiles) {
-        const fid = await uploadFile({ channelId, file: f });
-        if (fid) {
-          fileIds.push(fid);
-        } else {
-          uploadWarning = '\n\n:warning: Ein oder mehrere Screenshots konnten nicht hochgeladen werden';
-        }
-      }
-    }
-
-    const escapedDescription = description.replace(/\n/g, '\n> ');
-    const text =
-      `### :bug: ${fallbackPrefix}${ticketId} · Neuer Bug Report\n` +
-      `**Kategorie:** ${categoryEmoji} ${categoryLabel}\n` +
-      `**Status:** :hourglass_flowing_sand: offen\n` +
-      `**Reporter:** ${email}\n` +
-      `**Marke:** ${BRAND}\n\n` +
-      `| Feld | Inhalt |\n` +
-      `|------|--------|\n` +
-      `| **URL** | ${url} |\n` +
-      `| **Browser** | \`${userAgent}\` |\n` +
-      `| **Viewport** | ${viewport} |\n\n` +
-      `**Beschreibung:**\n> ${escapedDescription}${uploadWarning}`;
-
-    const sharedContext = {
+    await insertBugTicket({
       ticketId,
       category,
-      categoryLabel,
       reporterEmail: email,
       description,
       url,
-      userAgent,
-      viewport,
       brand: BRAND,
-    };
-
-    let delivered = false;
-    if (channelId) {
-      const postId = await postInteractiveMessage({
-        channelId,
-        text,
-        actions: [
-          { id: 'erledigt_bug', name: 'Erledigt', style: 'primary' },
-          { id: 'archive_bug', name: 'Archivieren', style: 'default' },
-        ],
-        context: sharedContext,
-        fileIds: fileIds.length > 0 ? fileIds : undefined,
-      });
-      delivered = postId !== null;
-    }
-
-    if (!delivered) {
-      const webhookOk = await postWebhook({
-        channel: channelName,
-        username: 'Bug-Bot',
-        icon_emoji: ':bug:',
-        text,
-      });
-      delivered = webhookOk;
-    }
-
-    if (!delivered) {
-      return jsonError('Interner Serverfehler. Bitte versuchen Sie es später erneut.', 500);
-    }
-
-    // Persist ticket to DB for /status lookups (best-effort)
-    try {
-      await insertBugTicket({
-        ticketId,
-        category,
-        reporterEmail: email,
-        description,
-        url,
-        brand: BRAND,
-      });
-    } catch (err) {
-      console.warn('[bug-report] DB insert failed (non-fatal):', err);
-    }
+    });
 
     return new Response(
       JSON.stringify({ success: true, ticketId }),

--- a/website/src/pages/api/mattermost/actions.ts
+++ b/website/src/pages/api/mattermost/actions.ts
@@ -1,6 +1,5 @@
 import type { APIRoute } from 'astro';
-import { updatePost, replyToPost, getFirstTeamId, getOrCreateCustomerChannel, postToChannel, postInteractiveMessage, openDialog } from '../../../lib/mattermost';
-import { archiveBugTicket } from '../../../lib/meetings-db';
+import { updatePost, replyToPost, getFirstTeamId, getOrCreateCustomerChannel, postToChannel, postInteractiveMessage } from '../../../lib/mattermost';
 import { createUser, sendPasswordResetEmail } from '../../../lib/keycloak';
 import { createCalendarEvent } from '../../../lib/caldav';
 import { createTalkRoom, inviteGuestByEmail } from '../../../lib/talk';
@@ -17,7 +16,7 @@ const PROD_DOMAIN = process.env.PROD_DOMAIN || '';
 export const POST: APIRoute = async ({ request }) => {
   try {
     const payload = await request.json();
-    const { post_id, channel_id, context, trigger_id } = payload;
+    const { post_id, channel_id, context } = payload;
     const action = context?.action;
 
     if (!action || !post_id) {
@@ -242,86 +241,6 @@ export const POST: APIRoute = async ({ request }) => {
           await replyToPost(post_id, channel_id, ':warning: Meeting-Finalisierung fehlgeschlagen. Bitte manuell prüfen.');
           return new Response(JSON.stringify({ ephemeral_text: 'Finalisierung fehlgeschlagen.' }));
         }
-      }
-
-      case 'erledigt_bug': {
-        if (!trigger_id) {
-          return new Response(
-            JSON.stringify({ ephemeral_text: ':warning: Kein trigger_id im Payload — Dialog kann nicht geöffnet werden.' }),
-            { status: 200, headers: { 'Content-Type': 'application/json' } }
-          );
-        }
-
-        const state = JSON.stringify({
-          postId: post_id ?? '',
-          channelId: channel_id ?? '',
-          ticketId: context.ticketId ?? '(kein Ticket)',
-          category: context.category ?? 'fehler',
-          categoryLabel: context.categoryLabel ?? 'Fehler',
-          reporterEmail: context.reporterEmail ?? 'unbekannt',
-          description: context.description ?? '',
-          url: context.url ?? 'unbekannt',
-          userAgent: context.userAgent ?? 'unbekannt',
-          viewport: context.viewport ?? 'unbekannt',
-          brand: context.brand ?? 'mentolder',
-        });
-
-        const siteUrl = process.env.SITE_URL || 'http://localhost:4321';
-
-        const opened = await openDialog({
-          triggerId: trigger_id,
-          url: `${siteUrl}/api/mattermost/dialog-submit`,
-          dialog: {
-            callback_id: 'erledigt_bug',
-            title: `${context.ticketId}: Als erledigt markieren`,
-            introduction_text: `**Kategorie:** ${context.categoryLabel}\n**Reporter:** ${context.reporterEmail}`,
-            elements: [
-              {
-                display_name: 'Was hast du gemacht?',
-                name: 'note',
-                type: 'textarea',
-                max_length: 500,
-                placeholder: 'Kurze Beschreibung der Lösung...',
-              },
-            ],
-            submit_label: 'Erledigt',
-            notify_on_cancel: false,
-            state,
-          },
-        });
-
-        if (!opened) {
-          return new Response(
-            JSON.stringify({ ephemeral_text: ':warning: Dialog konnte nicht geöffnet werden. Siehe Logs.' }),
-            { status: 200, headers: { 'Content-Type': 'application/json' } }
-          );
-        }
-
-        return new Response(JSON.stringify({}), { status: 200, headers: { 'Content-Type': 'application/json' } });
-      }
-
-      case 'archive_bug': {
-        const ticketId = context.ticketId ?? '(kein Ticket)';
-        const reporter = context.reporterEmail ?? 'unbekannt';
-        await updatePost(
-          post_id,
-          `### :file_cabinet: ${ticketId} · Archiviert\n\nReporter: ${reporter}`
-        );
-        // Update ticket status in DB (best-effort)
-        try {
-          await archiveBugTicket(ticketId);
-        } catch (err) {
-          console.warn('[actions] archive DB update failed (non-fatal):', err);
-        }
-        return new Response(
-          JSON.stringify({
-            update: {
-              message: `### :file_cabinet: ${ticketId} · Archiviert\n\nReporter: ${reporter}`,
-              props: { attachments: [] },
-            },
-          }),
-          { status: 200, headers: { 'Content-Type': 'application/json' } }
-        );
       }
 
       default:


### PR DESCRIPTION
## Summary

- **`bug-report.ts`**: DB insert is now the primary required operation. All Mattermost posting logic (interactive messages, webhooks, screenshot file upload) is removed. Screenshots are still validated client-side but not stored yet.
- **`actions.ts`**: Removes `erledigt_bug` and `archive_bug` Mattermost button handlers — ticket lifecycle is now managed exclusively via `/admin/bugs`.
- **DB migration**: Imported all missing `BR-20260414-*` tickets from Mattermost into the `bug_tickets` table:
  - 5 imported as **open**: f241, 1fb8, b80c, 4b91, 4b39
  - 4 imported as **resolved**: d624 (bug tracking visibility), 2568 (theming sprint), 82a0 (slogan fix), 3adf (multiple screenshots)
  - Test tickets (39a9, 4492, 6533, ce60) and duplicates (9214, b576, e337) discarded

## Test plan

- [ ] Submit a bug report on `web.mentolder.de` → ticket appears in `/admin/bugs`, no Mattermost post created
- [ ] Resolve/archive a ticket via `/admin/bugs` → status updates correctly
- [ ] `/admin/bugs` shows all 17+ open tickets cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)