### PR TITLE
fix(systembrett): force dark theme so navy background paints

### DIFF
--- a/scripts/systembrett-generate.mjs
+++ b/scripts/systembrett-generate.mjs
@@ -426,7 +426,10 @@ const scene = {
   elements,
   appState: {
     // mentolder --ink-800 (navy) — same token as the website's mid-depth surface.
+    // theme:"dark" is required — without it Excalidraw forces a white canvas
+    // regardless of viewBackgroundColor.
     viewBackgroundColor: "#17202e",
+    theme:               "dark",
     gridSize:            null,
   },
   files:        {},

--- a/website/public/systembrett/systembrett.whiteboard
+++ b/website/public/systembrett/systembrett.whiteboard
@@ -1035,6 +1035,7 @@
   ],
   "appState": {
     "viewBackgroundColor": "#17202e",
+    "theme": "dark",
     "gridSize": null
   },
   "files": {},


### PR DESCRIPTION
## Summary

Add `theme: "dark"` to the template's `appState`. Without it, Excalidraw falls back to the light theme and paints the canvas white, overriding `viewBackgroundColor: #17202e`.

## Test plan

- [x] `bash scripts/tests/systembrett-template.test.sh`
- [x] Deployed + whiteboard pods restarted on both clusters — `bg=#17202e` + `theme=dark` verified on all 5 user slots
- [ ] Open `Coaching/systembrett.whiteboard` → canvas is navy, not white

🤖 Generated with [Claude Code](https://claude.com/claude-code)