### PR TITLE
chore: pin CI tool versions, brand-agnostic website, Traefik dashboard, new E2E specs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         run: |
           curl -sSL "https://dl.k8s.io/release/v1.31.0/bin/linux/amd64/kubectl" \
             -o /usr/local/bin/kubectl && chmod +x /usr/local/bin/kubectl
-          curl -sSL https://github.com/yannh/kubeconform/releases/latest/download/kubeconform-linux-amd64.tar.gz \
+          curl -sSL https://github.com/yannh/kubeconform/releases/download/v0.6.7/kubeconform-linux-amd64.tar.gz \
             | sudo tar xz -C /usr/local/bin kubeconform
 
       - name: Create CI dummy secrets
@@ -47,7 +47,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Install yamllint
-        run: pip install yamllint
+        run: pip install yamllint==1.35.1
 
       - name: Lint k3d and prod manifests
         run: |
@@ -62,7 +62,9 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Install shellcheck
-        run: sudo apt-get install -y shellcheck
+        run: |
+          curl -sSL https://github.com/koalaman/shellcheck/releases/download/v0.10.0/shellcheck-v0.10.0.linux.x86_64.tar.xz \
+            | tar -xJf - --strip-components=1 -C /usr/local/bin shellcheck-v0.10.0/shellcheck
 
       - name: Check scripts
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -283,7 +283,7 @@ Non-obvious repo behaviors. Violating these silently breaks things or hits the w
 
 ### Scripts & env
 - **`scripts/env-resolve.sh` must be sourced, never executed.** It uses `return 1 2>/dev/null || exit 1`, so `bash scripts/env-resolve.sh` exits the parent shell and subsequent task commands never run. Always `source scripts/env-resolve.sh "$ENV"`.
-- **`envsubst` variable lists are hardcoded per task.** If you add a new `${VAR}` reference to a manifest, also add it to the `envsubst "\$VAR1 \$VAR2 ..."` list in every task that builds that manifest, or the placeholder stays literal and kubectl apply fails with an invalid manifest.
+- **`envsubst` variable lists are hardcoded per task in `Taskfile.yml` (not `Taskfile.yaml`).** If you add a new `${VAR}` reference to a manifest, also add it to the `envsubst "\$VAR1 \$VAR2 ..."` list in every task that builds that manifest, or the placeholder stays literal and kubectl apply fails with an invalid manifest. Key locations: dev deploy (line ~1117, vars: `PROD_DOMAIN BRAND_NAME CONTACT_EMAIL BRAND_ID`), prod deploy (line ~1145, dynamic `ENVSUBST_VARS` build — append there), `mcp:deploy` (line ~1350), `workspace:office:deploy` (line ~510).
 - **`env:generate ENV=<target>` must run before `env:seal` and before deploying prod.** `talk-hpb-setup.sh` aborts on placeholder `MANAGED_EXTERNALLY` values if signaling/turn secrets were never generated.
 
 ### Operational

--- a/k3d/configmap-domains.yaml
+++ b/k3d/configmap-domains.yaml
@@ -27,4 +27,3 @@ data:
   KC_USER2_USERNAME: ""
   KC_USER2_EMAIL: ""
   BRETT_DOMAIN: "brett.localhost"
-  AI_DOMAIN: "ai.localhost"

--- a/k3d/kustomization.yaml
+++ b/k3d/kustomization.yaml
@@ -29,6 +29,7 @@ resources:
   - oauth2-proxy-docs.yaml
   # Traefik dashboard SSO gateway
   - oauth2-proxy-traefik.yaml
+  - traefik-dashboard-dev.yaml
   # Mailpit SSO gateway
   - oauth2-proxy-mailpit.yaml
   - mail-ingressroute-dev.yaml

