### PR TITLE
fix(coturn): add TURN/relay UDP ports to cloud-init firewall rules

### DIFF
--- a/prod/cloud-init.yaml
+++ b/prod/cloud-init.yaml
@@ -84,6 +84,9 @@ runcmd:
   - ufw allow 10250/tcp
   - ufw allow 8472/udp
   - ufw allow 51820/udp    # WireGuard GPU worker tunnel
+  - ufw allow 3478/tcp     # coturn TURN/STUN (TCP)
+  - ufw allow 3478/udp     # coturn TURN/STUN (UDP)
+  - ufw allow 49152:49252/udp  # coturn TURN relay port range
   - ufw allow 2379:2380/tcp
   - ufw --force enable
 


### PR DESCRIPTION
## Summary
- Add `ufw allow 3478/tcp`, `3478/udp`, and `49152:49252/udp` to `prod/cloud-init.yaml` for coturn TURN server
- Fixes Nextcloud Talk mobile app connectivity (resolves BR-20260415-d155)
- Rules were already applied live on gekko-hetzner-2; this ensures reproducibility on new nodes

## Related
- BR-20260415-d155: Android/iOS Talk apps not working
- Also applied: synced TURN_SECRET from workspace-secrets to coturn-secrets and reconfigured Nextcloud Talk with production secret

🤖 Generated with [Claude Code](https://claude.com/claude-code)