### PR TITLE
feat(livekit): browser-based publishing + active-stream guard + wss in prod

### DIFF
--- a/website/src/components/LiveStream/StreamPlayer.svelte
+++ b/website/src/components/LiveStream/StreamPlayer.svelte
@@ -6,13 +6,112 @@
   import StreamReactions from './StreamReactions.svelte';
   import StreamHandRaise from './StreamHandRaise.svelte';
 
-  let { livekitUrl, isHost = false }: { livekitUrl: string; isHost?: boolean } = $props();
+  let { livekitUrl, isHost = false, publishMode = 'view' }
+    : { livekitUrl: string; isHost?: boolean; publishMode?: 'view' | 'browser' } = $props();
 
   type State = 'loading' | 'offline' | 'live' | 'error';
   let state = $state<State>('loading');
   let errorMsg = $state('');
   let room = $state<Room | null>(null);
   let videoEl: HTMLVideoElement;
+  let previewEl: HTMLVideoElement;
+
+  let camOn = $state(false);
+  let micOn = $state(false);
+  let screenOn = $state(false);
+  let publishBusy = $state(false);
+  let publishError = $state('');
+  let endingStream = $state(false);
+  // Number of *other* participants currently publishing video (Ingress / another host).
+  // Used to block the host from starting a competing stream.
+  let remoteVideoPublishers = $state(0);
+
+  const showPublishUI = $derived(isHost && publishMode === 'browser');
+  const otherStreamActive = $derived(remoteVideoPublishers > 0);
+  const publishLocked = $derived(otherStreamActive && !camOn && !screenOn && !micOn);
+
+  function recountRemoteVideo(r: Room) {
+    let count = 0;
+    r.remoteParticipants.forEach((p) => {
+      const hasVideo = Array.from(p.videoTrackPublications.values()).some((pub) => !!pub.track);
+      if (hasVideo) count++;
+    });
+    remoteVideoPublishers = count;
+  }
+
+  async function withBusy(fn: () => Promise<void>) {
+    if (!room) return;
+    publishBusy = true;
+    publishError = '';
+    try {
+      await fn();
+    } catch (e) {
+      publishError = (e as Error).message ?? String(e);
+    } finally {
+      publishBusy = false;
+    }
+  }
+
+  async function toggleCam() {
+    if (publishLocked) return;
+    await withBusy(async () => {
+      const next = !camOn;
+      await room!.localParticipant.setCameraEnabled(next);
+      camOn = next;
+      attachLocalCamera();
+    });
+  }
+
+  async function toggleMic() {
+    if (publishLocked) return;
+    await withBusy(async () => {
+      const next = !micOn;
+      await room!.localParticipant.setMicrophoneEnabled(next);
+      micOn = next;
+    });
+  }
+
+  async function toggleScreen() {
+    if (publishLocked) return;
+    await withBusy(async () => {
+      const next = !screenOn;
+      await room!.localParticipant.setScreenShareEnabled(next);
+      screenOn = next;
+    });
+  }
+
+  async function endActiveStream() {
+    if (endingStream) return;
+    endingStream = true;
+    publishError = '';
+    try {
+      const res = await fetch('/api/stream/end', { method: 'POST' });
+      if (!res.ok) {
+        publishError = 'Stream beenden fehlgeschlagen.';
+        return;
+      }
+      // Server has removed publishers; LiveKit will fire ParticipantDisconnected
+      // events that recountRemoteVideo() handles. As a belt-and-suspenders measure,
+      // recount immediately so the UI unlocks even if events are slow.
+      if (room) recountRemoteVideo(room);
+    } catch (e) {
+      publishError = (e as Error).message ?? String(e);
+    } finally {
+      endingStream = false;
+    }
+  }
+
+  function attachLocalCamera() {
+    if (!room || !previewEl) return;
+    const pub = room.localParticipant.getTrackPublication(Track.Source.Camera);
+    const track = pub?.videoTrack;
+    if (track) {
+      track.attach(previewEl);
+      state = 'live';
+    } else {
+      previewEl.srcObject = null;
+    }
+  }
 
   $effect(() => {
     let mounted = true;
@@ -29,9 +128,20 @@
             track.attach(videoEl);
             if (mounted) state = 'live';
           }
+          if (mounted) recountRemoteVideo(r);
         });
         r.on(RoomEvent.TrackUnsubscribed, (track) => {
           track.detach();
+          if (mounted) recountRemoteVideo(r);
+        });
+        r.on(RoomEvent.ParticipantDisconnected, () => {
+          if (mounted) recountRemoteVideo(r);
+        });
+        r.on(RoomEvent.TrackPublished, () => {
+          if (mounted) recountRemoteVideo(r);
+        });
+        r.on(RoomEvent.TrackUnpublished, () => {
+          if (mounted) recountRemoteVideo(r);
         });
         r.on(RoomEvent.Disconnected, () => {
           if (mounted) state = 'offline';
@@ -40,8 +150,13 @@
         await r.connect(livekitUrl, token);
         if (mounted) {
           room = r;
-          // If no tracks yet, show offline; tracks arriving will flip to live
-          state = r.remoteParticipants.size === 0 ? 'offline' : 'live';
+          recountRemoteVideo(r);
+          // Host in browser-publish mode needs the control bar before any tracks exist.
+          if (isHost && publishMode === 'browser') {
+            state = 'live';
+          } else {
+            state = r.remoteParticipants.size === 0 ? 'offline' : 'live';
+          }
         }
       } catch (e) {
         if (mounted) { state = 'error'; errorMsg = String(e); }
@@ -71,10 +186,72 @@
     <div class="flex flex-col bg-black">
       <div class="relative flex-1">
         <!-- svelte-ignore a11y_media_has_caption -->
-        <video bind:this={videoEl} autoplay playsinline class="w-full h-full object-contain"></video>
-        <span class="absolute top-3 right-3 bg-red-600 text-white text-xs font-bold px-2 py-0.5 rounded">● LIVE</span>
+        <video
+          bind:this={videoEl}
+          autoplay
+          playsinline
+          class="w-full h-full object-contain"
+          class:hidden={showPublishUI && camOn}
+        ></video>
+        {#if showPublishUI}
+          <!-- svelte-ignore a11y_media_has_caption -->
+          <video
+            bind:this={previewEl}
+            autoplay
+            playsinline
+            muted
+            class="w-full h-full object-contain"
+            class:hidden={!camOn}
+          ></video>
+        {/if}
+        {#if camOn || micOn || screenOn || !showPublishUI}
+          <span class="absolute top-3 right-3 bg-red-600 text-white text-xs font-bold px-2 py-0.5 rounded">● LIVE</span>
+        {/if}
       </div>
-      <div class="flex items-center gap-3 px-4 py-3 bg-dark-light border-t border-dark-lighter">
+      {#if showPublishUI && otherStreamActive}
+        <div class="flex items-start gap-3 px-4 py-3 bg-amber-950/40 border-t border-amber-800/60 text-sm">
+          <span class="text-amber-300">⚠️</span>
+          <div class="flex-1">
+            <p class="text-amber-100 font-semibold">Es läuft bereits ein Livestream.</p>
+            <p class="text-amber-200/80 text-xs mt-0.5">
+              Beende den aktuellen Stream (z.&nbsp;B. OBS oder einen anderen Browser-Sender), bevor du einen neuen startest.
+            </p>
+          </div>
+          <button
+            onclick={endActiveStream}
+            disabled={endingStream}
+            class="px-3 py-1.5 rounded-lg border border-amber-500 text-amber-100 text-xs font-semibold hover:bg-amber-500 hover:text-dark transition-colors disabled:opacity-50"
+          >{endingStream ? 'Beende…' : 'Aktuellen Stream beenden'}</button>
+        </div>
+      {/if}
+      <div class="flex flex-wrap items-center gap-3 px-4 py-3 bg-dark-light border-t border-dark-lighter">
+        {#if showPublishUI}
+          <button
+            onclick={toggleCam}
+            disabled={publishBusy || publishLocked}
+            title={publishLocked ? 'Beende zuerst den laufenden Stream.' : ''}
+            class="px-3 py-1.5 rounded-lg border text-sm font-semibold transition-colors disabled:opacity-50 disabled:cursor-not-allowed
+                   {camOn ? 'bg-gold text-dark border-gold' : 'bg-dark border-dark-lighter text-light hover:border-gold'}"
+          >📹 {camOn ? 'Kamera aus' : 'Kamera an'}</button>
+          <button
+            onclick={toggleMic}
+            disabled={publishBusy || publishLocked}
+            title={publishLocked ? 'Beende zuerst den laufenden Stream.' : ''}
+            class="px-3 py-1.5 rounded-lg border text-sm font-semibold transition-colors disabled:opacity-50 disabled:cursor-not-allowed
+                   {micOn ? 'bg-gold text-dark border-gold' : 'bg-dark border-dark-lighter text-light hover:border-gold'}"
+          >🎤 {micOn ? 'Mikro aus' : 'Mikro an'}</button>
+          <button
+            onclick={toggleScreen}
+            disabled={publishBusy || publishLocked}
+            title={publishLocked ? 'Beende zuerst den laufenden Stream.' : ''}
+            class="px-3 py-1.5 rounded-lg border text-sm font-semibold transition-colors disabled:opacity-50 disabled:cursor-not-allowed
+                   {screenOn ? 'bg-gold text-dark border-gold' : 'bg-dark border-dark-lighter text-light hover:border-gold'}"
+          >🖥️ {screenOn ? 'Bildschirm aus' : 'Bildschirm teilen'}</button>
+          {#if publishError}
+            <span class="text-xs text-red-400">{publishError}</span>
+          {/if}
+          <span class="ml-auto"></span>
+        {/if}
         <StreamReactions {room} />
         <StreamHandRaise {room} {isHost} />
       </div>

--- a/website/src/pages/admin/stream.astro
+++ b/website/src/pages/admin/stream.astro
@@ -8,7 +8,11 @@ if (!session) return Astro.redirect(getLoginUrl(Astro.url.pathname));
 if (!isAdmin(session)) return Astro.redirect('/admin');
 
 const livekitDomain = process.env.LIVEKIT_DOMAIN || 'livekit.localhost';
-const livekitUrl = `ws://${livekitDomain}`;
+// Plain ws:// only for *.localhost dev; everything else (prod TLS) needs wss://
+// or the HTTPS page blocks the connection as mixed content.
+const livekitUrl = livekitDomain.endsWith('.localhost')
+  ? `ws://${livekitDomain}`
+  : `wss://${livekitDomain}`;
 const streamDomain = process.env.STREAM_DOMAIN || 'stream.localhost';
 const rtmpKey = process.env.LIVEKIT_RTMP_KEY || 'devrtmpkey123456';
 ---
@@ -19,8 +23,26 @@ const rtmpKey = process.env.LIVEKIT_RTMP_KEY || 'devrtmpkey123456';
       <h1 class="text-xl font-bold text-light font-serif">Livestream</h1>
     </div>
 
-    <!-- RTMP credentials card -->
-    <div class="bg-dark-light border border-dark-lighter rounded-xl p-5">
+    <!-- Mode selector -->
+    <div class="flex gap-2" role="tablist" aria-label="Sendemodus">
+      <button
+        type="button"
+        data-mode-btn="browser"
+        role="tab"
+        aria-selected="true"
+        class="px-4 py-2 rounded-lg text-sm font-semibold border bg-gold text-dark border-gold transition-colors"
+      >📹 Im Browser senden</button>
+      <button
+        type="button"
+        data-mode-btn="obs"
+        role="tab"
+        aria-selected="false"
+        class="px-4 py-2 rounded-lg text-sm font-semibold border bg-dark border-dark-lighter text-light hover:border-gold transition-colors"
+      >🎬 Mit OBS (RTMP)</button>
+    </div>
+
+    <!-- OBS / RTMP credentials card -->
+    <div data-pane="obs" hidden class="bg-dark-light border border-dark-lighter rounded-xl p-5">
       <h2 class="text-sm font-semibold text-light mb-3">OBS / RTMP Zugangsdaten</h2>
       <div class="space-y-2 text-sm">
         <div>
@@ -41,55 +63,99 @@ const rtmpKey = process.env.LIVEKIT_RTMP_KEY || 'devrtmpkey123456';
       <div class="flex items-center gap-4">
         <button
           id="recording-btn"
-          class="px-4 py-2 rounded-lg text-sm font-semibold bg-dark border border-dark-lighter text-light hover:border-gold transition-colors"
-          onclick="toggleRecording()"
+          type="button"
+          class="px-4 py-2 rounded-lg text-sm font-semibold bg-dark border border-dark-lighter text-light hover:border-gold transition-colors disabled:opacity-50"
         >● Aufzeichnung starten</button>
         <span id="recording-status" class="text-sm text-muted"></span>
       </div>
     </div>
 
-    <!-- Live preview + host controls -->
+    <!--
+      Single player instance: serves both tabs.
+      Publish controls live inside the component; the host can ignore them when sending via OBS.
+      A second instance would collide on the publisher identity in the LiveKit room.
+    -->
     <StreamPlayer
       client:load
       livekitUrl={livekitUrl}
       isHost={true}
+      publishMode="browser"
     />
   </div>
 </AdminLayout>
 
 <script>
-  let egressId = null;
-  const btn = document.getElementById('recording-btn');
-  const status = document.getElementById('recording-status');
+  // Mode switcher: show one pane group at a time. Both panes per group share data-pane="<mode>".
+  const modeButtons = document.querySelectorAll<HTMLButtonElement>('[data-mode-btn]');
+  const panes = document.querySelectorAll<HTMLElement>('[data-pane]');
+  function selectMode(mode: string) {
+    modeButtons.forEach((b) => {
+      const active = b.getAttribute('data-mode-btn') === mode;
+      b.setAttribute('aria-selected', String(active));
+      b.classList.toggle('bg-gold', active);
+      b.classList.toggle('text-dark', active);
+      b.classList.toggle('border-gold', active);
+      b.classList.toggle('bg-dark', !active);
+      b.classList.toggle('border-dark-lighter', !active);
+      b.classList.toggle('text-light', !active);
+    });
+    panes.forEach((p) => {
+      p.hidden = p.getAttribute('data-pane') !== mode;
+    });
+  }
+  modeButtons.forEach((b) => {
+    b.addEventListener('click', () => {
+      const mode = b.getAttribute('data-mode-btn');
+      if (mode) selectMode(mode);
+    });
+  });
+
+  // Recording control — typed and null-safe.
+  let egressId: string | null = null;
+  const recordingBtn = document.getElementById('recording-btn') as HTMLButtonElement | null;
+  const recordingStatus = document.getElementById('recording-status');
 
   async function toggleRecording() {
-    if (!egressId) {
-      btn.disabled = true;
-      const res = await fetch('/api/stream/recording', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ action: 'start' }),
-      });
-      const data = await res.json();
-      if (data.egressId) {
+    if (!recordingBtn || !recordingStatus) return;
+    recordingBtn.disabled = true;
+    try {
+      if (!egressId) {
+        const res = await fetch('/api/stream/recording', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ action: 'start' }),
+        });
+        const data = await res.json() as { egressId?: string; error?: string };
+        if (!res.ok || !data.egressId) {
+          recordingStatus.textContent = data.error ?? 'Aufzeichnung konnte nicht gestartet werden.';
+          recordingStatus.classList.add('text-red-400');
+          return;
+        }
         egressId = data.egressId;
-        btn.textContent = '⏹ Aufzeichnung stoppen';
-        btn.classList.add('border-red-500', 'text-red-400');
-        status.textContent = 'Aufzeichnung läuft…';
+        recordingBtn.textContent = '⏹ Aufzeichnung stoppen';
+        recordingBtn.classList.add('border-red-500', 'text-red-400');
+        recordingStatus.classList.remove('text-red-400');
+        recordingStatus.textContent = 'Aufzeichnung läuft…';
+      } else {
+        const res = await fetch('/api/stream/recording', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ action: 'stop', egressId }),
+        });
+        if (!res.ok) {
+          recordingStatus.textContent = 'Stoppen fehlgeschlagen.';
+          recordingStatus.classList.add('text-red-400');
+          return;
+        }
+        egressId = null;
+        recordingBtn.textContent = '● Aufzeichnung starten';
+        recordingBtn.classList.remove('border-red-500', 'text-red-400');
+        recordingStatus.classList.remove('text-red-400');
+        recordingStatus.textContent = 'Aufzeichnung gespeichert in /recordings/';
       }
-      btn.disabled = false;
-    } else {
-      btn.disabled = true;
-      await fetch('/api/stream/recording', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ action: 'stop', egressId }),
-      });
-      egressId = null;
-      btn.textContent = '● Aufzeichnung starten';
-      btn.classList.remove('border-red-500', 'text-red-400');
-      status.textContent = 'Aufzeichnung gespeichert in /recordings/';
-      btn.disabled = false;
+    } finally {
+      recordingBtn.disabled = false;
     }
   }
