### PR TITLE
fix(auth,oauth2,vaultwarden): fix session expiry and correct service URLs

### DIFF
--- a/docs/superpowers/specs/2026-04-15-stripe-checkout-design.md
+++ b/docs/superpowers/specs/2026-04-15-stripe-checkout-design.md
@@ -1,0 +1,141 @@
+# Stripe Checkout — mentolder Homepage
+
+**Datum:** 2026-04-15  
+**Status:** Approved  
+**Scope:** mentolder-Brand (website-Namespace, mentolder-Cluster + korczewski-Cluster)
+
+---
+
+## Ziel
+
+Kunden können Coaching- und Digital-Café-Pakete direkt auf mentolder.de per Kreditkarte kaufen. Stripe Checkout (hosted) übernimmt Zahlungsabwicklung. Gerald erhält nach jeder Zahlung eine Mattermost-Notification.
+
+---
+
+## Architektur & Datenfluss
+
+```
+Homepage ServiceCard          Leistungen-Seite
+ "Ab 60 € — Jetzt buchen"     "5er-Paket 270 € — Kaufen"
+         │                              │
+         └──────────────┬───────────────┘
+                        ↓
+          POST /api/stripe/checkout
+          { serviceKey }
+                        │
+          Stripe API: createCheckoutSession()
+          ├─ success_url: /stripe/success?session_id={CHECKOUT_SESSION_ID}
+          └─ cancel_url:  /leistungen
+                        │
+                        ↓
+            checkout.stripe.com (hosted, PCI-compliant)
+                        │
+         ┌──────────────┴──────────────┐
+       Zahlung OK               Zahlung abgebrochen
+         │                              │
+    /stripe/success              /leistungen
+    + Mattermost-Notification    (stille Rückkehr)
+         │
+    POST /api/stripe/webhook
+    event: checkout.session.completed
+    → Mattermost-DM an Gerald
+```
+
+---
+
+## Neue Dateien
+
+| Datei | Zweck |
+|---|---|
+| `src/lib/stripe.ts` | Stripe-Client + Produkt/Preis-Mapping |
+| `src/pages/api/stripe/checkout.ts` | POST → erstellt Checkout Session, gibt `url` zurück |
+| `src/pages/api/stripe/webhook.ts` | POST → empfängt Stripe-Webhook, sendet MM-Notification |
+| `src/pages/stripe/success.astro` | Danke-Seite nach erfolgreicher Zahlung |
+
+## Geänderte Dateien
+
+| Datei | Änderung |
+|---|---|
+| `src/components/ServiceCard.svelte` | Optionaler Stripe-CTA-Button ("Ab X € direkt buchen") |
+| `src/pages/leistungen.astro` | "Kaufen"-Button pro Paket in der Preistabelle |
+| `src/config/brands/mentolder.ts` | `stripeServiceKey` pro leistungen-Eintrag ergänzen |
+
+---
+
+## Produkt-Mapping
+
+| serviceKey | Stripe-Produktname | Preis (€) | Checkout verfügbar |
+|---|---|---|---|
+| `digital-cafe-einzel` | 50+ digital — Einzelstunde | 60,00 | ja |
+| `digital-cafe-5er` | 50+ digital — 5er-Paket | 270,00 | ja (highlight) |
+| `digital-cafe-10er` | 50+ digital — 10er-Paket | 500,00 | ja |
+| `digital-cafe-gruppe` | 50+ digital — Gruppe | 40,00 | ja |
+| `coaching-session` | Coaching — Einzelsession (90 Min.) | 150,00 | ja |
+| `coaching-6er` | Coaching — 6er-Paket | 800,00 | ja (highlight) |
+| `coaching-intensiv` | Coaching — Intensivtag | 500,00 | ja |
+| `beratung-tag` | Unternehmensberatung | — | nein (→ Kontakt-CTA) |
+
+Produkte werden beim ersten Checkout-Aufruf via Stripe API erstellt (Price-Lookup-Key). Kein manuelles Anlegen in der Konsole nötig.
+
+---
+
+## Umgebungsvariablen
+
+| Variable | Quelle | Status |
+|---|---|---|
+| `STRIPE_SECRET_KEY` | workspace-secrets (beide Cluster) | bereits hinterlegt (sk_live) |
+| `STRIPE_PUBLISHABLE_KEY` | workspace-secrets (beide Cluster) | bereits hinterlegt (pk_live) |
+| `STRIPE_WEBHOOK_SECRET` | workspace-secrets (nach Webhook-Registrierung) | noch anzulegen |
+
+---
+
+## UI-Details
+
+**ServiceCard (Homepage):**
+- Jede Card mit `price`-Feld (außer Beratung) bekommt unter dem "Mehr erfahren"-Link einen zweiten Button: `💳 Ab [günstigster Preis] direkt buchen`
+- Button löst `fetch('/api/stripe/checkout', { method: 'POST', body: JSON.stringify({ serviceKey }) })` aus, leitet bei Erfolg auf `data.url` weiter
+- Loading-State während der API-Anfrage
+
+**Leistungen-Seite:**
+- Jede Preiszeile mit bekanntem `serviceKey` bekommt einen "Kaufen"-Button
+- Highlight-Pakete: gold-border, prominenter CTA
+- Beratung: Button ersetzt durch "Anfragen →" (Link zu /kontakt)
+
+**Success-Seite `/stripe/success`:**
+- Bestätigungstext: Produkt, Betrag, Hinweis "Gerald meldet sich innerhalb von 24h"
+- BugReportWidget mit vorausgefüllter Kategorie `zahlung` am Seitenende
+
+---
+
+## Webhook-Flow
+
+```
+Stripe → POST /api/stripe/webhook
+  Header: stripe-signature (HMAC-SHA256)
+  Body: { type: "checkout.session.completed", data: { object: session } }
+         │
+  stripe.webhooks.constructEvent() — Signatur prüfen
+         │
+  Mattermost-DM an Gerald:
+  "💳 Neue Zahlung: [Produkt] — [Betrag] € von [customer_email]"
+```
+
+Webhook-Endpoint ist öffentlich erreichbar (kein Auth-Guard), aber durch Stripe-Signaturprüfung gesichert.
+
+---
+
+## Fehlerbehandlung
+
+- API-Endpoint gibt `{ error }` zurück bei ungültigem `serviceKey` oder Stripe-Fehler → ServiceCard zeigt Fehlermeldung
+- Webhook: Signaturprüfung fehlgeschlagen → 400, kein Logging der Payload
+- Stripe Checkout abgebrochen → stille Rückkehr zu `/leistungen` (kein Fehler-Banner)
+- Zahlung fehlgeschlagen: Stripe-eigene Fehlermeldung auf hosted Checkout
+
+---
+
+## Nicht im Scope
+
+- Rechnungserstellung via Invoice Ninja (separater Flow)
+- Abo-/Subscription-Modelle
+- Rückerstattungen (Stripe-Dashboard)
+- Beratung-Tarif als Checkout (Preis variabel → Kontakt-Flow)

