### PR TITLE
feat(art-library): mentolder brand set

### DIFF
--- a/art-library/_tooling/validate-manifest.mjs
+++ b/art-library/_tooling/validate-manifest.mjs
@@ -49,7 +49,12 @@ for (const setName of sets) {
     ids.add(a.id);
     for (const [slot, rel] of Object.entries(a.files)) {
       const full = join(setDir, rel);
-      if (!existsSync(full)) { console.error(`✗ ${setName}: ${a.id}.files.${slot} → missing ${rel}`); failures++; }
+      // Also resolve ConfigMap-flat names (e.g. "props_chest.svg" → "props/chest.svg")
+      const m = rel.match(/^([a-z]+)_(.+)$/);
+      const altFull = m ? join(setDir, m[1], m[2]) : null;
+      if (!existsSync(full) && !(altFull && existsSync(altFull))) {
+        console.error(`✗ ${setName}: ${a.id}.files.${slot} → missing ${rel}`); failures++;
+      }
     }
   }
   if (failures === 0) console.log(`✓ ${setName}: ${manifest.assets.length} assets, all files exist`);

--- a/art-library/sets/mentolder/CREDITS.md
+++ b/art-library/sets/mentolder/CREDITS.md
@@ -1,0 +1,7 @@
+# mentolder Art Library — Credits
+
+Brand design by Gerald Korczewski / mentolder (2026).
+
+Source files: `Assets_mentolder/art_library_mentolder/` (archetypes.jsx, assets.jsx, colors_and_type.css).
+
+SVG assets derived from the Homepage Redesign reference and converted to standalone SVG for use in the Workspace art library system.

--- a/art-library/sets/mentolder/characters/consulting.figurine.svg
+++ b/art-library/sets/mentolder/characters/consulting.figurine.svg
@@ -1,0 +1,28 @@
+<svg viewBox="0 0 120 200" xmlns="http://www.w3.org/2000/svg" class="ch-figurine">
+  <defs>
+    <radialGradient id="figc-bg" cx="50%" cy="80%" r="80%">
+      <stop offset="0%" stop-color="#d7b06a" stop-opacity="0.18"/>
+      <stop offset="100%" stop-color="#0b111c" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="figc-brass" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#f0d28c"/>
+      <stop offset="100%" stop-color="#8a6a2a"/>
+    </linearGradient>
+  </defs>
+  <rect width="120" height="200" rx="8" fill="#1d2736"/>
+  <rect width="120" height="200" rx="8" fill="url(#figc-bg)"/>
+  <line x1="40" y1="0" x2="40" y2="200" stroke="rgba(255,255,255,0.10)" stroke-width="0.5"/>
+  <line x1="80" y1="0" x2="80" y2="200" stroke="rgba(255,255,255,0.10)" stroke-width="0.5"/>
+  <line x1="0" y1="67" x2="120" y2="67" stroke="rgba(255,255,255,0.10)" stroke-width="0.5"/>
+  <line x1="0" y1="133" x2="120" y2="133" stroke="rgba(255,255,255,0.10)" stroke-width="0.5"/>
+  <path d="M20,155 L40,155 L40,130 L65,130 L65,100 L100,100"
+        stroke="url(#figc-brass)" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+  <g fill="#1d2736" stroke="#f0d28c" stroke-width="2">
+    <circle cx="20" cy="155" r="6"/>
+    <circle cx="40" cy="130" r="6"/>
+    <circle cx="65" cy="100" r="6"/>
+    <circle cx="100" cy="100" r="7"/>
+  </g>
+  <circle cx="100" cy="100" r="3" fill="#f0d28c"/>
+  <text x="10" y="186" font-family='"Geist Mono", monospace' font-size="7" letter-spacing="1.5" fill="#a8c9b0" opacity="0.6">BERATUNG</text>
+</svg>

--- a/art-library/sets/mentolder/characters/consulting.portrait.svg
+++ b/art-library/sets/mentolder/characters/consulting.portrait.svg
@@ -1,0 +1,31 @@
+<svg viewBox="0 0 240 300" xmlns="http://www.w3.org/2000/svg" class="ch-portrait">
+  <defs>
+    <radialGradient id="sc-bg" cx="50%" cy="80%" r="80%">
+      <stop offset="0%" stop-color="#d7b06a" stop-opacity="0.15"/>
+      <stop offset="100%" stop-color="#0b111c" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="sc-brass" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#f0d28c"/>
+      <stop offset="100%" stop-color="#8a6a2a"/>
+    </linearGradient>
+  </defs>
+  <rect width="240" height="300" fill="#1d2736"/>
+  <rect width="240" height="300" fill="url(#sc-bg)"/>
+  <line x1="60" y1="0" x2="60" y2="300" stroke="rgba(255,255,255,0.12)" stroke-width="0.6"/>
+  <line x1="120" y1="0" x2="120" y2="300" stroke="rgba(255,255,255,0.12)" stroke-width="0.6"/>
+  <line x1="180" y1="0" x2="180" y2="300" stroke="rgba(255,255,255,0.12)" stroke-width="0.6"/>
+  <line x1="0" y1="75" x2="240" y2="75" stroke="rgba(255,255,255,0.12)" stroke-width="0.6"/>
+  <line x1="0" y1="150" x2="240" y2="150" stroke="rgba(255,255,255,0.12)" stroke-width="0.6"/>
+  <line x1="0" y1="225" x2="240" y2="225" stroke="rgba(255,255,255,0.12)" stroke-width="0.6"/>
+  <path d="M40,210 L80,210 L80,170 L130,170 L130,120 L200,120"
+        stroke="url(#sc-brass)" stroke-width="4" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+  <g fill="#1d2736" stroke="#f0d28c" stroke-width="2.5">
+    <circle cx="40" cy="210" r="9"/>
+    <circle cx="80" cy="170" r="9"/>
+    <circle cx="130" cy="120" r="9"/>
+    <circle cx="200" cy="120" r="11"/>
+  </g>
+  <circle cx="200" cy="120" r="4" fill="#f0d28c"/>
+  <line x1="0" y1="240" x2="240" y2="240" stroke="rgba(255,255,255,0.12)" stroke-width="0.8"/>
+  <text x="20" y="280" font-family='"Geist Mono", monospace' font-size="9" letter-spacing="2" fill="#a8c9b0" opacity="0.7">ROADMAP · 3–12 MONATE</text>
+</svg>

