### PR TITLE
fix(ddns): allow ddns-updater egress to Kubernetes API server

### DIFF
--- a/prod-korczewski/ddns-updater.yaml
+++ b/prod-korczewski/ddns-updater.yaml
@@ -41,6 +41,28 @@ metadata:
 data:
   ip: ""
 ---
+---
+# Allows ddns-updater pods to reach the Kubernetes API server (10.43.0.1:443),
+# which sits inside the 10.0.0.0/8 block excluded by allow-internet-egress.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: ddns-updater-apiserver-egress
+  namespace: workspace
+spec:
+  podSelector:
+    matchLabels:
+      app: ddns-updater
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - ipBlock:
+            cidr: 10.43.0.1/32
+      ports:
+        - protocol: TCP
+          port: 443
+---
 apiVersion: batch/v1
 kind: CronJob
 metadata:
@@ -54,6 +76,9 @@ spec:
   jobTemplate:
     spec:
       template:
+        metadata:
+          labels:
+            app: ddns-updater
         spec:
           serviceAccountName: ddns-updater
           restartPolicy: OnFailure


### PR DESCRIPTION
## Summary

- Adds `ddns-updater-apiserver-egress` NetworkPolicy: allows pods with `app=ddns-updater` to reach the Kubernetes API server at `10.43.0.1:443`
- Adds `app: ddns-updater` label to the CronJob pod template so the policy selects it

## Root cause

`allow-internet-egress` excludes all RFC1918 ranges (`10.0.0.0/8`), which also blocks the in-cluster API server (`kubernetes.default.svc` → `10.43.0.1`). The ddns-updater pod needs this to GET/PATCH the `ddns-last-ip` ConfigMap for IP-change detection.

Without this fix: every run sees `LAST_IP=<none>`, hits ipv64 even when IP hasn't changed, and silently fails to write the new IP back.

## Test plan

- [ ] ArgoCD syncs workspace-korczewski
- [ ] Next ddns-updater run logs `IP unchanged (x.x.x.x) — skipping update` (or updates and logs `✓ korczewski.de -> x.x.x.x`)
- [ ] No `WARN: failed to persist IP to ConfigMap` in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)