### PR TITLE
fix(janus): move ice_lite and full_trickle to general: section

### DIFF
--- a/k3d/coturn-stack/janus.yaml
+++ b/k3d/coturn-stack/janus.yaml
@@ -21,11 +21,11 @@ data:
       log_to_stdout = true
       debug_level = 4
       admin_secret = "devjanusadmin"
+      ice_lite = true
+      full_trickle = true
     }
     nat: {
       nice_debug = false
-      full_trickle = true
-      ice_lite = true
       nat_1_1_mapping = "${TURN_PUBLIC_IP}"
       keep_private_host = false
     }


### PR DESCRIPTION
## Summary
- Moves `ice_lite = true` and `full_trickle = true` from `nat:` section to `general:` section in `janus.jcfg`

## Root Cause
In Janus 1.x (JCFG format), `ice_lite` and `full_trickle` are **general-section options**, not nat-section options. Both were being silently ignored, causing Janus to run in **Full ICE mode with half-trickle** instead of ICE Lite with full-trickle.

Visible symptom: `Initializing ICE stuff (Full mode, ICE-TCP candidates disabled, half-trickle, ...)` in Janus startup logs.

**Impact:** ICE was failing for every WebRTC session because:
- In Full mode, Janus sends its own connectivity checks — but the spreed-signaling server expected ICE Lite behavior (only responds to checks)
- The spreed-signaling server also reported "Full-Trickle is NOT enabled in Janus!" causing candidate exchange failures

## Test plan
- [ ] After ArgoCD syncs, Janus restarts and startup log shows: `Initializing ICE stuff (ICE Lite mode, ...full-trickle...)`
- [ ] spreed-signaling no longer warns "Full-Trickle is NOT enabled in Janus!"
- [ ] `requestoffer` MCU messages no longer time out
- [ ] gekko can join a Talk call and maintain connection without reconnect loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)