### PR TITLE
feat(systemtest): enable SYSTEMTEST_LOOP_ENABLED on mentolder + korczewski

### DIFF
--- a/environments/korczewski.yaml
+++ b/environments/korczewski.yaml
@@ -45,9 +45,8 @@ env_vars:
   WEBSITE_HOST: web.korczewski.de
   WEBSITE_SITE_URL: "https://web.korczewski.de"
   KEYCLOAK_FRONTEND_URL: "https://auth.korczewski.de"
-  # System-test failure loop master kill-switch (Task 10). Flip to "true"
-  # only after running the rollout checklist on the feat/systemtest-failure-loop PR.
-  SYSTEMTEST_LOOP_ENABLED: "false"
+  # System-test failure loop master kill-switch (Task 10).
+  SYSTEMTEST_LOOP_ENABLED: "true"
 
 overlay: prod-korczewski
 workspace_namespace: workspace-korczewski

--- a/environments/mentolder.yaml
+++ b/environments/mentolder.yaml
@@ -45,9 +45,8 @@ env_vars:
   WEBSITE_HOST: web.mentolder.de
   WEBSITE_SITE_URL: "https://web.mentolder.de"
   KEYCLOAK_FRONTEND_URL: "https://auth.mentolder.de"
-  # System-test failure loop master kill-switch (Task 10). Flip to "true"
-  # only after running the rollout checklist on the feat/systemtest-failure-loop PR.
-  SYSTEMTEST_LOOP_ENABLED: "false"
+  # System-test failure loop master kill-switch (Task 10).
+  SYSTEMTEST_LOOP_ENABLED: "true"
 
 overlay: prod-mentolder
 workspace_namespace: workspace


### PR DESCRIPTION
## Summary
- Flips `SYSTEMTEST_LOOP_ENABLED` from `false` to `true` in both `environments/mentolder.yaml` and `environments/korczewski.yaml`.
- Activates `/admin/systemtest/board`, the `[Seed]` button on `/admin/fragebogen`, and the rrweb recorder.
- Schema bootstrap + cleanup CronJobs were already running as no-ops; they now have real fixtures to operate on.

## Test plan
- [x] `task env:validate ENV=mentolder` + `task env:validate ENV=korczewski` pass
- [ ] After merge: `task feature:website` rolls both clusters
- [ ] `/admin/systemtest/board` returns 200 (not the `systemtest-loop-disabled` redirect) on both domains
- [ ] Walk through Fragebögen end-to-end on web.mentolder.de

🤖 Generated with [Claude Code](https://claude.com/claude-code)