### PR TITLE
fix(deploy): chain talk-setup + coturn:sync-secret into workspace:deploy

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1120,6 +1120,18 @@ tasks:
         vars: { ENV: "{{.ENV}}" }
       - task: workspace:sync-db-passwords
         vars: { ENV: "{{.ENV}}" }
+      # Re-align Nextcloud Talk's spreed app config with the real SIGNALING_SECRET/
+      # TURN_SECRET in workspace-secrets on every deploy. Without this, a rotated
+      # SealedSecret leaves Talk pointing at stale secrets and calls fail to join
+      # the HPB. Gated on non-dev because the coturn stack only exists in prod.
+      # workspace:deploy has already switched kubectl context to ENV_CONTEXT, so
+      # workspace:coturn:sync-secret (which uses the active context) targets the
+      # right cluster.
+      - |
+        if [ "{{.ENV}}" != "dev" ]; then
+          task workspace:coturn:sync-secret || true
+          task workspace:talk-setup ENV="{{.ENV}}"
+        fi
       - 'echo "✓ Workspace deployed to {{.ENV}}"'
 
   workspace:sync-db-passwords:


### PR DESCRIPTION
## Summary
- Re-aligns Nextcloud Talk's spreed app config with `workspace-secrets` after every prod `workspace:deploy`, not just on first bring-up
- Also syncs `coturn/coturn-secrets` from `workspace/workspace-secrets` so HPB + coturn + Talk all share the same SIGNALING_SECRET / TURN_SECRET
- Gated on `ENV != dev` (coturn stack only exists in prod)

## Why
Last redeploy on both mentolder + korczewski: `workspace-secrets` and `coturn-secrets` held the real sealed secrets, but the `spreed` app on Nextcloud still pointed at stale values — dev placeholders on korczewski, empty on mentolder — so Talk clients auth'd against HPB with the wrong secret and calls never fully joined ("Konferenz loggt sich nicht komplett ein"). The fix (`task workspace:talk-setup`) already existed, it just wasn't chained into `workspace:deploy`.

## Test plan
- [x] `task --dry workspace:deploy ENV=korczewski` — parses, new block renders after sync-db-passwords
- [x] Live: `task workspace:talk-setup:all-prods` ran cleanly; spreed config on both clusters now shows the real `nqMyVCq8...` / `O6ZLrcjW...` secrets
- [ ] Next prod redeploy will exercise the new chained steps end-to-end