### PR TITLE
fix(brett): bot-setup CLI shape + workspace:deploy envsubst

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1127,6 +1127,7 @@ tasks:
           ENVSUBST_VARS="$ENVSUBST_VARS \$SMTP_FROM \$MAIL_FROM_LOCAL \$MAIL_FROM_DOMAIN"
           ENVSUBST_VARS="$ENVSUBST_VARS \$WEBSITE_IMAGE \$TURN_PUBLIC_IP \$TURN_NODE"
           ENVSUBST_VARS="$ENVSUBST_VARS \$KC_USER1_USERNAME \$KC_USER1_EMAIL \$KC_USER2_USERNAME \$KC_USER2_EMAIL"
+          ENVSUBST_VARS="$ENVSUBST_VARS \$BRETT_DOMAIN"
           kustomize build "$overlay/" \
             | envsubst "$ENVSUBST_VARS" \
             | kubectl --context "$ENV_CONTEXT" apply --server-side --force-conflicts -f -

--- a/scripts/brett-bot-setup.sh
+++ b/scripts/brett-bot-setup.sh
@@ -32,32 +32,39 @@ fi
 
 echo "Registering Talk bot for ${ENV} → ${WEBHOOK_URL}"
 
-INSTALL_OUT="$(kubectl exec -n workspace deploy/nextcloud --context "${ENV_CONTEXT}" -- \
-  php occ talk:bot:install \
-    "Systemisches Brett" \
-    "${SECRET}" \
-    "${WEBHOOK_URL}" \
-    "Stellt das Systemische Brett auf /brett bereit" \
-    "webhook" 2>&1)" || true
-
-if echo "${INSTALL_OUT}" | grep -qiE 'already.*exists|installiert'; then
-  echo "Bot already installed — skipping install."
-else
-  echo "${INSTALL_OUT}"
-fi
-
-# Enable globally for all conversations.
-echo "Enabling bot for all conversations..."
+# Idempotency: check whether the bot is already installed.
+# Prefer this over grepping install output (talk:bot:install error strings differ
+# across Nextcloud Talk versions and locales).
 LIST_OUT="$(kubectl exec -n workspace deploy/nextcloud --context "${ENV_CONTEXT}" -- \
-  php occ talk:bot:list)"
+  php occ talk:bot:list 2>&1)"
 BOT_ID="$(echo "${LIST_OUT}" | awk '/Systemisches Brett/ {print $1; exit}')"
+
+if [[ -n "${BOT_ID}" ]]; then
+  echo "Bot already installed (id=${BOT_ID}) — skipping install."
+else
+  # Per Nextcloud Talk Bots API, the feature is set via --feature, not a
+  # 5th positional argument. Talk 17+ accepts: webhook, response, event.
+  kubectl exec -n workspace deploy/nextcloud --context "${ENV_CONTEXT}" -- \
+    php occ talk:bot:install \
+      --feature webhook \
+      "Systemisches Brett" \
+      "${SECRET}" \
+      "${WEBHOOK_URL}" \
+      "Stellt das Systemische Brett auf /brett bereit"
+
+  # Re-list to capture the assigned id.
+  LIST_OUT="$(kubectl exec -n workspace deploy/nextcloud --context "${ENV_CONTEXT}" -- \
+    php occ talk:bot:list 2>&1)"
+  BOT_ID="$(echo "${LIST_OUT}" | awk '/Systemisches Brett/ {print $1; exit}')"
+fi
 
 if [[ -z "${BOT_ID}" ]]; then
   echo "ERROR: could not find bot id after install" >&2
   exit 1
 fi
 
-kubectl exec -n workspace deploy/nextcloud --context "${ENV_CONTEXT}" -- \
-  php occ talk:bot:setup "${BOT_ID}" --feature all || true
+# talk:bot:install (without --no-setup) automatically enables the bot for all
+# conversations. talk:bot:setup is only needed to enable for specific
+# conversation tokens, which isn't what we want here.
 
 echo "Done. Bot ID: ${BOT_ID}"


### PR DESCRIPTION
Two follow-up fixes from the prod rollout findings.

## scripts/brett-bot-setup.sh

The version that landed in #307 used the wrong CLI shape for \`occ talk:bot:install\` — \`webhook\` was passed as a 5th positional arg, which Talk 17+ rejects. Three changes:

1. \`--feature webhook\` flag instead of positional arg (matches Talk's actual API).
2. Idempotency via \`talk:bot:list\` before install, instead of grepping localized \"already exists\" strings.
3. Removed trailing \`talk:bot:setup --feature all\` — \`bot:install\` (without \`--no-setup\`) already enables for all conversations, and \`talk:bot:setup\` doesn't accept \`all\` (it takes explicit conversation tokens).

Verified working on both mentolder and korczewski during manual rollout.

## Taskfile.yml

Adds \`\\\$BRETT_DOMAIN\` to the \`workspace:deploy\` ENVSUBST_VARS list. Today only \`website:deploy\` references \`\${BRETT_DOMAIN}\` and has it in its envsubst list (line 1659). Adding it to workspace:deploy too future-proofs against any future prod manifest using \${BRETT_DOMAIN} (e.g., if \`prod/ingress.yaml\` is brought through the kustomize build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)