### PR TITLE
feat(transcription): post-meeting transcript → DB + Nextcloud

### DIFF
--- a/docs/admin-projekte.md
+++ b/docs/admin-projekte.md
@@ -1,3 +1,16 @@
+<div class="page-hero">
+  <span class="page-hero-icon">📊</span>
+  <div class="page-hero-body">
+    <div class="page-hero-title">Projektmanagement-Admin</div>
+    <p class="page-hero-desc">Admin-Panel für Projekte, Teilprojekte und Aufgaben je Brand und Kunde. Buchungen, Termine und Nutzerverwaltung mit Keycloak OIDC.</p>
+    <div class="page-hero-meta">
+      <span class="page-hero-tag">Website &amp; Admin</span>
+      <span class="page-hero-tag">OIDC-gesichert</span>
+    </div>
+  </div>
+  <a href="#/" class="page-hero-back">← Übersicht</a>
+</div>
+
 # Projektmanagement-Admin
 
 Das Admin-Panel unter `/admin/projekte` erlaubt die Verwaltung von Projekten, Teilprojekten

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,10 +1,24 @@
+<div class="page-hero">
+  <span class="page-hero-icon">🏗️</span>
+  <div class="page-hero-body">
+    <div class="page-hero-title">Architektur</div>
+    <p class="page-hero-desc">Systemübersicht, Kubernetes-Cluster-Topologie, Service-Abhängigkeiten und Infrastruktur-Design des Workspace MVP.</p>
+    <div class="page-hero-meta">
+      <span class="page-hero-tag">Für Administratoren</span>
+      <span class="page-hero-tag">Kubernetes</span>
+      <span class="page-hero-tag">Mermaid Diagramm</span>
+    </div>
+  </div>
+  <a href="#/" class="page-hero-back">← Übersicht</a>
+</div>
+
 # Architektur
 
 ## Systemuebersicht
 
 Workspace MVP ist eine Kubernetes-basierte Kollaborationsplattform fuer kleine Teams. Alle Services laufen als Deployments in einem k3d/k3s Cluster mit Traefik als Ingress Controller. Daten bleiben vollstaendig on-premises (DSGVO by Design).
 
-> **Tipp:** Die Service-Boxen im Diagramm sind klickbar und fuehren zu den Detail-Abschnitten weiter unten.
+> **Tipp:** Die Service-Boxen im Diagramm sind klickbar und fuehren zur jeweiligen Service-Dokumentation. Hover zeigt eine Kurzbeschreibung.
 
 ```mermaid
 flowchart TB
@@ -148,31 +162,31 @@ flowchart TB
     IN -. "SMTP" .-> MP
 
     %% --- Klickbare Nodes ---
-    click KC "#keycloak" "Keycloak: Zentraler OIDC Identity Provider fuer SSO. Verwaltet Benutzer, Rollen und 8 OIDC-Clients. Speichert Sessions und Realm-Konfiguration in PostgreSQL."
-    click MM "#mattermost" "Mattermost: Team-Chat mit Channels, Threads und Dateifreigabe. Integriert OpenSearch fuer Volltextsuche, Webhooks fuer Automatisierung und Slash-Commands fuer billing-bot."
-    click NC "#nextcloud" "Nextcloud: Dateiverwaltung, Kalender, Kontakte und Videokonferenzen via Talk. WOPI-Integration mit Collabora fuer Office-Dokumente. WebRTC via HPB Stack."
-    click CO "#collabora" "Collabora Online: LibreOffice-basierter Office-Editor im Browser. Bearbeitet DOCX, XLSX, PPTX, ODT Dateien kollaborativ ueber WOPI-Protokoll mit Nextcloud."
-    click OC "#claude-code" "Claude Code: KI-Assistent mit Claude Sonnet 4. Nutzt MCP-Server fuer Kubernetes-Verwaltung, Datenbank-Abfragen und Browser-Automatisierung. RBAC-gesichert."
-    click IN "#invoice-ninja" "Invoice Ninja: Rechnungserstellung, Kundenverwaltung und Zahlungsabwicklung via Stripe. Geschuetzt durch oauth2-proxy. Eigene MariaDB-Instanz."
-    click VW "#vaultwarden" "Vaultwarden: Self-hosted Bitwarden-kompatibler Passwort-Manager. Speichert verschluesselte Vault-Items in PostgreSQL. OIDC-Login via Keycloak."
-    click BB "#billing-bot" "billing-bot: Go-Microservice. Verbindet Mattermost Slash-Commands mit Invoice Ninja API fuer schnelle Rechnungs- und Kundenerstellung aus dem Chat."
-    click OL "#outline" "Outline: Kollaboratives Wiki fuer Teamwissen. Markdown-basiert mit Echtzeit-Bearbeitung, verschachtelten Dokumenten und Volltextsuche. Redis fuer Sessions."
-    click WB "#whiteboard" "Whiteboard: Nextcloud-integriertes Whiteboard fuer visuelle Zusammenarbeit. Echtzeit-Kollaboration ueber WebSockets."
-    click MP "#mailpit" "Mailpit: SMTP-Testserver fuer Entwicklung. Faengt alle ausgehenden E-Mails ab (kein Versand). Web-UI zur Inspektion von Benachrichtigungen."
-    click DB "#datenbank-layout" "PostgreSQL 16 shared-db: 7 isolierte Datenbanken (keycloak, mattermost, nextcloud, vaultwarden, outline, website, pentest) mit eigenem User je Service."
-    click MARIA "#datenbank-layout" "MariaDB 11: Dedizierte Instanz fuer Invoice Ninja (benoetigt MySQL-Kompatibilitaet)."
-    click OS "#datenbank-layout" "OpenSearch 2.19: Elasticsearch-kompatibler Suchindex fuer Mattermost Volltextsuche und Autocomplete."
-    click WEB "#website" "Website: Astro + Svelte Unternehmenswebsite mit Kontaktformular (Mattermost Webhook), OIDC-Login, Stripe-Checkout und Admin-Panel (/admin/projekte)."
-    click PROM "#monitoring" "Prometheus: Metriken-Sammlung aller Kubernetes-Ressourcen. Speist DSGVO-Compliance-Dashboard."
-    click GRAF "#monitoring" "Grafana: Visualisierung der Prometheus-Metriken. Enthaelt DSGVO-Compliance-Dashboard (NFA-02)."
-    click WHISPER "#whisper" "Whisper: faster-whisper Transkriptionsservice fuer Audio-zu-Text Konvertierung."
-    click EMB "#embedding" "Embedding: infinity-emb Text-Vektorisierung (BAAI/bge-base-en-v1.5) fuer Meeting-Transkript-Analyse."
-    click REC "#talk-recording" "Talk Recording: Firefox/geckodriver-basierte Anruf-Aufzeichnung fuer Nextcloud Talk."
-    click SIG "#talk-hpb" "spreed-signaling: WebRTC-Signaling-Server fuer Nextcloud Talk Videokonferenzen."
-    click MCP_K8S "#claude-code" "MCP Kubernetes: Read-only Zugriff auf Pods, Deployments, Services, Logs. Kann Deployments neu starten (mit Genehmigung)."
-    click MCP_PG "#claude-code" "MCP Postgres: Superuser-Zugriff auf alle shared-db Datenbanken fuer Analyse und Debugging."
-    click MCP_GRAF "#claude-code" "MCP Grafana: Zugriff auf Grafana Dashboards und Metriken."
-    click MCP_PROM "#claude-code" "MCP Prometheus: Direkte PromQL-Abfragen fuer Cluster-Metriken."
+    click KC "#/keycloak" "Keycloak: Zentraler OIDC Identity Provider fuer SSO. Verwaltet Benutzer, Rollen und 8 OIDC-Clients. Speichert Sessions und Realm-Konfiguration in PostgreSQL."
+    click MM "#/services?id=mattermost-chat" "Mattermost: Team-Chat mit Channels, Threads und Dateifreigabe. Integriert OpenSearch fuer Volltextsuche, Webhooks fuer Automatisierung und Slash-Commands fuer billing-bot."
+    click NC "#/services?id=nextcloud-dateien-talk" "Nextcloud: Dateiverwaltung, Kalender, Kontakte und Videokonferenzen via Talk. WOPI-Integration mit Collabora fuer Office-Dokumente. WebRTC via HPB Stack."
+    click CO "#/services?id=collabora-online-office" "Collabora Online: LibreOffice-basierter Office-Editor im Browser. Bearbeitet DOCX, XLSX, PPTX, ODT Dateien kollaborativ ueber WOPI-Protokoll mit Nextcloud."
+    click OC "#/services?id=claude-code-ki-assistent" "Claude Code: KI-Assistent mit Claude Sonnet 4. Nutzt MCP-Server fuer Kubernetes-Verwaltung, Datenbank-Abfragen und Browser-Automatisierung. RBAC-gesichert."
+    click IN "#/services?id=invoice-ninja-rechnungen" "Invoice Ninja: Rechnungserstellung, Kundenverwaltung und Zahlungsabwicklung via Stripe. Geschuetzt durch oauth2-proxy. Eigene MariaDB-Instanz."
+    click VW "#/services?id=vaultwarden-passwoerter" "Vaultwarden: Self-hosted Bitwarden-kompatibler Passwort-Manager. Speichert verschluesselte Vault-Items in PostgreSQL. OIDC-Login via Keycloak."
+    click BB "#/services?id=billing-bot" "billing-bot: Go-Microservice. Verbindet Mattermost Slash-Commands mit Invoice Ninja API fuer schnelle Rechnungs- und Kundenerstellung aus dem Chat."
+    click OL "#/services?id=outline-wiki-optional" "Outline: Kollaboratives Wiki fuer Teamwissen. Markdown-basiert mit Echtzeit-Bearbeitung, verschachtelten Dokumenten und Volltextsuche. Redis fuer Sessions."
+    click WB "#/services?id=whiteboard" "Whiteboard: Nextcloud-integriertes Whiteboard fuer visuelle Zusammenarbeit. Echtzeit-Kollaboration ueber WebSockets."
+    click MP "#/services?id=mailpit-dev-mail" "Mailpit: SMTP-Testserver fuer Entwicklung. Faengt alle ausgehenden E-Mails ab (kein Versand). Web-UI zur Inspektion von Benachrichtigungen."
+    click DB "#/architecture?id=datenbank-layout" "PostgreSQL 16 shared-db: 7 isolierte Datenbanken (keycloak, mattermost, nextcloud, vaultwarden, outline, website, pentest) mit eigenem User je Service."
+    click MARIA "#/architecture?id=datenbank-layout" "MariaDB 11: Dedizierte Instanz fuer Invoice Ninja (benoetigt MySQL-Kompatibilitaet)."
+    click OS "#/architecture?id=datenbank-layout" "OpenSearch 2.19: Elasticsearch-kompatibler Suchindex fuer Mattermost Volltextsuche und Autocomplete."
+    click WEB "#/services?id=website-astro-svelte" "Website: Astro + Svelte Unternehmenswebsite mit Kontaktformular (Mattermost Webhook), OIDC-Login, Stripe-Checkout und Admin-Panel (/admin/projekte)."
+    click PROM "#/architecture?id=deployment-ablauf" "Prometheus: Metriken-Sammlung aller Kubernetes-Ressourcen. Speist DSGVO-Compliance-Dashboard."
+    click GRAF "#/architecture?id=deployment-ablauf" "Grafana: Visualisierung der Prometheus-Metriken. Enthaelt DSGVO-Compliance-Dashboard (NFA-02)."
+    click WHISPER "#/services?id=whisper-transkription-optional" "Whisper: faster-whisper Transkriptionsservice fuer Audio-zu-Text Konvertierung."
+    click EMB "#/services?id=embedding-text-vektorisierung" "Embedding: infinity-emb Text-Vektorisierung (BAAI/bge-base-en-v1.5) fuer Meeting-Transkript-Analyse."
+    click REC "#/services?id=talk-recording-anruf-aufzeichnung" "Talk Recording: Firefox/geckodriver-basierte Anruf-Aufzeichnung fuer Nextcloud Talk."
+    click SIG "#/services?id=talk-hpb-signaling" "spreed-signaling: WebRTC-Signaling-Server fuer Nextcloud Talk Videokonferenzen."
+    click MCP_K8S "#/services?id=claude-code-ki-assistent" "MCP Kubernetes: Read-only Zugriff auf Pods, Deployments, Services, Logs. Kann Deployments neu starten (mit Genehmigung)."
+    click MCP_PG "#/services?id=claude-code-ki-assistent" "MCP Postgres: Superuser-Zugriff auf alle shared-db Datenbanken fuer Analyse und Debugging."
+    click MCP_GRAF "#/services?id=claude-code-ki-assistent" "MCP Grafana: Zugriff auf Grafana Dashboards und Metriken."
+    click MCP_PROM "#/services?id=claude-code-ki-assistent" "MCP Prometheus: Direkte PromQL-Abfragen fuer Cluster-Metriken."
 
     %% --- Styles ---
     classDef identity_style fill:#1b3766,color:#e8c870,stroke:#2a5291

--- a/docs/mcp-actions.md
+++ b/docs/mcp-actions.md
@@ -1,3 +1,16 @@
+<div class="page-hero">
+  <span class="page-hero-icon">🤖</span>
+  <div class="page-hero-body">
+    <div class="page-hero-title">MCP Actions</div>
+    <p class="page-hero-desc">Referenz aller Aktionen, die Claude Code über die verbundenen MCP-Server ausführen kann: Kubernetes, Postgres, Browser, Grafana, Prometheus.</p>
+    <div class="page-hero-meta">
+      <span class="page-hero-tag">Claude Code KI</span>
+      <span class="page-hero-tag">MCP Server</span>
+    </div>
+  </div>
+  <a href="#/" class="page-hero-back">← Übersicht</a>
+</div>
+
 # MCP-Aktionen Referenz
 
 Alle Aktionen, die Claude Code ueber die verbundenen MCP-Server ausfuehren kann.

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1,3 +1,16 @@
+<div class="page-hero">
+  <span class="page-hero-icon">🚀</span>
+  <div class="page-hero-body">
+    <div class="page-hero-title">Migration</div>
+    <p class="page-hero-desc">Upgrade-Pfade, Datenmigration aus Slack/Teams/Google Workspace, Rollback-Strategien und Import-Skripte.</p>
+    <div class="page-hero-meta">
+      <span class="page-hero-tag">Für Administratoren</span>
+      <span class="page-hero-tag">Datenmigration</span>
+    </div>
+  </div>
+  <a href="#/" class="page-hero-back">← Übersicht</a>
+</div>
+
 # Migration
 
 ## Uebersicht
@@ -32,14 +45,14 @@ flowchart LR
     M --> NC
     M --> KC
 
-    style SL fill:#611f69,color:#fff
-    style TE fill:#4a90d9,color:#fff
-    style GO fill:#2d8659,color:#fff
-    style CSV fill:#6b7280,color:#fff
-    style M fill:#374151,color:#fff
-    style MM fill:#2d8659,color:#fff
-    style NC fill:#0891b2,color:#fff
-    style KC fill:#4a90d9,color:#fff
+    style SL fill:#2a1654,color:#e8c870
+    style TE fill:#1b3766,color:#e8c870
+    style GO fill:#1a3d28,color:#e8c870
+    style CSV fill:#1f2937,color:#aabbcc
+    style M fill:#1a1a2e,color:#aabbcc
+    style MM fill:#1a3d28,color:#e8c870
+    style NC fill:#083344,color:#e8c870
+    style KC fill:#1b3766,color:#e8c870
 ```
 
 ## Migrations-Assistent

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -1,3 +1,16 @@
+<div class="page-hero">
+  <span class="page-hero-icon">📜</span>
+  <div class="page-hero-body">
+    <div class="page-hero-title">Skripte</div>
+    <p class="page-hero-desc">Referenz aller Bash-Hilfsskripte im <code>scripts/</code>-Verzeichnis: Setup, Migration, DSGVO-Checks, MCP-Registrierung und Stripe.</p>
+    <div class="page-hero-meta">
+      <span class="page-hero-tag">Für Administratoren</span>
+      <span class="page-hero-tag">Bash</span>
+    </div>
+  </div>
+  <a href="#/" class="page-hero-back">← Übersicht</a>
+</div>
+
 # Skripte
 
 Referenz aller Skripte im `scripts/`-Verzeichnis.
@@ -140,6 +153,15 @@ Konfiguriert Mattermost-Integrationen (Webhooks, Slash-Commands, Bot-Accounts) f
 scripts/mattermost-connectors-setup.sh
 ```
 
+### set-mattermost-theme.sh -- Mattermost Theme setzen
+
+Setzt das Dark+Gold-Custom-Theme fuer alle aktiven Nicht-Bot-Benutzer in Mattermost per REST-API. Idempotent und sicher fuer mehrfaches Ausfuehren. Liest das Admin-Passwort automatisch aus `workspace-secrets` oder nutzt den Standardwert (`devadmin`).
+
+```bash
+scripts/set-mattermost-theme.sh              # Namespace workspace (Standard)
+scripts/set-mattermost-theme.sh production   # alternativer Namespace
+```
+
 ### mattermost-anfragen-setup.sh -- Anfragen-Channel
 
 Erstellt einen "Anfragen"-Kanal und Incoming-Webhook in allen Mattermost-Teams fuer das Website-Kontaktformular.
@@ -164,12 +186,58 @@ Erstellt den `/meeting` Slash-Command in Mattermost fuer Meeting-Verwaltung (Ers
 scripts/meeting-slash-setup.sh
 ```
 
+### call-setup.sh -- /call Slash-Command
+
+Registriert den `/call` Slash-Command in allen Mattermost-Teams. Der Command zeigt auf den billing-bot-`/slash`-Endpunkt und erstellt einen Nextcloud Talk Video-Call-Raum. Erkennt die Mattermost-URL und generiert automatisch einen temporaeren Admin-Token via mmctl.
+
+```bash
+scripts/call-setup.sh
+MM_TOKEN=<token> scripts/call-setup.sh
+MM_URL=https://chat.example.com MM_TOKEN=<token> NAMESPACE=workspace scripts/call-setup.sh
+```
+
+| Variable | Beschreibung | Standard |
+|----------|-------------|---------|
+| `MM_URL` | Mattermost-URL | auto-detect via SiteURL |
+| `MM_TOKEN` | Personal Access Token | auto-generiert via mmctl |
+| `NAMESPACE` | Kubernetes-Namespace | `workspace` |
+| `KUBE_CONTEXT` | kubectl-Kontext | -- |
+
 ### recording-setup.sh -- Talk Recording konfigurieren
 
 Konfiguriert den Nextcloud Talk Recording-Service (spreed-Konfiguration, Recording-Secret).
 
 ```bash
 scripts/recording-setup.sh
+```
+
+### talk-hpb-setup.sh -- Nextcloud Talk HPB konfigurieren
+
+Verbindet den Nextcloud Talk-App mit dem spreed-signaling HPB, dem coturn TURN-Server und seinem STUN-Port. Liest `SIGNALING_SECRET` und `TURN_SECRET` aus dem `workspace-secrets`-Secret. Idempotent: ueberschreibt bei erneutem Ausfuehren nur die drei App-Config-Schlueessel.
+
+```bash
+scripts/talk-hpb-setup.sh
+NAMESPACE=workspace scripts/talk-hpb-setup.sh
+KUBE_CONTEXT=korczewski scripts/talk-hpb-setup.sh
+```
+
+Wendet zusaetzlich einen CoreDNS-Override an, damit der Nextcloud-PHP-Backend den signaling-Host intern aufloesung (wichtig fuer Produktionscluster hinter NAT).
+
+### transcriber-setup.sh -- Live-Transkription einrichten
+
+Legt den `transcriber-bot`-Nextcloud-User fuer den talk-transcriber-Pod an, registriert ihn als Talk-Bot (Webhook + Response) und aktiviert die Call-Transkription in spreed. Liest `TRANSCRIBER_BOT_PASSWORD` und `TRANSCRIBER_SECRET` aus `workspace-secrets`. Idempotent.
+
+```bash
+scripts/transcriber-setup.sh
+```
+
+### whiteboard-setup.sh -- Nextcloud Whiteboard konfigurieren
+
+Installiert und konfiguriert die Nextcloud Whiteboard-App und synchronisiert das JWT-Secret mit dem laufenden Whiteboard-Backend-Pod. Prueft vor dem Schreiben, ob das Secret im k8s-Secret und im Pod uebereinstimmt. Idempotent.
+
+```bash
+scripts/whiteboard-setup.sh
+NAMESPACE=workspace scripts/whiteboard-setup.sh
 ```
 
 ### check-updates.sh -- Image-Updates pruefen

--- a/docs/security-report.md
+++ b/docs/security-report.md
@@ -1,7 +1,20 @@
+<div class="page-hero">
+  <span class="page-hero-icon">📋</span>
+  <div class="page-hero-body">
+    <div class="page-hero-title">Security Report</div>
+    <p class="page-hero-desc">Sicherheitsbericht zum Workspace MVP: Testergebnisse SA-01–SA-10, Schwachstellenanalyse, CVSS-Bewertungen und Härtungsmaßnahmen.</p>
+    <div class="page-hero-meta">
+      <span class="page-hero-tag">Sicherheit</span>
+      <span class="page-hero-tag">SA-Anforderungen</span>
+    </div>
+  </div>
+  <a href="#/" class="page-hero-back">← Übersicht</a>
+</div>
+
 # Sicherheitsbericht — Workspace MVP
 
