### PR TITLE
fix(admin): centralize Angebote pricing + Leistungsumfang (BR-…5039/96c5/7abb/4461)

### DIFF
--- a/website/src/components/admin/inhalte/AngeboteSection.svelte
+++ b/website/src/components/admin/inhalte/AngeboteSection.svelte
@@ -41,6 +41,59 @@
     [arr[idx], arr[next]] = [arr[next], arr[idx]];
     services = [...arr];
   }
+
+  function ensurePageContent(svc: ServiceOverride) {
+    if (!svc.pageContent) svc.pageContent = {};
+    if (!svc.pageContent.sections) svc.pageContent.sections = [];
+    if (!svc.pageContent.pricing) svc.pageContent.pricing = [];
+    return svc.pageContent;
+  }
+
+  function addSection(svc: ServiceOverride) {
+    const pc = ensurePageContent(svc);
+    pc.sections = [...(pc.sections ?? []), { title: 'Neuer Bereich', items: [] }];
+    services = [...services];
+  }
+  function removeSection(svc: ServiceOverride, sIdx: number) {
+    if (!svc.pageContent?.sections) return;
+    svc.pageContent.sections = svc.pageContent.sections.filter((_, i) => i !== sIdx);
+    services = [...services];
+  }
+  function moveSection(svc: ServiceOverride, sIdx: number, delta: number) {
+    const arr = svc.pageContent?.sections;
+    if (!arr) return;
+    const next = sIdx + delta;
+    if (next < 0 || next >= arr.length) return;
+    [arr[sIdx], arr[next]] = [arr[next], arr[sIdx]];
+    services = [...services];
+  }
+
+  function addPricing(svc: ServiceOverride) {
+    const pc = ensurePageContent(svc);
+    pc.pricing = [...(pc.pricing ?? []), { label: 'Neuer Tarif', price: '0 €' }];
+    services = [...services];
+  }
+  function removePricing(svc: ServiceOverride, pIdx: number) {
+    if (!svc.pageContent?.pricing) return;
+    svc.pageContent.pricing = svc.pageContent.pricing.filter((_, i) => i !== pIdx);
+    services = [...services];
+  }
+  function movePricing(svc: ServiceOverride, pIdx: number, delta: number) {
+    const arr = svc.pageContent?.pricing;
+    if (!arr) return;
+    const next = pIdx + delta;
+    if (next < 0 || next >= arr.length) return;
+    [arr[pIdx], arr[next]] = [arr[next], arr[pIdx]];
+    services = [...services];
+  }
+
+  function moveLeistungService(cat: LeistungCategoryOverride, sIdx: number, delta: number) {
+    const arr = cat.services ?? [];
+    const next = sIdx + delta;
+    if (next < 0 || next >= arr.length) return;
+    [arr[sIdx], arr[next]] = [arr[next], arr[sIdx]];
+    leistungen = [...leistungen];
+  }
 </script>
 
 <div class="pt-6 pb-20 space-y-10">
@@ -91,7 +144,7 @@
         </div>
         <details class="text-xs text-muted">
           <summary class="cursor-pointer hover:text-light">Seiteninhalte (pageContent)</summary>
-          <div class="mt-3 space-y-3">
+          <div class="mt-3 space-y-4">
             <div><label class={labelCls}>Überschrift</label><input type="text" bind:value={svc.pageContent!.headline} class={inputCls} /></div>
             <div><label class={labelCls}>Intro</label><textarea bind:value={svc.pageContent!.intro} rows={3} class="{inputCls} resize-none"></textarea></div>
             <div>
@@ -101,6 +154,57 @@
                 oninput={(e) => { if (!svc.pageContent) svc.pageContent = {}; svc.pageContent.forWhom = (e.currentTarget as HTMLTextAreaElement).value.split('\n').map(f => f.trim()).filter(Boolean); }}
                 rows={4} class="{inputCls} resize-none font-mono"
               ></textarea>
