### PR TITLE
chore(taskfile,dashboard): drop historical tasks + split dashboard log

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -127,11 +127,6 @@ tasks:
       - npm install
       - PORT=3001 NO_AUTH=true node server.js
 
-  dashboard:bootstrap-korczewski:
-    desc: "One-shot: provision read-only SA on korczewski + seal kubeconfig into mentolder secrets"
-    cmds:
-      - bash scripts/dashboard-bootstrap-korczewski.sh
-
   # ─────────────────────────────────────────────
   # Cluster Lifecycle
   # ─────────────────────────────────────────────
@@ -973,33 +968,6 @@ tasks:
         kubectl $CTX rollout restart deployment/{{.CLI_ARGS}} -n "$NS"
         kubectl $CTX rollout status deployment/{{.CLI_ARGS}} -n "$NS" --timeout=120s
 
-  # NOTE: per-env shorthand tasks (korczewski:status / mentolder:logs / etc.)
-  # were dropped 2026-05-05 in favour of the ENV-parametrised versions:
-  #   task workspace:status  ENV=korczewski
-  #   task workspace:logs    ENV=mentolder -- nextcloud
-  #   task workspace:restart ENV=korczewski -- brett
-  # `korczewski:traefik:apply` and `korczewski:enroll-ha` survive because they
-  # run truly korczewski-specific bootstraps that don't generalise.
-
-  korczewski:traefik:apply:
-    desc: Apply (or re-apply) the Traefik ingress controller on korczewski (run once on bootstrap or after manifest changes)
-    cmds:
-      - |
-        # Remove finalizer from the stuck old Helm LoadBalancer service if still present
-        if kubectl --context korczewski get svc traefik -n kube-system -o jsonpath='{.metadata.finalizers}' 2>/dev/null | grep -q load-balancer-cleanup; then
-          echo "Removing stuck finalizer from old traefik LoadBalancer service..."
-          kubectl --context korczewski patch svc traefik -n kube-system -p '{"metadata":{"finalizers":[]}}' --type=merge
-        fi
-      - kubectl --context korczewski delete svc traefik-svc -n kube-system --ignore-not-found
-      - kubectl --context korczewski apply -f prod-korczewski/traefik.yaml
-      - kubectl --context korczewski rollout status deployment/traefik-manual -n kube-system --timeout=60s
-
-  # mentolder:status / mentolder:logs / mentolder:restart removed 2026-05-05.
-  # Use the ENV-parametrised tasks instead:
-  #   task workspace:status  ENV=mentolder
-  #   task workspace:logs    ENV=mentolder -- nextcloud
-  #   task workspace:restart ENV=mentolder -- nextcloud
-
   # ─────────────────────────────────────────────
   # Multi-Cluster Overview
   # ─────────────────────────────────────────────
@@ -1032,11 +1000,6 @@ tasks:
     desc: Bootstrap 3-node k3s HA cluster on Hetzner (run once)
     cmds:
       - ./scripts/setup-ha-cluster.sh
-
-  korczewski:enroll-ha:
-    desc: Convert korczewski to 3-node HA control-plane (pk-hetzner-2 + pk-hetzner-3)
-    cmds:
-      - ./scripts/enroll-korczewski-ha.sh
 
   ha:import-image:
     desc: "Build a local Docker image and import to all HA nodes (usage: task ha:import-image -- <path> <image:tag>)"
@@ -2366,32 +2329,6 @@ tasks:
   # ─────────────────────────────────────────────
   # Autonomous Browser Agent (Local LLM Reasoning)
   # ─────────────────────────────────────────────
-  browser-agent:init:
-    desc: Initialize local LLM for browser reasoning (GPT-OSS 20B)
-    cmds:
-      - docker exec -it ollama-gpu ollama pull mistral  # Using mistral as proxy for GPT-OSS 20B in demo
-      - echo "✓ LLM model pulled"
-
-  browser-agent:connect:
-    desc: Connect k3d cluster to local LLM and browser agent tools
-    cmds:
-      - |
-        LLM_IP=$(docker inspect ollama-gpu -f '{{ "{{" }}(index .NetworkSettings.Networks "k3d-dev").IPAddress{{ "}}" }}' 2>/dev/null)
-        if [ -z "$LLM_IP" ]; then
-          echo "ERROR: ollama-gpu not connected to k3d-dev network. Is it running?"
-          exit 1
-        fi
-        sed "s/__HOST_IP__/$LLM_IP/g" k3d/llm-gpu.yaml | kubectl apply -n workspace -f -
-      - kubectl apply -n workspace -f k3d/claude-code-mcp-browser.yaml
-      - echo "✓ Browser agent connectivity established"
-
-  browser-agent:status:
-    desc: Check status of browser agent components
-    cmds:
-      - kubectl get pods -n workspace -l app=mcp-browser
-      - docker exec -it ollama-gpu ollama list
-      - 'curl -sf http://localhost:11435/api/tags > /dev/null && echo "LLM Gateway: OK" || echo "LLM Gateway: DOWN"'
-
   # ─────────────────────────────────────────────
   # GPU Worker (External Whisper with NVIDIA CUDA)
   # ─────────────────────────────────────────────

