### PR TITLE
fix(backup,whisper,tracking): fix DB backup, add whisper prod overlay, add tracking app

### DIFF
--- a/.github/workflows/build-tracking.yml
+++ b/.github/workflows/build-tracking.yml
@@ -1,0 +1,38 @@
+name: Build Tracking UI
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "deploy/tracking/tracking-ui/**"
+      - ".github/workflows/build-tracking.yml"
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: paddione/bachelorprojekt
+
+jobs:
+  build-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: deploy/tracking/tracking-ui
+          push: true
+          tags: ghcr.io/paddione/bachelorprojekt:latest

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -635,6 +635,11 @@ tasks:
     cmds:
       - kubectl exec -it -n workspace deploy/shared-db -- psql -U postgres -d {{.CLI_ARGS | default "postgres"}}
 
+  tracking:psql:
+    desc: 'Open psql shell with bachelorprojekt search_path (requirements tracking DB)'
+    cmds:
+      - kubectl exec -it -n workspace deploy/shared-db -- env PGOPTIONS="-c search_path=bachelorprojekt,public" psql -U postgres -d postgres
+
   workspace:port-forward:
     desc: 'Forward shared-db to localhost:5432'
     cmds:

--- a/deploy/tracking/init.sql
+++ b/deploy/tracking/init.sql
@@ -1,0 +1,68 @@
+-- Bachelorprojekt Requirements Tracking Schema
+-- Apply to shared-db (postgres database) as the postgres superuser.
+-- Usage: psql -h shared-db -U postgres -d postgres -f init.sql
+
+CREATE SCHEMA IF NOT EXISTS bachelorprojekt;
+
+CREATE TABLE IF NOT EXISTS bachelorprojekt.requirements (
+  id          TEXT PRIMARY KEY,           -- FA-01, SA-03, NFA-02, AK-03 …
+  category    TEXT NOT NULL,              -- FA, SA, NFA, AK, L
+  name        TEXT NOT NULL,
+  description TEXT,
+  criteria    TEXT,
+  test_case   TEXT,
+  created_at  TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS bachelorprojekt.pipeline (
+  id         SERIAL PRIMARY KEY,
+  req_id     TEXT NOT NULL REFERENCES bachelorprojekt.requirements(id) ON DELETE CASCADE,
+  stage      TEXT NOT NULL CHECK (stage IN ('idea','implementation','testing','documentation','archive')),
+  entered_at TIMESTAMPTZ DEFAULT now(),
+  notes      TEXT
+);
+
+CREATE TABLE IF NOT EXISTS bachelorprojekt.test_results (
+  id      SERIAL PRIMARY KEY,
+  req_id  TEXT NOT NULL REFERENCES bachelorprojekt.requirements(id) ON DELETE CASCADE,
+  result  TEXT NOT NULL CHECK (result IN ('pass','fail','skip')),
+  run_at  TIMESTAMPTZ DEFAULT now(),
+  details TEXT
+);
+
+-- Latest pipeline stage per requirement
+CREATE OR REPLACE VIEW bachelorprojekt.v_pipeline_status AS
+SELECT
+  r.id, r.name, r.category,
+  COALESCE(p.stage, 'idea') AS current_stage,
+  p.entered_at AS stage_since
+FROM bachelorprojekt.requirements r
+LEFT JOIN bachelorprojekt.pipeline p
+  ON p.req_id = r.id
+  AND p.entered_at = (
+    SELECT MAX(p2.entered_at) FROM bachelorprojekt.pipeline p2 WHERE p2.req_id = r.id
+  );
+
+-- Progress count by stage
+CREATE OR REPLACE VIEW bachelorprojekt.v_progress_summary AS
+SELECT current_stage AS stage, COUNT(*) AS count
+FROM bachelorprojekt.v_pipeline_status
+GROUP BY current_stage
+ORDER BY ARRAY_POSITION(ARRAY['idea','implementation','testing','documentation','archive'], current_stage);
+
+-- Requirements not yet archived
+CREATE OR REPLACE VIEW bachelorprojekt.v_open_issues AS
+SELECT *
+FROM bachelorprojekt.v_pipeline_status
+WHERE current_stage != 'archive'
+ORDER BY category, id;
+
+-- Most recent test result per requirement
+CREATE OR REPLACE VIEW bachelorprojekt.v_latest_tests AS
+SELECT DISTINCT ON (req_id) req_id, result, run_at, details
+FROM bachelorprojekt.test_results
+ORDER BY req_id, run_at DESC;
+
+-- Grant read access to the postgres superuser (already has it) and a dedicated role if desired
+-- GRANT USAGE ON SCHEMA bachelorprojekt TO tracking_reader;
+-- GRANT SELECT ON ALL TABLES IN SCHEMA bachelorprojekt TO tracking_reader;

--- a/deploy/tracking/tracking-ui/Dockerfile
+++ b/deploy/tracking/tracking-ui/Dockerfile
@@ -1,0 +1,11 @@
+FROM denoland/deno:2.3.1
+
+WORKDIR /app
+COPY deno.json .
+COPY main.ts .
+RUN deno cache main.ts
+
+EXPOSE 80
+ENV PORT=80
+
+CMD ["deno", "run", "--allow-net", "--allow-env", "main.ts"]

--- a/deploy/tracking/tracking-ui/deno.json
+++ b/deploy/tracking/tracking-ui/deno.json
@@ -1,0 +1,8 @@
+{
+  "tasks": {
+    "start": "deno run --allow-net --allow-env main.ts"
+  },
+  "imports": {
+    "postgres": "https://deno.land/x/postgres@v0.19.3/mod.ts"
+  }
+}

--- a/deploy/tracking/tracking-ui/main.ts
+++ b/deploy/tracking/tracking-ui/main.ts
@@ -1,0 +1,133 @@
+import { Client } from "postgres";
+
+const DB_URL = Deno.env.get("DATABASE_URL") ?? "postgres://postgres@shared-db:5432/postgres";
+const PORT = parseInt(Deno.env.get("PORT") ?? "80");
+
+const css = `
+  body { font-family: system-ui, sans-serif; background: #0f1623; color: #e0e6f0; margin: 0; padding: 24px; }
+  h1 { color: #e8c870; margin-bottom: 4px; }
+  h2 { color: #a0b0c8; margin-top: 32px; font-size: 1rem; text-transform: uppercase; letter-spacing: .1em; }
+  nav a { color: #e8c870; margin-right: 16px; text-decoration: none; }
+  nav a:hover { text-decoration: underline; }
+  table { border-collapse: collapse; width: 100%; max-width: 1000px; margin-top: 12px; }
+  th { background: #1a2235; color: #a0b0c8; text-align: left; padding: 8px 12px; font-size: .85rem; }
+  td { padding: 8px 12px; border-bottom: 1px solid #1a2235; font-size: .9rem; }
+  tr:hover td { background: #161f30; }
+  .badge { display: inline-block; padding: 2px 8px; border-radius: 4px; font-size: .8rem; font-weight: 600; }
+  .idea         { background: #2a3040; color: #8090a8; }
+  .implementation { background: #1a3050; color: #60a0e0; }
+  .testing      { background: #1a3020; color: #50c070; }
+  .documentation { background: #2a2010; color: #d09040; }
+  .archive      { background: #1a1a1a; color: #606060; }
+  .pass { background: #1a3020; color: #50c070; }
+  .fail { background: #301a1a; color: #e06060; }
+  .skip { background: #2a2010; color: #d09040; }
+  .FA { color: #60a0e0; } .SA { color: #e06060; } .NFA { color: #d09040; } .L { color: #a060e0; }
+`;
+
+function layout(title: string, body: string): string {
+  return `<!DOCTYPE html><html lang="de"><head><meta charset="utf-8">
+<title>${title} — Bachelorprojekt</title>
+<style>${css}</style></head><body>
+<h1>Bachelorprojekt Tracking</h1>
+<nav>
+  <a href="/">Pipeline</a>
+  <a href="/summary">Übersicht</a>
+  <a href="/open">Offen</a>
+  <a href="/tests">Tests</a>
+</nav>
+${body}
+</body></html>`;
+}
+
+async function query<T>(sql: string): Promise<T[]> {
+  const client = new Client(DB_URL);
+  await client.connect();
+  try {
+    const result = await client.queryObject<T>(sql);
+    return result.rows;
+  } finally {
+    await client.end();
+  }
+}
+
+type PipelineRow = { id: string; name: string; category: string; current_stage: string; stage_since: string | null };
+type SummaryRow  = { stage: string; count: string };
+type TestRow     = { req_id: string; result: string; run_at: string; details: string | null };
+
+async function handlePipeline(): Promise<string> {
+  const rows = await query<PipelineRow>("SELECT * FROM bachelorprojekt.v_pipeline_status ORDER BY category, id");
+  const trs = rows.map(r => `
+    <tr>
+      <td class="${r.category}">${r.id}</td>
+      <td>${r.name}</td>
+      <td><span class="badge ${r.current_stage}">${r.current_stage}</span></td>
+      <td>${r.stage_since ? new Date(r.stage_since).toLocaleDateString("de-DE") : "—"}</td>
+    </tr>`).join("");
+  return layout("Pipeline", `
+    <h2>Pipeline Status</h2>
+    <table><thead><tr><th>ID</th><th>Name</th><th>Stage</th><th>Seit</th></tr></thead>
+    <tbody>${trs}</tbody></table>`);
+}
+
+async function handleSummary(): Promise<string> {
+  const rows = await query<SummaryRow>("SELECT * FROM bachelorprojekt.v_progress_summary");
+  const trs = rows.map(r => `
+    <tr>
+      <td><span class="badge ${r.stage}">${r.stage}</span></td>
+      <td>${r.count}</td>
+    </tr>`).join("");
+  return layout("Übersicht", `
+    <h2>Fortschritt nach Stage</h2>
+    <table><thead><tr><th>Stage</th><th>Anzahl</th></tr></thead>
+    <tbody>${trs}</tbody></table>`);
+}
+
+async function handleOpen(): Promise<string> {
+  const rows = await query<PipelineRow>("SELECT * FROM bachelorprojekt.v_open_issues");
+  const trs = rows.map(r => `
+    <tr>
+      <td class="${r.category}">${r.id}</td>
+      <td>${r.name}</td>
+      <td><span class="badge ${r.current_stage}">${r.current_stage}</span></td>
+    </tr>`).join("");
+  return layout("Offene Issues", `
+    <h2>Offene Anforderungen (${rows.length})</h2>
+    <table><thead><tr><th>ID</th><th>Name</th><th>Stage</th></tr></thead>
+    <tbody>${trs}</tbody></table>`);
+}
+
+async function handleTests(): Promise<string> {
+  const rows = await query<TestRow>("SELECT * FROM bachelorprojekt.v_latest_tests ORDER BY req_id");
+  const trs = rows.map(r => `
+    <tr>
+      <td>${r.req_id}</td>
+      <td><span class="badge ${r.result}">${r.result}</span></td>
+      <td>${new Date(r.run_at).toLocaleDateString("de-DE")}</td>
+      <td>${r.details ?? "—"}</td>
+    </tr>`).join("");
+  return layout("Tests", `
+    <h2>Aktuelle Testergebnisse</h2>
+    <table><thead><tr><th>Anforderung</th><th>Ergebnis</th><th>Datum</th><th>Details</th></tr></thead>
+    <tbody>${trs}</tbody></table>`);
+}
+
+Deno.serve({ port: PORT }, async (req) => {
+  const url = new URL(req.url);
+  try {
+    let html: string;
+    if (url.pathname === "/summary")      html = await handleSummary();
+    else if (url.pathname === "/open")    html = await handleOpen();
+    else if (url.pathname === "/tests")   html = await handleTests();
+    else                                   html = await handlePipeline();
+    return new Response(html, { headers: { "content-type": "text/html; charset=utf-8" } });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return new Response(layout("Fehler", `<p style="color:#e06060">Datenbankfehler: ${msg}</p>`), {
+      status: 503,
+      headers: { "content-type": "text/html; charset=utf-8" },
+    });
+  }
+});
+
+console.log(`Tracking UI listening on :${PORT}`);

--- a/k3d/backup-cronjob.yaml
+++ b/k3d/backup-cronjob.yaml
@@ -44,14 +44,18 @@ spec:
               args:
                 - |
                   set -e
+                  apk add --no-cache openssl >/dev/null 2>&1
                   STAMP=$(date +%Y%m%d-%H%M%S)
                   BACKUP_DIR=/backups/${STAMP}
                   mkdir -p "${BACKUP_DIR}"
 
                   # Dump each database (separate PostgreSQL instances)
                   for db in keycloak mattermost nextcloud; do
-                    PASSVAR=$(echo "${db}" | tr '[:lower:]' '[:upper:]')_DB_PASSWORD
-                    eval PASS=\$$PASSVAR
+                    case "${db}" in
+                      keycloak)   PASS="${KEYCLOAK_DB_PASSWORD}" ;;
+                      mattermost) PASS="${MATTERMOST_DB_PASSWORD}" ;;
+                      nextcloud)  PASS="${NEXTCLOUD_DB_PASSWORD}" ;;
+                    esac
                     echo "Backing up ${db}..."
                     PGPASSWORD="${PASS}" pg_dump -Fc \
                       -h "${db}-db" -U "${db}" -d "${db}" \

