### PR TITLE
fix(brett): bot reply HMAC signs message text not JSON body

### DIFF
--- a/website/src/lib/brett-bot.ts
+++ b/website/src/lib/brett-bot.ts
@@ -1,11 +1,14 @@
 // HMAC verification for incoming Talk bot webhooks, and signed replies.
-// Per Nextcloud Talk Bots API:
+// Per Nextcloud Talk Bots API (verified against spreed/lib source):
 //   Incoming webhook (Nextcloud → bot):
-//     - X-Nextcloud-Talk-Random: nonce
-//     - X-Nextcloud-Talk-Signature: hex SHA256(random + body) using shared secret
+//     - X-Nextcloud-Talk-Random: nonce (≥32 chars)
+//     - X-Nextcloud-Talk-Signature: hex SHA256(random + json_body) using shared secret
+//     (Talk hashes its full JSON request body — see Service/BotService.php sendAsyncRequest)
 //   Outgoing reply (bot → /ocs/v2.php/apps/spreed/api/v1/bot/<token>/message):
-//     - X-Nextcloud-Talk-Bot-Random: nonce
-//     - X-Nextcloud-Talk-Bot-Signature: hex SHA256(random + body) using same secret
+//     - X-Nextcloud-Talk-Bot-Random: nonce (≥32 chars)
+//     - X-Nextcloud-Talk-Bot-Signature: hex SHA256(random + message_text) using same secret
+//     (Talk hashes ONLY the message text param, not the json body — see
+//     Controller/BotController.php getBotFromHeaders called with $message)
 
 import { createHmac, randomBytes, timingSafeEqual } from 'node:crypto';
 
@@ -36,9 +39,13 @@ export async function postBotReply(
   message: string,
   secret: string
 ): Promise<boolean> {
-  const body = JSON.stringify({ message, referenceId: `brett-${Date.now()}` });
+  const referenceId = `brett-${Date.now()}`;
+  const body = JSON.stringify({ message, referenceId });
+  // Talk's BotController.php verifies the OUTGOING reply by hashing
+  // (random + $message), where $message is the `message` JSON field —
+  // NOT the full JSON body. Sign only the message text.
   const random = randomBytes(32).toString('hex');
-  const signature = hmacHex(secret, random, body);
+  const signature = hmacHex(secret, random, message);
 
   try {
     const res = await fetch(


### PR DESCRIPTION
Talk's outgoing-reply verification reads only the `message` field, not the full JSON body. The incoming-webhook verification was correct (full body); they're asymmetric. Verified by reading the live spreed source.