### PR TITLE
feat(admin): gebuchte Termine + vollständiges Usermanagement (BR-9857, BR-ee99)

### DIFF
--- a/docs/superpowers/plans/2026-04-16-slot-whitelist.md
+++ b/docs/superpowers/plans/2026-04-16-slot-whitelist.md
@@ -1,0 +1,713 @@
+# Slot-Whitelist für Terminbuchung — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Admin muss Terminslots explizit freigeben, bevor Kunden sie buchen können (Whitelist-Modell). Nicht freigegebene Slots erscheinen im Admin-Panel ausgegraut mit "Freigeben"-Button; freigegebene gold mit "×"-Button.
+
+**Architecture:** Neue `slot_whitelist` PostgreSQL-Tabelle speichert freigegebene Slots per `brand`. `getAvailableSlots()` in `caldav.ts` filtert zusätzlich auf Whitelist-Einträge wenn ein `brand`-Parameter übergeben wird. Zwei Admin-API-Endpoints (POST/DELETE) verwalten die Whitelist. Die Booking-API validiert Whitelist-Zugehörigkeit vor dem Akzeptieren.
+
+**Tech Stack:** TypeScript, Astro, PostgreSQL (`pg`), inline fetch + DOM-Update für Admin-Toggle (kein Svelte nötig).
+
+---
+
+## File Map
+
+| Datei | Aktion | Verantwortung |
+|-------|--------|---------------|
+| `website/src/lib/website-db.ts` | Modify (Ende anfügen) | `slot_whitelist`-Tabelle + CRUD-Funktionen |
+| `website/src/lib/caldav.ts` | Modify | `getAvailableSlots()` mit optionalem `brand`-Parameter |
+| `website/src/pages/api/calendar/slots.ts` | Modify | `brand` an `getAvailableSlots()` übergeben |
+| `website/src/pages/api/admin/slots/add.ts` | Create | POST-Endpoint: Slot zur Whitelist hinzufügen |
+| `website/src/pages/api/admin/slots/remove.ts` | Create | DELETE-Endpoint: Slot aus Whitelist entfernen |
+| `website/src/pages/api/booking.ts` | Modify | Whitelist-Validierung vor Buchungsannahme |
+| `website/src/pages/admin/termine.astro` | Modify | Toggle-UI mit freigegebenen/gesperrten Slots |
+| `website/tests/api.test.mjs` | Modify | Tests für neue Endpoints + aktualisierter Booking-Test |
+| `tests/e2e/specs/fa-16-booking.spec.ts` | Modify | T6 auf neue Whitelist-Semantik anpassen |
+
+---
+
+## Task 1: DB-Schicht — `slot_whitelist`-Tabelle und CRUD
+
+**Files:**
+- Modify: `website/src/lib/website-db.ts` (am Ende anfügen, nach Zeile 1636)
+
+- [ ] **Schritt 1: Neuen Code an `website-db.ts` anfügen**
+
+Am Ende der Datei (nach der letzten exportierten Funktion) einfügen:
+
+```typescript
+// ── Slot Whitelist ────────────────────────────────────────────────────────────
+
+export interface WhitelistedSlot {
+  slotStart: Date;
+  slotEnd: Date;
+}
+
+async function initSlotWhitelistTable(): Promise<void> {
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS slot_whitelist (
+      brand      TEXT        NOT NULL,
+      slot_start TIMESTAMPTZ NOT NULL,
+      slot_end   TIMESTAMPTZ NOT NULL,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      PRIMARY KEY (brand, slot_start)
+    )
+  `);
+}
+
+export async function getWhitelistedSlots(brand: string): Promise<WhitelistedSlot[]> {
+  await initSlotWhitelistTable();
+  const result = await pool.query(
+    `SELECT slot_start AS "slotStart", slot_end AS "slotEnd"
+     FROM slot_whitelist
+     WHERE brand = $1 AND slot_start > now()
+     ORDER BY slot_start ASC`,
+    [brand]
+  );
+  return result.rows;
+}
+
+export async function addSlotToWhitelist(brand: string, start: Date, end: Date): Promise<void> {
+  await initSlotWhitelistTable();
+  await pool.query(
+    `INSERT INTO slot_whitelist (brand, slot_start, slot_end)
+     VALUES ($1, $2, $3)
+     ON CONFLICT (brand, slot_start) DO UPDATE SET slot_end = $3`,
+    [brand, start, end]
+  );
+}
+
+export async function removeSlotFromWhitelist(brand: string, start: Date): Promise<void> {
+  await initSlotWhitelistTable();
+  await pool.query(
+    'DELETE FROM slot_whitelist WHERE brand = $1 AND slot_start = $2',
+    [brand, start]
+  );
+}
+
+export async function isSlotWhitelisted(brand: string, start: Date): Promise<boolean> {
+  await initSlotWhitelistTable();
+  const result = await pool.query(
+    'SELECT 1 FROM slot_whitelist WHERE brand = $1 AND slot_start = $2',
+    [brand, start]
+  );
+  return (result.rowCount ?? 0) > 0;
+}
+```
+
+- [ ] **Schritt 2: TypeScript-Kompilierung prüfen**
+
+```bash
+cd website && npx tsc --noEmit 2>&1 | grep -E "error|website-db"
+```
+
+Erwartet: keine Fehler.
+
+- [ ] **Schritt 3: Commit**
+
+```bash
+git add website/src/lib/website-db.ts
+git commit -m "feat(db): add slot_whitelist table and CRUD functions"
+```
+
+---
+
+## Task 2: CalDAV — `getAvailableSlots()` mit Whitelist-Filter
+
+**Files:**
+- Modify: `website/src/lib/caldav.ts`
+
+- [ ] **Schritt 1: Import hinzufügen**
+
+Am Anfang von `caldav.ts`, nach den bestehenden `const`-Deklarationen (nach Zeile 21), folgenden Import einfügen:
+
+```typescript
+import { getWhitelistedSlots } from './website-db';
+```
+
+- [ ] **Schritt 2: Signatur von `getAvailableSlots` anpassen**
+
+Zeile 192 in `caldav.ts` — Signatur ändern von:
+```typescript
+export async function getAvailableSlots(fromDate?: Date): Promise<DaySlots[]> {
+```
+zu:
+```typescript
+export async function getAvailableSlots(fromDate?: Date, brand?: string): Promise<DaySlots[]> {
+```
+
+- [ ] **Schritt 3: Whitelist-Logik in `getAvailableSlots` einfügen**
+
+Direkt nach `const events = await fetchEvents(start, end);` (Zeile 198) einfügen:
+
+```typescript
+  // Load whitelist once if brand is provided (whitelist mode)
+  let whitelistedKeys: Set<string> | null = null;
+  if (brand) {
+    const whitelisted = await getWhitelistedSlots(brand);
+    whitelistedKeys = new Set(whitelisted.map(w => w.slotStart.toISOString()));
+  }
+```
+
+- [ ] **Schritt 4: Whitelist-Filter in der Slot-Prüfung anwenden**
+
+In der inneren Schleife, nach `if (hasConflict) continue;` (bzw. nach dem `if (!hasConflict)` Block), den bestehenden Block so anpassen dass Slots die nicht in der Whitelist stehen übersprungen werden. Der Block ab `if (!hasConflict) {` wird zu:
+
+```typescript
+        if (!hasConflict) {
+          // Whitelist filter: skip if brand given and slot not whitelisted
+          if (whitelistedKeys !== null && !whitelistedKeys.has(slotStart.toISOString())) {
+            continue;
+          }
+
+          const startHH = slotStart.getHours().toString().padStart(2, '0');
+          const startMM = slotStart.getMinutes().toString().padStart(2, '0');
+          const endHH = slotEnd.getHours().toString().padStart(2, '0');
+          const endMM = slotEnd.getMinutes().toString().padStart(2, '0');
+
+          slots.push({
+            start: slotStart.toISOString(),
+            end: slotEnd.toISOString(),
+            display: `${startHH}:${startMM} - ${endHH}:${endMM}`,
+          });
+        }
+```
+
+- [ ] **Schritt 5: TypeScript-Kompilierung prüfen**
+
+```bash
+cd website && npx tsc --noEmit 2>&1 | grep -E "error|caldav"
+```
+
+Erwartet: keine Fehler.
+
+- [ ] **Schritt 6: `/api/calendar/slots` auf Whitelist-Modus umstellen**
+
+`website/src/pages/api/calendar/slots.ts` — `getAvailableSlots`-Aufruf anpassen:
+
+Aktuell (Zeile 11):
+```typescript
+    const slots = await getAvailableSlots(fromDate);
+```
+
+Ersetzen durch:
+```typescript
+    const brand = process.env.BRAND_NAME || 'mentolder';
+    const slots = await getAvailableSlots(fromDate, brand);
+```
+
+- [ ] **Schritt 7: Commit**
+
+```bash
+git add website/src/lib/caldav.ts website/src/pages/api/calendar/slots.ts
+git commit -m "feat(caldav): filter available slots by whitelist when brand provided"
+```
+
+---
+
+## Task 3: API-Endpoints für Whitelist-Verwaltung
+
+**Files:**
+- Create: `website/src/pages/api/admin/slots/add.ts`
+- Create: `website/src/pages/api/admin/slots/remove.ts`
+
+- [ ] **Schritt 1: POST-Endpoint `add.ts` erstellen**
+
+```typescript
+import type { APIRoute } from 'astro';
+import { getSession, isAdmin } from '../../../../lib/auth';
+import { addSlotToWhitelist } from '../../../../lib/website-db';
+
+const BRAND = process.env.BRAND_NAME || 'mentolder';
+
+export const POST: APIRoute = async ({ request }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 403,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  let slotStart: string, slotEnd: string;
+  try {
+    ({ slotStart, slotEnd } = await request.json());
+  } catch {
+    return new Response(JSON.stringify({ error: 'Ungültige Anfrage' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  if (!slotStart || !slotEnd) {
+    return new Response(JSON.stringify({ error: 'slotStart und slotEnd erforderlich' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const start = new Date(slotStart);
+  const end = new Date(slotEnd);
+  if (isNaN(start.getTime()) || isNaN(end.getTime())) {
+    return new Response(JSON.stringify({ error: 'Ungültiges Datumsformat' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  try {
+    await addSlotToWhitelist(BRAND, start, end);
+    return new Response(JSON.stringify({ success: true }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (err) {
+    console.error('[api/admin/slots/add]', err);
+    return new Response(JSON.stringify({ error: 'Datenbankfehler' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+};
+```
+
+- [ ] **Schritt 2: DELETE-Endpoint `remove.ts` erstellen**
+
+```typescript
+import type { APIRoute } from 'astro';
+import { getSession, isAdmin } from '../../../../lib/auth';
+import { removeSlotFromWhitelist } from '../../../../lib/website-db';
+
+const BRAND = process.env.BRAND_NAME || 'mentolder';
+
+export const DELETE: APIRoute = async ({ request }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 403,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  let slotStart: string;
+  try {
+    ({ slotStart } = await request.json());
+  } catch {
+    return new Response(JSON.stringify({ error: 'Ungültige Anfrage' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  if (!slotStart) {
+    return new Response(JSON.stringify({ error: 'slotStart erforderlich' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const start = new Date(slotStart);
+  if (isNaN(start.getTime())) {
+    return new Response(JSON.stringify({ error: 'Ungültiges Datumsformat' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  try {
+    await removeSlotFromWhitelist(BRAND, start);
+    return new Response(JSON.stringify({ success: true }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (err) {
+    console.error('[api/admin/slots/remove]', err);
+    return new Response(JSON.stringify({ error: 'Datenbankfehler' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+};
+```
+
+- [ ] **Schritt 3: TypeScript-Kompilierung prüfen**
+
+```bash
+cd website && npx tsc --noEmit 2>&1 | grep -E "error|slots"
+```
+
+Erwartet: keine Fehler.
+
+- [ ] **Schritt 4: Commit**
+
+```bash
+git add website/src/pages/api/admin/slots/
+git commit -m "feat(api): add POST/DELETE /api/admin/slots endpoints for whitelist management"
+```
+
+---
+
+## Task 4: Booking-API — Whitelist-Validierung
+
+**Files:**
+- Modify: `website/src/pages/api/booking.ts`
+
+- [ ] **Schritt 1: Import hinzufügen**
+
+Am Anfang von `booking.ts`, nach den bestehenden Imports (nach Zeile 3), einfügen:
+
+```typescript
+import { isSlotWhitelisted } from '../../lib/website-db';
+```
+
+- [ ] **Schritt 2: Brand-Konstante hinzufügen**
+
+Nach `const CONTACT_EMAIL = ...` (Zeile 6) einfügen:
+
+```typescript
+const BRAND = process.env.BRAND_NAME || 'mentolder';
+```
+
+- [ ] **Schritt 3: Whitelist-Check vor der Buchungsannahme einfügen**
+
+Direkt nach der bestehenden Validierung `if (!isCallback && (!slotStart || !slotEnd)) { ... }` (nach Zeile 31), aber vor dem `const typeLabel = ...`, folgenden Block einfügen:
+
+```typescript
+    // Whitelist check: slot must be explicitly released by admin
+    if (!isCallback && slotStart) {
+      const whitelisted = await isSlotWhitelisted(BRAND, new Date(slotStart));
+      if (!whitelisted) {
+        return new Response(
+          JSON.stringify({ error: 'Dieser Termin ist leider nicht mehr verfügbar.' }),
+          { status: 400, headers: { 'Content-Type': 'application/json' } }
+        );
+      }
+    }
+```
+
+- [ ] **Schritt 4: TypeScript-Kompilierung prüfen**
+
+```bash
+cd website && npx tsc --noEmit 2>&1 | grep -E "error|booking"
+```
+
+Erwartet: keine Fehler.
+
+- [ ] **Schritt 5: Commit**
+
+```bash
+git add website/src/pages/api/booking.ts
+git commit -m "feat(booking): reject bookings for non-whitelisted slots"
+```
+
+---
+
+## Task 5: Admin-UI — Toggle in `admin/termine.astro`
+
+**Files:**
+- Modify: `website/src/pages/admin/termine.astro`
+
+- [ ] **Schritt 1: Whitelist-Daten server-seitig laden**
+
+Im Frontmatter-Block (zwischen `---` und `---`), nach den Imports, `getWhitelistedSlots` importieren und Daten laden. Den bestehenden Frontmatter-Block ersetzen durch:
+
+```typescript
+---
+import Layout from '../../layouts/Layout.astro';
+import { getSession, getLoginUrl, isAdmin } from '../../lib/auth';
+import { getAvailableSlots } from '../../lib/caldav';
+import { getWhitelistedSlots } from '../../lib/website-db';
+import type { DaySlots } from '../../lib/caldav';
+
+const session = await getSession(Astro.request.headers.get('cookie'));
+if (!session) return Astro.redirect(getLoginUrl());
+if (!isAdmin(session)) return Astro.redirect('/admin');
+
+const BRAND = process.env.BRAND_NAME || 'mentolder';
+const NC_DOMAIN = process.env.NC_DOMAIN || 'files.mentolder.de';
+const calendarUrl = `https://${NC_DOMAIN}/apps/calendar`;
+
+const now = new Date();
+const horizon = new Date(now);
+horizon.setDate(horizon.getDate() + 14);
+
+let days: DaySlots[] = [];
+let calError = '';
+try {
+  // Without brand: all generated slots (no whitelist filter) for admin overview
+  const all = await getAvailableSlots(now);
+  days = all.filter(d => new Date(d.date) <= horizon);
+} catch (err) {
+  console.error('[admin/termine] getAvailableSlots failed:', err);
+  calError = 'Kalender konnte nicht geladen werden.';
+}
+
+// Load whitelist and build a Set of whitelisted ISO start strings
+const whitelistedSlots = await getWhitelistedSlots(BRAND).catch(() => []);
+const whitelistedSet = new Set(whitelistedSlots.map(w => w.slotStart.toISOString()));
+
+const totalSlots = days.reduce((sum, d) => sum + d.slots.length, 0);
+const releasedCount = days.reduce(
+  (sum, d) => sum + d.slots.filter(s => whitelistedSet.has(s.start)).length,
+  0
+);
+---
+```
+
+- [ ] **Schritt 2: Header-Statistik anpassen**
+
+Den bestehenden Absatz:
+```html
+          <p class="text-muted mt-1">Freie Slots der nächsten 14 Tage · {totalSlots} verfügbar</p>
+```
+ersetzen durch:
+```html
+          <p class="text-muted mt-1">Nächste 14 Tage · {totalSlots} generiert · <span class="text-gold"><span id="released-counter">{releasedCount}</span> freigegeben</span></p>
+```
+
+- [ ] **Schritt 3: Slot-Anzeige mit Toggle-Buttons**
+
+Den bestehenden Slot-Render-Block:
+```html
+            <div class="flex flex-wrap gap-2">
+              {day.slots.map(slot => (
+                <span class="px-3 py-1.5 bg-gold/10 text-gold rounded-lg text-sm font-mono border border-gold/20">
+                  {slot.display}
+                </span>
+              ))}
+            </div>
+```
+ersetzen durch:
+```html
+            <div class="flex flex-wrap gap-2">
+              {day.slots.map(slot => {
+                const released = whitelistedSet.has(slot.start);
+                return (
+                  <button
+                    class={`slot-toggle px-3 py-1.5 rounded-lg text-sm font-mono border transition-colors cursor-pointer ${
+                      released
+                        ? 'bg-gold/10 text-gold border-gold/20 hover:bg-gold/20'
+                        : 'bg-dark-lighter text-muted border-dark-lighter hover:border-gold/30'
+                    }`}
+                    data-start={slot.start}
+                    data-end={slot.end}
+                    data-released={released ? 'true' : 'false'}
+                    title={released ? 'Freigabe zurückziehen' : 'Slot freigeben'}
+                  >
+                    {slot.display}
+                    {released && <span class="ml-1 opacity-60">×</span>}
+                  </button>
+                );
+              })}
+            </div>
+```
+
+- [ ] **Schritt 4: Inline-Script für Toggle-Logik**
+
+Vor dem schließenden `</Layout>` Tag das folgende Script einfügen:
+
+```html
+<script>
+  document.querySelectorAll<HTMLButtonElement>('.slot-toggle').forEach(btn => {
+    btn.addEventListener('click', async () => {
+      const start = btn.dataset.start!;
+      const end   = btn.dataset.end!;
+      const isReleased = btn.dataset.released === 'true';
+
+      btn.disabled = true;
+      btn.style.opacity = '0.5';
+
+      try {
+        const res = await fetch(
+          isReleased ? '/api/admin/slots/remove' : '/api/admin/slots/add',
+          {
+            method: isReleased ? 'DELETE' : 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(isReleased ? { slotStart: start } : { slotStart: start, slotEnd: end }),
+          }
+        );
+
+        if (!res.ok) {
+          console.error('Slot toggle failed:', await res.text());
+          btn.disabled = false;
+          btn.style.opacity = '1';
+          return;
+        }
+
+        // Flip state
+        const nowReleased = !isReleased;
+        btn.dataset.released = nowReleased ? 'true' : 'false';
+
+        if (nowReleased) {
+          btn.classList.remove('bg-dark-lighter', 'text-muted', 'border-dark-lighter', 'hover:border-gold/30');
+          btn.classList.add('bg-gold/10', 'text-gold', 'border-gold/20', 'hover:bg-gold/20');
+          btn.title = 'Freigabe zurückziehen';
+          // Add × indicator
+          const text = btn.childNodes[0];
+          if (text && !btn.querySelector('.toggle-x')) {
+            const x = document.createElement('span');
+            x.className = 'ml-1 opacity-60 toggle-x';
+            x.textContent = '×';
+            btn.appendChild(x);
+          }
+        } else {
+          btn.classList.remove('bg-gold/10', 'text-gold', 'border-gold/20', 'hover:bg-gold/20');
+          btn.classList.add('bg-dark-lighter', 'text-muted', 'border-dark-lighter', 'hover:border-gold/30');
+          btn.title = 'Slot freigeben';
+          btn.querySelector('.toggle-x')?.remove();
+        }
+
+        // Update released counter
+        const counterEl = document.getElementById('released-counter');
+        if (counterEl) {
+          counterEl.textContent = String(Number(counterEl.textContent) + (nowReleased ? 1 : -1));
+        }
+      } finally {
+        btn.disabled = false;
+        btn.style.opacity = '1';
+      }
+    });
+  });
+</script>
+```
+
+Hinweis: Der Counter-Span im Header braucht `data-counter` Attribut. Den Span aus Schritt 2 so anpassen:
+```html
+<span class="text-gold"><span id="released-counter">{releasedCount}</span> freigegeben</span>
+```
+
+- [ ] **Schritt 5: Build-Check**
+
+```bash
+cd website && npx astro check 2>&1 | grep -E "error|termine"
+```
+
+Erwartet: keine Fehler.
+
+- [ ] **Schritt 6: Commit**
+
+```bash
+git add website/src/pages/admin/termine.astro
+git commit -m "feat(admin): slot whitelist toggle UI in Termine-Admin"
+```
+
+---
+
+## Task 6: Tests aktualisieren
+
+**Files:**
+- Modify: `website/tests/api.test.mjs`
+- Modify: `tests/e2e/specs/fa-16-booking.spec.ts`
+
+- [ ] **Schritt 1: Neue Sektion in `api.test.mjs` hinzufügen**
+
+Am Ende der Hauptfunktion (vor dem `section('Summary')` Block), neue Sektion einfügen:
+
+```javascript
+  // -- Slot Whitelist Admin Endpoints --
+  section('Slot Whitelist API (unauthenticated)');
+
+  await assert('POST /api/admin/slots/add without auth returns 403', async () => {
+    const res = await fetch(`${BASE_URL}/api/admin/slots/add`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ slotStart: '2026-05-01T08:00:00.000Z', slotEnd: '2026-05-01T09:00:00.000Z' }),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  await assert('DELETE /api/admin/slots/remove without auth returns 403', async () => {
+    const res = await fetch(`${BASE_URL}/api/admin/slots/remove`, {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ slotStart: '2026-05-01T08:00:00.000Z' }),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  await assert('GET /api/calendar/slots returns empty array (no slots whitelisted)', async () => {
+    const res = await fetch(`${BASE_URL}/api/calendar/slots`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    // With whitelist mode active and no whitelisted slots, array must be empty
+    expect(Array.isArray(body)).toBe(true);
+    expect(body.length).toBe(0);
+  });
+```
+
+- [ ] **Schritt 2: Booking-Test T6 in `fa-16-booking.spec.ts` anpassen**
+
+Den bisherigen Test T6 (Zeilen 53–70) ersetzen durch:
+
+```typescript
+  test('T6: POST /api/booking with non-whitelisted slot returns 400', async ({ request }) => {
+    const res = await request.post(`${BASE}/api/booking`, {
+      data: {
+        name: 'Test User',
+        email: 'test@example.de',
+        phone: '',
+        type: 'erstgespraech',
+        message: '',
+        slotStart: '2026-04-10T07:00:00.000Z',
+        slotEnd: '2026-04-10T08:00:00.000Z',
+        slotDisplay: '09:00 - 10:00',
+        date: '2026-04-10',
+      },
+    });
+    expect(res.status()).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain('nicht mehr verfügbar');
+  });
+```
+
+- [ ] **Schritt 3: Tests lokal ausführen** *(gegen laufende Dev-Instanz)*
+
+```bash
+cd website && BASE_URL=http://localhost:4321 node tests/api.test.mjs 2>&1 | grep -E "Slot Whitelist|✓|✗"
+```
+
+Erwartet: Alle drei Whitelist-Tests grün.
+
+- [ ] **Schritt 4: Commit**
+
+```bash
+git add website/tests/api.test.mjs tests/e2e/specs/fa-16-booking.spec.ts
+git commit -m "test: update booking + add slot whitelist API tests"
+```
+
+---
+
+## Task 7: Branch pushen und PR erstellen
+
+- [ ] **Schritt 1: CI-Validierung lokal**
+
+```bash
+task workspace:validate 2>&1 | tail -5
+```
+
+Erwartet: `Build successful` / keine Fehler.
+
+- [ ] **Schritt 2: Branch pushen und PR erstellen**
+
+```bash
+git push -u origin feature/slot-whitelist
+gh pr create \
+  --title "feat: Slot-Whitelist für Admin-Terminverwaltung (BR-20260415-d4be)" \
+  --body "$(cat <<'EOF'
+## Summary
+- Neue `slot_whitelist` PostgreSQL-Tabelle: Admin gibt Slots explizit frei
+- `getAvailableSlots()` filtert auf Whitelist wenn `brand` übergeben (öffentliche API + Booking)
+- Admin-UI `termine.astro`: Slots zeigen Toggle-Buttons (ausgegraut/gold)
+- Booking-API lehnt nicht freigegebene Slots mit 400 ab
+- Tests: API-Whitelist-Endpoints + FA-16 T6 angepasst
+
+## Test plan
+- [ ] `node tests/api.test.mjs` — alle Whitelist-Tests grün
+- [ ] `./tests/runner.sh local FA-16` — Booking-Tests grün
+- [ ] Admin-UI manuell prüfen: `/admin/termine` — Toggle-Buttons sichtbar, Klick ändert Status
+
+Closes BR-20260415-d4be
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```

--- a/docs/superpowers/specs/2026-04-16-slot-whitelist-design.md
+++ b/docs/superpowers/specs/2026-04-16-slot-whitelist-design.md
@@ -1,0 +1,80 @@
+# Slot-Whitelist für Terminbuchung
+
+**Ticket:** BR-20260415-d4be  
+**Datum:** 2026-04-16  
+**Status:** Approved
+
+## Zusammenfassung
+
+Der Admin muss Terminslots explizit freigeben, bevor Kunden sie buchen können (Whitelist-Modell). Slots werden weiterhin automatisch aus Nextcloud CalDAV + Arbeitszeitkonfiguration generiert, sind aber standardmäßig nicht buchbar. Wenn ein CalDAV-Eintrag mit einem freigegebenen Slot kollidiert, wird der Slot automatisch aus der Buchungsansicht entfernt (CalDAV hat Vorrang).
+
+## Datenschicht
+
+### Neue Tabelle `slot_whitelist`
+
+```sql
+CREATE TABLE IF NOT EXISTS slot_whitelist (
+  brand      TEXT        NOT NULL,
+  slot_start TIMESTAMPTZ NOT NULL,
+  slot_end   TIMESTAMPTZ NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (brand, slot_start)
+);
+```
+
+### Neue Funktionen in `website/src/lib/website-db.ts`
+
+- `getWhitelistedSlots(brand: string): Promise<{slot_start: Date, slot_end: Date}[]>` — alle Whitelist-Einträge ab jetzt
+- `addSlotToWhitelist(brand: string, start: Date, end: Date): Promise<void>` — Slot freigeben
+- `removeSlotFromWhitelist(brand: string, start: Date): Promise<void>` — Freigabe zurückziehen
+- `isSlotWhitelisted(brand: string, start: Date): Promise<boolean>` — Einzelprüfung
+
+### Änderung an `getAvailableSlots()` in `website/src/lib/caldav.ts`
+
+Signatur: `getAvailableSlots(fromDate?: Date, brand?: string): Promise<DaySlots[]>`
+
+- Ohne `brand`: Verhalten wie heute (alle konfliktfreien Slots) → für Admin-Ansicht
+- Mit `brand`: Nur Slots zurückgeben die **sowohl** whitelisted **als auch** konfliktfrei sind → für öffentliche API und Buchungsformular
+
+## API-Layer
+
+### `POST /api/admin/slots/whitelist`
+
+```
+Body: { slotStart: string (ISO8601), slotEnd: string (ISO8601) }
+Auth: Admin-Session erforderlich
+Response: 200 OK | 401 | 400
+```
+
+Ruft `addSlotToWhitelist(brand, start, end)`.
+
+### `DELETE /api/admin/slots/whitelist`
+
+```
+Body: { slotStart: string (ISO8601) }
+Auth: Admin-Session erforderlich
+Response: 200 OK | 401 | 400
+```
+
+Ruft `removeSlotFromWhitelist(brand, start)`.
+
+### Änderung an `POST /api/booking.ts`
+
+Vor dem Akzeptieren einer Buchung: `isSlotWhitelisted(brand, slotStart)` prüfen. Wenn nicht freigegeben → `400` mit Fehlermeldung "Dieser Termin ist leider nicht mehr verfügbar."
+
+`brand` kommt aus `process.env.BRAND_NAME` (konsistent mit restlichem Code).
+
+## Admin-UI (`website/src/pages/admin/termine.astro`)
+
+- Server-seitig: Sowohl alle generierten Slots als auch alle Whitelist-Einträge werden beim Rendern geladen. Jeder Slot kennt seinen Freigabe-Status ohne extra Client-Request.
+- **Nicht freigegebener Slot**: Ausgegraut, Button "Freigeben" (ruft POST-Endpoint)
+- **Freigegebener Slot**: Gold-Styling, Button "×" (ruft DELETE-Endpoint)
+- Toggle per `fetch()` + DOM-Update ohne Full-Page-Reload
+- Header-Statistik: *"X generiert · Y freigegeben"* statt *"X verfügbar"*
+- Kein Svelte nötig — Inline-Script reicht
+
+## Nicht in Scope
+
+- Ablauf-Automatisierung für alte Whitelist-Einträge (veraltete Einträge werden durch `slot_start < now()` Filter in `getWhitelistedSlots` ignoriert)
+- Batch-Freigabe ganzer Tage/Wochen
+- Whitelist/Blacklist-Modus-Umschalter

--- a/k3d/docs-content/index.html
+++ b/k3d/docs-content/index.html
@@ -51,6 +51,11 @@
     .results-panel .matching-post a { color: #e8c870; }
     /* Mermaid diagrams */
     .mermaid { background: #1a2235; border-radius: 6px; padding: 16px; }
+    .mermaid svg { display: block; width: 100% !important; height: auto !important; max-width: none !important; cursor: grab; }
+    .mermaid svg:active { cursor: grabbing; }
+    .mermaid-zoom-controls { display: flex; gap: 6px; justify-content: flex-end; margin-top: 6px; }
+    .mermaid-zoom-btn { font-size: 11px; padding: 2px 8px; background: #1a2235; border: 1px solid #243049; border-radius: 3px; color: #aabbcc; cursor: pointer; }
+    .mermaid-zoom-btn:hover { border-color: #e8c870; color: #e8c870; }
   </style>
 </head>
 <body>
@@ -74,6 +79,7 @@
     }
   </script>
   <script src="//cdn.jsdelivr.net/npm/docsify/lib/docsify.min.js"></script>
+  <script src="//cdn.jsdelivr.net/npm/panzoom@9.4.3/dist/panzoom.min.js"></script>
   <script src="//cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"></script>
   <script>
     mermaid.initialize({
@@ -119,7 +125,40 @@
     });
     window.$docsify.plugins = [].concat(function(hook) {
       hook.doneEach(function() {
-        mermaid.run({ querySelector: '.mermaid' });
+        mermaid.run({ querySelector: '.mermaid' }).then(function() {
+          document.querySelectorAll('.mermaid svg').forEach(function(svg) {
+            if (svg.dataset.panzoomApplied) return;
+            svg.dataset.panzoomApplied = '1';
+
+            var pz = panzoom(svg, { maxZoom: 8, minZoom: 0.3, boundsPadding: 0.1 });
+
+            var controls = document.createElement('div');
+            controls.className = 'mermaid-zoom-controls';
+
+            var resetBtn = document.createElement('button');
+            resetBtn.className = 'mermaid-zoom-btn';
+            resetBtn.textContent = 'Reset Zoom';
+            resetBtn.addEventListener('click', function() {
+              pz.moveTo(0, 0);
+              pz.zoomAbs(0, 0, 1);
+            });
+
+            var zoomInBtn = document.createElement('button');
+            zoomInBtn.className = 'mermaid-zoom-btn';
+            zoomInBtn.textContent = '+';
+            zoomInBtn.addEventListener('click', function() { pz.zoomIn(); });
+
+            var zoomOutBtn = document.createElement('button');
+            zoomOutBtn.className = 'mermaid-zoom-btn';
+            zoomOutBtn.textContent = '−';
+            zoomOutBtn.addEventListener('click', function() { pz.zoomOut(); });
+
+            controls.appendChild(zoomOutBtn);
+            controls.appendChild(resetBtn);
+            controls.appendChild(zoomInBtn);
+            svg.closest('.mermaid').insertAdjacentElement('afterend', controls);
+          });
+        });
       });
     }, window.$docsify.plugins || []);
   </script>

--- a/website/src/components/portal/MeetingsAdminTab.astro
+++ b/website/src/components/portal/MeetingsAdminTab.astro
@@ -1,5 +1,5 @@
 ---
-import { getMeetingsForClient, getCustomerByEmail, listProjects } from '../../lib/website-db';
+import { getMeetingsForClient, listProjects } from '../../lib/website-db';
 import type { Meeting, Project } from '../../lib/website-db';
 
 interface Props {
@@ -13,10 +13,7 @@ let meetings: Meeting[] = [];
 let projects: Project[] = [];
 try {
   meetings = await getMeetingsForClient(clientEmail, false); // all meetings
-  const customer = await getCustomerByEmail(clientEmail);
-  if (customer) {
-    projects = await listProjects({ brand, customerId: customer.id });
-  }
+  projects = await listProjects({ brand });
 } catch {
   // DB unavailable
 }

--- a/website/src/lib/caldav.ts
+++ b/website/src/lib/caldav.ts
@@ -146,6 +146,16 @@ export interface ClientBooking {
   status: string;
 }
 
+export interface AdminBooking {
+  uid: string;
+  summary: string;
+  start: Date;
+  end: Date;
+  status: string;
+  attendeeEmail: string;
+  attendeeName: string;
+}
+
 export async function getClientBookings(clientEmail: string): Promise<ClientBooking[]> {
   const now = new Date();
   const past = new Date(now);
@@ -185,6 +195,58 @@ export async function getClientBookings(clientEmail: string): Promise<ClientBook
   }
 
   bookings.sort((a, b) => b.start.getTime() - a.start.getTime());
+  return bookings;
+}
+
+export async function getAllBookings(): Promise<AdminBooking[]> {
+  const now = new Date();
+  const past = new Date(now);
+  past.setDate(past.getDate() - 90);
+  const future = new Date(now);
+  future.setDate(future.getDate() + BOOKING_HORIZON_DAYS);
+
+  const icals = await fetchEventsRaw(past, future);
+  const bookings: AdminBooking[] = [];
+
+  for (const ical of icals) {
+    const veventRegex = /BEGIN:VEVENT([\s\S]*?)END:VEVENT/gi;
+    let eventMatch;
+
+    while ((eventMatch = veventRegex.exec(ical)) !== null) {
+      const block = eventMatch[1];
+
+      const attendeeLineMatch = block.match(/^ATTENDEE([^\r\n]*)/im);
+      if (!attendeeLineMatch) continue;
+
+      const attendeeLine = attendeeLineMatch[0];
+      const emailMatch = attendeeLine.match(/mailto:(.+)$/i);
+      if (!emailMatch) continue;
+      const attendeeEmail = emailMatch[1].trim();
+
+      const cnMatch = attendeeLine.match(/CN=([^;:]+)/i);
+      const attendeeName = cnMatch ? cnMatch[1].trim() : attendeeEmail;
+
+      const uid = extractICalProp(block, 'UID') || '';
+      const dtstart = extractICalProp(block, 'DTSTART');
+      const dtend = extractICalProp(block, 'DTEND');
+      const summary = extractICalProp(block, 'SUMMARY') || 'Termin';
+      const status = extractICalProp(block, 'STATUS') || 'CONFIRMED';
+
+      if (!dtstart) continue;
+
+      bookings.push({
+        uid,
+        summary,
+        start: parseICalDate(dtstart),
+        end: dtend ? parseICalDate(dtend) : new Date(parseICalDate(dtstart).getTime() + 3600000),
+        status,
+        attendeeEmail,
+        attendeeName,
+      });
+    }
+  }
+
+  bookings.sort((a, b) => a.start.getTime() - b.start.getTime());
   return bookings;
 }
 

--- a/website/src/lib/keycloak.ts
+++ b/website/src/lib/keycloak.ts
@@ -116,3 +116,42 @@ export async function deleteUser(userId: string): Promise<boolean> {
   const res = await kcApi('DELETE', `/users/${encodeURIComponent(userId)}`);
   return res.ok || res.status === 404;
 }
+
+export async function updateUser(userId: string, params: {
+  firstName?: string;
+  lastName?: string;
+  email?: string;
+  enabled?: boolean;
+}): Promise<boolean> {
+  const res = await kcApi('PUT', `/users/${encodeURIComponent(userId)}`, params);
+  return res.ok;
+}
+
+export interface KcRole {
+  id: string;
+  name: string;
+}
+
+export async function listRealmRoles(): Promise<KcRole[]> {
+  const res = await kcApi('GET', '/roles');
+  if (!res.ok) return [];
+  const roles: KcRole[] = await res.json();
+  return roles.filter(r => !r.name.startsWith('default-roles-') && !r.name.startsWith('uma_') && r.name !== 'offline_access');
+}
+
+export async function getUserRealmRoles(userId: string): Promise<KcRole[]> {
+  const res = await kcApi('GET', `/users/${encodeURIComponent(userId)}/role-mappings/realm`);
+  if (!res.ok) return [];
+  const roles: KcRole[] = await res.json();
+  return roles.filter(r => !r.name.startsWith('default-roles-') && !r.name.startsWith('uma_') && r.name !== 'offline_access');
+}
+
+export async function assignRealmRole(userId: string, roles: KcRole[]): Promise<boolean> {
+  const res = await kcApi('POST', `/users/${encodeURIComponent(userId)}/role-mappings/realm`, roles);
+  return res.ok;
+}
+
+export async function removeRealmRole(userId: string, roles: KcRole[]): Promise<boolean> {
+  const res = await kcApi('DELETE', `/users/${encodeURIComponent(userId)}/role-mappings/realm`, roles);
+  return res.ok;
+}

--- a/website/src/lib/website-db.ts
+++ b/website/src/lib/website-db.ts
@@ -1664,6 +1664,8 @@ async function initSlotWhitelistTable(): Promise<void> {
 
 export async function getWhitelistedSlots(brand: string): Promise<WhitelistedSlot[]> {
   await initSlotWhitelistTable();
+  // Only return future slots for display — isSlotWhitelisted has no time filter
+  // so booking validation works even for slots that just started.
   const result = await pool.query(
     `SELECT slot_start AS "slotStart", slot_end AS "slotEnd"
      FROM slot_whitelist
@@ -1687,7 +1689,7 @@ export async function addSlotToWhitelist(brand: string, start: Date, end: Date):
 export async function removeSlotFromWhitelist(brand: string, start: Date): Promise<void> {
   await initSlotWhitelistTable();
   await pool.query(
-    'DELETE FROM slot_whitelist WHERE brand = $1 AND slot_start = $2',
+    'DELETE FROM slot_whitelist WHERE brand = $1 AND slot_start = $2::timestamptz',
     [brand, start]
   );
 }
@@ -1695,7 +1697,7 @@ export async function removeSlotFromWhitelist(brand: string, start: Date): Promi
 export async function isSlotWhitelisted(brand: string, start: Date): Promise<boolean> {
   await initSlotWhitelistTable();
   const result = await pool.query(
-    'SELECT 1 FROM slot_whitelist WHERE brand = $1 AND slot_start = $2',
+    'SELECT 1 FROM slot_whitelist WHERE brand = $1 AND slot_start = $2::timestamptz',
     [brand, start]
   );
   return (result.rowCount ?? 0) > 0;

--- a/website/src/lib/website-db.ts
+++ b/website/src/lib/website-db.ts
@@ -1601,6 +1601,106 @@ export interface BugTicketRow {
   screenshots: string[] | null;
 }
 
+let bookingProjectLinksReady = false;
+async function initBookingProjectLinks(): Promise<void> {
+  if (bookingProjectLinksReady) return;
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS booking_project_links (
+      caldav_uid  TEXT    NOT NULL,
+      brand       TEXT    NOT NULL,
+      project_id  UUID    REFERENCES projects(id) ON DELETE SET NULL,
+      created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+      PRIMARY KEY (caldav_uid, brand)
+    )
+  `);
+  bookingProjectLinksReady = true;
+}
+
+export async function getBookingProjects(caldavUids: string[], brand: string): Promise<Map<string, string>> {
+  if (caldavUids.length === 0) return new Map();
+  await initBookingProjectLinks();
+  const result = await pool.query(
+    `SELECT caldav_uid, project_id FROM booking_project_links
+     WHERE caldav_uid = ANY($1) AND brand = $2 AND project_id IS NOT NULL`,
+    [caldavUids, brand]
+  );
+  return new Map(result.rows.map((r: { caldav_uid: string; project_id: string }) => [r.caldav_uid, r.project_id]));
+}
+
+export async function setBookingProject(caldavUid: string, projectId: string | null, brand: string): Promise<void> {
+  await initBookingProjectLinks();
+  if (!projectId) {
+    await pool.query(
+      `DELETE FROM booking_project_links WHERE caldav_uid = $1 AND brand = $2`,
+      [caldavUid, brand]
+    );
+  } else {
+    await pool.query(
+      `INSERT INTO booking_project_links (caldav_uid, brand, project_id) VALUES ($1, $2, $3)
+       ON CONFLICT (caldav_uid, brand) DO UPDATE SET project_id = EXCLUDED.project_id`,
+      [caldavUid, brand, projectId]
+    );
+  }
+}
+
+// ── Slot Whitelist ────────────────────────────────────────────────────────────
+
+export interface WhitelistedSlot {
+  slotStart: Date;
+  slotEnd: Date;
+}
+
+async function initSlotWhitelistTable(): Promise<void> {
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS slot_whitelist (
+      brand      TEXT        NOT NULL,
+      slot_start TIMESTAMPTZ NOT NULL,
+      slot_end   TIMESTAMPTZ NOT NULL,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      PRIMARY KEY (brand, slot_start)
+    )
+  `);
+}
+
+export async function getWhitelistedSlots(brand: string): Promise<WhitelistedSlot[]> {
+  await initSlotWhitelistTable();
+  const result = await pool.query(
+    `SELECT slot_start AS "slotStart", slot_end AS "slotEnd"
+     FROM slot_whitelist
+     WHERE brand = $1 AND slot_start > now()
+     ORDER BY slot_start ASC`,
+    [brand]
+  );
+  return result.rows;
+}
+
+export async function addSlotToWhitelist(brand: string, start: Date, end: Date): Promise<void> {
+  await initSlotWhitelistTable();
+  await pool.query(
+    `INSERT INTO slot_whitelist (brand, slot_start, slot_end)
+     VALUES ($1, $2, $3)
+     ON CONFLICT (brand, slot_start) DO UPDATE SET slot_end = $3`,
+    [brand, start, end]
+  );
+}
+
+export async function removeSlotFromWhitelist(brand: string, start: Date): Promise<void> {
+  await initSlotWhitelistTable();
+  await pool.query(
+    'DELETE FROM slot_whitelist WHERE brand = $1 AND slot_start = $2',
+    [brand, start]
+  );
+}
+
+export async function isSlotWhitelisted(brand: string, start: Date): Promise<boolean> {
+  await initSlotWhitelistTable();
+  const result = await pool.query(
+    'SELECT 1 FROM slot_whitelist WHERE brand = $1 AND slot_start = $2',
+    [brand, start]
+  );
+  return (result.rowCount ?? 0) > 0;
+}
+
 export async function listBugTickets(filters: {
   status?: string;
   category?: string;

--- a/website/src/pages/admin/[clientId].astro
+++ b/website/src/pages/admin/[clientId].astro
@@ -1,7 +1,8 @@
 ---
 import Layout from '../../layouts/Layout.astro';
 import { getSession, getLoginUrl, isAdmin } from '../../lib/auth';
-import { getUserById } from '../../lib/keycloak';
+import { getUserById, getUserRealmRoles, listRealmRoles } from '../../lib/keycloak';
+import type { KcRole } from '../../lib/keycloak';
 import BookingsTab from '../../components/portal/BookingsTab.astro';
 import InvoicesTab from '../../components/portal/InvoicesTab.astro';
 import ClientNotesTab from '../../components/portal/ClientNotesTab.astro';
@@ -26,18 +27,116 @@ if (!client) {
 }
 
 const tab = Astro.url.searchParams.get('tab') ?? 'bookings';
+
+let userRoles: KcRole[] = [];
+let allRoles: KcRole[] = [];
+try {
+  [userRoles, allRoles] = await Promise.all([
+    getUserRealmRoles(clientId),
+    listRealmRoles(),
+  ]);
+} catch {
+  // Keycloak unavailable
+}
+const userRoleIds = new Set(userRoles.map(r => r.id));
 ---
 
 <Layout title={`Admin — ${client.firstName ?? client.username}`}>
   <section class="pt-28 pb-20 bg-dark min-h-screen">
     <div class="max-w-5xl mx-auto px-6">
       <div class="mb-2">
-        <a href="/admin" class="text-muted hover:text-gold text-sm">← Zurück zur Übersicht</a>
+        <a href="/admin/clients" class="text-muted hover:text-gold text-sm">← Zurück zur Übersicht</a>
       </div>
-      <div class="mb-8">
-        <h1 class="text-3xl font-bold text-light font-serif">{client.firstName} {client.lastName}</h1>
-        <p class="text-muted mt-1">{client.username} · {client.email ?? '—'}</p>
+
+      <!-- Header mit Usermanagement-Aktionen -->
+      <div class="mb-8 flex items-start justify-between gap-4 flex-wrap">
+        <div>
+          <div class="flex items-center gap-3">
+            <h1 class="text-3xl font-bold text-light font-serif">{client.firstName} {client.lastName}</h1>
+            {client.enabled === false && (
+              <span class="text-xs px-2 py-0.5 rounded-full bg-red-500/20 text-red-400">Deaktiviert</span>
+            )}
+          </div>
+          <p class="text-muted mt-1">{client.username} · {client.email ?? '—'}</p>
+        </div>
+        <div class="flex gap-2 flex-wrap">
+          <button
+            id="edit-user-btn"
+            class="px-3 py-1.5 bg-dark-light border border-dark-lighter text-light rounded-lg text-sm hover:border-gold/40 transition-colors"
+          >
+            ✏️ Bearbeiten
+          </button>
+          <button
+            id="toggle-enabled-btn"
+            data-user-id={clientId}
+            data-enabled={client.enabled !== false ? 'true' : 'false'}
+            class={`px-3 py-1.5 rounded-lg text-sm transition-colors ${client.enabled !== false ? 'bg-dark-light border border-dark-lighter text-muted hover:border-red-500/40 hover:text-red-400' : 'bg-green-500/20 border border-green-500/30 text-green-400 hover:bg-green-500/30'}`}
+          >
+            {client.enabled !== false ? '🔒 Deaktivieren' : '✅ Aktivieren'}
+          </button>
+          <button
+            id="reset-password-btn"
+            data-user-id={clientId}
+            class="px-3 py-1.5 bg-dark-light border border-dark-lighter text-muted rounded-lg text-sm hover:border-gold/40 hover:text-light transition-colors"
+          >
+            🔑 Passwort-Reset
+          </button>
+          <button
+            id="delete-user-btn"
+            data-user-id={clientId}
+            data-user-name={`${client.firstName} ${client.lastName}`}
+            class="px-3 py-1.5 bg-dark-light border border-dark-lighter text-muted rounded-lg text-sm hover:border-red-500/40 hover:text-red-400 transition-colors"
+          >
+            🗑️ Löschen
+          </button>
+        </div>
       </div>
+
+      <!-- Edit Modal (versteckt) -->
+      <div id="edit-modal" class="hidden mb-6 p-6 bg-dark-light rounded-xl border border-gold/30">
+        <h2 class="text-lg font-semibold text-light mb-4">Benutzer bearbeiten</h2>
+        <div id="edit-error" class="hidden mb-3 p-3 bg-red-500/10 border border-red-500/30 rounded-lg text-red-400 text-sm"></div>
+        <form id="edit-form" class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <div>
+            <label class="block text-sm text-muted mb-1">Vorname</label>
+            <input type="text" name="firstName" value={client.firstName ?? ''} class="w-full bg-dark border border-dark-lighter rounded-lg px-3 py-2 text-light text-sm focus:border-gold outline-none" />
+          </div>
+          <div>
+            <label class="block text-sm text-muted mb-1">Nachname</label>
+            <input type="text" name="lastName" value={client.lastName ?? ''} class="w-full bg-dark border border-dark-lighter rounded-lg px-3 py-2 text-light text-sm focus:border-gold outline-none" />
+          </div>
+          <div class="sm:col-span-2">
+            <label class="block text-sm text-muted mb-1">E-Mail</label>
+            <input type="email" name="email" value={client.email ?? ''} class="w-full bg-dark border border-dark-lighter rounded-lg px-3 py-2 text-light text-sm focus:border-gold outline-none" />
+          </div>
+          <div class="sm:col-span-2 flex gap-3 justify-end">
+            <button type="button" id="cancel-edit" class="px-4 py-2 text-sm text-muted hover:text-light transition-colors">Abbrechen</button>
+            <button type="submit" id="save-edit" class="px-5 py-2 bg-gold text-dark rounded-lg text-sm font-semibold hover:bg-gold/80 transition-colors">Speichern</button>
+          </div>
+        </form>
+      </div>
+
+      <!-- Rollen -->
+      {allRoles.length > 0 && (
+        <div class="mb-6 p-4 bg-dark-light rounded-xl border border-dark-lighter">
+          <h2 class="text-sm font-medium text-muted mb-3 uppercase tracking-wide">Rollen</h2>
+          <div class="flex flex-wrap gap-2" id="roles-container">
+            {allRoles.map(role => (
+              <label class="flex items-center gap-2 cursor-pointer">
+                <input
+                  type="checkbox"
+                  class="role-checkbox accent-gold"
+                  data-user-id={clientId}
+                  data-role-id={role.id}
+                  data-role-name={role.name}
+                  checked={userRoleIds.has(role.id)}
+                />
+                <span class="text-sm text-light">{role.name}</span>
+              </label>
+            ))}
+          </div>
+        </div>
+      )}
 
       <!-- Tab navigation -->
       <nav class="flex gap-1 mb-8 border-b border-dark-lighter overflow-x-auto" data-testid="admin-client-tabs">
@@ -86,3 +185,132 @@ const tab = Astro.url.searchParams.get('tab') ?? 'bookings';
     </div>
   </section>
 </Layout>
+
+<script>
+  const userId = (document.getElementById('toggle-enabled-btn') as HTMLButtonElement)?.dataset.userId ?? '';
+
+  // Edit modal
+  document.getElementById('edit-user-btn')?.addEventListener('click', () => {
+    document.getElementById('edit-modal')?.classList.toggle('hidden');
+  });
+  document.getElementById('cancel-edit')?.addEventListener('click', () => {
+    document.getElementById('edit-modal')?.classList.add('hidden');
+  });
+
+  const editForm = document.getElementById('edit-form') as HTMLFormElement | null;
+  editForm?.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const saveBtn = document.getElementById('save-edit') as HTMLButtonElement;
+    const errorEl = document.getElementById('edit-error');
+    saveBtn.disabled = true;
+    saveBtn.textContent = '...';
+    errorEl?.classList.add('hidden');
+
+    const data = Object.fromEntries(new FormData(editForm));
+    try {
+      const res = await fetch('/api/admin/clients/update', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ userId, ...data }),
+      });
+      if (res.ok) {
+        window.location.reload();
+      } else {
+        const json = await res.json().catch(() => ({}));
+        if (errorEl) { errorEl.textContent = json.error || 'Fehler.'; errorEl.classList.remove('hidden'); }
+      }
+    } catch {
+      if (errorEl) { errorEl.textContent = 'Netzwerkfehler.'; errorEl.classList.remove('hidden'); }
+    } finally {
+      saveBtn.disabled = false;
+      saveBtn.textContent = 'Speichern';
+    }
+  });
+
+  // Toggle enabled
+  document.getElementById('toggle-enabled-btn')?.addEventListener('click', async (e) => {
+    const btn = e.currentTarget as HTMLButtonElement;
+    const enabled = btn.dataset.enabled === 'true';
+    const action = enabled ? 'Deaktivieren' : 'Aktivieren';
+    if (!confirm(`Benutzer wirklich ${action.toLowerCase()}?`)) return;
+    btn.disabled = true;
+    try {
+      const res = await fetch('/api/admin/clients/update', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ userId, enabled: !enabled }),
+      });
+      if (res.ok) window.location.reload();
+      else alert('Fehler beim Ändern des Status.');
+    } catch {
+      alert('Netzwerkfehler.');
+    } finally {
+      btn.disabled = false;
+    }
+  });
+
+  // Password reset
+  document.getElementById('reset-password-btn')?.addEventListener('click', async () => {
+    if (!confirm('Passwort-Reset-Email senden?')) return;
+    try {
+      const res = await fetch('/api/admin/clients/reset-password', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ userId }),
+      });
+      if (res.ok) alert('Passwort-Reset-Email gesendet.');
+      else alert('Fehler beim Senden.');
+    } catch {
+      alert('Netzwerkfehler.');
+    }
+  });
+
+  // Delete user
+  document.getElementById('delete-user-btn')?.addEventListener('click', async (e) => {
+    const btn = e.currentTarget as HTMLButtonElement;
+    const name = btn.dataset.userName;
+    if (!confirm(`Benutzer "${name}" wirklich löschen? Diese Aktion kann nicht rückgängig gemacht werden.`)) return;
+    btn.disabled = true;
+    try {
+      const res = await fetch('/api/admin/clients/delete', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ userId }),
+      });
+      if (res.ok) window.location.href = '/admin/clients';
+      else alert('Fehler beim Löschen.');
+    } catch {
+      alert('Netzwerkfehler.');
+    } finally {
+      btn.disabled = false;
+    }
+  });
+
+  // Role checkboxes
+  document.querySelectorAll<HTMLInputElement>('.role-checkbox').forEach(cb => {
+    cb.addEventListener('change', async () => {
+      const uid = cb.dataset.userId;
+      const role = { id: cb.dataset.roleId!, name: cb.dataset.roleName! };
+      cb.disabled = true;
+      try {
+        const endpoint = cb.checked
+          ? '/api/admin/clients/roles-assign'
+          : '/api/admin/clients/roles-remove';
+        const res = await fetch(endpoint, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ userId: uid, roles: [role] }),
+        });
+        if (!res.ok) {
+          alert('Fehler beim Ändern der Rolle.');
+          cb.checked = !cb.checked;
+        }
+      } catch {
+        alert('Netzwerkfehler.');
+        cb.checked = !cb.checked;
+      } finally {
+        cb.disabled = false;
+      }
+    });
+  });
+</script>

--- a/website/src/pages/admin/clients.astro
+++ b/website/src/pages/admin/clients.astro
@@ -24,26 +24,107 @@ try {
           <h1 class="text-3xl font-bold text-light font-serif">Clients</h1>
           <p class="text-muted mt-1">{users.length} Benutzer</p>
         </div>
-        <a
-          href="/admin"
-          class="px-4 py-2 bg-dark-light text-muted rounded-lg text-sm font-medium hover:text-light transition-colors"
-        >
-          ← Zurück
-        </a>
+        <div class="flex gap-3">
+          <button
+            id="new-client-btn"
+            class="px-4 py-2 bg-gold text-dark rounded-lg text-sm font-semibold hover:bg-gold/80 transition-colors"
+          >
+            + Neuer Client
+          </button>
+          <a
+            href="/admin"
+            class="px-4 py-2 bg-dark-light text-muted rounded-lg text-sm font-medium hover:text-light transition-colors"
+          >
+            ← Zurück
+          </a>
+        </div>
+      </div>
+
+      <!-- Neuer Client Formular (versteckt) -->
+      <div id="new-client-form" class="hidden mb-8 p-6 bg-dark-light rounded-xl border border-gold/30">
+        <h2 class="text-lg font-semibold text-light mb-4">Neuen Client einladen</h2>
+        <div id="new-client-error" class="hidden mb-4 p-3 bg-red-500/10 border border-red-500/30 rounded-lg text-red-400 text-sm"></div>
+        <div id="new-client-success" class="hidden mb-4 p-3 bg-green-500/10 border border-green-500/30 rounded-lg text-green-400 text-sm"></div>
+        <form id="new-client-form-el" class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <div>
+            <label class="block text-sm text-muted mb-1">Vorname *</label>
+            <input
+              type="text"
+              name="firstName"
+              required
+              class="w-full bg-dark border border-dark-lighter rounded-lg px-3 py-2 text-light text-sm focus:border-gold focus:ring-1 focus:ring-gold/20 outline-none"
+            />
+          </div>
+          <div>
+            <label class="block text-sm text-muted mb-1">Nachname *</label>
+            <input
+              type="text"
+              name="lastName"
+              required
+              class="w-full bg-dark border border-dark-lighter rounded-lg px-3 py-2 text-light text-sm focus:border-gold focus:ring-1 focus:ring-gold/20 outline-none"
+            />
+          </div>
+          <div>
+            <label class="block text-sm text-muted mb-1">E-Mail *</label>
+            <input
+              type="email"
+              name="email"
+              required
+              class="w-full bg-dark border border-dark-lighter rounded-lg px-3 py-2 text-light text-sm focus:border-gold focus:ring-1 focus:ring-gold/20 outline-none"
+            />
+          </div>
+          <div>
+            <label class="block text-sm text-muted mb-1">Telefon</label>
+            <input
+              type="tel"
+              name="phone"
+              class="w-full bg-dark border border-dark-lighter rounded-lg px-3 py-2 text-light text-sm focus:border-gold focus:ring-1 focus:ring-gold/20 outline-none"
+            />
+          </div>
+          <div class="sm:col-span-2">
+            <label class="block text-sm text-muted mb-1">Unternehmen</label>
+            <input
+              type="text"
+              name="company"
+              class="w-full bg-dark border border-dark-lighter rounded-lg px-3 py-2 text-light text-sm focus:border-gold focus:ring-1 focus:ring-gold/20 outline-none"
+            />
+          </div>
+          <div class="sm:col-span-2 flex gap-3 justify-end">
+            <button
+              type="button"
+              id="cancel-new-client"
+              class="px-4 py-2 text-sm text-muted hover:text-light transition-colors"
+            >
+              Abbrechen
+            </button>
+            <button
+              type="submit"
+              id="submit-new-client"
+              class="px-5 py-2 bg-gold text-dark rounded-lg text-sm font-semibold hover:bg-gold/80 transition-colors disabled:opacity-50"
+            >
+              Einladen & Passwort-Email senden
+            </button>
+          </div>
+        </form>
       </div>
 
       <div class="grid gap-4" data-testid="admin-client-list">
         {users.map(user => (
           <a
             href={`/admin/${user.id}`}
-            class="flex items-center gap-4 p-4 bg-dark-light rounded-xl border border-dark-lighter hover:border-gold/40 transition-colors"
+            class={`flex items-center gap-4 p-4 bg-dark-light rounded-xl border transition-colors ${user.enabled === false ? 'border-red-500/20 opacity-60' : 'border-dark-lighter hover:border-gold/40'}`}
             data-testid="admin-client-item"
           >
             <div>
               <p class="text-light font-medium">{user.firstName} {user.lastName}</p>
               <p class="text-sm text-muted">{user.username} · {user.email ?? '—'}</p>
             </div>
-            <span class="ml-auto text-gold text-sm">→</span>
+            <div class="ml-auto flex items-center gap-3">
+              {user.enabled === false && (
+                <span class="text-xs px-2 py-0.5 rounded-full bg-red-500/20 text-red-400">Deaktiviert</span>
+              )}
+              <span class="text-gold text-sm">→</span>
+            </div>
           </a>
         ))}
         {users.length === 0 && (
@@ -53,3 +134,65 @@ try {
     </div>
   </section>
 </Layout>
+
+<script>
+  const btn = document.getElementById('new-client-btn');
+  const form = document.getElementById('new-client-form');
+  const cancelBtn = document.getElementById('cancel-new-client');
+  const formEl = document.getElementById('new-client-form-el') as HTMLFormElement | null;
+  const errorEl = document.getElementById('new-client-error');
+  const successEl = document.getElementById('new-client-success');
+  const submitBtn = document.getElementById('submit-new-client') as HTMLButtonElement | null;
+
+  btn?.addEventListener('click', () => {
+    form?.classList.toggle('hidden');
+  });
+
+  cancelBtn?.addEventListener('click', () => {
+    form?.classList.add('hidden');
+    formEl?.reset();
+    errorEl?.classList.add('hidden');
+    successEl?.classList.add('hidden');
+  });
+
+  formEl?.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    if (!submitBtn) return;
+
+    errorEl?.classList.add('hidden');
+    successEl?.classList.add('hidden');
+    submitBtn.disabled = true;
+    submitBtn.textContent = '...';
+
+    const data = Object.fromEntries(new FormData(formEl));
+    try {
+      const res = await fetch('/api/admin/clients/create', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      });
+      const json = await res.json().catch(() => ({}));
+      if (res.ok) {
+        if (successEl) {
+          successEl.textContent = `Client erstellt. Eine Passwort-Email wird gesendet.`;
+          successEl.classList.remove('hidden');
+        }
+        formEl.reset();
+        setTimeout(() => window.location.reload(), 1500);
+      } else {
+        if (errorEl) {
+          errorEl.textContent = json.error || 'Fehler beim Erstellen des Clients.';
+          errorEl.classList.remove('hidden');
+        }
+      }
+    } catch {
+      if (errorEl) {
+        errorEl.textContent = 'Netzwerkfehler.';
+        errorEl.classList.remove('hidden');
+      }
+    } finally {
+      submitBtn.disabled = false;
+      submitBtn.textContent = 'Einladen & Passwort-Email senden';
+    }
+  });
+</script>

--- a/website/src/pages/admin/termine.astro
+++ b/website/src/pages/admin/termine.astro
@@ -1,8 +1,10 @@
 ---
 import Layout from '../../layouts/Layout.astro';
 import { getSession, getLoginUrl, isAdmin } from '../../lib/auth';
-import { getAvailableSlots } from '../../lib/caldav';
-import type { DaySlots } from '../../lib/caldav';
+import { getAvailableSlots, getAllBookings } from '../../lib/caldav';
+import type { DaySlots, AdminBooking } from '../../lib/caldav';
+import { getBookingProjects, listProjects } from '../../lib/website-db';
+import type { Project } from '../../lib/website-db';
 
 const session = await getSession(Astro.request.headers.get('cookie'));
 if (!session) return Astro.redirect(getLoginUrl());
@@ -10,22 +12,45 @@ if (!isAdmin(session)) return Astro.redirect('/admin');
 
 const NC_DOMAIN = process.env.NC_DOMAIN || 'files.mentolder.de';
 const calendarUrl = `https://${NC_DOMAIN}/apps/calendar`;
+const brand = process.env.BRAND_NAME || 'mentolder';
 
 const now = new Date();
 const horizon = new Date(now);
 horizon.setDate(horizon.getDate() + 14);
 
 let days: DaySlots[] = [];
+let bookings: AdminBooking[] = [];
+let bookingProjectMap: Map<string, string> = new Map();
+let projects: Project[] = [];
 let calError = '';
+
 try {
-  const all = await getAvailableSlots(now);
-  days = all.filter(d => new Date(d.date) <= horizon);
+  const [allSlots, allBookings, allProjects] = await Promise.all([
+    getAvailableSlots(now),
+    getAllBookings(),
+    listProjects({ brand }),
+  ]);
+  days = allSlots.filter(d => new Date(d.date) <= horizon);
+  bookings = allBookings;
+  projects = allProjects;
+  const uids = bookings.map(b => b.uid).filter(Boolean);
+  bookingProjectMap = await getBookingProjects(uids, brand);
 } catch (err) {
-  console.error('[admin/termine] getAvailableSlots failed:', err);
+  console.error('[admin/termine] load failed:', err);
   calError = 'Kalender konnte nicht geladen werden.';
 }
 
 const totalSlots = days.reduce((sum, d) => sum + d.slots.length, 0);
+const upcomingBookings = bookings.filter(b => b.start >= now && b.status !== 'CANCELLED');
+const pastBookings = bookings.filter(b => b.start < now || b.status === 'CANCELLED');
+
+const WEEKDAYS_DE = ['Sonntag', 'Montag', 'Dienstag', 'Mittwoch', 'Donnerstag', 'Freitag', 'Samstag'];
+function formatBookingDate(d: Date) {
+  return `${WEEKDAYS_DE[d.getDay()]}, ${d.toLocaleDateString('de-DE', { day: '2-digit', month: '2-digit', year: 'numeric' })}`;
+}
+function formatTime(d: Date) {
+  return d.toLocaleTimeString('de-DE', { hour: '2-digit', minute: '2-digit' });
+}
 ---
 
 <Layout title="Admin — Termine">
@@ -35,7 +60,7 @@ const totalSlots = days.reduce((sum, d) => sum + d.slots.length, 0);
       <div class="mb-8 flex items-center justify-between">
         <div>
           <h1 class="text-3xl font-bold text-light font-serif">Termine</h1>
-          <p class="text-muted mt-1">Freie Slots der nächsten 14 Tage · {totalSlots} verfügbar</p>
+          <p class="text-muted mt-1">{bookings.length} gebucht · {totalSlots} freie Slots (14 Tage)</p>
         </div>
         <div class="flex gap-3">
           <a
@@ -61,31 +86,149 @@ const totalSlots = days.reduce((sum, d) => sum + d.slots.length, 0);
         </div>
       )}
 
-      {days.length === 0 && !calError && (
-        <div class="p-6 bg-dark-light rounded-xl border border-dark-lighter text-muted text-center">
-          Keine freien Termine in den nächsten 14 Tagen.
-        </div>
-      )}
+      <!-- Gebuchte Termine -->
+      <div class="mb-10">
+        <h2 class="text-xl font-semibold text-light mb-4">Gebuchte Termine</h2>
 
-      <div class="grid gap-4">
-        {days.map(day => (
-          <div class="p-5 bg-dark-light rounded-xl border border-dark-lighter">
-            <div class="flex items-center gap-3 mb-3">
-              <h2 class="text-light font-semibold">{day.weekday}</h2>
-              <span class="text-muted text-sm">{day.date}</span>
-              <span class="ml-auto text-xs text-muted">{day.slots.length} Slot{day.slots.length !== 1 ? 's' : ''}</span>
-            </div>
-            <div class="flex flex-wrap gap-2">
-              {day.slots.map(slot => (
-                <span class="px-3 py-1.5 bg-gold/10 text-gold rounded-lg text-sm font-mono border border-gold/20">
-                  {slot.display}
-                </span>
+        {bookings.length === 0 && !calError && (
+          <div class="p-6 bg-dark-light rounded-xl border border-dark-lighter text-muted text-center">
+            Keine gebuchten Termine vorhanden.
+          </div>
+        )}
+
+        {upcomingBookings.length > 0 && (
+          <div class="mb-6">
+            <h3 class="text-sm font-medium text-muted mb-3 uppercase tracking-wide">Anstehend</h3>
+            <div class="grid gap-3">
+              {upcomingBookings.map(b => (
+                <div class="p-4 bg-dark-light rounded-xl border border-dark-lighter" data-booking-uid={b.uid}>
+                  <div class="flex items-start justify-between gap-4 flex-wrap">
+                    <div>
+                      <p class="text-light font-medium">{b.summary}</p>
+                      <p class="text-sm text-muted mt-0.5">
+                        {formatBookingDate(b.start)} · {formatTime(b.start)} – {formatTime(b.end)}
+                      </p>
+                      <p class="text-sm text-accent mt-0.5">{b.attendeeName} &lt;{b.attendeeEmail}&gt;</p>
+                    </div>
+                    <div class="flex items-center gap-3 shrink-0 flex-wrap">
+                      {projects.length > 0 && (
+                        <select
+                          class="booking-project-select text-xs bg-dark border border-dark-lighter rounded-lg px-2 py-1 text-light focus:border-gold focus:ring-1 focus:ring-gold/20 outline-none cursor-pointer"
+                          data-booking-uid={b.uid}
+                        >
+                          <option value="">— Kein Projekt —</option>
+                          {projects.map(p => (
+                            <option value={p.id} selected={bookingProjectMap.get(b.uid) === p.id}>
+                              {p.name}
+                            </option>
+                          ))}
+                        </select>
+                      )}
+                      <span class={`text-xs px-2 py-0.5 rounded-full ${b.status === 'TENTATIVE' ? 'bg-gold/20 text-gold' : 'bg-accent/20 text-accent'}`}>
+                        {b.status === 'TENTATIVE' ? 'Anfrage' : 'Bestätigt'}
+                      </span>
+                    </div>
+                  </div>
+                </div>
               ))}
             </div>
           </div>
-        ))}
+        )}
+
+        {pastBookings.length > 0 && (
+          <div>
+            <h3 class="text-sm font-medium text-muted mb-3 uppercase tracking-wide">Vergangene</h3>
+            <div class="grid gap-3">
+              {pastBookings.map(b => (
+                <div class="p-4 bg-dark-light rounded-xl border border-dark-lighter opacity-60" data-booking-uid={b.uid}>
+                  <div class="flex items-start justify-between gap-4 flex-wrap">
+                    <div>
+                      <p class="text-light font-medium">{b.summary}</p>
+                      <p class="text-sm text-muted mt-0.5">
+                        {formatBookingDate(b.start)} · {formatTime(b.start)} – {formatTime(b.end)}
+                      </p>
+                      <p class="text-sm text-muted mt-0.5">{b.attendeeName} &lt;{b.attendeeEmail}&gt;</p>
+                    </div>
+                    <div class="flex items-center gap-3 shrink-0 flex-wrap">
+                      {projects.length > 0 && (
+                        <select
+                          class="booking-project-select text-xs bg-dark border border-dark-lighter rounded-lg px-2 py-1 text-light focus:border-gold focus:ring-1 focus:ring-gold/20 outline-none cursor-pointer"
+                          data-booking-uid={b.uid}
+                        >
+                          <option value="">— Kein Projekt —</option>
+                          {projects.map(p => (
+                            <option value={p.id} selected={bookingProjectMap.get(b.uid) === p.id}>
+                              {p.name}
+                            </option>
+                          ))}
+                        </select>
+                      )}
+                      <span class="text-xs px-2 py-0.5 rounded-full bg-dark-lighter text-muted">
+                        {b.status === 'CANCELLED' ? 'Abgesagt' : 'Vergangen'}
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+
+      <!-- Freie Slots -->
+      <div>
+        <h2 class="text-xl font-semibold text-light mb-4">Freie Slots <span class="text-sm font-normal text-muted">(nächste 14 Tage)</span></h2>
+
+        {days.length === 0 && !calError && (
+          <div class="p-6 bg-dark-light rounded-xl border border-dark-lighter text-muted text-center">
+            Keine freien Termine in den nächsten 14 Tagen.
+          </div>
+        )}
+
+        <div class="grid gap-4">
+          {days.map(day => (
+            <div class="p-5 bg-dark-light rounded-xl border border-dark-lighter">
+              <div class="flex items-center gap-3 mb-3">
+                <h3 class="text-light font-semibold">{day.weekday}</h3>
+                <span class="text-muted text-sm">{day.date}</span>
+                <span class="ml-auto text-xs text-muted">{day.slots.length} Slot{day.slots.length !== 1 ? 's' : ''}</span>
+              </div>
+              <div class="flex flex-wrap gap-2">
+                {day.slots.map(slot => (
+                  <span class="px-3 py-1.5 bg-gold/10 text-gold rounded-lg text-sm font-mono border border-gold/20">
+                    {slot.display}
+                  </span>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
       </div>
 
     </div>
   </section>
 </Layout>
+
+<script>
+  document.querySelectorAll<HTMLSelectElement>('.booking-project-select').forEach(sel => {
+    sel.addEventListener('change', async () => {
+      const uid = sel.dataset.bookingUid;
+      if (!uid) return;
+      sel.disabled = true;
+      try {
+        const res = await fetch(`/api/bookings/${encodeURIComponent(uid)}/project`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ projectId: sel.value || null }),
+        });
+        if (!res.ok) {
+          alert('Fehler beim Speichern der Projektzuordnung.');
+        }
+      } catch {
+        alert('Netzwerkfehler beim Speichern.');
+      } finally {
+        sel.disabled = false;
+      }
+    });
+  });
+</script>

--- a/website/src/pages/api/admin/clients/create.ts
+++ b/website/src/pages/api/admin/clients/create.ts
@@ -1,0 +1,50 @@
+import type { APIRoute } from 'astro';
+import { getSession, isAdmin } from '../../../../lib/auth';
+import { createUser } from '../../../../lib/keycloak';
+
+export const POST: APIRoute = async ({ request }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session) {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401, headers: { 'Content-Type': 'application/json' },
+    });
+  }
+  if (!isAdmin(session)) {
+    return new Response(JSON.stringify({ error: 'Forbidden' }), {
+      status: 403, headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  let body: { email?: string; firstName?: string; lastName?: string; phone?: string; company?: string };
+  try {
+    body = await request.json();
+  } catch {
+    return new Response(JSON.stringify({ error: 'Invalid JSON' }), {
+      status: 400, headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  if (!body.email || !body.firstName || !body.lastName) {
+    return new Response(JSON.stringify({ error: 'email, firstName und lastName sind erforderlich.' }), {
+      status: 400, headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const result = await createUser({
+    email: body.email,
+    firstName: body.firstName,
+    lastName: body.lastName,
+    phone: body.phone,
+    company: body.company,
+  });
+
+  if (!result.success) {
+    return new Response(JSON.stringify({ error: result.error }), {
+      status: 400, headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  return new Response(JSON.stringify({ ok: true, userId: result.userId }), {
+    status: 201, headers: { 'Content-Type': 'application/json' },
+  });
+};

--- a/website/src/pages/api/admin/clients/delete.ts
+++ b/website/src/pages/api/admin/clients/delete.ts
@@ -1,0 +1,37 @@
+import type { APIRoute } from 'astro';
+import { getSession, isAdmin } from '../../../../lib/auth';
+import { deleteUser } from '../../../../lib/keycloak';
+
+export const POST: APIRoute = async ({ request }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session) {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401, headers: { 'Content-Type': 'application/json' },
+    });
+  }
+  if (!isAdmin(session)) {
+    return new Response(JSON.stringify({ error: 'Forbidden' }), {
+      status: 403, headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  let body: { userId?: string };
+  try {
+    body = await request.json();
+  } catch {
+    return new Response(JSON.stringify({ error: 'Invalid JSON' }), {
+      status: 400, headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  if (!body.userId) {
+    return new Response(JSON.stringify({ error: 'userId erforderlich.' }), {
+      status: 400, headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const ok = await deleteUser(body.userId);
+  return new Response(JSON.stringify({ ok }), {
+    status: ok ? 200 : 500, headers: { 'Content-Type': 'application/json' },
+  });
+};

--- a/website/src/pages/api/admin/clients/reset-password.ts
+++ b/website/src/pages/api/admin/clients/reset-password.ts
@@ -1,0 +1,37 @@
+import type { APIRoute } from 'astro';
+import { getSession, isAdmin } from '../../../../lib/auth';
+import { sendPasswordResetEmail } from '../../../../lib/keycloak';
+
+export const POST: APIRoute = async ({ request }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session) {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401, headers: { 'Content-Type': 'application/json' },
+    });
+  }
+  if (!isAdmin(session)) {
+    return new Response(JSON.stringify({ error: 'Forbidden' }), {
+      status: 403, headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  let body: { userId?: string };
+  try {
+    body = await request.json();
+  } catch {
+    return new Response(JSON.stringify({ error: 'Invalid JSON' }), {
+      status: 400, headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  if (!body.userId) {
+    return new Response(JSON.stringify({ error: 'userId erforderlich.' }), {
+      status: 400, headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const ok = await sendPasswordResetEmail(body.userId);
+  return new Response(JSON.stringify({ ok }), {
+    status: ok ? 200 : 500, headers: { 'Content-Type': 'application/json' },
+  });
+};

--- a/website/src/pages/api/admin/clients/roles-assign.ts
+++ b/website/src/pages/api/admin/clients/roles-assign.ts
@@ -1,0 +1,38 @@
+import type { APIRoute } from 'astro';
+import { getSession, isAdmin } from '../../../../lib/auth';
+import { assignRealmRole } from '../../../../lib/keycloak';
+import type { KcRole } from '../../../../lib/keycloak';
+
+export const POST: APIRoute = async ({ request }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session) {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401, headers: { 'Content-Type': 'application/json' },
+    });
+  }
+  if (!isAdmin(session)) {
+    return new Response(JSON.stringify({ error: 'Forbidden' }), {
+      status: 403, headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  let body: { userId?: string; roles?: KcRole[] };
+  try {
+    body = await request.json();
+  } catch {
+    return new Response(JSON.stringify({ error: 'Invalid JSON' }), {
+      status: 400, headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  if (!body.userId || !Array.isArray(body.roles) || body.roles.length === 0) {
+    return new Response(JSON.stringify({ error: 'userId und roles erforderlich.' }), {
+      status: 400, headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const ok = await assignRealmRole(body.userId, body.roles);
+  return new Response(JSON.stringify({ ok }), {
+    status: ok ? 200 : 500, headers: { 'Content-Type': 'application/json' },
+  });
+};

--- a/website/src/pages/api/admin/clients/roles-remove.ts
+++ b/website/src/pages/api/admin/clients/roles-remove.ts
@@ -1,0 +1,38 @@
+import type { APIRoute } from 'astro';
+import { getSession, isAdmin } from '../../../../lib/auth';
+import { removeRealmRole } from '../../../../lib/keycloak';
+import type { KcRole } from '../../../../lib/keycloak';
+
+export const POST: APIRoute = async ({ request }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session) {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401, headers: { 'Content-Type': 'application/json' },
+    });
+  }
+  if (!isAdmin(session)) {
+    return new Response(JSON.stringify({ error: 'Forbidden' }), {
+      status: 403, headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  let body: { userId?: string; roles?: KcRole[] };
+  try {
+    body = await request.json();
+  } catch {
+    return new Response(JSON.stringify({ error: 'Invalid JSON' }), {
+      status: 400, headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  if (!body.userId || !Array.isArray(body.roles) || body.roles.length === 0) {
+    return new Response(JSON.stringify({ error: 'userId und roles erforderlich.' }), {
+      status: 400, headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const ok = await removeRealmRole(body.userId, body.roles);
+  return new Response(JSON.stringify({ ok }), {
+    status: ok ? 200 : 500, headers: { 'Content-Type': 'application/json' },
+  });
+};

--- a/website/src/pages/api/admin/clients/update.ts
+++ b/website/src/pages/api/admin/clients/update.ts
@@ -1,0 +1,43 @@
+import type { APIRoute } from 'astro';
+import { getSession, isAdmin } from '../../../../lib/auth';
+import { updateUser } from '../../../../lib/keycloak';
+
+export const POST: APIRoute = async ({ request }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session) {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401, headers: { 'Content-Type': 'application/json' },
+    });
+  }
+  if (!isAdmin(session)) {
+    return new Response(JSON.stringify({ error: 'Forbidden' }), {
+      status: 403, headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  let body: { userId?: string; firstName?: string; lastName?: string; email?: string; enabled?: boolean };
+  try {
+    body = await request.json();
+  } catch {
+    return new Response(JSON.stringify({ error: 'Invalid JSON' }), {
+      status: 400, headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  if (!body.userId) {
+    return new Response(JSON.stringify({ error: 'userId erforderlich.' }), {
+      status: 400, headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const ok = await updateUser(body.userId, {
+    firstName: body.firstName,
+    lastName: body.lastName,
+    email: body.email,
+    enabled: body.enabled,
+  });
+
+  return new Response(JSON.stringify({ ok }), {
+    status: ok ? 200 : 500, headers: { 'Content-Type': 'application/json' },
+  });
+};

--- a/website/src/pages/api/bookings/[uid]/project.ts
+++ b/website/src/pages/api/bookings/[uid]/project.ts
@@ -1,0 +1,46 @@
+import type { APIRoute } from 'astro';
+import { getSession, isAdmin } from '../../../../lib/auth';
+import { setBookingProject } from '../../../../lib/website-db';
+
+export const PATCH: APIRoute = async ({ request, params }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session) {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401, headers: { 'Content-Type': 'application/json' },
+    });
+  }
+  if (!isAdmin(session)) {
+    return new Response(JSON.stringify({ error: 'Forbidden' }), {
+      status: 403, headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const uid = params.uid;
+  if (!uid) {
+    return new Response(JSON.stringify({ error: 'Missing uid' }), {
+      status: 400, headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  let body: { projectId?: string | null };
+  try {
+    body = await request.json();
+  } catch {
+    return new Response(JSON.stringify({ error: 'Invalid JSON' }), {
+      status: 400, headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const brand = process.env.BRAND_NAME || 'mentolder';
+  try {
+    await setBookingProject(uid, body.projectId ?? null, brand);
+    return new Response(JSON.stringify({ ok: true }), {
+      status: 200, headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (err) {
+    console.error('[PATCH /api/bookings/[uid]/project] DB error:', err);
+    return new Response(JSON.stringify({ error: 'Database error' }), {
+      status: 500, headers: { 'Content-Type': 'application/json' },
+    });
+  }
+};


### PR DESCRIPTION
## Summary

- **BR-9857 (Bug)**: `admin/termine` zeigt jetzt gebuchte CalDAV-Termine mit Attendee-Info, Datum/Uhrzeit und Projektzuordnung — nicht mehr nur freie Slots
- **BR-ee99 (Feature)**: CalDAV-Termine können Projekten zugeordnet werden (neue `booking_project_links` DB-Tabelle + API + Dropdown in der UI)
- **BR-ee99 (Feature)**: `MeetingsAdminTab` zeigt alle Projekte statt nur kundenbezogene im Dropdown
- **BR-ee99 (Feature)**: Vollständiges Usermanagement in der Clientsektion — Benutzer erstellen (Einladung per E-Mail), bearbeiten, deaktivieren/aktivieren, Passwort-Reset, löschen, Keycloak-Rollen zuweisen/entfernen

## Geänderte Dateien

| Datei | Änderung |
|---|---|
| `caldav.ts` | `getAllBookings()` + `AdminBooking` Interface mit UID |
| `website-db.ts` | `booking_project_links` Tabelle + `getBookingProjects()` / `setBookingProject()` |
| `keycloak.ts` | `updateUser()`, `listRealmRoles()`, `getUserRealmRoles()`, `assignRealmRole()`, `removeRealmRole()` |
| `admin/termine.astro` | Sektion "Gebuchte Termine" mit Projekt-Dropdown |
| `admin/clients.astro` | "+ Neuer Client" Button + Einlade-Formular |
| `admin/[clientId].astro` | Aktionsleiste: Bearbeiten, Deaktivieren, Passwort-Reset, Löschen, Rollen |
| `MeetingsAdminTab.astro` | `listProjects({ brand })` statt `{ brand, customerId }` |
| `api/admin/clients/*` | 6 neue Endpunkte (create, update, delete, reset-password, roles-assign, roles-remove) |
| `api/bookings/[uid]/project` | PATCH Endpunkt für CalDAV-Termin → Projekt-Zuordnung |

## Test plan

- [ ] `admin/termine` zeigt "Gebuchte Termine" Abschnitt (leer wenn keine CalDAV-Events mit ATTENDEE)
- [ ] Wenn ein Termin bestätigt wird, erscheint er in "Gebuchte Termine" mit Attendee-Info
- [ ] Projekt-Dropdown in "Gebuchte Termine" speichert Zuordnung persistent
- [ ] `admin/clients` zeigt "+ Neuer Client" Button
- [ ] Neues Einlade-Formular erstellt Keycloak-User und sendet Passwort-Email
- [ ] Client-Detail zeigt Aktionsbuttons: Bearbeiten, Deaktivieren, Passwort-Reset, Löschen
- [ ] Bearbeiten-Formular aktualisiert Name/E-Mail in Keycloak
- [ ] Deaktivieren/Aktivieren toggelt `enabled` Status
- [ ] Passwort-Reset sendet E-Mail via Keycloak
- [ ] Löschen entfernt User aus Keycloak und leitet zurück
- [ ] Rollen-Checkboxen (falls Custom-Rollen vorhanden) weisen Keycloak Realm-Rollen zu/entfernen sie
- [ ] `MeetingsAdminTab` zeigt alle Projekte im Dropdown, nicht nur kundenbezogene

🤖 Generated with [Claude Code](https://claude.com/claude-code)