### PR TITLE
fix(tickets): self-heal notes column in PR3 migration script

### DIFF
--- a/scripts/migrate-projects-to-tickets.mjs
+++ b/scripts/migrate-projects-to-tickets.mjs
@@ -45,6 +45,12 @@ async function migrate(client, dryRun) {
     fksRePointed: 0, viewsCreated: 0, unknownStatus: 0,
   };
 
+  // Make sure the new `notes` column exists. The website pod's
+  // initTicketsSchema() also runs this, but the migration may be invoked
+  // before any website request has hit the new image — in which case the
+  // column would be missing and the INSERTs below would fail.
+  await client.query(`ALTER TABLE tickets.tickets ADD COLUMN IF NOT EXISTS notes TEXT`);
+
   const projectsIsTable    = await isBaseTable(client, 'public', 'projects');
   const subProjectsIsTable = await isBaseTable(client, 'public', 'sub_projects');
   const tasksIsTable       = await isBaseTable(client, 'public', 'project_tasks');


### PR DESCRIPTION
## Summary
The PR3 migration (`scripts/migrate-projects-to-tickets.mjs`) writes `tickets.tickets.notes` without first ensuring the column exists. The column is created by `initTicketsSchema()` in the website code, but on a freshly-rolled pod that hasn't served a tickets-related request yet, the column is missing — and the migration's INSERTs fail with `column "notes" of relation "tickets" does not exist`.

Hit during the PR3/5 prod runbook on both mentolder and korczewski. Worked around in-flight by running `ALTER TABLE tickets.tickets ADD COLUMN IF NOT EXISTS notes TEXT` manually before the retry.

## Fix
One-line idempotent ALTER at the top of `migrate()`. Mirrors what `initTicketsSchema()` does — same pattern, same idempotency. Safe to run on any cluster (clusters that already have the column see a NOTICE and continue).

## Test plan
- [x] `node --check scripts/migrate-projects-to-tickets.mjs`
- [x] `--apply` on mentolder + korczewski already complete (this PR is the fix-forward for any future cluster)

🤖 Generated with [Claude Code](https://claude.com/claude-code)