--- a/dashboard/public/index.html
+++ b/dashboard/public/index.html
@@ -257,7 +257,8 @@
             transition: height 0.18s ease;
         }
         #terminal-pane.collapsed { height: 30px; }
-        #terminal-pane.collapsed #terminal { display: none; }
+        #terminal-pane.collapsed #terminal,
+        #terminal-pane.collapsed #issues-pane { display: none; }
         #terminal-header {
             display: flex; align-items: center; gap: 10px;
             padding: 6px 16px; background: var(--bg2); font-size: 11px;
@@ -265,6 +266,13 @@
             font-family: monospace; flex-shrink: 0;
             user-select: none;
         }
+        #issues-count {
+            background: var(--danger-dim); color: var(--error);
+            border: 1px solid var(--danger-border);
+            padding: 1px 7px; border-radius: 10px; font-size: 10px;
+            font-weight: 600; display: none;
+        }
+        #issues-count.visible { display: inline-block; }
         #term-spacer { flex: 1; }
         #term-toggle {
             background: var(--bg4); color: var(--text-dim); border: 1px solid var(--border);
@@ -272,6 +280,27 @@
             font-family: inherit;
         }
         #term-toggle:hover { background: var(--bg3); color: var(--text); }
+        /* Issues pane — only shown when something warning-or-worse appears */
+        #issues-pane {
+            display: none; flex-direction: column;
+            max-height: 35%; min-height: 60px;
+            background: #1a1010; border-bottom: 1px solid var(--danger-border);
+            flex-shrink: 0;
+        }
+        #issues-pane.visible { display: flex; }
+        .pane-label {
+            padding: 4px 16px; font-family: monospace; font-size: 10px;
+            color: var(--error); background: rgba(196,64,64,0.08);
+            text-transform: uppercase; letter-spacing: 0.05em;
+            border-bottom: 1px solid var(--danger-border);
+            user-select: none;
+        }
+        #issues {
+            flex: 1; padding: 10px 16px;
+            font-family: 'Consolas','Monaco','Courier New',monospace;
+            font-size: 12px; overflow-y: auto; white-space: pre-wrap;
+            word-break: break-all; line-height: 1.55;
+        }
         #terminal {
             flex: 1; background: #0e0e10; color: #e0e0e0;
             padding: 12px 16px; font-family: 'Consolas','Monaco','Courier New',monospace;
@@ -441,9 +470,14 @@
 <section id="terminal-pane">
     <div id="terminal-header">
         <span id="term-label">Output</span>
+        <span id="issues-count" title="Warnings and errors collected in the Issues pane">0</span>
         <span id="term-spacer"></span>
-        <button id="copy-log-btn" title="Copy log output to clipboard">⎘ Copy</button>
+        <button id="copy-log-btn" title="Copy combined log output to clipboard (issues + output, in original order)">⎘ Copy</button>
         <button id="term-toggle" title="Collapse/expand the terminal pane">▼ collapse</button>
+    </div>
+    <div id="issues-pane">
+        <div class="pane-label">⚠ Issues — warnings &amp; errors</div>
+        <div id="issues"></div>
     </div>
     <div id="terminal"></div>
 </section>
@@ -1374,12 +1408,34 @@
     document.addEventListener('keydown', (e) => { if (e.key === 'Escape') dismissModal(); });
 
     // ── Task execution ─────────────────────────────────────────────────────
-    const terminal  = document.getElementById('terminal');
-    const statusEl  = document.getElementById('status');
-    const stopBtn   = document.getElementById('stop-btn');
-    const termLabel = document.getElementById('term-label');
-    const socket    = io();
+    const terminal    = document.getElementById('terminal');
+    const issuesPane  = document.getElementById('issues-pane');
+    const issues      = document.getElementById('issues');
+    const issuesCount = document.getElementById('issues-count');
+    const statusEl    = document.getElementById('status');
+    const stopBtn     = document.getElementById('stop-btn');
+    const termLabel   = document.getElementById('term-label');
+    const socket      = io();
     let running = false;
