### PR TITLE
fix(livekit): add CORS middleware + websecure IngressRoute

### DIFF
--- a/k3d/livekit.yaml
+++ b/k3d/livekit.yaml
@@ -186,6 +186,53 @@ spec:
                 port:
                   number: 7880
 ---
+# CORS middleware: livekit-client in the browser fetches /rtc/v1/validate
+# from the website origin before opening the wss:// connection. Without these
+# headers the cross-origin request is blocked and the WebSocket never opens.
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: livekit-cors
+  namespace: workspace
+spec:
+  headers:
+    accessControlAllowOriginList:
+      - "https://web.${PROD_DOMAIN}"
+    accessControlAllowMethods:
+      - GET
+      - POST
+      - OPTIONS
+    accessControlAllowHeaders:
+      - "*"
+    accessControlExposeHeaders:
+      - "*"
+    accessControlMaxAge: 100
+    accessControlAllowCredentials: true
+    addVaryHeader: true
+---
+# HTTPS entry for LiveKit. The plain HTTP Ingress above stays for local/legacy
+# clients (e.g. server-to-server calls inside the cluster); browsers must use
+# wss:// from the HTTPS website, which requires this websecure router with
+# the wildcard cert and the CORS middleware.
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: livekit-server
+  namespace: workspace
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - kind: Rule
+      match: Host(`livekit.${PROD_DOMAIN}`)
+      services:
+        - name: livekit-server
+          port: 7880
+      middlewares:
+        - name: livekit-cors
+  tls:
+    secretName: workspace-wildcard-tls
+---
 
 # ── LiveKit Ingress (RTMP → WebRTC) ──────────────────────────────
 apiVersion: apps/v1


### PR DESCRIPTION
## Summary
Browser-based publishing (#462) failed in prod because `livekit-client` calls `https://livekit.${PROD_DOMAIN}/rtc/v1/validate` from the website origin before opening the `wss://` connection. The plain HTTP Ingress had no CORS headers so the browser blocked the cross-origin fetch.

- New Traefik Middleware `livekit-cors` allowing `GET/POST/OPTIONS` from `https://web.${PROD_DOMAIN}` with credentials, expose-all-headers, and a 100s preflight cache.
- New Traefik IngressRoute `livekit-server` on the `websecure` entrypoint that terminates TLS with `workspace-wildcard-tls` and runs the CORS middleware in front of `livekit-server:7880`.

The original HTTP-only Ingress stays put for in-cluster / legacy clients.

## Test plan
- [x] Applied to mentolder; CORS preflight (`OPTIONS /rtc/v1/validate` with Origin) returns HTTP 200 + correct `access-control-allow-*` headers.
- [x] Actual `GET /rtc/v1/validate` includes `access-control-allow-origin: https://web.mentolder.de` and `vary: Origin`.
- [ ] Admin reloads `/admin/stream`, clicks "📹 Kamera an" → no CORS error in console, `wss://` opens, viewers see the WebRTC track.

🤖 Generated with [Claude Code](https://claude.com/claude-code)