### PR TITLE
fix(scripts): occ helpers no longer use broken su www-data wrapper

### DIFF
--- a/scripts/recording-setup.sh
+++ b/scripts/recording-setup.sh
@@ -13,7 +13,7 @@ KUBE_CONTEXT="${KUBE_CONTEXT:-}"
 _kubectl() { kubectl ${KUBE_CONTEXT:+--context "$KUBE_CONTEXT"} "$@"; }
 _occ() {
   _kubectl exec -n "${NAMESPACE}" deploy/nextcloud -c nextcloud -- \
-    su -s /bin/bash www-data -c "$1" 2>&1
+    sh -c "$1" 2>&1
 }
 
 echo "=== Talk Recording Backend Setup ==="

--- a/scripts/talk-hpb-setup.sh
+++ b/scripts/talk-hpb-setup.sh
@@ -78,7 +78,7 @@ TURN_JSON=$(jq -cn \
 # ── Apply to Nextcloud via occ ────────────────────────────────────────
 _occ() {
   kubectl ${KUBE_CONTEXT:+--context $KUBE_CONTEXT} exec -n "${NAMESPACE}" deploy/nextcloud -c nextcloud -- \
-    su -s /bin/bash www-data -c "$*"
+    sh -c "$*"
 }
 
 echo "  Konfiguriere spreed signaling_servers  → ${SIGNALING_URL}"

--- a/scripts/transcriber-setup.sh
+++ b/scripts/transcriber-setup.sh
@@ -11,7 +11,7 @@ NAMESPACE="workspace"
 # Hilfsfunktion für occ-Kommandos im Nextcloud-Container
 _occ() {
   kubectl exec -n "${NAMESPACE}" deploy/nextcloud -c nextcloud -- \
-    su -s /bin/bash www-data -c "$1"
+    sh -c "$1"
 }
 
 _kubectl() {
@@ -34,10 +34,9 @@ echo "  Erstelle Nextcloud-User transcriber-bot..."
 # User anlegen (|| true = idempotent)
 # shellcheck disable=SC2086
 _kubectl exec -n "${NAMESPACE}" deploy/nextcloud -c nextcloud -- \
-  bash -c "export OC_PASS='${TRANSCRIBER_PASS}' && \
-    su -s /bin/bash www-data -c \
-    'php occ user:add --display-name=\"Live-Transkription\" \
-     --password-from-env transcriber-bot 2>/dev/null || true'"
+  sh -c "export OC_PASS='${TRANSCRIBER_PASS}' && \
+    php occ user:add --display-name='Live-Transkription' \
+     --password-from-env transcriber-bot 2>/dev/null || true"
 
 echo "  Registriere Talk-Bot..."
 

--- a/scripts/whiteboard-setup.sh
+++ b/scripts/whiteboard-setup.sh
@@ -20,7 +20,7 @@ SCHEME="${SCHEME:-}"
 
 nc_occ() {
   kubectl exec -n "${NAMESPACE}" deploy/nextcloud -c nextcloud -- \
-    su -s /bin/bash www-data -c "$*"
+    sh -c "$*"
 }
 
 echo "=== Nextcloud Whiteboard Setup ==="


### PR DESCRIPTION
## Summary
Follow-up to #275. Four shell scripts (`recording-setup.sh`, `whiteboard-setup.sh`, `talk-hpb-setup.sh`, `transcriber-setup.sh`) wrapped occ invocations in \`su -s /bin/bash www-data -c\`. Same bug: the Nextcloud image runs as www-data and shadow-utils rejects \`su\` with \`Authentication failure\`.

- Replace with \`sh -c\` in each \`_occ\` / \`nc_occ\` helper.
- `transcriber-setup.sh` had a nested \`bash -c "… su -c …"\` to export \`OC_PASS\`; fold into a single \`sh -c\` that exports the env var and runs the occ call directly.

This unblocks \`task workspace:post-setup\` (which calls whiteboard-setup via \`workspace:whiteboard-setup\`) and any subsequent operator runs of the other three scripts.

## Test plan
- [x] Smoke-test \`kubectl exec … -- sh -c 'php occ app:list'\` on k3d-dev.
- [ ] After merge: re-run \`task workspace:post-setup\` clean through the whiteboard step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)