### PR TITLE
feat(chat): add direct 1:1 chat between admin and users via widget

### DIFF
--- a/docs/superpowers/plans/2026-04-19-leistung-stundensatz-terminbuchung.md
+++ b/docs/superpowers/plans/2026-04-19-leistung-stundensatz-terminbuchung.md
@@ -1,0 +1,914 @@
+# Leistung + Stundensatz + Terminbuchung — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Leistungen bekommen einen Stundensatz, Zeiteinträge frieren ihn ein, Terminbuchungen verknüpfen Leistung + Projekt — sowohl für Admins als auch für Kunden im Portal.
+
+**Architecture:** Ansatz A — JSONB-Erweiterung. `stundensatz_cents` wird in `LeistungServiceOverride` (JSONB) gespeichert. `time_entries` und `booking_project_links` bekommen neue `leistung_key`-Spalten via `ALTER TABLE ... ADD COLUMN IF NOT EXISTS`. Keine neuen Tabellen.
+
+**Tech Stack:** Astro 5, Svelte 5, TypeScript, PostgreSQL 16, Tailwind CSS
+
+---
+
+## File Map
+
+| Datei | Was sich ändert |
+|-------|----------------|
+| `src/config/types.ts` | `stundensatz_cents?` zu `LeistungService` |
+| `src/lib/website-db.ts` | `stundensatz_cents?` zu `LeistungServiceOverride`; migrations; `createTimeEntry` + `setBookingProject` erweitert; `getBookingLeistungen` neu |
+| `src/lib/content.ts` | `getEffectiveLeistungen` merged `stundensatz_cents` |
+| `src/pages/admin/angebote.astro` | Stundensatz-Input pro Leistung; DB-Merge |
+| `src/pages/api/admin/angebote/save.ts` | `stundensatz_cents` aus Form lesen + speichern |
+| `src/pages/admin/zeiterfassung.astro` | Leistung-Dropdown + Auto-fill + Betrag-Spalten |
+| `src/pages/api/admin/zeiterfassung/create.ts` | `leistung_key` entgegennehmen |
+| `src/pages/api/bookings/[uid]/project.ts` | `leistung_key` entgegennehmen |
+| `src/pages/admin/termine.astro` | Leistung-Dropdown beim Verknüpfen; requested Leistung/Projekt anzeigen |
+| `src/pages/api/leistungen.ts` | Neuer öffentlicher GET-Endpunkt (key + name, keine Rates) |
+| `src/components/BookingForm.svelte` | Leistung + Projekt Dropdowns wenn eingeloggt |
+| `src/pages/api/booking.ts` | `projectId` + `leistungKey` in Inbox-Payload speichern |
+
+---
+
+## Task 1: `stundensatz_cents` zu den Typ-Interfaces hinzufügen
+
+**Files:**
+- Modify: `src/config/types.ts:33-40`
+- Modify: `src/lib/website-db.ts:537-544`
+- Modify: `src/lib/content.ts:78-89`
+
+- [ ] **Schritt 1: `LeistungService` in `config/types.ts` erweitern**
+
+In `src/config/types.ts`, Zeile 39 (nach `highlight?: boolean;`):
+
+```typescript
+export interface LeistungService {
+  key: string;
+  name: string;
+  price: string;
+  unit: string;
+  desc: string;
+  highlight?: boolean;
+  stundensatz_cents?: number;
+}
+```
+
+- [ ] **Schritt 2: `LeistungServiceOverride` in `website-db.ts` erweitern**
+
+In `src/lib/website-db.ts`, Zeile 543 (nach `highlight?: boolean;`):
+
+```typescript
+export interface LeistungServiceOverride {
+  key: string;
+  name?: string;
+  price?: string;
+  unit?: string;
+  desc?: string;
+  highlight?: boolean;
+  stundensatz_cents?: number;
+}
+```
+
+- [ ] **Schritt 3: `getEffectiveLeistungen` in `content.ts` merged `stundensatz_cents`**
+
+In `src/lib/content.ts`, den `return { ...svc, ... }`-Block in `getEffectiveLeistungen` (Zeilen 81-87) ersetzen:
+
+```typescript
+      return {
+        ...svc,
+        name: so.name ?? svc.name,
+        price: so.price ?? svc.price,
+        unit: so.unit ?? svc.unit,
+        desc: so.desc ?? svc.desc,
+        highlight: so.highlight ?? svc.highlight,
+        stundensatz_cents: so.stundensatz_cents ?? svc.stundensatz_cents,
+      };
+```
+
+- [ ] **Schritt 4: TypeScript prüfen**
+
+```bash
+cd /home/patrick/Bachelorprojekt/website && npx tsc --noEmit 2>&1 | head -30
+```
+
+Erwartet: keine Fehler in den geänderten Dateien.
+
+- [ ] **Schritt 5: Commit**
+
+```bash
+git add src/config/types.ts src/lib/website-db.ts src/lib/content.ts
+git commit -m "feat: add stundensatz_cents to LeistungService and override interfaces"
+```
+
+---
+
+## Task 2: DB-Migrationen — neue Spalten
+
+**Files:**
+- Modify: `src/lib/website-db.ts` (initTimeEntriesTable, initBookingProjectLinks)
+
+- [ ] **Schritt 1: `leistung_key` zu `time_entries` Migration hinzufügen**
+
+In `src/lib/website-db.ts`, in der Funktion `initTimeEntriesTable()` (nach Zeile 1254, nach dem bestehenden `ALTER TABLE ... ADD COLUMN IF NOT EXISTS stripe_invoice_id`-Block):
+
+```typescript
+  await pool.query(`
+    ALTER TABLE time_entries ADD COLUMN IF NOT EXISTS leistung_key TEXT
+  `);
+```
+
+- [ ] **Schritt 2: `leistung_key` zu `booking_project_links` Migration hinzufügen**
+
+In `src/lib/website-db.ts`, in der Funktion `initBookingProjectLinks()` (nach dem `CREATE TABLE IF NOT EXISTS`-Block, also nach Zeile 1878):
+
+```typescript
+  await pool.query(`
+    ALTER TABLE booking_project_links ADD COLUMN IF NOT EXISTS leistung_key TEXT
+  `);
+```
+
+- [ ] **Schritt 3: `TimeEntry`-Interface um `leistungKey` erweitern**
+
+In `src/lib/website-db.ts`, das `TimeEntry`-Interface (Zeilen 1217-1230) um ein Feld ergänzen:
+
+```typescript
+export interface TimeEntry {
+  id: string;
+  projectId: string;
+  projectName: string;
+  taskId: string | null;
+  taskName: string | null;
+  description: string | null;
+  minutes: number;
+  billable: boolean;
+  rateCents: number;
+  leistungKey: string | null;
+  stripeInvoiceId: string | null;
+  entryDate: Date;
+  createdAt: Date;
+}
+```
+
+- [ ] **Schritt 4: TypeScript prüfen**
+
+```bash
+cd /home/patrick/Bachelorprojekt/website && npx tsc --noEmit 2>&1 | head -30
+```
+
+Erwartet: keine neuen Fehler.
+
+- [ ] **Schritt 5: Commit**
+
+```bash
+git add src/lib/website-db.ts
+git commit -m "feat: add leistung_key columns to time_entries and booking_project_links"
+```
+
+---
+
+## Task 3: DB-Funktionen erweitern
+
+**Files:**
+- Modify: `src/lib/website-db.ts` (createTimeEntry, listTimeEntries, listAllTimeEntries, setBookingProject)
+- Create: `src/lib/website-db.ts` (getBookingLeistungen — neue Funktion)
+
+- [ ] **Schritt 1: `createTimeEntry` — `leistungKey` Parameter + INSERT**
+
+In `src/lib/website-db.ts`, die Funktion `createTimeEntry` (ab Zeile 1266) vollständig ersetzen:
+
+```typescript
+export async function createTimeEntry(params: {
+  projectId: string;
+  taskId?: string;
+  description?: string;
+  minutes: number;
+  billable?: boolean;
+  rateCents?: number;
+  leistungKey?: string;
+  entryDate?: string;
+}): Promise<TimeEntry> {
+  await initTimeEntriesTable();
+  const result = await pool.query(
+    `INSERT INTO time_entries (project_id, task_id, description, minutes, billable, rate_cents, leistung_key, entry_date)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+     RETURNING
+       id,
+       project_id        AS "projectId",
+       NULL::text        AS "projectName",
+       task_id           AS "taskId",
+       NULL::text        AS "taskName",
+       description,
+       minutes,
+       billable,
+       rate_cents        AS "rateCents",
+       leistung_key      AS "leistungKey",
+       stripe_invoice_id AS "stripeInvoiceId",
+       entry_date        AS "entryDate",
+       created_at        AS "createdAt"`,
+    [
+      params.projectId,
+      params.taskId ?? null,
+      params.description ?? null,
+      params.minutes,
+      params.billable ?? true,
+      params.rateCents ?? 0,
+      params.leistungKey ?? null,
+      params.entryDate ?? null,
+    ]
+  );
+  return result.rows[0] as TimeEntry;
+}
+```
+
+- [ ] **Schritt 2: `listTimeEntries` und `listAllTimeEntries` — `leistung_key` in SELECT**
+
+In `src/lib/website-db.ts`, in beiden `SELECT`-Queries für `listTimeEntries` und `listAllTimeEntries`, nach der Zeile `te.stripe_invoice_id AS "stripeInvoiceId",` folgende Zeile einfügen:
+
+```sql
+            te.leistung_key      AS "leistungKey",
+```
+
+(In beiden Funktionen — `listTimeEntries` ab Zeile 1305 und `listAllTimeEntries` weiter unten.)
+
+- [ ] **Schritt 3: `setBookingProject` — `leistungKey` Parameter + UPSERT**
+
+In `src/lib/website-db.ts`, die Funktion `setBookingProject` (ab Zeile 1963) vollständig ersetzen:
+
+```typescript
+export async function setBookingProject(
+  caldavUid: string,
+  projectId: string | null,
+  brand: string,
+  leistungKey?: string
+): Promise<void> {
+  await initBookingProjectLinks();
+  if (!projectId) {
+    await pool.query(
+      `DELETE FROM booking_project_links WHERE caldav_uid = $1 AND brand = $2`,
+      [caldavUid, brand]
+    );
+  } else {
+    await pool.query(
+      `INSERT INTO booking_project_links (caldav_uid, brand, project_id, leistung_key)
+       VALUES ($1, $2, $3, $4)
+       ON CONFLICT (caldav_uid, brand) DO UPDATE
+         SET project_id  = EXCLUDED.project_id,
+             leistung_key = EXCLUDED.leistung_key`,
+      [caldavUid, brand, projectId, leistungKey ?? null]
+    );
+  }
+}
+```
+
+- [ ] **Schritt 4: `getBookingLeistungen` neue Funktion hinzufügen**
+
+In `src/lib/website-db.ts`, direkt nach der `getBookingProjects`-Funktion (nach Zeile 1960) einfügen:
+
+```typescript
+export async function getBookingLeistungen(caldavUids: string[], brand: string): Promise<Map<string, string>> {
+  if (caldavUids.length === 0) return new Map();
+  await initBookingProjectLinks();
+  const result = await pool.query(
+    `SELECT caldav_uid, leistung_key FROM booking_project_links
+     WHERE caldav_uid = ANY($1) AND brand = $2 AND leistung_key IS NOT NULL`,
+    [caldavUids, brand]
+  );
+  return new Map(result.rows.map((r: { caldav_uid: string; leistung_key: string }) => [r.caldav_uid, r.leistung_key]));
+}
+```
+
+- [ ] **Schritt 5: TypeScript prüfen**
+
+```bash
+cd /home/patrick/Bachelorprojekt/website && npx tsc --noEmit 2>&1 | head -30
+```
+
+Erwartet: keine Fehler.
+
+- [ ] **Schritt 6: Commit**
+
+```bash
+git add src/lib/website-db.ts
+git commit -m "feat: extend createTimeEntry, setBookingProject and add getBookingLeistungen"
+```
+
+---
+
+## Task 4: Admin Angebote — Stundensatz-Input pro Leistung
+
+**Files:**
+- Modify: `src/pages/admin/angebote.astro`
+- Modify: `src/pages/api/admin/angebote/save.ts`
+
+- [ ] **Schritt 1: Stundensatz-Wert im Frontmatter laden**
+
+In `src/pages/admin/angebote.astro`, den `leistungen`-Merge-Block (Zeilen 44-62) so erweitern, dass `stundensatz_cents` mitgeladen wird:
+
+```typescript
+const leistungen = mentolderConfig.leistungen.map(cat => {
+  const o = dbLeistungen?.find(x => x.id === cat.id);
+  return {
+    id: cat.id,
+    title: o?.title ?? cat.title,
+    icon: o?.icon ?? cat.icon,
+    services: cat.services.map(svc => {
+      const so = o?.services?.find(x => x.key === svc.key);
+      return {
+        key: svc.key,
+        name: so?.name ?? svc.name,
+        price: so?.price ?? svc.price,
+        unit: so?.unit ?? svc.unit,
+        desc: so?.desc ?? svc.desc,
+        highlight: so?.highlight ?? svc.highlight,
+        stundensatz_cents: so?.stundensatz_cents ?? svc.stundensatz_cents ?? 0,
+      };
+    }),
+  };
+});
+```
+
+- [ ] **Schritt 2: Stundensatz-Input-Feld pro Leistung in der UI**
+
+In `src/pages/admin/angebote.astro`, innerhalb des Leistungen-Abschnitts, nach dem bestehenden `grid grid-cols-2`-Block pro `svc` (nach dem `Einheit`-Input und dem `Hervorheben`-Checkbox-Block, also nach Zeile 218), einen neuen Block einfügen:
+
+```astro
+                        <div>
+                          <label class={labelCls}>Stundensatz (€/Std.)</label>
+                          <input
+                            type="number"
+                            name={`lk_${cat.id}_${svc.key}_stundensatz`}
+                            value={Math.round(svc.stundensatz_cents / 100)}
+                            min="0"
+                            step="1"
+                            class={inputCls}
+                            placeholder="z.B. 60"
+                          />
+                        </div>
+```
+
+Genauer: das `grid grid-cols-2`-Raster hat 4 Zellen (Name, Preis, Einheit, Hervorheben). Den Stundensatz als 5. Zelle in dasselbe Grid einfügen — vor dem schließenden `</div>` des Grid-Containers.
+
+Der vollständige Grid-Block nach der Änderung:
+
+```astro
+                      <div class="grid grid-cols-2 gap-3">
+                        <div>
+                          <label class={labelCls}>Name</label>
+                          <input type="text" name={`lk_${cat.id}_${svc.key}_name`} value={svc.name} class={inputCls} />
+                        </div>
+                        <div>
+                          <label class={labelCls}>Preis</label>
+                          <input type="text" name={`lk_${cat.id}_${svc.key}_price`} value={svc.price} class={inputCls} />
+                        </div>
+                        <div>
+                          <label class={labelCls}>Einheit</label>
+                          <input type="text" name={`lk_${cat.id}_${svc.key}_unit`} value={svc.unit} class={inputCls} />
+                        </div>
+                        <div>
+                          <label class={labelCls}>Stundensatz (€/Std.)</label>
+                          <input
+                            type="number"
+                            name={`lk_${cat.id}_${svc.key}_stundensatz`}
+                            value={Math.round(svc.stundensatz_cents / 100)}
+                            min="0"
+                            step="1"
+                            class={inputCls}
+                            placeholder="z.B. 60"
+                          />
+                        </div>
+                        <div class="flex items-end pb-1">
+                          <label class="flex items-center gap-2 text-sm text-muted cursor-pointer">
+                            <input type="checkbox" name={`lk_${cat.id}_${svc.key}_highlight`} value="1"
+                              checked={svc.highlight} class="rounded border-dark-lighter bg-dark accent-gold" />
+                            Hervorheben
+                          </label>
+                        </div>
+                      </div>
+```
+
+- [ ] **Schritt 3: `stundensatz_cents` im Save-Handler lesen**
+
+In `src/pages/api/admin/angebote/save.ts`, den `leistungenOverrides`-Block (Zeilen 52-64) um `stundensatz_cents` erweitern:
+
+```typescript
+  const leistungenOverrides: LeistungCategoryOverride[] = mentolderConfig.leistungen.map(cat => ({
+    id: cat.id,
+    title: (form.get(`lk_${cat.id}_title`) as string) || cat.title,
+    icon: (form.get(`lk_${cat.id}_icon`) as string) || cat.icon,
+    services: cat.services.map(svc => {
+      const stundensatzEuro = parseFloat((form.get(`lk_${cat.id}_${svc.key}_stundensatz`) as string) || '0');
+      const stundensatz_cents = isNaN(stundensatzEuro) ? 0 : Math.round(stundensatzEuro * 100);
+      return {
+        key: svc.key,
+        name: (form.get(`lk_${cat.id}_${svc.key}_name`) as string) || svc.name,
+        price: (form.get(`lk_${cat.id}_${svc.key}_price`) as string) || svc.price,
+        unit: (form.get(`lk_${cat.id}_${svc.key}_unit`) as string ?? svc.unit),
+        desc: (form.get(`lk_${cat.id}_${svc.key}_desc`) as string) || svc.desc,
+        highlight: form.get(`lk_${cat.id}_${svc.key}_highlight`) === '1',
+        stundensatz_cents,
+      };
+    }),
+  }));
+```
+
+- [ ] **Schritt 4: TypeScript prüfen**
+
+```bash
+cd /home/patrick/Bachelorprojekt/website && npx tsc --noEmit 2>&1 | head -30
+```
+
+Erwartet: keine Fehler.
+
+- [ ] **Schritt 5: Commit**
+
+```bash
+git add src/pages/admin/angebote.astro src/pages/api/admin/angebote/save.ts
+git commit -m "feat: add Stundensatz input per Leistung in admin Angebote"
+```
+
+---
+
+## Task 5: Admin Zeiterfassung — Leistung-Dropdown + Betrag-Spalten
+
+**Files:**
+- Modify: `src/pages/admin/zeiterfassung.astro`
+- Modify: `src/pages/api/admin/zeiterfassung/create.ts`
+
+- [ ] **Schritt 1: Leistungen im Frontmatter laden**
+
+In `src/pages/admin/zeiterfassung.astro`, den Import-Block oben erweitern:
+
+```typescript
+import { getLastTimeEntryRate, listAllTimeEntries, listProjects } from '../../lib/website-db';
+import { getEffectiveLeistungen } from '../../lib/content';
+import type { TimeEntry, Project } from '../../lib/website-db';
+import type { LeistungCategory } from '../../config/types';
+```
+
+Im Frontmatter, `leistungen` laden und eine Rate-Map für den Client erstellen (nach dem `lastRate`-Aufruf):
+
+```typescript
+const lastRate = await getLastTimeEntryRate();
+let leistungen: LeistungCategory[] = [];
+try {
+  leistungen = await getEffectiveLeistungen();
+} catch { /* ignore */ }
+
+// Map key → stundensatz_cents für client-seitiges Auto-fill
+const leistungRates: Record<string, number> = {};
+for (const cat of leistungen) {
+  for (const svc of cat.services) {
+    if (svc.stundensatz_cents != null) leistungRates[svc.key] = svc.stundensatz_cents;
+  }
+}
+```
+
+- [ ] **Schritt 2: Leistung-Dropdown + Auto-fill im Create-Dialog**
+
+In `src/pages/admin/zeiterfassung.astro`, im Dialog-Formular (nach dem Projekt-Dropdown, vor dem Minuten/Datum-Grid), einen neuen Block einfügen:
+
+```astro
+      <div>
+        <label class={labelCls}>Leistung</label>
+        <select name="leistungKey" id="leistung-select" class={selectCls}>
+          <option value="">— Keine Leistung —</option>
+          {leistungen.map(cat => (
+            <optgroup label={`${cat.icon} ${cat.title}`}>
+              {cat.services.map(svc => (
+                <option value={svc.key} data-rate={svc.stundensatz_cents ?? 0}>
+                  {svc.name}
+                </option>
+              ))}
+            </optgroup>
+          ))}
+        </select>
+      </div>
+```
+
+- [ ] **Schritt 3: Stundensatz-Feld anpassen**
+
+Das bestehende `rateCents`-Input-Feld (Zeilen 189-200) so anpassen, dass es eine `id` bekommt für das JS-Auto-fill:
+
+```astro
+      <div>
+        <label class={labelCls}>Stundensatz (€/h)</label>
+        <input
+          type="number"
+          id="rate-input"
+          name="rateCents"
+          min="0"
+          step="1"
+          required
+          class={inputCls}
+          placeholder="z.B. 100"
+          value={Math.round(lastRate / 100)}
+        />
+        <p class="text-xs text-muted mt-1">Wird bei Leistungsauswahl automatisch befüllt. Manuell überschreibbar.</p>
+      </div>
+```
+
+- [ ] **Schritt 4: Auto-fill JavaScript im `<script>`-Block**
+
+Im `<script>`-Block am Ende der Datei (Zeilen 218-222), das Auto-fill hinzufügen:
+
+```html
+<script>
+  const dialog = document.getElementById('create-dialog') as HTMLDialogElement;
+  document.getElementById('create-btn')?.addEventListener('click', () => dialog.showModal());
+  document.getElementById('create-cancel')?.addEventListener('click', () => dialog.close());
+
+  const leistungSelect = document.getElementById('leistung-select') as HTMLSelectElement;
+  const rateInput = document.getElementById('rate-input') as HTMLInputElement;
+  leistungSelect?.addEventListener('change', () => {
+    const selected = leistungSelect.options[leistungSelect.selectedIndex];
+    const rate = parseInt(selected.dataset.rate ?? '0', 10);
+    if (rate > 0) rateInput.value = String(Math.round(rate / 100));
+  });
+</script>
+```
+
+- [ ] **Schritt 5: Betrag-Spalte in der Tabelle ergänzen**
+
+In `src/pages/admin/zeiterfassung.astro`, in der Tabellen-Header-Zeile (nach `Abr.`-Spalte, vor `Aktionen`):
+
+```astro
+              <th class="text-right px-4 py-3 text-xs text-muted uppercase tracking-wide font-medium">Betrag</th>
+```
+
+In der Tabellen-Body-Zeile (nach der `e.billable`-Zelle, vor der Löschen-Zelle):
+
+```astro
+                <td class="px-4 py-3 text-sm text-right font-mono text-gold">
+                  {e.rateCents > 0
+                    ? `${((e.minutes / 60) * (e.rateCents / 100)).toFixed(2)} €`
+                    : <span class="text-muted">—</span>}
+                </td>
+```
+
+Außerdem in der `<p>`-Zeile unter dem H1 (Zeile 56), die Gesamtsumme ergänzen:
+
+```typescript
+const billableAmount = entries
+  .filter(e => e.billable && e.rateCents > 0)
+  .reduce((sum, e) => sum + (e.minutes / 60) * (e.rateCents / 100), 0);
+```
+
+Und in der Subtitle-Zeile:
+```astro
+          <p class="text-muted mt-1">{fmtMin(totalMinutes)} gesamt · {fmtMin(billableMinutes)} abrechenbar · {billableAmount.toFixed(2)} € abr. Betrag</p>
+```
+
+- [ ] **Schritt 6: `create.ts` — `leistungKey` entgegennehmen**
+
+In `src/pages/api/admin/zeiterfassung/create.ts`, nach dem `entryDate`-Auslesen:
+
+```typescript
+  const leistungKey = (form.get('leistungKey') as string | null) || undefined;
+```
+
+Den `createTimeEntry`-Aufruf ergänzen:
+
+```typescript
+    await createTimeEntry({
+      projectId,
+      taskId: taskId || undefined,
+      description: description || undefined,
+      minutes,
+      billable,
+      rateCents,
+      leistungKey,
+      entryDate: entryDate || undefined,
+    });
+```
+
+- [ ] **Schritt 7: TypeScript prüfen**
+
+```bash
+cd /home/patrick/Bachelorprojekt/website && npx tsc --noEmit 2>&1 | head -30
+```
+
+Erwartet: keine Fehler.
+
+- [ ] **Schritt 8: Commit**
+
+```bash
+git add src/pages/admin/zeiterfassung.astro src/pages/api/admin/zeiterfassung/create.ts
+git commit -m "feat: add Leistung dropdown and Betrag column to Zeiterfassung"
+```
+
+---
+
+## Task 6: Admin Termine — Leistung beim Booking-Link
+
+**Files:**
+- Modify: `src/pages/api/bookings/[uid]/project.ts`
+- Modify: `src/pages/admin/termine.astro`
+
+- [ ] **Schritt 1: PATCH-Endpunkt — `leistungKey` entgegennehmen**
+
+In `src/pages/api/bookings/[uid]/project.ts`, Zeilen 25-45 vollständig ersetzen:
+
+```typescript
+  let body: { projectId?: string | null; leistungKey?: string | null };
+  try {
+    body = await request.json();
+  } catch {
+    return new Response(JSON.stringify({ error: 'Invalid JSON' }), {
+      status: 400, headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const brand = process.env.BRAND_NAME || 'mentolder';
+  try {
+    await setBookingProject(uid, body.projectId ?? null, brand, body.leistungKey ?? undefined);
+    return new Response(JSON.stringify({ ok: true }), {
+      status: 200, headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (err) {
+    console.error('[PATCH /api/bookings/[uid]/project] DB error:', err);
+    return new Response(JSON.stringify({ error: 'Database error' }), {
+      status: 500, headers: { 'Content-Type': 'application/json' },
+    });
+  }
+```
+
+- [ ] **Schritt 2: Importe und Variablen in `termine.astro` erweitern**
+
+In `src/pages/admin/termine.astro`, Zeile 6 ersetzen:
+
+```typescript
+import { getBookingProjects, listProjects, getBookingInvoices, getWhitelistedSlots, getBookingLeistungen } from '../../lib/website-db';
+import type { Project, BookingInvoiceInfo } from '../../lib/website-db';
+```
+
+Nach Zeile 7, neuen Import einfügen:
+
+```typescript
+import { getEffectiveLeistungen } from '../../lib/content';
+import type { LeistungCategory } from '../../config/types';
+```
+
+Nach Zeile 26 (`let bookingInvoiceMap...`), neue Variablen hinzufügen:
+
+```typescript
+let bookingLeistungMap: Map<string, string> = new Map();
+let leistungen: LeistungCategory[] = [];
+```
+
+- [ ] **Schritt 3: Daten im `try`-Block laden**
+
+In `src/pages/admin/termine.astro`, im `try`-Block (Zeile 40), das `Promise.all` für `bookingProjectMap` und `bookingInvoiceMap` erweitern:
+
+```typescript
+  [bookingProjectMap, bookingInvoiceMap, bookingLeistungMap] = await Promise.all([
+    getBookingProjects(uids, brand),
+    getBookingInvoices(uids, brand),
+    getBookingLeistungen(uids, brand),
+  ]);
+  leistungen = await getEffectiveLeistungen();
+```
+
+- [ ] **Schritt 4: Leistung-Dropdown nach jedem Projekt-Select einfügen**
+
+In `src/pages/admin/termine.astro`, direkt nach dem `</select>`-Tag des Projekt-Selects bei den **Upcoming Bookings** (nach Zeile 135, vor `{inv && (`):
+
+```astro
+                        {leistungen.length > 0 && (
+                          <select
+                            class="booking-leistung-select text-xs bg-dark border border-dark-lighter rounded-lg px-2 py-1 text-light focus:border-gold focus:ring-1 focus:ring-gold/20 outline-none cursor-pointer"
+                            data-booking-uid={b.uid}
+                          >
+                            <option value="">— Keine Leistung —</option>
+                            {leistungen.map(cat => (
+                              <optgroup label={`${cat.icon} ${cat.title}`}>
+                                {cat.services.map(svc => (
+                                  <option value={svc.key} selected={bookingLeistungMap.get(b.uid) === svc.key}>
+                                    {svc.name}
+                                  </option>
+                                ))}
+                              </optgroup>
+                            ))}
+                          </select>
+                        )}
+```
+
+Dasselbe bei den **Past Bookings** einfügen (nach Zeile 190, nach dem schließenden `</select>` des Projekt-Selects).
+
+- [ ] **Schritt 5: JavaScript-Handler für Leistung-Select erweitern**
+
+In `src/pages/admin/termine.astro`, im `<script>`-Block, nach dem bestehenden `booking-project-select`-Handler (nach Zeile 341) einen neuen Handler hinzufügen:
+
+```javascript
+  // Booking leistung assignment
+  document.querySelectorAll<HTMLSelectElement>('.booking-leistung-select').forEach(sel => {
+    sel.addEventListener('change', async () => {
+      const uid = sel.dataset.bookingUid;
+      if (!uid) return;
+      // Find the sibling project select to get current projectId
+      const container = sel.closest('[data-booking-uid]') ?? sel.parentElement;
+      const projectSel = container?.querySelector<HTMLSelectElement>('.booking-project-select');
+      const projectId = projectSel?.value || null;
+      sel.disabled = true;
+      try {
+        const res = await fetch(`/api/bookings/${encodeURIComponent(uid)}/project`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ projectId, leistungKey: sel.value || null }),
+        });
+        if (!res.ok) alert('Fehler beim Speichern der Leistungszuordnung.');
+      } catch {
+        alert('Netzwerkfehler.');
+      } finally {
+        sel.disabled = false;
+      }
+    });
+  });
+```
+
+Außerdem den bestehenden `booking-project-select`-Handler aktualisieren, damit er beim Ändern des Projekts auch die aktuelle Leistung mitschickt (Zeile 335 ersetzen):
+
+```javascript
+          body: JSON.stringify({
+            projectId: sel.value || null,
+            leistungKey: sel.closest('[data-booking-uid]')?.querySelector<HTMLSelectElement>('.booking-leistung-select')?.value || null,
+          }),
+```
+
+- [ ] **Schritt 6: TypeScript prüfen**
+
+```bash
+cd /home/patrick/Bachelorprojekt/website && npx tsc --noEmit 2>&1 | head -30
+```
+
+Erwartet: keine Fehler.
+
+- [ ] **Schritt 7: Commit**
+
+```bash
+git add src/pages/api/bookings/[uid]/project.ts src/pages/admin/termine.astro
+git commit -m "feat: add leistung_key to booking project link in admin Termine"
+```
+
+---
+
+## Task 7: Öffentlicher Leistungen-Endpunkt + Portal BookingForm
+
+**Files:**
+- Create: `src/pages/api/leistungen.ts`
+- Modify: `src/components/BookingForm.svelte`
+- Modify: `src/pages/api/booking.ts`
+
+- [ ] **Schritt 1: Neuen öffentlichen GET-Endpunkt erstellen**
+
+Datei `src/pages/api/leistungen.ts` erstellen:
+
+```typescript
+import type { APIRoute } from 'astro';
+import { getEffectiveLeistungen } from '../../lib/content';
+
+export const GET: APIRoute = async () => {
+  const cats = await getEffectiveLeistungen();
+  const flat = cats.flatMap(cat =>
+    cat.services.map(svc => ({
+      key: svc.key,
+      name: svc.name,
+      category: cat.title,
+    }))
+  );
+  return new Response(JSON.stringify(flat), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+};
+```
+
+Hinweis: `stundensatz_cents` wird bewusst nicht zurückgegeben — das ist interne Admin-Information.
+
+- [ ] **Schritt 2: Endpunkt manuell testen**
+
+```bash
+curl -s http://localhost:4321/api/leistungen | head -c 200
+```
+
+Erwartet: JSON-Array mit `[{ key, name, category }, ...]`.
+
+- [ ] **Schritt 3: `booking.ts` — `projectId` + `leistungKey` in Payload speichern**
+
+In `src/pages/api/booking.ts`, die Destrukturierung der Request-Body (Zeile 18) erweitern:
+
+```typescript
+const { name, email, phone, type, message, slotStart, slotEnd, slotDisplay, date, serviceKey, projectId, leistungKey } = await request.json();
+```
+
+Im `createInboxItem`-Aufruf (Zeilen 60-68), das Payload-Objekt erweitern:
+
+```typescript
+    await createInboxItem({
+      type: 'booking',
+      payload: {
+        name, email, phone: phone ?? null, type, typeLabel,
+        slotStart: slotStart ?? null, slotEnd: slotEnd ?? null,
+        slotDisplay: slotDisplay ?? null, date: date ?? null,
+        serviceKey: serviceKey ?? null, message: message ?? null,
+        projectId: projectId ?? null, leistungKey: leistungKey ?? null,
+      },
+    });
+```
+
+- [ ] **Schritt 4: `BookingForm.svelte` — Leistung + Projekt Dropdowns**
+
+In `src/components/BookingForm.svelte`, im `<script>`-Block, Client-seitiges Laden der Daten hinzufügen:
+
+```typescript
+  import { onMount } from 'svelte';
+
+  let portalProjects: Array<{ id: string; name: string }> = [];
+  let leistungenOptions: Array<{ key: string; name: string; category: string }> = [];
+  let selectedProjectId = '';
+  let selectedLeistungKey = '';
+
+  onMount(async () => {
+    // Leistungen immer laden
+    try {
+      const res = await fetch('/api/leistungen');
+      if (res.ok) leistungenOptions = await res.json();
+    } catch { /* ignore */ }
+
+    // Projekte nur wenn eingeloggt
+    try {
+      const res = await fetch('/api/portal/projekte');
+      if (res.ok) portalProjects = await res.json();
+    } catch { /* ignore */ }
+  });
+```
+
+Im Template-Teil, unterhalb der bestehenden Felder (direkt vor dem Submit-Button), die optionalen Felder hinzufügen (nur wenn im `termin`/`erstgespraech`/`meeting`-Modus und Leistungen verfügbar):
+
+```svelte
+  {#if leistungenOptions.length > 0 && type !== 'callback'}
+    <div>
+      <label class="block text-sm text-muted mb-1">Leistung (optional)</label>
+      <select bind:value={selectedLeistungKey}
+        class="w-full px-3 py-2 bg-dark border border-dark-lighter rounded-lg text-light text-sm">
+        <option value="">— Keine Leistung auswählen —</option>
+        {#each leistungenOptions as opt}
+          <option value={opt.key}>{opt.category} — {opt.name}</option>
+        {/each}
+      </select>
+    </div>
+
+    {#if portalProjects.length > 0}
+      <div>
+        <label class="block text-sm text-muted mb-1">Für welches Projekt? (optional)</label>
+        <select bind:value={selectedProjectId}
+          class="w-full px-3 py-2 bg-dark border border-dark-lighter rounded-lg text-light text-sm">
+          <option value="">— Kein Projekt —</option>
+          {#each portalProjects as p}
+            <option value={p.id}>{p.name}</option>
+          {/each}
+        </select>
+      </div>
+    {/if}
+  {/if}
+```
+
+Im `handleSubmit`-Fetch-Aufruf, den Body um die neuen Felder erweitern (in der `body: JSON.stringify({...})`-Sektion):
+
+```javascript
+projectId: selectedProjectId || undefined,
+leistungKey: selectedLeistungKey || undefined,
+```
+
+- [ ] **Schritt 5: TypeScript prüfen**
+
+```bash
+cd /home/patrick/Bachelorprojekt/website && npx tsc --noEmit 2>&1 | head -30
+```
+
+Erwartet: keine Fehler.
+
+- [ ] **Schritt 6: Commit**
+
+```bash
+git add src/pages/api/leistungen.ts src/components/BookingForm.svelte src/pages/api/booking.ts
+git commit -m "feat: portal booking form with Leistung and Projekt selection"
+```
+
+---
+
+## Abschluss
+
+- [ ] **Build-Test**
+
+```bash
+cd /home/patrick/Bachelorprojekt/website && npm run build 2>&1 | tail -20
+```
+
+Erwartet: `Build complete.` ohne Fehler.
+
+- [ ] **Finaler Commit (falls nötig)**
+
+```bash
+git log --oneline -8
+```
+
+Alle 7 Feature-Commits sollten sichtbar sein.

