### PR TITLE
fix(docuseal): add production SMTP patch

### DIFF
--- a/prod/kustomization.yaml
+++ b/prod/kustomization.yaml
@@ -131,6 +131,7 @@ patches:
   - path: patch-claude-code-config.yaml
   # Production SMTP and service config
   - path: patch-vaultwarden.yaml
+  - path: patch-docuseal.yaml
   - path: patch-oauth2-proxy-docs.yaml
   # Pin amd64-only images to amd64 nodes
   - path: patch-amd64-only.yaml

--- a/prod/patch-docuseal.yaml
+++ b/prod/patch-docuseal.yaml
@@ -1,0 +1,39 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: docuseal
+spec:
+  template:
+    spec:
+      containers:
+        - name: docuseal
+          env:
+            - name: SMTP_ADDRESS
+              value: "smtp.mailbox.org"
+            - name: SMTP_PORT
+              value: "587"
+            - name: SMTP_DOMAIN
+              value: "sign.${PROD_DOMAIN}"
+            - name: SMTP_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: workspace-secrets
+                  key: SMTP_USER
+            - name: SMTP_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: workspace-secrets
+                  key: SMTP_PASSWORD
+            - name: SMTP_AUTH_METHOD
+              value: "login"
+            - name: SMTP_ENABLE_STARTTLS_AUTO
+              value: "true"
+            # mailbox.org rejects senders the authenticated account does not own (553),
+            # so MAILER_FROM_EMAIL must match the SMTP user.
+            - name: MAILER_FROM_EMAIL
+              valueFrom:
+                secretKeyRef:
+                  name: workspace-secrets
+                  key: SMTP_FROM
+            - name: MAILER_FROM_NAME
+              value: "${BRAND_NAME} Unterschriften"


### PR DESCRIPTION
Configures Docuseal to use production SMTP settings from workspace-secrets (SMTP_USER, SMTP_PASSWORD, SMTP_FROM) when deployed via the prod overlay. Verified with kustomize build.