### PR TITLE
fix(website): add ndots:3 to CronJob pod template to fix DNS resolution

### DIFF
--- a/k3d/website.yaml
+++ b/k3d/website.yaml
@@ -245,6 +245,10 @@ spec:
       activeDeadlineSeconds: 25
       template:
         spec:
+          dnsConfig:
+            options:
+              - name: ndots
+                value: "3"
           affinity:
             podAffinity:
               requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
## Summary

- The `meeting-reminders` CronJob pod uses `curlimages/curl` (Alpine/musl) and was missing the `dnsConfig.ndots:3` setting added to the website Deployment in #125
- Without `ndots:3`, the default `ndots:5` causes `website.website.svc.cluster.local` (4 dots) to first be tried with the fritz.box search-domain suffix → 5s timeout → curl exits with `CURLE_COULDNT_RESOLVE_HOST` (exit code 6)
- Observed on korczewski cluster: every CronJob run failed with exit code 6; no requests ever reached the website pod

## Test plan

- [x] Applied fix directly to korczewski cluster
- [x] Next CronJob run (`meeting-reminders-29606013`) completed in 4s (vs previous ≥25s failures)
- [x] `GET /api/reminders/process` confirmed reachable from inside pod with `{"sent":0,"pending":0}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)