### PR TITLE
fix(website): scope Kore overrides to body.kore (PR #568 follow-up)

### DIFF
--- a/website/public/brand/korczewski/colors_and_type.css
+++ b/website/public/brand/korczewski/colors_and_type.css
@@ -216,15 +216,37 @@ a { color: inherit; }
 button { font: inherit; }
 
 /* =========================================================================
-   Legacy token aliases — bridge mentolder-style inline styles
-   (var(--brass), var(--font-serif), …) used in PortalLayout/AdminLayout.
-   This file is only loaded on Kore deployments, so mentolder is unaffected.
+   Kore brand overrides — must beat mentolder's global.css.
+
+   global.css (compiled into _astro/*.css) is injected by Astro AFTER
+   explicit <link> tags, so its :root redefines --brass/--ink-900/--font-serif
+   etc. and silently clobbers Kore values. We use body.kore (specificity
+   0,1,1) so these definitions win over :root (0,1,0) regardless of load
+   order. Loaded only on Kore deployments — mentolder is unaffected.
    ========================================================================= */
-:root {
+body.kore {
+  /* Ink palette — override mentolder blue-black with Kore aubergine */
+  --ink-900: #120D1C;
+  --ink-850: #1A1326;
+  --ink-800: #221932;
+  --ink-750: #2C2240;
+
+  /* Foreground / hairlines — Kore values */
+  --fg:      #ECEFF3;
+  --fg-soft: #C6CCD4;
+  --mute:    #8A93A0;
+  --mute-2:  #69707B;
+  --line:    rgba(255,255,255,.07);
+  --line-2:  rgba(255,255,255,.12);
+
+  /* Legacy mentolder-named accents → Kore Plasma Lime / Cyan */
   --brass:        var(--copper);
   --brass-2:      var(--copper-2);
   --brass-d:      var(--copper-tint);
   --brass-deep:   var(--copper-deep);
+  --sage:         var(--teal);
+
+  /* Legacy mentolder-named font tokens → Kore fonts */
   --font-serif:   var(--serif);
   --font-sans:    var(--sans);
   --font-mono:    var(--mono);


### PR DESCRIPTION
## Summary

Follow-up to #568. The portal/admin still rendered mentolder colors after #568 merged because the alias bridge had no actual effect — Astro injects component-imported CSS (compiled \`global.css\` → \`/_astro/admin.D5tUAxCV.css\`) **after** explicit \`<link>\` tags. Both Kore tokens and mentolder \`global.css\` declared \`:root\` (specificity 0,1,0), so last-loaded wins — and that's mentolder.

## Why this only hit the logged-in surfaces

Marketing pages use \`var(--copper)\` / \`var(--teal)\` directly. Those tokens aren't redefined by \`global.css\`, so they survive cascade pressure. Portal and admin use \`var(--brass)\` / \`var(--ink-900)\` / \`var(--font-serif)\` everywhere — exactly the tokens that \`global.css\` redefines on \`:root\`. Result: portal got mentolder palette + Newsreader font despite \`body.kore\` being correctly applied and Kore CSS being correctly loaded.

## Fix

Move the override block from \`:root\` to \`body.kore\` (specificity 0,1,1) so it beats \`:root\` regardless of cascade order. Also widen scope to include every token \`global.css\` redefines:

- \`--ink-{900,850,800,750}\` → Kore aubergine palette
- \`--fg\`, \`--fg-soft\`, \`--mute\`, \`--mute-2\`
- \`--line\`, \`--line-2\`
- \`--brass*\` → \`--copper*\` (Plasma Lime)
- \`--sage\` → \`--teal\` (Cyan)
- \`--font-serif/sans/mono\` → Kore equivalents (Instrument Serif / Geist / JetBrains Mono)

Loaded only on Kore deployments (file is conditionally linked from PortalLayout/AdminLayout). mentolder unaffected.

## Test plan

- [ ] Deploy: \`task feature:website\`
- [ ] \`web.korczewski.de/portal\` — body background = aubergine \`#120D1C\`, accent = Plasma Lime, headings in Instrument Serif
- [ ] \`web.korczewski.de/admin\` — same; nav active state shows lime tint
- [ ] \`web.mentolder.de/portal\` — unchanged (brass / Newsreader)

🤖 Generated with [Claude Code](https://claude.com/claude-code)