### PR TITLE
fix(traefik): codify korczewski traefik-manual and update to v3.6.12

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -638,6 +638,19 @@ tasks:
       - kubectl --context korczewski rollout restart deployment/{{.CLI_ARGS}} -n workspace
       - kubectl --context korczewski rollout status deployment/{{.CLI_ARGS}} -n workspace --timeout=120s
 
+  korczewski:traefik:apply:
+    desc: Apply (or re-apply) the Traefik ingress controller on korczewski (run once on bootstrap or after manifest changes)
+    cmds:
+      - |
+        # Remove finalizer from the stuck old Helm LoadBalancer service if still present
+        if kubectl --context korczewski get svc traefik -n kube-system -o jsonpath='{.metadata.finalizers}' 2>/dev/null | grep -q load-balancer-cleanup; then
+          echo "Removing stuck finalizer from old traefik LoadBalancer service..."
+          kubectl --context korczewski patch svc traefik -n kube-system -p '{"metadata":{"finalizers":[]}}' --type=merge
+        fi
+      - kubectl --context korczewski delete svc traefik-svc -n kube-system --ignore-not-found
+      - kubectl --context korczewski apply -f prod-korczewski/traefik.yaml
+      - kubectl --context korczewski rollout status deployment/traefik-manual -n kube-system --timeout=60s
+
   mentolder:status:
     desc: Show mentolder.de cluster status
     cmds:

--- a/prod-korczewski/traefik.yaml
+++ b/prod-korczewski/traefik.yaml
@@ -1,0 +1,158 @@
+# Traefik ingress controller for korczewski — manually managed (not Helm).
+#
+# Intentionally uses hostNetwork:true on the control-plane node (pk-hetzner).
+# Mentolder uses a Helm DaemonSet with hostPort, which assumes working pod
+# networking across all nodes. Korczewski has a CNI partition (pk-hetzner →
+# LAN workers) that makes cross-node pod routing unreliable; hostNetwork
+# bypasses the CNI layer so Traefik uses the host's routing table to reach
+# backends on 192.168.100.x. pk-hetzner is also the only node with a public
+# IP, so a DaemonSet spread would serve no purpose.
+#
+# Apply via: task korczewski:traefik:apply
+# Do NOT include in kustomization.yaml — the namespace:workspace override
+# would move these kube-system resources into the wrong namespace.
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: traefik-manual
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: traefik-manual
+rules:
+  - apiGroups: [""]
+    resources: [services, endpoints, secrets]
+    verbs: [get, list, watch]
+  - apiGroups: [extensions, networking.k8s.io]
+    resources: [ingresses, ingressclasses]
+    verbs: [get, list, watch]
+  - apiGroups: [networking.k8s.io]
+    resources: [ingresses/status]
+    verbs: [update]
+  - apiGroups: [traefik.io]
+    resources:
+      - ingressroutes
+      - middlewares
+      - ingressroutetcps
+      - ingressrouteudps
+      - tlsoptions
+      - tlsstores
+      - traefikservices
+      - serverstransports
+    verbs: [get, list, watch]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: traefik-manual
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: traefik-manual
+subjects:
+  - kind: ServiceAccount
+    name: traefik-manual
+    namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: traefik-manual-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: traefik-manual
+    namespace: kube-system
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: traefik-manual
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/instance: traefik-kube-system
+    app.kubernetes.io/name: traefik
+spec:
+  replicas: 1
+  # hostNetwork binds ports 80/443 directly on the host — two pods cannot
+  # coexist on the same node, so RollingUpdate would deadlock.
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: traefik-kube-system
+      app.kubernetes.io/name: traefik
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/instance: traefik-kube-system
+        app.kubernetes.io/name: traefik
+    spec:
+      serviceAccountName: traefik-manual
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      nodeSelector:
+        node-role.kubernetes.io/control-plane: "true"
+      containers:
+        - name: traefik
+          image: traefik:v3.6.12
+          args:
+            - --providers.kubernetesingress
+            - --providers.kubernetescrd
+            - --entrypoints.web.address=:80
+            - --entrypoints.websecure.address=:443
+            - --entrypoints.traefik.address=:9000
+            - --api.dashboard=true
+            - --ping=true
+            - --accesslog=true
+            - --providers.kubernetesingress.ingressclass=traefik
+          ports:
+            - name: web
+              containerPort: 80
+              hostPort: 80
+            - name: websecure
+              containerPort: 443
+              hostPort: 443
+            - name: traefik
+              containerPort: 9000
+          livenessProbe:
+            httpGet:
+              path: /ping
+              port: 9000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /ping
+              port: 9000
+            initialDelaySeconds: 2
+            periodSeconds: 10
+            failureThreshold: 1
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: traefik
+  namespace: kube-system
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/instance: traefik-kube-system
+    app.kubernetes.io/name: traefik
+  ports:
+    - name: web
+      port: 80
+      targetPort: web
+    - name: websecure
+      port: 443
+      targetPort: websecure
+    - name: traefik
+      port: 9000
+      targetPort: traefik

--- a/prod/ingressclass.yaml
+++ b/prod/ingressclass.yaml
@@ -1,0 +1,6 @@
+apiVersion: networking.k8s.io/v1
+kind: IngressClass
+metadata:
+  name: traefik
+spec:
+  controller: traefik.io/ingress-controller

--- a/prod/kustomization.yaml
+++ b/prod/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - cluster-issuer.yaml
   - reflector.yaml
   - wildcard-certificate.yaml
+  - ingressclass.yaml
   - traefik-middlewares.yaml
   - tlsoption.yaml
   - old-webspace.yaml


### PR DESCRIPTION
## Summary

- Codifies `traefik-manual` deployment into `prod-korczewski/traefik.yaml` (was previously applied directly with kubectl, untracked in git)
- Updates Traefik image from `v3.3` → `v3.6.12` (matching mentolder and k3d-dev)
- Adds `strategy: Recreate` — required because `hostNetwork: true` binds ports 80/443 directly on the host; two pods can't coexist, which deadlocks `RollingUpdate`
- Adds liveness/readiness probes on `:9000/ping` (port 8080 already occupied on pk-hetzner)
- Adds `ClusterIP` Service `traefik` in `kube-system` (replaces the stuck terminating Helm `LoadBalancer` and the interim `traefik-svc`)
- Adds `task korczewski:traefik:apply` for bootstrap and re-apply; also handles removing the stuck finalizer from the old Helm LoadBalancer service

**Note:** korczewski intentionally uses `hostNetwork: true` on a single control-plane node (`pk-hetzner`) rather than a DaemonSet like mentolder. Only `pk-hetzner` has a public IP, and the CNI partition (cross-node pod routing broken) makes the Helm DaemonSet approach unsuitable here.

## Test plan

- [x] `traefik-manual` pod running `traefik:v3.6.12` on `pk-hetzner` — confirmed via `kubectl get pod`
- [x] Health probes passing (pod reached `1/1 Running` without restarts)
- [x] `task korczewski:traefik:apply` task added for future re-applies

🤖 Generated with [Claude Code](https://claude.com/claude-code)