-**Version:** 1.1
-**Datum:** 2026-04-14
+**Version:** 1.0
+**Datum:** 2026-04-13
 **Scope:** Kubernetes-basierter Collaboration-Stack (k3s/k3d), On-Premises
 
 ---
@@ -82,7 +95,7 @@ Der Workspace MVP ist eine selbst-gehostete Kollaborationsplattform auf Kubernet
 
 **Risiko nach Härtung:** NIEDRIG.
 
-**Verbleibend:** Ein vollständiger `monitoring`-Namespace (Prometheus/Grafana) ist aktuell auf der Produktionsumgebung nicht deployed. Die bestehende `allow-monitoring-ingress`-Policy im `workspace`-Namespace ist zukunftssicher vorbereitet; beim späteren Deployment von Prometheus/Grafana per `task workspace:monitoring` muss der `monitoring`-Namespace gleichzeitig mit eigenen Default-Deny-Policies versehen werden.
+**Verbleibend:** PostgreSQL intern ohne TLS — mitigiert durch NetworkPolicy-Isolation. Monitoring-Namespace ohne eigene Policies (Helm-verwaltet).
 
 ---
 
@@ -96,7 +109,7 @@ Der Workspace MVP ist eine selbst-gehostete Kollaborationsplattform auf Kubernet
 |-----------|-----------|--------|
 | Extern → Traefik | TLS 1.2/1.3 | ✓ Let's Encrypt Wildcard |
 | Traefik → Services (intern) | HTTP | Akzeptabel (gleiches Namespace, NetworkPolicies) |
-| Services → PostgreSQL | TCP (`sslmode=prefer`) mit Server-TLS | ✓ PG-TLS aktiv (self-signed, opportunistisch) |
+| Services → PostgreSQL | TCP (sslmode=disable) | Mitigiert durch NetworkPolicies |
 | TURN-Verbindungen (coturn) | TLS | ✓ |
 | Mattermost WebSocket extern | WSS (TLS) | ✓ |
 
@@ -105,12 +118,10 @@ Der Workspace MVP ist eine selbst-gehostete Kollaborationsplattform auf Kubernet
 - HSTS `max-age=31536000; includeSubDomains`
 - HTTP → HTTPS Redirect (301 Permanent)
 - Let's Encrypt ACME v2
-- Explizite `TLSOption default` in Traefik: `minVersion: VersionTLS12`, `sniStrict: true`
-- PostgreSQL-Server-TLS: Selbstsigniertes Zertifikat wird von einem initContainer bei jedem Pod-Start in ein `emptyDir` geschrieben; PG startet mit `ssl=on` + `ssl_cert_file` / `ssl_key_file`. Clients (Keycloak, Mattermost, Vaultwarden, Outline) nutzen `sslmode=prefer` und handeln TLS opportunistisch aus. Nextcloud und Meetings folgen später.
 
-**Risiko:** NIEDRIG extern, NIEDRIG intern.
+**Risiko:** NIEDRIG extern, NIEDRIG intern (mitigiert durch L3-Policies).
 
-**Zukünftige Erweiterung:** Vollständige PKI via cert-manager mit Client-CA-Verifikation (`sslmode=verify-ca`) für alle Services — schrittweise Migration nach v1.1.
+**Zukünftige Erweiterung:** PostgreSQL-TLS intern via cert-manager.
 
 ---
 
@@ -140,9 +151,10 @@ Der Workspace MVP ist eine selbst-gehostete Kollaborationsplattform auf Kubernet
 - Let's Encrypt Wildcard-Zertifikat: `*.korczewski.de` + `korczewski.de`
 - Automatische Erneuerung: 30 Tage vor Ablauf (cert-manager)
 - Cipher Suites: Traefik-Defaults (keine RC4, DES, 3DES)
-- `TLSOption default` (workspace-Namespace) mit `minVersion: VersionTLS12` und `sniStrict: true` — wird von Traefik automatisch auf alle IngressRoutes im Namespace angewendet
 
 **Risiko:** NIEDRIG.
+
+**Empfehlung:** `minVersion: VersionTLS12` explizit in Traefik-Config setzen.
 
 ---
 
@@ -429,8 +441,6 @@ task workspace:dsgvo-check                  # Kurzbefehl
 
 ## 7. Implementierte Änderungen
 
-### 7.1 Sicherheitshärtung v1.0 (2026-04-13)
-
 | Datei | Änderung |
 |-------|---------|
 | `k3d/network-policies.yaml` | Neu: 7 NetworkPolicies workspace |
@@ -446,55 +456,16 @@ task workspace:dsgvo-check                  # Kurzbefehl
 | `scripts/dsgvo-compliance-check.sh` | Ergänzt: D09–D12 (TLS, Passwort-Policy, Backup, NetworkPolicy) |
 | `website/src/pages/datenschutz.astro` | Ersetzt: vollständige Art. 13/14-konforme Datenschutzerklärung |
 
-### 7.2 Finalisierung v1.1 (2026-04-14)
-
-| Datei | Änderung |
-|-------|---------|
-| `prod/tlsoption.yaml` | Neu: Traefik `TLSOption default` (`minVersion: VersionTLS12`, `sniStrict: true`) |
-| `prod/kustomization.yaml` | Ergänzt: `tlsoption.yaml` als Resource |
-| `k3d/shared-db.yaml` | Ergänzt: initContainer `generate-tls-cert` (self-signed Cert in `emptyDir`), PG-Args `ssl=on` + `ssl_cert_file` / `ssl_key_file` |
-| `k3d/keycloak.yaml` | `KC_DB_URL` um `?sslmode=prefer` erweitert |
-| `k3d/vaultwarden.yaml` | `DATABASE_URL` um `?sslmode=prefer` erweitert |
-| `k3d/outline.yaml` | `PGSSLMODE=prefer` (vorher `disable`) |
-| `k3d/mattermost.yaml` | `MM_SQLSETTINGS_DATASOURCE` auf `sslmode=prefer` (vorher `disable`) |
-| `docs/security-report.md` | §3 Verbleibend, §4 Transport-Matrix, §6 Presentation, §7 Änderungen, §9 Fazit + Versionshistorie + Freigabe |
-| `docs/superpowers/specs/2026-04-14-security-report-finalization-design.md` | Neu: Design-Spec für diese Finalisierung |
-
 ---
 
 ## 8. Empfehlungen — Zukünftige Erweiterungen
 
 | Priorität | Maßnahme | Aufwand |
 |-----------|---------|---------|
-| HOCH | PostgreSQL cert-manager PKI + Client-CA-Verifikation (`sslmode=verify-ca`) | MITTEL |
-| HOCH | Nextcloud + Meetings auf `sslmode=prefer` umstellen (Config-Dateien statt Env) | NIEDRIG |
+| HOCH | PostgreSQL-TLS intern (cert-manager) | MITTEL |
+| HOCH | TLS minVersion: VersionTLS12 explizit in Traefik | NIEDRIG |
 | MITTEL | Cilium mit WireGuard für Pod-to-Pod-TLS (Service Mesh) | HOCH |
-| MITTEL | Monitoring-Stack auf korczewski deployen (Prometheus/Grafana) + Default-Deny-Policies im `monitoring`-Namespace | MITTEL |
+| MITTEL | Monitoring-Namespace NetworkPolicies | NIEDRIG |
 | MITTEL | OPA Gatekeeper / Kyverno für Policy-Enforcement | MITTEL |
 | NIEDRIG | LUKS Full-Disk-Encryption auf Host-Ebene | MITTEL |
 | NIEDRIG | SBOM + Image-Vulnerability-Scanning (Trivy) | NIEDRIG |
-
----
-
-## 9. Fazit, Versionshistorie und Freigabe
-
-### 9.1 Fazit
-
-Der Workspace MVP erreicht nach der zweistufigen Härtung (v1.0 Netzwerk- und Container-Härtung, v1.1 Transport-Layer-Finalisierung) ein durchgängiges Sicherheitsniveau auf allen sieben OSI-Schichten sowie der Kubernetes-Querschnittsebene. Alle in §3 identifizierten kritischen Lücken (East-West-Traffic, Container-Privilegien, unauthentifizierte interne Tools) sind geschlossen; PostgreSQL-Server-TLS und explizite Traefik-TLS-Mindestversion vervollständigen den Transport-Layer. Die DSGVO-Kapitel (Art. 5, 25, 32, 33/34, 35 sowie die vollständige Betroffenenrechte-Matrix Art. 15–22) sind inhaltlich und technisch mit konkreten Nachweisen unterlegt. Die verbleibenden Restrisiken (Nextcloud/Meetings-Client-TLS, cert-manager-PKI, Monitoring-Stack-Deployment, physische Server-Absicherung) sind dokumentiert, priorisiert und in §8 als geplante Erweiterungen ausgewiesen. **Gesamtbewertung: HOCH.**
-
-### 9.2 Versionshistorie
-
-| Version | Datum | Änderungen |
-|---------|-------|-----------|
-| 1.0 | 2026-04-13 | Erstveröffentlichung. OSI-Schichtanalyse L1–L7, Kubernetes-Querschnitt, DSGVO Art. 5/25/32/33/34/35, Risikomatrix, Änderungs- und Empfehlungsliste. |
-| 1.1 | 2026-04-14 | PostgreSQL-Server-TLS (self-signed, opportunistisch), Traefik `TLSOption default` mit expliziter `minVersion: VersionTLS12`, Client-`sslmode=prefer` für Keycloak/Mattermost/Vaultwarden/Outline, Korrektur §3 (Monitoring-Namespace), neues Kapitel §9 (Fazit, Versionshistorie, Freigabe). Gesamtbewertung von HOCH bestätigt. |
-
-### 9.3 Freigabe
-
-| Rolle | Name | Datum | Unterschrift |
-|-------|------|-------|--------------|
-| Verantwortlicher (lt. Impressum) |   |   |   |
-| Technische Umsetzung (DevOps) |   |   |   |
-| Datenschutzkoordination |   |   |   |
-
-*Dieser Bericht dient als Nachweis der technischen und organisatorischen Maßnahmen gemäß Art. 32 DSGVO und ergänzt das Verarbeitungsverzeichnis (`docs/verarbeitungsverzeichnis.md`).*

--- a/docs/stripe.md
+++ b/docs/stripe.md
@@ -1,3 +1,17 @@
+<div class="page-hero">
+  <span class="page-hero-icon">💳</span>
+  <div class="page-hero-body">
+    <div class="page-hero-title">Stripe-Integration</div>
+    <p class="page-hero-desc">Zahlungsgateway-Konfiguration, Stripe Checkout, Webhook-Setup und Anbindung an Invoice Ninja für automatische Rechnungsstellung.</p>
+    <div class="page-hero-meta">
+      <span class="page-hero-tag">Website &amp; Admin</span>
+      <span class="page-hero-tag">Stripe</span>
+      <span class="page-hero-tag">Invoice Ninja</span>
+    </div>
+  </div>
+  <a href="#/" class="page-hero-back">← Übersicht</a>
+</div>
+
 # Stripe-Integration
 
 Die Website (mentolder.de / korczewski.de) nutzt Stripe fuer zwei unabhaengige Zahlungsflueesse:

