### PR TITLE
feat(admin): overhaul admin UI — SVG icons, inbox flat feed, monitoring tabs, list view

### DIFF
--- a/website/src/components/InboxApp.svelte
+++ b/website/src/components/InboxApp.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import type { InboxItem, InboxType, InboxStatus, Message } from '../lib/messaging-db';
 
-  // Server passes initial data via props to avoid a flash of empty content
   const { initialItems, initialCounts }: {
     initialItems: InboxItem[];
     initialCounts: Record<string, number>;
@@ -9,7 +8,6 @@
 
   let items = $state<InboxItem[]>(initialItems);
   let counts = $state<Record<string, number>>(initialCounts);
-  let activeType = $state<InboxType | ''>('');
   let activeStatus = $state<InboxStatus>('pending');
   let loadingAction = $state<number | null>(null);
   let errors = $state<Record<number, string>>({});
@@ -17,7 +15,6 @@
   let noteText = $state('');
 
   // Thread inline view for user_message items
-  let sidebarCollapsed = $state(false);
   let expandedItemId = $state<number | null>(null);
   let threadMessages = $state<Message[]>([]);
   let threadLoading = $state(false);
@@ -43,26 +40,15 @@
 
   const totalPending = $derived(Object.values(counts).reduce((a, b) => a + b, 0));
 
-  const statusTabs: [string, string][] = [
+  const statusTabs: [InboxStatus, string][] = [
     ['pending', 'Offen'],
     ['actioned', 'Erledigt'],
     ['archived', 'Archiv'],
   ];
 
-  const filterTabs = $derived<[string, string, number][]>([
-    ['', 'Alle', totalPending],
-    ['registration', 'Registrierung', counts.registration ?? 0],
-    ['booking', 'Buchung', counts.booking ?? 0],
-    ['contact', 'Kontakt', counts.contact ?? 0],
-    ['bug', 'Bug', counts.bug ?? 0],
-    ['meeting_finalize', 'Meeting', counts.meeting_finalize ?? 0],
-    ['user_message', 'Nachricht', counts.user_message ?? 0],
-  ]);
-
   async function reload() {
     try {
       const p = new URLSearchParams({ status: activeStatus });
-      if (activeType) p.set('type', activeType);
       const res = await fetch(`/api/admin/inbox?${p}`);
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const data = await res.json() as { items: InboxItem[]; counts: Record<string, number> };
@@ -71,11 +57,6 @@
     } catch (err) {
       console.error('[InboxApp] reload failed:', err);
     }
-  }
-
-  function setType(t: InboxType | '') {
-    activeType = t;
-    reload();
   }
 
   function setStatus(s: InboxStatus) {
@@ -179,40 +160,27 @@
   }
 </script>
 
-<div class="inbox-layout">
-  <!-- Sidebar -->
-  <aside class="sidebar {sidebarCollapsed ? 'collapsed' : ''}">
-    <div class="sidebar-header">
-      <h2>Inbox</h2>
-      <button class="btn-collapse" onclick={() => sidebarCollapsed = !sidebarCollapsed} title={sidebarCollapsed ? 'Einblenden' : 'Ausblenden'}>
-        {sidebarCollapsed ? '›' : '‹'}
-      </button>
+<div class="inbox-wrap">
+  <!-- Header with count + status tabs -->
+  <div class="inbox-header">
+    <div class="inbox-title-row">
+      <h2 class="inbox-title">Eingehend</h2>
+      {#if totalPending > 0}
+        <span class="inbox-count">{totalPending}</span>
+      {/if}
     </div>
-    {#if !sidebarCollapsed}
-    <div class="filter-group">
-      {#each filterTabs as [t, label, count]}
-        <button
-          class="filter-btn {activeType === t ? 'active' : ''}"
-          onclick={() => setType(t as InboxType | '')}
-        >
-          {label}
-          {#if count > 0}<span class="badge">{count}</span>{/if}
-        </button>
-      {/each}
-    </div>
-    <div class="status-group">
+    <div class="status-tabs">
       {#each statusTabs as [s, label]}
         <button
-          class="status-btn {activeStatus === s ? 'active' : ''}"
-          onclick={() => setStatus(s as InboxStatus)}
+          class="status-tab {activeStatus === s ? 'active' : ''}"
+          onclick={() => setStatus(s)}
         >{label}</button>
       {/each}
     </div>
-    {/if}
-  </aside>
+  </div>
 
   <!-- Feed -->
-  <main class="feed">
+  <div class="feed">
     {#if items.length === 0}
       <p class="empty">Keine Einträge.</p>
     {:else}
@@ -306,26 +274,19 @@
         </div>
       {/each}
     {/if}
-  </main>
+  </div>
 </div>
 
 <style>
-  .inbox-layout { display: flex; gap: 24px; height: 100%; }
-  .sidebar { width: 200px; flex-shrink: 0; transition: width 0.2s; }
-  .sidebar.collapsed { width: 36px; }
-  .sidebar-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 16px; }
-  .sidebar h2 { font-size: 18px; margin: 0; white-space: nowrap; overflow: hidden; }
-  .sidebar.collapsed h2 { display: none; }
-  .btn-collapse { background: #1e1e2e; border: 1px solid #374151; color: #aaa; border-radius: 4px; padding: 2px 7px; font-size: 16px; cursor: pointer; line-height: 1; flex-shrink: 0; }
-  .btn-collapse:hover { background: #2a2a3e; color: #fff; }
-  .filter-group { display: flex; flex-direction: column; gap: 4px; margin-bottom: 20px; }
-  .filter-btn { background: transparent; border: none; text-align: left; padding: 7px 10px; border-radius: 6px; cursor: pointer; color: #ccc; font-size: 13px; display: flex; justify-content: space-between; }
-  .filter-btn.active { background: #2a2a3e; color: #fff; }
-  .filter-btn:hover:not(.active) { background: #1e1e2e; }
-  .badge { background: #7c6ff7; color: #fff; border-radius: 10px; padding: 0 6px; font-size: 11px; }
-  .status-group { display: flex; gap: 4px; }
-  .status-btn { flex: 1; background: #1e1e2e; border: none; padding: 5px; border-radius: 4px; cursor: pointer; color: #999; font-size: 12px; }
-  .status-btn.active { background: #2a2a3e; color: #fff; }
+  .inbox-wrap { display: flex; flex-direction: column; gap: 0; height: 100%; }
+  .inbox-header { display: flex; align-items: center; justify-content: space-between; flex-wrap: wrap; gap: 10px; margin-bottom: 16px; }
+  .inbox-title-row { display: flex; align-items: center; gap: 8px; }
+  .inbox-title { font-size: 18px; font-weight: 600; margin: 0; }
+  .inbox-count { background: #7c6ff7; color: #fff; border-radius: 10px; padding: 1px 8px; font-size: 12px; font-weight: 700; }
+  .status-tabs { display: flex; gap: 4px; }
+  .status-tab { background: #1e1e2e; border: none; padding: 5px 14px; border-radius: 6px; cursor: pointer; color: #999; font-size: 12px; font-weight: 500; }
+  .status-tab.active { background: #2a2a3e; color: #fff; }
+  .status-tab:hover:not(.active) { background: #252535; color: #ccc; }
   .feed { flex: 1; overflow-y: auto; }
   .empty { color: #666; text-align: center; margin-top: 48px; }
   .card { background: #1e1e2e; border-radius: 8px; padding: 14px 16px; margin-bottom: 8px; }
@@ -359,16 +320,9 @@
   .thread-reply textarea { flex: 1; background: #111827; color: #e8e8f0; border: 1px solid #374151; border-radius: 4px; padding: 8px; font-size: 13px; resize: none; box-sizing: border-box; }
 
   @media (max-width: 640px) {
-    .inbox-layout { flex-direction: column; gap: 0; height: auto; }
-    .sidebar { width: 100%; padding-bottom: 12px; border-bottom: 1px solid #2a2a3e; margin-bottom: 12px; }
-    .sidebar.collapsed { width: 100%; }
-    .sidebar h2 { font-size: 16px; margin: 0; }
-    .sidebar-header { margin-bottom: 10px; }
-    .filter-group { flex-direction: row; flex-wrap: nowrap; overflow-x: auto; gap: 6px; margin-bottom: 10px; padding-bottom: 4px; scrollbar-width: none; }
-    .filter-group::-webkit-scrollbar { display: none; }
-    .filter-btn { flex-shrink: 0; white-space: nowrap; padding: 6px 10px; font-size: 12px; }
-    .status-group { width: 100%; }
-    .status-btn { padding: 7px 4px; font-size: 11px; }
+    .inbox-header { flex-direction: column; align-items: flex-start; }
+    .status-tabs { width: 100%; }
+    .status-tab { flex: 1; text-align: center; padding: 7px 4px; }
     .feed { overflow-y: visible; }
     .card { padding: 12px; }
     .card-body strong { font-size: 13px; }

--- a/website/src/components/ServiceLinks.astro
+++ b/website/src/components/ServiceLinks.astro
@@ -11,6 +11,10 @@ interface Props {
 }
 
 const { links, heading } = Astro.props;
+
+function isSvg(icon: string) {
+  return icon.trimStart().startsWith('<svg');
+}
 ---
 
 {links.length > 0 && (
@@ -27,9 +31,17 @@ const { links, heading } = Astro.props;
           target={external ? '_blank' : undefined}
           rel={external ? 'noopener noreferrer' : undefined}
           data-testid={`service-link-${link.label}`}
-          class="flex flex-col items-center gap-1.5 p-4 bg-dark-light rounded-xl border border-dark-lighter hover:border-gold/40 transition-colors text-center"
+          class="flex flex-col items-center gap-2 p-4 bg-dark-light rounded-xl border border-dark-lighter hover:border-gold/40 transition-colors text-center"
         >
-          <span class="text-2xl leading-none">{link.icon}</span>
+          {isSvg(link.icon) ? (
+            <span
+              class="text-muted"
+              style="width:20px; height:20px; display:flex; align-items:center; justify-content:center;"
+              set:html={link.icon}
+            />
+          ) : (
+            <span class="text-xl leading-none">{link.icon}</span>
+          )}
           <span class="text-xs font-medium text-muted">{link.label}</span>
         </a>
         );

--- a/website/src/components/admin/MonitoringDashboard.svelte
+++ b/website/src/components/admin/MonitoringDashboard.svelte
@@ -2,19 +2,20 @@
   import { onMount } from 'svelte';
   import ClusterTab from './monitoring/ClusterTab.svelte';
   import DeploymentsTab from './monitoring/DeploymentsTab.svelte';
-  import TestsTab from './monitoring/TestsTab.svelte';
-
+  import TasksTab from './monitoring/TasksTab.svelte';
   import OverviewTab from './monitoring/OverviewTab.svelte';
-  import BerichteTab from './monitoring/BerichteTab.svelte';
+  import BugsTab from './monitoring/BugsTab.svelte';
+  import TrackingTab from './monitoring/TrackingTab.svelte';
 
-  type Tab = 'overview' | 'cluster' | 'tests' | 'deployments' | 'berichte';
+  export let trackingUrl: string = '';
+
+  type Tab = 'overview' | 'cluster' | 'deployments' | 'tasks' | 'bugs' | 'tracking';
 
   let activeTab: Tab = 'overview';
 
-  // Allow deep-linking via hash: /admin/monitoring#tests
   onMount(() => {
     const hash = location.hash.slice(1) as Tab;
-    if (['overview', 'cluster', 'tests', 'deployments', 'berichte'].includes(hash)) {
+    if (['overview', 'cluster', 'deployments', 'tasks', 'bugs', 'tracking'].includes(hash)) {
       activeTab = hash;
     }
   });
@@ -25,11 +26,12 @@
   }
 
   const tabs: { id: Tab; label: string }[] = [
-    { id: 'overview', label: 'Übersicht' },
-    { id: 'cluster', label: 'Cluster' },
-    { id: 'tests', label: 'Tests' },
-    { id: 'deployments', label: 'Deployments' },
-    { id: 'berichte', label: 'Berichte' },
+    { id: 'overview',     label: 'Übersicht' },
+    { id: 'cluster',      label: 'Cluster' },
+    { id: 'deployments',  label: 'Deployments' },
+    { id: 'tasks',        label: 'Tasks' },
+    { id: 'bugs',         label: 'Bugs' },
+    { id: 'tracking',     label: 'Tracking' },
   ];
 </script>
 
@@ -54,12 +56,14 @@
       <OverviewTab on:navigate={(e) => setTab(e.detail)} />
     {:else if activeTab === 'cluster'}
       <ClusterTab />
-    {:else if activeTab === 'tests'}
-      <TestsTab />
     {:else if activeTab === 'deployments'}
       <DeploymentsTab />
-    {:else if activeTab === 'berichte'}
-      <BerichteTab />
+    {:else if activeTab === 'tasks'}
+      <TasksTab />
+    {:else if activeTab === 'bugs'}
+      <BugsTab />
+    {:else if activeTab === 'tracking'}
+      <TrackingTab {trackingUrl} />
     {/if}
   </div>
 </div>

--- a/website/src/components/admin/monitoring/BugsTab.svelte
+++ b/website/src/components/admin/monitoring/BugsTab.svelte
@@ -1,0 +1,219 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+
+  type BugTicket = {
+    ticket_id: string;
+    category: string;
+    reporter_email: string;
+    description: string;
+    url: string | null;
+    brand: string;
+    status: 'open' | 'resolved' | 'archived';
+    created_at: string;
+    resolved_at: string | null;
+    resolution_note: string | null;
+    screenshots: { filename: string; data_url: string }[];
+  };
+
+  const CATEGORY_LABELS: Record<string, string> = {
+    fehler: 'Fehler',
+    verbesserung: 'Verbesserung',
+    erweiterungswunsch: 'Erweiterungswunsch',
+  };
+
+  let tickets: BugTicket[] = [];
+  let loading = true;
+  let activeStatus = 'open';
+  let activeCategory = '';
+  let search = '';
+  let expandedId: string | null = null;
+  let resolveModalId: string | null = null;
+  let resolveNote = '';
+  let resolveLoading = false;
+  let resolveError = '';
+  let actionLoading: string | null = null;
+
+  async function fetchTickets() {
+    loading = true;
+    const p = new URLSearchParams();
+    if (activeStatus) p.set('status', activeStatus);
+    if (activeCategory) p.set('category', activeCategory);
+    if (search.trim()) p.set('q', search.trim());
+    const res = await fetch(`/api/admin/bugs/list?${p}`).catch(() => null);
+    if (res?.ok) tickets = await res.json();
+    loading = false;
+  }
+
+  async function archiveTicket(id: string) {
+    actionLoading = id;
+    const res = await fetch('/api/admin/bugs/archive', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ticketId: id }),
+    }).catch(() => null);
+    if (res?.ok) await fetchTickets();
+    actionLoading = null;
+  }
+
+  async function resolveTicket() {
+    if (!resolveModalId || !resolveNote.trim()) return;
+    resolveLoading = true;
+    resolveError = '';
+    const res = await fetch('/api/admin/bugs/resolve', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ticketId: resolveModalId, resolutionNote: resolveNote }),
+    }).catch(() => null);
+    if (res?.ok) {
+      resolveModalId = null;
+      resolveNote = '';
+      await fetchTickets();
+    } else {
+      resolveError = 'Fehler beim Erledigen.';
+    }
+    resolveLoading = false;
+  }
+
+  function fmtDate(d: string) {
+    return new Date(d).toLocaleDateString('de-DE', { day: '2-digit', month: '2-digit', year: 'numeric' });
+  }
+
+  onMount(fetchTickets);
+
+  $: statusTabs = [
+    { id: '',         label: 'Alle' },
+    { id: 'open',     label: 'Offen' },
+    { id: 'resolved', label: 'Erledigt' },
+    { id: 'archived', label: 'Archiviert' },
+  ];
+</script>
+
+<div class="space-y-4">
+  <!-- Controls -->
+  <div class="flex flex-wrap items-center gap-3">
+    <!-- Status tabs -->
+    <div class="flex border border-gray-700 rounded overflow-hidden text-xs">
+      {#each statusTabs as st}
+        <button
+          on:click={() => { activeStatus = st.id; fetchTickets(); }}
+          class="px-3 py-1.5 {activeStatus === st.id ? 'bg-gray-600 text-white' : 'bg-gray-800 text-gray-400 hover:text-gray-200'}"
+        >{st.label}</button>
+      {/each}
+    </div>
+
+    <!-- Category filter -->
+    <select
+      bind:value={activeCategory}
+      on:change={fetchTickets}
+      class="bg-gray-800 border border-gray-700 text-gray-300 text-xs rounded px-2 py-1.5 focus:outline-none focus:border-gray-500"
+    >
+      <option value="">Alle Kategorien</option>
+      {#each Object.entries(CATEGORY_LABELS) as [val, lbl]}
+        <option value={val}>{lbl}</option>
+      {/each}
+    </select>
+
+    <!-- Search -->
+    <input
+      bind:value={search}
+      on:keydown={(e) => e.key === 'Enter' && fetchTickets()}
+      placeholder="Ticket-ID oder E-Mail…"
+      class="bg-gray-900 border border-gray-700 text-gray-300 text-xs rounded px-2 py-1.5 w-52 focus:outline-none focus:border-gray-500 font-mono"
+    />
+    <button on:click={fetchTickets}
+      class="px-3 py-1.5 text-xs bg-gray-700 hover:bg-gray-600 text-gray-200 rounded border border-gray-600">
+      Suchen
+    </button>
+  </div>
+
+  <!-- Table -->
+  <div class="bg-gray-800 border border-gray-700 rounded-lg overflow-hidden">
+    {#if loading}
+      <div class="px-4 py-8 text-center text-sm text-gray-500">Lädt…</div>
+    {:else if tickets.length === 0}
+      <div class="px-4 py-8 text-center text-sm text-gray-500">Keine Tickets gefunden.</div>
+    {:else}
+      <!-- Header -->
+      <div class="grid grid-cols-[120px_1fr_140px_90px_90px_120px] gap-2 px-4 py-2 border-b border-gray-700 text-xs text-gray-500 uppercase tracking-wide">
+        <span>Ticket-ID</span><span>Beschreibung</span><span>Reporter</span>
+        <span>Kategorie</span><span>Status</span><span>Datum</span>
+      </div>
+      {#each tickets as t (t.ticket_id)}
+        <div class="border-b border-gray-700/50 last:border-0">
+          <div
+            class="grid grid-cols-[120px_1fr_140px_90px_90px_120px] gap-2 px-4 py-2.5 text-xs items-center cursor-pointer hover:bg-gray-700/30 transition-colors"
+            on:click={() => expandedId = expandedId === t.ticket_id ? null : t.ticket_id}
+            role="button"
+            tabindex="0"
+            on:keydown={(e) => e.key === 'Enter' && (expandedId = expandedId === t.ticket_id ? null : t.ticket_id)}
+          >
+            <span class="font-mono text-gray-300">{t.ticket_id}</span>
+            <span class="text-gray-300 truncate">{t.description.slice(0, 80)}{t.description.length > 80 ? '…' : ''}</span>
+            <span class="text-gray-400 truncate">{t.reporter_email}</span>
+            <span class="text-gray-400">{CATEGORY_LABELS[t.category] ?? t.category}</span>
+            <span class="px-1.5 py-0.5 rounded text-xs font-mono
+              {t.status === 'open' ? 'bg-yellow-900/40 text-yellow-300' : t.status === 'resolved' ? 'bg-green-900/40 text-green-300' : 'bg-gray-700 text-gray-400'}">
+              {t.status}
+            </span>
+            <span class="text-gray-500">{fmtDate(t.created_at)}</span>
+          </div>
+
+          {#if expandedId === t.ticket_id}
+            <div class="px-4 pb-4 bg-gray-900/30 space-y-3 text-xs">
+              {#if t.url}
+                <p class="text-gray-500">URL: <a href={t.url} target="_blank" rel="noopener" class="text-blue-400 hover:underline">{t.url}</a></p>
+              {/if}
+              <p class="text-gray-300 whitespace-pre-wrap leading-relaxed">{t.description}</p>
+              {#if t.resolution_note}
+                <p class="text-green-400">Lösung: {t.resolution_note}</p>
+              {/if}
+              {#if t.screenshots?.length > 0}
+                <div class="flex gap-2 flex-wrap mt-2">
+                  {#each t.screenshots as ss}
+                    <a href={ss.data_url} target="_blank" rel="noopener">
+                      <img src={ss.data_url} alt={ss.filename} class="h-20 rounded border border-gray-700 object-cover" />
+                    </a>
+                  {/each}
+                </div>
+              {/if}
+              {#if t.status === 'open'}
+                <div class="flex gap-2 pt-1">
+                  <button
+                    on:click|stopPropagation={() => { resolveModalId = t.ticket_id; resolveNote = ''; resolveError = ''; }}
+                    class="px-3 py-1.5 bg-green-800 hover:bg-green-700 text-green-200 rounded text-xs">
+                    Erledigen
+                  </button>
+                  <button
+                    on:click|stopPropagation={() => archiveTicket(t.ticket_id)}
+                    disabled={actionLoading === t.ticket_id}
+                    class="px-3 py-1.5 bg-gray-700 hover:bg-gray-600 text-gray-300 rounded text-xs disabled:opacity-50">
+                    {actionLoading === t.ticket_id ? '…' : 'Archivieren'}
+                  </button>
+                </div>
+              {/if}
+            </div>
+          {/if}
+        </div>
+      {/each}
+    {/if}
+  </div>
+</div>
+
+<!-- Resolve modal -->
+{#if resolveModalId}
+  <div class="fixed inset-0 bg-black/60 flex items-center justify-center z-50" role="dialog">
+    <div class="bg-gray-800 border border-gray-600 rounded-lg p-5 w-full max-w-md space-y-3">
+      <h3 class="font-semibold text-gray-100 text-sm">Ticket erledigen: {resolveModalId}</h3>
+      <textarea bind:value={resolveNote} rows={3} placeholder="Lösungshinweis…"
+        class="w-full bg-gray-900 border border-gray-600 rounded p-2 text-sm text-gray-200 resize-none focus:outline-none"></textarea>
+      {#if resolveError}<p class="text-red-400 text-xs">{resolveError}</p>{/if}
+      <div class="flex gap-2 justify-end">
+        <button on:click={() => resolveModalId = null} class="px-3 py-1.5 text-sm text-gray-400 hover:text-gray-200">Abbrechen</button>
+        <button on:click={resolveTicket} disabled={resolveLoading || !resolveNote.trim()}
+          class="px-3 py-1.5 text-sm bg-green-700 hover:bg-green-600 disabled:opacity-50 text-white rounded">
+          {resolveLoading ? '…' : 'Speichern'}
+        </button>
+      </div>
+    </div>
+  </div>
+{/if}

--- a/website/src/components/admin/monitoring/OverviewTab.svelte
+++ b/website/src/components/admin/monitoring/OverviewTab.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { onMount, onDestroy, createEventDispatcher } from 'svelte';
 
-  const dispatch = createEventDispatcher<{ navigate: 'cluster' | 'tests' | 'deployments' | 'berichte' }>();
+  const dispatch = createEventDispatcher<{ navigate: 'cluster' | 'tasks' | 'deployments' }>();
 
   type Pod = { phase: string; ready: boolean; restarts: number };
   type Deployment = { status: 'healthy' | 'degraded' | 'stopped'; name: string };
@@ -47,7 +47,7 @@
   }
 
   async function startTests() {
-    dispatch('navigate', 'tests');
+    dispatch('navigate', 'tasks');
     // Give the tab a moment to mount, then trigger the run
     await fetch('/api/admin/tests/run', {
       method: 'POST',
@@ -109,7 +109,7 @@
       <div class="text-xs text-gray-500 mt-1 truncate">{firstDegraded ? firstDegraded.name : 'alle healthy'}</div>
     </button>
 
-    <button on:click={() => dispatch('navigate', 'tests')}
+    <button on:click={() => dispatch('navigate', 'tasks')}
       class="bg-gray-800 border border-gray-700 rounded-lg p-4 text-left hover:border-gray-500 transition-colors">
       <div class="text-xs text-gray-500 uppercase tracking-wide mb-1">Letzter Testlauf</div>
       {#if lastTestRun}
@@ -125,7 +125,7 @@
       {/if}
     </button>
 
-    <button on:click={() => dispatch('navigate', 'berichte')}
+    <button on:click={() => dispatch('navigate', 'tasks')}
       class="bg-gray-800 border border-gray-700 rounded-lg p-4 text-left hover:border-gray-500 transition-colors">
       <div class="text-xs text-gray-500 uppercase tracking-wide mb-1">Staleness</div>
       <div class="text-2xl font-bold font-mono {stalenessColor}">{stalenessStatus}</div>
@@ -164,7 +164,7 @@
     <div class="bg-gray-800 border border-gray-700 rounded-lg p-4">
       <div class="flex justify-between items-center mb-3">
         <span class="text-sm font-semibold text-gray-200">Staleness-Bericht</span>
-        <button on:click={() => dispatch('navigate', 'berichte')} class="text-xs text-blue-400 hover:text-blue-300">→ Berichte</button>
+        <button on:click={() => dispatch('navigate', 'tasks')} class="text-xs text-blue-400 hover:text-blue-300">→ Tasks</button>
       </div>
       {#if stalenessReport?.reportJson?.findings}
         <div class="space-y-1.5">
@@ -190,7 +190,7 @@
         <span class="text-sm font-semibold text-gray-200">
           Letzter Testlauf{lastTestRun ? ` — ${lastTestRun.tier} · ${new Date(lastTestRun.startedAt).toLocaleString('de-DE')}` : ''}
         </span>
-        <button on:click={() => dispatch('navigate', 'tests')} class="text-xs text-blue-400 hover:text-blue-300">→ Tests</button>
+        <button on:click={() => dispatch('navigate', 'tasks')} class="text-xs text-blue-400 hover:text-blue-300">→ Tasks</button>
       </div>
       {#if lastTestRun}
         <div class="flex gap-2 flex-wrap">

--- a/website/src/components/admin/monitoring/TasksTab.svelte
+++ b/website/src/components/admin/monitoring/TasksTab.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+  import TestRunner from './TestRunner.svelte';
+  import PlaywrightPanel from './PlaywrightPanel.svelte';
+</script>
+
+<div class="space-y-6">
+  <div>
+    <p class="text-xs font-semibold text-gray-500 uppercase tracking-widest mb-3">Unit &amp; Integration Tests</p>
+    <TestRunner />
+  </div>
+  <div>
+    <p class="text-xs font-semibold text-gray-500 uppercase tracking-widest mb-3">E2E Tests (Playwright)</p>
+    <PlaywrightPanel />
+  </div>
+</div>

--- a/website/src/components/admin/monitoring/TrackingTab.svelte
+++ b/website/src/components/admin/monitoring/TrackingTab.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+  export let trackingUrl: string = '';
+</script>
+
+<div class="space-y-4">
+  {#if trackingUrl}
+    <div class="bg-gray-800 border border-gray-700 rounded-lg overflow-hidden">
+      <div class="flex items-center justify-between px-4 py-3 border-b border-gray-700">
+        <span class="text-sm font-semibold text-gray-200">Anforderungs-Tracking (Bachelorprojekt)</span>
+        <a href={trackingUrl} target="_blank" rel="noopener noreferrer"
+           class="text-xs text-blue-400 hover:text-blue-300">↗ Öffnen</a>
+      </div>
+      <iframe
+        src={trackingUrl}
+        title="Bachelorprojekt Tracking"
+        class="w-full border-0"
+        style="height: 600px;"
+        sandbox="allow-same-origin allow-scripts allow-forms"
+      ></iframe>
+    </div>
+  {:else}
+    <div class="bg-gray-800 border border-gray-700 rounded-lg p-6 text-center">
+      <p class="text-sm text-gray-400 mb-2">Tracking-URL nicht konfiguriert.</p>
+      <p class="text-xs text-gray-500">Setze <code class="font-mono bg-gray-900 px-1 rounded">TRACKING_EXTERNAL_URL</code> in der Umgebungskonfiguration.</p>
+      <p class="text-xs text-gray-500 mt-1">Dev-Default: <code class="font-mono bg-gray-900 px-1 rounded">http://tracking.localhost</code></p>
+    </div>
+  {/if}
+</div>

--- a/website/src/components/portal/DashboardSection.astro
+++ b/website/src/components/portal/DashboardSection.astro
@@ -7,10 +7,9 @@ interface Props {
   pendingQuestionnaires: number;
   ncBase: string;
   vaultUrl: string;
-  wbUrl?: string;
 }
 
-const { session, pendingSignatures, pendingQuestionnaires, ncBase, vaultUrl, wbUrl = '' } = Astro.props;
+const { session, pendingSignatures, pendingQuestionnaires, ncBase, vaultUrl } = Astro.props;
 
 const firstName = session.given_name?.trim()
   || session.name?.split(' ')[0]?.trim()
@@ -35,7 +34,6 @@ const tiles = [
 const externalServices = [
   ...(ncBase   ? [{ href: ncBase,   label: 'Nextcloud',   desc: 'Dateien & Kalender' }] : []),
   ...(vaultUrl ? [{ href: vaultUrl, label: 'Vaultwarden', desc: 'Passwörter'         }] : []),
-  ...(wbUrl    ? [{ href: wbUrl,    label: 'Whiteboard',  desc: 'Skizzen & Boards'   }] : []),
 ];
 
 const hasPending = pendingSignatures > 0 || pendingQuestionnaires > 0;

--- a/website/src/components/portal/DiensteSection.astro
+++ b/website/src/components/portal/DiensteSection.astro
@@ -2,11 +2,10 @@
 interface Props {
   ncBase: string;
   vaultUrl: string;
-  wbUrl?: string;
   bretUrl?: string;
   keycloakBase: string;
 }
-const { ncBase, vaultUrl, wbUrl = '', bretUrl = '', keycloakBase } = Astro.props;
+const { ncBase, vaultUrl, bretUrl = '', keycloakBase } = Astro.props;
 
 const services = [
   ...(ncBase ? [
@@ -15,7 +14,6 @@ const services = [
     { href: `${ncBase}/apps/contacts/`,   label: 'Kontakte',   desc: 'Adressbuch',                 icon: '👥' },
     { href: `${ncBase}/apps/spreed/`,     label: 'Talk',       desc: 'Video & Gruppen-Chat',       icon: '🎥' },
   ] : []),
-  ...(wbUrl   ? [{ href: wbUrl,   label: 'Whiteboard', desc: 'Gemeinsames Zeichenbrett',  icon: '🖊️' }] : []),
   ...(bretUrl ? [{ href: bretUrl, label: 'Brett',      desc: 'Systemisches Brett (3D)',   icon: '🪄' }] : []),
   ...(vaultUrl ? [{ href: vaultUrl, label: 'Passwörter',  desc: 'Vaultwarden Safe',       icon: '🔒' }] : []),
 ];

--- a/website/src/components/portal/OverviewSection.astro
+++ b/website/src/components/portal/OverviewSection.astro
@@ -10,10 +10,9 @@ interface Props {
   onboardingPct: number;
   ncBase: string;
   vaultUrl: string;
-  wbUrl?: string;
 }
 
-const { session, nextBooking, openInvoices, unreadMessages, onboardingPct, ncBase, vaultUrl, wbUrl = '' } = Astro.props;
+const { session, nextBooking, openInvoices, unreadMessages, onboardingPct, ncBase, vaultUrl } = Astro.props;
 
 const services = [
   ...(ncBase ? [
@@ -21,7 +20,6 @@ const services = [
     { href: `${ncBase}/apps/calendar/`,    label: 'Kalender',   desc: 'Nextcloud' },
     { href: `${ncBase}/apps/spreed/`,      label: 'Talk',       desc: 'Video & Chat' },
   ] : []),
-  ...(wbUrl ? [{ href: wbUrl, label: 'Whiteboard', desc: 'Nextcloud' }] : []),
   ...(vaultUrl ? [{ href: vaultUrl, label: 'Passwörter', desc: 'Vaultwarden' }] : []),
 ];
 ---

--- a/website/src/env.d.ts
+++ b/website/src/env.d.ts
@@ -35,6 +35,7 @@ interface ImportMetaEnv {
   readonly AUTH_EXTERNAL_URL?: string;
   readonly VAULT_EXTERNAL_URL?: string;
   readonly WHITEBOARD_EXTERNAL_URL?: string;
+  readonly TRACKING_EXTERNAL_URL?: string;
   // Nextcloud CalDAV
   readonly NEXTCLOUD_URL: string;
   readonly NEXTCLOUD_CALDAV_USER: string;

--- a/website/src/layouts/AdminLayout.astro
+++ b/website/src/layouts/AdminLayout.astro
@@ -5,6 +5,7 @@ import BugReportWidget from '../components/BugReportWidget.svelte';
 import HelpPanel from '../components/HelpPanel.svelte';
 import ChatWidget from '../components/ChatWidget.svelte';
 import SessionExpiryWarning from '../components/SessionExpiryWarning.svelte';
+import { countPendingByType } from '../lib/messaging-db';
 
 interface Props {
   title: string;
@@ -15,6 +16,7 @@ interface NavItem {
   label: string;
   icon: string;
   matches?: string[];
+  badge?: number;
 }
 
 const { title } = Astro.props;
@@ -63,7 +65,6 @@ const navGroups: { label: string; items: NavItem[] }[] = [
   {
     label: 'Betrieb',
     items: [
-      { href: '/admin/bugs',          label: 'Bugs',          icon: 'bug' },
       { href: '/admin/meetings',      label: 'Meetings',      icon: 'microphone' },
       { href: '/admin/termine',       label: 'Termine',       icon: 'calendar' },
       { href: '/admin/clients',       label: 'Clients',       icon: 'users' },
@@ -97,7 +98,7 @@ const navGroups: { label: string; items: NavItem[] }[] = [
     label: 'System',
     items: [
       { href: '/admin/monitoring', label: 'Monitoring', icon: 'monitor' },
-      { href: '/admin/inbox',      label: 'Inbox',      icon: 'inbox' },
+      { href: '/admin/inbox',      label: 'Inbox',      icon: 'inbox', badge: inboxPending },
     ],
   },
   {
@@ -120,6 +121,12 @@ function isActive(href: string, matches?: string[]): boolean {
 }
 
 const brandWord = config.meta.siteTitle.replace(/\.de$/i, '').toLowerCase();
+
+let inboxPending = 0;
+try {
+  const counts = await countPendingByType();
+  inboxPending = Object.values(counts).reduce((a, b) => a + b, 0);
+} catch { /* ignore if messaging-db unavailable */ }
 ---
 
 <!doctype html>
@@ -327,7 +334,7 @@ const brandWord = config.meta.siteTitle.replace(/\.de$/i, '').toLowerCase();
                     href={item.href}
                     title={item.label}
                     class={`sidebar-nav-item${isActive(item.href, item.matches) ? ' is-active' : ''}`}
-                    style={`display:flex; align-items:center; gap:9px; padding:8px 10px; border-radius:8px; text-decoration:none; font-size:13px; font-weight:500; transition:background 0.1s ease, color 0.1s ease; ${
+                    style={`display:flex; align-items:center; gap:9px; padding:8px 10px; border-radius:10px; text-decoration:none; font-size:13px; font-weight:500; transition:background 0.1s ease, color 0.1s ease; ${
                       isActive(item.href, item.matches)
                         ? 'background:var(--brass-d); color:var(--brass);'
                         : 'color:var(--fg-soft);'
@@ -338,7 +345,10 @@ const brandWord = config.meta.siteTitle.replace(/\.de$/i, '').toLowerCase();
                       style={`flex-shrink:0; width:16px; height:16px; display:flex; align-items:center; justify-content:center; transition:color 0.1s ease; ${isActive(item.href, item.matches) ? 'color:var(--brass);' : 'color:var(--mute);'}`}
                       set:html={icons[item.icon]}
                     />
-                    <span class="sidebar-label">{item.label}</span>
+                    <span class="sidebar-label" style="flex:1;">{item.label}</span>
+                    {item.badge ? (
+                      <span class="sidebar-label" style="flex-shrink:0; min-width:18px; height:18px; padding:0 5px; border-radius:9px; background:var(--brass-d); color:var(--brass); font-family:var(--font-mono); font-size:10px; font-weight:700; display:flex; align-items:center; justify-content:center; line-height:1;">{item.badge}</span>
+                    ) : null}
                   </a>
                 </li>
               ))}

--- a/website/src/pages/admin.astro
+++ b/website/src/pages/admin.astro
@@ -56,22 +56,36 @@ const traefikUrl  = process.env.TRAEFIK_EXTERNAL_URL ?? '';
 const mailUrl     = process.env.MAIL_EXTERNAL_URL ?? '';
 const bretDomain  = process.env.BRETT_DOMAIN ?? '';
 const bretUrl     = bretDomain ? `https://${bretDomain}` : '';
+const SVG = {
+  inbox:      `<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3.5" width="12" height="10" rx="1"/><path d="M2 10h3.5l1.5 2 1.5-2H12"/></svg>`,
+  folder:     `<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M1.5 4.5h5L8 3h6.5v9.5a1 1 0 0 1-1 1h-12a1 1 0 0 1-1-1V5.5a1 1 0 0 1 1-1z"/></svg>`,
+  calendar:   `<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="12" height="11" rx="1"/><path d="M2 7h12M5.5 1.5v3M10.5 1.5v3"/></svg>`,
+  contacts:   `<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="5.5" cy="5" r="2.5"/><path d="M1 14a4.5 4.5 0 0 1 9 0"/><circle cx="12" cy="5" r="2"/><path d="M14.5 13a3.5 3.5 0 0 0-3.5-3"/></svg>`,
+  video:      `<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="1" y="4" width="9" height="8" rx="1"/><path d="M10 6.5l4-2v7l-4-2"/></svg>`,
+  brett:      `<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="2" width="12" height="12" rx="1"/><path d="M8 5v6M5 8h6"/></svg>`,
+  receipt:    `<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M4 1.5h8v13l-2-1.5-2 1.5-2-1.5-2 1.5z"/><path d="M6 6h4M6 8.5h4M6 11h2"/></svg>`,
+  lock:       `<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="7" width="10" height="8" rx="1"/><path d="M5 7V5a3 3 0 0 1 6 0v2"/><circle cx="8" cy="11" r="1" fill="currentColor" stroke="none"/></svg>`,
+  key:        `<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="5.5" cy="7" r="3.5"/><path d="M8.5 9.5l5.5 5.5M11 12l2-2"/></svg>`,
+  book:       `<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M3 2h9a1 1 0 0 1 1 1v10a1 1 0 0 1-1 1H3"/><path d="M3 2a1 1 0 0 0-1 1v10a1 1 0 0 0 1 1"/><path d="M8 6h3M8 9h3"/></svg>`,
+  network:    `<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="3" r="1.5"/><circle cx="2.5" cy="12" r="1.5"/><circle cx="13.5" cy="12" r="1.5"/><path d="M8 4.5v3M8 7.5l-4.5 3M8 7.5l4.5 3"/></svg>`,
+  mail:       `<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="4" width="12" height="9" rx="1"/><path d="M2 4.5l6 4.5 6-4.5"/></svg>`,
+};
+
 const adminLinks = [
-  { href: '/admin/inbox', label: 'Inbox', icon: '📬' },
+  { href: '/admin/inbox', label: 'Inbox', icon: SVG.inbox },
   ...(ncBase ? [
-    { href: `${ncBase}/apps/files/`,      label: 'Dateien',    icon: '📁' },
-    { href: `${ncBase}/apps/calendar/`,   label: 'Kalender',   icon: '📅' },
-    { href: `${ncBase}/apps/contacts/`,   label: 'Kontakte',   icon: '👥' },
-    { href: `${ncBase}/apps/spreed/`,     label: 'Talk',       icon: '🎥' },
+    { href: `${ncBase}/apps/files/`,    label: 'Dateien',  icon: SVG.folder },
+    { href: `${ncBase}/apps/calendar/`, label: 'Kalender', icon: SVG.calendar },
+    { href: `${ncBase}/apps/contacts/`, label: 'Kontakte', icon: SVG.contacts },
+    { href: `${ncBase}/apps/spreed/`,   label: 'Talk',     icon: SVG.video },
   ] : []),
-  ...(wbUrl    ? [{ href: wbUrl,    label: 'Whiteboard', icon: '🖊️' }] : []),
-  ...(bretUrl  ? [{ href: bretUrl,  label: 'Brett',      icon: '🪄' }] : []),
-  { href: '/admin/rechnungen', label: 'Abrechnung', icon: '🧾' },
-  ...(vaultUrl    ? [{ href: vaultUrl,          label: 'Passwörter', icon: '🔐' }] : []),
-  ...(authUrl     ? [{ href: `${authUrl}/admin/workspace/console/`, label: 'Keycloak', icon: '🔑' }] : []),
-  ...(docsUrl     ? [{ href: docsUrl,           label: 'Docs',       icon: '📖' }] : []),
-  ...(traefikUrl  ? [{ href: traefikUrl,        label: 'Traefik',    icon: '🛣️' }] : []),
-  ...(mailUrl     ? [{ href: mailUrl,            label: 'Mailpit',    icon: '✉️' }] : []),
+  ...(bretUrl  ? [{ href: bretUrl, label: 'Brett', icon: SVG.brett }] : []),
+  { href: '/admin/rechnungen', label: 'Abrechnung', icon: SVG.receipt },
+  ...(vaultUrl   ? [{ href: vaultUrl,                                 label: 'Passwörter', icon: SVG.lock }] : []),
+  ...(authUrl    ? [{ href: `${authUrl}/admin/workspace/console/`,    label: 'Keycloak',   icon: SVG.key }] : []),
+  ...(docsUrl    ? [{ href: docsUrl,                                  label: 'Docs',       icon: SVG.book }] : []),
+  ...(traefikUrl ? [{ href: traefikUrl,                               label: 'Traefik',    icon: SVG.network }] : []),
+  ...(mailUrl    ? [{ href: mailUrl,                                  label: 'Mailpit',    icon: SVG.mail }] : []),
 ];
 ---
 

--- a/website/src/pages/admin/[clientId].astro
+++ b/website/src/pages/admin/[clientId].astro
@@ -89,32 +89,45 @@ try {
         <div class="flex gap-2 flex-wrap">
           <button
             id="edit-user-btn"
-            class="px-3 py-1.5 bg-dark-light border border-dark-lighter text-light rounded-lg text-sm hover:border-gold/40 transition-colors"
+            class="inline-flex items-center gap-1.5 px-3 py-1.5 bg-dark-light border border-dark-lighter text-light rounded-lg text-sm hover:border-gold/40 transition-colors"
           >
-            ✏️ Bearbeiten
+            <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="w-3.5 h-3.5" aria-hidden="true"><path d="M11 2l3 3-8.5 8.5H2v-3.5z"/><path d="M9.5 3.5l3 3"/></svg>
+            Bearbeiten
           </button>
           <button
             id="toggle-enabled-btn"
             data-user-id={clientId}
             data-enabled={client.enabled !== false ? 'true' : 'false'}
-            class={`px-3 py-1.5 rounded-lg text-sm transition-colors ${client.enabled !== false ? 'bg-dark-light border border-dark-lighter text-muted hover:border-red-500/40 hover:text-red-400' : 'bg-green-500/20 border border-green-500/30 text-green-400 hover:bg-green-500/30'}`}
+            class={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm transition-colors ${client.enabled !== false ? 'bg-dark-light border border-dark-lighter text-muted hover:border-red-500/40 hover:text-red-400' : 'bg-green-500/20 border border-green-500/30 text-green-400 hover:bg-green-500/30'}`}
           >
-            {client.enabled !== false ? '🔒 Deaktivieren' : '✅ Aktivieren'}
+            {client.enabled !== false ? (
+              <>
+                <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="w-3.5 h-3.5" aria-hidden="true"><rect x="3" y="7" width="10" height="8" rx="1"/><path d="M5 7V5a3 3 0 0 1 6 0v2"/></svg>
+                Deaktivieren
+              </>
+            ) : (
+              <>
+                <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="w-3.5 h-3.5" aria-hidden="true"><path d="M2.5 8.5l4 4 7-8"/></svg>
+                Aktivieren
+              </>
+            )}
           </button>
           <button
             id="reset-password-btn"
             data-user-id={clientId}
-            class="px-3 py-1.5 bg-dark-light border border-dark-lighter text-muted rounded-lg text-sm hover:border-gold/40 hover:text-light transition-colors"
+            class="inline-flex items-center gap-1.5 px-3 py-1.5 bg-dark-light border border-dark-lighter text-muted rounded-lg text-sm hover:border-gold/40 hover:text-light transition-colors"
           >
-            🔑 Passwort-Reset
+            <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="w-3.5 h-3.5" aria-hidden="true"><circle cx="5.5" cy="7" r="3.5"/><path d="M8.5 9.5l5.5 5.5M11 12l2-2"/></svg>
+            Passwort-Reset
           </button>
           <button
             id="delete-user-btn"
             data-user-id={clientId}
             data-user-name={`${client.firstName} ${client.lastName}`}
-            class="px-3 py-1.5 bg-dark-light border border-dark-lighter text-muted rounded-lg text-sm hover:border-red-500/40 hover:text-red-400 transition-colors"
+            class="inline-flex items-center gap-1.5 px-3 py-1.5 bg-dark-light border border-dark-lighter text-muted rounded-lg text-sm hover:border-red-500/40 hover:text-red-400 transition-colors"
           >
-            🗑️ Löschen
+            <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="w-3.5 h-3.5" aria-hidden="true"><path d="M2.5 4.5h11M6 4.5V3h4v1.5M5 4.5l.5 9h5l.5-9"/><path d="M7 7v4.5M9 7v4.5"/></svg>
+            Löschen
           </button>
         </div>
       </div>

--- a/website/src/pages/admin/clients.astro
+++ b/website/src/pages/admin/clients.astro
@@ -43,7 +43,18 @@ try {
           <h1 class="text-3xl font-bold text-light font-serif">Clients</h1>
           <p class="text-muted mt-1">{users.length} Benutzer</p>
         </div>
-        <div class="flex gap-3">
+        <div class="flex gap-2">
+          <!-- View toggle -->
+          <div class="flex border border-dark-lighter rounded-lg overflow-hidden" id="view-toggle">
+            <button id="view-grid-btn" title="Kachelansicht"
+              class="px-3 py-2 bg-gold text-dark transition-colors" aria-pressed="true">
+              <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="w-4 h-4" aria-hidden="true"><rect x="2" y="2" width="5" height="5" rx="0.5"/><rect x="9" y="2" width="5" height="5" rx="0.5"/><rect x="2" y="9" width="5" height="5" rx="0.5"/><rect x="9" y="9" width="5" height="5" rx="0.5"/></svg>
+            </button>
+            <button id="view-list-btn" title="Listenansicht"
+              class="px-3 py-2 bg-dark-light text-muted hover:text-light transition-colors" aria-pressed="false">
+              <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="w-4 h-4" aria-hidden="true"><path d="M2 4h12M2 8h12M2 12h12"/></svg>
+            </button>
+          </div>
           <button
             id="new-client-btn"
             class="px-4 py-2 bg-gold text-dark rounded-lg text-sm font-semibold hover:bg-gold/80 transition-colors"
@@ -188,46 +199,120 @@ try {
         </div>
       )}
 
-      <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-3" data-testid="admin-client-list">
-        {users.map(user => {
-          const initial = ((user.firstName || user.lastName || user.username || '?')[0]).toUpperCase();
-          const fullName = [user.firstName, user.lastName].filter(Boolean).join(' ') || user.username;
-          const custNum = user.email ? customerNumberByEmail.get(user.email) : undefined;
-          return (
-            <a
-              href={`/admin/${user.id}`}
-              class={`group flex flex-col gap-3 p-4 bg-dark-light rounded-xl border transition-all duration-150 ${user.enabled === false ? 'border-red-500/20 opacity-60' : 'border-dark-lighter hover:border-gold/40'}`}
-              data-testid="admin-client-item"
-            >
-              <div class="flex items-start justify-between gap-2">
-                <div style="width:38px; height:38px; border-radius:50%; background:radial-gradient(circle at 30% 30%, var(--brass-2), var(--brass) 55%, #8a6a2a 100%); box-shadow:inset 0 0 0 1px rgba(255,255,255,.18), 0 0 0 1px rgba(0,0,0,.25); display:flex; align-items:center; justify-content:center; flex-shrink:0;">
-                  <span style="font-family:var(--font-serif); font-size:16px; font-weight:600; color:var(--ink-900); line-height:1;">{initial}</span>
+      <!-- Client list (grid/list switchable) -->
+      <div id="client-list-container" data-testid="admin-client-list">
+
+        <!-- Grid view -->
+        <div id="client-grid" class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-3">
+          {users.map(user => {
+            const initial = ((user.firstName || user.lastName || user.username || '?')[0]).toUpperCase();
+            const fullName = [user.firstName, user.lastName].filter(Boolean).join(' ') || user.username;
+            const custNum = user.email ? customerNumberByEmail.get(user.email) : undefined;
+            return (
+              <a
+                href={`/admin/${user.id}`}
+                class={`group flex flex-col gap-3 p-4 bg-dark-light rounded-xl border transition-all duration-150 ${user.enabled === false ? 'border-red-500/20 opacity-60' : 'border-dark-lighter hover:border-gold/40'}`}
+                data-testid="admin-client-item"
+              >
+                <div class="flex items-start justify-between gap-2">
+                  <div style="width:38px; height:38px; border-radius:50%; background:radial-gradient(circle at 30% 30%, var(--brass-2), var(--brass) 55%, #8a6a2a 100%); box-shadow:inset 0 0 0 1px rgba(255,255,255,.18), 0 0 0 1px rgba(0,0,0,.25); display:flex; align-items:center; justify-content:center; flex-shrink:0;">
+                    <span style="font-family:var(--font-serif); font-size:16px; font-weight:600; color:var(--ink-900); line-height:1;">{initial}</span>
+                  </div>
+                  {user.enabled === false && (
+                    <span class="text-xs px-1.5 py-0.5 rounded-full bg-red-500/20 text-red-400 leading-none mt-0.5">off</span>
+                  )}
                 </div>
-                {user.enabled === false && (
-                  <span class="text-xs px-1.5 py-0.5 rounded-full bg-red-500/20 text-red-400 leading-none mt-0.5">off</span>
+                <div class="min-w-0 flex-1">
+                  <p class="text-sm font-semibold text-light truncate leading-snug">{fullName}</p>
+                  <p class="text-xs text-muted truncate mt-0.5">{user.email ?? user.username}</p>
+                </div>
+                {custNum && (
+                  <span class="self-start text-xs px-2 py-0.5 rounded-full bg-gold/10 text-gold border border-gold/30 font-mono leading-none">
+                    {custNum}
+                  </span>
                 )}
+              </a>
+            );
+          })}
+          {users.length === 0 && (
+            <p class="text-muted col-span-full">Keine Benutzer gefunden.</p>
+          )}
+        </div>
+
+        <!-- List view (hidden by default) -->
+        <div id="client-list-view" class="hidden">
+          {users.length === 0 ? (
+            <p class="text-muted">Keine Benutzer gefunden.</p>
+          ) : (
+            <div class="rounded-xl border border-dark-lighter overflow-hidden">
+              <!-- Header -->
+              <div class="grid grid-cols-[44px_1fr_180px_120px_80px] gap-3 px-4 py-2.5 bg-dark-light border-b border-dark-lighter text-xs font-medium text-muted uppercase tracking-wide">
+                <span></span>
+                <span>Name</span>
+                <span>E-Mail</span>
+                <span>Kundennr.</span>
+                <span>Status</span>
               </div>
-              <div class="min-w-0 flex-1">
-                <p class="text-sm font-semibold text-light truncate leading-snug">{fullName}</p>
-                <p class="text-xs text-muted truncate mt-0.5">{user.email ?? user.username}</p>
-              </div>
-              {custNum && (
-                <span class="self-start text-xs px-2 py-0.5 rounded-full bg-gold/10 text-gold border border-gold/30 font-mono leading-none">
-                  {custNum}
-                </span>
-              )}
-            </a>
-          );
-        })}
-        {users.length === 0 && (
-          <p class="text-muted col-span-full">Keine Benutzer gefunden.</p>
-        )}
+              {users.map(user => {
+                const initial = ((user.firstName || user.lastName || user.username || '?')[0]).toUpperCase();
+                const fullName = [user.firstName, user.lastName].filter(Boolean).join(' ') || user.username;
+                const custNum = user.email ? customerNumberByEmail.get(user.email) : undefined;
+                return (
+                  <a
+                    href={`/admin/${user.id}`}
+                    class={`grid grid-cols-[44px_1fr_180px_120px_80px] gap-3 px-4 py-3 border-b border-dark-lighter/50 last:border-0 items-center transition-colors ${user.enabled === false ? 'opacity-60' : 'hover:bg-dark-light'}`}
+                    data-testid="admin-client-item"
+                  >
+                    <div style="width:32px; height:32px; border-radius:50%; background:radial-gradient(circle at 30% 30%, var(--brass-2), var(--brass) 55%, #8a6a2a 100%); display:flex; align-items:center; justify-content:center; flex-shrink:0;">
+                      <span style="font-family:var(--font-serif); font-size:13px; font-weight:600; color:var(--ink-900); line-height:1;">{initial}</span>
+                    </div>
+                    <span class="text-sm font-medium text-light truncate">{fullName}</span>
+                    <span class="text-xs text-muted truncate">{user.email ?? user.username}</span>
+                    <span class="text-xs font-mono text-gold truncate">{custNum ?? '—'}</span>
+                    <span class={`text-xs px-1.5 py-0.5 rounded-full self-center ${user.enabled === false ? 'bg-red-500/20 text-red-400' : 'bg-green-500/10 text-green-400'}`}>
+                      {user.enabled === false ? 'off' : 'aktiv'}
+                    </span>
+                  </a>
+                );
+              })}
+            </div>
+          )}
+        </div>
       </div>
     </div>
   </section>
 </AdminLayout>
 
 <script>
+  // View toggle
+  const gridBtn = document.getElementById('view-grid-btn');
+  const listBtn = document.getElementById('view-list-btn');
+  const gridView = document.getElementById('client-grid');
+  const listView = document.getElementById('client-list-view');
+  const STORAGE_KEY = 'admin-clients-view';
+
+  function applyView(mode: 'grid' | 'list') {
+    const isGrid = mode === 'grid';
+    gridView?.classList.toggle('hidden', !isGrid);
+    listView?.classList.toggle('hidden', isGrid);
+    gridBtn?.classList.toggle('bg-gold', isGrid);
+    gridBtn?.classList.toggle('text-dark', isGrid);
+    gridBtn?.classList.toggle('bg-dark-light', !isGrid);
+    gridBtn?.classList.toggle('text-muted', !isGrid);
+    listBtn?.classList.toggle('bg-gold', !isGrid);
+    listBtn?.classList.toggle('text-dark', !isGrid);
+    listBtn?.classList.toggle('bg-dark-light', isGrid);
+    listBtn?.classList.toggle('text-muted', isGrid);
+    gridBtn?.setAttribute('aria-pressed', isGrid ? 'true' : 'false');
+    listBtn?.setAttribute('aria-pressed', isGrid ? 'false' : 'true');
+  }
+
+  const saved = (localStorage.getItem(STORAGE_KEY) ?? 'grid') as 'grid' | 'list';
+  applyView(saved);
+
+  gridBtn?.addEventListener('click', () => { applyView('grid'); localStorage.setItem(STORAGE_KEY, 'grid'); });
+  listBtn?.addEventListener('click', () => { applyView('list'); localStorage.setItem(STORAGE_KEY, 'list'); });
+
   const btn = document.getElementById('new-client-btn');
   const form = document.getElementById('new-client-form');
   const cancelBtn = document.getElementById('cancel-new-client');

--- a/website/src/pages/admin/monitoring.astro
+++ b/website/src/pages/admin/monitoring.astro
@@ -7,16 +7,17 @@ const session = await getSession(Astro.request.headers.get('cookie'));
 if (!session) return Astro.redirect(getLoginUrl(Astro.url.pathname));
 if (!isAdmin(session)) return Astro.redirect('/admin');
 
-const title = "Monitoring";
-const description = "Live Kubernetes metrics and cluster events";
+const trackingUrl = process.env.TRACKING_EXTERNAL_URL ?? 'http://tracking.localhost';
 ---
 
-<AdminLayout title={title} description={description}>
-  <div class="space-y-6">
-    <div class="flex justify-between items-center">
-      <h1 class="text-2xl font-semibold text-gray-900 dark:text-white">System Monitoring</h1>
+<AdminLayout title="Monitoring">
+  <section class="pt-8 pb-20 px-4 sm:px-6 bg-dark min-h-screen">
+    <div class="max-w-7xl mx-auto">
+      <div class="mb-6">
+        <h1 class="text-2xl font-bold text-light font-serif">Monitoring</h1>
+        <p class="text-muted text-sm mt-1">Cluster, Tests, Bugs & Anforderungs-Tracking</p>
+      </div>
+      <MonitoringDashboard client:load {trackingUrl} />
     </div>
-    
-    <MonitoringDashboard client:load />
-  </div>
+  </section>
 </AdminLayout>

--- a/website/src/pages/api/admin/bugs/list.ts
+++ b/website/src/pages/api/admin/bugs/list.ts
@@ -1,0 +1,21 @@
+import type { APIRoute } from 'astro';
+import { getSession, isAdmin } from '../../../../lib/auth';
+import { listBugTickets } from '../../../../lib/website-db';
+
+export const GET: APIRoute = async ({ request }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 });
+  }
+
+  const url = new URL(request.url);
+  const status   = url.searchParams.get('status')   || undefined;
+  const category = url.searchParams.get('category') || undefined;
+  const q        = url.searchParams.get('q')        || undefined;
+  const brand    = process.env.BRAND || 'mentolder';
+
+  const tickets = await listBugTickets({ status, category, q, brand }).catch(() => []);
+  return new Response(JSON.stringify(tickets), {
+    headers: { 'Content-Type': 'application/json' },
+  });
+};

--- a/website/src/pages/portal.astro
+++ b/website/src/pages/portal.astro
@@ -41,7 +41,6 @@ const calMonth  = isNaN(calMonthQ) ? now.getMonth() + 1 : Math.max(1, Math.min(1
 
 const ncBase       = (process.env.NEXTCLOUD_EXTERNAL_URL ?? '').replace(/\/$/, '');
 const vaultUrl     = process.env.VAULT_EXTERNAL_URL ?? '';
-const wbUrl        = process.env.WHITEBOARD_EXTERNAL_URL ?? '';
 const keycloakBase = process.env.KEYCLOAK_FRONTEND_URL ?? '';
 const realm        = process.env.KEYCLOAK_REALM ?? 'workspace';
 const bretDomain   = process.env.BRETT_DOMAIN ?? '';
@@ -101,7 +100,7 @@ const questionnaires: QAssignment[] = (section === 'fragebögen' && customer)
   {pendingSignatures}
   {pendingQuestionnaires}
 >
-  {section === 'overview'       && <DashboardSection {session} {pendingSignatures} {pendingQuestionnaires} {ncBase} {vaultUrl} {wbUrl} />}
+  {section === 'overview'       && <DashboardSection {session} {pendingSignatures} {pendingQuestionnaires} {ncBase} {vaultUrl} />}
   {section === 'nachrichten'    && <NachrichtenSection {rooms} />}
   {section === 'besprechungen'  && <BesprechungenSection {meetings} />}
   {section === 'dateien'        && <DateienSection clientUsername={username} />}
@@ -122,7 +121,7 @@ const questionnaires: QAssignment[] = (section === 'fragebögen' && customer)
     </div>
   )}
   {section === 'fragebögen'     && <FragebogenSection assignments={questionnaires} />}
-  {section === 'dienste'        && <DiensteSection {ncBase} {vaultUrl} {wbUrl} {bretUrl} {keycloakBase} />}
+  {section === 'dienste'        && <DiensteSection {ncBase} {vaultUrl} {bretUrl} {keycloakBase} />}
   {section === 'konto'          && <KontoSection {session} {keycloakBase} {realm} />}
   {section === 'buchung'        && <BuchungSection ncBase={ncBase} />}
 </PortalLayout>


### PR DESCRIPTION
## Summary
- Replace all emoji icons in admin dashboard and client detail pages with inline SVGs; `ServiceLinks.astro` now handles both SVG strings and emoji
- `InboxApp`: remove type-filter sidebar — flat feed with status tabs inline in header + SSR pending badge on sidebar nav link
- `admin/clients`: grid/list toggle persisted in localStorage
- Monitoring: swap Tests/Berichte tabs for **Tasks** (TestRunner + Playwright), **Bugs** (full ticket management with resolve/archive), **Tracking** (bachelorprojekt requirements iframe)
- Remove Whiteboard shortcut from all portal and admin menus (`DashboardSection`, `DiensteSection`, `OverviewSection`, `admin.astro`)
- New: `BugsTab.svelte`, `TasksTab.svelte`, `TrackingTab.svelte`, `/api/admin/bugs/list`, `TRACKING_EXTERNAL_URL` env var

## Test plan
- [ ] Admin dashboard shows SVG service icons (no emoji)
- [ ] Client detail action buttons show SVG icons
- [ ] Inbox loads as flat feed with Offen/Erledigt/Archiv tabs; pending count badge visible in sidebar
- [ ] Clients page toggle between grid and list view; preference survives page reload
- [ ] Monitoring → Tasks tab shows test runner + Playwright panel with section labels
- [ ] Monitoring → Bugs tab loads tickets, resolve/archive works
- [ ] Monitoring → Tracking tab shows iframe (or "not configured" if env var missing)
- [ ] Portal Dienste and Dashboard sections no longer show Whiteboard tile

🤖 Generated with [Claude Code](https://claude.com/claude-code)