### PR TITLE
fix(taskfile): anchor hetzner cluster Secret match in argocd:cluster:register

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -739,9 +739,11 @@ tasks:
           --system-namespace argocd 2>/dev/null || \
           argocd cluster add hetzner --yes --name hetzner 2>/dev/null || true
         # Patch the cluster Secret with workspace labels and annotations
+        # Anchored match: a bare `cluster-` prefix also matches cluster-korczewski,
+        # which sorts first alphabetically and causes the wrong Secret to be patched.
         HETZNER_SECRET=$(kubectl --context mentolder get secret -n argocd \
           -l argocd.argoproj.io/secret-type=cluster \
-          --no-headers 2>/dev/null | grep -E "^hetzner|cluster-" | awk '{print $1}' | head -1)
+          --no-headers 2>/dev/null | awk '{print $1}' | grep -E "^(hetzner|cluster-mentolder|in-cluster)$" | head -1)
         if [ -n "$HETZNER_SECRET" ]; then
           kubectl --context mentolder patch secret "$HETZNER_SECRET" -n argocd --type=json -p="[
             {\"op\":\"add\",\"path\":\"/metadata/labels/workspace\",\"value\":\"true\"},


### PR DESCRIPTION
## Summary
- The `argocd:cluster:register` task's hetzner pass matched cluster Secrets with `grep -E "^hetzner|cluster-" | head -1`. Since all ArgoCD cluster Secrets start with `cluster-`, this matched both `cluster-mentolder` and `cluster-korczewski`, then picked the first alphabetically — so `cluster-korczewski` was silently patched during the hetzner pass and `cluster-mentolder` was skipped entirely.
- Anchor the match to the real hetzner Secret names (`hetzner` / `cluster-mentolder` / `in-cluster`) and `awk` the name column before grepping so the regex applies to the Secret name, not the full `get secret` row.

## Test plan
- [ ] `task argocd:cluster:register` patches `cluster-mentolder` (hetzner pass) and `cluster-korczewski` (korczewski pass) with the correct env-specific annotations.
- [ ] `kubectl --context mentolder get secret cluster-mentolder -n argocd -o yaml` shows `workspace-overlay: prod` and `workspace-domain: mentolder.de`.
- [ ] `kubectl --context mentolder get secret cluster-korczewski -n argocd -o yaml` shows `workspace-overlay: prod-korczewski` and `workspace-domain: korczewski.de`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)