### PR TITLE
feat(poll): live anonymous poll broadcast via Talk bot

### DIFF
--- a/docs/superpowers/plans/2026-04-26-live-poll.md
+++ b/docs/superpowers/plans/2026-04-26-live-poll.md
@@ -1,0 +1,1510 @@
+# Live Poll Feature — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add admin-triggered live polls that broadcast QR-code links to active Nextcloud Talk calls, collect anonymous answers, and let the admin share aggregated results back to the group.
+
+**Architecture:** All logic lives in the existing Astro website (website namespace). Two new DB tables (`polls`, `poll_answers`) are added to the shared-db website schema. Admin UI is added to `/admin/meetings`. Participant and results pages are new public Astro pages. Broadcasting reuses the existing `postBotReply` helper and `BRETT_BOT_SECRET`.
+
+**Tech Stack:** Astro (SSR, `output: 'server'`), TypeScript, PostgreSQL (`pg` pool via `SESSIONS_DATABASE_URL`), Node.js `node:test` + `tsx` for unit tests, `qrcode` npm package for client-side QR generation.
+
+---
+
+## File Map
+
+| Action | File |
+|--------|------|
+| Modify | `k3d/website-schema.yaml` |
+| Create | `website/src/lib/poll-db.ts` |
+| Create | `website/src/lib/poll-db.test.ts` |
+| Create | `website/src/pages/api/admin/poll/index.ts` |
+| Create | `website/src/pages/api/admin/poll/active.ts` |
+| Create | `website/src/pages/api/admin/poll/[id].ts` |
+| Create | `website/src/pages/api/admin/poll/[id]/share.ts` |
+| Create | `website/src/pages/api/poll/[id].ts` |
+| Create | `website/src/pages/api/poll/[id]/answer.ts` |
+| Create | `website/src/pages/api/poll/[id]/results.ts` |
+| Create | `website/src/pages/poll/[id].astro` |
+| Create | `website/src/pages/poll/[id]/results.astro` |
+| Modify | `website/src/pages/admin/meetings.astro` |
+
+---
+
+## Task 1: DB Schema
+
+**Files:**
+- Modify: `k3d/website-schema.yaml`
+
+- [ ] **Step 1: Add `polls` and `poll_answers` DDL**
+
+Open `k3d/website-schema.yaml`. Find the block containing `brett_rooms` and `brett_snapshots` DDL. Add the following directly after the `brett_snapshots` index block (before the `GRANT` statements):
+
+```yaml
+      CREATE TABLE IF NOT EXISTS polls (
+          id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+          question    TEXT NOT NULL,
+          kind        TEXT NOT NULL CHECK (kind IN ('multiple_choice', 'text')),
+          options     TEXT[],
+          status      TEXT NOT NULL DEFAULT 'open' CHECK (status IN ('open', 'locked')),
+          room_tokens TEXT[] NOT NULL DEFAULT '{}',
+          created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+          locked_at   TIMESTAMPTZ
+      );
+
+      CREATE TABLE IF NOT EXISTS poll_answers (
+          id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+          poll_id      UUID NOT NULL REFERENCES polls(id) ON DELETE CASCADE,
+          answer       TEXT NOT NULL,
+          submitted_at TIMESTAMPTZ NOT NULL DEFAULT now()
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_poll_answers_poll
+          ON poll_answers(poll_id, submitted_at DESC);
+```
+
+- [ ] **Step 2: Validate manifests**
+
+```bash
+task workspace:validate
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add k3d/website-schema.yaml
+git commit -m "feat(poll): add polls and poll_answers tables to website schema"
+```
+
+---
+
+## Task 2: Add qrcode Dependency
+
+**Files:**
+- Modify: `website/package.json`, `website/package-lock.json`
+
+- [ ] **Step 1: Install**
+
+```bash
+cd website && npm install qrcode && npm install --save-dev @types/qrcode
+```
+
+- [ ] **Step 2: Verify**
+
+```bash
+cd website && node -e "import('qrcode').then(m => console.log('qrcode ok:', typeof m.default.toCanvas))"
+```
+
+Expected: `qrcode ok: function`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add website/package.json website/package-lock.json
+git commit -m "feat(poll): add qrcode dependency for admin QR modal"
+```
+
+---
+
+## Task 3: poll-db.ts — DB Helpers and Unit Tests
+
+**Files:**
+- Create: `website/src/lib/poll-db.ts`
+- Create: `website/src/lib/poll-db.test.ts`
+
+- [ ] **Step 1: Write the failing tests first**
+
+Create `website/src/lib/poll-db.test.ts`:
+
+```typescript
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { POLL_TEMPLATES, buildResultsBotMessage } from './poll-db.js';
+
+test('POLL_TEMPLATES: has 5 entries', () => {
+  assert.equal(POLL_TEMPLATES.length, 5);
+});
+
+test('POLL_TEMPLATES: all MC templates have >= 2 options', () => {
+  for (const t of POLL_TEMPLATES) {
+    if (t.kind === 'multiple_choice') {
+      assert.ok(
+        Array.isArray(t.options) && t.options.length >= 2,
+        `${t.label} must have >= 2 options`,
+      );
+    }
+  }
+});
+
+test('POLL_TEMPLATES: text template has null options', () => {
+  const text = POLL_TEMPLATES.find(t => t.kind === 'text');
+  assert.ok(text, 'should have at least one text template');
+  assert.equal(text.options, null);
+});
+
+test('buildResultsBotMessage: MC format includes question, counts, and URL', () => {
+  const results = {
+    poll: {
+      id: 'abc', question: 'Wie geht es?', kind: 'multiple_choice' as const,
+      options: ['Gut', 'Mittel'], status: 'locked' as const,
+      room_tokens: [], created_at: new Date(), locked_at: new Date(),
+    },
+    total: 7,
+    counts: [{ answer: 'Gut', count: 5 }, { answer: 'Mittel', count: 2 }],
+  };
+  const msg = buildResultsBotMessage(results, 'https://web.example.com/poll/abc/results');
+  assert.ok(msg.includes('Wie geht es?'), 'should include question');
+  assert.ok(msg.includes('Gut: 5'), 'should include Gut count');
+  assert.ok(msg.includes('Mittel: 2'), 'should include Mittel count');
+  assert.ok(msg.includes('https://web.example.com/poll/abc/results'), 'should include URL');
+});
+
+test('buildResultsBotMessage: text format includes total and URL, not option breakdown', () => {
+  const results = {
+    poll: {
+      id: 'xyz', question: 'Was nehmen Sie mit?', kind: 'text' as const,
+      options: null, status: 'locked' as const,
+      room_tokens: [], created_at: new Date(), locked_at: new Date(),
+    },
+    total: 4,
+    counts: [{ answer: 'Fokus', count: 3 }, { answer: 'Pausen', count: 1 }],
+  };
+  const msg = buildResultsBotMessage(results, 'https://web.example.com/poll/xyz/results');
+  assert.ok(msg.includes('Was nehmen Sie mit?'), 'should include question');
+  assert.ok(msg.includes('4 Antworten'), 'should include total count');
+  assert.ok(msg.includes('https://web.example.com/poll/xyz/results'), 'should include URL');
+  assert.ok(!msg.includes('Fokus: 3'), 'should NOT list individual text answers');
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd website && npx tsx --test src/lib/poll-db.test.ts
+```
+
+Expected: Error — module `./poll-db.js` not found.
+
+- [ ] **Step 3: Create poll-db.ts**
+
+Create `website/src/lib/poll-db.ts`:
+
+```typescript
+import pg from 'pg';
+import { resolve4 } from 'dns';
+const { Pool } = pg;
+
+const DB_URL = process.env.SESSIONS_DATABASE_URL
+  || 'postgresql://website:devwebsitedb@shared-db.workspace.svc.cluster.local:5432/website';
+
+function nodeLookup(
+  hostname: string,
+  _opts: unknown,
+  cb: (err: Error | null, addr: string, family: number) => void,
+) {
+  resolve4(hostname, (err, addrs) => cb(err ?? null, addrs?.[0] ?? '', 4));
+}
+
+const pool = new Pool({ connectionString: DB_URL, lookup: nodeLookup } as unknown as import('pg').PoolConfig);
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export type PollKind = 'multiple_choice' | 'text';
+export type PollStatus = 'open' | 'locked';
+
+export interface Poll {
+  id: string;
+  question: string;
+  kind: PollKind;
+  options: string[] | null;
+  status: PollStatus;
+  room_tokens: string[];
+  created_at: Date;
+  locked_at: Date | null;
+}
+
+export interface PollTemplate {
+  label: string;
+  question: string;
+  kind: PollKind;
+  options: string[] | null;
+}
+
+export interface AnswerCount {
+  answer: string;
+  count: number;
+}
+
+export interface PollResults {
+  poll: Poll;
+  total: number;
+  counts: AnswerCount[];
+}
+
+// ── Templates (source of truth for the admin UI) ──────────────────────────────
+
+export const POLL_TEMPLATES: PollTemplate[] = [
+  {
+    label: 'Wie fühlen Sie sich gerade?',
+    question: 'Wie fühlen Sie sich gerade?',
+    kind: 'multiple_choice',
+    options: ['\u{1F60A} Gut', '\u{1F610} Mittel', '\u{1F614} Nicht so gut'],
+  },
+  {
+    label: 'Stimmen Sie zu?',
+    question: 'Stimmen Sie zu?',
+    kind: 'multiple_choice',
+    options: ['Ja', 'Nein', 'Enthaltung'],
+  },
+  {
+    label: 'Wie hilfreich war diese Session?',
+    question: 'Wie hilfreich war diese Session?',
+    kind: 'multiple_choice',
+    options: ['Sehr hilfreich', 'Hilfreich', 'Wenig hilfreich', 'Nicht hilfreich'],
+  },
+  {
+    label: 'Bereit für den nächsten Schritt?',
+    question: 'Bereit für den nächsten Schritt?',
+    kind: 'multiple_choice',
+    options: ['Ja', 'Noch nicht', 'Brauche mehr Info'],
+  },
+  {
+    label: 'Was nehmen Sie mit?',
+    question: 'Was nehmen Sie mit?',
+    kind: 'text',
+    options: null,
+  },
+];
+
+// ── DB Helpers ─────────────────────────────────────────────────────────────────
+
+export async function createPoll(
+  question: string,
+  kind: PollKind,
+  options: string[] | null,
+  roomTokens: string[],
+): Promise<Poll> {
+  const { rows } = await pool.query<Poll>(
+    `INSERT INTO polls (question, kind, options, room_tokens)
+     VALUES ($1, $2, $3, $4)
+     RETURNING id, question, kind, options, status, room_tokens, created_at, locked_at`,
+    [question, kind, options, roomTokens],
+  );
+  return rows[0];
+}
+
+export async function getActivePoll(): Promise<Poll | null> {
+  const { rows } = await pool.query<Poll>(
+    `SELECT id, question, kind, options, status, room_tokens, created_at, locked_at
+       FROM polls WHERE status = 'open'
+       ORDER BY created_at DESC LIMIT 1`,
+  );
+  return rows[0] ?? null;
+}
+
+export async function getPoll(id: string): Promise<Poll | null> {
+  const { rows } = await pool.query<Poll>(
+    `SELECT id, question, kind, options, status, room_tokens, created_at, locked_at
+       FROM polls WHERE id = $1`,
+    [id],
+  );
+  return rows[0] ?? null;
+}
+
+export async function submitAnswer(pollId: string, answer: string): Promise<void> {
+  await pool.query(
+    'INSERT INTO poll_answers (poll_id, answer) VALUES ($1, $2)',
+    [pollId, answer],
+  );
+}
+
+export async function getResults(pollId: string): Promise<PollResults | null> {
+  const poll = await getPoll(pollId);
+  if (!poll) return null;
+
+  const { rows } = await pool.query<{ answer: string; count: string }>(
+    `SELECT answer, COUNT(*)::text AS count
+       FROM poll_answers WHERE poll_id = $1
+       GROUP BY answer ORDER BY count DESC, answer ASC`,
+    [pollId],
+  );
+
+  const rawCounts: AnswerCount[] = rows.map(r => ({
+    answer: r.answer,
+    count: parseInt(r.count, 10),
+  }));
+  const total = rawCounts.reduce((s, r) => s + r.count, 0);
+
+  // MC polls: preserve option order and include zero-count options
+  const counts: AnswerCount[] =
+    poll.kind === 'multiple_choice' && poll.options
+      ? poll.options.map(opt => ({
+          answer: opt,
+          count: rawCounts.find(r => r.answer === opt)?.count ?? 0,
+        }))
+      : rawCounts;
+
+  return { poll, total, counts };
+}
+
+export async function lockPoll(id: string): Promise<Poll | null> {
+  const { rows } = await pool.query<Poll>(
+    `UPDATE polls SET status = 'locked', locked_at = now()
+       WHERE id = $1 AND status = 'open'
+       RETURNING id, question, kind, options, status, room_tokens, created_at, locked_at`,
+    [id],
+  );
+  return rows[0] ?? null;
+}
+
+// ── Pure Helpers ───────────────────────────────────────────────────────────────
+
+export function buildResultsBotMessage(results: PollResults, resultsUrl: string): string {
+  const { poll, total, counts } = results;
+  if (poll.kind === 'multiple_choice') {
+    const breakdown = counts.map(c => `${c.answer}: ${c.count}`).join(' | ');
+    return `\u{1F4CA} Umfrageergebnis: „${poll.question}“\n${breakdown}\n→ ${resultsUrl}`;
+  }
+  return `\u{1F4CA} Umfrageergebnis: „${poll.question}“\n${total} Antworten · Details: ${resultsUrl}`;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd website && npx tsx --test src/lib/poll-db.test.ts
+```
+
+Expected:
+```
+✔ POLL_TEMPLATES: has 5 entries
+✔ POLL_TEMPLATES: all MC templates have >= 2 options
+✔ POLL_TEMPLATES: text template has null options
+✔ buildResultsBotMessage: MC format includes question, counts, and URL
+✔ buildResultsBotMessage: text format includes total and URL, not option breakdown
+ℹ tests 5
+ℹ pass 5
+ℹ fail 0
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add website/src/lib/poll-db.ts website/src/lib/poll-db.test.ts
+git commit -m "feat(poll): add poll-db helpers, types, templates, and unit tests"
+```
+
+---
+
+## Task 4: Admin Create, Active, and Status API Routes
+
+**Files:**
+- Create: `website/src/pages/api/admin/poll/index.ts`
+- Create: `website/src/pages/api/admin/poll/active.ts`
+- Create: `website/src/pages/api/admin/poll/[id].ts`
+
+- [ ] **Step 1: Create `website/src/pages/api/admin/poll/index.ts`**
+
+```typescript
+import type { APIRoute } from 'astro';
+import { getSession, isAdmin } from '../../../../lib/auth';
+import { createPoll, getActivePoll } from '../../../../lib/poll-db';
+import { listActiveCallRooms, ensureBrettBotEnabledForRoom } from '../../../../lib/nextcloud-talk-db';
+import { postBotReply } from '../../../../lib/brett-bot';
+
+const SITE_URL = process.env.SITE_URL || 'https://web.localhost';
+const BOT_SECRET = process.env.BRETT_BOT_SECRET || '';
+
+export const POST: APIRoute = async ({ request }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 });
+  }
+
+  const existing = await getActivePoll();
+  if (existing) {
+    return new Response(
+      JSON.stringify({ error: 'poll_already_active', id: existing.id }),
+      { status: 409, headers: { 'Content-Type': 'application/json' } },
+    );
+  }
+
+  let body: unknown;
+  try { body = await request.json(); } catch {
+    return new Response(JSON.stringify({ error: 'invalid JSON' }), { status: 400 });
+  }
+  const { question, kind, options } = (body ?? {}) as Record<string, unknown>;
+
+  if (!question || typeof question !== 'string' || question.trim().length < 2) {
+    return new Response(JSON.stringify({ error: 'question required (min 2 chars)' }), { status: 400 });
+  }
+  if (kind !== 'multiple_choice' && kind !== 'text') {
+    return new Response(JSON.stringify({ error: 'kind must be multiple_choice or text' }), { status: 400 });
+  }
+  if (kind === 'multiple_choice' && (!Array.isArray(options) || options.length < 2)) {
+    return new Response(JSON.stringify({ error: 'multiple_choice requires >= 2 options' }), { status: 400 });
+  }
+
+  const rooms = await listActiveCallRooms();
+  const poll = await createPoll(
+    question.trim(),
+    kind,
+    kind === 'text' ? null : (options as string[]),
+    rooms.map(r => r.token),
+  );
+
+  const pollUrl = `${SITE_URL}/poll/${poll.id}`;
+  const broadcastResults = await Promise.all(
+    rooms.map(async r => {
+      await ensureBrettBotEnabledForRoom(r.token);
+      const ok = await postBotReply(r.token, `\u{1F4CA} Umfrage: ${pollUrl}`, BOT_SECRET);
+      return { token: r.token, displayName: r.displayName, ok };
+    }),
+  );
+
+  const sent = broadcastResults.filter(r => r.ok).length;
+  return new Response(
+    JSON.stringify({ poll, broadcastResults, sent, total: rooms.length }),
+    { status: 201, headers: { 'Content-Type': 'application/json' } },
+  );
+};
+```
+
+- [ ] **Step 2: Create `website/src/pages/api/admin/poll/active.ts`**
+
+```typescript
+import type { APIRoute } from 'astro';
+import { getSession, isAdmin } from '../../../../lib/auth';
+import { getActivePoll, getResults } from '../../../../lib/poll-db';
+
+export const GET: APIRoute = async ({ request }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 });
+  }
+
+  const poll = await getActivePoll();
+  if (!poll) {
+    return new Response(JSON.stringify({ poll: null }), {
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const results = await getResults(poll.id);
+  return new Response(JSON.stringify({ poll, results }), {
+    headers: { 'Content-Type': 'application/json' },
+  });
+};
+```
+
+- [ ] **Step 3: Create `website/src/pages/api/admin/poll/[id].ts`**
+
+```typescript
+import type { APIRoute } from 'astro';
+import { getSession, isAdmin } from '../../../../lib/auth';
+import { getResults } from '../../../../lib/poll-db';
+
+export const GET: APIRoute = async ({ request, params }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 });
+  }
+
+  const results = await getResults(params.id!);
+  if (!results) {
+    return new Response(JSON.stringify({ error: 'not found' }), { status: 404 });
+  }
+
+  return new Response(JSON.stringify(results), {
+    headers: { 'Content-Type': 'application/json' },
+  });
+};
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add website/src/pages/api/admin/poll/
+git commit -m "feat(poll): add admin create, active, and status API routes"
+```
+
+---
+
+## Task 5: Admin Share API Route
+
+**Files:**
+- Create: `website/src/pages/api/admin/poll/[id]/share.ts`
+
+- [ ] **Step 1: Create `website/src/pages/api/admin/poll/[id]/share.ts`**
+
+```typescript
+import type { APIRoute } from 'astro';
+import { getSession, isAdmin } from '../../../../../lib/auth';
+import { lockPoll, getResults, buildResultsBotMessage } from '../../../../../lib/poll-db';
+import { postBotReply } from '../../../../../lib/brett-bot';
+
+const SITE_URL = process.env.SITE_URL || 'https://web.localhost';
+const BOT_SECRET = process.env.BRETT_BOT_SECRET || '';
+
+export const POST: APIRoute = async ({ request, params }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 });
+  }
+
+  const poll = await lockPoll(params.id!);
+  if (!poll) {
+    return new Response(
+      JSON.stringify({ error: 'not found or already locked' }),
+      { status: 404, headers: { 'Content-Type': 'application/json' } },
+    );
+  }
+
+  const results = await getResults(poll.id);
+  if (!results) {
+    return new Response(JSON.stringify({ error: 'results unavailable' }), { status: 500 });
+  }
+
+  const resultsUrl = `${SITE_URL}/poll/${poll.id}/results`;
+  const message = buildResultsBotMessage(results, resultsUrl);
+
+  const broadcastResults = await Promise.all(
+    poll.room_tokens.map(async token => {
+      const ok = await postBotReply(token, message, BOT_SECRET);
+      return { token, ok };
+    }),
+  );
+
+  const sent = broadcastResults.filter(r => r.ok).length;
+  return new Response(
+    JSON.stringify({ poll, results, sent, total: poll.room_tokens.length, broadcastResults }),
+    { headers: { 'Content-Type': 'application/json' } },
+  );
+};
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add website/src/pages/api/admin/poll/
+git commit -m "feat(poll): add admin share/lock API route with Talk broadcast"
+```
+
+---
+
+## Task 6: Public Poll API Routes
+
+**Files:**
+- Create: `website/src/pages/api/poll/[id].ts`
+- Create: `website/src/pages/api/poll/[id]/answer.ts`
+- Create: `website/src/pages/api/poll/[id]/results.ts`
+
+- [ ] **Step 1: Create `website/src/pages/api/poll/[id].ts`**
+
+```typescript
+import type { APIRoute } from 'astro';
+import { getPoll } from '../../../../lib/poll-db';
+
+export const GET: APIRoute = async ({ params }) => {
+  const poll = await getPoll(params.id!);
+  if (!poll) {
+    return new Response(JSON.stringify({ error: 'not found' }), { status: 404 });
+  }
+  if (poll.status === 'locked') {
+    return new Response(JSON.stringify({ error: 'locked' }), { status: 410 });
+  }
+  return new Response(
+    JSON.stringify({ id: poll.id, question: poll.question, kind: poll.kind, options: poll.options }),
+    { headers: { 'Content-Type': 'application/json' } },
+  );
+};
+```
+
+- [ ] **Step 2: Create `website/src/pages/api/poll/[id]/answer.ts`**
+
+```typescript
+import type { APIRoute } from 'astro';
+import { getPoll, submitAnswer } from '../../../../../lib/poll-db';
+
+export const POST: APIRoute = async ({ request, params }) => {
+  const poll = await getPoll(params.id!);
+  if (!poll) {
+    return new Response(JSON.stringify({ error: 'not found' }), { status: 404 });
+  }
+  if (poll.status === 'locked') {
+    return new Response(JSON.stringify({ error: 'locked' }), { status: 409 });
+  }
+
+  let body: unknown;
+  try { body = await request.json(); } catch {
+    return new Response(JSON.stringify({ error: 'invalid JSON' }), { status: 400 });
+  }
+  const { answer } = (body ?? {}) as Record<string, unknown>;
+
+  if (!answer || typeof answer !== 'string' || answer.trim().length === 0) {
+    return new Response(JSON.stringify({ error: 'answer required' }), { status: 400 });
+  }
+  if (answer.trim().length > 1000) {
+    return new Response(JSON.stringify({ error: 'answer too long (max 1000 chars)' }), { status: 400 });
+  }
+  if (poll.kind === 'multiple_choice' && poll.options && !poll.options.includes(answer.trim())) {
+    return new Response(JSON.stringify({ error: 'invalid option' }), { status: 400 });
+  }
+
+  await submitAnswer(poll.id, answer.trim());
+  return new Response(JSON.stringify({ ok: true }), {
+    headers: { 'Content-Type': 'application/json' },
+  });
+};
+```
+
+- [ ] **Step 3: Create `website/src/pages/api/poll/[id]/results.ts`**
+
+```typescript
+import type { APIRoute } from 'astro';
+import { getResults } from '../../../../../lib/poll-db';
+
+export const GET: APIRoute = async ({ params }) => {
+  const results = await getResults(params.id!);
+  if (!results) {
+    return new Response(JSON.stringify({ error: 'not found' }), { status: 404 });
+  }
+  if (results.poll.status !== 'locked') {
+    return new Response(JSON.stringify({ error: 'results not available yet' }), { status: 403 });
+  }
+  return new Response(JSON.stringify(results), {
+    headers: { 'Content-Type': 'application/json' },
+  });
+};
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add website/src/pages/api/poll/
+git commit -m "feat(poll): add public poll API routes (get question, submit answer, get results)"
+```
+
+---
+
+## Task 7: Participant Page
+
+**Files:**
+- Create: `website/src/pages/poll/[id].astro`
+
+- [ ] **Step 1: Create `website/src/pages/poll/[id].astro`**
+
+```astro
+---
+import { getPoll } from '../../lib/poll-db';
+const { id } = Astro.params;
+const poll = await getPoll(id!);
+const isLocked = !poll || poll.status === 'locked';
+const resultsUrl = `/poll/${id}/results`;
+---
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Umfrage</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      background: #0b111c; color: #e8e4dc;
+      font-family: 'Geist', system-ui, sans-serif;
+      min-height: 100svh; display: flex; align-items: center;
+      justify-content: center; padding: 24px;
+    }
+    .card {
+      background: #131b2a; border-radius: 12px; padding: 32px;
+      max-width: 400px; width: 100%; text-align: center;
+    }
+    .eyebrow {
+      font-size: 11px; color: #9bc0a8; letter-spacing: 0.08em;
+      text-transform: uppercase; margin-bottom: 12px;
+    }
+    h1 {
+      font-size: 22px; font-weight: 600; line-height: 1.35;
+      margin-bottom: 24px; font-family: 'Newsreader', Georgia, serif;
+    }
+    .opt-btn {
+      display: block; width: 100%; padding: 14px;
+      border-radius: 8px; border: 1px solid #2a3547;
+      background: transparent; color: #e8e4dc; font-size: 15px;
+      cursor: pointer; margin-bottom: 10px;
+      text-align: center; transition: background 0.15s, border-color 0.15s;
+    }
+    .opt-btn:hover { background: #1e2d43; }
+    .opt-btn.selected { border-color: #d7b06a; color: #d7b06a; }
+    textarea {
+      width: 100%; background: #1a2538; border: 1px solid #2a3547;
+      border-radius: 8px; padding: 12px; color: #e8e4dc;
+      font-size: 14px; resize: vertical; min-height: 96px; font-family: inherit;
+    }
+    .submit-btn {
+      width: 100%; padding: 14px; border-radius: 8px; border: none;
+      background: #d7b06a; color: #0b111c; font-size: 15px;
+      font-weight: 600; cursor: pointer; margin-top: 12px;
+      transition: opacity 0.15s;
+    }
+    .submit-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+    .muted { font-size: 12px; color: #6b7a8f; margin-top: 16px; }
+    .big-icon { font-size: 48px; margin-bottom: 16px; }
+    .chosen-badge {
+      margin-top: 16px; padding: 10px 14px; border-radius: 8px;
+      border: 1px solid #2a3547; font-size: 13px;
+    }
+    a { color: #d7b06a; }
+  </style>
+</head>
+<body>
+  <div class="card" id="card">
+    {isLocked ? (
+      <>
+        <div class="big-icon">&#x1F512;</div>
+        <h1>Umfrage geschlossen</h1>
+        <p class="muted">Die Abstimmung wurde beendet.</p>
+        {poll && (
+          <p style="margin-top:16px"><a href={resultsUrl}>&#x2192; Ergebnisse ansehen</a></p>
+        )}
+      </>
+    ) : (
+      <>
+        <p class="eyebrow">Umfrage</p>
+        <h1>{poll!.question}</h1>
+        {poll!.kind === 'multiple_choice' ? (
+          <div id="mc-options">
+            {poll!.options!.map(opt => (
+              <button class="opt-btn" data-option={opt} type="button">{opt}</button>
+            ))}
+          </div>
+        ) : (
+          <textarea id="text-answer" placeholder="Ihre Antwort&#x2026;" maxlength="1000"></textarea>
+        )}
+        <button class="submit-btn" id="submit-btn" type="button" disabled>
+          Absenden
+        </button>
+        <p class="muted">Anonym &#xB7; Einmalig</p>
+      </>
+    )}
+  </div>
+
+  <script define:vars={{ pollId: id, pollKind: poll?.kind ?? 'text', isLocked }}>
+    function escText(s) {
+      const d = document.createElement('span');
+      d.textContent = s;
+      return d.textContent;
+    }
+
+    // Prevent duplicate submission in the same browser session
+    if (!isLocked && sessionStorage.getItem('poll_submitted_' + pollId)) {
+      const card = document.getElementById('card');
+      card.replaceChildren();
+      const icon = document.createElement('div');
+      icon.className = 'big-icon';
+      icon.textContent = '✅';
+      const msg = document.createElement('h1');
+      msg.style.cssText = 'font-size:18px;font-family:serif';
+      msg.textContent = 'Sie haben bereits abgestimmt.';
+      const sub = document.createElement('p');
+      sub.className = 'muted';
+      sub.textContent = 'Ihre Antwort wurde anonym erfasst.';
+      card.append(icon, msg, sub);
+    }
+
+    if (pollKind === 'text') {
+      const ta = document.getElementById('text-answer');
+      const btn = document.getElementById('submit-btn');
+      if (ta && btn) {
+        ta.addEventListener('input', () => { btn.disabled = ta.value.trim().length === 0; });
+      }
+    } else {
+      document.querySelectorAll('.opt-btn').forEach(btn => {
+        btn.addEventListener('click', () => {
+          document.querySelectorAll('.opt-btn').forEach(b => b.classList.remove('selected'));
+          btn.classList.add('selected');
+          document.getElementById('submit-btn').disabled = false;
+        });
+      });
+    }
+
+    document.getElementById('submit-btn')?.addEventListener('click', async () => {
+      const answer = pollKind === 'multiple_choice'
+        ? document.querySelector('.opt-btn.selected')?.dataset.option
+        : document.getElementById('text-answer')?.value.trim();
+      if (!answer) return;
+
+      const btn = document.getElementById('submit-btn');
+      btn.disabled = true;
+      btn.textContent = '…';
+
+      try {
+        const res = await fetch('/api/poll/' + pollId + '/answer', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ answer }),
+        });
+
+        if (res.ok) {
+          sessionStorage.setItem('poll_submitted_' + pollId, '1');
+          const card = document.getElementById('card');
+          card.replaceChildren();
+
+          const icon = document.createElement('div');
+          icon.className = 'big-icon';
+          icon.textContent = '✅';
+
+          const heading = document.createElement('h1');
+          heading.style.cssText = 'font-size:18px;font-family:serif';
+          heading.textContent = 'Danke für Ihre Antwort!';
+
+          const sub = document.createElement('p');
+          sub.className = 'muted';
+          sub.textContent = 'Ihre Antwort wurde anonym erfasst. Der Moderator teilt die Ergebnisse mit der Gruppe.';
+
+          const badge = document.createElement('div');
+          badge.className = 'chosen-badge';
+          badge.textContent = 'Sie haben gewählt: ';
+          const strong = document.createElement('strong');
+          strong.style.color = '#d7b06a';
+          strong.textContent = pollKind === 'multiple_choice' ? answer : 'Ihre Antwort';
+          badge.appendChild(strong);
+
+          card.append(icon, heading, sub, badge);
+        } else if (res.status === 409) {
+          const card = document.getElementById('card');
+          card.replaceChildren();
+          const icon = document.createElement('div');
+          icon.className = 'big-icon';
+          icon.textContent = '\u{1F512}';
+          const msg = document.createElement('h1');
+          msg.style.cssText = 'font-size:18px;font-family:serif';
+          msg.textContent = 'Umfrage geschlossen';
+          card.append(icon, msg);
+        } else {
+          btn.disabled = false;
+          btn.textContent = 'Absenden';
+          alert('Fehler beim Absenden. Bitte versuchen Sie es erneut.');
+        }
+      } catch {
+        btn.disabled = false;
+        btn.textContent = 'Absenden';
+        alert('Netzwerkfehler. Bitte versuchen Sie es erneut.');
+      }
+    });
+  </script>
+</body>
+</html>
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add website/src/pages/poll/
+git commit -m "feat(poll): add participant response page /poll/[id]"
+```
+
+---
+
+## Task 8: Results Page
+
+**Files:**
+- Create: `website/src/pages/poll/[id]/results.astro`
+
+- [ ] **Step 1: Create `website/src/pages/poll/[id]/results.astro`**
+
+```astro
+---
+import { getResults } from '../../../lib/poll-db';
+const { id } = Astro.params;
+const results = await getResults(id!);
+if (!results || results.poll.status !== 'locked') {
+  return Astro.redirect('/');
+}
+const { poll, total, counts } = results;
+---
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Ergebnis &#x2013; {poll.question}</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      background: #0b111c; color: #e8e4dc;
+      font-family: 'Geist', system-ui, sans-serif;
+      min-height: 100svh; display: flex; align-items: center;
+      justify-content: center; padding: 24px;
+    }
+    .card {
+      background: #131b2a; border-radius: 12px; padding: 32px;
+      max-width: 480px; width: 100%;
+    }
+    .eyebrow {
+      font-size: 11px; color: #9bc0a8; letter-spacing: 0.08em;
+      text-transform: uppercase; margin-bottom: 10px; text-align: center;
+    }
+    h1 {
+      font-size: 22px; font-weight: 600; line-height: 1.35; margin-bottom: 6px;
+      font-family: 'Newsreader', Georgia, serif; text-align: center;
+    }
+    .meta { font-size: 12px; color: #6b7a8f; text-align: center; margin-bottom: 24px; }
+    .bar-row { display: flex; align-items: center; gap: 10px; margin-bottom: 12px; font-size: 14px; }
+    .bar-label { width: 140px; flex-shrink: 0; }
+    .bar-track { flex: 1; background: #1e2d43; border-radius: 4px; height: 12px; }
+    .bar-fill { height: 100%; background: #d7b06a; border-radius: 4px; }
+    .bar-count { width: 36px; text-align: right; color: #6b7a8f; }
+    .answer-card {
+      background: #1a2538; border-radius: 8px; padding: 12px 14px;
+      font-size: 14px; line-height: 1.5; margin-bottom: 8px;
+    }
+    .footer {
+      font-size: 11px; color: #6b7a8f; text-align: center;
+      margin-top: 20px; padding-top: 16px; border-top: 1px solid #1e2d43;
+    }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <p class="eyebrow">Umfrageergebnis</p>
+    <h1>{poll.question}</h1>
+    <p class="meta">{total} Antworten &#xB7; abgeschlossen</p>
+
+    {poll.kind === 'multiple_choice' ? (
+      <div>
+        {counts.map(c => (
+          <div class="bar-row">
+            <span class="bar-label">{c.answer}</span>
+            <div class="bar-track">
+              <div
+                class="bar-fill"
+                style={`width:${total > 0 ? Math.round(c.count / total * 100) : 0}%`}
+              ></div>
+            </div>
+            <span class="bar-count">{c.count}</span>
+          </div>
+        ))}
+      </div>
+    ) : (
+      <div>
+        {counts.map(c => (
+          <div class="answer-card">&#x201E;{c.answer}&#x201C;</div>
+        ))}
+      </div>
+    )}
+
+    <p class="footer">Antworten waren anonym</p>
+  </div>
+</body>
+</html>
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add website/src/pages/poll/
+git commit -m "feat(poll): add public results page /poll/[id]/results"
+```
+
+---
+
+## Task 9: Admin UI — Meetings Page
+
+**Files:**
+- Modify: `website/src/pages/admin/meetings.astro`
+
+This task adds to the existing page: a poll button, a creation modal, a live status panel, and a QR code sub-modal.
+
+- [ ] **Step 1: Import POLL_TEMPLATES in the frontmatter**
+
+In the frontmatter of `website/src/pages/admin/meetings.astro`, add this import alongside the existing ones:
+
+```typescript
+import { POLL_TEMPLATES } from '../../lib/poll-db';
+```
+
+After the existing `const meetings = await listAllMeetings();` line, add:
+
+```typescript
+const pollTemplatesJson = JSON.stringify(POLL_TEMPLATES);
+```
+
+- [ ] **Step 2: Add "Umfrage starten" button**
+
+Find the existing `<button id="btn-brett"` element in the HTML. Add the following button immediately after it:
+
+```html
+<button id="btn-poll"
+  class="px-3 py-1.5 text-sm rounded bg-surface border border-border hover:border-accent transition-colors"
+  title="Umfrage in alle laufenden Talk-Calls posten">
+  &#x1F4CA; Umfrage starten
+</button>
+```
+
+- [ ] **Step 3: Add modals and status panel HTML**
+
+Add the following after the closing `</div>` of the existing `brett-modal` div:
+
+```html
+<!-- ── Poll Creation Modal ──────────────────────────────────────── -->
+<div id="poll-modal"
+  class="hidden fixed inset-0 bg-black/60 flex items-center justify-center z-50 p-4">
+  <div class="bg-surface rounded-xl p-6 w-full max-w-lg shadow-xl">
+    <h2 class="text-xl font-serif text-light mb-2">&#x1F4CA; Umfrage starten</h2>
+    <p class="text-sm text-muted mb-4">Frage w&#xE4;hlen und in alle aktiven Calls posten.</p>
+    <div id="poll-template-list" class="flex flex-col gap-2 mb-4"></div>
+    <div id="poll-custom-wrap" class="hidden mb-4">
+      <label class="block text-xs text-muted mb-1 uppercase tracking-wide">Eigene Frage</label>
+      <input id="poll-custom-question" type="text" maxlength="200"
+        class="w-full bg-bg border border-border rounded-lg px-3 py-2 text-sm focus:outline-none focus:border-accent"
+        placeholder="Ihre Frage&#x2026;" />
+    </div>
+    <div id="poll-modal-result" class="hidden mb-4 text-sm text-amber-400"></div>
+    <div class="flex gap-2 justify-end">
+      <button id="poll-modal-cancel"
+        class="px-4 py-2 text-sm rounded border border-border text-muted hover:text-light transition-colors">
+        Abbrechen
+      </button>
+      <button id="poll-modal-confirm" disabled
+        class="px-4 py-2 text-sm rounded bg-accent text-dark font-medium disabled:opacity-40 disabled:cursor-not-allowed">
+        &#x1F4CA; Umfrage starten
+      </button>
+    </div>
+  </div>
+</div>
+
+<!-- ── Poll Status Panel ────────────────────────────────────────── -->
+<div id="poll-status-panel" class="hidden mt-4">
+  <div class="bg-surface rounded-xl p-4 border border-border">
+    <div class="flex items-start justify-between mb-3">
+      <div>
+        <span class="text-xs text-muted uppercase tracking-wide">Aktive Umfrage</span>
+        <p id="poll-status-question" class="font-serif text-light mt-0.5 text-sm"></p>
+      </div>
+      <span id="poll-status-count" class="text-sm text-muted ml-4 flex-shrink-0"></span>
+    </div>
+    <div id="poll-status-bars" class="flex flex-col gap-2 mb-4 text-sm"></div>
+    <div class="flex gap-2 justify-end">
+      <button id="poll-qr-btn"
+        class="px-3 py-1.5 text-sm rounded border border-border text-muted hover:text-light transition-colors">
+        QR-Code zeigen
+      </button>
+      <button id="poll-share-btn"
+        class="px-3 py-1.5 text-sm rounded bg-accent text-dark font-medium hover:opacity-90 transition-opacity">
+        &#x1F4E4; Ergebnisse teilen &amp; schlie&#xDF;en
+      </button>
+    </div>
+    <p id="poll-status-msg" class="hidden text-sm text-muted mt-2 text-right"></p>
+  </div>
+</div>
+
+<!-- ── QR Code Modal ────────────────────────────────────────────── -->
+<div id="qr-modal"
+  class="hidden fixed inset-0 bg-black/60 flex items-center justify-center z-50 p-4">
+  <div class="bg-surface rounded-xl p-6 text-center shadow-xl">
+    <p class="text-sm text-muted mb-4">Teilnehmer scannen diesen Code:</p>
+    <canvas id="qr-canvas" class="mx-auto rounded-lg"></canvas>
+    <p id="qr-url" class="text-xs text-muted mt-3 break-all max-w-xs mx-auto"></p>
+    <button id="qr-close"
+      class="mt-4 px-4 py-2 text-sm rounded border border-border text-muted hover:text-light transition-colors">
+      Schlie&#xDF;en
+    </button>
+  </div>
+</div>
+
+<!-- Templates data island (avoids passing complex objects through define:vars) -->
+<script id="poll-templates-data" type="application/json" set:html={pollTemplatesJson}></script>
+```
+
+- [ ] **Step 4: Add poll JavaScript inside the existing script block**
+
+In the existing `<script>` block at the bottom of the page, append the following after the last line of the brett JavaScript:
+
+```javascript
+// ─── Poll ────────────────────────────────────────────────────────────────────
+const POLL_TEMPLATES_DATA = JSON.parse(
+  document.getElementById('poll-templates-data').textContent
+);
+
+const btnPoll            = document.getElementById('btn-poll');
+const pollModal          = document.getElementById('poll-modal');
+const pollModalCancel    = document.getElementById('poll-modal-cancel');
+const pollModalConfirm   = document.getElementById('poll-modal-confirm');
+const pollModalResult    = document.getElementById('poll-modal-result');
+const pollCustomWrap     = document.getElementById('poll-custom-wrap');
+const pollCustomQ        = document.getElementById('poll-custom-question');
+const pollTemplateList   = document.getElementById('poll-template-list');
+const pollStatusPanel    = document.getElementById('poll-status-panel');
+const pollStatusQuestion = document.getElementById('poll-status-question');
+const pollStatusCount    = document.getElementById('poll-status-count');
+const pollStatusBars     = document.getElementById('poll-status-bars');
+const pollStatusMsg      = document.getElementById('poll-status-msg');
+const pollShareBtn       = document.getElementById('poll-share-btn');
+const pollQrBtn          = document.getElementById('poll-qr-btn');
+const qrModal            = document.getElementById('qr-modal');
+const qrCanvas           = document.getElementById('qr-canvas');
+const qrUrl              = document.getElementById('qr-url');
+const qrClose            = document.getElementById('qr-close');
+
+let activePollId     = null;
+let pollRefreshTimer = null;
+
+function escText(s) {
+  const el = document.createElement('span');
+  el.textContent = String(s);
+  return el.textContent;
+}
+
+function renderTemplatePicker() {
+  pollTemplateList.replaceChildren();
+  POLL_TEMPLATES_DATA.forEach((t, i) => {
+    const label = document.createElement('label');
+    label.className =
+      'flex items-center gap-3 cursor-pointer px-3 py-2 rounded-lg border border-border hover:border-accent/50 transition-colors text-sm';
+    const radio = document.createElement('input');
+    radio.type = 'radio';
+    radio.name = 'poll-template';
+    radio.value = String(i);
+    radio.className = 'accent-[#d7b06a]';
+    const text = document.createElement('span');
+    const strong = document.createElement('strong');
+    strong.textContent = t.label;
+    text.appendChild(strong);
+    const sub = document.createElement('span');
+    sub.className = 'text-muted ml-1';
+    sub.textContent = t.options ? ' ' + t.options.join(' · ') : ' Freitext';
+    text.appendChild(sub);
+    label.append(radio, text);
+    pollTemplateList.appendChild(label);
+  });
+
+  // "Eigene Frage" option
+  const customLabel = document.createElement('label');
+  customLabel.className =
+    'flex items-center gap-3 cursor-pointer px-3 py-2 rounded-lg border border-border hover:border-accent/50 transition-colors text-sm';
+  const customRadio = document.createElement('input');
+  customRadio.type = 'radio';
+  customRadio.name = 'poll-template';
+  customRadio.value = 'custom';
+  customRadio.className = 'accent-[#d7b06a]';
+  const customText = document.createElement('span');
+  const customStrong = document.createElement('strong');
+  customStrong.style.color = '#d7b06a';
+  customStrong.textContent = 'Eigene Frage…';
+  const customSub = document.createElement('span');
+  customSub.className = 'text-muted ml-1';
+  customSub.textContent = ' Freitext-Antwort';
+  customText.append(customStrong, customSub);
+  customLabel.append(customRadio, customText);
+  pollTemplateList.appendChild(customLabel);
+
+  pollTemplateList.querySelectorAll('input[type=radio]').forEach(radio => {
+    radio.addEventListener('change', () => {
+      const isCustom = radio.value === 'custom';
+      pollCustomWrap.classList.toggle('hidden', !isCustom);
+      if (isCustom) {
+        pollModalConfirm.disabled = pollCustomQ.value.trim().length < 2;
+      } else {
+        pollModalConfirm.disabled = false;
+      }
+    });
+  });
+
+  pollCustomQ.addEventListener('input', () => {
+    const sel = pollTemplateList.querySelector('input[name=poll-template]:checked');
+    if (sel?.value === 'custom') {
+      pollModalConfirm.disabled = pollCustomQ.value.trim().length < 2;
+    }
+  });
+}
+
+function renderStatusBars(results) {
+  pollStatusBars.replaceChildren();
+  if (!results) return;
+  const { poll, total, counts } = results;
+  pollStatusCount.textContent = total + ' Antwort' + (total !== 1 ? 'en' : '');
+
+  if (poll.kind === 'multiple_choice') {
+    counts.forEach(c => {
+      const pct = total > 0 ? Math.round(c.count / total * 100) : 0;
+      const row = document.createElement('div');
+      row.className = 'flex items-center gap-2';
+
+      const lbl = document.createElement('span');
+      lbl.className = 'w-28 flex-shrink-0 truncate';
+      lbl.textContent = c.answer;
+
+      const track = document.createElement('div');
+      track.className = 'flex-1 bg-bg rounded h-2';
+      const fill = document.createElement('div');
+      fill.className = 'h-full bg-accent rounded';
+      fill.style.width = pct + '%';
+      track.appendChild(fill);
+
+      const cnt = document.createElement('span');
+      cnt.className = 'w-6 text-right text-muted';
+      cnt.textContent = String(c.count);
+
+      row.append(lbl, track, cnt);
+      pollStatusBars.appendChild(row);
+    });
+  } else {
+    const p = document.createElement('p');
+    p.className = 'text-muted text-xs';
+    p.textContent = total + ' Freitext-Antwort' + (total !== 1 ? 'en' : '') + ' eingegangen';
+    pollStatusBars.appendChild(p);
+  }
+}
+
+async function refreshPollStatus() {
+  if (!activePollId) return;
+  try {
+    const res = await fetch('/api/admin/poll/' + activePollId);
+    if (!res.ok) { stopPollRefresh(); return; }
+    renderStatusBars(await res.json());
+  } catch { /* ignore transient errors */ }
+}
+
+function startPollRefresh(id) {
+  activePollId = id;
+  stopPollRefresh();
+  pollRefreshTimer = setInterval(refreshPollStatus, 5000);
+}
+
+function stopPollRefresh() {
+  if (pollRefreshTimer) { clearInterval(pollRefreshTimer); pollRefreshTimer = null; }
+}
+
+function showStatusPanel(poll, results) {
+  btnPoll.classList.add('hidden');
+  pollStatusQuestion.textContent = poll.question;
+  renderStatusBars(results);
+  pollStatusPanel.classList.remove('hidden');
+  startPollRefresh(poll.id);
+}
+
+function hidePollModal() {
+  pollModal.classList.add('hidden');
+  pollModalResult.classList.add('hidden');
+  pollModalConfirm.disabled = true;
+  pollTemplateList.querySelectorAll('input[type=radio]').forEach(r => { r.checked = false; });
+  pollCustomWrap.classList.add('hidden');
+  pollCustomQ.value = '';
+  pollModalConfirm.textContent = '\u{1F4CA} Umfrage starten';
+}
+
+// Check for existing active poll on page load
+(async () => {
+  try {
+    const res = await fetch('/api/admin/poll/active');
+    if (!res.ok) return;
+    const { poll, results } = await res.json();
+    if (poll) showStatusPanel(poll, results);
+  } catch { /* no active poll or network error */ }
+})();
+
+btnPoll.addEventListener('click', () => {
+  renderTemplatePicker();
+  pollModal.classList.remove('hidden');
+});
+
+pollModalCancel.addEventListener('click', hidePollModal);
+
+pollModalConfirm.addEventListener('click', async () => {
+  const selected = pollTemplateList.querySelector('input[name=poll-template]:checked');
+  if (!selected) return;
+
+  let question, kind, options;
+  if (selected.value === 'custom') {
+    question = pollCustomQ.value.trim();
+    kind = 'text';
+    options = null;
+  } else {
+    const tpl = POLL_TEMPLATES_DATA[parseInt(selected.value, 10)];
+    question = tpl.question;
+    kind = tpl.kind;
+    options = tpl.options;
+  }
+
+  pollModalConfirm.disabled = true;
+  pollModalConfirm.textContent = '…';
+
+  try {
+    const res = await fetch('/api/admin/poll', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ question, kind, options }),
+    });
+    const data = await res.json();
+    if (res.ok) {
+      hidePollModal();
+      showStatusPanel(data.poll, null);
+      if (data.total === 0) {
+        pollStatusMsg.textContent =
+          'Keine aktiven Calls – Umfrage erstellt, aber nicht gepostet.';
+        pollStatusMsg.classList.remove('hidden');
+      } else if (data.sent < data.total) {
+        pollStatusMsg.textContent =
+          '⚠ ' + data.sent + '/' + data.total + ' Calls erreicht.';
+        pollStatusMsg.classList.remove('hidden');
+      }
+    } else if (res.status === 409) {
+      pollModalResult.textContent = 'Es läuft bereits eine Umfrage.';
+      pollModalResult.classList.remove('hidden');
+      pollModalConfirm.disabled = false;
+      pollModalConfirm.textContent = '\u{1F4CA} Umfrage starten';
+    } else {
+      pollModalResult.textContent = 'Fehler: ' + escText(data.error ?? 'Unbekannt');
+      pollModalResult.classList.remove('hidden');
+      pollModalConfirm.disabled = false;
+      pollModalConfirm.textContent = '\u{1F4CA} Umfrage starten';
+    }
+  } catch {
+    pollModalResult.textContent = 'Netzwerkfehler. Bitte erneut versuchen.';
+    pollModalResult.classList.remove('hidden');
+    pollModalConfirm.disabled = false;
+    pollModalConfirm.textContent = '\u{1F4CA} Umfrage starten';
+  }
+});
+
+pollShareBtn.addEventListener('click', async () => {
+  if (!activePollId) return;
+  pollShareBtn.disabled = true;
+  pollShareBtn.textContent = '…';
+  stopPollRefresh();
+
+  try {
+    const res = await fetch('/api/admin/poll/' + activePollId + '/share', { method: 'POST' });
+    const data = await res.json();
+    if (res.ok) {
+      pollStatusMsg.textContent =
+        '✓ Ergebnisse an ' + data.sent + ' Call(s) gesendet.';
+      pollStatusMsg.classList.remove('hidden');
+      pollShareBtn.classList.add('hidden');
+      pollQrBtn.classList.add('hidden');
+    } else {
+      pollStatusMsg.textContent = 'Fehler: ' + escText(data.error ?? 'Unbekannt');
+      pollStatusMsg.classList.remove('hidden');
+      pollShareBtn.disabled = false;
+      pollShareBtn.textContent =
+        '\u{1F4E4} Ergebnisse teilen & schließen';
+    }
+  } catch {
+    pollStatusMsg.textContent = 'Netzwerkfehler.';
+    pollStatusMsg.classList.remove('hidden');
+    pollShareBtn.disabled = false;
+    pollShareBtn.textContent =
+      '\u{1F4E4} Ergebnisse teilen & schließen';
+  }
+});
+
+pollQrBtn.addEventListener('click', async () => {
+  if (!activePollId) return;
+  const url = location.origin + '/poll/' + activePollId;
+  qrUrl.textContent = url;
+  qrModal.classList.remove('hidden');
+  const { default: QRCode } = await import('qrcode');
+  await QRCode.toCanvas(qrCanvas, url, {
+    width: 256, margin: 2,
+    color: { dark: '#0b111c', light: '#e8e4dc' },
+  });
+});
+
+qrClose.addEventListener('click', () => qrModal.classList.add('hidden'));
+```
+
+- [ ] **Step 5: Check TypeScript**
+
+```bash
+cd website && npx astro check 2>&1 | grep -E "^.*error" | head -20
+```
+
+Expected: no new type errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add website/src/pages/admin/meetings.astro
+git commit -m "feat(poll): add poll UI to admin/meetings — modal, status panel, QR modal"
+```
+
+---
+
+## Task 10: End-to-End Smoke Test
+
+Manual verification after `task workspace:deploy`.
+
+- [ ] **Step 1: Verify tables exist**
+
+```bash
+task workspace:psql -- website
+```
+
+Then in psql:
+```sql
+\dt polls
+\dt poll_answers
+\q
+```
+
+Expected: both tables listed with correct column counts.
+
+- [ ] **Step 2: Create a poll from the admin UI**
+
+1. Log in as admin at `https://web.localhost/admin/meetings`
+2. Click "📊 Umfrage starten"
+3. Select "Wie fühlen Sie sich gerade?" → click confirm
+4. Expected: modal closes, status panel appears showing "0 Antworten" and the bar chart
+
+- [ ] **Step 3: Submit answers as participants**
+
+Open `https://web.localhost/poll/<id>` in two different browser profiles.
+Select different options and submit. Expected: admin status panel updates within 5 seconds.
+
+- [ ] **Step 4: Verify QR modal**
+
+Click "QR-Code zeigen". Expected: dark QR code canvas renders. Scanning it opens the participant page.
+
+- [ ] **Step 5: Participant page after already voted**
+
+Reload the participant page in a browser that already submitted. Expected: "Sie haben bereits abgestimmt." (sessionStorage check fires before rendering the form).
+
+- [ ] **Step 6: Share results**
+
+Click "📤 Ergebnisse teilen & schließen". Expected:
+- Status message: "✓ Ergebnisse an X Call(s) gesendet."
+- Share and QR buttons disappear
+- `https://web.localhost/poll/<id>/results` shows bar chart with votes
+- `https://web.localhost/poll/<id>` shows "Umfrage geschlossen" with link to results
+
+- [ ] **Step 7: Late submission rejected**
+
+Attempt `POST /api/poll/<id>/answer` after locking. Expected: `409 Conflict`.
+
+- [ ] **Step 8: Open PR**
+
+```bash
+git log main..HEAD --oneline
+gh pr create \
+  --title "feat(poll): live anonymous poll broadcast via Talk bot" \
+  --body "$(cat <<'EOF'
+## Summary
+- Admin creates one-shot polls from 5 predefined templates (or custom question) and broadcasts the link to all active Talk calls via the brett bot
+- Anonymous participants scan a QR code or open the link, answer MC or free-text questions; one answer per browser session via sessionStorage
+- Admin sees live answer counts with 5s auto-refresh; clicking Ergebnisse teilen locks the poll and posts aggregated results back to Talk with a public results URL
+- Two new DB tables (polls, poll_answers), one new lib module (poll-db.ts), 6 new API routes, 2 new public pages, qrcode npm dependency; no new k8s resources
+
+## Test plan
+- [ ] Apply schema, verify polls + poll_answers tables exist
+- [ ] Create poll from admin/meetings, verify status panel and QR modal render
+- [ ] Submit answers from multiple browser profiles, verify live count updates
+- [ ] Share results: verify bot message format and /poll/[id]/results page
+- [ ] Verify 409 on late answer submission after locking
+
+Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```

--- a/k3d/website-schema.yaml
+++ b/k3d/website-schema.yaml
@@ -295,13 +295,15 @@ data:
           status      TEXT NOT NULL DEFAULT 'open' CHECK (status IN ('open', 'locked')),
           room_tokens TEXT[] NOT NULL DEFAULT '{}',
           created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
-          locked_at   TIMESTAMPTZ
+          locked_at   TIMESTAMPTZ,
+          CONSTRAINT polls_mc_options_not_null
+              CHECK (kind != 'multiple_choice' OR options IS NOT NULL)
       );
 
       CREATE TABLE IF NOT EXISTS poll_answers (
           id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
           poll_id      UUID NOT NULL REFERENCES polls(id) ON DELETE CASCADE,
-          answer       TEXT NOT NULL,
+          answer       TEXT NOT NULL CHECK (char_length(answer) <= 1000),
           submitted_at TIMESTAMPTZ NOT NULL DEFAULT now()
       );
 
