### PR TITLE
feat(inhalte): integrate brand design-system assets into Inhalte editor

### DIFF
--- a/website/public/brand/korczewski/app.css
+++ b/website/public/brand/korczewski/app.css
@@ -1,0 +1,155 @@
+/* Kore — App shell + cross-cutting styles */
+html,body{background:var(--ink-900);color:var(--fg);min-height:100%;}
+body{position:relative;font-family:var(--sans);}
+
+/* film grain on dark surfaces */
+body::before{
+  content:""; position:fixed; inset:0; pointer-events:none; z-index:1;
+  background-image:url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='160' height='160'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' seed='4'/><feColorMatrix values='0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.05 0'/></filter><rect width='100%25' height='100%25' filter='url(%23n)'/></svg>");
+  opacity:.55; mix-blend-mode:overlay;
+}
+main{position:relative; z-index:2;}
+
+a{color:inherit;}
+
+/* =========================================================================
+   App shell — top tab nav between the five artifacts
+   ========================================================================= */
+.shell-nav{
+  position:sticky; top:0; z-index:50;
+  backdrop-filter: blur(14px);
+  background: rgba(18,13,28,.78);
+  border-bottom:1px solid var(--line);
+}
+.shell-nav-inner{
+  max-width:1440px; margin:0 auto;
+  padding:14px 28px;
+  display:flex; align-items:center; gap:24px;
+}
+.shell-brand{
+  display:flex; align-items:center; gap:12px;
+  font-family:var(--serif); font-size:22px; letter-spacing:-0.01em;
+  text-decoration:none; color:var(--fg);
+}
+.shell-brand .dot{color:var(--copper);}
+.shell-brand .sep{color:var(--mute-2); margin: 0 4px; font-size:18px;}
+.shell-brand .crumb{font-family:var(--mono); font-size:11px; letter-spacing:.16em; text-transform:uppercase; color:var(--mute);}
+.shell-tabs{
+  margin-left:auto;
+  display:flex; gap:2px; align-items:center;
+  padding:4px;
+  border:1px solid var(--line-2);
+  border-radius:999px;
+  background:rgba(255,255,255,.02);
+}
+.shell-tab{
+  font-family:var(--mono); font-size:11px;
+  letter-spacing:.14em; text-transform:uppercase;
+  padding:8px 14px; border-radius:999px;
+  color:var(--mute); cursor:pointer;
+  border:0; background:transparent;
+  transition: all 180ms var(--ease);
+  display:inline-flex; align-items:center; gap:8px;
+}
+.shell-tab:hover{color:var(--fg);}
+.shell-tab.active{
+  color:var(--copper-deep);
+  background:var(--copper);
+  box-shadow: var(--inner-copper);
+}
+.shell-tab .num{
+  font-size:9.5px; opacity:.7;
+}
+
+.shell-meta{
+  font-family:var(--mono); font-size:10.5px;
+  letter-spacing:.14em; text-transform:uppercase;
+  color:var(--mute); margin-left:8px;
+}
+
+/* generic buttons reused across views */
+.btn{
+  display:inline-flex; align-items:center; gap:10px;
+  padding:11px 20px; border-radius:999px;
+  font-family:var(--sans); font-size:14px; font-weight:500;
+  cursor:pointer; border:1px solid transparent; text-decoration:none;
+  transition: all 200ms var(--ease);
+}
+.btn.primary{
+  background:var(--copper); color:var(--copper-deep);
+  box-shadow: var(--inner-copper), 0 8px 16px -8px rgba(200,247,106,.45);
+}
+.btn.primary:hover{background:var(--copper-2);}
+.btn.primary:active{transform:translateY(1px);}
+.btn.ghost{background:transparent; color:var(--fg); border-color:var(--line-2);}
+.btn.ghost:hover{border-color:var(--copper);}
+.btn.sm{padding:8px 14px; font-size:12.5px;}
+.btn.dark-on-paper{background:var(--ink-900); color:var(--paper); box-shadow: var(--inner-copper);}
+.btn.dark-on-paper:hover{background:var(--ink-800);}
+.btn.paper-ghost{background:transparent; color:var(--ink-text); border-color:var(--line-paper);}
+.btn.paper-ghost:hover{border-color:var(--copper-print);}
+
+.eyebrow{
+  font-family:var(--mono);
+  font-size:11px; letter-spacing:.18em; text-transform:uppercase;
+  color:var(--copper);
+  display:inline-flex; align-items:center; gap:10px;
+}
+.eyebrow::before{
+  content:""; width:22px; height:1px; background:currentColor;
+}
+.eyebrow.no-rule::before{display:none;}
+.eyebrow.on-paper{color:var(--copper-print);}
+
+em.kore, .em{font-style:italic; color:var(--copper-2); font-weight:400;}
+.on-paper em.kore, .on-paper .em{color:var(--copper-print);}
+
+/* shared: status pill */
+.pill{
+  display:inline-flex; align-items:center; gap:6px;
+  padding:3px 10px; border-radius:999px;
+  font-family:var(--mono); font-size:10px;
+  letter-spacing:.12em; text-transform:uppercase;
+}
+.pill .dot{width:6px; height:6px; border-radius:50%;}
+.pill.ok{background:rgba(91,212,208,.10); color:var(--teal); border:1px solid rgba(91,212,208,.25);}
+.pill.ok .dot{background:var(--teal);}
+.pill.sync{background:rgba(200,247,106,.10); color:var(--copper); border:1px solid rgba(200,247,106,.25);}
+.pill.sync .dot{background:var(--copper); animation:pulse 1.4s ease-in-out infinite;}
+.pill.fail{background:rgba(226,107,107,.10); color:#E26B6B; border:1px solid rgba(226,107,107,.25);}
+.pill.fail .dot{background:#E26B6B;}
+.pill.paused{background:rgba(255,255,255,.04); color:var(--mute); border:1px solid var(--line-2);}
+.pill.paused .dot{background:var(--mute);}
+.pill.paid{background:rgba(91,212,208,.10); color:var(--teal-print); border:1px solid rgba(44,134,130,.30);}
+.pill.paid .dot{background:var(--teal-print);}
+@keyframes pulse{50%{opacity:.4;}}
+
+/* shared: paper documents (invoice, contract) */
+.paper-stage{
+  background: linear-gradient(180deg, var(--ink-900), var(--ink-850));
+  padding: 60px 28px 120px;
+  min-height: calc(100vh - 60px);
+}
+.paper-doc{
+  position:relative;
+  max-width: 880px;
+  margin: 0 auto;
+  background: var(--paper);
+  color: var(--ink-text);
+  border-radius: var(--r-paper);
+  box-shadow: var(--shadow-paper);
+  font-family: var(--sans);
+  overflow:hidden;
+}
+.paper-doc::before{
+  content:""; position:absolute; inset:0; pointer-events:none;
+  background:
+    radial-gradient(50% 35% at 100% 0%, rgba(200,247,106,.12), transparent 60%),
+    radial-gradient(45% 35% at 0% 100%, rgba(91,212,208,.10), transparent 60%);
+  z-index:0;
+}
+.paper-doc > *{position:relative; z-index:1;}
+
+/* shared body containers */
+.surface-paper-rule{border-bottom: 1px solid var(--line-paper);}
+.row-rule{border-top:1px solid var(--line);}

--- a/website/public/brand/korczewski/colors_and_type.css
+++ b/website/public/brand/korczewski/colors_and_type.css
@@ -1,0 +1,216 @@
+/* =========================================================================
+   Kore Design System — colors_and_type.css
+   Drop-in stylesheet. Loads fonts and exposes all design tokens.
+   ========================================================================= */
+
+@import url("https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Geist:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap");
+
+:root {
+  /* ---------- Color · Aubergine Ink (deep purple-black) ------------------ */
+  --ink-900: #120D1C;
+  --ink-850: #1A1326;
+  --ink-800: #221932;
+  --ink-750: #2C2240;
+  --ink-700: #3A2E52;
+
+  /* ---------- Color · Plasma Lime (brand accent) ------------------------- */
+  --copper:        #C8F76A;   /* legacy var name kept for token compat = lime */
+  --copper-2:      #D8FF8A;   /* hover / lighter */
+  --copper-soft:   #E6FFB0;   /* tints, decorative */
+  --copper-print:  #6B8B1F;   /* print-safe ink for paper docs */
+  --copper-deep:   #2A3A0C;   /* text on lime fills */
+  --copper-tint:   rgba(200,247,106,.08);
+  --copper-tint-2: rgba(200,247,106,.14);
+
+  /* aliased semantic names for clarity */
+  --lime:         var(--copper);
+  --lime-2:       var(--copper-2);
+  --lime-print:   var(--copper-print);
+  --lime-deep:    var(--copper-deep);
+
+  /* ---------- Color · Cyan (healthy / paid / secondary) ------------------ */
+  --teal:        #5BD4D0;
+  --teal-2:      #82E2DF;
+  --teal-print:  #2C8682;
+  --teal-tint:   rgba(91,212,208,.10);
+  --cyan:        var(--teal);
+  --cyan-2:      var(--teal-2);
+  --cyan-print:  var(--teal-print);
+
+  /* ---------- Color · Bone Paper (warm off-white, no yellow) ------------- */
+  --paper:    #EDE6D8;
+  --paper-2:  #E2DACA;
+  --paper-3:  #D2C9B6;
+
+  /* ---------- Color · Foreground / utility ------------------------------- */
+  --fg:       #ECEFF3;
+  --fg-soft:  #C6CCD4;
+  --mute:     #8A93A0;
+  --mute-2:   #69707B;
+
+  --ink-text:   #16101E;       /* on paper */
+  --ink-soft:   #382E48;
+  --ink-mute:   #6A5F7A;
+  --ink-mute-2: #948AA0;
+
+  --line:    rgba(255,255,255,.07);
+  --line-2:  rgba(255,255,255,.12);
+  --line-3:  rgba(255,255,255,.20);
+  --line-paper: rgba(15,23,36,.10);
+
+  /* ---------- Color · Semantic ------------------------------------------ */
+  --ok:      var(--teal);
+  --warn:    var(--copper);
+  --fail:    #E26B6B;
+  --info:    #6FA8D8;
+
+  /* ---------- Type families --------------------------------------------- */
+  --serif: "Instrument Serif", "Iowan Old Style", Georgia, serif;
+  --sans:  "Geist", ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
+  --mono:  "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+
+  /* ---------- Type · semantic roles ------------------------------------- */
+  --fs-display: 64px;   --lh-display: 1.02; --ls-display: -0.02em;
+  --fs-h1: 48px;        --lh-h1: 1.05;      --ls-h1: -0.02em;
+  --fs-h2: 34px;        --lh-h2: 1.1;       --ls-h2: -0.02em;
+  --fs-h3: 24px;        --lh-h3: 1.2;       --ls-h3: -0.01em;
+  --fs-h4: 18px;        --lh-h4: 1.3;       --ls-h4: -0.005em;
+  --fs-lede: 17px;      --lh-lede: 1.55;
+  --fs-body: 15px;      --lh-body: 1.55;
+  --fs-small: 13px;     --lh-small: 1.5;
+  --fs-eyebrow: 11px;   --lh-eyebrow: 1.4;  --ls-eyebrow: 0.18em;
+  --fs-mono: 12.5px;    --lh-mono: 1.6;
+
+  /* ---------- Spacing (4px base) ---------------------------------------- */
+  --s-0: 0;
+  --s-1: 4px;
+  --s-2: 8px;
+  --s-3: 12px;
+  --s-4: 16px;
+  --s-5: 20px;
+  --s-6: 24px;
+  --s-8: 32px;
+  --s-10: 40px;
+  --s-12: 48px;
+  --s-16: 64px;
+  --s-20: 80px;
+  --s-24: 96px;
+  --s-32: 128px;
+
+  /* ---------- Radii ------------------------------------------------------ */
+  --r-pill: 999px;
+  --r-tile: 22px;
+  --r-card: 16px;
+  --r-input: 10px;
+  --r-paper: 4px;
+  --r-chip: 6px;
+
+  /* ---------- Shadow / elevation ---------------------------------------- */
+  --shadow-1: 0 12px 24px -12px rgba(0,0,0,.5);
+  --shadow-2: 0 30px 60px -30px rgba(0,0,0,.6);
+  --shadow-paper: 0 30px 80px -30px rgba(15,8,28,.7);
+  --shadow-press: 0 4px 8px -4px rgba(0,0,0,.5);
+  --inner-copper: inset 0 1px 0 rgba(255,255,255,.25);
+  --inner-line:   inset 0 1px 0 var(--copper);
+
+  /* ---------- Motion ----------------------------------------------------- */
+  --ease: cubic-bezier(.2,.7,.2,1);
+  --dur-fast: 120ms;
+  --dur: 200ms;
+  --dur-slow: 320ms;
+}
+
+/* =========================================================================
+   Base type roles — use these classes instead of raw font-size.
+   ========================================================================= */
+
+.h-display, h1.display {
+  font-family: var(--serif);
+  font-weight: 400;
+  font-size: var(--fs-display);
+  line-height: var(--lh-display);
+  letter-spacing: var(--ls-display);
+}
+h1, .h1 {
+  font-family: var(--serif); font-weight: 400;
+  font-size: var(--fs-h1); line-height: var(--lh-h1); letter-spacing: var(--ls-h1);
+}
+h2, .h2 {
+  font-family: var(--serif); font-weight: 400;
+  font-size: var(--fs-h2); line-height: var(--lh-h2); letter-spacing: var(--ls-h2);
+}
+h3, .h3 {
+  font-family: var(--serif); font-weight: 400;
+  font-size: var(--fs-h3); line-height: var(--lh-h3); letter-spacing: var(--ls-h3);
+}
+h4, .h4 {
+  font-family: var(--sans); font-weight: 600;
+  font-size: var(--fs-h4); line-height: var(--lh-h4); letter-spacing: var(--ls-h4);
+}
+.lede, p.lede {
+  font-family: var(--sans); font-weight: 400;
+  font-size: var(--fs-lede); line-height: var(--lh-lede); color: var(--fg-soft);
+}
+body, p, .body {
+  font-family: var(--sans); font-weight: 400;
+  font-size: var(--fs-body); line-height: var(--lh-body);
+}
+.small {
+  font-size: var(--fs-small); line-height: var(--lh-small);
+}
+.mono, code, kbd, samp {
+  font-family: var(--mono);
+  font-size: var(--fs-mono);
+  line-height: var(--lh-mono);
+}
+.eyebrow {
+  font-family: var(--mono);
+  font-size: var(--fs-eyebrow);
+  letter-spacing: var(--ls-eyebrow);
+  text-transform: uppercase;
+  color: var(--copper);
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+}
+.eyebrow::before {
+  content: "";
+  width: 22px; height: 1px;
+  background: currentColor;
+  display: inline-block;
+}
+.eyebrow.no-rule::before { display: none; }
+
+/* italic emphasis used for product/service names */
+em, .em {
+  font-style: italic;
+  color: var(--copper-2);
+  font-weight: 400;
+}
+
+/* =========================================================================
+   Surfaces
+   ========================================================================= */
+
+.surface-dark { background: var(--ink-900); color: var(--fg); }
+.surface-paper { background: var(--paper); color: var(--ink-text); }
+
+/* Film grain — apply to body or hero containers */
+.grain::before {
+  content: "";
+  position: absolute; inset: 0;
+  pointer-events: none;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='160' height='160'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' seed='4'/><feColorMatrix values='0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.05 0'/></filter><rect width='100%25' height='100%25' filter='url(%23n)'/></svg>");
+  opacity: .55;
+  mix-blend-mode: overlay;
+  z-index: 0;
+}
+
+/* =========================================================================
+   Reset-ish bits
+   ========================================================================= */
+* { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; }
+body { -webkit-font-smoothing: antialiased; text-rendering: optimizeLegibility; }
+a { color: inherit; }
+button { font: inherit; }

--- a/website/public/brand/korczewski/logo-lockup-light.svg
+++ b/website/public/brand/korczewski/logo-lockup-light.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 96" width="320" height="96">
+  <defs>
+    <radialGradient id="coreGlowP" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#C8F76A" stop-opacity="0.55"></stop>
+      <stop offset="100%" stop-color="#6B8B1F" stop-opacity="0"></stop>
+    </radialGradient>
+  </defs>
+  <rect x="8" y="8" width="80" height="80" rx="18" ry="18" fill="#EDE6D8"></rect>
+  <circle cx="48" cy="48" r="26" fill="url(#coreGlowP)"></circle>
+  <circle cx="48" cy="48" r="20" fill="none" stroke="#6B8B1F" stroke-opacity=".25" stroke-width="1"></circle>
+  <circle cx="48" cy="48" r="14" fill="none" stroke="#6B8B1F" stroke-opacity=".4" stroke-width="1"></circle>
+  <g stroke="#6B8B1F" stroke-linecap="round" fill="none">
+    <line x1="33" y1="18" x2="33" y2="78" stroke-width="6.5"></line>
+    <line x1="34" y1="48" x2="70" y2="22" stroke-width="6"></line>
+    <line x1="34" y1="48" x2="70" y2="74" stroke-width="6"></line>
+  </g>
+  <circle cx="34" cy="48" r="5" fill="#8FBE2E"></circle>
+  <circle cx="34" cy="48" r="8" fill="none" stroke="#8FBE2E" stroke-opacity=".5" stroke-width="1"></circle>
+  <text x="106" y="62" font-family="Instrument Serif, Georgia, serif" font-size="42" font-weight="400" fill="#16101E" letter-spacing="-0.5">Kore<tspan fill="#6B8B1F">.</tspan></text>
+</svg>

--- a/website/public/brand/korczewski/starters/questionnaire.html
+++ b/website/public/brand/korczewski/starters/questionnaire.html
@@ -1,0 +1,227 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Kore — Onboarding questionnaire</title>
+<link rel="stylesheet" href="/brand/korczewski/colors_and_type.css">
+<link rel="stylesheet" href="/brand/korczewski/app.css">
+<style>
+  body{padding:32px 28px 96px;}
+  .q{max-width:760px; margin:0 auto; position:relative; z-index:2;}
+
+  /* Header strip */
+  .strip{display:grid; grid-template-columns:auto 1fr auto; gap:18px; align-items:center; padding:14px 18px; border:1px solid var(--line-2); border-radius:14px; background:var(--ink-850); margin-bottom:32px;}
+  .strip .brand{display:flex; align-items:center; gap:10px; font-family:var(--serif); font-size:18px; letter-spacing:-0.01em;}
+  .strip .brand .dot{color:var(--copper);}
+  .strip .save{font-family:var(--mono); font-size:10px; letter-spacing:.18em; text-transform:uppercase; color:var(--mute); display:flex; align-items:center; gap:8px;}
+  .strip .save .dot{width:6px; height:6px; border-radius:50%; background:var(--teal); box-shadow:0 0 0 4px rgba(91,212,208,.18); animation:pulse 1.6s ease-in-out infinite;}
+
+  /* Hero */
+  .hero{margin-bottom:40px;}
+  .hero .eye{font-family:var(--mono); font-size:11px; letter-spacing:.18em; text-transform:uppercase; color:var(--copper); display:inline-flex; gap:10px; align-items:center;}
+  .hero .eye::before{content:""; width:22px; height:1px; background:currentColor;}
+  .hero h1{font-family:var(--serif); font-weight:400; font-size:48px; letter-spacing:-0.025em; line-height:1.05; margin:14px 0 0; max-width:18ch;}
+  .hero h1 em{font-style:italic; color:var(--copper-2);}
+  .hero p{font-family:var(--sans); font-size:16px; line-height:1.55; color:var(--fg-soft); margin:18px 0 0; max-width:60ch;}
+
+  /* Progress */
+  .prog{margin:28px 0 40px; display:flex; align-items:center; gap:18px;}
+  .prog .bar{flex:1; height:2px; background:var(--line-2); border-radius:1px; overflow:hidden; position:relative;}
+  .prog .bar i{position:absolute; left:0; top:0; bottom:0; background:var(--copper); width:62%;}
+  .prog .lab{font-family:var(--mono); font-size:10.5px; letter-spacing:.16em; text-transform:uppercase; color:var(--mute); white-space:nowrap;}
+  .prog .lab b{color:var(--copper); font-weight:500;}
+
+  /* Section */
+  .sec{padding:32px 0; border-top:1px solid var(--line);}
+  .sec:first-of-type{border-top:0; padding-top:0;}
+  .sec-head{display:grid; grid-template-columns:60px 1fr; gap:18px; align-items:baseline; margin-bottom:24px;}
+  .sec-head .num{font-family:var(--mono); font-size:11px; letter-spacing:.18em; color:var(--copper); text-transform:uppercase;}
+  .sec-head h2{font-family:var(--serif); font-weight:400; font-size:30px; letter-spacing:-0.02em; margin:0;}
+  .sec-head h2 em{font-style:italic; color:var(--copper-2);}
+
+  /* Question */
+  .q-row{display:grid; grid-template-columns:60px 1fr; gap:18px; padding:22px 0; border-top:1px dashed var(--line);}
+  .q-row:first-child{border-top:0;}
+  .q-row .qn{font-family:var(--mono); font-size:11px; letter-spacing:.14em; color:var(--mute); text-transform:uppercase; padding-top:3px;}
+  .q-row .ql{font-family:var(--serif); font-size:21px; letter-spacing:-0.01em; line-height:1.3; color:var(--fg);}
+  .q-row .ql em{font-style:italic; color:var(--copper-2);}
+  .q-row .help{font-family:var(--sans); font-size:13.5px; line-height:1.5; color:var(--fg-soft); margin-top:6px;}
+  .q-row .ans{margin-top:14px;}
+
+  /* Controls */
+  input.txt, textarea.txt{
+    width:100%; font:inherit; font-family:var(--sans); font-size:15px; color:var(--fg);
+    background:var(--ink-850); border:1px solid var(--line-2); border-radius:10px;
+    padding:14px 16px; outline:none; transition:all 200ms var(--ease);
+  }
+  textarea.txt{min-height:96px; resize:vertical; line-height:1.5;}
+  input.txt:focus, textarea.txt:focus{border-color:var(--copper); background:var(--ink-800); box-shadow:inset 0 1px 0 rgba(200,247,106,.2);}
+  input.txt::placeholder, textarea.txt::placeholder{color:var(--mute);}
+  .field-foot{display:flex; justify-content:space-between; margin-top:6px; font-family:var(--mono); font-size:10px; letter-spacing:.14em; text-transform:uppercase; color:var(--mute);}
+
+  .opts{display:grid; gap:8px;}
+  .opt{display:flex; align-items:flex-start; gap:14px; padding:14px 16px; border:1px solid var(--line-2); border-radius:12px; background:var(--ink-850); cursor:pointer; transition:all 200ms var(--ease);}
+  .opt:hover{border-color:var(--line-3);}
+  .opt.sel{border-color:var(--copper); background:var(--copper-tint);}
+  .opt .box{flex-shrink:0; width:18px; height:18px; border:1px solid var(--line-3); border-radius:5px; margin-top:2px; display:flex; align-items:center; justify-content:center;}
+  .opt.radio .box{border-radius:50%;}
+  .opt.sel .box{border-color:var(--copper); background:var(--copper);}
+  .opt.sel .box::after{content:""; width:8px; height:8px; border-radius:2px; background:var(--copper-deep);}
+  .opt.radio.sel .box::after{border-radius:50%;}
+  .opt .lab{font-family:var(--sans); font-size:14.5px; color:var(--fg);}
+  .opt .lab em{font-style:italic; color:var(--copper-2);}
+  .opt .sub{font-family:var(--mono); font-size:10.5px; letter-spacing:.06em; color:var(--mute); margin-top:4px;}
+
+  .opts-grid{display:grid; grid-template-columns:repeat(2,1fr); gap:8px;}
+
+  /* Segmented */
+  .seg{display:flex; padding:3px; border:1px solid var(--line-2); border-radius:999px; background:var(--ink-850); width:fit-content;}
+  .seg button{font-family:var(--mono); font-size:11px; letter-spacing:.14em; text-transform:uppercase; padding:8px 16px; border-radius:999px; color:var(--mute); border:0; background:transparent; cursor:pointer; transition:all 180ms var(--ease);}
+  .seg button.active{color:var(--copper-deep); background:var(--copper); box-shadow:var(--inner-copper);}
+
+  /* Slider */
+  .slider-wrap{margin-top:10px;}
+  .slider-wrap .ticks{display:flex; justify-content:space-between; font-family:var(--mono); font-size:9.5px; letter-spacing:.16em; text-transform:uppercase; color:var(--mute); margin-top:8px;}
+  .slider-wrap .v{font-family:var(--serif); font-size:30px; letter-spacing:-0.01em; line-height:1; color:var(--fg);}
+  .slider-wrap .v em{font-style:italic; color:var(--copper-2);}
+  .slider-wrap .v .u{font-family:var(--mono); font-size:12px; color:var(--mute); margin-left:4px;}
+  input[type=range].kr{
+    -webkit-appearance:none; appearance:none; width:100%; height:4px;
+    background:var(--line-2); border-radius:2px; outline:none; margin:14px 0 0;
+  }
+  input[type=range].kr::-webkit-slider-thumb{
+    -webkit-appearance:none; width:18px; height:18px; border-radius:50%;
+    background:var(--copper); box-shadow:0 0 0 4px rgba(200,247,106,.18);
+    cursor:pointer;
+  }
+
+  /* Footer actions */
+  .actions{margin-top:48px; display:flex; align-items:center; gap:14px; padding-top:24px; border-top:1px solid var(--line);}
+  .actions .meta{font-family:var(--mono); font-size:10.5px; letter-spacing:.14em; text-transform:uppercase; color:var(--mute);}
+  .actions .right{margin-left:auto; display:flex; gap:10px;}
+</style>
+</head>
+<body>
+<main>
+  <form class="q" onsubmit="event.preventDefault();">
+    <div class="strip">
+      <div class="brand"><img src="../../assets/logo-mark.svg" width="26" height="26">Kore<span class="dot">.</span></div>
+      <span class="save"><span class="dot"></span>Saved 14:02 CET · auto</span>
+      <a class="btn ghost sm">Save & exit</a>
+    </div>
+
+    <header class="hero">
+      <span class="eye">Onboarding · 03 of 04</span>
+      <h1>Tell us about your <em>cluster,</em> not yourself.</h1>
+      <p>Eight questions, takes about six minutes. We'll use your answers to draft a runbook before our intro call — so we can spend the call talking, not asking.</p>
+    </header>
+
+    <div class="prog">
+      <span class="lab"><b>Section 03</b> / 04 · Operations</span>
+      <div class="bar"><i></i></div>
+      <span class="lab">62%</span>
+    </div>
+
+    <section class="sec">
+      <div class="sec-head">
+        <span class="num">§01</span>
+        <h2>The <em>shape</em> of things.</h2>
+      </div>
+
+      <div class="q-row">
+        <span class="qn">Q1</span>
+        <div>
+          <div class="ql">Where does your control plane <em>live</em>?</div>
+          <div class="help">Pick all that apply. We've worked with each.</div>
+          <div class="ans opts opts-grid">
+            <div class="opt sel"><div class="box"></div><div><div class="lab">EKS · AWS</div><div class="sub">us-east-1, eu-west-1</div></div></div>
+            <div class="opt sel"><div class="box"></div><div><div class="lab">GKE · GCP</div><div class="sub">europe-west3</div></div></div>
+            <div class="opt"><div class="box"></div><div><div class="lab">AKS · Azure</div><div class="sub">—</div></div></div>
+            <div class="opt"><div class="box"></div><div><div class="lab">Bare metal / colo</div><div class="sub">Equinix · Hetzner · own racks</div></div></div>
+          </div>
+        </div>
+      </div>
+
+      <div class="q-row">
+        <span class="qn">Q2</span>
+        <div>
+          <div class="ql">How many <em>nodes</em>, roughly?</div>
+          <div class="help">A range is fine. We'll calibrate during adoption.</div>
+          <div class="ans slider-wrap">
+            <div class="v">42<span class="u">nodes</span> · <em>3</em> regions</div>
+            <input type="range" class="kr" min="1" max="200" value="42">
+            <div class="ticks"><span>1</span><span>50</span><span>100</span><span>150</span><span>200+</span></div>
+          </div>
+        </div>
+      </div>
+
+      <div class="q-row">
+        <span class="qn">Q3</span>
+        <div>
+          <div class="ql">Single tenant or <em>multi-tenant</em>?</div>
+          <div class="ans"><div class="seg">
+            <button type="button">Single</button>
+            <button type="button" class="active">Multi-tenant</button>
+            <button type="button">Both, separately</button>
+          </div></div>
+        </div>
+      </div>
+    </section>
+
+    <section class="sec">
+      <div class="sec-head">
+        <span class="num">§02</span>
+        <h2>The <em>boring</em> stuff.</h2>
+      </div>
+
+      <div class="q-row">
+        <span class="qn">Q4</span>
+        <div>
+          <div class="ql">Who carries the pager today?</div>
+          <div class="help">If "everyone" — give an estimate of the rotation size.</div>
+          <div class="ans opts">
+            <div class="opt radio"><div class="box"></div><div class="lab">A dedicated SRE team</div></div>
+            <div class="opt radio sel"><div class="box"></div><div class="lab">Platform engineers, on rotation</div></div>
+            <div class="opt radio"><div class="box"></div><div class="lab">Whoever wrote the service</div></div>
+            <div class="opt radio"><div class="box"></div><div class="lab">Nobody — alerts just pile up</div></div>
+          </div>
+        </div>
+      </div>
+
+      <div class="q-row">
+        <span class="qn">Q5</span>
+        <div>
+          <div class="ql">Tell us about the <em>last incident</em> in one paragraph.</div>
+          <div class="help">No need to anonymise. We sign an MNDA before reading.</div>
+          <div class="ans">
+            <textarea class="txt" placeholder="What broke, when did you notice, how did you fix it, and what would have prevented it?">etcd quorum loss in eu-west-1 on 2026-04-09 around 03:14 CET. Noticed via PagerDuty after about 9 minutes — third-party check beat our own. Fixed by snapshot restore from a 02:55 backup; lost ~18 minutes of audit-log writes. Would have been prevented by the cross-AZ etcd we keep saying we'll do.</textarea>
+            <div class="field-foot"><span>463 / 2000</span><span>Markdown OK</span></div>
+          </div>
+        </div>
+      </div>
+
+      <div class="q-row">
+        <span class="qn">Q6</span>
+        <div>
+          <div class="ql">Acceptable <em>downtime</em> per quarter?</div>
+          <div class="ans"><div class="seg">
+            <button type="button">0 min</button>
+            <button type="button" class="active">≤ 30 min</button>
+            <button type="button">≤ 2 h</button>
+            <button type="button">It depends</button>
+          </div></div>
+        </div>
+      </div>
+    </section>
+
+    <div class="actions">
+      <span class="meta">Section 03 of 04 · Operations</span>
+      <div class="right">
+        <a class="btn ghost">← Back</a>
+        <a class="btn primary">Continue → §04</a>
+      </div>
+    </div>
+  </form>
+</main>
+</body>
+</html>

--- a/website/public/brand/mentolder/colors_and_type.css
+++ b/website/public/brand/mentolder/colors_and_type.css
@@ -1,0 +1,214 @@
+/* =====================================================================
+   Mentolder — Colors & Typography
+   The single source of truth for tokens. Mirrors src/styles/global.css
+   from the production website (Astro + Svelte).
+   ===================================================================== */
+
+/* ---------- Webfonts (Google Fonts CDN) -------------------------------- */
+@import url("https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,300;0,6..72,400;0,6..72,500;0,6..72,600;1,6..72,400&family=Geist:wght@300;400;500;600;700&family=Geist+Mono:wght@400;500&display=swap");
+
+:root {
+  /* ---------- Ink palette (deep navy base, slightly warm) -------------- */
+  --ink-900: #0b111c;        /* page base */
+  --ink-850: #101826;        /* elevated panels (footer, "why" section) */
+  --ink-800: #17202e;        /* cards, quote panel */
+  --ink-750: #1d2736;        /* subtle alternate */
+
+  /* ---------- Foreground / text -------------------------------------- */
+  --fg:      #eef1f3;        /* primary text — warm off-white */
+  --fg-soft: #cdd3d9;        /* body / ledes */
+  --mute:    #8c96a3;        /* captions, meta */
+  --mute-2:  #6a727e;        /* deep meta (footer bottom) */
+
+  /* ---------- Brass accent (primary) --------------------------------- */
+  --brass:   oklch(0.80 0.09 75);            /* CTAs, eyebrows */
+  --brass-2: oklch(0.86 0.09 75);            /* hover, italic accent */
+  --brass-d: oklch(0.80 0.09 75 / .14);      /* tinted fills */
+  --brass-deep: #8a6a2a;                     /* gradient base of brand mark */
+  --brass-hex: #cda260;                      /* approximate hex for non-OKLCH contexts (PDF, email) */
+
+  /* ---------- Sage accent (secondary, calm) -------------------------- */
+  --sage:    oklch(0.80 0.06 160);
+
+  /* ---------- Semantic ----------------------------------------------- */
+  --success: oklch(0.80 0.06 160);
+  --danger:  oklch(0.62 0.18 22);
+  --info:    oklch(0.70 0.10 230);
+
+  /* ---------- Print/Invoice palette (warm paper) --------------------- */
+  --paper:     #f6f3ee;
+  --paper-2:   #efeae1;
+  --paper-ink: #1a2030;
+  --paper-ink-soft: #3a4150;
+  --paper-mute: #6a717e;
+  --paper-line: #d4cfc6;
+
+  /* ---------- Hairlines / dividers ----------------------------------- */
+  --line:   rgba(255, 255, 255, 0.07);
+  --line-2: rgba(255, 255, 255, 0.12);
+
+  /* ---------- Type families ------------------------------------------ */
+  --serif: "Newsreader", "Iowan Old Style", Georgia, serif;
+  --sans:  "Geist", ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
+  --mono:  "Geist Mono", ui-monospace, "SFMono-Regular", Menlo, monospace;
+
+  /* ---------- Type scale (semantic) ---------------------------------- */
+  --t-h1-size:   clamp(44px, 6.2vw, 88px);
+  --t-h1-weight: 350;
+  --t-h1-leading: 1.02;
+  --t-h1-tracking: -0.02em;
+
+  --t-h2-size:   clamp(32px, 3.6vw, 48px);
+  --t-h2-weight: 400;
+  --t-h2-leading: 1.1;
+  --t-h2-tracking: -0.02em;
+
+  --t-h3-size:   22px;        /* sans variant */
+  --t-h3-serif-size: 28px;    /* offer-row / editorial variant */
+  --t-h3-weight: 500;
+
+  --t-lede-size: 20px;
+  --t-body-size: 16px;
+  --t-small-size: 14px;
+  --t-eyebrow-size: 11px;
+  --t-eyebrow-tracking: 0.18em;
+
+  /* ---------- Radii --------------------------------------------------- */
+  --radius:    22px;          /* large cards, frames */
+  --radius-md: 12px;          /* fields, smaller cards */
+  --radius-sm: 8px;           /* brand mark, badges */
+  --radius-xs: 4px;           /* portrait frame */
+  --radius-pill: 999px;       /* buttons, pills, slot tags */
+
+  /* ---------- Spacing ------------------------------------------------- */
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 14px;
+  --space-4: 22px;
+  --space-5: 36px;
+  --space-6: 56px;
+  --space-7: 80px;
+  --space-8: 120px;          /* section vertical rhythm (desktop) */
+
+  /* ---------- Layout -------------------------------------------------- */
+  --maxw: 1240px;
+  --gutter: 40px;
+  --gutter-mobile: 22px;
+
+  /* ---------- Shadows ------------------------------------------------- */
+  /* The system mostly avoids shadows — relies on hairlines + halos.    */
+  --shadow-portrait:
+    0 40px 80px -30px rgba(0, 0, 0, .75),
+    0 2px 0 0 rgba(255, 255, 255, .04),
+    inset 0 0 0 1px var(--line-2);
+  --shadow-card:
+    0 1px 0 0 rgba(255,255,255,.03),
+    inset 0 0 0 1px var(--line);
+
+  /* ---------- Motion -------------------------------------------------- */
+  --ease-soft: cubic-bezier(.22, .61, .36, 1);
+  --ease-out:  cubic-bezier(.2, .8, .2, 1);
+  --dur-fast: 150ms;
+  --dur-base: 200ms;
+  --dur-slow: 500ms;
+  --dur-portrait: 800ms;
+}
+
+/* =====================================================================
+   Semantic typography (apply directly to elements where possible)
+   ===================================================================== */
+html { -webkit-font-smoothing: antialiased; text-rendering: optimizeLegibility; }
+
+body {
+  font-family: var(--sans);
+  font-size: var(--t-body-size);
+  line-height: 1.55;
+  letter-spacing: -0.005em;
+  color: var(--fg);
+  background: var(--ink-900);
+}
+
+h1, .t-h1 {
+  font-family: var(--serif);
+  font-size: var(--t-h1-size);
+  font-weight: var(--t-h1-weight);
+  line-height: var(--t-h1-leading);
+  letter-spacing: var(--t-h1-tracking);
+  color: var(--fg);
+  margin: 0;
+}
+h1 em, .t-h1 em { font-style: italic; font-weight: 400; color: var(--brass-2); }
+
+h2, .t-h2 {
+  font-family: var(--serif);
+  font-size: var(--t-h2-size);
+  font-weight: var(--t-h2-weight);
+  line-height: var(--t-h2-leading);
+  letter-spacing: var(--t-h2-tracking);
+  color: var(--fg);
+  margin: 0;
+}
+h2 em, .t-h2 em { font-style: italic; font-weight: 400; color: var(--brass-2); }
+
+h3, .t-h3 {
+  font-family: var(--sans);
+  font-size: var(--t-h3-size);
+  font-weight: var(--t-h3-weight);
+  line-height: 1.25;
+  letter-spacing: -0.01em;
+  color: var(--fg);
+  margin: 0;
+}
+.t-h3-serif {
+  font-family: var(--serif);
+  font-size: var(--t-h3-serif-size);
+  font-weight: 400;
+  letter-spacing: -0.015em;
+}
+
+.t-lede {
+  font-size: var(--t-lede-size);
+  line-height: 1.55;
+  color: var(--fg-soft);
+  max-width: 56ch;
+}
+
+p, .t-body { font-size: var(--t-body-size); color: var(--fg-soft); margin: 0; }
+
+.t-small  { font-size: var(--t-small-size); color: var(--mute); }
+
+.t-eyebrow {
+  font-family: var(--mono);
+  font-size: var(--t-eyebrow-size);
+  letter-spacing: var(--t-eyebrow-tracking);
+  text-transform: uppercase;
+  color: var(--brass);
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+}
+.t-eyebrow::before {
+  content: ""; width: 22px; height: 1px; background: currentColor; opacity: .8;
+}
+
+.t-kicker {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--mute);
+}
+
+.t-mono   { font-family: var(--mono); }
+.t-serif  { font-family: var(--serif); }
+.t-sans   { font-family: var(--sans);  }
+
+/* Stat number style */
+.t-stat {
+  font-family: var(--serif);
+  font-size: 44px;
+  line-height: 1;
+  letter-spacing: -0.02em;
+  color: var(--fg);
+}
+.t-stat em { color: var(--brass); font-style: normal; }

--- a/website/public/brand/mentolder/print.css
+++ b/website/public/brand/mentolder/print.css
@@ -1,0 +1,65 @@
+/* Print/document shared styles — invoice, contract, questionnaire, newsletter.
+   Warm-paper palette. Kept lean so each document HTML can override locally. */
+@import url("colors_and_type.css");
+
+*{box-sizing:border-box}
+html,body{margin:0;padding:0}
+body{
+  font-family:var(--sans);
+  background:#dad4c8;
+  color:var(--paper-ink);
+  font-size:14px; line-height:1.55;
+  letter-spacing:-0.005em;
+  padding:40px 0;
+}
+.page{
+  width:794px; min-height:1123px; /* A4 @ 96dpi */
+  margin:0 auto 32px;
+  background:var(--paper);
+  color:var(--paper-ink);
+  padding:64px 72px;
+  position:relative;
+  box-shadow: 0 24px 60px -20px rgba(0,0,0,.35);
+}
+.page::before{
+  content:""; position:absolute; left:0; right:0; top:0; height:4px;
+  background:linear-gradient(to right, transparent, #A8823A 30%, #A8823A 70%, transparent);
+  opacity:.7;
+}
+
+.brand-row{display:flex;align-items:center;gap:14px;}
+.brand-row img{width:36px;height:36px;display:block;}
+.brand-row .name{font-family:var(--serif);font-size:24px;letter-spacing:-0.01em;color:var(--paper-ink);}
+.brand-row .dot{color:#A8823A;}
+
+.eyebrow-print{font-family:var(--mono);font-size:10px;letter-spacing:.18em;text-transform:uppercase;color:#A8823A;display:inline-flex;align-items:center;gap:10px;}
+.eyebrow-print::before{content:"";width:22px;height:1px;background:currentColor;opacity:.8;}
+
+h1.print{font-family:var(--serif);font-weight:350;font-size:42px;line-height:1.05;letter-spacing:-0.02em;color:var(--paper-ink);margin:0;}
+h1.print em{font-style:italic;font-weight:400;color:#A8823A;}
+h2.print{font-family:var(--serif);font-weight:400;font-size:24px;line-height:1.2;letter-spacing:-0.01em;color:var(--paper-ink);margin:0;}
+h3.print{font-family:var(--sans);font-weight:600;font-size:14px;letter-spacing:-0.005em;color:var(--paper-ink);margin:0;}
+
+.kicker-print{font-family:var(--mono);font-size:10px;letter-spacing:.16em;text-transform:uppercase;color:var(--paper-mute);}
+.muted{color:var(--paper-mute);}
+.small{font-size:12px;}
+
+.rule{height:1px;background:var(--paper-line);border:0;}
+
+table.t{width:100%;border-collapse:collapse;}
+table.t th,table.t td{text-align:left;padding:14px 12px;font-size:14px;}
+table.t th{font-family:var(--mono);font-size:10px;letter-spacing:.14em;text-transform:uppercase;color:var(--paper-mute);font-weight:500;border-bottom:1px solid var(--paper-line);}
+table.t td{border-bottom:1px solid var(--paper-line);}
+table.t .num{text-align:right;font-variant-numeric:tabular-nums;}
+
+.totals{display:flex;justify-content:flex-end;margin-top:14px;}
+.totals dl{display:grid;grid-template-columns:auto auto;gap:4px 32px;font-size:14px;min-width:280px;}
+.totals dt{color:var(--paper-mute);}
+.totals dd{margin:0;text-align:right;font-variant-numeric:tabular-nums;}
+.totals .grand{font-family:var(--serif);font-size:24px;color:var(--paper-ink);letter-spacing:-0.01em;padding-top:10px;border-top:1px solid var(--paper-line);margin-top:6px;}
+.totals .grand-l{padding-top:10px;border-top:1px solid var(--paper-line);margin-top:6px;color:var(--paper-ink);font-weight:600;}
+
+.foot-print{margin-top:48px;padding-top:18px;border-top:1px solid var(--paper-line);
+  display:grid;grid-template-columns:repeat(3,1fr);gap:24px;font-size:11px;color:var(--paper-mute);}
+.foot-print h5{font-family:var(--mono);font-size:10px;letter-spacing:.14em;text-transform:uppercase;color:#A8823A;margin:0 0 6px;font-weight:500;}
+.foot-print p{margin:2px 0;}

--- a/website/public/brand/mentolder/starters/questionnaire.html
+++ b/website/public/brand/mentolder/starters/questionnaire.html
@@ -1,0 +1,93 @@
+<!doctype html>
+<html lang="de"><head><meta charset="utf-8" />
+<title>Mentolder — Fragebogen</title>
+<link rel="stylesheet" href="/brand/mentolder/colors_and_type.css" />
+<link rel="stylesheet" href="/brand/mentolder/print.css" />
+<style>
+.q{padding:22px 0;border-bottom:1px solid var(--paper-line);}
+.q:last-child{border-bottom:none;}
+.q .num{font-family:var(--mono);font-size:10px;letter-spacing:.16em;color:#A8823A;text-transform:uppercase;}
+.q .qt{font-family:var(--serif);font-size:20px;font-weight:400;letter-spacing:-0.01em;color:var(--paper-ink);margin:6px 0 4px;line-height:1.25;}
+.q .help{color:var(--paper-mute);font-size:13px;margin:4px 0 14px;line-height:1.55;}
+.choices{display:flex;flex-direction:column;gap:8px;}
+.choice{display:flex;align-items:center;gap:12px;padding:10px 14px;border:1px solid var(--paper-line);border-radius:10px;background:var(--paper);font-size:14px;color:var(--paper-ink);cursor:pointer;}
+.choice .box{width:16px;height:16px;border:1.5px solid #A8823A;border-radius:4px;flex:0 0 16px;display:inline-block;}
+.choice.checked{border-color:#A8823A;background:rgba(168,130,58,.08);}
+.choice.checked .box{background:#A8823A;position:relative;}
+.choice.checked .box::after{content:"";position:absolute;left:3px;top:0;width:5px;height:9px;border:solid #fff;border-width:0 2px 2px 0;transform:rotate(45deg);}
+.field{width:100%;border:1px solid var(--paper-line);border-radius:10px;background:var(--paper);padding:12px 14px;font-family:var(--sans);font-size:14px;color:var(--paper-ink);min-height:80px;}
+.field.short{min-height:auto;}
+.scale{display:grid;grid-template-columns:repeat(7,1fr);gap:8px;}
+.scale .s{aspect-ratio:1/1;border:1px solid var(--paper-line);border-radius:50%;display:flex;align-items:center;justify-content:center;font-family:var(--mono);font-size:12px;color:var(--paper-mute);}
+.scale .s.on{background:#A8823A;color:#fff;border-color:#A8823A;}
+.scale-l{display:flex;justify-content:space-between;font-family:var(--mono);font-size:10px;letter-spacing:.14em;color:var(--paper-mute);text-transform:uppercase;margin-top:8px;}
+</style>
+</head>
+<body>
+<div class="page">
+  <div style="display:flex;justify-content:space-between;align-items:flex-start;">
+    <div class="brand-row"><img src="/icon-128.png" alt="" /><span class="name">mentolder<span class="dot">.</span></span></div>
+    <div style="text-align:right;">
+      <div class="eyebrow-print">Vorbereitung Erstgespräch</div>
+      <div class="kicker-print" style="margin-top:6px;">10 Minuten · ehrlich, nicht perfekt</div>
+    </div>
+  </div>
+
+  <hr class="rule" style="margin:32px 0 28px;" />
+
+  <h1 class="print">Damit unser Gespräch nicht <em>bei Null beginnt.</em></h1>
+  <p class="muted" style="margin-top:14px;font-size:14px;line-height:1.65;max-width:60ch;">
+    Bevor wir uns sehen, möchte ich Ihre Situation grob verstehen. Beantworten Sie bitte nur das, was sich für Sie passend anfühlt — Lücken sind kein Problem.
+  </p>
+
+  <div style="margin-top:30px;">
+
+    <div class="q">
+      <div class="num">01 — Kontext</div>
+      <div class="qt">Wo stehen Sie aktuell beruflich?</div>
+      <div class="help">Eine bis drei Sätze reichen.</div>
+      <div class="field">Ich leite seit 8 Jahren den Bereich Vertrieb in einem mittelständischen Industrie-Unternehmen. Aktuell überlege ich, mich auf eine Geschäftsführungs-Position bei einem ehemaligen Wettbewerber zu bewerben.</div>
+    </div>
+
+    <div class="q">
+      <div class="num">02 — Anlass</div>
+      <div class="qt">Was hat Sie heute zu mir geführt?</div>
+      <div class="choices">
+        <label class="choice checked"><span class="box"></span>Ich denke über eine berufliche Veränderung nach.</label>
+        <label class="choice"><span class="box"></span>Ich bereite mich auf ein konkretes Gespräch vor.</label>
+        <label class="choice"><span class="box"></span>Ich möchte mein Profil schärfen — ohne Wechsel-Druck.</label>
+        <label class="choice"><span class="box"></span>Etwas anderes (gerne unten beschreiben).</label>
+      </div>
+    </div>
+
+    <div class="q">
+      <div class="num">03 — Selbsteinschätzung</div>
+      <div class="qt">Wie klar fühlen Sie sich aktuell über Ihre nächste Station?</div>
+      <div class="scale">
+        <div class="s">1</div><div class="s">2</div><div class="s">3</div><div class="s on">4</div><div class="s">5</div><div class="s">6</div><div class="s">7</div>
+      </div>
+      <div class="scale-l"><span>Diffus</span><span>Glasklar</span></div>
+    </div>
+
+    <div class="q">
+      <div class="num">04 — Erwartung</div>
+      <div class="qt">Was wäre für Sie ein gutes Ergebnis unserer Zusammenarbeit?</div>
+      <div class="field">Ich möchte wissen, ob ich für die GF-Rolle wirklich geeignet bin — und falls ja, wie ich mich im Bewerbungsprozess so präsentiere, dass meine Stärken klar werden.</div>
+    </div>
+
+    <div class="q">
+      <div class="num">05 — Sonstiges</div>
+      <div class="qt">Gibt es etwas, das ich vorab wissen sollte?</div>
+      <div class="help">Persönliche Themen, Gesundheit, Familie — alles, was Einfluss auf Tempo und Format hat.</div>
+      <div class="field short" style="min-height:48px;"></div>
+    </div>
+
+  </div>
+
+  <div class="foot-print">
+    <div><h5>Versand</h5><p>info@mentolder.de</p><p>oder im Erstgespräch besprechen</p></div>
+    <div><h5>Vertraulichkeit</h5><p>Alle Angaben bleiben streng vertraulich</p><p>(§ 4 Coaching-Vertrag)</p></div>
+    <div><h5>Mentolder</h5><p>Gerald Korczewski</p><p>Lüneburg · DE</p></div>
+  </div>
+</div>
+</body></html>

--- a/website/src/components/admin/InhalteEditor.svelte
+++ b/website/src/components/admin/InhalteEditor.svelte
@@ -35,7 +35,7 @@
     customSections: CustomSectionType[];
   };
 
-  let { initialData, rechnungsvorlagen }: { initialData: InitialData; rechnungsvorlagen: RechnungsvorlagenData } = $props();
+  let { initialData, rechnungsvorlagen, brand = 'mentolder' }: { initialData: InitialData; rechnungsvorlagen: RechnungsvorlagenData; brand?: string } = $props();
 
   type RechnungsvorlagenData = {
     invoice_intro_text: string;
@@ -186,6 +186,18 @@
     {:else if activeTab === 'fragebogen'}
       <div class="pt-6 pb-20">
         <QuestionnaireTemplateEditor />
+        <div class="mt-8 pt-6 border-t border-dark-lighter/60">
+          <p class="text-xs text-muted mb-2 font-mono uppercase tracking-widest">Druckvorlage</p>
+          <a
+            href="/brand/{brand}/starters/questionnaire.html"
+            target="_blank"
+            rel="noopener"
+            class="inline-flex items-center gap-2 text-sm text-muted hover:text-gold transition-colors"
+          >
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="w-4 h-4"><path d="M17 17H17.01M17 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V7l-4-4zm-5 8v6m-3-3h6"/></svg>
+            Branded Druckvorlage öffnen &amp; drucken
+          </a>
+        </div>
       </div>
     {:else if activeTab === 'vertraege'}
       <div class="pt-6 pb-20">

--- a/website/src/components/admin/inhalte/VertragsvorlagenSection.svelte
+++ b/website/src/components/admin/inhalte/VertragsvorlagenSection.svelte
@@ -21,6 +21,7 @@
   let composeMsg = $state('');
   let composeSaving = $state(false);
   let deleteConfirm: string | null = $state(null);
+  let starterLoading = $state(false);
 
   // Stand-date feature
   let standPickerId: string | null = $state(null);
@@ -92,6 +93,16 @@
     composeTitle = ''; composeHtml = '';
     showCompose = true;
     composeMsg = '';
+  }
+
+  async function loadStarter() {
+    starterLoading = true;
+    try {
+      const res = await fetch('/api/admin/brand-starter');
+      if (res.ok) composeHtml = await res.text();
+      else composeMsg = 'Starter-Vorlage nicht verfügbar.';
+    } catch { composeMsg = 'Verbindungsfehler.'; }
+    finally { starterLoading = false; }
   }
 
   function openStandPicker(t: Template) {
@@ -217,7 +228,16 @@
       <!-- HTML editor — DIN-A4 width (794 px) -->
       <div class="overflow-x-auto">
         <div>
-          <label class="block text-sm text-muted mb-1">HTML-Inhalt *</label>
+          <div class="flex items-center justify-between mb-1">
+            <label class="block text-sm text-muted">HTML-Inhalt *</label>
+            {#if !editingId}
+              <button
+                onclick={loadStarter}
+                disabled={starterLoading}
+                class="text-xs text-gold/80 hover:text-gold border border-gold/20 hover:border-gold/50 rounded px-2 py-1 transition-colors disabled:opacity-50"
+              >{starterLoading ? 'Lade…' : 'Design-System Vorlage laden'}</button>
+            {/if}
+          </div>
           <textarea
             bind:value={composeHtml}
             placeholder="<h1>Vertrag</h1><p>Inhalt hier…</p>"

--- a/website/src/lib/starters/contract-korczewski.html
+++ b/website/src/lib/starters/contract-korczewski.html
@@ -1,0 +1,211 @@
+<!doctype html>
+<html lang="de">
+<head>
+<meta charset="utf-8">
+<title>Kore — Dienstleistungsvertrag</title>
+<link rel="stylesheet" href="/brand/korczewski/colors_and_type.css">
+<link rel="stylesheet" href="/brand/korczewski/app.css">
+<style>
+  body{padding:48px 28px 96px;}
+
+  .contract{max-width:880px; margin:0 auto; background:var(--paper); color:var(--ink-text); border-radius:var(--r-paper); box-shadow:var(--shadow-paper); position:relative; overflow:hidden;}
+  .contract::before{content:""; position:absolute; inset:0; pointer-events:none; background:radial-gradient(50% 35% at 100% 0%, rgba(200,247,106,.16), transparent 60%), radial-gradient(45% 35% at 0% 100%, rgba(91,212,208,.10), transparent 60%); z-index:0;}
+  .contract > *{position:relative; z-index:1;}
+
+  .cover{padding:64px 64px 56px; border-bottom:1px solid var(--line-paper); display:grid; grid-template-columns:1fr auto; gap:32px; align-items:flex-start;}
+  .cover img{display:block;}
+  .cover .id{text-align:right;}
+  .cover .id .lab{font-family:var(--mono); font-size:10px; letter-spacing:.2em; text-transform:uppercase; color:var(--copper-print);}
+  .cover .id .num{font-family:var(--mono); font-size:14px; color:var(--ink-text); margin-top:6px; letter-spacing:.06em;}
+  .cover .id .v{font-family:var(--mono); font-size:11px; color:var(--ink-mute); margin-top:6px;}
+
+  .cover .title{grid-column:1 / -1; margin-top:36px;}
+  .cover .title .eye{font-family:var(--mono); font-size:11px; letter-spacing:.2em; text-transform:uppercase; color:var(--copper-print); display:inline-flex; gap:10px; align-items:center;}
+  .cover .title .eye::before{content:""; width:22px; height:1px; background:currentColor;}
+  .cover .title h1{font-family:var(--serif); font-weight:400; font-size:64px; letter-spacing:-0.025em; line-height:1.02; margin:14px 0 0; max-width:18ch;}
+  .cover .title h1 em{font-style:italic; color:var(--copper-print);}
+  .cover .title .lede{font-family:var(--sans); font-size:16px; line-height:1.55; color:var(--ink-soft); margin:18px 0 0; max-width:60ch;}
+
+  .parties{grid-column:1 / -1; margin-top:40px; display:grid; grid-template-columns:1fr 1fr; gap:32px;}
+  .party{padding:22px 24px; background:rgba(15,8,28,.04); border:1px solid var(--line-paper); border-radius:12px;}
+  .party .lab{font-family:var(--mono); font-size:10px; letter-spacing:.2em; text-transform:uppercase; color:var(--ink-mute);}
+  .party .nm{font-family:var(--serif); font-size:24px; margin-top:8px; letter-spacing:-0.01em;}
+  .party .nm em{font-style:italic; color:var(--copper-print);}
+  .party .meta{font-family:var(--mono); font-size:11px; line-height:1.7; color:var(--ink-mute); margin-top:8px; letter-spacing:.04em;}
+  .party .role{font-family:var(--mono); font-size:9.5px; letter-spacing:.18em; text-transform:uppercase; color:var(--copper-print); margin-top:10px;}
+
+  .body-c{padding:48px 64px;}
+  .body-c .preamble{font-family:var(--serif); font-style:italic; font-size:18px; line-height:1.6; color:var(--ink-soft); padding:24px 28px; border-left:2px solid var(--copper-print); margin-bottom:40px;}
+  .body-c .preamble em{color:var(--copper-print); font-style:italic;}
+
+  .clause{display:grid; grid-template-columns:80px 1fr; gap:24px; padding:24px 0; border-top:1px solid var(--line-paper);}
+  .clause:first-of-type{border-top:0; padding-top:0;}
+  .clause .num{font-family:var(--mono); font-size:11px; letter-spacing:.16em; color:var(--copper-print); text-transform:uppercase; padding-top:4px;}
+  .clause h3{font-family:var(--serif); font-weight:400; font-size:24px; letter-spacing:-0.01em; margin:0 0 10px;}
+  .clause h3 em{font-style:italic; color:var(--copper-print);}
+  .clause p{font-family:var(--sans); font-size:14.5px; line-height:1.65; color:var(--ink-text); margin:0 0 10px;}
+  .clause p:last-child{margin-bottom:0;}
+  .clause em.kw{font-style:italic; color:var(--copper-print);}
+  .clause .grid2{display:grid; grid-template-columns:1fr 1fr; gap:14px; margin-top:12px;}
+  .clause .term{padding:14px 16px; background:rgba(15,8,28,.04); border-radius:8px; border:1px solid var(--line-paper);}
+  .clause .term .k{font-family:var(--mono); font-size:9.5px; letter-spacing:.18em; text-transform:uppercase; color:var(--ink-mute);}
+  .clause .term .v{font-family:var(--serif); font-size:22px; margin-top:4px; letter-spacing:-0.005em; color:var(--ink-text);}
+  .clause .term .v em{font-style:italic; color:var(--copper-print);}
+  .clause .term .v .u{font-family:var(--mono); font-size:11px; color:var(--ink-mute); margin-left:3px;}
+
+  .clause ul{margin:6px 0 0; padding:0; list-style:none;}
+  .clause ul li{font-family:var(--sans); font-size:14.5px; line-height:1.65; color:var(--ink-text); padding:6px 0 6px 22px; position:relative;}
+  .clause ul li::before{content:""; position:absolute; left:0; top:14px; width:12px; height:1px; background:var(--copper-print);}
+
+  .sigs{padding:48px 64px 56px; border-top:1px solid var(--line-paper); display:grid; grid-template-columns:1fr 1fr; gap:48px;}
+  .sig-box .lab{font-family:var(--mono); font-size:10px; letter-spacing:.2em; text-transform:uppercase; color:var(--ink-mute);}
+  .sig-box .line{margin-top:42px; padding-bottom:8px; border-bottom:1px solid var(--ink-text); font-family:"Instrument Serif", Georgia, serif; font-style:italic; font-size:32px; color:var(--copper-print); letter-spacing:0;}
+  .sig-box .name{font-family:var(--mono); font-size:11px; color:var(--ink-text); margin-top:10px; letter-spacing:.06em;}
+  .sig-box .name b{font-family:var(--sans); font-size:14px; color:var(--ink-text); display:block; margin-bottom:2px; font-weight:500; letter-spacing:0;}
+  .sig-box .role{font-family:var(--mono); font-size:10px; letter-spacing:.16em; text-transform:uppercase; color:var(--ink-mute); margin-top:4px;}
+  .sig-box .meta{margin-top:12px; padding-top:12px; border-top:1px dashed var(--line-paper); font-family:var(--mono); font-size:10px; line-height:1.6; color:var(--ink-mute); letter-spacing:.04em;}
+
+  .foot-rule{padding:18px 64px 28px; display:flex; justify-content:space-between; gap:18px; font-family:var(--mono); font-size:9.5px; letter-spacing:.18em; text-transform:uppercase; color:var(--ink-mute); border-top:1px solid var(--line-paper);}
+</style>
+</head>
+<body>
+<main>
+  <article class="contract">
+    <div class="cover">
+      <img src="/brand/korczewski/logo-lockup-light.svg" width="200" height="60" alt="Kore">
+      <div class="id">
+        <div class="lab">Dienstleistungsvertrag</div>
+        <div class="num">{{KUNDENNUMMER}}</div>
+        <div class="v">Stand {{Stand}} · {{DATUM}}</div>
+      </div>
+
+      <div class="title">
+        <span class="eye">Reliability retainer · 12 Monate</span>
+        <h1>Zuverlässiger Betrieb, <em>in Ihrem Auftrag.</em></h1>
+        <p class="lede">
+          Ein verständlicher Rahmenvertrag für den laufenden Betrieb Ihrer Infrastruktur. Klare SLOs, transparente Vergütung, keine Überraschungen.
+        </p>
+      </div>
+
+      <div class="parties">
+        <div class="party">
+          <div class="lab">Auftragnehmer</div>
+          <div class="nm">Kore<em>.</em></div>
+          <div class="meta">K. KORCZEWSKI<br>BERLIN · DE<br>USt-ID DE-348-991-204</div>
+          <div class="role">Vertreten durch K. Korczewski</div>
+        </div>
+        <div class="party">
+          <div class="lab">Auftraggeber</div>
+          <div class="nm">{{FIRMA}}</div>
+          <div class="meta">{{ADRESSE}}<br>{{EMAIL}}</div>
+          <div class="role">Vertreten durch {{KUNDENNAME}}</div>
+        </div>
+      </div>
+    </div>
+
+    <div class="body-c">
+      <div class="preamble">
+        Die Parteien wollen die Infrastruktur <em>stabil,</em> die Bereitschaftszeiten <em>ruhig</em> und das Runbook so verständlich halten, dass ein Junior-SRE einen P2-Vorfall allein um 03:00 Uhr lösen kann. Dieses Dokument hält fest, was jede Partei tut, wann und zu welchem Preis.
+      </div>
+
+      <div class="clause">
+        <span class="num">§01</span>
+        <div>
+          <h3>Leistungs<em>umfang</em></h3>
+          <p>Der Auftragnehmer betreibt die unter <em class="kw">{{CLUSTER_ID}}</em> geführte Infrastruktur, einschließlich Control Plane, Worker Nodes und der im Repository des Auftraggebers verwalteten Manifeste.</p>
+          <ul>
+            <li>Sicherstellung der Control-Plane-Verfügbarkeit gemäß den SLOs in §03.</li>
+            <li>Aktualisierung des Runbooks innerhalb von sieben Kalendertagen nach jeder Änderung.</li>
+            <li>Triage und Behebung von Incidents gemäß den Reaktionszeiten in §04.</li>
+            <li>Übergabe aller Artefakte im Klartextformat bei Vertragsende — kein Vendor Lock-in.</li>
+          </ul>
+        </div>
+      </div>
+
+      <div class="clause">
+        <span class="num">§02</span>
+        <div>
+          <h3>Laufzeit &amp; <em>Vergütung</em></h3>
+          <p>Der Vertrag läuft für zwölf Kalendermonate ab dem Startdatum und verlängert sich anschließend monatlich. Beide Parteien können mit dreißig Tagen schriftlicher Frist kündigen.</p>
+          <div class="grid2">
+            <div class="term"><div class="k">Startdatum</div><div class="v">{{STARTDATUM}}</div></div>
+            <div class="term"><div class="k">Laufzeit</div><div class="v">12<span class="u">Mo</span> · auto-renew</div></div>
+            <div class="term"><div class="k">Monatliches Retainer</div><div class="v">{{BETRAG}}<span class="u">/Mo</span></div></div>
+            <div class="term"><div class="k">Incident-Rate</div><div class="v">{{STUNDENSATZ}}<span class="u">/h</span></div></div>
+          </div>
+        </div>
+      </div>
+
+      <div class="clause">
+        <span class="num">§03</span>
+        <div>
+          <h3>Service Level <em>Objectives</em></h3>
+          <p>Gemessen monatlich, zum Kalendermonatsende, in der Zeitzone Europe/Berlin.</p>
+          <div class="grid2">
+            <div class="term"><div class="k">Control-Plane-Verfügbarkeit</div><div class="v">99.95<span class="u">%</span></div></div>
+            <div class="term"><div class="k">P1-Bestätigung</div><div class="v">≤ 15<span class="u">min</span></div></div>
+            <div class="term"><div class="k">P1-Erstreaktion</div><div class="v">≤ 30<span class="u">min</span></div></div>
+            <div class="term"><div class="k">Runbook-Aktualität</div><div class="v">≤ 7<span class="u">Tage</span></div></div>
+          </div>
+        </div>
+      </div>
+
+      <div class="clause">
+        <span class="num">§04</span>
+        <div>
+          <h3>Bereitschaft &amp; <em>Reaktionszeiten</em></h3>
+          <p>Die Bereitschaft des Auftragnehmers umfasst <em class="kw">07:00–23:00 Europe/Berlin</em>, sieben Tage die Woche. Außerhalb dieses Fensters werden P1-Incidents innerhalb von dreißig Minuten bestätigt; niedrigere Prioritäten folgen am nächsten Werktag.</p>
+        </div>
+      </div>
+
+      <div class="clause">
+        <span class="num">§05</span>
+        <div>
+          <h3>Vertraulichkeit &amp; <em>Datenschutz</em></h3>
+          <p>Der Auftragnehmer behandelt alle Konfigurationen, Manifeste und Incident-Details als vertraulich. Keine Produktionsdaten werden außerhalb der EU ohne vorherige schriftliche Zustimmung verarbeitet.</p>
+        </div>
+      </div>
+
+      <div class="clause">
+        <span class="num">§06</span>
+        <div>
+          <h3>Haftung &amp; <em>Haftungsbeschränkung</em></h3>
+          <p>Die Gesamthaftung des Auftragnehmers ist auf die in den vorangegangenen zwölf Monaten gezahlten Vergütungen begrenzt. Diese Beschränkung gilt nicht bei Vorsatz oder grober Fahrlässigkeit.</p>
+        </div>
+      </div>
+
+      <div class="clause">
+        <span class="num">§07</span>
+        <div>
+          <h3>Anwendbares <em>Recht</em></h3>
+          <p>Es gilt deutsches Recht. Ausschließlicher Gerichtsstand ist Berlin.</p>
+        </div>
+      </div>
+    </div>
+
+    <div class="sigs">
+      <div class="sig-box">
+        <div class="lab">Für Kore.</div>
+        <div class="line">K. Korczewski</div>
+        <div class="name"><b>K. Korczewski</b><span>Operator · Gründer</span></div>
+        <div class="role">Unterzeichnet in Berlin</div>
+        <div class="meta">{{DATUM}}</div>
+      </div>
+      <div class="sig-box">
+        <div class="lab">Für {{FIRMA}}</div>
+        <div class="line" style="color:var(--ink-mute);border-bottom-style:dashed;"></div>
+        <div class="name" style="margin-top:0;"><b>{{VORNAME}} {{NACHNAME}}</b><span>{{TELEFON}}</span></div>
+        <div class="role">{{EMAIL}}</div>
+        <div class="meta">Ort, Datum</div>
+      </div>
+    </div>
+
+    <div class="foot-rule">
+      <span>Seite 1 / 1</span>
+      <span>Dienstleistungsvertrag · {{KUNDENNUMMER}}</span>
+      <span>Stand {{Stand}}</span>
+    </div>
+  </article>
+</main>
+</body>
+</html>

--- a/website/src/lib/starters/contract-mentolder.html
+++ b/website/src/lib/starters/contract-mentolder.html
@@ -1,0 +1,71 @@
+<!doctype html>
+<html lang="de"><head><meta charset="utf-8" />
+<title>Mentolder — Coaching-Vertrag</title>
+<link rel="stylesheet" href="/brand/mentolder/colors_and_type.css" />
+<link rel="stylesheet" href="/brand/mentolder/print.css" />
+<style>
+.contract h3{margin-top:22px;}
+.contract p{margin:8px 0;color:#3a4150;line-height:1.65;}
+.contract ul{margin:8px 0;padding-left:18px;color:#3a4150;}
+.contract li{margin:4px 0;line-height:1.6;}
+.sign{margin-top:48px;display:grid;grid-template-columns:1fr 1fr;gap:48px;}
+.sign .line{height:1px;background:var(--paper-line);margin-top:48px;}
+.sign .lab{margin-top:8px;font-family:var(--mono);font-size:10px;letter-spacing:.14em;text-transform:uppercase;color:var(--paper-mute);}
+.clause{font-family:var(--mono);font-size:10px;letter-spacing:.16em;text-transform:uppercase;color:#A8823A;display:block;margin-bottom:4px;}
+</style>
+</head>
+<body>
+<div class="page contract">
+  <div style="display:flex;justify-content:space-between;align-items:flex-start;">
+    <div class="brand-row"><img src="/icon-128.png" alt="" /><span class="name">mentolder<span class="dot">.</span></span></div>
+    <div style="text-align:right;">
+      <div class="eyebrow-print">Coaching-Vertrag</div>
+      <h2 class="print" style="margin-top:8px;">Nr. {{KUNDENNUMMER}}</h2>
+      <div class="kicker-print" style="margin-top:6px;">Lüneburg · {{DATUM}}</div>
+    </div>
+  </div>
+
+  <hr class="rule" style="margin:32px 0 28px;" />
+
+  <h1 class="print">Vereinbarung über <em>Führungskräfte-Coaching.</em></h1>
+  <p class="muted" style="margin-top:14px;font-size:14px;line-height:1.65;max-width:60ch;">
+    zwischen <strong>Gerald Korczewski</strong> (im Folgenden „Coach"), Bardowicker Straße 14, 21335 Lüneburg, und <strong>{{KUNDENNAME}}</strong> (im Folgenden „Klient/in"), {{FIRMA}}, {{ADRESSE}}.
+  </p>
+
+  <h3 class="print"><span class="clause">§ 1 — Gegenstand</span>Was ich für Sie tue.</h3>
+  <p>Der Coach begleitet die/den Klienten/in in sechs (6) Coaching-Sessions à 90 Minuten zur strategischen Neuausrichtung der beruflichen Position. Inhalte sind Profil-Schärfung, Vorbereitung auf Headhunter-Gespräche, Karriere-Strategie und Timing.</p>
+
+  <h3 class="print"><span class="clause">§ 2 — Zeitraum &amp; Format</span>Wann und wie wir arbeiten.</h3>
+  <p>Die Sessions finden zwischen dem <strong>{{STARTDATUM}}</strong> und dem <strong>{{ENDDATUM}}</strong> statt — wahlweise persönlich in Lüneburg oder online per Videokonferenz. Termine werden gemeinsam abgestimmt; eine Verschiebung mit weniger als 48 Stunden Vorlauf wird voll berechnet.</p>
+
+  <h3 class="print"><span class="clause">§ 3 — Vergütung</span>Was Sie investieren.</h3>
+  <ul>
+    <li>Paket S — 6 Sessions: <strong>{{BETRAG}} netto</strong> (Kleinunternehmer §19 UStG)</li>
+    <li>Fällig in zwei Raten: 50 % nach Vertragsschluss, 50 % nach der dritten Session.</li>
+    <li>Reisekosten außerhalb von Lüneburg nach Aufwand, vorab abgestimmt.</li>
+  </ul>
+
+  <h3 class="print"><span class="clause">§ 4 — Vertraulichkeit</span>Was zwischen uns bleibt.</h3>
+  <p>Alle Inhalte der Sessions sind streng vertraulich. Der Coach verpflichtet sich, keinerlei Informationen ohne ausdrückliche schriftliche Zustimmung der/des Klienten/in an Dritte weiterzugeben. Diese Verpflichtung gilt unbefristet über das Ende der Zusammenarbeit hinaus.</p>
+
+  <h3 class="print"><span class="clause">§ 5 — Verantwortung</span>Was Coaching nicht ersetzt.</h3>
+  <p>Coaching ist Begleitung, keine Therapie und keine Rechts- oder Steuerberatung. Entscheidungen trifft die/der Klient/in eigenverantwortlich. Der Coach übernimmt keine Erfolgsgarantie für berufliche Veränderungen.</p>
+
+  <h3 class="print"><span class="clause">§ 6 — Kündigung</span>Wenn es nicht passt.</h3>
+  <p>Beide Parteien können den Vertrag jederzeit schriftlich kündigen. Bereits durchgeführte Sessions werden anteilig abgerechnet; nicht begonnene Sessions werden nicht in Rechnung gestellt.</p>
+
+  <h3 class="print"><span class="clause">§ 7 — Schlussbestimmungen</span>Zur Vollständigkeit.</h3>
+  <p>Es gilt deutsches Recht. Gerichtsstand ist Lüneburg. Sollten einzelne Bestimmungen unwirksam sein, bleibt der Vertrag im Übrigen wirksam.</p>
+
+  <div class="sign">
+    <div><div class="line"></div><div class="lab">Gerald Korczewski · Coach</div></div>
+    <div><div class="line"></div><div class="lab">{{VORNAME}} {{NACHNAME}} · Klient/in</div></div>
+  </div>
+
+  <div class="foot-print">
+    <div><h5>Mentolder</h5><p>Gerald Korczewski</p><p>Bardowicker Straße 14</p><p>21335 Lüneburg</p></div>
+    <div><h5>Kontakt</h5><p>info@mentolder.de</p><p>+49 151 508 32 601</p><p>mentolder.de</p></div>
+    <div><h5>Rechtliches</h5><p>USt-IdNr. DE123456789</p><p>§19 UStG · Kleinunternehmer</p><p>Stand {{Stand}}</p></div>
+  </div>
+</div>
+</body></html>

--- a/website/src/pages/admin/inhalte.astro
+++ b/website/src/pages/admin/inhalte.astro
@@ -93,6 +93,6 @@ const initialData = JSON.parse(JSON.stringify({
       <h1 class="text-3xl font-bold text-light font-serif">Inhalte</h1>
       <p class="text-muted mt-1 text-sm">Website, Newsletter, Fragebögen und Vertragsvorlagen</p>
     </div>
-    <InhalteEditor {initialData} {rechnungsvorlagen} client:load />
+    <InhalteEditor {initialData} {rechnungsvorlagen} brand={BRAND} client:load />
   </section>
 </AdminLayout>

--- a/website/src/pages/api/admin/brand-starter.ts
+++ b/website/src/pages/api/admin/brand-starter.ts
@@ -1,0 +1,27 @@
+import type { APIRoute } from 'astro';
+import { getSession, isAdmin } from '../../../lib/auth';
+import { readFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+function readStarter(filename: string): string | null {
+  const candidates = [
+    join(process.cwd(), 'src/lib/starters', filename),
+    join(dirname(fileURLToPath(import.meta.url)), '../../../lib/starters', filename),
+  ];
+  for (const p of candidates) {
+    try { return readFileSync(p, 'utf-8'); } catch { /* try next */ }
+  }
+  return null;
+}
+
+export const GET: APIRoute = async ({ request }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) return new Response('Unauthorized', { status: 401 });
+
+  const brand = process.env.BRAND || 'mentolder';
+  const html = readStarter(`contract-${brand}.html`);
+  if (!html) return new Response('Starter not found', { status: 404 });
+
+  return new Response(html, { headers: { 'Content-Type': 'text/html; charset=utf-8' } });
+};


### PR DESCRIPTION
## Summary

- Copies brand CSS (`colors_and_type.css`, `print.css` / `app.css`) and the Kore logo SVG into `website/public/brand/<brand>/` so the preview iframe and print pages resolve styles from the same origin
- Adds `src/lib/starters/contract-{mentolder,korczewski}.html` — templated A4 contracts with existing DocuSeal placeholders, served via auth-gated `GET /api/admin/brand-starter`
- **Verträge tab**: "Design-System Vorlage laden" button (new template only) fetches the brand-appropriate contract HTML into the editor + live A4 preview
- **Fragebögen tab**: "Branded Druckvorlage öffnen & drucken" link opens the brand's print questionnaire in a new tab (mentolder warm-paper intake form / Kore onboarding questionnaire), URL driven by `BRAND` env so each cluster auto-resolves the right file
- Passes `brand={BRAND}` from `inhalte.astro` down to `InhalteEditor`; no breaking changes to existing props

## Test plan

- [ ] On mentolder cluster: open Admin → Inhalte → Verträge → Neue Vorlage → click "Design-System Vorlage laden" — verify mentolder warm-paper contract HTML loads and renders in the A4 preview iframe
- [ ] On korczewski cluster: same flow — verify Kore dark-paper contract loads
- [ ] Fragebögen tab: click "Branded Druckvorlage öffnen & drucken" — opens correct brand questionnaire in new tab; Ctrl+P renders a clean A4 page
- [ ] Existing Vertragsvorlagen (edit flow): confirm "Design-System Vorlage laden" button is hidden when editing an existing template
- [ ] `GET /api/admin/brand-starter` returns 401 for unauthenticated requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)