### PR TITLE
fix(keycloak-sync): resolve WEBSITE_OIDC_SECRET from website-secrets

### DIFF
--- a/scripts/keycloak-sync.sh
+++ b/scripts/keycloak-sync.sh
@@ -107,6 +107,12 @@ build_kv_map() {
   kubectl $CONTEXT_FLAG get secret workspace-secrets -n "$KC_NAMESPACE" \
     -o json 2>/dev/null \
     | jq -r '.data | to_entries[] | select(.key | endswith("_OIDC_SECRET")) | "\(.key)=\(.value|@base64d)"' 2>/dev/null || true
+
+  # WEBSITE_OIDC_SECRET lives in website-secrets (website namespace), not workspace-secrets.
+  # shellcheck disable=SC2086
+  kubectl $CONTEXT_FLAG get secret website-secrets -n website \
+    -o json 2>/dev/null \
+    | jq -r '.data | to_entries[] | select(.key | endswith("_OIDC_SECRET")) | "\(.key)=\(.value|@base64d)"' 2>/dev/null || true
 }
 
 KV_MAP=$(build_kv_map)


### PR DESCRIPTION
## Summary
- `keycloak-sync.sh` only read `workspace-secrets` (workspace ns), but `WEBSITE_OIDC_SECRET` lives in `website-secrets` (website ns)
- Result: realm-template placeholder `${WEBSITE_OIDC_SECRET}` was never substituted, and the `website` Keycloak client was skipped during `workspace:deploy`
- Fix: also pull `*_OIDC_SECRET` entries from `website-secrets` when building the substitution map

## Test plan
- [x] Re-ran `ENV=mentolder bash scripts/keycloak-sync.sh` — website client now syncs (8 secret-updated, 0 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)