### PR TITLE
fix(monitoring): allow port 6443 egress + chat widget + inbox thread view

### DIFF
--- a/k3d/website.yaml
+++ b/k3d/website.yaml
@@ -142,6 +142,7 @@ spec:
                     operator: NotIn
                     values:
                       - pk-hetzner
+                      - gekko-hetzner-4
       containers:
         - name: website
           image: ghcr.io/paddione/${WEBSITE_IMAGE}:latest
@@ -452,4 +453,6 @@ spec:
   egress:
   - ports:
     - port: 443
+      protocol: TCP
+    - port: 6443
       protocol: TCP

--- a/website/src/components/ChatWidget.svelte
+++ b/website/src/components/ChatWidget.svelte
@@ -1,0 +1,284 @@
+<script lang="ts">
+  import type { Message, MessageThread } from '../lib/messaging-db';
+
+  type AuthResponse = { authenticated: false } | { authenticated: true; user: { name: string; isAdmin: boolean } };
+
+  let open = $state(false);
+  let visible = $state(false);
+  let thread = $state<MessageThread | null>(null);
+  let messages = $state<Message[]>([]);
+  let newBody = $state('');
+  let sending = $state(false);
+  let loading = $state(true);
+  let pollInterval: ReturnType<typeof setInterval> | null = null;
+  let msgContainer = $state<HTMLDivElement | null>(null);
+
+  $effect(() => {
+    initWidget();
+    return () => { if (pollInterval) clearInterval(pollInterval); };
+  });
+
+  async function initWidget() {
+    try {
+      const res = await fetch('/api/auth/me');
+      const data = await res.json() as AuthResponse;
+      if (!data.authenticated || data.user.isAdmin) return;
+      visible = true;
+      await loadThread();
+    } finally {
+      loading = false;
+    }
+  }
+
+  async function loadThread() {
+    const res = await fetch('/api/portal/messages');
+    if (!res.ok) return;
+    const data = await res.json() as { thread: MessageThread | null };
+    thread = data.thread;
+    if (thread) {
+      await fetchMessages();
+    }
+  }
+
+  async function fetchMessages() {
+    if (!thread) return;
+    const res = await fetch(`/api/portal/messages/${thread.id}`);
+    if (!res.ok) return;
+    const data = await res.json() as { messages: Message[] };
+    messages = data.messages;
+    scrollToBottom();
+  }
+
+  function startPolling() {
+    if (pollInterval) clearInterval(pollInterval);
+    pollInterval = setInterval(async () => {
+      if (!open || !thread) return;
+      await fetchMessages();
+    }, 5000);
+  }
+
+  async function toggleOpen() {
+    open = !open;
+    if (open) {
+      if (!thread) await loadThread();
+      else await fetchMessages();
+      startPolling();
+      scrollToBottom();
+    } else {
+      if (pollInterval) clearInterval(pollInterval);
+    }
+  }
+
+  async function sendMessage() {
+    if (!newBody.trim() || sending) return;
+    sending = true;
+    const body = newBody.trim();
+    newBody = '';
+    try {
+      const url = thread ? `/api/portal/messages/${thread.id}` : '/api/portal/messages';
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ body }),
+      });
+      if (res.ok) {
+        const data = await res.json() as { message: Message; thread?: MessageThread };
+        if (data.thread) thread = data.thread;
+        messages = [...messages, data.message];
+        scrollToBottom();
+      }
+    } finally {
+      sending = false;
+    }
+  }
+
+  function handleKeydown(e: KeyboardEvent) {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      sendMessage();
+    }
+  }
+
+  function scrollToBottom() {
+    setTimeout(() => {
+      if (msgContainer) msgContainer.scrollTop = msgContainer.scrollHeight;
+    }, 50);
+  }
+</script>
+
+{#if visible}
+  <div class="chat-widget">
+    {#if open}
+      <div class="chat-panel">
+        <div class="chat-header">
+          <span>💬 Nachrichten</span>
+          <button class="close-btn" onclick={toggleOpen} aria-label="Schließen">✕</button>
+        </div>
+        <div class="chat-body" bind:this={msgContainer}>
+          {#if loading}
+            <p class="chat-hint">Lade…</p>
+          {:else if messages.length === 0}
+            <p class="chat-hint">Noch keine Nachrichten. Schreib uns gerne!</p>
+          {:else}
+            {#each messages as msg (msg.id)}
+              <div class="chat-msg {msg.sender_role === 'user' ? 'msg-me' : 'msg-admin'}">
+                <span class="msg-text">{msg.body}</span>
+                <span class="msg-time">
+                  {new Date(msg.created_at).toLocaleTimeString('de-DE', { hour: '2-digit', minute: '2-digit' })}
+                </span>
+              </div>
+            {/each}
+          {/if}
+        </div>
+        <div class="chat-footer">
+          <textarea
+            bind:value={newBody}
+            onkeydown={handleKeydown}
+            placeholder="Nachricht schreiben… (Enter zum Senden)"
+            rows="2"
+            disabled={sending}
+          ></textarea>
+          <button class="send-btn" onclick={sendMessage} disabled={!newBody.trim() || sending}>
+            {sending ? '…' : '➤'}
+          </button>
+        </div>
+      </div>
+    {/if}
+    <button class="toggle-btn" onclick={toggleOpen} aria-label="Chat öffnen/schließen">
+      {open ? '✕' : '💬'}
+    </button>
+  </div>
+{/if}
+
+<style>
+  .chat-widget {
+    position: fixed;
+    bottom: 24px;
+    right: 24px;
+    z-index: 9000;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 10px;
+  }
+  .chat-panel {
+    width: 320px;
+    background: #1a2235;
+    border: 1px solid #243049;
+    border-radius: 12px;
+    display: flex;
+    flex-direction: column;
+    box-shadow: 0 8px 32px rgba(0,0,0,.5);
+    overflow: hidden;
+  }
+  .chat-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 12px 16px;
+    background: #243049;
+    font-size: 14px;
+    font-weight: 600;
+    color: #e8e8f0;
+  }
+  .close-btn {
+    background: transparent;
+    border: none;
+    color: #aabbcc;
+    cursor: pointer;
+    font-size: 14px;
+    padding: 0;
+    line-height: 1;
+  }
+  .chat-body {
+    flex: 1;
+    overflow-y: auto;
+    padding: 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    min-height: 220px;
+    max-height: 340px;
+  }
+  .chat-hint {
+    font-size: 12px;
+    color: #8899aa;
+    text-align: center;
+    margin: auto 0;
+  }
+  .chat-msg {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    max-width: 85%;
+  }
+  .msg-me { align-self: flex-end; }
+  .msg-admin { align-self: flex-start; }
+  .msg-text {
+    padding: 8px 12px;
+    border-radius: 12px;
+    font-size: 13px;
+    color: #e8e8f0;
+    white-space: pre-wrap;
+    word-break: break-word;
+    line-height: 1.4;
+  }
+  .msg-me .msg-text { background: #e8c870; color: #0f1623; border-bottom-right-radius: 4px; }
+  .msg-admin .msg-text { background: #243049; border-bottom-left-radius: 4px; }
+  .msg-time {
+    font-size: 10px;
+    color: #5566aa;
+    padding: 0 4px;
+  }
+  .msg-me .msg-time { align-self: flex-end; }
+  .chat-footer {
+    display: flex;
+    gap: 8px;
+    padding: 10px 12px;
+    border-top: 1px solid #243049;
+    align-items: flex-end;
+  }
+  .chat-footer textarea {
+    flex: 1;
+    background: #0f1623;
+    color: #e8e8f0;
+    border: 1px solid #374151;
+    border-radius: 8px;
+    padding: 8px;
+    font-size: 13px;
+    resize: none;
+    box-sizing: border-box;
+    font-family: inherit;
+    line-height: 1.4;
+  }
+  .chat-footer textarea:focus { outline: none; border-color: #e8c870; }
+  .send-btn {
+    background: #e8c870;
+    color: #0f1623;
+    border: none;
+    border-radius: 8px;
+    padding: 8px 12px;
+    font-size: 16px;
+    cursor: pointer;
+    font-weight: 700;
+    flex-shrink: 0;
+    align-self: flex-end;
+  }
+  .send-btn:disabled { opacity: .5; cursor: not-allowed; }
+  .toggle-btn {
+    width: 52px;
+    height: 52px;
+    border-radius: 50%;
+    background: #e8c870;
+    color: #0f1623;
+    border: none;
+    font-size: 22px;
+    cursor: pointer;
+    box-shadow: 0 4px 16px rgba(0,0,0,.4);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: transform .15s, box-shadow .15s;
+  }
+  .toggle-btn:hover { transform: scale(1.08); box-shadow: 0 6px 20px rgba(0,0,0,.5); }
+</style>

--- a/website/src/components/InboxApp.svelte
+++ b/website/src/components/InboxApp.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { InboxItem, InboxType, InboxStatus } from '../lib/messaging-db';
+  import type { InboxItem, InboxType, InboxStatus, Message } from '../lib/messaging-db';
 
   // Server passes initial data via props to avoid a flash of empty content
   const { initialItems, initialCounts }: {
@@ -15,6 +15,13 @@
   let errors = $state<Record<number, string>>({});
   let noteInputId = $state<number | null>(null);
   let noteText = $state('');
+
+  // Thread inline view for user_message items
+  let expandedItemId = $state<number | null>(null);
+  let threadMessages = $state<Message[]>([]);
+  let threadLoading = $state(false);
+  let replyBody = $state('');
+  let replySending = $state(false);
 
   const TYPE_LABELS: Record<string, string> = {
     registration: 'Registrierung',
@@ -101,6 +108,48 @@
       errors = { ...errors, [item.id]: 'Netzwerkfehler' };
     } finally {
       loadingAction = null;
+    }
+  }
+
+  async function toggleThread(item: InboxItem) {
+    if (expandedItemId === item.id) {
+      expandedItemId = null;
+      threadMessages = [];
+      return;
+    }
+    expandedItemId = item.id;
+    threadMessages = [];
+    replyBody = '';
+    const threadId = item.reference_id;
+    if (!threadId) return;
+    threadLoading = true;
+    try {
+      const res = await fetch(`/api/admin/messages/${threadId}`);
+      if (res.ok) {
+        const data = await res.json() as { messages: Message[] };
+        threadMessages = data.messages;
+      }
+    } finally {
+      threadLoading = false;
+    }
+  }
+
+  async function sendReply(item: InboxItem) {
+    if (!replyBody.trim() || replySending || !item.reference_id) return;
+    replySending = true;
+    try {
+      const res = await fetch(`/api/admin/messages/${item.reference_id}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ body: replyBody.trim() }),
+      });
+      if (res.ok) {
+        const data = await res.json() as { message: Message };
+        threadMessages = [...threadMessages, data.message];
+        replyBody = '';
+      }
+    } finally {
+      replySending = false;
     }
   }
 
@@ -211,7 +260,39 @@
                 <button class="btn-approve" disabled={loadingAction === item.id} onclick={() => executeAction(item, 'finalize_meeting')}>
                   {loadingAction === item.id ? '…' : '▶ Finalisieren'}
                 </button>
+              {:else if item.type === 'user_message'}
+                <button class="btn-chat" onclick={() => toggleThread(item)}>
+                  {expandedItemId === item.id ? '▲ Schließen' : '💬 Konversation'}
+                </button>
+                <button class="btn-secondary" disabled={loadingAction === item.id} onclick={() => executeAction(item, 'close_user_message')}>
+                  {loadingAction === item.id ? '…' : '✓ Erledigt'}
+                </button>
               {/if}
+            </div>
+          {/if}
+          {#if item.type === 'user_message' && expandedItemId === item.id}
+            <div class="thread-panel">
+              {#if threadLoading}
+                <p class="thread-loading">Lade Konversation…</p>
+              {:else if threadMessages.length === 0}
+                <p class="thread-empty">Keine Nachrichten.</p>
+              {:else}
+                <div class="thread-messages">
+                  {#each threadMessages as msg (msg.id)}
+                    <div class="thread-msg {msg.sender_role === 'admin' ? 'msg-admin' : 'msg-user'}">
+                      <span class="msg-role">{msg.sender_role === 'admin' ? 'Du' : 'Nutzer'}</span>
+                      <span class="msg-body">{msg.body}</span>
+                      <span class="msg-time">{relativeTime(msg.created_at)}</span>
+                    </div>
+                  {/each}
+                </div>
+              {/if}
+              <div class="thread-reply">
+                <textarea bind:value={replyBody} placeholder="Antwort schreiben…" rows="2" disabled={replySending}></textarea>
+                <button class="btn-primary" disabled={!replyBody.trim() || replySending} onclick={() => sendReply(item)}>
+                  {replySending ? '…' : 'Senden'}
+                </button>
+              </div>
             </div>
           {/if}
         </div>
@@ -251,4 +332,16 @@
   .note-wrap { margin-top: 10px; }
   .note-wrap textarea { width: 100%; background: #111827; color: #e8e8f0; border: 1px solid #374151; border-radius: 4px; padding: 8px; font-size: 13px; resize: vertical; box-sizing: border-box; }
   .note-actions { display: flex; justify-content: flex-end; gap: 8px; margin-top: 8px; }
+  .btn-chat { background: #34d399; color: #000; padding: 5px 12px; border: none; border-radius: 4px; font-size: 12px; cursor: pointer; font-weight: 600; }
+  .thread-panel { margin-top: 12px; border-top: 1px solid #2a2a3e; padding-top: 12px; }
+  .thread-loading, .thread-empty { font-size: 12px; color: #666; margin: 0 0 8px; }
+  .thread-messages { display: flex; flex-direction: column; gap: 6px; max-height: 240px; overflow-y: auto; margin-bottom: 10px; }
+  .thread-msg { display: flex; flex-direction: column; gap: 2px; padding: 8px 10px; border-radius: 6px; max-width: 80%; }
+  .msg-admin { background: #1e3a5f; align-self: flex-end; }
+  .msg-user { background: #1e2a1e; align-self: flex-start; }
+  .msg-role { font-size: 10px; font-weight: 700; text-transform: uppercase; color: #888; }
+  .msg-body { font-size: 13px; color: #e8e8f0; white-space: pre-wrap; word-break: break-word; }
+  .msg-time { font-size: 10px; color: #555; align-self: flex-end; }
+  .thread-reply { display: flex; gap: 8px; align-items: flex-end; }
+  .thread-reply textarea { flex: 1; background: #111827; color: #e8e8f0; border: 1px solid #374151; border-radius: 4px; padding: 8px; font-size: 13px; resize: none; box-sizing: border-box; }
 </style>

--- a/website/src/layouts/Layout.astro
+++ b/website/src/layouts/Layout.astro
@@ -1,6 +1,7 @@
 ---
 import Navigation from '../components/Navigation.svelte';
 import CookieConsent from '../components/CookieConsent.svelte';
+import ChatWidget from '../components/ChatWidget.svelte';
 import '../styles/global.css';
 import { config } from '../config/index';
 import { getEffectiveServices } from '../lib/content';
@@ -79,5 +80,6 @@ const { title, description = config.meta.siteDescription } = Astro.props;
       </div>
     </footer>
     <CookieConsent client:load />
+    <ChatWidget client:load />
   </body>
 </html>

--- a/website/src/pages/api/admin/inbox/[id]/action.ts
+++ b/website/src/pages/api/admin/inbox/[id]/action.ts
@@ -158,6 +158,11 @@ export const POST: APIRoute = async ({ request, params }) => {
         return new Response(JSON.stringify({ success: true }), { headers: { 'Content-Type': 'application/json' } });
       }
 
+      case 'close_user_message': {
+        await updateInboxItemStatus(id, 'actioned', session.preferred_username);
+        return new Response(JSON.stringify({ success: true }), { headers: { 'Content-Type': 'application/json' } });
+      }
+
       case 'finalize_meeting': {
         const p = item.payload as {
           customerName: string; customerEmail: string; meetingType: string;


### PR DESCRIPTION
## Summary

- **Monitoring fix**: K8s API endpoints on this Hetzner cluster use public IPs on port 6443. After kube-proxy DNAT, port 6443 was blocked by the website namespace NetworkPolicy (`allow-https-egress` only had port 443). Added port 6443 to fix the `/api/admin/monitoring` endpoint.
- **Node affinity**: Excludes `gekko-hetzner-4` from website deployment (node was overloaded).
- **ChatWidget**: Integrated into global `Layout.astro` so it appears on all pages.
- **Inbox thread view**: Admin can now expand `user_message` inbox items to view the full conversation thread inline and send replies directly from the inbox.
- **close_user_message action**: New action to mark user message inbox items as actioned.

## Test plan

- [ ] Open `/admin/monitoring` — pods and events should load without 500 error
- [ ] Open any page on the website — ChatWidget should appear
- [ ] In admin inbox, open a `user_message` item and verify thread loads and reply sends
- [ ] Mark a `user_message` as "Erledigt" — status should change to actioned

🤖 Generated with [Claude Code](https://claude.com/claude-code)