### PR TITLE
fix(website): set ndots:3 to avoid fritz.box search-path timeouts

### DIFF
--- a/k3d/website.yaml
+++ b/k3d/website.yaml
@@ -99,6 +99,15 @@ spec:
     spec:
       imagePullSecrets:
         - name: ghcr-pull-secret
+      # Lower ndots so FQDNs like shared-db.workspace.svc.cluster.local (4 dots)
+      # are resolved as absolute names without iterating through search-path suffixes.
+      # On clusters where the node inherits a home-router search domain (e.g. fritz.box),
+      # the default ndots:5 causes those lookups to time out and Node.js (musl libc)
+      # returns EAI_AGAIN — breaking the pg-pool connection on first use.
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "3"
       nodeSelector:
         kubernetes.io/arch: amd64
       affinity:


### PR DESCRIPTION
## Summary

- Adds `dnsConfig: options: [{name: ndots, value: "3"}]` to the website Deployment
- With the default `ndots:5`, a 4-dot FQDN like `shared-db.workspace.svc.cluster.local` is tried with all search-path suffixes first (including `fritz.box` inherited from the k3s host nodes)
- The `fritz.box` lookup always times out (5 s), causing musl libc's `getaddrinfo` to return `EAI_AGAIN` — which breaks the `pg` connection pool on its first use after pod startup
- With `ndots:3`, any name with ≥ 3 dots is resolved as absolute first, skipping the search-path iteration entirely
- Fixes intermittent `Reminder processing error: EAI_AGAIN shared-db.workspace.svc.cluster.local` on the korczewski cluster

## Test plan

- [ ] Deploy to korczewski: `task website:deploy ENV=korczewski` (or equivalent)
- [ ] Verify meeting-reminders CronJob no longer logs `EAI_AGAIN` errors
- [ ] Confirm `kubectl exec -n website deployment/website -- node -e "require('dns').lookup('shared-db.workspace.svc.cluster.local', (e,a)=>console.log(e||a))"` resolves quickly without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)