--- a/docs/superpowers/specs/2026-04-19-leistung-stundensatz-terminbuchung-design.md
+++ b/docs/superpowers/specs/2026-04-19-leistung-stundensatz-terminbuchung-design.md
@@ -1,0 +1,131 @@
+# Design: Leistung + Stundensatz + Terminbuchung
+
+**Datum:** 2026-04-19
+**Ansatz:** A — JSONB-Erweiterung
+
+## Überblick
+
+Drei zusammenhängende Erweiterungen:
+1. Leistungen bekommen einen numerischen Stundensatz (admin-pflegbar)
+2. Zeiteinträge verknüpfen eine Leistung und frieren den Stundensatz ein
+3. Terminbuchungen (Admin + Kundenportal) verknüpfen Leistung + Projekt atomar
+
+---
+
+## 1. Datenmodell
+
+### `LeistungService` (config/types.ts)
+
+Neues optionales Feld:
+
+```typescript
+stundensatz_cents?: number  // z.B. 6000 = 60 €/Std.
+```
+
+Optional für Rückwärtskompatibilität mit bestehenden Configs ohne Migration.
+
+### `time_entries` Tabelle
+
+Zwei neue Spalten:
+
+```sql
+leistung_key      TEXT,     -- z.B. "digital-cafe-einzel"
+stundensatz_cents INTEGER   -- eingefroren bei Buchung, z.B. 6000 = 60 €
+```
+
+Beide nullable — bestehende Einträge ohne Leistung bleiben gültig.
+
+### `booking_project_links` Tabelle
+
+Eine neue Spalte:
+
+```sql
+leistung_key TEXT           -- welche Leistung wurde für diesen Termin gebucht
+```
+
+---
+
+## 2. Admin — Stundensatz pflegen
+
+**Wo:** Bestehendes Leistungen-Admin-UI
+
+**Änderung:** Jede `LeistungService`-Zeile erhält ein numerisches Eingabefeld "Stundensatz (€/Std.)".
+
+- Eingabe in Euro (z.B. `60`), Speicherung intern als Cents (`6000`)
+- Gespeichert über den bestehenden `leistungen_config`-JSONB-Endpunkt
+- Anzeige: `"60 € / Std."` neben dem Service-Namen in der UI
+
+Kein neuer API-Endpunkt — der bestehende Config-Save-Flow wird erweitert.
+
+---
+
+## 3. Zeiterfassung — Leistung & Stundensatz
+
+**Wo:** `/admin/zeiterfassung` — Zeiterfassungs-Formular
+
+### Neue Felder im Formular
+
+| Feld | Verhalten |
+|------|-----------|
+| **Leistung** | Dropdown, Optionen aus `getEffectiveLeistungen()`, nach Kategorie gruppiert |
+| **Stundensatz** | Numerisch, wird bei Leistungsauswahl automatisch befüllt — manuell überschreibbar |
+
+### Speicherverhalten
+
+Beim Speichern eines Zeiteintrags werden `leistung_key` und `stundensatz_cents` auf dem Eintrag eingefroren. Spätere Änderungen am Leistungs-Stundensatz haben keinen Einfluss auf bestehende Einträge.
+
+### Anzeige in der Übersicht
+
+- Neue Spalte "Stundensatz" in der Zeiterfassungstabelle
+- Neue Spalte "Betrag" pro Eintrag: `minutes / 60 × stundensatz_cents / 100`
+- Gesamtsumme (abrechenbar) am Tabellenende
+
+---
+
+## 4. Terminbuchung — Leistung & Projekt
+
+### 4a. Admin-Flow (`/admin/termine`)
+
+Beim Erstellen oder Bestätigen eines Termins: zwei neue optionale Felder:
+
+- **Projekt** — Dropdown aller aktiven Projekte
+- **Leistung** — Dropdown aller Leistungen
+
+Beide werden beim Speichern in `booking_project_links` mit `leistung_key` eingetragen.
+
+Die CalDAV-Terminbeschreibung wird um Projekt- und Leistungsname ergänzt.
+
+### 4b. Kundenportal-Flow (`BookingForm.svelte`)
+
+Nur wenn eingeloggt: zwei neue optionale Felder im Buchungsformular:
+
+- **Für welches Projekt?** — Dropdown der eigenen Projekte (via `/api/portal/projects`)
+- **Welche Leistung?** — Dropdown aller Leistungen (via `getEffectiveLeistungen()`)
+
+Der POST an `/api/booking` nimmt `project_id` und `leistung_key` entgegen und schreibt beide sofort in `booking_project_links` — kein nachträglicher Admin-Schritt mehr nötig.
+
+Der CalDAV-Termin wird wie bisher erstellt. Leistung und Projekt erscheinen in der Terminbeschreibung.
+
+---
+
+## 5. Betroffene Dateien
+
+| Datei | Änderung |
+|-------|----------|
+| `src/config/types.ts` | `stundensatz_cents?` zu `LeistungService` |
+| `src/lib/website-db.ts` | Migration: neue Spalten `time_entries`, `booking_project_links`; DB-Funktionen erweitern |
+| `src/pages/api/admin/zeiterfassung/create.ts` | `leistung_key` + `stundensatz_cents` verarbeiten |
+| `src/pages/admin/zeiterfassung.astro` | Leistung-Dropdown + Stundensatz-Feld + Betragsspalte |
+| `src/pages/admin/termine.astro` | Projekt + Leistung bei Terminbestätigung |
+| `src/pages/api/booking.ts` | `project_id` + `leistung_key` entgegennehmen, in `booking_project_links` schreiben |
+| `src/components/BookingForm.svelte` | Projekt + Leistung Dropdowns (nur eingeloggt) |
+| `src/pages/api/portal/projects.ts` | Neuer Endpunkt: Projekte des eingeloggten Kunden |
+
+---
+
+## 6. Nicht im Scope
+
+- Stundensatz pro Projekt überschreiben (global pro Leistung reicht)
+- Automatische Rechnungserstellung aus Zeiteinträgen
+- Kunden können gebuchte Termine nachträglich ändern/stornieren
+- Wiederkehrende Buchungen