--- a/art-library/sets/mentolder/characters/digital50.figurine.svg
+++ b/art-library/sets/mentolder/characters/digital50.figurine.svg
@@ -1,0 +1,25 @@
+<svg viewBox="0 0 120 200" xmlns="http://www.w3.org/2000/svg" class="ch-figurine">
+  <defs>
+    <radialGradient id="fig50-bg" cx="70%" cy="35%" r="80%">
+      <stop offset="0%" stop-color="#d7b06a" stop-opacity="0.20"/>
+      <stop offset="100%" stop-color="#0b111c" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="fig50-brass" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#f0d28c"/>
+      <stop offset="100%" stop-color="#8a6a2a"/>
+    </linearGradient>
+  </defs>
+  <rect width="120" height="200" rx="8" fill="#101826"/>
+  <rect width="120" height="200" rx="8" fill="url(#fig50-bg)"/>
+  <line x1="40" y1="0" x2="40" y2="200" stroke="rgba(255,255,255,0.10)" stroke-width="0.5"/>
+  <line x1="80" y1="0" x2="80" y2="200" stroke="rgba(255,255,255,0.10)" stroke-width="0.5"/>
+  <line x1="0" y1="67" x2="120" y2="67" stroke="rgba(255,255,255,0.10)" stroke-width="0.5"/>
+  <line x1="0" y1="133" x2="120" y2="133" stroke="rgba(255,255,255,0.10)" stroke-width="0.5"/>
+  <g transform="translate(60,100)" fill="none" stroke="url(#fig50-brass)" stroke-width="6" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M-18,-34 L12,-34"/>
+    <path d="M-18,-34 L-18,-5"/>
+    <path d="M-18,-5 Q-1,-12 12,-1 Q16,11 5,20 Q-8,27 -18,22"/>
+  </g>
+  <circle cx="96" cy="68" r="3" fill="#f0d28c" opacity="0.8"/>
+  <text x="10" y="186" font-family='"Geist Mono", monospace' font-size="7" letter-spacing="1.5" fill="#a8c9b0" opacity="0.6">50+</text>
+</svg>

--- a/art-library/sets/mentolder/characters/digital50.portrait.svg
+++ b/art-library/sets/mentolder/characters/digital50.portrait.svg
@@ -1,0 +1,31 @@
+<svg viewBox="0 0 240 300" xmlns="http://www.w3.org/2000/svg" class="ch-portrait">
+  <defs>
+    <radialGradient id="s50-bg" cx="70%" cy="35%" r="80%">
+      <stop offset="0%" stop-color="#d7b06a" stop-opacity="0.16"/>
+      <stop offset="100%" stop-color="#0b111c" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="s50-brass" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#f0d28c"/>
+      <stop offset="100%" stop-color="#8a6a2a"/>
+    </linearGradient>
+  </defs>
+  <rect width="240" height="300" fill="#101826"/>
+  <rect width="240" height="300" fill="url(#s50-bg)"/>
+  <line x1="60" y1="0" x2="60" y2="300" stroke="rgba(255,255,255,0.12)" stroke-width="0.6"/>
+  <line x1="120" y1="0" x2="120" y2="300" stroke="rgba(255,255,255,0.12)" stroke-width="0.6"/>
+  <line x1="180" y1="0" x2="180" y2="300" stroke="rgba(255,255,255,0.12)" stroke-width="0.6"/>
+  <line x1="0" y1="75" x2="240" y2="75" stroke="rgba(255,255,255,0.12)" stroke-width="0.6"/>
+  <line x1="0" y1="150" x2="240" y2="150" stroke="rgba(255,255,255,0.12)" stroke-width="0.6"/>
+  <line x1="0" y1="225" x2="240" y2="225" stroke="rgba(255,255,255,0.12)" stroke-width="0.6"/>
+  <g transform="translate(120,150)" fill="none" stroke="url(#s50-brass)" stroke-width="9" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M-30,-50 L18,-50"/>
+    <path d="M-30,-50 L-30,-8"/>
+    <path d="M-30,-8 Q-2,-18 18,-2 Q24,16 8,30 Q-12,40 -30,32"/>
+  </g>
+  <g transform="translate(180,108)" stroke="#f0d28c" stroke-width="3" stroke-linecap="round">
+    <line x1="-10" y1="0" x2="10" y2="0"/>
+    <line x1="0" y1="-10" x2="0" y2="10"/>
+  </g>
+  <circle cx="200" cy="200" r="4" fill="#f0d28c"/>
+  <text x="20" y="280" font-family='"Geist Mono", monospace' font-size="9" letter-spacing="2" fill="#a8c9b0" opacity="0.7">EINSTIEG · GENERATION 50+</text>
+</svg>

--- a/art-library/sets/mentolder/characters/leadership.figurine.svg
+++ b/art-library/sets/mentolder/characters/leadership.figurine.svg
@@ -1,0 +1,27 @@
+<svg viewBox="0 0 120 200" xmlns="http://www.w3.org/2000/svg" class="ch-figurine">
+  <defs>
+    <radialGradient id="figl-bg" cx="30%" cy="35%" r="80%">
+      <stop offset="0%" stop-color="#d7b06a" stop-opacity="0.20"/>
+      <stop offset="100%" stop-color="#0b111c" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="figl-brass" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#f0d28c"/>
+      <stop offset="100%" stop-color="#8a6a2a"/>
+    </linearGradient>
+  </defs>
+  <rect width="120" height="200" rx="8" fill="#17202e"/>
+  <rect width="120" height="200" rx="8" fill="url(#figl-bg)"/>
+  <line x1="40" y1="0" x2="40" y2="200" stroke="rgba(255,255,255,0.10)" stroke-width="0.5"/>
+  <line x1="80" y1="0" x2="80" y2="200" stroke="rgba(255,255,255,0.10)" stroke-width="0.5"/>
+  <line x1="0" y1="67" x2="120" y2="67" stroke="rgba(255,255,255,0.10)" stroke-width="0.5"/>
+  <line x1="0" y1="133" x2="120" y2="133" stroke="rgba(255,255,255,0.10)" stroke-width="0.5"/>
+  <g stroke="url(#figl-brass)" stroke-width="6" stroke-linecap="round" fill="none">
+    <path d="M30,60 L90,140"/>
+    <path d="M90,60 L30,140"/>
+  </g>
+  <circle cx="60" cy="100" r="10" fill="#17202e" stroke="#f0d28c" stroke-width="2"/>
+  <circle cx="60" cy="100" r="4" fill="#f0d28c"/>
+  <circle cx="30" cy="60" r="4" fill="#f0d28c"/>
+  <circle cx="90" cy="60" r="4" fill="#f0d28c"/>
+  <text x="10" y="186" font-family='"Geist Mono", monospace' font-size="7" letter-spacing="1.5" fill="#a8c9b0" opacity="0.6">FÜHRUNG</text>
+</svg>

