### PR TITLE
fix(bugs): resolve all 8 open bug tickets (BR-20260420-*)

### DIFF
--- a/deploy/mcp/claude-code-mcp-apps.yaml
+++ b/deploy/mcp/claude-code-mcp-apps.yaml
@@ -43,13 +43,13 @@ spec:
           readinessProbe:
             httpGet: { path: /health/ready, port: 8000 }
             initialDelaySeconds: 15
-            periodSeconds: 10
-            timeoutSeconds: 5
+            periodSeconds: 20
+            timeoutSeconds: 10
           livenessProbe:
             httpGet: { path: /health/ready, port: 8000 }
             initialDelaySeconds: 30
-            periodSeconds: 30
-            timeoutSeconds: 5
+            periodSeconds: 60
+            timeoutSeconds: 10
             failureThreshold: 5
           resources:
             requests: { memory: 128Mi, cpu: 50m }

--- a/k3d/claude-code-mcp-apps.yaml
+++ b/k3d/claude-code-mcp-apps.yaml
@@ -40,13 +40,13 @@ spec:
           readinessProbe:
             httpGet: { path: /health/ready, port: 8000 }
             initialDelaySeconds: 15
-            periodSeconds: 10
-            timeoutSeconds: 5
+            periodSeconds: 20
+            timeoutSeconds: 10
           livenessProbe:
             httpGet: { path: /health/ready, port: 8000 }
             initialDelaySeconds: 30
-            periodSeconds: 30
-            timeoutSeconds: 5
+            periodSeconds: 60
+            timeoutSeconds: 10
             failureThreshold: 5
           resources:
             requests: { memory: 128Mi, cpu: "100m" }

--- a/website/src/components/ChatRoomPanel.svelte
+++ b/website/src/components/ChatRoomPanel.svelte
@@ -197,11 +197,12 @@
         <div class="members-panel">
           <div class="members-search">
             <input bind:value={memberSearch} placeholder="Kunde suchen…" />
