### PR TITLE
feat(brett): minimap-only navigation, hold-to-rotate stones, preset camera buttons

### DIFF
--- a/brett/public/index.html
+++ b/brett/public/index.html
@@ -232,6 +232,17 @@
     font-size: 9px; color: #243550; text-align: center;
     margin-top: 5px; letter-spacing: 0.04em;
   }
+  #minimap-presets {
+    display: flex; gap: 4px; margin-top: 6px;
+  }
+  .preset-btn {
+    flex: 1; padding: 4px 0; font-size: 10px; font-weight: 600;
+    border-radius: 5px; border: 1px solid #1a3060; background: #08142a;
+    color: #3a6090; cursor: pointer; transition: all 0.12s; letter-spacing: 0.04em;
+    font-family: inherit; line-height: 1;
+  }
+  .preset-btn:hover { background: #1a3060; color: #7aaac8; }
+  .preset-btn.flash { background: #1a4a8a; color: #e0e0e0; transition: none; }
 </style>
 </head>
 <body>
@@ -308,7 +319,7 @@
 <div id="canvas-container">
   <canvas id="three-canvas"></canvas>
   <div id="hint">
-    LMB: Figur ziehen &nbsp;|&nbsp; RMB / 2-Finger: Blickwinkel drehen &nbsp;|&nbsp; MMB: Brett verschieben &nbsp;|&nbsp; Rad / Zoom-Slider: Zoom &nbsp;|&nbsp; Doppelklick: Beschriftung
+    LMB halten: Figur drehen &nbsp;|&nbsp; LMB ziehen: Figur bewegen &nbsp;|&nbsp; Übersicht LMB: Kamera pan &nbsp;|&nbsp; Übersicht MMB: Neigung &nbsp;|&nbsp; Rad: Zoom &nbsp;|&nbsp; Doppelklick: Beschriftung
   </div>
   <div id="selected-info"></div>
 </div>
@@ -323,7 +334,12 @@
       <canvas id="minimap-canvas"></canvas>
       <canvas id="minimap-ui"></canvas>
     </div>
-    <div id="minimap-foot">Klick · Ziehen: Ansicht navigieren</div>
+    <div id="minimap-presets">
+      <button class="preset-btn" data-preset="0" title="LMB: Linke Ansicht · MMB: Winkel speichern">L</button>
+      <button class="preset-btn" data-preset="1" title="LMB: Startansicht · MMB: Winkel speichern">⌂</button>
+      <button class="preset-btn" data-preset="2" title="LMB: Rechte Ansicht · MMB: Winkel speichern">R</button>
+    </div>
+    <div id="minimap-foot">LMB: Pan · MMB: Neigung · Tasten: Ansicht</div>
   </div>
 </div>
 
@@ -1199,27 +1215,14 @@ function pickBoard(ndc) {
 }
 
 // ── Mouse / touch ─────────────────────────────────────────────────────────────
-let drag   = { on: false, fig: null };
-let rmbOn  = false;
+let drag      = { on: false, fig: null, mode: null }; // mode: 'move' | 'rotate'
+let holdTimer = null;
+let holdStart = null;
 let lastClick = { fig: null, time: 0 };
 
 canvas.addEventListener('contextmenu', e => e.preventDefault());
-
-let panOn = false;
-canvas.addEventListener('contextmenu', e => e.preventDefault());
 canvas.addEventListener('mousedown', e => {
   if (modal.classList.contains('visible')) return;
-  if (e.button === 2) {
-    rmbOn = true;
-    orbit.startX = e.clientX; orbit.startY = e.clientY;
-    return;
-  }
-  if (e.button === 1) {
-    panOn = true;
-    orbit.startX = e.clientX; orbit.startY = e.clientY;
-    e.preventDefault();
-    return;
-  }
   if (e.button === 0) {
     const ndc = getNDC(e);
     const fig = pickFigure(ndc);
@@ -1228,7 +1231,16 @@ canvas.addEventListener('mousedown', e => {
       if (lastClick.fig === fig && now-lastClick.time < 380) { openLabelModal(fig); lastClick.fig = null; return; }
       lastClick = { fig, time: now };
       selectFigure(fig);
-      drag = { on: true, fig };
+      holdStart = { x: e.clientX, y: e.clientY };
+      drag = { on: false, fig, mode: null };
+      holdTimer = setTimeout(() => {
+        holdTimer = null;
+        if (drag.fig && !drag.on) {
+          drag.on   = true;
+          drag.mode = 'rotate';
+          drag.startX = holdStart ? holdStart.x : e.clientX;
+        }
+      }, 200);
     } else {
       selectFigure(null); lastClick.fig = null;
     }
@@ -1244,42 +1256,44 @@ function sendMoveThrottled(fig) {
 }
 
 canvas.addEventListener('mousemove', e => {
-  if (rmbOn) {
-    const dx = e.clientX - orbit.startX;
-    const dy = e.clientY - orbit.startY;
-    orbit.theta -= dx * 0.008;
-    orbit.phi = Math.max(0.12, Math.min(Math.PI/2.05, orbit.phi + dy*0.008));
-    orbit.startX = e.clientX; orbit.startY = e.clientY;
-    updateCamera(); return;
-  }
-  if (panOn) {
-    const dx = e.clientX - orbit.startX;
-    const dy = e.clientY - orbit.startY;
-    const f = orbit.radius * 0.01;
-    orbit.panX += dx * f * Math.cos(orbit.theta) + dy * f * Math.sin(orbit.theta);
-    orbit.panZ += dx * f * (-Math.sin(orbit.theta)) + dy * f * Math.cos(orbit.theta);
-    orbit.startX = e.clientX; orbit.startY = e.clientY;
-    updateCamera(); return;
+  // Escalate pending hold to move-mode if mouse moved significantly
+  if (holdStart && drag.fig && !drag.on) {
+    const dx = e.clientX - holdStart.x;
+    const dy = e.clientY - holdStart.y;
+    if (Math.sqrt(dx*dx + dy*dy) > 5) {
+      clearTimeout(holdTimer); holdTimer = null;
+      drag.on = true; drag.mode = 'move';
+    }
   }
   if (drag.on && drag.fig) {
-    const pos = pickBoard(getNDC(e));
-    if (pos) {
-      drag.fig.mesh.position.x = Math.max(-BW/2+1, Math.min(BW/2-1, pos.x));
-      drag.fig.mesh.position.z = Math.max(-BD/2+1, Math.min(BD/2-1, pos.z));
-      if (!applyingRemote) sendMoveThrottled(drag.fig);
+    if (drag.mode === 'move') {
+      const pos = pickBoard(getNDC(e));
+      if (pos) {
+        drag.fig.mesh.position.x = Math.max(-BW/2+1, Math.min(BW/2-1, pos.x));
+        drag.fig.mesh.position.z = Math.max(-BD/2+1, Math.min(BD/2-1, pos.z));
+        if (!applyingRemote) sendMoveThrottled(drag.fig);
+      }
+    } else if (drag.mode === 'rotate') {
+      const dx = e.clientX - drag.startX;
+      drag.startX = e.clientX;
+      const fig = drag.fig;
+      setRotY(fig, fig.rotY + dx * 0.02);
+      if (!applyingRemote) send({ type: 'update', id: fig.id, changes: { rotY: fig.rotY } });
     }
   }
 });
 
-canvas.addEventListener('mouseup', e => {
-  if (e.button === 2) rmbOn = false;
-  if (e.button === 1) panOn = false;
-  if (e.button === 0) {
-    if (drag.on && drag.fig && !applyingRemote) {
+function cleanupCanvasDrag() {
+  if (holdTimer !== null || holdStart !== null || drag.on) {
+    clearTimeout(holdTimer); holdTimer = null; holdStart = null;
+    if (drag.on && drag.fig && drag.mode === 'move' && !applyingRemote) {
       send({ type: 'move', id: drag.fig.id, x: drag.fig.mesh.position.x, z: drag.fig.mesh.position.z });
     }
-    drag = { on:false, fig:null };
+    drag = { on: false, fig: null, mode: null };
   }
+}
+canvas.addEventListener('mouseup', e => {
+  if (e.button === 0) cleanupCanvasDrag();
 });
 
 const zoomSlider = document.getElementById('zoom-slider');
@@ -1418,30 +1432,79 @@ animate();
   }
   animMinimap();
 
-  // Click / drag to navigate
+  // Click / drag to navigate — LMB: pan, MMB: orbit
   const mWrap = document.getElementById('minimap-wrap');
-  let mDrag = false, mDS = { x: 0, y: 0 };
+  let mDrag = false, mDragMode = null, mDS = { x: 0, y: 0 };
 
+  mWrap.addEventListener('contextmenu', e => e.preventDefault());
   mWrap.addEventListener('mousedown', e => {
-    mDrag = true;
-    mDS = { x: e.clientX, y: e.clientY };
-    const rect = mWrap.getBoundingClientRect();
-    orbit.panX = ((e.clientX - rect.left) / rect.width  - 0.5) * 2 * HALF_X;
-    orbit.panZ = ((e.clientY - rect.top)  / rect.height - 0.5) * 2 * HALF_Z;
-    updateCamera();
+    if (e.button === 0) {
+      mDrag = true; mDragMode = 'pan';
+      mDS = { x: e.clientX, y: e.clientY };
+      const rect = mWrap.getBoundingClientRect();
+      orbit.panX = ((e.clientX - rect.left) / rect.width  - 0.5) * 2 * HALF_X;
+      orbit.panZ = ((e.clientY - rect.top)  / rect.height - 0.5) * 2 * HALF_Z;
+      updateCamera();
+    } else if (e.button === 1) {
+      mDrag = true; mDragMode = 'orbit';
+      mDS = { x: e.clientX, y: e.clientY };
+    }
     e.preventDefault(); e.stopPropagation();
   });
 
+  mWrap.addEventListener('wheel', e => {
+    setZoom(orbit.radius + e.deltaY * 0.05);
+    e.preventDefault(); e.stopPropagation();
+  }, { passive: false });
+
   window.addEventListener('mousemove', e => {
-    if (!mDrag) return;
-    const rect = mWrap.getBoundingClientRect();
-    orbit.panX += (e.clientX - mDS.x) / rect.width  * 2 * HALF_X;
-    orbit.panZ += (e.clientY - mDS.y) / rect.height * 2 * HALF_Z;
-    mDS = { x: e.clientX, y: e.clientY };
-    updateCamera();
+    if (mDrag) {
+      if (mDragMode === 'pan') {
+        const rect = mWrap.getBoundingClientRect();
+        orbit.panX += (e.clientX - mDS.x) / rect.width  * 2 * HALF_X;
+        orbit.panZ += (e.clientY - mDS.y) / rect.height * 2 * HALF_Z;
+      } else if (mDragMode === 'orbit') {
+        orbit.theta -= (e.clientX - mDS.x) * 0.008;
+        orbit.phi = Math.max(0.12, Math.min(Math.PI/2.05, orbit.phi + (e.clientY - mDS.y) * 0.008));
+      }
+      mDS = { x: e.clientX, y: e.clientY };
+      updateCamera();
+    }
   });
 
-  window.addEventListener('mouseup', () => { mDrag = false; });
+  window.addEventListener('mouseup', e => {
+    mDrag = false; mDragMode = null;
+    // Also clean up canvas drag if mouse was released outside canvas
+    if (e.button === 0) cleanupCanvasDrag();
+  });
+
+  // Preset camera buttons
+  const camPresets = [
+    { theta: -Math.PI/2, phi: 0.95, radius: 44, panX: 0, panZ: 0 },
+    { theta: 0,          phi: 0.95, radius: 44, panX: 0, panZ: 0 },
+    { theta:  Math.PI/2, phi: 0.95, radius: 44, panX: 0, panZ: 0 },
+  ];
+
+  document.querySelectorAll('.preset-btn').forEach(btn => {
+    const idx = parseInt(btn.dataset.preset);
+    btn.addEventListener('click', () => {
+      const p = camPresets[idx];
+      orbit.theta = p.theta; orbit.phi = p.phi;
+      orbit.panX  = p.panX;  orbit.panZ = p.panZ;
+      setZoom(p.radius);
+      updateCamera();
+      btn.classList.add('flash');
+      setTimeout(() => btn.classList.remove('flash'), 250);
+    });
+    btn.addEventListener('mousedown', e => {
+      if (e.button === 1) {
+        camPresets[idx] = { theta: orbit.theta, phi: orbit.phi, radius: orbit.radius, panX: orbit.panX, panZ: orbit.panZ };
+        btn.classList.add('flash');
+        setTimeout(() => btn.classList.remove('flash'), 350);
+        e.preventDefault(); e.stopPropagation();
+      }
+    });
+  });
 
   // Collapse / expand
   document.getElementById('minimap-toggle').addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- Camera navigation (orbit + pan) moved exclusively to the minimap widget — main canvas no longer responds to RMB/MMB
- Mousewheel always zooms on both main canvas and minimap
- Minimap: LMB drag = pan, MMB drag = tilt/orbit, wheel = zoom
- LMB on stone: quick drag (< 200 ms or > 5 px) → move; hold in place → rotate mode (horizontal mouse → rotY, synced via WS)
- Three preset-camera buttons (L / ⌂ / R) below minimap: LMB = snap, MMB = save current angle

## Test plan
- [ ] Wheel zooms from both main canvas and minimap
- [ ] Dragging minimap with LMB pans the view
- [ ] Dragging minimap with MMB tilts/orbits the view
- [ ] Main canvas RMB/MMB no longer moves the camera
- [ ] Quick LMB drag on stone moves it as before
- [ ] Holding LMB on stone (still for ~200 ms) then dragging horizontally rotates the stone
- [ ] Rotation is broadcast to other participants via WebSocket
- [ ] L / ⌂ / R buttons snap to left, start, right camera presets
- [ ] MMB click on preset button saves current camera to that slot

🤖 Generated with [Claude Code](https://claude.com/claude-code)