### PR TITLE
fix(tracking): auto-init bachelorprojekt schema on shared-db startup

### DIFF
--- a/k3d/shared-db.yaml
+++ b/k3d/shared-db.yaml
@@ -192,6 +192,7 @@ spec:
                       -c "ALTER USER website WITH PASSWORD '${WEBSITE_DB_PASSWORD}';"
                     psql -U postgres -c "DO \$\$ BEGIN IF EXISTS (SELECT FROM pg_roles WHERE rolname = 'docuseal') THEN EXECUTE 'ALTER USER docuseal WITH PASSWORD ''${DOCUSEAL_DB_PASSWORD}'''; END IF; END \$\$;"
                     bash /scripts/ensure-meetings-schema.sh || true
+                    bash /scripts/ensure-bachelorprojekt-schema.sh || true
           ports:
             - containerPort: 5432
           volumeMounts:
@@ -207,6 +208,9 @@ spec:
             - name: website-schema
               mountPath: /scripts/ensure-meetings-schema.sh
               subPath: ensure-meetings-schema.sh
+            - name: website-schema
+              mountPath: /scripts/ensure-bachelorprojekt-schema.sh
+              subPath: ensure-bachelorprojekt-schema.sh
             - name: tls-certs
               mountPath: /etc/postgresql/certs
               readOnly: true

--- a/k3d/website-schema.yaml
+++ b/k3d/website-schema.yaml
@@ -659,3 +659,68 @@ data:
     EOSQL
 
     echo "Schema ensure complete."
+  ensure-bachelorprojekt-schema.sh: |
+    #!/bin/bash
+    set -e
+    echo "Ensuring bachelorprojekt schema is up to date..."
+
+    psql -v ON_ERROR_STOP=1 --username "postgres" --dbname postgres <<-'EOSQL'
+      CREATE SCHEMA IF NOT EXISTS bachelorprojekt;
+
+      CREATE TABLE IF NOT EXISTS bachelorprojekt.requirements (
+        id          TEXT PRIMARY KEY,
+        category    TEXT NOT NULL,
+        name        TEXT NOT NULL,
+        description TEXT,
+        criteria    TEXT,
+        test_case   TEXT,
+        created_at  TIMESTAMPTZ DEFAULT now()
+      );
+
+      CREATE TABLE IF NOT EXISTS bachelorprojekt.pipeline (
+        id         SERIAL PRIMARY KEY,
+        req_id     TEXT NOT NULL REFERENCES bachelorprojekt.requirements(id) ON DELETE CASCADE,
+        stage      TEXT NOT NULL CHECK (stage IN ('idea','implementation','testing','documentation','archive')),
+        entered_at TIMESTAMPTZ DEFAULT now(),
+        notes      TEXT
+      );
+
+      CREATE TABLE IF NOT EXISTS bachelorprojekt.test_results (
+        id      SERIAL PRIMARY KEY,
+        req_id  TEXT NOT NULL REFERENCES bachelorprojekt.requirements(id) ON DELETE CASCADE,
+        result  TEXT NOT NULL CHECK (result IN ('pass','fail','skip')),
+        run_at  TIMESTAMPTZ DEFAULT now(),
+        details TEXT
+      );
+
+      CREATE OR REPLACE VIEW bachelorprojekt.v_pipeline_status AS
+      SELECT
+        r.id, r.name, r.category,
+        COALESCE(p.stage, 'idea') AS current_stage,
+        p.entered_at AS stage_since
+      FROM bachelorprojekt.requirements r
+      LEFT JOIN bachelorprojekt.pipeline p
+        ON p.req_id = r.id
+        AND p.entered_at = (
+          SELECT MAX(p2.entered_at) FROM bachelorprojekt.pipeline p2 WHERE p2.req_id = r.id
+        );
+
+      CREATE OR REPLACE VIEW bachelorprojekt.v_progress_summary AS
+      SELECT current_stage AS stage, COUNT(*) AS count
+      FROM bachelorprojekt.v_pipeline_status
+      GROUP BY current_stage
+      ORDER BY ARRAY_POSITION(ARRAY['idea','implementation','testing','documentation','archive'], current_stage);
+
+      CREATE OR REPLACE VIEW bachelorprojekt.v_open_issues AS
+      SELECT *
+      FROM bachelorprojekt.v_pipeline_status
+      WHERE current_stage != 'archive'
+      ORDER BY category, id;
+
+      CREATE OR REPLACE VIEW bachelorprojekt.v_latest_tests AS
+      SELECT DISTINCT ON (req_id) req_id, result, run_at, details
+      FROM bachelorprojekt.test_results
+      ORDER BY req_id, run_at DESC;
+    EOSQL
+
+    echo "Bachelorprojekt schema ensure complete."


### PR DESCRIPTION
## Summary

- Add `ensure-bachelorprojekt-schema.sh` to `website-schema` ConfigMap with idempotent DDL (schema, 3 tables, 4 views) matching `deploy/tracking/init.sql`
- Mount the script into the shared-db pod and call it from `postStart` alongside the existing `ensure-meetings-schema.sh`
- Fresh deployments will now have the schema ready before the tracking app starts, eliminating the 503 at `tracking.localhost`

## Test plan

- [x] Schema applied to dev shared-db manually and `tracking.localhost` confirmed returning HTTP 200
- [x] `task workspace:validate` passes
- [ ] Verify on next `workspace:deploy` that tracking comes up green without manual intervention

🤖 Generated with [Claude Code](https://claude.com/claude-code)