### PR TITLE
fix(taskfile): sync Nextcloud config.php dbpassword during DB password sync

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1113,6 +1113,7 @@ tasks:
 
         echo "Syncing DB passwords from workspace-secrets → shared-db ({{.ENV}})..."
 
+        nc_needs_restart=0
         for user in keycloak nextcloud vaultwarden website docuseal; do
           key="${user^^}_DB_PASSWORD"
           pw=$(kubectl $context_flag get secret workspace-secrets -n workspace \
@@ -1121,10 +1122,49 @@ tasks:
             echo "  SKIP ${user}: ${key} not found in workspace-secrets"
             continue
           fi
+
+          # Nextcloud persists its DB password inside config.php on the PVC.
+          # When the secret rotates (e.g. sealed-secrets reseal), the PVC copy
+          # drifts — and the Nextcloud bootstrap opens a DB connection before
+          # `occ` can run, so `occ config:system:set dbpassword` cannot recover
+          # the state (this is the PR #282 outage shape). Patch config.php
+          # in-place via PHP (stdin-piped, special chars safe) BEFORE ALTER
+          # USER; if we actually changed it, rollout-restart nextcloud after
+          # the loop so it picks the file up cleanly.
+          if [ "$user" = "nextcloud" ]; then
+            nc_pod=$(kubectl $context_flag -n workspace get pod -l app=nextcloud \
+              -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
+            if [ -n "$nc_pod" ]; then
+              current_pw=$(kubectl $context_flag -n workspace exec "$nc_pod" -c nextcloud -- \
+                php -r 'if(!file_exists("/var/www/html/config/config.php")){exit;}$CONFIG=[];include "/var/www/html/config/config.php";echo $CONFIG["dbpassword"]??"";' 2>/dev/null || true)
+              if [ -z "$current_pw" ]; then
+                echo "  nextcloud-config.php: config.php missing or malformed — skipping in-place sync"
+              elif [ "$current_pw" = "$pw" ]; then
+                echo "  nextcloud-config.php: already in sync"
+              else
+                echo "  nextcloud-config.php: dbpassword drifted → patching in-place"
+                if printf '%s' "$pw" | kubectl $context_flag -n workspace exec -i "$nc_pod" -c nextcloud -- \
+                  php -r '$p="/var/www/html/config/config.php";$CONFIG=[];include $p;if(!isset($CONFIG["dbpassword"])){fwrite(STDERR,"refusing to write: existing config has no dbpassword\n");exit(1);}$CONFIG["dbpassword"]=stream_get_contents(STDIN);file_put_contents($p,"<?php\n\$CONFIG = ".var_export($CONFIG,true).";\n");' 2>&1 | sed "s/^/    /"; then
+                  nc_needs_restart=1
+                else
+                  echo "    (config.php patch failed — falling through to ALTER USER; pod may need manual repair)"
+                fi
+              fi
+            else
+              echo "  nextcloud-config.php: no nextcloud pod found — skipping config.php sync (ALTER USER below may strand the pod until config.php is repaired)"
+            fi
+          fi
+
           kubectl $context_flag exec -n workspace deployment/shared-db -- \
             psql -U postgres -c "ALTER USER ${user} WITH PASSWORD '$(printf "%s" "$pw" | sed "s/'/''/g")';" 2>&1 \
             | sed "s/^/  ${user}: /"
         done
+
+        if [ "$nc_needs_restart" = 1 ]; then
+          echo "Restarting nextcloud to pick up patched config.php..."
+          kubectl $context_flag -n workspace rollout restart deployment/nextcloud
+          kubectl $context_flag -n workspace rollout status deployment/nextcloud --timeout=180s
+        fi
         echo "✓ DB passwords synced"
 
   keycloak:sync:


### PR DESCRIPTION
## Summary
Prevent the PR #282 outage shape from recurring on the next sealed-secrets reseal.

**Problem.** `workspace:sync-db-passwords` rotates the Postgres password via `ALTER USER`, but Nextcloud persists `dbpassword` inside `/var/www/html/config/config.php` on its PVC. After a reseal, the PVC copy drifts from the new secret; Nextcloud's bootstrap opens a DB connection *before* `occ` runs, so `occ config:system:set dbpassword` cannot recover — the only escape route is a manual `sed` inside the pod (what we did for korczewski last time).

**Fix.** Extend the `nextcloud` branch of the sync loop to:
1. Read the current `dbpassword` from `config.php` via PHP-in-pod.
2. If it drifted, write the new value back with PHP (stdin-piped, so passwords with shell-special characters are safe) **before** `ALTER USER`.
3. Refuse to write if `config.php` has no existing `dbpassword` field (protects fresh installs and malformed files).
4. Rollout-restart `nextcloud` **only** if `config.php` actually changed — routine deploys stay zero-downtime; reseals pay the restart cost.

## Test plan
- [ ] `task workspace:sync-db-passwords -n ENV=dev` renders a parseable shell script (verified with `bash -n`).
- [ ] On dev cluster: run `task workspace:sync-db-passwords ENV=dev` with `dbpassword` in sync → logs `already in sync`, no restart.
- [ ] On dev cluster: tamper with `config.php` (change `dbpassword` to a wrong value) → rerun; task patches the file and rollout-restarts nextcloud.
- [ ] Next `task workspace:deploy ENV=korczewski` after a reseal should complete without the manual `sed` step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)