### PR TITLE
feat(booking): replace slot whitelist with admin-defined time windows

### DIFF
--- a/website/src/components/BookingForm.svelte
+++ b/website/src/components/BookingForm.svelte
@@ -41,15 +41,18 @@
   let agbAccepted = $state(false);
 
   let portalProjects = $state<Array<{ id: string; name: string }>>([]);
-  let leistungenOptions = $state<Array<{ key: string; name: string; category: string }>>([]);
+  let leistungenOptions = $state<Array<{ key: string; name: string; category: string; durationMin?: number }>>([]);
   let selectedProjectId = $state('');
   let selectedLeistungKey = $state('');
+  let leistungenLoaded = $state(false);
 
   onMount(async () => {
     try {
       const res = await fetch('/api/leistungen');
       if (res.ok) leistungenOptions = await res.json();
-    } catch { /* ignore */ }
+    } catch { /* ignore */ } finally {
+      leistungenLoaded = true;
+    }
 
     try {
       const res = await fetch('/api/portal/projekte');
@@ -57,7 +60,17 @@
     } catch { /* ignore */ }
   });
 
+  // Duration mapping per booking type (minutes)
+  const TYPE_DURATIONS: Record<string, number> = {
+    erstgespraech: 30,
+    meeting: 60,
+    termin: 60,
+  };
+
   let isCallback = $derived(bookingType === 'callback');
+  // Step 2 (leistung) is considered "done" when leistung is selected or none available
+  let leistungSelected = $derived(selectedLeistungKey !== '' || (leistungenLoaded && leistungenOptions.length === 0));
+  let showSlotSelection = $derived(!isCallback && leistungSelected);
   let showContactForm = $derived(isCallback || selectedSlot !== null);
   let currentDaySlots = $derived(days.find((d) => d.date === selectedDate));
 
@@ -69,27 +82,45 @@
   ];
 
   let slotLoadError = $state(false);
+  let slotsLoading = $state(false);
 
-  // Fetch available slots on mount
-  if (typeof window !== 'undefined' && initialType !== 'callback') {
+  async function loadSlots() {
+    if (isCallback) return;
+    slotsLoading = true;
+    loading = true;
+    slotLoadError = false;
+    selectedSlot = null;
+    days = [];
+    const selectedLeistung = leistungenOptions.find(l => l.key === selectedLeistungKey);
+    const duration = selectedLeistung?.durationMin ?? TYPE_DURATIONS[bookingType] ?? undefined;
+    const params = new URLSearchParams();
+    if (duration) params.set('durationMin', String(duration));
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), 10000);
-    fetch('/api/calendar/slots', { signal: controller.signal })
-      .then((r) => r.json())
-      .then((data) => {
-        clearTimeout(timeoutId);
-        if (Array.isArray(data)) {
-          days = data;
-          if (!initialDate && data.length > 0) selectedDate = data[0].date;
-        }
-        loading = false;
-      })
-      .catch(() => {
-        clearTimeout(timeoutId);
-        slotLoadError = true;
-        loading = false;
-      });
+    try {
+      const r = await fetch(`/api/calendar/slots${params.size ? '?' + params.toString() : ''}`, { signal: controller.signal });
+      clearTimeout(timeoutId);
+      const data = await r.json();
+      if (Array.isArray(data)) {
+        days = data;
+        if (!initialDate && data.length > 0) selectedDate = data[0].date;
+        else if (initialDate) selectedDate = initialDate;
+      }
+    } catch {
+      clearTimeout(timeoutId);
+      slotLoadError = true;
+    } finally {
+      loading = false;
+      slotsLoading = false;
+    }
   }
+
+  // Load slots when leistung selection is ready
+  $effect(() => {
+    if (showSlotSelection && days.length === 0 && !slotsLoading && !slotLoadError) {
+      loadSlots();
+    }
+  });
 
   function selectSlot(slot: TimeSlot) {
     selectedSlot = slot;
@@ -178,7 +209,7 @@
           class="p-4 rounded-xl border text-left transition-all {bookingType === bt.value
             ? 'border-gold bg-gold-dim text-gold'
             : 'border-dark-lighter bg-dark hover:border-gold/30 text-muted'}"
-          onclick={() => (bookingType = bt.value)}
+          onclick={() => { bookingType = bt.value; selectedLeistungKey = ''; selectedSlot = null; days = []; }}
         >
           {bt.label}
         </button>
@@ -186,10 +217,34 @@
     </div>
   </div>
 
