### PR TITLE
docs: update handbooks to reflect current architecture

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -1,20 +1,20 @@
 - [Home](/)
 - **Für Mitarbeiter**
 - [Benutzerhandbuch](benutzerhandbuch.md)
-- [Testanleitung](test-anleitung-korczewski.md)
 - **Für Administratoren**
+- [Administrator-Handbuch](adminhandbuch.md)
 - [Architektur](architecture.md)
-- [Datenbankmodelle](database.md)
 - [Services](services.md)
 - [Keycloak & SSO](keycloak.md)
+- [Datenbankmodelle](database.md)
+- [Sicherheit](security.md)
+- [Verarbeitungsverzeichnis (Art. 30)](verarbeitungsverzeichnis.md)
+- [Stripe-Integration](stripe.md)
+- [Projektmanagement-Admin](admin-projekte.md)
+- [MCP Actions](mcp-actions.md)
+- **Entwicklung & Betrieb**
 - [Migration](migration.md)
 - [Skripte](scripts.md)
 - [Tests](tests.md)
-- [Sicherheit](security.md)
-- [Verarbeitungsverzeichnis (Art. 30)](verarbeitungsverzeichnis.md)
 - [Fehlerbehebung](troubleshooting.md)
 - [Anforderungen](requirements.md)
-- [MCP Actions](mcp-actions.md)
-- **Website & Admin**
-- [Stripe-Integration](stripe.md)
-- [Projektmanagement-Admin](admin-projekte.md)

