### PR TITLE
fix(backup): correct Filen WebDAV path and add rclone vendor flag

### DIFF
--- a/k3d/backup-cronjob.yaml
+++ b/k3d/backup-cronjob.yaml
@@ -190,6 +190,7 @@ spec:
 
                   OBSCURED=$(rclone obscure "${FILEN_PASSWORD}")
                   export RCLONE_WEBDAV_URL=https://webdav.filen.io
+                  export RCLONE_WEBDAV_VENDOR=other
                   export RCLONE_WEBDAV_USER="${FILEN_EMAIL}"
                   export RCLONE_WEBDAV_PASS="${OBSCURED}"
 

--- a/prod-korczewski/patch-backup-config.yaml
+++ b/prod-korczewski/patch-backup-config.yaml
@@ -5,4 +5,4 @@ metadata:
   namespace: workspace
 data:
   BRAND: "korczewski"
-  FILEN_DEFAULT_UPLOAD_PATH: "/workspace-backups/korczewski"
+  FILEN_DEFAULT_UPLOAD_PATH: "/Backup"

--- a/prod-mentolder/patch-backup-config.yaml
+++ b/prod-mentolder/patch-backup-config.yaml
@@ -5,4 +5,4 @@ metadata:
   namespace: workspace
 data:
   BRAND: "mentolder"
-  FILEN_DEFAULT_UPLOAD_PATH: "/workspace-backups/mentolder"
+  FILEN_DEFAULT_UPLOAD_PATH: "/Backup"


### PR DESCRIPTION
## Summary

- Change `FILEN_DEFAULT_UPLOAD_PATH` from `/workspace-backups/<brand>` to `/Backup` in both prod patches — Filen's WebDAV root maps directly to Cloud Drive, so `Cloud Drive/Backup` = `/Backup`
- Add `RCLONE_WEBDAV_VENDOR=other` to the `filen-upload` container — without this rclone makes incorrect PROPFIND assumptions against Filen's non-standard WebDAV implementation, causing silent upload failures

## Test plan

- [ ] Trigger a manual backup job on mentolder: `kubectl create job --from=cronjob/db-backup manual-backup-test -n workspace --context mentolder`
- [ ] Check filen-upload container logs: confirm "Filen upload done" and no WARNING line
- [ ] Verify files appear under `Cloud Drive/Backup/<timestamp>/` in the Filen drive

🤖 Generated with [Claude Code](https://claude.com/claude-code)