+  recordingBtn?.addEventListener('click', toggleRecording);
 </script>

--- a/website/src/pages/api/stream/end.ts
+++ b/website/src/pages/api/stream/end.ts
@@ -1,0 +1,70 @@
+// website/src/pages/api/stream/end.ts
+import type { APIRoute } from 'astro';
+import { getSession, isAdmin } from '../../../lib/auth';
+import { IngressClient, RoomServiceClient } from 'livekit-server-sdk';
+
+const LIVEKIT_API_KEY = process.env.LIVEKIT_API_KEY || 'devlivekit';
+const LIVEKIT_API_SECRET = process.env.LIVEKIT_API_SECRET || 'devlivekitsecret1234567890abcdef';
+const LIVEKIT_URL = `http://${process.env.LIVEKIT_DOMAIN || 'livekit.localhost'}`;
+const ROOM_NAME = 'main-stream';
+
+// POST /api/stream/end
+// Forcibly ends the active livestream:
+//   - deletes any active LiveKit Ingress (RTMP/OBS publishers)
+//   - removes every participant in the room that is publishing tracks
+// Idempotent: returns 200 with counts even when nothing was active.
+export const POST: APIRoute = async ({ request }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const ingressClient = new IngressClient(LIVEKIT_URL, LIVEKIT_API_KEY, LIVEKIT_API_SECRET);
+  const roomClient = new RoomServiceClient(LIVEKIT_URL, LIVEKIT_API_KEY, LIVEKIT_API_SECRET);
+
+  let ingressDeleted = 0;
+  let participantsRemoved = 0;
+  const errors: string[] = [];
+
+  try {
+    const ingresses = await ingressClient.listIngress({ roomName: ROOM_NAME });
+    for (const ing of ingresses) {
+      if (!ing.ingressId) continue;
+      try {
+        await ingressClient.deleteIngress(ing.ingressId);
+        ingressDeleted++;
+      } catch (e) {
+        errors.push(`ingress ${ing.ingressId}: ${(e as Error).message}`);
+      }
+    }
+  } catch (e) {
+    errors.push(`listIngress: ${(e as Error).message}`);
+  }
+
+  try {
+    const participants = await roomClient.listParticipants(ROOM_NAME);
+    for (const p of participants) {
+      const isPublishing = (p.tracks ?? []).length > 0;
+      if (!isPublishing) continue;
+      try {
+        await roomClient.removeParticipant(ROOM_NAME, p.identity);
+        participantsRemoved++;
+      } catch (e) {
+        errors.push(`removeParticipant ${p.identity}: ${(e as Error).message}`);
+      }
+    }
+  } catch (e) {
+    // Room may simply not exist yet — treat as "nothing to end".
+    if (!String(e).includes('not found')) {
+      errors.push(`listParticipants: ${(e as Error).message}`);
+    }
+  }
+
+  return new Response(
+    JSON.stringify({ ingressDeleted, participantsRemoved, errors }),
+    { status: 200, headers: { 'Content-Type': 'application/json' } },
+  );
+};

