### PR TITLE
feat(brett): add interactive globe widget with zoom sync

### DIFF
--- a/brett/public/index.html
+++ b/brett/public/index.html
@@ -184,9 +184,78 @@
     font-size: 11px; color: #444; pointer-events: none; text-align: center; line-height: 1.7; white-space: nowrap;
   }
   #selected-info {
-    position: absolute; bottom: 12px; right: 14px;
+    position: absolute; bottom: 12px; left: 14px;
     font-size: 12px; color: #777; pointer-events: none;
   }
+
+  #canvas-container { position: relative; flex: 1; overflow: hidden; min-height: 0; }
+
+  /* ── Globe widget ───────────────────────────────────────────────────── */
+  #globe-widget {
+    position: fixed; bottom: 20px; right: 20px; z-index: 50;
+    background: rgba(7, 14, 38, 0.95);
+    border: 1px solid #1a3060;
+    border-radius: 14px;
+    padding: 10px 11px 11px;
+    width: 176px;
+    backdrop-filter: blur(10px);
+    box-shadow: 0 8px 40px rgba(0,0,0,0.65), inset 0 1px 0 rgba(255,255,255,0.03);
+    user-select: none;
+  }
+  #globe-header {
+    display: flex; align-items: center; justify-content: space-between;
+    margin-bottom: 8px;
+  }
+  #globe-title {
+    font-size: 10px; color: #3a6090;
+    text-transform: uppercase; letter-spacing: 0.1em; font-weight: 600;
+  }
+  #globe-modes { display: flex; gap: 3px; }
+  .globe-mode-btn {
+    padding: 2px 6px; font-size: 13px; line-height: 1.4;
+    border: 1px solid #162a50; background: #0b1830; color: #2a4870;
+    border-radius: 4px; cursor: pointer; transition: all 0.12s; font-family: inherit;
+  }
+  .globe-mode-btn:hover { color: #5a80b8; border-color: #2a4070; }
+  .globe-mode-btn.active { background: #0f2d5e; color: #4a90d9; border-color: #2a5898; }
+  #globe-canvas-wrap {
+    width: 150px; height: 150px; border-radius: 50%; overflow: hidden;
+    margin: 0 auto 9px; cursor: grab;
+    border: 1px solid #1a3060;
+    box-shadow: inset 0 0 28px rgba(0,0,0,0.75), 0 0 18px rgba(20,60,160,0.22), 0 3px 10px rgba(0,0,0,0.6);
+  }
+  #globe-canvas-wrap:active { cursor: grabbing; }
+  .globe-row { display: flex; align-items: center; gap: 6px; margin-bottom: 5px; }
+  .globe-lbl {
+    font-size: 9.5px; color: #3a5878;
+    text-transform: uppercase; letter-spacing: 0.07em;
+    min-width: 46px; font-weight: 600;
+  }
+  #globe-scale-slider, #globe-speed-slider {
+    -webkit-appearance: none; appearance: none;
+    flex: 1; height: 3px; background: #0e2a50; border-radius: 2px; outline: none; cursor: pointer;
+  }
+  #globe-scale-slider::-webkit-slider-thumb {
+    -webkit-appearance: none; width: 11px; height: 11px; border-radius: 50%;
+    background: #4a90d9; cursor: pointer; border: 2px solid #08122a;
+    box-shadow: 0 0 6px rgba(74,144,217,0.6);
+  }
+  #globe-speed-slider::-webkit-slider-thumb {
+    -webkit-appearance: none; width: 11px; height: 11px; border-radius: 50%;
+    background: #6be0a0; cursor: pointer; border: 2px solid #08122a;
+    box-shadow: 0 0 6px rgba(107,224,160,0.5);
+  }
+  #globe-scale-val, #globe-speed-val {
+    font-size: 10.5px; color: #6a8caa; min-width: 30px; text-align: right;
+    font-variant-numeric: tabular-nums;
+  }
+  #globe-reset {
+    width: 100%; margin-top: 4px; padding: 5px;
+    background: #0b1830; border: 1px solid #162a50; color: #3a5878;
+    border-radius: 6px; cursor: pointer; font-size: 11px;
+    transition: all 0.14s; font-family: inherit;
+  }
+  #globe-reset:hover { background: #142840; color: #7aaac8; border-color: #2a4a70; }
 </style>
 </head>
 <body>
