### PR TITLE
chore(pentest): update PENTEST_OVERVIEW to current stack + DASHBOARD_OIDC_SECRET

### DIFF
--- a/PENTEST_OVERVIEW.md
+++ b/PENTEST_OVERVIEW.md
@@ -1,66 +1,345 @@
-# 🛡️ Penetration Testing Scoping & Overview: Workspace MVP
+# Penetration Testing Scoping & Overview: Workspace MVP
 
-Dieses Dokument dient als technische Grundlage für einen Penetrationstest der Cluster-Infrastruktur. Es beschreibt die Architektur, Angriffsflächen und Sicherheitsmechanismen des "Workspace MVP" Projekts.
-
-## 1. Systemübersicht & Architektur
-Die Plattform ist eine Kubernetes-basierte Kollaborationsumgebung (K3s/K3d), die verschiedene Dienste (Chat, Files, IAM, Office) integriert.
-
-- **Orchestrierung:** Kubernetes (K3s/K3d)
-- **Ingress-Controller:** Traefik (Port 80/443)
-- **Zentrales IAM:** Keycloak (OIDC/SSO)
-- **Datenbank:** Zentrales PostgreSQL 16 (shared-db) mit separaten Datenbanken pro Dienst.
-- **Isolierung:** NetworkPolicies (Default-Deny für Ingress/Egress).
-
-## 2. Externe Endpunkte (Scope)
-Alle Dienste sind über Subdomains erreichbar. Ein Fokus des Tests sollte auf der Umgehung von Authentifizierungs-Layern liegen.
-
-| Dienst | URL | Primärer Schutzmechanismus |
-| :--- | :--- | :--- |
-| **Keycloak (IAM)** | `auth.korczewski.de` | Zentraler OIDC Provider |
-| **Mattermost** | `chat.korczewski.de` | Force-SSO Middleware (Redirect zu Keycloak) |
-| **Nextcloud** | `files.korczewski.de` | Native Auth + OIDC (Keycloak) |
-| **Invoice Ninja** | `billing.korczewski.de` | **OAuth2-Proxy** (Keycloak OIDC Gateway) |
-| **Vaultwarden** | `vault.korczewski.de` | Native Bitwarden-API |
-| **Mailpit** | `mail.korczewski.de` | **Traefik Basic Auth** |
-| **Dokumentation** | `docs.korczewski.de` | **Traefik Basic Auth** + OAuth2-Proxy |
-
-## 3. Sicherheitsrelevante Konfigurationen
-
-### 3.1 Authentifizierungs-Flows
-- **Force-SSO:** Eine Traefik-Middleware leitet alle Zugriffe auf `/login` bei Mattermost direkt zum Keycloak-Login weiter (`/oauth/gitlab/login`). Ein Testziel ist die Umgehung dieses Redirects, um das native Mattermost-Login-Formular zu erreichen.
-- **OAuth2-Proxy:** Dienste ohne native OIDC-Unterstützung (z.B. Invoice Ninja) sind hinter einem `oauth2-proxy` gekapselt. Der Proxy validiert JWT-Tokens von Keycloak und setzt X-Auth-Request-Header.
-
-### 3.2 Netzwerk-Segmentierung (NetworkPolicies)
-- **Default-Deny:** Alle Pods blockieren standardmäßig Ingress und Egress.
-- **Intra-Namespace:** Kommunikation zwischen Pods im Namespace `workspace` ist erlaubt.
-- **Egress-Kontrolle:** Nur spezifische Pods (z.B. MCP-Server) dürfen Verbindungen ins öffentliche Internet (Port 443) aufbauen.
-
-### 3.3 Datenbank-Sicherheit
-- Alle Dienste teilen sich eine PostgreSQL-Instanz (`shared-db`), nutzen aber getrennte User und Passwörter.
-- Verbindungen erfolgen cluster-intern.
-- Die Datenbank nutzt opportunistisches TLS (Self-signed Zertifikate, bei jedem Pod-Restart neu generiert).
-
-## 4. Capture The Flag (CTF) Objectives
-Um den Erfolg eines Angriffs objektiv zu messen, wurden strategische "Flags" in der Infrastruktur platziert. Das Ziel des Testers ist die Extraktion der folgenden fiktiven Geheimnisse:
-
-| Kategorie | Zielobjekt | Erwarteter Flag-Inhalt (Beispiel) | Nachweis von... |
-| :--- | :--- | :--- | :--- |
-| **Datenbank** | DB `pentest`, Tabelle `confidential_projects`, Spalte `secret_key` | `FLAG{SHARED_DB_DATA_EXFILTRATION_SUCCESS}` | SQL-Injection oder DB-Kompromittierung |
-| **Dateisystem** | Pfad `/var/www/html/pentest_flag.txt` (im Nextcloud-Pod) | `FLAG{NEXTCLOUD_FILESYSTEM_BREACH_2026}` | RCE oder File-Read-Schwachstelle |
-| **Kubernetes** | K8s Secret `pentest-internal-vault`, Key `secret-token` | `FLAG{K8S_API_ACCESS_GRANTED}` | Privilege Escalation in der K8s-API |
-
-## 5. Priorisierte Test-Szenarien (Angriffsvektoren)
-
-1.  **SSO Bypass:** Versuch, die Traefik-Middlewares zu umgehen, um unauthentifizierten Zugriff auf Backend-Dienste zu erlangen.
-2.  **Identity Provider Exploitation:** Angriffe auf Keycloak (z.B. Realm-Konfiguration, Brute-Force auf Endpunkte).
-3.  **Lateral Movement:** Kompromittierung eines Web-Dienstes (z.B. Nextcloud via App-Exploit) und anschließender Scan des internen Netzwerks (shared-db, andere Service-Pods).
-4.  **Header Injection:** Prüfung, ob der `oauth2-proxy` durch manipulierte Header (X-Forwarded-Groups, etc.) getäuscht werden kann.
-5.  **Sensitive Data Exposure:** Prüfung der `mail.korczewski.de` (Mailpit) oder `docs.korczewski.de` auf unzureichende Basic-Auth-Absicherung.
-
-## 5. Administrative Zugänge (Break-Glass)
-Im Falle eines Fehlers existieren folgende administrativen Möglichkeiten, die im Test auf Missbrauch geprüft werden sollten:
-- Zugriff auf die `shared-db` via Port-Forwarding (erfordert K8s-API-Zugriff).
-- Nutzung von CLI-Tools innerhalb der Pods (`mmctl`, `occ`, `vaultwarden` Admin-Panel).
+Autorisierter Pentest der eigenen Infrastruktur (Bachelorprojekt).
+Letztes Update: 2026-05-05. Vorheriger Stand war veraltet (Mattermost/InvoiceNinja entfernt, Cluster zusammengeführt).
 
 ---
