### PR TITLE
feat(systemtest): auto-file tickets on Playwright/runner.sh failures + run_id linkback

### DIFF
--- a/k3d/website-schema.yaml
+++ b/k3d/website-schema.yaml
@@ -350,6 +350,40 @@ data:
       CREATE INDEX IF NOT EXISTS test_results_test_id_created_idx ON test_results (test_id, created_at DESC);
       CREATE INDEX IF NOT EXISTS test_results_run_id_idx ON test_results (run_id);
 
+      -- Linkback from triage tickets back to the originating test_run/test_result.
+      -- Owned by website/src/lib/systemtest/db.ts (`ensureSystemtestSchema`); we
+      -- mirror the column adds + FKs here so a fresh DB has the linkage in place
+      -- as soon as both test_runs and tickets.tickets exist. Guarded by a
+      -- to_regclass() check because tickets.tickets is created at app boot,
+      -- not in this script.
+      DO $$
+      BEGIN
+        IF to_regclass('tickets.tickets') IS NOT NULL THEN
+          ALTER TABLE tickets.tickets
+            ADD COLUMN IF NOT EXISTS source_test_run_id    TEXT,
+            ADD COLUMN IF NOT EXISTS source_test_result_id BIGINT,
+            ADD COLUMN IF NOT EXISTS source_test_id        TEXT;
+          IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'tickets_source_test_run_fk') THEN
+            ALTER TABLE tickets.tickets
+              ADD CONSTRAINT tickets_source_test_run_fk
+              FOREIGN KEY (source_test_run_id) REFERENCES test_runs(id) ON DELETE SET NULL;
+          END IF;
+          IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'tickets_source_test_result_fk') THEN
+            ALTER TABLE tickets.tickets
+              ADD CONSTRAINT tickets_source_test_result_fk
+              FOREIGN KEY (source_test_result_id) REFERENCES test_results(id) ON DELETE SET NULL;
+          END IF;
+          CREATE UNIQUE INDEX IF NOT EXISTS tickets_one_open_per_test_run_test_uq
+            ON tickets.tickets (source_test_run_id, source_test_id)
+            WHERE source_test_run_id IS NOT NULL
+              AND source_test_id     IS NOT NULL
+              AND status NOT IN ('done','archived');
+          CREATE INDEX IF NOT EXISTS tickets_source_test_run_idx
+            ON tickets.tickets (source_test_run_id)
+            WHERE source_test_run_id IS NOT NULL;
+        END IF;
+      END$$;
+
       -- Grant full access to the website user
       GRANT ALL ON ALL TABLES IN SCHEMA public TO website;
       GRANT ALL ON ALL SEQUENCES IN SCHEMA public TO website;
@@ -692,6 +726,37 @@ data:
       );
       CREATE INDEX IF NOT EXISTS test_results_test_id_created_idx ON test_results (test_id, created_at DESC);
       CREATE INDEX IF NOT EXISTS test_results_run_id_idx ON test_results (run_id);
+
+      -- Linkback from triage tickets back to the originating test_run/test_result.
+      -- See ensureSystemtestSchema in website/src/lib/systemtest/db.ts for the
+      -- canonical owner. Mirrored here for fresh-DB ergonomics; idempotent.
+      DO $$
+      BEGIN
+        IF to_regclass('tickets.tickets') IS NOT NULL THEN
+          ALTER TABLE tickets.tickets
+            ADD COLUMN IF NOT EXISTS source_test_run_id    TEXT,
+            ADD COLUMN IF NOT EXISTS source_test_result_id BIGINT,
+            ADD COLUMN IF NOT EXISTS source_test_id        TEXT;
+          IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'tickets_source_test_run_fk') THEN
+            ALTER TABLE tickets.tickets
+              ADD CONSTRAINT tickets_source_test_run_fk
+              FOREIGN KEY (source_test_run_id) REFERENCES test_runs(id) ON DELETE SET NULL;
+          END IF;
+          IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'tickets_source_test_result_fk') THEN
+            ALTER TABLE tickets.tickets
+              ADD CONSTRAINT tickets_source_test_result_fk
+              FOREIGN KEY (source_test_result_id) REFERENCES test_results(id) ON DELETE SET NULL;
+          END IF;
+          CREATE UNIQUE INDEX IF NOT EXISTS tickets_one_open_per_test_run_test_uq
+            ON tickets.tickets (source_test_run_id, source_test_id)
+            WHERE source_test_run_id IS NOT NULL
+              AND source_test_id     IS NOT NULL
+              AND status NOT IN ('done','archived');
+          CREATE INDEX IF NOT EXISTS tickets_source_test_run_idx
+            ON tickets.tickets (source_test_run_id)
+            WHERE source_test_run_id IS NOT NULL;
+        END IF;
+      END$$;
 
       GRANT ALL ON ALL TABLES IN SCHEMA public TO website;
       GRANT ALL ON ALL SEQUENCES IN SCHEMA public TO website;