+    let logSeq = 0;          // monotonic sequence so split panes can be re-ordered for copy
+    let issueCount = 0;
+
+    function bumpIssueCount() {
+        issueCount += 1;
+        issuesCount.textContent = String(issueCount);
+        issuesCount.classList.add('visible');
+        issuesPane.classList.add('visible');
+    }
+
+    function resetPanes() {
+        terminal.textContent = '';
+        issues.textContent = '';
+        issueCount = 0;
+        logSeq = 0;
+        issuesCount.textContent = '0';
+        issuesCount.classList.remove('visible');
+        issuesPane.classList.remove('visible');
+    }
 
     function setButtons(disabled) {
         document.querySelectorAll('.task-card:not(.dangerous), .run-btn, #dryrun-btn').forEach((el) => {
@@ -1416,14 +1472,22 @@
         if (chainGroupIndex >= 0) cancelChain('Chain stopped');
         socket.emit('stop-task');
     });
-    document.getElementById('clear-btn').addEventListener('click', () => { terminal.textContent = ''; });
+    document.getElementById('clear-btn').addEventListener('click', resetPanes);
 
     // ── Copy log to clipboard ──────────────────────────────────────────────
     const copyLogBtn = document.getElementById('copy-log-btn');
     let copyFeedbackTimer = null;
 
     copyLogBtn.addEventListener('click', () => {
-        const text = [...terminal.querySelectorAll('span')].map((s) => s.textContent).join('');
+        // Combine spans from both panes and re-order by sequence so the copied
+        // transcript reads chronologically even though warnings/errors live in
+        // the separate Issues pane.
+        const spans = [
+            ...terminal.querySelectorAll('span[data-seq]'),
+            ...issues.querySelectorAll('span[data-seq]'),
+        ];
+        spans.sort((a, b) => Number(a.dataset.seq) - Number(b.dataset.seq));
+        const text = spans.map((s) => s.textContent).join('');
         if (!text) return;
         navigator.clipboard.writeText(text).then(() => {
             copyLogBtn.textContent = '✓ Copied';
@@ -1512,8 +1576,15 @@
         }
         span.className = cls;
         span.textContent = data;
-        terminal.appendChild(span);
-        terminal.scrollTop = terminal.scrollHeight;
+        span.dataset.seq = String(logSeq++);
+        if (cls === 'error' || cls === 'warning') {
+            issues.appendChild(span);
+            issues.scrollTop = issues.scrollHeight;
+            bumpIssueCount();
+        } else {
+            terminal.appendChild(span);
+            terminal.scrollTop = terminal.scrollHeight;
+        }
     });
 
     socket.on('task-finished', ({ code }) => {


### PR DESCRIPTION
## Summary
- Remove stale Taskfile entries that no longer have a working target (post-cluster-merge or orphaned demos).
- Split the local task-runner dashboard log into a top **Issues** pane (warnings + errors) and a bottom **Output** pane (everything else).

## What's removed
| Task | Why it's stale |
| --- | --- |
| `dashboard:bootstrap-korczewski` | Bootstrap path for a SA on the now-merged korczewski cluster; live path is the `cluster-korczewski` ArgoCD secret. |
| `korczewski:traefik:apply` | Traefik on mentolder Hetzner serves both domains since the 2026-05-05 cluster merge — there's no separate korczewski cluster to apply this to. |
| `korczewski:enroll-ha` | One-shot HA conversion of the disbanded korczewski cluster. |
| `browser-agent:init` / `connect` / `status` | Orphaned demo (PR #482) using `mistral` "as proxy for GPT-OSS 20B"; dev-only, undocumented, dashboard never exposed it. |
| Two tombstone `# *removed 2026-05-05*` comment blocks | Pure noise now that they've been gone for several PR cycles. |

The matching helper scripts (`scripts/dashboard-bootstrap-korczewski.sh`, `scripts/enroll-korczewski-ha.sh`, `scripts/setup-ha-cluster.sh`) are kept as bootstrap paper trail — git history references them via the spec docs.

## Dashboard log split
The single `#terminal` pane becomes two stacked panes inside `#terminal-pane`:

- **Issues** (top, hidden until populated, capped at 35% height) — only receives lines whose classifier resolves to `warning` or `error`.
- **Output** (bottom) — receives `stdout` / `stderr` (non-warning) / `info` / `success`.

Each line is appended to **exactly one** pane (split mode, not mirror). To keep `⎘ Copy` chronological, every span gets a monotonic `data-seq` attribute and the copy handler re-orders spans from both panes before joining. The header gains a small badge showing the issue count.

## Test plan
- [x] `node --check` on the inline dashboard script
- [x] `node --check dashboard/server.js`
- [x] `task workspace:validate` (kustomize manifests still build)
- [x] `task --list-all` no longer surfaces the removed tasks
- [x] Dashboard served locally — Issues pane hidden by default, badge hidden when count is 0
- [ ] Trigger a task that emits warnings (e.g. `workspace:validate`) and confirm warning lines route to the Issues pane while normal stdout stays in Output
- [ ] Confirm `⎘ Copy` produces a chronological transcript when both panes have content

🤖 Generated with [Claude Code](https://claude.com/claude-code)