### PR TITLE
feat(dashboard): art-library admin tab with filters and detail panel

### DIFF
--- a/dashboard/public/index.html
+++ b/dashboard/public/index.html
@@ -411,6 +411,9 @@
         <button id="autochain-btn" title="When a group chain finishes successfully, automatically continue with the next group's chain">
             🔗 AUTO-CHAIN <span id="autochain-badge">ON</span>
         </button>
+        <button id="groups-btn" title="Show or hide task groups">
+            ☰ Groups <span id="groups-badge">HIDDEN</span>
+        </button>
         <button id="stop-btn" class="ctrl-btn">■ Stop</button>
         <button id="clear-btn" class="ctrl-btn">Clear</button>
     </div>
@@ -424,6 +427,11 @@
     <div id="footgun-banner"></div>
 </header>
 
+<!-- ── Groups visibility panel ───────────────────────────────── -->
+<div id="groups-panel">
+    <div class="groups-panel-title">Show / Hide Groups</div>
+</div>
+
 <!-- ── Task grid (full-width, multi-column) ──────────────────── -->
 <main id="content">
     <div id="task-sections"></div>
@@ -434,6 +442,7 @@
     <div id="terminal-header">
         <span id="term-label">Output</span>
         <span id="term-spacer"></span>
+        <button id="copy-log-btn" title="Copy log output to clipboard">⎘ Copy</button>
         <button id="term-toggle" title="Collapse/expand the terminal pane">▼ collapse</button>
     </div>
     <div id="terminal"></div>
@@ -882,6 +891,7 @@
 
     // ── Build task grid ───────────────────────────────────────────────────
     const sectionsEl = document.getElementById('task-sections');
+    const sectionEls = [];   // indexed by groupIdx for groups panel
 
     GROUPS.forEach((group, groupIdx) => {
         const section = document.createElement('div');
@@ -1073,7 +1083,106 @@
         if (group.dangerZone || group.scratchZone) body.appendChild(wrap);
         section.appendChild(body);
         sectionsEl.appendChild(section);
+        sectionEls.push(section);
     });
+
+    // ── Groups visibility panel ────────────────────────────────────────────
+    const GROUPS_LS_KEY = 'dashboard-hidden-groups';
+    const groupsBtn     = document.getElementById('groups-btn');
+    const groupsBadge   = document.getElementById('groups-badge');
+    const groupsPanel   = document.getElementById('groups-panel');
+
+    let hiddenGroups = new Set(JSON.parse(localStorage.getItem(GROUPS_LS_KEY) || '[]'));
+
+    function applyGroupVisibility() {
+        GROUPS.forEach((_, i) => {
+            sectionEls[i].style.display = hiddenGroups.has(i) ? 'none' : '';
+        });
+        const count = hiddenGroups.size;
+        groupsBadge.textContent = count + ' hidden';
+        groupsBtn.classList.toggle('has-hidden', count > 0);
+    }
+
+    function saveHiddenGroups() {
+        localStorage.setItem(GROUPS_LS_KEY, JSON.stringify([...hiddenGroups]));
+    }
+
+    function buildGroupsPanel() {
+        // Clear existing checkboxes (keep title div)
+        while (groupsPanel.children.length > 1) groupsPanel.removeChild(groupsPanel.lastChild);
+
+        GROUPS.forEach((group, i) => {
+            const row = document.createElement('label');
+            row.className = 'group-row';
+
+            const cb = document.createElement('input');
+            cb.type = 'checkbox';
+            cb.checked = !hiddenGroups.has(i);
+            cb.addEventListener('change', () => {
+                if (cb.checked) hiddenGroups.delete(i);
+                else hiddenGroups.add(i);
+                saveHiddenGroups();
+                applyGroupVisibility();
+            });
+
+            const icon = document.createTextNode((group.icon ? group.icon + '  ' : '') + group.cat);
+            row.appendChild(cb);
+            row.appendChild(icon);
+            groupsPanel.appendChild(row);
+        });
+
+        const footer = document.createElement('div');
+        footer.className = 'groups-panel-footer';
+
+        const showAll = document.createElement('button');
+        showAll.textContent = 'Show all';
+        showAll.addEventListener('click', () => {
+            hiddenGroups.clear();
+            saveHiddenGroups();
+            applyGroupVisibility();
+            buildGroupsPanel();
+        });
+
+        const hideAll = document.createElement('button');
+        hideAll.textContent = 'Hide all';
+        hideAll.addEventListener('click', () => {
+            GROUPS.forEach((_, i) => hiddenGroups.add(i));
+            saveHiddenGroups();
+            applyGroupVisibility();
+            buildGroupsPanel();
+        });
+
+        footer.appendChild(showAll);
+        footer.appendChild(hideAll);
+        groupsPanel.appendChild(footer);
+    }
+
+    function positionGroupsPanel() {
+        const rect = groupsBtn.getBoundingClientRect();
+        groupsPanel.style.top  = (rect.bottom + 4) + 'px';
+        groupsPanel.style.right = (window.innerWidth - rect.right) + 'px';
+        groupsPanel.style.left = '';
+    }
+
+    groupsBtn.addEventListener('click', (e) => {
+        e.stopPropagation();
+        const open = groupsPanel.classList.contains('visible');
+        if (open) {
+            groupsPanel.classList.remove('visible');
+        } else {
+            buildGroupsPanel();
+            positionGroupsPanel();
+            groupsPanel.classList.add('visible');
+        }
+    });
+
+    document.addEventListener('click', (e) => {
+        if (!groupsPanel.contains(e.target) && e.target !== groupsBtn) {
+            groupsPanel.classList.remove('visible');
+        }
+    });
+
+    applyGroupVisibility();
 
     // ── Dry-run toggle ─────────────────────────────────────────────────────
     let dryRunActive = false;
