### PR TITLE
fix(taskfile): livekit:status no longer aborts before recordings section

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -2245,9 +2245,9 @@ tasks:
           -l 'app in (livekit-server,livekit-ingress,livekit-egress,livekit-redis)' -o wide
         echo "=== Service / Ingress ===" && kubectl $CTX_FLAG -n "$NS" get svc,ingress,ingressroute,middleware \
           -l 'app in (livekit-server,livekit-ingress)' 2>/dev/null
-        kubectl $CTX_FLAG -n "$NS" get svc livekit-server livekit-ingress-rtmp 2>/dev/null
-        kubectl $CTX_FLAG -n "$NS" get ingressroute livekit-server middleware/livekit-cors 2>/dev/null
-        echo "=== Recordings PVC ===" && kubectl $CTX_FLAG -n "$NS" get pvc livekit-recordings-pvc 2>/dev/null
+        kubectl $CTX_FLAG -n "$NS" get svc livekit-server livekit-ingress-rtmp 2>/dev/null || true
+        kubectl $CTX_FLAG -n "$NS" get ingressroute/livekit-server middleware/livekit-cors 2>/dev/null || true
+        echo "=== Recordings PVC ===" && kubectl $CTX_FLAG -n "$NS" get pvc livekit-recordings-pvc 2>/dev/null || true
         echo "=== Recordings count ==="
         kubectl $CTX_FLAG -n "$NS" exec deployment/livekit-egress -- sh -c 'ls /recordings/ 2>/dev/null | wc -l' 2>/dev/null \
           || echo "(egress pod not ready)"


### PR DESCRIPTION
## Summary
- `task livekit:status` exited 1 before printing the Recordings PVC / count sections on every env (dashboard surfaced this as `exit status 1` targeting korczewski).
- Root cause: `kubectl get ingressroute livekit-server middleware/livekit-cors` mixes a bare name with `resource/name` form — kubectl rejects this with exit 1, `2>/dev/null` hid the message, and Task's `sh -ec` propagated the failure.
- Fix: use `ingressroute/livekit-server middleware/livekit-cors` (kind/name for both) and add `|| true` to optional named lookups so a missing svc/pvc doesn't kill the report.

## Test plan
- [x] `task livekit:status ENV=korczewski` exits 0, prints all sections through Recordings count
- [x] `task livekit:status ENV=mentolder` exits 0, prints all sections through Recordings count

🤖 Generated with [Claude Code](https://claude.com/claude-code)