### PR TITLE
fix(schema): remove hardcoded mentolder brand default from bug_tickets

### DIFF
--- a/k3d/meetings-schema.yaml
+++ b/k3d/meetings-schema.yaml
@@ -114,7 +114,7 @@ data:
           reporter_email  TEXT NOT NULL,
           description     TEXT NOT NULL,
           url             TEXT,
-          brand           TEXT NOT NULL DEFAULT 'mentolder',
+          brand           TEXT NOT NULL,
           created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
           resolved_at     TIMESTAMPTZ,
           resolution_note TEXT


### PR DESCRIPTION
## Summary

- Removes hardcoded `DEFAULT 'mentolder'` from `bug_tickets.brand` in `k3d/meetings-schema.yaml`
- The application always provides `brand` explicitly via the `BRAND` env var — no default needed
- Silently wrong brand on korczewski cluster was root cause of the "wrong DB" confusion
- Applied `ALTER TABLE bug_tickets ALTER COLUMN brand DROP DEFAULT` to both live clusters

## Test plan

- [x] mentolder cluster: `brand` column has no default, existing tickets unaffected
- [x] korczewski cluster: `brand` column has no default, empty table ready for korczewski tickets

🤖 Generated with [Claude Code](https://claude.com/claude-code)