### PR TITLE
fix(dev): replace mentolder.de fallbacks with localhost

### DIFF
--- a/k3d/vaultwarden-seed-job.yaml
+++ b/k3d/vaultwarden-seed-job.yaml
@@ -55,12 +55,12 @@ spec:
                 echo "$item" | bw encode | bw create item
               }
 
-              NC="${NC_DOMAIN:-files.mentolder.de}"
-              KC="${KC_DOMAIN:-auth.mentolder.de}"
-              WEB="${WEB_DOMAIN:-web.mentolder.de}"
-              AI="${AI_DOMAIN:-ai.mentolder.de}"
-              DOCS="${DOCS_DOMAIN:-docs.mentolder.de}"
-              OFFICE="${OFFICE_DOMAIN:-office.mentolder.de}"
+              NC="${NC_DOMAIN:-files.localhost}"
+              KC="${KC_DOMAIN:-auth.localhost}"
+              WEB="${WEB_DOMAIN:-web.localhost}"
+              AI="${AI_DOMAIN:-ai.localhost}"
+              DOCS="${DOCS_DOMAIN:-docs.localhost}"
+              OFFICE="${OFFICE_DOMAIN:-office.localhost}"
 
               upsert_login "Nextcloud — Dateien"            "https://${NC}"               "Dateispeicher und Kollaboration"
               upsert_login "Nextcloud Talk — Video"         "https://${NC}/apps/spreed"   "Video-/Sprachanrufe via Nextcloud Talk"

--- a/scripts/seed-test-meetings.sh
+++ b/scripts/seed-test-meetings.sh
@@ -189,4 +189,4 @@ ORDER BY m.created_at DESC;
 "
 
 echo ""
-echo "✓ Done. Open https://web.mentolder.de/admin/meetings to verify."
+echo "✓ Done. Open http://web.localhost/admin/meetings to verify."

--- a/website/src/pages/api/stripe/checkout.ts
+++ b/website/src/pages/api/stripe/checkout.ts
@@ -13,7 +13,7 @@ export const POST: APIRoute = async ({ request }) => {
       );
     }
 
-    const siteUrl = (process.env.SITE_URL || 'https://web.mentolder.de').replace(/\/$/, '');
+    const siteUrl = (process.env.SITE_URL || 'http://web.localhost').replace(/\/$/, '');
     const url = await createCheckoutSession({
       serviceKey,
       successUrl: `${siteUrl}/stripe/success?session_id={CHECKOUT_SESSION_ID}`,


### PR DESCRIPTION
## Summary
- Vaultwarden seed job, Stripe checkout default URL, and meeting seed verification URL all fell back to prod mentolder.de domains when env vars were unset
- Replaced fallbacks with localhost equivalents so local k3d dev testing works without env overrides

## Test plan
- [x] Dev cluster still healthy after redeploy (all pods Running)
- [x] `./scripts/secrets-audit.sh dev` reports no sync drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)