### PR TITLE
feat(portal): add Systemisches Brett link to portal and admin service tiles

### DIFF
--- a/website/src/components/portal/DiensteSection.astro
+++ b/website/src/components/portal/DiensteSection.astro
@@ -3,9 +3,10 @@ interface Props {
   ncBase: string;
   vaultUrl: string;
   wbUrl?: string;
+  bretUrl?: string;
   keycloakBase: string;
 }
-const { ncBase, vaultUrl, wbUrl = '', keycloakBase } = Astro.props;
+const { ncBase, vaultUrl, wbUrl = '', bretUrl = '', keycloakBase } = Astro.props;
 
 const services = [
   ...(ncBase ? [
@@ -14,7 +15,8 @@ const services = [
     { href: `${ncBase}/apps/contacts/`,   label: 'Kontakte',   desc: 'Adressbuch',                 icon: '👥' },
     { href: `${ncBase}/apps/spreed/`,     label: 'Talk',       desc: 'Video & Gruppen-Chat',       icon: '🎥' },
   ] : []),
-  ...(wbUrl ? [{ href: wbUrl, label: 'Whiteboard', desc: 'Gemeinsames Zeichenbrett', icon: '🖊️' }] : []),
+  ...(wbUrl   ? [{ href: wbUrl,   label: 'Whiteboard', desc: 'Gemeinsames Zeichenbrett',  icon: '🖊️' }] : []),
+  ...(bretUrl ? [{ href: bretUrl, label: 'Brett',      desc: 'Systemisches Brett (3D)',   icon: '🪄' }] : []),
   ...(vaultUrl ? [{ href: vaultUrl, label: 'Passwörter',  desc: 'Vaultwarden Safe',       icon: '🔒' }] : []),
 ];
 ---

--- a/website/src/pages/admin.astro
+++ b/website/src/pages/admin.astro
@@ -54,6 +54,8 @@ const vaultUrl    = process.env.VAULT_EXTERNAL_URL ?? '';
 const wbUrl       = process.env.WHITEBOARD_EXTERNAL_URL ?? '';
 const traefikUrl  = process.env.TRAEFIK_EXTERNAL_URL ?? '';
 const mailUrl     = process.env.MAIL_EXTERNAL_URL ?? '';
+const bretDomain  = process.env.BRETT_DOMAIN ?? '';
+const bretUrl     = bretDomain ? `https://${bretDomain}` : '';
 const adminLinks = [
   { href: '/admin/inbox', label: 'Inbox', icon: '📬' },
   ...(ncBase ? [
@@ -62,7 +64,8 @@ const adminLinks = [
     { href: `${ncBase}/apps/contacts/`,   label: 'Kontakte',   icon: '👥' },
     { href: `${ncBase}/apps/spreed/`,     label: 'Talk',       icon: '🎥' },
   ] : []),
-  ...(wbUrl ? [{ href: wbUrl, label: 'Whiteboard', icon: '🖊️' }] : []),
+  ...(wbUrl    ? [{ href: wbUrl,    label: 'Whiteboard', icon: '🖊️' }] : []),
+  ...(bretUrl  ? [{ href: bretUrl,  label: 'Brett',      icon: '🪄' }] : []),
   { href: '/admin/rechnungen', label: 'Abrechnung', icon: '🧾' },
   ...(vaultUrl    ? [{ href: vaultUrl,          label: 'Passwörter', icon: '🔐' }] : []),
   ...(authUrl     ? [{ href: `${authUrl}/admin/workspace/console/`, label: 'Keycloak', icon: '🔑' }] : []),

--- a/website/src/pages/portal.astro
+++ b/website/src/pages/portal.astro
@@ -41,6 +41,8 @@ const vaultUrl     = process.env.VAULT_EXTERNAL_URL ?? '';
 const wbUrl        = process.env.WHITEBOARD_EXTERNAL_URL ?? '';
 const keycloakBase = process.env.KEYCLOAK_FRONTEND_URL ?? '';
 const realm        = process.env.KEYCLOAK_REALM ?? 'workspace';
+const bretDomain   = process.env.BRETT_DOMAIN ?? '';
+const bretUrl      = bretDomain ? `https://${bretDomain}` : '';
 
 // ── Badge counts (always fetched — needed for sidebar) ────────────
 let unreadMessages        = 0;
@@ -144,6 +146,6 @@ const questionnaires: QAssignment[] = (section === 'fragebögen' && customer)
     </div>
   )}
   {section === 'fragebögen'     && <FragebogenSection assignments={questionnaires} />}
-  {section === 'dienste'        && <DiensteSection {ncBase} {vaultUrl} {wbUrl} {keycloakBase} />}
+  {section === 'dienste'        && <DiensteSection {ncBase} {vaultUrl} {wbUrl} {bretUrl} {keycloakBase} />}
   {section === 'konto'          && <KontoSection {session} {keycloakBase} {realm} />}
 </PortalLayout>


### PR DESCRIPTION
## Summary

- **User portal** (`/portal?section=dienste`): new Brett tile (🪄 "Brett", desc "Systemisches Brett (3D)") added to the Dienste grid between Whiteboard and Passwörter
- **Admin dashboard** (`/admin`): Brett tile added to the service link strip, also between Whiteboard and Abrechnung
- Both use `BRETT_DOMAIN` env var already present in `website-config` ConfigMap — no infra changes required
- Tile is conditionally skipped when `BRETT_DOMAIN` is unset (dev environments without brett are unaffected)

## Test plan

- [ ] Deploy website: `task website:deploy ENV=mentolder`
- [ ] Log in as regular user → `/portal?section=dienste` → Brett tile visible, links to `https://brett.mentolder.de`
- [ ] Log in as admin → `/admin` → Brett tile visible in service strip
- [ ] Confirm tile is absent on environments without `BRETT_DOMAIN` set

🤖 Generated with [Claude Code](https://claude.com/claude-code)