### PR TITLE
fix(projekte): fix redirect bug, repair Teilprojekte/Aufgaben, add file attachments

### DIFF
--- a/website/src/lib/nextcloud-files.ts
+++ b/website/src/lib/nextcloud-files.ts
@@ -181,5 +181,17 @@ export function getClientFolderPath(username: string): string {
   return `Clients/${username}/`;
 }
 
+/**
+ * Delete a file from Nextcloud (WebDAV DELETE).
+ */
+export async function deleteFile(filePath: string): Promise<boolean> {
+  const url = davUrl(filePath);
+  const res = await fetch(url, {
+    method: 'DELETE',
+    headers: { Authorization: authHeader() },
+  });
+  return res.status === 204 || res.status === 200;
+}
+
 export const PENDING_SIGNATURES_DIR = 'pending-signatures';
 export const SIGNED_DIR = 'signed';

--- a/website/src/lib/redirect.ts
+++ b/website/src/lib/redirect.ts
@@ -1,0 +1,6 @@
+const SITE_URL = (process.env.SITE_URL || '').replace(/\/$/, '');
+
+export function siteRedirect(path: string, status: 301 | 302 | 303 | 307 | 308 = 303): Response {
+  const base = SITE_URL || 'http://localhost:4321';
+  return Response.redirect(`${base}${path.startsWith('/') ? path : '/' + path}`, status);
+}

--- a/website/src/lib/website-db.ts
+++ b/website/src/lib/website-db.ts
@@ -948,6 +948,17 @@ async function initProjectTables(): Promise<void> {
       updated_at     TIMESTAMPTZ NOT NULL DEFAULT now()
     )
   `);
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS project_attachments (
+      id          UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+      project_id  UUID        NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+      filename    TEXT        NOT NULL,
+      nc_path     TEXT        NOT NULL,
+      mime_type   TEXT        NOT NULL DEFAULT 'application/octet-stream',
+      file_size   BIGINT      NOT NULL DEFAULT 0,
+      uploaded_at TIMESTAMPTZ NOT NULL DEFAULT now()
+    )
+  `);
   projectTablesReady = true;
 }
 
