### PR TITLE
fix: resolve 2026-04-27 staleness audit (schema, backup, images, brand, E2E)

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1114,7 +1114,7 @@ tasks:
           echo "Waiting for shared-db to be ready before deploying dependent services..."
           kubectl rollout status deployment/shared-db -n workspace --timeout=120s
           # Full apply (idempotent — updates configs, adds remaining services)
-          kustomize build k3d/ | envsubst "\$PROD_DOMAIN \$BRAND_NAME \$CONTACT_EMAIL" | kubectl apply --server-side --force-conflicts -f -
+          kustomize build k3d/ | envsubst "\$PROD_DOMAIN \$BRAND_NAME \$CONTACT_EMAIL \$BRAND_ID" | kubectl apply --server-side --force-conflicts -f -
         else
           # Prod: build from overlay, apply to target cluster
           # Apply SealedSecret first so the Secret is ready when pods start
@@ -1144,7 +1144,7 @@ tasks:
           export MAIL_FROM_DOMAIN="${SMTP_FROM#*@}"
           ENVSUBST_VARS="\$PROD_DOMAIN \$BRAND_NAME \$CONTACT_EMAIL \$INFRA_NAMESPACE \$TLS_SECRET_NAME"
           ENVSUBST_VARS="$ENVSUBST_VARS \$SMTP_FROM \$MAIL_FROM_LOCAL \$MAIL_FROM_DOMAIN"
-          ENVSUBST_VARS="$ENVSUBST_VARS \$WEBSITE_IMAGE \$TURN_PUBLIC_IP \$TURN_NODE"
+          ENVSUBST_VARS="$ENVSUBST_VARS \$WEBSITE_IMAGE \$TURN_PUBLIC_IP \$TURN_NODE \$BRAND_ID"
           ENVSUBST_VARS="$ENVSUBST_VARS \$KC_USER1_USERNAME \$KC_USER1_EMAIL \$KC_USER2_USERNAME \$KC_USER2_EMAIL"
           ENVSUBST_VARS="$ENVSUBST_VARS \$BRETT_DOMAIN"
           kustomize build "$overlay/" \

--- a/environments/korczewski.yaml
+++ b/environments/korczewski.yaml
@@ -35,6 +35,9 @@ env_vars:
   MAIL_EXTERNAL_URL: "https://mail.korczewski.de"
   STRIPE_PUBLISHABLE_KEY: "pk_live_51RhKrcDGTY4NP8aeqnf69F1OVgNleqjLqR5ZHi8jkzlyxLiaTEnsY5xwhgPAVV7FdNb4eRnelIzt7DUj9TTAopXg00yyxjx03t"
   BRETT_DOMAIN: brett.korczewski.de
+  WEBSITE_HOST: web.korczewski.de
+  WEBSITE_SITE_URL: "https://web.korczewski.de"
+  KEYCLOAK_FRONTEND_URL: "https://auth.korczewski.de"
 
 overlay: prod-korczewski
 secrets_ref: sealed-secrets/korczewski.yaml

--- a/environments/mentolder.yaml
+++ b/environments/mentolder.yaml
@@ -35,6 +35,9 @@ env_vars:
   MAIL_EXTERNAL_URL: "https://mail.mentolder.de"
   STRIPE_PUBLISHABLE_KEY: "pk_live_51TOM2vPmjoQCVSEjX0mKUyfMoEJQssMbl2Me20WSiLJBjhIrxQJiesJrSw6GVlVetbJJ1cH7Wk0rOXHamMN5aVMD00gxhMrdoF"
   BRETT_DOMAIN: brett.mentolder.de
+  WEBSITE_HOST: web.mentolder.de
+  WEBSITE_SITE_URL: "https://web.mentolder.de"
+  KEYCLOAK_FRONTEND_URL: "https://auth.mentolder.de"
 
 overlay: prod-mentolder
 secrets_ref: sealed-secrets/mentolder.yaml

--- a/environments/schema.yaml
+++ b/environments/schema.yaml
@@ -129,6 +129,20 @@ env_vars:
     required: true
     default_dev: "brett.localhost"
 