--- a/docs/superpowers/plans/2026-04-16-docs-redesign.md
+++ b/docs/superpowers/plans/2026-04-16-docs-redesign.md
@@ -1,0 +1,911 @@
+# Docs Redesign — Mentolder Dark Theme Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Redesign the Docsify documentation with the Mentolder dark-navy/gold color scheme, automatic linked in-page TOC, and consistent page-hero sections on every page.
+
+**Architecture:** All styling lives in a single `<style>` block in `index.html` that fully overrides the Docsify Vue theme. A custom Docsify `doneEach` plugin auto-generates the in-page TOC from `h2` headings after every page render using safe DOM methods (no innerHTML with dynamic content). Pages without a `page-hero` HTML block receive one prepended to their content. Changes are applied to both `k3d/docs-content/` (served via ConfigMap) and mirrored to `docs/` + `docs-site/index.html`.
+
+**Tech Stack:** Docsify, vanilla CSS/JS, Inter + Merriweather (Google Fonts), Mermaid + Panzoom (unchanged)
+
+---
+
+## File Map
+
+| File | Action |
+|------|--------|
+| `k3d/docs-content/index.html` | Replace CSS + add Auto-TOC plugin + add Google Fonts |
+| `docs-site/index.html` | Identical copy of above |
+| `k3d/docs-content/architecture.md` | Add page-hero block at top |
+| `k3d/docs-content/migration.md` | Add page-hero block at top |
+| `k3d/docs-content/tests.md` | Add page-hero block at top |
+| `k3d/docs-content/scripts.md` | Add page-hero block at top |
+| `k3d/docs-content/stripe.md` | Add page-hero block at top |
+| `k3d/docs-content/admin-projekte.md` | Add page-hero block at top |
+| `k3d/docs-content/mcp-actions.md` | Add page-hero block at top |
+| `k3d/docs-content/verarbeitungsverzeichnis.md` | Add page-hero block at top |
+| `k3d/docs-content/security-report.md` | Add page-hero block at top |
+| `k3d/docs-content/test-anleitung-korczewski.md` | Add page-hero block at top |
+| `docs/architecture.md` | Mirror same page-hero as k3d/docs-content |
+| `docs/migration.md` | Mirror |
+| `docs/tests.md` | Mirror |
+| `docs/scripts.md` | Mirror |
+| `docs/stripe.md` | Mirror |
+| `docs/admin-projekte.md` | Mirror |
+| `docs/mcp-actions.md` | Mirror |
+| `docs/verarbeitungsverzeichnis.md` | Mirror |
+| `docs/security-report.md` | Mirror |
+| `docs/test-anleitung-korczewski.md` | Mirror |
+
+**Already have page-hero (CSS-only update, no content change needed):**
+`benutzerhandbuch.md`, `keycloak.md`, `database.md`, `security.md`, `troubleshooting.md`, `requirements.md`, `services.md`
+
+---
+
+## Task 1: Mentolder CSS Theme + Auto-TOC plugin in index.html
+
+**Files:**
+- Modify: `k3d/docs-content/index.html`
+- Modify: `docs-site/index.html`
+
+- [ ] **Step 1: Write new `k3d/docs-content/index.html`**
+
+Replace the entire file with the following. Note: the Auto-TOC plugin uses only `createElement` / `textContent` / `appendChild` — no dynamic innerHTML.
+
+```html
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8">
+  <title>Workspace MVP Documentation</title>
+  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
+  <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Merriweather:wght@400;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/docsify/lib/themes/vue.css">
+  <style>
+    /* ── Mentolder Tokens ───────────────────── */
+    :root {
+      --dark:         #0f1623;
+      --dark-light:   #1a2235;
+      --dark-lighter: #1e2d45;
+      --dark-border:  #2a3a52;
+      --gold:         #e8c870;
+      --gold-light:   #f0d88a;
+      --gold-dim:     rgba(232,200,112,0.10);
+      --light:        #e8e8f0;
+      --muted:        #aabbcc;
+      --muted-dark:   #8899aa;
+      --font-sans:    'Inter', 'Segoe UI', system-ui, sans-serif;
+      --font-serif:   'Merriweather', Georgia, serif;
+    }
+
+    /* ── Global ────────────────────────────── */
+    body {
+      font-family: var(--font-sans) !important;
+      background: #111827 !important;
+      color: var(--light) !important;
+    }
+
+    /* ── Sidebar ───────────────────────────── */
+    .sidebar {
+      background: var(--dark) !important;
+      border-right: 1px solid var(--dark-lighter) !important;
+    }
+    .sidebar .app-name {
+      font-family: var(--font-serif) !important;
+      font-size: 16px !important;
+      font-weight: 700 !important;
+      color: var(--gold) !important;
+      padding: 20px 16px 4px !important;
+      display: block;
+    }
+    .sidebar .app-name-link { color: var(--gold) !important; }
+    .sidebar-nav { padding: 0 0 24px !important; }
+    .sidebar-nav > ul { padding: 0 !important; }
+    .sidebar-nav > ul > li { margin: 0 !important; }
+    .sidebar-nav > ul > li > p,
+    .sidebar-nav > ul > li > strong {
+      font-size: 9px !important;
+      font-weight: 700 !important;
+      letter-spacing: 1.2px !important;
+      text-transform: uppercase !important;
+      color: #556070 !important;
+      padding: 14px 16px 5px !important;
+      margin: 0 !important;
+      display: block;
+    }
+    .sidebar-nav a {
+      color: var(--muted) !important;
+      font-size: 13px !important;
+      padding: 7px 16px !important;
+      display: block;
+      border-left: 2px solid transparent !important;
+      transition: all .15s !important;
+      text-decoration: none !important;
+    }
+    .sidebar-nav a:hover {
+      color: var(--light) !important;
+      background: var(--gold-dim) !important;
+    }
+    .sidebar-nav .active > a,
+    .sidebar-nav a.active {
+      color: var(--gold) !important;
+      background: rgba(232,200,112,.08) !important;
+      border-left-color: var(--gold) !important;
+      font-weight: 600 !important;
+    }
+    .sidebar-toggle { background: var(--dark) !important; border-color: var(--dark-border) !important; }
+    .sidebar-toggle span { background: var(--muted-dark) !important; }
+
+    /* ── Main Content Area ─────────────────── */
+    #main { background: #111827 !important; }
+    .content { max-width: 860px !important; }
+
+    /* ── Typography ────────────────────────── */
+    #main h1 {
+      font-family: var(--font-serif) !important;
+      font-size: 28px !important;
+      font-weight: 700 !important;
+      color: var(--gold-light) !important;
+      border-bottom: 1px solid var(--dark-lighter) !important;
+      padding-bottom: 12px !important;
+      margin-bottom: 24px !important;
+    }
+    #main h2 {
+      font-family: var(--font-serif) !important;
+      font-size: 20px !important;
+      font-weight: 700 !important;
+      color: var(--light) !important;
+      border-bottom: 1px solid var(--dark-lighter) !important;
+      padding-bottom: 10px !important;
+      margin: 36px 0 16px !important;
+    }
+    #main h3 {
+      font-size: 15px !important;
+      font-weight: 700 !important;
+      color: var(--light) !important;
+      margin: 24px 0 10px !important;
+    }
+    #main h4 {
+      font-size: 13px !important;
+      font-weight: 700 !important;
+      color: var(--muted) !important;
+      text-transform: uppercase !important;
+      letter-spacing: .6px !important;
+      margin: 18px 0 8px !important;
+    }
+    #main p  { color: var(--muted) !important; line-height: 1.75 !important; }
+    #main li { color: var(--muted) !important; line-height: 1.7  !important; }
+    #main strong { color: var(--light) !important; }
+
+    /* ── Links ──────────────────────────────── */
+    #main a       { color: var(--gold) !important; }
+    #main a:hover { color: var(--gold-light) !important; }
+
+    /* ── Tables ────────────────────────────── */
+    #main table { border-collapse: collapse !important; width: 100% !important; margin: 16px 0 !important; }
+    #main th {
+      background: var(--dark) !important;
+      color: var(--gold) !important;
+      font-size: 10px !important;
+      font-weight: 700 !important;
+      letter-spacing: .8px !important;
+      text-transform: uppercase !important;
+      padding: 9px 14px !important;
+      border-bottom: 1px solid var(--dark-border) !important;
+      text-align: left !important;
+    }
+    #main td {
+      color: var(--muted) !important;
+      padding: 8px 14px !important;
+      border-bottom: 1px solid var(--dark-lighter) !important;
+      font-size: 13.5px !important;
+    }
+    #main tr:hover td { background: var(--gold-dim) !important; }
+
+    /* ── Code ───────────────────────────────── */
+    #main code {
+      background: var(--dark) !important;
+      color: var(--gold) !important;
+      padding: 2px 7px !important;
+      border-radius: 4px !important;
+      font-size: 12.5px !important;
+      border: 1px solid var(--dark-border) !important;
+    }
+    #main pre {
+      background: var(--dark) !important;
+      border: 1px solid var(--dark-border) !important;
+      border-left: 3px solid var(--gold) !important;
+      border-radius: 0 8px 8px 0 !important;
+      padding: 16px 20px !important;
+    }
+    #main pre code {
+      background: transparent !important;
+      border: none !important;
+      color: #c9d1d9 !important;
+      padding: 0 !important;
+      font-size: 13px !important;
+    }
+
+    /* ── Blockquote / Callout ───────────────── */
+    #main blockquote {
+      background: rgba(232,200,112,.06) !important;
+      border-left: 3px solid var(--gold) !important;
+      border-radius: 0 6px 6px 0 !important;
+      padding: 12px 18px !important;
+      margin: 16px 0 !important;
+      color: var(--muted) !important;
+    }
+    #main blockquote p      { color: var(--muted) !important; margin: 0 !important; }
+    #main blockquote strong { color: var(--gold)  !important; }
+    #main hr { border-color: var(--dark-lighter) !important; margin: 28px 0 !important; }
+
+    /* ── Page Hero ──────────────────────────── */
+    .page-hero {
+      background: linear-gradient(135deg, var(--dark-light) 0%, #0f1a2e 100%);
+      border: 1px solid var(--dark-border);
+      border-left: 4px solid var(--gold);
+      border-radius: 10px;
+      padding: 20px 24px;
+      margin-bottom: 28px;
+      display: flex;
+      align-items: flex-start;
+      justify-content: space-between;
+      gap: 16px;
+    }
+    .page-hero-icon  { font-size: 32px; line-height: 1; flex-shrink: 0; margin-top: 2px; }
+    .page-hero-body  { flex: 1; }
+    .page-hero-title {
+      font-family: var(--font-serif);
+      font-size: 22px; font-weight: 700;
+      color: var(--gold-light);
+      margin-bottom: 6px; line-height: 1.2;
+    }
+    .page-hero-desc { font-size: 13.5px; color: var(--muted); line-height: 1.6; margin: 0; }
+    .page-hero-meta { display: flex; gap: 6px; flex-wrap: wrap; margin-top: 10px; }
+    .page-hero-tag {
+      font-size: 10px; font-weight: 600; letter-spacing: .4px;
+      background: var(--gold-dim); color: var(--gold);
+      border: 1px solid rgba(232,200,112,.25);
+      padding: 2px 9px; border-radius: 20px;
+    }
+    .page-hero-back {
+      font-size: 11px; color: var(--muted-dark);
+      white-space: nowrap; text-decoration: none !important;
+      padding: 4px 10px;
+      border: 1px solid var(--dark-border); border-radius: 5px;
+      flex-shrink: 0; transition: all .15s;
+    }
+    .page-hero-back:hover { color: var(--gold) !important; border-color: rgba(232,200,112,.3) !important; }
+
+    /* ── Auto-TOC Box ───────────────────────── */
+    .toc-box {
+      background: var(--dark);
+      border: 1px solid var(--dark-border);
+      border-radius: 8px;
+      padding: 16px 20px;
+      margin-bottom: 32px;
+    }
+    .toc-title {
+      font-size: 10px; font-weight: 700; letter-spacing: 1px;
+      color: var(--gold); text-transform: uppercase;
+      margin-bottom: 12px;
+      display: flex; align-items: center; gap: 8px;
+    }
+    .toc-title::after {
+      content: ''; flex: 1; height: 1px;
+      background: rgba(232,200,112,.2);
+    }
+    .toc-list {
+      display: grid; grid-template-columns: 1fr 1fr;
+      gap: 4px; list-style: none; margin: 0; padding: 0;
+    }
+    @media (max-width: 600px) { .toc-list { grid-template-columns: 1fr; } }
+    .toc-item a {
+      display: flex !important; align-items: center !important; gap: 7px !important;
+      font-size: 12.5px !important; color: var(--muted) !important;
+      text-decoration: none !important;
+      padding: 5px 8px !important; border-radius: 5px !important;
+      transition: all .12s !important; border: none !important;
+    }
+    .toc-item a:hover { background: var(--gold-dim) !important; color: var(--gold) !important; }
+    .toc-num {
+      font-size: 10px; font-weight: 700;
+      color: rgba(232,200,112,.5); min-width: 18px;
+    }
+
+    /* ── Homepage ───────────────────────────── */
+    .home-hero { text-align: center; padding: 40px 0 20px; }
+    .home-hero-tag {
+      display: inline-block; font-size: 11px; font-weight: 600; letter-spacing: .5px;
+      background: var(--gold-dim); color: var(--gold);
+      border: 1px solid rgba(232,200,112,.25);
+      padding: 4px 14px; border-radius: 20px; margin-bottom: 16px;
+    }
+    .home-hero-title {
+      font-family: var(--font-serif);
+      font-size: 38px; font-weight: 700; color: var(--gold-light);
+      margin-bottom: 14px; line-height: 1.15;
+    }
+    .home-hero-sub {
+      font-size: 15px; color: var(--muted);
+      max-width: 600px; margin: 0 auto 32px; line-height: 1.65;
+    }
+    .home-stats {
+      display: flex; gap: 0; justify-content: center; margin-bottom: 40px;
+      border: 1px solid var(--dark-border); border-radius: 10px;
+      overflow: hidden; background: var(--dark-light);
+    }
+    .home-stat {
+      flex: 1; display: flex; flex-direction: column; align-items: center;
+      padding: 18px 12px; border-right: 1px solid var(--dark-border);
+    }
+    .home-stat:last-child { border-right: none; }
+    .home-stat-value {
+      font-family: var(--font-serif); font-size: 22px; font-weight: 700;
+      color: var(--gold); line-height: 1;
+    }
+    .home-stat-label {
+      font-size: 10px; color: var(--muted-dark); margin-top: 4px;
+      font-weight: 600; text-transform: uppercase; letter-spacing: .5px;
+    }
+    .home-section { margin-bottom: 36px; }
+    .home-section-label {
+      display: block; font-size: 10px; font-weight: 700;
+      letter-spacing: 1.1px; text-transform: uppercase; color: var(--gold);
+      margin-bottom: 14px; padding-bottom: 8px;
+      border-bottom: 1px solid var(--dark-border);
+    }
+    .home-grid {
+      display: grid; grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+      gap: 12px;
+    }
+    .home-card {
+      background: var(--dark-light); border: 1px solid var(--dark-border);
+      border-radius: 8px; padding: 16px;
+      text-decoration: none !important; display: block; transition: all .15s;
+    }
+    .home-card:hover {
+      border-color: rgba(232,200,112,.35); background: rgba(26,34,53,.9);
+      transform: translateY(-2px); box-shadow: 0 6px 20px rgba(0,0,0,.3);
+    }
+    .home-card-icon  { font-size: 22px; display: block; margin-bottom: 8px; }
+    .home-card-title { font-size: 14px; font-weight: 700; color: var(--light) !important; display: block; margin-bottom: 4px; }
+    .home-card p, .home-card-desc { font-size: 12px; color: var(--muted-dark); line-height: 1.5; margin: 0; }
+
+    /* ── Mermaid Wrapper ────────────────────── */
+    .mermaid-wrapper {
+      position: relative; width: 100%; overflow: hidden;
+      border: 1px solid var(--dark-border); border-radius: 6px;
+      margin: 1em 0; background: var(--dark);
+    }
+    .mermaid-wrapper svg { display: block; width: 100% !important; height: auto !important; max-width: none !important; cursor: grab; }
+    .mermaid-wrapper svg:active { cursor: grabbing; }
+    .mermaid-zoom-hint {
+      position: absolute; bottom: 6px; right: 8px;
+      font-size: 11px; color: var(--muted-dark); pointer-events: none; user-select: none;
+    }
+    .mermaid-zoom-reset {
+      position: absolute; top: 6px; right: 8px; font-size: 11px;
+      padding: 2px 6px; background: var(--gold-dim);
+      border: 1px solid rgba(232,200,112,.3); color: var(--gold);
+      border-radius: 3px; cursor: pointer; display: none;
+    }
+    .mermaid-wrapper:hover .mermaid-zoom-reset { display: block; }
+    .mermaidTooltip {
+      background-color: var(--dark) !important; color: var(--gold) !important;
+      border: 1px solid var(--dark-border) !important; border-radius: 6px !important;
+      padding: 8px 12px !important; font-size: 12px !important; font-family: inherit !important;
+      max-width: 320px !important; line-height: 1.5 !important;
+      box-shadow: 0 4px 12px rgba(0,0,0,.6) !important; pointer-events: none;
+    }
+
+    /* ── Search ──────────────────────────────── */
+    .search input { background: var(--dark-light) !important; border: 1px solid var(--dark-border) !important; color: var(--light) !important; border-radius: 6px !important; }
+    .search .results-panel { background: var(--dark) !important; border: 1px solid var(--dark-border) !important; }
+    .search .matching-post { color: var(--muted) !important; border-bottom: 1px solid var(--dark-lighter) !important; }
+    .search .matching-post a { color: var(--gold) !important; }
+  </style>
+</head>
+<body>
+  <div id="app"></div>
+  <script>
+    window.$docsify = {
+      name: 'Workspace MVP',
+      repo: '',
+      loadSidebar: true,
+      subMaxLevel: 2,
+      search: { placeholder: 'Suchen\u2026', noData: 'Keine Ergebnisse.' },
+      plugins: [
+        /* Panzoom for Mermaid diagrams */
+        function(hook) {
+          hook.doneEach(function() {
+            setTimeout(function() {
+              document.querySelectorAll('.mermaid svg').forEach(function(svg) {
+                if (svg.dataset.panzoomApplied) return;
+                svg.dataset.panzoomApplied = '1';
+                var wrapper = document.createElement('div');
+                wrapper.className = 'mermaid-wrapper';
+                var hint = document.createElement('span');
+                hint.className = 'mermaid-zoom-hint';
+                hint.textContent = 'Scroll = Zoom \u00b7 Ziehen = Pan';
+                var resetBtn = document.createElement('button');
+                resetBtn.className = 'mermaid-zoom-reset';
+                resetBtn.textContent = 'Reset';
+                svg.parentNode.insertBefore(wrapper, svg);
+                wrapper.appendChild(svg);
+                wrapper.appendChild(hint);
+                wrapper.appendChild(resetBtn);
+                var pz = panzoom(svg, { maxZoom: 10, minZoom: 0.3, boundsPadding: 0.1 });
+                resetBtn.addEventListener('click', function() {
+                  pz.moveTo(0, 0);
+                  pz.zoomAbs(0, 0, 1);
+                });
+              });
+            }, 300);
+          });
+        },
+        /* Auto-TOC: builds a linked table of contents from h2 headings */
+        function(hook) {
+          hook.doneEach(function() {
+            var existing = document.querySelector('#main .auto-toc');
+            if (existing) existing.remove();
+
+            var headings = Array.from(document.querySelectorAll('#main h2'));
+            if (headings.length < 2) return;
+
+            var base = (window.location.hash.split('?')[0] || '#/').replace(/^#/, '') || '/';
+
+            /* Build TOC using only DOM methods (no dynamic innerHTML) */
+            var box = document.createElement('div');
+            box.className = 'toc-box auto-toc';
+
+            var titleEl = document.createElement('div');
+            titleEl.className = 'toc-title';
+            titleEl.textContent = 'Auf dieser Seite';
+            box.appendChild(titleEl);
+
+            var ul = document.createElement('ul');
+            ul.className = 'toc-list';
+
+            headings.forEach(function(h, i) {
+              var raw = h.textContent.trim();
+              var id = h.id || raw.toLowerCase()
+                .replace(/\u00e4/g,'ae').replace(/\u00c4/g,'ae')
+                .replace(/\u00f6/g,'oe').replace(/\u00d6/g,'oe')
+                .replace(/\u00fc/g,'ue').replace(/\u00dc/g,'ue')
+                .replace(/\u00df/g,'ss')
+                .replace(/\s+/g,'-').replace(/[^a-z0-9\-]/g,'');
+              if (!h.id) h.id = id;
+
+              var li = document.createElement('li');
+              li.className = 'toc-item';
+
+              var a = document.createElement('a');
+              a.href = '#' + base + '?id=' + id;
+
+              var num = document.createElement('span');
+              num.className = 'toc-num';
+              num.textContent = (i + 1) + '.';
+
+              a.appendChild(num);
+              a.appendChild(document.createTextNode('\u00a0' + raw));
+              li.appendChild(a);
+              ul.appendChild(li);
+            });
+
+            box.appendChild(ul);
+
+            var hero = document.querySelector('#main .page-hero');
+            var h1   = document.querySelector('#main h1');
+            var anchor = hero || h1;
+            if (anchor) {
+              anchor.insertAdjacentElement('afterend', box);
+            } else {
+              var main = document.querySelector('#main');
+              if (main) main.insertBefore(box, main.firstChild);
+            }
+          });
+        }
+      ]
+    };
+  </script>
+  <script src="//cdn.jsdelivr.net/npm/docsify/lib/docsify.min.js"></script>
+  <script src="//cdn.jsdelivr.net/npm/docsify/lib/plugins/search.min.js"></script>
+  <script src="//cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"></script>
+  <script src="//cdn.jsdelivr.net/npm/docsify-mermaid@2.0.1/dist/docsify-mermaid.js"></script>
+  <script src="//cdn.jsdelivr.net/npm/panzoom@9.4.3/dist/panzoom.min.js"></script>
+  <script>mermaid.initialize({ startOnLoad: false, useMaxWidth: true, securityLevel: 'loose' });</script>
+</body>
+</html>
+```
+
+- [ ] **Step 2: Copy to `docs-site/index.html`**
+
+```bash
+cp k3d/docs-content/index.html docs-site/index.html
+```
+
+- [ ] **Step 3: Verify locally**
+
+```bash
+cd k3d/docs-content && python3 -m http.server 3300 &
+```
+
+Open `http://localhost:3300` and confirm:
+- Dark navy background on body and sidebar
+- Sidebar brand name in gold serif font
+- Active sidebar link highlighted gold with left border
+- Homepage cards visible with dark background
+
+```bash
+kill %1
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add k3d/docs-content/index.html docs-site/index.html
+git commit -m "feat(docs): apply Mentolder dark-navy/gold theme + auto-TOC plugin"
+```
+
+---
+
+## Task 2: Add page-hero to architecture.md and migration.md
+
+**Files:**
+- Modify: `k3d/docs-content/architecture.md`
+- Modify: `k3d/docs-content/migration.md`
+- Modify: `docs/architecture.md`
+- Modify: `docs/migration.md`
+
+- [ ] **Step 1: Prepend page-hero to `k3d/docs-content/architecture.md`**
+
+The file currently starts with `# Architektur`. Insert the following block **before** that line (new content at the very top):
+
+```html
+<div class="page-hero">
+  <span class="page-hero-icon">🏗️</span>
+  <div class="page-hero-body">
+    <div class="page-hero-title">Architektur</div>
+    <p class="page-hero-desc">Systemübersicht, Kubernetes-Cluster-Topologie, Service-Abhängigkeiten und Infrastruktur-Design des Workspace MVP.</p>
+    <div class="page-hero-meta">
+      <span class="page-hero-tag">Für Administratoren</span>
+      <span class="page-hero-tag">Kubernetes</span>
+      <span class="page-hero-tag">Mermaid Diagramm</span>
+    </div>
+  </div>
+  <a href="#/" class="page-hero-back">← Übersicht</a>
+</div>
+
+```
+
+All existing content (`# Architektur` onwards) remains unchanged below.
+
+- [ ] **Step 2: Prepend page-hero to `k3d/docs-content/migration.md`**
+
+The file currently starts with `# Migration`. Insert before it:
+
+```html
+<div class="page-hero">
+  <span class="page-hero-icon">🚀</span>
+  <div class="page-hero-body">
+    <div class="page-hero-title">Migration</div>
+    <p class="page-hero-desc">Upgrade-Pfade, Datenmigration aus Slack/Teams/Google Workspace, Rollback-Strategien und Import-Skripte.</p>
+    <div class="page-hero-meta">
+      <span class="page-hero-tag">Für Administratoren</span>
+      <span class="page-hero-tag">Datenmigration</span>
+    </div>
+  </div>
+  <a href="#/" class="page-hero-back">← Übersicht</a>
+</div>
+
+```
+
+- [ ] **Step 3: Mirror to `docs/`**
+
+```bash
+cp k3d/docs-content/architecture.md docs/architecture.md
+cp k3d/docs-content/migration.md docs/migration.md
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add k3d/docs-content/architecture.md k3d/docs-content/migration.md \
+        docs/architecture.md docs/migration.md
+git commit -m "feat(docs): add page-hero to architecture and migration pages"
+```
+
+---
+
+## Task 3: Add page-hero to tests.md and scripts.md
+
+**Files:**
+- Modify: `k3d/docs-content/tests.md`
+- Modify: `k3d/docs-content/scripts.md`
+- Modify: `docs/tests.md`
+- Modify: `docs/scripts.md`
+
+- [ ] **Step 1: Prepend page-hero to `k3d/docs-content/tests.md`**
+
+The file currently starts with `# Tests`. Insert before it:
+
+```html
+<div class="page-hero">
+  <span class="page-hero-icon">✅</span>
+  <div class="page-hero-body">
+    <div class="page-hero-title">Tests</div>
+    <p class="page-hero-desc">Testframework, Testfall-Katalog (FA-01–FA-25, SA-01–SA-10, NFA-01–NFA-09, AK-03/04), Ausführung mit runner.sh und Report-Generierung.</p>
+    <div class="page-hero-meta">
+      <span class="page-hero-tag">Für Administratoren</span>
+      <span class="page-hero-tag">Bash + Playwright</span>
+      <span class="page-hero-tag">k3d Cluster</span>
+    </div>
+  </div>
+  <a href="#/" class="page-hero-back">← Übersicht</a>
+</div>
+
+```
+
+- [ ] **Step 2: Prepend page-hero to `k3d/docs-content/scripts.md`**
+
+The file currently starts with `# Skripte`. Insert before it:
+
+```html
+<div class="page-hero">
+  <span class="page-hero-icon">📜</span>
+  <div class="page-hero-body">
+    <div class="page-hero-title">Skripte</div>
+    <p class="page-hero-desc">Referenz aller Bash-Hilfsskripte im <code>scripts/</code>-Verzeichnis: Setup, Migration, DSGVO-Checks, MCP-Registrierung und Stripe.</p>
+    <div class="page-hero-meta">
+      <span class="page-hero-tag">Für Administratoren</span>
+      <span class="page-hero-tag">Bash</span>
+    </div>
+  </div>
+  <a href="#/" class="page-hero-back">← Übersicht</a>
+</div>
+
+```
+
+- [ ] **Step 3: Mirror to `docs/`**
+
+```bash
+cp k3d/docs-content/tests.md docs/tests.md
+cp k3d/docs-content/scripts.md docs/scripts.md
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add k3d/docs-content/tests.md k3d/docs-content/scripts.md \
+        docs/tests.md docs/scripts.md
+git commit -m "feat(docs): add page-hero to tests and scripts pages"
+```
+
+---
+
+## Task 4: Add page-hero to stripe.md, admin-projekte.md, mcp-actions.md
+
+**Files:**
+- Modify: `k3d/docs-content/stripe.md`
+- Modify: `k3d/docs-content/admin-projekte.md`
+- Modify: `k3d/docs-content/mcp-actions.md`
+- Modify: `docs/stripe.md` / `docs/admin-projekte.md` / `docs/mcp-actions.md`
+
+- [ ] **Step 1: Prepend page-hero to `k3d/docs-content/stripe.md`**
+
+File starts with `# Stripe-Integration`. Insert before it:
+
+```html
+<div class="page-hero">
+  <span class="page-hero-icon">💳</span>
+  <div class="page-hero-body">
+    <div class="page-hero-title">Stripe-Integration</div>
+    <p class="page-hero-desc">Zahlungsgateway-Konfiguration, Stripe Checkout, Webhook-Setup und Anbindung an Invoice Ninja für automatische Rechnungsstellung.</p>
+    <div class="page-hero-meta">
+      <span class="page-hero-tag">Website &amp; Admin</span>
+      <span class="page-hero-tag">Stripe</span>
+      <span class="page-hero-tag">Invoice Ninja</span>
+    </div>
+  </div>
+  <a href="#/" class="page-hero-back">← Übersicht</a>
+</div>
+
+```
+
+- [ ] **Step 2: Prepend page-hero to `k3d/docs-content/admin-projekte.md`**
+
+File starts with `# Projektmanagement-Admin`. Insert before it:
+
+```html
+<div class="page-hero">
+  <span class="page-hero-icon">📊</span>
+  <div class="page-hero-body">
+    <div class="page-hero-title">Projektmanagement-Admin</div>
+    <p class="page-hero-desc">Admin-Panel für Projekte, Teilprojekte und Aufgaben je Brand und Kunde. Buchungen, Termine und Nutzerverwaltung mit Keycloak OIDC.</p>
+    <div class="page-hero-meta">
+      <span class="page-hero-tag">Website &amp; Admin</span>
+      <span class="page-hero-tag">OIDC-gesichert</span>
+    </div>
+  </div>
+  <a href="#/" class="page-hero-back">← Übersicht</a>
+</div>
+
+```
+
+- [ ] **Step 3: Prepend page-hero to `k3d/docs-content/mcp-actions.md`**
+
+File starts with `# MCP-Aktionen Referenz`. Insert before it:
+
+```html
+<div class="page-hero">
+  <span class="page-hero-icon">🤖</span>
+  <div class="page-hero-body">
+    <div class="page-hero-title">MCP Actions</div>
+    <p class="page-hero-desc">Referenz aller Aktionen, die Claude Code über die verbundenen MCP-Server ausführen kann: Kubernetes, Postgres, Browser, Grafana, Prometheus.</p>
+    <div class="page-hero-meta">
+      <span class="page-hero-tag">Claude Code KI</span>
+      <span class="page-hero-tag">MCP Server</span>
+    </div>
+  </div>
+  <a href="#/" class="page-hero-back">← Übersicht</a>
+</div>
+
+```
+
+- [ ] **Step 4: Mirror to `docs/`**
+
+```bash
+cp k3d/docs-content/stripe.md docs/stripe.md
+cp k3d/docs-content/admin-projekte.md docs/admin-projekte.md
+cp k3d/docs-content/mcp-actions.md docs/mcp-actions.md
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add k3d/docs-content/stripe.md k3d/docs-content/admin-projekte.md k3d/docs-content/mcp-actions.md \
+        docs/stripe.md docs/admin-projekte.md docs/mcp-actions.md
+git commit -m "feat(docs): add page-hero to stripe, admin-projekte, mcp-actions pages"
+```
+
+---
+
+## Task 5: Add page-hero to verarbeitungsverzeichnis.md, security-report.md, test-anleitung-korczewski.md
+
+**Files:**
+- Modify: `k3d/docs-content/verarbeitungsverzeichnis.md`
+- Modify: `k3d/docs-content/security-report.md`
+- Modify: `k3d/docs-content/test-anleitung-korczewski.md`
+- Modify: mirrors in `docs/`
+
+- [ ] **Step 1: Prepend page-hero to `k3d/docs-content/verarbeitungsverzeichnis.md`**
+
+File starts with `# Verarbeitungsverzeichnis (Art. 30 DSGVO)`. Insert before it:
+
+```html
+<div class="page-hero">
+  <span class="page-hero-icon">📎</span>
+  <div class="page-hero-body">
+    <div class="page-hero-title">Verarbeitungsverzeichnis (Art. 30 DSGVO)</div>
+    <p class="page-hero-desc">Dokumentation aller Verarbeitungstätigkeiten personenbezogener Daten: Verantwortlicher, Zweck, Datenkategorien, Empfänger und Löschfristen.</p>
+    <div class="page-hero-meta">
+      <span class="page-hero-tag">DSGVO Art. 30</span>
+      <span class="page-hero-tag">Für Administratoren</span>
+    </div>
+  </div>
+  <a href="#/" class="page-hero-back">← Übersicht</a>
+</div>
+
+```
+
+- [ ] **Step 2: Prepend page-hero to `k3d/docs-content/security-report.md`**
+
+File starts with `# Sicherheitsbericht — Workspace MVP`. Insert before it:
+
+```html
+<div class="page-hero">
+  <span class="page-hero-icon">📋</span>
+  <div class="page-hero-body">
+    <div class="page-hero-title">Security Report</div>
+    <p class="page-hero-desc">Sicherheitsbericht zum Workspace MVP: Testergebnisse SA-01–SA-10, Schwachstellenanalyse, CVSS-Bewertungen und Härtungsmaßnahmen.</p>
+    <div class="page-hero-meta">
+      <span class="page-hero-tag">Sicherheit</span>
+      <span class="page-hero-tag">SA-Anforderungen</span>
+    </div>
+  </div>
+  <a href="#/" class="page-hero-back">← Übersicht</a>
+</div>
+
+```
+
+- [ ] **Step 3: Prepend page-hero to `k3d/docs-content/test-anleitung-korczewski.md`**
+
+File starts with `# Softwaretest Workspace`. Insert before it:
+
+```html
+<div class="page-hero">
+  <span class="page-hero-icon">🧪</span>
+  <div class="page-hero-body">
+    <div class="page-hero-title">Testanleitung</div>
+    <p class="page-hero-desc">Schritt-für-Schritt-Anleitung für Abnahmetests. Zugangsdaten, Service-Übersicht und zu prüfende Funktionen der Workspace-Plattform.</p>
+    <div class="page-hero-meta">
+      <span class="page-hero-tag">Für Mitarbeiter</span>
+      <span class="page-hero-tag">Abnahmetests</span>
+    </div>
+  </div>
+  <a href="#/" class="page-hero-back">← Übersicht</a>
+</div>
+
+```
+
+- [ ] **Step 4: Mirror to `docs/`**
+
+```bash
+cp k3d/docs-content/verarbeitungsverzeichnis.md docs/verarbeitungsverzeichnis.md
+cp k3d/docs-content/security-report.md docs/security-report.md
+cp k3d/docs-content/test-anleitung-korczewski.md docs/test-anleitung-korczewski.md
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add k3d/docs-content/verarbeitungsverzeichnis.md k3d/docs-content/security-report.md \
+        k3d/docs-content/test-anleitung-korczewski.md \
+        docs/verarbeitungsverzeichnis.md docs/security-report.md docs/test-anleitung-korczewski.md
+git commit -m "feat(docs): add page-hero to verarbeitungsverzeichnis, security-report, testanleitung"
+```
+
+---
+
+## Task 6: Final verification and deploy
+
+- [ ] **Step 1: Full spot-check across page types**
+
+```bash
+cd k3d/docs-content && python3 -m http.server 3300 &
+```
+
+Open `http://localhost:3300` and verify each of the following:
+
+| Page | Check |
+|------|-------|
+| Homepage (`/`) | Gold stats bar, dark cards, gold section labels |
+| Architektur | Page-hero visible, TOC appears below it, Mermaid diagram zoomable |
+| Services | Page-hero gold-styled (already had hero), TOC present |
+| Benutzerhandbuch | Page-hero gold-styled (already had hero), TOC present |
+| Stripe | New page-hero visible |
+| Verarbeitungsverzeichnis | New page-hero visible |
+| Any page with a table | Dark header row with gold uppercase text |
+| Any page with a `> **Tipp:**` | Gold left-border callout |
+| Any page with a code block | Dark bg, gold inline code, gold left-border on pre |
+
+```bash
+kill %1
+```
+
+- [ ] **Step 2: Commit spec and plan**
+
+```bash
+git add docs/superpowers/specs/2026-04-16-docs-redesign-design.md \
+        docs/superpowers/plans/2026-04-16-docs-redesign.md
+git commit -m "docs: add docs redesign spec and implementation plan"
+```
+
+- [ ] **Step 3: Deploy docs ConfigMap to live cluster**
+
+After the PR is merged to main, apply the docs ConfigMap and restart the pod:
+
+```bash
+kubectl patch configmap docs-content -n workspace \
+  --patch-file <(kubectl create configmap docs-content \
+    --from-file=k3d/docs-content/ --dry-run=client -o json | jq '.data') \
+  --type merge
+kubectl rollout restart deployment/docs -n workspace
+kubectl rollout status deployment/docs -n workspace
+```
+
+Expected: `deployment "docs" successfully rolled out`

