### PR TITLE
fix(brett): add imagePullSecrets for prod GHCR pulls

### DIFF
--- a/k3d/brett.yaml
+++ b/k3d/brett.yaml
@@ -25,6 +25,8 @@ spec:
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
+      imagePullSecrets:
+        - name: ghcr-pull-secret
       containers:
         - name: brett
           image: ghcr.io/paddione/workspace-brett:latest


### PR DESCRIPTION
Pod was ImagePullBackOff on mentolder because the GHCR repo is private and brett's manifest didn't reference `ghcr-pull-secret`. Aligns with the website pattern.