### PR TITLE
feat(tickets): unify bug reports into tickets schema (PR1/5)

### DIFF
--- a/docs/superpowers/plans/2026-05-08-unified-ticketing-pr1.md
+++ b/docs/superpowers/plans/2026-05-08-unified-ticketing-pr1.md
@@ -1,0 +1,1738 @@
+# Unified Ticketing PR1 — Schema, Bug Migration, Close-Mail Fix
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stand up the new `tickets` schema, migrate `bugs.bug_tickets` into it, and fix the missed-reporter-notification bug on every close path — without changing the public bug-report or admin-bugs UX.
+
+**Architecture:** A new `tickets` Postgres schema is created in the `website` database. All existing bug data migrates into `tickets.tickets` (type=`bug`). Three close paths (admin bug resolve, inbox resolve action, PR-merge auto-close) are rewritten to call a single `transitionTicket()` service that always notifies the reporter via email. The old `bugs.bug_tickets` table is replaced by a SQL view so external readers (`timeline.ts` `bugs_fixed` join, `kore/KoreBugs.astro`) keep working.
+
+**Tech Stack:** Astro 4, Svelte 4, TypeScript, PostgreSQL 16 (`shared-db`), `pg` driver, nodemailer (Mailpit dev / SMTP prod), Playwright + BATS for testing, `task` (go-task) for orchestration.
+
+**Spec:** `docs/superpowers/specs/2026-05-08-unified-ticketing-design.md` — sections 5, 6, 7, 9 (PR1 only).
+
+---
+
+## File Structure
+
+**Create:**
+- `website/src/lib/tickets-db.ts` — schema init (CREATE SCHEMA + tables + triggers + indexes), query helpers for the new model.
+- `website/src/lib/tickets/transition.ts` — single `transitionTicket()` service. The only code allowed to change `tickets.status`.
+- `website/src/lib/tickets/email-templates.ts` — close-notification templates.
+- `website/src/lib/tickets/reporter-link.ts` — reporter→customer auto-link helper.
+- `scripts/migrate-bugs-to-tickets.mjs` — one-shot, idempotent migration runner.
+- `tests/unit/tickets-transition.bats` — BATS state-machine tests.
+- `tests/unit/tickets-migration.bats` — BATS migration verification (row counts, key mappings).
+- `tests/e2e/specs/fa-bugs-notifications.spec.ts` — Playwright bug-report→admin-resolve→reporter-email E2E.
+
+**Modify:**
+- `website/src/lib/website-db.ts` — wire `initTicketsSchema()`; rewrite `insertBugTicket`/`resolveBugTicket`/`archiveBugTicket`/`reopenBugTicket`/`getBugTicketStatus`/`getBugTicketWithComments`/`appendBugTicketComment`/`listBugTickets` to read from `tickets.tickets`. Keep the JOIN at line 88-91 (`bugs_fixed` count) by replacing `bugs.bug_tickets` with the new view.
+- `website/src/pages/api/bug-report.ts` — write into `tickets.tickets` directly (still mints BR-IDs); call `linkReporterToCustomer()`.
+- `website/src/pages/api/admin/bugs/resolve.ts` — call `transitionTicket()`.
+- `website/src/pages/api/admin/inbox/[id]/action.ts` — `resolve_bug` case calls `transitionTicket()`; remove the broken `info@<brand>` email block.
+- `scripts/track-pr.mjs` — `writeRowToDb()` calls `transitionTicket()` with `status='done'` (not `'archived'`) and `resolution='fixed'`.
+
+**No UI change in PR1.** `/admin/bugs`, `/admin/bugs/[id]`, and `BugsTab.svelte` keep working unchanged because the website-db reader functions still expose the same interface — they just read from `tickets.tickets` underneath.
+
+---
+
+## Task 1: Scaffold tickets-db.ts with schema + tables
+
+**Files:**
+- Create: `website/src/lib/tickets-db.ts`
+
+- [ ] **Step 1: Create tickets-db.ts with schema init**
+
+```typescript
+// website/src/lib/tickets-db.ts
+import { pool } from './db';
+
+let schemaReady = false;
+
+export async function initTicketsSchema(): Promise<void> {
+  if (schemaReady) return;
+
+  await pool.query(`CREATE SCHEMA IF NOT EXISTS tickets AUTHORIZATION website`);
+
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS tickets.tickets (
+      id              UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+      external_id     TEXT        UNIQUE,
+      type            TEXT        NOT NULL CHECK (type IN ('bug','feature','task','project')),
+      parent_id       UUID        REFERENCES tickets.tickets(id) ON DELETE SET NULL,
+      brand           TEXT        NOT NULL,
+
+      title           TEXT        NOT NULL,
+      description     TEXT,
+      url             TEXT,
+      thesis_tag      TEXT,
+      component       TEXT,
+
+      status          TEXT        NOT NULL DEFAULT 'triage'
+                      CHECK (status IN ('triage','backlog','in_progress','in_review','blocked','done','archived')),
+      resolution      TEXT        CHECK (resolution IN
+                        ('fixed','shipped','wontfix','duplicate','cant_reproduce','obsolete')),
+      priority        TEXT        NOT NULL DEFAULT 'mittel'  CHECK (priority IN ('hoch','mittel','niedrig')),
+      severity        TEXT        CHECK (severity IN ('critical','major','minor','trivial')),
+
+      reporter_id     UUID        REFERENCES customers(id) ON DELETE SET NULL,
+      reporter_email  TEXT,
+      assignee_id     UUID        REFERENCES customers(id) ON DELETE SET NULL,
+      customer_id     UUID        REFERENCES customers(id) ON DELETE SET NULL,
+
+      start_date      DATE,
+      due_date        DATE,
+      estimate_minutes      INTEGER,
+      time_logged_minutes   INTEGER NOT NULL DEFAULT 0,
+
+      triaged_at      TIMESTAMPTZ,
+      started_at      TIMESTAMPTZ,
+      done_at         TIMESTAMPTZ,
+      archived_at     TIMESTAMPTZ,
+
+      created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+      updated_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+      CONSTRAINT resolution_only_when_closed CHECK (
+        (resolution IS NULL AND status NOT IN ('done','archived'))
+        OR status IN ('done','archived')
+      )
+    )
+  `);
+
+  await pool.query(`CREATE INDEX IF NOT EXISTS tickets_status_idx ON tickets.tickets (status) WHERE status NOT IN ('done','archived')`);
+  await pool.query(`CREATE INDEX IF NOT EXISTS tickets_type_brand_idx ON tickets.tickets (type, brand)`);
+  await pool.query(`CREATE INDEX IF NOT EXISTS tickets_parent_idx ON tickets.tickets (parent_id)`);
+  await pool.query(`CREATE INDEX IF NOT EXISTS tickets_assignee_idx ON tickets.tickets (assignee_id) WHERE assignee_id IS NOT NULL`);
+  await pool.query(`CREATE INDEX IF NOT EXISTS tickets_customer_idx ON tickets.tickets (customer_id) WHERE customer_id IS NOT NULL`);
+  await pool.query(`CREATE INDEX IF NOT EXISTS tickets_thesis_tag_idx ON tickets.tickets (thesis_tag) WHERE thesis_tag IS NOT NULL`);
+  await pool.query(`CREATE INDEX IF NOT EXISTS tickets_external_id_idx ON tickets.tickets (external_id)`);
+
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS tickets.ticket_links (
+      id          BIGSERIAL PRIMARY KEY,
+      from_id     UUID NOT NULL REFERENCES tickets.tickets(id) ON DELETE CASCADE,
+      to_id       UUID NOT NULL REFERENCES tickets.tickets(id) ON DELETE CASCADE,
+      kind        TEXT NOT NULL CHECK (kind IN ('blocks','blocked_by','duplicate_of','relates_to','fixes','fixed_by')),
+      pr_number   INTEGER,
+      created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+      created_by  UUID REFERENCES customers(id),
+      UNIQUE (from_id, to_id, kind)
+    )
+  `);
+  await pool.query(`CREATE INDEX IF NOT EXISTS ticket_links_from_idx ON tickets.ticket_links (from_id, kind)`);
+  await pool.query(`CREATE INDEX IF NOT EXISTS ticket_links_to_idx   ON tickets.ticket_links (to_id, kind)`);
+  await pool.query(`CREATE INDEX IF NOT EXISTS ticket_links_pr_idx   ON tickets.ticket_links (pr_number) WHERE pr_number IS NOT NULL`);
+
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS tickets.ticket_activity (
+      id          BIGSERIAL PRIMARY KEY,
+      ticket_id   UUID NOT NULL REFERENCES tickets.tickets(id) ON DELETE CASCADE,
+      actor_id    UUID REFERENCES customers(id),
+      actor_label TEXT,
+      field       TEXT NOT NULL,
+      old_value   JSONB,
+      new_value   JSONB,
+      created_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+    )
+  `);
+  await pool.query(`CREATE INDEX IF NOT EXISTS activity_ticket_idx ON tickets.ticket_activity (ticket_id, created_at)`);
+
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS tickets.ticket_comments (
+      id           BIGSERIAL PRIMARY KEY,
+      ticket_id    UUID NOT NULL REFERENCES tickets.tickets(id) ON DELETE CASCADE,
+      author_id    UUID REFERENCES customers(id),
+      author_label TEXT NOT NULL,
+      kind         TEXT NOT NULL DEFAULT 'comment'
+                   CHECK (kind IN ('comment','status_change','system')),
+      body         TEXT NOT NULL,
+      visibility   TEXT NOT NULL DEFAULT 'internal'
+                   CHECK (visibility IN ('internal','public')),
+      created_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+    )
+  `);
+  await pool.query(`CREATE INDEX IF NOT EXISTS ticket_comments_ticket_idx ON tickets.ticket_comments (ticket_id, created_at)`);
+
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS tickets.ticket_attachments (
+      id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      ticket_id   UUID NOT NULL REFERENCES tickets.tickets(id) ON DELETE CASCADE,
+      filename    TEXT NOT NULL,
+      nc_path     TEXT,
+      data_url    TEXT,
+      mime_type   TEXT NOT NULL DEFAULT 'application/octet-stream',
+      file_size   BIGINT,
+      uploaded_by UUID REFERENCES customers(id),
+      uploaded_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      CHECK (nc_path IS NOT NULL OR data_url IS NOT NULL)
+    )
+  `);
+  await pool.query(`CREATE INDEX IF NOT EXISTS ticket_attachments_ticket_idx ON tickets.ticket_attachments (ticket_id)`);
+
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS tickets.ticket_watchers (
+      ticket_id   UUID NOT NULL REFERENCES tickets.tickets(id) ON DELETE CASCADE,
+      user_id     UUID NOT NULL REFERENCES customers(id) ON DELETE CASCADE,
+      added_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+      PRIMARY KEY (ticket_id, user_id)
+    )
+  `);
+
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS tickets.tags (
+      id    UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      name  TEXT NOT NULL UNIQUE,
+      color TEXT,
+      brand TEXT
+    )
+  `);
+
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS tickets.ticket_tags (
+      ticket_id UUID NOT NULL REFERENCES tickets.tickets(id) ON DELETE CASCADE,
+      tag_id    UUID NOT NULL REFERENCES tickets.tags(id) ON DELETE CASCADE,
+      PRIMARY KEY (ticket_id, tag_id)
+    )
+  `);
+
+  schemaReady = true;
+}
+```
+
+- [ ] **Step 2: Verify the file compiles**
+
+Run: `cd website && npx tsc --noEmit src/lib/tickets-db.ts`
+Expected: no output (clean compile). If you see "Cannot find module './db'", check that `website/src/lib/db.ts` exists and exports `pool`. If not, fall back to `import { pool } from './website-db.js';` since `website-db.ts` is where `pool` lives in this codebase.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add website/src/lib/tickets-db.ts
+git commit -m "feat(tickets): create tickets schema and core tables"
+```
+
+---
+
+## Task 2: Add cycle-prevention and lifecycle-timestamp triggers
+
+**Files:**
+- Modify: `website/src/lib/tickets-db.ts`
+
+- [ ] **Step 1: Append trigger DDL to `initTicketsSchema()` after the table creates**
+
+Add at the end of `initTicketsSchema()` (before `schemaReady = true`):
+
+```typescript
+  await pool.query(`
+    CREATE OR REPLACE FUNCTION tickets.fn_prevent_cycle() RETURNS trigger AS $$
+    DECLARE
+      cur UUID := NEW.parent_id;
+      depth INT := 0;
+    BEGIN
+      WHILE cur IS NOT NULL AND depth < 100 LOOP
+        IF cur = NEW.id THEN
+          RAISE EXCEPTION 'parent_id cycle detected on ticket %', NEW.id;
+        END IF;
+        SELECT parent_id INTO cur FROM tickets.tickets WHERE id = cur;
+        depth := depth + 1;
+      END LOOP;
+      RETURN NEW;
+    END $$ LANGUAGE plpgsql
+  `);
+  await pool.query(`
+    DROP TRIGGER IF EXISTS trg_tickets_prevent_cycle ON tickets.tickets;
+    CREATE TRIGGER trg_tickets_prevent_cycle
+      BEFORE INSERT OR UPDATE OF parent_id ON tickets.tickets
+      FOR EACH ROW WHEN (NEW.parent_id IS NOT NULL)
+      EXECUTE FUNCTION tickets.fn_prevent_cycle()
+  `);
+
+  await pool.query(`
+    CREATE OR REPLACE FUNCTION tickets.fn_lifecycle_ts() RETURNS trigger AS $$
+    BEGIN
+      IF TG_OP = 'INSERT' THEN
+        IF NEW.status = 'triage' AND NEW.triaged_at IS NULL THEN NEW.triaged_at := now(); END IF;
+        IF NEW.status = 'in_progress' AND NEW.started_at IS NULL THEN NEW.started_at := now(); END IF;
+        IF NEW.status = 'done' AND NEW.done_at IS NULL THEN NEW.done_at := now(); END IF;
+        IF NEW.status = 'archived' AND NEW.archived_at IS NULL THEN NEW.archived_at := now(); END IF;
+      ELSE
+        IF NEW.status <> OLD.status THEN
+          IF NEW.status = 'triage'      AND NEW.triaged_at  IS NULL THEN NEW.triaged_at  := now(); END IF;
+          IF NEW.status = 'in_progress' AND NEW.started_at  IS NULL THEN NEW.started_at  := now(); END IF;
+          IF NEW.status = 'done'        AND NEW.done_at     IS NULL THEN NEW.done_at     := now(); END IF;
+          IF NEW.status = 'archived'    AND NEW.archived_at IS NULL THEN NEW.archived_at := now(); END IF;
+        END IF;
+        NEW.updated_at := now();
+      END IF;
+      RETURN NEW;
+    END $$ LANGUAGE plpgsql
+  `);
+  await pool.query(`
+    DROP TRIGGER IF EXISTS trg_tickets_lifecycle_ts ON tickets.tickets;
+    CREATE TRIGGER trg_tickets_lifecycle_ts
+      BEFORE INSERT OR UPDATE ON tickets.tickets
+      FOR EACH ROW EXECUTE FUNCTION tickets.fn_lifecycle_ts()
+  `);
+```
+
+- [ ] **Step 2: Smoke-check by initialising against a local k3d DB**
+
+Run from project root:
+```bash
+task workspace:port-forward ENV=mentolder &
+PG_PID=$!
+sleep 3
+PGPASSWORD=$(kubectl --context mentolder -n workspace get secret workspace-secrets -o jsonpath='{.data.POSTGRES_PASSWORD}' | base64 -d) \
+  psql -h localhost -U postgres -d website -c '\dt tickets.*'
+kill $PG_PID 2>/dev/null || true
+```
+Expected: error `Did not find any relation matching` (the schema doesn't exist yet — that's fine; we're just checking pool connectivity). If you get a connection error, the port-forward isn't up; investigate before continuing.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add website/src/lib/tickets-db.ts
+git commit -m "feat(tickets): add cycle-prevention and lifecycle-timestamp triggers"
+```
+
+---
+
+## Task 3: Add audit-log trigger
+
+**Files:**
+- Modify: `website/src/lib/tickets-db.ts`
+
+- [ ] **Step 1: Append audit-log trigger after the lifecycle-ts trigger**
+
+```typescript
+  await pool.query(`
+    CREATE OR REPLACE FUNCTION tickets.fn_audit_log() RETURNS trigger AS $$
+    DECLARE
+      actor_id_local UUID;
+      actor_label_local TEXT;
+      diff JSONB := '{}'::jsonb;
+      tracked_field TEXT;
+    BEGIN
+      BEGIN actor_id_local := current_setting('app.user_id', true)::uuid;
+      EXCEPTION WHEN OTHERS THEN actor_id_local := NULL; END;
+      BEGIN actor_label_local := current_setting('app.user_label', true);
+      EXCEPTION WHEN OTHERS THEN actor_label_local := NULL; END;
+
+      IF TG_OP = 'INSERT' THEN
+        INSERT INTO tickets.ticket_activity (ticket_id, actor_id, actor_label, field, new_value)
+        VALUES (NEW.id, actor_id_local, actor_label_local, '_created', to_jsonb(NEW));
+        RETURN NEW;
+      END IF;
+
+      FOR tracked_field IN SELECT unnest(ARRAY[
+        'status','resolution','priority','severity','assignee_id','customer_id',
+        'reporter_id','reporter_email','title','description','url','component',
+        'thesis_tag','parent_id','start_date','due_date','estimate_minutes'
+      ]) LOOP
+        IF (to_jsonb(OLD) -> tracked_field) IS DISTINCT FROM (to_jsonb(NEW) -> tracked_field) THEN
+          diff := diff || jsonb_build_object(tracked_field,
+            jsonb_build_object('old', to_jsonb(OLD) -> tracked_field,
+                               'new', to_jsonb(NEW) -> tracked_field));
+        END IF;
+      END LOOP;
+
+      IF diff <> '{}'::jsonb THEN
+        INSERT INTO tickets.ticket_activity (ticket_id, actor_id, actor_label, field, old_value, new_value)
+        VALUES (NEW.id, actor_id_local, actor_label_local, '_updated', NULL, diff);
+      END IF;
+      RETURN NEW;
+    END $$ LANGUAGE plpgsql
+  `);
+  await pool.query(`
+    DROP TRIGGER IF EXISTS trg_tickets_audit_log ON tickets.tickets;
+    CREATE TRIGGER trg_tickets_audit_log
+      AFTER INSERT OR UPDATE ON tickets.tickets
+      FOR EACH ROW EXECUTE FUNCTION tickets.fn_audit_log()
+  `);
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add website/src/lib/tickets-db.ts
+git commit -m "feat(tickets): add audit-log trigger writing to ticket_activity"
+```
+
+---
+
+## Task 4: Reporter→customer auto-link helper
+
+**Files:**
+- Create: `website/src/lib/tickets/reporter-link.ts`
+- Test: `tests/unit/tickets-reporter-link.bats`
+
+- [ ] **Step 1: Write the failing test**
+
+```bash
+# tests/unit/tickets-reporter-link.bats
+#!/usr/bin/env bats
+load ../helpers/test_helper
+
+setup() {
+  export PGURL="${TRACKING_DB_URL:-postgres://postgres:postgres@localhost:5432/website}"
+}
+
+@test "linkReporterByEmail sets reporter_id when email matches a keycloak-linked customer" {
+  psql "$PGURL" <<SQL
+    INSERT INTO customers (id, name, email, keycloak_user_id)
+      VALUES ('11111111-1111-1111-1111-111111111111', 'Test User', 'link-test@example.com', 'kc-1')
+      ON CONFLICT (email) DO NOTHING;
+    INSERT INTO tickets.tickets (id, type, brand, title, reporter_email)
+      VALUES ('22222222-2222-2222-2222-222222222222', 'bug', 'mentolder', 'T', 'link-test@example.com')
+      ON CONFLICT DO NOTHING;
+SQL
+  node --input-type=module -e "
+    import('./website/src/lib/tickets/reporter-link.js').then(async m => {
+      await m.linkReporterByEmail('link-test@example.com');
+      process.exit(0);
+    });
+  "
+  result=$(psql "$PGURL" -t -A -c "SELECT reporter_id::text FROM tickets.tickets WHERE id='22222222-2222-2222-2222-222222222222'")
+  [ "$result" = "11111111-1111-1111-1111-111111111111" ]
+}
+```
+
+- [ ] **Step 2: Verify it fails**
+
+Run: `./tests/runner.sh local -- tests/unit/tickets-reporter-link.bats`
+Expected: FAIL — module `./website/src/lib/tickets/reporter-link.js` not found.
+
+- [ ] **Step 3: Implement the helper**
+
+```typescript
+// website/src/lib/tickets/reporter-link.ts
+import { pool } from '../website-db';
+
+/**
+ * If a customer with this email exists and has a keycloak_user_id,
+ * link any tickets where reporter_email = email AND reporter_id IS NULL.
+ * Idempotent — safe to call repeatedly.
+ */
+export async function linkReporterByEmail(email: string): Promise<number> {
+  if (!email) return 0;
+  const r = await pool.query(
+    `UPDATE tickets.tickets t
+       SET reporter_id = c.id
+       FROM customers c
+      WHERE t.reporter_email = $1
+        AND t.reporter_id IS NULL
+        AND c.email = $1
+        AND c.keycloak_user_id IS NOT NULL`,
+    [email]
+  );
+  return r.rowCount ?? 0;
+}
+
+/**
+ * Batch link: for every distinct reporter_email in tickets where reporter_id is null,
+ * try to match against customers. Used by the migration script and as a nightly cron.
+ */
+export async function linkAllReporters(): Promise<number> {
+  const r = await pool.query(
+    `UPDATE tickets.tickets t
+       SET reporter_id = c.id
+       FROM customers c
+      WHERE t.reporter_id IS NULL
+        AND t.reporter_email IS NOT NULL
+        AND c.email = t.reporter_email
+        AND c.keycloak_user_id IS NOT NULL`
+  );
+  return r.rowCount ?? 0;
+}
+```
+
+- [ ] **Step 4: Run the test, verify pass**
+
+Run: `./tests/runner.sh local -- tests/unit/tickets-reporter-link.bats`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add website/src/lib/tickets/reporter-link.ts tests/unit/tickets-reporter-link.bats
+git commit -m "feat(tickets): reporter-email to customer auto-link helper"
+```
+
+---
+
+## Task 5: Close-notification email template
+
+**Files:**
+- Create: `website/src/lib/tickets/email-templates.ts`
+
+- [ ] **Step 1: Implement the template**
+
+```typescript
+// website/src/lib/tickets/email-templates.ts
+import { sendEmail } from '../email';
+
+const FROM_NAME = process.env.FROM_NAME || process.env.BRAND_NAME || 'Workspace';
+const PROD_DOMAIN = process.env.PROD_DOMAIN || '';
+const BRAND = process.env.BRAND || 'mentolder';
+const INFO_EMAIL = PROD_DOMAIN ? `info@${PROD_DOMAIN}` : `info@${BRAND}.de`;
+
+export interface CloseEmailParams {
+  externalId: string;
+  reporterEmail: string;
+  resolution: string;             // 'fixed' | 'shipped' | 'wontfix' | 'duplicate' | 'cant_reproduce' | 'obsolete'
+  note?: string;                   // optional public note
+  publicStatusUrl?: string;        // e.g. https://web.mentolder.de/portal/tickets/BR-…
+}
+
+const RESOLUTION_LABELS_DE: Record<string, string> = {
+  fixed:         'behoben',
+  shipped:       'umgesetzt',
+  wontfix:       'nicht umgesetzt',
+  duplicate:     'als Duplikat geschlossen',
+  cant_reproduce:'nicht reproduzierbar',
+  obsolete:      'nicht mehr relevant',
+};
+
+export async function sendBugCloseEmail(p: CloseEmailParams): Promise<boolean> {
+  if (!p.reporterEmail) return false;
+  const label = RESOLUTION_LABELS_DE[p.resolution] ?? p.resolution;
+
+  const text = `Hallo,
+
+Ihre Meldung mit der Nummer ${p.externalId} wurde ${label}.
+${p.note ? `\nAnmerkung: ${p.note}\n` : ''}
+${p.publicStatusUrl ? `Status & Verlauf: ${p.publicStatusUrl}\n\n` : ''}
+Vielen Dank für Ihren Beitrag.
+
+Mit freundlichen Grüßen
+${FROM_NAME}`;
+
+  const html = `<p>Hallo,</p>
+<p>Ihre Meldung mit der Nummer <strong>${p.externalId}</strong> wurde <strong>${label}</strong>.</p>
+${p.note ? `<p><em>Anmerkung:</em> ${p.note}</p>` : ''}
+${p.publicStatusUrl ? `<p>Status &amp; Verlauf: <a href="${p.publicStatusUrl}">${p.publicStatusUrl}</a></p>` : ''}
+<p>Vielen Dank für Ihren Beitrag.</p>
+<p>Mit freundlichen Grüßen<br>${FROM_NAME}</p>`;
+
+  return sendEmail({
+    to: p.reporterEmail,
+    bcc: INFO_EMAIL,
+    replyTo: INFO_EMAIL,
+    subject: `[${p.externalId}] Ihre Meldung wurde bearbeitet`,
+    text,
+    html,
+  });
+}
+```
+
+- [ ] **Step 2: Add `bcc` field to the email helper**
+
+Modify `website/src/lib/email.ts` — find the `SendEmailParams` interface and add `bcc?: string;`. Find the `transporter.sendMail({ ... })` call and add `bcc: params.bcc,`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add website/src/lib/tickets/email-templates.ts website/src/lib/email.ts
+git commit -m "feat(tickets): bug close-notification email template (To=reporter, BCC=info@brand)"
+```
+
+---
+
+## Task 6: `transitionTicket()` service — the only writer of `status`
+
+**Files:**
+- Create: `website/src/lib/tickets/transition.ts`
+- Test: `tests/unit/tickets-transition.bats`
+
+- [ ] **Step 1: Write the failing tests**
+
+```bash
+# tests/unit/tickets-transition.bats
+#!/usr/bin/env bats
+load ../helpers/test_helper
+
+setup() {
+  export PGURL="${TRACKING_DB_URL:-postgres://postgres:postgres@localhost:5432/website}"
+  export TICKET_ID="33333333-3333-3333-3333-333333333333"
+  psql "$PGURL" <<SQL
+    DELETE FROM tickets.tickets WHERE id = '$TICKET_ID';
+    INSERT INTO tickets.tickets (id, type, brand, title, status, reporter_email, external_id)
+      VALUES ('$TICKET_ID', 'bug', 'mentolder', 'T', 'triage', 'rep-test@example.com', 'BR-19990101-0001');
+SQL
+}
+
+@test "transitionTicket: triage -> done sets resolution, done_at, sends mail" {
+  node --input-type=module -e "
+    import('./website/src/lib/tickets/transition.js').then(async m => {
+      const r = await m.transitionTicket('$TICKET_ID', { status: 'done', resolution: 'fixed', actor: { label: 'test' } });
+      console.log(JSON.stringify(r));
+    });
+  "
+  result=$(psql "$PGURL" -t -A -c "SELECT status||','||resolution||','||CASE WHEN done_at IS NULL THEN 'null' ELSE 'set' END FROM tickets.tickets WHERE id='$TICKET_ID'")
+  [ "$result" = "done,fixed,set" ]
+}
+
+@test "transitionTicket: rejects done without resolution" {
+  output=$(node --input-type=module -e "
+    import('./website/src/lib/tickets/transition.js').then(async m => {
+      try { await m.transitionTicket('$TICKET_ID', { status: 'done', actor: { label: 'test' } }); console.log('OK'); }
+      catch (e) { console.log('ERR:'+e.message); }
+    });
+  " 2>&1)
+  [[ "$output" == *"ERR:"*"resolution"* ]]
+}
+
+@test "transitionTicket: rejects unknown status" {
+  output=$(node --input-type=module -e "
+    import('./website/src/lib/tickets/transition.js').then(async m => {
+      try { await m.transitionTicket('$TICKET_ID', { status: 'banana', actor: { label: 'test' } }); console.log('OK'); }
+      catch (e) { console.log('ERR:'+e.message); }
+    });
+  " 2>&1)
+  [[ "$output" == *"ERR:"* ]]
+}
+```
+
+- [ ] **Step 2: Verify tests fail**
+
+Run: `./tests/runner.sh local -- tests/unit/tickets-transition.bats`
+Expected: 3 FAILs — module not found.
+
+- [ ] **Step 3: Implement `transitionTicket()`**
+
+```typescript
+// website/src/lib/tickets/transition.ts
+import { pool } from '../website-db';
+import { sendBugCloseEmail } from './email-templates';
+import { linkReporterByEmail } from './reporter-link';
+
+export type TicketStatus =
+  'triage' | 'backlog' | 'in_progress' | 'in_review' | 'blocked' | 'done' | 'archived';
+
+export type TicketResolution =
+  'fixed' | 'shipped' | 'wontfix' | 'duplicate' | 'cant_reproduce' | 'obsolete';
+
+const VALID_STATUSES: ReadonlySet<TicketStatus> = new Set(
+  ['triage','backlog','in_progress','in_review','blocked','done','archived']);
+
+const VALID_RESOLUTIONS: ReadonlySet<TicketResolution> = new Set(
+  ['fixed','shipped','wontfix','duplicate','cant_reproduce','obsolete']);
+
+export interface TransitionParams {
+  status: TicketStatus;
+  resolution?: TicketResolution;
+  note?: string;
+  noteVisibility?: 'internal' | 'public';
+  actor: { id?: string; label: string };
+  prNumber?: number;
+}
+
+export interface TransitionResult {
+  id: string;
+  externalId: string | null;
+  type: string;
+  status: TicketStatus;
+  resolution: TicketResolution | null;
+  emailSent: boolean;
+}
+
+export async function transitionTicket(
+  ticketId: string,
+  p: TransitionParams
+): Promise<TransitionResult> {
+  if (!VALID_STATUSES.has(p.status)) {
+    throw new Error(`invalid status: ${p.status}`);
+  }
+  if ((p.status === 'done' || p.status === 'archived') && !p.resolution) {
+    throw new Error(`status=${p.status} requires a resolution`);
+  }
+  if (p.resolution && !VALID_RESOLUTIONS.has(p.resolution)) {
+    throw new Error(`invalid resolution: ${p.resolution}`);
+  }
+
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+    if (p.actor.id) {
+      await client.query(`SELECT set_config('app.user_id', $1, true)`, [p.actor.id]);
+    }
+    await client.query(`SELECT set_config('app.user_label', $1, true)`, [p.actor.label]);
+
+    const cur = await client.query(
+      `SELECT id, external_id, type, status, reporter_email, brand
+         FROM tickets.tickets WHERE id = $1 FOR UPDATE`,
+      [ticketId]
+    );
+    if (cur.rowCount === 0) throw new Error(`ticket ${ticketId} not found`);
+    const before = cur.rows[0];
+
+    const upd = await client.query(
+      `UPDATE tickets.tickets
+         SET status = $1,
+             resolution = $2
+       WHERE id = $3
+       RETURNING id, external_id, type, status, resolution, reporter_email, brand`,
+      [p.status, p.resolution ?? null, ticketId]
+    );
+    const after = upd.rows[0];
+
+    if (p.note) {
+      await client.query(
+        `INSERT INTO tickets.ticket_comments
+           (ticket_id, author_id, author_label, kind, body, visibility)
+         VALUES ($1, $2, $3, 'status_change', $4, $5)`,
+        [ticketId, p.actor.id ?? null, p.actor.label, p.note, p.noteVisibility ?? 'internal']
+      );
+    }
+
+    if (p.prNumber) {
+      await client.query(
+        `INSERT INTO tickets.ticket_links (from_id, to_id, kind, pr_number, created_by)
+         SELECT $1, $1, 'fixes', $2, $3
+         WHERE NOT EXISTS (
+           SELECT 1 FROM tickets.ticket_links
+           WHERE from_id = $1 AND kind = 'fixes' AND pr_number = $2
+         )`,
+        [ticketId, p.prNumber, p.actor.id ?? null]
+      );
+    }
+
+    await client.query('COMMIT');
+
+    let emailSent = false;
+    const becomingDone = before.status !== 'done' && p.status === 'done';
+    if (becomingDone && after.type === 'bug' && after.reporter_email) {
+      await linkReporterByEmail(after.reporter_email);
+      emailSent = await sendBugCloseEmail({
+        externalId: after.external_id ?? after.id,
+        reporterEmail: after.reporter_email,
+        resolution: after.resolution,
+        note: p.noteVisibility === 'public' ? p.note : undefined,
+      });
+    }
+
+    return {
+      id: after.id,
+      externalId: after.external_id,
+      type: after.type,
+      status: after.status,
+      resolution: after.resolution,
+      emailSent,
+    };
+  } catch (err) {
+    await client.query('ROLLBACK').catch(() => {});
+    throw err;
+  } finally {
+    client.release();
+  }
+}
+```
+
+- [ ] **Step 4: Run tests, verify pass**
+
+Run: `./tests/runner.sh local -- tests/unit/tickets-transition.bats`
+Expected: 3 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add website/src/lib/tickets/transition.ts tests/unit/tickets-transition.bats
+git commit -m "feat(tickets): transitionTicket service — single writer of status, fires close mail"
+```
+
+---
+
+## Task 7: Migration script — copy bugs into tickets.tickets
+
+**Files:**
+- Create: `scripts/migrate-bugs-to-tickets.mjs`
+- Test: `tests/unit/tickets-migration.bats`
+
+- [ ] **Step 1: Write the failing test**
+
+```bash
+# tests/unit/tickets-migration.bats
+#!/usr/bin/env bats
+load ../helpers/test_helper
+
+setup_file() {
+  export PGURL="${TRACKING_DB_URL:-postgres://postgres:postgres@localhost:5432/website}"
+}
+
+@test "migration: every bugs.bug_tickets row produces one tickets.tickets row" {
+  before=$(psql "$PGURL" -t -A -c "SELECT count(*) FROM bugs.bug_tickets")
+  node scripts/migrate-bugs-to-tickets.mjs --apply
+  after=$(psql "$PGURL" -t -A -c "SELECT count(*) FROM tickets.tickets WHERE type='bug'")
+  [ "$before" = "$after" ]
+}
+
+@test "migration: status mapping is correct" {
+  open_count=$(psql "$PGURL" -t -A -c "SELECT count(*) FROM bugs.bug_tickets WHERE status='open'")
+  triage_count=$(psql "$PGURL" -t -A -c "SELECT count(*) FROM tickets.tickets WHERE type='bug' AND status='triage'")
+  [ "$open_count" = "$triage_count" ]
+
+  resolved_count=$(psql "$PGURL" -t -A -c "SELECT count(*) FROM bugs.bug_tickets WHERE status='resolved'")
+  done_fixed_count=$(psql "$PGURL" -t -A -c "SELECT count(*) FROM tickets.tickets WHERE type='bug' AND status='done' AND resolution='fixed'")
+  [ "$resolved_count" = "$done_fixed_count" ]
+}
+
+@test "migration: idempotent — second run does not duplicate" {
+  before=$(psql "$PGURL" -t -A -c "SELECT count(*) FROM tickets.tickets WHERE type='bug'")
+  node scripts/migrate-bugs-to-tickets.mjs --apply
+  after=$(psql "$PGURL" -t -A -c "SELECT count(*) FROM tickets.tickets WHERE type='bug'")
+  [ "$before" = "$after" ]
+}
+```
+
+- [ ] **Step 2: Verify it fails**
+
+Run: `./tests/runner.sh local -- tests/unit/tickets-migration.bats`
+Expected: FAIL — script doesn't exist.
+
+- [ ] **Step 3: Implement migration script**
+
+```javascript
+// scripts/migrate-bugs-to-tickets.mjs
+import pg from 'pg';
+
+const STATUS_MAP = {
+  open:     { status: 'triage',   resolution: null    },
+  resolved: { status: 'done',     resolution: 'fixed' },
+  archived: { status: 'archived', resolution: 'fixed' },
+};
+
+const CATEGORY_TAG = {
+  fehler:             'kind:bug',
+  verbesserung:       'kind:improvement',
+  erweiterungswunsch: 'kind:wish',
+};
+
+async function ensureTag(client, name) {
+  const r = await client.query(
+    `INSERT INTO tickets.tags (name) VALUES ($1)
+       ON CONFLICT (name) DO UPDATE SET name = EXCLUDED.name
+       RETURNING id`,
+    [name]);
+  return r.rows[0].id;
+}
+
+async function migrate(client, dryRun) {
+  const bugs = (await client.query(`
+    SELECT ticket_id, category, reporter_email, description, url, brand,
+           status, created_at, resolved_at, resolution_note,
+           screenshots_json, fixed_in_pr, fixed_at
+      FROM bugs.bug_tickets
+     ORDER BY created_at`)).rows;
+
+  let inserted = 0, skipped = 0;
+  for (const b of bugs) {
+    const exists = await client.query(
+      `SELECT id FROM tickets.tickets WHERE external_id = $1`, [b.ticket_id]);
+    if (exists.rowCount > 0) { skipped++; continue; }
+
+    if (dryRun) { inserted++; continue; }
+
+    const m = STATUS_MAP[b.status] ?? STATUS_MAP.open;
+    const ins = await client.query(
+      `INSERT INTO tickets.tickets
+         (external_id, type, brand, title, description, url, reporter_email,
+          status, resolution, created_at, done_at, archived_at)
+       VALUES
+         ($1, 'bug', $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+       RETURNING id`,
+      [b.ticket_id, b.brand,
+       b.description.slice(0, 200),
+       b.description,
+       b.url, b.reporter_email,
+       m.status, m.resolution, b.created_at,
+       m.status === 'done'     ? (b.resolved_at ?? b.fixed_at) : null,
+       m.status === 'archived' ? (b.fixed_at    ?? b.resolved_at) : null]);
+    const newId = ins.rows[0].id;
+
+    if (b.category && CATEGORY_TAG[b.category]) {
+      const tagId = await ensureTag(client, CATEGORY_TAG[b.category]);
+      await client.query(
+        `INSERT INTO tickets.ticket_tags (ticket_id, tag_id) VALUES ($1, $2)
+           ON CONFLICT DO NOTHING`, [newId, tagId]);
+    }
+
+    if (b.resolution_note) {
+      await client.query(
+        `INSERT INTO tickets.ticket_comments
+           (ticket_id, author_label, kind, body, visibility, created_at)
+         VALUES ($1, 'migration', 'status_change', $2, 'internal', $3)`,
+        [newId, b.resolution_note, b.resolved_at ?? b.created_at]);
+    }
+
+    inserted++;
+  }
+  return { inserted, skipped };
+}
+
+async function main() {
+  const apply = process.argv.includes('--apply');
+  const url = process.env.TRACKING_DB_URL ?? process.env.WEBSITE_DB_URL
+    ?? 'postgres://postgres:postgres@localhost:5432/website';
+  const client = new pg.Client({ connectionString: url });
+  await client.connect();
+  try {
+    if (apply) await client.query('BEGIN');
+    const r = await migrate(client, !apply);
+    if (apply) await client.query('COMMIT');
+    console.log(JSON.stringify({ ...r, mode: apply ? 'apply' : 'dry-run' }));
+  } catch (err) {
+    if (apply) await client.query('ROLLBACK').catch(() => {});
+    console.error(err.message);
+    process.exit(1);
+  } finally { await client.end(); }
+}
+main();
+```
+
+- [ ] **Step 4: Run tests, verify pass**
+
+Run: `./tests/runner.sh local -- tests/unit/tickets-migration.bats`
+Expected: 3 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/migrate-bugs-to-tickets.mjs tests/unit/tickets-migration.bats
+git commit -m "feat(tickets): migration script bugs.bug_tickets -> tickets.tickets"
+```
+
+---
+
+## Task 8: Migrate comments + screenshots + fixed_in_pr
+
+**Files:**
+- Modify: `scripts/migrate-bugs-to-tickets.mjs`
+
+- [ ] **Step 1: Extend `migrate()` to also copy comments, attachments, and PR links**
+
+Insert just before `inserted++;` at the end of the per-bug loop:
+
+```javascript
+    // comments
+    const comments = (await client.query(
+      `SELECT author, kind, body, created_at FROM bugs.bug_ticket_comments
+        WHERE ticket_id = $1 ORDER BY created_at`, [b.ticket_id])).rows;
+    for (const c of comments) {
+      await client.query(
+        `INSERT INTO tickets.ticket_comments
+           (ticket_id, author_label, kind, body, visibility, created_at)
+         VALUES ($1, $2, $3, $4, 'internal', $5)`,
+        [newId, c.author, c.kind, c.body, c.created_at]);
+    }
+
+    // screenshots → attachments (kept as data_url for back-compat)
+    if (b.screenshots_json && Array.isArray(b.screenshots_json)) {
+      let i = 0;
+      for (const dataUrl of b.screenshots_json) {
+        const m = String(dataUrl).match(/^data:([^;]+);/);
+        await client.query(
+          `INSERT INTO tickets.ticket_attachments
+             (ticket_id, filename, data_url, mime_type)
+           VALUES ($1, $2, $3, $4)`,
+          [newId, `screenshot-${++i}`, dataUrl, m ? m[1] : 'application/octet-stream']);
+      }
+    }
+
+    // fixed_in_pr → ticket_links (self-link with kind=fixes + pr_number, matching transitionTicket convention)
+    if (b.fixed_in_pr) {
+      await client.query(
+        `INSERT INTO tickets.ticket_links (from_id, to_id, kind, pr_number)
+         VALUES ($1, $1, 'fixes', $2) ON CONFLICT DO NOTHING`,
+        [newId, b.fixed_in_pr]);
+    }
+```
+
+- [ ] **Step 2: Add a verification test**
+
+Append to `tests/unit/tickets-migration.bats`:
+
+```bash
+@test "migration: comments are copied" {
+  expected=$(psql "$PGURL" -t -A -c "SELECT count(*) FROM bugs.bug_ticket_comments")
+  actual=$(psql "$PGURL" -t -A -c "
+    SELECT count(*) FROM tickets.ticket_comments tc
+    JOIN tickets.tickets t ON t.id = tc.ticket_id
+    WHERE t.type = 'bug' AND tc.kind <> 'system'")
+  [ "$actual" -ge "$expected" ]
+}
+
+@test "migration: fixed_in_pr → ticket_links" {
+  expected=$(psql "$PGURL" -t -A -c "SELECT count(*) FROM bugs.bug_tickets WHERE fixed_in_pr IS NOT NULL")
+  actual=$(psql "$PGURL" -t -A -c "
+    SELECT count(*) FROM tickets.ticket_links WHERE kind='fixes' AND pr_number IS NOT NULL")
+  [ "$actual" = "$expected" ]
+}
+```
+
+- [ ] **Step 3: Run, verify pass**
+
+Run: `./tests/runner.sh local -- tests/unit/tickets-migration.bats`
+Expected: 5 PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/migrate-bugs-to-tickets.mjs tests/unit/tickets-migration.bats
+git commit -m "feat(tickets): migrate comments, screenshots, and fixed_in_pr links"
+```
+
+---
+
+## Task 9: Replace `bugs.bug_tickets` with a backward-compat view
+
+**Files:**
+- Modify: `scripts/migrate-bugs-to-tickets.mjs`
+
+The two known external readers are:
+1. `website/src/lib/website-db.ts:88` — joins on `fixed_in_pr` for the `bugs_fixed` count on the Kore homepage timeline.
+2. `website/src/components/kore/KoreBugs.astro:24` — only contains a hint string `"live aus bugs.bug_tickets"`; safe to leave as text.
+
+The view must expose `ticket_id` (TEXT) and `fixed_in_pr` (INT) so reader #1 keeps working unchanged.
+
+- [ ] **Step 1: Add view-creation step at the end of `migrate()` (after the loop)**
+
+```javascript
+  // Replace bugs.bug_tickets with a back-compat view (run only after data is in tickets.tickets)
+  if (!dryRun) {
+    await client.query(`ALTER TABLE IF EXISTS bugs.bug_tickets RENAME TO bug_tickets_legacy`);
+    await client.query(`ALTER TABLE IF EXISTS bugs.bug_ticket_comments RENAME TO bug_ticket_comments_legacy`);
+    await client.query(`
+      CREATE OR REPLACE VIEW bugs.bug_tickets AS
+      SELECT
+        t.external_id      AS ticket_id,
+        t.brand            AS brand,
+        t.url              AS url,
+        t.description      AS description,
+        t.reporter_email   AS reporter_email,
+        CASE t.status
+          WHEN 'triage' THEN 'open' WHEN 'backlog' THEN 'open'
+          WHEN 'in_progress' THEN 'open' WHEN 'in_review' THEN 'open'
+          WHEN 'blocked' THEN 'open'
+          WHEN 'done' THEN 'resolved' WHEN 'archived' THEN 'archived'
+        END                AS status,
+        t.created_at       AS created_at,
+        t.done_at          AS resolved_at,
+        (SELECT pr_number FROM tickets.ticket_links
+          WHERE from_id = t.id AND kind = 'fixes' AND pr_number IS NOT NULL
+          ORDER BY created_at DESC LIMIT 1) AS fixed_in_pr,
+        (SELECT created_at FROM tickets.ticket_links
+          WHERE from_id = t.id AND kind = 'fixes' AND pr_number IS NOT NULL
+          ORDER BY created_at DESC LIMIT 1) AS fixed_at
+      FROM tickets.tickets t
+      WHERE t.type = 'bug'
+    `);
+  }
+```
+
+- [ ] **Step 2: Verify the existing `bugs_fixed` JOIN still works**
+
+After running migration:
+```bash
+PGPASSWORD=$(...) psql -h localhost -U postgres -d website -c "
+  SELECT fixed_in_pr AS pr, COUNT(*)::int AS n
+    FROM bugs.bug_tickets
+   WHERE fixed_in_pr = ANY('{1,2,3}'::int[])
+  GROUP BY fixed_in_pr"
+```
+Expected: query runs without error (rows may be 0; that's fine).
+
+- [ ] **Step 3: Smoke-test the Kore timeline endpoint**
+
+Run: `curl -s https://web.mentolder.de/api/timeline | jq '.[] | select(.bugs_fixed > 0) | {pr: .pr_number, bugs_fixed}' | head`
+Expected: same shape as before migration. If empty, no bugs were ever PR-fixed before — that's also fine.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/migrate-bugs-to-tickets.mjs
+git commit -m "feat(tickets): replace bugs.bug_tickets with back-compat view"
+```
+
+---
+
+## Task 10: Wire `/api/bug-report` to write into `tickets.tickets`
+
+**Files:**
+- Modify: `website/src/pages/api/bug-report.ts`
+- Modify: `website/src/lib/website-db.ts` (rewrite `insertBugTicket`)
+
+- [ ] **Step 1: Rewrite `insertBugTicket` in website-db.ts**
+
+Find the existing `insertBugTicket` function (around line 605). Replace its body with:
+
+```typescript
+export async function insertBugTicket(params: {
+  ticketId: string;
+  category: string;
+  reporterEmail: string;
+  description: string;
+  url?: string;
+  brand: string;
+  screenshots?: string[];
+}): Promise<number> {
+  const { rows } = await pool.query(
+    `INSERT INTO tickets.tickets
+       (external_id, type, brand, title, description, url, reporter_email, status)
+     VALUES ($1, 'bug', $2, $3, $4, $5, $6, 'triage')
+     ON CONFLICT (external_id) DO NOTHING
+     RETURNING id`,
+    [params.ticketId, params.brand,
+     params.description.slice(0, 200),
+     params.description, params.url ?? null, params.reporterEmail]
+  );
+  if (rows.length === 0) return 0;
+  const newId = rows[0].id;
+
+  // Categorize as tag
+  const tagName = `kind:${params.category}`;
+  await pool.query(
+    `INSERT INTO tickets.tags (name) VALUES ($1) ON CONFLICT (name) DO NOTHING`,
+    [tagName]);
+  await pool.query(
+    `INSERT INTO tickets.ticket_tags (ticket_id, tag_id)
+     SELECT $1, id FROM tickets.tags WHERE name = $2 ON CONFLICT DO NOTHING`,
+    [newId, tagName]);
+
+  // Inline screenshots
+  for (const [idx, dataUrl] of (params.screenshots ?? []).entries()) {
+    const m = dataUrl.match(/^data:([^;]+);/);
+    await pool.query(
+      `INSERT INTO tickets.ticket_attachments (ticket_id, filename, data_url, mime_type)
+       VALUES ($1, $2, $3, $4)`,
+      [newId, `screenshot-${idx + 1}`, dataUrl, m ? m[1] : 'application/octet-stream']);
+  }
+  return 1;
+}
+```
+
+- [ ] **Step 2: Add reporter→customer auto-link in bug-report.ts**
+
+Modify `website/src/pages/api/bug-report.ts`. Add to the imports near the top:
+
+```typescript
+import { linkReporterByEmail } from '../../lib/tickets/reporter-link';
+```
+
+After the existing `await insertBugTicket({...})` call (around line 83), add:
+
+```typescript
+    await linkReporterByEmail(email).catch(err =>
+      console.error('[bug-report] reporter-link failed:', err));
+```
+
+- [ ] **Step 3: Local smoke**
+
+Start dev: `task website:dev` (different terminal). Then:
+```bash
+curl -X POST http://localhost:4321/api/bug-report \
+  -F 'description=test from plan' \
+  -F 'email=plan-test@example.com' \
+  -F 'category=fehler'
+```
+Expected: `{"success":true,"ticketId":"BR-..."}`. Check DB:
+```bash
+psql "$PGURL" -c "SELECT external_id, type, status, reporter_email FROM tickets.tickets ORDER BY created_at DESC LIMIT 1"
+```
+Expected: one row with the BR-ID, type=bug, status=triage.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add website/src/pages/api/bug-report.ts website/src/lib/website-db.ts
+git commit -m "feat(tickets): bug-report API writes to tickets.tickets directly"
+```
+
+---
+
+## Task 11: Rewire reader functions in website-db.ts
+
+The reader functions (`listBugTickets`, `getBugTicketStatus`, `getBugTicketWithComments`, `appendBugTicketComment`) are called by `/admin/bugs`, `/admin/bugs/[id]`, and the inbox. They keep their signatures but read from `tickets.*`.
+
+**Files:**
+- Modify: `website/src/lib/website-db.ts`
+
+- [ ] **Step 1: Rewrite `listBugTickets` (around line 2688)**
+
+Replace the body with:
+
+```typescript
+export async function listBugTickets(filters: {
+  status?: string;
+  category?: string;
+  brand?: string;
+  q?: string;
+}): Promise<BugTicketRow[]> {
+  const where: string[] = [`t.type = 'bug'`];
+  const vals: unknown[] = [];
+  if (filters.brand) {
+    vals.push(filters.brand);
+    where.push(`t.brand = $${vals.length}`);
+  }
+  if (filters.status) {
+    // Map legacy filter values back to new status set
+    const map: Record<string, string[]> = {
+      open:     ['triage','backlog','in_progress','in_review','blocked'],
+      resolved: ['done'],
+      archived: ['archived'],
+    };
+    const list = map[filters.status] ?? [filters.status];
+    vals.push(list);
+    where.push(`t.status = ANY($${vals.length}::text[])`);
+  }
+  if (filters.category) {
+    vals.push(`kind:${filters.category}`);
+    where.push(`EXISTS (SELECT 1 FROM tickets.ticket_tags tt
+                          JOIN tickets.tags g ON g.id = tt.tag_id
+                         WHERE tt.ticket_id = t.id AND g.name = $${vals.length})`);
+  }
+  if (filters.q) {
+    vals.push(filters.q);
+    where.push(`(t.description ILIKE '%' || $${vals.length} || '%'
+                 OR t.reporter_email ILIKE '%' || $${vals.length} || '%')`);
+  }
+  const sql = `
+    SELECT t.external_id   AS "ticketId",
+           COALESCE(SPLIT_PART(g.name, ':', 2), '') AS category,
+           t.reporter_email AS "reporterEmail",
+           t.description,
+           t.url,
+           t.brand,
+           CASE t.status WHEN 'done' THEN 'resolved'
+                         WHEN 'archived' THEN 'archived' ELSE 'open' END AS status,
+           t.created_at    AS "createdAt",
+           t.done_at       AS "resolvedAt",
+           NULL            AS "resolutionNote",
+           (SELECT pr_number FROM tickets.ticket_links
+              WHERE from_id = t.id AND kind = 'fixes' AND pr_number IS NOT NULL
+              ORDER BY created_at DESC LIMIT 1) AS "fixedInPr",
+           (SELECT created_at FROM tickets.ticket_links
+              WHERE from_id = t.id AND kind = 'fixes' AND pr_number IS NOT NULL
+              ORDER BY created_at DESC LIMIT 1) AS "fixedAt"
+      FROM tickets.tickets t
+      LEFT JOIN tickets.ticket_tags tt ON tt.ticket_id = t.id
+      LEFT JOIN tickets.tags g ON g.id = tt.tag_id AND g.name LIKE 'kind:%'
+     WHERE ${where.join(' AND ')}
+     ORDER BY t.created_at DESC`;
+  const r = await pool.query(sql, vals);
+  return r.rows;
+}
+```
+
+- [ ] **Step 2: Rewrite `getBugTicketStatus`, `getBugTicketWithComments`, and `appendBugTicketComment`**
+
+For `getBugTicketStatus` (around line 660):
+
+```typescript
+export async function getBugTicketStatus(ticketId: string): Promise<BugTicketStatus | null> {
+  const r = await pool.query(
+    `SELECT external_id AS "ticketId",
+            CASE status WHEN 'done' THEN 'resolved'
+                        WHEN 'archived' THEN 'archived' ELSE 'open' END AS status,
+            (SELECT SPLIT_PART(g.name, ':', 2)
+               FROM tickets.ticket_tags tt JOIN tickets.tags g ON g.id = tt.tag_id
+              WHERE tt.ticket_id = t.id AND g.name LIKE 'kind:%' LIMIT 1) AS category,
+            created_at AS "createdAt",
+            done_at AS "resolvedAt",
+            NULL AS "resolutionNote",
+            (SELECT pr_number FROM tickets.ticket_links
+              WHERE from_id = t.id AND kind = 'fixes' AND pr_number IS NOT NULL
+              ORDER BY created_at DESC LIMIT 1) AS "fixedInPr",
+            (SELECT created_at FROM tickets.ticket_links
+              WHERE from_id = t.id AND kind = 'fixes' AND pr_number IS NOT NULL
+              ORDER BY created_at DESC LIMIT 1) AS "fixedAt"
+       FROM tickets.tickets t
+      WHERE t.type = 'bug' AND t.external_id = $1`,
+    [ticketId]);
+  return r.rows[0] ?? null;
+}
+```
+
+For `getBugTicketWithComments` (around line 684) — replace the SQL inside with a `tickets.*` query of the same shape, and the comments fetch with `SELECT id, $1::text AS "ticketId", author_label AS author, kind, body, created_at AS "createdAt" FROM tickets.ticket_comments WHERE ticket_id = (SELECT id FROM tickets.tickets WHERE external_id = $1) ORDER BY created_at ASC`.
+
+For `appendBugTicketComment`:
+
+```typescript
+export async function appendBugTicketComment(params: {
+  ticketId: string;
+  author: string;
+  body: string;
+  kind?: 'comment' | 'status_change' | 'system';
+}): Promise<BugTicketComment> {
+  const r = await pool.query(
+    `INSERT INTO tickets.ticket_comments
+       (ticket_id, author_label, kind, body, visibility)
+     SELECT id, $2, $3, $4, 'internal' FROM tickets.tickets
+      WHERE type = 'bug' AND external_id = $1
+     RETURNING id, $1::text AS "ticketId", author_label AS author, kind, body, created_at AS "createdAt"`,
+    [params.ticketId, params.author, params.kind ?? 'comment', params.body]);
+  return r.rows[0];
+}
+```
+
+- [ ] **Step 3: Rewrite `resolveBugTicket`, `archiveBugTicket`, `reopenBugTicket` to delegate to `transitionTicket()`**
+
+```typescript
+import { transitionTicket } from './tickets/transition';
+
+async function ticketIdByExternal(externalId: string): Promise<string | null> {
+  const r = await pool.query(
+    `SELECT id FROM tickets.tickets WHERE type = 'bug' AND external_id = $1`,
+    [externalId]);
+  return r.rows[0]?.id ?? null;
+}
+
+export async function resolveBugTicket(ticketId: string, resolutionNote: string,
+                                       actor: { id?: string; label: string } = { label: 'admin' }
+): Promise<void> {
+  const id = await ticketIdByExternal(ticketId);
+  if (!id) throw new Error(`bug ${ticketId} not found`);
+  await transitionTicket(id, {
+    status: 'done', resolution: 'fixed',
+    note: resolutionNote, noteVisibility: 'public',
+    actor,
+  });
+  await pool.query(
+    `UPDATE inbox_items SET status = 'actioned', actioned_at = NOW()
+      WHERE bug_ticket_id = $1 AND status = 'pending'`, [ticketId]);
+}
+
+export async function archiveBugTicket(ticketId: string,
+                                       actor: { id?: string; label: string } = { label: 'admin' }
+): Promise<void> {
+  const id = await ticketIdByExternal(ticketId);
+  if (!id) return;
+  await transitionTicket(id, {
+    status: 'archived', resolution: 'obsolete', actor,
+  });
+  await pool.query(
+    `UPDATE inbox_items SET status = 'archived', actioned_at = NOW()
+      WHERE bug_ticket_id = $1 AND status = 'pending'`, [ticketId]);
+}
+
+export async function reopenBugTicket(ticketId: string, author: string,
+                                      reason?: string): Promise<void> {
+  const id = await ticketIdByExternal(ticketId);
+  if (!id) throw new Error(`ticket ${ticketId} not found`);
+  // Manual reopen → backlog (per spec §6)
+  await transitionTicket(id, {
+    status: 'backlog',
+    note: reason,
+    actor: { label: author },
+  });
+}
+```
+
+- [ ] **Step 4: Drop `initBugTicketsTable()` and `initBugTicketCommentsTable()` invocations**
+
+Search for `initBugTicketsTable` and `initBugTicketCommentsTable` calls — replace each with `await initTicketsSchema()`. Add the import:
+
+```typescript
+import { initTicketsSchema } from './tickets-db';
+```
+
+- [ ] **Step 5: Type-check**
+
+Run: `cd website && npx tsc --noEmit`
+Expected: clean (or only pre-existing errors unrelated to your changes).
+
+- [ ] **Step 6: Smoke**
+
+```bash
+curl -s 'https://web.mentolder.de/admin/bugs?status=resolved' -b "$ADMIN_COOKIE" | grep -c 'BR-'
+```
+Expected: ≥ count of resolved bugs in the system.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add website/src/lib/website-db.ts
+git commit -m "feat(tickets): rewire bug reader/writer functions to tickets.tickets"
+```
+
+---
+
+## Task 12: Rewire `/api/admin/bugs/resolve.ts`
+
+**Files:**
+- Modify: `website/src/pages/api/admin/bugs/resolve.ts`
+
+- [ ] **Step 1: Replace the resolve call with explicit actor passing**
+
+The existing handler already calls `resolveBugTicket(ticketId, resolutionNote)`. After Task 11, that already routes through `transitionTicket`, but the actor label defaults to `'admin'`. Pass the real session user:
+
+Replace lines 51-57 in `website/src/pages/api/admin/bugs/resolve.ts`:
+
+```typescript
+  try {
+    await resolveBugTicket(ticketId, resolutionNote,
+      { label: session.preferred_username });
+    // status_change comment is now created by transitionTicket; remove the duplicate append below.
+  } catch (err) { /* unchanged */ }
+```
+
+Delete the now-redundant `appendBugTicketComment` block below `resolveBugTicket`.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add website/src/pages/api/admin/bugs/resolve.ts
+git commit -m "fix(tickets): admin bug-resolve passes session user to transitionTicket"
+```
+
+---
+
+## Task 13: Rewire inbox `resolve_bug` action — the broken email path
+
+**Files:**
+- Modify: `website/src/pages/api/admin/inbox/[id]/action.ts`
+
+- [ ] **Step 1: Locate and replace the `resolve_bug` case**
+
+Find the case beginning at around line 200 (`case 'resolve_bug':` or similar — search for `info@${p.brand}`). Replace the entire case body with:
+
+```typescript
+      case 'resolve_bug': {
+        if (!resolveNote) {
+          return new Response(JSON.stringify({ error: 'Bitte geben Sie eine Notiz an.' }), { status: 400 });
+        }
+        if (resolveNote.length > 500) {
+          return new Response(JSON.stringify({ error: 'Max. 500 Zeichen.' }), { status: 400 });
+        }
+        const p = item.payload as { ticketId: string; reporterEmail: string; brand: string };
+        await resolveBugTicket(p.ticketId, resolveNote,
+          { label: session.preferred_username });
+        // No manual sendEmail() here — transitionTicket() handles the close-mail.
+        await updateInboxItemStatus(id, 'actioned', session.preferred_username);
+        return new Response(JSON.stringify({ success: true }),
+          { headers: { 'Content-Type': 'application/json' } });
+      }
+```
+
+- [ ] **Step 2: Remove now-unused `sendEmail` import if it was only used here**
+
+Check `grep -n 'sendEmail\|PROD_DOMAIN' website/src/pages/api/admin/inbox/[id]/action.ts`. If those are only used by the old resolve_bug path, remove them.
+
+- [ ] **Step 3: Smoke**
+
+Resolve a test bug from the inbox UI on `/admin/inbox`, then check Mailpit:
+```bash
+kubectl --context mentolder -n workspace port-forward svc/mailpit 8025:8025 &
+PFP=$!
+sleep 2
+curl -s http://localhost:8025/api/v1/messages | jq '.messages[0] | {to: .To, subject: .Subject}'
+kill $PFP
+```
+Expected: `to[0].Address == "rep-test@example.com"` (the reporter), `subject` starts with `[BR-`. **This is the fix verification — the reporter is now in the To: line.**
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add website/src/pages/api/admin/inbox/[id]/action.ts
+git commit -m "fix(tickets): inbox resolve_bug emails reporter (was: info@brand, reporter only in Reply-To)"
+```
+
+---
+
+## Task 14: Rewire `scripts/track-pr.mjs` — auto-close goes through `transitionTicket()`
+
+**Files:**
+- Modify: `scripts/track-pr.mjs`
+
+- [ ] **Step 1: Replace the `bugs.bug_tickets` UPDATE block**
+
+Find lines 74-81 (the `for (const ticketId of row.bug_refs)` loop). Replace with:
+
+```javascript
+  // Map external_id (BR-...) → ticket UUID, then transition through the unified service.
+  // We do this with raw SQL because track-pr.mjs runs as a Node script outside the website
+  // process, so we can't import the TypeScript transitionTicket directly. The CHECK constraint
+  // on (status, resolution) plus the audit trigger keep the result equivalent.
+  for (const externalId of row.bug_refs) {
+    const r = await pgClient.query(
+      `SELECT id, status, reporter_email FROM tickets.tickets
+        WHERE type = 'bug' AND external_id = $1`, [externalId]);
+    if (r.rowCount === 0) {
+      console.log(`skip ${externalId}: not found in tickets.tickets`);
+      continue;
+    }
+    const t = r.rows[0];
+    if (t.status === 'done' || t.status === 'archived') {
+      // already closed — just record the link
+      await pgClient.query(
+        `INSERT INTO tickets.ticket_links (from_id, to_id, kind, pr_number)
+         VALUES ($1, $1, 'fixes', $2) ON CONFLICT DO NOTHING`,
+        [t.id, row.pr_number]);
+      continue;
+    }
+    await pgClient.query('BEGIN');
+    try {
+      await pgClient.query(`SELECT set_config('app.user_label', 'github-bot', true)`);
+      await pgClient.query(
+        `UPDATE tickets.tickets SET status = 'done', resolution = 'fixed' WHERE id = $1`,
+        [t.id]);
+      await pgClient.query(
+        `INSERT INTO tickets.ticket_links (from_id, to_id, kind, pr_number)
+         VALUES ($1, $1, 'fixes', $2) ON CONFLICT DO NOTHING`,
+        [t.id, row.pr_number]);
+      await pgClient.query('COMMIT');
+    } catch (e) {
+      await pgClient.query('ROLLBACK').catch(() => {});
+      throw e;
+    }
+    // Reporter notification — call the website API so the email pipeline runs in-process.
+    if (t.reporter_email) {
+      const apiUrl = process.env.WEBSITE_API_URL ?? 'https://web.mentolder.de';
+      try {
+        await fetch(`${apiUrl}/api/internal/tickets/notify-close`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json',
+                     'X-Internal-Token': process.env.INTERNAL_API_TOKEN ?? '' },
+          body: JSON.stringify({ externalId, resolution: 'fixed' }),
+        });
+      } catch (e) {
+        console.error(`notify-close failed for ${externalId}: ${e.message}`);
+      }
+    }
+  }
+```
+
+- [ ] **Step 2: Add the internal notify endpoint**
+
+Create `website/src/pages/api/internal/tickets/notify-close.ts`:
+
+```typescript
+import type { APIRoute } from 'astro';
+import { pool } from '../../../../lib/website-db';
+import { sendBugCloseEmail } from '../../../../lib/tickets/email-templates';
+
+const TOKEN = process.env.INTERNAL_API_TOKEN ?? '';
+
+export const POST: APIRoute = async ({ request }) => {
+  if (!TOKEN || request.headers.get('x-internal-token') !== TOKEN) {
+    return new Response('forbidden', { status: 403 });
+  }
+  const body = await request.json() as { externalId: string; resolution: string };
+  const r = await pool.query(
+    `SELECT external_id, reporter_email FROM tickets.tickets
+      WHERE type = 'bug' AND external_id = $1`, [body.externalId]);
+  if (r.rowCount === 0) return new Response('not found', { status: 404 });
+  const t = r.rows[0];
+  if (!t.reporter_email) return new Response(JSON.stringify({ ok: true, skipped: true }),
+    { headers: { 'Content-Type': 'application/json' } });
+  const sent = await sendBugCloseEmail({
+    externalId: t.external_id,
+    reporterEmail: t.reporter_email,
+    resolution: body.resolution,
+  });
+  return new Response(JSON.stringify({ ok: true, sent }),
+    { headers: { 'Content-Type': 'application/json' } });
+};
+```
+
+- [ ] **Step 3: Add `INTERNAL_API_TOKEN` to env**
+
+Append to `environments/.secrets/mentolder.yaml` (gitignored):
+```yaml
+INTERNAL_API_TOKEN: <generate with `openssl rand -hex 32`>
+```
+Then: `task env:seal ENV=mentolder` and same for korczewski.
+
+Add `INTERNAL_API_TOKEN` to the env list in `environments/schema.yaml` so `env:validate` accepts it.
+Add it to the website Deployment env-from-secret in `k3d/website.yaml` (Sealed Secret block).
+
+- [ ] **Step 4: Verify the test for track-pr still passes**
+
+Run: `node scripts/track-pr.test.mjs` (existing test at `scripts/track-pr.test.mjs`)
+Expected: PASS. Update test fixtures if it explicitly asserts the old `bugs.bug_tickets` UPDATE.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/track-pr.mjs website/src/pages/api/internal/tickets/notify-close.ts \
+  environments/sealed-secrets/mentolder.yaml environments/sealed-secrets/korczewski.yaml \
+  environments/schema.yaml k3d/website.yaml
+git commit -m "fix(tickets): PR-merge auto-close transitions to done (not archived) and notifies reporter"
+```
+
+---
+
+## Task 15: End-to-end test — bug-report → admin resolve → reporter receives email
+
+**Files:**
+- Create: `tests/e2e/specs/fa-bugs-notifications.spec.ts`
+
+- [ ] **Step 1: Write the spec**
+
+```typescript
+// tests/e2e/specs/fa-bugs-notifications.spec.ts
+import { test, expect } from '@playwright/test';
+
+const BASE = process.env.BASE_URL ?? 'https://web.mentolder.de';
+const MAILPIT = process.env.MAILPIT_URL ?? 'http://localhost:8025';
+const ADMIN_USER = process.env.E2E_ADMIN_USER ?? 'patrick';
+const ADMIN_PASS = process.env.E2E_ADMIN_PASS!;
+
+test('FA-bug-notify: reporter receives close-mail when admin resolves ticket', async ({ page, request }) => {
+  const reporter = `e2e-${Date.now()}@example.com`;
+
+  // 1. Submit public bug report
+  const create = await request.post(`${BASE}/api/bug-report`, {
+    multipart: {
+      description: 'E2E notification test',
+      email: reporter,
+      category: 'fehler',
+      url: '/test',
+    },
+  });
+  expect(create.ok()).toBeTruthy();
+  const { ticketId } = await create.json();
+  expect(ticketId).toMatch(/^BR-/);
+
+  // 2. Admin login + resolve
+  await page.goto(`${BASE}/auth/login?next=/admin/bugs`);
+  await page.fill('input[name=username]', ADMIN_USER);
+  await page.fill('input[name=password]', ADMIN_PASS);
+  await page.click('button[type=submit]');
+  await page.waitForURL(/\/admin\/bugs/);
+
+  await page.goto(`${BASE}/admin/bugs/${ticketId}`);
+  await page.fill('textarea[name=resolutionNote]', 'fixed in plan E2E');
+  await page.click('button:has-text("Erledigt")');
+  await page.waitForLoadState('networkidle');
+
+  // 3. Verify reporter received the email (Mailpit)
+  await new Promise(r => setTimeout(r, 1500));
+  const mail = await request.get(`${MAILPIT}/api/v1/search?query=to:${reporter}`);
+  const data = await mail.json() as { messages: Array<{ Subject: string; To: Array<{ Address: string }> }> };
+  expect(data.messages.length).toBeGreaterThan(0);
+  const m = data.messages[0];
+  expect(m.Subject).toContain(ticketId);
+  expect(m.To.some(t => t.Address === reporter)).toBeTruthy();
+});
+```
+
+- [ ] **Step 2: Run the spec**
+
+Run: `npx playwright test tests/e2e/specs/fa-bugs-notifications.spec.ts`
+Expected: 1 PASS. The spec depends on Mailpit being reachable from the test runner — for prod tests, port-forward Mailpit first or set `MAILPIT_URL` to the in-cluster URL via a kubectl proxy.
+
+- [ ] **Step 3: Add to test runner registry**
+
+Open `tests/runner.sh` — find the test ID registry block. Add: `FA-BUG-NOTIFY|fa-bugs-notifications.spec.ts|Bug close-notification email reaches reporter`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/e2e/specs/fa-bugs-notifications.spec.ts tests/runner.sh
+git commit -m "test(tickets): E2E bug-report -> admin resolve -> reporter receives email"
+```
+
+---
+
+## Task 16: Deploy + production smoke
+
+**Files:** none
+
+- [ ] **Step 1: Deploy**
+
+```bash
+task website:deploy ENV=mentolder
+task website:deploy ENV=korczewski
+```
+Expected: both pods healthy after deploy.
+
+- [ ] **Step 2: Run migration on prod (mentolder first)**
+
+```bash
+task workspace:port-forward ENV=mentolder &
+PFP=$!
+sleep 3
+TRACKING_DB_URL="postgres://postgres:$(kubectl --context mentolder -n workspace get secret workspace-secrets -o jsonpath='{.data.POSTGRES_PASSWORD}' | base64 -d)@localhost:5432/website" \
+  node scripts/migrate-bugs-to-tickets.mjs --apply
+kill $PFP
+```
+Expected output: `{"inserted":N,"skipped":0,"mode":"apply"}` where N = current bug count.
+
+Repeat for korczewski:
+```bash
+task workspace:port-forward ENV=korczewski &
+# … same as above, --context korczewski, password from korczewski cluster
+```
+
+- [ ] **Step 3: Smoke `/admin/bugs` on both brands**
+
+Open `https://web.mentolder.de/admin/bugs` and `https://web.korczewski.de/admin/bugs`. Expected: same ticket count + same filters as before deploy.
+
+- [ ] **Step 4: Smoke the close-mail with a real reporter**
+
+Submit a test bug at `https://web.mentolder.de` (use a personal email you can check). Resolve it from `/admin/bugs/[id]`. Verify the email arrives in your inbox within ~1 minute.
+
+- [ ] **Step 5: Run the offline test bundle**
+
+```bash
+task test:all
+```
+Expected: all passing.
+
+- [ ] **Step 6: Open the PR**
+
+```bash
+git push -u origin <branch>
+gh pr create --title "feat(tickets): unify bug reports into tickets schema (PR1/5)" --body "$(cat <<'EOF'
+## Summary
+- Stand up new `tickets` Postgres schema with full ticket model from spec §5.
+- Migrate `bugs.bug_tickets` → `tickets.tickets` (type=`bug`); old table → backward-compat view.
+- Add `transitionTicket()` service — single writer of `status`. All three close paths (admin resolve, inbox resolve, PR-merge auto-close) now route through it.
+- **Fixes the missed-reporter-notification bug**: reporters are now emailed on ticket close. The inbox path used to email `info@<brand>` with the reporter only in `Reply-To`; the admin-resolve and PR-merge paths sent no email at all.
+- Auto-link `reporter_email` → `customers.id` when a Keycloak-linked customer exists.
+
+Spec: `docs/superpowers/specs/2026-05-08-unified-ticketing-design.md`
+Plan: `docs/superpowers/plans/2026-05-08-unified-ticketing-pr1.md`
+
+## Test plan
+- [ ] BATS migration tests pass (row counts, idempotency, comment + link copy)
+- [ ] BATS transition state-machine tests pass
+- [ ] Playwright `fa-bugs-notifications.spec.ts` passes (reporter receives email)
+- [ ] `/admin/bugs` lists same tickets pre/post deploy on both brands
+- [ ] Public bug-report form still mints BR-IDs and stores screenshots
+- [ ] Manual: real close-mail arrives at reporter inbox
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage check (against `docs/superpowers/specs/2026-05-08-unified-ticketing-design.md` §9 PR1):**
+- ✅ Create `tickets` schema with all tables — Tasks 1-3
+- ✅ DB triggers (cycle prevention, lifecycle timestamps, audit log) — Tasks 2, 3
+- ✅ Migrate `bugs.bug_tickets` → `tickets.tickets` — Task 7
+- ✅ Migrate `bugs.bug_ticket_comments` → `tickets.ticket_comments` — Task 8
+- ✅ Inline screenshots → `tickets.ticket_attachments` — Task 8
+- ✅ Reporter→customer auto-link batch — Task 4 + invocation in Task 10 + migration in Task 7
+- ✅ `transitionTicket()` service — Task 6
+- ✅ Rewire `/api/admin/bugs/resolve.ts` — Task 12
+- ✅ Rewire inbox `resolve_bug` action — Task 13
+- ✅ Rewire `track-pr.mjs` ingest — Task 14
+- ✅ Close-mail To=reporter, BCC=`info@<brand>` — Task 5 + Task 13 verification
+- ✅ `/admin/bugs` keeps working visually identical — Task 11 (signature-preserving rewrites)
+- ✅ `bugs.bug_tickets` becomes a SQL view — Task 9
+- ✅ BATS migration verification — Tasks 7, 8
+- ✅ Playwright bug-report → resolve → email E2E — Task 15
+
+**Type consistency:** `transitionTicket()` signature matches across Tasks 6, 11, 12, 13. `TicketStatus` and `TicketResolution` types used consistently. `linkReporterByEmail()` signature matches across Tasks 4, 7, 10. `sendBugCloseEmail()` parameters match across Tasks 5, 14.
+
+**Placeholder scan:** No "TBD"/"TODO"/"implement later" markers; every code-changing step has a code block; every test step has expected output; every migration step has a verifiable post-condition.
+
+**Risk callouts:**
+- Task 9 (table rename + view) is the irreversible step. The migration script is idempotent for inserts but the rename only runs once. Take a `task workspace:backup` before running on prod.
+- Task 11's reader-function rewrites are signature-preserving but the underlying SQL changed dramatically — exercise the admin/bugs page visually before promoting from mentolder to korczewski.
+- Task 14 introduces an `INTERNAL_API_TOKEN` that the GitHub-Actions ingest cron must have. Make sure the `tracking-import` CronJob's env-from-secret includes it.

--- a/docs/superpowers/specs/2026-05-08-unified-ticketing-design.md
+++ b/docs/superpowers/specs/2026-05-08-unified-ticketing-design.md
@@ -1,0 +1,421 @@
+# Unified Ticketing & Issue Tracking — Design
+
+**Date:** 2026-05-08
+**Status:** Spec — pending implementation plan
+**Scope:** Replace the four overlapping work-tracking systems on the Bachelorprojekt platform (public bug reports, thesis requirements, PR-driven feature timeline, and admin project hierarchy) with one unified ticket model.
+
+---
+
+## 1. Problem
+
+Today four systems describe overlapping work:
+
+| System | Table(s) | Purpose | Audience |
+|---|---|---|---|
+| Bug reports | `bugs.bug_tickets`, `bugs.bug_ticket_comments` | Public-reported issues from `/api/bug-report` | Public reporters + admin |
+| Thesis requirements | `bachelorprojekt.requirements`, `pipeline`, `test_results` | Academic FA/SA/NFA/AK requirements | Internal / thesis defense |
+| PR-driven features | `bachelorprojekt.features` | One row per merged PR, drives Kore homepage timeline | Public timeline + internal |
+| Admin projects | `projects`, `sub_projects`, `project_tasks`, `project_attachments` | Client-facing engagements with Gantt + assignments | Admin + customer portal |
+
+Each has its own status enum, its own admin UI, its own audit/comments capability (or none), and its own relationship to PRs. As a result:
+
+1. **No single inbox.** A bug, a feature request, and a customer task look like three different things.
+2. **Reporter notifications are broken on every close path.** `scripts/track-pr.mjs` archives bugs on PR merge with no email; `/api/admin/bugs/resolve.ts` resolves with no email; `/api/admin/inbox/[id]/action.ts` sends the close-mail to `info@<brand>` (with the reporter only in `Reply-To`). Reporters never hear back.
+3. **Auto-close jumps `resolved` and goes straight to `archived`.** PR-fixed bugs vanish from the "Erledigt" filter on `/admin/bugs`.
+4. **Data is thin.** Bugs lack severity, assignee, watchers, due dates, structured links, attachments, or a real audit trail.
+5. **Cross-references are weak.** `bug_tickets.fixed_in_pr` is a single integer; `bachelorprojekt.features.requirement_id` is a single FK. No way to say "this bug is a duplicate of that one", "this feature blocks that task", or "this PR fixed three bugs".
+
+## 2. Goals
+
+- One ticket model that covers bugs, features, projects, and tasks, with a shared lifecycle and unified admin UI.
+- Rich metadata per ticket: severity + priority, assignee + reporter + watchers, controlled component + free-form tags, structured ticket-to-ticket links, full audit log, generic attachments, dates + estimate + time-logged on every type.
+- Single close-handler that always notifies the reporter when a ticket is closed.
+- Auto-link of `reporter_email` to Keycloak users via the existing `customers` table.
+- Migration that ships in five small PRs, each independently revertable, with no production downtime.
+
+## 3. Non-Goals
+
+- Replacing or restructuring the messaging-db threads. Notifications in v1 are email-only.
+- Replacing the GitHub PR workflow itself. The webhook keeps writing `tracking/pending/<pr>.json`; only what happens after that changes.
+- Estimating sprint/iteration scheduling, story-point velocity, or burndown beyond raw `estimate_minutes` / `time_logged_minutes` columns.
+- Public ticket creation by customers from the portal (v1 keeps the public bug-report form as the only public entry point).
+
+## 4. Architecture
+
+A new `tickets` schema in the workspace `shared-db` database holds the entire model. Old tables become read-only SQL views during the migration window, then drop in PR5.
+
+```
+tickets                  ← core work-item (type ∈ bug | feature | task | project)
+ticket_links             ← typed relationships (blocks, fixes, duplicate_of, …)
+ticket_activity          ← immutable audit log (every field change)
+ticket_comments          ← discussion (replaces bugs.bug_ticket_comments)
+ticket_attachments       ← generic file refs (Nextcloud-backed; inline data_url for legacy)
+ticket_watchers          ← notification subscriptions
+ticket_tags              ← join table for free-form labels
+tags                     ← label vocabulary
+pr_events                ← PR ledger (renamed bachelorprojekt.features)
+```
+
+**Schema split rationale.** `tickets.*` is the work-plan domain — mutable, has lifecycle, owned by humans. `tickets.pr_events` is a git-history ledger — immutable, one row per merged PR, owned by the GitHub webhook. Tickets reference PRs through `ticket_links` (`kind='fixes'`). Keeping these separate means the PR ledger can never be corrupted by ticket-management actions.
+
+**Hierarchy.** A flat tickets table with a self-referential `parent_id`. UI enforces a 3-level convention (epic / project / task) but the schema permits arbitrary depth. Cycles are prevented by trigger.
+
+**Cross-cutting fields.**
+- `brand` on every ticket (mentolder | korczewski) — same multi-brand model as today.
+- `external_id` is the universal human key (`BR-YYYYMMDD-xxxx`, `FA-12`, `SA-03`, custom slug). Internal references use `id` (UUID); humans use `external_id`.
+- `customer_id` is on tickets directly (nullable). Required for `type='project'` (service-layer validation).
+- `thesis_tag` is a separate column for FA/SA/NFA/AK references — a feature can have both a freeform `external_id` and a thesis tag.
+
+## 5. Data Model
+
+```sql
+CREATE SCHEMA IF NOT EXISTS tickets AUTHORIZATION website;
+
+-- ── core ────────────────────────────────────────────────────────────
+CREATE TABLE tickets.tickets (
+  id              UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  external_id     TEXT        UNIQUE,
+  type            TEXT        NOT NULL CHECK (type IN ('bug','feature','task','project')),
+  parent_id       UUID        REFERENCES tickets.tickets(id) ON DELETE SET NULL,
+  brand           TEXT        NOT NULL,
+
+  title           TEXT        NOT NULL,
+  description     TEXT,
+  url             TEXT,
+  thesis_tag      TEXT,
+  component       TEXT,
+
+  status          TEXT        NOT NULL DEFAULT 'triage'
+                  CHECK (status IN ('triage','backlog','in_progress','in_review','blocked','done','archived')),
+  resolution      TEXT        CHECK (resolution IN
+                    ('fixed','shipped','wontfix','duplicate','cant_reproduce','obsolete')),
+  priority        TEXT        NOT NULL DEFAULT 'mittel'  CHECK (priority IN ('hoch','mittel','niedrig')),
+  severity        TEXT        CHECK (severity IN ('critical','major','minor','trivial')),
+
+  reporter_id     UUID        REFERENCES customers(id) ON DELETE SET NULL,
+  reporter_email  TEXT,
+  assignee_id     UUID        REFERENCES customers(id) ON DELETE SET NULL,
+  customer_id     UUID        REFERENCES customers(id) ON DELETE SET NULL,
+
+  start_date      DATE,
+  due_date        DATE,
+  estimate_minutes      INTEGER,
+  time_logged_minutes   INTEGER NOT NULL DEFAULT 0,
+
+  triaged_at      TIMESTAMPTZ,
+  started_at      TIMESTAMPTZ,
+  done_at         TIMESTAMPTZ,
+  archived_at     TIMESTAMPTZ,
+
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+  CONSTRAINT resolution_only_when_closed CHECK (
+    (resolution IS NULL AND status NOT IN ('done','archived'))
+    OR status IN ('done','archived')
+  )
+);
+
+CREATE INDEX tickets_status_idx        ON tickets.tickets (status) WHERE status NOT IN ('done','archived');
+CREATE INDEX tickets_type_brand_idx    ON tickets.tickets (type, brand);
+CREATE INDEX tickets_parent_idx        ON tickets.tickets (parent_id);
+CREATE INDEX tickets_assignee_idx      ON tickets.tickets (assignee_id) WHERE assignee_id IS NOT NULL;
+CREATE INDEX tickets_customer_idx      ON tickets.tickets (customer_id) WHERE customer_id IS NOT NULL;
+CREATE INDEX tickets_thesis_tag_idx    ON tickets.tickets (thesis_tag) WHERE thesis_tag IS NOT NULL;
+CREATE INDEX tickets_external_id_idx   ON tickets.tickets (external_id);
+
+-- ── relationships ───────────────────────────────────────────────────
+CREATE TABLE tickets.ticket_links (
+  id          BIGSERIAL PRIMARY KEY,
+  from_id     UUID NOT NULL REFERENCES tickets.tickets(id) ON DELETE CASCADE,
+  to_id       UUID NOT NULL REFERENCES tickets.tickets(id) ON DELETE CASCADE,
+  kind        TEXT NOT NULL CHECK (kind IN
+                ('blocks','blocked_by','duplicate_of','relates_to','fixes','fixed_by')),
+  pr_number   INTEGER,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  created_by  UUID REFERENCES customers(id),
+  UNIQUE (from_id, to_id, kind)
+);
+
+-- ── audit trail ─────────────────────────────────────────────────────
+CREATE TABLE tickets.ticket_activity (
+  id          BIGSERIAL PRIMARY KEY,
+  ticket_id   UUID NOT NULL REFERENCES tickets.tickets(id) ON DELETE CASCADE,
+  actor_id    UUID REFERENCES customers(id),
+  actor_label TEXT,
+  field       TEXT NOT NULL,                           -- 'status', 'assignee_id', '_created', '_link_added', …
+  old_value   JSONB,
+  new_value   JSONB,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX activity_ticket_idx ON tickets.ticket_activity (ticket_id, created_at);
+
+-- ── discussion ──────────────────────────────────────────────────────
+CREATE TABLE tickets.ticket_comments (
+  id           BIGSERIAL PRIMARY KEY,
+  ticket_id    UUID NOT NULL REFERENCES tickets.tickets(id) ON DELETE CASCADE,
+  author_id    UUID REFERENCES customers(id),
+  author_label TEXT NOT NULL,
+  kind         TEXT NOT NULL DEFAULT 'comment'
+               CHECK (kind IN ('comment','status_change','system')),
+  body         TEXT NOT NULL,
+  visibility   TEXT NOT NULL DEFAULT 'internal'
+               CHECK (visibility IN ('internal','public')),
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- ── attachments ─────────────────────────────────────────────────────
+CREATE TABLE tickets.ticket_attachments (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  ticket_id   UUID NOT NULL REFERENCES tickets.tickets(id) ON DELETE CASCADE,
+  filename    TEXT NOT NULL,
+  nc_path     TEXT,
+  data_url    TEXT,
+  mime_type   TEXT NOT NULL DEFAULT 'application/octet-stream',
+  file_size   BIGINT,
+  uploaded_by UUID REFERENCES customers(id),
+  uploaded_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CHECK (nc_path IS NOT NULL OR data_url IS NOT NULL)
+);
+
+-- ── watchers / labels ──────────────────────────────────────────────
+CREATE TABLE tickets.ticket_watchers (
+  ticket_id   UUID NOT NULL REFERENCES tickets.tickets(id) ON DELETE CASCADE,
+  user_id     UUID NOT NULL REFERENCES customers(id) ON DELETE CASCADE,
+  added_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (ticket_id, user_id)
+);
+
+CREATE TABLE tickets.tags (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name        TEXT NOT NULL UNIQUE,
+  color       TEXT,
+  brand       TEXT
+);
+
+CREATE TABLE tickets.ticket_tags (
+  ticket_id   UUID NOT NULL REFERENCES tickets.tickets(id) ON DELETE CASCADE,
+  tag_id      UUID NOT NULL REFERENCES tickets.tags(id) ON DELETE CASCADE,
+  PRIMARY KEY (ticket_id, tag_id)
+);
+
+-- ── PR ledger (renamed from bachelorprojekt.features) ──────────────
+CREATE TABLE tickets.pr_events (
+  pr_number    INTEGER PRIMARY KEY,
+  title        TEXT NOT NULL,
+  description  TEXT,
+  category     TEXT NOT NULL,
+  scope        TEXT,
+  brand        TEXT,
+  merged_at    TIMESTAMPTZ NOT NULL,
+  merged_by    TEXT,
+  status       TEXT NOT NULL DEFAULT 'shipped'
+               CHECK (status IN ('planned','in_progress','shipped','reverted')),
+  created_at   TIMESTAMPTZ DEFAULT now()
+);
+CREATE INDEX pr_events_merged_at_idx ON tickets.pr_events (merged_at DESC);
+```
+
+## 6. Lifecycle & Workflow
+
+### State machine
+
+```
+                   ┌─────────► blocked ─────────┐
+                   │              ▲             │
+                   │              │             ▼
+   triage ──► backlog ──► in_progress ──► in_review ──► done ──► archived
+      │                                                   ▲
+      └───────────────────────────────────────────────────┘
+                                                          
+   any status ──► archived (with resolution=obsolete|wontfix|duplicate)
+```
+
+- `triage` is the default for everything new. Admin must explicitly move out of triage — that's "I have looked at this".
+- `blocked` is a sidetrack from `in_progress`/`in_review`; returning resumes the timer.
+- `done` and `archived` require a `resolution` value (DB CHECK constraint).
+- Reopen = manual reset to `backlog` (or `triage` for bugs reopened by a customer).
+
+### Auto-set timestamps (DB trigger on UPDATE)
+
+`triaged_at`, `started_at`, `done_at`, `archived_at` are write-once on first transition. The full transition history lives in `ticket_activity`.
+
+### Audit log (DB trigger)
+
+Every `UPDATE` on `tickets.tickets` writes one row per changed field into `ticket_activity` with `old_value`/`new_value` (JSONB). `actor_id` comes from a session-local `app.user_id` setting set at the start of each request. Inserts log a single `_created` row. Link/comment/attachment changes also write activity rows so the UI can render one unified timeline.
+
+### Single transition handler
+
+All status changes go through one server-side service:
+
+```ts
+transitionTicket(id, {
+  status: 'done',
+  resolution: 'fixed',
+  note?: string,
+  visibility?: 'internal' | 'public',
+  actor: { id, label }
+}): Promise<Ticket>
+```
+
+This is the **only** code allowed to write to `tickets.status`. It enforces:
+- Valid source→target transition for the current status.
+- Required `resolution` for done/archived.
+- `triaged_at` / `started_at` / `done_at` / `archived_at` updates.
+- Comment row insert (when note provided).
+- **Reporter close-notification email** when transitioning to `done` (see §7).
+
+All callers — admin UI, inbox action, `track-pr.mjs` ingest — are rewritten to call this single function. This is the structural fix for the missed-notifications bug.
+
+### GitHub PR webhook automation
+
+The existing `.github/workflows/track-pr.yml` keeps writing `tracking/pending/<pr>.json`. The ingest cron is rewritten to drive `transitionTicket()`:
+
+| GitHub event | Action |
+|---|---|
+| PR opened | Parse title/body for `external_id` patterns; for each match, write `ticket_activity` `pr_opened` row |
+| PR opened, ticket status=`backlog` | Move to `in_review`, set `assignee_id` from PR author when mappable to a customer |
+| PR merged | Insert `pr_events` row; for each linked ticket, insert `ticket_links` (kind=`fixes`, pr_number=N), call `transitionTicket(id, { status: 'done', resolution: type==='bug' ? 'fixed' : 'shipped' })` |
+| PR merged, ticket already `done` | Just add the `ticket_links` row (multi-PR fix) |
+| PR closed unmerged | Write `ticket_activity` `pr_closed_unmerged`; if ticket was `in_review`, drop back to `in_progress` |
+
+### Invariants
+
+- `parent_id` cannot create a cycle (trigger walks chain on INSERT/UPDATE).
+- `customer_id` is required when `type='project'` (service-layer validation; not DB CHECK because back-migrated rows may not satisfy it).
+- `external_id` format is enforced by service layer per type, not by DB.
+- Closing a parent does not auto-close children — UI shows a warning.
+- `BR-YYYYMMDD-xxxx` IDs are minted exclusively by the public `/api/bug-report` endpoint.
+
+## 7. Notification Model
+
+### Email triggers
+
+| Event | Recipients |
+|---|---|
+| Ticket created with `reporter_email` | reporter (confirmation) |
+| Status transition to `done` or `archived` | reporter (To), `info@<brand>` (BCC), watchers + assignee (TO/CC) |
+| Public comment (`visibility='public'`) added | reporter (To) |
+| Internal status change | watchers + assignee only |
+
+### Close-notification email (the bug fix)
+
+Subject: `[<external_id>] Ihre Meldung wurde bearbeitet`
+
+To: `reporter_email` (when set)
+BCC: `info@<brand>.de` (for archive purposes)
+Reply-To: `info@<brand>.de`
+
+Body includes resolution category, optional admin note, and a link to the public status page (`/portal/tickets/<external_id>`) when v1.5 ships. Templated via the existing `website/src/lib/email.ts` helper.
+
+### Reporter→customer auto-link
+
+Before INSERT and on UPDATE of `reporter_email`, look up `customers.email`. If a customer exists with `keycloak_user_id IS NOT NULL`, set `reporter_id = customer.id`. Runs:
+- Synchronously inside `/api/bug-report` and `transitionTicket()`.
+- As an idempotent batch in PR1 migration.
+- Optionally as a nightly cron to pick up newly-registered users with old anonymous reports.
+
+### What we do NOT do in v1
+
+- No backfill mailing for already-closed tickets that missed their notification. Fix forward only — we don't want to suddenly mail dozens of reporters about months-old tickets.
+
+## 8. API & UI Surfaces
+
+### Public
+
+- `POST /api/bug-report` — unchanged signature; insert into `tickets` (type=bug, status=triage, external_id=BR-YYYYMMDD-xxxx).
+- `GET /api/tickets/public/:external_id` — public status lookup. Returns `{ external_id, status, resolution?, created_at, done_at?, public_comments[] }`. No PII, no internal comments.
+- `/portal/tickets/:external_id` (v1.5) — pretty page version of the above.
+
+### Customer portal
+
+- `/portal/tickets` — lists tickets where `reporter_id = me OR customer_id = me OR me ∈ watchers`.
+
+### Admin
+
+- `/admin/tickets` — single unified inbox (replaces `/admin/bugs` as primary view). Filters: type, status, component, brand, assignee, label, customer. Saved-view chips: "My open", "Triage queue", "In review", "Customer X", "Thesis FA".
+- `/admin/tickets/:id` — detail view: header, description, child tree, linked tickets, activity timeline, attachments, watchers, sidebar with metadata, action bar.
+- `/admin/bugs` — kept as a thin filter view (`?type=bug`) for muscle memory.
+- `/admin/projekte` — kept similarly (`?type=project`); existing Gantt visualization preserved, just driven from `tickets`.
+- `/admin/monitoring` BugsTab → TicketsTab.
+
+### Internal API (`session + isAdmin`)
+
+- `GET /api/admin/tickets` — list with filters, pagination, server-side search.
+- `GET /api/admin/tickets/:id` — full detail incl. children, links, activity, comments, attachments.
+- `POST /api/admin/tickets` — create.
+- `PATCH /api/admin/tickets/:id` — partial update; service layer writes activity rows.
+- `POST /api/admin/tickets/:id/comments` — add comment; if `visibility='public'` and `reporter_email` set, sends email.
+- `POST /api/admin/tickets/:id/links` — add link.
+- `POST /api/admin/tickets/:id/transition` — explicit status transition (calls `transitionTicket()`).
+- `POST /api/admin/tickets/:id/attachments` — upload (Nextcloud-backed for new uploads, inline data_url for legacy).
+
+## 9. Migration Sequence
+
+Five PRs, each shippable on its own. Old tables become SQL views over the new schema until PR5.
+
+### PR1 — `tickets` schema + bugs migration + close-mail fix
+- Create `tickets` schema with all tables from §5; idempotent init in `website-db.ts` mirroring the existing pattern.
+- Add DB triggers: cycle prevention, lifecycle timestamps, audit-log writer.
+- Migrate `bugs.bug_tickets` → `tickets.tickets` (`type='bug'`, `external_id=ticket_id`, `status` mapped: `open→triage`, `resolved→done`+`fixed`, `archived→archived`+`fixed`).
+- Migrate `bugs.bug_ticket_comments` → `tickets.ticket_comments` (visibility=`internal`).
+- Inline screenshots → `tickets.ticket_attachments` (data_url kept).
+- Reporter→customer auto-link batch.
+- Add `transitionTicket()`. Rewrite `/api/admin/bugs/resolve.ts`, inbox `resolve_bug` action, and `track-pr.mjs` ingest to call it.
+- Close-mail goes To: reporter, BCC: `info@<brand>`.
+- `/admin/bugs` and `/admin/bugs/[id]` rewired to read/write `tickets WHERE type='bug'`. UI stays visually identical.
+- `bugs.bug_tickets` becomes a SQL view so any straggling reader keeps working.
+- Tests: BATS migration verification (row counts match), Playwright spec for bug-report → resolve → reporter-receives-mail.
+
+### PR2 — features + requirements migration, PR ledger rename
+- Migrate `bachelorprojekt.requirements` → `tickets.tickets` (`type='feature'`, `external_id=requirement.id`, `thesis_tag=requirement.id`, status from latest `pipeline.stage` if present, else `backlog`).
+- Rename `bachelorprojekt.features` → `tickets.pr_events`; drop `requirement_id` column (replaced by `ticket_links`).
+- For each old `features.requirement_id`, write a `ticket_links` row (`kind='fixes'`).
+- Rebuild `bachelorprojekt.v_timeline` as a view over `tickets.pr_events` left-joined to `ticket_links` + `tickets`. Kore homepage timeline keeps rendering with the same shape (verified by `tests/e2e/specs/fa-29-tracking.spec.ts`).
+- `pipeline` and `test_results` stay as historical thesis artifacts.
+
+### PR3 — projects/sub_projects/tasks migration
+- Migrate `projects` → `tickets.tickets` (`type='project'`, status mapped: `entwurf→backlog`, `wartend→blocked`, `geplant→backlog`, `aktiv→in_progress`, `erledigt→done`+`shipped`, `archiviert→archived`).
+- Migrate `sub_projects` → `tickets.tickets` (`type='project'`, `parent_id=parent project`).
+- Migrate `project_tasks` → `tickets.tickets` (`type='task'`, `parent_id=sub_project_id ?? project_id`).
+- Migrate `project_attachments` → `tickets.ticket_attachments`.
+- `/admin/projekte` and Gantt rewired to read from `tickets WHERE type='project'`.
+- Old tables become views.
+
+### PR4 — unified `/admin/tickets` UI
+- New `/admin/tickets` index + `/admin/tickets/:id` detail pages.
+- New admin API endpoints (§8).
+- `/admin/bugs` and `/admin/projekte` kept as filtered views.
+- Unified inbox: bug-specific resolve action becomes generic transition action.
+- Activity-timeline component (audit log + comments + links + PR events) — single rendering path used everywhere.
+- Documentation update in docs-site.
+
+### PR5 — sunset old tables
+- Confirm no readers/writers reference old tables for ≥1 week of production traffic (greppable + `pg_stat_user_tables`).
+- Drop `bugs.bug_tickets` view, `bugs.bug_ticket_comments`, the `bugs` schema if empty.
+- Drop `projects/sub_projects/project_tasks/project_attachments` views/tables.
+- Drop `bachelorprojekt.requirements/pipeline/test_results` only if confirmed unread by thesis defense; otherwise keep as historical record.
+- Final test sweep across both brands.
+
+### Risk reduction
+
+- Each PR is independently revertable. PR1 revert = drop `tickets` schema + re-point `/admin/bugs` reads back at `bugs.bug_tickets`; one-commit rollback.
+- `task workspace:backup` before each prod deploy; the website DB is in the standard backup set.
+- Old tables aren't physically dropped (only views replace them) until PR5, so rollback to "before unified system" stays possible for weeks.
+
+## 10. Testing Strategy
+
+- **PR1**: BATS migration verification, Playwright `bug-report → admin resolve → reporter receives mail` end-to-end. Existing bug-report E2E specs (`tests/e2e/specs/fa-admin-crm.spec.ts`) updated to assert email delivery via Mailpit.
+- **PR2**: `tests/e2e/specs/fa-29-tracking.spec.ts` must keep passing unchanged; add an assertion that `v_timeline` returns the same row count as before migration.
+- **PR3**: existing project-tab E2E specs must keep passing; add migration-row-count check.
+- **PR4**: new E2E spec for `/admin/tickets` filters, transitions, link creation, comment posting (public + internal).
+- **PR5**: full Playwright website + services groups across both brands.
+
+## 11. Open Questions for Plan Phase
+
+- **DB trigger language**: PL/pgSQL for the audit-log writer vs Node-side logging. Trigger keeps the audit log honest even when bypassed by raw SQL; downside is harder testability. Lean toward trigger.
+- **Activity-log granularity**: log every JSONB field, or batch all fields of one UPDATE into a single row with a JSONB diff? Lean toward batch — fewer rows, easier to render.
+- **Watcher email throttling**: should rapid-fire updates (5+ in 5 minutes) coalesce into a digest email? Probably yes for v1.5, not v1.
+- **Permission to mint thesis tags**: should `thesis_tag` be a free-form column or constrained to a known list? Lean toward free-form with a service-layer validator that warns on unknown patterns.
+
+These are deliberately deferred to the implementation plan — they don't affect schema or migration shape.

--- a/environments/schema.yaml
+++ b/environments/schema.yaml
@@ -516,6 +516,15 @@ secrets:
     generate: false
     description: "PostgreSQL connection URL for the tracking-import CronJob"
 
+  - name: INTERNAL_API_TOKEN
+    required: true
+    generate: true
+    length: 48
+    description: "Shared secret for cron-driven internal API calls (e.g. notify-close). Set in environments/.secrets/<env>.yaml then run `task env:seal ENV=<env>`."
+    extra_namespaces:
+      - namespace: website
+        secret: website-secrets
+
 setup_vars:
   - name: KC_USER1_USERNAME
     required: true

--- a/k3d/secrets.yaml
+++ b/k3d/secrets.yaml
@@ -70,3 +70,6 @@ stringData:
   LIVEKIT_RTMP_KEY: "devrtmpkey123456"
   # Tracking import CronJob
   TRACKING_DB_URL: "postgresql://postgres:devshareddb@shared-db.workspace.svc.cluster.local:5432/postgres?sslmode=disable"
+  # Internal API token — used by tracking-import CronJob to call /api/internal/tickets/notify-close
+  # TODO: set a strong random value in environments/.secrets/<env>.yaml then `task env:seal ENV=<env>`
+  INTERNAL_API_TOKEN: "dev-placeholder-not-for-prod"

--- a/k3d/tracking-import-cronjob.yaml
+++ b/k3d/tracking-import-cronjob.yaml
@@ -30,6 +30,11 @@ spec:
                     secretKeyRef:
                       name: workspace-secrets
                       key: TRACKING_DB_URL
+                - name: INTERNAL_API_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: workspace-secrets
+                      key: INTERNAL_API_TOKEN
                 - name: GIT_REPO
                   value: "https://github.com/Paddione/Bachelorprojekt.git"
               command:

--- a/k3d/website.yaml
+++ b/k3d/website.yaml
@@ -346,6 +346,11 @@ spec:
                 secretKeyRef:
                   name: website-secrets
                   key: LIVEKIT_RTMP_KEY
+            - name: INTERNAL_API_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: website-secrets
+                  key: INTERNAL_API_TOKEN
             - name: LIVEKIT_SERVICE_URL
               value: "http://livekit-server.${WORKSPACE_NAMESPACE}.svc.cluster.local:7880"
           ports:

--- a/scripts/migrate-bugs-to-tickets.mjs
+++ b/scripts/migrate-bugs-to-tickets.mjs
@@ -88,6 +88,39 @@ async function migrate(client, dryRun) {
         [newId, b.resolution_note, b.resolved_at ?? b.created_at]);
     }
 
+    // comments — copy bugs.bug_ticket_comments to tickets.ticket_comments
+    const comments = (await client.query(
+      `SELECT author, kind, body, created_at FROM bugs.bug_ticket_comments
+        WHERE ticket_id = $1 ORDER BY created_at`, [b.ticket_id])).rows;
+    for (const c of comments) {
+      await client.query(
+        `INSERT INTO tickets.ticket_comments
+           (ticket_id, author_label, kind, body, visibility, created_at)
+         VALUES ($1, $2, $3, $4, 'internal', $5)`,
+        [newId, c.author, c.kind, c.body, c.created_at]);
+    }
+
+    // screenshots → attachments (kept as data_url for back-compat)
+    if (b.screenshots_json && Array.isArray(b.screenshots_json)) {
+      let i = 0;
+      for (const dataUrl of b.screenshots_json) {
+        const m = String(dataUrl).match(/^data:([^;]+);/);
+        await client.query(
+          `INSERT INTO tickets.ticket_attachments
+             (ticket_id, filename, data_url, mime_type)
+           VALUES ($1, $2, $3, $4)`,
+          [newId, `screenshot-${++i}`, dataUrl, m ? m[1] : 'application/octet-stream']);
+      }
+    }
+
+    // fixed_in_pr → ticket_links self-link with kind='fixes' + pr_number
+    if (b.fixed_in_pr) {
+      await client.query(
+        `INSERT INTO tickets.ticket_links (from_id, to_id, kind, pr_number)
+         VALUES ($1, $1, 'fixes', $2) ON CONFLICT DO NOTHING`,
+        [newId, b.fixed_in_pr]);
+    }
+
     inserted++;
   }
   return { inserted, skipped, unknownStatus };

--- a/scripts/migrate-bugs-to-tickets.mjs
+++ b/scripts/migrate-bugs-to-tickets.mjs
@@ -42,7 +42,7 @@ async function migrate(client, dryRun) {
       FROM bugs.bug_tickets
      ORDER BY created_at`)).rows;
 
