### PR TITLE
feat(pentest): local pentest dashboard with timeline, charts, and terminal UX

### DIFF
--- a/docs/superpowers/plans/2026-05-05-pentest-dashboard-improvements.md
+++ b/docs/superpowers/plans/2026-05-05-pentest-dashboard-improvements.md
@@ -1,0 +1,712 @@
+# Pentest Dashboard Improvements Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a persistent timeline activity log, SVG charts to the Overview, and terminal UX improvements (ANSI timestamps, save-to-finding button, smart auto-scroll) to the local pentest dashboard.
+
+**Architecture:** Two files change — `app.py` gets a `log_timeline()` helper wired into the scan lifecycle plus two new endpoints, and `index.html` gets the Timeline section, chart computed properties, and terminal UX. No new Python or JS dependencies; chart math is pure Alpine computed properties using SVG stroke-dasharray technique.
+
+**Tech Stack:** Python 3 / Flask, AlpineJS 3, SVG, Server-Sent Events (SSE), browser Fetch API
+
+---
+
+## File Map
+
+| File | Role |
+|------|------|
+| `pentest-dashboard/app.py` | Backend: timeline helper + lifecycle hooks + two new endpoints |
+| `pentest-dashboard/static/index.html` | Frontend: timeline nav/section, SVG charts, terminal UX |
+| `pentest-dashboard/data/timeline.json` | Runtime data file (auto-created on first scan, never commit) |
+
+---
+
+## Task 1: Backend — Timeline file constant + read/write helper + API endpoints
+
+**Files:**
+- Modify: `pentest-dashboard/app.py`
+
+- [ ] **Step 1: Add `TIMELINE_FILE` constant and `log_timeline()` helper**
+
+  In `app.py`, after the existing file-path constants (around line 28), add:
+
+  ```python
+  TIMELINE_FILE = DATA_DIR / "timeline.json"
+  ```
+
+  After the `save_json()` helper (around line 618), add:
+
+  ```python
+  def log_timeline(entry: dict) -> None:
+      """Append one event to data/timeline.json (thread-safe via GIL + single write)."""
+      entries = load_json(TIMELINE_FILE, [])
+      entries.append(entry)
+      save_json(TIMELINE_FILE, entries)
+  ```
+
+- [ ] **Step 2: Add `GET /api/timeline` endpoint**
+
+  After the `api_scan_history` route (around line 778), add:
+
+  ```python
+  @app.route("/api/timeline")
+  def api_get_timeline():
+      entries = load_json(TIMELINE_FILE, [])
+      return jsonify(list(reversed(entries)))
+
+
+  @app.route("/api/timeline", methods=["DELETE"])
+  def api_clear_timeline():
+      save_json(TIMELINE_FILE, [])
+      return jsonify({"ok": True})
+  ```
+
+- [ ] **Step 3: Start the server and verify endpoints work**
+
+  ```bash
+  cd pentest-dashboard
+  python3 app.py &
+  sleep 1
+
+  # Should return []
+  curl -s http://localhost:5000/api/timeline
+
+  # Should return {"ok": true} and create data/timeline.json
+  curl -s -X DELETE http://localhost:5000/api/timeline
+
+  # Should return [] again
+  curl -s http://localhost:5000/api/timeline
+
+  kill %1
+  ```
+
+  Expected: all three return valid JSON.
+
+- [ ] **Step 4: Commit**
+
+  ```bash
+  git add pentest-dashboard/app.py
+  git commit -m "feat(pentest): add timeline file + helper + API endpoints"
+  ```
+
+---
+
+## Task 2: Backend — Hook scan lifecycle into timeline
+
+**Files:**
+- Modify: `pentest-dashboard/app.py`
+
+- [ ] **Step 1: Record `started` event in `api_run_scan`**
+
+  In `api_run_scan`, after `t.start()` (around line 714) and before `return jsonify({"run_id": run_id})`, add:
+
+  ```python
+      tmpl_meta = next((t for t in SCAN_TEMPLATES if t["id"] == scan_id), None) if scan_id else None
+      log_timeline({
+          "ts": datetime.now().isoformat(timespec="seconds"),
+          "event": "started",
+          "run_id": run_id,
+          "scan_id": scan_id or "custom",
+          "name": tmpl_meta["name"] if tmpl_meta else "Custom",
+          "category": tmpl_meta["category"] if tmpl_meta else "custom",
+      })
+  ```
+
+  Note: `tmpl_meta` lookup reuses `tmpl` that was already resolved earlier in the function, but we compute it here independently to avoid naming conflicts. Alternatively, if `tmpl` is in scope at that line, use `tmpl` directly:
+  
+  ```python
+      log_timeline({
+          "ts": datetime.now().isoformat(timespec="seconds"),
+          "event": "started",
+          "run_id": run_id,
+          "scan_id": scan_id or "custom",
+          "name": tmpl["name"] if tmpl else "Custom",
+          "category": tmpl["category"] if tmpl else "custom",
+      })
+  ```
+
+- [ ] **Step 2: Record start time in scan registry**
+
+  In `api_run_scan`, when building the `scans[run_id]` dict (around line 705), add `"started_at": datetime.now().timestamp()` to the dict:
+
+  ```python
+      scans[run_id] = {
+          "status": "starting",
+          "command": command,
+          "output_file": output_file,
+          "created": datetime.now().isoformat(),
+          "scan_id": scan_id or "custom",
+          "started_at": datetime.now().timestamp(),
+      }
+  ```
+
+- [ ] **Step 3: Record `completed` event in `run_scan_thread`**
+
+  At the end of `run_scan_thread`, after `scans[run_id]["status"] = "done" if proc.returncode == 0 else "error"` (around line 641), add:
+
+  ```python
+              started_at = scans[run_id].get("started_at")
+              duration_s = round(time.time() - started_at) if started_at else None
+              meta = scans[run_id]
+              log_timeline({
+                  "ts": datetime.now().isoformat(timespec="seconds"),
+                  "event": "completed",
+                  "run_id": run_id,
+                  "scan_id": meta.get("scan_id", "custom"),
+                  "name": next((t["name"] for t in SCAN_TEMPLATES if t["id"] == meta.get("scan_id")), "Custom"),
+                  "category": next((t["category"] for t in SCAN_TEMPLATES if t["id"] == meta.get("scan_id")), "custom"),
+                  "duration_s": duration_s,
+                  "exit_code": proc.returncode,
+              })
+  ```
+
+- [ ] **Step 4: Record `killed` event in `api_kill_scan`**
+
+  In `api_kill_scan`, after `scans[run_id]["status"] = "killed"` (around line 767), add:
+
+  ```python
+          meta = scans[run_id]
+          started_at = meta.get("started_at")
+          duration_s = round(time.time() - started_at) if started_at else None
+          log_timeline({
+              "ts": datetime.now().isoformat(timespec="seconds"),
+              "event": "killed",
+              "run_id": run_id,
+              "scan_id": meta.get("scan_id", "custom"),
+              "name": next((t["name"] for t in SCAN_TEMPLATES if t["id"] == meta.get("scan_id")), "Custom"),
+              "category": next((t["category"] for t in SCAN_TEMPLATES if t["id"] == meta.get("scan_id")), "custom"),
+              "duration_s": duration_s,
+              "exit_code": None,
+          })
+  ```
+
+- [ ] **Step 5: Verify lifecycle logging end-to-end**
+
+  ```bash
+  cd pentest-dashboard
+  python3 app.py &
+  sleep 1
+
+  # Start a fast scan (headers probe takes ~5s)
+  RUN=$(curl -s -X POST http://localhost:5000/api/scan/run \
+    -H "Content-Type: application/json" \
+    -d '{"custom_command": "echo hello && sleep 2 && echo done"}' | python3 -c "import sys,json; print(json.load(sys.stdin)['run_id'])")
+  echo "run_id: $RUN"
+  sleep 4
+
+  # Should show one started + one completed entry
+  curl -s http://localhost:5000/api/timeline | python3 -m json.tool
+
+  kill %1
+  ```
+
+  Expected: two entries in the timeline — `started` then `completed` with `exit_code: 0` and `duration_s >= 2`.
+
+- [ ] **Step 6: Commit**
+
+  ```bash
+  git add pentest-dashboard/app.py
+  git commit -m "feat(pentest): hook scan lifecycle into timeline log"
+  ```
+
+---
+
+## Task 3: Frontend — Timeline state, nav item, section
+
+**Files:**
+- Modify: `pentest-dashboard/static/index.html`
+
+- [ ] **Step 1: Add `timeline` array to Alpine state**
+
+  In the `app()` function, in the state section (around line 897), add `timeline: []` after `reportCopied: false`:
+
+  ```js
+      reportCopied: false,
+      timeline: [],
+  ```
+
+- [ ] **Step 2: Add Timeline nav item**
+
+  In the `nav` array (around line 924), add after the `report` entry:
+
+  ```js
+      { id: 'report',   icon: '📄',  label: 'Report' },
+      { id: 'timeline', icon: '📋',  label: 'Timeline' },
+  ```
+
+- [ ] **Step 3: Fetch timeline on init**
+
+  In `init()` (around line 950), after `this.findings = d.findings;`, add:
+
+  ```js
+        const tl = await fetch('/api/timeline');
+        this.timeline = await tl.json();
+  ```
+
+- [ ] **Step 4: Refresh timeline when a scan completes**
+
+  In the SSE `onmessage` handler (around line 1053), inside the `if (msg.done)` block, add:
+
+  ```js
+          if (msg.done) {
+            this.scanning = false;
+            this.eventSource.close();
+            const tl = await fetch('/api/timeline');
+            this.timeline = await tl.json();
+          }
+  ```
+
+- [ ] **Step 5: Add clearTimeline method**
+
+  After `downloadReport()` (around line 1228), add:
+
+  ```js
+      async clearTimeline() {
+        await fetch('/api/timeline', { method: 'DELETE' });
+        this.timeline = [];
+      },
+  ```
+
+- [ ] **Step 6: Add Timeline section HTML**
+
+  In the `<main>` element, after the Report section closing `</div>` (around line 888), add:
+
+  ```html
+    <!-- ── Timeline ── -->
+    <div x-show="section==='timeline'">
+      <div class="section-title">📋 Activity Timeline
+        <span class="text-muted text-sm" x-text="timeline.length + ' entries'"></span>
+        <button x-show="timeline.length > 0" class="btn btn-ghost btn-sm" style="margin-left:auto" @click="clearTimeline()">Clear Log</button>
+      </div>
+
+      <template x-if="timeline.length === 0">
+        <div class="card text-muted text-sm">No scan activity yet. Run a scan to start logging.</div>
+      </template>
+
+      <div class="flex flex-col gap-1">
+        <template x-for="(entry, i) in timeline" :key="i">
+          <div class="card card-sm flex items-center gap-3">
+            <span class="text-xs text-muted" style="min-width:140px;font-family:var(--font-mono)"
+                  x-text="entry.ts?.replace('T',' ')"></span>
+            <span class="badge"
+                  :class="{
+                    'badge-blue':   entry.category==='recon',
+                    'badge-cyan':   entry.category==='probe',
+                    'badge-red':    entry.category==='vuln',
+                    'badge-yellow': entry.category==='auth',
+                    'badge-purple': entry.category==='post-exploit',
+                    'badge-gray':   entry.category==='custom',
+                  }"
+                  x-text="entry.category"></span>
+            <span class="flex-1 text-sm" x-text="entry.name"></span>
+            <span x-show="entry.duration_s != null" class="text-xs text-muted" x-text="entry.duration_s + 's'"></span>
+            <span x-show="entry.event === 'started'" class="badge badge-blue">started</span>
+            <span x-show="entry.event === 'completed' && entry.exit_code === 0" class="text-green text-sm">✓</span>
+            <span x-show="entry.event === 'completed' && entry.exit_code !== 0 && entry.exit_code != null" class="text-red text-sm">✗</span>
+            <span x-show="entry.event === 'killed'" class="badge badge-gray">killed</span>
+          </div>
+        </template>
+      </div>
+    </div>
+  ```
+
+- [ ] **Step 7: Verify in browser**
+
+  Start the server: `cd pentest-dashboard && python3 app.py`
+
+  Open http://localhost:5000, click "Timeline" in the sidebar. Should show "No scan activity yet."
+
+  Run any scan (e.g., "Load Nmap" → Run). After it starts, click Timeline — should show a `started` entry. After it completes, should show a `completed` entry too.
+
+- [ ] **Step 8: Commit**
+
+  ```bash
+  git add pentest-dashboard/static/index.html
+  git commit -m "feat(pentest): add timeline section + nav + lifecycle refresh"
+  ```
+
+---
+
+## Task 4: Frontend — Overview SVG Charts
+
+**Files:**
+- Modify: `pentest-dashboard/static/index.html`
+
+The SVG donut uses the `stroke-dasharray` technique: each severity level is a separate `<circle>` element with a stroke-dasharray of `[arc_length, circumference]` and a stroke-dashoffset that shifts it past previous segments. Circumference = 2π × 52 ≈ 326.73 (radius 52 in a 120×120 viewBox).
+
+- [ ] **Step 1: Add `sevSegments` computed getter**
+
+  In the `app()` function, after `get filteredScans()` (around line 969), add:
+
+  ```js
+      get sevSegments() {
+        const C = 2 * Math.PI * 52;
+        const total = this.findings.length;
+        if (total === 0) return [];
+        const defs = [
+          { sev: 'critical', color: 'var(--red)' },
+          { sev: 'high',     color: 'var(--orange)' },
+          { sev: 'medium',   color: 'var(--yellow)' },
+          { sev: 'low',      color: 'var(--blue)' },
+          { sev: 'info',     color: 'var(--muted)' },
+        ];
+        let offset = 0;
+        return defs
+          .map(d => ({ ...d, count: this.findings.filter(f => f.severity === d.sev).length }))
+          .filter(d => d.count > 0)
+          .map(d => {
+            const arc = (d.count / total) * C;
+            const seg = {
+              color: d.color,
+              dasharray: `${arc} ${C}`,
+              dashoffset: -offset,
+            };
+            offset += arc;
+            return seg;
+          });
+      },
+
+      get coverageData() {
+        const C = 2 * Math.PI * 52;
+        const total = this.vectors.length;
+        if (total === 0) return { pct: 0, arc: 0, C, color: 'var(--muted)', tested: 0, total: 0 };
+        const tested = this.vectors.filter(v => v.tested).length;
+        const pct = Math.round(tested / total * 100);
+        const arc = (tested / total) * C;
+        const color = pct >= 80 ? 'var(--green)' : pct >= 40 ? 'var(--yellow)' : 'var(--red)';
+        return { pct, arc, C, color, tested, total };
+      },
+  ```
+
+- [ ] **Step 2: Add chart HTML to Overview section**
+
+  In the Overview section, after the `grid-4 mb-4` stat cards block (around line 325) and before the `<!-- Flags summary -->` comment, insert:
+
+  ```html
+      <!-- Charts row -->
+      <div class="grid-2 mb-4">
+
+        <!-- Severity Donut -->
+        <div class="card" style="display:flex;flex-direction:column;align-items:center;padding:20px 14px">
+          <div class="stat-label mb-2">Findings by Severity</div>
+          <svg viewBox="0 0 120 120" width="120" height="120" style="transform:rotate(-90deg)">
+            <!-- Background track -->
+            <circle cx="60" cy="60" r="52" fill="none" stroke="var(--bg3)" stroke-width="12"/>
+            <!-- No findings placeholder -->
+            <template x-if="findings.length === 0">
+              <circle cx="60" cy="60" r="52" fill="none" stroke="var(--border)" stroke-width="12"
+                      :stroke-dasharray="`${2*Math.PI*52} 0`"/>
+            </template>
+            <!-- Severity segments -->
+            <template x-for="(seg, i) in sevSegments" :key="i">
+              <circle cx="60" cy="60" r="52" fill="none"
+                      :stroke="seg.color"
+                      stroke-width="12"
+                      :stroke-dasharray="seg.dasharray"
+                      :stroke-dashoffset="seg.dashoffset"
+                      stroke-linecap="butt"/>
+            </template>
+          </svg>
+          <div style="margin-top:-68px;margin-bottom:48px;font-size:20px;font-weight:700;text-align:center;transform:rotate(0deg)"
+               x-text="findings.length === 0 ? '—' : findings.length"></div>
+          <div x-show="findings.length === 0" class="text-xs text-muted mt-1">No findings yet</div>
+          <div x-show="findings.length > 0" class="flex gap-2 flex-wrap justify-center mt-2" style="max-width:200px">
+            <template x-for="seg in sevSegments" :key="seg.color">
+              <span class="text-xs" :style="'color:' + seg.color">●</span>
+            </template>
+          </div>
+        </div>
+
+        <!-- Coverage Ring -->
+        <div class="card" style="display:flex;flex-direction:column;align-items:center;padding:20px 14px">
+          <div class="stat-label mb-2">Attack Vector Coverage</div>
+          <svg viewBox="0 0 120 120" width="120" height="120" style="transform:rotate(-90deg)">
+            <circle cx="60" cy="60" r="52" fill="none" stroke="var(--bg3)" stroke-width="12"/>
+            <circle cx="60" cy="60" r="52" fill="none"
+                    :stroke="coverageData.color"
+                    stroke-width="12"
+                    :stroke-dasharray="`${coverageData.arc} ${coverageData.C}`"
+                    stroke-dashoffset="0"
+                    stroke-linecap="butt"/>
+          </svg>
+          <div style="margin-top:-68px;margin-bottom:48px;font-size:20px;font-weight:700;text-align:center"
+               :style="'color:' + coverageData.color"
+               x-text="coverageData.pct + '%'"></div>
+          <div class="text-xs text-muted mt-1"
+               x-text="coverageData.tested + ' / ' + coverageData.total + ' vectors'"></div>
+        </div>
+
+      </div>
+  ```
+
+- [ ] **Step 3: Verify in browser**
+
+  Open http://localhost:5000. In Overview:
+  - Both chart cards should render (donut shows placeholder ring, coverage shows 0% in red if no vectors tested)
+  - Add a finding via Findings → "+ Add Finding". Return to Overview — donut should show a colored segment
+  - Mark a vector as tested in Vectors. Return to Overview — coverage ring arc should grow
+
+- [ ] **Step 4: Commit**
+
+  ```bash
+  git add pentest-dashboard/static/index.html
+  git commit -m "feat(pentest): add severity donut + coverage ring to Overview"
+  ```
+
+---
+
+## Task 5: Frontend — Terminal ANSI timestamps
+
+**Files:**
+- Modify: `pentest-dashboard/static/index.html`
+
+Each SSE chunk arrives as a raw string. We prepend an ANSI-colored timestamp to the chunk before appending it to `terminalOutput`. Code 90 (bright black / dark gray) is already in `ansiToHtml()`'s `colorMap`.
+
+- [ ] **Step 1: Add timestamp helper**
+
+  In the `app()` function, before `_scrollTerminal()` (around line 1074), add:
+
+  ```js
+      _tsPrefix() {
+        const t = new Date().toLocaleTimeString('de', { hour12: false });
+        return `\x1B[90m[${t}]\x1B[0m `;
+      },
+  ```
+
+- [ ] **Step 2: Inject timestamp in SSE onmessage**
+
+  In `_startScan()`, in the `this.eventSource.onmessage` callback (around line 1047), change:
+
+  ```js
+          if (msg.text) {
+            this.terminalOutput += msg.text;
+  ```
+
+  to:
+
+  ```js
+          if (msg.text) {
+            const lines = msg.text.split('\n');
+            const stamped = lines.map((l, i) =>
+              (i === 0 || l.length > 0) ? this._tsPrefix() + l : l
+            ).join('\n');
+            this.terminalOutput += stamped;
+  ```
+
+  Note: we stamp every non-empty line. The first line of each chunk always gets a stamp; subsequent empty lines (bare newlines) are passed through unchanged to preserve formatting.
+
+- [ ] **Step 3: Verify in browser**
+
+  Run any scan. Each output line in the terminal should be prefixed with `[HH:MM:SS]` in muted gray.
+
+- [ ] **Step 4: Commit**
+
+  ```bash
+  git add pentest-dashboard/static/index.html
+  git commit -m "feat(pentest): inject ANSI timestamps into terminal output per chunk"
+  ```
+
+---
+
+## Task 6: Frontend — "Save as Finding" button
+
+**Files:**
+- Modify: `pentest-dashboard/static/index.html`
+
+After a scan finishes, a "Save as Finding" button appears next to "Clear". It strips ANSI codes from the terminal buffer, pre-fills the new-finding form with the scan name and a 500-char snippet, and navigates to the Findings section.
+
+- [ ] **Step 1: Add ANSI-strip helper and `saveOutputAsFinding` method**
+
+  In the `app()` function, after `clearTimeline()` (from Task 3), add:
+
+  ```js
+      _stripAnsi(text) {
+        return text.replace(/\x1B\[[0-9;]*m/g, '');
+      },
+
+      saveOutputAsFinding() {
+        const stripped = this._stripAnsi(this.terminalOutput);
+        this.newFinding = {
+          title: this.currentScanName || 'Scan Output',
+          severity: 'info',
+          target: '',
+          desc: stripped.slice(0, 500),
+        };
+        this.section = 'findings';
+        this.showAddFinding = true;
+      },
+  ```
+
+- [ ] **Step 2: Add "Save as Finding" button in Scans terminal header**
+
+  In the Scans section terminal header (around line 515), next to the existing Clear button:
+
+  ```html
+          <button x-show="!scanning && terminalOutput" class="btn btn-ghost btn-xs" @click="terminalOutput=''; currentScanId=null">Clear</button>
+  ```
+
+  Change to:
+
+  ```html
+          <button x-show="!scanning && terminalOutput" class="btn btn-ghost btn-xs" @click="terminalOutput=''; currentScanId=null">Clear</button>
+          <button x-show="!scanning && terminalOutput" class="btn btn-blue btn-xs" @click="saveOutputAsFinding()">→ Finding</button>
+  ```
+
+- [ ] **Step 3: Add same button in Custom section terminal header**
+
+  In the Custom section terminal header (around line 726), next to the existing Clear button:
+
+  ```html
+          <button x-show="!scanning && terminalOutput" class="btn btn-ghost btn-xs" @click="terminalOutput=''">Clear</button>
+  ```
+
+  Change to:
+
+  ```html
+          <button x-show="!scanning && terminalOutput" class="btn btn-ghost btn-xs" @click="terminalOutput=''">Clear</button>
+          <button x-show="!scanning && terminalOutput" class="btn btn-blue btn-xs" @click="saveOutputAsFinding()">→ Finding</button>
+  ```
+
+- [ ] **Step 4: Verify in browser**
+
+  Run a scan. After it completes: "→ Finding" button should appear. Click it — should navigate to Findings, open the add-finding form, with title = scan name and desc = first 500 chars of output (no ANSI codes). Save it to confirm the full flow works.
+
+- [ ] **Step 5: Commit**
+
+  ```bash
+  git add pentest-dashboard/static/index.html
+  git commit -m "feat(pentest): add save-as-finding button to terminal output"
+  ```
+
+---
+
+## Task 7: Frontend — Smart auto-scroll + new-output pill
+
+**Files:**
+- Modify: `pentest-dashboard/static/index.html`
+
+Auto-scroll stops if the user scrolls up. A "↓ new output" pill appears and re-enables auto-scroll on click.
+
+- [ ] **Step 1: Add `userScrolledUp` state**
+
+  In the Alpine state block, after `timeline: []`, add:
+
+  ```js
+      userScrolledUp: false,
+  ```
+
+- [ ] **Step 2: Replace `_scrollTerminal()` with scroll-aware version**
+
+  Find `_scrollTerminal()` (around line 1074):
+
+  ```js
+      _scrollTerminal() {
+        const el = this.section === 'custom' ? this.$refs.terminalCustom : this.$refs.terminal;
+        if (el) el.scrollTop = el.scrollHeight;
+      },
+  ```
+
+  Replace with:
+
+  ```js
+      _scrollTerminal() {
+        const el = this.section === 'custom' ? this.$refs.terminalCustom : this.$refs.terminal;
+        if (!el) return;
+        const atBottom = el.scrollTop + el.clientHeight >= el.scrollHeight - 20;
+        if (atBottom || !this.userScrolledUp) {
+          el.scrollTop = el.scrollHeight;
+          this.userScrolledUp = false;
+        }
+      },
+
+      _onTerminalScroll(el) {
+        if (!el) return;
+        const atBottom = el.scrollTop + el.clientHeight >= el.scrollHeight - 20;
+        if (!atBottom) {
+          this.userScrolledUp = true;
+        }
+      },
+
+      jumpToBottom() {
+        const el = this.section === 'custom' ? this.$refs.terminalCustom : this.$refs.terminal;
+        if (el) el.scrollTop = el.scrollHeight;
+        this.userScrolledUp = false;
+      },
+  ```
+
+- [ ] **Step 3: Wire scroll event listeners to terminal elements**
+
+  In the Scans terminal div (around line 517), add `@scroll="_onTerminalScroll($el)"`:
+
+  ```html
+        <div class="terminal terminal-with-header" style="height:400px" x-ref="terminal"
+             @scroll="_onTerminalScroll($el)"
+             x-html="ansiToHtml(terminalOutput)"></div>
+  ```
+
+  In the Custom terminal div (around line 729):
+
+  ```html
+        <div class="terminal terminal-with-header" style="height:500px" x-ref="terminalCustom"
+             @scroll="_onTerminalScroll($el)"
+             x-html="ansiToHtml(terminalOutput)"></div>
+  ```
+
+- [ ] **Step 4: Reset `userScrolledUp` when a new scan starts**
+
+  In `_startScan()`, before `this.scanning = true;` (around line 1033), add:
+
+  ```js
+      this.userScrolledUp = false;
+  ```
+
+- [ ] **Step 5: Add "↓ new output" pill**
+
+  In the Scans section, after the terminal div (around line 518), add the pill inside the `x-show="terminalOutput || scanning"` wrapper:
+
+  ```html
+        <div x-show="userScrolledUp && scanning" style="position:relative">
+          <button class="btn btn-ghost btn-xs"
+                  style="position:absolute;bottom:8px;right:8px;z-index:10;background:var(--bg3);border-color:var(--border)"
+                  @click="jumpToBottom()">↓ new output</button>
+        </div>
+  ```
+
+  Repeat the same pill structure after the Custom terminal div.
+
+- [ ] **Step 6: Verify in browser**
+
+  Run a long scan (e.g., Nmap Infrastructure — takes ~30s). While output is streaming: scroll up in the terminal. Auto-scroll should stop. The "↓ new output" pill should appear. Click it — should jump to bottom and resume auto-scroll.
+
+- [ ] **Step 7: Commit**
+
+  ```bash
+  git add pentest-dashboard/static/index.html
+  git commit -m "feat(pentest): smart auto-scroll with new-output pill in terminal"
+  ```
+
+---
+
+## Task 8: Final integration test
+
+- [ ] **Step 1: Full smoke test**
+
+  Start server: `cd pentest-dashboard && python3 app.py`
+
+  Walk through this checklist in the browser at http://localhost:5000:
+
+  1. **Overview** — both chart cards visible; donut shows placeholder; coverage shows 0% or current %
+  2. **Scans** — run "echo hello && sleep 1 && echo world" as Custom. Confirm timestamps appear per line. After completion: "→ Finding" button appears.
+  3. **Save as Finding** — click "→ Finding". Confirm Findings section opens with form pre-filled (title = "Custom", desc starts with `[HH:MM:SS] hello`). Save it.
+  4. **Overview** — return to Overview. Donut should show one `info` segment.
+  5. **Scroll test** — run a Nikto or Nmap scan (takes 30s+). Scroll up mid-stream. Confirm auto-scroll stops. Pill appears. Click pill — resumes.
+  6. **Timeline** — click Timeline. Confirm entries show for started + completed scans. Click "Clear Log" — list empties.
+  7. **Kill test** — start Nmap Infrastructure, then click Kill. Check Timeline — should show a `killed` entry with `exit_code: null`.
+
+- [ ] **Step 2: Final commit if any loose ends**
+
+  ```bash
+  git add pentest-dashboard/
+  git status
+  # Only commit if there are uncommitted changes
+  git commit -m "chore(pentest): final integration fixes" 2>/dev/null || echo "nothing to commit"
+  ```

--- a/docs/superpowers/specs/2026-05-05-pentest-dashboard-improvements-design.md
+++ b/docs/superpowers/specs/2026-05-05-pentest-dashboard-improvements-design.md
@@ -1,0 +1,159 @@
+# Pentest Dashboard Improvements — Design Spec
+
+**Date:** 2026-05-05  
+**Status:** Approved  
+**Scope:** `pentest-dashboard/`
+
+---
+
+## Overview
+
+Three improvements to the local pentest dashboard (Flask + AlpineJS + SSE):
+
+1. **Timeline / Activity Log** — persistent chronological log of all scan runs
+2. **Overview Charts** — severity donut + coverage ring in the Overview section
+3. **Terminal UX** — timestamps per line, "Save as Finding" button, smart auto-scroll
+
+No new Python packages. No new JS libraries. All chart math is client-side Alpine computed properties.
+
+---
+
+## Architecture
+
+### Files changed
+
+| File | Change |
+|------|--------|
+| `pentest-dashboard/app.py` | Add `log_timeline()` helper, hook into scan start/complete, add `GET /api/timeline` + `DELETE /api/timeline` endpoints |
+| `pentest-dashboard/static/index.html` | Add Timeline nav + section, SVG charts in Overview, timestamp injection + save-to-finding + smart scroll in terminal |
+
+### New data file
+
+`pentest-dashboard/data/timeline.json` — created on first scan run, array of log entry objects. Never committed (already gitignored alongside other `data/` files).
+
+---
+
+## Section 1: Timeline / Activity Log
+
+### Backend
+
+New helper appended to `app.py`:
+
+```python
+def log_timeline(entry):
+    path = DATA_DIR / 'timeline.json'
+    entries = json.loads(path.read_text()) if path.exists() else []
+    entries.append(entry)
+    path.write_text(json.dumps(entries, indent=2))
+```
+
+Called at two points in the scan lifecycle:
+- **Scan started**: event `started`, fields: `ts`, `scan_id`, `name`, `category`
+- **Scan completed**: event `completed`, fields: `ts`, `scan_id`, `name`, `category`, `duration_s`, `exit_code`
+
+New endpoints:
+- `GET /api/timeline` — returns full array (newest first via `reversed()`)
+- `DELETE /api/timeline` — overwrites file with `[]`
+
+### Entry schema
+
+```json
+{
+  "ts": "2026-05-05T14:23:01",
+  "event": "completed",
+  "scan_id": "nmap-recon",
+  "name": "Nmap Full Recon",
+  "category": "recon",
+  "duration_s": 47,
+  "exit_code": 0
+}
+```
+
+`exit_code: null` for killed/aborted scans.
+
+### Frontend
+
+- New nav item: `📋 Timeline` (no badge counter)
+- New `section === 'timeline'` panel
+- Data loaded in `init()` alongside `/api/data`, stored in `timeline: []` Alpine state
+- Refreshed when a scan completes (inside the SSE `msg.done` handler)
+- Each row: `[timestamp]` · category badge · scan name · duration · status icon (✓ green / ✗ red / — gray for killed)
+- "Clear Log" button at top → `DELETE /api/timeline` → resets `this.timeline = []`
+
+---
+
+## Section 2: Overview Charts
+
+Two SVG charts in a `grid-2` row below the four stat cards, above the flags summary.
+
+### Severity Donut
+
+- Pure SVG `<circle>` with `stroke-dasharray` / `stroke-dashoffset` technique
+- Segments: critical (`--red`), high (`--orange`), medium (`--yellow`), low (`--blue`), info (`--muted`)
+- Center label: total finding count
+- When `findings.length === 0`: single gray placeholder ring + "No findings yet" label
+- Circumference computed from radius 52 (SVG viewBox 120×120, cx/cy 60)
+- Alpine `get sevSegments()` computed property returns array of `{color, dash, offset}` per severity
+
+### Coverage Ring
+
+- Single SVG circle arc showing `vectors_tested / vectors_total`
+- Color thresholds: ≥ 80% → `--green`, 40–79% → `--yellow`, < 40% → `--red`
+- Center label: percentage (e.g. `73%`)
+- Below center: small muted text `X / Y vectors`
+- Alpine `get coveragePct()` computed property
+
+### Styling
+
+Both charts are wrapped in `.card` elements matching the existing `--bg2` / `--border` design. Chart title in `.stat-label` style above each SVG. No new CSS variables.
+
+---
+
+## Section 3: Terminal UX
+
+### Timestamps per line
+
+- Each SSE chunk is prepended with a real ANSI escape sequence before being appended to `terminalOutput`:
+  `\x1B[90m[HH:MM:SS]\x1B[0m ` where `HH:MM:SS` comes from `new Date().toLocaleTimeString('de')`
+- ANSI color code 90 is already in `ansiToHtml()`'s `colorMap` as `#6e7681` (muted gray) — no changes to that function needed
+- Timestamps appear in the raw buffer itself, so they survive copy/paste and the "Save as Finding" strip step
+
+### "Save as Finding" button
+
+- Rendered alongside "Clear" button when `!scanning && terminalOutput`
+- On click:
+  1. Strips ANSI escape codes from `terminalOutput`
+  2. Pre-fills `newFinding`: `title = currentScanName`, `severity = 'info'`, `desc = stripped.slice(0, 500)`
+  3. Sets `section = 'findings'`, `showAddFinding = true`
+- User reviews the pre-filled form and saves manually — no auto-submit
+
+### Smart auto-scroll
+
+- New state: `userScrolledUp: false`
+- `_scrollTerminal()` checks: if `el.scrollTop + el.clientHeight < el.scrollHeight - 20` → user has scrolled up → skip auto-scroll, set `userScrolledUp = true`
+- When user is scrolled up: show a fixed `↓ new output` pill (bottom-right of terminal) styled as `.btn-ghost.btn-xs`
+- Clicking the pill: scrolls to bottom, sets `userScrolledUp = false`, hides pill
+- Applies to both `$refs.terminal` (Scans) and `$refs.terminalCustom` (Custom)
+
+---
+
+## Out of Scope
+
+- Credential manager (future improvement)
+- Chart interactivity (clicking a donut segment to filter findings)
+- Timeline search/filter
+- Timeline export
+
+---
+
+## Testing
+
+Manual verification after implementation:
+1. Run a scan → confirm timeline entry appears with correct name, category, duration
+2. Kill a scan → confirm `exit_code: null` in timeline
+3. Clear log → confirm list empties, file resets
+4. Add 2+ findings of different severities → confirm donut segments appear proportionally
+5. Mark vectors as tested → confirm coverage ring updates
+6. Run a scan, scroll up mid-output → confirm auto-scroll stops, pill appears
+7. Click pill → confirm jumps to bottom, pill hides
+8. After scan completes, click "Save as Finding" → confirm finding form pre-filled and opened

--- a/pentest-dashboard/app.py
+++ b/pentest-dashboard/app.py
@@ -645,6 +645,20 @@ def run_scan_thread(run_id, command, output_file):
             proc.wait()
             scans[run_id]["returncode"] = proc.returncode
             scans[run_id]["status"] = "done" if proc.returncode == 0 else "error"
+
+            started_at = scans[run_id].get("started_at")
+            duration_s = round(time.time() - started_at) if started_at else None
+            meta = scans[run_id]
+            log_timeline({
+                "ts": datetime.now().isoformat(timespec="seconds"),
+                "event": "completed",
+                "run_id": run_id,
+                "scan_id": meta.get("scan_id", "custom"),
+                "name": next((t["name"] for t in SCAN_TEMPLATES if t["id"] == meta.get("scan_id")), "Custom"),
+                "category": next((t["category"] for t in SCAN_TEMPLATES if t["id"] == meta.get("scan_id")), "custom"),
+                "duration_s": duration_s,
+                "exit_code": proc.returncode,
+            })
     except Exception as e:
         try:
             with open(output_file, "a") as f:
@@ -693,6 +707,7 @@ def api_run_scan():
     scan_id = data.get("scan_id")
     custom_cmd = data.get("custom_command", "").strip()
 
+    tmpl = None
     command = custom_cmd
     if not command and scan_id:
         tmpl = next((t for t in SCAN_TEMPLATES if t["id"] == scan_id), None)
@@ -715,10 +730,21 @@ def api_run_scan():
         "output_file": output_file,
         "created": datetime.now().isoformat(),
         "scan_id": scan_id or "custom",
+        "started_at": datetime.now().timestamp(),
     }
 
     t = threading.Thread(target=run_scan_thread, args=(run_id, command, output_file), daemon=True)
     t.start()
+
+    log_timeline({
+        "ts": datetime.now().isoformat(timespec="seconds"),
+        "event": "started",
+        "run_id": run_id,
+        "scan_id": scan_id or "custom",
+        "name": tmpl["name"] if tmpl else "Custom",
+        "category": tmpl["category"] if tmpl else "custom",
+    })
+
     return jsonify({"run_id": run_id})
 
 
@@ -771,6 +797,20 @@ def api_kill_scan(run_id):
         try:
             os.killpg(os.getpgid(pid), signal.SIGKILL)
             scans[run_id]["status"] = "killed"
+
+            meta = scans[run_id]
+            started_at = meta.get("started_at")
+            duration_s = round(time.time() - started_at) if started_at else None
+            log_timeline({
+                "ts": datetime.now().isoformat(timespec="seconds"),
+                "event": "killed",
+                "run_id": run_id,
+                "scan_id": meta.get("scan_id", "custom"),
+                "name": next((t["name"] for t in SCAN_TEMPLATES if t["id"] == meta.get("scan_id")), "Custom"),
+                "category": next((t["category"] for t in SCAN_TEMPLATES if t["id"] == meta.get("scan_id")), "custom"),
+                "duration_s": duration_s,
+                "exit_code": None,
+            })
         except (ProcessLookupError, OSError):
             pass
     return jsonify({"ok": True})

--- a/pentest-dashboard/app.py
+++ b/pentest-dashboard/app.py
@@ -5,6 +5,7 @@ Targets: mentolder.de + korczewski.de
 """
 import json
 import os
+import signal
 import subprocess
 import threading
 import time
@@ -631,6 +632,7 @@ def run_scan_thread(run_id, command, output_file):
                 command, shell=True,
                 stdout=f, stderr=subprocess.STDOUT,
                 text=True, executable="/bin/bash",
+                preexec_fn=os.setsid,
             )
             scans[run_id]["pid"] = proc.pid
             proc.wait()
@@ -760,9 +762,9 @@ def api_kill_scan(run_id):
     pid = scans[run_id].get("pid")
     if pid:
         try:
-            os.kill(pid, 9)
+            os.killpg(os.getpgid(pid), signal.SIGKILL)
             scans[run_id]["status"] = "killed"
-        except ProcessLookupError:
+        except (ProcessLookupError, OSError):
             pass
     return jsonify({"ok": True})
 

--- a/pentest-dashboard/app.py
+++ b/pentest-dashboard/app.py
@@ -26,6 +26,7 @@ FLAGS_FILE = DATA_DIR / "flags.json"
 NOTES_FILE = DATA_DIR / "notes.json"
 FINDINGS_FILE = DATA_DIR / "findings.json"
 VECTORS_FILE = DATA_DIR / "vectors.json"
+TIMELINE_FILE = DATA_DIR / "timeline.json"
 
 # ── Scope ──────────────────────────────────────────────────────────────────────
 
@@ -617,6 +618,12 @@ def load_json(path, default):
 def save_json(path, data):
     path.write_text(json.dumps(data, indent=2))
 
+def log_timeline(entry: dict) -> None:
+    """Append one event to data/timeline.json (thread-safe via GIL + single write)."""
+    entries = load_json(TIMELINE_FILE, [])
+    entries.append(entry)
+    save_json(TIMELINE_FILE, entries)
+
 # ── In-memory scan registry ────────────────────────────────────────────────────
 
 scans = {}  # run_id → {status, command, output_file, created, ...}
@@ -775,6 +782,18 @@ def api_scan_history():
         {"run_id": k, **{kk: vv for kk, vv in v.items() if kk != "output_file"}}
         for k, v in sorted(scans.items(), key=lambda x: x[1]["created"], reverse=True)
     ])
+
+
+@app.route("/api/timeline")
+def api_get_timeline():
+    entries = load_json(TIMELINE_FILE, [])
+    return jsonify(list(reversed(entries)))
+
+
+@app.route("/api/timeline", methods=["DELETE"])
+def api_clear_timeline():
+    save_json(TIMELINE_FILE, [])
+    return jsonify({"ok": True})
 
 
 @app.route("/api/target/check")

--- a/pentest-dashboard/static/index.html
+++ b/pentest-dashboard/static/index.html
@@ -332,20 +332,11 @@ input, textarea, select { font-family: inherit; font-size: inherit; }
           <svg viewBox="0 0 120 120" width="120" height="120" style="transform:rotate(-90deg)">
             <!-- Background track -->
             <circle cx="60" cy="60" r="52" fill="none" stroke="var(--bg3)" stroke-width="12"/>
-            <!-- No findings placeholder -->
-            <template x-if="findings.length === 0">
-              <circle cx="60" cy="60" r="52" fill="none" stroke="var(--border)" stroke-width="12"
-                      :stroke-dasharray="`${2*Math.PI*52} 0`"/>
-            </template>
-            <!-- Severity segments -->
-            <template x-for="(seg, i) in sevSegments" :key="i">
-              <circle cx="60" cy="60" r="52" fill="none"
-                      :stroke="seg.color"
-                      stroke-width="12"
-                      :stroke-dasharray="seg.dasharray"
-                      :stroke-dashoffset="seg.dashoffset"
-                      stroke-linecap="butt"/>
-            </template>
+            <!-- No findings placeholder (x-show avoids template-in-SVG bug) -->
+            <circle x-show="findings.length === 0" cx="60" cy="60" r="52" fill="none" stroke="var(--border)" stroke-width="12"
+                    :stroke-dasharray="`${2*Math.PI*52} 0`"/>
+            <!-- Severity segments via x-html to avoid x-for-in-SVG bug -->
+            <g x-html="sevSegmentsHTML"></g>
           </svg>
           <div style="margin-top:-68px;margin-bottom:48px;font-size:20px;font-weight:700;text-align:center"
                x-text="findings.length === 0 ? '—' : findings.length"></div>
@@ -1065,6 +1056,12 @@ function app() {
       this.findings = d.findings;
       const tl = await fetch('/api/timeline');
       this.timeline = await tl.json();
+      this.$watch('section', async (val) => {
+        if (val === 'timeline') {
+          const r = await fetch('/api/timeline');
+          this.timeline = await r.json();
+        }
+      });
     },
 
     // ── Computed ──
@@ -1104,6 +1101,12 @@ function app() {
           offset += arc;
           return seg;
         });
+    },
+
+    get sevSegmentsHTML() {
+      return this.sevSegments.map(s =>
+        `<circle cx="60" cy="60" r="52" fill="none" stroke="${s.color}" stroke-width="12" stroke-dasharray="${s.dasharray}" stroke-dashoffset="${s.dashoffset}" stroke-linecap="butt"/>`
+      ).join('');
     },
 
     get coverageData() {
@@ -1223,6 +1226,8 @@ function app() {
       if (this.eventSource) this.eventSource.close();
       this.scanning = false;
       this.terminalOutput += '\n[killed by user]\n';
+      const tl = await fetch('/api/timeline');
+      this.timeline = await tl.json();
     },
 
     _tsPrefix() {

--- a/pentest-dashboard/static/index.html
+++ b/pentest-dashboard/static/index.html
@@ -93,6 +93,7 @@ input, textarea, select { font-family: inherit; font-size: inherit; }
 .badge-purple { background: #1e1040; color: var(--purple);border: 1px solid #4c2f8a; }
 .badge-gray   { background: var(--bg3); color: var(--muted); border: 1px solid var(--border); }
 .badge-orange { background: #2e1e00; color: var(--orange); border: 1px solid #6e4205; }
+.badge-cyan   { background: #0d2e35; color: var(--cyan);   border: 1px solid #1d6b75; }
 
 /* ── Buttons ── */
 .btn {
@@ -729,6 +730,163 @@ input, textarea, select { font-family: inherit; font-size: inherit; }
       </div>
     </div>
 
+    <!-- ── Report ── -->
+    <div x-show="section==='report'">
+      <div class="section-title">📄 Pentest Report
+        <div class="flex gap-2" style="margin-left:auto;">
+          <button class="btn btn-blue btn-sm" @click="copyReport()">
+            <span x-show="!reportCopied">📋 Copy Markdown</span>
+            <span x-show="reportCopied" class="text-green">✓ Copied!</span>
+          </button>
+          <button class="btn btn-ghost btn-sm" @click="downloadReport()">⬇ Download .md</button>
+        </div>
+      </div>
+
+      <div style="background:var(--bg2); border:1px solid var(--border); border-radius:6px; padding:28px; max-width:860px;">
+
+        <!-- Report header -->
+        <div style="border-bottom:2px solid var(--border); padding-bottom:18px; margin-bottom:22px;">
+          <div style="font-size:19px; font-weight:700; margin-bottom:10px;">Pentest Report — Workspace MVP</div>
+          <div style="display:grid; grid-template-columns:1fr 1fr; gap:4px 32px; font-size:12px;">
+            <div><span class="text-muted">Date:</span>&nbsp;<span x-text="new Date().toLocaleDateString('de-DE')"></span></div>
+            <div><span class="text-muted">Tester:</span>&nbsp;Patrick Korczewski</div>
+            <div><span class="text-muted">Scope:</span>&nbsp;mentolder.de | korczewski.de</div>
+            <div><span class="text-muted">Authorization:</span>&nbsp;Authorized Self-Pentest</div>
+          </div>
+        </div>
+
+        <!-- Executive summary -->
+        <div style="margin-bottom:24px;">
+          <div style="font-size:12px; font-weight:700; color:var(--blue); text-transform:uppercase; letter-spacing:.6px; margin-bottom:12px;">Executive Summary</div>
+          <div style="display:grid; grid-template-columns:repeat(4,1fr); gap:8px; margin-bottom:12px;">
+            <div style="background:var(--bg3); border-radius:4px; padding:10px 8px; text-align:center;">
+              <div style="font-size:22px; font-weight:700; color:var(--blue);" x-text="totalTargets"></div>
+              <div style="font-size:10px; color:var(--muted); text-transform:uppercase; margin-top:2px;">Targets</div>
+            </div>
+            <div style="background:var(--bg3); border-radius:4px; padding:10px 8px; text-align:center;">
+              <div style="font-size:22px; font-weight:700;"
+                   :style="'color:' + (findings.filter(f=>f.severity==='critical'||f.severity==='high').length ? 'var(--red)' : findings.length ? 'var(--yellow)' : 'var(--green)')"
+                   x-text="findings.length"></div>
+              <div style="font-size:10px; color:var(--muted); text-transform:uppercase; margin-top:2px;">Findings</div>
+            </div>
+            <div style="background:var(--bg3); border-radius:4px; padding:10px 8px; text-align:center;">
+              <div style="font-size:22px; font-weight:700;"
+                   :style="'color:' + (flags.filter(f=>f.captured).length===3 ? 'var(--green)' : 'var(--yellow)')"
+                   x-text="flags.filter(f=>f.captured).length + '/3'"></div>
+              <div style="font-size:10px; color:var(--muted); text-transform:uppercase; margin-top:2px;">Flags</div>
+            </div>
+            <div style="background:var(--bg3); border-radius:4px; padding:10px 8px; text-align:center;">
+              <div style="font-size:22px; font-weight:700; color:var(--purple)"
+                   x-text="vectors.length ? Math.round(vectors.filter(v=>v.tested).length/vectors.length*100)+'%' : '0%'"></div>
+              <div style="font-size:10px; color:var(--muted); text-transform:uppercase; margin-top:2px;">Coverage</div>
+            </div>
+          </div>
+          <div style="font-size:12px; display:flex; gap:6px; flex-wrap:wrap; align-items:center;">
+            <span class="text-muted">Findings:</span>
+            <template x-for="sev in ['critical','high','medium','low','info']" :key="sev">
+              <span x-show="findings.filter(f=>f.severity===sev).length > 0">
+                <span class="badge" :class="sevBadge(sev)"
+                      x-text="findings.filter(f=>f.severity===sev).length + ' ' + sev"></span>
+              </span>
+            </template>
+            <span x-show="findings.length===0" class="text-muted text-sm">none logged</span>
+          </div>
+        </div>
+
+        <div style="border-top:1px solid var(--border); margin-bottom:22px;"></div>
+
+        <!-- Findings -->
+        <div style="margin-bottom:24px;">
+          <div style="font-size:12px; font-weight:700; color:var(--blue); text-transform:uppercase; letter-spacing:.6px; margin-bottom:12px;">
+            Findings
+            <span class="text-muted" style="font-size:11px; font-weight:400; text-transform:none; letter-spacing:0;" x-text="'(' + findings.length + ')'"></span>
+          </div>
+          <template x-if="findings.length===0">
+            <div class="text-muted text-sm">No findings logged yet.</div>
+          </template>
+          <template x-for="f in [...findings].sort((a,b)=>sevOrder(a.severity)-sevOrder(b.severity))" :key="f.id">
+            <div style="border:1px solid var(--border); border-radius:4px; padding:12px 14px; margin-bottom:8px;"
+                 :style="'border-left:3px solid ' + sevColor(f.severity)">
+              <div class="flex items-center gap-2 mb-2">
+                <span class="badge" :class="sevBadge(f.severity)" x-text="f.severity.toUpperCase()"></span>
+                <span style="font-weight:600; font-size:13px;" x-text="f.title"></span>
+              </div>
+              <div x-show="f.target" style="font-size:11px; color:var(--blue); margin-bottom:4px; font-family:var(--font-mono);" x-text="f.target"></div>
+              <div style="font-size:12px; line-height:1.5; white-space:pre-wrap;" x-text="f.desc"></div>
+              <div style="font-size:10px; color:var(--muted); margin-top:6px;" x-text="f.created?.slice(0,19)?.replace('T',' ')"></div>
+            </div>
+          </template>
+        </div>
+
+        <div style="border-top:1px solid var(--border); margin-bottom:22px;"></div>
+
+        <!-- CTF Flags -->
+        <div style="margin-bottom:24px;">
+          <div style="font-size:12px; font-weight:700; color:var(--blue); text-transform:uppercase; letter-spacing:.6px; margin-bottom:12px;">CTF Flags</div>
+          <table style="width:100%; border-collapse:collapse; font-size:12px;">
+            <thead>
+              <tr style="font-size:10px; text-transform:uppercase; color:var(--muted); border-bottom:1px solid var(--border);">
+                <th style="text-align:left; padding:4px 10px;">Flag</th>
+                <th style="text-align:left; padding:4px 10px;">Name</th>
+                <th style="text-align:left; padding:4px 10px;">Vector</th>
+                <th style="text-align:left; padding:4px 10px;">Status</th>
+                <th style="text-align:left; padding:4px 10px;">Captured At</th>
+              </tr>
+            </thead>
+            <tbody>
+              <template x-for="f in flags" :key="f.id">
+                <tr style="border-bottom:1px solid var(--border);">
+                  <td style="padding:7px 10px; font-weight:700; font-family:var(--font-mono);" x-text="f.id"></td>
+                  <td style="padding:7px 10px;" x-text="f.name"></td>
+                  <td style="padding:7px 10px; color:var(--muted); font-size:11px;" x-text="f.vector"></td>
+                  <td style="padding:7px 10px;">
+                    <span class="badge" :class="f.captured ? 'badge-green' : 'badge-gray'"
+                          x-text="f.captured ? '✓ CAPTURED' : 'OPEN'"></span>
+                  </td>
+                  <td style="padding:7px 10px; color:var(--muted); font-size:11px;"
+                      x-text="f.found_at ? f.found_at.slice(0,19).replace('T',' ') : '—'"></td>
+                </tr>
+              </template>
+            </tbody>
+          </table>
+          <template x-for="f in flags.filter(f=>f.notes)" :key="'fn-'+f.id">
+            <div style="margin-top:8px; padding:8px 10px; background:var(--bg3); border-radius:4px; font-size:11px; border-left:2px solid var(--green);">
+              <span style="font-weight:600; color:var(--green);" x-text="f.id + ' — '"></span>
+              <span style="white-space:pre-wrap;" x-text="f.notes"></span>
+            </div>
+          </template>
+        </div>
+
+        <div style="border-top:1px solid var(--border); margin-bottom:22px;"></div>
+
+        <!-- Attack Vector Coverage -->
+        <div>
+          <div style="font-size:12px; font-weight:700; color:var(--blue); text-transform:uppercase; letter-spacing:.6px; margin-bottom:12px;">
+            Attack Vector Coverage
+            <span class="text-muted" style="font-size:11px; font-weight:400; text-transform:none; letter-spacing:0;"
+                  x-text="' — ' + vectors.filter(v=>v.tested).length + '/' + vectors.length + ' tested'"></span>
+          </div>
+          <template x-for="tier in [1,2,3]" :key="tier">
+            <div style="margin-bottom:14px;">
+              <div style="font-size:11px; font-weight:700; color:var(--yellow); text-transform:uppercase; margin-bottom:6px;"
+                   x-text="tier===1?'Tier 1 — Unauthenticated':tier===2?'Tier 2 — Authenticated / Semi-Exposed':'Tier 3 — Post-Exploitation / Lateral Movement'"></div>
+              <template x-for="v in vectors.filter(v=>v.tier===tier)" :key="v.id">
+                <div style="display:flex; align-items:center; gap:8px; padding:3px 4px; font-size:12px; border-radius:3px;"
+                     :style="v.tested ? '' : ''">
+                  <span style="font-size:10px; width:14px; text-align:center; flex-shrink:0;"
+                        :style="'color:' + (v.tested ? 'var(--green)' : 'var(--muted)')"
+                        x-text="v.tested ? '✓' : '○'"></span>
+                  <span :style="v.tested ? 'color:var(--muted); text-decoration:line-through;' : ''"
+                        x-text="v.name"></span>
+                </div>
+              </template>
+            </div>
+          </template>
+        </div>
+
+      </div>
+    </div>
+
   </main>
 </div>
 
@@ -761,6 +919,7 @@ function app() {
     customCmd: '',
     newFinding: { title: '', severity: 'info', target: '', desc: '' },
     eventSource: null,
+    reportCopied: false,
 
     nav: [
       { id: 'overview', icon: '🎯', label: 'Overview' },
@@ -770,6 +929,7 @@ function app() {
       { id: 'vectors',  icon: '🗺️',  label: 'Vectors',  badge: 'vectors' },
       { id: 'findings', icon: '🔍', label: 'Findings', badge: 'findings' },
       { id: 'custom',   icon: '⌨️',  label: 'Custom' },
+      { id: 'report',   icon: '📄',  label: 'Report' },
     ],
 
     scanCategories: [
@@ -912,7 +1072,7 @@ function app() {
     },
 
     _scrollTerminal() {
-      const el = this.$refs.terminal || this.$refs.terminalCustom;
+      const el = this.section === 'custom' ? this.$refs.terminalCustom : this.$refs.terminal;
       if (el) el.scrollTop = el.scrollHeight;
     },
 
@@ -968,6 +1128,103 @@ function app() {
     catBadge(cat) {
       const m = { recon:'badge-blue', probe:'badge-cyan', vuln:'badge-red', auth:'badge-yellow', 'post-exploit':'badge-purple' };
       return m[cat] || 'badge-gray';
+    },
+
+    // ── Report ──
+    sevOrder(sev) {
+      return {critical:0, high:1, medium:2, low:3, info:4}[sev] ?? 5;
+    },
+    sevColor(sev) {
+      return {critical:'var(--red)', high:'var(--orange)', medium:'var(--yellow)', low:'var(--blue)', info:'var(--muted)'}[sev] || 'var(--muted)';
+    },
+    generateMarkdown() {
+      const date = new Date().toLocaleDateString('de-DE');
+      const sorted = [...this.findings].sort((a,b) => this.sevOrder(a.severity) - this.sevOrder(b.severity));
+      const sevCounts = ['critical','high','medium','low','info']
+        .map(s => { const n = this.findings.filter(f=>f.severity===s).length; return n > 0 ? `${n} ${s}` : null; })
+        .filter(Boolean).join(' | ');
+      const coverage = this.vectors.length
+        ? Math.round(this.vectors.filter(v=>v.tested).length / this.vectors.length * 100) : 0;
+
+      const lines = [
+        '# Pentest Report — Workspace MVP',
+        '',
+        `**Date:** ${date}`,
+        '**Tester:** Patrick Korczewski',
+        '**Authorization:** Authorized Self-Pentest (Bachelorprojekt)',
+        '**Scope:** mentolder.de | korczewski.de',
+        '',
+        '---',
+        '',
+        '## Executive Summary',
+        '',
+        '| Metric | Value |',
+        '|--------|-------|',
+        `| Total Targets | ${this.totalTargets} |`,
+        `| Findings | ${this.findings.length}${sevCounts ? ' (' + sevCounts + ')' : ''} |`,
+        `| CTF Flags Captured | ${this.flags.filter(f=>f.captured).length} / 3 |`,
+        `| Attack Vectors Tested | ${this.vectors.filter(v=>v.tested).length} / ${this.vectors.length} (${coverage}%) |`,
+        '',
+        '---',
+        '',
+        '## Findings',
+        '',
+      ];
+
+      if (sorted.length === 0) {
+        lines.push('_No findings logged._');
+      } else {
+        for (const f of sorted) {
+          lines.push(`### [${f.severity.toUpperCase()}] ${f.title}`);
+          lines.push('');
+          lines.push(`**Target:** \`${f.target || '—'}\``);
+          lines.push(`**Date:** ${f.created?.slice(0,19)?.replace('T',' ') || '—'}`);
+          lines.push('');
+          if (f.desc) lines.push(f.desc);
+          lines.push('');
+        }
+      }
+
+      lines.push('---', '', '## CTF Flags', '');
+      lines.push('| Flag | Name | Vector | Status | Captured At |');
+      lines.push('|------|------|--------|--------|-------------|');
+      for (const f of this.flags) {
+        const status = f.captured ? '✓ CAPTURED' : 'OPEN';
+        const at = f.found_at ? f.found_at.slice(0,19).replace('T',' ') : '—';
+        lines.push(`| ${f.id} | ${f.name} | ${f.vector} | ${status} | ${at} |`);
+      }
+      lines.push('');
+      for (const f of this.flags.filter(f => f.notes)) {
+        lines.push(`**${f.id} Notes:** ${f.notes}`, '');
+      }
+
+      lines.push('---', '', '## Attack Vector Coverage', '');
+      const tierLabels = {1:'Tier 1 — Unauthenticated', 2:'Tier 2 — Authenticated / Semi-Exposed', 3:'Tier 3 — Post-Exploitation / Lateral Movement'};
+      for (const tier of [1,2,3]) {
+        lines.push(`### ${tierLabels[tier]}`, '');
+        for (const v of this.vectors.filter(v=>v.tier===tier)) {
+          lines.push(`- [${v.tested ? 'x' : ' '}] ${v.name}`);
+        }
+        lines.push('');
+      }
+
+      return lines.join('\n');
+    },
+    async copyReport() {
+      try {
+        await navigator.clipboard.writeText(this.generateMarkdown());
+        this.reportCopied = true;
+        setTimeout(() => this.reportCopied = false, 2000);
+      } catch(e) { alert('Copy failed: ' + e.message); }
+    },
+    downloadReport() {
+      const md = this.generateMarkdown();
+      const date = new Date().toISOString().slice(0,10);
+      const blob = new Blob([md], { type: 'text/markdown' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url; a.download = `pentest-report-${date}.md`; a.click();
+      URL.revokeObjectURL(url);
     },
 
     // ANSI → HTML (handles common tool output colors)

--- a/pentest-dashboard/static/index.html
+++ b/pentest-dashboard/static/index.html
@@ -887,6 +887,43 @@ input, textarea, select { font-family: inherit; font-size: inherit; }
       </div>
     </div>
 
+    <!-- ── Timeline ── -->
+    <div x-show="section==='timeline'">
+      <div class="section-title">📋 Activity Timeline
+        <span class="text-muted text-sm" x-text="timeline.length + ' entries'"></span>
+        <button x-show="timeline.length > 0" class="btn btn-ghost btn-sm" style="margin-left:auto" @click="clearTimeline()">Clear Log</button>
+      </div>
+
+      <template x-if="timeline.length === 0">
+        <div class="card text-muted text-sm">No scan activity yet. Run a scan to start logging.</div>
+      </template>
+
+      <div class="flex flex-col gap-1">
+        <template x-for="(entry, i) in timeline" :key="i">
+          <div class="card card-sm flex items-center gap-3">
+            <span class="text-xs text-muted" style="min-width:140px;font-family:var(--font-mono)"
+                  x-text="entry.ts?.replace('T',' ')"></span>
+            <span class="badge"
+                  :class="{
+                    'badge-blue':   entry.category==='recon',
+                    'badge-cyan':   entry.category==='probe',
+                    'badge-red':    entry.category==='vuln',
+                    'badge-yellow': entry.category==='auth',
+                    'badge-purple': entry.category==='post-exploit',
+                    'badge-gray':   entry.category==='custom',
+                  }"
+                  x-text="entry.category"></span>
+            <span class="flex-1 text-sm" x-text="entry.name"></span>
+            <span x-show="entry.duration_s != null" class="text-xs text-muted" x-text="entry.duration_s + 's'"></span>
+            <span x-show="entry.event === 'started'" class="badge badge-blue">started</span>
+            <span x-show="entry.event === 'completed' && entry.exit_code === 0" class="text-green text-sm">✓</span>
+            <span x-show="entry.event === 'completed' && entry.exit_code !== 0 && entry.exit_code != null" class="text-red text-sm">✗</span>
+            <span x-show="entry.event === 'killed'" class="badge badge-gray">killed</span>
+          </div>
+        </template>
+      </div>
+    </div>
+
   </main>
 </div>
 
@@ -920,6 +957,7 @@ function app() {
     newFinding: { title: '', severity: 'info', target: '', desc: '' },
     eventSource: null,
     reportCopied: false,
+    timeline: [],
 
     nav: [
       { id: 'overview', icon: '🎯', label: 'Overview' },
@@ -930,6 +968,7 @@ function app() {
       { id: 'findings', icon: '🔍', label: 'Findings', badge: 'findings' },
       { id: 'custom',   icon: '⌨️',  label: 'Custom' },
       { id: 'report',   icon: '📄',  label: 'Report' },
+      { id: 'timeline', icon: '📋',  label: 'Timeline' },
     ],
 
     scanCategories: [
@@ -956,6 +995,8 @@ function app() {
       this.vectors = d.vectors;
       this.notes = d.notes;
       this.findings = d.findings;
+      const tl = await fetch('/api/timeline');
+      this.timeline = await tl.json();
     },
 
     // ── Computed ──
@@ -1044,7 +1085,7 @@ function app() {
       if (this.eventSource) this.eventSource.close();
 
       this.eventSource = new EventSource('/api/scan/' + data.run_id + '/stream');
-      this.eventSource.onmessage = (e) => {
+      this.eventSource.onmessage = async (e) => {
         const msg = JSON.parse(e.data);
         if (msg.text) {
           this.terminalOutput += msg.text;
@@ -1053,6 +1094,8 @@ function app() {
         if (msg.done) {
           this.scanning = false;
           this.eventSource.close();
+          const tl = await fetch('/api/timeline');
+          this.timeline = await tl.json();
         }
       };
       this.eventSource.onerror = () => {
@@ -1225,6 +1268,11 @@ function app() {
       const a = document.createElement('a');
       a.href = url; a.download = `pentest-report-${date}.md`; a.click();
       URL.revokeObjectURL(url);
+    },
+
+    async clearTimeline() {
+      await fetch('/api/timeline', { method: 'DELETE' });
+      this.timeline = [];
     },
 
     // ANSI → HTML (handles common tool output colors)

--- a/pentest-dashboard/static/index.html
+++ b/pentest-dashboard/static/index.html
@@ -1181,7 +1181,11 @@ function app() {
       this.eventSource.onmessage = async (e) => {
         const msg = JSON.parse(e.data);
         if (msg.text) {
-          this.terminalOutput += msg.text;
+          const lines = msg.text.split('\n');
+          const stamped = lines.map((l, i) =>
+            (i === 0 || l.length > 0) ? this._tsPrefix() + l : l
+          ).join('\n');
+          this.terminalOutput += stamped;
           this.$nextTick(() => this._scrollTerminal());
         }
         if (msg.done) {
@@ -1205,6 +1209,11 @@ function app() {
       if (this.eventSource) this.eventSource.close();
       this.scanning = false;
       this.terminalOutput += '\n[killed by user]\n';
+    },
+
+    _tsPrefix() {
+      const t = new Date().toLocaleTimeString('de', { hour12: false });
+      return `\x1B[90m[${t}]\x1B[0m `;
     },
 
     _scrollTerminal() {

--- a/pentest-dashboard/static/index.html
+++ b/pentest-dashboard/static/index.html
@@ -568,6 +568,7 @@ input, textarea, select { font-family: inherit; font-size: inherit; }
           </div>
           <button x-show="scanning" class="btn btn-red btn-xs" @click="killScan()">Kill</button>
           <button x-show="!scanning && terminalOutput" class="btn btn-ghost btn-xs" @click="terminalOutput=''; currentScanId=null">Clear</button>
+          <button x-show="!scanning && terminalOutput" class="btn btn-blue btn-xs" @click="saveOutputAsFinding()">→ Finding</button>
         </div>
         <div class="terminal terminal-with-header" style="height:400px" x-ref="terminal"
              x-html="ansiToHtml(terminalOutput)"></div>
@@ -779,6 +780,7 @@ input, textarea, select { font-family: inherit; font-size: inherit; }
             <span x-show="scanning" class="running-indicator"> ● live</span>
           </div>
           <button x-show="!scanning && terminalOutput" class="btn btn-ghost btn-xs" @click="terminalOutput=''">Clear</button>
+          <button x-show="!scanning && terminalOutput" class="btn btn-blue btn-xs" @click="saveOutputAsFinding()">→ Finding</button>
         </div>
         <div class="terminal terminal-with-header" style="height:500px" x-ref="terminalCustom"
              x-html="ansiToHtml(terminalOutput)"></div>
@@ -1375,6 +1377,22 @@ function app() {
     async clearTimeline() {
       await fetch('/api/timeline', { method: 'DELETE' });
       this.timeline = [];
+    },
+
+    _stripAnsi(text) {
+      return text.replace(/\x1B\[[0-9;]*m/g, '');
+    },
+
+    saveOutputAsFinding() {
+      const stripped = this._stripAnsi(this.terminalOutput);
+      this.newFinding = {
+        title: this.currentScanName || 'Scan Output',
+        severity: 'info',
+        target: '',
+        desc: stripped.slice(0, 500),
+      };
+      this.section = 'findings';
+      this.showAddFinding = true;
     },
 
     // ANSI → HTML (handles common tool output colors)

--- a/pentest-dashboard/static/index.html
+++ b/pentest-dashboard/static/index.html
@@ -350,6 +350,11 @@ input, textarea, select { font-family: inherit; font-size: inherit; }
           <div style="margin-top:-68px;margin-bottom:48px;font-size:20px;font-weight:700;text-align:center"
                x-text="findings.length === 0 ? '—' : findings.length"></div>
           <div x-show="findings.length === 0" class="text-xs text-muted mt-1">No findings yet</div>
+          <div x-show="findings.length > 0" class="flex gap-2 flex-wrap justify-center mt-2" style="max-width:200px">
+            <template x-for="seg in sevSegments" :key="seg.color">
+              <span class="text-xs" :style="'color:' + seg.color">●</span>
+            </template>
+          </div>
         </div>
 
         <!-- Coverage Ring -->

--- a/pentest-dashboard/static/index.html
+++ b/pentest-dashboard/static/index.html
@@ -323,6 +323,56 @@ input, textarea, select { font-family: inherit; font-size: inherit; }
         </div>
       </div>
 
+      <!-- Charts row -->
+      <div class="grid-2 mb-4">
+
+        <!-- Severity Donut -->
+        <div class="card" style="display:flex;flex-direction:column;align-items:center;padding:20px 14px">
+          <div class="stat-label mb-2">Findings by Severity</div>
+          <svg viewBox="0 0 120 120" width="120" height="120" style="transform:rotate(-90deg)">
+            <!-- Background track -->
+            <circle cx="60" cy="60" r="52" fill="none" stroke="var(--bg3)" stroke-width="12"/>
+            <!-- No findings placeholder -->
+            <template x-if="findings.length === 0">
+              <circle cx="60" cy="60" r="52" fill="none" stroke="var(--border)" stroke-width="12"
+                      :stroke-dasharray="`${2*Math.PI*52} 0`"/>
+            </template>
+            <!-- Severity segments -->
+            <template x-for="(seg, i) in sevSegments" :key="i">
+              <circle cx="60" cy="60" r="52" fill="none"
+                      :stroke="seg.color"
+                      stroke-width="12"
+                      :stroke-dasharray="seg.dasharray"
+                      :stroke-dashoffset="seg.dashoffset"
+                      stroke-linecap="butt"/>
+            </template>
+          </svg>
+          <div style="margin-top:-68px;margin-bottom:48px;font-size:20px;font-weight:700;text-align:center"
+               x-text="findings.length === 0 ? '—' : findings.length"></div>
+          <div x-show="findings.length === 0" class="text-xs text-muted mt-1">No findings yet</div>
+        </div>
+
+        <!-- Coverage Ring -->
+        <div class="card" style="display:flex;flex-direction:column;align-items:center;padding:20px 14px">
+          <div class="stat-label mb-2">Attack Vector Coverage</div>
+          <svg viewBox="0 0 120 120" width="120" height="120" style="transform:rotate(-90deg)">
+            <circle cx="60" cy="60" r="52" fill="none" stroke="var(--bg3)" stroke-width="12"/>
+            <circle cx="60" cy="60" r="52" fill="none"
+                    :stroke="coverageData.color"
+                    stroke-width="12"
+                    :stroke-dasharray="`${coverageData.arc} ${coverageData.C}`"
+                    stroke-dashoffset="0"
+                    stroke-linecap="butt"/>
+          </svg>
+          <div style="margin-top:-68px;margin-bottom:48px;font-size:20px;font-weight:700;text-align:center"
+               :style="'color:' + coverageData.color"
+               x-text="coverageData.pct + '%'"></div>
+          <div class="text-xs text-muted mt-1"
+               x-text="coverageData.tested + ' / ' + coverageData.total + ' vectors'"></div>
+        </div>
+
+      </div>
+
       <!-- Flags summary -->
       <div class="section-title">🚩 CTF Flags</div>
       <div class="grid-3 mb-4">
@@ -1009,6 +1059,44 @@ function app() {
     get filteredScans() {
       if (this.scanFilter === 'all') return this.scan_templates;
       return this.scan_templates.filter(s => s.category === this.scanFilter);
+    },
+
+    get sevSegments() {
+      const C = 2 * Math.PI * 52;
+      const total = this.findings.length;
+      if (total === 0) return [];
+      const defs = [
+        { sev: 'critical', color: 'var(--red)' },
+        { sev: 'high',     color: 'var(--orange)' },
+        { sev: 'medium',   color: 'var(--yellow)' },
+        { sev: 'low',      color: 'var(--blue)' },
+        { sev: 'info',     color: 'var(--muted)' },
+      ];
+      let offset = 0;
+      return defs
+        .map(d => ({ ...d, count: this.findings.filter(f => f.severity === d.sev).length }))
+        .filter(d => d.count > 0)
+        .map(d => {
+          const arc = (d.count / total) * C;
+          const seg = {
+            color: d.color,
+            dasharray: `${arc} ${C}`,
+            dashoffset: -offset,
+          };
+          offset += arc;
+          return seg;
+        });
+    },
+
+    get coverageData() {
+      const C = 2 * Math.PI * 52;
+      const total = this.vectors.length;
+      if (total === 0) return { pct: 0, arc: 0, C, color: 'var(--muted)', tested: 0, total: 0 };
+      const tested = this.vectors.filter(v => v.tested).length;
+      const pct = Math.round(tested / total * 100);
+      const arc = (tested / total) * C;
+      const color = pct >= 80 ? 'var(--green)' : pct >= 40 ? 'var(--yellow)' : 'var(--red)';
+      return { pct, arc, C, color, tested, total };
     },
 
     getBadge(type) {

--- a/pentest-dashboard/static/index.html
+++ b/pentest-dashboard/static/index.html
@@ -570,8 +570,13 @@ input, textarea, select { font-family: inherit; font-size: inherit; }
           <button x-show="!scanning && terminalOutput" class="btn btn-ghost btn-xs" @click="terminalOutput=''; currentScanId=null">Clear</button>
           <button x-show="!scanning && terminalOutput" class="btn btn-blue btn-xs" @click="saveOutputAsFinding()">→ Finding</button>
         </div>
-        <div class="terminal terminal-with-header" style="height:400px" x-ref="terminal"
+        <div class="terminal terminal-with-header" style="height:400px" x-ref="terminal" @scroll="_onTerminalScroll($el)"
              x-html="ansiToHtml(terminalOutput)"></div>
+        <div x-show="userScrolledUp && scanning" style="position:relative">
+          <button class="btn btn-ghost btn-xs"
+                  style="position:absolute;bottom:8px;right:8px;z-index:10;background:var(--bg3);border-color:var(--border)"
+                  @click="jumpToBottom()">↓ new output</button>
+        </div>
       </div>
 
       <!-- Scan command preview modal -->
@@ -782,8 +787,13 @@ input, textarea, select { font-family: inherit; font-size: inherit; }
           <button x-show="!scanning && terminalOutput" class="btn btn-ghost btn-xs" @click="terminalOutput=''">Clear</button>
           <button x-show="!scanning && terminalOutput" class="btn btn-blue btn-xs" @click="saveOutputAsFinding()">→ Finding</button>
         </div>
-        <div class="terminal terminal-with-header" style="height:500px" x-ref="terminalCustom"
+        <div class="terminal terminal-with-header" style="height:500px" x-ref="terminalCustom" @scroll="_onTerminalScroll($el)"
              x-html="ansiToHtml(terminalOutput)"></div>
+        <div x-show="userScrolledUp && scanning" style="position:relative">
+          <button class="btn btn-ghost btn-xs"
+                  style="position:absolute;bottom:8px;right:8px;z-index:10;background:var(--bg3);border-color:var(--border)"
+                  @click="jumpToBottom()">↓ new output</button>
+        </div>
       </div>
     </div>
 
@@ -1015,6 +1025,7 @@ function app() {
     eventSource: null,
     reportCopied: false,
     timeline: [],
+    userScrolledUp: false,
 
     nav: [
       { id: 'overview', icon: '🎯', label: 'Overview' },
@@ -1167,6 +1178,7 @@ function app() {
     },
 
     async _startScan(payload) {
+      this.userScrolledUp = false;
       this.scanning = true;
       const res = await fetch('/api/scan/run', {
         method: 'POST',
@@ -1220,7 +1232,26 @@ function app() {
 
     _scrollTerminal() {
       const el = this.section === 'custom' ? this.$refs.terminalCustom : this.$refs.terminal;
+      if (!el) return;
+      const atBottom = el.scrollTop + el.clientHeight >= el.scrollHeight - 20;
+      if (atBottom || !this.userScrolledUp) {
+        el.scrollTop = el.scrollHeight;
+        this.userScrolledUp = false;
+      }
+    },
+
+    _onTerminalScroll(el) {
+      if (!el) return;
+      const atBottom = el.scrollTop + el.clientHeight >= el.scrollHeight - 20;
+      if (!atBottom) {
+        this.userScrolledUp = true;
+      }
+    },
+
+    jumpToBottom() {
+      const el = this.section === 'custom' ? this.$refs.terminalCustom : this.$refs.terminal;
       if (el) el.scrollTop = el.scrollHeight;
+      this.userScrolledUp = false;
     },
 
     previewScan(s) {


### PR DESCRIPTION
## Summary

- Add local Flask-based pentest dashboard for authorized testing of Mentolder & Korczewski services
- Backend: scan registry, SSE streaming, timeline file (`started`/`completed`/`killed` events), findings persistence
- Frontend (Alpine.js): Overview donut chart + coverage ring, Timeline section, ANSI timestamps in terminal, Save-as-Finding button, smart auto-scroll with new-output pill
- Fix SVG Alpine.js bugs (`<template>` inside `<svg>` crashes with `cloneNode` / `seg is not defined`) — replaced with `x-show` + `x-html` on `<g>` and `sevSegmentsHTML` getter
- Fix timeline not refreshing on nav or after kill — added `$watch('section')` and timeline fetch in `killScan()`

## Test plan

- [ ] Start server: `cd pentest-dashboard && python3 app.py`
- [ ] Overview: both chart cards render, donut shows "—" with no findings
- [ ] Custom: run `echo hello && sleep 1 && echo world` — timestamps appear per line, "→ Finding" button shown on completion
- [ ] Save as Finding: pre-fills title, severity, timestamped description; Overview donut updates
- [ ] Timeline: shows `STARTED` + `COMPLETED` entries after a scan; Clear Log empties list
- [ ] Kill: start Nmap Infrastructure, kill mid-run — Timeline shows `KILLED` entry immediately after

🤖 Generated with [Claude Code](https://claude.com/claude-code)