### PR TITLE
fix(admin/newsletter): wrap preview + send in branded template with legal footer (T000173)

### DIFF
--- a/website/src/components/admin/NewsletterAdmin.svelte
+++ b/website/src/components/admin/NewsletterAdmin.svelte
@@ -122,6 +122,36 @@
   let sending = $state(false);
   let nextAusgabe = $state('');
 
+  // Server-rendered preview HTML (matches the actual outbound send 1:1).
+  // We render via /api/admin/newsletter/preview so preview and send share the
+  // same branded wrapper + legal footer (fixes T000173 / T000171).
+  let previewHtml = $state('');
+  let previewDebounce: ReturnType<typeof setTimeout> | null = null;
+
+  async function refreshPreview() {
+    try {
+      const res = await fetch('/api/admin/newsletter/preview', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ subject: composeSubject, html_body: composeHtml }),
+      });
+      previewHtml = res.ok
+        ? await res.text()
+        : '<p style="color:#a33;font-family:sans-serif;padding:20px;">Vorschau konnte nicht geladen werden.</p>';
+    } catch {
+      previewHtml = '<p style="color:#a33;font-family:sans-serif;padding:20px;">Vorschau-Fehler (Verbindung).</p>';
+    }
+  }
+
+  $effect(() => {
+    if (activeTab !== 'compose') return;
+    // Track the deps Svelte needs to know about (synchronous reads).
+    void composeSubject;
+    void composeHtml;
+    if (previewDebounce) clearTimeout(previewDebounce);
+    previewDebounce = setTimeout(refreshPreview, 250);
+  });
+
   async function loadNextAusgabe() {
     try {
       const res = await fetch('/api/admin/newsletter/campaigns');
@@ -369,12 +399,14 @@
       </button>
     </div>
 
-    <!-- Preview — full DIN-A4 page (794 × 1123 px) -->
+    <!-- Preview — full DIN-A4 page (794 × 1123 px). Server-rendered with
+         the SAME branded wrapper the outbound send uses (header + Pflicht-
+         Footer mit Anbieterkennzeichnung + Abmelde-Link). -->
     <div class="overflow-x-auto">
       <div>
-        <p class="text-sm text-muted mb-1">Vorschau (DIN A4)</p>
+        <p class="text-sm text-muted mb-1">Vorschau (1:1 wie versendet)</p>
         <iframe
-          srcdoc={composeHtml || '<p style="color:#666;font-family:sans-serif;padding:20px;">Vorschau erscheint hier…</p>'}
+          srcdoc={previewHtml || '<p style="color:#666;font-family:sans-serif;padding:20px;">Vorschau erscheint hier…</p>'}
           title="E-Mail Vorschau"
           style="width: 794px; height: 1123px"
           class="rounded-xl border border-dark-lighter bg-white block"

--- a/website/src/lib/email.ts
+++ b/website/src/lib/email.ts
@@ -2,6 +2,7 @@
 // Uses Mailpit in dev (localhost:1025), real SMTP in prod.
 
 import nodemailer from 'nodemailer';
+import { renderNewsletterEmail, renderNewsletterText } from './newsletter-template';
 
 const SMTP_HOST = process.env.SMTP_HOST || 'mailpit.workspace.svc.cluster.local';
 const SMTP_PORT = parseInt(process.env.SMTP_PORT || '1025');
@@ -170,20 +171,30 @@ export async function sendNewsletterCampaign(params: {
   html: string;
   unsubscribeUrl: string;
 }): Promise<boolean> {
-  const footerHtml = `
-<hr style="margin:32px 0;border:none;border-top:1px solid #333;">
-<p style="font-size:12px;color:#888;">
-  Du erhältst diese E-Mail, weil du den Newsletter von ${FROM_NAME} abonniert hast.
-  <a href="${params.unsubscribeUrl}" style="color:#888;">Abmelden</a>
-</p>`;
-  const footerText = `\n\n---\nDu erhältst diese E-Mail, weil du den Newsletter von ${FROM_NAME} abonniert hast.\nAbmelden: ${params.unsubscribeUrl}`;
-  const htmlWithFooter = params.html + footerHtml;
-  const textWithFooter = params.html.replace(/<[^>]+>/g, '') + footerText;
+  // Wrap user-authored content in the shared branded template (header + body
+  // + mandatory legal footer). This is the SAME wrapper the admin preview
+  // endpoint uses — preview and send must never diverge (T000173 / T000171).
+  const htmlWithFooter = renderNewsletterEmail({
+    bodyHtml: params.html,
+    subject: params.subject,
+    unsubscribeUrl: params.unsubscribeUrl,
+  });
+  const textWithFooter = renderNewsletterText({
+    bodyHtml: params.html,
+    subject: params.subject,
+    unsubscribeUrl: params.unsubscribeUrl,
+  });
   return sendEmail({
     to: params.to,
     subject: params.subject,
     text: textWithFooter,
     html: htmlWithFooter,
+    headers: {
+      // RFC 8058 / RFC 2369 — one-click unsubscribe header pair.
+      // Many providers (Gmail, Apple Mail) require this for newsletters.
+      'List-Unsubscribe': `<${params.unsubscribeUrl}>`,
+      'List-Unsubscribe-Post': 'List-Unsubscribe=One-Click',
+    },
   });
 }
 

--- a/website/src/lib/newsletter-template.test.ts
+++ b/website/src/lib/newsletter-template.test.ts
@@ -1,0 +1,154 @@
+// Snapshot-style tests for the branded newsletter template.
+//
+// Regression tests for T000173 / T000171 — the preview iframe used to render
+// raw HTML without header or legal footer. These tests assert that BOTH a
+// brand header AND the mandatory Anbieterkennzeichnung + unsubscribe link are
+// always present in the rendered HTML, for both brands.
+
+import { describe, expect, it } from 'vitest';
+import { renderNewsletterEmail, renderNewsletterText } from './newsletter-template';
+
+const mentolderBrand = {
+  brandName: 'Mentolder',
+  brandId: 'mentolder',
+  contactName: 'Gerald Korczewski',
+  contactEmail: 'info@mentolder.de',
+  contactPhone: '+49 151 508 32 601',
+  legalStreet: 'Ludwig-Erhard-Str. 18',
+  legalZip: '20459',
+  legalCity: 'Hamburg',
+  legalJobtitle: 'Coach und digitaler Begleiter',
+  legalUstId: '33/023/05100',
+  legalWebsite: 'mentolder.de',
+};
+
+const korczewskiBrand = {
+  brandName: 'Patrick Korczewski',
+  brandId: 'korczewski',
+  contactName: 'Patrick Korczewski',
+  contactEmail: 'info@korczewski.de',
+  contactPhone: '+49 151 000 00 000',
+  legalStreet: 'In der Twiet 4',
+  legalZip: '21360',
+  legalCity: 'Vögelsen',
+  legalJobtitle: 'Software Engineer, IT-Security-Berater',
+  legalUstId: 'Kleinunternehmer gem. § 19 Abs. 1 UStG',
+  legalWebsite: 'korczewski.de',
+};
+
+describe('renderNewsletterEmail', () => {
+  const baseParams = {
+    bodyHtml: '<h1>Hallo!</h1><p>Newsletter-Inhalt.</p>',
+    subject: 'Test-Betreff',
+    unsubscribeUrl: 'https://web.mentolder.de/api/newsletter/unsubscribe?token=abc123',
+  };
+
+  it('returns a complete HTML document', () => {
+    const html = renderNewsletterEmail(baseParams, mentolderBrand);
+    expect(html).toMatch(/^<!doctype html>/i);
+    expect(html).toContain('<html lang="de">');
+    expect(html).toContain('</html>');
+    expect(html).toContain('<title>Test-Betreff</title>');
+  });
+
+  it('includes the brand header with brand name', () => {
+    const html = renderNewsletterEmail(baseParams, mentolderBrand);
+    expect(html).toContain('Mentolder');
+    expect(html).toContain('Coach und digitaler Begleiter');
+  });
+
+  it('includes the user-authored body content untouched', () => {
+    const html = renderNewsletterEmail(baseParams, mentolderBrand);
+    expect(html).toContain('<h1>Hallo!</h1>');
+    expect(html).toContain('<p>Newsletter-Inhalt.</p>');
+  });
+
+  it('includes the mandatory unsubscribe link', () => {
+    const html = renderNewsletterEmail(baseParams, mentolderBrand);
+    expect(html).toContain('https://web.mentolder.de/api/newsletter/unsubscribe?token=abc123');
+    expect(html.toLowerCase()).toContain('abmelden');
+  });
+
+  it('includes the full legal Anbieterkennzeichnung (UWG/TMG §5)', () => {
+    const html = renderNewsletterEmail(baseParams, mentolderBrand);
+    // Name, address, contact, USt-ID
+    expect(html).toContain('Gerald Korczewski');
+    expect(html).toContain('Ludwig-Erhard-Str. 18');
+    expect(html).toContain('20459 Hamburg');
+    expect(html).toContain('info@mentolder.de');
+    expect(html).toContain('+49 151 508 32 601');
+    expect(html).toContain('33/023/05100');
+    expect(html).toContain('mentolder.de');
+  });
+
+  it('renders the korczewski brand independently (different brand color + legal data)', () => {
+    const html = renderNewsletterEmail(baseParams, korczewskiBrand);
+    expect(html).toContain('Patrick Korczewski');
+    expect(html).toContain('In der Twiet 4');
+    expect(html).toContain('21360 Vögelsen');
+    expect(html).toContain('Kleinunternehmer gem. § 19 Abs. 1 UStG');
+    // korczewski uses a sage/teal accent, not brass
+    expect(html).toMatch(/#1f3b3b/);
+    expect(html).not.toMatch(/background:#b8973a/);
+  });
+
+  it('shows the preview banner when isPreview is set', () => {
+    const html = renderNewsletterEmail({ ...baseParams, isPreview: true }, mentolderBrand);
+    expect(html.toLowerCase()).toContain('vorschau');
+  });
+
+  it('does NOT show the preview banner for actual sends', () => {
+    const html = renderNewsletterEmail(baseParams, mentolderBrand);
+    expect(html).not.toMatch(/Vorschau — diese Ansicht/);
+  });
+
+  it('escapes HTML-unsafe characters in the unsubscribe URL', () => {
+    const html = renderNewsletterEmail(
+      { ...baseParams, unsubscribeUrl: 'https://x/?a=1&b=<script>' },
+      mentolderBrand,
+    );
+    expect(html).not.toContain('<script>');
+    expect(html).toContain('&lt;script&gt;');
+  });
+
+  it('degrades gracefully when legal env vars are missing', () => {
+    const html = renderNewsletterEmail(baseParams, {
+      brandName: 'Workspace',
+      brandId: 'mentolder',
+      contactName: '',
+      contactEmail: '',
+      contactPhone: '',
+      legalStreet: '',
+      legalZip: '',
+      legalCity: '',
+      legalJobtitle: '',
+      legalUstId: '',
+      legalWebsite: '',
+    });
+    // Even without legal data, the unsubscribe link MUST always be present.
+    expect(html).toContain(baseParams.unsubscribeUrl);
+    expect(html.toLowerCase()).toContain('abmelden');
+    // And the body still renders.
+    expect(html).toContain('<h1>Hallo!</h1>');
+  });
+});
+
+describe('renderNewsletterText', () => {
+  it('strips HTML and appends legal footer + unsubscribe URL', () => {
+    const text = renderNewsletterText(
+      {
+        bodyHtml: '<h1>Hallo!</h1><p>Inhalt.</p>',
+        subject: 'X',
+        unsubscribeUrl: 'https://web.mentolder.de/api/newsletter/unsubscribe?token=abc',
+      },
+      mentolderBrand,
+    );
+    expect(text).toContain('Hallo!');
+    expect(text).toContain('Inhalt.');
+    expect(text).not.toContain('<h1>');
+    expect(text).toContain('Abmelden:');
+    expect(text).toContain('https://web.mentolder.de/api/newsletter/unsubscribe?token=abc');
+    expect(text).toContain('Gerald Korczewski');
+    expect(text).toContain('Ludwig-Erhard-Str. 18');
+  });
+});

--- a/website/src/lib/newsletter-template.ts
+++ b/website/src/lib/newsletter-template.ts
@@ -1,0 +1,190 @@
+// Branded transactional-email wrapper for newsletters.
+//
+// Used by BOTH the admin preview iframe (`/api/admin/newsletter/preview`)
+// and the actual outbound campaign send (`lib/email.ts → sendNewsletterCampaign`).
+// Keeping a single source of truth here is the entire point of fixing T000173 /
+// T000171: previously the preview wrapped user HTML in a stub `<html><body>...`
+// while the send path tacked on only a minimal footer — neither matched and
+// neither carried the brand header or the German UWG / DSGVO mandatory legal
+// footer (full Anbieterkennzeichnung + Abmelde-Link).
+//
+// All brand data is read from `process.env` per the "Legal data single source"
+// rule in CLAUDE.md — no hardcoded addresses, phone numbers, or domains.
+
+export interface NewsletterTemplateParams {
+  /** User-authored HTML body (already AUSGABE-replaced for send, raw for preview). */
+  bodyHtml: string;
+  /** Subject line — used for the `<title>` tag. */
+  subject: string;
+  /**
+   * Absolute unsubscribe URL. For the live preview we substitute a sample token
+   * so the footer looks identical to the real send.
+   */
+  unsubscribeUrl: string;
+  /** Optional: render a "this is just a preview" banner above the content. */
+  isPreview?: boolean;
+}
+
+interface BrandLegalData {
+  brandName: string;
+  brandId: string;
+  contactName: string;
+  contactEmail: string;
+  contactPhone: string;
+  legalStreet: string;
+  legalZip: string;
+  legalCity: string;
+  legalJobtitle: string;
+  legalUstId: string;
+  legalWebsite: string;
+}
+
+/**
+ * Pure function — gets a snapshot of brand/legal env vars. Exposed so unit
+ * tests can stub it via dependency injection (`renderNewsletterEmail({...},
+ * stubbedBrand)`) without touching the global `process.env`.
+ */
+export function readBrandFromEnv(): BrandLegalData {
+  return {
+    brandName: process.env.BRAND_NAME || process.env.FROM_NAME || 'Workspace',
+    brandId: process.env.BRAND_ID || process.env.BRAND || 'mentolder',
+    contactName: process.env.CONTACT_NAME || '',
+    contactEmail: process.env.CONTACT_EMAIL || '',
+    contactPhone: process.env.CONTACT_PHONE || '',
+    legalStreet: process.env.LEGAL_STREET || '',
+    legalZip: process.env.LEGAL_ZIP || '',
+    legalCity: process.env.CONTACT_CITY || '',
+    legalJobtitle: process.env.LEGAL_JOBTITLE || '',
+    legalUstId: process.env.LEGAL_UST_ID || '',
+    legalWebsite: process.env.LEGAL_WEBSITE || process.env.PROD_DOMAIN || '',
+  };
+}
+
+const escAttr = (s: string): string =>
+  s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+
+const escText = (s: string): string =>
+  s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+
+/**
+ * Render the full branded newsletter as a complete HTML document.
+ * Output includes:
+ *   - `<html><head><title>...` with subject
+ *   - branded header (brand name + tagline / job title)
+ *   - main content slot (the user-authored bodyHtml, untouched)
+ *   - mandatory footer with legal address (Anbieterkennzeichnung), unsubscribe link
+ */
+export function renderNewsletterEmail(
+  params: NewsletterTemplateParams,
+  brand: BrandLegalData = readBrandFromEnv(),
+): string {
+  const { bodyHtml, subject, unsubscribeUrl, isPreview } = params;
+  const brandColor = brand.brandId === 'korczewski' ? '#1f3b3b' : '#b8973a';
+  const brandColorMuted = brand.brandId === 'korczewski' ? '#5b7a7a' : '#9b7e2f';
+
+  const addressLine = [brand.legalStreet, [brand.legalZip, brand.legalCity].filter(Boolean).join(' ')]
+    .filter(Boolean)
+    .join(', ');
+
+  const previewBanner = isPreview
+    ? `<div style="background:#fff3cd;border-bottom:1px solid #ffe49a;color:#664d03;padding:8px 16px;font:13px/1.4 system-ui,sans-serif;text-align:center;">
+  Vorschau — diese Ansicht entspricht der versendeten E-Mail (1:1).
+</div>`
+    : '';
+
+  const headerHtml = `<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:${brandColor};">
+  <tr>
+    <td style="padding:24px 32px;">
+      <div style="font:600 22px/1.2 Georgia,'Newsreader',serif;color:#fff;">
+        ${escText(brand.brandName)}
+      </div>
+      ${
+        brand.legalJobtitle
+          ? `<div style="font:14px/1.4 system-ui,sans-serif;color:rgba(255,255,255,0.85);margin-top:4px;">${escText(brand.legalJobtitle)}</div>`
+          : ''
+      }
+    </td>
+  </tr>
+</table>`;
+
+  // Mandatory legal footer (German UWG §6 Abs. 2 Nr. 1 + TMG §5 Anbieterkennzeichnung).
+  // Includes: Name, Anschrift, Kontakt, USt-ID/Steuernummer, Berufsbezeichnung,
+  // and the mandatory unsubscribe link. Address fields fall back gracefully
+  // if any env var is missing — but the unsubscribe link is ALWAYS rendered.
+  const footerHtml = `<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:#f5f3ee;border-top:3px solid ${brandColor};">
+  <tr>
+    <td style="padding:24px 32px;font:13px/1.6 system-ui,sans-serif;color:#4a4a4a;">
+      <p style="margin:0 0 12px 0;">
+        Du erhältst diese E-Mail, weil du den Newsletter von
+        <strong>${escText(brand.brandName)}</strong> abonniert hast.
+        <a href="${escAttr(unsubscribeUrl)}" style="color:${brandColorMuted};">Hier abmelden</a>.
+      </p>
+      <hr style="border:none;border-top:1px solid #ddd6c8;margin:12px 0;">
+      <p style="margin:0;font-size:12px;color:#6b6b6b;">
+        <strong>Anbieter</strong><br>
+        ${brand.contactName ? escText(brand.contactName) + '<br>' : ''}
+        ${brand.legalJobtitle ? escText(brand.legalJobtitle) + '<br>' : ''}
+        ${addressLine ? escText(addressLine) + '<br>' : ''}
+        ${
+          brand.contactEmail
+            ? `E-Mail: <a href="mailto:${escAttr(brand.contactEmail)}" style="color:${brandColorMuted};">${escText(brand.contactEmail)}</a><br>`
+            : ''
+        }
+        ${brand.contactPhone ? `Telefon: ${escText(brand.contactPhone)}<br>` : ''}
+        ${brand.legalUstId ? `Steuer-Nr. / USt-ID: ${escText(brand.legalUstId)}<br>` : ''}
+        ${brand.legalWebsite ? `Web: <a href="https://${escAttr(brand.legalWebsite)}" style="color:${brandColorMuted};">${escText(brand.legalWebsite)}</a>` : ''}
+      </p>
+    </td>
+  </tr>
+</table>`;
+
+  return `<!doctype html>
+<html lang="de">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>${escText(subject)}</title>
+</head>
+<body style="margin:0;padding:0;background:#e8e4d8;font-family:system-ui,sans-serif;">
+${previewBanner}
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:#e8e4d8;padding:24px 0;">
+  <tr>
+    <td align="center">
+      <table role="presentation" width="600" cellpadding="0" cellspacing="0" style="max-width:600px;width:100%;background:#fff;border-radius:8px;overflow:hidden;box-shadow:0 2px 8px rgba(0,0,0,0.06);">
+        <tr><td>${headerHtml}</td></tr>
+        <tr>
+          <td style="padding:32px;font:16px/1.6 system-ui,sans-serif;color:#1a1a1a;">
+            ${bodyHtml}
+          </td>
+        </tr>
+        <tr><td>${footerHtml}</td></tr>
+      </table>
+    </td>
+  </tr>
+</table>
+</body>
+</html>`;
+}
+
+/**
+ * Plain-text counterpart for the multipart/alternative `text` slot.
+ * Strips HTML tags from bodyHtml and appends the legal footer + unsubscribe link.
+ */
+export function renderNewsletterText(
+  params: NewsletterTemplateParams,
+  brand: BrandLegalData = readBrandFromEnv(),
+): string {
+  const { bodyHtml, unsubscribeUrl } = params;
+  const plain = bodyHtml.replace(/<style[\s\S]*?<\/style>/gi, '').replace(/<[^>]+>/g, '').trim();
+  const addressLine = [brand.legalStreet, [brand.legalZip, brand.legalCity].filter(Boolean).join(' ')]
+    .filter(Boolean)
+    .join(', ');
+  return `${plain}
+
+---
+Du erhältst diese E-Mail, weil du den Newsletter von ${brand.brandName} abonniert hast.
+Abmelden: ${unsubscribeUrl}
+
+Anbieter:
+${brand.contactName ? brand.contactName + '\n' : ''}${brand.legalJobtitle ? brand.legalJobtitle + '\n' : ''}${addressLine ? addressLine + '\n' : ''}${brand.contactEmail ? 'E-Mail: ' + brand.contactEmail + '\n' : ''}${brand.contactPhone ? 'Telefon: ' + brand.contactPhone + '\n' : ''}${brand.legalUstId ? 'Steuer-Nr. / USt-ID: ' + brand.legalUstId + '\n' : ''}${brand.legalWebsite ? 'Web: https://' + brand.legalWebsite : ''}`;
+}

--- a/website/src/pages/api/admin/newsletter/preview.ts
+++ b/website/src/pages/api/admin/newsletter/preview.ts
@@ -1,0 +1,56 @@
+// Server-side newsletter preview — returns the SAME branded wrapper that the
+// outbound send path uses (lib/newsletter-template.ts). Fixes T000173 / T000171,
+// where the admin iframe rendered raw HTML without header or legal footer
+// while the actual send had a (different, minimal) footer — divergence between
+// preview and send is the most insidious form of this bug.
+
+import type { APIRoute } from 'astro';
+import { getSession, isAdmin } from '../../../../lib/auth';
+import { renderNewsletterEmail } from '../../../../lib/newsletter-template';
+import { countSentCampaigns } from '../../../../lib/newsletter-db';
+
+export const POST: APIRoute = async ({ request }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 });
+  }
+
+  let body: { subject?: string; html_body?: string };
+  try {
+    body = await request.json();
+  } catch {
+    return new Response(JSON.stringify({ error: 'Invalid JSON' }), { status: 400 });
+  }
+
+  const subject = String(body.subject ?? '').trim() || '(ohne Betreff)';
+  const rawHtml = String(body.html_body ?? '').trim();
+
+  // Match the substitution the send path performs — preview must be 1:1.
+  let ausgabe = '01';
+  try {
+    const sentCount = await countSentCampaigns();
+    ausgabe = String(sentCount + 1).padStart(2, '0');
+  } catch {
+    // DB unavailable in dev or tests: fall back to '01' so the preview still renders.
+  }
+  const renderedBody = rawHtml.replace(/\{\{AUSGABE\}\}/g, ausgabe);
+
+  const prodDomain = process.env.PROD_DOMAIN || '';
+  const baseUrl = prodDomain ? `https://web.${prodDomain}` : 'http://web.localhost';
+  const unsubscribeUrl = `${baseUrl}/api/newsletter/unsubscribe?token=PREVIEW`;
+
+  const html = renderNewsletterEmail({
+    bodyHtml: renderedBody,
+    subject,
+    unsubscribeUrl,
+    isPreview: true,
+  });
+
+  return new Response(html, {
+    headers: {
+      'Content-Type': 'text/html; charset=utf-8',
+      // Prevent any caching — preview must reflect the current draft.
+      'Cache-Control': 'no-store',
+    },
+  });
+};


### PR DESCRIPTION
## Summary

The admin newsletter preview iframe rendered raw user HTML via `srcdoc={composeHtml}`,
omitting the brand header, the mandatory Anbieterkennzeichnung (UWG/TMG §5), and the
legally required Abmelde-Link. The actual send path tacked on only a minimal one-line
footer — preview and send diverged, and both were missing legally required content.

This PR introduces a single shared template (`lib/newsletter-template.ts`) that wraps
user content with brand header, body, and a full Pflicht-Footer (Anbieterkennzeichnung +
unsubscribe link), reading all legal data from `process.env` per the env-driven brand
config. A new server endpoint `/api/admin/newsletter/preview` returns the exact same
rendered HTML that subscribers will receive — preview is now 1:1 with send.

- Single source of truth: both preview and `sendNewsletterCampaign` go through `renderNewsletterEmail()`.
- Brand-aware: switches accent color and legal data based on `BRAND_ID` (mentolder vs korczewski).
- Legal: full Anbieterkennzeichnung block (Name, Anschrift, USt-ID/Steuer-Nr., Berufsbezeichnung) + unsubscribe link, with RFC 8058 `List-Unsubscribe` header on outbound mail.
- 11 vitest cases asserting header + Anbieterkennzeichnung + unsubscribe presence for both brands, including escape-safety and graceful degradation when env vars are missing.

Closes T000173
Closes T000171

## Test plan

- [x] `npx vitest run src/lib/newsletter-template.test.ts` — 11 passed
- [x] `npx vitest run` — 244 passed, 72 skipped (no regressions)
- [x] `task test:all` — exit 0
- [x] `npx astro check` — no new errors from changed files (16 pre-existing errors unrelated)
- [ ] Open `/admin/inhalte` newsletter tab in dev: type subject + body, verify the iframe shows the branded header and the full legal footer with unsubscribe link
- [ ] Send a test campaign to a confirmed test subscriber via Mailpit; verify the rendered email matches the preview 1:1

🤖 Generated with [Claude Code](https://claude.com/claude-code)