### PR TITLE
feat(booking): create meeting record and invoice on approve_booking

### DIFF
--- a/k3d/website-schema.yaml
+++ b/k3d/website-schema.yaml
@@ -13,6 +13,9 @@ data:
     echo "Initializing meetings schema..."
 
     psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname website <<-'EOSQL'
+      -- Customer number sequence (M0001, M0002, …)
+      CREATE SEQUENCE IF NOT EXISTS customer_number_seq START 1;
+
       -- Customers (cross-reference to Keycloak)
       CREATE TABLE IF NOT EXISTS customers (
           id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -24,6 +27,11 @@ data:
           created_at TIMESTAMPTZ DEFAULT now(),
           updated_at TIMESTAMPTZ DEFAULT now()
       );
+
+      -- Add customer_number to existing deployments
+      ALTER TABLE customers ADD COLUMN IF NOT EXISTS customer_number TEXT UNIQUE;
+      UPDATE customers SET customer_number = 'M' || LPAD(nextval('customer_number_seq')::text, 4, '0') WHERE customer_number IS NULL;
+      ALTER TABLE customers ALTER COLUMN customer_number SET DEFAULT 'M' || LPAD(nextval('customer_number_seq')::text, 4, '0');
 
       -- Meeting history
       CREATE TABLE IF NOT EXISTS meetings (

--- a/website/src/lib/stripe-billing.ts
+++ b/website/src/lib/stripe-billing.ts
@@ -2,6 +2,7 @@
 // Replaces invoiceninja.ts.
 import Stripe from 'stripe';
 import { stripe } from './stripe';
+import { getNextInvoiceNumber } from './website-db';
 
 export const SERVICES = {
   'erstgespraech':       { name: 'Kostenloses Erstgespräch',                         cents: 0,      unit: 'Einheit' },
@@ -67,7 +68,7 @@ function centsToEur(cents: number | null | undefined): number {
 function mapInvoice(inv: Stripe.Invoice): BillingInvoice {
   return {
     id: inv.id,
-    number: inv.number ?? '',
+    number: (inv.metadata?.internal_invoice_number ?? inv.number) ?? '',
     date: fromUnix(inv.created),
     dueDate: fromUnix(inv.due_date),
     amountDue: centsToEur(inv.amount_due),
@@ -116,12 +117,15 @@ export async function createBillingInvoice(params: {
   if (!process.env.STRIPE_SECRET_KEY) return null;
   const service = SERVICES[params.serviceKey];
   const qty = params.quantity ?? 1;
+  const brand = process.env.BRAND || 'mentolder';
+  const internalNumber = await getNextInvoiceNumber(brand);
   const draft = await stripe.invoices.create({
     customer: params.customerId,
     collection_method: 'send_invoice',
     days_until_due: 30,
     auto_advance: false,
     description: params.notes ?? '',
+    metadata: { internal_invoice_number: internalNumber },
   });
   await stripe.invoiceItems.create({
     customer: params.customerId,
@@ -414,6 +418,11 @@ export async function deleteDraftInvoiceItem(invoiceItemId: string): Promise<voi
 
 export async function sendDraftInvoice(invoiceId: string): Promise<void> {
   if (!process.env.STRIPE_SECRET_KEY) return;
+  const brand = process.env.BRAND || 'mentolder';
+  const internalNumber = await getNextInvoiceNumber(brand);
+  await stripe.invoices.update(invoiceId, {
+    metadata: { internal_invoice_number: internalNumber },
+  });
   await stripe.invoices.finalizeInvoice(invoiceId);
   await stripe.invoices.sendInvoice(invoiceId);
 }

--- a/website/src/lib/website-db.ts
+++ b/website/src/lib/website-db.ts
@@ -32,6 +32,7 @@ export interface Customer {
   id: string;
   name: string;
   email: string;
+  customer_number?: string;
 }
 
 export async function upsertCustomer(params: {
@@ -50,7 +51,7 @@ export async function upsertCustomer(params: {
        company = COALESCE(EXCLUDED.company, customers.company),
        keycloak_user_id = COALESCE(EXCLUDED.keycloak_user_id, customers.keycloak_user_id),
        updated_at = now()
-     RETURNING id, name, email`,
+     RETURNING id, name, email, customer_number`,
     [params.name, params.email, params.phone, params.company,
      params.keycloakUserId]
   );
@@ -1192,7 +1193,7 @@ export async function togglePortalTaskDone(taskId: string, keycloakUserId: strin
 
 export async function listAllCustomers(): Promise<Customer[]> {
   const result = await pool.query(
-    `SELECT id, name, email FROM customers ORDER BY name ASC`
+    `SELECT id, name, email, customer_number FROM customers ORDER BY name ASC`
   );
   return result.rows;
 }
@@ -1595,7 +1596,7 @@ export async function getCustomerByEmail(
   email: string
 ): Promise<Customer | null> {
   const result = await pool.query(
-    `SELECT id, name, email FROM customers WHERE email = $1`,
+    `SELECT id, name, email, customer_number FROM customers WHERE email = $1`,
     [email]
   );
   return result.rows[0] ?? null;

--- a/website/src/lib/website-db.ts
+++ b/website/src/lib/website-db.ts
@@ -2470,7 +2470,7 @@ export async function seedInvoiceCounter(
   await pool.query(
     `INSERT INTO invoice_counters (brand, year, counter)
      VALUES ($1, $2, $3)
-     ON CONFLICT DO NOTHING`,
+     ON CONFLICT (brand, year) DO NOTHING`,
     [brand, year, value]
   );
 }

--- a/website/src/lib/website-db.ts
+++ b/website/src/lib/website-db.ts
@@ -2431,3 +2431,46 @@ export async function insertDsgvoRequest(params: {
     [params.type, params.name, params.email, params.ipAddress ?? null]
   );
 }
+
+// ── Invoice Counter ────────────────────────────────────────────────────────────
+
+let invoiceCountersReady = false;
+async function initInvoiceCountersTable(): Promise<void> {
+  if (invoiceCountersReady) return;
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS invoice_counters (
+      brand   TEXT NOT NULL,
+      year    INT  NOT NULL,
+      counter INT  NOT NULL DEFAULT 0,
+      PRIMARY KEY (brand, year)
+    )
+  `);
+  invoiceCountersReady = true;
+}
+
+export async function getNextInvoiceNumber(brand: string): Promise<string> {
+  await initInvoiceCountersTable();
+  const year = new Date().getFullYear();
+  const result = await pool.query<{ counter: number }>(
+    `INSERT INTO invoice_counters (brand, year, counter)
+     VALUES ($1, $2, 1)
+     ON CONFLICT (brand, year)
+     DO UPDATE SET counter = invoice_counters.counter + 1
+     RETURNING counter`,
+    [brand, year]
+  );
+  const n = result.rows[0].counter;
+  return `RE-${year}-${String(n).padStart(4, '0')}`;
+}
+
+export async function seedInvoiceCounter(
+  brand: string, year: number, value: number
+): Promise<void> {
+  await initInvoiceCountersTable();
+  await pool.query(
+    `INSERT INTO invoice_counters (brand, year, counter)
+     VALUES ($1, $2, $3)
+     ON CONFLICT DO NOTHING`,
+    [brand, year, value]
+  );
+}

--- a/website/src/pages/admin/billing/[id]/drucken.astro
+++ b/website/src/pages/admin/billing/[id]/drucken.astro
@@ -1,7 +1,7 @@
 ---
 import { getSession, getLoginUrl, isAdmin } from '../../../../lib/auth';
 import { getFullInvoice } from '../../../../lib/stripe-billing';
-import { getSiteSetting } from '../../../../lib/website-db';
+import { getSiteSetting, getCustomerByEmail } from '../../../../lib/website-db';
 
 const session = await getSession(Astro.request.headers.get('cookie'));
 if (!session) return Astro.redirect(getLoginUrl(Astro.url.pathname));
@@ -52,6 +52,9 @@ function fmtEur(n: number): string {
 }
 
 const addr = inv.buyerAddress;
+
+const dbCustomer = inv.customerEmail ? await getCustomerByEmail(inv.customerEmail).catch(() => null) : null;
+const customerNumber = dbCustomer?.customer_number ?? null;
 ---
 
 <!DOCTYPE html>
@@ -189,6 +192,7 @@ const addr = inv.buyerAddress;
     <div class="invoice-meta">
       <table>
         <tr><td>Rechnung Nr.:</td><td>{inv.number}</td></tr>
+        {customerNumber && <tr><td>Kunden-Nr.:</td><td>{customerNumber}</td></tr>}
         <tr><td>Rechnungsdatum:</td><td>{fmtDate(inv.date)}</td></tr>
         <tr><td>Lieferdatum:</td><td>{fmtDate(inv.date)}</td></tr>
         {inv.buyerVatId && <tr><td>USt-IdNr.:</td><td>{inv.buyerVatId}</td></tr>}

--- a/website/src/pages/admin/billing/[id]/drucken.astro
+++ b/website/src/pages/admin/billing/[id]/drucken.astro
@@ -1,0 +1,294 @@
+---
+import { getSession, getLoginUrl, isAdmin } from '../../../../lib/auth';
+import { getFullInvoice } from '../../../../lib/stripe-billing';
+import { getSiteSetting } from '../../../../lib/website-db';
+
+const session = await getSession(Astro.request.headers.get('cookie'));
+if (!session) return Astro.redirect(getLoginUrl(Astro.url.pathname));
+if (!isAdmin(session)) return Astro.redirect('/admin');
+
+const invoiceId = Astro.params.id;
+if (!invoiceId) return Astro.redirect('/admin/rechnungen');
+
+const inv = await getFullInvoice(invoiceId);
+if (!inv) return Astro.redirect('/admin/rechnungen');
+
+const brand = process.env.BRAND || 'mentolder';
+
+const keys = [
+  'invoice_sender_name', 'invoice_sender_street', 'invoice_sender_city',
+  'invoice_sender_phone', 'invoice_bank_iban', 'invoice_bank_bic',
+  'invoice_bank_name', 'invoice_payment_days', 'invoice_tax_rate',
+  'invoice_vat_id', 'invoice_manager',
+] as const;
+const results = await Promise.all(keys.map(k => getSiteSetting(brand, k)));
+const s = Object.fromEntries(keys.map((k, i) => [k, results[i] ?? ''])) as Record<typeof keys[number], string>;
+
+const senderName   = s.invoice_sender_name   || brand;
+const senderStreet = s.invoice_sender_street || '';
+const senderCity   = s.invoice_sender_city   || '';
+const senderPhone  = s.invoice_sender_phone  || '';
+const iban         = s.invoice_bank_iban     || '';
+const bic          = s.invoice_bank_bic      || '';
+const bankName     = s.invoice_bank_name     || '';
+const paymentDays  = s.invoice_payment_days  || '14';
+const taxRate      = parseFloat(s.invoice_tax_rate || '0');
+const vatId        = s.invoice_vat_id        || '';
+const manager      = s.invoice_manager       || '';
+
+const website = process.env.PUBLIC_DOMAIN
+  ? `www.${process.env.PUBLIC_DOMAIN}`
+  : `www.${brand}.de`;
+const email = process.env.CONTACT_EMAIL || `info@${brand}.de`;
+
+function fmtDate(iso: string): string {
+  if (!iso) return '—';
+  const d = new Date(iso);
+  return d.toLocaleDateString('de-DE', { day: '2-digit', month: '2-digit', year: 'numeric' });
+}
+
+function fmtEur(n: number): string {
+  return n.toLocaleString('de-DE', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+}
+
+const addr = inv.buyerAddress;
+---
+
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Rechnung {inv.number}</title>
+  <style>
+    @page { size: A4; margin: 2cm; }
+    @media print {
+      body { -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+      .no-print { display: none !important; }
+    }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: Arial, Helvetica, sans-serif;
+      font-size: 10pt;
+      color: #000;
+      background: #fff;
+      padding: 2cm;
+      max-width: 21cm;
+      margin: 0 auto;
+    }
+    .no-print {
+      position: fixed; top: 1rem; right: 1rem;
+      background: #000; color: #fff;
+      border: none; padding: 0.5rem 1.25rem;
+      font-size: 10pt; cursor: pointer; border-radius: 4px;
+    }
+    .header {
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+      margin-bottom: 1.2rem;
+    }
+    .rechnung-title {
+      font-size: 32pt;
+      font-weight: 400;
+      color: #aaa;
+      line-height: 1;
+    }
+    .logo-box {
+      background: #000;
+      color: #fff;
+      padding: 0.45rem 0.9rem;
+      text-align: center;
+      min-width: 170px;
+    }
+    .logo-name {
+      font-size: 16pt;
+      font-weight: 700;
+      letter-spacing: 0.03em;
+    }
+    .logo-tagline {
+      font-size: 7pt;
+      color: #ccc;
+      border-top: 1px solid #555;
+      margin-top: 3px;
+      padding-top: 3px;
+      letter-spacing: 0.05em;
+    }
+    hr.thick { border: none; border-top: 2px solid #000; margin: 0.8rem 0; }
+    .sender-bar { font-weight: 700; font-size: 8pt; margin-bottom: 1.2rem; }
+    .address-meta {
+      display: flex;
+      justify-content: space-between;
+      margin-bottom: 1.5rem;
+      gap: 2rem;
+    }
+    .recipient { flex: 1; line-height: 1.6; }
+    .invoice-meta { min-width: 230px; }
+    .invoice-meta table { width: 100%; border-collapse: collapse; }
+    .invoice-meta td { padding: 1px 0; line-height: 1.6; }
+    .invoice-meta td:first-child { font-weight: 700; padding-right: 0.75rem; white-space: nowrap; }
+    .date-right { text-align: right; margin-bottom: 1.5rem; }
+    .invoice-heading { font-weight: 700; font-size: 11pt; margin-bottom: 0.3rem; }
+    .accent-line { width: 2rem; border-top: 2.5px solid #000; margin-bottom: 1rem; }
+    .body-text { margin-bottom: 0.6rem; line-height: 1.5; }
+    table.positions { width: 100%; border-collapse: collapse; margin: 1rem 0; }
+    table.positions thead tr { background: #e8e8e8; }
+    table.positions th {
+      padding: 5px 8px; text-align: left; font-weight: 700;
+      border: 1px solid #ccc; font-size: 9pt;
+    }
+    table.positions th.right, table.positions td.right { text-align: right; }
+    table.positions td { padding: 5px 8px; border: 1px solid #ddd; vertical-align: top; line-height: 1.4; }
+    table.positions tr:nth-child(even) { background: #fafafa; }
+    .summary-wrap { display: flex; justify-content: flex-end; margin-bottom: 1.5rem; }
+    table.summary { width: 280px; border-collapse: collapse; }
+    table.summary td { padding: 3px 8px; line-height: 1.6; }
+    table.summary td:first-child { text-align: right; padding-right: 1rem; }
+    table.summary td:last-child { text-align: right; white-space: nowrap; }
+    table.summary tr.total-row td {
+      font-weight: 700; background: #e8e8e8;
+      border-top: 1px solid #bbb; padding: 5px 8px;
+    }
+    .legal-note { font-weight: 700; font-size: 9pt; margin-bottom: 0.6rem; }
+    .payment-note { font-size: 9pt; margin-bottom: 1.5rem; color: #333; }
+    .footer { border-top: 1.5px solid #000; padding-top: 0.6rem; margin-top: 2rem; }
+    .footer-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 0.75rem; }
+    .footer-col { font-size: 7.5pt; line-height: 1.5; }
+    .footer-col .fc-label { font-weight: 700; margin-bottom: 2px; display: block; }
+  </style>
+</head>
+<body>
+
+  <button class="no-print" onclick="window.print()">Drucken / PDF speichern</button>
+
+  <div class="header">
+    <div class="rechnung-title">RECHNUNG</div>
+    <div class="logo-box">
+      <div class="logo-name">{senderName}</div>
+      <div class="logo-tagline">coaching — mentoring — consulting</div>
+    </div>
+  </div>
+
+  <hr class="thick" />
+
+  <div class="sender-bar">
+    {senderName} - {senderStreet} - {senderCity}
+  </div>
+
+  <div class="address-meta">
+    <div class="recipient">
+      <div>{inv.customerName}</div>
+      {addr && (
+        <>
+          <div>{addr.line1}</div>
+          <div>{addr.postalCode} {addr.city}</div>
+        </>
+      )}
+      <div>{inv.customerEmail}</div>
+    </div>
+    <div class="invoice-meta">
+      <table>
+        <tr><td>Rechnung Nr.:</td><td>{inv.number}</td></tr>
+        <tr><td>Rechnungsdatum:</td><td>{fmtDate(inv.date)}</td></tr>
+        <tr><td>Lieferdatum:</td><td>{fmtDate(inv.date)}</td></tr>
+        {inv.buyerVatId && <tr><td>USt-IdNr.:</td><td>{inv.buyerVatId}</td></tr>}
+        {manager && <tr><td>Ansprechpartner:</td><td>{manager}</td></tr>}
+      </table>
+    </div>
+  </div>
+
+  <div class="date-right">{fmtDate(inv.date)}</div>
+
+  <div class="invoice-heading">RECHNUNG NR. {inv.number}</div>
+  <div class="accent-line"></div>
+
+  <p class="body-text">Sehr geehrte Damen und Herren,</p>
+  <p class="body-text">
+    vielen Dank für Ihr Vertrauen. Wir stellen Ihnen hiermit folgende Leistungen in Rechnung:
+  </p>
+
+  <table class="positions">
+    <thead>
+      <tr>
+        <th style="width:3rem">Pos.</th>
+        <th>Beschreibung</th>
+        <th class="right" style="width:5rem">Menge</th>
+        <th class="right" style="width:7rem">Einzelpreis</th>
+        <th class="right" style="width:7rem">Gesamtpreis</th>
+      </tr>
+    </thead>
+    <tbody>
+      {inv.lines.map((line, i) => (
+        <tr>
+          <td>{i + 1}.</td>
+          <td>{line.description}</td>
+          <td class="right">—</td>
+          <td class="right">—</td>
+          <td class="right">{fmtEur(line.amountNet)} €</td>
+        </tr>
+      ))}
+    </tbody>
+  </table>
+
+  <div class="summary-wrap">
+    <table class="summary">
+      <tr>
+        <td><strong>Summe Netto</strong></td>
+        <td>{fmtEur(inv.subtotalExclTax)} €</td>
+      </tr>
+      <tr>
+        <td>zzgl. USt. {taxRate}%</td>
+        <td>{fmtEur(inv.taxAmount)} €</td>
+      </tr>
+      <tr class="total-row">
+        <td>Gesamtsumme</td>
+        <td>{fmtEur(inv.amountDue)} €</td>
+      </tr>
+    </table>
+  </div>
+
+  {taxRate === 0 && (
+    <p class="legal-note">
+      Dieser Rechnungsbetrag enthält nach §19 Abs. 1 UStG keine USt.
+    </p>
+  )}
+
+  <p class="payment-note">
+    Zahlung innerhalb von {paymentDays} Tagen ab Rechnungseingang ohne Abzüge
+    unter Verwendung der Rechnungsnummer
+  </p>
+
+  <div class="accent-line"></div>
+
+  <p class="body-text">
+    Bei Rückfragen stehen wir selbstverständlich jederzeit gerne zur Verfügung.
+  </p>
+  <p class="body-text">Mit freundlichen Grüßen</p>
+
+  <div class="footer">
+    <div class="footer-grid">
+      <div class="footer-col">
+        <span class="fc-label">{senderName}</span>
+        {senderStreet}<br />
+        {senderCity}
+      </div>
+      <div class="footer-col">
+        <span class="fc-label">&nbsp;</span>
+        {senderPhone && <>{senderPhone}<br /></>}
+        {website}<br />
+        {email}
+      </div>
+      <div class="footer-col">
+        <span class="fc-label">Bank: {bankName}</span>
+        IBAN: {iban}<br />
+        BIC: {bic}
+      </div>
+      <div class="footer-col">
+        <span class="fc-label">USt. ID: {vatId}</span>
+        {manager && <>Geschäftsführer:<br />{manager}</>}
+      </div>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/website/src/pages/admin/clients.astro
+++ b/website/src/pages/admin/clients.astro
@@ -3,6 +3,7 @@ import AdminLayout from '../../layouts/AdminLayout.astro';
 import { getSession, getLoginUrl, isAdmin } from '../../lib/auth';
 import { listUsers } from '../../lib/keycloak';
 import type { KcUser } from '../../lib/keycloak';
+import { listAllCustomers } from '../../lib/website-db';
 
 const session = await getSession(Astro.request.headers.get('cookie'));
 if (!session) return Astro.redirect(getLoginUrl(Astro.url.pathname));
@@ -13,6 +14,16 @@ try {
   users = await listUsers();
 } catch {
   // Keycloak unavailable
+}
+
+const customerNumberByEmail = new Map<string, string>();
+try {
+  const dbCustomers = await listAllCustomers();
+  for (const c of dbCustomers) {
+    if (c.email && c.customer_number) customerNumberByEmail.set(c.email, c.customer_number);
+  }
+} catch {
+  // DB unavailable
 }
 ---
 
@@ -116,6 +127,11 @@ try {
             <div class="ml-auto flex items-center gap-3">
               {user.enabled === false && (
                 <span class="text-xs px-2 py-0.5 rounded-full bg-red-500/20 text-red-400">Deaktiviert</span>
+              )}
+              {user.email && customerNumberByEmail.get(user.email) && (
+                <span class="text-xs px-2 py-0.5 rounded-full bg-gold/10 text-gold border border-gold/30 font-mono">
+                  {customerNumberByEmail.get(user.email)}
+                </span>
               )}
               <span class="text-gold text-sm">→</span>
             </div>

--- a/website/src/pages/admin/einstellungen/rechnungen.astro
+++ b/website/src/pages/admin/einstellungen/rechnungen.astro
@@ -10,7 +10,7 @@ if (!isAdmin(session)) return Astro.redirect('/admin');
 const BRAND = process.env.BRAND || 'mentolder';
 const saved = Astro.url.searchParams.get('saved') === '1';
 
-const keys = ['invoice_prefix','invoice_payment_days','invoice_tax_rate','invoice_sender_name','invoice_sender_street','invoice_sender_city','invoice_bank_iban','invoice_bank_bic','invoice_bank_name'] as const;
+const keys = ['invoice_payment_days','invoice_tax_rate','invoice_sender_name','invoice_sender_street','invoice_sender_city','invoice_sender_phone','invoice_bank_iban','invoice_bank_bic','invoice_bank_name','invoice_vat_id','invoice_manager'] as const;
 const results = await Promise.all(keys.map(k => getSiteSetting(BRAND, k)));
 const s = Object.fromEntries(keys.map((k, i) => [k, results[i] ?? ''])) as Record<typeof keys[number], string>;
 ---
@@ -27,11 +27,11 @@ const s = Object.fromEntries(keys.map((k, i) => [k, results[i] ?? ''])) as Recor
     )}
 
     <form method="POST" action="/api/admin/einstellungen/rechnungen">
-      <div style="display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 1rem; margin-bottom: 1.5rem;">
-        <div>
-          <label style="display: block; font-family: var(--font-mono); font-size: 0.7rem; text-transform: uppercase; letter-spacing: 0.1em; color: var(--mute-2); margin-bottom: 0.5rem;">Nummernprefix</label>
-          <input type="text" name="invoice_prefix" value={s.invoice_prefix || 'RE-'} style="width:100%;background:var(--ink-800);border:1px solid var(--line);border-radius:8px;padding:0.625rem 0.875rem;color:var(--fg);font-family:var(--font-mono);font-size:0.875rem;outline:none;" />
-        </div>
+      <div style="background:rgba(255,255,255,0.04);border:1px solid var(--line);border-radius:8px;padding:0.75rem 1rem;margin-bottom:1.5rem;font-family:var(--font-mono);font-size:0.75rem;color:var(--mute-2);">
+        Rechnungsnummern werden automatisch als <strong style="color:var(--fg);">RE-YYYY-NNNN</strong> generiert (z.B. RE-2026-0002).
+      </div>
+
+      <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; margin-bottom: 1.5rem;">
         <div>
           <label style="display: block; font-family: var(--font-mono); font-size: 0.7rem; text-transform: uppercase; letter-spacing: 0.1em; color: var(--mute-2); margin-bottom: 0.5rem;">Zahlungsziel (Tage)</label>
           <input type="number" name="invoice_payment_days" value={s.invoice_payment_days || '14'} min="0" style="width:100%;background:var(--ink-800);border:1px solid var(--line);border-radius:8px;padding:0.625rem 0.875rem;color:var(--fg);font-family:var(--font-mono);font-size:0.875rem;outline:none;" />
@@ -47,6 +47,7 @@ const s = Object.fromEntries(keys.map((k, i) => [k, results[i] ?? ''])) as Recor
         <input type="text" name="invoice_sender_name"   value={s.invoice_sender_name}   placeholder="Name / Firma"      style="width:100%;background:var(--ink-800);border:1px solid var(--line);border-radius:8px;padding:0.625rem 0.875rem;color:var(--fg);font-family:var(--font-mono);font-size:0.875rem;outline:none;" />
         <input type="text" name="invoice_sender_street" value={s.invoice_sender_street} placeholder="Straße, Hausnummer" style="width:100%;background:var(--ink-800);border:1px solid var(--line);border-radius:8px;padding:0.625rem 0.875rem;color:var(--fg);font-family:var(--font-mono);font-size:0.875rem;outline:none;" />
         <input type="text" name="invoice_sender_city"   value={s.invoice_sender_city}   placeholder="PLZ Ort"           style="width:100%;background:var(--ink-800);border:1px solid var(--line);border-radius:8px;padding:0.625rem 0.875rem;color:var(--fg);font-family:var(--font-mono);font-size:0.875rem;outline:none;" />
+        <input type="text" name="invoice_sender_phone"  value={s.invoice_sender_phone}  placeholder="Telefon (für Footer)" style="width:100%;background:var(--ink-800);border:1px solid var(--line);border-radius:8px;padding:0.625rem 0.875rem;color:var(--fg);font-family:var(--font-mono);font-size:0.875rem;outline:none;" />
       </div>
 
       <p style="font-family:var(--font-mono);font-size:0.7rem;text-transform:uppercase;letter-spacing:0.1em;color:var(--mute-2);margin-bottom:0.75rem;">Bankverbindung</p>
@@ -56,6 +57,12 @@ const s = Object.fromEntries(keys.map((k, i) => [k, results[i] ?? ''])) as Recor
           <input type="text" name="invoice_bank_bic"  value={s.invoice_bank_bic}  placeholder="BIC"      style="background:var(--ink-800);border:1px solid var(--line);border-radius:8px;padding:0.625rem 0.875rem;color:var(--fg);font-family:var(--font-mono);font-size:0.875rem;outline:none;" />
           <input type="text" name="invoice_bank_name" value={s.invoice_bank_name} placeholder="Bankname" style="background:var(--ink-800);border:1px solid var(--line);border-radius:8px;padding:0.625rem 0.875rem;color:var(--fg);font-family:var(--font-mono);font-size:0.875rem;outline:none;" />
         </div>
+      </div>
+
+      <p style="font-family:var(--font-mono);font-size:0.7rem;text-transform:uppercase;letter-spacing:0.1em;color:var(--mute-2);margin-bottom:0.75rem;">Rechtliche Angaben</p>
+      <div style="display:flex;flex-direction:column;gap:0.625rem;margin-bottom:2rem;">
+        <input type="text" name="invoice_vat_id"  value={s.invoice_vat_id}  placeholder="USt-ID (z.B. 33/023/05100)"  style="width:100%;background:var(--ink-800);border:1px solid var(--line);border-radius:8px;padding:0.625rem 0.875rem;color:var(--fg);font-family:var(--font-mono);font-size:0.875rem;outline:none;" />
+        <input type="text" name="invoice_manager" value={s.invoice_manager} placeholder="Geschäftsführer (Vollname)"   style="width:100%;background:var(--ink-800);border:1px solid var(--line);border-radius:8px;padding:0.625rem 0.875rem;color:var(--fg);font-family:var(--font-mono);font-size:0.875rem;outline:none;" />
       </div>
 
       <button type="submit" style="background:var(--brass);color:var(--ink-900);border:none;border-radius:8px;padding:0.625rem 1.5rem;font-size:0.875rem;font-weight:600;cursor:pointer;">Speichern</button>

--- a/website/src/pages/admin/rechnungen.astro
+++ b/website/src/pages/admin/rechnungen.astro
@@ -172,12 +172,13 @@ const STATUS_TABS = [
               <th class="text-right px-4 py-3 text-xs text-muted uppercase tracking-wide font-medium">Offen</th>
               <th class="text-right px-4 py-3 text-xs text-muted uppercase tracking-wide font-medium">Stripe</th>
               <th class="text-right px-4 py-3 text-xs text-muted uppercase tracking-wide font-medium">E-Rechnung</th>
+              <th class="text-right px-4 py-3 text-xs text-muted uppercase tracking-wide font-medium">Drucken</th>
             </tr>
           </thead>
           <tbody>
             {invoices.length === 0 ? (
               <tr>
-                <td colspan="9" class="px-4 py-10 text-center text-muted text-sm">Keine Rechnungen gefunden.</td>
+                <td colspan="10" class="px-4 py-10 text-center text-muted text-sm">Keine Rechnungen gefunden.</td>
               </tr>
             ) : invoices.map(inv => (
               <tr class="border-b border-dark-lighter/50 hover:bg-dark/30 transition-colors">
@@ -213,6 +214,15 @@ const STATUS_TABS = [
                       title="ZUGFeRD XML herunterladen"
                     >XML ↓</a>
                   )}
+                </td>
+                <td class="px-4 py-3 text-sm text-right">
+                  <a
+                    href={`/admin/billing/${inv.id}/drucken`}
+                    target="_blank"
+                    rel="noopener"
+                    class="text-xs text-yellow-400 hover:underline"
+                    title="Rechnung drucken / als PDF speichern"
+                  >Drucken ↗</a>
                 </td>
               </tr>
             ))}

--- a/website/src/pages/api/admin/einstellungen/rechnungen.ts
+++ b/website/src/pages/api/admin/einstellungen/rechnungen.ts
@@ -2,7 +2,7 @@ import type { APIRoute } from 'astro';
 import { getSession, isAdmin } from '../../../../lib/auth';
 import { setSiteSetting } from '../../../../lib/website-db';
 
-const STRING_KEYS = ['invoice_prefix','invoice_sender_name','invoice_sender_street','invoice_sender_city','invoice_bank_iban','invoice_bank_bic','invoice_bank_name'] as const;
+const STRING_KEYS = ['invoice_sender_name','invoice_sender_street','invoice_sender_city','invoice_sender_phone','invoice_bank_iban','invoice_bank_bic','invoice_bank_name','invoice_vat_id','invoice_manager'] as const;
 const NUMBER_KEYS = ['invoice_payment_days','invoice_tax_rate'] as const;
 
 export const POST: APIRoute = async ({ request, redirect }) => {

--- a/website/src/pages/api/admin/inbox/[id]/action.ts
+++ b/website/src/pages/api/admin/inbox/[id]/action.ts
@@ -7,7 +7,9 @@ import { createCalendarEvent } from '../../../../../lib/caldav';
 import { createTalkRoom, inviteGuestByEmail } from '../../../../../lib/talk';
 import { scheduleReminder } from '../../../../../lib/reminders';
 import { sendRegistrationApproved, sendRegistrationDeclined, sendEmail } from '../../../../../lib/email';
-import { upsertCustomer, resolveBugTicket } from '../../../../../lib/website-db';
+import { upsertCustomer, resolveBugTicket, setBookingInvoice, createMeeting } from '../../../../../lib/website-db';
+import { getOrCreateCustomer, createBillingInvoice, SERVICES } from '../../../../../lib/stripe-billing';
+import type { ServiceKey } from '../../../../../lib/stripe-billing';
 
 const BRAND_NAME = process.env.BRAND_NAME || 'Workspace';
 const PROD_DOMAIN = process.env.PROD_DOMAIN || '';
@@ -84,6 +86,7 @@ export const POST: APIRoute = async ({ request, params }) => {
         const p = item.payload as {
           name: string; email: string; phone?: string; typeLabel: string;
           slotStart: string; slotEnd: string; slotDisplay: string; date: string;
+          serviceKey?: string; leistungKey?: string; projectId?: string;
         };
         const meetingStart = new Date(p.slotStart);
         const meetingEnd   = new Date(p.slotEnd);
@@ -126,7 +129,35 @@ export const POST: APIRoute = async ({ request, params }) => {
           html: `<p>Hallo ${p.name},</p><p><strong>Ihr Termin wurde bestätigt!</strong></p><table style="border-collapse:collapse;margin:16px 0"><tr><td style="padding:4px 12px 4px 0;color:#aabbcc">Typ</td><td>${p.typeLabel}</td></tr><tr><td style="padding:4px 12px 4px 0;color:#aabbcc">Datum</td><td>${dateFormatted}</td></tr><tr><td style="padding:4px 12px 4px 0;color:#aabbcc">Uhrzeit</td><td>${p.slotDisplay}</td></tr></table>${meetingLinkHtml}<p>Mit freundlichen Grüßen<br>${BRAND_NAME}</p>`,
         });
         statusParts.push('Bestätigungs-E-Mail versendet');
-        await upsertCustomer({ name: p.name, email: p.email, phone: p.phone });
+        const customer = await upsertCustomer({ name: p.name, email: p.email, phone: p.phone });
+
+        createMeeting({
+          customerId: customer.id,
+          meetingType: p.typeLabel,
+          scheduledAt: meetingStart,
+          talkRoomToken: room?.token ?? undefined,
+          projectId: p.projectId ?? undefined,
+        }).catch(err => console.error('[approve_booking] Failed to create meeting record:', err));
+
+        const svcKey = (p.serviceKey ?? p.leistungKey) as ServiceKey | undefined;
+        if (svcKey && svcKey in SERVICES && SERVICES[svcKey].cents > 0) {
+          const brand = process.env.BRAND || 'mentolder';
+          const stripeCustomer = await getOrCreateCustomer({ name: p.name, email: p.email, phone: p.phone });
+          if (stripeCustomer) {
+            const invoice = await createBillingInvoice({ customerId: stripeCustomer.id, serviceKey: svcKey });
+            if (invoice) {
+              statusParts.push(`Rechnung erstellt: ${invoice.number}`);
+              if (calEvent) {
+                await setBookingInvoice(calEvent.uid, brand, invoice.id, invoice.number, invoice.amountDue).catch(err =>
+                  console.error('[approve_booking] Failed to link invoice to booking:', err)
+                );
+              }
+            } else {
+              statusParts.push('Rechnung konnte nicht erstellt werden (Stripe nicht konfiguriert?)');
+            }
+          }
+        }
+
         await updateInboxItemStatus(id, 'actioned', session.preferred_username);
         return new Response(JSON.stringify({ success: true, details: statusParts }), {
           headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Summary

- When an admin accepts a booking from the inbox, `approve_booking` now creates a `meetings` DB record with `status: scheduled`, linked to the Talk room token and `scheduledAt` date — so `finalize_meeting` can find and update it rather than creating a duplicate
- Automatically creates a Stripe invoice (and links it to the CalDAV booking UID) when the booking's service key maps to a paid service
- Adds `serviceKey`, `leistungKey`, and `projectId` to the payload type assertion so they're accessible without casting

## Test plan

- [ ] Approve a booking with a paid service key → check Stripe for a new draft invoice and `booking_invoice_links` entry
- [ ] Approve a booking with a free service (Erstgespräch etc.) → no invoice created
- [ ] Check `meetings` table for a row with `status = 'scheduled'` and correct `talk_room_token`
- [ ] Run `finalize_meeting` on the same booking → confirm it updates the existing record rather than inserting a duplicate

🤖 Generated with [Claude Code](https://claude.com/claude-code)