### PR TITLE
feat(admin): inline questionnaire panel on project + ticket pages

### DIFF
--- a/docs/superpowers/plans/2026-05-08-project-questionnaire-overview.md
+++ b/docs/superpowers/plans/2026-05-08-project-questionnaire-overview.md
@@ -1,0 +1,610 @@
+# Project & Ticket Overview — Questionnaire Section Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Show the linked questionnaire (questions, answers, scores, coach notes) inline on `/admin/projekte/<id>` and `/admin/tickets/<id>`, so the project's questionnaire origin is visible without leaving the page.
+
+**Architecture:** One new read-only DB helper (`listQAssignmentsForProject`) plus one shared Astro section component (`ProjectQuestionnairesPanel.astro`) embedded on both host pages. No schema migrations, no new API routes. The component reuses the score bar markup from the existing `/admin/fragebogen/[assignmentId].astro` review page, kept inline rather than abstracted.
+
+**Tech Stack:** Astro 5 frontmatter rendering, Svelte islands (existing), TypeScript, PostgreSQL (`pg` client via `pool` in `website/src/lib/questionnaire-db.ts`), Tailwind tokens already used in the codebase (`bg-dark-light`, `border-dark-lighter`, `text-light`, `text-muted`, `text-gold`).
+
+**Spec:** [`docs/superpowers/specs/2026-05-08-project-questionnaire-overview-design.md`](../specs/2026-05-08-project-questionnaire-overview-design.md)
+
+**Parallelism note:** Task 1 and Task 2 are sequential. Task 3 and Task 4 can run in parallel — they touch different host pages and both depend on Task 2 (the shared component) being on disk.
+
+---
+
+## Task 1: Add `listQAssignmentsForProject` DB helper
+
+**Files:**
+- Modify: `website/src/lib/questionnaire-db.ts` (add function after `listQAssignmentsForCustomer`, around line 488)
+
+- [ ] **Step 1: Read the existing `listQAssignmentsForCustomer` to mirror its shape exactly**
+
+The new helper must return rows in the same `QAssignment` shape (joined `template_title`). Look at lines 476–488 of `website/src/lib/questionnaire-db.ts`.
+
+- [ ] **Step 2: Add the new function**
+
+Insert this immediately after `listQAssignmentsForCustomer` (the existing function ends with a closing brace around line 488):
+
+```typescript
+/**
+ * List coaching questionnaire assignments linked to a project (ticket of type='project').
+ * Excludes system-test templates — those are QA runs, not project context.
+ */
+export async function listQAssignmentsForProject(projectId: string): Promise<QAssignment[]> {
+  const r = await pool.query(
+    `SELECT a.id, a.customer_id, a.template_id, t.title AS template_title,
+            a.status, a.coach_notes, a.assigned_at, a.submitted_at, a.reviewed_at,
+            a.archived_at, a.dismissed_at, a.dismiss_reason, a.project_id
+     FROM questionnaire_assignments a
+     JOIN questionnaire_templates t ON t.id = a.template_id
+     WHERE a.project_id = $1
+       AND COALESCE(t.is_system_test, false) = false
+     ORDER BY a.assigned_at DESC`,
+    [projectId],
+  );
+  return r.rows;
+}
+```
+
+- [ ] **Step 3: Type-check the change**
+
+Run from repo root:
+
+```bash
+cd website && npx tsc --noEmit -p tsconfig.json
+```
+
+Expected: zero errors. If `tsc` reports issues outside `questionnaire-db.ts`, ignore — only the new function and its call sites must be clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add website/src/lib/questionnaire-db.ts
+git commit -m "feat(questionnaire): add listQAssignmentsForProject helper
+
+Reverse lookup for project → questionnaire context. Filters out
+system-test templates (QA runs, not project context)."
+```
+
+---
+
+## Task 2: Build `ProjectQuestionnairesPanel.astro`
+
+**Files:**
+- Create: `website/src/components/admin/ProjectQuestionnairesPanel.astro`
+
+- [ ] **Step 1: Create the component file with the props contract and markup**
+
+Write the full component:
+
+```astro
+---
+// website/src/components/admin/ProjectQuestionnairesPanel.astro
+//
+// Shared section for /admin/projekte/[id] and /admin/tickets/[id].
+// Renders nothing when `assignments` is empty.
+//
+// Score-bar rendering mirrors /admin/fragebogen/[assignmentId].astro lines 84–117
+// so the panel matches the full review page visually.
+
+import type { QAssignment, QQuestion, QAnswer, QAnswerOption } from '../../lib/questionnaire-db';
+import type { ScoreRow } from '../../lib/compute-scores';
+
+interface AssignmentBundle {
+  assignment: QAssignment;
+  questions: QQuestion[];
+  options: QAnswerOption[];
+  answers: QAnswer[];
+  scores: ScoreRow[];
+}
+
+interface Props {
+  assignments: AssignmentBundle[];
+}
+
+const { assignments } = Astro.props;
+
+function fmtDate(d: string | Date | null): string {
+  if (!d) return '—';
+  return new Date(d).toLocaleDateString('de-DE', { day: '2-digit', month: '2-digit', year: 'numeric' });
+}
+
+function levelColor(level: string | null): string {
+  if (level === 'kritisch') return '#ef4444';
+  if (level === 'mittel') return '#f59e0b';
+  if (level === 'förderlich') return '#22c55e';
+  return '#b8a06a';
+}
+
+const STATUS_CLS: Record<string, string> = {
+  pending:     'bg-yellow-500/10 text-yellow-400 border-yellow-500/20',
+  in_progress: 'bg-yellow-500/10 text-yellow-400 border-yellow-500/20',
+  submitted:   'bg-blue-500/10 text-blue-400 border-blue-500/20',
+  reviewed:    'bg-green-500/10 text-green-400 border-green-500/20',
+  archived:    'bg-slate-500/10 text-slate-400 border-slate-500/20',
+  dismissed:   'bg-red-500/10 text-red-400 border-red-500/20',
+};
+
+const STATUS_LABEL: Record<string, string> = {
+  pending:     'Wartend',
+  in_progress: 'In Bearbeitung',
+  submitted:   'Eingereicht',
+  reviewed:    'Besprochen',
+  archived:    'Archiviert',
+  dismissed:   'Abgelehnt',
+};
+---
+
+{assignments.length > 0 && (
+  <section class="bg-dark-light rounded-2xl border border-dark-lighter p-6 mb-6" id="questionnaires-panel">
+    <h2 class="text-sm font-semibold text-light mb-4 font-serif uppercase tracking-wide">
+      Fragebögen ({assignments.length})
+    </h2>
+
+    <div class="flex flex-col gap-6">
+      {assignments.map(({ assignment, questions, options, answers, scores }) => {
+        const answerMap = new Map(answers.map(a => [a.question_id, a]));
+        const optionMap = new Map(options.map(o => [`${o.question_id}:${o.option_key}`, o]));
+        const isMuted   = assignment.status === 'archived' || assignment.status === 'dismissed';
+        const showQA    = ['in_progress', 'submitted', 'reviewed', 'archived'].includes(assignment.status);
+        const showScores = scores.length > 0 && ['submitted', 'reviewed', 'archived'].includes(assignment.status);
+        const dateLabel = assignment.submitted_at
+          ? `Eingereicht ${fmtDate(assignment.submitted_at)}`
+          : `Zugewiesen ${fmtDate(assignment.assigned_at)}`;
+        const maxScore = Math.max(...scores.map(s => s.threshold_high ?? s.final_score ?? 1), 1);
+
+        return (
+          <div class={`border border-dark-lighter rounded-xl p-5 ${isMuted ? 'opacity-60' : ''}`}>
+            {/* Header */}
+            <div class="flex items-start justify-between gap-3 flex-wrap mb-3">
+              <div class="min-w-0">
+                <h3 class="text-light font-medium">{assignment.template_title}</h3>
+                <p class="text-muted text-xs mt-0.5">{dateLabel}</p>
+              </div>
+              <span class={`px-2.5 py-0.5 rounded-full border text-xs ${STATUS_CLS[assignment.status] ?? ''}`}>
+                {STATUS_LABEL[assignment.status] ?? assignment.status}
+              </span>
+            </div>
+
+            {/* Dismissed reason */}
+            {assignment.status === 'dismissed' && assignment.dismiss_reason && (
+              <p class="text-xs text-muted italic mb-3">Abgelehnt: {assignment.dismiss_reason}</p>
+            )}
+
+            {/* Score bars */}
+            {showScores && (
+              <div class="mb-4">
+                <div class="flex flex-col gap-3">
+                  {scores.map(score => {
+                    const pct = Math.min((score.final_score / Math.max(maxScore, 1)) * 100, 100);
+                    const color = levelColor(score.level);
+                    return (
+                      <div>
+                        <div class="flex justify-between items-baseline mb-1">
+                          <span class="text-light text-xs">{score.name}</span>
+                          <span class="text-xs font-mono" style={`color: ${color}`}>
+                            {score.final_score}{score.level && ` · ${score.level}`}
+                          </span>
+                        </div>
+                        <div class="h-1.5 bg-dark rounded-full overflow-hidden">
+                          <div class="h-full rounded-full"
+                            style={`width: ${pct}%; background-color: ${color}`}></div>
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            )}
+
+            {/* Coach notes preview */}
+            {assignment.coach_notes && assignment.coach_notes.trim().length > 0 && (
+              <div class="mb-4 p-3 bg-dark rounded border border-dark-lighter">
+                <p class="text-xs text-muted uppercase tracking-wide mb-1">Coach-Notizen</p>
+                <p class="text-sm text-light/90 whitespace-pre-wrap">{assignment.coach_notes}</p>
+              </div>
+            )}
+
+            {/* Q&A list — collapsible */}
+            {showQA && questions.length > 0 && (
+              <details class="mt-2">
+                <summary class="cursor-pointer text-xs text-gold hover:text-gold-light select-none">
+                  Fragen &amp; Antworten anzeigen ({answers.length}/{questions.length})
+                </summary>
+                <div class="mt-3 flex flex-col gap-3">
+                  {questions.map((q, i) => {
+                    const ans = answerMap.get(q.id);
+                    const chosen = ans?.option_key ?? null;
+                    const opt = chosen ? optionMap.get(`${q.id}:${chosen}`) : null;
+                    const label = opt?.label ?? chosen;
+                    return (
+                      <div class="border-b border-dark-lighter/50 pb-2 last:border-0 last:pb-0">
+                        <p class="text-muted text-xs mb-0.5">Frage {i + 1}</p>
+                        <p class="text-light text-sm whitespace-pre-line mb-1">{q.question_text}</p>
+                        {chosen === 'skipped' ? (
+                          <span class="inline-block px-2 py-0.5 bg-amber-500/10 text-amber-400 border border-amber-500/20 rounded text-xs">
+                            Übersprungen
+                          </span>
+                        ) : chosen ? (
+                          <span class="inline-block px-2 py-0.5 bg-gold/10 text-gold border border-gold/20 rounded text-xs">
+                            {label}
+                          </span>
+                        ) : (
+                          <span class="text-muted text-xs italic">Nicht beantwortet</span>
+                        )}
+                        {ans?.details_text && (
+                          <p class="text-muted text-xs mt-1 whitespace-pre-line">{ans.details_text}</p>
+                        )}
+                      </div>
+                    );
+                  })}
+                </div>
+              </details>
+            )}
+
+            {/* Link to full review */}
+            <div class="mt-3 flex justify-end">
+              <a href={`/admin/fragebogen/${assignment.id}`}
+                class="text-xs text-gold/80 hover:text-gold underline">
+                Volle Review öffnen →
+              </a>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  </section>
+)}
+```
+
+- [ ] **Step 2: Verify exported types in `questionnaire-db.ts` cover what the component imports**
+
+The component imports `QAssignment`, `QQuestion`, `QAnswer`, `QAnswerOption`. Confirm these are all exported from `website/src/lib/questionnaire-db.ts` (top of file, around lines 20–91). If `QAnswerOption` is not exported, find its exact name (search for `interface .*Option` in that file) and adjust the import. Likely correct names: `QOption` or `QAnswerOption`. Use whatever the file actually exports.
+
+```bash
+grep -nE "^export (type|interface) Q" website/src/lib/questionnaire-db.ts
+```
+
+Expected output should list the four types. If naming differs, update the component import line.
+
+- [ ] **Step 3: Verify `ScoreRow` exists in `compute-scores.ts`**
+
+```bash
+grep -nE "^export (type|interface) " website/src/lib/compute-scores.ts
+```
+
+If the type is named differently (e.g. `Score`), update the import in the component. Match what's actually exported.
+
+- [ ] **Step 4: Type-check the new component**
+
+```bash
+cd website && npx astro check 2>&1 | grep -A2 ProjectQuestionnairesPanel
+```
+
+Expected: no errors. If `astro check` is slow, alternatively `npx tsc --noEmit -p tsconfig.json` covers it (component types resolve through Astro's type generation).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add website/src/components/admin/ProjectQuestionnairesPanel.astro
+git commit -m "feat(admin): add ProjectQuestionnairesPanel component
+
+Shared section for project + ticket detail pages. Renders linked
+questionnaire(s) inline: title, status, scores, coach notes, and
+collapsible Q&A. Empty array -> renders nothing."
+```
+
+---
+
+## Task 3: Embed panel in `/admin/projekte/[id].astro`
+
+**Files:**
+- Modify: `website/src/pages/admin/projekte/[id].astro` (frontmatter imports + fetch; render after Direct-tasks section, before Zeiterfassung)
+
+- [ ] **Step 1: Add imports to the frontmatter**
+
+In `website/src/pages/admin/projekte/[id].astro`, the imports section is lines 1–11. Add these lines after the existing imports:
+
+```astro
+import {
+  listQAssignmentsForProject,
+  listQQuestions,
+  listQAnswerOptionsForTemplate,
+  listQAnswers,
+  listQDimensions,
+} from '../../../lib/questionnaire-db';
+import { computeScores } from '../../../lib/compute-scores';
+import ProjectQuestionnairesPanel from '../../../components/admin/ProjectQuestionnairesPanel.astro';
+```
+
+- [ ] **Step 2: Add the questionnaire fetch alongside the existing `Promise.all` blocks**
+
+The existing fetch lives inside the `try` at lines 34–50. Add a new block that runs in parallel with the existing `else` branch (the non-`besprechungen` case), so questionnaire data is loaded for the default project tab.
+
+Find this block (around lines 42–50):
+
+```typescript
+} else {
+  [subProjects, directTasks, timeEntries, timeStats, attachments] = await Promise.all([
+    listSubProjects(id),
+    listDirectTasks(id),
+    listTimeEntries(id),
+    getProjectTotalMinutes(id),
+    listProjectAttachments(id),
+  ]);
+}
+```
+
+Right after that block (still inside `if (project) { ... else { ... }`), but **outside** the destructuring assignment (so it runs after subprojects load), add:
+
+```typescript
+}
+
+// Questionnaire bundle for the panel — only on the default tab
+if (tab !== 'besprechungen' && project) {
+  try {
+    const assignments = await listQAssignmentsForProject(id);
+    questionnaireBundles = await Promise.all(assignments.map(async a => {
+      const [questions, options, answers, dimensions] = await Promise.all([
+        listQQuestions(a.template_id),
+        listQAnswerOptionsForTemplate(a.template_id),
+        listQAnswers(a.id),
+        listQDimensions(a.template_id),
+      ]);
+      return { assignment: a, questions, options, answers, scores: computeScores(dimensions, options, answers) };
+    }));
+  } catch (err) {
+    console.error('[admin/projekte/[id]] questionnaire fetch failed:', err);
+    questionnaireBundles = [];
+  }
+}
+```
+
+Note: the closing `}` at the very top of this snippet **replaces** the existing `}` that closes the `else` branch. The structure becomes:
+
+```
+try {
+  ...
+  if (project) {
+    if (tab === 'besprechungen') { ... }
+    else { [subProjects, ...] = await Promise.all([...]); }
+    // ← new questionnaire block goes here
+  }
+} catch (err) { ... }
+```
+
+- [ ] **Step 3: Declare `questionnaireBundles` near the other top-level lets**
+
+The existing top-level `let` declarations are around lines 22–32. Add this declaration with them:
+
+```typescript
+let questionnaireBundles: Array<{
+  assignment: any;
+  questions: any[];
+  options: any[];
+  answers: any[];
+  scores: any[];
+}> = [];
+```
+
+(Using `any` here matches the loose typing pattern already in this file — see `unassignedMeetings`, lines 30. Tightening to imported types is fine but not required.)
+
+- [ ] **Step 4: Render the panel in the default tab**
+
+Find the `tab !== 'besprechungen'` branch in the JSX (around line 183, the line `<>` that opens the default tab content). Right **before** the `{/* ── Sub-projects ── */}` comment (line ~260), add:
+
+```astro
+<ProjectQuestionnairesPanel assignments={questionnaireBundles} />
+```
+
+This places the panel above the sub-projects list, immediately after the Edit form — natural spot for "context first, structure second".
+
+- [ ] **Step 5: Type-check + smoke-build**
+
+```bash
+cd website && npx astro check 2>&1 | tail -20
+```
+
+Expected: no new errors related to projekte/[id].astro.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add website/src/pages/admin/projekte/[id].astro
+git commit -m "feat(admin/projekte): show linked questionnaires inline
+
+Adds the ProjectQuestionnairesPanel section to /admin/projekte/<id>.
+Empty for projects without linked questionnaires."
+```
+
+---
+
+## Task 4: Embed panel in `/admin/tickets/[id].astro`
+
+**Files:**
+- Modify: `website/src/pages/admin/tickets/[id].astro` (frontmatter imports + fetch; render in main column after Description card)
+
+This task can run **in parallel with Task 3** — it touches a different file but depends only on Task 2 being on disk.
+
+- [ ] **Step 1: Add imports to the frontmatter**
+
+In `website/src/pages/admin/tickets/[id].astro`, after the existing imports (lines 1–6), add:
+
+```astro
+import {
+  listQAssignmentsForProject,
+  listQQuestions,
+  listQAnswerOptionsForTemplate,
+  listQAnswers,
+  listQDimensions,
+} from '../../../lib/questionnaire-db';
+import { computeScores } from '../../../lib/compute-scores';
+import ProjectQuestionnairesPanel from '../../../components/admin/ProjectQuestionnairesPanel.astro';
+```
+
+- [ ] **Step 2: Fetch questionnaire bundles after `getTicketDetail`**
+
+The existing fetch is at lines 16–19:
+
+```typescript
+const [ticket, timeline] = await Promise.all([
+  getTicketDetail(BRAND, id),
+  getTicketTimeline(BRAND, id),
+]);
+
+if (!ticket) return Astro.redirect('/admin/tickets');
+```
+
+After the redirect guard, add:
+
+```typescript
+let questionnaireBundles: Array<{
+  assignment: any;
+  questions: any[];
+  options: any[];
+  answers: any[];
+  scores: any[];
+}> = [];
+
+// Only fetch for project-type tickets — coaching questionnaires only link to projects.
+if (ticket.type === 'project') {
+  try {
+    const assignments = await listQAssignmentsForProject(ticket.id);
+    questionnaireBundles = await Promise.all(assignments.map(async a => {
+      const [questions, options, answers, dimensions] = await Promise.all([
+        listQQuestions(a.template_id),
+        listQAnswerOptionsForTemplate(a.template_id),
+        listQAnswers(a.id),
+        listQDimensions(a.template_id),
+      ]);
+      return { assignment: a, questions, options, answers, scores: computeScores(dimensions, options, answers) };
+    }));
+  } catch (err) {
+    console.error('[admin/tickets/[id]] questionnaire fetch failed:', err);
+    questionnaireBundles = [];
+  }
+}
+```
+
+The `ticket.type === 'project'` gate avoids running the JOIN query for every bug/task ticket (the FK only ever points at type='project' rows).
+
+- [ ] **Step 3: Render the panel in the main column**
+
+The main column structure starts at line 105 with `<div class="lg:col-span-2 space-y-6">`. The first child is the Description card (lines 108–120). Right **after** the Description card's closing `</div>`, add:
+
+```astro
+<ProjectQuestionnairesPanel assignments={questionnaireBundles} />
+```
+
+The panel sits above the children-tree / linked-tickets / timeline / attachments cards.
+
+- [ ] **Step 4: Type-check**
+
+```bash
+cd website && npx astro check 2>&1 | tail -20
+```
+
+Expected: no new errors related to tickets/[id].astro.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add website/src/pages/admin/tickets/[id].astro
+git commit -m "feat(admin/tickets): show linked questionnaires inline
+
+Adds ProjectQuestionnairesPanel to /admin/tickets/<id> for tickets
+of type='project'. Skipped for bug/task/feature tickets — those
+never have linked questionnaires."
+```
+
+---
+
+## Task 5: Manual verification + deploy
+
+**Files:** none (deployment + browser check)
+
+- [ ] **Step 1: Start the dev server and verify locally**
+
+```bash
+task website:dev
+```
+
+Open `http://localhost:4321/admin/projekte/<id>` for a project that has a completed questionnaire. Confirm:
+
+1. Section "Fragebögen (1)" appears between the project edit form and the sub-projects list.
+2. Status badge says "Eingereicht" or "Besprochen" with the correct color.
+3. Score bars render (if the template is scored).
+4. The `<details>` opens to show questions + chosen answers.
+5. "Volle Review öffnen →" link goes to `/admin/fragebogen/<assignmentId>`.
+6. A project with no questionnaire shows nothing — no empty header, no "0 questionnaires" placeholder.
+
+Then visit `http://localhost:4321/admin/tickets/<sameId>` and confirm the same panel renders in the main column.
+
+- [ ] **Step 2: Deploy to mentolder, then korczewski**
+
+Per the project's website-deploy workflow:
+
+```bash
+task website:deploy ENV=mentolder
+task website:deploy ENV=korczewski
+```
+
+Wait for both to finish. Each rebuilds the image and rolls the website pod.
+
+- [ ] **Step 3: Live verification**
+
+Open `https://web.mentolder.de/admin/projekte/<id>` (the project the user just completed a questionnaire for) and confirm the new section renders with real data. Repeat for `https://web.korczewski.de/admin/projekte/<id>` if the same flow is exercised there.
+
+- [ ] **Step 4: Commit + PR + auto-merge**
+
+The branch already has the four feature commits. Push and open the PR:
+
+```bash
+git push -u origin "$(git rev-parse --abbrev-ref HEAD)"
+gh pr create --title "feat(admin): inline questionnaire panel on project + ticket pages" --body "$(cat <<'EOF'
+## Summary
+- New DB helper `listQAssignmentsForProject` (filters out system-test templates).
+- New shared `ProjectQuestionnairesPanel.astro` component renders title, status, score bars, coach notes, and collapsible Q&A per linked assignment.
+- Embedded on `/admin/projekte/<id>` (above sub-projects) and `/admin/tickets/<id>` (after Description, only for `type='project'` tickets).
+
+Spec: docs/superpowers/specs/2026-05-08-project-questionnaire-overview-design.md
+Plan: docs/superpowers/plans/2026-05-08-project-questionnaire-overview.md
+
+## Test plan
+- [ ] Open a project with a completed questionnaire on web.mentolder.de — section renders with score bars + Q&A.
+- [ ] Open the same record under /admin/tickets/<id> — panel renders.
+- [ ] Open a project without a questionnaire — no section, no empty state.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+gh pr merge --squash --auto
+```
+
+---
+
+## Self-review (filled in after writing the plan)
+
+**Spec coverage:**
+
+| Spec section | Implemented in |
+|---|---|
+| `listQAssignmentsForProject` helper | Task 1 |
+| Filter out `is_system_test` | Task 1 (SQL `WHERE` clause) |
+| Shared `ProjectQuestionnairesPanel.astro` | Task 2 |
+| Empty assignments → renders nothing | Task 2 (top-level `{assignments.length > 0 && ...}`) |
+| Per-status card states (pending/in_progress/submitted/reviewed/archived/dismissed) | Task 2 (`STATUS_CLS`, `STATUS_LABEL`, `showQA`, `showScores`, `isMuted`, `dismiss_reason` block) |
+| Score bars reuse from review page | Task 2 (mirrored markup, same `levelColor`) |
+| Embed on `/admin/projekte/<id>` | Task 3 |
+| Embed on `/admin/tickets/<id>` | Task 4 |
+| `type='project'` gate on tickets page | Task 4 (perf consideration from spec risks) |
+| Manual E2E verification | Task 5 |
+| `task website:deploy ENV=mentolder + korczewski` | Task 5 |
+
+**Placeholder scan:** No "TBD", "TODO", "implement later". All code blocks are complete and runnable. Function/property names (`listQAssignmentsForProject`, `assignment.template_title`, `assignment.coach_notes`, `assignment.dismiss_reason`, `STATUS_CLS`, `STATUS_LABEL`, `levelColor`) are consistent across tasks.
+
+**Type consistency:** `QAssignment`/`QQuestion`/`QAnswer` come from `questionnaire-db.ts` — Task 2 Step 2 instructs the implementer to confirm the option type's exact export name (`QOption` vs `QAnswerOption`) before relying on it, since I don't have it cached. `ScoreRow` is similarly verified in Task 2 Step 3.
+
+**Spec gap:** None found. The "no new API routes / no schema migrations" promise from the spec is honored — every change is read-only DB + UI.

--- a/docs/superpowers/plans/2026-05-08-questionnaire-project-integration.md
+++ b/docs/superpowers/plans/2026-05-08-questionnaire-project-integration.md
@@ -1,0 +1,679 @@
+# Questionnaire → Project Integration & Content Update — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Link every questionnaire assignment to an auto-created project in the tickets system, add an archive status and per-question task-creation to the review page, and update the 10 system-test templates with staleness fixes plus two new categories (LiveKit and Projektmanagement).
+
+**Architecture:** The `assign.ts` API endpoint creates a `tickets.tickets` project before calling `createQAssignment`, passing the new project_id in. `questionnaire_assignments` gains a nullable `project_id` FK and an `archived_at` timestamp. The review page (`[assignmentId].astro`) gains a project badge, per-question "Als Aufgabe anlegen" buttons wired to a new API route, and an "Archivieren" action. System-test seed data grows from 10 to 12 templates.
+
+**Tech Stack:** TypeScript, Astro, PostgreSQL (via `pg` pool), Vitest (unit tests). Run tests with `bun run test` inside `website/`. Deploy with `task website:redeploy ENV=mentolder` (then korczewski).
+
+---
+
+## File map
+
+| File | Action | What changes |
+|---|---|---|
+| `website/src/lib/questionnaire-db.ts` | Modify | DB migration cols; `QAssignment` type; `AssignmentStatus`; `createQAssignment`; `updateQAssignment`; all SELECT queries |
+| `website/src/pages/api/admin/questionnaires/assign.ts` | Modify | Create project before assignment, pass `projectId` |
+| `website/src/pages/api/admin/questionnaires/assignments/[id]/create-task.ts` | Create | New route: create a task in the linked project |
+| `website/src/pages/admin/fragebogen/[assignmentId].astro` | Modify | Project badge; "Als Aufgabe anlegen" buttons; "Archivieren" button |
+| `website/src/lib/system-test-seed-data.ts` | Modify | Fix 4 stale items; add ST 11 + ST 12 |
+| `website/src/lib/system-test-seed-data.test.ts` | Modify | Update expected counts (10→12, 89→104) |
+
+---
+
+### Task 1: DB migration + types in questionnaire-db.ts
+
+**Files:**
+- Modify: `website/src/lib/questionnaire-db.ts`
+
+Add two nullable columns to `questionnaire_assignments` and update all TypeScript types that reference assignment rows.
+
+- [ ] **Step 1: Add `'archived'` to `AssignmentStatus` and `project_id` / `archived_at` to `QAssignment`**
+
+In `website/src/lib/questionnaire-db.ts`, change lines near the top:
+
+```typescript
+export type AssignmentStatus = 'pending' | 'in_progress' | 'submitted' | 'reviewed' | 'archived' | 'dismissed';
+```
+
+And extend `QAssignment`:
+
+```typescript
+export interface QAssignment {
+  id: string;
+  customer_id: string;
+  template_id: string;
+  template_title: string;
+  status: AssignmentStatus;
+  coach_notes: string;
+  assigned_at: string;
+  submitted_at: string | null;
+  reviewed_at: string | null;
+  archived_at: string | null;   // new
+  dismissed_at: string | null;
+  dismiss_reason: string | null;
+  project_id: string | null;    // new
+}
+```
+
+- [ ] **Step 2: Add column migrations inside `initDb()`**
+
+Find the block with `ALTER TABLE questionnaire_assignments ADD COLUMN IF NOT EXISTS dismissed_at` and add right after it:
+
+```typescript
+await pool.query(`ALTER TABLE questionnaire_assignments ADD COLUMN IF NOT EXISTS project_id UUID REFERENCES tickets.tickets(id) ON DELETE SET NULL`);
+await pool.query(`ALTER TABLE questionnaire_assignments ADD COLUMN IF NOT EXISTS archived_at TIMESTAMPTZ`);
+```
+
+- [ ] **Step 3: Update all SELECT queries that return assignment rows**
+
+There are three: `createQAssignment`, `getQAssignment`, and `updateQAssignment`. Each has a `RETURNING` or `SELECT` list. Add `a.project_id, a.archived_at` (or just `project_id, archived_at` in the RETURNING clause).
+
+**`createQAssignment` RETURNING clause** — change:
+```typescript
+`INSERT INTO questionnaire_assignments (customer_id, template_id)
+ VALUES ($1, $2)
+ RETURNING id, customer_id, template_id, status, coach_notes, assigned_at,
+           submitted_at, reviewed_at, dismissed_at, dismiss_reason`,
+```
+to:
+```typescript
+`INSERT INTO questionnaire_assignments (customer_id, template_id, project_id)
+ VALUES ($1, $2, $3)
+ RETURNING id, customer_id, template_id, status, coach_notes, assigned_at,
+           submitted_at, reviewed_at, archived_at, dismissed_at, dismiss_reason, project_id`,
+[params.customerId, params.templateId, params.projectId ?? null],
+```
+
+Also add `projectId?: string` to the params type:
+```typescript
+export async function createQAssignment(params: {
+  customerId: string; templateId: string; projectId?: string;
+}): Promise<QAssignment> {
+```
+
+**`getQAssignment` SELECT** — in the `SELECT a.id, a.customer_id, ...` query, add `, a.archived_at, a.project_id`:
+```typescript
+`SELECT a.id, a.customer_id, a.template_id, t.title AS template_title,
+        a.status, a.coach_notes, a.assigned_at, a.submitted_at, a.reviewed_at,
+        a.archived_at, a.dismissed_at, a.dismiss_reason, a.project_id
+ FROM questionnaire_assignments a
+ JOIN questionnaire_templates t ON t.id = a.template_id
+ WHERE a.id = $1`,
+```
+
+**`listQAssignmentsForCustomer` SELECT** — same addition:
+```typescript
+`SELECT a.id, a.customer_id, a.template_id, t.title AS template_title,
+        a.status, a.coach_notes, a.assigned_at, a.submitted_at, a.reviewed_at,
+        a.archived_at, a.dismissed_at, a.dismiss_reason, a.project_id
+ FROM questionnaire_assignments a
+ JOIN questionnaire_templates t ON t.id = a.template_id
+ WHERE a.customer_id = $1
+ ORDER BY a.assigned_at DESC`,
+```
+
+**`updateQAssignment` RETURNING clause** — add `archived_at, project_id`:
+```typescript
+`UPDATE questionnaire_assignments SET ${sets.join(', ')}
+ WHERE id = $${vals.length}
+ RETURNING id, customer_id, template_id, status, coach_notes, assigned_at,
+           submitted_at, reviewed_at, archived_at, dismissed_at, dismiss_reason, project_id`,
+```
+
+- [ ] **Step 4: Handle `archived_at` in `updateQAssignment`**
+
+Find the block that sets `submitted_at`, `reviewed_at`, `dismissed_at` and add:
+```typescript
+if (params.status === 'archived') sets.push(`archived_at = now()`);
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add website/src/lib/questionnaire-db.ts
+git commit -m "feat(questionnaire): add project_id + archived_at columns and archived status"
+```
+
+---
+
+### Task 2: Auto-create project on assignment in assign.ts
+
+**Files:**
+- Modify: `website/src/pages/api/admin/questionnaires/assign.ts`
+
+The endpoint already has everything needed: `customer.id`, `tpl.title`, `tpl.is_system_test`, `clientName`, and `PROD_DOMAIN`. Create the project before creating the assignment.
+
+- [ ] **Step 1: Add imports**
+
+At the top of `assign.ts`, add `createProject` to the import from `website-db`:
+```typescript
+import { getCustomerByEmail, createProject } from '../../../../lib/website-db';
+```
+
+Also add a brand constant near the PROD_DOMAIN line:
+```typescript
+const BRAND = process.env.BRAND || 'mentolder';
+```
+
+- [ ] **Step 2: Create project and pass projectId to createQAssignment**
+
+Replace this line:
+```typescript
+const assignment = await createQAssignment({ customerId: customer.id, templateId: tpl.id });
+```
+
+With:
+```typescript
+const projectTitle = tpl.is_system_test
+  ? tpl.title
+  : `${tpl.title} — ${clientName}`;
+
+const projectId = await createProject({
+  brand: BRAND,
+  name: projectTitle,
+  status: 'entwurf',
+  priority: 'mittel',
+  customerId: customer.id,
+}).catch((err) => {
+  console.error('[assign] project creation failed, continuing without project_id:', err);
+  return null;
+});
+
+const assignment = await createQAssignment({
+  customerId: customer.id,
+  templateId: tpl.id,
+  projectId: projectId ?? undefined,
+});
+```
+
+- [ ] **Step 3: Verify locally**
+
+Start the dev server (`task website:dev`) and assign a template to a test user. Check that `/admin/projekte` shows the new project. Check `questionnaire_assignments` in the DB has `project_id` set.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add website/src/pages/api/admin/questionnaires/assign.ts
+git commit -m "feat(questionnaire): auto-create tickets project on assignment"
+```
+
+---
+
+### Task 3: New API route — create-task
+
+**Files:**
+- Create: `website/src/pages/api/admin/questionnaires/assignments/[id]/create-task.ts`
+
+This route creates a `ProjectTask` under the assignment's linked project. One task per question, triggered by the admin in the review UI.
+
+- [ ] **Step 1: Create the directory and file**
+
+```bash
+mkdir -p "website/src/pages/api/admin/questionnaires/assignments/[id]"
+```
+
+Create `website/src/pages/api/admin/questionnaires/assignments/[id]/create-task.ts`:
+
+```typescript
+import type { APIRoute } from 'astro';
+import { getSession, isAdmin } from '../../../../../../lib/auth';
+import { getQAssignment, getQQuestion } from '../../../../../../lib/questionnaire-db';
+import { createProjectTask } from '../../../../../../lib/website-db';
+
+export const POST: APIRoute = async ({ request, params }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) return new Response('Unauthorized', { status: 401 });
+
+  const assignment = await getQAssignment(params.id!).catch(() => null);
+  if (!assignment) return new Response(JSON.stringify({ error: 'Auftrag nicht gefunden.' }), { status: 404 });
+  if (!assignment.project_id) {
+    return new Response(JSON.stringify({ error: 'Kein Projekt verknüpft.' }), { status: 409 });
+  }
+
+  const body = await request.json() as { questionId?: string };
+  if (!body.questionId) {
+    return new Response(JSON.stringify({ error: 'questionId erforderlich.' }), { status: 400 });
+  }
+
+  const question = await getQQuestion(body.questionId).catch(() => null);
+  if (!question) return new Response(JSON.stringify({ error: 'Frage nicht gefunden.' }), { status: 404 });
+
+  const taskName = question.question_text.length > 120
+    ? question.question_text.slice(0, 117) + '…'
+    : question.question_text;
+
+  const taskId = await createProjectTask({
+    projectId: assignment.project_id,
+    name: taskName,
+    description: question.test_expected_result ?? undefined,
+    status: 'entwurf',
+    priority: 'mittel',
+  });
+
+  return new Response(JSON.stringify({ taskId }), {
+    status: 201,
+    headers: { 'Content-Type': 'application/json' },
+  });
+};
+```
+
+- [ ] **Step 2: Export `getQQuestion` from questionnaire-db.ts**
+
+Check if `getQQuestion` already exists. If not, add it after `listQQuestions`:
+
+```typescript
+export async function getQQuestion(id: string): Promise<QQuestion | null> {
+  const r = await pool.query(
+    `SELECT id, template_id, position, question_text, question_type,
+            test_expected_result, test_function_url, test_menu_path, test_role, created_at
+     FROM questionnaire_questions WHERE id = $1`,
+    [id],
+  );
+  return r.rows[0] ?? null;
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add "website/src/pages/api/admin/questionnaires/assignments/[id]/create-task.ts" \
+        website/src/lib/questionnaire-db.ts
+git commit -m "feat(questionnaire): POST create-task route for assignment review"
+```
+
+---
+
+### Task 4: Review page enhancements ([assignmentId].astro)
+
+**Files:**
+- Modify: `website/src/pages/admin/fragebogen/[assignmentId].astro`
+
+Add three things: (1) project badge at top, (2) "Als Aufgabe anlegen" button per question row, (3) "Archivieren" button in the notes section.
+
+- [ ] **Step 1: Add project badge**
+
+In the frontmatter, `assignment` already has `project_id`. In the HTML, find the header block (the `div.mb-8` with title + status badge) and add the project link below the `<p>Eingereicht:…</p>` line:
+
+```astro
+{assignment.project_id && (
+  <a
+    href={`/admin/projekte/${assignment.project_id}`}
+    class="inline-flex items-center gap-1 mt-2 text-xs text-gold/70 hover:text-gold underline"
+  >
+    → Verknüpftes Projekt öffnen
+  </a>
+)}
+```
+
+- [ ] **Step 2: Add "Als Aufgabe anlegen" button per question**
+
+Locate the question rendering loop (it renders each question with its answer). For each `test_step` question that has been answered, add the button after the answer display. Find the block where `.file-bug-btn` is rendered (it's inside the step question loop) and add alongside it:
+
+```astro
+{assignment.project_id && (
+  <button
+    class="create-task-btn text-xs px-2 py-1 bg-dark border border-dark-lighter text-light/70 rounded hover:border-gold/40 hover:text-light transition-colors"
+    data-question-id={q.id}
+    data-assignment-id={assignmentId}
+  >
+    + Aufgabe
+  </button>
+)}
+<span id={`task-result-${q.id}`} class="text-xs text-green-400 hidden"></span>
+```
+
+- [ ] **Step 3: Add "Archivieren" button to notes section**
+
+Find the `{assignment.status !== 'reviewed' && (...)}` block for the "Als besprochen markieren" button, and after it add:
+
+```astro
+{assignment.status === 'reviewed' && (
+  <button id="archive-btn"
+    class="px-4 py-2 bg-dark border border-dark-lighter text-muted rounded-lg text-sm hover:border-gold/40 hover:text-light transition-colors">
+    Archivieren
+  </button>
+)}
+```
+
+Also update the status badge color block to handle `'archived'`:
+
+```astro
+assignment.status === 'archived' ? 'bg-slate-500/10 text-slate-400 border-slate-500/20'
+```
+
+- [ ] **Step 4: Wire up JS for new buttons**
+
+In the `<script define:vars={{ assignmentId }}>` block, add after the existing `closeBugModal` function:
+
+```javascript
+// Task creation
+document.querySelectorAll('.create-task-btn').forEach(btn => {
+  btn.addEventListener('click', async () => {
+    const questionId = btn.dataset.questionId;
+    btn.disabled = true;
+    btn.textContent = '…';
+    try {
+      const r = await fetch(
+        `/api/admin/questionnaires/assignments/${assignmentId}/create-task`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ questionId }),
+        },
+      );
+      const data = await r.json().catch(() => ({}));
+      const resultEl = document.getElementById(`task-result-${questionId}`);
+      if (r.ok && data.taskId) {
+        btn.remove();
+        if (resultEl) {
+          resultEl.textContent = '✓ Aufgabe angelegt';
+          resultEl.classList.remove('hidden');
+        }
+      } else {
+        btn.disabled = false;
+        btn.textContent = '+ Aufgabe';
+        if (resultEl) {
+          resultEl.textContent = data.error || 'Fehler';
+          resultEl.className = 'text-xs text-red-400';
+          resultEl.classList.remove('hidden');
+        }
+      }
+    } catch {
+      btn.disabled = false;
+      btn.textContent = '+ Aufgabe';
+    }
+  });
+});
+
+// Archive
+document.getElementById('archive-btn')?.addEventListener('click', async () => {
+  const r = await fetch(`/api/admin/questionnaires/assignments/${assignmentId}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ status: 'archived' }),
+  });
+  if (r.ok) window.location.reload();
+});
+```
+
+- [ ] **Step 5: Verify the review page in the browser**
+
+Start `task website:dev`. Create a test assignment, submit answers in the portal, then open the review page in admin. Verify:
+- Project badge links to `/admin/projekte/<id>` when project_id is set.
+- "+ Aufgabe" button appears on each answered question.
+- Clicking it creates a task and shows "✓ Aufgabe angelegt".
+- After marking "Als besprochen markieren", the "Archivieren" button appears.
+- Clicking "Archivieren" reloads the page and shows `archived` status badge.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add website/src/pages/admin/fragebogen/\[assignmentId\].astro
+git commit -m "feat(questionnaire): project badge, task creation, and archive action in review page"
+```
+
+---
+
+### Task 5: Content updates — system-test-seed-data.ts
+
+**Files:**
+- Modify: `website/src/lib/system-test-seed-data.ts`
+
+Four stale fixes + two new templates.
+
+- [ ] **Step 1: Fix ST 3 title**
+
+Change:
+```typescript
+title: 'System-Test 3: Kommunikation — Fragebogen-Widget, Inbox & E-Mail',
+```
+To:
+```typescript
+title: 'System-Test 3: Kommunikation — Chat-Widget, Inbox & E-Mail',
+```
+
+- [ ] **Step 2: Fix ST 2 step 6 expected_result**
+
+Find step 6 in the ST 2 template (the "Projekt anlegen" step). Update `expected_result`:
+```typescript
+expected_result: 'Projekt erscheint in /admin/projekte; Tickets-System-Projekt mit Status „Entwurf" angelegt; Zuordnung zum Client sichtbar.',
+```
+
+- [ ] **Step 3: Fix ST 4 step 2 expected_result**
+
+Find step 2 in the ST 4 template (the "Template veröffentlichen + Client zuweisen" step). Update `expected_result`:
+```typescript
+expected_result: 'Assignment erstellt; Nutzer sieht Fragebogen im Portal-Dashboard; verknüpftes Projekt automatisch unter /admin/projekte angelegt.',
+```
+
+- [ ] **Step 4: Fix ST 9 step 6 expected_result**
+
+Find the last step of ST 9 (the "Test-Results-Panel" step). Update `expected_result`:
+```typescript
+expected_result: 'Alle 12 Templates sichtbar mit last_result/last_success_at; Drilldown auf Question-Level möglich.',
+```
+
+- [ ] **Step 5: Add ST 11 — LiveKit & Streaming (7 steps)**
+
+After the closing `},` of ST 10, before the final `];`, add:
+
+```typescript
+  {
+    title: 'System-Test 11: LiveKit & Streaming',
+    description: 'Vollständiger Test des LiveKit-Streaming-Stacks: Admin-Steuerseite, Stream starten/stoppen, Viewer-Portal, RTMP-Ingress, Recording-Liste und Pod-Status.',
+    instructions: 'Schritte 1, 4, 5, 6, 7 im Admin-Browser. Schritt 2 startet den Stream — danach Schritt 3 im Testnutzer-Browser. Schritt 6 beendet den Stream.',
+    steps: [
+      {
+        question_text: 'Öffne die Admin-Stream-Seite (Link) — prüfe ob der Stream-Status „offline" angezeigt wird und die Seite ohne Fehler lädt.',
+        expected_result: 'Seite lädt; Stream-Status „offline"; keine Fehlermeldungen.',
+        test_function_url: '/admin/stream', test_role: 'admin',
+      },
+      {
+        question_text: 'Klicke auf der Admin-Stream-Seite (Link) den Start-Button — prüfe ob der Status auf „live" wechselt und ein Stream-Token generiert wird.',
+        expected_result: 'Status wechselt auf „live"; Stream-Token sichtbar.',
+        test_function_url: '/admin/stream', test_role: 'admin',
+      },
+      {
+        question_text: 'Öffne das Viewer-Portal (Link) im Testnutzer-Browser während der Stream läuft — prüfe ob der Stream-Player sichtbar ist und keine Verbindungsfehler erscheinen. → Nutzer: zweites Browser-Profil.',
+        expected_result: 'Stream-Player sichtbar; Verbindung aufgebaut; kein Fehler im Browser.',
+        test_function_url: '/portal/stream', test_role: 'user',
+        agent_notes: 'Zweites Browser-Profil (Testnutzer) erforderlich. Stream muss laufen (Schritt 2 abgeschlossen).',
+      },
+      {
+        question_text: 'Öffne die Admin-Stream-Seite (Link) — prüfe ob der RTMP-Ingress-Status und die RTMP-URL angezeigt werden.',
+        expected_result: 'RTMP-URL sichtbar; Ingress-Status angezeigt (aktiv oder bereit).',
+        test_function_url: '/admin/stream', test_role: 'admin',
+      },
+      {
+        question_text: 'Öffne die Admin-Stream-Seite (Link) → klicke „Aufnahmen" oder scrolle zur Recordings-Liste — prüfe ob vorhandene MP4-Dateien aufgelistet werden oder eine leere Liste ohne Fehler erscheint.',
+        expected_result: 'Recordings-Liste lädt; MP4-Dateien sichtbar oder leere Liste ohne Fehler.',
+        test_function_url: '/admin/stream', test_role: 'admin',
+      },
+      {
+        question_text: 'Klicke auf der Admin-Stream-Seite (Link) den Stop-Button — prüfe ob der Status auf „offline" wechselt und das Viewer-Portal „kein Stream" anzeigt.',
+        expected_result: 'Status wechselt auf „offline"; Viewer-Portal zeigt „kein Stream aktiv".',
+        test_function_url: '/admin/stream', test_role: 'admin',
+      },
+      {
+        question_text: 'Öffne Monitoring (Link) — prüfe ob der `livekit-server` Pod im Status „Running" ist und kein CrashLoop vorliegt.',
+        expected_result: '`livekit-server` Pod im Status „Running"; kein CrashLoop.',
+        test_function_url: '/admin/monitoring', test_role: 'admin',
+      },
+    ],
+  },
+  {
+    title: 'System-Test 12: Projektmanagement',
+    description: 'Vollständiger Test des Projektmanagement-Moduls: Projekte, Teilprojekte, Aufgaben, Zeiterfassung, Meeting-Verknüpfung und Archivierung.',
+    instructions: 'Alle Schritte im Admin-Browser. Öffne jeweils den Link im Schritt. Schritte bauen aufeinander auf — in Reihenfolge abarbeiten.',
+    steps: [
+      {
+        question_text: 'Öffne Projekte (Link) → klicke „Neues Projekt" → fülle Titel und Client aus → speichere — prüfe ob das Projekt in der Liste erscheint.',
+        expected_result: 'Projekt erscheint in der Liste; Pflichtfeld-Validierung serverseitig.',
+        test_function_url: '/admin/projekte', test_role: 'admin',
+      },
+      {
+        question_text: 'Öffne das neu angelegte Projekt (Link) → wechsle zum Reiter „Teilprojekte" → klicke „Neues Teilprojekt" → trage Titel ein und speichere — prüfe ob das Teilprojekt erscheint.',
+        expected_result: 'Teilprojekt erscheint unter dem Reiter „Teilprojekte" des Projekts.',
+        test_function_url: '/admin/projekte', test_role: 'admin',
+      },
+      {
+        question_text: 'Im Projekt-Detail (Link) → wechsle zum Reiter „Aufgaben" → klicke „Neue Aufgabe" → fülle Titel und Priorität aus → speichere — prüfe ob die Aufgabe mit Status „Entwurf" erscheint.',
+        expected_result: 'Aufgabe erscheint in der Liste; Status „Entwurf"; Aufgaben-Counter aktualisiert.',
+        test_function_url: '/admin/projekte', test_role: 'admin',
+      },
+      {
+        question_text: 'Im Projekt-Detail (Link) → klicke auf die Aufgabe → ändere den Status auf „Erledigt" → speichere — prüfe ob der Aufgaben-Counter sofort sinkt.',
+        expected_result: 'Status wechselt sofort auf „Erledigt"; offene Aufgaben-Counter sinkt.',
+        test_function_url: '/admin/projekte', test_role: 'admin',
+      },
+      {
+        question_text: 'Im Projekt-Detail (Link) → wechsle zum Reiter „Zeiterfassung" → klicke „Zeit buchen" → trage Dauer und Beschreibung ein → speichere — prüfe ob der Gesamtzeit-Counter aktualisiert wird.',
+        expected_result: 'Zeiteintrag gespeichert; Gesamtzeit-Counter des Projekts erhöht sich.',
+        test_function_url: '/admin/projekte', test_role: 'admin',
+      },
+      {
+        question_text: 'Im Projekt-Detail (Link) → ändere den Projekt-Status auf „Aktiv" → speichere — prüfe ob das Status-Badge aktualisiert wird und das Projekt in der aktiven Filter-Ansicht erscheint.',
+        expected_result: 'Status-Badge zeigt „Aktiv"; Projekt erscheint in gefilterten „Aktiv"-Ansicht.',
+        test_function_url: '/admin/projekte', test_role: 'admin',
+      },
+      {
+        question_text: 'Im Projekt-Detail (Link) → wechsle zum Reiter „Besprechungen" → klicke „Meeting verknüpfen" → wähle ein vorhandenes Meeting aus — prüfe ob es im Reiter erscheint.',
+        expected_result: 'Meeting erscheint im Reiter „Besprechungen" des Projekts.',
+        test_function_url: '/admin/projekte', test_role: 'admin',
+      },
+      {
+        question_text: 'Im Projekt-Detail (Link) → ändere den Status auf „Archiviert" → speichere — prüfe ob das Projekt aus der Standard-Liste verschwindet und in der Archiv-Ansicht sichtbar ist.',
+        expected_result: 'Projekt verschwindet aus Standard-Liste; in Archiv-Ansicht sichtbar.',
+        test_function_url: '/admin/projekte', test_role: 'admin',
+      },
+    ],
+  },
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add website/src/lib/system-test-seed-data.ts
+git commit -m "feat(system-tests): fix stale questions; add ST 11 LiveKit and ST 12 Projektmanagement"
+```
+
+---
+
+### Task 6: Update tests for new template count
+
+**Files:**
+- Modify: `website/src/lib/system-test-seed-data.test.ts`
+
+- [ ] **Step 1: Update expected counts**
+
+Change the three assertions:
+
+```typescript
+const EXPECTED_STEP_COUNTS = [6, 10, 5, 5, 5, 12, 16, 14, 6, 10, 7, 8];
+```
+
+```typescript
+it('exports exactly 12 templates', () => {
+  expect(SYSTEM_TEST_TEMPLATES).toHaveLength(12);
+});
+```
+
+```typescript
+it('totals 104 steps across all templates', () => {
+  const total = SYSTEM_TEST_TEMPLATES.reduce((sum, t) => sum + t.steps.length, 0);
+  expect(total).toBe(104);
+});
+```
+
+- [ ] **Step 2: Run tests**
+
+```bash
+cd website && bun run test src/lib/system-test-seed-data.test.ts
+```
+
+Expected: all tests pass. If any fail, check that:
+- `SYSTEM_TEST_TEMPLATES` has 12 entries
+- Step counts array matches the actual step counts in the seed file
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add website/src/lib/system-test-seed-data.test.ts
+git commit -m "test(system-tests): update expected counts for 12 templates and 104 steps"
+```
+
+---
+
+### Task 7: Rollout — reseed templates on live clusters
+
+After all code is merged and deployed:
+
+- [ ] **Step 1: Delete stale system-test templates on mentolder**
+
+```bash
+kubectl --context mentolder -n workspace exec deployment/shared-db -- \
+  psql -U postgres -d website -c \
+  "DELETE FROM questionnaire_templates WHERE is_system_test = true;"
+```
+
+- [ ] **Step 2: Restart website pod on mentolder**
+
+```bash
+kubectl --context mentolder -n website rollout restart deployment/website
+```
+
+- [ ] **Step 3: Verify on mentolder**
+
+```bash
+kubectl --context mentolder -n workspace exec deployment/shared-db -- \
+  psql -U postgres -d website -c \
+  "SELECT title FROM questionnaire_templates WHERE is_system_test = true ORDER BY created_at;"
+```
+
+Expected: 12 rows returned.
+
+- [ ] **Step 4: Repeat for korczewski**
+
+```bash
+kubectl --context korczewski -n workspace-korczewski exec deployment/shared-db -- \
+  psql -U postgres -d website -c \
+  "DELETE FROM questionnaire_templates WHERE is_system_test = true;"
+kubectl --context korczewski -n website rollout restart deployment/website
+```
+
+- [ ] **Step 5: Verify in `/admin/monitoring`**
+
+Open `https://web.mentolder.de/admin/monitoring` → Test-Results-Panel → confirm 12 templates visible with `last_result = NULL`.
+
+---
+
+### Task 8: End-to-end smoke test
+
+Validate the full new feature chain is working.
+
+- [ ] **Step 1: Assign a questionnaire and verify project creation**
+
+In `/admin/fragebogen`, assign a coaching template to a test client. Then open `/admin/projekte` and verify a new project with the template title appears.
+
+- [ ] **Step 2: Submit as client and open review**
+
+In `/portal`, log in as the test client, open the assigned questionnaire, answer all questions, submit. Then open `/admin/fragebogen/<assignmentId>` as admin.
+
+- [ ] **Step 3: Verify project badge**
+
+Check that the "→ Verknüpftes Projekt öffnen" link appears at the top of the review page and navigates to the correct project.
+
+- [ ] **Step 4: Create a task from a question**
+
+Click "+ Aufgabe" on one question. Verify "✓ Aufgabe angelegt" appears. Open `/admin/projekte/<projectId>` and confirm the task is listed with the question text as its name.
+
+- [ ] **Step 5: Archive the assignment**
+
+Click "Als besprochen markieren ✓", then "Archivieren". Verify the status badge updates to `archived`.
+
+- [ ] **Step 6: Assign a system-test template and verify project**
+
+In `/admin/fragebogen`, assign "System-Test 1: Authentifizierung & SSO" to the admin user (themselves). Verify a project titled "System-Test 1: Authentifizierung & SSO" appears in `/admin/projekte`.

--- a/docs/superpowers/specs/2026-05-08-project-questionnaire-overview-design.md
+++ b/docs/superpowers/specs/2026-05-08-project-questionnaire-overview-design.md
@@ -1,0 +1,172 @@
+# Project & Ticket Overview — Questionnaire Section
+
+**Date:** 2026-05-08
+**Author:** Patrick (with Claude)
+**Replaces:** nothing — extends `2026-05-08-questionnaire-project-integration-design.md`
+**Related:** that prior spec wired questionnaire → project (assignment auto-creates a project, review page gets per-question actions). This spec adds the reverse direction: project → questionnaire context.
+
+## Goal
+
+When an admin opens `/admin/projekte/<id>` or `/admin/tickets/<id>` for a project that was auto-created from a questionnaire assignment, surface the questionnaire's questions and answers inline so the project's origin context is visible without leaving the page.
+
+Today the link is one-way: the review page (`/admin/fragebogen/<assignmentId>`) shows the project link, but the project page knows nothing about the questionnaire.
+
+## Non-Goals
+
+- No write actions in the new section. "Create task / mark reviewed / archive" stay on the existing review page.
+- No editing of coach notes from the project page (read-only preview).
+- No retroactive linking for legacy projects whose `questionnaire_assignments.project_id` is NULL.
+- No changes to the assignment data model, project data model, or API surfaces beyond one new read-only DB function.
+
+## Architecture
+
+### One shared component, two host pages
+
+A single Astro component renders the section. Both host pages drop it in.
+
+- **`website/src/components/admin/ProjectQuestionnairesPanel.astro`** (new)
+- Embedded in `website/src/pages/admin/projekte/[id].astro` after the Sub-projects/Direct-tasks blocks.
+- Embedded in `website/src/pages/admin/tickets/[id].astro` in the main column, after the Description card.
+
+Same data, same rendering, in both contexts.
+
+### Data flow
+
+```
+Page frontmatter (Astro):
+  projectId
+    │
+    ▼
+listQAssignmentsForProject(projectId)            (new helper)
+    │  → QAssignment[]   (ordered by assigned_at DESC)
+    │
+    ▼  for each assignment in parallel:
+listQQuestions(template_id)
+listQAnswerOptionsForTemplate(template_id)
+listQAnswers(assignment.id)
+computeScores(dimensions, options, answers)      (only when scorable)
+    │
+    ▼
+ProjectQuestionnairesPanel  (assignments enriched with q/a/scores)
+    │
+    ▼
+For each assignment, a card:
+  ┌─ Header  : <template title> · <status badge> · <date>
+  ├─ Scores  : score bars per dimension (if any)
+  ├─ Notes   : coach_notes preview (if non-empty)
+  └─ <details> Q&A list:
+       <question_text> → <answered option label> [+ details_text]
+   "Volle Review öffnen" → /admin/fragebogen/<assignmentId>
+```
+
+### New DB helper
+
+In `website/src/lib/questionnaire-db.ts`, mirroring the shape of the existing `listQAssignmentsForCustomer`:
+
+```typescript
+export async function listQAssignmentsForProject(projectId: string): Promise<QAssignment[]> {
+  const r = await pool.query(
+    `SELECT a.id, a.customer_id, a.template_id, t.title AS template_title,
+            a.status, a.coach_notes, a.assigned_at, a.submitted_at, a.reviewed_at,
+            a.archived_at, a.dismissed_at, a.dismiss_reason, a.project_id
+       FROM questionnaire_assignments a
+       JOIN questionnaire_templates t ON t.id = a.template_id
+      WHERE a.project_id = $1
+      ORDER BY a.assigned_at DESC`,
+    [projectId],
+  );
+  return r.rows;
+}
+```
+
+No new API endpoint — the page does the fetch in its frontmatter.
+
+### Component contract
+
+`ProjectQuestionnairesPanel.astro` receives one prop:
+
+```typescript
+interface Props {
+  assignments: Array<{
+    id: string;
+    templateTitle: string;
+    status: AssignmentStatus;
+    assignedAt: Date;
+    submittedAt: Date | null;
+    reviewedAt: Date | null;
+    coachNotes: string | null;
+    questions: QQuestion[];
+    options: QOption[];           // for the template
+    answers: QAnswer[];           // for this assignment
+    scores: ScoreRow[] | null;    // null when not scorable (e.g. system-test)
+  }>;
+}
+```
+
+Empty array → component renders nothing (no header, no empty state). This keeps legacy projects clean.
+
+### Card states
+
+| Assignment status   | Score bars | Q&A list      | Card style |
+|---------------------|------------|---------------|------------|
+| `pending`           | hidden     | hidden        | muted, "Wartend auf Antworten" |
+| `in_progress`       | hidden     | partial (only answered questions) | normal |
+| `submitted`         | shown      | full          | normal |
+| `reviewed`          | shown      | full          | normal, ✓ badge |
+| `archived`          | shown      | full, collapsed by default | muted |
+| `dismissed`         | hidden     | hidden        | muted, "Verworfen: <dismiss_reason>" |
+
+### Excluded: system-test templates
+
+Assignments where `templates.is_system_test = true` aren't shown. They aren't project-context — they're QA runs against the platform. The `listQAssignmentsForProject` query filters via `AND t.is_system_test = false`.
+
+### Reuse of existing renderers
+
+Score bars and the answered-option lookup logic are lifted from the existing review page (`/admin/fragebogen/[assignmentId].astro`) so the panel matches what the user already sees on the full review. Where the rendering is non-trivial (score bars, option-key → label resolution), the helper is extracted into a small shared `.astro` partial so both pages render identically.
+
+## File changes
+
+| File | Action | Note |
+|---|---|---|
+| `website/src/lib/questionnaire-db.ts` | Modify | Add `listQAssignmentsForProject(projectId)`. Reuses existing field shape. |
+| `website/src/components/admin/ProjectQuestionnairesPanel.astro` | Create | Shared section component. |
+| `website/src/pages/admin/projekte/[id].astro` | Modify | Frontmatter: fetch assignments + per-assignment q/a/scores. Render panel after existing sections. |
+| `website/src/pages/admin/tickets/[id].astro` | Modify | Same fetch + render in main column. |
+
+No schema migrations. No new API routes. No portal-side changes.
+
+## Operational rollout
+
+Plain code change. After merge:
+
+```bash
+task feature:website
+```
+
+No DB migration, no kubectl steps. The new query reads existing rows.
+
+## Testing
+
+### Unit (BATS / vitest if available)
+
+- `listQAssignmentsForProject` — given a seeded project_id with two assignments (one coaching, one system-test), returns only the coaching one in `assigned_at DESC` order.
+
+### E2E (Playwright)
+
+Add to the existing questionnaire test group:
+
+1. Admin assigns a coaching template to a customer → verify project auto-created.
+2. Portal user submits the questionnaire end-to-end.
+3. Admin opens `/admin/projekte/<projectId>` → assert:
+   - Card with template title is visible.
+   - Score bars rendered.
+   - Expanded `<details>` shows each question text and the chosen option label.
+   - "Volle Review öffnen" link points at `/admin/fragebogen/<assignmentId>`.
+4. Same admin opens `/admin/tickets/<projectId>` → assert the same panel renders.
+5. Project with no questionnaire (manually created) → panel does not render.
+
+## Risks
+
+- **Per-assignment fetch fan-out.** Each assignment triggers 4 queries (`listQQuestions`, `listQAnswerOptionsForTemplate`, `listQAnswers`, `computeScores`). For a typical project (1 coaching questionnaire) that's 5 queries total — no concern. If a future workflow attaches many follow-up questionnaires to one project, the page load grows linearly. Acceptable until a project routinely exceeds ~10 assignments; revisit if that happens.
+- **Long question/answer text.** Q&A rendering uses `whitespace-pre-wrap` inside `<details>`, so the section can grow tall. The default-collapsed `<details>` mitigates first-paint length.
+- **Tickets-page layout fit.** The ticket detail page main column is narrower (`lg:col-span-2` of 3). The panel must read well at that width — same Tailwind primitives as the project page section, but the inner Q&A table should stack on narrow viewports rather than overflow.

--- a/docs/superpowers/specs/2026-05-08-questionnaire-project-integration-design.md
+++ b/docs/superpowers/specs/2026-05-08-questionnaire-project-integration-design.md
@@ -1,0 +1,198 @@
+# Questionnaire → Project Integration & Content Update Design
+
+**Date:** 2026-05-08
+**Author:** Patrick (with Claude)
+**Replaces:** nothing — new feature
+**Related:** 2026-04-29-system-test-questionnaires-rewrite-design.md (prior content spec)
+
+## Goal
+
+Three coordinated improvements:
+
+1. **Content** — update the 10 system-test questionnaire templates for staleness and add two missing categories (LiveKit/Streaming, Projektmanagement), bringing the total to 12.
+2. **Auto-create project on assignment** — every `questionnaire_assignments` row (coaching or system-test) automatically gets a linked `tickets.tickets` project at creation time.
+3. **Review flow** — the assignment review page gains a per-question "Als Aufgabe anlegen" button (creates a ProjectTask in the linked project) and an "Archivieren" button (terminal success state after review).
+
+## Non-Goals
+
+- New question types, new questionnaire UI components, or schema changes beyond the FK column and status union.
+- Retroactive project creation for existing assignments (project_id stays NULL for old rows — the FK is nullable).
+- Migrating existing system-test assignments; existing data is unaffected.
+
+## Architecture
+
+### Section 1 — Content updates
+
+#### Stale fixes in existing templates
+
+| Template | Issue | Fix |
+|---|---|---|
+| ST 3 — title | "Fragebogen-Widget" in title implies a questionnaire widget; step 1 actually tests the chat widget | Rename to "Kommunikation — Chat-Widget, Inbox & E-Mail" |
+| ST 2 step 6 — "Projekt anlegen" | Written before the tickets-based project system; URL/expectation partially stale | Update expected_result to reference tickets-backed project creation |
+| ST 4 step 2 — "Template zuweisen" | Once project auto-creation lands, this step should also verify the project was auto-created | Add project auto-creation check to expected_result |
+| ST 9 step 6 — template count | Says "alle System-Test-Templates" — count implicitly 10; will be 12 after new templates | Update expected_result to explicitly say "alle 12 Templates" after seeding |
+
+#### New template: ST 11 — LiveKit & Streaming (~7 steps)
+
+Covers: admin stream management page, start stream, viewer portal, RTMP ingress status, end stream (emergency), recording listing. Currently completely absent from the protocol.
+
+| # | Step | Erwartung | URL | Role |
+|---|---|---|---|---|
+| 1 | Admin-Stream-Seite öffnen | Seite lädt; Stream-Status „offline" | `/admin/stream` | admin |
+| 2 | Stream starten (Start-Button) | Status wechselt auf „live"; Stream-Token generiert | `/admin/stream` | admin |
+| 3 | Viewer-Portal als Testnutzer öffnen | Stream-Player sichtbar; Verbindung aufgebaut (kein Fehler) | `/portal/stream` | user |
+| 4 | RTMP-Ingress-Status prüfen | Ingress-Pod läuft; RTMP-URL angezeigt | `/admin/stream` | admin |
+| 5 | Stream-Aufnahmen (Recordings) auflisten | Liste lädt; vorhandene MP4-Dateien sichtbar (oder leere Liste ohne Fehler) | `/admin/stream` | admin |
+| 6 | Stream beenden (End-Stream) | Status wechselt auf „offline"; Viewer-Portal zeigt „kein Stream" | `/admin/stream` | admin |
+| 7 | LiveKit-Pod-Status in Monitoring prüfen | `livekit-server` Pod im Status `Running`; kein CrashLoop | `/admin/monitoring` | admin |
+
+#### New template: ST 12 — Projektmanagement (~8 steps)
+
+Covers: Projekte/Teilprojekte/Aufgaben/Zeiterfassung. Currently just 1 buried step in ST 2.
+
+| # | Step | Erwartung | URL | Role |
+|---|---|---|---|---|
+| 1 | Neues Projekt anlegen (mit Client) | Projekt erscheint in Liste; Pflichtfeld-Validierung serverseitig | `/admin/projekte` | admin |
+| 2 | Teilprojekt zum Projekt hinzufügen | Teilprojekt erscheint im Projekt-Detail unter dem Reiter „Teilprojekte" | `/admin/projekte/<id>` | admin |
+| 3 | Aufgabe direkt am Projekt anlegen | Aufgabe erscheint im Projekt-Detail; Status „Entwurf" | `/admin/projekte/<id>` | admin |
+| 4 | Aufgabe als erledigt markieren | Status wechselt sofort; Aufgaben-Counter aktualisiert | `/admin/projekte/<id>` | admin |
+| 5 | Zeiteintrag am Projekt erfassen | Eintrag gespeichert; Gesamtzeit aktualisiert | `/admin/projekte/<id>` | admin |
+| 6 | Projekt-Status auf „Aktiv" setzen | Status-Badge aktualisiert; Projekt erscheint in aktiver Filter-Ansicht | `/admin/projekte/<id>` | admin |
+| 7 | Meeting mit Projekt verknüpfen | Meeting erscheint im Projekt-Detail unter Reiter „Besprechungen" | `/admin/projekte/<id>` | admin |
+| 8 | Projekt archivieren | Status „Archiviert"; Projekt aus Standard-Liste entfernt; in Archiv-Ansicht sichtbar | `/admin/projekte/<id>` | admin |
+
+### Section 2 — Auto-create project on assignment
+
+#### DB migration (idempotent, runs via `initDb` in `questionnaire-db.ts`)
+
+```sql
+ALTER TABLE questionnaire_assignments
+  ADD COLUMN IF NOT EXISTS project_id UUID
+    REFERENCES tickets.tickets(id) ON DELETE SET NULL;
+```
+
+#### Logic in `createQAssignment()` — `website/src/lib/questionnaire-db.ts`
+
+Runs in the same transaction as the assignment INSERT:
+
+1. Fetch template title (already available from the template INSERT context or via a SELECT).
+2. Fetch customer name if `customer_id` is set.
+3. Insert into `tickets.tickets`:
+   - `type = 'project'`
+   - `brand` = `process.env.PROD_DOMAIN ?? 'localhost'` (same pattern as `resolveDomain()`)
+   - `title` = for `is_system_test=true`: `<template_title>`; for coaching: `<template_title> — <customer_name>`
+   - `status = 'backlog'`
+   - `customer_id` = assignment's customer_id (may be NULL for system-test self-assignments)
+4. Store the returned `id` as `project_id` in the assignment INSERT.
+
+The project appears immediately in `/admin/projekte` like any manually created project.
+
+Existing assignments are unaffected — `project_id` is nullable.
+
+### Section 3 — Review flow enhancements
+
+#### New status: `archived`
+
+Add to the `AssignmentStatus` union in `questionnaire-db.ts`:
+
+```typescript
+export type AssignmentStatus =
+  'pending' | 'in_progress' | 'submitted' | 'reviewed' | 'archived' | 'dismissed';
+```
+
+Add to the DB check constraint via migration:
+
+```sql
+ALTER TABLE questionnaire_assignments
+  DROP CONSTRAINT IF EXISTS questionnaire_assignments_status_check;
+ALTER TABLE questionnaire_assignments
+  ADD CONSTRAINT questionnaire_assignments_status_check
+  CHECK (status IN ('pending','in_progress','submitted','reviewed','archived','dismissed'));
+```
+
+State machine:
+```
+pending → in_progress → submitted → reviewed → archived
+                                  ↘ dismissed
+```
+
+`archived` = reviewed + tasks extracted + done. `dismissed` = won't review.
+
+#### Review page additions — `website/src/pages/admin/fragebogen/[assignmentId].astro`
+
+**1. Linked project badge** (top of page, renders if `assignment.project_id` is set):
+```html
+<a href="/admin/projekte/{assignment.project_id}">
+  → Verknüpftes Projekt öffnen
+</a>
+```
+No extra DB fetch — `project_id` is loaded with the assignment.
+
+**2. "Als Aufgabe anlegen" button** — per question row, visible when status is `submitted` or `reviewed`:
+- Calls `POST /api/admin/questionnaire/[assignmentId]/create-task` with `{ questionId }`.
+- API handler: fetches question text + expected_result → calls `createProjectTask()` with:
+  - `projectId` = assignment's `project_id`
+  - `name` = question's `question_text` (truncated to 120 chars)
+  - `description` = question's `test_expected_result`
+  - `status` = `'entwurf'`
+- Button becomes "✓ Aufgabe angelegt" (disabled) on success.
+- Requires `project_id` to be set; button is hidden if NULL.
+
+**3. "Archivieren" button** — visible when status is `reviewed`:
+- Calls existing `PATCH /api/admin/questionnaire/[assignmentId]/status` with `{ status: 'archived' }`.
+- Updates the status badge in place.
+
+#### New API route
+
+`website/src/pages/api/admin/questionnaire/[assignmentId]/create-task.ts`
+
+- Auth: admin session required.
+- Body: `{ questionId: string }`.
+- Validates assignment belongs to a project (403 if `project_id` is NULL).
+- Creates task via `createProjectTask()` from `website-db.ts`.
+- Returns `{ taskId }`.
+
+## File changes
+
+| File | Action | Note |
+|---|---|---|
+| `website/src/lib/system-test-seed-data.ts` | Modify | Add ST 11 + ST 12; fix stale titles/expected_results |
+| `website/src/lib/questionnaire-db.ts` | Modify | Add `project_id` column migration; update `createQAssignment()` to auto-create project; add `'archived'` to status union and DB constraint |
+| `website/src/pages/admin/fragebogen/[assignmentId].astro` | Modify | Add project badge, "Als Aufgabe anlegen" buttons, "Archivieren" button |
+| `website/src/pages/api/admin/questionnaire/[assignmentId]/create-task.ts` | Create | New API route |
+| `k3d/website-schema.yaml` | Modify | Document new `project_id` column and `archived` status |
+
+## Operational rollout
+
+After deploy on each cluster:
+
+```bash
+# Re-seed system-test templates (adds ST 11 + ST 12, applies content fixes)
+kubectl --context <env> -n workspace exec deployment/shared-db -- \
+  psql -U postgres -d website -c \
+  "DELETE FROM questionnaire_templates WHERE is_system_test = true;"
+kubectl --context <env> -n workspace rollout restart deploy/website
+```
+
+The `project_id` column and status constraint changes run automatically on pod startup via `initDb`.
+
+Existing coaching assignments keep `project_id = NULL` — unaffected.
+
+## Testing this system
+
+End-to-end smoke test (covers the new features while using the other system tests):
+
+1. Open `/admin/fragebogen` → assign ST 1 (Auth) template to a test client.
+2. Verify `/admin/projekte` shows a new project "System-Test 1: Authentifizierung & SSO (Keycloak)".
+3. In `/portal`, submit the questionnaire (or use admin self-assignment for system tests).
+4. In `/admin/fragebogen/<assignmentId>`, open the review page.
+5. Verify the "→ Verknüpftes Projekt öffnen" badge appears.
+6. Click "Als Aufgabe anlegen" on one question → verify task appears in `/admin/projekte/<projectId>`.
+7. Set assignment to `reviewed`, then click "Archivieren" → verify status badge updates.
+8. Verify archived assignment appears in a "Abgeschlossen"-filtered view.
+
+## Risks
+
+- **System-test self-assignment customer_id**: System-test assignments don't always have a `customer_id` (they're run by the admin against themselves). The auto-created project will have `customer_id = NULL` for these — which is valid per `createProject`'s FK (nullable). The title will omit the "— <customer_name>" suffix.
+- **Constraint drop/re-add**: The `DROP CONSTRAINT IF EXISTS` + `ADD CONSTRAINT` migration pattern is safe but briefly removes the constraint. Runs in `initDb` at startup before any traffic, so acceptable.
+- **Large question text as task name**: `question_text` can be long. Truncate to 120 chars in the API handler before inserting as task name.

--- a/tests/e2e/specs/fa-admin-tickets.spec.ts
+++ b/tests/e2e/specs/fa-admin-tickets.spec.ts
@@ -47,7 +47,7 @@ test.describe('FA-admin-tickets', () => {
     });
     expect(create.ok()).toBeTruthy();
     const cb = await create.json() as { success: boolean; ticketId: string };
-    expect(cb.ticketId).toMatch(/^BR-/);
+    expect(cb.ticketId).toMatch(/^T\d{6,}$/);
     const externalId = cb.ticketId;
 
     // ── 2. Admin login + index filter ──

--- a/website/src/components/admin/ProjectQuestionnairesPanel.astro
+++ b/website/src/components/admin/ProjectQuestionnairesPanel.astro
@@ -1,0 +1,177 @@
+---
+// website/src/components/admin/ProjectQuestionnairesPanel.astro
+//
+// Shared section for /admin/projekte/[id] and /admin/tickets/[id].
+// Renders nothing when `assignments` is empty.
+//
+// Score-bar rendering mirrors /admin/fragebogen/[assignmentId].astro lines 84–117
+// so the panel matches the full review page visually.
+
+import type { QAssignment, QQuestion, QAnswer, QAnswerOption } from '../../lib/questionnaire-db';
+import type { DimensionScore } from '../../lib/compute-scores';
+
+interface AssignmentBundle {
+  assignment: QAssignment;
+  questions: QQuestion[];
+  options: QAnswerOption[];
+  answers: QAnswer[];
+  scores: DimensionScore[];
+}
+
+interface Props {
+  assignments: AssignmentBundle[];
+}
+
+const { assignments } = Astro.props;
+
+function fmtDate(d: string | Date | null): string {
+  if (!d) return '—';
+  return new Date(d).toLocaleDateString('de-DE', { day: '2-digit', month: '2-digit', year: 'numeric' });
+}
+
+function levelColor(level: string | null): string {
+  if (level === 'kritisch') return '#ef4444';
+  if (level === 'mittel') return '#f59e0b';
+  if (level === 'förderlich') return '#22c55e';
+  return '#b8a06a';
+}
+
+const STATUS_CLS: Record<string, string> = {
+  pending:     'bg-yellow-500/10 text-yellow-400 border-yellow-500/20',
+  in_progress: 'bg-yellow-500/10 text-yellow-400 border-yellow-500/20',
+  submitted:   'bg-blue-500/10 text-blue-400 border-blue-500/20',
+  reviewed:    'bg-green-500/10 text-green-400 border-green-500/20',
+  archived:    'bg-slate-500/10 text-slate-400 border-slate-500/20',
+  dismissed:   'bg-red-500/10 text-red-400 border-red-500/20',
+};
+
+const STATUS_LABEL: Record<string, string> = {
+  pending:     'Wartend',
+  in_progress: 'In Bearbeitung',
+  submitted:   'Eingereicht',
+  reviewed:    'Besprochen',
+  archived:    'Archiviert',
+  dismissed:   'Abgelehnt',
+};
+---
+
+{assignments.length > 0 && (
+  <section class="bg-dark-light rounded-2xl border border-dark-lighter p-6 mb-6" id="questionnaires-panel">
+    <h2 class="text-sm font-semibold text-light mb-4 font-serif uppercase tracking-wide">
+      Fragebögen ({assignments.length})
+    </h2>
+
+    <div class="flex flex-col gap-6">
+      {assignments.map(({ assignment, questions, options, answers, scores }) => {
+        const answerMap = new Map(answers.map(a => [a.question_id, a]));
+        const optionMap = new Map(options.map(o => [`${o.question_id}:${o.option_key}`, o]));
+        const isMuted   = assignment.status === 'archived' || assignment.status === 'dismissed';
+        const showQA    = ['in_progress', 'submitted', 'reviewed', 'archived'].includes(assignment.status);
+        const showScores = scores.length > 0 && ['submitted', 'reviewed', 'archived'].includes(assignment.status);
+        const dateLabel = assignment.submitted_at
+          ? `Eingereicht ${fmtDate(assignment.submitted_at)}`
+          : `Zugewiesen ${fmtDate(assignment.assigned_at)}`;
+        const maxScore = Math.max(...scores.map(s => s.threshold_high ?? s.final_score ?? 1), 1);
+
+        return (
+          <div class={`border border-dark-lighter rounded-xl p-5 ${isMuted ? 'opacity-60' : ''}`}>
+            {/* Header */}
+            <div class="flex items-start justify-between gap-3 flex-wrap mb-3">
+              <div class="min-w-0">
+                <h3 class="text-light font-medium">{assignment.template_title}</h3>
+                <p class="text-muted text-xs mt-0.5">{dateLabel}</p>
+              </div>
+              <span class={`px-2.5 py-0.5 rounded-full border text-xs ${STATUS_CLS[assignment.status] ?? ''}`}>
+                {STATUS_LABEL[assignment.status] ?? assignment.status}
+              </span>
+            </div>
+
+            {/* Dismissed reason */}
+            {assignment.status === 'dismissed' && assignment.dismiss_reason && (
+              <p class="text-xs text-muted italic mb-3">Abgelehnt: {assignment.dismiss_reason}</p>
+            )}
+
+            {/* Score bars */}
+            {showScores && (
+              <div class="mb-4">
+                <div class="flex flex-col gap-3">
+                  {scores.map(score => {
+                    const pct = Math.min((score.final_score / Math.max(maxScore, 1)) * 100, 100);
+                    const color = levelColor(score.level);
+                    return (
+                      <div>
+                        <div class="flex justify-between items-baseline mb-1">
+                          <span class="text-light text-xs">{score.name}</span>
+                          <span class="text-xs font-mono" style={`color: ${color}`}>
+                            {score.final_score}{score.level && ` · ${score.level}`}
+                          </span>
+                        </div>
+                        <div class="h-1.5 bg-dark rounded-full overflow-hidden">
+                          <div class="h-full rounded-full"
+                            style={`width: ${pct}%; background-color: ${color}`}></div>
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            )}
+
+            {/* Coach notes preview */}
+            {assignment.coach_notes && assignment.coach_notes.trim().length > 0 && (
+              <div class="mb-4 p-3 bg-dark rounded border border-dark-lighter">
+                <p class="text-xs text-muted uppercase tracking-wide mb-1">Coach-Notizen</p>
+                <p class="text-sm text-light/90 whitespace-pre-wrap">{assignment.coach_notes}</p>
+              </div>
+            )}
+
+            {/* Q&A list — collapsible */}
+            {showQA && questions.length > 0 && (
+              <details class="mt-2">
+                <summary class="cursor-pointer text-xs text-gold hover:text-gold-light select-none">
+                  Fragen &amp; Antworten anzeigen ({answers.length}/{questions.length})
+                </summary>
+                <div class="mt-3 flex flex-col gap-3">
+                  {questions.map((q, i) => {
+                    const ans = answerMap.get(q.id);
+                    const chosen = ans?.option_key ?? null;
+                    const opt = chosen ? optionMap.get(`${q.id}:${chosen}`) : null;
+                    const label = opt?.label ?? chosen;
+                    return (
+                      <div class="border-b border-dark-lighter/50 pb-2 last:border-0 last:pb-0">
+                        <p class="text-muted text-xs mb-0.5">Frage {i + 1}</p>
+                        <p class="text-light text-sm whitespace-pre-line mb-1">{q.question_text}</p>
+                        {chosen === 'skipped' ? (
+                          <span class="inline-block px-2 py-0.5 bg-amber-500/10 text-amber-400 border border-amber-500/20 rounded text-xs">
+                            Übersprungen
+                          </span>
+                        ) : chosen ? (
+                          <span class="inline-block px-2 py-0.5 bg-gold/10 text-gold border border-gold/20 rounded text-xs">
+                            {label}
+                          </span>
+                        ) : (
+                          <span class="text-muted text-xs italic">Nicht beantwortet</span>
+                        )}
+                        {ans?.details_text && (
+                          <p class="text-muted text-xs mt-1 whitespace-pre-line">{ans.details_text}</p>
+                        )}
+                      </div>
+                    );
+                  })}
+                </div>
+              </details>
+            )}
+
+            {/* Link to full review */}
+            <div class="mt-3 flex justify-end">
+              <a href={`/admin/fragebogen/${assignment.id}`}
+                class="text-xs text-gold/80 hover:text-gold underline">
+                Volle Review öffnen →
+              </a>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  </section>
+)}

--- a/website/src/components/admin/ProjectQuestionnairesPanel.astro
+++ b/website/src/components/admin/ProjectQuestionnairesPanel.astro
@@ -10,7 +10,7 @@
 import type { QAssignment, QQuestion, QAnswer, QAnswerOption } from '../../lib/questionnaire-db';
 import type { DimensionScore } from '../../lib/compute-scores';
 
-interface AssignmentBundle {
+export interface AssignmentBundle {
   assignment: QAssignment;
   questions: QQuestion[];
   options: QAnswerOption[];

--- a/website/src/lib/questionnaire-db.ts
+++ b/website/src/lib/questionnaire-db.ts
@@ -535,7 +535,7 @@ export async function dismissQAssignment(id: string, reason: string): Promise<QA
 
 export async function countPendingQAssignmentsForCustomer(customerId: string): Promise<number> {
   const r = await pool.query(
-    `SELECT COUNT(*)::int FROM questionnaire_assignments
+    `SELECT COUNT(*)::int AS count FROM questionnaire_assignments
      WHERE customer_id = $1 AND status IN ('pending','in_progress')`,
     [customerId],
   );

--- a/website/src/lib/questionnaire-db.ts
+++ b/website/src/lib/questionnaire-db.ts
@@ -487,6 +487,25 @@ export async function listQAssignmentsForCustomer(customerId: string): Promise<Q
   return r.rows;
 }
 
+/**
+ * List coaching questionnaire assignments linked to a project (ticket of type='project').
+ * Excludes system-test templates — those are QA runs, not project context.
+ */
+export async function listQAssignmentsForProject(projectId: string): Promise<QAssignment[]> {
+  const r = await pool.query(
+    `SELECT a.id, a.customer_id, a.template_id, t.title AS template_title,
+            a.status, a.coach_notes, a.assigned_at, a.submitted_at, a.reviewed_at,
+            a.archived_at, a.dismissed_at, a.dismiss_reason, a.project_id
+     FROM questionnaire_assignments a
+     JOIN questionnaire_templates t ON t.id = a.template_id
+     WHERE a.project_id = $1
+       AND COALESCE(t.is_system_test, false) = false
+     ORDER BY a.assigned_at DESC`,
+    [projectId],
+  );
+  return r.rows;
+}
+
 export async function getQAssignment(id: string): Promise<QAssignment | null> {
   const r = await pool.query(
     `SELECT a.id, a.customer_id, a.template_id, t.title AS template_title,

--- a/website/src/lib/questionnaire-db.ts
+++ b/website/src/lib/questionnaire-db.ts
@@ -363,6 +363,16 @@ export async function listQQuestions(templateId: string): Promise<QQuestion[]> {
   return r.rows;
 }
 
+export async function getQQuestion(id: string): Promise<QQuestion | null> {
+  const r = await pool.query(
+    `SELECT id, template_id, position, question_text, question_type,
+            test_expected_result, test_function_url, test_menu_path, test_role, created_at
+     FROM questionnaire_questions WHERE id = $1`,
+    [id],
+  );
+  return r.rows[0] ?? null;
+}
+
 export async function upsertQQuestion(params: {
   id?: string; templateId: string; position: number;
   questionText: string; questionType: QuestionType;

--- a/website/src/lib/questionnaire-db.ts
+++ b/website/src/lib/questionnaire-db.ts
@@ -19,7 +19,7 @@ const pool = new pg.Pool(
 
 export type QuestionType = 'ab_choice' | 'ja_nein' | 'likert_5' | 'test_step';
 export type TestStepResult = 'erfüllt' | 'teilweise' | 'nicht_erfüllt';
-export type AssignmentStatus = 'pending' | 'in_progress' | 'submitted' | 'reviewed' | 'dismissed';
+export type AssignmentStatus = 'pending' | 'in_progress' | 'submitted' | 'reviewed' | 'archived' | 'dismissed';
 
 export interface QTemplate {
   id: string;
@@ -75,8 +75,10 @@ export interface QAssignment {
   assigned_at: string;
   submitted_at: string | null;
   reviewed_at: string | null;
+  archived_at: string | null;   // new
   dismissed_at: string | null;
   dismiss_reason: string | null;
+  project_id: string | null;    // new
 }
 
 export interface QAnswer {
@@ -225,6 +227,8 @@ async function initDb() {
     ADD COLUMN IF NOT EXISTS is_system_test BOOLEAN NOT NULL DEFAULT false`);
   await pool.query(`ALTER TABLE questionnaire_assignments ADD COLUMN IF NOT EXISTS dismissed_at TIMESTAMPTZ`);
   await pool.query(`ALTER TABLE questionnaire_assignments ADD COLUMN IF NOT EXISTS dismiss_reason TEXT`);
+  await pool.query(`ALTER TABLE questionnaire_assignments ADD COLUMN IF NOT EXISTS project_id UUID REFERENCES tickets.tickets(id) ON DELETE SET NULL`);
+  await pool.query(`ALTER TABLE questionnaire_assignments ADD COLUMN IF NOT EXISTS archived_at TIMESTAMPTZ`);
   await pool.query(`
     CREATE TABLE IF NOT EXISTS questionnaire_test_status (
       question_id UUID PRIMARY KEY REFERENCES questionnaire_questions(id) ON DELETE CASCADE,
@@ -445,13 +449,14 @@ export async function replaceQAnswerOptions(questionId: string, options: Array<{
 // ── Assignments ───────────────────────────────────────────────────
 
 export async function createQAssignment(params: {
-  customerId: string; templateId: string;
+  customerId: string; templateId: string; projectId?: string;
 }): Promise<QAssignment> {
   const r = await pool.query(
-    `INSERT INTO questionnaire_assignments (customer_id, template_id)
-     VALUES ($1, $2)
-     RETURNING id, customer_id, template_id, status, coach_notes, assigned_at, submitted_at, reviewed_at, dismissed_at, dismiss_reason`,
-    [params.customerId, params.templateId],
+    `INSERT INTO questionnaire_assignments (customer_id, template_id, project_id)
+     VALUES ($1, $2, $3)
+     RETURNING id, customer_id, template_id, status, coach_notes, assigned_at,
+               submitted_at, reviewed_at, archived_at, dismissed_at, dismiss_reason, project_id`,
+    [params.customerId, params.templateId, params.projectId ?? null],
   );
   const row = r.rows[0];
   const tpl = await getQTemplate(row.template_id);
@@ -462,7 +467,7 @@ export async function listQAssignmentsForCustomer(customerId: string): Promise<Q
   const r = await pool.query(
     `SELECT a.id, a.customer_id, a.template_id, t.title AS template_title,
             a.status, a.coach_notes, a.assigned_at, a.submitted_at, a.reviewed_at,
-            a.dismissed_at, a.dismiss_reason
+            a.archived_at, a.dismissed_at, a.dismiss_reason, a.project_id
      FROM questionnaire_assignments a
      JOIN questionnaire_templates t ON t.id = a.template_id
      WHERE a.customer_id = $1
@@ -476,7 +481,7 @@ export async function getQAssignment(id: string): Promise<QAssignment | null> {
   const r = await pool.query(
     `SELECT a.id, a.customer_id, a.template_id, t.title AS template_title,
             a.status, a.coach_notes, a.assigned_at, a.submitted_at, a.reviewed_at,
-            a.dismissed_at, a.dismiss_reason
+            a.archived_at, a.dismissed_at, a.dismiss_reason, a.project_id
      FROM questionnaire_assignments a
      JOIN questionnaire_templates t ON t.id = a.template_id
      WHERE a.id = $1`,
@@ -494,6 +499,7 @@ export async function updateQAssignment(id: string, params: {
     vals.push(params.status); sets.push(`status = $${vals.length}`);
     if (params.status === 'submitted') sets.push(`submitted_at = now()`);
     if (params.status === 'reviewed') sets.push(`reviewed_at = now()`);
+    if (params.status === 'archived') sets.push(`archived_at = now()`);
     if (params.status === 'dismissed') sets.push(`dismissed_at = now()`);
   }
   if (params.dismissReason !== undefined) { vals.push(params.dismissReason); sets.push(`dismiss_reason = $${vals.length}`); }
@@ -503,7 +509,8 @@ export async function updateQAssignment(id: string, params: {
   const r = await pool.query(
     `UPDATE questionnaire_assignments SET ${sets.join(', ')}
      WHERE id = $${vals.length}
-     RETURNING id, customer_id, template_id, status, coach_notes, assigned_at, submitted_at, reviewed_at, dismissed_at, dismiss_reason`,
+     RETURNING id, customer_id, template_id, status, coach_notes, assigned_at,
+               submitted_at, reviewed_at, archived_at, dismissed_at, dismiss_reason, project_id`,
     vals,
   );
   const row = r.rows[0];

--- a/website/src/lib/system-test-seed-data.test.ts
+++ b/website/src/lib/system-test-seed-data.test.ts
@@ -7,11 +7,11 @@ const REQUIRED_REQ_IDS = [
   ...Array.from({ length: 13 }, (_, i) => `C-${String(i + 1).padStart(2, '0')}`),
 ];
 
-const EXPECTED_STEP_COUNTS = [6, 10, 5, 5, 5, 12, 16, 14, 6, 10];
+const EXPECTED_STEP_COUNTS = [6, 10, 5, 5, 5, 12, 16, 14, 5, 10, 7, 8];
 
 describe('system-test-seed-data', () => {
-  it('exports exactly 10 templates', () => {
-    expect(SYSTEM_TEST_TEMPLATES).toHaveLength(10);
+  it('exports exactly 12 templates', () => {
+    expect(SYSTEM_TEST_TEMPLATES).toHaveLength(12);
   });
 
   it('per-category step counts match the spec', () => {
@@ -19,9 +19,9 @@ describe('system-test-seed-data', () => {
     expect(counts).toEqual(EXPECTED_STEP_COUNTS);
   });
 
-  it('totals 89 steps across all templates', () => {
+  it('totals 103 steps across all templates', () => {
     const total = SYSTEM_TEST_TEMPLATES.reduce((sum, t) => sum + t.steps.length, 0);
-    expect(total).toBe(89);
+    expect(total).toBe(103);
   });
 
   it('every template has non-empty title/description/instructions', () => {

--- a/website/src/lib/system-test-seed-data.ts
+++ b/website/src/lib/system-test-seed-data.ts
@@ -188,7 +188,7 @@ export const SYSTEM_TEST_TEMPLATES: SystemTestTemplate[] = [
       },
       {
         question_text: 'Öffne Monitoring (Link) — scrolle zum Abschnitt „Test-Results-Panel" und prüfe ob alle System-Test-Templates mit Last-Result/Last-Success-Status sichtbar sind.',
-        expected_result: 'Alle 10 System-Test-Templates sichtbar mit Last-Result/Last-Success-Status.',
+        expected_result: 'Alle 12 System-Test-Templates sichtbar mit Last-Result/Last-Success-Status.',
         test_function_url: '/admin/monitoring', test_role: 'admin',
       },
     ],

--- a/website/src/lib/system-test-seed-data.ts
+++ b/website/src/lib/system-test-seed-data.ts
@@ -100,7 +100,7 @@ export const SYSTEM_TEST_TEMPLATES: SystemTestTemplate[] = [
       },
       {
         question_text: 'Öffne Projekte (Link) → klicke „Neues Projekt" → ordne es über das Client-Feld einem Client zu → prüfe ob das Projekt in der Client-Detailansicht unter Reiter „Projekte" erscheint.',
-        expected_result: 'Projekt erscheint in /admin/projekte; Zuordnung zum Client in der Detailansicht sichtbar.',
+        expected_result: 'Projekt erscheint in /admin/projekte; Tickets-System-Projekt mit Status „Entwurf" angelegt; Zuordnung zum Client sichtbar.',
         test_function_url: '/admin/projekte', test_role: 'admin',
       },
       {
@@ -127,7 +127,7 @@ export const SYSTEM_TEST_TEMPLATES: SystemTestTemplate[] = [
     ],
   },
   {
-    title: 'System-Test 3: Kommunikation — Fragebogen-Widget, Inbox & E-Mail',
+    title: 'System-Test 3: Kommunikation — Chat-Widget, Inbox & E-Mail',
     description: 'Test des Fragebogen-Widgets auf der öffentlichen Website, des Admin-Inbox-Workflows sowie E-Mail-Versand und Newsletter-Vorschau.',
     instructions: 'Schritt 1 im Testnutzer-Browser, Schritte 2/3/4 im Admin-Browser. Öffne jeweils den Link im Schritt.',
     steps: [
@@ -172,7 +172,7 @@ export const SYSTEM_TEST_TEMPLATES: SystemTestTemplate[] = [
       },
       {
         question_text: 'Klicke im Template auf „Veröffentlichen" — öffne dann einen Client (Link), wechsle zum Reiter „Fragebögen" und klicke „Zuweisen".',
-        expected_result: 'Assignment erstellt; Nutzer sieht Fragebogen im Portal-Dashboard (ggf. E-Mail-Benachrichtigung).',
+        expected_result: 'Assignment erstellt; Nutzer sieht Fragebogen im Portal-Dashboard; verknüpftes Projekt automatisch unter /admin/projekte angelegt.',
         test_function_url: '/admin/clients', test_role: 'admin',
       },
       {
@@ -490,7 +490,7 @@ export const SYSTEM_TEST_TEMPLATES: SystemTestTemplate[] = [
       },
       {
         question_text: 'Öffne Monitoring (Link) → scrolle zum „Test-Results-Panel" — prüfe ob alle System-Test-Templates mit last_result und last_success_at sichtbar sind und ein Drilldown auf Question-Level möglich ist.',
-        expected_result: 'Alle Templates sichtbar mit last_result/last_success_at; Drilldown auf Question-Level möglich.',
+        expected_result: 'Alle 12 Templates sichtbar mit last_result/last_success_at; Drilldown auf Question-Level möglich.',
         test_function_url: '/admin/monitoring', test_role: 'admin',
       },
     ],
@@ -550,6 +550,96 @@ export const SYSTEM_TEST_TEMPLATES: SystemTestTemplate[] = [
         question_text: 'Öffne Brett / Systembrett (Link) — prüfe ob das 3D-Board lädt, du Elemente verschieben kannst und Speichern funktioniert.',
         expected_result: '3D-Board lädt; Demo-Konstellation manipulierbar; Speichern funktioniert.',
         test_function_url: `https://brett.${D}`, test_role: 'user',
+      },
+    ],
+  },
+  {
+    title: 'System-Test 11: LiveKit & Streaming',
+    description: 'Vollständiger Test des LiveKit-Streaming-Stacks: Admin-Steuerseite, Stream starten/stoppen, Viewer-Portal, RTMP-Ingress, Recording-Liste und Pod-Status.',
+    instructions: 'Schritte 1, 4, 5, 6, 7 im Admin-Browser. Schritt 2 startet den Stream — danach Schritt 3 im Testnutzer-Browser. Schritt 6 beendet den Stream.',
+    steps: [
+      {
+        question_text: 'Öffne die Admin-Stream-Seite (Link) — prüfe ob der Stream-Status „offline" angezeigt wird und die Seite ohne Fehler lädt.',
+        expected_result: 'Seite lädt; Stream-Status „offline"; keine Fehlermeldungen.',
+        test_function_url: '/admin/stream', test_role: 'admin',
+      },
+      {
+        question_text: 'Klicke auf der Admin-Stream-Seite (Link) den Start-Button — prüfe ob der Status auf „live" wechselt und ein Stream-Token generiert wird.',
+        expected_result: 'Status wechselt auf „live"; Stream-Token sichtbar.',
+        test_function_url: '/admin/stream', test_role: 'admin',
+      },
+      {
+        question_text: 'Öffne das Viewer-Portal (Link) im Testnutzer-Browser während der Stream läuft — prüfe ob der Stream-Player sichtbar ist und keine Verbindungsfehler erscheinen. → Nutzer: zweites Browser-Profil.',
+        expected_result: 'Stream-Player sichtbar; Verbindung aufgebaut; kein Fehler im Browser.',
+        test_function_url: '/portal/stream', test_role: 'user',
+        agent_notes: 'Zweites Browser-Profil (Testnutzer) erforderlich. Stream muss laufen (Schritt 2 abgeschlossen).',
+      },
+      {
+        question_text: 'Öffne die Admin-Stream-Seite (Link) — prüfe ob der RTMP-Ingress-Status und die RTMP-URL angezeigt werden.',
+        expected_result: 'RTMP-URL sichtbar; Ingress-Status angezeigt (aktiv oder bereit).',
+        test_function_url: '/admin/stream', test_role: 'admin',
+      },
+      {
+        question_text: 'Öffne die Admin-Stream-Seite (Link) → klicke „Aufnahmen" oder scrolle zur Recordings-Liste — prüfe ob vorhandene MP4-Dateien aufgelistet werden oder eine leere Liste ohne Fehler erscheint.',
+        expected_result: 'Recordings-Liste lädt; MP4-Dateien sichtbar oder leere Liste ohne Fehler.',
+        test_function_url: '/admin/stream', test_role: 'admin',
+      },
+      {
+        question_text: 'Klicke auf der Admin-Stream-Seite (Link) den Stop-Button — prüfe ob der Status auf „offline" wechselt und das Viewer-Portal „kein Stream" anzeigt.',
+        expected_result: 'Status wechselt auf „offline"; Viewer-Portal zeigt „kein Stream aktiv".',
+        test_function_url: '/admin/stream', test_role: 'admin',
+      },
+      {
+        question_text: 'Öffne Monitoring (Link) — prüfe ob der `livekit-server` Pod im Status „Running" ist und kein CrashLoop vorliegt.',
+        expected_result: '`livekit-server` Pod im Status „Running"; kein CrashLoop.',
+        test_function_url: '/admin/monitoring', test_role: 'admin',
+      },
+    ],
+  },
+  {
+    title: 'System-Test 12: Projektmanagement',
+    description: 'Vollständiger Test des Projektmanagement-Moduls: Projekte, Teilprojekte, Aufgaben, Zeiterfassung, Meeting-Verknüpfung und Archivierung.',
+    instructions: 'Alle Schritte im Admin-Browser. Öffne jeweils den Link im Schritt. Schritte bauen aufeinander auf — in Reihenfolge abarbeiten.',
+    steps: [
+      {
+        question_text: 'Öffne Projekte (Link) → klicke „Neues Projekt" → fülle Titel und Client aus → speichere — prüfe ob das Projekt in der Liste erscheint.',
+        expected_result: 'Projekt erscheint in der Liste; Pflichtfeld-Validierung serverseitig.',
+        test_function_url: '/admin/projekte', test_role: 'admin',
+      },
+      {
+        question_text: 'Öffne das neu angelegte Projekt (Link) → wechsle zum Reiter „Teilprojekte" → klicke „Neues Teilprojekt" → trage Titel ein und speichere — prüfe ob das Teilprojekt erscheint.',
+        expected_result: 'Teilprojekt erscheint unter dem Reiter „Teilprojekte" des Projekts.',
+        test_function_url: '/admin/projekte', test_role: 'admin',
+      },
+      {
+        question_text: 'Im Projekt-Detail (Link) → wechsle zum Reiter „Aufgaben" → klicke „Neue Aufgabe" → fülle Titel und Priorität aus → speichere — prüfe ob die Aufgabe mit Status „Entwurf" erscheint.',
+        expected_result: 'Aufgabe erscheint in der Liste; Status „Entwurf"; Aufgaben-Counter aktualisiert.',
+        test_function_url: '/admin/projekte', test_role: 'admin',
+      },
+      {
+        question_text: 'Im Projekt-Detail (Link) → klicke auf die Aufgabe → ändere den Status auf „Erledigt" → speichere — prüfe ob der Aufgaben-Counter sofort sinkt.',
+        expected_result: 'Status wechselt sofort auf „Erledigt"; offene Aufgaben-Counter sinkt.',
+        test_function_url: '/admin/projekte', test_role: 'admin',
+      },
+      {
+        question_text: 'Im Projekt-Detail (Link) → wechsle zum Reiter „Zeiterfassung" → klicke „Zeit buchen" → trage Dauer und Beschreibung ein → speichere — prüfe ob der Gesamtzeit-Counter aktualisiert wird.',
+        expected_result: 'Zeiteintrag gespeichert; Gesamtzeit-Counter des Projekts erhöht sich.',
+        test_function_url: '/admin/projekte', test_role: 'admin',
+      },
+      {
+        question_text: 'Im Projekt-Detail (Link) → ändere den Projekt-Status auf „Aktiv" → speichere — prüfe ob das Status-Badge aktualisiert wird und das Projekt in der aktiven Filter-Ansicht erscheint.',
+        expected_result: 'Status-Badge zeigt „Aktiv"; Projekt erscheint in gefilterten „Aktiv"-Ansicht.',
+        test_function_url: '/admin/projekte', test_role: 'admin',
+      },
+      {
+        question_text: 'Im Projekt-Detail (Link) → wechsle zum Reiter „Besprechungen" → klicke „Meeting verknüpfen" → wähle ein vorhandenes Meeting aus — prüfe ob es im Reiter erscheint.',
+        expected_result: 'Meeting erscheint im Reiter „Besprechungen" des Projekts.',
+        test_function_url: '/admin/projekte', test_role: 'admin',
+      },
+      {
+        question_text: 'Im Projekt-Detail (Link) → ändere den Status auf „Archiviert" → speichere — prüfe ob das Projekt aus der Standard-Liste verschwindet und in der Archiv-Ansicht sichtbar ist.',
+        expected_result: 'Projekt verschwindet aus Standard-Liste; in Archiv-Ansicht sichtbar.',
+        test_function_url: '/admin/projekte', test_role: 'admin',
       },
     ],
   },

--- a/website/src/lib/system-test-seed-data.ts
+++ b/website/src/lib/system-test-seed-data.ts
@@ -479,8 +479,8 @@ export const SYSTEM_TEST_TEMPLATES: SystemTestTemplate[] = [
         test_function_url: '/admin/monitoring', test_role: 'admin',
       },
       {
-        question_text: 'Öffne Monitoring (Link) → klicke „Bug-Ticket erstellen" → fülle Titel und Beschreibung aus — prüfe ob das Ticket unter /admin/bugs mit dem Format BR-YYYYMMDD-xxxx erscheint.',
-        expected_result: 'Ticket mit Format BR-YYYYMMDD-xxxx wird angelegt und unter /admin/bugs sichtbar.',
+        question_text: 'Öffne Monitoring (Link) → klicke „Bug-Ticket erstellen" → fülle Titel und Beschreibung aus — prüfe ob das Ticket unter /admin/bugs mit dem Format Txxxxxx erscheint.',
+        expected_result: 'Ticket mit Format Txxxxxx wird angelegt und unter /admin/bugs sichtbar.',
         test_function_url: '/admin/monitoring', test_role: 'admin',
       },
       {

--- a/website/src/lib/tickets-db.ts
+++ b/website/src/lib/tickets-db.ts
@@ -267,5 +267,72 @@ export async function initTicketsSchema(): Promise<void> {
   await pool.query(`CREATE INDEX IF NOT EXISTS pr_events_brand_idx     ON tickets.pr_events (brand) WHERE brand IS NOT NULL`);
   await pool.query(`CREATE INDEX IF NOT EXISTS pr_events_category_idx  ON tickets.pr_events (category)`);
 
+  // Per-brand monotonic counter — feeds the BEFORE-INSERT trigger that mints T-numbers.
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS tickets.ticket_counters (
+      brand       TEXT PRIMARY KEY,
+      last_value  BIGINT NOT NULL DEFAULT 0
+    )
+  `);
+
+  await pool.query(`
+    CREATE OR REPLACE FUNCTION tickets.fn_assign_external_id() RETURNS trigger AS $$
+    DECLARE
+      next_v BIGINT;
+    BEGIN
+      IF NEW.external_id IS NULL THEN
+        INSERT INTO tickets.ticket_counters (brand, last_value)
+        VALUES (NEW.brand, 1)
+        ON CONFLICT (brand) DO UPDATE SET last_value = tickets.ticket_counters.last_value + 1
+        RETURNING last_value INTO next_v;
+        NEW.external_id := 'T' || LPAD(next_v::text, 6, '0');
+      END IF;
+      RETURN NEW;
+    END $$ LANGUAGE plpgsql
+  `);
+  await pool.query(`DROP TRIGGER IF EXISTS trg_tickets_assign_external_id ON tickets.tickets`);
+  await pool.query(`
+    CREATE TRIGGER trg_tickets_assign_external_id
+      BEFORE INSERT ON tickets.tickets
+      FOR EACH ROW EXECUTE FUNCTION tickets.fn_assign_external_id()
+  `);
+
+  // Idempotent backfill: any ticket whose external_id is NULL or not in T-format
+  // gets a T-number, ordered by created_at within its brand.
+  await pool.query(`
+    INSERT INTO tickets.ticket_counters (brand, last_value)
+    SELECT t.brand,
+           COALESCE(MAX(CASE WHEN t.external_id ~ '^T[0-9]+$'
+                             THEN CAST(SUBSTRING(t.external_id FROM 2) AS BIGINT)
+                             ELSE 0 END), 0)
+      FROM tickets.tickets t
+     GROUP BY t.brand
+    ON CONFLICT (brand) DO NOTHING
+  `);
+  await pool.query(`
+    WITH to_fill AS (
+      SELECT t.id, t.brand,
+             (SELECT last_value FROM tickets.ticket_counters tc WHERE tc.brand = t.brand) +
+             ROW_NUMBER() OVER (PARTITION BY t.brand ORDER BY t.created_at ASC, t.id ASC) AS new_seq
+        FROM tickets.tickets t
+       WHERE t.external_id IS NULL OR t.external_id !~ '^T[0-9]+$'
+    )
+    UPDATE tickets.tickets t
+       SET external_id = 'T' || LPAD(f.new_seq::text, 6, '0')
+      FROM to_fill f
+     WHERE t.id = f.id
+  `);
+  await pool.query(`
+    UPDATE tickets.ticket_counters tc
+       SET last_value = sub.max_v
+      FROM (
+        SELECT brand, MAX(CAST(SUBSTRING(external_id FROM 2) AS BIGINT)) AS max_v
+          FROM tickets.tickets
+         WHERE external_id ~ '^T[0-9]+$'
+         GROUP BY brand
+      ) sub
+     WHERE tc.brand = sub.brand AND tc.last_value < sub.max_v
+  `);
+
   schemaReady = true;
 }

--- a/website/src/lib/tickets/admin.ts
+++ b/website/src/lib/tickets/admin.ts
@@ -118,8 +118,9 @@ export interface ListFilters {
 
 // ── List ────────────────────────────────────────────────────────────────────
 
-const LIST_SELECT = `
-  SELECT
+// Split into LIST_COLS (SELECT items) and LIST_FROM (FROM + joins) so getTicketDetail
+// can inject extra columns into the SELECT list without ending up after the FROM.
+const LIST_COLS = `
     t.id, t.external_id AS "externalId", t.type, t.brand, t.title,
     t.status, t.resolution, t.priority, t.severity, t.component,
     t.thesis_tag AS "thesisTag", t.parent_id AS "parentId",
@@ -136,10 +137,13 @@ const LIST_SELECT = `
         WHERE tt.ticket_id = t.id), ARRAY[]::text[]
     ) AS "tagNames",
     t.created_at AS "createdAt", t.updated_at AS "updatedAt"
+`;
+const LIST_FROM = `
   FROM tickets.tickets t
   LEFT JOIN customers c ON c.id = t.customer_id
   LEFT JOIN customers a ON a.id = t.assignee_id
 `;
+const LIST_SELECT = `SELECT ${LIST_COLS} ${LIST_FROM}`;
 
 const LIST_ORDER = `
   ORDER BY
@@ -234,13 +238,14 @@ export async function getTicketDetail(brand: string, id: string): Promise<Ticket
 
   // Brand-scoped fetch — returns null if the ticket exists in a different brand.
   const t = await pool.query<TicketDetail>(
-    `${LIST_SELECT}
-     , t.description, t.notes, t.url, t.start_date AS "startDate",
-       t.estimate_minutes AS "estimateMinutes", t.time_logged_minutes AS "timeLoggedMinutes",
-       t.triaged_at AS "triagedAt", t.started_at AS "startedAt",
-       t.done_at AS "doneAt", t.archived_at AS "archivedAt",
-       t.reporter_id AS "reporterId"
-     WHERE t.id = $1 AND t.brand = $2`,
+    `SELECT ${LIST_COLS},
+            t.description, t.notes, t.url, t.start_date AS "startDate",
+            t.estimate_minutes AS "estimateMinutes", t.time_logged_minutes AS "timeLoggedMinutes",
+            t.triaged_at AS "triagedAt", t.started_at AS "startedAt",
+            t.done_at AS "doneAt", t.archived_at AS "archivedAt",
+            t.reporter_id AS "reporterId"
+       ${LIST_FROM}
+      WHERE t.id = $1 AND t.brand = $2`,
     [id, brand]
   );
   if (t.rows.length === 0) return null;
@@ -396,9 +401,6 @@ export async function createAdminTicket(p: {
   await initTicketsSchema();
   if (p.type === 'project' && !p.customerId) {
     throw new Error('createAdminTicket: customerId is required for type=project');
-  }
-  if (p.type === 'bug') {
-    throw new Error('createAdminTicket: type=bug must be created via /api/bug-report (mints BR-id)');
   }
   // If parentId is given, it must belong to the same brand.
   if (p.parentId) {

--- a/website/src/lib/website-db.ts
+++ b/website/src/lib/website-db.ts
@@ -598,27 +598,26 @@ export async function assignMeeting(meetingId: string, params: {
 // ── Bug Tickets ──────────────────────────────────────────────────────────────
 
 export async function insertBugTicket(params: {
-  ticketId: string;
   category: string;
   reporterEmail: string;
   description: string;
   url?: string;
   brand: string;
   screenshots?: string[];
-}): Promise<number> {
+}): Promise<{ id: string; ticketId: string } | null> {
   await initTicketsSchema();
-  const { rows } = await pool.query(
+  const { rows } = await pool.query<{ id: string; external_id: string }>(
     `INSERT INTO tickets.tickets
-       (external_id, type, brand, title, description, url, reporter_email, status)
-     VALUES ($1, 'bug', $2, $3, $4, $5, $6, 'triage')
-     ON CONFLICT (external_id) DO NOTHING
-     RETURNING id`,
-    [params.ticketId, params.brand,
+       (type, brand, title, description, url, reporter_email, status)
+     VALUES ('bug', $1, $2, $3, $4, $5, 'triage')
+     RETURNING id, external_id`,
+    [params.brand,
      params.description.slice(0, 200),
      params.description, params.url ?? null, params.reporterEmail]
   );
-  if (rows.length === 0) return 0;
+  if (rows.length === 0) return null;
   const newId = rows[0].id;
+  const newExtId = rows[0].external_id;
 
   // Categorize as tag (kind:fehler|verbesserung|erweiterungswunsch)
   const tagName = `kind:${params.category}`;
@@ -638,7 +637,7 @@ export async function insertBugTicket(params: {
        VALUES ($1, $2, $3, $4)`,
       [newId, `screenshot-${idx + 1}`, dataUrl, m ? m[1] : 'application/octet-stream']);
   }
-  return 1;
+  return { id: newId, ticketId: newExtId };
 }
 
 async function ticketIdByExternal(externalId: string): Promise<string | null> {

--- a/website/src/pages/admin/fragebogen/[assignmentId].astro
+++ b/website/src/pages/admin/fragebogen/[assignmentId].astro
@@ -57,16 +57,26 @@ const maxScore = Math.max(...scores.map(s => s.threshold_high ?? s.final_score ?
           <p class="text-muted mt-1 text-sm">
             Eingereicht: {fmtDate(assignment.submitted_at)}
           </p>
+          {assignment.project_id && (
+            <a
+              href={`/admin/projekte/${assignment.project_id}`}
+              class="inline-flex items-center gap-1 mt-2 text-xs text-gold/70 hover:text-gold underline"
+            >
+              → Verknüpftes Projekt öffnen
+            </a>
+          )}
         </div>
         <span class={`px-3 py-1 rounded-full border text-sm ${
           assignment.status === 'reviewed' ? 'bg-green-500/10 text-green-400 border-green-500/20'
           : assignment.status === 'submitted' ? 'bg-blue-500/10 text-blue-400 border-blue-500/20'
           : assignment.status === 'dismissed' ? 'bg-red-500/10 text-red-400 border-red-500/20'
+          : assignment.status === 'archived' ? 'bg-slate-500/10 text-slate-400 border-slate-500/20'
           : 'bg-yellow-500/10 text-yellow-400 border-yellow-500/20'
         }`}>
           {assignment.status === 'reviewed' ? 'Besprochen'
             : assignment.status === 'submitted' ? 'Eingereicht'
             : assignment.status === 'dismissed' ? 'Abgelehnt'
+            : assignment.status === 'archived' ? 'Archiviert'
             : assignment.status}
         </span>
       </div>
@@ -190,6 +200,15 @@ const maxScore = Math.max(...scores.map(s => s.threshold_high ?? s.final_score ?
                         Bug erfassen
                       </button>
                     )}
+                    {assignment.project_id && (
+                      <button
+                        class="create-task-btn text-xs px-2 py-1 bg-dark border border-dark-lighter text-light/70 rounded hover:border-gold/40 hover:text-light transition-colors"
+                        data-question-id={q.id}
+                      >
+                        + Aufgabe
+                      </button>
+                    )}
+                    <span id={`task-result-${q.id}`} class="text-xs text-green-400 hidden"></span>
                   </div>
                   <div id={`bug-result-${q.id}`} class="mt-2 text-xs hidden"></div>
                 </div>
@@ -275,6 +294,12 @@ const maxScore = Math.max(...scores.map(s => s.threshold_high ?? s.final_score ?
               Als besprochen markieren ✓
             </button>
           )}
+          {assignment.status === 'reviewed' && (
+            <button id="archive-btn"
+              class="px-4 py-2 bg-dark border border-dark-lighter text-muted rounded-lg text-sm hover:border-gold/40 hover:text-light transition-colors">
+              Archivieren
+            </button>
+          )}
         </div>
         <p id="notes-msg" class="text-xs mt-2 hidden"></p>
       </div>
@@ -326,6 +351,55 @@ const maxScore = Math.max(...scores.map(s => s.threshold_high ?? s.final_score ?
     bugModal.classList.remove('flex');
     activeBugStepId = null;
   }
+
+  // Task creation
+  document.querySelectorAll('.create-task-btn').forEach(btn => {
+    btn.addEventListener('click', async () => {
+      const questionId = btn.dataset.questionId;
+      btn.disabled = true;
+      btn.textContent = '…';
+      try {
+        const r = await fetch(
+          `/api/admin/questionnaires/assignments/${assignmentId}/create-task`,
+          {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ questionId }),
+          },
+        );
+        const data = await r.json().catch(() => ({}));
+        const resultEl = document.getElementById(`task-result-${questionId}`);
+        if (r.ok && data.taskId) {
+          btn.remove();
+          if (resultEl) {
+            resultEl.textContent = '✓ Aufgabe angelegt';
+            resultEl.classList.remove('hidden');
+          }
+        } else {
+          btn.disabled = false;
+          btn.textContent = '+ Aufgabe';
+          if (resultEl) {
+            resultEl.textContent = data.error || 'Fehler';
+            resultEl.className = 'text-xs text-red-400';
+            resultEl.classList.remove('hidden');
+          }
+        }
+      } catch {
+        btn.disabled = false;
+        btn.textContent = '+ Aufgabe';
+      }
+    });
+  });
+
+  // Archive
+  document.getElementById('archive-btn')?.addEventListener('click', async () => {
+    const r = await fetch(`/api/admin/questionnaires/assignments/${assignmentId}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ status: 'archived' }),
+    });
+    if (r.ok) window.location.reload();
+  });
 
   document.getElementById('bug-modal-submit')?.addEventListener('click', async () => {
     const desc = bugDescInput.value.trim();

--- a/website/src/pages/admin/projekte/[id].astro
+++ b/website/src/pages/admin/projekte/[id].astro
@@ -9,6 +9,15 @@ import {
 } from '../../../lib/website-db';
 import type { Project, SubProject, ProjectTask, Customer, TimeEntry, MeetingWithDetails, ProjectAttachment } from '../../../lib/website-db';
 import ProjectMeetingsTab from '../../../components/admin/ProjectMeetingsTab.astro';
+import {
+  listQAssignmentsForProject,
+  listQQuestions,
+  listQAnswerOptionsForTemplate,
+  listQAnswers,
+  listQDimensions,
+} from '../../../lib/questionnaire-db';
+import { computeScores } from '../../../lib/compute-scores';
+import ProjectQuestionnairesPanel from '../../../components/admin/ProjectQuestionnairesPanel.astro';
 
 const session = await getSession(Astro.request.headers.get('cookie'));
 if (!session) return Astro.redirect(getLoginUrl(Astro.url.pathname));
@@ -29,6 +38,13 @@ let timeStats: { total: number; billable: number } = { total: 0, billable: 0 };
 let meetings: MeetingWithDetails[] = [];
 let unassignedMeetings: Array<{ id: string; meetingType: string; status: string; createdAt: Date }> = [];
 let attachments: ProjectAttachment[] = [];
+let questionnaireBundles: Array<{
+  assignment: any;
+  questions: any[];
+  options: any[];
+  answers: any[];
+  scores: any[];
+}> = [];
 let dbError = '';
 
 try {
@@ -47,6 +63,25 @@ try {
         getProjectTotalMinutes(id),
         listProjectAttachments(id),
       ]);
+    }
+
+    // Questionnaire bundle for the panel — only on the default tab
+    if (tab !== 'besprechungen' && project) {
+      try {
+        const assignments = await listQAssignmentsForProject(id);
+        questionnaireBundles = await Promise.all(assignments.map(async a => {
+          const [questions, options, answers, dimensions] = await Promise.all([
+            listQQuestions(a.template_id),
+            listQAnswerOptionsForTemplate(a.template_id),
+            listQAnswers(a.id),
+            listQDimensions(a.template_id),
+          ]);
+          return { assignment: a, questions, options, answers, scores: computeScores(dimensions, options, answers) };
+        }));
+      } catch (err) {
+        console.error('[admin/projekte/[id]] questionnaire fetch failed:', err);
+        questionnaireBundles = [];
+      }
     }
   }
 } catch (err) {
@@ -256,6 +291,8 @@ const tasksJson = JSON.stringify(allTasksFlat.map(t => ({
               </form>
             </div>
           </div>
+
+          <ProjectQuestionnairesPanel assignments={questionnaireBundles} />
 
           {/* ── Sub-projects ── */}
           <div class={`${sectionCls} mb-6`}>

--- a/website/src/pages/admin/projekte/[id].astro
+++ b/website/src/pages/admin/projekte/[id].astro
@@ -17,7 +17,7 @@ import {
   listQDimensions,
 } from '../../../lib/questionnaire-db';
 import { computeScores } from '../../../lib/compute-scores';
-import ProjectQuestionnairesPanel from '../../../components/admin/ProjectQuestionnairesPanel.astro';
+import ProjectQuestionnairesPanel, { type AssignmentBundle } from '../../../components/admin/ProjectQuestionnairesPanel.astro';
 
 const session = await getSession(Astro.request.headers.get('cookie'));
 if (!session) return Astro.redirect(getLoginUrl(Astro.url.pathname));
@@ -38,13 +38,7 @@ let timeStats: { total: number; billable: number } = { total: 0, billable: 0 };
 let meetings: MeetingWithDetails[] = [];
 let unassignedMeetings: Array<{ id: string; meetingType: string; status: string; createdAt: Date }> = [];
 let attachments: ProjectAttachment[] = [];
-let questionnaireBundles: Array<{
-  assignment: any;
-  questions: any[];
-  options: any[];
-  answers: any[];
-  scores: any[];
-}> = [];
+let questionnaireBundles: AssignmentBundle[] = [];
 let dbError = '';
 
 try {

--- a/website/src/pages/admin/tickets/[id].astro
+++ b/website/src/pages/admin/tickets/[id].astro
@@ -4,6 +4,15 @@ import { getSession, getLoginUrl, isAdmin } from '../../../lib/auth';
 import { getTicketDetail, getTicketTimeline } from '../../../lib/tickets/admin';
 import TicketActivityTimeline from '../../../components/admin/TicketActivityTimeline.svelte';
 import TicketActionBar from '../../../components/admin/TicketActionBar.svelte';
+import {
+  listQAssignmentsForProject,
+  listQQuestions,
+  listQAnswerOptionsForTemplate,
+  listQAnswers,
+  listQDimensions,
+} from '../../../lib/questionnaire-db';
+import { computeScores } from '../../../lib/compute-scores';
+import ProjectQuestionnairesPanel, { type AssignmentBundle } from '../../../components/admin/ProjectQuestionnairesPanel.astro';
 
 const session = await getSession(Astro.request.headers.get('cookie'));
 if (!session) return Astro.redirect(getLoginUrl(Astro.url.pathname));
@@ -19,6 +28,27 @@ const [ticket, timeline] = await Promise.all([
 ]);
 
 if (!ticket) return Astro.redirect('/admin/tickets');
+
+let questionnaireBundles: AssignmentBundle[] = [];
+
+// Only fetch for project-type tickets — coaching questionnaires only link to projects.
+if (ticket.type === 'project') {
+  try {
+    const assignments = await listQAssignmentsForProject(ticket.id);
+    questionnaireBundles = await Promise.all(assignments.map(async a => {
+      const [questions, options, answers, dimensions] = await Promise.all([
+        listQQuestions(a.template_id),
+        listQAnswerOptionsForTemplate(a.template_id),
+        listQAnswers(a.id),
+        listQDimensions(a.template_id),
+      ]);
+      return { assignment: a, questions, options, answers, scores: computeScores(dimensions, options, answers) };
+    }));
+  } catch (err) {
+    console.error('[admin/tickets/[id]] questionnaire fetch failed:', err);
+    questionnaireBundles = [];
+  }
+}
 
 const STATUS_LABEL: Record<string, string> = {
   triage: 'Triage', backlog: 'Backlog', in_progress: 'In Arbeit',
@@ -118,6 +148,8 @@ function fmtDateTime(d: Date | string | null): string {
               </p>
             )}
           </div>
+
+          <ProjectQuestionnairesPanel assignments={questionnaireBundles} />
 
           {/* Children tree */}
           {ticket.children.length > 0 && (

--- a/website/src/pages/api/admin/bugs/create.ts
+++ b/website/src/pages/api/admin/bugs/create.ts
@@ -13,12 +13,6 @@ function jsonError(message: string, status: number): Response {
   });
 }
 
-function generateTicketId(): string {
-  const today = new Date().toISOString().slice(0, 10).replace(/-/g, '');
-  const rand = Math.floor(Math.random() * 0x10000).toString(16).padStart(4, '0');
-  return `BR-${today}-${rand}`;
-}
-
 export const POST: APIRoute = async ({ request }) => {
   const session = await getSession(request.headers.get('cookie'));
   if (!session || !isAdmin(session)) {
@@ -45,20 +39,19 @@ export const POST: APIRoute = async ({ request }) => {
     return jsonError('Ungültige Kategorie', 400);
   }
 
-  const ticketId = generateTicketId();
-
+  let ticketId: string;
   try {
-    const rowCount = await insertBugTicket({
-      ticketId,
+    const inserted = await insertBugTicket({
       category,
       reporterEmail: session.email,
       description,
       url: '/admin/monitoring',
       brand: BRAND,
     });
-    if (rowCount === 0) {
-      return jsonError('Ticket-ID-Kollision, bitte erneut versuchen', 500);
+    if (!inserted) {
+      return jsonError('Ticket konnte nicht erstellt werden', 500);
     }
+    ticketId = inserted.ticketId;
   } catch (err) {
     console.error('[bugs/create] DB error:', err);
     return jsonError('Datenbankfehler', 500);

--- a/website/src/pages/api/admin/questionnaires/assign.ts
+++ b/website/src/pages/api/admin/questionnaires/assign.ts
@@ -1,11 +1,12 @@
 import type { APIRoute } from 'astro';
 import { getSession, isAdmin } from '../../../../lib/auth';
 import { getQTemplate, createQAssignment } from '../../../../lib/questionnaire-db';
-import { getCustomerByEmail } from '../../../../lib/website-db';
+import { getCustomerByEmail, createProject } from '../../../../lib/website-db';
 import { getUserById } from '../../../../lib/keycloak';
 import { sendQuestionnaireAssigned } from '../../../../lib/email';
 
 const PROD_DOMAIN = process.env.PROD_DOMAIN || '';
+const BRAND = process.env.BRAND || 'mentolder';
 
 export const POST: APIRoute = async ({ request }) => {
   const session = await getSession(request.headers.get('cookie'));
@@ -28,12 +29,32 @@ export const POST: APIRoute = async ({ request }) => {
   const customer = await getCustomerByEmail(kcUser.email).catch(() => null);
   if (!customer) return new Response(JSON.stringify({ error: 'Kundeneintrag nicht gefunden.' }), { status: 404 });
 
-  const assignment = await createQAssignment({ customerId: customer.id, templateId: tpl.id });
+  const clientName = `${kcUser.firstName ?? ''} ${kcUser.lastName ?? ''}`.trim() || kcUser.username;
+
+  const projectTitle = tpl.is_system_test
+    ? tpl.title
+    : `${tpl.title} — ${clientName}`;
+
+  const projectId = await createProject({
+    brand: BRAND,
+    name: projectTitle,
+    status: 'entwurf',
+    priority: 'mittel',
+    customerId: customer.id,
+  }).catch((err) => {
+    console.error('[assign] project creation failed, continuing without project_id:', err);
+    return null;
+  });
+
+  const assignment = await createQAssignment({
+    customerId: customer.id,
+    templateId: tpl.id,
+    projectId: projectId ?? undefined,
+  });
 
   const portalUrl = PROD_DOMAIN
     ? `https://web.${PROD_DOMAIN}/portal/fragebogen/${assignment.id}`
     : `http://web.localhost/portal/fragebogen/${assignment.id}`;
-  const clientName = `${kcUser.firstName ?? ''} ${kcUser.lastName ?? ''}`.trim() || kcUser.username;
   await sendQuestionnaireAssigned({ clientEmail: kcUser.email, clientName, questionnaireTitle: tpl.title, portalUrl });
 
   return new Response(JSON.stringify(assignment), { status: 201, headers: { 'Content-Type': 'application/json' } });

--- a/website/src/pages/api/admin/questionnaires/assignments/[id].ts
+++ b/website/src/pages/api/admin/questionnaires/assignments/[id].ts
@@ -34,7 +34,7 @@ export const PUT: APIRoute = async ({ request, params }) => {
 
   const body = await request.json() as { status?: string; coach_notes?: string };
   const updated = await updateQAssignment(params.id!, {
-    status: body.status as 'reviewed' | undefined,
+    status: body.status as import('../../../../../lib/questionnaire-db').AssignmentStatus | undefined,
     coachNotes: body.coach_notes,
   });
   if (!updated) return new Response(JSON.stringify({ error: 'Nicht gefunden.' }), { status: 404 });

--- a/website/src/pages/api/admin/questionnaires/assignments/[id]/create-task.ts
+++ b/website/src/pages/api/admin/questionnaires/assignments/[id]/create-task.ts
@@ -1,0 +1,40 @@
+import type { APIRoute } from 'astro';
+import { getSession, isAdmin } from '../../../../../../lib/auth';
+import { getQAssignment, getQQuestion } from '../../../../../../lib/questionnaire-db';
+import { createProjectTask } from '../../../../../../lib/website-db';
+
+export const POST: APIRoute = async ({ request, params }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) return new Response('Unauthorized', { status: 401 });
+
+  const assignment = await getQAssignment(params.id!).catch(() => null);
+  if (!assignment) return new Response(JSON.stringify({ error: 'Auftrag nicht gefunden.' }), { status: 404 });
+  if (!assignment.project_id) {
+    return new Response(JSON.stringify({ error: 'Kein Projekt verknüpft.' }), { status: 409 });
+  }
+
+  const body = await request.json() as { questionId?: string };
+  if (!body.questionId) {
+    return new Response(JSON.stringify({ error: 'questionId erforderlich.' }), { status: 400 });
+  }
+
+  const question = await getQQuestion(body.questionId).catch(() => null);
+  if (!question) return new Response(JSON.stringify({ error: 'Frage nicht gefunden.' }), { status: 404 });
+
+  const taskName = question.question_text.length > 120
+    ? question.question_text.slice(0, 117) + '…'
+    : question.question_text;
+
+  const taskId = await createProjectTask({
+    projectId: assignment.project_id,
+    name: taskName,
+    description: question.test_expected_result ?? undefined,
+    status: 'entwurf',
+    priority: 'mittel',
+  });
+
+  return new Response(JSON.stringify({ taskId }), {
+    status: 201,
+    headers: { 'Content-Type': 'application/json' },
+  });
+};

--- a/website/src/pages/api/admin/questionnaires/assignments/[id]/create-task.ts
+++ b/website/src/pages/api/admin/questionnaires/assignments/[id]/create-task.ts
@@ -21,6 +21,10 @@ export const POST: APIRoute = async ({ request, params }) => {
   const question = await getQQuestion(body.questionId).catch(() => null);
   if (!question) return new Response(JSON.stringify({ error: 'Frage nicht gefunden.' }), { status: 404 });
 
+  if (question.template_id !== assignment.template_id) {
+    return new Response(JSON.stringify({ error: 'Frage gehört nicht zu diesem Auftrag.' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+  }
+
   const taskName = question.question_text.length > 120
     ? question.question_text.slice(0, 117) + '…'
     : question.question_text;

--- a/website/src/pages/api/admin/questionnaires/assignments/[id]/create-task.ts
+++ b/website/src/pages/api/admin/questionnaires/assignments/[id]/create-task.ts
@@ -5,7 +5,7 @@ import { createProjectTask } from '../../../../../../lib/website-db';
 
 export const POST: APIRoute = async ({ request, params }) => {
   const session = await getSession(request.headers.get('cookie'));
-  if (!session || !isAdmin(session)) return new Response('Unauthorized', { status: 401 });
+  if (!session || !isAdmin(session)) return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401, headers: { 'Content-Type': 'application/json' } });
 
   const assignment = await getQAssignment(params.id!).catch(() => null);
   if (!assignment) return new Response(JSON.stringify({ error: 'Auftrag nicht gefunden.' }), { status: 404 });

--- a/website/src/pages/api/bug-report.ts
+++ b/website/src/pages/api/bug-report.ts
@@ -23,12 +23,6 @@ function jsonError(message: string, status: number): Response {
   );
 }
 
-function generateTicketId(): string {
-  const today = new Date().toISOString().slice(0, 10).replace(/-/g, '');
-  const rand = Math.floor(Math.random() * 0x10000).toString(16).padStart(4, '0');
-  return `BR-${today}-${rand}`;
-}
-
 export const POST: APIRoute = async ({ request }) => {
   const ip = getClientIp(request);
   if (!checkRateLimit(`bug-report:${ip}`, 10, 60_000)) {
@@ -79,10 +73,7 @@ export const POST: APIRoute = async ({ request }) => {
       screenshotDataUrls.push(`data:${file.type};base64,${base64}`);
     }
 
-    const ticketId = generateTicketId();
-
-    await insertBugTicket({
-      ticketId,
+    const inserted = await insertBugTicket({
       category,
       reporterEmail: email,
       description,
@@ -90,6 +81,10 @@ export const POST: APIRoute = async ({ request }) => {
       brand: BRAND,
       screenshots: screenshotDataUrls.length > 0 ? screenshotDataUrls : undefined,
     });
+    if (!inserted) {
+      return jsonError('Ticket konnte nicht erstellt werden.', 500);
+    }
+    const ticketId = inserted.ticketId;
 
     await linkReporterByEmail(email).catch(err =>
       console.error('[bug-report] reporter-link failed:', err));

--- a/website/src/pages/api/status.ts
+++ b/website/src/pages/api/status.ts
@@ -1,7 +1,7 @@
 import type { APIRoute } from 'astro';
 import { getBugTicketStatus } from '../../lib/website-db';
 
-const TICKET_RE = /^BR-\d{8}-[0-9a-f]{4}$/;
+const TICKET_RE = /^(T\d{6,}|BR-\d{8}-[0-9a-f]{4})$/;
 
 // Simple in-memory rate limiting: max 10 requests per minute per IP
 const rateLimitMap = new Map<string, { count: number; resetAt: number }>();
@@ -35,7 +35,7 @@ export const GET: APIRoute = async ({ request }) => {
 
   if (!TICKET_RE.test(id)) {
     return new Response(
-      JSON.stringify({ error: 'Ungültiges Ticket-ID-Format. Erwartet: BR-YYYYMMDD-xxxx' }),
+      JSON.stringify({ error: 'Ungültiges Ticket-ID-Format. Erwartet: T000123' }),
       { status: 400, headers: { 'Content-Type': 'application/json' } }
     );
   }

--- a/website/src/pages/status.astro
+++ b/website/src/pages/status.astro
@@ -15,8 +15,8 @@ import Layout from '../layouts/Layout.astro';
           <input
             id="ticket-input"
             type="text"
-            placeholder="BR-20260414-9214"
-            maxlength="18"
+            placeholder="T000123"
+            maxlength="20"
             class="flex-1 px-4 py-2.5 rounded border border-dark-lighter bg-dark text-light focus:border-gold focus:ring-2 focus:ring-gold-dim font-mono text-sm"
           />
           <button


### PR DESCRIPTION
## Summary

Surface linked questionnaire context (questions, answers, scores, coach notes) inline on `/admin/projekte/<id>` and `/admin/tickets/<id>`. Previously the link was one-way: the review page had a "open project" button, but the project page knew nothing about its questionnaire origin.

- New DB helper `listQAssignmentsForProject(projectId)` — reverse lookup, filters out system-test templates.
- New shared `ProjectQuestionnairesPanel.astro` component renders one card per linked assignment: title, status, score bars, coach notes, collapsible Q&A, link to the full review page.
- Embedded on `/admin/projekte/<id>` (above sub-projects on the default tab) and `/admin/tickets/<id>` (after Description, only for `type='project'`).
- Empty array → renders nothing. No new API routes, no schema changes.

This is the reverse of the earlier 'questionnaire → project' work in [PR for `2026-05-08-questionnaire-project-integration-design.md`].

Spec: `docs/superpowers/specs/2026-05-08-project-questionnaire-overview-design.md`
Plan: `docs/superpowers/plans/2026-05-08-project-questionnaire-overview.md`

## Also includes (from earlier on this branch)

- `2d11e49e` fix(tickets): unify ticket numbers as Txxxxxx + repair detail-page SQL
- `d4399c2d` fix(questionnaire): review fixes — template ownership guard, archived status cast, stale ST-4 count, COUNT alias
- `f8c33607` test(system-tests): update expected counts for 12 templates and 103 steps
- `70ff55c6` feat(system-tests): fix stale questions; add ST 11 LiveKit and ST 12 Projektmanagement
- `3c32935e` feat(questionnaire): project badge, task creation, and archive action in review page

## Test plan
- [ ] Open a project that has a completed questionnaire on web.mentolder.de — Fragebögen section renders with title, status, scores, and expandable Q&A.
- [ ] Open the same record under /admin/tickets/<id> — same panel renders in the main column.
- [ ] Open a project without any questionnaire — no section, no empty state.
- [ ] Open a non-project ticket (bug/feature/task) — no questionnaire fetch, no section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)