### PR TITLE
fix(mentolder): content polish + remove direct-buy CTAs (BR-…4047/a6b0/9849)

### DIFF
--- a/website/src/components/Hero.svelte
+++ b/website/src/components/Hero.svelte
@@ -15,9 +15,9 @@
 
   let {
     title = 'Menschen, Prozesse und Technik',
-    titleEmphasis = 'wieder verbinden.',
+    titleEmphasis = 'der Mensch und Technologie wieder verbindet.',
     subtitle = 'Mit 30+ Jahren Führungserfahrung begleite ich Menschen und Organisationen bei der digitalen Transformation — praxisnah, empathisch und auf Augenhöhe.',
-    tagline = 'Digital Coaching · Führungskräfte-Beratung',
+    tagline = 'Digital Coach & Führungskräfte-Mentor',
     avatarType = 'initials',
     avatarSrc,
     avatarInitials = '',

--- a/website/src/components/Navigation.svelte
+++ b/website/src/components/Navigation.svelte
@@ -60,7 +60,7 @@
     </nav>
 
     <div class="nav-right">
-      <span class="nav-meta" aria-hidden="true">Lüneburg · DE</span>
+      <span class="nav-meta" aria-hidden="true">Lüneburg, Hamburg und Umgebung · DE</span>
 
       {#if authChecked}
         {#if user}

--- a/website/src/components/ServiceCard.svelte
+++ b/website/src/components/ServiceCard.svelte
@@ -6,35 +6,11 @@
     features: string[];
     href: string;
     price?: string;
+    /** @deprecated direct buy buttons removed; kept for backwards compat */
     stripeServiceKey?: string;
   }
 
-  let { title, description, icon, features, href, price, stripeServiceKey }: Props = $props();
-
-  let loading = $state(false);
-  let errorMsg = $state('');
-
-  async function handleBuy() {
-    loading = true;
-    errorMsg = '';
-    try {
-      const res = await fetch('/api/stripe/checkout', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ serviceKey: stripeServiceKey }),
-      });
-      const data = await res.json();
-      if (data.url) {
-        window.location.href = data.url;
-      } else {
-        errorMsg = data.error || 'Checkout fehlgeschlagen.';
-      }
-    } catch {
-      errorMsg = 'Verbindungsfehler. Bitte erneut versuchen.';
-    } finally {
-      loading = false;
-    }
-  }
+  let { title, description, icon, features, href, price }: Props = $props();
 </script>
 
 <div class="bg-dark-light rounded-2xl border border-dark-lighter p-8 hover:border-gold/30 transition-all duration-300 hover:-translate-y-1 flex flex-col h-full">
@@ -63,22 +39,4 @@
   >
     Mehr erfahren
   </a>
-
-  {#if stripeServiceKey}
-    <button
-      type="button"
-      onclick={handleBuy}
-      disabled={loading}
-      class="mt-3 block w-full text-center border border-gold/60 hover:border-gold text-gold px-6 py-2.5 rounded-full font-semibold text-sm transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-    >
-      {#if loading}
-        Wird geladen…
-      {:else}
-        💳 Direkt buchen & zahlen
-      {/if}
-    </button>
-    {#if errorMsg}
-      <p class="text-red-400 text-xs mt-2 text-center">{errorMsg}</p>
-    {/if}
-  {/if}
 </div>

--- a/website/src/components/ServiceRow.svelte
+++ b/website/src/components/ServiceRow.svelte
@@ -8,39 +8,15 @@
     price: string;
     priceUnit?: string;
     href: string;
+    /** @deprecated direct buy buttons removed; kept for backwards compat */
     stripeServiceKey?: string;
   }
 
-  let { num, title, meta, description, features, price, priceUnit, href, stripeServiceKey }: Props = $props();
-
-  let loading = $state(false);
-  let errorMsg = $state('');
+  let { num, title, meta, description, features, price, priceUnit, href }: Props = $props();
 
   // Split price on "/" to extract unit if not provided
   const [priceMain, priceUnitFallback] = price.split('/').map(s => s.trim());
   const displayUnit = priceUnit ?? priceUnitFallback ?? '';
-
-  async function handleBuy() {
-    loading = true;
-    errorMsg = '';
-    try {
-      const res = await fetch('/api/stripe/checkout', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ serviceKey: stripeServiceKey }),
-      });
-      const data = await res.json();
-      if (data.url) {
-        window.location.href = data.url;
-      } else {
-        errorMsg = data.error || 'Checkout fehlgeschlagen.';
-      }
-    } catch {
-      errorMsg = 'Verbindungsfehler. Bitte erneut versuchen.';
-    } finally {
-      loading = false;
-    }
-  }
 </script>
 
 <div class="offer">
