### PR TITLE
fix(keycloak): add SMTP_HOST and DASHBOARD_DOMAIN to ArgoCD sync path

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1030,7 +1030,7 @@ tasks:
           ENVSUBST_VARS="$ENVSUBST_VARS \$SMTP_FROM \$SMTP_HOST \$MAIL_FROM_LOCAL \$MAIL_FROM_DOMAIN"
           ENVSUBST_VARS="$ENVSUBST_VARS \$WEBSITE_IMAGE \$TURN_PUBLIC_IP \$TURN_NODE \$BRAND_ID"
           ENVSUBST_VARS="$ENVSUBST_VARS \$KC_USER1_USERNAME \$KC_USER1_EMAIL \$KC_USER2_USERNAME \$KC_USER2_EMAIL"
-          ENVSUBST_VARS="$ENVSUBST_VARS \$BRETT_DOMAIN"
+          ENVSUBST_VARS="$ENVSUBST_VARS \$BRETT_DOMAIN \$DASHBOARD_DOMAIN"
           kustomize build "$overlay/" \
             | envsubst "$ENVSUBST_VARS" \
             | kubectl --context "$ENV_CONTEXT" apply --server-side --force-conflicts -f -

--- a/argocd/applicationset.yaml
+++ b/argocd/applicationset.yaml
@@ -65,6 +65,10 @@ spec:
               value: "{{metadata.annotations.workspace-tls-secret}}"
             - name: SMTP_FROM
               value: "{{metadata.annotations.workspace-smtp-from}}"
+            - name: SMTP_HOST
+              value: "{{metadata.annotations.workspace-smtp-host}}"
+            - name: DASHBOARD_DOMAIN
+              value: "{{metadata.annotations.workspace-dashboard-domain}}"
             - name: TURN_PUBLIC_IP
               value: "{{metadata.annotations.workspace-turn-ip}}"
             - name: TURN_NODE

--- a/environments/korczewski.yaml
+++ b/environments/korczewski.yaml
@@ -36,6 +36,7 @@ env_vars:
   MAIL_EXTERNAL_URL: "https://mail.korczewski.de"
   STRIPE_PUBLISHABLE_KEY: "pk_live_51RhKrcDGTY4NP8aeqnf69F1OVgNleqjLqR5ZHi8jkzlyxLiaTEnsY5xwhgPAVV7FdNb4eRnelIzt7DUj9TTAopXg00yyxjx03t"
   BRETT_DOMAIN: brett.korczewski.de
+  DASHBOARD_DOMAIN: dashboard.korczewski.de
   WEBSITE_HOST: web.korczewski.de
   WEBSITE_SITE_URL: "https://web.korczewski.de"
   KEYCLOAK_FRONTEND_URL: "https://auth.korczewski.de"

--- a/environments/mentolder.yaml
+++ b/environments/mentolder.yaml
@@ -36,6 +36,7 @@ env_vars:
   MAIL_EXTERNAL_URL: "https://mail.mentolder.de"
   STRIPE_PUBLISHABLE_KEY: "pk_live_51TOM2vPmjoQCVSEjX0mKUyfMoEJQssMbl2Me20WSiLJBjhIrxQJiesJrSw6GVlVetbJJ1cH7Wk0rOXHamMN5aVMD00gxhMrdoF"
   BRETT_DOMAIN: brett.mentolder.de
+  DASHBOARD_DOMAIN: dashboard.mentolder.de
   WEBSITE_HOST: web.mentolder.de
   WEBSITE_SITE_URL: "https://web.mentolder.de"
   KEYCLOAK_FRONTEND_URL: "https://auth.mentolder.de"

--- a/environments/schema.yaml
+++ b/environments/schema.yaml
@@ -144,6 +144,10 @@ env_vars:
     required: true
     default_dev: "brett.localhost"
 
+  - name: DASHBOARD_DOMAIN
+    required: true
+    default_dev: "dashboard.localhost"
+
   - name: WEBSITE_HOST
     required: true
     default_dev: "web.localhost"

--- a/prod/import-entrypoint.sh
+++ b/prod/import-entrypoint.sh
@@ -30,6 +30,7 @@ for var in \
     WEB_DOMAIN \
     DOCS_DOMAIN \
     TRAEFIK_DOMAIN \
+    DASHBOARD_DOMAIN \
     MAIL_DOMAIN \
     PROD_DOMAIN \
     KC_USER1_EMAIL \

--- a/prod/patch-keycloak.yaml
+++ b/prod/patch-keycloak.yaml
@@ -18,6 +18,8 @@ spec:
               value: "false"
             - name: SMTP_HOST
               value: "${SMTP_HOST}"
+            - name: DASHBOARD_DOMAIN
+              value: "${DASHBOARD_DOMAIN}"
             - name: SMTP_PORT
               value: "587"
             - name: SMTP_FROM


### PR DESCRIPTION
## Summary

- **Root cause**: Two consecutive PRs left `${SMTP_HOST}` and `${DASHBOARD_DOMAIN}` unresolved in the Keycloak deployment, causing `import-entrypoint.sh`'s sanity check to abort on every pod start (1142 CrashLoopBackOff restarts on mentolder over 4 days; old pod still serving SSO)
- **PR #448** added `${SMTP_HOST}` to `prod/patch-keycloak.yaml` but didn't add it to the ArgoCD ApplicationSet `plugin.env` — ArgoCD synced the literal string `${SMTP_HOST}` into the pod's env var
- **PR #453** added `${DASHBOARD_DOMAIN}` to the prod realm JSON and the dev entrypoint but never updated `prod/import-entrypoint.sh` or the ApplicationSet

## Changes

- `argocd/applicationset.yaml`: add `SMTP_HOST` and `DASHBOARD_DOMAIN` to plugin env, referencing new `workspace-smtp-host` / `workspace-dashboard-domain` cluster annotations
- `prod/patch-keycloak.yaml`: inject `DASHBOARD_DOMAIN` as a container env var (so `import-entrypoint.sh` can read it at runtime)
- `prod/import-entrypoint.sh`: add `DASHBOARD_DOMAIN` to the sed substitution loop
- `environments/{mentolder,korczewski}.yaml`: declare `DASHBOARD_DOMAIN` values
- `environments/schema.yaml`: register `DASHBOARD_DOMAIN` (required, `default_dev=dashboard.localhost`)
- `Taskfile.yml`: add `$DASHBOARD_DOMAIN` to prod deploy `ENVSUBST_VARS`

## Pre-merge action already done

Both ArgoCD cluster secrets have been annotated:
```
kubectl annotate secret cluster-mentolder -n argocd --context mentolder \
  workspace-smtp-host=smtp.mailbox.org \
  workspace-dashboard-domain=dashboard.mentolder.de

kubectl annotate secret cluster-korczewski -n argocd --context mentolder \
  workspace-smtp-host=smtp.mailbox.org \
  workspace-dashboard-domain=dashboard.korczewski.de
```

## Test plan

- [ ] CI passes (kustomize validate, yamllint, shellcheck)
- [ ] After merge: ArgoCD auto-syncs → new Keycloak pod starts without CrashLoopBackOff
- [ ] Rolling update completes: `keycloak-688df57bfc-phlgk` replaced, old `keycloak-6c94d47444-mb62s` terminated
- [ ] `task env:validate ENV=mentolder` and `ENV=korczewski` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)