+            <p class="members-caption">Nur Kunden mit aktivem Portal-Zugang (SSO) werden angezeigt.</p>
           </div>
           {#if memberLoading}
             <p class="members-hint">Lade…</p>
           {:else if allCustomers.length === 0}
-            <p class="members-hint">Keine Kunden vorhanden.</p>
+            <p class="members-hint">Keine Kunden mit Portal-Zugang vorhanden.</p>
           {:else}
             <ul class="members-list">
               {#each filteredCustomers as c (c.id)}
@@ -255,6 +256,7 @@
   .members-search { padding: 8px 12px; border-bottom: 1px solid #2a2a3e; }
   .members-search input { width: 100%; background: #1e1e2e; color: #e8e8f0; border: 1px solid #374151; border-radius: 4px; padding: 5px 8px; font-size: 12px; box-sizing: border-box; }
   .members-hint { color: #555; font-size: 12px; padding: 10px 12px; margin: 0; }
+  .members-caption { color: #4b5563; font-size: 10px; margin: 4px 0 0; }
   .members-list { list-style: none; margin: 0; padding: 0; overflow-y: auto; flex: 1; }
   .member-row { display: flex; align-items: center; gap: 8px; padding: 6px 12px; border-bottom: 1px solid #1e1e2e; }
   .member-row.is-member { background: #1a2435; }

--- a/website/src/components/InboxApp.svelte
+++ b/website/src/components/InboxApp.svelte
@@ -17,6 +17,7 @@
   let noteText = $state('');
 
   // Thread inline view for user_message items
+  let sidebarCollapsed = $state(false);
   let expandedItemId = $state<number | null>(null);
   let threadMessages = $state<Message[]>([]);
   let threadLoading = $state(false);
@@ -180,8 +181,14 @@
 
 <div class="inbox-layout">
   <!-- Sidebar -->
-  <aside class="sidebar">
-    <h2>Inbox</h2>
+  <aside class="sidebar {sidebarCollapsed ? 'collapsed' : ''}">
+    <div class="sidebar-header">
+      <h2>Inbox</h2>
+      <button class="btn-collapse" onclick={() => sidebarCollapsed = !sidebarCollapsed} title={sidebarCollapsed ? 'Einblenden' : 'Ausblenden'}>
+        {sidebarCollapsed ? '›' : '‹'}
+      </button>
+    </div>
+    {#if !sidebarCollapsed}
     <div class="filter-group">
       {#each filterTabs as [t, label, count]}
         <button
@@ -201,6 +208,7 @@
         >{label}</button>
       {/each}
     </div>
+    {/if}
   </aside>
 
   <!-- Feed -->
@@ -303,8 +311,13 @@
 
 <style>
   .inbox-layout { display: flex; gap: 24px; height: 100%; }
-  .sidebar { width: 200px; flex-shrink: 0; }
-  .sidebar h2 { font-size: 18px; margin: 0 0 16px; }
+  .sidebar { width: 200px; flex-shrink: 0; transition: width 0.2s; }
+  .sidebar.collapsed { width: 36px; }
+  .sidebar-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 16px; }
+  .sidebar h2 { font-size: 18px; margin: 0; white-space: nowrap; overflow: hidden; }
+  .sidebar.collapsed h2 { display: none; }
+  .btn-collapse { background: #1e1e2e; border: 1px solid #374151; color: #aaa; border-radius: 4px; padding: 2px 7px; font-size: 16px; cursor: pointer; line-height: 1; flex-shrink: 0; }
+  .btn-collapse:hover { background: #2a2a3e; color: #fff; }
   .filter-group { display: flex; flex-direction: column; gap: 4px; margin-bottom: 20px; }
   .filter-btn { background: transparent; border: none; text-align: left; padding: 7px 10px; border-radius: 6px; cursor: pointer; color: #ccc; font-size: 13px; display: flex; justify-content: space-between; }
   .filter-btn.active { background: #2a2a3e; color: #fff; }
@@ -348,7 +361,9 @@
   @media (max-width: 640px) {
     .inbox-layout { flex-direction: column; gap: 0; height: auto; }
     .sidebar { width: 100%; padding-bottom: 12px; border-bottom: 1px solid #2a2a3e; margin-bottom: 12px; }
-    .sidebar h2 { font-size: 16px; margin: 0 0 10px; }
+    .sidebar.collapsed { width: 100%; }
+    .sidebar h2 { font-size: 16px; margin: 0; }
+    .sidebar-header { margin-bottom: 10px; }
     .filter-group { flex-direction: row; flex-wrap: nowrap; overflow-x: auto; gap: 6px; margin-bottom: 10px; padding-bottom: 4px; scrollbar-width: none; }
     .filter-group::-webkit-scrollbar { display: none; }
     .filter-btn { flex-shrink: 0; white-space: nowrap; padding: 6px 10px; font-size: 12px; }

--- a/website/src/components/admin/AdminBookingModal.svelte
+++ b/website/src/components/admin/AdminBookingModal.svelte
@@ -79,6 +79,21 @@
   let slotsError = $state('');
   let selectedSlot = $state<TimeSlot | null>(null);
 
+  // Custom date/time mode for admin manual bookings
+  let useCustomTime = $state(false);
+  let customDate = $state('');
+  let customStartTime = $state('09:00');
+  let customDurationMin = $state(60);
+  const DURATIONS = [15, 30, 45, 60, 90, 120];
+
+  const customEndTime = $derived(() => {
+    if (!customDate || !customStartTime) return '';
+    const [h, m] = customStartTime.split(':').map(Number);
+    const end = new Date(customDate);
+    end.setHours(h, m + customDurationMin, 0, 0);
+    return `${end.getHours().toString().padStart(2,'0')}:${end.getMinutes().toString().padStart(2,'0')}`;
+  });
+
   const isCallback = $derived(bookingType === 'callback');
 
   const slotsForDate = $derived(
@@ -112,6 +127,10 @@
     message = '';
     selectedDate = '';
     selectedSlot = null;
+    useCustomTime = false;
+    customDate = '';
+    customStartTime = '09:00';
+    customDurationMin = 60;
     clientSearch = '';
     selectedClient = isPrefilled
       ? { id: '', name: prefillName || prefillEmail, email: prefillEmail }
@@ -166,8 +185,35 @@
 
     if (!clientEmail) { error = 'Bitte einen Client auswählen.'; return; }
     if (!leistungKey)  { error = 'Bitte eine Leistung auswählen.'; return; }
-    if (!isCallback && !selectedSlot) { error = 'Bitte einen Termin wählen.'; return; }
+    if (!isCallback) {
+      if (useCustomTime) {
+        if (!customDate || !customStartTime) { error = 'Bitte Datum und Uhrzeit eingeben.'; return; }
+      } else if (!selectedSlot) {
+        error = 'Bitte einen Termin wählen.'; return;
+      }
+    }
     if (isCallback && !phone.trim())  { error = 'Telefonnummer erforderlich.'; return; }
+
+    let slotStart: string | null = null;
+    let slotEnd: string | null = null;
+    let slotDisplay: string | null = null;
+    if (!isCallback) {
+      if (useCustomTime && customDate && customStartTime) {
+        const [h, m] = customStartTime.split(':').map(Number);
+        const start = new Date(customDate);
+        start.setHours(h, m, 0, 0);
+        const end = new Date(start.getTime() + customDurationMin * 60000);
+        slotStart = start.toISOString();
+        slotEnd = end.toISOString();
+        const eH = end.getHours().toString().padStart(2,'0');
+        const eM = end.getMinutes().toString().padStart(2,'0');
+        slotDisplay = `${customStartTime} – ${eH}:${eM}`;
+      } else {
+        slotStart = selectedSlot?.start ?? null;
+        slotEnd = selectedSlot?.end ?? null;
+        slotDisplay = selectedSlot?.display ?? null;
+      }
+    }
 
     submitting = true;
     try {
@@ -177,10 +223,10 @@
         type: bookingType,
         leistungKey,
         projectId: projectId || null,
-        slotStart: selectedSlot?.start ?? null,
-        slotEnd: selectedSlot?.end ?? null,
-        slotDisplay: selectedSlot?.display ?? null,
-        date: selectedDate || null,
+        slotStart,
+        slotEnd,
+        slotDisplay,
+        date: useCustomTime ? customDate : (selectedDate || null),
         phone: phone || null,
         message: message || null,
       };
@@ -322,41 +368,76 @@
         {/if}
 
         {#if !isCallback}
-          <div>
-            <label class="block text-xs text-muted uppercase tracking-wide mb-1">Datum</label>
-            {#if !slotsLoaded}
-              <p class="text-sm text-muted">Lade Slots…</p>
-            {:else if slotsError}
-              <p class="text-sm text-red-400">{slotsError}</p>
-            {:else if availableDates.length === 0}
-              <p class="text-sm text-muted">Keine freien Slots verfügbar.</p>
-            {:else}
-              <select
-                bind:value={selectedDate}
-                onchange={() => { selectedSlot = null; }}
-                class="w-full bg-dark border border-dark-lighter rounded-lg px-3 py-2 text-light text-sm focus:border-gold outline-none"
-              >
-                {#each daySlots.filter(d => d.slots.length > 0) as d}
-                  <option value={d.date}>{d.weekday}, {d.date}</option>
-                {/each}
-              </select>
-            {/if}
+          <div class="flex gap-3 text-sm mb-1">
+            <label class="flex items-center gap-1.5 cursor-pointer">
+              <input type="radio" bind:group={useCustomTime} value={false} class="accent-gold" />
+              <span class="text-light">Aus freien Slots</span>
+            </label>
+            <label class="flex items-center gap-1.5 cursor-pointer">
+              <input type="radio" bind:group={useCustomTime} value={true} class="accent-gold" />
+              <span class="text-light">Freier Termin</span>
+            </label>
           </div>
 
-          {#if selectedDate && slotsForDate.length > 0}
-            <div>
-              <label class="block text-xs text-muted uppercase tracking-wide mb-1">Uhrzeit</label>
-              <div class="flex flex-wrap gap-2">
-                {#each slotsForDate as slot}
-                  <button
-                    onclick={() => { selectedSlot = slot; }}
-                    class={`px-3 py-1.5 rounded-lg text-sm transition-colors ${selectedSlot?.start === slot.start ? 'bg-gold text-dark font-semibold' : 'bg-dark-light border border-dark-lighter text-light hover:border-gold/40'}`}
-                  >
-                    {slot.display}
-                  </button>
-                {/each}
+          {#if useCustomTime}
+            <div class="grid grid-cols-2 gap-3">
+              <div>
+                <label class="block text-xs text-muted uppercase tracking-wide mb-1">Datum</label>
+                <input type="date" bind:value={customDate}
+                  class="w-full bg-dark border border-dark-lighter rounded-lg px-3 py-2 text-light text-sm focus:border-gold outline-none" />
+              </div>
+              <div>
+                <label class="block text-xs text-muted uppercase tracking-wide mb-1">Startzeit</label>
+                <input type="time" bind:value={customStartTime}
+                  class="w-full bg-dark border border-dark-lighter rounded-lg px-3 py-2 text-light text-sm focus:border-gold outline-none" />
               </div>
             </div>
+            <div>
+              <label class="block text-xs text-muted uppercase tracking-wide mb-1">Dauer</label>
+              <select bind:value={customDurationMin}
+                class="w-full bg-dark border border-dark-lighter rounded-lg px-3 py-2 text-light text-sm focus:border-gold outline-none">
+                {#each DURATIONS as d}
+                  <option value={d}>{d} Minuten{customDate && customStartTime ? ` (bis ${customEndTime()})` : ''}</option>
+                {/each}
+              </select>
+            </div>
+          {:else}
+            <div>
+              <label class="block text-xs text-muted uppercase tracking-wide mb-1">Datum</label>
+              {#if !slotsLoaded}
+                <p class="text-sm text-muted">Lade Slots…</p>
+              {:else if slotsError}
+                <p class="text-sm text-red-400">{slotsError}</p>
+              {:else if availableDates.length === 0}
+                <p class="text-sm text-muted">Keine freien Slots verfügbar.</p>
+              {:else}
+                <select
+                  bind:value={selectedDate}
+                  onchange={() => { selectedSlot = null; }}
+                  class="w-full bg-dark border border-dark-lighter rounded-lg px-3 py-2 text-light text-sm focus:border-gold outline-none"
+                >
+                  {#each daySlots.filter(d => d.slots.length > 0) as d}
+                    <option value={d.date}>{d.weekday}, {d.date}</option>
+                  {/each}
+                </select>
+              {/if}
+            </div>
+
+            {#if selectedDate && slotsForDate.length > 0}
+              <div>
+                <label class="block text-xs text-muted uppercase tracking-wide mb-1">Uhrzeit</label>
+                <div class="flex flex-wrap gap-2">
+                  {#each slotsForDate as slot}
+                    <button
+                      onclick={() => { selectedSlot = slot; }}
+                      class={`px-3 py-1.5 rounded-lg text-sm transition-colors ${selectedSlot?.start === slot.start ? 'bg-gold text-dark font-semibold' : 'bg-dark-light border border-dark-lighter text-light hover:border-gold/40'}`}
+                    >
+                      {slot.display}
+                    </button>
+                  {/each}
+                </div>
+              </div>
+            {/if}
           {/if}
         {/if}
 

--- a/website/src/layouts/AdminLayout.astro
+++ b/website/src/layouts/AdminLayout.astro
@@ -63,7 +63,6 @@ const navGroups = [
       { href: '/admin/projekte',      label: 'Projekte',      icon: 'clipboard' },
       { href: '/admin/zeiterfassung', label: 'Zeiterfassung', icon: 'clock' },
       { href: '/admin/rechnungen',    label: 'Rechnungen',    icon: 'receipt' },
-      { href: '/admin/followups',     label: 'Follow-ups',    icon: 'bell' },
       { href: '/admin/newsletter',    label: 'Newsletter',    icon: 'mail' },
       { href: '/admin/kalender',      label: 'Kalender',      icon: 'calendar2' },
     ],

--- a/website/src/lib/caldav.ts
+++ b/website/src/lib/caldav.ts
@@ -255,6 +255,8 @@ export async function getClientBookings(clientEmail: string): Promise<ClientBook
 // Without brand, all calendar-free slots are returned (admin overview).
 export async function getAvailableSlots(fromDate?: Date, brand?: string): Promise<DaySlots[]> {
   let whitelistedSet: Set<string> | null = null;
+  let vacationDays: Set<string> = new Set();
+  const effectiveBrand = brand || process.env.BRAND || 'mentolder';
   if (brand) {
     try {
       const { getWhitelistedSlots } = await import('./website-db.js');
@@ -263,6 +265,20 @@ export async function getAvailableSlots(fromDate?: Date, brand?: string): Promis
     } catch {
       // If whitelist table missing, fall back to showing all slots
     }
+  }
+  try {
+    const { getVacationPeriods } = await import('./website-db.js');
+    const periods = await getVacationPeriods(effectiveBrand);
+    for (const p of periods) {
+      const cur = new Date(p.start);
+      const endDate = new Date(p.end);
+      while (cur <= endDate) {
+        vacationDays.add(cur.toISOString().split('T')[0]);
+        cur.setDate(cur.getDate() + 1);
+      }
+    }
+  } catch {
+    // vacation periods unavailable — continue without them
   }
   const now = new Date();
   const start = fromDate || now;
@@ -278,9 +294,9 @@ export async function getAvailableSlots(fromDate?: Date, brand?: string): Promis
   while (cursor < end) {
     const dayOfWeek = cursor.getDay();
     const isoDay = dayOfWeek === 0 ? 7 : dayOfWeek;
+    const dayStr = cursor.toISOString().split('T')[0];
 
-    if (WORK_DAYS.includes(isoDay)) {
-      const dayStr = cursor.toISOString().split('T')[0];
+    if (WORK_DAYS.includes(isoDay) && !vacationDays.has(dayStr)) {
       const slots: TimeSlot[] = [];
 
       for (let hour = WORK_START_HOUR; hour < WORK_END_HOUR; hour += SLOT_DURATION_MIN / 60) {

--- a/website/src/lib/messaging-db.ts
+++ b/website/src/lib/messaging-db.ts
@@ -472,7 +472,9 @@ export async function ensureDirectRoomForCustomer(
 }
 
 export async function listAllCustomers(): Promise<Array<{ id: string; name: string; email: string }>> {
-  const { rows } = await pool.query('SELECT id, name, email FROM customers ORDER BY name ASC');
+  const { rows } = await pool.query(
+    'SELECT id, name, email FROM customers WHERE keycloak_user_id IS NOT NULL ORDER BY name ASC'
+  );
   return rows;
 }
 

--- a/website/src/lib/website-db.ts
+++ b/website/src/lib/website-db.ts
@@ -668,6 +668,25 @@ export async function setSiteSetting(brand: string, key: string, value: string):
   );
 }
 
+// ── Vacation / Blackout Periods ───────────────────────────────────────────────
+
+export interface VacationPeriod {
+  id: string;
+  start: string; // YYYY-MM-DD
+  end: string;   // YYYY-MM-DD
+  label: string;
+}
+
+export async function getVacationPeriods(brand: string): Promise<VacationPeriod[]> {
+  const raw = await getSiteSetting(brand, 'vacation_periods');
+  if (!raw) return [];
+  try { return JSON.parse(raw) as VacationPeriod[]; } catch { return []; }
+}
+
+export async function saveVacationPeriods(brand: string, periods: VacationPeriod[]): Promise<void> {
+  await setSiteSetting(brand, 'vacation_periods', JSON.stringify(periods));
+}
+
 // ── Legal Pages (admin-editable HTML content) ────────────────────────────────
 
 export async function initLegalPagesTable(): Promise<void> {

--- a/website/src/pages/admin.astro
+++ b/website/src/pages/admin.astro
@@ -1,7 +1,7 @@
 ---
 import AdminLayout from '../layouts/AdminLayout.astro';
 import { getSession, getLoginUrl, isAdmin } from '../lib/auth';
-import { listBugTickets, listProjects, getDueFollowUps, listAdminShortcuts } from '../lib/website-db';
+import { listBugTickets, listProjects, listAdminShortcuts } from '../lib/website-db';
 import type { AdminShortcut } from '../lib/website-db';
 import { getAllBillingInvoices } from '../lib/stripe-billing';
 import { getAvailableSlots } from '../lib/caldav';
@@ -18,7 +18,6 @@ let openBugCount      = 0;
 let activeProjects    = 0;
 let openInvoices      = 0;
 let openInvoiceAmount = 0;
-let dueFollowUps      = 0;
 let freeSlots         = 0;
 let shortcuts: AdminShortcut[] = [];
 
@@ -33,8 +32,6 @@ await Promise.allSettled([
       openInvoices      = open.length;
       openInvoiceAmount = open.reduce((s, i) => s + i.amountRemaining, 0);
     }),
-  getDueFollowUps()
-    .then(f => { dueFollowUps = f.length; }),
   getAvailableSlots(new Date())
     .then(slots => {
       const horizon = new Date(); horizon.setDate(horizon.getDate() + 7);
@@ -82,12 +79,11 @@ const adminLinks = [
       </div>
 
       <!-- KPI Banner -->
-<div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3 mb-8">
+<div class="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-8">
   {[
     { label: 'Aktive Projekte',   value: String(activeProjects),           href: '/admin/projekte',  cls: 'border-yellow-800' },
     { label: 'Offene Rechnungen', value: openInvoices > 0 ? `${openInvoices} (${fmtCurrency(openInvoiceAmount)})` : '0', href: '/admin/rechnungen', cls: openInvoices > 0 ? 'border-yellow-800' : 'border-dark-lighter' },
     { label: 'Überfällige Bugs',   value: String(openBugCount),             href: '/admin/bugs',      cls: openBugCount > 0 ? 'border-red-800' : 'border-dark-lighter' },
-    { label: 'Follow-ups fällig', value: String(dueFollowUps),             href: '/admin/followups', cls: dueFollowUps > 0 ? 'border-red-800' : 'border-dark-lighter' },
     { label: 'Freie Slots (7 T)', value: String(freeSlots),                href: '/admin/termine',   cls: freeSlots > 0 ? 'border-green-800' : 'border-dark-lighter' },
   ].map(k => (
     <a href={k.href} class={`p-4 bg-dark-light rounded-xl border hover:border-gold/40 transition-colors ${k.cls}`}>

--- a/website/src/pages/admin/startseite.astro
+++ b/website/src/pages/admin/startseite.astro
@@ -123,9 +123,19 @@ const sectionCls = 'p-6 bg-dark-light rounded-xl border border-dark-lighter spac
           </label>
         </div>
         <div id="avatar-image-field" class={hp.avatarType === 'initials' ? 'hidden' : ''}>
-          <label class={labelCls}>Bild-URL (z. B. /gerald.webp oder https://...)</label>
-          <input type="text" name="avatar_src" value={hp.avatarSrc ?? ''} class={inputCls}
-            placeholder="/gerald.webp" />
+          <label class={labelCls}>Bild hochladen oder URL eingeben</label>
+          <div class="flex gap-2 items-center">
+            <input type="text" id="avatar_src_input" name="avatar_src" value={hp.avatarSrc ?? ''} class={`${inputCls} flex-1`}
+              placeholder="/gerald.webp oder https://..." />
+            <label class="px-3 py-2 bg-dark-lighter border border-dark-lighter rounded-lg text-sm text-light cursor-pointer hover:border-gold/50 whitespace-nowrap">
+              📷 Datei wählen
+              <input type="file" id="avatar_file_input" accept="image/jpeg,image/png,image/webp,image/gif" class="hidden" />
+            </label>
+          </div>
+          <p id="avatar-upload-status" class="text-xs mt-1 text-muted hidden"></p>
+          {hp.avatarSrc?.startsWith('data:') && (
+            <img src={hp.avatarSrc} alt="Vorschau" class="mt-2 h-20 w-20 rounded-full object-cover border border-dark-lighter" />
+          )}
         </div>
         <div id="avatar-initials-field" class={hp.avatarType !== 'initials' ? 'hidden' : ''}>
           <label class={labelCls}>Initialen (z. B. GK)</label>
@@ -143,6 +153,33 @@ const sectionCls = 'p-6 bg-dark-light rounded-xl border border-dark-lighter spac
           imageField?.classList.toggle('hidden', !isImage);
           initialsField?.classList.toggle('hidden', isImage);
         }));
+
+        const fileInput = document.getElementById('avatar_file_input') as HTMLInputElement | null;
+        const srcInput = document.getElementById('avatar_src_input') as HTMLInputElement | null;
+        const statusEl = document.getElementById('avatar-upload-status');
+        fileInput?.addEventListener('change', async () => {
+          const file = fileInput?.files?.[0];
+          if (!file || !srcInput || !statusEl) return;
+          statusEl.textContent = 'Lädt hoch…';
+          statusEl.className = 'text-xs mt-1 text-muted';
+          const fd = new FormData();
+          fd.append('file', file);
+          try {
+            const res = await fetch('/api/admin/startseite/upload-portrait', { method: 'POST', body: fd });
+            const data = await res.json() as { src?: string; error?: string };
+            if (!res.ok || data.error) {
+              statusEl.textContent = data.error ?? 'Upload fehlgeschlagen';
+              statusEl.className = 'text-xs mt-1 text-red-400';
+            } else {
+              srcInput.value = data.src!;
+              statusEl.textContent = '✓ Bild hochgeladen — bitte speichern';
+              statusEl.className = 'text-xs mt-1 text-green-400';
+            }
+          } catch {
+            statusEl.textContent = 'Netzwerkfehler beim Upload';
+            statusEl.className = 'text-xs mt-1 text-red-400';
+          }
+        });
       </script>
 
       <!-- Quote -->

--- a/website/src/pages/admin/termine.astro
+++ b/website/src/pages/admin/termine.astro
@@ -3,8 +3,8 @@ import AdminLayout from '../../layouts/AdminLayout.astro';
 import { getSession, getLoginUrl, isAdmin } from '../../lib/auth';
 import { getAvailableSlots, getAllBookings } from '../../lib/caldav';
 import type { DaySlots, AdminBooking } from '../../lib/caldav';
-import { getBookingProjects, listProjects, getBookingInvoices, getWhitelistedSlots, getBookingLeistungen } from '../../lib/website-db';
-import type { Project, BookingInvoiceInfo } from '../../lib/website-db';
+import { getBookingProjects, listProjects, getBookingInvoices, getWhitelistedSlots, getBookingLeistungen, getVacationPeriods } from '../../lib/website-db';
+import type { Project, BookingInvoiceInfo, VacationPeriod } from '../../lib/website-db';
 import { getEffectiveLeistungen } from '../../lib/content';
 import type { LeistungCategory } from '../../config/types';
 import AdminBookingModal from '../../components/admin/AdminBookingModal.svelte';
@@ -30,6 +30,11 @@ let bookingLeistungMap: Map<string, string> = new Map();
 let leistungen: LeistungCategory[] = [];
 let projects: Project[] = [];
 let calError = '';
+let vacationPeriods: VacationPeriod[] = [];
+
+try {
+  vacationPeriods = await getVacationPeriods(brand).catch(() => []);
+} catch { /**/ }
 
 try {
   const [allSlots, allBookings, allProjects] = await Promise.all([
@@ -347,6 +352,28 @@ function formatTime(d: Date) {
       </div>
 
     </div>
+
+    <!-- Urlaubsplanung / Auszeiten -->
+    <div class="mt-12">
+      <h2 class="text-xl font-semibold text-light mb-4">Urlaubsplanung <span class="text-sm font-normal text-muted">/ Auszeiten</span></h2>
+      <p class="text-sm text-muted mb-4">Geblockte Zeiträume erscheinen nicht in der Buchungsansicht. Änderungen wirken sofort.</p>
+      <div id="vacation-list" class="space-y-2 mb-4">
+        {vacationPeriods.map((p, i) => (
+          <div class="vacation-row flex gap-2 items-center flex-wrap p-3 bg-dark-light rounded-lg border border-dark-lighter" data-id={p.id}>
+            <input type="text" class="vacation-label flex-1 min-w-32 bg-dark border border-dark-lighter rounded px-2 py-1 text-light text-sm focus:border-gold outline-none" value={p.label} placeholder="Bezeichnung (z.B. Sommerurlaub)" />
+            <input type="date" class="vacation-start bg-dark border border-dark-lighter rounded px-2 py-1 text-light text-sm focus:border-gold outline-none" value={p.start} />
+            <span class="text-muted text-sm">bis</span>
+            <input type="date" class="vacation-end bg-dark border border-dark-lighter rounded px-2 py-1 text-light text-sm focus:border-gold outline-none" value={p.end} />
+            <button class="vacation-remove text-xs px-2 py-1 bg-dark-lighter text-muted rounded hover:text-red-400 border border-dark-lighter">✕</button>
+          </div>
+        ))}
+      </div>
+      <button id="vacation-add" class="text-sm px-3 py-1.5 border border-dashed border-gold/30 text-gold/70 rounded-lg hover:border-gold/60 hover:text-gold transition-colors">＋ Zeitraum hinzufügen</button>
+      <button id="vacation-save" class="ml-3 text-sm px-4 py-1.5 bg-gold text-dark rounded-lg font-semibold hover:bg-gold/90 transition-colors">Speichern</button>
+      <span id="vacation-status" class="ml-3 text-sm hidden"></span>
+    </div>
+
+    </div>
   </section>
 </AdminLayout>
 
@@ -590,5 +617,49 @@ function formatTime(d: Date) {
       btn.disabled = false;
       btn.textContent = '✉ Erinnerung';
     });
+  });
+
+  // Vacation planning
+  const CLS = {
+    row: 'vacation-row flex gap-2 items-center flex-wrap p-3 bg-dark-light rounded-lg border border-dark-lighter',
+    input: 'bg-dark border border-dark-lighter rounded px-2 py-1 text-light text-sm focus:border-gold outline-none',
+  };
+
+  function makeVacationRow(): HTMLElement {
+    const div = document.createElement('div');
+    div.className = CLS.row;
+    const lbl = Object.assign(document.createElement('input'), { type: 'text', className: `vacation-label flex-1 min-w-32 ${CLS.input}`, placeholder: 'Bezeichnung (z.B. Sommerurlaub)' });
+    const s = Object.assign(document.createElement('input'), { type: 'date', className: `vacation-start ${CLS.input}` });
+    const sep = Object.assign(document.createElement('span'), { className: 'text-muted text-sm', textContent: 'bis' });
+    const e = Object.assign(document.createElement('input'), { type: 'date', className: `vacation-end ${CLS.input}` });
+    const rm = Object.assign(document.createElement('button'), { type: 'button', className: 'vacation-remove text-xs px-2 py-1 bg-dark-lighter text-muted rounded hover:text-red-400 border border-dark-lighter', textContent: '✕' });
+    div.append(lbl, s, sep, e, rm);
+    return div;
+  }
+
+  const vacList = document.getElementById('vacation-list')!;
+  vacList.addEventListener('click', e => {
+    const btn = (e.target as HTMLElement).closest<HTMLButtonElement>('.vacation-remove');
+    if (btn) btn.closest('.vacation-row')?.remove();
+  });
+  document.getElementById('vacation-add')?.addEventListener('click', () => vacList.appendChild(makeVacationRow()));
+  document.getElementById('vacation-save')?.addEventListener('click', async () => {
+    const statusEl = document.getElementById('vacation-status')!;
+    const periods = Array.from(vacList.querySelectorAll<HTMLElement>('.vacation-row')).map(row => ({
+      label: (row.querySelector<HTMLInputElement>('.vacation-label')?.value ?? '').trim() || 'Auszeit',
+      start: row.querySelector<HTMLInputElement>('.vacation-start')?.value ?? '',
+      end: row.querySelector<HTMLInputElement>('.vacation-end')?.value ?? '',
+    })).filter(p => p.start && p.end && p.start <= p.end);
+    try {
+      const res = await fetch('/api/admin/urlaub/save', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ periods }) });
+      if (!res.ok) throw new Error();
+      statusEl.textContent = '✓ Gespeichert';
+      statusEl.className = 'ml-3 text-sm text-green-400';
+    } catch {
+      statusEl.textContent = 'Fehler beim Speichern';
+      statusEl.className = 'ml-3 text-sm text-red-400';
+    }
+    statusEl.classList.remove('hidden');
+    setTimeout(() => statusEl.classList.add('hidden'), 3000);
   });
 </script>

--- a/website/src/pages/api/admin/startseite/upload-portrait.ts
+++ b/website/src/pages/api/admin/startseite/upload-portrait.ts
@@ -1,0 +1,30 @@
+import type { APIRoute } from 'astro';
+import { getSession, isAdmin } from '../../../../lib/auth';
+
+const MAX_SIZE = 2 * 1024 * 1024; // 2 MB
+const ALLOWED = ['image/jpeg', 'image/png', 'image/webp', 'image/gif'];
+
+export const POST: APIRoute = async ({ request }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 });
+
+  const form = await request.formData();
+  const file = form.get('file') as File | null;
+  if (!file || typeof file === 'string') {
+    return new Response(JSON.stringify({ error: 'Keine Datei übermittelt' }), { status: 400 });
+  }
+  if (!ALLOWED.includes(file.type)) {
+    return new Response(JSON.stringify({ error: 'Nur JPEG, PNG, WebP oder GIF erlaubt' }), { status: 400 });
+  }
+  if (file.size > MAX_SIZE) {
+    return new Response(JSON.stringify({ error: 'Datei zu groß (max. 2 MB)' }), { status: 400 });
+  }
+
+  const buffer = await file.arrayBuffer();
+  const base64 = Buffer.from(buffer).toString('base64');
+  const dataUrl = `data:${file.type};base64,${base64}`;
+
+  return new Response(JSON.stringify({ src: dataUrl }), {
+    headers: { 'Content-Type': 'application/json' },
+  });
+};

--- a/website/src/pages/api/admin/urlaub/save.ts
+++ b/website/src/pages/api/admin/urlaub/save.ts
@@ -1,0 +1,22 @@
+import type { APIRoute } from 'astro';
+import { getSession, isAdmin } from '../../../../lib/auth';
+import { saveVacationPeriods } from '../../../../lib/website-db';
+import type { VacationPeriod } from '../../../../lib/website-db';
+import { randomUUID } from 'crypto';
+
+const BRAND = process.env.BRAND || 'mentolder';
+
+export const POST: APIRoute = async ({ request }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 });
+
+  const { periods } = await request.json() as { periods: Omit<VacationPeriod, 'id'>[] };
+  if (!Array.isArray(periods)) return new Response(JSON.stringify({ error: 'periods required' }), { status: 400 });
+
+  const validated: VacationPeriod[] = periods
+    .filter(p => p.start && p.end && p.start <= p.end)
+    .map(p => ({ id: randomUUID(), start: p.start, end: p.end, label: (p.label || '').trim() || 'Auszeit' }));
+
+  await saveVacationPeriods(BRAND, validated);
+  return new Response(JSON.stringify({ success: true }), { headers: { 'Content-Type': 'application/json' } });
+};


### PR DESCRIPTION
## Summary

- **BR-20260420-8c59** — Fix `claude-code-mcp-apps` crashloop (169 restarts): increased nextcloud-mcp liveness probe timeout 5 s → 10 s and interval 30 s → 60 s to stop false-positive kills when Nextcloud is slow to respond
- **BR-20260420-1687** — Chat member picker now only shows SSO-linked customers (`keycloak_user_id IS NOT NULL`); added clarifying label so the admin knows why some customers are missing
- **BR-20260420-e144** — Removed Follow-Ups from admin navigation, dashboard KPI card, and data fetch
- **BR-20260420-0e37** — Added collapse/expand toggle button to InboxApp filter sidebar
- **BR-20260420-5155** — Portrait image upload in Startseite admin (JPEG/PNG/WebP/GIF, max 2 MB, stored as base64 data URL); URL input remains as alternative
- **BR-20260420-bd7f + BR-20260420-0f63** — AdminBookingModal: new "Freier Termin" mode lets admin pick any date, start time, and duration (15/30/45/60/90/120 min); end time calculated automatically
- **BR-20260420-60f8** — Vacation/blackout period management section in admin Termine page; periods stored in `site_settings`, `getAvailableSlots` skips blocked days

## Test plan

- [ ] Verify `claude-code-mcp-apps` pod stays stable after redeployment
- [ ] Open chat room member panel — only SSO-linked customers appear, label visible
- [ ] Admin nav: Follow-ups entry gone; dashboard: no Follow-ups KPI card
- [ ] Inbox page: collapse button on left sidebar works
- [ ] Startseite admin → Porträtbild: file upload button appears, selecting image sets URL field
- [ ] Termine admin → "＋ Manuelle Buchung": "Freier Termin" radio visible; custom date/time/duration inputs work
- [ ] Termine admin → Urlaubsplanung: add/remove periods, save; verify blocked days don't show slots on booking page

🤖 Generated with [Claude Code](https://claude.ai/claude-code)