### PR TITLE
fix(ci): drop tasks with kubectl preconditions from dry-run test

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -181,7 +181,7 @@ tasks:
     cmds:
       - |
         TASKS="workspace:deploy workspace:status workspace:teardown workspace:validate \
-               workspace:post-setup config:show website:deploy mcp:deploy"
+               workspace:post-setup config:show"
         FAIL=0
         for t in $TASKS; do
           (


### PR DESCRIPTION
## Summary
- `mcp:deploy` and `website:deploy` have `preconditions: kubectl cluster-info > /dev/null 2>&1` which go-task evaluates even in `--dry` mode
- CI has no cluster, so both tasks have been failing the `test:dry-run` check since they were added — a false negative with no relation to Taskfile syntax
- Removed them from the dry-run list; their syntax is still validated when go-task parses the Taskfile on every run

## Test plan
- [x] `task test:dry-run` passes locally (all 6 remaining tasks show ✓)
- [x] CI green (no cluster required for any task in the list)

🤖 Generated with [Claude Code](https://claude.com/claude-code)