### PR TITLE
fix: link Keycloak admin shortcut to workspace realm

### DIFF
--- a/website/src/pages/admin.astro
+++ b/website/src/pages/admin.astro
@@ -67,7 +67,7 @@ const adminLinks = [
   ] : []),
   ...(billingUrl  ? [{ href: billingUrl,        label: 'Abrechnung', icon: '🧾' }] : []),
   ...(vaultUrl    ? [{ href: vaultUrl,          label: 'Passwörter', icon: '🔐' }] : []),
-  ...(authUrl     ? [{ href: `${authUrl}/admin/`, label: 'Keycloak', icon: '🔑' }] : []),
+  ...(authUrl     ? [{ href: `${authUrl}/admin/workspace/console/`, label: 'Keycloak', icon: '🔑' }] : []),
   ...(docsUrl     ? [{ href: docsUrl,           label: 'Docs',       icon: '📖' }] : []),
 ];
 ---


### PR DESCRIPTION
## Summary
- Admin-Dashboard-Shortcut für Keycloak zeigt jetzt direkt auf den `workspace`-Realm (`/admin/workspace/console/`) statt auf den Master-Realm (`/admin/`)

## Test plan
- [ ] Admin-Dashboard öffnen → Keycloak-Link klicken → landet im workspace-Realm (nicht master)

🤖 Generated with [Claude Code](https://claude.com/claude-code)