### PR TITLE
fix(livekit): use INGRESS_CONFIG_BODY for livekit-ingress configuration

### DIFF
--- a/k3d/livekit.yaml
+++ b/k3d/livekit.yaml
@@ -218,8 +218,6 @@ spec:
             - name: http
               containerPort: 8080
           env:
-            - name: LIVEKIT_URL
-              value: "ws://livekit-server:7880"
             - name: API_KEY
               valueFrom:
                 secretKeyRef:
@@ -230,8 +228,16 @@ spec:
                 secretKeyRef:
                   name: workspace-secrets
                   key: LIVEKIT_API_SECRET
-            - name: REDIS_URL
-              value: "redis://livekit-redis:6379"
+            - name: INGRESS_CONFIG_BODY
+              value: |
+                api_key: $(API_KEY)
+                api_secret: $(API_SECRET)
+                ws_url: ws://livekit-server:7880
+                redis:
+                  address: livekit-redis:6379
+                rtmp:
+                  port: 1935
+                http_relay_port: 8080
           resources:
             requests:
               memory: 128Mi


### PR DESCRIPTION
## Summary
- `livekit-ingress` was crashing with "missing config" — the binary requires a config file or `INGRESS_CONFIG_BODY` env var, not individual `LIVEKIT_URL`/`API_KEY` env vars
- Switch to `INGRESS_CONFIG_BODY` pattern (same as how `livekit-egress` uses `EGRESS_CONFIG_BODY`)
- API key/secret injected via K8s `$(API_KEY)`/`$(API_SECRET)` substitution from `workspace-secrets`

## Test Plan
- [ ] `livekit-ingress` pod reaches Running state on mentolder
- [ ] OBS can connect via RTMP to `rtmp://stream.mentolder.de/live/<RTMP_KEY>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)