### PR TITLE
fix(ingress): move website ingress to website namespace

### DIFF
--- a/prod/ingress.yaml
+++ b/prod/ingress.yaml
@@ -98,11 +98,12 @@ spec:
                 port:
                   number: 80
 ---
-# ── Website (Astro) ─────────────────────────────────────────────────
+# ── Website (Astro) — Namespace: website (service lives there) ───────
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: workspace-ingress-web
+  name: website-ingress-web
+  namespace: website
   annotations:
     traefik.ingress.kubernetes.io/router.middlewares: "workspace-redirect-https@kubernetescrd,workspace-hsts-headers@kubernetescrd,workspace-security-headers@kubernetescrd,workspace-rate-limit-web@kubernetescrd"
 spec:


### PR DESCRIPTION
## Summary

- The `website` Service lives in the `website` namespace, not `workspace`
- The old `workspace-ingress-web` in the `workspace` namespace could not resolve the backend (`website:80 <none>`) — causing 404 on `web.mentolder.de`
- Renamed to `website-ingress-web` and added `namespace: website` so kustomize's `namespace: workspace` does not override it
- All workspace middlewares are still referenced via the `namespace-name@kubernetescrd` annotation format (cross-namespace middleware references work in standard Ingress annotations)
- The `workspace-wildcard-tls` secret has been copied to the `website` namespace on the live cluster

## Test plan

- [x] `https://web.mentolder.de/` returns HTTP 200 (verified live)
- [ ] After next ArgoCD sync / `task workspace:prod:deploy`, ingress is in correct namespace

🤖 Generated with [Claude Code](https://claude.com/claude-code)