### PR TITLE
fix(help-panel): restore + fix positioning and content

### DIFF
--- a/website/src/components/HelpPanel.svelte
+++ b/website/src/components/HelpPanel.svelte
@@ -26,15 +26,15 @@
 
 <svelte:window onkeydown={(e) => { if (e.key === 'Escape' && open) close(); }} />
 
-<!-- Floating Button -->
+<!-- Floating Button — sits above BugReportWidget (bottom-6 right-6) -->
 <button
   onclick={toggle}
   aria-label={open ? 'Hilfe schließen' : 'Hilfe öffnen'}
   style="
     position: fixed;
-    bottom: 1.5rem;
-    left: 1.5rem;
-    z-index: 50;
+    bottom: 5.5rem;
+    right: 1.5rem;
+    z-index: 60;
     width: 40px;
     height: 40px;
     border-radius: 50%;
@@ -68,7 +68,7 @@
     style="
       position: fixed;
       inset: 0;
-      z-index: 51;
+      z-index: 61;
       background: rgba(0,0,0,0.35);
       display: none;
     "
@@ -89,7 +89,7 @@
     top: 0;
     right: 0;
     bottom: 0;
-    z-index: 52;
+    z-index: 62;
     width: 320px;
     background: var(--ink-850);
     border-left: 1px solid var(--line);

--- a/website/src/layouts/AdminLayout.astro
+++ b/website/src/layouts/AdminLayout.astro
@@ -2,6 +2,7 @@
 import '../styles/global.css';
 import { config } from '../config/index';
 import BugReportWidget from '../components/BugReportWidget.svelte';
+import HelpPanel from '../components/HelpPanel.svelte';
 import AssistantWidget from '../components/assistant/AssistantWidget.svelte';
 const ASSISTANT_ENABLED = (process.env.ENABLE_ASSISTANT_ADMIN ?? 'false') === 'true';
 import ChatWidget from '../components/ChatWidget.svelte';
@@ -417,8 +418,10 @@ const isKore = brandId === 'korczewski';
       <slot />
     </main>
 
-    {ASSISTANT_ENABLED && (
+    {ASSISTANT_ENABLED ? (
       <AssistantWidget client:load profile="admin" />
+    ) : (
+      <HelpPanel client:load section={helpSection} context="admin" />
     )}
     <BugReportWidget client:load />
     <ChatWidget client:load />

--- a/website/src/layouts/PortalLayout.astro
+++ b/website/src/layouts/PortalLayout.astro
@@ -4,6 +4,7 @@ import { config } from '../config/index';
 import { isAdmin } from '../lib/auth';
 import type { UserSession } from '../lib/auth';
 import ChatWidget from '../components/ChatWidget.svelte';
+import HelpPanel from '../components/HelpPanel.svelte';
 import AssistantWidget from '../components/assistant/AssistantWidget.svelte';
 const ASSISTANT_ENABLED = (process.env.ENABLE_ASSISTANT_PORTAL ?? 'false') === 'true';
 import SessionExpiryWarning from '../components/SessionExpiryWarning.svelte';
@@ -256,8 +257,10 @@ const isKore        = brandId === 'korczewski';
       <slot />
     </main>
 
-    {ASSISTANT_ENABLED && (
+    {ASSISTANT_ENABLED ? (
       <AssistantWidget client:load profile="portal" />
+    ) : (
+      <HelpPanel client:load section={section} context="portal" />
     )}
     <ChatWidget client:load />
     <SessionExpiryWarning client:load />

--- a/website/src/lib/helpContent.ts
+++ b/website/src/lib/helpContent.ts
@@ -338,6 +338,57 @@ export const helpContent: Record<HelpContext, Record<string, HelpSection>> = {
         },
       ],
     },
+    tickets: {
+      title: 'Tickets',
+      description: 'Aufgaben, Features, Bugs und Projekte verwalten — alles in einem System.',
+      actions: [
+        'Neues Ticket anlegen (Bug, Feature, Task oder Projekt)',
+        'Ticket nach Status, Typ, Komponente oder Schlagwort filtern',
+        'Ticket einem Teammitglied zuweisen',
+        'Schlagwörter (Tags) per Klick oder Textsuche filtern',
+      ],
+      guides: [
+        {
+          title: 'Ticket anlegen',
+          steps: [
+            'Klicke auf „+ Neues Ticket".',
+            'Wähle den Typ: Bug, Feature, Task oder Projekt.',
+            'Gib Titel und optional eine Beschreibung ein.',
+            'Setze Priorität, Komponente und weise das Ticket zu.',
+            'Klicke auf „Erstellen".',
+          ],
+        },
+        {
+          title: 'Nach Schlagwort filtern',
+          steps: [
+            'Gib einen Tag-Namen ins Feld „Schlagwort" ein.',
+            'Klicke auf „Filtern".',
+            'Alternativ: klicke direkt auf einen Tag-Chip in der Tabelle.',
+          ],
+        },
+      ],
+    },
+    live: {
+      title: 'Live-Stream',
+      description: 'Livestream starten, Zuschauer verwalten und Aufzeichnungen herunterladen.',
+      actions: [
+        'Stream starten und stoppen',
+        'Stream-Titel und -Beschreibung setzen',
+        'Aufzeichnung herunterladen',
+        'Zuschauer-Link teilen',
+      ],
+      guides: [
+        {
+          title: 'Stream starten',
+          steps: [
+            'Stelle sicher, dass OBS oder dein Stream-Tool konfiguriert ist.',
+            'Klicke auf „Stream starten" — LiveKit erstellt einen neuen Raum.',
+            'Teile den Zuschauer-Link unter /portal/stream.',
+            'Klicke auf „Stream beenden" wenn du fertig bist.',
+          ],
+        },
+      ],
+    },
     zeiterfassung: {
       title: 'Zeiterfassung',
       description: 'Arbeitsstunden für Projekte und Klienten erfassen und Berichte erstellen.',


### PR DESCRIPTION
## Summary

Reverts the removal of HelpPanel — it was dropped too aggressively. The real issues were:

- **Wrong position**: button was bottom-left while the slide-over panel opens from the right — confusing UX
- **z-index conflict**: HelpPanel button (z-50) was covered by the BugReportWidget modal backdrop (also z-50) whenever that modal opened

**Fixes:**
- Button moved to `bottom: 5.5rem; right: 1.5rem` — sits directly above the BugReportWidget trigger, same corner as the slide-over panel
- z-indexes raised: button → 60, backdrop → 61, panel → 62 (above BugReport modal's z-50)
- Added `tickets` and `live` help sections so those pages show real content instead of the fallback message

🤖 Generated with [Claude Code](https://claude.ai/claude-code)