### PR TITLE
fix: remove KI-Dienst from user-facing docs, keep MCP

### DIFF
--- a/k3d/docs-content/_sidebar.md
+++ b/k3d/docs-content/_sidebar.md
@@ -7,7 +7,7 @@
   - [Nextcloud (Dateien & Talk)](nextcloud)
   - [Collabora (Office)](collabora)
   - [Talk HPB (Signaling)](talk-hpb)
-  - [Claude Code (KI & MCP)](claude-code)
+  - [MCP-Server](claude-code)
   - [Vaultwarden (Passwörter)](vaultwarden)
   - [Website (Astro & Svelte)](website)
   - [Whiteboard](whiteboard)

--- a/k3d/docs-content/benutzerhandbuch.md
+++ b/k3d/docs-content/benutzerhandbuch.md
@@ -16,7 +16,6 @@ Du brauchst **nur einen einzigen Account** — mit diesem einen Login kommst Du 
 | Collabora Online | Browser-basiertes Office | öffnet aus Nextcloud |
 | Whiteboard | Kollaboratives Whiteboard | `board.{DOMAIN}` |
 | Vaultwarden | Passwort-Safe | `vault.{DOMAIN}` |
-| KI-Assistent | Claude Code Status-Dashboard | `ai.{DOMAIN}` |
 | Dokumentation | Dieses Handbuch | `docs.{DOMAIN}` |
 
 ---

--- a/k3d/docs-content/claude-code.md
+++ b/k3d/docs-content/claude-code.md
@@ -1,8 +1,8 @@
-# Claude Code — KI-Assistent & MCP-Server
+# MCP-Server
 
 ## Übersicht
 
-**Claude Code** ist der KI-Assistent der Workspace-Plattform. Er läuft als CLI-Tool auf dem Entwicklerrechner und kommuniziert über die Anthropic API mit dem Claude-Modell. Die zugehörigen **MCP-Server** (Model Context Protocol) laufen als Kubernetes-Pods im Cluster und stellen Claude Code Werkzeuge bereit — etwa Zugriff auf den Cluster, die Datenbank, den Browser, GitHub oder Stripe.
+Die **MCP-Server** (Model Context Protocol) laufen als Kubernetes-Pods im Cluster und stellen Werkzeuge bereit — etwa Zugriff auf den Cluster, die Datenbank, den Browser, GitHub oder Stripe.
 
 | Eigenschaft | Wert |
 |-------------|------|

--- a/k3d/docs-content/services.md
+++ b/k3d/docs-content/services.md
@@ -69,11 +69,9 @@ Drei Deployments fuer WebRTC-Videokonferenzen:
 
 Janus konfiguriert mit STUN/TURN ueber coturn. RTP-Port-Range: 20000--40000. Alle Konfigurationen ueber ConfigMaps inline im Manifest.
 
-## AI
+## MCP & KI-Integration
 
-### Claude Code (KI-Assistent)
-
-**Für Mitarbeiter:** Claude ist Dein interner KI-Assistent. Du kannst ihm Fragen stellen, Texte schreiben lassen, Zusammenfassungen anfordern oder Dir bei Aufgaben helfen lassen. Zugriff über die KI-Seite in Deinem Browser. Gib keine sensiblen Kundendaten in die KI ein.
+### Claude Code (MCP-Server)
 
 Claude Code ist ein lokaler KI-Client (CLI/Desktop/IDE), der ueber MCP-Server (Model Context Protocol) mit dem Kubernetes-Cluster interagiert. Es gibt kein Web-UI im Cluster -- stattdessen zeigt `ai.localhost` eine MCP-Status-Seite mit Health-Checks aller MCP-Server.
 


### PR DESCRIPTION
## Summary

- Removes Claude Code as a user-facing AI service from all user-facing documentation
- KI-Assistent row removed from Benutzerhandbuch services table
- Sidebar entry renamed from "Claude Code (KI & MCP)" to "MCP-Server"
- `claude-code.md` page retitled to "MCP-Server", AI assistant framing dropped
- `services.md` "Für Mitarbeiter" AI assistant description removed, section renamed from "AI" to "MCP & KI-Integration"
- All MCP technical documentation is preserved

## Test plan

- [ ] Verify docs site shows no KI-Assistent entry in Benutzerhandbuch
- [ ] Verify sidebar shows "MCP-Server" instead of "Claude Code (KI & MCP)"
- [ ] Verify MCP-Server page and all technical MCP content still renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)