### PR TITLE
fix(nextcloud): pass config.php path to notify_push 1.3.x

### DIFF
--- a/k3d/nextcloud.yaml
+++ b/k3d/nextcloud.yaml
@@ -301,7 +301,11 @@ spec:
                 echo "notify_push: waiting for binary at $BIN"
                 sleep 30
               done
-              exec "$BIN" /var/www/html
+              until [ -r "/var/www/html/config/config.php" ]; do
+                echo "notify_push: waiting for config.php"
+                sleep 10
+              done
+              exec "$BIN" /var/www/html/config/config.php
           volumeMounts:
             - name: app
               mountPath: /var/www/html


### PR DESCRIPTION
## Summary
- `notify_push` 1.3.x changed its CLI argument from the Nextcloud root directory to the explicit config file path
- The sidecar was crash-looping with "Failed to read config file" because we passed `/var/www/html` (a directory) instead of `/var/www/html/config/config.php`
- Also adds a readiness loop so the sidecar waits for `config.php` to exist before starting (handles race on first boot)

## Test plan
- [ ] Nextcloud pod starts with all 3 containers healthy (`nextcloud`, `nextcloud-cron`, `notify-push`)
- [ ] `notify-push` container no longer shows `CrashLoopBackOff`

🤖 Generated with [Claude Code](https://claude.com/claude-code)