### PR TITLE
chore(post-pr2): tickets-grants script + backup:list fix + log polish

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1230,6 +1230,34 @@ tasks:
       - 'echo ""'
       - 'echo "  Next → task workspace:office:deploy ENV={{.ENV}}"'
 
+  workspace:fix-tickets-grants:
+    desc: "Idempotent: GRANT website role on tickets+bachelorprojekt schemas (ENV=dev|mentolder|korczewski). Run once after fresh bootstrap or any time pg_dump fails on tickets.* with permission denied."
+    vars:
+      ENV: '{{.ENV | default "dev"}}'
+    cmds:
+      - |
+        source scripts/env-resolve.sh "{{.ENV}}"
+        ctx_flag=""
+        [ "{{.ENV}}" != "dev" ] && ctx_flag="--context $ENV_CONTEXT"
+        NS="${WORKSPACE_NAMESPACE:-workspace}"
+
+        echo "Fetching postgres superuser password from ${NS}/shared-db..."
+        PG_PW=$(kubectl $ctx_flag -n "$NS" exec deploy/shared-db -- \
+          printenv POSTGRES_PASSWORD | tr -d '\r\n')
+        if [ -z "$PG_PW" ]; then
+          echo "ERROR: could not read POSTGRES_PASSWORD from shared-db"; exit 1
+        fi
+
+        echo "Port-forwarding shared-db (5432) and applying GRANTs..."
+        kubectl $ctx_flag -n "$NS" port-forward svc/shared-db 5432:5432 \
+          >/tmp/fix-grants-pf.log 2>&1 &
+        PF=$!
+        trap 'kill $PF 2>/dev/null' EXIT
+        sleep 3
+
+        TRACKING_DB_URL="postgres://postgres:${PG_PW}@localhost:5432/website" \
+          node scripts/fix-tickets-grants.mjs --apply
+
   workspace:sync-db-passwords:
     desc: "Sync alle DB-Passwörter aus workspace-secrets → PostgreSQL ALTER USER (ENV=dev|mentolder|korczewski)"
     vars:

--- a/scripts/backup-restore.sh
+++ b/scripts/backup-restore.sh
@@ -71,11 +71,24 @@ case "${CMD:-}" in
   list)
     echo "Backups on backup-pvc (newest first):"
     POD="backup-list-$$"
-    # Only show YYYYMMDD-HHMMSS directories (not debug/log files)
-    OVERRIDES='{"spec":{"restartPolicy":"Never","volumes":[{"name":"b","persistentVolumeClaim":{"claimName":"backup-pvc"}}],"containers":[{"name":"c","image":"busybox","command":["/bin/sh","-c","find /backups -maxdepth 1 -mindepth 1 -type d -name '"'"'[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]-[0-9][0-9][0-9][0-9][0-9][0-9]'"'"' | xargs -I{} basename {} | sort -r"],"volumeMounts":[{"name":"b","mountPath":"/backups"}]}]}}'
-    $KC run "$POD" -n "$NS" --restart=Never --image=busybox \
-      --overrides="$OVERRIDES" --quiet 2>/dev/null || true
-    for _ in $(seq 1 30); do
+    # Only show YYYYMMDD-HHMMSS directories (not debug/log files).
+    # The override must include:
+    #   - securityContext fields — workspace/workspace-korczewski both run
+    #     PodSecurity=restricted; without them apiserver rejects the pod
+    #     silently and the previous `2>/dev/null` swallowed the warning.
+    #   - nodeAffinity that excludes home workers (k3s-1/2/3, k3w-1/2/3) —
+    #     backup-pvc is Longhorn ReadWriteOnce and the home nodes don't run
+    #     the longhorn CSI driver, so a pod scheduled there hangs in
+    #     ContainerCreating with FailedAttachVolume forever. Mirrors the
+    #     affinity on the db-backup CronJob.
+    OVERRIDES='{"spec":{"restartPolicy":"Never","volumes":[{"name":"b","persistentVolumeClaim":{"claimName":"backup-pvc"}}],"securityContext":{"runAsNonRoot":true,"runAsUser":65532,"runAsGroup":65532,"seccompProfile":{"type":"RuntimeDefault"}},"affinity":{"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"kubernetes.io/hostname","operator":"NotIn","values":["k3s-1","k3s-2","k3s-3","k3w-1","k3w-2","k3w-3"]}]}]}}},"containers":[{"name":"c","image":"busybox","command":["/bin/sh","-c","find /backups -maxdepth 1 -mindepth 1 -type d -name '"'"'[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]-[0-9][0-9][0-9][0-9][0-9][0-9]'"'"' | xargs -I{} basename {} | sort -r"],"securityContext":{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]}},"volumeMounts":[{"name":"b","mountPath":"/backups","readOnly":true}]}]}}'
+    if ! $KC run "$POD" -n "$NS" --restart=Never --image=busybox \
+        --overrides="$OVERRIDES" --quiet 2>&1; then
+      echo "(failed to schedule backup-list pod — see warning above)"
+      exit 1
+    fi
+    # Volume attach can take ~10s on a cold node; allow up to 90s before giving up.
+    for _ in $(seq 1 90); do
       PHASE=$($KC get pod -n "$NS" "$POD" -o jsonpath='{.status.phase}' 2>/dev/null || echo "")
       [[ "$PHASE" == "Succeeded" || "$PHASE" == "Failed" ]] && break
       sleep 1

