### PR TITLE
fix(network): fix cronjob→website port (4321→80) + allow both ports in netpol

### DIFF
--- a/k3d/cronjob-monthly-billing.yaml
+++ b/k3d/cronjob-monthly-billing.yaml
@@ -34,7 +34,7 @@ spec:
                   curl -sf -X POST \
                     -H "Content-Type: application/json" \
                     -H "X-Cron-Secret: $CRON_SECRET" \
-                    http://website.website.svc.cluster.local:4321/api/admin/billing/create-monthly-invoices
+                    http://website.website.svc.cluster.local/api/admin/billing/create-monthly-invoices
               env:
                 - name: CRON_SECRET
                   valueFrom:

--- a/k3d/network-policies.yaml
+++ b/k3d/network-policies.yaml
@@ -145,6 +145,8 @@ spec:
     - ipBlock:
         cidr: 10.42.0.0/16   # pod CIDR (after DNAT)
     ports:
+    - port: 80
+      protocol: TCP
     - port: 4321
       protocol: TCP
 ---

--- a/k3d/notify-unread-cronjob.yaml
+++ b/k3d/notify-unread-cronjob.yaml
@@ -32,7 +32,7 @@ spec:
                   curl -sf -X POST \
                     -H "Authorization: Bearer $CRON_SECRET" \
                     -H "Content-Type: application/json" \
-                    http://website.website.svc.cluster.local:4321/api/cron/notify-unread
+                    http://website.website.svc.cluster.local/api/cron/notify-unread
               env:
                 - name: CRON_SECRET
                   valueFrom:

--- a/scripts/verify-deployment.sh
+++ b/scripts/verify-deployment.sh
@@ -146,9 +146,9 @@ if [[ "$ENV" != "dev" ]]; then
 
   # workspace cronjobs → website API (billing, notify-unread, monthly-billing)
   _http_probe \
-    "${NS} → website:4321 (cronjob API)" \
+    "${NS} → website:80 (cronjob API)" \
     "$NS" "nextcloud" \
-    "http://website.${WEB_NS}.svc.cluster.local:4321/"
+    "http://website.${WEB_NS}.svc.cluster.local/"
 
   # workspace → shared-db:5432
   _tcp_probe \


### PR DESCRIPTION
## Summary
- CronJob URLs were calling `website.website.svc.cluster.local:4321` directly on the ClusterIP — but the website Service only exposes port 80 (targetPort 4321), so kube-proxy has no DNAT rule for port 4321 → every connection timed out
- Drops `:4321` from both cronjob URLs (notify-unread, monthly-billing) so they hit the service on port 80
- Updates `allow-cronjobs-to-website-egress` NetworkPolicy to allow both port 80 (service port, pre-DNAT) and 4321 (pod port, post-DNAT), matching the existing `allow-transcriber-to-website-egress` pattern
- Fixes verify-deployment.sh probe to check port 80 instead of 4321

## Test plan
- [ ] `task workspace:deploy ENV=mentolder` applies cleanly
- [ ] `scripts/verify-deployment.sh ENV=mentolder` — `workspace → website:80 (cronjob API)` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)