### PR TITLE
fix(db): sync DB passwords on every shared-db restart + remove duplicate docs client

### DIFF
--- a/k3d/realm-workspace-dev.json
+++ b/k3d/realm-workspace-dev.json
@@ -321,60 +321,6 @@
           }
         }
       ]
-    },
-    {
-      "clientId": "docs",
-      "name": "Docs",
-      "enabled": true,
-      "clientAuthenticatorType": "client-secret",
-      "secret": "${DOCS_OIDC_SECRET}",
-      "redirectUris": [
-        "http://docs.localhost/oauth2/callback"
-      ],
-      "webOrigins": [
-        "http://docs.localhost"
-      ],
-      "standardFlowEnabled": true,
-      "implicitFlowEnabled": false,
-      "directAccessGrantsEnabled": false,
-      "serviceAccountsEnabled": false,
-      "protocol": "openid-connect",
-      "publicClient": false,
-      "attributes": {
-        "oidc.ciba.grant.enabled": "false",
-        "oauth2.device.authorization.grant.enabled": "false",
-        "backchannel.logout.session.required": "true"
-      },
-      "protocolMappers": [
-        {
-          "name": "email",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-usermodel-property-mapper",
-          "consentRequired": false,
-          "config": {
-            "userinfo.token.claim": "true",
-            "user.attribute": "email",
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "claim.name": "email",
-            "jsonType.label": "String"
-          }
-        },
-        {
-          "name": "username",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-usermodel-property-mapper",
-          "consentRequired": false,
-          "config": {
-            "userinfo.token.claim": "true",
-            "user.attribute": "username",
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "claim.name": "preferred_username",
-            "jsonType.label": "String"
-          }
-        }
-      ]
     }
   ]
 }

--- a/k3d/shared-db.yaml
+++ b/k3d/shared-db.yaml
@@ -153,6 +153,19 @@ spec:
                 secretKeyRef:
                   name: workspace-secrets
                   key: WEBSITE_DB_PASSWORD
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                  - /bin/bash
+                  - -c
+                  - |
+                    until pg_isready -U postgres; do sleep 2; done
+                    psql -U postgres \
+                      -c "ALTER USER keycloak WITH PASSWORD '${KEYCLOAK_DB_PASSWORD}';" \
+                      -c "ALTER USER nextcloud WITH PASSWORD '${NEXTCLOUD_DB_PASSWORD}';" \
+                      -c "ALTER USER vaultwarden WITH PASSWORD '${VAULTWARDEN_DB_PASSWORD}';" \
+                      -c "ALTER USER website WITH PASSWORD '${WEBSITE_DB_PASSWORD}';"
           ports:
             - containerPort: 5432
           volumeMounts:


### PR DESCRIPTION
## Summary

- **Root cause of today's login outage**: `workspace-secrets` were rotated after the DB was first initialised. The `/docker-entrypoint-initdb.d/` password-sync script only runs on an empty PGDATA, so DB user passwords drifted out of sync with the secret. When `shared-db` restarted (due to missing `MATTERMOST_DB_PASSWORD` key), Keycloak and all other services failed TCP auth.
- Adds a `postStart` lifecycle hook to `shared-db` that re-runs `ALTER USER … WITH PASSWORD` for all service accounts on every pod start — keeps DB passwords in sync with the secret regardless of when it was rotated.
- Removes a duplicate `docs` OIDC client entry (with protocol mappers) from `k3d/realm-workspace-dev.json`; the correct minimal client definition already follows it.

## What was fixed live (already applied to mentolder)

1. Removed stale `MATTERMOST_DB_PASSWORD` env ref from the live `shared-db` Deployment (`kubectl set env`)
2. Manually ran `ALTER USER` for all four service accounts to match current secrets
3. Reverted an uncommitted `realm-import-entrypoint.sh` change that broke Keycloak startup

## Test plan

- [ ] `task workspace:validate` passes
- [ ] After merge + ArgoCD sync, `shared-db` pod starts and postStart hook runs without error (`kubectl describe pod shared-db -n workspace`)
- [ ] Keycloak, Nextcloud, Vaultwarden, and website connect to DB successfully after a fresh `shared-db` restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)