### PR TITLE
refactor(env): rewrite env-resolve.sh with a real YAML parser

### DIFF
--- a/scripts/env-resolve.sh
+++ b/scripts/env-resolve.sh
@@ -2,18 +2,22 @@
 # ═══════════════════════════════════════════════════════════════════
 # env-resolve.sh — Resolve and export all variables for an environment
 # ═══════════════════════════════════════════════════════════════════
-# Reads an environment file + schema defaults and exports all
-# variables as shell environment variables.
+# Reads an environment file + schema defaults and exports all variables
+# as shell environment variables, using python3/PyYAML so multi-line
+# strings, quoted scalars, and block scalars all resolve correctly.
+# (The previous grep/awk implementation silently truncated values that
+# spanned multiple lines — notably STRIPE_PUBLISHABLE_KEY using YAML
+# line-continuation — to the first line.)
 #
 # Usage:
 #   source scripts/env-resolve.sh <env-name> [env-dir]
 #
 # Exports:
-#   - All env_vars as shell variables (e.g. export PROD_DOMAIN=mentolder.de)
-#   - All setup_vars as shell variables
 #   - ENV_CONTEXT — kubectl context from environment file
 #   - ENV_DOMAIN  — domain from environment file
 #   - ENV_OVERLAY — overlay from environment file (empty if not set)
+#   - All schema env_vars, with default_dev fallback for dev envs
+#   - All schema setup_vars (no dev fallback)
 # ═══════════════════════════════════════════════════════════════════
 set -euo pipefail
 
@@ -40,104 +44,65 @@ if [[ ! -f "$_ENV_FILE" ]]; then
   return 1 2>/dev/null || exit 1
 fi
 
-# ── Helpers (prefixed to avoid namespace collisions) ─────────────
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "ERROR: python3 not found (required for YAML parsing)" >&2
+  return 1 2>/dev/null || exit 1
+fi
 
-# _resolve_yaml_get <file> <key> — extract value for a key
-_resolve_yaml_get() {
-  local file="$1" key="$2"
-  local line
-  line=$(grep -E "^[[:space:]]*${key}:" "$file" 2>/dev/null | head -1) || true
-  if [[ -z "$line" ]]; then
-    return 0
-  fi
-  echo "$line" \
-    | sed 's/^[^:]*:[[:space:]]*//' \
-    | sed 's/^["'"'"']//' \
-    | sed 's/["'"'"']$//' \
-    | sed 's/[[:space:]]*$//'
-}
+# ── Build export block via python3/PyYAML ────────────────────────
 
