### PR TITLE
fix(k3d): shared-db namespace + whisper CPU for single-node dev

### DIFF
--- a/k3d-config.yaml
+++ b/k3d-config.yaml
@@ -5,7 +5,7 @@ kind: Simple
 metadata:
   name: dev
 servers: 1
-agents: 5
+agents: 0
 kubeAPI:
   host: "127.0.0.1"
   hostIP: "127.0.0.1"
@@ -20,12 +20,12 @@ ports:
       - loadbalancer
   - port: 8080:30080
     nodeFilters:
-      - agents:*
+      - server:0
 # Local volume mount for fast I/O during development
 volumes:
   - volume: ${PWD}/data:/mnt/data
     nodeFilters:
-      - agents:*
+      - server:0
 # Environment variables for all nodes
 env:
   - envVar: K3S_DEBUG=false

--- a/k3d/shared-db.yaml
+++ b/k3d/shared-db.yaml
@@ -6,6 +6,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: shared-db-pvc
+  namespace: workspace
 spec:
   storageClassName: local-path
   accessModes: [ReadWriteOnce]
@@ -17,6 +18,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: shared-db-init
+  namespace: workspace
 data:
   init-databases.sh: |
     #!/bin/bash
@@ -70,6 +72,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: shared-db
+  namespace: workspace
   labels:
     app: shared-db
 spec:
@@ -243,6 +246,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: shared-db
+  namespace: workspace
 spec:
   selector:
     app: shared-db
@@ -255,6 +259,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: keycloak-db
+  namespace: workspace
 spec:
   selector:
     app: shared-db
@@ -266,6 +271,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: nextcloud-db
+  namespace: workspace
 spec:
   selector:
     app: shared-db

--- a/k3d/whisper.yaml
+++ b/k3d/whisper.yaml
@@ -28,7 +28,7 @@ spec:
           resources:
             requests:
               memory: "4Gi"
-              cpu: "2"
+              cpu: "500m"
             limits:
               memory: "8Gi"
               cpu: "8"


### PR DESCRIPTION
## Summary
- **shared-db.yaml**: explicit `namespace: workspace` on PVC, ConfigMap, Deployment, and 3 Services. The `task workspace:deploy` preflight runs `kubectl apply -f k3d/shared-db.yaml` before the kustomize build, and the manifest had no `namespace:` field, so resources landed in `default`. The later kustomize apply created the real copies in `workspace`, leaving stray objects in `default`.
- **whisper.yaml**: `requests.cpu 2 → 500m`. With `k3d-config.yaml` collapsed to a single-node cluster (previous commit), the 2-CPU request can't schedule. Limit stays at 8 so model load still bursts.
- **k3d-config.yaml**: collapse dev cluster to 1 server, 0 agents (ports/volumes moved `agents:* → server:0`).

## Test plan
- [x] `task workspace:validate` passes (kustomize build + kubeconform dry-run).
- [ ] After merge: re-apply on k3d-dev, confirm whisper pod schedules, confirm no stray shared-db resources in `default` after deploy.
- [ ] `task workspace:transcriber-build`, `task workspace:post-setup`, `task workspace:office:deploy` run clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)