@@ -594,13 +596,15 @@ data:
           status      TEXT NOT NULL DEFAULT 'open' CHECK (status IN ('open', 'locked')),
           room_tokens TEXT[] NOT NULL DEFAULT '{}',
           created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
-          locked_at   TIMESTAMPTZ
+          locked_at   TIMESTAMPTZ,
+          CONSTRAINT polls_mc_options_not_null
+              CHECK (kind != 'multiple_choice' OR options IS NOT NULL)
       );
 
       CREATE TABLE IF NOT EXISTS poll_answers (
           id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
           poll_id      UUID NOT NULL REFERENCES polls(id) ON DELETE CASCADE,
-          answer       TEXT NOT NULL,
+          answer       TEXT NOT NULL CHECK (char_length(answer) <= 1000),
           submitted_at TIMESTAMPTZ NOT NULL DEFAULT now()
       );
 

--- a/k3d/website-schema.yaml
+++ b/k3d/website-schema.yaml
@@ -285,6 +285,29 @@ data:
       ALTER TABLE meetings
           ADD COLUMN IF NOT EXISTS brett_link_posted_at TIMESTAMPTZ;
 
+      -- ── Live Poll System ──────────────────────────────────────────
+
+      CREATE TABLE IF NOT EXISTS polls (
+          id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+          question    TEXT NOT NULL,
+          kind        TEXT NOT NULL CHECK (kind IN ('multiple_choice', 'text')),
+          options     TEXT[],
+          status      TEXT NOT NULL DEFAULT 'open' CHECK (status IN ('open', 'locked')),
+          room_tokens TEXT[] NOT NULL DEFAULT '{}',
+          created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+          locked_at   TIMESTAMPTZ
+      );
+
+      CREATE TABLE IF NOT EXISTS poll_answers (
+          id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+          poll_id      UUID NOT NULL REFERENCES polls(id) ON DELETE CASCADE,
+          answer       TEXT NOT NULL,
+          submitted_at TIMESTAMPTZ NOT NULL DEFAULT now()
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_poll_answers_poll
+          ON poll_answers(poll_id, submitted_at DESC);
+
       -- Grant full access to the website user
       GRANT ALL ON ALL TABLES IN SCHEMA public TO website;
       GRANT ALL ON ALL SEQUENCES IN SCHEMA public TO website;
@@ -560,6 +583,29 @@ data:
       -- Idempotency for auto-post on Talk-roomed meeting creation.
       ALTER TABLE meetings
           ADD COLUMN IF NOT EXISTS brett_link_posted_at TIMESTAMPTZ;
+
+      -- ── Live Poll System ──────────────────────────────────────────
+
+      CREATE TABLE IF NOT EXISTS polls (
+          id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+          question    TEXT NOT NULL,
+          kind        TEXT NOT NULL CHECK (kind IN ('multiple_choice', 'text')),
+          options     TEXT[],
+          status      TEXT NOT NULL DEFAULT 'open' CHECK (status IN ('open', 'locked')),
+          room_tokens TEXT[] NOT NULL DEFAULT '{}',
+          created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+          locked_at   TIMESTAMPTZ
+      );
+
+      CREATE TABLE IF NOT EXISTS poll_answers (
+          id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+          poll_id      UUID NOT NULL REFERENCES polls(id) ON DELETE CASCADE,
+          answer       TEXT NOT NULL,
+          submitted_at TIMESTAMPTZ NOT NULL DEFAULT now()
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_poll_answers_poll
+          ON poll_answers(poll_id, submitted_at DESC);
 
       GRANT ALL ON ALL TABLES IN SCHEMA public TO website;
       GRANT ALL ON ALL SEQUENCES IN SCHEMA public TO website;

--- a/k3d/website-schema.yaml
+++ b/k3d/website-schema.yaml
@@ -310,6 +310,9 @@ data:
       CREATE INDEX IF NOT EXISTS idx_poll_answers_poll
           ON poll_answers(poll_id, submitted_at DESC);
 
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_polls_one_open
+          ON polls ((true)) WHERE status = 'open';
+
       -- Grant full access to the website user
       GRANT ALL ON ALL TABLES IN SCHEMA public TO website;
       GRANT ALL ON ALL SEQUENCES IN SCHEMA public TO website;
@@ -610,6 +613,9 @@ data:
 
       CREATE INDEX IF NOT EXISTS idx_poll_answers_poll
           ON poll_answers(poll_id, submitted_at DESC);
+
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_polls_one_open
+          ON polls ((true)) WHERE status = 'open';
 
       GRANT ALL ON ALL TABLES IN SCHEMA public TO website;
       GRANT ALL ON ALL SEQUENCES IN SCHEMA public TO website;

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -19,12 +19,14 @@
         "astro": "^5.7.0",
         "nodemailer": "^8.0.4",
         "pg": "^8.20.0",
+        "qrcode": "^1.5.4",
         "stripe": "^22.0.1",
         "svelte": "^5.0.0"
       },
       "devDependencies": {
         "@tailwindcss/vite": "^4.1.0",
         "@types/nodemailer": "^7.0.11",
+        "@types/qrcode": "^1.5.6",
         "tailwindcss": "^4.1.0",
         "typescript": "^5.9.3"
       }
@@ -2158,6 +2160,16 @@
         "pg-types": "^2.2.0"
       }
     },
