### PR TITLE
ci(e2e): run Playwright suite against both prod clusters

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,101 @@
+name: E2E (Live Production)
+
+# Runs the Playwright suite against both production clusters in parallel.
+# Triggered manually or on a nightly cron — not on every PR, since each run
+# hits live web.mentolder.de and web.korczewski.de.
+#
+# Auth-gated specs need MM_TEST_USER / MM_TEST_PASS repo secrets (Keycloak
+# credentials of a workspace user). Without them, login flows fall back to
+# defaults and the affected tests will fail or skip.
+
+on:
+  workflow_dispatch:
+    inputs:
+      cluster:
+        description: "Cluster to test (default: both)"
+        required: false
+        default: both
+        type: choice
+        options: [both, mentolder, korczewski]
+  schedule:
+    - cron: "0 3 * * *"  # 03:00 UTC nightly
+
+concurrency:
+  group: e2e-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  playwright:
+    name: ${{ matrix.cluster }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - cluster: mentolder
+            website_url: https://web.mentolder.de
+            prod_domain: mentolder.de
+          - cluster: korczewski
+            website_url: https://web.korczewski.de
+            prod_domain: korczewski.de
+    env:
+      SELECTED_CLUSTER: ${{ inputs.cluster }}
+      EVENT_NAME: ${{ github.event_name }}
+      MATRIX_CLUSTER: ${{ matrix.cluster }}
+    steps:
+      - name: Skip if non-matching manual input
+        id: gate
+        run: |
+          if [ "$EVENT_NAME" = "workflow_dispatch" ] && [ "$SELECTED_CLUSTER" != "both" ] && [ "$SELECTED_CLUSTER" != "$MATRIX_CLUSTER" ]; then
+            echo "Skipping $MATRIX_CLUSTER (manual input selected '$SELECTED_CLUSTER')"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/checkout@v5
+        if: steps.gate.outputs.skip != 'true'
+
+      - uses: actions/setup-node@v4
+        if: steps.gate.outputs.skip != 'true'
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: tests/e2e/package-lock.json
+
+      - name: Install dependencies
+        if: steps.gate.outputs.skip != 'true'
+        working-directory: tests/e2e
+        run: npm ci
+
+      - name: Install Playwright browsers
+        if: steps.gate.outputs.skip != 'true'
+        working-directory: tests/e2e
+        run: npx playwright install --with-deps chromium webkit
+
+      - name: Run Playwright suite against ${{ matrix.website_url }}
+        if: steps.gate.outputs.skip != 'true'
+        working-directory: tests/e2e
+        env:
+          WEBSITE_URL: ${{ matrix.website_url }}
+          PROD_DOMAIN: ${{ matrix.prod_domain }}
+          MM_TEST_USER: ${{ secrets.MM_TEST_USER }}
+          MM_TEST_PASS: ${{ secrets.MM_TEST_PASS }}
+        run: npx playwright test
+
+      - name: Upload Playwright report
+        if: always() && steps.gate.outputs.skip != 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-${{ matrix.cluster }}
+          path: tests/e2e/playwright-report
+          retention-days: 14
+
+      - name: Upload traces on failure
+        if: failure() && steps.gate.outputs.skip != 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-traces-${{ matrix.cluster }}
+          path: tests/results/playwright-traces
+          retention-days: 14

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -326,6 +326,33 @@ tasks:
     cmds:
       - ./tests/unit/lib/bats-core/bin/bats --formatter tap tests/unit/
 
+  test:e2e:
+    desc: "Run Playwright e2e suite against ENV=mentolder|korczewski (default mentolder)"
+    dir: tests/e2e
+    vars:
+      ENV: '{{.ENV | default "mentolder"}}'
+    preconditions:
+      - sh: '[ "{{.ENV}}" = "mentolder" ] || [ "{{.ENV}}" = "korczewski" ]'
+        msg: "test:e2e requires ENV=mentolder or ENV=korczewski, got ENV={{.ENV}}"
+    cmds:
+      - |
+        case "{{.ENV}}" in
+          mentolder)  WEBSITE_URL=https://web.mentolder.de  PROD_DOMAIN=mentolder.de ;;
+          korczewski) WEBSITE_URL=https://web.korczewski.de PROD_DOMAIN=korczewski.de ;;
+        esac
+        export WEBSITE_URL PROD_DOMAIN
+        [ -d node_modules ] || npm ci
+        npx playwright install chromium webkit >/dev/null 2>&1 || true
+        npx playwright test {{.CLI_ARGS}}
+
+  test:e2e:all-prods:
+    desc: "Run Playwright e2e suite against mentolder + korczewski"
+    cmds:
+      - task: test:e2e
+        vars: { ENV: "mentolder" }
+      - task: test:e2e
+        vars: { ENV: "korczewski" }
+
   # ─────────────────────────────────────────────
   # Quick Start
   # ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- New `.github/workflows/e2e.yml` runs the Playwright suite in a 2-cluster matrix (`mentolder`, `korczewski`) — manual `workflow_dispatch` (with optional single-cluster pick) and nightly cron at 03:00 UTC. **Not** on PRs, since runs hit live prod.
- New `task test:e2e ENV=mentolder|korczewski` and `task test:e2e:all-prods` for local parity.

## Why
Audit of `tests/e2e/` showed the suite is single-cluster per run: one `WEBSITE_URL` + one `PROD_DOMAIN`. The documented run command in memory only ever hit mentolder. Of 45 specs, only 3 hardcode korczewski (`korczewski-home`, `brett-art`, `dashboard-art`). The remaining 42 silently bypass `*.korczewski.de` because nobody runs them with `WEBSITE_URL=https://web.korczewski.de`.

Cheapest fix per the audit: invoke the existing suite twice with the right env per cluster. No spec changes.

## Notes
- Auth-gated specs (e.g. `sa-08-sso`, `fa-15-oidc`) read `MM_TEST_USER` / `MM_TEST_PASS`. Workflow forwards them from repo secrets — if those aren't set, those specs will hit Keycloak login with default placeholders and fail. Add the secrets in repo settings to get them green.
- Webkit is installed in CI so the `ios` Playwright project runs too.
- `fail-fast: false` so a mentolder failure doesn't cancel korczewski (and vice versa).
- Concurrency group prevents overlapping nightly + manual runs from racing.

## Test plan
- [ ] Trigger `E2E (Live Production)` workflow with `cluster=mentolder` once main has the workflow → verify it runs only the mentolder matrix entry.
- [ ] Trigger again with `cluster=both` → verify both matrix entries run in parallel.
- [ ] Add `MM_TEST_USER` / `MM_TEST_PASS` repo secrets if not present; rerun and confirm auth-gated specs pass.
- [ ] Local: `task test:e2e ENV=korczewski -- --project=korczewski` to smoke-test the Taskfile path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)