### PR TITLE
fix(staleness): schema vars, brand parameterization, doc accuracy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -300,10 +300,9 @@ graph TB
 ## CI/CD
 
 GitHub Actions (`.github/workflows/ci.yml`) runs on every PR:
-- Manifest validation: `kustomize build` + `kubeconform` (K8s 1.31.0)
-- YAML linting: `yamllint` (200-char line limit)
-- Shell linting: `shellcheck` on all scripts
-- Config validation: JSON (realm), PHP (OIDC), secret detection, image pinning checks
+- Offline tests: `task test:all` (BATS unit tests, kustomize manifest structure, Taskfile dry-run)
+- Systembrett template validation
+- Security scan: image-pin advisory + hardcoded-secret detection in `k3d/*.yaml`
 
 ## Development Rules
 
@@ -342,7 +341,7 @@ Non-obvious repo behaviors. Violating these silently breaks things or hits the w
 
 ### Operational
 - **Docs ConfigMap is not auto-synced by ArgoCD.** After changing `docs-site/` or the `docs-content` ConfigMap, run `task docs:deploy ENV=<env>` then `task docs:restart ENV=<env>`. Applying the ConfigMap alone leaves the old content served.
-- **yamllint runs a 200-char line limit in CI only.** Long base64 strings or multiline patches that are fine locally will fail the `lint-yaml` job on PR. Run `yamllint -d '{extends: relaxed, rules: {line-length: {max: 200}}}' <file>` before pushing.
+- **No yamllint/shellcheck/kubeconform in CI.** Earlier docs claimed these ran on PRs; the current `ci.yml` only runs `task test:all`. Run `yamllint`/`shellcheck` locally if you want lint feedback before pushing.
 - **LiveKit needs node-pinning + DNS-pinning + ufw rules.** `livekit-server` runs with `hostNetwork: true` (workspace ns is `pod-security: privileged` for this) and is pinned via `nodeAffinity` to `gekko-hetzner-3` (mentolder). The Hetzner host firewall blocks all inter-node traffic except 80/443 — `prod/cloud-init.yaml` opens 7880/tcp + 7881/tcp + 50000-60000/udp + 30000-40000/udp on every node. `livekit.<domain>` and `stream.<domain>` should DNS-pin to the pin-node IP via `task livekit:dns-pin` (browsers otherwise hit a non-LiveKit node ~66% of the time and ICE silently fails). `Room.connect()` must run from a user gesture — Chrome blocks the AudioContext otherwise.
 
 ### Korczewski homepage uses the Kore design system (different from mentolder)

--- a/environments/korczewski.yaml
+++ b/environments/korczewski.yaml
@@ -38,6 +38,8 @@ env_vars:
   MAIL_EXTERNAL_URL: "https://mail.korczewski.de"
   STRIPE_PUBLISHABLE_KEY: "pk_live_51RhKrcDGTY4NP8aeqnf69F1OVgNleqjLqR5ZHi8jkzlyxLiaTEnsY5xwhgPAVV7FdNb4eRnelIzt7DUj9TTAopXg00yyxjx03t"
   BRETT_DOMAIN: brett.korczewski.de
+  LIVEKIT_DOMAIN: livekit.korczewski.de
+  STREAM_DOMAIN: stream.korczewski.de
   DASHBOARD_DOMAIN: dashboard.korczewski.de
   WEBSITE_HOST: web.korczewski.de
   WEBSITE_SITE_URL: "https://web.korczewski.de"

--- a/environments/mentolder.yaml
+++ b/environments/mentolder.yaml
@@ -38,6 +38,8 @@ env_vars:
   MAIL_EXTERNAL_URL: "https://mail.mentolder.de"
   STRIPE_PUBLISHABLE_KEY: "pk_live_51TOM2vPmjoQCVSEjX0mKUyfMoEJQssMbl2Me20WSiLJBjhIrxQJiesJrSw6GVlVetbJJ1cH7Wk0rOXHamMN5aVMD00gxhMrdoF"
   BRETT_DOMAIN: brett.mentolder.de
+  LIVEKIT_DOMAIN: livekit.mentolder.de
+  STREAM_DOMAIN: stream.mentolder.de
   DASHBOARD_DOMAIN: dashboard.mentolder.de
   WEBSITE_HOST: web.mentolder.de
   WEBSITE_SITE_URL: "https://web.mentolder.de"