--- a/docs/superpowers/specs/2026-04-16-docs-redesign-design.md
+++ b/docs/superpowers/specs/2026-04-16-docs-redesign-design.md
@@ -1,0 +1,110 @@
+---
+name: Docs Redesign — Mentolder Dark Theme
+description: Visuelles Redesign der Docsify-Docs mit Mentolder Dark-Navy/Gold-Farbschema, verlinktem In-Page-TOC und einheitlichen Page-Hero-Sektionen
+type: project
+---
+
+# Design: Docs Redesign — Mentolder Dark Theme
+
+**Datum:** 2026-04-16
+**Status:** Approved
+
+## Ziel
+
+Die Docsify-Dokumentation erhält ein grafisch ansprechendes Redesign, das das Mentolder-Farbschema (Dark Navy + Gold) konsequent verwendet. Jede Seite bekommt ein verlinktes Inhaltsverzeichnis und visuell hervorgehobene Abschnitte.
+
+## Farbschema (Mentolder)
+
+| Variable           | Wert                        | Verwendung                          |
+|--------------------|-----------------------------|-------------------------------------|
+| `--dark`           | `#0f1623`                   | Sidebar-Hintergrund, Code-Bg        |
+| `--dark-light`     | `#1a2235`                   | Hero-Bg, TOC-Box-Bg                 |
+| `--dark-lighter`   | `#243049` / `#1e2d45`       | Borders, Trennlinien, Hover         |
+| `--gold`           | `#e8c870`                   | Akzentfarbe, aktive Links, Badges   |
+| `--gold-light`     | `#f0d88a`                   | Hover-Gold                          |
+| `--gold-dim`       | `rgba(232,200,112,0.10–.15)`| Subtile Gold-Flächen                |
+| `--light`          | `#e8e8f0`                   | Haupt-Textfarbe                     |
+| `--muted`          | `#aabbcc`                   | Sekundärer Text, Tabellenzellen     |
+| `--muted-dark`     | `#8899aa`                   | Metadata, Tags                      |
+| Schriften          | Inter (sans), Merriweather (serif) | UI / Überschriften             |
+
+## Komponenten
+
+### 1. Globales CSS — `index.html`
+
+Das komplette Docsify-Styling wird in `index.html` per `<style>` definiert und überschreibt das Vue-Theme vollständig. Betrifft:
+
+- **`body`, `#main`** — dunkler Hintergrund `#111827`, helle Schrift
+- **`.sidebar`** — `#0f1623`, Gold-Akzent für aktive Links, Kategorie-Labels in Caps
+- **`h1`–`h3`** — Merriweather, `#e8e8f0`
+- **`a`** — `#e8c870`, Hover `#f0d88a`
+- **`table`** — dunkle Header (`#0f1623` + Gold-Text), Zeilen mit subtiler Gold-Hover-Fläche
+- **`code`, `pre`** — `#0f1623` Hintergrund, Gold-Text
+- **`blockquote`** — Gold-Linker-Rand, gedimmter Hintergrund
+
+### 2. Docsify-Plugin: Auto-TOC
+
+Ein Docsify-`hook.afterEach`-Plugin liest nach dem Rendern jeder Seite alle `h2`-Überschriften aus und injiziert automatisch eine `.toc-box` direkt nach dem `.page-hero`-Block (falls vorhanden) oder nach dem ersten `h1`. Die TOC-Box:
+
+- Nummerierte Einträge (`1.`, `2.`, …)
+- `<a href="#...">` mit korrekten Docsify-Anker-IDs
+- Grid-Layout 2-spaltig (ab 4 Einträgen)
+- Goldener Titel „Auf dieser Seite" mit Trennlinie
+
+### 3. Page-Hero-Klassen
+
+Jede Docs-Seite bekommt am Anfang einen HTML-Block:
+
+```html
+<div class="page-hero">
+  <span class="page-hero-icon">⚙️</span>
+  <div class="page-hero-body">
+    <div class="page-hero-title">Seitenname</div>
+    <p class="page-hero-desc">Kurzbeschreibung</p>
+    <div class="page-hero-tags">
+      <span class="page-hero-tag">Tag1</span>
+    </div>
+  </div>
+  <a href="#/" class="page-hero-back">← Übersicht</a>
+</div>
+```
+
+CSS: `linear-gradient(135deg, #1a2235, #0f1a2e)`, `border-left: 4px solid #e8c870`, `border-radius: 10px`.
+
+Seiten, die bereits einen `page-hero`-Block haben: `services.md` — nur CSS-Anpassung nötig.
+Seiten ohne Hero: alle anderen `.md`-Dateien in `k3d/docs-content/` — HTML-Block wird hinzugefügt.
+
+### 4. Sektions-Header-Stil
+
+`h2`-Überschriften erhalten automatisch über CSS:
+- `border-bottom: 1px solid #1e2d45`
+- Vorangestellte nummerierte Badge-Boxen werden vom Auto-TOC-Plugin eingefügt (`.section-num`)
+- Margin-Top `32px`, Padding-Bottom `10px`
+
+### 5. Callout-Blöcke
+
+`> **Tipp:**`-Blockquotes → Gold-Linker-Rand + `rgba(232,200,112,.07)` Hintergrund
+
+## Dateien
+
+| Datei | Änderung |
+|-------|----------|
+| `k3d/docs-content/index.html` | Komplett neues CSS-Theme, Auto-TOC-Plugin |
+| `docs-site/index.html` | Identische Änderung (Mirror) |
+| `k3d/docs-content/*.md` | Page-Hero-Blöcke hinzufügen (alle ohne Hero) |
+| `k3d/docs-content/README.md` | Bestehende Cards ans neue CSS anpassen |
+| `docs/*.md` | Mirror-Änderungen (sofern vorhanden) |
+
+## Was NICHT geändert wird
+
+- Sidebar-Struktur (`_sidebar.md`) — bleibt unverändert
+- Mermaid-Plugin und Panzoom — bleiben unverändert
+- Inhalt der `.md`-Dateien — nur Metadaten-Block am Anfang
+
+## Erfolgskriterien
+
+1. Alle Seiten haben Gold-Akzentfarbe, dunklen Hintergrund, sichtbaren Page-Hero
+2. Jede Seite zeigt automatisch ein verlinktes TOC (außer Seiten mit < 2 Überschriften)
+3. Tabellen, Code-Blöcke, Blockquotes folgen dem Farbschema
+4. Sidebar zeigt Gold-Akzent für aktiven Link, Kategorie-Labels klar abgesetzt
+5. `docs-site/index.html` und `k3d/docs-content/index.html` sind identisch

--- a/docs/test-anleitung-korczewski.md
+++ b/docs/test-anleitung-korczewski.md
@@ -1,3 +1,16 @@
+<div class="page-hero">
+  <span class="page-hero-icon">🧪</span>
+  <div class="page-hero-body">
+    <div class="page-hero-title">Testanleitung</div>
+    <p class="page-hero-desc">Schritt-für-Schritt-Anleitung für Abnahmetests. Zugangsdaten, Service-Übersicht und zu prüfende Funktionen der Workspace-Plattform.</p>
+    <div class="page-hero-meta">
+      <span class="page-hero-tag">Für Mitarbeiter</span>
+      <span class="page-hero-tag">Abnahmetests</span>
+    </div>
+  </div>
+  <a href="#/" class="page-hero-back">← Übersicht</a>
+</div>
+
 # Softwaretest Workspace – Anleitung für Testerinnen und Tester
 
 Herzlich willkommen und vielen Dank, dass Du Dir Zeit nimmst, die Workspace-Plattform
@@ -40,15 +53,17 @@ eingeloggt bist, wirst Du in den anderen automatisch erkannt.
 
 | Was?                                 | URL                              |
 |--------------------------------------|----------------------------------|
