### PR TITLE
feat(brett): broadcast Systemisches Brett link to all active Talk calls

### DIFF
--- a/scripts/brett-bot-setup.sh
+++ b/scripts/brett-bot-setup.sh
@@ -46,7 +46,7 @@ else
   # 5th positional argument. Talk 17+ accepts: webhook, response, event.
   kubectl exec -n workspace deploy/nextcloud --context "${ENV_CONTEXT}" -- \
     php occ talk:bot:install \
-      --feature webhook \
+      --feature webhook --feature response \
       "Systemisches Brett" \
       "${SECRET}" \
       "${WEBHOOK_URL}" \

--- a/website/src/lib/talk.ts
+++ b/website/src/lib/talk.ts
@@ -176,6 +176,42 @@ export async function deleteTalkRoom(roomToken: string): Promise<boolean> {
   }
 }
 
+// List Talk rooms that currently have an active call.
+// Returns rooms visible to the configured admin user where the call flag is set.
+export interface ActiveCallRoom {
+  token: string;
+  name: string;
+  displayName: string;
+  callStartTime?: number;
+}
+
+export async function listActiveCallRooms(): Promise<ActiveCallRoom[]> {
+  try {
+    const res = await ocsApi('GET', '/room');
+    if (!res.ok) {
+      console.error('[talk] List rooms failed:', res.status, await res.text());
+      return [];
+    }
+    const data = await res.json();
+    const rooms: unknown = data?.ocs?.data;
+    if (!Array.isArray(rooms)) return [];
+
+    return rooms
+      .filter((r): r is Record<string, unknown> => r !== null && typeof r === 'object')
+      .filter((r) => r.hasCall === true || (typeof r.callFlag === 'number' && r.callFlag > 0))
+      .map((r) => ({
+        token: String(r.token ?? ''),
+        name: String(r.name ?? ''),
+        displayName: String(r.displayName ?? r.name ?? ''),
+        callStartTime: typeof r.callStartTime === 'number' ? r.callStartTime : undefined,
+      }))
+      .filter((r) => r.token);
+  } catch (err) {
+    console.error('[talk] List rooms error:', err);
+    return [];
+  }
+}
+
 // Post a chat message into a Talk conversation as the admin user.
 // Used for the auto-post on Talk-roomed meeting creation.
 export async function sendChatMessage(roomToken: string, message: string): Promise<boolean> {

--- a/website/src/pages/admin/meetings.astro
+++ b/website/src/pages/admin/meetings.astro
@@ -56,6 +56,11 @@ function statusColor(s: string) {
           </p>
         </div>
         <div class="flex gap-2">
+          <button id="btn-brett"
+            class="px-4 py-2 bg-dark-light text-light rounded-lg text-sm font-semibold border border-dark-lighter hover:border-gold/40"
+            title="Systemisches Brett in alle laufenden Talk-Calls posten">
+            🎯 Brett für alle
+          </button>
           <button id="btn-all"
             class="px-4 py-2 bg-gold text-dark rounded-lg text-sm font-semibold">
             Alle
@@ -123,11 +128,131 @@ function statusColor(s: string) {
       </div>
     </div>
   </section>
+
+  <!-- ── Brett-Broadcast Modal ──────────────────────────────────────────── -->
+  <div id="brett-modal"
+       class="hidden fixed inset-0 z-50 bg-black/70 backdrop-blur-sm items-center justify-center p-4">
+    <div class="bg-dark-light rounded-2xl border border-dark-lighter max-w-lg w-full p-6 shadow-xl">
+      <h2 class="text-xl font-serif text-light mb-2">🎯 Systemisches Brett</h2>
+      <p class="text-sm text-muted mb-4" id="brett-modal-intro">Lade laufende Calls…</p>
+
+      <ul id="brett-modal-rooms"
+          class="max-h-64 overflow-y-auto space-y-1 mb-5 text-sm text-light"></ul>
+
+      <div id="brett-modal-result" class="hidden mb-4 text-sm"></div>
+
+      <div class="flex justify-end gap-2">
+        <button id="brett-modal-cancel"
+          class="px-4 py-2 bg-dark rounded-lg border border-dark-lighter text-sm text-muted hover:text-light">
+          Abbrechen
+        </button>
+        <button id="brett-modal-confirm"
+          class="px-4 py-2 bg-gold text-dark rounded-lg text-sm font-semibold hover:bg-gold/90 disabled:opacity-40 disabled:cursor-not-allowed"
+          disabled>
+          Senden
+        </button>
+      </div>
+    </div>
+  </div>
 </AdminLayout>
 
 <script>
   const btnAll = document.getElementById('btn-all')!;
   const btnUA  = document.getElementById('btn-unassigned')!;
+  const btnBrett = document.getElementById('btn-brett')!;
+  const modal = document.getElementById('brett-modal')!;
+  const modalIntro = document.getElementById('brett-modal-intro')!;
+  const modalRooms = document.getElementById('brett-modal-rooms')!;
+  const modalResult = document.getElementById('brett-modal-result')!;
+  const modalCancel = document.getElementById('brett-modal-cancel') as HTMLButtonElement;
+  const modalConfirm = document.getElementById('brett-modal-confirm') as HTMLButtonElement;
+
+  type ActiveRoom = { token: string; name: string; displayName: string };
+
+  function openModal() {
+    modal.classList.remove('hidden');
+    modal.classList.add('flex');
+  }
+  function closeModal() {
+    modal.classList.add('hidden');
+    modal.classList.remove('flex');
+    modalResult.classList.add('hidden');
+    modalResult.textContent = '';
+    modalConfirm.disabled = true;
+    modalConfirm.textContent = 'Senden';
+  }
+
+  function renderRooms(rooms: ActiveRoom[]) {
+    modalRooms.replaceChildren();
+    for (const r of rooms) {
+      const li = document.createElement('li');
+      li.className = 'px-3 py-2 bg-dark rounded border border-dark-lighter';
+      li.textContent = r.displayName || r.name || r.token;
+      modalRooms.appendChild(li);
+    }
+  }
+
+  async function loadActiveCalls() {
+    modalIntro.textContent = 'Lade laufende Calls…';
+    modalRooms.replaceChildren();
+    modalConfirm.disabled = true;
+
+    try {
+      const res = await fetch('/api/admin/brett/broadcast');
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data = await res.json() as { rooms: ActiveRoom[] };
+      const rooms = data.rooms ?? [];
+
+      if (rooms.length === 0) {
+        modalIntro.textContent = 'Aktuell läuft kein Talk-Call.';
+        return;
+      }
+
+      modalIntro.textContent =
+        `Brett-Link wird in folgende ${rooms.length} laufende(n) Call(s) gepostet:`;
+      renderRooms(rooms);
+      modalConfirm.disabled = false;
+    } catch (err) {
+      modalIntro.textContent = 'Fehler beim Laden der Calls.';
+      console.error(err);
+    }
+  }
+
+  async function broadcast() {
+    modalConfirm.disabled = true;
+    modalConfirm.textContent = 'Sende…';
+    try {
+      const res = await fetch('/api/admin/brett/broadcast', { method: 'POST' });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data = await res.json() as { total: number; sent: number; failed: number };
+      modalResult.classList.remove('hidden');
+      if (data.failed === 0) {
+        modalResult.className = 'mb-4 text-sm text-green-400';
+        modalResult.textContent = `✓ Brett-Link an ${data.sent} Call(s) gesendet.`;
+      } else {
+        modalResult.className = 'mb-4 text-sm text-yellow-400';
+        modalResult.textContent = `${data.sent}/${data.total} gesendet, ${data.failed} fehlgeschlagen.`;
+      }
+      modalConfirm.textContent = 'Schließen';
+      modalConfirm.disabled = false;
+      modalConfirm.onclick = closeModal;
+    } catch (err) {
+      modalResult.classList.remove('hidden');
+      modalResult.className = 'mb-4 text-sm text-red-400';
+      modalResult.textContent = 'Senden fehlgeschlagen.';
+      modalConfirm.textContent = 'Senden';
+      modalConfirm.disabled = false;
+      console.error(err);
+    }
+  }
+
+  btnBrett.addEventListener('click', () => {
+    modalConfirm.onclick = broadcast;
+    openModal();
+    loadActiveCalls();
+  });
+  modalCancel.addEventListener('click', closeModal);
+  modal.addEventListener('click', (e) => { if (e.target === modal) closeModal(); });
 
   function setActive(btn: HTMLElement, other: HTMLElement) {
     btn.className   = 'px-4 py-2 bg-gold text-dark rounded-lg text-sm font-semibold';

--- a/website/src/pages/api/admin/brett/broadcast.ts
+++ b/website/src/pages/api/admin/brett/broadcast.ts
@@ -1,0 +1,44 @@
+// Admin-only: list Talk rooms with an active call, and broadcast the
+// Systemisches-Brett link to all of them. Powers the "Brett für alle starten"
+// button on /admin/meetings.
+import type { APIRoute } from 'astro';
+import { getSession, isAdmin } from '../../../../lib/auth';
+import { listActiveCallRooms, sendChatMessage } from '../../../../lib/talk';
+
+const BRETT_DOMAIN = process.env.BRETT_DOMAIN || 'brett.localhost';
+
+function brettUrlFor(roomToken: string): string {
+  return `https://${BRETT_DOMAIN}/?room=${encodeURIComponent(roomToken)}`;
+}
+
+export const GET: APIRoute = async ({ request }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 });
+  }
+  const rooms = await listActiveCallRooms();
+  return new Response(JSON.stringify({ rooms }), {
+    headers: { 'Content-Type': 'application/json' },
+  });
+};
+
+export const POST: APIRoute = async ({ request }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 });
+  }
+
+  const rooms = await listActiveCallRooms();
+  const results = await Promise.all(
+    rooms.map(async (r) => {
+      const ok = await sendChatMessage(r.token, `🎯 Systemisches Brett: ${brettUrlFor(r.token)}`);
+      return { token: r.token, displayName: r.displayName, ok };
+    })
+  );
+
+  const sent = results.filter((r) => r.ok).length;
+  return new Response(
+    JSON.stringify({ total: rooms.length, sent, failed: rooms.length - sent, results }),
+    { headers: { 'Content-Type': 'application/json' } }
+  );
+};


### PR DESCRIPTION
## Summary
- New admin button `🎯 Brett für alle` on `/admin/meetings` (top right) opens a confirm modal that lists every Talk room currently in an active call
- On confirm, posts `🎯 Systemisches Brett: https://${BRETT_DOMAIN}/?room=<token>` into each room via existing `sendChatMessage` (admin user, no bot HMAC path needed)
- Server re-fetches the active-call list on POST so the broadcast scope cannot be widened from the client

## Test plan
- [ ] Open two Talk calls on mentolder, click the button, verify the modal lists both rooms
- [ ] Confirm and verify both Talk chats receive the brett link
- [ ] Cancel the modal and verify nothing is sent
- [ ] Click with no active calls and verify the modal shows "Aktuell läuft kein Talk-Call." with disabled Send

🤖 Generated with [Claude Code](https://claude.com/claude-code)