### PR TITLE
fix(admin): replace native fetch with https.request for Kubernetes API calls

### DIFF
--- a/website/src/pages/api/admin/monitoring.ts
+++ b/website/src/pages/api/admin/monitoring.ts
@@ -26,24 +26,31 @@ export const GET: APIRoute = async ({ request }) => {
       });
     }
 
-    const httpsAgent = new https.Agent({
-      ca: caCert,
-    });
-
-    const fetchK8s = async (path: string) => {
-      const res = await fetch(`https://kubernetes.default.svc${path}`, {
-        headers: {
-          Authorization: `Bearer ${k8sToken}`,
-          Accept: 'application/json',
-        },
-        // @ts-ignore - node-fetch specific
-        agent: httpsAgent,
+    const fetchK8s = (path: string): Promise<any> =>
+      new Promise((resolve, reject) => {
+        const req = https.request(
+          {
+            hostname: 'kubernetes.default.svc',
+            path,
+            method: 'GET',
+            headers: { Authorization: `Bearer ${k8sToken}`, Accept: 'application/json' },
+            ca: caCert,
+          },
+          (res) => {
+            let data = '';
+            res.on('data', (chunk: string) => { data += chunk; });
+            res.on('end', () => {
+              if (res.statusCode && res.statusCode >= 400) {
+                reject(new Error(`Kubernetes API error: ${res.statusCode} ${res.statusMessage}`));
+              } else {
+                try { resolve(JSON.parse(data)); } catch (e) { reject(e); }
+              }
+            });
+          }
+        );
+        req.on('error', reject);
+        req.end();
       });
-      if (!res.ok) {
-        throw new Error(`Kubernetes API error: ${res.status} ${res.statusText}`);
-      }
-      return res.json();
-    };
 
     // Parallel fetches
     const [podsData, eventsData, podMetricsResult, nodeMetricsResult] = await Promise.allSettled([


### PR DESCRIPTION
## Summary
- Node.js 18+ native `fetch` ignores the `agent` option (a `node-fetch`-specific feature), so the CA certificate was silently dropped
- TLS verification against `kubernetes.default.svc` failed, causing the monitoring endpoint to always return 500
- Replaced with `node:https.request` (already imported) which properly supports the `ca` option

## Test plan
- [ ] Visit `/admin/monitoring` — should load pod status and events without error
- [ ] Verify no 500 response in browser DevTools network tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)