### PR TITLE
fix: adopt coturn/collabora secrets via SealedSecret, skip mcp-tokens on prod, fix whiteboard URL

### DIFF
--- a/k3d/coturn-stack/secret.yaml
+++ b/k3d/coturn-stack/secret.yaml
@@ -13,11 +13,20 @@
 # RespectIgnoreDifferences=true), so live values set by
 # `task workspace:coturn:sync-secret` are never overwritten by these
 # placeholders on subsequent syncs.
+#
+# The `sealedsecrets.bitnami.com/managed: "true"` annotation lets the
+# SealedSecret controller adopt this ArgoCD-created Secret so the
+# prod-env sealed file (environments/sealed-secrets/<env>.yaml) can
+# write the real values. Without it the controller refuses updates
+# with "already exists and is not managed by SealedSecret" and the
+# sealed coturn-secrets block is silently ignored.
 apiVersion: v1
 kind: Secret
 metadata:
   name: coturn-secrets
   namespace: coturn
+  annotations:
+    sealedsecrets.bitnami.com/managed: "true"
 type: Opaque
 stringData:
   SIGNALING_SECRET: "devsignalingsecret1234567890abcdef"

--- a/k3d/office-stack/secret.yaml
+++ b/k3d/office-stack/secret.yaml
@@ -14,6 +14,11 @@ metadata:
   namespace: workspace-office
   annotations:
     argocd.argoproj.io/sync-options: Skip=true
+    # Lets the SealedSecret controller adopt this ArgoCD-created Secret so
+    # the prod-env sealed file can overwrite the placeholder below. Without
+    # it the controller errors with "already exists and is not managed by
+    # SealedSecret" and the sealed collabora-secrets block never applies.
+    sealedsecrets.bitnami.com/managed: "true"
 type: Opaque
 stringData:
   COLLABORA_ADMIN_PASSWORD: "devcollaboraadmin"

