### PR TITLE
feat(billing): tax-mode toggle + monthly revenue overview

### DIFF
--- a/website/src/lib/tax-monitor.ts
+++ b/website/src/lib/tax-monitor.ts
@@ -66,6 +66,25 @@ export async function checkAndApplyTaxModeSwitch(brand: string, invoiceId: strin
   return false;
 }
 
+export async function getMonthlyBreakdown(brand: string, year: number): Promise<{
+  month: number; net: number; cumulative: number; status: TaxThresholdStatus;
+}[]> {
+  const r = await pool.query(
+    `SELECT EXTRACT(MONTH FROM issue_date)::int AS month, COALESCE(SUM(net_amount),0)::numeric AS net
+     FROM billing_invoices
+     WHERE brand=$1 AND EXTRACT(YEAR FROM issue_date)=$2
+       AND status IN ('open','paid')
+     GROUP BY month ORDER BY month`,
+    [brand, year]
+  );
+  const byMonth = Object.fromEntries(r.rows.map((row: { month: number; net: string }) => [row.month, Number(row.net)]));
+  let cumulative = 0;
+  return Array.from({ length: 12 }, (_, i) => {
+    cumulative += byMonth[i + 1] ?? 0;
+    return { month: i + 1, net: byMonth[i + 1] ?? 0, cumulative, status: checkThreshold(cumulative) };
+  });
+}
+
 export async function getUstvaExport(brand: string, year: number, quarter?: number): Promise<{
   period: string; taxMode: string; revenue0: number; revenue7: number; revenue19: number;
   tax7: number; tax19: number; totalTax: number;

--- a/website/src/pages/admin/einstellungen/rechnungen.astro
+++ b/website/src/pages/admin/einstellungen/rechnungen.astro
@@ -3,6 +3,7 @@ import AdminLayout from '../../../layouts/AdminLayout.astro';
 import AdminEinstellungenTabs from '../../../components/AdminEinstellungenTabs.astro';
 import { getSession, getLoginUrl, isAdmin } from '../../../lib/auth';
 import { getSiteSetting } from '../../../lib/website-db';
+import { getTaxMode } from '../../../lib/tax-monitor';
 
 const session = await getSession(Astro.request.headers.get('cookie'));
 if (!session) return Astro.redirect(getLoginUrl(Astro.url.pathname));
@@ -12,7 +13,10 @@ const BRAND = process.env.BRAND || 'mentolder';
 const saved = Astro.url.searchParams.get('saved') === '1';
 
 const keys = ['invoice_payment_days','invoice_tax_rate','invoice_sender_name','invoice_sender_street','invoice_sender_city','invoice_sender_phone','invoice_bank_iban','invoice_bank_bic','invoice_bank_name','invoice_vat_id','invoice_manager'] as const;
-const results = await Promise.all(keys.map(k => getSiteSetting(BRAND, k)));
+const [results, taxMode] = await Promise.all([
+  Promise.all(keys.map(k => getSiteSetting(BRAND, k))),
+  getTaxMode(BRAND),
+]);
 const s = Object.fromEntries(keys.map((k, i) => [k, results[i] ?? ''])) as Record<typeof keys[number], string>;
 ---
 
@@ -29,6 +33,32 @@ const s = Object.fromEntries(keys.map((k, i) => [k, results[i] ?? ''])) as Recor
     )}
 
     <form method="POST" action="/api/admin/einstellungen/rechnungen">
