### PR TITLE
fix(smtp): use authenticated mailbox as sender for Vaultwarden + Nextcloud

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1079,8 +1079,13 @@ tasks:
           kubectl --context "$ENV_CONTEXT" rollout status deployment/shared-db -n workspace --timeout=120s
 
           overlay="${ENV_OVERLAY:-prod}"
+          # Derive Nextcloud MAIL_FROM_ADDRESS / MAIL_DOMAIN from the authoritative SMTP_FROM
+          # so Nextcloud's sender matches the SMTP-authenticated mailbox (mailbox.org rejects
+          # senders the authenticated account does not own with 553).
+          export MAIL_FROM_LOCAL="${SMTP_FROM%@*}"
+          export MAIL_FROM_DOMAIN="${SMTP_FROM#*@}"
           kustomize build "$overlay/" \
-            | envsubst "\$PROD_DOMAIN \$BRAND_NAME \$CONTACT_EMAIL \$INFRA_NAMESPACE \$TLS_SECRET_NAME \$SMTP_FROM" \
+            | envsubst "\$PROD_DOMAIN \$BRAND_NAME \$CONTACT_EMAIL \$INFRA_NAMESPACE \$TLS_SECRET_NAME \$SMTP_FROM \$MAIL_FROM_LOCAL \$MAIL_FROM_DOMAIN" \
             | kubectl --context "$ENV_CONTEXT" apply --server-side --force-conflicts -f -
         fi
       - task: keycloak:sync-secrets

--- a/k3d/secrets.yaml
+++ b/k3d/secrets.yaml
@@ -42,6 +42,11 @@ stringData:
   SMTP_PASSWORD: "devsmtppassword"
   # Website-namespace alias for SMTP_PASSWORD (synced cross-namespace)
   SMTP_PASS: "devsmtppassword"
+  # SMTP sender + auth user — sourced from workspace-secrets so prod envs can override
+  # per-environment without needing kustomize overlays to replace env entries. Prod values
+  # are sealed in environments/sealed-secrets/<env>.yaml.
+  SMTP_FROM: "vaultwarden@workspace.local"
+  SMTP_USER: "dev"
   # Meetings pipeline DB
   MEETINGS_DB_PASSWORD: "devmeetingsdb"
   # Operational secrets

--- a/k3d/vaultwarden.yaml
+++ b/k3d/vaultwarden.yaml
@@ -107,7 +107,10 @@ spec:
             - name: SMTP_SECURITY
               value: "off"
             - name: SMTP_FROM
-              value: "vaultwarden@workspace.local"
+              valueFrom:
+                secretKeyRef:
+                  name: workspace-secrets
+                  key: SMTP_FROM
             - name: SMTP_FROM_NAME
               value: "Vaultwarden"
             - name: TZ

--- a/prod/patch-nextcloud.yaml
+++ b/prod/patch-nextcloud.yaml
@@ -35,9 +35,9 @@ spec:
                   name: workspace-secrets
                   key: SMTP_PASSWORD
             - name: MAIL_FROM_ADDRESS
-              value: "nextcloud"
+              value: "${MAIL_FROM_LOCAL}"
             - name: MAIL_DOMAIN
-              value: "${PROD_DOMAIN}"
+              value: "${MAIL_FROM_DOMAIN}"
           readinessProbe:
             httpGet:
               httpHeaders:

--- a/prod/patch-vaultwarden.yaml
+++ b/prod/patch-vaultwarden.yaml
@@ -28,7 +28,5 @@ spec:
                 secretKeyRef:
                   name: workspace-secrets
                   key: SMTP_PASSWORD
-            - name: SMTP_FROM
-              value: "vaultwarden@${PROD_DOMAIN}"
             - name: SMTP_FROM_NAME
               value: "Vaultwarden"


### PR DESCRIPTION
## Summary

- Vaultwarden + Nextcloud were sending mail as `vaultwarden@mentolder.de` / `nextcloud@mentolder.de`, which mailbox.org rejects with `553 5.7.1 Sender address rejected: not owned by user mentolder@mailbox.org`.
- Switches both to use the sender stored in `workspace-secrets` (the env registry already has the correct per-env value sealed).
- Incidentally fixes a broken kustomize merge where `prod/patch-vaultwarden.yaml` produced a Deployment with both `value` and `valueFrom` on `SMTP_FROM`.

## Changes

- `k3d/vaultwarden.yaml` + `k3d/secrets.yaml`: `SMTP_FROM` sourced from `workspace-secrets.SMTP_FROM`. Dev gets a dev literal in the secret; prod uses the sealed per-env value.
- `prod/patch-vaultwarden.yaml`: drop the `SMTP_FROM` override (base now handles it correctly for all envs).
- `prod/patch-nextcloud.yaml` + `Taskfile.yml` (`workspace:deploy`): derive `MAIL_FROM_LOCAL`/`MAIL_FROM_DOMAIN` from `SMTP_FROM` at deploy time and pass via `envsubst`. Nextcloud's env now renders as `MAIL_FROM_ADDRESS=mentolder`, `MAIL_DOMAIN=mailbox.org` (mentolder) and `MAIL_FROM_ADDRESS=korczewski`, `MAIL_DOMAIN=mailbox.org` (korczewski).

## Test plan

- [x] `kustomize build prod-mentolder/` + `kubeconform` — all resources valid.
- [x] `kustomize build prod-korczewski/` + `kubeconform` — all resources valid.
- [x] `kustomize build k3d/` (dev) + `kubeconform` — all resources valid.
- [x] Rendered output confirmed: Vaultwarden `SMTP_FROM → secretKeyRef workspace-secrets:SMTP_FROM` (no more value+valueFrom conflict); Nextcloud `MAIL_FROM_ADDRESS` + `MAIL_DOMAIN` substitute correctly for both envs.
- [ ] Deploy to mentolder + korczewski and trigger a Vaultwarden/Nextcloud test email to confirm no 553.

## Note

`environments/korczewski.yaml` has `SMTP_FROM: korczewski@mailbox.org` but `SMTP_USER: mentolder@mailbox.org`. mailbox.org will only accept that if `korczewski@mailbox.org` is configured as an alias of the `mentolder@mailbox.org` account. If it isn't, the fix avoids the `vaultwarden@...` / `nextcloud@...` failures but korczewski will still need either an alias or `SMTP_FROM=mentolder@mailbox.org` set in the env registry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)