@@ -61,20 +37,6 @@
           <li>{feature}</li>
         {/each}
       </ul>
-    {/if}
-    {#if stripeServiceKey}
-      <button
-        type="button"
-        onclick={handleBuy}
-        disabled={loading}
-        class="buy-btn"
-        aria-label="Direkt buchen und bezahlen"
-      >
-        {loading ? 'Wird geladen…' : '💳 Direkt buchen & zahlen'}
-      </button>
-      {#if errorMsg}
-        <p class="error" role="alert">{errorMsg}</p>
-      {/if}
     {/if}
   </div>
 
@@ -235,35 +197,6 @@
     background: var(--brass);
     border-color: var(--brass);
     color: var(--ink-900);
-  }
-
-  .buy-btn {
-    margin-top: 12px;
-    background: none;
-    border: 1px solid var(--line-2);
-    color: var(--fg-soft);
-    padding: 6px 14px;
-    border-radius: 999px;
-    font-size: 12px;
-    cursor: pointer;
-    transition: border-color 0.2s ease, color 0.2s ease;
-    font-family: var(--sans);
-  }
-
-  .buy-btn:hover:not(:disabled) {
-    border-color: var(--brass);
-    color: var(--brass);
-  }
-
-  .buy-btn:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
-  }
-
-  .error {
-    color: oklch(0.65 0.2 25);
-    font-size: 12px;
-    margin-top: 6px;
   }
 
   @media (max-width: 1000px) {

--- a/website/src/config/brands/mentolder.ts
+++ b/website/src/config/brands/mentolder.ts
@@ -45,7 +45,7 @@ export const mentolderConfig: BrandConfig = {
       },
       {
         iconPath: 'M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z',
-        title: 'Selbst Generation 50+',
+        title: 'Generation 50+ aus eigener Erfahrung',
         text: '65 Jahre. Ich kenne die Herausforderungen aus eigener Erfahrung und spreche Ihre Sprache.',
       },
     ],
@@ -64,7 +64,7 @@ export const mentolderConfig: BrandConfig = {
         'Smartphone, Tablet & Computer Grundlagen',
         'WhatsApp, Email & Videocalls',
         'Online-Banking & Shopping sicher nutzen',
-        'Datenschutz & Sicherheit verstehen',
+        'Datenschutz & Sicherheit verstehen – inkl. ChatGPT, Claude, Perplexity',
       ],
       price: 'Ab 60 € / Stunde',
       stripeServiceKey: '50plus-digital-einzel',