+      <!-- Tax mode toggle -->
+      <div style="background:rgba(255,255,255,0.04);border:1px solid var(--line);border-radius:8px;padding:1rem;margin-bottom:1.5rem;">
+        <p style="font-family:var(--font-mono);font-size:0.7rem;text-transform:uppercase;letter-spacing:0.1em;color:var(--mute-2);margin-bottom:0.75rem;">Steuer-Modus (§ 19 UStG)</p>
+        <div style="display:flex;gap:0.75rem;">
+          <label style="flex:1;cursor:pointer;">
+            <input type="radio" name="tax_mode" value="kleinunternehmer" checked={taxMode === 'kleinunternehmer'} style="display:none;" class="tax-radio" />
+            <div class={`tax-option ${taxMode === 'kleinunternehmer' ? 'tax-option--active' : ''}`}
+                 style={`border:1px solid ${taxMode === 'kleinunternehmer' ? 'var(--brass)' : 'var(--line)'};border-radius:8px;padding:0.75rem;background:${taxMode === 'kleinunternehmer' ? 'rgba(181,140,86,0.08)' : 'rgba(255,255,255,0.02)'};`}>
+              <p style="font-family:var(--font-mono);font-size:0.8rem;font-weight:600;color:var(--fg);margin-bottom:0.25rem;">Kleinunternehmer</p>
+              <p style="font-size:0.75rem;color:var(--mute);line-height:1.4;">§ 19 UStG — keine Umsatzsteuer auf Rechnungen. Grenze: 25.000 €/Jahr.</p>
+            </div>
+          </label>
+          <label style="flex:1;cursor:pointer;">
+            <input type="radio" name="tax_mode" value="regelbesteuerung" checked={taxMode === 'regelbesteuerung'} style="display:none;" class="tax-radio" />
+            <div class={`tax-option ${taxMode === 'regelbesteuerung' ? 'tax-option--active' : ''}`}
+                 style={`border:1px solid ${taxMode === 'regelbesteuerung' ? 'var(--brass)' : 'var(--line)'};border-radius:8px;padding:0.75rem;background:${taxMode === 'regelbesteuerung' ? 'rgba(181,140,86,0.08)' : 'rgba(255,255,255,0.02)'};`}>
+              <p style="font-family:var(--font-mono);font-size:0.8rem;font-weight:600;color:var(--fg);margin-bottom:0.25rem;">Regelbesteuerung</p>
+              <p style="font-size:0.75rem;color:var(--mute);line-height:1.4;">USt ausweisen & abführen. Vorsteuerabzug möglich.</p>
+            </div>
+          </label>
+        </div>
+        <p style="font-size:0.7rem;color:var(--mute-2);margin-top:0.625rem;">
+          Jahresumsatz-Übersicht: <a href="/admin/steuer" style="color:var(--brass);text-decoration:none;">Steuerauswertung →</a>
+        </p>
+      </div>
+
       <div style="background:rgba(255,255,255,0.04);border:1px solid var(--line);border-radius:8px;padding:0.75rem 1rem;margin-bottom:1.5rem;font-family:var(--font-mono);font-size:0.75rem;color:var(--mute-2);">
         Rechnungsnummern werden automatisch als <strong style="color:var(--fg);">RE-YYYY-NNNN</strong> generiert (z.B. RE-2026-0002).
       </div>
@@ -71,3 +101,16 @@ const s = Object.fromEntries(keys.map((k, i) => [k, results[i] ?? ''])) as Recor
     </form>
   </div>
 </AdminLayout>
+
+<script>
+  document.querySelectorAll('.tax-radio').forEach(radio => {
+    radio.addEventListener('change', () => {
+      document.querySelectorAll('.tax-radio').forEach(r => {
+        const card = r.nextElementSibling as HTMLElement;
+        const active = (r as HTMLInputElement).checked;
+        card.style.borderColor = active ? 'var(--brass)' : 'var(--line)';
+        card.style.background  = active ? 'rgba(181,140,86,0.08)' : 'rgba(255,255,255,0.02)';
+      });
+    });
+  });
+</script>

--- a/website/src/pages/admin/steuer.astro
+++ b/website/src/pages/admin/steuer.astro
@@ -1,7 +1,8 @@
 ---
 import AdminLayout from '../../layouts/AdminLayout.astro';
+import TaxMonitorWidget from '../../components/admin/TaxMonitorWidget.svelte';
 import { getSession, getLoginUrl, isAdmin } from '../../lib/auth';
-import { getUstvaExport, getTaxMode } from '../../lib/tax-monitor';
+import { getUstvaExport, getTaxMode, getMonthlyBreakdown, THRESHOLD_KLEIN, THRESHOLD_WARNING } from '../../lib/tax-monitor';
 
 const session = await getSession(Astro.request.headers.get('cookie'));
 if (!session) return Astro.redirect(getLoginUrl(Astro.url.pathname));
@@ -9,23 +10,81 @@ if (!isAdmin(session)) return Astro.redirect('/admin');
 
 const brand   = process.env.BRAND || 'mentolder';
 const year    = new Date().getFullYear();
