### PR TITLE
feat(website): add KI-Transition Coaching service to mentolder

### DIFF
--- a/website/src/config/brands/mentolder.ts
+++ b/website/src/config/brands/mentolder.ts
@@ -241,6 +241,76 @@ export const mentolderConfig: BrandConfig = {
         faq: [],
       },
     },
+    {
+      slug: 'ki-transition',
+      title: 'KI-Transition Coaching',
+      description: 'Orientierung im digitalen Wandel. Für IT-Fachkräfte, Führungskräfte und Unternehmen, die sich neu ausrichten wollen, wenn KI Berufsbilder verändert.',
+      icon: '🤖',
+      features: [
+        'Standortbestimmung & Kompetenz-Analyse',
+        'Strukturierter Unlearning-Prozess',
+        'Neuorientierung & Strategie für die KI-Zukunft',
+        'Team-Workshops & Change-Begleitung',
+      ],
+      price: 'Ab 150 € / Session',
+      stripeServiceKey: 'coaching-session',
+      pageContent: {
+        headline: 'Wenn das Vertraute geht – und das Neue wartet.',
+        intro: 'Mehr Software entsteht durch KI. Weniger durch Menschen. Das verändert Berufsbilder schneller als je zuvor – in der IT, im Management, in der Verwaltung. Ich begleite Sie und Ihr Team beim bewussten Loslassen und beim mutigen Schritt in die neue Arbeitswelt.',
+        forWhom: [
+          'Sie in der IT arbeiten und merken, dass KI Ihre bisherigen Aufgaben übernimmt',
+          'Sie als Führungskraft Ihr Team durch den KI-Wandel führen möchten',
+          'Sie sich neu orientieren und nicht wissen, wo Sie anfangen sollen',
+          'Ihr Unternehmen KI einführen will, aber die Mitarbeiter noch nicht mitgehen',
+          'Sie Altes loslassen möchten, aber nicht wissen, wie',
+          'Sie eine klare Strategie für Ihre persönliche oder unternehmerische KI-Zukunft suchen',
+        ],
+        sections: [
+          {
+            title: 'Standortbestimmung',
+            items: [
+              'Analyse Ihrer aktuellen Fähigkeiten & Rolle',
+              'Welche Kompetenzen bleiben wertvoll?',
+              'Wo liegen blinde Flecken?',
+              'Persönliche KI-Readiness einschätzen',
+            ],
+          },
+          {
+            title: 'Unlearning-Prozess',
+            items: [
+              'Alte Denk- und Arbeitsmuster erkennen',
+              'Bewusst loslassen – strukturiert & begleitet',
+              'Psychologische Widerstände verstehen',
+              'Raum schaffen für Neues',
+            ],
+          },
+          {
+            title: 'Neuorientierung & Strategie',
+            items: [
+              'Neue Rollen & Kompetenzfelder identifizieren',
+              'Persönliche Lernstrategie entwickeln',
+              'KI als Werkzeug – nicht als Bedrohung',
+              'Konkrete nächste Schritte definieren',
+            ],
+          },
+          {
+            title: 'Für Unternehmen',
+            items: [
+              'Team-Workshops: KI-Readiness',
+              'Change-Begleitung im Transformationsprozess',
+              'Führungskräfte-Sparring zum Thema KI',
+              'Nachhaltige Lernkultur aufbauen',
+            ],
+          },
+        ],
+        pricing: [
+          { label: 'Einzelsession (90 Min.)', price: '150 €', unit: 'pro Session' },
+          { label: 'Paket 6 Sessions', price: '800 €', unit: 'statt 900 €', highlight: true },
+          { label: 'Unternehmen & Teams', price: 'auf Anfrage', unit: 'ab 5 Personen möglich' },
+        ],
+        faq: [],
+      },
+    },
   ],
   leistungen: [
     {

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -45,6 +45,7 @@ const serviceMeta: Record<string, string> = {
   'digital-cafe': 'Einzeln · Gruppe · Pakete',
   'coaching': 'Sparring auf Augenhöhe',
   'beratung': 'Mittelstand · Verwaltung',
+  'ki-transition': 'Unlearning · Neuorientierung · Strategie',
   'ki-beratung': 'Strategie · Tool-Auswahl · Compliance',
   'software-dev': 'Architektur · Review · Umsetzung',
   'deployment': 'K8s · GitOps · Self-Hosted',


### PR DESCRIPTION
## Summary
New service tile + dedicated page on mentolder for IT specialists, leadership, and organisations navigating the AI-driven shift in roles.

- New `ki-transition` slug in `mentolder.ts` with full \`pageContent\` (headline, intro, forWhom, four sections, pricing, faq).
- Pricing: 150 € / 90-min session, 800 € / 6-session package (highlighted), on-request for teams ≥5.
- Reuses the existing `coaching-session` Stripe service key.
- Adds the \`ki-transition\` row to the homepage service-meta map so the tile renders \"Unlearning · Neuorientierung · Strategie\" on `web.mentolder.de`.
- mentolder-only — korczewski's brand config is unchanged.

## Test plan
- [x] Astro dev build picks up the new service (\`task website:dev\`)
- [ ] Live verification on `https://web.mentolder.de` after `task feature:website`
- [ ] Stripe checkout still resolves \`coaching-session\` for the new tile

🤖 Generated with [Claude Code](https://claude.com/claude-code)