@@ -268,6 +337,31 @@
   <div id="selected-info"></div>
 </div>
 
+<div id="globe-widget">
+  <div id="globe-header">
+    <span id="globe-title">Ansicht</span>
+    <div id="globe-modes">
+      <button class="globe-mode-btn active" data-mode="solid" title="Solid">●</button>
+      <button class="globe-mode-btn" data-mode="wireframe" title="Gitter">◎</button>
+      <button class="globe-mode-btn" data-mode="both" title="Kombination">◉</button>
+    </div>
+  </div>
+  <div id="globe-canvas-wrap">
+    <canvas id="globe-canvas"></canvas>
+  </div>
+  <div class="globe-row">
+    <span class="globe-lbl">Skala</span>
+    <input type="range" id="globe-scale-slider" min="0.1" max="3" step="0.01" value="1">
+    <span id="globe-scale-val">1.00×</span>
+  </div>
+  <div class="globe-row">
+    <span class="globe-lbl">Rotation</span>
+    <input type="range" id="globe-speed-slider" min="0" max="2" step="0.05" value="0.3">
+    <span id="globe-speed-val">0.3×</span>
+  </div>
+  <button id="globe-reset">↺ Zurücksetzen</button>
+</div>
+
 <div id="confirm-modal">
   <div id="confirm-box">
     <p id="confirm-text">Alle Figuren entfernen?</p>