--- a/art-library/sets/mentolder/characters/leadership.portrait.svg
+++ b/art-library/sets/mentolder/characters/leadership.portrait.svg
@@ -1,0 +1,31 @@
+<svg viewBox="0 0 240 300" xmlns="http://www.w3.org/2000/svg" class="ch-portrait">
+  <defs>
+    <radialGradient id="sl-bg" cx="30%" cy="35%" r="80%">
+      <stop offset="0%" stop-color="#d7b06a" stop-opacity="0.18"/>
+      <stop offset="100%" stop-color="#0b111c" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="sl-brass" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#f0d28c"/>
+      <stop offset="100%" stop-color="#8a6a2a"/>
+    </linearGradient>
+  </defs>
+  <rect width="240" height="300" fill="#17202e"/>
+  <rect width="240" height="300" fill="url(#sl-bg)"/>
+  <line x1="60" y1="0" x2="60" y2="300" stroke="rgba(255,255,255,0.12)" stroke-width="0.6"/>
+  <line x1="120" y1="0" x2="120" y2="300" stroke="rgba(255,255,255,0.12)" stroke-width="0.6"/>
+  <line x1="180" y1="0" x2="180" y2="300" stroke="rgba(255,255,255,0.12)" stroke-width="0.6"/>
+  <line x1="0" y1="75" x2="240" y2="75" stroke="rgba(255,255,255,0.12)" stroke-width="0.6"/>
+  <line x1="0" y1="150" x2="240" y2="150" stroke="rgba(255,255,255,0.12)" stroke-width="0.6"/>
+  <line x1="0" y1="225" x2="240" y2="225" stroke="rgba(255,255,255,0.12)" stroke-width="0.6"/>
+  <g stroke="url(#sl-brass)" stroke-width="9" stroke-linecap="round" fill="none">
+    <path d="M60,90 L180,210"/>
+    <path d="M180,90 L60,210"/>
+  </g>
+  <circle cx="120" cy="150" r="14" fill="#17202e" stroke="#f0d28c" stroke-width="2.5"/>
+  <circle cx="120" cy="150" r="5" fill="#f0d28c"/>
+  <circle cx="60" cy="90" r="5" fill="#f0d28c"/>
+  <circle cx="180" cy="90" r="5" fill="#f0d28c"/>
+  <circle cx="60" cy="210" r="3" fill="#a8c9b0" opacity="0.7"/>
+  <circle cx="180" cy="210" r="3" fill="#a8c9b0" opacity="0.7"/>
+  <text x="20" y="280" font-family='"Geist Mono", monospace' font-size="9" letter-spacing="2" fill="#a8c9b0" opacity="0.7">SPARRING · 90 MIN.</text>
+</svg>

--- a/art-library/sets/mentolder/logos/app-icon.svg
+++ b/art-library/sets/mentolder/logos/app-icon.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512" shape-rendering="geometricPrecision">
+    <defs>
+      <linearGradient id="bg512" x1="0" y1="0" x2="0" y2="1">
+        <stop offset="0%" stop-color="#1a2436"></stop>
+        <stop offset="60%" stop-color="#101826"></stop>
+        <stop offset="100%" stop-color="#0a0f18"></stop>
+      </linearGradient>
+      <linearGradient id="brass512" x1="0" y1="0" x2="0" y2="1">
+        <stop offset="0%" stop-color="#f0d28c"></stop>
+        <stop offset="45%" stop-color="#d7b06a"></stop>
+        <stop offset="100%" stop-color="#8a6a2a"></stop>
+      </linearGradient>
+      <linearGradient id="brassRing512" x1="0" y1="0" x2="1" y2="1">
+        <stop offset="0%" stop-color="#f4dc9a"></stop>
+        <stop offset="50%" stop-color="#c89a4a"></stop>
+        <stop offset="100%" stop-color="#7a5a1a"></stop>
+      </linearGradient>
+      <filter id="shadow512" x="-20%" y="-20%" width="140%" height="140%">
+        <feGaussianBlur stdDeviation="2.56"></feGaussianBlur>
+        <feOffset dy="2.56"></feOffset>
+        <feComponentTransfer><feFuncA type="linear" slope=".35"></feFuncA></feComponentTransfer>
+        <feMerge><feMergeNode></feMergeNode><feMergeNode in="SourceGraphic"></feMergeNode></feMerge>
+      </filter>
+    </defs>
+    <rect width="512" height="512" rx="115" ry="115" fill="url(#bg512)"></rect>
+    <rect x="14" y="14" width="484" height="484" rx="101" ry="101" fill="none" stroke="url(#brassRing512)" stroke-width="6"></rect>
+    
+      <text x="256" y="317" text-anchor="middle" font-family="EB Garamond, Newsreader, Georgia, serif" font-weight="600" font-size="256" fill="url(#brass512)" filter="url(#shadow512)">m</text>
+  </svg>

--- a/art-library/sets/mentolder/logos/brass-pulse.svg
+++ b/art-library/sets/mentolder/logos/brass-pulse.svg
@@ -1,0 +1,46 @@
+<svg width="160" height="160" viewBox="0 0 160 160" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="bp-bg" cx="50%" cy="50%" r="60%">
+      <stop offset="0%" stop-color="#152033"/>
+      <stop offset="100%" stop-color="#0a0f18"/>
+    </radialGradient>
+    <radialGradient id="bp-core" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#fff3d4"/>
+      <stop offset="40%" stop-color="#e8c878"/>
+      <stop offset="100%" stop-color="#8a6a2a" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="bp-ring" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#f4dc9a"/>
+      <stop offset="100%" stop-color="#7a5a1a"/>
+    </linearGradient>
+    <filter id="bp-glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="3"/>
+    </filter>
+    <clipPath id="bp-clip"><rect width="160" height="160" rx="36" ry="36"/></clipPath>
+  </defs>
+  <g clip-path="url(#bp-clip)">
+    <rect width="160" height="160" fill="url(#bp-bg)"/>
+    <rect x="4" y="4" width="152" height="152" rx="32" ry="32" fill="none" stroke="url(#bp-ring)" stroke-width="2"/>
+    <g transform="translate(80,80)" fill="none" stroke="#e8c878" stroke-width="0.6">
+      <circle r="22" opacity="0.22"/>
+      <circle r="42" opacity="0.13"/>
+      <circle r="62" opacity="0.07"/>
+    </g>
+    <g transform="translate(80,80)" fill="none" stroke="#f0d28c" stroke-width="1.2">
+      <circle r="28" opacity="0">
+        <animate attributeName="r" values="14;50" dur="2.4s" repeatCount="indefinite"/>
+        <animate attributeName="opacity" values="0.7;0" dur="2.4s" repeatCount="indefinite"/>
+      </circle>
+      <circle r="28" opacity="0">
+        <animate attributeName="r" values="14;50" dur="2.4s" begin="0.8s" repeatCount="indefinite"/>
+        <animate attributeName="opacity" values="0.7;0" dur="2.4s" begin="0.8s" repeatCount="indefinite"/>
+      </circle>
+      <circle r="28" opacity="0">
+        <animate attributeName="r" values="14;50" dur="2.4s" begin="1.6s" repeatCount="indefinite"/>
+        <animate attributeName="opacity" values="0.7;0" dur="2.4s" begin="1.6s" repeatCount="indefinite"/>
+      </circle>
+    </g>
+    <circle cx="80" cy="80" r="18" fill="url(#bp-core)" filter="url(#bp-glow)"/>
+    <circle cx="80" cy="80" r="7" fill="#fff3d4"/>
+  </g>
+</svg>

