### PR TITLE
fix(admin): inline rename + error surfacing for AdminShortcuts (BR-20260506-c409)

### DIFF
--- a/website/src/components/admin/AdminShortcuts.svelte
+++ b/website/src/components/admin/AdminShortcuts.svelte
@@ -18,6 +18,29 @@
   let saving = $state(false);
   let hoveredId = $state<string | null>(null);
 
+  // Inline rename state
+  let editingId = $state<string | null>(null);
+  let editLabel = $state('');
+  let editUrl = $state('');
+  let editSaving = $state(false);
+
+  // Error surfacing — replaces the previous silent catches
+  let errorMsg = $state<string | null>(null);
+  let errorTimer: ReturnType<typeof setTimeout> | null = null;
+  function showError(msg: string) {
+    errorMsg = msg;
+    if (errorTimer) clearTimeout(errorTimer);
+    errorTimer = setTimeout(() => { errorMsg = null; }, 5000);
+  }
+  async function readError(res: Response, fallback: string): Promise<string> {
+    try {
+      const j = await res.json();
+      return j?.error ?? fallback;
+    } catch {
+      return fallback;
+    }
+  }
+
   function faviconUrl(url: string): string {
     try {
       const { hostname } = new URL(url);
@@ -60,9 +83,11 @@
         formUrl = '';
         formLabel = '';
         showForm = false;
+      } else {
+        showError(await readError(res, 'Speichern fehlgeschlagen.'));
       }
-    } catch {
-      // silent
+    } catch (e) {
+      showError('Netzwerkfehler beim Speichern.');
     } finally {
       saving = false;
     }
@@ -77,9 +102,47 @@
       });
       if (res.ok) {
         links = links.filter(l => l.id !== id);
+      } else {
+        showError(await readError(res, 'Löschen fehlgeschlagen.'));
+      }
+    } catch (e) {
+      showError('Netzwerkfehler beim Löschen.');
+    }
+  }
+
+  function startEdit(link: Shortcut) {
+    editingId = link.id;
+    editLabel = link.label;
+    editUrl = link.url;
+  }
+  function cancelEdit() {
+    editingId = null;
+    editLabel = '';
+    editUrl = '';
+  }
+  async function saveEdit() {
+    if (!editingId || editSaving) return;
+    const trimmedLabel = editLabel.trim();
+    const trimmedUrl = editUrl.trim();
+    if (!trimmedLabel || !trimmedUrl.startsWith('https://')) return;
+    editSaving = true;
+    try {
+      const res = await fetch('/api/admin/shortcuts/update', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id: editingId, url: trimmedUrl, label: trimmedLabel }),
+      });
+      if (res.ok) {
+        const updated = await res.json();
+        links = links.map(l => l.id === updated.id ? { ...l, ...updated } : l);
+        cancelEdit();
+      } else {
+        showError(await readError(res, 'Aktualisieren fehlgeschlagen.'));
       }
     } catch {
-      // silent
+      showError('Netzwerkfehler beim Aktualisieren.');
+    } finally {
+      editSaving = false;
     }
   }
 
@@ -93,6 +156,13 @@
 <div class="mb-6">
   <p class="text-xs font-semibold text-muted uppercase tracking-widest mb-2">Eigene Links</p>
 
