### PR TITLE
fix(website): add 404.astro to break /404 redirect loop

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1575,6 +1575,39 @@ tasks:
 
         echo "Waiting for website..."
         kubectl ${CTX_ARG} -n website rollout status deployment/website --timeout=180s
+      - |
+        set -euo pipefail
+        source scripts/env-resolve.sh "{{.ENV}}"
+        if [ "{{.ENV}}" = "dev" ]; then
+          SMOKE_URL="http://web.localhost/404"
+        else
+          SMOKE_URL="https://web.${PROD_DOMAIN}/404"
+        fi
+        echo ""
+        echo "Smoke check: ${SMOKE_URL} must not redirect to itself (would cause ERR_TOO_MANY_REDIRECTS)..."
+        HEADERS=$(curl -sS -I --max-redirs 0 --max-time 15 "${SMOKE_URL}" 2>/dev/null || true)
+        if [ -z "${HEADERS}" ]; then
+          echo "⚠ Smoke check skipped — ${SMOKE_URL} not reachable from this host."
+        else
+          STATUS=$(printf '%s\n' "${HEADERS}" | awk 'NR==1{print $2}')
+          LOCATION=$(printf '%s\n' "${HEADERS}" | awk 'tolower($1)=="location:"{print $2; exit}' | tr -d '\r')
+          case "${STATUS}" in
+            200|404)
+              echo "✓ /404 returns HTTP ${STATUS} (no redirect loop)"
+              ;;
+            30[12378])
+              if printf '%s' "${LOCATION}" | grep -qE '(^|/)404/?$'; then
+                echo "✗ /404 redirects to itself (${STATUS} → ${LOCATION}). ERR_TOO_MANY_REDIRECTS regression."
+                echo "  Ensure website/src/pages/404.astro exists so Astro serves a static 404 page."
+                exit 1
+              fi
+              echo "⚠ /404 responded ${STATUS} → ${LOCATION} (unexpected but not a self-loop)"
+              ;;
+            *)
+              echo "⚠ /404 returned HTTP '${STATUS:-<empty>}' — expected 200/404. Not failing deploy."
+              ;;
+          esac
+        fi
       - echo ""
       - |
         source scripts/env-resolve.sh "{{.ENV}}"

--- a/website/src/pages/404.astro
+++ b/website/src/pages/404.astro
@@ -1,0 +1,33 @@
+---
+import Layout from '../layouts/Layout.astro';
+---
+
+<Layout title="Seite nicht gefunden">
+  <section class="pt-28 pb-24">
+    <div class="max-w-2xl mx-auto px-6 text-center">
+      <p style="font-family:var(--mono); font-size:12px; letter-spacing:0.22em; text-transform:uppercase; color:var(--brass); margin:0 0 24px;">
+        Fehler 404
+      </p>
+      <h1 style="font-family:var(--serif); font-size:clamp(2.75rem, 8vw, 5rem); color:var(--fg); line-height:1.08; letter-spacing:-0.01em; margin:0 0 24px;">
+        Seite nicht gefunden
+      </h1>
+      <p style="font-size:18px; color:var(--fg-soft); line-height:1.65; margin:0 0 40px;">
+        Die von Ihnen aufgerufene Seite existiert nicht oder wurde verschoben.
+      </p>
+      <div style="display:flex; gap:16px; justify-content:center; flex-wrap:wrap;">
+        <a
+          href="/"
+          style="display:inline-block; padding:14px 28px; background:var(--brass); color:var(--ink-900); font-weight:600; text-decoration:none; border-radius:6px;"
+        >
+          Zur Startseite
+        </a>
+        <a
+          href="/leistungen"
+          style="display:inline-block; padding:14px 28px; background:transparent; color:var(--fg); font-weight:500; text-decoration:none; border:1px solid var(--line); border-radius:6px;"
+        >
+          Alle Leistungen
+        </a>
+      </div>
+    </div>
+  </section>
+</Layout>


### PR DESCRIPTION
## Summary
- `web.korczewski.de/404` (and any unknown path) hit `ERR_TOO_MANY_REDIRECTS` because `src/pages/[service].astro` is a dynamic catch-all that redirects unknown slugs to `/404`, and there was no static `404.astro` to terminate the loop. Static routes beat dynamic ones in Astro, so adding `src/pages/404.astro` makes `/404` resolve to a real page and also wires it up as the SSR fallback for truly unmatched paths.
- Adds a smoke check at the end of `task website:deploy`: it curls `/404` and fails the task if the response is a self-redirect (status 30x → `/404`). Per-env URL: `http://web.localhost/404` in dev, `https://web.${PROD_DOMAIN}/404` otherwise. Non-fatal when the host isn't reachable from the deploy runner.

## Test plan
- [x] `npm --prefix website run build` succeeds with the new page
- [x] `astro check` reports no new errors for `src/pages/404.astro`
- [ ] After merge + `task website:deploy ENV=korczewski` from clean `main`: `curl -sI https://web.korczewski.de/404` returns `HTTP/2 200`, not `302 → /404`
- [ ] Smoke check prints `✓ /404 returns HTTP 200 (no redirect loop)` in the deploy output

🤖 Generated with [Claude Code](https://claude.com/claude-code)