### PR TITLE
fix(website): correct PORTAL_ADMIN_USERNAME to gekko

### DIFF
--- a/k3d/website.yaml
+++ b/k3d/website.yaml
@@ -57,7 +57,7 @@ data:
   # Mattermost signing channel
   MATTERMOST_SIGNING_CHANNEL: "signing"
   # Portal admin
-  PORTAL_ADMIN_USERNAME: "admin"
+  PORTAL_ADMIN_USERNAME: "gekko"
   CALENDAR_NAME: "personal"
   WORK_START_HOUR: "9"
   WORK_END_HOUR: "17"


### PR DESCRIPTION
## Summary

`PORTAL_ADMIN_USERNAME` was set to `"admin"` but no Keycloak user with that username exists in the workspace realm. Gerald's username is `gekko`. This caused all admin page access to silently redirect to `/portal`.

Live-patched on mentolder cluster already — this commit persists the fix.

## Test plan
- [ ] Log in as `gekko` on `web.mentolder.de` → navigation shows "Admin"
- [ ] `/admin` loads the dashboard grid
- [ ] `/admin/bugs` shows all open tickets

🤖 Generated with [Claude Code](https://claude.com/claude-code)