@@ -127,7 +127,7 @@ export const mentolderConfig: BrandConfig = {
     },
     {
       slug: 'coaching',
-      title: 'Führungskräfte-Coaching',
+      title: 'Coaching für Führungskräfte und Menschen in Verantwortung',
       description: 'Ihre Karriere strategisch gestalten. Ich unterstütze erfahrene Führungskräfte bei der beruflichen Neuorientierung.',
       icon: '🎯',
       features: [
@@ -140,9 +140,9 @@ export const mentolderConfig: BrandConfig = {
       stripeServiceKey: 'coaching-session',
       pageContent: {
         headline: 'Ihre Karriere strategisch gestalten',
-        intro: 'Sie sind erfahrene Führungskraft und stehen vor einer beruflichen Neuorientierung? Ich begleite Sie dabei, Ihre Stärken zu schärfen und sich optimal zu positionieren.',
+        intro: 'Sie möchten Ihre Karriere strategisch weiterentwickeln oder sich neu ausrichten? Ich begleite Sie dabei, Ihre Stärken zu schärfen und sich optimal zu positionieren.',
         forWhom: [
-          'Als erfahrene Führungskraft Ihre Karriere neu ausrichten möchten',
+          'Sie sind erfahrene Führungskraft oder neu in der Führungsrolle – und möchten Ihre Karriere gezielt ausrichten.',
           'Sich auf wichtige Gespräche mit Headhuntern vorbereiten',
           'Ihr Profil schärfen und Ihre USPs herausarbeiten wollen',
           'Einen Sparring-Partner auf Augenhöhe suchen',
@@ -369,7 +369,7 @@ export const mentolderConfig: BrandConfig = {
     ],
     milestones: [
       { year: '1980-2023', title: 'Polizei Hamburg', desc: 'Über 30 Jahre in Führungspositionen. Personalführung, Organisationsentwicklung, Strategie.' },
-      { year: 'Highlight', title: 'KI-Pionier', desc: 'Erste deutsche Polizeibehörde mit KI/Gesichtserkennung. BOS-Digitalfunk bundesweit führend gemacht.' },
+      { year: 'ca. 2016/2017', title: 'KI-Pionier', desc: 'Erste deutsche Polizeibehörde mit KI/Gesichtserkennung. BOS-Digitalfunk bundesweit führend gemacht.' },
       { year: '2023', title: 'Digital Café', desc: '6 Monate intensives Digital Café im Altenheim. Über 50 Teilnehmer individuell begleitet.' },
       { year: 'Seit 2024', title: 'Selbstständig', desc: 'Coach und Digitaler Begleiter. Führungskräfte-Coaching und Unternehmensberatung.' },
     ],

--- a/website/src/layouts/Layout.astro
+++ b/website/src/layouts/Layout.astro
@@ -98,7 +98,7 @@ const brandWord = config.meta.siteTitle.replace(/\.de$/i, '').toLowerCase();
                 <a href={`mailto:${footerEmail}`} style="font-size:14px; color:var(--mute); text-decoration:none; display:block;" class="footer-link">{footerEmail}</a>
               </li>
               <li>
-                <span style="font-size:14px; color:var(--mute);">{footerCity} und Umgebung</span>
+                <span style="font-size:14px; color:var(--mute);">{footerCity}</span>
               </li>
             </ul>
           </div>

--- a/website/src/lib/content.ts
+++ b/website/src/lib/content.ts
@@ -116,8 +116,8 @@ export async function getEffectiveHomepage(): Promise<HomepageContent> {
   // hardcoded here. The admin UI (admin/startseite) overwrites this on first save.
   if (!db) return {
     hero: {
-      title: 'Menschen, Prozesse und Technik',
-      titleEmphasis: 'wieder verbinden.',
+      title: 'Digital Coach & Führungskräfte-Mentor –',
+      titleEmphasis: 'der Mensch und Technologie wieder verbindet.',
       subtitle: c.whyMeIntro,
       tagline: 'Praxisnah. Strukturiert. Auf Augenhöhe.',
     },
@@ -137,7 +137,7 @@ export async function getEffectiveHomepage(): Promise<HomepageContent> {
     ...db,
     hero: {
       ...db.hero,
-      titleEmphasis: db.hero.titleEmphasis ?? 'wieder verbinden.',
+      titleEmphasis: db.hero.titleEmphasis ?? 'der Mensch und Technologie wieder verbindet.',
     },
     avatarType: db.avatarType ?? c.avatarType,
     avatarSrc: db.avatarSrc ?? c.avatarSrc,

--- a/website/src/pages/leistungen.astro
+++ b/website/src/pages/leistungen.astro
@@ -103,30 +103,12 @@ const [leistungen, priceListUrl] = await Promise.all([
                   <p class="text-muted mb-4">{svc.desc}</p>
                 </div>
                 <div class="flex flex-col gap-2 mt-auto">
-                  {svc.price !== 'nach Vereinbarung' ? (
-                    <>
-                      <button
-                        type="button"
-                        class="stripe-buy-btn w-full text-center bg-gold hover:bg-gold-light text-dark px-6 py-3 rounded-full font-bold transition-colors uppercase tracking-wide text-sm"
-                        data-service-key={svc.key}
-                      >
-                        💳 Jetzt kaufen
-                      </button>
-                      <a
-                        href={`${leistungenCta.href}?service=${svc.key}`}
-                        class="block text-center border border-gold/40 hover:border-gold text-gold px-6 py-2 rounded-full font-semibold text-sm transition-colors"
-                      >
-                        Termin vereinbaren
-                      </a>
-                    </>
-                  ) : (
-                    <a
-                      href={leistungenCta.href}
-                      class="block text-center bg-gold hover:bg-gold-light text-dark px-6 py-3 rounded-full font-bold transition-colors uppercase tracking-wide text-sm"
-                    >
-                      {leistungenCta.text}
-                    </a>
-                  )}
+                  <a
+                    href="/kontakt"
+                    class="block text-center bg-gold hover:bg-gold-light text-dark px-6 py-3 rounded-full font-bold transition-colors uppercase tracking-wide text-sm"
+                  >
+                    Kontakt aufnehmen
+                  </a>
                 </div>
               </div>
             ))}
@@ -163,33 +145,3 @@ const [leistungen, priceListUrl] = await Promise.all([
   <CallToAction client:visible secondaryText={contact.email} secondaryHref={`mailto:${contact.email}`} />
 </Layout>
 
-<script>
-  document.querySelectorAll<HTMLButtonElement>('.stripe-buy-btn').forEach(btn => {
-    btn.addEventListener('click', async () => {
-      const serviceKey = btn.dataset.serviceKey;
-      if (!serviceKey) return;
-      const originalText = btn.textContent ?? '';
-      btn.textContent = 'Wird geladen…';
-      btn.disabled = true;
-      try {
-        const res = await fetch('/api/stripe/checkout', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ serviceKey }),
-        });
-        const data = await res.json();
-        if (data.url) {
-          window.location.href = data.url;
-        } else {
-          alert(data.error || 'Checkout fehlgeschlagen. Bitte erneut versuchen.');
-          btn.textContent = originalText;
-          btn.disabled = false;
-        }
-      } catch {
-        alert('Verbindungsfehler. Bitte erneut versuchen.');
-        btn.textContent = originalText;
-        btn.disabled = false;
-      }
-    });
-  });
-</script>


### PR DESCRIPTION
## Summary
- Hero, Coaching-Seite, Über-mich Timeline, Footer/Header: textuelle Korrekturen wie vom Reporter gewünscht
- 'Direkt buchen & zahlen' / 'Jetzt kaufen'-Buttons entfernt — alle Wege gehen jetzt über Kontakt/Termin
- DB-Inhalte (homepage_content, uebermich, service_config) wurden direkt aktualisiert; Code-Defaults gleichgezogen

## Tickets
- BR-20260507-4047 — Coaching-Seitentitel, forWhom-Bullet, KI- Welt, Footer Lünebur/Hamburg, Coaching-Intro
- BR-20260507-a6b0 — Hero-Headline, Wohnort über-mich, Timeline KI-Pionier-Jahr, 'Selbst' Generation 50+, Header/Footer-Vereinheitlichung
- BR-20260507-9849 — Direkt-buchen-Buttons komplett raus

## Test plan
- [ ] Startseite: Hero-Headline lautet 'Digital Coach & Führungskräfte-Mentor – der Mensch und Technologie wieder verbindet.'
- [ ] Header rechts: 'Lüneburg, Hamburg und Umgebung · DE'
- [ ] Footer Kontakt-Spalte: 'Lüneburg, Hamburg und Umgebung'
- [ ] Coaching-Seite: Titel 'Coaching für Führungskräfte und Menschen in Verantwortung'; Bullet 1 unter 'Für wen ist das?' beginnt mit 'Sie sind erfahrene Führungskraft …'
- [ ] Über mich: KI-Pionier-Eintrag zeigt 'ca. 2016/2017'
- [ ] Startseite Angebot 50+ digital, letzter Bullet: '… inkl. ChatGPT, Claude, Perplexity'
- [ ] Keine '💳 Direkt buchen & zahlen'/'Jetzt kaufen'-Buttons mehr auf Startseite oder /leistungen

🤖 Generated with [Claude Code](https://claude.com/claude-code)