### PR TITLE
fix(images): update kubernetes_mcp_server to 2026-04-27 release

### DIFF
--- a/k3d/claude-code-mcp-ops.yaml
+++ b/k3d/claude-code-mcp-ops.yaml
@@ -32,7 +32,7 @@ spec:
         # ─── Kubernetes MCP (port 8080) ──────────────────────────
         # Pre-built image — no runtime GitHub download needed.
         - name: mcp-kubernetes
-          image: quay.io/containers/kubernetes_mcp_server@sha256:a7186e4a8dc4e2995fd142d8d9eb428bff192918ef3a211aeddfe7b9d318ea7b
+          image: quay.io/containers/kubernetes_mcp_server@sha256:fae7dae4972a7af5708dc29767ee890adfba6a73a6356ef2933c578ee954882a
           imagePullPolicy: IfNotPresent
           args: ["--port", "8080", "--stateless", "--cluster-provider", "in-cluster"]
           securityContext:


### PR DESCRIPTION
## Summary

- Updates `quay.io/containers/kubernetes_mcp_server` digest from `sha256:a7186...` to `sha256:fae7dae...` (released 2026-04-27)
- Previous digest was superseded and caused `ImagePullBackOff` on both mentolder and korczewski
- New digest is the multi-arch manifest list — latest / v0.0.61+

## Test plan

- [ ] ArgoCD auto-syncs workspace-mentolder and workspace-korczewski
- [ ] `claude-code-mcp-ops` goes from `2/3 ImagePullBackOff` → `3/3 Running`

🤖 Generated with [Claude Code](https://claude.com/claude-code)