### PR TITLE
fix(chat-widget): fix panel overflow on landscape phones

### DIFF
--- a/website/src/components/ChatWidget.svelte
+++ b/website/src/components/ChatWidget.svelte
@@ -264,7 +264,7 @@
 
 <style>
   .cw { position: fixed; bottom: 24px; right: 184px; z-index: 9000; display: flex; flex-direction: column; align-items: flex-end; gap: 10px; }
-  .panel { width: 560px; height: 440px; background: #1a2235; border: 1px solid #243049; border-radius: 12px; display: flex; flex-direction: column; box-shadow: 0 8px 32px rgba(0,0,0,.5); overflow: hidden; }
+  .panel { width: min(560px, calc(100vw - 192px)); height: 440px; background: #1a2235; border: 1px solid #243049; border-radius: 12px; display: flex; flex-direction: column; box-shadow: 0 8px 32px rgba(0,0,0,.5); overflow: hidden; }
   .hdr { display: flex; justify-content: space-between; align-items: center; padding: 12px 16px; background: #243049; font-size: 14px; font-weight: 600; color: #e8e8f0; flex-shrink: 0; }
   .x { background: transparent; border: none; color: #aabbcc; cursor: pointer; font-size: 14px; padding: 0; line-height: 1; }
   .body { display: flex; flex: 1; min-height: 0; }
@@ -302,7 +302,7 @@
   .new-chat:hover { background: #1e2a3a; }
   .picker { position: absolute; left: 0; top: 0; width: 160px; height: 100%; background: #1a2235; border-right: 1px solid #243049; display: flex; flex-direction: column; z-index: 10; overflow-y: auto; }
   .picker-hdr { display: flex; justify-content: space-between; align-items: center; padding: 8px 10px; background: #243049; font-size: 11px; font-weight: 600; color: #e8e8f0; flex-shrink: 0; }
-  @media (max-width: 600px) {
+  @media (max-width: 767px) {
     .cw { right: 8px; bottom: 16px; }
     .panel { width: calc(100vw - 16px); height: 75vh; }
     .rooms { width: 110px; }


### PR DESCRIPTION
## Summary

- Bumped responsive media query breakpoint from `600px` to `767px` to match the admin sidebar mobile threshold — landscape phones (600–767px wide) were previously not covered
- Added `min(560px, calc(100vw - 192px))` on `.panel` width so the fixed `right: 184px` desktop offset never pushes the panel off-screen on intermediate viewports

## Root Cause

The admin sidebar is `13rem ≈ 208px` wide, so the chat widget sits at `right: 184px`. On any viewport narrower than `184 + 560 = 744px`, the panel overflowed to the left. The existing `600px` breakpoint only caught portrait phones; landscape phones (e.g. 667–767px) hit the desktop styles and rendered the panel partially off-screen.

## Test plan

- [ ] Open chat widget on a desktop browser — panel renders at full 560px, no change
- [ ] Open on a phone in portrait mode (≤767px) — panel fills viewport width, height 75vh
- [ ] Open on a phone in landscape mode (600–767px) — panel no longer overflows off-screen
- [ ] Verify admin sidebar still visible alongside widget on desktop

Closes BR-20260420-7279.

🤖 Generated with [Claude Code](https://claude.com/claude-code)