### PR TITLE
fix(auth): support multiple admin usernames (gekko + paddione)

### DIFF
--- a/k3d/website.yaml
+++ b/k3d/website.yaml
@@ -57,7 +57,7 @@ data:
   # Mattermost signing channel
   MATTERMOST_SIGNING_CHANNEL: "signing"
   # Portal admin
-  PORTAL_ADMIN_USERNAME: "gekko"
+  PORTAL_ADMIN_USERNAME: "gekko,paddione"
   CALENDAR_NAME: "personal"
   WORK_START_HOUR: "9"
   WORK_END_HOUR: "17"

--- a/website/src/lib/auth.ts
+++ b/website/src/lib/auth.ts
@@ -136,10 +136,12 @@ export async function exchangeCode(code: string): Promise<{ sessionId: string; u
   return { sessionId, user };
 }
 
-const ADMIN_USERNAME = process.env.PORTAL_ADMIN_USERNAME || 'admin';
+const ADMIN_USERNAMES = new Set(
+  (process.env.PORTAL_ADMIN_USERNAME || 'admin').split(',').map(s => s.trim()).filter(Boolean)
+);
 
 export function isAdmin(session: UserSession): boolean {
-  return session.preferred_username === ADMIN_USERNAME;
+  return ADMIN_USERNAMES.has(session.preferred_username);
 }
 
 export async function getSession(cookieHeader: string | null): Promise<UserSession | null> {


### PR DESCRIPTION
## Summary

- `isAdmin` now splits `PORTAL_ADMIN_USERNAME` on commas, so multiple users can have admin access
- ConfigMap updated to `"gekko,paddione"` — both Gerald and Patrick can access `/admin`

Live-patched on mentolder already.

## Test plan
- [ ] Log in as `gekko` → "Admin" visible in nav, `/admin/bugs` loads tickets
- [ ] Log in as `paddione` → same

🤖 Generated with [Claude Code](https://claude.com/claude-code)