### PR TITLE
feat: add delete, cancel, confirm, and reminder actions to admin/termine

### DIFF
--- a/website/src/lib/caldav.ts
+++ b/website/src/lib/caldav.ts
@@ -326,6 +326,52 @@ export async function getAvailableSlots(fromDate?: Date, brand?: string): Promis
   return result;
 }
 
+async function findEventUrl(uid: string): Promise<string | null> {
+  const rawUid = uid.replace(/@.+$/, '');
+  const url = `${CALDAV_BASE}/${rawUid}.ics`;
+  try {
+    const res = await fetch(url, { method: 'HEAD', headers: { Authorization: getAuthHeader() } });
+    if (res.ok) return url;
+  } catch {}
+  return null;
+}
+
+export async function deleteCalendarEvent(uid: string): Promise<boolean> {
+  const url = await findEventUrl(uid);
+  if (!url) return false;
+  try {
+    const res = await fetch(url, { method: 'DELETE', headers: { Authorization: getAuthHeader() } });
+    return res.ok || res.status === 204;
+  } catch (err) {
+    console.error('[caldav] Delete event error:', err);
+    return false;
+  }
+}
+
+export async function updateCalendarEventStatus(uid: string, status: 'CANCELLED' | 'CONFIRMED'): Promise<boolean> {
+  const url = await findEventUrl(uid);
+  if (!url) return false;
+  try {
+    const getRes = await fetch(url, { headers: { Authorization: getAuthHeader() } });
+    if (!getRes.ok) return false;
+    let ical = await getRes.text();
+    if (/STATUS:/i.test(ical)) {
+      ical = ical.replace(/STATUS:[^\r\n]+/i, `STATUS:${status}`);
+    } else {
+      ical = ical.replace(/END:VEVENT/, `STATUS:${status}\r\nEND:VEVENT`);
+    }
+    const putRes = await fetch(url, {
+      method: 'PUT',
+      headers: { Authorization: getAuthHeader(), 'Content-Type': 'text/calendar; charset=utf-8' },
+      body: ical,
+    });
+    return putRes.ok || putRes.status === 204;
+  } catch (err) {
+    console.error('[caldav] Update event status error:', err);
+    return false;
+  }
+}
+
 // Create a calendar event in Nextcloud
 export async function createCalendarEvent(params: {
   summary: string;

--- a/website/src/pages/admin/termine.astro
+++ b/website/src/pages/admin/termine.astro
@@ -127,7 +127,7 @@ function formatTime(d: Date) {
               {upcomingBookings.map(b => {
                 const inv = bookingInvoiceMap.get(b.uid);
                 return (
-                  <div class="p-4 bg-dark-light rounded-xl border border-dark-lighter" data-booking-uid={b.uid}>
+                  <div class="p-4 bg-dark-light rounded-xl border border-dark-lighter" data-booking-uid={b.uid} data-booking-summary={b.summary} data-booking-attendee-email={b.attendeeEmail} data-booking-attendee-name={b.attendeeName} data-booking-date={formatBookingDate(b.start)} data-booking-time={`${formatTime(b.start)} – ${formatTime(b.end)}`}>
                     <div class="flex items-start justify-between gap-4 flex-wrap">
                       <div>
                         <p class="text-light font-medium">{b.summary}</p>
@@ -180,9 +180,39 @@ function formatTime(d: Date) {
                               #{inv.invoiceNumber} · {inv.amount.toFixed(0)} EUR
                             </span>
                         )}
-                        <span class={`text-xs px-2 py-0.5 rounded-full ${b.status === 'TENTATIVE' ? 'bg-gold/20 text-gold' : 'bg-accent/20 text-accent'}`}>
+                        <span class={`booking-status-badge text-xs px-2 py-0.5 rounded-full ${b.status === 'TENTATIVE' ? 'bg-gold/20 text-gold' : 'bg-accent/20 text-accent'}`}>
                           {b.status === 'TENTATIVE' ? 'Anfrage' : 'Bestätigt'}
                         </span>
+                        {b.status === 'TENTATIVE' && (
+                          <button
+                            class="booking-confirm-btn text-xs px-2 py-0.5 rounded-full bg-accent/10 text-accent border border-accent/20 hover:bg-accent/20 transition-colors cursor-pointer whitespace-nowrap"
+                            data-booking-uid={b.uid}
+                            title="Termin bestätigen"
+                          >
+                            ✓ Bestätigen
+                          </button>
+                        )}
+                        <button
+                          class="booking-remind-btn text-xs px-2 py-0.5 rounded-full bg-dark-lighter text-muted border border-dark-lighter hover:text-light hover:border-muted transition-colors cursor-pointer whitespace-nowrap"
+                          data-booking-uid={b.uid}
+                          title="Erinnerung per E-Mail senden"
+                        >
+                          ✉ Erinnerung
+                        </button>
+                        <button
+                          class="booking-cancel-btn text-xs px-2 py-0.5 rounded-full bg-dark-lighter text-muted border border-dark-lighter hover:text-red-400 hover:border-red-400/30 transition-colors cursor-pointer whitespace-nowrap"
+                          data-booking-uid={b.uid}
+                          title="Termin absagen (bleibt im Kalender als Abgesagt)"
+                        >
+                          Absagen
+                        </button>
+                        <button
+                          class="booking-delete-btn text-xs px-2 py-0.5 rounded-full bg-dark-lighter text-muted border border-dark-lighter hover:text-red-400 hover:border-red-400/30 transition-colors cursor-pointer whitespace-nowrap"
+                          data-booking-uid={b.uid}
+                          title="Termin endgültig löschen"
+                        >
+                          Löschen
+                        </button>
                       </div>
                     </div>
                   </div>
@@ -255,6 +285,13 @@ function formatTime(d: Date) {
                         <span class="text-xs px-2 py-0.5 rounded-full bg-dark-lighter text-muted">
                           {b.status === 'CANCELLED' ? 'Abgesagt' : 'Vergangen'}
                         </span>
+                        <button
+                          class="booking-delete-btn text-xs px-2 py-0.5 rounded-full bg-dark-lighter text-muted border border-dark-lighter hover:text-red-400 hover:border-red-400/30 transition-colors cursor-pointer whitespace-nowrap"
+                          data-booking-uid={b.uid}
+                          title="Termin endgültig löschen"
+                        >
+                          Löschen
+                        </button>
                       </div>
                     </div>
                   </div>
@@ -418,6 +455,140 @@ function formatTime(d: Date) {
       } finally {
         sel.disabled = false;
       }
+    });
+  });
+
+  // Delete booking
+  document.querySelectorAll<HTMLButtonElement>('.booking-delete-btn').forEach(btn => {
+    btn.addEventListener('click', async () => {
+      const uid = btn.dataset.bookingUid;
+      if (!uid) return;
+      if (!confirm('Termin endgültig löschen? Dies kann nicht rückgängig gemacht werden.')) return;
+      btn.disabled = true;
+      btn.textContent = '…';
+      try {
+        const res = await fetch(`/api/admin/bookings/${encodeURIComponent(uid)}/delete`, { method: 'DELETE' });
+        if (!res.ok) {
+          const err = await res.json().catch(() => ({}));
+          alert(err.error || 'Löschen fehlgeschlagen.');
+          btn.disabled = false;
+          btn.textContent = 'Löschen';
+          return;
+        }
+        btn.closest<HTMLElement>('[data-booking-uid]')?.remove();
+      } catch {
+        alert('Netzwerkfehler beim Löschen.');
+        btn.disabled = false;
+        btn.textContent = 'Löschen';
+      }
+    });
+  });
+
+  // Cancel booking
+  document.querySelectorAll<HTMLButtonElement>('.booking-cancel-btn').forEach(btn => {
+    btn.addEventListener('click', async () => {
+      const uid = btn.dataset.bookingUid;
+      if (!uid) return;
+      if (!confirm('Termin absagen? Er bleibt im Kalender als "Abgesagt" sichtbar.')) return;
+      btn.disabled = true;
+      btn.textContent = '…';
+      try {
+        const res = await fetch(`/api/admin/bookings/${encodeURIComponent(uid)}/status`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ status: 'CANCELLED' }),
+        });
+        if (!res.ok) {
+          const err = await res.json().catch(() => ({}));
+          alert(err.error || 'Absagen fehlgeschlagen.');
+          btn.disabled = false;
+          btn.textContent = 'Absagen';
+          return;
+        }
+        const card = btn.closest<HTMLElement>('[data-booking-uid]');
+        if (card) {
+          const badge = card.querySelector('.booking-status-badge');
+          if (badge) { badge.textContent = 'Abgesagt'; badge.className = 'booking-status-badge text-xs px-2 py-0.5 rounded-full bg-dark-lighter text-muted'; }
+          card.classList.add('opacity-60');
+          btn.remove();
+          card.querySelector('.booking-confirm-btn')?.remove();
+          card.querySelector('.booking-remind-btn')?.remove();
+        }
+      } catch {
+        alert('Netzwerkfehler beim Absagen.');
+        btn.disabled = false;
+        btn.textContent = 'Absagen';
+      }
+    });
+  });
+
+  // Confirm booking (TENTATIVE → CONFIRMED)
+  document.querySelectorAll<HTMLButtonElement>('.booking-confirm-btn').forEach(btn => {
+    btn.addEventListener('click', async () => {
+      const uid = btn.dataset.bookingUid;
+      if (!uid) return;
+      btn.disabled = true;
+      btn.textContent = '…';
+      try {
+        const res = await fetch(`/api/admin/bookings/${encodeURIComponent(uid)}/status`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ status: 'CONFIRMED' }),
+        });
+        if (!res.ok) {
+          const err = await res.json().catch(() => ({}));
+          alert(err.error || 'Bestätigen fehlgeschlagen.');
+          btn.disabled = false;
+          btn.textContent = '✓ Bestätigen';
+          return;
+        }
+        const card = btn.closest<HTMLElement>('[data-booking-uid]');
+        if (card) {
+          const badge = card.querySelector('.booking-status-badge');
+          if (badge) { badge.textContent = 'Bestätigt'; badge.className = 'booking-status-badge text-xs px-2 py-0.5 rounded-full bg-accent/20 text-accent'; }
+        }
+        btn.remove();
+      } catch {
+        alert('Netzwerkfehler beim Bestätigen.');
+        btn.disabled = false;
+        btn.textContent = '✓ Bestätigen';
+      }
+    });
+  });
+
+  // Send reminder email
+  document.querySelectorAll<HTMLButtonElement>('.booking-remind-btn').forEach(btn => {
+    btn.addEventListener('click', async () => {
+      const uid = btn.dataset.bookingUid;
+      if (!uid) return;
+      const card = btn.closest<HTMLElement>('[data-booking-uid]');
+      const attendeeEmail = card?.dataset.bookingAttendeeEmail;
+      const attendeeName = card?.dataset.bookingAttendeeName;
+      const summary = card?.dataset.bookingSummary;
+      const dateDisplay = card?.dataset.bookingDate;
+      const timeDisplay = card?.dataset.bookingTime;
+      if (!attendeeEmail) return;
+      btn.disabled = true;
+      btn.textContent = '…';
+      try {
+        const res = await fetch(`/api/admin/bookings/${encodeURIComponent(uid)}/remind`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ attendeeEmail, attendeeName, summary, dateDisplay, timeDisplay }),
+        });
+        if (!res.ok) {
+          const err = await res.json().catch(() => ({}));
+          alert(err.error || 'Erinnerung konnte nicht gesendet werden.');
+        } else {
+          btn.textContent = '✓ Gesendet';
+          setTimeout(() => { btn.textContent = '✉ Erinnerung'; btn.disabled = false; }, 3000);
+          return;
+        }
+      } catch {
+        alert('Netzwerkfehler beim Senden der Erinnerung.');
+      }
+      btn.disabled = false;
+      btn.textContent = '✉ Erinnerung';
     });
   });
 </script>

