### PR TITLE
fix(dashboard): move skipState hydration after const declaration

### DIFF
--- a/dashboard/public/index.html
+++ b/dashboard/public/index.html
@@ -926,11 +926,6 @@
         sectionsEl.appendChild(section);
     }());
 
-    // Hydrate per-ENV skip set and render checkbox state on first load.
-    hydrateSkipStateForActiveEnv();
-    applySkipUiForEnv();
-    updatePipelineStartBtnState();
-
     GROUPS.forEach((group) => {
         if (group.pipeline) return; // rendered by buildPipelineSection above
 
@@ -1112,6 +1107,11 @@
     // In-memory `skipState` mirrors localStorage for the *currently selected* ENV.
     const SKIP_KEY_PREFIX = 'dashboard.pipeline.skipped.';
     const skipState = { env: null, cmds: new Set() };
+
+    // Hydrate per-ENV skip state now that skipState is declared.
+    hydrateSkipStateForActiveEnv();
+    applySkipUiForEnv();
+    updatePipelineStartBtnState();
 
     function getActiveEnv() {
         // envSelect is defined earlier in the file (line ~681).


### PR DESCRIPTION
## Summary

- Every page load of the dashboard threw `ReferenceError: Cannot access 'skipState' before initialization` at startup
- Root cause: `hydrateSkipStateForActiveEnv()` / `applySkipUiForEnv()` / `updatePipelineStartBtnState()` were called immediately after the `buildPipelineSection` IIFE (~line 930), but `const skipState` wasn't declared until ~line 1114 — `const` variables are in the temporal dead zone until their declaration line
- Result: socket stuck on "Connecting…", pipeline checkboxes never rendered checked state, skip-toggle feature completely non-functional
- Fix: move the three initialisation calls to just after `const skipState = { env: null, cmds: new Set() }` where the variable is live

## Test plan

- [x] Reload `http://localhost:3000` — zero JS errors in console
- [x] Socket connects immediately, status shows "Ready"
- [x] ENV auto-snaps to live kubectl context (`mentolder`)
- [x] All 7 pipeline step checkboxes render as `checked`
- [x] Toggling a checkbox marks step inactive + persists to `localStorage`
- [x] Switching ENV updates prod-banner and live-ctx mismatch warning correctly
- [x] Dry-run toggle activates badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)