### PR TITLE
feat(admin): dashboard grid replaces button bar

### DIFF
--- a/website/src/pages/admin.astro
+++ b/website/src/pages/admin.astro
@@ -1,9 +1,7 @@
 ---
 import Layout from '../layouts/Layout.astro';
 import { getSession, getLoginUrl, isAdmin } from '../lib/auth';
-import { listUsers } from '../lib/keycloak';
 import { listBugTickets } from '../lib/meetings-db';
-import type { KcUser } from '../lib/keycloak';
 
 const session = await getSession(Astro.request.headers.get('cookie'));
 if (!session) {
@@ -13,85 +11,71 @@ if (!isAdmin(session)) {
   return Astro.redirect('/portal');
 }
 
-let users: KcUser[] = [];
-try {
-  users = await listUsers();
-} catch {
-  // Keycloak unavailable
-}
+const BRAND = process.env.BRAND || 'mentolder';
 
 let openBugCount = 0;
 try {
-  const openTickets = await listBugTickets({
-    status: 'open',
-    brand: process.env.BRAND || 'mentolder',
-    limit: 1000,
-  });
+  const openTickets = await listBugTickets({ status: 'open', brand: BRAND, limit: 1000 });
   openBugCount = openTickets.length;
 } catch {
-  // DB unavailable — badge just shows 0
+  // DB unavailable — badge shows 0
 }
 ---
 
-<Layout title="Admin — Alle Clients">
+<Layout title="Admin — Dashboard">
   <section class="pt-28 pb-20 bg-dark min-h-screen">
     <div class="max-w-5xl mx-auto px-6">
-      <div class="mb-8 flex items-center justify-between">
-        <div>
-          <h1 class="text-3xl font-bold text-light font-serif">Clients</h1>
-          <p class="text-muted mt-1">{users.length} Benutzer</p>
-        </div>
-        <div class="flex gap-3">
-          <a
-            href="/admin/bugs"
-            class="relative px-4 py-2 bg-gold/20 text-gold rounded-lg text-sm font-medium hover:bg-gold/30 transition-colors"
-          >
-            Bug Reports
-            {openBugCount > 0 && (
-              <span class="absolute -top-1.5 -right-1.5 bg-red-500 text-white text-xs rounded-full w-5 h-5 flex items-center justify-center font-bold">
-                {openBugCount > 99 ? '99+' : openBugCount}
-              </span>
-            )}
-          </a>
-          <a
-            href="/admin/termine"
-            class="px-4 py-2 bg-gold/20 text-gold rounded-lg text-sm font-medium hover:bg-gold/30 transition-colors"
-          >
-            Termine
-          </a>
-          <a
-            href="/admin/angebote"
-            class="px-4 py-2 bg-gold/20 text-gold rounded-lg text-sm font-medium hover:bg-gold/30 transition-colors"
-          >
-            Angebote
-          </a>
-          <a
-            href="/admin/mattermost"
-            class="px-4 py-2 bg-gold/20 text-gold rounded-lg text-sm font-medium hover:bg-gold/30 transition-colors"
-          >
-            Mattermost
-          </a>
-        </div>
+
+      <div class="mb-10">
+        <h1 class="text-3xl font-bold text-light font-serif">Admin</h1>
+        <p class="text-muted mt-1">Verwaltung & Werkzeuge</p>
       </div>
 
-      <div class="grid gap-4" data-testid="admin-client-list">
-        {users.map(user => (
-          <a
-            href={`/admin/${user.id}`}
-            class="flex items-center gap-4 p-4 bg-dark-light rounded-xl border border-dark-lighter hover:border-gold/40 transition-colors"
-            data-testid="admin-client-item"
-          >
-            <div>
-              <p class="text-light font-medium">{user.firstName} {user.lastName}</p>
-              <p class="text-sm text-muted">{user.username} · {user.email ?? '—'}</p>
-            </div>
-            <span class="ml-auto text-gold text-sm">→</span>
-          </a>
-        ))}
-        {users.length === 0 && (
-          <p class="text-muted">Keine Benutzer gefunden.</p>
-        )}
+      <!-- Dashboard grid -->
+      <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 mb-10">
+
+        <!-- Bug Reports -->
+        <a href="/admin/bugs" class="relative group p-6 bg-dark-light rounded-xl border border-dark-lighter hover:border-gold/40 transition-colors">
+          {openBugCount > 0 && (
+            <span class="absolute top-4 right-4 bg-red-500 text-white text-xs font-bold rounded-full w-6 h-6 flex items-center justify-center">
+              {openBugCount > 99 ? '99+' : openBugCount}
+            </span>
+          )}
+          <div class="text-3xl mb-3">🐛</div>
+          <h2 class="text-light font-semibold text-lg group-hover:text-gold transition-colors">Bug Reports</h2>
+          <p class="text-muted text-sm mt-1">Issue-Tracking · Tickets auflisten, bearbeiten und schließen</p>
+        </a>
+
+        <!-- Termine -->
+        <a href="/admin/termine" class="group p-6 bg-dark-light rounded-xl border border-dark-lighter hover:border-gold/40 transition-colors">
+          <div class="text-3xl mb-3">📅</div>
+          <h2 class="text-light font-semibold text-lg group-hover:text-gold transition-colors">Termine</h2>
+          <p class="text-muted text-sm mt-1">Freie Slots der nächsten 14 Tage · Nextcloud-Kalender</p>
+        </a>
+
+        <!-- Angebote -->
+        <a href="/admin/angebote" class="group p-6 bg-dark-light rounded-xl border border-dark-lighter hover:border-gold/40 transition-colors">
+          <div class="text-3xl mb-3">🛍️</div>
+          <h2 class="text-light font-semibold text-lg group-hover:text-gold transition-colors">Angebote</h2>
+          <p class="text-muted text-sm mt-1">Titel, Beschreibung, Preis und Sichtbarkeit der Services</p>
+        </a>
+
+        <!-- Clients -->
+        <a href="/admin/clients" class="group p-6 bg-dark-light rounded-xl border border-dark-lighter hover:border-gold/40 transition-colors">
+          <div class="text-3xl mb-3">👥</div>
+          <h2 class="text-light font-semibold text-lg group-hover:text-gold transition-colors">Clients</h2>
+          <p class="text-muted text-sm mt-1">Registrierte Benutzer und deren Termine</p>
+        </a>
+
+        <!-- Mattermost -->
+        <a href="/admin/mattermost" class="group p-6 bg-dark-light rounded-xl border border-dark-lighter hover:border-gold/40 transition-colors">
+          <div class="text-3xl mb-3">💬</div>
+          <h2 class="text-light font-semibold text-lg group-hover:text-gold transition-colors">Mattermost</h2>
+          <p class="text-muted text-sm mt-1">Kanäle und Nachrichten verwalten</p>
+        </a>
+
       </div>
+
     </div>
   </section>
 </Layout>

--- a/website/src/pages/admin/clients.astro
+++ b/website/src/pages/admin/clients.astro
@@ -1,0 +1,55 @@
+---
+import Layout from '../../layouts/Layout.astro';
+import { getSession, getLoginUrl, isAdmin } from '../../lib/auth';
+import { listUsers } from '../../lib/keycloak';
+import type { KcUser } from '../../lib/keycloak';
+
+const session = await getSession(Astro.request.headers.get('cookie'));
+if (!session) return Astro.redirect(getLoginUrl());
+if (!isAdmin(session)) return Astro.redirect('/admin');
+
+let users: KcUser[] = [];
+try {
+  users = await listUsers();
+} catch {
+  // Keycloak unavailable
+}
+---
+
+<Layout title="Admin — Clients">
+  <section class="pt-28 pb-20 bg-dark min-h-screen">
+    <div class="max-w-5xl mx-auto px-6">
+      <div class="mb-8 flex items-center justify-between">
+        <div>
+          <h1 class="text-3xl font-bold text-light font-serif">Clients</h1>
+          <p class="text-muted mt-1">{users.length} Benutzer</p>
+        </div>
+        <a
+          href="/admin"
+          class="px-4 py-2 bg-dark-light text-muted rounded-lg text-sm font-medium hover:text-light transition-colors"
+        >
+          ← Zurück
+        </a>
+      </div>
+
+      <div class="grid gap-4" data-testid="admin-client-list">
+        {users.map(user => (
+          <a
+            href={`/admin/${user.id}`}
+            class="flex items-center gap-4 p-4 bg-dark-light rounded-xl border border-dark-lighter hover:border-gold/40 transition-colors"
+            data-testid="admin-client-item"
+          >
+            <div>
+              <p class="text-light font-medium">{user.firstName} {user.lastName}</p>
+              <p class="text-sm text-muted">{user.username} · {user.email ?? '—'}</p>
+            </div>
+            <span class="ml-auto text-gold text-sm">→</span>
+          </a>
+        ))}
+        {users.length === 0 && (
+          <p class="text-muted">Keine Benutzer gefunden.</p>
+        )}
+      </div>
+    </div>
+  </section>
+</Layout>


### PR DESCRIPTION
## Summary

- `/admin` is now a proper dashboard with labeled cards instead of a client list with small navigation buttons in the corner
- Bug Reports card shows open-ticket badge prominently — immediately visible as the issue tracker
- Client list moved to `/admin/clients` as its own page with a back link
- Cards: Bug Reports 🐛 · Termine 📅 · Angebote 🛍️ · Clients 👥 · Mattermost 💬

## Test plan

- [ ] Visit `https://web.mentolder.de/admin` → dashboard grid visible with all 5 cards
- [ ] Bug Reports card shows red badge with open ticket count
- [ ] Each card navigates to the correct sub-page
- [ ] `/admin/clients` shows user list with back link

🤖 Generated with [Claude Code](https://claude.com/claude-code)