### PR TITLE
fix(ui): redesign user menu and admin sidebar to match site aesthetic

### DIFF
--- a/docs/superpowers/plans/2026-04-18-monitoring-event-to-bug-ticket.md
+++ b/docs/superpowers/plans/2026-04-18-monitoring-event-to-bug-ticket.md
@@ -1,0 +1,350 @@
+# Monitoring Event → Bug Ticket Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a bug-icon button to each Recent Events row in the monitoring dashboard that opens a pre-filled modal for creating a bug ticket via a new admin-only API endpoint.
+
+**Architecture:** A new `POST /api/admin/bugs/create` endpoint accepts JSON `{description, category}`, fills server-side fields from the admin session, and calls the existing `insertBugTicket` DB function. `MonitoringDashboard.svelte` gains per-row buttons and an overlay modal with pre-filled description from the event data.
+
+**Tech Stack:** Astro API routes (TypeScript), Svelte 4, Tailwind CSS, PostgreSQL via existing `insertBugTicket` helper in `website-db.ts`.
+
+---
+
+## File Map
+
+| Action | Path |
+|---|---|
+| Create | `website/src/pages/api/admin/bugs/create.ts` |
+| Modify | `website/src/components/admin/MonitoringDashboard.svelte` |
+
+---
+
+### Task 1: New API endpoint `/api/admin/bugs/create`
+
+**Files:**
+- Create: `website/src/pages/api/admin/bugs/create.ts`
+
+- [ ] **Step 1: Create the endpoint file**
+
+```typescript
+// website/src/pages/api/admin/bugs/create.ts
+import type { APIRoute } from 'astro';
+import { getSession, isAdmin } from '../../../../lib/auth';
+import { insertBugTicket } from '../../../../lib/website-db';
+
+const BRAND = process.env.BRAND || 'mentolder';
+const VALID_CATEGORIES = new Set(['fehler', 'verbesserung', 'erweiterungswunsch']);
+
+function jsonError(message: string, status: number): Response {
+  return new Response(JSON.stringify({ error: message }), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function generateTicketId(): string {
+  const today = new Date().toISOString().slice(0, 10).replace(/-/g, '');
+  const rand = Math.floor(Math.random() * 0x10000).toString(16).padStart(4, '0');
+  return `BR-${today}-${rand}`;
+}
+
+export const POST: APIRoute = async ({ request }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) {
+    return jsonError('Nicht autorisiert', 401);
+  }
+
+  let body: { description?: unknown; category?: unknown };
+  try {
+    body = await request.json();
+  } catch {
+    return jsonError('Ungültiger JSON-Body', 400);
+  }
+
+  const description = (typeof body.description === 'string' ? body.description : '').trim();
+  const category = (typeof body.category === 'string' ? body.category : '').trim();
+
+  if (!description) {
+    return jsonError('Beschreibung ist erforderlich', 400);
+  }
+  if (description.length > 2000) {
+    return jsonError('Beschreibung zu lang (max. 2000 Zeichen)', 400);
+  }
+  if (!VALID_CATEGORIES.has(category)) {
+    return jsonError('Ungültige Kategorie', 400);
+  }
+
+  const ticketId = generateTicketId();
+
+  try {
+    await insertBugTicket({
+      ticketId,
+      category,
+      reporterEmail: session.email,
+      description,
+      url: '/admin/monitoring',
+      brand: BRAND,
+    });
+  } catch (err) {
+    console.error('[bugs/create] DB error:', err);
+    return jsonError('Datenbankfehler', 500);
+  }
+
+  return new Response(JSON.stringify({ ticketId }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+};
+```
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+```bash
+cd /home/patrick/Bachelorprojekt/website && npx tsc --noEmit 2>&1 | head -30
+```
+
+Expected: no errors related to the new file.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add website/src/pages/api/admin/bugs/create.ts
+git commit -m "feat(admin): add /api/admin/bugs/create endpoint for monitoring-sourced tickets"
+```
+
+---
+
+### Task 2: Bug button + modal in MonitoringDashboard.svelte
+
+**Files:**
+- Modify: `website/src/components/admin/MonitoringDashboard.svelte`
+
+- [ ] **Step 1: Add modal state variables to the `<script>` block**
+
+In `MonitoringDashboard.svelte`, after the existing `let` declarations (after line 32), add:
+
+```typescript
+  let selectedEvent: Event | null = null;
+  let modalDescription = '';
+  let modalCategory = 'fehler';
+  let modalLoading = false;
+  let modalError: string | null = null;
+  let modalSuccessId: string | null = null;
+  let modalCloseTimer: ReturnType<typeof setTimeout> | null = null;
+
+  function openModal(event: Event) {
+    selectedEvent = event;
+    modalDescription = `${event.reason} on ${event.object}: ${event.message}`;
+    modalCategory = 'fehler';
+    modalLoading = false;
+    modalError = null;
+    modalSuccessId = null;
+  }
+
+  function closeModal() {
+    if (modalCloseTimer) clearTimeout(modalCloseTimer);
+    selectedEvent = null;
+    modalSuccessId = null;
+    modalError = null;
+  }
+
+  async function submitTicket() {
+    if (!selectedEvent) return;
+    modalLoading = true;
+    modalError = null;
+    try {
+      const res = await fetch('/api/admin/bugs/create', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ description: modalDescription, category: modalCategory }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        modalError = data.error ?? 'Unbekannter Fehler';
+        return;
+      }
+      modalSuccessId = data.ticketId;
+      modalCloseTimer = setTimeout(closeModal, 3000);
+    } catch {
+      modalError = 'Netzwerkfehler';
+    } finally {
+      modalLoading = false;
+    }
+  }
+```
+
+- [ ] **Step 2: Add the bug-icon button to each event row**
+
+In the `{#each data.events as event}` block, the current row ends with:
+
+```html
+              <div class="flex-shrink-0 text-xs text-gray-500">
+                {event.age}
+              </div>
+```
+
+Replace that `</div>` section with:
+
+```html
+              <div class="flex-shrink-0 flex items-center gap-2 text-xs text-gray-500">
+                <span>{event.age}</span>
+                <button
+                  on:click={() => openModal(event)}
+                  title="Bug Ticket erstellen"
+                  class="text-gray-400 hover:text-red-500 transition-colors"
+                  aria-label="Bug Ticket erstellen"
+                >
+                  <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+                    <path fill-rule="evenodd" d="M6.267 3.455a3.066 3.066 0 001.745-.723 3.066 3.066 0 013.976 0 3.066 3.066 0 001.745.723 3.066 3.066 0 012.812 2.812c.051.643.304 1.254.723 1.745a3.066 3.066 0 010 3.976 3.066 3.066 0 00-.723 1.745 3.066 3.066 0 01-2.812 2.812 3.066 3.066 0 00-1.745.723 3.066 3.066 0 01-3.976 0 3.066 3.066 0 00-1.745-.723 3.066 3.066 0 01-2.812-2.812 3.066 3.066 0 00-.723-1.745 3.066 3.066 0 010-3.976 3.066 3.066 0 00.723-1.745 3.066 3.066 0 012.812-2.812zm7.44 5.252a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd" />
+                  </svg>
+                </button>
+              </div>
+```
+
+- [ ] **Step 3: Add the modal markup**
+
+At the very end of the component (after the closing `</div>` of the whole `<div class="space-y-6">` block, before the end of file), add:
+
+```html
+{#if selectedEvent}
+  <!-- Modal backdrop -->
+  <div
+    class="fixed inset-0 bg-black/60 z-50 flex items-center justify-center p-4"
+    on:click|self={closeModal}
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="modal-title"
+  >
+    <div class="bg-dark-light border border-dark-lighter rounded-lg shadow-xl w-full max-w-lg">
+      <!-- Header -->
+      <div class="px-6 py-4 border-b border-dark-lighter flex items-center justify-between">
+        <h2 id="modal-title" class="text-lg font-semibold text-light">Bug Ticket erstellen</h2>
+        <button on:click={closeModal} class="text-gray-400 hover:text-light transition-colors" aria-label="Schließen">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+            <path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd" />
+          </svg>
+        </button>
+      </div>
+
+      <!-- Body -->
+      <div class="px-6 py-4 space-y-4">
+        <!-- Event summary -->
+        <p class="text-xs text-muted font-mono bg-dark rounded px-3 py-2">
+          {selectedEvent.type} · {selectedEvent.reason} · {selectedEvent.object}
+        </p>
+
+        {#if modalSuccessId}
+          <div class="text-sm text-green-500 space-y-1">
+            <p>Ticket erstellt: <strong>{modalSuccessId}</strong></p>
+            <a href="/admin/bugs" class="underline hover:text-green-400">Zur Ticket-Übersicht →</a>
+            <p class="text-xs text-muted">Schließt in 3 Sekunden…</p>
+          </div>
+        {:else}
+          <!-- Description -->
+          <div>
+            <label for="modal-desc" class="block text-sm font-medium text-light mb-1">Beschreibung</label>
+            <textarea
+              id="modal-desc"
+              bind:value={modalDescription}
+              rows={4}
+              maxlength={2000}
+              class="w-full rounded-md border border-dark-lighter bg-dark text-light text-sm px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            ></textarea>
+          </div>
+
+          <!-- Category -->
+          <div>
+            <label for="modal-cat" class="block text-sm font-medium text-light mb-1">Kategorie</label>
+            <select
+              id="modal-cat"
+              bind:value={modalCategory}
+              class="w-full rounded-md border border-dark-lighter bg-dark text-light text-sm px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            >
+              <option value="fehler">Fehler</option>
+              <option value="verbesserung">Verbesserung</option>
+              <option value="erweiterungswunsch">Erweiterungswunsch</option>
+            </select>
+          </div>
+
+          {#if modalError}
+            <p class="text-sm text-red-500">{modalError}</p>
+          {/if}
+        {/if}
+      </div>
+
+      <!-- Footer -->
+      {#if !modalSuccessId}
+        <div class="px-6 py-4 border-t border-dark-lighter flex justify-end gap-3">
+          <button
+            on:click={closeModal}
+            class="px-4 py-2 text-sm rounded-md border border-dark-lighter text-light hover:bg-dark transition-colors"
+          >
+            Abbrechen
+          </button>
+          <button
+            on:click={submitTicket}
+            disabled={modalLoading || !modalDescription.trim()}
+            class="px-4 py-2 text-sm rounded-md bg-blue-600 hover:bg-blue-700 text-white font-medium disabled:opacity-50 transition-colors"
+          >
+            {modalLoading ? 'Erstelle…' : 'Erstellen'}
+          </button>
+        </div>
+      {/if}
+    </div>
+  </div>
+{/if}
+```
+
+- [ ] **Step 4: Verify TypeScript compiles**
+
+```bash
+cd /home/patrick/Bachelorprojekt/website && npx tsc --noEmit 2>&1 | head -30
+```
+
+Expected: no new errors.
+
+- [ ] **Step 5: Start dev server and manually test**
+
+```bash
+cd /home/patrick/Bachelorprojekt && task website:dev
+```
+
+Navigate to `http://web.localhost/admin/monitoring` (or the local dev URL). Verify:
+
+1. Each event row shows a small icon button on the right.
+2. Clicking it opens the modal with the summary line and pre-filled description.
+3. Description is editable; category dropdown works.
+4. "Abbrechen" closes the modal.
+5. "Erstellen" submits, shows success with ticket ID and link.
+6. Modal auto-closes after ~3 seconds.
+7. Navigate to `/admin/bugs` — the new ticket appears.
+8. Verify clicking outside the modal (backdrop) also closes it.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add website/src/components/admin/MonitoringDashboard.svelte
+git commit -m "feat(admin): add 'create bug ticket' button and modal to monitoring Recent Events"
+```
+
+---
+
+### Task 3: Deploy
+
+- [ ] **Step 1: Deploy to live**
+
+```bash
+cd /home/patrick/Bachelorprojekt && task website:deploy
+```
+
+- [ ] **Step 2: Smoke-test on live**
+
+Navigate to the live monitoring page, open the modal on any event, create a ticket, confirm it appears in `/admin/bugs`.
+
+- [ ] **Step 3: Commit docs**
+
+```bash
+git add docs/superpowers/specs/2026-04-18-monitoring-event-to-bug-ticket-design.md \
+        docs/superpowers/plans/2026-04-18-monitoring-event-to-bug-ticket.md
+git commit -m "docs: add monitoring event → bug ticket spec and plan"
+```

--- a/docs/superpowers/specs/2026-04-18-monitoring-event-to-bug-ticket-design.md
+++ b/docs/superpowers/specs/2026-04-18-monitoring-event-to-bug-ticket-design.md
@@ -1,0 +1,86 @@
+# Design: Create Bug Ticket from Monitoring Event
+
+## Overview
+
+Add a "create bug ticket" action to each row in the Recent Events table on the monitoring dashboard. Clicking opens a modal pre-filled from the event data. The admin can review/edit before submitting. A new admin-only API endpoint inserts the ticket directly via the existing `insertBugTicket` DB function.
+
+## Affected Files
+
+| File | Change |
+|---|---|
+| `src/components/admin/MonitoringDashboard.svelte` | Add button per event row + modal |
+| `src/pages/api/admin/bugs/create.ts` | New endpoint (new file) |
+
+---
+
+## Component Changes: MonitoringDashboard.svelte
+
+### Event Row Button
+
+- Each row in the Recent Events table gets an always-visible bug icon button on the right column.
+- Clicking sets `selectedEvent` to that event object and opens the modal.
+- No other row styling changes.
+
+### Modal
+
+Triggered by `selectedEvent !== null`. A centered overlay with:
+
+- **Title:** "Bug Ticket erstellen"
+- **Read-only summary:** `[type] · [reason] · [object]` — identifies which event is being filed
+- **Description textarea:** pre-filled with `"[reason] on [object]: [message]"`, editable, ~4 rows
+- **Category dropdown:** options `fehler` | `verbesserung` | `erweiterungswunsch`, defaults to `fehler`
+- **Buttons:** "Erstellen" (submit) + "Abbrechen" (closes modal, clears `selectedEvent`)
+- **On success:** displays the returned `ticketId` (e.g. `BR-20260418-0001`) with a link to `/admin/bugs`, then auto-closes after 3 seconds
+- **On error:** shows an inline error message, keeps modal open
+
+### State
+
+```typescript
+let selectedEvent: Event | null = null;
+let modalDescription = '';
+let modalCategory = 'fehler';
+let modalLoading = false;
+let modalError: string | null = null;
+let modalSuccessId: string | null = null;
+```
+
+---
+
+## New API Endpoint: `/api/admin/bugs/create`
+
+**File:** `src/pages/api/admin/bugs/create.ts`
+
+**Method:** POST
+**Body:** JSON `{ description: string, category: string }`
+**Auth:** `getSession` + `isAdmin` — returns 401 if not admin
+
+**Server-side fills:**
+- `reporterEmail` — from admin session (`session.email`)
+- `url` — `"/admin/monitoring"`
+- `brand` — `process.env.BRAND || 'mentolder'`
+
+**Response (success):** `{ ticketId: string }` with HTTP 200
+**Response (error):** `{ error: string }` with appropriate HTTP status
+
+**Implementation:** validates input, then calls `insertBugTicket(...)` directly — no FormData, no screenshot handling.
+
+---
+
+## Data Flow
+
+1. Admin clicks bug icon on an event row in Recent Events
+2. `selectedEvent` is set; modal opens with pre-filled description and `category = 'fehler'`
+3. Admin optionally edits description or changes category
+4. Admin clicks "Erstellen"
+5. `POST /api/admin/bugs/create` with `{ description, category }`
+6. Server validates session, fills remaining fields, calls `insertBugTicket`
+7. Returns `{ ticketId }`
+8. Modal shows success message with ticket ID + link to `/admin/bugs`, auto-closes after 3 s
+
+---
+
+## Out of Scope
+
+- Screenshots (not relevant for system events)
+- Pre-filling `userAgent` / `viewport` (admin context, not meaningful)
+- Editing `reporterEmail` in the modal (always the admin's session email)

--- a/website/src/components/Navigation.svelte
+++ b/website/src/components/Navigation.svelte
@@ -1,9 +1,12 @@
 <script lang="ts">
-  let { siteTitle = '' } = $props();
+  import { onMount } from 'svelte';
 
+  let { siteTitle = '' } = $props();
   const brandWord = siteTitle.replace(/\.de$/i, '').toLowerCase();
 
   let mobileOpen = $state(false);
+  let menuOpen = $state(false);
+  let menuEl = $state<HTMLElement | null>(null);
   let user = $state<{ name: string; email: string; isAdmin?: boolean } | null>(null);
   let authChecked = $state(false);
 
@@ -16,6 +19,18 @@
       })
       .catch(() => { authChecked = true; });
   }
+
+  onMount(() => {
+    function handleOutside(e: MouseEvent) {
+      if (menuEl && !menuEl.contains(e.target as Node)) menuOpen = false;
+    }
+    document.addEventListener('mousedown', handleOutside);
+    return () => document.removeEventListener('mousedown', handleOutside);
+  });
+
+  function initial(name: string) {
+    return name.charAt(0).toUpperCase();
+  }
 </script>
 
 <header class="topbar" aria-label="Hauptnavigation">
@@ -23,7 +38,9 @@
     <!-- Brand mark -->
     <a href="/" class="brand" aria-label="{brandWord} Startseite">
       <div class="mark" aria-hidden="true">
-        <div class="mark-m"></div>
+        <svg class="mark-m" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+          <path d="M0,14 L0,4 L3,4 L8,9 L13,4 L16,4 L16,14 L13,14 L13,6 L8,11 L3,6 L3,14 Z" fill="currentColor"/>
+        </svg>
       </div>
       <span class="brand-name">{brandWord}<span class="brand-dot">.</span></span>
     </a>
@@ -34,12 +51,6 @@
       <a href="/ueber-mich">Über mich</a>
       <a href="/referenzen">Referenzen</a>
       <a href="/kontakt">Kontakt</a>
-
-      {#if authChecked && user}
-        <a href={user.isAdmin ? '/admin' : '/portal'} data-testid="nav-user-area">
-          {user.isAdmin ? 'Admin' : 'Mein Portal'}
-        </a>
-      {/if}
     </nav>
 
     <div class="nav-right">
@@ -47,8 +58,74 @@
 
       {#if authChecked}
         {#if user}
-          <span class="nav-user-name">{user.name}</span>
-          <a href="/api/auth/logout" class="nav-link-sm">Abmelden</a>
+          <!-- User pill + dropdown -->
+          <div class="user-pill-wrap" bind:this={menuEl}>
+            <button
+              class="user-pill"
+              onclick={() => (menuOpen = !menuOpen)}
+              aria-expanded={menuOpen}
+              aria-haspopup="true"
+              aria-label="Benutzermenu öffnen"
+            >
+              <span class="user-avatar">{initial(user.name)}</span>
+              <span class="user-pill-name">{user.name.split(' ')[0]}</span>
+              <svg
+                class="user-chevron"
+                class:rotated={menuOpen}
+                viewBox="0 0 10 6"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.5"
+                stroke-linecap="round"
+                aria-hidden="true"
+              >
+                <path d="M1 1l4 4 4-4"/>
+              </svg>
+            </button>
+
+            {#if menuOpen}
+              <div class="user-dropdown" role="menu">
+                <div class="user-dropdown-info">
+                  <span class="user-dropdown-name">{user.name}</span>
+                  <span class="user-dropdown-email">{user.email}</span>
+                </div>
+
+                <a
+                  href={user.isAdmin ? '/admin' : '/portal'}
+                  class="user-dropdown-item"
+                  onclick={() => (menuOpen = false)}
+                  role="menuitem"
+                  data-testid="nav-user-area"
+                >
+                  {#if user.isAdmin}
+                    <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                      <rect x="2" y="2" width="5" height="5" rx="0.5"/>
+                      <rect x="9" y="2" width="5" height="5" rx="0.5"/>
+                      <rect x="2" y="9" width="5" height="5" rx="0.5"/>
+                      <rect x="9" y="9" width="5" height="5" rx="0.5"/>
+                    </svg>
+                    Admin
+                  {:else}
+                    <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                      <circle cx="8" cy="5" r="3"/>
+                      <path d="M2 15a6 6 0 0 1 12 0"/>
+                    </svg>
+                    Mein Portal
+                  {/if}
+                </a>
+
+                <div class="user-dropdown-divider"></div>
+
+                <a href="/api/auth/logout" class="user-dropdown-item logout" role="menuitem">
+                  <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <path d="M6 12H3a1 1 0 0 1-1-1V5a1 1 0 0 1 1-1h3"/>
+                    <path d="M10.5 11l3-3-3-3M13.5 8H6"/>
+                  </svg>
+                  Abmelden
+                </a>
+              </div>
+            {/if}
+          </div>
         {:else}
           <a href="/registrieren" class="nav-link-sm">Registrieren</a>
           <a href="/api/auth/login" class="nav-link-sm">Anmelden</a>
@@ -91,9 +168,15 @@
       {#if authChecked}
         {#if user}
           <div class="mobile-divider"></div>
-          <span class="mobile-user">Angemeldet als {user.name}</span>
-          <a href={user.isAdmin ? '/admin' : '/portal'} onclick={() => (mobileOpen = false)}>{user.isAdmin ? 'Admin' : 'Mein Portal'}</a>
-          <a href="/api/auth/logout" onclick={() => (mobileOpen = false)}>Abmelden</a>
+          <div class="mobile-user-row">
+            <span class="mobile-user-avatar">{initial(user.name)}</span>
+            <div class="mobile-user-info">
+              <span class="mobile-user-name">{user.name}</span>
+              <span class="mobile-user-email">{user.email}</span>
+            </div>
+          </div>
+          <a href={user.isAdmin ? '/admin' : '/portal'} onclick={() => (mobileOpen = false)} data-testid="nav-user-area">{user.isAdmin ? 'Admin' : 'Mein Portal'}</a>
+          <a href="/api/auth/logout" onclick={() => (mobileOpen = false)} class="mobile-logout">Abmelden</a>
         {:else}
           <div class="mobile-divider"></div>
           <a href="/registrieren" onclick={() => (mobileOpen = false)}>Registrieren</a>
@@ -151,9 +234,8 @@
   .mark-m {
     position: absolute;
     inset: 7px;
-    border-radius: 3px;
-    background: var(--ink-900);
-    clip-path: polygon(0 55%, 30% 55%, 30% 0, 70% 0, 70% 55%, 100% 55%, 100% 100%, 0 100%);
+    color: var(--ink-900);
+    display: block;
   }
 
   .brand-name {
@@ -187,7 +269,7 @@
   .nav-right {
     display: flex;
     align-items: center;
-    gap: 20px;
+    gap: 16px;
   }
 
   .nav-meta {
@@ -208,11 +290,149 @@
     color: var(--fg);
   }
 
-  .nav-user-name {
-    font-size: 13px;
-    color: var(--mute);
+  /* ── User pill ── */
+  .user-pill-wrap {
+    position: relative;
   }
 
+  .user-pill {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    background: rgba(255,255,255,0.04);
+    border: 1px solid var(--line-2);
+    border-radius: 999px;
+    padding: 5px 10px 5px 5px;
+    cursor: pointer;
+    color: var(--fg-soft);
+    font-size: 13px;
+    font-weight: 500;
+    font-family: var(--sans);
+    transition: border-color 0.15s ease, background 0.15s ease, color 0.15s ease;
+  }
+
+  .user-pill:hover {
+    border-color: rgba(255,255,255,0.2);
+    color: var(--fg);
+    background: rgba(255,255,255,0.07);
+  }
+
+  .user-avatar {
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    background: var(--brass-d);
+    border: 1.5px solid var(--brass);
+    color: var(--brass);
+    font-size: 10px;
+    font-weight: 700;
+    font-family: var(--mono);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    line-height: 1;
+  }
+
+  .user-chevron {
+    width: 10px;
+    height: 6px;
+    color: var(--mute);
+    transition: transform 0.2s ease;
+    flex-shrink: 0;
+  }
+
+  .user-chevron.rotated {
+    transform: rotate(180deg);
+  }
+
+  /* ── Dropdown ── */
+  .user-dropdown {
+    position: absolute;
+    top: calc(100% + 10px);
+    right: 0;
+    width: 224px;
+    background: var(--ink-800);
+    border: 1px solid var(--line-2);
+    border-radius: 14px;
+    overflow: hidden;
+    box-shadow: 0 20px 48px rgba(0,0,0,0.5), 0 0 0 1px rgba(255,255,255,0.03);
+    animation: dropdown-in 0.14s ease;
+  }
+
+  @keyframes dropdown-in {
+    from { opacity: 0; transform: translateY(-5px) scale(0.98); }
+    to   { opacity: 1; transform: translateY(0) scale(1); }
+  }
+
+  .user-dropdown-info {
+    padding: 14px 16px 12px;
+    border-bottom: 1px solid var(--line);
+  }
+
+  .user-dropdown-name {
+    display: block;
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--fg);
+    margin-bottom: 3px;
+  }
+
+  .user-dropdown-email {
+    display: block;
+    font-family: var(--mono);
+    font-size: 10px;
+    color: var(--mute);
+    letter-spacing: 0.02em;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .user-dropdown-divider {
+    height: 1px;
+    background: var(--line);
+    margin: 3px 0;
+  }
+
+  .user-dropdown-item {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 16px;
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--fg-soft);
+    text-decoration: none;
+    transition: background 0.1s ease, color 0.1s ease;
+  }
+
+  .user-dropdown-item svg {
+    width: 15px;
+    height: 15px;
+    flex-shrink: 0;
+    color: var(--mute);
+    transition: color 0.1s ease;
+  }
+
+  .user-dropdown-item:hover {
+    background: var(--ink-750);
+    color: var(--fg);
+  }
+
+  .user-dropdown-item:hover svg {
+    color: var(--brass);
+  }
+
+  .user-dropdown-item.logout:hover {
+    color: #f87171;
+  }
+
+  .user-dropdown-item.logout:hover svg {
+    color: #f87171;
+  }
+
+  /* ── CTA ── */
   .nav-cta {
     font-family: var(--sans);
     font-size: 13px;
@@ -238,6 +458,7 @@
     background: var(--brass-2);
   }
 
+  /* ── Mobile toggle ── */
   .mobile-toggle {
     display: none;
     background: none;
@@ -252,6 +473,7 @@
     height: 24px;
   }
 
+  /* ── Mobile menu ── */
   .mobile-menu {
     border-top: 1px solid var(--line);
     background: var(--ink-850);
@@ -281,13 +503,56 @@
     margin: 8px 0;
   }
 
-  .mobile-user {
+  .mobile-user-row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 10px 0;
+    border-bottom: 1px solid var(--line);
+  }
+
+  .mobile-user-avatar {
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    background: var(--brass-d);
+    border: 1.5px solid var(--brass);
+    color: var(--brass);
+    font-size: 13px;
+    font-weight: 700;
     font-family: var(--mono);
-    font-size: 11px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    line-height: 1;
+  }
+
+  .mobile-user-info {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+  }
+
+  .mobile-user-name {
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--fg);
+  }
+
+  .mobile-user-email {
+    font-family: var(--mono);
+    font-size: 10px;
     color: var(--mute);
-    letter-spacing: 0.06em;
-    text-transform: uppercase;
-    padding: 6px 0;
+    letter-spacing: 0.02em;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .mobile-logout {
+    color: var(--mute) !important;
   }
 
   .mobile-cta {
@@ -315,7 +580,7 @@
     .nav-link-sm {
       display: none;
     }
-    .nav-user-name {
+    .user-pill-wrap {
       display: none;
     }
     .mobile-toggle {

--- a/website/src/components/admin/MonitoringDashboard.svelte
+++ b/website/src/components/admin/MonitoringDashboard.svelte
@@ -10,7 +10,7 @@
     memory?: string;
   };
 
-  type Event = {
+  type KubeEvent = {
     type: string;
     reason: string;
     object: string;
@@ -20,7 +20,7 @@
 
   type MonitoringData = {
     pods: Pod[];
-    events: Event[];
+    events: KubeEvent[];
     node?: { cpu: string; memory: string };
     metricsAvailable: boolean;
     fetchedAt: string;
@@ -31,7 +31,7 @@
   let error: string | null = null;
   let refreshInterval: ReturnType<typeof setInterval>;
 
-  let selectedEvent: Event | null = null;
+  let selectedEvent: KubeEvent | null = null;
   let modalDescription = '';
   let modalCategory = 'fehler';
   let modalLoading = false;
@@ -39,7 +39,8 @@
   let modalSuccessId: string | null = null;
   let modalCloseTimer: ReturnType<typeof setTimeout> | null = null;
 
-  function openModal(event: Event) {
+  function openModal(event: KubeEvent) {
+    if (modalCloseTimer) clearTimeout(modalCloseTimer);
     selectedEvent = event;
     modalDescription = `${event.reason} on ${event.object}: ${event.message}`;
     modalCategory = 'fehler';
@@ -49,7 +50,7 @@
   }
 
   function closeModal() {
-    if (modalCloseTimer) clearTimeout(modalCloseTimer);
+    if (modalCloseTimer) { clearTimeout(modalCloseTimer); modalCloseTimer = null; }
     selectedEvent = null;
     modalSuccessId = null;
     modalError = null;
@@ -102,11 +103,18 @@
 
   onDestroy(() => {
     if (refreshInterval) clearInterval(refreshInterval);
+    if (modalCloseTimer) clearTimeout(modalCloseTimer);
   });
 
   $: runningCount = data?.pods.filter(p => p.phase === 'Running' || p.ready).length || 0;
   $: failedCount = data?.pods.filter(p => p.phase === 'Failed' || p.phase === 'Unknown' || p.phase === 'CrashLoopBackOff').length || 0;
   $: restartingCount = data?.pods.filter(p => !p.ready && p.phase !== 'Failed' && p.phase !== 'Succeeded').length || 0;
+
+  function focusTrap(node: HTMLElement) {
+    const prev = document.activeElement as HTMLElement | null;
+    node.focus();
+    return { destroy() { prev?.focus(); } };
+  }
 
   function getStatusColor(pod: Pod) {
     if (pod.phase === 'Failed' || pod.phase === 'CrashLoopBackOff' || pod.phase === 'Unknown') return 'border-red-500 bg-red-50 dark:bg-red-900/10 text-red-700 dark:text-red-400';
@@ -257,15 +265,20 @@
 </div>
 
 {#if selectedEvent}
+  <svelte:window on:keydown={(e) => { if (e.key === 'Escape') closeModal(); }} />
   <!-- Modal backdrop -->
   <div
     class="fixed inset-0 bg-black/60 z-50 flex items-center justify-center p-4"
     on:click|self={closeModal}
-    role="dialog"
-    aria-modal="true"
-    aria-labelledby="modal-title"
   >
-    <div class="bg-dark-light border border-dark-lighter rounded-lg shadow-xl w-full max-w-lg">
+    <div
+      class="bg-dark-light border border-dark-lighter rounded-lg shadow-xl w-full max-w-lg"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="modal-title"
+      use:focusTrap
+      tabindex="-1"
+    >
       <!-- Header -->
       <div class="px-6 py-4 border-b border-dark-lighter flex items-center justify-between">
         <h2 id="modal-title" class="text-lg font-semibold text-light">Bug Ticket erstellen</h2>

--- a/website/src/components/admin/MonitoringDashboard.svelte
+++ b/website/src/components/admin/MonitoringDashboard.svelte
@@ -65,12 +65,12 @@
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ description: modalDescription, category: modalCategory }),
       });
-      const data = await res.json();
+      const responseData = await res.json();
       if (!res.ok) {
-        modalError = data.error ?? 'Unbekannter Fehler';
+        modalError = responseData.error ?? 'Unbekannter Fehler';
         return;
       }
-      modalSuccessId = data.ticketId;
+      modalSuccessId = responseData.ticketId;
       modalCloseTimer = setTimeout(closeModal, 3000);
     } catch {
       modalError = 'Netzwerkfehler';

--- a/website/src/components/admin/MonitoringDashboard.svelte
+++ b/website/src/components/admin/MonitoringDashboard.svelte
@@ -31,6 +31,54 @@
   let error: string | null = null;
   let refreshInterval: ReturnType<typeof setInterval>;
 
+  let selectedEvent: Event | null = null;
+  let modalDescription = '';
+  let modalCategory = 'fehler';
+  let modalLoading = false;
+  let modalError: string | null = null;
+  let modalSuccessId: string | null = null;
+  let modalCloseTimer: ReturnType<typeof setTimeout> | null = null;
+
+  function openModal(event: Event) {
+    selectedEvent = event;
+    modalDescription = `${event.reason} on ${event.object}: ${event.message}`;
+    modalCategory = 'fehler';
+    modalLoading = false;
+    modalError = null;
+    modalSuccessId = null;
+  }
+
+  function closeModal() {
+    if (modalCloseTimer) clearTimeout(modalCloseTimer);
+    selectedEvent = null;
+    modalSuccessId = null;
+    modalError = null;
+  }
+
+  async function submitTicket() {
+    if (!selectedEvent) return;
+    modalLoading = true;
+    modalError = null;
+    try {
+      const res = await fetch('/api/admin/bugs/create', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ description: modalDescription, category: modalCategory }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        modalError = data.error ?? 'Unbekannter Fehler';
+        return;
+      }
+      modalSuccessId = data.ticketId;
+      modalCloseTimer = setTimeout(closeModal, 3000);
+    } catch {
+      modalError = 'Netzwerkfehler';
+    } finally {
+      modalLoading = false;
+    }
+  }
+
   const fetchData = async () => {
     try {
       loading = true;
@@ -180,8 +228,18 @@
                   {event.message}
                 </p>
               </div>
-              <div class="flex-shrink-0 text-xs text-gray-500">
-                {event.age}
+              <div class="flex-shrink-0 flex items-center gap-2 text-xs text-gray-500">
+                <span>{event.age}</span>
+                <button
+                  on:click={() => openModal(event)}
+                  title="Bug Ticket erstellen"
+                  class="text-gray-400 hover:text-red-500 transition-colors"
+                  aria-label="Bug Ticket erstellen"
+                >
+                  <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+                    <path fill-rule="evenodd" d="M6.267 3.455a3.066 3.066 0 001.745-.723 3.066 3.066 0 013.976 0 3.066 3.066 0 001.745.723 3.066 3.066 0 012.812 2.812c.051.643.304 1.254.723 1.745a3.066 3.066 0 010 3.976 3.066 3.066 0 00-.723 1.745 3.066 3.066 0 01-2.812 2.812 3.066 3.066 0 00-1.745.723 3.066 3.066 0 01-3.976 0 3.066 3.066 0 00-1.745-.723 3.066 3.066 0 01-2.812-2.812 3.066 3.066 0 00-.723-1.745 3.066 3.066 0 010-3.976 3.066 3.066 0 00.723-1.745 3.066 3.066 0 012.812-2.812zm7.44 5.252a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd" />
+                  </svg>
+                </button>
               </div>
             </div>
           </li>
@@ -197,3 +255,91 @@
     </div>
   {/if}
 </div>
+
+{#if selectedEvent}
+  <!-- Modal backdrop -->
+  <div
+    class="fixed inset-0 bg-black/60 z-50 flex items-center justify-center p-4"
+    on:click|self={closeModal}
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="modal-title"
+  >
+    <div class="bg-dark-light border border-dark-lighter rounded-lg shadow-xl w-full max-w-lg">
+      <!-- Header -->
+      <div class="px-6 py-4 border-b border-dark-lighter flex items-center justify-between">
+        <h2 id="modal-title" class="text-lg font-semibold text-light">Bug Ticket erstellen</h2>
+        <button on:click={closeModal} class="text-gray-400 hover:text-light transition-colors" aria-label="Schließen">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+            <path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd" />
+          </svg>
+        </button>
+      </div>
+
+      <!-- Body -->
+      <div class="px-6 py-4 space-y-4">
+        <!-- Event summary -->
+        <p class="text-xs text-muted font-mono bg-dark rounded px-3 py-2">
+          {selectedEvent.type} · {selectedEvent.reason} · {selectedEvent.object}
+        </p>
+
+        {#if modalSuccessId}
+          <div class="text-sm text-green-500 space-y-1">
+            <p>Ticket erstellt: <strong>{modalSuccessId}</strong></p>
+            <a href="/admin/bugs" class="underline hover:text-green-400">Zur Ticket-Übersicht →</a>
+            <p class="text-xs text-muted">Schließt in 3 Sekunden…</p>
+          </div>
+        {:else}
+          <!-- Description -->
+          <div>
+            <label for="modal-desc" class="block text-sm font-medium text-light mb-1">Beschreibung</label>
+            <textarea
+              id="modal-desc"
+              bind:value={modalDescription}
+              rows={4}
+              maxlength={2000}
+              class="w-full rounded-md border border-dark-lighter bg-dark text-light text-sm px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            ></textarea>
+          </div>
+
+          <!-- Category -->
+          <div>
+            <label for="modal-cat" class="block text-sm font-medium text-light mb-1">Kategorie</label>
+            <select
+              id="modal-cat"
+              bind:value={modalCategory}
+              class="w-full rounded-md border border-dark-lighter bg-dark text-light text-sm px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            >
+              <option value="fehler">Fehler</option>
+              <option value="verbesserung">Verbesserung</option>
+              <option value="erweiterungswunsch">Erweiterungswunsch</option>
+            </select>
+          </div>
+
+          {#if modalError}
+            <p class="text-sm text-red-500">{modalError}</p>
+          {/if}
+        {/if}
+      </div>
+
+      <!-- Footer -->
+      {#if !modalSuccessId}
+        <div class="px-6 py-4 border-t border-dark-lighter flex justify-end gap-3">
+          <button
+            on:click={closeModal}
+            class="px-4 py-2 text-sm rounded-md border border-dark-lighter text-light hover:bg-dark transition-colors"
+          >
+            Abbrechen
+          </button>
+          <button
+            on:click={submitTicket}
+            disabled={modalLoading || !modalDescription.trim()}
+            class="px-4 py-2 text-sm rounded-md bg-blue-600 hover:bg-blue-700 text-white font-medium disabled:opacity-50 transition-colors"
+          >
+            {modalLoading ? 'Erstelle…' : 'Erstellen'}
+          </button>
+        </div>
+      {/if}
+    </div>
+  </div>
+{/if}

--- a/website/src/components/admin/MonitoringDashboard.svelte
+++ b/website/src/components/admin/MonitoringDashboard.svelte
@@ -96,14 +96,20 @@
     }
   };
 
+  function handleKeydown(e: KeyboardEvent) {
+    if (e.key === 'Escape' && selectedEvent) closeModal();
+  }
+
   onMount(() => {
     fetchData();
-    refreshInterval = setInterval(fetchData, 15000); // refresh every 15s
+    refreshInterval = setInterval(fetchData, 15000);
+    window.addEventListener('keydown', handleKeydown);
   });
 
   onDestroy(() => {
     if (refreshInterval) clearInterval(refreshInterval);
     if (modalCloseTimer) clearTimeout(modalCloseTimer);
+    window.removeEventListener('keydown', handleKeydown);
   });
 
   $: runningCount = data?.pods.filter(p => p.phase === 'Running' || p.ready).length || 0;
@@ -265,7 +271,6 @@
 </div>
 
 {#if selectedEvent}
-  <svelte:window on:keydown={(e) => { if (e.key === 'Escape') closeModal(); }} />
   <!-- Modal backdrop -->
   <div
     class="fixed inset-0 bg-black/60 z-50 flex items-center justify-center p-4"

--- a/website/src/layouts/AdminLayout.astro
+++ b/website/src/layouts/AdminLayout.astro
@@ -10,45 +10,70 @@ interface Props {
 const { title } = Astro.props;
 const path = Astro.url.pathname;
 
+const icons: Record<string, string> = {
+  dashboard: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="2" width="5" height="5" rx="0.5"/><rect x="9" y="2" width="5" height="5" rx="0.5"/><rect x="2" y="9" width="5" height="5" rx="0.5"/><rect x="9" y="9" width="5" height="5" rx="0.5"/></svg>`,
+  bug: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="9" r="3.5"/><path d="M8 5.5V3.5M5 7H2.5M11 7h2.5M5.5 5l-2-2M10.5 5l2-2M5 12l-2 1.5M11 12l2 1.5"/></svg>`,
+  microphone: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="5.5" y="1.5" width="5" height="7" rx="2.5"/><path d="M3.5 8a4.5 4.5 0 0 0 9 0M8 12.5v2M6 14.5h4"/></svg>`,
+  calendar: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="12" height="11" rx="1"/><path d="M2 7h12M5.5 1.5v3M10.5 1.5v3"/></svg>`,
+  users: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="5.5" cy="5" r="2.5"/><path d="M1 14a4.5 4.5 0 0 1 9 0"/><circle cx="12" cy="5" r="2"/><path d="M14.5 13a3.5 3.5 0 0 0-3.5-3"/></svg>`,
+  message: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M2 3h12v8H9.5L8 13l-1.5-2H2z"/></svg>`,
+  home: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M1.5 8.5l6.5-6 6.5 6"/><path d="M3.5 7.5v6.5h3.5v-4h2v4h3.5V7.5"/></svg>`,
+  clipboard: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M5.5 2.5h5v2.5h-5V2.5z"/><rect x="3" y="2.5" width="10" height="12" rx="1"/><path d="M5.5 7.5h5M5.5 10.5h5M5.5 13.5h3"/></svg>`,
+  clock: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="8" r="6"/><path d="M8 5v3.5l2.5 1.5"/></svg>`,
+  receipt: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M4 1.5h8v13l-2-1.5-2 1.5-2-1.5-2 1.5z"/><path d="M6 6h4M6 8.5h4M6 11h2"/></svg>`,
+  bell: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 2.5a4 4 0 0 0-4 4c0 2.5-1.5 3.5-1.5 3.5h11S12 9 12 6.5a4 4 0 0 0-4-4z"/><path d="M7 13.5h2"/></svg>`,
+  calendar2: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="12" height="11" rx="1"/><path d="M2 7h12M5.5 1.5v3M10.5 1.5v3M5.5 10h1M8 10h1M10.5 10h1"/></svg>`,
+  monitor: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="1.5" y="2.5" width="13" height="9" rx="1"/><path d="M5 11.5l-.5 3h7l-.5-3M5.5 14.5h5"/></svg>`,
+  layout: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="2.5" width="12" height="11" rx="1"/><path d="M2 7h12M6 7v6.5"/></svg>`,
+  person: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="5" r="3"/><path d="M2.5 14.5a5.5 5.5 0 0 1 11 0"/></svg>`,
+  tag: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M2 2.5h4.5l7 7a2 2 0 0 1 0 2.8l-2.2 2.2a2 2 0 0 1-2.8 0l-7-7V2.5z"/><circle cx="5.5" cy="5.5" r=".75" fill="currentColor" stroke="none"/></svg>`,
+  help: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="8" r="6.5"/><path d="M6.5 6a2 2 0 0 1 3.5 1c0 1.5-2 2-2 3M8 12.5v.5"/></svg>`,
+  mail: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="4" width="12" height="9" rx="1"/><path d="M2 4.5l6 4.5 6-4.5"/></svg>`,
+  star: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 2l2 4 4.5.7-3.3 3.1.8 4.7L8 12l-4 2.5.8-4.7L1.5 6.7 6 6z"/></svg>`,
+  scale: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 1.5v13M3 4.5h10M2 14.5h12"/><path d="M5 4.5L2.5 10h5zM11 4.5L8.5 10h5z"/></svg>`,
+  inbox: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3.5" width="12" height="10" rx="1"/><path d="M2 10h3.5l1.5 2 1.5-2H12"/></svg>`,
+};
+
 const navGroups = [
   {
     label: 'Übersicht',
     items: [
-      { href: '/admin', label: 'Dashboard', icon: '📊' },
+      { href: '/admin', label: 'Dashboard', icon: 'dashboard' },
     ],
   },
   {
     label: 'Betrieb',
     items: [
-      { href: '/admin/bugs',         label: 'Bugs',          icon: '🐛' },
-      { href: '/admin/meetings',     label: 'Meetings',      icon: '🎙️' },
-      { href: '/admin/termine',      label: 'Termine',       icon: '📅' },
-      { href: '/admin/clients',      label: 'Clients',       icon: '👥' },
-      { href: '/admin/nachrichten',  label: 'Nachrichten',   icon: '💬' },
-      { href: '/admin/raeume',       label: 'Räume',         icon: '🏠' },
-      { href: '/admin/projekte',     label: 'Projekte',      icon: '📋' },
-      { href: '/admin/zeiterfassung',label: 'Zeiterfassung', icon: '⏱️' },
-      { href: '/admin/rechnungen',   label: 'Rechnungen',    icon: '💶' },
-      { href: '/admin/followups',    label: 'Follow-ups',    icon: '🔔' },
-      { href: '/admin/kalender',     label: 'Kalender',      icon: '🗓️' },
+      { href: '/admin/bugs',          label: 'Bugs',          icon: 'bug' },
+      { href: '/admin/meetings',      label: 'Meetings',      icon: 'microphone' },
+      { href: '/admin/termine',       label: 'Termine',       icon: 'calendar' },
+      { href: '/admin/clients',       label: 'Clients',       icon: 'users' },
+      { href: '/admin/nachrichten',   label: 'Nachrichten',   icon: 'message' },
+      { href: '/admin/raeume',        label: 'Räume',         icon: 'home' },
+      { href: '/admin/projekte',      label: 'Projekte',      icon: 'clipboard' },
+      { href: '/admin/zeiterfassung', label: 'Zeiterfassung', icon: 'clock' },
+      { href: '/admin/rechnungen',    label: 'Rechnungen',    icon: 'receipt' },
+      { href: '/admin/followups',     label: 'Follow-ups',    icon: 'bell' },
+      { href: '/admin/kalender',      label: 'Kalender',      icon: 'calendar2' },
     ],
   },
   {
     label: 'System',
     items: [
-      { href: '/admin/monitoring', label: 'Monitoring', icon: '🖥️' },
+      { href: '/admin/monitoring', label: 'Monitoring', icon: 'monitor' },
+      { href: '/admin/inbox',      label: 'Inbox',      icon: 'inbox' },
     ],
   },
   {
     label: 'Website',
     items: [
-      { href: '/admin/startseite',   label: 'Startseite',    icon: '🏠' },
-      { href: '/admin/uebermich',    label: 'Über mich',     icon: '🙋' },
-      { href: '/admin/angebote',     label: 'Angebote',      icon: '🛍️' },
-      { href: '/admin/faq',          label: 'FAQ',           icon: '❓' },
-      { href: '/admin/kontakt',      label: 'Kontakt',       icon: '✉️' },
-      { href: '/admin/referenzen',   label: 'Referenzen',    icon: '🏆' },
-      { href: '/admin/rechtliches',  label: 'Rechtliches',   icon: '⚖️' },
+      { href: '/admin/startseite',  label: 'Startseite',  icon: 'layout' },
+      { href: '/admin/uebermich',   label: 'Über mich',   icon: 'person' },
+      { href: '/admin/angebote',    label: 'Angebote',    icon: 'tag' },
+      { href: '/admin/faq',         label: 'FAQ',         icon: 'help' },
+      { href: '/admin/kontakt',     label: 'Kontakt',     icon: 'mail' },
+      { href: '/admin/referenzen',  label: 'Referenzen',  icon: 'star' },
+      { href: '/admin/rechtliches', label: 'Rechtliches', icon: 'scale' },
     ],
   },
 ];
