### PR TITLE
feat(questionnaires): admin Reopen action for full re-runs

### DIFF
--- a/website/src/lib/questionnaire-db.ts
+++ b/website/src/lib/questionnaire-db.ts
@@ -575,6 +575,87 @@ export async function dismissQAssignment(id: string, reason: string): Promise<QA
   return updateQAssignment(id, { status: 'dismissed', dismissReason: reason });
 }
 
+/**
+ * Reset a finished assignment so it can be filled out again.
+ *
+ * Reopen path used by the admin "Erneut durchführen" button on
+ * `/admin/fragebogen/[assignmentId].astro`. Wipes the previous answers,
+ * clears all completion timestamps, and bumps `retest_attempt` for every
+ * `test_step` question in the template so the next [Seed] click partitions
+ * fresh fixtures from prior runs.
+ *
+ * Coach notes are preserved — they're admin commentary, not user answers.
+ * Test evidence rows (rrweb recordings) stay too: they're audit trail keyed
+ * by `(question_id, attempt)` and survive across re-runs.
+ *
+ * Returns `null` when no assignment exists with that id, or `{ reason: ... }`
+ * when the status isn't reopen-able. Returns the updated assignment + the
+ * number of test-status rows bumped on success.
+ */
+export async function reopenQAssignment(id: string): Promise<
+  | { assignment: QAssignment; testStatusBumped: number }
+  | { reason: 'not_found' | 'not_reopenable'; status?: AssignmentStatus }
+> {
+  const REOPENABLE: AssignmentStatus[] = ['submitted', 'reviewed', 'archived', 'dismissed'];
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+    const a = await client.query<{ template_id: string; status: AssignmentStatus }>(
+      `SELECT template_id, status FROM questionnaire_assignments
+        WHERE id = $1 FOR UPDATE`,
+      [id],
+    );
+    if (a.rows.length === 0) {
+      await client.query('ROLLBACK');
+      return { reason: 'not_found' };
+    }
+    const status = a.rows[0].status;
+    if (!REOPENABLE.includes(status)) {
+      await client.query('ROLLBACK');
+      return { reason: 'not_reopenable', status };
+    }
+    const templateId = a.rows[0].template_id;
+
+    await client.query(
+      `UPDATE questionnaire_assignments
+          SET status = 'pending',
+              submitted_at = NULL,
+              reviewed_at = NULL,
+              archived_at = NULL,
+              dismissed_at = NULL,
+              dismiss_reason = NULL
+        WHERE id = $1`,
+      [id],
+    );
+
+    await client.query(
+      `DELETE FROM questionnaire_answers WHERE assignment_id = $1`,
+      [id],
+    );
+
+    const bump = await client.query(
+      `UPDATE questionnaire_test_status qts
+          SET retest_attempt    = qts.retest_attempt + 1,
+              retest_pending_at = COALESCE(qts.retest_pending_at, now())
+         FROM questionnaire_questions qq
+        WHERE qts.question_id = qq.id
+          AND qq.template_id = $1
+          AND qq.question_type = 'test_step'`,
+      [templateId],
+    );
+
+    await client.query('COMMIT');
+    const updated = await getQAssignment(id);
+    if (!updated) return { reason: 'not_found' };
+    return { assignment: updated, testStatusBumped: bump.rowCount ?? 0 };
+  } catch (e) {
+    await client.query('ROLLBACK').catch(() => {});
+    throw e;
+  } finally {
+    client.release();
+  }
+}
+
 export async function countPendingQAssignmentsForCustomer(customerId: string): Promise<number> {
   const r = await pool.query(
     `SELECT COUNT(*)::int AS count FROM questionnaire_assignments

--- a/website/src/pages/admin/fragebogen/[assignmentId].astro
+++ b/website/src/pages/admin/fragebogen/[assignmentId].astro
@@ -330,6 +330,14 @@ const maxScore = Math.max(...scores.map(s => s.threshold_high ?? s.final_score ?
               Archivieren
             </button>
           )}
+          {(assignment.status === 'submitted' || assignment.status === 'reviewed' || assignment.status === 'archived' || assignment.status === 'dismissed') && (
+            <button id="reopen-btn"
+              data-testid="reopen-questionnaire"
+              class="px-4 py-2 bg-amber-700 text-white rounded-lg text-sm font-semibold hover:bg-amber-600 transition-colors"
+              title={isSystemTest ? 'Antworten löschen, retest_attempt hochzählen, Fragebogen erneut starten.' : 'Antworten löschen und Fragebogen erneut zuweisen.'}>
+              Erneut durchführen ↻
+            </button>
+          )}
         </div>
         <p id="notes-msg" class="text-xs mt-2 hidden"></p>
       </div>
@@ -429,6 +437,38 @@ const maxScore = Math.max(...scores.map(s => s.threshold_high ?? s.final_score ?
       body: JSON.stringify({ status: 'archived' }),
     });
     if (r.ok) window.location.reload();
+  });
+
+  // Reopen — wipe answers + reset to pending, then jump to portal wizard
+  const reopenBtn = document.getElementById('reopen-btn');
+  reopenBtn?.addEventListener('click', async () => {
+    const ok = window.confirm(
+      'Diesen Fragebogen erneut durchführen? Bisherige Antworten werden gelöscht (Coach-Notizen bleiben). Bei System-Tests bekommen alle Test-Schritte einen neuen Retest-Versuch — alte Fixtures werden vom Cleanup-Job entfernt.',
+    );
+    if (!ok) return;
+    reopenBtn.disabled = true;
+    reopenBtn.textContent = 'Wird zurückgesetzt …';
+    try {
+      const r = await fetch(`/api/admin/questionnaires/assignments/${assignmentId}/reopen`, {
+        method: 'POST',
+      });
+      const d = await r.json().catch(() => ({}));
+      if (!r.ok) {
+        reopenBtn.disabled = false;
+        reopenBtn.textContent = 'Erneut durchführen ↻';
+        msgEl.textContent = d.error || 'Fehler beim Zurücksetzen.';
+        msgEl.className = 'text-xs mt-2 text-red-400';
+        msgEl.classList.remove('hidden');
+        return;
+      }
+      window.location.href = `/portal/fragebogen/${assignmentId}`;
+    } catch {
+      reopenBtn.disabled = false;
+      reopenBtn.textContent = 'Erneut durchführen ↻';
+      msgEl.textContent = 'Netzwerkfehler.';
+      msgEl.className = 'text-xs mt-2 text-red-400';
+      msgEl.classList.remove('hidden');
+    }
   });
 
   document.getElementById('bug-modal-submit')?.addEventListener('click', async () => {

--- a/website/src/pages/api/admin/questionnaires/assignments/[id]/reopen.ts
+++ b/website/src/pages/api/admin/questionnaires/assignments/[id]/reopen.ts
@@ -1,0 +1,31 @@
+import type { APIRoute } from 'astro';
+import { getSession, isAdmin } from '../../../../../../lib/auth';
+import { reopenQAssignment } from '../../../../../../lib/questionnaire-db';
+
+const PROD_DOMAIN = process.env.PROD_DOMAIN || '';
+
+export const POST: APIRoute = async ({ request, params }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) return new Response('Unauthorized', { status: 401 });
+  if (!params.id) return new Response(JSON.stringify({ error: 'id missing' }), { status: 400 });
+
+  const result = await reopenQAssignment(params.id);
+  if ('reason' in result) {
+    if (result.reason === 'not_found') {
+      return new Response(JSON.stringify({ error: 'Nicht gefunden.' }), { status: 404 });
+    }
+    return new Response(JSON.stringify({
+      error: `Fragebogen kann im Status '${result.status}' nicht wieder geöffnet werden.`,
+    }), { status: 409 });
+  }
+
+  const portalUrl = PROD_DOMAIN
+    ? `https://web.${PROD_DOMAIN}/portal/fragebogen/${result.assignment.id}`
+    : `/portal/fragebogen/${result.assignment.id}`;
+
+  return new Response(JSON.stringify({
+    assignment: result.assignment,
+    testStatusBumped: result.testStatusBumped,
+    portalUrl,
+  }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+};


### PR DESCRIPTION
## Summary
- New `POST /api/admin/questionnaires/assignments/[id]/reopen` endpoint resets status → pending, NULLs `submitted_at` / `reviewed_at` / `archived_at` / `dismissed_at`, deletes prior answers, and bumps `retest_attempt` on each `test_step` question in the template.
- New "Erneut durchführen ↻" button on `/admin/fragebogen/[assignmentId].astro` — visible when status is submitted/reviewed/archived/dismissed. Confirms, calls the API, then jumps to `/portal/fragebogen/<id>` for a fresh fill-out.
- Skips the assign-API path (which would spawn a placeholder project ticket each rerun); reuses the existing assignment + customer + project_id link.

## Test plan
- [ ] Open an admin view of a submitted system-test assignment, click **Erneut durchführen ↻**, confirm.
- [ ] Verify portal wizard loads at step 1 with no pre-filled answers.
- [ ] Run a [Seed] step — confirm a new Keycloak user is created (different from the previous attempt).
- [ ] Submit and verify `retest_attempt` increment in `questionnaire_test_status`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)