### PR TITLE
fix(einvoice): close prod-path BR-E-02 + unblock billing API in live verification

### DIFF
--- a/k3d/website-seller-config.yaml
+++ b/k3d/website-seller-config.yaml
@@ -8,5 +8,10 @@ data:
   SELLER_ADDRESS: "Ludwig-Erhard-Str. 18"
   SELLER_POSTAL_CODE: "20459"
   SELLER_CITY: "Hamburg"
-  SELLER_COUNTRY: "Deutschland"
-  SELLER_VAT_ID: "33/023/05100"
+  # ISO 3166-1 alpha-2 — required by EN 16931 schematron (BR-CL-14 / Zod string.length(2)).
+  SELLER_COUNTRY: "DE"
+  # Empty: Kleinunternehmer (§19 UStG) has no VAT ID. The previous value
+  # 33/023/05100 was a Steuernummer mislabelled as a VAT ID — it now lives
+  # in SELLER_TAX_NUMBER and is emitted as schemeID="FC" (BT-32).
+  SELLER_VAT_ID: ""
+  SELLER_TAX_NUMBER: "33/023/05100"

--- a/k3d/website.yaml
+++ b/k3d/website.yaml
@@ -291,6 +291,11 @@ spec:
                 configMapKeyRef:
                   name: website-seller-config
                   key: SELLER_VAT_ID
+            - name: SELLER_TAX_NUMBER
+              valueFrom:
+                configMapKeyRef:
+                  name: website-seller-config
+                  key: SELLER_TAX_NUMBER
             - name: BRETT_BOT_SECRET
               valueFrom:
                 secretKeyRef:

--- a/website/src/lib/einvoice-profile.test.ts
+++ b/website/src/lib/einvoice-profile.test.ts
@@ -72,6 +72,35 @@ describe('generateEInvoiceXml', () => {
     expect(() => generateXRechnungCii(noLeitweg)).toThrow(/Leitweg-ID/);
   });
 
