### PR TITLE
fix(rbac): grant claude-code-agent ClusterRole to workspace-korczewski SA

### DIFF
--- a/k3d/claude-code-rbac.yaml
+++ b/k3d/claude-code-rbac.yaml
@@ -60,6 +60,9 @@ subjects:
   - kind: ServiceAccount
     name: claude-code-agent
     namespace: workspace
+  - kind: ServiceAccount
+    name: claude-code-agent
+    namespace: workspace-korczewski
 roleRef:
   kind: ClusterRole
   name: claude-code-agent


### PR DESCRIPTION
## Summary

- `ClusterRoleBinding` `claude-code-agent` previously only bound `system:serviceaccount:workspace:claude-code-agent`
- The `workspace-korczewski:claude-code-agent` SA (used by `claude-code-mcp-ops` in workspace-korczewski) had no cluster permissions
- Kubernetes MCP server in korczewski was silently non-functional — could not list pods, deployments, events, or any resource

## Root cause

The `prod-korczewski/kustomization.yaml` deletes both the `ClusterRole` and `ClusterRoleBinding` from the korczewski overlay (to avoid ArgoCD SharedResourceWarning since both overlays target the same physical cluster). The mentolder overlay owns these cluster-scoped resources, but its `ClusterRoleBinding` was missing the korczewski SA as a subject.

## Fix

Add `workspace-korczewski` as a second subject in `k3d/claude-code-rbac.yaml`'s `ClusterRoleBinding`. Since this is a `ClusterRoleBinding`, both SAs gain the same read + limited-write access to all namespaces.

## Test plan

- [x] `kubectl auth can-i list pods -n workspace-korczewski --as=system:serviceaccount:workspace-korczewski:claude-code-agent` → `yes`
- [x] `kubectl auth can-i get secrets -n workspace --as=system:serviceaccount:workspace-korczewski:claude-code-agent` → `no` (secrets still blocked)
- [ ] ArgoCD syncs and applies the updated ClusterRoleBinding after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)