-  let inserted = 0, skipped = 0;
+  let inserted = 0, skipped = 0, unknownStatus = 0;
   for (const b of bugs) {
     const exists = await client.query(
       `SELECT id FROM tickets.tickets WHERE external_id = $1`, [b.ticket_id]);
@@ -50,7 +50,13 @@ async function migrate(client, dryRun) {
 
     if (dryRun) { inserted++; continue; }
 
-    const m = STATUS_MAP[b.status] ?? STATUS_MAP.open;
+    const known = STATUS_MAP[b.status];
+    if (!known) {
+      console.warn(`WARN: unknown status "${b.status}" for ticket ${b.ticket_id} — migrating as triage`);
+      unknownStatus++;
+    }
+    const m = known ?? STATUS_MAP.open;
+
     const ins = await client.query(
       `INSERT INTO tickets.tickets
          (external_id, type, brand, title, description, url, reporter_email,
@@ -84,7 +90,7 @@ async function migrate(client, dryRun) {
 
     inserted++;
   }
-  return { inserted, skipped };
+  return { inserted, skipped, unknownStatus };
 }
 
 async function main() {
@@ -100,8 +106,10 @@ async function main() {
     console.log(JSON.stringify({ ...r, mode: apply ? 'apply' : 'dry-run' }));
   } catch (err) {
     if (apply) await client.query('ROLLBACK').catch(() => {});
+    await client.end().catch(() => {});
     console.error(err.message);
     process.exit(1);
-  } finally { await client.end(); }
+  }
+  await client.end();
 }
 main();

--- a/scripts/migrate-bugs-to-tickets.mjs
+++ b/scripts/migrate-bugs-to-tickets.mjs
@@ -1,0 +1,107 @@
+// scripts/migrate-bugs-to-tickets.mjs
+//
+// Migrates bugs.bug_tickets → tickets.tickets (and associated tags/comments).
+// Idempotent: uses the UNIQUE constraint on tickets.tickets(external_id) to
+// detect already-migrated rows and skip them.
+//
+// Usage:
+//   node scripts/migrate-bugs-to-tickets.mjs            # dry-run (default)
+//   node scripts/migrate-bugs-to-tickets.mjs --apply    # execute changes
+//
+// Environment:
+//   TRACKING_DB_URL  or  WEBSITE_DB_URL  — PostgreSQL connection string.
+//   Falls back to: postgres://postgres:postgres@localhost:5432/website
+import pg from 'pg';
+
+const STATUS_MAP = {
+  open:     { status: 'triage',   resolution: null    },
+  resolved: { status: 'done',     resolution: 'fixed' },
+  archived: { status: 'archived', resolution: 'fixed' },
+};
+
+const CATEGORY_TAG = {
+  fehler:             'kind:bug',
+  verbesserung:       'kind:improvement',
+  erweiterungswunsch: 'kind:wish',
+};
+
+async function ensureTag(client, name) {
+  const r = await client.query(
+    `INSERT INTO tickets.tags (name) VALUES ($1)
+       ON CONFLICT (name) DO UPDATE SET name = EXCLUDED.name
+       RETURNING id`,
+    [name]);
+  return r.rows[0].id;
+}
+
+async function migrate(client, dryRun) {
+  const bugs = (await client.query(`
+    SELECT ticket_id, category, reporter_email, description, url, brand,
+           status, created_at, resolved_at, resolution_note,
+           screenshots_json, fixed_in_pr, fixed_at
+      FROM bugs.bug_tickets
+     ORDER BY created_at`)).rows;
+
+  let inserted = 0, skipped = 0;
+  for (const b of bugs) {
+    const exists = await client.query(
+      `SELECT id FROM tickets.tickets WHERE external_id = $1`, [b.ticket_id]);
+    if (exists.rowCount > 0) { skipped++; continue; }
+
+    if (dryRun) { inserted++; continue; }
+
+    const m = STATUS_MAP[b.status] ?? STATUS_MAP.open;
+    const ins = await client.query(
+      `INSERT INTO tickets.tickets
+         (external_id, type, brand, title, description, url, reporter_email,
+          status, resolution, created_at, done_at, archived_at)
+       VALUES
+         ($1, 'bug', $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+       RETURNING id`,
+      [b.ticket_id, b.brand,
+       b.description.slice(0, 200),
+       b.description,
+       b.url, b.reporter_email,
+       m.status, m.resolution, b.created_at,
+       m.status === 'done'     ? (b.resolved_at ?? b.fixed_at) : null,
+       m.status === 'archived' ? (b.fixed_at    ?? b.resolved_at) : null]);
+    const newId = ins.rows[0].id;
+
+    if (b.category && CATEGORY_TAG[b.category]) {
+      const tagId = await ensureTag(client, CATEGORY_TAG[b.category]);
+      await client.query(
+        `INSERT INTO tickets.ticket_tags (ticket_id, tag_id) VALUES ($1, $2)
+           ON CONFLICT DO NOTHING`, [newId, tagId]);
+    }
+
+    if (b.resolution_note) {
+      await client.query(
+        `INSERT INTO tickets.ticket_comments
+           (ticket_id, author_label, kind, body, visibility, created_at)
+         VALUES ($1, 'migration', 'status_change', $2, 'internal', $3)`,
+        [newId, b.resolution_note, b.resolved_at ?? b.created_at]);
+    }
+
+    inserted++;
+  }
+  return { inserted, skipped };
+}
+
+async function main() {
+  const apply = process.argv.includes('--apply');
+  const url = process.env.TRACKING_DB_URL ?? process.env.WEBSITE_DB_URL
+    ?? 'postgres://postgres:postgres@localhost:5432/website';
+  const client = new pg.Client({ connectionString: url });
+  await client.connect();
+  try {
+    if (apply) await client.query('BEGIN');
+    const r = await migrate(client, !apply);
+    if (apply) await client.query('COMMIT');
+    console.log(JSON.stringify({ ...r, mode: apply ? 'apply' : 'dry-run' }));
+  } catch (err) {
+    if (apply) await client.query('ROLLBACK').catch(() => {});
+    console.error(err.message);
+    process.exit(1);
+  } finally { await client.end(); }
+}
+main();

--- a/scripts/migrate-bugs-to-tickets.mjs
+++ b/scripts/migrate-bugs-to-tickets.mjs
@@ -123,6 +123,56 @@ async function migrate(client, dryRun) {
 
     inserted++;
   }
+
+  // Replace bugs.bug_tickets with a back-compat view (run only after data is in tickets.tickets)
+  if (!dryRun) {
+    // Rename legacy tables only if they still exist as tables (not views).
+    // pg_tables only lists base tables, not views — so this is idempotent.
+    await client.query(`
+      DO $$
+      BEGIN
+        IF EXISTS (
+          SELECT 1 FROM pg_tables WHERE schemaname='bugs' AND tablename='bug_tickets'
+        ) THEN
+          EXECUTE 'ALTER TABLE bugs.bug_tickets RENAME TO bug_tickets_legacy';
+        END IF;
+        IF EXISTS (
+          SELECT 1 FROM pg_tables WHERE schemaname='bugs' AND tablename='bug_ticket_comments'
+        ) THEN
+          EXECUTE 'ALTER TABLE bugs.bug_ticket_comments RENAME TO bug_ticket_comments_legacy';
+        END IF;
+      END $$
+    `);
+    await client.query(`
+      CREATE OR REPLACE VIEW bugs.bug_tickets AS
+      SELECT
+        t.external_id      AS ticket_id,
+        t.brand            AS brand,
+        t.url              AS url,
+        t.description      AS description,
+        t.reporter_email   AS reporter_email,
+        CASE t.status
+          WHEN 'triage'       THEN 'open'
+          WHEN 'backlog'      THEN 'open'
+          WHEN 'in_progress'  THEN 'open'
+          WHEN 'in_review'    THEN 'open'
+          WHEN 'blocked'      THEN 'open'
+          WHEN 'done'         THEN 'resolved'
+          WHEN 'archived'     THEN 'archived'
+        END                AS status,
+        t.created_at       AS created_at,
+        t.done_at          AS resolved_at,
+        (SELECT pr_number FROM tickets.ticket_links
+          WHERE from_id = t.id AND kind = 'fixes' AND pr_number IS NOT NULL
+          ORDER BY created_at DESC LIMIT 1) AS fixed_in_pr,
+        (SELECT created_at FROM tickets.ticket_links
+          WHERE from_id = t.id AND kind = 'fixes' AND pr_number IS NOT NULL
+          ORDER BY created_at DESC LIMIT 1) AS fixed_at
+      FROM tickets.tickets t
+      WHERE t.type = 'bug'
+    `);
+  }
+
   return { inserted, skipped, unknownStatus };
 }
 

--- a/scripts/track-pr.mjs
+++ b/scripts/track-pr.mjs
@@ -71,13 +71,60 @@ export async function writeRowToDb(row, pgClient) {
      requirementId, row.merged_at, row.merged_by]
   );
 
-  for (const ticketId of row.bug_refs) {
-    await pgClient.query(
-      `UPDATE bugs.bug_tickets
-         SET fixed_in_pr = $1, fixed_at = $2, status = 'archived'
-       WHERE ticket_id = $3 AND (fixed_in_pr IS NULL OR fixed_in_pr <> $1)`,
-      [row.pr_number, row.merged_at, ticketId]
-    );
+  // Map external_id (BR-...) -> ticket UUID, transition through tickets.tickets.
+  // We use raw SQL because track-pr.mjs runs as a Node script outside the website
+  // process (so we can't import the TypeScript transitionTicket directly).
+  // Reporter notification is fired via a thin internal HTTP endpoint that lives
+  // inside the website pod, which has SMTP credentials in its env.
+  for (const externalId of row.bug_refs) {
+    const r = await pgClient.query(
+      `SELECT id, status, reporter_email FROM tickets.tickets
+        WHERE type = 'bug' AND external_id = $1`, [externalId]);
+    if (r.rowCount === 0) {
+      console.log(`skip ${externalId}: not found in tickets.tickets`);
+      continue;
+    }
+    const t = r.rows[0];
+    if (t.status === 'done' || t.status === 'archived') {
+      // already closed — just record the link (idempotent)
+      await pgClient.query(
+        `INSERT INTO tickets.ticket_links (from_id, to_id, kind, pr_number)
+         VALUES ($1, $1, 'fixes', $2) ON CONFLICT (from_id, to_id, kind) DO NOTHING`,
+        [t.id, row.pr_number]);
+      continue;
+    }
+    await pgClient.query('BEGIN');
+    try {
+      await pgClient.query(`SELECT set_config('app.user_label', 'github-bot', true)`);
+      await pgClient.query(
+        `UPDATE tickets.tickets SET status = 'done', resolution = 'fixed' WHERE id = $1`,
+        [t.id]);
+      await pgClient.query(
+        `INSERT INTO tickets.ticket_links (from_id, to_id, kind, pr_number)
+         VALUES ($1, $1, 'fixes', $2) ON CONFLICT (from_id, to_id, kind) DO NOTHING`,
+        [t.id, row.pr_number]);
+      await pgClient.query('COMMIT');
+    } catch (e) {
+      await pgClient.query('ROLLBACK').catch(() => {});
+      throw e;
+    }
+    // Reporter notification — call the website API so the email pipeline runs in-process.
+    if (t.reporter_email) {
+      const apiUrl = process.env.WEBSITE_API_URL ?? 'https://web.mentolder.de';
+      try {
+        const resp = await fetch(`${apiUrl}/api/internal/tickets/notify-close`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json',
+                     'X-Internal-Token': process.env.INTERNAL_API_TOKEN ?? '' },
+          body: JSON.stringify({ externalId, resolution: 'fixed' }),
+        });
+        if (!resp.ok) {
+          console.error(`notify-close ${externalId}: HTTP ${resp.status}`);
+        }
+      } catch (e) {
+        console.error(`notify-close failed for ${externalId}: ${e.message}`);
+      }
+    }
   }
 }
 

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -53,6 +53,7 @@ export default defineConfig({
         '**/fa-admin-billing-system.spec.ts',   // native SEPA billing, EÜR, UStVA
         '**/fa-admin-crm.spec.ts',              // CRM: termine, followups, projekte, rooms, meetings
         '**/fa-admin-settings.spec.ts',         // settings: email, rechnungen, branding, benachrichtigungen
+        '**/fa-bugs-notifications.spec.ts',     // bug-report → admin resolve → reporter email (FA-bug-notify)
       ],
       use: {
         ...devices['Desktop Chrome'],

--- a/tests/e2e/specs/fa-bugs-notifications.spec.ts
+++ b/tests/e2e/specs/fa-bugs-notifications.spec.ts
@@ -14,7 +14,6 @@
 //   E2E_ADMIN_PASS  — Keycloak password                  (required to run)
 //   WEBSITE_URL     — Astro website base URL              (default: http://localhost:4321)
 //   MAILPIT_URL     — Mailpit base URL                    (default: http://localhost:8025)
-//   KC_URL          — Keycloak base URL                   (default: http://auth.localhost)
 //
 // The test skips gracefully when E2E_ADMIN_PASS is unset (CI without secrets).
 
@@ -22,7 +21,6 @@ import { test, expect } from '@playwright/test';
 
 const BASE       = process.env.WEBSITE_URL ?? 'http://localhost:4321';
 const MAILPIT    = process.env.MAILPIT_URL  ?? 'http://localhost:8025';
-const KC_URL     = process.env.KC_URL       ?? 'http://auth.localhost';
 const ADMIN_USER = process.env.E2E_ADMIN_USER ?? 'patrick';
 const ADMIN_PASS = process.env.E2E_ADMIN_PASS;
 

--- a/tests/e2e/specs/fa-bugs-notifications.spec.ts
+++ b/tests/e2e/specs/fa-bugs-notifications.spec.ts
@@ -1,0 +1,120 @@
+// tests/e2e/specs/fa-bugs-notifications.spec.ts
+//
+// FA-bug-notify: bug-report submission → admin resolve → reporter email
+//
+// This test verifies the full notification loop:
+//   1. A public bug-report is submitted via POST /api/bug-report (no auth).
+//   2. An admin authenticates via Keycloak OIDC and resolves the ticket
+//      via POST /api/admin/bugs/resolve (JSON body).
+//   3. Mailpit confirms an email arrived at the reporter's address
+//      with a subject containing the ticket's BR-ID.
+//
+// Requirements:
+//   E2E_ADMIN_USER  — Keycloak username with admin role  (default: patrick)
+//   E2E_ADMIN_PASS  — Keycloak password                  (required to run)
+//   WEBSITE_URL     — Astro website base URL              (default: http://localhost:4321)
+//   MAILPIT_URL     — Mailpit base URL                    (default: http://localhost:8025)
+//   KC_URL          — Keycloak base URL                   (default: http://auth.localhost)
+//
+// The test skips gracefully when E2E_ADMIN_PASS is unset (CI without secrets).
+
+import { test, expect } from '@playwright/test';
+
+const BASE       = process.env.WEBSITE_URL ?? 'http://localhost:4321';
+const MAILPIT    = process.env.MAILPIT_URL  ?? 'http://localhost:8025';
+const KC_URL     = process.env.KC_URL       ?? 'http://auth.localhost';
+const ADMIN_USER = process.env.E2E_ADMIN_USER ?? 'patrick';
+const ADMIN_PASS = process.env.E2E_ADMIN_PASS;
+
+test.describe('FA-bug-notify', () => {
+  test('reporter receives close-mail when admin resolves ticket', async ({ page, request }) => {
+    test.skip(!ADMIN_PASS, 'E2E_ADMIN_PASS not set — skipping (set to enable live run)');
+
+    // ── Step 1: Submit public bug report via API (no auth required) ──
+    const reporter = `e2e-${Date.now()}@example.com`;
+
+    const create = await request.post(`${BASE}/api/bug-report`, {
+      multipart: {
+        description: 'E2E notification test — Playwright FA-bug-notify',
+        email:       reporter,
+        category:    'fehler',
+        url:         '/e2e-test',
+      },
+    });
+    expect(create.ok(), `bug-report POST failed: ${create.status()}`).toBeTruthy();
+
+    const createBody = await create.json() as { success: boolean; ticketId: string };
+    expect(createBody.success).toBe(true);
+    expect(createBody.ticketId).toMatch(/^BR-/);
+    const ticketId = createBody.ticketId;
+
+    // ── Step 2: Admin login via Keycloak OIDC ───────────────────────
+    // Navigate to the login redirect — the Astro app redirects to Keycloak.
+    await page.goto(`${BASE}/api/auth/login?returnTo=/admin/bugs`);
+
+    // Wait for Keycloak login page (URL contains /realms/workspace)
+    await page.waitForURL(/realms\/workspace/, { timeout: 20_000 });
+
+    // Fill Keycloak login form
+    const kcUsername = page.locator('#username, input[name="username"]').first();
+    const kcPassword = page.locator('#password, input[name="password"]').first();
+    await expect(kcUsername).toBeVisible({ timeout: 10_000 });
+    await kcUsername.fill(ADMIN_USER);
+    await kcPassword.fill(ADMIN_PASS!);
+    await page.locator('#kc-login, input[type="submit"]').first().click();
+
+    // Wait for redirect back to the website admin page
+    await page.waitForURL(/\/admin/, { timeout: 20_000 });
+
+    // ── Step 3: Resolve ticket via API with admin session cookies ───
+    // Use page.request so Playwright sends the session cookies from the
+    // logged-in browser context.
+    const resolveRes = await page.request.post(`${BASE}/api/admin/bugs/resolve`, {
+      headers: { 'Content-Type': 'application/json' },
+      data: JSON.stringify({
+        ticketId,
+        resolutionNote: 'fixed in E2E plan — Playwright FA-bug-notify',
+      }),
+    });
+    expect(resolveRes.ok(), `resolve POST failed: ${resolveRes.status()}`).toBeTruthy();
+
+    const resolveBody = await resolveRes.json() as { ok: boolean };
+    expect(resolveBody.ok).toBe(true);
+
+    // ── Step 4: Confirm email in Mailpit ────────────────────────────
+    // Allow a short window for the email to be queued and delivered.
+    await page.waitForTimeout(2000);
+
+    const mailRes = await request.get(
+      `${MAILPIT}/api/v1/search?query=${encodeURIComponent(`to:${reporter}`)}`
+    );
+    expect(mailRes.ok(), `Mailpit search failed: ${mailRes.status()}`).toBeTruthy();
+
+    interface MailpitAddress { Address: string }
+    interface MailpitMessage { Subject: string; To: MailpitAddress[] }
+    interface MailpitSearchResult { messages: MailpitMessage[] }
+
+    const mailData = await mailRes.json() as MailpitSearchResult;
+    expect(mailData.messages.length,
+      `No email found for ${reporter} in Mailpit`
+    ).toBeGreaterThan(0);
+
+    const msg = mailData.messages[0];
+    // Subject must contain the BR-ID: "[BR-YYYYMMDD-xxxx] Ihre Meldung wurde bearbeitet"
+    expect(msg.Subject).toContain(ticketId);
+    // Must be addressed to the reporter (not only to the info@ BCC)
+    expect(
+      msg.To.some(t => t.Address === reporter),
+      `Email To field does not contain ${reporter}: ${JSON.stringify(msg.To)}`
+    ).toBeTruthy();
+  });
+
+  // ── Guard: public resolve endpoint requires auth ─────────────────
+  test('POST /api/admin/bugs/resolve returns 403 without auth', async ({ request }) => {
+    const res = await request.post(`${BASE}/api/admin/bugs/resolve`, {
+      headers: { 'Content-Type': 'application/json' },
+      data: JSON.stringify({ ticketId: 'BR-20260101-0000', resolutionNote: 'test' }),
+    });
+    expect([401, 403]).toContain(res.status());
+  });
+});

--- a/tests/unit/tickets-migration.bats
+++ b/tests/unit/tickets-migration.bats
@@ -15,15 +15,14 @@ load test_helper
 PROJECT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
 
 setup() {
-  PGURL="${TRACKING_DB_URL:-${SESSIONS_DATABASE_URL:-postgres://postgres:postgres@localhost:5432/website}}"
+  PGURL="${TRACKING_DB_URL:-postgres://postgres:postgres@localhost:5432/website}"
   export PGURL
   export PROJECT_DIR
 
   # Safety guard: refuse to run against production databases.
   case "$PGURL" in
     *mentolder*|*korczewski*)
-      echo "TRACKING_DB_URL points to a production host ($PGURL). Aborting to protect live data." >&2
-      exit 1
+      skip "TRACKING_DB_URL points to a production host — refusing to run against live data"
       ;;
   esac
 }
@@ -134,12 +133,13 @@ db_available() {
   [ "$comment_count" = "$with_note" ]
 }
 
-@test "runtime: idempotent — second run does not duplicate tickets" {
-  if ! db_available; then skip "No database available (set TRACKING_DB_URL)"; fi
-  before=$(psql "$PGURL" -t -A -c "SELECT count(*) FROM tickets.tickets WHERE type='bug'")
+@test "runtime: idempotent — second run does not duplicate" {
+  if ! db_available; then skip "No database available"; fi
   node "${PROJECT_DIR}/scripts/migrate-bugs-to-tickets.mjs" --apply >/dev/null
-  after=$(psql "$PGURL" -t -A -c "SELECT count(*) FROM tickets.tickets WHERE type='bug'")
-  [ "$before" = "$after" ]
+  count1=$(psql "$PGURL" -t -A -c "SELECT count(*) FROM tickets.tickets WHERE type='bug'")
+  node "${PROJECT_DIR}/scripts/migrate-bugs-to-tickets.mjs" --apply >/dev/null
+  count2=$(psql "$PGURL" -t -A -c "SELECT count(*) FROM tickets.tickets WHERE type='bug'")
+  [ "$count1" = "$count2" ]
 }
 
 @test "runtime: idempotent — second run reports all rows as skipped" {

--- a/tests/unit/tickets-migration.bats
+++ b/tests/unit/tickets-migration.bats
@@ -1,0 +1,170 @@
+#!/usr/bin/env bats
+# ═══════════════════════════════════════════════════════════════════
+# tickets-migration.bats — Idempotency tests for
+#   scripts/migrate-bugs-to-tickets.mjs
+# ═══════════════════════════════════════════════════════════════════
+# Static tests run without a database. Runtime tests require a live
+# PostgreSQL instance with both bugs.bug_tickets and tickets.* schemas.
+#
+# Set TRACKING_DB_URL to your website DB URL.
+# Default fallback: postgres://postgres:postgres@localhost:5432/website
+# ═══════════════════════════════════════════════════════════════════
+
+load test_helper
+
+PROJECT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+
+setup() {
+  PGURL="${TRACKING_DB_URL:-${SESSIONS_DATABASE_URL:-postgres://postgres:postgres@localhost:5432/website}}"
+  export PGURL
+  export PROJECT_DIR
+
+  # Safety guard: refuse to run against production databases.
+  case "$PGURL" in
+    *mentolder*|*korczewski*)
+      echo "TRACKING_DB_URL points to a production host ($PGURL). Aborting to protect live data." >&2
+      exit 1
+      ;;
+  esac
+}
+
+# ── Static checks (no DB required) ───────────────────────────────
+
+@test "static: migration script exists and is idempotent (uses external_id check)" {
+  [ -f "${PROJECT_DIR}/scripts/migrate-bugs-to-tickets.mjs" ]
+  grep -q 'WHERE external_id = \$1' "${PROJECT_DIR}/scripts/migrate-bugs-to-tickets.mjs"
+}
+
+@test "static: apply mode wraps in BEGIN/COMMIT/ROLLBACK transaction" {
+  grep -q "apply ? 'BEGIN'" "${PROJECT_DIR}/scripts/migrate-bugs-to-tickets.mjs" || \
+  grep -q 'if (apply) await client.query' "${PROJECT_DIR}/scripts/migrate-bugs-to-tickets.mjs"
+  grep -q 'COMMIT'   "${PROJECT_DIR}/scripts/migrate-bugs-to-tickets.mjs"
+  grep -q 'ROLLBACK' "${PROJECT_DIR}/scripts/migrate-bugs-to-tickets.mjs"
+}
+
+@test "static: dry-run mode supported (default, --apply flag required)" {
+  grep -q "process.argv.includes('--apply')" "${PROJECT_DIR}/scripts/migrate-bugs-to-tickets.mjs"
+  grep -q 'dryRun' "${PROJECT_DIR}/scripts/migrate-bugs-to-tickets.mjs"
+}
+
+@test "static: STATUS_MAP covers open->triage, resolved->done+fixed, archived->archived+fixed" {
+  grep -q "open.*triage"    "${PROJECT_DIR}/scripts/migrate-bugs-to-tickets.mjs"
+  grep -q "resolved.*done"  "${PROJECT_DIR}/scripts/migrate-bugs-to-tickets.mjs"
+  grep -q "archived"        "${PROJECT_DIR}/scripts/migrate-bugs-to-tickets.mjs"
+  grep -q "'fixed'"         "${PROJECT_DIR}/scripts/migrate-bugs-to-tickets.mjs"
+}
+
+@test "static: CATEGORY_TAG maps all three bug categories to kind: tags" {
+  grep -q 'fehler.*kind:bug'              "${PROJECT_DIR}/scripts/migrate-bugs-to-tickets.mjs"
+  grep -q 'verbesserung.*kind:improvement' "${PROJECT_DIR}/scripts/migrate-bugs-to-tickets.mjs"
+  grep -q 'erweiterungswunsch.*kind:wish' "${PROJECT_DIR}/scripts/migrate-bugs-to-tickets.mjs"
+}
+
+@test "static: title is description sliced to 200 chars" {
+  grep -q 'slice(0, 200)' "${PROJECT_DIR}/scripts/migrate-bugs-to-tickets.mjs"
+}
+
+@test "static: resolution_note migrated as status_change comment with author_label=migration" {
+  grep -q "'migration'" "${PROJECT_DIR}/scripts/migrate-bugs-to-tickets.mjs"
+  grep -q "'status_change'" "${PROJECT_DIR}/scripts/migrate-bugs-to-tickets.mjs"
+  grep -q 'resolution_note' "${PROJECT_DIR}/scripts/migrate-bugs-to-tickets.mjs"
+}
+
+@test "static: output JSON includes inserted, skipped, and mode fields" {
+  grep -q 'inserted' "${PROJECT_DIR}/scripts/migrate-bugs-to-tickets.mjs"
+  grep -q 'skipped'  "${PROJECT_DIR}/scripts/migrate-bugs-to-tickets.mjs"
+  grep -q 'mode'     "${PROJECT_DIR}/scripts/migrate-bugs-to-tickets.mjs"
+}
+
+@test "static: script syntax is valid (node --check)" {
+  node --check "${PROJECT_DIR}/scripts/migrate-bugs-to-tickets.mjs"
+}
+
+# ── Runtime tests (require live DB) ──────────────────────────────
+
+db_available() {
+  psql "$PGURL" -c "SELECT 1" >/dev/null 2>&1
+}
+
+@test "runtime: every bugs.bug_tickets row produces one tickets.tickets row" {
+  if ! db_available; then skip "No database available (set TRACKING_DB_URL)"; fi
+  before=$(psql "$PGURL" -t -A -c "SELECT count(*) FROM bugs.bug_tickets")
+  node "${PROJECT_DIR}/scripts/migrate-bugs-to-tickets.mjs" --apply >/dev/null
+  after=$(psql "$PGURL" -t -A -c "SELECT count(*) FROM tickets.tickets WHERE type='bug'")
+  [ "$before" = "$after" ]
+}
+
+@test "runtime: status mapping is correct (open->triage, resolved->done+fixed)" {
+  if ! db_available; then skip "No database available (set TRACKING_DB_URL)"; fi
+  open_count=$(psql "$PGURL" -t -A -c "SELECT count(*) FROM bugs.bug_tickets WHERE status='open'")
+  triage_count=$(psql "$PGURL" -t -A -c "SELECT count(*) FROM tickets.tickets WHERE type='bug' AND status='triage'")
+  [ "$open_count" = "$triage_count" ]
+  resolved_count=$(psql "$PGURL" -t -A -c "SELECT count(*) FROM bugs.bug_tickets WHERE status='resolved'")
+  done_fixed_count=$(psql "$PGURL" -t -A -c "SELECT count(*) FROM tickets.tickets WHERE type='bug' AND status='done' AND resolution='fixed'")
+  [ "$resolved_count" = "$done_fixed_count" ]
+}
+
+@test "runtime: archived rows map to status=archived resolution=fixed" {
+  if ! db_available; then skip "No database available (set TRACKING_DB_URL)"; fi
+  archived_count=$(psql "$PGURL" -t -A -c "SELECT count(*) FROM bugs.bug_tickets WHERE status='archived'")
+  mapped_count=$(psql "$PGURL" -t -A -c "SELECT count(*) FROM tickets.tickets WHERE type='bug' AND status='archived' AND resolution='fixed'")
+  [ "$archived_count" = "$mapped_count" ]
+}
+
+@test "runtime: category tags are created (kind:bug for fehler rows)" {
+  if ! db_available; then skip "No database available (set TRACKING_DB_URL)"; fi
+  fehler_count=$(psql "$PGURL" -t -A -c "SELECT count(*) FROM bugs.bug_tickets WHERE category='fehler'")
+  if [ "$fehler_count" = "0" ]; then skip "No fehler rows in bugs.bug_tickets"; fi
+  tag_count=$(psql "$PGURL" -t -A -c "
+    SELECT count(DISTINCT tt.ticket_id)
+      FROM tickets.ticket_tags tt
+      JOIN tickets.tags tg ON tg.id = tt.tag_id
+      JOIN tickets.tickets t ON t.id = tt.ticket_id
+     WHERE tg.name = 'kind:bug' AND t.type = 'bug'")
+  [ "$tag_count" = "$fehler_count" ]
+}
+
+@test "runtime: resolution_note rows produce a status_change comment" {
+  if ! db_available; then skip "No database available (set TRACKING_DB_URL)"; fi
+  with_note=$(psql "$PGURL" -t -A -c "SELECT count(*) FROM bugs.bug_tickets WHERE resolution_note IS NOT NULL AND resolution_note <> ''")
+  if [ "$with_note" = "0" ]; then skip "No rows with resolution_note in bugs.bug_tickets"; fi
+  comment_count=$(psql "$PGURL" -t -A -c "
+    SELECT count(*) FROM tickets.ticket_comments
+     WHERE kind='status_change' AND author_label='migration'")
+  [ "$comment_count" = "$with_note" ]
+}
+
+@test "runtime: idempotent — second run does not duplicate tickets" {
+  if ! db_available; then skip "No database available (set TRACKING_DB_URL)"; fi
+  before=$(psql "$PGURL" -t -A -c "SELECT count(*) FROM tickets.tickets WHERE type='bug'")
+  node "${PROJECT_DIR}/scripts/migrate-bugs-to-tickets.mjs" --apply >/dev/null
+  after=$(psql "$PGURL" -t -A -c "SELECT count(*) FROM tickets.tickets WHERE type='bug'")
+  [ "$before" = "$after" ]
+}
+
+@test "runtime: idempotent — second run reports all rows as skipped" {
+  if ! db_available; then skip "No database available (set TRACKING_DB_URL)"; fi
+  total=$(psql "$PGURL" -t -A -c "SELECT count(*) FROM bugs.bug_tickets")
+  output=$(node "${PROJECT_DIR}/scripts/migrate-bugs-to-tickets.mjs" --apply 2>&1)
+  skipped=$(echo "$output" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d['skipped'])" 2>/dev/null)
+  [ "$skipped" = "$total" ]
+}
+
+@test "runtime: dry-run (default) makes no changes to tickets table" {
+  if ! db_available; then skip "No database available (set TRACKING_DB_URL)"; fi
+  before=$(psql "$PGURL" -t -A -c "SELECT count(*) FROM tickets.tickets WHERE type='bug'")
+  node "${PROJECT_DIR}/scripts/migrate-bugs-to-tickets.mjs" >/dev/null
+  after=$(psql "$PGURL" -t -A -c "SELECT count(*) FROM tickets.tickets WHERE type='bug'")
+  [ "$before" = "$after" ]
+}
+
+@test "runtime: dry-run output JSON has mode=dry-run" {
+  if ! db_available; then skip "No database available (set TRACKING_DB_URL)"; fi
+  output=$(node "${PROJECT_DIR}/scripts/migrate-bugs-to-tickets.mjs" 2>&1)
+  echo "$output" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+assert d['mode'] == 'dry-run', f'expected dry-run, got {d[\"mode\"]}'
+print('OK')
+"
+}

--- a/tests/unit/tickets-migration.bats
+++ b/tests/unit/tickets-migration.bats
@@ -196,3 +196,39 @@ print('OK')
   grep -q 'ticket_links' "${PROJECT_DIR}/scripts/migrate-bugs-to-tickets.mjs"
   grep -q "kind='fixes'" "${PROJECT_DIR}/scripts/migrate-bugs-to-tickets.mjs"
 }
+
+@test "static: view-creation block is guarded by !dryRun" {
+  grep -q 'CREATE OR REPLACE VIEW bugs.bug_tickets' "${PROJECT_DIR}/scripts/migrate-bugs-to-tickets.mjs"
+  grep -q 'pg_tables' "${PROJECT_DIR}/scripts/migrate-bugs-to-tickets.mjs"
+  grep -q 'bug_tickets_legacy' "${PROJECT_DIR}/scripts/migrate-bugs-to-tickets.mjs"
+}
+
+@test "runtime: bugs.bug_tickets is a view after migration" {
+  if ! psql "$PGURL" -c "SELECT 1" >/dev/null 2>&1; then skip "No database available"; fi
+  node "${PROJECT_DIR}/scripts/migrate-bugs-to-tickets.mjs" --apply >/dev/null
+  result=$(psql "$PGURL" -t -A -c "
+    SELECT relkind FROM pg_class
+     WHERE relname='bug_tickets' AND relnamespace=(SELECT oid FROM pg_namespace WHERE nspname='bugs')")
+  # 'r' = ordinary table, 'v' = view, 'm' = materialized view
+  [ "$result" = "v" ]
+}
+
+@test "runtime: legacy fixed_in_pr JOIN still works against the view" {
+  if ! psql "$PGURL" -c "SELECT 1" >/dev/null 2>&1; then skip "No database available"; fi
+  # The query mirrors the one in website/src/lib/website-db.ts line 88-91
+  psql "$PGURL" -c "
+    SELECT fixed_in_pr AS pr, COUNT(*)::int AS n
+      FROM bugs.bug_tickets
+     WHERE fixed_in_pr = ANY('{1,2,3,99999}'::int[])
+     GROUP BY fixed_in_pr" >/dev/null
+}
+
+@test "runtime: re-running migration is idempotent (view not corrupted)" {
+  if ! psql "$PGURL" -c "SELECT 1" >/dev/null 2>&1; then skip "No database available"; fi
+  node "${PROJECT_DIR}/scripts/migrate-bugs-to-tickets.mjs" --apply >/dev/null
+  node "${PROJECT_DIR}/scripts/migrate-bugs-to-tickets.mjs" --apply >/dev/null
+  result=$(psql "$PGURL" -t -A -c "
+    SELECT relkind FROM pg_class
+     WHERE relname='bug_tickets' AND relnamespace=(SELECT oid FROM pg_namespace WHERE nspname='bugs')")
+  [ "$result" = "v" ]
+}

--- a/tests/unit/tickets-migration.bats
+++ b/tests/unit/tickets-migration.bats
@@ -168,3 +168,31 @@ assert d['mode'] == 'dry-run', f'expected dry-run, got {d[\"mode\"]}'
 print('OK')
 "
 }
+
+@test "runtime: comments are copied" {
+  if ! psql "$PGURL" -c "SELECT 1" >/dev/null 2>&1; then skip "No database available"; fi
+  node "${PROJECT_DIR}/scripts/migrate-bugs-to-tickets.mjs" --apply >/dev/null
+  expected=$(psql "$PGURL" -t -A -c "SELECT count(*) FROM bugs.bug_ticket_comments")
+  actual=$(psql "$PGURL" -t -A -c "
+    SELECT count(*) FROM tickets.ticket_comments tc
+    JOIN tickets.tickets t ON t.id = tc.ticket_id
+    WHERE t.type = 'bug' AND tc.kind <> 'system' AND tc.author_label <> 'migration'")
+  [ "$actual" -ge "$expected" ]
+}
+
+@test "runtime: fixed_in_pr → ticket_links" {
+  if ! psql "$PGURL" -c "SELECT 1" >/dev/null 2>&1; then skip "No database available"; fi
+  node "${PROJECT_DIR}/scripts/migrate-bugs-to-tickets.mjs" --apply >/dev/null
+  expected=$(psql "$PGURL" -t -A -c "SELECT count(*) FROM bugs.bug_tickets WHERE fixed_in_pr IS NOT NULL")
+  actual=$(psql "$PGURL" -t -A -c "
+    SELECT count(*) FROM tickets.ticket_links WHERE kind='fixes' AND pr_number IS NOT NULL")
+  [ "$actual" = "$expected" ]
+}
+
+@test "static: extension blocks present (comments + screenshots + fixed_in_pr)" {
+  grep -q 'bug_ticket_comments' "${PROJECT_DIR}/scripts/migrate-bugs-to-tickets.mjs"
+  grep -q 'screenshots_json' "${PROJECT_DIR}/scripts/migrate-bugs-to-tickets.mjs"
+  grep -q 'ticket_attachments' "${PROJECT_DIR}/scripts/migrate-bugs-to-tickets.mjs"
+  grep -q 'ticket_links' "${PROJECT_DIR}/scripts/migrate-bugs-to-tickets.mjs"
+  grep -q "kind='fixes'" "${PROJECT_DIR}/scripts/migrate-bugs-to-tickets.mjs"
+}

--- a/tests/unit/tickets-reporter-link.bats
+++ b/tests/unit/tickets-reporter-link.bats
@@ -1,0 +1,167 @@
+#!/usr/bin/env bats
+# ═══════════════════════════════════════════════════════════════════
+# tickets-reporter-link.bats — Unit/integration tests for
+#   website/src/lib/tickets/reporter-link.ts
+# ═══════════════════════════════════════════════════════════════════
+# Runtime tests (linkReporterByEmail, linkAllReporters) require a live
+# PostgreSQL database with the `customers` and `tickets.tickets` tables.
+#
+# Set TRACKING_DB_URL (or SESSIONS_DATABASE_URL) to your website DB URL.
+# Default fallback: postgres://postgres:postgres@localhost:5432/website
+#
+# TypeScript is executed via `npx tsx` (tsx is not bundled in the
+# project's devDependencies; npx will download it on demand or use the
+# locally cached version). If running offline, set TSX_BIN to a local
+# path, e.g.: TSX_BIN=/usr/local/bin/tsx bats tests/unit/tickets-reporter-link.bats
+# ═══════════════════════════════════════════════════════════════════
+
+load test_helper
+
+PROJECT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+TSX_BIN="${TSX_BIN:-npx tsx}"
+
+setup() {
+  PGURL="${TRACKING_DB_URL:-${SESSIONS_DATABASE_URL:-postgres://postgres:postgres@localhost:5432/website}}"
+  export PGURL
+  export PROJECT_DIR
+}
+
+# ── Helper ────────────────────────────────────────────────────────
+
+# Returns 0 if psql can reach the target DB, 1 otherwise.
+db_available() {
+  psql "$PGURL" -c "SELECT 1" >/dev/null 2>&1
+}
+
+# ── Static checks (no DB required) ───────────────────────────────
+
+@test "reporter-link.ts file exists" {
+  [ -f "${PROJECT_DIR}/website/src/lib/tickets/reporter-link.ts" ]
+}
+
+@test "reporter-link.ts exports linkReporterByEmail" {
+  grep -q "export async function linkReporterByEmail" \
+    "${PROJECT_DIR}/website/src/lib/tickets/reporter-link.ts"
+}
+
+@test "reporter-link.ts exports linkAllReporters" {
+  grep -q "export async function linkAllReporters" \
+    "${PROJECT_DIR}/website/src/lib/tickets/reporter-link.ts"
+}
+
+@test "linkReporterByEmail uses parameterized query (no string interpolation)" {
+  # Ensure SQL uses $1 placeholder, not template literals, for the email value.
+  grep -q '\$1' "${PROJECT_DIR}/website/src/lib/tickets/reporter-link.ts"
+}
+
+@test "both functions check reporter_id IS NULL (idempotency guard)" {
+  # Match only the SQL clause form (t.reporter_id IS NULL) to avoid counting the JSDoc comment.
+  count=$(grep -c "t\.reporter_id IS NULL" "${PROJECT_DIR}/website/src/lib/tickets/reporter-link.ts")
+  [ "$count" -eq 2 ]
+}
+
+@test "both functions filter on keycloak_user_id IS NOT NULL" {
+  count=$(grep -c "keycloak_user_id IS NOT NULL" "${PROJECT_DIR}/website/src/lib/tickets/reporter-link.ts")
+  [ "$count" -eq 2 ]
+}
+
+# ── Runtime tests (require live DB) ──────────────────────────────
+
+@test "linkReporterByEmail sets reporter_id when email matches a keycloak-linked customer" {
+  if ! db_available; then
+    skip "No database available (set TRACKING_DB_URL)"
+  fi
+
+  psql "$PGURL" >/dev/null <<SQL
+    INSERT INTO customers (id, name, email, keycloak_user_id)
+      VALUES ('11111111-1111-1111-1111-111111111111', 'Test User', 'link-test@example.com', 'kc-1')
+      ON CONFLICT (email) DO UPDATE SET keycloak_user_id = EXCLUDED.keycloak_user_id;
+    DELETE FROM tickets.tickets WHERE id = '22222222-2222-2222-2222-222222222222';
+    INSERT INTO tickets.tickets (id, type, brand, title, reporter_email)
+      VALUES ('22222222-2222-2222-2222-222222222222', 'bug', 'mentolder', 'T', 'link-test@example.com');
+SQL
+
+  SESSIONS_DATABASE_URL="$PGURL" $TSX_BIN -e "
+    import { linkReporterByEmail } from '${PROJECT_DIR}/website/src/lib/tickets/reporter-link.ts';
+    linkReporterByEmail('link-test@example.com').then(() => process.exit(0));
+  "
+
+  result=$(psql "$PGURL" -t -A -c \
+    "SELECT reporter_id::text FROM tickets.tickets WHERE id='22222222-2222-2222-2222-222222222222'")
+  [ "$result" = "11111111-1111-1111-1111-111111111111" ]
+
+  # Cleanup
+  psql "$PGURL" -c "DELETE FROM tickets.tickets WHERE id='22222222-2222-2222-2222-222222222222'" >/dev/null
+}
+
+@test "linkReporterByEmail returns 0 when email matches no customer" {
+  if ! db_available; then
+    skip "No database available (set TRACKING_DB_URL)"
+  fi
+
+  result=$(SESSIONS_DATABASE_URL="$PGURL" $TSX_BIN -e "
+    import { linkReporterByEmail } from '${PROJECT_DIR}/website/src/lib/tickets/reporter-link.ts';
+    linkReporterByEmail('does-not-exist-${RANDOM}@example.com').then(n => { console.log(n); process.exit(0); });
+  ")
+  [ "$result" = "0" ]
+}
+
+@test "linkAllReporters links unlinked tickets in batch" {
+  if ! db_available; then
+    skip "No database available (set TRACKING_DB_URL)"
+  fi
+
+  psql "$PGURL" >/dev/null <<SQL
+    INSERT INTO customers (id, name, email, keycloak_user_id)
+      VALUES ('33333333-3333-3333-3333-333333333333', 'Batch User', 'batch-test@example.com', 'kc-batch')
+      ON CONFLICT (email) DO UPDATE SET keycloak_user_id = EXCLUDED.keycloak_user_id;
+    DELETE FROM tickets.tickets WHERE id = '44444444-4444-4444-4444-444444444444';
+    INSERT INTO tickets.tickets (id, type, brand, title, reporter_email)
+      VALUES ('44444444-4444-4444-4444-444444444444', 'bug', 'mentolder', 'Batch T', 'batch-test@example.com');
+SQL
+
+  linked=$(SESSIONS_DATABASE_URL="$PGURL" $TSX_BIN -e "
+    import { linkAllReporters } from '${PROJECT_DIR}/website/src/lib/tickets/reporter-link.ts';
+    linkAllReporters().then(n => { console.log(n); process.exit(0); });
+  ")
+  # At least one row must have been linked
+  [ "$linked" -ge 1 ]
+
+  result=$(psql "$PGURL" -t -A -c \
+    "SELECT reporter_id::text FROM tickets.tickets WHERE id='44444444-4444-4444-4444-444444444444'")
+  [ "$result" = "33333333-3333-3333-3333-333333333333" ]
+
+  # Cleanup
+  psql "$PGURL" -c "DELETE FROM tickets.tickets WHERE id='44444444-4444-4444-4444-444444444444'" >/dev/null
+}
+
+@test "linkReporterByEmail is idempotent (second call returns 0)" {
+  if ! db_available; then
+    skip "No database available (set TRACKING_DB_URL)"
+  fi
+
+  psql "$PGURL" >/dev/null <<SQL
+    INSERT INTO customers (id, name, email, keycloak_user_id)
+      VALUES ('55555555-5555-5555-5555-555555555555', 'Idem User', 'idem-test@example.com', 'kc-idem')
+      ON CONFLICT (email) DO UPDATE SET keycloak_user_id = EXCLUDED.keycloak_user_id;
+    DELETE FROM tickets.tickets WHERE id = '66666666-6666-6666-6666-666666666666';
+    INSERT INTO tickets.tickets (id, type, brand, title, reporter_email)
+      VALUES ('66666666-6666-6666-6666-666666666666', 'bug', 'mentolder', 'Idem T', 'idem-test@example.com');
+SQL
+
+  # First call links the row
+  SESSIONS_DATABASE_URL="$PGURL" $TSX_BIN -e "
+    import { linkReporterByEmail } from '${PROJECT_DIR}/website/src/lib/tickets/reporter-link.ts';
+    linkReporterByEmail('idem-test@example.com').then(() => process.exit(0));
+  "
+
+  # Second call must return 0 (already linked, reporter_id IS NULL guard fires)
+  second=$(SESSIONS_DATABASE_URL="$PGURL" $TSX_BIN -e "
+    import { linkReporterByEmail } from '${PROJECT_DIR}/website/src/lib/tickets/reporter-link.ts';
+    linkReporterByEmail('idem-test@example.com').then(n => { console.log(n); process.exit(0); });
+  ")
+  [ "$second" = "0" ]
+
+  # Cleanup
+  psql "$PGURL" -c "DELETE FROM tickets.tickets WHERE id='66666666-6666-6666-6666-666666666666'" >/dev/null
+}

--- a/tests/unit/tickets-reporter-link.bats
+++ b/tests/unit/tickets-reporter-link.bats
@@ -24,6 +24,34 @@ setup() {
   PGURL="${TRACKING_DB_URL:-${SESSIONS_DATABASE_URL:-postgres://postgres:postgres@localhost:5432/website}}"
   export PGURL
   export PROJECT_DIR
+
+  # Safety guard: refuse to run against production databases.
+  case "$PGURL" in
+    *mentolder*|*korczewski*)
+      echo "TRACKING_DB_URL points to a production host ($PGURL). Aborting to protect live data." >&2
+      exit 1
+      ;;
+  esac
+}
+
+teardown() {
+  # Remove fixture customer rows inserted by runtime tests.
+  # Ticket rows are cleaned up inline; we only need the customers here.
+  # This also covers the case where a test aborted mid-run and left rows behind.
+  if db_available 2>/dev/null; then
+    psql "$PGURL" >/dev/null 2>&1 <<SQL
+      DELETE FROM customers WHERE id IN (
+        '11111111-1111-1111-1111-111111111111',
+        '33333333-3333-3333-3333-333333333333',
+        '55555555-5555-5555-5555-555555555555'
+      );
+      DELETE FROM tickets.tickets WHERE id IN (
+        '22222222-2222-2222-2222-222222222222',
+        '44444444-4444-4444-4444-444444444444',
+        '66666666-6666-6666-6666-666666666666'
+      );
+SQL
+  fi
 }
 
 # ── Helper ────────────────────────────────────────────────────────

--- a/tests/unit/tickets-transition.bats
+++ b/tests/unit/tickets-transition.bats
@@ -1,0 +1,336 @@
+#!/usr/bin/env bats
+# ═══════════════════════════════════════════════════════════════════
+# tickets-transition.bats — Unit/integration tests for
+#   website/src/lib/tickets/transition.ts
+# ═══════════════════════════════════════════════════════════════════
+# Runtime tests require a live PostgreSQL database with the tickets
+# schema already applied (run initTicketsSchema() once).
+#
+# Set TRACKING_DB_URL (or SESSIONS_DATABASE_URL) to your website DB URL.
+# Default fallback: postgres://postgres:postgres@localhost:5432/website
+#
+# TypeScript is executed via `npx tsx`. If running offline set TSX_BIN
+# to a local path, e.g.: TSX_BIN=/usr/local/bin/tsx bats tests/unit/tickets-transition.bats
+# ═══════════════════════════════════════════════════════════════════
+
+load test_helper
+
+PROJECT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+TSX_BIN="${TSX_BIN:-npx tsx}"
+
+setup() {
+  PGURL="${TRACKING_DB_URL:-${SESSIONS_DATABASE_URL:-postgres://postgres:postgres@localhost:5432/website}}"
+  export PGURL
+  export PROJECT_DIR
+
+  # Safety guard: refuse to run against production databases.
+  case "$PGURL" in
+    *mentolder*|*korczewski*)
+      echo "TRACKING_DB_URL points to a production host ($PGURL). Aborting to protect live data." >&2
+      exit 1
+      ;;
+  esac
+
+  export TICKET_ID="33333333-3333-3333-3333-333333333333"
+}
+
+teardown() {
+  if psql "$PGURL" -c "SELECT 1" >/dev/null 2>&1; then
+    psql "$PGURL" >/dev/null 2>&1 <<SQL || true
+      DELETE FROM tickets.ticket_links  WHERE from_id = '$TICKET_ID';
+      DELETE FROM tickets.ticket_comments WHERE ticket_id = '$TICKET_ID';
+      DELETE FROM tickets.ticket_activity WHERE ticket_id = '$TICKET_ID';
+      DELETE FROM tickets.tickets WHERE id = '$TICKET_ID';
+SQL
+  fi
+}
+
+# ── Helper ────────────────────────────────────────────────────────
+
+db_available() {
+  psql "$PGURL" -c "SELECT 1" >/dev/null 2>&1
+}
+
+seed_ticket() {
+  local status="${1:-triage}"
+  psql "$PGURL" >/dev/null <<SQL
+    DELETE FROM tickets.ticket_links  WHERE from_id = '$TICKET_ID';
+    DELETE FROM tickets.ticket_comments WHERE ticket_id = '$TICKET_ID';
+    DELETE FROM tickets.ticket_activity WHERE ticket_id = '$TICKET_ID';
+    DELETE FROM tickets.tickets WHERE id = '$TICKET_ID';
+    INSERT INTO tickets.tickets (id, type, brand, title, status, reporter_email, external_id)
+      VALUES ('$TICKET_ID', 'bug', 'mentolder', 'Transition Test', '$status',
+              'rep-test@example.com', 'BR-19990101-0001');
+SQL
+}
+
+# ── Static checks (no DB required) ───────────────────────────────
+
+@test "static: transition.ts file exists" {
+  [ -f "${PROJECT_DIR}/website/src/lib/tickets/transition.ts" ]
+}
+
+@test "static: exports transitionTicket" {
+  grep -q 'export async function transitionTicket' \
+    "${PROJECT_DIR}/website/src/lib/tickets/transition.ts"
+}
+
+@test "static: exports TicketStatus type" {
+  grep -q 'export type TicketStatus' \
+    "${PROJECT_DIR}/website/src/lib/tickets/transition.ts"
+}
+
+@test "static: exports TicketResolution type" {
+  grep -q 'export type TicketResolution' \
+    "${PROJECT_DIR}/website/src/lib/tickets/transition.ts"
+}
+
+@test "static: exports TransitionResult interface" {
+  grep -q 'export interface TransitionResult' \
+    "${PROJECT_DIR}/website/src/lib/tickets/transition.ts"
+}
+
+@test "static: rejects done without resolution at validation level" {
+  grep -q 'requires a resolution' \
+    "${PROJECT_DIR}/website/src/lib/tickets/transition.ts"
+}
+
+@test "static: uses pool.connect() not bare pool.query for transaction" {
+  grep -q 'pool\.connect()' \
+    "${PROJECT_DIR}/website/src/lib/tickets/transition.ts"
+}
+
+@test "static: BEGIN/COMMIT/ROLLBACK transaction flow present" {
+  grep -q "BEGIN"    "${PROJECT_DIR}/website/src/lib/tickets/transition.ts"
+  grep -q "COMMIT"   "${PROJECT_DIR}/website/src/lib/tickets/transition.ts"
+  grep -q "ROLLBACK" "${PROJECT_DIR}/website/src/lib/tickets/transition.ts"
+}
+
+@test "static: sets app.user_label session config" {
+  grep -q "app.user_label" \
+    "${PROJECT_DIR}/website/src/lib/tickets/transition.ts"
+}
+
+@test "static: sets app.user_id session config" {
+  grep -q "app.user_id" \
+    "${PROJECT_DIR}/website/src/lib/tickets/transition.ts"
+}
+
+@test "static: calls linkReporterByEmail before sendBugCloseEmail" {
+  local file="${PROJECT_DIR}/website/src/lib/tickets/transition.ts"
+  local link_line close_line
+  # Skip import lines; look for the actual await call sites.
+  link_line=$(grep -n 'await linkReporterByEmail' "$file" | head -1 | cut -d: -f1)
+  close_line=$(grep -n 'await sendBugCloseEmail' "$file" | head -1 | cut -d: -f1)
+  [ -n "$link_line" ]
+  [ -n "$close_line" ]
+  [ "$link_line" -lt "$close_line" ]
+}
+
+@test "static: email only sent when noteVisibility is public (public note guard)" {
+  grep -q "noteVisibility === 'public'" \
+    "${PROJECT_DIR}/website/src/lib/tickets/transition.ts"
+}
+
+@test "static: becomingDone guard checks before.status !== done" {
+  grep -q "before.status !== 'done'" \
+    "${PROJECT_DIR}/website/src/lib/tickets/transition.ts"
+}
+
+# ── Runtime: validation errors (no DB needed) ─────────────────────
+
+@test "runtime: rejects unknown status" {
+  output=$(SESSIONS_DATABASE_URL="$PGURL" $TSX_BIN -e "
+    import { transitionTicket } from '${PROJECT_DIR}/website/src/lib/tickets/transition.ts';
+    transitionTicket('00000000-0000-0000-0000-000000000000', { status: 'banana' as any, actor: { label: 'test' } })
+      .then(() => console.log('OK'))
+      .catch(e => console.log('ERR:' + e.message));
+  " 2>&1)
+  [[ "$output" == *"ERR:"*"invalid status"* ]]
+}
+
+@test "runtime: rejects done without resolution" {
+  output=$(SESSIONS_DATABASE_URL="$PGURL" $TSX_BIN -e "
+    import { transitionTicket } from '${PROJECT_DIR}/website/src/lib/tickets/transition.ts';
+    transitionTicket('00000000-0000-0000-0000-000000000000', { status: 'done', actor: { label: 'test' } })
+      .then(() => console.log('OK'))
+      .catch(e => console.log('ERR:' + e.message));
+  " 2>&1)
+  [[ "$output" == *"ERR:"*"resolution"* ]]
+}
+
+@test "runtime: rejects archived without resolution" {
+  output=$(SESSIONS_DATABASE_URL="$PGURL" $TSX_BIN -e "
+    import { transitionTicket } from '${PROJECT_DIR}/website/src/lib/tickets/transition.ts';
+    transitionTicket('00000000-0000-0000-0000-000000000000', { status: 'archived', actor: { label: 'test' } })
+      .then(() => console.log('OK'))
+      .catch(e => console.log('ERR:' + e.message));
+  " 2>&1)
+  [[ "$output" == *"ERR:"*"resolution"* ]]
+}
+
+@test "runtime: rejects unknown resolution" {
+  output=$(SESSIONS_DATABASE_URL="$PGURL" $TSX_BIN -e "
+    import { transitionTicket } from '${PROJECT_DIR}/website/src/lib/tickets/transition.ts';
+    transitionTicket('00000000-0000-0000-0000-000000000000', { status: 'done', resolution: 'banana' as any, actor: { label: 'test' } })
+      .then(() => console.log('OK'))
+      .catch(e => console.log('ERR:' + e.message));
+  " 2>&1)
+  [[ "$output" == *"ERR:"*"invalid resolution"* ]]
+}
+
+# ── Runtime: DB-required tests ───────────────────────────────────
+
+@test "runtime: triage -> done sets resolution and done_at" {
+  if ! db_available; then skip "No database available (set TRACKING_DB_URL)"; fi
+  seed_ticket "triage"
+
+  SESSIONS_DATABASE_URL="$PGURL" $TSX_BIN -e "
+    import { transitionTicket } from '${PROJECT_DIR}/website/src/lib/tickets/transition.ts';
+    transitionTicket('$TICKET_ID', { status: 'done', resolution: 'fixed', actor: { label: 'test' } })
+      .then(r => { console.log(JSON.stringify(r)); process.exit(0); })
+      .catch(e => { console.error(e.message); process.exit(1); });
+  "
+
+  result=$(psql "$PGURL" -t -A -c \
+    "SELECT status||','||resolution||','||CASE WHEN done_at IS NULL THEN 'null' ELSE 'set' END
+       FROM tickets.tickets WHERE id='$TICKET_ID'")
+  [ "$result" = "done,fixed,set" ]
+}
+
+@test "runtime: triage -> backlog -> in_progress sets started_at" {
+  if ! db_available; then skip "No database available (set TRACKING_DB_URL)"; fi
+  seed_ticket "backlog"
+
+  SESSIONS_DATABASE_URL="$PGURL" $TSX_BIN -e "
+    import { transitionTicket } from '${PROJECT_DIR}/website/src/lib/tickets/transition.ts';
+    transitionTicket('$TICKET_ID', { status: 'in_progress', actor: { label: 'test' } })
+      .then(() => process.exit(0))
+      .catch(e => { console.error(e.message); process.exit(1); });
+  "
+
+  result=$(psql "$PGURL" -t -A -c \
+    "SELECT CASE WHEN started_at IS NULL THEN 'null' ELSE 'set' END
+       FROM tickets.tickets WHERE id='$TICKET_ID'")
+  [ "$result" = "set" ]
+}
+
+@test "runtime: note is inserted as status_change comment" {
+  if ! db_available; then skip "No database available (set TRACKING_DB_URL)"; fi
+  seed_ticket "triage"
+
+  SESSIONS_DATABASE_URL="$PGURL" $TSX_BIN -e "
+    import { transitionTicket } from '${PROJECT_DIR}/website/src/lib/tickets/transition.ts';
+    transitionTicket('$TICKET_ID', {
+      status: 'done',
+      resolution: 'fixed',
+      note: 'shipped in v1.2',
+      noteVisibility: 'internal',
+      actor: { label: 'admin' }
+    }).then(() => process.exit(0)).catch(e => { console.error(e.message); process.exit(1); });
+  "
+
+  count=$(psql "$PGURL" -t -A -c \
+    "SELECT COUNT(*) FROM tickets.ticket_comments
+       WHERE ticket_id='$TICKET_ID' AND kind='status_change' AND body='shipped in v1.2'")
+  [ "$count" = "1" ]
+}
+
+@test "runtime: prNumber creates ticket_links row" {
+  if ! db_available; then skip "No database available (set TRACKING_DB_URL)"; fi
+  seed_ticket "in_review"
+
+  SESSIONS_DATABASE_URL="$PGURL" $TSX_BIN -e "
+    import { transitionTicket } from '${PROJECT_DIR}/website/src/lib/tickets/transition.ts';
+    transitionTicket('$TICKET_ID', {
+      status: 'done',
+      resolution: 'shipped',
+      prNumber: 42,
+      actor: { label: 'ci' }
+    }).then(() => process.exit(0)).catch(e => { console.error(e.message); process.exit(1); });
+  "
+
+  count=$(psql "$PGURL" -t -A -c \
+    "SELECT COUNT(*) FROM tickets.ticket_links
+       WHERE from_id='$TICKET_ID' AND kind='fixes' AND pr_number=42")
+  [ "$count" = "1" ]
+}
+
+@test "runtime: prNumber link is idempotent (second call is no-op)" {
+  if ! db_available; then skip "No database available (set TRACKING_DB_URL)"; fi
+  seed_ticket "in_review"
+
+  for _i in 1 2; do
+    SESSIONS_DATABASE_URL="$PGURL" $TSX_BIN -e "
+      import { transitionTicket } from '${PROJECT_DIR}/website/src/lib/tickets/transition.ts';
+      transitionTicket('$TICKET_ID', {
+        status: 'done',
+        resolution: 'shipped',
+        prNumber: 99,
+        actor: { label: 'ci' }
+      }).then(() => process.exit(0)).catch(e => { console.error(e.message); process.exit(1); });
+    "
+    # Re-seed to done so second call can re-enter (already done -> done is fine)
+  done
+
+  count=$(psql "$PGURL" -t -A -c \
+    "SELECT COUNT(*) FROM tickets.ticket_links
+       WHERE from_id='$TICKET_ID' AND kind='fixes' AND pr_number=99")
+  [ "$count" = "1" ]
+}
+
+@test "runtime: ticket not found throws error" {
+  if ! db_available; then skip "No database available (set TRACKING_DB_URL)"; fi
+
+  output=$(SESSIONS_DATABASE_URL="$PGURL" $TSX_BIN -e "
+    import { transitionTicket } from '${PROJECT_DIR}/website/src/lib/tickets/transition.ts';
+    transitionTicket('ffffffff-ffff-ffff-ffff-ffffffffffff', { status: 'backlog', actor: { label: 'test' } })
+      .then(() => console.log('OK'))
+      .catch(e => console.log('ERR:' + e.message));
+  " 2>&1)
+  [[ "$output" == *"ERR:"*"not found"* ]]
+}
+
+@test "runtime: audit log entry created on transition" {
+  if ! db_available; then skip "No database available (set TRACKING_DB_URL)"; fi
+  seed_ticket "triage"
+
+  SESSIONS_DATABASE_URL="$PGURL" $TSX_BIN -e "
+    import { transitionTicket } from '${PROJECT_DIR}/website/src/lib/tickets/transition.ts';
+    transitionTicket('$TICKET_ID', {
+      status: 'backlog',
+      actor: { label: 'reviewer' }
+    }).then(() => process.exit(0)).catch(e => { console.error(e.message); process.exit(1); });
+  "
+
+  count=$(psql "$PGURL" -t -A -c \
+    "SELECT COUNT(*) FROM tickets.ticket_activity
+       WHERE ticket_id='$TICKET_ID' AND field='_updated'")
+  [ "$count" -ge 1 ]
+}
+
+@test "runtime: TransitionResult shape is correct" {
+  if ! db_available; then skip "No database available (set TRACKING_DB_URL)"; fi
+  seed_ticket "triage"
+
+  result=$(SESSIONS_DATABASE_URL="$PGURL" $TSX_BIN -e "
+    import { transitionTicket } from '${PROJECT_DIR}/website/src/lib/tickets/transition.ts';
+    transitionTicket('$TICKET_ID', { status: 'done', resolution: 'wontfix', actor: { label: 'test' } })
+      .then(r => console.log(JSON.stringify(r)))
+      .catch(e => { console.error(e.message); process.exit(1); });
+  " 2>&1)
+
+  echo "$result" | python3 -c "
+import json, sys
+r = json.load(sys.stdin)
+assert 'id' in r, 'missing id'
+assert 'externalId' in r, 'missing externalId'
+assert 'type' in r, 'missing type'
+assert 'status' in r, 'missing status'
+assert 'resolution' in r, 'missing resolution'
+assert 'emailSent' in r, 'missing emailSent'
+assert r['status'] == 'done', f'expected done, got {r[\"status\"]}'
+assert r['resolution'] == 'wontfix', f'expected wontfix, got {r[\"resolution\"]}'
+print('shape OK')
+"
+}

--- a/website/src/lib/email.ts
+++ b/website/src/lib/email.ts
@@ -33,6 +33,7 @@ interface SendEmailParams {
   text: string;
   html?: string;
   replyTo?: string;
+  bcc?: string;
   headers?: Record<string, string>;
   from?: string;
   attachments?: EmailAttachment[];
@@ -47,6 +48,7 @@ export async function sendEmail(params: SendEmailParams): Promise<boolean> {
       text: params.text,
       html: params.html,
       replyTo: params.replyTo,
+      bcc: params.bcc,
       headers: params.headers,
       attachments: params.attachments,
     });

--- a/website/src/lib/tickets-db.ts
+++ b/website/src/lib/tickets-db.ts
@@ -1,0 +1,154 @@
+// website/src/lib/tickets-db.ts
+import { pool } from './website-db';
+
+let schemaReady = false;
+
+export async function initTicketsSchema(): Promise<void> {
+  if (schemaReady) return;
+
+  await pool.query(`CREATE SCHEMA IF NOT EXISTS tickets AUTHORIZATION website`);
+
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS tickets.tickets (
+      id              UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+      external_id     TEXT        UNIQUE,
+      type            TEXT        NOT NULL CHECK (type IN ('bug','feature','task','project')),
+      parent_id       UUID        REFERENCES tickets.tickets(id) ON DELETE SET NULL,
+      brand           TEXT        NOT NULL,
+
+      title           TEXT        NOT NULL,
+      description     TEXT,
+      url             TEXT,
+      thesis_tag      TEXT,
+      component       TEXT,
+
+      status          TEXT        NOT NULL DEFAULT 'triage'
+                      CHECK (status IN ('triage','backlog','in_progress','in_review','blocked','done','archived')),
+      resolution      TEXT        CHECK (resolution IN
+                        ('fixed','shipped','wontfix','duplicate','cant_reproduce','obsolete')),
+      priority        TEXT        NOT NULL DEFAULT 'mittel'  CHECK (priority IN ('hoch','mittel','niedrig')),
+      severity        TEXT        CHECK (severity IN ('critical','major','minor','trivial')),
+
+      reporter_id     UUID        REFERENCES customers(id) ON DELETE SET NULL,
+      reporter_email  TEXT,
+      assignee_id     UUID        REFERENCES customers(id) ON DELETE SET NULL,
+      customer_id     UUID        REFERENCES customers(id) ON DELETE SET NULL,
+
+      start_date      DATE,
+      due_date        DATE,
+      estimate_minutes      INTEGER,
+      time_logged_minutes   INTEGER NOT NULL DEFAULT 0,
+
+      triaged_at      TIMESTAMPTZ,
+      started_at      TIMESTAMPTZ,
+      done_at         TIMESTAMPTZ,
+      archived_at     TIMESTAMPTZ,
+
+      created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+      updated_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+      CONSTRAINT resolution_only_when_closed CHECK (
+        (resolution IS NULL AND status NOT IN ('done','archived'))
+        OR status IN ('done','archived')
+      )
+    )
+  `);
+
+  await pool.query(`CREATE INDEX IF NOT EXISTS tickets_status_idx ON tickets.tickets (status) WHERE status NOT IN ('done','archived')`);
+  await pool.query(`CREATE INDEX IF NOT EXISTS tickets_type_brand_idx ON tickets.tickets (type, brand)`);
+  await pool.query(`CREATE INDEX IF NOT EXISTS tickets_parent_idx ON tickets.tickets (parent_id)`);
+  await pool.query(`CREATE INDEX IF NOT EXISTS tickets_assignee_idx ON tickets.tickets (assignee_id) WHERE assignee_id IS NOT NULL`);
+  await pool.query(`CREATE INDEX IF NOT EXISTS tickets_customer_idx ON tickets.tickets (customer_id) WHERE customer_id IS NOT NULL`);
+  await pool.query(`CREATE INDEX IF NOT EXISTS tickets_thesis_tag_idx ON tickets.tickets (thesis_tag) WHERE thesis_tag IS NOT NULL`);
+  await pool.query(`CREATE INDEX IF NOT EXISTS tickets_external_id_idx ON tickets.tickets (external_id)`);
+
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS tickets.ticket_links (
+      id          BIGSERIAL PRIMARY KEY,
+      from_id     UUID NOT NULL REFERENCES tickets.tickets(id) ON DELETE CASCADE,
+      to_id       UUID NOT NULL REFERENCES tickets.tickets(id) ON DELETE CASCADE,
+      kind        TEXT NOT NULL CHECK (kind IN ('blocks','blocked_by','duplicate_of','relates_to','fixes','fixed_by')),
+      pr_number   INTEGER,
+      created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+      created_by  UUID REFERENCES customers(id),
+      UNIQUE (from_id, to_id, kind)
+    )
+  `);
+  await pool.query(`CREATE INDEX IF NOT EXISTS ticket_links_from_idx ON tickets.ticket_links (from_id, kind)`);
+  await pool.query(`CREATE INDEX IF NOT EXISTS ticket_links_to_idx   ON tickets.ticket_links (to_id, kind)`);
+  await pool.query(`CREATE INDEX IF NOT EXISTS ticket_links_pr_idx   ON tickets.ticket_links (pr_number) WHERE pr_number IS NOT NULL`);
+
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS tickets.ticket_activity (
+      id          BIGSERIAL PRIMARY KEY,
+      ticket_id   UUID NOT NULL REFERENCES tickets.tickets(id) ON DELETE CASCADE,
+      actor_id    UUID REFERENCES customers(id),
+      actor_label TEXT,
+      field       TEXT NOT NULL,
+      old_value   JSONB,
+      new_value   JSONB,
+      created_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+    )
+  `);
+  await pool.query(`CREATE INDEX IF NOT EXISTS activity_ticket_idx ON tickets.ticket_activity (ticket_id, created_at)`);
+
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS tickets.ticket_comments (
+      id           BIGSERIAL PRIMARY KEY,
+      ticket_id    UUID NOT NULL REFERENCES tickets.tickets(id) ON DELETE CASCADE,
+      author_id    UUID REFERENCES customers(id),
+      author_label TEXT NOT NULL,
+      kind         TEXT NOT NULL DEFAULT 'comment'
+                   CHECK (kind IN ('comment','status_change','system')),
+      body         TEXT NOT NULL,
+      visibility   TEXT NOT NULL DEFAULT 'internal'
+                   CHECK (visibility IN ('internal','public')),
+      created_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+    )
+  `);
+  await pool.query(`CREATE INDEX IF NOT EXISTS ticket_comments_ticket_idx ON tickets.ticket_comments (ticket_id, created_at)`);
+
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS tickets.ticket_attachments (
+      id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      ticket_id   UUID NOT NULL REFERENCES tickets.tickets(id) ON DELETE CASCADE,
+      filename    TEXT NOT NULL,
+      nc_path     TEXT,
+      data_url    TEXT,
+      mime_type   TEXT NOT NULL DEFAULT 'application/octet-stream',
+      file_size   BIGINT,
+      uploaded_by UUID REFERENCES customers(id),
+      uploaded_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      CHECK (nc_path IS NOT NULL OR data_url IS NOT NULL)
+    )
+  `);
+  await pool.query(`CREATE INDEX IF NOT EXISTS ticket_attachments_ticket_idx ON tickets.ticket_attachments (ticket_id)`);
+
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS tickets.ticket_watchers (
+      ticket_id   UUID NOT NULL REFERENCES tickets.tickets(id) ON DELETE CASCADE,
+      user_id     UUID NOT NULL REFERENCES customers(id) ON DELETE CASCADE,
+      added_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+      PRIMARY KEY (ticket_id, user_id)
+    )
+  `);
+
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS tickets.tags (
+      id    UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      name  TEXT NOT NULL UNIQUE,
+      color TEXT,
+      brand TEXT
+    )
+  `);
+
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS tickets.ticket_tags (
+      ticket_id UUID NOT NULL REFERENCES tickets.tickets(id) ON DELETE CASCADE,
+      tag_id    UUID NOT NULL REFERENCES tickets.tags(id) ON DELETE CASCADE,
+      PRIMARY KEY (ticket_id, tag_id)
+    )
+  `);
+
+  schemaReady = true;
+}

--- a/website/src/lib/tickets-db.ts
+++ b/website/src/lib/tickets-db.ts
@@ -201,5 +201,50 @@ export async function initTicketsSchema(): Promise<void> {
       FOR EACH ROW EXECUTE FUNCTION tickets.fn_lifecycle_ts()
   `);
 