--- a/k3d/traefik-dashboard-dev.yaml
+++ b/k3d/traefik-dashboard-dev.yaml
@@ -1,0 +1,67 @@
+# k3d/traefik-dashboard-dev.yaml
+# Traefik Dashboard (api@internal) — OIDC-protected via oauth2-proxy (dev, HTTP only)
+# Flow: ForwardAuth → 202 (pass) or 401 → errors middleware → sign_in → Keycloak
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: traefik-dashboard-auth
+  namespace: workspace
+spec:
+  forwardAuth:
+    address: http://oauth2-proxy-traefik.workspace.svc.cluster.local:4180/oauth2/auth
+    trustForwardHeader: true
+    authResponseHeaders:
+      - X-Auth-Request-User
+      - X-Auth-Request-Email
+      - X-Auth-Request-Access-Token
+---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: traefik-dashboard-errors
+  namespace: workspace
+spec:
+  errors:
+    status:
+      - "401"
+    service:
+      name: oauth2-proxy-traefik
+      port: 4180
+    query: "/oauth2/sign_in?rd={url}"
+---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: traefik-dashboard-redirect-root
+  namespace: workspace
+spec:
+  redirectRegex:
+    regex: "^http://([^/]+)/?$"
+    replacement: "http://$1/dashboard/"
+    permanent: false
+---
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: traefik-dashboard-dev
+  namespace: workspace
+spec:
+  entryPoints:
+    - web
+  routes:
+    # oauth2-proxy endpoints — no auth middleware
+    - match: Host(`traefik.localhost`) && PathPrefix(`/oauth2`)
+      kind: Rule
+      services:
+        - name: oauth2-proxy-traefik
+          port: 4180
+    # Dashboard + API — require auth. Redirects bare `/` to `/dashboard/`.
+    - match: Host(`traefik.localhost`)
+      kind: Rule
+      middlewares:
+        - name: traefik-dashboard-redirect-root
+        - name: traefik-dashboard-errors
+        - name: traefik-dashboard-auth
+      services:
+        - name: api@internal
+          kind: TraefikService

--- a/prod/configmap-domains.yaml
+++ b/prod/configmap-domains.yaml
@@ -16,7 +16,6 @@ data:
   WHITEBOARD_DOMAIN: "board.${PROD_DOMAIN}"
   TRAEFIK_DOMAIN: "traefik.${PROD_DOMAIN}"
   BRETT_DOMAIN: "brett.${PROD_DOMAIN}"