@@ -1310,6 +1419,30 @@
         socket.emit('stop-task');
     });
     document.getElementById('clear-btn').addEventListener('click', () => { terminal.textContent = ''; });
+
+    // ── Copy log to clipboard ──────────────────────────────────────────────
+    const copyLogBtn = document.getElementById('copy-log-btn');
+    let copyFeedbackTimer = null;
+
+    copyLogBtn.addEventListener('click', () => {
+        const text = [...terminal.querySelectorAll('span')].map((s) => s.textContent).join('');
+        if (!text) return;
+        navigator.clipboard.writeText(text).then(() => {
+            copyLogBtn.textContent = '✓ Copied';
+            copyLogBtn.classList.add('copied');
+            clearTimeout(copyFeedbackTimer);
+            copyFeedbackTimer = setTimeout(() => {
+                copyLogBtn.textContent = '⎘ Copy';
+                copyLogBtn.classList.remove('copied');
+            }, 2000);
+        }).catch(() => {
+            copyLogBtn.textContent = '✗ Failed';
+            clearTimeout(copyFeedbackTimer);
+            copyFeedbackTimer = setTimeout(() => {
+                copyLogBtn.textContent = '⎘ Copy';
+            }, 2000);
+        });
+    });
 
     // ── Socket ─────────────────────────────────────────────────────────────
     const connDot = document.getElementById('conn-dot');

