### PR TITLE
fix(brett): correct controls — RMB rotate, minimap LMB=tilt MMB=pan

### DIFF
--- a/brett/public/index.html
+++ b/brett/public/index.html
@@ -319,7 +319,7 @@
 <div id="canvas-container">
   <canvas id="three-canvas"></canvas>
   <div id="hint">
-    LMB halten: Figur drehen &nbsp;|&nbsp; LMB ziehen: Figur bewegen &nbsp;|&nbsp; Übersicht LMB: Kamera pan &nbsp;|&nbsp; Übersicht MMB: Neigung &nbsp;|&nbsp; Rad: Zoom &nbsp;|&nbsp; Doppelklick: Beschriftung
+    LMB: Figur auswählen/bewegen &nbsp;|&nbsp; RMB halten: Figur drehen &nbsp;|&nbsp; Minimap LMB: Neigung &nbsp;|&nbsp; Minimap MMB: Verschieben &nbsp;|&nbsp; Rad: Zoom &nbsp;|&nbsp; Doppelklick: Beschriftung
   </div>
   <div id="selected-info"></div>
 </div>
@@ -1215,9 +1215,8 @@ function pickBoard(ndc) {
 }
 
 // ── Mouse / touch ─────────────────────────────────────────────────────────────
-let drag      = { on: false, fig: null, mode: null }; // mode: 'move' | 'rotate'
-let holdTimer = null;
-let holdStart = null;
+let drag    = { on: false, fig: null };
+let rotDrag = { on: false, fig: null, startX: 0 };
 let lastClick = { fig: null, time: 0 };
 
 canvas.addEventListener('contextmenu', e => e.preventDefault());
@@ -1231,18 +1230,16 @@ canvas.addEventListener('mousedown', e => {
       if (lastClick.fig === fig && now-lastClick.time < 380) { openLabelModal(fig); lastClick.fig = null; return; }
       lastClick = { fig, time: now };
       selectFigure(fig);
-      holdStart = { x: e.clientX, y: e.clientY };
-      drag = { on: false, fig, mode: null };
-      holdTimer = setTimeout(() => {
-        holdTimer = null;
-        if (drag.fig && !drag.on) {
-          drag.on   = true;
-          drag.mode = 'rotate';
-          drag.startX = holdStart ? holdStart.x : e.clientX;
-        }
-      }, 200);
+      drag = { on: true, fig };
     } else {
       selectFigure(null); lastClick.fig = null;
+    }
+  } else if (e.button === 2) {
+    const ndc = getNDC(e);
+    const fig = pickFigure(ndc);
+    if (fig) {
+      selectFigure(fig);
+      rotDrag = { on: true, fig, startX: e.clientX };
     }
   }
 });