+  {#if errorMsg}
+    <div class="mb-3 px-3 py-2 bg-red-900/30 border border-red-800 text-red-200 text-xs rounded-lg flex items-center justify-between gap-2">
+      <span>{errorMsg}</span>
+      <button onclick={() => { errorMsg = null; }} aria-label="Fehlermeldung schließen" class="text-red-300 hover:text-red-100">×</button>
+    </div>
+  {/if}
+
   <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3">
     {#each links as link (link.id)}
       <!-- svelte-ignore a11y_no_static_element_interactions -->
@@ -101,44 +171,83 @@
         onmouseenter={() => (hoveredId = link.id)}
         onmouseleave={() => (hoveredId = null)}
       >
-        <a
-          href={link.url}
-          target="_blank"
-          rel="noopener noreferrer"
-          class="flex flex-col items-center gap-1.5 p-4 bg-dark-light rounded-xl border border-dark-lighter hover:border-gold/40 transition-colors text-center"
-        >
-          <img
-            src={faviconUrl(link.url)}
-            alt=""
-            width="24"
-            height="24"
-            class="rounded-sm"
-            onerror={(e) => { const img = e.currentTarget as HTMLImageElement; img.style.display = 'none'; (img.nextElementSibling as HTMLElement | null)?.style.setProperty('display', 'block'); }}
-          />
-          <!-- Fallback icon -->
-          <svg
-            style="display:none"
-            xmlns="http://www.w3.org/2000/svg"
-            width="24"
-            height="24"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2"
-            class="text-muted"
+        {#if editingId === link.id}
+          <div class="flex flex-col gap-1.5 p-3 bg-dark-light rounded-xl border border-gold/40">
+            <input
+              type="text"
+              bind:value={editLabel}
+              placeholder="Name"
+              class="w-full bg-dark rounded border border-dark-lighter px-2 py-1 text-xs text-light placeholder:text-muted focus:outline-none focus:border-gold/50"
+            />
+            <input
+              type="url"
+              bind:value={editUrl}
+              placeholder="https://"
+              class="w-full bg-dark rounded border border-dark-lighter px-2 py-1 text-xs text-light placeholder:text-muted focus:outline-none focus:border-gold/50"
+            />
+            <div class="flex gap-1.5">
+              <button
+                onclick={saveEdit}
+                disabled={editSaving || !editLabel.trim() || !editUrl.startsWith('https://')}
+                class="flex-1 px-2 py-1 bg-gold text-dark text-[11px] font-semibold rounded hover:bg-gold/90 disabled:opacity-40"
+              >
+                {editSaving ? '…' : 'Speichern'}
+              </button>
+              <button
+                onclick={cancelEdit}
+                class="px-2 py-1 bg-dark border border-dark-lighter text-[11px] text-muted hover:text-light rounded"
+              >✕</button>
+            </div>
+          </div>
+        {:else}
+          <a
+            href={link.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            class="flex flex-col items-center gap-1.5 p-4 bg-dark-light rounded-xl border border-dark-lighter hover:border-gold/40 transition-colors text-center"
           >
-            <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
-            <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
-          </svg>
-          <span class="text-xs font-medium text-muted truncate w-full text-center">{link.label}</span>
-        </a>
+            <img
+              src={faviconUrl(link.url)}
+              alt=""
+              width="24"
+              height="24"
+              class="rounded-sm"
+              onerror={(e) => { const img = e.currentTarget as HTMLImageElement; img.style.display = 'none'; (img.nextElementSibling as HTMLElement | null)?.style.setProperty('display', 'block'); }}
+            />
+            <!-- Fallback icon -->
+            <svg
+              style="display:none"
+              xmlns="http://www.w3.org/2000/svg"
+              width="24"
+              height="24"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              class="text-muted"
+            >
+              <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+              <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+            </svg>
+            <span class="text-xs font-medium text-muted truncate w-full text-center">{link.label}</span>
+          </a>
 
-        {#if hoveredId === link.id}
-          <button
-            onclick={() => remove(link.id)}
-            class="absolute -top-1.5 -right-1.5 w-5 h-5 bg-red-600 hover:bg-red-500 text-white rounded-full text-xs flex items-center justify-center leading-none transition-colors"
-            aria-label="Link entfernen"
-          >×</button>
+          {#if hoveredId === link.id}
+            <div class="absolute -top-1.5 -right-1.5 flex gap-1">
+              <button
+                onclick={() => startEdit(link)}
+                class="w-5 h-5 bg-gray-700 hover:bg-gray-600 text-white rounded-full text-[10px] flex items-center justify-center leading-none transition-colors"
+                aria-label="Link bearbeiten"
+                title="Bearbeiten"
+              >✎</button>
+              <button
+                onclick={() => remove(link.id)}
+                class="w-5 h-5 bg-red-600 hover:bg-red-500 text-white rounded-full text-xs flex items-center justify-center leading-none transition-colors"
+                aria-label="Link entfernen"
+                title="Entfernen"
+              >×</button>
+            </div>
+          {/if}
         {/if}
       </div>
     {/each}

--- a/website/src/lib/website-db.ts
+++ b/website/src/lib/website-db.ts
@@ -2859,6 +2859,25 @@ export async function deleteAdminShortcut(id: string): Promise<void> {
   await pool.query('DELETE FROM admin_shortcuts WHERE id = $1', [id]);
 }
 
+export async function updateAdminShortcut(
+  id: string,
+  fields: { url?: string; label?: string }
+): Promise<AdminShortcut | null> {
+  await initAdminShortcutsTable();
+  const sets: string[] = [];
+  const vals: unknown[] = [id];
+  if (fields.url !== undefined)   { vals.push(fields.url);   sets.push(`url   = $${vals.length}`); }
+  if (fields.label !== undefined) { vals.push(fields.label); sets.push(`label = $${vals.length}`); }
+  if (sets.length === 0) return null;
+  const result = await pool.query(
+    `UPDATE admin_shortcuts SET ${sets.join(', ')}
+     WHERE id = $1
+     RETURNING id, url, label, sort_order AS "sortOrder", created_at AS "createdAt"`,
+    vals
+  );
+  return result.rows[0] ?? null;
+}
+
 // ── DSGVO Audit Log ──────────────────────────────────────────────────────────
 
 async function initDsgvoAuditTable(): Promise<void> {

--- a/website/src/pages/api/admin/shortcuts/update.ts
+++ b/website/src/pages/api/admin/shortcuts/update.ts
@@ -1,0 +1,58 @@
+import type { APIRoute } from 'astro';
+import { getSession, isAdmin } from '../../../../lib/auth';
+import { updateAdminShortcut } from '../../../../lib/website-db';
+
+export const PATCH: APIRoute = async ({ request }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) {
+    return new Response(JSON.stringify({ error: 'Forbidden' }), {
+      status: 403,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  let id = '';
+  let url: string | undefined;
+  let label: string | undefined;
+  try {
+    const body = await request.json();
+    id = String(body?.id ?? '').trim();
+    if (typeof body?.url === 'string')   url = body.url.trim();
+    if (typeof body?.label === 'string') label = body.label.trim();
+  } catch {
+    return new Response(JSON.stringify({ error: 'Invalid JSON' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  if (!id) {
+    return new Response(JSON.stringify({ error: 'id required' }), { status: 400 });
+  }
+  if (url !== undefined && !url.startsWith('https://')) {
+    return new Response(JSON.stringify({ error: 'url must start with https://' }), { status: 400 });
+  }
+  if (url !== undefined && url.length > 2048) {
+    return new Response(JSON.stringify({ error: 'url too long' }), { status: 400 });
+  }
+  if (label !== undefined && (!label || label.length > 120)) {
+    return new Response(JSON.stringify({ error: 'label is required (max 120 chars)' }), { status: 400 });
+  }
+  if (url === undefined && label === undefined) {
+    return new Response(JSON.stringify({ error: 'nothing to update' }), { status: 400 });
+  }
+
+  try {
+    const updated = await updateAdminShortcut(id, { url, label });
+    if (!updated) {
+      return new Response(JSON.stringify({ error: 'Shortcut not found' }), { status: 404 });
+    }
+    return new Response(JSON.stringify(updated), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (err: any) {
+    console.error('[shortcuts/update]', err);
+    return new Response(JSON.stringify({ error: err.message ?? 'DB error' }), { status: 500 });
+  }
+};


### PR DESCRIPTION
## Summary
Resolves bug ticket **BR-20260506-c409** ("Ich kann dies nicht pflegen", reporter on `/admin`).

The ticket is short, but the same reporter filed three other tickets the same day about UI elements not being editable. The only user-customisable thing on the `/admin` top page is `AdminShortcuts`, and it had two real problems:
- shortcuts could only be **added or deleted**, not renamed (no way to fix a typo or update a URL),
- every fetch had a silent `catch {}`, so any backend error was invisible.

## Changes
- `AdminShortcuts.svelte`: hover reveals **pencil ✎ + delete ×**; pencil flips the tile into an inline edit form (label + URL) with Save / Cancel.
- All catches replaced with a dismissible in-component error banner (auto-clears after 5 s).
- New `PATCH /api/admin/shortcuts/update` — same auth + validation as `create.ts` (https-only URL, label ≤ 120 chars, URL ≤ 2048 chars). Returns the updated row so the UI doesn't refetch.
- New `updateAdminShortcut(id, { url?, label? })` in `website-db.ts` — partial update.

## Test plan
- [x] Live deploy verified — `Bearbeiten`, `/api/admin/shortcuts/update`, `Aktualisieren fehlgeschlagen`, `Speichern fehlgeschlagen` all in compiled bundle on both clusters.
- [ ] After merge: hover a shortcut on `/admin` → click pencil → rename → Save → tile updates without refresh.
- [ ] Force a backend failure (e.g. invalid URL) → red banner appears with the server's error message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)