@@ -57,6 +82,8 @@ function isActive(href: string): boolean {
   if (href === '/admin') return path === '/admin';
   return path.startsWith(href);
 }
+
+const brandWord = config.meta.siteTitle.replace(/\.de$/i, '').toLowerCase();
 ---
 
 <!doctype html>
@@ -67,94 +94,142 @@ function isActive(href: string): boolean {
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Merriweather:wght@400;700&display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,300;0,6..72,400;0,6..72,500;0,6..72,600;1,6..72,400&family=Geist:wght@300;400;500;600;700&family=Geist+Mono:wght@400;500&display=swap" rel="stylesheet" />
     <title>{title} | Admin — {config.meta.siteTitle}</title>
     <script is:inline>
-  try {
-    if (localStorage.getItem('admin-sidebar-collapsed') === '1') {
-      document.documentElement.classList.add('sidebar-collapsed');
-    }
-  } catch (_) {}
-</script>
-<style>
-  #admin-sidebar {
-    width: 13rem;
-    transition: width 0.2s ease;
-    overflow: hidden;
-  }
-  html.sidebar-collapsed #admin-sidebar {
-    width: 3rem;
-  }
-  .sidebar-label {
-    transition: opacity 0.15s ease, max-width 0.2s ease;
-    white-space: nowrap;
-    overflow: hidden;
-    max-width: 200px;
-  }
-  html.sidebar-collapsed .sidebar-label {
-    opacity: 0;
-    max-width: 0;
-  }
-  .sidebar-group-label {
-    transition: opacity 0.15s ease, max-height 0.2s ease;
-    overflow: hidden;
-    max-height: 2rem;
-  }
-  html.sidebar-collapsed .sidebar-group-label {
-    opacity: 0;
-    max-height: 0;
-    margin: 0 !important;
-    padding: 0 !important;
-  }
-  html.sidebar-collapsed .sidebar-nav-item {
-    justify-content: center;
-    padding-left: 0 !important;
-    padding-right: 0 !important;
-  }
-  html.sidebar-collapsed .sidebar-footer-link span {
-    opacity: 0;
-    max-width: 0;
-    overflow: hidden;
-    display: inline-block;
-  }
-</style>
+      try {
+        if (localStorage.getItem('admin-sidebar-collapsed') === '1') {
+          document.documentElement.classList.add('sidebar-collapsed');
+        }
+      } catch (_) {}
+    </script>
+    <style>
+      #admin-sidebar {
+        width: 13rem;
+        transition: width 0.2s ease;
+        overflow: hidden;
+      }
+      html.sidebar-collapsed #admin-sidebar {
+        width: 3rem;
+      }
+      .sidebar-label {
+        transition: opacity 0.15s ease, max-width 0.2s ease;
+        white-space: nowrap;
+        overflow: hidden;
+        max-width: 200px;
+      }
+      html.sidebar-collapsed .sidebar-label {
+        opacity: 0;
+        max-width: 0;
+      }
+      .sidebar-group-label {
+        transition: opacity 0.15s ease, max-height 0.2s ease;
+        overflow: hidden;
+        max-height: 2rem;
+      }
+      html.sidebar-collapsed .sidebar-group-label {
+        opacity: 0;
+        max-height: 0;
+        margin: 0 !important;
+        padding: 0 !important;
+      }
+      html.sidebar-collapsed .sidebar-nav-item {
+        justify-content: center;
+        padding-left: 0 !important;
+        padding-right: 0 !important;
+      }
+      html.sidebar-collapsed .sidebar-footer-link span {
+        opacity: 0;
+        max-width: 0;
+        overflow: hidden;
+        display: inline-block;
+      }
+      .sidebar-nav-item:not(.is-active):hover {
+        background: var(--ink-800) !important;
+        color: var(--fg) !important;
+      }
+      .sidebar-nav-item:not(.is-active):hover .nav-icon {
+        color: var(--brass) !important;
+      }
+      .nav-icon svg {
+        width: 16px;
+        height: 16px;
+      }
+      .sidebar-footer-link:hover {
+        background: var(--ink-800);
+        color: var(--fg-soft);
+      }
+      .sidebar-footer-link.danger:hover {
+        background: rgba(248, 113, 113, 0.07);
+        color: #f87171;
+      }
+      #sidebar-toggle:hover {
+        background: var(--ink-800);
+        color: var(--brass);
+      }
+      /* Collapsed: show expand chevron, hide collapse chevron */
+      #icon-collapse { display: block; }
+      #icon-expand   { display: none; }
+      html.sidebar-collapsed #icon-collapse { display: none; }
+      html.sidebar-collapsed #icon-expand   { display: block; }
+    </style>
   </head>
