### PR TITLE
fix(livekit): hostNetwork on livekit-server for WebRTC media

### DIFF
--- a/k3d/livekit.yaml
+++ b/k3d/livekit.yaml
@@ -73,7 +73,10 @@ data:
       tcp_port: 7881
       port_range_start: 50000
       port_range_end: 60000
-      use_external_ip: false
+      # With hostNetwork: true the pod sees the node's interfaces directly,
+      # so STUN-discovered srflx == bound IP. Leaving this enabled also lets
+      # LiveKit fall back to STUN if the node ever ends up behind NAT.
+      use_external_ip: true
     redis:
       address: livekit-redis:6379
     turn:
@@ -102,6 +105,24 @@ spec:
       labels:
         app: livekit-server
     spec:
+      # WebRTC media uses UDP 50000-60000 + TCP 7881. The Service can't
+      # publish a 10k-port UDP range, so the pod shares the node's network
+      # namespace and binds those ports directly on the host. This locks
+      # LiveKit to one node — the nodeAffinity below pins it to gekko-hetzner-3,
+      # which the wildcard `livekit.${PROD_DOMAIN}` DNS round-robin already
+      # includes. ClusterFirstWithHostNet keeps cluster DNS (e.g. livekit-redis)
+      # resolvable from inside the pod even though the host's resolver isn't.
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/hostname
+                    operator: In
+                    values:
+                      - gekko-hetzner-3
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000

--- a/k3d/namespace.yaml
+++ b/k3d/namespace.yaml
@@ -4,5 +4,9 @@ metadata:
   name: workspace
   labels:
     app.kubernetes.io/part-of: workspace-mvp
-    pod-security.kubernetes.io/enforce: baseline
+    # livekit-server needs hostNetwork: true so WebRTC media (UDP 50000-60000)
+    # can leave the cluster — Services can't publish that port range. Mirrors
+    # the coturn namespace, which is privileged for the same reason. Other
+    # pods still get warned at the restricted level so audits stay loud.
+    pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/warn: restricted


### PR DESCRIPTION
## Summary
Browser publishing (#462) signaling worked but ICE always failed — the pod's UDP 50000-60000 range was never published to the host. Sessions opened, no media flowed, SDK gave up after 15 s (server log: `removing participant without connection`).

- `livekit-server` now runs with `hostNetwork: true`, pinned to `gekko-hetzner-3` (one of the three DNS-RR addresses for `livekit.${PROD_DOMAIN}`, and the IP LiveKit already advertised as srflx).
- `dnsPolicy: ClusterFirstWithHostNet` so cluster DNS keeps working from the host-net pod (e.g. `livekit-redis`).
- `use_external_ip: true` in `livekit-server-config` (belt-and-suspenders if the node ever lands behind NAT).
- `workspace` namespace bumped from PSA `enforce=baseline` → `enforce=privileged`. Required for `hostNetwork`. Mirrors the `coturn` namespace, which already runs privileged for the same reason. `warn=restricted` is preserved.

## Test plan
- [x] After ArgoCD sync: new pod runs with `hostNetwork: true`, `node=gekko-hetzner-3`.
- [ ] `nc -uvz 46.225.125.59 50000-50010` from the public Internet succeeds (or browser ICE completes).
- [ ] Admin reloads `/admin/stream`, clicks "📹 Kamera an" → no "removing participant without connection" in server log; viewer in another browser sees the WebRTC track.

🤖 Generated with [Claude Code](https://claude.com/claude-code)