+  - name: WEBSITE_HOST
+    required: true
+    default_dev: "web.localhost"
+    validate: "^[a-z0-9.-]+(:[0-9]+)?$"
+
+  - name: WEBSITE_SITE_URL
+    required: true
+    default_dev: "http://web.localhost"
+
+  # Used as OIDC issuer URL in the website ConfigMap — missing breaks SSO
+  - name: KEYCLOAK_FRONTEND_URL
+    required: true
+    default_dev: "http://auth.localhost"
+
 secrets:
   - name: SHARED_DB_PASSWORD
     required: true

--- a/k3d/backup-config.yaml
+++ b/k3d/backup-config.yaml
@@ -3,6 +3,8 @@ kind: ConfigMap
 metadata:
   name: backup-config
   namespace: workspace
+  # Dev defaults — overridden by prod-mentolder/ and prod-korczewski/ patch-backup-config.yaml
+  # for production (prod overlays set BRAND and FILEN_DEFAULT_UPLOAD_PATH to env-specific values).
 data:
   BRAND: "${BRAND_ID}"
   FILEN_DEFAULT_UPLOAD_PATH: "/workspace-backups/${BRAND_ID}"

--- a/k3d/backup-config.yaml
+++ b/k3d/backup-config.yaml
@@ -4,5 +4,5 @@ metadata:
   name: backup-config
   namespace: workspace
 data:
-  BRAND: "mentolder"
-  FILEN_DEFAULT_UPLOAD_PATH: "/workspace-backups/mentolder"
+  BRAND: "${BRAND_ID}"
+  FILEN_DEFAULT_UPLOAD_PATH: "/workspace-backups/${BRAND_ID}"

--- a/k3d/backup-cronjob.yaml
+++ b/k3d/backup-cronjob.yaml
@@ -101,6 +101,8 @@ spec:
                 capabilities:
                   drop: ["ALL"]
               command: ["/bin/sh", "-c"]
+              # Shell vars below (STAMP, BACKUP_DIR, PASS, FILEN_PATH) are evaluated
+              # by the container shell at runtime — NOT Taskfile envsubst targets.
               args:
                 - |
                   set -e

--- a/k3d/claude-code-mcp-ops.yaml
+++ b/k3d/claude-code-mcp-ops.yaml
@@ -33,7 +33,7 @@ spec:
         # Pre-built image — no runtime GitHub download needed.
         - name: mcp-kubernetes
           image: quay.io/containers/kubernetes_mcp_server@sha256:a7186e4a8dc4e2995fd142d8d9eb428bff192918ef3a211aeddfe7b9d318ea7b
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           args: ["--port", "8080", "--stateless", "--cluster-provider", "in-cluster"]
           securityContext:
             allowPrivilegeEscalation: false

--- a/k3d/claude-code-mcp-ops.yaml
+++ b/k3d/claude-code-mcp-ops.yaml
@@ -32,7 +32,7 @@ spec:
         # ─── Kubernetes MCP (port 8080) ──────────────────────────
         # Pre-built image — no runtime GitHub download needed.
         - name: mcp-kubernetes
-          image: quay.io/containers/kubernetes_mcp_server:latest
+          image: quay.io/containers/kubernetes_mcp_server@sha256:a7186e4a8dc4e2995fd142d8d9eb428bff192918ef3a211aeddfe7b9d318ea7b
           imagePullPolicy: Always
           args: ["--port", "8080", "--stateless", "--cluster-provider", "in-cluster"]
           securityContext:

--- a/k3d/tracking.yaml
+++ b/k3d/tracking.yaml
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: tracking-ui
           image: ghcr.io/paddione/bachelorprojekt@sha256:5e9e584bff33031c89137d4cf1232d737d2030f3443633e2a0786a90fe83ab63
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 80
           env:

--- a/k3d/tracking.yaml
+++ b/k3d/tracking.yaml
@@ -27,7 +27,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: tracking-ui
-          image: ghcr.io/paddione/bachelorprojekt:latest
+          image: ghcr.io/paddione/bachelorprojekt@sha256:5e9e584bff33031c89137d4cf1232d737d2030f3443633e2a0786a90fe83ab63
           imagePullPolicy: Always
           ports:
             - containerPort: 80

