### PR TITLE
fix(admin): editable Referenzen heading/subheading + groupable types

### DIFF
--- a/website/src/components/admin/InhalteEditor.svelte
+++ b/website/src/components/admin/InhalteEditor.svelte
@@ -16,7 +16,7 @@
     UebermichContent,
     FaqItem,
     KontaktContent,
-    ReferenzItem,
+    ReferenzenConfig,
     CustomSection as CustomSectionType,
     ServiceOverride,
     LeistungCategoryOverride,
@@ -30,7 +30,7 @@
     priceListUrl: string;
     faq: FaqItem[];
     kontakt: KontaktContent;
-    referenzen: ReferenzItem[];
+    referenzen: ReferenzenConfig;
     rechtliches: Record<string, string>;
     customSections: CustomSectionType[];
   };

--- a/website/src/components/admin/inhalte/ReferenzenSection.svelte
+++ b/website/src/components/admin/inhalte/ReferenzenSection.svelte
@@ -1,9 +1,13 @@
 <script lang="ts">
-  import type { ReferenzItem } from '../../../lib/website-db';
+  import type { ReferenzenConfig, ReferenzItem, ReferenzenType } from '../../../lib/website-db';
 
-  let { initialData }: { initialData: ReferenzItem[] } = $props();
+  let { initialData }: { initialData: ReferenzenConfig } = $props();
 
-  let items = $state(JSON.parse(JSON.stringify(initialData)));
+  let heading = $state(initialData.heading ?? '');
+  let subheading = $state(initialData.subheading ?? '');
+  let types = $state<ReferenzenType[]>(JSON.parse(JSON.stringify(initialData.types ?? [])));
+  let items = $state<ReferenzItem[]>(JSON.parse(JSON.stringify(initialData.items ?? [])));
+
   let saving = $state(false);
   let msg = $state('');
   let msgOk = $state(true);
@@ -14,7 +18,12 @@
       const res = await fetch('/api/admin/referenzen/save', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(items),
+        body: JSON.stringify({
+          heading: heading.trim() || undefined,
+          subheading: subheading.trim() || undefined,
+          types,
+          items,
+        }),
       });
       const json = await res.json();
       if (res.ok) { msg = 'Gespeichert.'; msgOk = true; }
@@ -23,53 +32,142 @@
     finally { saving = false; }
   }
 
-  function addItem() { items = [...items, { id: crypto.randomUUID(), name: '', url: undefined, logoUrl: undefined, description: undefined }]; }
+  function addItem() {
+    items = [...items, { id: crypto.randomUUID(), name: '', url: undefined, logoUrl: undefined, description: undefined, type: undefined }];
+  }
   function removeItem(i: number) { items = items.filter((_, idx) => idx !== i); }
+
+  function addType() {
+    const id = crypto.randomUUID().slice(0, 8);
+    types = [...types, { id, label: '' }];
+  }
+  function removeType(i: number) {
+    const removed = types[i];
+    types = types.filter((_, idx) => idx !== i);
+    // Items previously tagged with the removed type fall back to "untyped"
+    items = items.map((it) => it.type === removed.id ? { ...it, type: undefined } : it);
+  }
+  function moveType(i: number, dir: -1 | 1) {
+    const j = i + dir;
+    if (j < 0 || j >= types.length) return;
+    const next = [...types];
+    [next[i], next[j]] = [next[j], next[i]];
+    types = next;
+  }
+
+  function moveItem(i: number, dir: -1 | 1) {
+    const j = i + dir;
+    if (j < 0 || j >= items.length) return;
+    const next = [...items];
+    [next[i], next[j]] = [next[j], next[i]];
+    items = next;
+  }
 
   const inputCls = 'w-full px-3 py-2 bg-dark border border-dark-lighter rounded-lg text-light text-sm focus:outline-none focus:border-gold/50';
   const labelCls = 'block text-xs text-muted mb-1';
+  const smallBtnCls = 'px-2 py-1 text-xs border border-dark-lighter text-muted rounded hover:text-light disabled:opacity-30 disabled:cursor-not-allowed';
 </script>
 
-<div class="pt-6 pb-20 space-y-6">
+<div class="pt-6 pb-20 space-y-8">
   <div class="flex justify-between items-start">
     <div>