+    "node_modules/@types/qrcode": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/@types/qrcode/-/qrcode-1.5.6.tgz",
+      "integrity": "sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
@@ -2960,6 +2972,15 @@
         }
       }
     },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/decode-named-character-reference": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
@@ -3067,6 +3088,12 @@
       "engines": {
         "node": ">=0.3.1"
       }
+    },
+    "node_modules/dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
+      "license": "MIT"
     },
     "node_modules/dlv": {
       "version": "1.1.3",
@@ -3370,6 +3397,19 @@
         "picomatch": {
           "optional": true
         }
+      }
+    },
+    "node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/flattie": {
@@ -4109,6 +4149,18 @@
       "resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
       "integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==",
       "license": "MIT"
+    },
+    "node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/longest-streak": {
       "version": "3.1.0",
@@ -5142,6 +5194,33 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-locate/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/p-queue": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-8.1.1.tgz",
@@ -5168,6 +5247,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/package-manager-detector": {
@@ -5211,6 +5299,15 @@
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
       "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
       "license": "MIT"
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/pg": {
       "version": "8.20.0",
@@ -5323,6 +5420,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/postcss": {
@@ -5446,6 +5552,154 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/qrcode": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "dijkstrajs": "^1.0.1",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "qrcode": "bin/qrcode"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/qrcode/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/qrcode/node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/qrcode/node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "node_modules/qrcode/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/qrcode/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "license": "ISC"
+    },
+    "node_modules/qrcode/node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/radix3": {
@@ -5666,6 +5920,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "license": "ISC"
+    },
     "node_modules/retext": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/retext/-/retext-9.0.0.tgz",
