### PR TITLE
fix(admin/tickets): hide is_test_data rows by default; add toggle

### DIFF
--- a/website/src/lib/tickets/admin.ts
+++ b/website/src/lib/tickets/admin.ts
@@ -112,6 +112,10 @@ export interface ListFilters {
   tagName?: string;
   q?: string;                        // free-text over title + external_id + reporter_email
   parentIsNull?: boolean;            // for the index, hide child tickets by default
+  /** Include `is_test_data=true` rows. Defaults to false — seeded systemtest
+   *  fixtures are kept out of the real triage queue unless explicitly requested
+   *  via the "Inkl. Testdaten" toggle on /admin/tickets. */
+  includeTestData?: boolean;
   limit?: number;
   offset?: number;
 }
@@ -192,6 +196,7 @@ export async function listAdminTickets(f: ListFilters): Promise<ListedTicket[]> 
             OR COALESCE(t.reporter_email,'') ILIKE '%' || $N || '%')`, f.q);
   }
   if (f.parentIsNull) where.push('t.parent_id IS NULL');
+  if (!f.includeTestData) where.push('t.is_test_data = false');
 
   const limit  = Math.min(Math.max(f.limit  ?? 100, 1), 500);
   const offset = Math.max(f.offset ?? 0, 0);
@@ -225,6 +230,7 @@ export async function countAdminTickets(f: ListFilters): Promise<number> {
        OR t.external_id ILIKE '%' || $N || '%'
        OR COALESCE(t.reporter_email,'') ILIKE '%' || $N || '%')`, f.q);
   if (f.parentIsNull) where.push('t.parent_id IS NULL');
+  if (!f.includeTestData) where.push('t.is_test_data = false');
 
   const r = await pool.query<{ count: string }>(
     `SELECT COUNT(*)::text AS count FROM tickets.tickets t WHERE ${where.join(' AND ')}`, vals);
@@ -635,11 +641,12 @@ export async function searchTicketsForLink(brand: string, q: string, limit = 10)
 
 // ── Distinct components for the filter dropdown ─────────────────────────────
 
-export async function listKnownComponents(brand: string): Promise<string[]> {
+export async function listKnownComponents(brand: string, opts: { includeTestData?: boolean } = {}): Promise<string[]> {
   await initTicketsSchema();
+  const filter = opts.includeTestData ? '' : ' AND is_test_data = false';
   const r = await pool.query<{ component: string }>(
     `SELECT DISTINCT component FROM tickets.tickets
-      WHERE brand = $1 AND component IS NOT NULL ORDER BY component`,
+      WHERE brand = $1 AND component IS NOT NULL${filter} ORDER BY component`,
     [brand]);
   return r.rows.map(x => x.component);
 }

--- a/website/src/pages/admin/tickets.astro
+++ b/website/src/pages/admin/tickets.astro
@@ -22,19 +22,22 @@ const customerFilter  = sp.get('customerId') ?? '';
 const tagFilter       = sp.get('tag')        ?? '';
 const thesisFilter    = sp.get('thesisTag')  ?? '';
 const qFilter         = sp.get('q')          ?? '';
+// Hide seeded systemtest fixtures by default; toggle via `?testData=1`.
+const includeTestData = sp.get('testData') === '1';
 
 const filters: ListFilters = {
-  brand:        BRAND,
-  type:         (typeFilter as TicketType) || undefined,
-  status:       statusFilter === 'all' ? undefined : (statusFilter as TicketStatus | 'open'),
-  component:    componentFilter || undefined,
-  assigneeId:   assigneeFilter  || undefined,
-  customerId:   customerFilter  || undefined,
-  thesisTag:    thesisFilter    || undefined,
-  tagName:      tagFilter       || undefined,
-  q:            qFilter         || undefined,
-  parentIsNull: true,
-  limit:        200,
+  brand:           BRAND,
+  type:            (typeFilter as TicketType) || undefined,
+  status:          statusFilter === 'all' ? undefined : (statusFilter as TicketStatus | 'open'),
+  component:       componentFilter || undefined,
+  assigneeId:      assigneeFilter  || undefined,
+  customerId:      customerFilter  || undefined,
+  thesisTag:       thesisFilter    || undefined,
+  tagName:         tagFilter       || undefined,
+  q:               qFilter         || undefined,
+  parentIsNull:    true,
+  includeTestData,
+  limit:           200,
 };
 
 let tickets:   ListedTicket[] = [];
@@ -48,7 +51,7 @@ try {
   [tickets, total, components, customers, admins] = await Promise.all([
     listAdminTickets(filters),
     countAdminTickets(filters),
-    listKnownComponents(BRAND),
+    listKnownComponents(BRAND, { includeTestData }),
     listAllCustomers(),
     listAdminUsers(),
   ]);
@@ -85,7 +88,8 @@ function buildLink(ov: Record<string, string | undefined>): string {
   const p = new URLSearchParams();
   const keep = { type: typeFilter, status: statusFilter, component: componentFilter,
                  assigneeId: assigneeFilter, customerId: customerFilter,
-                 thesisTag: thesisFilter, tag: tagFilter, q: qFilter };
+                 thesisTag: thesisFilter, tag: tagFilter, q: qFilter,
+                 testData: includeTestData ? '1' : '' };
   const merged = { ...keep, ...ov };
   for (const [k, v] of Object.entries(merged)) if (v) p.set(k, String(v));
   const qs = p.toString();
@@ -200,6 +204,11 @@ const SAVED_VIEWS: { label: string; href: string }[] = [
             placeholder="Tag-Name"
             class="px-3 py-1.5 bg-dark-light border border-dark-lighter text-sm text-light rounded-lg w-36" />
         </div>
+        <label class="flex items-center gap-2 px-3 py-1.5 bg-dark-light border border-dark-lighter rounded-lg text-sm text-muted cursor-pointer select-none whitespace-nowrap">
+          <input type="checkbox" name="testData" value="1" checked={includeTestData}
+            class="accent-gold cursor-pointer" />
+          Inkl. Testdaten
+        </label>
         <button type="submit"
           class="px-4 py-1.5 bg-gold/20 text-gold rounded-lg text-sm hover:bg-gold/30 transition-colors">
           Filtern


### PR DESCRIPTION
## Summary
- After PR #591, the 2 systemtest grouping epics still appeared in `/admin/tickets?status=open` (status='in_progress', is_test_data=true, 0 open children) — visual noise next to the 1 real triage ticket.
- Default `is_test_data=false` filter on listAdminTickets / countAdminTickets / listKnownComponents.
- "Inkl. Testdaten" checkbox in the filter form (`?testData=1`) brings them back on demand.

## Test plan
- [x] `astro check` clean for changed files
- [ ] After deploy: `/admin/tickets?status=open` shows 8 rows (7 manual projects + 1 real bug); the 2 EPIC-SYS-* rows are hidden
- [ ] Tick "Inkl. Testdaten" → row count rises to 10, epics reappear

🤖 Generated with [Claude Code](https://claude.com/claude-code)