### PR TITLE
fix(admin): add @types/node reference, fix inboxPending TDZ, remove Stripe column

### DIFF
--- a/website/src/env.d.ts
+++ b/website/src/env.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="astro/client" />
+/// <reference types="node" />
 
 interface ImportMetaEnv {
   // Keycloak

--- a/website/src/layouts/AdminLayout.astro
+++ b/website/src/layouts/AdminLayout.astro
@@ -56,6 +56,12 @@ const icons: Record<string, string> = {
   broadcast: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 8a6 6 0 0 1 0 8"/><path d="M6 8a6 6 0 0 0 0 8"/><circle cx="12" cy="12" r="2"/><path d="M21 5a11 11 0 0 1 0 14"/><path d="M3 5a11 11 0 0 0 0 14"/></svg>`,
 };
 
+let inboxPending = 0;
+try {
+  const counts = await countPendingByType();
+  inboxPending = Object.values(counts).reduce((a, b) => a + b, 0);
+} catch { /* ignore if messaging-db unavailable */ }
+
 const navGroups: { label: string; items: NavItem[] }[] = [
   {
     label: 'Übersicht',
@@ -123,12 +129,6 @@ function isActive(href: string, matches?: string[]): boolean {
 }
 
 const brandWord = config.meta.siteTitle.replace(/\.de$/i, '').toLowerCase();
-
-let inboxPending = 0;
-try {
-  const counts = await countPendingByType();
-  inboxPending = Object.values(counts).reduce((a, b) => a + b, 0);
-} catch { /* ignore if messaging-db unavailable */ }
 ---
 
 <!doctype html>

--- a/website/src/pages/admin/rechnungen.astro
+++ b/website/src/pages/admin/rechnungen.astro
@@ -1,7 +1,7 @@
 ---
 import AdminLayout from '../../layouts/AdminLayout.astro';
 import { getSession, getLoginUrl, isAdmin } from '../../lib/auth';
-import { getAllBillingInvoices, stripeInvoiceDashboardUrl, getDraftInvoices } from '../../lib/stripe-billing';
+import { getAllBillingInvoices, getDraftInvoices } from '../../lib/stripe-billing';
 import { listPendingDunnings, type PendingDunning } from '../../lib/invoice-dunning';
 import type { AdminBillingInvoice } from '../../lib/stripe-billing';
 import CreateInvoiceModal from '../../components/admin/CreateInvoiceModal.svelte';
@@ -38,7 +38,7 @@ if (statusFilter === 'mahnwesen') {
     invoices = await getAllBillingInvoices({ status: statusFilter || undefined, perPage: 200 });
   } catch (err) {
     console.error('[admin/rechnungen]', err);
-    apiError = 'Stripe nicht erreichbar.';
+    apiError = 'Datenbank nicht erreichbar.';
   }
 }
 
@@ -181,7 +181,6 @@ const STATUS_TABS = [
               <th class="text-left px-4 py-3 text-xs text-muted uppercase tracking-wide font-medium">Fällig</th>
               <th class="text-right px-4 py-3 text-xs text-muted uppercase tracking-wide font-medium">Betrag</th>
               <th class="text-right px-4 py-3 text-xs text-muted uppercase tracking-wide font-medium">Offen</th>
-              <th class="text-right px-4 py-3 text-xs text-muted uppercase tracking-wide font-medium">Stripe</th>
               <th class="text-right px-4 py-3 text-xs text-muted uppercase tracking-wide font-medium">E-Rechnung</th>
               <th class="text-right px-4 py-3 text-xs text-muted uppercase tracking-wide font-medium">Drucken</th>
             </tr>
@@ -190,7 +189,7 @@ const STATUS_TABS = [
             {statusFilter === 'mahnwesen' ? (
               pendingDunnings.length === 0 ? (
                 <tr>
-                  <td colspan="10" class="px-4 py-10 text-center text-muted text-sm">Keine ausstehenden Mahnungen.</td>
+                  <td colspan="9" class="px-4 py-10 text-center text-muted text-sm">Keine ausstehenden Mahnungen.</td>
                 </tr>
               ) : pendingDunnings.map(d => (
                 <tr class="border-b border-dark-lighter/50 hover:bg-dark/30 transition-colors">
@@ -211,7 +210,6 @@ const STATUS_TABS = [
                   </td>
                   <td class="px-4 py-3 text-sm text-right text-yellow-400 font-medium">{fmtCurrency(d.outstanding)}</td>
                   <td class="px-4 py-3 text-sm text-right">—</td>
-                  <td class="px-4 py-3 text-sm text-right">—</td>
                   <td class="px-4 py-3 text-sm text-right">
                     <button
                       class="text-xs text-yellow-400 hover:underline"
@@ -231,7 +229,7 @@ const STATUS_TABS = [
             ) : (
               invoices.length === 0 ? (
                 <tr>
-                  <td colspan="10" class="px-4 py-10 text-center text-muted text-sm">Keine Rechnungen gefunden.</td>
+                  <td colspan="9" class="px-4 py-10 text-center text-muted text-sm">Keine Rechnungen gefunden.</td>
                 </tr>
               ) : invoices.map(inv => (
               <tr class="border-b border-dark-lighter/50 hover:bg-dark/30 transition-colors">
@@ -252,9 +250,6 @@ const STATUS_TABS = [
                 <td class="px-4 py-3 text-sm text-light text-right font-medium">{fmtCurrency(inv.amountDue)}</td>
                 <td class={`px-4 py-3 text-sm text-right font-medium ${inv.amountRemaining > 0 ? 'text-yellow-400' : 'text-muted'}`}>
                   {inv.amountRemaining > 0 ? fmtCurrency(inv.amountRemaining) : '—'}
-                </td>
-                <td class="px-4 py-3 text-sm text-right">
-                  <a href={stripeInvoiceDashboardUrl(inv.id)} target="_blank" rel="noopener" class="text-xs text-blue-400 hover:underline">Stripe ↗</a>
                 </td>
                 <td class="px-4 py-3 text-sm text-right">
                   {['draft', 'void'].includes(inv.status) ? (


### PR DESCRIPTION
## Summary
- `env.d.ts`: add `/// <reference types="node" />` so `process.env` is typed in server-side API routes (LiveKit token + recording endpoints)
- `AdminLayout.astro`: move `inboxPending` initialization before `navGroups` — it was referenced inside the array literal before the `let` declaration, causing a temporal dead zone error on every admin page render
- `rechnungen.astro`: remove Stripe dashboard URL column and update colspans accordingly

## Test Plan
- [ ] No TypeScript diagnostics in `livekit-token.ts`, `token.ts`, `recording.ts`
- [ ] Admin pages render without TDZ crash
- [ ] Inbox badge shows correct pending count in admin nav

🤖 Generated with [Claude Code](https://claude.com/claude-code)