### PR TITLE
fix(tests-retention): replace dead bitnami/kubectl image with alpine/k8s

### DIFF
--- a/k3d/tests-retention-cronjob.yaml
+++ b/k3d/tests-retention-cronjob.yaml
@@ -23,7 +23,12 @@ spec:
                         values: [gekko-hetzner-2, gekko-hetzner-3, gekko-hetzner-4, pk-hetzner, pk-hetzner-2, pk-hetzner-3]
           containers:
             - name: prune
-              image: bitnami/kubectl:1.31
+              # alpine/k8s ships kubectl + /bin/sh on Alpine; matches the k3s
+              # 1.34.x line our prod clusters run. The previous image
+              # `bitnami/kubectl:1.31` was both version-mismatched and pulled
+              # from a Bitnami tag that has since been removed from Docker Hub
+              # (ImagePullBackOff: "docker.io/bitnami/kubectl:1.31: not found").
+              image: alpine/k8s:1.34.0
               command: [sh, -c]
               args:
                 - |


### PR DESCRIPTION
## Summary

Smoke-testing the namespace fix from #579 revealed the retention pod was
stuck in `ImagePullBackOff`:

```
docker.io/bitnami/kubectl:1.31: not found
```

The Bitnami `kubectl:1.31` tag was removed from Docker Hub. It was also
already mismatched with our k3s 1.34 prod clusters.

`alpine/k8s:1.34.0` ships both `kubectl` and `/bin/sh` (the CronJob uses
`sh -c`) and matches the cluster minor version.

## Test plan

- [x] `kubectl run kubectl-image-test --image=alpine/k8s:1.34.0 --command -- /bin/sh -c 'kubectl version --client'` → `Client Version: v1.34.0`
- [ ] After merge: `task workspace:deploy ENV=mentolder` + `ENV=korczewski`, then trigger `kubectl create job tests-retention-smoke --from=cronjob/tests-results-retention -n <ns>` and verify the pod reaches `Succeeded`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)