@@ -5828,6 +6088,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/server-destroy/-/server-destroy-1.0.1.tgz",
       "integrity": "sha512-rb+9B5YBIEzYcD6x2VKidaa+cqYBJQKnU4oe4E3ANwRRN56yk/ua1YCJT1n21NTS8w6CcOclAKNP3PhdCXKYtQ==",
+      "license": "ISC"
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
       "license": "ISC"
     },
     "node_modules/setprototypeof": {
@@ -7355,6 +7621,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "license": "ISC"
     },
     "node_modules/which-pm-runs": {
       "version": "1.1.0",

--- a/website/package.json
+++ b/website/package.json
@@ -23,12 +23,14 @@
     "astro": "^5.7.0",
     "nodemailer": "^8.0.4",
     "pg": "^8.20.0",
+    "qrcode": "^1.5.4",
     "stripe": "^22.0.1",
     "svelte": "^5.0.0"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.1.0",
     "@types/nodemailer": "^7.0.11",
+    "@types/qrcode": "^1.5.6",
     "tailwindcss": "^4.1.0",
     "typescript": "^5.9.3"
   }

--- a/website/src/lib/poll-db.test.ts
+++ b/website/src/lib/poll-db.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { POLL_TEMPLATES, buildResultsBotMessage } from './poll-db.js';
+import { POLL_TEMPLATES, buildResultsBotMessage } from './poll-db';
 
 test('POLL_TEMPLATES: has 5 entries', () => {
   assert.equal(POLL_TEMPLATES.length, 5);

--- a/website/src/lib/poll-db.test.ts
+++ b/website/src/lib/poll-db.test.ts
@@ -1,0 +1,58 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { POLL_TEMPLATES, buildResultsBotMessage } from './poll-db.js';
+
+test('POLL_TEMPLATES: has 5 entries', () => {
+  assert.equal(POLL_TEMPLATES.length, 5);
+});
+
+test('POLL_TEMPLATES: all MC templates have >= 2 options', () => {
+  for (const t of POLL_TEMPLATES) {
+    if (t.kind === 'multiple_choice') {
+      assert.ok(
+        Array.isArray(t.options) && t.options.length >= 2,
+        `${t.label} must have >= 2 options`,
+      );
+    }
+  }
+});
+
+test('POLL_TEMPLATES: text template has null options', () => {
+  const text = POLL_TEMPLATES.find(t => t.kind === 'text');
+  assert.ok(text, 'should have at least one text template');
+  assert.equal(text.options, null);
+});
+
+test('buildResultsBotMessage: MC format includes question, counts, and URL', () => {
+  const results = {
+    poll: {
+      id: 'abc', question: 'Wie geht es?', kind: 'multiple_choice' as const,
+      options: ['Gut', 'Mittel'], status: 'locked' as const,
+      room_tokens: [], created_at: new Date(), locked_at: new Date(),
+    },
+    total: 7,
+    counts: [{ answer: 'Gut', count: 5 }, { answer: 'Mittel', count: 2 }],
+  };
+  const msg = buildResultsBotMessage(results, 'https://web.example.com/poll/abc/results');
+  assert.ok(msg.includes('Wie geht es?'), 'should include question');
+  assert.ok(msg.includes('Gut: 5'), 'should include Gut count');
+  assert.ok(msg.includes('Mittel: 2'), 'should include Mittel count');
+  assert.ok(msg.includes('https://web.example.com/poll/abc/results'), 'should include URL');
+});
+
+test('buildResultsBotMessage: text format includes total and URL, not option breakdown', () => {
+  const results = {
+    poll: {
+      id: 'xyz', question: 'Was nehmen Sie mit?', kind: 'text' as const,
+      options: null, status: 'locked' as const,
+      room_tokens: [], created_at: new Date(), locked_at: new Date(),
+    },
+    total: 4,
+    counts: [{ answer: 'Fokus', count: 3 }, { answer: 'Pausen', count: 1 }],
+  };
+  const msg = buildResultsBotMessage(results, 'https://web.example.com/poll/xyz/results');
+  assert.ok(msg.includes('Was nehmen Sie mit?'), 'should include question');
+  assert.ok(msg.includes('4 Antworten'), 'should include total count');
+  assert.ok(msg.includes('https://web.example.com/poll/xyz/results'), 'should include URL');
+  assert.ok(!msg.includes('Fokus: 3'), 'should NOT list individual text answers');
+});

--- a/website/src/lib/poll-db.ts
+++ b/website/src/lib/poll-db.ts
@@ -1,0 +1,177 @@
+import pg from 'pg';
+import { resolve4 } from 'dns';
+const { Pool } = pg;
+
+const DB_URL = process.env.SESSIONS_DATABASE_URL
+  || 'postgresql://website:devwebsitedb@shared-db.workspace.svc.cluster.local:5432/website';
+
+function nodeLookup(
+  hostname: string,
+  _opts: unknown,
+  cb: (err: Error | null, addr: string, family: number) => void,
+) {
+  resolve4(hostname, (err, addrs) => cb(err ?? null, addrs?.[0] ?? '', 4));
+}
+
+const pool = new Pool({ connectionString: DB_URL, lookup: nodeLookup } as unknown as import('pg').PoolConfig);
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export type PollKind = 'multiple_choice' | 'text';
+export type PollStatus = 'open' | 'locked';
+
+export interface Poll {
+  id: string;
+  question: string;
+  kind: PollKind;
+  options: string[] | null;
+  status: PollStatus;
+  room_tokens: string[];
+  created_at: Date;
+  locked_at: Date | null;
+}
+
+export interface PollTemplate {
+  label: string;
+  question: string;
+  kind: PollKind;
+  options: string[] | null;
+}
+
+export interface AnswerCount {
+  answer: string;
+  count: number;
+}
+
+export interface PollResults {
+  poll: Poll;
+  total: number;
+  counts: AnswerCount[];
+}
+
+// ── Templates (source of truth for the admin UI) ──────────────────────────────
+
+export const POLL_TEMPLATES: PollTemplate[] = [
+  {
+    label: 'Wie fühlen Sie sich gerade?',
+    question: 'Wie fühlen Sie sich gerade?',
+    kind: 'multiple_choice',
+    options: ['\u{1F60A} Gut', '\u{1F610} Mittel', '\u{1F614} Nicht so gut'],
+  },
+  {
+    label: 'Stimmen Sie zu?',
+    question: 'Stimmen Sie zu?',
+    kind: 'multiple_choice',
+    options: ['Ja', 'Nein', 'Enthaltung'],
+  },
+  {
+    label: 'Wie hilfreich war diese Session?',
+    question: 'Wie hilfreich war diese Session?',
+    kind: 'multiple_choice',
+    options: ['Sehr hilfreich', 'Hilfreich', 'Wenig hilfreich', 'Nicht hilfreich'],
+  },
+  {
+    label: 'Bereit für den nächsten Schritt?',
+    question: 'Bereit für den nächsten Schritt?',
+    kind: 'multiple_choice',
+    options: ['Ja', 'Noch nicht', 'Brauche mehr Info'],
+  },
+  {
+    label: 'Was nehmen Sie mit?',
+    question: 'Was nehmen Sie mit?',
+    kind: 'text',
+    options: null,
+  },
+];
+
+// ── DB Helpers ─────────────────────────────────────────────────────────────────
+
+export async function createPoll(
+  question: string,
+  kind: PollKind,
+  options: string[] | null,
+  roomTokens: string[],
+): Promise<Poll> {
+  const { rows } = await pool.query<Poll>(
+    `INSERT INTO polls (question, kind, options, room_tokens)
+     VALUES ($1, $2, $3, $4)
+     RETURNING id, question, kind, options, status, room_tokens, created_at, locked_at`,
+    [question, kind, options, roomTokens],
+  );
+  return rows[0];
+}
+
+export async function getActivePoll(): Promise<Poll | null> {
+  const { rows } = await pool.query<Poll>(
+    `SELECT id, question, kind, options, status, room_tokens, created_at, locked_at
+       FROM polls WHERE status = 'open'
+       ORDER BY created_at DESC LIMIT 1`,
+  );
+  return rows[0] ?? null;
+}
+
+export async function getPoll(id: string): Promise<Poll | null> {
+  const { rows } = await pool.query<Poll>(
+    `SELECT id, question, kind, options, status, room_tokens, created_at, locked_at
+       FROM polls WHERE id = $1`,
+    [id],
+  );
+  return rows[0] ?? null;
+}
+
+export async function submitAnswer(pollId: string, answer: string): Promise<void> {
+  await pool.query(
+    'INSERT INTO poll_answers (poll_id, answer) VALUES ($1, $2)',
+    [pollId, answer],
+  );
+}
+
+export async function getResults(pollId: string): Promise<PollResults | null> {
+  const poll = await getPoll(pollId);
+  if (!poll) return null;
+
+  const { rows } = await pool.query<{ answer: string; count: string }>(
+    `SELECT answer, COUNT(*)::text AS count
+       FROM poll_answers WHERE poll_id = $1
+       GROUP BY answer ORDER BY count DESC, answer ASC`,
+    [pollId],
+  );
+
+  const rawCounts: AnswerCount[] = rows.map(r => ({
+    answer: r.answer,
+    count: parseInt(r.count, 10),
+  }));
+  const total = rawCounts.reduce((s, r) => s + r.count, 0);
+
+  // MC polls: preserve option order and include zero-count options
+  const counts: AnswerCount[] =
+    poll.kind === 'multiple_choice' && poll.options
+      ? poll.options.map(opt => ({
+          answer: opt,
+          count: rawCounts.find(r => r.answer === opt)?.count ?? 0,
+        }))
+      : rawCounts;
+
+  return { poll, total, counts };
+}
+
+export async function lockPoll(id: string): Promise<Poll | null> {
+  const { rows } = await pool.query<Poll>(
+    `UPDATE polls SET status = 'locked', locked_at = now()
+       WHERE id = $1 AND status = 'open'
+       RETURNING id, question, kind, options, status, room_tokens, created_at, locked_at`,
+    [id],
+  );
+  return rows[0] ?? null;
+}
+
+// ── Pure Helpers ───────────────────────────────────────────────────────────────
+
+export function buildResultsBotMessage(results: PollResults, resultsUrl: string): string {
+  const { poll, total, counts } = results;
+  if (poll.kind === 'multiple_choice') {
+    const breakdown = counts.map(c => `${c.answer}: ${c.count}`).join(' | ');
+    return `\u{1F4CA} Umfrageergebnis: „${poll.question}"\n${breakdown}\n→ ${resultsUrl}`;
+  }
+  return `\u{1F4CA} Umfrageergebnis: „${poll.question}"\n${total} Antworten · Details: ${resultsUrl}`;
+}

--- a/website/src/pages/admin/meetings.astro
+++ b/website/src/pages/admin/meetings.astro
@@ -421,10 +421,6 @@ function statusColor(s: string) {
         pollModalConfirm.disabled = isCustom ? pollCustomQ.value.trim().length < 2 : false;
       });
     });
