### PR TITLE
fix(website-db): use SESSIONS_DATABASE_URL instead of stale MEETINGS_DATABASE_URL

### DIFF
--- a/website/src/lib/website-db.ts
+++ b/website/src/lib/website-db.ts
@@ -5,7 +5,7 @@
 import pg from 'pg';
 const { Pool } = pg;
 
-const MEETINGS_DB_URL = process.env.MEETINGS_DATABASE_URL
+const MEETINGS_DB_URL = process.env.SESSIONS_DATABASE_URL
   || 'postgresql://website:devwebsitedb@shared-db.workspace.svc.cluster.local:5432/website';
 const EMBEDDING_URL = process.env.EMBEDDING_URL
   || 'http://embedding.workspace.svc.cluster.local:8080';


### PR DESCRIPTION
## Summary

- After PR #101 renamed the meetings DB to `website`, `k3d/website.yaml` was updated to inject `SESSIONS_DATABASE_URL`
- `website-db.ts` still referenced the old `MEETINGS_DATABASE_URL` env var
- This caused a silent fallback to the hardcoded dev connection string on every request that hit `website-db.ts` functions (projects, customers, bug tickets, etc.)
- `auth.ts` and `reminders.ts` already used `SESSIONS_DATABASE_URL` correctly — this aligns `website-db.ts` with them

Fixes ticket **BR-20260415-0a20**

## Test plan

- [ ] Deploy to mentolder and verify project creation persists correctly
- [ ] Confirm no fallback warning in website pod logs
- [ ] Resolve ticket BR-20260415-0a20 in admin panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)