### PR TITLE
fix(admin): editable Hero emphasis + reorderable Leistungskarten (BR-20260507-5104, -f250)

### DIFF
--- a/website/src/components/admin/inhalte/AngeboteSection.svelte
+++ b/website/src/components/admin/inhalte/AngeboteSection.svelte
@@ -32,6 +32,15 @@
   const inputCls = 'w-full px-3 py-2 bg-dark border border-dark-lighter rounded-lg text-light text-sm focus:outline-none focus:border-gold/50';
   const labelCls = 'block text-xs text-muted mb-1';
   const sectionCls = 'p-6 bg-dark-light rounded-xl border border-dark-lighter space-y-4';
+  const moveBtnCls = 'px-2 py-1 rounded-md border border-dark-lighter text-muted hover:text-light hover:border-gold/50 disabled:opacity-30 disabled:cursor-not-allowed text-sm';
+
+  function moveService(idx: number, delta: number) {
+    const next = idx + delta;
+    if (next < 0 || next >= services.length) return;
+    const arr = services;
+    [arr[idx], arr[next]] = [arr[next], arr[idx]];
+    services = [...arr];
+  }
 </script>
 
 <div class="pt-6 pb-20 space-y-10">
@@ -52,9 +61,15 @@
   <!-- Services -->
   <div class={sectionCls}>
     <h3 class="text-xl font-bold text-light font-serif">Leistungskarten</h3>
