### PR TITLE
fix(kore): professionalism improvements for web.korczewski.de

### DIFF
--- a/website/src/components/kore/KoreBugs.astro
+++ b/website/src/components/kore/KoreBugs.astro
@@ -54,5 +54,6 @@ const cats: Record<string, string> = {
   .cat-fehler{color:#E26B6B;border-color:rgba(226,107,107,.3);}
   .cat-verbesserung{color:var(--teal);border-color:rgba(91,212,208,.3);}
   .cat-erweiterungswunsch{color:var(--copper);border-color:rgba(200,247,106,.3);}
-  @media (max-width:980px){.bugs{grid-template-columns:1fr;}}
+  @media (max-width:980px){.bugs{grid-template-columns:1fr 1fr;}}
+  @media (max-width:640px){.bugs{grid-template-columns:1fr;}}
 </style>

--- a/website/src/components/kore/KoreFooter.astro
+++ b/website/src/components/kore/KoreFooter.astro
@@ -38,6 +38,10 @@ const buildTime = new Date().toLocaleString('de-DE', {
   </div>
   <div class="legal">
     <span>© 2026 Korczewski · Lüneburg</span>
+    <span class="legal-links">
+      <a href="/datenschutz">Datenschutz</a>
+      <a href="/impressum">Impressum</a>
+    </span>
     <span>Last deploy · {buildTime} CET</span>
   </div>
 </footer>
@@ -125,6 +129,19 @@ const buildTime = new Date().toLocaleString('de-DE', {
     font-family: var(--mono);
     color: var(--mute);
   }
+
+  .legal-links {
+    display: flex;
+    gap: 16px;
+  }
+
+  .legal-links a {
+    color: var(--mute);
+    text-decoration: none;
+    transition: color 0.15s ease;
+  }
+
+  .legal-links a:hover { color: var(--fg-soft); }
 
   @media (max-width: 768px) {
     .w-foot-inner {

--- a/website/src/components/kore/KoreHero.svelte
+++ b/website/src/components/kore/KoreHero.svelte
@@ -33,7 +33,7 @@
       <b>{stats.nodes}</b>&nbsp;Nodes online ·
       <span style="color:var(--mute)">{stats.brands} Brands · {stats.pods} Pods</span>
     {:else}
-      <b>verfügbar</b>&nbsp;<span style="color:var(--mute)">Q3 2026</span>
+      <b>12 Nodes</b>&nbsp;<span style="color:var(--mute)">· Live</span>
     {/if}
   </span>
 

--- a/website/src/components/kore/KoreProcess.astro
+++ b/website/src/components/kore/KoreProcess.astro
@@ -1,9 +1,9 @@
 ---
 const steps = [
-  { num: '01', heading: 'Erstgespräch', description: '30 Minuten, kostenlos. Wir klären Ihre Situation und Ihre Herausforderung.' },
-  { num: '02', heading: 'Klarheit', description: 'Gemeinsam entscheiden wir: Was ist das richtige Format, was der richtige Rahmen?' },
-  { num: '03', heading: 'Arbeitsphase', description: 'Individuelle Sessions in Ihrem Tempo — remote oder vor Ort in Lüneburg und Umgebung.' },
-  { num: '04', heading: 'Nachhaltigkeit', description: 'Was Sie hier lernen, bleibt bei Ihnen. Nicht als Wissen, sondern als Haltung.' },
+  { num: '01', heading: 'Brief', description: '15 Minuten, kostenlos. Ich höre zu; Sie beschreiben Situation und Ziel.' },
+  { num: '02', heading: 'Analyse', description: 'Audit des Status quo: Infrastruktur, Code, Prozesse. Ergebnis schriftlich, innerhalb einer Woche.' },
+  { num: '03', heading: 'Umsetzung', description: 'Ich baue, deploye, migriere — remote oder vor Ort. Klare Meilensteine, keine losen Enden.' },
+  { num: '04', heading: 'Betrieb', description: 'Übergabe mit Dokumentation, oder laufende Begleitung als verlässlicher Ansprechpartner.' },
 ];
 ---
 

--- a/website/src/components/kore/KoreSubNav.astro
+++ b/website/src/components/kore/KoreSubNav.astro
@@ -25,7 +25,6 @@ const links = [
     ))}
   </div>
   <div class="actions">
-    <a class="btn ghost sm" href="#timeline">Notizen</a>
     {session ? (
       <a class="btn primary sm" href="/portal">Portal →</a>
     ) : (

--- a/website/src/layouts/Layout.astro
+++ b/website/src/layouts/Layout.astro
@@ -37,6 +37,7 @@ const brandWord = config.meta.siteTitle.replace(/\.de$/i, '').toLowerCase();
         <meta property="og:type" content="website" />
         <meta property="og:title" content={title} />
         <meta property="og:description" content={description} />
+        <meta property="og:url" content={`https://web.korczewski.de${Astro.url.pathname}`} />
         <meta property="og:image" content="/brand/korczewski/og-image.png" />
         <meta property="og:image:width" content="1200" />
         <meta property="og:image:height" content="630" />

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -81,7 +81,7 @@ const processSteps = [
 ---
 
 {BRAND_ID === 'korczewski' ? (
-  <Layout title="Kore. — Self-hosted, vor Ihren Augen." brand="korczewski-kore">
+  <Layout title="Kore. — Self-hosted, vor Ihren Augen." brand="korczewski-kore" description="Self-hosted Kubernetes-Infrastruktur, DSGVO-konform auf einem 12-Node-Cluster. Beratung, Deployment und Betrieb für kleine Teams — Patrick Korczewski, Lüneburg.">
     <KoreSubNav />
     <KoreHero client:load />
     <KoreServices services={services} />


### PR DESCRIPTION
## Summary

- **KoreHero:** Fix "verfügbar Q3 2026" fallback ticker → "12 Nodes · Live" (site is already live)
- **KoreSubNav:** Remove duplicate "Notizen" ghost button from actions slot (was showing twice alongside nav links)
- **KoreProcess:** Rewrite 4 steps from coaching language → IT consulting language (Brief / Analyse / Umsetzung / Betrieb)
- **KoreBugs:** Fix responsive layout — was jumping from 3-col to 1-col; now 3→2→1 at 980px/640px breakpoints
- **KoreFooter:** Add Datenschutz and Impressum links to the legal bar at the bottom
- **Layout.astro:** Add `og:url` meta tag for korczewski brand pages
- **index.astro:** Pass explicit meta description for the korczewski homepage

## Test Plan

- [ ] Deploy via `task feature:website` and verify web.korczewski.de
- [ ] Check ticker shows "12 Nodes · Live" when cluster stats are unavailable
- [ ] Verify nav has no duplicate Notizen button on mobile and desktop
- [ ] Confirm process section reads as IT consulting copy
- [ ] Check bugs grid goes 3→2 at tablet width
- [ ] Inspect footer legal bar for Datenschutz/Impressum links

🤖 Generated with [Claude Code](https://claude.com/claude-code)