--- a/scripts/fix-tickets-grants.mjs
+++ b/scripts/fix-tickets-grants.mjs
@@ -1,0 +1,132 @@
+// scripts/fix-tickets-grants.mjs
+//
+// Idempotent fix for the latent grant gap that surfaced after PR2 of the
+// unified-ticketing migration: the `website` PG role lacks SELECT/INSERT/
+// UPDATE/DELETE on most tables in the `tickets` and `bachelorprojekt`
+// schemas because PR1's migration script (and parts of bachelorprojekt's
+// init.sql) was run as the `postgres` superuser, which makes those tables
+// postgres-owned. The website pod connects as `website` and could not
+// touch them — and pg_dump (running as website during scheduled backups)
+// failed with `permission denied for table tickets`.
+//
+// Run this once after a fresh cluster bootstrap, or any time you suspect
+// the `website` role is missing access to a table in either schema. It
+// only GRANTs (never REVOKEs), and `ALTER DEFAULT PRIVILEGES` ensures any
+// future tables created in these schemas by `postgres` automatically grant
+// the same set to `website`.
+//
+// Usage:
+//   node scripts/fix-tickets-grants.mjs            # dry-run (default)
+//   node scripts/fix-tickets-grants.mjs --apply    # execute
+//
+// Env: TRACKING_DB_URL or WEBSITE_DB_URL — must connect as the postgres
+//      superuser (the `website` role can't grant on tables it doesn't own).
+import pg from 'pg';
+
+const SCHEMAS = ['tickets', 'bachelorprojekt'];
+
+// Per schema, which privilege set we want on existing + future objects.
+const SCHEMA_GRANTS = {
+  tickets: {
+    tablePrivs: 'SELECT, INSERT, UPDATE, DELETE, REFERENCES, TRIGGER',
+    seqPrivs:   'USAGE, SELECT, UPDATE',
+  },
+  bachelorprojekt: {
+    tablePrivs: 'SELECT, INSERT, UPDATE, DELETE',
+    seqPrivs:   'USAGE, SELECT, UPDATE',
+  },
+};
+
+async function audit(client) {
+  // Returns { schema -> [{ name, owner, kind, has_select_for_website }] }
+  const rows = (await client.query(`
+    SELECT n.nspname AS schema,
+           c.relname AS name,
+           c.relkind AS kind,
+           r.rolname AS owner,
+           has_table_privilege('website', c.oid, 'SELECT') AS website_select
+      FROM pg_class c
+      JOIN pg_namespace n ON n.oid = c.relnamespace
+      JOIN pg_roles     r ON r.oid = c.relowner
+     WHERE n.nspname = ANY($1)
+       AND c.relkind IN ('r','v','m','S')
+     ORDER BY n.nspname, c.relname
+  `, [SCHEMAS])).rows;
+  const out = {};
+  for (const r of rows) {
+    (out[r.schema] ??= []).push(r);
+  }
+  return out;
+}
+
+async function applyGrants(client) {
+  for (const schema of SCHEMAS) {
+    const { tablePrivs, seqPrivs } = SCHEMA_GRANTS[schema];
+
+    await client.query(`GRANT USAGE ON SCHEMA ${schema} TO website`);
+
+    await client.query(
+      `GRANT ${tablePrivs} ON ALL TABLES    IN SCHEMA ${schema} TO website`);
+    await client.query(
+      `GRANT ${seqPrivs}   ON ALL SEQUENCES IN SCHEMA ${schema} TO website`);
+
+    // Default privileges so postgres-created future objects in this schema
+    // automatically grant the same set to `website`. This is what stops the
+    // gap from coming back after the next time someone runs a migration as
+    // postgres.
+    await client.query(
+      `ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA ${schema}
+         GRANT ${tablePrivs} ON TABLES TO website`);
+    await client.query(
+      `ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA ${schema}
+         GRANT ${seqPrivs} ON SEQUENCES TO website`);
+  }
+}
+
+function summarize(label, audit) {
+  console.log(`\n[${label}]`);
+  for (const schema of SCHEMAS) {
+    const objs = audit[schema] ?? [];
+    const missingSelect = objs.filter(o =>
+      ['r', 'v', 'm'].includes(o.kind) && !o.website_select);
+    console.log(`  ${schema}: ${objs.length} objects, ${missingSelect.length} without website SELECT`);
+    for (const o of missingSelect.slice(0, 8)) {
+      console.log(`    - ${o.name} (kind=${o.kind}, owner=${o.owner})`);
+    }
+    if (missingSelect.length > 8) {
+      console.log(`    … and ${missingSelect.length - 8} more`);
+    }
+  }
+}
+
+async function main() {
+  const apply = process.argv.includes('--apply');
+  const url = process.env.TRACKING_DB_URL ?? process.env.WEBSITE_DB_URL
+    ?? 'postgres://postgres:postgres@localhost:5432/website';
+  const client = new pg.Client({ connectionString: url });
+  await client.connect();
+  try {
+    const before = await audit(client);
+    summarize('BEFORE', before);
+
+    if (!apply) {
+      console.log('\n(dry-run — pass --apply to execute the GRANTs)');
+      return;
+    }
+
+    await client.query('BEGIN');
+    await applyGrants(client);
+    await client.query('COMMIT');
+
+    const after = await audit(client);
+    summarize('AFTER', after);
+    console.log('\nDone.');
+  } catch (err) {
+    if (apply) await client.query('ROLLBACK').catch(() => {});
+    console.error(err.message);
+    process.exit(1);
+  } finally {
+    await client.end();
+  }
+}
+main();

