### PR TITLE
fix(inhalte): fix admin editor hydration DataCloneError

### DIFF
--- a/website/src/pages/admin/inhalte.astro
+++ b/website/src/pages/admin/inhalte.astro
@@ -73,7 +73,7 @@ const rechnungsvorlagen = Object.fromEntries(
   RECHNUNG_KEYS.map((k, i) => [k, rechnungsResults[i] ?? RECHNUNG_DEFAULTS[k]])
 ) as Record<typeof RECHNUNG_KEYS[number], string>;
 
-const initialData = {
+const initialData = JSON.parse(JSON.stringify({
   startseite,
   uebermich,
   services,
@@ -84,7 +84,7 @@ const initialData = {
   referenzen,
   rechtliches: { 'impressum-zusatz': impressum, datenschutz, agb, barrierefreiheit },
   customSections,
-};
+}));
 ---
 
 <AdminLayout title="Admin — Inhalte">


### PR DESCRIPTION
## Summary
- /admin/inhalte was failing to hydrate on mentolder with `DataCloneError: ... #<Object> could not be cloned` from astro-island, leaving the editor blank.
- Root cause: `listCustomSections` returns Postgres `TIMESTAMPTZ` columns as `Date` instances, which Svelte 5's deep `$state` proxy chokes on when wrapping `initialData.customSections` during hydration.
- Fix: round-trip `initialData` through `JSON.parse(JSON.stringify(...))` so only POJO values cross the SSR→client boundary. Dates flatten to ISO strings; the Svelte components don't read those fields.

## Test plan
- [ ] Open https://web.mentolder.de/admin/inhalte as admin and confirm tabs (Website / Newsletter / Fragebögen / Verträge / Rechnungen) and Website sub-sections render
- [ ] Browser console clean of astro-island hydration errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)