### PR TITLE
ops(sealed-secrets): claim website-secrets ownership on korczewski

### DIFF
--- a/environments/sealed-secrets/korczewski.yaml
+++ b/environments/sealed-secrets/korczewski.yaml
@@ -83,6 +83,7 @@ spec:
       namespace: workspace-office
     type: Opaque
 ---
+# website-secrets: SealedSecret ownership claimed 2026-04-22 (deleted bootstrap Secret so controller could take over)
 ---
 apiVersion: bitnami.com/v1alpha1
 kind: SealedSecret


### PR DESCRIPTION
## Summary

- The manually-created bootstrap Secret `website-secrets` (ns `website`) was blocking the SealedSecret controller on korczewski: `failed update: Resource "website-secrets" already exists and is not managed by SealedSecret`.
- Fixed by applying the full 17-key SealedSecret from git (PR #263 payload), then deleting the unmanaged Secret — controller immediately recreated it from the SealedSecret.
- `SYNCED=True` confirmed; all 17 keys present; website pod still `Running`.

## Follow-up from PR #263

This closes the operational step documented in #263:
> On korczewski, the pre-existing unmanaged Secret will need a one-time delete so the controller can take ownership.

🤖 Generated with [Claude Code](https://claude.com/claude-code)