+  await pool.query(`
+    CREATE OR REPLACE FUNCTION tickets.fn_audit_log() RETURNS trigger AS $$
+    DECLARE
+      actor_id_local UUID;
+      actor_label_local TEXT;
+      diff JSONB := '{}'::jsonb;
+      tracked_field TEXT;
+    BEGIN
+      BEGIN actor_id_local := current_setting('app.user_id', true)::uuid;
+      EXCEPTION WHEN OTHERS THEN actor_id_local := NULL; END;
+      BEGIN actor_label_local := current_setting('app.user_label', true);
+      EXCEPTION WHEN OTHERS THEN actor_label_local := NULL; END;
+
+      IF TG_OP = 'INSERT' THEN
+        INSERT INTO tickets.ticket_activity (ticket_id, actor_id, actor_label, field, new_value)
+        VALUES (NEW.id, actor_id_local, actor_label_local, '_created', to_jsonb(NEW));
+        RETURN NEW;
+      END IF;
+
+      FOR tracked_field IN SELECT unnest(ARRAY[
+        'status','resolution','priority','severity','assignee_id','customer_id',
+        'reporter_id','reporter_email','title','description','url','component',
+        'thesis_tag','parent_id','start_date','due_date','estimate_minutes'
+      ]) LOOP
+        IF (to_jsonb(OLD) -> tracked_field) IS DISTINCT FROM (to_jsonb(NEW) -> tracked_field) THEN
+          diff := diff || jsonb_build_object(tracked_field,
+            jsonb_build_object('old', to_jsonb(OLD) -> tracked_field,
+                               'new', to_jsonb(NEW) -> tracked_field));
+        END IF;
+      END LOOP;
+
+      IF diff <> '{}'::jsonb THEN
+        INSERT INTO tickets.ticket_activity (ticket_id, actor_id, actor_label, field, old_value, new_value)
+        VALUES (NEW.id, actor_id_local, actor_label_local, '_updated', NULL, diff);
+      END IF;
+      RETURN NEW;
+    END $$ LANGUAGE plpgsql
+  `);
+  await pool.query(`DROP TRIGGER IF EXISTS trg_tickets_audit_log ON tickets.tickets`);
+  await pool.query(`
+    CREATE TRIGGER trg_tickets_audit_log
+      AFTER INSERT OR UPDATE ON tickets.tickets
+      FOR EACH ROW EXECUTE FUNCTION tickets.fn_audit_log()
+  `);
+
   schemaReady = true;
 }

