### PR TITLE
fix(mcp): gate-create mcp-tokens to prevent token overwrite on redeploy

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1337,6 +1337,13 @@ tasks:
           -o jsonpath='{.data.KEYCLOAK_ADMIN_PASSWORD}' 2>/dev/null | base64 -d || echo "admin")
         export SHARED_DB_PASSWORD GITHUB_PAT STRIPE_SECRET_KEY KEYCLOAK_ADMIN_PASSWORD
         kustomize build deploy/mcp/ | envsubst "\$PROD_DOMAIN \$INFRA_NAMESPACE \$TLS_SECRET_NAME \$SHARED_DB_PASSWORD \$GITHUB_PAT \$STRIPE_SECRET_KEY \$KEYCLOAK_ADMIN_PASSWORD" | kubectl $CTX apply -f -
+        # Create mcp-tokens only on first deploy — never overwrite real tokens
+        if ! kubectl $CTX get secret mcp-tokens -n default &>/dev/null; then
+          kubectl $CTX create secret generic mcp-tokens \
+            --from-literal="CLUSTER_TOKEN=dev-cluster-token-placeholder" \
+            --from-literal="BUSINESS_TOKEN=dev-business-token-placeholder"
+          echo "⚠ mcp-tokens created with placeholders — run 'task claude-code:rotate-tokens ENV={{.ENV}}' to set real tokens"
+        fi
       - 'echo "Waiting for pods to roll out..."'
       - |
         source scripts/env-resolve.sh "{{.ENV}}"

--- a/prod/import-entrypoint.sh
+++ b/prod/import-entrypoint.sh
@@ -31,7 +31,15 @@ for var in \
     DOCS_DOMAIN \
     TRAEFIK_DOMAIN \
     MAIL_DOMAIN \
-    PROD_DOMAIN; do
+    PROD_DOMAIN \
+    KC_USER1_EMAIL \
+    KC_USER2_EMAIL \
+    SMTP_HOST \
+    SMTP_PORT \
+    SMTP_FROM \
+    SMTP_USER \
+    SMTP_PASSWORD \
+    BRETT_OIDC_SECRET; do
   eval val="\${${var}:-}"
   if [ -z "$val" ]; then
     echo "[import-entrypoint] WARNUNG: ${var} ist nicht gesetzt!"


### PR DESCRIPTION
## Summary

- `mcp:deploy` previously applied `mcp-tokens.yaml` on every run, silently overwriting real rotated tokens with placeholder values (`dev-cluster-token-placeholder`). The auth-proxy would then pick up the placeholders on its next restart, breaking all MCP authentication.
- Now the task creates `mcp-tokens` only when the secret doesn't already exist. Subsequent deploys skip the secret entirely, leaving real tokens untouched.
- Tokens are managed separately via `task claude-code:rotate-tokens ENV=<env>`.

## Test plan

- [ ] Run `task mcp:deploy ENV=mentolder` on a cluster that already has real tokens — verify `mcp-tokens` secret is unchanged
- [ ] Run `task mcp:deploy` on a fresh cluster — verify `mcp-tokens` is created with placeholders and the warning message is printed
- [ ] Run `task claude-code:rotate-tokens ENV=mentolder` and confirm auth-proxy picks up new tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)