### PR TITLE
fix(admin): sync username on email change and surface Keycloak errors

### DIFF
--- a/website/src/lib/keycloak.ts
+++ b/website/src/lib/keycloak.ts
@@ -87,6 +87,10 @@ export async function createUser(params: CreateUserParams): Promise<{ success: b
 
 export async function sendPasswordResetEmail(userId: string): Promise<boolean> {
   const res = await kcApi('PUT', `/users/${userId}/execute-actions-email`, ['UPDATE_PASSWORD']);
+  if (!res.ok) {
+    const body = await res.text().catch(() => '');
+    console.error(`Keycloak execute-actions-email failed: ${res.status} ${body}`);
+  }
   return res.ok;
 }
 
@@ -123,7 +127,16 @@ export async function updateUser(userId: string, params: {
   email?: string;
   enabled?: boolean;
 }): Promise<boolean> {
-  const res = await kcApi('PUT', `/users/${encodeURIComponent(userId)}`, params);
+  const payload: Record<string, unknown> = { ...params };
+  if (params.email !== undefined) {
+    payload.username = params.email.toLowerCase();
+    payload.emailVerified = true;
+  }
+  const res = await kcApi('PUT', `/users/${encodeURIComponent(userId)}`, payload);
+  if (!res.ok) {
+    const body = await res.text().catch(() => '');
+    console.error(`Keycloak updateUser failed: ${res.status} ${body}`);
+  }
   return res.ok;
 }
 


### PR DESCRIPTION
## Summary

- When admin updates a user's email, now also updates Keycloak `username` (set to email at creation) — fixes the dual-email display (`old@email · new@email`) in the client detail header
- Sets `emailVerified: true` on admin-set emails so Keycloak doesn't re-add `VERIFY_EMAIL` to required actions, which was blocking password-reset emails after an email change
- Logs the full Keycloak error body for `updateUser` and `sendPasswordResetEmail` to make future failures diagnosable

## Test plan

- [ ] Change a user's email in admin → header should show only the new email
- [ ] After changing a user's email → Passwort-Reset button should send successfully
- [ ] Check website pod logs after a failed Keycloak call to confirm error body is printed

🤖 Generated with [Claude Code](https://claude.com/claude-code)