--- a/website/src/lib/tickets-db.ts
+++ b/website/src/lib/tickets-db.ts
@@ -150,5 +150,56 @@ export async function initTicketsSchema(): Promise<void> {
     )
   `);
 
+  await pool.query(`
+    CREATE OR REPLACE FUNCTION tickets.fn_prevent_cycle() RETURNS trigger AS $$
+    DECLARE
+      cur UUID := NEW.parent_id;
+      depth INT := 0;
+    BEGIN
+      WHILE cur IS NOT NULL AND depth < 100 LOOP
+        IF cur = NEW.id THEN
+          RAISE EXCEPTION 'parent_id cycle detected on ticket %', NEW.id;
+        END IF;
+        SELECT parent_id INTO cur FROM tickets.tickets WHERE id = cur;
+        depth := depth + 1;
+      END LOOP;
+      RETURN NEW;
+    END $$ LANGUAGE plpgsql
+  `);
+  await pool.query(`DROP TRIGGER IF EXISTS trg_tickets_prevent_cycle ON tickets.tickets`);
+  await pool.query(`
+    CREATE TRIGGER trg_tickets_prevent_cycle
+      BEFORE INSERT OR UPDATE OF parent_id ON tickets.tickets
+      FOR EACH ROW WHEN (NEW.parent_id IS NOT NULL)
+      EXECUTE FUNCTION tickets.fn_prevent_cycle()
+  `);
+
+  await pool.query(`
+    CREATE OR REPLACE FUNCTION tickets.fn_lifecycle_ts() RETURNS trigger AS $$
+    BEGIN
+      IF TG_OP = 'INSERT' THEN
+        IF NEW.status = 'triage' AND NEW.triaged_at IS NULL THEN NEW.triaged_at := now(); END IF;
+        IF NEW.status = 'in_progress' AND NEW.started_at IS NULL THEN NEW.started_at := now(); END IF;
+        IF NEW.status = 'done' AND NEW.done_at IS NULL THEN NEW.done_at := now(); END IF;
+        IF NEW.status = 'archived' AND NEW.archived_at IS NULL THEN NEW.archived_at := now(); END IF;
+      ELSE
+        IF NEW.status <> OLD.status THEN
+          IF NEW.status = 'triage'      AND NEW.triaged_at  IS NULL THEN NEW.triaged_at  := now(); END IF;
+          IF NEW.status = 'in_progress' AND NEW.started_at  IS NULL THEN NEW.started_at  := now(); END IF;
+          IF NEW.status = 'done'        AND NEW.done_at     IS NULL THEN NEW.done_at     := now(); END IF;
+          IF NEW.status = 'archived'    AND NEW.archived_at IS NULL THEN NEW.archived_at := now(); END IF;
+        END IF;
+        NEW.updated_at := now();
+      END IF;
+      RETURN NEW;
+    END $$ LANGUAGE plpgsql
+  `);
+  await pool.query(`DROP TRIGGER IF EXISTS trg_tickets_lifecycle_ts ON tickets.tickets`);
+  await pool.query(`
+    CREATE TRIGGER trg_tickets_lifecycle_ts
+      BEFORE INSERT OR UPDATE ON tickets.tickets
+      FOR EACH ROW EXECUTE FUNCTION tickets.fn_lifecycle_ts()
+  `);
+
   schemaReady = true;
 }

--- a/website/src/lib/tickets/email-templates.ts
+++ b/website/src/lib/tickets/email-templates.ts
@@ -1,0 +1,55 @@
+// website/src/lib/tickets/email-templates.ts
+import { sendEmail } from '../email';
+
+const FROM_NAME = process.env.FROM_NAME || process.env.BRAND_NAME || 'Workspace';
+const PROD_DOMAIN = process.env.PROD_DOMAIN || '';
+const BRAND = process.env.BRAND || 'mentolder';
+const INFO_EMAIL = PROD_DOMAIN ? `info@${PROD_DOMAIN}` : `info@${BRAND}.de`;
+
+export interface CloseEmailParams {
+  externalId: string;
+  reporterEmail: string;
+  resolution: string;             // 'fixed' | 'shipped' | 'wontfix' | 'duplicate' | 'cant_reproduce' | 'obsolete'
+  note?: string;                   // optional public note
+  publicStatusUrl?: string;        // e.g. https://web.mentolder.de/portal/tickets/BR-…
+}
+
+const RESOLUTION_LABELS_DE: Record<string, string> = {
+  fixed:         'behoben',
+  shipped:       'umgesetzt',
+  wontfix:       'nicht umgesetzt',
+  duplicate:     'als Duplikat geschlossen',
+  cant_reproduce:'nicht reproduzierbar',
+  obsolete:      'nicht mehr relevant',
+};
+
+export async function sendBugCloseEmail(p: CloseEmailParams): Promise<boolean> {
+  if (!p.reporterEmail) return false;
+  const label = RESOLUTION_LABELS_DE[p.resolution] ?? p.resolution;
+
+  const text = `Hallo,
+
+Ihre Meldung mit der Nummer ${p.externalId} wurde ${label}.
+${p.note ? `\nAnmerkung: ${p.note}\n` : ''}
+${p.publicStatusUrl ? `Status & Verlauf: ${p.publicStatusUrl}\n\n` : ''}
+Vielen Dank für Ihren Beitrag.
+
+Mit freundlichen Grüßen
+${FROM_NAME}`;
+
+  const html = `<p>Hallo,</p>
+<p>Ihre Meldung mit der Nummer <strong>${p.externalId}</strong> wurde <strong>${label}</strong>.</p>
+${p.note ? `<p><em>Anmerkung:</em> ${p.note}</p>` : ''}
+${p.publicStatusUrl ? `<p>Status &amp; Verlauf: <a href="${p.publicStatusUrl}">${p.publicStatusUrl}</a></p>` : ''}
+<p>Vielen Dank für Ihren Beitrag.</p>
+<p>Mit freundlichen Grüßen<br>${FROM_NAME}</p>`;
+
+  return sendEmail({
+    to: p.reporterEmail,
+    bcc: INFO_EMAIL,
+    replyTo: INFO_EMAIL,
+    subject: `[${p.externalId}] Ihre Meldung wurde bearbeitet`,
+    text,
+    html,
+  });
+}

--- a/website/src/lib/tickets/email-templates.ts
+++ b/website/src/lib/tickets/email-templates.ts
@@ -6,6 +6,9 @@ const PROD_DOMAIN = process.env.PROD_DOMAIN || '';
 const BRAND = process.env.BRAND || 'mentolder';
 const INFO_EMAIL = PROD_DOMAIN ? `info@${PROD_DOMAIN}` : `info@${BRAND}.de`;
 
+const escHtml = (s: string) =>
+  s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+
 export interface CloseEmailParams {
   externalId: string;
   reporterEmail: string;
@@ -39,7 +42,7 @@ ${FROM_NAME}`;
 
   const html = `<p>Hallo,</p>
 <p>Ihre Meldung mit der Nummer <strong>${p.externalId}</strong> wurde <strong>${label}</strong>.</p>
-${p.note ? `<p><em>Anmerkung:</em> ${p.note}</p>` : ''}
+${p.note ? `<p><em>Anmerkung:</em> ${escHtml(p.note)}</p>` : ''}
 ${p.publicStatusUrl ? `<p>Status &amp; Verlauf: <a href="${p.publicStatusUrl}">${p.publicStatusUrl}</a></p>` : ''}
 <p>Vielen Dank für Ihren Beitrag.</p>
 <p>Mit freundlichen Grüßen<br>${FROM_NAME}</p>`;

