### PR TITLE
fix(taskfile): re-apply ApplicationSet manifests in argocd:cluster:register

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -801,6 +801,14 @@ tasks:
         echo "Registered clusters:"
         argocd cluster list 2>/dev/null || kubectl --context mentolder get secrets -n argocd \
           -l argocd.argoproj.io/secret-type=cluster -o custom-columns='NAME:.metadata.name,LABELS:.metadata.labels'
+      # Re-apply ApplicationSet manifests so template changes (e.g. new annotations
+      # wired through to overlays) take effect without a separate `argocd:apps:apply`.
+      - |
+        echo ""
+        echo "Re-applying ApplicationSet manifests..."
+        kubectl --context mentolder apply -f argocd/applicationset.yaml
+        kubectl --context mentolder apply -f argocd/applicationset-coturn.yaml
+        kubectl --context mentolder apply -f argocd/applicationset-office.yaml
 
   argocd:apps:apply:
     desc: Apply AppProject and ApplicationSet (creates workspace-hetzner + workspace-korczewski apps)


### PR DESCRIPTION
## Summary
- When the ArgoCD ApplicationSet template changes in git (e.g. new annotations wired through to overlay generators, as in #289), neither a merge to main nor `task argocd:cluster:register` pushes the updated template to the hub cluster — only `task argocd:apps:apply` does. Cluster annotations get refreshed but the ApplicationSet that consumes them is still the old version.
- Re-apply `applicationset.yaml` / `applicationset-coturn.yaml` / `applicationset-office.yaml` at the end of `argocd:cluster:register`. `kubectl apply` is idempotent, so this is safe to repeat and keeps cluster registration and ApplicationSet template in lockstep.

## Test plan
- [ ] `task argocd:cluster:register` logs a "Re-applying ApplicationSet manifests..." section with three `kubectl apply` results (`applicationset.apps.argoproj.io/... configured` or `unchanged`).
- [ ] Modifying a template field in `argocd/applicationset.yaml` and running `task argocd:cluster:register` updates the live `ApplicationSet` on the hub (`kubectl --context mentolder get applicationset workspace -n argocd -o yaml`).
- [ ] `task argocd:setup` still works end-to-end (the extra apply in `cluster:register` is idempotent vs. the follow-up `argocd:apps:apply`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)