### PR TITLE
fix(nextcloud): chmod data dir to 0770 in init container

### DIFF
--- a/k3d/nextcloud.yaml
+++ b/k3d/nextcloud.yaml
@@ -45,6 +45,28 @@ spec:
         seccompProfile:
           type: RuntimeDefault
       initContainers:
+        - name: fix-data-perms
+          image: busybox:1.36
+          imagePullPolicy: Always
+          # Nextcloud refuses to start (HTTP 503) when the data dir is
+          # world-readable. local-path provisions PVCs as 2777, so we
+          # tighten it to 0770 and ensure www-data ownership here.
+          securityContext:
+            runAsUser: 0
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            seccompProfile:
+              type: RuntimeDefault
+          command:
+            - sh
+            - -c
+            - |
+              chown 33:33 /var/www/html/data
+              chmod 0770 /var/www/html/data
+          volumeMounts:
+            - name: data
+              mountPath: /var/www/html/data
         - name: fix-config-perms
           image: busybox:1.36
           imagePullPolicy: Always


### PR DESCRIPTION
## Summary
- Fresh `nextcloud-data-pvc` comes up as `2777` (local-path default) which makes Nextcloud serve HTTP 503 with "Your data directory is readable by other people" and every `occ` call fail with "Environment not properly prepared".
- Adds a root-privileged init container that runs `chown 33:33 && chmod 0770` on `/var/www/html/data` before the app starts, so fresh PVCs come up clean.

## Test plan
- [x] Observed live mentolder Nextcloud 503 on `/status.php` after fresh PVC provisioning
- [x] One-off chmod on the live PVC restored `HTTP 200` / `maintenance:false`
- [x] `kustomize build k3d/` + yamllint (200-char CI rule) pass locally
- [ ] ArgoCD syncs workspace-mentolder; pod rolls over and `/status.php` stays 200 after a synthetic PVC wipe

🤖 Generated with [Claude Code](https://claude.com/claude-code)