--- a/website/src/lib/tickets/reporter-link.ts
+++ b/website/src/lib/tickets/reporter-link.ts
@@ -1,0 +1,39 @@
+// website/src/lib/tickets/reporter-link.ts
+import { pool } from '../website-db';
+
+/**
+ * If a customer with this email exists and has a keycloak_user_id,
+ * link any tickets where reporter_email = email AND reporter_id IS NULL.
+ * Idempotent — safe to call repeatedly.
+ */
+export async function linkReporterByEmail(email: string): Promise<number> {
+  if (!email) return 0;
+  const r = await pool.query(
+    `UPDATE tickets.tickets t
+       SET reporter_id = c.id
+       FROM customers c
+      WHERE t.reporter_email = $1
+        AND t.reporter_id IS NULL
+        AND c.email = $1
+        AND c.keycloak_user_id IS NOT NULL`,
+    [email]
+  );
+  return r.rowCount ?? 0;
+}
+
+/**
+ * Batch link: for every distinct reporter_email in tickets where reporter_id is null,
+ * try to match against customers. Used by the migration script and as a nightly cron.
+ */
+export async function linkAllReporters(): Promise<number> {
+  const r = await pool.query(
+    `UPDATE tickets.tickets t
+       SET reporter_id = c.id
+       FROM customers c
+      WHERE t.reporter_id IS NULL
+        AND t.reporter_email IS NOT NULL
+        AND c.email = t.reporter_email
+        AND c.keycloak_user_id IS NOT NULL`
+  );
+  return r.rowCount ?? 0;
+}

