### PR TITLE
fix(schema): add screenshots_json column to bug_tickets migration

### DIFF
--- a/k3d/website-schema.yaml
+++ b/k3d/website-schema.yaml
@@ -145,8 +145,9 @@ data:
       CREATE INDEX IF NOT EXISTS idx_bug_tickets_status ON bugs.bug_tickets(status);
       ALTER TABLE bugs.bug_tickets OWNER TO website;
       ALTER TABLE bugs.bug_tickets
-        ADD COLUMN IF NOT EXISTS fixed_in_pr   INTEGER,
-        ADD COLUMN IF NOT EXISTS fixed_at      TIMESTAMPTZ;
+        ADD COLUMN IF NOT EXISTS screenshots_json JSONB,
+        ADD COLUMN IF NOT EXISTS fixed_in_pr      INTEGER,
+        ADD COLUMN IF NOT EXISTS fixed_at         TIMESTAMPTZ;
       CREATE INDEX IF NOT EXISTS idx_bug_tickets_fixed_in_pr ON bugs.bug_tickets (fixed_in_pr);
 
       -- Indexes for MCP query patterns
@@ -469,8 +470,9 @@ data:
       CREATE INDEX IF NOT EXISTS idx_bug_tickets_status ON bugs.bug_tickets(status);
       ALTER TABLE bugs.bug_tickets OWNER TO website;
       ALTER TABLE bugs.bug_tickets
-        ADD COLUMN IF NOT EXISTS fixed_in_pr   INTEGER,
-        ADD COLUMN IF NOT EXISTS fixed_at      TIMESTAMPTZ;
+        ADD COLUMN IF NOT EXISTS screenshots_json JSONB,
+        ADD COLUMN IF NOT EXISTS fixed_in_pr      INTEGER,
+        ADD COLUMN IF NOT EXISTS fixed_at         TIMESTAMPTZ;
       CREATE INDEX IF NOT EXISTS idx_bug_tickets_fixed_in_pr ON bugs.bug_tickets (fixed_in_pr);
 
       CREATE INDEX IF NOT EXISTS idx_meetings_customer ON meetings(customer_id);


### PR DESCRIPTION
## Summary
- `screenshots_json JSONB` existed on mentolder's `bugs.bug_tickets` but was never in the schema ensure script
- Korczewski's `website` DB was missing this column, causing `/api/timeline` to throw `column "fixed_in_pr" does not exist` (the error surfaced on the timeline join after the NetworkPolicy and DB access were unblocked)
- All 5 korczewski homepage E2E tests now pass including `timeline loads at least 1 row`

## Test plan
- [x] `curl https://web.korczewski.de/api/timeline?limit=3` returns rows
- [x] Playwright `korczewski-home` suite: 5/5 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)