### PR TITLE
fix(admin/inbox): createBillingInvoice 500 on booking confirmation (T000172)

### DIFF
--- a/website/src/lib/stripe-billing.test.ts
+++ b/website/src/lib/stripe-billing.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+// Mock native-billing to avoid hitting the DB. The whole point of this test is
+// to verify the createBillingInvoice shim translates SERVICES + ServiceKey into
+// the correct native-billing createInvoice call — which used to throw, breaking
+// /api/admin/inbox/[id]/action.ts (T000172, T000170).
+vi.mock('./native-billing', () => ({
+  createCustomer: vi.fn(),
+  createInvoice: vi.fn(),
+  getCustomerById: vi.fn(),
+}));
+
+// website-db's pool is lazy (new Pool() doesn't connect), and initBillingTables
+// is only called inside discardDraftInvoice / get*Invoice paths we don't test
+// here, so no mock needed for the shim under test.
+
+import { createBillingInvoice, SERVICES } from './stripe-billing';
+import * as nativeBilling from './native-billing';
+
+const mockedNative = nativeBilling as unknown as {
+  createInvoice: ReturnType<typeof vi.fn>;
+  getCustomerById: ReturnType<typeof vi.fn>;
+};
+
+describe('createBillingInvoice (booking-confirmation shim)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedNative.getCustomerById.mockResolvedValue({
+      id: 'cust-1', brand: 'mentolder', name: 'Test', email: 't@e.de', landIso: 'DE',
+    });
+    mockedNative.createInvoice.mockResolvedValue({
+      id: 'inv-1', brand: 'mentolder', number: 'RE-2026-0001', status: 'draft',
+      customerId: 'cust-1', issueDate: '2026-05-08', dueDate: '2026-05-22',
+      taxMode: 'regelbesteuerung', netAmount: 60, taxRate: 19, taxAmount: 11.4,
+      grossAmount: 71.4, locked: false, currency: 'EUR', currencyRate: null,
+      netAmountEur: 60, grossAmountEur: 71.4, kind: 'regular',
+    });
+  });
+
+  it('does not throw — regression for T000172/T000170', async () => {
+    const promise = createBillingInvoice({
+      customerId: 'cust-1',
+      serviceKey: '50plus-digital-einzel',
+    });
+    await expect(promise).resolves.toBeDefined();
+  });
+
+  it('converts SERVICES.cents to euros for the line unitPrice', async () => {
+    await createBillingInvoice({
+      customerId: 'cust-1',
+      serviceKey: '50plus-digital-einzel', // cents: 6000 → €60
+    });
+    expect(mockedNative.createInvoice).toHaveBeenCalledTimes(1);
+    const args = mockedNative.createInvoice.mock.calls[0][0];
+    expect(args.lines).toHaveLength(1);
+    expect(args.lines[0].unitPrice).toBe(60);
+    expect(args.lines[0].description).toBe(SERVICES['50plus-digital-einzel'].name);
+    expect(args.lines[0].unit).toBe(SERVICES['50plus-digital-einzel'].unit);
+  });
+
+  it('returns a BillingInvoice shape compatible with action.ts callers', async () => {
+    const inv = await createBillingInvoice({
+      customerId: 'cust-1',
+      serviceKey: 'coaching-session',
+    });
+    // action.ts reads invoice.id, invoice.number, invoice.amountDue.
+    expect(inv.id).toBe('inv-1');
+    expect(inv.number).toBe('RE-2026-0001');
+    expect(inv.amountDue).toBe(71.4);
+    expect(inv.status).toBe('draft');
+  });
+
+  it('throws a clear error for unknown serviceKey', async () => {
+    await expect(
+      createBillingInvoice({ customerId: 'cust-1', serviceKey: 'nope' as never }),
+    ).rejects.toThrow(/unknown serviceKey/);
+  });
+
+  it('throws for free-tier services (cents=0) instead of issuing zero-EUR invoices', async () => {
+    await expect(
+      createBillingInvoice({ customerId: 'cust-1', serviceKey: 'erstgespraech' }),
+    ).rejects.toThrow(/no chargeable price/);
+  });
+
+  it('throws if customer is not found in the brand (FK guard)', async () => {
+    mockedNative.getCustomerById.mockResolvedValueOnce(null);
+    await expect(
+      createBillingInvoice({ customerId: 'missing', serviceKey: 'coaching-session' }),
+    ).rejects.toThrow(/customer missing not found/);
+  });
+
+  it('honours the quantity parameter', async () => {
+    await createBillingInvoice({
+      customerId: 'cust-1',
+      serviceKey: 'coaching-session',
+      quantity: 3,
+    });
+    const args = mockedNative.createInvoice.mock.calls[0][0];
+    expect(args.lines[0].quantity).toBe(3);
+  });
+});