--- a/art-library/sets/mentolder/logos/lockup-dark.svg
+++ b/art-library/sets/mentolder/logos/lockup-dark.svg
@@ -1,0 +1,36 @@
+<svg viewBox="0 0 320 64" width="320" height="64" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="ld-bg" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#1a2436"/>
+      <stop offset="60%" stop-color="#101826"/>
+      <stop offset="100%" stop-color="#0a0f18"/>
+    </linearGradient>
+    <linearGradient id="ld-brass" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#f0d28c"/>
+      <stop offset="45%" stop-color="#d7b06a"/>
+      <stop offset="100%" stop-color="#8a6a2a"/>
+    </linearGradient>
+    <linearGradient id="ld-ring" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#f4dc9a"/>
+      <stop offset="50%" stop-color="#c89a4a"/>
+      <stop offset="100%" stop-color="#7a5a1a"/>
+    </linearGradient>
+  </defs>
+  <!-- mark tile -->
+  <rect x="0" y="0" width="52" height="52" rx="12" ry="12" fill="url(#ld-bg)" transform="translate(0,6)"/>
+  <rect x="1.5" y="1.5" width="49" height="49" rx="10.5" ry="10.5" fill="none" stroke="url(#ld-ring)" stroke-width="1" transform="translate(0,6)"/>
+  <text x="26" y="42" text-anchor="middle"
+        font-family='Newsreader, "EB Garamond", Georgia, serif'
+        font-weight="500" font-size="30"
+        fill="url(#ld-brass)">m</text>
+  <circle cx="40" cy="41" r="1.8" fill="url(#ld-brass)"/>
+  <!-- wordmark -->
+  <text x="66" y="38"
+        font-family='Newsreader, "EB Garamond", Georgia, serif'
+        font-weight="400" font-size="26" letter-spacing="-0.01em"
+        fill="#eef1f3">mentolder</text>
+  <text x="213" y="38"
+        font-family='Newsreader, "EB Garamond", Georgia, serif'
+        font-weight="400" font-size="26"
+        fill="#d7b06a">.</text>
+</svg>

--- a/art-library/sets/mentolder/logos/lockup-light.svg
+++ b/art-library/sets/mentolder/logos/lockup-light.svg
@@ -1,0 +1,33 @@
+<svg viewBox="0 0 320 64" width="320" height="64" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="ll-brass" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#f0d28c"/>
+      <stop offset="45%" stop-color="#d7b06a"/>
+      <stop offset="100%" stop-color="#8a6a2a"/>
+    </linearGradient>
+    <linearGradient id="ll-ring" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#f4dc9a"/>
+      <stop offset="50%" stop-color="#c89a4a"/>
+      <stop offset="100%" stop-color="#7a5a1a"/>
+    </linearGradient>
+  </defs>
+  <!-- light background -->
+  <rect width="320" height="64" fill="#f8f6f0" rx="4"/>
+  <!-- mark tile -->
+  <rect x="0" y="0" width="52" height="52" rx="12" ry="12" fill="#0b111c" transform="translate(6,6)"/>
+  <rect x="1.5" y="1.5" width="49" height="49" rx="10.5" ry="10.5" fill="none" stroke="url(#ll-ring)" stroke-width="1" transform="translate(6,6)"/>
+  <text x="32" y="42" text-anchor="middle"
+        font-family='Newsreader, "EB Garamond", Georgia, serif'
+        font-weight="500" font-size="30"
+        fill="url(#ll-brass)">m</text>
+  <circle cx="46" cy="41" r="1.8" fill="url(#ll-brass)"/>
+  <!-- wordmark -->
+  <text x="72" y="38"
+        font-family='Newsreader, "EB Garamond", Georgia, serif'
+        font-weight="400" font-size="26" letter-spacing="-0.01em"
+        fill="#0b111c">mentolder</text>
+  <text x="219" y="38"
+        font-family='Newsreader, "EB Garamond", Georgia, serif'
+        font-weight="400" font-size="26"
+        fill="#8a6a2a">.</text>
+</svg>

--- a/art-library/sets/mentolder/logos/mark.svg
+++ b/art-library/sets/mentolder/logos/mark.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" width="128" height="128" shape-rendering="geometricPrecision">
+    <defs>
+      <linearGradient id="bg128" x1="0" y1="0" x2="0" y2="1">
+        <stop offset="0%" stop-color="#1a2436"></stop>
+        <stop offset="60%" stop-color="#101826"></stop>
+        <stop offset="100%" stop-color="#0a0f18"></stop>
+      </linearGradient>
+      <linearGradient id="brass128" x1="0" y1="0" x2="0" y2="1">
+        <stop offset="0%" stop-color="#f0d28c"></stop>
+        <stop offset="45%" stop-color="#d7b06a"></stop>
+        <stop offset="100%" stop-color="#8a6a2a"></stop>
+      </linearGradient>
+      <linearGradient id="brassRing128" x1="0" y1="0" x2="1" y2="1">
+        <stop offset="0%" stop-color="#f4dc9a"></stop>
+        <stop offset="50%" stop-color="#c89a4a"></stop>
+        <stop offset="100%" stop-color="#7a5a1a"></stop>
+      </linearGradient>
+      <filter id="shadow128" x="-20%" y="-20%" width="140%" height="140%">
+        <feGaussianBlur stdDeviation="1"></feGaussianBlur>
+        <feOffset dy="1"></feOffset>
+        <feComponentTransfer><feFuncA type="linear" slope=".35"></feFuncA></feComponentTransfer>
+        <feMerge><feMergeNode></feMergeNode><feMergeNode in="SourceGraphic"></feMergeNode></feMerge>
+      </filter>
+    </defs>
+    <rect width="128" height="128" rx="29" ry="29" fill="url(#bg128)"></rect>
+    <rect x="3" y="3" width="122" height="122" rx="26" ry="26" fill="none" stroke="url(#brassRing128)" stroke-width="2"></rect>
+    
+      <text x="64" y="79" text-anchor="middle" font-family="EB Garamond, Newsreader, Georgia, serif" font-weight="600" font-size="64" fill="url(#brass128)" filter="url(#shadow128)">m</text>
+  </svg>

