### PR TITLE
fix(coturn): add TURNS/TLS on port 5349 for iPhone compatibility

### DIFF
--- a/k3d/coturn-stack/coturn-cert.yaml
+++ b/k3d/coturn-stack/coturn-cert.yaml
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: coturn-tls
+  namespace: coturn
+spec:
+  secretName: coturn-tls
+  issuerRef:
+    name: letsencrypt-prod
+    kind: ClusterIssuer
+  dnsNames:
+    - "turn.${PROD_DOMAIN}"

--- a/k3d/coturn-stack/coturn.yaml
+++ b/k3d/coturn-stack/coturn.yaml
@@ -45,9 +45,11 @@ spec:
           # only touches ${VAR}, so $(TURN_SECRET) survives build-time.
           command: ["turnserver"]
           args:
-            - "--no-tls"
             - "--no-dtls"
             - "--listening-port=3478"
+            - "--tls-listening-port=5349"
+            - "--cert=/etc/coturn-tls/tls.crt"
+            - "--pkey=/etc/coturn-tls/tls.key"
             - "--min-port=49152"
             - "--max-port=49252"
             - "--realm=turn.${PROD_DOMAIN}"
@@ -61,6 +63,9 @@ spec:
             - "--log-file=stdout"
             - "--no-stdout-log"
             - "--simple-log"
+            - "--no-sslv3"
+            - "--no-tlsv1"
+            - "--no-tlsv1_1"
           env:
             - name: TURN_SECRET
               valueFrom:
@@ -73,6 +78,10 @@ spec:
               add:
                 - NET_ADMIN
                 - NET_RAW
+          volumeMounts:
+            - name: coturn-tls
+              mountPath: /etc/coturn-tls
+              readOnly: true
           ports:
             - containerPort: 3478
               hostPort: 3478
@@ -80,6 +89,9 @@ spec:
             - containerPort: 3478
               hostPort: 3478
               protocol: UDP
+            - containerPort: 5349
+              hostPort: 5349
+              protocol: TCP
           resources:
             requests:
               memory: 64Mi
@@ -87,3 +99,7 @@ spec:
             limits:
               memory: 256Mi
               cpu: "500m"
+      volumes:
+        - name: coturn-tls
+          secret:
+            secretName: coturn-tls

--- a/k3d/coturn-stack/coturn.yaml
+++ b/k3d/coturn-stack/coturn.yaml
@@ -63,9 +63,6 @@ spec:
             - "--log-file=stdout"
             - "--no-stdout-log"
             - "--simple-log"
-            - "--no-sslv3"
-            - "--no-tlsv1"
-            - "--no-tlsv1_1"
           env:
             - name: TURN_SECRET
               valueFrom:

--- a/k3d/coturn-stack/kustomization.yaml
+++ b/k3d/coturn-stack/kustomization.yaml
@@ -12,5 +12,6 @@ kind: Kustomization
 resources:
   - namespace.yaml
   - secret.yaml
+  - coturn-cert.yaml
   - coturn.yaml
   - janus.yaml

--- a/prod/cloud-init.yaml
+++ b/prod/cloud-init.yaml
@@ -86,6 +86,7 @@ runcmd:
   - ufw allow 51820/udp    # WireGuard GPU worker tunnel
   - ufw allow 3478/tcp     # coturn TURN/STUN (TCP)
   - ufw allow 3478/udp     # coturn TURN/STUN (UDP)
+  - ufw allow 5349/tcp     # coturn TURNS (TLS TURN — iOS/iPhone)
   - ufw allow 49152:49252/udp  # coturn TURN relay port range
   - ufw allow 2379:2380/tcp
   - ufw --force enable

--- a/prod/patch-signaling-backend.yaml
+++ b/prod/patch-signaling-backend.yaml
@@ -39,4 +39,4 @@ data:
     [turn]
     apikey = @@TURN_APIKEY@@
     secret = @@TURN_SECRET@@
-    servers = turn:turn.${PROD_DOMAIN}:3478?transport=udp,turn:turn.${PROD_DOMAIN}:3478?transport=tcp
+    servers = turn:turn.${PROD_DOMAIN}:3478?transport=udp,turn:turn.${PROD_DOMAIN}:3478?transport=tcp,turns:turn.${PROD_DOMAIN}:5349?transport=tcp


### PR DESCRIPTION
## Summary

- Add TURNS/TLS listener on port 5349 so iOS clients can relay media through coturn (iOS enforces TLS for WebRTC TURN)
- Add cert-manager Certificate resource for `turn.${PROD_DOMAIN}` via letsencrypt-prod ClusterIssuer
- Mount the issued TLS cert into the coturn pod
- Register the `turns:` URL in the HPB signaling backend config alongside the existing `turn:` URLs
- Remove `--no-tls` flag (previously disabled TLS entirely) and remove invalid `--no-sslv3` / `--no-tlsv1_1` flags not supported by coturn 4.9

## Test plan

- [ ] Verify coturn pod starts without CrashLoopBackOff after deploy
- [ ] Verify cert-manager issues the `coturn-tls` certificate for `turn.<domain>`
- [ ] Verify TURNS on port 5349 is reachable from an iOS device in a Nextcloud Talk call
- [ ] Verify existing TURN on port 3478 (UDP/TCP) still works for non-iOS clients
- [ ] Check HPB signaling backend picks up the new `turns:` server entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)