### PR TITLE
fix(k3d): update stale pinned image digests for brett and mcp-kubernetes

### DIFF
--- a/k3d/brett.yaml
+++ b/k3d/brett.yaml
@@ -41,7 +41,7 @@ spec:
                       - gekko-hetzner-4
       containers:
         - name: brett
-          image: ghcr.io/paddione/workspace-brett@sha256:0601cb9f85735f7f8a6287e97dc34a5f3c09beec93b18abe83812affb1f3bc48
+          image: ghcr.io/paddione/workspace-brett@sha256:6e6885bc64b5d4df64285c799a499ed278eac30a69dd089b4dc443f38db03672
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/k3d/claude-code-mcp-ops.yaml
+++ b/k3d/claude-code-mcp-ops.yaml
@@ -32,7 +32,7 @@ spec:
         # ─── Kubernetes MCP (port 8080) ──────────────────────────
         # Pre-built image — no runtime GitHub download needed.
         - name: mcp-kubernetes
-          image: quay.io/containers/kubernetes_mcp_server@sha256:fae7dae4972a7af5708dc29767ee890adfba6a73a6356ef2933c578ee954882a
+          image: quay.io/containers/kubernetes_mcp_server@sha256:7c36722a6cbfd06b0662ce2237a19f563643988ad6669a9cfeac677b26adf591
           imagePullPolicy: IfNotPresent
           args: ["--port", "8080", "--stateless", "--cluster-provider", "in-cluster"]
           securityContext:


### PR DESCRIPTION
## Summary

- Updates `brett` image digest to the current locally-built image (`sha256:6e6885bc...`)
- Updates `kubernetes_mcp_server` digest to the current quay.io latest (`sha256:7c36722a...`) — the previous digest had been removed from the registry

## Test plan

- [x] Both pods came up healthy during dev workspace deployment (`task workspace:deploy ENV=dev`)
- [x] `brett` running 1/1, `claude-code-mcp-ops` running 3/3

🤖 Generated with [Claude Code](https://claude.com/claude-code)