### PR TITLE
fix(tests-retention): exec into website pod across namespaces

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1167,6 +1167,10 @@ tasks:
           kubectl rollout status deployment/shared-db -n workspace --timeout=120s
           # Full apply (idempotent — updates configs, adds remaining services)
           kustomize build k3d/ --load-restrictor=LoadRestrictionsNone | envsubst "\$PROD_DOMAIN \$BRAND_NAME \$CONTACT_EMAIL \$BRAND_ID \$LIVEKIT_DOMAIN \$STREAM_DOMAIN" | kubectl apply --server-side --force-conflicts -f -
+          # Tests retention CronJob — applied separately so its Role+RoleBinding
+          # can land in WEBSITE_NAMESPACE (kustomize's top-level namespace
+          # transformer would otherwise force them into workspace).
+          envsubst "\$WORKSPACE_NAMESPACE \$WEBSITE_NAMESPACE" < k3d/tests-retention-cronjob.yaml | kubectl apply -f -
         else
           # Prod: build from overlay, apply to target cluster
           # Apply SealedSecret first so the Secret is ready when pods start
@@ -1207,6 +1211,12 @@ tasks:
           kustomize build "$overlay/" --load-restrictor=LoadRestrictionsNone \
             | envsubst "$ENVSUBST_VARS" \
             | kubectl --context "$ENV_CONTEXT" apply --server-side --force-conflicts -f -
+          # Tests retention CronJob — applied separately so its Role+RoleBinding
+          # can land in WEBSITE_NAMESPACE (kustomize's top-level namespace
+          # transformer would otherwise force them into the workspace ns,
+          # where the website pod does NOT live).
+          envsubst "\$WORKSPACE_NAMESPACE \$WEBSITE_NAMESPACE" < k3d/tests-retention-cronjob.yaml \
+            | kubectl --context "$ENV_CONTEXT" apply -f -
         fi
       - task: keycloak:sync
         vars: { ENV: "{{.ENV}}" }

--- a/k3d/kustomization.yaml
+++ b/k3d/kustomization.yaml
@@ -55,8 +55,12 @@ resources:
   # Anforderungs-Tracking
   - tracking.yaml
   - tracking-import-cronjob.yaml
-  # Tests retention (prune tests/results/ nightly)
-  - tests-retention-cronjob.yaml
+  # Tests retention (prune tests/results/ nightly).
+  # Applied separately via envsubst by `workspace:deploy` so its Role+RoleBinding
+  # can land in ${WEBSITE_NAMESPACE} (cross-NS exec into the website pod) — the
+  # top-level `namespace: workspace` in this kustomization would otherwise force
+  # all retention resources into the workspace ns, where the website does NOT live.
+  # See k3d/tests-retention-cronjob.yaml.
   # Transkription
   - whisper.yaml
   # Live-Transkription Bot

--- a/k3d/tests-retention-cronjob.yaml
+++ b/k3d/tests-retention-cronjob.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: tests-results-retention
-  namespace: workspace
+  namespace: ${WORKSPACE_NAMESPACE}
 spec:
   schedule: '0 3 * * *'
   successfulJobsHistoryLimit: 1
@@ -28,9 +28,9 @@ spec:
               args:
                 - |
                   set -e
-                  POD=$(kubectl -n workspace get pod -l app=website -o jsonpath='{.items[0].metadata.name}')
-                  if [ -z "$POD" ]; then echo "no website pod"; exit 0; fi
-                  kubectl -n workspace exec "$POD" -- sh -c '
+                  POD=$(kubectl -n ${WEBSITE_NAMESPACE} get pod -l app=website -o jsonpath='{.items[0].metadata.name}')
+                  if [ -z "$POD" ]; then echo "no website pod in ${WEBSITE_NAMESPACE}"; exit 0; fi
+                  kubectl -n ${WEBSITE_NAMESPACE} exec "$POD" -- sh -c '
                     cd /app/tests/results 2>/dev/null || cd /tests/results 2>/dev/null || exit 0
                     find . -maxdepth 1 -type f \( -name "*.json" -o -name "*.md" -o -name "*.jsonl" \) -mtime +30 -print -delete
                     find . -maxdepth 1 -type d -name "playwright-traces" -mtime +14 -print -exec rm -rf {} +
@@ -40,13 +40,16 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: tests-retention-sa
-  namespace: workspace
+  namespace: ${WORKSPACE_NAMESPACE}
 ---
+# Role lives in the website namespace because that is where the target pods
+# (the Astro website Deployment) actually run. The CronJob's SA in
+# ${WORKSPACE_NAMESPACE} reaches across via the RoleBinding below.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: tests-retention-role
-  namespace: workspace
+  namespace: ${WEBSITE_NAMESPACE}
 rules:
   - apiGroups: [""]
     resources: [pods]
@@ -59,11 +62,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: tests-retention-rb
-  namespace: workspace
+  namespace: ${WEBSITE_NAMESPACE}
 subjects:
   - kind: ServiceAccount
     name: tests-retention-sa
-    namespace: workspace
+    namespace: ${WORKSPACE_NAMESPACE}
 roleRef:
   kind: Role
   name: tests-retention-role


### PR DESCRIPTION
## Summary

The nightly `tests-results-retention` CronJob added in #577 was a silent
no-op: it queried `kubectl -n workspace get pod -l app=website`, but the
website Deployment lives in `${WEBSITE_NAMESPACE}` (`website` on mentolder,
`website-korczewski` on korczewski). The selector matched zero pods, the
inner script printed "no website pod" and exited, and `tests/results/`
was never pruned.

- CronJob + SA stay in `${WORKSPACE_NAMESPACE}`.
- Role + RoleBinding move to `${WEBSITE_NAMESPACE}` (cross-NS exec into
  the website pod, RoleBinding subject = SA in `${WORKSPACE_NAMESPACE}`).
- Inner script now uses `kubectl -n ${WEBSITE_NAMESPACE} ...` for both
  `get pod` and `exec`.

### Why the obvious fix didn't work

Adding `namespace: ${WEBSITE_NAMESPACE}` to the Role/RoleBinding inside
kustomize doesn't help: the top-level `namespace: workspace` in
`k3d/kustomization.yaml` is a kustomize transformer that runs *after*
patches and overrides every resource's namespace before envsubst can see
it. The fix lifts the manifest out of kustomize and applies it via
envsubst directly from `workspace:deploy` (both dev and prod paths).

## Test plan

- [x] `task test:manifests` — 24/24 pass
- [x] `task test:unit` — pass (env-seal + assertion lib + script syntax)
- [x] `task workspace:validate` — `✓ Manifests are valid`
- [x] Dry-render with `WORKSPACE_NAMESPACE=workspace-korczewski WEBSITE_NAMESPACE=website-korczewski envsubst < k3d/tests-retention-cronjob.yaml` — verified namespaces resolve and script body references the right namespaces.
- [x] `kustomize build k3d/ | grep tests-retention` returns no hits (no longer in kustomize set, applied via envsubst as intended).
- [ ] After merge: `task workspace:deploy ENV=mentolder` + `ENV=korczewski`, then delete orphan Role/RoleBinding from `workspace`/`workspace-korczewski` ns:
      ```
      kubectl --context mentolder  -n workspace             delete role tests-retention-role rolebinding tests-retention-rb 2>/dev/null
      kubectl --context korczewski -n workspace-korczewski  delete role tests-retention-role rolebinding tests-retention-rb 2>/dev/null
      ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)