-  AI_DOMAIN: "ai.${PROD_DOMAIN}"
   # Env-registry values (substituted from environments/<env>.yaml at deploy time)
   PROD_DOMAIN: "${PROD_DOMAIN}"
   WEBSITE_IMAGE: "${WEBSITE_IMAGE}"

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -45,9 +45,14 @@ export default defineConfig({
         '**/fa-client-portal.spec.ts', // client portal auth-gate
         '**/fa-meeting-history.spec.ts',  // meeting history & release
         '**/fa-document-signing.spec.ts', // document signing flow
-        '**/fa-admin-monitoring.spec.ts',     // admin monitoring page auth
-        '**/fa-admin-newsletter.spec.ts',     // admin newsletter page auth
-        '**/fa-admin-backup-settings.spec.ts', // admin backup settings auth
+        '**/fa-admin-monitoring.spec.ts',       // admin monitoring page auth
+        '**/fa-admin-newsletter.spec.ts',       // admin newsletter page auth
+        '**/fa-admin-backup-settings.spec.ts',  // admin backup settings auth
+        '**/fa-public-pages.spec.ts',           // public static & legal pages
+        '**/fa-admin-inhalte.spec.ts',          // unified content editor + legacy stubs
+        '**/fa-admin-billing-system.spec.ts',   // native SEPA billing, EÜR, UStVA
+        '**/fa-admin-crm.spec.ts',              // CRM: termine, followups, projekte, rooms, meetings
+        '**/fa-admin-settings.spec.ts',         // settings: email, rechnungen, branding, benachrichtigungen
       ],
       use: {
         ...devices['Desktop Chrome'],

--- a/tests/e2e/specs/fa-admin-billing-system.spec.ts
+++ b/tests/e2e/specs/fa-admin-billing-system.spec.ts
@@ -1,0 +1,83 @@
+import { test, expect } from '@playwright/test';
+
+const BASE = process.env.WEBSITE_URL || 'http://localhost:4321';
+
+test.describe('FA: Admin native billing system (SEPA/ZUGFeRD)', () => {
+  // ── Page auth-gating ───────────────────────────────────────────
+  const adminPages = [
+    '/admin/rechnungen',
+    '/admin/steuer',
+    '/admin/buchhaltung',
+  ];
+
+  for (const path of adminPages) {
+    test(`${path} redirects unauthenticated users`, async ({ page }) => {
+      await page.goto(`${BASE}${path}`);
+      await expect(page).not.toHaveURL(`${BASE}${path}`);
+    });
+  }
+
+  test('/admin/billing/:id/drucken redirects unauthenticated users', async ({ page }) => {
+    await page.goto(`${BASE}/admin/billing/00000000-0000-0000-0000-000000000000/drucken`);
+    await expect(page).not.toHaveURL(/\/admin\/billing\/.*\/drucken/);
+  });
+
+  test('/portal/billing/:id/drucken redirects unauthenticated users', async ({ page }) => {
+    await page.goto(`${BASE}/portal/billing/00000000-0000-0000-0000-000000000000/drucken`);
+    await expect(page).not.toHaveURL(/\/portal\/billing\/.*\/drucken/);
+  });
+
+  // ── Billing invoice CRUD API ───────────────────────────────────
+  test('GET /api/admin/billing/drafts returns 401 without auth', async ({ request }) => {
+    const res = await request.get(`${BASE}/api/admin/billing/drafts`);
+    expect([401, 403]).toContain(res.status());
+  });
+
+  test('GET /api/admin/billing/draft-count returns 401 without auth', async ({ request }) => {
+    const res = await request.get(`${BASE}/api/admin/billing/draft-count`);
+    expect([401, 403]).toContain(res.status());
+  });
+
+  test('GET /api/admin/billing/:id returns 401 without auth', async ({ request }) => {
+    const res = await request.get(`${BASE}/api/admin/billing/00000000-0000-0000-0000-000000000000`);
+    expect([401, 403, 404]).toContain(res.status());
+  });
+
+  test('POST /api/admin/billing/:id/send returns 401 without auth', async ({ request }) => {
+    const res = await request.post(`${BASE}/api/admin/billing/00000000-0000-0000-0000-000000000000/send`, { data: {} });
+    expect([401, 403, 404]).toContain(res.status());
+  });
+
+  test('POST /api/admin/billing/:id/discard returns 401 without auth', async ({ request }) => {
+    const res = await request.post(`${BASE}/api/admin/billing/00000000-0000-0000-0000-000000000000/discard`, { data: {} });
+    expect([401, 403, 404]).toContain(res.status());
+  });
+
+  test('POST /api/admin/billing/create-monthly-invoices returns 401 without auth', async ({ request }) => {
+    const res = await request.post(`${BASE}/api/admin/billing/create-monthly-invoices`, { data: {} });
+    expect([401, 403]).toContain(res.status());
+  });
+
+  // ── Bookkeeping / EÜR ─────────────────────────────────────────
+  test('GET /api/admin/bookkeeping/summary returns 401 without auth', async ({ request }) => {
+    const res = await request.get(`${BASE}/api/admin/bookkeeping/summary`);
+    expect([401, 403]).toContain(res.status());
+  });
+
+  // ── Tax monitor (UStVA / Kleinunternehmer threshold) ──────────
+  test('GET /api/admin/tax-monitor/status returns 401 without auth', async ({ request }) => {
+    const res = await request.get(`${BASE}/api/admin/tax-monitor/status`);
+    expect([401, 403]).toContain(res.status());
+  });
+
+  test('GET /api/admin/tax-monitor/ustvaexport returns 401 without auth', async ({ request }) => {
+    const res = await request.get(`${BASE}/api/admin/tax-monitor/ustvaexport`);
+    expect([401, 403]).toContain(res.status());
+  });
+
+  // ── ZUGFeRD export (portal) ────────────────────────────────────
+  test('GET /api/billing/invoice/:id/zugferd returns 401 without auth', async ({ request }) => {
+    const res = await request.get(`${BASE}/api/billing/invoice/00000000-0000-0000-0000-000000000000/zugferd`);
+    expect([401, 403, 404]).toContain(res.status());
+  });
+});

--- a/tests/e2e/specs/fa-admin-crm.spec.ts
+++ b/tests/e2e/specs/fa-admin-crm.spec.ts
@@ -1,0 +1,129 @@
+import { test, expect } from '@playwright/test';
+
+const BASE = process.env.WEBSITE_URL || 'http://localhost:4321';
+
+test.describe('FA: Admin CRM & operations pages', () => {
+  // ── Page auth-gating ───────────────────────────────────────────
+  const adminPages = [
+    '/admin/termine',
+    '/admin/kalender',
+    '/admin/followups',
+    '/admin/nachrichten',
+    '/admin/inbox',
+    '/admin/raeume',
+    '/admin/projekte',
+    '/admin/meetings',
+    '/admin/zeiterfassung',
+  ];
+
+  for (const path of adminPages) {
+    test(`${path} redirects unauthenticated users`, async ({ page }) => {
+      await page.goto(`${BASE}${path}`);
+      await expect(page).not.toHaveURL(`${BASE}${path}`);
+    });
+  }
+
+  test('/admin/projekte/:id redirects unauthenticated users', async ({ page }) => {
+    await page.goto(`${BASE}/admin/projekte/1`);
+    await expect(page).not.toHaveURL(/\/admin\/projekte\/\d+/);
+  });
+
+  test('/admin/meetings/:id redirects unauthenticated users', async ({ page }) => {
+    await page.goto(`${BASE}/admin/meetings/00000000-0000-0000-0000-000000000000`);
+    await expect(page).not.toHaveURL(/\/admin\/meetings\/.+/);
+  });
+
+  // ── Follow-ups API ─────────────────────────────────────────────
+  test('POST /api/admin/followups/create returns 401/403 without auth', async ({ request }) => {
+    const res = await request.post(`${BASE}/api/admin/followups/create`, {
+      form: { reason: 'test', dueDate: '2026-05-01' },
+    });
+    expect([401, 403]).toContain(res.status());
+  });
+
+  test('POST /api/admin/followups/update returns 401/403 without auth', async ({ request }) => {
+    const res = await request.post(`${BASE}/api/admin/followups/update`, { form: { id: '1', done: 'true' } });
+    expect([401, 403]).toContain(res.status());
+  });
+
+  test('POST /api/admin/followups/delete returns 401/403 without auth', async ({ request }) => {
+    const res = await request.post(`${BASE}/api/admin/followups/delete`, { form: { id: '1' } });
+    expect([401, 403]).toContain(res.status());
+  });
+
+  test('POST /api/admin/followups/notify returns 401/403 without auth', async ({ request }) => {
+    const res = await request.post(`${BASE}/api/admin/followups/notify`, { form: { id: '1' } });
+    expect([401, 403]).toContain(res.status());
+  });
+
+  // ── Time tracking (Zeiterfassung) API ─────────────────────────
+  test('POST /api/admin/zeiterfassung/create returns 401/403 without auth', async ({ request }) => {
+    const res = await request.post(`${BASE}/api/admin/zeiterfassung/create`, { form: { projectId: '1', minutes: '60' } });
+    expect([401, 403]).toContain(res.status());
+  });
+
+  test('POST /api/admin/zeiterfassung/delete returns 401/403 without auth', async ({ request }) => {
+    const res = await request.post(`${BASE}/api/admin/zeiterfassung/delete`, { form: { id: '1' } });
+    expect([401, 403]).toContain(res.status());
+  });
+
+  test('GET /api/admin/zeiterfassung/export returns 401/403 without auth', async ({ request }) => {
+    const res = await request.get(`${BASE}/api/admin/zeiterfassung/export`);
+    expect([401, 403]).toContain(res.status());
+  });
+
+  // ── Projekte API ───────────────────────────────────────────────
+  test('POST /api/admin/projekte/create returns 401/403 without auth', async ({ request }) => {
+    const res = await request.post(`${BASE}/api/admin/projekte/create`, { data: { name: 'Test' } });
+    expect([401, 403]).toContain(res.status());
+  });
+
+  test('POST /api/admin/projekte/update returns 401/403 without auth', async ({ request }) => {
+    const res = await request.post(`${BASE}/api/admin/projekte/update`, { data: { id: 1, name: 'X' } });
+    expect([401, 403]).toContain(res.status());
+  });
+
+  test('POST /api/admin/projekte/delete returns 401/403 without auth', async ({ request }) => {
+    const res = await request.post(`${BASE}/api/admin/projekte/delete`, { data: { id: 1 } });
+    expect([401, 403]).toContain(res.status());
+  });
+
+  test('GET /api/admin/projekte/export returns 401/403 without auth', async ({ request }) => {
+    const res = await request.get(`${BASE}/api/admin/projekte/export`);
+    expect([401, 403]).toContain(res.status());
+  });
+
+  // ── Rooms API ─────────────────────────────────────────────────
+  test('GET /api/admin/rooms returns 401/403 without auth', async ({ request }) => {
+    const res = await request.get(`${BASE}/api/admin/rooms`);
+    expect([401, 403]).toContain(res.status());
+  });
+
+  test('POST /api/admin/rooms/direct returns 401/403 without auth', async ({ request }) => {
+    const res = await request.post(`${BASE}/api/admin/rooms/direct`, { data: { userId: 'test' } });
+    expect([401, 403]).toContain(res.status());
+  });
+
+  // ── Meetings API ──────────────────────────────────────────────
+  test('GET /api/admin/meetings returns 401/403 without auth', async ({ request }) => {
+    const res = await request.get(`${BASE}/api/admin/meetings`);
+    expect([401, 403]).toContain(res.status());
+  });
+
+  test('GET /api/admin/meetings/:id returns 401/403 without auth', async ({ request }) => {
+    const res = await request.get(`${BASE}/api/admin/meetings/00000000-0000-0000-0000-000000000000`);
+    expect([401, 403, 404]).toContain(res.status());
+  });
+
+  // ── Inbox API ─────────────────────────────────────────────────
+  test('GET /api/admin/inbox returns 401/403 without auth', async ({ request }) => {
+    const res = await request.get(`${BASE}/api/admin/inbox`);
+    expect([401, 403]).toContain(res.status());
+  });
+
+  // ── Staleness / monitoring API ────────────────────────────────
+  test('GET /api/admin/staleness-report returns 401/403 without auth', async ({ request }) => {
+    const res = await request.get(`${BASE}/api/admin/staleness-report`);
+    expect([401, 403]).toContain(res.status());
+  });
+});

--- a/tests/e2e/specs/fa-admin-inhalte.spec.ts
+++ b/tests/e2e/specs/fa-admin-inhalte.spec.ts
@@ -1,0 +1,80 @@
+import { test, expect } from '@playwright/test';
+
+const BASE = process.env.WEBSITE_URL || 'http://localhost:4321';
+
+test.describe('FA: Admin Inhalte — unified content editor + legacy stubs', () => {
+  // ── Main editor ────────────────────────────────────────────────
+  test('T1: /admin/inhalte redirects unauthenticated users', async ({ page }) => {
+    await page.goto(`${BASE}/admin/inhalte`);
+    await expect(page).not.toHaveURL(`${BASE}/admin/inhalte`);
+  });
+
+  // ── Legacy stubs (auth-gate → 301 to /admin/inhalte) ──────────
+  const legacyStubs = [
+    '/admin/angebote',
+    '/admin/faq',
+    '/admin/kontakt',
+    '/admin/rechtliches',
+    '/admin/referenzen',
+    '/admin/startseite',
+    '/admin/uebermich',
+  ];
+
+  for (const path of legacyStubs) {
+    test(`T: ${path} redirects unauthenticated users`, async ({ page }) => {
+      await page.goto(`${BASE}${path}`);
+      await expect(page).not.toHaveURL(`${BASE}${path}`);
+    });
+  }
+
+  // ── API auth checks ────────────────────────────────────────────
+  test('T: POST /api/admin/angebote/save returns 401/403 without auth', async ({ request }) => {
+    const res = await request.post(`${BASE}/api/admin/angebote/save`, { data: {} });
+    expect([401, 403]).toContain(res.status());
+  });
+
+  test('T: GET /api/admin/inhalte/custom returns 401/403 without auth', async ({ request }) => {
+    const res = await request.get(`${BASE}/api/admin/inhalte/custom`);
+    expect([401, 403]).toContain(res.status());
+  });
+
+  test('T: POST /api/admin/inhalte/custom returns 401/403 without auth', async ({ request }) => {
+    const res = await request.post(`${BASE}/api/admin/inhalte/custom`, { data: { slug: 'test', title: 'T', body: '' } });
+    expect([401, 403]).toContain(res.status());
+  });
+
+  test('T: POST /api/admin/faq/save returns 401/403 without auth', async ({ request }) => {
+    const res = await request.post(`${BASE}/api/admin/faq/save`, { data: {} });
+    expect([401, 403]).toContain(res.status());
+  });
+
+  test('T: POST /api/admin/kontakt/save returns 401/403 without auth', async ({ request }) => {
+    const res = await request.post(`${BASE}/api/admin/kontakt/save`, { data: {} });
+    expect([401, 403]).toContain(res.status());
+  });
+
+  test('T: POST /api/admin/rechtliches/save returns 401/403 without auth', async ({ request }) => {
+    const res = await request.post(`${BASE}/api/admin/rechtliches/save`, { data: {} });
+    expect([401, 403]).toContain(res.status());
+  });
+
+  test('T: POST /api/admin/referenzen/save returns 401/403 without auth', async ({ request }) => {
+    const res = await request.post(`${BASE}/api/admin/referenzen/save`, { data: {} });
+    expect([401, 403]).toContain(res.status());
+  });
+
+  test('T: POST /api/admin/startseite/save returns 401/403 without auth', async ({ request }) => {
+    const res = await request.post(`${BASE}/api/admin/startseite/save`, { data: {} });
+    expect([401, 403]).toContain(res.status());
+  });
+
+  test('T: POST /api/admin/uebermich/save returns 401/403 without auth', async ({ request }) => {
+    const res = await request.post(`${BASE}/api/admin/uebermich/save`, { data: {} });
+    expect([401, 403]).toContain(res.status());
+  });
+
+  test('T: POST /api/admin/inhalte/rechnungsvorlagen/save returns 401/403 without auth', async ({ request }) => {
+    const res = await request.post(`${BASE}/api/admin/inhalte/rechnungsvorlagen/save`, { data: {} });
+    expect([401, 403]).toContain(res.status());
+  });
+});

--- a/tests/e2e/specs/fa-admin-settings.spec.ts
+++ b/tests/e2e/specs/fa-admin-settings.spec.ts
@@ -1,0 +1,84 @@
+import { test, expect } from '@playwright/test';
+
+const BASE = process.env.WEBSITE_URL || 'http://localhost:4321';
+
+test.describe('FA: Admin settings pages', () => {
+  // ── Page auth-gating ───────────────────────────────────────────
+  const settingsPages = [
+    '/admin/einstellungen/email',
+    '/admin/einstellungen/rechnungen',
+    '/admin/einstellungen/branding',
+    '/admin/einstellungen/benachrichtigungen',
+  ];
+
+  for (const path of settingsPages) {
+    test(`${path} redirects unauthenticated users`, async ({ page }) => {
+      await page.goto(`${BASE}${path}`);
+      await expect(page).not.toHaveURL(`${BASE}${path}`);
+    });
+  }
+
+  // ── Settings API auth checks ───────────────────────────────────
+  test('POST /api/admin/einstellungen/email returns 401/403 without auth', async ({ request }) => {
+    const res = await request.post(`${BASE}/api/admin/einstellungen/email`, { form: {} });
+    expect([401, 403]).toContain(res.status());
+  });
+
+  test('POST /api/admin/einstellungen/rechnungen returns 401/403 without auth', async ({ request }) => {
+    const res = await request.post(`${BASE}/api/admin/einstellungen/rechnungen`, { form: {} });
+    expect([401, 403]).toContain(res.status());
+  });
+
+  test('POST /api/admin/einstellungen/branding returns 401/403 without auth', async ({ request }) => {
+    const res = await request.post(`${BASE}/api/admin/einstellungen/branding`, { form: {} });
+    expect([401, 403]).toContain(res.status());
+  });
+
+  test('POST /api/admin/einstellungen/benachrichtigungen returns 401/403 without auth', async ({ request }) => {
+    const res = await request.post(`${BASE}/api/admin/einstellungen/benachrichtigungen`, { form: {} });
+    expect([401, 403]).toContain(res.status());
+  });
+
+  // ── Client management API (new endpoints) ─────────────────────
+  test('POST /api/admin/clients/flag-user returns 401/403 without auth', async ({ request }) => {
+    const res = await request.post(`${BASE}/api/admin/clients/flag-user`, { data: { userId: 'test', role: 'admin' } });
+    expect([401, 403]).toContain(res.status());
+  });
+
+  test('POST /api/admin/clients/set-admin-number returns 401/403 without auth', async ({ request }) => {
+    const res = await request.post(`${BASE}/api/admin/clients/set-admin-number`, { data: { userId: 'test', number: 1 } });
+    expect([401, 403]).toContain(res.status());
+  });
+
+  test('POST /api/admin/clients/set-customer-number returns 401/403 without auth', async ({ request }) => {
+    const res = await request.post(`${BASE}/api/admin/clients/set-customer-number`, { data: { userId: 'test', number: 1 } });
+    expect([401, 403]).toContain(res.status());
+  });
+
+  // ── Shortcut API ───────────────────────────────────────────────
+  test('POST /api/admin/shortcuts/create returns 401/403 without auth', async ({ request }) => {
+    const res = await request.post(`${BASE}/api/admin/shortcuts/create`, { data: { url: 'https://example.com' } });
+    expect([401, 403]).toContain(res.status());
+  });
+
+  test('POST /api/admin/shortcuts/delete returns 401/403 without auth', async ({ request }) => {
+    const res = await request.post(`${BASE}/api/admin/shortcuts/delete`, { data: { id: 1 } });
+    expect([401, 403]).toContain(res.status());
+  });
+
+  // ── Deployment control API ────────────────────────────────────
+  test('GET /api/admin/deployments returns 401/403 without auth', async ({ request }) => {
+    const res = await request.get(`${BASE}/api/admin/deployments`);
+    expect([401, 403]).toContain(res.status());
+  });
+
+  test('POST /api/admin/deployments/:name/restart returns 401/403 without auth', async ({ request }) => {
+    const res = await request.post(`${BASE}/api/admin/deployments/website/restart`, { data: {} });
+    expect([401, 403]).toContain(res.status());
+  });
+
+  test('POST /api/admin/deployments/:name/scale returns 401/403 without auth', async ({ request }) => {
+    const res = await request.post(`${BASE}/api/admin/deployments/website/scale`, { data: { replicas: 1 } });
+    expect([401, 403]).toContain(res.status());
+  });
+});

--- a/tests/e2e/specs/fa-public-pages.spec.ts
+++ b/tests/e2e/specs/fa-public-pages.spec.ts
@@ -1,0 +1,58 @@
+import { test, expect } from '@playwright/test';
+
+const BASE = process.env.WEBSITE_URL || 'http://localhost:4321';
+
+test.describe('FA: Public static pages', () => {
+  const publicPages = [
+    { path: '/agb',                   title: /AGB|Geschäftsbedingungen/i },
+    { path: '/datenschutz',           title: /Datenschutz/i },
+    { path: '/impressum',             title: /Impressum/i },
+    { path: '/barrierefreiheit',      title: /Barrierefreiheit/i },
+    { path: '/cookie-einstellungen',  title: /Cookie/i },
+    { path: '/referenzen',            title: /Referenzen/i },
+    { path: '/meine-daten',           title: /Meine Daten/i },
+    { path: '/status',                title: /Bug-Status/i },
+  ];
+
+  for (const { path, title } of publicPages) {
+    test(`${path} loads and shows expected heading`, async ({ page }) => {
+      const res = await page.goto(`${BASE}${path}`);
+      expect(res?.status(), `${path} should return 200`).toBe(200);
+      await expect(page.locator('h1').first()).toBeVisible();
+      await expect(page.locator('h1').first()).toContainText(title);
+    });
+  }
+
+  test('/newsletter/bestaetigt renders confirmation', async ({ page }) => {
+    const res = await page.goto(`${BASE}/newsletter/bestaetigt`);
+    expect(res?.status()).toBe(200);
+    await expect(page.locator('h1').first()).toContainText('Anmeldung bestätigt');
+  });
+
+  test('/newsletter/token-ungueltig renders error page', async ({ page }) => {
+    const res = await page.goto(`${BASE}/newsletter/token-ungueltig`);
+    expect(res?.status()).toBe(200);
+    await expect(page.locator('body')).not.toContainText('500');
+    await expect(page.locator('h1').first()).toBeVisible();
+  });
+
+  test('/stripe/success renders without 500', async ({ page }) => {
+    // Without a valid session_id it renders a generic confirmation
+    const res = await page.goto(`${BASE}/stripe/success`);
+    expect(res?.status()).not.toBe(500);
+    await expect(page.locator('body')).not.toContainText('500');
+  });
+
+  test('/404 renders maintenance/not-found page', async ({ page }) => {
+    const res = await page.goto(`${BASE}/404`);
+    // The 404 page itself returns 200 (it's a static page in Astro)
+    expect(res?.status()).not.toBe(500);
+    await expect(page.locator('body')).not.toContainText('500');
+  });
+
+  test('unknown route returns non-500', async ({ page }) => {
+    const res = await page.goto(`${BASE}/does-not-exist-xyzzy`);
+    expect(res?.status()).not.toBe(500);
+    await expect(page.locator('body')).not.toContainText('500');
+  });
+});

--- a/website/src/components/CallToAction.svelte
+++ b/website/src/components/CallToAction.svelte
@@ -17,8 +17,8 @@
     subtitle = 'Kein Verkaufsgespräch. Kein Druck. Nur Klarheit. Wo stehen Sie – und wie könnte eine Zusammenarbeit konkret aussehen?',
     primaryText = 'Termin vorschlagen',
     primaryHref = '/kontakt',
-    secondaryText = 'info@mentolder.de',
-    secondaryHref = 'mailto:info@mentolder.de',
+    secondaryText = '',
+    secondaryHref = '',
   }: Props = $props();
 </script>
 

--- a/website/src/lib/invoice-pdf.ts
+++ b/website/src/lib/invoice-pdf.ts
@@ -74,8 +74,9 @@ export async function generateInvoicePdf(p: {
       try { doc.image(LOGO, L, 47, { width: 42, height: 42 }); } catch { /* skip */ }
     }
 
+    const brandName = process.env.BRAND_NAME || 'mentolder';
     doc.font('Times-Italic').fontSize(18).fillColor(C.ink)
-       .text('mentolder', 102, 55, { continued: true, lineBreak: false });
+       .text(brandName, 102, 55, { continued: true, lineBreak: false });
     doc.fillColor(C.brass).text('.', { lineBreak: false });
 
     doc.font('Helvetica').fontSize(8).fillColor(C.inkMute).text(seller.name, 102, 76);

--- a/website/src/pages/api/admin/angebote/save.ts
+++ b/website/src/pages/api/admin/angebote/save.ts
@@ -2,7 +2,7 @@ import type { APIRoute } from 'astro';
 import { getSession, isAdmin } from '../../../../lib/auth';
 import { saveServiceConfig, saveLeistungenConfig, setSiteSetting } from '../../../../lib/website-db';
 import type { ServiceOverride, LeistungCategoryOverride } from '../../../../lib/website-db';
-import { mentolderConfig } from '../../../../config/brands/mentolder';
+import { config } from '../../../../config/index';
 
 function parseJson<T>(raw: string | null, fallback: T): T {
   if (!raw?.trim()) return fallback;
@@ -45,7 +45,7 @@ export const POST: APIRoute = async ({ request, redirect }) => {
   const form = await request.formData();
 
   // ── Services (card fields + pageContent) ──────────────────────────────────
-  const serviceOverrides: ServiceOverride[] = mentolderConfig.services.map(s => {
+  const serviceOverrides: ServiceOverride[] = config.services.map(s => {
     const features = ((form.get(`${s.slug}_features`) as string) ?? '').split('\n').map(f => f.trim()).filter(Boolean);
     const forWhom = ((form.get(`${s.slug}_pc_forWhom`) as string) ?? '').split('\n').map(f => f.trim()).filter(Boolean);
     return {
@@ -68,7 +68,7 @@ export const POST: APIRoute = async ({ request, redirect }) => {
   });
 
   // ── Leistungen (pricing table) ─────────────────────────────────────────────
-  const leistungenOverrides: LeistungCategoryOverride[] = mentolderConfig.leistungen.map(cat => ({
+  const leistungenOverrides: LeistungCategoryOverride[] = config.leistungen.map(cat => ({
     id: cat.id,
     title: (form.get(`lk_${cat.id}_title`) as string) || cat.title,
     icon: (form.get(`lk_${cat.id}_icon`) as string) || cat.icon,

--- a/website/src/pages/api/admin/inbox/[id]/action.ts
+++ b/website/src/pages/api/admin/inbox/[id]/action.ts
@@ -204,13 +204,9 @@ export const POST: APIRoute = async ({ request, params }) => {
         }
         const p = item.payload as { ticketId: string; reporterEmail: string; brand: string };
         await resolveBugTicket(p.ticketId, resolveNote);
-        const BRAND_INBOX: Record<string, string> = {
-          mentolder: `info@mentolder.de`,
-          korczewski: `info@korczewski.de`,
-        };
-        const fallbackEmail = PROD_DOMAIN ? `info@${PROD_DOMAIN}` : 'info@mentolder.de';
+        const toEmail = PROD_DOMAIN ? `info@${PROD_DOMAIN}` : `info@${p.brand}.de`;
         await sendEmail({
-          to: BRAND_INBOX[p.brand] ?? fallbackEmail,
+          to: toEmail,
           subject: `[${p.ticketId}] Erledigt`,
           text: `Ticket ${p.ticketId} wurde als erledigt markiert.\n\nNotiz:\n${resolveNote}`,
           replyTo: p.reporterEmail,


### PR DESCRIPTION
## Summary

- **CI**: Pin `kubeconform` → v0.6.7, `yamllint` → 1.35.1, `shellcheck` → v0.10.0 (binary download, not apt) for fully reproducible builds
- **Manifests**: Remove unused `AI_DOMAIN` from dev + prod configmaps; add `traefik-dashboard-dev.yaml` to kustomization base
- **Website**: Use `BRAND_NAME` env var in invoice PDF (was hardcoded `'mentolder'`); replace `mentolderConfig` with brand-agnostic `config` in angebote/save; simplify bug-ticket email routing via `PROD_DOMAIN`; clear `CallToAction` default secondary link
- **E2E tests**: Add five new spec files (public-pages, admin-inhalte, billing-system, crm, settings) + register all in playwright skip list
- **Docs**: Sharpen CLAUDE.md envsubst gotcha with Taskfile line numbers

## Test plan

- [ ] CI passes (manifest validation, yamllint, shellcheck)
- [ ] `task workspace:validate` clean locally
- [ ] Invoice PDF renders brand name from env on mentolder cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)