### PR TITLE
chore(prod): allow LiveKit ports through host ufw

### DIFF
--- a/prod/cloud-init.yaml
+++ b/prod/cloud-init.yaml
@@ -89,6 +89,13 @@ runcmd:
   - ufw allow 5349/tcp     # coturn TURNS (TLS TURN — iOS/iPhone)
   - ufw allow 49152:49252/udp  # coturn TURN relay port range
   - ufw allow 2379:2380/tcp
+  # LiveKit ports — Hetzner host firewall blocks inter-node traffic on every
+  # port except 80/443 by default. Without these the host-network livekit-server
+  # pod is unreachable from Traefik on other nodes (see k3d/livekit.yaml).
+  - ufw allow 7880/tcp     # LiveKit signaling (HTTP/WS)
+  - ufw allow 7881/tcp     # LiveKit RTC TCP fallback
+  - ufw allow 50000:60000/udp  # LiveKit RTC media range
+  - ufw allow 30000:40000/udp  # LiveKit TURN relay range
   - ufw --force enable
 
   # Services


### PR DESCRIPTION
## Summary
Hetzner host firewall blocks all inter-node TCP/UDP except 80/443/SSH/cluster-overlay. With `livekit-server` on `hostNetwork` pinned to `gekko-hetzner-3` (PR #464), Traefik on the other two nodes couldn't reach the pod — ~66% of browser requests landed on a node that silently dropped the upstream connection.

Persists the ufw rules I already applied to `gekko-hetzner-3` so future re-provisioning via `cloud-init` includes them, and so re-pinning the LiveKit pod to a different node becomes a manifest-only change.

- `7880/tcp` — LiveKit signaling (HTTP/WS upstream from Traefik)
- `7881/tcp` — RTC TCP fallback
- `50000-60000/udp` — RTC media range
- `30000-40000/udp` — LiveKit TURN relay range

## Test plan
- [x] Cross-node curl: each of the 3 public node IPs now returns HTTP 200 from `https://livekit.mentolder.de/` (previously 2/3 timed out).

🤖 Generated with [Claude Code](https://claude.com/claude-code)