--- a/dashboard/web/public/app.js
+++ b/dashboard/web/public/app.js
@@ -27,6 +27,21 @@ const TRANSLATIONS = {
     resolution_note: 'Resolution note:',
     reopen_reason: 'Reopen reason:',
     archive_confirm: 'Archive this ticket?',
+    tab_art:        'Art Library',
+    art_kind_all:   'all',
+    art_kind_character: 'characters',
+    art_kind_prop:  'props',
+    art_kind_terrain: 'terrain',
+    art_kind_logo:  'logos',
+    art_search_ph:  'search assets…',
+    art_palette:    'Palette',
+    art_download:   'Download',
+    art_no_assets:  'No art library configured for this environment.',
+    art_copied:     'Copied ✓',
+    art_tags:       'Tags',
+    art_id:         'ID',
+    art_kind:       'Kind',
+    art_no_palette: '(no palette)',
   },
   de: {
     tab_tickets: 'Tickets',      tab_pods: 'Pods & Dienste',
@@ -53,6 +68,21 @@ const TRANSLATIONS = {
     resolution_note: 'Lösungshinweis:',
     reopen_reason: 'Grund für Wiedereröffnung:',
     archive_confirm: 'Dieses Ticket archivieren?',
+    tab_art:        'Bibliothek',
+    art_kind_all:   'alle',
+    art_kind_character: 'Figuren',
+    art_kind_prop:  'Requisiten',
+    art_kind_terrain: 'Untergründe',
+    art_kind_logo:  'Logos',
+    art_search_ph:  'Assets suchen…',
+    art_palette:    'Palette',
+    art_download:   'Herunterladen',
+    art_no_assets:  'Keine Kunstbibliothek für diese Umgebung konfiguriert.',
+    art_copied:     'Kopiert ✓',
+    art_tags:       'Tags',
+    art_id:         'ID',
+    art_kind:       'Art',
+    art_no_palette: '(keine Palette)',
   },
 };
 
@@ -101,6 +131,7 @@ const state = {
     { id: 'pods',    labelKey: 'tab_pods',    visible: true },
     { id: 'logs',    labelKey: 'tab_logs',    visible: true },
     { id: 'argocd',  labelKey: 'tab_argocd',  visible: true },
+    { id: 'art',     labelKey: 'tab_art',     visible: true },
   ],
 };
 
@@ -426,7 +457,16 @@ async function render() {
   else if (state.tab === 'pods')  await renderPods();
   else if (state.tab === 'logs')  await renderLogs();
   else if (state.tab === 'argocd') await renderArgoCD();
+  else if (state.tab === 'art')   await renderArt();
   setPolling();
+}
+
+// ── Art Library ──────────────────────────────────────────────────────────
+async function renderArt() {
+  setMain(el('div', { class: 'art-pane' }, [
+    el('h2', {}, t('tab_art')),
+    el('div', { class: 'mute' }, 'Loading…'),
+  ]));
 }
 
 // ── Init ──────────────────────────────────────────────────────────────────

--- a/dashboard/web/public/app.js
+++ b/dashboard/web/public/app.js
@@ -462,11 +462,181 @@ async function render() {
 }
 
 // ── Art Library ──────────────────────────────────────────────────────────
