### PR TITLE
style(systembrett): default canvas to mentolder navy

### DIFF
--- a/scripts/systembrett-generate.mjs
+++ b/scripts/systembrett-generate.mjs
@@ -425,7 +425,8 @@ const scene = {
   source:  "mentolder-systembrett",
   elements,
   appState: {
-    viewBackgroundColor: "#0b111c",
+    // mentolder --ink-800 (navy) — same token as the website's mid-depth surface.
+    viewBackgroundColor: "#17202e",
     gridSize:            null,
   },
   files:        {},

--- a/website/public/systembrett/systembrett.whiteboard
+++ b/website/public/systembrett/systembrett.whiteboard
@@ -1034,7 +1034,7 @@
     }
   ],
   "appState": {
-    "viewBackgroundColor": "#0b111c",
+    "viewBackgroundColor": "#17202e",
     "gridSize": null
   },
   "files": {},


### PR DESCRIPTION
## Summary

Changes the Systembrett template's default canvas background from `#0b111c` (deepest ink) to `#17202e` — the `--ink-800` token the website uses for its mid-depth navy surfaces.

## Why

`#0b111c` read as near-black; `#17202e` reads as a clear mentolder navy while keeping enough contrast for the brass/sage tray pieces.

## Test plan

- [x] `bash scripts/tests/systembrett-template.test.sh`
- [x] Deployed to all 5 user slots (mentolder+korczewski), `viewBackgroundColor=#17202e` verified on disk
- [ ] Open `Coaching/systembrett.whiteboard` in Nextcloud Whiteboard — canvas is navy

🤖 Generated with [Claude Code](https://claude.com/claude-code)