### PR TITLE
fix(website): force rollout on mixed-arch deploys so new :latest is actually pulled

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1562,7 +1562,11 @@ tasks:
           echo "Pinning deployment to ${IMAGE}@${DIGEST}..."
           kubectl ${CTX_ARG} -n website set image deployment/website "website=${IMAGE}@${DIGEST}"
         elif [ -n "${DIGEST}" ]; then
-          echo "Mixed-arch cluster detected — skipping digest pin, using :latest"
+          # Without a digest pin the Deployment spec is unchanged, so `apply` is a
+          # no-op and the pod keeps its cached :latest image. Force a rollout so
+          # imagePullPolicy:Always actually pulls the freshly-pushed tag.
+          echo "Mixed-arch cluster detected — forcing rollout to pick up :latest"
+          kubectl ${CTX_ARG} -n website rollout restart deployment/website
         fi
 
         # For production: upgrade IngressRoute to HTTPS with letsencrypt


### PR DESCRIPTION
## Summary
`task website:deploy` pins to an amd64-only digest for pure-amd64 clusters (via \`kubectl set image\`, which forces a rollout). On mixed-arch clusters (e.g. korczewski — amd64 + arm64) it was logging "skipping digest pin" and then doing nothing — the Deployment spec was unchanged, \`kubectl apply\` was a no-op, and the existing pod kept serving its cached \`:latest\` image. The freshly pushed tag sat in the registry and was never pulled.

Caught by the /404 smoke check added in #245 on the last korczewski deploy: \`rollout status\` returned "successfully rolled out" because no rollout was needed; the smoke check then hit the old pod (age 95m) and correctly flagged the redirect-loop regression.

## Fix
Add \`kubectl rollout restart deployment/website\` in the mixed-arch branch. \`imagePullPolicy: Always\` then pulls the just-pushed \`:latest\` for the new pod.

## Test plan
- [x] Manually ran \`kubectl rollout restart\` on korczewski after the bad deploy — \`/404\` now returns HTTP 404 and \`/nonexistent-path\` returns \`302 → /404\` without looping
- [ ] Next \`task website:deploy ENV=korczewski\` should auto-rollout without manual intervention; smoke check should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)