### PR TITLE
fix(ddns): NetworkPolicy for API server egress + diagnostic HTTP status in PATCH

### DIFF
--- a/prod-korczewski/ddns-updater.yaml
+++ b/prod-korczewski/ddns-updater.yaml
@@ -41,6 +41,28 @@ metadata:
 data:
   ip: ""
 ---
+---
+# Allows ddns-updater pods to reach the Kubernetes API server (10.43.0.1:443),
+# which sits inside the 10.0.0.0/8 block excluded by allow-internet-egress.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: ddns-updater-apiserver-egress
+  namespace: workspace
+spec:
+  podSelector:
+    matchLabels:
+      app: ddns-updater
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - ipBlock:
+            cidr: 10.43.0.1/32
+      ports:
+        - protocol: TCP
+          port: 443
+---
 apiVersion: batch/v1
 kind: CronJob
 metadata:
@@ -54,6 +76,9 @@ spec:
   jobTemplate:
     spec:
       template:
+        metadata:
+          labels:
+            app: ddns-updater
         spec:
           serviceAccountName: ddns-updater
           restartPolicy: OnFailure

--- a/prod-korczewski/ddns-updater.yaml
+++ b/prod-korczewski/ddns-updater.yaml
@@ -148,14 +148,16 @@ spec:
                   done
 
                   # Persist new IP — non-fatal; DNS update already succeeded above
-                  if curl -sf --cacert "$CACERT" \
+                  PATCH_STATUS=$(curl -s --cacert "$CACERT" \
                     -H "Authorization: Bearer $TOKEN" \
                     -H "Content-Type: application/merge-patch+json" \
                     -X PATCH \
                     "$KUBE/api/v1/namespaces/$NS/configmaps/ddns-last-ip" \
-                    -d "{\"data\":{\"ip\":\"$CURRENT_IP\"}}" > /dev/null 2>&1; then
+                    -d "{\"data\":{\"ip\":\"$CURRENT_IP\"}}" \
+                    -o /dev/null -w "%{http_code}" || echo "000")
+                  if [ "$PATCH_STATUS" = "200" ] || [ "$PATCH_STATUS" = "201" ]; then
                     echo "✓ $DDNS_HOSTNAME -> $CURRENT_IP"
                   else
-                    echo "WARN: failed to persist IP to ConfigMap; next run will re-check" >&2
+                    echo "WARN: failed to persist IP to ConfigMap (HTTP $PATCH_STATUS); next run will re-check" >&2
                     echo "✓ $DDNS_HOSTNAME -> $CURRENT_IP (DNS updated)"
                   fi


### PR DESCRIPTION
## Summary

- Adds `ddns-updater-apiserver-egress` NetworkPolicy: allows ddns-updater pods to reach `10.43.0.1:443` (Kubernetes API server excluded by `allow-internet-egress`'s RFC1918 exception)
- Adds `app: ddns-updater` label to CronJob pod template so the NetworkPolicy selects it
- Changes ConfigMap PATCH to capture HTTP status code explicitly so WARN messages show the actual error code

🤖 Generated with [Claude Code](https://claude.com/claude-code)