### PR TITLE
fix(coredns): static signaling override + drop forced restart (no more nextcloud-db DNS race)

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -581,25 +581,26 @@ tasks:
         vars: { ENV: "korczewski" }
 
   workspace:talk-dns-fix:
-    desc: "Apply CoreDNS signaling override for a cluster (ENV=mentolder|korczewski)"
+    desc: "Apply CoreDNS signaling override (kube-system is shared by mentolder + korczewski; ENV defaults to mentolder)"
     vars:
       ENV: '{{.ENV | default "mentolder"}}'
     cmds:
       - |
         source scripts/env-resolve.sh "{{.ENV}}"
-        envsubst "\$PROD_DOMAIN" < prod/coredns-signaling-override.yaml \
-          | kubectl --context "${ENV_CONTEXT}" apply -f -
+        kubectl --context "${ENV_CONTEXT}" apply -f prod/coredns-signaling-override.yaml
+        # CoreDNS has the `reload` plugin and re-reads the ConfigMap every ~30s
+        # automatically. Force-restart here so the override takes effect now,
+        # which is the whole point of this manual "fix it" task.
         kubectl --context "${ENV_CONTEXT}" rollout restart deployment/coredns -n kube-system 2>/dev/null || \
           kubectl --context "${ENV_CONTEXT}" rollout restart daemonset/coredns -n kube-system 2>/dev/null || true
-        echo "✓ CoreDNS signaling override applied for ${PROD_DOMAIN}"
+        kubectl --context "${ENV_CONTEXT}" rollout status deployment/coredns -n kube-system --timeout=60s 2>/dev/null || true
+        echo "✓ CoreDNS signaling override applied (mentolder.de + korczewski.de)"
 
   workspace:talk-dns-fix:all-prods:
-    desc: Apply CoreDNS signaling override on all production clusters
+    desc: Apply CoreDNS signaling override (single shared kube-system; one apply suffices)
     cmds:
       - task: workspace:talk-dns-fix
         vars: { ENV: "mentolder" }
-      - task: workspace:talk-dns-fix
-        vars: { ENV: "korczewski" }
 
   workspace:coturn:sync-secret:
     desc: "Copy SIGNALING_SECRET and TURN_SECRET from workspace-secrets into coturn/coturn-secrets (ENV=dev|mentolder|korczewski)"

--- a/prod/coredns-signaling-override.yaml
+++ b/prod/coredns-signaling-override.yaml
@@ -4,11 +4,17 @@
 # (z.B. POST /api/v1/room/<id>). Die externe IP ist aus dem Cluster heraus durch
 # die NetworkPolicy (allow-internet-egress blockt RFC1918) nicht erreichbar.
 # Diese Konfiguration überschreibt die DNS-Auflösung cluster-intern so, dass
-# signaling.${PROD_DOMAIN} auf die Traefik-ClusterIP zeigt, die innerhalb des
+# signaling.<domain> auf die Traefik-ClusterIP zeigt, die innerhalb des
 # Clusters per HTTPS erreichbar ist (NetworkPolicy: allow-traefik-egress).
 #
-# Deployment: task workspace:talk-dns-fix ENV=mentolder|korczewski
-# (manuell; kube-system liegt ausserhalb des ArgoCD workspace-Scopes)
+# Beide produktiven Domains werden explizit aufgeführt: mentolder und korczewski
+# laufen nach der Cluster-Konsolidierung in derselben physischen kube-system,
+# also kann pro Cluster nur eine Datei existieren — wir listen alle Domains.
+#
+# CoreDNS hat das `reload`-Plugin aktiv (Corefile in `coredns` ConfigMap), das
+# diese Datei alle 30s automatisch neu einliest. Ein expliziter Restart ist
+# nicht nötig und vermeidet die unvermeidbare DNS-Lücke einer 1-replica
+# RollingUpdate-Deployment.
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -16,4 +22,5 @@ metadata:
   namespace: kube-system
 data:
   signaling.override: |
-    rewrite name signaling.${PROD_DOMAIN} traefik.kube-system.svc.cluster.local
+    rewrite name signaling.mentolder.de traefik.kube-system.svc.cluster.local
+    rewrite name signaling.korczewski.de traefik.kube-system.svc.cluster.local

--- a/scripts/talk-hpb-setup.sh
+++ b/scripts/talk-hpb-setup.sh
@@ -101,16 +101,27 @@ _occ "php occ config:app:set spreed turn_servers --value='${TURN_JSON}'" > /dev/
 # Die NetworkPolicy allow-internet-egress blockt RFC1918-Adressen, weshalb
 # die externe signaling-Domain vom PHP-Backend nicht erreichbar wäre.
 # Dieser Rewrite leitet signaling.<domain> intern zur Traefik-ClusterIP um.
