### PR TITLE
feat(testdata): Testdaten-Panel im Admin-Monitoring

### DIFF
--- a/docs/superpowers/plans/2026-05-08-questionnaire-project-integration.md
+++ b/docs/superpowers/plans/2026-05-08-questionnaire-project-integration.md
@@ -1,0 +1,679 @@
+# Questionnaire → Project Integration & Content Update — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Link every questionnaire assignment to an auto-created project in the tickets system, add an archive status and per-question task-creation to the review page, and update the 10 system-test templates with staleness fixes plus two new categories (LiveKit and Projektmanagement).
+
+**Architecture:** The `assign.ts` API endpoint creates a `tickets.tickets` project before calling `createQAssignment`, passing the new project_id in. `questionnaire_assignments` gains a nullable `project_id` FK and an `archived_at` timestamp. The review page (`[assignmentId].astro`) gains a project badge, per-question "Als Aufgabe anlegen" buttons wired to a new API route, and an "Archivieren" action. System-test seed data grows from 10 to 12 templates.
+
+**Tech Stack:** TypeScript, Astro, PostgreSQL (via `pg` pool), Vitest (unit tests). Run tests with `bun run test` inside `website/`. Deploy with `task website:redeploy ENV=mentolder` (then korczewski).
+
+---
+
+## File map
+
+| File | Action | What changes |
+|---|---|---|
+| `website/src/lib/questionnaire-db.ts` | Modify | DB migration cols; `QAssignment` type; `AssignmentStatus`; `createQAssignment`; `updateQAssignment`; all SELECT queries |
+| `website/src/pages/api/admin/questionnaires/assign.ts` | Modify | Create project before assignment, pass `projectId` |
+| `website/src/pages/api/admin/questionnaires/assignments/[id]/create-task.ts` | Create | New route: create a task in the linked project |
+| `website/src/pages/admin/fragebogen/[assignmentId].astro` | Modify | Project badge; "Als Aufgabe anlegen" buttons; "Archivieren" button |
+| `website/src/lib/system-test-seed-data.ts` | Modify | Fix 4 stale items; add ST 11 + ST 12 |
+| `website/src/lib/system-test-seed-data.test.ts` | Modify | Update expected counts (10→12, 89→104) |
+
+---
+
+### Task 1: DB migration + types in questionnaire-db.ts
+
+**Files:**
+- Modify: `website/src/lib/questionnaire-db.ts`
+
+Add two nullable columns to `questionnaire_assignments` and update all TypeScript types that reference assignment rows.
+
+- [ ] **Step 1: Add `'archived'` to `AssignmentStatus` and `project_id` / `archived_at` to `QAssignment`**
+
+In `website/src/lib/questionnaire-db.ts`, change lines near the top:
+
+```typescript
+export type AssignmentStatus = 'pending' | 'in_progress' | 'submitted' | 'reviewed' | 'archived' | 'dismissed';
+```
+
+And extend `QAssignment`:
+
+```typescript
+export interface QAssignment {
+  id: string;
+  customer_id: string;
+  template_id: string;
+  template_title: string;
+  status: AssignmentStatus;
+  coach_notes: string;
+  assigned_at: string;
+  submitted_at: string | null;
+  reviewed_at: string | null;
+  archived_at: string | null;   // new
+  dismissed_at: string | null;
+  dismiss_reason: string | null;
+  project_id: string | null;    // new
+}
+```
+
+- [ ] **Step 2: Add column migrations inside `initDb()`**
+
+Find the block with `ALTER TABLE questionnaire_assignments ADD COLUMN IF NOT EXISTS dismissed_at` and add right after it:
+
+```typescript
+await pool.query(`ALTER TABLE questionnaire_assignments ADD COLUMN IF NOT EXISTS project_id UUID REFERENCES tickets.tickets(id) ON DELETE SET NULL`);
+await pool.query(`ALTER TABLE questionnaire_assignments ADD COLUMN IF NOT EXISTS archived_at TIMESTAMPTZ`);
+```
+
+- [ ] **Step 3: Update all SELECT queries that return assignment rows**
+
+There are three: `createQAssignment`, `getQAssignment`, and `updateQAssignment`. Each has a `RETURNING` or `SELECT` list. Add `a.project_id, a.archived_at` (or just `project_id, archived_at` in the RETURNING clause).
+
+**`createQAssignment` RETURNING clause** — change:
+```typescript
+`INSERT INTO questionnaire_assignments (customer_id, template_id)
+ VALUES ($1, $2)
+ RETURNING id, customer_id, template_id, status, coach_notes, assigned_at,
+           submitted_at, reviewed_at, dismissed_at, dismiss_reason`,
+```
+to:
+```typescript
+`INSERT INTO questionnaire_assignments (customer_id, template_id, project_id)
+ VALUES ($1, $2, $3)
+ RETURNING id, customer_id, template_id, status, coach_notes, assigned_at,
+           submitted_at, reviewed_at, archived_at, dismissed_at, dismiss_reason, project_id`,
+[params.customerId, params.templateId, params.projectId ?? null],
+```
+
+Also add `projectId?: string` to the params type:
+```typescript
+export async function createQAssignment(params: {
+  customerId: string; templateId: string; projectId?: string;
+}): Promise<QAssignment> {
+```
+
+**`getQAssignment` SELECT** — in the `SELECT a.id, a.customer_id, ...` query, add `, a.archived_at, a.project_id`:
+```typescript
+`SELECT a.id, a.customer_id, a.template_id, t.title AS template_title,
+        a.status, a.coach_notes, a.assigned_at, a.submitted_at, a.reviewed_at,
+        a.archived_at, a.dismissed_at, a.dismiss_reason, a.project_id
+ FROM questionnaire_assignments a
+ JOIN questionnaire_templates t ON t.id = a.template_id
+ WHERE a.id = $1`,
+```
+
+**`listQAssignmentsForCustomer` SELECT** — same addition:
+```typescript
+`SELECT a.id, a.customer_id, a.template_id, t.title AS template_title,
+        a.status, a.coach_notes, a.assigned_at, a.submitted_at, a.reviewed_at,
+        a.archived_at, a.dismissed_at, a.dismiss_reason, a.project_id
+ FROM questionnaire_assignments a
+ JOIN questionnaire_templates t ON t.id = a.template_id
+ WHERE a.customer_id = $1
+ ORDER BY a.assigned_at DESC`,
+```
+
+**`updateQAssignment` RETURNING clause** — add `archived_at, project_id`:
+```typescript
+`UPDATE questionnaire_assignments SET ${sets.join(', ')}
+ WHERE id = $${vals.length}
+ RETURNING id, customer_id, template_id, status, coach_notes, assigned_at,
+           submitted_at, reviewed_at, archived_at, dismissed_at, dismiss_reason, project_id`,
+```
+
+- [ ] **Step 4: Handle `archived_at` in `updateQAssignment`**
+
+Find the block that sets `submitted_at`, `reviewed_at`, `dismissed_at` and add:
+```typescript
+if (params.status === 'archived') sets.push(`archived_at = now()`);
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add website/src/lib/questionnaire-db.ts
+git commit -m "feat(questionnaire): add project_id + archived_at columns and archived status"
+```
+
+---
+
+### Task 2: Auto-create project on assignment in assign.ts
+
+**Files:**
+- Modify: `website/src/pages/api/admin/questionnaires/assign.ts`
+
+The endpoint already has everything needed: `customer.id`, `tpl.title`, `tpl.is_system_test`, `clientName`, and `PROD_DOMAIN`. Create the project before creating the assignment.
+
+- [ ] **Step 1: Add imports**
+
+At the top of `assign.ts`, add `createProject` to the import from `website-db`:
+```typescript
+import { getCustomerByEmail, createProject } from '../../../../lib/website-db';
+```
+
+Also add a brand constant near the PROD_DOMAIN line:
+```typescript
+const BRAND = process.env.BRAND || 'mentolder';
+```
+
+- [ ] **Step 2: Create project and pass projectId to createQAssignment**
+
+Replace this line:
+```typescript
+const assignment = await createQAssignment({ customerId: customer.id, templateId: tpl.id });
+```
+
+With:
+```typescript
+const projectTitle = tpl.is_system_test
+  ? tpl.title
+  : `${tpl.title} — ${clientName}`;
+
+const projectId = await createProject({
+  brand: BRAND,
+  name: projectTitle,
+  status: 'entwurf',
+  priority: 'mittel',
+  customerId: customer.id,
+}).catch((err) => {
+  console.error('[assign] project creation failed, continuing without project_id:', err);
+  return null;
+});
+
+const assignment = await createQAssignment({
+  customerId: customer.id,
+  templateId: tpl.id,
+  projectId: projectId ?? undefined,
+});
+```
+
+- [ ] **Step 3: Verify locally**
+
+Start the dev server (`task website:dev`) and assign a template to a test user. Check that `/admin/projekte` shows the new project. Check `questionnaire_assignments` in the DB has `project_id` set.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add website/src/pages/api/admin/questionnaires/assign.ts
+git commit -m "feat(questionnaire): auto-create tickets project on assignment"
+```
+
+---
+
+### Task 3: New API route — create-task
+
+**Files:**
+- Create: `website/src/pages/api/admin/questionnaires/assignments/[id]/create-task.ts`
+
+This route creates a `ProjectTask` under the assignment's linked project. One task per question, triggered by the admin in the review UI.
+
+- [ ] **Step 1: Create the directory and file**
+
+```bash
+mkdir -p "website/src/pages/api/admin/questionnaires/assignments/[id]"
+```
+
+Create `website/src/pages/api/admin/questionnaires/assignments/[id]/create-task.ts`:
+
+```typescript
+import type { APIRoute } from 'astro';
+import { getSession, isAdmin } from '../../../../../../lib/auth';
+import { getQAssignment, getQQuestion } from '../../../../../../lib/questionnaire-db';
+import { createProjectTask } from '../../../../../../lib/website-db';
+
+export const POST: APIRoute = async ({ request, params }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) return new Response('Unauthorized', { status: 401 });
+
+  const assignment = await getQAssignment(params.id!).catch(() => null);
+  if (!assignment) return new Response(JSON.stringify({ error: 'Auftrag nicht gefunden.' }), { status: 404 });
+  if (!assignment.project_id) {
+    return new Response(JSON.stringify({ error: 'Kein Projekt verknüpft.' }), { status: 409 });
+  }
+
+  const body = await request.json() as { questionId?: string };
+  if (!body.questionId) {
+    return new Response(JSON.stringify({ error: 'questionId erforderlich.' }), { status: 400 });
+  }
+
+  const question = await getQQuestion(body.questionId).catch(() => null);
+  if (!question) return new Response(JSON.stringify({ error: 'Frage nicht gefunden.' }), { status: 404 });
+
+  const taskName = question.question_text.length > 120
+    ? question.question_text.slice(0, 117) + '…'
+    : question.question_text;
+
+  const taskId = await createProjectTask({
+    projectId: assignment.project_id,
+    name: taskName,
+    description: question.test_expected_result ?? undefined,
+    status: 'entwurf',
+    priority: 'mittel',
+  });
+
+  return new Response(JSON.stringify({ taskId }), {
+    status: 201,
+    headers: { 'Content-Type': 'application/json' },
+  });
+};
+```
+
+- [ ] **Step 2: Export `getQQuestion` from questionnaire-db.ts**
+
+Check if `getQQuestion` already exists. If not, add it after `listQQuestions`:
+
+```typescript
+export async function getQQuestion(id: string): Promise<QQuestion | null> {
+  const r = await pool.query(
+    `SELECT id, template_id, position, question_text, question_type,
+            test_expected_result, test_function_url, test_menu_path, test_role, created_at
+     FROM questionnaire_questions WHERE id = $1`,
+    [id],
+  );
+  return r.rows[0] ?? null;
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add "website/src/pages/api/admin/questionnaires/assignments/[id]/create-task.ts" \
+        website/src/lib/questionnaire-db.ts
+git commit -m "feat(questionnaire): POST create-task route for assignment review"
+```
+
+---
+
+### Task 4: Review page enhancements ([assignmentId].astro)
+
+**Files:**
+- Modify: `website/src/pages/admin/fragebogen/[assignmentId].astro`
+
+Add three things: (1) project badge at top, (2) "Als Aufgabe anlegen" button per question row, (3) "Archivieren" button in the notes section.
+
+- [ ] **Step 1: Add project badge**
+
+In the frontmatter, `assignment` already has `project_id`. In the HTML, find the header block (the `div.mb-8` with title + status badge) and add the project link below the `<p>Eingereicht:…</p>` line:
+
+```astro
+{assignment.project_id && (
+  <a
+    href={`/admin/projekte/${assignment.project_id}`}
+    class="inline-flex items-center gap-1 mt-2 text-xs text-gold/70 hover:text-gold underline"
+  >
+    → Verknüpftes Projekt öffnen
+  </a>
+)}
+```
+
+- [ ] **Step 2: Add "Als Aufgabe anlegen" button per question**
+
+Locate the question rendering loop (it renders each question with its answer). For each `test_step` question that has been answered, add the button after the answer display. Find the block where `.file-bug-btn` is rendered (it's inside the step question loop) and add alongside it:
+
+```astro
+{assignment.project_id && (
+  <button
+    class="create-task-btn text-xs px-2 py-1 bg-dark border border-dark-lighter text-light/70 rounded hover:border-gold/40 hover:text-light transition-colors"
+    data-question-id={q.id}
+    data-assignment-id={assignmentId}
+  >
+    + Aufgabe
+  </button>
+)}
+<span id={`task-result-${q.id}`} class="text-xs text-green-400 hidden"></span>
+```
+
+- [ ] **Step 3: Add "Archivieren" button to notes section**
+
+Find the `{assignment.status !== 'reviewed' && (...)}` block for the "Als besprochen markieren" button, and after it add:
+
+```astro
+{assignment.status === 'reviewed' && (
+  <button id="archive-btn"
+    class="px-4 py-2 bg-dark border border-dark-lighter text-muted rounded-lg text-sm hover:border-gold/40 hover:text-light transition-colors">
+    Archivieren
+  </button>
+)}
+```
+
+Also update the status badge color block to handle `'archived'`:
+
+```astro
+assignment.status === 'archived' ? 'bg-slate-500/10 text-slate-400 border-slate-500/20'
+```
+
+- [ ] **Step 4: Wire up JS for new buttons**
+
+In the `<script define:vars={{ assignmentId }}>` block, add after the existing `closeBugModal` function:
+
+```javascript
+// Task creation
+document.querySelectorAll('.create-task-btn').forEach(btn => {
+  btn.addEventListener('click', async () => {
+    const questionId = btn.dataset.questionId;
+    btn.disabled = true;
+    btn.textContent = '…';
+    try {
+      const r = await fetch(
+        `/api/admin/questionnaires/assignments/${assignmentId}/create-task`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ questionId }),
+        },
+      );
+      const data = await r.json().catch(() => ({}));
+      const resultEl = document.getElementById(`task-result-${questionId}`);
+      if (r.ok && data.taskId) {
+        btn.remove();
+        if (resultEl) {
+          resultEl.textContent = '✓ Aufgabe angelegt';
+          resultEl.classList.remove('hidden');
+        }
+      } else {
+        btn.disabled = false;
+        btn.textContent = '+ Aufgabe';
+        if (resultEl) {
+          resultEl.textContent = data.error || 'Fehler';
+          resultEl.className = 'text-xs text-red-400';
+          resultEl.classList.remove('hidden');
+        }
+      }
+    } catch {
+      btn.disabled = false;
+      btn.textContent = '+ Aufgabe';
+    }
+  });
+});
+
+// Archive
+document.getElementById('archive-btn')?.addEventListener('click', async () => {
+  const r = await fetch(`/api/admin/questionnaires/assignments/${assignmentId}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ status: 'archived' }),
+  });
+  if (r.ok) window.location.reload();
+});
+```
+
+- [ ] **Step 5: Verify the review page in the browser**
+
+Start `task website:dev`. Create a test assignment, submit answers in the portal, then open the review page in admin. Verify:
+- Project badge links to `/admin/projekte/<id>` when project_id is set.
+- "+ Aufgabe" button appears on each answered question.
+- Clicking it creates a task and shows "✓ Aufgabe angelegt".
+- After marking "Als besprochen markieren", the "Archivieren" button appears.
+- Clicking "Archivieren" reloads the page and shows `archived` status badge.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add website/src/pages/admin/fragebogen/\[assignmentId\].astro
+git commit -m "feat(questionnaire): project badge, task creation, and archive action in review page"
+```
+
+---
+
+### Task 5: Content updates — system-test-seed-data.ts
+
+**Files:**
+- Modify: `website/src/lib/system-test-seed-data.ts`
+
+Four stale fixes + two new templates.
+
+- [ ] **Step 1: Fix ST 3 title**
+
+Change:
+```typescript
+title: 'System-Test 3: Kommunikation — Fragebogen-Widget, Inbox & E-Mail',
+```
+To:
+```typescript
+title: 'System-Test 3: Kommunikation — Chat-Widget, Inbox & E-Mail',
+```
+
+- [ ] **Step 2: Fix ST 2 step 6 expected_result**
+
+Find step 6 in the ST 2 template (the "Projekt anlegen" step). Update `expected_result`:
+```typescript
+expected_result: 'Projekt erscheint in /admin/projekte; Tickets-System-Projekt mit Status „Entwurf" angelegt; Zuordnung zum Client sichtbar.',
+```
+
+- [ ] **Step 3: Fix ST 4 step 2 expected_result**
+
+Find step 2 in the ST 4 template (the "Template veröffentlichen + Client zuweisen" step). Update `expected_result`:
+```typescript
+expected_result: 'Assignment erstellt; Nutzer sieht Fragebogen im Portal-Dashboard; verknüpftes Projekt automatisch unter /admin/projekte angelegt.',
+```
+
+- [ ] **Step 4: Fix ST 9 step 6 expected_result**
+
+Find the last step of ST 9 (the "Test-Results-Panel" step). Update `expected_result`:
+```typescript
+expected_result: 'Alle 12 Templates sichtbar mit last_result/last_success_at; Drilldown auf Question-Level möglich.',
+```
+
+- [ ] **Step 5: Add ST 11 — LiveKit & Streaming (7 steps)**
+
+After the closing `},` of ST 10, before the final `];`, add:
+
+```typescript
+  {
+    title: 'System-Test 11: LiveKit & Streaming',
+    description: 'Vollständiger Test des LiveKit-Streaming-Stacks: Admin-Steuerseite, Stream starten/stoppen, Viewer-Portal, RTMP-Ingress, Recording-Liste und Pod-Status.',
+    instructions: 'Schritte 1, 4, 5, 6, 7 im Admin-Browser. Schritt 2 startet den Stream — danach Schritt 3 im Testnutzer-Browser. Schritt 6 beendet den Stream.',
+    steps: [
+      {
+        question_text: 'Öffne die Admin-Stream-Seite (Link) — prüfe ob der Stream-Status „offline" angezeigt wird und die Seite ohne Fehler lädt.',
+        expected_result: 'Seite lädt; Stream-Status „offline"; keine Fehlermeldungen.',
+        test_function_url: '/admin/stream', test_role: 'admin',
+      },
+      {
+        question_text: 'Klicke auf der Admin-Stream-Seite (Link) den Start-Button — prüfe ob der Status auf „live" wechselt und ein Stream-Token generiert wird.',
+        expected_result: 'Status wechselt auf „live"; Stream-Token sichtbar.',
+        test_function_url: '/admin/stream', test_role: 'admin',
+      },
+      {
+        question_text: 'Öffne das Viewer-Portal (Link) im Testnutzer-Browser während der Stream läuft — prüfe ob der Stream-Player sichtbar ist und keine Verbindungsfehler erscheinen. → Nutzer: zweites Browser-Profil.',
+        expected_result: 'Stream-Player sichtbar; Verbindung aufgebaut; kein Fehler im Browser.',
+        test_function_url: '/portal/stream', test_role: 'user',
+        agent_notes: 'Zweites Browser-Profil (Testnutzer) erforderlich. Stream muss laufen (Schritt 2 abgeschlossen).',
+      },
+      {
+        question_text: 'Öffne die Admin-Stream-Seite (Link) — prüfe ob der RTMP-Ingress-Status und die RTMP-URL angezeigt werden.',
+        expected_result: 'RTMP-URL sichtbar; Ingress-Status angezeigt (aktiv oder bereit).',
+        test_function_url: '/admin/stream', test_role: 'admin',
+      },
+      {
+        question_text: 'Öffne die Admin-Stream-Seite (Link) → klicke „Aufnahmen" oder scrolle zur Recordings-Liste — prüfe ob vorhandene MP4-Dateien aufgelistet werden oder eine leere Liste ohne Fehler erscheint.',
+        expected_result: 'Recordings-Liste lädt; MP4-Dateien sichtbar oder leere Liste ohne Fehler.',
+        test_function_url: '/admin/stream', test_role: 'admin',
+      },
+      {
+        question_text: 'Klicke auf der Admin-Stream-Seite (Link) den Stop-Button — prüfe ob der Status auf „offline" wechselt und das Viewer-Portal „kein Stream" anzeigt.',
+        expected_result: 'Status wechselt auf „offline"; Viewer-Portal zeigt „kein Stream aktiv".',
+        test_function_url: '/admin/stream', test_role: 'admin',
+      },
+      {
+        question_text: 'Öffne Monitoring (Link) — prüfe ob der `livekit-server` Pod im Status „Running" ist und kein CrashLoop vorliegt.',
+        expected_result: '`livekit-server` Pod im Status „Running"; kein CrashLoop.',
+        test_function_url: '/admin/monitoring', test_role: 'admin',
+      },
+    ],
+  },
+  {
+    title: 'System-Test 12: Projektmanagement',
+    description: 'Vollständiger Test des Projektmanagement-Moduls: Projekte, Teilprojekte, Aufgaben, Zeiterfassung, Meeting-Verknüpfung und Archivierung.',
+    instructions: 'Alle Schritte im Admin-Browser. Öffne jeweils den Link im Schritt. Schritte bauen aufeinander auf — in Reihenfolge abarbeiten.',
+    steps: [
+      {
+        question_text: 'Öffne Projekte (Link) → klicke „Neues Projekt" → fülle Titel und Client aus → speichere — prüfe ob das Projekt in der Liste erscheint.',
+        expected_result: 'Projekt erscheint in der Liste; Pflichtfeld-Validierung serverseitig.',
+        test_function_url: '/admin/projekte', test_role: 'admin',
+      },
+      {
+        question_text: 'Öffne das neu angelegte Projekt (Link) → wechsle zum Reiter „Teilprojekte" → klicke „Neues Teilprojekt" → trage Titel ein und speichere — prüfe ob das Teilprojekt erscheint.',
+        expected_result: 'Teilprojekt erscheint unter dem Reiter „Teilprojekte" des Projekts.',
+        test_function_url: '/admin/projekte', test_role: 'admin',
+      },
+      {
+        question_text: 'Im Projekt-Detail (Link) → wechsle zum Reiter „Aufgaben" → klicke „Neue Aufgabe" → fülle Titel und Priorität aus → speichere — prüfe ob die Aufgabe mit Status „Entwurf" erscheint.',
+        expected_result: 'Aufgabe erscheint in der Liste; Status „Entwurf"; Aufgaben-Counter aktualisiert.',
+        test_function_url: '/admin/projekte', test_role: 'admin',
+      },
+      {
+        question_text: 'Im Projekt-Detail (Link) → klicke auf die Aufgabe → ändere den Status auf „Erledigt" → speichere — prüfe ob der Aufgaben-Counter sofort sinkt.',
+        expected_result: 'Status wechselt sofort auf „Erledigt"; offene Aufgaben-Counter sinkt.',
+        test_function_url: '/admin/projekte', test_role: 'admin',
+      },
+      {
+        question_text: 'Im Projekt-Detail (Link) → wechsle zum Reiter „Zeiterfassung" → klicke „Zeit buchen" → trage Dauer und Beschreibung ein → speichere — prüfe ob der Gesamtzeit-Counter aktualisiert wird.',
+        expected_result: 'Zeiteintrag gespeichert; Gesamtzeit-Counter des Projekts erhöht sich.',
+        test_function_url: '/admin/projekte', test_role: 'admin',
+      },
+      {
+        question_text: 'Im Projekt-Detail (Link) → ändere den Projekt-Status auf „Aktiv" → speichere — prüfe ob das Status-Badge aktualisiert wird und das Projekt in der aktiven Filter-Ansicht erscheint.',
+        expected_result: 'Status-Badge zeigt „Aktiv"; Projekt erscheint in gefilterten „Aktiv"-Ansicht.',
+        test_function_url: '/admin/projekte', test_role: 'admin',
+      },
+      {
+        question_text: 'Im Projekt-Detail (Link) → wechsle zum Reiter „Besprechungen" → klicke „Meeting verknüpfen" → wähle ein vorhandenes Meeting aus — prüfe ob es im Reiter erscheint.',
+        expected_result: 'Meeting erscheint im Reiter „Besprechungen" des Projekts.',
+        test_function_url: '/admin/projekte', test_role: 'admin',
+      },
+      {
+        question_text: 'Im Projekt-Detail (Link) → ändere den Status auf „Archiviert" → speichere — prüfe ob das Projekt aus der Standard-Liste verschwindet und in der Archiv-Ansicht sichtbar ist.',
+        expected_result: 'Projekt verschwindet aus Standard-Liste; in Archiv-Ansicht sichtbar.',
+        test_function_url: '/admin/projekte', test_role: 'admin',
+      },
+    ],
+  },
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add website/src/lib/system-test-seed-data.ts
+git commit -m "feat(system-tests): fix stale questions; add ST 11 LiveKit and ST 12 Projektmanagement"
+```
+
+---
+
+### Task 6: Update tests for new template count
+
+**Files:**
+- Modify: `website/src/lib/system-test-seed-data.test.ts`
+
+- [ ] **Step 1: Update expected counts**
+
+Change the three assertions:
+
+```typescript
+const EXPECTED_STEP_COUNTS = [6, 10, 5, 5, 5, 12, 16, 14, 6, 10, 7, 8];
+```
+
+```typescript
+it('exports exactly 12 templates', () => {
+  expect(SYSTEM_TEST_TEMPLATES).toHaveLength(12);
+});
+```
+
+```typescript
+it('totals 104 steps across all templates', () => {
+  const total = SYSTEM_TEST_TEMPLATES.reduce((sum, t) => sum + t.steps.length, 0);
+  expect(total).toBe(104);
+});
+```
+
+- [ ] **Step 2: Run tests**
+
+```bash
+cd website && bun run test src/lib/system-test-seed-data.test.ts
+```
+
+Expected: all tests pass. If any fail, check that:
+- `SYSTEM_TEST_TEMPLATES` has 12 entries
+- Step counts array matches the actual step counts in the seed file
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add website/src/lib/system-test-seed-data.test.ts
+git commit -m "test(system-tests): update expected counts for 12 templates and 104 steps"
+```
+
+---
+
+### Task 7: Rollout — reseed templates on live clusters
+
+After all code is merged and deployed:
+
+- [ ] **Step 1: Delete stale system-test templates on mentolder**
+
+```bash
+kubectl --context mentolder -n workspace exec deployment/shared-db -- \
+  psql -U postgres -d website -c \
+  "DELETE FROM questionnaire_templates WHERE is_system_test = true;"
+```
+
+- [ ] **Step 2: Restart website pod on mentolder**
+
+```bash
+kubectl --context mentolder -n website rollout restart deployment/website
+```
+
+- [ ] **Step 3: Verify on mentolder**
+
+```bash
+kubectl --context mentolder -n workspace exec deployment/shared-db -- \
+  psql -U postgres -d website -c \
+  "SELECT title FROM questionnaire_templates WHERE is_system_test = true ORDER BY created_at;"
+```
+
+Expected: 12 rows returned.
+
+- [ ] **Step 4: Repeat for korczewski**
+
+```bash
+kubectl --context korczewski -n workspace-korczewski exec deployment/shared-db -- \
+  psql -U postgres -d website -c \
+  "DELETE FROM questionnaire_templates WHERE is_system_test = true;"
+kubectl --context korczewski -n website rollout restart deployment/website
+```
+
+- [ ] **Step 5: Verify in `/admin/monitoring`**
+
+Open `https://web.mentolder.de/admin/monitoring` → Test-Results-Panel → confirm 12 templates visible with `last_result = NULL`.
+
+---
+
+### Task 8: End-to-end smoke test
+
+Validate the full new feature chain is working.
+
+- [ ] **Step 1: Assign a questionnaire and verify project creation**
+
+In `/admin/fragebogen`, assign a coaching template to a test client. Then open `/admin/projekte` and verify a new project with the template title appears.
+
+- [ ] **Step 2: Submit as client and open review**
+
+In `/portal`, log in as the test client, open the assigned questionnaire, answer all questions, submit. Then open `/admin/fragebogen/<assignmentId>` as admin.
+
+- [ ] **Step 3: Verify project badge**
+
+Check that the "→ Verknüpftes Projekt öffnen" link appears at the top of the review page and navigates to the correct project.
+
+- [ ] **Step 4: Create a task from a question**
+
+Click "+ Aufgabe" on one question. Verify "✓ Aufgabe angelegt" appears. Open `/admin/projekte/<projectId>` and confirm the task is listed with the question text as its name.
+
+- [ ] **Step 5: Archive the assignment**
+
+Click "Als besprochen markieren ✓", then "Archivieren". Verify the status badge updates to `archived`.
+
+- [ ] **Step 6: Assign a system-test template and verify project**
+
+In `/admin/fragebogen`, assign "System-Test 1: Authentifizierung & SSO" to the admin user (themselves). Verify a project titled "System-Test 1: Authentifizierung & SSO" appears in `/admin/projekte`.

--- a/docs/superpowers/plans/2026-05-08-testdata-panel.md
+++ b/docs/superpowers/plans/2026-05-08-testdata-panel.md
@@ -1,0 +1,564 @@
+# Testdaten-Panel Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a "Testdaten" tab to `/admin/monitoring` that lets Gekko generate `[TEST]`-prefixed seed records (clients, invoices, meetings, bookings) and purge them all in one click.
+
+**Architecture:** Two new Astro API endpoints (`seed.ts`, `purge.ts`) call existing DB helpers and direct pool queries. A new `TestDataPanel.svelte` component renders two buttons with confirmation modal; it is wired into `MonitoringDashboard.svelte` as a new "Testdaten" tab.
+
+**Tech Stack:** Astro API routes (TypeScript), Svelte 4, PostgreSQL via `pg` pool, existing `native-billing` + `messaging-db` + `website-db` helpers.
+
+---
+
+## File map
+
+| Action | Path | Responsibility |
+|--------|------|----------------|
+| Create | `website/src/pages/api/admin/testdata/seed.ts` | POST: insert [TEST] records |
+| Create | `website/src/pages/api/admin/testdata/purge.ts` | DELETE: remove all [TEST] records |
+| Create | `website/src/components/admin/monitoring/TestDataPanel.svelte` | UI card with two buttons + confirmation modal |
+| Modify | `website/src/components/admin/MonitoringDashboard.svelte` | Add "Testdaten" tab wired to TestDataPanel |
+
+---
+
+## Task 1: Seed API endpoint
+
+**Files:**
+- Create: `website/src/pages/api/admin/testdata/seed.ts`
+
+### Implementation note on invoices
+
+Only **draft** invoices are created (not finalized). `finalizeInvoice` sets `locked=true`, which the GoBD delete trigger blocks. Draft invoices (locked=false) can be purged cleanly. Three drafts at 500 / 1200 / 3400 € still exercise invoice creation and provide varied amounts for tax threshold testing.
+
+- [ ] **Step 1: Create the seed endpoint**
+
+```typescript
+// website/src/pages/api/admin/testdata/seed.ts
+import type { APIRoute } from 'astro';
+import { getSession, isAdmin } from '../../../../lib/auth';
+import { pool } from '../../../../lib/website-db';
+import { createCustomer as createBillingCustomer, createInvoice } from '../../../../lib/native-billing';
+import { createInboxItem } from '../../../../lib/messaging-db';
+
+function jsonError(msg: string, status: number) {
+  return new Response(JSON.stringify({ error: msg }), {
+    status, headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+export const POST: APIRoute = async ({ request }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) return jsonError('Nicht autorisiert', 401);
+
+  const brand = process.env.BRAND || 'mentolder';
+  const today = new Date().toISOString().split('T')[0];
+
+  try {
+    // 1. CRM customers (customers table — no Keycloak)
+    await pool.query(
+      `INSERT INTO customers (name, email, phone, company)
+       VALUES ($1,$2,$3,$4), ($5,$6,$7,$8)
+       ON CONFLICT (email) DO UPDATE
+         SET name = EXCLUDED.name, company = EXCLUDED.company, updated_at = now()`,
+      [
+        '[TEST] Max Mustermann', 'test-max@test.invalid', '+49 111 0000001', '[TEST] Coaching AG',
+        '[TEST] Erika Musterfrau', 'test-erika@test.invalid', '+49 111 0000002', '[TEST] Musterfirma GmbH',
+      ]
+    );
+    const crmRes = await pool.query(
+      `SELECT id FROM customers WHERE email IN ($1,$2)`,
+      ['test-max@test.invalid', 'test-erika@test.invalid']
+    );
+    const [crmId1, crmId2] = crmRes.rows.map((r: { id: string }) => r.id);
+
+    // 2. Billing customer
+    const billingCustomer = await createBillingCustomer({
+      brand,
+      name: '[TEST] Test GmbH',
+      email: 'test-billing@test.invalid',
+      company: '[TEST] Test GmbH',
+      addressLine1: 'Teststraße 1',
+      city: 'Teststadt',
+      postalCode: '12345',
+    });
+
+    // 3. Draft invoices (not finalized — keeps locked=false so purge can delete them)
+    const invoiceAmounts = [
+      { amount: 500,  desc: '[TEST] Coaching-Einzelstunde' },
+      { amount: 1200, desc: '[TEST] Coaching-Paket 3 Sitzungen' },
+      { amount: 3400, desc: '[TEST] Coaching-Intensivprogramm' },
+    ];
+    let invoiceCount = 0;
+    for (const { amount, desc } of invoiceAmounts) {
+      await createInvoice({
+        brand,
+        customerId: billingCustomer.id,
+        issueDate: today,
+        dueDays: 14,
+        taxMode: 'kleinunternehmer',
+        lines: [{ description: desc, quantity: 1, unitPrice: amount }],
+        notes: '[TEST] Automatisch generierter Testdatensatz',
+      });
+      invoiceCount++;
+    }
+
+    // 4. Meetings (linked to CRM customers)
+    const tomorrow = new Date(Date.now() + 86_400_000).toISOString();
+    const in3days  = new Date(Date.now() + 3 * 86_400_000).toISOString();
+    if (crmId1 && crmId2) {
+      await pool.query(
+        `INSERT INTO meetings (customer_id, meeting_type, scheduled_at, status)
+         VALUES ($1,$2,$3,$4), ($5,$6,$7,$8)
+         ON CONFLICT DO NOTHING`,
+        [
+          crmId1, '[TEST] Erstgespräch',   tomorrow, 'scheduled',
+          crmId2, '[TEST] Folgegespräch',  in3days,  'scheduled',
+        ]
+      );
+    }
+
+    // 5. Inbox bookings (Termine)
+    await createInboxItem({
+      type: 'booking',
+      payload: {
+        name: '[TEST] Max Mustermann', email: 'test-max@test.invalid',
+        type: 'erstgespraech', typeLabel: '[TEST] Kostenloses Erstgespräch',
+        slotStart: tomorrow, slotEnd: in3days, slotDisplay: '10:00–11:00',
+        date: today, leistungKey: 'coaching', adminCreated: true,
+      },
+    });
+    await createInboxItem({
+      type: 'booking',
+      payload: {
+        name: '[TEST] Erika Musterfrau', email: 'test-erika@test.invalid',
+        type: 'termin', typeLabel: '[TEST] Termin vor Ort',
+        slotStart: in3days, slotEnd: in3days, slotDisplay: '14:00–15:00',
+        date: today, leistungKey: 'coaching', adminCreated: true,
+      },
+    });
+
+    return new Response(JSON.stringify({
+      created: { customers: 2, billingCustomers: 1, invoices: invoiceCount, meetings: 2, bookings: 2 },
+    }), { status: 201, headers: { 'Content-Type': 'application/json' } });
+
+  } catch (err) {
+    console.error('[testdata/seed]', err);
+    return jsonError('Fehler beim Anlegen der Testdaten', 500);
+  }
+};
+```
+
+- [ ] **Step 2: Test seed manually**
+
+```bash
+# Port-forward to local (adjust ENV as needed — dev cluster for safety)
+# Then in a new terminal:
+curl -s -X POST http://localhost:4321/api/admin/testdata/seed \
+  -H "Cookie: <paste an admin session cookie from browser>" | jq .
+```
+
+Expected output:
+```json
+{"created":{"customers":2,"billingCustomers":1,"invoices":3,"meetings":2,"bookings":2}}
+```
+
+Running it a second time should return the same counts (idempotent for customers/billing customer, new invoices/meetings/bookings are added each time — that's acceptable for test data).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add website/src/pages/api/admin/testdata/seed.ts
+git commit -m "feat(testdata): seed endpoint — [TEST] clients, invoices, meetings, bookings"
+```
+
+---
+
+## Task 2: Purge API endpoint
+
+**Files:**
+- Create: `website/src/pages/api/admin/testdata/purge.ts`
+
+The purge uses `pool` from `website-db` for all deletes (both `website-db` and `messaging-db` point to the same PostgreSQL instance via `SESSIONS_DATABASE_URL`, so cross-table deletes via one pool client work correctly).
+
+- [ ] **Step 1: Create the purge endpoint**
+
+```typescript
+// website/src/pages/api/admin/testdata/purge.ts
+import type { APIRoute } from 'astro';
+import { getSession, isAdmin } from '../../../../lib/auth';
+import { pool } from '../../../../lib/website-db';
+
+function jsonError(msg: string, status: number) {
+  return new Response(JSON.stringify({ error: msg }), {
+    status, headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+export const DELETE: APIRoute = async ({ request }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) return jsonError('Nicht autorisiert', 401);
+
+  try {
+    // 1. Inbox bookings where payload.name starts with [TEST]
+    const bookingRes = await pool.query(
+      `DELETE FROM inbox_items WHERE payload->>'name' LIKE '[TEST]%' RETURNING id`
+    );
+
+    // 2. Meetings linked to [TEST] CRM customers
+    const meetingRes = await pool.query(
+      `DELETE FROM meetings
+       WHERE customer_id IN (SELECT id FROM customers WHERE name LIKE '[TEST]%')
+       RETURNING id`
+    );
+
+    // 3. Find unlocked [TEST] invoices (locked=false only — GoBD blocks locked ones)
+    const lockedRes = await pool.query(
+      `SELECT COUNT(*) AS cnt FROM billing_invoices i
+       JOIN billing_customers c ON c.id = i.customer_id
+       WHERE c.name LIKE '[TEST]%' AND i.locked = true`
+    );
+    const skippedLocked = parseInt(lockedRes.rows[0]?.cnt ?? '0', 10);
+
+    // 4. Line items for unlocked [TEST] invoices
+    const lineRes = await pool.query(
+      `DELETE FROM billing_invoice_line_items
+       WHERE invoice_id IN (
+         SELECT i.id FROM billing_invoices i
+         JOIN billing_customers c ON c.id = i.customer_id
+         WHERE c.name LIKE '[TEST]%' AND i.locked = false
+       )
+       RETURNING id`
+    );
+
+    // 5. Unlocked [TEST] invoices
+    const invoiceRes = await pool.query(
+      `DELETE FROM billing_invoices i
+       USING billing_customers c
+       WHERE c.id = i.customer_id AND c.name LIKE '[TEST]%' AND i.locked = false
+       RETURNING i.id`
+    );
+
+    // 6. [TEST] billing customers (after invoices are gone)
+    const billingCustRes = await pool.query(
+      `DELETE FROM billing_customers WHERE name LIKE '[TEST]%' RETURNING id`
+    );
+
+    // 7. [TEST] CRM customers
+    const crmCustRes = await pool.query(
+      `DELETE FROM customers WHERE name LIKE '[TEST]%' RETURNING id`
+    );
+
+    return new Response(JSON.stringify({
+      deleted: {
+        bookings:         bookingRes.rowCount ?? 0,
+        meetings:         meetingRes.rowCount ?? 0,
+        invoiceLines:     lineRes.rowCount ?? 0,
+        invoices:         invoiceRes.rowCount ?? 0,
+        billingCustomers: billingCustRes.rowCount ?? 0,
+        customers:        crmCustRes.rowCount ?? 0,
+      },
+      skipped: { lockedInvoices: skippedLocked },
+    }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+
+  } catch (err) {
+    console.error('[testdata/purge]', err);
+    return jsonError('Fehler beim Löschen der Testdaten', 500);
+  }
+};
+```
+
+- [ ] **Step 2: Test purge manually**
+
+After running seed (Task 1 Step 2), run:
+
+```bash
+curl -s -X DELETE http://localhost:4321/api/admin/testdata/purge \
+  -H "Cookie: <admin session cookie>" | jq .
+```
+
+Expected output (counts match what seed created):
+```json
+{
+  "deleted": {"bookings":2,"meetings":2,"invoiceLines":3,"invoices":3,"billingCustomers":1,"customers":2},
+  "skipped": {"lockedInvoices":0}
+}
+```
+
+Running purge a second time should return all-zeros (idempotent).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add website/src/pages/api/admin/testdata/purge.ts
+git commit -m "feat(testdata): purge endpoint — delete all [TEST]-prefixed records"
+```
+
+---
+
+## Task 3: TestDataPanel Svelte component
+
+**Files:**
+- Create: `website/src/components/admin/monitoring/TestDataPanel.svelte`
+
+Style follows the same card/button pattern used in `BugsTab.svelte` and other monitoring tabs (gray-800 card background, blue primary button, red destructive button, spinner via `animate-spin`).
+
+- [ ] **Step 1: Create the component**
+
+```svelte
+<!-- website/src/components/admin/monitoring/TestDataPanel.svelte -->
+<script lang="ts">
+  let seeding  = false;
+  let purging  = false;
+  let message: { text: string; kind: 'ok' | 'warn' | 'error' } | null = null;
+  let confirmOpen = false;
+  let msgTimer: ReturnType<typeof setTimeout>;
+
+  function showMessage(text: string, kind: 'ok' | 'warn' | 'error') {
+    message = { text, kind };
+    clearTimeout(msgTimer);
+    msgTimer = setTimeout(() => { message = null; }, 5000);
+  }
+
+  async function seed() {
+    seeding = true;
+    message = null;
+    try {
+      const res = await fetch('/api/admin/testdata/seed', { method: 'POST' });
+      const data = await res.json();
+      if (!res.ok) {
+        showMessage(data.error || 'Fehler beim Generieren', 'error');
+      } else {
+        const c = data.created;
+        showMessage(
+          `Erstellt: ${c.customers} Clients, ${c.invoices} Rechnungen, ${c.meetings} Meetings, ${c.bookings} Buchungen`,
+          'ok'
+        );
+      }
+    } catch {
+      showMessage('Netzwerkfehler', 'error');
+    } finally {
+      seeding = false;
+    }
+  }
+
+  async function purge() {
+    confirmOpen = false;
+    purging = true;
+    message = null;
+    try {
+      const res = await fetch('/api/admin/testdata/purge', { method: 'DELETE' });
+      const data = await res.json();
+      if (!res.ok) {
+        showMessage(data.error || 'Fehler beim Löschen', 'error');
+      } else {
+        const d = data.deleted;
+        const skipped = data.skipped?.lockedInvoices ?? 0;
+        const summary = `Gelöscht: ${d.customers} Clients, ${d.invoices} Rechnungen, ${d.meetings} Meetings, ${d.bookings} Buchungen`;
+        showMessage(
+          skipped > 0 ? `${summary} — ${skipped} gesperrte Rechnungen übersprungen` : summary,
+          skipped > 0 ? 'warn' : 'ok'
+        );
+      }
+    } catch {
+      showMessage('Netzwerkfehler', 'error');
+    } finally {
+      purging = false;
+    }
+  }
+</script>
+
+<div class="bg-gray-800 rounded-lg p-5 space-y-4">
+  <div>
+    <h3 class="text-sm font-semibold text-gray-100">Testdaten</h3>
+    <p class="text-xs text-gray-400 mt-1">
+      Erzeugt <code class="text-gray-300">[TEST]</code>-Datensätze für Clients, Rechnungen, Meetings und Termine.
+      Alle Testdaten können auf Knopfdruck vollständig entfernt werden.
+    </p>
+  </div>
+
+  <div class="flex gap-3 flex-wrap">
+    <button
+      on:click={seed}
+      disabled={seeding || purging}
+      class="flex items-center gap-2 px-4 py-2 rounded text-sm font-medium bg-blue-600 hover:bg-blue-500
+             disabled:opacity-50 disabled:cursor-not-allowed transition-colors text-white"
+    >
+      {#if seeding}
+        <svg class="animate-spin h-4 w-4" fill="none" viewBox="0 0 24 24">
+          <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/>
+          <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8z"/>
+        </svg>
+      {/if}
+      Testdaten generieren
+    </button>
+
+    <button
+      on:click={() => { confirmOpen = true; }}
+      disabled={seeding || purging}
+      class="flex items-center gap-2 px-4 py-2 rounded text-sm font-medium bg-red-700 hover:bg-red-600
+             disabled:opacity-50 disabled:cursor-not-allowed transition-colors text-white"
+    >
+      {#if purging}
+        <svg class="animate-spin h-4 w-4" fill="none" viewBox="0 0 24 24">
+          <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/>
+          <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8z"/>
+        </svg>
+      {/if}
+      Alle [TEST]-Daten löschen
+    </button>
+  </div>
+
+  {#if message}
+    <p class="text-xs px-3 py-2 rounded {
+      message.kind === 'ok'    ? 'bg-green-900 text-green-300' :
+      message.kind === 'warn'  ? 'bg-yellow-900 text-yellow-300' :
+                                 'bg-red-900 text-red-300'
+    }">
+      {message.text}
+    </p>
+  {/if}
+</div>
+
+<!-- Confirmation modal -->
+{#if confirmOpen}
+  <div class="fixed inset-0 z-50 flex items-center justify-center bg-black/60" role="dialog" aria-modal="true">
+    <div class="bg-gray-800 rounded-lg p-6 max-w-sm w-full mx-4 space-y-4 shadow-xl">
+      <h4 class="text-sm font-semibold text-gray-100">Testdaten löschen?</h4>
+      <p class="text-xs text-gray-400">
+        Alle Datensätze mit <code class="text-gray-300">[TEST]</code>-Präfix werden unwiderruflich gelöscht.
+        Gesperrte Rechnungen werden übersprungen und als Warnung gemeldet.
+      </p>
+      <div class="flex gap-3 justify-end">
+        <button
+          on:click={() => { confirmOpen = false; }}
+          class="px-4 py-2 rounded text-sm text-gray-300 hover:text-white transition-colors"
+        >
+          Abbrechen
+        </button>
+        <button
+          on:click={purge}
+          class="px-4 py-2 rounded text-sm font-medium bg-red-700 hover:bg-red-600 text-white transition-colors"
+        >
+          Löschen
+        </button>
+      </div>
+    </div>
+  </div>
+{/if}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add website/src/components/admin/monitoring/TestDataPanel.svelte
+git commit -m "feat(testdata): TestDataPanel Svelte component — seed/purge buttons with confirmation"
+```
+
+---
+
+## Task 4: Wire TestDataPanel into MonitoringDashboard
+
+**Files:**
+- Modify: `website/src/components/admin/MonitoringDashboard.svelte`
+
+Add a new "Testdaten" tab using the same pattern as the existing tabs.
+
+- [ ] **Step 1: Add the import and tab registration**
+
+In `MonitoringDashboard.svelte`, add the import after the existing imports:
+
+```typescript
+// Add after line 9 (after import LogsTab):
+import TestDataPanel from './monitoring/TestDataPanel.svelte';
+```
+
+Change the `Tab` type from:
+```typescript
+type Tab = 'overview' | 'cluster' | 'deployments' | 'argocd' | 'logs' | 'bugs' | 'tracking';
+```
+to:
+```typescript
+type Tab = 'overview' | 'cluster' | 'deployments' | 'argocd' | 'logs' | 'bugs' | 'tracking' | 'testdaten';
+```
+
+Change the `VALID_TABS` array from:
+```typescript
+const VALID_TABS: Tab[] = ['overview', 'cluster', 'deployments', 'argocd', 'logs', 'bugs', 'tracking'];
+```
+to:
+```typescript
+const VALID_TABS: Tab[] = ['overview', 'cluster', 'deployments', 'argocd', 'logs', 'bugs', 'tracking', 'testdaten'];
+```
+
+Add the tab label to the `tabs` array after the `tracking` entry:
+```typescript
+{ id: 'tracking',  label: 'Tracking' },
+{ id: 'testdaten', label: 'Testdaten' },   // ← add this line
+```
+
+- [ ] **Step 2: Add the tab content panel**
+
+In the `{#if activeTab === ...}` block, add after the tracking branch:
+
+```svelte
+{:else if activeTab === 'testdaten'}
+  <TestDataPanel />
+```
+
+- [ ] **Step 3: Verify in browser**
+
+Start the dev server:
+```bash
+cd website && npm run dev
+```
+
+Navigate to `http://localhost:4321/admin/monitoring` (admin session required).
+
+Check:
+1. A "Testdaten" tab appears in the tab bar
+2. Clicking it shows the panel with two buttons
+3. "Testdaten generieren" spins, then shows a success message
+4. "Alle [TEST]-Daten löschen" opens the confirmation modal
+5. Confirming deletion shows deleted counts in the success message
+6. Verify in `/admin/clients` that `[TEST] Max Mustermann` and `[TEST] Erika Musterfrau` appear after seed and disappear after purge
+7. Verify in `/admin/rechnungen` that 3 `[TEST]`-noted draft invoices appear/disappear
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add website/src/components/admin/MonitoringDashboard.svelte
+git commit -m "feat(testdata): wire TestDataPanel as Testdaten tab in monitoring dashboard"
+```
+
+---
+
+## Task 5: Deploy
+
+- [ ] **Step 1: Deploy to mentolder**
+
+```bash
+task website:deploy ENV=mentolder
+```
+
+Wait for rollout to complete, then open `https://web.mentolder.de/admin/monitoring#testdaten` and verify the tab and both buttons work against the live database.
+
+- [ ] **Step 2: Deploy to korczewski**
+
+```bash
+task website:deploy ENV=korczewski
+```
+
+- [ ] **Step 3: Final smoke test**
+
+On `https://web.mentolder.de/admin/monitoring#testdaten`:
+1. Click "Testdaten generieren" — confirm success message with counts
+2. Check `/admin/clients` for `[TEST]` clients
+3. Check `/admin/rechnungen` for `[TEST]` invoices
+4. Click "Alle [TEST]-Daten löschen" → confirm → verify all counts returned are non-zero and records disappear from the list pages
+
+- [ ] **Step 4: Commit tracking entry**
+
+```bash
+# No additional commit needed if all changes are already committed above.
+# Run the tracking PR workflow if required by project convention.
+```

--- a/docs/superpowers/specs/2026-05-08-questionnaire-project-integration-design.md
+++ b/docs/superpowers/specs/2026-05-08-questionnaire-project-integration-design.md
@@ -1,0 +1,198 @@
+# Questionnaire → Project Integration & Content Update Design
+
+**Date:** 2026-05-08
+**Author:** Patrick (with Claude)
+**Replaces:** nothing — new feature
+**Related:** 2026-04-29-system-test-questionnaires-rewrite-design.md (prior content spec)
+
+## Goal
+
+Three coordinated improvements:
+
+1. **Content** — update the 10 system-test questionnaire templates for staleness and add two missing categories (LiveKit/Streaming, Projektmanagement), bringing the total to 12.
+2. **Auto-create project on assignment** — every `questionnaire_assignments` row (coaching or system-test) automatically gets a linked `tickets.tickets` project at creation time.
+3. **Review flow** — the assignment review page gains a per-question "Als Aufgabe anlegen" button (creates a ProjectTask in the linked project) and an "Archivieren" button (terminal success state after review).
+
+## Non-Goals
+
+- New question types, new questionnaire UI components, or schema changes beyond the FK column and status union.
+- Retroactive project creation for existing assignments (project_id stays NULL for old rows — the FK is nullable).
+- Migrating existing system-test assignments; existing data is unaffected.
+
+## Architecture
+
+### Section 1 — Content updates
+
+#### Stale fixes in existing templates
+
+| Template | Issue | Fix |
+|---|---|---|
+| ST 3 — title | "Fragebogen-Widget" in title implies a questionnaire widget; step 1 actually tests the chat widget | Rename to "Kommunikation — Chat-Widget, Inbox & E-Mail" |
+| ST 2 step 6 — "Projekt anlegen" | Written before the tickets-based project system; URL/expectation partially stale | Update expected_result to reference tickets-backed project creation |
+| ST 4 step 2 — "Template zuweisen" | Once project auto-creation lands, this step should also verify the project was auto-created | Add project auto-creation check to expected_result |
+| ST 9 step 6 — template count | Says "alle System-Test-Templates" — count implicitly 10; will be 12 after new templates | Update expected_result to explicitly say "alle 12 Templates" after seeding |
+
+#### New template: ST 11 — LiveKit & Streaming (~7 steps)
+
+Covers: admin stream management page, start stream, viewer portal, RTMP ingress status, end stream (emergency), recording listing. Currently completely absent from the protocol.
+
+| # | Step | Erwartung | URL | Role |
+|---|---|---|---|---|
+| 1 | Admin-Stream-Seite öffnen | Seite lädt; Stream-Status „offline" | `/admin/stream` | admin |
+| 2 | Stream starten (Start-Button) | Status wechselt auf „live"; Stream-Token generiert | `/admin/stream` | admin |
+| 3 | Viewer-Portal als Testnutzer öffnen | Stream-Player sichtbar; Verbindung aufgebaut (kein Fehler) | `/portal/stream` | user |
+| 4 | RTMP-Ingress-Status prüfen | Ingress-Pod läuft; RTMP-URL angezeigt | `/admin/stream` | admin |
+| 5 | Stream-Aufnahmen (Recordings) auflisten | Liste lädt; vorhandene MP4-Dateien sichtbar (oder leere Liste ohne Fehler) | `/admin/stream` | admin |
+| 6 | Stream beenden (End-Stream) | Status wechselt auf „offline"; Viewer-Portal zeigt „kein Stream" | `/admin/stream` | admin |
+| 7 | LiveKit-Pod-Status in Monitoring prüfen | `livekit-server` Pod im Status `Running`; kein CrashLoop | `/admin/monitoring` | admin |
+
+#### New template: ST 12 — Projektmanagement (~8 steps)
+
+Covers: Projekte/Teilprojekte/Aufgaben/Zeiterfassung. Currently just 1 buried step in ST 2.
+
+| # | Step | Erwartung | URL | Role |
+|---|---|---|---|---|
+| 1 | Neues Projekt anlegen (mit Client) | Projekt erscheint in Liste; Pflichtfeld-Validierung serverseitig | `/admin/projekte` | admin |
+| 2 | Teilprojekt zum Projekt hinzufügen | Teilprojekt erscheint im Projekt-Detail unter dem Reiter „Teilprojekte" | `/admin/projekte/<id>` | admin |
+| 3 | Aufgabe direkt am Projekt anlegen | Aufgabe erscheint im Projekt-Detail; Status „Entwurf" | `/admin/projekte/<id>` | admin |
+| 4 | Aufgabe als erledigt markieren | Status wechselt sofort; Aufgaben-Counter aktualisiert | `/admin/projekte/<id>` | admin |
+| 5 | Zeiteintrag am Projekt erfassen | Eintrag gespeichert; Gesamtzeit aktualisiert | `/admin/projekte/<id>` | admin |
+| 6 | Projekt-Status auf „Aktiv" setzen | Status-Badge aktualisiert; Projekt erscheint in aktiver Filter-Ansicht | `/admin/projekte/<id>` | admin |
+| 7 | Meeting mit Projekt verknüpfen | Meeting erscheint im Projekt-Detail unter Reiter „Besprechungen" | `/admin/projekte/<id>` | admin |
+| 8 | Projekt archivieren | Status „Archiviert"; Projekt aus Standard-Liste entfernt; in Archiv-Ansicht sichtbar | `/admin/projekte/<id>` | admin |
+
+### Section 2 — Auto-create project on assignment
+
+#### DB migration (idempotent, runs via `initDb` in `questionnaire-db.ts`)
+
+```sql
+ALTER TABLE questionnaire_assignments
+  ADD COLUMN IF NOT EXISTS project_id UUID
+    REFERENCES tickets.tickets(id) ON DELETE SET NULL;
+```
+
+#### Logic in `createQAssignment()` — `website/src/lib/questionnaire-db.ts`
+
+Runs in the same transaction as the assignment INSERT:
+
+1. Fetch template title (already available from the template INSERT context or via a SELECT).
+2. Fetch customer name if `customer_id` is set.
+3. Insert into `tickets.tickets`:
+   - `type = 'project'`
+   - `brand` = `process.env.PROD_DOMAIN ?? 'localhost'` (same pattern as `resolveDomain()`)
+   - `title` = for `is_system_test=true`: `<template_title>`; for coaching: `<template_title> — <customer_name>`
+   - `status = 'backlog'`
+   - `customer_id` = assignment's customer_id (may be NULL for system-test self-assignments)
+4. Store the returned `id` as `project_id` in the assignment INSERT.
+
+The project appears immediately in `/admin/projekte` like any manually created project.
+
+Existing assignments are unaffected — `project_id` is nullable.
+
+### Section 3 — Review flow enhancements
+
+#### New status: `archived`
+
+Add to the `AssignmentStatus` union in `questionnaire-db.ts`:
+
+```typescript
+export type AssignmentStatus =
+  'pending' | 'in_progress' | 'submitted' | 'reviewed' | 'archived' | 'dismissed';
+```
+
+Add to the DB check constraint via migration:
+
+```sql
+ALTER TABLE questionnaire_assignments
+  DROP CONSTRAINT IF EXISTS questionnaire_assignments_status_check;
+ALTER TABLE questionnaire_assignments
+  ADD CONSTRAINT questionnaire_assignments_status_check
+  CHECK (status IN ('pending','in_progress','submitted','reviewed','archived','dismissed'));
+```
+
+State machine:
+```
+pending → in_progress → submitted → reviewed → archived
+                                  ↘ dismissed
+```
+
+`archived` = reviewed + tasks extracted + done. `dismissed` = won't review.
+
+#### Review page additions — `website/src/pages/admin/fragebogen/[assignmentId].astro`
+
+**1. Linked project badge** (top of page, renders if `assignment.project_id` is set):
+```html
+<a href="/admin/projekte/{assignment.project_id}">
+  → Verknüpftes Projekt öffnen
+</a>
+```
+No extra DB fetch — `project_id` is loaded with the assignment.
+
+**2. "Als Aufgabe anlegen" button** — per question row, visible when status is `submitted` or `reviewed`:
+- Calls `POST /api/admin/questionnaire/[assignmentId]/create-task` with `{ questionId }`.
+- API handler: fetches question text + expected_result → calls `createProjectTask()` with:
+  - `projectId` = assignment's `project_id`
+  - `name` = question's `question_text` (truncated to 120 chars)
+  - `description` = question's `test_expected_result`
+  - `status` = `'entwurf'`
+- Button becomes "✓ Aufgabe angelegt" (disabled) on success.
+- Requires `project_id` to be set; button is hidden if NULL.
+
+**3. "Archivieren" button** — visible when status is `reviewed`:
+- Calls existing `PATCH /api/admin/questionnaire/[assignmentId]/status` with `{ status: 'archived' }`.
+- Updates the status badge in place.
+
+#### New API route
+
+`website/src/pages/api/admin/questionnaire/[assignmentId]/create-task.ts`
+
+- Auth: admin session required.
+- Body: `{ questionId: string }`.
+- Validates assignment belongs to a project (403 if `project_id` is NULL).
+- Creates task via `createProjectTask()` from `website-db.ts`.
+- Returns `{ taskId }`.
+
+## File changes
+
+| File | Action | Note |
+|---|---|---|
+| `website/src/lib/system-test-seed-data.ts` | Modify | Add ST 11 + ST 12; fix stale titles/expected_results |
+| `website/src/lib/questionnaire-db.ts` | Modify | Add `project_id` column migration; update `createQAssignment()` to auto-create project; add `'archived'` to status union and DB constraint |
+| `website/src/pages/admin/fragebogen/[assignmentId].astro` | Modify | Add project badge, "Als Aufgabe anlegen" buttons, "Archivieren" button |
+| `website/src/pages/api/admin/questionnaire/[assignmentId]/create-task.ts` | Create | New API route |
+| `k3d/website-schema.yaml` | Modify | Document new `project_id` column and `archived` status |
+
+## Operational rollout
+
+After deploy on each cluster:
+
+```bash
+# Re-seed system-test templates (adds ST 11 + ST 12, applies content fixes)
+kubectl --context <env> -n workspace exec deployment/shared-db -- \
+  psql -U postgres -d website -c \
+  "DELETE FROM questionnaire_templates WHERE is_system_test = true;"
+kubectl --context <env> -n workspace rollout restart deploy/website
+```
+
+The `project_id` column and status constraint changes run automatically on pod startup via `initDb`.
+
+Existing coaching assignments keep `project_id = NULL` — unaffected.
+
+## Testing this system
+
+End-to-end smoke test (covers the new features while using the other system tests):
+
+1. Open `/admin/fragebogen` → assign ST 1 (Auth) template to a test client.
+2. Verify `/admin/projekte` shows a new project "System-Test 1: Authentifizierung & SSO (Keycloak)".
+3. In `/portal`, submit the questionnaire (or use admin self-assignment for system tests).
+4. In `/admin/fragebogen/<assignmentId>`, open the review page.
+5. Verify the "→ Verknüpftes Projekt öffnen" badge appears.
+6. Click "Als Aufgabe anlegen" on one question → verify task appears in `/admin/projekte/<projectId>`.
+7. Set assignment to `reviewed`, then click "Archivieren" → verify status badge updates.
+8. Verify archived assignment appears in a "Abgeschlossen"-filtered view.
+
+## Risks
+
+- **System-test self-assignment customer_id**: System-test assignments don't always have a `customer_id` (they're run by the admin against themselves). The auto-created project will have `customer_id = NULL` for these — which is valid per `createProject`'s FK (nullable). The title will omit the "— <customer_name>" suffix.
+- **Constraint drop/re-add**: The `DROP CONSTRAINT IF EXISTS` + `ADD CONSTRAINT` migration pattern is safe but briefly removes the constraint. Runs in `initDb` at startup before any traffic, so acceptable.
+- **Large question text as task name**: `question_text` can be long. Truncate to 120 chars in the API handler before inserting as task name.

--- a/docs/superpowers/specs/2026-05-08-testdata-panel-design.md
+++ b/docs/superpowers/specs/2026-05-08-testdata-panel-design.md
@@ -1,0 +1,123 @@
+# Testdaten-Panel — Design Spec
+
+**Date:** 2026-05-08
+**Status:** Approved
+
+## Problem
+
+Gekko (admin of mentolder.de) needs a way to quickly generate realistic test records before running system tests (clients, invoices, appointments, meetings), and to wipe them cleanly afterwards. Currently he has to create them manually through the admin UI and delete them one by one.
+
+## Scope
+
+Generate and purge `[TEST]`-prefixed records for:
+- CRM clients (`customers` table)
+- Billing customers + invoices (`billing_customers`, `billing_invoices`, `billing_invoice_line_items`)
+- Meetings (`meetings` table)
+- Bookings/Termine (inbox items in `messaging-db`)
+
+Entry point: existing `/admin/monitoring` page (new compact card at the bottom of the page).
+
+Out of scope: questionnaire assignments, projects, documents, Keycloak user creation.
+
+## Architecture
+
+### New files
+
+```
+website/src/pages/api/admin/testdata/
+  seed.ts     ← POST — inserts [TEST] records
+  purge.ts    ← DELETE — removes all [TEST] records
+
+website/src/components/admin/monitoring/
+  TestDataPanel.svelte   ← compact card with two buttons + status display
+```
+
+### Modified files
+
+```
+website/src/components/admin/MonitoringDashboard.svelte
+  ← import and render TestDataPanel
+```
+
+## Seed endpoint — `POST /api/admin/testdata/seed`
+
+Auth: admin session required (401 otherwise).
+
+Inserts directly into DB — no Keycloak calls, no emails sent.
+
+**Records created:**
+
+| Table | Records | Key fields |
+|---|---|---|
+| `customers` | 2 | name `[TEST] Max Mustermann` / `[TEST] Erika Musterfrau`, fake emails `test-max@test.invalid` / `test-erika@test.invalid` |
+| `billing_customers` | 1 | name `[TEST] Test GmbH`, email `test-billing@test.invalid`, brand from env |
+| `billing_invoices` | 3 | statuses: draft / open / paid; amounts: 500 / 1200 / 3400 €; notes prefixed `[TEST]`; linked to the billing customer |
+| `billing_invoice_line_items` | 3 | one line per invoice (coaching session description) |
+| `meetings` | 2 | `meeting_type = '[TEST] Erstgespräch'` / `'[TEST] Folgegespräch'`; `status = 'scheduled'`; linked to test customers; `scheduled_at` = now+1d / now+3d |
+| inbox items | 2 | `type = 'booking'`, `payload.name = '[TEST] ...'`; `adminCreated: true`; no email sent |
+
+Customers use `ON CONFLICT (email) DO UPDATE` so running seed twice is safe — existing records are updated, not duplicated.
+
+Invoice number generation uses the existing `createInvoice` helper from `lib/native-billing` to ensure correct numbering sequence.
+
+**Response:**
+```json
+{ "created": { "customers": 2, "billingCustomers": 1, "invoices": 3, "meetings": 2, "bookings": 2 } }
+```
+
+## Purge endpoint — `DELETE /api/admin/testdata/purge`
+
+Auth: admin session required (401 otherwise).
+
+Deletes in FK-safe order:
+
+1. Inbox items where `payload->>'name' LIKE '[TEST]%'`
+2. Meetings where `customer_id IN (SELECT id FROM customers WHERE name LIKE '[TEST]%')`
+3. `billing_invoice_line_items` for invoices where `customer_id IN ([TEST] billing_customers)` AND `locked = false`
+4. `billing_invoices` where `customer_id IN ([TEST] billing_customers)` AND `locked = false`
+5. `billing_customers` where `name LIKE '[TEST]%'`
+6. `customers` where `name LIKE '[TEST]%'`
+
+Locked invoices are skipped (GoBD trigger blocks them anyway). The response reports skipped locked invoices as a warning, not a failure.
+
+**Response:**
+```json
+{
+  "deleted": { "bookings": 2, "meetings": 2, "invoiceLines": 3, "invoices": 3, "billingCustomers": 1, "customers": 2 },
+  "skipped": { "lockedInvoices": 0 }
+}
+```
+
+## UI — `TestDataPanel.svelte`
+
+Compact card styled consistently with other monitoring cards (e.g. `BugsTab.svelte` button patterns).
+
+```
+┌─────────────────────────────────────────────────┐
+│ Testdaten                                        │
+│ Erzeugt [TEST]-Datensätze für Clients,           │
+│ Rechnungen und Termine. Löscht alle [TEST]-Daten │
+│ auf Knopfdruck.                                  │
+│                                                  │
+│ [Testdaten generieren]  [Alle [TEST]-Daten ...]  │
+│                                                  │
+│ ✓ 2 Clients, 3 Rechnungen, 2 Meetings erstellt   │
+└─────────────────────────────────────────────────┘
+```
+
+- Both buttons show a spinner while request is in flight
+- Success/error message appears below buttons, auto-clears after 5 seconds
+- "Alle [TEST]-Daten löschen" opens a confirmation modal before calling purge:
+  > "Alle Datensätze mit [TEST]-Präfix werden unwiderruflich gelöscht. Fortfahren?"
+
+## Error handling
+
+- Seed: if any step fails, error is returned with which step failed; completed steps are not rolled back (partial seed is better than no seed for test purposes)
+- Purge: each delete step runs independently; first failure returns error with partial count
+- Locked invoice skip: reported in response `skipped.lockedInvoices`, shown as yellow warning in UI (not a red error)
+
+## Security
+
+- Both endpoints check `isAdmin(session)` — same pattern as all other admin API routes
+- `.invalid` TLD on test emails ensures no accidental email delivery if something bypasses the seed path
+- `[TEST]` prefix is the only deletion filter — purge cannot touch records without it

--- a/website/src/components/admin/MonitoringDashboard.svelte
+++ b/website/src/components/admin/MonitoringDashboard.svelte
@@ -7,13 +7,14 @@
   import TrackingTab from './monitoring/TrackingTab.svelte';
   import ArgoCDTab from './monitoring/ArgoCDTab.svelte';
   import LogsTab from './monitoring/LogsTab.svelte';
+  import TestDataPanel from './monitoring/TestDataPanel.svelte';
 
   export let trackingUrl: string = '';
 
-  type Tab = 'overview' | 'cluster' | 'deployments' | 'argocd' | 'logs' | 'bugs' | 'tracking';
+  type Tab = 'overview' | 'cluster' | 'deployments' | 'argocd' | 'logs' | 'bugs' | 'tracking' | 'testdaten';
 
   let activeTab: Tab = 'overview';
-  const VALID_TABS: Tab[] = ['overview', 'cluster', 'deployments', 'argocd', 'logs', 'bugs', 'tracking'];
+  const VALID_TABS: Tab[] = ['overview', 'cluster', 'deployments', 'argocd', 'logs', 'bugs', 'tracking', 'testdaten'];
 
   onMount(() => {
     const hash = location.hash.slice(1) as Tab;
@@ -35,6 +36,7 @@
     { id: 'logs',         label: 'Logs' },
     { id: 'bugs',         label: 'Bugs' },
     { id: 'tracking',     label: 'Tracking' },
+    { id: 'testdaten',    label: 'Testdaten' },
   ];
 </script>
 
@@ -69,6 +71,8 @@
       <BugsTab />
     {:else if activeTab === 'tracking'}
       <TrackingTab {trackingUrl} />
+    {:else if activeTab === 'testdaten'}
+      <TestDataPanel />
     {/if}
   </div>
 </div>

--- a/website/src/components/admin/monitoring/TestDataPanel.svelte
+++ b/website/src/components/admin/monitoring/TestDataPanel.svelte
@@ -59,6 +59,8 @@
   }
 </script>
 
+<svelte:window on:keydown={(e) => { if (e.key === 'Escape') confirmOpen = false; }} />
+
 <div class="bg-gray-800 rounded-lg p-5 space-y-4">
   <div>
     <h3 class="text-sm font-semibold text-gray-100">Testdaten</h3>
@@ -113,9 +115,9 @@
 
 <!-- Confirmation modal -->
 {#if confirmOpen}
-  <div class="fixed inset-0 z-50 flex items-center justify-center bg-black/60" role="dialog" aria-modal="true">
+  <div class="fixed inset-0 z-50 flex items-center justify-center bg-black/60" role="dialog" aria-modal="true" aria-labelledby="testdata-purge-modal-title">
     <div class="bg-gray-800 rounded-lg p-6 max-w-sm w-full mx-4 space-y-4 shadow-xl">
-      <h4 class="text-sm font-semibold text-gray-100">Testdaten löschen?</h4>
+      <h4 id="testdata-purge-modal-title" class="text-sm font-semibold text-gray-100">Testdaten löschen?</h4>
       <p class="text-xs text-gray-400">
         Alle Datensätze mit <code class="text-gray-300">[TEST]</code>-Präfix werden unwiderruflich gelöscht.
         Gesperrte Rechnungen werden übersprungen und als Warnung gemeldet.

--- a/website/src/components/admin/monitoring/TestDataPanel.svelte
+++ b/website/src/components/admin/monitoring/TestDataPanel.svelte
@@ -1,0 +1,139 @@
+<script lang="ts">
+  let seeding  = false;
+  let purging  = false;
+  let message: { text: string; kind: 'ok' | 'warn' | 'error' } | null = null;
+  let confirmOpen = false;
+  let msgTimer: ReturnType<typeof setTimeout>;
+
+  function showMessage(text: string, kind: 'ok' | 'warn' | 'error') {
+    message = { text, kind };
+    clearTimeout(msgTimer);
+    msgTimer = setTimeout(() => { message = null; }, 5000);
+  }
+
+  async function seed() {
+    seeding = true;
+    message = null;
+    try {
+      const res = await fetch('/api/admin/testdata/seed', { method: 'POST' });
+      const data = await res.json();
+      if (!res.ok) {
+        showMessage(data.error || 'Fehler beim Generieren', 'error');
+      } else {
+        const c = data.created;
+        showMessage(
+          `Erstellt: ${c.customers} Clients, ${c.invoices} Rechnungen, ${c.meetings} Meetings, ${c.bookings} Buchungen`,
+          'ok'
+        );
+      }
+    } catch {
+      showMessage('Netzwerkfehler', 'error');
+    } finally {
+      seeding = false;
+    }
+  }
+
+  async function purge() {
+    confirmOpen = false;
+    purging = true;
+    message = null;
+    try {
+      const res = await fetch('/api/admin/testdata/purge', { method: 'DELETE' });
+      const data = await res.json();
+      if (!res.ok) {
+        showMessage(data.error || 'Fehler beim Löschen', 'error');
+      } else {
+        const d = data.deleted;
+        const skipped = data.skipped?.lockedInvoices ?? 0;
+        const summary = `Gelöscht: ${d.customers} Clients, ${d.invoices} Rechnungen, ${d.meetings} Meetings, ${d.bookings} Buchungen`;
+        showMessage(
+          skipped > 0 ? `${summary} — ${skipped} gesperrte Rechnungen übersprungen` : summary,
+          skipped > 0 ? 'warn' : 'ok'
+        );
+      }
+    } catch {
+      showMessage('Netzwerkfehler', 'error');
+    } finally {
+      purging = false;
+    }
+  }
+</script>
+
+<div class="bg-gray-800 rounded-lg p-5 space-y-4">
+  <div>
+    <h3 class="text-sm font-semibold text-gray-100">Testdaten</h3>
+    <p class="text-xs text-gray-400 mt-1">
+      Erzeugt <code class="text-gray-300">[TEST]</code>-Datensätze für Clients, Rechnungen, Meetings und Termine.
+      Alle Testdaten können auf Knopfdruck vollständig entfernt werden.
+    </p>
+  </div>
+
+  <div class="flex gap-3 flex-wrap">
+    <button
+      on:click={seed}
+      disabled={seeding || purging}
+      class="flex items-center gap-2 px-4 py-2 rounded text-sm font-medium bg-blue-600 hover:bg-blue-500
+             disabled:opacity-50 disabled:cursor-not-allowed transition-colors text-white"
+    >
+      {#if seeding}
+        <svg class="animate-spin h-4 w-4" fill="none" viewBox="0 0 24 24">
+          <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/>
+          <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8z"/>
+        </svg>
+      {/if}
+      Testdaten generieren
+    </button>
+
+    <button
+      on:click={() => { confirmOpen = true; }}
+      disabled={seeding || purging}
+      class="flex items-center gap-2 px-4 py-2 rounded text-sm font-medium bg-red-700 hover:bg-red-600
+             disabled:opacity-50 disabled:cursor-not-allowed transition-colors text-white"
+    >
+      {#if purging}
+        <svg class="animate-spin h-4 w-4" fill="none" viewBox="0 0 24 24">
+          <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/>
+          <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8z"/>
+        </svg>
+      {/if}
+      Alle [TEST]-Daten löschen
+    </button>
+  </div>
+
+  {#if message}
+    <p class="text-xs px-3 py-2 rounded {
+      message.kind === 'ok'    ? 'bg-green-900 text-green-300' :
+      message.kind === 'warn'  ? 'bg-yellow-900 text-yellow-300' :
+                                 'bg-red-900 text-red-300'
+    }">
+      {message.text}
+    </p>
+  {/if}
+</div>
+
+<!-- Confirmation modal -->
+{#if confirmOpen}
+  <div class="fixed inset-0 z-50 flex items-center justify-center bg-black/60" role="dialog" aria-modal="true">
+    <div class="bg-gray-800 rounded-lg p-6 max-w-sm w-full mx-4 space-y-4 shadow-xl">
+      <h4 class="text-sm font-semibold text-gray-100">Testdaten löschen?</h4>
+      <p class="text-xs text-gray-400">
+        Alle Datensätze mit <code class="text-gray-300">[TEST]</code>-Präfix werden unwiderruflich gelöscht.
+        Gesperrte Rechnungen werden übersprungen und als Warnung gemeldet.
+      </p>
+      <div class="flex gap-3 justify-end">
+        <button
+          on:click={() => { confirmOpen = false; }}
+          class="px-4 py-2 rounded text-sm text-gray-300 hover:text-white transition-colors"
+        >
+          Abbrechen
+        </button>
+        <button
+          on:click={purge}
+          class="px-4 py-2 rounded text-sm font-medium bg-red-700 hover:bg-red-600 text-white transition-colors"
+        >
+          Löschen
+        </button>
+      </div>
+    </div>
+  </div>
+{/if}

--- a/website/src/lib/questionnaire-db.ts
+++ b/website/src/lib/questionnaire-db.ts
@@ -535,7 +535,7 @@ export async function dismissQAssignment(id: string, reason: string): Promise<QA
 
 export async function countPendingQAssignmentsForCustomer(customerId: string): Promise<number> {
   const r = await pool.query(
-    `SELECT COUNT(*)::int FROM questionnaire_assignments
+    `SELECT COUNT(*)::int AS count FROM questionnaire_assignments
      WHERE customer_id = $1 AND status IN ('pending','in_progress')`,
     [customerId],
   );

--- a/website/src/lib/questionnaire-db.ts
+++ b/website/src/lib/questionnaire-db.ts
@@ -363,6 +363,16 @@ export async function listQQuestions(templateId: string): Promise<QQuestion[]> {
   return r.rows;
 }
 
+export async function getQQuestion(id: string): Promise<QQuestion | null> {
+  const r = await pool.query(
+    `SELECT id, template_id, position, question_text, question_type,
+            test_expected_result, test_function_url, test_menu_path, test_role, created_at
+     FROM questionnaire_questions WHERE id = $1`,
+    [id],
+  );
+  return r.rows[0] ?? null;
+}
+
 export async function upsertQQuestion(params: {
   id?: string; templateId: string; position: number;
   questionText: string; questionType: QuestionType;

--- a/website/src/lib/questionnaire-db.ts
+++ b/website/src/lib/questionnaire-db.ts
@@ -19,7 +19,7 @@ const pool = new pg.Pool(
 
 export type QuestionType = 'ab_choice' | 'ja_nein' | 'likert_5' | 'test_step';
 export type TestStepResult = 'erfüllt' | 'teilweise' | 'nicht_erfüllt';
-export type AssignmentStatus = 'pending' | 'in_progress' | 'submitted' | 'reviewed' | 'dismissed';
+export type AssignmentStatus = 'pending' | 'in_progress' | 'submitted' | 'reviewed' | 'archived' | 'dismissed';
 
 export interface QTemplate {
   id: string;
@@ -75,8 +75,10 @@ export interface QAssignment {
   assigned_at: string;
   submitted_at: string | null;
   reviewed_at: string | null;
+  archived_at: string | null;   // new
   dismissed_at: string | null;
   dismiss_reason: string | null;
+  project_id: string | null;    // new
 }
 
 export interface QAnswer {
@@ -225,6 +227,8 @@ async function initDb() {
     ADD COLUMN IF NOT EXISTS is_system_test BOOLEAN NOT NULL DEFAULT false`);
   await pool.query(`ALTER TABLE questionnaire_assignments ADD COLUMN IF NOT EXISTS dismissed_at TIMESTAMPTZ`);
   await pool.query(`ALTER TABLE questionnaire_assignments ADD COLUMN IF NOT EXISTS dismiss_reason TEXT`);
+  await pool.query(`ALTER TABLE questionnaire_assignments ADD COLUMN IF NOT EXISTS project_id UUID REFERENCES tickets.tickets(id) ON DELETE SET NULL`);
+  await pool.query(`ALTER TABLE questionnaire_assignments ADD COLUMN IF NOT EXISTS archived_at TIMESTAMPTZ`);
   await pool.query(`
     CREATE TABLE IF NOT EXISTS questionnaire_test_status (
       question_id UUID PRIMARY KEY REFERENCES questionnaire_questions(id) ON DELETE CASCADE,
@@ -445,13 +449,14 @@ export async function replaceQAnswerOptions(questionId: string, options: Array<{
 // ── Assignments ───────────────────────────────────────────────────
 
 export async function createQAssignment(params: {
-  customerId: string; templateId: string;
+  customerId: string; templateId: string; projectId?: string;
 }): Promise<QAssignment> {
   const r = await pool.query(
-    `INSERT INTO questionnaire_assignments (customer_id, template_id)
-     VALUES ($1, $2)
-     RETURNING id, customer_id, template_id, status, coach_notes, assigned_at, submitted_at, reviewed_at, dismissed_at, dismiss_reason`,
-    [params.customerId, params.templateId],
+    `INSERT INTO questionnaire_assignments (customer_id, template_id, project_id)
+     VALUES ($1, $2, $3)
+     RETURNING id, customer_id, template_id, status, coach_notes, assigned_at,
+               submitted_at, reviewed_at, archived_at, dismissed_at, dismiss_reason, project_id`,
+    [params.customerId, params.templateId, params.projectId ?? null],
   );
   const row = r.rows[0];
   const tpl = await getQTemplate(row.template_id);
@@ -462,7 +467,7 @@ export async function listQAssignmentsForCustomer(customerId: string): Promise<Q
   const r = await pool.query(
     `SELECT a.id, a.customer_id, a.template_id, t.title AS template_title,
             a.status, a.coach_notes, a.assigned_at, a.submitted_at, a.reviewed_at,
-            a.dismissed_at, a.dismiss_reason
+            a.archived_at, a.dismissed_at, a.dismiss_reason, a.project_id
      FROM questionnaire_assignments a
      JOIN questionnaire_templates t ON t.id = a.template_id
      WHERE a.customer_id = $1
@@ -476,7 +481,7 @@ export async function getQAssignment(id: string): Promise<QAssignment | null> {
   const r = await pool.query(
     `SELECT a.id, a.customer_id, a.template_id, t.title AS template_title,
             a.status, a.coach_notes, a.assigned_at, a.submitted_at, a.reviewed_at,
-            a.dismissed_at, a.dismiss_reason
+            a.archived_at, a.dismissed_at, a.dismiss_reason, a.project_id
      FROM questionnaire_assignments a
      JOIN questionnaire_templates t ON t.id = a.template_id
      WHERE a.id = $1`,
@@ -494,6 +499,7 @@ export async function updateQAssignment(id: string, params: {
     vals.push(params.status); sets.push(`status = $${vals.length}`);
     if (params.status === 'submitted') sets.push(`submitted_at = now()`);
     if (params.status === 'reviewed') sets.push(`reviewed_at = now()`);
+    if (params.status === 'archived') sets.push(`archived_at = now()`);
     if (params.status === 'dismissed') sets.push(`dismissed_at = now()`);
   }
   if (params.dismissReason !== undefined) { vals.push(params.dismissReason); sets.push(`dismiss_reason = $${vals.length}`); }
@@ -503,7 +509,8 @@ export async function updateQAssignment(id: string, params: {
   const r = await pool.query(
     `UPDATE questionnaire_assignments SET ${sets.join(', ')}
      WHERE id = $${vals.length}
-     RETURNING id, customer_id, template_id, status, coach_notes, assigned_at, submitted_at, reviewed_at, dismissed_at, dismiss_reason`,
+     RETURNING id, customer_id, template_id, status, coach_notes, assigned_at,
+               submitted_at, reviewed_at, archived_at, dismissed_at, dismiss_reason, project_id`,
     vals,
   );
   const row = r.rows[0];

--- a/website/src/lib/system-test-seed-data.test.ts
+++ b/website/src/lib/system-test-seed-data.test.ts
@@ -7,11 +7,11 @@ const REQUIRED_REQ_IDS = [
   ...Array.from({ length: 13 }, (_, i) => `C-${String(i + 1).padStart(2, '0')}`),
 ];
 
-const EXPECTED_STEP_COUNTS = [6, 10, 5, 5, 5, 12, 16, 14, 6, 10];
+const EXPECTED_STEP_COUNTS = [6, 10, 5, 5, 5, 12, 16, 14, 5, 10, 7, 8];
 
 describe('system-test-seed-data', () => {
-  it('exports exactly 10 templates', () => {
-    expect(SYSTEM_TEST_TEMPLATES).toHaveLength(10);
+  it('exports exactly 12 templates', () => {
+    expect(SYSTEM_TEST_TEMPLATES).toHaveLength(12);
   });
 
   it('per-category step counts match the spec', () => {
@@ -19,9 +19,9 @@ describe('system-test-seed-data', () => {
     expect(counts).toEqual(EXPECTED_STEP_COUNTS);
   });
 
-  it('totals 89 steps across all templates', () => {
+  it('totals 103 steps across all templates', () => {
     const total = SYSTEM_TEST_TEMPLATES.reduce((sum, t) => sum + t.steps.length, 0);
-    expect(total).toBe(89);
+    expect(total).toBe(103);
   });
 
   it('every template has non-empty title/description/instructions', () => {

--- a/website/src/lib/system-test-seed-data.ts
+++ b/website/src/lib/system-test-seed-data.ts
@@ -188,7 +188,7 @@ export const SYSTEM_TEST_TEMPLATES: SystemTestTemplate[] = [
       },
       {
         question_text: 'Öffne Monitoring (Link) — scrolle zum Abschnitt „Test-Results-Panel" und prüfe ob alle System-Test-Templates mit Last-Result/Last-Success-Status sichtbar sind.',
-        expected_result: 'Alle 10 System-Test-Templates sichtbar mit Last-Result/Last-Success-Status.',
+        expected_result: 'Alle 12 System-Test-Templates sichtbar mit Last-Result/Last-Success-Status.',
         test_function_url: '/admin/monitoring', test_role: 'admin',
       },
     ],

--- a/website/src/lib/system-test-seed-data.ts
+++ b/website/src/lib/system-test-seed-data.ts
@@ -100,7 +100,7 @@ export const SYSTEM_TEST_TEMPLATES: SystemTestTemplate[] = [
       },
       {
         question_text: 'Öffne Projekte (Link) → klicke „Neues Projekt" → ordne es über das Client-Feld einem Client zu → prüfe ob das Projekt in der Client-Detailansicht unter Reiter „Projekte" erscheint.',
-        expected_result: 'Projekt erscheint in /admin/projekte; Zuordnung zum Client in der Detailansicht sichtbar.',
+        expected_result: 'Projekt erscheint in /admin/projekte; Tickets-System-Projekt mit Status „Entwurf" angelegt; Zuordnung zum Client sichtbar.',
         test_function_url: '/admin/projekte', test_role: 'admin',
       },
       {
@@ -127,7 +127,7 @@ export const SYSTEM_TEST_TEMPLATES: SystemTestTemplate[] = [
     ],
   },
   {
-    title: 'System-Test 3: Kommunikation — Fragebogen-Widget, Inbox & E-Mail',
+    title: 'System-Test 3: Kommunikation — Chat-Widget, Inbox & E-Mail',
     description: 'Test des Fragebogen-Widgets auf der öffentlichen Website, des Admin-Inbox-Workflows sowie E-Mail-Versand und Newsletter-Vorschau.',
     instructions: 'Schritt 1 im Testnutzer-Browser, Schritte 2/3/4 im Admin-Browser. Öffne jeweils den Link im Schritt.',
     steps: [
@@ -172,7 +172,7 @@ export const SYSTEM_TEST_TEMPLATES: SystemTestTemplate[] = [
       },
       {
         question_text: 'Klicke im Template auf „Veröffentlichen" — öffne dann einen Client (Link), wechsle zum Reiter „Fragebögen" und klicke „Zuweisen".',
-        expected_result: 'Assignment erstellt; Nutzer sieht Fragebogen im Portal-Dashboard (ggf. E-Mail-Benachrichtigung).',
+        expected_result: 'Assignment erstellt; Nutzer sieht Fragebogen im Portal-Dashboard; verknüpftes Projekt automatisch unter /admin/projekte angelegt.',
         test_function_url: '/admin/clients', test_role: 'admin',
       },
       {
@@ -490,7 +490,7 @@ export const SYSTEM_TEST_TEMPLATES: SystemTestTemplate[] = [
       },
       {
         question_text: 'Öffne Monitoring (Link) → scrolle zum „Test-Results-Panel" — prüfe ob alle System-Test-Templates mit last_result und last_success_at sichtbar sind und ein Drilldown auf Question-Level möglich ist.',
-        expected_result: 'Alle Templates sichtbar mit last_result/last_success_at; Drilldown auf Question-Level möglich.',
+        expected_result: 'Alle 12 Templates sichtbar mit last_result/last_success_at; Drilldown auf Question-Level möglich.',
         test_function_url: '/admin/monitoring', test_role: 'admin',
       },
     ],
@@ -550,6 +550,96 @@ export const SYSTEM_TEST_TEMPLATES: SystemTestTemplate[] = [
         question_text: 'Öffne Brett / Systembrett (Link) — prüfe ob das 3D-Board lädt, du Elemente verschieben kannst und Speichern funktioniert.',
         expected_result: '3D-Board lädt; Demo-Konstellation manipulierbar; Speichern funktioniert.',
         test_function_url: `https://brett.${D}`, test_role: 'user',
+      },
+    ],
+  },
+  {
+    title: 'System-Test 11: LiveKit & Streaming',
+    description: 'Vollständiger Test des LiveKit-Streaming-Stacks: Admin-Steuerseite, Stream starten/stoppen, Viewer-Portal, RTMP-Ingress, Recording-Liste und Pod-Status.',
+    instructions: 'Schritte 1, 4, 5, 6, 7 im Admin-Browser. Schritt 2 startet den Stream — danach Schritt 3 im Testnutzer-Browser. Schritt 6 beendet den Stream.',
+    steps: [
+      {
+        question_text: 'Öffne die Admin-Stream-Seite (Link) — prüfe ob der Stream-Status „offline" angezeigt wird und die Seite ohne Fehler lädt.',
+        expected_result: 'Seite lädt; Stream-Status „offline"; keine Fehlermeldungen.',
+        test_function_url: '/admin/stream', test_role: 'admin',
+      },
+      {
+        question_text: 'Klicke auf der Admin-Stream-Seite (Link) den Start-Button — prüfe ob der Status auf „live" wechselt und ein Stream-Token generiert wird.',
+        expected_result: 'Status wechselt auf „live"; Stream-Token sichtbar.',
+        test_function_url: '/admin/stream', test_role: 'admin',
+      },
+      {
+        question_text: 'Öffne das Viewer-Portal (Link) im Testnutzer-Browser während der Stream läuft — prüfe ob der Stream-Player sichtbar ist und keine Verbindungsfehler erscheinen. → Nutzer: zweites Browser-Profil.',
+        expected_result: 'Stream-Player sichtbar; Verbindung aufgebaut; kein Fehler im Browser.',
+        test_function_url: '/portal/stream', test_role: 'user',
+        agent_notes: 'Zweites Browser-Profil (Testnutzer) erforderlich. Stream muss laufen (Schritt 2 abgeschlossen).',
+      },
+      {
+        question_text: 'Öffne die Admin-Stream-Seite (Link) — prüfe ob der RTMP-Ingress-Status und die RTMP-URL angezeigt werden.',
+        expected_result: 'RTMP-URL sichtbar; Ingress-Status angezeigt (aktiv oder bereit).',
+        test_function_url: '/admin/stream', test_role: 'admin',
+      },
+      {
+        question_text: 'Öffne die Admin-Stream-Seite (Link) → klicke „Aufnahmen" oder scrolle zur Recordings-Liste — prüfe ob vorhandene MP4-Dateien aufgelistet werden oder eine leere Liste ohne Fehler erscheint.',
+        expected_result: 'Recordings-Liste lädt; MP4-Dateien sichtbar oder leere Liste ohne Fehler.',
+        test_function_url: '/admin/stream', test_role: 'admin',
+      },
+      {
+        question_text: 'Klicke auf der Admin-Stream-Seite (Link) den Stop-Button — prüfe ob der Status auf „offline" wechselt und das Viewer-Portal „kein Stream" anzeigt.',
+        expected_result: 'Status wechselt auf „offline"; Viewer-Portal zeigt „kein Stream aktiv".',
+        test_function_url: '/admin/stream', test_role: 'admin',
+      },
+      {
+        question_text: 'Öffne Monitoring (Link) — prüfe ob der `livekit-server` Pod im Status „Running" ist und kein CrashLoop vorliegt.',
+        expected_result: '`livekit-server` Pod im Status „Running"; kein CrashLoop.',
+        test_function_url: '/admin/monitoring', test_role: 'admin',
+      },
+    ],
+  },
+  {
+    title: 'System-Test 12: Projektmanagement',
+    description: 'Vollständiger Test des Projektmanagement-Moduls: Projekte, Teilprojekte, Aufgaben, Zeiterfassung, Meeting-Verknüpfung und Archivierung.',
+    instructions: 'Alle Schritte im Admin-Browser. Öffne jeweils den Link im Schritt. Schritte bauen aufeinander auf — in Reihenfolge abarbeiten.',
+    steps: [
+      {
+        question_text: 'Öffne Projekte (Link) → klicke „Neues Projekt" → fülle Titel und Client aus → speichere — prüfe ob das Projekt in der Liste erscheint.',
+        expected_result: 'Projekt erscheint in der Liste; Pflichtfeld-Validierung serverseitig.',
+        test_function_url: '/admin/projekte', test_role: 'admin',
+      },
+      {
+        question_text: 'Öffne das neu angelegte Projekt (Link) → wechsle zum Reiter „Teilprojekte" → klicke „Neues Teilprojekt" → trage Titel ein und speichere — prüfe ob das Teilprojekt erscheint.',
+        expected_result: 'Teilprojekt erscheint unter dem Reiter „Teilprojekte" des Projekts.',
+        test_function_url: '/admin/projekte', test_role: 'admin',
+      },
+      {
+        question_text: 'Im Projekt-Detail (Link) → wechsle zum Reiter „Aufgaben" → klicke „Neue Aufgabe" → fülle Titel und Priorität aus → speichere — prüfe ob die Aufgabe mit Status „Entwurf" erscheint.',
+        expected_result: 'Aufgabe erscheint in der Liste; Status „Entwurf"; Aufgaben-Counter aktualisiert.',
+        test_function_url: '/admin/projekte', test_role: 'admin',
+      },
+      {
+        question_text: 'Im Projekt-Detail (Link) → klicke auf die Aufgabe → ändere den Status auf „Erledigt" → speichere — prüfe ob der Aufgaben-Counter sofort sinkt.',
+        expected_result: 'Status wechselt sofort auf „Erledigt"; offene Aufgaben-Counter sinkt.',
+        test_function_url: '/admin/projekte', test_role: 'admin',
+      },
+      {
+        question_text: 'Im Projekt-Detail (Link) → wechsle zum Reiter „Zeiterfassung" → klicke „Zeit buchen" → trage Dauer und Beschreibung ein → speichere — prüfe ob der Gesamtzeit-Counter aktualisiert wird.',
+        expected_result: 'Zeiteintrag gespeichert; Gesamtzeit-Counter des Projekts erhöht sich.',
+        test_function_url: '/admin/projekte', test_role: 'admin',
+      },
+      {
+        question_text: 'Im Projekt-Detail (Link) → ändere den Projekt-Status auf „Aktiv" → speichere — prüfe ob das Status-Badge aktualisiert wird und das Projekt in der aktiven Filter-Ansicht erscheint.',
+        expected_result: 'Status-Badge zeigt „Aktiv"; Projekt erscheint in gefilterten „Aktiv"-Ansicht.',
+        test_function_url: '/admin/projekte', test_role: 'admin',
+      },
+      {
+        question_text: 'Im Projekt-Detail (Link) → wechsle zum Reiter „Besprechungen" → klicke „Meeting verknüpfen" → wähle ein vorhandenes Meeting aus — prüfe ob es im Reiter erscheint.',
+        expected_result: 'Meeting erscheint im Reiter „Besprechungen" des Projekts.',
+        test_function_url: '/admin/projekte', test_role: 'admin',
+      },
+      {
+        question_text: 'Im Projekt-Detail (Link) → ändere den Status auf „Archiviert" → speichere — prüfe ob das Projekt aus der Standard-Liste verschwindet und in der Archiv-Ansicht sichtbar ist.',
+        expected_result: 'Projekt verschwindet aus Standard-Liste; in Archiv-Ansicht sichtbar.',
+        test_function_url: '/admin/projekte', test_role: 'admin',
       },
     ],
   },

--- a/website/src/pages/admin/fragebogen/[assignmentId].astro
+++ b/website/src/pages/admin/fragebogen/[assignmentId].astro
@@ -57,16 +57,26 @@ const maxScore = Math.max(...scores.map(s => s.threshold_high ?? s.final_score ?
           <p class="text-muted mt-1 text-sm">
             Eingereicht: {fmtDate(assignment.submitted_at)}
           </p>
+          {assignment.project_id && (
+            <a
+              href={`/admin/projekte/${assignment.project_id}`}
+              class="inline-flex items-center gap-1 mt-2 text-xs text-gold/70 hover:text-gold underline"
+            >
+              → Verknüpftes Projekt öffnen
+            </a>
+          )}
         </div>
         <span class={`px-3 py-1 rounded-full border text-sm ${
           assignment.status === 'reviewed' ? 'bg-green-500/10 text-green-400 border-green-500/20'
           : assignment.status === 'submitted' ? 'bg-blue-500/10 text-blue-400 border-blue-500/20'
           : assignment.status === 'dismissed' ? 'bg-red-500/10 text-red-400 border-red-500/20'
+          : assignment.status === 'archived' ? 'bg-slate-500/10 text-slate-400 border-slate-500/20'
           : 'bg-yellow-500/10 text-yellow-400 border-yellow-500/20'
         }`}>
           {assignment.status === 'reviewed' ? 'Besprochen'
             : assignment.status === 'submitted' ? 'Eingereicht'
             : assignment.status === 'dismissed' ? 'Abgelehnt'
+            : assignment.status === 'archived' ? 'Archiviert'
             : assignment.status}
         </span>
       </div>
@@ -190,6 +200,15 @@ const maxScore = Math.max(...scores.map(s => s.threshold_high ?? s.final_score ?
                         Bug erfassen
                       </button>
                     )}
+                    {assignment.project_id && (
+                      <button
+                        class="create-task-btn text-xs px-2 py-1 bg-dark border border-dark-lighter text-light/70 rounded hover:border-gold/40 hover:text-light transition-colors"
+                        data-question-id={q.id}
+                      >
+                        + Aufgabe
+                      </button>
+                    )}
+                    <span id={`task-result-${q.id}`} class="text-xs text-green-400 hidden"></span>
                   </div>
                   <div id={`bug-result-${q.id}`} class="mt-2 text-xs hidden"></div>
                 </div>
@@ -275,6 +294,12 @@ const maxScore = Math.max(...scores.map(s => s.threshold_high ?? s.final_score ?
               Als besprochen markieren ✓
             </button>
           )}
+          {assignment.status === 'reviewed' && (
+            <button id="archive-btn"
+              class="px-4 py-2 bg-dark border border-dark-lighter text-muted rounded-lg text-sm hover:border-gold/40 hover:text-light transition-colors">
+              Archivieren
+            </button>
+          )}
         </div>
         <p id="notes-msg" class="text-xs mt-2 hidden"></p>
       </div>
@@ -326,6 +351,55 @@ const maxScore = Math.max(...scores.map(s => s.threshold_high ?? s.final_score ?
     bugModal.classList.remove('flex');
     activeBugStepId = null;
   }
+
+  // Task creation
+  document.querySelectorAll('.create-task-btn').forEach(btn => {
+    btn.addEventListener('click', async () => {
+      const questionId = btn.dataset.questionId;
+      btn.disabled = true;
+      btn.textContent = '…';
+      try {
+        const r = await fetch(
+          `/api/admin/questionnaires/assignments/${assignmentId}/create-task`,
+          {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ questionId }),
+          },
+        );
+        const data = await r.json().catch(() => ({}));
+        const resultEl = document.getElementById(`task-result-${questionId}`);
+        if (r.ok && data.taskId) {
+          btn.remove();
+          if (resultEl) {
+            resultEl.textContent = '✓ Aufgabe angelegt';
+            resultEl.classList.remove('hidden');
+          }
+        } else {
+          btn.disabled = false;
+          btn.textContent = '+ Aufgabe';
+          if (resultEl) {
+            resultEl.textContent = data.error || 'Fehler';
+            resultEl.className = 'text-xs text-red-400';
+            resultEl.classList.remove('hidden');
+          }
+        }
+      } catch {
+        btn.disabled = false;
+        btn.textContent = '+ Aufgabe';
+      }
+    });
+  });
+
+  // Archive
+  document.getElementById('archive-btn')?.addEventListener('click', async () => {
+    const r = await fetch(`/api/admin/questionnaires/assignments/${assignmentId}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ status: 'archived' }),
+    });
+    if (r.ok) window.location.reload();
+  });
 
   document.getElementById('bug-modal-submit')?.addEventListener('click', async () => {
     const desc = bugDescInput.value.trim();

--- a/website/src/pages/api/admin/questionnaires/assign.ts
+++ b/website/src/pages/api/admin/questionnaires/assign.ts
@@ -1,11 +1,12 @@
 import type { APIRoute } from 'astro';
 import { getSession, isAdmin } from '../../../../lib/auth';
 import { getQTemplate, createQAssignment } from '../../../../lib/questionnaire-db';
-import { getCustomerByEmail } from '../../../../lib/website-db';
+import { getCustomerByEmail, createProject } from '../../../../lib/website-db';
 import { getUserById } from '../../../../lib/keycloak';
 import { sendQuestionnaireAssigned } from '../../../../lib/email';
 
 const PROD_DOMAIN = process.env.PROD_DOMAIN || '';
+const BRAND = process.env.BRAND || 'mentolder';
 
 export const POST: APIRoute = async ({ request }) => {
   const session = await getSession(request.headers.get('cookie'));
@@ -28,12 +29,32 @@ export const POST: APIRoute = async ({ request }) => {
   const customer = await getCustomerByEmail(kcUser.email).catch(() => null);
   if (!customer) return new Response(JSON.stringify({ error: 'Kundeneintrag nicht gefunden.' }), { status: 404 });
 
-  const assignment = await createQAssignment({ customerId: customer.id, templateId: tpl.id });
+  const clientName = `${kcUser.firstName ?? ''} ${kcUser.lastName ?? ''}`.trim() || kcUser.username;
+
+  const projectTitle = tpl.is_system_test
+    ? tpl.title
+    : `${tpl.title} — ${clientName}`;
+
+  const projectId = await createProject({
+    brand: BRAND,
+    name: projectTitle,
+    status: 'entwurf',
+    priority: 'mittel',
+    customerId: customer.id,
+  }).catch((err) => {
+    console.error('[assign] project creation failed, continuing without project_id:', err);
+    return null;
+  });
+
+  const assignment = await createQAssignment({
+    customerId: customer.id,
+    templateId: tpl.id,
+    projectId: projectId ?? undefined,
+  });
 
   const portalUrl = PROD_DOMAIN
     ? `https://web.${PROD_DOMAIN}/portal/fragebogen/${assignment.id}`
     : `http://web.localhost/portal/fragebogen/${assignment.id}`;
-  const clientName = `${kcUser.firstName ?? ''} ${kcUser.lastName ?? ''}`.trim() || kcUser.username;
   await sendQuestionnaireAssigned({ clientEmail: kcUser.email, clientName, questionnaireTitle: tpl.title, portalUrl });
 
   return new Response(JSON.stringify(assignment), { status: 201, headers: { 'Content-Type': 'application/json' } });

--- a/website/src/pages/api/admin/questionnaires/assignments/[id].ts
+++ b/website/src/pages/api/admin/questionnaires/assignments/[id].ts
@@ -34,7 +34,7 @@ export const PUT: APIRoute = async ({ request, params }) => {
 
   const body = await request.json() as { status?: string; coach_notes?: string };
   const updated = await updateQAssignment(params.id!, {
-    status: body.status as 'reviewed' | undefined,
+    status: body.status as import('../../../../../lib/questionnaire-db').AssignmentStatus | undefined,
     coachNotes: body.coach_notes,
   });
   if (!updated) return new Response(JSON.stringify({ error: 'Nicht gefunden.' }), { status: 404 });

--- a/website/src/pages/api/admin/questionnaires/assignments/[id]/create-task.ts
+++ b/website/src/pages/api/admin/questionnaires/assignments/[id]/create-task.ts
@@ -1,0 +1,40 @@
+import type { APIRoute } from 'astro';
+import { getSession, isAdmin } from '../../../../../../lib/auth';
+import { getQAssignment, getQQuestion } from '../../../../../../lib/questionnaire-db';
+import { createProjectTask } from '../../../../../../lib/website-db';
+
+export const POST: APIRoute = async ({ request, params }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) return new Response('Unauthorized', { status: 401 });
+
+  const assignment = await getQAssignment(params.id!).catch(() => null);
+  if (!assignment) return new Response(JSON.stringify({ error: 'Auftrag nicht gefunden.' }), { status: 404 });
+  if (!assignment.project_id) {
+    return new Response(JSON.stringify({ error: 'Kein Projekt verknüpft.' }), { status: 409 });
+  }
+
+  const body = await request.json() as { questionId?: string };
+  if (!body.questionId) {
+    return new Response(JSON.stringify({ error: 'questionId erforderlich.' }), { status: 400 });
+  }
+
+  const question = await getQQuestion(body.questionId).catch(() => null);
+  if (!question) return new Response(JSON.stringify({ error: 'Frage nicht gefunden.' }), { status: 404 });
+
+  const taskName = question.question_text.length > 120
+    ? question.question_text.slice(0, 117) + '…'
+    : question.question_text;
+
+  const taskId = await createProjectTask({
+    projectId: assignment.project_id,
+    name: taskName,
+    description: question.test_expected_result ?? undefined,
+    status: 'entwurf',
+    priority: 'mittel',
+  });
+
+  return new Response(JSON.stringify({ taskId }), {
+    status: 201,
+    headers: { 'Content-Type': 'application/json' },
+  });
+};

--- a/website/src/pages/api/admin/questionnaires/assignments/[id]/create-task.ts
+++ b/website/src/pages/api/admin/questionnaires/assignments/[id]/create-task.ts
@@ -21,6 +21,10 @@ export const POST: APIRoute = async ({ request, params }) => {
   const question = await getQQuestion(body.questionId).catch(() => null);
   if (!question) return new Response(JSON.stringify({ error: 'Frage nicht gefunden.' }), { status: 404 });
 
+  if (question.template_id !== assignment.template_id) {
+    return new Response(JSON.stringify({ error: 'Frage gehört nicht zu diesem Auftrag.' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+  }
+
   const taskName = question.question_text.length > 120
     ? question.question_text.slice(0, 117) + '…'
     : question.question_text;

--- a/website/src/pages/api/admin/questionnaires/assignments/[id]/create-task.ts
+++ b/website/src/pages/api/admin/questionnaires/assignments/[id]/create-task.ts
@@ -5,7 +5,7 @@ import { createProjectTask } from '../../../../../../lib/website-db';
 
 export const POST: APIRoute = async ({ request, params }) => {
   const session = await getSession(request.headers.get('cookie'));
-  if (!session || !isAdmin(session)) return new Response('Unauthorized', { status: 401 });
+  if (!session || !isAdmin(session)) return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401, headers: { 'Content-Type': 'application/json' } });
 
   const assignment = await getQAssignment(params.id!).catch(() => null);
   if (!assignment) return new Response(JSON.stringify({ error: 'Auftrag nicht gefunden.' }), { status: 404 });

--- a/website/src/pages/api/admin/testdata/purge.ts
+++ b/website/src/pages/api/admin/testdata/purge.ts
@@ -13,67 +13,79 @@ export const DELETE: APIRoute = async ({ request }) => {
   if (!session || !isAdmin(session)) return jsonError('Nicht autorisiert', 401);
 
   try {
-    // 1. Inbox bookings where payload.name starts with [TEST]
-    const bookingRes = await pool.query(
-      `DELETE FROM inbox_items WHERE payload->>'name' LIKE '[TEST]%' RETURNING id`
-    );
+    const client = await pool.connect();
+    try {
+      await client.query('BEGIN');
 
-    // 2. Meetings linked to [TEST] CRM customers
-    const meetingRes = await pool.query(
-      `DELETE FROM meetings
-       WHERE customer_id IN (SELECT id FROM customers WHERE name LIKE '[TEST]%')
-       RETURNING id`
-    );
+      // 1. Inbox bookings where payload.name starts with [TEST]
+      const bookingRes = await client.query(
+        `DELETE FROM inbox_items WHERE payload->>'name' LIKE '[TEST]%' RETURNING id`
+      );
 
-    // 3. Find unlocked [TEST] invoices (locked=false only — GoBD blocks locked ones)
-    const lockedRes = await pool.query(
-      `SELECT COUNT(*) AS cnt FROM billing_invoices i
-       JOIN billing_customers c ON c.id = i.customer_id
-       WHERE c.name LIKE '[TEST]%' AND i.locked = true`
-    );
-    const skippedLocked = parseInt(lockedRes.rows[0]?.cnt ?? '0', 10);
+      // 2. Meetings linked to [TEST] CRM customers
+      const meetingRes = await client.query(
+        `DELETE FROM meetings
+         WHERE customer_id IN (SELECT id FROM customers WHERE name LIKE '[TEST]%')
+         RETURNING id`
+      );
 
-    // 4. Line items for unlocked [TEST] invoices
-    const lineRes = await pool.query(
-      `DELETE FROM billing_invoice_line_items
-       WHERE invoice_id IN (
-         SELECT i.id FROM billing_invoices i
+      // 3. Find unlocked [TEST] invoices (locked=false only — GoBD blocks locked ones)
+      const lockedRes = await client.query(
+        `SELECT COUNT(*) AS cnt FROM billing_invoices i
          JOIN billing_customers c ON c.id = i.customer_id
-         WHERE c.name LIKE '[TEST]%' AND i.locked = false
-       )
-       RETURNING id`
-    );
+         WHERE c.name LIKE '[TEST]%' AND i.locked = true`
+      );
+      const skippedLocked = parseInt(lockedRes.rows[0]?.cnt ?? '0', 10);
 
-    // 5. Unlocked [TEST] invoices
-    const invoiceRes = await pool.query(
-      `DELETE FROM billing_invoices i
-       USING billing_customers c
-       WHERE c.id = i.customer_id AND c.name LIKE '[TEST]%' AND i.locked = false
-       RETURNING i.id`
-    );
+      // 4. Line items for unlocked [TEST] invoices
+      const lineRes = await client.query(
+        `DELETE FROM billing_invoice_line_items
+         WHERE invoice_id IN (
+           SELECT i.id FROM billing_invoices i
+           JOIN billing_customers c ON c.id = i.customer_id
+           WHERE c.name LIKE '[TEST]%' AND i.locked = false
+         )
+         RETURNING id`
+      );
 
-    // 6. [TEST] billing customers (after invoices are gone)
-    const billingCustRes = await pool.query(
-      `DELETE FROM billing_customers WHERE name LIKE '[TEST]%' RETURNING id`
-    );
+      // 5. Unlocked [TEST] invoices
+      const invoiceRes = await client.query(
+        `DELETE FROM billing_invoices i
+         USING billing_customers c
+         WHERE c.id = i.customer_id AND c.name LIKE '[TEST]%' AND i.locked = false
+         RETURNING i.id`
+      );
 
-    // 7. [TEST] CRM customers
-    const crmCustRes = await pool.query(
-      `DELETE FROM customers WHERE name LIKE '[TEST]%' RETURNING id`
-    );
+      // 6. [TEST] billing customers (after invoices are gone)
+      const billingCustRes = await client.query(
+        `DELETE FROM billing_customers WHERE name LIKE '[TEST]%' RETURNING id`
+      );
 
-    return new Response(JSON.stringify({
-      deleted: {
-        bookings:         bookingRes.rowCount ?? 0,
-        meetings:         meetingRes.rowCount ?? 0,
-        invoiceLines:     lineRes.rowCount ?? 0,
-        invoices:         invoiceRes.rowCount ?? 0,
-        billingCustomers: billingCustRes.rowCount ?? 0,
-        customers:        crmCustRes.rowCount ?? 0,
-      },
-      skipped: { lockedInvoices: skippedLocked },
-    }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      // 7. [TEST] CRM customers
+      const crmCustRes = await client.query(
+        `DELETE FROM customers WHERE name LIKE '[TEST]%' RETURNING id`
+      );
 
+      await client.query('COMMIT');
+
+      return new Response(JSON.stringify({
+        deleted: {
+          bookings:         bookingRes.rowCount ?? 0,
+          meetings:         meetingRes.rowCount ?? 0,
+          invoiceLines:     lineRes.rowCount ?? 0,
+          invoices:         invoiceRes.rowCount ?? 0,
+          billingCustomers: billingCustRes.rowCount ?? 0,
+          customers:        crmCustRes.rowCount ?? 0,
+        },
+        skipped: { lockedInvoices: skippedLocked },
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+
+    } catch (err) {
+      await client.query('ROLLBACK');
+      throw err;
+    } finally {
+      client.release();
+    }
   } catch (err) {
     console.error('[testdata/purge]', err);
     return jsonError('Fehler beim Löschen der Testdaten', 500);

--- a/website/src/pages/api/admin/testdata/purge.ts
+++ b/website/src/pages/api/admin/testdata/purge.ts
@@ -1,0 +1,81 @@
+import type { APIRoute } from 'astro';
+import { getSession, isAdmin } from '../../../../lib/auth';
+import { pool } from '../../../../lib/website-db';
+
+function jsonError(msg: string, status: number) {
+  return new Response(JSON.stringify({ error: msg }), {
+    status, headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+export const DELETE: APIRoute = async ({ request }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) return jsonError('Nicht autorisiert', 401);
+
+  try {
+    // 1. Inbox bookings where payload.name starts with [TEST]
+    const bookingRes = await pool.query(
+      `DELETE FROM inbox_items WHERE payload->>'name' LIKE '[TEST]%' RETURNING id`
+    );
+
+    // 2. Meetings linked to [TEST] CRM customers
+    const meetingRes = await pool.query(
+      `DELETE FROM meetings
+       WHERE customer_id IN (SELECT id FROM customers WHERE name LIKE '[TEST]%')
+       RETURNING id`
+    );
+
+    // 3. Find unlocked [TEST] invoices (locked=false only — GoBD blocks locked ones)
+    const lockedRes = await pool.query(
+      `SELECT COUNT(*) AS cnt FROM billing_invoices i
+       JOIN billing_customers c ON c.id = i.customer_id
+       WHERE c.name LIKE '[TEST]%' AND i.locked = true`
+    );
+    const skippedLocked = parseInt(lockedRes.rows[0]?.cnt ?? '0', 10);
+
+    // 4. Line items for unlocked [TEST] invoices
+    const lineRes = await pool.query(
+      `DELETE FROM billing_invoice_line_items
+       WHERE invoice_id IN (
+         SELECT i.id FROM billing_invoices i
+         JOIN billing_customers c ON c.id = i.customer_id
+         WHERE c.name LIKE '[TEST]%' AND i.locked = false
+       )
+       RETURNING id`
+    );
+
+    // 5. Unlocked [TEST] invoices
+    const invoiceRes = await pool.query(
+      `DELETE FROM billing_invoices i
+       USING billing_customers c
+       WHERE c.id = i.customer_id AND c.name LIKE '[TEST]%' AND i.locked = false
+       RETURNING i.id`
+    );
+
+    // 6. [TEST] billing customers (after invoices are gone)
+    const billingCustRes = await pool.query(
+      `DELETE FROM billing_customers WHERE name LIKE '[TEST]%' RETURNING id`
+    );
+
+    // 7. [TEST] CRM customers
+    const crmCustRes = await pool.query(
+      `DELETE FROM customers WHERE name LIKE '[TEST]%' RETURNING id`
+    );
+
+    return new Response(JSON.stringify({
+      deleted: {
+        bookings:         bookingRes.rowCount ?? 0,
+        meetings:         meetingRes.rowCount ?? 0,
+        invoiceLines:     lineRes.rowCount ?? 0,
+        invoices:         invoiceRes.rowCount ?? 0,
+        billingCustomers: billingCustRes.rowCount ?? 0,
+        customers:        crmCustRes.rowCount ?? 0,
+      },
+      skipped: { lockedInvoices: skippedLocked },
+    }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+
+  } catch (err) {
+    console.error('[testdata/purge]', err);
+    return jsonError('Fehler beim Löschen der Testdaten', 500);
+  }
+};

--- a/website/src/pages/api/admin/testdata/seed.ts
+++ b/website/src/pages/api/admin/testdata/seed.ts
@@ -73,7 +73,8 @@ export const POST: APIRoute = async ({ request }) => {
     if (crmId1 && crmId2) {
       await pool.query(
         `INSERT INTO meetings (customer_id, meeting_type, scheduled_at, status)
-         VALUES ($1,$2,$3,$4), ($5,$6,$7,$8)`,
+         VALUES ($1,$2,$3,$4), ($5,$6,$7,$8)
+         ON CONFLICT DO NOTHING`,
         [
           crmId1, '[TEST] Erstgespräch', tomorrow, 'scheduled',
           crmId2, '[TEST] Folgegespräch', in3days, 'scheduled',

--- a/website/src/pages/api/admin/testdata/seed.ts
+++ b/website/src/pages/api/admin/testdata/seed.ts
@@ -1,0 +1,123 @@
+import type { APIRoute } from 'astro';
+import { getSession, isAdmin } from '../../../../lib/auth';
+import { pool } from '../../../../lib/website-db';
+import { createCustomer as createBillingCustomer, createInvoice } from '../../../../lib/native-billing';
+import { createInboxItem } from '../../../../lib/messaging-db';
+
+function jsonError(msg: string, status: number) {
+  return new Response(JSON.stringify({ error: msg }), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+export const POST: APIRoute = async ({ request }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) return jsonError('Nicht autorisiert', 401);
+
+  const brand = process.env.BRAND || 'mentolder';
+  const today = new Date().toISOString().split('T')[0];
+
+  try {
+    // 1. CRM customers (customers table — no Keycloak)
+    await pool.query(
+      `INSERT INTO customers (name, email, phone, company)
+       VALUES ($1,$2,$3,$4), ($5,$6,$7,$8)
+       ON CONFLICT (email) DO UPDATE
+         SET name = EXCLUDED.name, company = EXCLUDED.company, updated_at = now()`,
+      [
+        '[TEST] Max Mustermann', 'test-max@test.invalid', '+49 111 0000001', '[TEST] Coaching AG',
+        '[TEST] Erika Musterfrau', 'test-erika@test.invalid', '+49 111 0000002', '[TEST] Musterfirma GmbH',
+      ]
+    );
+    const crmRes = await pool.query(
+      `SELECT id FROM customers WHERE email IN ($1,$2)`,
+      ['test-max@test.invalid', 'test-erika@test.invalid']
+    );
+    const [crmId1, crmId2] = crmRes.rows.map((r: { id: string }) => r.id);
+
+    // 2. Billing customer
+    const billingCustomer = await createBillingCustomer({
+      brand,
+      name: '[TEST] Test GmbH',
+      email: 'test-billing@test.invalid',
+      company: '[TEST] Test GmbH',
+      addressLine1: 'Teststraße 1',
+      city: 'Teststadt',
+      postalCode: '12345',
+    });
+
+    // 3. Draft invoices (not finalized — keeps locked=false so purge can delete them)
+    const invoiceAmounts = [
+      { amount: 500, desc: '[TEST] Coaching-Einzelstunde' },
+      { amount: 1200, desc: '[TEST] Coaching-Paket 3 Sitzungen' },
+      { amount: 3400, desc: '[TEST] Coaching-Intensivprogramm' },
+    ];
+    let invoiceCount = 0;
+    for (const { amount, desc } of invoiceAmounts) {
+      await createInvoice({
+        brand,
+        customerId: billingCustomer.id,
+        issueDate: today,
+        dueDays: 14,
+        taxMode: 'kleinunternehmer',
+        lines: [{ description: desc, quantity: 1, unitPrice: amount }],
+        notes: '[TEST] Automatisch generierter Testdatensatz',
+      });
+      invoiceCount++;
+    }
+
+    // 4. Meetings (linked to CRM customers)
+    const tomorrow = new Date(Date.now() + 86_400_000).toISOString();
+    const in3days = new Date(Date.now() + 3 * 86_400_000).toISOString();
+    if (crmId1 && crmId2) {
+      await pool.query(
+        `INSERT INTO meetings (customer_id, meeting_type, scheduled_at, status)
+         VALUES ($1,$2,$3,$4), ($5,$6,$7,$8)`,
+        [
+          crmId1, '[TEST] Erstgespräch', tomorrow, 'scheduled',
+          crmId2, '[TEST] Folgegespräch', in3days, 'scheduled',
+        ]
+      );
+    }
+
+    // 5. Inbox bookings (Termine)
+    await createInboxItem({
+      type: 'booking',
+      payload: {
+        name: '[TEST] Max Mustermann',
+        email: 'test-max@test.invalid',
+        type: 'erstgespraech',
+        typeLabel: '[TEST] Kostenloses Erstgespräch',
+        slotStart: tomorrow,
+        slotEnd: in3days,
+        slotDisplay: '10:00–11:00',
+        date: today,
+        leistungKey: 'coaching',
+        adminCreated: true,
+      },
+    });
+    await createInboxItem({
+      type: 'booking',
+      payload: {
+        name: '[TEST] Erika Musterfrau',
+        email: 'test-erika@test.invalid',
+        type: 'termin',
+        typeLabel: '[TEST] Termin vor Ort',
+        slotStart: in3days,
+        slotEnd: in3days,
+        slotDisplay: '14:00–15:00',
+        date: today,
+        leistungKey: 'coaching',
+        adminCreated: true,
+      },
+    });
+
+    return new Response(JSON.stringify({
+      created: { customers: 2, billingCustomers: 1, invoices: invoiceCount, meetings: 2, bookings: 2 },
+    }), { status: 201, headers: { 'Content-Type': 'application/json' } });
+  } catch (err) {
+    console.error('[testdata/seed]', err);
+    return jsonError('Fehler beim Anlegen der Testdaten', 500);
+  }
+};


### PR DESCRIPTION
## Summary

- Adds a new **Testdaten** tab to `/admin/monitoring` so Gekko can generate and wipe test records in one click
- `POST /api/admin/testdata/seed` — inserts 2 CRM clients, 1 billing customer, 3 draft invoices (500/1200/3400 €), 2 meetings, 2 inbox bookings — all with `[TEST]` prefix; idempotent on customers via upsert
- `DELETE /api/admin/testdata/purge` — removes all `[TEST]`-prefixed records in FK-safe order inside a single DB transaction; skips GoBD-locked invoices and reports them as a warning
- `TestDataPanel.svelte` — compact card with seed/purge buttons, SVG spinners, confirmation modal (Escape + aria-labelledby), three-state status messages (ok/warn/error) with 5s auto-dismiss

## Test plan

- [ ] Navigate to `/admin/monitoring#testdaten` — confirm "Testdaten" tab appears
- [ ] Click "Testdaten generieren" — confirm success message with counts (2 clients, 3 invoices, 2 meetings, 2 bookings)
- [ ] Check `/admin/clients` for `[TEST] Max Mustermann` and `[TEST] Erika Musterfrau`
- [ ] Check `/admin/rechnungen` for 3 draft invoices with `[TEST]` notes
- [ ] Click "Alle [TEST]-Daten löschen" → confirm modal → confirm deletion counts returned match seeded counts
- [ ] Verify `[TEST]` records gone from client and invoice list views
- [ ] Run seed twice — confirm no duplicate clients/billing customers (upsert); meetings may duplicate (no unique constraint, purge cleans all)
- [ ] Press Escape while confirmation modal is open — modal closes

🤖 Generated with [Claude Code](https://claude.com/claude-code)