### PR TITLE
fix(argocd): use env-specific cluster annotations, add missing ConfigMap vars to CMP pipeline

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -750,11 +750,16 @@ tasks:
             {\"op\":\"add\",\"path\":\"/metadata/annotations/workspace-domain\",\"value\":\"${PROD_DOMAIN}\"},
             {\"op\":\"add\",\"path\":\"/metadata/annotations/workspace-brand\",\"value\":\"${BRAND_NAME}\"},
             {\"op\":\"add\",\"path\":\"/metadata/annotations/workspace-email\",\"value\":\"${CONTACT_EMAIL}\"},
-            {\"op\":\"add\",\"path\":\"/metadata/annotations/workspace-infra-namespace\",\"value\":\"workspace-infra\"},
-            {\"op\":\"add\",\"path\":\"/metadata/annotations/workspace-tls-secret\",\"value\":\"workspace-wildcard-tls\"},
+            {\"op\":\"add\",\"path\":\"/metadata/annotations/workspace-infra-namespace\",\"value\":\"${INFRA_NAMESPACE}\"},
+            {\"op\":\"add\",\"path\":\"/metadata/annotations/workspace-tls-secret\",\"value\":\"${TLS_SECRET_NAME}\"},
             {\"op\":\"add\",\"path\":\"/metadata/annotations/workspace-smtp-from\",\"value\":\"${SMTP_FROM}\"},
             {\"op\":\"add\",\"path\":\"/metadata/annotations/workspace-turn-ip\",\"value\":\"${TURN_PUBLIC_IP}\"},
-            {\"op\":\"add\",\"path\":\"/metadata/annotations/workspace-turn-node\",\"value\":\"${TURN_NODE}\"}
+            {\"op\":\"add\",\"path\":\"/metadata/annotations/workspace-turn-node\",\"value\":\"${TURN_NODE}\"},
+            {\"op\":\"add\",\"path\":\"/metadata/annotations/workspace-website-image\",\"value\":\"${WEBSITE_IMAGE}\"},
+            {\"op\":\"add\",\"path\":\"/metadata/annotations/workspace-kc-user1-username\",\"value\":\"${KC_USER1_USERNAME}\"},
+            {\"op\":\"add\",\"path\":\"/metadata/annotations/workspace-kc-user1-email\",\"value\":\"${KC_USER1_EMAIL}\"},
+            {\"op\":\"add\",\"path\":\"/metadata/annotations/workspace-kc-user2-username\",\"value\":\"${KC_USER2_USERNAME}\"},
+            {\"op\":\"add\",\"path\":\"/metadata/annotations/workspace-kc-user2-email\",\"value\":\"${KC_USER2_EMAIL}\"}
           ]" 2>/dev/null || echo "  (patch skipped — annotations may already exist)"
           echo "  ✓ hetzner registered and annotated"
         else
@@ -776,11 +781,16 @@ tasks:
             {\"op\":\"add\",\"path\":\"/metadata/annotations/workspace-domain\",\"value\":\"${PROD_DOMAIN}\"},
             {\"op\":\"add\",\"path\":\"/metadata/annotations/workspace-brand\",\"value\":\"${BRAND_NAME}\"},
             {\"op\":\"add\",\"path\":\"/metadata/annotations/workspace-email\",\"value\":\"${CONTACT_EMAIL}\"},
-            {\"op\":\"add\",\"path\":\"/metadata/annotations/workspace-infra-namespace\",\"value\":\"workspace-infra\"},
-            {\"op\":\"add\",\"path\":\"/metadata/annotations/workspace-tls-secret\",\"value\":\"workspace-wildcard-tls\"},
+            {\"op\":\"add\",\"path\":\"/metadata/annotations/workspace-infra-namespace\",\"value\":\"${INFRA_NAMESPACE}\"},
+            {\"op\":\"add\",\"path\":\"/metadata/annotations/workspace-tls-secret\",\"value\":\"${TLS_SECRET_NAME}\"},
             {\"op\":\"add\",\"path\":\"/metadata/annotations/workspace-smtp-from\",\"value\":\"${SMTP_FROM}\"},
             {\"op\":\"add\",\"path\":\"/metadata/annotations/workspace-turn-ip\",\"value\":\"${TURN_PUBLIC_IP}\"},
-            {\"op\":\"add\",\"path\":\"/metadata/annotations/workspace-turn-node\",\"value\":\"${TURN_NODE}\"}
+            {\"op\":\"add\",\"path\":\"/metadata/annotations/workspace-turn-node\",\"value\":\"${TURN_NODE}\"},
+            {\"op\":\"add\",\"path\":\"/metadata/annotations/workspace-website-image\",\"value\":\"${WEBSITE_IMAGE}\"},
+            {\"op\":\"add\",\"path\":\"/metadata/annotations/workspace-kc-user1-username\",\"value\":\"${KC_USER1_USERNAME}\"},
+            {\"op\":\"add\",\"path\":\"/metadata/annotations/workspace-kc-user1-email\",\"value\":\"${KC_USER1_EMAIL}\"},
+            {\"op\":\"add\",\"path\":\"/metadata/annotations/workspace-kc-user2-username\",\"value\":\"${KC_USER2_USERNAME}\"},
+            {\"op\":\"add\",\"path\":\"/metadata/annotations/workspace-kc-user2-email\",\"value\":\"${KC_USER2_EMAIL}\"}
           ]" 2>/dev/null || echo "  (patch skipped — annotations may already exist)"
           echo "  ✓ korczewski registered and annotated"
         else

--- a/argocd/applicationset.yaml
+++ b/argocd/applicationset.yaml
@@ -18,9 +18,14 @@ spec:
   #   workspace-domain           Production domain (e.g. mentolder.de)
   #   workspace-brand            Brand name (e.g. Mentolder)
   #   workspace-email            Contact email
-  #   workspace-infra-namespace  Traefik middleware namespace (usually workspace-infra)
-  #   workspace-tls-secret       TLS wildcard secret name (usually workspace-wildcard-tls)
+  #   workspace-infra-namespace  Traefik middleware namespace (e.g. mentolder-infra)
+  #   workspace-tls-secret       TLS wildcard secret name (e.g. mentolder-tls)
   #   workspace-smtp-from        SMTP sender address
+  #   workspace-website-image    Website container image name (e.g. mentolder-website)
+  #   workspace-kc-user1-username  Keycloak admin user 1 username
+  #   workspace-kc-user1-email     Keycloak admin user 1 email
+  #   workspace-kc-user2-username  Keycloak admin user 2 username
+  #   workspace-kc-user2-email     Keycloak admin user 2 email
   generators:
     - clusters:
         selector:
@@ -64,6 +69,16 @@ spec:
               value: "{{metadata.annotations.workspace-turn-ip}}"
             - name: TURN_NODE
               value: "{{metadata.annotations.workspace-turn-node}}"
+            - name: WEBSITE_IMAGE
+              value: "{{metadata.annotations.workspace-website-image}}"
+            - name: KC_USER1_USERNAME
+              value: "{{metadata.annotations.workspace-kc-user1-username}}"
+            - name: KC_USER1_EMAIL
+              value: "{{metadata.annotations.workspace-kc-user1-email}}"
+            - name: KC_USER2_USERNAME
+              value: "{{metadata.annotations.workspace-kc-user2-username}}"
+            - name: KC_USER2_EMAIL
+              value: "{{metadata.annotations.workspace-kc-user2-email}}"
 
       destination:
         server: "{{server}}"


### PR DESCRIPTION
## Summary

- `argocd:cluster:register` was hardcoding `workspace-infra-namespace: workspace-infra` and `workspace-tls-secret: workspace-wildcard-tls` for both clusters, even though `env-resolve.sh` already exports the correct per-env values (`mentolder-infra`/`mentolder-tls`, `korczewski-infra`/`korczewski-tls`). Changed to `${INFRA_NAMESPACE}` / `${TLS_SECRET_NAME}`.
- Adds 5 previously-missing variables (`WEBSITE_IMAGE`, `KC_USER1_USERNAME`, `KC_USER1_EMAIL`, `KC_USER2_USERNAME`, `KC_USER2_EMAIL`) to both the cluster annotation patch and the ApplicationSet CMP env — these existed in `prod/configmap-domains.yaml` but were never substituted by ArgoCD, causing literal `${...}` placeholders in the live `domain-config` ConfigMap (read by `secrets-audit.sh`).

## Test plan

- [ ] Run `task argocd:cluster:register` to repatch both cluster Secrets with correct values
- [ ] Trigger ArgoCD sync (`task argocd:sync -- workspace-hetzner`) and verify `domain-config` ConfigMap shows `mentolder-infra` / `mentolder-tls` instead of dev defaults
- [ ] Run `/usage` status dialog — items [57], [58], [56], [78]–[81] should no longer show discrepancies

🤖 Generated with [Claude Code](https://claude.com/claude-code)