+const ART_STATE = { manifest: null, filterKind: 'all', filterTags: new Set(), q: '', selectedId: null };
+
+function injectSvg(target, svgText) {
+  while (target.firstChild) target.removeChild(target.firstChild);
+  const doc = new DOMParser().parseFromString(svgText, 'image/svg+xml');
+  const node = doc.documentElement;
+  if (node && node.nodeName.toLowerCase() === 'svg') {
+    target.appendChild(document.importNode(node, true));
+  }
+}
+
 async function renderArt() {
-  setMain(el('div', { class: 'art-pane' }, [
-    el('h2', {}, t('tab_art')),
-    el('div', { class: 'mute' }, 'Loading…'),
-  ]));
+  if (!ART_STATE.manifest && ART_STATE.manifest !== 'missing') {
+    try {
+      const r = await fetch('/art-library/manifest.json');
+      if (!r.ok) throw new Error(String(r.status));
+      ART_STATE.manifest = await r.json();
+    } catch (_) {
+      ART_STATE.manifest = 'missing';
+    }
+  }
+
+  if (ART_STATE.manifest === 'missing') {
+    setMain(el('div', { class: 'art-pane art-empty' }, [
+      el('h2', {}, t('tab_art')),
+      el('p', { class: 'mute' }, t('art_no_assets')),
+    ]));
+    return;
+  }
+
+  const manifest = ART_STATE.manifest;
+  const kinds = ['all', 'character', 'prop', 'terrain', 'logo'];
+  const allTags = [...new Set(manifest.assets.flatMap(a => a.tags))].sort();
+
+  const filtered = manifest.assets.filter(a => {
+    if (ART_STATE.filterKind !== 'all' && a.kind !== ART_STATE.filterKind) return false;
+    if (ART_STATE.filterTags.size > 0 && !a.tags.some(tag => ART_STATE.filterTags.has(tag))) return false;
+    if (ART_STATE.q) {
+      const q = ART_STATE.q.toLowerCase();
+      if (!a.id.toLowerCase().includes(q) &&
+          !(a.name_de || '').toLowerCase().includes(q) &&
+          !(a.name_en || '').toLowerCase().includes(q)) return false;
+    }
+    return true;
+  });
+
+  const byKind = { character: [], prop: [], terrain: [], logo: [] };
+  for (const a of filtered) byKind[a.kind].push(a);
+
+  const kindChips = el('div', { class: 'art-kinds' },
+    kinds.map(k => el('button', {
+      class: 'art-chip' + (ART_STATE.filterKind === k ? ' active' : ''),
+      on: { click: () => { ART_STATE.filterKind = k; renderArt(); } },
+    }, t('art_kind_' + k))));
+
+  const tagChips = el('div', { class: 'art-tags' }, allTags.map(tag =>
+    el('button', {
+      class: 'art-tag' + (ART_STATE.filterTags.has(tag) ? ' active' : ''),
+      on: { click: () => {
+        if (ART_STATE.filterTags.has(tag)) ART_STATE.filterTags.delete(tag);
+        else ART_STATE.filterTags.add(tag);
+        renderArt();
+      } },
+    }, tag)));
+
+  const search = el('input', { class: 'art-search', type: 'text', placeholder: t('art_search_ph'), value: ART_STATE.q });
+  search.addEventListener('input', () => { ART_STATE.q = search.value; renderArt(); });
+
+  const sections = [];
+  for (const kind of ['character', 'prop', 'terrain', 'logo']) {
+    if (byKind[kind].length === 0) continue;
+    sections.push(
+      el('h3', { class: 'art-section' }, `${t('art_kind_' + kind)} (${byKind[kind].length})`),
+      el('div', { class: 'art-grid' }, byKind[kind].map((a, i) => buildArtCard(a, i + 1))),
+    );
+  }
+
+  if (sections.length === 0) {
+    sections.push(el('p', { class: 'mute' }, '(no matches)'));
+  }
+
+  const selected = ART_STATE.selectedId
+    ? manifest.assets.find(a => a.id === ART_STATE.selectedId)
+    : null;
+  const panel = selected ? buildArtPanel(selected) : null;
+
+  setMain(el('div', { class: 'art-pane' + (selected ? ' art-pane--with-panel' : '') }, [
+    el('div', { class: 'art-main' }, [
+      el('div', { class: 'art-toolbar' }, [search, kindChips]),
+      el('div', { class: 'art-tag-row' }, tagChips),
+      ...sections,
+    ]),
+    panel,
+  ].filter(Boolean)));
+}
+
+function primarySlot(asset) {
+  return asset.kind === 'character' ? asset.files.portrait
+       : asset.kind === 'prop'      ? asset.files.icon
+       : asset.kind === 'terrain'   ? asset.files.swatch
+       :                              asset.files.svg;
+}
+
+function buildArtCard(asset, index) {
+  const card = el('button', {
+    class: 'art-card' + (ART_STATE.selectedId === asset.id ? ' active' : ''),
+    on: { click: () => { ART_STATE.selectedId = asset.id; renderArt(); } },
+  }, [
+    el('span', { class: 'art-card-idx' }, String(index).padStart(2, '0')),
+    el('div', { class: 'art-card-art' }),
+  ]);
+  fetch('/art-library/' + primarySlot(asset))
+    .then(r => r.text())
+    .then(svg => {
+      const target = card.querySelector('.art-card-art');
+      if (target) injectSvg(target, svg);
+    })
+    .catch(() => {});
+  return card;
+}
+
+function buildArtPanel(asset) {
+  const close = el('button', { class: 'art-panel-close',
+    on: { click: () => { ART_STATE.selectedId = null; renderArt(); } } }, '×');
+
+  const primary = el('div', { class: 'art-panel-art' });
+  fetch('/art-library/' + primarySlot(asset))
+    .then(r => r.text())
+    .then(svg => injectSvg(primary, svg))
+    .catch(() => {});
+
+  const tagRow = el('div', { class: 'art-panel-tags' },
+    asset.tags.map(tg => el('span', { class: 'art-tag' }, tg)));
+
+  const palette = asset.palette
+    ? el('div', { class: 'art-panel-palette' }, Object.entries(asset.palette).map(([key, hex]) =>
+        el('button', {
+          class: 'art-palette-row',
+          on: { click: async (e) => {
+            await navigator.clipboard.writeText(hex);
+            const btn = e.currentTarget;
+            const hexSpan = btn.querySelector('.art-palette-hex');
+            const prev = hexSpan.textContent;
+            hexSpan.textContent = t('art_copied');
+            setTimeout(() => { hexSpan.textContent = prev; }, 1200);
+          } },
+        }, [
+          el('span', { class: 'art-palette-swatch', style: `background:${hex}` }),
+          el('span', { class: 'art-palette-key' }, key),
+          el('span', { class: 'art-palette-hex' }, hex),
+        ])))
+    : el('p', { class: 'mute' }, t('art_no_palette'));
+
+  const downloads = el('div', { class: 'art-panel-downloads' },
+    Object.entries(asset.files).map(([slot, rel]) =>
+      el('a', { class: 'btn', href: '/art-library/' + rel, download: rel.split('/').pop() },
+        `${t('art_download')} ${slot}.svg`)));
+
+  const displayName = state.lang === 'de'
+    ? (asset.name_de || asset.id)
+    : (asset.name_en || asset.name_de || asset.id);
+
+  return el('aside', { class: 'art-panel' }, [
+    close,
+    primary,
+    el('h3', {}, displayName),
+    el('dl', { class: 'art-panel-meta' }, [
+      el('dt', {}, t('art_id')),   el('dd', {}, asset.id),
+      el('dt', {}, t('art_kind')), el('dd', {}, t('art_kind_' + asset.kind)),
+      el('dt', {}, t('art_tags')), el('dd', {}, tagRow),
+    ]),
+    el('h4', {}, t('art_palette')),
+    palette,
+    downloads,
+  ]);
 }
 
 // ── Init ──────────────────────────────────────────────────────────────────

