### PR TITLE
fix(kore): make KoreSubNav + KoreHero auth-aware, redirect to /portal after login

### DIFF
--- a/website/src/components/kore/KoreHero.svelte
+++ b/website/src/components/kore/KoreHero.svelte
@@ -4,6 +4,7 @@
   type Stats = { nodes: number; pods: number; brands: number };
   let stats: Stats | null = null;
   let pollInterval: number | undefined;
+  let loggedIn = $state(false);
 
   async function fetchStats() {
     try {
@@ -17,6 +18,10 @@
   onMount(() => {
     fetchStats();
     pollInterval = window.setInterval(fetchStats, 30_000);
+    fetch('/api/auth/me')
+      .then((r) => r.json())
+      .then((d) => { if (d.authenticated) loggedIn = true; })
+      .catch(() => {});
     return () => clearInterval(pollInterval);
   });
 </script>
@@ -41,7 +46,11 @@
   </p>
 
   <div class="cta-row">
-    <a class="btn primary" href="/api/auth/login">Anmelden →</a>
+    {#if loggedIn}
+      <a class="btn primary" href="/portal">Portal →</a>
+    {:else}
+      <a class="btn primary" href="/api/auth/login?returnTo=/portal">Anmelden →</a>
+    {/if}
     <a class="btn ghost" href="#timeline">Notizen lesen</a>
   </div>
 

--- a/website/src/components/kore/KoreSubNav.astro
+++ b/website/src/components/kore/KoreSubNav.astro
@@ -1,5 +1,8 @@
 ---
+import { getSession } from '../../lib/auth';
+
 const { active = 'work' } = Astro.props as { active?: string };
+const session = await getSession(Astro.request.headers.get('cookie'));
 const links = [
   { id: 'work',     label: 'Cluster' },
   { id: 'services', label: 'Leistungen' },
@@ -23,6 +26,10 @@ const links = [
   </div>
   <div class="actions">
     <a class="btn ghost sm" href="#timeline">Notizen</a>
-    <a class="btn primary sm" href="/api/auth/login">Anmelden →</a>
+    {session ? (
+      <a class="btn primary sm" href="/portal">Portal →</a>
+    ) : (
+      <a class="btn primary sm" href="/api/auth/login?returnTo=/portal">Anmelden →</a>
+    )}
   </div>
 </nav>


### PR DESCRIPTION
## Summary

- **Root cause:** The OIDC/SSO flow was working correctly end-to-end. The problem was purely UX — `KoreSubNav.astro` and `KoreHero.svelte` showed \"Anmelden →\" unconditionally with no `returnTo`, so after a successful login the user was sent back to the homepage which looked identical to the logged-out state.
- `KoreSubNav.astro`: now calls `getSession()` server-side; shows **\"Portal →\"** when logged in, \"Anmelden →\" with `returnTo=/portal` when not
- `KoreHero.svelte`: now fetches `/api/auth/me` client-side on mount and swaps the CTA to **\"Portal →\"** when authenticated

## Test plan

- [ ] Navigate to `web.korczewski.de` while logged out → see \"Anmelden →\" in nav and hero
- [ ] Click \"Anmelden →\" → Keycloak login → land on `/portal` (not homepage)
- [ ] Navigate back to `web.korczewski.de` while logged in → nav shows \"Portal →\", hero updates to \"Portal →\" after mount
- [ ] Mentolder (`web.mentolder.de`) unaffected — its `Navigation.svelte` was already auth-aware

🤖 Generated with [Claude Code](https://claude.com/claude-code)