### PR TITLE
fix(admin-users): make KC_USER2_* optional

### DIFF
--- a/scripts/admin-users-setup.sh
+++ b/scripts/admin-users-setup.sh
@@ -40,9 +40,10 @@ err()  { echo -e "${RED}[ERR]${NC}   $*"; exit 1; }
 : "${KC_USER1_USERNAME:?KC_USER1_USERNAME not set — check environments/${ENV}.yaml}"
 : "${KC_USER1_EMAIL:?KC_USER1_EMAIL not set — check environments/${ENV}.yaml}"
 : "${KC_USER1_PASSWORD:?KC_USER1_PASSWORD not set — check environments/${ENV}.yaml}"
-: "${KC_USER2_USERNAME:?KC_USER2_USERNAME not set — check environments/${ENV}.yaml}"
-: "${KC_USER2_EMAIL:?KC_USER2_EMAIL not set — check environments/${ENV}.yaml}"
-: "${KC_USER2_PASSWORD:?KC_USER2_PASSWORD not set — check environments/${ENV}.yaml}"
+# KC_USER2_* is optional — provisioned only when all three vars are set.
+KC_USER2_USERNAME="${KC_USER2_USERNAME:-}"
+KC_USER2_EMAIL="${KC_USER2_EMAIL:-}"
+KC_USER2_PASSWORD="${KC_USER2_PASSWORD:-}"
 
 # ── Wait for Keycloak ──────────────────────────────────────────────────
 log "Waiting for Keycloak to be ready..."
@@ -138,12 +139,18 @@ echo ""
 log "Provisioning SSO admin users in realm '${KC_REALM}'..."
 
 upsert_user "$KC_USER1_USERNAME" "$KC_USER1_EMAIL" "$KC_USER1_PASSWORD"
-upsert_user "$KC_USER2_USERNAME" "$KC_USER2_EMAIL" "$KC_USER2_PASSWORD"
+if [[ -n "$KC_USER2_USERNAME" && -n "$KC_USER2_EMAIL" && -n "$KC_USER2_PASSWORD" ]]; then
+  upsert_user "$KC_USER2_USERNAME" "$KC_USER2_EMAIL" "$KC_USER2_PASSWORD"
+else
+  warn "KC_USER2_* not set in environments/${ENV}.yaml — skipping second admin user"
+fi
 
 echo ""
 log "═══════════════════════════════════════════"
 log "  SSO admin users provisioned"
 log "  User 1: ${KC_USER1_USERNAME} (${KC_USER1_EMAIL})"
-log "  User 2: ${KC_USER2_USERNAME} (${KC_USER2_EMAIL})"
+if [[ -n "$KC_USER2_USERNAME" ]]; then
+  log "  User 2: ${KC_USER2_USERNAME} (${KC_USER2_EMAIL})"
+fi
 log "  Realm:  ${KC_REALM}"
 log "═══════════════════════════════════════════"


### PR DESCRIPTION
## Summary
- `workspace:admin-users-setup` failed against `dev` because `environments/dev.yaml` only defines `KC_USER1_*`.
- Make `KC_USER2_*` optional: provision the second admin only when all three vars are set, otherwise warn and continue.

## Test plan
- [x] `task workspace:admin-users-setup` succeeds on dev with only `KC_USER1_*` set
- [x] Existing prod envs (mentolder, korczewski) still provision both users

🤖 Generated with [Claude Code](https://claude.com/claude-code)