### PR TITLE
fix(network): allow workspace cronjobs egress to website:4321

### DIFF
--- a/k3d/network-policies.yaml
+++ b/k3d/network-policies.yaml
@@ -127,6 +127,27 @@ spec:
           operator: In
           values: ["website", "website-korczewski"]
 ---
+# workspace CronJobs → website API (billing, notify-unread)
+# Uses ipBlock for service CIDR (ClusterIP before DNAT) and pod CIDR (post-DNAT).
+# Short-lived CronJob pods have no stable label, so podSelector: {} (all workspace pods).
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-cronjobs-to-website-egress
+spec:
+  podSelector: {}
+  policyTypes:
+  - Egress
+  egress:
+  - to:
+    - ipBlock:
+        cidr: 10.43.0.0/16   # service CIDR (ClusterIP before DNAT)
+    - ipBlock:
+        cidr: 10.42.0.0/16   # pod CIDR (after DNAT)
+    ports:
+    - port: 4321
+      protocol: TCP
+---
 # talk-transcriber → website-Namespace (save-transcript API)
 # Uses ipBlock for the service CIDR (10.43.0.0/16) because namespaceSelector
 # alone doesn't match ClusterIP traffic before DNAT.


### PR DESCRIPTION
## Summary
- Adds `allow-cronjobs-to-website-egress` NetworkPolicy in the workspace namespace
- Fixes `workspace → website:4321 (cronjob API)` post-deploy verification check
- `notify-unread` and `monthly-billing` CronJobs couldn't reach `website.website.svc.cluster.local:4321` because `allow-internet-egress` blocks all private CIDRs (10.0.0.0/8) and no policy covered port 4321

## Test plan
- [ ] `task workspace:deploy ENV=mentolder` applies cleanly
- [ ] `scripts/verify-deployment.sh ENV=mentolder` — `workspace → website:4321 (cronjob API)` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)