### PR TITLE
fix(ci): wire per-service URLs and contact info into e2e workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -36,9 +36,13 @@ jobs:
           - cluster: mentolder
             website_url: https://web.mentolder.de
             prod_domain: mentolder.de
+            contact_email: info@mentolder.de
+            contact_phone: "+49 151 508 32 601"
           - cluster: korczewski
             website_url: https://web.korczewski.de
             prod_domain: korczewski.de
+            contact_email: info@korczewski.de
+            contact_phone: ""
     env:
       SELECTED_CLUSTER: ${{ inputs.cluster }}
       EVENT_NAME: ${{ github.event_name }}
@@ -78,24 +82,35 @@ jobs:
         if: steps.gate.outputs.skip != 'true'
         working-directory: tests/e2e
         env:
+          # Primary URLs
           WEBSITE_URL: ${{ matrix.website_url }}
           PROD_DOMAIN: ${{ matrix.prod_domain }}
+          # Per-service URL overrides — without these the specs fall back to
+          # *.localhost defaults and ECONNREFUSED on the runner.
+          TEST_KC_URL: https://auth.${{ matrix.prod_domain }}
+          TEST_NC_URL: https://files.${{ matrix.prod_domain }}
+          TEST_SIGNALING_URL: https://signaling.${{ matrix.prod_domain }}
+          NC_DOMAIN: files.${{ matrix.prod_domain }}
+          SIGNALING_DOMAIN: signaling.${{ matrix.prod_domain }}
+          VAULT_URL: https://vault.${{ matrix.prod_domain }}
+          MAIL_URL: https://mail.${{ matrix.prod_domain }}
+          BOARD_URL: https://board.${{ matrix.prod_domain }}
+          BRETT_URL: https://brett.${{ matrix.prod_domain }}
+          TRACKING_URL: https://tracking.${{ matrix.prod_domain }}
+          DASHBOARD_URL: https://dashboard.${{ matrix.prod_domain }}
+          # Per-cluster brand assertions
+          CONTACT_EMAIL: ${{ matrix.contact_email }}
+          CONTACT_PHONE: ${{ matrix.contact_phone }}
+          # Auth
           MM_TEST_USER: ${{ secrets.MM_TEST_USER }}
           MM_TEST_PASS: ${{ secrets.MM_TEST_PASS }}
         run: npx playwright test
 
-      - name: Upload Playwright report
+      - name: Upload results (traces + JSON report)
         if: always() && steps.gate.outputs.skip != 'true'
         uses: actions/upload-artifact@v4
         with:
-          name: playwright-report-${{ matrix.cluster }}
-          path: tests/e2e/playwright-report
+          name: playwright-results-${{ matrix.cluster }}
+          path: tests/results
           retention-days: 14
-
-      - name: Upload traces on failure
-        if: failure() && steps.gate.outputs.skip != 'true'
-        uses: actions/upload-artifact@v4
-        with:
-          name: playwright-traces-${{ matrix.cluster }}
-          path: tests/results/playwright-traces
-          retention-days: 14
+          if-no-files-found: ignore


### PR DESCRIPTION
## Summary
Fixes the first E2E (Live Production) run, which had ~30 failures per cluster due to specs falling back to `*.localhost` defaults.

## What changed
- **Per-service env vars**: workflow now sets `TEST_KC_URL`, `TEST_NC_URL`, `TEST_SIGNALING_URL`, `NC_DOMAIN`, `SIGNALING_DOMAIN`, `VAULT_URL`, `MAIL_URL`, `BOARD_URL`, `BRETT_URL`, `TRACKING_URL`, `DASHBOARD_URL` — all derived from `${{ matrix.prod_domain }}`.
- **Per-cluster brand**: matrix carries `contact_email` / `contact_phone` so `fa-10-website` asserts the right strings on each homepage.
- **Artifact path**: was `tests/e2e/playwright-report/` (empty — that reporter isn't configured); now uploads `tests/results/` where the JSON report and traces actually land. Single artifact instead of two.

## Why
First run results showed a clear pattern: every spec that has its own per-service URL env var (vaultwarden, mailpit, whiteboard, sso, etc.) was hitting `http://*.localhost` instead of `*.${PROD_DOMAIN}`. Shape of the failures was identical across mentolder and korczewski (36 / 33), confirming it's an env-wiring bug, not cluster-specific brittleness.

## Test plan
- [ ] After merge, trigger `E2E (Live Production)` with `cluster=both` and verify the connection-refused failures go away.
- [ ] Confirm `playwright-results-mentolder` / `playwright-results-korczewski` artifacts now have content (JSON report + traces).
- [ ] Triage whatever specs remain red — those will be the genuine pre-existing brittleness, not env-wiring artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)