### PR TITLE
fix(traefik): add IngressClass resource to prod manifests

### DIFF
--- a/prod/ingressclass.yaml
+++ b/prod/ingressclass.yaml
@@ -1,0 +1,6 @@
+apiVersion: networking.k8s.io/v1
+kind: IngressClass
+metadata:
+  name: traefik
+spec:
+  controller: traefik.io/ingress-controller

--- a/prod/kustomization.yaml
+++ b/prod/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - cluster-issuer.yaml
   - reflector.yaml
   - wildcard-certificate.yaml
+  - ingressclass.yaml
   - traefik-middlewares.yaml
   - tlsoption.yaml
   - old-webspace.yaml


### PR DESCRIPTION
## Summary

- Adds `prod/ingressclass.yaml` defining `IngressClass/traefik` with controller `traefik.io/ingress-controller`
- Registers it in `prod/kustomization.yaml` so ArgoCD manages it on both prod clusters

Without this resource, Traefik v3 with `--providers.kubernetesingress.ingressclass=traefik` still silently ignores all Ingresses with `spec.ingressClassName: traefik` — the HTTPS routers for Keycloak, Nextcloud, Vaultwarden etc. are never created. The `IngressClass` resource is what triggers Traefik to start processing them.

Already live-applied on korczewski via `kubectl apply`.

## Test plan

- [ ] ArgoCD sync `workspace-korczewski` shows Synced (no OutOfSync for IngressClass)
- [ ] `https://auth.korczewski.de` serves the Keycloak login page (not 404)
- [ ] `https://web.korczewski.de` login completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)