### PR TITLE
fix(backup): switch rclone from WebDAV to native Filen backend

### DIFF
--- a/k3d/backup-cronjob.yaml
+++ b/k3d/backup-cronjob.yaml
@@ -189,13 +189,12 @@ spec:
                   echo "Uploading ${STAMP} to Filen: ${UPLOAD_PATH}/${STAMP}/"
 
                   OBSCURED=$(rclone obscure "${FILEN_PASSWORD}")
-                  export RCLONE_WEBDAV_URL=https://webdav.filen.io
-                  export RCLONE_WEBDAV_VENDOR=other
-                  export RCLONE_WEBDAV_USER="${FILEN_EMAIL}"
-                  export RCLONE_WEBDAV_PASS="${OBSCURED}"
+                  mkdir -p /tmp/rclone
+                  printf '[filen]\ntype = filen\nemail = %s\npassword = %s\n' \
+                    "${FILEN_EMAIL}" "${OBSCURED}" > /tmp/rclone/rclone.conf
 
-                  rclone copy "/backups/${STAMP}/" ":webdav:${UPLOAD_PATH}/${STAMP}/" \
-                    --no-traverse \
+                  rclone copy "/backups/${STAMP}/" "filen:${UPLOAD_PATH}/${STAMP}/" \
+                    --config /tmp/rclone/rclone.conf \
                     --stats-one-line \
                     || echo "WARNING: Filen upload failed — local backup intact"
 


### PR DESCRIPTION
## Summary

- `webdav.filen.io` deliberately resolves to `127.0.0.1` — Filen WebDAV is a local desktop-app server, not a cloud endpoint, so it can never be reached from inside Kubernetes
- Switch to rclone's native `filen:` backend (added in rclone 1.67, we run 1.68) which uses the Filen HTTP API directly
- Write rclone config via `printf` into `/tmp/rclone/rclone.conf` to avoid YAML heredoc `<<` parse errors

## Test plan

- [ ] Redeploy mentolder: `task workspace:deploy ENV=mentolder`
- [ ] Trigger manual job and tail `filen-upload` logs — expect "Filen upload done" with no errors
- [ ] Verify `Cloud Drive/Backup/<timestamp>/` appears in Filen drive

🤖 Generated with [Claude Code](https://claude.com/claude-code)