### PR TITLE
fix(brett): enable bot per room before broadcast (HTTP 401 fix)

### DIFF
--- a/website/src/lib/nextcloud-talk-db.ts
+++ b/website/src/lib/nextcloud-talk-db.ts
@@ -72,3 +72,48 @@ export async function listActiveCallRooms(): Promise<ActiveCallRoom[]> {
     return [];
   }
 }
+
+const BRETT_BOT_NAME = 'Systemisches Brett';
+
+// Look up the brett bot's server-side id from oc_talk_bots_server.
+async function getBrettBotId(): Promise<number | null> {
+  try {
+    const { rows } = await getPool().query<{ id: string }>(
+      `SELECT id FROM oc_talk_bots_server WHERE name = $1 LIMIT 1`,
+      [BRETT_BOT_NAME]
+    );
+    return rows.length === 0 ? null : parseInt(rows[0].id, 10);
+  } catch (err) {
+    console.error('[nc-talk-db] getBrettBotId failed:', err);
+    return null;
+  }
+}
+
+// Ensure the brett bot is enabled for the given conversation. Talk's
+// `talk:bot:install` does NOT auto-enable a bot for every room — each room
+// needs an explicit row in oc_talk_bots_conversation, normally created by
+// `talk:bot:setup BOT_ID TOKEN`. Without this row, bot-reply HMAC fails
+// with HTTP 401. We mirror that one-row insert here so /admin/brett/broadcast
+// works for rooms the operator hasn't set up manually.
+export async function ensureBrettBotEnabledForRoom(roomToken: string): Promise<boolean> {
+  const botId = await getBrettBotId();
+  if (botId === null) {
+    console.error('[nc-talk-db] brett bot not found in oc_talk_bots_server');
+    return false;
+  }
+  try {
+    await getPool().query(
+      `INSERT INTO oc_talk_bots_conversation (bot_id, token, state)
+       SELECT $1::bigint, $2::text, 1::smallint
+       WHERE NOT EXISTS (
+         SELECT 1 FROM oc_talk_bots_conversation
+         WHERE bot_id = $1::bigint AND token = $2::text
+       )`,
+      [botId, roomToken]
+    );
+    return true;
+  } catch (err) {
+    console.error('[nc-talk-db] ensureBrettBotEnabledForRoom failed:', err);
+    return false;
+  }
+}

--- a/website/src/pages/api/admin/brett/broadcast.ts
+++ b/website/src/pages/api/admin/brett/broadcast.ts
@@ -11,7 +11,10 @@
 // so it can post to any conversation regardless of admin participation.
 import type { APIRoute } from 'astro';
 import { getSession, isAdmin } from '../../../../lib/auth';
-import { listActiveCallRooms } from '../../../../lib/nextcloud-talk-db';
+import {
+  listActiveCallRooms,
+  ensureBrettBotEnabledForRoom,
+} from '../../../../lib/nextcloud-talk-db';
 import { postBotReply } from '../../../../lib/brett-bot';
 
 const BRETT_DOMAIN = process.env.BRETT_DOMAIN || 'brett.localhost';
@@ -44,6 +47,10 @@ export const POST: APIRoute = async ({ request }) => {
   const rooms = await listActiveCallRooms();
   const results = await Promise.all(
     rooms.map(async (r) => {
+      // Talk's bot-reply endpoint returns 401 unless the bot is explicitly
+      // enabled for the conversation. talk:bot:install does not enable it
+      // for every room automatically, so make sure the row exists first.
+      await ensureBrettBotEnabledForRoom(r.token);
       const ok = await postBotReply(
         r.token,
         `🎯 Systemisches Brett: ${brettUrlFor(r.token)}`,


### PR DESCRIPTION
## Summary

The 🎯 Brett broadcast button found rooms but posting failed with HTTP 401 from Talk's bot-reply endpoint. Root cause: `talk:bot:install` does NOT add an `oc_talk_bots_conversation` row for every room — only rooms explicitly set up via `talk:bot:setup BOT_ID TOKEN` get the bot enabled. Without that row, the bot HMAC fails verification.

Mirror what `talk:bot:setup` does from the website pod: look up the brett bot id by name in `oc_talk_bots_server`, then `INSERT … WHERE NOT EXISTS` into `oc_talk_bots_conversation` before each post.

## Test plan
- [ ] After deploy: click 🎯 with an active call in a previously-unseen room → bot posts the brett link
- [ ] Click again with the same room → no duplicate row, still works
- [ ] Verify `oc_talk_bots_conversation` rows have state=1 for each broadcast target

🤖 Generated with [Claude Code](https://claude.com/claude-code)