### PR TITLE
fix(website): wire PortalLayout into Kore brand system

### DIFF
--- a/website/public/brand/korczewski/colors_and_type.css
+++ b/website/public/brand/korczewski/colors_and_type.css
@@ -214,3 +214,18 @@ html, body { margin: 0; padding: 0; }
 body { -webkit-font-smoothing: antialiased; text-rendering: optimizeLegibility; }
 a { color: inherit; }
 button { font: inherit; }
+
+/* =========================================================================
+   Legacy token aliases — bridge mentolder-style inline styles
+   (var(--brass), var(--font-serif), …) used in PortalLayout/AdminLayout.
+   This file is only loaded on Kore deployments, so mentolder is unaffected.
+   ========================================================================= */
+:root {
+  --brass:        var(--copper);
+  --brass-2:      var(--copper-2);
+  --brass-d:      var(--copper-tint);
+  --brass-deep:   var(--copper-deep);
+  --font-serif:   var(--serif);
+  --font-sans:    var(--sans);
+  --font-mono:    var(--mono);
+}

--- a/website/src/layouts/PortalLayout.astro
+++ b/website/src/layouts/PortalLayout.astro
@@ -50,6 +50,8 @@ const avatarInitial = (session.given_name || session.name || session.preferred_u
 const displayName   = session.given_name || session.name || session.preferred_username;
 const brandWord     = config.meta.siteTitle.replace(/\.de$/i, '').toLowerCase();
 const userIsAdmin   = isAdmin(session);
+const brandId       = (process.env.BRAND_ID ?? process.env.BRAND ?? 'mentolder').toLowerCase();
+const isKore        = brandId === 'korczewski';
 ---
 
 <!doctype html>
@@ -57,10 +59,12 @@ const userIsAdmin   = isAdmin(session);
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="icon" type="image/svg+xml" href={isKore ? '/brand/korczewski/favicon.svg' : '/favicon.svg'} />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,300;0,6..72,400;0,6..72,500;0,6..72,600;1,6..72,400&family=Geist:wght@300;400;500;600;700&family=Geist+Mono:wght@400;500&display=swap" rel="stylesheet" />
+    {!isKore && <link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,300;0,6..72,400;0,6..72,500;0,6..72,600;1,6..72,400&family=Geist:wght@300;400;500;600;700&family=Geist+Mono:wght@400;500&display=swap" rel="stylesheet" />}
+    {isKore && <link rel="stylesheet" href="/brand/korczewski/colors_and_type.css" />}
+    {isKore && <link rel="stylesheet" href="/brand/korczewski/kore-app.css" />}
     <title>{title} | Portal — {config.meta.siteTitle}</title>
     <style>
       .portal-nav-item:not(.is-active):hover {
@@ -114,7 +118,7 @@ const userIsAdmin   = isAdmin(session);
       }
     </style>
   </head>
-  <body style="min-height:100vh; background:var(--ink-900); color:var(--fg); display:flex; font-family:var(--font-sans);">
+  <body class={isKore ? 'kore' : ''} style="min-height:100vh; background:var(--ink-900); color:var(--fg); display:flex; font-family:var(--font-sans);">
 
     <!-- Mobile topbar -->
     <div id="portal-mobile-topbar">
@@ -131,7 +135,7 @@ const userIsAdmin   = isAdmin(session);
         </svg>
       </button>
       <div style="display:flex; align-items:center; gap:8px; flex:1; min-width:0;">
-        <div style="width:28px; height:28px; border-radius:50%; background:radial-gradient(circle at 30% 30%, var(--brass-2), var(--brass) 55%, #8a6a2a 100%); display:flex; align-items:center; justify-content:center; flex-shrink:0;">
+        <div style="width:28px; height:28px; border-radius:50%; background:radial-gradient(circle at 30% 30%, var(--brass-2), var(--brass) 55%, var(--brass-deep, #8a6a2a) 100%); display:flex; align-items:center; justify-content:center; flex-shrink:0;">
           <span style="font-family:var(--font-serif); font-size:13px; font-weight:600; color:var(--ink-900);">{avatarInitial}</span>
         </div>
         <span style="font-size:13px; font-weight:600; color:var(--fg); white-space:nowrap; overflow:hidden; text-overflow:ellipsis;">{displayName}</span>
@@ -148,7 +152,7 @@ const userIsAdmin   = isAdmin(session);
       <div style="padding:20px 14px 16px; border-bottom:1px solid var(--line);">
         <!-- Avatar row -->
         <div style="display:flex; align-items:center; gap:10px; margin-bottom:10px;">
-          <div style="width:34px; height:34px; border-radius:50%; background:radial-gradient(circle at 30% 30%, var(--brass-2), var(--brass) 55%, #8a6a2a 100%); box-shadow:inset 0 0 0 1px rgba(255,255,255,.18), 0 0 0 1px rgba(0,0,0,.3); display:flex; align-items:center; justify-content:center; flex-shrink:0;">
+          <div style="width:34px; height:34px; border-radius:50%; background:radial-gradient(circle at 30% 30%, var(--brass-2), var(--brass) 55%, var(--brass-deep, #8a6a2a) 100%); box-shadow:inset 0 0 0 1px rgba(255,255,255,.18), 0 0 0 1px rgba(0,0,0,.3); display:flex; align-items:center; justify-content:center; flex-shrink:0;">
             <span style="font-family:var(--font-serif); font-size:15px; font-weight:600; color:var(--ink-900); line-height:1;">{avatarInitial}</span>
           </div>
           <div style="min-width:0; overflow:hidden;">


### PR DESCRIPTION
## Summary

The user portal on `web.korczewski.de` was rendering in mentolder's brass/Newsreader art style despite the rest of the brand system. Root cause: `PortalLayout.astro` had **zero brand awareness** — no `BRAND_ID` detection, no Kore CSS loading, no `body.kore` class. Meanwhile `public/brand/korczewski/kore-app.css` (562 lines, explicitly designed for "admin + portal surfaces") was orphaned with nothing importing it.

`AdminLayout.astro` was half-migrated: it set `body.kore` and loaded the Kore CSS, but the layout's inline styles still referenced mentolder tokens (`var(--brass)`, `var(--font-serif)`) that the Kore CSS doesn't define — so active-state highlights, badges, and chrome silently fell back.

## Changes

- **`PortalLayout.astro`** — added `isKore` detection (same `process.env.BRAND_ID ?? process.env.BRAND` pattern as `index.astro` and `AdminLayout`); conditionally loads Kore favicon, `colors_and_type.css`, and `kore-app.css`; sets `body.kore`; skips mentolder's Newsreader/Geist Mono font request on Kore.
- **`public/brand/korczewski/colors_and_type.css`** — appended a "legacy token aliases" block mapping `--brass → --copper`, `--brass-2 → --copper-2`, `--brass-d → --copper-tint`, `--brass-deep → --copper-deep`, and `--font-serif/sans/mono → --serif/sans/mono`. Loaded only on Kore deployments, so mentolder is unaffected. AdminLayout's existing `var(--brass)`/`var(--font-serif)` references retroactively resolve to Kore values.
- Replaced two hardcoded `#8a6a2a` deep-stop literals in PortalLayout's avatar gradients with `var(--brass-deep, #8a6a2a)` so the Kore palette covers the deep gradient stop.

No edits needed in AdminLayout — it already had the brand wiring; the alias bridge fixes its leftover token references.

## Test plan

- [ ] `task website:deploy ENV=mentolder` — verify mentolder portal still renders brass/Newsreader (no regression).
- [ ] `task website:deploy ENV=korczewski` — verify `web.korczewski.de/portal` renders Kore palette (Plasma Lime accent, aubergine `#120D1C` ink, Instrument Serif).
- [ ] Spot-check `/portal?section=overview`, `/portal?section=dateien`, `/portal?section=konto` for active-state highlights.
- [ ] Spot-check `/admin` (already had body.kore — verify nav active-state and badge now show lime instead of empty/transparent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)