--- a/k3d/oauth2-proxy-invoiceninja.yaml
+++ b/k3d/oauth2-proxy-invoiceninja.yaml
@@ -53,6 +53,8 @@ spec:
             - --insecure-oidc-allow-unverified-email=true
             - --oidc-extra-audience=invoiceninja
             - --scope=openid email profile
+            - --cookie-expire=168h
+            - --cookie-refresh=1h
           env:
             - name: INVOICENINJA_OIDC_SECRET
               valueFrom:

--- a/k3d/vaultwarden-seed-job.yaml
+++ b/k3d/vaultwarden-seed-job.yaml
@@ -41,6 +41,41 @@ spec:
               bw create folder '{"name":"Services"}'
               bw create folder '{"name":"MCP Keys"}'
 
+              # Seed workspace service URLs (upsert: delete existing by name, then create)
+              upsert_login() {
+                local name="$1" uri="$2" notes="$3"
+                # Delete any existing item with the same name
+                local existing_id
+                existing_id=$(bw list items --search "$name" 2>/dev/null | jq -r ".[] | select(.name==\"$name\") | .id" | head -1)
+                [ -n "$existing_id" ] && bw delete item "$existing_id" 2>/dev/null || true
+                local item
+                item=$(bw get template item | jq \
+                  --arg n "$name" --arg u "$uri" --arg note "$notes" \
+                  '.type=1 | .name=$n | .notes=$note | .login.uris=[{"match":null,"uri":$u}]')
+                echo "$item" | bw encode | bw create item
+              }
+
+              MM="${MM_DOMAIN:-chat.mentolder.de}"
+              NC="${NC_DOMAIN:-files.mentolder.de}"
+              KC="${KC_DOMAIN:-auth.mentolder.de}"
+              BILLING="${BILLING_DOMAIN:-billing.mentolder.de}"
+              WEB="${WEB_DOMAIN:-web.mentolder.de}"
+              AI="${AI_DOMAIN:-ai.mentolder.de}"
+              DOCS="${DOCS_DOMAIN:-docs.mentolder.de}"
+              OFFICE="${OFFICE_DOMAIN:-office.mentolder.de}"
+
+              upsert_login "Mattermost — Chat"              "https://${MM}"               "Team-Chat und Kommunikation"
+              upsert_login "Nextcloud — Dateien"            "https://${NC}"               "Dateispeicher und Kollaboration"
+              upsert_login "Nextcloud Talk — Video"         "https://${NC}/apps/spreed"   "Video-/Sprachanrufe via Nextcloud Talk"
+              upsert_login "Whiteboard"                     "https://${NC}/apps/whiteboard" "Kollaboratives Whiteboard (Nextcloud-App, nicht board.* öffnen)"
+              upsert_login "Collabora Office"               "https://${OFFICE}"           "Online-Office (Word/Excel/Impress)"
+              upsert_login "Invoice Ninja — Abrechnung"     "https://${BILLING}"          "Rechnungen und Abrechnung (Login via Keycloak SSO)"
+              upsert_login "Keycloak — Benutzerverwaltung"  "https://${KC}"               "SSO und Benutzerverwaltung"
+              upsert_login "Portal — Kundenbereich"         "https://${WEB}/portal"       "Kundenportal (Login via Keycloak SSO)"
+              upsert_login "Admin — Website-Verwaltung"     "https://${WEB}/admin"        "Website-Admin (Login via Keycloak SSO)"
+              upsert_login "Claude Code KI"                 "https://${AI}"               "KI-Assistent"
+              upsert_login "Docs"                           "https://${DOCS}"             "Dokumentation"
+
               echo "Vaultwarden seeding completed successfully."
           env:
             - name: BW_EMAIL