@@ -324,6 +418,8 @@
 <script src="/three.min.js"></script>
 <script>
 (function(){
+
+let globeSyncFn = null;
 
 // ─── Cluster integration config ──────────────────────────────────
 const params   = new URLSearchParams(window.location.search);
@@ -1213,6 +1309,7 @@ function setZoom(r) {
   zoomSlider.value = orbit.radius;
   zoomVal.textContent = Math.round(orbit.radius);
   updateCamera();
+  if (globeSyncFn) globeSyncFn(orbit.radius);
 }
 
 zoomSlider.addEventListener('input', () => setZoom(parseFloat(zoomSlider.value)));
@@ -1285,6 +1382,167 @@ function animate() {
   renderer.render(scene, camera);
 }
 animate();
+
+// ── Globe Widget ──────────────────────────────────────────────────────────────
+{
+  const DEFAULT_ZOOM = 44;
+
+  const gCvs = document.getElementById('globe-canvas');
+  const gR = new THREE.WebGLRenderer({ canvas: gCvs, antialias: true, alpha: true });
+  gR.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+  gR.setSize(150, 150);
+
+  const gSc = new THREE.Scene();
+  const gCam = new THREE.PerspectiveCamera(42, 1, 0.1, 50);
+  gCam.position.z = 3.2;
+
+  // Atmosphere halo (BackSide sphere slightly larger)
+  gSc.add(new THREE.Mesh(
+    new THREE.SphereGeometry(1.16, 32, 24),
+    new THREE.MeshBasicMaterial({ color: 0x1848a0, transparent: true, opacity: 0.15, side: THREE.BackSide })
+  ));
+
+  gSc.add(new THREE.AmbientLight(0x334477, 0.85));
+  const gSun = new THREE.DirectionalLight(0xaabbff, 1.9);
+  gSun.position.set(4, 2, 4);
+  gSc.add(gSun);
+  const gFill = new THREE.DirectionalLight(0x112244, 0.55);
+  gFill.position.set(-3, -1, -3);
+  gSc.add(gFill);
+
+  const gGeo = new THREE.SphereGeometry(1, 48, 32);
+
+  function makeGlobeTex() {
+    const W = 512, H = 256;
+    const cv = document.createElement('canvas');
+    cv.width = W; cv.height = H;
+    const c = cv.getContext('2d');
+    // Ocean
+    c.fillStyle = '#091c42'; c.fillRect(0, 0, W, H);
+    const grd = c.createRadialGradient(W*.3, H*.3, 0, W*.5, H*.5, W*.7);
+    grd.addColorStop(0, 'rgba(30,70,140,0.28)');
+    grd.addColorStop(1, 'rgba(4,10,28,0.28)');
+    c.fillStyle = grd; c.fillRect(0, 0, W, H);
+    // Land blobs (approximate equirectangular positions)
+    c.fillStyle = '#2b5c19';
+    const el = (cx, cy, rx, ry, rot) => {
+      c.save(); c.translate(cx, cy); if (rot) c.rotate(rot);
+      c.beginPath(); c.ellipse(0, 0, rx, ry, 0, 0, Math.PI * 2); c.fill(); c.restore();
+    };
+    el(80, 80, 38, 30, -0.3); el(65, 55, 20, 18, -0.1);   // North America
+    el(100, 165, 18, 32, 0.2);                              // South America
+    el(238, 68, 18, 20, 0); el(245, 145, 26, 48, 0);        // Europe + Africa
+    el(268, 90, 12, 14, 0.3);                               // Middle East
+    el(330, 55, 65, 42, -0.1); el(310, 38, 24, 14, 0);      // Asia
+    el(385, 55, 18, 16, 0);                                 // East Asia
+    el(295, 112, 14, 20, 0);                                // India
+    el(388, 172, 30, 22, 0.1);                              // Australia
+    el(155, 28, 18, 14, 0);                                 // Greenland
+    // Ice caps
+    c.fillStyle = 'rgba(200,225,248,0.82)'; c.fillRect(0, 0, W, 16);
+    c.fillStyle = 'rgba(210,235,252,0.88)'; c.fillRect(0, H - 18, W, 18);
+    // Polar atmosphere tint
+    const atm = c.createLinearGradient(0, 0, 0, H);
+    atm.addColorStop(0, 'rgba(60,120,220,0.12)');
+    atm.addColorStop(0.5, 'rgba(60,120,220,0)');
+    atm.addColorStop(1, 'rgba(60,120,220,0.12)');
+    c.fillStyle = atm; c.fillRect(0, 0, W, H);
+    const tex = new THREE.CanvasTexture(cv);
+    tex.wrapS = THREE.RepeatWrapping;
+    tex.wrapT = THREE.ClampToEdgeWrapping;
+    return tex;
+  }
+
+  const gSolMat = new THREE.MeshStandardMaterial({ map: makeGlobeTex(), roughness: 0.52, metalness: 0.06 });
+  const gSolMesh = new THREE.Mesh(gGeo, gSolMat);
+
+  const gWireGeo = new THREE.WireframeGeometry(new THREE.SphereGeometry(1.004, 20, 14));
+  const gWireMesh = new THREE.LineSegments(gWireGeo,
+    new THREE.LineBasicMaterial({ color: 0x4a90d9, transparent: true, opacity: 0.38 }));
+
+  const gGrp = new THREE.Group();
+  gSc.add(gGrp);
+
+  let gSF = 1.0, gRS = 0.3, gMode = 'solid';
+  let gDrag = false, gDS = {x: 0, y: 0};
+  let gMR = {x: 0, y: 0}, gAR = 0, gLT = 0;
+
+  function applyGlobeMode(m) {
+    gMode = m;
+    gGrp.remove(gSolMesh, gWireMesh);
+    gSolMat.transparent = m === 'both';
+    gSolMat.opacity = m === 'both' ? 0.76 : 1.0;
+    gSolMat.needsUpdate = true;
+    if (m !== 'wireframe') gGrp.add(gSolMesh);
+    if (m !== 'solid')     gGrp.add(gWireMesh);
+    document.querySelectorAll('.globe-mode-btn').forEach(b =>
+      b.classList.toggle('active', b.dataset.mode === m));
+  }
+
+  function applyGlobeScale(f, fromExternal) {
+    gSF = Math.max(0.1, Math.min(3.0, f));
+    gGrp.scale.setScalar(gSF);
+    document.getElementById('globe-scale-slider').value = gSF;
+    document.getElementById('globe-scale-val').textContent = gSF.toFixed(2) + '×';
+    if (!fromExternal) setZoom(DEFAULT_ZOOM / gSF);
+  }
+
+  // Called by setZoom when zoom changes via other controls
+  globeSyncFn = function(radius) {
+    applyGlobeScale(Math.max(0.1, Math.min(3.0, DEFAULT_ZOOM / radius)), true);
+  };
+
+  document.getElementById('globe-scale-slider').addEventListener('input', e =>
+    applyGlobeScale(parseFloat(e.target.value)));
+
+  document.getElementById('globe-speed-slider').addEventListener('input', e => {
+    gRS = parseFloat(e.target.value);
+    document.getElementById('globe-speed-val').textContent = gRS.toFixed(1) + '×';
+  });
+
+  document.querySelectorAll('.globe-mode-btn').forEach(btn =>
+    btn.addEventListener('click', () => applyGlobeMode(btn.dataset.mode)));
+
+  document.getElementById('globe-reset').addEventListener('click', () => {
+    applyGlobeScale(1.0);
+    gRS = 0.3;
+    document.getElementById('globe-speed-slider').value = 0.3;
+    document.getElementById('globe-speed-val').textContent = '0.3×';
+    applyGlobeMode('solid');
+    gMR = {x: 0, y: 0}; gAR = 0;
+  });
+
+  const gWrap = document.getElementById('globe-canvas-wrap');
+  gWrap.addEventListener('mousedown', e => {
+    gDrag = true; gDS = {x: e.clientX, y: e.clientY};
+    e.preventDefault(); e.stopPropagation();
+  });
+  window.addEventListener('mousemove', e => {
+    if (!gDrag) return;
+    gMR.y += (e.clientX - gDS.x) * 0.018;
+    gMR.x = Math.max(-1.5, Math.min(1.5, gMR.x + (e.clientY - gDS.y) * 0.018));
+    gDS = {x: e.clientX, y: e.clientY};
+  });
+  window.addEventListener('mouseup', () => { gDrag = false; });
+
+  gWrap.addEventListener('wheel', e => {
+    applyGlobeScale(gSF - e.deltaY * 0.003);
+    e.preventDefault(); e.stopPropagation();
+  }, { passive: false });
+
+  function animGlobe(t) {
+    requestAnimationFrame(animGlobe);
+    const dt = Math.min((t - gLT) * 0.001, 0.05); gLT = t;
+    if (!gDrag) gAR += gRS * dt;
+    gGrp.rotation.y = gAR + gMR.y;
+    gGrp.rotation.x = gMR.x;
+    gR.render(gSc, gCam);
+  }
+  requestAnimationFrame(animGlobe);
+
+  applyGlobeMode('solid');
+  globeSyncFn(orbit.radius);
+}
 
 connect();
 


### PR DESCRIPTION
## Summary
- Adds a Three.js globe widget overlay to the 3D whiteboard (brett)
- Globe scale syncs bidirectionally with the main camera orbit radius
- User controls: drag-to-rotate, scale slider, rotation speed slider, render mode (solid/wireframe/both), reset button

## Test plan
- [ ] Open brett whiteboard, verify globe widget appears in bottom-right
- [ ] Drag globe to rotate, adjust sliders, switch render modes
- [ ] Verify zoom slider syncs globe scale and vice versa

🤖 Generated with [Claude Code](https://claude.com/claude-code)