--- a/k3d/website-schema.yaml
+++ b/k3d/website-schema.yaml
@@ -153,12 +153,16 @@ data:
       CREATE INDEX IF NOT EXISTS idx_messages_thread ON messages(thread_id, id ASC);
 
       CREATE TABLE IF NOT EXISTS chat_rooms (
-        id          SERIAL PRIMARY KEY,
-        name        TEXT NOT NULL,
-        created_by  TEXT NOT NULL,
-        created_at  TIMESTAMPTZ DEFAULT now(),
-        archived_at TIMESTAMPTZ
+        id                  SERIAL PRIMARY KEY,
+        name                TEXT NOT NULL,
+        created_by          TEXT NOT NULL,
+        created_at          TIMESTAMPTZ DEFAULT now(),
+        archived_at         TIMESTAMPTZ,
+        is_direct           BOOLEAN NOT NULL DEFAULT FALSE,
+        direct_customer_id  UUID REFERENCES customers(id) ON DELETE SET NULL
       );
+      ALTER TABLE chat_rooms ADD COLUMN IF NOT EXISTS is_direct BOOLEAN NOT NULL DEFAULT FALSE;
+      ALTER TABLE chat_rooms ADD COLUMN IF NOT EXISTS direct_customer_id UUID REFERENCES customers(id) ON DELETE SET NULL;
 
       CREATE TABLE IF NOT EXISTS chat_room_members (
         room_id     INT NOT NULL REFERENCES chat_rooms(id),

--- a/website/src/components/ChatWidget.svelte
+++ b/website/src/components/ChatWidget.svelte
@@ -188,7 +188,7 @@
 {/if}
 
 <style>
-  .cw { position: fixed; bottom: 24px; right: 90px; z-index: 9000; display: flex; flex-direction: column; align-items: flex-end; gap: 10px; }
+  .cw { position: fixed; bottom: 24px; right: 184px; z-index: 9000; display: flex; flex-direction: column; align-items: flex-end; gap: 10px; }
   .panel { width: 560px; height: 440px; background: #1a2235; border: 1px solid #243049; border-radius: 12px; display: flex; flex-direction: column; box-shadow: 0 8px 32px rgba(0,0,0,.5); overflow: hidden; }
   .hdr { display: flex; justify-content: space-between; align-items: center; padding: 12px 16px; background: #243049; font-size: 14px; font-weight: 600; color: #e8e8f0; flex-shrink: 0; }
   .x { background: transparent; border: none; color: #aabbcc; cursor: pointer; font-size: 14px; padding: 0; line-height: 1; }

--- a/website/src/components/ChatWidget.svelte
+++ b/website/src/components/ChatWidget.svelte
@@ -1,17 +1,24 @@
 <script lang="ts">
-  import type { Message, MessageThread } from '../lib/messaging-db';
+  import type { RoomInboxItem, ChatMessage } from '../lib/messaging-db';
 
   type AuthResponse = { authenticated: false } | { authenticated: true; user: { name: string; isAdmin: boolean } };
 
   let open = $state(false);
   let visible = $state(false);
-  let thread = $state<MessageThread | null>(null);
-  let messages = $state<Message[]>([]);
+  let rooms = $state<RoomInboxItem[]>([]);
+  let activeRoomId = $state<number | null>(null);
+  let messages = $state<ChatMessage[]>([]);
   let newBody = $state('');
   let sending = $state(false);
   let loading = $state(true);
+  let lastId = $state(0);
+  let customerId = $state('');
+  let adminMode = $state(false);
   let pollInterval: ReturnType<typeof setInterval> | null = null;
   let msgContainer = $state<HTMLDivElement | null>(null);
+
+  let totalUnread = $derived(rooms.reduce((sum, r) => sum + r.unreadCount, 0));
+  let activeRoom = $derived(rooms.find(r => r.id === activeRoomId) ?? null);
 
   $effect(() => {
     initWidget();
@@ -23,262 +30,194 @@
       const res = await fetch('/api/auth/me');
       const data = await res.json() as AuthResponse;
       if (!data.authenticated) return;
+      adminMode = data.user.isAdmin;
       visible = true;
-      await loadThread();
+      if (adminMode) {
+        await loadRooms();
+        if (rooms.length > 0) { activeRoomId = rooms[0].id; await loadMessages(); }
+      } else {
+        const dr = await fetch('/api/portal/rooms/ensure-direct', { method: 'POST' });
+        if (!dr.ok) return;
+        const { room_id, customer_id } = await dr.json() as { room_id: number; customer_id: string };
+        customerId = customer_id;
+        await loadRooms();
+        activeRoomId = room_id;
+        await loadMessages();
+      }
+      startPolling();
     } finally {
       loading = false;
     }
   }
 
-  async function loadThread() {
-    const res = await fetch('/api/portal/messages');
-    if (!res.ok) return;
-    const data = await res.json() as { thread: MessageThread | null };
-    thread = data.thread;
-    if (thread) {
-      await fetchMessages();
+  async function loadRooms() {
+    if (adminMode) {
+      const res = await fetch('/api/admin/rooms');
+      if (!res.ok) return;
+      const data = await res.json() as { rooms: Array<{ id: number; name: string; is_direct: boolean; direct_customer_id: string | null }> };
+      rooms = data.rooms.map(r => ({ id: r.id, name: r.name, is_direct: r.is_direct, direct_customer_id: r.direct_customer_id, lastMessageBody: null, lastMessageSenderName: null, lastMessageAt: null, unreadCount: 0 }));
+    } else {
+      const res = await fetch('/api/portal/rooms');
+      if (!res.ok) return;
+      const data = await res.json() as { rooms: RoomInboxItem[] };
+      rooms = data.rooms;
     }
   }
 
-  async function fetchMessages() {
-    if (!thread) return;
-    const res = await fetch(`/api/portal/messages/${thread.id}`);
+  function msgUrl(roomId: number, afterId?: number): string {
+    if (adminMode) return afterId !== undefined ? `/api/admin/rooms/${roomId}?after=${afterId}` : `/api/admin/rooms/${roomId}`;
+    return afterId !== undefined ? `/api/portal/rooms/${roomId}/messages?after=${afterId}` : `/api/portal/rooms/${roomId}/messages`;
+  }
+
+  async function loadMessages() {
+    if (!activeRoomId) return;
+    const res = await fetch(msgUrl(activeRoomId));
     if (!res.ok) return;
-    const data = await res.json() as { messages: Message[] };
+    const data = await res.json() as { messages: ChatMessage[] };
     messages = data.messages;
+    lastId = messages.length ? messages[messages.length - 1].id : 0;
     scrollToBottom();
+  }
+
+  async function selectRoom(roomId: number) {
+    if (pollInterval) clearInterval(pollInterval);
+    activeRoomId = roomId; messages = []; lastId = 0;
+    await loadMessages();
+    startPolling();
   }
 
   function startPolling() {
     if (pollInterval) clearInterval(pollInterval);
     pollInterval = setInterval(async () => {
-      if (!open || !thread) return;
-      await fetchMessages();
+      if (!activeRoomId) return;
+      const res = await fetch(msgUrl(activeRoomId, lastId));
+      if (!res.ok) return;
+      const data = await res.json() as { messages: ChatMessage[] };
+      if (data.messages.length > 0) {
+        messages = [...messages, ...data.messages];
+        lastId = data.messages[data.messages.length - 1].id;
+        if (open) scrollToBottom();
+      }
+      await loadRooms();
     }, 5000);
   }
 
   async function toggleOpen() {
     open = !open;
-    if (open) {
-      if (!thread) await loadThread();
-      else await fetchMessages();
-      startPolling();
-      scrollToBottom();
-    } else {
-      if (pollInterval) clearInterval(pollInterval);
-    }
+    if (open) { if (activeRoomId) await loadMessages(); scrollToBottom(); }
   }
 
   async function sendMessage() {
-    if (!newBody.trim() || sending) return;
+    if (!newBody.trim() || !activeRoomId || sending) return;
     sending = true;
-    const body = newBody.trim();
-    newBody = '';
+    const body = newBody.trim(); newBody = '';
     try {
-      const url = thread ? `/api/portal/messages/${thread.id}` : '/api/portal/messages';
-      const res = await fetch(url, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ body }),
-      });
+      const url = adminMode ? `/api/admin/rooms/${activeRoomId}` : `/api/portal/rooms/${activeRoomId}/messages`;
+      const res = await fetch(url, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ body }) });
       if (res.ok) {
-        const data = await res.json() as { message: Message; thread?: MessageThread };
-        if (data.thread) thread = data.thread;
-        messages = [...messages, data.message];
-        scrollToBottom();
+        const data = await res.json() as { message: ChatMessage };
+        messages = [...messages, data.message]; lastId = data.message.id; scrollToBottom();
       }
-    } finally {
-      sending = false;
-    }
+    } finally { sending = false; }
   }
 
   function handleKeydown(e: KeyboardEvent) {
-    if (e.key === 'Enter' && !e.shiftKey) {
-      e.preventDefault();
-      sendMessage();
-    }
+    if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); sendMessage(); }
   }
 
   function scrollToBottom() {
-    setTimeout(() => {
-      if (msgContainer) msgContainer.scrollTop = msgContainer.scrollHeight;
-    }, 50);
+    setTimeout(() => { if (msgContainer) msgContainer.scrollTop = msgContainer.scrollHeight; }, 50);
+  }
+
+  function formatTime(d: Date | string) {
+    return new Date(d).toLocaleTimeString('de-DE', { hour: '2-digit', minute: '2-digit' });
+  }
+
+  function isOwn(msg: ChatMessage) {
+    return adminMode ? msg.sender_customer_id === null : msg.sender_customer_id === customerId;
   }
 </script>
 
 {#if visible}
-  <div class="chat-widget">
+  <div class="cw">
     {#if open}
-      <div class="chat-panel">
-        <div class="chat-header">
-          <span>💬 Nachrichten</span>
-          <button class="close-btn" onclick={toggleOpen} aria-label="Schließen">✕</button>
+      <div class="panel">
+        <div class="hdr">
+          <span>💬 {activeRoom?.name ?? 'Chat'}</span>
+          <button class="x" onclick={toggleOpen} aria-label="Schließen">✕</button>
         </div>
-        <div class="chat-body" bind:this={msgContainer}>
-          {#if loading}
-            <p class="chat-hint">Lade…</p>
-          {:else if messages.length === 0}
-            <p class="chat-hint">Noch keine Nachrichten. Schreib uns gerne!</p>
-          {:else}
-            {#each messages as msg (msg.id)}
-              <div class="chat-msg {msg.sender_role === 'user' ? 'msg-me' : 'msg-admin'}">
-                <span class="msg-text">{msg.body}</span>
-                <span class="msg-time">
-                  {new Date(msg.created_at).toLocaleTimeString('de-DE', { hour: '2-digit', minute: '2-digit' })}
-                </span>
-              </div>
+        <div class="body">
+          <aside class="rooms">
+            {#each rooms as r (r.id)}
+              <button class="ri {activeRoomId === r.id ? 'active' : ''}" onclick={() => selectRoom(r.id)}>
+                <span class="rn">{r.name}</span>
+                {#if r.unreadCount > 0}<span class="badge">{r.unreadCount > 9 ? '9+' : r.unreadCount}</span>{/if}
+              </button>
             {/each}
-          {/if}
-        </div>
-        <div class="chat-footer">
-          <textarea
-            bind:value={newBody}
-            onkeydown={handleKeydown}
-            placeholder="Nachricht schreiben… (Enter zum Senden)"
-            rows="2"
-            disabled={sending}
-          ></textarea>
-          <button class="send-btn" onclick={sendMessage} disabled={!newBody.trim() || sending}>
-            {sending ? '…' : '➤'}
-          </button>
+          </aside>
+          <div class="msgs">
+            <div class="list" bind:this={msgContainer}>
+              {#if loading}<p class="hint">Lade…</p>
+              {:else if messages.length === 0}<p class="hint">Noch keine Nachrichten.</p>
+              {:else}
+                {#each messages as msg (msg.id)}
+                  {@const own = isOwn(msg)}
+                  <div class="row {own ? 'own' : 'other'}">
+                    {#if !own}<span class="who">{msg.sender_name}</span>{/if}
+                    <div class="bbl">
+                      <span class="txt">{msg.body}</span>
+                      <span class="ts">{formatTime(msg.created_at)}</span>
+                    </div>
+                  </div>
+                {/each}
+              {/if}
+            </div>
+            <div class="bar">
+              <textarea bind:value={newBody} onkeydown={handleKeydown} placeholder="Nachricht… (Enter)" rows="2" disabled={sending || !activeRoomId}></textarea>
+              <button class="send" onclick={sendMessage} disabled={!newBody.trim() || sending || !activeRoomId}>{sending ? '…' : '➤'}</button>
+            </div>
+          </div>
         </div>
       </div>
     {/if}
-    <button class="toggle-btn" onclick={toggleOpen} aria-label="Chat öffnen/schließen">
+    <button class="fab" onclick={toggleOpen} aria-label="Chat">
+      {#if totalUnread > 0 && !open}<span class="dot">{totalUnread > 9 ? '9+' : totalUnread}</span>{/if}
       {open ? '✕' : '💬'}
     </button>
   </div>
 {/if}
 
 <style>
-  .chat-widget {
-    position: fixed;
-    bottom: 24px;
-    right: 168px;
-    z-index: 9000;
-    display: flex;
-    flex-direction: column;
-    align-items: flex-end;
-    gap: 10px;
-  }
-  .chat-panel {
-    width: 320px;
-    background: #1a2235;
-    border: 1px solid #243049;
-    border-radius: 12px;
-    display: flex;
-    flex-direction: column;
-    box-shadow: 0 8px 32px rgba(0,0,0,.5);
-    overflow: hidden;
-  }
-  .chat-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding: 12px 16px;
-    background: #243049;
-    font-size: 14px;
-    font-weight: 600;
-    color: #e8e8f0;
-  }
-  .close-btn {
-    background: transparent;
-    border: none;
-    color: #aabbcc;
-    cursor: pointer;
-    font-size: 14px;
-    padding: 0;
-    line-height: 1;
-  }
-  .chat-body {
-    flex: 1;
-    overflow-y: auto;
-    padding: 12px;
-    display: flex;
-    flex-direction: column;
-    gap: 8px;
-    min-height: 220px;
-    max-height: 340px;
-  }
-  .chat-hint {
-    font-size: 12px;
-    color: #8899aa;
-    text-align: center;
-    margin: auto 0;
-  }
-  .chat-msg {
-    display: flex;
-    flex-direction: column;
-    gap: 2px;
-    max-width: 85%;
-  }
-  .msg-me { align-self: flex-end; }
-  .msg-admin { align-self: flex-start; }
-  .msg-text {
-    padding: 8px 12px;
-    border-radius: 12px;
-    font-size: 13px;
-    color: #e8e8f0;
-    white-space: pre-wrap;
-    word-break: break-word;
-    line-height: 1.4;
-  }
-  .msg-me .msg-text { background: #e8c870; color: #0f1623; border-bottom-right-radius: 4px; }
-  .msg-admin .msg-text { background: #243049; border-bottom-left-radius: 4px; }
-  .msg-time {
-    font-size: 10px;
-    color: #5566aa;
-    padding: 0 4px;
-  }
-  .msg-me .msg-time { align-self: flex-end; }
-  .chat-footer {
-    display: flex;
-    gap: 8px;
-    padding: 10px 12px;
-    border-top: 1px solid #243049;
-    align-items: flex-end;
-  }
-  .chat-footer textarea {
-    flex: 1;
-    background: #0f1623;
-    color: #e8e8f0;
-    border: 1px solid #374151;
-    border-radius: 8px;
-    padding: 8px;
-    font-size: 13px;
-    resize: none;
-    box-sizing: border-box;
-    font-family: inherit;
-    line-height: 1.4;
-  }
-  .chat-footer textarea:focus { outline: none; border-color: #e8c870; }
-  .send-btn {
-    background: #e8c870;
-    color: #0f1623;
-    border: none;
-    border-radius: 8px;
-    padding: 8px 12px;
-    font-size: 16px;
-    cursor: pointer;
-    font-weight: 700;
-    flex-shrink: 0;
-    align-self: flex-end;
-  }
-  .send-btn:disabled { opacity: .5; cursor: not-allowed; }
-  .toggle-btn {
-    width: 52px;
-    height: 52px;
-    border-radius: 50%;
-    background: #e8c870;
-    color: #0f1623;
-    border: none;
-    font-size: 22px;
-    cursor: pointer;
-    box-shadow: 0 4px 16px rgba(0,0,0,.4);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    transition: transform .15s, box-shadow .15s;
-  }
-  .toggle-btn:hover { transform: scale(1.08); box-shadow: 0 6px 20px rgba(0,0,0,.5); }
+  .cw { position: fixed; bottom: 24px; right: 90px; z-index: 9000; display: flex; flex-direction: column; align-items: flex-end; gap: 10px; }
+  .panel { width: 560px; height: 440px; background: #1a2235; border: 1px solid #243049; border-radius: 12px; display: flex; flex-direction: column; box-shadow: 0 8px 32px rgba(0,0,0,.5); overflow: hidden; }
+  .hdr { display: flex; justify-content: space-between; align-items: center; padding: 12px 16px; background: #243049; font-size: 14px; font-weight: 600; color: #e8e8f0; flex-shrink: 0; }
+  .x { background: transparent; border: none; color: #aabbcc; cursor: pointer; font-size: 14px; padding: 0; line-height: 1; }
+  .body { display: flex; flex: 1; min-height: 0; }
+  .rooms { width: 160px; flex-shrink: 0; border-right: 1px solid #243049; overflow-y: auto; display: flex; flex-direction: column; }
+  .ri { width: 100%; background: transparent; border: none; border-bottom: 1px solid #1e2a3a; text-align: left; padding: 10px 12px; cursor: pointer; color: #aabbcc; font-size: 12px; display: flex; align-items: center; justify-content: space-between; gap: 4px; }
+  .ri.active { background: #243049; color: #e8e8f0; }
+  .ri:hover:not(.active) { background: #1e2a3a; }
+  .rn { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .badge { flex-shrink: 0; background: #3b82f6; color: #fff; border-radius: 999px; font-size: 10px; font-weight: 700; padding: 1px 5px; font-family: monospace; }
+  .msgs { flex: 1; display: flex; flex-direction: column; min-width: 0; }
+  .list { flex: 1; overflow-y: auto; padding: 12px; display: flex; flex-direction: column; gap: 6px; }
+  .hint { font-size: 12px; color: #8899aa; text-align: center; margin: auto 0; }
+  .row { display: flex; flex-direction: column; gap: 2px; max-width: 88%; }
+  .row.own { align-self: flex-end; }
+  .row.other { align-self: flex-start; }
+  .who { font-size: 10px; color: #5566aa; padding: 0 4px; }
+  .bbl { display: flex; flex-direction: column; gap: 2px; }
+  .txt { padding: 7px 11px; border-radius: 12px; font-size: 13px; color: #e8e8f0; white-space: pre-wrap; word-break: break-word; line-height: 1.4; }
+  .row.own .txt { background: #e8c870; color: #0f1623; border-bottom-right-radius: 4px; }
+  .row.other .txt { background: #243049; border-bottom-left-radius: 4px; }
+  .ts { font-size: 10px; color: #5566aa; padding: 0 4px; }
+  .row.own .ts { align-self: flex-end; }
+  .bar { display: flex; gap: 8px; padding: 10px 12px; border-top: 1px solid #243049; align-items: flex-end; flex-shrink: 0; }
+  .bar textarea { flex: 1; background: #0f1623; color: #e8e8f0; border: 1px solid #374151; border-radius: 8px; padding: 7px; font-size: 13px; resize: none; box-sizing: border-box; font-family: inherit; line-height: 1.4; }
+  .bar textarea:focus { outline: none; border-color: #e8c870; }
+  .send { background: #e8c870; color: #0f1623; border: none; border-radius: 8px; padding: 8px 12px; font-size: 16px; cursor: pointer; font-weight: 700; flex-shrink: 0; align-self: flex-end; }
+  .send:disabled { opacity: .5; cursor: not-allowed; }
+  .fab { position: relative; width: 52px; height: 52px; border-radius: 50%; background: #e8c870; color: #0f1623; border: none; font-size: 22px; cursor: pointer; box-shadow: 0 4px 16px rgba(0,0,0,.4); display: flex; align-items: center; justify-content: center; transition: transform .15s, box-shadow .15s; }
+  .fab:hover { transform: scale(1.08); box-shadow: 0 6px 20px rgba(0,0,0,.5); }
+  .dot { position: absolute; top: -4px; right: -4px; background: #ef4444; color: #fff; border-radius: 999px; font-size: 10px; font-weight: 700; padding: 2px 5px; font-family: monospace; min-width: 18px; text-align: center; line-height: 1.4; pointer-events: none; }
 </style>

--- a/website/src/components/ChatWidget.svelte
+++ b/website/src/components/ChatWidget.svelte
@@ -1,11 +1,13 @@
 <script lang="ts">
-  import type { RoomInboxItem, ChatMessage } from '../lib/messaging-db';
+  import type { ChatMessage } from '../lib/messaging-db';
 
+  interface DirectRoom { id: number; name: string; is_direct: boolean; direct_customer_id: string | null; unreadCount: number; }
+  interface Customer { id: string; name: string; email: string; }
   type AuthResponse = { authenticated: false } | { authenticated: true; user: { name: string; isAdmin: boolean } };
 
   let open = $state(false);
   let visible = $state(false);
-  let rooms = $state<RoomInboxItem[]>([]);
+  let rooms = $state<DirectRoom[]>([]);
   let activeRoomId = $state<number | null>(null);
   let messages = $state<ChatMessage[]>([]);
   let newBody = $state('');
@@ -17,8 +19,20 @@
   let pollInterval: ReturnType<typeof setInterval> | null = null;
   let msgContainer = $state<HTMLDivElement | null>(null);
 
+  let showPicker = $state(false);
+  let allCustomers = $state<Customer[]>([]);
+  let customerSearch = $state('');
+  let pickerLoading = $state(false);
+
   let totalUnread = $derived(rooms.reduce((sum, r) => sum + r.unreadCount, 0));
   let activeRoom = $derived(rooms.find(r => r.id === activeRoomId) ?? null);
+  let filteredCustomers = $derived(
+    allCustomers.filter(c =>
+      customerSearch === '' ||
+      c.name.toLowerCase().includes(customerSearch.toLowerCase()) ||
+      c.email.toLowerCase().includes(customerSearch.toLowerCase())
+    )
+  );
 
   $effect(() => {
     initWidget();
@@ -40,9 +54,9 @@
         if (!dr.ok) return;
         const { room_id, customer_id } = await dr.json() as { room_id: number; customer_id: string };
         customerId = customer_id;
-        await loadRooms();
         activeRoomId = room_id;
         await loadMessages();
+        await loadRooms();
       }
       startPolling();
     } finally {
@@ -55,12 +69,14 @@
       const res = await fetch('/api/admin/rooms');
       if (!res.ok) return;
       const data = await res.json() as { rooms: Array<{ id: number; name: string; is_direct: boolean; direct_customer_id: string | null }> };
-      rooms = data.rooms.map(r => ({ id: r.id, name: r.name, is_direct: r.is_direct, direct_customer_id: r.direct_customer_id, lastMessageBody: null, lastMessageSenderName: null, lastMessageAt: null, unreadCount: 0 }));
+      rooms = data.rooms
+        .filter(r => r.is_direct)
+        .map(r => ({ id: r.id, name: r.name, is_direct: r.is_direct, direct_customer_id: r.direct_customer_id, unreadCount: 0 }));
     } else {
       const res = await fetch('/api/portal/rooms');
       if (!res.ok) return;
-      const data = await res.json() as { rooms: RoomInboxItem[] };
-      rooms = data.rooms;
+      const data = await res.json() as { rooms: Array<{ id: number; name: string; lastMessageBody: string | null; unreadCount: number }> };
+      rooms = data.rooms.map(r => ({ id: r.id, name: r.name, is_direct: true, direct_customer_id: null, unreadCount: r.unreadCount }));
     }
   }
 
@@ -136,6 +152,34 @@
   function isOwn(msg: ChatMessage) {
     return adminMode ? msg.sender_customer_id === null : msg.sender_customer_id === customerId;
   }
+
+  async function openPicker() {
+    showPicker = true;
+    customerSearch = '';
+    if (allCustomers.length === 0) {
+      pickerLoading = true;
+      try {
+        const res = await fetch('/api/admin/customers');
+        if (res.ok) {
+          const data = await res.json() as { customers: Customer[] };
+          allCustomers = data.customers;
+        }
+      } finally { pickerLoading = false; }
+    }
+  }
+
+  async function startDirectChat(customer: Customer) {
+    showPicker = false;
+    const res = await fetch('/api/admin/rooms/direct', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ customerId: customer.id }),
+    });
+    if (!res.ok) return;
+    const { room_id } = await res.json() as { room_id: number };
+    await loadRooms();
+    await selectRoom(room_id);
+  }
 </script>
 
 {#if visible}
@@ -143,21 +187,28 @@
     {#if open}
       <div class="panel">
         <div class="hdr">
-          <span>💬 {activeRoom?.name ?? 'Chat'}</span>
+          <span>💬 {adminMode ? (activeRoom?.name ?? 'Chats') : 'Chat mit Admin'}</span>
           <button class="x" onclick={toggleOpen} aria-label="Schließen">✕</button>
         </div>
         <div class="body">
-          <aside class="rooms">
-            {#each rooms as r (r.id)}
-              <button class="ri {activeRoomId === r.id ? 'active' : ''}" onclick={() => selectRoom(r.id)}>
-                <span class="rn">{r.name}</span>
-                {#if r.unreadCount > 0}<span class="badge">{r.unreadCount > 9 ? '9+' : r.unreadCount}</span>{/if}
-              </button>
-            {/each}
-          </aside>
+          {#if adminMode}
+            <aside class="rooms">
+              <button class="new-chat" onclick={openPicker} title="Neuen Chat starten">＋</button>
+              {#each rooms as r (r.id)}
+                <button class="ri {activeRoomId === r.id ? 'active' : ''}" onclick={() => selectRoom(r.id)}>
+                  <span class="rn">{r.name}</span>
+                  {#if r.unreadCount > 0}<span class="badge">{r.unreadCount > 9 ? '9+' : r.unreadCount}</span>{/if}
+                </button>
+              {/each}
+              {#if rooms.length === 0}
+                <p class="no-chats">Noch keine Chats.<br/>Mit ＋ starten.</p>
+              {/if}
+            </aside>
+          {/if}
           <div class="msgs">
             <div class="list" bind:this={msgContainer}>
               {#if loading}<p class="hint">Lade…</p>
+              {:else if !activeRoomId}<p class="hint">Wähle einen Chat oder starte einen neuen.</p>
               {:else if messages.length === 0}<p class="hint">Noch keine Nachrichten.</p>
               {:else}
                 {#each messages as msg (msg.id)}
@@ -178,6 +229,29 @@
             </div>
           </div>
         </div>
+        {#if showPicker}
+          <div class="picker">
+            <div class="picker-hdr">
+              <span>Neuen Chat starten</span>
+              <button class="x" onclick={() => showPicker = false}>✕</button>
+            </div>
+            <input class="picker-search" bind:value={customerSearch} placeholder="Name oder E-Mail suchen…" autofocus />
+            <div class="picker-list">
+              {#if pickerLoading}
+                <p class="hint">Lade…</p>
+              {:else if filteredCustomers.length === 0}
+                <p class="hint">Keine Treffer.</p>
+              {:else}
+                {#each filteredCustomers as c (c.id)}
+                  <button class="picker-item" onclick={() => startDirectChat(c)}>
+                    <span class="pi-name">{c.name}</span>
+                    <span class="pi-email">{c.email}</span>
+                  </button>
+                {/each}
+              {/if}
+            </div>
+          </div>
+        {/if}
       </div>
     {/if}
     <button class="fab" onclick={toggleOpen} aria-label="Chat">
@@ -189,11 +263,14 @@
 
 <style>
   .cw { position: fixed; bottom: 24px; right: 184px; z-index: 9000; display: flex; flex-direction: column; align-items: flex-end; gap: 10px; }
-  .panel { width: 560px; height: 440px; background: #1a2235; border: 1px solid #243049; border-radius: 12px; display: flex; flex-direction: column; box-shadow: 0 8px 32px rgba(0,0,0,.5); overflow: hidden; }
+  .panel { width: 560px; height: 440px; background: #1a2235; border: 1px solid #243049; border-radius: 12px; display: flex; flex-direction: column; box-shadow: 0 8px 32px rgba(0,0,0,.5); overflow: hidden; position: relative; }
   .hdr { display: flex; justify-content: space-between; align-items: center; padding: 12px 16px; background: #243049; font-size: 14px; font-weight: 600; color: #e8e8f0; flex-shrink: 0; }
   .x { background: transparent; border: none; color: #aabbcc; cursor: pointer; font-size: 14px; padding: 0; line-height: 1; }
   .body { display: flex; flex: 1; min-height: 0; }
   .rooms { width: 160px; flex-shrink: 0; border-right: 1px solid #243049; overflow-y: auto; display: flex; flex-direction: column; }
+  .new-chat { width: 100%; background: #1e2a3a; border: none; border-bottom: 1px solid #243049; padding: 8px 12px; cursor: pointer; color: #e8c870; font-size: 18px; font-weight: 700; text-align: center; transition: background .15s; }
+  .new-chat:hover { background: #243049; }
+  .no-chats { font-size: 11px; color: #5566aa; text-align: center; padding: 12px 8px; line-height: 1.5; }
   .ri { width: 100%; background: transparent; border: none; border-bottom: 1px solid #1e2a3a; text-align: left; padding: 10px 12px; cursor: pointer; color: #aabbcc; font-size: 12px; display: flex; align-items: center; justify-content: space-between; gap: 4px; }
   .ri.active { background: #243049; color: #e8e8f0; }
   .ri:hover:not(.active) { background: #1e2a3a; }
@@ -220,4 +297,13 @@
   .fab { position: relative; width: 52px; height: 52px; border-radius: 50%; background: #e8c870; color: #0f1623; border: none; font-size: 22px; cursor: pointer; box-shadow: 0 4px 16px rgba(0,0,0,.4); display: flex; align-items: center; justify-content: center; transition: transform .15s, box-shadow .15s; }
   .fab:hover { transform: scale(1.08); box-shadow: 0 6px 20px rgba(0,0,0,.5); }
   .dot { position: absolute; top: -4px; right: -4px; background: #ef4444; color: #fff; border-radius: 999px; font-size: 10px; font-weight: 700; padding: 2px 5px; font-family: monospace; min-width: 18px; text-align: center; line-height: 1.4; pointer-events: none; }
+  .picker { position: absolute; inset: 0; background: #1a2235; border-radius: 12px; display: flex; flex-direction: column; z-index: 10; }
+  .picker-hdr { display: flex; justify-content: space-between; align-items: center; padding: 12px 16px; background: #243049; font-size: 14px; font-weight: 600; color: #e8e8f0; flex-shrink: 0; border-radius: 12px 12px 0 0; }
+  .picker-search { margin: 10px 12px; background: #0f1623; color: #e8e8f0; border: 1px solid #374151; border-radius: 8px; padding: 7px 10px; font-size: 13px; font-family: inherit; }
+  .picker-search:focus { outline: none; border-color: #e8c870; }
+  .picker-list { flex: 1; overflow-y: auto; display: flex; flex-direction: column; }
+  .picker-item { background: transparent; border: none; border-bottom: 1px solid #1e2a3a; padding: 10px 12px; cursor: pointer; text-align: left; display: flex; flex-direction: column; gap: 2px; transition: background .15s; }
+  .picker-item:hover { background: #1e2a3a; }
+  .pi-name { font-size: 13px; color: #e8e8f0; font-weight: 500; }
+  .pi-email { font-size: 11px; color: #5566aa; }
 </style>

--- a/website/src/config/types.ts
+++ b/website/src/config/types.ts
@@ -37,6 +37,7 @@ export interface LeistungService {
   unit: string;
   desc: string;
   highlight?: boolean;
+  stundensatz_cents?: number;
 }
 
 export interface LeistungCategory {

--- a/website/src/layouts/AdminLayout.astro
+++ b/website/src/layouts/AdminLayout.astro
@@ -49,8 +49,6 @@ const navGroups = [
       { href: '/admin/meetings',      label: 'Meetings',      icon: 'microphone' },
       { href: '/admin/termine',       label: 'Termine',       icon: 'calendar' },
       { href: '/admin/clients',       label: 'Clients',       icon: 'users' },
-      { href: '/admin/nachrichten',   label: 'Nachrichten',   icon: 'message' },
-      { href: '/admin/raeume',        label: 'Räume',         icon: 'home' },
       { href: '/admin/projekte',      label: 'Projekte',      icon: 'clipboard' },
       { href: '/admin/zeiterfassung', label: 'Zeiterfassung', icon: 'clock' },
       { href: '/admin/rechnungen',    label: 'Rechnungen',    icon: 'receipt' },

--- a/website/src/lib/content.ts
+++ b/website/src/lib/content.ts
@@ -85,6 +85,7 @@ export async function getEffectiveLeistungen(): Promise<LeistungCategory[]> {
         unit: so.unit ?? svc.unit,
         desc: so.desc ?? svc.desc,
         highlight: so.highlight ?? svc.highlight,
+        stundensatz_cents: so.stundensatz_cents ?? svc.stundensatz_cents,
       };
     });
 

--- a/website/src/lib/messaging-db.ts
+++ b/website/src/lib/messaging-db.ts
@@ -143,6 +143,8 @@ export interface ChatRoom {
   created_by: string;
   created_at: Date;
   archived_at: Date | null;
+  is_direct: boolean;
+  direct_customer_id: string | null;
   member_count?: number;
 }
 
@@ -427,6 +429,46 @@ export async function getCustomerByEmail(email: string): Promise<{ id: string; n
     [email],
   );
   return rows[0] ?? null;
+}
+
+export async function getCustomerById(id: string): Promise<{ id: string; name: string; email: string } | null> {
+  const { rows } = await pool.query(
+    'SELECT id, name, email FROM customers WHERE id = $1',
+    [id],
+  );
+  return rows[0] ?? null;
+}
+
+export async function ensureDirectRoomForCustomer(
+  customerId: string,
+  customerName: string,
+  createdBy: string,
+): Promise<{ room_id: number; customer_id: string }> {
+  const existing = await pool.query<{ id: number }>(
+    'SELECT id FROM chat_rooms WHERE direct_customer_id = $1 AND is_direct = TRUE LIMIT 1',
+    [customerId],
+  );
+  if (existing.rows.length) return { room_id: existing.rows[0].id, customer_id: customerId };
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+    const { rows } = await client.query<ChatRoom>(
+      'INSERT INTO chat_rooms (name, created_by, is_direct, direct_customer_id) VALUES ($1, $2, TRUE, $3) RETURNING *',
+      [`Chat mit ${customerName}`, createdBy, customerId],
+    );
+    const room = rows[0];
+    await client.query(
+      'INSERT INTO chat_room_members (room_id, customer_id) VALUES ($1, $2) ON CONFLICT DO NOTHING',
+      [room.id, customerId],
+    );
+    await client.query('COMMIT');
+    return { room_id: room.id, customer_id: customerId };
+  } catch (e) {
+    await client.query('ROLLBACK');
+    throw e;
+  } finally {
+    client.release();
+  }
 }
 
 export async function listAllCustomers(): Promise<Array<{ id: string; name: string; email: string }>> {

--- a/website/src/lib/website-db.ts
+++ b/website/src/lib/website-db.ts
@@ -1215,6 +1215,8 @@ export async function exportProjectsFlat(brand: string): Promise<ProjectExportRo
 
 // ── Time Entries ──────────────────────────────────────────────────────────────
 
+let timeEntriesReady = false;
+
 export interface TimeEntry {
   id: string;
   projectId: string;
@@ -1232,6 +1234,7 @@ export interface TimeEntry {
 }
 
 async function initTimeEntriesTable(): Promise<void> {
+  if (timeEntriesReady) return;
   await pool.query(`
     CREATE TABLE IF NOT EXISTS time_entries (
       id                UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -1258,6 +1261,7 @@ async function initTimeEntriesTable(): Promise<void> {
   await pool.query(`
     ALTER TABLE time_entries ADD COLUMN IF NOT EXISTS leistung_key TEXT
   `);
+  timeEntriesReady = true;
 }
 
 export async function getLastTimeEntryRate(): Promise<number> {
@@ -1275,12 +1279,13 @@ export async function createTimeEntry(params: {
   minutes: number;
   billable?: boolean;
   rateCents?: number;
+  leistungKey?: string;
   entryDate?: string;
 }): Promise<TimeEntry> {
   await initTimeEntriesTable();
   const result = await pool.query(
-    `INSERT INTO time_entries (project_id, task_id, description, minutes, billable, rate_cents, entry_date)
-     VALUES ($1, $2, $3, $4, $5, $6, $7)
+    `INSERT INTO time_entries (project_id, task_id, description, minutes, billable, rate_cents, leistung_key, entry_date)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
      RETURNING
        id,
        project_id        AS "projectId",
@@ -1291,6 +1296,7 @@ export async function createTimeEntry(params: {
        minutes,
        billable,
        rate_cents        AS "rateCents",
+       leistung_key      AS "leistungKey",
        stripe_invoice_id AS "stripeInvoiceId",
        entry_date        AS "entryDate",
        created_at        AS "createdAt"`,
@@ -1301,6 +1307,7 @@ export async function createTimeEntry(params: {
       params.minutes,
       params.billable ?? true,
       params.rateCents ?? 0,
+      params.leistungKey ?? null,
       params.entryDate ?? null,
     ]
   );
@@ -1320,6 +1327,7 @@ export async function listTimeEntries(projectId: string): Promise<TimeEntry[]> {
             te.billable,
             te.rate_cents        AS "rateCents",
             te.stripe_invoice_id AS "stripeInvoiceId",
+            te.leistung_key      AS "leistungKey",
             te.entry_date        AS "entryDate",
             te.created_at        AS "createdAt"
      FROM time_entries te
@@ -1348,6 +1356,7 @@ export async function listAllTimeEntries(params?: {
             te.billable,
             te.rate_cents        AS "rateCents",
             te.stripe_invoice_id AS "stripeInvoiceId",
+            te.leistung_key      AS "leistungKey",
             te.entry_date        AS "entryDate",
             te.created_at        AS "createdAt"
      FROM time_entries te
@@ -1968,7 +1977,12 @@ export async function getBookingProjects(caldavUids: string[], brand: string): P
   return new Map(result.rows.map((r: { caldav_uid: string; project_id: string }) => [r.caldav_uid, r.project_id]));
 }
 
-export async function setBookingProject(caldavUid: string, projectId: string | null, brand: string): Promise<void> {
+export async function setBookingProject(
+  caldavUid: string,
+  projectId: string | null,
+  brand: string,
+  leistungKey?: string
+): Promise<void> {
   await initBookingProjectLinks();
   if (!projectId) {
     await pool.query(
@@ -1977,11 +1991,25 @@ export async function setBookingProject(caldavUid: string, projectId: string | n
     );
   } else {
     await pool.query(
-      `INSERT INTO booking_project_links (caldav_uid, brand, project_id) VALUES ($1, $2, $3)
-       ON CONFLICT (caldav_uid, brand) DO UPDATE SET project_id = EXCLUDED.project_id`,
-      [caldavUid, brand, projectId]
+      `INSERT INTO booking_project_links (caldav_uid, brand, project_id, leistung_key)
+       VALUES ($1, $2, $3, $4)
+       ON CONFLICT (caldav_uid, brand) DO UPDATE
+         SET project_id  = EXCLUDED.project_id,
+             leistung_key = EXCLUDED.leistung_key`,
+      [caldavUid, brand, projectId, leistungKey ?? null]
     );
   }
+}
+
+export async function getBookingLeistungen(caldavUids: string[], brand: string): Promise<Map<string, string>> {
+  if (caldavUids.length === 0) return new Map();
+  await initBookingProjectLinks();
+  const result = await pool.query(
+    `SELECT caldav_uid, leistung_key FROM booking_project_links
+     WHERE caldav_uid = ANY($1) AND brand = $2 AND leistung_key IS NOT NULL`,
+    [caldavUids, brand]
+  );
+  return new Map(result.rows.map((r: { caldav_uid: string; leistung_key: string }) => [r.caldav_uid, r.leistung_key]));
 }
 
 // ── Slot Whitelist ────────────────────────────────────────────────────────────

--- a/website/src/lib/website-db.ts
+++ b/website/src/lib/website-db.ts
@@ -1225,6 +1225,7 @@ export interface TimeEntry {
   minutes: number;
   billable: boolean;
   rateCents: number;
+  leistungKey: string | null;
   stripeInvoiceId: string | null;
   entryDate: Date;
   createdAt: Date;
@@ -1253,6 +1254,9 @@ async function initTimeEntriesTable(): Promise<void> {
   `);
   await pool.query(`
     ALTER TABLE time_entries ADD COLUMN IF NOT EXISTS stripe_invoice_id TEXT
+  `);
+  await pool.query(`
+    ALTER TABLE time_entries ADD COLUMN IF NOT EXISTS leistung_key TEXT
   `);
 }
 
@@ -1876,6 +1880,9 @@ async function initBookingProjectLinks(): Promise<void> {
       created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
       PRIMARY KEY (caldav_uid, brand)
     )
+  `);
+  await pool.query(`
+    ALTER TABLE booking_project_links ADD COLUMN IF NOT EXISTS leistung_key TEXT
   `);
   bookingProjectLinksReady = true;
 }

--- a/website/src/lib/website-db.ts
+++ b/website/src/lib/website-db.ts
@@ -541,6 +541,7 @@ export interface LeistungServiceOverride {
   unit?: string;
   desc?: string;
   highlight?: boolean;
+  stundensatz_cents?: number;
 }
 
 export interface LeistungCategoryOverride {

--- a/website/src/lib/whisper.ts
+++ b/website/src/lib/whisper.ts
@@ -25,11 +25,8 @@ export async function transcribeAudio(
   try {
     const formData = new FormData();
 
-    if (audioData instanceof Buffer) {
-      formData.append('file', new Blob([audioData]), filename);
-    } else {
-      formData.append('file', audioData, filename);
-    }
+    const blob: Blob = audioData instanceof Buffer ? new Blob([new Uint8Array(audioData)]) : audioData as Blob;
+    formData.append('file', blob, filename);
 
     formData.append('model', 'Systran/faster-whisper-medium');
     formData.append('language', language);

--- a/website/src/pages/admin/angebote.astro
+++ b/website/src/pages/admin/angebote.astro
@@ -56,6 +56,7 @@ const leistungen = mentolderConfig.leistungen.map(cat => {
         unit: so?.unit ?? svc.unit,
         desc: so?.desc ?? svc.desc,
         highlight: so?.highlight ?? svc.highlight,
+        stundensatz_cents: so?.stundensatz_cents ?? svc.stundensatz_cents ?? 0,
       };
     }),
   };
@@ -208,6 +209,18 @@ const sectionCls = 'p-6 bg-dark-light rounded-xl border border-dark-lighter spac
                         <div>
                           <label class={labelCls}>Einheit</label>
                           <input type="text" name={`lk_${cat.id}_${svc.key}_unit`} value={svc.unit} class={inputCls} />
+                        </div>
+                        <div>
+                          <label class={labelCls}>Stundensatz (€/Std.)</label>
+                          <input
+                            type="number"
+                            name={`lk_${cat.id}_${svc.key}_stundensatz`}
+                            value={Math.round(svc.stundensatz_cents / 100)}
+                            min="0"
+                            step="1"
+                            class={inputCls}
+                            placeholder="z.B. 60"
+                          />
                         </div>
                         <div class="flex items-end pb-1">
                           <label class="flex items-center gap-2 text-sm text-muted cursor-pointer">

--- a/website/src/pages/api/admin/angebote/save.ts
+++ b/website/src/pages/api/admin/angebote/save.ts
@@ -53,14 +53,19 @@ export const POST: APIRoute = async ({ request, redirect }) => {
     id: cat.id,
     title: (form.get(`lk_${cat.id}_title`) as string) || cat.title,
     icon: (form.get(`lk_${cat.id}_icon`) as string) || cat.icon,
-    services: cat.services.map(svc => ({
-      key: svc.key,
-      name: (form.get(`lk_${cat.id}_${svc.key}_name`) as string) || svc.name,
-      price: (form.get(`lk_${cat.id}_${svc.key}_price`) as string) || svc.price,
-      unit: (form.get(`lk_${cat.id}_${svc.key}_unit`) as string ?? svc.unit),
-      desc: (form.get(`lk_${cat.id}_${svc.key}_desc`) as string) || svc.desc,
-      highlight: form.get(`lk_${cat.id}_${svc.key}_highlight`) === '1',
-    })),
+    services: cat.services.map(svc => {
+      const stundensatzEuro = parseFloat((form.get(`lk_${cat.id}_${svc.key}_stundensatz`) as string) || '0');
+      const stundensatz_cents = isNaN(stundensatzEuro) ? 0 : Math.round(stundensatzEuro * 100);
+      return {
+        key: svc.key,
+        name: (form.get(`lk_${cat.id}_${svc.key}_name`) as string) || svc.name,
+        price: (form.get(`lk_${cat.id}_${svc.key}_price`) as string) || svc.price,
+        unit: (form.get(`lk_${cat.id}_${svc.key}_unit`) as string ?? svc.unit),
+        desc: (form.get(`lk_${cat.id}_${svc.key}_desc`) as string) || svc.desc,
+        highlight: form.get(`lk_${cat.id}_${svc.key}_highlight`) === '1',
+        stundensatz_cents,
+      };
+    }),
   }));
 
   const priceListUrl = (form.get('price_list_url') as string)?.trim() ?? '';

--- a/website/src/pages/api/admin/angebote/save.ts
+++ b/website/src/pages/api/admin/angebote/save.ts
@@ -63,7 +63,7 @@ export const POST: APIRoute = async ({ request, redirect }) => {
         unit: (form.get(`lk_${cat.id}_${svc.key}_unit`) as string ?? svc.unit),
         desc: (form.get(`lk_${cat.id}_${svc.key}_desc`) as string) || svc.desc,
         highlight: form.get(`lk_${cat.id}_${svc.key}_highlight`) === '1',
-        stundensatz_cents,
+        ...(stundensatz_cents > 0 ? { stundensatz_cents } : {}),
       };
     }),
   }));

--- a/website/src/pages/api/admin/rooms/direct.ts
+++ b/website/src/pages/api/admin/rooms/direct.ts
@@ -1,0 +1,14 @@
+import type { APIRoute } from 'astro';
+import { getSession, isAdmin } from '../../../../lib/auth';
+import { getCustomerById, ensureDirectRoomForCustomer } from '../../../../lib/messaging-db';
+
+export const POST: APIRoute = async ({ request }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 });
+  const { customerId } = await request.json() as { customerId: string };
+  if (!customerId?.trim()) return new Response(JSON.stringify({ error: 'customerId required' }), { status: 400 });
+  const customer = await getCustomerById(customerId);
+  if (!customer) return new Response(JSON.stringify({ error: 'Customer not found' }), { status: 404 });
+  const result = await ensureDirectRoomForCustomer(customer.id, customer.name, session.sub);
+  return new Response(JSON.stringify(result), { headers: { 'Content-Type': 'application/json' } });
+};

--- a/website/src/pages/api/portal/rooms/ensure-direct.ts
+++ b/website/src/pages/api/portal/rooms/ensure-direct.ts
@@ -1,0 +1,12 @@
+import type { APIRoute } from 'astro';
+import { getSession } from '../../../../lib/auth';
+import { getCustomerByEmail, ensureDirectRoomForCustomer } from '../../../../lib/messaging-db';
+
+export const POST: APIRoute = async ({ request }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session) return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 });
+  const customer = await getCustomerByEmail(session.email);
+  if (!customer) return new Response(JSON.stringify({ error: 'Customer not found' }), { status: 403 });
+  const result = await ensureDirectRoomForCustomer(customer.id, customer.name, 'system');
+  return new Response(JSON.stringify(result), { headers: { 'Content-Type': 'application/json' } });
+};


### PR DESCRIPTION
## Summary

- Admin kann im Chat-Widget über einen ＋-Button direkte 1:1-Chats mit beliebigen Kunden starten (Kundenpicker-Overlay mit Suche)
- User öffnet das Widget und landet automatisch in ihrem persönlichen Direktchat mit dem Admin ("Chat mit Admin")
- DB-Schema: neue Spalten `is_direct` + `direct_customer_id` in `chat_rooms` (inkl. `ALTER TABLE IF EXISTS` für laufende DBs)
- Zwei neue API-Endpunkte: `POST /api/portal/rooms/ensure-direct` (User) und `POST /api/admin/rooms/direct` (Admin)

## Test plan

- [ ] User einloggen → Widget öffnen → Direktraum wird automatisch angelegt, Header zeigt "Chat mit Admin"
- [ ] Admin einloggen → Widget öffnen → Sidebar zeigt nur Direktchats, ＋-Button öffnet Kundenpicker
- [ ] Admin wählt Kunde → Chat wird erstellt/geöffnet, Name "Chat mit [Kundenname]" erscheint
- [ ] Zweiter Klick auf denselben Kunden → kein Duplikat, bestehender Chat wird geöffnet
- [ ] DB-Migration: `ALTER TABLE IF EXISTS` läuft idempotent auf bestehenden Deployments

🤖 Generated with [Claude Code](https://claude.com/claude-code)