@@ -53,5 +88,53 @@ spec:
                 secretKeyRef:
                   name: vaultwarden-seed-credentials
                   key: BW_PASSWORD
+            - name: MM_DOMAIN
+              valueFrom:
+                configMapKeyRef:
+                  name: domain-config
+                  key: MM_DOMAIN
+                  optional: true
+            - name: NC_DOMAIN
+              valueFrom:
+                configMapKeyRef:
+                  name: domain-config
+                  key: NC_DOMAIN
+                  optional: true
+            - name: KC_DOMAIN
+              valueFrom:
+                configMapKeyRef:
+                  name: domain-config
+                  key: KC_DOMAIN
+                  optional: true
+            - name: BILLING_DOMAIN
+              valueFrom:
+                configMapKeyRef:
+                  name: domain-config
+                  key: BILLING_DOMAIN
+                  optional: true
+            - name: WEB_DOMAIN
+              valueFrom:
+                configMapKeyRef:
+                  name: domain-config
+                  key: WEB_DOMAIN
+                  optional: true
+            - name: AI_DOMAIN
+              valueFrom:
+                configMapKeyRef:
+                  name: domain-config
+                  key: AI_DOMAIN
+                  optional: true
+            - name: DOCS_DOMAIN
+              valueFrom:
+                configMapKeyRef:
+                  name: domain-config
+                  key: DOCS_DOMAIN
+                  optional: true
+            - name: OFFICE_DOMAIN
+              valueFrom:
+                configMapKeyRef:
+                  name: domain-config
+                  key: COLLABORA_DOMAIN
+                  optional: true
       restartPolicy: OnFailure
   backoffLimit: 2

--- a/prod/patch-oauth2-proxy.yaml
+++ b/prod/patch-oauth2-proxy.yaml
@@ -33,4 +33,6 @@ spec:
             - "--insecure-oidc-allow-unverified-email=true"
             - "--oidc-extra-audience=invoiceninja"
             - "--scope=openid email profile"
+            - "--cookie-expire=168h"
+            - "--cookie-refresh=1h"
             - "--skip-auth-regex=^/(favicon\\.ico|manifest\\.json|css/|js/|images/|fonts/|payment_webhook/|api/v1/payment_webhook)"

--- a/website/src/lib/auth.ts
+++ b/website/src/lib/auth.ts
@@ -83,6 +83,30 @@ export async function getLogoutUrl(sessionId?: string): Promise<string> {
   return `${LOGOUT_ENDPOINT}?${params}`;
 }
 
