### PR TITLE
feat(kore): fix subpage styling inconsistency for korczewski brand

### DIFF
--- a/website/src/components/kore/KoreSubNav.astro
+++ b/website/src/components/kore/KoreSubNav.astro
@@ -1,7 +1,7 @@
 ---
 import { getSession } from '../../lib/auth';
 
-const { active = 'work' } = Astro.props as { active?: string };
+const { active = 'work', subpage = false } = Astro.props as { active?: string; subpage?: boolean };
 const session = await getSession(Astro.request.headers.get('cookie'));
 const links = [
   { id: 'work',     label: 'Cluster' },
@@ -21,7 +21,7 @@ const links = [
   </a>
   <div class="links">
     {links.map(({id, label}) => (
-      <a href={id === 'contact' ? '/kontakt' : `#${id}`} class={active === id ? 'active' : ''}>{label}</a>
+      <a href={id === 'contact' ? '/kontakt' : subpage ? `/#${id}` : `#${id}`} class={active === id ? 'active' : ''}>{label}</a>
     ))}
   </div>
   <div class="actions">

--- a/website/src/layouts/KoreLayout.astro
+++ b/website/src/layouts/KoreLayout.astro
@@ -1,0 +1,19 @@
+---
+// website/src/layouts/KoreLayout.astro
+import Layout from './Layout.astro';
+import KoreSubNav from '../components/kore/KoreSubNav.astro';
+import KoreFooter from '../components/kore/KoreFooter.astro';
+
+interface Props {
+  title: string;
+  description?: string;
+  active?: string;
+}
+const { title, description, active } = Astro.props;
+---
+
+<Layout title={title} description={description} brand="korczewski-kore">
+  <KoreSubNav active={active ?? ''} subpage={true} />
+  <slot />
+  <KoreFooter />
+</Layout>

--- a/website/src/pages/datenschutz.astro
+++ b/website/src/pages/datenschutz.astro
@@ -1,22 +1,23 @@
 ---
 import Layout from '../layouts/Layout.astro';
+import KoreLayout from '../layouts/KoreLayout.astro';
 import { config } from '../config/index';
 import { getLegalPage } from '../lib/website-db';
 
 const { contact, legal } = config;
 const BRAND = process.env.BRAND || 'mentolder';
+const BRAND_ID = process.env.BRAND_ID ?? BRAND;
+const isKore = BRAND_ID === 'korczewski';
 const customHtml = await getLegalPage(BRAND, 'datenschutz').catch(() => null);
 ---
 
-<Layout title="Datenschutzerklärung">
-  <section class="pt-28 pb-20">
-    <div class="max-w-3xl mx-auto px-6 prose prose-lg prose-slate">
+{isKore ? (
+  <KoreLayout title="Datenschutzerklärung">
+    <article class="kore-legal">
       <h1>Datenschutzerklärung</h1>
 
       <h2>1. Verantwortlicher</h2>
-      <p>
-        Verantwortlicher im Sinne der Datenschutz-Grundverordnung (DSGVO) ist:
-      </p>
+      <p>Verantwortlicher im Sinne der Datenschutz-Grundverordnung (DSGVO) ist:</p>
       <p>
         <strong>{contact.name}</strong><br />
         {legal.tagline}<br />
@@ -62,44 +63,12 @@ const customHtml = await getLegalPage(BRAND, 'datenschutz').catch(() => null);
         notwendige Cookies erfordern keine Einwilligung (§ 25 Abs. 2 TTDSG).
       </p>
 
-      <table>
-        <thead>
-          <tr>
-            <th>Cookie / Storage-Eintrag</th>
-            <th>Zweck</th>
-            <th>Speicherdauer</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td><code>session</code></td>
-            <td>Authentifizierung und Sitzungsverwaltung</td>
-            <td>Sitzungsende</td>
-          </tr>
-          <tr>
-            <td><code>KEYCLOAK_*</code></td>
-            <td>Single Sign-On Session (Keycloak OIDC)</td>
-            <td>Sitzungsende</td>
-          </tr>
-          <tr>
-            <td><code>cookie_consent_v1</code> (localStorage)</td>
-            <td>Speichert Cookie-Einwilligung lokal im Browser</td>
-            <td>Bis zur manuellen Löschung (wird nicht an Server übertragen)</td>
-          </tr>
-        </tbody>
-      </table>
-
       <h3>Kontaktformular und Terminbuchung</h3>
       <p>
         Wenn Sie das Kontaktformular nutzen oder einen Termin buchen, werden Ihr
         Name, Ihre E-Mail-Adresse sowie der Nachrichteninhalt verarbeitet, um Ihre
         Anfrage zu bearbeiten und den Termin zu koordinieren. Die Daten werden
         intern weitergeleitet und nicht an Dritte weitergegeben.
-      </p>
-      <p>
-        Im Rahmen der Coaching-Leistungserbringung werden zudem Termindaten und
-        Sitzungsnotizen verarbeitet (ausschließlich intern, nicht weitergegeben)
-        sowie Rechnungsdaten gemäß gesetzlicher Aufbewahrungspflicht (10 Jahre).
       </p>
       <p>
         Rechtsgrundlage: Art. 6 Abs. 1 lit. b DSGVO (Vertragserfüllung /
@@ -110,74 +79,21 @@ const customHtml = await getLegalPage(BRAND, 'datenschutz').catch(() => null);
       <p>
         Diese Website und alle damit verbundenen Dienste werden auf Servern der
         <strong>Hetzner Online GmbH</strong> (Deutschland) betrieben. Alle Daten
-        verbleiben innerhalb der Europäischen Union. Es findet keine Übermittlung
-        personenbezogener Daten an Server in Drittländern außerhalb der EU statt.
+        verbleiben innerhalb der Europäischen Union.
       </p>
       <p>
-        Eingesetzte Dienste (alle selbst gehostet auf Hetzner-Infrastruktur):
-      </p>
-      <ul>
-        <li>Nextcloud — Dokumentenablage, Kalender</li>
-        <li>Nextcloud Talk — Online-Coaching-Sitzungen per Video</li>
-        <li>Eigene Terminverwaltung und Rechnungsstellung</li>
-      </ul>
-      <p>
-        Es werden keine Dienste von Google (Analytics, Fonts, Maps), Meta (Facebook,
-        Instagram Pixel), Zoom, HubSpot oder sonstigen US-Anbietern eingesetzt.
+        Es werden keine Dienste von Google (Analytics, Fonts, Maps), Meta, Zoom,
+        HubSpot oder sonstigen US-Anbietern eingesetzt.
       </p>
 
       <h2>4. Ihre Rechte als betroffene Person</h2>
+      <p>Sie haben nach der DSGVO folgende Rechte gegenüber uns als Verantwortlichem:</p>
       <p>
-        Sie haben nach der DSGVO folgende Rechte gegenüber uns als Verantwortlichem:
+        <strong>Auskunft</strong> (Art. 15 DSGVO) · <strong>Berichtigung</strong> (Art. 16 DSGVO) ·
+        <strong>Löschung</strong> (Art. 17 DSGVO) · <strong>Einschränkung</strong> (Art. 18 DSGVO) ·
+        <strong>Datenportabilität</strong> (Art. 20 DSGVO) · <strong>Widerspruch</strong> (Art. 21 DSGVO) ·
+        <strong>Widerruf</strong> (Art. 7 Abs. 3 DSGVO)
       </p>
-
-      <table>
-        <thead>
-          <tr>
-            <th>Recht</th>
-            <th>Rechtsgrundlage</th>
-            <th>Beschreibung</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td><strong>Auskunft</strong></td>
-            <td>Art. 15 DSGVO</td>
-            <td>Sie können Auskunft über die von uns verarbeiteten personenbezogenen Daten verlangen.</td>
-          </tr>
-          <tr>
-            <td><strong>Berichtigung</strong></td>
-            <td>Art. 16 DSGVO</td>
-            <td>Sie können die Berichtigung unrichtiger Daten verlangen.</td>
-          </tr>
-          <tr>
-            <td><strong>Löschung</strong></td>
-            <td>Art. 17 DSGVO</td>
-            <td>Sie können die Löschung Ihrer Daten verlangen, sofern keine gesetzliche Aufbewahrungspflicht besteht.</td>
-          </tr>
-          <tr>
-            <td><strong>Einschränkung</strong></td>
-            <td>Art. 18 DSGVO</td>
-            <td>Sie können die Einschränkung der Verarbeitung Ihrer Daten verlangen.</td>
-          </tr>
-          <tr>
-            <td><strong>Datenportabilität</strong></td>
-            <td>Art. 20 DSGVO</td>
-            <td>Sie können Ihre Daten in einem strukturierten, maschinenlesbaren Format erhalten.</td>
-          </tr>
-          <tr>
-            <td><strong>Widerspruch</strong></td>
-            <td>Art. 21 DSGVO</td>
-            <td>Sie können der Verarbeitung Ihrer Daten auf Basis von Art. 6 Abs. 1 lit. f DSGVO widersprechen.</td>
-          </tr>
-          <tr>
-            <td><strong>Widerruf</strong></td>
-            <td>Art. 7 Abs. 3 DSGVO</td>
-            <td>Erteilte Einwilligungen können Sie jederzeit mit Wirkung für die Zukunft widerrufen.</td>
-          </tr>
-        </tbody>
-      </table>
-
       <p>
         Zur Ausübung Ihrer Rechte wenden Sie sich bitte per E-Mail an:{' '}
         <a href={`mailto:${contact.email}`}>{contact.email}</a>
@@ -192,38 +108,320 @@ const customHtml = await getLegalPage(BRAND, 'datenschutz').catch(() => null);
       <h2>6. Beschwerderecht bei der Aufsichtsbehörde</h2>
       <p>
         Sie haben das Recht, sich bei der zuständigen Datenschutz-Aufsichtsbehörde
-        zu beschweren. Die zuständige Behörde richtet sich nach Ihrem Wohnort bzw.
-        dem Sitz des Verantwortlichen. Eine Liste der Datenschutzbehörden in
-        Deutschland finden Sie auf der Website der Bundesbeauftragten für den
-        Datenschutz und die Informationsfreiheit (BfDI):
-        <a href="https://www.bfdi.bund.de" target="_blank" rel="noopener noreferrer">www.bfdi.bund.de</a>.
+        zu beschweren:{' '}
+        <a href="https://www.bfdi.bund.de" target="_blank" rel="noopener noreferrer">www.bfdi.bund.de</a>
       </p>
 
       <h2>7. Aktualität dieser Erklärung</h2>
-      <p class="text-sm text-slate-500 mt-8">
-        Stand: April 2026. Diese Datenschutzerklärung wird bei Änderungen der
-        Verarbeitungstätigkeiten oder der Rechtslage aktualisiert.
-      </p>
+      <p>Stand: April 2026. Diese Datenschutzerklärung wird bei Änderungen der Verarbeitungstätigkeiten oder der Rechtslage aktualisiert.</p>
 
       <h2>8. Ihre Rechte — Daten einsehen und löschen</h2>
       <p>
-        Sie können Auskunft anfordern und Löschung beantragen direkt über unsere
+        Sie können Auskunft anfordern und Löschung beantragen direkt über unsere{' '}
         <a href="/meine-daten">Datenverwaltungsseite</a>. Eingeloggte Nutzer können ihr
         Konto dort unmittelbar löschen.
       </p>
+
       {customHtml && customHtml.trim() && (
-        <Fragment>
+        <>
           <h2>Weitere Hinweise</h2>
           <div set:html={customHtml} />
-        </Fragment>
+        </>
       )}
 
-      <div class="not-prose mt-10 pt-6 border-t border-slate-700 flex items-center justify-between">
-        <a href="/admin/rechtliches" class="text-xs text-slate-500 hover:text-gold transition-colors">✏️ Bearbeiten</a>
-        <button onclick="window.print()" class="text-xs px-3 py-1.5 bg-slate-700 hover:bg-slate-600 text-slate-300 rounded transition-colors">
-          Drucken / PDF
-        </button>
+      <div class="kore-legal-actions">
+        <button onclick="window.print()" class="kore-print-btn">Drucken / PDF</button>
       </div>
-    </div>
-  </section>
-</Layout>
+    </article>
+  </KoreLayout>
+) : (
+  <Layout title="Datenschutzerklärung">
+    <section class="pt-28 pb-20">
+      <div class="max-w-3xl mx-auto px-6 prose prose-lg prose-slate">
+        <h1>Datenschutzerklärung</h1>
+
+        <h2>1. Verantwortlicher</h2>
+        <p>
+          Verantwortlicher im Sinne der Datenschutz-Grundverordnung (DSGVO) ist:
+        </p>
+        <p>
+          <strong>{contact.name}</strong><br />
+          {legal.tagline}<br />
+          {legal.street && <>{legal.street}<br /></>}
+          {legal.zip && <>{legal.zip} {contact.city}<br /></>}
+          {!legal.street && <>{contact.city}<br /></>}
+          E-Mail: <a href={`mailto:${contact.email}`}>{contact.email}</a><br />
+          {contact.phone && <>Telefon: {contact.phone}</>}
+        </p>
+
+        <h2>2. Grundsätze der Datenverarbeitung</h2>
+        <p>
+          Wir verarbeiten personenbezogene Daten nur, soweit dies zur Bereitstellung
+          unserer Dienste erforderlich ist. Alle Daten verbleiben vollständig auf
+          eigener Infrastruktur (On-Premises). Es findet keine Übermittlung an
+          Cloud-Anbieter oder Dritte statt.
+        </p>
+        <p>
+          Rechtsgrundlagen der Verarbeitung: Art. 6 Abs. 1 lit. b DSGVO (Vertragserfüllung
+          und vorvertragliche Maßnahmen), Art. 6 Abs. 1 lit. c DSGVO (gesetzliche
+          Verpflichtung), Art. 6 Abs. 1 lit. f DSGVO (berechtigte Interessen).
+        </p>
+
+        <h2>3. Datenerfassung auf dieser Website</h2>
+
+        <h3>Server-Log-Dateien</h3>
+        <p>
+          Beim Aufruf dieser Website werden automatisch technische Zugriffsdaten
+          erfasst: IP-Adresse, Browsertyp, Betriebssystem, Referrer-URL, aufgerufene
+          Seite, Zeitpunkt des Zugriffs. Diese Daten werden ausschließlich zur
+          technischen Bereitstellung der Website benötigt und nach 7 Tagen automatisch
+          gelöscht. Eine Zuordnung zu bestimmten Personen ist nicht beabsichtigt.
+        </p>
+        <p>
+          Rechtsgrundlage: Art. 6 Abs. 1 lit. f DSGVO (berechtigtes Interesse am
+          sicheren Betrieb der Website).
+        </p>
+
+        <h3>Cookies</h3>
+        <p>
+          Diese Website verwendet ausschließlich technisch notwendige Cookies. Es
+          werden keine Tracking-, Analyse- oder Werbe-Cookies eingesetzt. Technisch
+          notwendige Cookies erfordern keine Einwilligung (§ 25 Abs. 2 TTDSG).
+        </p>
+
+        <table>
+          <thead>
+            <tr>
+              <th>Cookie / Storage-Eintrag</th>
+              <th>Zweck</th>
+              <th>Speicherdauer</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>session</code></td>
+              <td>Authentifizierung und Sitzungsverwaltung</td>
+              <td>Sitzungsende</td>
+            </tr>
+            <tr>
+              <td><code>KEYCLOAK_*</code></td>
+              <td>Single Sign-On Session (Keycloak OIDC)</td>
+              <td>Sitzungsende</td>
+            </tr>
+            <tr>
+              <td><code>cookie_consent_v1</code> (localStorage)</td>
+              <td>Speichert Cookie-Einwilligung lokal im Browser</td>
+              <td>Bis zur manuellen Löschung (wird nicht an Server übertragen)</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <h3>Kontaktformular und Terminbuchung</h3>
+        <p>
+          Wenn Sie das Kontaktformular nutzen oder einen Termin buchen, werden Ihr
+          Name, Ihre E-Mail-Adresse sowie der Nachrichteninhalt verarbeitet, um Ihre
+          Anfrage zu bearbeiten und den Termin zu koordinieren. Die Daten werden
+          intern weitergeleitet und nicht an Dritte weitergegeben.
+        </p>
+        <p>
+          Im Rahmen der Coaching-Leistungserbringung werden zudem Termindaten und
+          Sitzungsnotizen verarbeitet (ausschließlich intern, nicht weitergegeben)
+          sowie Rechnungsdaten gemäß gesetzlicher Aufbewahrungspflicht (10 Jahre).
+        </p>
+        <p>
+          Rechtsgrundlage: Art. 6 Abs. 1 lit. b DSGVO (Vertragserfüllung /
+          vorvertragliche Maßnahmen). Speicherdauer Kontaktdaten: 3 Jahre.
+        </p>
+
+        <h3>Hosting</h3>
+        <p>
+          Diese Website und alle damit verbundenen Dienste werden auf Servern der
+          <strong>Hetzner Online GmbH</strong> (Deutschland) betrieben. Alle Daten
+          verbleiben innerhalb der Europäischen Union. Es findet keine Übermittlung
+          personenbezogener Daten an Server in Drittländern außerhalb der EU statt.
+        </p>
+        <p>
+          Eingesetzte Dienste (alle selbst gehostet auf Hetzner-Infrastruktur):
+        </p>
+        <ul>
+          <li>Nextcloud — Dokumentenablage, Kalender</li>
+          <li>Nextcloud Talk — Online-Coaching-Sitzungen per Video</li>
+          <li>Eigene Terminverwaltung und Rechnungsstellung</li>
+        </ul>
+        <p>
+          Es werden keine Dienste von Google (Analytics, Fonts, Maps), Meta (Facebook,
+          Instagram Pixel), Zoom, HubSpot oder sonstigen US-Anbietern eingesetzt.
+        </p>
+
+        <h2>4. Ihre Rechte als betroffene Person</h2>
+        <p>
+          Sie haben nach der DSGVO folgende Rechte gegenüber uns als Verantwortlichem:
+        </p>
+
+        <table>
+          <thead>
+            <tr>
+              <th>Recht</th>
+              <th>Rechtsgrundlage</th>
+              <th>Beschreibung</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><strong>Auskunft</strong></td>
+              <td>Art. 15 DSGVO</td>
+              <td>Sie können Auskunft über die von uns verarbeiteten personenbezogenen Daten verlangen.</td>
+            </tr>
+            <tr>
+              <td><strong>Berichtigung</strong></td>
+              <td>Art. 16 DSGVO</td>
+              <td>Sie können die Berichtigung unrichtiger Daten verlangen.</td>
+            </tr>
+            <tr>
+              <td><strong>Löschung</strong></td>
+              <td>Art. 17 DSGVO</td>
+              <td>Sie können die Löschung Ihrer Daten verlangen, sofern keine gesetzliche Aufbewahrungspflicht besteht.</td>
+            </tr>
+            <tr>
+              <td><strong>Einschränkung</strong></td>
+              <td>Art. 18 DSGVO</td>
+              <td>Sie können die Einschränkung der Verarbeitung Ihrer Daten verlangen.</td>
+            </tr>
+            <tr>
+              <td><strong>Datenportabilität</strong></td>
+              <td>Art. 20 DSGVO</td>
+              <td>Sie können Ihre Daten in einem strukturierten, maschinenlesbaren Format erhalten.</td>
+            </tr>
+            <tr>
+              <td><strong>Widerspruch</strong></td>
+              <td>Art. 21 DSGVO</td>
+              <td>Sie können der Verarbeitung Ihrer Daten auf Basis von Art. 6 Abs. 1 lit. f DSGVO widersprechen.</td>
+            </tr>
+            <tr>
+              <td><strong>Widerruf</strong></td>
+              <td>Art. 7 Abs. 3 DSGVO</td>
+              <td>Erteilte Einwilligungen können Sie jederzeit mit Wirkung für die Zukunft widerrufen.</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <p>
+          Zur Ausübung Ihrer Rechte wenden Sie sich bitte per E-Mail an:{' '}
+          <a href={`mailto:${contact.email}`}>{contact.email}</a>
+        </p>
+
+        <h2>5. Keine automatisierten Entscheidungen</h2>
+        <p>
+          Es finden keine automatisierten Entscheidungen im Sinne von Art. 22 DSGVO
+          statt. Es wird kein Profiling betrieben.
+        </p>
+
+        <h2>6. Beschwerderecht bei der Aufsichtsbehörde</h2>
+        <p>
+          Sie haben das Recht, sich bei der zuständigen Datenschutz-Aufsichtsbehörde
+          zu beschweren. Die zuständige Behörde richtet sich nach Ihrem Wohnort bzw.
+          dem Sitz des Verantwortlichen. Eine Liste der Datenschutzbehörden in
+          Deutschland finden Sie auf der Website der Bundesbeauftragten für den
+          Datenschutz und die Informationsfreiheit (BfDI):
+          <a href="https://www.bfdi.bund.de" target="_blank" rel="noopener noreferrer">www.bfdi.bund.de</a>.
+        </p>
+
+        <h2>7. Aktualität dieser Erklärung</h2>
+        <p class="text-sm text-slate-500 mt-8">
+          Stand: April 2026. Diese Datenschutzerklärung wird bei Änderungen der
+          Verarbeitungstätigkeiten oder der Rechtslage aktualisiert.
+        </p>
+
+        <h2>8. Ihre Rechte — Daten einsehen und löschen</h2>
+        <p>
+          Sie können Auskunft anfordern und Löschung beantragen direkt über unsere
+          <a href="/meine-daten">Datenverwaltungsseite</a>. Eingeloggte Nutzer können ihr
+          Konto dort unmittelbar löschen.
+        </p>
+        {customHtml && customHtml.trim() && (
+          <Fragment>
+            <h2>Weitere Hinweise</h2>
+            <div set:html={customHtml} />
+          </Fragment>
+        )}
+
+        <div class="not-prose mt-10 pt-6 border-t border-slate-700 flex items-center justify-between">
+          <a href="/admin/rechtliches" class="text-xs text-slate-500 hover:text-gold transition-colors">✏️ Bearbeiten</a>
+          <button onclick="window.print()" class="text-xs px-3 py-1.5 bg-slate-700 hover:bg-slate-600 text-slate-300 rounded transition-colors">
+            Drucken / PDF
+          </button>
+        </div>
+      </div>
+    </section>
+  </Layout>
+)}
+
+<style>
+  .kore-legal {
+    max-width: 720px;
+    margin: 0 auto;
+    padding: 80px 28px 120px;
+  }
+  .kore-legal h1 {
+    font-family: var(--serif);
+    font-size: clamp(36px, 5vw, 56px);
+    font-weight: 400;
+    letter-spacing: -0.02em;
+    margin: 0 0 56px;
+    line-height: 1.05;
+  }
+  .kore-legal h2 {
+    font-family: var(--serif);
+    font-size: 22px;
+    font-weight: 400;
+    letter-spacing: -0.01em;
+    margin: 48px 0 12px;
+    color: var(--fg);
+  }
+  .kore-legal h3 {
+    font-family: var(--sans);
+    font-size: 15px;
+    font-weight: 600;
+    letter-spacing: 0.01em;
+    margin: 28px 0 8px;
+    color: var(--fg);
+  }
+  .kore-legal h2:first-of-type { margin-top: 0; }
+  .kore-legal p {
+    font-family: var(--sans);
+    font-size: 15px;
+    line-height: 1.7;
+    color: var(--fg-soft);
+    margin: 0 0 12px;
+  }
+  .kore-legal strong {
+    color: var(--fg);
+    font-weight: 600;
+  }
+  .kore-legal a {
+    color: var(--copper);
+    text-decoration: none;
+  }
+  .kore-legal a:hover { text-decoration: underline; text-underline-offset: 3px; }
+  .kore-legal-actions {
+    margin-top: 56px;
+    padding-top: 24px;
+    border-top: 1px solid var(--line);
+    display: flex;
+    justify-content: flex-end;
+  }
+  .kore-print-btn {
+    font-family: var(--mono);
+    font-size: 11px;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    background: var(--ink-800);
+    border: 1px solid var(--line-2);
+    border-radius: 8px;
+    color: var(--mute);
+    padding: 8px 16px;
+    cursor: pointer;
+    transition: color 0.15s ease, border-color 0.15s ease;
+  }
+  .kore-print-btn:hover { color: var(--fg); border-color: var(--line-3); }
+</style>

--- a/website/src/pages/impressum.astro
+++ b/website/src/pages/impressum.astro
@@ -1,130 +1,246 @@
 ---
 import Layout from '../layouts/Layout.astro';
+import KoreLayout from '../layouts/KoreLayout.astro';
 import { config } from '../config/index';
 import { getLegalPage } from '../lib/website-db';
 
 const { contact, legal } = config;
 const BRAND = process.env.BRAND || 'mentolder';
+const BRAND_ID = process.env.BRAND_ID ?? BRAND;
+const isKore = BRAND_ID === 'korczewski';
 const customHtml = await getLegalPage(BRAND, 'impressum-zusatz').catch(() => null);
 ---
 
-<Layout title="Impressum">
-  <section class="pt-28 pb-20">
-    <div class="max-w-3xl mx-auto px-6 prose prose-lg prose-slate">
+{isKore ? (
+  <KoreLayout title="Impressum">
+    <article class="kore-legal">
       <h1>Impressum</h1>
 
-      <h2>Angaben gemäß &sect; 5 DDG</h2>
-      <p>
-        {contact.name}<br />
-        {legal.tagline}<br />
-        {legal.street}<br />
-        {legal.zip} {contact.city}<br />
-        Deutschland
-      </p>
+      <h2>Angaben gemäß § 5 DDG</h2>
+      <p>{contact.name}<br />{legal.tagline}<br />{legal.street}<br />{legal.zip} {contact.city}<br />Deutschland</p>
 
       <h2>Kontakt</h2>
       <p>
-        {contact.phone && contact.phone !== '***' && <>Telefon: {contact.phone}<br /></>}
-        E-Mail: {contact.email}<br />
-        Web: www.{legal.website}
+        {contact.phone && contact.phone !== '***' && <>{`Telefon: ${contact.phone}`}<br /></>}
+        {`E-Mail: ${contact.email}`}<br />
+        {`Web: www.${legal.website}`}
       </p>
 
       <h2>Berufsbezeichnung und berufsrechtliche Regelungen</h2>
       <p>
-        Berufsbezeichnung: {legal.jobtitle}<br />
-        Zuständige Kammer: {legal.chamber}<br />
+        {`Berufsbezeichnung: ${legal.jobtitle}`}<br />
+        {`Zuständige Kammer: ${legal.chamber}`}<br />
         Verliehen in: Bundesrepublik Deutschland
       </p>
-      <p>
-        Coaching und Beratung sind in Deutschland nicht reglementierte Berufe.
-        Es bestehen keine besonderen berufsrechtlichen Regelungen.
-      </p>
+      <p>Coaching und Beratung sind in Deutschland nicht reglementierte Berufe. Es bestehen keine besonderen berufsrechtlichen Regelungen.</p>
 
       <h2>Umsatzsteuer</h2>
-      <p>
-        {legal.ustId}
-      </p>
+      <p>{legal.ustId}</p>
 
       <h2>Redaktionell Verantwortlicher</h2>
-      <p>
-        {contact.name}<br />
-        {legal.street}<br />
-        {legal.zip} {contact.city}
-      </p>
+      <p>{contact.name}<br />{legal.street}<br />{legal.zip} {contact.city}</p>
 
       <h2>EU-Streitschlichtung</h2>
-      <p>
-        Die Europäische Kommission stellt eine Plattform zur Online-Streitbeilegung (OS) bereit:
-        <a href="https://ec.europa.eu/consumers/odr/" target="_blank" rel="noopener noreferrer">
-          https://ec.europa.eu/consumers/odr/
-        </a>
-      </p>
-      <p>
-        Unsere E-Mail-Adresse finden Sie oben im Impressum.
-      </p>
+      <p>Die Europäische Kommission stellt eine Plattform zur Online-Streitbeilegung (OS) bereit: <a href="https://ec.europa.eu/consumers/odr/" target="_blank" rel="noopener noreferrer">https://ec.europa.eu/consumers/odr/</a></p>
+      <p>Unsere E-Mail-Adresse finden Sie oben im Impressum.</p>
 
       <h2>Verbraucherstreitbeilegung / Universalschlichtungsstelle</h2>
-      <p>
-        Wir sind nicht bereit oder verpflichtet, an Streitbeilegungsverfahren
-        vor einer Verbraucherschlichtungsstelle teilzunehmen.
-      </p>
+      <p>Wir sind nicht bereit oder verpflichtet, an Streitbeilegungsverfahren vor einer Verbraucherschlichtungsstelle teilzunehmen.</p>
 
       <h2>Haftung für Inhalte</h2>
-      <p>
-        Als Diensteanbieter sind wir gemäß &sect; 7 Abs. 1 DDG für eigene Inhalte
-        auf diesen Seiten nach den allgemeinen Gesetzen verantwortlich. Nach &sect;&sect; 8 bis 10
-        DDG sind wir als Diensteanbieter jedoch nicht verpflichtet, übermittelte oder
-        gespeicherte fremde Informationen zu überwachen oder nach Umständen zu forschen,
-        die auf eine rechtswidrige Tätigkeit hinweisen.
-      </p>
-      <p>
-        Verpflichtungen zur Entfernung oder Sperrung der Nutzung von Informationen nach den
-        allgemeinen Gesetzen bleiben hiervon unberührt. Eine diesbezügliche Haftung ist
-        jedoch erst ab dem Zeitpunkt der Kenntnis einer konkreten Rechtsverletzung möglich.
-        Bei Bekanntwerden von entsprechenden Rechtsverletzungen werden wir diese Inhalte
-        umgehend entfernen.
-      </p>
+      <p>Als Diensteanbieter sind wir gemäß § 7 Abs. 1 DDG für eigene Inhalte auf diesen Seiten nach den allgemeinen Gesetzen verantwortlich. Nach §§ 8 bis 10 DDG sind wir als Diensteanbieter jedoch nicht verpflichtet, übermittelte oder gespeicherte fremde Informationen zu überwachen oder nach Umständen zu forschen, die auf eine rechtswidrige Tätigkeit hinweisen.</p>
+      <p>Verpflichtungen zur Entfernung oder Sperrung der Nutzung von Informationen nach den allgemeinen Gesetzen bleiben hiervon unberührt. Eine diesbezügliche Haftung ist jedoch erst ab dem Zeitpunkt der Kenntnis einer konkreten Rechtsverletzung möglich. Bei Bekanntwerden von entsprechenden Rechtsverletzungen werden wir diese Inhalte umgehend entfernen.</p>
 
       <h2>Haftung für Links</h2>
-      <p>
-        Unser Angebot enthält Links zu externen Websites Dritter, auf deren Inhalte wir
-        keinen Einfluss haben. Deshalb können wir für diese fremden Inhalte auch keine
-        Gewähr übernehmen. Für die Inhalte der verlinkten Seiten ist stets der jeweilige
-        Anbieter oder Betreiber der Seiten verantwortlich. Die verlinkten Seiten wurden zum
-        Zeitpunkt der Verlinkung auf mögliche Rechtsverstöße überprüft. Rechtswidrige
-        Inhalte waren zum Zeitpunkt der Verlinkung nicht erkennable.
-      </p>
-      <p>
-        Eine permanente inhaltliche Kontrolle der verlinkten Seiten ist jedoch ohne konkrete
-        Anhaltspunkte einer Rechtsverletzung nicht zumutbar. Bei Bekanntwerden von
-        Rechtsverletzungen werden wir derartige Links umgehend entfernen.
-      </p>
+      <p>Unser Angebot enthält Links zu externen Websites Dritter, auf deren Inhalte wir keinen Einfluss haben. Deshalb können wir für diese fremden Inhalte auch keine Gewähr übernehmen. Für die Inhalte der verlinkten Seiten ist stets der jeweilige Anbieter oder Betreiber der Seiten verantwortlich.</p>
 
       <h2>Urheberrecht</h2>
-      <p>
-        Die durch die Seitenbetreiber erstellten Inhalte und Werke auf diesen Seiten
-        unterliegen dem deutschen Urheberrecht. Die Vervielfältigung, Bearbeitung, Verbreitung
-        und jede Art der Verwertung außerhalb der Grenzen des Urheberrechtes bedürfen der
-        schriftlichen Zustimmung des jeweiligen Autors bzw. Erstellers. Downloads und Kopien
-        dieser Seite sind nur für den privaten, nicht kommerziellen Gebrauch gestattet.
-      </p>
-      <p>
-        Soweit die Inhalte auf dieser Seite nicht vom Betreiber erstellt wurden, werden die
-        Urheberrechte Dritter beachtet. Insbesondere werden Inhalte Dritter als solche
-        gekennzeichnet. Sollten Sie trotzdem auf eine Urheberrechtsverletzung aufmerksam
-        werden, bitten wir um einen entsprechenden Hinweis. Bei Bekanntwerden von
-        Rechtsverletzungen werden wir derartige Inhalte umgehend entfernen.
-      </p>
-      {customHtml && customHtml.trim() && (
-        <div set:html={customHtml} />
-      )}
+      <p>Die durch die Seitenbetreiber erstellten Inhalte und Werke auf diesen Seiten unterliegen dem deutschen Urheberrecht. Die Vervielfältigung, Bearbeitung, Verbreitung und jede Art der Verwertung außerhalb der Grenzen des Urheberrechtes bedürfen der schriftlichen Zustimmung des jeweiligen Autors bzw. Erstellers.</p>
 
-      <div class="not-prose mt-10 pt-6 border-t border-slate-700 flex items-center justify-between">
-        <a href="/admin/rechtliches" class="text-xs text-slate-500 hover:text-gold transition-colors">✏️ Bearbeiten</a>
-        <button onclick="window.print()" class="text-xs px-3 py-1.5 bg-slate-700 hover:bg-slate-600 text-slate-300 rounded transition-colors">
-          Drucken / PDF
-        </button>
+      {customHtml && customHtml.trim() && <div set:html={customHtml} />}
+
+      <div class="kore-legal-actions">
+        <button onclick="window.print()" class="kore-print-btn">Drucken / PDF</button>
       </div>
-    </div>
-  </section>
-</Layout>
+    </article>
+  </KoreLayout>
+) : (
+  <Layout title="Impressum">
+    <section class="pt-28 pb-20">
+      <div class="max-w-3xl mx-auto px-6 prose prose-lg prose-slate">
+        <h1>Impressum</h1>
+
+        <h2>Angaben gemäß &sect; 5 DDG</h2>
+        <p>
+          {contact.name}<br />
+          {legal.tagline}<br />
+          {legal.street}<br />
+          {legal.zip} {contact.city}<br />
+          Deutschland
+        </p>
+
+        <h2>Kontakt</h2>
+        <p>
+          {contact.phone && contact.phone !== '***' && <>Telefon: {contact.phone}<br /></>}
+          E-Mail: {contact.email}<br />
+          Web: www.{legal.website}
+        </p>
+
+        <h2>Berufsbezeichnung und berufsrechtliche Regelungen</h2>
+        <p>
+          Berufsbezeichnung: {legal.jobtitle}<br />
+          Zuständige Kammer: {legal.chamber}<br />
+          Verliehen in: Bundesrepublik Deutschland
+        </p>
+        <p>
+          Coaching und Beratung sind in Deutschland nicht reglementierte Berufe.
+          Es bestehen keine besonderen berufsrechtlichen Regelungen.
+        </p>
+
+        <h2>Umsatzsteuer</h2>
+        <p>
+          {legal.ustId}
+        </p>
+
+        <h2>Redaktionell Verantwortlicher</h2>
+        <p>
+          {contact.name}<br />
+          {legal.street}<br />
+          {legal.zip} {contact.city}
+        </p>
+
+        <h2>EU-Streitschlichtung</h2>
+        <p>
+          Die Europäische Kommission stellt eine Plattform zur Online-Streitbeilegung (OS) bereit:
+          <a href="https://ec.europa.eu/consumers/odr/" target="_blank" rel="noopener noreferrer">
+            https://ec.europa.eu/consumers/odr/
+          </a>
+        </p>
+        <p>
+          Unsere E-Mail-Adresse finden Sie oben im Impressum.
+        </p>
+
+        <h2>Verbraucherstreitbeilegung / Universalschlichtungsstelle</h2>
+        <p>
+          Wir sind nicht bereit oder verpflichtet, an Streitbeilegungsverfahren
+          vor einer Verbraucherschlichtungsstelle teilzunehmen.
+        </p>
+
+        <h2>Haftung für Inhalte</h2>
+        <p>
+          Als Diensteanbieter sind wir gemäß &sect; 7 Abs. 1 DDG für eigene Inhalte
+          auf diesen Seiten nach den allgemeinen Gesetzen verantwortlich. Nach &sect;&sect; 8 bis 10
+          DDG sind wir als Diensteanbieter jedoch nicht verpflichtet, übermittelte oder
+          gespeicherte fremde Informationen zu überwachen oder nach Umständen zu forschen,
+          die auf eine rechtswidrige Tätigkeit hinweisen.
+        </p>
+        <p>
+          Verpflichtungen zur Entfernung oder Sperrung der Nutzung von Informationen nach den
+          allgemeinen Gesetzen bleiben hiervon unberührt. Eine diesbezügliche Haftung ist
+          jedoch erst ab dem Zeitpunkt der Kenntnis einer konkreten Rechtsverletzung möglich.
+          Bei Bekanntwerden von entsprechenden Rechtsverletzungen werden wir diese Inhalte
+          umgehend entfernen.
+        </p>
+
+        <h2>Haftung für Links</h2>
+        <p>
+          Unser Angebot enthält Links zu externen Websites Dritter, auf deren Inhalte wir
+          keinen Einfluss haben. Deshalb können wir für diese fremden Inhalte auch keine
+          Gewähr übernehmen. Für die Inhalte der verlinkten Seiten ist stets der jeweilige
+          Anbieter oder Betreiber der Seiten verantwortlich. Die verlinkten Seiten wurden zum
+          Zeitpunkt der Verlinkung auf mögliche Rechtsverstöße überprüft. Rechtswidrige
+          Inhalte waren zum Zeitpunkt der Verlinkung nicht erkennable.
+        </p>
+        <p>
+          Eine permanente inhaltliche Kontrolle der verlinkten Seiten ist jedoch ohne konkrete
+          Anhaltspunkte einer Rechtsverletzung nicht zumutbar. Bei Bekanntwerden von
+          Rechtsverletzungen werden wir derartige Links umgehend entfernen.
+        </p>
+
+        <h2>Urheberrecht</h2>
+        <p>
+          Die durch die Seitenbetreiber erstellten Inhalte und Werke auf diesen Seiten
+          unterliegen dem deutschen Urheberrecht. Die Vervielfältigung, Bearbeitung, Verbreitung
+          und jede Art der Verwertung außerhalb der Grenzen des Urheberrechtes bedürfen der
+          schriftlichen Zustimmung des jeweiligen Autors bzw. Erstellers. Downloads und Kopien
+          dieser Seite sind nur für den privaten, nicht kommerziellen Gebrauch gestattet.
+        </p>
+        <p>
+          Soweit die Inhalte auf dieser Seite nicht vom Betreiber erstellt wurden, werden die
+          Urheberrechte Dritter beachtet. Insbesondere werden Inhalte Dritter als solche
+          gekennzeichnet. Sollten Sie trotzdem auf eine Urheberrechtsverletzung aufmerksam
+          werden, bitten wir um einen entsprechenden Hinweis. Bei Bekanntwerden von
+          Rechtsverletzungen werden wir derartige Inhalte umgehend entfernen.
+        </p>
+        {customHtml && customHtml.trim() && (
+          <div set:html={customHtml} />
+        )}
+
+        <div class="not-prose mt-10 pt-6 border-t border-slate-700 flex items-center justify-between">
+          <a href="/admin/rechtliches" class="text-xs text-slate-500 hover:text-gold transition-colors">✏️ Bearbeiten</a>
+          <button onclick="window.print()" class="text-xs px-3 py-1.5 bg-slate-700 hover:bg-slate-600 text-slate-300 rounded transition-colors">
+            Drucken / PDF
+          </button>
+        </div>
+      </div>
+    </section>
+  </Layout>
+)}
+
+<style>
+  .kore-legal {
+    max-width: 720px;
+    margin: 0 auto;
+    padding: 80px 28px 120px;
+  }
+  .kore-legal h1 {
+    font-family: var(--serif);
+    font-size: clamp(36px, 5vw, 56px);
+    font-weight: 400;
+    letter-spacing: -0.02em;
+    margin: 0 0 56px;
+    line-height: 1.05;
+  }
+  .kore-legal h2 {
+    font-family: var(--serif);
+    font-size: 22px;
+    font-weight: 400;
+    letter-spacing: -0.01em;
+    margin: 48px 0 12px;
+    color: var(--fg);
+  }
+  .kore-legal h2:first-of-type { margin-top: 0; }
+  .kore-legal p {
+    font-family: var(--sans);
+    font-size: 15px;
+    line-height: 1.7;
+    color: var(--fg-soft);
+    margin: 0 0 12px;
+  }
+  .kore-legal a {
+    color: var(--copper);
+    text-decoration: none;
+  }
+  .kore-legal a:hover { text-decoration: underline; text-underline-offset: 3px; }
+  .kore-legal-actions {
+    margin-top: 56px;
+    padding-top: 24px;
+    border-top: 1px solid var(--line);
+    display: flex;
+    justify-content: flex-end;
+  }
+  .kore-print-btn {
+    font-family: var(--mono);
+    font-size: 11px;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    background: var(--ink-800);
+    border: 1px solid var(--line-2);
+    border-radius: 8px;
+    color: var(--mute);
+    padding: 8px 16px;
+    cursor: pointer;
+    transition: color 0.15s ease, border-color 0.15s ease;
+  }
+  .kore-print-btn:hover { color: var(--fg); border-color: var(--line-3); }
+</style>

--- a/website/src/pages/kontakt.astro
+++ b/website/src/pages/kontakt.astro
@@ -1,8 +1,14 @@
 ---
 import Layout from '../layouts/Layout.astro';
+import KoreLayout from '../layouts/KoreLayout.astro';
+import KoreContact from '../components/kore/KoreContact.astro';
 import ContactHub from '../components/ContactHub.svelte';
+import BookingForm from '../components/BookingForm.svelte';
 import { config } from '../config/index';
 import { getEffectiveKontakt } from '../lib/content';
+
+const BRAND_ID = process.env.BRAND_ID ?? process.env.BRAND ?? 'mentolder';
+const isKore = BRAND_ID === 'korczewski';
 
 const { contact } = config;
 const kontakt = await getEffectiveKontakt();
@@ -15,70 +21,154 @@ const initialServiceKey = Astro.url.searchParams.get('service') ?? undefined;
 const initialDate  = Astro.url.searchParams.get('date')  ?? '';
 const initialStart = Astro.url.searchParams.get('start') ?? '';
 const initialEnd   = Astro.url.searchParams.get('end')   ?? '';
+
+// For Kore booking: detect if we have slot params to pre-open booking
+const koreBooking = isKore && rawMode === 'termin' && initialDate && initialStart;
 ---
 
-<Layout title="Kontakt" description="Nehmen Sie Kontakt auf. Kostenloses Erstgespräch vereinbaren.">
-  <section class="pt-28 pb-20 bg-dark">
-    <div class="max-w-5xl mx-auto px-6">
-      <div class="text-center mb-14">
-        <h1 class="text-4xl md:text-5xl font-bold text-light mb-4 font-serif">Kontakt aufnehmen</h1>
-        <p class="text-xl text-muted max-w-2xl mx-auto">{kontakt.intro}</p>
-      </div>
-
-      <div class="grid grid-cols-1 lg:grid-cols-5 gap-12">
-        <div class="lg:col-span-3 bg-dark-light rounded-2xl border border-dark-lighter p-8">
-          <ContactHub client:load initialMode={initialMode} initialServiceKey={initialServiceKey} {initialDate} {initialStart} {initialEnd} />
+{isKore ? (
+  <KoreLayout title="Kontakt" description="E-Mail oder direkt einen Termin buchen — Patrick Korczewski, Lüneburg." active="contact">
+    {koreBooking && (
+      <section class="kore-booking-section">
+        <div class="kore-booking-inner">
+          <span class="kore-booking-eyebrow">Terminbuchung</span>
+          <h1>Slot vormerken.</h1>
+          <p class="kore-booking-date">{initialDate} · {initialStart}{initialEnd ? ` – ${initialEnd}` : ''}</p>
+          <div class="kore-booking-form">
+            <BookingForm client:load initialType="erstgespraech" serviceKey={initialServiceKey} {initialDate} {initialStart} {initialEnd} />
+          </div>
+          <a href="/kontakt" class="kore-booking-back">← Zurück zur Übersicht</a>
+        </div>
+      </section>
+    )}
+    <KoreContact />
+  </KoreLayout>
+) : (
+  <Layout title="Kontakt" description="Nehmen Sie Kontakt auf. Kostenloses Erstgespräch vereinbaren.">
+    <section class="pt-28 pb-20 bg-dark">
+      <div class="max-w-5xl mx-auto px-6">
+        <div class="text-center mb-14">
+          <h1 class="text-4xl md:text-5xl font-bold text-light mb-4 font-serif">Kontakt aufnehmen</h1>
+          <p class="text-xl text-muted max-w-2xl mx-auto">{kontakt.intro}</p>
         </div>
 
-        <div class="lg:col-span-2 space-y-8">
-          <div class="bg-dark-light rounded-2xl border border-dark-lighter p-8">
-            <h2 class="text-xl font-bold text-gold mb-6 font-serif">Direkt erreichen</h2>
-            <div class="space-y-5">
-              {kontakt.showPhone && contact.phone && (
+        <div class="grid grid-cols-1 lg:grid-cols-5 gap-12">
+          <div class="lg:col-span-3 bg-dark-light rounded-2xl border border-dark-lighter p-8">
+            <ContactHub client:load initialMode={initialMode} initialServiceKey={initialServiceKey} {initialDate} {initialStart} {initialEnd} />
+          </div>
+
+          <div class="lg:col-span-2 space-y-8">
+            <div class="bg-dark-light rounded-2xl border border-dark-lighter p-8">
+              <h2 class="text-xl font-bold text-gold mb-6 font-serif">Direkt erreichen</h2>
+              <div class="space-y-5">
+                {kontakt.showPhone && contact.phone && (
+                  <div class="flex items-start gap-4">
+                    <svg class="w-6 h-6 text-gold flex-shrink-0 mt-1" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z" /></svg>
+                    <div>
+                      <p class="font-medium text-light">Telefon</p>
+                      <a href={`tel:${contact.phone}`} class="text-gold hover:underline text-lg">{contact.phone}</a>
+                    </div>
+                  </div>
+                )}
                 <div class="flex items-start gap-4">
-                  <svg class="w-6 h-6 text-gold flex-shrink-0 mt-1" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z" /></svg>
+                  <svg class="w-6 h-6 text-gold flex-shrink-0 mt-1" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" /></svg>
                   <div>
-                    <p class="font-medium text-light">Telefon</p>
-                    <a href={`tel:${contact.phone}`} class="text-gold hover:underline text-lg">{contact.phone}</a>
+                    <p class="font-medium text-light">E-Mail</p>
+                    <a href={`mailto:${contact.email}`} class="text-gold hover:underline text-lg">{contact.email}</a>
                   </div>
                 </div>
-              )}
-              <div class="flex items-start gap-4">
-                <svg class="w-6 h-6 text-gold flex-shrink-0 mt-1" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" /></svg>
-                <div>
-                  <p class="font-medium text-light">E-Mail</p>
-                  <a href={`mailto:${contact.email}`} class="text-gold hover:underline text-lg">{contact.email}</a>
-                </div>
-              </div>
-              <div class="flex items-start gap-4">
-                <svg class="w-6 h-6 text-gold flex-shrink-0 mt-1" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" /><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" /></svg>
-                <div>
-                  <p class="font-medium text-light">Standort</p>
-                  <p class="text-muted text-lg">{contact.city} und Umgebung</p>
+                <div class="flex items-start gap-4">
+                  <svg class="w-6 h-6 text-gold flex-shrink-0 mt-1" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" /><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" /></svg>
+                  <div>
+                    <p class="font-medium text-light">Standort</p>
+                    <p class="text-muted text-lg">{contact.city} und Umgebung</p>
+                  </div>
                 </div>
               </div>
             </div>
-          </div>
 
-          <div class="bg-dark-light rounded-2xl p-8 border-l-4 border-gold">
-            <h2 class="text-xl font-bold text-light mb-4 font-serif">{kontakt.sidebarTitle}</h2>
-            <p class="text-muted leading-relaxed">{kontakt.sidebarText}</p>
-            <p class="text-gold font-semibold mt-4">{kontakt.sidebarCta}</p>
-          </div>
-
-          {kontakt.showSteps && (
-            <div class="bg-dark-light rounded-2xl p-8 border border-dark-lighter">
-              <h2 class="text-xl font-bold text-light mb-4 font-serif">Wie geht es weiter?</h2>
-              <ol class="space-y-3 text-muted">
-                <li class="flex gap-3"><span class="text-gold font-bold">1.</span><span>Sie schreiben mir über das Formular oder per E-Mail</span></li>
-                <li class="flex gap-3"><span class="text-gold font-bold">2.</span><span>Ich melde mich innerhalb von 24 Stunden</span></li>
-                <li class="flex gap-3"><span class="text-gold font-bold">3.</span><span>Wir vereinbaren ein Kennenlerngespräch</span></li>
-                <li class="flex gap-3"><span class="text-gold font-bold">4.</span><span>Danach entscheiden Sie, ob wir zusammenarbeiten</span></li>
-              </ol>
+            <div class="bg-dark-light rounded-2xl p-8 border-l-4 border-gold">
+              <h2 class="text-xl font-bold text-light mb-4 font-serif">{kontakt.sidebarTitle}</h2>
+              <p class="text-muted leading-relaxed">{kontakt.sidebarText}</p>
+              <p class="text-gold font-semibold mt-4">{kontakt.sidebarCta}</p>
             </div>
-          )}
+
+            {kontakt.showSteps && (
+              <div class="bg-dark-light rounded-2xl p-8 border border-dark-lighter">
+                <h2 class="text-xl font-bold text-light mb-4 font-serif">Wie geht es weiter?</h2>
+                <ol class="space-y-3 text-muted">
+                  <li class="flex gap-3"><span class="text-gold font-bold">1.</span><span>Sie schreiben mir über das Formular oder per E-Mail</span></li>
+                  <li class="flex gap-3"><span class="text-gold font-bold">2.</span><span>Ich melde mich innerhalb von 24 Stunden</span></li>
+                  <li class="flex gap-3"><span class="text-gold font-bold">3.</span><span>Wir vereinbaren ein Kennenlerngespräch</span></li>
+                  <li class="flex gap-3"><span class="text-gold font-bold">4.</span><span>Danach entscheiden Sie, ob wir zusammenarbeiten</span></li>
+                </ol>
+              </div>
+            )}
+          </div>
         </div>
       </div>
-    </div>
-  </section>
-</Layout>
+    </section>
+  </Layout>
+)}
+
+<style>
+  /* Kore booking section — shown when arriving from a slot link */
+  .kore-booking-section {
+    max-width: 1280px;
+    margin: 0 auto;
+    padding: 80px 28px 0;
+  }
+  .kore-booking-inner {
+    background: var(--ink-850);
+    border: 1px solid var(--line);
+    border-radius: 16px;
+    padding: 48px;
+    max-width: 680px;
+  }
+  .kore-booking-eyebrow {
+    font-family: var(--mono);
+    font-size: 11px;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--copper);
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    margin-bottom: 12px;
+  }
+  .kore-booking-eyebrow::before {
+    content: "";
+    width: 22px;
+    height: 1px;
+    background: currentColor;
+  }
+  .kore-booking-inner h1 {
+    font-family: var(--serif);
+    font-weight: 400;
+    font-size: 36px;
+    letter-spacing: -0.02em;
+    margin: 0 0 12px;
+  }
+  .kore-booking-date {
+    font-family: var(--mono);
+    font-size: 13px;
+    color: var(--copper);
+    margin: 0 0 32px;
+    letter-spacing: 0.04em;
+  }
+  .kore-booking-form {
+    background: var(--ink-800);
+    border: 1px solid var(--line-2);
+    border-radius: 12px;
+    padding: 28px;
+    margin-bottom: 24px;
+  }
+  .kore-booking-back {
+    font-family: var(--mono);
+    font-size: 12px;
+    color: var(--mute);
+    text-decoration: none;
+    letter-spacing: 0.06em;
+  }
+  .kore-booking-back:hover { color: var(--fg); }
+</style>


### PR DESCRIPTION
## Summary
- Subpages (`/kontakt`, `/impressum`, `/datenschutz`) were showing the mentolder dark/gold theme on `web.korczewski.de` instead of the Kore design system — wrong nav, wrong fonts (Newsreader vs Instrument Serif), wrong accent color (gold vs lime)
- New `KoreLayout.astro` wraps `Layout` with `brand="korczewski-kore"` and auto-injects `KoreSubNav` + `KoreFooter`, making it trivial to add Kore brand to any subpage
- `KoreSubNav` gains a `subpage` prop — when true, hash links become `/#anchor` so they navigate to the correct homepage section from any URL
- `kontakt.astro`: Kore branch shows `KoreContact` (calendar slots + email, consistent with homepage design); handles `?mode=termin` slot params with a Kore-styled pre-filled `BookingForm` panel
- `impressum.astro` + `datenschutz.astro`: Kore branch uses `.kore-legal` article style (Instrument Serif headings, copper links, ink-850 surface); mentolder branch unchanged

## Test plan
- [ ] Navigate to `web.korczewski.de/kontakt` — should show Kore subnav, Kore contact section, Kore footer
- [ ] Click a calendar slot on the homepage → arrives at `/kontakt?mode=termin&date=...` → should show Kore-styled booking form above the contact section
- [ ] Navigate to `web.korczewski.de/impressum` and `/datenschutz` — should show Kore subnav, Instrument Serif headings, copper links, Kore footer
- [ ] Subnav links (Cluster, Leistungen, etc.) from `/kontakt` → navigate to `/#work` etc. on homepage (not broken anchors)
- [ ] `web.mentolder.de` pages unchanged (mentolder nav, Newsreader font, gold accents)

🤖 Generated with [Claude Code](https://claude.com/claude-code)