-  <body class="min-h-screen bg-dark text-light flex">
+  <body style="min-height:100vh; background:var(--ink-900); color:var(--fg); display:flex; font-family:var(--font-sans);">
 
     <!-- Sidebar -->
-    <aside id="admin-sidebar" class="flex-shrink-0 min-h-screen bg-dark-light border-r border-dark-lighter flex flex-col">
-      <div class="px-3 py-5 border-b border-dark-lighter flex items-center gap-2 min-w-0">
-        <div class="flex-1 min-w-0">
-          <a href="/admin" class="sidebar-label text-gold font-bold text-lg font-serif leading-tight block">Admin</a>
-          <p class="sidebar-label text-xs text-muted mt-0.5">{config.meta.siteTitle}</p>
-        </div>
+    <aside id="admin-sidebar" style="flex-shrink:0; min-height:100vh; background:var(--ink-850); border-right:1px solid var(--line); display:flex; flex-direction:column;">
+
+      <!-- Header -->
+      <div style="padding:20px 14px 18px; border-bottom:1px solid var(--line); display:flex; align-items:center; gap:8px; min-width:0;">
+        <a href="/admin" style="display:flex; align-items:center; gap:10px; text-decoration:none; flex:1; min-width:0; overflow:hidden;">
+          <div style="width:28px; height:28px; border-radius:7px; background:radial-gradient(circle at 30% 30%, var(--brass-2), var(--brass) 55%, #8a6a2a 100%); box-shadow:inset 0 0 0 1px rgba(255,255,255,.2), 0 0 0 1px rgba(0,0,0,.3); position:relative; flex-shrink:0;">
+            <div style="position:absolute; inset:6px; border-radius:2px; background:var(--ink-850); clip-path:polygon(0 55%, 30% 55%, 30% 0, 70% 0, 70% 55%, 100% 55%, 100% 100%, 0 100%);"></div>
+          </div>
+          <div class="sidebar-label" style="min-width:0;">
+            <span style="font-family:var(--font-serif); font-size:15px; color:var(--brass); letter-spacing:-0.01em; display:block; line-height:1.2;">{brandWord}<span style="color:var(--mute);">.</span></span>
+            <span style="font-family:var(--font-mono); font-size:9px; color:var(--mute); letter-spacing:0.12em; text-transform:uppercase; display:block; margin-top:1px;">Admin</span>
+          </div>
+        </a>
         <button
           id="sidebar-toggle"
           title="Sidebar einklappen"
           aria-label="Sidebar einklappen"