-      <h2 class="text-2xl font-bold text-light font-serif">Referenzen</h2>
-      <p class="text-muted mt-1 text-sm">{items.length} Einträge</p>
+      <h2 class="text-2xl font-bold text-light font-serif">Referenzen / Kooperationspartner</h2>
+      <p class="text-muted mt-1 text-sm">{items.length} Einträge · {types.length} Gruppen</p>
     </div>
-    <div class="flex gap-3">
-      <button onclick={addItem} class="px-3 py-2 border border-dark-lighter text-muted rounded-lg text-sm hover:text-light">+ Referenz</button>
-      <button onclick={save} disabled={saving} class="px-5 py-2 bg-gold text-dark font-semibold rounded-lg hover:bg-gold/90 disabled:opacity-50">
-        {saving ? 'Speichere…' : 'Speichern'}
-      </button>
-    </div>
+    <button onclick={save} disabled={saving} class="px-5 py-2 bg-gold text-dark font-semibold rounded-lg hover:bg-gold/90 disabled:opacity-50">
+      {saving ? 'Speichere…' : 'Speichern'}
+    </button>
   </div>
 
   {#if msg}
     <div class={`p-4 rounded-xl text-sm ${msgOk ? 'bg-green-500/10 border border-green-500/30 text-green-400' : 'bg-red-500/10 border border-red-500/30 text-red-400'}`}>{msg}</div>
   {/if}
 
-  {#each items as item, i}
-    <div class="p-5 bg-dark-light rounded-xl border border-dark-lighter space-y-3">
-      <div class="flex justify-between items-center">
-        <span class="text-xs font-mono text-muted">{item.id.slice(0, 8)}</span>
-        <button onclick={() => removeItem(i)} class="text-xs text-red-400 hover:text-red-300">Entfernen</button>
-      </div>
-      <div>
-        <label class={labelCls}>Name *</label>
-        <input type="text" bind:value={item.name} required class={inputCls} />
-      </div>
-      <div>
-        <label class={labelCls}>Website-URL</label>
-        <input type="url" bind:value={item.url} class={inputCls} placeholder="https://..." />
-      </div>
-      <div>
-        <label class={labelCls}>Logo-URL</label>
-        <input type="url" bind:value={item.logoUrl} class={inputCls} placeholder="https://..." />
-      </div>
-      <div>
-        <label class={labelCls}>Beschreibung</label>
-        <textarea bind:value={item.description} rows={2} class="{inputCls} resize-none"></textarea>
-      </div>
+  <!-- Headings -->
+  <div class="p-5 bg-dark-light rounded-xl border border-dark-lighter space-y-3">
+    <h3 class="text-sm font-semibold text-light">Seiten-Überschrift</h3>
+    <div>
+      <label class={labelCls}>Überschrift</label>
+      <input type="text" bind:value={heading} placeholder="Referenzen" class={inputCls} />
+      <p class="text-xs text-muted mt-1">Leer lassen für Standard: „Referenzen“.</p>
     </div>
-  {/each}
+    <div>
+      <label class={labelCls}>Unterüberschrift</label>
+      <textarea bind:value={subheading} rows={2} placeholder="Unternehmen und Personen, die mir ihr Vertrauen geschenkt haben." class="{inputCls} resize-none"></textarea>
+    </div>
+  </div>
+
+  <!-- Type / group manager -->
+  <div class="p-5 bg-dark-light rounded-xl border border-dark-lighter space-y-3">
+    <div class="flex justify-between items-center">
+      <div>
+        <h3 class="text-sm font-semibold text-light">Gruppen / Typen</h3>
+        <p class="text-xs text-muted mt-1">Gruppen ordnen die Einträge auf der Seite. Reihenfolge bestimmt die Anzeige-Reihenfolge.</p>
+      </div>
+      <button onclick={addType} class="px-3 py-1.5 border border-dark-lighter text-muted rounded-lg text-xs hover:text-light">+ Gruppe</button>
+    </div>
+    {#if types.length === 0}
+      <p class="text-xs text-muted italic">Keine Gruppen — alle Einträge erscheinen ohne Gruppierung.</p>
+    {:else}
+      <div class="space-y-2">
+        {#each types as t, i (t.id)}
+          <div class="flex gap-2 items-center">
+            <span class="font-mono text-xs text-muted w-16 shrink-0">{t.id.slice(0, 6)}</span>
+            <input type="text" bind:value={t.label} placeholder="Gruppenname (z.B. Mediation)" class="flex-1 px-3 py-2 bg-dark border border-dark-lighter rounded-lg text-light text-sm focus:outline-none focus:border-gold/50" />
+            <button onclick={() => moveType(i, -1)} disabled={i === 0} class={smallBtnCls} aria-label="Nach oben">↑</button>
+            <button onclick={() => moveType(i, 1)} disabled={i === types.length - 1} class={smallBtnCls} aria-label="Nach unten">↓</button>
+            <button onclick={() => removeType(i)} class="px-2 py-1 text-xs text-red-400 hover:text-red-300" aria-label="Gruppe löschen">✕</button>
+          </div>
+        {/each}
+      </div>
+    {/if}
+  </div>
+
+  <!-- Items -->
+  <div class="space-y-3">
+    <div class="flex justify-between items-center">
+      <h3 class="text-sm font-semibold text-light">Einträge</h3>
+      <button onclick={addItem} class="px-3 py-1.5 border border-dark-lighter text-muted rounded-lg text-xs hover:text-light">+ Referenz</button>
+    </div>
+
+    {#each items as item, i (item.id)}
+      <div class="p-5 bg-dark-light rounded-xl border border-dark-lighter space-y-3">
+        <div class="flex justify-between items-center gap-2">
+          <span class="text-xs font-mono text-muted">{item.id.slice(0, 8)}</span>
+          <div class="flex gap-2 items-center">
+            <button onclick={() => moveItem(i, -1)} disabled={i === 0} class={smallBtnCls} aria-label="Nach oben">↑</button>
+            <button onclick={() => moveItem(i, 1)} disabled={i === items.length - 1} class={smallBtnCls} aria-label="Nach unten">↓</button>
+            <button onclick={() => removeItem(i)} class="text-xs text-red-400 hover:text-red-300">Entfernen</button>
+          </div>
+        </div>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
+          <div>
+            <label class={labelCls}>Name *</label>
+            <input type="text" bind:value={item.name} required class={inputCls} />
+          </div>
+          <div>
+            <label class={labelCls}>Gruppe / Typ</label>
+            <select bind:value={item.type} class={inputCls}>
+              <option value={undefined}>— ohne Gruppe —</option>
+              {#each types as t}
+                <option value={t.id}>{t.label || t.id.slice(0, 6)}</option>
+              {/each}
+            </select>
+          </div>
+        </div>
+        <div>
+          <label class={labelCls}>Website-URL</label>
+          <input type="url" bind:value={item.url} class={inputCls} placeholder="https://..." />
+        </div>
+        <div>
+          <label class={labelCls}>Logo-URL</label>
+          <input type="url" bind:value={item.logoUrl} class={inputCls} placeholder="https://..." />
+        </div>
+        <div>
+          <label class={labelCls}>Beschreibung</label>
+          <textarea bind:value={item.description} rows={2} class="{inputCls} resize-none"></textarea>
+        </div>
+      </div>
+    {/each}
+  </div>
 </div>

--- a/website/src/lib/content.ts
+++ b/website/src/lib/content.ts
@@ -10,7 +10,7 @@ import {
   getKontaktContent,
 } from './website-db';
 import type { HomepageService, LeistungCategory } from '../config/types';
-import type { ReferenzItem } from './website-db';
+import type { ReferenzenConfig } from './website-db';
 import type {
   HomepageContent,
   UebermichContent,
@@ -24,8 +24,8 @@ export async function getPriceListUrl(): Promise<string | null> {
   return getSiteSetting(BRAND, 'price_list_url').catch(() => null);
 }
 
-export async function getEffectiveReferenzen(): Promise<ReferenzItem[]> {
-  return (await getReferenzen(BRAND).catch(() => null)) ?? [];
+export async function getEffectiveReferenzen(): Promise<ReferenzenConfig> {
+  return (await getReferenzen(BRAND).catch(() => null)) ?? { types: [], items: [] };
 }
 
 /**

--- a/website/src/lib/website-db.ts
+++ b/website/src/lib/website-db.ts
@@ -1022,6 +1022,21 @@ export interface ReferenzItem {
   url?: string;
   logoUrl?: string;
   description?: string;
+  /** Optional type/group ID — must match one of `ReferenzenConfig.types[].id` */
+  type?: string;
+}
+
+export interface ReferenzenType {
+  id: string;
+  label: string;
+}
+
+export interface ReferenzenConfig {
+  heading?: string;
+  subheading?: string;
+  /** Ordered list — display order of groups follows this array. */
+  types: ReferenzenType[];
+  items: ReferenzItem[];
 }
 
 export async function initReferenzenTable(): Promise<void> {
@@ -1034,22 +1049,40 @@ export async function initReferenzenTable(): Promise<void> {
   `);
 }
 
-export async function getReferenzen(brand: string): Promise<ReferenzItem[] | null> {
+function normalizeReferenzen(raw: unknown): ReferenzenConfig {
+  // Legacy shape: bare array of items.
+  if (Array.isArray(raw)) {
+    return { types: [], items: raw as ReferenzItem[] };
+  }
+  if (raw && typeof raw === 'object') {
+    const o = raw as Partial<ReferenzenConfig>;
+    return {
+      heading: o.heading,
+      subheading: o.subheading,
+      types: Array.isArray(o.types) ? o.types : [],
+      items: Array.isArray(o.items) ? o.items : [],
+    };
+  }
+  return { types: [], items: [] };
+}
+
+export async function getReferenzen(brand: string): Promise<ReferenzenConfig | null> {
   await initReferenzenTable();
   const result = await pool.query(
     'SELECT items_json FROM referenzen_config WHERE brand = $1',
     [brand]
   );
-  return result.rows[0]?.items_json ?? null;
+  if (!result.rows[0]) return null;
+  return normalizeReferenzen(result.rows[0].items_json);
 }
 
-export async function saveReferenzen(brand: string, items: ReferenzItem[]): Promise<void> {
+export async function saveReferenzen(brand: string, config: ReferenzenConfig): Promise<void> {
   await initReferenzenTable();
   await pool.query(
     `INSERT INTO referenzen_config (brand, items_json, updated_at)
      VALUES ($1, $2, now())
      ON CONFLICT (brand) DO UPDATE SET items_json = $2, updated_at = now()`,
-    [brand, JSON.stringify(items)]
+    [brand, JSON.stringify(config)]
   );
 }
 

--- a/website/src/pages/api/admin/referenzen/save.ts
+++ b/website/src/pages/api/admin/referenzen/save.ts
@@ -1,58 +1,55 @@
 import type { APIRoute } from 'astro';
 import { getSession, isAdmin } from '../../../../lib/auth';
 import { saveReferenzen } from '../../../../lib/website-db';
-import type { ReferenzItem } from '../../../../lib/website-db';
+import type { ReferenzenConfig, ReferenzItem, ReferenzenType } from '../../../../lib/website-db';
 
-export const POST: APIRoute = async ({ request, redirect }) => {
+function sanitizeConfig(input: unknown): ReferenzenConfig {
+  const obj = (input ?? {}) as Partial<ReferenzenConfig> & { items?: unknown; types?: unknown };
+  const types: ReferenzenType[] = Array.isArray(obj.types)
+    ? (obj.types as ReferenzenType[])
+        .filter((t) => t && typeof t.id === 'string' && t.id.trim() && typeof t.label === 'string')
+        .map((t) => ({ id: t.id.trim(), label: t.label.trim() }))
+    : [];
+  const validTypeIds = new Set(types.map((t) => t.id));
+  const items: ReferenzItem[] = Array.isArray(obj.items)
+    ? (obj.items as ReferenzItem[])
+        .filter((it) => it && typeof it.name === 'string' && it.name.trim())
+        .map((it) => ({
+          id: typeof it.id === 'string' && it.id ? it.id : crypto.randomUUID(),
+          name: it.name.trim(),
+          url: it.url?.trim() || undefined,
+          logoUrl: it.logoUrl?.trim() || undefined,
+          description: it.description?.trim() || undefined,
+          type: it.type && validTypeIds.has(it.type) ? it.type : undefined,
+        }))
+    : [];
+  return {
+    heading: typeof obj.heading === 'string' ? obj.heading.trim() || undefined : undefined,
+    subheading: typeof obj.subheading === 'string' ? obj.subheading.trim() || undefined : undefined,
+    types,
+    items,
+  };
+}
+
+export const POST: APIRoute = async ({ request }) => {
   const session = await getSession(request.headers.get('cookie'));
   if (!session || !isAdmin(session)) return new Response('Forbidden', { status: 403 });
 
   const BRAND = process.env.BRAND || 'mentolder';
 
-  if (request.headers.get('content-type')?.includes('application/json')) {
-    let items: ReferenzItem[];
-    try {
-      items = await request.json() as ReferenzItem[];
-    } catch {
-      return new Response(JSON.stringify({ error: 'Invalid JSON' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
-    }
-    try {
-      await saveReferenzen(BRAND, items);
-    } catch (err) {
-      console.error('[referenzen/save] DB error:', err);
-      return new Response(JSON.stringify({ error: 'DB error' }), { status: 500, headers: { 'Content-Type': 'application/json' } });
-    }
-    return new Response(JSON.stringify({ ok: true }), { headers: { 'Content-Type': 'application/json' } });
+  let raw: unknown;
+  try {
+    raw = await request.json();
+  } catch {
+    return new Response(JSON.stringify({ error: 'Invalid JSON' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
   }
 
-  const form = await request.formData();
-  const items: ReferenzItem[] = [];
-  let i = 0;
-  // Collect existing entries (by index) unless marked for deletion
-  while (form.has(`ref_${i}_id`)) {
-    const deleted = form.get(`ref_${i}_delete`) === '1';
-    if (!deleted) {
-      const name = (form.get(`ref_${i}_name`) as string)?.trim();
-      if (name) items.push({
-        id: (form.get(`ref_${i}_id`) as string) || crypto.randomUUID(),
-        name,
-        url: (form.get(`ref_${i}_url`) as string)?.trim() || undefined,
-        logoUrl: (form.get(`ref_${i}_logoUrl`) as string)?.trim() || undefined,
-        description: (form.get(`ref_${i}_description`) as string)?.trim() || undefined,
-      });
-    }
-    i++;
+  const config = sanitizeConfig(raw);
+  try {
+    await saveReferenzen(BRAND, config);
+  } catch (err) {
+    console.error('[referenzen/save] DB error:', err);
+    return new Response(JSON.stringify({ error: 'DB error' }), { status: 500, headers: { 'Content-Type': 'application/json' } });
   }
-  // Add new entry if name provided
-  const newName = (form.get('new_name') as string)?.trim();
-  if (newName) items.push({
-    id: crypto.randomUUID(),
-    name: newName,
-    url: (form.get('new_url') as string)?.trim() || undefined,
-    logoUrl: (form.get('new_logoUrl') as string)?.trim() || undefined,
-    description: (form.get('new_description') as string)?.trim() || undefined,
-  });
-
-  await saveReferenzen(BRAND, items);
-  return redirect('/admin/referenzen?saved=1', 303);
+  return new Response(JSON.stringify({ ok: true }), { headers: { 'Content-Type': 'application/json' } });
 };

--- a/website/src/pages/referenzen.astro
+++ b/website/src/pages/referenzen.astro
@@ -1,52 +1,88 @@
 ---
 import Layout from '../layouts/Layout.astro';
 import { getEffectiveReferenzen } from '../lib/content';
+import type { ReferenzItem } from '../lib/website-db';
 
-const referenzen = await getEffectiveReferenzen();
+const config = await getEffectiveReferenzen();
+const heading = config.heading?.trim() || 'Referenzen';
+const subheading = config.subheading?.trim() || 'Unternehmen und Personen, die mir ihr Vertrauen geschenkt haben.';
+
+// Group items by type, in the order defined by config.types.
+// Items with no type (or with a type that no longer exists) are appended in a final "Weitere" group.
+const knownTypeIds = new Set(config.types.map((t) => t.id));
+const groups: { id: string; label: string | null; items: ReferenzItem[] }[] = config.types.map((t) => ({
+  id: t.id,
+  label: t.label?.trim() || t.id.slice(0, 6),
+  items: [],
+}));
+const untyped: ReferenzItem[] = [];
+for (const item of config.items) {
+  if (item.type && knownTypeIds.has(item.type)) {
+    groups.find((g) => g.id === item.type)!.items.push(item);
+  } else {
+    untyped.push(item);
+  }
+}
+if (untyped.length > 0) {
+  groups.push({ id: '__untyped__', label: groups.length > 0 ? 'Weitere' : null, items: untyped });
+}
+const populatedGroups = groups.filter((g) => g.items.length > 0);
+const hasGrouping = populatedGroups.length > 1 || (populatedGroups.length === 1 && populatedGroups[0].id !== '__untyped__');
 ---
 
-<Layout title="Referenzen">
+<Layout title={heading}>
   <section class="pt-28 pb-20">
     <div class="max-w-4xl mx-auto px-6">
 
       <div class="text-center mb-14">
-        <h1 class="text-4xl font-bold text-light font-serif mb-4">Referenzen</h1>
+        <h1 class="text-4xl font-bold text-light font-serif mb-4">{heading}</h1>
         <p class="text-muted text-lg max-w-2xl mx-auto">
-          Unternehmen und Personen, die mir ihr Vertrauen geschenkt haben.
+          {subheading}
         </p>
       </div>
 
-      {referenzen.length === 0 ? (
+      {populatedGroups.length === 0 ? (
         <div class="text-center py-20 text-muted">
           <p class="text-lg">Referenzen werden demnächst ergänzt.</p>
         </div>
       ) : (
-        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-          {referenzen.map((ref) => (
-            <div class="p-6 bg-dark-light rounded-xl border border-dark-lighter hover:border-gold/30 transition-colors flex flex-col gap-3">
-              {ref.logoUrl && (
-                <img
-                  src={ref.logoUrl}
-                  alt={`Logo ${ref.name}`}
-                  class="h-12 w-auto object-contain opacity-80"
-                />
+        <div class="space-y-14">
+          {populatedGroups.map((group) => (
+            <div>
+              {hasGrouping && group.label && (
+                <h2 class="text-2xl font-semibold text-light font-serif mb-6 border-b border-dark-lighter pb-2">
+                  {group.label}
+                </h2>
               )}
-              <div>
-                {ref.url ? (
-                  <a
-                    href={ref.url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    class="text-light font-semibold hover:text-gold transition-colors"
-                  >
-                    {ref.name}
-                  </a>
-                ) : (
-                  <span class="text-light font-semibold">{ref.name}</span>
-                )}
-                {ref.description && (
-                  <p class="text-muted text-sm mt-1">{ref.description}</p>
-                )}
+              <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+                {group.items.map((ref) => (
+                  <div class="p-6 bg-dark-light rounded-xl border border-dark-lighter hover:border-gold/30 transition-colors flex flex-col gap-3">
+                    {ref.logoUrl && (
+                      <img
+                        src={ref.logoUrl}
+                        alt={`Logo ${ref.name}`}
+                        class="h-12 w-auto object-contain opacity-80"
+                      />
+                    )}
+                    <div>
+                      {ref.url ? (
+                        <a
+                          href={ref.url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          class="text-light font-semibold hover:text-gold transition-colors"
+                        >
+                          {ref.name}
+                        </a>
+                      ) : (
+                        <span class="text-light font-semibold">{ref.name}</span>
+                      )}
+                      {ref.description && (
+                        <p class="text-muted text-sm mt-1">{ref.description}</p>
+                      )}
+                    </div>
+                  </div>
+                ))}
               </div>
             </div>
           ))}


### PR DESCRIPTION
## Summary
Resolves four bug-tracker tickets against `/admin/inhalte?tab=website&section=referenzen` plus closes the auto-generated E2E noise ticket.

- BR-20260507-f981 — make the "Referenzen" heading editable
- BR-20260507-523f — add an editable subheading
- BR-20260507-a41d — extensible type/group picker; group entries by type on the public page
- BR-20260507-6cc5 — reorder groups (and items) as blocks
- BR-20260507-fd2f — synthetic E2E artifact, will be archived

## Changes
- Referenzen storage now persists `{ heading, subheading, types[], items[] }`. Legacy bare-array entries are normalized on read so existing data keeps working without migration.
- Admin section gains heading + subheading fields, an extensible group/type list with up/down reordering, and a per-item type picker.
- Public `/referenzen` renders the editable heading/subheading and groups items by type in the order configured. Untyped items fall into a final "Weitere" block.

## Test plan
- [x] `npm run build` passes
- [x] `npx astro check` introduces no new errors (16 errors are pre-existing, unrelated to this PR)
- [ ] After deploy: open `/admin/inhalte?tab=website&section=referenzen`, edit heading/subheading, add 2 groups, assign items, save
- [ ] Public `/referenzen` shows new heading and grouped layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)