-const taxMode = await getTaxMode(brand);
-const quarters = await Promise.all([1,2,3,4].map(q => getUstvaExport(brand, year, q)));
+const currentMonth = new Date().getMonth() + 1;
+const [taxMode, quarters, monthly] = await Promise.all([
+  getTaxMode(brand),
+  Promise.all([1,2,3,4].map(q => getUstvaExport(brand, year, q))),
+  getMonthlyBreakdown(brand, year),
+]);
+
+const monthNames = ['Jan','Feb','Mär','Apr','Mai','Jun','Jul','Aug','Sep','Okt','Nov','Dez'];
+const fmt = (n: number) => n.toFixed(2).replace('.', ',') + ' €';
+
+function barColor(status: string) {
+  if (status === 'hard' || status === 'exceeded') return '#ef4444';
+  if (status === 'warning') return '#f59e0b';
+  return '#22c55e';
+}
 ---
 
 <AdminLayout title="Steuerauswertung">
-  <div style="padding:2rem;max-width:720px;">
-    <h1 style="font-family:var(--font-serif);font-size:1.5rem;color:var(--fg);margin-bottom:0.25rem;">Steuerauswertung {year}</h1>
-    <p style="color:var(--mute);font-size:0.875rem;margin-bottom:2rem;">
-      Aktueller Modus: <strong>{taxMode === 'kleinunternehmer' ? '§ 19 UStG (Kleinunternehmer)' : 'Regelbesteuerung'}</strong>
+  <div style="padding:2rem;max-width:760px;">
+    <div style="display:flex;align-items:baseline;justify-content:space-between;margin-bottom:0.25rem;">
+      <h1 style="font-family:var(--font-serif);font-size:1.5rem;color:var(--fg);">Steuerauswertung {year}</h1>
+      <a href="/admin/einstellungen/rechnungen" style="font-size:0.75rem;color:var(--brass);text-decoration:none;">
+        Modus ändern →
+      </a>
+    </div>
+    <p style="color:var(--mute);font-size:0.875rem;margin-bottom:1.5rem;">
+      Aktueller Modus: <strong style="color:var(--fg);">{taxMode === 'kleinunternehmer' ? '§ 19 UStG (Kleinunternehmer)' : 'Regelbesteuerung'}</strong>
     </p>
