### PR TITLE
fix(korczewski): allow cross-ns egress + rewrite cronjob URLs

### DIFF
--- a/k3d/network-policies.yaml
+++ b/k3d/network-policies.yaml
@@ -275,6 +275,29 @@ spec:
     - port: 8080
       protocol: TCP
 ---
+# shared-db: allow ingress from korczewski namespace (tracking-import
+# CronJob in workspace-korczewski writes feature events into
+# bachelorprojekt.features on mentolder's shared-db; this is by design).
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-korczewski-to-shared-db-ingress
+  namespace: workspace
+spec:
+  podSelector:
+    matchLabels:
+      app: shared-db
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: workspace-korczewski
+    ports:
+    - port: 5432
+      protocol: TCP
+---
 # shared-db: allow ingress from MCP monolith in default namespace
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/prod-korczewski/kustomization.yaml
+++ b/prod-korczewski/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - dashboard-web.yaml
   - oauth2-proxy-dashboard.yaml
   - ingress-dashboard.yaml
+  - netpol-cross-namespace.yaml
 
 # Override realm with korczewski-specific config
 configMapGenerator:
@@ -79,6 +80,7 @@ patches:
                         - k3w-3
   - path: patch-livekit.yaml
   - path: patch-backup-config.yaml
+  - path: patch-cronjob-urls.yaml
   # Cluster-scoped resources are owned exclusively by workspace-hetzner (mentolder).
   # Both overlays deploy to the same physical cluster, so rendering these here
   # causes ArgoCD SharedResourceWarning — suppress them from korczewski.

--- a/prod-korczewski/netpol-cross-namespace.yaml
+++ b/prod-korczewski/netpol-cross-namespace.yaml
@@ -1,0 +1,39 @@
+# Cross-namespace egress for workspace-korczewski.
+#
+# Cronjobs in workspace-korczewski need to reach:
+#   - shared-db.workspace.svc.cluster.local (tracking-import writes
+#     feature events into mentolder's bachelorprojekt.features by design)
+#   - website.website-korczewski.svc.cluster.local (billing-dunning-
+#     detection, notify-unread, monthly-billing trigger korczewski's
+#     own website API)
+#
+# default-deny-egress + allow-internet-egress (which excludes RFC1918)
+# block these by default. Without this policy the cronjobs crashloop
+# with ECONNREFUSED.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-egress-to-workspace
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: workspace
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-egress-to-website-korczewski
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: website-korczewski

--- a/prod-korczewski/patch-cronjob-urls.yaml
+++ b/prod-korczewski/patch-cronjob-urls.yaml
@@ -1,0 +1,68 @@
+# Cronjobs in workspace-korczewski need to call services in their own
+# namespace (website-korczewski / workspace-korczewski). Base manifests
+# in k3d/ hardcode "workspace.svc.cluster.local" / "website.svc.cluster.local"
+# which silently end up calling mentolder's services. These patches rewrite
+# the URLs to the korczewski-local equivalents.
+#
+# Note: tracking-import is intentionally cross-namespace (writes to
+# mentolder's shared-db). It is NOT patched here. Cross-ns access is
+# allowed by the NetworkPolicy in workspace ns.
+
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: billing-dunning-detection
+  namespace: workspace
+spec:
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: detector
+              command:
+                - /bin/sh
+                - -c
+                - 'curl -s -X POST http://website.website-korczewski.svc.cluster.local/api/admin/billing/dunning/run -H "X-Cron-Secret: ${CRON_SECRET}" || exit 1'
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: notify-unread
+  namespace: workspace
+spec:
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: notify
+              command:
+                - sh
+                - -c
+                - |
+                  curl -sf -X POST \
+                    -H "Authorization: Bearer $CRON_SECRET" \
+                    -H "Content-Type: application/json" \
+                    http://website.website-korczewski.svc.cluster.local:4321/api/cron/notify-unread
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: monthly-billing
+  namespace: workspace
+spec:
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: trigger
+              command:
+                - sh
+                - -c
+                - |
+                  curl -sf -X POST \
+                    -H "Content-Type: application/json" \
+                    -H "X-Cron-Secret: $CRON_SECRET" \
+                    http://website.website-korczewski.svc.cluster.local:4321/api/admin/billing/create-monthly-invoices


### PR DESCRIPTION
## Summary
- Adds NetworkPolicies in `workspace-korczewski` permitting egress to `workspace` and `website-korczewski` namespaces.
- Adds NetworkPolicy in `workspace` permitting ingress to shared-db from `workspace-korczewski`.
- Patches korczewski cronjob URLs (billing-dunning-detection, notify-unread, monthly-billing) to target `website.website-korczewski.svc.cluster.local` instead of mentolder's namespace.

## Why
On the unified cluster, korczewski cronjobs were crashlooping with ECONNREFUSED. Two root causes:
1. URLs hardcoded `workspace.svc.cluster.local` / `website.svc.cluster.local` → silently called mentolder.
2. `default-deny-egress` + `allow-internet-egress` (excludes RFC1918) blocked all in-cluster cross-ns traffic. tracking-import (intentionally cross-ns to mentolder shared-db) and billing/notify (which should hit korczewski's website) all failed.

Verified live: tracking-import job 29632750 completed (`ingested 6 rows`); curl test from a Hetzner-pinned pod resolves website.website-korczewski and gets HTTP 403 (auth rejection — proves connectivity).

## Test plan
- [x] Cross-ns DB connectivity: tracking-import succeeds on workspace-korczewski (was failing for >1h)
- [x] kustomize build prod-korczewski/ succeeds
- [ ] After ArgoCD syncs: billing-dunning-detection, notify-unread, monthly-billing complete successfully on workspace-korczewski schedule