### PR TITLE
fix(maint): pin einvoice-sidecar digest + resource requests on init/CronJob containers

### DIFF
--- a/k3d/cronjob-dunning-detection.yaml
+++ b/k3d/cronjob-dunning-detection.yaml
@@ -17,6 +17,12 @@ spec:
             - /bin/sh
             - -c
             - "curl -s -X POST http://website.workspace.svc.cluster.local/api/admin/billing/dunning/run -H \"X-Cron-Secret: ${CRON_SECRET}\" || exit 1"
+            resources:
+              requests:
+                cpu: 10m
+                memory: 32Mi
+              limits:
+                memory: 64Mi
             env:
             - name: CRON_SECRET
               valueFrom:

--- a/k3d/cronjob-monthly-billing.yaml
+++ b/k3d/cronjob-monthly-billing.yaml
@@ -35,6 +35,12 @@ spec:
                     -H "Content-Type: application/json" \
                     -H "X-Cron-Secret: $CRON_SECRET" \
                     http://website.website.svc.cluster.local/api/admin/billing/create-monthly-invoices
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 32Mi
+                limits:
+                  memory: 64Mi
               env:
                 - name: CRON_SECRET
                   valueFrom:

--- a/k3d/einvoice-sidecar.yaml
+++ b/k3d/einvoice-sidecar.yaml
@@ -24,8 +24,7 @@ spec:
         - name: ghcr-pull-secret
       containers:
         - name: sidecar
-          image: ghcr.io/paddione/einvoice-sidecar:latest
-          imagePullPolicy: Always
+          image: ghcr.io/paddione/einvoice-sidecar@sha256:f346809b82c625f5f55c7b8be6c5d0be35ccce414015201ceaa293c6ea58156f
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/k3d/nextcloud.yaml
+++ b/k3d/nextcloud.yaml
@@ -62,6 +62,12 @@ spec:
             - |
               chown 33:33 /var/www/html/data
               chmod 0770 /var/www/html/data
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 64Mi
           volumeMounts:
             - name: data
               mountPath: /var/www/html/data
@@ -75,6 +81,12 @@ spec:
             capabilities:
               drop: ["ALL"]
           command: ["sh", "-c", "mkdir -p /var/www/html/config"]
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 64Mi
           volumeMounts:
             - name: app
               mountPath: /var/www/html
@@ -88,6 +100,12 @@ spec:
             capabilities:
               drop: ["ALL"]
           command: ["sh", "-c", "cp -r /usr/local/etc/php/conf.d/. /php-conf-d/"]
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 64Mi
           volumeMounts:
             - name: php-conf-d
               mountPath: /php-conf-d

--- a/k3d/notify-unread-cronjob.yaml
+++ b/k3d/notify-unread-cronjob.yaml
@@ -33,6 +33,12 @@ spec:
                     -H "Authorization: Bearer $CRON_SECRET" \
                     -H "Content-Type: application/json" \
                     http://website.website.svc.cluster.local/api/cron/notify-unread
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 32Mi
+                limits:
+                  memory: 64Mi
               env:
                 - name: CRON_SECRET
                   valueFrom:

--- a/k3d/oauth2-proxy-brett.yaml
+++ b/k3d/oauth2-proxy-brett.yaml
@@ -36,6 +36,12 @@ spec:
             runAsUser: 65534
             capabilities:
               drop: ["ALL"]
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 64Mi
           env:
             - name: OAUTH2_PROXY_COOKIE_SECRET
               valueFrom:

--- a/k3d/oauth2-proxy-docs.yaml
+++ b/k3d/oauth2-proxy-docs.yaml
@@ -39,6 +39,12 @@ spec:
             runAsUser: 65534
             capabilities:
               drop: ["ALL"]
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 64Mi
           env:
             - name: OAUTH2_PROXY_COOKIE_SECRET
               valueFrom:

--- a/k3d/oauth2-proxy-mailpit.yaml
+++ b/k3d/oauth2-proxy-mailpit.yaml
@@ -47,6 +47,12 @@ spec:
             runAsUser: 65534
             capabilities:
               drop: ["ALL"]
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 64Mi
           env:
             - name: OAUTH2_PROXY_COOKIE_SECRET
               valueFrom:

--- a/k3d/oauth2-proxy-traefik.yaml
+++ b/k3d/oauth2-proxy-traefik.yaml
@@ -48,6 +48,12 @@ spec:
             runAsUser: 65534
             capabilities:
               drop: ["ALL"]
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 64Mi
           env:
             - name: OAUTH2_PROXY_COOKIE_SECRET
               valueFrom:

--- a/k3d/shared-db.yaml
+++ b/k3d/shared-db.yaml
@@ -119,6 +119,12 @@ spec:
               chmod 600 /etc/postgresql/certs/server.key
               chmod 644 /etc/postgresql/certs/server.crt
               echo "PostgreSQL TLS-Zertifikat generiert"
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 64Mi
           volumeMounts:
             - name: tls-certs
               mountPath: /etc/postgresql/certs

--- a/k3d/talk-hpb.yaml
+++ b/k3d/talk-hpb.yaml
@@ -178,6 +178,12 @@ spec:
                 -e "s|@@CLIENTS_INTERNALSECRET@@|${CLIENTS_INTERNALSECRET}|g" \
                 -e "s|@@TURN_APIKEY@@|${TURN_APIKEY}|g" \
                 /tpl/server.conf.template > /shared/server.conf
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 64Mi
           env:
             - name: SIGNALING_SECRET
               valueFrom:

--- a/k3d/tracking-import-cronjob.yaml
+++ b/k3d/tracking-import-cronjob.yaml
@@ -18,6 +18,12 @@ spec:
           containers:
             - name: importer
               image: node:20-alpine
+              resources:
+                requests:
+                  cpu: 50m
+                  memory: 128Mi
+                limits:
+                  memory: 256Mi
               env:
                 - name: TRACKING_DB_URL
                   valueFrom:


### PR DESCRIPTION
## Summary

Clears the remaining two findings from #532:

- **`einvoice-sidecar:latest`** → pinned to `@sha256:f346809b…` (only tag in GHCR is `latest`; digest removes the implicit `imagePullPolicy: Always` and makes the image reproducible)
- **13 init/CronJob containers with no `resources.requests`** → `BestEffort` → `Burstable`:
  - `Deployment/nextcloud` — `fix-data-perms`, `fix-config-perms`, `copy-php-conf` (10m/32Mi, limit 64Mi)
  - `Deployment/oauth2-proxy-{brett,docs,mailpit,traefik}` — `write-cookie-secret` (10m/32Mi, limit 64Mi)
  - `Deployment/shared-db` — `generate-tls-cert` (10m/32Mi, limit 64Mi)
  - `Deployment/spreed-signaling` — `render-config` (10m/32Mi, limit 64Mi)
  - `CronJob/{billing-dunning-detection,monthly-billing,notify-unread}` — curl containers (10m/32Mi, limit 64Mi)
  - `CronJob/tracking-import` — `importer` (50m/128Mi, limit 256Mi — git clone + npm + Node.js)

## Test plan

- [x] `task workspace:validate` passes
- [x] All 12 modified files diff-reviewed
- [ ] CI kustomize build green

Closes #532

🤖 Generated with [Claude Code](https://claude.com/claude-code)