### PR TITLE
fix(docuseal): substitute customer variables in contract HTML before creating DocuSeal template

### DIFF
--- a/k3d/website-schema.yaml
+++ b/k3d/website-schema.yaml
@@ -236,6 +236,8 @@ data:
         signed_at TIMESTAMPTZ
       );
 
+      ALTER TABLE document_assignments ADD COLUMN IF NOT EXISTS docuseal_template_id INTEGER;
+
       CREATE INDEX IF NOT EXISTS idx_doc_assignments_customer ON document_assignments(customer_id);
       CREATE INDEX IF NOT EXISTS idx_doc_assignments_status ON document_assignments(status);
 

--- a/website/src/components/admin/DokumentEditor.svelte
+++ b/website/src/components/admin/DokumentEditor.svelte
@@ -177,6 +177,18 @@
               rows="18"
               class="w-full bg-dark border border-dark-lighter rounded-lg px-3 py-2 text-light text-sm font-mono focus:border-gold focus:ring-1 focus:ring-gold/20 outline-none resize-y"
             ></textarea>
+            <p class="text-xs text-muted mt-1">
+              Verfügbare Platzhalter (werden beim Zuweisen automatisch befüllt):
+              <span class="font-mono text-gold/80">&#123;&#123;KUNDENNAME&#125;&#125;</span>
+              <span class="font-mono text-gold/80">&#123;&#123;KUNDENNUMMER&#125;&#125;</span>
+              <span class="font-mono text-gold/80">&#123;&#123;EMAIL&#125;&#125;</span>
+              <span class="font-mono text-gold/80">&#123;&#123;TELEFON&#125;&#125;</span>
+              <span class="font-mono text-gold/80">&#123;&#123;FIRMA&#125;&#125;</span>
+              <span class="font-mono text-gold/80">&#123;&#123;VORNAME&#125;&#125;</span>
+              <span class="font-mono text-gold/80">&#123;&#123;NACHNAME&#125;&#125;</span>
+              <span class="font-mono text-gold/80">&#123;&#123;DATUM&#125;&#125;</span>
+              <span class="font-mono text-gold/80">&#123;&#123;JAHR&#125;&#125;</span>
+            </p>
           </div>
           {#if composeMsg}
             <p class={`text-sm ${composeMsg.includes('Fehler') || composeMsg.includes('erforderlich') ? 'text-red-400' : 'text-green-400'}`}>{composeMsg}</p>

--- a/website/src/lib/documents-db.ts
+++ b/website/src/lib/documents-db.ts
@@ -30,6 +30,7 @@ export interface DocumentAssignment {
   customer_id: string;
   template_id: string;
   template_title: string;
+  docuseal_template_id: number | null;
   docuseal_submission_slug: string | null;
   docuseal_embed_src: string | null;
   status: 'pending' | 'completed' | 'expired';
@@ -97,18 +98,18 @@ export async function deleteDocumentTemplate(id: string): Promise<void> {
 export async function createDocumentAssignment(params: {
   customerId: string;
   templateId: string;
+  dsTemplateId: number;
   submissionSlug: string;
   embedSrc: string;
 }): Promise<DocumentAssignment> {
   const r = await pool.query(
     `INSERT INTO document_assignments
-       (customer_id, template_id, docuseal_submission_slug, docuseal_embed_src)
-     VALUES ($1, $2, $3, $4)
-     RETURNING id, customer_id, template_id, docuseal_submission_slug,
+       (customer_id, template_id, docuseal_template_id, docuseal_submission_slug, docuseal_embed_src)
+     VALUES ($1, $2, $3, $4, $5)
+     RETURNING id, customer_id, template_id, docuseal_template_id, docuseal_submission_slug,
                docuseal_embed_src, status, assigned_at, signed_at`,
-    [params.customerId, params.templateId, params.submissionSlug, params.embedSrc],
+    [params.customerId, params.templateId, params.dsTemplateId, params.submissionSlug, params.embedSrc],
   );
-  // fetch title for the returned object
   const row = r.rows[0];
   const tpl = await getDocumentTemplate(row.template_id);
   return { ...row, template_title: tpl?.title ?? '' };

--- a/website/src/lib/website-db.ts
+++ b/website/src/lib/website-db.ts
@@ -33,6 +33,8 @@ export interface Customer {
   name: string;
   email: string;
   customer_number?: string;
+  phone?: string;
+  company?: string;
 }
 
 export async function upsertCustomer(params: {
@@ -1661,7 +1663,7 @@ export async function getCustomerByEmail(
   email: string
 ): Promise<Customer | null> {
   const result = await pool.query(
-    `SELECT id, name, email, customer_number FROM customers WHERE email = $1`,
+    `SELECT id, name, email, customer_number, phone, company FROM customers WHERE email = $1`,
     [email]
   );
   return result.rows[0] ?? null;

--- a/website/src/pages/api/admin/documents/assign.ts
+++ b/website/src/pages/api/admin/documents/assign.ts
@@ -1,9 +1,44 @@
 import type { APIRoute } from 'astro';
 import { getSession, isAdmin } from '../../../../lib/auth';
-import { getDocumentTemplate, createDocumentAssignment, updateDocumentTemplate } from '../../../../lib/documents-db';
+import { getDocumentTemplate, createDocumentAssignment } from '../../../../lib/documents-db';
 import { getCustomerByEmail } from '../../../../lib/website-db';
 import { createTemplate, createSubmission } from '../../../../lib/docuseal';
 import { getUserById } from '../../../../lib/keycloak';
+
+// Substitutes {{VARIABLE}} placeholders in the HTML with customer data.
+// Available variables that the Dokumenteneditor can use:
+//   {{KUNDENNAME}}    – full name from customers table
+//   {{KUNDENNUMMER}}  – customer number (e.g. M0042)
+//   {{EMAIL}}         – email address
+//   {{TELEFON}}       – phone number
+//   {{FIRMA}}         – company name
+//   {{VORNAME}}       – first name from Keycloak
+//   {{NACHNAME}}      – last name from Keycloak
+//   {{DATUM}}         – current date in German format (TT.MM.JJJJ)
+//   {{JAHR}}          – current year (JJJJ)
+function substituteVars(html: string, vars: {
+  name: string;
+  customerNumber: string;
+  email: string;
+  phone: string;
+  company: string;
+  firstName: string;
+  lastName: string;
+}): string {
+  const now = new Date();
+  const datum = now.toLocaleDateString('de-DE', { day: '2-digit', month: '2-digit', year: 'numeric' });
+  const jahr = now.getFullYear().toString();
+  return html
+    .replace(/\{\{KUNDENNAME\}\}/g, vars.name)
+    .replace(/\{\{KUNDENNUMMER\}\}/g, vars.customerNumber)
+    .replace(/\{\{EMAIL\}\}/g, vars.email)
+    .replace(/\{\{TELEFON\}\}/g, vars.phone)
+    .replace(/\{\{FIRMA\}\}/g, vars.company)
+    .replace(/\{\{VORNAME\}\}/g, vars.firstName)
+    .replace(/\{\{NACHNAME\}\}/g, vars.lastName)
+    .replace(/\{\{DATUM\}\}/g, datum)
+    .replace(/\{\{JAHR\}\}/g, jahr);
+}
 
 export const POST: APIRoute = async ({ request }) => {
   const session = await getSession(request.headers.get('cookie'));
@@ -29,19 +64,32 @@ export const POST: APIRoute = async ({ request }) => {
     return new Response(JSON.stringify({ error: 'Kundeneintrag nicht gefunden.' }), { status: 404 });
   }
 
-  // Create or reuse DocuSeal template
-  let dsTemplateId = template.docuseal_template_id;
-  if (!dsTemplateId) {
-    try {
-      dsTemplateId = await createTemplate(template.title, template.html_body);
-      await updateDocumentTemplate(template.id, { docuseal_template_id: dsTemplateId });
-    } catch (err) {
-      console.error('DocuSeal createTemplate error:', err);
-      return new Response(JSON.stringify({ error: 'DocuSeal-Vorlage konnte nicht erstellt werden.' }), { status: 502 });
-    }
+  // Substitute all {{VARIABLE}} placeholders with real customer data before
+  // sending to DocuSeal — each assignment gets its own rendered template so
+  // client-specific fields (name, number, date) are already embedded in the PDF.
+  const renderedHtml = substituteVars(template.html_body, {
+    name: customer.name,
+    customerNumber: customer.customer_number ?? '',
+    email: customer.email,
+    phone: customer.phone ?? '',
+    company: customer.company ?? '',
+    firstName: kcUser.firstName ?? '',
+    lastName: kcUser.lastName ?? '',
+  });
+
+  // Always create a fresh DocuSeal template per assignment so the embedded
+  // data is immutable for each client (never reuse the base template ID).
+  let dsTemplateId: number;
+  try {
+    dsTemplateId = await createTemplate(
+      `${template.title} — ${customer.name}`,
+      renderedHtml,
+    );
+  } catch (err) {
+    console.error('DocuSeal createTemplate error:', err);
+    return new Response(JSON.stringify({ error: 'DocuSeal-Vorlage konnte nicht erstellt werden.' }), { status: 502 });
   }
 
-  // Create submission in DocuSeal
   let submitter;
   try {
     submitter = await createSubmission({
@@ -57,6 +105,7 @@ export const POST: APIRoute = async ({ request }) => {
   const assignment = await createDocumentAssignment({
     customerId: customer.id,
     templateId: template.id,
+    dsTemplateId,
     submissionSlug: submitter.slug,
     embedSrc: submitter.embed_src,
   });


### PR DESCRIPTION
## Summary

- `assign.ts`: fügt `substituteVars()` hinzu, das `{{VARIABLE}}`-Platzhalter im HTML durch echte Kundendaten ersetzt, bevor das Template an DocuSeal gesendet wird
- Erstellt jetzt pro Zuweisung ein frisches DocuSeal-Template (mit bereits eingebetteten Kundendaten) statt die geteilte Template-ID wiederzuverwenden
- Neues `docuseal_template_id`-Feld auf `document_assignments` (Schema via `ALTER TABLE ADD COLUMN IF NOT EXISTS`)
- `getCustomerByEmail` gibt jetzt auch `phone` und `company` zurück
- `DokumentEditor.svelte`: zeigt verfügbare Platzhalter als Hinweis unter dem HTML-Textfeld

**Verfügbare Platzhalter:**
`{{KUNDENNAME}}` `{{KUNDENNUMMER}}` `{{EMAIL}}` `{{TELEFON}}` `{{FIRMA}}` `{{VORNAME}}` `{{NACHNAME}}` `{{DATUM}}` `{{JAHR}}`

## Test plan

- [ ] Coaching-Vertrag im Dokumenteneditor mit Platzhaltern anlegen (z.B. `{{KUNDENNAME}}`, `{{KUNDENNUMMER}}`, `{{DATUM}}`)
- [ ] Vertrag einem Kunden zuweisen → DocuSeal-Submission wird erstellt
- [ ] Verify: im DocuSeal-Template sind die Platzhalter durch echte Kundendaten ersetzt
- [ ] Verify: zwei Kunden mit demselben Template erhalten unterschiedliche DocuSeal-Templates

🤖 Generated with [Claude Code](https://claude.com/claude-code)