--- a/website/src/lib/systemtest/cleanup.ts
+++ b/website/src/lib/systemtest/cleanup.ts
@@ -41,6 +41,7 @@ import type { Pool } from 'pg';
 
 import * as keycloak from '../keycloak';
 import { openFailureTicket } from './failure-bridge';
+import { openTestRunFailureTicket } from './test-run-bridge';
 
 /**
  * The full set of tables the cleanup CronJob is allowed to touch via fixture
@@ -224,10 +225,18 @@ export interface DrainOutboxResult {
 export async function drainOutbox(pool: Pool): Promise<DrainOutboxResult> {
   const due = await pool.query<{
     id: string;
-    assignment_id: string;
-    question_id: string;
+    source_kind: string | null;
+    assignment_id: string | null;
+    question_id: string | null;
+    run_id: string | null;
+    test_id: string | null;
+    test_result_id: number | null;
+    test_name: string | null;
+    error_message: string | null;
+    file_path: string | null;
   }>(
-    `SELECT id, assignment_id, question_id
+    `SELECT id, source_kind, assignment_id, question_id,
+            run_id, test_id, test_result_id, test_name, error_message, file_path
        FROM systemtest_failure_outbox
       WHERE retry_after <= now()
         AND retry_count < 12
@@ -238,10 +247,33 @@ export async function drainOutbox(pool: Pool): Promise<DrainOutboxResult> {
   let succeeded = 0;
   for (const row of due.rows) {
     try {
-      await openFailureTicket(pool, {
-        assignmentId: row.assignment_id,
-        questionId: row.question_id,
-      });
+      // source_kind is NOT NULL with default 'questionnaire' — but pre-migration
+      // rows carried no value, so we route on that default.
+      if (row.source_kind === 'test_run' && row.run_id && row.test_id) {
+        await openTestRunFailureTicket(pool, {
+          runId: row.run_id,
+          testId: row.test_id,
+          resultId: row.test_result_id ?? null,
+          name: row.test_name ?? row.test_id,
+          error: row.error_message,
+          filePath: row.file_path,
+        });
+      } else if (row.assignment_id && row.question_id) {
+        await openFailureTicket(pool, {
+          assignmentId: row.assignment_id,
+          questionId: row.question_id,
+        });
+      } else {
+        // Malformed row — skip rather than retry forever.
+        await pool.query(
+          `UPDATE systemtest_failure_outbox
+              SET retry_count = 12,
+                  last_error  = 'malformed: missing key columns'
+            WHERE id = $1`,
+          [row.id],
+        );
+        continue;
+      }
       await pool.query(`DELETE FROM systemtest_failure_outbox WHERE id = $1`, [row.id]);
       succeeded++;
     } catch (e) {

--- a/website/src/lib/systemtest/db.ts
+++ b/website/src/lib/systemtest/db.ts
@@ -98,7 +98,48 @@ export async function ensureSystemtestSchema(pool: Pool): Promise<void> {
 
     ALTER TABLE tickets.tickets
       ADD COLUMN IF NOT EXISTS source_test_assignment_id UUID,
-      ADD COLUMN IF NOT EXISTS source_test_question_id   UUID;
+      ADD COLUMN IF NOT EXISTS source_test_question_id   UUID,
+      ADD COLUMN IF NOT EXISTS source_test_run_id        TEXT,
+      ADD COLUMN IF NOT EXISTS source_test_result_id     BIGINT,
+      ADD COLUMN IF NOT EXISTS source_test_id            TEXT;
+  `);
+
+  // Test-run failure outbox extensions. The same outbox table now serves
+  // BOTH paths (questionnaire failures + Playwright/runner.sh failures).
+  // For test-run rows, assignment_id/question_id stay NULL and the new
+  // run_id/test_id/result_id columns identify the dropped insert.
+  await pool.query(`
+    ALTER TABLE systemtest_failure_outbox
+      ADD COLUMN IF NOT EXISTS source_kind     TEXT NOT NULL DEFAULT 'questionnaire'
+                                CHECK (source_kind IN ('questionnaire','test_run')),
+      ADD COLUMN IF NOT EXISTS run_id          TEXT,
+      ADD COLUMN IF NOT EXISTS test_result_id  BIGINT,
+      ADD COLUMN IF NOT EXISTS test_id         TEXT,
+      ADD COLUMN IF NOT EXISTS test_name       TEXT,
+      ADD COLUMN IF NOT EXISTS error_message   TEXT,
+      ADD COLUMN IF NOT EXISTS file_path       TEXT;
+
+    -- Existing rows are questionnaire failures; the legacy NOT NULL
+    -- constraints on assignment_id/question_id stay enforced for those.
+    -- For test_run rows we relax them via partial check (source_kind gates
+    -- which key set must be populated).
+    ALTER TABLE systemtest_failure_outbox
+      ALTER COLUMN assignment_id DROP NOT NULL,
+      ALTER COLUMN question_id   DROP NOT NULL;
+
+    DO $$
+    BEGIN
+      IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'outbox_keys_by_kind') THEN
+        ALTER TABLE systemtest_failure_outbox
+          ADD CONSTRAINT outbox_keys_by_kind CHECK (
+            (source_kind = 'questionnaire'
+              AND assignment_id IS NOT NULL AND question_id IS NOT NULL)
+            OR
+            (source_kind = 'test_run'
+              AND run_id IS NOT NULL AND test_id IS NOT NULL)
+          );
+      END IF;
+    END$$;
   `);
 
   // is_test_data columns: defense-in-depth marker for seeded fixtures so
@@ -156,7 +197,35 @@ export async function ensureSystemtestSchema(pool: Pool): Promise<void> {
           ADD CONSTRAINT tickets_source_question_fk
           FOREIGN KEY (source_test_question_id) REFERENCES questionnaire_questions(id);
       END IF;
+      -- test_runs / test_results FKs: nullable, NO CASCADE — keep the ticket
+      -- around if the run/result row gets pruned by a future retention sweep.
+      -- ON DELETE SET NULL keeps the ticket discoverable but breaks the link.
+      IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'tickets_source_test_run_fk') THEN
+        ALTER TABLE tickets.tickets
+          ADD CONSTRAINT tickets_source_test_run_fk
+          FOREIGN KEY (source_test_run_id) REFERENCES test_runs(id) ON DELETE SET NULL;
+      END IF;
+      IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'tickets_source_test_result_fk') THEN
+        ALTER TABLE tickets.tickets
+          ADD CONSTRAINT tickets_source_test_result_fk
+          FOREIGN KEY (source_test_result_id) REFERENCES test_results(id) ON DELETE SET NULL;
+      END IF;
     END$$;
+  `);
+
+  // Defense-in-depth dedup race guard: at most one OPEN ticket per
+  // (run_id, test_id) pair. The bridge looks up an existing open ticket
+  // first; this partial unique index makes a concurrent insert race deterministic.
+  await pool.query(`
+    CREATE UNIQUE INDEX IF NOT EXISTS tickets_one_open_per_test_run_test_uq
+      ON tickets.tickets (source_test_run_id, source_test_id)
+      WHERE source_test_run_id IS NOT NULL
+        AND source_test_id     IS NOT NULL
+        AND status NOT IN ('done','archived');
+
+    CREATE INDEX IF NOT EXISTS tickets_source_test_run_idx
+      ON tickets.tickets (source_test_run_id)
+      WHERE source_test_run_id IS NOT NULL;
   `);
 
   await pool.query(`

--- a/website/src/lib/systemtest/test-run-bridge.ts
+++ b/website/src/lib/systemtest/test-run-bridge.ts
@@ -1,0 +1,268 @@
+// website/src/lib/systemtest/test-run-bridge.ts
+//
+// Auto-files a `tickets.tickets` row of type='bug' for each failing test in
+// a Playwright JSON report or a `tests/runner.sh` JSONL stream. Bridges the
+// SECOND failure surface — questionnaire failures continue to flow through
+// `failure-bridge.ts`. Both bridges share `systemtest_failure_outbox` for
+// best-effort retries.
+//
+// Idempotency contract:
+//   - One ticket per (run_id, test_id). Lookup-then-insert is wrapped with
+//     the partial unique index `tickets_one_open_per_test_run_test_uq` as
+//     the race guard.
+//   - Closed tickets (`status IN ('done','archived')`) are excluded from the
+//     "exists open" check so a regression on a later run still opens a
+//     fresh ticket.
+//
+// Test-data marker:
+//   - `is_test_data` is always FALSE for test-run failures. The runner.sh
+//     and Playwright suites are real-environment health probes, not seeded
+//     fixtures. Hiding them with the test-data toggle would defeat the
+//     point of the loop.
+//
+// Why a separate file:
+//   - failure-bridge.ts is large, deeply tied to questionnaire_test_status,
+//     and uses an entirely different dedup key (source_test_question_id).
+//     A sibling file with its own `enqueueTestRunOutboxRetry` keeps both
+//     paths legible.
+//
+// Outbox shape:
+//   - The shared `systemtest_failure_outbox` table now distinguishes paths
+//     via `source_kind` (`'questionnaire'` or `'test_run'`). For test_run
+//     rows, run_id/test_id are required and assignment_id/question_id stay
+//     NULL (enforced by the `outbox_keys_by_kind` CHECK).
+
+import type { Pool } from 'pg';
+
+export interface OpenTestRunFailureOpts {
+  /** test_runs.id — TEXT primary key (UUID-shaped in practice). */
+  runId: string;
+  /** test_results.id — BIGSERIAL. Optional: missing for runner.sh paths
+   *  that haven't yet inserted into test_results. */
+  resultId?: number | null;
+  /** Stable identifier for the failing test (e.g. spec-title :: test-title
+   *  for Playwright, or `<TEST-ID>/<case>` for runner.sh). */
+  testId: string;
+  /** Human-readable test name for the ticket title. */
+  name: string;
+  /** Originating category — used for routing and shows up in the ticket
+   *  description. */
+  category?: 'FA' | 'SA' | 'NFA' | 'AK' | 'E2E' | 'BATS' | null;
+  /** First-line error message (truncated to 1000 chars in the description). */
+  error?: string | null;
+  /** Optional file path of the failing spec. Useful for "open in editor". */
+  filePath?: string | null;
+  /** Where the run came from: `'github'` for nightly e2e, `'admin'` for
+   *  admin-triggered runs, `'cli'` for runner.sh on a workstation. */
+  source?: 'github' | 'admin' | 'cli' | null;
+  /** GitHub Actions run id — populates the link in the ticket description
+   *  when source='github'. */
+  githubRunId?: string | null;
+  /** Optional cluster label (mentolder|korczewski|dev). */
+  cluster?: string | null;
+}
+
+/** Lazy-loaded; multiple modules may invoke this. */
+let ticketsSchemaInitPromise: Promise<void> | null = null;
+async function ensureTicketsSchema(): Promise<void> {
+  if (!ticketsSchemaInitPromise) {
+    ticketsSchemaInitPromise = import('../tickets-db').then(m => m.initTicketsSchema());
+  }
+  return ticketsSchemaInitPromise;
+}
+
+function truncate(text: string, max: number): string {
+  if (text.length <= max) return text;
+  return text.slice(0, Math.max(0, max - 1)).trimEnd() + '…';
+}
+
+function publicBaseUrl(): string {
+  const domain = process.env.PROD_DOMAIN;
+  if (domain) return `https://web.${domain}`;
+  return 'http://web.localhost';
+}
+
+function buildTitle(name: string, category: string | null | undefined): string {
+  const head = `Testfehler${category ? ` [${category}]` : ''}: `;
+  return truncate(head + name.replace(/\s+/g, ' ').trim(), 200);
+}
+
+function buildDescription(opts: OpenTestRunFailureOpts): string {
+  const parts: string[] = [];
+  parts.push(`**Test:** ${opts.testId}`);
+  if (opts.filePath) parts.push(`**Datei:** ${opts.filePath}`);
+  if (opts.cluster) parts.push(`**Cluster:** ${opts.cluster}`);
+  if (opts.category) parts.push(`**Kategorie:** ${opts.category}`);
+  if (opts.error) {
+    parts.push(`**Fehler:**\n\n\`\`\`\n${truncate(opts.error, 1000)}\n\`\`\``);
+  }
+  const baseUrl = publicBaseUrl();
+  parts.push(`**Run:** ${baseUrl}/admin/tests/runs/${encodeURIComponent(opts.runId)}`);
+  if (opts.source === 'github' && opts.githubRunId) {
+    parts.push(
+      `**GitHub Actions:** https://github.com/Paddione/Bachelorprojekt/actions/runs/${opts.githubRunId}`,
+    );
+  }
+  return parts.join('\n\n');
+}
+
+/**
+ * Find-or-create a bug ticket for a failing Playwright/runner.sh test.
+ *
+ * Returns the ticket UUID, or `null` if dedup found an existing open ticket
+ * (the existing ticket id is still returned in that case — null is reserved
+ * for "schema unavailable / silent skip").
+ *
+ * Throws on unexpected DB errors so the caller can decide whether to
+ * enqueue a retry via `enqueueTestRunOutboxRetry`.
+ */
+export async function openTestRunFailureTicket(
+  pool: Pool,
+  opts: OpenTestRunFailureOpts,
+): Promise<string | null> {
+  await ensureTicketsSchema();
+
+  // Dedup: any OPEN ticket for this (run_id, test_id) wins. The partial
+  // unique index `tickets_one_open_per_test_run_test_uq` is the race guard.
+  const existing = await pool.query<{ id: string }>(
+    `SELECT id FROM tickets.tickets
+      WHERE source_test_run_id = $1
+        AND source_test_id     = $2
+        AND status NOT IN ('done','archived')
+      ORDER BY created_at DESC
+      LIMIT 1`,
+    [opts.runId, opts.testId],
+  );
+  if (existing.rows.length > 0) {
+    const ticketId = existing.rows[0].id;
+    // Refresh result_id linkage in case the second call learned the row id
+    // after the first call inserted without one.
+    if (opts.resultId != null) {
+      await pool.query(
+        `UPDATE tickets.tickets
+            SET source_test_result_id = COALESCE(source_test_result_id, $1),
+                updated_at = now()
+          WHERE id = $2`,
+        [opts.resultId, ticketId],
+      );
+    }
+    return ticketId;
+  }
+
+  const brand = process.env.BRAND_ID || process.env.BRAND || 'mentolder';
+  const title = buildTitle(opts.name, opts.category ?? null);
+  const description = buildDescription(opts);
+
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+    await client.query(
+      `SELECT set_config('app.user_label', $1, true)`,
+      ['systemtest:test-run-bridge'],
+    );
+
+    // ON CONFLICT on the partial unique index: if a sibling concurrent
+    // insert beat us, we resolve to the existing row's id by re-selecting.
+    const insert = await client.query<{ id: string }>(
+      `INSERT INTO tickets.tickets
+         (type, brand, component, severity,
+          title, description, status,
+          source_test_run_id, source_test_result_id, source_test_id,
+          is_test_data)
+       VALUES ('bug', $1, 'systemtest', 'minor',
+               $2, $3, 'triage',
+               $4, $5, $6,
+               false)
+       ON CONFLICT (source_test_run_id, source_test_id)
+         WHERE source_test_run_id IS NOT NULL
+           AND source_test_id     IS NOT NULL
+           AND status NOT IN ('done','archived')
+       DO UPDATE SET
+         source_test_result_id = COALESCE(EXCLUDED.source_test_result_id,
+                                          tickets.tickets.source_test_result_id),
+         updated_at = now()
+       RETURNING id`,
+      [brand, title, description,
+       opts.runId, opts.resultId ?? null, opts.testId],
+    );
+    const ticketId = insert.rows[0].id;
+
+    await client.query('COMMIT');
+    return ticketId;
+  } catch (err) {
+    await client.query('ROLLBACK').catch(() => {});
+    throw err;
+  } finally {
+    client.release();
+  }
+}
+
+/**
+ * Enqueue a retry row in `systemtest_failure_outbox` keyed on
+ * (run_id, test_id). Picked up by the same 5-min cron drain that handles
+ * questionnaire failures (see `cleanup.ts:drainOutbox`).
+ */
+export async function enqueueTestRunOutboxRetry(
+  pool: Pool,
+  opts: {
+    runId: string;
+    testId: string;
+    resultId?: number | null;
+    name: string;
+    error?: string | null;
+    filePath?: string | null;
+    attempt?: number;
+    failureMessage: string;
+  },
+): Promise<void> {
+  await pool.query(
+    `INSERT INTO systemtest_failure_outbox
+       (source_kind, run_id, test_id, test_result_id, test_name,
+        error_message, file_path,
+        attempt, last_error, retry_count, retry_after, created_at)
+     VALUES ('test_run', $1, $2, $3, $4,
+             $5, $6,
+             $7, $8, 0, now() + INTERVAL '5 minutes', now())`,
+    [
+      opts.runId,
+      opts.testId,
+      opts.resultId ?? null,
+      opts.name.slice(0, 500),
+      opts.error?.slice(0, 4000) ?? null,
+      opts.filePath?.slice(0, 500) ?? null,
+      opts.attempt ?? 0,
+      opts.failureMessage.slice(0, 4000),
+    ],
+  );
+}
+
+/**
+ * Best-effort wrapper used by callers that want fire-and-forget behaviour.
+ * Catches any error and routes it through the outbox so the answer-save /
+ * ingest-e2e response is never delayed by ticket creation.
+ */
+export async function safeOpenTestRunFailureTicket(
+  pool: Pool,
+  opts: OpenTestRunFailureOpts,
+): Promise<string | null> {
+  try {
+    return await openTestRunFailureTicket(pool, opts);
+  } catch (err) {
+    const msg = (err as Error)?.message ?? String(err);
+    await enqueueTestRunOutboxRetry(pool, {
+      runId: opts.runId,
+      testId: opts.testId,
+      resultId: opts.resultId ?? null,
+      name: opts.name,
+      error: opts.error ?? null,
+      filePath: opts.filePath ?? null,
+      attempt: 0,
+      failureMessage: msg,
+    }).catch((outboxErr) =>
+      // Don't let outbox failures bubble — the caller's primary work
+      // (saving test_results) must still succeed.
+      console.error('[test-run-bridge] outbox enqueue failed:', outboxErr),
+    );
+    return null;
+  }
+}

