### PR TITLE
chore(cleanup): drop orphan rate-limit-billing middleware + k3s ingress billing rule

### DIFF
--- a/k3s/patches/ingress.yaml
+++ b/k3s/patches/ingress.yaml
@@ -27,7 +27,6 @@
   value: docs.${PROD_DOMAIN}
 - op: replace
   path: /spec/rules/8/host
-  value: billing.${PROD_DOMAIN}
-- op: replace
-  path: /spec/rules/9/host
   value: vault.${PROD_DOMAIN}
+- op: remove
+  path: /spec/rules/9

--- a/prod/traefik-middlewares.yaml
+++ b/prod/traefik-middlewares.yaml
@@ -68,17 +68,6 @@ spec:
     average: 20
     burst: 40
 ---
-# ── Rate-Limiting: Invoice Ninja ───────────────────────────────────
-apiVersion: traefik.io/v1alpha1
-kind: Middleware
-metadata:
-  name: rate-limit-billing
-  namespace: workspace
-spec:
-  rateLimit:
-    average: 30
-    burst: 60
----
 # ── Rate-Limiting: Website (öffentlich) ───────────────────────────
 apiVersion: traefik.io/v1alpha1
 kind: Middleware


### PR DESCRIPTION
## Summary
Follow-up to #247 (Invoice Ninja removal). Two orphaned billing references cleaned up:

- **`prod/traefik-middlewares.yaml`** — deleted the `rate-limit-billing` Middleware block. No Ingress or IngressRoute references it anywhere in the repo (confirmed via `grep -rn rate-limit-billing`).
- **`k3s/patches/ingress.yaml`** — the JSON-patch for the legacy monolithic `workspace-ingress` still mapped rule index 8 to `billing.${PROD_DOMAIN}`. Replaced the billing op with a `vault` replace (moved up from index 9) and added a `remove /spec/rules/9` to drop the trailing leftover base rule. The `k3s/` overlay is dormant — only referenced by `scripts/setup-ha-cluster.sh` comments, not applied by any task/CI/ArgoCD path — so this is consistency hygiene in case it's ever revived.

## Test plan
- [x] `yamllint` — clean on both files
- [x] `kustomize build prod` — remaining "billing" hits are only the unrelated Stripe `monthly-billing` CronJob and its `/api/admin/billing/create-monthly-invoices` endpoint (legit)
- [x] `grep -rn rate-limit-billing` — no remaining references

🤖 Generated with [Claude Code](https://claude.com/claude-code)