### PR TITLE
feat(admin): Admin-Toolkit Erweiterung — Zeiterfassung, Rechnungen, Follow-ups, Kalender, KPI-Dashboard

### DIFF
--- a/website/src/components/portal/ClientNotesTab.astro
+++ b/website/src/components/portal/ClientNotesTab.astro
@@ -9,10 +9,11 @@ interface Props {
 const { keycloakUserId, back } = Astro.props;
 
 let notes: ClientNote[] = [];
+let dbError = false;
 try {
   notes = await listClientNotes(keycloakUserId);
 } catch {
-  // DB unavailable
+  dbError = true;
 }
 
 function fmtDate(d: Date): string {
@@ -39,9 +40,13 @@ function fmtDate(d: Date): string {
     </button>
   </form>
 
-  {notes.length === 0 ? (
+  {dbError && (
+    <p class="text-red-400 text-sm">Fehler beim Laden der Notizen.</p>
+  )}
+  {!dbError && notes.length === 0 && (
     <p class="text-muted text-sm">Noch keine Notizen vorhanden.</p>
-  ) : (
+  )}
+  {!dbError && notes.length > 0 && (
     <ul class="space-y-3">
       {notes.map(n => (
         <li class="flex gap-3 p-4 bg-dark rounded-xl border border-dark-lighter" data-testid="client-note-item">

--- a/website/src/components/portal/ClientNotesTab.astro
+++ b/website/src/components/portal/ClientNotesTab.astro
@@ -1,0 +1,66 @@
+---
+import { listClientNotes } from '../../lib/website-db';
+import type { ClientNote } from '../../lib/website-db';
+
+interface Props {
+  keycloakUserId: string;
+  back: string;
+}
+const { keycloakUserId, back } = Astro.props;
+
+let notes: ClientNote[] = [];
+try {
+  notes = await listClientNotes(keycloakUserId);
+} catch {
+  // DB unavailable
+}
+
+function fmtDate(d: Date): string {
+  return new Date(d).toLocaleString('de-DE', {
+    day: '2-digit', month: '2-digit', year: 'numeric',
+    hour: '2-digit', minute: '2-digit',
+  });
+}
+---
+
+<div data-testid="client-notes-tab">
+  <h3 class="text-lg font-semibold text-light mb-4">Notizen & Aktivitäten</h3>
+
+  <!-- New note form -->
+  <form method="post" action="/api/admin/clientnotes/create" class="mb-6 flex gap-2">
+    <input type="hidden" name="keycloakUserId" value={keycloakUserId} />
+    <input type="hidden" name="_back" value={back} />
+    <textarea name="content" rows="2" maxlength="2000" required
+      placeholder="Neue Notiz eingeben …"
+      class="flex-1 px-3 py-2 bg-dark border border-dark-lighter rounded-lg text-light text-sm focus:border-gold focus:ring-2 focus:ring-gold/20 outline-none resize-none"></textarea>
+    <button type="submit"
+      class="px-4 py-2 bg-gold hover:bg-gold-light text-dark text-sm font-semibold rounded-lg transition-colors self-start">
+      Hinzufügen
+    </button>
+  </form>
+
+  {notes.length === 0 ? (
+    <p class="text-muted text-sm">Noch keine Notizen vorhanden.</p>
+  ) : (
+    <ul class="space-y-3">
+      {notes.map(n => (
+        <li class="flex gap-3 p-4 bg-dark rounded-xl border border-dark-lighter" data-testid="client-note-item">
+          <div class="flex-1">
+            <p class="text-light text-sm whitespace-pre-wrap">{n.content}</p>
+            <p class="text-xs text-muted mt-1">{fmtDate(n.createdAt)}</p>
+          </div>
+          <form method="post" action="/api/admin/clientnotes/delete">
+            <input type="hidden" name="id" value={n.id} />
+            <input type="hidden" name="_back" value={back} />
+            <button type="submit"
+              class="text-muted hover:text-red-400 transition-colors text-lg leading-none"
+              title="Notiz löschen"
+              onclick="return confirm('Notiz löschen?')">
+              ✕
+            </button>
+          </form>
+        </li>
+      ))}
+    </ul>
+  )}
+</div>

--- a/website/src/components/portal/OnboardingTab.astro
+++ b/website/src/components/portal/OnboardingTab.astro
@@ -1,0 +1,66 @@
+---
+import { getOrCreateOnboardingChecklist } from '../../lib/website-db';
+
+interface Props {
+  keycloakUserId: string;
+  back: string;
+}
+const { keycloakUserId, back } = Astro.props;
+
+let items: Awaited<ReturnType<typeof getOrCreateOnboardingChecklist>> = [];
+try {
+  items = await getOrCreateOnboardingChecklist(keycloakUserId);
+} catch {
+  // DB unavailable
+}
+
+const doneCount = items.filter(i => i.done).length;
+const pct       = items.length ? Math.round((doneCount / items.length) * 100) : 0;
+---
+
+<div data-testid="onboarding-tab">
+  <div class="flex items-center justify-between mb-4">
+    <div>
+      <h3 class="text-lg font-semibold text-light">Onboarding-Checkliste</h3>
+      <p class="text-sm text-muted mt-0.5">{doneCount}/{items.length} Schritte abgeschlossen</p>
+    </div>
+    <form method="post" action="/api/admin/onboarding/reset">
+      <input type="hidden" name="keycloakUserId" value={keycloakUserId} />
+      <input type="hidden" name="_back" value={back} />
+      <button type="submit"
+        class="px-3 py-1.5 text-xs bg-dark border border-dark-lighter text-muted rounded-lg hover:text-light hover:border-gold/40 transition-colors"
+        onclick="return confirm('Checkliste zurücksetzen?')">
+        Zurücksetzen
+      </button>
+    </form>
+  </div>
+
+  <!-- Progress bar -->
+  <div class="w-full bg-dark rounded-full h-2 mb-6 overflow-hidden">
+    <div class={`h-full rounded-full transition-all duration-500 ${pct === 100 ? 'bg-green-500' : 'bg-gold'}`}
+      style={`width: ${pct}%`}></div>
+  </div>
+
+  <ul class="space-y-2">
+    {items.map(item => (
+      <li class="flex items-center gap-3 p-3 bg-dark rounded-xl border border-dark-lighter"
+        data-testid="onboarding-item">
+        <form method="post" action="/api/admin/onboarding/update" class="contents">
+          <input type="hidden" name="id" value={item.id} />
+          <input type="hidden" name="done" value={item.done ? 'false' : 'true'} />
+          <input type="hidden" name="_back" value={back} />
+          <button type="submit"
+            class={`w-6 h-6 rounded-full border-2 flex items-center justify-center shrink-0 transition-colors
+              ${item.done
+                ? 'border-green-500 bg-green-500/20 text-green-400 hover:bg-green-500/30'
+                : 'border-dark-lighter text-transparent hover:border-gold'}`}>
+            {item.done ? '✓' : ''}
+          </button>
+        </form>
+        <span class={`text-sm ${item.done ? 'text-muted line-through' : 'text-light'}`}>
+          {item.label}
+        </span>
+      </li>
+    ))}
+  </ul>
+</div>

--- a/website/src/lib/invoiceninja.ts
+++ b/website/src/lib/invoiceninja.ts
@@ -255,3 +255,38 @@ export async function getClientInvoices(clientEmail: string): Promise<ClientInvo
     statusLabel: INVOICE_STATUS_LABELS[inv.status_id] || 'Unbekannt',
   }));
 }
+
+export interface AdminInvoiceListItem extends ClientInvoiceListItem {
+  clientName: string;
+  clientEmail: string;
+}
+
+export async function getAllInvoices(params?: {
+  statusId?: string;  // '1'=draft,'2'=sent,'3'=partial,'4'=paid,'5'=cancelled,'6'=overdue
+  perPage?: number;
+}): Promise<AdminInvoiceListItem[]> {
+  if (!IN_TOKEN) return [];
+
+  const perPage = params?.perPage ?? 100;
+  const statusFilter = params?.statusId ? `&invoice_status_id=${params.statusId}` : '';
+  const res = await inApi('GET', `/invoices?sort=date|desc&per_page=${perPage}&include=client${statusFilter}`);
+  if (!res.ok) return [];
+
+  const data = await res.json();
+  return (data.data || []).map((inv: {
+    id: string; number: string; date: string; due_date: string;
+    amount: number; balance: number; status_id: string;
+    client: { name: string; contacts: Array<{ email: string }> };
+  }) => ({
+    id: inv.id,
+    number: inv.number,
+    date: inv.date,
+    dueDate: inv.due_date,
+    amount: inv.amount,
+    balance: inv.balance,
+    statusId: inv.status_id,
+    statusLabel: INVOICE_STATUS_LABELS[inv.status_id] || 'Unbekannt',
+    clientName: inv.client?.name ?? '—',
+    clientEmail: inv.client?.contacts?.[0]?.email ?? '—',
+  }));
+}

--- a/website/src/lib/website-db.ts
+++ b/website/src/lib/website-db.ts
@@ -1133,6 +1133,7 @@ export async function listAllTimeEntries(params?: {
 }
 
 export async function deleteTimeEntry(id: string): Promise<void> {
+  await initTimeEntriesTable();
   await pool.query('DELETE FROM time_entries WHERE id = $1', [id]);
 }
 
@@ -1272,10 +1273,12 @@ export async function getOrCreateOnboardingChecklist(keycloakUserId: string): Pr
 }
 
 export async function toggleOnboardingItem(id: string, done: boolean): Promise<void> {
+  await initOnboardingTable();
   await pool.query('UPDATE onboarding_items SET done = $2 WHERE id = $1', [id, done]);
 }
 
 export async function resetOnboardingChecklist(keycloakUserId: string): Promise<void> {
+  await initOnboardingTable();
   await pool.query(
     'UPDATE onboarding_items SET done = false WHERE keycloak_user_id = $1',
     [keycloakUserId]
@@ -1413,7 +1416,7 @@ export interface CalendarTask {
 export async function listTasksInMonth(year: number, month: number): Promise<CalendarTask[]> {
   await initProjectTables();
   const firstDay = `${year}-${String(month).padStart(2, '0')}-01`;
-  const lastDay = new Date(year, month, 0).toISOString().slice(0, 10);
+  const lastDay = new Date(Date.UTC(year, month, 0)).toISOString().slice(0, 10);
   const result = await pool.query(
     `SELECT pt.id,
             pt.name,

--- a/website/src/lib/website-db.ts
+++ b/website/src/lib/website-db.ts
@@ -1011,6 +1011,426 @@ export async function exportProjectsFlat(brand: string): Promise<ProjectExportRo
   return rows;
 }
 
+// ── Time Entries ──────────────────────────────────────────────────────────────
+
+export interface TimeEntry {
+  id: string;
+  projectId: string;
+  projectName: string;
+  taskId: string | null;
+  taskName: string | null;
+  description: string | null;
+  minutes: number;
+  billable: boolean;
+  entryDate: Date;
+  createdAt: Date;
+}
+
+async function initTimeEntriesTable(): Promise<void> {
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS time_entries (
+      id          UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+      project_id  UUID        NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+      task_id     UUID        REFERENCES project_tasks(id) ON DELETE SET NULL,
+      description TEXT,
+      minutes     INTEGER     NOT NULL CHECK (minutes > 0),
+      billable    BOOLEAN     NOT NULL DEFAULT true,
+      entry_date  DATE        NOT NULL DEFAULT CURRENT_DATE,
+      created_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+    )
+  `);
+  await pool.query(`
+    CREATE INDEX IF NOT EXISTS time_entries_project_id_idx ON time_entries(project_id)
+  `);
+}
+
+export async function createTimeEntry(params: {
+  projectId: string;
+  taskId?: string;
+  description?: string;
+  minutes: number;
+  billable?: boolean;
+  entryDate?: string;
+}): Promise<TimeEntry> {
+  await initTimeEntriesTable();
+  const result = await pool.query(
+    `INSERT INTO time_entries (project_id, task_id, description, minutes, billable, entry_date)
+     VALUES ($1, $2, $3, $4, $5, $6)
+     RETURNING
+       id,
+       project_id  AS "projectId",
+       ''          AS "projectName",
+       task_id     AS "taskId",
+       NULL        AS "taskName",
+       description,
+       minutes,
+       billable,
+       entry_date  AS "entryDate",
+       created_at  AS "createdAt"`,
+    [
+      params.projectId,
+      params.taskId ?? null,
+      params.description ?? null,
+      params.minutes,
+      params.billable ?? true,
+      params.entryDate ?? null,
+    ]
+  );
+  // Re-fetch with JOINs to get names
+  return (await listTimeEntries(params.projectId)).find(
+    (e) => e.id === result.rows[0].id
+  ) as TimeEntry;
+}
+
+export async function listTimeEntries(projectId: string): Promise<TimeEntry[]> {
+  await initTimeEntriesTable();
+  const result = await pool.query(
+    `SELECT te.id,
+            te.project_id  AS "projectId",
+            p.name         AS "projectName",
+            te.task_id     AS "taskId",
+            pt.name        AS "taskName",
+            te.description,
+            te.minutes,
+            te.billable,
+            te.entry_date  AS "entryDate",
+            te.created_at  AS "createdAt"
+     FROM time_entries te
+     JOIN projects      p  ON p.id  = te.project_id
+     LEFT JOIN project_tasks pt ON pt.id = te.task_id
+     WHERE te.project_id = $1
+     ORDER BY te.entry_date DESC`,
+    [projectId]
+  );
+  return result.rows;
+}
+
+export async function listAllTimeEntries(params?: {
+  billable?: boolean;
+  since?: string;
+}): Promise<TimeEntry[]> {
+  await initTimeEntriesTable();
+  const result = await pool.query(
+    `SELECT te.id,
+            te.project_id  AS "projectId",
+            p.name         AS "projectName",
+            te.task_id     AS "taskId",
+            pt.name        AS "taskName",
+            te.description,
+            te.minutes,
+            te.billable,
+            te.entry_date  AS "entryDate",
+            te.created_at  AS "createdAt"
+     FROM time_entries te
+     JOIN projects      p  ON p.id  = te.project_id
+     LEFT JOIN project_tasks pt ON pt.id = te.task_id
+     WHERE ($1::boolean IS NULL OR te.billable = $1)
+       AND ($2::date    IS NULL OR te.entry_date >= $2::date)
+     ORDER BY te.entry_date DESC`,
+    [params?.billable ?? null, params?.since ?? null]
+  );
+  return result.rows;
+}
+
+export async function deleteTimeEntry(id: string): Promise<void> {
+  await pool.query('DELETE FROM time_entries WHERE id = $1', [id]);
+}
+
+export async function getProjectTotalMinutes(
+  projectId: string
+): Promise<{ total: number; billable: number }> {
+  await initTimeEntriesTable();
+  const result = await pool.query(
+    `SELECT
+       COALESCE(SUM(minutes), 0)::int                                          AS total,
+       COALESCE(SUM(CASE WHEN billable THEN minutes ELSE 0 END), 0)::int       AS billable
+     FROM time_entries
+     WHERE project_id = $1`,
+    [projectId]
+  );
+  return result.rows[0];
+}
+
+// ── Client Notes ──────────────────────────────────────────────────────────────
+
+export interface ClientNote {
+  id: string;
+  keycloakUserId: string;
+  content: string;
+  createdAt: Date;
+}
+
+async function initClientNotesTable(): Promise<void> {
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS client_notes (
+      id                UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+      keycloak_user_id  TEXT        NOT NULL,
+      content           TEXT        NOT NULL,
+      created_at        TIMESTAMPTZ NOT NULL DEFAULT now()
+    )
+  `);
+  await pool.query(`
+    CREATE INDEX IF NOT EXISTS client_notes_keycloak_user_id_idx ON client_notes(keycloak_user_id)
+  `);
+}
+
+export async function listClientNotes(keycloakUserId: string): Promise<ClientNote[]> {
+  await initClientNotesTable();
+  const result = await pool.query(
+    `SELECT id,
+            keycloak_user_id AS "keycloakUserId",
+            content,
+            created_at       AS "createdAt"
+     FROM client_notes
+     WHERE keycloak_user_id = $1
+     ORDER BY created_at DESC`,
+    [keycloakUserId]
+  );
+  return result.rows;
+}
+
+export async function createClientNote(keycloakUserId: string, content: string): Promise<ClientNote> {
+  await initClientNotesTable();
+  const result = await pool.query(
+    `INSERT INTO client_notes (keycloak_user_id, content)
+     VALUES ($1, $2)
+     RETURNING id,
+               keycloak_user_id AS "keycloakUserId",
+               content,
+               created_at       AS "createdAt"`,
+    [keycloakUserId, content]
+  );
+  return result.rows[0];
+}
+
+export async function deleteClientNote(id: string): Promise<void> {
+  await pool.query('DELETE FROM client_notes WHERE id = $1', [id]);
+}
+
+// ── Onboarding-Checkliste ─────────────────────────────────────────────────────
+
+export interface OnboardingItem {
+  id: string;
+  keycloakUserId: string;
+  label: string;
+  done: boolean;
+  sortOrder: number;
+}
+
+const DEFAULT_ONBOARDING_ITEMS = [
+  'Erstgespräch gebucht',
+  'Vertrag unterzeichnet',
+  'Nextcloud-Ordner erstellt',
+  'Mattermost-Kanal eingerichtet',
+  'Rechnungsadresse erfasst',
+  'Zugangsdaten versendet',
+];
+
+async function initOnboardingTable(): Promise<void> {
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS onboarding_items (
+      id                UUID    PRIMARY KEY DEFAULT gen_random_uuid(),
+      keycloak_user_id  TEXT    NOT NULL,
+      label             TEXT    NOT NULL,
+      done              BOOLEAN NOT NULL DEFAULT false,
+      sort_order        INTEGER NOT NULL DEFAULT 0
+    )
+  `);
+  await pool.query(`
+    CREATE INDEX IF NOT EXISTS onboarding_items_keycloak_user_id_idx ON onboarding_items(keycloak_user_id)
+  `);
+}
+
+export async function getOrCreateOnboardingChecklist(keycloakUserId: string): Promise<OnboardingItem[]> {
+  await initOnboardingTable();
+  const existing = await pool.query(
+    `SELECT id, keycloak_user_id AS "keycloakUserId", label, done, sort_order AS "sortOrder"
+     FROM onboarding_items
+     WHERE keycloak_user_id = $1
+     ORDER BY sort_order ASC`,
+    [keycloakUserId]
+  );
+  if (existing.rows.length > 0) return existing.rows;
+
+  // Seed defaults
+  for (let i = 0; i < DEFAULT_ONBOARDING_ITEMS.length; i++) {
+    await pool.query(
+      `INSERT INTO onboarding_items (keycloak_user_id, label, sort_order)
+       VALUES ($1, $2, $3)`,
+      [keycloakUserId, DEFAULT_ONBOARDING_ITEMS[i], i]
+    );
+  }
+
+  const seeded = await pool.query(
+    `SELECT id, keycloak_user_id AS "keycloakUserId", label, done, sort_order AS "sortOrder"
+     FROM onboarding_items
+     WHERE keycloak_user_id = $1
+     ORDER BY sort_order ASC`,
+    [keycloakUserId]
+  );
+  return seeded.rows;
+}
+
+export async function toggleOnboardingItem(id: string, done: boolean): Promise<void> {
+  await pool.query('UPDATE onboarding_items SET done = $2 WHERE id = $1', [id, done]);
+}
+
+export async function resetOnboardingChecklist(keycloakUserId: string): Promise<void> {
+  await pool.query(
+    'UPDATE onboarding_items SET done = false WHERE keycloak_user_id = $1',
+    [keycloakUserId]
+  );
+}
+
+// ── Follow-ups ────────────────────────────────────────────────────────────────
+
+export interface FollowUp {
+  id: string;
+  keycloakUserId: string | null;
+  clientName: string | null;
+  clientEmail: string | null;
+  reason: string;
+  dueDate: Date;
+  done: boolean;
+  createdAt: Date;
+}
+
+async function initFollowUpsTable(): Promise<void> {
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS follow_ups (
+      id                UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+      keycloak_user_id  TEXT,
+      client_name       TEXT,
+      client_email      TEXT,
+      reason            TEXT        NOT NULL,
+      due_date          DATE        NOT NULL,
+      done              BOOLEAN     NOT NULL DEFAULT false,
+      created_at        TIMESTAMPTZ NOT NULL DEFAULT now()
+    )
+  `);
+}
+
+export async function createFollowUp(params: {
+  keycloakUserId?: string;
+  clientName?: string;
+  clientEmail?: string;
+  reason: string;
+  dueDate: string;
+}): Promise<FollowUp> {
+  await initFollowUpsTable();
+  const result = await pool.query(
+    `INSERT INTO follow_ups (keycloak_user_id, client_name, client_email, reason, due_date)
+     VALUES ($1, $2, $3, $4, $5)
+     RETURNING id,
+               keycloak_user_id AS "keycloakUserId",
+               client_name      AS "clientName",
+               client_email     AS "clientEmail",
+               reason,
+               due_date         AS "dueDate",
+               done,
+               created_at       AS "createdAt"`,
+    [
+      params.keycloakUserId ?? null,
+      params.clientName ?? null,
+      params.clientEmail ?? null,
+      params.reason,
+      params.dueDate,
+    ]
+  );
+  return result.rows[0];
+}
+
+export async function listFollowUps(showDone = false): Promise<FollowUp[]> {
+  await initFollowUpsTable();
+  const result = await pool.query(
+    `SELECT id,
+            keycloak_user_id AS "keycloakUserId",
+            client_name      AS "clientName",
+            client_email     AS "clientEmail",
+            reason,
+            due_date         AS "dueDate",
+            done,
+            created_at       AS "createdAt"
+     FROM follow_ups
+     WHERE ($1 OR done = false)
+     ORDER BY due_date ASC`,
+    [showDone]
+  );
+  return result.rows;
+}
+
+export async function getDueFollowUps(): Promise<FollowUp[]> {
+  await initFollowUpsTable();
+  const result = await pool.query(
+    `SELECT id,
+            keycloak_user_id AS "keycloakUserId",
+            client_name      AS "clientName",
+            client_email     AS "clientEmail",
+            reason,
+            due_date         AS "dueDate",
+            done,
+            created_at       AS "createdAt"
+     FROM follow_ups
+     WHERE done = false AND due_date <= CURRENT_DATE
+     ORDER BY due_date ASC`
+  );
+  return result.rows;
+}
+
+export async function updateFollowUp(id: string, params: {
+  done?: boolean;
+  dueDate?: string;
+  reason?: string;
+}): Promise<void> {
+  const sets: string[] = [];
+  const values: unknown[] = [id];
+  let idx = 2;
+
+  if (params.done !== undefined) { sets.push(`done = $${idx}`); values.push(params.done); idx++; }
+  if (params.dueDate !== undefined) { sets.push(`due_date = $${idx}`); values.push(params.dueDate); idx++; }
+  if (params.reason !== undefined) { sets.push(`reason = $${idx}`); values.push(params.reason); idx++; }
+
+  if (sets.length === 0) return;
+  await pool.query(`UPDATE follow_ups SET ${sets.join(', ')} WHERE id = $1`, values);
+}
+
+export async function deleteFollowUp(id: string): Promise<void> {
+  await pool.query('DELETE FROM follow_ups WHERE id = $1', [id]);
+}
+
+// ── Task Calendar ─────────────────────────────────────────────────────────────
+
+export interface CalendarTask {
+  id: string;
+  name: string;
+  projectId: string;
+  projectName: string;
+  dueDate: Date;
+  status: string;
+  priority: string;
+}
+
+export async function listTasksInMonth(year: number, month: number): Promise<CalendarTask[]> {
+  await initProjectTables();
+  const firstDay = `${year}-${String(month).padStart(2, '0')}-01`;
+  const lastDay = new Date(year, month, 0).toISOString().slice(0, 10);
+  const result = await pool.query(
+    `SELECT pt.id,
+            pt.name,
+            pt.project_id AS "projectId",
+            p.name        AS "projectName",
+            pt.due_date   AS "dueDate",
+            pt.status,
+            pt.priority
+     FROM project_tasks pt
+     JOIN projects p ON p.id = pt.project_id
+     WHERE pt.due_date BETWEEN $1::date AND $2::date
+     ORDER BY pt.due_date ASC, pt.priority DESC`,
+    [firstDay, lastDay]
+  );
+  return result.rows;
+}
+
 // ── Bug Ticket List ───────────────────────────────────────────────────────────
 
 export interface BugTicketRow {

--- a/website/src/pages/admin.astro
+++ b/website/src/pages/admin.astro
@@ -59,7 +59,7 @@ function fmtCurrency(n: number): string {
   {[
     { label: 'Aktive Projekte',   value: String(activeProjects),           href: '/admin/projekte',  cls: 'border-yellow-800' },
     { label: 'Offene Rechnungen', value: openInvoices > 0 ? `${openInvoices} (${fmtCurrency(openInvoiceAmount)})` : '0', href: '/admin/rechnungen', cls: openInvoices > 0 ? 'border-yellow-800' : 'border-dark-lighter' },
-    { label: 'Offene Bugs',       value: String(openBugCount),             href: '/admin/bugs',      cls: openBugCount > 0 ? 'border-red-800' : 'border-dark-lighter' },
+    { label: 'Überfällige Bugs',   value: String(openBugCount),             href: '/admin/bugs',      cls: openBugCount > 0 ? 'border-red-800' : 'border-dark-lighter' },
     { label: 'Follow-ups fällig', value: String(dueFollowUps),             href: '/admin/followups', cls: dueFollowUps > 0 ? 'border-red-800' : 'border-dark-lighter' },
     { label: 'Freie Slots (7 T)', value: String(freeSlots),                href: '/admin/termine',   cls: freeSlots > 0 ? 'border-green-800' : 'border-dark-lighter' },
   ].map(k => (

--- a/website/src/pages/admin.astro
+++ b/website/src/pages/admin.astro
@@ -1,24 +1,47 @@
 ---
 import Layout from '../layouts/Layout.astro';
 import { getSession, getLoginUrl, isAdmin } from '../lib/auth';
-import { listBugTickets } from '../lib/website-db';
+import { listBugTickets, listProjects, getDueFollowUps } from '../lib/website-db';
+import { getAllInvoices } from '../lib/invoiceninja';
+import { getAvailableSlots } from '../lib/caldav';
 
 const session = await getSession(Astro.request.headers.get('cookie'));
-if (!session) {
-  return Astro.redirect(getLoginUrl());
-}
-if (!isAdmin(session)) {
-  return Astro.redirect('/portal');
-}
+if (!session) return Astro.redirect(getLoginUrl());
+if (!isAdmin(session)) return Astro.redirect('/portal');
 
 const BRAND = process.env.BRAND || 'mentolder';
 
-let openBugCount = 0;
-try {
-  const openTickets = await listBugTickets({ status: 'open', brand: BRAND, limit: 1000 });
-  openBugCount = openTickets.length;
-} catch {
-  // DB unavailable — badge shows 0
+let openBugCount      = 0;
+let activeProjects    = 0;
+let openInvoices      = 0;
+let openInvoiceAmount = 0;
+let dueFollowUps      = 0;
+let freeSlots         = 0;
+
+await Promise.allSettled([
+  listBugTickets({ status: 'open', brand: BRAND, limit: 1000 })
+    .then(t => { openBugCount = t.length; }),
+  listProjects({ brand: BRAND, status: 'aktiv' })
+    .then(p => { activeProjects = p.length; }),
+  getAllInvoices({ perPage: 200 })
+    .then(inv => {
+      const open = inv.filter(i => i.balance > 0 && !['4','5'].includes(i.statusId));
+      openInvoices      = open.length;
+      openInvoiceAmount = open.reduce((s, i) => s + i.balance, 0);
+    }),
+  getDueFollowUps()
+    .then(f => { dueFollowUps = f.length; }),
+  getAvailableSlots(new Date())
+    .then(slots => {
+      const horizon = new Date(); horizon.setDate(horizon.getDate() + 7);
+      freeSlots = slots
+        .filter(d => new Date(d.date) <= horizon)
+        .reduce((s, d) => s + d.slots.length, 0);
+    }),
+]);
+
+function fmtCurrency(n: number): string {
+  return new Intl.NumberFormat('de-DE', { style: 'currency', currency: 'EUR' }).format(n);
 }
 ---
 
@@ -30,6 +53,22 @@ try {
         <h1 class="text-3xl font-bold text-light font-serif">Admin</h1>
         <p class="text-muted mt-1">Verwaltung & Werkzeuge</p>
       </div>
+
+      <!-- KPI Banner -->
+<div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3 mb-8">
+  {[
+    { label: 'Aktive Projekte',   value: String(activeProjects),           href: '/admin/projekte',  cls: 'border-yellow-800' },
+    { label: 'Offene Rechnungen', value: openInvoices > 0 ? `${openInvoices} (${fmtCurrency(openInvoiceAmount)})` : '0', href: '/admin/rechnungen', cls: openInvoices > 0 ? 'border-yellow-800' : 'border-dark-lighter' },
+    { label: 'Offene Bugs',       value: String(openBugCount),             href: '/admin/bugs',      cls: openBugCount > 0 ? 'border-red-800' : 'border-dark-lighter' },
+    { label: 'Follow-ups fällig', value: String(dueFollowUps),             href: '/admin/followups', cls: dueFollowUps > 0 ? 'border-red-800' : 'border-dark-lighter' },
+    { label: 'Freie Slots (7 T)', value: String(freeSlots),                href: '/admin/termine',   cls: freeSlots > 0 ? 'border-green-800' : 'border-dark-lighter' },
+  ].map(k => (
+    <a href={k.href} class={`p-4 bg-dark-light rounded-xl border hover:border-gold/40 transition-colors ${k.cls}`}>
+      <div class="text-xl font-bold text-light">{k.value}</div>
+      <div class="text-xs text-muted mt-0.5">{k.label}</div>
+    </a>
+  ))}
+</div>
 
       <!-- Dashboard grid -->
       <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 mb-10">
@@ -93,6 +132,39 @@ try {
           <div class="text-3xl mb-3">📋</div>
           <h2 class="text-light font-semibold text-lg group-hover:text-gold transition-colors">Projekte</h2>
           <p class="text-muted text-sm mt-1">Projekte, Teilprojekte und Aufgaben verwalten</p>
+        </a>
+
+        <!-- Zeiterfassung -->
+        <a href="/admin/zeiterfassung" class="group p-6 bg-dark-light rounded-xl border border-dark-lighter hover:border-gold/40 transition-colors">
+          <div class="text-3xl mb-3">⏱️</div>
+          <h2 class="text-light font-semibold text-lg group-hover:text-gold transition-colors">Zeiterfassung</h2>
+          <p class="text-muted text-sm mt-1">Stunden auf Projekte buchen · CSV-Export für Invoice Ninja</p>
+        </a>
+
+        <!-- Rechnungen -->
+        <a href="/admin/rechnungen" class="group p-6 bg-dark-light rounded-xl border border-dark-lighter hover:border-gold/40 transition-colors">
+          <div class="text-3xl mb-3">💶</div>
+          <h2 class="text-light font-semibold text-lg group-hover:text-gold transition-colors">Rechnungen</h2>
+          <p class="text-muted text-sm mt-1">Alle Rechnungen im Überblick · Status und offene Beträge</p>
+        </a>
+
+        <!-- Follow-ups -->
+        <a href="/admin/followups" class="relative group p-6 bg-dark-light rounded-xl border border-dark-lighter hover:border-gold/40 transition-colors">
+          {dueFollowUps > 0 && (
+            <span class="absolute top-4 right-4 bg-red-500 text-white text-xs font-bold rounded-full w-6 h-6 flex items-center justify-center">
+              {dueFollowUps > 99 ? '99+' : dueFollowUps}
+            </span>
+          )}
+          <div class="text-3xl mb-3">🔔</div>
+          <h2 class="text-light font-semibold text-lg group-hover:text-gold transition-colors">Follow-ups</h2>
+          <p class="text-muted text-sm mt-1">Wiedervorlagen · fällige Erinnerungen an Clients</p>
+        </a>
+
+        <!-- Kalender -->
+        <a href="/admin/kalender" class="group p-6 bg-dark-light rounded-xl border border-dark-lighter hover:border-gold/40 transition-colors">
+          <div class="text-3xl mb-3">🗓️</div>
+          <h2 class="text-light font-semibold text-lg group-hover:text-gold transition-colors">Aufgaben-Kalender</h2>
+          <p class="text-muted text-sm mt-1">Alle Aufgaben mit Fälligkeit in der Monatsansicht</p>
         </a>
 
       </div>

--- a/website/src/pages/admin/[clientId].astro
+++ b/website/src/pages/admin/[clientId].astro
@@ -7,6 +7,7 @@ import InvoicesTab from '../../components/portal/InvoicesTab.astro';
 import FilesTab from '../../components/portal/FilesTab.astro';
 import SignaturesTab from '../../components/portal/SignaturesTab.astro';
 import MeetingsAdminTab from '../../components/portal/MeetingsAdminTab.astro';
+import OnboardingTab from '../../components/portal/OnboardingTab.astro';
 
 const session = await getSession(Astro.request.headers.get('cookie'));
 if (!session) {
@@ -45,6 +46,7 @@ const tab = Astro.url.searchParams.get('tab') ?? 'bookings';
           { id: 'files', label: 'Dateien' },
           { id: 'signatures', label: 'Zur Unterschrift' },
           { id: 'meetings', label: 'Besprechungen' },
+          { id: 'onboarding', label: 'Onboarding' },
         ].map(t => (
           <a
             href={`/admin/${clientId}?tab=${t.id}`}
@@ -66,6 +68,12 @@ const tab = Astro.url.searchParams.get('tab') ?? 'bookings';
         {tab === 'files' && <FilesTab clientUsername={client.username} />}
         {tab === 'signatures' && <SignaturesTab clientUsername={client.username} />}
         {tab === 'meetings' && <MeetingsAdminTab clientEmail={client.email ?? ''} />}
+        {tab === 'onboarding' && (
+          <OnboardingTab
+            keycloakUserId={clientId}
+            back={`/admin/${clientId}?tab=onboarding`}
+          />
+        )}
       </div>
     </div>
   </section>

--- a/website/src/pages/admin/[clientId].astro
+++ b/website/src/pages/admin/[clientId].astro
@@ -4,6 +4,7 @@ import { getSession, getLoginUrl, isAdmin } from '../../lib/auth';
 import { getUserById } from '../../lib/keycloak';
 import BookingsTab from '../../components/portal/BookingsTab.astro';
 import InvoicesTab from '../../components/portal/InvoicesTab.astro';
+import ClientNotesTab from '../../components/portal/ClientNotesTab.astro';
 import FilesTab from '../../components/portal/FilesTab.astro';
 import SignaturesTab from '../../components/portal/SignaturesTab.astro';
 import MeetingsAdminTab from '../../components/portal/MeetingsAdminTab.astro';
@@ -43,6 +44,7 @@ const tab = Astro.url.searchParams.get('tab') ?? 'bookings';
         {[
           { id: 'bookings', label: 'Termine' },
           { id: 'invoices', label: 'Rechnungen' },
+          { id: 'notes', label: 'Notizen' },
           { id: 'files', label: 'Dateien' },
           { id: 'signatures', label: 'Zur Unterschrift' },
           { id: 'meetings', label: 'Besprechungen' },
@@ -65,6 +67,12 @@ const tab = Astro.url.searchParams.get('tab') ?? 'bookings';
       <div class="bg-dark-light rounded-xl border border-dark-lighter p-6">
         {tab === 'bookings' && <BookingsTab clientEmail={client.email ?? ''} />}
         {tab === 'invoices' && <InvoicesTab clientEmail={client.email ?? ''} />}
+        {tab === 'notes' && (
+          <ClientNotesTab
+            keycloakUserId={clientId}
+            back={`/admin/${clientId}?tab=notes`}
+          />
+        )}
         {tab === 'files' && <FilesTab clientUsername={client.username} />}
         {tab === 'signatures' && <SignaturesTab clientUsername={client.username} />}
         {tab === 'meetings' && <MeetingsAdminTab clientEmail={client.email ?? ''} />}

--- a/website/src/pages/admin/followups.astro
+++ b/website/src/pages/admin/followups.astro
@@ -62,7 +62,7 @@ const labelCls = 'block text-xs text-muted mb-1';
 
       {(errorMsg || dbError) && (
         <div id="err-banner" class="mb-6 p-4 bg-red-900/30 border border-red-800 rounded-xl text-red-300 text-sm flex items-start justify-between gap-4">
-          <span>{decodeURIComponent((errorMsg || dbError).replace(/\+/g, ' '))}</span>
+          <span>{(() => { const raw = (errorMsg || dbError).replace(/\+/g, ' '); try { return decodeURIComponent(raw); } catch { return raw; } })()}</span>
           <button type="button" onclick="document.getElementById('err-banner').remove()" class="text-red-400 hover:text-red-200 shrink-0">✕</button>
         </div>
       )}
@@ -185,6 +185,7 @@ const labelCls = 'block text-xs text-muted mb-1';
     btn.textContent = 'Sende …';
     try {
       const res  = await fetch('/api/admin/followups/notify', { method: 'POST' });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const data = await res.json();
       btn.textContent = data.sent ? `✓ ${data.count} versendet` : 'Keine fälligen';
     } catch {

--- a/website/src/pages/admin/followups.astro
+++ b/website/src/pages/admin/followups.astro
@@ -1,0 +1,198 @@
+---
+import Layout from '../../layouts/Layout.astro';
+import { getSession, getLoginUrl, isAdmin } from '../../lib/auth';
+import { listFollowUps } from '../../lib/website-db';
+import type { FollowUp } from '../../lib/website-db';
+
+const session = await getSession(Astro.request.headers.get('cookie'));
+if (!session) return Astro.redirect(getLoginUrl());
+if (!isAdmin(session)) return Astro.redirect('/admin');
+
+const showDone = Astro.url.searchParams.get('done') === '1';
+const errorMsg = Astro.url.searchParams.get('error') ?? '';
+const saved    = Astro.url.searchParams.get('saved')  ?? '';
+
+let followUps: FollowUp[] = [];
+let dbError = '';
+try {
+  followUps = await listFollowUps(showDone);
+} catch (err) {
+  console.error('[admin/followups]', err);
+  dbError = 'Datenbankfehler beim Laden der Follow-ups.';
+}
+
+const today = new Date(); today.setHours(0, 0, 0, 0);
+const dueCount = followUps.filter(f => !f.done && new Date(f.dueDate) <= today).length;
+
+function fmtDate(d: Date): string {
+  return new Date(d).toLocaleDateString('de-DE', { day: '2-digit', month: '2-digit', year: 'numeric' });
+}
+
+const inputCls = 'w-full px-3 py-2 bg-dark border border-dark-lighter rounded-lg text-light text-sm focus:border-gold focus:ring-2 focus:ring-gold/20 outline-none';
+const labelCls = 'block text-xs text-muted mb-1';
+---
+
+<Layout title="Admin — Follow-ups">
+  <section class="pt-28 pb-20 bg-dark min-h-screen">
+    <div class="max-w-4xl mx-auto px-6">
+
+      <div class="mb-2">
+        <a href="/admin" class="text-muted hover:text-gold text-sm">← Zurück zur Übersicht</a>
+      </div>
+
+      <div class="mb-8 flex items-center justify-between gap-4 flex-wrap">
+        <div>
+          <h1 class="text-3xl font-bold text-light font-serif">Follow-ups</h1>
+          <p class="text-muted mt-1">
+            {followUps.length} {showDone ? 'gesamt' : 'offen'} ·
+            {dueCount > 0 ? `${dueCount} fällig` : 'keine fällig'}
+          </p>
+        </div>
+        <div class="flex gap-3">
+          <button type="button" id="notify-btn"
+            class="px-4 py-2 bg-dark-light border border-dark-lighter text-muted text-sm rounded-lg hover:text-light hover:border-gold/40 transition-colors">
+            Mattermost Reminder
+          </button>
+          <button type="button" id="create-btn"
+            class="px-4 py-2 bg-gold hover:bg-gold-light text-dark text-sm font-semibold rounded-lg transition-colors">
+            + Follow-up
+          </button>
+        </div>
+      </div>
+
+      {(errorMsg || dbError) && (
+        <div id="err-banner" class="mb-6 p-4 bg-red-900/30 border border-red-800 rounded-xl text-red-300 text-sm flex items-start justify-between gap-4">
+          <span>{decodeURIComponent((errorMsg || dbError).replace(/\+/g, ' '))}</span>
+          <button type="button" onclick="document.getElementById('err-banner').remove()" class="text-red-400 hover:text-red-200 shrink-0">✕</button>
+        </div>
+      )}
+      {saved && (
+        <div id="ok-banner" class="mb-6 p-4 bg-green-900/30 border border-green-800 rounded-xl text-green-300 text-sm flex items-start justify-between gap-4">
+          <span>Follow-up gespeichert.</span>
+          <button type="button" onclick="document.getElementById('ok-banner').remove()" class="text-green-400 hover:text-green-200 shrink-0">✕</button>
+        </div>
+      )}
+
+      <!-- Filter -->
+      <div class="flex gap-1 p-1 bg-dark-light rounded-lg border border-dark-lighter mb-6 w-fit">
+        <a href="/admin/followups"
+          class={`px-3 py-1.5 rounded text-sm font-medium transition-colors ${!showDone ? 'bg-gold text-dark' : 'text-muted hover:text-light'}`}>
+          Offen
+        </a>
+        <a href="/admin/followups?done=1"
+          class={`px-3 py-1.5 rounded text-sm font-medium transition-colors ${showDone ? 'bg-gold text-dark' : 'text-muted hover:text-light'}`}>
+          Alle (inkl. erledigt)
+        </a>
+      </div>
+
+      <!-- List -->
+      <div class="space-y-3">
+        {followUps.length === 0 && (
+          <div class="p-10 text-center bg-dark-light rounded-2xl border border-dark-lighter">
+            <p class="text-muted">Keine Follow-ups vorhanden.</p>
+          </div>
+        )}
+        {followUps.map(f => {
+          const isOverdue = !f.done && new Date(f.dueDate) <= today;
+          return (
+            <div class={`flex items-start gap-4 p-4 bg-dark-light rounded-xl border transition-colors ${f.done ? 'opacity-50 border-dark-lighter' : isOverdue ? 'border-red-800' : 'border-dark-lighter'}`}
+              data-testid="followup-item">
+              <!-- Done toggle -->
+              <form method="post" action="/api/admin/followups/update" class="mt-0.5">
+                <input type="hidden" name="id" value={f.id} />
+                <input type="hidden" name="done" value={f.done ? 'false' : 'true'} />
+                <input type="hidden" name="_back" value={`${Astro.url.pathname}${Astro.url.search}`} />
+                <button type="submit"
+                  class={`w-6 h-6 rounded-full border-2 flex items-center justify-center transition-colors
+                    ${f.done
+                      ? 'border-green-500 bg-green-500/20 text-green-400 hover:bg-green-500/30'
+                      : 'border-dark-lighter text-transparent hover:border-gold'}`}>
+                  {f.done ? '✓' : ''}
+                </button>
+              </form>
+              <!-- Content -->
+              <div class="flex-1 min-w-0">
+                <p class={`text-sm font-medium ${f.done ? 'text-muted line-through' : 'text-light'}`}>{f.reason}</p>
+                {(f.clientName || f.clientEmail) && (
+                  <p class="text-xs text-muted mt-0.5">
+                    {f.clientName ?? ''}{f.clientEmail ? ` · ${f.clientEmail}` : ''}
+                  </p>
+                )}
+                <p class={`text-xs mt-1 font-medium ${isOverdue ? 'text-red-400' : 'text-muted'}`}>
+                  Fällig: {fmtDate(f.dueDate)}{isOverdue ? ' ⚠ Überfällig' : ''}
+                </p>
+              </div>
+              <!-- Delete -->
+              <form method="post" action="/api/admin/followups/delete">
+                <input type="hidden" name="id" value={f.id} />
+                <input type="hidden" name="_back" value={`${Astro.url.pathname}${Astro.url.search}`} />
+                <button type="submit"
+                  class="text-muted hover:text-red-400 transition-colors text-lg leading-none"
+                  title="Löschen"
+                  onclick="return confirm('Follow-up löschen?')">
+                  ✕
+                </button>
+              </form>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  </section>
+
+  <!-- Create dialog -->
+  <dialog id="create-dialog"
+    class="bg-dark-light border border-dark-lighter rounded-2xl p-6 w-full max-w-lg backdrop:bg-black/60">
+    <h2 class="text-lg font-semibold text-light mb-4 font-serif">Neues Follow-up</h2>
+    <form method="post" action="/api/admin/followups/create" class="space-y-4">
+      <input type="hidden" name="_back" value="/admin/followups" />
+      <div>
+        <label class={labelCls}>Grund / Erinnerung <span class="text-red-400">*</span></label>
+        <input type="text" name="reason" required maxlength="500" class={inputCls}
+          placeholder="z.B. Angebot nachfassen" />
+      </div>
+      <div class="grid grid-cols-2 gap-3">
+        <div>
+          <label class={labelCls}>Client-Name</label>
+          <input type="text" name="clientName" maxlength="200" class={inputCls} />
+        </div>
+        <div>
+          <label class={labelCls}>Client-E-Mail</label>
+          <input type="email" name="clientEmail" maxlength="200" class={inputCls} />
+        </div>
+      </div>
+      <div>
+        <label class={labelCls}>Fälligkeitsdatum <span class="text-red-400">*</span></label>
+        <input type="date" name="dueDate" required class={inputCls}
+          value={new Date(Date.now() + 7 * 86400 * 1000).toISOString().slice(0, 10)} />
+      </div>
+      <div class="flex gap-3 justify-end pt-2">
+        <button type="button" id="create-cancel" class="px-4 py-2 text-sm text-muted hover:text-light transition-colors">Abbrechen</button>
+        <button type="submit" class="px-4 py-2 text-sm bg-gold hover:bg-gold-light text-dark font-semibold rounded-lg transition-colors">Erstellen</button>
+      </div>
+    </form>
+  </dialog>
+</Layout>
+
+<script>
+  const dialog = document.getElementById('create-dialog') as HTMLDialogElement;
+  document.getElementById('create-btn')?.addEventListener('click', () => dialog.showModal());
+  document.getElementById('create-cancel')?.addEventListener('click', () => dialog.close());
+
+  document.getElementById('notify-btn')?.addEventListener('click', async () => {
+    const btn = document.getElementById('notify-btn') as HTMLButtonElement;
+    btn.disabled = true;
+    btn.textContent = 'Sende …';
+    try {
+      const res  = await fetch('/api/admin/followups/notify', { method: 'POST' });
+      const data = await res.json();
+      btn.textContent = data.sent ? `✓ ${data.count} versendet` : 'Keine fälligen';
+    } catch {
+      btn.textContent = 'Fehler';
+    }
+    setTimeout(() => {
+      btn.disabled = false;
+      btn.textContent = 'Mattermost Reminder';
+    }, 3000);
+  });
+</script>

--- a/website/src/pages/admin/followups.astro
+++ b/website/src/pages/admin/followups.astro
@@ -23,6 +23,7 @@ try {
 
 const today = new Date(); today.setHours(0, 0, 0, 0);
 const dueCount = followUps.filter(f => !f.done && new Date(f.dueDate) <= today).length;
+const overdueSet = new Set(followUps.filter(f => !f.done && new Date(f.dueDate) <= today).map(f => f.id));
 
 function fmtDate(d: Date): string {
   return new Date(d).toLocaleDateString('de-DE', { day: '2-digit', month: '2-digit', year: 'numeric' });
@@ -93,7 +94,7 @@ const labelCls = 'block text-xs text-muted mb-1';
           </div>
         )}
         {followUps.map(f => {
-          const isOverdue = !f.done && new Date(f.dueDate) <= today;
+          const isOverdue = overdueSet.has(f.id);
           return (
             <div class={`flex items-start gap-4 p-4 bg-dark-light rounded-xl border transition-colors ${f.done ? 'opacity-50 border-dark-lighter' : isOverdue ? 'border-red-800' : 'border-dark-lighter'}`}
               data-testid="followup-item">

--- a/website/src/pages/admin/kalender.astro
+++ b/website/src/pages/admin/kalender.astro
@@ -30,7 +30,7 @@ const totalDays    = lastDay.getDate();
 
 const tasksByDay = new Map<number, CalendarTask[]>();
 for (const t of tasks) {
-  const d = new Date(t.dueDate).getUTCDate();
+  const d = parseInt(new Date(t.dueDate).toISOString().slice(8, 10), 10);
   if (!tasksByDay.has(d)) tasksByDay.set(d, []);
   tasksByDay.get(d)!.push(t);
 }

--- a/website/src/pages/admin/kalender.astro
+++ b/website/src/pages/admin/kalender.astro
@@ -1,0 +1,149 @@
+---
+import Layout from '../../layouts/Layout.astro';
+import { getSession, getLoginUrl, isAdmin } from '../../lib/auth';
+import { listTasksInMonth } from '../../lib/website-db';
+import type { CalendarTask } from '../../lib/website-db';
+
+const session = await getSession(Astro.request.headers.get('cookie'));
+if (!session) return Astro.redirect(getLoginUrl());
+if (!isAdmin(session)) return Astro.redirect('/admin');
+
+const now    = new Date();
+const yearQ  = parseInt(Astro.url.searchParams.get('year')  ?? String(now.getFullYear()), 10);
+const monthQ = parseInt(Astro.url.searchParams.get('month') ?? String(now.getMonth() + 1), 10);
+const year   = isNaN(yearQ)  ? now.getFullYear()  : yearQ;
+const month  = isNaN(monthQ) ? now.getMonth() + 1 : Math.max(1, Math.min(12, monthQ));
+
+let tasks: CalendarTask[] = [];
+let dbError = '';
+try {
+  tasks = await listTasksInMonth(year, month);
+} catch (err) {
+  console.error('[admin/kalender]', err);
+  dbError = 'Datenbankfehler beim Laden.';
+}
+
+const firstDay     = new Date(year, month - 1, 1);
+const lastDay      = new Date(year, month, 0);
+const startWeekday = (firstDay.getDay() + 6) % 7; // Mon=0
+const totalDays    = lastDay.getDate();
+
+const tasksByDay = new Map<number, CalendarTask[]>();
+for (const t of tasks) {
+  const d = new Date(t.dueDate).getUTCDate();
+  if (!tasksByDay.has(d)) tasksByDay.set(d, []);
+  tasksByDay.get(d)!.push(t);
+}
+
+function navUrl(y: number, m: number): string {
+  if (m < 1)  { y--; m = 12; }
+  if (m > 12) { y++; m = 1; }
+  return `/admin/kalender?year=${y}&month=${m}`;
+}
+
+const MONTH_NAMES = ['Januar','Februar','März','April','Mai','Juni','Juli','August','September','Oktober','November','Dezember'];
+const DAY_NAMES   = ['Mo','Di','Mi','Do','Fr','Sa','So'];
+
+const PRIO_DOT: Record<string, string> = {
+  hoch: 'bg-red-500', mittel: 'bg-yellow-500', niedrig: 'bg-green-500',
+};
+const STATUS_CLS: Record<string, string> = {
+  erledigt: 'line-through opacity-50',
+  archiviert: 'line-through opacity-30',
+};
+---
+
+<Layout title="Admin — Aufgaben-Kalender">
+  <section class="pt-28 pb-20 bg-dark min-h-screen">
+    <div class="max-w-5xl mx-auto px-6">
+
+      <div class="mb-2">
+        <a href="/admin" class="text-muted hover:text-gold text-sm">← Zurück zur Übersicht</a>
+      </div>
+
+      <div class="mb-8 flex items-center justify-between gap-4 flex-wrap">
+        <div>
+          <h1 class="text-3xl font-bold text-light font-serif">Aufgaben-Kalender</h1>
+          <p class="text-muted mt-1">{tasks.length} Aufgaben mit Fälligkeit im {MONTH_NAMES[month - 1]} {year}</p>
+        </div>
+        <div class="flex items-center gap-2">
+          <a href={navUrl(year, month - 1)}
+            class="px-3 py-2 bg-dark-light border border-dark-lighter text-muted rounded-lg hover:text-light hover:border-gold/40 transition-colors text-sm">
+            ← Vorheriger
+          </a>
+          <a href={`/admin/kalender?year=${now.getFullYear()}&month=${now.getMonth() + 1}`}
+            class="px-3 py-2 bg-dark-light border border-dark-lighter text-muted rounded-lg hover:text-light hover:border-gold/40 transition-colors text-sm">
+            Heute
+          </a>
+          <a href={navUrl(year, month + 1)}
+            class="px-3 py-2 bg-dark-light border border-dark-lighter text-muted rounded-lg hover:text-light hover:border-gold/40 transition-colors text-sm">
+            Nächster →
+          </a>
+        </div>
+      </div>
+
+      {dbError && (
+        <div class="mb-6 p-4 bg-red-900/30 border border-red-800 rounded-xl text-red-300 text-sm">{dbError}</div>
+      )}
+
+      <div class="bg-dark-light rounded-2xl border border-dark-lighter overflow-hidden">
+        <!-- Day headers -->
+        <div class="grid grid-cols-7 border-b border-dark-lighter">
+          {DAY_NAMES.map(d => (
+            <div class={`px-2 py-3 text-center text-xs font-semibold ${['Sa','So'].includes(d) ? 'text-muted/60' : 'text-muted'}`}>
+              {d}
+            </div>
+          ))}
+        </div>
+
+        <!-- Calendar cells -->
+        <div class="grid grid-cols-7">
+          {Array.from({ length: startWeekday }).map(() => (
+            <div class="min-h-[100px] border-b border-r border-dark-lighter/50 bg-dark/30"></div>
+          ))}
+
+          {Array.from({ length: totalDays }, (_, i) => i + 1).map(day => {
+            const isToday = year === now.getFullYear() && month === now.getMonth() + 1 && day === now.getDate();
+            const dayTasks = tasksByDay.get(day) ?? [];
+            const col = (startWeekday + day - 1) % 7;
+            const isWeekend = col >= 5;
+            return (
+              <div class={`min-h-[100px] border-b border-r border-dark-lighter/50 p-2 transition-colors hover:bg-dark/30 ${isWeekend ? 'bg-dark/20' : ''}`}>
+                <div class={`text-xs font-semibold mb-1.5 w-6 h-6 flex items-center justify-center rounded-full
+                  ${isToday ? 'bg-gold text-dark' : 'text-muted'}`}>
+                  {day}
+                </div>
+                <div class="space-y-1">
+                  {dayTasks.slice(0, 3).map(t => (
+                    <a href={`/admin/projekte/${t.projectId}`}
+                      class={`flex items-center gap-1 rounded px-1.5 py-0.5 text-xs bg-dark border border-dark-lighter hover:border-gold/40 transition-colors group ${STATUS_CLS[t.status] ?? ''}`}
+                      title={`${t.name} — ${t.projectName}`}>
+                      <span class={`w-1.5 h-1.5 rounded-full shrink-0 ${PRIO_DOT[t.priority] ?? 'bg-dark-lighter'}`}></span>
+                      <span class="truncate text-muted group-hover:text-light transition-colors">{t.name}</span>
+                    </a>
+                  ))}
+                  {dayTasks.length > 3 && (
+                    <p class="text-xs text-muted pl-1">+{dayTasks.length - 3} weitere</p>
+                  )}
+                </div>
+              </div>
+            );
+          })}
+
+          {(() => {
+            const trailing = (7 - (startWeekday + totalDays) % 7) % 7;
+            return Array.from({ length: trailing }).map(() => (
+              <div class="min-h-[100px] border-b border-r border-dark-lighter/50 bg-dark/30"></div>
+            ));
+          })()}
+        </div>
+      </div>
+
+      <div class="flex gap-4 mt-4 text-xs text-muted">
+        <span class="flex items-center gap-1"><span class="w-2 h-2 rounded-full bg-red-500 inline-block"></span> Hoch</span>
+        <span class="flex items-center gap-1"><span class="w-2 h-2 rounded-full bg-yellow-500 inline-block"></span> Mittel</span>
+        <span class="flex items-center gap-1"><span class="w-2 h-2 rounded-full bg-green-500 inline-block"></span> Niedrig</span>
+      </div>
+    </div>
+  </section>
+</Layout>

--- a/website/src/pages/admin/projekte/[id].astro
+++ b/website/src/pages/admin/projekte/[id].astro
@@ -3,8 +3,9 @@ import Layout from '../../../layouts/Layout.astro';
 import { getSession, getLoginUrl, isAdmin } from '../../../lib/auth';
 import {
   getProject, listSubProjects, listDirectTasks, listSubProjectTasks, listAllCustomers,
+  listTimeEntries, getProjectTotalMinutes,
 } from '../../../lib/website-db';
-import type { Project, SubProject, ProjectTask, Customer } from '../../../lib/website-db';
+import type { Project, SubProject, ProjectTask, Customer, TimeEntry } from '../../../lib/website-db';
 
 const session = await getSession(Astro.request.headers.get('cookie'));
 if (!session) return Astro.redirect(getLoginUrl());
@@ -17,14 +18,18 @@ let project: Project | null = null;
 let subProjects: SubProject[] = [];
 let directTasks: ProjectTask[] = [];
 let customers: Customer[] = [];
+let timeEntries: TimeEntry[] = [];
+let timeStats: { total: number; billable: number } = { total: 0, billable: 0 };
 let dbError = '';
 
 try {
   [project, customers] = await Promise.all([getProject(id), listAllCustomers()]);
   if (project) {
-    [subProjects, directTasks] = await Promise.all([
+    [subProjects, directTasks, timeEntries, timeStats] = await Promise.all([
       listSubProjects(id),
       listDirectTasks(id),
+      listTimeEntries(id),
+      getProjectTotalMinutes(id),
     ]);
   }
 } catch (err) {
@@ -70,6 +75,9 @@ function isoDate(d: Date | null | string): string {
 }
 function isOverdue(dueDate: Date | null, status: string): boolean {
   return !!dueDate && new Date(dueDate) < today && !['erledigt','archiviert'].includes(status);
+}
+function fmtMin(m: number): string {
+  return `${Math.floor(m / 60)}h ${(m % 60).toString().padStart(2, '0')}m`;
 }
 
 const inputCls    = 'w-full px-3 py-2 bg-dark border border-dark-lighter rounded-lg text-light text-sm focus:border-gold focus:ring-2 focus:ring-gold/20 outline-none';
@@ -373,6 +381,65 @@ const tasksJson = JSON.stringify(allTasksFlat.map(t => ({
               </table>
             )}
           </div>
+
+          {/* ── Zeiterfassung ── */}
+          <section class="mt-10">
+            <div class="flex items-center justify-between mb-4">
+              <div>
+                <h2 class="text-xl font-semibold text-light font-serif">Zeiterfassung</h2>
+                <p class="text-muted text-sm mt-0.5">
+                  {fmtMin(timeStats.total)} gesamt · {fmtMin(timeStats.billable)} abrechenbar
+                </p>
+              </div>
+              <button type="button" id="time-create-btn"
+                class="px-3 py-1.5 bg-gold hover:bg-gold-light text-dark text-sm font-semibold rounded-lg transition-colors">
+                + Zeit buchen
+              </button>
+            </div>
+
+            {timeEntries.length === 0 ? (
+              <p class="text-muted text-sm">Noch keine Einträge.</p>
+            ) : (
+              <div class="bg-dark-light rounded-xl border border-dark-lighter overflow-hidden">
+                <table class="w-full">
+                  <thead>
+                    <tr class="border-b border-dark-lighter">
+                      <th class="text-left px-3 py-2 text-xs text-muted uppercase tracking-wide font-medium">Datum</th>
+                      <th class="text-left px-3 py-2 text-xs text-muted uppercase tracking-wide font-medium">Aufgabe</th>
+                      <th class="text-left px-3 py-2 text-xs text-muted uppercase tracking-wide font-medium">Beschreibung</th>
+                      <th class="text-right px-3 py-2 text-xs text-muted uppercase tracking-wide font-medium">Min.</th>
+                      <th class="text-center px-3 py-2 text-xs text-muted uppercase tracking-wide font-medium">Abr.</th>
+                      <th class="px-3 py-2"></th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {timeEntries.map(e => (
+                      <tr class="border-b border-dark-lighter/50 hover:bg-dark/30 transition-colors">
+                        <td class="px-3 py-2 text-xs text-muted whitespace-nowrap">
+                          {new Date(e.entryDate).toLocaleDateString('de-DE', { day: '2-digit', month: '2-digit', year: 'numeric' })}
+                        </td>
+                        <td class="px-3 py-2 text-xs text-muted">{e.taskName ?? '—'}</td>
+                        <td class="px-3 py-2 text-xs text-muted max-w-[160px] truncate">{e.description ?? '—'}</td>
+                        <td class="px-3 py-2 text-xs text-light text-right font-mono">{e.minutes}</td>
+                        <td class="px-3 py-2 text-center text-xs">
+                          {e.billable ? <span class="text-green-400">✓</span> : <span class="text-muted">—</span>}
+                        </td>
+                        <td class="px-3 py-2 text-right">
+                          <form method="post" action="/api/admin/zeiterfassung/delete">
+                            <input type="hidden" name="id" value={e.id} />
+                            <input type="hidden" name="_back" value={`/admin/projekte/${id}`} />
+                            <button type="submit"
+                              class="text-muted hover:text-red-400 transition-colors text-sm"
+                              onclick="return confirm('Eintrag löschen?')">✕</button>
+                          </form>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </section>
         </>
       )}
 
@@ -460,6 +527,43 @@ const tasksJson = JSON.stringify(allTasksFlat.map(t => ({
       <div><label class={labelCls}>Notizen</label><textarea name="notes" id="edit-sp-notes" rows="2" maxlength="4000" class={`${inputCls} resize-none`}></textarea></div>
       <div class="flex gap-3 justify-end pt-2">
         <button type="button" id="edit-sp-cancel" class="px-4 py-2 text-sm text-muted hover:text-light transition-colors">Abbrechen</button>
+        <button type="submit" class="px-4 py-2 text-sm bg-gold hover:bg-gold-light text-dark font-semibold rounded-lg transition-colors">Speichern</button>
+      </div>
+    </form>
+  </dialog>
+
+  {/* ── Zeit-buchen Dialog ── */}
+  <dialog id="time-create-dialog"
+    class="bg-dark-light border border-dark-lighter rounded-2xl p-6 w-full max-w-md backdrop:bg-black/60">
+    <h2 class="text-lg font-semibold text-light mb-4 font-serif">Zeit buchen</h2>
+    <form method="post" action="/api/admin/zeiterfassung/create" class="space-y-4">
+      <input type="hidden" name="projectId" value={project?.id ?? ''} />
+      <input type="hidden" name="_back" value={`/admin/projekte/${project?.id ?? ''}`} />
+      <div class="grid grid-cols-2 gap-3">
+        <div>
+          <label class="block text-xs text-muted mb-1">Minuten <span class="text-red-400">*</span></label>
+          <input type="number" name="minutes" min="1" max="1440" required
+            class="w-full px-3 py-2 bg-dark border border-dark-lighter rounded-lg text-light text-sm focus:border-gold focus:ring-2 focus:ring-gold/20 outline-none"
+            placeholder="z.B. 90" />
+        </div>
+        <div>
+          <label class="block text-xs text-muted mb-1">Datum</label>
+          <input type="date" name="entryDate"
+            class="w-full px-3 py-2 bg-dark border border-dark-lighter rounded-lg text-light text-sm focus:border-gold focus:ring-2 focus:ring-gold/20 outline-none"
+            value={new Date().toISOString().slice(0, 10)} />
+        </div>
+      </div>
+      <div>
+        <label class="block text-xs text-muted mb-1">Beschreibung</label>
+        <input type="text" name="description" maxlength="500"
+          class="w-full px-3 py-2 bg-dark border border-dark-lighter rounded-lg text-light text-sm focus:border-gold focus:ring-2 focus:ring-gold/20 outline-none" />
+      </div>
+      <div class="flex items-center gap-2">
+        <input type="checkbox" name="billable" value="true" id="time-billable-cb" checked class="accent-gold w-4 h-4" />
+        <label for="time-billable-cb" class="text-sm text-light cursor-pointer">Abrechenbar</label>
+      </div>
+      <div class="flex gap-3 justify-end pt-2">
+        <button type="button" id="time-create-cancel" class="px-4 py-2 text-sm text-muted hover:text-light transition-colors">Abbrechen</button>
         <button type="submit" class="px-4 py-2 text-sm bg-gold hover:bg-gold-light text-dark font-semibold rounded-lg transition-colors">Speichern</button>
       </div>
     </form>
@@ -607,4 +711,9 @@ const tasksJson = JSON.stringify(allTasksFlat.map(t => ({
       if (!confirm('Aufgabe löschen?')) e.preventDefault();
     });
   });
+
+  // ── Zeit buchen dialog ──
+  const timeDialog = document.getElementById('time-create-dialog') as HTMLDialogElement;
+  document.getElementById('time-create-btn')?.addEventListener('click', () => timeDialog.showModal());
+  document.getElementById('time-create-cancel')?.addEventListener('click', () => timeDialog.close());
 </script>

--- a/website/src/pages/admin/projekte/[id].astro
+++ b/website/src/pages/admin/projekte/[id].astro
@@ -539,6 +539,15 @@ const tasksJson = JSON.stringify(allTasksFlat.map(t => ({
     <form method="post" action="/api/admin/zeiterfassung/create" class="space-y-4">
       <input type="hidden" name="projectId" value={project?.id ?? ''} />
       <input type="hidden" name="_back" value={`/admin/projekte/${project?.id ?? ''}`} />
+      <div>
+        <label class="block text-sm text-muted mb-1">Aufgabe (optional)</label>
+        <select name="taskId" class="w-full bg-dark border border-dark-lighter rounded-lg px-3 py-2 text-light text-sm focus:outline-none focus:border-gold/50">
+          <option value="">— keine Aufgabe —</option>
+          {directTasks.map(t => (
+            <option value={t.id}>{t.name}</option>
+          ))}
+        </select>
+      </div>
       <div class="grid grid-cols-2 gap-3">
         <div>
           <label class="block text-xs text-muted mb-1">Minuten <span class="text-red-400">*</span></label>

--- a/website/src/pages/admin/projekte/[id].astro
+++ b/website/src/pages/admin/projekte/[id].astro
@@ -90,7 +90,7 @@ const spJson = JSON.stringify(subProjects.map(sp => ({
   id: sp.id, name: sp.name, description: sp.description ?? '',
   notes: sp.notes ?? '', startDate: isoDate(sp.startDate), dueDate: isoDate(sp.dueDate),
   status: sp.status, priority: sp.priority, customerId: sp.customerId ?? '',
-})));
+}))).replace(/</g, '\\u003c');
 
 const allTasksFlat = [...directTasks, ...Object.values(spTasks).flat()];
 const tasksJson = JSON.stringify(allTasksFlat.map(t => ({
@@ -98,7 +98,7 @@ const tasksJson = JSON.stringify(allTasksFlat.map(t => ({
   notes: t.notes ?? '', startDate: isoDate(t.startDate), dueDate: isoDate(t.dueDate),
   status: t.status, priority: t.priority, customerId: t.customerId ?? '',
   subProjectId: t.subProjectId ?? '',
-})));
+}))).replace(/</g, '\\u003c');
 ---
 
 <Layout title={`Admin — ${project?.name ?? 'Projekt'}`}>
@@ -543,7 +543,7 @@ const tasksJson = JSON.stringify(allTasksFlat.map(t => ({
         <label class="block text-sm text-muted mb-1">Aufgabe (optional)</label>
         <select name="taskId" class="w-full bg-dark border border-dark-lighter rounded-lg px-3 py-2 text-light text-sm focus:outline-none focus:border-gold/50">
           <option value="">— keine Aufgabe —</option>
-          {directTasks.map(t => (
+          {allTasksFlat.map(t => (
             <option value={t.id}>{t.name}</option>
           ))}
         </select>
@@ -558,8 +558,7 @@ const tasksJson = JSON.stringify(allTasksFlat.map(t => ({
         <div>
           <label class="block text-xs text-muted mb-1">Datum</label>
           <input type="date" name="entryDate"
-            class="w-full px-3 py-2 bg-dark border border-dark-lighter rounded-lg text-light text-sm focus:border-gold focus:ring-2 focus:ring-gold/20 outline-none"
-            value={new Date().toISOString().slice(0, 10)} />
+            class="w-full px-3 py-2 bg-dark border border-dark-lighter rounded-lg text-light text-sm focus:border-gold focus:ring-2 focus:ring-gold/20 outline-none" />
         </div>
       </div>
       <div>
@@ -723,6 +722,13 @@ const tasksJson = JSON.stringify(allTasksFlat.map(t => ({
 
   // ── Zeit buchen dialog ──
   const timeDialog = document.getElementById('time-create-dialog') as HTMLDialogElement;
-  document.getElementById('time-create-btn')?.addEventListener('click', () => timeDialog.showModal());
+  document.getElementById('time-create-btn')?.addEventListener('click', () => {
+    // Set entryDate client-side to avoid UTC-offset giving yesterday's date
+    const dateInput = timeDialog.querySelector<HTMLInputElement>('input[name="entryDate"]');
+    if (dateInput && !dateInput.value) {
+      dateInput.value = new Date().toLocaleDateString('sv'); // sv locale → YYYY-MM-DD in local time
+    }
+    timeDialog.showModal();
+  });
   document.getElementById('time-create-cancel')?.addEventListener('click', () => timeDialog.close());
 </script>

--- a/website/src/pages/admin/rechnungen.astro
+++ b/website/src/pages/admin/rechnungen.astro
@@ -1,0 +1,141 @@
+---
+import Layout from '../../layouts/Layout.astro';
+import { getSession, getLoginUrl, isAdmin } from '../../lib/auth';
+import { getAllInvoices } from '../../lib/invoiceninja';
+import type { AdminInvoiceListItem } from '../../lib/invoiceninja';
+
+const session = await getSession(Astro.request.headers.get('cookie'));
+if (!session) return Astro.redirect(getLoginUrl());
+if (!isAdmin(session)) return Astro.redirect('/admin');
+
+const statusFilter = Astro.url.searchParams.get('status') ?? '';
+
+let invoices: AdminInvoiceListItem[] = [];
+let apiError = '';
+try {
+  invoices = await getAllInvoices({ statusId: statusFilter || undefined, perPage: 200 });
+} catch (err) {
+  console.error('[admin/rechnungen]', err);
+  apiError = 'Invoice Ninja nicht erreichbar.';
+}
+
+const totalOpen       = invoices.filter(i => i.balance > 0 && !['4','5'].includes(i.statusId)).reduce((s, i) => s + i.balance, 0);
+const totalPaid       = invoices.filter(i => i.statusId === '4').reduce((s, i) => s + i.amount, 0);
+const countOverdue    = invoices.filter(i => i.statusId === '6').length;
+
+function fmtCurrency(n: number): string {
+  return new Intl.NumberFormat('de-DE', { style: 'currency', currency: 'EUR' }).format(n);
+}
+function fmtDate(s: string): string {
+  if (!s) return '—';
+  return new Date(s).toLocaleDateString('de-DE', { day: '2-digit', month: '2-digit', year: 'numeric' });
+}
+
+const STATUS_CLS: Record<string, string> = {
+  '1': 'bg-slate-900/40 text-slate-300 border-slate-700',
+  '2': 'bg-blue-900/40 text-blue-300 border-blue-800',
+  '3': 'bg-yellow-900/40 text-yellow-300 border-yellow-800',
+  '4': 'bg-green-900/40 text-green-300 border-green-800',
+  '5': 'bg-dark border border-dark-lighter text-muted',
+  '6': 'bg-red-900/40 text-red-300 border-red-800',
+};
+
+const STATUS_TABS = [
+  { value: '',  label: 'Alle' },
+  { value: '2', label: 'Versendet' },
+  { value: '6', label: 'Überfällig' },
+  { value: '4', label: 'Bezahlt' },
+  { value: '1', label: 'Entwurf' },
+  { value: '5', label: 'Storniert' },
+];
+---
+
+<Layout title="Admin — Rechnungen">
+  <section class="pt-28 pb-20 bg-dark min-h-screen">
+    <div class="max-w-6xl mx-auto px-6">
+
+      <div class="mb-2">
+        <a href="/admin" class="text-muted hover:text-gold text-sm">← Zurück zur Übersicht</a>
+      </div>
+
+      <div class="mb-8">
+        <h1 class="text-3xl font-bold text-light font-serif">Rechnungen</h1>
+        <p class="text-muted mt-1">{invoices.length} Rechnungen über alle Clients</p>
+      </div>
+
+      <!-- KPI Cards -->
+      <div class="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-8">
+        {[
+          { label: 'Offen',      value: fmtCurrency(totalOpen),  cls: totalOpen > 0 ? 'border-yellow-800' : 'border-dark-lighter' },
+          { label: 'Bezahlt',    value: fmtCurrency(totalPaid),  cls: 'border-green-800' },
+          { label: 'Überfällig', value: countOverdue,            cls: countOverdue > 0 ? 'border-red-800' : 'border-dark-lighter' },
+          { label: 'Gesamt',     value: invoices.length,         cls: 'border-dark-lighter' },
+        ].map(s => (
+          <div class={`p-4 bg-dark-light rounded-xl border ${s.cls}`}>
+            <div class="text-xl font-bold text-light">{s.value}</div>
+            <div class="text-xs text-muted mt-0.5">{s.label}</div>
+          </div>
+        ))}
+      </div>
+
+      {apiError && (
+        <div class="mb-6 p-4 bg-red-900/30 border border-red-800 rounded-xl text-red-300 text-sm">{apiError}</div>
+      )}
+
+      <!-- Status filter tabs -->
+      <div class="flex gap-1 p-1 bg-dark-light rounded-lg border border-dark-lighter mb-6 w-fit flex-wrap">
+        {STATUS_TABS.map(t => (
+          <a href={`/admin/rechnungen${t.value ? '?status=' + t.value : ''}`}
+            class={`px-3 py-1.5 rounded text-sm font-medium transition-colors ${statusFilter === t.value ? 'bg-gold text-dark' : 'text-muted hover:text-light'}`}>
+            {t.label}
+          </a>
+        ))}
+      </div>
+
+      <!-- Table -->
+      <div class="bg-dark-light rounded-2xl border border-dark-lighter overflow-hidden">
+        <table class="w-full">
+          <thead>
+            <tr class="border-b border-dark-lighter">
+              <th class="text-left px-4 py-3 text-xs text-muted uppercase tracking-wide font-medium">Nr.</th>
+              <th class="text-left px-4 py-3 text-xs text-muted uppercase tracking-wide font-medium">Client</th>
+              <th class="text-left px-4 py-3 text-xs text-muted uppercase tracking-wide font-medium">Status</th>
+              <th class="text-left px-4 py-3 text-xs text-muted uppercase tracking-wide font-medium">Datum</th>
+              <th class="text-left px-4 py-3 text-xs text-muted uppercase tracking-wide font-medium">Fällig</th>
+              <th class="text-right px-4 py-3 text-xs text-muted uppercase tracking-wide font-medium">Betrag</th>
+              <th class="text-right px-4 py-3 text-xs text-muted uppercase tracking-wide font-medium">Offen</th>
+            </tr>
+          </thead>
+          <tbody>
+            {invoices.length === 0 ? (
+              <tr>
+                <td colspan="7" class="px-4 py-10 text-center text-muted text-sm">Keine Rechnungen gefunden.</td>
+              </tr>
+            ) : invoices.map(inv => (
+              <tr class="border-b border-dark-lighter/50 hover:bg-dark/30 transition-colors">
+                <td class="px-4 py-3 text-sm text-light font-mono">#{inv.number}</td>
+                <td class="px-4 py-3 text-sm">
+                  <div class="text-light">{inv.clientName}</div>
+                  <div class="text-xs text-muted">{inv.clientEmail}</div>
+                </td>
+                <td class="px-4 py-3">
+                  <span class={`text-xs px-2 py-0.5 rounded-full border whitespace-nowrap ${STATUS_CLS[inv.statusId] ?? ''}`}>
+                    {inv.statusLabel}
+                  </span>
+                </td>
+                <td class="px-4 py-3 text-sm text-muted whitespace-nowrap">{fmtDate(inv.date)}</td>
+                <td class={`px-4 py-3 text-sm whitespace-nowrap font-medium ${inv.statusId === '6' ? 'text-red-400' : 'text-muted'}`}>
+                  {fmtDate(inv.dueDate)}{inv.statusId === '6' ? ' ⚠' : ''}
+                </td>
+                <td class="px-4 py-3 text-sm text-light text-right font-medium">{fmtCurrency(inv.amount)}</td>
+                <td class={`px-4 py-3 text-sm text-right font-medium ${inv.balance > 0 ? 'text-yellow-400' : 'text-muted'}`}>
+                  {inv.balance > 0 ? fmtCurrency(inv.balance) : '—'}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </section>
+</Layout>

--- a/website/src/pages/admin/zeiterfassung.astro
+++ b/website/src/pages/admin/zeiterfassung.astro
@@ -86,7 +86,7 @@ const labelCls  = 'block text-xs text-muted mb-1';
 
       {(errorMsg || dbError) && (
         <div id="err-banner" class="mb-6 p-4 bg-red-900/30 border border-red-800 rounded-xl text-red-300 text-sm flex items-start justify-between gap-4">
-          <span>{decodeURIComponent((errorMsg || dbError).replace(/\+/g, ' '))}</span>
+          <span>{(() => { const raw = (errorMsg || dbError).replace(/\+/g, ' '); try { return decodeURIComponent(raw); } catch { return raw; } })()}</span>
           <button type="button" onclick="document.getElementById('err-banner').remove()" class="text-red-400 hover:text-red-200 shrink-0">✕</button>
         </div>
       )}

--- a/website/src/pages/admin/zeiterfassung.astro
+++ b/website/src/pages/admin/zeiterfassung.astro
@@ -1,0 +1,210 @@
+---
+import Layout from '../../layouts/Layout.astro';
+import { getSession, getLoginUrl, isAdmin } from '../../lib/auth';
+import { listAllTimeEntries, listProjects } from '../../lib/website-db';
+import type { TimeEntry, Project } from '../../lib/website-db';
+
+const session = await getSession(Astro.request.headers.get('cookie'));
+if (!session) return Astro.redirect(getLoginUrl());
+if (!isAdmin(session)) return Astro.redirect('/admin');
+
+const BRAND = process.env.BRAND || 'mentolder';
+const errorMsg       = Astro.url.searchParams.get('error') ?? '';
+const saved          = Astro.url.searchParams.get('saved')  ?? '';
+const filterBillable = Astro.url.searchParams.get('billable') ?? '';
+
+let entries: TimeEntry[] = [];
+let projects: Project[]  = [];
+let dbError = '';
+
+try {
+  [entries, projects] = await Promise.all([
+    listAllTimeEntries({
+      billable: filterBillable === 'true' ? true : filterBillable === 'false' ? false : undefined,
+    }),
+    listProjects({ brand: BRAND }),
+  ]);
+} catch (err) {
+  console.error('[admin/zeiterfassung]', err);
+  dbError = 'Datenbankfehler beim Laden.';
+}
+
+const totalMinutes    = entries.reduce((s, e) => s + e.minutes, 0);
+const billableMinutes = entries.filter(e => e.billable).reduce((s, e) => s + e.minutes, 0);
+
+function fmtMin(m: number): string {
+  return `${Math.floor(m / 60)}h ${(m % 60).toString().padStart(2, '0')}m`;
+}
+function fmtDate(d: Date): string {
+  return new Date(d).toLocaleDateString('de-DE', { day: '2-digit', month: '2-digit', year: 'numeric' });
+}
+
+const inputCls  = 'w-full px-3 py-2 bg-dark border border-dark-lighter rounded-lg text-light text-sm focus:border-gold focus:ring-2 focus:ring-gold/20 outline-none';
+const selectCls = 'w-full px-3 py-2 bg-dark border border-dark-lighter rounded-lg text-light text-sm cursor-pointer focus:border-gold focus:ring-2 focus:ring-gold/20 outline-none';
+const labelCls  = 'block text-xs text-muted mb-1';
+---
+
+<Layout title="Admin — Zeiterfassung">
+  <section class="pt-28 pb-20 bg-dark min-h-screen">
+    <div class="max-w-6xl mx-auto px-6">
+
+      <div class="mb-2">
+        <a href="/admin" class="text-muted hover:text-gold text-sm">← Zurück zur Übersicht</a>
+      </div>
+
+      <div class="mb-8 flex items-center justify-between gap-4 flex-wrap">
+        <div>
+          <h1 class="text-3xl font-bold text-light font-serif">Zeiterfassung</h1>
+          <p class="text-muted mt-1">{fmtMin(totalMinutes)} gesamt · {fmtMin(billableMinutes)} abrechenbar</p>
+        </div>
+        <div class="flex gap-3">
+          <a href="/api/admin/zeiterfassung/export?billable=true"
+            class="px-4 py-2 bg-dark-light border border-dark-lighter text-muted text-sm rounded-lg hover:text-light hover:border-gold/40 transition-colors">
+            ↓ CSV (abrechenbar)
+          </a>
+          <button type="button" id="create-btn"
+            class="px-4 py-2 bg-gold hover:bg-gold-light text-dark text-sm font-semibold rounded-lg transition-colors">
+            + Zeit buchen
+          </button>
+        </div>
+      </div>
+
+      {/* KPI Cards */}
+      <div class="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-8">
+        {[
+          { label: 'Einträge',    value: entries.length,                         cls: 'border-dark-lighter' },
+          { label: 'Gesamt',      value: fmtMin(totalMinutes),                   cls: 'border-dark-lighter' },
+          { label: 'Abrechenbar', value: fmtMin(billableMinutes),                cls: 'border-yellow-800' },
+          { label: 'Nicht abr.',  value: fmtMin(totalMinutes - billableMinutes), cls: 'border-dark-lighter' },
+        ].map(s => (
+          <div class={`p-4 bg-dark-light rounded-xl border ${s.cls}`}>
+            <div class="text-xl font-bold text-light">{s.value}</div>
+            <div class="text-xs text-muted mt-0.5">{s.label}</div>
+          </div>
+        ))}
+      </div>
+
+      {(errorMsg || dbError) && (
+        <div id="err-banner" class="mb-6 p-4 bg-red-900/30 border border-red-800 rounded-xl text-red-300 text-sm flex items-start justify-between gap-4">
+          <span>{decodeURIComponent((errorMsg || dbError).replace(/\+/g, ' '))}</span>
+          <button type="button" onclick="document.getElementById('err-banner').remove()" class="text-red-400 hover:text-red-200 shrink-0">✕</button>
+        </div>
+      )}
+      {saved && (
+        <div id="ok-banner" class="mb-6 p-4 bg-green-900/30 border border-green-800 rounded-xl text-green-300 text-sm flex items-start justify-between gap-4">
+          <span>Eintrag gespeichert.</span>
+          <button type="button" onclick="document.getElementById('ok-banner').remove()" class="text-green-400 hover:text-green-200 shrink-0">✕</button>
+        </div>
+      )}
+
+      {/* Filter bar */}
+      <div class="flex gap-1 p-1 bg-dark-light rounded-lg border border-dark-lighter mb-6 w-fit">
+        {[
+          { label: 'Alle',        value: '' },
+          { label: 'Abrechenbar', value: 'true' },
+          { label: 'Nicht abr.', value: 'false' },
+        ].map(opt => (
+          <a href={`/admin/zeiterfassung${opt.value ? '?billable=' + opt.value : ''}`}
+            class={`px-3 py-1.5 rounded text-sm font-medium transition-colors ${filterBillable === opt.value ? 'bg-gold text-dark' : 'text-muted hover:text-light'}`}>
+            {opt.label}
+          </a>
+        ))}
+      </div>
+
+      {/* Table */}
+      <div class="bg-dark-light rounded-2xl border border-dark-lighter overflow-hidden">
+        <table class="w-full">
+          <thead>
+            <tr class="border-b border-dark-lighter">
+              <th class="text-left px-4 py-3 text-xs text-muted uppercase tracking-wide font-medium">Datum</th>
+              <th class="text-left px-4 py-3 text-xs text-muted uppercase tracking-wide font-medium">Projekt</th>
+              <th class="text-left px-4 py-3 text-xs text-muted uppercase tracking-wide font-medium">Aufgabe</th>
+              <th class="text-left px-4 py-3 text-xs text-muted uppercase tracking-wide font-medium">Beschreibung</th>
+              <th class="text-right px-4 py-3 text-xs text-muted uppercase tracking-wide font-medium">Minuten</th>
+              <th class="text-center px-4 py-3 text-xs text-muted uppercase tracking-wide font-medium">Abr.</th>
+              <th class="text-right px-4 py-3 text-xs text-muted uppercase tracking-wide font-medium">Aktionen</th>
+            </tr>
+          </thead>
+          <tbody>
+            {entries.length === 0 ? (
+              <tr>
+                <td colspan="7" class="px-4 py-10 text-center text-muted text-sm">Keine Einträge vorhanden.</td>
+              </tr>
+            ) : entries.map(e => (
+              <tr class="border-b border-dark-lighter/50 hover:bg-dark/30 transition-colors">
+                <td class="px-4 py-3 text-sm text-muted whitespace-nowrap">{fmtDate(e.entryDate)}</td>
+                <td class="px-4 py-3 text-sm text-light">
+                  <a href={`/admin/projekte/${e.projectId}`} class="hover:text-gold transition-colors">{e.projectName}</a>
+                </td>
+                <td class="px-4 py-3 text-sm text-muted">{e.taskName ?? '—'}</td>
+                <td class="px-4 py-3 text-sm text-muted max-w-[200px] truncate">{e.description ?? '—'}</td>
+                <td class="px-4 py-3 text-sm text-right font-mono">
+                  {e.minutes} <span class="text-muted text-xs">({fmtMin(e.minutes)})</span>
+                </td>
+                <td class="px-4 py-3 text-center text-sm">
+                  {e.billable ? <span class="text-green-400">✓</span> : <span class="text-muted">—</span>}
+                </td>
+                <td class="px-4 py-3 text-right">
+                  <form method="post" action="/api/admin/zeiterfassung/delete">
+                    <input type="hidden" name="id" value={e.id} />
+                    <input type="hidden" name="_back" value="/admin/zeiterfassung" />
+                    <button type="submit"
+                      class="px-3 py-1 text-xs bg-red-900/20 border border-red-900/40 text-red-400 rounded hover:bg-red-900/40 transition-colors"
+                      onclick="return confirm('Eintrag löschen?')">
+                      Löschen
+                    </button>
+                  </form>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </section>
+
+  {/* Create dialog */}
+  <dialog id="create-dialog"
+    class="bg-dark-light border border-dark-lighter rounded-2xl p-6 w-full max-w-lg backdrop:bg-black/60">
+    <h2 class="text-lg font-semibold text-light mb-4 font-serif">Zeit buchen</h2>
+    <form method="post" action="/api/admin/zeiterfassung/create" class="space-y-4">
+      <input type="hidden" name="_back" value="/admin/zeiterfassung" />
+      <div>
+        <label class={labelCls}>Projekt <span class="text-red-400">*</span></label>
+        <select name="projectId" required class={selectCls}>
+          <option value="">— Projekt wählen —</option>
+          {projects.map(p => <option value={p.id}>{p.name}</option>)}
+        </select>
+      </div>
+      <div class="grid grid-cols-2 gap-3">
+        <div>
+          <label class={labelCls}>Minuten <span class="text-red-400">*</span></label>
+          <input type="number" name="minutes" min="1" max="1440" required class={inputCls} placeholder="z.B. 90" />
+        </div>
+        <div>
+          <label class={labelCls}>Datum</label>
+          <input type="date" name="entryDate" class={inputCls}
+            value={new Date().toISOString().slice(0, 10)} />
+        </div>
+      </div>
+      <div>
+        <label class={labelCls}>Beschreibung</label>
+        <input type="text" name="description" maxlength="500" class={inputCls} />
+      </div>
+      <div class="flex items-center gap-2">
+        <input type="checkbox" name="billable" value="true" id="billable-cb" checked class="accent-gold w-4 h-4" />
+        <label for="billable-cb" class="text-sm text-light cursor-pointer">Abrechenbar</label>
+      </div>
+      <div class="flex gap-3 justify-end pt-2">
+        <button type="button" id="create-cancel" class="px-4 py-2 text-sm text-muted hover:text-light transition-colors">Abbrechen</button>
+        <button type="submit" class="px-4 py-2 text-sm bg-gold hover:bg-gold-light text-dark font-semibold rounded-lg transition-colors">Speichern</button>
+      </div>
+    </form>
+  </dialog>
+</Layout>
+
+<script>
+  const dialog = document.getElementById('create-dialog') as HTMLDialogElement;
+  document.getElementById('create-btn')?.addEventListener('click', () => dialog.showModal());
+  document.getElementById('create-cancel')?.addEventListener('click', () => dialog.close());
+</script>

--- a/website/src/pages/api/admin/clientnotes/create.ts
+++ b/website/src/pages/api/admin/clientnotes/create.ts
@@ -4,7 +4,7 @@ import { createClientNote } from '../../../../lib/website-db';
 
 export const POST: APIRoute = async ({ request }) => {
   const session = await getSession(request.headers.get('cookie'));
-  if (!session || !isAdmin(session)) return new Response(null, { status: 401 });
+  if (!session || !isAdmin(session)) return new Response(null, { status: 403 });
 
   const form    = await request.formData();
   const userId  = form.get('keycloakUserId') as string;

--- a/website/src/pages/api/admin/clientnotes/create.ts
+++ b/website/src/pages/api/admin/clientnotes/create.ts
@@ -1,0 +1,32 @@
+import type { APIRoute } from 'astro';
+import { getSession, isAdmin } from '../../../../lib/auth';
+import { createClientNote } from '../../../../lib/website-db';
+
+export const POST: APIRoute = async ({ request }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) return new Response(null, { status: 401 });
+
+  const form    = await request.formData();
+  const userId  = form.get('keycloakUserId') as string;
+  const content = (form.get('content') as string)?.trim();
+  const back    = form.get('_back') as string | null;
+
+  if (!userId || !content) {
+    return new Response(null, {
+      status: 302,
+      headers: { Location: `${back || '/admin'}?error=${encodeURIComponent('Notiz darf nicht leer sein')}` },
+    });
+  }
+
+  try {
+    await createClientNote(userId, content);
+  } catch (err) {
+    console.error('[api/clientnotes/create]', err);
+    return new Response(null, {
+      status: 302,
+      headers: { Location: `${back || '/admin'}?error=${encodeURIComponent('Datenbankfehler')}` },
+    });
+  }
+
+  return new Response(null, { status: 302, headers: { Location: `${back || '/admin'}?saved=1` } });
+};

--- a/website/src/pages/api/admin/clientnotes/delete.ts
+++ b/website/src/pages/api/admin/clientnotes/delete.ts
@@ -4,7 +4,7 @@ import { deleteClientNote } from '../../../../lib/website-db';
 
 export const POST: APIRoute = async ({ request }) => {
   const session = await getSession(request.headers.get('cookie'));
-  if (!session || !isAdmin(session)) return new Response(null, { status: 401 });
+  if (!session || !isAdmin(session)) return new Response(null, { status: 403 });
 
   const form = await request.formData();
   const id   = form.get('id') as string;

--- a/website/src/pages/api/admin/clientnotes/delete.ts
+++ b/website/src/pages/api/admin/clientnotes/delete.ts
@@ -1,0 +1,16 @@
+import type { APIRoute } from 'astro';
+import { getSession, isAdmin } from '../../../../lib/auth';
+import { deleteClientNote } from '../../../../lib/website-db';
+
+export const POST: APIRoute = async ({ request }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) return new Response(null, { status: 401 });
+
+  const form = await request.formData();
+  const id   = form.get('id') as string;
+  const back = form.get('_back') as string | null;
+
+  if (id) await deleteClientNote(id);
+
+  return new Response(null, { status: 302, headers: { Location: back || '/admin' } });
+};

--- a/website/src/pages/api/admin/followups/create.ts
+++ b/website/src/pages/api/admin/followups/create.ts
@@ -1,0 +1,40 @@
+import type { APIRoute } from 'astro';
+import { getSession, isAdmin } from '../../../../lib/auth';
+import { createFollowUp } from '../../../../lib/website-db';
+
+export const POST: APIRoute = async ({ request }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) return new Response(null, { status: 401 });
+
+  const form        = await request.formData();
+  const reason      = (form.get('reason') as string)?.trim();
+  const dueDate     = form.get('dueDate') as string;
+  const clientName  = form.get('clientName') as string | null;
+  const clientEmail = form.get('clientEmail') as string | null;
+  const userId      = form.get('keycloakUserId') as string | null;
+  const back        = form.get('_back') as string | null;
+
+  if (!reason || !dueDate) {
+    return new Response(null, {
+      status: 302,
+      headers: { Location: `${back || '/admin/followups'}?error=${encodeURIComponent('Grund und Datum erforderlich')}` },
+    });
+  }
+
+  try {
+    await createFollowUp({
+      reason, dueDate,
+      keycloakUserId: userId || undefined,
+      clientName: clientName || undefined,
+      clientEmail: clientEmail || undefined,
+    });
+  } catch (err) {
+    console.error('[api/followups/create]', err);
+    return new Response(null, {
+      status: 302,
+      headers: { Location: `${back || '/admin/followups'}?error=${encodeURIComponent('Datenbankfehler')}` },
+    });
+  }
+
+  return new Response(null, { status: 302, headers: { Location: `${back || '/admin/followups'}?saved=1` } });
+};

--- a/website/src/pages/api/admin/followups/create.ts
+++ b/website/src/pages/api/admin/followups/create.ts
@@ -4,7 +4,7 @@ import { createFollowUp } from '../../../../lib/website-db';
 
 export const POST: APIRoute = async ({ request }) => {
   const session = await getSession(request.headers.get('cookie'));
-  if (!session || !isAdmin(session)) return new Response(null, { status: 401 });
+  if (!session || !isAdmin(session)) return new Response(null, { status: 403 });
 
   const form        = await request.formData();
   const reason      = (form.get('reason') as string)?.trim();

--- a/website/src/pages/api/admin/followups/delete.ts
+++ b/website/src/pages/api/admin/followups/delete.ts
@@ -1,0 +1,16 @@
+import type { APIRoute } from 'astro';
+import { getSession, isAdmin } from '../../../../lib/auth';
+import { deleteFollowUp } from '../../../../lib/website-db';
+
+export const POST: APIRoute = async ({ request }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) return new Response(null, { status: 401 });
+
+  const form = await request.formData();
+  const id   = form.get('id') as string;
+  const back = form.get('_back') as string | null;
+
+  if (id) await deleteFollowUp(id);
+
+  return new Response(null, { status: 302, headers: { Location: back || '/admin/followups' } });
+};

--- a/website/src/pages/api/admin/followups/delete.ts
+++ b/website/src/pages/api/admin/followups/delete.ts
@@ -4,7 +4,7 @@ import { deleteFollowUp } from '../../../../lib/website-db';
 
 export const POST: APIRoute = async ({ request }) => {
   const session = await getSession(request.headers.get('cookie'));
-  if (!session || !isAdmin(session)) return new Response(null, { status: 401 });
+  if (!session || !isAdmin(session)) return new Response(null, { status: 403 });
 
   const form = await request.formData();
   const id   = form.get('id') as string;

--- a/website/src/pages/api/admin/followups/notify.ts
+++ b/website/src/pages/api/admin/followups/notify.ts
@@ -5,7 +5,7 @@ import { postWebhook } from '../../../../lib/mattermost';
 
 export const POST: APIRoute = async ({ request }) => {
   const session = await getSession(request.headers.get('cookie'));
-  if (!session || !isAdmin(session)) return new Response(null, { status: 401 });
+  if (!session || !isAdmin(session)) return new Response(null, { status: 403 });
 
   const due = await getDueFollowUps();
   if (due.length === 0) {

--- a/website/src/pages/api/admin/followups/notify.ts
+++ b/website/src/pages/api/admin/followups/notify.ts
@@ -1,0 +1,26 @@
+import type { APIRoute } from 'astro';
+import { getSession, isAdmin } from '../../../../lib/auth';
+import { getDueFollowUps } from '../../../../lib/website-db';
+import { postWebhook } from '../../../../lib/mattermost';
+
+export const POST: APIRoute = async ({ request }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) return new Response(null, { status: 401 });
+
+  const due = await getDueFollowUps();
+  if (due.length === 0) {
+    return Response.json({ sent: false, message: 'Keine fälligen Follow-ups.' });
+  }
+
+  const lines = due.map(f => {
+    const client = f.clientName ?? f.clientEmail ?? 'Unbekannt';
+    const date   = new Date(f.dueDate).toLocaleDateString('de-DE', { day: '2-digit', month: '2-digit', year: 'numeric' });
+    return `• **${client}** — ${f.reason} (fällig: ${date})`;
+  });
+
+  const message = `### 🔔 Follow-up Erinnerung\n\n${lines.join('\n')}\n\n[Follow-ups öffnen](/admin/followups)`;
+
+  const sent = await postWebhook({ text: message });
+
+  return Response.json({ sent, count: due.length });
+};

--- a/website/src/pages/api/admin/followups/update.ts
+++ b/website/src/pages/api/admin/followups/update.ts
@@ -1,0 +1,25 @@
+import type { APIRoute } from 'astro';
+import { getSession, isAdmin } from '../../../../lib/auth';
+import { updateFollowUp } from '../../../../lib/website-db';
+
+export const POST: APIRoute = async ({ request }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) return new Response(null, { status: 401 });
+
+  const form    = await request.formData();
+  const id      = form.get('id') as string;
+  const done    = form.get('done');
+  const dueDate = form.get('dueDate') as string | null;
+  const reason  = form.get('reason') as string | null;
+  const back    = form.get('_back') as string | null;
+
+  if (!id) return new Response(null, { status: 302, headers: { Location: back || '/admin/followups' } });
+
+  await updateFollowUp(id, {
+    done: done !== null ? done === 'true' : undefined,
+    dueDate: dueDate || undefined,
+    reason: reason || undefined,
+  });
+
+  return new Response(null, { status: 302, headers: { Location: back || '/admin/followups' } });
+};

--- a/website/src/pages/api/admin/followups/update.ts
+++ b/website/src/pages/api/admin/followups/update.ts
@@ -4,7 +4,7 @@ import { updateFollowUp } from '../../../../lib/website-db';
 
 export const POST: APIRoute = async ({ request }) => {
   const session = await getSession(request.headers.get('cookie'));
-  if (!session || !isAdmin(session)) return new Response(null, { status: 401 });
+  if (!session || !isAdmin(session)) return new Response(null, { status: 403 });
 
   const form    = await request.formData();
   const id      = form.get('id') as string;
@@ -15,11 +15,19 @@ export const POST: APIRoute = async ({ request }) => {
 
   if (!id) return new Response(null, { status: 302, headers: { Location: back || '/admin/followups' } });
 
-  await updateFollowUp(id, {
-    done: done !== null ? done === 'true' : undefined,
-    dueDate: dueDate || undefined,
-    reason: reason || undefined,
-  });
+  try {
+    await updateFollowUp(id, {
+      done: done !== null ? done === 'true' : undefined,
+      dueDate: dueDate || undefined,
+      reason: reason || undefined,
+    });
+  } catch (err) {
+    console.error('[api/followups/update]', err);
+    return new Response(null, {
+      status: 302,
+      headers: { Location: `${back || '/admin/followups'}?error=${encodeURIComponent('Datenbankfehler')}` },
+    });
+  }
 
   return new Response(null, { status: 302, headers: { Location: back || '/admin/followups' } });
 };

--- a/website/src/pages/api/admin/onboarding/reset.ts
+++ b/website/src/pages/api/admin/onboarding/reset.ts
@@ -4,7 +4,7 @@ import { resetOnboardingChecklist } from '../../../../lib/website-db';
 
 export const POST: APIRoute = async ({ request }) => {
   const session = await getSession(request.headers.get('cookie'));
-  if (!session || !isAdmin(session)) return new Response(null, { status: 401 });
+  if (!session || !isAdmin(session)) return new Response(null, { status: 403 });
 
   const form   = await request.formData();
   const userId = form.get('keycloakUserId') as string;

--- a/website/src/pages/api/admin/onboarding/reset.ts
+++ b/website/src/pages/api/admin/onboarding/reset.ts
@@ -1,0 +1,16 @@
+import type { APIRoute } from 'astro';
+import { getSession, isAdmin } from '../../../../lib/auth';
+import { resetOnboardingChecklist } from '../../../../lib/website-db';
+
+export const POST: APIRoute = async ({ request }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) return new Response(null, { status: 401 });
+
+  const form   = await request.formData();
+  const userId = form.get('keycloakUserId') as string;
+  const back   = form.get('_back') as string | null;
+
+  if (userId) await resetOnboardingChecklist(userId);
+
+  return new Response(null, { status: 302, headers: { Location: back || '/admin' } });
+};

--- a/website/src/pages/api/admin/onboarding/update.ts
+++ b/website/src/pages/api/admin/onboarding/update.ts
@@ -1,0 +1,17 @@
+import type { APIRoute } from 'astro';
+import { getSession, isAdmin } from '../../../../lib/auth';
+import { toggleOnboardingItem } from '../../../../lib/website-db';
+
+export const POST: APIRoute = async ({ request }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) return new Response(null, { status: 401 });
+
+  const form = await request.formData();
+  const id   = form.get('id') as string;
+  const done = form.get('done') === 'true';
+  const back = form.get('_back') as string | null;
+
+  if (id) await toggleOnboardingItem(id, done);
+
+  return new Response(null, { status: 302, headers: { Location: back || '/admin' } });
+};

--- a/website/src/pages/api/admin/onboarding/update.ts
+++ b/website/src/pages/api/admin/onboarding/update.ts
@@ -4,7 +4,7 @@ import { toggleOnboardingItem } from '../../../../lib/website-db';
 
 export const POST: APIRoute = async ({ request }) => {
   const session = await getSession(request.headers.get('cookie'));
-  if (!session || !isAdmin(session)) return new Response(null, { status: 401 });
+  if (!session || !isAdmin(session)) return new Response(null, { status: 403 });
 
   const form = await request.formData();
   const id   = form.get('id') as string;

--- a/website/src/pages/api/admin/zeiterfassung/create.ts
+++ b/website/src/pages/api/admin/zeiterfassung/create.ts
@@ -4,7 +4,7 @@ import { createTimeEntry } from '../../../../lib/website-db';
 
 export const POST: APIRoute = async ({ request }) => {
   const session = await getSession(request.headers.get('cookie'));
-  if (!session || !isAdmin(session)) return new Response(null, { status: 401 });
+  if (!session || !isAdmin(session)) return new Response(null, { status: 403 });
 
   const form = await request.formData();
   const projectId    = form.get('projectId') as string;

--- a/website/src/pages/api/admin/zeiterfassung/create.ts
+++ b/website/src/pages/api/admin/zeiterfassung/create.ts
@@ -1,0 +1,47 @@
+import type { APIRoute } from 'astro';
+import { getSession, isAdmin } from '../../../../lib/auth';
+import { createTimeEntry } from '../../../../lib/website-db';
+
+export const POST: APIRoute = async ({ request }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) return new Response(null, { status: 401 });
+
+  const form = await request.formData();
+  const projectId    = form.get('projectId') as string;
+  const taskId       = form.get('taskId') as string | null;
+  const description  = form.get('description') as string | null;
+  const minutesRaw   = form.get('minutes') as string;
+  const billable     = form.get('billable') === 'true';
+  const entryDate    = form.get('entryDate') as string | null;
+  const back         = form.get('_back') as string | null;
+
+  const minutes = parseInt(minutesRaw, 10);
+  if (!projectId || isNaN(minutes) || minutes <= 0) {
+    const dest = back || '/admin/zeiterfassung';
+    return new Response(null, {
+      status: 302,
+      headers: { Location: `${dest}?error=${encodeURIComponent('Ungültige Eingabe')}` },
+    });
+  }
+
+  try {
+    await createTimeEntry({
+      projectId,
+      taskId: taskId || undefined,
+      description: description || undefined,
+      minutes,
+      billable,
+      entryDate: entryDate || undefined,
+    });
+  } catch (err) {
+    console.error('[api/zeiterfassung/create]', err);
+    const dest = back || '/admin/zeiterfassung';
+    return new Response(null, {
+      status: 302,
+      headers: { Location: `${dest}?error=${encodeURIComponent('Datenbankfehler')}` },
+    });
+  }
+
+  const dest = back || '/admin/zeiterfassung';
+  return new Response(null, { status: 302, headers: { Location: `${dest}?saved=1` } });
+};

--- a/website/src/pages/api/admin/zeiterfassung/delete.ts
+++ b/website/src/pages/api/admin/zeiterfassung/delete.ts
@@ -4,7 +4,7 @@ import { deleteTimeEntry } from '../../../../lib/website-db';
 
 export const POST: APIRoute = async ({ request }) => {
   const session = await getSession(request.headers.get('cookie'));
-  if (!session || !isAdmin(session)) return new Response(null, { status: 401 });
+  if (!session || !isAdmin(session)) return new Response(null, { status: 403 });
 
   const form = await request.formData();
   const id   = form.get('id') as string;

--- a/website/src/pages/api/admin/zeiterfassung/delete.ts
+++ b/website/src/pages/api/admin/zeiterfassung/delete.ts
@@ -1,0 +1,16 @@
+import type { APIRoute } from 'astro';
+import { getSession, isAdmin } from '../../../../lib/auth';
+import { deleteTimeEntry } from '../../../../lib/website-db';
+
+export const POST: APIRoute = async ({ request }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) return new Response(null, { status: 401 });
+
+  const form = await request.formData();
+  const id   = form.get('id') as string;
+  const back = form.get('_back') as string | null;
+
+  if (id) await deleteTimeEntry(id);
+
+  return new Response(null, { status: 302, headers: { Location: back || '/admin/zeiterfassung' } });
+};

--- a/website/src/pages/api/admin/zeiterfassung/export.ts
+++ b/website/src/pages/api/admin/zeiterfassung/export.ts
@@ -4,7 +4,7 @@ import { listAllTimeEntries } from '../../../../lib/website-db';
 
 export const GET: APIRoute = async ({ request, url }) => {
   const session = await getSession(request.headers.get('cookie'));
-  if (!session || !isAdmin(session)) return new Response(null, { status: 401 });
+  if (!session || !isAdmin(session)) return new Response(null, { status: 403 });
 
   const billableOnly = url.searchParams.get('billable') === 'true';
   const since        = url.searchParams.get('since') || undefined;

--- a/website/src/pages/api/admin/zeiterfassung/export.ts
+++ b/website/src/pages/api/admin/zeiterfassung/export.ts
@@ -1,0 +1,31 @@
+import type { APIRoute } from 'astro';
+import { getSession, isAdmin } from '../../../../lib/auth';
+import { listAllTimeEntries } from '../../../../lib/website-db';
+
+export const GET: APIRoute = async ({ request, url }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) return new Response(null, { status: 401 });
+
+  const billableOnly = url.searchParams.get('billable') === 'true';
+  const since        = url.searchParams.get('since') || undefined;
+
+  const entries = await listAllTimeEntries({
+    billable: billableOnly ? true : undefined,
+    since,
+  });
+
+  const header = 'Datum,Projekt,Aufgabe,Beschreibung,Minuten,Stunden,Abrechenbar\n';
+  const rows = entries.map(e => {
+    const stunden = (e.minutes / 60).toFixed(2);
+    const datum   = new Date(e.entryDate).toLocaleDateString('de-DE');
+    const desc    = (e.description || '').replace(/"/g, '""');
+    return `${datum},"${e.projectName}","${e.taskName || ''}","${desc}",${e.minutes},${stunden},${e.billable ? 'Ja' : 'Nein'}`;
+  }).join('\n');
+
+  return new Response(header + rows, {
+    headers: {
+      'Content-Type': 'text/csv; charset=utf-8',
+      'Content-Disposition': `attachment; filename="zeiterfassung-${new Date().toISOString().slice(0,10)}.csv"`,
+    },
+  });
+};


### PR DESCRIPTION
## Summary

- **Zeiterfassung** (`/admin/zeiterfassung`): Zeiteinträge buchen, filtern (abrechenbar/nicht abr.), CSV-Export; Einbindung im Projektdetail mit Aufgaben-Selektor
- **Rechnungsübersicht** (`/admin/rechnungen`): Alle Invoice-Ninja-Rechnungen mit KPI-Kacheln, Status-Filter und farbigen Badges
- **Follow-up-System** (`/admin/followups`): Follow-ups anlegen, abhaken, überfällige hervorheben, Mattermost-Erinnerung per Klick
- **Aufgaben-Kalender** (`/admin/kalender`): Monatsansicht aller Projektaufgaben mit Prioritäts-Dots und Navigation
- **KPI-Dashboard** (`/admin`): 5 Kennzahl-Kacheln (Aktive Projekte, Offene Rechnungen, Überfällige Bugs, Follow-ups fällig, Freie Slots) + 4 neue Tool-Kacheln
- **Kunden-Notizen** (Tab im Client-Profil): Freie Notizen je Kunde anlegen und löschen
- **Onboarding-Checkliste** (Tab im Client-Profil): Standard-Checkliste mit Fortschrittsbalken, abhakbar und zurücksetzbar

**Neue DB-Tabellen:** `time_entries`, `client_notes`, `onboarding_items`, `follow_ups` (alle via `CREATE TABLE IF NOT EXISTS`)

## Test Plan

- [ ] `/admin` zeigt KPI-Banner mit 5 klickbaren Kacheln und 4 neue Tool-Tiles
- [ ] `/admin/zeiterfassung`: Zeiteintrag buchen (mit Projekt- und Aufgaben-Selektor), Filter, CSV-Export
- [ ] `/admin/rechnungen`: Rechnungsliste mit Status-Filter und KPI-Kacheln
- [ ] `/admin/followups`: Follow-up anlegen, als erledigt markieren, überfällige rot hervorgehoben, Mattermost-Reminder-Button
- [ ] `/admin/kalender`: Monatsansicht mit Aufgaben, Prioritäts-Dots, Monatsnavigation
- [ ] `/admin/<clientId>` → Tab „Notizen": Notiz erstellen und löschen
- [ ] `/admin/<clientId>` → Tab „Onboarding": Items abhaken, Fortschrittsbalken, Reset
- [ ] Projektdetail `/admin/projekte/<id>`: Zeiterfassungs-Sektion mit Buchungs-Dialog und Eintrags-Tabelle
- [ ] `astro check` meldet keine neuen Fehler gegenüber `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)