--- a/website/src/pages/api/admin/bookings/[uid]/delete.ts
+++ b/website/src/pages/api/admin/bookings/[uid]/delete.ts
@@ -1,0 +1,17 @@
+import type { APIRoute } from 'astro';
+import { getSession, isAdmin } from '../../../../../lib/auth';
+import { deleteCalendarEvent } from '../../../../../lib/caldav';
+
+export const DELETE: APIRoute = async ({ request, params }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session) return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401, headers: { 'Content-Type': 'application/json' } });
+  if (!isAdmin(session)) return new Response(JSON.stringify({ error: 'Forbidden' }), { status: 403, headers: { 'Content-Type': 'application/json' } });
+
+  const uid = params.uid;
+  if (!uid) return new Response(JSON.stringify({ error: 'Missing uid' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+
+  const ok = await deleteCalendarEvent(uid);
+  if (!ok) return new Response(JSON.stringify({ error: 'Löschen fehlgeschlagen. Termin wurde möglicherweise extern erstellt.' }), { status: 500, headers: { 'Content-Type': 'application/json' } });
+
+  return new Response(JSON.stringify({ ok: true }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+};

--- a/website/src/pages/api/admin/bookings/[uid]/remind.ts
+++ b/website/src/pages/api/admin/bookings/[uid]/remind.ts
@@ -1,0 +1,29 @@
+import type { APIRoute } from 'astro';
+import { getSession, isAdmin } from '../../../../../lib/auth';
+import { sendEmail } from '../../../../../lib/email';
+
+const BRAND_NAME = process.env.BRAND_NAME || 'Workspace';
+
+export const POST: APIRoute = async ({ request, params }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session) return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401, headers: { 'Content-Type': 'application/json' } });
+  if (!isAdmin(session)) return new Response(JSON.stringify({ error: 'Forbidden' }), { status: 403, headers: { 'Content-Type': 'application/json' } });
+
+  const uid = params.uid;
+  if (!uid) return new Response(JSON.stringify({ error: 'Missing uid' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+
+  let body: { attendeeEmail?: string; attendeeName?: string; summary?: string; dateDisplay?: string; timeDisplay?: string };
+  try { body = await request.json(); } catch { return new Response(JSON.stringify({ error: 'Invalid JSON' }), { status: 400, headers: { 'Content-Type': 'application/json' } }); }
+
+  if (!body.attendeeEmail) return new Response(JSON.stringify({ error: 'attendeeEmail required' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+
+  const ok = await sendEmail({
+    to: body.attendeeEmail,
+    subject: `Erinnerung: ${body.summary || 'Ihr Termin'} bei ${BRAND_NAME}`,
+    text: `Hallo ${body.attendeeName || body.attendeeEmail},\n\ndies ist eine freundliche Erinnerung an Ihren bevorstehenden Termin:\n\n${body.summary || 'Termin'}\n${body.dateDisplay ? `Datum: ${body.dateDisplay}` : ''}\n${body.timeDisplay ? `Uhrzeit: ${body.timeDisplay}` : ''}\n\nMit freundlichen Grüßen\n${BRAND_NAME}`,
+  });
+
+  if (!ok) return new Response(JSON.stringify({ error: 'E-Mail konnte nicht gesendet werden.' }), { status: 500, headers: { 'Content-Type': 'application/json' } });
+
+  return new Response(JSON.stringify({ ok: true }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+};

--- a/website/src/pages/api/admin/bookings/[uid]/status.ts
+++ b/website/src/pages/api/admin/bookings/[uid]/status.ts
@@ -1,0 +1,24 @@
+import type { APIRoute } from 'astro';
+import { getSession, isAdmin } from '../../../../../lib/auth';
+import { updateCalendarEventStatus } from '../../../../../lib/caldav';
+
+export const PATCH: APIRoute = async ({ request, params }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session) return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401, headers: { 'Content-Type': 'application/json' } });
+  if (!isAdmin(session)) return new Response(JSON.stringify({ error: 'Forbidden' }), { status: 403, headers: { 'Content-Type': 'application/json' } });
+
+  const uid = params.uid;
+  if (!uid) return new Response(JSON.stringify({ error: 'Missing uid' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+
+  let body: { status?: string };
+  try { body = await request.json(); } catch { return new Response(JSON.stringify({ error: 'Invalid JSON' }), { status: 400, headers: { 'Content-Type': 'application/json' } }); }
+
+  if (body.status !== 'CANCELLED' && body.status !== 'CONFIRMED') {
+    return new Response(JSON.stringify({ error: 'status must be CANCELLED or CONFIRMED' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+  }
+
+  const ok = await updateCalendarEventStatus(uid, body.status);
+  if (!ok) return new Response(JSON.stringify({ error: 'Status-Update fehlgeschlagen.' }), { status: 500, headers: { 'Content-Type': 'application/json' } });
+
+  return new Response(JSON.stringify({ ok: true }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+};


### PR DESCRIPTION
## Summary

- **Löschen**: Hard-deletes the CalDAV `.ics` event after a confirmation dialog; card is removed from the view
- **Absagen**: Sets `STATUS:CANCELLED` in CalDAV (keeps event in calendar history), card fades in-place
- **Bestätigen**: One-click promotion of TENTATIVE → CONFIRMED for booking requests; button disappears after confirming
- **✉ Erinnerung**: Sends a reminder email to the attendee with appointment details

## New files

- `api/admin/bookings/[uid]/delete.ts` — DELETE endpoint
- `api/admin/bookings/[uid]/status.ts` — PATCH endpoint (cancel / confirm)
- `api/admin/bookings/[uid]/remind.ts` — POST endpoint (reminder email)
- `caldav.ts` — added `deleteCalendarEvent`, `updateCalendarEventStatus`, `findEventUrl`

## Test plan

- [ ] Book a test appointment and verify all 4 buttons appear on upcoming bookings
- [ ] Löschen: confirm dialog shows, card disappears, event gone from Nextcloud Calendar
- [ ] Absagen: card fades and badge changes to "Abgesagt", event marked CANCELLED in Nextcloud
- [ ] Bestätigen: badge changes to "Bestätigt", button disappears
- [ ] Erinnerung: button shows "✓ Gesendet" briefly, email arrives at attendee address
- [ ] Past/cancelled bookings show only the Löschen button

🤖 Generated with [Claude Code](https://claude.com/claude-code)