-          aria-expanded="false"
+          aria-expanded="true"
           aria-controls="admin-sidebar"
-          class="flex-shrink-0 w-6 h-6 flex items-center justify-center text-gold hover:text-gold-light transition-colors text-lg font-bold leading-none"
-        >‹</button>
+          style="flex-shrink:0; width:24px; height:24px; display:flex; align-items:center; justify-content:center; background:none; border:none; cursor:pointer; color:var(--mute); border-radius:6px; transition:color 0.15s ease, background 0.15s ease;"
+        >
+          <svg id="icon-collapse" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" style="width:14px; height:14px;" aria-hidden="true">
+            <path d="M10 3l-5 5 5 5"/>
+          </svg>
+          <svg id="icon-expand" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" style="width:14px; height:14px;" aria-hidden="true">
+            <path d="M6 3l5 5-5 5"/>
+          </svg>
+        </button>
       </div>
 
-      <nav class="flex-1 overflow-y-auto py-4 px-2 space-y-5">
+      <!-- Nav -->
+      <nav style="flex:1; overflow-y:auto; padding:12px 8px; display:flex; flex-direction:column; gap:20px;">
         {navGroups.map(group => (
           <div>
-            <p class="sidebar-group-label px-2 mb-1.5 text-xs font-semibold text-muted uppercase tracking-widest">{group.label}</p>
-            <ul class="space-y-0.5">
+            <p class="sidebar-group-label" style="padding:0 10px; margin-bottom:4px; font-family:var(--font-mono); font-size:9px; font-weight:500; color:var(--mute-2); text-transform:uppercase; letter-spacing:0.14em;">{group.label}</p>
+            <ul style="list-style:none; padding:0; margin:0; display:flex; flex-direction:column; gap:1px;">
               {group.items.map(item => (
                 <li>
                   <a
                     href={item.href}
                     title={item.label}
-                    class={`sidebar-nav-item flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
+                    class={`sidebar-nav-item${isActive(item.href) ? ' is-active' : ''}`}
+                    style={`display:flex; align-items:center; gap:9px; padding:8px 10px; border-radius:8px; text-decoration:none; font-size:13px; font-weight:500; transition:background 0.1s ease, color 0.1s ease; ${
                       isActive(item.href)
-                        ? 'bg-gold/10 text-gold'
-                        : 'text-muted hover:text-light hover:bg-dark-lighter'
+                        ? 'background:var(--brass-d); color:var(--brass);'
+                        : 'color:var(--fg-soft);'
                     }`}
                   >
-                    <span class="text-base leading-none flex-shrink-0">{item.icon}</span>
+                    <span
+                      class="nav-icon"
+                      style={`flex-shrink:0; width:16px; height:16px; display:flex; align-items:center; justify-content:center; transition:color 0.1s ease; ${isActive(item.href) ? 'color:var(--brass);' : 'color:var(--mute);'}`}
+                      set:html={icons[item.icon]}
+                    />
                     <span class="sidebar-label">{item.label}</span>
                   </a>
                 </li>
@@ -164,43 +239,52 @@ function isActive(href: string): boolean {
         ))}
       </nav>
 
-      <div class="px-4 py-4 border-t border-dark-lighter flex flex-col gap-2">
-        <a href="/" class="sidebar-footer-link flex items-center gap-1 text-xs text-muted hover:text-gold transition-colors whitespace-nowrap">
-          <span>←</span>
+      <!-- Footer -->
+      <div style="padding:10px 8px 12px; border-top:1px solid var(--line); display:flex; flex-direction:column; gap:1px;">
+        <a href="/" class="sidebar-footer-link" style="display:flex; align-items:center; gap:9px; padding:8px 10px; border-radius:8px; text-decoration:none; font-size:12px; color:var(--mute); transition:background 0.1s ease, color 0.1s ease;">
+          <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" style="width:14px; height:14px; flex-shrink:0;" aria-hidden="true">
+            <path d="M10 3l-5 5 5 5M5 8h8"/>
+          </svg>
           <span class="sidebar-label">Website</span>
         </a>
-        <a href="/api/auth/logout" class="sidebar-footer-link flex items-center gap-1 text-xs text-muted hover:text-red-400 transition-colors whitespace-nowrap">
-          <span>⏻</span>
+        <a href="/api/auth/logout" class="sidebar-footer-link danger" style="display:flex; align-items:center; gap:9px; padding:8px 10px; border-radius:8px; text-decoration:none; font-size:12px; color:var(--mute); transition:background 0.1s ease, color 0.1s ease;">
+          <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" style="width:14px; height:14px; flex-shrink:0;" aria-hidden="true">
+            <path d="M6 12H3a1 1 0 0 1-1-1V5a1 1 0 0 1 1-1h3"/>
+            <path d="M10.5 11l3-3-3-3M13.5 8H6"/>
+          </svg>
           <span class="sidebar-label">Abmelden</span>
         </a>
       </div>
     </aside>
 
     <!-- Main -->
-    <main class="flex-1 min-h-screen overflow-y-auto">
+    <main style="flex:1; min-height:100vh; overflow-y:auto;">
       <slot />
     </main>
 
-  <BugReportWidget client:load />
-  <script is:inline>
-  (function() {
-    var btn = document.getElementById('sidebar-toggle');
-    if (!btn) return;
-    var collapsed = document.documentElement.classList.contains('sidebar-collapsed');
-    btn.textContent = collapsed ? '›' : '‹';
-    btn.title = collapsed ? 'Sidebar ausklappen' : 'Sidebar einklappen';
-    btn.setAttribute('aria-label', btn.title);
-    btn.setAttribute('aria-expanded', collapsed ? 'false' : 'true');
+    <BugReportWidget client:load />
 
-    btn.addEventListener('click', function() {
-      collapsed = document.documentElement.classList.toggle('sidebar-collapsed');
-      localStorage.setItem('admin-sidebar-collapsed', collapsed ? '1' : '0');
-      btn.textContent = collapsed ? '›' : '‹';
-      btn.title = collapsed ? 'Sidebar ausklappen' : 'Sidebar einklappen';
-      btn.setAttribute('aria-label', btn.title);
-      btn.setAttribute('aria-expanded', collapsed ? 'false' : 'true');
-    });
-  })();
-</script>
+    <script is:inline>
+      (function() {
+        var btn = document.getElementById('sidebar-toggle');
+        if (!btn) return;
+        var collapsed = document.documentElement.classList.contains('sidebar-collapsed');
+
+        function updateState(isCollapsed) {
+          var label = isCollapsed ? 'Sidebar ausklappen' : 'Sidebar einklappen';
+          btn.title = label;
+          btn.setAttribute('aria-label', label);
+          btn.setAttribute('aria-expanded', isCollapsed ? 'false' : 'true');
+        }
+
+        updateState(collapsed);
+
+        btn.addEventListener('click', function() {
+          collapsed = document.documentElement.classList.toggle('sidebar-collapsed');
+          localStorage.setItem('admin-sidebar-collapsed', collapsed ? '1' : '0');
+          updateState(collapsed);
+        });
+      })();
+    </script>
   </body>
 </html>

--- a/website/src/layouts/Layout.astro
+++ b/website/src/layouts/Layout.astro
@@ -46,6 +46,9 @@ const brandWord = config.meta.siteTitle.replace(/\.de$/i, '').toLowerCase();
           <div>
             <div style="display:flex; align-items:center; gap:10px; margin-bottom:16px; text-decoration:none;">
               <div class="footer-mark" style="width:28px; height:28px; border-radius:8px; background:radial-gradient(circle at 30% 30%, var(--brass-2), var(--brass) 55%, #8a6a2a 100%); box-shadow:inset 0 0 0 1px rgba(255,255,255,.2), 0 0 0 1px rgba(0,0,0,.3); position:relative; flex-shrink:0;">
+                <svg style="position:absolute; inset:7px; color:var(--ink-900); display:block;" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                  <path d="M0,14 L0,4 L3,4 L8,9 L13,4 L16,4 L16,14 L13,14 L13,6 L8,11 L3,6 L3,14 Z" fill="currentColor"/>
+                </svg>
               </div>
               <span style="font-family:var(--serif); font-size:18px; letter-spacing:-0.01em; color:var(--fg);">{brandWord}<span style="color:var(--brass);">.</span></span>
             </div>

--- a/website/src/lib/website-db.ts
+++ b/website/src/lib/website-db.ts
@@ -431,18 +431,19 @@ export async function insertBugTicket(params: {
   url?: string;
   brand: string;
   screenshots?: string[];
-}): Promise<void> {
+}): Promise<number> {
   await initBugTicketsTable();
   const screenshotsJson = params.screenshots && params.screenshots.length > 0
     ? JSON.stringify(params.screenshots)
     : null;
-  await pool.query(
+  const result = await pool.query(
     `INSERT INTO bug_tickets (ticket_id, category, reporter_email, description, url, brand, screenshots_json)
      VALUES ($1, $2, $3, $4, $5, $6, $7)
      ON CONFLICT (ticket_id) DO NOTHING`,
     [params.ticketId, params.category, params.reporterEmail,
      params.description, params.url ?? null, params.brand, screenshotsJson]
   );
+  return result.rowCount ?? 0;
 }
 
 export async function resolveBugTicket(ticketId: string, resolutionNote: string): Promise<void> {

--- a/website/src/pages/api/admin/bugs/create.ts
+++ b/website/src/pages/api/admin/bugs/create.ts
@@ -47,7 +47,7 @@ export const POST: APIRoute = async ({ request }) => {
   const ticketId = generateTicketId();
 
   try {
-    await insertBugTicket({
+    const rowCount = await insertBugTicket({
       ticketId,
       category,
       reporterEmail: session.email,
@@ -55,13 +55,16 @@ export const POST: APIRoute = async ({ request }) => {
       url: '/admin/monitoring',
       brand: BRAND,
     });
+    if (rowCount === 0) {
+      return jsonError('Ticket-ID-Kollision, bitte erneut versuchen', 500);
+    }
   } catch (err) {
     console.error('[bugs/create] DB error:', err);
     return jsonError('Datenbankfehler', 500);
   }
 
   return new Response(JSON.stringify({ ticketId }), {
-    status: 200,
+    status: 201,
     headers: { 'Content-Type': 'application/json' },
   });
 };

--- a/website/src/pages/api/admin/bugs/create.ts
+++ b/website/src/pages/api/admin/bugs/create.ts
@@ -1,0 +1,67 @@
+import type { APIRoute } from 'astro';
+import { getSession, isAdmin } from '../../../../lib/auth';
+import { insertBugTicket } from '../../../../lib/website-db';
+
+const BRAND = process.env.BRAND || 'mentolder';
+const VALID_CATEGORIES = new Set(['fehler', 'verbesserung', 'erweiterungswunsch']);
+
+function jsonError(message: string, status: number): Response {
+  return new Response(JSON.stringify({ error: message }), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function generateTicketId(): string {
+  const today = new Date().toISOString().slice(0, 10).replace(/-/g, '');
+  const rand = Math.floor(Math.random() * 0x10000).toString(16).padStart(4, '0');
+  return `BR-${today}-${rand}`;
+}
+
+export const POST: APIRoute = async ({ request }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) {
+    return jsonError('Nicht autorisiert', 401);
+  }
+
+  let body: { description?: unknown; category?: unknown };
+  try {
+    body = await request.json();
+  } catch {
+    return jsonError('Ungültiger JSON-Body', 400);
+  }
+
+  const description = (typeof body.description === 'string' ? body.description : '').trim();
+  const category = (typeof body.category === 'string' ? body.category : '').trim();
+
+  if (!description) {
+    return jsonError('Beschreibung ist erforderlich', 400);
+  }
+  if (description.length > 2000) {
+    return jsonError('Beschreibung zu lang (max. 2000 Zeichen)', 400);
+  }
+  if (!VALID_CATEGORIES.has(category)) {
+    return jsonError('Ungültige Kategorie', 400);
+  }
+
+  const ticketId = generateTicketId();
+
+  try {
+    await insertBugTicket({
+      ticketId,
+      category,
+      reporterEmail: session.email,
+      description,
+      url: '/admin/monitoring',
+      brand: BRAND,
+    });
+  } catch (err) {
+    console.error('[bugs/create] DB error:', err);
+    return jsonError('Datenbankfehler', 500);
+  }
+
+  return new Response(JSON.stringify({ ticketId }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+};


### PR DESCRIPTION
## Summary

- **Nav user menu**: replaces scattered username + logout + portal links with a cohesive brass-rimmed avatar pill (user initial + first name + chevron); clicking opens a dropdown with user info, portal/admin link with icon, and styled logout with red hover
- **Admin sidebar**: swaps `Inter`/`Merriweather` for `Geist`/`Newsreader` (matching main site), replaces emoji icons with consistent 16px SVG stroke icons, adds the brand mark to the sidebar header, refines active/hover states with brass accent
- **Bug fix**: resolves pre-existing Svelte 5 build error in `MonitoringDashboard` where `<svelte:window>` inside `{#if}` was incompatible — replaced with native `addEventListener` in `onMount`/`onDestroy`

## Test plan

- [ ] Nav pill renders with avatar initial + name on logged-in pages
- [ ] Dropdown opens/closes on click; closes on outside click
- [ ] Admin/Portal link in dropdown navigates correctly
- [ ] Logout works from dropdown
- [ ] Admin sidebar shows SVG icons (no emoji), correct fonts, brass active state
- [ ] Sidebar collapse/expand toggle still works
- [ ] Mobile menu still shows user info + portal + logout links
- [ ] Website build passes (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)