### PR TITLE
feat(tracking): add K8s deployment and multi-arch CI build

### DIFF
--- a/.github/workflows/build-tracking.yml
+++ b/.github/workflows/build-tracking.yml
@@ -30,9 +30,16 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
           context: deploy/tracking/tracking-ui
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ghcr.io/paddione/bachelorprojekt:latest

--- a/k3d/kustomization.yaml
+++ b/k3d/kustomization.yaml
@@ -45,6 +45,8 @@ resources:
   - docs.yaml
   # Wiki
   - outline.yaml
+  # Anforderungs-Tracking
+  - tracking.yaml
   # Transkription
   - whisper.yaml
   # Live-Transkription Bot

--- a/k3d/tracking.yaml
+++ b/k3d/tracking.yaml
@@ -1,0 +1,84 @@
+# ═══════════════════════════════════════════════════════════════════
+# Bachelorprojekt Requirements Tracking UI
+# Deno HTTP server reading from bachelorprojekt schema in shared-db
+# ═══════════════════════════════════════════════════════════════════
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: bachelorprojekt
+  labels:
+    app: bachelorprojekt
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: bachelorprojekt
+  template:
+    metadata:
+      labels:
+        app: bachelorprojekt
+    spec:
+      nodeSelector:
+        kubernetes.io/arch: amd64
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: DoesNotExist
+      containers:
+        - name: tracking-ui
+          image: ghcr.io/paddione/bachelorprojekt:latest
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 80
+          env:
+            - name: SHARED_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: workspace-secrets
+                  key: SHARED_DB_PASSWORD
+            - name: DATABASE_URL
+              value: "postgres://postgres:$(SHARED_DB_PASSWORD)@shared-db:5432/postgres"
+            - name: PORT
+              value: "80"
+          resources:
+            requests:
+              memory: 64Mi
+              cpu: "50m"
+            limits:
+              memory: 256Mi
+              cpu: "500m"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: bachelorprojekt
+  labels:
+    app: bachelorprojekt
+spec:
+  selector:
+    app: bachelorprojekt
+  ports:
+    - port: 80
+      targetPort: 80
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: bachelorprojekt
+  labels:
+    app: bachelorprojekt
+spec:
+  rules:
+    - host: tracking.localhost
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: bachelorprojekt
+                port:
+                  number: 80


### PR DESCRIPTION
## Summary

- **feat(tracking):** Add `k3d/tracking.yaml` — Deployment + Service + Ingress for the bachelorprojekt requirements tracking UI (`ghcr.io/paddione/bachelorprojekt:latest`). Includes `amd64` nodeSelector and control-plane nodeAffinity exclusion (pods on `pk-hetzner` have DNS issues). `DATABASE_URL` reads password via `$(SHARED_DB_PASSWORD)` from `workspace-secrets`.
- **feat(tracking):** Wire `tracking.yaml` into `k3d/kustomization.yaml`.
- **feat(ci):** Update `build-tracking.yml` to build `linux/amd64,linux/arm64` via QEMU + Buildx so the image runs on Raspberry Pi (`k3w-*`) nodes without `exec format error`.

## Test plan

- [x] Tracking UI pod running on `k3s-3` (amd64 worker), serving HTTP 200 on `/summary`
- [x] DB connection works: `postgres://postgres:$(SHARED_DB_PASSWORD)@shared-db:5432/postgres`
- [x] nodeAffinity excludes `pk-hetzner` (control-plane, broken DNS)
- [ ] Multi-arch image build will trigger on next merge to main touching `deploy/tracking/tracking-ui/**`

🤖 Generated with [Claude Code](https://claude.com/claude-code)