### PR TITLE
fix(korczewski): allow website-korczewski→keycloak ingress + brand 404 page

### DIFF
--- a/prod-korczewski/netpol-cross-namespace.yaml
+++ b/prod-korczewski/netpol-cross-namespace.yaml
@@ -58,3 +58,24 @@ spec:
       ports:
         - port: 5432
           protocol: TCP
+---
+# keycloak: allow ingress from website-korczewski so the auth callback can
+# exchange the OIDC code for tokens via the internal service URL.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-website-korczewski-to-keycloak-ingress
+spec:
+  podSelector:
+    matchLabels:
+      app: keycloak
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: website-korczewski
+      ports:
+        - port: 8080
+          protocol: TCP

--- a/website/src/pages/404.astro
+++ b/website/src/pages/404.astro
@@ -1,8 +1,10 @@
 ---
 import Layout from '../layouts/Layout.astro';
+const BRAND_ID = process.env.BRAND_ID ?? process.env.BRAND ?? 'mentolder';
+const brand = BRAND_ID === 'korczewski' ? 'korczewski-kore' : undefined;
 ---
 
-<Layout title="Wartungsarbeiten">
+<Layout title="Wartungsarbeiten" brand={brand}>
   <section class="pt-28 pb-24">
     <div class="max-w-2xl mx-auto px-6 text-center">
       <p style="font-family:var(--mono); font-size:12px; letter-spacing:0.22em; text-transform:uppercase; color:var(--brass); margin:0 0 24px;">


### PR DESCRIPTION
## Summary

- **NetworkPolicy gap (root cause of /404 redirect)**: `workspace-korczewski` had `default-deny-ingress` with no rule allowing traffic from `website-korczewski`. When a user logs in, Keycloak redirects to `/api/auth/callback`, which calls Keycloak internally to exchange the OIDC code for tokens — that fetch failed with `ECONNREFUSED`, Astro's router caught the unhandled error and served the 404 page. Added `allow-website-korczewski-to-keycloak-ingress` NetworkPolicy (port 8080 from `website-korczewski` namespace) to `prod-korczewski/netpol-cross-namespace.yaml`. Applied live immediately; verified the website pod can now reach Keycloak.

- **404 page brand styling**: `404.astro` rendered `<Layout>` without `brand="korczewski-kore"`, so it used mentolder's CSS (wrong colors, wrong typography). Now reads `BRAND`/`BRAND_ID` env at render time and passes the correct brand prop.

## Test plan

- [x] NetworkPolicy applied live — `wget` from website pod to `keycloak.workspace-korczewski.svc.cluster.local:8080` returns 200
- [x] Website redeployed with updated 404 page brand fix
- [ ] Full login flow: visit `web.korczewski.de` → click Anmelden → Keycloak → callback succeeds → lands on portal
- [ ] Visit `web.korczewski.de/404` directly — should render with Kore dark theme, not mentolder styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)