### PR TITLE
fix(auth): fix oauth2-proxy errors middleware rd template and skip-provider-button

### DIFF
--- a/k3d/mail-ingressroute-dev.yaml
+++ b/k3d/mail-ingressroute-dev.yaml
@@ -27,7 +27,7 @@ spec:
     service:
       name: oauth2-proxy-mailpit
       port: 4180
-    query: "/oauth2/sign_in?rd={scheme}://{host}{url}"
+    query: "/oauth2/sign_in?rd={url}"
 ---
 apiVersion: traefik.io/v1alpha1
 kind: IngressRoute

--- a/k3d/oauth2-proxy-mailpit.yaml
+++ b/k3d/oauth2-proxy-mailpit.yaml
@@ -82,7 +82,6 @@ spec:
             - --pass-access-token=true
             - --pass-authorization-header=true
             - --set-xauthrequest=true
-            - --skip-provider-button=true
             - --code-challenge-method=S256
             - --insecure-oidc-allow-unverified-email=true
             - --oidc-extra-audience=mailpit-admin

--- a/k3d/oauth2-proxy-traefik.yaml
+++ b/k3d/oauth2-proxy-traefik.yaml
@@ -83,7 +83,6 @@ spec:
             - --pass-access-token=true
             - --pass-authorization-header=true
             - --set-xauthrequest=true
-            - --skip-provider-button=true
             - --code-challenge-method=S256
             - --insecure-oidc-allow-unverified-email=true
             - --oidc-extra-audience=traefik-dashboard

--- a/prod/patch-oauth2-proxy-mailpit.yaml
+++ b/prod/patch-oauth2-proxy-mailpit.yaml
@@ -30,7 +30,6 @@ spec:
             - "--pass-access-token=true"
             - "--pass-authorization-header=true"
             - "--set-xauthrequest=true"
-            - "--skip-provider-button=true"
             - "--code-challenge-method=S256"
             - "--insecure-oidc-allow-unverified-email=true"
             - "--oidc-extra-audience=mailpit-admin"

--- a/prod/patch-oauth2-proxy-traefik.yaml
+++ b/prod/patch-oauth2-proxy-traefik.yaml
@@ -29,7 +29,6 @@ spec:
             - "--pass-access-token=true"
             - "--pass-authorization-header=true"
             - "--set-xauthrequest=true"
-            - "--skip-provider-button=true"
             - "--code-challenge-method=S256"
             - "--insecure-oidc-allow-unverified-email=true"
             - "--oidc-extra-audience=traefik-dashboard"

--- a/prod/traefik-dashboard.yaml
+++ b/prod/traefik-dashboard.yaml
@@ -3,10 +3,11 @@
 # Flow:
 #   1. Browser hits https://traefik.<domain>/
 #   2. ForwardAuth middleware calls oauth2-proxy /oauth2/auth → 202 or 401
-#   3. On 401, the errors middleware serves oauth2-proxy /oauth2/sign_in
-#      which presents a sign-in link to /oauth2/start?rd=<original>
-#   4. /oauth2/start redirects to Keycloak, user authenticates, returns
-#      via /oauth2/callback; session cookie is set; user retries /
+#   3. On 401, the errors middleware fetches /oauth2/sign_in?rd=<original>
+#      and serves the HTML sign-in button page ({url} = full original URL)
+#   4. User clicks "Sign in with Keycloak" → /oauth2/start sets CSRF cookie
+#      and redirects to Keycloak; user authenticates; /oauth2/callback sets
+#      session cookie and redirects back to <original>
 # ═══════════════════════════════════════════════════════════════════
 apiVersion: traefik.io/v1alpha1
 kind: Middleware
@@ -34,7 +35,7 @@ spec:
     service:
       name: oauth2-proxy-traefik
       port: 4180
-    query: "/oauth2/sign_in?rd={scheme}://{host}{url}"
+    query: "/oauth2/sign_in?rd={url}"
 ---
 # Redirect https://traefik.<domain>/  →  /dashboard/ (the actual dashboard URL)
 apiVersion: traefik.io/v1alpha1


### PR DESCRIPTION
## Summary

- Fixed the errors middleware `query` template: `{scheme}://{host}{url}` → `{url}` — Traefik only substitutes `{url}` (as the full URL), leaving `{scheme}` and `{host}` as literal text, which caused oauth2-proxy to reject the `rd` redirect as invalid and fall back to `rd=/`
- Removed `--skip-provider-button=true` from all four oauth2-proxy configs (k3d + prod patches for traefik and mailpit) — with this flag set, the errors middleware's internal sign_in call immediately started a PKCE flow and set the CSRF cookie; page refreshes generated a new cookie while the cached Keycloak link still had the old challenge, causing CSRF/PKCE mismatches → 500
- Updated the flow comment in `prod/traefik-dashboard.yaml` to reflect the correct behavior

## Test plan

- [ ] Deploy to mentolder/korczewski via `task workspace:deploy ENV=mentolder` (ArgoCD will pick up changes)
- [ ] Open admin panel → click Traefik button → should redirect to `/dashboard/` and show oauth2-proxy sign-in button page
- [ ] Click "Sign in with Keycloak" → should complete auth flow and land on Traefik dashboard
- [ ] Open admin panel → click Mailpit button → same flow, lands on Mailpit inbox
- [ ] Verify no 500 errors on `/oauth2/callback` in oauth2-proxy logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)