### PR TITLE
fix(coturn): migrate AppArmor to securityContext.appArmorProfile

### DIFF
--- a/k3d/coturn-stack/coturn.yaml
+++ b/k3d/coturn-stack/coturn.yaml
@@ -27,8 +27,6 @@ spec:
     metadata:
       labels:
         app: coturn
-      annotations:
-        container.apparmor.security.beta.kubernetes.io/coturn: unconfined
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
@@ -71,6 +69,8 @@ spec:
                   key: TURN_SECRET
           securityContext:
             runAsUser: 0
+            appArmorProfile:
+              type: Unconfined
             capabilities:
               add:
                 - NET_ADMIN


### PR DESCRIPTION
## Summary
- Replaces deprecated pod-level annotation `container.apparmor.security.beta.kubernetes.io/coturn: unconfined` with the stable k8s 1.30+ container field `securityContext.appArmorProfile.type: Unconfined`
- Eliminates the deprecation warning that appeared on every ArgoCD sync / kubectl apply

## Test plan
- [ ] ArgoCD syncs coturn without deprecation warning
- [ ] coturn pod starts healthy (`kubectl get pod -n coturn`)
- [ ] TURN connectivity still works (Nextcloud Talk media relay)

🤖 Generated with [Claude Code](https://claude.com/claude-code)