--- a/art-library/sets/mentolder/manifest.json
+++ b/art-library/sets/mentolder/manifest.json
@@ -1,0 +1,43 @@
+{
+  "version": "2026-05-04",
+  "brand": "mentolder",
+  "tokens": {
+    "ink-900": "#0b111c",
+    "brass":   "#d7b06a",
+    "sage":    "#a8c9b0"
+  },
+  "assets": [
+    { "id": "digital50",  "kind": "character", "name_de": "50+ Digital",              "name_en": "50+ Digital",
+      "tags": ["coaching","digital","einsteiger"],
+      "palette": { "ink": "#0b111c", "surface": "#101826", "accent": "#d7b06a", "accent2": "#f0d28c", "soft": "#a8c9b0" },
+      "files": { "portrait": "characters_digital50.portrait.svg", "figurine": "characters_digital50.figurine.svg" } },
+    { "id": "leadership", "kind": "character", "name_de": "Führungskräfte-Coaching",   "name_en": "Leadership Coaching",
+      "tags": ["coaching","fuehrung","sparring"],
+      "palette": { "ink": "#0b111c", "surface": "#17202e", "accent": "#d7b06a", "accent2": "#f0d28c", "soft": "#a8c9b0" },
+      "files": { "portrait": "characters_leadership.portrait.svg", "figurine": "characters_leadership.figurine.svg" } },
+    { "id": "consulting",  "kind": "character", "name_de": "Unternehmensberatung",      "name_en": "Business Consulting",
+      "tags": ["beratung","strategie","roadmap"],
+      "palette": { "ink": "#0b111c", "surface": "#1d2736", "accent": "#d7b06a", "accent2": "#f0d28c", "soft": "#6fa8d8" },
+      "files": { "portrait": "characters_consulting.portrait.svg", "figurine": "characters_consulting.figurine.svg" } },
+
+    { "id": "prop-compass",   "kind": "prop", "name_de": "Orientierung", "name_en": "Compass",   "tags": ["strategie","klarheit"],        "files": { "icon": "props_compass.svg" } },
+    { "id": "prop-handshake", "kind": "prop", "name_de": "Begleitung",   "name_en": "Handshake", "tags": ["coaching","sparring"],          "files": { "icon": "props_handshake.svg" } },
+    { "id": "prop-briefcase", "kind": "prop", "name_de": "Beratung",     "name_en": "Briefcase", "tags": ["beratung","unternehmen"],       "files": { "icon": "props_briefcase.svg" } },
+    { "id": "prop-bookmark",  "kind": "prop", "name_de": "Methode",      "name_en": "Bookmark",  "tags": ["werkzeug","notiz"],             "files": { "icon": "props_bookmark.svg" } },
+    { "id": "prop-chat",      "kind": "prop", "name_de": "Erstgespräch", "name_en": "Chat",      "tags": ["kontakt","kostenlos"],          "files": { "icon": "props_chat.svg" } },
+    { "id": "prop-spark",     "kind": "prop", "name_de": "Veränderung",  "name_en": "Spark",     "tags": ["transfer","haltung","impact"],  "files": { "icon": "props_spark.svg" } },
+
+    { "id": "sur-01", "kind": "terrain", "name_de": "Tinte · Tief",     "name_en": "Deep Ink",       "tags": ["substrat","dunkel","tief"],   "files": { "swatch": "terrain_sur-01.svg" } },
+    { "id": "sur-02", "kind": "terrain", "name_de": "Messing-Halo",     "name_en": "Brass Halo",     "tags": ["hero","cta","warm"],          "files": { "swatch": "terrain_sur-02.svg" } },
+    { "id": "sur-03", "kind": "terrain", "name_de": "Stille-Blau",      "name_en": "Still Blue",     "tags": ["schatten","tiefe","blau"],    "files": { "swatch": "terrain_sur-03.svg" } },
+    { "id": "sur-04", "kind": "terrain", "name_de": "Hairline-Gitter",  "name_en": "Hairline Grid",  "tags": ["strip","karte","gitter"],     "files": { "swatch": "terrain_sur-04.svg" } },
+    { "id": "sur-05", "kind": "terrain", "name_de": "Duotone · Porträt","name_en": "Portrait Wash",  "tags": ["bild","portrait","warm"],      "files": { "swatch": "terrain_sur-05.svg" } },
+    { "id": "sur-06", "kind": "terrain", "name_de": "Salbei-Puls",      "name_en": "Sage Pulse",     "tags": ["availability","live","sage"],"files": { "swatch": "terrain_sur-06.svg" } },
+
+    { "id": "logo-mark",         "kind": "logo", "name_de": "Marke",                 "name_en": "Mark",          "tags": ["logo","brand","square"],   "animated": false, "files": { "svg": "logos_mark.svg" } },
+    { "id": "logo-lockup-dark",  "kind": "logo", "name_de": "Wortmarke · Dunkel",    "name_en": "Lockup · Dark", "tags": ["logo","brand","wordmark"],  "animated": false, "files": { "svg": "logos_lockup-dark.svg" } },
+    { "id": "logo-lockup-light", "kind": "logo", "name_de": "Wortmarke · Hell",      "name_en": "Lockup · Light","tags": ["logo","brand","wordmark"],  "animated": false, "files": { "svg": "logos_lockup-light.svg" } },
+    { "id": "logo-app-icon",     "kind": "logo", "name_de": "App-Icon",              "name_en": "App Icon",      "tags": ["logo","brand","icon"],      "animated": false, "files": { "svg": "logos_app-icon.svg" } },
+    { "id": "logo-brass-pulse",  "kind": "logo", "name_de": "Animiert · Brass-Puls", "name_en": "Brass Pulse",   "tags": ["logo","brand","animated"],  "animated": true,  "files": { "svg": "logos_brass-pulse.svg" } }
+  ]
+}

--- a/art-library/sets/mentolder/props/bookmark.svg
+++ b/art-library/sets/mentolder/props/bookmark.svg
@@ -1,0 +1,4 @@
+<svg viewBox="0 0 64 64" width="64" height="64" xmlns="http://www.w3.org/2000/svg" fill="none" stroke="#d7b06a" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M16 10 L48 10 Q50 10 50 12 L50 54 L32 44 L14 54 L14 12 Q14 10 16 10 Z" fill="#d7b06a" fill-opacity="0.08"/>
+  <path d="M22 22 L42 22 M22 30 L36 30" opacity="0.7"/>
+</svg>