+            </div>
+
+            <!-- Leistungsumfang (sections) -->
+            <div class="border-t border-dark-lighter pt-3">
+              <div class="flex items-center justify-between mb-2">
+                <span class="text-sm font-semibold text-light">Leistungsumfang (Spalten/Bereiche)</span>
+                <button type="button" onclick={() => addSection(svc)} class="px-2 py-1 text-xs rounded-md border border-gold/40 text-gold hover:bg-gold/10">+ Bereich</button>
+              </div>
+              {#each (svc.pageContent?.sections ?? []) as sec, sIdx}
+                <div class="p-3 bg-dark-lighter/30 rounded-lg space-y-2 mb-2">
+                  <div class="flex items-center gap-2">
+                    <button type="button" onclick={() => moveSection(svc, sIdx, -1)} disabled={sIdx === 0} class={moveBtnCls} aria-label="Bereich nach oben">↑</button>
+                    <button type="button" onclick={() => moveSection(svc, sIdx, 1)} disabled={sIdx === (svc.pageContent?.sections?.length ?? 0) - 1} class={moveBtnCls} aria-label="Bereich nach unten">↓</button>
+                    <input type="text" bind:value={sec.title} class={inputCls} placeholder="Titel des Bereichs" />
+                    <button type="button" onclick={() => removeSection(svc, sIdx)} class="px-2 py-1 text-xs rounded-md border border-red-500/40 text-red-400 hover:bg-red-500/10">Entfernen</button>
+                  </div>
+                  <textarea
+                    value={(sec.items ?? []).join('\n')}
+                    oninput={(e) => { sec.items = (e.currentTarget as HTMLTextAreaElement).value.split('\n').map(f => f.trim()).filter(Boolean); services = [...services]; }}
+                    rows={4} class="{inputCls} resize-none font-mono" placeholder="Ein Bullet pro Zeile"
+                  ></textarea>
+                </div>
+              {/each}
+            </div>
+
+            <!-- Investition (pricing) -->
+            <div class="border-t border-dark-lighter pt-3">
+              <div class="flex items-center justify-between mb-2">
+                <span class="text-sm font-semibold text-light">Investition (Preis-Boxen)</span>
+                <button type="button" onclick={() => addPricing(svc)} class="px-2 py-1 text-xs rounded-md border border-gold/40 text-gold hover:bg-gold/10">+ Preis</button>
+              </div>
+              <p class="text-xs text-muted mb-2">Werden auf der Detailseite des Angebots als 'Investition'-Boxen angezeigt. 'Hervorheben' markiert die Box mit Goldrand.</p>
+              {#each (svc.pageContent?.pricing ?? []) as p, pIdx}
+                <div class="p-3 bg-dark-lighter/30 rounded-lg space-y-2 mb-2">
+                  <div class="flex items-center gap-2">
+                    <button type="button" onclick={() => movePricing(svc, pIdx, -1)} disabled={pIdx === 0} class={moveBtnCls} aria-label="Preis nach oben">↑</button>
+                    <button type="button" onclick={() => movePricing(svc, pIdx, 1)} disabled={pIdx === (svc.pageContent?.pricing?.length ?? 0) - 1} class={moveBtnCls} aria-label="Preis nach unten">↓</button>
+                    <span class="text-xs text-muted">#{pIdx + 1}</span>
+                    <button type="button" onclick={() => removePricing(svc, pIdx)} class="ml-auto px-2 py-1 text-xs rounded-md border border-red-500/40 text-red-400 hover:bg-red-500/10">Entfernen</button>
+                  </div>
+                  <div class="grid grid-cols-3 gap-2">
+                    <div><label class={labelCls}>Bezeichnung</label><input type="text" bind:value={p.label} class={inputCls} /></div>
+                    <div><label class={labelCls}>Preis</label><input type="text" bind:value={p.price} class={inputCls} /></div>
+                    <div><label class={labelCls}>Einheit / Hinweis</label><input type="text" bind:value={p.unit} class={inputCls} /></div>
+                  </div>
+                  <label class="flex items-center gap-2 cursor-pointer text-xs text-muted">
+                    <input type="checkbox" bind:checked={p.highlight} class="accent-gold" />
+                    <span>Hervorheben (Goldrand)</span>
+                  </label>
+                </div>
+              {/each}
             </div>
           </div>
         </details>
@@ -123,9 +227,17 @@
           <div><label class={labelCls}>Kategorie-Titel</label><input type="text" bind:value={cat.title} class={inputCls} /></div>
           <div><label class={labelCls}>Icon</label><input type="text" bind:value={cat.icon} class={inputCls} /></div>
         </div>
-        {#each (cat.services ?? []) as svc}
+        {#each (cat.services ?? []) as svc, sIdx}
           <div class="p-3 bg-dark-lighter/30 rounded-lg space-y-2">
-            <p class="text-xs font-mono text-muted">{svc.key}</p>
+            <div class="flex items-center gap-2">
+              <button type="button" onclick={() => moveLeistungService(cat, sIdx, -1)} disabled={sIdx === 0} class={moveBtnCls} aria-label="Nach oben">↑</button>
+              <button type="button" onclick={() => moveLeistungService(cat, sIdx, 1)} disabled={sIdx === (cat.services?.length ?? 0) - 1} class={moveBtnCls} aria-label="Nach unten">↓</button>
+              <p class="text-xs font-mono text-muted">{svc.key}</p>
+              <label class="ml-auto flex items-center gap-2 cursor-pointer text-xs text-muted">
+                <input type="checkbox" bind:checked={svc.highlight} class="accent-gold" />
+                <span>Hervorheben</span>
+              </label>
+            </div>
             <div class="grid grid-cols-3 gap-3">
               <div><label class={labelCls}>Name</label><input type="text" bind:value={svc.name} class={inputCls} /></div>
               <div><label class={labelCls}>Preis</label><input type="text" bind:value={svc.price} class={inputCls} /></div>

--- a/website/src/pages/leistungen.astro
+++ b/website/src/pages/leistungen.astro
@@ -4,7 +4,7 @@ import CallToAction from '../components/CallToAction.svelte';
 import { config } from '../config/index';
 import { getEffectiveLeistungen, getPriceListUrl } from '../lib/content';
 
-const { leistungenCta, leistungenPricingHighlight, contact } = config;
+const { leistungenCta, contact } = config;
 const [leistungen, priceListUrl] = await Promise.all([
   getEffectiveLeistungen(),
   getPriceListUrl(),
@@ -35,53 +35,63 @@ const [leistungen, priceListUrl] = await Promise.all([
         </a>
       </div>
 
-      <!-- Pricing comparison table -->
-      <div class="mb-16">
-        <h2 class="text-2xl md:text-3xl font-bold text-light mb-8 font-serif text-center">Coaching-Angebote im Überblick</h2>
-        <div class="overflow-x-auto rounded-2xl border border-dark-lighter">
-          <table class="w-full text-left border-collapse">
-            <thead>
-              <tr style="background:var(--ink-800);">
-                <th class="px-6 py-4 text-muted font-mono text-xs tracking-widest uppercase">Leistung</th>
-                <th class="px-6 py-4 text-gold font-mono text-xs tracking-widest uppercase text-center">Führungskräfte</th>
-                <th class="px-6 py-4 text-gold font-mono text-xs tracking-widest uppercase text-center">50+ Digital</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr class="border-t border-dark-lighter hover:bg-dark-light transition-colors">
-                <td class="px-6 py-4 text-light">Einzelstunde (60 Min.)</td>
-                <td class="px-6 py-4 text-center font-bold text-light">150 €</td>
-                <td class="px-6 py-4 text-center font-bold text-light">60 €</td>
-              </tr>
-              <tr class="border-t border-dark-lighter hover:bg-dark-light transition-colors" style="background:rgba(255,255,255,0.02)">
-                <td class="px-6 py-4 text-light">
-                  Paket S — 6 Sessions
-                  <span class="ml-2 text-xs px-2 py-0.5 rounded-full bg-gold/10 text-gold border border-gold/20">Beliebt</span>
-                </td>
-                <td class="px-6 py-4 text-center font-bold text-gold">840 €</td>
-                <td class="px-6 py-4 text-center font-bold text-gold">330 €</td>
-              </tr>
-              <tr class="border-t border-dark-lighter hover:bg-dark-light transition-colors">
-                <td class="px-6 py-4 text-light">Paket M — 12 Sessions</td>
-                <td class="px-6 py-4 text-center font-bold text-light">1.560 €</td>
-                <td class="px-6 py-4 text-center font-bold text-light">600 €</td>
-              </tr>
-              <tr class="border-t border-dark-lighter hover:bg-dark-light transition-colors" style="background:rgba(255,255,255,0.02)">
-                <td class="px-6 py-4 text-muted">Erstgespräch (30 Min.)</td>
-                <td class="px-6 py-4 text-center text-muted">kostenlos</td>
-                <td class="px-6 py-4 text-center text-muted">kostenlos</td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-        <p class="text-xs text-muted mt-3 text-center">
-          Alle Preise sind Nettopreise gemäß §&nbsp;19 UStG — kein Ausweis von Umsatzsteuer.
-        </p>
-        <p class="text-sm text-muted mt-2 text-center">
-          Für Unternehmenskunden (ab 3 Personen) erstelle ich gerne ein individuelles Angebot.
-          <a href="/kontakt" class="text-gold hover:underline ml-1">Anfrage stellen →</a>
-        </p>
-      </div>
+      {/* Pricing comparison table — driven by `leistungen` config so editing it in /admin/inhalte
+          (Angebote → Leistungskatalog) is the single source of truth. Compares the first two
+          categories pairwise by row index. */}
+      {leistungen.length >= 2 && (() => {
+        const cmpCats = leistungen.slice(0, 2);
+        const maxRows = Math.max(...cmpCats.map((c) => c.services.length));
+        return (
+          <div class="mb-16">
+            <h2 class="text-2xl md:text-3xl font-bold text-light mb-8 font-serif text-center">Angebote im Überblick</h2>
+            <div class="overflow-x-auto rounded-2xl border border-dark-lighter">
+              <table class="w-full text-left border-collapse">
+                <thead>
+                  <tr style="background:var(--ink-800);">
+                    <th class="px-6 py-4 text-muted font-mono text-xs tracking-widest uppercase">Leistung</th>
+                    {cmpCats.map((c) => (
+                      <th class="px-6 py-4 text-gold font-mono text-xs tracking-widest uppercase text-center">{c.title}</th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {Array.from({ length: maxRows }).map((_, rowIdx) => {
+                    const rowServices = cmpCats.map((c) => c.services[rowIdx]);
+                    const rowName = rowServices.find((s) => s)?.name ?? '';
+                    const isHighlighted = rowServices.some((s) => s?.highlight);
+                    return (
+                      <tr class="border-t border-dark-lighter hover:bg-dark-light transition-colors" style={isHighlighted ? 'background:rgba(255,255,255,0.02)' : ''}>
+                        <td class="px-6 py-4 text-light">
+                          {rowName}
+                          {isHighlighted && (
+                            <span class="ml-2 text-xs px-2 py-0.5 rounded-full bg-gold/10 text-gold border border-gold/20">Beliebt</span>
+                          )}
+                        </td>
+                        {rowServices.map((s) => (
+                          <td class={`px-6 py-4 text-center font-bold ${isHighlighted ? 'text-gold' : 'text-light'}`}>{s?.price ?? '—'}</td>
+                        ))}
+                      </tr>
+                    );
+                  })}
+                  <tr class="border-t border-dark-lighter hover:bg-dark-light transition-colors" style="background:rgba(255,255,255,0.02)">
+                    <td class="px-6 py-4 text-muted">Erstgespräch (30 Min.)</td>
+                    {cmpCats.map(() => (
+                      <td class="px-6 py-4 text-center text-muted">kostenlos</td>
+                    ))}
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+            <p class="text-xs text-muted mt-3 text-center">
+              Alle Preise sind Nettopreise gemäß §&nbsp;19 UStG — kein Ausweis von Umsatzsteuer.
+            </p>
+            <p class="text-sm text-muted mt-2 text-center">
+              Für Unternehmenskunden (ab 3 Personen) erstelle ich gerne ein individuelles Angebot.
+              <a href="/kontakt" class="text-gold hover:underline ml-1">Anfrage stellen →</a>
+            </p>
+          </div>
+        );
+      })()}
 
       {leistungen.map((cat) => (
         <div id={cat.id} class="mb-16">


### PR DESCRIPTION
## Summary
- Admin /inhalte → Angebote: Seiteninhalte-Editor erweitert um Leistungsumfang (Bereiche + Bullets) und Investition (Preis-Boxen), jeweils mit Add/Remove/Reorder/Highlight
- /leistungen Vergleichstabelle wird jetzt vom Leistungskatalog gespeist (single source of truth) — keine doppelte Preispflege mehr
- Reorder + Highlight im Leistungskatalog hinzugefügt

## Tickets
- BR-20260507-5039 — Preise auf Startseite/Angebot-Detailseiten pflegbar machen
- BR-20260507-96c5 — Preise pflegbar (zweite Stelle)
- BR-20260507-7abb — Preise pflegbar (dritte Stelle)
- BR-20260507-4461 — Leistungsumfang 50+ digital pflegbar

## Test plan
- [ ] /admin/inhalte → Tab Angebote: für jedes Service unter "Seiteninhalte (pageContent)" gibt es jetzt 'Leistungsumfang' (Bereiche) und 'Investition' (Preise) mit Add/Remove/Reorder
- [ ] Änderung an einem 'Investition'-Preis erscheint auf der zugehörigen Service-Detailseite (/50plus-digital, /coaching, …)
- [ ] Änderung an einem 'Leistungsumfang'-Bereich erscheint als Spalte unter 'Leistungsumfang' auf der Detailseite
- [ ] /leistungen Vergleichstabelle zeigt aktuelle Preise aus dem Leistungskatalog (keine 1.560 €-Hardcodes mehr)
- [ ] Highlight-Toggle markiert Tarif visuell (Goldrand/Beliebt-Badge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)