### PR TITLE
fix(argocd): point mentolder at prod-mentolder overlay

### DIFF
--- a/Taskfile.argocd.yml
+++ b/Taskfile.argocd.yml
@@ -132,7 +132,7 @@ tasks:
           kubectl --context mentolder patch secret "$HETZNER_SECRET" -n argocd --type=json -p="[
             {\"op\":\"add\",\"path\":\"/metadata/labels/workspace\",\"value\":\"true\"},
             {\"op\":\"add\",\"path\":\"/metadata/annotations\",\"value\":{}},
-            {\"op\":\"add\",\"path\":\"/metadata/annotations/workspace-overlay\",\"value\":\"prod\"},
+            {\"op\":\"add\",\"path\":\"/metadata/annotations/workspace-overlay\",\"value\":\"prod-mentolder\"},
             {\"op\":\"add\",\"path\":\"/metadata/annotations/workspace-domain\",\"value\":\"${PROD_DOMAIN}\"},
             {\"op\":\"add\",\"path\":\"/metadata/annotations/workspace-brand\",\"value\":\"${BRAND_NAME}\"},
             {\"op\":\"add\",\"path\":\"/metadata/annotations/workspace-email\",\"value\":\"${CONTACT_EMAIL}\"},


### PR DESCRIPTION
## Summary
- `Taskfile.argocd.yml:135` registered the mentolder cluster Secret with `workspace-overlay=prod` instead of `prod-mentolder`
- `workspace-mentolder` ArgoCD Application has been syncing the shared `prod/` base since cluster registration on 2026-04-22
- Concrete drift on live mentolder: `backup-config` ConfigMap has literal `${BRAND_ID}` strings (compare `korczewski`: `BRAND=korczewski, FILEN_DEFAULT_UPLOAD_PATH=/Backup`)

## Test plan
- [ ] Re-run `task argocd:cluster:register` on a fresh hub and confirm `cluster-mentolder` Secret has annotation `workspace-overlay=prod-mentolder`
- [ ] Live cluster: `kubectl --context mentolder -n argocd annotate secret cluster-mentolder workspace-overlay=prod-mentolder --overwrite` → ArgoCD resync → `backup-config` ConfigMap should pick up `BRAND=mentolder, FILEN_DEFAULT_UPLOAD_PATH=/Backup`

🤖 Generated with [Claude Code](https://claude.com/claude-code)