### PR TITLE
feat(projekte): admin/customer separation with admin numbers and dual responsibility

### DIFF
--- a/website/src/pages/admin/[clientId].astro
+++ b/website/src/pages/admin/[clientId].astro
@@ -196,6 +196,7 @@ try {
         </div>
       )}
 
+
       <!-- Kundennummer / Admin-Nummer -->
       {customerRecord && (
         <div class="mb-6 grid grid-cols-1 sm:grid-cols-2 gap-4">
@@ -624,6 +625,7 @@ try {
   document.getElementById('flag-as-admin-btn')?.addEventListener('click', (e) => {
     flagUser(e.currentTarget as HTMLButtonElement);
   });
+
 
   // Role checkboxes
   document.querySelectorAll<HTMLInputElement>('.role-checkbox').forEach(cb => {


### PR DESCRIPTION
## Summary
- Admins (`is_admin=true`) now get A####-numbers instead of customer numbers; new API endpoints `set-is-admin` and `set-admin-number` manage these
- Projects, sub-projects, and tasks can assign a responsible customer **and** a responsible admin independently
- Client detail page lets admins toggle the `is_admin` flag and manage admin numbers

## Included chore
- `prod/patch-docuseal.yaml`: wire SMTP vars from `workspace-secrets`
- `prod/kustomization.yaml`: add defensive `$patch:delete` for `backup-passphrase` and `vaultwarden-seed-credentials`
- E2E: move fa-18 transcription to services group, update website/booking/bug/questionnaire/slot specs to match current UI

## Test plan
- [ ] Admin user gets A####-number in client list
- [ ] `is_admin` toggle works on client detail page
- [ ] Project/subproject/task responsible fields show both customer and admin dropdowns
- [ ] Existing customer numbers unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)