### PR TITLE
chore(taskfile): remove dead workspace:call-setup task

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,6 @@ task workspace:restore -- all <timestamp>                # Restore all DBs from 
 task workspace:office:deploy ENV=<env>    # Deploy Collabora (separate overlay — required for full bring-up)
 task workspace:post-setup                 # Enable Nextcloud apps (calendar, contacts, OIDC, Collabora)
 task workspace:talk-setup                 # Configure Nextcloud Talk HPB signaling + coturn
-task workspace:call-setup                 # Configure Nextcloud Talk call settings
 task workspace:recording-setup            # Configure Talk recording backend
 task workspace:whiteboard-setup           # Install + configure Nextcloud Whiteboard app
 task workspace:systembrett-setup          # Set up Brett (Systembrett) integration in Nextcloud

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -201,7 +201,6 @@ tasks:
       - task: mcp:deploy
       - task: workspace:post-setup
       - task: workspace:talk-setup
-      - task: workspace:call-setup
       - task: workspace:recording-setup
       - task: workspace:transcriber-setup
       - echo ""
@@ -223,8 +222,6 @@ tasks:
       - task: workspace:post-setup
         vars: { ENV: "{{.ENV}}" }
       - task: workspace:talk-setup
-        vars: { ENV: "{{.ENV}}" }
-      - task: workspace:call-setup
         vars: { ENV: "{{.ENV}}" }
       - task: workspace:recording-setup
         vars: { ENV: "{{.ENV}}" }
@@ -380,7 +377,7 @@ tasks:
         [ "{{.ENV}}" != "dev" ] && export KUBE_CONTEXT="${ENV_CONTEXT}"
         bash scripts/talk-hpb-setup.sh
       - 'echo ""'
-      - 'echo "  Next → task workspace:call-setup ENV={{.ENV}}"'
+      - 'echo "  Next → task workspace:recording-setup ENV={{.ENV}}"'
       - 'echo "  Optional → task workspace:admin-users-setup ENV={{.ENV}}"'
 
   workspace:talk-setup:all-prods:
@@ -566,26 +563,6 @@ tasks:
       - task: workspace:recording-setup
         vars: { ENV: "mentolder" }
       - task: workspace:recording-setup
-        vars: { ENV: "korczewski" }
-
-  workspace:call-setup:
-    desc: "Register /call slash command (ENV=dev|mentolder|korczewski)"
-    vars:
-      ENV: '{{.ENV | default "dev"}}'
-    cmds:
-      - |
-        source scripts/env-resolve.sh "{{.ENV}}"
-        [ "{{.ENV}}" != "dev" ] && export KUBE_CONTEXT="${ENV_CONTEXT}" || true
-        bash scripts/call-setup.sh
-      - 'echo ""'
-      - 'echo "  Next → task workspace:recording-setup ENV={{.ENV}}"'
-
-  workspace:call-setup:all-prods:
-    desc: Register /call slash command in both production clusters (mentolder + korczewski)
-    cmds:
-      - task: workspace:call-setup
-        vars: { ENV: "mentolder" }
-      - task: workspace:call-setup
         vars: { ENV: "korczewski" }
 
   workspace:status:
@@ -1043,7 +1020,7 @@ tasks:
         source scripts/env-resolve.sh "{{.ENV}}"
         bash scripts/admin-users-setup.sh
       - 'echo ""'
-      - 'echo "  Next → task workspace:call-setup ENV={{.ENV}}"'
+      - 'echo "  Done. Re-run any specific setup task as needed."'
 
   workspace:validate:
     desc: Validate k3d manifests with kustomize dry-run


### PR DESCRIPTION
## Summary
- Delete \`workspace:call-setup\` and \`workspace:call-setup:all-prods\` — \`scripts/call-setup.sh\` was removed with Mattermost in #189.
- Drop call-setup from the \`workspace:up\` and \`workspace:setup\` chains and from post-task hints.
- Remove the lingering CLAUDE.md command reference.

## Test plan
- [x] \`grep -n call-setup Taskfile.yml\` returns nothing.
- [ ] \`task workspace:setup ENV=dev\` proceeds past talk-setup into recording-setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)