### PR TITLE
fix(nextcloud): move pentest_flag to data/ to avoid rsync conflict

### DIFF
--- a/k3d/nextcloud.yaml
+++ b/k3d/nextcloud.yaml
@@ -177,7 +177,7 @@ spec:
               subPath: signaling-proxy.conf
               readOnly: true
             - name: pentest-flag
-              mountPath: /var/www/html/pentest_flag.txt
+              mountPath: /var/www/html/data/pentest_flag.txt
               subPath: pentest_flag.txt
               readOnly: true
             - name: php-conf-d


### PR DESCRIPTION
## Summary
- Nextcloud Docker entrypoint rsyncs web root with `--delete`, failing when it tries to remove the read-only ConfigMap-mounted `pentest_flag.txt`
- Move mount from `/var/www/html/pentest_flag.txt` → `/var/www/html/data/pentest_flag.txt` (excluded from rsync)

## Test plan
- [ ] Nextcloud starts without rsync error

🤖 Generated with [Claude Code](https://claude.ai/claude-code)