### PR TITLE
fix(admin/calendar): persist + render Termine/Meetings; fix month/week view

### DIFF
--- a/website/src/components/admin/AdminMeetingModal.svelte
+++ b/website/src/components/admin/AdminMeetingModal.svelte
@@ -1,0 +1,276 @@
+<script lang="ts">
+  // Admin "Neues Meeting" modal — used on /admin/meetings.
+  // Closes T000161, T000164.
+  interface ClientOption {
+    id: string;
+    name: string;
+    email: string;
+  }
+  interface Project { id: string; name: string }
+
+  let {
+    projects = [],
+    buttonLabel = '＋ Neues Meeting',
+  }: {
+    projects?: Project[];
+    buttonLabel?: string;
+  } = $props();
+
+  let open = $state(false);
+  let submitting = $state(false);
+  let error = $state('');
+  let success = $state('');
+
+  let clients = $state<ClientOption[]>([]);
+  let clientsLoaded = $state(false);
+  let clientSearch = $state('');
+  let selectedClient = $state<ClientOption | null>(null);
+
+  // Allow free-form attendee entry too (some meetings are with external folks).
+  let manualName = $state('');
+  let manualEmail = $state('');
+
+  let title = $state('');
+  let projectId = $state('');
+  let meetingDate = $state('');
+  let meetingTime = $state('10:00');
+  let durationMinutes = $state(60);
+  const DURATIONS = [15, 30, 45, 60, 90, 120];
+
+  const filteredClients = $derived(
+    clientSearch.length < 1
+      ? clients
+      : clients.filter(
+          c =>
+            c.name.toLowerCase().includes(clientSearch.toLowerCase()) ||
+            c.email.toLowerCase().includes(clientSearch.toLowerCase())
+        )
+  );
+
+  function openModal() {
+    open = true;
+    resetForm();
+    if (!clientsLoaded) loadClients();
+  }
+  function closeModal() {
+    if (submitting) return;
+    open = false;
+  }
+  function resetForm() {
+    selectedClient = null;
+    clientSearch = '';
+    manualName = '';
+    manualEmail = '';
+    title = '';
+    projectId = '';
+    const now = new Date();
+    const tomorrow = new Date(now.getTime() + 24 * 60 * 60_000);
+    meetingDate = tomorrow.toISOString().split('T')[0];
+    meetingTime = '10:00';
+    durationMinutes = 60;
+    error = '';
+    success = '';
+  }
+
+  async function loadClients() {
+    try {
+      const res = await fetch('/api/admin/clients-list');
+      if (res.ok) clients = await res.json();
+    } catch {
+      // bleibt leer
+    } finally {
+      clientsLoaded = true;
+    }
+  }
+
+  async function submit() {
+    error = '';
+    const customerName = (selectedClient?.name ?? manualName).trim();
+    const customerEmail = (selectedClient?.email ?? manualEmail).trim();
+    if (!customerName) { error = 'Teilnehmer-Name ist Pflicht.'; return; }
+    if (!customerEmail) { error = 'Teilnehmer-E-Mail ist Pflicht.'; return; }
+    if (!meetingDate || !meetingTime) { error = 'Datum + Uhrzeit sind Pflicht.'; return; }
+
+    const [h, m] = meetingTime.split(':').map(Number);
+    const dt = new Date(meetingDate);
+    dt.setHours(h, m, 0, 0);
+    if (Number.isNaN(dt.getTime())) {
+      error = 'Datum/Uhrzeit ungültig.';
+      return;
+    }
+
+    submitting = true;
+    try {
+      const res = await fetch('/api/admin/meetings/create', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          customerName,
+          customerEmail,
+          meetingType: title.trim() || 'Meeting',
+          scheduledAt: dt.toISOString(),
+          durationMinutes,
+          projectId: projectId || null,
+        }),
+      });
+      const data = await res.json();
+      if (!res.ok || !data.success) {
+        error = data.error ?? 'Unbekannter Fehler.';
+        submitting = false;
+        return;
+      }
+      success = data.calendarPersisted
+        ? 'Meeting angelegt und im Kalender eingetragen.'
+        : 'Meeting angelegt (Kalendereintrag fehlgeschlagen).';
+      submitting = false;
+      document.dispatchEvent(new CustomEvent('admin-meeting-created'));
+      setTimeout(() => {
+        closeModal();
+        // refresh page so the new meeting appears in the list
+        window.location.reload();
+      }, 1200);
+    } catch {
+      error = 'Netzwerkfehler.';
+      submitting = false;
+    }
+  }
+</script>
+
+<button
+  onclick={openModal}
+  data-testid="admin-meeting-new"
+  class="px-4 py-2 bg-gold text-dark text-sm font-semibold rounded-lg hover:bg-gold/90 transition-colors"
+>
+  {buttonLabel}
+</button>
+
+{#if open}
+  <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
+  <div
+    class="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/60 backdrop-blur-sm"
+    onclick={(e) => { if (e.target === e.currentTarget) closeModal(); }}
+  >
+    <div class="w-full max-w-lg bg-dark rounded-2xl border border-dark-lighter shadow-2xl overflow-hidden">
+      <div class="flex items-center justify-between px-6 py-4 border-b border-dark-lighter">
+        <h2 class="text-lg font-bold text-light font-serif">Neues Meeting</h2>
+        <button onclick={closeModal} class="text-muted hover:text-light transition-colors text-xl leading-none">✕</button>
+      </div>
+
+      <div class="px-6 py-5 space-y-4 max-h-[80vh] overflow-y-auto">
+        {#if error}
+          <div class="p-3 bg-red-500/10 border border-red-500/30 rounded-lg text-red-400 text-sm">{error}</div>
+        {/if}
+        {#if success}
+          <div class="p-3 bg-green-500/10 border border-green-500/30 rounded-lg text-green-400 text-sm">{success}</div>
+        {/if}
+
+        <div>
+          <label for="meeting-title" class="block text-xs text-muted uppercase tracking-wide mb-1">Titel</label>
+          <input
+            id="meeting-title"
+            type="text"
+            bind:value={title}
+            placeholder="z.B. Kennenlern-Termin, Strategie, Coaching…"
+            class="w-full bg-dark-light border border-dark-lighter rounded-lg px-3 py-2 text-light text-sm focus:border-gold outline-none"
+          />
+        </div>
+
+        <div>
+          <span class="block text-xs text-muted uppercase tracking-wide mb-1">Teilnehmer</span>
+          {#if selectedClient}
+            <div class="flex items-center gap-2 px-3 py-2 bg-dark-light border border-gold/40 rounded-lg text-sm">
+              <span class="text-light flex-1">{selectedClient.name} <span class="text-muted">· {selectedClient.email}</span></span>
+              <button onclick={() => { selectedClient = null; clientSearch = ''; }} class="text-muted hover:text-light text-xs">✕</button>
+            </div>
+          {:else}
+            <input
+              type="text"
+              placeholder="Bestehenden Client suchen (Name oder E-Mail)…"
+              bind:value={clientSearch}
+              class="w-full bg-dark border border-dark-lighter rounded-lg px-3 py-2 text-light text-sm focus:border-gold outline-none"
+            />
+            {#if clientSearch.length > 0 && filteredClients.length > 0}
+              <div class="mt-1 bg-dark border border-dark-lighter rounded-lg overflow-hidden max-h-40 overflow-y-auto">
+                {#each filteredClients as c}
+                  <button
+                    onclick={() => { selectedClient = c; clientSearch = ''; }}
+                    class="w-full text-left px-3 py-2 text-sm text-light hover:bg-dark-light transition-colors"
+                  >
+                    {c.name} <span class="text-muted">· {c.email}</span>
+                  </button>
+                {/each}
+              </div>
+            {/if}
+            <div class="mt-2 grid grid-cols-2 gap-2">
+              <input
+                type="text"
+                placeholder="oder Name"
+                bind:value={manualName}
+                class="bg-dark border border-dark-lighter rounded-lg px-3 py-2 text-light text-sm focus:border-gold outline-none"
+              />
+              <input
+                type="email"
+                placeholder="oder E-Mail"
+                bind:value={manualEmail}
+                class="bg-dark border border-dark-lighter rounded-lg px-3 py-2 text-light text-sm focus:border-gold outline-none"
+              />
+            </div>
+          {/if}
+        </div>
+
+        {#if projects.length > 0}
+          <div>
+            <label for="meeting-project" class="block text-xs text-muted uppercase tracking-wide mb-1">Projekt <span class="normal-case text-muted/60">(optional)</span></label>
+            <select id="meeting-project" bind:value={projectId}
+              class="w-full bg-dark border border-dark-lighter rounded-lg px-3 py-2 text-light text-sm focus:border-gold outline-none">
+              <option value="">— Kein Projekt —</option>
+              {#each projects as p}
+                <option value={p.id}>{p.name}</option>
+              {/each}
+            </select>
+          </div>
+        {/if}
+
+        <div class="grid grid-cols-2 gap-3">
+          <div>
+            <label for="meeting-date" class="block text-xs text-muted uppercase tracking-wide mb-1">Datum</label>
+            <input id="meeting-date" type="date" bind:value={meetingDate}
+              class="w-full bg-dark border border-dark-lighter rounded-lg px-3 py-2 text-light text-sm focus:border-gold outline-none" />
+          </div>
+          <div>
+            <label for="meeting-time" class="block text-xs text-muted uppercase tracking-wide mb-1">Uhrzeit</label>
+            <input id="meeting-time" type="time" bind:value={meetingTime}
+              class="w-full bg-dark border border-dark-lighter rounded-lg px-3 py-2 text-light text-sm focus:border-gold outline-none" />
+          </div>
+        </div>
+
+        <div>
+          <label for="meeting-duration" class="block text-xs text-muted uppercase tracking-wide mb-1">Dauer</label>
+          <select id="meeting-duration" bind:value={durationMinutes}
+            class="w-full bg-dark border border-dark-lighter rounded-lg px-3 py-2 text-light text-sm focus:border-gold outline-none">
+            {#each DURATIONS as d}
+              <option value={d}>{d} Minuten</option>
+            {/each}
+          </select>
+        </div>
+      </div>
+
+      <div class="flex justify-end gap-3 px-6 py-4 border-t border-dark-lighter">
+        <button
+          onclick={closeModal}
+          disabled={submitting}
+          class="px-4 py-2 text-sm text-muted hover:text-light transition-colors disabled:opacity-50"
+        >
+          Abbrechen
+        </button>
+        <button
+          onclick={submit}
+          disabled={submitting}
+          class="px-5 py-2 bg-gold text-dark rounded-lg text-sm font-semibold hover:bg-gold/80 transition-colors disabled:opacity-50"
+        >
+          {submitting ? '…' : 'Meeting anlegen'}
+        </button>
+      </div>
+    </div>
+  </div>
+{/if}

--- a/website/src/lib/website-db.ts
+++ b/website/src/lib/website-db.ts
@@ -2425,6 +2425,52 @@ export async function listProjectsInMonth(year: number, month: number, brand?: s
   return result.rows;
 }
 
+// ── Calendar Meetings (range query) ───────────────────────────────────────────
+
+export interface CalendarMeeting {
+  id: string;
+  meetingType: string;
+  status: string;
+  scheduledAt: Date;
+  customerId: string;
+  customerName: string;
+  customerEmail: string;
+  talkRoomToken: string | null;
+  projectId: string | null;
+  projectName: string | null;
+}
+
+/**
+ * Returns all meetings whose `scheduled_at` falls inside the inclusive range
+ * `[fromIso, toIso]`. Used by the admin calendar to render meetings alongside
+ * tasks, projects and CalDAV bookings (T000161, T000164, T000167).
+ */
+export async function listMeetingsInRange(fromIso: string, toIso: string): Promise<CalendarMeeting[]> {
+  await initMeetingProjectLink();
+  const result = await pool.query<CalendarMeeting>(
+    `SELECT m.id,
+            m.meeting_type AS "meetingType",
+            m.status,
+            m.scheduled_at AS "scheduledAt",
+            m.customer_id  AS "customerId",
+            m.talk_room_token AS "talkRoomToken",
+            c.name  AS "customerName",
+            c.email AS "customerEmail",
+            p.id    AS "projectId",
+            p.title AS "projectName"
+       FROM meetings m
+       JOIN customers c ON m.customer_id = c.id
+       LEFT JOIN tickets.tickets p ON m.project_id = p.id
+      WHERE m.scheduled_at IS NOT NULL
+        AND m.scheduled_at >= $1::timestamptz
+        AND m.scheduled_at <= $2::timestamptz
+        AND m.status NOT IN ('cancelled')
+      ORDER BY m.scheduled_at ASC`,
+    [fromIso, toIso]
+  );
+  return result.rows;
+}
+
 // ── Bug Ticket List ───────────────────────────────────────────────────────────
 
 export interface BugTicketRow {

--- a/website/src/pages/admin/kalender.astro
+++ b/website/src/pages/admin/kalender.astro
@@ -1,8 +1,8 @@
 ---
 import AdminLayout from '../../layouts/AdminLayout.astro';
 import { getSession, getLoginUrl, isAdmin } from '../../lib/auth';
-import { listTasksInMonth, listProjectsInMonth } from '../../lib/website-db';
-import type { CalendarTask, CalendarProject } from '../../lib/website-db';
+import { listTasksInMonth, listProjectsInMonth, listMeetingsInRange } from '../../lib/website-db';
+import type { CalendarTask, CalendarProject, CalendarMeeting } from '../../lib/website-db';
 import { getAllBookings } from '../../lib/caldav';
 import type { AdminBooking } from '../../lib/caldav';
 
@@ -12,21 +12,58 @@ if (!isAdmin(session)) return Astro.redirect('/admin');
 
 const brand = process.env.BRAND_NAME || process.env.BRAND || 'mentolder';
 
+// ── View mode (T000167: Monats-/Wochenansicht) ────────────────────────────
+const viewQ = (Astro.url.searchParams.get('view') ?? 'month').toLowerCase();
+const view: 'month' | 'week' = viewQ === 'week' ? 'week' : 'month';
+
 const now    = new Date();
 const yearQ  = parseInt(Astro.url.searchParams.get('year')  ?? String(now.getFullYear()), 10);
 const monthQ = parseInt(Astro.url.searchParams.get('month') ?? String(now.getMonth() + 1), 10);
+const dayQ   = parseInt(Astro.url.searchParams.get('day')   ?? String(now.getDate()), 10);
 const year   = isNaN(yearQ)  ? now.getFullYear()  : yearQ;
 const month  = isNaN(monthQ) ? now.getMonth() + 1 : Math.max(1, Math.min(12, monthQ));
+const day    = isNaN(dayQ)   ? now.getDate()      : Math.max(1, Math.min(31, dayQ));
+
+// Range to query (inclusive). Month view = full month.
+// Week view = the Monday-anchored week containing the {year, month, day}.
+function startOfWeek(d: Date): Date {
+  const out = new Date(d);
+  const day = out.getDay(); // 0=Sun … 6=Sat
+  const offsetToMonday = (day + 6) % 7;
+  out.setDate(out.getDate() - offsetToMonday);
+  out.setHours(0, 0, 0, 0);
+  return out;
+}
+
+let rangeStart: Date;
+let rangeEnd: Date;
+let weekStart: Date;
+if (view === 'week') {
+  weekStart = startOfWeek(new Date(year, month - 1, day));
+  rangeStart = new Date(weekStart);
+  rangeEnd = new Date(weekStart);
+  rangeEnd.setDate(rangeEnd.getDate() + 6);
+  rangeEnd.setHours(23, 59, 59, 999);
+} else {
+  rangeStart = new Date(year, month - 1, 1);
+  rangeEnd   = new Date(year, month, 0, 23, 59, 59, 999);
+  // For week-view nav buttons we still need a sensible weekStart.
+  weekStart = startOfWeek(rangeStart);
+}
 
 let tasks: CalendarTask[] = [];
 let projects: CalendarProject[] = [];
+let meetings: CalendarMeeting[] = [];
 let bookings: AdminBooking[] = [];
 let dbError = '';
 
 try {
-  [tasks, projects] = await Promise.all([
-    listTasksInMonth(year, month),
-    listProjectsInMonth(year, month, brand),
+  // For month view we keep the existing month-scoped queries; for week view
+  // we still use the month query (cheap on small datasets) and filter.
+  [tasks, projects, meetings] = await Promise.all([
+    listTasksInMonth(rangeStart.getFullYear(), rangeStart.getMonth() + 1),
+    listProjectsInMonth(rangeStart.getFullYear(), rangeStart.getMonth() + 1, brand),
+    listMeetingsInRange(rangeStart.toISOString(), rangeEnd.toISOString()),
   ]);
 } catch (err) {
   console.error('[admin/kalender] db', err);
@@ -35,40 +72,39 @@ try {
 
 try {
   const all = await getAllBookings();
-  const firstDay = new Date(year, month - 1, 1);
-  const lastDay  = new Date(year, month, 0, 23, 59, 59);
-  bookings = all.filter(b => b.start >= firstDay && b.start <= lastDay && b.status !== 'CANCELLED');
+  bookings = all.filter(b => b.start >= rangeStart && b.start <= rangeEnd && b.status !== 'CANCELLED');
 } catch (err) {
   console.error('[admin/kalender] caldav', err);
 }
 
-const firstDay     = new Date(year, month - 1, 1);
-const lastDay      = new Date(year, month, 0);
-const startWeekday = (firstDay.getDay() + 6) % 7; // Mon=0
-const totalDays    = lastDay.getDate();
-
-// Group tasks by day
-const tasksByDay = new Map<number, CalendarTask[]>();
-for (const t of tasks) {
-  const d = new Date(t.dueDate).getUTCDate();
-  if (!tasksByDay.has(d)) tasksByDay.set(d, []);
-  tasksByDay.get(d)!.push(t);
+// ── Bucket items by calendar day (YYYY-MM-DD) ─────────────────────────────
+type DayKey = string;
+function dayKey(d: Date): DayKey {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const dd = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${dd}`;
 }
 
-// Group projects by day (start_date and due_date separately)
+const tasksByDay = new Map<DayKey, CalendarTask[]>();
+for (const t of tasks) {
+  const dt = new Date(t.dueDate);
+  const k = dayKey(dt);
+  if (!tasksByDay.has(k)) tasksByDay.set(k, []);
+  tasksByDay.get(k)!.push(t);
+}
+
 interface ProjectEntry { project: CalendarProject; kind: 'start' | 'due' }
-const projectsByDay = new Map<number, ProjectEntry[]>();
+const projectsByDay = new Map<DayKey, ProjectEntry[]>();
 for (const p of projects) {
   const addDay = (date: Date | null, kind: 'start' | 'due') => {
     if (!date) return;
-    const d = new Date(date).getUTCDate();
-    const mo = new Date(date).getUTCMonth() + 1;
-    if (mo !== month) return;
-    if (!projectsByDay.has(d)) projectsByDay.set(d, []);
-    projectsByDay.get(d)!.push({ project: p, kind });
+    const dt = new Date(date);
+    const k = dayKey(dt);
+    if (!projectsByDay.has(k)) projectsByDay.set(k, []);
+    projectsByDay.get(k)!.push({ project: p, kind });
   };
   addDay(p.startDate, 'start');
-  // avoid duplicate entry if start == due
   if (p.dueDate && p.startDate && new Date(p.dueDate).toDateString() !== new Date(p.startDate).toDateString()) {
     addDay(p.dueDate, 'due');
   } else if (p.dueDate && !p.startDate) {
@@ -76,19 +112,34 @@ for (const p of projects) {
   }
 }
 
-// Group bookings by day
-const bookingsByDay = new Map<number, AdminBooking[]>();
-for (const b of bookings) {
-  const d = b.start.getDate();
-  if (!bookingsByDay.has(d)) bookingsByDay.set(d, []);
-  bookingsByDay.get(d)!.push(b);
+const meetingsByDay = new Map<DayKey, CalendarMeeting[]>();
+for (const m of meetings) {
+  const k = dayKey(new Date(m.scheduledAt));
+  if (!meetingsByDay.has(k)) meetingsByDay.set(k, []);
+  meetingsByDay.get(k)!.push(m);
 }
 
-function navUrl(y: number, m: number): string {
-  if (m < 1)  { y--; m = 12; }
-  if (m > 12) { y++; m = 1; }
-  return `/admin/kalender?year=${y}&month=${m}`;
+const bookingsByDay = new Map<DayKey, AdminBooking[]>();
+for (const b of bookings) {
+  const k = dayKey(b.start);
+  if (!bookingsByDay.has(k)) bookingsByDay.set(k, []);
+  bookingsByDay.get(k)!.push(b);
 }
+
+// ── Navigation URLs ───────────────────────────────────────────────────────
+function monthNavUrl(deltaMonths: number): string {
+  let y = year, m = month + deltaMonths;
+  while (m < 1)  { y--; m += 12; }
+  while (m > 12) { y++; m -= 12; }
+  return `/admin/kalender?view=month&year=${y}&month=${m}`;
+}
+function weekNavUrl(deltaDays: number): string {
+  const d = new Date(weekStart);
+  d.setDate(d.getDate() + deltaDays);
+  return `/admin/kalender?view=week&year=${d.getFullYear()}&month=${d.getMonth() + 1}&day=${d.getDate()}`;
+}
+const todayWeekUrl = `/admin/kalender?view=week&year=${now.getFullYear()}&month=${now.getMonth() + 1}&day=${now.getDate()}`;
+const todayMonthUrl = `/admin/kalender?view=month&year=${now.getFullYear()}&month=${now.getMonth() + 1}`;
 
 const MONTH_NAMES = ['Januar','Februar','März','April','Mai','Juni','Juli','August','September','Oktober','November','Dezember'];
 const DAY_NAMES   = ['Mo','Di','Mi','Do','Fr','Sa','So'];
@@ -100,6 +151,31 @@ const STATUS_CLS: Record<string, string> = {
   erledigt: 'line-through opacity-50',
   archiviert: 'line-through opacity-30',
 };
+
+// ── Month grid layout ─────────────────────────────────────────────────────
+const monthFirstDay     = new Date(year, month - 1, 1);
+const monthLastDay      = new Date(year, month, 0);
+const startWeekday      = (monthFirstDay.getDay() + 6) % 7; // Mon=0
+const totalDays         = monthLastDay.getDate();
+
+// ── Week grid layout ──────────────────────────────────────────────────────
+const weekDays: Array<{ date: Date; key: DayKey; label: string; isToday: boolean }> = [];
+{
+  for (let i = 0; i < 7; i++) {
+    const d = new Date(weekStart);
+    d.setDate(d.getDate() + i);
+    weekDays.push({
+      date: d,
+      key: dayKey(d),
+      label: `${DAY_NAMES[i]} ${String(d.getDate()).padStart(2, '0')}.${String(d.getMonth() + 1).padStart(2, '0')}.`,
+      isToday: dayKey(d) === dayKey(now),
+    });
+  }
+}
+
+const headerLabel = view === 'week'
+  ? `Woche vom ${weekStart.toLocaleDateString('de-DE', { day: '2-digit', month: '2-digit', year: 'numeric' })}`
+  : `${MONTH_NAMES[month - 1]} ${year}`;
 ---
 
 <AdminLayout title="Admin — Kalender">
@@ -109,24 +185,63 @@ const STATUS_CLS: Record<string, string> = {
       <div class="mb-8 flex items-center justify-between gap-4 flex-wrap">
         <div>
           <h1 class="text-3xl font-bold text-light font-serif">Kalender</h1>
-          <p class="text-muted mt-1">
-            {MONTH_NAMES[month - 1]} {year}
-            &mdash; {tasks.length} Aufgaben &middot; {projects.length} Projekte &middot; {bookings.length} Termine
+          <p class="text-muted mt-1" data-testid="kalender-summary">
+            {headerLabel}
+            &mdash; {tasks.length} Aufgaben &middot; {projects.length} Projekte &middot; {bookings.length} Termine &middot; {meetings.length} Meetings
           </p>
         </div>
+
+        <!-- View toggle (Monats- / Wochenansicht) -->
+        <div class="flex items-center gap-2" role="tablist" aria-label="Kalenderansicht">
+          <a
+            href={view === 'week' ? todayMonthUrl : `/admin/kalender?view=month&year=${year}&month=${month}`}
+            role="tab"
+            aria-selected={view === 'month' ? 'true' : 'false'}
+            data-testid="kalender-view-month"
+            class={`px-3 py-2 rounded-lg text-sm font-medium transition-colors border ${view === 'month' ? 'bg-gold text-dark border-gold' : 'bg-dark-light text-muted border-dark-lighter hover:text-light hover:border-gold/40'}`}
+          >Monat</a>
+          <a
+            href={view === 'month' ? todayWeekUrl : `/admin/kalender?view=week&year=${weekStart.getFullYear()}&month=${weekStart.getMonth() + 1}&day=${weekStart.getDate()}`}
+            role="tab"
+            aria-selected={view === 'week' ? 'true' : 'false'}
+            data-testid="kalender-view-week"
+            class={`px-3 py-2 rounded-lg text-sm font-medium transition-colors border ${view === 'week' ? 'bg-gold text-dark border-gold' : 'bg-dark-light text-muted border-dark-lighter hover:text-light hover:border-gold/40'}`}
+          >Woche</a>
+        </div>
+
+        <!-- Period nav -->
         <div class="flex items-center gap-2">
-          <a href={navUrl(year, month - 1)}
-            class="px-3 py-2 bg-dark-light border border-dark-lighter text-muted rounded-lg hover:text-light hover:border-gold/40 transition-colors text-sm">
-            ← Vorheriger
-          </a>
-          <a href={`/admin/kalender?year=${now.getFullYear()}&month=${now.getMonth() + 1}`}
-            class="px-3 py-2 bg-dark-light border border-dark-lighter text-muted rounded-lg hover:text-light hover:border-gold/40 transition-colors text-sm">
-            Heute
-          </a>
-          <a href={navUrl(year, month + 1)}
-            class="px-3 py-2 bg-dark-light border border-dark-lighter text-muted rounded-lg hover:text-light hover:border-gold/40 transition-colors text-sm">
-            Nächster →
-          </a>
+          {view === 'month' ? (
+            <>
+              <a href={monthNavUrl(-1)}
+                class="px-3 py-2 bg-dark-light border border-dark-lighter text-muted rounded-lg hover:text-light hover:border-gold/40 transition-colors text-sm">
+                ← Vorheriger
+              </a>
+              <a href={todayMonthUrl}
+                class="px-3 py-2 bg-dark-light border border-dark-lighter text-muted rounded-lg hover:text-light hover:border-gold/40 transition-colors text-sm">
+                Heute
+              </a>
+              <a href={monthNavUrl(1)}
+                class="px-3 py-2 bg-dark-light border border-dark-lighter text-muted rounded-lg hover:text-light hover:border-gold/40 transition-colors text-sm">
+                Nächster →
+              </a>
+            </>
+          ) : (
+            <>
+              <a href={weekNavUrl(-7)}
+                class="px-3 py-2 bg-dark-light border border-dark-lighter text-muted rounded-lg hover:text-light hover:border-gold/40 transition-colors text-sm">
+                ← Vorherige Woche
+              </a>
+              <a href={todayWeekUrl}
+                class="px-3 py-2 bg-dark-light border border-dark-lighter text-muted rounded-lg hover:text-light hover:border-gold/40 transition-colors text-sm">
+                Heute
+              </a>
+              <a href={weekNavUrl(7)}
+                class="px-3 py-2 bg-dark-light border border-dark-lighter text-muted rounded-lg hover:text-light hover:border-gold/40 transition-colors text-sm">
+                Nächste Woche →
+              </a>
+            </>
+          )}
         </div>
       </div>
 
@@ -134,85 +249,160 @@ const STATUS_CLS: Record<string, string> = {
         <div class="mb-6 p-4 bg-red-900/30 border border-red-800 rounded-xl text-red-300 text-sm">{dbError}</div>
       )}
 
-      <div class="bg-dark-light rounded-2xl border border-dark-lighter overflow-hidden">
-        <!-- Day headers -->
-        <div class="grid grid-cols-7 border-b border-dark-lighter">
-          {DAY_NAMES.map(d => (
-            <div class={`px-2 py-3 text-center text-xs font-semibold ${['Sa','So'].includes(d) ? 'text-muted/60' : 'text-muted'}`}>
-              {d}
-            </div>
-          ))}
-        </div>
-
-        <!-- Calendar cells -->
-        <div class="grid grid-cols-7">
-          {Array.from({ length: startWeekday }).map(() => (
-            <div class="min-h-[120px] border-b border-r border-dark-lighter/50 bg-dark/30"></div>
-          ))}
-
-          {Array.from({ length: totalDays }, (_, i) => i + 1).map(day => {
-            const isToday = year === now.getFullYear() && month === now.getMonth() + 1 && day === now.getDate();
-            const dayTasks    = tasksByDay.get(day)    ?? [];
-            const dayProjects = projectsByDay.get(day) ?? [];
-            const dayBookings = bookingsByDay.get(day) ?? [];
-            const col = (startWeekday + day - 1) % 7;
-            const isWeekend = col >= 5;
-            const totalItems = dayBookings.length + dayProjects.length + dayTasks.length;
-            return (
-              <div class={`min-h-[120px] border-b border-r border-dark-lighter/50 p-2 transition-colors hover:bg-dark/30 ${isWeekend ? 'bg-dark/20' : ''}`}>
-                <div class={`text-xs font-semibold mb-1.5 w-6 h-6 flex items-center justify-center rounded-full
-                  ${isToday ? 'bg-gold text-dark' : 'text-muted'}`}>
-                  {day}
-                </div>
-                <div class="space-y-1">
-                  {/* Bookings (CalDAV appointments) */}
-                  {dayBookings.slice(0, 2).map(b => (
-                    <a href="/admin/termine"
-                      class="flex items-center gap-1 rounded px-1.5 py-0.5 text-xs bg-blue-950/60 border border-blue-800/40 hover:border-blue-600/60 transition-colors group"
-                      title={`${b.summary} — ${b.attendeeName}`}>
-                      <span class="w-1.5 h-1.5 rounded-full shrink-0 bg-blue-400"></span>
-                      <span class="truncate text-blue-300 group-hover:text-blue-100 transition-colors">{b.summary}</span>
-                    </a>
-                  ))}
-                  {/* Projects */}
-                  {dayProjects.slice(0, 2).map(({ project: p, kind }) => (
-                    <a href={`/admin/projekte/${p.id}`}
-                      class="flex items-center gap-1 rounded px-1.5 py-0.5 text-xs bg-emerald-950/60 border border-emerald-800/40 hover:border-emerald-600/60 transition-colors group"
-                      title={`${p.name}${p.customerName ? ` — ${p.customerName}` : ''} (${kind === 'start' ? 'Start' : 'Fällig'})`}>
-                      <span class="w-1.5 h-1.5 rounded-full shrink-0 bg-emerald-400"></span>
-                      <span class="truncate text-emerald-300 group-hover:text-emerald-100 transition-colors">
-                        {kind === 'due' ? '⏱ ' : ''}{p.name}
-                      </span>
-                    </a>
-                  ))}
-                  {/* Tasks */}
-                  {dayTasks.slice(0, Math.max(0, 3 - dayBookings.length - dayProjects.length)).map(t => (
-                    <a href={`/admin/projekte/${t.projectId}`}
-                      class={`flex items-center gap-1 rounded px-1.5 py-0.5 text-xs bg-dark border border-dark-lighter hover:border-gold/40 transition-colors group ${STATUS_CLS[t.status] ?? ''}`}
-                      title={`${t.name} — ${t.projectName}`}>
-                      <span class={`w-1.5 h-1.5 rounded-full shrink-0 ${PRIO_DOT[t.priority] ?? 'bg-dark-lighter'}`}></span>
-                      <span class="truncate text-muted group-hover:text-light transition-colors">{t.name}</span>
-                    </a>
-                  ))}
-                  {totalItems > 4 && (
-                    <p class="text-xs text-muted pl-1">+{totalItems - 4} weitere</p>
-                  )}
-                </div>
+      {view === 'month' ? (
+        <div class="bg-dark-light rounded-2xl border border-dark-lighter overflow-hidden" data-testid="kalender-grid-month">
+          <!-- Day headers -->
+          <div class="grid grid-cols-7 border-b border-dark-lighter">
+            {DAY_NAMES.map(d => (
+              <div class={`px-2 py-3 text-center text-xs font-semibold ${['Sa','So'].includes(d) ? 'text-muted/60' : 'text-muted'}`}>
+                {d}
               </div>
-            );
-          })}
+            ))}
+          </div>
 
-          {(() => {
-            const trailing = (7 - (startWeekday + totalDays) % 7) % 7;
-            return Array.from({ length: trailing }).map(() => (
+          <!-- Calendar cells -->
+          <div class="grid grid-cols-7">
+            {Array.from({ length: startWeekday }).map(() => (
               <div class="min-h-[120px] border-b border-r border-dark-lighter/50 bg-dark/30"></div>
-            ));
-          })()}
+            ))}
+
+            {Array.from({ length: totalDays }, (_, i) => i + 1).map(d => {
+              const dt = new Date(year, month - 1, d);
+              const k = dayKey(dt);
+              const isToday = dayKey(now) === k;
+              const dayTasks    = tasksByDay.get(k)    ?? [];
+              const dayProjects = projectsByDay.get(k) ?? [];
+              const dayBookings = bookingsByDay.get(k) ?? [];
+              const dayMeetings = meetingsByDay.get(k) ?? [];
+              const col = (startWeekday + d - 1) % 7;
+              const isWeekend = col >= 5;
+              const totalItems = dayBookings.length + dayMeetings.length + dayProjects.length + dayTasks.length;
+              return (
+                <div class={`min-h-[120px] border-b border-r border-dark-lighter/50 p-2 transition-colors hover:bg-dark/30 ${isWeekend ? 'bg-dark/20' : ''}`}
+                  data-testid="kalender-cell" data-day={k}>
+                  <div class={`text-xs font-semibold mb-1.5 w-6 h-6 flex items-center justify-center rounded-full
+                    ${isToday ? 'bg-gold text-dark' : 'text-muted'}`}>
+                    {d}
+                  </div>
+                  <div class="space-y-1">
+                    {dayBookings.slice(0, 2).map(b => (
+                      <a href="/admin/termine"
+                        class="flex items-center gap-1 rounded px-1.5 py-0.5 text-xs bg-blue-950/60 border border-blue-800/40 hover:border-blue-600/60 transition-colors group"
+                        title={`${b.summary} — ${b.attendeeName}`}>
+                        <span class="w-1.5 h-1.5 rounded-full shrink-0 bg-blue-400"></span>
+                        <span class="truncate text-blue-300 group-hover:text-blue-100 transition-colors">{b.summary}</span>
+                      </a>
+                    ))}
+                    {dayMeetings.slice(0, 2).map(m => (
+                      <a href={`/admin/live/sessions/${m.id}`}
+                        class="flex items-center gap-1 rounded px-1.5 py-0.5 text-xs bg-purple-950/60 border border-purple-800/40 hover:border-purple-600/60 transition-colors group"
+                        title={`${m.meetingType} — ${m.customerName}`}>
+                        <span class="w-1.5 h-1.5 rounded-full shrink-0 bg-purple-400"></span>
+                        <span class="truncate text-purple-300 group-hover:text-purple-100 transition-colors">{m.meetingType}: {m.customerName}</span>
+                      </a>
+                    ))}
+                    {dayProjects.slice(0, 2).map(({ project: p, kind }) => (
+                      <a href={`/admin/projekte/${p.id}`}
+                        class="flex items-center gap-1 rounded px-1.5 py-0.5 text-xs bg-emerald-950/60 border border-emerald-800/40 hover:border-emerald-600/60 transition-colors group"
+                        title={`${p.name}${p.customerName ? ` — ${p.customerName}` : ''} (${kind === 'start' ? 'Start' : 'Fällig'})`}>
+                        <span class="w-1.5 h-1.5 rounded-full shrink-0 bg-emerald-400"></span>
+                        <span class="truncate text-emerald-300 group-hover:text-emerald-100 transition-colors">
+                          {kind === 'due' ? '⏱ ' : ''}{p.name}
+                        </span>
+                      </a>
+                    ))}
+                    {dayTasks.slice(0, Math.max(0, 4 - dayBookings.length - dayMeetings.length - dayProjects.length)).map(t => (
+                      <a href={`/admin/projekte/${t.projectId}`}
+                        class={`flex items-center gap-1 rounded px-1.5 py-0.5 text-xs bg-dark border border-dark-lighter hover:border-gold/40 transition-colors group ${STATUS_CLS[t.status] ?? ''}`}
+                        title={`${t.name} — ${t.projectName}`}>
+                        <span class={`w-1.5 h-1.5 rounded-full shrink-0 ${PRIO_DOT[t.priority] ?? 'bg-dark-lighter'}`}></span>
+                        <span class="truncate text-muted group-hover:text-light transition-colors">{t.name}</span>
+                      </a>
+                    ))}
+                    {totalItems > 6 && (
+                      <p class="text-xs text-muted pl-1">+{totalItems - 6} weitere</p>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+
+            {(() => {
+              const trailing = (7 - (startWeekday + totalDays) % 7) % 7;
+              return Array.from({ length: trailing }).map(() => (
+                <div class="min-h-[120px] border-b border-r border-dark-lighter/50 bg-dark/30"></div>
+              ));
+            })()}
+          </div>
         </div>
-      </div>
+      ) : (
+        <div class="bg-dark-light rounded-2xl border border-dark-lighter overflow-hidden" data-testid="kalender-grid-week">
+          <div class="grid grid-cols-7 border-b border-dark-lighter">
+            {weekDays.map(wd => (
+              <div class={`px-2 py-3 text-center text-xs font-semibold ${wd.isToday ? 'text-gold' : 'text-muted'}`}>
+                {wd.label}
+              </div>
+            ))}
+          </div>
+          <div class="grid grid-cols-7">
+            {weekDays.map(wd => {
+              const dayTasks    = tasksByDay.get(wd.key)    ?? [];
+              const dayProjects = projectsByDay.get(wd.key) ?? [];
+              const dayBookings = bookingsByDay.get(wd.key) ?? [];
+              const dayMeetings = meetingsByDay.get(wd.key) ?? [];
+              const col = (wd.date.getDay() + 6) % 7;
+              const isWeekend = col >= 5;
+              return (
+                <div class={`min-h-[280px] border-b border-r border-dark-lighter/50 p-2 ${isWeekend ? 'bg-dark/20' : ''} ${wd.isToday ? 'bg-gold/5' : ''}`}
+                  data-testid="kalender-cell" data-day={wd.key}>
+                  <div class="space-y-1">
+                    {dayBookings.map(b => (
+                      <a href="/admin/termine"
+                        class="block rounded px-1.5 py-1 text-xs bg-blue-950/60 border border-blue-800/40 hover:border-blue-600/60 transition-colors"
+                        title={`${b.summary} — ${b.attendeeName}`}>
+                        <p class="text-blue-200 font-medium truncate">{b.start.toLocaleTimeString('de-DE', { hour: '2-digit', minute: '2-digit' })} {b.summary}</p>
+                        <p class="text-blue-400/80 text-[10px] truncate">{b.attendeeName}</p>
+                      </a>
+                    ))}
+                    {dayMeetings.map(m => (
+                      <a href={`/admin/live/sessions/${m.id}`}
+                        class="block rounded px-1.5 py-1 text-xs bg-purple-950/60 border border-purple-800/40 hover:border-purple-600/60 transition-colors"
+                        title={`${m.meetingType} — ${m.customerName}`}>
+                        <p class="text-purple-200 font-medium truncate">{new Date(m.scheduledAt).toLocaleTimeString('de-DE', { hour: '2-digit', minute: '2-digit' })} {m.meetingType}</p>
+                        <p class="text-purple-400/80 text-[10px] truncate">{m.customerName}</p>
+                      </a>
+                    ))}
+                    {dayProjects.map(({ project: p, kind }) => (
+                      <a href={`/admin/projekte/${p.id}`}
+                        class="block rounded px-1.5 py-1 text-xs bg-emerald-950/60 border border-emerald-800/40 hover:border-emerald-600/60 transition-colors"
+                        title={`${p.name}${p.customerName ? ` — ${p.customerName}` : ''}`}>
+                        <p class="text-emerald-200 truncate">{kind === 'due' ? '⏱ ' : '▶ '}{p.name}</p>
+                      </a>
+                    ))}
+                    {dayTasks.map(t => (
+                      <a href={`/admin/projekte/${t.projectId}`}
+                        class={`block rounded px-1.5 py-1 text-xs bg-dark border border-dark-lighter hover:border-gold/40 transition-colors ${STATUS_CLS[t.status] ?? ''}`}
+                        title={`${t.name} — ${t.projectName}`}>
+                        <p class="text-muted truncate">
+                          <span class={`inline-block w-1.5 h-1.5 rounded-full mr-1 align-middle ${PRIO_DOT[t.priority] ?? 'bg-dark-lighter'}`}></span>
+                          {t.name}
+                        </p>
+                      </a>
+                    ))}
+                    {dayTasks.length + dayProjects.length + dayBookings.length + dayMeetings.length === 0 && (
+                      <p class="text-xs text-muted/40 italic">—</p>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
 
       <div class="flex flex-wrap gap-4 mt-4 text-xs text-muted">
         <span class="flex items-center gap-1"><span class="w-2 h-2 rounded-full bg-blue-400 inline-block"></span> Termin (CalDAV)</span>
+        <span class="flex items-center gap-1"><span class="w-2 h-2 rounded-full bg-purple-400 inline-block"></span> Meeting</span>
         <span class="flex items-center gap-1"><span class="w-2 h-2 rounded-full bg-emerald-400 inline-block"></span> Projekt</span>
         <span class="flex items-center gap-1"><span class="w-2 h-2 rounded-full bg-red-500 inline-block"></span> Aufgabe Hoch</span>
         <span class="flex items-center gap-1"><span class="w-2 h-2 rounded-full bg-yellow-500 inline-block"></span> Aufgabe Mittel</span>

--- a/website/src/pages/admin/meetings.astro
+++ b/website/src/pages/admin/meetings.astro
@@ -1,5 +1,144 @@
 ---
-// Legacy route kept for backwards-compatible bookmarks.
-// Live cockpit lives at /admin/live; per-session detail at /admin/live/sessions/[id].
-return Astro.redirect('/admin/live', 301);
+// /admin/meetings — Übersicht aller Meetings + "Neues Meeting" Anlegen.
+// Zuvor war diese Route nur ein 301-Redirect auf /admin/live; das brach
+// System-Test 2 / Q4 (T000161, T000164), weil dort kein "Neues Meeting"
+// Button existiert. Jetzt rendert die Seite eine echte Meeting-Liste.
+import AdminLayout from '../../layouts/AdminLayout.astro';
+import { getSession, getLoginUrl, isAdmin } from '../../lib/auth';
+import { listAllMeetings, listProjects } from '../../lib/website-db';
+import type { AdminMeeting, Project } from '../../lib/website-db';
+import AdminMeetingModal from '../../components/admin/AdminMeetingModal.svelte';
+
+const session = await getSession(Astro.request.headers.get('cookie'));
+if (!session) return Astro.redirect(getLoginUrl(Astro.url.pathname));
+if (!isAdmin(session)) return Astro.redirect('/admin');
+
+const brand = process.env.BRAND_NAME || process.env.BRAND || 'mentolder';
+
+let meetings: AdminMeeting[] = [];
+let projects: Project[] = [];
+let loadError = '';
+
+try {
+  [meetings, projects] = await Promise.all([
+    listAllMeetings({ limit: 200 }),
+    listProjects({ brand }),
+  ]);
+} catch (err) {
+  console.error('[admin/meetings]', err);
+  loadError = 'Meetings konnten nicht geladen werden.';
+}
+
+const now = new Date();
+const upcoming = meetings.filter(m => {
+  const t = m.startedAt ?? m.createdAt;
+  return t && new Date(t) >= now && m.status !== 'cancelled';
+});
+const past = meetings.filter(m => {
+  const t = m.startedAt ?? m.createdAt;
+  return !t || new Date(t) < now || m.status === 'cancelled';
+});
+
+function fmtDate(d: Date | string | null): string {
+  if (!d) return '—';
+  return new Date(d).toLocaleDateString('de-DE', {
+    weekday: 'short', day: '2-digit', month: '2-digit', year: 'numeric',
+  });
+}
+function fmtTime(d: Date | string | null): string {
+  if (!d) return '';
+  return new Date(d).toLocaleTimeString('de-DE', { hour: '2-digit', minute: '2-digit' });
+}
 ---
+
+<AdminLayout title="Admin — Meetings">
+  <section class="pt-10 pb-20 bg-dark min-h-screen">
+    <div class="max-w-5xl mx-auto px-6">
+
+      <div class="mb-8 flex items-center justify-between gap-4 flex-wrap">
+        <div>
+          <h1 class="text-3xl font-bold text-light font-serif">Meetings</h1>
+          <p class="text-muted mt-1">{meetings.length} Meetings · {upcoming.length} anstehend</p>
+        </div>
+        <div class="flex gap-3">
+          <AdminMeetingModal
+            client:load
+            projects={projects.map(p => ({ id: p.id, name: p.name }))}
+            buttonLabel="＋ Neues Meeting"
+          />
+          <a
+            href="/admin/live"
+            class="px-4 py-2 bg-gold/20 text-gold rounded-lg text-sm font-medium hover:bg-gold/30 transition-colors"
+          >
+            Live-Cockpit →
+          </a>
+        </div>
+      </div>
+
+      {loadError && (
+        <div class="mb-6 p-4 bg-red-500/10 border border-red-500/30 rounded-xl text-red-400 text-sm">
+          {loadError}
+        </div>
+      )}
+
+      {meetings.length === 0 && !loadError && (
+        <div class="p-6 bg-dark-light rounded-xl border border-dark-lighter text-muted text-center" data-testid="meetings-empty">
+          Noch keine Meetings angelegt. Klicke auf „＋ Neues Meeting" um zu starten.
+        </div>
+      )}
+
+      {upcoming.length > 0 && (
+        <div class="mb-10">
+          <h2 class="text-sm font-medium text-muted mb-3 uppercase tracking-wide">Anstehend</h2>
+          <div class="grid gap-3" data-testid="meetings-upcoming">
+            {upcoming.map(m => (
+              <div class="p-4 bg-dark-light rounded-xl border border-dark-lighter flex items-start justify-between gap-4 flex-wrap" data-meeting-id={m.id}>
+                <div>
+                  <p class="text-light font-medium">{m.meetingType} · {m.customerName}</p>
+                  <p class="text-sm text-muted mt-0.5">
+                    {fmtDate(m.startedAt ?? m.createdAt)} · {fmtTime(m.startedAt ?? m.createdAt)}
+                    {m.projectName ? ` · ${m.projectName}` : ''}
+                  </p>
+                  <p class="text-sm text-accent mt-0.5">{m.customerEmail}</p>
+                </div>
+                <div class="flex items-center gap-2 shrink-0">
+                  <span class="text-xs px-2 py-0.5 rounded-full bg-accent/20 text-accent">{m.status}</span>
+                  <a
+                    href={`/admin/live/sessions/${m.id}`}
+                    class="text-xs px-3 py-1 rounded-lg bg-gold/10 text-gold border border-gold/20 hover:bg-gold/20 transition-colors"
+                  >Details →</a>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {past.length > 0 && (
+        <div>
+          <h2 class="text-sm font-medium text-muted mb-3 uppercase tracking-wide">Vergangene</h2>
+          <div class="grid gap-3" data-testid="meetings-past">
+            {past.slice(0, 50).map(m => (
+              <div class="p-4 bg-dark-light rounded-xl border border-dark-lighter opacity-60 flex items-start justify-between gap-4 flex-wrap" data-meeting-id={m.id}>
+                <div>
+                  <p class="text-light font-medium">{m.meetingType} · {m.customerName}</p>
+                  <p class="text-sm text-muted mt-0.5">
+                    {fmtDate(m.startedAt ?? m.createdAt)} · {fmtTime(m.startedAt ?? m.createdAt)}
+                  </p>
+                </div>
+                <div class="flex items-center gap-2 shrink-0">
+                  <span class="text-xs px-2 py-0.5 rounded-full bg-dark-lighter text-muted">{m.status}</span>
+                  <a
+                    href={`/admin/live/sessions/${m.id}`}
+                    class="text-xs px-3 py-1 rounded-lg bg-dark-lighter text-muted hover:text-light transition-colors"
+                  >Details →</a>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+    </div>
+  </section>
+</AdminLayout>

--- a/website/src/pages/api/admin/bookings/create.ts
+++ b/website/src/pages/api/admin/bookings/create.ts
@@ -4,6 +4,7 @@ import { getSession, isAdmin } from '../../../../lib/auth';
 import { createInboxItem } from '../../../../lib/messaging-db';
 import { sendEmail } from '../../../../lib/email';
 import { sendAdminNotification } from '../../../../lib/notifications';
+import { createCalendarEvent } from '../../../../lib/caldav';
 
 const BRAND_NAME = process.env.BRAND_NAME || 'Workspace';
 
@@ -72,6 +73,33 @@ export const POST: APIRoute = async ({ request }) => {
         adminCreated: true,
       },
     });
+
+    // Persist directly into CalDAV so the booking appears immediately in
+    // /admin/termine and /admin/kalender. Without this step the booking
+    // would only show up after admin approval of the inbox item — which is
+    // surprising for a "manual" admin-created booking and broke the
+    // System-Test 2 / Q5 expectation (T000162, T000165).
+    if (!isCallback && slotStart && slotEnd) {
+      try {
+        await createCalendarEvent({
+          summary: `${typeLabel}: ${clientName}`,
+          description: [
+            `Termin mit ${clientName} (${clientEmail})`,
+            `Typ: ${typeLabel}`,
+            phone ? `Telefon: ${phone}` : null,
+            message ? `Notiz: ${message}` : null,
+          ].filter(Boolean).join('\n'),
+          start: new Date(slotStart),
+          end: new Date(slotEnd),
+          attendeeEmail: clientEmail,
+          attendeeName: clientName,
+        });
+      } catch (err) {
+        console.error('[admin/bookings/create] CalDAV persist failed:', err);
+        // Non-fatal: inbox item is the source of truth, calendar entry is
+        // a convenience. Admin can still approve via inbox to retry.
+      }
+    }
 
     await sendEmail({
       to: clientEmail,

--- a/website/src/pages/api/admin/meetings/create.ts
+++ b/website/src/pages/api/admin/meetings/create.ts
@@ -1,0 +1,107 @@
+// website/src/pages/api/admin/meetings/create.ts
+//
+// Manually create a meeting from the admin /admin/meetings UI.
+// Persists into both the `meetings` table (so it shows on /admin/meetings,
+// in /admin/live's recent sessions and in the calendar) and into Nextcloud
+// CalDAV (so it shows in /admin/kalender alongside tasks/projects/bookings).
+// Closes T000161, T000164.
+import type { APIRoute } from 'astro';
+import { getSession, isAdmin } from '../../../../lib/auth';
+import { upsertCustomer, createMeeting } from '../../../../lib/website-db';
+import { createCalendarEvent } from '../../../../lib/caldav';
+
+const BRAND_NAME = process.env.BRAND_NAME || 'Workspace';
+
+interface CreateMeetingBody {
+  customerName?: string;
+  customerEmail?: string;
+  meetingType?: string;
+  scheduledAt?: string;     // ISO 8601
+  durationMinutes?: number; // optional, default 60
+  projectId?: string | null;
+}
+
+function jsonError(status: number, error: string) {
+  return new Response(JSON.stringify({ error }), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+export const POST: APIRoute = async ({ request }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session) return jsonError(401, 'Unauthorized');
+  if (!isAdmin(session)) return jsonError(403, 'Forbidden');
+
+  let body: CreateMeetingBody;
+  try {
+    body = await request.json();
+  } catch {
+    return jsonError(400, 'Ungültiger Request-Body.');
+  }
+
+  const customerName = body.customerName?.trim();
+  const customerEmail = body.customerEmail?.trim();
+  const meetingType = body.meetingType?.trim() || 'Meeting';
+  const scheduledAtRaw = body.scheduledAt?.trim();
+  const durationMinutes = body.durationMinutes && body.durationMinutes > 0
+    ? Math.min(body.durationMinutes, 8 * 60)
+    : 60;
+
+  if (!customerName) return jsonError(400, 'Teilnehmer-Name ist Pflicht.');
+  if (!customerEmail || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(customerEmail)) {
+    return jsonError(400, 'Gültige Teilnehmer-E-Mail ist Pflicht.');
+  }
+  if (!scheduledAtRaw) return jsonError(400, 'Datum + Uhrzeit sind Pflicht.');
+
+  const scheduledAt = new Date(scheduledAtRaw);
+  if (Number.isNaN(scheduledAt.getTime())) {
+    return jsonError(400, 'Ungültiges Datum/Uhrzeit-Format.');
+  }
+  const endsAt = new Date(scheduledAt.getTime() + durationMinutes * 60_000);
+
+  try {
+    const customer = await upsertCustomer({ name: customerName, email: customerEmail });
+
+    const meeting = await createMeeting({
+      customerId: customer.id,
+      meetingType,
+      scheduledAt,
+      projectId: body.projectId ?? undefined,
+    });
+
+    // Best-effort calendar persist — meetings list + admin calendar still
+    // visualise the meeting via the meetings table even if CalDAV is down.
+    let calendarPersisted = true;
+    try {
+      const result = await createCalendarEvent({
+        summary: `${meetingType}: ${customerName}`,
+        description: `Meeting mit ${customerName} (${customerEmail})\nTyp: ${meetingType}`,
+        start: scheduledAt,
+        end: endsAt,
+        attendeeEmail: customerEmail,
+        attendeeName: customerName,
+      });
+      if (!result) calendarPersisted = false;
+    } catch (err) {
+      console.error('[admin/meetings/create] CalDAV persist failed:', err);
+      calendarPersisted = false;
+    }
+
+    return new Response(JSON.stringify({
+      success: true,
+      meeting: {
+        id: meeting.id,
+        customerId: meeting.customerId,
+        meetingType,
+        scheduledAt: scheduledAt.toISOString(),
+        durationMinutes,
+      },
+      calendarPersisted,
+      brand: BRAND_NAME,
+    }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+  } catch (err) {
+    console.error('[api/admin/meetings/create]', err);
+    return jsonError(500, 'Interner Serverfehler beim Anlegen des Meetings.');
+  }
+};


### PR DESCRIPTION
## Summary
Five tickets reported the same workflow gap: creating Termine/Meetings via admin didn't surface them in the calendar, and the month/week view had rendering bugs.

## Fix
- DB: ensure appointments/meetings query covers the calendar's date range
- API: new `/api/admin/meetings/create.ts` for the meetings flow
- UI: AdminMeetingModal component, kalender.astro + meetings.astro fixes for month/week visualization

Closes T000161
Closes T000162
Closes T000164
Closes T000165
Closes T000167

## Test plan
- [x] `astro check` passes
- [ ] Manual on mentolder: create Termin → see it in calendar (month + week view)
- [ ] Manual on mentolder: create Meeting → visualizes