### PR TITLE
fix(taskfile): extract push digest via docker inspect instead of tee log

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1742,10 +1742,9 @@ tasks:
           KEYCLOAK_FRONTEND_URL="https://auth.${PROD_DOMAIN}"
           task website:build ENV={{.ENV}}
           echo "Pushing ${IMAGE}:latest..."
-          docker push "${IMAGE}:latest" | tee /tmp/website-push.log
-          DIGEST=$(grep -oE 'sha256:[a-f0-9]{64}' /tmp/website-push.log | tail -1)
-          rm -f /tmp/website-push.log
-          [ -z "${DIGEST}" ] && { echo "ERROR: could not read digest from push"; exit 1; }
+          docker push "${IMAGE}:latest"
+          DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' "${IMAGE}:latest" 2>/dev/null | grep -oE 'sha256:[a-f0-9]{64}' | head -1)
+          [ -z "${DIGEST}" ] && { echo "ERROR: could not read digest after push"; exit 1; }
           echo "✓ Pushed digest: ${DIGEST}"
         fi
         export WEBSITE_HOST WEBSITE_SITE_URL KEYCLOAK_FRONTEND_URL


### PR DESCRIPTION
## Summary

- Docker BuildKit sends push progress (including the final digest line) to stderr, not stdout — so `docker push | tee /tmp/website-push.log` captured an empty stream and `grep` failed with "No such file or directory", aborting the korczewski `website:deploy`
- Replace the tee/grep approach with `docker inspect --format='{{index .RepoDigests 0}}'` after the push, which reliably reads the content-addressable digest from local image metadata without any temp-file gymnastics

## Test plan

- [ ] Run `task website:deploy ENV=korczewski` — should push successfully and print `✓ Pushed digest: sha256:...`
- [ ] Run `task website:deploy ENV=mentolder` — pure-amd64 cluster should still pin the deployment to the digest

🤖 Generated with [Claude Code](https://claude.com/claude-code)