### PR TITLE
fix(deploy): wait for shared-db before DB sync + restore caps for nextcloud fix-data-perms

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1108,6 +1108,9 @@ tasks:
         context_flag=""
         [ "{{.ENV}}" != "dev" ] && context_flag="--context $ENV_CONTEXT"
 
+        echo "Waiting for shared-db to be ready before syncing DB passwords..."
+        kubectl $context_flag rollout status deployment/shared-db -n workspace --timeout=120s
+
         echo "Syncing DB passwords from workspace-secrets → shared-db ({{.ENV}})..."
 
         for user in keycloak nextcloud vaultwarden website docuseal; do

--- a/k3d/nextcloud.yaml
+++ b/k3d/nextcloud.yaml
@@ -54,8 +54,6 @@ spec:
           securityContext:
             runAsUser: 0
             allowPrivilegeEscalation: false
-            capabilities:
-              drop: ["ALL"]
             seccompProfile:
               type: RuntimeDefault
           command:


### PR DESCRIPTION
## Summary
- `workspace:sync-db-passwords` now waits for the `shared-db` rollout before the `ALTER USER` loop (uses the same `--timeout=120s` pattern as the two existing guards at Taskfile.yml:1059 / :1079). Fixes `error: unable to upgrade connection` when the deployment is mid-rollout after a full deploy.
- `fix-data-perms` init container drops the `capabilities: drop: ["ALL"]` restriction so root keeps `CAP_CHOWN`/`CAP_FOWNER` and the `chown 33:33` + `chmod 0770` on `/var/www/html/data` actually succeed. Namespace enforces `baseline` (not `restricted`), so default caps are allowed. Other init containers are untouched.

## Test plan
- [ ] `task workspace:validate` passes
- [ ] `task workspace:deploy ENV=mentolder` completes without retry; sync-db-passwords prints ALTER ROLE for all five users
- [ ] `kubectl rollout status deployment/nextcloud -n workspace --context mentolder --timeout=180s` succeeds (init container completes)
- [ ] Same checks on `ENV=korczewski`

🤖 Generated with [Claude Code](https://claude.com/claude-code)