### PR TITLE
fix(keycloak-sync): PUT client to set secret value (was silently regenerating)

### DIFF
--- a/scripts/keycloak-sync-secrets.sh
+++ b/scripts/keycloak-sync-secrets.sh
@@ -118,13 +118,15 @@ for SECRET_KEY in "${!CLIENT_MAP[@]}"; do
     continue
   fi
 
-  # Secret setzen via POST /clients/{uuid}/client-secret
+  # Secret setzen via PUT /clients/{uuid} (POST /client-secret regeneriert statt zu setzen!)
+  # Escape special chars for JSON string (backslash, double-quote).
+  SECRET_JSON=$(printf '%s' "$SECRET_VAL" | sed 's/\\/\\\\/g; s/"/\\"/g')
   HTTP_STATUS=$(curl -sk \
     -o /dev/null -w "%{http_code}" \
-    -X POST "${KC_URL}/admin/realms/${KC_REALM}/clients/${CLIENT_UUID}/client-secret" \
+    -X PUT "${KC_URL}/admin/realms/${KC_REALM}/clients/${CLIENT_UUID}" \
     -H "Authorization: Bearer ${ADMIN_TOKEN}" \
     -H "Content-Type: application/json" \
-    -d "{\"type\":\"secret\",\"value\":\"${SECRET_VAL}\"}" || echo "000")
+    -d "{\"secret\":\"${SECRET_JSON}\"}" || echo "000")
 
   if [[ "$HTTP_STATUS" =~ ^2 ]]; then
     log "  ✓ ${CLIENT_ID} (${SECRET_KEY})"


### PR DESCRIPTION
## Summary
Second root cause after #259: `POST /admin/realms/{r}/clients/{id}/client-secret` regenerates the secret server-side and ignores the `value` field. The sync script therefore got 2xx back while Keycloak filled its `client.secret` column with a fresh random string nobody holds → every OIDC login kept failing after sync.

Switch to `PUT /admin/realms/{r}/clients/{id}` with `{"secret":"<value>"}`. JSON-escape the secret value so `\` / `"` don't corrupt the body.

## Verification
- Ran `bash scripts/keycloak-sync-secrets.sh` with `ENV=korczewski` and `ENV=mentolder`.
- All 5 OIDC clients (vaultwarden, nextcloud, website, docs, claude-code) → `client.secret` in Keycloak DB now matches `workspace-secrets` byte-for-byte on both clusters.
- `POST /realms/workspace/protocol/openid-connect/token` with `grant_type=client_credentials` + vaultwarden's secret returns `Client not enabled to retrieve service account` (auth layer accepts the creds) instead of `Invalid client credentials`.
- Keycloak authorize endpoint returns HTTP 200 for `client_id=vaultwarden` + PKCE challenge on both realms.

## Test plan
- [x] Sync script succeeds without the `Invalid user credentials` silent-exit (fixed in #259) and now writes the intended value (fixed here).
- [x] `client.secret` matches `workspace-secrets.*_OIDC_SECRET` for all 5 clients on korczewski + mentolder.
- [x] vaultwarden token probe authenticates.
- [ ] Browser SSO flow on vault.korczewski.de / vault.mentolder.de — user to verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)