### PR TITLE
fix(vaultwarden): SSO-only + PKCE, repair OIDC secret sync

### DIFF
--- a/k3d/vaultwarden.yaml
+++ b/k3d/vaultwarden.yaml
@@ -71,10 +71,18 @@ spec:
                   name: domain-config
                   key: VAULT_DOMAIN
             # ── SSO via Keycloak ──────────────────────────────────
+            # Bitwarden/Vaultwarden speichert Accounts nach E-Mail; der Master-
+            # Passwort-Flow ist unvermeidbar (Vault-Verschlüsselung). SSO hier
+            # ersetzt nur das Login-Passwort — die E-Mail wird aus dem OIDC-
+            # Token vorbefüllt, nicht manuell abgefragt.
             - name: SSO_ENABLED
               value: "true"
             - name: SSO_ONLY
-              value: "false"
+              value: "true"
+            - name: SSO_PKCE
+              value: "true"
+            - name: SSO_SCOPES
+              value: "email profile"
             - name: SSO_CLIENT_ID
               value: "vaultwarden"
             - name: SSO_CLIENT_SECRET
@@ -84,6 +92,8 @@ spec:
                   key: VAULTWARDEN_OIDC_SECRET
             - name: SSO_AUTHORITY
               value: "http://keycloak:8080/realms/workspace"
+            - name: SIGNUPS_ALLOWED
+              value: "true"
             - name: KC_DOMAIN
               valueFrom:
                 configMapKeyRef:

--- a/scripts/keycloak-sync-secrets.sh
+++ b/scripts/keycloak-sync-secrets.sh
@@ -67,14 +67,22 @@ KC_ADMIN_PASS=$(kubectl $CONTEXT_FLAG get secret workspace-secrets \
   | base64 -d 2>/dev/null || echo "devadmin")
 
 log "Hole Admin-Token von ${KC_URL}..."
+# --data-urlencode escapes special chars (& # + =) that otherwise corrupt the form body.
 ADMIN_TOKEN=$(curl -sk \
   -X POST "${KC_URL}/realms/master/protocol/openid-connect/token" \
   -H "Content-Type: application/x-www-form-urlencoded" \
-  -d "grant_type=password&client_id=admin-cli&username=admin&password=${KC_ADMIN_PASS}" \
+  --data-urlencode "grant_type=password" \
+  --data-urlencode "client_id=admin-cli" \
+  --data-urlencode "username=admin" \
+  --data-urlencode "password=${KC_ADMIN_PASS}" \
   | grep -o '"access_token":"[^"]*"' | cut -d'"' -f4 || true)
 
 if [[ -z "$ADMIN_TOKEN" ]]; then
   warn "Admin-Token nicht erhältlich — Sync wird übersprungen."
+  warn "Hinweis: Admin-Passwort in workspace-secrets muss mit dem Passwort des 'admin'-Users im"
+  warn "Keycloak-Realm 'master' übereinstimmen. Bei Drift: Passwort in Keycloak zurücksetzen"
+  warn "(kcadm.sh set-password -r master --username admin --new-password \$NEU) oder"
+  warn "workspace-secrets auf den alten Wert zurücksetzen."
   exit 0
 fi
 


### PR DESCRIPTION
## Summary
- **Root cause**: `keycloak-sync-secrets.sh` builds the admin-token form body as a raw `-d` string, so any `&`, `#`, `+` or `=` in the Keycloak admin password corrupts the POST → master token fails → all OIDC client secrets silently drift. All 5 clients (vaultwarden, nextcloud, website, docs, claude-code) had drifted on both korczewski and mentolder. User-visible symptom: Vaultwarden SSO → `Invalid client or Invalid client credentials`.
- Switched the script to `--data-urlencode` so special chars survive; added a warning path when the admin token cannot be obtained (mentolder also has an admin-password drift that this change exposes instead of hiding).
- Tightened Vaultwarden SSO: `SSO_ONLY=true`, `SSO_PKCE=true`, explicit `SSO_SCOPES=email profile`, `SIGNUPS_ALLOWED=true`. Email prompt on first login is a Bitwarden protocol constraint (vault encryption key derives from email + master password); the email field is now prefilled from the OIDC claim.

## Live repair (already applied)
Both clusters had their Keycloak `client.secret` rows updated to match `workspace-secrets` via direct SQL (kcadm was also broken on mentolder due to admin-pw drift). Both Keycloak + Vaultwarden deployments were restarted. Client-credentials probe now returns `Client not enabled to retrieve service account` (auth accepted, wrong grant) instead of `unauthorized_client`.

## Follow-up
- Mentolder Keycloak admin password in `workspace-secrets` no longer matches the user in the `master` realm. Fix by resetting via kcadm from korczewski Keycloak or via a one-shot `kc.sh bootstrap-admin user` — tracked separately from this PR.

## Test plan
- [x] `task workspace:validate` green
- [x] `/alive` returns HTTP 200 on both `vault.korczewski.de` and `vault.mentolder.de`
- [x] `client_credentials` probe against `vaultwarden` client returns `Client not enabled to retrieve service account` (auth-layer OK) on both realms
- [ ] Manual SSO login flow on both environments — user will verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)