### PR TITLE
fix(auto): pin curlimages/curl:latest to 8.7.1 in dunning-detection cronjob

### DIFF
--- a/k3d/cronjob-dunning-detection.yaml
+++ b/k3d/cronjob-dunning-detection.yaml
@@ -12,7 +12,7 @@ spec:
         spec:
           containers:
           - name: detector
-            image: curlimages/curl:latest
+            image: curlimages/curl:8.7.1
             command:
             - /bin/sh
             - -c


### PR DESCRIPTION
## Summary

Automated maintenance pass (2026-05-06) found one fixable image-pin issue:

- `k3d/cronjob-dunning-detection.yaml` used `curlimages/curl:latest` while the two sibling CronJobs (`notify-unread-cronjob.yaml`, `cronjob-monthly-billing.yaml`) already pin `curlimages/curl:8.7.1`. Aligned to match.

Closes #532 (partially — the `einvoice-sidecar:latest` and missing `resources.requests` items in that issue still need manual attention).

## Test plan

- [x] `grep -n 'image:' k3d/cronjob-dunning-detection.yaml` confirms `8.7.1`
- [x] All curl CronJobs in `k3d/` now use the same pinned tag
- [ ] CI kustomize build passes (covered by `test:manifests` bats suite)

https://claude.ai/code/session_01Mmgn1ZcqpJEKYbXnGXLTo7

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mmgn1ZcqpJEKYbXnGXLTo7)_