### PR TITLE
fix(korczewski): add livekit-redis hostAlias to livekit-server

### DIFF
--- a/prod-korczewski/patch-livekit.yaml
+++ b/prod-korczewski/patch-livekit.yaml
@@ -29,11 +29,16 @@ spec:
       # hostNetwork and calls STUN (stun1.l.google.com) at startup to detect
       # its external IP — that lookup goes to CoreDNS and times out.
       # Override to public DNS so the STUN lookup succeeds.
+      # livekit-redis is a ClusterIP → kube-proxy on k3s-3 DNATs it to the
+      # local pod, so the alias still works without CoreDNS.
       dnsPolicy: "None"
       dnsConfig:
         nameservers:
           - "8.8.8.8"
           - "8.8.4.4"
+      hostAliases:
+        - ip: 10.43.167.113   # livekit-redis ClusterIP → pod on k3s-3
+          hostnames: [livekit-redis]
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
## Summary

- `dnsPolicy: None` (added in #495) fixed the STUN external-IP lookup but broke Kubernetes service resolution — `livekit-server` tries to connect to `livekit-redis` by hostname at startup and now gets `no such host` from Google DNS.
- Add `hostAliases` for `livekit-redis` (ClusterIP `10.43.167.113`) to the `livekit-server` pod spec. kube-proxy on k3s-3 DNATs the ClusterIP to the local pod, so no CoreDNS involvement is needed. Same pattern already in use for `livekit-egress` and `livekit-ingress`.

## Test plan

- [ ] ArgoCD syncs `workspace-korczewski` cleanly
- [ ] korczewski `livekit-server` pod starts without CrashLoopBackOff
- [ ] `livekit-server` logs show successful Redis connection and RTC config validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)