### PR TITLE
fix(korczewski): patch CronJobs + pin all livekit-* to k3s-3

### DIFF
--- a/prod-korczewski/kustomization.yaml
+++ b/prod-korczewski/kustomization.yaml
@@ -56,5 +56,26 @@ patches:
                         - k3w-1
                         - k3w-2
                         - k3w-3
+  # CronJob templates are nested one level deeper than Deployments,
+  # so they need a separate patch path.
+  - target:
+      kind: CronJob
+    patch: |-
+      - op: add
+        path: /spec/jobTemplate/spec/template/spec/affinity
+        value:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: kubernetes.io/hostname
+                      operator: NotIn
+                      values:
+                        - k3s-1
+                        - k3s-2
+                        - k3s-3
+                        - k3w-1
+                        - k3w-2
+                        - k3w-3
   - path: patch-livekit.yaml
   - path: patch-backup-config.yaml

--- a/prod-korczewski/patch-livekit.yaml
+++ b/prod-korczewski/patch-livekit.yaml
@@ -1,3 +1,12 @@
+# Pin all livekit-* Deployments to k3s-3.
+#
+# livekit-server uses hostNetwork: true with the pinned public IP
+# 192.168.100.4 (k3s-3 wg0). livekit-redis is co-located so livekit-server
+# reaches it on the same node (intra-node pod traffic works fine across
+# the CNI partition). livekit-egress / livekit-ingress connect to redis
+# via ClusterIP — they must also live on k3s-3, otherwise the Hetzner →
+# home-worker pod-network path (broken) takes them down.
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -20,6 +29,42 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: livekit-redis
+  namespace: workspace
+spec:
+  template:
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/hostname
+                    operator: In
+                    values:
+                      - k3s-3
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: livekit-egress
+  namespace: workspace
+spec:
+  template:
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/hostname
+                    operator: In
+                    values:
+                      - k3s-3
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: livekit-ingress
   namespace: workspace
 spec:
   template:


### PR DESCRIPTION
## Summary

Two follow-ups to PR #489 found while validating the recovered korczewski deployment:

- The placement patch in #489 only targeted `kind: Deployment`. CronJob pods (ddns-updater, db-backup, billing-dunning-detection, monthly-billing, notify-unread, tls-sync) bypassed it and still landed on home workers, where they fail DNS lookups against CoreDNS. Add a sibling patch with the `/spec/jobTemplate/spec/template/spec/affinity` path that targets CronJobs.
- `livekit-egress` and `livekit-ingress` connect to `livekit-redis` via ClusterIP. With the new Hetzner-only affinity they ended up on `pk-hetzner-2`, but `livekit-redis` lives on `k3s-3` (intentionally co-located with `livekit-server` for hostNetwork reasons). The Hetzner→home pod-network path is broken, so they crashlooped on `dial tcp 10.43.x.y:6379: i/o timeout`. Pin them to `k3s-3` so all four livekit-* Deployments run on the same node — intra-node pod traffic works fine across the partition.

## Test plan

- [x] `kustomize build prod-korczewski` shows all 6 CronJobs with `kubernetes.io/hostname NotIn [k3s-1/2/3, k3w-1/2/3]` at `/spec/jobTemplate/...`.
- [x] After applying, ddns-updater's next cron run lands on `pk-hetzner-2` and Completes successfully.
- [x] livekit-egress / livekit-ingress on `k3s-3` go `1/1 Running` and stop crashlooping (Redis reachable on same node).

🤖 Generated with [Claude Code](https://claude.com/claude-code)