--- a/k3d/whisper.yaml
+++ b/k3d/whisper.yaml
@@ -17,7 +17,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: whisper
-          image: fedirz/faster-whisper-server:latest-cpu
+          image: fedirz/faster-whisper-server@sha256:760e5e43d427dc6cfbbc4731934b908b7de9c7e6d5309c6a1f0c8c923a5b6030
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/k3d/whisper.yaml
+++ b/k3d/whisper.yaml
@@ -18,7 +18,7 @@ spec:
       containers:
         - name: whisper
           image: fedirz/faster-whisper-server@sha256:760e5e43d427dc6cfbbc4731934b908b7de9c7e6d5309c6a1f0c8c923a5b6030
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -45,6 +45,9 @@ export default defineConfig({
         '**/fa-client-portal.spec.ts', // client portal auth-gate
         '**/fa-meeting-history.spec.ts',  // meeting history & release
         '**/fa-document-signing.spec.ts', // document signing flow
+        '**/fa-admin-monitoring.spec.ts',     // admin monitoring page auth
+        '**/fa-admin-newsletter.spec.ts',     // admin newsletter page auth
+        '**/fa-admin-backup-settings.spec.ts', // admin backup settings auth
       ],
       use: {
         ...devices['Desktop Chrome'],

--- a/tests/e2e/specs/fa-admin-backup-settings.spec.ts
+++ b/tests/e2e/specs/fa-admin-backup-settings.spec.ts
@@ -1,0 +1,17 @@
+import { test, expect } from '@playwright/test';
+
+const BASE = process.env.WEBSITE_URL || 'http://localhost:4321';
+
+test.describe('FA: Admin Backup Settings page', () => {
+  test('T1: /admin/einstellungen/backup redirects unauthenticated users', async ({ page }) => {
+    await page.goto(`${BASE}/admin/einstellungen/backup`);
+    await expect(page).not.toHaveURL(`${BASE}/admin/einstellungen/backup`);
+  });
+
+  test('T2: POST /api/admin/einstellungen/backup returns 401 or 403 without auth', async ({ request }) => {
+    const res = await request.post(`${BASE}/api/admin/einstellungen/backup`, {
+      form: { filen_upload_path: '/test' },
+    });
+    expect([401, 403]).toContain(res.status());
+  });
+});

--- a/tests/e2e/specs/fa-admin-monitoring.spec.ts
+++ b/tests/e2e/specs/fa-admin-monitoring.spec.ts
@@ -1,0 +1,15 @@
+import { test, expect } from '@playwright/test';
+
+const BASE = process.env.WEBSITE_URL || 'http://localhost:4321';
+
+test.describe('FA: Admin Monitoring page', () => {
+  test('T1: /admin/monitoring redirects unauthenticated users', async ({ page }) => {
+    await page.goto(`${BASE}/admin/monitoring`);
+    await expect(page).not.toHaveURL(`${BASE}/admin/monitoring`);
+  });
+
+  test('T2: GET /api/admin/monitoring returns 401 or 403 without auth', async ({ request }) => {
+    const res = await request.get(`${BASE}/api/admin/monitoring`);
+    expect([401, 403]).toContain(res.status());
+  });
+});

--- a/tests/e2e/specs/fa-admin-newsletter.spec.ts
+++ b/tests/e2e/specs/fa-admin-newsletter.spec.ts
@@ -1,0 +1,16 @@
+import { test, expect } from '@playwright/test';
+
+const BASE = process.env.WEBSITE_URL || 'http://localhost:4321';
+
+test.describe('FA: Admin Newsletter page', () => {
+  test('T1: /admin/newsletter redirects to /admin/dokumente', async ({ page }) => {
+    await page.goto(`${BASE}/admin/newsletter`);
+    // Newsletter is a redirect stub — always redirects to dokumente (auth-gate is on dokumente)
+    await expect(page).not.toHaveURL(`${BASE}/admin/newsletter`);
+  });
+
+  test('T2: GET /api/admin/newsletter/campaigns returns 401 or 403 without auth', async ({ request }) => {
+    const res = await request.get(`${BASE}/api/admin/newsletter/campaigns`);
+    expect([401, 403]).toContain(res.status());
+  });
+});

--- a/website/src/lib/caldav.ts
+++ b/website/src/lib/caldav.ts
@@ -1,5 +1,6 @@
 // Nextcloud CalDAV helper.
 // Fetches events from the admin's calendar and computes free time slots.
+import { config } from '../config/index.js';
 
 const NC_URL = process.env.NEXTCLOUD_URL || 'http://nextcloud.workspace.svc.cluster.local';
 const NC_USER = process.env.NEXTCLOUD_CALDAV_USER || 'admin';
@@ -259,7 +260,7 @@ export async function getAvailableSlots(fromDate?: Date, brand?: string, slotDur
   // windowsMap: date string → array of {winStart, winEnd} (HH:MM strings)
   let windowsMap: Map<string, Array<{ winStart: string; winEnd: string }>> | null = null;
   let vacationDays: Set<string> = new Set();
-  const effectiveBrand = brand || process.env.BRAND || 'mentolder';
+  const effectiveBrand = brand || config.brand;
 
   if (brand) {
     try {

--- a/website/src/lib/stripe-billing.ts
+++ b/website/src/lib/stripe-billing.ts
@@ -3,6 +3,7 @@
 import Stripe from 'stripe';
 import { stripe } from './stripe';
 import { getNextInvoiceNumber } from './website-db';
+import { config } from '../config/index.js';
 
 export const SERVICES = {
   'erstgespraech':       { name: 'Kostenloses Erstgespräch',                         cents: 0,      unit: 'Einheit' },
@@ -117,7 +118,7 @@ export async function createBillingInvoice(params: {
   if (!process.env.STRIPE_SECRET_KEY) return null;
   const service = SERVICES[params.serviceKey];
   const qty = params.quantity ?? 1;
-  const brand = process.env.BRAND || 'mentolder';
+  const brand = config.brand;
   const internalNumber = await getNextInvoiceNumber(brand);
   const draft = await stripe.invoices.create({
     customer: params.customerId,
@@ -418,7 +419,7 @@ export async function deleteDraftInvoiceItem(invoiceItemId: string): Promise<voi
 
 export async function sendDraftInvoice(invoiceId: string): Promise<void> {
   if (!process.env.STRIPE_SECRET_KEY) return;
-  const brand = process.env.BRAND || 'mentolder';
+  const brand = config.brand;
   const internalNumber = await getNextInvoiceNumber(brand);
   await stripe.invoices.update(invoiceId, {
     metadata: { internal_invoice_number: internalNumber },


### PR DESCRIPTION
## Summary

- **Schema completeness:** Add `WEBSITE_HOST`, `WEBSITE_SITE_URL`, `KEYCLOAK_FRONTEND_URL` to `environments/schema.yaml` env_vars (with prod values for both clusters); add SSO-breakage comment on `KEYCLOAK_FRONTEND_URL`
- **Backup config:** Template `k3d/backup-config.yaml` with `${BRAND_ID}` instead of hardcoded `mentolder`; add `$BRAND_ID` to both dev and prod `envsubst` lists in `Taskfile.yml`; annotate container-internal shell vars in `backup-cronjob.yaml`
- **Image pins:** Pin `kubernetes_mcp_server`, `bachelorprojekt`, and `faster-whisper-server` to sha256 digests; set `imagePullPolicy: IfNotPresent` on pinned containers
- **Brand config:** Replace direct `process.env.BRAND || 'mentolder'` reads in `caldav.ts` and `stripe-billing.ts` with `config.brand` from the central config
- **E2E coverage:** Add Playwright auth-protection specs for `/admin/monitoring`, `/admin/newsletter`, and `/admin/einstellungen/backup`; register in `playwright.config.ts`

## Test Plan

- [x] `task workspace:validate` — all manifests valid
- [x] `task env:validate:all` — dev, mentolder, korczewski all pass
- [ ] Deploy to dev cluster and verify backup CronJob reads `BRAND` correctly from ConfigMap
- [ ] Verify pinned images pull successfully on a fresh node
- [ ] Run `npx playwright test --project=website` against a live cluster to confirm new auth specs pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)