--- a/scripts/secrets-audit.sh
+++ b/scripts/secrets-audit.sh
@@ -148,8 +148,6 @@ SOLO_LABELS=(
   "coturn-secrets: SIGNALING_SECRET"
   "coturn-secrets: TURN_SECRET"
   "collabora-secrets: COLLABORA_ADMIN_PASSWORD"
-  "mcp-tokens: CLUSTER_TOKEN"
-  "mcp-tokens: BUSINESS_TOKEN"
 )
 
 SOLO_MEMBERS=(
@@ -183,9 +181,21 @@ SOLO_MEMBERS=(
   "coturn:coturn-secrets:SIGNALING_SECRET"
   "coturn:coturn-secrets:TURN_SECRET"
   "workspace-office:collabora-secrets:COLLABORA_ADMIN_PASSWORD"
-  "default:mcp-tokens:CLUSTER_TOKEN"
-  "default:mcp-tokens:BUSINESS_TOKEN"
 )
+
+# mcp-tokens only exists on the dev cluster (MCP servers are not deployed to
+# prod). Include the entries only when auditing dev so prod audits don't
+# surface "(secret not found in cluster)" false-positives.
+if [[ "$ENV" == "dev" ]]; then
+  SOLO_LABELS+=(
+    "mcp-tokens: CLUSTER_TOKEN"
+    "mcp-tokens: BUSINESS_TOKEN"
+  )
+  SOLO_MEMBERS+=(
+    "default:mcp-tokens:CLUSTER_TOKEN"
+    "default:mcp-tokens:BUSINESS_TOKEN"
+  )
+fi
 
 NUM_SOLOS=${#SOLO_LABELS[@]}
 

--- a/website/src/components/portal/DiensteSection.astro
+++ b/website/src/components/portal/DiensteSection.astro
@@ -2,9 +2,10 @@
 interface Props {
   ncBase: string;
   vaultUrl: string;
+  wbUrl?: string;
   keycloakBase: string;
 }
-const { ncBase, vaultUrl, keycloakBase } = Astro.props;
+const { ncBase, vaultUrl, wbUrl = '', keycloakBase } = Astro.props;
 
 const services = [
   ...(ncBase ? [
@@ -12,8 +13,8 @@ const services = [
     { href: `${ncBase}/apps/calendar/`,   label: 'Kalender',   desc: 'Termine und Ereignisse',     icon: '📅' },
     { href: `${ncBase}/apps/contacts/`,   label: 'Kontakte',   desc: 'Adressbuch',                 icon: '👥' },
     { href: `${ncBase}/apps/spreed/`,     label: 'Talk',       desc: 'Video & Gruppen-Chat',       icon: '🎥' },
-    { href: `${ncBase}/apps/whiteboard/`, label: 'Whiteboard', desc: 'Gemeinsames Zeichenbrett',   icon: '🖊️' },
   ] : []),
+  ...(wbUrl ? [{ href: wbUrl, label: 'Whiteboard', desc: 'Gemeinsames Zeichenbrett', icon: '🖊️' }] : []),
   ...(vaultUrl ? [{ href: vaultUrl, label: 'Passwörter',  desc: 'Vaultwarden Safe',       icon: '🔒' }] : []),
 ];
 ---

--- a/website/src/components/portal/OverviewSection.astro
+++ b/website/src/components/portal/OverviewSection.astro
@@ -10,17 +10,18 @@ interface Props {
   onboardingPct: number;
   ncBase: string;
   vaultUrl: string;
+  wbUrl?: string;
 }
 
-const { session, nextBooking, openInvoices, unreadMessages, onboardingPct, ncBase, vaultUrl } = Astro.props;
+const { session, nextBooking, openInvoices, unreadMessages, onboardingPct, ncBase, vaultUrl, wbUrl = '' } = Astro.props;
 
 const services = [
   ...(ncBase ? [
     { href: `${ncBase}/apps/files/`,       label: 'Dateien',    desc: 'Nextcloud' },
     { href: `${ncBase}/apps/calendar/`,    label: 'Kalender',   desc: 'Nextcloud' },
     { href: `${ncBase}/apps/spreed/`,      label: 'Talk',       desc: 'Video & Chat' },
-    { href: `${ncBase}/apps/whiteboard/`,  label: 'Whiteboard', desc: 'Nextcloud' },
   ] : []),
+  ...(wbUrl ? [{ href: wbUrl, label: 'Whiteboard', desc: 'Nextcloud' }] : []),
   ...(vaultUrl ? [{ href: vaultUrl, label: 'Passwörter', desc: 'Vaultwarden' }] : []),
 ];
 ---

--- a/website/src/pages/portal.astro
+++ b/website/src/pages/portal.astro
@@ -28,6 +28,7 @@ const username = session.preferred_username ?? session.sub;
 
 const ncBase       = (process.env.NEXTCLOUD_EXTERNAL_URL ?? '').replace(/\/$/, '');
 const vaultUrl     = process.env.VAULT_EXTERNAL_URL ?? '';
+const wbUrl        = process.env.WHITEBOARD_EXTERNAL_URL ?? '';
 const keycloakBase = process.env.KEYCLOAK_FRONTEND_URL ?? '';
 const realm        = process.env.KEYCLOAK_REALM ?? 'workspace';
 
@@ -105,7 +106,7 @@ const projects = section === 'projekte'
   {session}
   {pendingSignatures}
 >
-  {section === 'overview'       && <OverviewSection {session} {nextBooking} {openInvoices} {unreadMessages} {onboardingPct} {ncBase} {vaultUrl} />}
+  {section === 'overview'       && <OverviewSection {session} {nextBooking} {openInvoices} {unreadMessages} {onboardingPct} {ncBase} {vaultUrl} {wbUrl} />}
   {section === 'nachrichten'    && <NachrichtenSection {rooms} />}
   {section === 'besprechungen'  && <BesprechungenSection {meetings} />}
   {section === 'dateien'        && <DateienSection clientUsername={username} />}
@@ -124,6 +125,6 @@ const projects = section === 'projekte'
       <OnboardingTab keycloakUserId={session.sub} back={Astro.url.href} />
     </div>
   )}
-  {section === 'dienste'        && <DiensteSection {ncBase} {vaultUrl} {keycloakBase} />}
+  {section === 'dienste'        && <DiensteSection {ncBase} {vaultUrl} {wbUrl} {keycloakBase} />}
   {section === 'konto'          && <KontoSection {session} {keycloakBase} {realm} />}
 </PortalLayout>


### PR DESCRIPTION
## Summary

Three post-deploy issues surfaced after running `task workspace:deploy ENV=korczewski`:

1. **coturn-secrets drift (korczewski)**: `workspace/workspace-secrets` had correct `SIGNALING_SECRET`/`TURN_SECRET` but `coturn/coturn-secrets` was stuck on stale values from an April 12 sync.
   **Root cause**: The sealed coturn block in `environments/sealed-secrets/korczewski.yaml` was being refused by the SealedSecret controller with `"already exists and is not managed by SealedSecret"` because ArgoCD had created the base Secret from `k3d/coturn-stack/secret.yaml` without the adoption annotation. Same pattern exists on mentolder (`collabora-secrets` too).
   **Fix**: Annotate both base secrets with `sealedsecrets.bitnami.com/managed: "true"` so the SealedSecret controller adopts the ArgoCD-created Secret and applies the sealed values.
   **Live recovery already applied**: patched `korczewski/coturn-secrets` with current `workspace-secrets` values and rolled `coturn` + `janus`.

2. **mcp-tokens false positive in secrets-audit**: `[41] CLUSTER_TOKEN` / `[42] BUSINESS_TOKEN` showed `(secret not found in cluster)` on mentolder/korczewski. MCP servers are dev-only — `mcp-tokens` legitimately doesn't exist in prod.
   **Fix**: Include those solo entries only when `ENV=dev`.

3. **mentolder whiteboard URL wrong**: Portal's "Whiteboard" link went to `https://files.mentolder.de/apps/whiteboard/`. `environments/mentolder.yaml` already sets `WHITEBOARD_EXTERNAL_URL=https://files.mentolder.de/apps/files` and `admin.astro` reads it, but `portal.astro`/`OverviewSection`/`DiensteSection` hardcoded `${ncBase}/apps/whiteboard/`.
   **Fix**: thread `WHITEBOARD_EXTERNAL_URL` through `portal.astro` as `wbUrl` prop; both portal sections now use it and drop the Whiteboard entry entirely if it's unset.

## Test plan
- [x] Live sync of `korczewski/coturn-secrets` verified (`SIGNALING_SECRET=nqMyVCq8WY…`, `TURN_SECRET=O6ZLrcjWSF…` — matches `workspace-secrets`).
- [x] `bash scripts/secrets-audit.sh korczewski` no longer lists mcp-tokens entries.
- [x] `yamllint -d '{extends: relaxed, rules: {line-length: {max: 200}}}' k3d/coturn-stack/secret.yaml k3d/office-stack/secret.yaml` clean.
- [x] `kustomize build k3d/coturn-stack` renders the new annotation.
- [ ] After merge + next `workspace:deploy ENV=korczewski`/`ENV=mentolder`, verify SealedSecret status flips from "already exists and is not managed by SealedSecret" to Synced.
- [ ] After `task website:deploy`, confirm portal Whiteboard link on `web.mentolder.de/portal` points to `https://files.mentolder.de/apps/files`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)