### PR TITLE
fix(nextcloud+portal): remove pentest flag mount and add Fragebogen dismiss

### DIFF
--- a/k3d/nextcloud.yaml
+++ b/k3d/nextcloud.yaml
@@ -196,10 +196,6 @@ spec:
               mountPath: /etc/apache2/conf-enabled/signaling-proxy.conf
               subPath: signaling-proxy.conf
               readOnly: true
-            - name: pentest-flag
-              mountPath: /var/www/html/data/pentest_flag.txt
-              subPath: pentest_flag.txt
-              readOnly: true
             - name: php-conf-d
               mountPath: /usr/local/etc/php/conf.d
             - name: db-config
@@ -341,9 +337,6 @@ spec:
         - name: signaling-proxy-conf
           configMap:
             name: nextcloud-signaling-proxy
-        - name: pentest-flag
-          configMap:
-            name: pentest-filesystem-flag
         - name: php-conf-d
           emptyDir: {}
         - name: db-config

--- a/website/src/components/portal/FragebogenSection.astro
+++ b/website/src/components/portal/FragebogenSection.astro
@@ -28,17 +28,27 @@ function fmtDate(d: string) {
       <p class="text-xs font-semibold text-muted uppercase tracking-widest mb-3">Ausstehend</p>
       <ul class="space-y-3">
         {pending.map(a => (
-          <li>
+          <li class="flex items-center gap-2">
             <a href={`/portal/fragebogen/${a.id}`}
-               class="flex items-center justify-between gap-4 p-4 bg-dark-light rounded-xl border border-gold/30 hover:border-gold/60 transition-colors group">
-              <div>
-                <div class="text-light font-medium group-hover:text-gold transition-colors">{a.template_title}</div>
+               class="flex-1 flex items-center justify-between gap-4 p-4 bg-dark-light rounded-xl border border-gold/30 hover:border-gold/60 transition-colors group min-w-0">
+              <div class="min-w-0">
+                <div class="text-light font-medium group-hover:text-gold transition-colors truncate">{a.template_title}</div>
                 <div class="text-xs text-muted mt-0.5">Zugewiesen am {fmtDate(a.assigned_at)}</div>
               </div>
               <span class={`text-xs px-2 py-0.5 rounded-full shrink-0 ${a.status === 'in_progress' ? 'bg-blue-500/20 text-blue-400' : 'bg-amber-500/20 text-amber-400'}`}>
                 {a.status === 'in_progress' ? 'In Bearbeitung' : 'Ausstehend'}
               </span>
             </a>
+            <button
+              data-dismiss-id={a.id}
+              title="Fragebogen ablehnen"
+              class="dismiss-btn shrink-0 p-2 rounded-lg text-muted hover:text-red-400 hover:bg-red-500/10 transition-colors cursor-pointer border border-transparent hover:border-red-500/20"
+              aria-label="Fragebogen ablehnen"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="w-4 h-4">
+                <path d="M6.28 5.22a.75.75 0 0 0-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 1 0 1.06 1.06L10 11.06l3.72 3.72a.75.75 0 1 0 1.06-1.06L11.06 10l3.72-3.72a.75.75 0 0 0-1.06-1.06L10 8.94 6.28 5.22Z"/>
+              </svg>
+            </button>
           </li>
         ))}
       </ul>
@@ -87,3 +97,32 @@ function fmtDate(d: string) {
     </div>
   )}
 </div>
+
+<script>
+  document.querySelectorAll<HTMLButtonElement>('.dismiss-btn').forEach(btn => {
+    btn.addEventListener('click', async () => {
+      const id = btn.dataset.dismissId;
+      if (!id) return;
+      const reason = window.prompt('Grund für die Ablehnung (optional):') ?? null;
+      if (reason === null) return; // cancelled
+      btn.disabled = true;
+      try {
+        const r = await fetch(`/api/portal/questionnaires/${id}/dismiss`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ reason }),
+        });
+        if (r.ok) {
+          window.location.reload();
+        } else {
+          const d = await r.json().catch(() => ({})) as { error?: string };
+          alert(d.error ?? 'Fehler beim Ablehnen.');
+          btn.disabled = false;
+        }
+      } catch {
+        alert('Netzwerkfehler.');
+        btn.disabled = false;
+      }
+    });
+  });
+</script>


### PR DESCRIPTION
## Summary
- Remove `pentest-filesystem-flag` volume and volumeMount from Nextcloud deployment (pentest CTF flag no longer exposed in filesystem)
- Add dismiss button to pending questionnaires in `FragebogenSection.astro` — calls `POST /api/portal/questionnaires/[id]/dismiss` with optional reason

## Test plan
- [ ] Deploy to mentolder/korczewski: `task workspace:deploy ENV=mentolder` — Nextcloud pod starts without pentest-flag mount
- [ ] Visit `/portal` → pending Fragebogen show X button → clicking prompts for reason → dismisses and reloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)