### PR TITLE
fix(argocd): force ServerSideApply for docs-content ConfigMap

### DIFF
--- a/k3d/kustomization.yaml
+++ b/k3d/kustomization.yaml
@@ -76,6 +76,9 @@ configMapGenerator:
     files:
       - zz-extra.config.php=nextcloud-extra-config.php
   - name: docs-content
+    options:
+      annotations:
+        argocd.argoproj.io/sync-options: ServerSideApply=true
     files:
       - docs-content/index.html
       - docs-content/README.md


### PR DESCRIPTION
## Summary
- `docs-content` ConfigMap is ~350KB and ArgoCD was using client-side apply despite `ServerSideApply=true` app-level sync option
- Adds `argocd.argoproj.io/sync-options: ServerSideApply=true` directly to the ConfigMap via kustomize generator options, bypassing the 262KB annotation limit

## Test plan
- [ ] ArgoCD workspace-mentolder sync succeeds without docs-content error

🤖 Generated with [Claude Code](https://claude.ai/claude-code)