--- a/art-library/sets/mentolder/props/briefcase.svg
+++ b/art-library/sets/mentolder/props/briefcase.svg
@@ -1,0 +1,6 @@
+<svg viewBox="0 0 64 64" width="64" height="64" xmlns="http://www.w3.org/2000/svg" fill="none" stroke="#d7b06a" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="10" y="20" width="44" height="32" rx="3"/>
+  <path d="M24 20 L24 14 Q24 12 26 12 L38 12 Q40 12 40 14 L40 20"/>
+  <line x1="10" y1="34" x2="54" y2="34"/>
+  <rect x="28" y="32" width="8" height="4" rx="1" fill="#d7b06a" opacity="0.15"/>
+</svg>

--- a/art-library/sets/mentolder/props/chat.svg
+++ b/art-library/sets/mentolder/props/chat.svg
@@ -1,0 +1,7 @@
+<svg viewBox="0 0 64 64" width="64" height="64" xmlns="http://www.w3.org/2000/svg" fill="none" stroke="#d7b06a" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M10 16 Q10 12 14 12 L46 12 Q50 12 50 16 L50 36 Q50 40 46 40 L26 40 L18 48 L18 40 L14 40 Q10 40 10 36 Z"
+        fill="#d7b06a" fill-opacity="0.08"/>
+  <circle cx="22" cy="26" r="1.6" fill="#d7b06a"/>
+  <circle cx="30" cy="26" r="1.6" fill="#d7b06a"/>
+  <circle cx="38" cy="26" r="1.6" fill="#d7b06a"/>
+</svg>

--- a/art-library/sets/mentolder/props/compass.svg
+++ b/art-library/sets/mentolder/props/compass.svg
@@ -1,0 +1,8 @@
+<svg viewBox="0 0 64 64" width="64" height="64" xmlns="http://www.w3.org/2000/svg" fill="none" stroke="#d7b06a" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="32" cy="32" r="22"/>
+  <circle cx="32" cy="32" r="2.2" fill="#d7b06a"/>
+  <path d="M32 14 L36 30 L32 50 L28 30 Z" fill="#d7b06a" opacity="0.15"/>
+  <path d="M32 14 L36 30 L32 32"/>
+  <path d="M32 50 L28 30 L32 32"/>
+  <path d="M32 8 L32 12 M32 52 L32 56 M8 32 L12 32 M52 32 L56 32" opacity="0.5"/>
+</svg>

--- a/art-library/sets/mentolder/props/handshake.svg
+++ b/art-library/sets/mentolder/props/handshake.svg
@@ -1,0 +1,6 @@
+<svg viewBox="0 0 64 64" width="64" height="64" xmlns="http://www.w3.org/2000/svg" fill="none" stroke="#d7b06a" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M6 28 L18 28 L26 36 L30 32 L40 42 L36 46 L30 40"/>
+  <path d="M58 28 L46 28 L38 36"/>
+  <path d="M30 32 L36 26 L42 32"/>
+  <path d="M14 24 L20 22 L26 26 M50 24 L44 22 L38 26" opacity="0.7"/>
+</svg>

--- a/art-library/sets/mentolder/props/spark.svg
+++ b/art-library/sets/mentolder/props/spark.svg
@@ -1,0 +1,6 @@
+<svg viewBox="0 0 64 64" width="64" height="64" xmlns="http://www.w3.org/2000/svg" fill="none" stroke="#d7b06a" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M32 8 L34 26 L52 28 L34 30 L32 48 L30 30 L12 28 L30 26 Z"
+        fill="#d7b06a" fill-opacity="0.15"/>
+  <path d="M48 50 L49 54 L53 55 L49 56 L48 60 L47 56 L43 55 L47 54 Z"
+        fill="#d7b06a" fill-opacity="0.4"/>
+</svg>

--- a/art-library/sets/mentolder/terrain/sur-01.svg
+++ b/art-library/sets/mentolder/terrain/sur-01.svg
@@ -1,0 +1,21 @@
+<svg viewBox="0 0 240 160" width="240" height="160" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="sur1" cx="60%" cy="40%" r="80%">
+      <stop offset="0%" stop-color="#1a2436"/>
+      <stop offset="100%" stop-color="#070b14"/>
+    </radialGradient>
+  </defs>
+  <rect width="240" height="160" fill="url(#sur1)"/>
+  <circle cx="37" cy="16" r="0.5" fill="#fff" opacity="0.10"/>
+  <circle cx="74" cy="69" r="0.5" fill="#fff" opacity="0.12"/>
+  <circle cx="111" cy="46" r="0.5" fill="#fff" opacity="0.08"/>
+  <circle cx="148" cy="123" r="0.5" fill="#fff" opacity="0.14"/>
+  <circle cx="185" cy="32" r="0.5" fill="#fff" opacity="0.10"/>
+  <circle cx="222" cy="87" r="0.5" fill="#fff" opacity="0.08"/>
+  <circle cx="55" cy="100" r="0.5" fill="#fff" opacity="0.12"/>
+  <circle cx="92" cy="143" r="0.5" fill="#fff" opacity="0.10"/>
+  <circle cx="129" cy="20" r="0.5" fill="#fff" opacity="0.08"/>
+  <circle cx="166" cy="77" r="0.5" fill="#fff" opacity="0.14"/>
+  <circle cx="203" cy="130" r="0.5" fill="#fff" opacity="0.10"/>
+  <circle cx="18" cy="55" r="0.5" fill="#fff" opacity="0.08"/>
+</svg>

--- a/art-library/sets/mentolder/terrain/sur-02.svg
+++ b/art-library/sets/mentolder/terrain/sur-02.svg
@@ -1,0 +1,11 @@
+<svg viewBox="0 0 240 160" width="240" height="160" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="sur2" cx="70%" cy="40%" r="60%">
+      <stop offset="0%" stop-color="#e8c878" stop-opacity="0.55"/>
+      <stop offset="60%" stop-color="#8a6a2a" stop-opacity="0.15"/>
+      <stop offset="100%" stop-color="#0b111c" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+  <rect width="240" height="160" fill="#0b111c"/>
+  <rect width="240" height="160" fill="url(#sur2)"/>
+</svg>

--- a/art-library/sets/mentolder/terrain/sur-03.svg
+++ b/art-library/sets/mentolder/terrain/sur-03.svg
@@ -1,0 +1,10 @@
+<svg viewBox="0 0 240 160" width="240" height="160" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="sur3" cx="30%" cy="70%" r="70%">
+      <stop offset="0%" stop-color="#3a5a82" stop-opacity="0.55"/>
+      <stop offset="100%" stop-color="#0b111c" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+  <rect width="240" height="160" fill="#0b111c"/>
+  <rect width="240" height="160" fill="url(#sur3)"/>
+</svg>

