### PR TITLE
fix(chat): make chat widget work for all authenticated users incl. admins

### DIFF
--- a/website/src/components/ChatWidget.svelte
+++ b/website/src/components/ChatWidget.svelte
@@ -22,7 +22,7 @@
     try {
       const res = await fetch('/api/auth/me');
       const data = await res.json() as AuthResponse;
-      if (!data.authenticated || data.user.isAdmin) return;
+      if (!data.authenticated) return;
       visible = true;
       await loadThread();
     } finally {

--- a/website/src/pages/api/portal/messages.ts
+++ b/website/src/pages/api/portal/messages.ts
@@ -1,13 +1,13 @@
 // website/src/pages/api/portal/messages.ts
 import type { APIRoute } from 'astro';
 import { getSession } from '../../../lib/auth';
-import { getCustomerByEmail, getThreadByCustomerId, getOrCreateThreadForCustomer, addMessage, createInboxItem } from '../../../lib/messaging-db';
+import { getThreadByCustomerId, getOrCreateThreadForCustomer, addMessage, createInboxItem } from '../../../lib/messaging-db';
+import { upsertCustomer } from '../../../lib/website-db';
 
 export const GET: APIRoute = async ({ request }) => {
   const session = await getSession(request.headers.get('cookie'));
   if (!session) return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 });
-  const customer = await getCustomerByEmail(session.email);
-  if (!customer) return new Response(JSON.stringify({ thread: null }), { headers: { 'Content-Type': 'application/json' } });
+  const customer = await upsertCustomer({ name: session.name, email: session.email, keycloakUserId: session.sub });
   const thread = await getThreadByCustomerId(customer.id);
   return new Response(JSON.stringify({ thread: thread ?? null }), { headers: { 'Content-Type': 'application/json' } });
 };
@@ -15,8 +15,7 @@ export const GET: APIRoute = async ({ request }) => {
 export const POST: APIRoute = async ({ request }) => {
   const session = await getSession(request.headers.get('cookie'));
   if (!session) return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 });
-  const customer = await getCustomerByEmail(session.email);
-  if (!customer) return new Response(JSON.stringify({ error: 'Customer not found' }), { status: 403 });
+  const customer = await upsertCustomer({ name: session.name, email: session.email, keycloakUserId: session.sub });
   const { body } = await request.json() as { body: string };
   if (!body?.trim()) return new Response(JSON.stringify({ error: 'body required' }), { status: 400 });
   const thread = await getOrCreateThreadForCustomer(customer.id);

--- a/website/src/pages/api/portal/messages/[threadId].ts
+++ b/website/src/pages/api/portal/messages/[threadId].ts
@@ -1,13 +1,13 @@
 // website/src/pages/api/portal/messages/[threadId].ts
 import type { APIRoute } from 'astro';
 import { getSession } from '../../../../lib/auth';
-import { getCustomerByEmail, getThread, getThreadMessages, addMessage, markThreadRead } from '../../../../lib/messaging-db';
+import { getThread, getThreadMessages, addMessage, markThreadRead } from '../../../../lib/messaging-db';
+import { upsertCustomer } from '../../../../lib/website-db';
 
 export const GET: APIRoute = async ({ request, params }) => {
   const session = await getSession(request.headers.get('cookie'));
   if (!session) return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 });
-  const customer = await getCustomerByEmail(session.email);
-  if (!customer) return new Response(JSON.stringify({ error: 'Customer not found' }), { status: 403 });
+  const customer = await upsertCustomer({ name: session.name, email: session.email, keycloakUserId: session.sub });
   const threadId = parseInt(params.threadId!, 10);
   if (isNaN(threadId)) return new Response(JSON.stringify({ error: 'Invalid ID' }), { status: 400 });
   const thread = await getThread(threadId);
@@ -20,8 +20,7 @@ export const GET: APIRoute = async ({ request, params }) => {
 export const POST: APIRoute = async ({ request, params }) => {
   const session = await getSession(request.headers.get('cookie'));
   if (!session) return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 });
-  const customer = await getCustomerByEmail(session.email);
-  if (!customer) return new Response(JSON.stringify({ error: 'Customer not found' }), { status: 403 });
+  const customer = await upsertCustomer({ name: session.name, email: session.email, keycloakUserId: session.sub });
   const threadId = parseInt(params.threadId!, 10);
   if (isNaN(threadId)) return new Response(JSON.stringify({ error: 'Invalid ID' }), { status: 400 });
   const thread = await getThread(threadId);


### PR DESCRIPTION
## Summary

- Reverts the `isAdmin` hide added in #180 — admins should see the chat widget too
- Replaces `getCustomerByEmail` (which returned 403 when no customer entry existed) with `upsertCustomer` in both `/api/portal/messages` and `/api/portal/messages/[threadId]` — any authenticated user now gets a customer record created on first use
- The chat widget floating button now appears and is fully functional in both the portal and the admin panel

## Test plan

- [ ] Log in as admin → chat widget appears in `/admin`
- [ ] Admin can open widget, send a message, and receive replies
- [ ] Regular users still see and can use the chat widget in `/portal`

🤖 Generated with [Claude Code](https://claude.com/claude-code)