-  <!-- Step 2: Choose date + slot (not needed for callback) -->
-  {#if !isCallback}
+  <!-- Step 2: Choose Leistung (not needed for callback) -->
+  {#if !isCallback && leistungenOptions.length > 0}
   <div>
-    <h3 class="text-xl font-semibold text-light mb-4">2. Termin wählen</h3>
+    <h3 class="text-xl font-semibold text-light mb-4">2. Gewünschte Leistung</h3>
+    <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+      {#each leistungenOptions as opt}
+        <button
+          type="button"
+          class="p-4 rounded-xl border text-left transition-all {selectedLeistungKey === opt.key
+            ? 'border-gold bg-gold-dim text-gold'
+            : 'border-dark-lighter bg-dark hover:border-gold/30 text-muted'}"
+          onclick={() => { selectedLeistungKey = opt.key; selectedSlot = null; days = []; }}
+        >
+          <div class="font-medium">{opt.name}</div>
+          <div class="text-xs mt-1 opacity-70">{opt.category}{opt.durationMin ? ` · ${opt.durationMin} Min.` : ''}</div>
+        </button>
+      {/each}
+    </div>
+    {#if !leistungenLoaded}
+      <p class="text-muted text-sm mt-3">Leistungen werden geladen…</p>
+    {/if}
+  </div>
+  {/if}
+
+  <!-- Step 3: Choose date + slot (not needed for callback, requires leistung selection) -->
+  {#if showSlotSelection}
+  <div>
+    <h3 class="text-xl font-semibold text-light mb-4">{leistungenOptions.length > 0 ? '3' : '2'}. Termin wählen</h3>
 
     {#if loading}
       <div class="text-muted py-8 text-center">Verfügbare Termine werden geladen...</div>
@@ -199,7 +254,7 @@
       </div>
     {:else if days.length === 0}
       <div class="text-muted py-8 text-center bg-dark rounded-xl border border-dark-lighter">
-        Derzeit sind keine freien Termine verfügbar. Bitte kontaktieren Sie uns direkt.
+        Derzeit sind keine freien Termine für diese Leistung verfügbar. Bitte kontaktieren Sie uns direkt.
       </div>
     {:else}
       <!-- Date tabs -->
@@ -244,10 +299,12 @@
   </div>
   {/if}
 
-  <!-- Step 3 (or Step 2 for callback): Contact details -->
+  <!-- Last step: Contact details -->
   {#if showContactForm}
     <form onsubmit={handleSubmit} class="space-y-6">
-      <h3 class="text-xl font-semibold text-light">{isCallback ? '2' : '3'}. Ihre Kontaktdaten</h3>
+      <h3 class="text-xl font-semibold text-light">
+        {#if isCallback}2{:else if leistungenOptions.length > 0}4{:else}3{/if}. Ihre Kontaktdaten
+      </h3>
 
       <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
         <div>
@@ -322,30 +379,17 @@
         </label>
       </div>
 
-      {#if leistungenOptions.length > 0 && bookingType !== 'callback'}
+      {#if portalProjects.length > 0}
         <div>
-          <label class="block text-sm text-muted mb-1">Leistung (optional)</label>
-          <select bind:value={selectedLeistungKey}
+          <label class="block text-sm text-muted mb-1">Für welches Projekt? (optional)</label>
+          <select bind:value={selectedProjectId}
             class="w-full px-3 py-2 bg-dark border border-dark-lighter rounded-lg text-light text-sm">
-            <option value="">— Keine Leistung —</option>
-            {#each leistungenOptions as opt}
-              <option value={opt.key}>{opt.category} — {opt.name}</option>
+            <option value="">— Kein Projekt —</option>
+            {#each portalProjects as p}
+              <option value={p.id}>{p.name}</option>
             {/each}
           </select>
         </div>
-
-        {#if portalProjects.length > 0}
-          <div>
-            <label class="block text-sm text-muted mb-1">Für welches Projekt? (optional)</label>
-            <select bind:value={selectedProjectId}
-              class="w-full px-3 py-2 bg-dark border border-dark-lighter rounded-lg text-light text-sm">
-              <option value="">— Kein Projekt —</option>
-              {#each portalProjects as p}
-                <option value={p.id}>{p.name}</option>
-              {/each}
-            </select>
-          </div>
-        {/if}
       {/if}
 
       <button

--- a/website/src/config/types.ts
+++ b/website/src/config/types.ts
@@ -38,6 +38,7 @@ export interface LeistungService {
   desc: string;
   highlight?: boolean;
   stundensatz_cents?: number;
+  durationMin?: number;
 }
 
 export interface LeistungCategory {

--- a/website/src/lib/caldav.ts
+++ b/website/src/lib/caldav.ts
@@ -251,21 +251,34 @@ export async function getClientBookings(clientEmail: string): Promise<ClientBook
 }
 
 // Compute available booking slots for a range of days.
-// When brand is provided, only whitelisted slots are returned (public booking view).
-// Without brand, all calendar-free slots are returned (admin overview).
-export async function getAvailableSlots(fromDate?: Date, brand?: string): Promise<DaySlots[]> {
-  let whitelistedSet: Set<string> | null = null;
+// When brand is provided, slots are generated from admin-defined free time windows.
+// Without brand, all calendar-free slots in working hours are returned (admin overview).
+export async function getAvailableSlots(fromDate?: Date, brand?: string, slotDurationMin?: number): Promise<DaySlots[]> {
+  const duration = slotDurationMin ?? SLOT_DURATION_MIN;
+
+  // windowsMap: date string → array of {winStart, winEnd} (HH:MM strings)
+  let windowsMap: Map<string, Array<{ winStart: string; winEnd: string }>> | null = null;
   let vacationDays: Set<string> = new Set();
   const effectiveBrand = brand || process.env.BRAND || 'mentolder';
+
   if (brand) {
     try {
-      const { getWhitelistedSlots } = await import('./website-db.js');
-      const wl = await getWhitelistedSlots(brand);
-      whitelistedSet = new Set(wl.map((w: { slotStart: Date }) => w.slotStart.toISOString()));
+      const { getFreeTimeWindows } = await import('./website-db.js');
+      const fromStr = (fromDate || new Date()).toISOString().split('T')[0];
+      const horizonDate = new Date(fromDate || new Date());
+      horizonDate.setDate(horizonDate.getDate() + BOOKING_HORIZON_DAYS);
+      const toStr = horizonDate.toISOString().split('T')[0];
+      const windows = await getFreeTimeWindows(brand, fromStr, toStr);
+      windowsMap = new Map();
+      for (const w of windows) {
+        if (!windowsMap.has(w.date)) windowsMap.set(w.date, []);
+        windowsMap.get(w.date)!.push({ winStart: w.winStart, winEnd: w.winEnd });
+      }
     } catch {
-      // If whitelist table missing, fall back to showing all slots
+      // fall back to showing all slots if windows table missing
     }
   }
+
   try {
     const { getVacationPeriods } = await import('./website-db.js');
     const periods = await getVacationPeriods(effectiveBrand);
@@ -280,6 +293,7 @@ export async function getAvailableSlots(fromDate?: Date, brand?: string): Promis
   } catch {
     // vacation periods unavailable — continue without them
   }
+
   const now = new Date();
   const start = fromDate || now;
   const end = new Date(start);
@@ -296,44 +310,65 @@ export async function getAvailableSlots(fromDate?: Date, brand?: string): Promis
     const isoDay = dayOfWeek === 0 ? 7 : dayOfWeek;
     const dayStr = cursor.toISOString().split('T')[0];
 
-    if (WORK_DAYS.includes(isoDay) && !vacationDays.has(dayStr)) {
-      const slots: TimeSlot[] = [];
+    if (vacationDays.has(dayStr)) {
+      cursor.setDate(cursor.getDate() + 1);
+      continue;
+    }
 
-      for (let hour = WORK_START_HOUR; hour < WORK_END_HOUR; hour += SLOT_DURATION_MIN / 60) {
-        const slotStart = new Date(cursor);
-        slotStart.setHours(Math.floor(hour), (hour % 1) * 60, 0, 0);
-        const slotEnd = new Date(slotStart.getTime() + SLOT_DURATION_MIN * 60000);
+    const slots: TimeSlot[] = [];
 
-        if (slotStart.getTime() < now.getTime() + MIN_ADVANCE_HOURS * 3600000) continue;
+    if (windowsMap !== null) {
+      // Customer view: generate slots within admin-defined time windows
+      const dayWindows = windowsMap.get(dayStr) ?? [];
+      for (const win of dayWindows) {
+        const [wsh, wsm] = win.winStart.split(':').map(Number);
+        const [weh, wem] = win.winEnd.split(':').map(Number);
+        const winStartMin = wsh * 60 + wsm;
+        const winEndMin = weh * 60 + wem;
 
-        const hasConflict = events.some(
-          (ev) => ev.start < slotEnd && ev.end > slotStart
-        );
+        for (let t = winStartMin; t + duration <= winEndMin; t += duration) {
+          const slotStart = new Date(cursor);
+          slotStart.setHours(Math.floor(t / 60), t % 60, 0, 0);
+          const slotEnd = new Date(slotStart.getTime() + duration * 60000);
 
-        if (!hasConflict) {
-          const isoStart = slotStart.toISOString();
-          if (whitelistedSet !== null && !whitelistedSet.has(isoStart)) continue;
+          if (slotStart.getTime() < now.getTime() + MIN_ADVANCE_HOURS * 3600000) continue;
+          if (events.some((ev) => ev.start < slotEnd && ev.end > slotStart)) continue;
 
           const startHH = slotStart.getHours().toString().padStart(2, '0');
           const startMM = slotStart.getMinutes().toString().padStart(2, '0');
           const endHH = slotEnd.getHours().toString().padStart(2, '0');
           const endMM = slotEnd.getMinutes().toString().padStart(2, '0');
-
           slots.push({
-            start: isoStart,
+            start: slotStart.toISOString(),
             end: slotEnd.toISOString(),
             display: `${startHH}:${startMM} - ${endHH}:${endMM}`,
           });
         }
       }
+    } else if (WORK_DAYS.includes(isoDay)) {
+      // Admin overview: all calendar-free slots in configured working hours
+      for (let hour = WORK_START_HOUR; hour < WORK_END_HOUR; hour += duration / 60) {
+        const slotStart = new Date(cursor);
+        slotStart.setHours(Math.floor(hour), (hour % 1) * 60, 0, 0);
+        const slotEnd = new Date(slotStart.getTime() + duration * 60000);
 
-      if (slots.length > 0) {
-        result.push({
-          date: dayStr,
-          weekday: WEEKDAYS_DE[dayOfWeek],
-          slots,
+        if (slotStart.getTime() < now.getTime() + MIN_ADVANCE_HOURS * 3600000) continue;
+        if (events.some((ev) => ev.start < slotEnd && ev.end > slotStart)) continue;
+
+        const startHH = slotStart.getHours().toString().padStart(2, '0');
+        const startMM = slotStart.getMinutes().toString().padStart(2, '0');
+        const endHH = slotEnd.getHours().toString().padStart(2, '0');
+        const endMM = slotEnd.getMinutes().toString().padStart(2, '0');
+        slots.push({
+          start: slotStart.toISOString(),
+          end: slotEnd.toISOString(),
+          display: `${startHH}:${startMM} - ${endHH}:${endMM}`,
         });
       }
+    }
+
+    if (slots.length > 0) {
+      result.push({ date: dayStr, weekday: WEEKDAYS_DE[dayOfWeek], slots });
     }
 
     cursor.setDate(cursor.getDate() + 1);

--- a/website/src/lib/website-db.ts
+++ b/website/src/lib/website-db.ts
@@ -2124,6 +2124,83 @@ export async function claimSlot(brand: string, start: Date): Promise<boolean> {
   return (result.rowCount ?? 0) > 0;
 }
 
+// ── Free Time Windows ────────────────────────────────────────────────────────
+
+export interface FreeTimeWindow {
+  id: string;
+  date: string;     // YYYY-MM-DD
+  winStart: string; // HH:MM
+  winEnd: string;   // HH:MM
+}
+
+async function initFreeTimeWindowsTable(): Promise<void> {
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS free_time_windows (
+      id         TEXT        NOT NULL DEFAULT gen_random_uuid()::text,
+      brand      TEXT        NOT NULL,
+      date       DATE        NOT NULL,
+      win_start  TIME        NOT NULL,
+      win_end    TIME        NOT NULL,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      PRIMARY KEY (id)
+    )
+  `);
+}
+
+export async function getFreeTimeWindows(brand: string, fromDate?: string, toDate?: string): Promise<FreeTimeWindow[]> {
+  await initFreeTimeWindowsTable();
+  const result = await pool.query(
+    `SELECT id,
+            to_char(date, 'YYYY-MM-DD')   AS date,
+            to_char(win_start, 'HH24:MI') AS "winStart",
+            to_char(win_end,   'HH24:MI') AS "winEnd"
+     FROM free_time_windows
+     WHERE brand = $1
+       AND ($2::date IS NULL OR date >= $2::date)
+       AND ($3::date IS NULL OR date <= $3::date)
+     ORDER BY date ASC, win_start ASC`,
+    [brand, fromDate ?? null, toDate ?? null]
+  );
+  return result.rows;
+}
+
+export async function addFreeTimeWindow(brand: string, date: string, winStart: string, winEnd: string): Promise<string> {
+  await initFreeTimeWindowsTable();
+  const result = await pool.query(
+    `INSERT INTO free_time_windows (brand, date, win_start, win_end)
+     VALUES ($1, $2::date, $3::time, $4::time)
+     RETURNING id`,
+    [brand, date, winStart, winEnd]
+  );
+  return result.rows[0].id as string;
+}
+
+export async function removeFreeTimeWindow(brand: string, id: string): Promise<void> {
+  await initFreeTimeWindowsTable();
+  await pool.query(
+    'DELETE FROM free_time_windows WHERE id = $1 AND brand = $2',
+    [id, brand]
+  );
+}
+
+export async function isSlotInAnyWindow(brand: string, slotStart: Date, slotEnd: Date): Promise<boolean> {
+  await initFreeTimeWindowsTable();
+  const dateStr = slotStart.toISOString().split('T')[0];
+  const sh = slotStart.getHours().toString().padStart(2, '0');
+  const sm = slotStart.getMinutes().toString().padStart(2, '0');
+  const eh = slotEnd.getHours().toString().padStart(2, '0');
+  const em = slotEnd.getMinutes().toString().padStart(2, '0');
+  const result = await pool.query(
+    `SELECT 1 FROM free_time_windows
+     WHERE brand = $1
+       AND date = $2::date
+       AND win_start <= $3::time
+       AND win_end   >= $4::time`,
+    [brand, dateStr, `${sh}:${sm}`, `${eh}:${em}`]
+  );
+  return (result.rowCount ?? 0) > 0;
+}
+
 export async function listBugTickets(filters: {
   status?: string;
   category?: string;

--- a/website/src/pages/admin/termine.astro
+++ b/website/src/pages/admin/termine.astro
@@ -1,10 +1,10 @@
 ---
 import AdminLayout from '../../layouts/AdminLayout.astro';
 import { getSession, getLoginUrl, isAdmin } from '../../lib/auth';
-import { getAvailableSlots, getAllBookings } from '../../lib/caldav';
-import type { DaySlots, AdminBooking } from '../../lib/caldav';
-import { getBookingProjects, listProjects, getBookingInvoices, getWhitelistedSlots, getBookingLeistungen, getVacationPeriods } from '../../lib/website-db';
-import type { Project, BookingInvoiceInfo, VacationPeriod } from '../../lib/website-db';
+import { getAllBookings } from '../../lib/caldav';
+import type { AdminBooking } from '../../lib/caldav';
+import { getBookingProjects, listProjects, getBookingInvoices, getBookingLeistungen, getVacationPeriods, getFreeTimeWindows } from '../../lib/website-db';
+import type { Project, BookingInvoiceInfo, VacationPeriod, FreeTimeWindow } from '../../lib/website-db';
 import { getEffectiveLeistungen } from '../../lib/content';
 import type { LeistungCategory } from '../../config/types';
 import AdminBookingModal from '../../components/admin/AdminBookingModal.svelte';
@@ -18,11 +18,12 @@ const calendarUrl = `https://${NC_DOMAIN}/apps/calendar`;
 const brand = process.env.BRAND_NAME || 'mentolder';
 const IN_PUBLIC_URL = process.env.INVOICENINJA_PUBLIC_URL || '';
 
+const WEEKDAYS_DE = ['Sonntag', 'Montag', 'Dienstag', 'Mittwoch', 'Donnerstag', 'Freitag', 'Samstag'];
+
 const now = new Date();
 const horizon = new Date(now);
 horizon.setDate(horizon.getDate() + 14);
 
-let days: DaySlots[] = [];
 let bookings: AdminBooking[] = [];
 let bookingProjectMap: Map<string, string> = new Map();
 let bookingInvoiceMap: Map<string, BookingInvoiceInfo> = new Map();
@@ -37,13 +38,10 @@ try {
 } catch { /**/ }
 
 try {
-  const [allSlots, allBookings, allProjects] = await Promise.all([
-    // Without brand: all generated slots (no whitelist filter) for admin overview
-    getAvailableSlots(now),
+  const [allBookings, allProjects] = await Promise.all([
     getAllBookings(),
     listProjects({ brand }),
   ]);
-  days = allSlots.filter(d => new Date(d.date) <= horizon);
   bookings = allBookings;
   projects = allProjects;
   const uids = bookings.map(b => b.uid).filter(Boolean);
@@ -62,15 +60,32 @@ try {
   calError = 'Kalender konnte nicht geladen werden.';
 }
 
-// Load whitelist and build a Set of whitelisted ISO start strings
-const whitelistedSlots = await getWhitelistedSlots(brand).catch(() => [] as { slotStart: Date }[]);
-const whitelistedSet = new Set(whitelistedSlots.map((w: { slotStart: Date }) => w.slotStart.toISOString()));
+// Generate all days for next 14 days (show every day, not just work days)
+const allDays: Array<{ date: string; weekday: string }> = [];
+{
+  const cur = new Date(now);
+  cur.setHours(0, 0, 0, 0);
+  while (cur <= horizon) {
+    const dayStr = cur.toISOString().split('T')[0];
+    allDays.push({ date: dayStr, weekday: WEEKDAYS_DE[cur.getDay()] });
+    cur.setDate(cur.getDate() + 1);
+  }
+}
 
-const totalSlots = days.reduce((sum, d) => sum + d.slots.length, 0);
-const releasedCount = days.reduce(
-  (sum, d) => sum + d.slots.filter(s => whitelistedSet.has(s.start)).length,
-  0
-);
+// Load time windows and group by date
+const timeWindowsList = await getFreeTimeWindows(
+  brand,
+  now.toISOString().split('T')[0],
+  horizon.toISOString().split('T')[0]
+).catch(() => [] as FreeTimeWindow[]);
+
+const windowsByDate = new Map<string, FreeTimeWindow[]>();
+for (const w of timeWindowsList) {
+  if (!windowsByDate.has(w.date)) windowsByDate.set(w.date, []);
+  windowsByDate.get(w.date)!.push(w);
+}
+
+const totalWindows = timeWindowsList.length;
 const upcomingBookings = bookings.filter(b => b.start >= now && b.status !== 'CANCELLED');
 const pastBookings = bookings.filter(b => b.start < now || b.status === 'CANCELLED');
 
@@ -90,7 +105,7 @@ function formatTime(d: Date) {
       <div class="mb-8 flex items-center justify-between">
         <div>
           <h1 class="text-3xl font-bold text-light font-serif">Termine</h1>
-          <p class="text-muted mt-1">{bookings.length} gebucht · {totalSlots} generierte Slots · <span class="text-gold"><span id="released-counter">{releasedCount}</span> freigegeben</span></p>
+          <p class="text-muted mt-1">{bookings.length} gebucht · <span class="text-gold"><span id="windows-counter">{totalWindows}</span> Zeiträume freigegeben</span></p>
         </div>
         <div class="flex gap-3">
           <AdminBookingModal
@@ -307,47 +322,55 @@ function formatTime(d: Date) {
         )}
       </div>
 
-      <!-- Freie Slots (Whitelist-Verwaltung) -->
+      <!-- Freie Zeiträume -->
       <div>
-        <h2 class="text-xl font-semibold text-light mb-4">Freie Slots <span class="text-sm font-normal text-muted">(nächste 14 Tage)</span></h2>
+        <h2 class="text-xl font-semibold text-light mb-1">Freie Zeiträume <span class="text-sm font-normal text-muted">(nächste 14 Tage)</span></h2>
+        <p class="text-sm text-muted mb-4">Definiere Zeitfenster pro Tag. Kunden sehen automatisch alle Terminslots innerhalb dieser Fenster.</p>
 
-        {days.length === 0 && !calError && (
-          <div class="p-6 bg-dark-light rounded-xl border border-dark-lighter text-muted text-center">
-            Keine generierten Termine in den nächsten 14 Tagen.
-          </div>
-        )}
+        <div class="grid gap-3">
+          {allDays.map(day => {
+            const windows = windowsByDate.get(day.date) ?? [];
+            return (
+              <div class="p-4 bg-dark-light rounded-xl border border-dark-lighter" data-date={day.date}>
+                <div class="flex items-center gap-3 mb-2">
+                  <h3 class="text-light font-semibold text-sm">{day.weekday}</h3>
+                  <span class="text-muted text-xs">{day.date}</span>
+                  {windows.length > 0 && (
+                    <span class="ml-auto text-xs text-gold">{windows.length} Zeitraum{windows.length !== 1 ? 'e' : ''}</span>
+                  )}
+                </div>
 
-        <div class="grid gap-4">
-          {days.map(day => (
-            <div class="p-5 bg-dark-light rounded-xl border border-dark-lighter">
-              <div class="flex items-center gap-3 mb-3">
-                <h3 class="text-light font-semibold">{day.weekday}</h3>
-                <span class="text-muted text-sm">{day.date}</span>
-                <span class="ml-auto text-xs text-muted">{day.slots.length} Slot{day.slots.length !== 1 ? 's' : ''}</span>
+                <div class="space-y-1.5 mb-2 windows-list">
+                  {windows.map(w => (
+                    <div class="flex items-center gap-2 px-3 py-1.5 bg-gold/5 rounded-lg border border-gold/20 window-entry" data-id={w.id}>
+                      <span class="text-gold font-mono text-sm">{w.winStart} – {w.winEnd}</span>
+                      <button
+                        class="window-remove ml-auto text-muted hover:text-red-400 transition-colors text-xs px-1"
+                        data-id={w.id}
+                        data-date={day.date}
+                        title="Zeitraum entfernen"
+                      >✕</button>
+                    </div>
+                  ))}
+                </div>
+
+                <div class="window-add-form hidden gap-2 items-center flex-wrap" style="display:none" data-date={day.date}>
+                  <input type="time" class="window-start bg-dark border border-dark-lighter rounded px-2 py-1 text-light text-sm focus:border-gold outline-none" value="09:00" />
+                  <span class="text-muted text-xs">bis</span>
+                  <input type="time" class="window-end bg-dark border border-dark-lighter rounded px-2 py-1 text-light text-sm focus:border-gold outline-none" value="12:00" />
+                  <button class="window-save text-xs px-3 py-1 bg-gold text-dark rounded font-semibold hover:bg-gold/90 transition-colors" data-date={day.date}>Speichern</button>
+                  <button class="window-cancel text-xs px-2 py-1 text-muted hover:text-light transition-colors">✕</button>
+                </div>
+
+                <button
+                  class="window-add text-xs px-3 py-1.5 border border-dashed border-gold/30 text-gold/60 rounded-lg hover:border-gold/60 hover:text-gold transition-colors"
+                  data-date={day.date}
+                >
+                  ＋ Zeitraum
+                </button>
               </div>
-              <div class="flex flex-wrap gap-2">
-                {day.slots.map(slot => {
-                  const released = whitelistedSet.has(slot.start);
-                  return (
-                    <button
-                      class={`slot-toggle px-3 py-1.5 rounded-lg text-sm font-mono border transition-colors cursor-pointer ${
-                        released
-                          ? 'bg-gold/10 text-gold border-gold/20 hover:bg-gold/20'
-                          : 'bg-dark-lighter text-muted border-dark-lighter hover:border-gold/30'
-                      }`}
-                      data-start={slot.start}
-                      data-end={slot.end}
-                      data-released={released ? 'true' : 'false'}
-                      title={released ? 'Freigabe zurückziehen' : 'Slot freigeben'}
-                    >
-                      {slot.display}
-                      {released && <span class="ml-1 opacity-60">×</span>}
-                    </button>
-                  );
-                })}
-              </div>
-            </div>
-          ))}
+            );
+          })}
         </div>
       </div>
 
@@ -378,62 +401,145 @@ function formatTime(d: Date) {
 </AdminLayout>
 
 <script>
-  // Whitelist slot toggle
-  document.querySelectorAll<HTMLButtonElement>('.slot-toggle').forEach(btn => {
-    btn.addEventListener('click', async () => {
-      const start = btn.dataset.start!;
-      const end   = btn.dataset.end!;
-      const isReleased = btn.dataset.released === 'true';
+  // ── Zeitraum-Verwaltung ────────────────────────────────────────────────────
 
-      btn.disabled = true;
-      btn.style.opacity = '0.5';
+  function updateWindowsCounter(delta: number) {
+    const el = document.getElementById('windows-counter');
+    if (el) el.textContent = String(Number(el.textContent) + delta);
+  }
+
+  function makeWindowEntry(id: string, winStart: string, winEnd: string, date: string): HTMLElement {
+    const div = document.createElement('div');
+    div.className = 'flex items-center gap-2 px-3 py-1.5 bg-gold/5 rounded-lg border border-gold/20 window-entry';
+    div.dataset.id = id;
+    const label = document.createElement('span');
+    label.className = 'text-gold font-mono text-sm';
+    label.textContent = `${winStart} – ${winEnd}`;
+    const btn = document.createElement('button');
+    btn.className = 'window-remove ml-auto text-muted hover:text-red-400 transition-colors text-xs px-1';
+    btn.dataset.id = id;
+    btn.dataset.date = date;
+    btn.title = 'Zeitraum entfernen';
+    btn.textContent = '✕';
+    div.append(label, btn);
+    return div;
+  }
+
+  // Show/hide add-form on "＋ Zeitraum" click
+  document.addEventListener('click', async (e) => {
+    const target = e.target as HTMLElement;
+
+    // ＋ Zeitraum button
+    const addBtn = target.closest<HTMLButtonElement>('.window-add');
+    if (addBtn) {
+      const card = addBtn.closest<HTMLElement>('[data-date]')!;
+      const form = card.querySelector<HTMLElement>('.window-add-form')!;
+      form.style.display = 'flex';
+      addBtn.style.display = 'none';
+      return;
+    }
+
+    // Cancel form
+    const cancelBtn = target.closest<HTMLButtonElement>('.window-cancel');
+    if (cancelBtn) {
+      const card = cancelBtn.closest<HTMLElement>('[data-date]')!;
+      const form = card.querySelector<HTMLElement>('.window-add-form')!;
+      form.style.display = 'none';
+      const wb = card.querySelector<HTMLButtonElement>('.window-add')!;
+      wb.style.display = '';
+      return;
+    }
+
+    // Save window
+    const saveBtn = target.closest<HTMLButtonElement>('.window-save');
+    if (saveBtn) {
+      const card = saveBtn.closest<HTMLElement>('[data-date]')!;
+      const date = card.dataset.date!;
+      const form = card.querySelector<HTMLElement>('.window-add-form')!;
+      const winStart = form.querySelector<HTMLInputElement>('.window-start')!.value;
+      const winEnd   = form.querySelector<HTMLInputElement>('.window-end')!.value;
+
+      if (!winStart || !winEnd || winStart >= winEnd) {
+        alert('Bitte gültige Start- und Endzeit eingeben (Start muss vor Ende liegen).');
+        return;
+      }
+
+      saveBtn.textContent = '…';
+      saveBtn.disabled = true;
 
       try {
-        const res = await fetch(
-          isReleased ? '/api/admin/slots/remove' : '/api/admin/slots/add',
-          {
-            method: isReleased ? 'DELETE' : 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(isReleased ? { slotStart: start } : { slotStart: start, slotEnd: end }),
-          }
-        );
+        const res = await fetch('/api/admin/time-windows/add', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ date, winStart, winEnd }),
+        });
+        if (!res.ok) { alert('Fehler beim Speichern.'); return; }
+        const { id } = await res.json();
 
-        if (!res.ok) {
-          console.error('Slot toggle failed:', await res.text());
-          return;
-        }
+        const list = card.querySelector<HTMLElement>('.windows-list')!;
+        list.appendChild(makeWindowEntry(id, winStart, winEnd, date));
 
-        // Flip state
-        const nowReleased = !isReleased;
-        btn.dataset.released = nowReleased ? 'true' : 'false';
-
-        if (nowReleased) {
-          btn.classList.remove('bg-dark-lighter', 'text-muted', 'border-dark-lighter', 'hover:border-gold/30');
-          btn.classList.add('bg-gold/10', 'text-gold', 'border-gold/20', 'hover:bg-gold/20');
-          btn.title = 'Freigabe zurückziehen';
-          if (!btn.querySelector('.toggle-x')) {
-            const x = document.createElement('span');
-            x.className = 'ml-1 opacity-60 toggle-x';
-            x.textContent = '×';
-            btn.appendChild(x);
-          }
+        // Update badge
+        const badge = card.querySelector<HTMLElement>('.text-gold.ml-auto');
+        const count = card.querySelectorAll('.window-entry').length;
+        if (badge) {
+          badge.textContent = `${count} Zeitraum${count !== 1 ? 'e' : ''}`;
         } else {
-          btn.classList.remove('bg-gold/10', 'text-gold', 'border-gold/20', 'hover:bg-gold/20');
-          btn.classList.add('bg-dark-lighter', 'text-muted', 'border-dark-lighter', 'hover:border-gold/30');
-          btn.title = 'Slot freigeben';
-          btn.querySelector('.toggle-x')?.remove();
+          const header = card.querySelector<HTMLElement>('.flex.items-center.gap-3')!;
+          const newBadge = document.createElement('span');
+          newBadge.className = 'ml-auto text-xs text-gold';
+          newBadge.textContent = `${count} Zeitraum${count !== 1 ? 'e' : ''}`;
+          header.appendChild(newBadge);
         }
 
-        // Update released counter
-        const counterEl = document.getElementById('released-counter');
-        if (counterEl) {
-          counterEl.textContent = String(Number(counterEl.textContent) + (nowReleased ? 1 : -1));
-        }
+        updateWindowsCounter(1);
+        form.style.display = 'none';
+        const addBtnAfterSave = card.querySelector<HTMLButtonElement>('.window-add')!;
+        addBtnAfterSave.style.display = '';
+        // Reset time inputs
+        form.querySelector<HTMLInputElement>('.window-start')!.value = '09:00';
+        form.querySelector<HTMLInputElement>('.window-end')!.value = '12:00';
+      } catch {
+        alert('Netzwerkfehler.');
       } finally {
-        btn.disabled = false;
-        btn.style.opacity = '1';
+        saveBtn.textContent = 'Speichern';
+        saveBtn.disabled = false;
       }
-    });
+      return;
+    }
+
+    // Remove window
+    const removeBtn = target.closest<HTMLButtonElement>('.window-remove');
+    if (removeBtn) {
+      const id = removeBtn.dataset.id!;
+      removeBtn.disabled = true;
+      removeBtn.textContent = '…';
+      try {
+        const res = await fetch('/api/admin/time-windows/remove', {
+          method: 'DELETE',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ id }),
+        });
+        if (!res.ok) { alert('Fehler beim Entfernen.'); removeBtn.disabled = false; removeBtn.textContent = '✕'; return; }
+
+        const entry = removeBtn.closest<HTMLElement>('.window-entry')!;
+        const card  = entry.closest<HTMLElement>('[data-date]')!;
+        entry.remove();
+
+        const count = card.querySelectorAll('.window-entry').length;
+        const badge = card.querySelector<HTMLElement>('.text-gold.ml-auto');
+        if (badge) {
+          if (count === 0) badge.remove();
+          else badge.textContent = `${count} Zeitraum${count !== 1 ? 'e' : ''}`;
+        }
+
+        updateWindowsCounter(-1);
+      } catch {
+        alert('Netzwerkfehler.');
+        removeBtn.disabled = false;
+        removeBtn.textContent = '✕';
+      }
+    }
   });
 
   // Booking project assignment

--- a/website/src/pages/api/admin/bookings/create.ts
+++ b/website/src/pages/api/admin/bookings/create.ts
@@ -1,7 +1,6 @@
 // website/src/pages/api/admin/bookings/create.ts
 import type { APIRoute } from 'astro';
 import { getSession, isAdmin } from '../../../../lib/auth';
-import { isSlotWhitelisted } from '../../../../lib/website-db';
 import { createInboxItem } from '../../../../lib/messaging-db';
 import { sendEmail } from '../../../../lib/email';
 import { sendAdminNotification } from '../../../../lib/notifications';
@@ -45,13 +44,6 @@ export const POST: APIRoute = async ({ request }) => {
     }
     if (isCallback && !phone?.trim()) {
       return new Response(JSON.stringify({ error: 'Telefonnummer ist bei Rückruf Pflicht.' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
-    }
-
-    if (!isCallback && slotStart) {
-      const whitelisted = await isSlotWhitelisted(BRAND_NAME, new Date(slotStart));
-      if (!whitelisted) {
-        return new Response(JSON.stringify({ error: 'Dieser Slot ist nicht freigegeben.' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
-      }
     }
 
     const typeLabel = TYPE_LABELS[type] || type;

--- a/website/src/pages/api/admin/time-windows/add.ts
+++ b/website/src/pages/api/admin/time-windows/add.ts
@@ -1,0 +1,26 @@
+import type { APIRoute } from 'astro';
+import { getSession, isAdmin } from '../../../../lib/auth';
+import { addFreeTimeWindow } from '../../../../lib/website-db';
+
+const BRAND = process.env.BRAND_NAME || 'mentolder';
+
+export const POST: APIRoute = async ({ request }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session) return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401, headers: { 'Content-Type': 'application/json' } });
+  if (!isAdmin(session)) return new Response(JSON.stringify({ error: 'Forbidden' }), { status: 403, headers: { 'Content-Type': 'application/json' } });
+
+  try {
+    const { date, winStart, winEnd } = await request.json();
+    if (!date || !winStart || !winEnd) {
+      return new Response(JSON.stringify({ error: 'date, winStart und winEnd sind Pflicht.' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+    }
+    if (winStart >= winEnd) {
+      return new Response(JSON.stringify({ error: 'winStart muss vor winEnd liegen.' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+    }
+    const id = await addFreeTimeWindow(BRAND, date, winStart, winEnd);
+    return new Response(JSON.stringify({ id }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+  } catch (err) {
+    console.error('[time-windows/add]', err);
+    return new Response(JSON.stringify({ error: 'Interner Serverfehler.' }), { status: 500, headers: { 'Content-Type': 'application/json' } });
+  }
+};

--- a/website/src/pages/api/admin/time-windows/remove.ts
+++ b/website/src/pages/api/admin/time-windows/remove.ts
@@ -1,0 +1,23 @@
+import type { APIRoute } from 'astro';
+import { getSession, isAdmin } from '../../../../lib/auth';
+import { removeFreeTimeWindow } from '../../../../lib/website-db';
+
+const BRAND = process.env.BRAND_NAME || 'mentolder';
+
+export const DELETE: APIRoute = async ({ request }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session) return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401, headers: { 'Content-Type': 'application/json' } });
+  if (!isAdmin(session)) return new Response(JSON.stringify({ error: 'Forbidden' }), { status: 403, headers: { 'Content-Type': 'application/json' } });
+
+  try {
+    const { id } = await request.json();
+    if (!id) {
+      return new Response(JSON.stringify({ error: 'id ist Pflicht.' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+    }
+    await removeFreeTimeWindow(BRAND, id);
+    return new Response(JSON.stringify({ ok: true }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+  } catch (err) {
+    console.error('[time-windows/remove]', err);
+    return new Response(JSON.stringify({ error: 'Interner Serverfehler.' }), { status: 500, headers: { 'Content-Type': 'application/json' } });
+  }
+};

--- a/website/src/pages/api/booking.ts
+++ b/website/src/pages/api/booking.ts
@@ -2,7 +2,7 @@ import type { APIRoute } from 'astro';
 import { createInboxItem } from '../../lib/messaging-db';
 import { sendEmail } from '../../lib/email';
 import { sendAdminNotification } from '../../lib/notifications';
-import { claimSlot } from '../../lib/website-db';
+import { isSlotInAnyWindow } from '../../lib/website-db';
 import { checkRateLimit, getClientIp } from '../../lib/rate-limit';
 
 const BRAND_NAME = process.env.BRAND_NAME || 'Workspace';
@@ -39,11 +39,10 @@ export const POST: APIRoute = async ({ request }) => {
       );
     }
 
-    // Atomically claim the slot: removes it from whitelist in one DB operation.
-    // Prevents race conditions where two users book the same slot simultaneously.
-    if (!isCallback && slotStart) {
-      const claimed = await claimSlot(BRAND_NAME, new Date(slotStart));
-      if (!claimed) {
+    // Validate that the requested slot falls within an admin-defined time window.
+    if (!isCallback && slotStart && slotEnd) {
+      const valid = await isSlotInAnyWindow(BRAND_NAME, new Date(slotStart), new Date(slotEnd));
+      if (!valid) {
         return new Response(
           JSON.stringify({ error: 'Dieser Termin ist leider nicht mehr verfügbar.' }),
           { status: 409, headers: { 'Content-Type': 'application/json' } }

--- a/website/src/pages/api/calendar/slots.ts
+++ b/website/src/pages/api/calendar/slots.ts
@@ -2,14 +2,16 @@ import type { APIRoute } from 'astro';
 import { getAvailableSlots } from '../../../lib/caldav';
 
 // Returns available booking slots as JSON.
-// Optional query param: ?from=2026-04-07 (defaults to today)
+// Optional query params: ?from=2026-04-07, ?durationMin=30
 export const GET: APIRoute = async ({ url }) => {
   try {
     const fromParam = url.searchParams.get('from');
     const fromDate = fromParam ? new Date(fromParam) : undefined;
+    const durationParam = url.searchParams.get('durationMin');
+    const durationMin = durationParam ? parseInt(durationParam, 10) : undefined;
 
     const brand = process.env.BRAND_NAME || 'mentolder';
-    const slots = await getAvailableSlots(fromDate, brand);
+    const slots = await getAvailableSlots(fromDate, brand, durationMin);
 
     return new Response(JSON.stringify(slots), {
       status: 200,

--- a/website/src/pages/api/leistungen.ts
+++ b/website/src/pages/api/leistungen.ts
@@ -5,7 +5,12 @@ export const GET: APIRoute = async () => {
   try {
     const cats = await getEffectiveLeistungen();
     const flat = cats.flatMap(cat =>
-      cat.services.map(svc => ({ key: svc.key, name: svc.name, category: cat.title }))
+      cat.services.map(svc => ({
+        key: svc.key,
+        name: svc.name,
+        category: cat.title,
+        durationMin: svc.durationMin ?? null,
+      }))
     );
     return new Response(JSON.stringify(flat), {
       status: 200,


### PR DESCRIPTION
## Summary

- **Admin**: Statt Einzelslots per Toggle definiert der Admin pro Tag beliebig viele Zeiträume (z.B. `09:00–12:00`, `14:00–17:00`) über einen `＋ Zeitraum`-Button
- **Kunde**: Wählt zuerst die gewünschte Leistung, sieht dann alle Terminslots die in die freigegebenen Zeiträume passen
- **Backend**: Neue `free_time_windows` DB-Tabelle ersetzt `slot_whitelist` für die Slot-Generierung; `isSlotInAnyWindow` ersetzt `claimSlot` bei der Buchungsvalidierung

## Changes

- `website-db.ts`: Neue Tabelle `free_time_windows` + CRUD-Funktionen (`getFreeTimeWindows`, `addFreeTimeWindow`, `removeFreeTimeWindow`, `isSlotInAnyWindow`)
- `caldav.ts`: `getAvailableSlots` generiert Slots aus Zeiträumen statt Whitelist; akzeptiert optionalen `slotDurationMin`-Parameter
- `admin/termine.astro`: Zeitraumverwaltung pro Tag (Inline-Formular, goldene Pills, ✕ entfernen) statt Slot-Buttons
- `BookingForm.svelte`: Leistung-Auswahl als Schritt 2 vor Slot-Auswahl; Slots werden erst nach Leistungswahl geladen
- Neue API-Routen: `POST /api/admin/time-windows/add`, `DELETE /api/admin/time-windows/remove`
- `api/booking.ts`: `claimSlot` → `isSlotInAnyWindow`
- `api/admin/bookings/create.ts`: Whitelist-Check entfernt (Admin kann ohne Einschränkung buchen)
- `config/types.ts`: `durationMin?: number` zu `LeistungService` hinzugefügt

## Test plan

- [ ] Admin: `＋ Zeitraum` öffnet Inline-Formular; Speichern fügt goldenen Eintrag hinzu
- [ ] Admin: `✕` entfernt Zeitraum sofort; Counter wird aktualisiert
- [ ] Kunde: Leistung wählen → Termine werden geladen → Slots innerhalb der Zeiträume sichtbar
- [ ] Kunde: Ohne definierten Zeitraum → „Derzeit keine freien Termine" Meldung
- [ ] Buchung: Slot außerhalb aller Zeiträume → 409-Fehler

🤖 Generated with [Claude Code](https://claude.com/claude-code)