### PR TITLE
fix(mcp): fix cross-namespace service URL bugs for workspace-korczewski

### DIFF
--- a/k3d/claude-code-mcp-auth.yaml
+++ b/k3d/claude-code-mcp-auth.yaml
@@ -27,7 +27,7 @@ spec:
           imagePullPolicy: IfNotPresent
           env:
             - name: KC_URL
-              value: "http://keycloak.workspace.svc.cluster.local:8080"
+              value: "http://keycloak:8080"
             - name: KC_REALM
               value: "master"
             - name: OIDC_CLIENT_ID

--- a/prod-korczewski/kustomization.yaml
+++ b/prod-korczewski/kustomization.yaml
@@ -17,6 +17,10 @@ configMapGenerator:
     behavior: replace
     files:
       - realm-workspace.json=realm-workspace-korczewski.json
+  - name: nextcloud-extra-config
+    behavior: replace
+    files:
+      - zz-extra.config.php=nextcloud-extra-config-korczewski.php
 generatorOptions:
   disableNameSuffixHash: true
 
@@ -81,6 +85,7 @@ patches:
   - path: patch-livekit.yaml
   - path: patch-backup-config.yaml
   - path: patch-cronjob-urls.yaml
+  - path: patch-mcp-config.yaml
   # Cluster-scoped resources are owned exclusively by workspace-hetzner (mentolder).
   # Both overlays deploy to the same physical cluster, so rendering these here
   # causes ArgoCD SharedResourceWarning — suppress them from korczewski.

--- a/prod-korczewski/nextcloud-extra-config-korczewski.php
+++ b/prod-korczewski/nextcloud-extra-config-korczewski.php
@@ -1,0 +1,28 @@
+<?php
+$CONFIG = [
+    // Reverse proxy — trust in-cluster pod/service CIDRs (RFC1918)
+    'trusted_proxies' => [
+        '10.0.0.0/8',
+        '172.16.0.0/12',
+        '192.168.0.0/16',
+        '127.0.0.1/32',
+    ],
+    'forwarded_for_headers' => ['HTTP_X_FORWARDED_FOR'],
+
+    // Memcache
+    'memcache.local'       => '\\OC\\Memcache\\APCu',
+    'memcache.distributed' => '\\OC\\Memcache\\Redis',
+    'memcache.locking'     => '\\OC\\Memcache\\Redis',
+    'redis' => [
+        'host'    => 'nextcloud-redis.workspace-korczewski.svc.cluster.local',
+        'port'    => 6379,
+        'timeout' => 1.5,
+        'dbindex' => 0,
+    ],
+
+    // Admin warnings
+    'default_phone_region'     => 'DE',
+    'maintenance_window_start' => 1,
+    'serverid'                 => 'workspace-nc-korczewski-01',
+    'log_rotate_size'          => 104857600,
+];

--- a/prod-korczewski/patch-mcp-config.yaml
+++ b/prod-korczewski/patch-mcp-config.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: claude-code-config
+data:
+  MCP_BROWSER_URL: ""
+  MCP_GITHUB_URL: ""


### PR DESCRIPTION
## Summary

Three bugs where `workspace-korczewski` services connected to wrong-namespace endpoints or advertised dead URLs — all silent failures.

- **mcp-auth Keycloak URL** hardcoded to `keycloak.workspace.svc.cluster.local`, so korczewski's Keycloak MCP was authenticating against _mentolder's_ Keycloak. Changed base to relative `http://keycloak:8080` — resolves correctly in each namespace.
- **claude-code-config dead MCP URLs** — prod overlay deletes `mcp-browser` and `mcp-github` in korczewski, but ConfigMap still advertised their service URLs. Added `patch-mcp-config.yaml` to clear `MCP_BROWSER_URL` / `MCP_GITHUB_URL` in the korczewski overlay.
- **Nextcloud Redis host** hardcoded to `nextcloud-redis.workspace.svc.cluster.local`, so korczewski Nextcloud used mentolder's Redis for distributed cache and file locking. Created `nextcloud-extra-config-korczewski.php` with the correct FQDN and unique `serverid`.

## Test plan

- [ ] ArgoCD syncs `workspace-korczewski` and `claude-code-mcp-auth` pod restarts pointing to `http://keycloak:8080`
- [ ] `kubectl get cm claude-code-config -n workspace-korczewski -o yaml` shows empty `MCP_BROWSER_URL` / `MCP_GITHUB_URL`
- [ ] `kubectl get cm nextcloud-extra-config -n workspace-korczewski -o yaml` shows `nextcloud-redis.workspace-korczewski.svc.cluster.local`
- [ ] Nextcloud on korczewski.de can log in (Redis reachable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)