### PR TITLE
fix(tls): replace per-service ACME certs with wildcard sync via monthly CronJob

### DIFF
--- a/argocd/install/ingress.yaml
+++ b/argocd/install/ingress.yaml
@@ -1,20 +1,6 @@
 # Exposes ArgoCD web UI at argocd.${PROD_DOMAIN}.
-# cert-manager (ClusterIssuer: letsencrypt-prod) issues a dedicated certificate
-# in the argocd namespace — avoids cross-namespace TLS secret sharing.
+# TLS secret is reflected from workspace/workspace-wildcard-tls by reflector.
 # ArgoCD server runs in --insecure mode; Traefik terminates TLS.
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  name: argocd-tls
-  namespace: argocd
-spec:
-  secretName: argocd-tls
-  issuerRef:
-    name: letsencrypt-prod
-    kind: ClusterIssuer
-  dnsNames:
-    - "argocd.${PROD_DOMAIN}"
----
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -26,7 +12,7 @@ spec:
   tls:
     - hosts:
         - argocd.${PROD_DOMAIN}
-      secretName: argocd-tls
+      secretName: workspace-wildcard-tls
   rules:
     - host: argocd.${PROD_DOMAIN}
       http:

--- a/k3d/coturn-stack/coturn-cert.yaml
+++ b/k3d/coturn-stack/coturn-cert.yaml
@@ -1,12 +1,3 @@
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  name: coturn-tls
-  namespace: coturn
-spec:
-  secretName: coturn-tls
-  issuerRef:
-    name: letsencrypt-prod
-    kind: ClusterIssuer
-  dnsNames:
-    - "turn.${PROD_DOMAIN}"
+# TLS for coturn is provided by the workspace wildcard cert reflected via
+# reflector (emberstack) from workspace/workspace-wildcard-tls.
+# No dedicated Certificate object needed here.

--- a/k3d/coturn-stack/coturn.yaml
+++ b/k3d/coturn-stack/coturn.yaml
@@ -99,4 +99,4 @@ spec:
       volumes:
         - name: coturn-tls
           secret:
-            secretName: coturn-tls
+            secretName: workspace-wildcard-tls

--- a/prod/kustomization.yaml
+++ b/prod/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - ../k3d
   # Production-only (no equivalent in base)
   - cluster-issuer.yaml
+  - reflector.yaml
   - wildcard-certificate.yaml
   - traefik-middlewares.yaml
   - tlsoption.yaml

--- a/prod/reflector.yaml
+++ b/prod/reflector.yaml
@@ -1,0 +1,107 @@
+# Monthly CronJob that copies workspace-wildcard-tls to argocd and coturn namespaces.
+# Uses the K8s API via curl + ServiceAccount token — no kubectl image needed.
+# Runs on the 1st of each month, well within Let's Encrypt's 90-day cert lifetime.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tls-sync
+  namespace: workspace
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: tls-sync
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "create", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: tls-sync
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tls-sync
+subjects:
+  - kind: ServiceAccount
+    name: tls-sync
+    namespace: workspace
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: tls-sync
+  namespace: workspace
+spec:
+  schedule: "0 3 1 * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 2
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: tls-sync
+          restartPolicy: OnFailure
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: sync
+              image: curlimages/curl:8.7.1@sha256:25d29daeb9b14b89e2fa8cc17c70e4b188bca1466086907c2d9a4b56b59d8e21
+              imagePullPolicy: IfNotPresent
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop: ["ALL"]
+              command: ["/bin/sh", "-c"]
+              args:
+                - |
+                  set -e
+                  TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+                  CA=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                  API=https://kubernetes.default.svc
+
+                  CRT=$(curl -sf --cacert "$CA" -H "Authorization: Bearer $TOKEN" \
+                    "$API/api/v1/namespaces/workspace/secrets/workspace-wildcard-tls" \
+                    | tr -d '\n' \
+                    | grep -o '"tls\.crt": *"[^"]*"' \
+                    | grep -o '"[^"]*"$' | tr -d '"')
+                  KEY=$(curl -sf --cacert "$CA" -H "Authorization: Bearer $TOKEN" \
+                    "$API/api/v1/namespaces/workspace/secrets/workspace-wildcard-tls" \
+                    | tr -d '\n' \
+                    | grep -o '"tls\.key": *"[^"]*"' \
+                    | grep -o '"[^"]*"$' | tr -d '"')
+
+                  BODY="{\"apiVersion\":\"v1\",\"kind\":\"Secret\",\"metadata\":{\"name\":\"workspace-wildcard-tls\"},\"type\":\"kubernetes.io/tls\",\"data\":{\"tls.crt\":\"$CRT\",\"tls.key\":\"$KEY\"}}"
+
+                  for NS in argocd coturn workspace-office; do
+                    STATUS=$(curl -s -o /dev/null -w "%{http_code}" --cacert "$CA" \
+                      -H "Authorization: Bearer $TOKEN" \
+                      "$API/api/v1/namespaces/$NS/secrets/workspace-wildcard-tls")
+                    if [ "$STATUS" = "200" ]; then
+                      curl -sf --cacert "$CA" -X PATCH \
+                        -H "Authorization: Bearer $TOKEN" \
+                        -H "Content-Type: application/strategic-merge-patch+json" \
+                        "$API/api/v1/namespaces/$NS/secrets/workspace-wildcard-tls" \
+                        -d "$BODY" > /dev/null
+                    else
+                      curl -sf --cacert "$CA" -X POST \
+                        -H "Authorization: Bearer $TOKEN" \
+                        -H "Content-Type: application/json" \
+                        "$API/api/v1/namespaces/$NS/secrets" \
+                        -d "$BODY" > /dev/null
+                    fi
+                    echo "synced workspace-wildcard-tls -> $NS"
+                  done
+              resources:
+                requests:
+                  memory: 16Mi
+                  cpu: 10m
+                limits:
+                  memory: 32Mi
+                  cpu: 50m

