### PR TITLE
fix(admin): resolve monitoring 500 error and add chat room member management

### DIFF
--- a/website/src/components/ChatRoomPanel.svelte
+++ b/website/src/components/ChatRoomPanel.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
   import type { ChatRoom, ChatMessage } from '../lib/messaging-db';
 
+  type Member = { customer_id: string; name: string; email: string };
+  type Customer = { id: string; name: string; email: string };
+
   const {
     rooms: initialRooms,
     role,
@@ -14,6 +17,7 @@
   let rooms = $state<ChatRoom[]>(initialRooms);
   let activeRoom = $state<ChatRoom | null>(null);
   let messages = $state<ChatMessage[]>([]);
+  let members = $state<Member[]>([]);
   let newBody = $state('');
   let sending = $state(false);
   let lastId = $state(0);
@@ -22,12 +26,24 @@
   let showNewRoom = $state(false);
   let newRoomName = $state('');
 
+  let showMembers = $state(false);
+  let allCustomers = $state<Customer[]>([]);
+  let memberSearch = $state('');
+  let memberLoading = $state(false);
+
+  // Admin uses /api/admin/rooms/[id] (no /messages suffix)
+  // Portal uses /api/portal/rooms/[id]/messages
+  function roomUrl(roomId: number) {
+    return role === 'admin'
+      ? `${messagesBaseUrl}/${roomId}`
+      : `${messagesBaseUrl}/${roomId}/messages`;
+  }
+
   function startPolling() {
     if (pollInterval) clearInterval(pollInterval);
     pollInterval = setInterval(async () => {
       if (!activeRoom) return;
-      const url = `${messagesBaseUrl}/${activeRoom.id}/messages?after=${lastId}`;
-      const res = await fetch(url);
+      const res = await fetch(`${roomUrl(activeRoom.id)}?after=${lastId}`);
       if (!res.ok) return;
       const data = await res.json() as { messages: ChatMessage[] };
       if (data.messages.length > 0) {
@@ -40,13 +56,16 @@
   async function openRoom(room: ChatRoom) {
     if (pollInterval) clearInterval(pollInterval);
     activeRoom = room;
+    showMembers = false;
     try {
-      const res = await fetch(`${messagesBaseUrl}/${room.id}/messages`);
-      const data = await res.json() as { messages: ChatMessage[] };
+      const res = await fetch(roomUrl(room.id));
+      const data = await res.json() as { messages: ChatMessage[]; members?: Member[] };
       messages = data.messages;
+      members = data.members ?? [];
       lastId = messages.length ? messages[messages.length - 1].id : 0;
     } catch {
       messages = [];
+      members = [];
       lastId = 0;
     }
     startPolling();
@@ -55,7 +74,7 @@
   async function sendMessage() {
     if (!newBody.trim() || !activeRoom || sending) return;
     sending = true;
-    const res = await fetch(`${messagesBaseUrl}/${activeRoom.id}/messages`, {
+    const res = await fetch(roomUrl(activeRoom.id), {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ body: newBody.trim() }),
@@ -83,6 +102,44 @@
       newRoomName = '';
     }
   }
+
+  async function openMembers() {
+    showMembers = !showMembers;
+    if (showMembers && allCustomers.length === 0) {
+      memberLoading = true;
+      try {
+        const res = await fetch('/api/admin/customers');
+        const data = await res.json() as { customers: Customer[] };
+        allCustomers = data.customers;
+      } finally {
+        memberLoading = false;
+      }
+    }
+  }
+
+  async function toggleMember(customer: Customer) {
+    if (!activeRoom) return;
+    const isMember = members.some(m => m.customer_id === customer.id);
+    const res = await fetch(`${messagesBaseUrl}/${activeRoom.id}/members`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ customerId: customer.id, action: isMember ? 'remove' : 'add' }),
+    });
+    if (res.ok) {
+      if (isMember) {
+        members = members.filter(m => m.customer_id !== customer.id);
+      } else {
+        members = [...members, { customer_id: customer.id, name: customer.name, email: customer.email }];
+      }
+    }
+  }
+
+  let filteredCustomers = $derived(
+    allCustomers.filter(c =>
+      !memberSearch || c.name.toLowerCase().includes(memberSearch.toLowerCase()) ||
+      c.email.toLowerCase().includes(memberSearch.toLowerCase())
+    )
+  );
 
   function formatTime(date: Date | string): string {
     return new Date(date).toLocaleTimeString('de-DE', { hour: '2-digit', minute: '2-digit' });
@@ -127,7 +184,41 @@
     {#if !activeRoom}
       <p class="hint">Raum auswählen.</p>
     {:else}
-      <div class="chat-header">{activeRoom.name}</div>
+      <div class="chat-header">
+        <span>{activeRoom.name}</span>
+        {#if role === 'admin'}
+          <button class="btn-members" onclick={openMembers}>
+            👥 Mitglieder ({members.length})
+          </button>
+        {/if}
+      </div>
+
+      {#if showMembers && role === 'admin'}
+        <div class="members-panel">
+          <div class="members-search">
+            <input bind:value={memberSearch} placeholder="Kunde suchen…" />
+          </div>
+          {#if memberLoading}
+            <p class="members-hint">Lade…</p>
+          {:else if allCustomers.length === 0}
+            <p class="members-hint">Keine Kunden vorhanden.</p>
+          {:else}
+            <ul class="members-list">
+              {#each filteredCustomers as c (c.id)}
+                {@const isMember = members.some(m => m.customer_id === c.id)}
+                <li class="member-row {isMember ? 'is-member' : ''}">
+                  <span class="member-name">{c.name}</span>
+                  <span class="member-email">{c.email}</span>
+                  <button class="btn-toggle" onclick={() => toggleMember(c)}>
+                    {isMember ? '−' : '+'}
+                  </button>
+                </li>
+              {/each}
+            </ul>
+          {/if}
+        </div>
+      {/if}
+
       <div class="msg-list">
         {#each messages as msg (msg.id)}
           <div class="msg">
@@ -157,7 +248,20 @@
   .room-item:hover:not(.active) { background: #1e1e2e; }
   .empty, .hint { color: #555; font-size: 13px; padding: 16px; }
   .chat-view { flex: 1; display: flex; flex-direction: column; min-width: 0; }
-  .chat-header { padding: 12px 16px; border-bottom: 1px solid #2a2a3e; font-weight: 600; font-size: 14px; }
+  .chat-header { padding: 10px 16px; border-bottom: 1px solid #2a2a3e; font-weight: 600; font-size: 14px; display: flex; justify-content: space-between; align-items: center; }
+  .btn-members { background: #374151; color: #ccc; border: none; border-radius: 4px; padding: 4px 10px; font-size: 12px; cursor: pointer; }
+  .btn-members:hover { background: #4b5563; }
+  .members-panel { border-bottom: 1px solid #2a2a3e; background: #13131f; max-height: 240px; display: flex; flex-direction: column; }
+  .members-search { padding: 8px 12px; border-bottom: 1px solid #2a2a3e; }
+  .members-search input { width: 100%; background: #1e1e2e; color: #e8e8f0; border: 1px solid #374151; border-radius: 4px; padding: 5px 8px; font-size: 12px; box-sizing: border-box; }
+  .members-hint { color: #555; font-size: 12px; padding: 10px 12px; margin: 0; }
+  .members-list { list-style: none; margin: 0; padding: 0; overflow-y: auto; flex: 1; }
+  .member-row { display: flex; align-items: center; gap: 8px; padding: 6px 12px; border-bottom: 1px solid #1e1e2e; }
+  .member-row.is-member { background: #1a2435; }
+  .member-name { font-size: 12px; color: #e8e8f0; flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .member-email { font-size: 11px; color: #666; flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .btn-toggle { background: #374151; color: #e8e8f0; border: none; border-radius: 4px; padding: 2px 8px; font-size: 14px; cursor: pointer; font-weight: bold; flex-shrink: 0; }
+  .member-row.is-member .btn-toggle { background: #7f1d1d; color: #fca5a5; }
   .msg-list { flex: 1; overflow-y: auto; padding: 16px; display: flex; flex-direction: column; gap: 8px; }
   .msg { background: #1e1e2e; border-radius: 6px; padding: 8px 12px; }
   .msg-meta { font-size: 10px; color: #666; display: block; margin-bottom: 4px; }

--- a/website/src/pages/api/admin/customers.ts
+++ b/website/src/pages/api/admin/customers.ts
@@ -1,0 +1,10 @@
+import type { APIRoute } from 'astro';
+import { getSession, isAdmin } from '../../../lib/auth';
+import { listAllCustomers } from '../../../lib/messaging-db';
+
+export const GET: APIRoute = async ({ request }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 });
+  const customers = await listAllCustomers();
+  return new Response(JSON.stringify({ customers }), { headers: { 'Content-Type': 'application/json' } });
+};

--- a/website/src/pages/api/admin/monitoring.ts
+++ b/website/src/pages/api/admin/monitoring.ts
@@ -79,7 +79,8 @@ export const GET: APIRoute = async ({ request }) => {
         const metrics = podMetrics.items.find((m: any) => m.metadata.name === pod.metadata.name);
         if (metrics && metrics.containers && metrics.containers.length > 0) {
            const cpuUsage = metrics.containers.reduce((acc: number, c: any) => {
-              const val = c.usage.cpu;
+              const val = c.usage?.cpu;
+              if (!val) return acc;
               if (val.endsWith('n')) return acc + parseInt(val) / 1000000;
               if (val.endsWith('u')) return acc + parseInt(val) / 1000;
               if (val.endsWith('m')) return acc + parseInt(val);
@@ -88,7 +89,8 @@ export const GET: APIRoute = async ({ request }) => {
            cpu = `${Math.round(cpuUsage)}m`;
 
            const memUsage = metrics.containers.reduce((acc: number, c: any) => {
-              const val = c.usage.memory;
+              const val = c.usage?.memory;
+              if (!val) return acc;
               if (val.endsWith('Ki')) return acc + parseInt(val) / 1024;
               if (val.endsWith('Mi')) return acc + parseInt(val);
               if (val.endsWith('Gi')) return acc + parseInt(val) * 1024;
@@ -109,10 +111,15 @@ export const GET: APIRoute = async ({ request }) => {
     });
 
     const events = eventsData.value.items
-      .sort((a: any, b: any) => new Date(b.lastTimestamp).getTime() - new Date(a.lastTimestamp).getTime())
+      .sort((a: any, b: any) => {
+        const tA = new Date(a.lastTimestamp ?? a.eventTime ?? 0).getTime();
+        const tB = new Date(b.lastTimestamp ?? b.eventTime ?? 0).getTime();
+        return tB - tA;
+      })
       .slice(0, 10)
       .map((event: any) => {
-        const ageMs = Date.now() - new Date(event.lastTimestamp).getTime();
+        const ts = event.lastTimestamp ?? event.eventTime;
+        const ageMs = ts ? Date.now() - new Date(ts).getTime() : 0;
         const ageMins = Math.floor(ageMs / 60000);
         const age = ageMins < 60 ? `${ageMins}m` : `${Math.floor(ageMins/60)}h`;
 


### PR DESCRIPTION
## Summary

- Fix `TypeError` in `/api/admin/monitoring` caused by accessing `c.usage.cpu` / `c.usage.memory` on containers where `usage` is `null`/`undefined` (transitional pod states) — was causing a 500 for every monitoring page load
- Fix K8s event sorting to fall back to `eventTime` when `lastTimestamp` is absent (newer K8s event format)
- Add member management panel to `ChatRoomPanel` (admin only): view, search, add/remove customers from a chat room
- Add `/api/admin/customers` endpoint listing all customers for the member picker
- Add `/api/admin/rooms/[id]/members` POST endpoint for toggling room membership

## Test plan

- [ ] Open admin monitoring page — should return 200 and show pod list
- [ ] Open admin chat view, select a room — "👥 Mitglieder" button visible, click shows member panel
- [ ] Search for a customer, add/remove them from the room
- [ ] Verify `/api/admin/customers` returns customer list
- [ ] Verify portal chat (non-admin) shows no member button

🤖 Generated with [Claude Code](https://claude.com/claude-code)