### PR TITLE
fix(keycloak): use kc.sh import + start for KC 26 compatibility

### DIFF
--- a/k3d/realm-import-entrypoint.sh
+++ b/k3d/realm-import-entrypoint.sh
@@ -40,5 +40,10 @@ fi
 
 echo "[import-entrypoint] Realm JSON generiert: $OUTPUT"
 
-# Original Keycloak Entrypoint aufrufen
-exec /opt/keycloak/bin/kc.sh start --import-realm "$@"
+# KC 26 changed --import-realm to exit after import.
+# Use 'import' subcommand (idempotent, skips existing realms) then 'start'.
+/opt/keycloak/bin/kc.sh import --file "$OUTPUT" --override false
+
+echo "[import-entrypoint] Realm importiert (oder bereits vorhanden). Starte KC-Server..."
+
+exec /opt/keycloak/bin/kc.sh start "$@"

--- a/prod/import-entrypoint.sh
+++ b/prod/import-entrypoint.sh
@@ -47,5 +47,10 @@ fi
 
 echo "[import-entrypoint] Realm JSON generiert: $OUTPUT"
 
-# Original Keycloak Entrypoint aufrufen
-exec /opt/keycloak/bin/kc.sh start --import-realm "$@"
+# KC 26 changed --import-realm to exit after import.
+# Use 'import' subcommand (idempotent, skips existing realms) then 'start'.
+/opt/keycloak/bin/kc.sh import --file "$OUTPUT" --override false
+
+echo "[import-entrypoint] Realm importiert (oder bereits vorhanden). Starte KC-Server..."
+
+exec /opt/keycloak/bin/kc.sh start "$@"

--- a/scripts/import-entrypoint.sh
+++ b/scripts/import-entrypoint.sh
@@ -40,5 +40,10 @@ fi
 
 echo "[import-entrypoint] Realm JSON generiert: $OUTPUT"
 
-# Original Keycloak Entrypoint aufrufen
-exec /opt/keycloak/bin/kc.sh start --import-realm "$@"
+# KC 26 changed --import-realm to exit after import.
+# Use 'import' subcommand (idempotent, skips existing realms) then 'start'.
+/opt/keycloak/bin/kc.sh import --file "$OUTPUT" --override false
+
+echo "[import-entrypoint] Realm importiert (oder bereits vorhanden). Starte KC-Server..."
+
+exec /opt/keycloak/bin/kc.sh start "$@"


### PR DESCRIPTION
## Summary
- Keycloak 26 changed `--import-realm` behavior: it now exits after importing instead of keeping the server running
- Replace `kc.sh start --import-realm` with `kc.sh import --override false` (idempotent, skips existing realms) followed by `kc.sh start`
- Fixes Keycloak CrashLoopBackOff on mentolder after fresh namespace creation

## Test plan
- [ ] Keycloak starts and stays running on mentolder

🤖 Generated with [Claude Code](https://claude.ai/claude-code)