### PR TITLE
fix(livekit): use ${TLS_SECRET_NAME} for IngressRoute TLS + WORKSPACE_NAMESPACE in ApplicationSet

### DIFF
--- a/k3d/livekit.yaml
+++ b/k3d/livekit.yaml
@@ -253,7 +253,7 @@ spec:
       middlewares:
         - name: livekit-cors
   tls:
-    secretName: workspace-wildcard-tls
+    secretName: ${TLS_SECRET_NAME}
 ---
 
 # ── LiveKit Ingress (RTMP → WebRTC) ──────────────────────────────


### PR DESCRIPTION
## Summary

- Fix livekit IngressRoute to use `${TLS_SECRET_NAME}` instead of hardcoded `workspace-wildcard-tls` — the korczewski env uses `korczewski-tls`, causing Traefik TLS config errors and a broken livekit route
- Re-applied `argocd/applicationset.yaml` via `task argocd:apps:apply` — the live ApplicationSet was missing `WORKSPACE_NAMESPACE` in the CMP plugin env, leaving `${WORKSPACE_NAMESPACE}` unresolved in all Ingress middleware annotations (`workspace-redirect-https@kubernetescrd` etc.). Traefik v3 drops routes where any referenced middleware doesn't exist, causing HTTP 404 for all services in both namespaces

## Root cause

The `applicationset.yaml` had `WORKSPACE_NAMESPACE` added in git but the live ApplicationSet on the cluster was never updated (`task argocd:apps:apply` was not re-run). ArgoCD's CMP envsubst didn't substitute the variable, so every Ingress got literal `${WORKSPACE_NAMESPACE}-redirect-https@kubernetescrd` in its middleware annotation.

## Fix applied

1. `task argocd:apps:apply` — pushed updated ApplicationSet to cluster (immediate fix, no code change needed)
2. `k3d/livekit.yaml` — replaced hardcoded `workspace-wildcard-tls` with `${TLS_SECRET_NAME}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)