### PR TITLE
feat(portal): add Fragebögen section to user portal

### DIFF
--- a/website/src/components/portal/FragebogenSection.astro
+++ b/website/src/components/portal/FragebogenSection.astro
@@ -1,0 +1,67 @@
+---
+import type { QAssignment } from '../../lib/questionnaire-db';
+
+interface Props {
+  assignments: QAssignment[];
+}
+
+const { assignments } = Astro.props;
+
+const pending   = assignments.filter(a => a.status === 'pending' || a.status === 'in_progress');
+const completed = assignments.filter(a => a.status === 'submitted' || a.status === 'reviewed');
+
+function fmtDate(d: string) {
+  return new Date(d).toLocaleDateString('de-DE', { day: '2-digit', month: '2-digit', year: 'numeric' });
+}
+---
+
+<div class="pt-10 pb-20 px-8 max-w-2xl" data-testid="fragebogen-section">
+  <h2 class="text-xl font-bold text-light font-serif mb-6">Fragebögen</h2>
+
+  {pending.length === 0 && completed.length === 0 && (
+    <p class="text-muted text-sm">Keine Fragebögen zugewiesen.</p>
+  )}
+
+  {pending.length > 0 && (
+    <div class="mb-8">
+      <p class="text-xs font-semibold text-muted uppercase tracking-widest mb-3">Ausstehend</p>
+      <ul class="space-y-3">
+        {pending.map(a => (
+          <li>
+            <a href={`/portal/fragebogen/${a.id}`}
+               class="flex items-center justify-between gap-4 p-4 bg-dark-light rounded-xl border border-gold/30 hover:border-gold/60 transition-colors group">
+              <div>
+                <div class="text-light font-medium group-hover:text-gold transition-colors">{a.template_title}</div>
+                <div class="text-xs text-muted mt-0.5">Zugewiesen am {fmtDate(a.assigned_at)}</div>
+              </div>
+              <span class={`text-xs px-2 py-0.5 rounded-full shrink-0 ${a.status === 'in_progress' ? 'bg-blue-500/20 text-blue-400' : 'bg-amber-500/20 text-amber-400'}`}>
+                {a.status === 'in_progress' ? 'In Bearbeitung' : 'Ausstehend'}
+              </span>
+            </a>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )}
+
+  {completed.length > 0 && (
+    <div>
+      <p class="text-xs font-semibold text-muted uppercase tracking-widest mb-3">Abgeschlossen</p>
+      <ul class="space-y-2">
+        {completed.map(a => (
+          <li class="flex items-center justify-between gap-4 p-4 bg-dark-light rounded-xl border border-dark-lighter">
+            <div>
+              <div class="text-muted font-medium">{a.template_title}</div>
+              <div class="text-xs text-muted mt-0.5">
+                Eingereicht {a.submitted_at ? fmtDate(a.submitted_at) : '—'}
+              </div>
+            </div>
+            <span class="text-xs px-2 py-0.5 rounded-full bg-green-500/20 text-green-400 shrink-0">
+              {a.status === 'reviewed' ? 'Bewertet' : 'Eingereicht'}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )}
+</div>

--- a/website/src/layouts/PortalLayout.astro
+++ b/website/src/layouts/PortalLayout.astro
@@ -12,15 +12,17 @@ interface Props {
   section: string;
   session: UserSession;
   pendingSignatures: number;
+  pendingQuestionnaires?: number;
 }
 
-const { title, section, session, pendingSignatures } = Astro.props;
+const { title, section, session, pendingSignatures, pendingQuestionnaires = 0 } = Astro.props;
 
 const icons: Record<string, string> = {
   overview:       `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="2" width="5" height="5" rx="0.5"/><rect x="9" y="2" width="5" height="5" rx="0.5"/><rect x="2" y="9" width="5" height="5" rx="0.5"/><rect x="9" y="9" width="5" height="5" rx="0.5"/></svg>`,
   besprechungen:  `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="5.5" y="1.5" width="5" height="7" rx="2.5"/><path d="M3.5 8a4.5 4.5 0 0 0 9 0M8 12.5v2M6 14.5h4"/></svg>`,
   dateien:        `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M4 2h5.5L13 5.5V14H4V2z"/><path d="M9.5 2v3.5H13"/><path d="M6 8h4M6 10.5h4M6 13h2.5"/></svg>`,
   unterschriften: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M2.5 10.5c1-2 2-4 3-3s0 3 1.5 2 2-3 3-2"/><path d="M2.5 13.5h11"/></svg>`,
+  fragebögen:     `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="2.5" y="1.5" width="11" height="13" rx="1"/><path d="M5.5 5.5h5M5.5 8h3"/><circle cx="8" cy="11.5" r="0.75" fill="currentColor" stroke="none"/></svg>`,
   termine:        `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="12" height="11" rx="1"/><path d="M2 7h12M5.5 1.5v3M10.5 1.5v3"/></svg>`,
   rechnungen:     `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M4 1.5h8v13l-2-1.5-2 1.5-2-1.5-2 1.5z"/><path d="M6 6h4M6 8.5h4M6 11h2"/></svg>`,
   projekte:       `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M5.5 2.5h5v2.5h-5V2.5z"/><rect x="3" y="2.5" width="10" height="12" rx="1"/><path d="M5.5 7.5h5M5.5 10.5h5M5.5 13.5h3"/></svg>`,
@@ -59,6 +61,7 @@ const navGroups: NavGroup[] = [
     items: [
       { id: 'dateien',        label: 'Dateien',        icon: 'dateien' },
       { id: 'unterschriften', label: 'Unterschriften', icon: 'unterschriften', badge: pendingSignatures },
+      { id: 'fragebögen',    label: 'Fragebögen',    icon: 'fragebögen',    badge: pendingQuestionnaires },
     ],
   },
   {

--- a/website/src/pages/portal.astro
+++ b/website/src/pages/portal.astro
@@ -7,6 +7,8 @@ import { getClientBookings } from '../lib/caldav';
 import { getCustomerInvoices } from '../lib/stripe-billing';
 import { listFiles, getClientFolderPath, PENDING_SIGNATURES_DIR } from '../lib/nextcloud-files';
 import { countPendingAssignmentsForCustomer } from '../lib/documents-db';
+import { countPendingQAssignmentsForCustomer, listQAssignmentsForCustomer } from '../lib/questionnaire-db';
+import type { QAssignment } from '../lib/questionnaire-db';
 
 import OverviewSection      from '../components/portal/OverviewSection.astro';
 import NachrichtenSection   from '../components/portal/NachrichtenSection.astro';
@@ -19,6 +21,7 @@ import SignaturesTab        from '../components/portal/SignaturesTab.astro';
 import OnboardingTab        from '../components/portal/OnboardingTab.astro';
 import DiensteSection       from '../components/portal/DiensteSection.astro';
 import KontoSection         from '../components/portal/KontoSection.astro';
+import FragebogenSection    from '../components/portal/FragebogenSection.astro';
 
 const session = await getSession(Astro.request.headers.get('cookie'));
 if (!session) return Astro.redirect(getLoginUrl(Astro.url.pathname));
@@ -33,8 +36,9 @@ const keycloakBase = process.env.KEYCLOAK_FRONTEND_URL ?? '';
 const realm        = process.env.KEYCLOAK_REALM ?? 'workspace';
 
 // ── Badge counts (always fetched — needed for sidebar) ────────────
-let unreadMessages    = 0;
-let pendingSignatures = 0;
+let unreadMessages        = 0;
+let pendingSignatures     = 0;
+let pendingQuestionnaires = 0;
 
 // Ensure a customer record exists for every Keycloak user so room lookups work
 await upsertCustomer({ name: session.name, email: session.email, keycloakUserId: session.sub }).catch(() => null);
@@ -53,6 +57,7 @@ try {
 if (customer) {
   const docusealPending = await countPendingAssignmentsForCustomer(customer.id).catch(() => 0);
   pendingSignatures += docusealPending;
+  pendingQuestionnaires = await countPendingQAssignmentsForCustomer(customer.id).catch(() => 0);
 }
 
 // ── Section data (lazy — only what the active section needs) ──────
@@ -98,6 +103,10 @@ const bookings = section === 'termine'
 const projects = section === 'projekte'
   ? await listProjectsForCustomer(session.sub).catch(() => [])
   : [];
+
+const questionnaires: QAssignment[] = (section === 'fragebögen' && customer)
+  ? await listQAssignmentsForCustomer(customer.id).catch(() => [])
+  : [];
 ---
 
 <PortalLayout
@@ -105,6 +114,7 @@ const projects = section === 'projekte'
   {section}
   {session}
   {pendingSignatures}
+  {pendingQuestionnaires}
 >
   {section === 'overview'       && <OverviewSection {session} {nextBooking} {openInvoices} {unreadMessages} {onboardingPct} {ncBase} {vaultUrl} {wbUrl} />}
   {section === 'nachrichten'    && <NachrichtenSection {rooms} />}
@@ -125,6 +135,7 @@ const projects = section === 'projekte'
       <OnboardingTab keycloakUserId={session.sub} back={Astro.url.href} />
     </div>
   )}
+  {section === 'fragebögen'     && <FragebogenSection assignments={questionnaires} />}
   {section === 'dienste'        && <DiensteSection {ncBase} {vaultUrl} {wbUrl} {keycloakBase} />}
   {section === 'konto'          && <KontoSection {session} {keycloakBase} {realm} />}
 </PortalLayout>

--- a/website/src/pages/portal/fragebogen/[assignmentId].astro
+++ b/website/src/pages/portal/fragebogen/[assignmentId].astro
@@ -38,7 +38,8 @@ const pendingCount = await countPendingQAssignmentsForCustomer(customer.id).catc
   title={`Fragebogen — ${assignment.template_title}`}
   section="fragebögen"
   session={session}
-  pendingSignatures={pendingCount}
+  pendingSignatures={0}
+  pendingQuestionnaires={pendingCount}
 >
   <section class="pt-6 pb-20 bg-dark min-h-screen">
     <div class="max-w-3xl mx-auto px-6">


### PR DESCRIPTION
## Summary

- Questionnaires assigned to users were invisible in the client portal — the only way to reach them was a direct URL in the assignment email
- Adds a **Fragebögen** sidebar entry (under "Dokumente") with a pending-count badge, backed by the existing `countPendingQAssignmentsForCustomer` query
- Adds `FragebogenSection.astro` listing pending (with links to the wizard) and completed assignments
- Wires `portal.astro` to lazy-fetch assignments when the section is active and pass the badge count to `PortalLayout`
- Fixes `[assignmentId].astro` which was passing questionnaire count to `pendingSignatures` instead of the new `pendingQuestionnaires` prop

## Test plan

- [ ] Log in as a non-admin user (e.g. paddione) — sidebar shows "Fragebögen" entry
- [ ] Assign a published questionnaire to that user from the admin panel
- [ ] Reload portal — badge appears on the sidebar item
- [ ] Click "Fragebögen" — list shows the pending assignment with a link
- [ ] Click the link — wizard opens correctly
- [ ] Submit the questionnaire — returns to fragebögen section showing it as "Eingereicht"

🤖 Generated with [Claude Code](https://claude.com/claude-code)