### PR TITLE
fix(website): fix whiteboard link in admin/portal dashboards

### DIFF
--- a/website/src/pages/admin.astro
+++ b/website/src/pages/admin.astro
@@ -58,7 +58,7 @@ const adminLinks = [
     { href: `${ncBase}/apps/calendar/`,   label: 'Kalender',   icon: '📅' },
     { href: `${ncBase}/apps/contacts/`,   label: 'Kontakte',   icon: '👥' },
     { href: `${ncBase}/apps/spreed/`,     label: 'Talk',       icon: '🎥' },
-    { href: `${ncBase}/apps/whiteboard/`, label: 'Whiteboard', icon: '🖊️' },
+    { href: `${ncBase}/apps/files/`,      label: 'Whiteboard', icon: '🖊️' },
   ] : []),
   ...(wikiUrl     ? [{ href: wikiUrl,           label: 'Wiki',       icon: '📚' }] : []),
   ...(mmUrl       ? [{ href: mmUrl,             label: 'Mattermost', icon: '💬' }] : []),

--- a/website/src/pages/portal.astro
+++ b/website/src/pages/portal.astro
@@ -24,7 +24,7 @@ const portalLinks = [
     { href: `${ncBase}/apps/calendar/`,    label: 'Kalender',   icon: '📅' },
     { href: `${ncBase}/apps/contacts/`,    label: 'Kontakte',   icon: '👥' },
     { href: `${ncBase}/apps/spreed/`,      label: 'Talk',       icon: '🎥' },
-    { href: `${ncBase}/apps/whiteboard/`,  label: 'Whiteboard', icon: '🖊️' },
+    { href: `${ncBase}/apps/files/`,       label: 'Whiteboard', icon: '🖊️' },
   ] : []),
   ...(wikiUrl ? [{ href: wikiUrl, label: 'Wiki', icon: '📚' }] : []),
 ];


### PR DESCRIPTION
## Summary

- `/apps/whiteboard/` has no index route — the Nextcloud whiteboard app is a file-type viewer, not a navigation app like Calendar or Deck
- The Whiteboard quick-link in admin and portal dashboards now points to `/apps/files/` where users can create new whiteboard files via **+ Neu → Neues Whiteboard**
- Also fixed JWT secret mismatch on mentolder: whiteboard pod restarted to pick up production secret, and Nextcloud config synced via `occ config:app:set`

## Test plan

- [ ] Click Whiteboard link on Admin Dashboard → lands on Nextcloud Files
- [ ] Click Whiteboard link on User Portal → lands on Nextcloud Files
- [ ] Create a new `.whiteboard` file in Files → opens the whiteboard editor without auth errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)