--- a/website/src/lib/tickets-db.ts
+++ b/website/src/lib/tickets-db.ts
@@ -56,6 +56,17 @@ export async function initTicketsSchema(): Promise<void> {
 
   await pool.query(`ALTER TABLE tickets.tickets ADD COLUMN IF NOT EXISTS notes TEXT`);
 
+  // Test-run linkback columns. Mirrored in `systemtest/db.ts` (the canonical
+  // owner — that module also installs FKs to test_runs/test_results once those
+  // tables exist). We add the columns here too so a tickets-only init path
+  // doesn't break the failure-bridge: the FKs are deferred to ensureSystemtestSchema.
+  await pool.query(`
+    ALTER TABLE tickets.tickets
+      ADD COLUMN IF NOT EXISTS source_test_run_id    TEXT,
+      ADD COLUMN IF NOT EXISTS source_test_result_id BIGINT,
+      ADD COLUMN IF NOT EXISTS source_test_id        TEXT
+  `);
+
   await pool.query(`CREATE INDEX IF NOT EXISTS tickets_status_idx ON tickets.tickets (status) WHERE status NOT IN ('done','archived')`);
   await pool.query(`CREATE INDEX IF NOT EXISTS tickets_type_brand_idx ON tickets.tickets (type, brand)`);
   await pool.query(`CREATE INDEX IF NOT EXISTS tickets_parent_idx ON tickets.tickets (parent_id)`);
@@ -74,6 +85,17 @@ export async function initTicketsSchema(): Promise<void> {
     CREATE UNIQUE INDEX IF NOT EXISTS tickets_one_open_per_test_question_uq
       ON tickets.tickets (source_test_question_id)
       WHERE source_test_question_id IS NOT NULL AND status NOT IN ('done','archived')
+  `);
+
+  // Test-run linkback dedup: at most one OPEN ticket per (run_id, test_id).
+  // The test-run failure-bridge reuses the existing open ticket; this index
+  // is the race guard.
+  await pool.query(`
+    CREATE UNIQUE INDEX IF NOT EXISTS tickets_one_open_per_test_run_test_uq
+      ON tickets.tickets (source_test_run_id, source_test_id)
+      WHERE source_test_run_id IS NOT NULL
+        AND source_test_id     IS NOT NULL
+        AND status NOT IN ('done','archived')
   `);
 
   await pool.query(`

--- a/website/src/lib/website-db.ts
+++ b/website/src/lib/website-db.ts
@@ -3166,18 +3166,43 @@ export interface TestResultRow {
   message?: string;
 }
 
-export async function saveTestResults(runId: string, rows: TestResultRow[]): Promise<void> {
-  if (rows.length === 0) return;
+export interface SavedTestResult {
+  id: number;
+  testId: string;
+  category: string;
+  status: string;
+  durationMs: number | null;
+  message: string | null;
+}
+
+export async function saveTestResults(
+  runId: string,
+  rows: TestResultRow[],
+): Promise<SavedTestResult[]> {
+  if (rows.length === 0) return [];
   const values: unknown[] = [];
   const placeholders = rows.map((r, i) => {
     const base = i * 6;
     values.push(runId, r.testId, r.category, r.status, r.durationMs ?? null, r.message ?? null);
     return `($${base + 1}, $${base + 2}, $${base + 3}, $${base + 4}, $${base + 5}, $${base + 6})`;
   }).join(',');
-  await pool.query(
-    `INSERT INTO test_results (run_id, test_id, category, status, duration_ms, message) VALUES ${placeholders}`,
+  const result = await pool.query<{
+    id: number; test_id: string; category: string; status: string;
+    duration_ms: number | null; message: string | null;
+  }>(
+    `INSERT INTO test_results (run_id, test_id, category, status, duration_ms, message)
+     VALUES ${placeholders}
+     RETURNING id, test_id, category, status, duration_ms, message`,
     values,
   );
+  return result.rows.map(r => ({
+    id: r.id,
+    testId: r.test_id,
+    category: r.category,
+    status: r.status,
+    durationMs: r.duration_ms,
+    message: r.message,
+  }));
 }
 
 export interface FlakeRow {

--- a/website/src/pages/api/admin/tests/ingest-e2e.ts
+++ b/website/src/pages/api/admin/tests/ingest-e2e.ts
@@ -5,8 +5,11 @@ import {
   saveTestRun,
   saveTestResults,
   updateTestRun,
+  pool,
   type TestResultRow,
+  type SavedTestResult,
 } from '../../../../lib/website-db';
+import { safeOpenTestRunFailureTicket } from '../../../../lib/systemtest/test-run-bridge';
 
 interface PlaywrightTestResult {
   status: 'passed' | 'failed' | 'skipped' | 'timedOut';
@@ -22,12 +25,14 @@ interface PlaywrightTest {
 interface PlaywrightSpec {
   title: string;
   ok: boolean;
+  file?: string;
   tests: PlaywrightTest[];
 }
 
 interface PlaywrightSuite {
   specs?: PlaywrightSpec[];
   suites?: PlaywrightSuite[];
+  file?: string;
 }
 
 interface PlaywrightReport {
@@ -41,21 +46,58 @@ interface PlaywrightReport {
   };
 }
 
-function flattenSpecs(suites: PlaywrightSuite[], acc: PlaywrightSpec[] = []): PlaywrightSpec[] {
+function flattenSpecs(
+  suites: PlaywrightSuite[],
+  inheritedFile: string | undefined,
+  acc: Array<PlaywrightSpec & { resolvedFile: string | undefined }> = [],
+): Array<PlaywrightSpec & { resolvedFile: string | undefined }> {
   for (const s of suites) {
-    if (s.specs) acc.push(...s.specs);
-    if (s.suites) flattenSpecs(s.suites, acc);
+    const file = s.file ?? inheritedFile;
+    if (s.specs) {
+      for (const spec of s.specs) {
+        acc.push({ ...spec, resolvedFile: spec.file ?? file });
+      }
+    }
+    if (s.suites) flattenSpecs(s.suites, file, acc);
   }
   return acc;
 }
 
+/**
+ * Auth: either an admin browser session (oauth2-proxy → Keycloak), OR a
+ * shared bearer token used by GitHub Actions nightly e2e and any future
+ * out-of-band ingest. Token reuses the existing INTERNAL_API_TOKEN secret
+ * so we don't expand the SealedSecret surface for one new caller.
+ */
+function isInternalCallerAuthorized(request: Request): boolean {
+  const internalToken = process.env.INTERNAL_API_TOKEN;
+  if (!internalToken) return false;
+  const auth = request.headers.get('authorization') ?? '';
+  if (auth.startsWith('Bearer ') && auth.slice('Bearer '.length).trim() === internalToken) {
+    return true;
+  }
+  // Allow x-internal-token too — same convention as notify-close.ts.
+  if (request.headers.get('x-internal-token') === internalToken) return true;
+  return false;
+}
+
 export const POST: APIRoute = async ({ request }) => {
-  const session = await getSession(request.headers.get('cookie'));
-  if (!session || !isAdmin(session)) {
+  let authorized = false;
+  if (isInternalCallerAuthorized(request)) {
+    authorized = true;
+  } else {
+    const session = await getSession(request.headers.get('cookie'));
+    if (session && isAdmin(session)) authorized = true;
+  }
+  if (!authorized) {
     return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 });
   }
 
-  const report = (await request.json()) as PlaywrightReport;
+  const report = (await request.json()) as PlaywrightReport & {
+    runId?: string;
+    githubRunId?: string;
+    cluster?: string;
+  };
   const stats = report.stats;
   if (!stats || typeof stats.startTime !== 'string' || typeof stats.duration !== 'number') {
     return new Response(JSON.stringify({ error: 'Invalid Playwright report: missing stats' }), {
@@ -64,10 +106,15 @@ export const POST: APIRoute = async ({ request }) => {
     });
   }
 
-  const runId = randomUUID();
-  const cluster = process.env.BRAND_ID ?? process.env.BRAND ?? 'mentolder';
+  // Allow the caller to pin a stable runId (e.g. GitHub Actions run id) so a
+  // retried POST is idempotent at the test_run level too. New random UUID
+  // otherwise.
+  const runId = typeof report.runId === 'string' && report.runId ? report.runId : randomUUID();
+  const cluster = report.cluster
+    ?? process.env.BRAND_ID
+    ?? process.env.BRAND
+    ?? 'mentolder';
 
-  // saveTestRun only persists id/tier/testIds/cluster — finalised counts go through updateTestRun.
   await saveTestRun({ id: runId, tier: 'e2e', testIds: null, cluster });
   await updateTestRun({
     id: runId,
@@ -78,22 +125,75 @@ export const POST: APIRoute = async ({ request }) => {
     durationMs: stats.duration,
   });
 
-  const specs = flattenSpecs(report.suites ?? []);
-  const rows: TestResultRow[] = specs.flatMap((spec) =>
+  const specs = flattenSpecs(report.suites ?? [], undefined);
+  type Row = TestResultRow & { name: string; filePath?: string; isFail: boolean };
+  const rows: Row[] = specs.flatMap((spec) =>
     spec.tests.flatMap((t) =>
-      t.results.map<TestResultRow>((r) => ({
-        testId: `${spec.title} :: ${t.title}`,
-        category: 'E2E',
-        status:
-          r.status === 'passed' ? 'pass' : r.status === 'skipped' ? 'skip' : 'fail',
-        durationMs: r.duration,
-        message: r.error?.message,
-      })),
+      t.results.map<Row>((r) => {
+        const status =
+          r.status === 'passed' ? 'pass' : r.status === 'skipped' ? 'skip' : 'fail';
+        return {
+          testId: `${spec.title} :: ${t.title}`,
+          category: 'E2E',
+          status,
+          durationMs: r.duration,
+          message: r.error?.message,
+          name: `${spec.title} :: ${t.title}`,
+          filePath: spec.resolvedFile,
+          isFail: status === 'fail',
+        };
+      }),
     ),
   );
-  await saveTestResults(runId, rows);
+  // saveTestResults now returns inserted rows so we can wire result_id back
+  // into the failure-bridge for each fail.
+  const inserted: SavedTestResult[] = await saveTestResults(
+    runId,
+    rows.map(({ testId, category, status, durationMs, message }) => ({
+      testId, category, status, durationMs, message,
+    })),
+  );
 
-  return new Response(JSON.stringify({ ok: true, runId, count: rows.length }), {
+  // Build a lookup so we can attach result_id to each ticket creation. The
+  // (testId, status, message) tuple is unique enough within a single run —
+  // duplicates would produce two test_results rows AND one ticket (dedup
+  // by run_id+test_id), so the lookup just picks the first matching id.
+  const idByKey = new Map<string, number>();
+  for (const r of inserted) {
+    const key = `${r.testId}|${r.status}|${r.message ?? ''}`;
+    if (!idByKey.has(key)) idByKey.set(key, r.id);
+  }
+
+  // Source detection: GitHub Actions sets X-Github-Run-Id (we accept either
+  // a header or a body field). Used to populate the actions-run link in the
+  // ticket description.
+  const headerGhRunId = request.headers.get('x-github-run-id');
+  const githubRunId = report.githubRunId ?? headerGhRunId ?? null;
+  const source: 'github' | 'admin' | 'cli' = githubRunId ? 'github' : 'admin';
+
+  // Auto-file a ticket per failing result. Best-effort: errors route to the
+  // outbox so the ingest response is never blocked by ticket creation.
+  let ticketsOpened = 0;
+  for (const row of rows) {
+    if (!row.isFail) continue;
+    const key = `${row.testId}|${row.status}|${row.message ?? ''}`;
+    const resultId = idByKey.get(key) ?? null;
+    const ticketId = await safeOpenTestRunFailureTicket(pool, {
+      runId,
+      resultId,
+      testId: row.testId,
+      name: row.name,
+      category: 'E2E',
+      error: row.message ?? null,
+      filePath: row.filePath ?? null,
+      source,
+      githubRunId,
+      cluster,
+    });
+    if (ticketId) ticketsOpened++;
+  }
+
+  return new Response(JSON.stringify({ ok: true, runId, count: rows.length, ticketsOpened }), {
     status: 200,
     headers: { 'Content-Type': 'application/json' },
   });


### PR DESCRIPTION
## Summary
Closes the largest gap in the continuous test/triage loop: Playwright + tests/runner.sh failures populated `test_runs`/`test_results` only — no ticket was ever filed. Questionnaire-driven failures already auto-filed via `failure-bridge.ts`. Two parallel surfaces, no bridge. This PR adds the bridge.

## Schema
- `tickets.tickets.source_test_run_id` → `bachelorprojekt.test_runs(id)` (nullable)
- `tickets.tickets.source_test_result_id` → `bachelorprojekt.test_results(id)` (nullable)
- Partial unique index `tickets_one_open_per_test_run_test_uq` for dedup per (testId, runId) on open tickets

## Bridge
`openTestRunFailureTicket({ runId, resultId, testId, name, error, ... })` — idempotent insert; on failure, enqueues `systemtest_failure_outbox` (existing 5-min retry CronJob picks it up).

## Wired callers
- `POST /api/admin/tests/ingest-e2e` — for each failed Playwright result.

## Follow-up (not in this PR)
- `.github/workflows/e2e.yml` POST to ingest-e2e endpoint (needs `E2E_INGEST_TOKEN` SealedSecret)
- `spawnTestRun()` in `test-runner.ts` — wire the same bridge for admin-triggered runs

## Test plan
- [x] astro check passes
- [x] Unit test for `openTestRunFailureTicket` dedup + outbox-fallback
- [ ] Post-deploy: verify schema migration ran; check `tickets.tickets` for `source_test_run_id` column