### PR TITLE
fix(keycloak): update realm passwords to meet specialChars(1) policy

### DIFF
--- a/prod/realm-workspace-prod.json
+++ b/prod/realm-workspace-prod.json
@@ -44,7 +44,7 @@
       "credentials": [
         {
           "type": "password",
-          "value": "0tizrHZ1uqYvptHmRn4xa5LD",
+          "value": "0tizrHZ1uqYvptHmRn4xa5LD!",
           "temporary": false
         }
       ],
@@ -67,7 +67,7 @@
       "credentials": [
         {
           "type": "password",
-          "value": "0tizrHZ1uqYvptHmRn4xa5LD",
+          "value": "0tizrHZ1uqYvptHmRn4xa5LD!",
           "temporary": false
         }
       ],


### PR DESCRIPTION
## Summary
- `kc.sh import` validates passwords against the realm password policy (unlike the old `start --import-realm`)
- `patrick` and `gekko` users had `0tizrHZ1uqYvptHmRn4xa5LD` (no special chars), failing `specialChars(1)` 
- Added `!` to satisfy the policy for initial import (users can change password after first login)

## Test plan
- [ ] Keycloak import succeeds without `invalidPasswordMinSpecialCharsMessage` error

🤖 Generated with [Claude Code](https://claude.ai/claude-code)