### PR TITLE
feat(ingress): redirect mentolder.de apex to web.mentolder.de

### DIFF
--- a/prod/ingress.yaml
+++ b/prod/ingress.yaml
@@ -2,13 +2,13 @@
 # Production Ingress — per-Service mit Traefik-Middlewares
 # ═══════════════════════════════════════════════════════════════════
 
-# ── Apex Domain → Old Webspace ─────────────────────────────────────
+# ── Apex Domain → web.PROD_DOMAIN (permanent redirect) ─────────────
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: workspace-ingress-apex
   annotations:
-    traefik.ingress.kubernetes.io/router.middlewares: "workspace-redirect-https@kubernetescrd,workspace-hsts-headers@kubernetescrd,workspace-security-headers@kubernetescrd"
+    traefik.ingress.kubernetes.io/router.middlewares: "workspace-redirect-https@kubernetescrd,workspace-redirect-apex-to-web@kubernetescrd,workspace-hsts-headers@kubernetescrd,workspace-security-headers@kubernetescrd"
 spec:
   tls:
     - hosts:

--- a/prod/traefik-middlewares.yaml
+++ b/prod/traefik-middlewares.yaml
@@ -78,3 +78,15 @@ spec:
   rateLimit:
     average: 200
     burst: 400
+---
+# ── Apex → Website redirect ────────────────────────────────────────
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: redirect-apex-to-web
+  namespace: workspace
+spec:
+  redirectRegex:
+    regex: "^https?://${PROD_DOMAIN}(.*)"
+    replacement: "https://web.${PROD_DOMAIN}$1"
+    permanent: true


### PR DESCRIPTION
## Summary

- Adds a new Traefik `RedirectRegex` middleware (`redirect-apex-to-web`) that issues a permanent 301 redirect from `mentolder.de` (and any path) to `https://web.mentolder.de`
- Updates `workspace-ingress-apex` to apply this middleware (placed after `redirect-https`, before HSTS/security headers)
- The `old-webspace` backend is kept as a no-op fallback; the redirect fires before any request reaches it

## Test plan

- [ ] `task workspace:validate` passes (already verified locally)
- [ ] After `task workspace:deploy ENV=mentolder`: `curl -I https://mentolder.de` returns `301` with `Location: https://web.mentolder.de`
- [ ] `curl -I https://mentolder.de/foo` redirects to `https://web.mentolder.de/foo` (path preserved)
- [ ] `web.mentolder.de` remains accessible without redirect loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)