-| Zentraler Login (SSO)                | https://auth.korczewski.de       |
-| **Chat** (Mattermost)                | https://chat.korczewski.de       |
-| **Dateien & Kalender** (Nextcloud)   | https://files.korczewski.de      |
-| **Video­konferenz** (Nextcloud Talk) | https://meet.korczewski.de       |
+| Zentraler Login (SSO)                | [auth.korczewski.de](https://auth.korczewski.de) |
+| **Chat** (Mattermost)                | [chat.korczewski.de](https://chat.korczewski.de) |
+| **Dateien & Kalender** (Nextcloud)   | [files.korczewski.de](https://files.korczewski.de) |
+| **Video­konferenz** (Nextcloud Talk) | [meet.korczewski.de](https://meet.korczewski.de) |
 | **Office** (Word/Excel/PowerPoint)   | öffnet sich aus Nextcloud heraus |
-| **Whiteboard**                       | https://board.korczewski.de      |
-| **KI-Assistent** (Claude Code)       | https://ai.korczewski.de         |
-| **Wissensdatenbank** (Outline)       | https://wiki.korczewski.de       |
-| **Passwort-Safe** (Vaultwarden)      | https://vault.korczewski.de      |
+| **Whiteboard**                       | [board.korczewski.de](https://board.korczewski.de) |
+| **KI-Assistent** (Claude Code)       | [ai.korczewski.de](https://ai.korczewski.de) |
+| **Wissensdatenbank** (Outline)       | [wiki.korczewski.de](https://wiki.korczewski.de) |
+| **Passwort-Safe** (Vaultwarden)      | [vault.korczewski.de](https://vault.korczewski.de) |
+| **Dokumentation** (Handbuch)         | [docs.korczewski.de](https://docs.korczewski.de) |
+| **Bug-Meldung** (Fehler melden)      | [bug.korczewski.de](https://bug.korczewski.de) |
 
 Alle Dienste sind per HTTPS erreichbar und haben ein gültiges Zertifikat – Dein
 Browser sollte **keine** Sicherheitswarnung anzeigen. Falls doch: bitte
@@ -69,7 +84,7 @@ Am Ende dieser Anleitung findest Du einen **Rückmelde-Block** zum Ausfüllen.
 
 ### 1. Erster Login & Passwort ändern
 
-1. Öffne https://chat.korczewski.de
+1. Öffne [https://chat.korczewski.de](https://chat.korczewski.de)
 2. Klicke auf **"Anmelden mit Keycloak"**.
 3. Gib Deinen Benutzernamen (z. B. `martina.semmler`) und das Start-Passwort ein.
 4. Du wirst automatisch auf eine Seite geleitet, die Dich bittet, ein **neues
@@ -99,7 +114,7 @@ Nachrichten auf?
 
 ### 3. Dateien (Nextcloud)
 
-1. Öffne in einem **neuen Tab** https://files.korczewski.de
+1. Öffne in einem **neuen Tab** [https://files.korczewski.de](https://files.korczewski.de)
 2. Du solltest **ohne erneute Passwort-Eingabe** direkt in Nextcloud landen. Das
    ist das "Single Sign-On" in Aktion. Falls Du doch nochmal klicken musst:
    ganz normal, aber bitte kurz notieren.
@@ -130,7 +145,7 @@ oder Ihr Euch nicht gleichzeitig sehen könnt, bitte melden.
 
 ### 5. Videokonferenz (Nextcloud Talk)
 
-1. Öffne https://meet.korczewski.de
+1. Öffne [https://meet.korczewski.de](https://meet.korczewski.de)
 2. Klicke auf **"+ Neues Gespräch erstellen"**, vergib einen Namen
    (z. B. `Testmeeting`), und füge die beiden anderen Testnutzer als Teilnehmer
    hinzu.
@@ -146,14 +161,14 @@ oder Ihr Euch nicht gleichzeitig sehen könnt, bitte melden.
 
 ### 6. Whiteboard
 
-1. Öffne https://board.korczewski.de
+1. Öffne [https://board.korczewski.de](https://board.korczewski.de)
 2. Erstelle ein neues Board und male / schreibe ein bisschen.
 3. Teile den Board-Link (oder lade einen der anderen Tester ein, wenn die
    Oberfläche es anbietet) und schaut, ob Ihr gleichzeitig zeichnen könnt.
 
 ### 7. KI-Assistent (Claude Code)
 
-1. Öffne https://ai.korczewski.de
+1. Öffne [https://ai.korczewski.de](https://ai.korczewski.de)
 2. Logge Dich mit Deinem SSO-Account ein.
 3. Stelle eine einfache Frage, z. B.:
    * *"Fasse mir in drei Sätzen zusammen, was Nextcloud Talk ist."*
@@ -162,19 +177,27 @@ oder Ihr Euch nicht gleichzeitig sehen könnt, bitte melden.
 
 ### 8. Wiki / Wissensdatenbank (Outline)
 
-1. Öffne https://wiki.korczewski.de
+1. Öffne [https://wiki.korczewski.de](https://wiki.korczewski.de)
 2. Lege eine neue Seite an und schreibe 2–3 Sätze Testtext.
 3. Prüfe, ob die Seite für die anderen Tester sichtbar ist.
 
-### 9. Passwort-Safe (Vaultwarden)
+### 9. Dokumentation (Docs)
 
-1. Öffne https://vault.korczewski.de
+1. Öffne [https://docs.korczewski.de](https://docs.korczewski.de)
+2. Du wirst zur Keycloak-Anmeldeseite weitergeleitet – melde Dich mit Deinem SSO-Konto an.
+3. Nach dem Login siehst Du das interne Handbuch des Workspace.
+
+➡️ **Fragestellung:** Hat der SSO-Login funktioniert, ohne dass Du ein separates Passwort eingeben musstest?
+
+### 10. Passwort-Safe (Vaultwarden)
+
+1. Öffne [https://vault.korczewski.de](https://vault.korczewski.de)
 2. Registriere Dich **mit Deiner Test-E-Mail-Adresse** (Vaultwarden hat einen
    eigenen Master-Passwort-Flow – dieses Master-Passwort ist **nicht** dasselbe
    wie Dein SSO-Passwort, bitte extra notieren).
 3. Lege einen Test-Eintrag an, z. B. *"Test-Login für Beispielseite"*.
 
-### 10. Logout-Test
+### 11. Logout-Test
 
 1. Melde Dich in **einem** der Dienste ab (oben rechts auf Deinen Namen →
    "Abmelden").

--- a/docs/tests.md
+++ b/docs/tests.md
@@ -1,3 +1,17 @@
+<div class="page-hero">
+  <span class="page-hero-icon">✅</span>
+  <div class="page-hero-body">
+    <div class="page-hero-title">Tests</div>
+    <p class="page-hero-desc">Testframework, Testfall-Katalog (FA-01–FA-25, SA-01–SA-10, NFA-01–NFA-09, AK-03/04), Ausführung mit runner.sh und Report-Generierung.</p>
+    <div class="page-hero-meta">
+      <span class="page-hero-tag">Für Administratoren</span>
+      <span class="page-hero-tag">Bash + Playwright</span>
+      <span class="page-hero-tag">k3d Cluster</span>
+    </div>
+  </div>
+  <a href="#/" class="page-hero-back">← Übersicht</a>
+</div>
+
 # Tests
 
 ## Uebersicht
@@ -20,16 +34,16 @@ flowchart TB
     PR --> PBASH["fa:fa-terminal Bash-Tests ausfuehren"]
     PBASH --> JSON
 
-    style R fill:#2d6a4f,color:#fff
-    style L fill:#4a90d9,color:#fff
-    style PR fill:#d97706,color:#fff
-    style REP fill:#6b7280,color:#fff
-    style BOOT fill:#374151,color:#fff
-    style BASH fill:#8b5cf6,color:#fff
-    style PBASH fill:#8b5cf6,color:#fff
-    style PW fill:#0891b2,color:#fff
-    style JSON fill:#2d8659,color:#fff
-    style MD fill:#2d8659,color:#fff
+    style R fill:#0a1a0a,color:#b8e8b8
+    style L fill:#1b3766,color:#e8c870
+    style PR fill:#3a2000,color:#e8c870
+    style REP fill:#1f2937,color:#aabbcc
+    style BOOT fill:#1a1a2e,color:#aabbcc
+    style BASH fill:#2a1654,color:#e8c870
+    style PBASH fill:#2a1654,color:#e8c870
+    style PW fill:#083344,color:#e8c870
+    style JSON fill:#1a3d28,color:#e8c870
+    style MD fill:#1a3d28,color:#e8c870
 ```
 
 ## Ausfuehrung
@@ -80,11 +94,10 @@ flowchart TB
 | FA-19 | Outline Wiki | Wiki-Deployment, Keycloak-OIDC |
 | FA-20 | Finalisierung | Abschlusspruefungen |
 | FA-21 | Billing Workflows | Rechnungsworkflows |
-| FA-22 | Stripe Payment | Stripe als Zahlungsgateway |
+| FA-22 | Stripe Payment Gateway | Stripe als Zahlungsgateway in Invoice Ninja (nur Shell-Tests, kein Playwright-Spec) |
 | FA-23 | Vaultwarden | Passwort-Manager mit Keycloak SSO |
-| FA-24 | Whiteboard | Nextcloud Whiteboard (board.{domain}) |
+| FA-24 | Kollaboratives Whiteboard | Nextcloud Whiteboard (board.{domain}) |
 | FA-25 | Mailpit | Self-hosted SMTP-Server und Web-UI |
-| FA-26 | Bug Report Form | Fehler-Reporting Widget |
 
 ### Sicherheits-Tests (SA)
 
@@ -96,11 +109,7 @@ flowchart TB
 | SA-04--SA-07 | Autorisierung | Zugriffskontrolle und Berechtigungen |
 | SA-08 | SSO-Integration | Keycloak OIDC Flow |
 | SA-09 | Weitere Sicherheit | Zusaetzliche Sicherheitspruefungen |
-<<<<<<< HEAD
-| SA-10 | MCP-Authentifizierung | MCP-Server Auth-Proxy, Token-Validierung |
-=======
 | SA-10 | MCP-Endpunkt-Absicherung | ForwardAuth-Proxy, Bearer-Token, HTTP 401 ohne Token |
->>>>>>> origin/main
 
 ### Nicht-funktionale Tests (NFA)
 
@@ -113,8 +122,6 @@ flowchart TB
 | NFA-05 | Usability | Barrierefreiheit, UX |
 | NFA-06 | Datenbank-Konsistenz | DB-Integritaet |
 | NFA-07 | Logging & Monitoring | Log-Verfuegbarkeit |
-| NFA-08 | Backup & Recovery | Backup-CronJob, Verschluesselung, Wiederherstellung |
-| NFA-09 | Multi-Cluster | ArgoCD Sync, Cluster-Registrierung |
 
 ### Abnahme-Tests (AK)
 
@@ -158,7 +165,7 @@ siehe "Playwright gegen Produktion" unten.
 Bootstrap in `tests/lib/k3d.sh` angelegt) mit `MM_TEST_PASS` (Standard
 `Testpassword123!`), deaktiviert Onboarding/Tutorials, speichert Session.
 
-**Test-Specs (35 Dateien):**
+**Test-Specs (29 Dateien):**
 - `fa-01-messaging.spec.ts` -- DM- und Channel-Nachrichten
 - `fa-02-channels.spec.ts` -- Kanal-Erstellung, Berechtigungen
 - `fa-03-video.spec.ts` -- Nextcloud Talk / Signaling
@@ -176,23 +183,18 @@ Bootstrap in `tests/lib/k3d.sh` angelegt) mit `MM_TEST_PASS` (Standard
 - `fa-15-oidc.spec.ts` -- OIDC-Website-Login
 - `fa-16-booking.spec.ts` -- Kalender / Buchung
 - `fa-17-meeting.spec.ts` -- Meeting-Lifecycle
-- `fa-18-transcription.spec.ts` -- Whisper-Upload-API
+- `fa-18-transcription.spec.ts` -- Whisper-Upload-API (akzeptiert 404/405 für GET)
 - `fa-19-outline.spec.ts` -- Outline Wiki
 - `fa-20-finalize.spec.ts` -- Meeting-Finalisierung
 - `fa-21-billing.spec.ts` -- Service Catalog, Invoice-API
 - `fa-23-vaultwarden.spec.ts` -- Vaultwarden-Gesundheit
 - `fa-24-whiteboard.spec.ts` -- Whiteboard-Service
 - `fa-25-mailpit.spec.ts` -- Mailpit Web-UI und API
-- `fa-26-bug-report-form.spec.ts` -- Fehler-Reporting Widget
-- `fa-client-portal.spec.ts` -- Kunden-Portal (Login, Dokumente, Rechnungen)
-- `fa-document-signing.spec.ts` -- Dokumenten-Signierung
-- `fa-meeting-history.spec.ts` -- Meeting-Verlauf und Insights
-- `fa-slot-widget.spec.ts` -- Buchungs-Slot-Widget
 - `sa-02-auth.spec.ts` -- Falsches Passwort, SSO-Button
 - `sa-08-sso.spec.ts` -- Cross-Service-SSO (Browser)
 - `sa-10-mcp-auth.spec.ts` -- MCP-Statusseite ohne Auth
 - `nfa-05-usability.spec.ts` -- Mobile, Quick-Switcher
-- `integration-smoke.spec.ts` -- Cross-Service Smoke Tests
+- `integration-smoke.spec.ts` -- Cross-Service Smoke gegen Produktion
 
 **Hilfsfunktionen** (`specs/helpers.ts`):
 - `dismissOverlays(page)` -- Tour/Onboarding entfernen

--- a/docs/verarbeitungsverzeichnis.md
+++ b/docs/verarbeitungsverzeichnis.md
@@ -1,3 +1,16 @@
+<div class="page-hero">
+  <span class="page-hero-icon">📎</span>
+  <div class="page-hero-body">
+    <div class="page-hero-title">Verarbeitungsverzeichnis (Art. 30 DSGVO)</div>
+    <p class="page-hero-desc">Dokumentation aller Verarbeitungstätigkeiten personenbezogener Daten: Verantwortlicher, Zweck, Datenkategorien, Empfänger und Löschfristen.</p>
+    <div class="page-hero-meta">
+      <span class="page-hero-tag">DSGVO Art. 30</span>
+      <span class="page-hero-tag">Für Administratoren</span>
+    </div>
+  </div>
+  <a href="#/" class="page-hero-back">← Übersicht</a>
+</div>
+
 # Verarbeitungsverzeichnis (Art. 30 DSGVO)
 
 **Verantwortlicher:** Gemäß Impressum (`/impressum`)  

--- a/k3d/docs-content/admin-projekte.md
+++ b/k3d/docs-content/admin-projekte.md
@@ -1,3 +1,16 @@
+<div class="page-hero">
+  <span class="page-hero-icon">📊</span>
+  <div class="page-hero-body">
+    <div class="page-hero-title">Projektmanagement-Admin</div>
+    <p class="page-hero-desc">Admin-Panel für Projekte, Teilprojekte und Aufgaben je Brand und Kunde. Buchungen, Termine und Nutzerverwaltung mit Keycloak OIDC.</p>
+    <div class="page-hero-meta">
+      <span class="page-hero-tag">Website &amp; Admin</span>
+      <span class="page-hero-tag">OIDC-gesichert</span>
+    </div>
+  </div>
+  <a href="#/" class="page-hero-back">← Übersicht</a>
+</div>
+
 # Projektmanagement-Admin
 
 Das Admin-Panel unter `/admin/projekte` erlaubt die Verwaltung von Projekten, Teilprojekten

--- a/k3d/docs-content/architecture.md
+++ b/k3d/docs-content/architecture.md
@@ -2,22 +2,23 @@
   <span class="page-hero-icon">🏗️</span>
   <div class="page-hero-body">
     <div class="page-hero-title">Architektur</div>
-    <p class="page-hero-desc">Kubernetes-Systemübersicht, Service-Topologie und Datenflüsse des Workspace MVP — alle Komponenten on-premises, DSGVO-konform vernetzt.</p>
+    <p class="page-hero-desc">Systemübersicht, Kubernetes-Cluster-Topologie, Service-Abhängigkeiten und Infrastruktur-Design des Workspace MVP.</p>
     <div class="page-hero-meta">
-      <span class="page-hero-tag">k3d / k3s</span>
-      <span class="page-hero-tag">Traefik Ingress</span>
-      <span class="page-hero-tag">12+ Services</span>
-      <span class="page-hero-tag">PostgreSQL 16</span>
+      <span class="page-hero-tag">Für Administratoren</span>
+      <span class="page-hero-tag">Kubernetes</span>
+      <span class="page-hero-tag">Mermaid Diagramm</span>
     </div>
   </div>
   <a href="#/" class="page-hero-back">← Übersicht</a>
 </div>
 
+# Architektur
+
 ## Systemuebersicht
 
 Workspace MVP ist eine Kubernetes-basierte Kollaborationsplattform fuer kleine Teams. Alle Services laufen als Deployments in einem k3d/k3s Cluster mit Traefik als Ingress Controller. Daten bleiben vollstaendig on-premises (DSGVO by Design).
 
-> **Tipp:** Die Service-Boxen im Diagramm sind klickbar und fuehren zu den Detail-Abschnitten weiter unten.
+> **Tipp:** Die Service-Boxen im Diagramm sind klickbar und fuehren zur jeweiligen Service-Dokumentation. Hover zeigt eine Kurzbeschreibung.
 
 ```mermaid
 flowchart TB
@@ -161,31 +162,31 @@ flowchart TB
     IN -. "SMTP" .-> MP
 
     %% --- Klickbare Nodes ---
-    click KC "#keycloak" "Keycloak: Zentraler OIDC Identity Provider fuer SSO. Verwaltet Benutzer, Rollen und 8 OIDC-Clients. Speichert Sessions und Realm-Konfiguration in PostgreSQL."
-    click MM "#mattermost" "Mattermost: Team-Chat mit Channels, Threads und Dateifreigabe. Integriert OpenSearch fuer Volltextsuche, Webhooks fuer Automatisierung und Slash-Commands fuer billing-bot."
-    click NC "#nextcloud" "Nextcloud: Dateiverwaltung, Kalender, Kontakte und Videokonferenzen via Talk. WOPI-Integration mit Collabora fuer Office-Dokumente. WebRTC via HPB Stack."
-    click CO "#collabora" "Collabora Online: LibreOffice-basierter Office-Editor im Browser. Bearbeitet DOCX, XLSX, PPTX, ODT Dateien kollaborativ ueber WOPI-Protokoll mit Nextcloud."
-    click OC "#claude-code" "Claude Code: KI-Assistent mit Claude Sonnet 4. Nutzt MCP-Server fuer Kubernetes-Verwaltung, Datenbank-Abfragen und Browser-Automatisierung. RBAC-gesichert."
-    click IN "#invoice-ninja" "Invoice Ninja: Rechnungserstellung, Kundenverwaltung und Zahlungsabwicklung via Stripe. Geschuetzt durch oauth2-proxy. Eigene MariaDB-Instanz."
-    click VW "#vaultwarden" "Vaultwarden: Self-hosted Bitwarden-kompatibler Passwort-Manager. Speichert verschluesselte Vault-Items in PostgreSQL. OIDC-Login via Keycloak."
-    click BB "#billing-bot" "billing-bot: Go-Microservice. Verbindet Mattermost Slash-Commands mit Invoice Ninja API fuer schnelle Rechnungs- und Kundenerstellung aus dem Chat."
-    click OL "#outline" "Outline: Kollaboratives Wiki fuer Teamwissen. Markdown-basiert mit Echtzeit-Bearbeitung, verschachtelten Dokumenten und Volltextsuche. Redis fuer Sessions."
-    click WB "#whiteboard" "Whiteboard: Nextcloud-integriertes Whiteboard fuer visuelle Zusammenarbeit. Echtzeit-Kollaboration ueber WebSockets."
-    click MP "#mailpit" "Mailpit: SMTP-Testserver fuer Entwicklung. Faengt alle ausgehenden E-Mails ab (kein Versand). Web-UI zur Inspektion von Benachrichtigungen."
-    click DB "#datenbank-layout" "PostgreSQL 16 shared-db: 7 isolierte Datenbanken (keycloak, mattermost, nextcloud, vaultwarden, outline, website, pentest) mit eigenem User je Service."
-    click MARIA "#datenbank-layout" "MariaDB 11: Dedizierte Instanz fuer Invoice Ninja (benoetigt MySQL-Kompatibilitaet)."
-    click OS "#datenbank-layout" "OpenSearch 2.19: Elasticsearch-kompatibler Suchindex fuer Mattermost Volltextsuche und Autocomplete."
-    click WEB "#website" "Website: Astro + Svelte Unternehmenswebsite mit Kontaktformular (Mattermost Webhook), OIDC-Login, Stripe-Checkout und Admin-Panel (/admin/projekte)."
-    click PROM "#monitoring" "Prometheus: Metriken-Sammlung aller Kubernetes-Ressourcen. Speist DSGVO-Compliance-Dashboard."
-    click GRAF "#monitoring" "Grafana: Visualisierung der Prometheus-Metriken. Enthaelt DSGVO-Compliance-Dashboard (NFA-02)."
-    click WHISPER "#whisper" "Whisper: faster-whisper Transkriptionsservice fuer Audio-zu-Text Konvertierung."
-    click EMB "#embedding" "Embedding: infinity-emb Text-Vektorisierung (BAAI/bge-base-en-v1.5) fuer Meeting-Transkript-Analyse."
-    click REC "#talk-recording" "Talk Recording: Firefox/geckodriver-basierte Anruf-Aufzeichnung fuer Nextcloud Talk."
-    click SIG "#talk-hpb" "spreed-signaling: WebRTC-Signaling-Server fuer Nextcloud Talk Videokonferenzen."
-    click MCP_K8S "#claude-code" "MCP Kubernetes: Read-only Zugriff auf Pods, Deployments, Services, Logs. Kann Deployments neu starten (mit Genehmigung)."
-    click MCP_PG "#claude-code" "MCP Postgres: Superuser-Zugriff auf alle shared-db Datenbanken fuer Analyse und Debugging."
-    click MCP_GRAF "#claude-code" "MCP Grafana: Zugriff auf Grafana Dashboards und Metriken."
-    click MCP_PROM "#claude-code" "MCP Prometheus: Direkte PromQL-Abfragen fuer Cluster-Metriken."
+    click KC "#/keycloak" "Keycloak: Zentraler OIDC Identity Provider fuer SSO. Verwaltet Benutzer, Rollen und 8 OIDC-Clients. Speichert Sessions und Realm-Konfiguration in PostgreSQL."
+    click MM "#/services?id=mattermost-chat" "Mattermost: Team-Chat mit Channels, Threads und Dateifreigabe. Integriert OpenSearch fuer Volltextsuche, Webhooks fuer Automatisierung und Slash-Commands fuer billing-bot."
+    click NC "#/services?id=nextcloud-dateien-talk" "Nextcloud: Dateiverwaltung, Kalender, Kontakte und Videokonferenzen via Talk. WOPI-Integration mit Collabora fuer Office-Dokumente. WebRTC via HPB Stack."
+    click CO "#/services?id=collabora-online-office" "Collabora Online: LibreOffice-basierter Office-Editor im Browser. Bearbeitet DOCX, XLSX, PPTX, ODT Dateien kollaborativ ueber WOPI-Protokoll mit Nextcloud."
+    click OC "#/services?id=claude-code-ki-assistent" "Claude Code: KI-Assistent mit Claude Sonnet 4. Nutzt MCP-Server fuer Kubernetes-Verwaltung, Datenbank-Abfragen und Browser-Automatisierung. RBAC-gesichert."
+    click IN "#/services?id=invoice-ninja-rechnungen" "Invoice Ninja: Rechnungserstellung, Kundenverwaltung und Zahlungsabwicklung via Stripe. Geschuetzt durch oauth2-proxy. Eigene MariaDB-Instanz."
+    click VW "#/services?id=vaultwarden-passwoerter" "Vaultwarden: Self-hosted Bitwarden-kompatibler Passwort-Manager. Speichert verschluesselte Vault-Items in PostgreSQL. OIDC-Login via Keycloak."
+    click BB "#/services?id=billing-bot" "billing-bot: Go-Microservice. Verbindet Mattermost Slash-Commands mit Invoice Ninja API fuer schnelle Rechnungs- und Kundenerstellung aus dem Chat."
+    click OL "#/services?id=outline-wiki-optional" "Outline: Kollaboratives Wiki fuer Teamwissen. Markdown-basiert mit Echtzeit-Bearbeitung, verschachtelten Dokumenten und Volltextsuche. Redis fuer Sessions."
+    click WB "#/services?id=whiteboard" "Whiteboard: Nextcloud-integriertes Whiteboard fuer visuelle Zusammenarbeit. Echtzeit-Kollaboration ueber WebSockets."
+    click MP "#/services?id=mailpit-dev-mail" "Mailpit: SMTP-Testserver fuer Entwicklung. Faengt alle ausgehenden E-Mails ab (kein Versand). Web-UI zur Inspektion von Benachrichtigungen."
+    click DB "#/architecture?id=datenbank-layout" "PostgreSQL 16 shared-db: 7 isolierte Datenbanken (keycloak, mattermost, nextcloud, vaultwarden, outline, website, pentest) mit eigenem User je Service."
+    click MARIA "#/architecture?id=datenbank-layout" "MariaDB 11: Dedizierte Instanz fuer Invoice Ninja (benoetigt MySQL-Kompatibilitaet)."
+    click OS "#/architecture?id=datenbank-layout" "OpenSearch 2.19: Elasticsearch-kompatibler Suchindex fuer Mattermost Volltextsuche und Autocomplete."
+    click WEB "#/services?id=website-astro-svelte" "Website: Astro + Svelte Unternehmenswebsite mit Kontaktformular (Mattermost Webhook), OIDC-Login, Stripe-Checkout und Admin-Panel (/admin/projekte)."
+    click PROM "#/architecture?id=deployment-ablauf" "Prometheus: Metriken-Sammlung aller Kubernetes-Ressourcen. Speist DSGVO-Compliance-Dashboard."
+    click GRAF "#/architecture?id=deployment-ablauf" "Grafana: Visualisierung der Prometheus-Metriken. Enthaelt DSGVO-Compliance-Dashboard (NFA-02)."
+    click WHISPER "#/services?id=whisper-transkription-optional" "Whisper: faster-whisper Transkriptionsservice fuer Audio-zu-Text Konvertierung."
+    click EMB "#/services?id=embedding-text-vektorisierung" "Embedding: infinity-emb Text-Vektorisierung (BAAI/bge-base-en-v1.5) fuer Meeting-Transkript-Analyse."
+    click REC "#/services?id=talk-recording-anruf-aufzeichnung" "Talk Recording: Firefox/geckodriver-basierte Anruf-Aufzeichnung fuer Nextcloud Talk."
+    click SIG "#/services?id=talk-hpb-signaling" "spreed-signaling: WebRTC-Signaling-Server fuer Nextcloud Talk Videokonferenzen."
+    click MCP_K8S "#/services?id=claude-code-ki-assistent" "MCP Kubernetes: Read-only Zugriff auf Pods, Deployments, Services, Logs. Kann Deployments neu starten (mit Genehmigung)."
+    click MCP_PG "#/services?id=claude-code-ki-assistent" "MCP Postgres: Superuser-Zugriff auf alle shared-db Datenbanken fuer Analyse und Debugging."
+    click MCP_GRAF "#/services?id=claude-code-ki-assistent" "MCP Grafana: Zugriff auf Grafana Dashboards und Metriken."
+    click MCP_PROM "#/services?id=claude-code-ki-assistent" "MCP Prometheus: Direkte PromQL-Abfragen fuer Cluster-Metriken."
 
     %% --- Styles ---
     classDef identity_style fill:#1b3766,color:#e8c870,stroke:#2a5291

--- a/k3d/docs-content/index.html
+++ b/k3d/docs-content/index.html
@@ -31,7 +31,7 @@
 
     /* ---- Base ---------------------------------------------------------- */
     html, body {
-      background: #111827;
+      background: #111827 !important;
       color: var(--light);
       font-family: var(--font-sans);
     }
@@ -84,33 +84,37 @@
     }
     .content {
       color: var(--light);
+      max-width: 860px !important;
     }
 
     /* ---- Headings ------------------------------------------------------ */
-    h1 {
-      font-family: var(--font-serif);
-      font-weight: 700;
-      color: var(--gold-light);
-      border-bottom: 2px solid var(--dark-border);
-      padding-bottom: 0.4em;
-      margin-top: 0.5em;
+    #main h1 {
+      font-family: var(--font-serif) !important;
+      font-weight: 700 !important;
+      color: var(--gold-light) !important;
+      border-bottom: 2px solid var(--dark-border) !important;
+      padding-bottom: 0.4em !important;
+      margin-top: 0.5em !important;
     }
-    h2 {
-      font-family: var(--font-serif);
-      font-weight: 400;
-      color: var(--light);
-      border-bottom: 1px solid var(--gold);
-      padding-bottom: 0.25em;
+    #main h2 {
+      font-family: var(--font-serif) !important;
+      font-weight: 400 !important;
+      color: var(--light) !important;
+      border-bottom: 1px solid var(--gold) !important;
+      padding-bottom: 0.25em !important;
     }
-    h3 {
-      font-family: var(--font-sans);
-      font-weight: 600;
-      color: var(--light);
+    #main h3 {
+      font-family: var(--font-sans) !important;
+      font-weight: 600 !important;
+      color: var(--light) !important;
     }
-    h4 {
-      font-family: var(--font-sans);
-      font-weight: 500;
-      color: var(--muted);
+    #main h4 {
+      font-family: var(--font-sans) !important;
+      font-weight: 500 !important;
+      color: var(--muted) !important;
+    }
+    #main strong {
+      color: var(--light) !important;
     }
 
     /* ---- Links --------------------------------------------------------- */
@@ -131,12 +135,12 @@
     thead tr {
       background: var(--dark-lighter) !important;
     }
-    thead th {
+    #main thead th {
       color: var(--gold) !important;
       font-size: 0.72rem;
       font-weight: 700;
       letter-spacing: 0.08em;
-      text-transform: uppercase;
+      text-transform: uppercase !important;
       border: 1px solid var(--dark-border) !important;
       padding: 0.6em 0.9em;
     }
@@ -146,10 +150,10 @@
     tbody tr:hover {
       background: var(--gold-dim) !important;
     }
-    tbody td {
+    #main tbody td {
       border: 1px solid var(--dark-border) !important;
       padding: 0.5em 0.9em;
-      color: var(--light);
+      color: var(--light) !important;
     }
 
     /* ---- Code ---------------------------------------------------------- */

--- a/k3d/docs-content/index.html
+++ b/k3d/docs-content/index.html
@@ -7,96 +7,519 @@
   <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Syne:wght@700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Merriweather:ital,wght@0,300;0,400;0,700;1,400&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/docsify/lib/themes/vue.css">
   <style>
-    :root { --gold:#e8c870; --bg:#0f1623; --bg-deep:#0a0f1a; --border:#1e2d40; --border-dim:#243049; --text:#e8e8f0; --text-muted:#7a8fa8; --text-dim:#4a5e74; --sidebar-width:260px; --theme-color:#e8c870; }
-    *{box-sizing:border-box}
-    body{background:var(--bg);color:var(--text);font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;margin:0}
-    .sidebar{background:var(--bg-deep);border-right:1px solid var(--border-dim);padding:20px 0}
-    .sidebar-nav{padding:0 16px}.sidebar-nav ul{padding-left:16px;list-style:none}
-    .sidebar-nav li a{color:#aabbcc;text-decoration:none;font-size:.9rem;line-height:1.8}
-    .sidebar-nav li.active>a,.sidebar-nav li>a:hover{color:var(--gold)}
-    .sidebar>h1 a{color:var(--gold)!important;font-size:1.2rem;padding:0 16px;display:block}
-    .sidebar-toggle{background:var(--bg-deep);border:none}.sidebar-toggle span{background-color:var(--gold)}
-    .app-nav{background:var(--bg-deep);border-bottom:1px solid var(--border-dim)}
-    .app-nav a{color:#aabbcc;text-decoration:none}.app-nav a:hover{color:var(--gold)}
-    .content{padding:0 40px 60px;max-width:900px}
-    h1,h2,h3,h4,h5,h6{color:var(--text);border-bottom-color:var(--border-dim)}
-    .markdown-section>h1:first-child{font-family:'Syne',sans-serif;font-size:2.2rem;font-weight:800;color:var(--text);border:none;padding:40px 0 0;margin:0 0 6px;line-height:1.15}
-    .markdown-section>h1:first-child::after{content:'';display:block;width:36px;height:3px;background:var(--gold);margin-top:14px;border-radius:2px}
-    .markdown-section h2{font-family:'JetBrains Mono',monospace;font-size:.68rem;font-weight:500;color:var(--gold);text-transform:uppercase;letter-spacing:.2em;border-bottom:1px solid var(--border);padding:0 0 10px;margin:52px 0 22px}
-    .markdown-section h3{font-size:1.05rem;font-weight:600;color:#c8d8e8;margin:32px 0 12px;padding-left:12px;border-left:3px solid var(--border-dim)}
-    .markdown-section h4{font-family:'JetBrains Mono',monospace;font-size:.78rem;color:var(--text-muted);text-transform:uppercase;letter-spacing:.1em;margin:24px 0 8px}
-    a{color:var(--gold)}.markdown-section a{color:var(--gold)}
-    a:hover,.markdown-section a:hover{color:#f0d88a;text-decoration:none}
-    p{color:var(--text);line-height:1.75}.markdown-section>p{max-width:680px}
-    hr{border:none;border-top:1px solid var(--border);margin:40px 0}
-    blockquote{border:none;border-left:3px solid var(--gold);background:linear-gradient(90deg,rgba(232,200,112,.06) 0%,transparent 70%);border-radius:0 6px 6px 0;margin:24px 0;padding:14px 20px}
-    blockquote p{color:#b8cce0;font-size:.9rem;margin:0;line-height:1.6}
-    blockquote strong{color:var(--gold)}
-    code{font-family:'JetBrains Mono','Courier New',monospace;background:#151f2e;color:#b8d4f0;padding:2px 7px;border-radius:4px;font-size:.84em;border:1px solid var(--border)}
-    pre{background:#0d1520;border:1px solid var(--border);border-radius:8px;padding:20px;overflow-x:auto;margin:20px 0}
-    pre code{background:none;padding:0;border:none;color:#c8dff5;font-size:.85rem;line-height:1.65}
-    .markdown-section code{font-family:'JetBrains Mono','Courier New',monospace;background:#151f2e;color:#b8d4f0;padding:2px 7px;border-radius:4px;font-size:.84em;border:1px solid var(--border)}
-    .markdown-section pre{background:#0d1520;border:1px solid var(--border);border-radius:8px;padding:20px}
-    .markdown-section pre code{background:none;padding:0;border:none;color:#c8dff5}
-    table{border-collapse:collapse;width:100%;border:1px solid var(--border);border-radius:6px;overflow:hidden;margin:20px 0}
-    table th{background:#0d1520;color:var(--gold);padding:10px 14px;text-align:left;font-family:'JetBrains Mono',monospace;font-size:.75rem;text-transform:uppercase;letter-spacing:.08em;border-bottom:1px solid var(--border);white-space:nowrap}
-    table td{padding:9px 14px;border-bottom:1px solid var(--border);color:var(--text);font-size:.9rem;vertical-align:top}
-    table tr:last-child td{border-bottom:none}
-    table tr:nth-child(even) td{background:rgba(10,15,26,.4)}
-    table tr:hover td{background:rgba(232,200,112,.04)}
-    .markdown-section img{max-width:100%;border-radius:4px}
-    .markdown-section ul{padding-left:20px}.markdown-section ul li{color:var(--text);line-height:1.7;margin-bottom:4px}
-    .markdown-section ul li::marker{color:var(--gold)}
-    .markdown-section ol li{color:var(--text);line-height:1.7;margin-bottom:4px}
-    .markdown-section ol li::marker{color:var(--gold);font-family:'JetBrains Mono',monospace;font-size:.85em}
-    .anchor span{color:var(--gold)}
-    .search input{background:#151f2e;color:var(--text);border:1px solid var(--border-dim);border-radius:4px;padding:6px 10px;width:100%;font-family:'JetBrains Mono',monospace;font-size:.85rem}
-    .search input::placeholder{color:var(--text-dim)}.search .clear-button{color:var(--text-dim)}
-    .results-panel{background:var(--bg-deep);border:1px solid var(--border-dim);border-radius:4px}
-    .results-panel .matching-post{border-bottom:1px solid var(--border)}.results-panel .matching-post a{color:var(--gold)}
-    .mermaid{background:#0d1520;border:1px solid var(--border);border-radius:8px;padding:20px;margin:24px 0}
-    .mermaid svg{display:block;width:100%!important;height:auto!important;max-width:none!important;cursor:grab}
-    .mermaid svg:active{cursor:grabbing}
-    .mermaid-zoom-controls{display:flex;gap:6px;justify-content:flex-end;margin-top:6px}
-    .mermaid-zoom-btn{font-size:11px;padding:2px 8px;background:#151f2e;border:1px solid var(--border);border-radius:3px;color:#aabbcc;cursor:pointer;font-family:'JetBrains Mono',monospace}
-    .mermaid-zoom-btn:hover{border-color:var(--gold);color:var(--gold)}
-    /* HOME */
-    .home-hero{padding:56px 0 40px}.home-hero-tag{font-family:'JetBrains Mono',monospace;font-size:.7rem;color:var(--gold);letter-spacing:.18em;text-transform:uppercase;display:block;margin-bottom:18px}
-    .home-hero-title{font-family:'Syne',sans-serif;font-size:2.8rem;font-weight:800;color:var(--text);margin:0 0 14px;border:none!important;padding:0!important;line-height:1.1}
-    .home-hero-sub{color:var(--text-dim);font-size:.95rem;max-width:560px;margin:0;line-height:1.65}
-    .home-stats{display:grid;grid-template-columns:repeat(4,1fr);gap:0;margin:40px 0;border:1px solid var(--border);border-radius:6px;overflow:hidden}
-    .home-stat{padding:20px 24px;border-right:1px solid var(--border);background:var(--bg-deep)}.home-stat:last-child{border-right:none}
-    .home-stat-value{font-family:'Syne',sans-serif;font-size:1.5rem;font-weight:800;color:var(--gold);display:block}
-    .home-stat-label{font-family:'JetBrains Mono',monospace;font-size:.62rem;color:var(--text-dim);text-transform:uppercase;letter-spacing:.12em;margin-top:3px;display:block}
-    .home-section{margin:44px 0 0}
-    .home-section-label{font-family:'JetBrains Mono',monospace;font-size:.68rem;color:var(--gold);letter-spacing:.2em;text-transform:uppercase;margin-bottom:14px;display:flex;align-items:center;gap:14px}
-    .home-section-label::after{content:'';flex:1;height:1px;background:var(--border)}
-    .home-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(210px,1fr));gap:10px}
-    .home-card{display:block!important;background:var(--bg-deep);border:1px solid var(--border);border-radius:5px;padding:18px 20px;text-decoration:none!important;transition:border-color .15s,box-shadow .15s,transform .15s;position:relative;overflow:hidden}
-    .home-card::after{content:'→';position:absolute;top:18px;right:18px;font-size:.75rem;color:var(--border-dim);transition:color .15s,right .15s}
-    .home-card:hover{border-color:var(--gold);box-shadow:0 0 24px rgba(232,200,112,.07);transform:translateY(-2px);text-decoration:none!important}
-    .home-card:hover::after{color:var(--gold);right:14px}
-    .home-card-icon{font-size:1.25rem;margin-bottom:10px;display:block}
-    .home-card-title{font-family:'JetBrains Mono',monospace;font-size:.82rem;font-weight:500;color:#c8d8e8;margin:0 0 6px;display:block;transition:color .15s}
-    .home-card:hover .home-card-title{color:var(--gold)}
-    .home-card-desc{font-size:.75rem;color:var(--text-dim);margin:0;line-height:1.5}
-    /* PAGE HERO */
-    .page-hero{display:flex;align-items:flex-start;gap:20px;padding:40px 0 28px;border-bottom:1px solid var(--border);margin-bottom:4px}
-    .page-hero-icon{font-size:2.2rem;flex-shrink:0;margin-top:2px}
-    .page-hero-body{flex:1;min-width:0}
-    .page-hero-title{font-family:'Syne',sans-serif;font-size:2rem;font-weight:800;color:var(--text);margin:0 0 8px;border:none!important;padding:0!important;line-height:1.15}
-    .page-hero-title::after{display:none!important}
-    .page-hero-desc{color:var(--text-muted);font-size:.9rem;margin:0;line-height:1.6;max-width:600px}
-    .page-hero-meta{display:flex;gap:8px;flex-wrap:wrap;margin-top:14px}
-    .page-hero-tag{font-family:'JetBrains Mono',monospace;font-size:.65rem;color:var(--text-dim);background:var(--bg-deep);border:1px solid var(--border);border-radius:3px;padding:3px 8px;text-transform:uppercase;letter-spacing:.1em}
-    .page-hero-back{font-family:'JetBrains Mono',monospace;font-size:.68rem;color:var(--text-dim);text-decoration:none;white-space:nowrap;align-self:flex-start;padding-top:6px;transition:color .15s;flex-shrink:0}
-    .page-hero-back:hover{color:var(--gold);text-decoration:none}
-    .callout-tip{border-left-color:#4ade80!important;background:linear-gradient(90deg,rgba(74,222,128,.06) 0%,transparent 70%)!important}
-    .callout-warn{border-left-color:#fb923c!important;background:linear-gradient(90deg,rgba(251,146,60,.06) 0%,transparent 70%)!important}
-    .callout-info{border-left-color:#60a5fa!important;background:linear-gradient(90deg,rgba(96,165,250,.06) 0%,transparent 70%)!important}
-    @media(max-width:768px){.content{padding:0 20px 40px}.home-stats{grid-template-columns:repeat(2,1fr)}.home-hero-title,.page-hero-title{font-size:1.7rem}.page-hero{flex-direction:column;gap:12px}.page-hero-back{display:none}}
+    /* =====================================================================
+       MENTOLDER DARK-NAVY / GOLD THEME
+       ===================================================================== */
+
+    :root {
+      --dark:          #0f1623;
+      --dark-light:    #1a2235;
+      --dark-lighter:  #1e2d45;
+      --dark-border:   #2a3a52;
+      --gold:          #e8c870;
+      --gold-light:    #f0d88a;
+      --gold-dim:      rgba(232, 200, 112, 0.10);
+      --light:         #e8e8f0;
+      --muted:         #aabbcc;
+      --muted-dark:    #8899aa;
+      --font-sans:     'Inter', system-ui, -apple-system, sans-serif;
+      --font-serif:    'Merriweather', Georgia, serif;
+    }
+
+    /* ---- Base ---------------------------------------------------------- */
+    html, body {
+      background: #111827;
+      color: var(--light);
+      font-family: var(--font-sans);
+    }
+
+    /* ---- Sidebar ------------------------------------------------------- */
+    .sidebar {
+      background: var(--dark) !important;
+      border-right: 1px solid var(--dark-border) !important;
+    }
+    .sidebar .sidebar-nav a {
+      color: var(--muted) !important;
+      transition: color 0.15s;
+    }
+    .sidebar .sidebar-nav a:hover {
+      color: var(--gold-light) !important;
+    }
+    .sidebar .sidebar-nav li.active > a,
+    .sidebar .sidebar-nav a.active {
+      color: var(--gold) !important;
+      border-left: 3px solid var(--gold) !important;
+      padding-left: 0.6em;
+      font-weight: 600;
+    }
+    .sidebar h5,
+    .sidebar .sidebar-nav > ul > li > p,
+    .sidebar .sidebar-nav > ul > li > span {
+      font-size: 0.68rem;
+      font-weight: 700;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      color: var(--muted-dark) !important;
+      margin: 1.2em 0 0.3em;
+    }
+    .sidebar-toggle {
+      background: var(--dark) !important;
+    }
+    .sidebar-toggle span {
+      background-color: var(--muted) !important;
+    }
+    .app-name-link {
+      color: var(--gold) !important;
+      font-weight: 700 !important;
+      font-family: var(--font-serif) !important;
+    }
+
+    /* ---- Main content -------------------------------------------------- */
+    #main {
+      background: #111827 !important;
+      color: var(--light);
+    }
+    .content {
+      color: var(--light);
+    }
+
+    /* ---- Headings ------------------------------------------------------ */
+    h1 {
+      font-family: var(--font-serif);
+      font-weight: 700;
+      color: var(--gold-light);
+      border-bottom: 2px solid var(--dark-border);
+      padding-bottom: 0.4em;
+      margin-top: 0.5em;
+    }
+    h2 {
+      font-family: var(--font-serif);
+      font-weight: 400;
+      color: var(--light);
+      border-bottom: 1px solid var(--gold);
+      padding-bottom: 0.25em;
+    }
+    h3 {
+      font-family: var(--font-sans);
+      font-weight: 600;
+      color: var(--light);
+    }
+    h4 {
+      font-family: var(--font-sans);
+      font-weight: 500;
+      color: var(--muted);
+    }
+
+    /* ---- Links --------------------------------------------------------- */
+    a, .anchor span {
+      color: var(--gold) !important;
+    }
+    a:hover {
+      color: var(--gold-light) !important;
+      text-decoration: underline;
+    }
+
+    /* ---- Tables -------------------------------------------------------- */
+    table {
+      border-collapse: collapse;
+      width: 100%;
+      margin: 1em 0;
+    }
+    thead tr {
+      background: var(--dark-lighter) !important;
+    }
+    thead th {
+      color: var(--gold) !important;
+      font-size: 0.72rem;
+      font-weight: 700;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      border: 1px solid var(--dark-border) !important;
+      padding: 0.6em 0.9em;
+    }
+    tbody tr {
+      border-bottom: 1px solid var(--dark-border);
+    }
+    tbody tr:hover {
+      background: var(--gold-dim) !important;
+    }
+    tbody td {
+      border: 1px solid var(--dark-border) !important;
+      padding: 0.5em 0.9em;
+      color: var(--light);
+    }
+
+    /* ---- Code ---------------------------------------------------------- */
+    code {
+      background: var(--dark-lighter) !important;
+      color: var(--gold) !important;
+      border: 1px solid var(--dark-border) !important;
+      border-radius: 4px;
+      padding: 0.15em 0.4em;
+      font-size: 0.88em;
+    }
+    pre {
+      background: var(--dark-light) !important;
+      border-left: 4px solid var(--gold) !important;
+      border-radius: 6px;
+      padding: 1em 1.2em;
+      overflow-x: auto;
+    }
+    pre code {
+      background: transparent !important;
+      border: none !important;
+      padding: 0;
+      color: var(--light) !important;
+    }
+
+    /* ---- Blockquote ---------------------------------------------------- */
+    blockquote {
+      border-left: 4px solid var(--gold) !important;
+      background: var(--gold-dim) !important;
+      color: var(--muted) !important;
+      padding: 0.8em 1.2em;
+      border-radius: 0 6px 6px 0;
+      margin: 1em 0;
+    }
+    blockquote p {
+      margin: 0;
+    }
+
+    /* ---- Page Hero ----------------------------------------------------- */
+    .page-hero {
+      background: linear-gradient(135deg, var(--dark-light) 0%, var(--dark) 100%);
+      border-left: 4px solid var(--gold);
+      border-radius: 0 10px 10px 0;
+      padding: 1.6em 2em;
+      margin: 0 0 2em;
+      display: flex;
+      align-items: flex-start;
+      gap: 1.2em;
+    }
+    .page-hero-icon {
+      font-size: 2.4rem;
+      line-height: 1;
+      flex-shrink: 0;
+    }
+    .page-hero-body {
+      flex: 1;
+    }
+    .page-hero-title {
+      font-family: var(--font-serif);
+      font-size: 1.6rem;
+      font-weight: 700;
+      color: var(--gold-light);
+      margin: 0 0 0.3em;
+    }
+    .page-hero-desc {
+      color: var(--muted);
+      font-size: 0.95rem;
+      margin: 0 0 0.6em;
+      line-height: 1.6;
+    }
+    .page-hero-meta {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.4em;
+      margin-top: 0.5em;
+    }
+    .page-hero-tag {
+      display: inline-block;
+      background: var(--gold-dim);
+      color: var(--gold);
+      border: 1px solid rgba(232, 200, 112, 0.25);
+      border-radius: 20px;
+      padding: 0.15em 0.7em;
+      font-size: 0.72rem;
+      font-weight: 600;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+    }
+    .page-hero-back {
+      display: inline-block;
+      color: var(--muted-dark) !important;
+      font-size: 0.8rem;
+      margin-bottom: 0.5em;
+      text-decoration: none !important;
+    }
+    .page-hero-back:hover {
+      color: var(--gold) !important;
+    }
+
+    /* ---- TOC Box ------------------------------------------------------- */
+    .toc-box {
+      background: var(--dark-light);
+      border: 1px solid var(--dark-border);
+      border-top: 3px solid var(--gold);
+      border-radius: 8px;
+      padding: 1.2em 1.5em;
+      margin: 2em 0;
+    }
+    .toc-title {
+      font-size: 0.72rem;
+      font-weight: 700;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      color: var(--gold);
+      margin: 0 0 0.8em;
+    }
+    .toc-list {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+      gap: 0.3em 1.5em;
+    }
+    .toc-item {
+      margin: 0;
+    }
+    .toc-item a {
+      color: var(--muted) !important;
+      text-decoration: none !important;
+      font-size: 0.875rem;
+      display: flex;
+      align-items: baseline;
+      gap: 0.4em;
+      padding: 0.2em 0;
+      transition: color 0.15s;
+    }
+    .toc-item a:hover {
+      color: var(--gold-light) !important;
+    }
+    .toc-num {
+      color: var(--gold);
+      font-size: 0.75rem;
+      font-weight: 600;
+      flex-shrink: 0;
+      min-width: 1.4em;
+    }
+
+    /* ---- Home Hero ----------------------------------------------------- */
+    .home-hero {
+      text-align: center;
+      padding: 3em 1em 2em;
+    }
+    .home-hero-tag {
+      display: inline-block;
+      background: var(--gold-dim);
+      color: var(--gold);
+      border: 1px solid rgba(232, 200, 112, 0.3);
+      border-radius: 20px;
+      padding: 0.25em 1em;
+      font-size: 0.75rem;
+      font-weight: 700;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+      margin-bottom: 0.8em;
+    }
+    .home-hero-title {
+      font-family: var(--font-serif);
+      font-size: 2.4rem;
+      font-weight: 700;
+      color: var(--gold-light);
+      margin: 0 0 0.5em;
+      line-height: 1.2;
+    }
+    .home-hero-sub {
+      color: var(--muted);
+      font-size: 1.05rem;
+      max-width: 600px;
+      margin: 0 auto;
+      line-height: 1.7;
+    }
+
+    /* ---- Home Stats ---------------------------------------------------- */
+    .home-stats {
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: center;
+      gap: 1.5em;
+      padding: 1.5em 0;
+      border-top: 1px solid var(--dark-border);
+      border-bottom: 1px solid var(--dark-border);
+      margin: 1.5em 0;
+    }
+    .home-stat {
+      text-align: center;
+    }
+    .home-stat-value {
+      font-size: 1.8rem;
+      font-weight: 700;
+      color: var(--gold);
+      font-family: var(--font-serif);
+    }
+    .home-stat-label {
+      font-size: 0.75rem;
+      color: var(--muted-dark);
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+    }
+
+    /* ---- Home Sections & Cards ---------------------------------------- */
+    .home-section {
+      margin: 2em 0;
+    }
+    .home-section-label {
+      font-size: 0.68rem;
+      font-weight: 700;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      color: var(--gold);
+      margin-bottom: 0.8em;
+      padding-bottom: 0.4em;
+      border-bottom: 1px solid var(--dark-border);
+    }
+    .home-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+      gap: 1em;
+    }
+    .home-card {
+      background: var(--dark-light);
+      border: 1px solid var(--dark-border);
+      border-radius: 8px;
+      padding: 1.2em 1.4em;
+      text-decoration: none !important;
+      display: block;
+      transition: border-color 0.15s, transform 0.15s;
+    }
+    .home-card:hover {
+      border-color: var(--gold);
+      transform: translateY(-2px);
+    }
+    .home-card-icon {
+      font-size: 1.5rem;
+      margin-bottom: 0.4em;
+    }
+    .home-card-title {
+      font-weight: 600;
+      color: var(--light) !important;
+      margin-bottom: 0.3em;
+      font-size: 0.95rem;
+    }
+    .home-card-desc {
+      color: var(--muted-dark);
+      font-size: 0.82rem;
+      line-height: 1.5;
+    }
+
+    /* ---- Mermaid ------------------------------------------------------- */
+    .mermaid-wrapper {
+      position: relative;
+      width: 100%;
+      overflow: hidden;
+      border: 1px solid var(--dark-border);
+      border-radius: 6px;
+      margin: 1em 0;
+      background: var(--dark-light);
+    }
+    .mermaid-wrapper svg {
+      display: block;
+      width: 100% !important;
+      height: auto !important;
+      max-width: none !important;
+      cursor: grab;
+    }
+    .mermaid-wrapper svg:active {
+      cursor: grabbing;
+    }
+    .mermaid-zoom-hint {
+      position: absolute;
+      bottom: 6px;
+      right: 8px;
+      font-size: 11px;
+      color: var(--muted-dark);
+      pointer-events: none;
+      user-select: none;
+    }
+    .mermaid-zoom-reset {
+      position: absolute;
+      top: 6px;
+      right: 8px;
+      font-size: 11px;
+      padding: 2px 6px;
+      background: rgba(0, 0, 0, 0.35);
+      border: 1px solid var(--dark-border);
+      border-radius: 3px;
+      cursor: pointer;
+      display: none;
+      color: var(--muted);
+    }
+    .mermaid-wrapper:hover .mermaid-zoom-reset {
+      display: block;
+    }
+    .mermaidTooltip {
+      background-color: var(--dark-light) !important;
+      color: var(--gold) !important;
+      border: 1px solid var(--dark-border) !important;
+      border-radius: 6px !important;
+      padding: 8px 12px !important;
+      font-size: 12px !important;
+      font-family: inherit !important;
+      max-width: 320px !important;
+      line-height: 1.5 !important;
+      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.6) !important;
+      pointer-events: none;
+    }
+
+    /* ---- Search -------------------------------------------------------- */
+    .search {
+      background: var(--dark-lighter) !important;
+      border-bottom: 1px solid var(--dark-border) !important;
+    }
+    .search input {
+      background: var(--dark) !important;
+      color: var(--light) !important;
+      border: 1px solid var(--dark-border) !important;
+      border-radius: 4px;
+    }
+    .search input::placeholder {
+      color: var(--muted-dark) !important;
+    }
+    .search .matching-post {
+      background: var(--dark-light) !important;
+      border-bottom: 1px solid var(--dark-border) !important;
+    }
+    .search .matching-post:hover {
+      background: var(--gold-dim) !important;
+    }
+    .search .matching-post h2 {
+      color: var(--gold) !important;
+      font-size: 0.95rem !important;
+      border: none !important;
+    }
+    .search .matching-post p {
+      color: var(--muted) !important;
+      font-size: 0.82rem;
+    }
+    mark {
+      background: rgba(232, 200, 112, 0.3) !important;
+      color: var(--gold-light) !important;
+      border-radius: 2px;
+    }
+
+    /* ---- Miscellaneous ------------------------------------------------- */
+    hr {
+      border: none;
+      border-top: 1px solid var(--dark-border);
+      margin: 2em 0;
+    }
+    .markdown-section {
+      color: var(--light);
+    }
+    .cover-main {
+      background: var(--dark) !important;
+    }
+    nav.app-nav a {
+      color: var(--muted) !important;
+    }
+    nav.app-nav a:hover {
+      color: var(--gold) !important;
+    }
   </style>
 </head>
 <body>
@@ -107,71 +530,117 @@
       repo: '',
       loadSidebar: true,
       subMaxLevel: 2,
-      markdown: {
-        renderer: {
-          code: function(code, lang) {
-            if (lang === 'mermaid') {
-              return '<div class="mermaid">' + code + '</div>';
+      search: {
+        maxAge: 86400000,
+        paths: 'auto',
+        placeholder: 'Suchen …',
+        noData: 'Kein Ergebnis',
+        depth: 3
+      },
+      plugins: [
+        /* ---- Mermaid Panzoom ------------------------------------------ */
+        function(hook) {
+          hook.doneEach(function() {
+            setTimeout(function() {
+              document.querySelectorAll('.mermaid svg').forEach(function(svg) {
+                if (svg.dataset.panzoomApplied) return;
+                svg.dataset.panzoomApplied = '1';
+
+                var wrapper = document.createElement('div');
+                wrapper.className = 'mermaid-wrapper';
+
+                var hint = document.createElement('span');
+                hint.className = 'mermaid-zoom-hint';
+                hint.textContent = 'Scroll = Zoom · Ziehen = Pan';
+
+                var resetBtn = document.createElement('button');
+                resetBtn.className = 'mermaid-zoom-reset';
+                resetBtn.textContent = 'Reset';
+
+                svg.parentNode.insertBefore(wrapper, svg);
+                wrapper.appendChild(svg);
+                wrapper.appendChild(hint);
+                wrapper.appendChild(resetBtn);
+
+                var pz = panzoom(svg, { maxZoom: 10, minZoom: 0.3, boundsPadding: 0.1 });
+
+                resetBtn.addEventListener('click', function() {
+                  pz.moveTo(0, 0);
+                  pz.zoomAbs(0, 0, 1);
+                });
+              });
+            }, 300);
+          });
+        },
+        /* ---- Auto-TOC -------------------------------------------------- */
+        function(hook) {
+          hook.doneEach(function() {
+            var existing = document.querySelector('#main .auto-toc');
+            if (existing) existing.remove();
+
+            var headings = Array.from(document.querySelectorAll('#main h2'));
+            if (headings.length < 2) return;
+
+            var base = (window.location.hash.split('?')[0] || '#/').replace(/^#/, '') || '/';
+
+            var box = document.createElement('div');
+            box.className = 'toc-box auto-toc';
+
+            var titleEl = document.createElement('div');
+            titleEl.className = 'toc-title';
+            titleEl.textContent = 'Auf dieser Seite';
+            box.appendChild(titleEl);
+
+            var ul = document.createElement('ul');
+            ul.className = 'toc-list';
+
+            headings.forEach(function(h, i) {
+              var raw = h.textContent.trim();
+              var id = h.id || raw.toLowerCase()
+                .replace(/\u00e4/g, 'ae').replace(/\u00c4/g, 'ae')
+                .replace(/\u00f6/g, 'oe').replace(/\u00d6/g, 'oe')
+                .replace(/\u00fc/g, 'ue').replace(/\u00dc/g, 'ue')
+                .replace(/\u00df/g, 'ss')
+                .replace(/\s+/g, '-').replace(/[^a-z0-9\-]/g, '');
+              if (!h.id) h.id = id;
+
+              var li = document.createElement('li');
+              li.className = 'toc-item';
+
+              var a = document.createElement('a');
+              a.href = '#' + base + '?id=' + id;
+
+              var num = document.createElement('span');
+              num.className = 'toc-num';
+              num.textContent = (i + 1) + '.';
+
+              a.appendChild(num);
+              a.appendChild(document.createTextNode('\u00a0' + raw));
+              li.appendChild(a);
+              ul.appendChild(li);
+            });
+
+            box.appendChild(ul);
+
+            var hero = document.querySelector('#main .page-hero');
+            var h1   = document.querySelector('#main h1');
+            var anchor = hero || h1;
+            if (anchor) {
+              anchor.insertAdjacentElement('afterend', box);
+            } else {
+              var main = document.querySelector('#main');
+              if (main) main.insertBefore(box, main.firstChild);
             }
-            return this.origin.code.apply(this, arguments);
-          }
+          });
         }
-      }
+      ],
     }
   </script>
   <script src="//cdn.jsdelivr.net/npm/docsify/lib/docsify.min.js"></script>
-  <script src="//cdn.jsdelivr.net/npm/panzoom@9.4.3/dist/panzoom.min.js"></script>
+  <script src="//cdn.jsdelivr.net/npm/docsify/lib/plugins/search.min.js"></script>
   <script src="//cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"></script>
-  <script>
-    mermaid.initialize({
-      startOnLoad: false,
-      securityLevel: 'loose',
-      theme: 'dark',
-      themeVariables: {
-        background: '#0d1520', mainBkg: '#111827', nodeBorder: '#1e2d40',
-        clusterBkg: '#0f1623', clusterBorder: '#e8c870', edgeLabelBackground: '#111827',
-        lineColor: '#e8c870', textColor: '#e8e8f0', primaryColor: '#1b3766',
-        primaryTextColor: '#e8c870', primaryBorderColor: '#2a5291',
-        secondaryColor: '#1a3d28', secondaryTextColor: '#e8c870',
-        tertiaryColor: '#2a1654', tertiaryTextColor: '#e8c870',
-        actorBkg: '#1b3766', actorBorder: '#2a5291', actorTextColor: '#e8c870',
-        actorLineColor: '#e8c870', signalColor: '#e8c870', signalTextColor: '#e8e8f0',
-        labelBoxBkgColor: '#111827', labelBoxBorderColor: '#1e2d40', labelTextColor: '#e8e8f0',
-        loopTextColor: '#e8e8f0', noteBorderColor: '#e8c870', noteBkgColor: '#111827',
-        noteTextColor: '#e8e8f0', activationBorderColor: '#e8c870', activationBkgColor: '#1e2d40',
-        sequenceNumberColor: '#0a0f1a', pieTextColor: '#e8e8f0',
-        pieLegendTextColor: '#e8e8f0', pieLabelTextColor: '#e8e8f0',
-      }
-    });
-    window.$docsify.plugins = [].concat(function(hook) {
-      hook.doneEach(function() {
-        mermaid.run({ querySelector: '.mermaid' }).then(function() {
-          document.querySelectorAll('.mermaid svg').forEach(function(svg) {
-            if (svg.dataset.panzoomApplied) return;
-            svg.dataset.panzoomApplied = '1';
-            var pz = panzoom(svg, { maxZoom: 8, minZoom: 0.3, boundsPadding: 0.1 });
-            var controls = document.createElement('div');
-            controls.className = 'mermaid-zoom-controls';
-            var resetBtn = document.createElement('button');
-            resetBtn.className = 'mermaid-zoom-btn';
-            resetBtn.textContent = 'Reset Zoom';
-            resetBtn.addEventListener('click', function() { pz.moveTo(0,0); pz.zoomAbs(0,0,1); });
-            var zoomInBtn = document.createElement('button');
-            zoomInBtn.className = 'mermaid-zoom-btn';
-            zoomInBtn.textContent = '+';
-            zoomInBtn.addEventListener('click', function() { pz.zoomIn(); });
-            var zoomOutBtn = document.createElement('button');
-            zoomOutBtn.className = 'mermaid-zoom-btn';
-            zoomOutBtn.textContent = '−';
-            zoomOutBtn.addEventListener('click', function() { pz.zoomOut(); });
-            controls.appendChild(zoomOutBtn);
-            controls.appendChild(resetBtn);
-            controls.appendChild(zoomInBtn);
-            svg.closest('.mermaid').insertAdjacentElement('afterend', controls);
-          });
-        });
-      });
-    }, window.$docsify.plugins || []);
-  </script>
+  <script src="//cdn.jsdelivr.net/npm/docsify-mermaid@2.0.1/dist/docsify-mermaid.js"></script>
+  <script src="//cdn.jsdelivr.net/npm/panzoom@9.4.3/dist/panzoom.min.js"></script>
+  <script>mermaid.initialize({ startOnLoad: false, useMaxWidth: true, securityLevel: 'loose' });</script>
 </body>
 </html>

--- a/k3d/docs-content/mcp-actions.md
+++ b/k3d/docs-content/mcp-actions.md
@@ -1,3 +1,16 @@
+<div class="page-hero">
+  <span class="page-hero-icon">🤖</span>
+  <div class="page-hero-body">
+    <div class="page-hero-title">MCP Actions</div>
+    <p class="page-hero-desc">Referenz aller Aktionen, die Claude Code über die verbundenen MCP-Server ausführen kann: Kubernetes, Postgres, Browser, Grafana, Prometheus.</p>
+    <div class="page-hero-meta">
+      <span class="page-hero-tag">Claude Code KI</span>
+      <span class="page-hero-tag">MCP Server</span>
+    </div>
+  </div>
+  <a href="#/" class="page-hero-back">← Übersicht</a>
+</div>
+
 # MCP-Aktionen Referenz
 
 Alle Aktionen, die Claude Code ueber die verbundenen MCP-Server ausfuehren kann.

--- a/k3d/docs-content/migration.md
+++ b/k3d/docs-content/migration.md
@@ -1,3 +1,16 @@
+<div class="page-hero">
+  <span class="page-hero-icon">🚀</span>
+  <div class="page-hero-body">
+    <div class="page-hero-title">Migration</div>
+    <p class="page-hero-desc">Upgrade-Pfade, Datenmigration aus Slack/Teams/Google Workspace, Rollback-Strategien und Import-Skripte.</p>
+    <div class="page-hero-meta">
+      <span class="page-hero-tag">Für Administratoren</span>
+      <span class="page-hero-tag">Datenmigration</span>
+    </div>
+  </div>
+  <a href="#/" class="page-hero-back">← Übersicht</a>
+</div>
+
 # Migration
 
 ## Uebersicht

--- a/k3d/docs-content/scripts.md
+++ b/k3d/docs-content/scripts.md
@@ -1,3 +1,16 @@
+<div class="page-hero">
+  <span class="page-hero-icon">📜</span>
+  <div class="page-hero-body">
+    <div class="page-hero-title">Skripte</div>
+    <p class="page-hero-desc">Referenz aller Bash-Hilfsskripte im <code>scripts/</code>-Verzeichnis: Setup, Migration, DSGVO-Checks, MCP-Registrierung und Stripe.</p>
+    <div class="page-hero-meta">
+      <span class="page-hero-tag">Für Administratoren</span>
+      <span class="page-hero-tag">Bash</span>
+    </div>
+  </div>
+  <a href="#/" class="page-hero-back">← Übersicht</a>
+</div>
+
 # Skripte
 
 Referenz aller Skripte im `scripts/`-Verzeichnis.

--- a/k3d/docs-content/security-report.md
+++ b/k3d/docs-content/security-report.md
@@ -1,3 +1,16 @@
+<div class="page-hero">
+  <span class="page-hero-icon">📋</span>
+  <div class="page-hero-body">
+    <div class="page-hero-title">Security Report</div>
+    <p class="page-hero-desc">Sicherheitsbericht zum Workspace MVP: Testergebnisse SA-01–SA-10, Schwachstellenanalyse, CVSS-Bewertungen und Härtungsmaßnahmen.</p>
+    <div class="page-hero-meta">
+      <span class="page-hero-tag">Sicherheit</span>
+      <span class="page-hero-tag">SA-Anforderungen</span>
+    </div>
+  </div>
+  <a href="#/" class="page-hero-back">← Übersicht</a>
+</div>
+
 # Sicherheitsbericht — Workspace MVP
 
 **Version:** 1.0

--- a/k3d/docs-content/stripe.md
+++ b/k3d/docs-content/stripe.md
@@ -1,3 +1,17 @@
+<div class="page-hero">
+  <span class="page-hero-icon">💳</span>
+  <div class="page-hero-body">
+    <div class="page-hero-title">Stripe-Integration</div>
+    <p class="page-hero-desc">Zahlungsgateway-Konfiguration, Stripe Checkout, Webhook-Setup und Anbindung an Invoice Ninja für automatische Rechnungsstellung.</p>
+    <div class="page-hero-meta">
+      <span class="page-hero-tag">Website &amp; Admin</span>
+      <span class="page-hero-tag">Stripe</span>
+      <span class="page-hero-tag">Invoice Ninja</span>
+    </div>
+  </div>
+  <a href="#/" class="page-hero-back">← Übersicht</a>
+</div>
+
 # Stripe-Integration
 
 Die Website (mentolder.de / korczewski.de) nutzt Stripe fuer zwei unabhaengige Zahlungsflueesse:

--- a/k3d/docs-content/test-anleitung-korczewski.md
+++ b/k3d/docs-content/test-anleitung-korczewski.md
@@ -1,3 +1,16 @@
+<div class="page-hero">
+  <span class="page-hero-icon">🧪</span>
+  <div class="page-hero-body">
+    <div class="page-hero-title">Testanleitung</div>
+    <p class="page-hero-desc">Schritt-für-Schritt-Anleitung für Abnahmetests. Zugangsdaten, Service-Übersicht und zu prüfende Funktionen der Workspace-Plattform.</p>
+    <div class="page-hero-meta">
+      <span class="page-hero-tag">Für Mitarbeiter</span>
+      <span class="page-hero-tag">Abnahmetests</span>
+    </div>
+  </div>
+  <a href="#/" class="page-hero-back">← Übersicht</a>
+</div>
+
 # Softwaretest Workspace – Anleitung für Testerinnen und Tester
 
 Herzlich willkommen und vielen Dank, dass Du Dir Zeit nimmst, die Workspace-Plattform

--- a/k3d/docs-content/tests.md
+++ b/k3d/docs-content/tests.md
@@ -1,3 +1,17 @@
+<div class="page-hero">
+  <span class="page-hero-icon">✅</span>
+  <div class="page-hero-body">
+    <div class="page-hero-title">Tests</div>
+    <p class="page-hero-desc">Testframework, Testfall-Katalog (FA-01–FA-25, SA-01–SA-10, NFA-01–NFA-09, AK-03/04), Ausführung mit runner.sh und Report-Generierung.</p>
+    <div class="page-hero-meta">
+      <span class="page-hero-tag">Für Administratoren</span>
+      <span class="page-hero-tag">Bash + Playwright</span>
+      <span class="page-hero-tag">k3d Cluster</span>
+    </div>
+  </div>
+  <a href="#/" class="page-hero-back">← Übersicht</a>
+</div>
+
 # Tests
 
 ## Uebersicht

--- a/k3d/docs-content/verarbeitungsverzeichnis.md
+++ b/k3d/docs-content/verarbeitungsverzeichnis.md
@@ -1,3 +1,16 @@
+<div class="page-hero">
+  <span class="page-hero-icon">📎</span>
+  <div class="page-hero-body">
+    <div class="page-hero-title">Verarbeitungsverzeichnis (Art. 30 DSGVO)</div>
+    <p class="page-hero-desc">Dokumentation aller Verarbeitungstätigkeiten personenbezogener Daten: Verantwortlicher, Zweck, Datenkategorien, Empfänger und Löschfristen.</p>
+    <div class="page-hero-meta">
+      <span class="page-hero-tag">DSGVO Art. 30</span>
+      <span class="page-hero-tag">Für Administratoren</span>
+    </div>
+  </div>
+  <a href="#/" class="page-hero-back">← Übersicht</a>
+</div>
+
 # Verarbeitungsverzeichnis (Art. 30 DSGVO)
 
 **Verantwortlicher:** Gemäß Impressum (`/impressum`)  

--- a/k3d/talk-transcriber.yaml
+++ b/k3d/talk-transcriber.yaml
@@ -1,6 +1,8 @@
-# ── Nextcloud Talk Live-Transkription ─────────────────────────────────────────
+# ── Nextcloud Talk Post-Meeting-Transkription ─────────────────────────────────
 # Pollt auf aktive Calls, tritt headless bei (Firefox + PulseAudio),
-# schickt 5-s-Chunks an Whisper, postet Transkripte in den Talk-Chat.
+# schickt Audio-Chunks an Whisper. Nach Gespraechsende sendet der Bot das
+# vollstaendige Transkript an die Website-API (/api/meeting/save-transcript),
+# die es in der Datenbank und als Markdown-Datei in Nextcloud speichert.
 # ──────────────────────────────────────────────────────────────────────────────
 apiVersion: apps/v1
 kind: Deployment
@@ -39,6 +41,8 @@ spec:
                 secretKeyRef:
                   name: workspace-secrets
                   key: TRANSCRIBER_SECRET
+            - name: WEBSITE_URL
+              value: "http://website.website.svc.cluster.local"
             - name: NC_VERIFY_SSL
               value: "false"
             - name: CHUNK_SECONDS

--- a/k3d/talk-transcriber/app.py
+++ b/k3d/talk-transcriber/app.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python3
 """
-talk-transcriber -- Nextcloud Talk Live-Transkription
+talk-transcriber -- Nextcloud Talk Post-Meeting-Transkription
 Pollt alle CHUNK_SECONDS nach aktiven Calls, tritt headless bei,
-buffert Audio und schickt 5-s-Chunks an Whisper.
+buffert Audio und schickt Chunks an Whisper. Nach Gespraechsende
+wird das vollstaendige Transkript an die Website-API gesendet,
+die es in der Datenbank und in Nextcloud-Dateien speichert.
 """
 import asyncio, hashlib, hmac, os, subprocess, tempfile
 from contextlib import asynccontextmanager
@@ -19,6 +21,7 @@ NC_PASS      = os.environ["TRANSCRIBER_BOT_PASSWORD"]
 NC_SECRET    = os.environ.get("TRANSCRIBER_SECRET", "")
 NC_VERIFY    = os.environ.get("NC_VERIFY_SSL", "false").lower() == "true"
 WHISPER      = os.environ.get("WHISPER_BASE_URL", "http://whisper:8000")
+WEBSITE_URL  = os.environ.get("WEBSITE_URL", "http://website.website.svc.cluster.local")
 CHUNK_S      = int(os.environ.get("CHUNK_SECONDS", "5"))
 MAX_SESSIONS = int(os.environ.get("MAX_SESSIONS", "3"))
 
@@ -185,20 +188,31 @@ async def run_session(token: str) -> None:
 
     await asyncio.sleep(5)  # let call establish in Firefox
 
-    async with httpx.AsyncClient(
-        auth=(NC_USER, NC_PASS), verify=NC_VERIFY, timeout=10
-    ) as client:
-        try:
-            while token in sessions and sessions[token]:
-                chunk = await _record_chunk(sink)
-                if chunk:
-                    text = await _whisper(chunk)
-                    if text:
-                        await _post_chat(client, token, f"\U0001f3a4 {text}")
-        except asyncio.CancelledError:
-            pass
-        finally:
-            _teardown(token, display_num)
+    sessions[token] |= {
+        "transcript_parts": [],
+        "segments": [],
+        "chunk_offset": 0.0,
+    }
+
+    try:
+        while token in sessions and sessions[token]:
+            chunk = await _record_chunk(sink)
+            if chunk:
+                text, segs = await _whisper(chunk)
+                if text:
+                    sessions[token]["transcript_parts"].append(text)
+                    offset = sessions[token].get("chunk_offset", 0.0)
+                    for seg in segs:
+                        sessions[token]["segments"].append({
+                            "start": round(offset + seg.get("start", 0), 2),
+                            "end":   round(offset + seg.get("end",   0), 2),
+                            "text":  seg.get("text", "").strip(),
+                        })
+                    sessions[token]["chunk_offset"] = offset + CHUNK_S
+    except asyncio.CancelledError:
+        pass
+    finally:
+        await _finalize_and_teardown(token, display_num)
 
 
 def _start_browser(env: dict) -> subprocess.Popen:
@@ -261,26 +275,23 @@ async def _record_chunk(sink: str) -> str | None:
     return path
 
 
-async def _whisper(audio_path: str) -> str:
+async def _whisper(audio_path: str) -> tuple[str, list]:
+    """Returns (full_text, segments) from Whisper. Segments contain start/end/text."""
     try:
         async with httpx.AsyncClient(timeout=30) as c:
             with open(audio_path, "rb") as f:
                 r = await c.post(
                     f"{WHISPER}/v1/audio/transcriptions",
                     files={"file": ("chunk.wav", f, "audio/wav")},
-                    data={"model": "whisper-1", "language": "de"},
+                    data={"model": "whisper-1", "language": "de",
+                          "response_format": "verbose_json"},
                 )
-            return r.json().get("text", "").strip() if r.is_success else ""
+            if r.is_success:
+                data = r.json()
+                return data.get("text", "").strip(), data.get("segments", [])
+            return "", []
     finally:
         Path(audio_path).unlink(missing_ok=True)
-
-
-async def _post_chat(client: httpx.AsyncClient, token: str, message: str) -> None:
-    await client.post(
-        f"{NC_URL}/ocs/v2.php/apps/spreed/api/v1/chat/{token}",
-        headers={"OCS-APIRequest": "true"},
-        json={"message": message},
-    )
 
 
 # ---------- Cleanup -----------------------------------------------------------
@@ -305,12 +316,38 @@ def _cancel(token: str) -> None:
     s = sessions.get(token)
     if s and (t := s.get("task")):
         t.cancel()
-    # Do NOT pop from sessions here -- run_session finally calls _teardown
+    # Do NOT pop from sessions here -- run_session finally calls _finalize_and_teardown
 
 
-def _teardown(token: str, display_num: int | None = None) -> None:
+async def _finalize_and_teardown(token: str, display_num: int | None = None) -> None:
+    """POST accumulated transcript to website API, then release resources."""
+    s = sessions.get(token, {})
+    transcript_parts: list[str] = s.get("transcript_parts", [])
+    segments: list[dict] = s.get("segments", [])
+
+    if transcript_parts and WEBSITE_URL:
+        full_text = "\n".join(transcript_parts)
+        print(f"[{token}] saving transcript ({len(full_text)} chars, "
+              f"{len(segments)} segments)", flush=True)
+        try:
+            async with httpx.AsyncClient(timeout=30) as wc:
+                resp = await wc.post(
+                    f"{WEBSITE_URL}/api/meeting/save-transcript",
+                    json={
+                        "roomToken": token,
+                        "transcriptText": full_text,
+                        "segments": segments,
+                    },
+                )
+                if not resp.is_success:
+                    print(f"[{token}] save-transcript returned {resp.status_code}: "
+                          f"{resp.text[:200]}", flush=True)
+        except Exception as exc:
+            print(f"[{token}] failed to save transcript: {exc}", flush=True)
+    elif not transcript_parts:
+        print(f"[{token}] no transcript accumulated, skipping save", flush=True)
+
     s = sessions.pop(token, {})
-    # If display_num was passed and not in state (e.g. session init failed early), use it
     if display_num is not None and "display_num" not in s:
         s["display_num"] = display_num
     print(f"[{token}] stopping", flush=True)

--- a/website/src/lib/nextcloud-files.ts
+++ b/website/src/lib/nextcloud-files.ts
@@ -110,6 +110,35 @@ export async function hashFile(filePath: string): Promise<string> {
 }
 
 /**
+ * Upload a file to Nextcloud (WebDAV PUT). Creates or overwrites the file.
+ */
+export async function uploadFile(
+  filePath: string,
+  content: Buffer | string,
+  contentType = 'application/octet-stream',
+): Promise<void> {
+  const url = davUrl(filePath);
+  // Convert Buffer to ArrayBuffer for Blob compatibility
+  const blobPart: BlobPart = typeof content === 'string'
+    ? content
+    : content.buffer.slice(content.byteOffset, content.byteOffset + content.byteLength) as ArrayBuffer;
+  const body = new Blob([blobPart], { type: contentType });
+  const res = await fetch(url, {
+    method: 'PUT',
+    headers: {
+      Authorization: authHeader(),
+      'Content-Type': contentType,
+    },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    body: body as any,
+  });
+  // 201 = created, 204 = overwritten — both are fine
+  if (res.status !== 201 && res.status !== 204) {
+    throw new Error(`Failed to upload ${filePath}: ${res.status}`);
+  }
+}
+
+/**
  * Ensure a folder exists in Nextcloud (MKCOL, ignores 405 if already exists).
  */
 export async function ensureFolder(folderPath: string): Promise<void> {

--- a/website/src/lib/website-db.ts
+++ b/website/src/lib/website-db.ts
@@ -124,6 +124,34 @@ export interface MeetingWithDetails {
   }>;
 }
 
+export interface MeetingWithCustomer {
+  id: string;
+  customerId: string;
+  customerName: string;
+  customerEmail: string;
+  meetingType: string;
+  status: string;
+  talkRoomToken: string | null;
+}
+
+export async function getMeetingByRoomToken(
+  roomToken: string,
+): Promise<MeetingWithCustomer | null> {
+  const result = await pool.query(
+    `SELECT m.id, m.customer_id AS "customerId",
+            c.name AS "customerName", c.email AS "customerEmail",
+            m.meeting_type AS "meetingType", m.status,
+            m.talk_room_token AS "talkRoomToken"
+     FROM meetings m
+     JOIN customers c ON m.customer_id = c.id
+     WHERE m.talk_room_token = $1
+     ORDER BY m.created_at DESC
+     LIMIT 1`,
+    [roomToken],
+  );
+  return result.rows[0] ?? null;
+}
+
 export async function createMeeting(params: {
   customerId: string;
   meetingType: string;

--- a/website/src/pages/admin.astro
+++ b/website/src/pages/admin.astro
@@ -45,28 +45,27 @@ function fmtCurrency(n: number): string {
   return new Intl.NumberFormat('de-DE', { style: 'currency', currency: 'EUR' }).format(n);
 }
 
-const ncBase       = (process.env.NEXTCLOUD_EXTERNAL_URL ?? '').replace(/\/$/, '');
-const mmUrl        = process.env.MATTERMOST_EXTERNAL_URL ?? '';
-const docsUrl      = process.env.DOCS_URL ?? '';
-const billingUrl   = process.env.BILLING_EXTERNAL_URL ?? '';
-const authUrl      = process.env.AUTH_EXTERNAL_URL ?? '';
-const vaultUrl     = process.env.VAULT_EXTERNAL_URL ?? '';
-const whiteboardUrl = process.env.WHITEBOARD_EXTERNAL_URL ?? '';
-const wikiUrl      = process.env.WIKI_EXTERNAL_URL ?? '';
+const ncBase      = (process.env.NEXTCLOUD_EXTERNAL_URL ?? '').replace(/\/$/, '');
+const mmUrl       = process.env.MATTERMOST_EXTERNAL_URL ?? '';
+const docsUrl     = process.env.DOCS_URL ?? '';
+const billingUrl  = process.env.BILLING_EXTERNAL_URL ?? '';
+const authUrl     = process.env.AUTH_EXTERNAL_URL ?? '';
+const vaultUrl    = process.env.VAULT_EXTERNAL_URL ?? '';
+const wikiUrl     = process.env.WIKI_EXTERNAL_URL ?? '';
 const adminLinks = [
   ...(ncBase ? [
-    { href: `${ncBase}/apps/files/`,    label: 'Dateien',     icon: '📁' },
-    { href: `${ncBase}/apps/calendar/`, label: 'Kalender',    icon: '📅' },
-    { href: `${ncBase}/apps/contacts/`, label: 'Kontakte',    icon: '👥' },
-    { href: `${ncBase}/apps/spreed/`,   label: 'Talk',        icon: '🎥' },
+    { href: `${ncBase}/apps/files/`,      label: 'Dateien',    icon: '📁' },
+    { href: `${ncBase}/apps/calendar/`,   label: 'Kalender',   icon: '📅' },
+    { href: `${ncBase}/apps/contacts/`,   label: 'Kontakte',   icon: '👥' },
+    { href: `${ncBase}/apps/spreed/`,     label: 'Talk',       icon: '🎥' },
+    { href: `${ncBase}/apps/whiteboard/`, label: 'Whiteboard', icon: '🖊️' },
   ] : []),
-  ...(wikiUrl      ? [{ href: wikiUrl,      label: 'Wiki',         icon: '📚' }] : []),
-  ...(whiteboardUrl ? [{ href: whiteboardUrl, label: 'Whiteboard', icon: '🖊️' }] : []),
-  ...(mmUrl        ? [{ href: mmUrl,        label: 'Mattermost',   icon: '💬' }] : []),
-  ...(billingUrl   ? [{ href: billingUrl,   label: 'Abrechnung',   icon: '🧾' }] : []),
-  ...(vaultUrl     ? [{ href: vaultUrl,     label: 'Passwörter',   icon: '🔐' }] : []),
-  ...(authUrl      ? [{ href: `${authUrl}/admin/`, label: 'Keycloak', icon: '🔑' }] : []),
-  ...(docsUrl      ? [{ href: docsUrl,      label: 'Docs',         icon: '📖' }] : []),
+  ...(wikiUrl     ? [{ href: wikiUrl,           label: 'Wiki',       icon: '📚' }] : []),
+  ...(mmUrl       ? [{ href: mmUrl,             label: 'Mattermost', icon: '💬' }] : []),
+  ...(billingUrl  ? [{ href: billingUrl,        label: 'Abrechnung', icon: '🧾' }] : []),
+  ...(vaultUrl    ? [{ href: vaultUrl,          label: 'Passwörter', icon: '🔐' }] : []),
+  ...(authUrl     ? [{ href: `${authUrl}/admin/`, label: 'Keycloak', icon: '🔑' }] : []),
+  ...(docsUrl     ? [{ href: docsUrl,           label: 'Docs',       icon: '📖' }] : []),
 ];
 ---
 

--- a/website/src/pages/api/meeting/save-transcript.ts
+++ b/website/src/pages/api/meeting/save-transcript.ts
@@ -1,0 +1,162 @@
+import type { APIRoute } from 'astro';
+import {
+  getMeetingByRoomToken,
+  saveTranscript,
+  saveArtifact,
+  updateMeetingStatus,
+} from '../../../lib/website-db';
+import { ensureFolder, uploadFile } from '../../../lib/nextcloud-files';
+
+// Called by talk-transcriber after a Nextcloud Talk call ends.
+// Saves the accumulated transcript to the database and as a Markdown file in Nextcloud.
+//
+// Body: {
+//   roomToken: string,
+//   transcriptText: string,
+//   segments?: Array<{ start: number, end: number, text: string }>
+// }
+export const POST: APIRoute = async ({ request }) => {
+  let body: { roomToken?: string; transcriptText?: string; segments?: unknown[] };
+  try {
+    body = await request.json();
+  } catch {
+    return json({ error: 'Invalid JSON' }, 400);
+  }
+
+  const { roomToken, transcriptText, segments = [] } = body;
+
+  if (!roomToken || typeof roomToken !== 'string') {
+    return json({ error: 'roomToken required' }, 400);
+  }
+  if (!transcriptText || typeof transcriptText !== 'string') {
+    return json({ error: 'transcriptText required' }, 400);
+  }
+
+  // ── 1. Look up meeting by room token ──────────────────────────────────────
+  const meeting = await getMeetingByRoomToken(roomToken);
+  if (!meeting) {
+    console.warn(`[save-transcript] no meeting found for roomToken=${roomToken}`);
+    return json({ error: 'Meeting not found for this room token' }, 404);
+  }
+
+  if (['transcribed', 'finalized'].includes(meeting.status)) {
+    return json({ error: 'Meeting already transcribed', meetingId: meeting.id }, 409);
+  }
+
+  const results: string[] = [];
+  const errors: string[] = [];
+
+  // ── 2. Mark meeting as ended ──────────────────────────────────────────────
+  try {
+    await updateMeetingStatus(meeting.id, 'ended', { endedAt: new Date() });
+    results.push('Meeting status → ended');
+  } catch (err) {
+    errors.push(`Status update: ${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  // ── 3. Save transcript to DB ──────────────────────────────────────────────
+  let transcriptId: string | null = null;
+  try {
+    const typedSegments = (segments as Array<{ start: number; end: number; text: string }>)
+      .filter(s => s && typeof s.start === 'number' && typeof s.end === 'number');
+
+    const saved = await saveTranscript({
+      meetingId: meeting.id,
+      fullText: transcriptText,
+      segments: typedSegments,
+    });
+    transcriptId = saved.id;
+    await updateMeetingStatus(meeting.id, 'transcribed');
+    results.push(`DB: Transcript ${saved.id} (${typedSegments.length} segments)`);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    errors.push(`Save transcript to DB: ${msg}`);
+  }
+
+  // ── 4. Upload transcript to Nextcloud ─────────────────────────────────────
+  if (transcriptId) {
+    try {
+      const date = new Date().toISOString().slice(0, 10);
+      const safeName = meeting.customerName.replace(/[^a-zA-Z0-9äöüÄÖÜß.\-_ ]/g, '_');
+      const folderPath = `Meetings/${safeName}`;
+      const fileName = `${date}_${meeting.meetingType.replace(/\s+/g, '_')}_Transkript.md`;
+      const filePath = `${folderPath}/${fileName}`;
+
+      const markdown = buildMarkdown({
+        customerName: meeting.customerName,
+        customerEmail: meeting.customerEmail,
+        meetingType: meeting.meetingType,
+        date,
+        transcriptText,
+        segments: segments as Array<{ start: number; end: number; text: string }>,
+      });
+
+      await ensureFolder(folderPath);
+      await uploadFile(filePath, markdown, 'text/markdown; charset=utf-8');
+
+      await saveArtifact({
+        meetingId: meeting.id,
+        artifactType: 'document',
+        name: fileName,
+        storagePath: filePath,
+        contentText: transcriptText.substring(0, 5000),
+      });
+
+      results.push(`Nextcloud: ${filePath}`);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      errors.push(`Nextcloud upload: ${msg}`);
+    }
+  }
+
+  return json({
+    success: errors.length === 0,
+    meetingId: meeting.id,
+    results,
+    ...(errors.length > 0 ? { errors } : {}),
+  }, 200);
+};
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function json(data: unknown, status: number): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function formatSeconds(s: number): string {
+  const m = Math.floor(s / 60);
+  const sec = Math.floor(s % 60);
+  return `${String(m).padStart(2, '0')}:${String(sec).padStart(2, '0')}`;
+}
+
+function buildMarkdown(params: {
+  customerName: string;
+  customerEmail: string;
+  meetingType: string;
+  date: string;
+  transcriptText: string;
+  segments: Array<{ start: number; end: number; text: string }>;
+}): string {
+  const { customerName, customerEmail, meetingType, date, transcriptText, segments } = params;
+
+  let md = `# Transkript: ${meetingType} — ${date}\n\n`;
+  md += `**Kunde:** ${customerName} (${customerEmail})\n`;
+  md += `**Typ:** ${meetingType}\n`;
+  md += `**Datum:** ${date}\n`;
+  md += `**Erstellt:** ${new Date().toLocaleString('de-DE')}\n\n---\n\n`;
+
+  if (segments.length > 0) {
+    md += `## Transkript mit Zeitstempeln\n\n`;
+    for (const seg of segments) {
+      md += `**[${formatSeconds(seg.start)}]** ${seg.text}\n\n`;
+    }
+  } else {
+    md += `## Transkript\n\n${transcriptText}\n`;
+  }
+
+  md += `\n---\n*Automatisch erstellt durch talk-transcriber + Whisper*\n`;
+  return md;
+}

--- a/website/src/pages/portal.astro
+++ b/website/src/pages/portal.astro
@@ -15,19 +15,18 @@ if (!session) {
 
 const tab = Astro.url.searchParams.get('tab') ?? 'bookings';
 
-const ncBase        = (process.env.NEXTCLOUD_EXTERNAL_URL ?? '').replace(/\/$/, '');
-const wikiUrl       = process.env.WIKI_EXTERNAL_URL ?? '';
-const whiteboardUrl = process.env.WHITEBOARD_EXTERNAL_URL ?? '';
+const ncBase  = (process.env.NEXTCLOUD_EXTERNAL_URL ?? '').replace(/\/$/, '');
+const wikiUrl = process.env.WIKI_EXTERNAL_URL ?? '';
 
 const portalLinks = [
   ...(ncBase ? [
-    { href: `${ncBase}/apps/files/`,    label: 'Dateien',    icon: '📁' },
-    { href: `${ncBase}/apps/calendar/`, label: 'Kalender',   icon: '📅' },
-    { href: `${ncBase}/apps/contacts/`, label: 'Kontakte',   icon: '👥' },
-    { href: `${ncBase}/apps/spreed/`,   label: 'Talk',       icon: '🎥' },
+    { href: `${ncBase}/apps/files/`,       label: 'Dateien',    icon: '📁' },
+    { href: `${ncBase}/apps/calendar/`,    label: 'Kalender',   icon: '📅' },
+    { href: `${ncBase}/apps/contacts/`,    label: 'Kontakte',   icon: '👥' },
+    { href: `${ncBase}/apps/spreed/`,      label: 'Talk',       icon: '🎥' },
+    { href: `${ncBase}/apps/whiteboard/`,  label: 'Whiteboard', icon: '🖊️' },
   ] : []),
-  ...(wikiUrl       ? [{ href: wikiUrl,       label: 'Wiki',       icon: '📚' }] : []),
-  ...(whiteboardUrl ? [{ href: whiteboardUrl, label: 'Whiteboard', icon: '🖊️' }] : []),
+  ...(wikiUrl ? [{ href: wikiUrl, label: 'Wiki', icon: '📚' }] : []),
 ];
 ---
 


### PR DESCRIPTION
## Summary

- **Removes live transcription**: talk-transcriber no longer posts individual Whisper results to the Talk chat during a call
- **Accumulates full transcript**: each audio chunk's text and timestamped segments are collected in session state throughout the call
- **Saves on call end**: when `hasCall` goes false, the bot POSTs the complete transcript to `/api/meeting/save-transcript`, which stores it in the DB and uploads a Markdown file to Nextcloud under `Meetings/{customer}/`
- **New files**: `website/src/pages/api/meeting/save-transcript.ts`, `uploadFile()` in `nextcloud-files.ts`, `getMeetingByRoomToken()` in `website-db.ts`

## Test plan

- [ ] Start a Nextcloud Talk call — confirm no live messages appear in the Talk chat
- [ ] End the call — check talk-transcriber logs for `saving transcript (N chars, M segments)`
- [ ] Verify `transcripts` + `transcript_segments` rows in the `website` DB for the meeting
- [ ] Verify Markdown file created under `Meetings/` in Nextcloud admin files
- [ ] Verify `meeting_artifacts` row with the Nextcloud path
- [ ] Verify meeting status updated to `transcribed`
- [ ] Test with a room token that has no matching meeting → expect 404 from endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)