### PR TITLE
fix: complete website security and UX audit — all 25 bug reports resolved

### DIFF
--- a/website/src/components/BookingForm.svelte
+++ b/website/src/components/BookingForm.svelte
@@ -127,7 +127,7 @@
           message,
           slotStart: selectedSlot?.start ?? null,
           slotEnd: selectedSlot?.end ?? null,
-          slotDisplay: selectedSlot?.display ?? null,
+          slotDisplay: selectedSlot ? formatSlotTime(selectedSlot.start, selectedSlot.end) : null,
           date: selectedDate,
           serviceKey: serviceKey ?? null,
           projectId: selectedProjectId || undefined,
@@ -154,6 +154,15 @@
     } finally {
       submitting = false;
     }
+  }
+
+  // Format ISO timestamp in user's local timezone so slot times are correct
+  // regardless of server timezone (server runs UTC, users may be in CEST etc.)
+  function formatSlotTime(isoStart: string, isoEnd: string): string {
+    const fmt = (iso: string) => new Date(iso).toLocaleTimeString('de-DE', {
+      hour: '2-digit', minute: '2-digit', timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+    });
+    return `${fmt(isoStart)} - ${fmt(isoEnd)}`;
   }
 
 </script>
@@ -220,7 +229,7 @@
                 : 'border-dark-lighter bg-dark hover:border-gold/30 text-muted hover:text-light'}"
               onclick={() => selectSlot(slot)}
             >
-              {slot.display}
+              {formatSlotTime(slot.start, slot.end)}
             </button>
           {/each}
         </div>
