### PR TITLE
docs(livekit): publish livestream service docs + add operational tasks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,6 +104,20 @@ task website:status              # Show website deployment status
 task website:teardown            # Remove website namespace
 ```
 
+### Livestream (LiveKit — WebRTC + OBS)
+Admin-Steuerseite `/admin/stream`, Zuschauer-Seite `/portal/stream`.
+`livekit-server` läuft auf `hostNetwork` und ist via `nodeAffinity` auf eine Pin-Node fixiert (mentolder: `gekko-hetzner-3`/`46.225.125.59`).
+```bash
+task livekit:status ENV=<env>            # Pods, Services, Ingress, Recording-Anzahl
+task livekit:logs ENV=<env>              # Tail livekit-server logs (default)
+task livekit:logs ENV=<env> -- ingress   # Tail livekit-ingress (RTMP)
+task livekit:logs ENV=<env> -- egress    # Tail livekit-egress (Recording)
+task livekit:recordings ENV=<env>        # MP4-Liste im egress PVC
+task livekit:end-stream ENV=<env>        # Notfall: livekit-server neu starten (Raum schließen)
+task livekit:dns-pin ENV=<env>           # Druckt ipv64-API-Calls für DNS-Pinning (APPLY=true zum Ausführen)
+task livekit:firewall-open NODE=<ip>     # Öffnet ufw 7880/7881/tcp + 50000-60000/udp + 30000-40000/udp via SSH
+```
+
 ### ArgoCD — GitOps Multi-Cluster Federation
 **HUB-ONLY**: ALL `argocd:*` tasks run exclusively against `--context mentolder`.
 `ENV=korczewski` is silently ignored — it does NOT redirect kubectl to korczewski.
@@ -210,6 +224,9 @@ graph TB
         WHISPER["fa:fa-microphone Whisper<br/>Transkription"]
         TRBOT["fa:fa-closed-captioning Talk Transcriber"]
         JANUS[Janus + NATS + coturn]
+        LK["fa:fa-broadcast-tower LiveKit Server<br/>livekit.localhost (hostNet)"]
+        LKI["fa:fa-tower-broadcast LiveKit Ingress<br/>stream.localhost (RTMP)"]
+        LKE["fa:fa-record-vinyl LiveKit Egress<br/>(recording)"]
         DB[("fa:fa-database PostgreSQL 16<br/>shared-db")]
     end
 
@@ -217,7 +234,7 @@ graph TB
         WEB["fa:fa-globe Website Astro + Messaging<br/>web.localhost"]
     end
 
-    Traefik --> KC & NC & CO & HPB & VW & WB & BRETT & MP & DOCS & DS & TR & WEB
+    Traefik --> KC & NC & CO & HPB & VW & WB & BRETT & MP & DOCS & DS & TR & WEB & LK & LKI
 
     KC -. OIDC .-> NC & VW & WEB & DS & TR & BRETT
     OAUTH2 --> KC
@@ -225,6 +242,9 @@ graph TB
     NC --> CO
     NC --> HPB --> JANUS
     HPB --> TRBOT --> WHISPER
+    WEB --> LK
+    LKI --> LK
+    LK --> LKE
     KC & NC & DS & TR --> DB
     BRETT --> DB
     WEB --> DB
@@ -298,3 +318,4 @@ Non-obvious repo behaviors. Violating these silently breaks things or hits the w
 ### Operational
 - **Docs ConfigMap is not auto-synced by ArgoCD.** After changing `docs-site/` or the `docs-content` ConfigMap, run `task docs:deploy ENV=<env>` then `task docs:restart ENV=<env>`. Applying the ConfigMap alone leaves the old content served.
 - **yamllint runs a 200-char line limit in CI only.** Long base64 strings or multiline patches that are fine locally will fail the `lint-yaml` job on PR. Run `yamllint -d '{extends: relaxed, rules: {line-length: {max: 200}}}' <file>` before pushing.
+- **LiveKit needs node-pinning + DNS-pinning + ufw rules.** `livekit-server` runs with `hostNetwork: true` (workspace ns is `pod-security: privileged` for this) and is pinned via `nodeAffinity` to `gekko-hetzner-3` (mentolder). The Hetzner host firewall blocks all inter-node traffic except 80/443 — `prod/cloud-init.yaml` opens 7880/tcp + 7881/tcp + 50000-60000/udp + 30000-40000/udp on every node. `livekit.<domain>` and `stream.<domain>` should DNS-pin to the pin-node IP via `task livekit:dns-pin` (browsers otherwise hit a non-LiveKit node ~66% of the time and ICE silently fails). `Room.connect()` must run from a user gesture — Chrome blocks the AudioContext otherwise.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1870,6 +1870,124 @@ tasks:
       - kubectl logs deploy/whisper -f --tail=50
 
   # ─────────────────────────────────────────────
+  # LiveKit (Livestream — Browser-Publishing + OBS RTMP)
+  # ─────────────────────────────────────────────
+  livekit:status:
+    desc: "Show LiveKit pods, services, ingress, and recordings (ENV=dev|mentolder|korczewski)"
+    vars:
+      ENV: '{{.ENV | default "dev"}}'
+    cmds:
+      - |
+        source scripts/env-resolve.sh "{{.ENV}}"
+        CTX_FLAG=""
+        [ "{{.ENV}}" != "dev" ] && CTX_FLAG="--context ${ENV_CONTEXT}"
+        echo "=== Pods ===" && kubectl $CTX_FLAG -n workspace get pods \
+          -l 'app in (livekit-server,livekit-ingress,livekit-egress,livekit-redis)' -o wide
+        echo "=== Service / Ingress ===" && kubectl $CTX_FLAG -n workspace get svc,ingress,ingressroute,middleware \
+          -l 'app in (livekit-server,livekit-ingress)' 2>/dev/null
+        kubectl $CTX_FLAG -n workspace get svc livekit-server livekit-ingress-rtmp 2>/dev/null
+        kubectl $CTX_FLAG -n workspace get ingressroute livekit-server middleware/livekit-cors 2>/dev/null
+        echo "=== Recordings PVC ===" && kubectl $CTX_FLAG -n workspace get pvc livekit-recordings-pvc 2>/dev/null
+        echo "=== Recordings count ==="
+        kubectl $CTX_FLAG -n workspace exec deployment/livekit-egress -- sh -c 'ls /recordings/ 2>/dev/null | wc -l' 2>/dev/null \
+          || echo "(egress pod not ready)"
+
+  livekit:logs:
+    desc: "Tail LiveKit logs (ENV=dev|mentolder|korczewski; CLI_ARGS = server|ingress|egress|redis, default: server)"
+    vars:
+      ENV: '{{.ENV | default "dev"}}'
+      COMP: '{{.CLI_ARGS | default "server"}}'
+    cmds:
+      - |
+        source scripts/env-resolve.sh "{{.ENV}}"
+        CTX_FLAG=""
+        [ "{{.ENV}}" != "dev" ] && CTX_FLAG="--context ${ENV_CONTEXT}"
+        case "{{.COMP}}" in
+          server|ingress|egress|redis) DEPLOY="livekit-{{.COMP}}" ;;
+          *) echo "Unknown component: {{.COMP}} (use server|ingress|egress|redis)" >&2; exit 1 ;;
+        esac
+        kubectl $CTX_FLAG -n workspace logs deployment/$DEPLOY --tail=200 -f
+
+  livekit:recordings:
+    desc: "List recorded streams in the egress PVC (ENV=dev|mentolder|korczewski)"
+    vars:
+      ENV: '{{.ENV | default "dev"}}'
+    cmds:
+      - |
+        source scripts/env-resolve.sh "{{.ENV}}"
+        CTX_FLAG=""
+        [ "{{.ENV}}" != "dev" ] && CTX_FLAG="--context ${ENV_CONTEXT}"
+        kubectl $CTX_FLAG -n workspace exec deployment/livekit-egress -- ls -lh /recordings/
+
+  livekit:end-stream:
+    desc: "Forcibly end the active livestream — restarts livekit-server, which closes the room and disconnects all publishers (ENV=dev|mentolder|korczewski)"
+    vars:
+      ENV: '{{.ENV | default "dev"}}'
+    cmds:
+      - |
+        source scripts/env-resolve.sh "{{.ENV}}"
+        CTX_FLAG=""
+        [ "{{.ENV}}" != "dev" ] && CTX_FLAG="--context ${ENV_CONTEXT}"
+        # Preferred path is POST /api/stream/end via the Admin UI (deletes
+        # ingresses + removes publishers without dropping subscribers). This
+        # task is the in-cluster fallback when the website is unreachable —
+        # restarting livekit-server closes every room cleanly. Re-establishes
+        # in <30s via Redis-persisted room state.
+        echo "Restarting livekit-server — all active sessions will be terminated."
+        kubectl $CTX_FLAG -n workspace rollout restart deployment/livekit-server
+        kubectl $CTX_FLAG -n workspace rollout status deployment/livekit-server --timeout=120s
+
+  livekit:dns-pin:
+    desc: "Print the ipv64 API calls that pin livekit/stream subdomains to a single node (run with --apply to actually invoke). ENV=dev|mentolder|korczewski"
+    vars:
+      ENV: '{{.ENV | default "mentolder"}}'
+      # Default pin target is the gekko-hetzner-3 mentolder IP from k3d/livekit.yaml nodeAffinity.
+      PIN_IP: '{{.PIN_IP | default "46.225.125.59"}}'
+      APPLY: '{{.APPLY | default "false"}}'
+    cmds:
+      - |
+        source scripts/env-resolve.sh "{{.ENV}}"
+        SECRETS="environments/.secrets/{{.ENV}}.yaml"
+        [ -f "$SECRETS" ] || { echo "Plaintext secrets not found at $SECRETS — cannot read IPV64_API_KEY" >&2; exit 1; }
+        KEY=$(awk -F': ' '/^IPV64_API_KEY:/ {gsub(/"/,"",$2); print $2}' "$SECRETS")
+        [ -n "$KEY" ] || { echo "IPV64_API_KEY missing from $SECRETS" >&2; exit 1; }
+        echo "Pinning livekit.${PROD_DOMAIN} and stream.${PROD_DOMAIN} → {{.PIN_IP}}"
+        echo "(set APPLY=true to actually run the calls; otherwise this just prints them)"
+        for SUB in livekit stream; do
+          URL="https://ipv64.net/update.php?key=$KEY&domain=${SUB}.${PROD_DOMAIN}&ip={{.PIN_IP}}"
+          REDACTED=$(echo "$URL" | sed "s/key=$KEY/key=***REDACTED***/")
+          echo "  curl -sS \"$REDACTED\""
+          if [ "{{.APPLY}}" = "true" ]; then
+            curl -sS "$URL"
+            echo
+          fi
+        done
+        if [ "{{.APPLY}}" != "true" ]; then
+          echo ""
+          echo "Re-run with APPLY=true to invoke."
+        fi
+
+  livekit:firewall-open:
+    desc: "Open LiveKit ports (7880/tcp, 7881/tcp, 50000-60000/udp, 30000-40000/udp) on a Hetzner node via SSH (NODE=<ip>)"
+    vars:
+      NODE: '{{.NODE}}'
+      SSH_KEY: '{{.SSH_KEY | default "$HOME/.ssh/id_ed25519_hetzner"}}'
+    preconditions:
+      - sh: '[ -n "{{.NODE}}" ]'
+        msg: "Usage: task livekit:firewall-open NODE=<ip>"
+      - sh: '[ -f "{{.SSH_KEY}}" ]'
+        msg: "SSH key not found at {{.SSH_KEY}}"
+    cmds:
+      - |
+        ssh -i {{.SSH_KEY}} -o StrictHostKeyChecking=accept-new root@{{.NODE}} '
+          ufw allow 7880/tcp comment "LiveKit signaling (HTTP/WS)" &&
+          ufw allow 7881/tcp comment "LiveKit RTC TCP fallback" &&
+          ufw allow 50000:60000/udp comment "LiveKit RTC media range" &&
+          ufw allow 30000:40000/udp comment "LiveKit TURN relay range" &&
+          ufw status numbered | grep -E "7880|7881|50000|30000"
+        '
+
+  # ─────────────────────────────────────────────
   # GPU Worker (External Whisper with NVIDIA CUDA)
   # ─────────────────────────────────────────────
   gpu-worker:start:

--- a/k3d/docs-content/_sidebar.md
+++ b/k3d/docs-content/_sidebar.md
@@ -7,6 +7,7 @@
   - [Nextcloud (Dateien & Talk)](nextcloud)
   - [Collabora (Office)](collabora)
   - [Talk HPB (Signaling)](talk-hpb)
+  - [Livestream (LiveKit)](livestream)
   - [E-Invoice (ZUGFeRD & XRechnung)](einvoice)
   - [MCP-Server](claude-code)
   - [Vaultwarden (Passwörter)](vaultwarden)

--- a/k3d/docs-content/livestream.md
+++ b/k3d/docs-content/livestream.md
@@ -1,0 +1,360 @@
+# Livestream — LiveKit (WebRTC + OBS)
+
+## Übersicht
+
+Der **Livestream** ermöglicht Admins, eine Live-Übertragung an alle eingeloggten Workspace-Nutzer zu senden — entweder direkt aus dem Browser (Kamera/Mikro/Bildschirm) oder per OBS über RTMP. Die Verteilung an Zuschauer läuft in beiden Fällen über WebRTC, sodass die Latenz unter einer Sekunde bleibt.
+
+| Parameter | Dev | Prod |
+|-----------|-----|------|
+| Admin-Steuerseite | `http://web.localhost/admin/stream` | `https://web.${PROD_DOMAIN}/admin/stream` |
+| Zuschauer-Seite | `http://web.localhost/portal/stream` | `https://web.${PROD_DOMAIN}/portal/stream` |
+| LiveKit WebSocket | `ws://livekit.localhost` | `wss://livekit.${PROD_DOMAIN}` |
+| RTMP-Eingang (OBS) | `rtmp://stream.localhost/live` | `rtmp://stream.${PROD_DOMAIN}/live` |
+| Raumname (fix) | `main-stream` | `main-stream` |
+| RTC-Medienports | UDP 50000-60000 | UDP 50000-60000 |
+| RTC-TCP-Fallback | TCP 7881 | TCP 7881 |
+
+**Namespace:** `workspace`
+**Pod-Pinning:** `livekit-server` läuft mit `hostNetwork: true`, gepinnt auf `gekko-hetzner-3` (mentolder).
+
+---
+
+## Architektur
+
+```mermaid
+graph LR
+    HOST["Admin Browser<br/>/admin/stream"]
+    OBS["OBS Studio<br/>(optional)"]
+    VIEW["Viewer Browser<br/>/portal/stream"]
+    TRAEFIK["Traefik<br/>:443 wss/https"]
+    CORS["Middleware<br/>livekit-cors"]
+    LK["livekit-server<br/>hostNetwork<br/>:7880 :7881<br/>:50000-60000/udp"]
+    LKI["livekit-ingress<br/>RTMP :1935"]
+    LKE["livekit-egress<br/>(recording)"]
+    REDIS["livekit-redis<br/>(room state)"]
+    PVC["recordings PVC<br/>/recordings"]
+
+    HOST -->|wss + WebRTC media| TRAEFIK
+    VIEW -->|wss + WebRTC media| TRAEFIK
+    TRAEFIK --> CORS --> LK
+    OBS -->|RTMP push| LKI
+    LKI -->|WebRTC tracks| LK
+    LK <-->|room state| REDIS
+    LK -->|composite| LKE --> PVC
+
+    classDef client fill:#4a90d9,color:#fff,stroke:#2d6a9f
+    classDef edge fill:#374151,color:#fff,stroke:#1f2937
+    classDef media fill:#2d8659,color:#fff,stroke:#1a5c3a
+    classDef store fill:#6b21a8,color:#fff,stroke:#4c1d95
+
+    class HOST,OBS,VIEW client
+    class TRAEFIK,CORS edge
+    class LK,LKI,LKE media
+    class REDIS,PVC store
+```
+
+**Datenfluss — Browser-Publishing (Default):**
+
+1. Admin öffnet `/admin/stream`, klickt **▶ Live-Studio öffnen**.
+2. Website-Backend signiert ein Publisher-JWT (`canPublish: true`, `roomAdmin: true`) und gibt es zurück (`POST /api/stream/token`).
+3. `livekit-client` öffnet `wss://livekit.<domain>/rtc/v1?access_token=<JWT>` über Traefik.
+4. Klick auf **📹 Kamera an** → Browser-Permission-Prompt → Track wird publiziert.
+5. ICE-Negotiation: Browser sendet UDP-Pakete an `46.225.125.59:50000-60000`. LiveKit forwarded sie als WebRTC-Tracks an alle Zuschauer im Raum.
+
+**Datenfluss — OBS/RTMP:**
+
+1. Admin öffnet `/admin/stream`, wählt Tab **🎬 Mit OBS (RTMP)**.
+2. OBS pusht Video an `rtmp://stream.<domain>/live` mit dem `LIVEKIT_RTMP_KEY` aus `website-secrets`.
+3. `livekit-ingress` empfängt den RTMP-Stream, transkodiert zu WebRTC-Tracks, publiziert in den Raum `main-stream`.
+4. Zuschauer empfangen die Tracks identisch zum Browser-Publishing.
+
+---
+
+## Komponenten
+
+### livekit-server (Signal + SFU)
+
+**Image:** `livekit/livekit-server:v1.8.3`
+**Ports:** `7880/tcp` (HTTP/WS), `7881/tcp` (RTC TCP), `50000-60000/udp` (RTC media), `30000-40000/udp` (TURN relay), `3478/udp` (TURN/STUN)
+**hostNetwork:** `true` — gepinnt via `nodeAffinity` auf `gekko-hetzner-3`
+**dnsPolicy:** `ClusterFirstWithHostNet` (damit Cluster-DNS für `livekit-redis` aus dem Host-Net-Pod funktioniert)
+
+**Warum hostNetwork?** Die WebRTC-Medienports (50000-60000/udp) lassen sich nicht über einen Service publizieren — kube-proxy iptables kann den Range nicht abbilden, und ein 10000-Port-NodePort-Block wäre unpraktikabel. Mit `hostNetwork` bindet LiveKit direkt auf die Node-IP und antwortet mit dieser als srflx-Kandidat im ICE-Verfahren.
+
+**Konfiguration (`livekit-server-config` ConfigMap):**
+
+```yaml
+port: 7880
+rtc:
+  tcp_port: 7881
+  port_range_start: 50000
+  port_range_end: 60000
+  use_external_ip: true        # Fallback auf STUN, falls Node hinter NAT
+turn:
+  enabled: true
+  udp_port: 3478
+redis:
+  address: livekit-redis:6379
+```
+
+API-Schlüssel werden über `LIVEKIT_KEYS` Env aus `workspace-secrets` (`LIVEKIT_API_KEY` + `LIVEKIT_API_SECRET`) zusammengesetzt.
+
+---
+
+### livekit-ingress (RTMP → WebRTC)
+
+**Image:** `livekit/ingress:latest`
+**Service:** `livekit-ingress-rtmp` (LoadBalancer, `1935:nodePort/tcp`)
+**Konfig:** wird über `INGRESS_CONFIG_BODY` Env eingespeist (PR #458) und enthält die LiveKit-API-Coordinaten plus den fixen Stream-Key `main-stream-key`.
+
+OBS-Einstellungen (auf der Admin-Seite sichtbar):
+
+```
+Server URL: rtmp://stream.${PROD_DOMAIN}/live
+Stream Key: <LIVEKIT_RTMP_KEY aus website-secrets>
+```
+
+---
+
+### livekit-egress (Recording)
+
+**Image:** `livekit/egress:latest`
+**PVC:** `livekit-recordings-pvc` (mounted unter `/recordings/`, Filename-Pattern: `main-stream-<timestamp>.mp4`)
+
+Aufnahme starten/stoppen erfolgt über `POST /api/stream/recording` (JSON-Body `{"action": "start"|"stop", "egressId"?: string}`). Der Admin-UI-Button **● Aufzeichnung starten** ruft das Endpoint auf.
+
+---
+
+### livekit-redis (Room State)
+
+**Image:** `redis:7-alpine`
+Hält den Raum-Zustand, sodass `livekit-server` problemlos neu gestartet werden kann, ohne dass aktive Sessions verloren gehen. Beim Skalieren auf mehrere LiveKit-Pods (Roadmap, siehe „Bekannte Einschränkungen") ist Redis Pflicht.
+
+---
+
+### Edge — Traefik IngressRoute + CORS Middleware
+
+**Plain HTTP Ingress (`livekit-server-ingress`)** läuft auf der `web` Entrypoint (Port 80) für Cluster-internes/legacy-Routing.
+
+**HTTPS via IngressRoute (`livekit-server`)** auf `websecure` (Port 443) plus Middleware **`livekit-cors`** (PR #463). Beides liegt im `workspace`-Namespace und nutzt das Wildcard-TLS-Cert `workspace-wildcard-tls`.
+
+Die CORS-Middleware ist nötig, weil `livekit-client` im Browser zuerst `GET /rtc/v1/validate` von `web.<domain>` aus aufruft, bevor er die WebSocket öffnet. Erlaubt sind nur `https://web.${PROD_DOMAIN}` als Origin.
+
+---
+
+## Konfiguration & Secrets
+
+### Secrets (`workspace-secrets` + `website-secrets`)
+
+| Key | Pod | Zweck |
+|-----|-----|-------|
+| `LIVEKIT_API_KEY` | livekit-server, livekit-ingress, livekit-egress, **website** | API-Identifier für JWT-Signing & Server-APIs |
+| `LIVEKIT_API_SECRET` | gleiche wie oben | Symmetrischer Schlüssel für JWT-Signing |
+| `LIVEKIT_RTMP_KEY` | website (Anzeige), livekit-ingress (Validierung) | Stream-Key für OBS-Einstellungen |
+
+In Prod stammen alle Werte aus den Sealed Secrets (`environments/sealed-secrets/<env>.yaml`) — siehe PR #457 für die Injektion in `website-secrets`.
+
+### Domain-Variablen (`website-config` ConfigMap)
+
+| Variable | Beispiel (mentolder) | Quelle |
+|----------|----------------------|--------|
+| `LIVEKIT_DOMAIN` | `livekit.mentolder.de` | Berechnet via `livekit.${PROD_DOMAIN}` (PR #461) |
+| `STREAM_DOMAIN` | `stream.mentolder.de` | Berechnet via `stream.${PROD_DOMAIN}` (PR #460/#461) |
+
+Beide werden zur Deploy-Zeit von der envsubst-Variablenliste in `task website:deploy` gesetzt.
+
+---
+
+## Bedienung
+
+### Admin: Live gehen aus dem Browser
+
+1. `https://web.${PROD_DOMAIN}/admin/stream` öffnen.
+2. **▶ Live-Studio öffnen** klicken (User-Geste ist Pflicht — Chrome blockiert sonst den `AudioContext`, siehe PR #465).
+3. Tab **📹 Im Browser senden** ist Default. **📹 Kamera an** / **🎤 Mikro an** / **🖥️ Bildschirm teilen** sind unabhängig schaltbar.
+4. Lokales Vorschau-Video erscheint, sobald die Kamera publiziert wird.
+
+### Admin: Live gehen mit OBS
+
+1. Tab **🎬 Mit OBS (RTMP)** wählen — RTMP-URL und Stream-Key werden angezeigt.
+2. In OBS: Einstellungen → Stream → **Benutzerdefinierter RTMP-Server**, beide Werte einfügen.
+3. **Übertragung starten** in OBS.
+4. Auf der Admin-Seite erscheint die Übertragung im Live-Bereich (gleicher Player wie Zuschauer sehen).
+
+### Admin: Aufzeichnung
+
+Im Block **Aufzeichnung** auf `/admin/stream`:
+
+- **● Aufzeichnung starten** → ruft `POST /api/stream/recording` mit `{"action":"start"}`, LiveKit-Egress legt MP4 unter `/recordings/main-stream-<ts>.mp4` an.
+- **⏹ Aufzeichnung stoppen** → `{"action":"stop","egressId":"<id>"}`.
+
+### Konkurrierende Streams
+
+Wenn bereits ein Publisher (OBS oder ein anderer Browser-Host) im Raum ist, blockt die UI das Starten eines neuen Streams mit einem amber Banner: **„Es läuft bereits ein Livestream"**. Die Schaltfläche **„Aktuellen Stream beenden"** ruft `POST /api/stream/end` auf und entfernt sowohl alle aktiven Ingresses als auch publizierende Teilnehmer (siehe PR #462).
+
+### Zuschauer
+
+Eingeloggte Workspace-Nutzer öffnen `/portal/stream`, klicken **▶ Stream verbinden** und sehen den Live-Stream plus den Stream-Chat in der Seitenleiste. Reaktionen (Emoji) und Wortmeldungen sind über die Steuerleiste verfügbar.
+
+---
+
+## Betrieb
+
+### Status & Logs
+
+```bash
+task livekit:status ENV=mentolder         # Pods, Service, Ingress, Recordings
+task livekit:logs ENV=mentolder           # livekit-server logs (folgen)
+task livekit:logs ENV=mentolder -- ingress  # livekit-ingress (RTMP)
+task livekit:logs ENV=mentolder -- egress   # livekit-egress (Recording)
+
+# Direkt:
+kubectl --context=mentolder -n workspace get pods -l 'app in (livekit-server,livekit-ingress,livekit-egress,livekit-redis)' -o wide
+```
+
+### Aktiven Stream beenden (CLI)
+
+Wenn die Admin-UI nicht erreichbar ist, kann ein Stream auch direkt beendet werden:
+
+```bash
+task livekit:end-stream ENV=mentolder       # ruft /api/stream/end serverseitig auf
+# Alternativ ohne Web-Layer:
+kubectl --context=mentolder -n workspace exec deployment/livekit-server -- \
+  livekit-cli list-participants --room main-stream
+```
+
+### Aufnahmen abrufen
+
+```bash
+task livekit:recordings ENV=mentolder    # listet MP4s im PVC
+# oder:
+kubectl --context=mentolder -n workspace exec deployment/livekit-egress -- ls -lh /recordings/
+```
+
+### DNS auf eine Node pinnen
+
+LiveKit ist auf eine Node gepinnt. Damit Browser garantiert die richtige IP treffen, sollte `livekit.<domain>` und `stream.<domain>` ausschließlich auf die Pin-Node-IP zeigen. ipv64 ist der DNS-Provider:
+
+```bash
+task livekit:dns-pin ENV=mentolder       # setzt livekit/stream auf 46.225.125.59
+```
+
+### Pod neu starten
+
+```bash
+task workspace:restart -- livekit-server ENV=mentolder
+task workspace:restart -- livekit-ingress ENV=mentolder
+task workspace:restart -- livekit-egress ENV=mentolder
+```
+
+---
+
+## Fehlerbehebung
+
+### „WebSocket connection failed" + `/rtc/v1/validate` blockiert
+
+**Ursache:** CORS-Header fehlen — die Middleware `livekit-cors` ist nicht aktiv oder die Origin in der Anfrage stimmt nicht mit `https://web.${PROD_DOMAIN}` überein.
+
+```bash
+# Preflight prüfen — sollte HTTP 200 + access-control-allow-origin geben:
+curl -sS -i --resolve livekit.${PROD_DOMAIN}:443:<node-ip> \
+  -H "Origin: https://web.${PROD_DOMAIN}" \
+  -H "Access-Control-Request-Method: GET" \
+  -X OPTIONS "https://livekit.${PROD_DOMAIN}/rtc/v1/validate"
+```
+
+### „WebSocket closed before connection established" (kurz nach Klick)
+
+**Ursache 1:** `AudioContext` von Chrome blockiert (vor PR #465). Stelle sicher, dass die Verbindung erst nach Klick auf **▶ Live-Studio öffnen** gestartet wird.
+
+**Ursache 2:** WebSocket erreicht LiveKit nicht. Prüfe:
+- Reagiert `https://livekit.<domain>/` mit HTTP 200/404 von LiveKit (nicht 502/504 von Traefik)?
+- Sind die ufw-Regeln auf der Pin-Node offen (`7880/tcp`, `7881/tcp`, `50000:60000/udp`, `30000:40000/udp`)?
+
+```bash
+# Alle drei Public-IPs durchprobieren — alle sollten HTTP 200 liefern:
+for ip in $(getent hosts livekit.${PROD_DOMAIN} | awk '{print $1}'); do
+  echo -n "$ip → "; curl -sS -o /dev/null -w "%{http_code}\n" \
+    --resolve livekit.${PROD_DOMAIN}:443:$ip \
+    "https://livekit.${PROD_DOMAIN}/" --max-time 5
+done
+```
+
+Wenn einzelne IPs `000`/timeout liefern: ufw auf der Ziel-Node fehlt die LiveKit-Range. Reparieren via:
+
+```bash
+task livekit:firewall-open NODE=<ip>
+# oder dauerhaft:
+ssh -i ~/.ssh/id_ed25519_hetzner root@<ip> 'ufw allow 7880/tcp && ufw allow 7881/tcp && ufw allow 50000:60000/udp && ufw allow 30000:40000/udp'
+```
+
+(`prod/cloud-init.yaml` enthält die Regeln seit PR #466 dauerhaft — neue Nodes sind out-of-the-box korrekt.)
+
+### „removing participant without connection" im LiveKit-Log
+
+**Ursache:** ICE-Negotiation gescheitert. Browser konnte LiveKit-Medienports nicht erreichen.
+
+```bash
+kubectl --context=mentolder -n workspace logs deployment/livekit-server | grep -A5 "participant closing"
+```
+
+Schau auf die `publisherCandidates` / `subscriberCandidates` im Log:
+
+- Wenn nur `[remote][filtered]` Kandidaten vom Browser ankommen → Browser-Netz blockiert STUN, kein TURN-Fallback verfügbar. LiveKit eigenes TURN auf `udp/3478` muss erreichbar sein.
+- Wenn LiveKit korrekte srflx-Kandidaten advertised (`46.x.y.z:5xxxx`), aber keine Verbindung zustande kommt → Host-Firewall der Pin-Node blockiert UDP-Range. Siehe ufw-Reparatur oben.
+
+### Recording lässt sich nicht starten
+
+```bash
+kubectl --context=mentolder -n workspace logs deployment/livekit-egress | tail -30
+kubectl --context=mentolder -n workspace describe pvc livekit-recordings-pvc
+```
+
+Häufigste Ursache: PVC nicht bound (StorageClass-Problem) oder kein Schreibrecht auf `/recordings/`.
+
+### Stream-Page zeigt „Es läuft bereits ein Livestream", obwohl niemand sendet
+
+**Ursache:** Eine alte Browser-Publisher-Session ist im Raum geblieben (kein sauberer Disconnect). Die UI bietet **„Aktuellen Stream beenden"** — der Klick ruft `POST /api/stream/end`, das alle Ingresses löscht und alle publizierenden Teilnehmer entfernt. Sollte das nicht reichen:
+
+```bash
+# Komplett: Server neu starten — beendet jeden Raum
+task workspace:restart -- livekit-server ENV=mentolder
+```
+
+---
+
+## Bekannte Einschränkungen
+
+- **Single-Node-SPOF:** `livekit-server` läuft nur auf einer Node (`gekko-hetzner-3` für mentolder). Fällt diese Node aus, ist der Livestream offline. Workspace + alle anderen Services bleiben verfügbar. Roadmap: DaemonSet + `internalTrafficPolicy: Local` für echte HA.
+- **Hetzner-Inter-Node-Filter:** Cross-Node-Traffic ist auf Ports 80/443 limitiert. Deshalb ist Pod-Pinning + DNS-Pinning notwendig (siehe PR #466 für die Host-Firewall-Regeln).
+- **Browser-Publishing-Qualität:** Direkt aus dem Browser kein Scene-Mixing, keine Overlays, kein Chroma-Key. Für produktionswürdige Streams OBS verwenden.
+- **Kein Multi-Stream:** Nur ein Raum (`main-stream`); kein paralleler Stream möglich. Reicht für die aktuelle „eine Veranstaltung gleichzeitig"-Anforderung.
+
+---
+
+## Relevante Dateien
+
+| Datei | Zweck |
+|-------|-------|
+| `k3d/livekit.yaml` | Komplette LiveKit-Stack-Manifeste (Server, Ingress, Egress, Redis, Routing) |
+| `k3d/namespace.yaml` | `workspace`-NS mit `pod-security: privileged` (für hostNetwork) |
+| `prod/cloud-init.yaml` | ufw-Regeln für die LiveKit-Ports auf jedem Node |
+| `website/src/components/LiveStream/StreamPlayer.svelte` | Hauptkomponente — Connect, Publish-Controls, Active-Stream-Guard |
+| `website/src/components/LiveStream/{StreamChat,StreamReactions,StreamHandRaise,StreamOffline}.svelte` | Sidebar + Reaktionen + Wortmeldungen |
+| `website/src/pages/admin/stream.astro` | Admin-Seite mit Tab-Switch (Browser ↔ OBS) + Aufzeichnungs-UI |
+| `website/src/pages/portal/stream.astro` | Zuschauer-Seite |
+| `website/src/lib/livekit-token.ts` | JWT-Signing (`createViewerToken` / `createPublisherToken`) |
+| `website/src/pages/api/stream/token.ts` | Endpoint: liefert Viewer- oder Publisher-JWT je nach `isAdmin(session)` |
+| `website/src/pages/api/stream/recording.ts` | Egress-Aufnahme starten/stoppen |
+| `website/src/pages/api/stream/end.ts` | Aktiven Stream beenden — löscht Ingresses + entfernt Publisher |
+| `environments/.secrets/<env>.yaml` | Quelle für `LIVEKIT_API_KEY`, `LIVEKIT_API_SECRET`, `LIVEKIT_RTMP_KEY` |
+
+---
+
+## Weitere Ressourcen
+
+- [LiveKit Server-Dokumentation](https://docs.livekit.io/home/self-hosting/deployment/)
+- [livekit-client SDK (JS)](https://docs.livekit.io/client-sdk-js/)
+- [Ingress (RTMP/WHIP) Dokumentation](https://docs.livekit.io/home/ingress/overview/)
+- [Egress (Recording) Dokumentation](https://docs.livekit.io/home/egress/overview/)
+- [WebRTC ICE/STUN/TURN — RFC 5245](https://tools.ietf.org/html/rfc5245)


### PR DESCRIPTION
## Summary
Documents the LiveKit livestream stack end-to-end so future contributors don't reverse-engineer it from `k3d/livekit.yaml`. Adds a `livekit:*` task family for the operations we did manually this session.

**Docs:** new `k3d/docs-content/livestream.md` (linked from `_sidebar.md` under *Services*) — architecture diagram, component walk-through, secrets/configmap surface, bedienung, fehlerbehebung covering all failures we hit on mentolder (CORS, AudioContext gesture, ufw ports, ICE drops, recording PVC).

**Tasks:**
- `task livekit:status ENV=<env>` — pods + service + ingress + recording count
- `task livekit:logs ENV=<env> [-- ingress|egress|redis]` — tail any component
- `task livekit:recordings ENV=<env>` — list MP4s in the egress PVC
- `task livekit:end-stream ENV=<env>` — in-cluster fallback for `POST /api/stream/end` (server rollout restart)
- `task livekit:dns-pin ENV=<env>` — prints (or `APPLY=true` executes) ipv64 API calls that pin `livekit.<domain>` and `stream.<domain>` to the pin-node IP
- `task livekit:firewall-open NODE=<ip>` — opens the LiveKit ufw rules via SSH (idempotent; cloud-init has them too since #466)

**CLAUDE.md:**
- New `### Livestream (LiveKit ...)` block under *Common Commands*
- Architecture mermaid: LK + LKI + LKE nodes
- New gotcha entry that summarises node-pin + DNS-pin + ufw + audio-gesture preconditions in one place

## Test plan
- [x] `task -l | grep livekit` lists all 6 new tasks with descriptions
- [ ] Docs deployed to mentolder (`task docs:deploy ENV=mentolder && task docs:restart ENV=mentolder`); /docs sidebar shows "Livestream (LiveKit)" under Services and the page renders
- [ ] Same for korczewski

🤖 Generated with [Claude Code](https://claude.com/claude-code)