### PR TITLE
fix(k3d): pin whisper resources to workspace namespace

### DIFF
--- a/k3d/whisper.yaml
+++ b/k3d/whisper.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: whisper
+  namespace: workspace
 spec:
   replicas: 1
   selector:
@@ -50,6 +51,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: whisper
+  namespace: workspace
 spec:
   selector:
     app: whisper


### PR DESCRIPTION
## Summary
- Adds `namespace: workspace` to the whisper Deployment and Service in `k3d/whisper.yaml`.
- Same bug class as the shared-db preflight fix in #274: `task whisper:deploy` runs `kubectl apply -f k3d/whisper.yaml` directly (Taskfile.yml:1696) without `-n workspace`, so it would land stray copies in whatever namespace the active context points at. The kustomize path is unaffected.

## Test plan
- [x] `yamllint` clean under CI rules (200-char line limit)
- [x] `kubectl kustomize k3d` still renders whisper with `namespace: workspace` on both resources
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)