--- a/art-library/sets/mentolder/terrain/sur-04.svg
+++ b/art-library/sets/mentolder/terrain/sur-04.svg
@@ -1,0 +1,12 @@
+<svg viewBox="0 0 240 160" width="240" height="160" xmlns="http://www.w3.org/2000/svg">
+  <rect width="240" height="160" fill="#101826"/>
+  <line x1="40" y1="0" x2="40" y2="160" stroke="rgba(255,255,255,0.07)" stroke-width="1"/>
+  <line x1="80" y1="0" x2="80" y2="160" stroke="rgba(255,255,255,0.07)" stroke-width="1"/>
+  <line x1="120" y1="0" x2="120" y2="160" stroke="rgba(255,255,255,0.07)" stroke-width="1"/>
+  <line x1="160" y1="0" x2="160" y2="160" stroke="rgba(255,255,255,0.07)" stroke-width="1"/>
+  <line x1="200" y1="0" x2="200" y2="160" stroke="rgba(255,255,255,0.07)" stroke-width="1"/>
+  <line x1="0" y1="40" x2="240" y2="40" stroke="rgba(255,255,255,0.07)" stroke-width="1"/>
+  <line x1="0" y1="80" x2="240" y2="80" stroke="rgba(255,255,255,0.07)" stroke-width="1"/>
+  <line x1="0" y1="120" x2="240" y2="120" stroke="rgba(255,255,255,0.07)" stroke-width="1"/>
+  <line x1="120" y1="0" x2="120" y2="160" stroke="#d7b06a" stroke-width="1" opacity="0.45"/>
+</svg>

--- a/art-library/sets/mentolder/terrain/sur-05.svg
+++ b/art-library/sets/mentolder/terrain/sur-05.svg
@@ -1,0 +1,19 @@
+<svg viewBox="0 0 240 160" width="240" height="160" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="sur5" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#e8c878" stop-opacity="0.18"/>
+      <stop offset="40%" stop-color="#8a8a8a" stop-opacity="0.08"/>
+      <stop offset="100%" stop-color="#1a2436" stop-opacity="0.6"/>
+    </linearGradient>
+  </defs>
+  <rect width="240" height="160" fill="#3c4452"/>
+  <rect width="240" height="160" fill="url(#sur5)"/>
+  <circle cx="29" cy="19" r="0.4" fill="#fff" opacity="0.15"/>
+  <circle cx="58" cy="57" r="0.4" fill="#fff" opacity="0.15"/>
+  <circle cx="87" cy="38" r="0.4" fill="#fff" opacity="0.15"/>
+  <circle cx="116" cy="95" r="0.4" fill="#fff" opacity="0.15"/>
+  <circle cx="145" cy="19" r="0.4" fill="#fff" opacity="0.15"/>
+  <circle cx="174" cy="76" r="0.4" fill="#fff" opacity="0.15"/>
+  <circle cx="203" cy="133" r="0.4" fill="#fff" opacity="0.15"/>
+  <circle cx="232" cy="57" r="0.4" fill="#fff" opacity="0.15"/>
+</svg>

--- a/art-library/sets/mentolder/terrain/sur-06.svg
+++ b/art-library/sets/mentolder/terrain/sur-06.svg
@@ -1,0 +1,7 @@
+<svg viewBox="0 0 240 160" width="240" height="160" xmlns="http://www.w3.org/2000/svg">
+  <rect width="240" height="160" fill="#101826"/>
+  <circle cx="120" cy="80" r="50" fill="none" stroke="#a8c9b0" stroke-width="0.6" opacity="0.45"/>
+  <circle cx="120" cy="80" r="32" fill="none" stroke="#a8c9b0" stroke-width="0.8" opacity="0.6"/>
+  <circle cx="120" cy="80" r="16" fill="none" stroke="#a8c9b0" stroke-width="1" opacity="0.85"/>
+  <circle cx="120" cy="80" r="5" fill="#a8c9b0"/>
+</svg>

