### PR TITLE
fix(keycloak): add missing nextcloud+website OIDC clients to mentolder realm

### DIFF
--- a/prod-mentolder/realm-workspace-mentolder.json
+++ b/prod-mentolder/realm-workspace-mentolder.json
@@ -60,6 +60,105 @@
   ],
   "clients": [
     {
+      "clientId": "nextcloud",
+      "name": "Nextcloud",
+      "enabled": true,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "${NEXTCLOUD_OIDC_SECRET}",
+      "redirectUris": [
+        "https://${NC_DOMAIN}/apps/oidc_login/oidc",
+        "https://${NC_DOMAIN}/index.php/apps/oidc_login/oidc",
+        "https://${NC_DOMAIN}/apps/sociallogin/custom_oidc/keycloak",
+        "https://${NC_DOMAIN}/index.php/apps/sociallogin/custom_oidc/keycloak"
+      ],
+      "webOrigins": [
+        "https://${NC_DOMAIN}"
+      ],
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "protocol": "openid-connect",
+      "publicClient": false,
+      "protocolMappers": [
+        {
+          "name": "email",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "email",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "email",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "name": "username",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "username",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "preferred_username",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    },
+    {
+      "clientId": "website",
+      "name": "Website",
+      "enabled": true,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "${WEBSITE_OIDC_SECRET}",
+      "redirectUris": [
+        "https://${WEB_DOMAIN}/*"
+      ],
+      "webOrigins": [
+        "https://${WEB_DOMAIN}"
+      ],
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "protocol": "openid-connect",
+      "publicClient": false,
+      "protocolMappers": [
+        {
+          "name": "email",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "email",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "email",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "name": "username",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "username",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "preferred_username",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    },
+    {
       "clientId": "vaultwarden",
       "name": "Vaultwarden",
       "enabled": true,

--- a/prod/import-entrypoint.sh
+++ b/prod/import-entrypoint.sh
@@ -18,16 +18,19 @@ mkdir -p "$(dirname "$OUTPUT")"
 # Alle ${VAR} Referenzen im JSON durch aktuelle Env-Werte ersetzen (sed-basiert)
 cp "$TEMPLATE" "$OUTPUT"
 for var in \
-    \
     NEXTCLOUD_OIDC_SECRET \
     VAULTWARDEN_OIDC_SECRET \
     CLAUDE_CODE_OIDC_SECRET \
     WEBSITE_OIDC_SECRET \
     DOCS_OIDC_SECRET \
+    TRAEFIK_OIDC_SECRET \
+    MAIL_OIDC_SECRET \
     NC_DOMAIN \
     VAULT_DOMAIN \
     WEB_DOMAIN \
     DOCS_DOMAIN \
+    TRAEFIK_DOMAIN \
+    MAIL_DOMAIN \
     PROD_DOMAIN; do
   eval val="\${${var}:-}"
   if [ -z "$val" ]; then


### PR DESCRIPTION
## Summary

- `prod-mentolder/realm-workspace-mentolder.json` was missing the `nextcloud` and `website` OIDC clients (only had 4 of 6), causing Keycloak to reject all `files.mentolder.de` logins with **"Invalid parameter: redirect_uri"**
- Added both `/apps/oidc_login/oidc` and `/index.php/apps/oidc_login/oidc` redirect URI variants for Nextcloud (the latter is what Nextcloud sends when pretty-URLs are disabled)
- Synced `prod/import-entrypoint.sh` with the dev entrypoint by adding `TRAEFIK_DOMAIN`, `MAIL_DOMAIN`, `TRAEFIK_OIDC_SECRET`, `MAIL_OIDC_SECRET` substitutions — these were already in `k3d/realm-import-entrypoint.sh` but missing from the prod version

## Live fix required

Because Keycloak uses `--override false`, merging this PR alone won't fix the live cluster — the realm won't be reimported on redeploy. Run this after merge to add the client immediately:

```bash
KC_POD=$(kubectl --context mentolder -n workspace get pod -l app=keycloak -o jsonpath='{.items[0].metadata.name}')
KC_ADMIN_PASS=$(kubectl --context mentolder -n workspace get secret workspace-secrets -o jsonpath='{.data.KEYCLOAK_ADMIN_PASSWORD}' | base64 -d)
NC_SECRET=$(kubectl --context mentolder -n workspace get secret workspace-secrets -o jsonpath='{.data.NEXTCLOUD_OIDC_SECRET}' | base64 -d)

kubectl --context mentolder -n workspace exec "$KC_POD" -- \
  /opt/keycloak/bin/kcadm.sh config credentials \
  --server http://localhost:8080 --realm master \
  --user admin --password "$KC_ADMIN_PASS"

kubectl --context mentolder -n workspace exec "$KC_POD" -- \
  /opt/keycloak/bin/kcadm.sh create clients -r workspace -s clientId=nextcloud \
  -s 'redirectUris=["https://files.mentolder.de/apps/oidc_login/oidc","https://files.mentolder.de/index.php/apps/oidc_login/oidc","https://files.mentolder.de/apps/sociallogin/custom_oidc/keycloak","https://files.mentolder.de/index.php/apps/sociallogin/custom_oidc/keycloak"]' \
  -s enabled=true -s protocol=openid-connect -s publicClient=false \
  -s clientAuthenticatorType=client-secret -s "secret=$NC_SECRET"
```

## Test plan

- [ ] After live fix: navigate to `https://files.mentolder.de` — should redirect to Keycloak login without "Invalid parameter: redirect_uri"
- [ ] Login completes and lands in Nextcloud
- [ ] `https://web.mentolder.de` login still works (website client also added)

🤖 Generated with [Claude Code](https://claude.com/claude-code)