### PR TITLE
fix(korczewski): pin livekit to gekko-hetzner-4 for public IP WebRTC

### DIFF
--- a/prod-korczewski/patch-livekit.yaml
+++ b/prod-korczewski/patch-livekit.yaml
@@ -1,11 +1,9 @@
-# Pin all livekit-* Deployments to k3s-3.
+# Pin all livekit-* Deployments to gekko-hetzner-4 (178.104.159.79).
 #
-# livekit-server uses hostNetwork: true with the pinned public IP
-# 192.168.100.4 (k3s-3 wg0). livekit-redis is co-located so livekit-server
-# reaches it on the same node (intra-node pod traffic works fine across
-# the CNI partition). livekit-egress / livekit-ingress connect to redis
-# via ClusterIP — they must also live on k3s-3, otherwise the Hetzner →
-# home-worker pod-network path (broken) takes them down.
+# livekit-server uses hostNetwork: true; on a Hetzner node STUN discovers
+# the real public IP. All four components are co-located so livekit-egress /
+# livekit-ingress reach livekit-server and livekit-redis via normal DNS
+# (CoreDNS is reachable from Hetzner nodes).
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -23,22 +21,7 @@ spec:
                   - key: kubernetes.io/hostname
                     operator: In
                     values:
-                      - k3s-3
-      # k3s-3 is a home worker: CoreDNS ClusterIP (10.43.0.10) is unreachable
-      # due to the Flannel/WireGuard CNI partition. livekit-server uses
-      # hostNetwork and calls STUN (stun1.l.google.com) at startup to detect
-      # its external IP — that lookup goes to CoreDNS and times out.
-      # Override to public DNS so the STUN lookup succeeds.
-      # livekit-redis is a ClusterIP → kube-proxy on k3s-3 DNATs it to the
-      # local pod, so the alias still works without CoreDNS.
-      dnsPolicy: "None"
-      dnsConfig:
-        nameservers:
-          - "8.8.8.8"
-          - "8.8.4.4"
-      hostAliases:
-        - ip: 10.43.167.113   # livekit-redis ClusterIP → pod on k3s-3
-          hostnames: [livekit-redis]
+                      - gekko-hetzner-4
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -56,7 +39,7 @@ spec:
                   - key: kubernetes.io/hostname
                     operator: In
                     values:
-                      - k3s-3
+                      - gekko-hetzner-4
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -74,15 +57,7 @@ spec:
                   - key: kubernetes.io/hostname
                     operator: In
                     values:
-                      - k3s-3
-      # CoreDNS lives on Hetzner; the WireGuard/Flannel double-hop is broken
-      # so DNS lookups from k3s-3 pods time out. Pin the only two hostnames
-      # egress dials to addresses kube-proxy can DNAT locally on k3s-3.
-      hostAliases:
-        - ip: 10.43.167.113   # livekit-redis ClusterIP -> backed by pod on k3s-3
-          hostnames: [livekit-redis]
-        - ip: 192.168.100.4   # livekit-server hostNetwork on k3s-3 wg0
-          hostnames: [livekit-server]
+                      - gekko-hetzner-4
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -100,9 +75,4 @@ spec:
                   - key: kubernetes.io/hostname
                     operator: In
                     values:
-                      - k3s-3
-      hostAliases:
-        - ip: 10.43.167.113
-          hostnames: [livekit-redis]
-        - ip: 192.168.100.4
-          hostnames: [livekit-server]
+                      - gekko-hetzner-4

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -65,17 +65,36 @@ export default defineConfig({
     {
       name: 'services',
       testMatch: [
-        '**/fa-03-*.spec.ts',  // Nextcloud Talk / video
-        '**/fa-18-*.spec.ts',  // transcription service (cluster-internal URL)
-        '**/fa-23-*.spec.ts',  // Vaultwarden
-        '**/fa-24-*.spec.ts',  // Whiteboard
-        '**/fa-25-*.spec.ts',  // Mailpit
-        '**/sa-08-*.spec.ts',  // SSO integration browser flow
-        '**/nfa-05-*.spec.ts', // usability / mobile
+        '**/fa-03-*.spec.ts',    // Nextcloud Talk / video
+        '**/fa-18-*.spec.ts',    // transcription service (cluster-internal URL)
+        '**/fa-23-*.spec.ts',    // Vaultwarden
+        '**/fa-24-*.spec.ts',    // Whiteboard
+        '**/fa-25-*.spec.ts',    // Mailpit
+        '**/fa-27-*.spec.ts',    // Systemisches Brett service
+        '**/fa-29-*.spec.ts',    // Requirements Tracking UI
+        '**/fa-livekit.spec.ts', // LiveKit / Livestream auth-gating
+        '**/sa-02-*.spec.ts',    // Authentication (wrong password → Keycloak error)
+        '**/sa-08-*.spec.ts',    // SSO integration browser flow
+        '**/nfa-05-*.spec.ts',   // usability / mobile
       ],
       use: {
         ...devices['Desktop Chrome'],
         baseURL: websiteURL,
+      },
+    },
+
+    // ── korczewski: Korczewski-brand & cross-cluster specs ───────
+    // Run: npx playwright test --project=korczewski
+    {
+      name: 'korczewski',
+      testMatch: [
+        '**/korczewski-home.spec.ts',  // Kore brand homepage
+        '**/brett-art.spec.ts',        // Brett art-library (canvas sprites)
+        '**/dashboard-art.spec.ts',    // Dashboard art-library tab
+      ],
+      use: {
+        ...devices['Desktop Chrome'],
+        ignoreHTTPSErrors: true,
       },
     },
 

--- a/tests/e2e/specs/fa-27-brett.spec.ts
+++ b/tests/e2e/specs/fa-27-brett.spec.ts
@@ -1,0 +1,39 @@
+import { test, expect } from '@playwright/test';
+
+const BRETT_URL = process.env.BRETT_URL
+  ?? (process.env.PROD_DOMAIN ? `https://brett.${process.env.PROD_DOMAIN}` : 'http://brett.localhost');
+
+test.describe('FA-27: Systemisches Brett', () => {
+  test('T1: Brett service is reachable', async ({ request }) => {
+    const res = await request.get(BRETT_URL);
+    expect([200, 301, 302]).toContain(res.status());
+  });
+
+  test('T2: /healthz returns 200', async ({ request }) => {
+    const res = await request.get(`${BRETT_URL}/healthz`);
+    expect(res.status()).toBe(200);
+  });
+
+  test('T3: /api/state returns JSON figures array for unknown room', async ({ request }) => {
+    const res = await request.get(`${BRETT_URL}/api/state?room=e2e-probe-${Date.now()}`);
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    expect(body).toHaveProperty('figures');
+    expect(Array.isArray(body.figures)).toBe(true);
+  });
+
+  test('T4: /three.min.js static asset is served', async ({ request }) => {
+    const res = await request.get(`${BRETT_URL}/three.min.js`);
+    expect(res.status()).toBe(200);
+  });
+
+  test('T5: POST /api/snapshots creates a snapshot', async ({ request }) => {
+    const room = `e2e-snap-${Date.now()}`;
+    const res = await request.post(`${BRETT_URL}/api/snapshots`, {
+      data: { room, name: 'e2e-test-snapshot', figures: [] },
+    });
+    expect([200, 201]).toContain(res.status());
+    const body = await res.json();
+    expect(body).toHaveProperty('id');
+  });
+});

--- a/tests/e2e/specs/fa-29-tracking.spec.ts
+++ b/tests/e2e/specs/fa-29-tracking.spec.ts
@@ -1,0 +1,31 @@
+import { test, expect } from '@playwright/test';
+
+const TRACKING_URL = process.env.TRACKING_URL
+  ?? (process.env.PROD_DOMAIN ? `https://tracking.${process.env.PROD_DOMAIN}` : 'http://tracking.localhost');
+
+test.describe('FA-29: Requirements Tracking UI', () => {
+  test('T1: Tracking service is reachable', async ({ request }) => {
+    const res = await request.get(TRACKING_URL);
+    // 200 = public UI; 301/302 = redirect; 401 = auth-protected
+    expect([200, 301, 302, 401]).toContain(res.status());
+  });
+
+  test('T2: Tracking UI returns a non-empty page title', async ({ page }) => {
+    await page.goto(TRACKING_URL, { waitUntil: 'domcontentloaded' });
+    const title = await page.title();
+    expect(title.length).toBeGreaterThan(0);
+  });
+
+  test('T3: /api/timeline returns JSON array', async ({ request }) => {
+    const res = await request.get(`${TRACKING_URL}/api/timeline`).catch(() => null);
+    if (res === null || res.status() === 404) {
+      test.skip(true, 'Timeline API not available on this cluster');
+      return;
+    }
+    expect([200, 401]).toContain(res.status());
+    if (res.status() === 200) {
+      const body = await res.json();
+      expect(Array.isArray(body)).toBe(true);
+    }
+  });
+});

--- a/tests/e2e/specs/fa-livekit.spec.ts
+++ b/tests/e2e/specs/fa-livekit.spec.ts
@@ -1,0 +1,45 @@
+import { test, expect } from '@playwright/test';
+
+const BASE = process.env.WEBSITE_URL || 'http://localhost:4321';
+const DOMAIN = process.env.PROD_DOMAIN || 'localhost';
+
+test.describe('FA-LiveKit: Livestream — Auth-Gating & API', () => {
+  test('T1: /admin/stream redirects unauthenticated users', async ({ page }) => {
+    await page.goto(`${BASE}/admin/stream`);
+    await expect(page).not.toHaveURL(/\/admin\/stream$/, { timeout: 10_000 });
+  });
+
+  test('T2: /portal/stream redirects unauthenticated users', async ({ page }) => {
+    await page.goto(`${BASE}/portal/stream`);
+    await expect(page).not.toHaveURL(/\/portal\/stream$/, { timeout: 10_000 });
+  });
+
+  test('T3: /api/stream/token requires authentication', async ({ request }) => {
+    const res = await request.post(`${BASE}/api/stream/token`, {
+      data: { room: 'e2e-probe' },
+    });
+    expect([401, 403]).toContain(res.status());
+  });
+
+  test('T4: /api/stream/status endpoint exists', async ({ request }) => {
+    const res = await request.get(`${BASE}/api/stream/status`);
+    expect([200, 401, 403]).toContain(res.status());
+  });
+
+  test('T5: /api/stream/end requires authentication', async ({ request }) => {
+    const res = await request.post(`${BASE}/api/stream/end`);
+    expect([401, 403]).toContain(res.status());
+  });
+
+  test('T6: LiveKit server ingress is reachable', async ({ request }) => {
+    const res = await request.get(`https://livekit.${DOMAIN}/`, {
+      timeout: 10_000,
+    }).catch(() => null);
+    if (res === null) {
+      test.skip(true, 'LiveKit not reachable (dev cluster or not deployed)');
+      return;
+    }
+    // LiveKit returns 404/426 on HTTP root — both confirm the ingress is alive
+    expect([200, 404, 426]).toContain(res.status());
+  });
+});

--- a/tests/e2e/specs/integration-smoke.spec.ts
+++ b/tests/e2e/specs/integration-smoke.spec.ts
@@ -97,4 +97,27 @@ test.describe('Integration Smoke Tests', () => {
     // 200 = fully operational; 503 = ingress alive but NATS backend unavailable
     expect([200, 503]).toContain(res.status());
   });
+
+  // ── New k3d Services ──────────────────────────────────────────
+  test('Brett systemisches Brett healthz is reachable', async ({ request }) => {
+    const res = await request.get(`https://brett.${DOMAIN}/healthz`);
+    expect(res.status()).toBe(200);
+  });
+
+  test('DocuSeal document signing is reachable', async ({ request }) => {
+    const res = await request.get(`https://sign.${DOMAIN}`);
+    // 200 = public UI; 301/302 = redirect; 401 = auth-protected
+    expect([200, 301, 302, 401]).toContain(res.status());
+  });
+
+  test('Requirements Tracking UI is reachable', async ({ request }) => {
+    const res = await request.get(`https://tracking.${DOMAIN}`);
+    expect([200, 301, 302, 401]).toContain(res.status());
+  });
+
+  test('LiveKit server ingress is reachable', async ({ request }) => {
+    const res = await request.get(`https://livekit.${DOMAIN}/`, { timeout: 10_000 });
+    // LiveKit returns 404/426 on HTTP root — both confirm the ingress is alive
+    expect([200, 404, 426]).toContain(res.status());
+  });
 });