@@ -1256,44 +1253,36 @@ function sendMoveThrottled(fig) {
 }
 
 canvas.addEventListener('mousemove', e => {
-  // Escalate pending hold to move-mode if mouse moved significantly
-  if (holdStart && drag.fig && !drag.on) {
-    const dx = e.clientX - holdStart.x;
-    const dy = e.clientY - holdStart.y;
-    if (Math.sqrt(dx*dx + dy*dy) > 5) {
-      clearTimeout(holdTimer); holdTimer = null;
-      drag.on = true; drag.mode = 'move';
+  if (drag.on && drag.fig) {
+    const pos = pickBoard(getNDC(e));
+    if (pos) {
+      drag.fig.mesh.position.x = Math.max(-BW/2+1, Math.min(BW/2-1, pos.x));
+      drag.fig.mesh.position.z = Math.max(-BD/2+1, Math.min(BD/2-1, pos.z));
+      if (!applyingRemote) sendMoveThrottled(drag.fig);
     }
   }
-  if (drag.on && drag.fig) {
-    if (drag.mode === 'move') {
-      const pos = pickBoard(getNDC(e));
-      if (pos) {
-        drag.fig.mesh.position.x = Math.max(-BW/2+1, Math.min(BW/2-1, pos.x));
-        drag.fig.mesh.position.z = Math.max(-BD/2+1, Math.min(BD/2-1, pos.z));
-        if (!applyingRemote) sendMoveThrottled(drag.fig);
-      }
-    } else if (drag.mode === 'rotate') {
-      const dx = e.clientX - drag.startX;
-      drag.startX = e.clientX;
-      const fig = drag.fig;
-      setRotY(fig, fig.rotY + dx * 0.02);
-      if (!applyingRemote) send({ type: 'update', id: fig.id, changes: { rotY: fig.rotY } });
-    }
+  if (rotDrag.on && rotDrag.fig) {
+    const dx = e.clientX - rotDrag.startX;
+    rotDrag.startX = e.clientX;
+    const fig = rotDrag.fig;
+    setRotY(fig, fig.rotY + dx * 0.02);
+    if (!applyingRemote) send({ type: 'update', id: fig.id, changes: { rotY: fig.rotY } });
   }
 });
 
-function cleanupCanvasDrag() {
-  if (holdTimer !== null || holdStart !== null || drag.on) {
-    clearTimeout(holdTimer); holdTimer = null; holdStart = null;
-    if (drag.on && drag.fig && drag.mode === 'move' && !applyingRemote) {
+function cleanupCanvasDrag(button) {
+  if (button === 0 || button === undefined) {
+    if (drag.on && drag.fig && !applyingRemote) {
       send({ type: 'move', id: drag.fig.id, x: drag.fig.mesh.position.x, z: drag.fig.mesh.position.z });
     }
-    drag = { on: false, fig: null, mode: null };
+    drag = { on: false, fig: null };
+  }
+  if (button === 2 || button === undefined) {
+    rotDrag = { on: false, fig: null, startX: 0 };
   }
 }
 canvas.addEventListener('mouseup', e => {
-  if (e.button === 0) cleanupCanvasDrag();
+  cleanupCanvasDrag(e.button);
 });
 
 const zoomSlider = document.getElementById('zoom-slider');
@@ -1439,15 +1428,15 @@ animate();
   mWrap.addEventListener('contextmenu', e => e.preventDefault());
   mWrap.addEventListener('mousedown', e => {
     if (e.button === 0) {
+      mDrag = true; mDragMode = 'orbit';
+      mDS = { x: e.clientX, y: e.clientY };
+    } else if (e.button === 1) {
       mDrag = true; mDragMode = 'pan';
       mDS = { x: e.clientX, y: e.clientY };
       const rect = mWrap.getBoundingClientRect();
       orbit.panX = ((e.clientX - rect.left) / rect.width  - 0.5) * 2 * HALF_X;
       orbit.panZ = ((e.clientY - rect.top)  / rect.height - 0.5) * 2 * HALF_Z;
       updateCamera();
-    } else if (e.button === 1) {
-      mDrag = true; mDragMode = 'orbit';
-      mDS = { x: e.clientX, y: e.clientY };
     }
     e.preventDefault(); e.stopPropagation();
   });
@@ -1459,13 +1448,13 @@ animate();
 
   window.addEventListener('mousemove', e => {
     if (mDrag) {
-      if (mDragMode === 'pan') {
+      if (mDragMode === 'orbit') {
+        orbit.theta -= (e.clientX - mDS.x) * 0.008;
+        orbit.phi = Math.max(0.12, Math.min(Math.PI/2.05, orbit.phi + (e.clientY - mDS.y) * 0.008));
+      } else if (mDragMode === 'pan') {
         const rect = mWrap.getBoundingClientRect();
         orbit.panX += (e.clientX - mDS.x) / rect.width  * 2 * HALF_X;
         orbit.panZ += (e.clientY - mDS.y) / rect.height * 2 * HALF_Z;
-      } else if (mDragMode === 'orbit') {
-        orbit.theta -= (e.clientX - mDS.x) * 0.008;
-        orbit.phi = Math.max(0.12, Math.min(Math.PI/2.05, orbit.phi + (e.clientY - mDS.y) * 0.008));
       }
       mDS = { x: e.clientX, y: e.clientY };
       updateCamera();
@@ -1474,8 +1463,7 @@ animate();
 
   window.addEventListener('mouseup', e => {
     mDrag = false; mDragMode = null;
-    // Also clean up canvas drag if mouse was released outside canvas
-    if (e.button === 0) cleanupCanvasDrag();
+    cleanupCanvasDrag(e.button);
   });
 
   // Preset camera buttons


### PR DESCRIPTION
## Summary
- **Stone rotation**: RMB hold + horizontal drag → rotY (was: LMB hold-timer)
- **Stone move**: LMB drag as before, hold-timer logic removed
- **Minimap LMB drag**: tilt / orbit (theta + phi) — was pan, now swapped
- **Minimap MMB drag**: pan / move (panX + panZ) — was orbit, now swapped
- Camera navigation strictly minimap-only; main canvas has no camera gestures

## Test plan
- [ ] LMB drag on stone → moves stone on board
- [ ] RMB hold + drag on stone → spins stone (rotY), synced to peers
- [ ] Minimap LMB drag → tilts camera view
- [ ] Minimap MMB drag → pans/moves camera
- [ ] Wheel zooms on both canvas and minimap
- [ ] L / ⌂ / R preset buttons snap to predefined views

🤖 Generated with [Claude Code](https://claude.com/claude-code)