### PR TITLE
fix(taskfile): escape Go template braces in docker inspect format string

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1743,7 +1743,7 @@ tasks:
           task website:build ENV={{.ENV}}
           echo "Pushing ${IMAGE}:latest..."
           docker push "${IMAGE}:latest"
-          DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' "${IMAGE}:latest" 2>/dev/null | grep -oE 'sha256:[a-f0-9]{64}' | head -1)
+          DIGEST=$(docker inspect --format='{{`{{index .RepoDigests 0}}`}}' "${IMAGE}:latest" 2>/dev/null | grep -oE 'sha256:[a-f0-9]{64}' | head -1)
           [ -z "${DIGEST}" ] && { echo "ERROR: could not read digest after push"; exit 1; }
           echo "✓ Pushed digest: ${DIGEST}"
         fi


### PR DESCRIPTION
## Summary

- Backtick-quote `{{index .RepoDigests 0}}` so task's own template engine doesn't try to resolve it as a variable — fixes potential parse error when running `task website:build`.

## Test plan

- [ ] Run `task website:deploy ENV=mentolder` and confirm digest is extracted correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)