--- a/docs/adminhandbuch.md
+++ b/docs/adminhandbuch.md
@@ -1,0 +1,257 @@
+<div class="page-hero">
+  <span class="page-hero-icon">🛠️</span>
+  <div class="page-hero-body">
+    <div class="page-hero-title">Administrator-Handbuch</div>
+    <p class="page-hero-desc">Einrichtung, Betrieb und Verwaltung des Workspace – für Administratoren ohne Kubernetes-Vorkenntnisse.</p>
+    <div class="page-hero-meta">
+      <span class="page-hero-tag">Für Administratoren</span>
+      <span class="page-hero-tag">Betrieb</span>
+    </div>
+  </div>
+  <a href="#/" class="page-hero-back">← Übersicht</a>
+</div>
+
+# Administrator-Handbuch – Workspace
+
+Dieses Handbuch beschreibt die wichtigsten Administrationsaufgaben: Benutzer anlegen, Dienste überwachen, Backups verwalten und häufige Probleme beheben. Für tiefgehende technische Details zu Kubernetes-Manifesten und Architektur: [Architektur](architecture.md) und [Services](services.md).
+
+---
+
+## Dienstübersicht mit Admin-Links
+
+| Dienst | Funktion | Dev-URL | Admin-Zugang |
+|--------|----------|---------|--------------|
+| **Keycloak** | Benutzerverwaltung & SSO | [auth.localhost](http://auth.localhost) | [auth.localhost/admin](http://auth.localhost/admin) |
+| **Nextcloud** | Dateien, Kalender, Talk | [files.localhost](http://files.localhost) | [files.localhost/settings/admin](http://files.localhost/settings/admin) |
+| **Collabora** | Office-Editor (in NC eingebettet) | [office.localhost](http://office.localhost) | Konfiguration via Nextcloud |
+| **Whiteboard** | Digitales Whiteboard | [board.localhost](http://board.localhost) | — |
+| **Vaultwarden** | Passwort-Safe | [vault.localhost](http://vault.localhost) | [vault.localhost/admin](http://vault.localhost/admin) |
+| **Website / Portal** | Unternehmenswebsite + Messaging | [web.localhost](http://web.localhost) | [web.localhost/admin](http://web.localhost/admin) |
+| **Dokumentation** | Dieses Handbuch | [docs.localhost](http://docs.localhost) | SSO-geschützt (Keycloak) |
+| **Mailpit** | Ausgehende E-Mails (Dev) | [mail.localhost](http://mail.localhost) | Direktzugang (keine Auth) |
+| **Claude Code KI** | KI-Status & MCP-Dashboard | [ai.localhost](http://ai.localhost) | MCP-Status-Dashboard |
+
+> **Produktion:** Ersetze `localhost` durch Deine konfigurierte Domain (z. B. `auth.meinunternehmen.de`). Die Domain wird in `.env` als `PROD_DOMAIN` gesetzt.
+
+---
+
+## Benutzer verwalten (Keycloak)
+
+Alle Benutzerkonten werden zentral in Keycloak gepflegt. Jede Änderung gilt sofort für alle Dienste (SSO).
+
+### Neuen Benutzer anlegen
+
+1. Öffne [auth.localhost/admin](http://auth.localhost/admin) → Realm **workspace**
+2. Navigiere zu **Benutzer** → **Benutzer hinzufügen**
+3. Felder ausfüllen:
+   - **Benutzername**: Kleinbuchstaben, kein Leerzeichen
+   - **E-Mail**: Pflichtfeld für Benachrichtigungen
+   - **Vorname / Nachname**
+4. Reiter **Zugangsdaten** → Temporäres Passwort vergeben (Benutzer muss es beim ersten Login ändern)
+5. Reiter **Gruppen** → Benutzer der passenden Gruppe zuweisen:
+   - `workspace-users` – normaler Mitarbeiter-Zugang
+   - `workspace-admins` – Administratorzugang (Website-Admin-Panel, erweiterte Rechte)
+
+### Passwort zurücksetzen
+
+1. Keycloak Admin → **Benutzer** → Benutzer auswählen
+2. Reiter **Zugangsdaten** → **Passwort zurücksetzen**
+3. Temporäres Passwort eingeben → **Temporär: Ja** → Speichern
+
+Der Benutzer wird beim nächsten Login aufgefordert, ein neues Passwort zu setzen.
+
+### Benutzer deaktivieren
+
+1. Keycloak Admin → **Benutzer** → Benutzer auswählen
+2. Reiter **Details** → **Aktiviert**: Schalter ausschalten → Speichern
+
+Der Benutzer kann sich sofort nicht mehr anmelden. Daten bleiben erhalten.
+
+---
+
+## Website-Admin-Panel
+
+Das Admin-Panel ist erreichbar unter [web.localhost/admin](http://web.localhost/admin) (Keycloak-Login mit `workspace-admins`-Gruppe erforderlich).
+
+### Verfügbare Admin-Bereiche
+
+| Bereich | Pfad | Funktion |
+|---------|------|----------|
+| **Startseite** | `/admin/startseite` | Startseiten-Texte und Hero-Bereich bearbeiten |
+| **Leistungen** | `/admin/angebote` | Dienstleistungen und Preise verwalten |
+| **Über mich** | `/admin/uebermich` | Profilseite bearbeiten |
+| **Referenzen** | `/admin/referenzen` | Kundenstimmen und Referenzen |
+| **FAQ** | `/admin/faq` | Häufig gestellte Fragen pflegen |
+| **Rechtliches** | `/admin/rechtliches` | Impressum, Datenschutz, AGB |
+| **Inbox** | `/admin/inbox` | Eingehende Kontaktanfragen |
+| **Nachrichten** | `/admin/nachrichten` | Direkte Nachrichten und Chat-Räume |
+| **Räume** | `/admin/raeume` | Chat-Räume verwalten |
+| **Kunden** | `/admin/clients` | Kundenverwaltung |
+| **Projekte** | `/admin/projekte` | Projektmanagement mit Gantt-Diagramm |
+| **Termine** | `/admin/termine` | Terminbuchungen und Kalender |
+| **Zeiterfassung** | `/admin/zeiterfassung` | Arbeitszeiterfassung |
+| **Rechnungen** | `/admin/rechnungen` | Rechnungen und Stripe-Zahlungen |
+| **Follow-ups** | `/admin/followups` | Wiedervorlagen und Erinnerungen |
+| **Meetings** | `/admin/meetings` | Aufgezeichnete Meetings und Transkripte |
+| **Kalender** | `/admin/kalender` | Kalenderübersicht |
+| **Monitoring** | `/admin/monitoring` | Live-Übersicht: Pod-Status und Ressourcen |
+| **Bugs** | `/admin/bugs` | Bug-Reports und Ticket-Tracking |
+
+### Kunden-Detail-Ansicht
+
+Unter `/admin/clients/{id}` ist eine umfassende Kundenübersicht verfügbar:
+- Kontaktdaten und Kommunikationshistorie
+- Zugehörige Projekte und Aufgaben
+- Offene und bezahlte Rechnungen
+- Direktnachrichten (DMs)
+- Gebuchte Leistungen
+
+---
+
+## Stripe-Zahlungen
+
+Stripe ist die Zahlungsplattform für Leistungen und Rechnungen. Zahlungen werden auf der Leistungen-Seite oder über den CTA der Homepage abgewickelt.
+
+**Einrichtung (einmalig):**
+```bash
+task workspace:stripe-setup
+```
+
+**Konfiguration:**
+- Stripe-Keys in `workspace-secrets` als Kubernetes Secret gespeichert
+- Webhook-Endpoint: `/api/stripe/webhook` (Ereignis: `checkout.session.completed`)
+- Zahlungsstatus in der Admin-Oberfläche unter `/admin/rechnungen`
+
+Weitere Details: [Stripe-Integration](stripe.md)
+
+---
+
+## Monitoring & Systemstatus
+
+### Live-Monitoring im Admin-Panel
+
+Das Admin-Panel unter [web.localhost/admin/monitoring](http://web.localhost/admin/monitoring) zeigt:
+- Status aller Kubernetes-Pods (laufend / fehler / neustart)
+- CPU- und RAM-Auslastung je Pod
+- Aktuelle Kubernetes-Events (Warnungen, Restarts)
+
+### Status über die Kommandozeile prüfen
+
+```bash
+task workspace:status          # Pods, Services, Ingress, PVCs
+task workspace:logs -- keycloak   # Logs eines Services anzeigen
+task workspace:logs -- nextcloud
+task workspace:logs -- website
+```
+
+### Service neustarten
+
+```bash
+task workspace:restart -- nextcloud    # Nextcloud neustarten
+task workspace:restart -- keycloak     # Keycloak neustarten
+task workspace:restart -- vaultwarden  # Vaultwarden neustarten
+```
+
+---
+
+## Backups
+
+Backups werden automatisch per Kubernetes CronJob erstellt (`k3d/backup-cronjob.yaml`).
+
+**Backup-Inhalt:**
+- PostgreSQL-Datenbank-Dumps (alle Datenbanken)
+- Nextcloud-Daten (Dateien)
+- Vaultwarden-Vault
+
+**Status prüfen:**
+```bash
+kubectl get cronjobs -n workspace
+kubectl get jobs -n workspace | grep backup
+```
+
+**Manuelles Backup auslösen:**
+```bash
+kubectl create job --from=cronjob/backup-job manual-backup-$(date +%Y%m%d) -n workspace
+```
+
+---
+
+## Häufige Aufgaben – Schnellreferenz
+
+| Aufgabe | Befehl / Ort |
+|---------|--------------|
+| Cluster starten | `task cluster:start` |
+| Alle Services deployen | `task workspace:deploy` |
+| Website neu bauen & deployen | `task website:redeploy` |
+| Post-Deploy-Setup (Nextcloud-Apps) | `task workspace:post-setup` |
+| Datenbankshell öffnen | `task workspace:psql -- website` |
+| Vaultwarden-Seed ausführen | `task workspace:vaultwarden:seed` |
+| DSGVO-Compliance prüfen | `task workspace:dsgvo-check` |
+| Alle Tests ausführen | `./tests/runner.sh local` |
+
+---
+
+## Häufig gestellte Fragen (Admin)
+
+### Ein Service startet nicht – wie debugge ich?
+
+```bash
+task workspace:logs -- <servicename>    # Logs anzeigen
+kubectl describe pod -n workspace -l app=<servicename>   # Events prüfen
+```
+
+Häufige Ursachen: Datenbankverbindung fehlgeschlagen, Secret nicht vorhanden, unzureichende Ressourcen.
+
+### Nextcloud friert ein oder reagiert langsam
+
+Nextcloud manchmal im Maintenance-Modus oder OPcache überlastet:
+```bash
+task workspace:restart -- nextcloud
+```
+
+Falls das nicht hilft: `task workspace:logs -- nextcloud` auf Datenbankfehler prüfen.
+
+### Keycloak-Login funktioniert nicht für einen Dienst
+
+1. Prüfe ob der Dienst als OIDC-Client in Keycloak registriert ist: [auth.localhost/admin](http://auth.localhost/admin) → Clients
+2. Prüfe die Redirect-URIs des Clients
+3. Dienst neustarten: `task workspace:restart -- <dienst>`
+
+### Wie füge ich eine neue Domain hinzu?
+
+1. `k3d/configmap-domains.yaml` und `prod/configmap-domains.yaml` anpassen
+2. Ingress-Regel in `k3d/ingress.yaml` ergänzen
+3. `task workspace:validate` ausführen
+4. PR erstellen und nach Merge deployen: `task workspace:deploy`
+
+### Wie aktualisiere ich die Dokumentation?
+
+Die Docs-Seite lädt Markdown-Dateien aus `docs/`. Nach einer Änderung:
+```bash
+# Nach PR-Merge auf main:
+kubectl patch configmap docs-content -n workspace --patch-file /dev/stdin <<EOF
+... (Inhalt aus CI/Deploy-Skript)
+EOF
+kubectl rollout restart deployment/docs -n workspace
+```
+
+Weitere Details: Siehe [Docs-Deployment Referenz](../memory/reference_docs_deployment.md).
+
+---
+
+## Weiterführende Dokumentation
+
+| Thema | Dokument |
+|-------|----------|
+| Systemarchitektur | [Architektur](architecture.md) |
+| Alle Services (technisch) | [Services](services.md) |
+| Keycloak & SSO konfigurieren | [Keycloak & SSO](keycloak.md) |
+| Datenbankmodelle | [Datenbankmodelle](database.md) |
+| Sicherheit & DSGVO | [Sicherheit](security.md) |
+| Datenschutz-Verarbeitungsverzeichnis | [Verarbeitungsverzeichnis (Art. 30)](verarbeitungsverzeichnis.md) |
+| Projektmanagement (API) | [Projektmanagement-Admin](admin-projekte.md) |
+| Stripe-Integration | [Stripe](stripe.md) |
+| Skripte & Automatisierung | [Skripte](scripts.md) |
+| Fehlerbehebung | [Fehlerbehebung](troubleshooting.md) |
+| Testframework | [Tests](tests.md) |
+| Claude Code MCP-Actions | [MCP Actions](mcp-actions.md) |

--- a/docs/benutzerhandbuch.md
+++ b/docs/benutzerhandbuch.md
@@ -1,3 +1,16 @@
+<div class="page-hero">
+  <span class="page-hero-icon">📖</span>
+  <div class="page-hero-body">
+    <div class="page-hero-title">Benutzerhandbuch</div>
+    <p class="page-hero-desc">Alle Werkzeuge des Workspace auf einen Blick – verständlich erklärt, ohne technisches Vorwissen.</p>
+    <div class="page-hero-meta">
+      <span class="page-hero-tag">Für Mitarbeiter</span>
+      <span class="page-hero-tag">Einsteiger</span>
+    </div>
+  </div>
+  <a href="#/" class="page-hero-back">← Übersicht</a>
+</div>
+
 # Benutzerhandbuch – Workspace
 
 Willkommen beim Workspace! Dieses Handbuch erklärt, welche Werkzeuge Dir zur Verfügung stehen, wofür Du sie nutzen kannst und wie Du einfache Aufgaben erledigst – ganz ohne technisches Vorwissen.
@@ -16,36 +29,57 @@ Du brauchst **nur einen einzigen Account** – mit diesem einen Login kommst Du 
 
 Alle Dienste sind über einen zentralen Login verbunden. Das bedeutet:
 
-- Du loggst Dich **einmal** ein – zum Beispiel in Mattermost.
-- Wenn Du dann Nextcloud, das Wiki oder den Passwort-Safe öffnest, bist Du dort **automatisch** angemeldet, ohne das Passwort erneut eingeben zu müssen.
+- Du loggst Dich **einmal** ein – zum Beispiel im Portal auf der Website.
+- Wenn Du dann Nextcloud, den Passwort-Safe oder die Dokumentation öffnest, bist Du dort **automatisch** angemeldet, ohne das Passwort erneut eingeben zu müssen.
 - Wenn Du Dich **abmeldest**, wirst Du aus allen Diensten gleichzeitig ausgeloggt.
 
 Dieser zentrale Login nennt sich **Single Sign-On (SSO)** und wird durch ein System namens Keycloak bereitgestellt.
 
 ---
 
+## Dienstübersicht mit Links
+
+| Dienst | Beschreibung | Link (Entwicklung) |
+|--------|-------------|---------------------|
+| **Portal / Nachrichten** | Chat, Direktnachrichten, Dokumente | [web.localhost/portal](http://web.localhost/portal) |
+| **Dateien & Kalender** | Cloud-Speicher, Kalender, Kontakte | [files.localhost](http://files.localhost) |
+| **Videokonferenz** | Meetings & Sprachanrufe (in Nextcloud) | [files.localhost](http://files.localhost) → Talk |
+| **Dokumente** | Gemeinsame Office-Bearbeitung | Öffnet sich aus Nextcloud heraus |
+| **Whiteboard** | Digitales Whiteboard | [board.localhost](http://board.localhost) |
+| **KI-Assistent** | Claude AI-Status & MCP-Dashboard | [ai.localhost](http://ai.localhost) |
+| **Passwort-Safe** | Sichere Passwortverwaltung | [vault.localhost](http://vault.localhost) |
+| **Dokumentation** | Dieses Handbuch und weitere Docs | [docs.localhost](http://docs.localhost) |
+
+> In der Produktivumgebung ersetze `localhost` durch die Unternehmens-Domain (z. B. `files.meinunternehmen.de`).
+
+---
+
 ## Die Dienste im Überblick
 
-### Chat (Mattermost)
+### Nachrichten & Chat (Portal)
 
-**Wozu?** Schreiben, Diskutieren, Teamkommunikation – wie WhatsApp, aber für die Arbeit und sicher auf Deinen eigenen Servern.
+**Wozu?** Schreiben, Diskutieren, Teamkommunikation – direkt im Benutzerportal der Unternehmenswebsite.
+
+**Zugang:** [web.localhost/portal](http://web.localhost/portal) → Nach dem Login automatisch verfügbar
 
 **Was kannst Du tun?**
-- Nachrichten in Kanälen (themenbasierten Gruppen) schreiben
-- Private Direktnachrichten an einzelne Kollegen senden
-- Dateien direkt in den Chat hochladen und teilen
-- Auf Nachrichten mit Emojis reagieren
-- Benachrichtigungen erhalten, wenn Dich jemand erwähnt (`@deinname`)
+- Nachrichten in **Räumen** (themenbasierte Gruppen) schreiben und lesen
+- **Direktnachrichten** an einzelne Kollegen oder Kunden senden
+- Ungelesene Nachrichten werden automatisch durch Benachrichtigungen markiert
+- Eingegangene Anfragen (Kontaktformulare, Buchungen) in der **Inbox** sehen
 
-**Tipps:**
-- Klicke links auf **"+"** um einem neuen Kanal beizutreten oder einen zu erstellen
-- Mit **`/billing`** kannst Du Rechnungen direkt aus dem Chat erstellen (mehr dazu weiter unten)
+**Räume:**
+1. Klicke im Portal auf **„Nachrichten"**
+2. Wähle einen vorhandenen Raum oder erstelle einen neuen
+3. Schreibe Deine Nachricht und sende sie ab
 
 ---
 
 ### Dateien & Kalender (Nextcloud)
 
 **Wozu?** Dein persönlicher Cloud-Speicher im Büro – wie Dropbox, aber sicher auf Deinen eigenen Servern.
+
+**Zugang:** [files.localhost](http://files.localhost)
 
 **Was kannst Du tun?**
 - Dateien hochladen, herunterladen und mit Kollegen teilen
@@ -55,7 +89,7 @@ Dieser zentrale Login nennt sich **Single Sign-On (SSO)** und wird durch ein Sys
 - Kontakte verwalten
 
 **Dateien teilen:**
-1. Rechtsklick auf eine Datei oder einen Ordner → **"Teilen"**
+1. Rechtsklick auf eine Datei oder einen Ordner → **„Teilen"**
 2. Namen des Kollegen eingeben
 3. Berechtigungen festlegen (nur lesen / auch bearbeiten)
 
@@ -65,15 +99,17 @@ Dieser zentrale Login nennt sich **Single Sign-On (SSO)** und wird durch ein Sys
 
 **Wozu?** Word, Excel und PowerPoint direkt im Browser bearbeiten – kein separates Programm nötig.
 
+**Zugang:** Öffnet sich automatisch aus [Nextcloud](http://files.localhost) heraus – keine eigene Adresse nötig.
+
 **Was kannst Du tun?**
 - Neue Textdokumente, Tabellen oder Präsentationen erstellen
 - Bestehende Dateien (`.docx`, `.xlsx`, `.pptx`) öffnen und bearbeiten
 - Gleichzeitig mit Kollegen am selben Dokument arbeiten – Du siehst in Echtzeit, was andere tippen
 
 **So öffnest Du ein Dokument:**
-1. Gehe zu **Nextcloud** (Dateien)
+1. Gehe zu **Nextcloud** ([files.localhost](http://files.localhost))
 2. Klicke auf eine Datei – sie öffnet sich automatisch im Editor
-3. Oder: Klicke auf **"+"** → **"Neues Dokument"**, um von vorne anzufangen
+3. Oder: Klicke auf **„+"** → **„Neues Dokument"**, um von vorne anzufangen
 
 > Collabora ist direkt in Nextcloud eingebettet. Du musst keine separate Webseite öffnen.
 
@@ -83,6 +119,8 @@ Dieser zentrale Login nennt sich **Single Sign-On (SSO)** und wird durch ein Sys
 
 **Wozu?** Video- und Sprachanrufe direkt im Browser – wie Zoom oder Teams, aber auf Deinen eigenen Servern.
 
+**Zugang:** [files.localhost](http://files.localhost) → **Talk** (linke Seitenleiste)
+
 **Was kannst Du tun?**
 - Einzelgespräche oder Gruppenmeetings starten
 - Video und Mikrofon ein-/ausschalten
@@ -91,7 +129,7 @@ Dieser zentrale Login nennt sich **Single Sign-On (SSO)** und wird durch ein Sys
 
 **Meeting starten:**
 1. Gehe zu Nextcloud Talk
-2. Klicke auf **"+ Neues Gespräch erstellen"**
+2. Klicke auf **„+ Neues Gespräch erstellen"**
 3. Vergib einen Namen und füge Teilnehmer hinzu
 4. Starte den Anruf über das **Kamera-Symbol**
 
@@ -102,6 +140,8 @@ Dieser zentrale Login nennt sich **Single Sign-On (SSO)** und wird durch ein Sys
 ### Whiteboard
 
 **Wozu?** Gemeinsam skizzieren, brainstormen und visualisieren – wie ein digitales Whiteboard in einer Besprechung.
+
+**Zugang:** [board.localhost](http://board.localhost)
 
 **Was kannst Du tun?**
 - Freihand zeichnen, Formen und Text einfügen
@@ -114,6 +154,8 @@ Dieser zentrale Login nennt sich **Single Sign-On (SSO)** und wird durch ein Sys
 
 **Wozu?** Ein intelligenter Assistent, der Dir bei Texten, Fragen und Aufgaben hilft.
 
+**Zugang:** [ai.localhost](http://ai.localhost) (Status-Dashboard) – Claude Code wird lokal auf dem Rechner des Administrators ausgeführt.
+
 **Was kannst Du tun?**
 - Texte verfassen lassen (E-Mails, Zusammenfassungen, Berichte)
 - Fragen stellen und Erklärungen erhalten
@@ -121,34 +163,19 @@ Dieser zentrale Login nennt sich **Single Sign-On (SSO)** und wird durch ein Sys
 - Daten zusammenfassen
 
 **Beispiel-Fragen:**
-- *"Schreibe eine freundliche Absage-E-Mail auf Deutsch."*
-- *"Fasse mir diesen Text in drei Sätzen zusammen."*
-- *"Was ist der Unterschied zwischen einer GmbH und einer UG?"*
+- *„Schreibe eine freundliche Absage-E-Mail auf Deutsch."*
+- *„Fasse mir diesen Text in drei Sätzen zusammen."*
+- *„Was ist der Unterschied zwischen einer GmbH und einer UG?"*
 
 > Der KI-Assistent ist nur für den Einsatz im internen Kontext gedacht. Gib keine sensiblen Kundendaten ein.
-
----
-
-### Wissensdatenbank / Wiki (Outline)
-
-**Wozu?** Das interne Nachschlagewerk des Teams – Anleitungen, Prozesse, Wissen aufschreiben und für alle zugänglich machen.
-
-**Was kannst Du tun?**
-- Neue Seiten und Artikel anlegen
-- Seiten in Sammlungen (Ordner) organisieren
-- Andere Teammitglieder zum gemeinsamen Bearbeiten einladen
-- Die Volltextsuche nutzen, um schnell etwas zu finden
-
-**Neue Seite anlegen:**
-1. Klicke links auf eine Sammlung oder erstelle eine neue
-2. Klicke auf **"Neue Seite"**
-3. Schreibe Deinen Inhalt und speichere
 
 ---
 
 ### Passwort-Safe (Vaultwarden)
 
 **Wozu?** Passwörter sicher speichern und im Team teilen – auf Deinen eigenen Servern, nicht bei einem externen Anbieter.
+
+**Zugang:** [vault.localhost](http://vault.localhost)
 
 **Was kannst Du tun?**
 - Passwörter und Zugangsdaten sicher verwahren
@@ -159,25 +186,6 @@ Dieser zentrale Login nennt sich **Single Sign-On (SSO)** und wird durch ein Sys
 > Vaultwarden ist kompatibel mit dem **Bitwarden**-Browser-Plugin, das Du Dir kostenlos installieren kannst.
 
 **Wichtig:** Du brauchst ein eigenes **Master-Passwort** für den Passwort-Safe. Dieses ist unabhängig von Deinem normalen Workspace-Passwort und sollte besonders sicher sein – schreib es Dir auf und verwahre es gut.
-
----
-
-### Rechnungen (Invoice Ninja)
-
-**Wozu?** Rechnungen erstellen, Kunden verwalten und Zahlungen nachverfolgen.
-
-**Was kannst Du tun?**
-- Neue Kunden anlegen
-- Rechnungen erstellen und per E-Mail versenden
-- Den Status von Rechnungen einsehen (offen, bezahlt, überfällig)
-- Zahlungen per Stripe verarbeiten
-
-**Rechnungen aus dem Chat erstellen:**
-Tippe in Mattermost einfach:
-```
-/billing invoice Kundenname
-```
-Der Billing-Bot erstellt die Rechnung automatisch und schickt Dir den Link.
 
 ---
 
@@ -193,10 +201,11 @@ Nein. Alle Dienste haben gültige Sicherheitszertifikate. Eine Warnung ist ein Z
 
 ### Kann ich die Dienste auch auf dem Smartphone nutzen?
 
-Ja. Die meisten Dienste haben Apps:
-- **Mattermost**: App für iOS und Android verfügbar
+Ja. Mehrere Dienste haben offizielle Apps:
 - **Nextcloud**: App für iOS und Android verfügbar (Dateien, Kalender, Talk)
 - **Vaultwarden**: Bitwarden-App für iOS und Android kompatibel
+
+Das Portal und die meisten anderen Dienste sind außerdem als responsive Website im mobilen Browser nutzbar.
 
 ### Wer hat Zugriff auf meine Dateien und Nachrichten?
 
@@ -208,20 +217,19 @@ Ja – das ist genau der Zweck. Da alle Daten auf Deinen eigenen Servern liegen 
 
 ### Etwas funktioniert nicht – an wen wende ich mich?
 
-Schreibe eine Nachricht im Mattermost-Kanal des Administrators oder schicke eine E-Mail an den Systemverantwortlichen.
+Schreibe eine Nachricht im Portal-Chat an den Administrator oder schicke eine E-Mail an den Systemverantwortlichen. In der Produktivumgebung steht auch ein Bug-Report-Formular unter `/admin/bugs` bereit.
 
 ---
 
 ## Kurzübersicht: Welcher Dienst wofür?
 
-| Ich möchte…                                  | Dienst               |
-|----------------------------------------------|----------------------|
-| Eine Nachricht an einen Kollegen schicken     | **Mattermost**       |
-| Eine Datei teilen                             | **Nextcloud**        |
-| Gemeinsam an einem Dokument arbeiten          | **Nextcloud + Collabora** |
-| Ein Meeting starten                           | **Nextcloud Talk**   |
-| Ideen gemeinsam aufzeichnen                   | **Whiteboard**       |
-| Eine KI fragen                                | **Claude**           |
-| Wissen im Team festhalten                     | **Outline (Wiki)**   |
-| Ein Passwort sicher aufbewahren               | **Vaultwarden**      |
-| Eine Rechnung erstellen                       | **Invoice Ninja**    |
+| Ich möchte…                                  | Dienst                    | Link |
+|----------------------------------------------|---------------------------|------|
+| Eine Nachricht an einen Kollegen schicken     | **Portal – Nachrichten**  | [Portal](http://web.localhost/portal) |
+| Eine Datei teilen                             | **Nextcloud**             | [files.localhost](http://files.localhost) |
+| Gemeinsam an einem Dokument arbeiten          | **Nextcloud + Collabora** | [files.localhost](http://files.localhost) |
+| Ein Meeting starten                           | **Nextcloud Talk**        | [files.localhost](http://files.localhost) |
+| Ideen gemeinsam aufzeichnen                   | **Whiteboard**            | [board.localhost](http://board.localhost) |
+| Eine KI fragen                                | **Claude**                | [ai.localhost](http://ai.localhost) |
+| Ein Passwort sicher aufbewahren               | **Vaultwarden**           | [vault.localhost](http://vault.localhost) |
+| Diese Dokumentation lesen                     | **Docs**                  | [docs.localhost](http://docs.localhost) |

--- a/docs/database.md
+++ b/docs/database.md
@@ -79,7 +79,7 @@ erDiagram
         text        insight_type
         text        content
         text        generated_by
-        text        outline_document_id
+        text        doc_reference
         timestamptz created_at
     }
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -31,7 +31,7 @@ flowchart LR
     end
 
     subgraph Ziele ["fa:fa-bullseye Ziele"]
-        MM["fa:fa-comments Mattermost<br/>Chat + Kanaele"]
+        MSG["fa:fa-comments Website Messaging<br/>Chat-Räume + Inbox"]
         NC["fa:fa-cloud Nextcloud<br/>Dateien + Kalender + Kontakte"]
         KC["fa:fa-key Keycloak<br/>Benutzerkonten"]
     end
@@ -41,7 +41,7 @@ flowchart LR
     GO --> M
     CSV --> M
 
-    M --> MM
+    M --> MSG
     M --> NC
     M --> KC
 
@@ -50,7 +50,7 @@ flowchart LR
     style GO fill:#1a3d28,color:#e8c870
     style CSV fill:#1f2937,color:#aabbcc
     style M fill:#1a1a2e,color:#aabbcc
-    style MM fill:#1a3d28,color:#e8c870
+    style MSG fill:#1a3d28,color:#e8c870
     style NC fill:#083344,color:#e8c870
     style KC fill:#1b3766,color:#e8c870
 ```
@@ -74,41 +74,41 @@ scripts/migrate.sh --dry-run
 
 | # | Aktion | Quelle | Ziel |
 |---|--------|--------|------|
-| 1 | Slack importieren | Slack Export ZIP | Mattermost (JSONL Bulk Import) |
-| 2 | Teams importieren | GDPR-Export oder lokaler Cache | Mattermost + Nextcloud |
-| 3 | Google importieren | Google Takeout | Mattermost + Nextcloud |
+| 1 | Slack importieren | Slack Export ZIP | Website Messaging (Chat-Räume via API) |
+| 2 | Teams importieren | GDPR-Export oder lokaler Cache | Website Messaging + Nextcloud |
+| 3 | Google importieren | Google Takeout | Website Messaging + Nextcloud |
 | 4 | Benutzer importieren | CSV oder LDIF | Keycloak |
-| 5 | Daten exportieren | Mattermost + Nextcloud + Keycloak | ZIP-Archiv |
+| 5 | Daten exportieren | Website Messaging + Nextcloud + Keycloak | ZIP-Archiv |
 | 6 | Server konfigurieren | -- | Verbindungsdaten setzen |
 | 7 | Quellen scannen | Lokales System | Erkennung vorhandener Exporte |
 
 ## Import-Details
 
-### Slack nach Mattermost
+### Slack nach Website Messaging
 
 **Skript:** `scripts/lib/slack-import.sh`
 
 - Akzeptiert Slack Export ZIP oder entpacktes Verzeichnis
-- Konvertiert zu Mattermost JSONL Bulk Import Format
+- Konvertiert Channels zu Chat-Räumen, Direktnachrichten zu DMs im Website-Messaging
 - Wandelt um: Channels, Benutzer, Nachrichten, Threads, Mentions, Links
-- Upload via `mmctl`
+- Import via Website-API (`/api/messaging/import`)
 
-### Microsoft Teams nach Mattermost + Nextcloud
+### Microsoft Teams nach Website Messaging + Nextcloud
 
 **Skript:** `scripts/lib/teams-import.sh`
 
 - Unterstuetzt GDPR-Datenexport (myaccount.microsoft.com) und lokalen Teams-Cache
 - Erkennt Export-Typ automatisch
-- Chat-Nachrichten nach Mattermost (JSONL)
+- Chat-Nachrichten nach Website Messaging (Chat-Räume)
 - Dateien nach Nextcloud (WebDAV)
 - Kalender nach .ics, Kontakte nach .vcf
 
-### Google Workspace nach Mattermost + Nextcloud
+### Google Workspace nach Website Messaging + Nextcloud
 
 **Skript:** `scripts/lib/google-import.sh`
 
 - Google Takeout Export (takeout.google.com)
-- Google Chat nach Mattermost (JSONL)
+- Google Chat nach Website Messaging (Chat-Räume)
 - Drive nach Nextcloud (WebDAV)
 - Kalender nach Nextcloud Calendar (CalDAV)
 - Kontakte nach Nextcloud Contacts (CardDAV)
@@ -144,7 +144,7 @@ Erstellt fehlende Gruppen automatisch. Setzt temporaere Passwoerter (Aenderung b
 
 Option 5 im Migrations-Assistenten erstellt ein ZIP-Archiv mit selektiv exportierten Daten:
 
-- **Mattermost:** Nachrichten (JSONL via mmctl/API), Dateien (aus Volume)
+- **Website Messaging:** Nachrichten und Räume (JSON via API)
 - **Nextcloud:** Dateien (WebDAV), Kalender (CalDAV/iCal), Kontakte (CardDAV/vCard)
 - **Keycloak:** Benutzer (CSV + LDIF), Realm-Konfiguration (JSON)
 
@@ -157,7 +157,6 @@ Option 5 im Migrations-Assistenten erstellt ein ZIP-Archiv mit selektiv exportie
 Scannt automatisch typische Speicherorte fuer vorhandene Exporte:
 - Slack: Cache und Download-Verzeichnisse
 - Teams: lokaler Cache und GDPR-Exporte
-- Mattermost: bestehende Installationen
 - Nextcloud: Desktop-Client-Synchronisierung
 - Google Takeout: Download-Verzeichnisse
 

--- a/docs/verarbeitungsverzeichnis.md
+++ b/docs/verarbeitungsverzeichnis.md
@@ -40,14 +40,14 @@
 
 | Feld | Wert |
 |------|------|
-| **Zweck** | Interne Kommunikation zwischen Teammitgliedern |
+| **Zweck** | Interne Kommunikation zwischen Teammitgliedern sowie zwischen Kunden und Administratoren |
 | **Rechtsgrundlage** | Art. 6 Abs. 1 lit. b DSGVO (Vertragserfüllung) |
-| **Betroffene Personen** | Nutzer der Mattermost-Instanz |
-| **Datenkategorien** | Nachrichteninhalte, Zeitstempel, Absender-User-ID, Kanal-Zugehörigkeit, Anhänge |
-| **Empfänger** | Keine Dritten — On-Premises (Mattermost im `workspace`-Namespace) |
+| **Betroffene Personen** | Registrierte Nutzer des Website-Portals (Mitarbeiter und Kunden) |
+| **Datenkategorien** | Nachrichteninhalte, Zeitstempel, Absender-User-ID, Raum-Zugehörigkeit, Gelesen-Status |
+| **Empfänger** | Keine Dritten — On-Premises (Messaging-System im `website`-Namespace, PostgreSQL `shared-db`) |
 | **Drittlandübermittlung** | Keine |
-| **Speicherdauer** | Konfigurierbar (Standard: unbegrenzt); auf Anfrage (Art. 17) löschbar |
-| **Technische Schutzmaßnahmen** | TLS in Transit, Keycloak OIDC SSO, NetworkPolicy-Isolation, Audit-Log `/api/v4/audits` |
+| **Speicherdauer** | Auf Anfrage (Art. 17) löschbar; ansonsten unbegrenzt gespeichert |
+| **Technische Schutzmaßnahmen** | TLS in Transit, Keycloak OIDC SSO, NetworkPolicy-Isolation, Zugriff nur nach Authentifizierung |
 
 ---
 
@@ -74,25 +74,25 @@
 | **Rechtsgrundlage** | Art. 6 Abs. 1 lit. b DSGVO (Durchführung vorvertraglicher Maßnahmen) |
 | **Betroffene Personen** | Interessenten und Auftraggeber (Website-Besucher) |
 | **Datenkategorien** | Name, E-Mail-Adresse, gewählter Termin/Zeitslot, optionale Nachricht |
-| **Empfänger** | Keine Dritten — Weiterleitung intern via Mattermost-Webhook; CalDAV-Eintrag in Nextcloud |
+| **Empfänger** | Keine Dritten — Weiterleitung intern in die Admin-Inbox (`/admin/termine`); CalDAV-Eintrag in Nextcloud |
 | **Drittlandübermittlung** | Keine |
 | **Speicherdauer** | 3 Jahre (handelsrechtliche Aufbewahrungsfrist für vorvertragliche Korrespondenz) |
-| **Technische Schutzmaßnahmen** | TLS in Transit, Mattermost-Webhook nur intern erreichbar (NetworkPolicy), keine externe Weitergabe |
+| **Technische Schutzmaßnahmen** | TLS in Transit, Keycloak OIDC SSO für Admin-Zugriff, NetworkPolicy-Isolation, keine externe Weitergabe |
 
 ---
 
-## VT-05: Rechnungsstellung und Buchführung
+## VT-05: Rechnungsstellung und Zahlungsabwicklung
 
 | Feld | Wert |
 |------|------|
-| **Zweck** | Erstellung, Verwaltung und Archivierung von Rechnungen |
-| **Rechtsgrundlage** | Art. 6 Abs. 1 lit. c DSGVO (rechtliche Verpflichtung: § 257 HGB, § 14 UStG) |
-| **Betroffene Personen** | Auftraggeber (Rechnungsempfänger) |
-| **Datenkategorien** | Name, Unternehmensname, Rechnungsadresse, E-Mail, Leistungsbeschreibung, Beträge, Rechnungsnummer, Datum |
-| **Empfänger** | Keine Dritten — On-Premises (Invoice Ninja im `workspace`-Namespace) |
-| **Drittlandübermittlung** | Keine |
+| **Zweck** | Erstellung, Verwaltung und Archivierung von Rechnungen sowie Abwicklung von Online-Zahlungen |
+| **Rechtsgrundlage** | Art. 6 Abs. 1 lit. c DSGVO (rechtliche Verpflichtung: § 257 HGB, § 14 UStG); Art. 6 Abs. 1 lit. b (Vertragserfüllung) |
+| **Betroffene Personen** | Auftraggeber (Rechnungsempfänger, Zahlende) |
+| **Datenkategorien** | Name, Unternehmensname, Rechnungsadresse, E-Mail, Leistungsbeschreibung, Beträge, Rechnungsnummer, Datum; Stripe-Checkout-Sitzungs-ID |
+| **Empfänger** | Rechnungsdaten: On-Premises (Website `website`-Namespace, PostgreSQL). Zahlungsabwicklung: **Stripe Inc.** (Auftragsverarbeiter gemäß Art. 28 DSGVO, EU-Standardvertragsklauseln) |
+| **Drittlandübermittlung** | Stripe: Datenübertragung in die USA auf Basis von EU-Standardvertragsklauseln (SCC) |
 | **Speicherdauer** | 10 Jahre (§ 257 HGB — gesetzliche Aufbewahrungspflicht für Buchungsbelege) |
-| **Technische Schutzmaßnahmen** | TLS in Transit, Keycloak OIDC SSO + OAuth2-Proxy, Rate-Limiting (30 req/s), NetworkPolicy-Isolation |
+| **Technische Schutzmaßnahmen** | TLS in Transit, Keycloak OIDC SSO für Admin-Zugriff, Stripe Hosted Checkout (keine Kartenddaten on-premises), Webhook-Signaturprüfung |
 
 ---
 
@@ -104,10 +104,10 @@
 | **Rechtsgrundlage** | Art. 6 Abs. 1 lit. b DSGVO (vorvertragliche Maßnahmen), hilfsweise Art. 6 Abs. 1 lit. f (berechtigtes Interesse an Anfragenbearbeitung) |
 | **Betroffene Personen** | Website-Besucher, die das Kontaktformular nutzen |
 | **Datenkategorien** | Name, E-Mail-Adresse, Nachrichteninhalt |
-| **Empfänger** | Keine Dritten — Weiterleitung intern via Mattermost-Webhook in den Kanal `anfragen` |
+| **Empfänger** | Keine Dritten — Weiterleitung intern in die Admin-Inbox (`/admin/inbox`, PostgreSQL `website`-Datenbank) |
 | **Drittlandübermittlung** | Keine |
 | **Speicherdauer** | 3 Jahre (Verjährungsfrist für Ansprüche aus vorvertraglichen Verhältnissen, § 195 BGB) |
-| **Technische Schutzmaßnahmen** | TLS in Transit, Mattermost-Webhook nur intern erreichbar, keine Speicherung in externer Datenbank |
+| **Technische Schutzmaßnahmen** | TLS in Transit, Keycloak OIDC SSO für Admin-Zugriff auf Inbox, keine Speicherung in externer Datenbank, NetworkPolicy-Isolation |
 
 ---
 
@@ -117,4 +117,8 @@ Es findet **keine Übermittlung personenbezogener Daten in Drittländer** (auße
 
 ## Auftragsverarbeiter
 
-Keine Auftragsverarbeiter (Art. 28 DSGVO) — die Verarbeitung erfolgt vollständig durch den Verantwortlichen selbst auf eigener Infrastruktur.
+| Auftragsverarbeiter | Sitz | Zweck | Rechtsgrundlage |
+|---------------------|------|-------|-----------------|
+| **Stripe Inc.** | USA (EU-Niederlassung: Irland) | Online-Zahlungsabwicklung (Kreditkarte, SEPA) | EU-Standardvertragsklauseln (SCC) gem. Art. 46 Abs. 2 lit. c DSGVO |
+
+Alle übrigen Verarbeitungen erfolgen vollständig durch den Verantwortlichen selbst auf eigener On-Premises-Infrastruktur (kein weiterer Auftragsverarbeiter).

--- a/k3d/docs-content/_sidebar.md
+++ b/k3d/docs-content/_sidebar.md
@@ -1,20 +1,20 @@
 - [Home](/)
 - **Für Mitarbeiter**
 - [Benutzerhandbuch](benutzerhandbuch.md)
-- [Testanleitung](test-anleitung-korczewski.md)
 - **Für Administratoren**
+- [Administrator-Handbuch](adminhandbuch.md)
 - [Architektur](architecture.md)
-- [Datenbankmodelle](database.md)
 - [Services](services.md)
 - [Keycloak & SSO](keycloak.md)
+- [Datenbankmodelle](database.md)
+- [Sicherheit](security.md)
+- [Verarbeitungsverzeichnis (Art. 30)](verarbeitungsverzeichnis.md)
+- [Stripe-Integration](stripe.md)
+- [Projektmanagement-Admin](admin-projekte.md)
+- [MCP Actions](mcp-actions.md)
+- **Entwicklung & Betrieb**
 - [Migration](migration.md)
 - [Skripte](scripts.md)
 - [Tests](tests.md)
-- [Sicherheit](security.md)
-- [Verarbeitungsverzeichnis (Art. 30)](verarbeitungsverzeichnis.md)
 - [Fehlerbehebung](troubleshooting.md)
 - [Anforderungen](requirements.md)
-- [MCP Actions](mcp-actions.md)
-- **Website & Admin**
-- [Stripe-Integration](stripe.md)
-- [Projektmanagement-Admin](admin-projekte.md)

--- a/k3d/docs-content/adminhandbuch.md
+++ b/k3d/docs-content/adminhandbuch.md
@@ -1,0 +1,257 @@
+<div class="page-hero">
+  <span class="page-hero-icon">🛠️</span>
+  <div class="page-hero-body">
+    <div class="page-hero-title">Administrator-Handbuch</div>
+    <p class="page-hero-desc">Einrichtung, Betrieb und Verwaltung des Workspace – für Administratoren ohne Kubernetes-Vorkenntnisse.</p>
+    <div class="page-hero-meta">
+      <span class="page-hero-tag">Für Administratoren</span>
+      <span class="page-hero-tag">Betrieb</span>
+    </div>
+  </div>
+  <a href="#/" class="page-hero-back">← Übersicht</a>
+</div>
+
+# Administrator-Handbuch – Workspace
+
+Dieses Handbuch beschreibt die wichtigsten Administrationsaufgaben: Benutzer anlegen, Dienste überwachen, Backups verwalten und häufige Probleme beheben. Für tiefgehende technische Details zu Kubernetes-Manifesten und Architektur: [Architektur](architecture.md) und [Services](services.md).
+
+---
+
+## Dienstübersicht mit Admin-Links
+
+| Dienst | Funktion | Dev-URL | Admin-Zugang |
+|--------|----------|---------|--------------|
+| **Keycloak** | Benutzerverwaltung & SSO | [auth.localhost](http://auth.localhost) | [auth.localhost/admin](http://auth.localhost/admin) |
+| **Nextcloud** | Dateien, Kalender, Talk | [files.localhost](http://files.localhost) | [files.localhost/settings/admin](http://files.localhost/settings/admin) |
+| **Collabora** | Office-Editor (in NC eingebettet) | [office.localhost](http://office.localhost) | Konfiguration via Nextcloud |
+| **Whiteboard** | Digitales Whiteboard | [board.localhost](http://board.localhost) | — |
+| **Vaultwarden** | Passwort-Safe | [vault.localhost](http://vault.localhost) | [vault.localhost/admin](http://vault.localhost/admin) |
+| **Website / Portal** | Unternehmenswebsite + Messaging | [web.localhost](http://web.localhost) | [web.localhost/admin](http://web.localhost/admin) |
+| **Dokumentation** | Dieses Handbuch | [docs.localhost](http://docs.localhost) | SSO-geschützt (Keycloak) |
+| **Mailpit** | Ausgehende E-Mails (Dev) | [mail.localhost](http://mail.localhost) | Direktzugang (keine Auth) |
+| **Claude Code KI** | KI-Status & MCP-Dashboard | [ai.localhost](http://ai.localhost) | MCP-Status-Dashboard |
+
+> **Produktion:** Ersetze `localhost` durch Deine konfigurierte Domain (z. B. `auth.meinunternehmen.de`). Die Domain wird in `.env` als `PROD_DOMAIN` gesetzt.
+
+---
+
+## Benutzer verwalten (Keycloak)
+
+Alle Benutzerkonten werden zentral in Keycloak gepflegt. Jede Änderung gilt sofort für alle Dienste (SSO).
+
+### Neuen Benutzer anlegen
+
+1. Öffne [auth.localhost/admin](http://auth.localhost/admin) → Realm **workspace**
+2. Navigiere zu **Benutzer** → **Benutzer hinzufügen**
+3. Felder ausfüllen:
+   - **Benutzername**: Kleinbuchstaben, kein Leerzeichen
+   - **E-Mail**: Pflichtfeld für Benachrichtigungen
+   - **Vorname / Nachname**
+4. Reiter **Zugangsdaten** → Temporäres Passwort vergeben (Benutzer muss es beim ersten Login ändern)
+5. Reiter **Gruppen** → Benutzer der passenden Gruppe zuweisen:
+   - `workspace-users` – normaler Mitarbeiter-Zugang
+   - `workspace-admins` – Administratorzugang (Website-Admin-Panel, erweiterte Rechte)
+
+### Passwort zurücksetzen
+
+1. Keycloak Admin → **Benutzer** → Benutzer auswählen
+2. Reiter **Zugangsdaten** → **Passwort zurücksetzen**
+3. Temporäres Passwort eingeben → **Temporär: Ja** → Speichern
+
+Der Benutzer wird beim nächsten Login aufgefordert, ein neues Passwort zu setzen.
+
+### Benutzer deaktivieren
+
+1. Keycloak Admin → **Benutzer** → Benutzer auswählen
+2. Reiter **Details** → **Aktiviert**: Schalter ausschalten → Speichern
+
+Der Benutzer kann sich sofort nicht mehr anmelden. Daten bleiben erhalten.
+
+---
+
+## Website-Admin-Panel
+
+Das Admin-Panel ist erreichbar unter [web.localhost/admin](http://web.localhost/admin) (Keycloak-Login mit `workspace-admins`-Gruppe erforderlich).
+
+### Verfügbare Admin-Bereiche
+
+| Bereich | Pfad | Funktion |
+|---------|------|----------|
+| **Startseite** | `/admin/startseite` | Startseiten-Texte und Hero-Bereich bearbeiten |
+| **Leistungen** | `/admin/angebote` | Dienstleistungen und Preise verwalten |
+| **Über mich** | `/admin/uebermich` | Profilseite bearbeiten |
+| **Referenzen** | `/admin/referenzen` | Kundenstimmen und Referenzen |
+| **FAQ** | `/admin/faq` | Häufig gestellte Fragen pflegen |
+| **Rechtliches** | `/admin/rechtliches` | Impressum, Datenschutz, AGB |
+| **Inbox** | `/admin/inbox` | Eingehende Kontaktanfragen |
+| **Nachrichten** | `/admin/nachrichten` | Direkte Nachrichten und Chat-Räume |
+| **Räume** | `/admin/raeume` | Chat-Räume verwalten |
+| **Kunden** | `/admin/clients` | Kundenverwaltung |
+| **Projekte** | `/admin/projekte` | Projektmanagement mit Gantt-Diagramm |
+| **Termine** | `/admin/termine` | Terminbuchungen und Kalender |
+| **Zeiterfassung** | `/admin/zeiterfassung` | Arbeitszeiterfassung |
+| **Rechnungen** | `/admin/rechnungen` | Rechnungen und Stripe-Zahlungen |
+| **Follow-ups** | `/admin/followups` | Wiedervorlagen und Erinnerungen |
+| **Meetings** | `/admin/meetings` | Aufgezeichnete Meetings und Transkripte |
+| **Kalender** | `/admin/kalender` | Kalenderübersicht |
+| **Monitoring** | `/admin/monitoring` | Live-Übersicht: Pod-Status und Ressourcen |
+| **Bugs** | `/admin/bugs` | Bug-Reports und Ticket-Tracking |
+
+### Kunden-Detail-Ansicht
+
+Unter `/admin/clients/{id}` ist eine umfassende Kundenübersicht verfügbar:
+- Kontaktdaten und Kommunikationshistorie
+- Zugehörige Projekte und Aufgaben
+- Offene und bezahlte Rechnungen
+- Direktnachrichten (DMs)
+- Gebuchte Leistungen
+
+---
+
+## Stripe-Zahlungen
+
+Stripe ist die Zahlungsplattform für Leistungen und Rechnungen. Zahlungen werden auf der Leistungen-Seite oder über den CTA der Homepage abgewickelt.
+
+**Einrichtung (einmalig):**
+```bash
+task workspace:stripe-setup
+```
+
+**Konfiguration:**
+- Stripe-Keys in `workspace-secrets` als Kubernetes Secret gespeichert
+- Webhook-Endpoint: `/api/stripe/webhook` (Ereignis: `checkout.session.completed`)
+- Zahlungsstatus in der Admin-Oberfläche unter `/admin/rechnungen`
+
+Weitere Details: [Stripe-Integration](stripe.md)
+
+---
+
+## Monitoring & Systemstatus
+
+### Live-Monitoring im Admin-Panel
+
+Das Admin-Panel unter [web.localhost/admin/monitoring](http://web.localhost/admin/monitoring) zeigt:
+- Status aller Kubernetes-Pods (laufend / fehler / neustart)
+- CPU- und RAM-Auslastung je Pod
+- Aktuelle Kubernetes-Events (Warnungen, Restarts)
+
+### Status über die Kommandozeile prüfen
+
+```bash
+task workspace:status          # Pods, Services, Ingress, PVCs
+task workspace:logs -- keycloak   # Logs eines Services anzeigen
+task workspace:logs -- nextcloud
+task workspace:logs -- website
+```
+
+### Service neustarten
+
+```bash
+task workspace:restart -- nextcloud    # Nextcloud neustarten
+task workspace:restart -- keycloak     # Keycloak neustarten
+task workspace:restart -- vaultwarden  # Vaultwarden neustarten
+```
+
+---
+
+## Backups
+
+Backups werden automatisch per Kubernetes CronJob erstellt (`k3d/backup-cronjob.yaml`).
+
+**Backup-Inhalt:**
+- PostgreSQL-Datenbank-Dumps (alle Datenbanken)
+- Nextcloud-Daten (Dateien)
+- Vaultwarden-Vault
+
+**Status prüfen:**
+```bash
+kubectl get cronjobs -n workspace
+kubectl get jobs -n workspace | grep backup
+```
+
+**Manuelles Backup auslösen:**
+```bash
+kubectl create job --from=cronjob/backup-job manual-backup-$(date +%Y%m%d) -n workspace
+```
+
+---
+
+## Häufige Aufgaben – Schnellreferenz
+
+| Aufgabe | Befehl / Ort |
+|---------|--------------|
+| Cluster starten | `task cluster:start` |
+| Alle Services deployen | `task workspace:deploy` |
+| Website neu bauen & deployen | `task website:redeploy` |
+| Post-Deploy-Setup (Nextcloud-Apps) | `task workspace:post-setup` |
+| Datenbankshell öffnen | `task workspace:psql -- website` |
+| Vaultwarden-Seed ausführen | `task workspace:vaultwarden:seed` |
+| DSGVO-Compliance prüfen | `task workspace:dsgvo-check` |
+| Alle Tests ausführen | `./tests/runner.sh local` |
+
+---
+
+## Häufig gestellte Fragen (Admin)
+
+### Ein Service startet nicht – wie debugge ich?
+
+```bash
+task workspace:logs -- <servicename>    # Logs anzeigen
+kubectl describe pod -n workspace -l app=<servicename>   # Events prüfen
+```
+
+Häufige Ursachen: Datenbankverbindung fehlgeschlagen, Secret nicht vorhanden, unzureichende Ressourcen.
+
+### Nextcloud friert ein oder reagiert langsam
+
+Nextcloud manchmal im Maintenance-Modus oder OPcache überlastet:
+```bash
+task workspace:restart -- nextcloud
+```
+
+Falls das nicht hilft: `task workspace:logs -- nextcloud` auf Datenbankfehler prüfen.
+
+### Keycloak-Login funktioniert nicht für einen Dienst
+
+1. Prüfe ob der Dienst als OIDC-Client in Keycloak registriert ist: [auth.localhost/admin](http://auth.localhost/admin) → Clients
+2. Prüfe die Redirect-URIs des Clients
+3. Dienst neustarten: `task workspace:restart -- <dienst>`
+
+### Wie füge ich eine neue Domain hinzu?
+
+1. `k3d/configmap-domains.yaml` und `prod/configmap-domains.yaml` anpassen
+2. Ingress-Regel in `k3d/ingress.yaml` ergänzen
+3. `task workspace:validate` ausführen
+4. PR erstellen und nach Merge deployen: `task workspace:deploy`
+
+### Wie aktualisiere ich die Dokumentation?
+
+Die Docs-Seite lädt Markdown-Dateien aus `docs/`. Nach einer Änderung:
+```bash
+# Nach PR-Merge auf main:
+kubectl patch configmap docs-content -n workspace --patch-file /dev/stdin <<EOF
+... (Inhalt aus CI/Deploy-Skript)
+EOF
+kubectl rollout restart deployment/docs -n workspace
+```
+
+Weitere Details: Siehe [Docs-Deployment Referenz](../memory/reference_docs_deployment.md).
+
+---
+
+## Weiterführende Dokumentation
+
+| Thema | Dokument |
+|-------|----------|
+| Systemarchitektur | [Architektur](architecture.md) |
+| Alle Services (technisch) | [Services](services.md) |
+| Keycloak & SSO konfigurieren | [Keycloak & SSO](keycloak.md) |
+| Datenbankmodelle | [Datenbankmodelle](database.md) |
+| Sicherheit & DSGVO | [Sicherheit](security.md) |
+| Datenschutz-Verarbeitungsverzeichnis | [Verarbeitungsverzeichnis (Art. 30)](verarbeitungsverzeichnis.md) |
+| Projektmanagement (API) | [Projektmanagement-Admin](admin-projekte.md) |
+| Stripe-Integration | [Stripe](stripe.md) |
+| Skripte & Automatisierung | [Skripte](scripts.md) |
+| Fehlerbehebung | [Fehlerbehebung](troubleshooting.md) |
+| Testframework | [Tests](tests.md) |
+| Claude Code MCP-Actions | [MCP Actions](mcp-actions.md) |

--- a/k3d/docs-content/benutzerhandbuch.md
+++ b/k3d/docs-content/benutzerhandbuch.md
@@ -1,16 +1,17 @@
 <div class="page-hero">
-  <span class="page-hero-icon">📋</span>
+  <span class="page-hero-icon">📖</span>
   <div class="page-hero-body">
     <div class="page-hero-title">Benutzerhandbuch</div>
-    <p class="page-hero-desc">Willkommen im Workspace — alles was Du brauchst, um sofort loszulegen. Chat, Dateien, Videokonferenzen, KI-Assistent und mehr, erklärt ohne technisches Vorwissen.</p>
+    <p class="page-hero-desc">Alle Werkzeuge des Workspace auf einen Blick – verständlich erklärt, ohne technisches Vorwissen.</p>
     <div class="page-hero-meta">
       <span class="page-hero-tag">Für Mitarbeiter</span>
-      <span class="page-hero-tag">Kein Vorwissen nötig</span>
-      <span class="page-hero-tag">Single Sign-On</span>
+      <span class="page-hero-tag">Einsteiger</span>
     </div>
   </div>
   <a href="#/" class="page-hero-back">← Übersicht</a>
 </div>
+
+# Benutzerhandbuch – Workspace
 
 Willkommen beim Workspace! Dieses Handbuch erklärt, welche Werkzeuge Dir zur Verfügung stehen, wofür Du sie nutzen kannst und wie Du einfache Aufgaben erledigst – ganz ohne technisches Vorwissen.
 
@@ -28,57 +29,57 @@ Du brauchst **nur einen einzigen Account** – mit diesem einen Login kommst Du 
 
 Alle Dienste sind über einen zentralen Login verbunden. Das bedeutet:
 
-- Du loggst Dich **einmal** ein – zum Beispiel in Mattermost.
-- Wenn Du dann Nextcloud, das Wiki oder den Passwort-Safe öffnest, bist Du dort **automatisch** angemeldet, ohne das Passwort erneut eingeben zu müssen.
+- Du loggst Dich **einmal** ein – zum Beispiel im Portal auf der Website.
+- Wenn Du dann Nextcloud, den Passwort-Safe oder die Dokumentation öffnest, bist Du dort **automatisch** angemeldet, ohne das Passwort erneut eingeben zu müssen.
 - Wenn Du Dich **abmeldest**, wirst Du aus allen Diensten gleichzeitig ausgeloggt.
 
 Dieser zentrale Login nennt sich **Single Sign-On (SSO)** und wird durch ein System namens Keycloak bereitgestellt.
 
 ---
 
-## Die Dienste im Überblick
+## Dienstübersicht mit Links
 
-### Schnellzugriff
+| Dienst | Beschreibung | Link (Entwicklung) |
+|--------|-------------|---------------------|
+| **Portal / Nachrichten** | Chat, Direktnachrichten, Dokumente | [web.localhost/portal](http://web.localhost/portal) |
+| **Dateien & Kalender** | Cloud-Speicher, Kalender, Kontakte | [files.localhost](http://files.localhost) |
+| **Videokonferenz** | Meetings & Sprachanrufe (in Nextcloud) | [files.localhost](http://files.localhost) → Talk |
+| **Dokumente** | Gemeinsame Office-Bearbeitung | Öffnet sich aus Nextcloud heraus |
+| **Whiteboard** | Digitales Whiteboard | [board.localhost](http://board.localhost) |
+| **KI-Assistent** | Claude AI-Status & MCP-Dashboard | [ai.localhost](http://ai.localhost) |
+| **Passwort-Safe** | Sichere Passwortverwaltung | [vault.localhost](http://vault.localhost) |
+| **Dokumentation** | Dieses Handbuch und weitere Docs | [docs.localhost](http://docs.localhost) |
 
-| Dienst | korczewski.de | mentolder.de |
-|--------|--------------|--------------|
-| Chat (Mattermost) | [chat.korczewski.de](https://chat.korczewski.de) | [chat.mentolder.de](https://chat.mentolder.de) |
-| Dateien & Kalender (Nextcloud) | [files.korczewski.de](https://files.korczewski.de) | [files.mentolder.de](https://files.mentolder.de) |
-| Videokonferenz (Nextcloud Talk) | [meet.korczewski.de](https://meet.korczewski.de) | [meet.mentolder.de](https://meet.mentolder.de) |
-| Whiteboard | [board.korczewski.de](https://board.korczewski.de) | [board.mentolder.de](https://board.mentolder.de) |
-| KI-Assistent (Claude) | [ai.korczewski.de](https://ai.korczewski.de) | [ai.mentolder.de](https://ai.mentolder.de) |
-| Wissensdatenbank (Outline) | [wiki.korczewski.de](https://wiki.korczewski.de) | [wiki.mentolder.de](https://wiki.mentolder.de) |
-| Dokumentation (Handbuch) | [docs.korczewski.de](https://docs.korczewski.de) | [docs.mentolder.de](https://docs.mentolder.de) |
-| Passwort-Safe (Vaultwarden) | [vault.korczewski.de](https://vault.korczewski.de) | [vault.mentolder.de](https://vault.mentolder.de) |
-| Rechnungen (Invoice Ninja) | [billing.korczewski.de](https://billing.korczewski.de) | [billing.mentolder.de](https://billing.mentolder.de) |
-| Login-Verwaltung (Keycloak) | [auth.korczewski.de](https://auth.korczewski.de) | [auth.mentolder.de](https://auth.mentolder.de) |
+> In der Produktivumgebung ersetze `localhost` durch die Unternehmens-Domain (z. B. `files.meinunternehmen.de`).
 
 ---
 
-### Chat (Mattermost)
+## Die Dienste im Überblick
 
-**Öffnen:** [chat.korczewski.de](https://chat.korczewski.de) · [chat.mentolder.de](https://chat.mentolder.de)
+### Nachrichten & Chat (Portal)
 
-**Wozu?** Schreiben, Diskutieren, Teamkommunikation – wie WhatsApp, aber für die Arbeit und sicher auf Deinen eigenen Servern.
+**Wozu?** Schreiben, Diskutieren, Teamkommunikation – direkt im Benutzerportal der Unternehmenswebsite.
+
+**Zugang:** [web.localhost/portal](http://web.localhost/portal) → Nach dem Login automatisch verfügbar
 
 **Was kannst Du tun?**
-- Nachrichten in Kanälen (themenbasierten Gruppen) schreiben
-- Private Direktnachrichten an einzelne Kollegen senden
-- Dateien direkt in den Chat hochladen und teilen
-- Auf Nachrichten mit Emojis reagieren
-- Benachrichtigungen erhalten, wenn Dich jemand erwähnt (`@deinname`)
+- Nachrichten in **Räumen** (themenbasierte Gruppen) schreiben und lesen
+- **Direktnachrichten** an einzelne Kollegen oder Kunden senden
+- Ungelesene Nachrichten werden automatisch durch Benachrichtigungen markiert
+- Eingegangene Anfragen (Kontaktformulare, Buchungen) in der **Inbox** sehen
 
-**Tipps:**
-- Klicke links auf **"+"** um einem neuen Kanal beizutreten oder einen zu erstellen
-- Mit **`/billing`** kannst Du Rechnungen direkt aus dem Chat erstellen (mehr dazu weiter unten)
+**Räume:**
+1. Klicke im Portal auf **„Nachrichten"**
+2. Wähle einen vorhandenen Raum oder erstelle einen neuen
+3. Schreibe Deine Nachricht und sende sie ab
 
 ---
 
 ### Dateien & Kalender (Nextcloud)
 
-**Öffnen:** [files.korczewski.de](https://files.korczewski.de) · [files.mentolder.de](https://files.mentolder.de)
-
 **Wozu?** Dein persönlicher Cloud-Speicher im Büro – wie Dropbox, aber sicher auf Deinen eigenen Servern.
+
+**Zugang:** [files.localhost](http://files.localhost)
 
 **Was kannst Du tun?**
 - Dateien hochladen, herunterladen und mit Kollegen teilen
@@ -88,7 +89,7 @@ Dieser zentrale Login nennt sich **Single Sign-On (SSO)** und wird durch ein Sys
 - Kontakte verwalten
 
 **Dateien teilen:**
-1. Rechtsklick auf eine Datei oder einen Ordner → **"Teilen"**
+1. Rechtsklick auf eine Datei oder einen Ordner → **„Teilen"**
 2. Namen des Kollegen eingeben
 3. Berechtigungen festlegen (nur lesen / auch bearbeiten)
 
@@ -96,9 +97,9 @@ Dieser zentrale Login nennt sich **Single Sign-On (SSO)** und wird durch ein Sys
 
 ### Dokumente gemeinsam bearbeiten (Collabora Online Office)
 
-**Öffnen:** Direkt aus Nextcloud heraus – kein separater Link nötig.
-
 **Wozu?** Word, Excel und PowerPoint direkt im Browser bearbeiten – kein separates Programm nötig.
+
+**Zugang:** Öffnet sich automatisch aus [Nextcloud](http://files.localhost) heraus – keine eigene Adresse nötig.
 
 **Was kannst Du tun?**
 - Neue Textdokumente, Tabellen oder Präsentationen erstellen
@@ -106,9 +107,9 @@ Dieser zentrale Login nennt sich **Single Sign-On (SSO)** und wird durch ein Sys
 - Gleichzeitig mit Kollegen am selben Dokument arbeiten – Du siehst in Echtzeit, was andere tippen
 
 **So öffnest Du ein Dokument:**
-1. Gehe zu **Nextcloud** (Dateien)
+1. Gehe zu **Nextcloud** ([files.localhost](http://files.localhost))
 2. Klicke auf eine Datei – sie öffnet sich automatisch im Editor
-3. Oder: Klicke auf **"+"** → **"Neues Dokument"**, um von vorne anzufangen
+3. Oder: Klicke auf **„+"** → **„Neues Dokument"**, um von vorne anzufangen
 
 > Collabora ist direkt in Nextcloud eingebettet. Du musst keine separate Webseite öffnen.
 
@@ -116,9 +117,9 @@ Dieser zentrale Login nennt sich **Single Sign-On (SSO)** und wird durch ein Sys
 
 ### Videokonferenz (Nextcloud Talk)
 
-**Öffnen:** [meet.korczewski.de](https://meet.korczewski.de) · [meet.mentolder.de](https://meet.mentolder.de)
-
 **Wozu?** Video- und Sprachanrufe direkt im Browser – wie Zoom oder Teams, aber auf Deinen eigenen Servern.
+
+**Zugang:** [files.localhost](http://files.localhost) → **Talk** (linke Seitenleiste)
 
 **Was kannst Du tun?**
 - Einzelgespräche oder Gruppenmeetings starten
@@ -128,7 +129,7 @@ Dieser zentrale Login nennt sich **Single Sign-On (SSO)** und wird durch ein Sys
 
 **Meeting starten:**
 1. Gehe zu Nextcloud Talk
-2. Klicke auf **"+ Neues Gespräch erstellen"**
+2. Klicke auf **„+ Neues Gespräch erstellen"**
 3. Vergib einen Namen und füge Teilnehmer hinzu
 4. Starte den Anruf über das **Kamera-Symbol**
 
@@ -136,23 +137,11 @@ Dieser zentrale Login nennt sich **Single Sign-On (SSO)** und wird durch ein Sys
 
 ---
 
-### Live-Transkription (Talk Transcriber)
-
-**Wozu?** Automatische Mitschrift laufender Videokonferenzen – der Dienst wandelt gesprochene Sprache in Text um, während das Meeting läuft.
-
-**Was kannst Du tun?**
-- Einen laufenden Nextcloud-Talk-Anruf automatisch transkribieren lassen
-- Die Mitschrift nach dem Meeting als Textdatei abrufen
-
-> Der Dienst arbeitet im Hintergrund und ist in Nextcloud Talk integriert.
-
----
-
 ### Whiteboard
 
-**Öffnen:** [board.korczewski.de](https://board.korczewski.de) · [board.mentolder.de](https://board.mentolder.de)
-
 **Wozu?** Gemeinsam skizzieren, brainstormen und visualisieren – wie ein digitales Whiteboard in einer Besprechung.
+
+**Zugang:** [board.localhost](http://board.localhost)
 
 **Was kannst Du tun?**
 - Freihand zeichnen, Formen und Text einfügen
@@ -163,9 +152,9 @@ Dieser zentrale Login nennt sich **Single Sign-On (SSO)** und wird durch ein Sys
 
 ### KI-Assistent (Claude)
 
-**Öffnen:** [ai.korczewski.de](https://ai.korczewski.de) · [ai.mentolder.de](https://ai.mentolder.de)
-
 **Wozu?** Ein intelligenter Assistent, der Dir bei Texten, Fragen und Aufgaben hilft.
+
+**Zugang:** [ai.localhost](http://ai.localhost) (Status-Dashboard) – Claude Code wird lokal auf dem Rechner des Administrators ausgeführt.
 
 **Was kannst Du tun?**
 - Texte verfassen lassen (E-Mails, Zusammenfassungen, Berichte)
@@ -174,50 +163,19 @@ Dieser zentrale Login nennt sich **Single Sign-On (SSO)** und wird durch ein Sys
 - Daten zusammenfassen
 
 **Beispiel-Fragen:**
-- *"Schreibe eine freundliche Absage-E-Mail auf Deutsch."*
-- *"Fasse mir diesen Text in drei Sätzen zusammen."*
-- *"Was ist der Unterschied zwischen einer GmbH und einer UG?"*
+- *„Schreibe eine freundliche Absage-E-Mail auf Deutsch."*
+- *„Fasse mir diesen Text in drei Sätzen zusammen."*
+- *„Was ist der Unterschied zwischen einer GmbH und einer UG?"*
 
 > Der KI-Assistent ist nur für den Einsatz im internen Kontext gedacht. Gib keine sensiblen Kundendaten ein.
 
 ---
 
-### Wissensdatenbank / Wiki (Outline)
-
-**Öffnen:** [wiki.korczewski.de](https://wiki.korczewski.de) · [wiki.mentolder.de](https://wiki.mentolder.de)
-
-**Wozu?** Das interne Nachschlagewerk des Teams – Anleitungen, Prozesse, Wissen aufschreiben und für alle zugänglich machen.
-
-**Was kannst Du tun?**
-- Neue Seiten und Artikel anlegen
-- Seiten in Sammlungen (Ordner) organisieren
-- Andere Teammitglieder zum gemeinsamen Bearbeiten einladen
-- Die Volltextsuche nutzen, um schnell etwas zu finden
-
-**Neue Seite anlegen:**
-1. Klicke links auf eine Sammlung oder erstelle eine neue
-2. Klicke auf **"Neue Seite"**
-3. Schreibe Deinen Inhalt und speichere
-
----
-
-### Dokumentation & Handbuch
-
-**Öffnen:** [docs.korczewski.de](https://docs.korczewski.de) · [docs.mentolder.de](https://docs.mentolder.de)
-
-**Wozu?** Das technische und organisatorische Handbuch des Workspace – Installationsanleitungen, Architektur, Dienst-Beschreibungen und Fehlerbehebung.
-
-**Zugriff:** Die Dokumentation ist nur für angemeldete Benutzer zugänglich. Du wirst beim Öffnen automatisch zur Keycloak-Anmeldung weitergeleitet.
-
-> Dieses Handbuch, das Du gerade liest, läuft selbst auf dem Docs-Dienst.
-
----
-
 ### Passwort-Safe (Vaultwarden)
 
-**Öffnen:** [vault.korczewski.de](https://vault.korczewski.de) · [vault.mentolder.de](https://vault.mentolder.de)
-
 **Wozu?** Passwörter sicher speichern und im Team teilen – auf Deinen eigenen Servern, nicht bei einem externen Anbieter.
+
+**Zugang:** [vault.localhost](http://vault.localhost)
 
 **Was kannst Du tun?**
 - Passwörter und Zugangsdaten sicher verwahren
@@ -228,27 +186,6 @@ Dieser zentrale Login nennt sich **Single Sign-On (SSO)** und wird durch ein Sys
 > Vaultwarden ist kompatibel mit dem **Bitwarden**-Browser-Plugin, das Du Dir kostenlos installieren kannst.
 
 **Wichtig:** Du brauchst ein eigenes **Master-Passwort** für den Passwort-Safe. Dieses ist unabhängig von Deinem normalen Workspace-Passwort und sollte besonders sicher sein – schreib es Dir auf und verwahre es gut.
-
----
-
-### Rechnungen (Invoice Ninja)
-
-**Öffnen:** [billing.korczewski.de](https://billing.korczewski.de) · [billing.mentolder.de](https://billing.mentolder.de)
-
-**Wozu?** Rechnungen erstellen, Kunden verwalten und Zahlungen nachverfolgen.
-
-**Was kannst Du tun?**
-- Neue Kunden anlegen
-- Rechnungen erstellen und per E-Mail versenden
-- Den Status von Rechnungen einsehen (offen, bezahlt, überfällig)
-- Zahlungen per Stripe verarbeiten
-
-**Rechnungen aus dem Chat erstellen:**
-Tippe in Mattermost einfach:
-```
-/billing invoice Kundenname
-```
-Der Billing-Bot erstellt die Rechnung automatisch und schickt Dir den Link.
 
 ---
 
@@ -264,10 +201,11 @@ Nein. Alle Dienste haben gültige Sicherheitszertifikate. Eine Warnung ist ein Z
 
 ### Kann ich die Dienste auch auf dem Smartphone nutzen?
 
-Ja. Die meisten Dienste haben Apps:
-- **Mattermost**: App für iOS und Android verfügbar
+Ja. Mehrere Dienste haben offizielle Apps:
 - **Nextcloud**: App für iOS und Android verfügbar (Dateien, Kalender, Talk)
 - **Vaultwarden**: Bitwarden-App für iOS und Android kompatibel
+
+Das Portal und die meisten anderen Dienste sind außerdem als responsive Website im mobilen Browser nutzbar.
 
 ### Wer hat Zugriff auf meine Dateien und Nachrichten?
 
@@ -279,21 +217,19 @@ Ja – das ist genau der Zweck. Da alle Daten auf Deinen eigenen Servern liegen 
 
 ### Etwas funktioniert nicht – an wen wende ich mich?
 
-Schreibe eine Nachricht im Mattermost-Kanal des Administrators oder schicke eine E-Mail an den Systemverantwortlichen.
+Schreibe eine Nachricht im Portal-Chat an den Administrator oder schicke eine E-Mail an den Systemverantwortlichen. In der Produktivumgebung steht auch ein Bug-Report-Formular unter `/admin/bugs` bereit.
 
 ---
 
 ## Kurzübersicht: Welcher Dienst wofür?
 
-| Ich möchte…                                  | Dienst               |
-|----------------------------------------------|----------------------|
-| Eine Nachricht an einen Kollegen schicken     | **Mattermost**       |
-| Eine Datei teilen                             | **Nextcloud**        |
-| Gemeinsam an einem Dokument arbeiten          | **Nextcloud + Collabora** |
-| Ein Meeting starten                           | **Nextcloud Talk**   |
-| Ideen gemeinsam aufzeichnen                   | **Whiteboard**       |
-| Eine KI fragen                                | **Claude**           |
-| Wissen im Team festhalten                     | **Outline (Wiki)**   |
-| Ein Passwort sicher aufbewahren               | **Vaultwarden**      |
-| Eine Rechnung erstellen                       | **Invoice Ninja**    |
-| Eine Besprechung automatisch transkribieren lassen | **Nextcloud Talk + Talk Transcriber** |
+| Ich möchte…                                  | Dienst                    | Link |
+|----------------------------------------------|---------------------------|------|
+| Eine Nachricht an einen Kollegen schicken     | **Portal – Nachrichten**  | [Portal](http://web.localhost/portal) |
+| Eine Datei teilen                             | **Nextcloud**             | [files.localhost](http://files.localhost) |
+| Gemeinsam an einem Dokument arbeiten          | **Nextcloud + Collabora** | [files.localhost](http://files.localhost) |
+| Ein Meeting starten                           | **Nextcloud Talk**        | [files.localhost](http://files.localhost) |
+| Ideen gemeinsam aufzeichnen                   | **Whiteboard**            | [board.localhost](http://board.localhost) |
+| Eine KI fragen                                | **Claude**                | [ai.localhost](http://ai.localhost) |
+| Ein Passwort sicher aufbewahren               | **Vaultwarden**           | [vault.localhost](http://vault.localhost) |
+| Diese Dokumentation lesen                     | **Docs**                  | [docs.localhost](http://docs.localhost) |

--- a/k3d/docs-content/database.md
+++ b/k3d/docs-content/database.md
@@ -79,7 +79,7 @@ erDiagram
         text        insight_type
         text        content
         text        generated_by
-        text        outline_document_id
+        text        doc_reference
         timestamptz created_at
     }
 

--- a/k3d/docs-content/migration.md
+++ b/k3d/docs-content/migration.md
@@ -31,7 +31,7 @@ flowchart LR
     end
 
     subgraph Ziele ["fa:fa-bullseye Ziele"]
-        MM["fa:fa-comments Mattermost<br/>Chat + Kanaele"]
+        MSG["fa:fa-comments Website Messaging<br/>Chat-Räume + Inbox"]
         NC["fa:fa-cloud Nextcloud<br/>Dateien + Kalender + Kontakte"]
         KC["fa:fa-key Keycloak<br/>Benutzerkonten"]
     end
@@ -41,7 +41,7 @@ flowchart LR
     GO --> M
     CSV --> M
 
-    M --> MM
+    M --> MSG
     M --> NC
     M --> KC
 
@@ -50,7 +50,7 @@ flowchart LR
     style GO fill:#1a3d28,color:#e8c870
     style CSV fill:#1f2937,color:#aabbcc
     style M fill:#1a1a2e,color:#aabbcc
-    style MM fill:#1a3d28,color:#e8c870
+    style MSG fill:#1a3d28,color:#e8c870
     style NC fill:#083344,color:#e8c870
     style KC fill:#1b3766,color:#e8c870
 ```
@@ -74,41 +74,41 @@ scripts/migrate.sh --dry-run
 
 | # | Aktion | Quelle | Ziel |
 |---|--------|--------|------|
-| 1 | Slack importieren | Slack Export ZIP | Mattermost (JSONL Bulk Import) |
-| 2 | Teams importieren | GDPR-Export oder lokaler Cache | Mattermost + Nextcloud |
-| 3 | Google importieren | Google Takeout | Mattermost + Nextcloud |
+| 1 | Slack importieren | Slack Export ZIP | Website Messaging (Chat-Räume via API) |
+| 2 | Teams importieren | GDPR-Export oder lokaler Cache | Website Messaging + Nextcloud |
+| 3 | Google importieren | Google Takeout | Website Messaging + Nextcloud |
 | 4 | Benutzer importieren | CSV oder LDIF | Keycloak |
-| 5 | Daten exportieren | Mattermost + Nextcloud + Keycloak | ZIP-Archiv |
+| 5 | Daten exportieren | Website Messaging + Nextcloud + Keycloak | ZIP-Archiv |
 | 6 | Server konfigurieren | -- | Verbindungsdaten setzen |
 | 7 | Quellen scannen | Lokales System | Erkennung vorhandener Exporte |
 
 ## Import-Details
 
-### Slack nach Mattermost
+### Slack nach Website Messaging
 
 **Skript:** `scripts/lib/slack-import.sh`
 
 - Akzeptiert Slack Export ZIP oder entpacktes Verzeichnis
-- Konvertiert zu Mattermost JSONL Bulk Import Format
+- Konvertiert Channels zu Chat-Räumen, Direktnachrichten zu DMs im Website-Messaging
 - Wandelt um: Channels, Benutzer, Nachrichten, Threads, Mentions, Links
-- Upload via `mmctl`
+- Import via Website-API (`/api/messaging/import`)
 
-### Microsoft Teams nach Mattermost + Nextcloud
+### Microsoft Teams nach Website Messaging + Nextcloud
 
 **Skript:** `scripts/lib/teams-import.sh`
 
 - Unterstuetzt GDPR-Datenexport (myaccount.microsoft.com) und lokalen Teams-Cache
 - Erkennt Export-Typ automatisch
-- Chat-Nachrichten nach Mattermost (JSONL)
+- Chat-Nachrichten nach Website Messaging (Chat-Räume)
 - Dateien nach Nextcloud (WebDAV)
 - Kalender nach .ics, Kontakte nach .vcf
 
-### Google Workspace nach Mattermost + Nextcloud
+### Google Workspace nach Website Messaging + Nextcloud
 
 **Skript:** `scripts/lib/google-import.sh`
 
 - Google Takeout Export (takeout.google.com)
-- Google Chat nach Mattermost (JSONL)
+- Google Chat nach Website Messaging (Chat-Räume)
 - Drive nach Nextcloud (WebDAV)
 - Kalender nach Nextcloud Calendar (CalDAV)
 - Kontakte nach Nextcloud Contacts (CardDAV)
@@ -144,7 +144,7 @@ Erstellt fehlende Gruppen automatisch. Setzt temporaere Passwoerter (Aenderung b
 
 Option 5 im Migrations-Assistenten erstellt ein ZIP-Archiv mit selektiv exportierten Daten:
 
-- **Mattermost:** Nachrichten (JSONL via mmctl/API), Dateien (aus Volume)
+- **Website Messaging:** Nachrichten und Räume (JSON via API)
 - **Nextcloud:** Dateien (WebDAV), Kalender (CalDAV/iCal), Kontakte (CardDAV/vCard)
 - **Keycloak:** Benutzer (CSV + LDIF), Realm-Konfiguration (JSON)
 
@@ -157,7 +157,6 @@ Option 5 im Migrations-Assistenten erstellt ein ZIP-Archiv mit selektiv exportie
 Scannt automatisch typische Speicherorte fuer vorhandene Exporte:
 - Slack: Cache und Download-Verzeichnisse
 - Teams: lokaler Cache und GDPR-Exporte
-- Mattermost: bestehende Installationen
 - Nextcloud: Desktop-Client-Synchronisierung
 - Google Takeout: Download-Verzeichnisse
 

--- a/k3d/docs-content/verarbeitungsverzeichnis.md
+++ b/k3d/docs-content/verarbeitungsverzeichnis.md
@@ -40,14 +40,14 @@
 
 | Feld | Wert |
 |------|------|
-| **Zweck** | Interne Kommunikation zwischen Teammitgliedern |
+| **Zweck** | Interne Kommunikation zwischen Teammitgliedern sowie zwischen Kunden und Administratoren |
 | **Rechtsgrundlage** | Art. 6 Abs. 1 lit. b DSGVO (Vertragserfüllung) |
-| **Betroffene Personen** | Nutzer der Mattermost-Instanz |
-| **Datenkategorien** | Nachrichteninhalte, Zeitstempel, Absender-User-ID, Kanal-Zugehörigkeit, Anhänge |
-| **Empfänger** | Keine Dritten — On-Premises (Mattermost im `workspace`-Namespace) |
+| **Betroffene Personen** | Registrierte Nutzer des Website-Portals (Mitarbeiter und Kunden) |
+| **Datenkategorien** | Nachrichteninhalte, Zeitstempel, Absender-User-ID, Raum-Zugehörigkeit, Gelesen-Status |
+| **Empfänger** | Keine Dritten — On-Premises (Messaging-System im `website`-Namespace, PostgreSQL `shared-db`) |
 | **Drittlandübermittlung** | Keine |
-| **Speicherdauer** | Konfigurierbar (Standard: unbegrenzt); auf Anfrage (Art. 17) löschbar |
-| **Technische Schutzmaßnahmen** | TLS in Transit, Keycloak OIDC SSO, NetworkPolicy-Isolation, Audit-Log `/api/v4/audits` |
+| **Speicherdauer** | Auf Anfrage (Art. 17) löschbar; ansonsten unbegrenzt gespeichert |
+| **Technische Schutzmaßnahmen** | TLS in Transit, Keycloak OIDC SSO, NetworkPolicy-Isolation, Zugriff nur nach Authentifizierung |
 
 ---
 
@@ -74,25 +74,25 @@
 | **Rechtsgrundlage** | Art. 6 Abs. 1 lit. b DSGVO (Durchführung vorvertraglicher Maßnahmen) |
 | **Betroffene Personen** | Interessenten und Auftraggeber (Website-Besucher) |
 | **Datenkategorien** | Name, E-Mail-Adresse, gewählter Termin/Zeitslot, optionale Nachricht |
-| **Empfänger** | Keine Dritten — Weiterleitung intern via Mattermost-Webhook; CalDAV-Eintrag in Nextcloud |
+| **Empfänger** | Keine Dritten — Weiterleitung intern in die Admin-Inbox (`/admin/termine`); CalDAV-Eintrag in Nextcloud |
 | **Drittlandübermittlung** | Keine |
 | **Speicherdauer** | 3 Jahre (handelsrechtliche Aufbewahrungsfrist für vorvertragliche Korrespondenz) |
-| **Technische Schutzmaßnahmen** | TLS in Transit, Mattermost-Webhook nur intern erreichbar (NetworkPolicy), keine externe Weitergabe |
+| **Technische Schutzmaßnahmen** | TLS in Transit, Keycloak OIDC SSO für Admin-Zugriff, NetworkPolicy-Isolation, keine externe Weitergabe |
 
 ---
 
-## VT-05: Rechnungsstellung und Buchführung
+## VT-05: Rechnungsstellung und Zahlungsabwicklung
 
 | Feld | Wert |
 |------|------|
-| **Zweck** | Erstellung, Verwaltung und Archivierung von Rechnungen |
-| **Rechtsgrundlage** | Art. 6 Abs. 1 lit. c DSGVO (rechtliche Verpflichtung: § 257 HGB, § 14 UStG) |
-| **Betroffene Personen** | Auftraggeber (Rechnungsempfänger) |
-| **Datenkategorien** | Name, Unternehmensname, Rechnungsadresse, E-Mail, Leistungsbeschreibung, Beträge, Rechnungsnummer, Datum |
-| **Empfänger** | Keine Dritten — On-Premises (Invoice Ninja im `workspace`-Namespace) |
-| **Drittlandübermittlung** | Keine |
+| **Zweck** | Erstellung, Verwaltung und Archivierung von Rechnungen sowie Abwicklung von Online-Zahlungen |
+| **Rechtsgrundlage** | Art. 6 Abs. 1 lit. c DSGVO (rechtliche Verpflichtung: § 257 HGB, § 14 UStG); Art. 6 Abs. 1 lit. b (Vertragserfüllung) |
+| **Betroffene Personen** | Auftraggeber (Rechnungsempfänger, Zahlende) |
+| **Datenkategorien** | Name, Unternehmensname, Rechnungsadresse, E-Mail, Leistungsbeschreibung, Beträge, Rechnungsnummer, Datum; Stripe-Checkout-Sitzungs-ID |
+| **Empfänger** | Rechnungsdaten: On-Premises (Website `website`-Namespace, PostgreSQL). Zahlungsabwicklung: **Stripe Inc.** (Auftragsverarbeiter gemäß Art. 28 DSGVO, EU-Standardvertragsklauseln) |
+| **Drittlandübermittlung** | Stripe: Datenübertragung in die USA auf Basis von EU-Standardvertragsklauseln (SCC) |
 | **Speicherdauer** | 10 Jahre (§ 257 HGB — gesetzliche Aufbewahrungspflicht für Buchungsbelege) |
-| **Technische Schutzmaßnahmen** | TLS in Transit, Keycloak OIDC SSO + OAuth2-Proxy, Rate-Limiting (30 req/s), NetworkPolicy-Isolation |
+| **Technische Schutzmaßnahmen** | TLS in Transit, Keycloak OIDC SSO für Admin-Zugriff, Stripe Hosted Checkout (keine Kartenddaten on-premises), Webhook-Signaturprüfung |
 
 ---
 
@@ -104,10 +104,10 @@
 | **Rechtsgrundlage** | Art. 6 Abs. 1 lit. b DSGVO (vorvertragliche Maßnahmen), hilfsweise Art. 6 Abs. 1 lit. f (berechtigtes Interesse an Anfragenbearbeitung) |
 | **Betroffene Personen** | Website-Besucher, die das Kontaktformular nutzen |
 | **Datenkategorien** | Name, E-Mail-Adresse, Nachrichteninhalt |
-| **Empfänger** | Keine Dritten — Weiterleitung intern via Mattermost-Webhook in den Kanal `anfragen` |
+| **Empfänger** | Keine Dritten — Weiterleitung intern in die Admin-Inbox (`/admin/inbox`, PostgreSQL `website`-Datenbank) |
 | **Drittlandübermittlung** | Keine |
 | **Speicherdauer** | 3 Jahre (Verjährungsfrist für Ansprüche aus vorvertraglichen Verhältnissen, § 195 BGB) |
-| **Technische Schutzmaßnahmen** | TLS in Transit, Mattermost-Webhook nur intern erreichbar, keine Speicherung in externer Datenbank |
+| **Technische Schutzmaßnahmen** | TLS in Transit, Keycloak OIDC SSO für Admin-Zugriff auf Inbox, keine Speicherung in externer Datenbank, NetworkPolicy-Isolation |
 
 ---
 
@@ -117,4 +117,8 @@ Es findet **keine Übermittlung personenbezogener Daten in Drittländer** (auße
 
 ## Auftragsverarbeiter
 
-Keine Auftragsverarbeiter (Art. 28 DSGVO) — die Verarbeitung erfolgt vollständig durch den Verantwortlichen selbst auf eigener Infrastruktur.
+| Auftragsverarbeiter | Sitz | Zweck | Rechtsgrundlage |
+|---------------------|------|-------|-----------------|
+| **Stripe Inc.** | USA (EU-Niederlassung: Irland) | Online-Zahlungsabwicklung (Kreditkarte, SEPA) | EU-Standardvertragsklauseln (SCC) gem. Art. 46 Abs. 2 lit. c DSGVO |
+
+Alle übrigen Verarbeitungen erfolgen vollständig durch den Verantwortlichen selbst auf eigener On-Premises-Infrastruktur (kein weiterer Auftragsverarbeiter).

--- a/k3d/kustomization.yaml
+++ b/k3d/kustomization.yaml
@@ -83,6 +83,7 @@ configMapGenerator:
       - docs-content/architecture.md
       - docs-content/database.md
       - docs-content/benutzerhandbuch.md
+      - docs-content/adminhandbuch.md
       - docs-content/keycloak.md
       - docs-content/mcp-actions.md
       - docs-content/migration.md


### PR DESCRIPTION
## Summary

- **Neues Admin-Handbuch** (`adminhandbuch.md`): Dienstübersicht mit Links, Keycloak-Benutzerverwaltung, Website-Admin-Panel-Übersicht, Monitoring, Backups, Schnellreferenz
- **Benutzerhandbuch aktualisiert**: Mattermost → Website Messaging, Invoice Ninja und Outline entfernt, Service-Links bei jedem Dienst ergänzt
- **Verarbeitungsverzeichnis bereinigt**: VT-02/04/05/06 referenzieren jetzt Website Messaging und Stripe statt Mattermost/Invoice Ninja; Stripe als Auftragsverarbeiter korrekt eingetragen (SCC)
- **migration.md**: Mattermost in Flowchart, Tabelle und Import-Details durch Website Messaging ersetzt
- **database.md**: `outline_document_id` → `doc_reference` (Outline ist nicht mehr deployed)
- **k3d/docs-content/** synchronisiert; `adminhandbuch.md` zur kustomization.yaml hinzugefügt

## Test plan

- [ ] `task workspace:validate` ✅ (bereits geprüft)
- [ ] Docs-Seite nach Merge deployen: `kubectl patch configmap docs-content ... && kubectl rollout restart deployment/docs -n workspace`

🤖 Generated with [Claude Code](https://claude.com/claude-code)