### PR TITLE
fix(website): guard messaging-db calls + print CSS for prose pages

### DIFF
--- a/website/src/pages/admin/inbox.astro
+++ b/website/src/pages/admin/inbox.astro
@@ -8,10 +8,16 @@ const session = await getSession(Astro.request.headers.get('cookie'));
 if (!session) return Astro.redirect(getLoginUrl());
 if (!isAdmin(session)) return Astro.redirect('/admin');
 
-const [initialItems, initialCounts] = await Promise.all([
-  listInboxItems({ status: 'pending' }),
-  countPendingByType(),
-]);
+let initialItems: Awaited<ReturnType<typeof listInboxItems>> = [];
+let initialCounts: Awaited<ReturnType<typeof countPendingByType>> = {};
+try {
+  [initialItems, initialCounts] = await Promise.all([
+    listInboxItems({ status: 'pending' }),
+    countPendingByType(),
+  ]);
+} catch (err) {
+  console.error('[admin/inbox] DB error:', err);
+}
 ---
 
 <AdminLayout title="Inbox">

--- a/website/src/pages/admin/nachrichten.astro
+++ b/website/src/pages/admin/nachrichten.astro
@@ -8,10 +8,13 @@ const session = await getSession(Astro.request.headers.get('cookie'));
 if (!session) return Astro.redirect(getLoginUrl());
 if (!isAdmin(session)) return Astro.redirect('/admin');
 
-const [threads, customers] = await Promise.all([
-  listThreadsForAdmin(),
-  listAllCustomers(),
-]);
+let threads: Awaited<ReturnType<typeof listThreadsForAdmin>> = [];
+let customers: Awaited<ReturnType<typeof listAllCustomers>> = [];
+try {
+  [threads, customers] = await Promise.all([listThreadsForAdmin(), listAllCustomers()]);
+} catch (err) {
+  console.error('[admin/nachrichten] DB error:', err);
+}
 ---
 
 <AdminLayout title="Nachrichten">

--- a/website/src/pages/admin/raeume.astro
+++ b/website/src/pages/admin/raeume.astro
@@ -8,7 +8,12 @@ const session = await getSession(Astro.request.headers.get('cookie'));
 if (!session) return Astro.redirect(getLoginUrl());
 if (!isAdmin(session)) return Astro.redirect('/admin');
 
-const rooms = await listRoomsForAdmin();
+let rooms: Awaited<ReturnType<typeof listRoomsForAdmin>> = [];
+try {
+  rooms = await listRoomsForAdmin();
+} catch (err) {
+  console.error('[admin/raeume] DB error:', err);
+}
 ---
 
 <AdminLayout title="Räume">

--- a/website/src/pages/portal/index.astro
+++ b/website/src/pages/portal/index.astro
@@ -6,9 +6,18 @@ import { getCustomerByEmail, getThreadByCustomerId, listRoomsForCustomer } from 
 const session = await getSession(Astro.request.headers.get('cookie'));
 if (!session) return Astro.redirect(getLoginUrl('/portal'));
 
-const customer = await getCustomerByEmail(session.email);
-const thread = customer ? await getThreadByCustomerId(customer.id) : null;
-const rooms = customer ? await listRoomsForCustomer(customer.id) : [];
+let customer: Awaited<ReturnType<typeof getCustomerByEmail>> = null;
+let thread: Awaited<ReturnType<typeof getThreadByCustomerId>> = null;
+let rooms: Awaited<ReturnType<typeof listRoomsForCustomer>> = [];
+try {
+  customer = await getCustomerByEmail(session.email);
+  [thread, rooms] = await Promise.all([
+    customer ? getThreadByCustomerId(customer.id) : Promise.resolve(null),
+    customer ? listRoomsForCustomer(customer.id) : Promise.resolve([]),
+  ]);
+} catch (err) {
+  console.error('[portal] DB error:', err);
+}
 ---
 
 <Layout title="Mein Portal">

--- a/website/src/pages/portal/nachrichten.astro
+++ b/website/src/pages/portal/nachrichten.astro
@@ -11,7 +11,12 @@ if (!session) return Astro.redirect(getLoginUrl('/portal/nachrichten'));
 const customer = await getCustomerByEmail(session.email);
 if (!customer) return Astro.redirect('/portal');
 
-const thread = await getThreadByCustomerId(customer.id);
+let thread: MessageThread | null = null;
+try {
+  thread = await getThreadByCustomerId(customer.id);
+} catch (err) {
+  console.error('[portal/nachrichten] DB error:', err);
+}
 const threads: MessageThread[] = thread ? [thread] : [];
 ---
 

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -81,3 +81,30 @@ section {
   border-bottom: 1px solid var(--color-dark-lighter);
   padding: 0.5rem 1rem 0.5rem 0;
 }
+
+@media print {
+  body {
+    background: white !important;
+    color: black !important;
+  }
+  .prose,
+  .prose h1, .prose h2, .prose h3, .prose h4,
+  .prose p, .prose li, .prose strong {
+    color: black !important;
+    background: transparent !important;
+  }
+  .prose a {
+    color: #333 !important;
+  }
+  .prose th {
+    color: black !important;
+    border-bottom-color: #ccc !important;
+  }
+  .prose td {
+    color: #333 !important;
+    border-bottom-color: #eee !important;
+  }
+  .prose hr {
+    border-color: #ccc !important;
+  }
+}


### PR DESCRIPTION
## Summary

- Wrap all SSR messaging-db calls in `try/catch` so pages with missing tables (chat_rooms, message_threads) render gracefully instead of crashing into a `ERR_TOO_MANY_REDIRECTS` loop (fixes admin/raeume, admin/nachrichten, admin/inbox, portal/index, portal/nachrichten)
- Add `@media print` overrides to global.css so legal document pages (datenschutz, impressum, agb, barrierefreiheit) render readable dark text on white paper when printed or exported to PDF

## Test plan

- [ ] Navigate to `/admin/raeume` — should show empty room list, no redirect loop
- [ ] Navigate to `/admin/nachrichten` — should load without crash
- [ ] Navigate to `/admin/inbox` — should load without crash
- [ ] Print `/datenschutz` or `/impressum` — text should be black on white background

Closes BR-20260417-4708, BR-20260417-1547, BR-20260417-4ea2

🤖 Generated with [Claude Code](https://claude.com/claude-code)