### PR TITLE
fix(env): set korczewski BRAND_ID back to 'korczewski'

### DIFF
--- a/environments/korczewski.yaml
+++ b/environments/korczewski.yaml
@@ -6,7 +6,7 @@ domain: korczewski.de
 env_vars:
   PROD_DOMAIN: korczewski.de
   BRAND_NAME: "KORE"
-  BRAND_ID: KORE
+  BRAND_ID: korczewski
   CONTACT_EMAIL: info@korczewski.de
   CONTACT_PHONE: ""
   CONTACT_CITY: "Lüneburg"


### PR DESCRIPTION
## Summary
- `environments/korczewski.yaml` set `BRAND_ID: KORE` (from PR #230).
- `website/src/config/index.ts:5-6` only recognizes `'mentolder' | 'korczewski'`, so the korczewski cluster was silently loading `mentolderConfig`.
- Every brand-keyed DB query (`notifications.ts`, `stripe-billing.ts`, `content.ts`, …) was looking up `brand='KORE'` and missing rows seeded under `'korczewski'`.
- Revert **only** `BRAND_ID` → `korczewski`; keep `BRAND_NAME: "KORE"` as the user-facing display string. `BRAND_NAME` is the label, `BRAND_ID` is the programmatic key — decoupling them is the cleanest reading.

No `.secrets` / sealed files are touched. The fix is picked up on the next `task website:deploy ENV=korczewski` via envsubst into the `website-config` ConfigMap.

## Test plan
- [ ] `task workspace:validate ENV=korczewski` still green
- [ ] After merge, run `task website:deploy ENV=korczewski` and confirm `kubectl get cm website-config -n website --context korczewski -o jsonpath='{.data.BRAND}'` returns `korczewski`
- [ ] Smoke-check a brand-keyed page on `https://web.korczewski.de` (bug reports, legal footer) to verify the korczewski config is now served

🤖 Generated with [Claude Code](https://claude.com/claude-code)