### PR TITLE
fix(dashboard): match allowlist by preferred-username; swap Traefik tile for Dashboard

### DIFF
--- a/dashboard/web/lib/auth.js
+++ b/dashboard/web/lib/auth.js
@@ -13,7 +13,13 @@ function buildAdminGuard(rawAllowlist) {
   );
 
   return function adminGuard(req, res, next) {
-    const user = req.headers['x-auth-request-user'];
+    // oauth2-proxy with --set-xauthrequest=true sets X-Auth-Request-User to the
+    // OIDC `sub` (a UUID for Keycloak), and X-Auth-Request-Preferred-Username
+    // to the human-readable username. The allowlist (PORTAL_ADMIN_USERNAME) is
+    // a comma-separated list of usernames, so prefer the username header.
+    const user =
+      req.headers['x-auth-request-preferred-username'] ||
+      req.headers['x-auth-request-user'];
     if (typeof user !== 'string' || !allowed.has(user)) {
       res.status(403).send('forbidden');
       return;

--- a/dashboard/web/test/auth.test.js
+++ b/dashboard/web/test/auth.test.js
@@ -39,6 +39,31 @@ test('buildAdminGuard handles whitespace and empty entries', () => {
   assert.equal(called, true);
 });
 
+test('buildAdminGuard prefers x-auth-request-preferred-username over x-auth-request-user', () => {
+  // Real Keycloak setup: x-auth-request-user is the sub UUID, the
+  // human-readable username is in x-auth-request-preferred-username.
+  const guard = buildAdminGuard('alice,bob');
+  const req = {
+    headers: {
+      'x-auth-request-user': 'caf40515-52b3-44c6-aa64-4416f75e1ede',
+      'x-auth-request-preferred-username': 'alice',
+    },
+  };
+  const res = mockRes();
+  let called = false;
+  guard(req, res, () => { called = true; });
+  assert.equal(called, true);
+  assert.equal(req.adminUser, 'alice');
+});
+
+test('buildAdminGuard rejects when only sub UUID is present and not allowlisted', () => {
+  const guard = buildAdminGuard('alice,bob');
+  const req = { headers: { 'x-auth-request-user': 'caf40515-52b3-44c6-aa64-4416f75e1ede' } };
+  const res = mockRes();
+  guard(req, res, () => assert.fail('next should not be called'));
+  assert.equal(res.statusCode, 403);
+});
+
 function mockRes() {
   return {
     statusCode: 200,

--- a/prod-korczewski/dashboard-web.yaml
+++ b/prod-korczewski/dashboard-web.yaml
@@ -91,7 +91,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: dashboard-web
-          image: ghcr.io/paddione/workspace-dashboard:0.2.0
+          image: ghcr.io/paddione/workspace-dashboard:0.2.1
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 3000

--- a/prod-mentolder/dashboard-web.yaml
+++ b/prod-mentolder/dashboard-web.yaml
@@ -91,7 +91,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: dashboard-web
-          image: ghcr.io/paddione/workspace-dashboard:0.2.0
+          image: ghcr.io/paddione/workspace-dashboard:0.2.1
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 3000

--- a/website/src/pages/admin.astro
+++ b/website/src/pages/admin.astro
@@ -52,10 +52,11 @@ const docsUrl     = process.env.DOCS_URL ?? '';
 const authUrl     = process.env.AUTH_EXTERNAL_URL ?? '';
 const vaultUrl    = process.env.VAULT_EXTERNAL_URL ?? '';
 const wbUrl       = process.env.WHITEBOARD_EXTERNAL_URL ?? '';
-const traefikUrl  = process.env.TRAEFIK_EXTERNAL_URL ?? '';
 const mailUrl     = process.env.MAIL_EXTERNAL_URL ?? '';
 const bretDomain  = process.env.BRETT_DOMAIN ?? '';
 const bretUrl     = bretDomain ? `https://${bretDomain}` : '';
+const prodDomain  = process.env.PROD_DOMAIN ?? '';
+const dashUrl     = prodDomain && prodDomain !== 'localhost' ? `https://dashboard.${prodDomain}` : '';
 const SVG = {
   inbox:      `<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3.5" width="12" height="10" rx="1"/><path d="M2 10h3.5l1.5 2 1.5-2H12"/></svg>`,
   folder:     `<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M1.5 4.5h5L8 3h6.5v9.5a1 1 0 0 1-1 1h-12a1 1 0 0 1-1-1V5.5a1 1 0 0 1 1-1z"/></svg>`,
@@ -68,6 +69,7 @@ const SVG = {
   key:        `<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="5.5" cy="7" r="3.5"/><path d="M8.5 9.5l5.5 5.5M11 12l2-2"/></svg>`,
   book:       `<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M3 2h9a1 1 0 0 1 1 1v10a1 1 0 0 1-1 1H3"/><path d="M3 2a1 1 0 0 0-1 1v10a1 1 0 0 0 1 1"/><path d="M8 6h3M8 9h3"/></svg>`,
   network:    `<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="3" r="1.5"/><circle cx="2.5" cy="12" r="1.5"/><circle cx="13.5" cy="12" r="1.5"/><path d="M8 4.5v3M8 7.5l-4.5 3M8 7.5l4.5 3"/></svg>`,
+  dashboard:  `<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="2" width="5" height="5" rx="0.5"/><rect x="9" y="2" width="5" height="5" rx="0.5"/><rect x="2" y="9" width="5" height="5" rx="0.5"/><rect x="9" y="9" width="5" height="5" rx="0.5"/></svg>`,
   mail:       `<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="4" width="12" height="9" rx="1"/><path d="M2 4.5l6 4.5 6-4.5"/></svg>`,
 };
 
@@ -84,7 +86,7 @@ const adminLinks = [
   ...(vaultUrl   ? [{ href: vaultUrl,                                 label: 'Passwörter', icon: SVG.lock }] : []),
   ...(authUrl    ? [{ href: `${authUrl}/admin/workspace/console/`,    label: 'Keycloak',   icon: SVG.key }] : []),
   ...(docsUrl    ? [{ href: docsUrl,                                  label: 'Docs',       icon: SVG.book }] : []),
-  ...(traefikUrl ? [{ href: traefikUrl,                               label: 'Traefik',    icon: SVG.network }] : []),
+  ...(dashUrl    ? [{ href: dashUrl,                                  label: 'Dashboard',  icon: SVG.dashboard }] : []),
   ...(mailUrl    ? [{ href: mailUrl,                                  label: 'Mailpit',    icon: SVG.mail }] : []),
 ];
 


### PR DESCRIPTION
## Summary
- **Dashboard 403 Forbidden after OAuth callback**: oauth2-proxy was sending the Keycloak `sub` UUID in `X-Auth-Request-User`, but `PORTAL_ADMIN_USERNAME` is a list of human usernames (`paddione,gekko`), so the comparison always failed. Switch the guard to read `X-Auth-Request-Preferred-Username` first, falling back to `X-Auth-Request-User`.
- **Admin menu**: drop the unused Traefik tile, add a Dashboard tile that points at `https://dashboard.${PROD_DOMAIN}`. URL is derived from the existing `PROD_DOMAIN` env var — no new env wiring.
- Bump dashboard image to `0.2.1` in both prod overlays so the new auth code rolls out.

## Root cause (live mentolder oauth2-proxy log)
```
[AuthSuccess] Authenticated via OAuth2: Session{
  email:patrick@korczewski.de
  user:caf40515-52b3-44c6-aa64-4416f75e1ede   ← X-Auth-Request-User (UUID)
  PreferredUsername:paddione                  ← what the allowlist expects
}
```

## Test plan
- [x] `node --test dashboard/web/test/auth.test.js` — 6/6 pass (4 existing + 2 new precedence tests)
- [ ] After deploy, login at https://dashboard.mentolder.de works for `paddione` (no 403)
- [ ] After deploy, login at https://dashboard.korczewski.de works
- [ ] `https://web.mentolder.de/admin` admin menu shows "Dashboard" tile, no "Traefik" tile

🤖 Generated with [Claude Code](https://claude.com/claude-code)