### PR TITLE
fix(website): correct import depth in create-invoice.ts

### DIFF
--- a/website/src/pages/api/admin/billing/create-invoice.ts
+++ b/website/src/pages/api/admin/billing/create-invoice.ts
@@ -1,7 +1,7 @@
 import type { APIRoute } from 'astro';
-import { getSession, isAdmin } from '../../../../../lib/auth';
-import { createInvoice, type InvoiceLine } from '../../../../../lib/native-billing';
-import { getCustomerByEmail, createCustomer } from '../../../../../lib/native-billing';
+import { getSession, isAdmin } from '../../../../lib/auth';
+import { createInvoice, type InvoiceLine } from '../../../../lib/native-billing';
+import { getCustomerByEmail, createCustomer } from '../../../../lib/native-billing';
 
 export const POST: APIRoute = async ({ request }) => {
   const session = await getSession(request.headers.get('cookie'));


### PR DESCRIPTION
Build hotfix. create-invoice.ts uses 5 `../` to reach `lib/auth` but it's only 4 levels deep — resolves above src/ and breaks the prod build. Sibling files under `[id]/` are one level deeper, so theirs are correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)