--- a/art-library/sets/mentolder/tokens.css
+++ b/art-library/sets/mentolder/tokens.css
@@ -1,0 +1,47 @@
+/* =========================================================================
+   Mentolder Design System — tokens.css
+   Art-library drop-in: exposes brand color tokens for dashboard rendering.
+   Source: mentolder/colors_and_type.css (2026-05-04)
+   ========================================================================= */
+
+:root {
+  --ink-900: #0b111c;
+  --ink-850: #101826;
+  --ink-800: #17202e;
+  --ink-750: #1d2736;
+  --ink-700: #25303f;
+
+  --brass:        #d7b06a;
+  --brass-2:      #f0d28c;
+  --brass-soft:   #f6e4b8;
+  --brass-print:  #8a6a2a;
+  --brass-deep:   #4a3814;
+  --brass-tint:   rgba(215,176,106,.14);
+  --brass-tint-2: rgba(215,176,106,.25);
+
+  /* legacy aliases */
+  --copper:   var(--brass);
+  --copper-2: var(--brass-2);
+
+  --sage:      #a8c9b0;
+  --sage-2:    #c4ddc9;
+  --sage-tint: rgba(168,201,176,.18);
+
+  --fg:       #eef1f3;
+  --fg-soft:  #cdd3d9;
+  --mute:     #8c96a3;
+  --mute-2:   #6a727e;
+
+  --line:    rgba(255,255,255,0.07);
+  --line-2:  rgba(255,255,255,0.12);
+  --line-3:  rgba(255,255,255,0.20);
+
+  --ok:    var(--sage);
+  --warn:  var(--brass);
+  --fail:  #d77a6e;
+  --info:  #6fa8d8;
+
+  --serif: "Newsreader", "Iowan Old Style", Georgia, serif;
+  --sans:  "Geist", ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
+  --mono:  "Geist Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+}

--- a/prod-mentolder/kustomization.yaml
+++ b/prod-mentolder/kustomization.yaml
@@ -15,6 +15,40 @@ configMapGenerator:
     behavior: replace
     files:
       - realm-workspace.json=realm-workspace-mentolder.json
+  - name: art-library
+    options:
+      annotations:
+        argocd.argoproj.io/sync-options: ServerSideApply=true
+    files:
+      - manifest.json=../art-library/sets/mentolder/manifest.json
+      - tokens.css=../art-library/sets/mentolder/tokens.css
+
+      - characters_digital50.portrait.svg=../art-library/sets/mentolder/characters/digital50.portrait.svg
+      - characters_digital50.figurine.svg=../art-library/sets/mentolder/characters/digital50.figurine.svg
+      - characters_leadership.portrait.svg=../art-library/sets/mentolder/characters/leadership.portrait.svg
+      - characters_leadership.figurine.svg=../art-library/sets/mentolder/characters/leadership.figurine.svg
+      - characters_consulting.portrait.svg=../art-library/sets/mentolder/characters/consulting.portrait.svg
+      - characters_consulting.figurine.svg=../art-library/sets/mentolder/characters/consulting.figurine.svg
+
+      - props_compass.svg=../art-library/sets/mentolder/props/compass.svg
+      - props_handshake.svg=../art-library/sets/mentolder/props/handshake.svg
+      - props_briefcase.svg=../art-library/sets/mentolder/props/briefcase.svg
+      - props_bookmark.svg=../art-library/sets/mentolder/props/bookmark.svg
+      - props_chat.svg=../art-library/sets/mentolder/props/chat.svg
+      - props_spark.svg=../art-library/sets/mentolder/props/spark.svg
+
+      - terrain_sur-01.svg=../art-library/sets/mentolder/terrain/sur-01.svg
+      - terrain_sur-02.svg=../art-library/sets/mentolder/terrain/sur-02.svg
+      - terrain_sur-03.svg=../art-library/sets/mentolder/terrain/sur-03.svg
+      - terrain_sur-04.svg=../art-library/sets/mentolder/terrain/sur-04.svg
+      - terrain_sur-05.svg=../art-library/sets/mentolder/terrain/sur-05.svg
+      - terrain_sur-06.svg=../art-library/sets/mentolder/terrain/sur-06.svg
+
+      - logos_mark.svg=../art-library/sets/mentolder/logos/mark.svg
+      - logos_lockup-dark.svg=../art-library/sets/mentolder/logos/lockup-dark.svg
+      - logos_lockup-light.svg=../art-library/sets/mentolder/logos/lockup-light.svg
+      - logos_app-icon.svg=../art-library/sets/mentolder/logos/app-icon.svg
+      - logos_brass-pulse.svg=../art-library/sets/mentolder/logos/brass-pulse.svg
 generatorOptions:
   disableNameSuffixHash: true
 

--- a/tests/e2e/specs/dashboard-art.spec.ts
+++ b/tests/e2e/specs/dashboard-art.spec.ts
@@ -4,8 +4,8 @@
 // or these will assert redirect behaviour only.
 import { test, expect } from '@playwright/test';
 
-const URL = process.env.DASHBOARD_URL || 'https://dashboard.korczewski.de';
-const URL_MENTOLDER = process.env.DASHBOARD_URL_MENTOLDER || 'https://dashboard.mentolder.de';
+const DASHBOARD_URL = process.env.DASHBOARD_URL || 'https://dashboard.korczewski.de';
+const DASHBOARD_URL_MENTOLDER = process.env.DASHBOARD_URL_MENTOLDER || 'https://dashboard.mentolder.de';
 const COOKIE = process.env.DASHBOARD_COOKIE || '';
 
 function useAuthCookie(page: import('@playwright/test').Page) {
@@ -14,7 +14,7 @@ function useAuthCookie(page: import('@playwright/test').Page) {
   return page.context().addCookies([{
     name: name.trim(),
     value: rest.join('=').trim(),
-    domain: new URL(URL).hostname,
+    domain: new URL(DASHBOARD_URL).hostname,
     path: '/',
     secure: true,
     httpOnly: true,
@@ -23,7 +23,7 @@ function useAuthCookie(page: import('@playwright/test').Page) {
 }
 
 test('art tab button is present in the nav after login', async ({ page }) => {
-  await page.goto(URL, { waitUntil: 'domcontentloaded' });
+  await page.goto(DASHBOARD_URL, { waitUntil: 'domcontentloaded' });
   if (!COOKIE) {
     // Without auth the dashboard redirects to Keycloak — just check the redirect happens
     await expect(page).toHaveURL(/auth\.|realms\/workspace/, { timeout: 15_000 });
@@ -37,7 +37,7 @@ test('art tab button is present in the nav after login', async ({ page }) => {
 
 test('art tab is visible and renders art cards', async ({ page }) => {
   if (!COOKIE) { test.skip(); return; }
-  await page.goto(URL, { waitUntil: 'domcontentloaded' });
+  await page.goto(DASHBOARD_URL, { waitUntil: 'domcontentloaded' });
   await useAuthCookie(page);
   await page.reload();
   await page.click('button:has-text("Art Library"), button:has-text("Bibliothek")');
@@ -48,7 +48,7 @@ test('art tab is visible and renders art cards', async ({ page }) => {
 
 test('clicking a card opens the side panel with palette swatches', async ({ page }) => {
   if (!COOKIE) { test.skip(); return; }
-  await page.goto(URL, { waitUntil: 'domcontentloaded' });
+  await page.goto(DASHBOARD_URL, { waitUntil: 'domcontentloaded' });
   await useAuthCookie(page);
   await page.reload();
   await page.click('button:has-text("Art Library"), button:has-text("Bibliothek")');
@@ -61,7 +61,7 @@ test('clicking a card opens the side panel with palette swatches', async ({ page
 test('mentolder context shows empty-state (no art library)', async ({ page }) => {
   if (!COOKIE) { test.skip(); return; }
   // Use mentolder domain cookie if separate env provided
-  await page.goto(URL_MENTOLDER, { waitUntil: 'domcontentloaded' });
+  await page.goto(DASHBOARD_URL_MENTOLDER, { waitUntil: 'domcontentloaded' });
   const redirected = page.url().includes('auth.') || page.url().includes('realms/workspace');
   if (redirected) { test.skip(); return; }
   await page.click('button:has-text("Art Library"), button:has-text("Bibliothek")');


### PR DESCRIPTION
## Summary

- Adds `art-library/sets/mentolder/` with 20 assets derived from the Homepage Redesign handoff (`Assets_mentolder/art_library_mentolder/`)
  - 3 service-archetype sigils (digital50 / leadership / consulting) — portrait (240×300) + figurine (120×200) each
  - 6 service icons as props (compass, handshake, briefcase, bookmark, chat, spark) — 64×64 brass-stroke SVGs
  - 6 surface/terrain tiles (SUR-01..06: deep ink, brass halo, still blue, hairline grid, portrait wash, sage pulse)
  - 5 logo variants (mark, app-icon, lockup-dark, lockup-light, animated brass-pulse)
- Wires the set into `prod-mentolder/kustomization.yaml` as a `configMapGenerator` entry (27 keys, `ServerSideApply=true`)
- Fixes the art-library validator to resolve ConfigMap-flat filenames (`props_chest.svg` → `props/chest.svg`) so `task test:art-library` passes for both korczewski and mentolder

## Test plan

- [x] `task test:art-library` — both sets pass (ok 1 + ok 2)
- [x] `task workspace:validate` — manifests valid
- [ ] Deploy to mentolder and verify art tab shows 20 assets, palette swatches, SVG downloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)