--- a/website/src/lib/tickets/transition.ts
+++ b/website/src/lib/tickets/transition.ts
@@ -46,6 +46,9 @@ export async function transitionTicket(
   if (p.resolution && !VALID_RESOLUTIONS.has(p.resolution)) {
     throw new Error(`invalid resolution: ${p.resolution}`);
   }
+  if (p.resolution && p.status !== 'done' && p.status !== 'archived') {
+    throw new Error(`resolution must not be set for non-terminal status: ${p.status}`);
+  }
 
   const client = await pool.connect();
   try {
@@ -66,7 +69,7 @@ export async function transitionTicket(
     const upd = await client.query(
       `UPDATE tickets.tickets
          SET status = $1,
-             resolution = $2
+             resolution = CASE WHEN $1 IN ('done','archived') THEN $2 ELSE NULL END
        WHERE id = $3
        RETURNING id, external_id, type, status, resolution, reporter_email, brand`,
       [p.status, p.resolution ?? null, ticketId]
@@ -85,11 +88,8 @@ export async function transitionTicket(
     if (p.prNumber) {
       await client.query(
         `INSERT INTO tickets.ticket_links (from_id, to_id, kind, pr_number, created_by)
-         SELECT $1, $1, 'fixes', $2, $3
-         WHERE NOT EXISTS (
-           SELECT 1 FROM tickets.ticket_links
-           WHERE from_id = $1 AND kind = 'fixes' AND pr_number = $2
-         )`,
+         VALUES ($1, $1, 'fixes', $2, $3)
+         ON CONFLICT (from_id, to_id, kind) DO NOTHING`,
         [ticketId, p.prNumber, p.actor.id ?? null]
       );
     }

--- a/website/src/lib/tickets/transition.ts
+++ b/website/src/lib/tickets/transition.ts
@@ -1,0 +1,125 @@
+// website/src/lib/tickets/transition.ts
+import { pool } from '../website-db';
+import { sendBugCloseEmail } from './email-templates';
+import { linkReporterByEmail } from './reporter-link';
+
+export type TicketStatus =
+  'triage' | 'backlog' | 'in_progress' | 'in_review' | 'blocked' | 'done' | 'archived';
+
+export type TicketResolution =
+  'fixed' | 'shipped' | 'wontfix' | 'duplicate' | 'cant_reproduce' | 'obsolete';
+
+const VALID_STATUSES: ReadonlySet<TicketStatus> = new Set(
+  ['triage', 'backlog', 'in_progress', 'in_review', 'blocked', 'done', 'archived']);
+
+const VALID_RESOLUTIONS: ReadonlySet<TicketResolution> = new Set(
+  ['fixed', 'shipped', 'wontfix', 'duplicate', 'cant_reproduce', 'obsolete']);
+
+export interface TransitionParams {
+  status: TicketStatus;
+  resolution?: TicketResolution;
+  note?: string;
+  noteVisibility?: 'internal' | 'public';
+  actor: { id?: string; label: string };
+  prNumber?: number;
+}
+
+export interface TransitionResult {
+  id: string;
+  externalId: string | null;
+  type: string;
+  status: TicketStatus;
+  resolution: TicketResolution | null;
+  emailSent: boolean;
+}
+
+export async function transitionTicket(
+  ticketId: string,
+  p: TransitionParams
+): Promise<TransitionResult> {
+  if (!VALID_STATUSES.has(p.status)) {
+    throw new Error(`invalid status: ${p.status}`);
+  }
+  if ((p.status === 'done' || p.status === 'archived') && !p.resolution) {
+    throw new Error(`status=${p.status} requires a resolution`);
+  }
+  if (p.resolution && !VALID_RESOLUTIONS.has(p.resolution)) {
+    throw new Error(`invalid resolution: ${p.resolution}`);
+  }
+
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+    if (p.actor.id) {
+      await client.query(`SELECT set_config('app.user_id', $1, true)`, [p.actor.id]);
+    }
+    await client.query(`SELECT set_config('app.user_label', $1, true)`, [p.actor.label]);
+
+    const cur = await client.query(
+      `SELECT id, external_id, type, status, reporter_email, brand
+         FROM tickets.tickets WHERE id = $1 FOR UPDATE`,
+      [ticketId]
+    );
+    if (cur.rowCount === 0) throw new Error(`ticket ${ticketId} not found`);
+    const before = cur.rows[0];
+
+    const upd = await client.query(
+      `UPDATE tickets.tickets
+         SET status = $1,
+             resolution = $2
+       WHERE id = $3
+       RETURNING id, external_id, type, status, resolution, reporter_email, brand`,
+      [p.status, p.resolution ?? null, ticketId]
+    );
+    const after = upd.rows[0];
+
+    if (p.note) {
+      await client.query(
+        `INSERT INTO tickets.ticket_comments
+           (ticket_id, author_id, author_label, kind, body, visibility)
+         VALUES ($1, $2, $3, 'status_change', $4, $5)`,
+        [ticketId, p.actor.id ?? null, p.actor.label, p.note, p.noteVisibility ?? 'internal']
+      );
+    }
+
+    if (p.prNumber) {
+      await client.query(
+        `INSERT INTO tickets.ticket_links (from_id, to_id, kind, pr_number, created_by)
+         SELECT $1, $1, 'fixes', $2, $3
+         WHERE NOT EXISTS (
+           SELECT 1 FROM tickets.ticket_links
+           WHERE from_id = $1 AND kind = 'fixes' AND pr_number = $2
+         )`,
+        [ticketId, p.prNumber, p.actor.id ?? null]
+      );
+    }
+
+    await client.query('COMMIT');
+
+    let emailSent = false;
+    const becomingDone = before.status !== 'done' && p.status === 'done';
+    if (becomingDone && after.type === 'bug' && after.reporter_email) {
+      await linkReporterByEmail(after.reporter_email);
+      emailSent = await sendBugCloseEmail({
+        externalId: after.external_id ?? after.id,
+        reporterEmail: after.reporter_email,
+        resolution: after.resolution,
+        note: p.noteVisibility === 'public' ? p.note : undefined,
+      });
+    }
+
+    return {
+      id: after.id,
+      externalId: after.external_id,
+      type: after.type,
+      status: after.status,
+      resolution: after.resolution,
+      emailSent,
+    };
+  } catch (err) {
+    await client.query('ROLLBACK').catch(() => {});
+    throw err;
+  } finally {
+    client.release();
+  }
+}

--- a/website/src/lib/website-db.ts
+++ b/website/src/lib/website-db.ts
@@ -4,6 +4,7 @@
 
 import pg from 'pg';
 import { resolve4 } from 'dns';
+import { initTicketsSchema } from './tickets-db';
 const { Pool } = pg;
 
 const MEETINGS_DB_URL = process.env.SESSIONS_DATABASE_URL
@@ -604,18 +605,39 @@ export async function insertBugTicket(params: {
   brand: string;
   screenshots?: string[];
 }): Promise<number> {
-  await initBugTicketsTable();
-  const screenshotsJson = params.screenshots && params.screenshots.length > 0
-    ? JSON.stringify(params.screenshots)
-    : null;
-  const result = await pool.query(
-    `INSERT INTO bugs.bug_tickets (ticket_id, category, reporter_email, description, url, brand, screenshots_json)
-     VALUES ($1, $2, $3, $4, $5, $6, $7)
-     ON CONFLICT (ticket_id) DO NOTHING`,
-    [params.ticketId, params.category, params.reporterEmail,
-     params.description, params.url ?? null, params.brand, screenshotsJson]
+  await initTicketsSchema();
+  const { rows } = await pool.query(
+    `INSERT INTO tickets.tickets
+       (external_id, type, brand, title, description, url, reporter_email, status)
+     VALUES ($1, 'bug', $2, $3, $4, $5, $6, 'triage')
+     ON CONFLICT (external_id) DO NOTHING
+     RETURNING id`,
+    [params.ticketId, params.brand,
+     params.description.slice(0, 200),
+     params.description, params.url ?? null, params.reporterEmail]
   );
-  return result.rowCount ?? 0;
+  if (rows.length === 0) return 0;
+  const newId = rows[0].id;
+
+  // Categorize as tag (kind:fehler|verbesserung|erweiterungswunsch)
+  const tagName = `kind:${params.category}`;
+  await pool.query(
+    `INSERT INTO tickets.tags (name) VALUES ($1) ON CONFLICT (name) DO NOTHING`,
+    [tagName]);
+  await pool.query(
+    `INSERT INTO tickets.ticket_tags (ticket_id, tag_id)
+     SELECT $1, id FROM tickets.tags WHERE name = $2 ON CONFLICT DO NOTHING`,
+    [newId, tagName]);
+
+  // Inline screenshots — kept as data_url for back-compat with existing form behavior
+  for (const [idx, dataUrl] of (params.screenshots ?? []).entries()) {
+    const m = dataUrl.match(/^data:([^;]+);/);
+    await pool.query(
+      `INSERT INTO tickets.ticket_attachments (ticket_id, filename, data_url, mime_type)
+       VALUES ($1, $2, $3, $4)`,
+      [newId, `screenshot-${idx + 1}`, dataUrl, m ? m[1] : 'application/octet-stream']);
+  }
+  return 1;
 }
 
 export async function resolveBugTicket(ticketId: string, resolutionNote: string): Promise<void> {

--- a/website/src/lib/website-db.ts
+++ b/website/src/lib/website-db.ts
@@ -5,6 +5,7 @@
 import pg from 'pg';
 import { resolve4 } from 'dns';
 import { initTicketsSchema } from './tickets-db';
+import { transitionTicket } from './tickets/transition';
 const { Pool } = pg;
 
 const MEETINGS_DB_URL = process.env.SESSIONS_DATABASE_URL
@@ -86,10 +87,10 @@ export async function listTimeline(opts: {
   const bugCounts = new Map<number, number>();
   if (prNumbers.length > 0) {
     const counts = (await pool.query(
-      `SELECT fixed_in_pr AS pr, COUNT(*)::int AS n
-         FROM bugs.bug_tickets
-        WHERE fixed_in_pr = ANY($1::int[])
-        GROUP BY fixed_in_pr`,
+      `SELECT pr_number AS pr, COUNT(*)::int AS n
+         FROM tickets.ticket_links
+        WHERE kind = 'fixes' AND pr_number = ANY($1::int[])
+        GROUP BY pr_number`,
       [prNumbers],
     )).rows as { pr: number; n: number }[];
     for (const c of counts) bugCounts.set(c.pr, c.n);
@@ -640,34 +641,42 @@ export async function insertBugTicket(params: {
   return 1;
 }
 
-export async function resolveBugTicket(ticketId: string, resolutionNote: string): Promise<void> {
-  await initBugTicketsTable();
-  await pool.query(
-    `UPDATE bugs.bug_tickets
-     SET status = 'resolved', resolved_at = NOW(), resolution_note = $2
-     WHERE ticket_id = $1 AND status = 'open'`,
-    [ticketId, resolutionNote]
-  );
-  await pool.query(
-    `UPDATE inbox_items
-     SET status = 'actioned', actioned_at = NOW()
-     WHERE bug_ticket_id = $1 AND status = 'pending'`,
-    [ticketId]
-  );
+async function ticketIdByExternal(externalId: string): Promise<string | null> {
+  const r = await pool.query(
+    `SELECT id FROM tickets.tickets WHERE type = 'bug' AND external_id = $1`,
+    [externalId]);
+  return r.rows[0]?.id ?? null;
 }
 
-export async function archiveBugTicket(ticketId: string): Promise<void> {
-  await initBugTicketsTable();
+export async function resolveBugTicket(
+  ticketId: string,
+  resolutionNote: string,
+  actor: { id?: string; label: string } = { label: 'admin' }
+): Promise<void> {
+  const id = await ticketIdByExternal(ticketId);
+  if (!id) throw new Error(`bug ${ticketId} not found`);
+  await transitionTicket(id, {
+    status: 'done', resolution: 'fixed',
+    note: resolutionNote, noteVisibility: 'public',
+    actor,
+  });
   await pool.query(
-    `UPDATE bugs.bug_tickets SET status = 'archived' WHERE ticket_id = $1 AND status != 'archived'`,
-    [ticketId]
-  );
+    `UPDATE inbox_items SET status = 'actioned', actioned_at = NOW()
+      WHERE bug_ticket_id = $1 AND status = 'pending'`, [ticketId]);
+}
+
+export async function archiveBugTicket(
+  ticketId: string,
+  actor: { id?: string; label: string } = { label: 'admin' }
+): Promise<void> {
+  const id = await ticketIdByExternal(ticketId);
+  if (!id) return;
+  await transitionTicket(id, {
+    status: 'archived', resolution: 'obsolete', actor,
+  });
   await pool.query(
-    `UPDATE inbox_items
-     SET status = 'archived', actioned_at = NOW()
-     WHERE bug_ticket_id = $1 AND status = 'pending'`,
-    [ticketId]
-  );
+    `UPDATE inbox_items SET status = 'archived', actioned_at = NOW()
+      WHERE bug_ticket_id = $1 AND status = 'pending'`, [ticketId]);
 }
 
 export interface BugTicketStatus {
@@ -680,16 +689,27 @@ export interface BugTicketStatus {
 }
 
 export async function getBugTicketStatus(ticketId: string): Promise<BugTicketStatus | null> {
-  await initBugTicketsTable();
-  const result = await pool.query(
-    `SELECT ticket_id as "ticketId", status, category,
-            created_at as "createdAt", resolved_at as "resolvedAt",
-            resolution_note as "resolutionNote",
-            fixed_in_pr as "fixedInPr", fixed_at as "fixedAt"
-     FROM bugs.bug_tickets WHERE ticket_id = $1`,
-    [ticketId]
-  );
-  return result.rows[0] ?? null;
+  await initTicketsSchema();
+  const r = await pool.query(
+    `SELECT t.external_id AS "ticketId",
+            CASE t.status WHEN 'done' THEN 'resolved'
+                          WHEN 'archived' THEN 'archived' ELSE 'open' END AS status,
+            (SELECT SPLIT_PART(g.name, ':', 2)
+               FROM tickets.ticket_tags tt JOIN tickets.tags g ON g.id = tt.tag_id
+              WHERE tt.ticket_id = t.id AND g.name LIKE 'kind:%' LIMIT 1) AS category,
+            t.created_at AS "createdAt",
+            t.done_at AS "resolvedAt",
+            NULL AS "resolutionNote",
+            (SELECT pr_number FROM tickets.ticket_links
+              WHERE from_id = t.id AND kind = 'fixes' AND pr_number IS NOT NULL
+              ORDER BY created_at DESC LIMIT 1) AS "fixedInPr",
+            (SELECT created_at FROM tickets.ticket_links
+              WHERE from_id = t.id AND kind = 'fixes' AND pr_number IS NOT NULL
+              ORDER BY created_at DESC LIMIT 1) AS "fixedAt"
+       FROM tickets.tickets t
+      WHERE t.type = 'bug' AND t.external_id = $1`,
+    [ticketId]);
+  return r.rows[0] ?? null;
 }
 
 // ── Bug Ticket Comments ──────────────────────────────────────────────────────
@@ -706,33 +726,45 @@ export interface BugTicketComment {
 export async function getBugTicketWithComments(
   ticketId: string
 ): Promise<{ ticket: BugTicketRow; comments: BugTicketComment[] } | null> {
-  await initBugTicketsTable();
-  await initBugTicketCommentsTable();
+  await initTicketsSchema();
   const t = await pool.query(
-    `SELECT ticket_id        AS "ticketId",
-            category,
-            reporter_email   AS "reporterEmail",
-            description,
-            url,
-            brand,
-            status,
-            created_at       AS "createdAt",
-            resolved_at      AS "resolvedAt",
-            resolution_note  AS "resolutionNote",
-            screenshots_json AS "screenshots",
-            fixed_in_pr      AS "fixedInPr",
-            fixed_at         AS "fixedAt"
-       FROM bugs.bug_tickets WHERE ticket_id = $1`,
-    [ticketId]
-  );
+    `SELECT t.external_id   AS "ticketId",
+            COALESCE((SELECT SPLIT_PART(g.name, ':', 2)
+                        FROM tickets.ticket_tags tt JOIN tickets.tags g ON g.id = tt.tag_id
+                       WHERE tt.ticket_id = t.id AND g.name LIKE 'kind:%' LIMIT 1), '') AS category,
+            t.reporter_email AS "reporterEmail",
+            t.description,
+            t.url,
+            t.brand,
+            CASE t.status WHEN 'done' THEN 'resolved'
+                          WHEN 'archived' THEN 'archived' ELSE 'open' END AS status,
+            t.created_at    AS "createdAt",
+            t.done_at       AS "resolvedAt",
+            NULL            AS "resolutionNote",
+            (SELECT json_agg(data_url ORDER BY uploaded_at)
+               FROM tickets.ticket_attachments WHERE ticket_id = t.id) AS "screenshots",
+            (SELECT pr_number FROM tickets.ticket_links
+               WHERE from_id = t.id AND kind = 'fixes' AND pr_number IS NOT NULL
+               ORDER BY created_at DESC LIMIT 1) AS "fixedInPr",
+            (SELECT created_at FROM tickets.ticket_links
+               WHERE from_id = t.id AND kind = 'fixes' AND pr_number IS NOT NULL
+               ORDER BY created_at DESC LIMIT 1) AS "fixedAt"
+       FROM tickets.tickets t
+      WHERE t.type = 'bug' AND t.external_id = $1`,
+    [ticketId]);
   if (t.rows.length === 0) return null;
   const c = await pool.query(
-    `SELECT id, ticket_id AS "ticketId", author, kind, body, created_at AS "createdAt"
-       FROM bugs.bug_ticket_comments
-       WHERE ticket_id = $1
-       ORDER BY created_at ASC`,
-    [ticketId]
-  );
+    `SELECT tc.id,
+            $1::text AS "ticketId",
+            tc.author_label AS author,
+            tc.kind,
+            tc.body,
+            tc.created_at AS "createdAt"
+       FROM tickets.ticket_comments tc
+       JOIN tickets.tickets t ON t.id = tc.ticket_id
+      WHERE t.type = 'bug' AND t.external_id = $1
+      ORDER BY tc.created_at ASC`,
+    [ticketId]);
   return { ticket: t.rows[0], comments: c.rows };
 }
 
@@ -742,13 +774,14 @@ export async function appendBugTicketComment(params: {
   body: string;
   kind?: 'comment' | 'status_change' | 'system';
 }): Promise<BugTicketComment> {
-  await initBugTicketCommentsTable();
+  await initTicketsSchema();
   const r = await pool.query(
-    `INSERT INTO bugs.bug_ticket_comments (ticket_id, author, kind, body)
-     VALUES ($1, $2, $3, $4)
-     RETURNING id, ticket_id AS "ticketId", author, kind, body, created_at AS "createdAt"`,
-    [params.ticketId, params.author, params.kind ?? 'comment', params.body]
-  );
+    `INSERT INTO tickets.ticket_comments
+       (ticket_id, author_label, kind, body, visibility)
+     SELECT id, $2, $3, $4, 'internal' FROM tickets.tickets
+      WHERE type = 'bug' AND external_id = $1
+     RETURNING id, $1::text AS "ticketId", author_label AS author, kind, body, created_at AS "createdAt"`,
+    [params.ticketId, params.author, params.kind ?? 'comment', params.body]);
   return r.rows[0];
 }
 
@@ -757,22 +790,13 @@ export async function reopenBugTicket(
   author: string,
   reason?: string
 ): Promise<void> {
-  await initBugTicketsTable();
-  await initBugTicketCommentsTable();
-  const upd = await pool.query(
-    `UPDATE bugs.bug_tickets
-       SET status = 'open', resolved_at = NULL, resolution_note = NULL
-       WHERE ticket_id = $1 AND status IN ('resolved', 'archived')`,
-    [ticketId]
-  );
-  if (upd.rowCount === 0) {
-    throw new Error(`ticket ${ticketId} not in 'resolved' or 'archived' state`);
-  }
-  await pool.query(
-    `INSERT INTO bugs.bug_ticket_comments (ticket_id, author, kind, body)
-     VALUES ($1, $2, 'status_change', $3)`,
-    [ticketId, author, `reopened${reason ? `: ${reason}` : ''}`]
-  );
+  const id = await ticketIdByExternal(ticketId);
+  if (!id) throw new Error(`ticket ${ticketId} not found`);
+  await transitionTicket(id, {
+    status: 'backlog',
+    note: reason,
+    actor: { label: author },
+  });
 }
 
 export async function initBugTicketCommentsTable(): Promise<void> {
@@ -2714,33 +2738,60 @@ export async function listBugTickets(filters: {
   q?: string;
   limit?: number;
 }): Promise<BugTicketRow[]> {
-  await initBugTicketsTable();
-  const { status, category, brand, q, limit = 200 } = filters;
-  const result = await pool.query(
-    `SELECT ticket_id        AS "ticketId",
-            category,
-            reporter_email   AS "reporterEmail",
-            description,
-            url,
-            brand,
-            status,
-            created_at       AS "createdAt",
-            resolved_at      AS "resolvedAt",
-            resolution_note  AS "resolutionNote",
-            screenshots_json AS "screenshots",
-            fixed_in_pr      AS "fixedInPr",
-            fixed_at         AS "fixedAt"
-     FROM bugs.bug_tickets
-     WHERE ($1::text IS NULL OR brand = $1)
-       AND ($2::text IS NULL OR status = $2)
-       AND ($3::text IS NULL OR category = $3)
-       AND ($4::text IS NULL OR ticket_id ILIKE '%' || $4 || '%'
-                              OR reporter_email ILIKE '%' || $4 || '%')
-     ORDER BY created_at DESC
-     LIMIT $5`,
-    [brand ?? null, status ?? null, category ?? null, q ?? null, limit]
-  );
-  return result.rows;
+  await initTicketsSchema();
+  const where: string[] = [`t.type = 'bug'`];
+  const vals: unknown[] = [];
+  if (filters.brand) {
+    vals.push(filters.brand);
+    where.push(`t.brand = $${vals.length}`);
+  }
+  if (filters.status) {
+    // Map legacy filter values back to new status set
+    const map: Record<string, string[]> = {
+      open:     ['triage','backlog','in_progress','in_review','blocked'],
+      resolved: ['done'],
+      archived: ['archived'],
+    };
+    const list = map[filters.status] ?? [filters.status];
+    vals.push(list);
+    where.push(`t.status = ANY($${vals.length}::text[])`);
+  }
+  if (filters.category) {
+    vals.push(`kind:${filters.category}`);
+    where.push(`EXISTS (SELECT 1 FROM tickets.ticket_tags tt
+                          JOIN tickets.tags g ON g.id = tt.tag_id
+                         WHERE tt.ticket_id = t.id AND g.name = $${vals.length})`);
+  }
+  if (filters.q) {
+    vals.push(filters.q);
+    where.push(`(t.description ILIKE '%' || $${vals.length} || '%'
+                 OR t.reporter_email ILIKE '%' || $${vals.length} || '%')`);
+  }
+  const sql = `
+    SELECT t.external_id   AS "ticketId",
+           COALESCE(SPLIT_PART(g.name, ':', 2), '') AS category,
+           t.reporter_email AS "reporterEmail",
+           t.description,
+           t.url,
+           t.brand,
+           CASE t.status WHEN 'done' THEN 'resolved'
+                         WHEN 'archived' THEN 'archived' ELSE 'open' END AS status,
+           t.created_at    AS "createdAt",
+           t.done_at       AS "resolvedAt",
+           NULL            AS "resolutionNote",
+           (SELECT pr_number FROM tickets.ticket_links
+              WHERE from_id = t.id AND kind = 'fixes' AND pr_number IS NOT NULL
+              ORDER BY created_at DESC LIMIT 1) AS "fixedInPr",
+           (SELECT created_at FROM tickets.ticket_links
+              WHERE from_id = t.id AND kind = 'fixes' AND pr_number IS NOT NULL
+              ORDER BY created_at DESC LIMIT 1) AS "fixedAt"
+      FROM tickets.tickets t
+      LEFT JOIN tickets.ticket_tags tt ON tt.ticket_id = t.id
+      LEFT JOIN tickets.tags g ON g.id = tt.tag_id AND g.name LIKE 'kind:%'
+     WHERE ${where.join(' AND ')}
+     ORDER BY t.created_at DESC`;
+  const r = await pool.query(sql, vals);
+  return r.rows;
 }
 
 // ── Homepage Content (hero + startseite) ─────────────────────────────────────

--- a/website/src/lib/website-db.ts
+++ b/website/src/lib/website-db.ts
@@ -2767,9 +2767,11 @@ export async function listBugTickets(filters: {
     where.push(`(t.description ILIKE '%' || $${vals.length} || '%'
                  OR t.reporter_email ILIKE '%' || $${vals.length} || '%')`);
   }
+  vals.push(filters.limit ?? 200);
+  const limitClause = `LIMIT $${vals.length}`;
   const sql = `
     SELECT t.external_id   AS "ticketId",
-           COALESCE(SPLIT_PART(g.name, ':', 2), '') AS category,
+           COALESCE((SELECT SPLIT_PART(g.name, ':', 2) FROM tickets.ticket_tags tt JOIN tickets.tags g ON g.id = tt.tag_id WHERE tt.ticket_id = t.id AND g.name LIKE 'kind:%' LIMIT 1), '') AS category,
            t.reporter_email AS "reporterEmail",
            t.description,
            t.url,
@@ -2786,10 +2788,8 @@ export async function listBugTickets(filters: {
               WHERE from_id = t.id AND kind = 'fixes' AND pr_number IS NOT NULL
               ORDER BY created_at DESC LIMIT 1) AS "fixedAt"
       FROM tickets.tickets t
-      LEFT JOIN tickets.ticket_tags tt ON tt.ticket_id = t.id
-      LEFT JOIN tickets.tags g ON g.id = tt.tag_id AND g.name LIKE 'kind:%'
      WHERE ${where.join(' AND ')}
-     ORDER BY t.created_at DESC`;
+     ORDER BY t.created_at DESC ${limitClause}`;
   const r = await pool.query(sql, vals);
   return r.rows;
 }

--- a/website/src/pages/api/admin/bugs/reopen.ts
+++ b/website/src/pages/api/admin/bugs/reopen.ts
@@ -29,7 +29,7 @@ export const POST: APIRoute = async ({ request }) => {
     });
   } catch (err: any) {
     console.error('[bugs/reopen] DB error:', err);
-    const status = err.message?.includes('not in') ? 409 : 500;
+    const status = err.message?.includes('not found') ? 404 : 500;
     return new Response(JSON.stringify({ error: err.message ?? 'DB error' }), { status });
   }
 };

--- a/website/src/pages/api/admin/bugs/resolve.ts
+++ b/website/src/pages/api/admin/bugs/resolve.ts
@@ -1,6 +1,6 @@
 import type { APIRoute } from 'astro';
 import { getSession, isAdmin } from '../../../../lib/auth';
-import { appendBugTicketComment, resolveBugTicket } from '../../../../lib/website-db';
+import { resolveBugTicket } from '../../../../lib/website-db';
 import { buildBackUrl, buildErrorUrl } from './_helpers';
 
 export const POST: APIRoute = async ({ request }) => {
@@ -48,13 +48,7 @@ export const POST: APIRoute = async ({ request }) => {
   }
 
   try {
-    await resolveBugTicket(ticketId, resolutionNote);
-    await appendBugTicketComment({
-      ticketId,
-      author: session.preferred_username,
-      kind: 'status_change',
-      body: `resolved: ${resolutionNote}`,
-    }).catch(() => {/* status_change comment is best-effort, don't fail the resolve */});
+    await resolveBugTicket(ticketId, resolutionNote, { label: session.preferred_username });
   } catch (err) {
     console.error('[bugs/resolve] DB error:', err);
     if (isJson) {

--- a/website/src/pages/api/admin/inbox/[id]/action.ts
+++ b/website/src/pages/api/admin/inbox/[id]/action.ts
@@ -203,16 +203,12 @@ export const POST: APIRoute = async ({ request, params }) => {
           return new Response(JSON.stringify({ error: 'Max. 500 Zeichen.' }), { status: 400 });
         }
         const p = item.payload as { ticketId: string; reporterEmail: string; brand: string };
-        await resolveBugTicket(p.ticketId, resolveNote);
-        const toEmail = PROD_DOMAIN ? `info@${PROD_DOMAIN}` : `info@${p.brand}.de`;
-        await sendEmail({
-          to: toEmail,
-          subject: `[${p.ticketId}] Erledigt`,
-          text: `Ticket ${p.ticketId} wurde als erledigt markiert.\n\nNotiz:\n${resolveNote}`,
-          replyTo: p.reporterEmail,
-        });
+        await resolveBugTicket(p.ticketId, resolveNote,
+          { label: session.preferred_username });
+        // No manual sendEmail() here — transitionTicket() handles the close-mail.
         await updateInboxItemStatus(id, 'actioned', session.preferred_username);
-        return new Response(JSON.stringify({ success: true }), { headers: { 'Content-Type': 'application/json' } });
+        return new Response(JSON.stringify({ success: true }),
+          { headers: { 'Content-Type': 'application/json' } });
       }
 
       case 'close_user_message': {

--- a/website/src/pages/api/bug-report.ts
+++ b/website/src/pages/api/bug-report.ts
@@ -3,6 +3,7 @@ import { insertBugTicket } from '../../lib/website-db';
 import { createInboxItem } from '../../lib/messaging-db';
 import { checkRateLimit, getClientIp } from '../../lib/rate-limit';
 import { config } from '../../config/index.js';
+import { linkReporterByEmail } from '../../lib/tickets/reporter-link';
 
 const MAX_BYTES = 5 * 1024 * 1024;
 const ALLOWED_MIME = new Set(['image/png', 'image/jpeg', 'image/webp']);
@@ -89,6 +90,9 @@ export const POST: APIRoute = async ({ request }) => {
       brand: BRAND,
       screenshots: screenshotDataUrls.length > 0 ? screenshotDataUrls : undefined,
     });
+
+    await linkReporterByEmail(email).catch(err =>
+      console.error('[bug-report] reporter-link failed:', err));
 
     await createInboxItem({
       type: 'bug',

--- a/website/src/pages/api/internal/tickets/notify-close.ts
+++ b/website/src/pages/api/internal/tickets/notify-close.ts
@@ -1,0 +1,26 @@
+import type { APIRoute } from 'astro';
+import { pool } from '../../../../lib/website-db';
+import { sendBugCloseEmail } from '../../../../lib/tickets/email-templates';
+
+const TOKEN = process.env.INTERNAL_API_TOKEN ?? '';
+
+export const POST: APIRoute = async ({ request }) => {
+  if (!TOKEN || request.headers.get('x-internal-token') !== TOKEN) {
+    return new Response('forbidden', { status: 403 });
+  }
+  const body = await request.json() as { externalId: string; resolution: string };
+  const r = await pool.query(
+    `SELECT external_id, reporter_email FROM tickets.tickets
+      WHERE type = 'bug' AND external_id = $1`, [body.externalId]);
+  if (r.rowCount === 0) return new Response('not found', { status: 404 });
+  const t = r.rows[0];
+  if (!t.reporter_email) return new Response(JSON.stringify({ ok: true, skipped: true }),
+    { headers: { 'Content-Type': 'application/json' } });
+  const sent = await sendBugCloseEmail({
+    externalId: t.external_id,
+    reporterEmail: t.reporter_email,
+    resolution: body.resolution,
+  });
+  return new Response(JSON.stringify({ ok: true, sent }),
+    { headers: { 'Content-Type': 'application/json' } });
+};


### PR DESCRIPTION
## Summary
Stand up the new `tickets` Postgres schema and migrate `bugs.bug_tickets` into it, while fixing the missed-reporter-notification bug on every close path. This is the first of 5 planned PRs (PR2: features+requirements; PR3: projects/sub_projects/tasks; PR4: unified `/admin/tickets` UI; PR5: drop legacy tables).

**Spec:** `docs/superpowers/specs/2026-05-08-unified-ticketing-design.md`
**Plan:** `docs/superpowers/plans/2026-05-08-unified-ticketing-pr1.md`

### What's new
- `tickets` schema with 8 tables (tickets, ticket_links, ticket_activity, ticket_comments, ticket_attachments, ticket_watchers, tags, ticket_tags) + DB triggers for cycle prevention, lifecycle timestamps, and audit logging.
- `transitionTicket()` service in `website/src/lib/tickets/transition.ts` — the **single writer** of `status`. All three close paths (admin resolve, inbox action, PR-merge auto-close) now route through it.
- Reporter→customer auto-link via `linkReporterByEmail()` — when a public bug-report's email matches a Keycloak-linked customer, `reporter_id` gets populated.
- Idempotent migration script `scripts/migrate-bugs-to-tickets.mjs` with dry-run default + `--apply` mode.
- `bugs.bug_tickets` becomes a SQL view over `tickets.tickets WHERE type='bug'` — preserves the `bugs_fixed` JOIN on the Kore homepage timeline and any other readers.

### The bug fix
Three close paths previously failed to notify the reporter:
1. `scripts/track-pr.mjs` — set `status='archived'` (skipping `resolved`!) and sent **no email at all**.
2. `/api/admin/bugs/resolve.ts` — sent **no email at all**.
3. `/api/admin/inbox/[id]/action.ts` — sent email to `info@<brand>.de` with the reporter only in `Reply-To`.

After this PR, the unified `transitionTicket()` sends a templated German email **To: the reporter, BCC: info@<brand>** whenever a bug ticket transitions into `done` (auto-close on PR merge or manual admin resolve). Reporters finally hear back.

### Tests
- BATS unit tests: `tests/unit/tickets-reporter-link.bats`, `tests/unit/tickets-transition.bats`, `tests/unit/tickets-migration.bats`. All have prod-URL guards and clean up test fixtures.
- Playwright E2E: `tests/e2e/specs/fa-bugs-notifications.spec.ts` — bug-report → admin resolve → assert reporter received email at the address they entered.

### ⚠️ Required human follow-up (before deploying)
1. **Generate the new `INTERNAL_API_TOKEN`** secret (used by track-pr.mjs to call the in-pod notify-close endpoint that sends the close-mail). Per env:
   ```
   echo "INTERNAL_API_TOKEN: \"$(openssl rand -base64 36)\"" >> environments/.secrets/mentolder.yaml
   echo "INTERNAL_API_TOKEN: \"$(openssl rand -base64 36)\"" >> environments/.secrets/korczewski.yaml
   task env:seal ENV=mentolder
   task env:seal ENV=korczewski
   git add environments/sealed-secrets/*.yaml && git commit -m "chore(secrets): seal INTERNAL_API_TOKEN" && git push
   ```
2. **Run the data migration** (after the deploy lands the new schema). Per env, with `task workspace:port-forward ENV=<env>` running:
   ```
   TRACKING_DB_URL="postgres://postgres:$PG_PW@localhost:5432/website" \
     node scripts/migrate-bugs-to-tickets.mjs --apply
   ```
   Expected output: `{"inserted":N,"skipped":0,"unknownStatus":0,"mode":"apply"}` where N = count from old `bugs.bug_tickets`.
3. **Smoke** `https://web.mentolder.de/admin/bugs` and `https://web.korczewski.de/admin/bugs` — same ticket counts and same filters as before deploy.
4. **Manual verify the close-mail**: file a test bug at `https://web.mentolder.de` with a real email you can check, resolve it from `/admin/bugs/[id]`, expect the email within 1 minute.

### Migration risk-reduction
- Old `bugs.bug_tickets` and `bugs.bug_ticket_comments` tables are renamed to `*_legacy` (not dropped) — rollback is `DROP VIEW + ALTER TABLE … RENAME` and re-deploy old code.
- Migration script is idempotent (`external_id` UNIQUE guards re-runs).
- Take `task workspace:backup` before running `--apply` on prod.

## Test plan
- [ ] `task test:all` (BATS unit + manifest validation) green
- [ ] BATS migration tests pass against a non-prod port-forward
- [ ] Playwright `fa-bugs-notifications.spec.ts` passes after deploy + Mailpit reachable
- [ ] `/admin/bugs` ticket counts match pre-deploy on both brands
- [ ] Public bug-report still mints BR-IDs and stores screenshots
- [ ] Manual: real reporter receives close-mail to the address they entered

🤖 Generated with [Claude Code](https://claude.com/claude-code)