--- a/dashboard/web/public/style.css
+++ b/dashboard/web/public/style.css
@@ -47,3 +47,63 @@ pre.logs { background: #000; padding: .75rem; max-height: 70vh; overflow: auto; 
 }
 .log-handle:hover { background: #3a4252; }
 pre.logs { height: 40vh; max-height: none; }
+
+/* ── Art Library tab ─────────────────────────────────────────────────── */
+.art-pane { display: grid; grid-template-columns: 1fr; gap: 12px; padding: 8px; }
+.art-pane--with-panel { grid-template-columns: 1fr 360px; }
+.art-main { min-width: 0; }
+
+.art-toolbar { display: flex; gap: 12px; align-items: center; flex-wrap: wrap; margin-bottom: 6px; }
+.art-search { flex: 1; min-width: 220px; padding: 6px 10px; background: #0a1422; border: 1px solid #2c4d80; border-radius: 4px; color: #e6efff; }
+
+.art-kinds, .art-tags { display: flex; gap: 6px; flex-wrap: wrap; }
+.art-chip, .art-tag {
+  font: inherit; padding: 4px 10px; border-radius: 12px; border: 1px solid #2c4d80;
+  background: #0a1422; color: #c5d3e6; cursor: pointer;
+}
+.art-chip.active, .art-tag.active { background: #2c4d80; color: #ffd84a; border-color: #ffd84a; }
+.art-tag-row { margin-bottom: 14px; }
+
+.art-section { margin: 18px 0 8px; font-size: .9rem; text-transform: uppercase; letter-spacing: .12em; opacity: .7; }
+.art-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(140px, 1fr)); gap: 12px; }
+.art-card {
+  position: relative; aspect-ratio: 4 / 5; padding: 6px;
+  background: #102540; border: 1px solid #2c4d80; border-radius: 6px;
+  cursor: pointer; display: flex; align-items: center; justify-content: center;
+}
+.art-card.active { border-color: #ffd84a; box-shadow: 0 0 0 1px #ffd84a inset; }
+.art-card:hover { background: #1a4a8a; }
+.art-card-idx {
+  position: absolute; bottom: 4px; left: 6px;
+  font-family: ui-monospace, "JetBrains Mono", monospace; font-size: 10px;
+  color: #88a0c8; letter-spacing: .1em;
+}
+.art-card-art { width: 100%; height: 100%; display: flex; align-items: center; justify-content: center; }
+.art-card-art svg { width: 100%; height: 100%; }
+
+.art-panel {
+  background: #0a1422; border: 1px solid #2c4d80; border-radius: 6px;
+  padding: 14px; position: sticky; top: 12px; max-height: calc(100vh - 24px); overflow-y: auto;
+  align-self: start;
+}
+.art-panel-close {
+  position: absolute; top: 6px; right: 6px; width: 28px; height: 28px;
+  border: 0; background: transparent; color: #c5d3e6; font-size: 18px; cursor: pointer;
+}
+.art-panel-art { display: flex; align-items: center; justify-content: center; min-height: 220px; margin-bottom: 12px; }
+.art-panel-art svg { max-width: 100%; max-height: 320px; }
+
+.art-panel-meta { display: grid; grid-template-columns: 80px 1fr; gap: 4px 10px; margin: 8px 0; font-size: .85rem; }
+.art-panel-meta dt { color: #88a0c8; text-transform: uppercase; letter-spacing: .08em; font-size: .75rem; }
+.art-panel-meta dd { margin: 0; }
+.art-panel-tags { display: flex; gap: 4px; flex-wrap: wrap; }
+.art-panel-palette { display: grid; gap: 4px; }
+.art-palette-row {
+  display: grid; grid-template-columns: 18px 1fr 80px; gap: 8px; align-items: center;
+  background: transparent; border: 0; padding: 4px; cursor: pointer; color: inherit; text-align: left;
+}
+.art-palette-row:hover { background: #102540; }
+.art-palette-swatch { width: 16px; height: 16px; border-radius: 3px; border: 1px solid rgba(255,255,255,.1); }
+.art-palette-key { font-family: ui-monospace, monospace; font-size: .8rem; color: #c5d3e6; }
+.art-palette-hex { font-family: ui-monospace, monospace; font-size: .75rem; color: #88a0c8; text-align: right; }
+.art-panel-downloads { display: flex; gap: 6px; flex-wrap: wrap; margin-top: 12px; }

--- a/prod-korczewski/dashboard-web.yaml
+++ b/prod-korczewski/dashboard-web.yaml
@@ -91,7 +91,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: dashboard-web
-          image: ghcr.io/paddione/workspace-dashboard:0.1.0
+          image: ghcr.io/paddione/workspace-dashboard:0.2.0
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 3000

--- a/prod-mentolder/dashboard-web.yaml
+++ b/prod-mentolder/dashboard-web.yaml
@@ -91,7 +91,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: dashboard-web
-          image: ghcr.io/paddione/workspace-dashboard:0.1.0
+          image: ghcr.io/paddione/workspace-dashboard:0.2.0
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 3000

--- a/tests/e2e/specs/dashboard-art.spec.ts
+++ b/tests/e2e/specs/dashboard-art.spec.ts
@@ -1,0 +1,72 @@
+// tests/e2e/specs/dashboard-art.spec.ts
+// Dashboard is SSO-gated (oauth2-proxy → Keycloak).
+// Set DASHBOARD_COOKIE=<session-cookie> to run authenticated tests,
+// or these will assert redirect behaviour only.
+import { test, expect } from '@playwright/test';
+
+const URL = process.env.DASHBOARD_URL || 'https://dashboard.korczewski.de';
+const URL_MENTOLDER = process.env.DASHBOARD_URL_MENTOLDER || 'https://dashboard.mentolder.de';
+const COOKIE = process.env.DASHBOARD_COOKIE || '';
+
+function useAuthCookie(page: import('@playwright/test').Page) {
+  if (!COOKIE) return Promise.resolve();
+  const [name, ...rest] = COOKIE.split('=');
+  return page.context().addCookies([{
+    name: name.trim(),
+    value: rest.join('=').trim(),
+    domain: new URL(URL).hostname,
+    path: '/',
+    secure: true,
+    httpOnly: true,
+    sameSite: 'Lax',
+  }]);
+}
+
+test('art tab button is present in the nav after login', async ({ page }) => {
+  await page.goto(URL, { waitUntil: 'domcontentloaded' });
+  if (!COOKIE) {
+    // Without auth the dashboard redirects to Keycloak — just check the redirect happens
+    await expect(page).toHaveURL(/auth\.|realms\/workspace/, { timeout: 15_000 });
+    test.skip(); // remaining assertions need auth
+    return;
+  }
+  await useAuthCookie(page);
+  await page.reload();
+  await expect(page.locator('button', { hasText: /Art Library|Bibliothek/ })).toBeVisible({ timeout: 8_000 });
+});
+
+test('art tab is visible and renders art cards', async ({ page }) => {
+  if (!COOKIE) { test.skip(); return; }
+  await page.goto(URL, { waitUntil: 'domcontentloaded' });
+  await useAuthCookie(page);
+  await page.reload();
+  await page.click('button:has-text("Art Library"), button:has-text("Bibliothek")');
+  await page.waitForSelector('.art-grid', { timeout: 8_000 });
+  const cardCount = await page.locator('.art-card').count();
+  expect(cardCount).toBeGreaterThan(0);
+});
+
+test('clicking a card opens the side panel with palette swatches', async ({ page }) => {
+  if (!COOKIE) { test.skip(); return; }
+  await page.goto(URL, { waitUntil: 'domcontentloaded' });
+  await useAuthCookie(page);
+  await page.reload();
+  await page.click('button:has-text("Art Library"), button:has-text("Bibliothek")');
+  await page.waitForSelector('.art-grid');
+  await page.locator('.art-card').nth(0).click();
+  await page.waitForSelector('.art-panel');
+  expect(await page.locator('.art-palette-row').count()).toBeGreaterThan(0);
+});
+
+test('mentolder context shows empty-state (no art library)', async ({ page }) => {
+  if (!COOKIE) { test.skip(); return; }
+  // Use mentolder domain cookie if separate env provided
+  await page.goto(URL_MENTOLDER, { waitUntil: 'domcontentloaded' });
+  const redirected = page.url().includes('auth.') || page.url().includes('realms/workspace');
+  if (redirected) { test.skip(); return; }
+  await page.click('button:has-text("Art Library"), button:has-text("Bibliothek")');
+  await expect(page.locator('.art-empty')).toContainText(
+    /No art library configured|Keine Kunstbibliothek/,
+    { timeout: 6_000 },
+  );
+});


### PR DESCRIPTION
## Summary
- New `art` tab in the dashboard admin menu (DE/EN i18n: "Art Library" / "Bibliothek")
- Reads `/art-library/manifest.json` (mounted from the art-library ConfigMap on korczewski)
- Renders assets grouped by kind (characters, props, terrain, logos) in a responsive grid
- Filters: kind chips, tag multiselect, live search on id/name_de/name_en
- Side panel: full-size SVG art, palette swatches with one-click copy-to-clipboard, per-slot SVG download links
- Empty-state copy shown when ConfigMap is absent (e.g. mentolder)
- Bumped dashboard-web image to 0.2.0 (multi-arch amd64+arm64 via buildx)

## Test plan
- [x] tests/e2e/specs/dashboard-art.spec.ts added (auth-aware: skips gracefully without DASHBOARD_COOKIE)
- [x] korczewski: dashboard-web rolled out with image 0.2.0 — Art Library tab live
- [x] mentolder: dashboard-web rolled out with image 0.2.0 — empty-state rendered
- [x] Kind chips, tag filter, search, side panel all wired up
- [x] Lang toggle swaps tab label, kind chips, palette/download buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)