### PR TITLE
chore(secrets-audit): pin dev context, skip absent-ns groups, align dev SMTP_PASSWORD

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,4 @@ website/.superpowers.superpowers/
 test-results/
 .worktrees/
 memory
+whisper

--- a/k3d/website-dev-secrets.yaml
+++ b/k3d/website-dev-secrets.yaml
@@ -9,7 +9,7 @@ stringData:
   WEBSITE_DB_PASSWORD: "devwebsitedb"
   WEBSITE_OIDC_SECRET: "devwebsiteoidcsecret12345"
   KEYCLOAK_ADMIN_PASSWORD: "devadmin"
-  SMTP_PASSWORD: ""
+  SMTP_PASSWORD: "devsmtppassword"
   STRIPE_SECRET_KEY: "sk_test_dev_placeholder"
   STRIPE_WEBHOOK_SECRET: ""
   NEXTCLOUD_ADMIN_PASS: "devnextcloudadmin"

--- a/scripts/secrets-audit.sh
+++ b/scripts/secrets-audit.sh
@@ -57,7 +57,7 @@ fi
 
 # ── kubectl context ───────────────────────────────────────────────────────────
 case "$ENV" in
-  dev)        K_ARGS=() ;;
+  dev)        K_ARGS=(--context k3d-dev) ;;
   mentolder)  K_ARGS=(--context mentolder) ;;
   korczewski) K_ARGS=(--context korczewski) ;;
 esac
@@ -318,6 +318,11 @@ secret_exists() {
   "${K[@]}" get secret "$2" -n "$1" &>/dev/null
 }
 
+# ── Helper: check if a namespace exists ──────────────────────────────────────
+namespace_exists() {
+  "${K[@]}" get namespace "$1" &>/dev/null
+}
+
 # ── Helper: display value ────────────────────────────────────────────────────
 display_val() {
   local v="$1"
@@ -337,6 +342,25 @@ print_group() {
   local members_str="${GROUP_MEMBERS[$idx]}"
 
   IFS='|' read -ra MEMBERS <<< "$members_str"
+
+  # Skip group when a destination namespace is absent (e.g. workspace-office
+  # on dev without office-stack, coturn on dev without signaling). The source
+  # namespace is always assumed present — the pre-flight verifies `workspace`.
+  local skip_reason=""
+  for (( j=1; j<${#MEMBERS[@]}; j++ )); do
+    IFS=':' read -r ns secret key <<< "${MEMBERS[$j]}"
+    if ! namespace_exists "$ns"; then
+      skip_reason="namespace '$ns' absent"
+      break
+    fi
+  done
+
+  if [[ -n "$skip_reason" ]]; then
+    LAST_GROUP_MISMATCH=0
+    printf "${BLD}[%d]${RST} %-46s [%b]\n" "$num" "$label" "${YLW}${BLD}SKIPPED${RST}"
+    printf "    %s%s%s\n\n" "$DIM" "$skip_reason" "$RST"
+    return
+  fi
 
   # Collect values
   local -a VALS


### PR DESCRIPTION
## Summary
- Pin `secrets-audit.sh dev` to `--context k3d-dev` so it can't silently audit whichever context happens to be active (same footgun class as the `ENV=dev` default documented in CLAUDE.md gotchas).
- Skip sync groups with `[SKIPPED]` when a destination namespace is absent (e.g. `workspace-office` on dev without office-stack, `coturn` on dev without signaling) instead of reporting a false mismatch.
- Set `SMTP_PASSWORD` in `k3d/website-dev-secrets.yaml` to `devsmtppassword` so Group 9 matches the canonical source in `workspace-secrets` on dev.
- Small drive-by: add `whisper/` to `.gitignore`.

## Test plan
- [ ] `bash -n scripts/secrets-audit.sh` passes
- [ ] `./scripts/secrets-audit.sh dev` against a running k3d cluster — Group 3 shows `[SKIPPED]` when `workspace-office` ns absent, Group 9 shows `OK`
- [ ] `./scripts/secrets-audit.sh mentolder` / `korczewski` unchanged behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)