### PR TITLE
fix(livekit): upgrade server to v1.11.0, fix WebSocket NegotiationError

### DIFF
--- a/k3d/livekit.yaml
+++ b/k3d/livekit.yaml
@@ -124,15 +124,6 @@ spec:
       # resolvable from inside the pod even though the host's resolver isn't.
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-              - matchExpressions:
-                  - key: kubernetes.io/hostname
-                    operator: In
-                    values:
-                      - gekko-hetzner-3
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000
@@ -140,7 +131,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: livekit
-          image: livekit/livekit-server:v1.8.3
+          image: livekit/livekit-server:v1.11.0
           args:
             - --config=/etc/livekit/config.yaml
           ports:
@@ -289,7 +280,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: ingress
-          image: livekit/ingress:v1.4.3
+          image: livekit/ingress:v1.5.0
           ports:
             - name: rtmp
               containerPort: 1935
@@ -376,7 +367,7 @@ spec:
     spec:
       containers:
         - name: egress
-          image: livekit/egress:v1.8.4
+          image: livekit/egress:v1.9.0
           env:
             - name: EGRESS_CONFIG_BODY
               value: |

--- a/prod-korczewski/kustomization.yaml
+++ b/prod-korczewski/kustomization.yaml
@@ -23,3 +23,4 @@ generatorOptions:
 patches:
   - path: patch-avoid-pk-hetzner.yaml
   - path: patch-backup-config.yaml
+  - path: patch-livekit.yaml

--- a/prod-korczewski/patch-livekit.yaml
+++ b/prod-korczewski/patch-livekit.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: livekit-server
+  namespace: workspace
+spec:
+  template:
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/hostname
+                    operator: In
+                    values:
+                      - k3s-3

--- a/prod-mentolder/kustomization.yaml
+++ b/prod-mentolder/kustomization.yaml
@@ -55,3 +55,4 @@ generatorOptions:
 
 patches:
   - path: patch-backup-config.yaml
+  - path: patch-livekit.yaml

--- a/prod-mentolder/patch-livekit.yaml
+++ b/prod-mentolder/patch-livekit.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: livekit-server
+  namespace: workspace
+spec:
+  template:
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/hostname
+                    operator: In
+                    values:
+                      - gekko-hetzner-3

--- a/scripts/pre-deploy-check.sh
+++ b/scripts/pre-deploy-check.sh
@@ -283,7 +283,7 @@ fi
 
 # Kustomize build dry-run (catches missing patches, bad refs)
 info "Running kustomize build dry-run on ${OVERLAY_DIR}/ ..."
-if kustomize build "${OVERLAY_DIR}/" >/dev/null 2>/tmp/kustomize-build-err; then
+if kustomize build "${OVERLAY_DIR}/" --load-restrictor=LoadRestrictionsNone >/dev/null 2>/tmp/kustomize-build-err; then
   pass "kustomize build ${OVERLAY_DIR}/ succeeded"
 else
   fail "kustomize build ${OVERLAY_DIR}/ failed:"


### PR DESCRIPTION
## Summary
- **Root cause**: livekit-client SDK v2.18.8 requires server v1.9+ for `/rtc/v1/validate` endpoint and `_data_track` data channel support. Server v1.8.3 was missing both, causing every WebSocket connection to fail with `NegotiationError: negotiation timed out` after 15 seconds — which is why viewers couldn't connect and the stream kept reconnecting
- Bumps livekit-server v1.8.3 → v1.11.0, ingress v1.4.3 → v1.5.0, egress v1.8.4 → v1.9.0
- Moves nodeAffinity from base manifest to env-specific kustomize patches (mentolder → gekko-hetzner-3, korczewski → k3s-3)
- Adds `--load-restrictor=LoadRestrictionsNone` to kustomize build in pre-deploy-check.sh for cross-directory patches

## Test plan
- [ ] Verify `GET https://livekit.mentolder.de/rtc/v1/validate` returns 401 (not 404) — already confirmed post-deploy
- [ ] Open `/portal/stream`, click connect — should no longer get NegotiationError loops
- [ ] Admin user streams via `/admin/stream`, non-admin viewer can watch from `/portal/stream`

## Known remaining issue
`livekit.mentolder.de` still resolves to all 3 Hetzner nodes (DNS not pinned). The ipv64 API key in `environments/.secrets/mentolder.yaml` is returning 401 from ipv64.net — needs a fresh key to run `task livekit:dns-pin ENV=mentolder APPLY=true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)