### PR TITLE
fix(janus): remove videoroom admin_key blocking room creation

### DIFF
--- a/k3d/coturn-stack/janus.yaml
+++ b/k3d/coturn-stack/janus.yaml
@@ -43,7 +43,6 @@ data:
     }
   janus.plugin.videoroom.jcfg: |
     general: {
-      admin_key = "devvideoroomadmin"
     }
 ---
 apiVersion: apps/v1


### PR DESCRIPTION
## Summary
- Removes `admin_key` from `janus.plugin.videoroom.jcfg`

## Root Cause
spreed-signaling creates videoroom rooms without providing `admin_key`. With `admin_key = "devvideoroomadmin"` set in the plugin config, Janus returned `Missing mandatory element (admin_key)` for every room creation, causing all `requestoffer` calls to timeout with `context deadline exceeded`.

## Security
The Janus WebSocket API (port 8188) is exposed only as a ClusterIP service (`janus.coturn:8188`). It is not reachable from outside the cluster, so removing `admin_key` does not introduce a security risk.

## Test plan
- [ ] Janus logs no longer show `Missing mandatory element (admin_key)` errors
- [ ] `requestoffer` MCU messages complete successfully
- [ ] `Publishing video as X for session Y` appears in spreed-signaling logs
- [ ] `Subscriber received connected` appears in spreed-signaling logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)