### PR TITLE
fix(coturn): add TURNS/TLS on port 5349 for iPhone compatibility

### DIFF
--- a/k3d/coturn-stack/coturn-cert.yaml
+++ b/k3d/coturn-stack/coturn-cert.yaml
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: coturn-tls
+  namespace: coturn
+spec:
+  secretName: coturn-tls
+  issuerRef:
+    name: letsencrypt-prod
+    kind: ClusterIssuer
+  dnsNames:
+    - "turn.${PROD_DOMAIN}"

--- a/k3d/coturn-stack/coturn.yaml
+++ b/k3d/coturn-stack/coturn.yaml
@@ -45,9 +45,11 @@ spec:
           # only touches ${VAR}, so $(TURN_SECRET) survives build-time.
           command: ["turnserver"]
           args:
-            - "--no-tls"
             - "--no-dtls"
             - "--listening-port=3478"
+            - "--tls-listening-port=5349"
+            - "--cert=/etc/coturn-tls/tls.crt"
+            - "--pkey=/etc/coturn-tls/tls.key"
             - "--min-port=49152"
             - "--max-port=49252"
             - "--realm=turn.${PROD_DOMAIN}"
@@ -61,6 +63,9 @@ spec:
             - "--log-file=stdout"
             - "--no-stdout-log"
             - "--simple-log"
+            - "--no-sslv3"
+            - "--no-tlsv1"
+            - "--no-tlsv1_1"
           env:
             - name: TURN_SECRET
               valueFrom:
@@ -73,6 +78,10 @@ spec:
               add:
                 - NET_ADMIN
                 - NET_RAW
+          volumeMounts:
+            - name: coturn-tls
+              mountPath: /etc/coturn-tls
+              readOnly: true
           ports:
             - containerPort: 3478
               hostPort: 3478
@@ -80,6 +89,9 @@ spec:
             - containerPort: 3478
               hostPort: 3478
               protocol: UDP
+            - containerPort: 5349
+              hostPort: 5349
+              protocol: TCP
           resources:
             requests:
               memory: 64Mi
@@ -87,3 +99,7 @@ spec:
             limits:
               memory: 256Mi
               cpu: "500m"
+      volumes:
+        - name: coturn-tls
+          secret:
+            secretName: coturn-tls

--- a/k3d/coturn-stack/kustomization.yaml
+++ b/k3d/coturn-stack/kustomization.yaml
@@ -12,5 +12,6 @@ kind: Kustomization
 resources:
   - namespace.yaml
   - secret.yaml
+  - coturn-cert.yaml
   - coturn.yaml
   - janus.yaml

--- a/prod/cloud-init.yaml
+++ b/prod/cloud-init.yaml
@@ -86,6 +86,7 @@ runcmd:
   - ufw allow 51820/udp    # WireGuard GPU worker tunnel
   - ufw allow 3478/tcp     # coturn TURN/STUN (TCP)
   - ufw allow 3478/udp     # coturn TURN/STUN (UDP)
+  - ufw allow 5349/tcp     # coturn TURNS (TLS TURN — iOS/iPhone)
   - ufw allow 49152:49252/udp  # coturn TURN relay port range
   - ufw allow 2379:2380/tcp
   - ufw --force enable

--- a/prod/patch-signaling-backend.yaml
+++ b/prod/patch-signaling-backend.yaml
@@ -39,4 +39,4 @@ data:
     [turn]
     apikey = @@TURN_APIKEY@@
     secret = @@TURN_SECRET@@
-    servers = turn:turn.${PROD_DOMAIN}:3478?transport=udp,turn:turn.${PROD_DOMAIN}:3478?transport=tcp
+    servers = turn:turn.${PROD_DOMAIN}:3478?transport=udp,turn:turn.${PROD_DOMAIN}:3478?transport=tcp,turns:turn.${PROD_DOMAIN}:5349?transport=tcp


### PR DESCRIPTION
## Summary

- iPhones on cellular/restrictive networks often block port 3478 UDP+TCP, preventing TURN relay and breaking Nextcloud Talk audio/video
- Adds `turns:` (TURN over TLS) support on port 5349 so iOS clients can reach the relay through TLS, which passes through virtually all firewalls
- Creates a cert-manager `Certificate` for `turn.${PROD_DOMAIN}` in the `coturn` namespace (mounted into the coturn pod)
- Enforces TLS 1.2+ only (SSLv3, TLSv1.0, TLSv1.1 disabled)
- Adds `turns:turn.${PROD_DOMAIN}:5349?transport=tcp` to the signaling server list alongside existing `turn:` entries

## Test plan

- [ ] ArgoCD syncs `workspace-coturn-*` cleanly (Certificate issued, coturn pod restarts with new config)
- [ ] Verify `turn.mentolder.de:5349` reachable after manually opening port on live server: `! ssh patrick@178.104.169.206 "sudo ufw allow 5349/tcp && sudo ufw reload"`
- [ ] Test Nextcloud Talk call from iPhone on mobile data — audio/video should connect
- [ ] Confirm existing desktop/Android clients still work (turn: entries unchanged)
- [ ] Check coturn logs: `task workspace:logs -- coturn -n coturn` — should show TLS handshakes on 5349

> **Note:** The `cloud-init.yaml` change only applies to newly provisioned servers. Existing prod nodes need the firewall rule applied manually (see test plan above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)