### PR TITLE
fix(coturn): remove --no-sslv3/--no-tlsv1/--no-tlsv1_1 invalid in coturn 4.9

### DIFF
--- a/k3d/coturn-stack/coturn.yaml
+++ b/k3d/coturn-stack/coturn.yaml
@@ -63,9 +63,6 @@ spec:
             - "--log-file=stdout"
             - "--no-stdout-log"
             - "--simple-log"
-            - "--no-sslv3"
-            - "--no-tlsv1"
-            - "--no-tlsv1_1"
           env:
             - name: TURN_SECRET
               valueFrom:


### PR DESCRIPTION
## Summary

- Removes `--no-sslv3`, `--no-tlsv1`, `--no-tlsv1_1` flags that do not exist in coturn 4.9
- These flags were reintroduced by the squash-merge of PR #383 (the branch was based on a state predating PR #381/#382, so the squash diff included the bad flags)
- Without this fix, coturn prints `--help` and exits on every startup → CrashLoopBackOff → iPhone users have no TURN relay

## Test plan

- [ ] After merge + ArgoCD sync, coturn pod should start and stay Running
- [ ] TURN on port 3478 and TURNS on port 5349 both reachable

🤖 Generated with [Claude Code](https://claude.com/claude-code)