### PR TITLE
fix(keycloak): add BRETT_OIDC_SECRET to deployment env and import script

### DIFF
--- a/deploy/mcp/kustomization.yaml
+++ b/deploy/mcp/kustomization.yaml
@@ -12,7 +12,7 @@ resources:
   # Consolidated MCP pods (all containers in one pod for resource efficiency)
   - claude-code-mcp-monolith.yaml
   # Auth
-  - mcp-tokens.yaml             # Bearer tokens for Claude Code access
+  # mcp-tokens managed separately — created once via task claude-code:rotate-tokens, never overwritten by deploy
   - mcp-auth-proxy.yaml         # ForwardAuth proxy (token validation + role enforcement)
   # Ingress — exposes MCP servers via mcp-*.localhost for external clients
   - ingress.yaml

--- a/k3d/keycloak.yaml
+++ b/k3d/keycloak.yaml
@@ -143,6 +143,11 @@ spec:
                 configMapKeyRef:
                   name: domain-config
                   key: MAIL_DOMAIN
+            - name: BRETT_OIDC_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: workspace-secrets
+                  key: BRETT_OIDC_SECRET
             - name: TZ
               value: Europe/Berlin
           ports:

--- a/k3d/realm-import-entrypoint.sh
+++ b/k3d/realm-import-entrypoint.sh
@@ -24,7 +24,8 @@ for var in NEXTCLOUD_OIDC_SECRET \
            DOCS_OIDC_SECRET TRAEFIK_OIDC_SECRET MAIL_OIDC_SECRET \
            NC_DOMAIN WEB_DOMAIN VAULT_DOMAIN DOCS_DOMAIN TRAEFIK_DOMAIN MAIL_DOMAIN \
            PROD_DOMAIN KC_USER1_EMAIL KC_USER2_EMAIL \
-           SMTP_HOST SMTP_PORT SMTP_FROM SMTP_USER SMTP_PASSWORD; do
+           SMTP_HOST SMTP_PORT SMTP_FROM SMTP_USER SMTP_PASSWORD \
+           BRETT_OIDC_SECRET; do
   eval val="\${${var}:-}"
   if [ -z "$val" ]; then
     echo "[import-entrypoint] WARNUNG: ${var} ist nicht gesetzt!"

--- a/scripts/gemini-settings-merge.py
+++ b/scripts/gemini-settings-merge.py
@@ -16,7 +16,7 @@ if os.path.exists(settings_file):
 else:
     data = {}
 
-data["mcpServers"] = mcp_servers
+data.setdefault("mcpServers", {}).update(mcp_servers)
 
 with open(settings_file, "w") as f:
     json.dump(data, f, indent=2)


### PR DESCRIPTION
## Summary

- **Root cause**: `feat(brett)` (#340) added `BRETT_OIDC_SECRET` to the realm JSON but never wired it into the Keycloak Pod env or the import script's substitution loop
- **Symptom**: New Keycloak Pod (`keycloak-86d6db448b-xdsvg`) crashes in CrashLoopBackOff on mentolder — the import entrypoint sanity check aborts with "unresolved placeholder: `${BRETT_OIDC_SECRET}`"
- **Status**: Old Pod from before the Brett rollout is still running (already imported the realm), so SSO is live but no new Pod can start

### Changes

| File | Fix |
|------|-----|
| `k3d/keycloak.yaml` | Add `BRETT_OIDC_SECRET` env var (secretKeyRef → workspace-secrets) |
| `k3d/realm-import-entrypoint.sh` | Add `BRETT_OIDC_SECRET` to the sed substitution loop |
| `deploy/mcp/kustomization.yaml` | Stop deploying `mcp-tokens` Secret on every deploy (must be created once via `task claude-code:rotate-tokens`, never overwritten) |
| `scripts/gemini-settings-merge.py` | Use `setdefault().update()` so existing mcpServers keys are merged, not overwritten |

## Test plan

- [ ] `task workspace:validate` passes (kustomize build clean)
- [ ] After merge: `task workspace:deploy ENV=mentolder` — new Keycloak Pod starts healthy (no CrashLoopBackOff)
- [ ] SSO login still works on auth.mentolder.de

🤖 Generated with [Claude Code](https://claude.com/claude-code)