### PR TITLE
fix(korczewski): avoid pk-hetzner for networking-sensitive pods + fix talk-hpb-setup DNS race

### DIFF
--- a/prod-korczewski/kustomization.yaml
+++ b/prod-korczewski/kustomization.yaml
@@ -14,3 +14,7 @@ configMapGenerator:
       - realm-workspace.json=realm-workspace-korczewski.json
 generatorOptions:
   disableNameSuffixHash: true
+
+# korczewski-specific workload placement — see patch file for rationale.
+patches:
+  - path: patch-avoid-pk-hetzner.yaml

--- a/prod-korczewski/patch-avoid-pk-hetzner.yaml
+++ b/prod-korczewski/patch-avoid-pk-hetzner.yaml
@@ -1,0 +1,83 @@
+# Keep networking-sensitive workloads off pk-hetzner on korczewski.
+#
+# pk-hetzner is the remote Hetzner control-plane node (62.238.9.39); the rest
+# of the cluster sits on the home LAN (192.168.100.0/24). Cross-node pod
+# traffic FROM pk-hetzner TO k3w-{1,2,3} is currently broken at the CNI/VXLAN
+# layer — pods there cannot reach ClusterIPs or pod IPs on LAN workers, while
+# node-level traffic across the underlay still works fine. Until the underlay
+# partition is fixed (needs SSH to pk-hetzner to inspect flannel/iptables),
+# any workload that talks to NATS or spreed-signaling via ClusterIP must not
+# schedule onto pk-hetzner.
+#
+# Scope is deliberately narrow: workloads that MUST run on pk-hetzner
+# (coturn, janus — hostNetwork + public IP) are not patched. amd64-only
+# constraints on talk-{recording,transcriber} still apply; with pk-hetzner
+# excluded they land on k3s-{1,2,3}.
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nats
+  namespace: workspace
+spec:
+  template:
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/hostname
+                    operator: NotIn
+                    values: ["pk-hetzner"]
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: spreed-signaling
+  namespace: workspace
+spec:
+  template:
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/hostname
+                    operator: NotIn
+                    values: ["pk-hetzner"]
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: talk-transcriber
+  namespace: workspace
+spec:
+  template:
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/hostname
+                    operator: NotIn
+                    values: ["pk-hetzner"]
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: talk-recording
+  namespace: workspace
+spec:
+  template:
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/hostname
+                    operator: NotIn
+                    values: ["pk-hetzner"]

--- a/scripts/talk-hpb-setup.sh
+++ b/scripts/talk-hpb-setup.sh
@@ -96,10 +96,14 @@ _occ "php occ config:app:set spreed turn_servers --value='${TURN_JSON}'" > /dev/
 # Dieser Rewrite leitet signaling.<domain> intern zur Traefik-ClusterIP um.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 COREDNS_OVERRIDE="${SCRIPT_DIR}/../prod/coredns-signaling-override.yaml"
-if [ -f "${COREDNS_OVERRIDE}" ] && [ "${SIGNALING_HOST}" != *"localhost"* ]; then
+if [[ -f "${COREDNS_OVERRIDE}" && "${SIGNALING_HOST}" != *localhost* ]]; then
   echo "  Wende CoreDNS-Override an (${SIGNALING_HOST} → traefik intern) ..."
   kubectl ${KUBE_CONTEXT:+--context $KUBE_CONTEXT} apply -f "${COREDNS_OVERRIDE}"
   kubectl ${KUBE_CONTEXT:+--context $KUBE_CONTEXT} rollout restart deployment/coredns -n kube-system > /dev/null 2>&1 || true
+  # Block until CoreDNS is fully rolled — otherwise the verification _occ calls
+  # below race the rollout and hit the ~seconds window where a DNS lookup for
+  # nextcloud-db can land on a not-ready / terminating endpoint and time out.
+  kubectl ${KUBE_CONTEXT:+--context $KUBE_CONTEXT} rollout status deployment/coredns -n kube-system --timeout=60s > /dev/null 2>&1 || true
 fi
 
 # ── Verification ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- **Two-in-one fix.** Root cause of both symptoms traces back to pk-hetzner's broken pod-network path to LAN workers.
- Pin `nats`, `spreed-signaling`, `talk-transcriber`, `talk-recording` away from `pk-hetzner` on korczewski via a new `prod-korczewski` overlay patch. Until the underlay partition is debugged, anything that talks to other pods cross-node must not land there.
- Fix `scripts/talk-hpb-setup.sh` verification crash: block on `kubectl rollout status deployment/coredns` after the CoreDNS rollout-restart so the subsequent `occ config:app:get` calls stop racing the rollout and hitting "nextcloud-db host not resolvable". Also fix a silently-dead single-bracket glob guard (`[ … != *localhost* ]` never matched).

## What the diagnosis showed

- Fresh nettest pod on pk-hetzner → `nc -zv nats 4222`: timeout.
- 5h-old `talk-transcriber` pod on pk-hetzner → socket.connect(('nats',4222)): timeout. So the "old pods fine" assumption was wrong — they were silently broken too, just not noticed because Talk calls weren't being initiated.
- Same fresh pod → `192.168.100.12:10250` (node IP of k3w-2): succeeded. Node-level underlay is fine; only pod↔pod VXLAN across pk-hetzner is broken.
- CoreDNS had 1 of 3 endpoints on pk-hetzner, which is exactly why the DNS race in `talk-hpb-setup.sh` was biting: a ~1-in-3 chance of hitting the partitioned endpoint during rollout.

Root-cause debugging of the CNI/VXLAN/firewall state on pk-hetzner needs SSH access and is out of scope for this PR.

## Live cluster state after applying

- 0 workspace pods on `pk-hetzner` (coturn/janus/cert-manager stay there by design).
- 3/3 CoreDNS replicas on `k3w-{1,2,3}`.
- `spreed-signaling` logs: `Connection established to nats://nats:4222 (NCPOJ…)`.
- `talk-transcriber` (k3s-1) → NATS: OK. `talk-recording` (k3s-2) → NATS: OK.

## Test plan
- [x] `kustomize build prod-korczewski/` renders pk-hetzner exclusion on nats / spreed-signaling / talk-transcriber / talk-recording and preserves existing `preferredDuringScheduling` on spreed-signaling.
- [x] `task workspace:validate` passes.
- [x] `bash -n scripts/talk-hpb-setup.sh` passes.
- [x] Live verification: rescheduled pods reach NATS cross-node; 0 workspace pods remain on pk-hetzner.
- [ ] Next `task workspace:talk-setup ENV=korczewski` run shows no "nextcloud-db not resolvable" noise in verification output.

## Out of scope (flagged for follow-up)
- Underlying VXLAN/CNI partition on pk-hetzner — needs a dedicated debug session with SSH access.
- Pre-existing drift on korczewski's talk-transcriber Deployment: `NC_DOMAIN=files.mentolder.de` instead of `files.korczewski.de`. A clean `task workspace:deploy ENV=korczewski` will correct it.
- CoreDNS pk-hetzner avoidance was applied live via `kubectl patch`; since CoreDNS is managed by k3s from `/var/lib/rancher/k3s/server/manifests/`, a k3s server restart may revert it. Persisting that needs a custom manifest on the node itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)