@@ -228,7 +237,7 @@
 
       {#if selectedSlot}
         <p class="mt-4 text-gold font-medium" data-testid="selected-slot-display">
-          Gewählt: {currentDaySlots?.weekday}, {formatDate(selectedDate)} um {selectedSlot.display}
+          Gewählt: {currentDaySlots?.weekday}, {formatDate(selectedDate)} um {formatSlotTime(selectedSlot.start, selectedSlot.end)}
         </p>
       {/if}
     {/if}

--- a/website/src/components/SessionExpiryWarning.svelte
+++ b/website/src/components/SessionExpiryWarning.svelte
@@ -1,0 +1,73 @@
+<script lang="ts">
+  import { onDestroy } from 'svelte';
+
+  const WARN_BEFORE_MS = 10 * 60 * 1000; // show warning 10 min before expiry
+  const CHECK_INTERVAL_MS = 60 * 1000;   // check every minute
+
+  let showWarning = $state(false);
+  let minutesLeft = $state(0);
+
+  async function checkExpiry() {
+    try {
+      const res = await fetch('/api/auth/me');
+      if (!res.ok) return;
+      const data = await res.json() as { authenticated: boolean; expiresAt?: number };
+      if (!data.authenticated || !data.expiresAt) return;
+
+      const msLeft = data.expiresAt - Date.now();
+      if (msLeft > 0 && msLeft <= WARN_BEFORE_MS) {
+        minutesLeft = Math.ceil(msLeft / 60_000);
+        showWarning = true;
+      } else {
+        showWarning = false;
+      }
+    } catch {
+      // network error — don't show warning
+    }
+  }
+
+  checkExpiry();
+  const interval = setInterval(checkExpiry, CHECK_INTERVAL_MS);
+  onDestroy(() => clearInterval(interval));
+</script>
+
+{#if showWarning}
+  <div class="session-warning" role="alert">
+    <span>⚠ Sitzung läuft in {minutesLeft} Min. ab.</span>
+    <a href="/api/auth/login">Jetzt verlängern</a>
+    <button onclick={() => showWarning = false} aria-label="Schließen">✕</button>
+  </div>
+{/if}
+
+<style>
+  .session-warning {
+    position: fixed;
+    bottom: 80px;
+    right: 24px;
+    z-index: 8999;
+    background: #92400e;
+    color: #fef3c7;
+    border: 1px solid #d97706;
+    border-radius: 8px;
+    padding: 10px 14px;
+    font-size: 13px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    box-shadow: 0 4px 16px rgba(0,0,0,.4);
+  }
+  .session-warning a {
+    color: #fcd34d;
+    text-decoration: underline;
+    white-space: nowrap;
+  }
+  .session-warning button {
+    background: transparent;
+    border: none;
+    color: #fef3c7;
+    cursor: pointer;
+    font-size: 13px;
+    padding: 0;
+    line-height: 1;
+  }
+</style>

--- a/website/src/layouts/AdminLayout.astro
+++ b/website/src/layouts/AdminLayout.astro
@@ -3,6 +3,7 @@ import '../styles/global.css';
 import { config } from '../config/index';
 import BugReportWidget from '../components/BugReportWidget.svelte';
 import ChatWidget from '../components/ChatWidget.svelte';
+import SessionExpiryWarning from '../components/SessionExpiryWarning.svelte';
 
 interface Props {
   title: string;
@@ -264,6 +265,7 @@ const brandWord = config.meta.siteTitle.replace(/\.de$/i, '').toLowerCase();
 
     <BugReportWidget client:load />
     <ChatWidget client:load />
+    <SessionExpiryWarning client:load />
 
     <script is:inline>
       (function() {

--- a/website/src/layouts/PortalLayout.astro
+++ b/website/src/layouts/PortalLayout.astro
@@ -4,6 +4,7 @@ import { config } from '../config/index';
 import { isAdmin } from '../lib/auth';
 import type { UserSession } from '../lib/auth';
 import ChatWidget from '../components/ChatWidget.svelte';
+import SessionExpiryWarning from '../components/SessionExpiryWarning.svelte';
 
 interface Props {
   title: string;
@@ -239,5 +240,6 @@ const userIsAdmin   = isAdmin(session);
     </main>
 
     <ChatWidget client:load />
+    <SessionExpiryWarning client:load />
   </body>
 </html>

--- a/website/src/lib/rate-limit.ts
+++ b/website/src/lib/rate-limit.ts
@@ -1,0 +1,46 @@
+// Simple in-memory IP-based rate limiter.
+// Not persistent across pod restarts, but prevents basic spam/DoS on public endpoints.
+
+interface Bucket {
+  count: number;
+  resetAt: number;
+}
+
+const store = new Map<string, Bucket>();
+const CLEANUP_INTERVAL_MS = 60_000;
+
+// Periodically remove expired buckets to prevent unbounded memory growth.
+setInterval(() => {
+  const now = Date.now();
+  for (const [key, bucket] of store) {
+    if (bucket.resetAt <= now) store.delete(key);
+  }
+}, CLEANUP_INTERVAL_MS);
+
+/**
+ * Returns true if the request should be allowed through, false if rate-limited.
+ * @param key     Unique key (e.g. `ip:endpoint`)
+ * @param limit   Max requests per window
+ * @param windowMs  Window size in milliseconds
+ */
+export function checkRateLimit(key: string, limit: number, windowMs: number): boolean {
+  const now = Date.now();
+  const bucket = store.get(key);
+
+  if (!bucket || bucket.resetAt <= now) {
+    store.set(key, { count: 1, resetAt: now + windowMs });
+    return true;
+  }
+
+  if (bucket.count >= limit) return false;
+  bucket.count++;
+  return true;
+}
+
+export function getClientIp(request: Request): string {
+  return (
+    request.headers.get('x-forwarded-for')?.split(',')[0].trim() ??
+    request.headers.get('x-real-ip') ??
+    'unknown'
+  );
+}

--- a/website/src/lib/website-db.ts
+++ b/website/src/lib/website-db.ts
@@ -2072,6 +2072,17 @@ export async function isSlotWhitelisted(brand: string, start: Date): Promise<boo
   return (result.rowCount ?? 0) > 0;
 }
 
+// Atomically removes the slot from the whitelist and returns true if it was
+// available (i.e. not already claimed by another concurrent booking).
+export async function claimSlot(brand: string, start: Date): Promise<boolean> {
+  await initSlotWhitelistTable();
+  const result = await pool.query(
+    'DELETE FROM slot_whitelist WHERE brand = $1 AND slot_start = $2::timestamptz RETURNING 1',
+    [brand, start]
+  );
+  return (result.rowCount ?? 0) > 0;
+}
+
 export async function listBugTickets(filters: {
   status?: string;
   category?: string;
@@ -2271,4 +2282,34 @@ export async function createAdminShortcut(url: string, label: string): Promise<A
 export async function deleteAdminShortcut(id: string): Promise<void> {
   await initAdminShortcutsTable();
   await pool.query('DELETE FROM admin_shortcuts WHERE id = $1', [id]);
+}
+
+// ── DSGVO Audit Log ──────────────────────────────────────────────────────────
+
+async function initDsgvoAuditTable(): Promise<void> {
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS dsgvo_audit_log (
+      id         BIGSERIAL PRIMARY KEY,
+      type       TEXT        NOT NULL,
+      name       TEXT        NOT NULL,
+      email      TEXT        NOT NULL,
+      ip_address TEXT,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      deadline   TIMESTAMPTZ NOT NULL GENERATED ALWAYS AS (created_at + INTERVAL '30 days') STORED
+    )
+  `);
+}
+
+export async function insertDsgvoRequest(params: {
+  type: string;
+  name: string;
+  email: string;
+  ipAddress?: string;
+}): Promise<void> {
+  await initDsgvoAuditTable();
+  await pool.query(
+    `INSERT INTO dsgvo_audit_log (type, name, email, ip_address)
+     VALUES ($1, $2, $3, $4)`,
+    [params.type, params.name, params.email, params.ipAddress ?? null]
+  );
 }

--- a/website/src/pages/api/admin/billing/create-monthly-invoices.ts
+++ b/website/src/pages/api/admin/billing/create-monthly-invoices.ts
@@ -13,6 +13,9 @@ export const POST: APIRoute = async ({ request }) => {
   const isAdminUser = !!session && isAdmin(session);
   if (!isCron && !isAdminUser) return new Response(null, { status: 403 });
 
+  const url    = new URL(request.url);
+  const dryRun = url.searchParams.get('dryRun') === 'true';
+
   const body  = await request.json().catch(() => ({}));
   const now   = new Date();
   const year  = body.year  ?? (now.getMonth() === 0 ? now.getFullYear() - 1 : now.getFullYear());
@@ -24,18 +27,39 @@ export const POST: APIRoute = async ({ request }) => {
 
   const groups = await getUnbilledBillableEntriesByCustomer(year, month);
   if (groups.length === 0) {
-    return Response.json({ created: 0, message: 'Keine abrechenbaren Einträge gefunden.' });
+    return Response.json({ created: 0, dryRun, message: 'Keine abrechenbaren Einträge gefunden.' });
   }
 
-  const invoiceMap = await createMonthlyDraftInvoices(groups, monthLabel);
+  if (dryRun) {
+    const preview = groups.map(g => ({
+      customerName: g.customerName,
+      customerEmail: g.customerEmail,
+      entryCount: g.entries.length,
+      totalMinutes: g.entries.reduce((s, e) => s + e.minutes, 0),
+    }));
+    return Response.json({ dryRun: true, wouldCreate: groups.length, period: monthLabel, preview });
+  }
+
+  // Create invoices and immediately mark each customer's time entries to prevent
+  // duplicate invoices if the endpoint is called again before all entries are marked.
+  let created = 0;
+  let skipped = 0;
 
   for (const group of groups) {
-    const invoiceId = invoiceMap.get(group.customerId);
-    if (invoiceId) {
-      await setTimeEntryStripeInvoice(group.entries.map(e => e.id), invoiceId);
+    try {
+      const invoiceMap = await createMonthlyDraftInvoices([group], monthLabel);
+      const invoiceId = invoiceMap.get(group.customerId);
+      if (invoiceId) {
+        await setTimeEntryStripeInvoice(group.entries.map(e => e.id), invoiceId);
+        created++;
+      } else {
+        skipped++;
+      }
+    } catch (err) {
+      console.error(`[billing] Failed for customer ${group.customerId}:`, err);
+      skipped++;
     }
   }
 
-  const skipped = groups.length - invoiceMap.size;
-  return Response.json({ created: invoiceMap.size, skipped, period: monthLabel });
+  return Response.json({ created, skipped, period: monthLabel });
 };

--- a/website/src/pages/api/admin/inbox/[id]/action.ts
+++ b/website/src/pages/api/admin/inbox/[id]/action.ts
@@ -43,12 +43,30 @@ export const POST: APIRoute = async ({ request, params }) => {
         const fullName = `${p.firstName} ${p.lastName}`;
 
         const result = await createUser({ email: p.email, firstName: p.firstName, lastName: p.lastName, phone: p.phone, company: p.company });
-        if (!result.success || !result.userId) {
+
+        let userId = result.userId;
+
+        // If user already exists (e.g. partial failure on prior attempt), look up the existing user
+        // so we can still send the password reset and complete the approval.
+        if (!result.success && result.error?.includes('bereits')) {
+          const { listUsers } = await import('../../../../../lib/keycloak');
+          const allUsers = await listUsers();
+          const existing = allUsers.find(u => u.email?.toLowerCase() === p.email.toLowerCase());
+          if (existing) {
+            userId = existing.id;
+          } else {
+            return new Response(JSON.stringify({ error: `Keycloak-Fehler: ${result.error}` }), { status: 500 });
+          }
+        } else if (!result.success || !userId) {
           return new Response(JSON.stringify({ error: `Keycloak-Fehler: ${result.error}` }), { status: 500 });
         }
-        await sendPasswordResetEmail(result.userId);
-        await sendRegistrationApproved(p.email, fullName);
-        await upsertCustomer({ name: fullName, email: p.email, phone: p.phone, company: p.company, keycloakUserId: result.userId });
+
+        await sendPasswordResetEmail(userId);
+        // Emails are best-effort — upsertCustomer and inbox update must still succeed
+        sendRegistrationApproved(p.email, fullName).catch(err =>
+          console.error('[approve_registration] Failed to send approval email:', err)
+        );
+        await upsertCustomer({ name: fullName, email: p.email, phone: p.phone, company: p.company, keycloakUserId: userId });
         await updateInboxItemStatus(id, 'actioned', session.preferred_username);
         return new Response(JSON.stringify({ success: true, message: `${fullName} freigeschaltet` }), {
           headers: { 'Content-Type': 'application/json' },

--- a/website/src/pages/api/auth/me.ts
+++ b/website/src/pages/api/auth/me.ts
@@ -16,6 +16,7 @@ export const GET: APIRoute = async ({ request }) => {
   return new Response(
     JSON.stringify({
       authenticated: true,
+      expiresAt: session.expires_at,
       user: {
         name: session.name,
         email: session.email,

--- a/website/src/pages/api/booking.ts
+++ b/website/src/pages/api/booking.ts
@@ -1,7 +1,8 @@
 import type { APIRoute } from 'astro';
 import { createInboxItem } from '../../lib/messaging-db';
 import { sendEmail } from '../../lib/email';
-import { isSlotWhitelisted } from '../../lib/website-db';
+import { claimSlot } from '../../lib/website-db';
+import { checkRateLimit, getClientIp } from '../../lib/rate-limit';
 
 const BRAND_NAME = process.env.BRAND_NAME || 'Workspace';
 const CONTACT_EMAIL = process.env.CONTACT_EMAIL || '';
@@ -14,6 +15,12 @@ const TYPE_LABELS: Record<string, string> = {
 };
 
 export const POST: APIRoute = async ({ request }) => {
+  const ip = getClientIp(request);
+  if (!checkRateLimit(`booking:${ip}`, 5, 60_000)) {
+    return new Response(JSON.stringify({ error: 'Zu viele Anfragen. Bitte warten Sie einen Moment.' }), {
+      status: 429, headers: { 'Content-Type': 'application/json' },
+    });
+  }
   try {
     const { name, email, phone, type, message, slotStart, slotEnd, slotDisplay, date, serviceKey, projectId, leistungKey } = await request.json();
 
@@ -32,13 +39,14 @@ export const POST: APIRoute = async ({ request }) => {
       );
     }
 
-    // Whitelist check: slot must be explicitly released by admin
+    // Atomically claim the slot: removes it from whitelist in one DB operation.
+    // Prevents race conditions where two users book the same slot simultaneously.
     if (!isCallback && slotStart) {
-      const whitelisted = await isSlotWhitelisted(BRAND_NAME, new Date(slotStart));
-      if (!whitelisted) {
+      const claimed = await claimSlot(BRAND_NAME, new Date(slotStart));
+      if (!claimed) {
         return new Response(
           JSON.stringify({ error: 'Dieser Termin ist leider nicht mehr verfügbar.' }),
-          { status: 400, headers: { 'Content-Type': 'application/json' } }
+          { status: 409, headers: { 'Content-Type': 'application/json' } }
         );
       }
     }

--- a/website/src/pages/api/bug-report.ts
+++ b/website/src/pages/api/bug-report.ts
@@ -1,6 +1,7 @@
 import type { APIRoute } from 'astro';
 import { insertBugTicket } from '../../lib/website-db';
 import { createInboxItem } from '../../lib/messaging-db';
+import { checkRateLimit, getClientIp } from '../../lib/rate-limit';
 
 const MAX_BYTES = 5 * 1024 * 1024;
 const ALLOWED_MIME = new Set(['image/png', 'image/jpeg', 'image/webp']);
@@ -27,6 +28,10 @@ function generateTicketId(): string {
 }
 
 export const POST: APIRoute = async ({ request }) => {
+  const ip = getClientIp(request);
+  if (!checkRateLimit(`bug-report:${ip}`, 10, 60_000)) {
+    return jsonError('Zu viele Anfragen. Bitte warten Sie einen Moment.', 429);
+  }
   try {
     const formData = await request.formData();
 

--- a/website/src/pages/api/contact.ts
+++ b/website/src/pages/api/contact.ts
@@ -1,6 +1,7 @@
 import type { APIRoute } from 'astro';
 import { createInboxItem } from '../../lib/messaging-db';
 import { sendEmail } from '../../lib/email';
+import { checkRateLimit, getClientIp } from '../../lib/rate-limit';
 
 const CONTACT_EMAIL = process.env.CONTACT_EMAIL || '';
 const BRAND_NAME = process.env.BRAND_NAME || 'Workspace';
@@ -16,6 +17,12 @@ const TYPE_LABELS: Record<string, string> = {
 };
 
 export const POST: APIRoute = async ({ request }) => {
+  const ip = getClientIp(request);
+  if (!checkRateLimit(`contact:${ip}`, 5, 60_000)) {
+    return new Response(JSON.stringify({ error: 'Zu viele Anfragen. Bitte warten Sie einen Moment.' }), {
+      status: 429, headers: { 'Content-Type': 'application/json' },
+    });
+  }
   try {
     const body = await request.json();
     const { name, email, phone, type, message } = body;

--- a/website/src/pages/api/dsgvo-request.ts
+++ b/website/src/pages/api/dsgvo-request.ts
@@ -1,10 +1,20 @@
 import type { APIRoute } from 'astro';
 import { sendEmail } from '../../lib/email';
+import { insertDsgvoRequest } from '../../lib/website-db';
+import { checkRateLimit, getClientIp } from '../../lib/rate-limit';
 
 const CONTACT_EMAIL = process.env.CONTACT_EMAIL || '';
+const BRAND_NAME = process.env.BRAND_NAME || 'Workspace';
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 export const POST: APIRoute = async ({ request }) => {
+  const ip = getClientIp(request);
+  if (!checkRateLimit(`dsgvo:${ip}`, 3, 3_600_000)) {
+    return new Response(JSON.stringify({ error: 'Zu viele Anfragen. Bitte warten Sie eine Stunde.' }), {
+      status: 429, headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
   try {
     const { type, name, email } = await request.json();
 
@@ -24,20 +34,31 @@ export const POST: APIRoute = async ({ request }) => {
       });
     }
 
-    const subject = type === 'auskunft'
-      ? 'DSGVO-Auskunftsanfrage'
-      : 'DSGVO-Löschungsanfrage';
+    const articleNum = type === 'auskunft' ? '15' : '17';
+    const subject = type === 'auskunft' ? 'DSGVO-Auskunftsanfrage' : 'DSGVO-Löschungsanfrage';
+    const deadline = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toLocaleDateString('de-DE');
 
-    const text = `${subject}\n\nName: ${name}\nE-Mail: ${email}\n\nBitte bearbeiten Sie diese Anfrage innerhalb von 30 Tagen gemäß Art. ${type === 'auskunft' ? '15' : '17'} DSGVO.`;
+    // 1. Audit-Log in DB (Pflicht für Nachweispflicht nach DSGVO)
+    await insertDsgvoRequest({ type, name, email, ipAddress: ip });
 
-    if (!CONTACT_EMAIL) {
-      console.warn('[dsgvo-request] CONTACT_EMAIL not set, email not sent');
-      return new Response(JSON.stringify({ success: true }), {
-        status: 200, headers: { 'Content-Type': 'application/json' },
-      });
+    // 2. Bestätigungs-E-Mail an Antragsteller (Art. 12 DSGVO)
+    sendEmail({
+      to: email,
+      subject: `Ihre ${subject} bei ${BRAND_NAME}`,
+      text: `Hallo ${name},\n\nwir haben Ihre ${subject} erhalten und werden diese innerhalb von 30 Tagen bearbeiten.\n\nFristdatum: ${deadline}\nRechtsgrundlage: Art. ${articleNum} DSGVO\n\nMit freundlichen Grüßen\n${BRAND_NAME}`,
+    }).catch(err => console.error('[dsgvo-request] Failed to send confirmation email:', err));
+
+    // 3. Admin-Benachrichtigung (best-effort)
+    if (CONTACT_EMAIL) {
+      sendEmail({
+        to: CONTACT_EMAIL,
+        subject: `[DSGVO] ${subject} von ${name}`,
+        text: `${subject}\n\nName: ${name}\nE-Mail: ${email}\nEingegangen: ${new Date().toLocaleString('de-DE')}\nFrist: ${deadline}\n\nBitte bearbeiten Sie diese Anfrage innerhalb von 30 Tagen gemäß Art. ${articleNum} DSGVO.`,
+        replyTo: email,
+      }).catch(err => console.error('[dsgvo-request] Failed to send admin notification:', err));
+    } else {
+      console.warn('[dsgvo-request] CONTACT_EMAIL not set — admin notification skipped');
     }
-
-    await sendEmail({ to: CONTACT_EMAIL, subject, text, replyTo: email });
 
     return new Response(JSON.stringify({ success: true }), {
       status: 200, headers: { 'Content-Type': 'application/json' },

--- a/website/src/pages/api/meeting/finalize.ts
+++ b/website/src/pages/api/meeting/finalize.ts
@@ -4,7 +4,7 @@ import { transcribeAudio, formatTranscript } from '../../../lib/whisper';
 import { getWhiteboardArtifacts, extractWhiteboardText } from '../../../lib/whiteboard';
 import {
   upsertCustomer, createMeeting, updateMeetingStatus,
-  saveTranscript, saveArtifact, saveInsight,
+  saveTranscript, saveArtifact, saveInsight, getMeetingByRoomToken,
 } from '../../../lib/website-db';
 import { generateMeetingInsights } from '../../../lib/claude';
 
@@ -37,6 +37,17 @@ export const POST: APIRoute = async ({ request }) => {
         JSON.stringify({ error: 'customerName and customerEmail required' }),
         { status: 400, headers: { 'Content-Type': 'application/json' } }
       );
+    }
+
+    // ── 0. Idempotency check: if this room token was already finalized, return early ──
+    if (roomToken) {
+      const existing = await getMeetingByRoomToken(roomToken);
+      if (existing && existing.status === 'finalized') {
+        return new Response(
+          JSON.stringify({ success: true, results: ['Meeting bereits finalisiert (idempotent).'], alreadyFinalized: true }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        );
+      }
     }
 
     // ── 1. Upsert customer in meetings DB ──────────────────────────

--- a/website/src/pages/api/register.ts
+++ b/website/src/pages/api/register.ts
@@ -1,8 +1,15 @@
 import type { APIRoute } from 'astro';
 import { createInboxItem } from '../../lib/messaging-db';
 import { sendRegistrationConfirmation } from '../../lib/email';
+import { checkRateLimit, getClientIp } from '../../lib/rate-limit';
 
 export const POST: APIRoute = async ({ request }) => {
+  const ip = getClientIp(request);
+  if (!checkRateLimit(`register:${ip}`, 5, 60_000)) {
+    return new Response(JSON.stringify({ error: 'Zu viele Anfragen. Bitte warten Sie einen Moment.' }), {
+      status: 429, headers: { 'Content-Type': 'application/json' },
+    });
+  }
   try {
     const { firstName, lastName, email, phone, company, message } = await request.json();
 


### PR DESCRIPTION
## Summary

Completes the systematic website process audit started in PR #185. All 25 bug reports (BR-20260419-0001 through BR-20260419-0025) are now resolved.

**Rate Limiting (BR-0001)**
- New `rate-limit.ts`: in-memory token bucket per IP with automatic cleanup
- Applied to all public endpoints: register (5/min), contact (5/min), booking (5/min), bug-report (10/min), dsgvo-request (3/h)

**Slot Race Condition (BR-0013)**
- `claimSlot()` in website-db.ts: atomic `DELETE...RETURNING` replaces the non-atomic `isSlotWhitelisted()` check
- Concurrent bookings now correctly get 409 instead of both succeeding

**DSGVO Compliance (BR-0014, BR-0018)**
- New `dsgvo_audit_log` table with `GENERATED ALWAYS deadline` column for 30-day frist tracking
- `insertDsgvoRequest()` writes audit log before any email dispatch
- Confirmation email sent to requester (Art. 12 DSGVO); admin notification decoupled as fire-and-forget

**Monthly Billing Idempotency (BR-0010, BR-0011, BR-0024)**
- Invoice creation and `setTimeEntryStripeInvoice()` now interleaved per customer — one failure no longer prevents other customers from being processed
- `?dryRun=true` returns a preview without creating any invoices

**Meeting Finalization Idempotency (BR-0023)**
- `getMeetingByRoomToken()` idempotency check: if roomToken already finalized, returns 200 with `alreadyFinalized: true`

**Booking Approval Partial-Failure Recovery (BR-0012)**
- If `createUser()` fails with "already exists" (retry after prior partial failure), looks up existing Keycloak user by email and continues with password reset
- `sendRegistrationApproved()` decoupled as fire-and-forget

**Session Expiry Warning (BR-0025)**
- New `SessionExpiryWarning.svelte`: polls `/api/auth/me` every minute, shows banner 10 min before expiry with re-login link
- `/api/auth/me` now includes `expiresAt` timestamp
- Integrated into `PortalLayout` and `AdminLayout`

**Timezone Fix (BR-0019)**
- `formatSlotTime()` in BookingForm.svelte uses `Intl.DateTimeFormat().resolvedOptions().timeZone` to display slot times in user's browser timezone instead of server UTC

## Test plan

- [ ] Submit registration form 6× rapidly from same IP → 6th gets 429
- [ ] Two browser tabs: both fetch same slot, both try to book → one gets 409
- [ ] Submit DSGVO request → check `dsgvo_audit_log` table has entry + confirmation email arrives
- [ ] POST billing endpoint with `?dryRun=true` → verify no invoices created, preview returned
- [ ] Trigger finalize twice with same roomToken → second call returns `alreadyFinalized: true`
- [ ] Approve registration twice (simulate retry) → second attempt recovers and sends password reset
- [ ] Wait near session expiry → confirm warning banner appears 10 min before
- [ ] Browser in different timezone → slot times display in local time

🤖 Generated with [Claude Code](https://claude.com/claude-code)