+#
+# Die Override-Datei ist domain-agnostisch (listet alle prod-Domains explizit) —
+# da mentolder und korczewski auf derselben physischen kube-system laufen,
+# darf hier KEIN per-Env Template verwendet werden, sonst überschreibt der
+# zuletzt deployende ENV den anderen.
+#
+# CoreDNS hat das `reload`-Plugin aktiv und liest die ConfigMap alle 30s neu —
+# ein Restart ist nicht nötig und würde durch die 1-replica RollingUpdate-
+# Deployment eine ~2-5s DNS-Lücke erzeugen, in die verification _occ-Calls
+# rennen würden ("nextcloud-db: Temporary failure in name resolution").
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 COREDNS_OVERRIDE="${SCRIPT_DIR}/../prod/coredns-signaling-override.yaml"
 if [[ -f "${COREDNS_OVERRIDE}" && "${SIGNALING_HOST}" != *localhost* ]]; then
   echo "  Wende CoreDNS-Override an (${SIGNALING_HOST} → traefik intern) ..."
-  kubectl ${KUBE_CONTEXT:+--context $KUBE_CONTEXT} apply -f "${COREDNS_OVERRIDE}"
-  kubectl ${KUBE_CONTEXT:+--context $KUBE_CONTEXT} rollout restart deployment/coredns -n kube-system > /dev/null 2>&1 || true
-  # Block until CoreDNS is fully rolled — otherwise the verification _occ calls
-  # below race the rollout and hit the ~seconds window where a DNS lookup for
-  # nextcloud-db can land on a not-ready / terminating endpoint and time out.
-  kubectl ${KUBE_CONTEXT:+--context $KUBE_CONTEXT} rollout status deployment/coredns -n kube-system --timeout=60s > /dev/null 2>&1 || true
+  APPLY_OUT=$(kubectl ${KUBE_CONTEXT:+--context $KUBE_CONTEXT} apply -f "${COREDNS_OVERRIDE}")
+  echo "    ${APPLY_OUT}"
+  if [[ "${APPLY_OUT}" == *unchanged* ]]; then
+    echo "    CoreDNS-Override bereits aktiv."
+  else
+    echo "    CoreDNS lädt die ConfigMap automatisch innerhalb von ~30s nach (reload-Plugin)."
+  fi
 fi
 
 # ── Verification ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
Fixes the `could not translate host name "nextcloud-db"` error seen during `task workspace:deploy ENV=korczewski` post-setup.

Two stacked bugs:

1. **`scripts/talk-hpb-setup.sh:108`** applied `prod/coredns-signaling-override.yaml` without `envsubst`, so the live `coredns-custom` ConfigMap contained literal `signaling.${PROD_DOMAIN}` — a no-op rewrite. The dedicated `workspace:talk-dns-fix` task *did* substitute correctly, but per-env templating is the wrong model anyway: after the cluster merge, mentolder + korczewski share one physical `kube-system`, so the last `apply` overwrites the other env.
2. The script then forced a `kubectl rollout restart deployment/coredns`. CoreDNS runs **1 replica, maxUnavailable=1**, producing an unavoidable 2–5 s DNS gap. The immediately-following verification `_occ` call landed in that gap and emitted a Doctrine stack trace. Talk config itself wrote *before* the restart and persisted, so the error was cosmetic but noisy.

## Fix
- `prod/coredns-signaling-override.yaml`: list `mentolder.de` + `korczewski.de` rewrites explicitly. No `envsubst` variable; cluster-wide config.
- `scripts/talk-hpb-setup.sh`: apply once, **no restart**. CoreDNS Corefile already imports the override and runs the `reload` plugin, so the ConfigMap is re-read every ~30 s automatically.
- `Taskfile.yml workspace:talk-dns-fix`: drop `envsubst`; keep the explicit restart since this task is the manual "apply now" trigger. `:all-prods` collapses to one apply.

## Verification
- `kubectl -n kube-system get cm coredns-custom` now shows both rewrites.
- From inside the NC pod, `getent hosts signaling.mentolder.de` and `signaling.korczewski.de` both return `10.43.119.133` (Traefik ClusterIP).
- Re-running `task workspace:talk-setup ENV=korczewski` is a no-op (`configmap unchanged`) and produces no DNS error; all three verification calls return valid JSON.

## Test plan
- [x] Live cluster: both rewrites resolve to Traefik
- [x] Idempotent re-run: no restart, no error
- [ ] Fresh deploy: `task feature:deploy` produces no `nextcloud-db` trace

🤖 Generated with [Claude Code](https://claude.com/claude-code)