### PR TITLE
fix(questionnaire): fix reactivity bug and improve option selection UX

### DIFF
--- a/website/src/components/portal/QuestionnaireWizard.svelte
+++ b/website/src/components/portal/QuestionnaireWizard.svelte
@@ -9,7 +9,10 @@
   };
   const { assignmentId, title, instructions, questions, initialAnswers }: Props = $props();
 
-  const answerMap = $state(new Map(initialAnswers.map(a => [a.question_id, a.option_key])));
+  // Plain object instead of Map — Svelte 5 tracks property assignments reliably
+  let answers = $state<Record<string, string>>(
+    Object.fromEntries(initialAnswers.map(a => [a.question_id, a.option_key]))
+  );
   let currentIndex = $state(0);
   let phase: 'intro' | 'question' | 'done' = $state(initialAnswers.length === 0 ? 'intro' : 'question');
   let saving = $state(false);
@@ -18,14 +21,15 @@
 
   // Resume at first unanswered question
   if (initialAnswers.length > 0) {
-    const firstUnanswered = questions.findIndex(q => !answerMap.has(q.id));
+    const firstUnanswered = questions.findIndex(q => !(q.id in answers));
     currentIndex = firstUnanswered >= 0 ? firstUnanswered : questions.length - 1;
   }
 
   const current = $derived(questions[currentIndex]);
-  const answered = $derived(answerMap.size);
+  const answered = $derived(Object.keys(answers).length);
   const total = $derived(questions.length);
   const progressPct = $derived(Math.round((answered / total) * 100));
