### PR TITLE
fix(nextcloud): lower prod CPU request 500m→200m to unblock scheduling

### DIFF
--- a/prod/patch-nextcloud.yaml
+++ b/prod/patch-nextcloud.yaml
@@ -7,6 +7,13 @@ spec:
     spec:
       containers:
         - name: nextcloud
+          resources:
+            requests:
+              memory: 512Mi
+              cpu: "200m"
+            limits:
+              memory: 2Gi
+              cpu: "2"
           env:
             - name: OVERWRITEPROTOCOL
               value: "https"


### PR DESCRIPTION
## Summary
- gekko-hetzner-3 (mentolder) sits at 94% CPU requests / 6% actual usage; nextcloud pod cannot reschedule after restarts because its local-path PVCs pin it to that node and the 500m request doesn't fit in the remaining ~210m
- Lowers the request to 200m for prod only (dev keeps 500m via base manifest); CPU limit stays at 2 cores so burst behaviour is unchanged
- Unblocks the stuck `workspace:setup` rollout on mentolder

## Test plan
- [x] `kubectl kustomize prod-mentolder/` renders nextcloud with `requests.cpu: 200m`
- [ ] After ArgoCD syncs, nextcloud pod schedules and reaches Ready on mentolder
- [ ] `task workspace:setup ENV=mentolder` completes (talk-setup + remaining steps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)