--- a/website/src/lib/stripe-billing.ts
+++ b/website/src/lib/stripe-billing.ts
@@ -1,5 +1,9 @@
 import { pool, initBillingTables } from './website-db';
-import { createCustomer as nativeCreateCustomer } from './native-billing';
+import {
+  createCustomer as nativeCreateCustomer,
+  createInvoice as nativeCreateInvoice,
+  getCustomerById as nativeGetCustomerById,
+} from './native-billing';
 
 // ---- Static service catalog ----
 export const SERVICES = {
@@ -221,9 +225,69 @@ export async function getFullInvoice(invoiceId: string): Promise<FullInvoice | n
   return getDraftInvoiceDetail(invoiceId);
 }
 
-// Stub functions — these workflows moved to /api/admin/billing/* routes
-export async function createBillingInvoice(_params: unknown): Promise<BillingInvoice> {
-  throw new Error('createBillingInvoice: use /api/admin/billing/ native routes instead');
+/**
+ * Creates a draft invoice in the native billing system for a single service line.
+ *
+ * This is the compatibility shim that callers from the booking-confirmation flow
+ * (admin/inbox/[id]/action.ts → approve_booking) and the admin CreateInvoiceModal
+ * use. The legacy name comes from the pre-2026 Stripe integration; today it
+ * delegates to native-billing's `createInvoice`.
+ *
+ * SERVICES.cents is in cents — convert to euros (the unit native-billing stores
+ * in `unit_price`). The returned shape mirrors `BillingInvoice` so existing
+ * callers (which read `id`, `number`, `amountDue`) keep working unchanged.
+ */
+export async function createBillingInvoice(params: {
+  customerId: string;
+  serviceKey: ServiceKey;
+  quantity?: number;
+  sendEmail?: boolean;
+}): Promise<BillingInvoice> {
+  const brand = process.env.BRAND || 'mentolder';
+  const service = SERVICES[params.serviceKey];
+  if (!service) throw new Error(`createBillingInvoice: unknown serviceKey "${params.serviceKey}"`);
+  if (service.cents <= 0) {
+    throw new Error(`createBillingInvoice: service "${params.serviceKey}" has no chargeable price`);
+  }
+
+  // Verify the customer exists in this brand to fail fast with a clear message
+  // instead of a foreign-key violation deep inside the INSERT.
+  const customer = await nativeGetCustomerById(brand, params.customerId);
+  if (!customer) {
+    throw new Error(`createBillingInvoice: customer ${params.customerId} not found for brand ${brand}`);
+  }
+
+  const quantity = params.quantity ?? 1;
+  const unitPriceEur = service.cents / 100;
+
+  const inv = await nativeCreateInvoice({
+    brand,
+    customerId: params.customerId,
+    issueDate: new Date().toISOString().split('T')[0],
+    dueDays: 14,
+    taxMode: 'regelbesteuerung',
+    taxRate: 19,
+    lines: [{
+      description: service.name,
+      quantity,
+      unitPrice: unitPriceEur,
+      unit: service.unit,
+    }],
+  });
+
+  return {
+    id: inv.id,
+    number: inv.number,
+    date: inv.issueDate,
+    dueDate: inv.dueDate,
+    amountDue: inv.grossAmount,
+    amountPaid: 0,
+    amountRemaining: inv.grossAmount,
+    status: 'draft',
+    statusLabel: STATUS_LABELS.draft ?? 'Entwurf',
+    hostedUrl: null,
+    pdfUrl: null,
+  };
 }
 
 export async function createBillingQuote(_params: unknown): Promise<unknown> {

--- a/website/src/pages/api/admin/inbox/[id]/action.ts
+++ b/website/src/pages/api/admin/inbox/[id]/action.ts
@@ -153,19 +153,24 @@ export const POST: APIRoute = async ({ request, params }) => {
         const svcKey = (p.serviceKey ?? p.leistungKey) as ServiceKey | undefined;
         if (svcKey && svcKey in SERVICES && SERVICES[svcKey].cents > 0) {
           const brand = process.env.BRAND || 'mentolder';
-          const stripeCustomer = await getOrCreateCustomer({ brand: process.env.BRAND || 'mentolder', name: p.name, email: p.email });
-          if (stripeCustomer) {
-            const invoice = await createBillingInvoice({ customerId: stripeCustomer.id, serviceKey: svcKey });
-            if (invoice) {
+          try {
+            const billingCustomer = await getOrCreateCustomer({ brand, name: p.name, email: p.email });
+            if (billingCustomer) {
+              const invoice = await createBillingInvoice({ customerId: billingCustomer.id, serviceKey: svcKey });
               statusParts.push(`Rechnung erstellt: ${invoice.number}`);
               if (calEvent) {
                 await setBookingInvoice(calEvent.uid, brand, invoice.id, invoice.number, invoice.amountDue).catch(err =>
                   console.error('[approve_booking] Failed to link invoice to booking:', err)
                 );
               }
-            } else {
-              statusParts.push('Rechnung konnte nicht erstellt werden (Stripe nicht konfiguriert?)');
             }
+          } catch (err) {
+            // Invoice creation must not abort the booking confirmation — the
+            // Talk room, calendar event, and confirmation email are already
+            // committed at this point. Log it and surface a status hint so the
+            // caller still gets HTTP 200 with details.
+            console.error('[approve_booking] Failed to create billing invoice:', err);
+            statusParts.push('Rechnung konnte nicht erstellt werden (siehe Logs)');
           }
         }
 


### PR DESCRIPTION
## Summary

The booking-confirmation flow in `/api/admin/inbox/[id]/action.ts` (`approve_booking`) imported and called `createBillingInvoice` from `lib/stripe-billing.ts` whenever a paid `serviceKey` was attached to the booking. That function was a leftover stub from the Stripe removal — it unconditionally threw `Error: createBillingInvoice: use /api/admin/billing/ native routes instead`. Result: every "✓ Bestätigen" click on a paid booking returned HTTP 500 and the Mailpit confirmation email was never sent.

## Root cause

`lib/stripe-billing.ts` retained the `createBillingInvoice` symbol as a placeholder after the Stripe → native-billing migration. Action.ts (and `/api/billing/create-invoice`) still imported the original API. Nothing pointed callers at the new native flow.

## Fix

- Replace the throwing stub with a real implementation that delegates to `native-billing.createInvoice`: cents → euros, default 19% Regelbesteuerung, 14-day due, single-line invoice from `SERVICES[serviceKey]`. The returned `BillingInvoice` shape is unchanged so existing callers don't move.
- Wrap the invoice block in `action.ts` in a try/catch so a billing failure no longer rolls back the confirmation after the Talk room, calendar event, and confirmation email are already committed. Status hint is added to the response.
- New unit test `website/src/lib/stripe-billing.test.ts` (7 cases) locks in the contract: shape compatibility, cent→euro conversion, unknown-service rejection, missing-customer guard, free-tier rejection, quantity passthrough.

## Test plan

- [x] `npm run test:unit` (vitest) — 240 passed, 72 skipped (DB-gated), 0 failed; new file 7/7 pass
- [x] `task test:all` — exit 0
- [x] `npx astro check` — 0 new errors in changed files (pre-existing errors in unrelated files only)
- [ ] Manual: confirm a booking with `serviceKey: '50plus-digital-einzel'` from `/admin/inbox` after deploy returns 200 with `Rechnung erstellt: RE-…` and Mailpit receives the confirmation mail

Closes T000172
Closes T000170

🤖 Generated with [Claude Code](https://claude.com/claude-code)