### PR TITLE
fix(transcriber): remove unschedulable affinity — all nodes are control-plane

### DIFF
--- a/prod/patch-talk-transcriber.yaml
+++ b/prod/patch-talk-transcriber.yaml
@@ -6,19 +6,8 @@ metadata:
 spec:
   template:
     spec:
-      # Avoid control-plane node (pk-hetzner) which has limited cross-node
-      # network connectivity to the workspace pods on the worker nodes.
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: node-role.kubernetes.io/control-plane
-                operator: DoesNotExist
-              - key: kubernetes.io/arch
-                operator: In
-                values: [amd64]
-      nodeSelector: {}
+      nodeSelector:
+        kubernetes.io/arch: amd64
       containers:
         - name: transcriber
           image: ghcr.io/paddione/talk-transcriber:latest


### PR DESCRIPTION
## Summary

- The prod patch for `talk-transcriber` required scheduling on non-control-plane nodes (`node-role.kubernetes.io/control-plane: DoesNotExist`)
- All 3 nodes in the mentolder cluster now carry the `control-plane` role — no node satisfies this constraint
- The new pod has been `Pending` for 42 h; the old pod (started before the patch was applied) keeps running with stale dev env vars including the wrong DB password (`devnextclouddb` instead of the sealed secret value)
- This caused `FATAL: password authentication failed` on every poll and auto-join cycle, so the bot cannot detect or join any calls

## Fix

Replace the `nodeAffinity` block (which was originally added to avoid a single node `pk-hetzner` with cross-node connectivity issues, but is now too restrictive) with a plain `nodeSelector: kubernetes.io/arch: amd64` that all current nodes satisfy.

## Test plan

- [ ] After merge + ArgoCD sync, verify the pending pod schedules and reaches `Running`
- [ ] Check logs: `[db-poll]` and `[auto-join]` errors should stop; `[auto-join] joined N new room(s)` should appear
- [ ] Start a Nextcloud Talk call and confirm the bot joins and transcription resumes

🤖 Generated with [Claude Code](https://claude.com/claude-code)