### PR TITLE
fix(mattermost): ensure MATTERMOST_DB_PASSWORD is defined before datasource env var

### DIFF
--- a/prod/patch-mattermost.yaml
+++ b/prod/patch-mattermost.yaml
@@ -40,6 +40,11 @@ spec:
               value: "noreply@${PROD_DOMAIN}"
             - name: MM_EMAILSETTINGS_FEEDBACKNAME
               value: "${BRAND_NAME}"
+            - name: MATTERMOST_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: workspace-secrets
+                  key: MATTERMOST_DB_PASSWORD
             - name: MM_SQLSETTINGS_DATASOURCE
               value: "host=mattermost-db port=5432 user=mattermost password=$(MATTERMOST_DB_PASSWORD) dbname=mattermost sslmode=disable connect_timeout=10"
             - name: MM_LOGSETTINGS_ENABLEDIAGNOSTICS


### PR DESCRIPTION
## Summary

- Adds `MATTERMOST_DB_PASSWORD` to `prod/patch-mattermost.yaml` **before** `MM_SQLSETTINGS_DATASOURCE` so Kubernetes env-var substitution (`$(MATTERMOST_DB_PASSWORD)`) resolves correctly
- Without this fix, newly scheduled Mattermost pods used the literal string `$(MATTERMOST_DB_PASSWORD)` as the DB password, causing immediate CrashLoopBackOff on every rollout

## Test plan

- [ ] Apply patch to prod cluster and verify `kubectl rollout status deployment/mattermost -n workspace` completes successfully
- [ ] Confirm new pod connects to DB (no `password authentication failed` in logs)
- [ ] Old running pod terminates cleanly after new pod is healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)