+  // BR-CO-26 / BR-E-02: Kleinunternehmer (no VAT ID) must still expose a
+  // Seller tax registration. Steuernummer goes in schemeID="FC" — the live
+  // production-path generators (factur-x-minimum and xrechnung-cii) both
+  // need to honour it.
+  const kleinTaxNumberInput = {
+    ...baseInput,
+    invoice: { ...baseInput.invoice, taxMode: 'kleinunternehmer' as const, taxRate: 0, taxAmount: 0, grossAmount: baseInput.invoice.netAmount },
+    lines: [{ description: 'Coaching', quantity: 1, unitPrice: 100, unit: 'HUR' }],
+    seller: { ...baseInput.seller, vatId: '', taxNumber: '33/023/05100' },
+  };
+
+  it('factur-x-minimum (Kleinunternehmer): emits SellerTradeParty/ID + FC-scheme registration when only taxNumber is set', () => {
+    const xml = generateEInvoiceXml('factur-x-minimum', kleinTaxNumberInput);
+    expect(xml).toContain('<ram:SpecifiedTaxRegistration><ram:ID schemeID="FC">33/023/05100</ram:ID></ram:SpecifiedTaxRegistration>');
+    expect(xml).toContain('<ram:ID>33/023/05100</ram:ID>');
+    expect(xml).not.toContain('schemeID="VA">');
+  });
+
+  it('xrechnung-cii (Kleinunternehmer): emits FC-scheme registration when only taxNumber is set', () => {
+    const xml = generateEInvoiceXml('xrechnung-cii', kleinTaxNumberInput);
+    expect(xml).toContain('<ram:ID schemeID="FC">33/023/05100</ram:ID>');
+    expect(xml).not.toContain('schemeID="VA">');
+  });
+
+  it('xrechnung-ubl (Kleinunternehmer): emits FC TaxScheme when only taxNumber is set', () => {
+    const xml = generateEInvoiceXml('xrechnung-ubl', kleinTaxNumberInput);
+    expect(xml).toMatch(/<cbc:CompanyID>33\/023\/05100<\/cbc:CompanyID>\s*<cac:TaxScheme><cbc:ID>FC<\/cbc:ID><\/cac:TaxScheme>/);
+  });
+
   it('xrechnung-ubl mappt BT-1/BT-2/BT-5/BT-9/BT-10/BT-31 + IBAN', () => {
     const xml = generateEInvoiceXml('xrechnung-ubl', baseInput);
     expect(xml).toContain('<cbc:ID>RE-2026-0001</cbc:ID>');

--- a/website/src/lib/einvoice-profile.ts
+++ b/website/src/lib/einvoice-profile.ts
@@ -24,6 +24,7 @@ function toZugferdNativeInput(p: EInvoiceInput): ZugferdNativeInput {
     seller: {
       name: p.seller.name, address: p.seller.address, postalCode: p.seller.postalCode,
       city: p.seller.city, country: p.seller.country, vatId: p.seller.vatId,
+      taxNumber: p.seller.taxNumber,
     },
   };
 }

--- a/website/src/lib/einvoice-types.ts
+++ b/website/src/lib/einvoice-types.ts
@@ -13,6 +13,10 @@ export interface EInvoiceSeller {
   country: string; vatId: string; iban?: string; bic?: string;
   email?: string;  // BT-34 / BG-6
   phone?: string;  // BG-6 contact
+  // BT-32 — German Steuernummer for Kleinunternehmer who have no VAT ID.
+  // Emitted as <SpecifiedTaxRegistration schemeID="FC"> (CII) /
+  // <PartyTaxScheme><TaxScheme><ID>FC</ID></TaxScheme> (UBL).
+  taxNumber?: string;
 }
 
 export interface EInvoiceLine {

--- a/website/src/lib/native-billing.ts
+++ b/website/src/lib/native-billing.ts
@@ -468,6 +468,7 @@ export async function getInvoiceForEInvoice(id: string): Promise<EInvoiceInput |
       city:       process.env.SELLER_CITY        || '',
       country:    process.env.SELLER_COUNTRY     || 'DE',
       vatId:      process.env.SELLER_VAT_ID      || '',
+      taxNumber:  process.env.SELLER_TAX_NUMBER  || undefined,
       iban:       process.env.SELLER_IBAN        || undefined,
       bic:        process.env.SELLER_BIC         || undefined,
       email:      process.env.SELLER_EMAIL       || undefined,

--- a/website/src/lib/website-db.ts
+++ b/website/src/lib/website-db.ts
@@ -3140,6 +3140,20 @@ async function initBillingAuditTable(): Promise<void> {
 }
 
 async function installInvoiceImmutabilityTriggers(): Promise<void> {
+  try {
+    await installInvoiceImmutabilityTriggersInner();
+  } catch (err) {
+    // 42501 = insufficient_privilege. Triggers/functions exist from a prior
+    // deploy under a different role (e.g. postgres superuser); current role
+    // can't replace them but they enforce the same invariants. Leaving them
+    // alone is correct — `initBillingTables` runs on every billing call so a
+    // hard error here would break the entire billing API in production.
+    if ((err as { code?: string } | null)?.code === '42501') return;
+    throw err;
+  }
+}
+
+async function installInvoiceImmutabilityTriggersInner(): Promise<void> {
   await pool.query(`
     CREATE OR REPLACE FUNCTION billing_invoices_immutable() RETURNS trigger AS $fn$
     BEGIN

--- a/website/src/lib/xrechnung-ubl.ts
+++ b/website/src/lib/xrechnung-ubl.ts
@@ -73,11 +73,15 @@ export function generateXRechnungUbl(p: EInvoiceInput): string {
         <cbc:PostalZone>${esc(p.seller.postalCode)}</cbc:PostalZone>
         <cac:Country><cbc:IdentificationCode>${esc(p.seller.country)}</cbc:IdentificationCode></cac:Country>
       </cac:PostalAddress>
-      <cac:PartyTaxScheme>
+${p.seller.vatId ? `      <cac:PartyTaxScheme>
         <cbc:CompanyID>${esc(p.seller.vatId)}</cbc:CompanyID>
         <cac:TaxScheme><cbc:ID>VAT</cbc:ID></cac:TaxScheme>
       </cac:PartyTaxScheme>
-      <cac:PartyLegalEntity>
+` : ''}${p.seller.taxNumber ? `      <cac:PartyTaxScheme>
+        <cbc:CompanyID>${esc(p.seller.taxNumber)}</cbc:CompanyID>
+        <cac:TaxScheme><cbc:ID>FC</cbc:ID></cac:TaxScheme>
+      </cac:PartyTaxScheme>
+` : ''}      <cac:PartyLegalEntity>
         <cbc:RegistrationName>${esc(p.seller.name)}</cbc:RegistrationName>
       </cac:PartyLegalEntity>
       <cac:Contact>

--- a/website/src/lib/zugferd.ts
+++ b/website/src/lib/zugferd.ts
@@ -18,7 +18,7 @@ export interface ZugferdNativeInput {
   invoice: { number: string; issueDate: string; grossAmount: number; netAmount: number; taxAmount: number; taxMode: string; taxRate: number };
   lines: Array<{ description: string; netAmount: number }>;
   customer: { name: string; email: string };
-  seller: { name: string; address: string; postalCode: string; city: string; country: string; vatId: string };
+  seller: { name: string; address: string; postalCode: string; city: string; country: string; vatId: string; taxNumber?: string };
 }
 
 export function generateZugferdXml(): string {
@@ -63,6 +63,7 @@ export function generateZugferdXmlFromNative(input: any): string {
       city: input.seller.city,
       country: input.seller.country,
       vatId: input.seller.vatId || undefined,
+      taxNumber: input.seller.taxNumber || undefined,
       contactEmail: 'contact@example.com',
       iban: 'DE12345678901234567890',
     },
@@ -162,7 +163,8 @@ export function generateXRechnungCii(p: EInvoiceInput): string {
   <rsm:SupplyChainTradeTransaction>${lineXml}
     <ram:ApplicableHeaderTradeAgreement>
       <ram:BuyerReference>${esc(p.customer.leitwegId)}</ram:BuyerReference>
-      <ram:SellerTradeParty>
+      <ram:SellerTradeParty>${!p.seller.vatId && p.seller.taxNumber ? `
+        <ram:ID>${esc(p.seller.taxNumber)}</ram:ID>` : ''}
         <ram:Name>${esc(p.seller.name)}</ram:Name>
         <ram:DefinedTradeContact>
           <ram:PersonName>${esc(p.seller.name)}</ram:PersonName>${p.seller.phone ? `
@@ -177,10 +179,13 @@ export function generateXRechnungCii(p: EInvoiceInput): string {
         </ram:PostalTradeAddress>
         <ram:URIUniversalCommunication>
           <ram:URIID schemeID="EM">${esc(p.seller.email)}</ram:URIID>
-        </ram:URIUniversalCommunication>
+        </ram:URIUniversalCommunication>${p.seller.vatId ? `
         <ram:SpecifiedTaxRegistration>
           <ram:ID schemeID="VA">${esc(p.seller.vatId)}</ram:ID>
-        </ram:SpecifiedTaxRegistration>
+        </ram:SpecifiedTaxRegistration>` : ''}${p.seller.taxNumber ? `
+        <ram:SpecifiedTaxRegistration>
+          <ram:ID schemeID="FC">${esc(p.seller.taxNumber)}</ram:ID>
+        </ram:SpecifiedTaxRegistration>` : ''}
       </ram:SellerTradeParty>
       <ram:BuyerTradeParty>
         <ram:Name>${esc(p.customer.name)}</ram:Name>


### PR DESCRIPTION
## Summary
Live verification of #524 against `web.mentolder.de` surfaced three pre-existing prod issues that meant the deployed Kleinunternehmer e-invoice path *still* failed Mustang. This closes all three so `factur-x-minimum` (the live default profile served by `/api/billing/invoice/[id]/zugferd`) is now `status="valid", Errors:[]` for the existing prod invoices.

## What was broken in prod (before this PR)
| Symptom | Root cause |
|---|---|
| `BR-CO-26` + `BR-E-02` on every Kleinunternehmer invoice | `EInvoiceInput.seller.taxNumber` did not exist — and even if it did, `generateZugferdXmlFromNative` / `toZugferdNativeInput` dropped it when mapping to `InvoiceInput`. So the FC-scheme support added in #524's `einvoice/cii.ts` never reached the live endpoint. |
| `ZodError: SELLER country must be exactly 2 characters` | `website-seller-config` had `SELLER_COUNTRY=Deutschland`. Generation threw before any XML was produced. |
| `42501 must be owner of function billing_invoices_immutable` on every billing call | Trigger functions on `shared-db` were owned by `postgres`, but `initBillingTables` runs `CREATE OR REPLACE FUNCTION` as `website`. Hard-failed the entire admin billing API. |

## Fix 1 — thread `taxNumber` through the live path
- `einvoice-types.ts`: add `taxNumber?: string` to `EInvoiceSeller` (BT-32).
- `einvoice-profile.ts:toZugferdNativeInput`: forward `taxNumber`.
- `zugferd.ts`:
  - Add `taxNumber?` to `ZugferdNativeInput.seller` and forward it in `generateZugferdXmlFromNative`.
  - In `generateXRechnungCii`, emit `<ram:SellerTradeParty/ram:ID>` and `<ram:SpecifiedTaxRegistration><ram:ID schemeID=\"FC\">` when only `taxNumber` is set (Kleinunternehmer fallback for `BR-CO-26`).
- `xrechnung-ubl.ts`: emit a second `<cac:PartyTaxScheme>` with `<cac:TaxScheme><cbc:ID>FC</cbc:ID></cac:TaxScheme>` for `BT-32`.
- `native-billing.ts:getInvoiceForEInvoice`: read `process.env.SELLER_TAX_NUMBER`.

## Fix 2 — `website-seller-config` ConfigMap
- `SELLER_COUNTRY: \"Deutschland\"` → `\"DE\"` (ISO 3166-1 alpha-2; required by EN 16931 schematron / `z.string().length(2)`).
- `SELLER_VAT_ID: \"33/023/05100\"` → `\"\"` (Kleinunternehmer §19 UStG has no USt-IdNr; the previous value was a Steuernummer mislabelled as a VAT ID and was emitted as `schemeID=\"VA\"`).
- `SELLER_TAX_NUMBER: \"33/023/05100\"` (new — now correctly emitted as `schemeID=\"FC\"` / `FC` TaxScheme).
- Wire `SELLER_TAX_NUMBER` env binding in `k3d/website.yaml`.

## Fix 3 — make `installInvoiceImmutabilityTriggers` permission-error resilient
Wrap the trigger/function installation in a `try/catch` that swallows `42501 insufficient_privilege`. The functions exist and enforce the same invariants — leaving them alone is correct, since `initBillingTables` runs on every billing call and a hard error here breaks the entire admin billing API. The existing functions on mentolder `shared-db` were also chowned to `website` so the next migration can replace them cleanly.

## Verification
- ✅ vitest: 22 passed, 0 failed (3 new `Kleinunternehmer + taxNumber` assertions cover all three profiles).
- ✅ `task billing:validate-einvoice` over the four committed fixtures: still `status=\"valid\", Errors:[]`.
- ✅ Mustang on a synthetic Kleinunternehmer-only-`taxNumber` sample through `generateEInvoiceXml('factur-x-minimum', …)`: 66 fired / 0 failed.
- ✅ **Live verification.** After applying the ConfigMap + `ALTER FUNCTION ... OWNER TO website` and re-applying `website.yaml` on both clusters, regenerated XML for the real prod invoice `RE-2026-0022` through the deployed pod's bundled `generateEInvoiceXml`. Mustang: `fired:66 failed:0, status=\"valid\", Errors:[]`.
- ✅ `getInvoiceForEInvoice` no longer hits 42501 — live in-pod call returns the populated `EInvoiceInput` with `taxNumber=33/023/05100`.

## Out of scope (logged for a future PR)
- XRechnung-3.0 (BR-DE-1, BR-DE-6) requires seller IBAN + phone. None of the existing prod customers have a `leitweg_id` so the XRechnung profiles aren't actually exercised today.
- UBL-flavoured Kleinunternehmer fails its own `BR-CO-26` because the schematron requires a `cac:PartyTaxScheme` with `VAT` scheme specifically (FC scheme alone doesn't satisfy it). Same as above — no Leitweg-IDs in DB, so not on the live path.

## Test plan
- [x] vitest unit suites
- [x] Mustang on fixtures
- [x] Mustang on synthetic Kleinunternehmer-only-taxNumber sample
- [x] Mustang on the regenerated live `RE-2026-0022` through the deployed pod
- [x] `getInvoiceForEInvoice` runs cleanly in the deployed pod

🤖 Generated with [Claude Code](https://claude.com/claude-code)