--- a/prod/kustomization.yaml
+++ b/prod/kustomization.yaml
@@ -71,3 +71,5 @@ patches:
   - path: patch-talk-transcriber.yaml
   # Override signaling backend URL for production (HTTPS + real domain)
   - path: patch-signaling-backend.yaml
+  # Whisper: use public Docker image in production (registry.localhost not accessible)
+  - path: patch-whisper.yaml

--- a/prod/patch-whisper.yaml
+++ b/prod/patch-whisper.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: whisper
+  namespace: workspace
+spec:
+  template:
+    spec:
+      containers:
+        - name: whisper
+          image: fedirz/faster-whisper-server:latest-cpu
+          imagePullPolicy: Always

--- a/scripts/mattermost-cleanup-channels.sh
+++ b/scripts/mattermost-cleanup-channels.sh
@@ -1,0 +1,371 @@
+#!/usr/bin/env bash
+# ══════════════════════════════════════════════════════════════════════════════
+# mattermost-cleanup-channels.sh
+# Bereinigt Mattermost-Kanäle in Live-Umgebungen:
+#   - Löscht doppelte Service-Verzeichnis-Posts in workspace-services
+#   - Löscht doppelte Willkommensposts in Town Square
+#   - Aktualisiert Channel-Header mit aktuellen Production-Domains
+#   - Erstellt saubere, aktuelle Posts (1x pro Kanal)
+#
+# Usage:
+#   bash scripts/mattermost-cleanup-channels.sh korczewski
+#   bash scripts/mattermost-cleanup-channels.sh mentolder
+#   bash scripts/mattermost-cleanup-channels.sh korczewski mentolder
+#
+# Environment:
+#   NAMESPACE  - Kubernetes namespace (default: workspace)
+#   DRY_RUN    - "true": nur anzeigen, nichts ändern
+# ══════════════════════════════════════════════════════════════════════════════
+set -euo pipefail
+
+NAMESPACE="${NAMESPACE:-workspace}"
+DRY_RUN="${DRY_RUN:-false}"
+
+# Globale Variablen für mm_api (werden pro Kontext gesetzt)
+MM_URL=""
+MM_TOKEN=""
+
+CONTEXTS=("$@")
+if [ "${#CONTEXTS[@]}" -eq 0 ]; then
+  echo "Usage: $0 <kubectl-context> [<kubectl-context> ...]"
+  echo "  Beispiel: $0 korczewski mentolder"
+  exit 1
+fi
+
+# ── Logging ───────────────────────────────────────────────────────────────────
+log()  { echo "  $*"; }
+warn() { echo "  WARNUNG: $*"; }
+ok()   { echo "  OK: $*"; }
+dry()  { echo "  [DRY] $*"; }
+
+# ── Mattermost REST API ───────────────────────────────────────────────────────
+mm_api() {
+  local method="$1" endpoint="$2"
+  shift 2
+  curl -sf -X "${method}" "${MM_URL}/api/v4${endpoint}" \
+    -H "Authorization: Bearer ${MM_TOKEN}" \
+    -H "Content-Type: application/json" \
+    "$@"
+}
+
+# ── Post löschen ──────────────────────────────────────────────────────────────
+delete_post() {
+  local post_id="$1" reason="$2"
+  if [ "${DRY_RUN}" = "true" ]; then
+    dry "würde Post ${post_id} löschen (${reason})"
+    return 0
+  fi
+  mm_api DELETE "/posts/${post_id}" > /dev/null 2>&1 \
+    && ok "Post ${post_id} gelöscht (${reason})" \
+    || warn "Post ${post_id} konnte nicht gelöscht werden"
+}
+
+# ── Channel-Header setzen ─────────────────────────────────────────────────────
+update_channel_header() {
+  local channel_id="$1" header="$2" label="$3"
+  if [ "${DRY_RUN}" = "true" ]; then
+    dry "würde Header von ${label} aktualisieren"
+    return 0
+  fi
+  mm_api PUT "/channels/${channel_id}/patch" \
+    -d "{\"header\": $(echo "${header}" | python3 -c "import sys,json; print(json.dumps(sys.stdin.read().strip()))")}" \
+    > /dev/null 2>&1 \
+    && ok "${label} Header aktualisiert" \
+    || warn "${label} Header konnte nicht aktualisiert werden"
+}
+
+# ── Post aktualisieren ────────────────────────────────────────────────────────
+update_post() {
+  local post_id="$1" message="$2" label="$3"
+  if [ "${DRY_RUN}" = "true" ]; then
+    dry "würde Post ${post_id} in ${label} aktualisieren"
+    return 0
+  fi
+  mm_api PUT "/posts/${post_id}/patch" \
+    -d "{\"message\": $(echo "${message}" | python3 -c "import sys,json; print(json.dumps(sys.stdin.read()))")}" \
+    > /dev/null 2>&1 \
+    && ok "Post in ${label} aktualisiert (${post_id})" \
+    || warn "Post ${post_id} in ${label} konnte nicht aktualisiert werden"
+}
+
+# ── Post erstellen und pinnen ─────────────────────────────────────────────────
+post_and_pin() {
+  local channel_id="$1" message="$2" label="$3"
+  if [ "${DRY_RUN}" = "true" ]; then
+    dry "würde neuen Post in ${label} erstellen und pinnen"
+    return 0
+  fi
+  local post_json post_id
+  post_json=$(mm_api POST "/posts" \
+    -d "{\"channel_id\": \"${channel_id}\", \"message\": $(echo "${message}" | python3 -c "import sys,json; print(json.dumps(sys.stdin.read()))")}")
+  post_id=$(echo "${post_json}" | python3 -c "import sys,json; print(json.load(sys.stdin).get('id',''))" 2>/dev/null || echo "")
+  if [ -n "${post_id}" ]; then
+    mm_api POST "/posts/${post_id}/pin" > /dev/null 2>&1
+    ok "Post in ${label} erstellt und gepinnt (${post_id})"
+  else
+    warn "Post in ${label} konnte nicht erstellt werden"
+  fi
+}
+
+# ── Posts mit Suchbegriff im Kanal finden (älteste zuerst) ───────────────────
+find_posts_in_channel() {
+  local team_id="$1" channel_id="$2" search_term="$3"
+  mm_api POST "/teams/${team_id}/posts/search" \
+    -d "{\"terms\": \"${search_term}\", \"is_or_search\": false}" 2>/dev/null \
+  | python3 -c "
+import sys,json
+data = json.load(sys.stdin)
+posts = data.get('posts', {})
+result = [(p['id'], p['create_at']) for p in posts.values()
+          if '${search_term}' in p.get('message','')
+          and p.get('channel_id','') == '${channel_id}']
+result.sort(key=lambda x: x[1])  # älteste zuerst
+for pid, _ in result:
+    print(pid)
+" 2>/dev/null || true
+}
+
+# ── Kanal bereinigen: Duplikate löschen, verbleibenden Post aktualisieren ─────
+cleanup_channel_posts() {
+  local team_id="$1" channel_id="$2" search_term="$3" new_message="$4" label="$5"
+
+  local posts post_count newest_id
+  posts=$(find_posts_in_channel "${team_id}" "${channel_id}" "${search_term}")
+  post_count=0
+  [ -n "${posts}" ] && post_count=$(echo "${posts}" | wc -l | tr -d ' ')
+
+  log "${label}: ${post_count} passende Posts gefunden (Suchbegriff: '${search_term}')"
+
+  if [ "${post_count}" -eq 0 ]; then
+    log "Kein Post vorhanden — erstelle neuen..."
+    post_and_pin "${channel_id}" "${new_message}" "${label}"
+    return 0
+  fi
+
+  newest_id=$(echo "${posts}" | tail -1)
+
+  # Alle außer dem neuesten löschen
+  if [ "${post_count}" -gt 1 ]; then
+    while IFS= read -r pid; do
+      if [ "${pid}" != "${newest_id}" ]; then
+        delete_post "${pid}" "Duplikat in ${label}"
+      fi
+    done <<< "${posts}"
+  fi
+
+  # Neuesten Post auf aktuelle Inhalte aktualisieren
+  update_post "${newest_id}" "${new_message}" "${label}"
+  # Sicherstellen dass er gepinnt ist
+  if [ "${DRY_RUN}" != "true" ]; then
+    mm_api POST "/posts/${newest_id}/pin" > /dev/null 2>&1 || true
+  fi
+}
+
+# ── Einen Kontext (Cluster) verarbeiten ───────────────────────────────────────
+process_context() {
+  local CTX="$1"
+  echo ""
+  echo "══════════════════════════════════════════════════════"
+  echo "  Kontext: ${CTX}"
+  echo "══════════════════════════════════════════════════════"
+
+  # Mattermost URL — zuerst via mmctl config (JSON-Ausgabe), sonst aus ConfigMap
+  local RAW_URL
+  RAW_URL=$(kubectl --context="${CTX}" exec -n "${NAMESPACE}" deploy/mattermost -- \
+    mmctl --local config get ServiceSettings.SiteURL 2>/dev/null \
+    | python3 -c "import sys,json; v=sys.stdin.read().strip(); print(json.loads(v) if v.startswith('\"') else v)" \
+    2>/dev/null) || true
+
+  if [ -z "${RAW_URL}" ]; then
+    # Fallback: aus ConfigMap (MM_DOMAIN) mit https-Prefix
+    local MM_DOMAIN
+    MM_DOMAIN=$(kubectl --context="${CTX}" get configmap domain-config -n "${NAMESPACE}" \
+      -o jsonpath="{.data.MM_DOMAIN}" 2>/dev/null || echo "")
+    if [ -n "${MM_DOMAIN}" ]; then
+      RAW_URL="https://${MM_DOMAIN}"
+    fi
+  fi
+
+  MM_URL="${RAW_URL}"
+  if [ -z "${MM_URL}" ]; then
+    warn "Konnte Mattermost URL nicht ermitteln — überspringe ${CTX}"
+    return 1
+  fi
+  log "Mattermost URL: ${MM_URL}"
+
+  # Domains aus ConfigMap lesen
+  read_domain() {
+    kubectl --context="${CTX}" get configmap domain-config -n "${NAMESPACE}" \
+      -o "jsonpath={.data.$1}" 2>/dev/null || echo "$2"
+  }
+
+  local KC_DOMAIN NC_DOMAIN BILLING_DOMAIN VAULT_DOMAIN DOCS_DOMAIN WEB_DOMAIN AI_DOMAIN SCHEME
+  SCHEME="https"
+  KC_DOMAIN=$(read_domain "KC_DOMAIN" "auth.${CTX}.de")
+  NC_DOMAIN=$(read_domain "NC_DOMAIN" "files.${CTX}.de")
+  BILLING_DOMAIN=$(read_domain "BILLING_DOMAIN" "billing.${CTX}.de")
+  VAULT_DOMAIN=$(read_domain "VAULT_DOMAIN" "vault.${CTX}.de")
+  DOCS_DOMAIN=$(read_domain "DOCS_DOMAIN" "docs.${CTX}.de")
+  WEB_DOMAIN=$(read_domain "WEB_DOMAIN" "web.${CTX}.de")
+  AI_DOMAIN=$(read_domain "AI_DOMAIN" "ai.${CTX}.de")
+
+  log "Domains: NC=${NC_DOMAIN} | KC=${KC_DOMAIN} | BILLING=${BILLING_DOMAIN}"
+  log "         VAULT=${VAULT_DOMAIN} | DOCS=${DOCS_DOMAIN} | WEB=${WEB_DOMAIN} | AI=${AI_DOMAIN}"
+
+  # API-Token via mmctl generieren
+  MM_TOKEN=""
+  local ADMIN_USER_ID TOKEN_OUTPUT
+  ADMIN_USER_ID=$(kubectl --context="${CTX}" exec -n "${NAMESPACE}" deploy/mattermost -- \
+    mmctl --local user list --json 2>/dev/null | \
+    python3 -c "
+import sys,json
+users = json.load(sys.stdin) or []
+admins = [u for u in users if 'system_admin' in u.get('roles','')]
+if admins:
+    print(admins[0]['id'])
+" 2>/dev/null) || true
+
+  if [ -z "${ADMIN_USER_ID}" ]; then
+    warn "Kein Admin-User gefunden — überspringe ${CTX}"
+    return 1
+  fi
+
+  TOKEN_OUTPUT=$(kubectl --context="${CTX}" exec -n "${NAMESPACE}" deploy/mattermost -- \
+    mmctl --local token generate "${ADMIN_USER_ID}" "cleanup-$(date +%s)" 2>/dev/null) || true
+  MM_TOKEN=$(echo "${TOKEN_OUTPUT}" | grep -oP '^[a-z0-9]{26}' | head -1) || true
+
+  if [ -z "${MM_TOKEN}" ]; then
+    warn "Konnte keinen API-Token generieren — überspringe ${CTX}"
+    return 1
+  fi
+  log "API-Token generiert."
+
+  # ── Texte (Production, ohne Mailpit/localhost) ────────────────────────────
+  local TOWN_SQUARE_HEADER SVC_CHANNEL_HEADER SERVICE_DIRECTORY_MSG WELCOME_MSG
+
+  TOWN_SQUARE_HEADER=":file_folder: [Dateien](${SCHEME}://${NC_DOMAIN}) | :movie_camera: [Talk](${SCHEME}://${NC_DOMAIN}/apps/spreed) | :key: [SSO](${SCHEME}://${KC_DOMAIN}) | :receipt: [Rechnungen](${SCHEME}://${BILLING_DOMAIN}) | :lock: [Passwoerter](${SCHEME}://${VAULT_DOMAIN}) | :books: [Docs](${SCHEME}://${DOCS_DOMAIN}) | :globe_with_meridians: [Website](${SCHEME}://${WEB_DOMAIN})"
+
+  SVC_CHANNEL_HEADER=":file_folder: [Dateien](${SCHEME}://${NC_DOMAIN}) | :movie_camera: [Talk](${SCHEME}://${NC_DOMAIN}/apps/spreed) | :key: [SSO](${SCHEME}://${KC_DOMAIN}) | :receipt: [Rechnungen](${SCHEME}://${BILLING_DOMAIN}) | :lock: [Passwoerter](${SCHEME}://${VAULT_DOMAIN}) | :books: [Docs](${SCHEME}://${DOCS_DOMAIN}) | :globe_with_meridians: [Website](${SCHEME}://${WEB_DOMAIN}) | :robot_face: [MCP Status](${SCHEME}://${AI_DOMAIN})"
+
+  SERVICE_DIRECTORY_MSG="### :link: Workspace Service-Verzeichnis
+
+Alle direkt erreichbaren Services auf einen Blick:
+
+| Service | URL | Beschreibung |
+|---------|-----|--------------|
+| :file_folder: **Nextcloud** | [${NC_DOMAIN}](${SCHEME}://${NC_DOMAIN}) | Dateien, Kalender, Kontakte & gemeinsame Ordner |
+| :movie_camera: **Nextcloud Talk** | [${NC_DOMAIN}/apps/spreed](${SCHEME}://${NC_DOMAIN}/apps/spreed) | Video-Konferenzen & Gruppen-Calls |
+| :key: **Keycloak** | [${KC_DOMAIN}](${SCHEME}://${KC_DOMAIN}) | SSO & Benutzerverwaltung |
+| :receipt: **Invoice Ninja** | [${BILLING_DOMAIN}](${SCHEME}://${BILLING_DOMAIN}) | Rechnungen & Buchhaltung |
+| :lock: **Vaultwarden** | [${VAULT_DOMAIN}](${SCHEME}://${VAULT_DOMAIN}) | Passwort-Manager |
+| :books: **Dokumentation** | [${DOCS_DOMAIN}](${SCHEME}://${DOCS_DOMAIN}) | Anleitungen & Referenz |
+| :globe_with_meridians: **Website** | [${WEB_DOMAIN}](${SCHEME}://${WEB_DOMAIN}) | Unternehmens-Website |
+| :robot_face: **MCP Status** | [${AI_DOMAIN}](${SCHEME}://${AI_DOMAIN}) | KI-Infrastruktur & MCP-Server Status |
+
+---
+
+:pencil: **Collabora Office** und :art: **Whiteboard** sind in Nextcloud integriert und werden von dort aus geoeffnet — kein eigener Aufruf noetig.
+
+**Login:** Alle Services nutzen **Single Sign-On** ueber [Keycloak](${SCHEME}://${KC_DOMAIN}). Einmal anmelden — ueberall eingeloggt.
+
+**Hilfe:** Bei Fragen den Kanal \`claude-code\` nutzen oder die [Dokumentation](${SCHEME}://${DOCS_DOMAIN}) lesen."
+
+  WELCOME_MSG=":wave: **Workspace-Plattform — Uebersicht aller Services**
+
+Alle Services sind ueber den Browser erreichbar. Einmal mit **Single Sign-On** (Keycloak) anmelden — ueberall eingeloggt.
+
+:file_folder: **[Nextcloud — Dateien](${SCHEME}://${NC_DOMAIN})** — Dateien, Kalender, Kontakte & gemeinsame Ordner
+:movie_camera: **[Nextcloud Talk — Video](${SCHEME}://${NC_DOMAIN}/apps/spreed)** — Video-Konferenzen & Gruppen-Calls
+:key: **[Keycloak — SSO](${SCHEME}://${KC_DOMAIN})** — Benutzerverwaltung & Single Sign-On
+:receipt: **[Invoice Ninja — Rechnungen](${SCHEME}://${BILLING_DOMAIN})** — Buchhaltung & Rechnungsstellung
+:lock: **[Vaultwarden — Passwoerter](${SCHEME}://${VAULT_DOMAIN})** — Team-Passwort-Manager
+:books: **[Dokumentation](${SCHEME}://${DOCS_DOMAIN})** — Anleitungen & Referenz
+:globe_with_meridians: **[Website](${SCHEME}://${WEB_DOMAIN})** — Unternehmens-Website
+:robot_face: **[MCP Status](${SCHEME}://${AI_DOMAIN})** — KI-Infrastruktur & MCP-Server Status
+
+> :pencil: **Office-Dokumente & Whiteboards** werden direkt aus Nextcloud heraus geoeffnet — kein separater Login noetig.
+> Detaillierte Uebersicht im Kanal **~workspace-services**"
+
+  # ── Teams verarbeiten ─────────────────────────────────────────────────────
+  local TEAMS_JSON
+  TEAMS_JSON=$(mm_api GET "/teams")
+
+  while read -r TEAM_ID TEAM_NAME; do
+    echo ""
+    echo "  ── Team: ${TEAM_NAME} (${TEAM_ID}) ──"
+
+    # Town Square
+    local TS_JSON TS_CHANNEL_ID
+    TS_JSON=$(mm_api GET "/teams/${TEAM_ID}/channels/name/town-square" 2>/dev/null || echo "{}")
+    TS_CHANNEL_ID=$(echo "${TS_JSON}" | python3 -c "import sys,json; print(json.load(sys.stdin).get('id',''))" 2>/dev/null || echo "")
+
+    if [ -z "${TS_CHANNEL_ID}" ]; then
+      warn "Town Square nicht gefunden in Team ${TEAM_NAME}"
+    else
+      update_channel_header "${TS_CHANNEL_ID}" "${TOWN_SQUARE_HEADER}" "Town Square"
+      cleanup_channel_posts "${TEAM_ID}" "${TS_CHANNEL_ID}" "Workspace-Plattform" "${WELCOME_MSG}" "Town Square"
+    fi
+
+    # workspace-services
+    local SVC_JSON SVC_CHANNEL_ID
+    SVC_JSON=$(mm_api GET "/teams/${TEAM_ID}/channels/name/workspace-services" 2>/dev/null || echo "{}")
+    SVC_CHANNEL_ID=$(echo "${SVC_JSON}" | python3 -c "import sys,json; print(json.load(sys.stdin).get('id',''))" 2>/dev/null || echo "")
+
+    if [ -z "${SVC_CHANNEL_ID}" ]; then
+      log "workspace-services nicht gefunden — erstelle Kanal..."
+      if [ "${DRY_RUN}" != "true" ]; then
+        SVC_JSON=$(mm_api POST "/channels" \
+          -d "{
+            \"team_id\": \"${TEAM_ID}\",
+            \"name\": \"workspace-services\",
+            \"display_name\": \"Workspace Services\",
+            \"purpose\": \"Uebersicht und Links zu allen Workspace-Diensten\",
+            \"type\": \"O\"
+          }")
+        SVC_CHANNEL_ID=$(echo "${SVC_JSON}" | python3 -c "import sys,json; print(json.load(sys.stdin).get('id',''))" 2>/dev/null || echo "")
+        [ -n "${SVC_CHANNEL_ID}" ] && ok "Kanal workspace-services erstellt (${SVC_CHANNEL_ID})" || warn "Erstellung fehlgeschlagen"
+      else
+        dry "würde workspace-services erstellen"
+      fi
+    else
+      ok "Kanal workspace-services gefunden (${SVC_CHANNEL_ID})"
+    fi
+
+    if [ -n "${SVC_CHANNEL_ID}" ]; then
+      update_channel_header "${SVC_CHANNEL_ID}" "${SVC_CHANNEL_HEADER}" "workspace-services"
+      cleanup_channel_posts "${TEAM_ID}" "${SVC_CHANNEL_ID}" "Workspace Service-Verzeichnis" "${SERVICE_DIRECTORY_MSG}" "workspace-services"
+    fi
+
+  done < <(echo "${TEAMS_JSON}" | python3 -c "
+import sys,json
+for t in json.load(sys.stdin):
+    print(t['id'], t['name'])
+")
+
+  # Token widerrufen
+  local TOKEN_ID
+  TOKEN_ID=$(mm_api GET "/users/me/tokens" 2>/dev/null | python3 -c "
+import sys,json
+tokens = json.load(sys.stdin) or []
+for t in tokens:
+    if 'cleanup-' in t.get('description',''):
+        print(t['id'])
+        break
+" 2>/dev/null || echo "")
+  if [ -n "${TOKEN_ID}" ]; then
+    mm_api POST "/users/tokens/revoke" -d "{\"token_id\": \"${TOKEN_ID}\"}" > /dev/null 2>&1
+    log "Temporaerer Token bereinigt."
+  fi
+}
+
+# ── Hauptprogramm ─────────────────────────────────────────────────────────────
+echo "=== Mattermost Channel Cleanup + Update ==="
+[ "${DRY_RUN}" = "true" ] && echo "  [DRY RUN — keine Aenderungen werden vorgenommen]"
+echo ""
+
+for CTX in "${CONTEXTS[@]}"; do
+  process_context "${CTX}" || echo "  FEHLER in Kontext ${CTX} — fortfahren mit nächstem"
+done
+
+echo ""
+echo "=== Cleanup abgeschlossen ==="


### PR DESCRIPTION
## Summary

- **fix(backup):** Replace broken `eval PASS=\$$PASSVAR` with explicit `case` statement — in Alpine's `/bin/sh`, the eval pattern fails to expand the variable, causing pg_dump to authenticate with the literal string `KEYCLOAK_DB_PASSWORD` instead of the actual password. Also adds `apk add openssl` since `postgres:16-alpine` ships without it (needed for AES-256 dump encryption).
- **feat(whisper):** Add `prod/patch-whisper.yaml` to override the image from `registry.localhost:5000` (k3d-local only) to the public `fedirz/faster-whisper-server:latest-cpu` image; wired into `prod/kustomization.yaml`.
- **feat(tracking):** Add bachelorprojekt requirements-tracking Deno app (`deploy/tracking/`): Dockerfile, HTTP server (`main.ts`), `deno.json`, PostgreSQL schema (`init.sql`), GitHub Actions CI workflow that builds and pushes to GHCR, and `tracking:psql` Taskfile convenience task.
- **chore(scripts):** Add `mattermost-cleanup-channels.sh` utility script.

## Test plan

- [x] DB backup job `db-backup-verify2` completed successfully — all 3 DBs dumped and AES-256 encrypted
- [x] Whisper pod on production resolves `ImagePullBackOff` (public image now used)
- [x] Tracking app CI workflow triggers on push to `deploy/tracking/tracking-ui/**`

🤖 Generated with [Claude Code](https://claude.com/claude-code)