### PR TITLE
fix(traefik): ingressclass routing and network policy for hostNetwork pod

### DIFF
--- a/k3d/network-policies.yaml
+++ b/k3d/network-policies.yaml
@@ -87,7 +87,10 @@ spec:
   - from:
     - podSelector: {}
 ---
-# Traefik-Ingress aus kube-system erlauben
+# Traefik-Ingress aus kube-system erlauben.
+# Traefik läuft im hostNetwork-Modus (podIP = 192.168.100.1), sendet aber via
+# flannel.1 mit src-IP 10.42.0.0 (VTEP des Control-Plane-Nodes). Deshalb
+# muss neben dem namespaceSelector auch der ipBlock für den VTEP freigegeben werden.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -104,6 +107,8 @@ spec:
       podSelector:
         matchLabels:
           app.kubernetes.io/name: traefik
+    - ipBlock:
+        cidr: 10.42.0.0/32
 ---
 # Website-Backend aus website-Namespace erlauben
 apiVersion: networking.k8s.io/v1

--- a/prod/cloud-init.yaml
+++ b/prod/cloud-init.yaml
@@ -117,6 +117,6 @@ runcmd:
   # Install Traefik via Helm
   - su - patrick -c "helm repo add traefik https://traefik.github.io/charts"
   - su - patrick -c "helm repo update"
-  - su - patrick -c "KUBECONFIG=/home/patrick/.kube/config helm install traefik traefik/traefik -n kube-system --set ports.web.hostPort=80 --set ports.websecure.hostPort=443 --set deployment.kind=DaemonSet --set ingressRoute.dashboard.enabled=false"
+  - su - patrick -c "KUBECONFIG=/home/patrick/.kube/config helm install traefik traefik/traefik -n kube-system --set ports.web.hostPort=80 --set ports.websecure.hostPort=443 --set deployment.kind=DaemonSet --set ingressRoute.dashboard.enabled=false --set providers.kubernetesingress.ingressClass=traefik"
 
 final_message: "k3s control plane ready on $(hostname) - $(date)"


### PR DESCRIPTION
## Summary

- **Traefik v3 ingressclass**: `--providers.kubernetesingress` without `--providers.kubernetesingress.ingressclass=traefik` silently ignores all Ingresses with `spec.ingressClassName: traefik` — every workspace service (Keycloak, Nextcloud, Vaultwarden, etc.) was dark. Added the flag to `cloud-init.yaml`; already live-patched via `kubectl patch deployment`.
- **Network policy VTEP mismatch**: `allow-traefik-ingress` matched the Traefik pod's registered IP (`192.168.100.1`) but the pod runs with `hostNetwork: true`, so VXLAN packets arrive at workspace pods with source `10.42.0.0` (pk-hetzner's Flannel VTEP). k3s iptables applied `default-deny-ingress`, dropping every TCP SYN. Added `ipBlock: 10.42.0.0/32` to the allow rule; already live-applied via `kubectl apply`.

## Test plan

- [ ] Navigate to `https://web.korczewski.de` and log in — should redirect to Keycloak and complete auth without 404
- [ ] Verify `https://auth.korczewski.de/realms/workspace` returns Keycloak JSON
- [ ] Verify `https://files.korczewski.de`, `https://vault.korczewski.de` and other workspace services load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)