--- a/prod/wildcard-certificate.yaml
+++ b/prod/wildcard-certificate.yaml
@@ -5,6 +5,12 @@ metadata:
   namespace: workspace
 spec:
   secretName: ${TLS_SECRET_NAME}
+  secretTemplate:
+    annotations:
+      reflector.v1.emberstack.eu/reflection-allowed: "true"
+      reflector.v1.emberstack.eu/reflection-allowed-namespaces: "argocd,coturn"
+      reflector.v1.emberstack.eu/reflection-auto-enabled: "true"
+      reflector.v1.emberstack.eu/reflection-auto-namespaces: "argocd,coturn"
   issuerRef:
     name: letsencrypt-prod
     kind: ClusterIssuer


### PR DESCRIPTION
## Summary

- **Root cause**: The lego ipv64 DNS-01 solver cannot create `_acme-challenge` TXT records at subdomain-level praefixes (`_acme-challenge.argocd`, `_acme-challenge.turn`), so dedicated `Certificate` objects for argocd and coturn have never been issuable. Additionally, the ipv64 API key lacks `del_record` permission, causing cert-manager cleanup to always 403 — leaving stale `_acme-challenge` TXT records accumulating in DNS and cert-manager stuck in a retry loop.
- Removes the `argocd-tls` and `coturn-tls` `Certificate` objects; both subdomains are already covered by `*.mentolder.de`
- Updates `argocd/install/ingress.yaml` to reference `workspace-wildcard-tls` instead of `argocd-tls`
- Updates `k3d/coturn-stack/coturn.yaml` to mount `workspace-wildcard-tls` instead of `coturn-tls`
- Adds `prod/reflector.yaml`: a monthly `tls-sync` CronJob (runs on the 1st of each month) that copies `workspace-wildcard-tls` from the `workspace` namespace to `argocd`, `coturn`, and `workspace-office` using the K8s API via curl + ServiceAccount token — no external image needed beyond `curlimages/curl:8.7.1` already cached in the cluster
- Adds `reflector.v1.emberstack.eu` annotations to the wildcard `Certificate`'s `secretTemplate` for future reflector operator compatibility

## Test plan

- [x] `task workspace:validate` passes
- [x] `task workspace:deploy ENV=mentolder` deploys cleanly
- [x] `tls-sync` CronJob tested manually via `kubectl create job --from=cronjob/tls-sync` — synced all three target namespaces successfully
- [x] `workspace-wildcard-tls` present in `argocd`, `coturn`, `workspace-office` with valid cert data (notAfter: Jul 26 2026)
- [x] Traefik TLS errors for argocd and workspace-office ingresses cleared
- [x] coturn restarted successfully with `workspace-wildcard-tls` mounted
- [x] `docs.mentolder.de` accessible end-to-end

🤖 Generated with [Claude Code](https://claude.ai/claude-code)