### PR TITLE
feat(portal): tile-grid nav in portal sidebar + client Kacheln in admin

### DIFF
--- a/website/src/layouts/PortalLayout.astro
+++ b/website/src/layouts/PortalLayout.astro
@@ -112,6 +112,13 @@ const userIsAdmin   = isAdmin(session);
       .portal-nav-item:not(.is-active):hover .nav-icon {
         color: var(--brass) !important;
       }
+      .portal-nav-tile:not(.is-active):hover {
+        background: var(--ink-800) !important;
+        color: var(--fg) !important;
+      }
+      .portal-nav-tile:not(.is-active):hover .nav-icon {
+        color: var(--brass) !important;
+      }
       .portal-footer-link:hover {
         background: var(--ink-800);
         color: var(--fg-soft);
@@ -130,7 +137,7 @@ const userIsAdmin   = isAdmin(session);
           position: fixed !important;
           top: 0; left: 0; bottom: 0;
           z-index: 100;
-          width: 13rem !important;
+          width: 14rem !important;
           min-height: unset !important;
           transform: translateX(-100%);
           transition: transform 0.25s ease;
@@ -184,7 +191,7 @@ const userIsAdmin   = isAdmin(session);
     <div id="portal-backdrop"></div>
 
     <!-- Sidebar -->
-    <aside id="portal-sidebar" style="width:13rem; flex-shrink:0; min-height:100vh; background:var(--ink-850); border-right:1px solid var(--line); display:flex; flex-direction:column;">
+    <aside id="portal-sidebar" style="width:14rem; flex-shrink:0; min-height:100vh; background:var(--ink-850); border-right:1px solid var(--line); display:flex; flex-direction:column;">
 
       <!-- Header: user avatar + info + brand link -->
       <div style="padding:20px 14px 16px; border-bottom:1px solid var(--line);">
@@ -208,43 +215,41 @@ const userIsAdmin   = isAdmin(session);
       </div>
 
       <!-- Nav -->
-      <nav style="flex:1; overflow-y:auto; padding:12px 8px; display:flex; flex-direction:column; gap:18px;">
+      <nav style="flex:1; overflow-y:auto; padding:10px 8px; display:flex; flex-direction:column; gap:10px;">
         {navGroups.map(group => (
           <div>
             {group.label && (
-              <p style="padding:0 10px; margin-bottom:4px; font-family:var(--font-mono); font-size:9px; font-weight:500; color:var(--mute-2); text-transform:uppercase; letter-spacing:0.14em;">{group.label}</p>
+              <p style="padding:0 3px; margin-bottom:5px; font-family:var(--font-mono); font-size:8px; font-weight:500; color:var(--mute-2); text-transform:uppercase; letter-spacing:0.14em;">{group.label}</p>
             )}
-            <ul style="list-style:none; padding:0; margin:0; display:flex; flex-direction:column; gap:1px;">
+            <div style="display:grid; grid-template-columns:1fr 1fr; gap:3px;">
               {group.items.map(item => {
                 const active = section === item.id;
                 return (
-                  <li>
-                    <a
-                      href={`/portal?section=${item.id}`}
-                      title={item.label}
-                      class={`portal-nav-item${active ? ' is-active' : ''}`}
-                      style={`display:flex; align-items:center; gap:9px; padding:8px 10px; border-radius:8px; text-decoration:none; font-size:13px; font-weight:500; transition:background 0.1s ease, color 0.1s ease; ${
-                        active
-                          ? 'background:var(--brass-d); color:var(--brass);'
-                          : 'color:var(--fg-soft);'
-                      }`}
-                    >
-                      <span
-                        class="nav-icon"
-                        style={`flex-shrink:0; width:16px; height:16px; display:flex; align-items:center; justify-content:center; transition:color 0.1s ease; ${active ? 'color:var(--brass);' : 'color:var(--mute);'}`}
-                        set:html={icons[item.icon]}
-                      />
-                      <span style="flex:1; white-space:nowrap; overflow:hidden; text-overflow:ellipsis;">{item.label}</span>
-                      {item.badge !== undefined && item.badge > 0 && (
-                        <span style="flex-shrink:0; display:inline-flex; align-items:center; justify-content:center; min-width:18px; height:18px; padding:0 5px; border-radius:999px; background:var(--brass); color:var(--ink-900); font-family:var(--font-mono); font-size:10px; font-weight:700; line-height:1;">
-                          {item.badge > 99 ? '99+' : item.badge}
-                        </span>
-                      )}
-                    </a>
-                  </li>
+                  <a
+                    href={`/portal?section=${item.id}`}
+                    title={item.label}
+                    class={`portal-nav-tile${active ? ' is-active' : ''}`}
+                    style={`position:relative; display:flex; flex-direction:column; align-items:center; justify-content:flex-start; gap:5px; padding:9px 4px 8px; border-radius:8px; text-decoration:none; transition:background 0.1s ease, color 0.1s ease; ${
+                      active
+                        ? 'background:var(--brass-d); color:var(--brass);'
+                        : 'color:var(--fg-soft);'
+                    }`}
+                  >
+                    <span
+                      class="nav-icon"
+                      style={`width:18px; height:18px; display:flex; align-items:center; justify-content:center; flex-shrink:0; transition:color 0.1s ease; ${active ? 'color:var(--brass);' : 'color:var(--mute);'}`}
+                      set:html={icons[item.icon]}
+                    />
+                    <span style={`font-family:var(--font-sans); font-size:9.5px; font-weight:500; line-height:1.25; text-align:center; overflow:hidden; display:-webkit-box; -webkit-line-clamp:2; -webkit-box-orient:vertical; word-break:break-word; width:100%; ${active ? 'color:var(--brass);' : 'color:inherit;'}`}>{item.label}</span>
+                    {item.badge !== undefined && item.badge > 0 && (
+                      <span style="position:absolute; top:4px; right:4px; min-width:14px; height:14px; padding:0 3px; border-radius:999px; background:var(--brass); color:var(--ink-900); font-family:var(--font-mono); font-size:8px; font-weight:700; display:flex; align-items:center; justify-content:center; line-height:1;">
+                        {item.badge > 99 ? '99+' : item.badge}
+                      </span>
+                    )}
+                  </a>
                 );
               })}
-            </ul>
+            </div>
           </div>
         ))}
       </nav>

--- a/website/src/pages/admin/clients.astro
+++ b/website/src/pages/admin/clients.astro
@@ -188,32 +188,39 @@ try {
         </div>
       )}
 