+// 8 hours — session lifetime in the DB (independent of the short-lived access token)
+const SESSION_TTL_MS = 8 * 60 * 60 * 1000;
+
+async function refreshTokens(refreshToken: string): Promise<{ access_token: string; refresh_token: string; expires_in: number } | null> {
+  try {
+    const res = await fetch(TOKEN_ENDPOINT, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        grant_type: 'refresh_token',
+        client_id: CLIENT_ID,
+        client_secret: CLIENT_SECRET,
+        refresh_token: refreshToken,
+      }),
+    });
+    if (!res.ok) return null;
+    const data = await res.json();
+    if (!data.access_token) return null;
+    return { access_token: data.access_token, refresh_token: data.refresh_token || refreshToken, expires_in: data.expires_in || 300 };
+  } catch {
+    return null;
+  }
+}
+
 export async function exchangeCode(code: string): Promise<{ sessionId: string; user: UserSession } | null> {
   const res = await fetch(TOKEN_ENDPOINT, {
     method: 'POST',
@@ -116,6 +140,7 @@ export async function exchangeCode(code: string): Promise<{ sessionId: string; u
   const userInfo = await userRes.json();
 
   const sessionId = generateSessionId();
+  const sessionExpiry = Date.now() + SESSION_TTL_MS;
   const user: UserSession = {
     sub: userInfo.sub,
     email: userInfo.email,
@@ -125,13 +150,13 @@ export async function exchangeCode(code: string): Promise<{ sessionId: string; u
     family_name: userInfo.family_name,
     access_token: tokens.access_token,
     refresh_token: tokens.refresh_token,
-    expires_at: Date.now() + tokens.expires_in * 1000,
+    expires_at: sessionExpiry,
   };
 
   await ensureSessionsTable();
   await sessionPool.query(
     'INSERT INTO web_sessions (id, data, expires_at) VALUES ($1, $2, $3)',
-    [sessionId, JSON.stringify(user), new Date(user.expires_at)]
+    [sessionId, JSON.stringify(user), new Date(sessionExpiry)]
   );
   return { sessionId, user };
 }
@@ -161,11 +186,30 @@ export async function getSession(cookieHeader: string | null): Promise<UserSessi
 
     if (result.rows.length === 0) return null;
 
-    const session = result.rows[0].data as UserSession;
+    let session = result.rows[0].data as UserSession;
 
-    if (session.expires_at < Date.now() + 60000) {
-      await sessionPool.query('DELETE FROM web_sessions WHERE id = $1', [sessionId]);
-      return null;
+    // Proactively refresh Keycloak access token when it's within 5 minutes of expiry
+    // while keeping the DB session alive for the full SESSION_TTL_MS.
+    const ACCESS_TOKEN_BUFFER_MS = 5 * 60 * 1000;
+    if (session.expires_at - Date.now() < ACCESS_TOKEN_BUFFER_MS) {
+      const refreshed = await refreshTokens(session.refresh_token);
+      if (refreshed) {
+        const newExpiry = Date.now() + SESSION_TTL_MS;
+        session = {
+          ...session,
+          access_token: refreshed.access_token,
+          refresh_token: refreshed.refresh_token,
+          expires_at: newExpiry,
+        };
+        await sessionPool.query(
+          'UPDATE web_sessions SET data = $1, expires_at = $2 WHERE id = $3',
+          [JSON.stringify(session), new Date(newExpiry), sessionId]
+        );
+      } else {
+        // Refresh failed — session is expired, clean up
+        await sessionPool.query('DELETE FROM web_sessions WHERE id = $1', [sessionId]);
+        return null;
+      }
     }
 
     return session;
@@ -182,7 +226,8 @@ export function getSessionId(cookieHeader: string | null): string | undefined {
 }
 
 export function setSessionCookie(sessionId: string): string {
-  return `${COOKIE_NAME}=${sessionId}; Path=/; HttpOnly; SameSite=Lax; Max-Age=86400`;
+  const maxAgeSeconds = Math.floor(SESSION_TTL_MS / 1000);
+  return `${COOKIE_NAME}=${sessionId}; Path=/; HttpOnly; SameSite=Lax; Max-Age=${maxAgeSeconds}`;
 }
 
 export function clearSessionCookie(): string {


### PR DESCRIPTION
## Summary
- **Portal re-login (BR-c59e)**: Session lifetime was `tokens.expires_in` (~5 min Keycloak default), causing login prompts after brief inactivity. Now 8h with automatic silent refresh via `refresh_token`.
- **Invoice Ninja re-login (BR-2556)**: oauth2-proxy had no `--cookie-expire`/`--cookie-refresh`. Added `168h` expire + `1h` refresh; applied live via `kubectl patch`.
- **Whiteboard URL (BR-4754)**: Vaultwarden seed job now creates login entries for all services with correct URLs. Whiteboard → `files.<domain>/apps/whiteboard`. Run `task workspace:vaultwarden:seed` to update existing vault entries.

## Test plan
- [ ] Log into portal, wait 6+ minutes, navigate to another page → should stay logged in
- [ ] Open Invoice Ninja from Vaultwarden → should redirect via Keycloak SSO (first time only, then cookie valid 7 days)
- [ ] Re-run `task workspace:vaultwarden:seed ENV=mentolder` → check that service entries are created with correct URLs
- [ ] Click Whiteboard entry in Vaultwarden → should open Nextcloud whiteboard, not the backend server

🤖 Generated with [Claude Code](https://claude.com/claude-code)