--- a/environments/schema.yaml
+++ b/environments/schema.yaml
@@ -154,6 +154,14 @@ env_vars:
     required: true
     default_dev: "brett.localhost"
 
+  - name: LIVEKIT_DOMAIN
+    required: true
+    default_dev: "livekit.localhost"
+
+  - name: STREAM_DOMAIN
+    required: true
+    default_dev: "stream.localhost"
+
   - name: DASHBOARD_DOMAIN
     required: true
     default_dev: "dashboard.localhost"

--- a/website/src/lib/pdf-a3-embed.ts
+++ b/website/src/lib/pdf-a3-embed.ts
@@ -15,6 +15,8 @@ export interface EmbedOptions {
 
 const ICC_PATH = join(dirname(fileURLToPath(import.meta.url)), '..', 'assets', 'sRGB.icc');
 
+const BRAND_TAG = `${process.env.BRAND_ID ?? process.env.BRAND ?? 'mentolder'}-billing`;
+
 function pdfDate(d: Date): string {
   const p = (n: number, w = 2) => String(n).padStart(w, '0');
   const tz = -d.getTimezoneOffset();
@@ -41,10 +43,10 @@ function buildXmp(opts: EmbedOptions, modDate: Date): string {
                                   xmlns:pdfaProperty="http://www.aiim.org/pdfa/ns/property#"
                                   pdfaid:part="3" pdfaid:conformance="B">
       <dc:title><rdf:Alt><rdf:li xml:lang="x-default">Rechnung ${escapeXml(opts.invoiceNumber)}</rdf:li></rdf:Alt></dc:title>
-      <xmp:CreatorTool>mentolder-billing</xmp:CreatorTool>
+      <xmp:CreatorTool>${BRAND_TAG}</xmp:CreatorTool>
       <xmp:CreateDate>${iso}</xmp:CreateDate>
       <xmp:ModifyDate>${iso}</xmp:ModifyDate>
-      <pdf:Producer>pdf-lib + mentolder-billing</pdf:Producer>
+      <pdf:Producer>pdf-lib + ${BRAND_TAG}</pdf:Producer>
       <fx:DocumentType>INVOICE</fx:DocumentType>
       <fx:DocumentFileName>${escapeXml(fileName)}</fx:DocumentFileName>
       <fx:Version>1.0</fx:Version>
@@ -162,7 +164,7 @@ export async function embedFacturXIntoPdfA3(
 
   // Document Info dict
   pdf.setTitle(`Rechnung ${opts.invoiceNumber}`);
-  pdf.setProducer('pdf-lib + mentolder-billing');
+  pdf.setProducer(`pdf-lib + ${BRAND_TAG}`);
   pdf.setCreationDate(modDate);
   pdf.setModificationDate(modDate);
 


### PR DESCRIPTION
## Summary
Resolves substantive items from the 2026-04-27 staleness audit; the rest are scanner false positives (file-extension confusion, IngressRoute vs Ingress kind, shell-internal vars).

- Add LIVEKIT_DOMAIN + STREAM_DOMAIN to schema + both env files.
- Parameterize PDF producer/creator strings (BRAND env) so korczewski invoices stop showing "mentolder-billing".
- Correct CLAUDE.md CI section — yamllint/shellcheck/kubeconform are not actually wired into ci.yml.

## False positives identified (no code change needed)
- Taskfile envsubst lists: scanner greps `Taskfile.yaml`; file is `Taskfile.yml`. CLAUDE.md text already says so.
- ArgoCD annotation keys: scanner greps Taskfile.yml; keys live in Taskfile.argocd.yml lines 135-139, 171-175.
- "Missing schema vars" KC/NC/PASS/BACKUP_DIR/...: shell-internal variables inside ConfigMap-embedded scripts, not envsubst placeholders.
- Domain vs Ingress: scanner only checks `Ingress` kind; LIVEKIT/STREAM/MAIL/WEB/TRAEFIK use Traefik IngressRoute.

## Test plan
- [x] env:validate (schema additions don't break)
- [ ] Next staleness audit picks up reduction in flagged items