### PR TITLE
fix(coturn): add NET_ADMIN/NET_RAW capabilities and disable AppArmor

### DIFF
--- a/k3d/coturn-stack/coturn.yaml
+++ b/k3d/coturn-stack/coturn.yaml
@@ -27,6 +27,8 @@ spec:
     metadata:
       labels:
         app: coturn
+      annotations:
+        container.apparmor.security.beta.kubernetes.io/coturn: unconfined
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
@@ -65,6 +67,11 @@ spec:
                 secretKeyRef:
                   name: coturn-secrets
                   key: TURN_SECRET
+          securityContext:
+            capabilities:
+              add:
+                - NET_ADMIN
+                - NET_RAW
           ports:
             - containerPort: 3478
               hostPort: 3478


### PR DESCRIPTION
## Summary
- Adds `NET_ADMIN` and `NET_RAW` capabilities to the coturn container securityContext
- Annotates the pod template with `container.apparmor.security.beta.kubernetes.io/coturn: unconfined`

## Root Cause
coturn runs as uid 65534 (`nobody`) in the `coturn/coturn:4.9-alpine` image with only `CAP_NET_BIND_SERVICE` effective. TURN relay requires `CAP_NET_ADMIN` for `IP_TRANSPARENT` socket operations (source-IP binding on relay sockets). Additionally, the `cri-containerd.apparmor.d` AppArmor profile in enforce mode was blocking `sendmsg` syscalls at the kernel level.

Result: every UDP relay attempt returned `EPERM` → coturn logs filled with `udp send: Operation not permitted` → Janus ICE failures (`ICE failed for component 1 in stream 1`) → `requestoffer` MCU timeouts → gekko and all clients unable to establish video calls.

## Test plan
- [ ] After ArgoCD syncs, coturn restarts with new securityContext
- [ ] `kubectl logs -n coturn -l app=coturn --tail=30` shows no `udp send: Operation not permitted`
- [ ] Janus logs show no `ICE failed` entries for new sessions
- [ ] `kubectl logs -n workspace deploy/spreed-signaling | grep "deadline exceeded"` returns nothing
- [ ] gekko can join a Talk call and stay connected without timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)