--- a/scripts/track-pr.mjs
+++ b/scripts/track-pr.mjs
@@ -88,7 +88,12 @@ export async function writeRowToDb(row, pgClient) {
       `SELECT id, status, reporter_email FROM tickets.tickets
         WHERE type = 'bug' AND external_id = $1`, [externalId]);
     if (r.rowCount === 0) {
-      console.log(`skip ${externalId}: not found in tickets.tickets`);
+      // Both clusters' crons process the same tracking/pending JSON files,
+      // but tickets.tickets is brand-scoped (BR-IDs are minted per cluster).
+      // A skip here is normal when the PR mentions a BR-ID from the other
+      // cluster's brand — that link will be created on the cluster that
+      // actually has the bug ticket.
+      console.log(`skip ${externalId}: not on this cluster (cross-brand BR-ID)`);
       continue;
     }
     const t = r.rows[0];


### PR DESCRIPTION
## Summary
Three small follow-ups surfaced by the PR2 unified-ticketing migration (#565). All three were noted in PR2's "findings worth a follow-up" list and cleared up here in one bundled chore PR.

### 1. New `scripts/fix-tickets-grants.mjs` + `task workspace:fix-tickets-grants`
PR1's bug-tickets migration was run as the `postgres` superuser, which makes tables postgres-owned. The `website` role couldn't SELECT/INSERT on most `tickets.*` tables, and `pg_dump` (running as `website` during scheduled backups) was failing with `permission denied for table tickets` — the user had to apply GRANTs imperatively during the PR2 deploy. This codifies that fix:

- Idempotent script, `--apply` gated, dry-run by default.
- GRANTs the `website` role appropriate access on `tickets` and `bachelorprojekt` schemas (existing tables/sequences).
- Sets `ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA … GRANT … TO website` so any future postgres-created table in these schemas auto-grants.
- Taskfile entry handles port-forward + postgres password fetch automatically: `task workspace:fix-tickets-grants ENV=mentolder|korczewski`.

Run once after a fresh cluster bootstrap, or any time pg_dump fails with `permission denied for table` in the `tickets` or `bachelorprojekt` schemas.

### 2. `task workspace:backup:list` fix
Was reporting `(no backups found)` even when 17+ backups existed. Two root causes, both silenced by the script's `2>/dev/null`:
- The busybox override lacked `securityContext` fields that workspace's `restricted` PodSecurity policy requires → apiserver rejected the pod silently.
- It had no nodeAffinity, so kube-scheduler could land it on a home worker (k3s-1/2/3, k3w-1/2/3) that doesn't run the longhorn CSI driver → pod hung in `ContainerCreating` with `FailedAttachVolume` forever.

Override now includes both, mirroring the db-backup CronJob's affinity. Wait bumped 30s→90s to tolerate cold volume attach. Verified: the command now returns the real list of 17 backup timestamps.

### 3. `track-pr.mjs --ingest` skip log clarified
Cross-brand BR-IDs are expected (each cluster's `tickets.tickets` is brand-scoped — mentolder has 58 bug tickets, korczewski has 5), so the cron's per-PR skip log now reads `"skip BR-…: not on this cluster (cross-brand BR-ID)"` instead of `"not found in tickets.tickets"` which read like a real failure when grepping logs.

## Test plan
- [x] `node --check` on both new/modified `.mjs` files
- [x] `task workspace:backup:list` against mentolder returns 17 timestamps
- [x] `node scripts/fix-tickets-grants.mjs` (dry-run) against mentolder reports `0 without website SELECT` on both schemas — confirms the imperative fix from PR2 deploy is in place and the script is a no-op for already-correct clusters
- [ ] `task workspace:fix-tickets-grants ENV=mentolder` — full task path (port-forward + apply) (deferred to user)
- [ ] cron log no longer has alarming "not found in tickets.tickets" lines after next ingest tick

🤖 Generated with [Claude Code](https://claude.com/claude-code)