### PR TITLE
fix(dashboard): debug log + email fallback in adminGuard; bump to 0.2.2

### DIFF
--- a/dashboard/web/lib/auth.js
+++ b/dashboard/web/lib/auth.js
@@ -15,16 +15,26 @@ function buildAdminGuard(rawAllowlist) {
   return function adminGuard(req, res, next) {
     // oauth2-proxy with --set-xauthrequest=true sets X-Auth-Request-User to the
     // OIDC `sub` (a UUID for Keycloak), and X-Auth-Request-Preferred-Username
-    // to the human-readable username. The allowlist (PORTAL_ADMIN_USERNAME) is
-    // a comma-separated list of usernames, so prefer the username header.
-    const user =
-      req.headers['x-auth-request-preferred-username'] ||
-      req.headers['x-auth-request-user'];
-    if (typeof user !== 'string' || !allowed.has(user)) {
+    // to the human-readable username. PORTAL_ADMIN_USERNAME may list either
+    // usernames (e.g. "paddione") or full emails — try each header in turn.
+    const candidates = [
+      req.headers['x-auth-request-preferred-username'],
+      req.headers['x-auth-request-email'],
+      req.headers['x-auth-request-user'],
+    ];
+    const matched = candidates.find(c => typeof c === 'string' && allowed.has(c));
+    if (!matched) {
+      console.warn('[adminGuard] reject', JSON.stringify({
+        path: req.path,
+        preferredUsername: req.headers['x-auth-request-preferred-username'] || null,
+        email: req.headers['x-auth-request-email'] || null,
+        user: req.headers['x-auth-request-user'] || null,
+        allowlistSize: allowed.size,
+      }));
       res.status(403).send('forbidden');
       return;
     }
-    req.adminUser = user;
+    req.adminUser = matched;
     next();
   };
 }

--- a/dashboard/web/test/auth.test.js
+++ b/dashboard/web/test/auth.test.js
@@ -44,6 +44,7 @@ test('buildAdminGuard prefers x-auth-request-preferred-username over x-auth-requ
   // human-readable username is in x-auth-request-preferred-username.
   const guard = buildAdminGuard('alice,bob');
   const req = {
+    path: '/api/k8s/pods',
     headers: {
       'x-auth-request-user': 'caf40515-52b3-44c6-aa64-4416f75e1ede',
       'x-auth-request-preferred-username': 'alice',
@@ -58,10 +59,28 @@ test('buildAdminGuard prefers x-auth-request-preferred-username over x-auth-requ
 
 test('buildAdminGuard rejects when only sub UUID is present and not allowlisted', () => {
   const guard = buildAdminGuard('alice,bob');
-  const req = { headers: { 'x-auth-request-user': 'caf40515-52b3-44c6-aa64-4416f75e1ede' } };
+  const req = { path: '/', headers: { 'x-auth-request-user': 'caf40515-52b3-44c6-aa64-4416f75e1ede' } };
   const res = mockRes();
   guard(req, res, () => assert.fail('next should not be called'));
   assert.equal(res.statusCode, 403);
+});
+
+test('buildAdminGuard accepts email as fallback when listed', () => {
+  // Allows the operator to seed the allowlist with an email instead of a
+  // username — useful when oauth2-proxy isn't passing preferred_username.
+  const guard = buildAdminGuard('paddione,patrick@korczewski.de');
+  const req = {
+    path: '/',
+    headers: {
+      'x-auth-request-user': 'caf40515-52b3-44c6-aa64-4416f75e1ede',
+      'x-auth-request-email': 'patrick@korczewski.de',
+    },
+  };
+  const res = mockRes();
+  let called = false;
+  guard(req, res, () => { called = true; });
+  assert.equal(called, true);
+  assert.equal(req.adminUser, 'patrick@korczewski.de');
 });
 
 function mockRes() {

--- a/prod-korczewski/dashboard-web.yaml
+++ b/prod-korczewski/dashboard-web.yaml
@@ -91,7 +91,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: dashboard-web
-          image: ghcr.io/paddione/workspace-dashboard:0.2.1
+          image: ghcr.io/paddione/workspace-dashboard:0.2.2
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 3000

--- a/prod-mentolder/dashboard-web.yaml
+++ b/prod-mentolder/dashboard-web.yaml
@@ -91,7 +91,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: dashboard-web
-          image: ghcr.io/paddione/workspace-dashboard:0.2.1
+          image: ghcr.io/paddione/workspace-dashboard:0.2.2
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 3000


### PR DESCRIPTION
## Summary
- Login at https://dashboard.mentolder.de still 403s after PR #552 even though oauth2-proxy stored \`PreferredUsername:paddione\` in the session. The dashboard pod has the new auth.js (verified) yet upstream returns 403 — so the \`X-Auth-Request-Preferred-Username\` header isn't arriving at express, and we have no signal as to why.
- Add a one-line \`console.warn\` on rejection that dumps the four relevant header values + request path, so the next 403 in the logs tells us exactly what oauth2-proxy is sending.
- Widen the matcher to also accept \`X-Auth-Request-Email\` — the operator can drop \`patrick@korczewski.de\` into the allowlist as a working fallback while we track down the preferred-username drop.
- Bump dashboard image to \`0.2.2\` in both prod overlays.

## Test plan
- [x] \`node --test dashboard/web/test/auth.test.js\` — 7/7 (added email-fallback test)
- [ ] After deploy, retry login → check \`kubectl logs deploy/dashboard-web\` for one \`[adminGuard] reject\` line, decide next move

🤖 Generated with [Claude Code](https://claude.com/claude-code)