### PR TITLE
fix(janus): correct ice_lite/full_trickle section, load ConfigMap, fix coturn root

### DIFF
--- a/k3d/coturn-stack/coturn.yaml
+++ b/k3d/coturn-stack/coturn.yaml
@@ -68,6 +68,7 @@ spec:
                   name: coturn-secrets
                   key: TURN_SECRET
           securityContext:
+            runAsUser: 0
             capabilities:
               add:
                 - NET_ADMIN

--- a/k3d/coturn-stack/janus.yaml
+++ b/k3d/coturn-stack/janus.yaml
@@ -21,11 +21,11 @@ data:
       log_to_stdout = true
       debug_level = 4
       admin_secret = "devjanusadmin"
-      ice_lite = true
-      full_trickle = true
     }
     nat: {
       nice_debug = false
+      full_trickle = true
+      ice_lite = true
       nat_1_1_mapping = "${TURN_PUBLIC_IP}"
       keep_private_host = false
     }
@@ -73,6 +73,7 @@ spec:
         - name: janus
           image: canyan/janus-gateway:master_cefca79700bdadd32d759ce65ba3805552a4d312
           imagePullPolicy: Always
+          command: ["/usr/local/bin/janus", "--configs-folder", "/etc/janus"]
           ports:
             - containerPort: 8188
               hostPort: 8188


### PR DESCRIPTION
## Summary
- Moves `ice_lite` and `full_trickle` back to `nat:` section in Janus ConfigMap (they belong there per `janus.jcfg.sample`)
- Adds `--configs-folder /etc/janus` to Janus startup so it reads from the mounted ConfigMap instead of the compiled-in default path
- Adds `runAsUser: 0` to coturn so `NET_ADMIN`/`NET_RAW` capabilities are effective

## Root Cause Chain
Without `--configs-folder /etc/janus`, Janus read from `/usr/local/etc/janus/janus.jcfg` where `ice_lite` and `full_trickle` are commented out. Result: Janus ran in **Full ICE mode with half-trickle** for the entire cluster lifetime.

Full ICE mode → Janus sent its own connectivity checks → spreed-signaling expected ICE Lite behavior → `requestoffer` always timed out after 10s → gekko/paddione could never establish video calls.

For coturn: `runAsUser: 0` is required because the Alpine `nobody` user (uid 65534) drops all effective capabilities on `exec` unless file capabilities are set on the binary. Without root, `NET_ADMIN` and `NET_RAW` from the securityContext are in the bounding set but never make it to the effective set.

## Test plan
- [ ] Janus startup log shows: `Initializing ICE stuff (Lite mode, ..., full-trickle, ...)`
- [ ] spreed-signaling no longer warns "Full-Trickle is NOT enabled in Janus!"
- [ ] `requestoffer` MCU messages complete without timeout
- [ ] gekko can join a Talk call and maintain connection

🤖 Generated with [Claude Code](https://claude.com/claude-code)