### PR TITLE
fix(brett): GHCR image reference for prod kubelet pulls

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1782,14 +1782,13 @@ tasks:
     vars:
       ENV: '{{.ENV | default "dev"}}'
     cmds:
-      - docker build -t workspace-brett:latest brett/
+      - docker build -t ghcr.io/paddione/workspace-brett:latest brett/
       - |
         if [ "{{.ENV}}" = "dev" ]; then
-          k3d image import workspace-brett:latest -c {{.CLUSTER_NAME}}
+          k3d image import ghcr.io/paddione/workspace-brett:latest -c {{.CLUSTER_NAME}}
           echo "✓ brett image imported into k3d cluster"
         else
-          docker tag workspace-brett:latest ghcr.io/paddione/workspace-brett:latest
-          echo "✓ brett image built and tagged for ghcr.io (run 'task brett:push ENV={{.ENV}}' to publish)"
+          echo "✓ brett image built (run 'task brett:push ENV={{.ENV}}' to publish)"
         fi
 
   brett:push:

--- a/k3d/brett.yaml
+++ b/k3d/brett.yaml
@@ -27,7 +27,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: brett
-          image: workspace-brett:latest
+          image: ghcr.io/paddione/workspace-brett:latest
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
Bare `workspace-brett:latest` in the manifest only worked in dev where k3d-import bypasses any registry. On prod, kubelet must pull from `ghcr.io/paddione/workspace-brett:latest`. Aligning build + manifest.