### PR TITLE
chore(dashboard): kill existing server before starting

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -14,6 +14,7 @@ tasks:
     desc: Start the local task execution dashboard
     dir: dashboard
     cmds:
+      - pkill -f "node server.js" 2>/dev/null || true
       - npm install
       - node server.js
 


### PR DESCRIPTION
## Summary
- `task dashboard` now runs `pkill -f "node server.js"` before starting, so any previously running dashboard instance is cleaned up automatically.

## Test plan
- [ ] Run `task dashboard`, then run `task dashboard` again — second invocation should kill the first without error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)