### PR TITLE
fix(website): replace hero "Kennenlernen" CTA with direct login (kore)

### DIFF
--- a/website/src/components/kore/KoreHero.svelte
+++ b/website/src/components/kore/KoreHero.svelte
@@ -41,7 +41,7 @@
   </p>
 
   <div class="cta-row">
-    <a class="btn primary" href="/kontakt">Kennenlernen →</a>
+    <a class="btn primary" href="/api/auth/login">Anmelden →</a>
     <a class="btn ghost" href="#timeline">Notizen lesen</a>
   </div>
 


### PR DESCRIPTION
## Summary
Follow-up to #516. The hero on `web.korczewski.de` still showed the legacy "Kennenlernen → /kontakt" button. Replaces it with "Anmelden → /api/auth/login" so both visible CTAs (top-right subnav + hero) take visitors straight to Keycloak.

## Test plan
- [ ] `task feature:website` rolls the website on mentolder + korczewski
- [ ] https://web.korczewski.de hero shows "Anmelden →" linking to `/api/auth/login`

🤖 Generated with [Claude Code](https://claude.com/claude-code)