### PR TITLE
fix(env): prevent SMTP drift, allow blank CONTACT_PHONE, document hardcoded signaling keys

### DIFF
--- a/environments/korczewski.yaml
+++ b/environments/korczewski.yaml
@@ -8,7 +8,7 @@ env_vars:
   BRAND_NAME: "KORE"
   BRAND_ID: KORE
   CONTACT_EMAIL: info@korczewski.de
-  CONTACT_PHONE: "***"
+  CONTACT_PHONE: ""
   CONTACT_CITY: "Lüneburg"
   CONTACT_NAME: "Patrick Korczewski"
   LEGAL_STREET: "In der Twiet 4"

--- a/environments/schema.yaml
+++ b/environments/schema.yaml
@@ -23,7 +23,7 @@ env_vars:
     validate: "^.+@.+$"
 
   - name: CONTACT_PHONE
-    required: true
+    required: false
     default_dev: "+49 000 000 00 000"
 
   - name: CONTACT_CITY
@@ -156,6 +156,13 @@ secrets:
     generate: true
     length: 40
 
+  # The following signaling keys are NOT managed by this schema:
+  #   SESSION_HASHKEY, SESSION_BLOCKKEY, CLIENTS_INTERNALSECRET, TURN_APIKEY
+  # They are hardcoded directly in the spreed-signaling Deployment env
+  # (k3d/talk-hpb.yaml, prod/patch-signaling-backend.yaml). Rationale:
+  # they only need to be stable within a pod's lifetime, and TURN_APIKEY
+  # is unused because the REST API auth uses TURN_SECRET. If these ever
+  # become rotated secrets, promote them into this section.
   - name: SIGNALING_SECRET
     required: true
     generate: true

--- a/scripts/env-generate.sh
+++ b/scripts/env-generate.sh
@@ -68,6 +68,24 @@ schema_field() {
   ' "$file"
 }
 
+# env_file_var <file> <key> — read a scalar from the env_vars: section of an env file
+env_file_var() {
+  local file="$1" key="$2"
+  [[ -f "$file" ]] || return 0
+  awk -v keyname="$key" '
+    /^env_vars:/ { in_sect=1; next }
+    /^[a-z_]+:/ && !/^env_vars:/ { in_sect=0 }
+    in_sect && $0 ~ "^[[:space:]]+" keyname ":" {
+      val = $0
+      sub(/^[^:]*:[[:space:]]*/, "", val)
+      gsub(/^["'\'']|["'\'']$/, "", val)
+      sub(/[[:space:]]+$/, "", val)
+      print val
+      exit
+    }
+  ' "$file"
+}
+
 # ── Parse Arguments ──────────────────────────────────────────────
 
 [[ $# -eq 0 ]] && usage
@@ -83,6 +101,7 @@ done
 [[ -z "$ENV_NAME" ]] && die "--env <name> is required"
 
 SCHEMA="${ENV_DIR}/schema.yaml"
+ENV_FILE="${ENV_DIR}/${ENV_NAME}.yaml"
 SECRETS_DIR="${ENV_DIR}/.secrets"
 OUTPUT="${SECRETS_DIR}/${ENV_NAME}.yaml"
 
@@ -130,6 +149,15 @@ setup_keys=$(schema_keys "$SCHEMA" "setup_vars")
       echo "${key}: \"${value}\""
       info "  Generated: ${key} (${hex_len} hex chars)"
     else
+      # If the same key is defined in env_vars of the env file, copy it.
+      # This keeps SMTP_FROM/SMTP_USER from diverging via typo at the prompt.
+      env_value=$(env_file_var "$ENV_FILE" "$key")
+      if [[ -n "$env_value" ]]; then
+        echo "${key}: \"${env_value}\""
+        info "  Set: ${key} (copied from ${ENV_FILE})"
+        continue
+      fi
+
       echo "" >&2
       read -rp "Enter value for ${key}: " user_value </dev/tty
       if [[ -z "$user_value" ]]; then

--- a/scripts/env-resolve.sh
+++ b/scripts/env-resolve.sh
@@ -86,11 +86,19 @@ for src_key, export_name in (
 env_vars = env_file.get("env_vars") or {}
 for entry in schema.get("env_vars") or []:
     name = entry["name"]
-    v = env_vars.get(name)
-    if (v is None or v == "") and is_dev:
-        v = entry.get("default_dev")
-    if v is not None and v != "":
-        emit(name, v)
+    if name in env_vars:
+        v = env_vars[name]
+        if (v is None or v == "") and is_dev:
+            dv = entry.get("default_dev")
+            if dv is not None:
+                v = dv
+        # Emit explicit keys even when blank so callers under `set -u`
+        # don't trip on e.g. CONTACT_PHONE="" in environments/korczewski.yaml.
+        emit(name, v if v is not None else "")
+    elif is_dev:
+        dv = entry.get("default_dev")
+        if dv is not None:
+            emit(name, dv)
 
 setup_vars = env_file.get("setup_vars") or {}
 for entry in schema.get("setup_vars") or []:


### PR DESCRIPTION
## Summary
- `env-generate.sh` now auto-copies `SMTP_FROM`/`SMTP_USER` (and any `generate: false` secret whose key also lives in env_vars) from `environments/<env>.yaml` instead of prompting — a typo at the prompt can no longer silently diverge from the env file.
- `schema.yaml`: `CONTACT_PHONE` relaxed to `required: false`; added a comment block explaining that `SESSION_HASHKEY`/`SESSION_BLOCKKEY`/`CLIENTS_INTERNALSECRET`/`TURN_APIKEY` are intentionally hardcoded in the spreed-signaling Deployment env and not managed here.
- `environments/korczewski.yaml`: `CONTACT_PHONE` set to `""`. Footer, impressum, datenschutz, barrierefreiheit and Kontakt pages all guard on truthiness, so the phone row disappears cleanly.
- `env-resolve.sh`: emit env_vars that are explicitly present in the env file even when blank, so callers under `set -u` (e.g. `task website:build` referencing `${CONTACT_PHONE}`) don't trip on "unbound variable".

## Test plan
- [x] `bash scripts/env-validate.sh --env korczewski --schema-only` → passes
- [x] `bash scripts/env-validate.sh --env mentolder --schema-only` → passes
- [x] `bash scripts/env-validate.sh --env dev --schema-only` → passes
- [x] `bash scripts/env-validate.sh --drift --schema-only` → no drift
- [x] `source scripts/env-resolve.sh korczewski` → `CONTACT_PHONE=""` exported (no unset error under `set -u`)
- [x] `source scripts/env-resolve.sh dev` → `CONTACT_PHONE="+49 000 000 00 000"` (default_dev fallback preserved)
- [x] `source scripts/env-resolve.sh mentolder` → real phone emitted
- [x] `yamllint -d '{extends: relaxed, rules: {line-length: {max: 200}}}'` on edited YAML → clean
- [x] `shellcheck scripts/env-generate.sh` → clean (pre-existing SC2317 in env-resolve.sh unchanged; CI runs with `|| true`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)