-      <div class="grid gap-4" data-testid="admin-client-list">
-        {users.map(user => (
-          <a
-            href={`/admin/${user.id}`}
-            class={`flex items-center gap-4 p-4 bg-dark-light rounded-xl border transition-colors ${user.enabled === false ? 'border-red-500/20 opacity-60' : 'border-dark-lighter hover:border-gold/40'}`}
-            data-testid="admin-client-item"
-          >
-            <div>
-              <p class="text-light font-medium">{user.firstName} {user.lastName}</p>
-              <p class="text-sm text-muted">{user.username} · {user.email ?? '—'}</p>
-            </div>
-            <div class="ml-auto flex items-center gap-3">
-              {user.enabled === false && (
-                <span class="text-xs px-2 py-0.5 rounded-full bg-red-500/20 text-red-400">Deaktiviert</span>
-              )}
-              {user.email && customerNumberByEmail.get(user.email) && (
-                <span class="text-xs px-2 py-0.5 rounded-full bg-gold/10 text-gold border border-gold/30 font-mono">
-                  {customerNumberByEmail.get(user.email)}
+      <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-3" data-testid="admin-client-list">
+        {users.map(user => {
+          const initial = ((user.firstName || user.lastName || user.username || '?')[0]).toUpperCase();
+          const fullName = [user.firstName, user.lastName].filter(Boolean).join(' ') || user.username;
+          const custNum = user.email ? customerNumberByEmail.get(user.email) : undefined;
+          return (
+            <a
+              href={`/admin/${user.id}`}
+              class={`group flex flex-col gap-3 p-4 bg-dark-light rounded-xl border transition-all duration-150 ${user.enabled === false ? 'border-red-500/20 opacity-60' : 'border-dark-lighter hover:border-gold/40'}`}
+              data-testid="admin-client-item"
+            >
+              <div class="flex items-start justify-between gap-2">
+                <div style="width:38px; height:38px; border-radius:50%; background:radial-gradient(circle at 30% 30%, var(--brass-2), var(--brass) 55%, #8a6a2a 100%); box-shadow:inset 0 0 0 1px rgba(255,255,255,.18), 0 0 0 1px rgba(0,0,0,.25); display:flex; align-items:center; justify-content:center; flex-shrink:0;">
+                  <span style="font-family:var(--font-serif); font-size:16px; font-weight:600; color:var(--ink-900); line-height:1;">{initial}</span>
+                </div>
+                {user.enabled === false && (
+                  <span class="text-xs px-1.5 py-0.5 rounded-full bg-red-500/20 text-red-400 leading-none mt-0.5">off</span>
+                )}
+              </div>
+              <div class="min-w-0 flex-1">
+                <p class="text-sm font-semibold text-light truncate leading-snug">{fullName}</p>
+                <p class="text-xs text-muted truncate mt-0.5">{user.email ?? user.username}</p>
+              </div>
+              {custNum && (
+                <span class="self-start text-xs px-2 py-0.5 rounded-full bg-gold/10 text-gold border border-gold/30 font-mono leading-none">
+                  {custNum}
                 </span>
               )}
-              <span class="text-gold text-sm">→</span>
-            </div>
-          </a>
-        ))}
+            </a>
+          );
+        })}
         {users.length === 0 && (
-          <p class="text-muted">Keine Benutzer gefunden.</p>
+          <p class="text-muted col-span-full">Keine Benutzer gefunden.</p>
         )}
       </div>
     </div>


### PR DESCRIPTION
## Summary

- **Portal sidebar**: replaces single-column grouped list nav with a compact 2-column icon-tile grid — all 10+ sections now visible without scrolling; sidebar widened 13 → 14 rem; badges shown as a small brass pill in the tile's top-right corner
- **Admin clients page**: replaces flat list rows with a responsive tile grid (2 cols mobile → 3 tablet → 4 desktop) — each tile shows brass avatar circle with initial, full name, email, and customer-number badge; disabled state preserved

## Test plan

- [ ] Open `/admin/clients` — verify clients render as tiles, avatar initials show, customer numbers appear, disabled clients show red "off" badge
- [ ] Open `/portal` — verify sidebar shows 2-col tile grid, all sections visible without scrolling, active state (brass tint) correct, badges on Unterschriften/Fragebögen appear top-right of tile
- [ ] Mobile: open portal, verify hamburger opens 14rem sidebar with tile grid intact
- [ ] Navigate between portal sections — verify active tile highlights correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)