### PR TITLE
fix(taskfile): Nextcloud NC_EXEC no longer uses broken su wrapper

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -241,7 +241,7 @@ tasks:
   workspace:theme:nextcloud:
     desc: Apply dark+gold Nextcloud branding via OCC (idempotent)
     vars:
-      NC_EXEC: "kubectl exec -n workspace -c nextcloud deploy/nextcloud -- su -s /bin/bash www-data -c"
+      NC_EXEC: "kubectl exec -n workspace -c nextcloud deploy/nextcloud -- sh -c"
       BRAND: '{{.BRAND_NAME | default "mentolder"}}'
       DOMAIN: '{{.PROD_DOMAIN | default "mentolder.localhost"}}'
     cmds:
@@ -261,7 +261,7 @@ tasks:
   workspace:post-setup:
     desc: Enable Nextcloud apps, wire WOPI to office-stack collabora, run hardening (indices, MIME repair)
     vars:
-      NC_EXEC: "kubectl exec -n workspace -c nextcloud deploy/nextcloud -- su -s /bin/bash www-data -c"
+      NC_EXEC: "kubectl exec -n workspace -c nextcloud deploy/nextcloud -- sh -c"
       FILES_HOST: '{{.FILES_HOST | default "files.localhost"}}'
     cmds:
       - echo "Ensuring trusted_domains includes {{.FILES_HOST}}..."


### PR DESCRIPTION
## Summary
- `NC_EXEC` in `workspace:post-setup` and `workspace:theme:nextcloud` wrapped every command in `su -s /bin/bash www-data -c`. The `nextcloud:33-apache` image runs as www-data natively, so kubectl exec is already www-data — and shadow-utils rejects `su` with \`su: Authentication failure\` because www-data has no password set.
- Net effect: post-setup failed on every occ command silently (trailing `|| true` hid it), theme task likely same.
- Fix: replace with `sh -c` — no privilege change needed.

Verified with \`kubectl exec ... -- sh -c "php occ status"\` returning proper output.

## Test plan
- [x] Smoke-test new NC_EXEC pattern on k3d-dev.
- [ ] After merge: re-run \`task workspace:post-setup\` and confirm app installs succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)