### PR TITLE
fix(brett): install bot with webhook + response features

### DIFF
--- a/scripts/brett-bot-setup.sh
+++ b/scripts/brett-bot-setup.sh
@@ -46,7 +46,7 @@ else
   # 5th positional argument. Talk 17+ accepts: webhook, response, event.
   kubectl exec -n workspace deploy/nextcloud --context "${ENV_CONTEXT}" -- \
     php occ talk:bot:install \
-      --feature webhook \
+      --feature webhook --feature response \
       "Systemisches Brett" \
       "${SECRET}" \
       "${WEBHOOK_URL}" \


### PR DESCRIPTION
Without `--feature response`, Talk rejects bot replies with 401. Both features are needed for /brett to actually work. Mirrors what was done manually on the live mentolder + korczewski clusters.