### PR TITLE
fix(dashboard): read X-Forwarded-* headers (reverse-proxy mode); bump to 0.2.3

### DIFF
--- a/dashboard/web/lib/auth.js
+++ b/dashboard/web/lib/auth.js
@@ -13,22 +13,32 @@ function buildAdminGuard(rawAllowlist) {
   );
 
   return function adminGuard(req, res, next) {
-    // oauth2-proxy with --set-xauthrequest=true sets X-Auth-Request-User to the
-    // OIDC `sub` (a UUID for Keycloak), and X-Auth-Request-Preferred-Username
-    // to the human-readable username. PORTAL_ADMIN_USERNAME may list either
-    // usernames (e.g. "paddione") or full emails — try each header in turn.
+    // oauth2-proxy in reverse-proxy mode (--upstream=...) passes user
+    // identity to the upstream as X-Forwarded-* headers (via --pass-user-headers,
+    // default-on). The X-Auth-Request-* family is only set on /oauth2/auth
+    // responses for the Traefik forward-auth pattern, so reading those alone
+    // misses the reverse-proxy case. Try both, falling back to email or user.
+    // PORTAL_ADMIN_USERNAME may list either usernames (e.g. "paddione") or
+    // full emails (e.g. "patrick@korczewski.de").
+    const h = req.headers;
     const candidates = [
-      req.headers['x-auth-request-preferred-username'],
-      req.headers['x-auth-request-email'],
-      req.headers['x-auth-request-user'],
+      h['x-forwarded-preferred-username'],
+      h['x-auth-request-preferred-username'],
+      h['x-forwarded-email'],
+      h['x-auth-request-email'],
+      h['x-forwarded-user'],
+      h['x-auth-request-user'],
     ];
     const matched = candidates.find(c => typeof c === 'string' && allowed.has(c));
     if (!matched) {
       console.warn('[adminGuard] reject', JSON.stringify({
         path: req.path,
-        preferredUsername: req.headers['x-auth-request-preferred-username'] || null,
-        email: req.headers['x-auth-request-email'] || null,
-        user: req.headers['x-auth-request-user'] || null,
+        fwdPreferredUsername: h['x-forwarded-preferred-username'] || null,
+        authPreferredUsername: h['x-auth-request-preferred-username'] || null,
+        fwdEmail: h['x-forwarded-email'] || null,
+        authEmail: h['x-auth-request-email'] || null,
+        fwdUser: h['x-forwarded-user'] || null,
+        authUser: h['x-auth-request-user'] || null,
         allowlistSize: allowed.size,
       }));
       res.status(403).send('forbidden');

--- a/dashboard/web/test/auth.test.js
+++ b/dashboard/web/test/auth.test.js
@@ -83,6 +83,27 @@ test('buildAdminGuard accepts email as fallback when listed', () => {
   assert.equal(req.adminUser, 'patrick@korczewski.de');
 });
 
+test('buildAdminGuard accepts X-Forwarded-Preferred-Username (reverse-proxy mode)', () => {
+  // oauth2-proxy with --upstream=... uses X-Forwarded-* headers for
+  // upstream identity (driven by --pass-user-headers, default-on). The
+  // X-Auth-Request-* family is only set on /oauth2/auth responses for
+  // the Traefik forward-auth pattern.
+  const guard = buildAdminGuard('paddione,gekko');
+  const req = {
+    path: '/',
+    headers: {
+      'x-forwarded-user': 'caf40515-52b3-44c6-aa64-4416f75e1ede',
+      'x-forwarded-email': 'patrick@korczewski.de',
+      'x-forwarded-preferred-username': 'paddione',
+    },
+  };
+  const res = mockRes();
+  let called = false;
+  guard(req, res, () => { called = true; });
+  assert.equal(called, true);
+  assert.equal(req.adminUser, 'paddione');
+});
+
 function mockRes() {
   return {
     statusCode: 200,

--- a/prod-korczewski/dashboard-web.yaml
+++ b/prod-korczewski/dashboard-web.yaml
@@ -91,7 +91,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: dashboard-web
-          image: ghcr.io/paddione/workspace-dashboard:0.2.2
+          image: ghcr.io/paddione/workspace-dashboard:0.2.3
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 3000

--- a/prod-mentolder/dashboard-web.yaml
+++ b/prod-mentolder/dashboard-web.yaml
@@ -91,7 +91,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: dashboard-web
-          image: ghcr.io/paddione/workspace-dashboard:0.2.2
+          image: ghcr.io/paddione/workspace-dashboard:0.2.3
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 3000


### PR DESCRIPTION
## Root cause (proven by 0.2.2 debug log)
\`\`\`
[adminGuard] reject {"path":"/","preferredUsername":null,"email":null,"user":null,"allowlistSize":2}
\`\`\`
All three \`X-Auth-Request-*\` headers arrive empty. Dashboard's IngressRoute proxies directly to \`oauth2-proxy-dashboard:4180\`, which forwards to \`dashboard-web:3000\` via \`--upstream\` (reverse-proxy mode). In that mode oauth2-proxy uses \`--pass-user-headers\` (default-on) to set \`X-Forwarded-*\` headers; the \`X-Auth-Request-*\` family is only emitted on the \`/oauth2/auth\` response for Traefik forward-auth — which we don't use.

## Summary
- Read \`X-Forwarded-Preferred-Username\` first (the actual header reverse-proxy mode sends), then the \`X-Auth-Request-*\` fallbacks.
- Allowlist accepts usernames or emails.
- Image bumped to \`0.2.3\` in both prod overlays.

## Test plan
- [x] \`node --test dashboard/web/test/auth.test.js\` — 8/8 (added X-Forwarded-Preferred-Username case)
- [ ] After deploy, login at https://dashboard.mentolder.de no longer 403s
- [ ] Same on https://dashboard.korczewski.de

🤖 Generated with [Claude Code](https://claude.com/claude-code)