-# _resolve_schema_keys <file> <section> — extract all "name:" values under a section
-_resolve_schema_keys() {
-  local file="$1" section="$2"
-  awk -v sect="$section" '
-    /^[a-z_]+:/ { in_sect = ($0 ~ "^" sect ":"); next }
-    in_sect && /^[[:space:]]*- name:/ {
-      sub(/^[[:space:]]*- name:[[:space:]]*/, "")
-      gsub(/"/, "")
-      print
-    }
-  ' "$file"
-}
+_exports=$(SCHEMA="$_SCHEMA" ENV_FILE="$_ENV_FILE" python3 <<'PY'
+import os, shlex, sys
+try:
+    import yaml
+except ImportError:
+    sys.stderr.write("ERROR: PyYAML not installed (pip install pyyaml)\n")
+    sys.exit(1)
 
-# _resolve_schema_field <file> <section> <key> <field>
-_resolve_schema_field() {
-  local file="$1" section="$2" key="$3" field="$4"
-  awk -v sect="$section" -v keyname="$key" -v fname="$field" '
-    /^[a-z_]+:/ { in_sect = ($0 ~ "^" sect ":"); next }
-    in_sect && /^[[:space:]]*- name:/ {
-      sub(/^[[:space:]]*- name:[[:space:]]*/, "")
-      gsub(/"/, "")
-      current_key = $0
-      next
-    }
-    in_sect && current_key == keyname && $0 ~ "^[[:space:]]+" fname ":" {
-      val = $0
-      sub(/^[^:]*:[[:space:]]*/, "", val)
-      gsub(/"/, "", val)
-      print val
-      exit
-    }
-  ' "$file"
-}
+with open(os.environ["SCHEMA"]) as f:
+    schema = yaml.safe_load(f) or {}
+with open(os.environ["ENV_FILE"]) as f:
+    env_file = yaml.safe_load(f) or {}
 
-# ── Detect if this is a dev environment ──────────────────────────
+is_dev = env_file.get("environment") == "dev"
 
-_env_type=$(_resolve_yaml_get "$_ENV_FILE" "environment")
-_is_dev=false
-[[ "$_env_type" == "dev" ]] && _is_dev=true
 
-# ── Export convenience vars ──────────────────────────────────────
+def emit(name, value):
+    # Always export convenience vars (empty ok); skip env/setup vars
+    # with no value to match the original shell-script behaviour.
+    print(f"export {name}={shlex.quote(str(value))}")
 
-ENV_CONTEXT=$(_resolve_yaml_get "$_ENV_FILE" "context")
-ENV_DOMAIN=$(_resolve_yaml_get "$_ENV_FILE" "domain")
-ENV_OVERLAY=$(_resolve_yaml_get "$_ENV_FILE" "overlay")
-export ENV_CONTEXT ENV_DOMAIN ENV_OVERLAY
 
-# ── Export env_vars ──────────────────────────────────────────────
+# Convenience vars — exported even when empty so callers can reference
+# them under `set -u` without tripping.
+for src_key, export_name in (
+    ("context", "ENV_CONTEXT"),
+    ("domain", "ENV_DOMAIN"),
+    ("overlay", "ENV_OVERLAY"),
+):
+    v = env_file.get(src_key)
+    emit(export_name, v if v is not None else "")
 
-_env_keys=$(_resolve_schema_keys "$_SCHEMA" "env_vars")
+env_vars = env_file.get("env_vars") or {}
+for entry in schema.get("env_vars") or []:
+    name = entry["name"]
+    v = env_vars.get(name)
+    if (v is None or v == "") and is_dev:
+        v = entry.get("default_dev")
+    if v is not None and v != "":
+        emit(name, v)
 
-while IFS= read -r _key; do
-  [[ -z "$_key" ]] && continue
+setup_vars = env_file.get("setup_vars") or {}
+for entry in schema.get("setup_vars") or []:
+    name = entry["name"]
+    v = setup_vars.get(name)
+    if v is not None and v != "":
+        emit(name, v)
+PY
+)
 
-  _val=$(_resolve_yaml_get "$_ENV_FILE" "$_key")
-
-  # Dev environments fall back to default_dev from schema
-  if [[ -z "$_val" && "$_is_dev" == "true" ]]; then
-    _val=$(_resolve_schema_field "$_SCHEMA" "env_vars" "$_key" "default_dev")
-  fi
-
-  if [[ -n "$_val" ]]; then
-    export "${_key}=${_val}"
-  fi
-done <<< "$_env_keys"
-
-# ── Export setup_vars ────────────────────────────────────────────
-
-_setup_keys=$(_resolve_schema_keys "$_SCHEMA" "setup_vars")
-
-while IFS= read -r _key; do
-  [[ -z "$_key" ]] && continue
-
-  _val=$(_resolve_yaml_get "$_ENV_FILE" "$_key")
-
-  if [[ -n "$_val" ]]; then
-    export "${_key}=${_val}"
-  fi
-done <<< "$_setup_keys"
+eval "$_exports"
 
 # ── Cleanup internal vars ───────────────────────────────────────
 
-unset _ENV_NAME _ENV_DIR _SCHEMA _ENV_FILE _env_type _is_dev
-unset _env_keys _setup_keys _key _val
+unset _ENV_NAME _ENV_DIR _SCHEMA _ENV_FILE _exports

--- a/tests/unit/env-resolve.bats
+++ b/tests/unit/env-resolve.bats
@@ -1,0 +1,102 @@
+#!/usr/bin/env bats
+# ═══════════════════════════════════════════════════════════════════
+# env-resolve.bats — Tests for scripts/env-resolve.sh
+# ═══════════════════════════════════════════════════════════════════
+# Verifies that sourcing env-resolve.sh exports the expected variables
+# with the correct values, including values defined via YAML line
+# continuation (regression guard against the old grep-based parser
+# that silently truncated STRIPE_PUBLISHABLE_KEY to 55 chars).
+#
+# Prerequisites: bash, python3, PyYAML
+# ═══════════════════════════════════════════════════════════════════
+
+load test_helper
+
+SCRIPT="${PROJECT_DIR}/scripts/env-resolve.sh"
+
+setup_file() {
+  export ENV_DIR="${BATS_FILE_TMPDIR}/environments"
+  mkdir -p "$ENV_DIR"
+
+  cat > "${ENV_DIR}/schema.yaml" <<'YAML'
+version: 1
+env_vars:
+  - name: PROD_DOMAIN
+    required: true
+    default_dev: "localhost"
+  - name: STRIPE_PUBLISHABLE_KEY
+    required: false
+    default_dev: ""
+  - name: MISSING_IN_ENV
+    required: false
+    default_dev: "dev-fallback"
+setup_vars:
+  - name: KC_USER1_USERNAME
+    required: true
+YAML
+
+  cat > "${ENV_DIR}/prod.yaml" <<'YAML'
+environment: prod
+context: test-ctx
+domain: example.test
+overlay: prod-test
+env_vars:
+  PROD_DOMAIN: example.test
+  STRIPE_PUBLISHABLE_KEY: "pk_live_51RhKrcDGTY4NP8aeqnf69F1OVgNleqjLqR5ZHi8jkzlyx\
+    LiaTEnsY5xwhgPAVV7FdNb4eRnelIzt7DUj9TTAopXg00yyxjx03t"
+setup_vars:
+  KC_USER1_USERNAME: alice
+YAML
+
+  cat > "${ENV_DIR}/dev.yaml" <<'YAML'
+environment: dev
+context: k3d-dev
+domain: localhost
+env_vars:
+  PROD_DOMAIN: localhost
+setup_vars:
+  KC_USER1_USERNAME: devuser
+YAML
+}
+
+@test "multi-line STRIPE_PUBLISHABLE_KEY resolves to the full 107-char value" {
+  run bash -c "source '$SCRIPT' prod '$ENV_DIR' >/dev/null && echo \"\${#STRIPE_PUBLISHABLE_KEY}:\$STRIPE_PUBLISHABLE_KEY\""
+  [ "$status" -eq 0 ]
+  [[ "$output" == "107:pk_live_51RhKrcDGTY4NP8aeqnf69F1OVgNleqjLqR5ZHi8jkzlyxLiaTEnsY5xwhgPAVV7FdNb4eRnelIzt7DUj9TTAopXg00yyxjx03t" ]]
+}
+
+@test "single-line env_vars and setup_vars export correctly" {
+  run bash -c "source '$SCRIPT' prod '$ENV_DIR' >/dev/null && echo \"\$PROD_DOMAIN|\$KC_USER1_USERNAME\""
+  [ "$status" -eq 0 ]
+  [ "$output" = "example.test|alice" ]
+}
+
+@test "convenience vars ENV_CONTEXT / ENV_DOMAIN / ENV_OVERLAY export from top-level keys" {
+  run bash -c "source '$SCRIPT' prod '$ENV_DIR' >/dev/null && echo \"\$ENV_CONTEXT|\$ENV_DOMAIN|\$ENV_OVERLAY\""
+  [ "$status" -eq 0 ]
+  [ "$output" = "test-ctx|example.test|prod-test" ]
+}
+
+@test "dev env falls back to default_dev when a schema var is missing from env file" {
+  run bash -c "source '$SCRIPT' dev '$ENV_DIR' >/dev/null && echo \"\$MISSING_IN_ENV\""
+  [ "$status" -eq 0 ]
+  [ "$output" = "dev-fallback" ]
+}
+
+@test "prod env does NOT fall back to default_dev for missing vars" {
+  run bash -c "source '$SCRIPT' prod '$ENV_DIR' >/dev/null && echo \"MISSING_IN_ENV=[\${MISSING_IN_ENV:-<unset>}]\""
+  [ "$status" -eq 0 ]
+  [ "$output" = "MISSING_IN_ENV=[<unset>]" ]
+}
+
+@test "exits non-zero when env name is missing" {
+  run bash -c "source '$SCRIPT' '' '$ENV_DIR'"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Usage:"* ]]
+}
+
+@test "exits non-zero when env file does not exist" {
+  run bash -c "source '$SCRIPT' does-not-exist '$ENV_DIR'"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Environment file not found"* ]]
+}


### PR DESCRIPTION
## Summary
The previous \`scripts/env-resolve.sh\` used a grep/sed pipeline that only read the first line matching each key. Values split across multiple lines — YAML line-continuation, block scalars — were silently truncated to that first line. Most recent bite: \`STRIPE_PUBLISHABLE_KEY\` wrapped across two lines parsed to **55 chars ending in a literal backslash**, which in turn produced invalid envsubst'd YAML and made \`kubectl apply\` fail during \`task website:deploy\`.

Replace the core with a single python3/PyYAML block that emits shell-safe \`export KEY=VALUE\` lines (\`shlex.quote\`) for \`eval\`. Single-line behaviour is preserved, \`default_dev\` fallback still fires only for \`environment: dev\`, and the exported variable set is unchanged (verified against live \`korczewski\` and \`mentolder\` environments).

## Tests
New \`tests/unit/env-resolve.bats\` — runs locally with the vendored bats (\`tests/unit/lib/bats-core/bin/bats\`). All 7 cases pass:

1. multi-line STRIPE_PUBLISHABLE_KEY resolves to the full 107-char value
2. single-line env_vars and setup_vars export correctly
3. ENV_CONTEXT / ENV_DOMAIN / ENV_OVERLAY export from top-level keys
4. dev env falls back to default_dev for missing vars
5. prod env does NOT fall back to default_dev
6. missing env-name arg exits non-zero with usage message
7. non-existent env file exits non-zero with clear error

## Test plan
- [x] New BATS tests pass
- [x] \`source scripts/env-resolve.sh korczewski\` exports the 107-char STRIPE key (vs. 55 before), all other variables unchanged from the previous live resolve
- [x] \`source scripts/env-resolve.sh mentolder\` likewise
- [ ] Next \`task website:deploy\` succeeds end-to-end (smoke check still passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)