### PR TITLE
fix(portal): show live stream banner on dashboard when stream is active

### DIFF
--- a/k3d/website.yaml
+++ b/k3d/website.yaml
@@ -335,6 +335,8 @@ spec:
                 secretKeyRef:
                   name: website-secrets
                   key: LIVEKIT_RTMP_KEY
+            - name: LIVEKIT_SERVICE_URL
+              value: "http://livekit-server.workspace.svc.cluster.local:7880"
           ports:
             - containerPort: 4321
           resources:

--- a/website/src/components/portal/DashboardSection.astro
+++ b/website/src/components/portal/DashboardSection.astro
@@ -37,6 +37,12 @@ const externalServices = [
 ];
 
 const hasPending = pendingSignatures > 0 || pendingQuestionnaires > 0;
+
+let streamLive = false;
+try {
+  const res = await fetch(`${Astro.url.origin}/api/stream/status`);
+  if (res.ok) ({ live: streamLive } = await res.json());
+} catch { /* ignore — stream banner stays hidden */ }
 ---
 
 <div style="padding: 32px 32px 48px; max-width: 800px;">
@@ -47,6 +53,21 @@ const hasPending = pendingSignatures > 0 || pendingQuestionnaires > 0;
   <p style="font-size:13px; color:var(--mute); margin-bottom:28px;">
     Willkommen zurück, {firstName}.{hasPending ? ' Es warten Aufgaben auf Sie.' : ''}
   </p>
+
+  {streamLive && (
+    <a href="/portal/stream"
+       class="dash-alert"
+       style="display:flex; align-items:center; gap:12px; padding:12px 16px; margin-bottom:10px; background:rgba(220,38,38,0.12); border:1px solid rgba(220,38,38,0.35); border-radius:10px; text-decoration:none; transition:border-color 0.1s ease;"
+    >
+      <span style="display:flex; align-items:center; justify-content:center; width:14px; height:14px; flex-shrink:0; color:#f87171;">
+        <svg viewBox="0 0 16 16" fill="currentColor"><circle cx="8" cy="8" r="4"/></svg>
+      </span>
+      <span style="font-size:13px; color:var(--fg-soft); flex:1;">
+        <strong style="color:#f87171; font-weight:600;">Live</strong> — ein Stream läuft gerade
+      </span>
+      <span style="font-size:12px; font-weight:600; color:#f87171;">Beitreten →</span>
+    </a>
+  )}
 
   {pendingSignatures > 0 && (
     <a href="/portal?section=vertraege"

--- a/website/src/pages/api/stream/end.ts
+++ b/website/src/pages/api/stream/end.ts
@@ -5,7 +5,7 @@ import { IngressClient, RoomServiceClient } from 'livekit-server-sdk';
 
 const LIVEKIT_API_KEY = process.env.LIVEKIT_API_KEY || 'devlivekit';
 const LIVEKIT_API_SECRET = process.env.LIVEKIT_API_SECRET || 'devlivekitsecret1234567890abcdef';
-const LIVEKIT_URL = `http://${process.env.LIVEKIT_DOMAIN || 'livekit.localhost'}`;
+const LIVEKIT_URL = process.env.LIVEKIT_SERVICE_URL || `http://${process.env.LIVEKIT_DOMAIN || 'livekit.localhost'}`;
 const ROOM_NAME = 'main-stream';
 
 // POST /api/stream/end

--- a/website/src/pages/api/stream/status.ts
+++ b/website/src/pages/api/stream/status.ts
@@ -4,7 +4,7 @@ import { RoomServiceClient } from 'livekit-server-sdk';
 
 const LIVEKIT_API_KEY = process.env.LIVEKIT_API_KEY || 'devlivekit';
 const LIVEKIT_API_SECRET = process.env.LIVEKIT_API_SECRET || 'devlivekitsecret1234567890abcdef';
-const LIVEKIT_URL = `http://${process.env.LIVEKIT_DOMAIN || 'livekit.localhost'}`;
+const LIVEKIT_URL = process.env.LIVEKIT_SERVICE_URL || `http://${process.env.LIVEKIT_DOMAIN || 'livekit.localhost'}`;
 const ROOM_NAME = 'main-stream';
 
 export const GET: APIRoute = async () => {


### PR DESCRIPTION
## Summary

- Non-admin users (e.g. gekko) saw no indication that a stream was running and no way to join from the portal overview
- Adds a server-side fetch of `/api/stream/status` in `DashboardSection.astro` at render time
- Renders a red "Live — ein Stream läuft gerade / Beitreten →" alert banner (matching the existing pending-signatures card style) that links to `/portal/stream`
- No client-side polling — state is accurate at page load; user can refresh to recheck

## Test plan

- [ ] Start a stream via admin panel
- [ ] Log in as gekko and open `https://web.mentolder.de/portal?section=overview`
- [ ] Verify the red "Live" banner appears and clicking it navigates to `/portal/stream`
- [ ] Stop the stream, reload the page — banner should be gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)