### PR TITLE
fix(infra): mentolder nodeAffinity + korczewski livekit DNS + backup scheduling

### DIFF
--- a/k3d/backup-cronjob.yaml
+++ b/k3d/backup-cronjob.yaml
@@ -21,14 +21,18 @@ spec:
             app: db-backup
         spec:
           restartPolicy: OnFailure
-          # Co-locate with shared-db to avoid cross-node CNI routing issues.
+          # Prefer to co-locate with shared-db (same-node pg_dump is faster and avoids
+          # cross-node routing) but don't block scheduling if that node is full.
+          # The backup connects via the shared-db Service, so any reachable node works.
           affinity:
             podAffinity:
-              requiredDuringSchedulingIgnoredDuringExecution:
-                - labelSelector:
-                    matchLabels:
-                      app: shared-db
-                  topologyKey: kubernetes.io/hostname
+              preferredDuringSchedulingIgnoredDuringExecution:
+                - weight: 100
+                  podAffinityTerm:
+                    labelSelector:
+                      matchLabels:
+                        app: shared-db
+                    topologyKey: kubernetes.io/hostname
           securityContext:
             runAsNonRoot: true
             runAsUser: 65534

--- a/prod-korczewski/patch-livekit.yaml
+++ b/prod-korczewski/patch-livekit.yaml
@@ -24,6 +24,16 @@ spec:
                     operator: In
                     values:
                       - k3s-3
+      # k3s-3 is a home worker: CoreDNS ClusterIP (10.43.0.10) is unreachable
+      # due to the Flannel/WireGuard CNI partition. livekit-server uses
+      # hostNetwork and calls STUN (stun1.l.google.com) at startup to detect
+      # its external IP — that lookup goes to CoreDNS and times out.
+      # Override to public DNS so the STUN lookup succeeds.
+      dnsPolicy: "None"
+      dnsConfig:
+        nameservers:
+          - "8.8.8.8"
+          - "8.8.4.4"
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/prod-mentolder/kustomization.yaml
+++ b/prod-mentolder/kustomization.yaml
@@ -53,6 +53,48 @@ configMapGenerator:
 generatorOptions:
   disableNameSuffixHash: true
 
+# Prevent pods from drifting to home workers (k3s-1/2/3, k3w-1/2/3) after they
+# joined the unified cluster. The CNI partition breaks DNS and ClusterIP routing
+# from those nodes. livekit-* are exempt: patch-livekit.yaml pins them to
+# gekko-hetzner-3 explicitly, overriding this blanket affinity.
 patches:
+  - target:
+      kind: Deployment
+    patch: |-
+      - op: add
+        path: /spec/template/spec/affinity
+        value:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: kubernetes.io/hostname
+                      operator: NotIn
+                      values:
+                        - k3s-1
+                        - k3s-2
+                        - k3s-3
+                        - k3w-1
+                        - k3w-2
+                        - k3w-3
+  - target:
+      kind: CronJob
+    patch: |-
+      - op: add
+        path: /spec/jobTemplate/spec/template/spec/affinity
+        value:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: kubernetes.io/hostname
+                      operator: NotIn
+                      values:
+                        - k3s-1
+                        - k3s-2
+                        - k3s-3
+                        - k3w-1
+                        - k3w-2
+                        - k3w-3
   - path: patch-backup-config.yaml
   - path: patch-livekit.yaml


### PR DESCRIPTION
## Summary

- **prod-mentolder nodeAffinity**: Add blanket `NotIn [k3s-1..k3w-3]` affinity for all Deployments and CronJobs — same pattern as `prod-korczewski`. Fixes `tracking-import` CronJob pods and rescheduled pods (e.g. `mcp-ops`) drifting to home workers where CoreDNS/ClusterIP is unreachable due to the Flannel/WireGuard CNI partition.
- **korczewski livekit-server DNS**: Add `dnsPolicy: None` + Google public DNS to `prod-korczewski/patch-livekit.yaml`. With `hostNetwork: true`, the pod queries CoreDNS (10.43.0.10) for `stun1.l.google.com` at startup — that ClusterIP is unreachable from k3s-3, causing CrashLoopBackOff.
- **db-backup affinity**: Change pod affinity from `required` to `preferred` co-location with `shared-db`. The backup connects via the Service hostname so same-node placement is a latency hint, not a hard requirement. Prevents scheduling deadlock when `gekko-hetzner-3` (which hosts `shared-db`) is at 98% CPU requests.

## Test plan

- [ ] ArgoCD syncs `workspace-mentolder` and `workspace-korczewski` cleanly
- [ ] `tracking-import` CronJob pods land on Hetzner nodes (not k3s-*/k3w-*)
- [ ] `claude-code-mcp-ops` in workspace ns reschedules to a Hetzner node
- [ ] korczewski `livekit-server` starts without CrashLoopBackOff
- [ ] Next `db-backup` CronJob run schedules successfully (no longer Pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)