+
+    <!-- Live widget: progress bar toward limit -->
+    <TaxMonitorWidget client:load />
+
+    <!-- Monthly revenue overview -->
+    <div style="background:rgba(255,255,255,0.03);border:1px solid var(--line);border-radius:8px;padding:1.25rem;margin-bottom:1.5rem;">
+      <p style="font-family:var(--font-mono);font-size:0.7rem;text-transform:uppercase;letter-spacing:0.1em;color:var(--mute-2);margin-bottom:1rem;">
+        Monatlicher Umsatz & kumulierter Jahresverlauf
+      </p>
+      <div style="display:flex;flex-direction:column;gap:0.5rem;">
+        {monthly.map(m => {
+          const pct = Math.min(100, (m.cumulative / THRESHOLD_KLEIN) * 100);
+          const color = barColor(m.status);
+          const isFuture = m.month > currentMonth;
+          return (
+            <div style={`opacity:${isFuture ? '0.4' : '1'}`}>
+              <div style="display:flex;align-items:center;gap:0.75rem;margin-bottom:0.2rem;">
+                <span style="font-family:var(--font-mono);font-size:0.7rem;color:var(--mute-2);width:2.5rem;flex-shrink:0;">{monthNames[m.month-1]}</span>
+                <div style="flex:1;height:5px;background:rgba(255,255,255,0.08);border-radius:3px;overflow:hidden;">
+                  <div style={`height:100%;width:${pct}%;background:${color};border-radius:3px;transition:width 0.3s;`}></div>
+                </div>
+                <span style={`font-family:var(--font-mono);font-size:0.7rem;width:5.5rem;text-align:right;color:${color};flex-shrink:0;`}>
+                  {fmt(m.cumulative)}
+                </span>
+                <span style="font-family:var(--font-mono);font-size:0.65rem;color:var(--mute-2);width:4.5rem;text-align:right;flex-shrink:0;">
+                  +{fmt(m.net)}
+                </span>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+      <div style="display:flex;gap:1.5rem;margin-top:1rem;padding-top:0.75rem;border-top:1px solid var(--line);font-size:0.7rem;color:var(--mute-2);font-family:var(--font-mono);">
+        <span>Warnung: {fmt(THRESHOLD_WARNING)}</span>
+        <span>Grenze §19: {fmt(THRESHOLD_KLEIN)}</span>
+      </div>
+    </div>
+
+    <!-- Quarterly UStVA -->
+    <p style="font-family:var(--font-mono);font-size:0.7rem;text-transform:uppercase;letter-spacing:0.1em;color:var(--mute-2);margin-bottom:0.75rem;">Quartalsauswertung (UStVA)</p>
     {quarters.map(q => (
-      <div style="background:rgba(255,255,255,0.03);border:1px solid var(--line);border-radius:8px;padding:1rem;margin-bottom:1rem;">
+      <div style="background:rgba(255,255,255,0.03);border:1px solid var(--line);border-radius:8px;padding:1rem;margin-bottom:0.75rem;">
         <p style="font-family:var(--font-mono);font-size:0.75rem;text-transform:uppercase;color:var(--mute-2);margin-bottom:0.5rem;">{q.period}</p>
         <div style="display:grid;grid-template-columns:repeat(3,1fr);gap:0.5rem;font-size:0.875rem;">
-          <div><span style="color:var(--mute);">Umsatz 0%</span><br/>{q.revenue0.toFixed(2)} €</div>
-          <div><span style="color:var(--mute);">Umsatz 19%</span><br/>{q.revenue19.toFixed(2)} €</div>
-          <div><span style="color:var(--mute);">USt 19%</span><br/>{q.tax19.toFixed(2)} €</div>
+          <div><span style="color:var(--mute);font-size:0.75rem;">Umsatz 0%</span><br/>{fmt(q.revenue0)}</div>
+          <div><span style="color:var(--mute);font-size:0.75rem;">Umsatz 19%</span><br/>{fmt(q.revenue19)}</div>
+          <div><span style="color:var(--mute);font-size:0.75rem;">USt 19%</span><br/>{fmt(q.tax19)}</div>
         </div>
         <a href={`/api/admin/tax-monitor/ustvaexport?year=${year}&quarter=${q.period.split('/')[0].replace('Q','')}&format=csv`}
            style="font-size:0.75rem;color:var(--brass);text-decoration:none;margin-top:0.5rem;display:inline-block;">

--- a/website/src/pages/api/admin/einstellungen/rechnungen.ts
+++ b/website/src/pages/api/admin/einstellungen/rechnungen.ts
@@ -1,6 +1,7 @@
 import type { APIRoute } from 'astro';
 import { getSession, isAdmin } from '../../../../lib/auth';
 import { setSiteSetting } from '../../../../lib/website-db';
+import { setTaxMode } from '../../../../lib/tax-monitor';
 
 const STRING_KEYS = ['invoice_sender_name','invoice_sender_street','invoice_sender_city','invoice_sender_phone','invoice_bank_iban','invoice_bank_bic','invoice_bank_name','invoice_vat_id','invoice_manager'] as const;
 const NUMBER_KEYS = ['invoice_payment_days','invoice_tax_rate'] as const;
@@ -20,6 +21,11 @@ export const POST: APIRoute = async ({ request, redirect }) => {
   for (const key of NUMBER_KEYS) {
     const val = parseInt(form.get(key) as string, 10);
     saves.push(setSiteSetting(brand, key, isNaN(val) ? '0' : String(val)));
+  }
+
+  const rawMode = form.get('tax_mode') as string;
+  if (rawMode === 'kleinunternehmer' || rawMode === 'regelbesteuerung') {
+    saves.push(setTaxMode(brand, rawMode, { notes: 'Manuell geändert über Einstellungen' }));
   }
 
   await Promise.all(saves);


### PR DESCRIPTION
## Summary

- **Tax-mode toggle** added to `/admin/einstellungen/rechnungen` — two clickable cards (Kleinunternehmer § 19 UStG / Regelbesteuerung) with live highlight on selection; saving calls `setTaxMode()` which writes to `site_settings` and appends an audit row to `tax_mode_changes`
- **`getMonthlyBreakdown()`** added to `tax-monitor.ts` — returns per-month net revenue + running cumulative total + threshold status for all 12 months
- **`/admin/steuer`** enhanced with the existing `TaxMonitorWidget` (live progress bar) and a new month-by-month table showing cumulative Jahresumsatz with color-coded bars (green → amber at 20k → red at 25k); future months are dimmed; links cross-reference between the two pages

## Test plan

- [ ] Visit `/admin/einstellungen/rechnungen` — tax-mode section appears at top; selected card is highlighted in brass
- [ ] Click the other card, hit Speichern — mode changes and page reloads with correct card pre-selected
- [ ] Visit `/admin/steuer` — TaxMonitorWidget loads with current revenue; monthly table shows all 12 months with correct cumulative values and colors; future months are dimmed
- [ ] Verify "Modus ändern →" link on steuer page navigates to rechnungen settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)