### PR TITLE
fix(secrets): declare SMTP_FROM and SMTP_USER in schema secrets

### DIFF
--- a/environments/schema.yaml
+++ b/environments/schema.yaml
@@ -251,6 +251,14 @@ secrets:
       - namespace: website
         secret: website-secrets
 
+  - name: SMTP_FROM
+    required: true
+    generate: false
+
+  - name: SMTP_USER
+    required: true
+    generate: false
+
   - name: DOCS_OIDC_SECRET
     required: true
     generate: true


### PR DESCRIPTION
## Summary
- Adds `SMTP_FROM` and `SMTP_USER` to the `secrets:` block of `environments/schema.yaml`.
- Fixes CI failure on `main` (test #97 in `tests/unit/secrets-sync.bats` — "every k3d/secrets.yaml workspace-secrets key exists in schema"), which has been red since #268 / #269.

## Why
Both keys are already present in `k3d/secrets.yaml` `workspace-secrets` (dev) and in `environments/sealed-secrets/{mentolder,korczewski}.yaml` (prod), and are consumed via `secretKeyRef` by vaultwarden and docuseal. They were previously declared only as `env_vars` in the schema (needed for envsubst into `website-config` ConfigMap). That made them orphans in the three-way consistency check (schema ↔ dev secrets ↔ sealed secrets).

Having a key in both `env_vars` and `secrets` is safe here: `scripts/env-resolve.sh` only reads `env_vars`, and the `secrets:` block is consumed independently by `env-seal.sh` / sealed-secret tooling.

## Test plan
- [x] `./tests/unit/lib/bats-core/bin/bats tests/unit/` — all 99 pass locally
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)