### PR TITLE
fix(nextcloud): make theming occ commands tolerant of non-zero exits

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -309,10 +309,10 @@ tasks:
         BRAND="${BRAND_NAME:-mentolder}"
         DOMAIN="${PROD_DOMAIN:-localhost}"
         $NC_EXEC "php occ config:system:set trusted_domains 1 --value=files.${DOMAIN}" || true
-        $NC_EXEC "php occ config:app:set theming name --value='${BRAND}'"
-        $NC_EXEC "php occ config:app:set theming url            --value=https://web.${DOMAIN}"
-        $NC_EXEC "php occ config:app:set theming color          --value=#e8c870"
-        $NC_EXEC "php occ config:app:set theming enforce-theme --value=dark"
+        $NC_EXEC "php occ config:app:set theming name --value='${BRAND}'"           || true
+        $NC_EXEC "php occ config:app:set theming url            --value=https://web.${DOMAIN}" || true
+        $NC_EXEC "php occ config:app:set theming color          --value=#e8c870"   || true
+        $NC_EXEC "php occ config:app:set theming enforce-theme --value=dark"       || true
         echo "Nextcloud theme applied."
 
   workspace:theme:


### PR DESCRIPTION
## Summary
- Add `|| true` to all four `theming` `occ config:app:set` commands in `workspace:post-setup`
- Prevents post-setup from aborting when the theming app is disabled or returns a non-zero exit code on partially configured instances

## Test plan
- [ ] Run `task workspace:post-setup` on a fresh dev cluster — should complete without error
- [ ] Verify theming is applied when the app is enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)