### PR TITLE
feat(enrollment): user enrollment from Leistungsbuchung + Kundennummer editing

### DIFF
--- a/k3d/website-schema.yaml
+++ b/k3d/website-schema.yaml
@@ -13,8 +13,19 @@ data:
     echo "Initializing meetings schema..."
 
     psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname website <<-'EOSQL'
-      -- Customer number sequence (M0001, M0002, …)
-      CREATE SEQUENCE IF NOT EXISTS customer_number_seq START 1;
+      -- Customer number sequence (M0020, M0021, …)
+      CREATE SEQUENCE IF NOT EXISTS customer_number_seq START 20;
+
+      -- For existing deployments: ensure the next nextval() call returns at least 20.
+      -- Uses is_called to distinguish fresh sequences (next = last_value) from
+      -- used ones (next = last_value + 1) without advancing the sequence itself.
+      DO $$
+      BEGIN
+        IF (SELECT CASE WHEN is_called THEN last_value + 1 ELSE last_value END
+            FROM customer_number_seq) < 20 THEN
+          PERFORM setval('customer_number_seq', 20, false);
+        END IF;
+      END $$;
 
       -- Customers (cross-reference to Keycloak)
       CREATE TABLE IF NOT EXISTS customers (
@@ -32,6 +43,9 @@ data:
       ALTER TABLE customers ADD COLUMN IF NOT EXISTS customer_number TEXT UNIQUE;
       UPDATE customers SET customer_number = 'M' || LPAD(nextval('customer_number_seq')::text, 4, '0') WHERE customer_number IS NULL;
       ALTER TABLE customers ALTER COLUMN customer_number SET DEFAULT 'M' || LPAD(nextval('customer_number_seq')::text, 4, '0');
+
+      -- Enrollment tracking: allows admin to dismiss a pending enrollment without creating a portal account
+      ALTER TABLE customers ADD COLUMN IF NOT EXISTS enrollment_declined BOOLEAN NOT NULL DEFAULT FALSE;
 
       -- Meeting history
       CREATE TABLE IF NOT EXISTS meetings (

--- a/website/src/lib/website-db.ts
+++ b/website/src/lib/website-db.ts
@@ -50,12 +50,72 @@ export async function upsertCustomer(params: {
        phone = COALESCE(EXCLUDED.phone, customers.phone),
        company = COALESCE(EXCLUDED.company, customers.company),
        keycloak_user_id = COALESCE(EXCLUDED.keycloak_user_id, customers.keycloak_user_id),
+       enrollment_declined = false,
        updated_at = now()
      RETURNING id, name, email, customer_number`,
     [params.name, params.email, params.phone, params.company,
      params.keycloakUserId]
   );
   return result.rows[0];
+}
+
+export interface PendingEnrollment {
+  id: string;
+  name: string;
+  email: string;
+  phone?: string;
+  company?: string;
+  created_at: string;
+}
+
+export async function listPendingEnrollments(): Promise<PendingEnrollment[]> {
+  const result = await pool.query(
+    `SELECT id, name, email, phone, company, created_at
+     FROM customers
+     WHERE keycloak_user_id IS NULL AND enrollment_declined = false
+     ORDER BY created_at DESC`
+  );
+  return result.rows;
+}
+
+export async function declineEnrollment(id: string): Promise<void> {
+  await pool.query(
+    'UPDATE customers SET enrollment_declined = true WHERE id = $1',
+    [id]
+  );
+}
+
+export async function getCustomerFullById(id: string): Promise<{
+  id: string; name: string; email: string; phone?: string; company?: string; customer_number?: string;
+} | null> {
+  const result = await pool.query(
+    `SELECT id, name, email, phone, company, customer_number FROM customers WHERE id = $1`,
+    [id]
+  );
+  return result.rows[0] ?? null;
+}
+
+export async function setCustomerNumber(
+  customerId: string,
+  customerNumber: string | null
+): Promise<{ ok: boolean; error?: string }> {
+  if (customerNumber !== null && !/^M\d{4}$/.test(customerNumber)) {
+    return { ok: false, error: 'Ungültiges Format. Erwartet: M0020–M9999' };
+  }
+  if (customerNumber !== null) {
+    const dup = await pool.query(
+      'SELECT id FROM customers WHERE customer_number = $1 AND id != $2',
+      [customerNumber, customerId]
+    );
+    if (dup.rows.length > 0) {
+      return { ok: false, error: `${customerNumber} ist bereits vergeben.` };
+    }
+  }
+  await pool.query(
+    'UPDATE customers SET customer_number = $1 WHERE id = $2',
+    [customerNumber, customerId]
+  );
+  return { ok: true };
 }
 
 // ── Schema init ─────────────────────────────────────────────────────────────

--- a/website/src/lib/website-db.ts
+++ b/website/src/lib/website-db.ts
@@ -820,7 +820,10 @@ export interface ProjectTask {
   updatedAt: Date;
 }
 
+let projectTablesReady = false;
+
 async function initProjectTables(): Promise<void> {
+  if (projectTablesReady) return;
   await pool.query(`
     CREATE TABLE IF NOT EXISTS projects (
       id          UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -870,6 +873,7 @@ async function initProjectTables(): Promise<void> {
       updated_at     TIMESTAMPTZ NOT NULL DEFAULT now()
     )
   `);
+  projectTablesReady = true;
 }
 
 const PROJECT_SELECT = `
@@ -1277,6 +1281,7 @@ export interface TimeEntry {
 
 async function initTimeEntriesTable(): Promise<void> {
   if (timeEntriesReady) return;
+  await initProjectTables();
   await pool.query(`
     CREATE TABLE IF NOT EXISTS time_entries (
       id                UUID        PRIMARY KEY DEFAULT gen_random_uuid(),

--- a/website/src/pages/admin/[clientId].astro
+++ b/website/src/pages/admin/[clientId].astro
@@ -11,7 +11,7 @@ import SignaturesTab from '../../components/portal/SignaturesTab.astro';
 import MeetingsAdminTab from '../../components/portal/MeetingsAdminTab.astro';
 import OnboardingTab from '../../components/portal/OnboardingTab.astro';
 import AdminBookingModal from '../../components/admin/AdminBookingModal.svelte';
-import { listProjectsForCustomer } from '../../lib/website-db';
+import { listProjectsForCustomer, getCustomerByEmail } from '../../lib/website-db';
 
 const session = await getSession(Astro.request.headers.get('cookie'));
 if (!session) {
@@ -48,6 +48,13 @@ try {
   clientProjects = all.map(p => ({ id: p.id, name: p.name }));
 } catch {
   // Projekte-Dropdown bleibt leer
+}
+
+let customerRecord: { id: string; customer_number?: string } | null = null;
+try {
+  if (client.email) customerRecord = await getCustomerByEmail(client.email);
+} catch {
+  // DB unavailable
 }
 ---
 
@@ -141,6 +148,39 @@ try {
                 <span class="text-sm text-light">{role.name}</span>
               </label>
             ))}
+          </div>
+        </div>
+      )}
+
+      <!-- Kundennummer -->
+      {customerRecord && (
+        <div class="mb-6 p-4 bg-dark-light rounded-xl border border-dark-lighter" id="customer-number-section">
+          <h2 class="text-sm font-medium text-muted mb-3 uppercase tracking-wide">Kundennummer</h2>
+          <div class="flex items-center gap-3">
+            <span id="customer-number-display" class="font-mono text-light text-sm">
+              {customerRecord.customer_number ?? '—'}
+            </span>
+            <button
+              id="edit-customer-number-btn"
+              class="px-2 py-1 text-xs text-muted border border-dark-lighter rounded hover:border-gold/40 hover:text-light transition-colors"
+            >
+              Bearbeiten
+            </button>
+          </div>
+          <div id="customer-number-edit" class="hidden mt-3 flex items-center gap-2">
+            <input
+              id="customer-number-input"
+              type="text"
+              placeholder="M0020"
+              maxlength="5"
+              value={customerRecord.customer_number ?? ''}
+              data-customer-id={customerRecord.id}
+              class="w-28 bg-dark border border-dark-lighter rounded-lg px-3 py-1.5 text-light text-sm font-mono focus:border-gold focus:ring-1 focus:ring-gold/20 outline-none"
+            />
+            <button id="save-customer-number-btn" class="px-3 py-1.5 bg-gold text-dark rounded-lg text-xs font-semibold hover:bg-gold/80 transition-colors">Speichern</button>
+            <button id="clear-customer-number-btn" class="px-3 py-1.5 text-xs text-muted hover:text-red-400 transition-colors">Entfernen</button>
+            <button id="cancel-customer-number-btn" class="px-3 py-1.5 text-xs text-muted hover:text-light transition-colors">Abbrechen</button>
+            <span id="customer-number-error" class="text-xs text-red-400 hidden"></span>
           </div>
         </div>
       )}
@@ -306,6 +346,54 @@ try {
     } finally {
       btn.disabled = false;
     }
+  });
+
+  // Customer number editing
+  const cnEditBtn = document.getElementById('edit-customer-number-btn');
+  const cnEditPanel = document.getElementById('customer-number-edit');
+  const cnDisplay = document.getElementById('customer-number-display');
+  const cnInput = document.getElementById('customer-number-input') as HTMLInputElement | null;
+  const cnError = document.getElementById('customer-number-error');
+
+  cnEditBtn?.addEventListener('click', () => {
+    cnEditPanel?.classList.toggle('hidden');
+  });
+  document.getElementById('cancel-customer-number-btn')?.addEventListener('click', () => {
+    cnEditPanel?.classList.add('hidden');
+    if (cnError) cnError.classList.add('hidden');
+  });
+
+  async function saveCustomerNumber(value: string | null) {
+    const customerId = cnInput?.dataset.customerId;
+    if (!customerId) return;
+    if (cnError) cnError.classList.add('hidden');
+    const saveBtn = document.getElementById('save-customer-number-btn') as HTMLButtonElement | null;
+    if (saveBtn) { saveBtn.disabled = true; saveBtn.textContent = '...'; }
+    try {
+      const res = await fetch('/api/admin/clients/set-customer-number', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ customerId, customerNumber: value }),
+      });
+      const json = await res.json().catch(() => ({})) as { error?: string };
+      if (res.ok) {
+        if (cnDisplay) cnDisplay.textContent = value ?? '—';
+        cnEditPanel?.classList.add('hidden');
+      } else {
+        if (cnError) { cnError.textContent = json.error ?? 'Fehler.'; cnError.classList.remove('hidden'); }
+      }
+    } catch {
+      if (cnError) { cnError.textContent = 'Netzwerkfehler.'; cnError.classList.remove('hidden'); }
+    } finally {
+      if (saveBtn) { saveBtn.disabled = false; saveBtn.textContent = 'Speichern'; }
+    }
+  }
+
+  document.getElementById('save-customer-number-btn')?.addEventListener('click', () => {
+    saveCustomerNumber(cnInput?.value.trim() || null);
+  });
+  document.getElementById('clear-customer-number-btn')?.addEventListener('click', () => {
+    if (confirm('Kundennummer entfernen?')) saveCustomerNumber(null);
   });
 
   // Role checkboxes

--- a/website/src/pages/admin/clients.astro
+++ b/website/src/pages/admin/clients.astro
@@ -3,7 +3,8 @@ import AdminLayout from '../../layouts/AdminLayout.astro';
 import { getSession, getLoginUrl, isAdmin } from '../../lib/auth';
 import { listUsers } from '../../lib/keycloak';
 import type { KcUser } from '../../lib/keycloak';
-import { listAllCustomers } from '../../lib/website-db';
+import { listAllCustomers, listPendingEnrollments } from '../../lib/website-db';
+import type { PendingEnrollment } from '../../lib/website-db';
 
 const session = await getSession(Astro.request.headers.get('cookie'));
 if (!session) return Astro.redirect(getLoginUrl(Astro.url.pathname));
@@ -22,6 +23,13 @@ try {
   for (const c of dbCustomers) {
     if (c.email && c.customer_number) customerNumberByEmail.set(c.email, c.customer_number);
   }
+} catch {
+  // DB unavailable
+}
+
+let pendingEnrollments: PendingEnrollment[] = [];
+try {
+  pendingEnrollments = await listPendingEnrollments();
 } catch {
   // DB unavailable
 }
@@ -112,6 +120,41 @@ try {
           </div>
         </form>
       </div>
+
+      <!-- Ausstehende Enrollments -->
+      {pendingEnrollments.length > 0 && (
+        <div class="mb-8">
+          <h2 class="text-lg font-semibold text-light mb-3">Ausstehende Enrollments <span class="text-sm font-normal text-muted ml-1">({pendingEnrollments.length})</span></h2>
+          <div class="grid gap-3" id="enrollment-list">
+            {pendingEnrollments.map(e => (
+              <div
+                class="flex items-center gap-4 p-4 bg-dark-light rounded-xl border border-gold/20"
+                data-enrollment-id={e.id}
+              >
+                <div class="flex-1 min-w-0">
+                  <p class="text-light font-medium">{e.name}</p>
+                  <p class="text-sm text-muted truncate">{e.email}{e.company ? ` · ${e.company}` : ''}{e.phone ? ` · ${e.phone}` : ''}</p>
+                </div>
+                <div class="flex gap-2 shrink-0">
+                  <button
+                    class="enroll-btn px-3 py-1.5 bg-gold text-dark rounded-lg text-sm font-semibold hover:bg-gold/80 transition-colors disabled:opacity-50"
+                    data-id={e.id}
+                    data-name={e.name}
+                  >
+                    Enrollen
+                  </button>
+                  <button
+                    class="decline-btn px-3 py-1.5 bg-dark border border-dark-lighter text-muted rounded-lg text-sm hover:border-red-500/40 hover:text-red-400 transition-colors disabled:opacity-50"
+                    data-id={e.id}
+                  >
+                    Ablehnen
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
 
       <div class="grid gap-4" data-testid="admin-client-list">
         {users.map(user => (
@@ -204,5 +247,60 @@ try {
       submitBtn.disabled = false;
       submitBtn.textContent = 'Einladen & Passwort-Email senden';
     }
+  });
+
+  // Enrollment actions
+  document.querySelectorAll<HTMLButtonElement>('.enroll-btn').forEach(btn => {
+    btn.addEventListener('click', async () => {
+      const id = btn.dataset.id!;
+      const name = btn.dataset.name ?? '';
+      if (!confirm(`${name} enrollen und Passwort-Email senden?`)) return;
+      btn.disabled = true;
+      btn.textContent = '...';
+      try {
+        const res = await fetch('/api/admin/clients/enroll', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ customerId: id }),
+        });
+        const json = await res.json().catch(() => ({})) as { error?: string; message?: string };
+        if (res.ok) {
+          btn.closest('[data-enrollment-id]')?.remove();
+        } else {
+          alert(json.error ?? 'Fehler beim Enrollen.');
+          btn.disabled = false;
+          btn.textContent = 'Enrollen';
+        }
+      } catch {
+        alert('Netzwerkfehler.');
+        btn.disabled = false;
+        btn.textContent = 'Enrollen';
+      }
+    });
+  });
+
+  document.querySelectorAll<HTMLButtonElement>('.decline-btn').forEach(btn => {
+    btn.addEventListener('click', async () => {
+      const id = btn.dataset.id!;
+      if (!confirm('Enrollment ablehnen?')) return;
+      btn.disabled = true;
+      try {
+        const res = await fetch('/api/admin/clients/decline-enrollment', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ customerId: id }),
+        });
+        if (res.ok) {
+          btn.closest('[data-enrollment-id]')?.remove();
+        } else {
+          const json = await res.json().catch(() => ({})) as { error?: string };
+          alert(json.error ?? 'Fehler.');
+          btn.disabled = false;
+        }
+      } catch {
+        alert('Netzwerkfehler.');
+        btn.disabled = false;
+      }
+    });
   });
 </script>

--- a/website/src/pages/api/admin/clients/decline-enrollment.ts
+++ b/website/src/pages/api/admin/clients/decline-enrollment.ts
@@ -1,0 +1,24 @@
+import type { APIRoute } from 'astro';
+import { getSession, isAdmin } from '../../../../lib/auth';
+import { declineEnrollment } from '../../../../lib/website-db';
+
+export const POST: APIRoute = async ({ request }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401, headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const body = await request.json() as { customerId?: string };
+  if (!body.customerId) {
+    return new Response(JSON.stringify({ error: 'customerId erforderlich' }), {
+      status: 400, headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  await declineEnrollment(body.customerId);
+  return new Response(JSON.stringify({ success: true }), {
+    status: 200, headers: { 'Content-Type': 'application/json' },
+  });
+};

--- a/website/src/pages/api/admin/clients/enroll.ts
+++ b/website/src/pages/api/admin/clients/enroll.ts
@@ -1,0 +1,72 @@
+import type { APIRoute } from 'astro';
+import { getSession, isAdmin } from '../../../../lib/auth';
+import { getCustomerFullById, upsertCustomer } from '../../../../lib/website-db';
+import { createUser, sendPasswordResetEmail, listUsers } from '../../../../lib/keycloak';
+
+export const POST: APIRoute = async ({ request }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401, headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const body = await request.json() as { customerId?: string };
+  if (!body.customerId) {
+    return new Response(JSON.stringify({ error: 'customerId erforderlich' }), {
+      status: 400, headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const customer = await getCustomerFullById(body.customerId);
+  if (!customer) {
+    return new Response(JSON.stringify({ error: 'Kunde nicht gefunden' }), {
+      status: 404, headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const spaceIdx = customer.name.indexOf(' ');
+  const firstName = spaceIdx > -1 ? customer.name.slice(0, spaceIdx) : customer.name;
+  const lastName = spaceIdx > -1 ? customer.name.slice(spaceIdx + 1) : '';
+
+  const result = await createUser({
+    email: customer.email,
+    firstName,
+    lastName,
+    phone: customer.phone,
+    company: customer.company,
+  });
+
+  let userId = result.userId;
+  if (!result.success && result.error?.includes('bereits')) {
+    const allUsers = await listUsers();
+    const existing = allUsers.find(u => u.email?.toLowerCase() === customer.email.toLowerCase());
+    if (existing) {
+      userId = existing.id;
+    } else {
+      return new Response(JSON.stringify({ error: `Keycloak-Fehler: ${result.error}` }), {
+        status: 500, headers: { 'Content-Type': 'application/json' },
+      });
+    }
+  } else if (!result.success || !userId) {
+    return new Response(JSON.stringify({ error: `Keycloak-Fehler: ${result.error}` }), {
+      status: 500, headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  if (result.success) {
+    await sendPasswordResetEmail(userId);
+  }
+  await upsertCustomer({
+    name: customer.name,
+    email: customer.email,
+    phone: customer.phone,
+    company: customer.company,
+    keycloakUserId: userId,
+  });
+
+  return new Response(
+    JSON.stringify({ success: true, message: `${customer.name} wurde eingeschrieben. Passwort-Email wurde gesendet.` }),
+    { status: 200, headers: { 'Content-Type': 'application/json' } }
+  );
+};

--- a/website/src/pages/api/admin/clients/set-customer-number.ts
+++ b/website/src/pages/api/admin/clients/set-customer-number.ts
@@ -1,0 +1,30 @@
+import type { APIRoute } from 'astro';
+import { getSession, isAdmin } from '../../../../lib/auth';
+import { setCustomerNumber } from '../../../../lib/website-db';
+
+export const POST: APIRoute = async ({ request }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401, headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const body = await request.json() as { customerId?: string; customerNumber?: string | null };
+  if (!body.customerId) {
+    return new Response(JSON.stringify({ error: 'customerId erforderlich' }), {
+      status: 400, headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const result = await setCustomerNumber(body.customerId, body.customerNumber ?? null);
+  if (!result.ok) {
+    return new Response(JSON.stringify({ error: result.error }), {
+      status: 400, headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  return new Response(JSON.stringify({ success: true }), {
+    status: 200, headers: { 'Content-Type': 'application/json' },
+  });
+};


### PR DESCRIPTION
## Summary

- Accepting a Leistungsbuchung from a new email address now surfaces the contact as a pending enrollment in the Admin Clients View
- Admin can **Enrollen** (creates Keycloak account, sends password-reset email) or **Ablehnen** (dismisses; re-booking reopens the queue)
- Kundennummer sequence now starts at **M0020**; inline editing with format validation and uniqueness check added to the Client Detail page

## Changes

- `k3d/website-schema.yaml`: sequence `START 20`, safe `DO $$` migration for existing deployments, new `enrollment_declined` column
- `website/src/lib/website-db.ts`: `listPendingEnrollments`, `declineEnrollment`, `getCustomerFullById`, `setCustomerNumber`; `upsertCustomer` resets `enrollment_declined` on conflict so re-bookings reopen the queue
- 3 new API endpoints: `/api/admin/clients/enroll`, `decline-enrollment`, `set-customer-number`
- `admin/clients.astro`: "Ausstehende Enrollments" section with instant DOM removal on action
- `admin/[clientId].astro`: Kundennummer card with inline edit, `/^M\d{4}$/` validation, clear option

## Test plan

- [ ] Approve a booking from an unknown email → customer appears in "Ausstehende Enrollments"
- [ ] Click "Enrollen" → Keycloak user created, password email sent, row disappears
- [ ] Click "Ablehnen" → row disappears; same email books again → reappears
- [ ] Edit Kundennummer in Client Detail → invalid format rejected; duplicate rejected; save updates display
- [ ] Fresh cluster deploy → first customer gets M0020

🤖 Generated with [Claude Code](https://claude.com/claude-code)