### PR TITLE
fix(nextcloud): drop prod CPU request to 100m for scheduling headroom

### DIFF
--- a/prod/patch-nextcloud.yaml
+++ b/prod/patch-nextcloud.yaml
@@ -10,7 +10,7 @@ spec:
           resources:
             requests:
               memory: 512Mi
-              cpu: "200m"
+              cpu: "100m"
             limits:
               memory: 2Gi
               cpu: "2"

--- a/prod/patch-nextcloud.yaml
+++ b/prod/patch-nextcloud.yaml
@@ -7,6 +7,13 @@ spec:
     spec:
       containers:
         - name: nextcloud
+          resources:
+            requests:
+              memory: 512Mi
+              cpu: "200m"
+            limits:
+              memory: 2Gi
+              cpu: "2"
           env:
             - name: OVERWRITEPROTOCOL
               value: "https"


### PR DESCRIPTION
## Summary
- Follow-up to #420: 200m wasn't enough — nextcloud (200m) + cron sidecar (50m) = 250m, but node has only 210m free
- Lowering main container request to 100m total = 150m, fits with margin

## Test plan
- [ ] Pod schedules on gekko-hetzner-3 after ArgoCD sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)