### PR TITLE
chore(mcp): move API-only MCP servers to dev cluster only

### DIFF
--- a/prod/kustomization.yaml
+++ b/prod/kustomization.yaml
@@ -76,6 +76,62 @@ patches:
       metadata:
         name: workspace-ingress-internal
       $patch: delete
+  # API-only MCP servers (GitHub, Stripe, Browser) run on the dev cluster only.
+  # They reach the same external APIs from anywhere, so no prod deployment needed.
+  - target:
+      kind: Deployment
+      name: mcp-github
+    patch: |
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: mcp-github
+      $patch: delete
+  - target:
+      kind: Service
+      name: mcp-github
+    patch: |
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: mcp-github
+      $patch: delete
+  - target:
+      kind: Deployment
+      name: claude-code-mcp-stripe
+    patch: |
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: claude-code-mcp-stripe
+      $patch: delete
+  - target:
+      kind: Service
+      name: claude-code-mcp-stripe
+    patch: |
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: claude-code-mcp-stripe
+      $patch: delete
+  - target:
+      kind: Deployment
+      name: mcp-browser
+    patch: |
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: mcp-browser
+      $patch: delete
+  - target:
+      kind: Service
+      name: mcp-browser
+    patch: |
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: mcp-browser
+      $patch: delete
   # Override domains
   - path: configmap-domains.yaml
   # Override ingress (add TLS + real hostnames)
@@ -89,7 +145,6 @@ patches:
   - path: patch-oauth2-proxy-docs.yaml
   # Pin amd64-only images to amd64 nodes
   - path: patch-amd64-only.yaml
-  - path: patch-mcp-browser.yaml
   # Collabora lives in the workspace-office namespace via its own
   # ArgoCD Application (argocd/applicationset-office.yaml) — no
   # patch target on this overlay.

--- a/prod/patch-mcp-browser.yaml
+++ b/prod/patch-mcp-browser.yaml
@@ -1,9 +1,0 @@
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: mcp-browser
-spec:
-  template:
-    spec:
-      nodeSelector:
-        kubernetes.io/arch: amd64

--- a/scripts/secrets-audit.sh
+++ b/scripts/secrets-audit.sh
@@ -149,6 +149,10 @@ SOLO_LABELS=(
   "coturn-secrets: SIGNALING_SECRET"
   "coturn-secrets: TURN_SECRET"
   "collabora-secrets: COLLABORA_ADMIN_PASSWORD"
+  "claude-code-secrets: NEXTCLOUD_USERNAME"
+  "claude-code-secrets: NEXTCLOUD_PASSWORD"
+  "mcp-tokens: CLUSTER_TOKEN"
+  "mcp-tokens: BUSINESS_TOKEN"
 )
 
 SOLO_MEMBERS=(
@@ -183,6 +187,10 @@ SOLO_MEMBERS=(
   "coturn:coturn-secrets:SIGNALING_SECRET"
   "coturn:coturn-secrets:TURN_SECRET"
   "workspace-office:collabora-secrets:COLLABORA_ADMIN_PASSWORD"
+  "workspace:claude-code-secrets:NEXTCLOUD_USERNAME"
+  "workspace:claude-code-secrets:NEXTCLOUD_PASSWORD"
+  "default:mcp-tokens:CLUSTER_TOKEN"
+  "default:mcp-tokens:BUSINESS_TOKEN"
 )
 
 NUM_SOLOS=${#SOLO_LABELS[@]}


### PR DESCRIPTION
## Summary
- Strip `mcp-github`, `claude-code-mcp-stripe`, and `mcp-browser` from prod overlays via `$patch: delete` in `prod/kustomization.yaml`. These servers hit external APIs (GitHub, Stripe, Playwright browsing) and have no in-cluster dependencies, so a single dev-cluster instance is sufficient.
- Remove the now-orphan `prod/patch-mcp-browser.yaml` amd64 nodeSelector patch.
- Extend `scripts/secrets-audit.sh` with `claude-code-secrets` (NEXTCLOUD_USERNAME/PASSWORD) and `mcp-tokens` (CLUSTER_TOKEN/BUSINESS_TOKEN) solo entries so the audit covers every Secret the cluster actually holds.

What stays on each prod cluster (in-cluster deps, can't move):
- `claude-code-mcp-auth` (in-cluster Keycloak)
- `claude-code-mcp-ops` (mcp-postgres / mcp-meetings / mcp-kubernetes via cluster-local DNS + ServiceAccount)

## Test plan
- [x] `kustomize build prod-korczewski/` — no mcp-github/stripe/browser in output
- [x] `kustomize build prod-mentolder/` — no mcp-github/stripe/browser in output
- [x] `kustomize build k3d/` — all five MCPs still present (dev keeps them)
- [x] Live `kubectl delete` executed on korczewski + mentolder; remaining MCPs (`claude-code-mcp-auth`, `claude-code-mcp-ops`) healthy
- [ ] Next `task mcp:deploy ENV=dev` should (re)create the three on the dev cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)