### PR TITLE
fix(nextcloud): lower prod CPU request 200m→100m

### DIFF
--- a/prod/patch-nextcloud.yaml
+++ b/prod/patch-nextcloud.yaml
@@ -10,7 +10,7 @@ spec:
           resources:
             requests:
               memory: 512Mi
-              cpu: "200m"
+              cpu: "100m"
             limits:
               memory: 2Gi
               cpu: "2"


### PR DESCRIPTION
## Summary
Follow-up to #420. 200m still didn't fit — node had 210m free vs 250m needed (200m + 50m cron). Lowering to 100m.

🤖 Generated with [Claude Code](https://claude.com/claude-code)