### PR TITLE
fix(keycloak): korczewski NC OIDC redirect URIs incl. /index.php + wildcard

### DIFF
--- a/prod-korczewski/realm-workspace-korczewski.json
+++ b/prod-korczewski/realm-workspace-korczewski.json
@@ -69,7 +69,10 @@
       "secret": "${NEXTCLOUD_OIDC_SECRET}",
       "redirectUris": [
         "https://${NC_DOMAIN}/apps/oidc_login/oidc",
-        "https://${NC_DOMAIN}/apps/sociallogin/custom_oidc/keycloak"
+        "https://${NC_DOMAIN}/apps/sociallogin/custom_oidc/keycloak",
+        "https://${NC_DOMAIN}/index.php/apps/oidc_login/oidc",
+        "https://${NC_DOMAIN}/index.php/apps/sociallogin/custom_oidc/keycloak",
+        "https://${NC_DOMAIN}/*"
       ],
       "webOrigins": [
         "https://${NC_DOMAIN}"


### PR DESCRIPTION
## Summary
After fresh `workspace:deploy ENV=korczewski`, files.korczewski.de returned HTTP 400 from Keycloak: `Invalid parameter: redirect_uri`. NC sends `https://files.korczewski.de/index.php/apps/oidc_login/oidc` while the realm import only registered the rewrite-clean form. Mirroring the mentolder client list fixes login.

Already patched live via kcadm; this commit makes future re-imports honor it.

## Test plan
- [x] kcadm-patched live cluster, `curl -L https://files.korczewski.de/` now returns Keycloak login (HTTP 200) instead of 400
- [ ] Re-import realm (fresh cluster) → NC login succeeds end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)