--- a/tests/e2e/specs/sa-02-auth.spec.ts
+++ b/tests/e2e/specs/sa-02-auth.spec.ts
@@ -4,18 +4,10 @@ test.describe('SA-02: Authentifizierung — Browser', () => {
   test('T1: Falsches Passwort → Fehlermeldung (über Keycloak)', async ({ browser }) => {
     const context = await browser.newContext();
     const page = await context.newPage();
-    const baseURL = process.env.TEST_BASE_URL || 'http://localhost:8065';
+    const baseURL = process.env.TEST_BASE_URL || process.env.WEBSITE_URL || 'http://localhost:4321';
 
-    // Force-SSO: /login redirects to Keycloak; credentials are entered there.
+    // /login on the website redirects directly to Keycloak (force-SSO).
     await page.goto(`${baseURL}/login`);
-
-    const browserLink = page.getByRole('link', { name: /in browser|im browser/i });
-    try {
-      await browserLink.waitFor({ state: 'visible', timeout: 5_000 });
-      await browserLink.click();
-    } catch {
-      // Already redirected to Keycloak
-    }
 
     await expect(page).toHaveURL(/.*realms\/workspace.*/, { timeout: 15_000 });
 
@@ -32,19 +24,11 @@ test.describe('SA-02: Authentifizierung — Browser', () => {
   test('T4: /login leitet automatisch zu Keycloak (force-SSO)', async ({ browser }) => {
     const context = await browser.newContext();
     const page = await context.newPage();
-    const baseURL = process.env.TEST_BASE_URL || 'http://localhost:8065';
+    const baseURL = process.env.TEST_BASE_URL || process.env.WEBSITE_URL || 'http://localhost:4321';
 
     await page.goto(`${baseURL}/login`);
 
-    const browserLink = page.getByRole('link', { name: /in browser|im browser/i });
-    try {
-      await browserLink.waitFor({ state: 'visible', timeout: 5_000 });
-      await browserLink.click();
-    } catch {
-      // Already redirected
-    }
-
-    // No native form, no SSO button — we expect the Keycloak realm URL.
+    // /login redirects directly to Keycloak (force-SSO)
     await expect(page).toHaveURL(/.*realms\/workspace.*/, { timeout: 10_000 });
     await context.close();
   });


### PR DESCRIPTION
## Summary

- `livekit-server` was pinned to `k3s-3` (home worker, WireGuard IP `192.168.100.4`), which has no reachable public IP for WebRTC ICE — STUN discovers the home router NAT IP but UDP ports 50000–60000 are not forwarded, so media paths fail silently
- Move all four livekit-* Deployments to `gekko-hetzner-4` (`178.104.159.79`), a Hetzner node where STUN correctly discovers the real public IP
- Drop all k3s-3 workarounds: `dnsPolicy: None`, public nameservers (`8.8.8.8`), and `hostAliases` for `livekit-redis`/`livekit-server` — CoreDNS is reachable from Hetzner nodes so none of these are needed

## Post-merge

Run DNS-pin to update `livekit.korczewski.de` and `stream.korczewski.de` to point to the new node:
```bash
task livekit:dns-pin ENV=korczewski APPLY=true
```

## Test plan

- [ ] ArgoCD syncs `workspace-korczewski` cleanly (no SharedResourceWarning)
- [ ] `livekit-server`, `livekit-redis`, `livekit-egress`, `livekit-ingress` pods land on `gekko-hetzner-4`
- [ ] `livekit-server` logs show STUN-discovered IP `178.104.159.79`
- [ ] WebRTC stream connects successfully from a browser on `web.korczewski.de`

🤖 Generated with [Claude Code](https://claude.com/claude-code)