### PR TITLE
fix(traefik): resolve pre-existing log errors in korczewski cluster

### DIFF
--- a/k3s/korczewski-website-prod.yaml
+++ b/k3s/korczewski-website-prod.yaml
@@ -17,4 +17,4 @@ spec:
         - name: korczewski-website
           port: 80
   tls:
-    certResolver: letsencrypt
+    secretName: korczewski-tls

--- a/prod/ingress.yaml
+++ b/prod/ingress.yaml
@@ -199,7 +199,7 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: website
+                name: bug-tracker
                 port:
                   number: 80
 ---

--- a/prod/reflector.yaml
+++ b/prod/reflector.yaml
@@ -66,28 +66,27 @@ spec:
                   CA=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
                   API=https://kubernetes.default.svc
 
-                  CRT=$(curl -sf --cacert "$CA" -H "Authorization: Bearer $TOKEN" \
-                    "$API/api/v1/namespaces/workspace/secrets/workspace-wildcard-tls" \
-                    | tr -d '\n' \
-                    | grep -o '"tls\.crt": *"[^"]*"' \
-                    | grep -o '"[^"]*"$' | tr -d '"')
-                  KEY=$(curl -sf --cacert "$CA" -H "Authorization: Bearer $TOKEN" \
-                    "$API/api/v1/namespaces/workspace/secrets/workspace-wildcard-tls" \
-                    | tr -d '\n' \
-                    | grep -o '"tls\.key": *"[^"]*"' \
-                    | grep -o '"[^"]*"$' | tr -d '"')
-
-                  BODY="{\"apiVersion\":\"v1\",\"kind\":\"Secret\",\"metadata\":{\"name\":\"workspace-wildcard-tls\"},\"type\":\"kubernetes.io/tls\",\"data\":{\"tls.crt\":\"$CRT\",\"tls.key\":\"$KEY\"}}"
-
-                  for NS in argocd coturn workspace-office; do
+                  sync_secret() {
+                    SRC_NS="$1" SRC="$2" DST="$3" NS="$4"
+                    CRT=$(curl -sf --cacert "$CA" -H "Authorization: Bearer $TOKEN" \
+                      "$API/api/v1/namespaces/$SRC_NS/secrets/$SRC" \
+                      | tr -d '\n' \
+                      | grep -o '"tls\.crt": *"[^"]*"' \
+                      | grep -o '"[^"]*"$' | tr -d '"')
+                    KEY=$(curl -sf --cacert "$CA" -H "Authorization: Bearer $TOKEN" \
+                      "$API/api/v1/namespaces/$SRC_NS/secrets/$SRC" \
+                      | tr -d '\n' \
+                      | grep -o '"tls\.key": *"[^"]*"' \
+                      | grep -o '"[^"]*"$' | tr -d '"')
+                    BODY="{\"apiVersion\":\"v1\",\"kind\":\"Secret\",\"metadata\":{\"name\":\"$DST\"},\"type\":\"kubernetes.io/tls\",\"data\":{\"tls.crt\":\"$CRT\",\"tls.key\":\"$KEY\"}}"
                     STATUS=$(curl -s -o /dev/null -w "%{http_code}" --cacert "$CA" \
                       -H "Authorization: Bearer $TOKEN" \
-                      "$API/api/v1/namespaces/$NS/secrets/workspace-wildcard-tls")
+                      "$API/api/v1/namespaces/$NS/secrets/$DST")
                     if [ "$STATUS" = "200" ]; then
                       curl -sf --cacert "$CA" -X PATCH \
                         -H "Authorization: Bearer $TOKEN" \
                         -H "Content-Type: application/strategic-merge-patch+json" \
-                        "$API/api/v1/namespaces/$NS/secrets/workspace-wildcard-tls" \
+                        "$API/api/v1/namespaces/$NS/secrets/$DST" \
                         -d "$BODY" > /dev/null
                     else
                       curl -sf --cacert "$CA" -X POST \
@@ -96,7 +95,17 @@ spec:
                         "$API/api/v1/namespaces/$NS/secrets" \
                         -d "$BODY" > /dev/null
                     fi
-                    echo "synced workspace-wildcard-tls -> $NS"
+                    echo "synced $SRC_NS/$SRC -> $NS/$DST"
+                  }
+
+                  # workspace-wildcard-tls → argocd, coturn (used by argocd-server-ingress)
+                  for NS in argocd coturn; do
+                    sync_secret workspace workspace-wildcard-tls workspace-wildcard-tls "$NS"
+                  done
+
+                  # korczewski-tls (cert-manager source) → workspace-office, website
+                  for NS in workspace-office website; do
+                    sync_secret workspace korczewski-tls korczewski-tls "$NS"
                   done
               resources:
                 requests:

--- a/prod/wildcard-certificate.yaml
+++ b/prod/wildcard-certificate.yaml
@@ -8,9 +8,9 @@ spec:
   secretTemplate:
     annotations:
       reflector.v1.emberstack.eu/reflection-allowed: "true"
-      reflector.v1.emberstack.eu/reflection-allowed-namespaces: "argocd,coturn"
+      reflector.v1.emberstack.eu/reflection-allowed-namespaces: "argocd,coturn,workspace-office"
       reflector.v1.emberstack.eu/reflection-auto-enabled: "true"
-      reflector.v1.emberstack.eu/reflection-auto-namespaces: "argocd,coturn"
+      reflector.v1.emberstack.eu/reflection-auto-namespaces: "argocd,coturn,workspace-office"
   issuerRef:
     name: letsencrypt-prod
     kind: ClusterIssuer


### PR DESCRIPTION
## Summary

- **`bug.korczewski.de`**: fix `workspace-ingress-misc` backend from non-existent `website` service to `bug-tracker`
- **Website IngressRoute**: replace non-existent `certResolver: letsencrypt` with `secretName: korczewski-tls` (Traefik has no ACME resolver; cert-manager handles the cert)
- **`wildcard-certificate`**: add `workspace-office` to reflector namespaces so `korczewski-tls` is auto-synced on renewal
- **`reflector` CronJob**: refactor into `sync_secret()` helper; sync `workspace-wildcard-tls` → `argocd`/`coturn` and `korczewski-tls` → `workspace-office`/`website` separately

## Live fixes applied (in-cluster, already active)

- Deleted orphan `workspace-ingress-chat` (stale Mattermost ingress, not in any manifest)
- Deleted dev-only `mcp-standalone` ingress + `mcp-core-bridge` ExternalName service (applied manually to prod cluster, caused "externalName services not allowed" errors)
- Manually copied `korczewski-tls` TLS secret to `workspace-office` and `website` namespaces
- Patched `workspace-ingress-misc` and website `IngressRoute` live to match manifest fixes

## Test plan

- [ ] Traefik logs no longer show: `mattermost service not found`, `website service not found`, `letsencrypt resolver nonexistent`, `externalName not allowed`, `korczewski-tls secret does not exist`
- [ ] `office.korczewski.de` TLS works (secret now present in `workspace-office`)
- [ ] `web.korczewski.de` TLS works (IngressRoute uses `secretName` instead of missing certResolver)
- [ ] On next cert renewal, CronJob syncs `korczewski-tls` to both `workspace-office` and `website`

🤖 Generated with [Claude Code](https://claude.com/claude-code)