### PR TITLE
fix(admin): logout button, monitoring dark theme + RBAC

### DIFF
--- a/k3d/website.yaml
+++ b/k3d/website.yaml
@@ -71,6 +71,38 @@ data:
   # Site
   SITE_URL: "${WEBSITE_SITE_URL}"
 ---
+# ── Monitoring RBAC ──────────────────────────────────────────────────────────
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: website
+  namespace: website
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: website-monitoring-reader
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "events", "nodes"]
+    verbs: ["get", "list"]
+  - apiGroups: ["metrics.k8s.io"]
+    resources: ["pods", "nodes"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: website-monitoring-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: website-monitoring-reader
+subjects:
+  - kind: ServiceAccount
+    name: website
+    namespace: website
+---
 # ── Website Deployment ────────────────────────────────────────────────────────
 apiVersion: apps/v1
 kind: Deployment
@@ -87,6 +119,7 @@ spec:
       labels:
         app: website
     spec:
+      serviceAccountName: website
       imagePullSecrets:
         - name: ghcr-pull-secret
       # Lower ndots so FQDNs like shared-db.workspace.svc.cluster.local (4 dots)

--- a/website/src/components/admin/MonitoringDashboard.svelte
+++ b/website/src/components/admin/MonitoringDashboard.svelte
@@ -70,7 +70,7 @@
 <div class="space-y-6">
   <!-- Top Bar -->
   <div class="flex justify-between items-center">
-    <div class="text-sm text-gray-500 dark:text-gray-400">
+    <div class="text-sm text-muted">
       {#if data?.fetchedAt}
         Last updated: {new Date(data.fetchedAt).toLocaleTimeString()}
       {/if}
@@ -100,38 +100,38 @@
   {#if data}
     <!-- Summary Stats -->
     <div class="grid grid-cols-1 md:grid-cols-4 gap-4">
-      <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-4 border-l-4 border-green-500">
-        <h3 class="text-sm font-medium text-gray-500 dark:text-gray-400">Running / Ready</h3>
+      <div class="bg-dark-light border border-dark-lighter rounded-lg shadow p-4 border-l-4 border-green-500">
+        <h3 class="text-sm font-medium text-muted">Running / Ready</h3>
         <p class="mt-1 text-2xl font-semibold text-green-600 dark:text-green-400">{runningCount}</p>
       </div>
-      <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-4 border-l-4 border-yellow-500">
-        <h3 class="text-sm font-medium text-gray-500 dark:text-gray-400">Pending / Restarting</h3>
+      <div class="bg-dark-light border border-dark-lighter rounded-lg shadow p-4 border-l-4 border-yellow-500">
+        <h3 class="text-sm font-medium text-muted">Pending / Restarting</h3>
         <p class="mt-1 text-2xl font-semibold text-yellow-600 dark:text-yellow-400">{restartingCount}</p>
       </div>
-      <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-4 border-l-4 border-red-500">
-        <h3 class="text-sm font-medium text-gray-500 dark:text-gray-400">Failed / Unknown</h3>
+      <div class="bg-dark-light border border-dark-lighter rounded-lg shadow p-4 border-l-4 border-red-500">
+        <h3 class="text-sm font-medium text-muted">Failed / Unknown</h3>
         <p class="mt-1 text-2xl font-semibold text-red-600 dark:text-red-400">{failedCount}</p>
       </div>
       {#if data.metricsAvailable && data.node}
-        <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-4 border-l-4 border-blue-500">
-          <h3 class="text-sm font-medium text-gray-500 dark:text-gray-400">Node Resources</h3>
-          <p class="mt-1 text-sm text-gray-900 dark:text-white">CPU: {data.node.cpu}</p>
-          <p class="text-sm text-gray-900 dark:text-white">Mem: {data.node.memory}</p>
+        <div class="bg-dark-light border border-dark-lighter rounded-lg shadow p-4 border-l-4 border-blue-500">
+          <h3 class="text-sm font-medium text-muted">Node Resources</h3>
+          <p class="mt-1 text-sm text-light">CPU: {data.node.cpu}</p>
+          <p class="text-sm text-light">Mem: {data.node.memory}</p>
         </div>
       {/if}
     </div>
 
     <!-- Pods List -->
-    <div class="bg-white dark:bg-gray-800 rounded-lg shadow overflow-hidden">
-      <div class="px-4 py-5 sm:px-6 border-b border-gray-200 dark:border-gray-700">
-        <h3 class="text-lg leading-6 font-medium text-gray-900 dark:text-white">Workloads</h3>
+    <div class="bg-dark-light border border-dark-lighter rounded-lg shadow overflow-hidden">
+      <div class="px-4 py-5 sm:px-6 border-b border-dark-lighter">
+        <h3 class="text-lg leading-6 font-medium text-light">Workloads</h3>
       </div>
-      <ul class="divide-y divide-gray-200 dark:divide-gray-700 max-h-[500px] overflow-y-auto">
+      <ul class="divide-y divide-dark-lighter max-h-[500px] overflow-y-auto">
         {#each data.pods as pod}
-          <li class="px-4 py-4 sm:px-6 border-l-4 {getStatusColor(pod)} hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors">
+          <li class="px-4 py-4 sm:px-6 border-l-4 {getStatusColor(pod)} hover:bg-dark transition-colors">
             <div class="flex items-center justify-between">
               <div class="flex flex-col">
-                <p class="text-sm font-medium text-gray-900 dark:text-white truncate">{pod.name}</p>
+                <p class="text-sm font-medium text-light truncate">{pod.name}</p>
                 <div class="mt-1 flex items-center space-x-2 text-xs">
                   <span>{pod.phase}</span>
                   {#if pod.restarts > 0}
@@ -139,7 +139,7 @@
                   {/if}
                 </div>
               </div>
-              <div class="flex flex-col items-end text-sm text-gray-500 dark:text-gray-400">
+              <div class="flex flex-col items-end text-sm text-muted">
                 <p>CPU: {pod.cpu || '—'}</p>
                 <p>Mem: {pod.memory || '—'}</p>
               </div>
@@ -153,11 +153,11 @@
     </div>
 
     <!-- Events List -->
-    <div class="bg-white dark:bg-gray-800 rounded-lg shadow overflow-hidden">
-      <div class="px-4 py-5 sm:px-6 border-b border-gray-200 dark:border-gray-700">
-        <h3 class="text-lg leading-6 font-medium text-gray-900 dark:text-white">Recent Events</h3>
+    <div class="bg-dark-light border border-dark-lighter rounded-lg shadow overflow-hidden">
+      <div class="px-4 py-5 sm:px-6 border-b border-dark-lighter">
+        <h3 class="text-lg leading-6 font-medium text-light">Recent Events</h3>
       </div>
-      <ul class="divide-y divide-gray-200 dark:divide-gray-700 max-h-[400px] overflow-y-auto">
+      <ul class="divide-y divide-dark-lighter max-h-[400px] overflow-y-auto">
         {#each data.events as event}
           <li class="px-4 py-4 sm:px-6">
             <div class="flex items-start space-x-3">
@@ -173,10 +173,10 @@
                 {/if}
               </div>
               <div class="flex-1 min-w-0">
-                <p class="text-sm font-medium text-gray-900 dark:text-white">
+                <p class="text-sm font-medium text-light">
                   {event.reason} <span class="text-gray-500 font-normal">on {event.object}</span>
                 </p>
-                <p class="text-sm text-gray-500 dark:text-gray-400 truncate mt-1">
+                <p class="text-sm text-muted truncate mt-1">
                   {event.message}
                 </p>
               </div>

--- a/website/src/layouts/AdminLayout.astro
+++ b/website/src/layouts/AdminLayout.astro
@@ -163,10 +163,14 @@ function isActive(href: string): boolean {
         ))}
       </nav>
 
-      <div class="px-4 py-4 border-t border-dark-lighter">
+      <div class="px-4 py-4 border-t border-dark-lighter flex flex-col gap-2">
         <a href="/" class="sidebar-footer-link flex items-center gap-1 text-xs text-muted hover:text-gold transition-colors whitespace-nowrap">
           <span>←</span>
           <span class="sidebar-label">Website</span>
+        </a>
+        <a href="/api/auth/logout" class="sidebar-footer-link flex items-center gap-1 text-xs text-muted hover:text-red-400 transition-colors whitespace-nowrap">
+          <span>⏻</span>
+          <span class="sidebar-label">Abmelden</span>
         </a>
       </div>
     </aside>

--- a/website/src/pages/api/admin/monitoring.ts
+++ b/website/src/pages/api/admin/monitoring.ts
@@ -20,8 +20,8 @@ export const GET: APIRoute = async ({ request }) => {
       k8sToken = await fs.readFile(tokenPath, 'utf-8');
       caCert = await fs.readFile(caPath, 'utf-8');
     } catch (e) {
-      return new Response(JSON.stringify({ error: 'Kubernetes credentials not found' }), {
-        status: 500,
+      return new Response(JSON.stringify({ error: 'Kein Service-Account-Token gefunden. Bitte RBAC für den website-Pod konfigurieren.' }), {
+        status: 503,
         headers: { 'Content-Type': 'application/json' },
       });
     }
@@ -147,7 +147,10 @@ export const GET: APIRoute = async ({ request }) => {
     });
 
   } catch (error: any) {
-    return new Response(JSON.stringify({ error: error.message }), {
+    const msg = error.code === 'ECONNREFUSED'
+      ? 'Kubernetes API-Server nicht erreichbar. Bitte Netzwerkrichtlinien und RBAC prüfen.'
+      : error.message;
+    return new Response(JSON.stringify({ error: msg }), {
       status: 500,
       headers: { 'Content-Type': 'application/json' }
     });


### PR DESCRIPTION
## Summary

- **Abmelden-Button**: Logout-Link im Admin-Sidebar-Footer hinzugefügt → `/api/auth/logout` (BR-20260417-b442)
- **Monitoring dark theme**: `bg-white dark:bg-gray-800` durch site-native Klassen ersetzt (`bg-dark-light`, `text-light`, `text-muted`) — Dashboard ist jetzt im dunklen Design lesbar, kein Tailwind dark-mode nötig (BR-20260417-9453)
- **Monitoring API errors**: ECONNREFUSED und fehlender SA-Token geben jetzt deutsche Hinweistexte statt rohe Fehlercodes
- **Monitoring RBAC**: ServiceAccount, ClusterRole und ClusterRoleBinding zu `website.yaml` hinzugefügt; `serviceAccountName: website` im Deployment gesetzt — sobald die k8s API-Netzwerkverbindung funktioniert, hat der Pod die nötigen Rechte

## Test plan

- [ ] Admin-Sidebar zeigt "Abmelden"-Link unten links → klicken meldet ab
- [ ] `/admin/monitoring` zeigt Fehlermeldung auf dunklem Hintergrund (statt weißen Karten)
- [ ] Fehlermeldung lautet "Kubernetes API-Server nicht erreichbar…" statt rohem 500-Fehler

🤖 Generated with [Claude Code](https://claude.com/claude-code)