-*Erstellt am: 15. April 2026*
+
+## 1. Infrastrukturübersicht
+
+| Merkmal | Wert |
+|---|---|
+| Orchestrierung | Kubernetes K3s (unified 12-node cluster) |
+| Ingress Controller | Traefik v2 (Port 80/443 + hostNetwork für LiveKit/CoTURN) |
+| IAM/SSO | Keycloak 26.6 |
+| Datenbank | PostgreSQL 16 (`shared-db`, eine Instanz, separate DBs pro Service) |
+| TLS | Wildcard-Cert via Let's Encrypt DNS-01 (ipv64 webhook) |
+| GitOps | ArgoCD (Hub: mentolder, managed: korczewski-Namespace) |
+
+**Physische Cluster-Nodes:**
+- 6 Control-Planes (Hetzner Helsinki): `gekko-hetzner-2/3/4`, `pk-hetzner`, `pk-hetzner-2/3`
+- 6 Home-Workers (via WireGuard durch pk-hetzner): `k3s-1/2/3`, `k3w-1/2/3`
+- WireGuard-Hub: `pk-hetzner` (192.168.100.1) — Home-Worker können nicht über Hetzner-VTEP geroutet werden (CNI-Partition)
+
+---
+
+## 2. Öffentliche Endpunkte
+
+### 2.1 mentolder.de
+
+Alle HTTPS-Services laufen auf Port 443 mit HSTS (`max-age=31536000; includeSubDomains`).
+
+| Service | URL | Auth-Mechanismus | Rate-Limit |
+|---|---|---|---|
+| **Website (Astro+Svelte)** | `https://web.mentolder.de` | Öffentlich (kein Login nötig) | 200 req/s, Burst 400 |
+| **Apex-Redirect** | `https://mentolder.de` | → Redirect zu web.mentolder.de | — |
+| **Keycloak (SSO/IAM)** | `https://auth.mentolder.de` | OIDC Provider, eigene Login-UI | **20 req/s, Burst 40** |
+| **Nextcloud** | `https://files.mentolder.de` | Native Auth **+ OIDC** (Keycloak) | 50 req/s, Burst 100 |
+| **Vaultwarden** | `https://vault.mentolder.de` | Bitwarden-API, native Login | **20 req/s, Burst 40** |
+| **DocuSeal (E-Signaturen)** | `https://sign.mentolder.de` | Native Auth + OIDC (Keycloak) | keines |
+| **Nextcloud Whiteboard** | `https://board.mentolder.de` | Nextcloud-Auth (via Proxy) | keines |
+| **Talk HPB Signaling** | `https://signaling.mentolder.de` | Shared-Secret (intern) | keines |
+| **Nextcloud Talk (Meet)** | `https://meet.mentolder.de` | → identisch signaling | keines |
+| **Systembrett 3D (Brett)** | `https://brett.mentolder.de` | **OAuth2-Proxy → Keycloak OIDC** | keines |
+| **Dokumentation** | `https://docs.mentolder.de` | **OAuth2-Proxy → Keycloak OIDC** | keines |
+| **Mailpit (Dev-SMTP UI)** | `https://mail.mentolder.de` | **OAuth2-Proxy → Keycloak OIDC** | keines |
+| **Traefik Dashboard** | `https://traefik.mentolder.de` | **OAuth2-Proxy → Keycloak OIDC** | keines |
+| **Admin-Dashboard** | `https://dashboard.mentolder.de` | **OAuth2-Proxy → Keycloak OIDC** | keines |
+| **Tracking (Bachelorprojekt)** | `https://tracking.mentolder.de` | Nextcloud OIDC-gesteuert | keines |
+| **LiveKit Server (WebRTC)** | `https://livekit.mentolder.de` | LIVEKIT_API_KEY+SECRET (JWT) | keines |
+| **LiveKit Ingress (RTMP)** | `https://stream.mentolder.de` | LIVEKIT_API_KEY+SECRET (JWT) | keines |
+| **Collabora Online** | `https://office.mentolder.de` | WOPI-Token (von Nextcloud) | keines |
+
+### 2.2 korczewski.de
+
+Gleicher physischer Cluster, Namespace `workspace-korczewski`. Dienste spiegeln mentolder.de exakt.
+
+| Service | URL | Auth-Mechanismus |
+|---|---|---|
+| **Website** | `https://web.korczewski.de` | Öffentlich |
+| **Apex-Redirect** | `https://korczewski.de` | → web.korczewski.de |
+| **Keycloak** | `https://auth.korczewski.de` | OIDC Provider |
+| **Nextcloud** | `https://files.korczewski.de` | Native + OIDC |
+| **Vaultwarden** | `https://vault.korczewski.de` | Bitwarden-API |
+| **DocuSeal** | `https://sign.korczewski.de` | OIDC |
+| **Brett** | `https://brett.korczewski.de` | OAuth2-Proxy → Keycloak |
+| **Docs** | `https://docs.korczewski.de` | OAuth2-Proxy → Keycloak |
+| **Mailpit** | `https://mail.korczewski.de` | OAuth2-Proxy → Keycloak |
+| **Traefik Dashboard** | `https://traefik.korczewski.de` | OAuth2-Proxy → Keycloak |
+| **Admin-Dashboard** | `https://dashboard.korczewski.de` | OAuth2-Proxy → Keycloak |
+| **Tracking** | `https://tracking.korczewski.de` | OIDC |
+| **LiveKit** | `https://livekit.korczewski.de` | JWT |
+| **Stream (RTMP)** | `https://stream.korczewski.de` | JWT |
+
+---
+
+## 3. Nicht-HTTP-Ports (direkt exponiert)
+
+Diese Ports sind **nicht** hinter Traefik — sie laufen mit `hostNetwork: true` direkt auf Node-IPs.
+
+| Port / Protokoll | Service | Node (mentolder) | Node (korczewski) | Anmerkung |
+|---|---|---|---|---|
+| `7880/tcp` | LiveKit Server (HTTP/WS) | `gekko-hetzner-3` (46.225.125.59) | gleicher Node | PIN via nodeAffinity |
+| `7881/tcp` | LiveKit Server (TLS/WS) | `gekko-hetzner-3` | gleicher Node | |
+| `50000–60000/udp` | LiveKit WebRTC Media | `gekko-hetzner-3` | gleicher Node | ICE candidates |
+| `30000–40000/udp` | LiveKit Ingress Media | `gekko-hetzner-3` | gleicher Node | |
+| `3478/tcp+udp` | CoTURN (STUN/TURN) | `gekko-hetzner-2` (178.104.169.206) | `pk-hetzner` (62.238.9.39) | hostPort |
+| `5349/tcp+udp` | CoTURN (TURNS) | `gekko-hetzner-2` | `pk-hetzner` | hostPort, TLS |
+| `49152–49252/udp` | CoTURN Relay-Ports | `gekko-hetzner-2` | `pk-hetzner` | |
+| `8188/tcp` | Janus WebSocket MCU | coturn-Namespace, hostNetwork | gleicher Node | Talk MCU |
+| `1935/tcp` | RTMP (LiveKit Ingress) | `gekko-hetzner-3` | gleicher Node | OBS-Ingest |
+| `6443/tcp` | K3s API Server | alle Control-Planes | `pk-hetzner` API-Endpoint | Intern; extern via Kubeconfig |
+
+---
+
+## 4. Sicherheitsarchitektur
+
+### 4.1 Traefik Security-Headers (alle Prod-Services)
+
+```
+X-Frame-Options: SAMEORIGIN
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 1; mode=block
+Referrer-Policy: strict-origin-when-cross-origin
+Strict-Transport-Security: max-age=31536000; includeSubDomains
+X-Robots-Tag: noindex
+```
+
+### 4.2 OAuth2-Proxy Flow (ForwardAuth)
+
+Schützt: Brett, Docs, Mailpit, Traefik Dashboard, Dashboard.
+
+```
+Browser → Traefik → ForwardAuth (oauth2-proxy :4180)
+  → 202: Request wird durchgeleitet
+  → 401: Middleware leitet zu /oauth2/sign_in → Keycloak
+Callback: Keycloak → /oauth2/callback → Session-Cookie
+```
+
+Relevante Header (nach erfolgreicher Auth):
+- `X-Auth-Request-User` — Keycloak-Username
+- `X-Auth-Request-Email` — Keycloak-Email
+- `X-Auth-Request-Groups` — Keycloak-Gruppen
+
+### 4.3 NetworkPolicies
+
+| Policy | Wirkung |
+|---|---|
+| `default-deny-ingress` | Blockiert **alle** eingehenden Verbindungen (Default) |
+| `default-deny-egress` | Blockiert **alle** ausgehenden Verbindungen (Default) |
+| `allow-dns-egress` | DNS → kube-system:53 (alle Pods) |
+| `allow-intra-namespace-egress/ingress` | Pod-zu-Pod im workspace-Namespace (alle Pods) |
+| `allow-traefik-ingress` | Traefik (kube-system) → alle workspace-Pods |
+| `allow-internet-egress` | **Alle Pods → beliebige externe IPs, beliebige Ports** (außer RFC1918) |
+| `allow-website-ingress` | website/korczewski-website Namespace → workspace |
+| `allow-mcp-external-egress` | mcp-github-Pod → 443/tcp extern |
+| `brett-egress` | Brett → shared-db:5432 + DNS only |
+
+> **Pentest-Hinweis:** `allow-internet-egress` gilt für **alle** Pods ohne Port-Einschränkung. Bei RCE in einem beliebigen Pod ist ausgehender Traffic auf jede externe IP auf jedem Port möglich (C2-Beacon, Datenexfiltration via beliebiges Protokoll).
+
+### 4.4 Keycloak-Realm-Konfiguration
+
+- Realm: `workspace`
+- Clients: `nextcloud`, `website`, `vaultwarden`, `claude-code`, `docs`, `traefik`, `mailpit`, `docuseal`, `brett`, `dashboard`, `tracking`
+- Auth-Flow: Standard OIDC Authorization Code Flow
+- Keycloak-Version: **26.6** (quay.io/keycloak/keycloak:26.6)
+- Admin-Konsole: `https://auth.<domain>/admin` (nicht rate-limited — separater Pfad vom Login-Endpoint)
+
+---
+
+## 5. CTF-Flags (Pentest-Objectives)
+
+| Flag-ID | Zielobjekt | Erwarteter Inhalt | Nachweis von |
+|---|---|---|---|
+| `FLAG-01` | K8s Secret `pentest-internal-vault` (Namespace: workspace), Key `secret-token` | `FLAG{K8S_API_ACCESS_GRANTED}` | K8s-API-Zugriff / Privilege Escalation |
+| `FLAG-02` | ConfigMap `pentest-filesystem-flag` (workspace), Key `pentest_flag.txt` | `FLAG{NEXTCLOUD_FILESYSTEM_BREACH_2026}` | Pod-Exec / Filesystem-Lesezugriff |
+| `FLAG-03` | DB `pentest`, Tabelle `confidential_projects`, Spalte `secret_key` | `FLAG{SHARED_DB_DATA_EXFILTRATION_SUCCESS}` | SQL-Injection oder DB-Kompromittierung |
+
+Flag-Ressourcen sind in `k3d/pentest-flags.yaml` definiert.
+
+---
+
+## 6. Priorisierte Angriffsvektoren
+
+### Tier 1 — Unauthentifizierte Angriffsfläche
+
+1. **Keycloak (auth.\*) — Identity Provider Exploitation**
+   - Brute-Force Login-Endpunkt (rate-limited: 20 req/s)
+   - Realm-Discovery: `/.well-known/openid-configuration`, `/realms/workspace`
+   - Admin-Konsole auf `/admin/` (eigene Credentials, separater Pfad)
+   - User-Enumeration via Login-Fehlermeldungen
+   - Keycloak 26.6 CVEs prüfen
+
+2. **Website (web.\*) — öffentliche Angriffsfläche**
+   - Chat-Funktionalität (eingebaut, Astro+Svelte): XSS, CSRF, Injections
+   - API-Endpunkte (`/api/*`): Input-Validation, Auth-Bypass
+   - Stripe-Integration: Publishable-Key im Frontend sichtbar (`pk_live_...`)
+   - Admin-Panel: `https://web.mentolder.de/admin/` (Keycloak-geschützt — kann direkt aufgerufen werden?)
+
+3. **Nextcloud (files.\*) — Breit exponiert**
+   - Native Login-Form (User-Enumeration, Brute-Force)
+   - Nextcloud-Apps: DAV-Endpoints, OCS-API, Talk WebSocket
+   - OIDC-Bypass versuchen (direkte Login-URL trotz SSO)
+   - WebDAV-Endpunkte auf unauthentifizierten Zugriff prüfen
+
+4. **Vaultwarden (vault.\*)**
+   - Bitwarden-API (nativer Login, kein SSO-Zwang)
+   - Admin-Panel: `/admin` (durch eigenes Passwort geschützt — nicht OIDC)
+   - Bitwarden-API Swagger-Endpunkte
+
+5. **DocuSeal (sign.\*)**
+   - Öffentliche Signatur-Links (URL-Guessing)
+   - Unauthentifizierter API-Zugriff
+
+### Tier 2 — Authentifizierte / Semi-exponierte Fläche
+
+6. **OAuth2-Proxy Bypass (brett/docs/mail/traefik/dashboard)**
+   - Header-Injection: `X-Auth-Request-User`, `X-Auth-Request-Groups`, `X-Forwarded-*`
+   - Direct-Access ohne Traefik (falls Service-IPs erreichbar)
+   - `/oauth2/`-Endpunkte ohne Auth-Middleware: logout-poisoning, open redirect
+
+7. **Talk HPB Signaling (signaling.\*)**
+   - Shared-Secret-Extraktion aus Nextcloud-Konfig
+   - WebSocket-Upgrade ohne Auth
+
+8. **LiveKit (livekit.\*, 7880/7881/tcp)**
+   - API-Schlüssel-Brute-Force oder -Leakage
+   - Room-Token-Forgery (JWT-Secret-Leak)
+   - ICE-Endpunkte auf falsche Konfiguration prüfen
+
+9. **CoTURN (3478/5349)**
+   - TURN-Auth-Bypass (Long-Term Credential vs. HMAC)
+   - STUN-Amplification (UDP, 3478)
+   - Relay-Missbrauch als Proxy
+
+### Tier 3 — Post-Exploitation / Lateral Movement
+
+10. **Shared-DB Lateral Movement**
+    - Nach App-Kompromittierung: DB-Credentials aus Pod-Env-Vars
+    - Cross-DB-Zugriff (alle Services teilen shared-db, separate User/DBs)
+    - `pg_hba.conf` auf fehlende Isolierung prüfen
+
+11. **K8s-API via Service-Account**
+    - Jeder Pod hat ein gemountetes Service-Account-Token
+    - Default SA-Permissions prüfen (`kubectl auth can-i --list`)
+    - Secrets in anderen Namespaces lesbar?
+
+12. **Internet-Egress aus kompromittiertem Pod**
+    - `allow-internet-egress` erlaubt unbeschränkten ausgehenden Traffic
+    - C2-Beacon, Datenexfiltration, SSRF-Pivot nach extern
+
+---
+
+## 7. Kali-Linux Automatisierungs-Vorschlag
+
+```bash
+# Scope-Datei (scope.txt) für beide Environments
+cat > /tmp/scope.txt << 'EOF'
+# mentolder.de
+web.mentolder.de
+auth.mentolder.de
+files.mentolder.de
+vault.mentolder.de
+sign.mentolder.de
+board.mentolder.de
+signaling.mentolder.de
+brett.mentolder.de
+docs.mentolder.de
+mail.mentolder.de
+traefik.mentolder.de
+dashboard.mentolder.de
+tracking.mentolder.de
+livekit.mentolder.de
+stream.mentolder.de
+office.mentolder.de
+# korczewski.de (gleiche Services)
+web.korczewski.de
+auth.korczewski.de
+files.korczewski.de
+vault.korczewski.de
+sign.korczewski.de
+brett.korczewski.de
+docs.korczewski.de
+mail.korczewski.de
+traefik.korczewski.de
+dashboard.korczewski.de
+livekit.korczewski.de
+# Non-HTTP (explizite IP+Port-Targets)
+178.104.169.206:3478   # CoTURN mentolder (gekko-hetzner-2)
+178.104.169.206:5349
+46.225.125.59:7880     # LiveKit mentolder (gekko-hetzner-3)
+46.225.125.59:7881
+62.238.9.39:3478       # CoTURN korczewski (pk-hetzner)
+62.238.9.39:5349
+EOF
+
+# --- Phase 1: Recon ---
+# Subdomain-Enum (eigene DNS-Records bestätigen)
+for d in mentolder.de korczewski.de; do
+  amass enum -passive -d $d -o /tmp/amass-$d.txt
+done
+
+# HTTP-Header + TLS-Analyse
+cat /tmp/scope.txt | grep -v "#" | grep "\." | while read host; do
+  curl -sI "https://$host" -o /tmp/headers-$host.txt 2>&1
+done
+
+# Nmap: Alle Hosts + Non-Standard-Ports
+nmap -sV -sC -p 80,443,3478,5349,7880,7881,8188,1935 \
+  178.104.169.206 46.225.125.59 62.238.9.39 \
+  -oN /tmp/nmap-infra.txt
+
+# --- Phase 2: Web-Scan ---
+# Nuclei gegen alle HTTPS-Targets
+nuclei -l /tmp/scope.txt -t /opt/nuclei-templates/ \
+  -severity medium,high,critical -o /tmp/nuclei-results.txt
+
+# Nikto gegen Nextcloud + Keycloak
+nikto -h https://files.mentolder.de -o /tmp/nikto-nc.txt
+nikto -h https://auth.mentolder.de -o /tmp/nikto-kc.txt
+
+# Keycloak: Well-Known + Realm-Endpoints
+curl https://auth.mentolder.de/realms/workspace/.well-known/openid-configuration | jq .
+curl https://auth.mentolder.de/realms/workspace/
+
+# --- Phase 3: Vaultwarden Admin-Panel Probe ---
+curl -si https://vault.mentolder.de/admin
+curl -si https://vault.korczewski.de/admin
+
+# --- Phase 4: CoTURN Test ---
+turnutils_uclient -T -u test -w test -p 3478 178.104.169.206
+# STUN-Check
+stunclient 178.104.169.206 3478
+
+# --- Phase 5: LiveKit API Probe ---
+# ohne gültigen JWT sollte 401/403 kommen
+curl -si https://livekit.mentolder.de/twirp/livekit.RoomService/ListRooms \
+  -H "Content-Type: application/json" -d '{}'
+```
+
+---
+
+## 8. Entfernte Services (nicht mehr im Stack)
+
+Die folgenden Services sind vollständig entfernt — Tests darauf sind Out-of-Scope:
+
+| Service | Vorher | Status |
+|---|---|---|
+| Mattermost | `chat.korczewski.de` | ENTFERNT (durch Astro-nativen Chat ersetzt) |
+| Invoice Ninja | `billing.korczewski.de` | ENTFERNT |
+
+---
+
+## 9. Administrative Break-Glass-Zugänge
+
+Diese Zugänge existieren und sollten auf Missbrauch geprüft werden:
+
+- **Keycloak Admin-Konsole:** `https://auth.<domain>/admin` — eigene Credentials (nicht via Keycloak-Realm)
+- **Vaultwarden Admin-Panel:** `https://vault.<domain>/admin` — eigenes Admin-Token (env var)
+- **shared-db via Port-Forward:** `task workspace:port-forward` (erfordert K8s-API-Zugriff)
+- **Pod-CLI:** `kubectl exec -n workspace` für mmctl-artige Tools (erfordert K8s-RBAC)
+- **Traefik API:** `https://traefik.<domain>/api/` (OAuth2-Proxy-geschützt)
+
+---
+
+*Erstellt/aktualisiert: 2026-05-05 — vollständige Neufassung auf Basis aktueller Manifeste*

