### PR TITLE
fix(portal): send admin email when user dismisses a Fragebogen

### DIFF
--- a/website/src/lib/email.ts
+++ b/website/src/lib/email.ts
@@ -228,3 +228,20 @@ ${FROM_NAME}`,
 <p><a href="${params.auswertungUrl}">Auswertung ansehen →</a></p>`,
   });
 }
+
+export async function sendQuestionnaireDismissed(params: {
+  adminEmail: string;
+  clientName: string;
+  questionnaireTitle: string;
+  reason: string;
+}): Promise<boolean> {
+  const reasonLine = params.reason ? `\nGrund: ${params.reason}` : '';
+  return sendEmail({
+    to: params.adminEmail,
+    subject: `Fragebogen abgelehnt: ${params.questionnaireTitle} — ${params.clientName}`,
+    text: `${params.clientName} hat den Fragebogen "${params.questionnaireTitle}" abgelehnt.${reasonLine}
+
+${FROM_NAME}`,
+    html: `<p><strong>${params.clientName}</strong> hat den Fragebogen <strong>${params.questionnaireTitle}</strong> abgelehnt.</p>${params.reason ? `<p>Grund: ${params.reason}</p>` : ''}`,
+  });
+}

--- a/website/src/pages/api/portal/questionnaires/[id]/dismiss.ts
+++ b/website/src/pages/api/portal/questionnaires/[id]/dismiss.ts
@@ -2,6 +2,9 @@ import type { APIRoute } from 'astro';
 import { getSession } from '../../../../../lib/auth';
 import { getCustomerByEmail } from '../../../../../lib/website-db';
 import { getQAssignment, dismissQAssignment } from '../../../../../lib/questionnaire-db';
+import { sendQuestionnaireDismissed } from '../../../../../lib/email';
+
+const ADMIN_EMAIL = process.env.CONTACT_EMAIL || process.env.FROM_EMAIL || '';
 
 export const POST: APIRoute = async ({ request, params }) => {
   const session = await getSession(request.headers.get('cookie'));
@@ -25,6 +28,16 @@ export const POST: APIRoute = async ({ request, params }) => {
   } catch { /* no body */ }
 
   await dismissQAssignment(assignment.id, reason);
+
+  if (ADMIN_EMAIL) {
+    const clientName = session.name || session.email;
+    await sendQuestionnaireDismissed({
+      adminEmail: ADMIN_EMAIL,
+      clientName,
+      questionnaireTitle: assignment.template_title,
+      reason,
+    }).catch(() => null);
+  }
 
   return new Response(JSON.stringify({ ok: true }), { headers: { 'Content-Type': 'application/json' } });
 };


### PR DESCRIPTION
## Summary

- Add `sendQuestionnaireDismissed()` to `email.ts` (mirrors the existing `sendQuestionnaireSubmitted` pattern)
- Wire it into `dismiss.ts` so the admin receives an email (subject + optional reason) whenever a user dismisses an assigned questionnaire
- Fixes false claim in `QuestionnaireWizard` that \"Ihr Coach wurde benachrichtigt\" — now that's actually true

## Root cause

The dismiss feature was deployed in #469 but the email notification was never implemented, so coaches had no visibility when clients rejected questionnaires.

## Test plan

- [ ] Assign a Fragebogen to a test user on mentolder
- [ ] Log in as test user, navigate to `/portal?section=fragebögen`
- [ ] Click the X button next to the pending Fragebogen, enter an optional reason
- [ ] Verify admin receives email at `CONTACT_EMAIL` with subject "Fragebogen abgelehnt: …"
- [ ] Test again from inside the wizard (open Fragebogen → "Fragebogen ablehnen" link)
- [ ] Verify dismiss with empty reason also sends email (without "Grund:" line)

🤖 Generated with [Claude Code](https://claude.com/claude-code)