### PR TITLE
fix: remove Wiki entry from external services

### DIFF
--- a/website/src/components/portal/DiensteSection.astro
+++ b/website/src/components/portal/DiensteSection.astro
@@ -15,7 +15,6 @@ const services = [
     { href: `${ncBase}/apps/spreed/`,     label: 'Talk',       desc: 'Video & Gruppen-Chat',       icon: '🎥' },
     { href: `${ncBase}/apps/whiteboard/`, label: 'Whiteboard', desc: 'Gemeinsames Zeichenbrett',   icon: '🖊️' },
   ] : []),
-  ...(wikiUrl  ? [{ href: wikiUrl,  label: 'Wiki',        desc: 'Dokumentation & Wissen', icon: '📚' }] : []),
   ...(vaultUrl ? [{ href: vaultUrl, label: 'Passwörter',  desc: 'Vaultwarden Safe',       icon: '🔒' }] : []),
 ];
 ---

--- a/website/src/components/portal/OverviewSection.astro
+++ b/website/src/components/portal/OverviewSection.astro
@@ -22,7 +22,6 @@ const services = [
     { href: `${ncBase}/apps/spreed/`,      label: 'Talk',       desc: 'Video & Chat' },
     { href: `${ncBase}/apps/whiteboard/`,  label: 'Whiteboard', desc: 'Nextcloud' },
   ] : []),
-  ...(wikiUrl  ? [{ href: wikiUrl,  label: 'Wiki',       desc: 'Dokumentation' }] : []),
   ...(vaultUrl ? [{ href: vaultUrl, label: 'Passwörter', desc: 'Vaultwarden' }] : []),
 ];
 ---

--- a/website/src/pages/admin.astro
+++ b/website/src/pages/admin.astro
@@ -65,7 +65,6 @@ const adminLinks = [
     { href: `${ncBase}/apps/spreed/`,     label: 'Talk',       icon: '🎥' },
     { href: `${ncBase}/apps/files/`,      label: 'Whiteboard', icon: '🖊️' },
   ] : []),
-  ...(wikiUrl     ? [{ href: wikiUrl,           label: 'Wiki',       icon: '📚' }] : []),
   ...(billingUrl  ? [{ href: billingUrl,        label: 'Abrechnung', icon: '🧾' }] : []),
   ...(vaultUrl    ? [{ href: vaultUrl,          label: 'Passwörter', icon: '🔐' }] : []),
   ...(authUrl     ? [{ href: `${authUrl}/admin/`, label: 'Keycloak', icon: '🔑' }] : []),


### PR DESCRIPTION
## Summary
- Removes the Wiki link from the external services list in the user portal (OverviewSection, DiensteSection) and the admin dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)