-    pollCustomQ.addEventListener('input', () => {
-      const sel = pollTemplateList.querySelector<HTMLInputElement>('input[name=poll-template]:checked');
-      if (sel?.value === 'custom') pollModalConfirm.disabled = pollCustomQ.value.trim().length < 2;
-    });
   }
 
   function renderStatusBars(results: PollResults | null) {
@@ -513,6 +509,10 @@ function statusColor(s: string) {
   });
   pollModalCancel.addEventListener('click', hidePollModal);
   pollModal.addEventListener('click', (e) => { if (e.target === pollModal) hidePollModal(); });
+  pollCustomQ.addEventListener('input', () => {
+    const sel = pollTemplateList.querySelector<HTMLInputElement>('input[name=poll-template]:checked');
+    if (sel?.value === 'custom') pollModalConfirm.disabled = pollCustomQ.value.trim().length < 2;
+  });
 
   pollModalConfirm.addEventListener('click', async () => {
     const selected = pollTemplateList.querySelector<HTMLInputElement>('input[name=poll-template]:checked');

--- a/website/src/pages/admin/meetings.astro
+++ b/website/src/pages/admin/meetings.astro
@@ -2,12 +2,14 @@
 import AdminLayout from '../../layouts/AdminLayout.astro';
 import { getSession, getLoginUrl, isAdmin } from '../../lib/auth';
 import { listAllMeetings } from '../../lib/website-db';
+import { POLL_TEMPLATES } from '../../lib/poll-db';
 
 const session = await getSession(Astro.request.headers.get('cookie'));
 if (!session) return Astro.redirect(getLoginUrl(Astro.url.pathname));
 if (!isAdmin(session)) return Astro.redirect('/admin');
 
 const meetings = await listAllMeetings();
+const pollTemplatesJson = JSON.stringify(POLL_TEMPLATES);
 
 const unassignedCount = meetings.filter(m =>
   m.customerEmail.endsWith('@unknown.local') || m.meetingType === 'Talk-Session'
@@ -60,6 +62,11 @@ function statusColor(s: string) {
             class="px-4 py-2 bg-dark-light text-light rounded-lg text-sm font-semibold border border-dark-lighter hover:border-gold/40"
             title="Systemisches Brett in alle laufenden Talk-Calls posten">
             🎯 Brett für alle
+          </button>
+          <button id="btn-poll"
+            class="px-4 py-2 bg-dark-light text-light rounded-lg text-sm font-semibold border border-dark-lighter hover:border-gold/40"
+            title="Umfrage in alle laufenden Talk-Calls posten">
+            &#x1F4CA; Umfrage starten
           </button>
           <button id="btn-all"
             class="px-4 py-2 bg-gold text-dark rounded-lg text-sm font-semibold">
@@ -154,6 +161,75 @@ function statusColor(s: string) {
       </div>
     </div>
   </div>
+
+  <!-- ── Poll Creation Modal ──────────────────────────────────────── -->
+  <div id="poll-modal"
+       class="hidden fixed inset-0 z-50 bg-black/70 backdrop-blur-sm items-center justify-center p-4">
+    <div class="bg-dark-light rounded-2xl border border-dark-lighter max-w-lg w-full p-6 shadow-xl">
+      <h2 class="text-xl font-serif text-light mb-2">&#x1F4CA; Umfrage starten</h2>
+      <p class="text-sm text-muted mb-4">Frage w&#xE4;hlen und in alle aktiven Calls posten.</p>
+      <div id="poll-template-list" class="flex flex-col gap-2 mb-4"></div>
+      <div id="poll-custom-wrap" class="hidden mb-4">
+        <label class="block text-xs text-muted mb-1 uppercase tracking-wide">Eigene Frage</label>
+        <input id="poll-custom-question" type="text" maxlength="200"
+          class="w-full bg-dark border border-dark-lighter rounded-lg px-3 py-2 text-sm text-light focus:outline-none focus:border-gold"
+          placeholder="Ihre Frage&#x2026;" />
+      </div>
+      <div id="poll-modal-result" class="hidden mb-4 text-sm text-yellow-400"></div>
+      <div class="flex gap-2 justify-end">
+        <button id="poll-modal-cancel"
+          class="px-4 py-2 bg-dark rounded-lg border border-dark-lighter text-sm text-muted hover:text-light">
+          Abbrechen
+        </button>
+        <button id="poll-modal-confirm" disabled
+          class="px-4 py-2 bg-gold text-dark rounded-lg text-sm font-semibold disabled:opacity-40 disabled:cursor-not-allowed">
+          &#x1F4CA; Umfrage starten
+        </button>
+      </div>
+    </div>
+  </div>
+
+  <!-- ── Poll Status Panel ────────────────────────────────────────── -->
+  <div id="poll-status-panel" class="hidden max-w-6xl mx-auto px-6 mt-4 pb-6">
+    <div class="bg-dark-light rounded-2xl border border-dark-lighter p-4">
+      <div class="flex items-start justify-between mb-3">
+        <div>
+          <span class="text-xs text-muted uppercase tracking-wide">Aktive Umfrage</span>
+          <p id="poll-status-question" class="font-serif text-light mt-0.5 text-sm"></p>
+        </div>
+        <span id="poll-status-count" class="text-sm text-muted ml-4 flex-shrink-0"></span>
+      </div>
+      <div id="poll-status-bars" class="flex flex-col gap-2 mb-4 text-sm"></div>
+      <div class="flex gap-2 justify-end">
+        <button id="poll-qr-btn"
+          class="px-3 py-1.5 text-sm rounded-lg border border-dark-lighter text-muted hover:text-light">
+          QR-Code zeigen
+        </button>
+        <button id="poll-share-btn"
+          class="px-3 py-1.5 text-sm rounded-lg bg-gold text-dark font-semibold hover:bg-gold/90">
+          &#x1F4E4; Ergebnisse teilen &amp; schlie&#xDF;en
+        </button>
+      </div>
+      <p id="poll-status-msg" class="hidden text-sm text-muted mt-2 text-right"></p>
+    </div>
+  </div>
+
+  <!-- ── QR Code Modal ────────────────────────────────────────────── -->
+  <div id="qr-modal"
+       class="hidden fixed inset-0 z-50 bg-black/70 backdrop-blur-sm items-center justify-center p-4">
+    <div class="bg-dark-light rounded-2xl border border-dark-lighter p-6 text-center shadow-xl">
+      <p class="text-sm text-muted mb-4">Teilnehmer scannen diesen Code:</p>
+      <canvas id="qr-canvas" class="mx-auto rounded-lg"></canvas>
+      <p id="qr-url" class="text-xs text-muted mt-3 break-all max-w-xs mx-auto"></p>
+      <button id="qr-close"
+        class="mt-4 px-4 py-2 text-sm rounded-lg border border-dark-lighter text-muted hover:text-light">
+        Schlie&#xDF;en
+      </button>
+    </div>
+  </div>
+
+  <!-- Templates data island -->
+  <script id="poll-templates-data" type="application/json" set:html={pollTemplatesJson}></script>
 </AdminLayout>
 
 <script>
@@ -269,5 +345,265 @@ function statusColor(s: string) {
     document.querySelectorAll<HTMLElement>('.meeting-row').forEach(r => {
       r.style.display = r.dataset.unassigned === '1' ? '' : 'none';
     });
+  });
+
+  // ─── Poll ─────────────────────────────────────────────────────────────────
+  const POLL_TEMPLATES_DATA = JSON.parse(
+    document.getElementById('poll-templates-data')!.textContent!
+  );
+
+  const btnPoll            = document.getElementById('btn-poll')!;
+  const pollModal          = document.getElementById('poll-modal')!;
+  const pollModalCancel    = document.getElementById('poll-modal-cancel') as HTMLButtonElement;
+  const pollModalConfirm   = document.getElementById('poll-modal-confirm') as HTMLButtonElement;
+  const pollModalResult    = document.getElementById('poll-modal-result')!;
+  const pollCustomWrap     = document.getElementById('poll-custom-wrap')!;
+  const pollCustomQ        = document.getElementById('poll-custom-question') as HTMLInputElement;
+  const pollTemplateList   = document.getElementById('poll-template-list')!;
+  const pollStatusPanel    = document.getElementById('poll-status-panel')!;
+  const pollStatusQuestion = document.getElementById('poll-status-question')!;
+  const pollStatusCount    = document.getElementById('poll-status-count')!;
+  const pollStatusBars     = document.getElementById('poll-status-bars')!;
+  const pollStatusMsg      = document.getElementById('poll-status-msg')!;
+  const pollShareBtn       = document.getElementById('poll-share-btn') as HTMLButtonElement;
+  const pollQrBtn          = document.getElementById('poll-qr-btn') as HTMLButtonElement;
+  const qrModal            = document.getElementById('qr-modal')!;
+  const qrCanvas           = document.getElementById('qr-canvas') as HTMLCanvasElement;
+  const qrUrlEl            = document.getElementById('qr-url')!;
+  const qrClose            = document.getElementById('qr-close')!;
+
+  interface PollTemplate { label: string; question: string; kind: string; options: string[] | null; }
+  interface PollResults { poll: { id: string; question: string; kind: string }; total: number; counts: { answer: string; count: number }[]; }
+
+  let activePollId: string | null = null;
+  let pollRefreshTimer: ReturnType<typeof setInterval> | null = null;
+
+  function renderTemplatePicker() {
+    pollTemplateList.replaceChildren();
+    (POLL_TEMPLATES_DATA as PollTemplate[]).forEach((t, i) => {
+      const label = document.createElement('label');
+      label.className = 'flex items-center gap-3 cursor-pointer px-3 py-2 rounded-lg border border-dark-lighter hover:border-gold/40 text-sm text-light';
+      const radio = document.createElement('input');
+      radio.type = 'radio'; radio.name = 'poll-template'; radio.value = String(i);
+      radio.className = 'accent-gold';
+      const text = document.createElement('span');
+      const strong = document.createElement('strong');
+      strong.textContent = t.label;
+      text.appendChild(strong);
+      const sub = document.createElement('span');
+      sub.className = 'text-muted ml-1';
+      sub.textContent = t.options ? ' ' + t.options.join(' · ') : ' Freitext';
+      text.appendChild(sub);
+      label.append(radio, text);
+      pollTemplateList.appendChild(label);
+    });
+
+    const customLabel = document.createElement('label');
+    customLabel.className = 'flex items-center gap-3 cursor-pointer px-3 py-2 rounded-lg border border-dark-lighter hover:border-gold/40 text-sm';
+    const customRadio = document.createElement('input');
+    customRadio.type = 'radio'; customRadio.name = 'poll-template'; customRadio.value = 'custom';
+    customRadio.className = 'accent-gold';
+    const customText = document.createElement('span');
+    const customStrong = document.createElement('strong');
+    customStrong.style.color = '#d7b06a';
+    customStrong.textContent = 'Eigene Frage…';
+    const customSub = document.createElement('span');
+    customSub.className = 'text-muted ml-1';
+    customSub.textContent = ' Freitext-Antwort';
+    customText.append(customStrong, customSub);
+    customLabel.append(customRadio, customText);
+    pollTemplateList.appendChild(customLabel);
+
+    pollTemplateList.querySelectorAll<HTMLInputElement>('input[type=radio]').forEach(radio => {
+      radio.addEventListener('change', () => {
+        const isCustom = radio.value === 'custom';
+        pollCustomWrap.classList.toggle('hidden', !isCustom);
+        pollModalConfirm.disabled = isCustom ? pollCustomQ.value.trim().length < 2 : false;
+      });
+    });
+    pollCustomQ.addEventListener('input', () => {
+      const sel = pollTemplateList.querySelector<HTMLInputElement>('input[name=poll-template]:checked');
+      if (sel?.value === 'custom') pollModalConfirm.disabled = pollCustomQ.value.trim().length < 2;
+    });
+  }
+
+  function renderStatusBars(results: PollResults | null) {
+    pollStatusBars.replaceChildren();
+    if (!results) return;
+    const { poll, total, counts } = results;
+    pollStatusCount.textContent = total + ' Antwort' + (total !== 1 ? 'en' : '');
+    if (poll.kind === 'multiple_choice') {
+      counts.forEach(c => {
+        const pct = total > 0 ? Math.round(c.count / total * 100) : 0;
+        const row = document.createElement('div');
+        row.className = 'flex items-center gap-2';
+        const lbl = document.createElement('span');
+        lbl.className = 'w-28 flex-shrink-0 truncate text-light';
+        lbl.textContent = c.answer;
+        const track = document.createElement('div');
+        track.className = 'flex-1 bg-dark rounded h-2';
+        const fill = document.createElement('div');
+        fill.className = 'h-full bg-gold rounded';
+        fill.style.width = pct + '%';
+        track.appendChild(fill);
+        const cnt = document.createElement('span');
+        cnt.className = 'w-6 text-right text-muted';
+        cnt.textContent = String(c.count);
+        row.append(lbl, track, cnt);
+        pollStatusBars.appendChild(row);
+      });
+    } else {
+      const p = document.createElement('p');
+      p.className = 'text-muted text-xs';
+      p.textContent = total + ' Freitext-Antwort' + (total !== 1 ? 'en' : '') + ' eingegangen';
+      pollStatusBars.appendChild(p);
+    }
+  }
+
+  async function refreshPollStatus() {
+    if (!activePollId) return;
+    try {
+      const res = await fetch('/api/admin/poll/' + activePollId);
+      if (!res.ok) { stopPollRefresh(); return; }
+      renderStatusBars(await res.json() as PollResults);
+    } catch { /* ignore transient errors */ }
+  }
+
+  function startPollRefresh(id: string) {
+    activePollId = id; stopPollRefresh();
+    pollRefreshTimer = setInterval(refreshPollStatus, 5000);
+  }
+  function stopPollRefresh() {
+    if (pollRefreshTimer) { clearInterval(pollRefreshTimer); pollRefreshTimer = null; }
+  }
+
+  function showStatusPanel(poll: { id: string; question: string }, results: PollResults | null) {
+    btnPoll.classList.add('hidden');
+    pollStatusQuestion.textContent = poll.question;
+    renderStatusBars(results);
+    pollStatusPanel.classList.remove('hidden');
+    startPollRefresh(poll.id);
+  }
+
+  function hidePollModal() {
+    pollModal.classList.add('hidden');
+    pollModal.classList.remove('flex');
+    pollModalResult.classList.add('hidden');
+    pollTemplateList.querySelectorAll<HTMLInputElement>('input[type=radio]').forEach(r => { r.checked = false; });
+    pollCustomWrap.classList.add('hidden');
+    pollCustomQ.value = '';
+    pollModalConfirm.disabled = true;
+    pollModalConfirm.textContent = '\u{1F4CA} Umfrage starten';
+  }
+
+  // Check for existing active poll on page load
+  (async () => {
+    try {
+      const res = await fetch('/api/admin/poll/active');
+      if (!res.ok) return;
+      const { poll, results } = await res.json() as { poll: { id: string; question: string } | null; results: PollResults | null };
+      if (poll) showStatusPanel(poll, results);
+    } catch { /* no active poll */ }
+  })();
+
+  btnPoll.addEventListener('click', () => {
+    renderTemplatePicker();
+    pollModal.classList.remove('hidden');
+    pollModal.classList.add('flex');
+  });
+  pollModalCancel.addEventListener('click', hidePollModal);
+  pollModal.addEventListener('click', (e) => { if (e.target === pollModal) hidePollModal(); });
+
+  pollModalConfirm.addEventListener('click', async () => {
+    const selected = pollTemplateList.querySelector<HTMLInputElement>('input[name=poll-template]:checked');
+    if (!selected) return;
+    let question: string, kind: string, options: string[] | null;
+    if (selected.value === 'custom') {
+      question = pollCustomQ.value.trim(); kind = 'text'; options = null;
+    } else {
+      const tpl = (POLL_TEMPLATES_DATA as PollTemplate[])[parseInt(selected.value, 10)];
+      question = tpl.question; kind = tpl.kind; options = tpl.options;
+    }
+    pollModalConfirm.disabled = true;
+    pollModalConfirm.textContent = '…';
+    try {
+      const res = await fetch('/api/admin/poll', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ question, kind, options }),
+      });
+      const data = await res.json() as { poll?: { id: string; question: string }; error?: string; sent?: number; total?: number };
+      if (res.ok && data.poll) {
+        hidePollModal();
+        showStatusPanel(data.poll, null);
+        if ((data.total ?? 0) === 0) {
+          pollStatusMsg.textContent = 'Keine aktiven Calls – Umfrage erstellt, aber nicht gepostet.';
+          pollStatusMsg.classList.remove('hidden');
+        } else if ((data.sent ?? 0) < (data.total ?? 0)) {
+          pollStatusMsg.textContent = '⚠ ' + data.sent + '/' + data.total + ' Calls erreicht.';
+          pollStatusMsg.classList.remove('hidden');
+        }
+      } else if (res.status === 409) {
+        pollModalResult.textContent = 'Es läuft bereits eine Umfrage.';
+        pollModalResult.classList.remove('hidden');
+        pollModalConfirm.disabled = false;
+        pollModalConfirm.textContent = '\u{1F4CA} Umfrage starten';
+      } else {
+        pollModalResult.textContent = 'Fehler: ' + (data.error ?? 'Unbekannt');
+        pollModalResult.classList.remove('hidden');
+        pollModalConfirm.disabled = false;
+        pollModalConfirm.textContent = '\u{1F4CA} Umfrage starten';
+      }
+    } catch {
+      pollModalResult.textContent = 'Netzwerkfehler. Bitte erneut versuchen.';
+      pollModalResult.classList.remove('hidden');
+      pollModalConfirm.disabled = false;
+      pollModalConfirm.textContent = '\u{1F4CA} Umfrage starten';
+    }
+  });
+
+  pollShareBtn.addEventListener('click', async () => {
+    if (!activePollId) return;
+    pollShareBtn.disabled = true;
+    pollShareBtn.textContent = '…';
+    stopPollRefresh();
+    try {
+      const res = await fetch('/api/admin/poll/' + activePollId + '/share', { method: 'POST' });
+      const data = await res.json() as { sent?: number; error?: string };
+      if (res.ok) {
+        pollStatusMsg.textContent = '✓ Ergebnisse an ' + data.sent + ' Call(s) gesendet.';
+        pollStatusMsg.classList.remove('hidden');
+        pollShareBtn.classList.add('hidden');
+        pollQrBtn.classList.add('hidden');
+      } else {
+        pollStatusMsg.textContent = 'Fehler: ' + (data.error ?? 'Unbekannt');
+        pollStatusMsg.classList.remove('hidden');
+        pollShareBtn.disabled = false;
+        pollShareBtn.textContent = '\u{1F4E4} Ergebnisse teilen & schließen';
+      }
+    } catch {
+      pollStatusMsg.textContent = 'Netzwerkfehler.';
+      pollStatusMsg.classList.remove('hidden');
+      pollShareBtn.disabled = false;
+      pollShareBtn.textContent = '\u{1F4E4} Ergebnisse teilen & schließen';
+    }
+  });
+
+  pollQrBtn.addEventListener('click', async () => {
+    if (!activePollId) return;
+    const url = location.origin + '/poll/' + activePollId;
+    qrUrlEl.textContent = url;
+    qrModal.classList.remove('hidden');
+    qrModal.classList.add('flex');
+    const { default: QRCode } = await import('qrcode');
+    await QRCode.toCanvas(qrCanvas, url, { width: 256, margin: 2, color: { dark: '#0b111c', light: '#e8e4dc' } });
+  });
+
+  qrClose.addEventListener('click', () => {
+    qrModal.classList.add('hidden');
+    qrModal.classList.remove('flex');
+  });
+  qrModal.addEventListener('click', (e) => {
+    if (e.target === qrModal) { qrModal.classList.add('hidden'); qrModal.classList.remove('flex'); }
   });
 </script>

--- a/website/src/pages/api/admin/poll/[id].ts
+++ b/website/src/pages/api/admin/poll/[id].ts
@@ -5,12 +5,12 @@ import { getResults } from '../../../../lib/poll-db';
 export const GET: APIRoute = async ({ request, params }) => {
   const session = await getSession(request.headers.get('cookie'));
   if (!session || !isAdmin(session)) {
-    return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 });
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401, headers: { 'Content-Type': 'application/json' } });
   }
 
   const results = await getResults(params.id!);
   if (!results) {
-    return new Response(JSON.stringify({ error: 'not found' }), { status: 404 });
+    return new Response(JSON.stringify({ error: 'not found' }), { status: 404, headers: { 'Content-Type': 'application/json' } });
   }
 
   return new Response(JSON.stringify(results), {

--- a/website/src/pages/api/admin/poll/[id].ts
+++ b/website/src/pages/api/admin/poll/[id].ts
@@ -1,0 +1,19 @@
+import type { APIRoute } from 'astro';
+import { getSession, isAdmin } from '../../../../lib/auth';
+import { getResults } from '../../../../lib/poll-db';
+
+export const GET: APIRoute = async ({ request, params }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 });
+  }
+
+  const results = await getResults(params.id!);
+  if (!results) {
+    return new Response(JSON.stringify({ error: 'not found' }), { status: 404 });
+  }
+
+  return new Response(JSON.stringify(results), {
+    headers: { 'Content-Type': 'application/json' },
+  });
+};

