### PR TITLE
fix(env): keep STRIPE_PUBLISHABLE_KEY on one line (env-resolve.sh limitation)

### DIFF
--- a/environments/korczewski.yaml
+++ b/environments/korczewski.yaml
@@ -31,10 +31,10 @@ env_vars:
   AUTH_EXTERNAL_URL: "https://auth.korczewski.de"
   VAULT_EXTERNAL_URL: "https://vault.korczewski.de"
   WHITEBOARD_EXTERNAL_URL: "https://files.korczewski.de/apps/files"
-  STRIPE_PUBLISHABLE_KEY: "pk_live_51RhKrcDGTY4NP8aeqnf69F1OVgNleqjLqR5ZHi8jkzlyx\
-    LiaTEnsY5xwhgPAVV7FdNb4eRnelIzt7DUj9TTAopXg00yyxjx03t"
-overlay: "prod-korczewski"
-secrets_ref: "sealed-secrets/korczewski.yaml"
+  STRIPE_PUBLISHABLE_KEY: "pk_live_51RhKrcDGTY4NP8aeqnf69F1OVgNleqjLqR5ZHi8jkzlyxLiaTEnsY5xwhgPAVV7FdNb4eRnelIzt7DUj9TTAopXg00yyxjx03t"
+
+overlay: prod-korczewski
+secrets_ref: sealed-secrets/korczewski.yaml
 
 setup_vars:
   KC_USER1_USERNAME: paddione

--- a/environments/mentolder.yaml
+++ b/environments/mentolder.yaml
@@ -31,8 +31,7 @@ env_vars:
   AUTH_EXTERNAL_URL: "https://auth.mentolder.de"
   VAULT_EXTERNAL_URL: "https://vault.mentolder.de"
   WHITEBOARD_EXTERNAL_URL: "https://files.mentolder.de/apps/files"
-  STRIPE_PUBLISHABLE_KEY: "pk_live_51TOM2vPmjoQCVSEjX0mKUyfMoEJQssMbl2Me20WSiLJBj\
-    hIrxQJiesJrSw6GVlVetbJJ1cH7Wk0rOXHamMN5aVMD00gxhMrdoF"
+  STRIPE_PUBLISHABLE_KEY: "pk_live_51TOM2vPmjoQCVSEjX0mKUyfMoEJQssMbl2Me20WSiLJBjhIrxQJiesJrSw6GVlVetbJJ1cH7Wk0rOXHamMN5aVMD00gxhMrdoF"
 
 overlay: prod-mentolder
 secrets_ref: sealed-secrets/mentolder.yaml


### PR DESCRIPTION
## Summary
\`scripts/env-resolve.sh:49\` uses a grep-based YAML reader that only captures the first line matching a key. The prior YAML-continuation formatting of \`STRIPE_PUBLISHABLE_KEY\` across two lines is valid YAML, but the bash parser truncated the exported shell value to 55 chars ending in a literal backslash — \`\${STRIPE_PUBLISHABLE_KEY}\` envsubst then produced broken YAML that \`kubectl apply\` rejected ("did not find expected key" on the ConfigMap).

The full key is only ~135 chars including the YAML key/quotes — well under yamllint's 200-char limit — so no wrapping is needed.

## Fix
- \`environments/{korczewski,mentolder}.yaml\` — STRIPE back on one line.

## Test plan
- [x] \`source scripts/env-resolve.sh korczewski\` exports the full 107-char \`pk_live_…\` value
- [x] \`yamllint\` clean on both env files
- [ ] \`task website:deploy ENV=korczewski\` succeeds

## Separate follow-up (not in this PR)
Rewrite \`env-resolve.sh\` to use a real YAML parser (\`yq\` or python) so future multi-line / quoted / block-scalar values don't silently truncate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)