### PR TITLE
fix(coturn): remove invalid TLS version flags for coturn 4.9

### DIFF
--- a/k3d/coturn-stack/coturn-cert.yaml
+++ b/k3d/coturn-stack/coturn-cert.yaml
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: coturn-tls
+  namespace: coturn
+spec:
+  secretName: coturn-tls
+  issuerRef:
+    name: letsencrypt-prod
+    kind: ClusterIssuer
+  dnsNames:
+    - "turn.${PROD_DOMAIN}"

--- a/k3d/coturn-stack/coturn.yaml
+++ b/k3d/coturn-stack/coturn.yaml
@@ -45,9 +45,11 @@ spec:
           # only touches ${VAR}, so $(TURN_SECRET) survives build-time.
           command: ["turnserver"]
           args:
-            - "--no-tls"
             - "--no-dtls"
             - "--listening-port=3478"
+            - "--tls-listening-port=5349"
+            - "--cert=/etc/coturn-tls/tls.crt"
+            - "--pkey=/etc/coturn-tls/tls.key"
             - "--min-port=49152"
             - "--max-port=49252"
             - "--realm=turn.${PROD_DOMAIN}"
@@ -61,6 +63,9 @@ spec:
             - "--log-file=stdout"
             - "--no-stdout-log"
             - "--simple-log"
+            - "--no-sslv3"
+            - "--no-tlsv1"
+            - "--no-tlsv1_1"
           env:
             - name: TURN_SECRET
               valueFrom:
@@ -73,6 +78,10 @@ spec:
               add:
                 - NET_ADMIN
                 - NET_RAW
+          volumeMounts:
+            - name: coturn-tls
+              mountPath: /etc/coturn-tls
+              readOnly: true
           ports:
             - containerPort: 3478
               hostPort: 3478
@@ -80,6 +89,9 @@ spec:
             - containerPort: 3478
               hostPort: 3478
               protocol: UDP
+            - containerPort: 5349
+              hostPort: 5349
+              protocol: TCP
           resources:
             requests:
               memory: 64Mi
@@ -87,3 +99,7 @@ spec:
             limits:
               memory: 256Mi
               cpu: "500m"
+      volumes:
+        - name: coturn-tls
+          secret:
+            secretName: coturn-tls

--- a/k3d/coturn-stack/coturn.yaml
+++ b/k3d/coturn-stack/coturn.yaml
@@ -63,9 +63,6 @@ spec:
             - "--log-file=stdout"
             - "--no-stdout-log"
             - "--simple-log"
-            - "--no-sslv3"
-            - "--no-tlsv1"
-            - "--no-tlsv1_1"
           env:
             - name: TURN_SECRET
               valueFrom:

--- a/k3d/coturn-stack/kustomization.yaml
+++ b/k3d/coturn-stack/kustomization.yaml
@@ -12,5 +12,6 @@ kind: Kustomization
 resources:
   - namespace.yaml
   - secret.yaml
+  - coturn-cert.yaml
   - coturn.yaml
   - janus.yaml

--- a/prod/cloud-init.yaml
+++ b/prod/cloud-init.yaml
@@ -86,6 +86,7 @@ runcmd:
   - ufw allow 51820/udp    # WireGuard GPU worker tunnel
   - ufw allow 3478/tcp     # coturn TURN/STUN (TCP)
   - ufw allow 3478/udp     # coturn TURN/STUN (UDP)
+  - ufw allow 5349/tcp     # coturn TURNS (TLS TURN — iOS/iPhone)
   - ufw allow 49152:49252/udp  # coturn TURN relay port range
   - ufw allow 2379:2380/tcp
   - ufw --force enable

--- a/prod/patch-signaling-backend.yaml
+++ b/prod/patch-signaling-backend.yaml
@@ -39,4 +39,4 @@ data:
     [turn]
     apikey = @@TURN_APIKEY@@
     secret = @@TURN_SECRET@@
-    servers = turn:turn.${PROD_DOMAIN}:3478?transport=udp,turn:turn.${PROD_DOMAIN}:3478?transport=tcp
+    servers = turn:turn.${PROD_DOMAIN}:3478?transport=udp,turn:turn.${PROD_DOMAIN}:3478?transport=tcp,turns:turn.${PROD_DOMAIN}:5349?transport=tcp


### PR DESCRIPTION
## Summary

- coturn 4.9-alpine does not support `--no-sslv3`, `--no-tlsv1`, `--no-tlsv1_1` — these flags caused an immediate crash (process printed help and exited)
- The only protocol-floor flag in this version is `--no-tlsv1_2` (enforces TLS 1.3 minimum)
- Removes the three invalid flags; the pod now starts cleanly

## Note on cert management

The `coturn-cert.yaml` Certificate resource (from PR #381) cannot auto-issue via cert-manager DNS-01 because ipv64 cannot set `_acme-challenge.turn.${PROD_DOMAIN}` (sub-subdomain TXT records not supported). The `coturn-tls` secret is currently populated by manually copying the existing wildcard cert:
```
kubectl get secret workspace-wildcard-tls -n website --context mentolder -o json \
  | jq '.metadata.name = "coturn-tls" | del(...)' \
  | kubectl apply -n coturn --context mentolder -f -
```
A permanent sync mechanism (e.g. reflector or sealed-secrets copy) can be added separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)