--- a/website/src/pages/api/admin/poll/[id]/share.ts
+++ b/website/src/pages/api/admin/poll/[id]/share.ts
@@ -9,7 +9,7 @@ const BOT_SECRET = process.env.BRETT_BOT_SECRET || '';
 export const POST: APIRoute = async ({ request, params }) => {
   const session = await getSession(request.headers.get('cookie'));
   if (!session || !isAdmin(session)) {
-    return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 });
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401, headers: { 'Content-Type': 'application/json' } });
   }
 
   const poll = await lockPoll(params.id!);
@@ -22,7 +22,7 @@ export const POST: APIRoute = async ({ request, params }) => {
 
   const results = await getResults(poll.id);
   if (!results) {
-    return new Response(JSON.stringify({ error: 'results unavailable' }), { status: 500 });
+    return new Response(JSON.stringify({ error: 'results unavailable' }), { status: 500, headers: { 'Content-Type': 'application/json' } });
   }
 
   const resultsUrl = `${SITE_URL}/poll/${poll.id}/results`;

--- a/website/src/pages/api/admin/poll/[id]/share.ts
+++ b/website/src/pages/api/admin/poll/[id]/share.ts
@@ -1,0 +1,43 @@
+import type { APIRoute } from 'astro';
+import { getSession, isAdmin } from '../../../../../lib/auth';
+import { lockPoll, getResults, buildResultsBotMessage } from '../../../../../lib/poll-db';
+import { postBotReply } from '../../../../../lib/brett-bot';
+
+const SITE_URL = process.env.SITE_URL || 'https://web.localhost';
+const BOT_SECRET = process.env.BRETT_BOT_SECRET || '';
+
+export const POST: APIRoute = async ({ request, params }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 });
+  }
+
+  const poll = await lockPoll(params.id!);
+  if (!poll) {
+    return new Response(
+      JSON.stringify({ error: 'not found or already locked' }),
+      { status: 404, headers: { 'Content-Type': 'application/json' } },
+    );
+  }
+
+  const results = await getResults(poll.id);
+  if (!results) {
+    return new Response(JSON.stringify({ error: 'results unavailable' }), { status: 500 });
+  }
+
+  const resultsUrl = `${SITE_URL}/poll/${poll.id}/results`;
+  const message = buildResultsBotMessage(results, resultsUrl);
+
+  const broadcastResults = await Promise.all(
+    poll.room_tokens.map(async token => {
+      const ok = await postBotReply(token, message, BOT_SECRET);
+      return { token, ok };
+    }),
+  );
+
+  const sent = broadcastResults.filter(r => r.ok).length;
+  return new Response(
+    JSON.stringify({ poll, results, sent, total: poll.room_tokens.length, broadcastResults }),
+    { headers: { 'Content-Type': 'application/json' } },
+  );
+};

