### PR TITLE
fix(whisper,shared-db): fix base image, prod CPU patch, and kustomize namespace mismatch

### DIFF
--- a/k3d/shared-db.yaml
+++ b/k3d/shared-db.yaml
@@ -72,7 +72,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: shared-db
-  namespace: workspace
   labels:
     app: shared-db
 spec:

--- a/k3d/whisper.yaml
+++ b/k3d/whisper.yaml
@@ -2,7 +2,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: whisper
-  namespace: workspace
 spec:
   replicas: 1
   selector:
@@ -18,7 +17,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: whisper
-          image: registry.localhost:5000/faster-whisper:latest
+          image: fedirz/faster-whisper-server:latest-cpu
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false
@@ -51,7 +50,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: whisper
-  namespace: workspace
 spec:
   selector:
     app: whisper

--- a/prod/kustomization.yaml
+++ b/prod/kustomization.yaml
@@ -144,7 +144,7 @@ patches:
   - path: patch-talk-transcriber.yaml
   # Override signaling backend URL for production (HTTPS + real domain)
   - path: patch-signaling-backend.yaml
-  # Whisper: use public Docker image in production (registry.localhost not accessible)
+  # Whisper: restore pre-#274 CPU request (500m in base fits dev; prod gets 2)
   - path: patch-whisper.yaml
   # Override traefik basic-auth with production credentials (replaces dev admin:admin hash)
   - path: patch-traefik-basic-auth.yaml

--- a/prod/patch-whisper.yaml
+++ b/prod/patch-whisper.yaml
@@ -2,11 +2,15 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: whisper
-  namespace: workspace
 spec:
   template:
     spec:
       containers:
         - name: whisper
-          image: fedirz/faster-whisper-server:latest-cpu
-          imagePullPolicy: Always
+          resources:
+            requests:
+              memory: "4Gi"
+              cpu: "2"
+            limits:
+              memory: "8Gi"
+              cpu: "8"


### PR DESCRIPTION
## Summary

- **Swap whisper base image** from `registry.localhost:5000/faster-whisper:latest` (never built, breaks naked `kubectl apply`) to `fedirz/faster-whisper-server:latest-cpu`
- **Repurpose `prod/patch-whisper.yaml`** from an image override (now redundant with base fix) into a CPU-only patch that restores the pre-#274 prod resource level (`cpu: 2`, vs `500m` dev baseline set in #274)
- **Fix pre-existing kustomize v5 namespace mismatch** that broke `prod-mentolder`/`prod-korczewski` builds since #277: remove redundant `namespace: workspace` from `k3d/whisper.yaml` and `k3d/shared-db.yaml` Deployments — the global `namespace: workspace` in `kustomization.yaml` is authoritative; duplicating it in manifest metadata causes kustomize v5 strategic-merge patch matching to fail with `[noNs]` ID mismatch

## Verified renders
| Target | Image | CPU request |
|---|---|---|
| k3d (dev) | `fedirz/faster-whisper-server:latest-cpu` | `500m` |
| prod-mentolder | `fedirz/faster-whisper-server:latest-cpu` | `2` |
| prod-korczewski | `fedirz/faster-whisper-server:latest-cpu` | `2` |

All three `kustomize build` targets pass.

## Test plan
- [ ] `kubectl kustomize k3d/` builds cleanly
- [ ] `kubectl kustomize prod-mentolder/` builds cleanly
- [ ] `kubectl kustomize prod-korczewski/` builds cleanly
- [ ] CI kustomize validation passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)