-    {#each services as svc}
+    <p class="text-xs text-muted -mt-2">Reihenfolge mit den Pfeilen ändern. Diese Reihenfolge bestimmt, wie die Karten auf der Startseite und im Footer erscheinen.</p>
+    {#each services as svc, idx (svc.slug)}
       <div class="p-4 bg-dark rounded-lg border border-dark-lighter space-y-3">
         <div class="flex items-center gap-3">
+          <div class="flex items-center gap-1" role="group" aria-label="Reihenfolge ändern">
+            <button type="button" onclick={() => moveService(idx, -1)} disabled={idx === 0} class={moveBtnCls} title="Nach oben" aria-label="Nach oben">↑</button>
+            <button type="button" onclick={() => moveService(idx, 1)} disabled={idx === services.length - 1} class={moveBtnCls} title="Nach unten" aria-label="Nach unten">↓</button>
+          </div>
+          <span class="text-xs text-muted">#{idx + 1}</span>
           <label class="flex items-center gap-2 cursor-pointer">
             <input type="checkbox" bind:checked={svc.hidden} class="accent-gold" />
             <span class="text-xs text-muted">Ausblenden</span>

--- a/website/src/components/admin/inhalte/StartseiteSection.svelte
+++ b/website/src/components/admin/inhalte/StartseiteSection.svelte
@@ -55,6 +55,11 @@
       <textarea bind:value={data.hero.title} rows={2} class="{inputCls} resize-none"></textarea>
     </div>
     <div>
+      <label class={labelCls}>Titel-Hervorhebung (kursiv, hinter dem Titel)</label>
+      <input type="text" bind:value={data.hero.titleEmphasis} class={inputCls} placeholder="z. B. wieder verbinden." />
+      <p class="text-xs text-muted mt-1">Leer lassen, um keinen kursiven Zusatz anzuzeigen.</p>
+    </div>
+    <div>
       <label class={labelCls}>Untertitel</label>
       <textarea bind:value={data.hero.subtitle} rows={3} class="{inputCls} resize-none"></textarea>
     </div>

--- a/website/src/lib/content.ts
+++ b/website/src/lib/content.ts
@@ -31,15 +31,17 @@ export async function getEffectiveReferenzen(): Promise<ReferenzItem[]> {
 /**
  * Returns the effective services list, merging DB overrides over the static
  * config. Hidden services are included — callers decide whether to filter them.
+ *
+ * Order: when DB overrides exist, the override array order wins (so admins can
+ * reorder cards). Static services not yet present in the overrides are appended
+ * at the end so newly-added entries from `config.services` don't disappear.
  */
 export async function getEffectiveServices(): Promise<(HomepageService & { hidden?: boolean })[]> {
   const overrides = await getServiceConfig(BRAND).catch(() => null);
   if (!overrides) return config.services;
 
-  return config.services.map((svc) => {
-    const o = overrides.find((x) => x.slug === svc.slug);
-    if (!o) return svc;
-
+  const staticBySlug = new Map(config.services.map((s) => [s.slug, s]));
+  const merge = (svc: HomepageService, o: typeof overrides[number]) => {
     const pc = o.pageContent;
     return {
       ...svc,
@@ -60,7 +62,16 @@ export async function getEffectiveServices(): Promise<(HomepageService & { hidde
           }
         : svc.pageContent,
     };
-  });
+  };
+
+  const overrideSlugs = new Set(overrides.map((o) => o.slug));
+  const fromOverrides: (HomepageService & { hidden?: boolean })[] = [];
+  for (const o of overrides) {
+    const svc = staticBySlug.get(o.slug);
+    if (svc) fromOverrides.push(merge(svc, o));
+  }
+  const missing = config.services.filter((s) => !overrideSlugs.has(s.slug));
+  return [...fromOverrides, ...missing];
 }
 
 /**
@@ -104,7 +115,12 @@ export async function getEffectiveHomepage(): Promise<HomepageContent> {
   // Fallback: BrandConfig.homepage has no hero sub-object, so title/tagline are
   // hardcoded here. The admin UI (admin/startseite) overwrites this on first save.
   if (!db) return {
-    hero: { title: 'Digital Coach &\nFührungskräfte-Mentor', subtitle: c.whyMeIntro, tagline: 'Praxisnah. Strukturiert. Auf Augenhöhe.' },
+    hero: {
+      title: 'Menschen, Prozesse und Technik',
+      titleEmphasis: 'wieder verbinden.',
+      subtitle: c.whyMeIntro,
+      tagline: 'Praxisnah. Strukturiert. Auf Augenhöhe.',
+    },
     stats: c.stats,
     servicesHeadline: c.servicesHeadline,
     servicesSubheadline: c.servicesSubheadline,
@@ -119,6 +135,10 @@ export async function getEffectiveHomepage(): Promise<HomepageContent> {
   };
   return {
     ...db,
+    hero: {
+      ...db.hero,
+      titleEmphasis: db.hero.titleEmphasis ?? 'wieder verbinden.',
+    },
     avatarType: db.avatarType ?? c.avatarType,
     avatarSrc: db.avatarSrc ?? c.avatarSrc,
     avatarInitials: db.avatarInitials ?? c.avatarInitials,

--- a/website/src/lib/website-db.ts
+++ b/website/src/lib/website-db.ts
@@ -2694,6 +2694,7 @@ export interface HomepageHero {
   title: string;
   subtitle: string;
   tagline: string;
+  titleEmphasis?: string;
 }
 
 export interface WhyMePoint {

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -101,6 +101,7 @@ const processSteps = [
     <Hero
       client:load
       title={homepage.hero.title}
+      titleEmphasis={homepage.hero.titleEmphasis}
       subtitle={homepage.hero.subtitle}
       tagline={homepage.hero.tagline}
       avatarType={homepage.avatarType}


### PR DESCRIPTION
## Summary
- **BR-20260507-5104** — `/admin` → Inhalte → Startseite: the italic *wieder verbinden.* in the Hero was a Svelte default with no DB field. Added `HomepageHero.titleEmphasis`, an input row in `StartseiteSection`, and wired it through `index.astro` → `Hero.svelte`. Empty value = no italic part rendered.
- **BR-20260507-f250** — `/admin/inhalte?tab=website&section=angebote`: Leistungskarten order was locked to static `config.services`. `getEffectiveServices` now respects the saved override order (config-only services not yet saved are appended at the end), and `AngeboteSection` has ↑/↓ buttons per card.

## Test plan
- [ ] Open `/admin/inhalte?tab=website&section=startseite`, change Titel-Hervorhebung, save, reload home — italic part updates.
- [ ] Clear Titel-Hervorhebung, save, reload — italic block disappears.
- [ ] Open `…&section=angebote`, reorder cards with ↑/↓, save, reload home + footer — order persists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)