+  const allAnswered = $derived(answered >= total);
 
   async function selectOption(optionKey: string) {
     if (!current || saving) return;
@@ -37,8 +41,10 @@
         body: JSON.stringify({ question_id: current.id, option_key: optionKey }),
       });
       if (r.ok) {
-        answerMap.set(current.id, optionKey);
+        answers[current.id] = optionKey;
         if (currentIndex < questions.length - 1) {
+          // Short delay so the selection highlight is visible before advancing
+          await new Promise(r => setTimeout(r, 200));
           currentIndex++;
         }
       } else {
@@ -94,7 +100,7 @@
     {/if}
     <p class="text-muted text-sm mb-6">{total} Fragen · Ihre Antworten werden automatisch gespeichert.</p>
     <button onclick={() => { phase = 'question'; }}
-      class="px-6 py-3 bg-gold text-dark rounded-xl font-semibold hover:bg-gold/80 transition-colors">
+      class="px-6 py-3 bg-gold text-dark rounded-xl font-semibold hover:bg-gold/80 transition-colors cursor-pointer">
       Fragebogen starten →
     </button>
   </div>
@@ -105,9 +111,9 @@
     <div class="mb-6">
       <div class="flex justify-between text-xs text-muted mb-2">
         <span>Frage {currentIndex + 1} von {total}</span>
-        <span>{answered} beantwortet</span>
+        <span>{answered} von {total} beantwortet</span>
       </div>
-      <div class="h-1.5 bg-dark-light rounded-full overflow-hidden">
+      <div class="h-2 bg-dark-light rounded-full overflow-hidden">
         <div class="h-full bg-gold rounded-full transition-all duration-300" style={`width: ${progressPct}%`}></div>
       </div>
     </div>
@@ -118,17 +124,22 @@
         <p class="text-muted text-xs mb-3">Wählen Sie die Aussage, die besser auf Sie zutrifft:</p>
         <div class="flex flex-col gap-3">
           {#each abOptions(current.question_text) as opt}
-            {@const isChosen = answerMap.get(current.id) === opt.key}
+            {@const isChosen = answers[current.id] === opt.key}
             <button
               onclick={() => selectOption(opt.key)}
               disabled={saving}
-              class={`text-left p-4 rounded-xl border transition-all text-sm ${
+              class={`text-left p-4 rounded-xl border-2 transition-all text-sm cursor-pointer flex items-start gap-3 ${
                 isChosen
-                  ? 'border-gold bg-gold/10 text-light'
-                  : 'border-dark-lighter bg-dark text-muted hover:border-gold/40 hover:text-light'
-              }`}
+                  ? 'border-gold bg-gold/20 text-light shadow-[0_0_0_1px_theme(colors.gold/0.3)]'
+                  : 'border-dark-lighter bg-dark text-muted hover:border-gold/50 hover:text-light hover:bg-dark-lighter'
+              } ${saving ? 'opacity-60 cursor-not-allowed' : ''}`}
             >
-              {opt.label}
+              <span class={`mt-0.5 w-5 h-5 rounded-full border-2 flex-shrink-0 flex items-center justify-center text-xs font-bold ${
+                isChosen ? 'border-gold bg-gold text-dark' : 'border-muted/40'
+              }`}>
+                {#if isChosen}✓{/if}
+              </span>
+              <span>{opt.label}</span>
             </button>
           {/each}
         </div>
@@ -136,17 +147,17 @@
         <p class="text-light text-base mb-4 whitespace-pre-line">{current.question_text}</p>
         <div class="flex gap-3">
           {#each ['Ja', 'Nein'] as opt}
-            {@const isChosen = answerMap.get(current.id) === opt}
+            {@const isChosen = answers[current.id] === opt}
             <button
               onclick={() => selectOption(opt)}
               disabled={saving}
-              class={`flex-1 py-3 rounded-xl border text-sm font-medium transition-all ${
+              class={`flex-1 py-4 rounded-xl border-2 text-sm font-semibold transition-all cursor-pointer ${
                 isChosen
-                  ? 'border-gold bg-gold/10 text-gold'
-                  : 'border-dark-lighter bg-dark text-muted hover:border-gold/40 hover:text-light'
-              }`}
+                  ? 'border-gold bg-gold text-dark shadow-md'
+                  : 'border-dark-lighter bg-dark text-muted hover:border-gold/50 hover:text-light hover:bg-dark-lighter'
+              } ${saving ? 'opacity-60 cursor-not-allowed' : ''}`}
             >
-              {opt}
+              {#if isChosen}<span class="mr-1">✓</span>{/if}{opt}
             </button>
           {/each}
         </div>
@@ -156,23 +167,31 @@
         <p class="text-muted text-xs mb-4">Die Aussage trifft auf mich zu:</p>
         <div class="flex gap-2">
           {#each likertOptions() as opt}
-            {@const isChosen = answerMap.get(current.id) === opt}
+            {@const isChosen = answers[current.id] === opt}
             <button
               onclick={() => selectOption(opt)}
               disabled={saving}
-              class={`flex-1 flex flex-col items-center gap-1 py-3 rounded-xl border text-sm transition-all ${
+              class={`flex-1 flex flex-col items-center gap-1.5 py-3 rounded-xl border-2 text-sm transition-all cursor-pointer ${
                 isChosen
-                  ? 'border-gold bg-gold/10 text-gold'
-                  : 'border-dark-lighter bg-dark text-muted hover:border-gold/40 hover:text-light'
-              }`}
+                  ? 'border-gold bg-gold text-dark shadow-md'
+                  : 'border-dark-lighter bg-dark text-muted hover:border-gold/50 hover:text-light hover:bg-dark-lighter'
+              } ${saving ? 'opacity-60 cursor-not-allowed' : ''}`}
             >
-              <span class="font-bold">{opt}</span>
+              <span class="font-bold text-base">{opt}</span>
               <span class="text-xs text-center leading-tight hidden sm:block">{likertLabel(opt)}</span>
             </button>
           {/each}
         </div>
+        <div class="flex justify-between text-xs text-muted mt-2 px-1">
+          <span>Gar nicht</span>
+          <span>Voll und ganz</span>
+        </div>
       {/if}
     </div>
+
+    {#if saving}
+      <p class="text-muted text-xs mb-3 animate-pulse">Speichern…</p>
+    {/if}
 
     {#if error}
       <p class="text-red-400 text-sm mb-3">{error}</p>
@@ -183,30 +202,35 @@
       <button
         onclick={() => currentIndex = Math.max(0, currentIndex - 1)}
         disabled={currentIndex === 0}
-        class="px-4 py-2 border border-dark-lighter text-muted rounded-lg text-sm hover:text-light disabled:opacity-30 transition-colors"
+        class="px-4 py-2 border border-dark-lighter text-muted rounded-lg text-sm hover:text-light disabled:opacity-30 transition-colors cursor-pointer"
       >← Zurück</button>
 
       {#if currentIndex < questions.length - 1}
         <button
           onclick={() => currentIndex++}
-          disabled={!answerMap.has(current.id)}
-          class="px-4 py-2 bg-gold text-dark rounded-lg text-sm font-semibold hover:bg-gold/80 disabled:opacity-50 transition-colors"
+          disabled={!(current.id in answers)}
+          class="px-4 py-2 bg-gold text-dark rounded-lg text-sm font-semibold hover:bg-gold/80 disabled:opacity-40 transition-colors cursor-pointer"
         >Weiter →</button>
       {:else}
-        <button
-          onclick={submit}
-          disabled={submitting || answered < total}
-          class="px-6 py-2 bg-gold text-dark rounded-lg text-sm font-semibold hover:bg-gold/80 disabled:opacity-50 transition-colors"
-        >
-          {submitting ? 'Wird abgesendet…' : `Fragebogen absenden (${answered}/${total})`}
-        </button>
+        <div class="flex flex-col items-end gap-1">
+          {#if !allAnswered}
+            <p class="text-muted text-xs">Noch {total - answered} Frage(n) offen</p>
+          {/if}
+          <button
+            onclick={submit}
+            disabled={submitting || !allAnswered}
+            class="px-6 py-2 bg-gold text-dark rounded-lg text-sm font-semibold hover:bg-gold/80 disabled:opacity-40 transition-colors cursor-pointer"
+          >
+            {submitting ? 'Wird abgesendet…' : allAnswered ? 'Fragebogen absenden ✓' : `Absenden (${answered}/${total})`}
+          </button>
+        </div>
       {/if}
     </div>
   </div>
 
 {:else if phase === 'done'}
   <div class="max-w-2xl mx-auto text-center py-16">
-    <div class="text-4xl mb-4">✓</div>
+    <div class="text-5xl mb-4">✓</div>
     <h1 class="text-2xl font-bold text-light font-serif mb-3">Vielen Dank!</h1>
     <p class="text-muted mb-6">Ihr Fragebogen wurde erfolgreich eingereicht. Ihr Coach wird die Ergebnisse mit Ihnen besprechen.</p>
     <a href="/portal" class="text-gold hover:underline text-sm">← Zurück zum Portal</a>


### PR DESCRIPTION
## Summary
- Replace `$state(new Map())` with `$state({})` plain object — Svelte 5 doesn't reliably track `Map.set()` mutations in derived values, causing the submit button to stay disabled after answering the last question until page reload
- Selected options now use filled gold background (`bg-gold`) instead of barely-visible 10% opacity (`bg-gold/10`), with a ✓ checkmark indicator
- Added 200ms delay before auto-advancing so the selected highlight is visible before moving to the next question
- Improved Ja/Nein and Likert buttons with `border-2` and stronger selected states
- Added `cursor-pointer` to all interactive elements

## Test plan
- [ ] Fill all questions in a Fragebogen → submit button should activate immediately after the last answer
- [ ] Selected option should be clearly highlighted in gold with a checkmark
- [ ] Likert scale (1–5) selected button shows gold fill
- [ ] Ja/Nein selected button shows gold fill
- [ ] Auto-advance shows selection briefly before moving to next question

🤖 Generated with [Claude Code](https://claude.com/claude-code)