--- a/website/src/pages/api/admin/poll/active.ts
+++ b/website/src/pages/api/admin/poll/active.ts
@@ -1,0 +1,22 @@
+import type { APIRoute } from 'astro';
+import { getSession, isAdmin } from '../../../../lib/auth';
+import { getActivePoll, getResults } from '../../../../lib/poll-db';
+
+export const GET: APIRoute = async ({ request }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 });
+  }
+
+  const poll = await getActivePoll();
+  if (!poll) {
+    return new Response(JSON.stringify({ poll: null }), {
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const results = await getResults(poll.id);
+  return new Response(JSON.stringify({ poll, results }), {
+    headers: { 'Content-Type': 'application/json' },
+  });
+};

--- a/website/src/pages/api/admin/poll/active.ts
+++ b/website/src/pages/api/admin/poll/active.ts
@@ -5,7 +5,7 @@ import { getActivePoll, getResults } from '../../../../lib/poll-db';
 export const GET: APIRoute = async ({ request }) => {
   const session = await getSession(request.headers.get('cookie'));
   if (!session || !isAdmin(session)) {
-    return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 });
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401, headers: { 'Content-Type': 'application/json' } });
   }
 
   const poll = await getActivePoll();

--- a/website/src/pages/api/admin/poll/index.ts
+++ b/website/src/pages/api/admin/poll/index.ts
@@ -1,0 +1,62 @@
+import type { APIRoute } from 'astro';
+import { getSession, isAdmin } from '../../../../lib/auth';
+import { createPoll, getActivePoll } from '../../../../lib/poll-db';
+import { listActiveCallRooms, ensureBrettBotEnabledForRoom } from '../../../../lib/nextcloud-talk-db';
+import { postBotReply } from '../../../../lib/brett-bot';
+
+const SITE_URL = process.env.SITE_URL || 'https://web.localhost';
+const BOT_SECRET = process.env.BRETT_BOT_SECRET || '';
+
+export const POST: APIRoute = async ({ request }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 });
+  }
+
+  const existing = await getActivePoll();
+  if (existing) {
+    return new Response(
+      JSON.stringify({ error: 'poll_already_active', id: existing.id }),
+      { status: 409, headers: { 'Content-Type': 'application/json' } },
+    );
+  }
+
+  let body: unknown;
+  try { body = await request.json(); } catch {
+    return new Response(JSON.stringify({ error: 'invalid JSON' }), { status: 400 });
+  }
+  const { question, kind, options } = (body ?? {}) as Record<string, unknown>;
+
+  if (!question || typeof question !== 'string' || question.trim().length < 2) {
+    return new Response(JSON.stringify({ error: 'question required (min 2 chars)' }), { status: 400 });
+  }
+  if (kind !== 'multiple_choice' && kind !== 'text') {
+    return new Response(JSON.stringify({ error: 'kind must be multiple_choice or text' }), { status: 400 });
+  }
+  if (kind === 'multiple_choice' && (!Array.isArray(options) || options.length < 2)) {
+    return new Response(JSON.stringify({ error: 'multiple_choice requires >= 2 options' }), { status: 400 });
+  }
+
+  const rooms = await listActiveCallRooms();
+  const poll = await createPoll(
+    question.trim(),
+    kind,
+    kind === 'text' ? null : (options as string[]),
+    rooms.map(r => r.token),
+  );
+
+  const pollUrl = `${SITE_URL}/poll/${poll.id}`;
+  const broadcastResults = await Promise.all(
+    rooms.map(async r => {
+      await ensureBrettBotEnabledForRoom(r.token);
+      const ok = await postBotReply(r.token, `\u{1F4CA} Umfrage: ${pollUrl}`, BOT_SECRET);
+      return { token: r.token, displayName: r.displayName, ok };
+    }),
+  );
+
+  const sent = broadcastResults.filter(r => r.ok).length;
+  return new Response(
+    JSON.stringify({ poll, broadcastResults, sent, total: rooms.length }),
+    { status: 201, headers: { 'Content-Type': 'application/json' } },
+  );
+};

--- a/website/src/pages/api/admin/poll/index.ts
+++ b/website/src/pages/api/admin/poll/index.ts
@@ -10,7 +10,7 @@ const BOT_SECRET = process.env.BRETT_BOT_SECRET || '';
 export const POST: APIRoute = async ({ request }) => {
   const session = await getSession(request.headers.get('cookie'));
   if (!session || !isAdmin(session)) {
-    return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 });
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401, headers: { 'Content-Type': 'application/json' } });
   }
 
   const existing = await getActivePoll();
