### PR TITLE
chore(dashboard): remove stale task references

### DIFF
--- a/dashboard/public/index.html
+++ b/dashboard/public/index.html
@@ -484,10 +484,10 @@
         'workspace:systembrett-setup', 'workspace:admin-users-setup',
         'workspace:vaultwarden:seed', 'workspace:sync-db-passwords',
         'workspace:create-guest', 'workspace:import-users', 'workspace:migrate',
-        'keycloak:sync', 'keycloak:sync-secrets',
+        'keycloak:sync',
         'argocd:setup', 'argocd:install', 'argocd:apps:apply',
         'argocd:cluster:register', 'argocd:sync',
-        'docs:deploy', 'docs:restart',
+        'docs:deploy',
         'mcp:deploy', 'mcp:restart',
         'website:deploy',
         'whisper:deploy',
@@ -520,8 +520,7 @@
             { title: 'Whiteboard Setup',      cmd: 'workspace:whiteboard-setup',   desc: 'Install + configure Nextcloud Whiteboard app' },
             { title: 'Systembrett Setup',     cmd: 'workspace:systembrett-setup',  desc: 'Set up Brett (Systembrett) integration in Nextcloud Talk' },
             { title: 'Transcriber Setup',     cmd: 'workspace:transcriber-setup',  desc: 'Set up talk-transcriber bot + Whisper' },
-            { title: 'Keycloak Sync',         cmd: 'keycloak:sync',                desc: 'Sync realm config and OIDC clients to Keycloak' },
-            { title: 'Keycloak Sync Secrets', cmd: 'keycloak:sync-secrets',        desc: 'Push updated Keycloak client secrets to the live cluster' },
+            { title: 'Keycloak Sync',         cmd: 'keycloak:sync',                desc: 'Sync realm config + OIDC clients and push regenerated client secrets to the live cluster' },
         ]},
         { cat: 'Compliance & Hardening', icon: '🛡️', accent: ACCENTS.users, items: [
             { title: 'DSGVO Check',       cmd: 'workspace:dsgvo-check',       desc: 'Run DSGVO/GDPR compliance verification (NFA-01)' },
@@ -640,8 +639,7 @@
             { title: 'Cert Status',          cmd: 'cert:status',  desc: 'Show wildcard cert and ClusterIssuer status' },
         ]},
         { cat: 'Docs Site', icon: '📚', accent: ACCENTS.website, items: [
-            { title: 'Deploy Docs ConfigMap', cmd: 'docs:deploy',  desc: 'Push the docs ConfigMap to the selected cluster (ArgoCD does NOT auto-sync this)' },
-            { title: 'Restart Docs Pod',      cmd: 'docs:restart', desc: 'Force-restart the docs pod after a ConfigMap update' },
+            { title: 'Deploy Docs ConfigMap', cmd: 'docs:deploy',  desc: 'Push the docs ConfigMap to both prod clusters and restart the docs pods (ArgoCD does NOT auto-sync this)' },
         ]},
         { cat: 'HA Cluster', icon: '🛠️', accent: ACCENTS.cluster, items: [
             { title: 'HA Status',         cmd: 'ha:status',     desc: 'Show node health for the 3-node HA cluster' },

--- a/dashboard/server.js
+++ b/dashboard/server.js
@@ -30,7 +30,7 @@ const ALLOWED_COMMANDS = new Set([
   'workspace:preflight', 'workspace:validate', 'workspace:up',
   'workspace:deploy', 'workspace:status', 'workspace:office:deploy',
   'workspace:post-setup', 'workspace:talk-setup',
-  'keycloak:sync', 'keycloak:sync-secrets',
+  'keycloak:sync',
   'workspace:recording-setup', 'workspace:transcriber-setup', 'workspace:whiteboard-setup',
   'workspace:systembrett-setup', 'workspace:admin-users-setup',
   'workspace:logs', 'workspace:restart', 'workspace:check-connectivity', 'workspace:check-updates',
@@ -40,8 +40,6 @@ const ALLOWED_COMMANDS = new Set([
   'workspace:db:start', 'workspace:db:drop', 'workspace:db:restore',
   'workspace:teardown',
   'workspace:create-guest', 'workspace:import-users', 'workspace:migrate',
-  'mentolder:status', 'mentolder:logs', 'mentolder:restart',
-  'korczewski:status', 'korczewski:logs', 'korczewski:restart',
   'clusters:status',
   'argocd:setup', 'argocd:status', 'argocd:apps:apply',
   'argocd:install', 'argocd:password', 'argocd:cluster:register',
@@ -57,7 +55,7 @@ const ALLOWED_COMMANDS = new Set([
   'einvoice-sidecar:build', 'einvoice-sidecar:import', 'einvoice-sidecar:push', 'einvoice-sidecar:logs',
   'billing:validate-einvoice',
   'cert:install', 'cert:status',
-  'docs:deploy', 'docs:restart',
+  'docs:deploy',
   'test:all', 'test:unit', 'test:manifests',
 ]);
 


### PR DESCRIPTION
## Summary
- Local admin dashboard's auto-chain was firing `keycloak:sync-secrets` after `keycloak:sync`, failing every run because the task was dropped in PR #511.
- Removes the eight stale task names from `dashboard/server.js` ALLOWED_COMMANDS and `dashboard/public/index.html` PROD_GATE_COMMANDS + UI button list: `keycloak:sync-secrets`, `mentolder:{status,logs,restart}`, `korczewski:{status,logs,restart}`, `docs:restart`.
- Folded the dropped buttons' descriptions into the surviving `keycloak:sync` (already pushes regenerated client secrets) and `docs:deploy` (already restarts the docs pod) entries.

## Test plan
- [x] `node --check dashboard/server.js`
- [x] grep for the 8 stale names returns nothing
- [ ] Restart local dashboard and confirm Keycloak Sync auto-chain completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)