--- a/k3d/keycloak.yaml
+++ b/k3d/keycloak.yaml
@@ -148,6 +148,11 @@ spec:
                 secretKeyRef:
                   name: workspace-secrets
                   key: BRETT_OIDC_SECRET
+            - name: DASHBOARD_OIDC_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: workspace-secrets
+                  key: DASHBOARD_OIDC_SECRET
             - name: TZ
               value: Europe/Berlin
           ports:

--- a/prod/import-entrypoint.sh
+++ b/prod/import-entrypoint.sh
@@ -40,7 +40,8 @@ for var in \
     SMTP_FROM \
     SMTP_USER \
     SMTP_PASSWORD \
-    BRETT_OIDC_SECRET; do
+    BRETT_OIDC_SECRET \
+    DASHBOARD_OIDC_SECRET; do
   eval val="\${${var}:-}"
   if [ -z "$val" ]; then
     echo "[import-entrypoint] WARNUNG: ${var} ist nicht gesetzt!"


### PR DESCRIPTION
## Summary

- Complete rewrite of `PENTEST_OVERVIEW.md` — old version referenced Mattermost, Invoice Ninja, and only korczewski.de; now reflects the unified 12-node cluster with both domains
- Documents all ~16 HTTPS endpoints per domain (mentolder.de + korczewski.de) with correct auth mechanisms, rate limits, and security headers
- Adds non-HTTP surface: LiveKit (7880/7881/50k-60k udp on 46.225.125.59), CoTURN (3478/5349 on both TURN nodes), RTMP (1935), Janus (8188)
- Flags `allow-internet-egress` NetworkPolicy (all pods, any external port — C2/exfil risk post-RCE)
- Adds Kali automation starter script with concrete node IPs and scope file
- Wires `DASHBOARD_OIDC_SECRET` into Keycloak env + `import-entrypoint.sh` (was missing)

## Test plan

- [ ] `task workspace:validate` — manifest dry-run passes
- [ ] Keycloak pod starts cleanly with `DASHBOARD_OIDC_SECRET` env var present
- [ ] PENTEST_OVERVIEW.md reviewed for accuracy before starting pentest

🤖 Generated with [Claude Code](https://claude.com/claude-code)