### PR TITLE
fix(db): resolve race condition in project table init

### DIFF
--- a/website/src/lib/website-db.ts
+++ b/website/src/lib/website-db.ts
@@ -820,7 +820,10 @@ export interface ProjectTask {
   updatedAt: Date;
 }
 
+let projectTablesReady = false;
+
 async function initProjectTables(): Promise<void> {
+  if (projectTablesReady) return;
   await pool.query(`
     CREATE TABLE IF NOT EXISTS projects (
       id          UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -870,6 +873,7 @@ async function initProjectTables(): Promise<void> {
       updated_at     TIMESTAMPTZ NOT NULL DEFAULT now()
     )
   `);
+  projectTablesReady = true;
 }
 
 const PROJECT_SELECT = `
@@ -1277,6 +1281,7 @@ export interface TimeEntry {
 
 async function initTimeEntriesTable(): Promise<void> {
   if (timeEntriesReady) return;
+  await initProjectTables();
   await pool.query(`
     CREATE TABLE IF NOT EXISTS time_entries (
       id                UUID        PRIMARY KEY DEFAULT gen_random_uuid(),


### PR DESCRIPTION
## Summary

- `initTimeEntriesTable` now calls `initProjectTables` first, guaranteeing the `projects` table exists before `time_entries` (which holds a FK on `projects.id`) is created
- Adds a `projectTablesReady` guard to `initProjectTables` — mirrors the existing `timeEntriesReady` pattern, eliminating 3 redundant DDL queries per project operation

## Root cause

On a fresh pod or new DB, `[id].astro` loads project details via `Promise.all([listSubProjects, listDirectTasks, listTimeEntries, getProjectTotalMinutes])`. The time-entry inits ran concurrently with the project-table inits, causing `CREATE TABLE time_entries` to fail with a FK violation when `projects` didn't exist yet.

## Test plan

- [ ] Load `/admin/projekte/<id>` on a fresh DB — no database error
- [ ] Verify time entries tab loads correctly
- [ ] Verify Besprechungen tab loads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)