### PR TITLE
fix(brett): nodeAffinity excludes pk-hetzner (korczewski CNI)

### DIFF
--- a/k3d/brett.yaml
+++ b/k3d/brett.yaml
@@ -27,6 +27,18 @@ spec:
           type: RuntimeDefault
       imagePullSecrets:
         - name: ghcr-pull-secret
+      nodeSelector:
+        kubernetes.io/arch: amd64
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/hostname
+                    operator: NotIn
+                    values:
+                      - pk-hetzner
+                      - gekko-hetzner-4
       containers:
         - name: brett
           image: ghcr.io/paddione/workspace-brett:latest


### PR DESCRIPTION
Korczewski has a known CNI partition where pk-hetzner can't reach LAN-worker pods including shared-db. Mirrors website's pattern.