### PR TITLE
fix(dashboard): auto-sync ENV on connect + unblock mid-run skip toggles

### DIFF
--- a/dashboard/public/index.html
+++ b/dashboard/public/index.html
@@ -885,7 +885,8 @@
             check.dataset.cmd = step.cmd;
             check.addEventListener('click', (ev) => {
                 ev.stopPropagation();           // do not trigger row-click run
-                if (pipeline.active) return;    // freeze toggles mid-run
+                // Allow toggling even mid-run: the pipeline uses a snapshot (pipeline.skipped)
+                // taken at start, so this only affects the next run.
                 toggleSkipForCmd(step.cmd);
                 applySkipUiForEnv();
                 updatePipelineStartBtnState();
@@ -1458,6 +1459,9 @@
 
     function closeModal() {
         document.getElementById('modal-overlay').classList.remove('visible');
+        // If a pipeline was started but its task never ran (ctx modal was shown and cancelled),
+        // pipeline.active is stuck true with running=false. Abort it so checkboxes work.
+        if (pending && pipeline.active && !running) abortPipeline();
         pending = null;
     }
 
@@ -1539,8 +1543,28 @@
         statusEl.className = 'fail'; statusEl.textContent = 'Disconnected from server';
     });
 
+    const CTX_ENV = { 'k3d-dev': 'dev', 'mentolder': 'mentolder', 'korczewski': 'korczewski' };
+    let initialCtxApplied = false;
+
     socket.on('current-context', ({ ctx }) => {
         liveContext = ctx || null;
+        // On first connect, snap the ENV selector to match the live context so
+        // the guard doesn't immediately block every task with a modal.
+        if (!initialCtxApplied && liveContext && CTX_ENV[liveContext]) {
+            initialCtxApplied = true;
+            const matched = CTX_ENV[liveContext];
+            if (envSelect.value !== matched) {
+                envSelect.value = matched;
+                const isProd = matched !== 'dev';
+                document.getElementById('prod-banner').classList.toggle('visible', isProd);
+                envSelect.classList.toggle('prod', isProd);
+                updateCtxBtnTitle();
+                hydrateSkipStateForActiveEnv();
+                if (typeof applySkipUiForEnv === 'function') applySkipUiForEnv();
+                updatePipelineStartBtnState();
+            }
+            ctxConfirmed = true;
+        }
         updateLiveCtxDisplay();
     });
 


### PR DESCRIPTION
## Summary

- Auto-snap the ENV selector to match the live kubectl context on first `current-context` socket event, eliminating the spurious run-guard modal that fired on every page load
- Allow skip-checkbox toggling while a pipeline is active — the pipeline captures `pipeline.skipped` as a snapshot at start, so toggling mid-run only affects the next run
- Abort a stuck `pipeline.active = true` state when the context-confirmation modal is dismissed before any task ever ran (prevents checkboxes being permanently frozen)

## Test plan

- [ ] Load dashboard with a live cluster connected — ENV selector should auto-match the context without a modal
- [ ] Start a pipeline run, toggle a skip checkbox mid-run — should be allowed and take effect on next run
- [ ] Open the ctx modal, cancel it without confirming — checkboxes should remain interactive

🤖 Generated with [Claude Code](https://claude.com/claude-code)