### PR TITLE
fix(dashboard): use public Keycloak issuer URL in oauth2-proxy

### DIFF
--- a/prod-korczewski/oauth2-proxy-dashboard.yaml
+++ b/prod-korczewski/oauth2-proxy-dashboard.yaml
@@ -55,7 +55,7 @@ spec:
             - --client-id=dashboard
             - --client-secret=$(DASHBOARD_OIDC_SECRET)
             - --redirect-url=https://${DASHBOARD_DOMAIN}/oauth2/callback
-            - --oidc-issuer-url=http://keycloak:8080/realms/workspace
+            - --oidc-issuer-url=https://auth.${PROD_DOMAIN}/realms/workspace
             - --ssl-insecure-skip-verify=true
             - --skip-oidc-discovery=true
             - --login-url=https://auth.${PROD_DOMAIN}/realms/workspace/protocol/openid-connect/auth

--- a/prod-mentolder/oauth2-proxy-dashboard.yaml
+++ b/prod-mentolder/oauth2-proxy-dashboard.yaml
@@ -55,7 +55,7 @@ spec:
             - --client-id=dashboard
             - --client-secret=$(DASHBOARD_OIDC_SECRET)
             - --redirect-url=https://${DASHBOARD_DOMAIN}/oauth2/callback
-            - --oidc-issuer-url=http://keycloak:8080/realms/workspace
+            - --oidc-issuer-url=https://auth.${PROD_DOMAIN}/realms/workspace
             - --ssl-insecure-skip-verify=true
             - --skip-oidc-discovery=true
             - --login-url=https://auth.${PROD_DOMAIN}/realms/workspace/protocol/openid-connect/auth


### PR DESCRIPTION
## Summary
- Switch dashboard `oauth2-proxy` `--oidc-issuer-url` from the internal `http://keycloak:8080/realms/workspace` to the public `https://auth.${PROD_DOMAIN}/realms/workspace` in both prod overlays.
- Unblocks `https://dashboard.<DOMAIN>/oauth2/callback`, which was returning 500 because Keycloak signs ID tokens with `iss=https://auth.<DOMAIN>/...` (its `KC_HOSTNAME`) and oauth2-proxy rejected them on issuer verification.
- Aligns with the pattern already used by `prod/patch-oauth2-proxy-{traefik,brett,docs,mailpit}.yaml`.
- `PROD_DOMAIN` is already wired into the ArgoCD ApplicationSet plugin env, so each cluster gets the right value on sync — future deploys won't regress.

## Root cause (live mentolder pod log, pre-fix)
```
oidc: id token issued by a different provider,
  expected "http://keycloak:8080/realms/workspace"
  got     "https://auth.mentolder.de/realms/workspace"
```

## Test plan
- [ ] ArgoCD syncs `workspace-mentolder` and `workspace-korczewski`
- [ ] `kubectl --context mentolder get deploy oauth2-proxy-dashboard -n workspace -o jsonpath='{.spec.template.spec.containers[0].args}'` shows `--oidc-issuer-url=https://auth.mentolder.de/realms/workspace`
- [ ] Same check on `-n workspace-korczewski` shows `…auth.korczewski.de…`
- [ ] Logging in at `https://dashboard.mentolder.de` and `https://dashboard.korczewski.de` no longer returns 500 on `/oauth2/callback`

🤖 Generated with [Claude Code](https://claude.com/claude-code)