@@ -23,18 +23,18 @@ export const POST: APIRoute = async ({ request }) => {
 
   let body: unknown;
   try { body = await request.json(); } catch {
-    return new Response(JSON.stringify({ error: 'invalid JSON' }), { status: 400 });
+    return new Response(JSON.stringify({ error: 'invalid JSON' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
   }
   const { question, kind, options } = (body ?? {}) as Record<string, unknown>;
 
   if (!question || typeof question !== 'string' || question.trim().length < 2) {
-    return new Response(JSON.stringify({ error: 'question required (min 2 chars)' }), { status: 400 });
+    return new Response(JSON.stringify({ error: 'question required (min 2 chars)' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
   }
   if (kind !== 'multiple_choice' && kind !== 'text') {
-    return new Response(JSON.stringify({ error: 'kind must be multiple_choice or text' }), { status: 400 });
+    return new Response(JSON.stringify({ error: 'kind must be multiple_choice or text' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
   }
   if (kind === 'multiple_choice' && (!Array.isArray(options) || options.length < 2)) {
-    return new Response(JSON.stringify({ error: 'multiple_choice requires >= 2 options' }), { status: 400 });
+    return new Response(JSON.stringify({ error: 'multiple_choice requires >= 2 options' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
   }
 
   const rooms = await listActiveCallRooms();

--- a/website/src/pages/api/poll/[id].ts
+++ b/website/src/pages/api/poll/[id].ts
@@ -1,5 +1,5 @@
 import type { APIRoute } from 'astro';
-import { getPoll } from '../../../../lib/poll-db';
+import { getPoll } from '../../../lib/poll-db';
 
 export const GET: APIRoute = async ({ params }) => {
   const poll = await getPoll(params.id!);

--- a/website/src/pages/api/poll/[id].ts
+++ b/website/src/pages/api/poll/[id].ts
@@ -1,0 +1,16 @@
+import type { APIRoute } from 'astro';
+import { getPoll } from '../../../../lib/poll-db';
+
+export const GET: APIRoute = async ({ params }) => {
+  const poll = await getPoll(params.id!);
+  if (!poll) {
+    return new Response(JSON.stringify({ error: 'not found' }), { status: 404 });
+  }
+  if (poll.status === 'locked') {
+    return new Response(JSON.stringify({ error: 'locked' }), { status: 410 });
+  }
+  return new Response(
+    JSON.stringify({ id: poll.id, question: poll.question, kind: poll.kind, options: poll.options }),
+    { headers: { 'Content-Type': 'application/json' } },
+  );
+};

--- a/website/src/pages/api/poll/[id].ts
+++ b/website/src/pages/api/poll/[id].ts
@@ -4,10 +4,10 @@ import { getPoll } from '../../../lib/poll-db';
 export const GET: APIRoute = async ({ params }) => {
   const poll = await getPoll(params.id!);
   if (!poll) {
-    return new Response(JSON.stringify({ error: 'not found' }), { status: 404 });
+    return new Response(JSON.stringify({ error: 'not found' }), { status: 404, headers: { 'Content-Type': 'application/json' } });
   }
   if (poll.status === 'locked') {
-    return new Response(JSON.stringify({ error: 'locked' }), { status: 410 });
+    return new Response(JSON.stringify({ error: 'locked' }), { status: 410, headers: { 'Content-Type': 'application/json' } });
   }
   return new Response(
     JSON.stringify({ id: poll.id, question: poll.question, kind: poll.kind, options: poll.options }),

--- a/website/src/pages/api/poll/[id].ts
+++ b/website/src/pages/api/poll/[id].ts
@@ -1,8 +1,13 @@
 import type { APIRoute } from 'astro';
 import { getPoll } from '../../../lib/poll-db';
 
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 export const GET: APIRoute = async ({ params }) => {
-  const poll = await getPoll(params.id!);
+  if (!params.id || !UUID_RE.test(params.id)) {
+    return new Response(JSON.stringify({ error: 'not found' }), { status: 404, headers: { 'Content-Type': 'application/json' } });
+  }
+  const poll = await getPoll(params.id);
   if (!poll) {
     return new Response(JSON.stringify({ error: 'not found' }), { status: 404, headers: { 'Content-Type': 'application/json' } });
   }

--- a/website/src/pages/api/poll/[id]/answer.ts
+++ b/website/src/pages/api/poll/[id]/answer.ts
@@ -4,26 +4,26 @@ import { getPoll, submitAnswer } from '../../../../lib/poll-db';
 export const POST: APIRoute = async ({ request, params }) => {
   const poll = await getPoll(params.id!);
   if (!poll) {
-    return new Response(JSON.stringify({ error: 'not found' }), { status: 404 });
+    return new Response(JSON.stringify({ error: 'not found' }), { status: 404, headers: { 'Content-Type': 'application/json' } });
   }
   if (poll.status === 'locked') {
-    return new Response(JSON.stringify({ error: 'locked' }), { status: 409 });
+    return new Response(JSON.stringify({ error: 'locked' }), { status: 409, headers: { 'Content-Type': 'application/json' } });
   }
 
   let body: unknown;
   try { body = await request.json(); } catch {
-    return new Response(JSON.stringify({ error: 'invalid JSON' }), { status: 400 });
+    return new Response(JSON.stringify({ error: 'invalid JSON' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
   }
   const { answer } = (body ?? {}) as Record<string, unknown>;
 
   if (!answer || typeof answer !== 'string' || answer.trim().length === 0) {
-    return new Response(JSON.stringify({ error: 'answer required' }), { status: 400 });
+    return new Response(JSON.stringify({ error: 'answer required' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
   }
   if (answer.trim().length > 1000) {
-    return new Response(JSON.stringify({ error: 'answer too long (max 1000 chars)' }), { status: 400 });
+    return new Response(JSON.stringify({ error: 'answer too long (max 1000 chars)' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
   }
   if (poll.kind === 'multiple_choice' && poll.options && !poll.options.includes(answer.trim())) {
-    return new Response(JSON.stringify({ error: 'invalid option' }), { status: 400 });
+    return new Response(JSON.stringify({ error: 'invalid option' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
   }
 
   await submitAnswer(poll.id, answer.trim());

--- a/website/src/pages/api/poll/[id]/answer.ts
+++ b/website/src/pages/api/poll/[id]/answer.ts
@@ -1,5 +1,5 @@
 import type { APIRoute } from 'astro';
-import { getPoll, submitAnswer } from '../../../../../lib/poll-db';
+import { getPoll, submitAnswer } from '../../../../lib/poll-db';
 
 export const POST: APIRoute = async ({ request, params }) => {
   const poll = await getPoll(params.id!);

--- a/website/src/pages/api/poll/[id]/answer.ts
+++ b/website/src/pages/api/poll/[id]/answer.ts
@@ -1,0 +1,33 @@
+import type { APIRoute } from 'astro';
+import { getPoll, submitAnswer } from '../../../../../lib/poll-db';
+
+export const POST: APIRoute = async ({ request, params }) => {
+  const poll = await getPoll(params.id!);
+  if (!poll) {
+    return new Response(JSON.stringify({ error: 'not found' }), { status: 404 });
+  }
+  if (poll.status === 'locked') {
+    return new Response(JSON.stringify({ error: 'locked' }), { status: 409 });
+  }
+
+  let body: unknown;
+  try { body = await request.json(); } catch {
+    return new Response(JSON.stringify({ error: 'invalid JSON' }), { status: 400 });
+  }
+  const { answer } = (body ?? {}) as Record<string, unknown>;
+
+  if (!answer || typeof answer !== 'string' || answer.trim().length === 0) {
+    return new Response(JSON.stringify({ error: 'answer required' }), { status: 400 });
+  }
+  if (answer.trim().length > 1000) {
+    return new Response(JSON.stringify({ error: 'answer too long (max 1000 chars)' }), { status: 400 });
+  }
+  if (poll.kind === 'multiple_choice' && poll.options && !poll.options.includes(answer.trim())) {
+    return new Response(JSON.stringify({ error: 'invalid option' }), { status: 400 });
+  }
+
+  await submitAnswer(poll.id, answer.trim());
+  return new Response(JSON.stringify({ ok: true }), {
+    headers: { 'Content-Type': 'application/json' },
+  });
+};

--- a/website/src/pages/api/poll/[id]/answer.ts
+++ b/website/src/pages/api/poll/[id]/answer.ts
@@ -1,8 +1,13 @@
 import type { APIRoute } from 'astro';
 import { getPoll, submitAnswer } from '../../../../lib/poll-db';
 
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 export const POST: APIRoute = async ({ request, params }) => {
-  const poll = await getPoll(params.id!);
+  if (!params.id || !UUID_RE.test(params.id)) {
+    return new Response(JSON.stringify({ error: 'not found' }), { status: 404, headers: { 'Content-Type': 'application/json' } });
+  }
+  const poll = await getPoll(params.id);
   if (!poll) {
     return new Response(JSON.stringify({ error: 'not found' }), { status: 404, headers: { 'Content-Type': 'application/json' } });
   }

--- a/website/src/pages/api/poll/[id]/results.ts
+++ b/website/src/pages/api/poll/[id]/results.ts
@@ -4,10 +4,10 @@ import { getResults } from '../../../../lib/poll-db';
 export const GET: APIRoute = async ({ params }) => {
   const results = await getResults(params.id!);
   if (!results) {
-    return new Response(JSON.stringify({ error: 'not found' }), { status: 404 });
+    return new Response(JSON.stringify({ error: 'not found' }), { status: 404, headers: { 'Content-Type': 'application/json' } });
   }
   if (results.poll.status !== 'locked') {
-    return new Response(JSON.stringify({ error: 'results not available yet' }), { status: 403 });
+    return new Response(JSON.stringify({ error: 'results not available yet' }), { status: 403, headers: { 'Content-Type': 'application/json' } });
   }
   return new Response(JSON.stringify(results), {
     headers: { 'Content-Type': 'application/json' },

--- a/website/src/pages/api/poll/[id]/results.ts
+++ b/website/src/pages/api/poll/[id]/results.ts
@@ -1,8 +1,13 @@
 import type { APIRoute } from 'astro';
 import { getResults } from '../../../../lib/poll-db';
 
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 export const GET: APIRoute = async ({ params }) => {
-  const results = await getResults(params.id!);
+  if (!params.id || !UUID_RE.test(params.id)) {
+    return new Response(JSON.stringify({ error: 'not found' }), { status: 404, headers: { 'Content-Type': 'application/json' } });
+  }
+  const results = await getResults(params.id);
   if (!results) {
     return new Response(JSON.stringify({ error: 'not found' }), { status: 404, headers: { 'Content-Type': 'application/json' } });
   }

--- a/website/src/pages/api/poll/[id]/results.ts
+++ b/website/src/pages/api/poll/[id]/results.ts
@@ -1,5 +1,5 @@
 import type { APIRoute } from 'astro';
-import { getResults } from '../../../../../lib/poll-db';
+import { getResults } from '../../../../lib/poll-db';
 
 export const GET: APIRoute = async ({ params }) => {
   const results = await getResults(params.id!);

--- a/website/src/pages/api/poll/[id]/results.ts
+++ b/website/src/pages/api/poll/[id]/results.ts
@@ -1,0 +1,15 @@
+import type { APIRoute } from 'astro';
+import { getResults } from '../../../../../lib/poll-db';
+
+export const GET: APIRoute = async ({ params }) => {
+  const results = await getResults(params.id!);
+  if (!results) {
+    return new Response(JSON.stringify({ error: 'not found' }), { status: 404 });
+  }
+  if (results.poll.status !== 'locked') {
+    return new Response(JSON.stringify({ error: 'results not available yet' }), { status: 403 });
+  }
+  return new Response(JSON.stringify(results), {
+    headers: { 'Content-Type': 'application/json' },
+  });
+};

--- a/website/src/pages/poll/[id].astro
+++ b/website/src/pages/poll/[id].astro
@@ -94,12 +94,6 @@ const resultsUrl = `/poll/${id}/results`;
   </div>
 
   <script define:vars={{ pollId: id, pollKind: poll?.kind ?? 'text', isLocked }}>
-    function escText(s) {
-      const d = document.createElement('span');
-      d.textContent = s;
-      return d.textContent;
-    }
-
     // Prevent duplicate submission in the same browser session
     if (!isLocked && sessionStorage.getItem('poll_submitted_' + pollId)) {
       const card = document.getElementById('card');

--- a/website/src/pages/poll/[id].astro
+++ b/website/src/pages/poll/[id].astro
@@ -1,0 +1,201 @@
+---
+import { getPoll } from '../../lib/poll-db';
+const { id } = Astro.params;
+const poll = await getPoll(id!);
+const isLocked = !poll || poll.status === 'locked';
+const resultsUrl = `/poll/${id}/results`;
+---
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Umfrage</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      background: #0b111c; color: #e8e4dc;
+      font-family: 'Geist', system-ui, sans-serif;
+      min-height: 100svh; display: flex; align-items: center;
+      justify-content: center; padding: 24px;
+    }
+    .card {
+      background: #131b2a; border-radius: 12px; padding: 32px;
+      max-width: 400px; width: 100%; text-align: center;
+    }
+    .eyebrow {
+      font-size: 11px; color: #9bc0a8; letter-spacing: 0.08em;
+      text-transform: uppercase; margin-bottom: 12px;
+    }
+    h1 {
+      font-size: 22px; font-weight: 600; line-height: 1.35;
+      margin-bottom: 24px; font-family: 'Newsreader', Georgia, serif;
+    }
+    .opt-btn {
+      display: block; width: 100%; padding: 14px;
+      border-radius: 8px; border: 1px solid #2a3547;
+      background: transparent; color: #e8e4dc; font-size: 15px;
+      cursor: pointer; margin-bottom: 10px;
+      text-align: center; transition: background 0.15s, border-color 0.15s;
+    }
+    .opt-btn:hover { background: #1e2d43; }
+    .opt-btn.selected { border-color: #d7b06a; color: #d7b06a; }
+    textarea {
+      width: 100%; background: #1a2538; border: 1px solid #2a3547;
+      border-radius: 8px; padding: 12px; color: #e8e4dc;
+      font-size: 14px; resize: vertical; min-height: 96px; font-family: inherit;
+    }
+    .submit-btn {
+      width: 100%; padding: 14px; border-radius: 8px; border: none;
+      background: #d7b06a; color: #0b111c; font-size: 15px;
+      font-weight: 600; cursor: pointer; margin-top: 12px;
+      transition: opacity 0.15s;
+    }
+    .submit-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+    .muted { font-size: 12px; color: #6b7a8f; margin-top: 16px; }
+    .big-icon { font-size: 48px; margin-bottom: 16px; }
+    .chosen-badge {
+      margin-top: 16px; padding: 10px 14px; border-radius: 8px;
+      border: 1px solid #2a3547; font-size: 13px;
+    }
+    a { color: #d7b06a; }
+  </style>
+</head>
+<body>
+  <div class="card" id="card">
+    {isLocked ? (
+      <>
+        <div class="big-icon">&#x1F512;</div>
+        <h1>Umfrage geschlossen</h1>
+        <p class="muted">Die Abstimmung wurde beendet.</p>
+        {poll && (
+          <p style="margin-top:16px"><a href={resultsUrl}>&#x2192; Ergebnisse ansehen</a></p>
+        )}
+      </>
+    ) : (
+      <>
+        <p class="eyebrow">Umfrage</p>
+        <h1>{poll!.question}</h1>
+        {poll!.kind === 'multiple_choice' ? (
+          <div id="mc-options">
+            {poll!.options!.map(opt => (
+              <button class="opt-btn" data-option={opt} type="button">{opt}</button>
+            ))}
+          </div>
+        ) : (
+          <textarea id="text-answer" placeholder="Ihre Antwort&#x2026;" maxlength="1000"></textarea>
+        )}
+        <button class="submit-btn" id="submit-btn" type="button" disabled>
+          Absenden
+        </button>
+        <p class="muted">Anonym &#xB7; Einmalig</p>
+      </>
+    )}
+  </div>
+
+  <script define:vars={{ pollId: id, pollKind: poll?.kind ?? 'text', isLocked }}>
+    function escText(s) {
+      const d = document.createElement('span');
+      d.textContent = s;
+      return d.textContent;
+    }
+
+    // Prevent duplicate submission in the same browser session
+    if (!isLocked && sessionStorage.getItem('poll_submitted_' + pollId)) {
+      const card = document.getElementById('card');
+      card.replaceChildren();
+      const icon = document.createElement('div');
+      icon.className = 'big-icon';
+      icon.textContent = '✅';
+      const msg = document.createElement('h1');
+      msg.style.cssText = 'font-size:18px;font-family:serif';
+      msg.textContent = 'Sie haben bereits abgestimmt.';
+      const sub = document.createElement('p');
+      sub.className = 'muted';
+      sub.textContent = 'Ihre Antwort wurde anonym erfasst.';
+      card.append(icon, msg, sub);
+    }
+
+    if (pollKind === 'text') {
+      const ta = document.getElementById('text-answer');
+      const btn = document.getElementById('submit-btn');
+      if (ta && btn) {
+        ta.addEventListener('input', () => { btn.disabled = ta.value.trim().length === 0; });
+      }
+    } else {
+      document.querySelectorAll('.opt-btn').forEach(btn => {
+        btn.addEventListener('click', () => {
+          document.querySelectorAll('.opt-btn').forEach(b => b.classList.remove('selected'));
+          btn.classList.add('selected');
+          document.getElementById('submit-btn').disabled = false;
+        });
+      });
+    }
+
+    document.getElementById('submit-btn')?.addEventListener('click', async () => {
+      const answer = pollKind === 'multiple_choice'
+        ? document.querySelector('.opt-btn.selected')?.dataset.option
+        : document.getElementById('text-answer')?.value.trim();
+      if (!answer) return;
+
+      const btn = document.getElementById('submit-btn');
+      btn.disabled = true;
+      btn.textContent = '…';
+
+      try {
+        const res = await fetch('/api/poll/' + pollId + '/answer', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ answer }),
+        });
+
+        if (res.ok) {
+          sessionStorage.setItem('poll_submitted_' + pollId, '1');
+          const card = document.getElementById('card');
+          card.replaceChildren();
+
+          const icon = document.createElement('div');
+          icon.className = 'big-icon';
+          icon.textContent = '✅';
+
+          const heading = document.createElement('h1');
+          heading.style.cssText = 'font-size:18px;font-family:serif';
+          heading.textContent = 'Danke für Ihre Antwort!';
+
+          const sub = document.createElement('p');
+          sub.className = 'muted';
+          sub.textContent = 'Ihre Antwort wurde anonym erfasst. Der Moderator teilt die Ergebnisse mit der Gruppe.';
+
+          const badge = document.createElement('div');
+          badge.className = 'chosen-badge';
+          badge.textContent = 'Sie haben gewählt: ';
+          const strong = document.createElement('strong');
+          strong.style.color = '#d7b06a';
+          strong.textContent = pollKind === 'multiple_choice' ? answer : 'Ihre Antwort';
+          badge.appendChild(strong);
+
+          card.append(icon, heading, sub, badge);
+        } else if (res.status === 409) {
+          const card = document.getElementById('card');
+          card.replaceChildren();
+          const icon = document.createElement('div');
+          icon.className = 'big-icon';
+          icon.textContent = '\u{1F512}';
+          const msg = document.createElement('h1');
+          msg.style.cssText = 'font-size:18px;font-family:serif';
+          msg.textContent = 'Umfrage geschlossen';
+          card.append(icon, msg);
+        } else {
+          btn.disabled = false;
+          btn.textContent = 'Absenden';
+          alert('Fehler beim Absenden. Bitte versuchen Sie es erneut.');
+        }
+      } catch {
+        btn.disabled = false;
+        btn.textContent = 'Absenden';
+        alert('Netzwerkfehler. Bitte versuchen Sie es erneut.');
+      }
+    });
+  </script>
+</body>
+</html>

--- a/website/src/pages/poll/[id]/results.astro
+++ b/website/src/pages/poll/[id]/results.astro
@@ -1,0 +1,84 @@
+---
+import { getResults } from '../../../lib/poll-db';
+const { id } = Astro.params;
+const results = await getResults(id!);
+if (!results || results.poll.status !== 'locked') {
+  return Astro.redirect('/');
+}
+const { poll, total, counts } = results;
+---
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Ergebnis &#x2013; {poll.question}</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      background: #0b111c; color: #e8e4dc;
+      font-family: 'Geist', system-ui, sans-serif;
+      min-height: 100svh; display: flex; align-items: center;
+      justify-content: center; padding: 24px;
+    }
+    .card {
+      background: #131b2a; border-radius: 12px; padding: 32px;
+      max-width: 480px; width: 100%;
+    }
+    .eyebrow {
+      font-size: 11px; color: #9bc0a8; letter-spacing: 0.08em;
+      text-transform: uppercase; margin-bottom: 10px; text-align: center;
+    }
+    h1 {
+      font-size: 22px; font-weight: 600; line-height: 1.35; margin-bottom: 6px;
+      font-family: 'Newsreader', Georgia, serif; text-align: center;
+    }
+    .meta { font-size: 12px; color: #6b7a8f; text-align: center; margin-bottom: 24px; }
+    .bar-row { display: flex; align-items: center; gap: 10px; margin-bottom: 12px; font-size: 14px; }
+    .bar-label { width: 140px; flex-shrink: 0; }
+    .bar-track { flex: 1; background: #1e2d43; border-radius: 4px; height: 12px; }
+    .bar-fill { height: 100%; background: #d7b06a; border-radius: 4px; }
+    .bar-count { width: 36px; text-align: right; color: #6b7a8f; }
+    .answer-card {
+      background: #1a2538; border-radius: 8px; padding: 12px 14px;
+      font-size: 14px; line-height: 1.5; margin-bottom: 8px;
+    }
+    .footer {
+      font-size: 11px; color: #6b7a8f; text-align: center;
+      margin-top: 20px; padding-top: 16px; border-top: 1px solid #1e2d43;
+    }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <p class="eyebrow">Umfrageergebnis</p>
+    <h1>{poll.question}</h1>
+    <p class="meta">{total} Antworten &#xB7; abgeschlossen</p>
+
+    {poll.kind === 'multiple_choice' ? (
+      <div>
+        {counts.map(c => (
+          <div class="bar-row">
+            <span class="bar-label">{c.answer}</span>
+            <div class="bar-track">
+              <div
+                class="bar-fill"
+                style={`width:${total > 0 ? Math.round(c.count / total * 100) : 0}%`}
+              ></div>
+            </div>
+            <span class="bar-count">{c.count}</span>
+          </div>
+        ))}
+      </div>
+    ) : (
+      <div>
+        {counts.map(c => (
+          <div class="answer-card">&#x201E;{c.answer}&#x201C;</div>
+        ))}
+      </div>
+    )}
+
+    <p class="footer">Antworten waren anonym</p>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Admin creates one-shot polls from 5 predefined templates (or a custom free-text question) and broadcasts the link to all active Nextcloud Talk calls via the existing brett bot
- Anonymous participants scan a QR code or open the link, submit MC or free-text answers; one answer per browser session via `sessionStorage`
- Admin sees live answer counts with 5 s auto-refresh; clicking "Ergebnisse teilen & schließen" atomically locks the poll and posts aggregated results back to Talk with a public `/poll/[id]/results` URL

## Changes

- `k3d/website-schema.yaml` — two new tables (`polls`, `poll_answers`) with DB-level check constraints and a partial unique index enforcing at most one open poll at a time
- `website/src/lib/poll-db.ts` + `poll-db.test.ts` — DB helpers, `POLL_TEMPLATES` constant, `buildResultsBotMessage` pure function, 5 unit tests (5/5 passing)
- `website/src/pages/api/admin/poll/` — 4 admin API routes: create+broadcast, get active, get status, share+lock
- `website/src/pages/api/poll/` — 3 public API routes: get question, submit answer, get results (with UUID validation to prevent unhandled 500s)
- `website/src/pages/poll/[id].astro` — participant response page; safe DOM manipulation, sessionStorage dedup
- `website/src/pages/poll/[id]/results.astro` — public results page with bar chart (MC) or card list (text)
- `website/src/pages/admin/meetings.astro` — "Umfrage starten" button, creation modal with template picker, live status panel, QR code modal
- `website/package.json` — `qrcode` npm dependency for client-side QR generation

## Test Plan

- [ ] Deploy to dev cluster (`task workspace:deploy`) and verify `polls` + `poll_answers` tables are created
- [ ] Create a poll from `/admin/meetings`, verify status panel appears with 0 answers and QR modal renders
- [ ] Submit answers from two different browser profiles, verify live count updates within 5 s
- [ ] Click "Ergebnisse teilen & schließen", verify bot message in Talk and `/poll/[id]/results` shows bar chart
- [ ] Verify late answer submission returns 409 after locking
- [ ] Verify `/api/poll/not-a-uuid` returns 404 (not 500)

🤖 Generated with [Claude Code](https://claude.com/claude-code)