### PR TITLE
fix(website): hide standard nav and footer for korczewski kore brand

### DIFF
--- a/prod-korczewski/patch-livekit.yaml
+++ b/prod-korczewski/patch-livekit.yaml
@@ -29,11 +29,16 @@ spec:
       # hostNetwork and calls STUN (stun1.l.google.com) at startup to detect
       # its external IP — that lookup goes to CoreDNS and times out.
       # Override to public DNS so the STUN lookup succeeds.
+      # livekit-redis is a ClusterIP → kube-proxy on k3s-3 DNATs it to the
+      # local pod, so the alias still works without CoreDNS.
       dnsPolicy: "None"
       dnsConfig:
         nameservers:
           - "8.8.8.8"
           - "8.8.4.4"
+      hostAliases:
+        - ip: 10.43.167.113   # livekit-redis ClusterIP → pod on k3s-3
+          hostnames: [livekit-redis]
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/tracking/pending/496.json
+++ b/tracking/pending/496.json
@@ -1,0 +1,12 @@
+{
+  "pr_number": 496,
+  "title": "add livekit-redis hostAlias to livekit-server",
+  "description": "## Summary\n\n- `dnsPolicy: None` (added in #495) fixed the STUN external-IP lookup but broke Kubernetes service resolution — `livekit-server` tries to connect to `livekit-redis` by hostname at startup and now gets `no such host` from Google DNS.\n- Add `hostAliases` for `livekit-redis` (ClusterIP `10.43.167.113`) to the `livekit-server` pod spec. kube-proxy on k3s-3 DNATs the ClusterIP to the local pod, so no CoreDNS involvement is needed. Same pattern already in use for `livekit-egress` and `livekit-ingress`.\n\n## Test plan\n\n- [ ] ArgoCD syncs `workspace-korczewski` cleanly\n- [ ] korczewski `livekit-server` pod starts without CrashLoopBackOff\n- [ ] `livekit-server` logs show successful Redis connection and RTC config validation\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)",
+  "category": "fix",
+  "scope": "korczewski",
+  "brand": "korczewski",
+  "requirement_id": null,
+  "merged_at": "2026-05-05T06:15:26Z",
+  "merged_by": "Paddione",
+  "bug_refs": []
+}

--- a/website/src/layouts/Layout.astro
+++ b/website/src/layouts/Layout.astro
@@ -37,12 +37,12 @@ const brandWord = config.meta.siteTitle.replace(/\.de$/i, '').toLowerCase();
     <a href="#main-content" class="sr-only focus:not-sr-only focus:fixed focus:top-4 focus:left-4 focus:z-50 focus:px-4 focus:py-2 focus:rounded" style="background:var(--brass); color:var(--ink-900); font-weight:600;">
       Zum Hauptinhalt springen
     </a>
-    <Navigation client:load siteTitle={config.meta.siteTitle} />
+    {!isKore && <Navigation client:load siteTitle={config.meta.siteTitle} />}
     <main id="main-content" class="flex-1">
       <slot />
     </main>
 
-    <footer style="background:var(--ink-850); border-top:1px solid var(--line); padding:72px 0 36px;">
+    {!isKore && (<footer style="background:var(--ink-850); border-top:1px solid var(--line); padding:72px 0 36px;">
       <div style="max-width:var(--maxw); margin:0 auto; padding:0 40px;">
         <div class="footer-grid" style="display:grid; grid-template-columns:1.4fr repeat(3,1fr); gap:48px; margin-bottom:56px;">
           <!-- Brand col -->
@@ -121,7 +121,7 @@ const brandWord = config.meta.siteTitle.replace(/\.de$/i, '').toLowerCase();
           </p>
         </div>
       </div>
-    </footer>
+    </footer>)}
 
     <style>
       .footer-link:hover {


### PR DESCRIPTION
## Summary
- `Layout.astro` was always rendering `<Navigation>` and the generic footer regardless of brand
- For `brand="korczewski-kore"`, the page already includes `<KoreSubNav>` and `<KoreFooter>` in the slot, causing a double navbar and double footer on `web.korczewski.de`
- Conditionally skip both when `isKore` is true

## Test plan
- [ ] Visit `web.korczewski.de` — should show only the KoreSubNav and KoreFooter, no duplicate mentolder nav/footer
- [ ] Visit `web.mentolder.de` — standard nav and footer still present, no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)