@@ -1183,6 +1194,61 @@ export async function updateProjectTask(id: string, params: {
 
 export async function deleteProjectTask(id: string): Promise<void> {
   await pool.query('DELETE FROM project_tasks WHERE id=$1', [id]);
+}
+
+// Project Attachments ─────────────────────────────────────────────────────────
+
+export interface ProjectAttachment {
+  id: string;
+  projectId: string;
+  filename: string;
+  ncPath: string;
+  mimeType: string;
+  fileSize: number;
+  uploadedAt: Date;
+}
+
+export async function listProjectAttachments(projectId: string): Promise<ProjectAttachment[]> {
+  await initProjectTables();
+  const r = await pool.query(
+    `SELECT id, project_id AS "projectId", filename, nc_path AS "ncPath",
+            mime_type AS "mimeType", file_size AS "fileSize", uploaded_at AS "uploadedAt"
+     FROM project_attachments WHERE project_id=$1 ORDER BY uploaded_at DESC`,
+    [projectId]
+  );
+  return r.rows;
+}
+
+export async function getProjectAttachment(id: string): Promise<ProjectAttachment | null> {
+  await initProjectTables();
+  const r = await pool.query(
+    `SELECT id, project_id AS "projectId", filename, nc_path AS "ncPath",
+            mime_type AS "mimeType", file_size AS "fileSize", uploaded_at AS "uploadedAt"
+     FROM project_attachments WHERE id=$1`,
+    [id]
+  );
+  return r.rows[0] ?? null;
+}
+
+export async function createProjectAttachment(params: {
+  projectId: string; filename: string; ncPath: string; mimeType: string; fileSize: number;
+}): Promise<string> {
+  await initProjectTables();
+  const r = await pool.query(
+    `INSERT INTO project_attachments (project_id, filename, nc_path, mime_type, file_size)
+     VALUES ($1,$2,$3,$4,$5) RETURNING id`,
+    [params.projectId, params.filename, params.ncPath, params.mimeType, params.fileSize]
+  );
+  return r.rows[0].id;
+}
+
+export async function deleteProjectAttachmentRecord(id: string): Promise<string | null> {
+  await initProjectTables();
+  const r = await pool.query(
+    'DELETE FROM project_attachments WHERE id=$1 RETURNING nc_path',
+    [id]
+  );
+  return r.rows[0]?.nc_path ?? null;
 }
 
 // ── Portal: user-scoped project access ───────────────────────────────────────

--- a/website/src/pages/admin/projekte/[id].astro
+++ b/website/src/pages/admin/projekte/[id].astro
@@ -5,8 +5,9 @@ import {
   getProject, listSubProjects, listDirectTasks, listSubProjectTasks, listAllCustomers,
   listTimeEntries, getProjectTotalMinutes,
   listMeetingsForProject, listUnassignedMeetingsForCustomer,
+  listProjectAttachments,
 } from '../../../lib/website-db';
-import type { Project, SubProject, ProjectTask, Customer, TimeEntry, MeetingWithDetails } from '../../../lib/website-db';
+import type { Project, SubProject, ProjectTask, Customer, TimeEntry, MeetingWithDetails, ProjectAttachment } from '../../../lib/website-db';
 import ProjectMeetingsTab from '../../../components/admin/ProjectMeetingsTab.astro';
 
 const session = await getSession(Astro.request.headers.get('cookie'));
@@ -26,6 +27,7 @@ let timeEntries: TimeEntry[] = [];
 let timeStats: { total: number; billable: number } = { total: 0, billable: 0 };
 let meetings: MeetingWithDetails[] = [];
 let unassignedMeetings: Array<{ id: string; meetingType: string; status: string; createdAt: Date }> = [];
+let attachments: ProjectAttachment[] = [];
 let dbError = '';
 
 try {
@@ -37,11 +39,12 @@ try {
         project.customerId ? listUnassignedMeetingsForCustomer(project.customerId) : Promise.resolve([]),
       ]);
     } else {
-      [subProjects, directTasks, timeEntries, timeStats] = await Promise.all([
+      [subProjects, directTasks, timeEntries, timeStats, attachments] = await Promise.all([
         listSubProjects(id),
         listDirectTasks(id),
         listTimeEntries(id),
         getProjectTotalMinutes(id),
+        listProjectAttachments(id),
       ]);
     }
   }
@@ -466,6 +469,67 @@ const tasksJson = JSON.stringify(allTasksFlat.map(t => ({
               </div>
             )}
           </section>
+
+          {/* ── Anhänge ── */}
+          <section class="mt-10" id="attachments-section">
+            <div class="flex items-center justify-between mb-4">
+              <div>
+                <h2 class="text-xl font-semibold text-light font-serif">Anhänge</h2>
+                <p class="text-muted text-sm mt-0.5">{attachments.length} {attachments.length === 1 ? 'Datei' : 'Dateien'}</p>
+              </div>
+              <button type="button" id="upload-btn"
+                class="px-3 py-1.5 bg-gold hover:bg-gold-light text-dark text-sm font-semibold rounded-lg transition-colors">
+                + Datei anhängen
+              </button>
+            </div>
+
+            {attachments.length === 0 ? (
+              <p class="text-muted text-sm">Noch keine Anhänge.</p>
+            ) : (
+              <div class="bg-dark-light rounded-xl border border-dark-lighter overflow-hidden">
+                <table class="w-full">
+                  <thead>
+                    <tr class="border-b border-dark-lighter">
+                      <th class="text-left px-4 py-2 text-xs text-muted uppercase tracking-wide font-medium">Dateiname</th>
+                      <th class="text-left px-4 py-2 text-xs text-muted uppercase tracking-wide font-medium">Typ</th>
+                      <th class="text-right px-4 py-2 text-xs text-muted uppercase tracking-wide font-medium">Größe</th>
+                      <th class="text-left px-4 py-2 text-xs text-muted uppercase tracking-wide font-medium">Hochgeladen</th>
+                      <th class="px-4 py-2"></th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {attachments.map(a => (
+                      <tr class="border-b border-dark-lighter/50 hover:bg-dark/30 transition-colors">
+                        <td class="px-4 py-3 text-sm text-light max-w-[220px] truncate">{a.filename}</td>
+                        <td class="px-4 py-3 text-xs text-muted">{a.mimeType.split('/')[1] ?? a.mimeType}</td>
+                        <td class="px-4 py-3 text-xs text-muted text-right font-mono">
+                          {a.fileSize < 1024 ? `${a.fileSize} B`
+                            : a.fileSize < 1024 * 1024 ? `${(a.fileSize / 1024).toFixed(1)} KB`
+                            : `${(a.fileSize / 1024 / 1024).toFixed(1)} MB`}
+                        </td>
+                        <td class="px-4 py-3 text-xs text-muted whitespace-nowrap">
+                          {new Date(a.uploadedAt).toLocaleDateString('de-DE', { day: '2-digit', month: '2-digit', year: 'numeric' })}
+                        </td>
+                        <td class="px-4 py-3">
+                          <div class="flex gap-3 justify-end">
+                            <a href={`/api/admin/projekte/attachments/download?id=${a.id}`}
+                              class="text-xs text-gold hover:text-gold-light transition-colors">
+                              ↓ Download
+                            </a>
+                            <form method="post" action="/api/admin/projekte/attachments/delete" class="delete-attachment-form">
+                              <input type="hidden" name="id"    value={a.id} />
+                              <input type="hidden" name="_back" value={`/admin/projekte/${project.id}`} />
+                              <button type="submit" class="text-xs text-red-400/60 hover:text-red-400 transition-colors">Löschen</button>
+                            </form>
+                          </div>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </section>
           </>
           )}
         </>
@@ -601,6 +665,25 @@ const tasksJson = JSON.stringify(allTasksFlat.map(t => ({
       <div class="flex gap-3 justify-end pt-2">
         <button type="button" id="time-create-cancel" class="px-4 py-2 text-sm text-muted hover:text-light transition-colors">Abbrechen</button>
         <button type="submit" class="px-4 py-2 text-sm bg-gold hover:bg-gold-light text-dark font-semibold rounded-lg transition-colors">Speichern</button>
+      </div>
+    </form>
+  </dialog>
+
+  {/* ── Upload attachment dialog ── */}
+  <dialog id="upload-dialog" class="bg-dark-light border border-dark-lighter rounded-2xl p-6 w-full max-w-md backdrop:bg-black/60">
+    <h2 class="text-lg font-semibold text-light mb-4 font-serif">Datei anhängen</h2>
+    <form method="post" action="/api/admin/projekte/attachments/upload" enctype="multipart/form-data" class="space-y-4">
+      <input type="hidden" name="projectId" value={project?.id ?? ''} />
+      <input type="hidden" name="_back"     value={`/admin/projekte/${project?.id ?? ''}`} />
+      <div>
+        <label class={labelCls}>Datei <span class="text-red-400">*</span></label>
+        <input type="file" name="file" required
+          class="w-full text-sm text-muted file:mr-3 file:py-1.5 file:px-3 file:rounded file:border-0 file:text-xs file:font-medium file:bg-gold/20 file:text-gold hover:file:bg-gold/30 file:cursor-pointer cursor-pointer" />
+        <p class="text-xs text-muted mt-1">Max. 50 MB</p>
+      </div>
+      <div class="flex gap-3 justify-end pt-2">
+        <button type="button" id="upload-cancel" class="px-4 py-2 text-sm text-muted hover:text-light transition-colors">Abbrechen</button>
+        <button type="submit" class="px-4 py-2 text-sm bg-gold hover:bg-gold-light text-dark font-semibold rounded-lg transition-colors">Hochladen</button>
       </div>
     </form>
   </dialog>
@@ -747,6 +830,18 @@ const tasksJson = JSON.stringify(allTasksFlat.map(t => ({
       if (!confirm('Aufgabe löschen?')) e.preventDefault();
     });
   });
+
+  // ── Delete attachment confirm ──
+  document.querySelectorAll('.delete-attachment-form').forEach(form => {
+    form.addEventListener('submit', e => {
+      if (!confirm('Anhang wirklich löschen?')) e.preventDefault();
+    });
+  });
+
+  // ── Upload dialog ──
+  const uploadDialog = document.getElementById('upload-dialog') as HTMLDialogElement;
+  document.getElementById('upload-btn')?.addEventListener('click', () => uploadDialog.showModal());
+  document.getElementById('upload-cancel')?.addEventListener('click', () => uploadDialog.close());
 
   // ── Zeit buchen dialog ──
   const timeDialog = document.getElementById('time-create-dialog') as HTMLDialogElement;

--- a/website/src/pages/api/admin/projekte/attachments/delete.ts
+++ b/website/src/pages/api/admin/projekte/attachments/delete.ts
@@ -1,0 +1,29 @@
+import type { APIRoute } from 'astro';
+import { getSession, isAdmin } from '../../../../../lib/auth';
+import { deleteProjectAttachmentRecord } from '../../../../../lib/website-db';
+import { deleteFile } from '../../../../../lib/nextcloud-files';
+import { siteRedirect } from '../../../../../lib/redirect';
+
+export const POST: APIRoute = async ({ request }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) return new Response(null, { status: 403 });
+
+  const form = await request.formData();
+  const id   = form.get('id')?.toString().trim() ?? '';
+  const back = form.get('_back')?.toString()      || '/admin/projekte';
+
+  if (!id) return siteRedirect(`${back}?error=ID+fehlt`);
+
+  try {
+    const ncPath = await deleteProjectAttachmentRecord(id);
+    if (ncPath) {
+      // Best-effort: don't fail the request if Nextcloud delete errors
+      deleteFile(ncPath).catch(err => console.error('[attachments/delete] nc', err));
+    }
+  } catch (err) {
+    console.error('[attachments/delete] db', err);
+    return siteRedirect(`${back}?error=Fehler+beim+Löschen`);
+  }
+
+  return siteRedirect(back);
+};

--- a/website/src/pages/api/admin/projekte/attachments/download.ts
+++ b/website/src/pages/api/admin/projekte/attachments/download.ts
@@ -1,0 +1,41 @@
+import type { APIRoute } from 'astro';
+import { getSession, isAdmin } from '../../../../../lib/auth';
+import { getProjectAttachment } from '../../../../../lib/website-db';
+import { downloadFile } from '../../../../../lib/nextcloud-files';
+
+export const GET: APIRoute = async ({ request, url }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) return new Response(null, { status: 403 });
+
+  const id = url.searchParams.get('id') ?? '';
+  if (!id) return new Response('Missing id', { status: 400 });
+
+  let attachment;
+  try {
+    attachment = await getProjectAttachment(id);
+  } catch (err) {
+    console.error('[attachments/download] db', err);
+    return new Response('Internal error', { status: 500 });
+  }
+
+  if (!attachment) return new Response('Not found', { status: 404 });
+
+  let buffer: Buffer;
+  try {
+    buffer = await downloadFile(attachment.ncPath);
+  } catch (err) {
+    console.error('[attachments/download] nc', err);
+    return new Response('Download failed', { status: 502 });
+  }
+
+  const safeFilename = attachment.filename.replace(/["\r\n]/g, '_');
+
+  return new Response(new Uint8Array(buffer), {
+    headers: {
+      'Content-Type': attachment.mimeType,
+      'Content-Disposition': `attachment; filename="${safeFilename}"`,
+      'Content-Length': String(buffer.length),
+      'Cache-Control': 'private, no-store',
+    },
+  });
+};

--- a/website/src/pages/api/admin/projekte/attachments/upload.ts
+++ b/website/src/pages/api/admin/projekte/attachments/upload.ts
@@ -1,0 +1,42 @@
+import type { APIRoute } from 'astro';
+import { getSession, isAdmin } from '../../../../../lib/auth';
+import { createProjectAttachment } from '../../../../../lib/website-db';
+import { ensureFolder, uploadFile } from '../../../../../lib/nextcloud-files';
+import { siteRedirect } from '../../../../../lib/redirect';
+import { randomUUID } from 'node:crypto';
+
+const MAX_FILE_SIZE = 50 * 1024 * 1024; // 50 MB
+
+export const POST: APIRoute = async ({ request }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) return new Response(null, { status: 403 });
+
+  const form      = await request.formData();
+  const projectId = form.get('projectId')?.toString().trim() ?? '';
+  const file      = form.get('file') as File | null;
+  const back      = form.get('_back')?.toString() || '/admin/projekte';
+
+  if (!projectId || !file || !file.name || file.size === 0) {
+    return siteRedirect(`${back}?error=Keine+Datei+ausgewählt`);
+  }
+
+  if (file.size > MAX_FILE_SIZE) {
+    return siteRedirect(`${back}?error=Datei+zu+groß+(max+50+MB)`);
+  }
+
+  const attachmentId = randomUUID();
+  const ncPath       = `Projects/${projectId}/${attachmentId}`;
+  const mimeType     = file.type || 'application/octet-stream';
+
+  try {
+    const buffer = Buffer.from(await file.arrayBuffer());
+    await ensureFolder(`Projects/${projectId}`);
+    await uploadFile(ncPath, buffer, mimeType);
+    await createProjectAttachment({ projectId, filename: file.name, ncPath, mimeType, fileSize: file.size });
+  } catch (err) {
+    console.error('[attachments/upload]', err);
+    return siteRedirect(`${back}?error=Upload+fehlgeschlagen`);
+  }
+
+  return siteRedirect(back);
+};

--- a/website/src/pages/api/admin/projekte/create.ts
+++ b/website/src/pages/api/admin/projekte/create.ts
@@ -1,6 +1,7 @@
 import type { APIRoute } from 'astro';
 import { getSession, isAdmin } from '../../../../lib/auth';
 import { createProject } from '../../../../lib/website-db';
+import { siteRedirect } from '../../../../lib/redirect';
 
 export const POST: APIRoute = async ({ request }) => {
   const session = await getSession(request.headers.get('cookie'));
@@ -18,7 +19,7 @@ export const POST: APIRoute = async ({ request }) => {
   const customerId  = form.get('customerId')?.toString().trim()  ?? '';
 
   if (!name) {
-    return Response.redirect(new URL('/admin/projekte?error=Name+ist+erforderlich', request.url), 303);
+    return siteRedirect('/admin/projekte?error=Name+ist+erforderlich');
   }
 
   let id: string;
@@ -26,8 +27,8 @@ export const POST: APIRoute = async ({ request }) => {
     id = await createProject({ brand, name, description, notes, startDate, dueDate, status, priority, customerId });
   } catch (err) {
     console.error('[projekte/create]', err);
-    return Response.redirect(new URL('/admin/projekte?error=Datenbankfehler', request.url), 303);
+    return siteRedirect('/admin/projekte?error=Datenbankfehler');
   }
 
-  return Response.redirect(new URL(`/admin/projekte/${id}?saved=1`, request.url), 303);
+  return siteRedirect(`/admin/projekte/${id}?saved=1`);
 };

--- a/website/src/pages/api/admin/projekte/delete.ts
+++ b/website/src/pages/api/admin/projekte/delete.ts
@@ -1,6 +1,7 @@
 import type { APIRoute } from 'astro';
 import { getSession, isAdmin } from '../../../../lib/auth';
 import { deleteProject } from '../../../../lib/website-db';
+import { siteRedirect } from '../../../../lib/redirect';
 
 export const POST: APIRoute = async ({ request }) => {
   const session = await getSession(request.headers.get('cookie'));
@@ -11,15 +12,15 @@ export const POST: APIRoute = async ({ request }) => {
   const back = form.get('_back')?.toString()        || '/admin/projekte';
 
   if (!id) {
-    return Response.redirect(new URL(`/admin/projekte?error=ID+fehlt`, request.url), 303);
+    return siteRedirect('/admin/projekte?error=ID+fehlt');
   }
 
   try {
     await deleteProject(id);
   } catch (err) {
     console.error('[projekte/delete]', err);
-    return Response.redirect(new URL(`${back}?error=Datenbankfehler`, request.url), 303);
+    return siteRedirect(`${back}?error=Datenbankfehler`);
   }
 
-  return Response.redirect(new URL('/admin/projekte', request.url), 303);
+  return siteRedirect('/admin/projekte');
 };

--- a/website/src/pages/api/admin/projekte/update.ts
+++ b/website/src/pages/api/admin/projekte/update.ts
@@ -1,6 +1,7 @@
 import type { APIRoute } from 'astro';
 import { getSession, isAdmin } from '../../../../lib/auth';
 import { updateProject } from '../../../../lib/website-db';
+import { siteRedirect } from '../../../../lib/redirect';
 
 export const POST: APIRoute = async ({ request }) => {
   const session = await getSession(request.headers.get('cookie'));
@@ -19,15 +20,15 @@ export const POST: APIRoute = async ({ request }) => {
   const back        = form.get('_back')?.toString()              || '/admin/projekte';
 
   if (!id || !name) {
-    return Response.redirect(new URL(`${back}${back.includes('?') ? '&' : '?'}error=Pflichtfelder+fehlen`, request.url), 303);
+    return siteRedirect(`${back}${back.includes('?') ? '&' : '?'}error=Pflichtfelder+fehlen`);
   }
 
   try {
     await updateProject(id, { name, description, notes, startDate, dueDate, status, priority, customerId });
   } catch (err) {
     console.error('[projekte/update]', err);
-    return Response.redirect(new URL(`${back}${back.includes('?') ? '&' : '?'}error=Datenbankfehler`, request.url), 303);
+    return siteRedirect(`${back}${back.includes('?') ? '&' : '?'}error=Datenbankfehler`);
   }
 
-  return Response.redirect(new URL(back, request.url), 303);
+  return siteRedirect(back);
 };

--- a/website/src/pages/api/admin/projekttasks/create.ts
+++ b/website/src/pages/api/admin/projekttasks/create.ts
@@ -1,6 +1,7 @@
 import type { APIRoute } from 'astro';
 import { getSession, isAdmin } from '../../../../lib/auth';
 import { createProjectTask } from '../../../../lib/website-db';
+import { siteRedirect } from '../../../../lib/redirect';
 
 export const POST: APIRoute = async ({ request }) => {
   const session = await getSession(request.headers.get('cookie'));
@@ -20,15 +21,15 @@ export const POST: APIRoute = async ({ request }) => {
   const back          = form.get('_back')?.toString()                || '/admin/projekte';
 
   if (!projectId || !name) {
-    return Response.redirect(new URL(`${back}?error=Pflichtfelder+fehlen`, request.url), 303);
+    return siteRedirect(`${back}?error=Pflichtfelder+fehlen`);
   }
 
   try {
     await createProjectTask({ projectId, subProjectId, name, description, notes, startDate, dueDate, status, priority, customerId });
   } catch (err) {
     console.error('[projekttasks/create]', err);
-    return Response.redirect(new URL(`${back}?error=Datenbankfehler`, request.url), 303);
+    return siteRedirect(`${back}?error=Datenbankfehler`);
   }
 
-  return Response.redirect(new URL(back, request.url), 303);
+  return siteRedirect(back);
 };

--- a/website/src/pages/api/admin/projekttasks/delete.ts
+++ b/website/src/pages/api/admin/projekttasks/delete.ts
@@ -1,6 +1,7 @@
 import type { APIRoute } from 'astro';
 import { getSession, isAdmin } from '../../../../lib/auth';
 import { deleteProjectTask } from '../../../../lib/website-db';
+import { siteRedirect } from '../../../../lib/redirect';
 
 export const POST: APIRoute = async ({ request }) => {
   const session = await getSession(request.headers.get('cookie'));
@@ -11,15 +12,15 @@ export const POST: APIRoute = async ({ request }) => {
   const back = form.get('_back')?.toString()      || '/admin/projekte';
 
   if (!id) {
-    return Response.redirect(new URL(`${back}?error=ID+fehlt`, request.url), 303);
+    return siteRedirect(`${back}?error=ID+fehlt`);
   }
 
   try {
     await deleteProjectTask(id);
   } catch (err) {
     console.error('[projekttasks/delete]', err);
-    return Response.redirect(new URL(`${back}?error=Datenbankfehler`, request.url), 303);
+    return siteRedirect(`${back}?error=Datenbankfehler`);
   }
 
-  return Response.redirect(new URL(back, request.url), 303);
+  return siteRedirect(back);
 };

--- a/website/src/pages/api/admin/projekttasks/update.ts
+++ b/website/src/pages/api/admin/projekttasks/update.ts
@@ -1,6 +1,7 @@
 import type { APIRoute } from 'astro';
 import { getSession, isAdmin } from '../../../../lib/auth';
 import { updateProjectTask } from '../../../../lib/website-db';
+import { siteRedirect } from '../../../../lib/redirect';
 
 export const POST: APIRoute = async ({ request }) => {
   const session = await getSession(request.headers.get('cookie'));
@@ -19,15 +20,15 @@ export const POST: APIRoute = async ({ request }) => {
   const back        = form.get('_back')?.toString()              || '/admin/projekte';
 
   if (!id || !name) {
-    return Response.redirect(new URL(`${back}?error=Pflichtfelder+fehlen`, request.url), 303);
+    return siteRedirect(`${back}?error=Pflichtfelder+fehlen`);
   }
 
   try {
     await updateProjectTask(id, { name, description, notes, startDate, dueDate, status, priority, customerId });
   } catch (err) {
     console.error('[projekttasks/update]', err);
-    return Response.redirect(new URL(`${back}?error=Datenbankfehler`, request.url), 303);
+    return siteRedirect(`${back}?error=Datenbankfehler`);
   }
 
-  return Response.redirect(new URL(back, request.url), 303);
+  return siteRedirect(back);
 };

--- a/website/src/pages/api/admin/subprojekte/create.ts
+++ b/website/src/pages/api/admin/subprojekte/create.ts
@@ -1,6 +1,7 @@
 import type { APIRoute } from 'astro';
 import { getSession, isAdmin } from '../../../../lib/auth';
 import { createSubProject } from '../../../../lib/website-db';
+import { siteRedirect } from '../../../../lib/redirect';
 
 export const POST: APIRoute = async ({ request }) => {
   const session = await getSession(request.headers.get('cookie'));
@@ -19,15 +20,15 @@ export const POST: APIRoute = async ({ request }) => {
   const back       = form.get('_back')?.toString()              || '/admin/projekte';
 
   if (!projectId || !name) {
-    return Response.redirect(new URL(`${back}?error=Pflichtfelder+fehlen`, request.url), 303);
+    return siteRedirect(`${back}?error=Pflichtfelder+fehlen`);
   }
 
   try {
     await createSubProject({ projectId, name, description, notes, startDate, dueDate, status, priority, customerId });
   } catch (err) {
     console.error('[subprojekte/create]', err);
-    return Response.redirect(new URL(`${back}?error=Datenbankfehler`, request.url), 303);
+    return siteRedirect(`${back}?error=Datenbankfehler`);
   }
 
-  return Response.redirect(new URL(back, request.url), 303);
+  return siteRedirect(back);
 };

--- a/website/src/pages/api/admin/subprojekte/delete.ts
+++ b/website/src/pages/api/admin/subprojekte/delete.ts
@@ -1,6 +1,7 @@
 import type { APIRoute } from 'astro';
 import { getSession, isAdmin } from '../../../../lib/auth';
 import { deleteSubProject } from '../../../../lib/website-db';
+import { siteRedirect } from '../../../../lib/redirect';
 
 export const POST: APIRoute = async ({ request }) => {
   const session = await getSession(request.headers.get('cookie'));
@@ -11,15 +12,15 @@ export const POST: APIRoute = async ({ request }) => {
   const back = form.get('_back')?.toString()      || '/admin/projekte';
 
   if (!id) {
-    return Response.redirect(new URL(`${back}?error=ID+fehlt`, request.url), 303);
+    return siteRedirect(`${back}?error=ID+fehlt`);
   }
 
   try {
     await deleteSubProject(id);
   } catch (err) {
     console.error('[subprojekte/delete]', err);
-    return Response.redirect(new URL(`${back}?error=Datenbankfehler`, request.url), 303);
+    return siteRedirect(`${back}?error=Datenbankfehler`);
   }
 
-  return Response.redirect(new URL(back, request.url), 303);
+  return siteRedirect(back);
 };

--- a/website/src/pages/api/admin/subprojekte/update.ts
+++ b/website/src/pages/api/admin/subprojekte/update.ts
@@ -1,6 +1,7 @@
 import type { APIRoute } from 'astro';
 import { getSession, isAdmin } from '../../../../lib/auth';
 import { updateSubProject } from '../../../../lib/website-db';
+import { siteRedirect } from '../../../../lib/redirect';
 
 export const POST: APIRoute = async ({ request }) => {
   const session = await getSession(request.headers.get('cookie'));
@@ -19,15 +20,15 @@ export const POST: APIRoute = async ({ request }) => {
   const back        = form.get('_back')?.toString()              || '/admin/projekte';
 
   if (!id || !name) {
-    return Response.redirect(new URL(`${back}?error=Pflichtfelder+fehlen`, request.url), 303);
+    return siteRedirect(`${back}?error=Pflichtfelder+fehlen`);
   }
 
   try {
     await updateSubProject(id, { name, description, notes, startDate, dueDate, status, priority, customerId });
   } catch (err) {
     console.error('[subprojekte/update]', err);
-    return Response.redirect(new URL(`${back}?error=Datenbankfehler`, request.url), 303);
+    return siteRedirect(`${back}?error=Datenbankfehler`);
   }
 
-  return Response.redirect(new URL(back, request.url), 303);
+  return siteRedirect(back);
 };


### PR DESCRIPTION
## Summary

- **Root cause fixed**: All 9 project-related API routes used `new URL(path, request.url)` for post-form redirects. Behind Traefik/Kubernetes, `request.url` resolves to the internal pod hostname, so the browser was sent to an unreachable internal address after every form submit. Replaced with a shared `siteRedirect()` helper in `src/lib/redirect.ts` that always uses the `SITE_URL` env var.
- **Teilprojekte & Aufgaben**: Same redirect bug affected create/update/delete for sub-projects and tasks — fixed by the same helper.
- **File attachments**: New end-to-end attachment system — `project_attachments` DB table (auto-created on first use), Nextcloud-backed upload/download/delete API routes under `/api/admin/projekte/attachments/`, `deleteFile()` added to `nextcloud-files.ts`, and an **Anhänge** section in the project detail page with upload dialog, file table (name / type / size / date), download links, and delete with confirm.

## Test plan

- [ ] Create a project → verify redirect lands on the project detail page (not localhost)
- [ ] Add a Teilprojekt → verify page reloads correctly at the right URL
- [ ] Add an Aufgabe (direct and within a Teilprojekt) → verify same
- [ ] Edit and delete Teilprojekte and Aufgaben → verify redirects work
- [ ] Upload a file attachment → verify it appears in the Anhänge table
- [ ] Download the attachment → verify correct file is served with proper filename
- [ ] Delete the attachment → verify it disappears from the table
- [ ] Verify CI passes (manifest validation, YAML lint, shellcheck)

🤖 Generated with [Claude Code](https://claude.com/claude-code)