--- a/website/src/pages/portal/stream.astro
+++ b/website/src/pages/portal/stream.astro
@@ -7,7 +7,11 @@ const session = await getSession(Astro.request.headers.get('cookie'));
 if (!session) return Astro.redirect(getLoginUrl(Astro.url.pathname));
 
 const livekitDomain = process.env.LIVEKIT_DOMAIN || 'livekit.localhost';
-const livekitUrl = `ws://${livekitDomain}`;
+// Plain ws:// only for *.localhost dev; everything else (prod TLS) needs wss://
+// or the HTTPS page blocks the connection as mixed content.
+const livekitUrl = livekitDomain.endsWith('.localhost')
+  ? `ws://${livekitDomain}`
+  : `wss://${livekitDomain}`;
 ---
 
 <Layout title="Livestream">


### PR DESCRIPTION
## Summary
- Adds in-browser host publishing (cam / mic / screen-share) on the admin stream page alongside the existing OBS/RTMP path. Both produce WebRTC tracks for viewers.
- Detects when another stream is already live (Ingress or another host) and blocks starting a competing one — admin gets an amber banner and an "Aktuellen Stream beenden" button that calls a new `POST /api/stream/end` endpoint (admin-only; deletes Ingresses + removes publishing participants).
- Picks `wss://` for the LiveKit websocket whenever the domain is not `*.localhost`, so the HTTPS page in prod no longer triggers a mixed-content block. Applied to admin and portal pages.
- Rewrites the recording control's inline `<script>` with proper types + null guards; clears the pre-existing astro-check errors on `admin/stream.astro`.

## Test plan
- [ ] Admin opens `/admin/stream` on mentolder, sees "📹 Im Browser senden" tab selected.
- [ ] Click "Kamera an" → browser prompts for permissions → local preview appears, viewers see the WebRTC track.
- [ ] Switch to "🎬 Mit OBS (RTMP)" tab → credentials card shown, controls bar still functional.
- [ ] With OBS pushing, admin reload → amber banner appears + publish buttons disabled. Click "Aktuellen Stream beenden" → Ingress deleted, banner clears, publish controls re-enable.
- [ ] Recording start/stop both work with no console errors; status updates between "Aufzeichnung läuft…" and "Aufzeichnung gespeichert in /recordings/".
- [ ] `livekit-client` connects via `wss://livekit.mentolder.de` (no mixed-content warning in browser console).

🤖 Generated with [Claude Code](https://claude.com/claude-code)