### PR TITLE
chore(auto): manifest maintenance 2026-05-08

### DIFF
--- a/k3d/nextcloud-redis.yaml
+++ b/k3d/nextcloud-redis.yaml
@@ -24,7 +24,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: redis
-          image: redis:7-alpine
+          image: redis:7.4-alpine
           imagePullPolicy: Always
           args:
             - redis-server

--- a/k3d/tracking-import-cronjob.yaml
+++ b/k3d/tracking-import-cronjob.yaml
@@ -17,7 +17,7 @@ spec:
           restartPolicy: OnFailure
           containers:
             - name: importer
-              image: node:20-alpine
+              image: node:22-alpine
               resources:
                 requests:
                   cpu: 50m

--- a/k3d/vaultwarden-seed-job.yaml
+++ b/k3d/vaultwarden-seed-job.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
         - name: seeder
-          image: node:20-alpine
+          image: node:22-alpine
           imagePullPolicy: Always
           command: ["/bin/sh", "-c"]
           args:


### PR DESCRIPTION
Automated maintenance pass (2026-05-08) found and fixed the following issues:

## Fixes

### Node 20 EOL → Node 22 (2 files)

Node 20 reached end-of-life in **April 2026**. Two manifests were still using `node:20-alpine` while the rest of the repo already uses `node:22-alpine`:

- `k3d/tracking-import-cronjob.yaml` — `node:20-alpine` → `node:22-alpine`
- `k3d/vaultwarden-seed-job.yaml` — `node:20-alpine` → `node:22-alpine`

### Pin redis minor version (1 file)

`k3d/nextcloud-redis.yaml` used the floating `redis:7-alpine` tag while `k3d/livekit.yaml` already pins to `redis:7.4-alpine`. Pinned for consistency and reproducibility:

- `k3d/nextcloud-redis.yaml` — `redis:7-alpine` → `redis:7.4-alpine`

## Checks performed

- `kustomize build k3d/ --load-restrictor=LoadRestrictionsNone` — **OK** (before and after fix)
- `kustomize build prod-mentolder/` — **OK**
- `kustomize build prod-korczewski/` — **OK**
- All containers have `resources.requests` defined — **OK**
- No new unpinned `:latest` images (outside of intentional `website.yaml` and `talk-transcriber.yaml`)
- Open issues: 1 (issue #545 from 2026-05-06, not yet stale)
- Open PRs: 0

https://claude.ai/code/session_018Z7LSLeqjnr38opkcQ4zfb

---
_Generated by [Claude Code](https://claude.ai/code/session_018Z7LSLeqjnr38opkcQ4zfb)_