### PR TITLE
feat(systemtest): wire nightly e2e + admin-spawned runs to test-run-bridge

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -79,6 +79,7 @@ jobs:
         run: npx playwright install --with-deps chromium webkit
 
       - name: Run Playwright suite against ${{ matrix.website_url }}
+        id: playwright
         if: steps.gate.outputs.skip != 'true'
         working-directory: tests/e2e
         env:
@@ -105,6 +106,49 @@ jobs:
           MM_TEST_USER: ${{ secrets.MM_TEST_USER }}
           MM_TEST_PASS: ${{ secrets.MM_TEST_PASS }}
         run: npx playwright test
+
+      # Ingest Playwright JSON into the website's test_runs/test_results +
+      # auto-file bug tickets for failures (PR #599 wired the endpoint to
+      # accept Bearer token auth + X-Github-Run-Id for ticket linkage).
+      # Runs on both pass and fail so flake/trend matrices reflect every
+      # nightly. Best-effort: never fail the workflow on ingest hiccups.
+      - name: Ingest Playwright results into website
+        if: always() && steps.playwright.outcome != 'skipped' && steps.gate.outputs.skip != 'true'
+        env:
+          INGEST_TOKEN: ${{ secrets.E2E_INGEST_TOKEN }}
+          INGEST_URL: ${{ matrix.website_url }}/api/admin/tests/ingest-e2e
+          REPORT: tests/results/.tmp-e2e-results.json
+          GH_RUN_ID: ${{ github.run_id }}
+          MATRIX_CLUSTER: ${{ matrix.cluster }}
+        run: |
+          if [ -z "${INGEST_TOKEN}" ]; then
+            echo "::warning::E2E_INGEST_TOKEN not set; skipping ingest. Add the token in repo secrets to enable auto-ticketing."
+            exit 0
+          fi
+          if [ ! -s "${REPORT}" ]; then
+            echo "::warning::Playwright JSON report not found at ${REPORT}; skipping ingest."
+            exit 0
+          fi
+          echo "POST ${INGEST_URL} (run=${GH_RUN_ID}, cluster=${MATRIX_CLUSTER})"
+          # Wrap the report so the endpoint sees runId/cluster too. The
+          # endpoint accepts a bare report or a wrapped envelope — we use
+          # the envelope to pin runId and cluster explicitly.
+          jq --arg cluster "${MATRIX_CLUSTER}" \
+             --arg runId "gh-${GH_RUN_ID}-${MATRIX_CLUSTER}" \
+             '. + {cluster: $cluster, runId: $runId}' \
+             "${REPORT}" > /tmp/ingest-payload.json
+          http_code=$(curl -s -o /tmp/ingest-response.json -w '%{http_code}' \
+            -X POST \
+            -H "Authorization: Bearer ${INGEST_TOKEN}" \
+            -H "Content-Type: application/json" \
+            -H "X-Github-Run-Id: ${GH_RUN_ID}" \
+            --data-binary @/tmp/ingest-payload.json \
+            "${INGEST_URL}" || echo "000")
+          echo "ingest http_code=${http_code}"
+          cat /tmp/ingest-response.json || true
+          if [ "${http_code}" != "200" ]; then
+            echo "::warning::Ingest returned HTTP ${http_code} (continuing — workflow status unaffected)."
+          fi
 
       - name: Upload results (traces + JSON report)
         if: always() && steps.gate.outputs.skip != 'true'

--- a/website/src/lib/test-runner.ts
+++ b/website/src/lib/test-runner.ts
@@ -3,7 +3,15 @@ import { createInterface } from 'readline';
 import { watch, existsSync, readdirSync } from 'fs';
 import { readFile } from 'fs/promises';
 import { randomUUID } from 'crypto';
-import { saveTestRun, saveTestResults, updateTestRun, type TestResultRow } from './website-db.js';
+import {
+  saveTestRun,
+  saveTestResults,
+  updateTestRun,
+  pool,
+  type TestResultRow,
+  type SavedTestResult,
+} from './website-db.js';
+import { safeOpenTestRunFailureTicket } from './systemtest/test-run-bridge.js';
 
 export interface TestResult {
   req: string;
@@ -223,22 +231,61 @@ export async function spawnTestRun(tier: string, testIds: string[]): Promise<str
     if (sourceResults.length > 0) {
       const allowedCategories = new Set(['FA', 'SA', 'NFA', 'AK', 'E2E', 'BATS']);
       const allowedStatuses = new Set(['pass', 'fail', 'skip']);
-      const rows: TestResultRow[] = sourceResults
+      type EnrichedRow = TestResultRow & { name: string };
+      const rows: EnrichedRow[] = sourceResults
         .filter(r => allowedStatuses.has(r.status))
         .map(r => {
           const fallbackId = r.req && r.test ? `${r.req}/${r.test}` : (r.req ?? 'unknown');
           const cat = r.category && allowedCategories.has(r.category)
             ? (r.category as TestResultRow['category'])
             : 'FA';
+          const testId = r.test_id ?? fallbackId;
           return {
-            testId: r.test_id ?? fallbackId,
+            testId,
             category: cat,
             status: r.status as TestResultRow['status'],
             durationMs: r.duration_ms,
             message: r.message ?? r.detail,
+            name: testId,
           };
         });
-      await saveTestResults(id, rows).catch(() => {});
+      // Save and capture inserted result_ids so we can wire each failure to
+      // the bridge with the precise test_results row id (mirrors what
+      // ingest-e2e.ts does for the nightly path).
+      const inserted: SavedTestResult[] = await saveTestResults(
+        id,
+        rows.map(({ testId, category, status, durationMs, message }) => ({
+          testId, category, status, durationMs, message,
+        })),
+      ).catch(() => [] as SavedTestResult[]);
+
+      // Best-effort auto-ticketing per failure — same contract as ingest-e2e:
+      // dedup by (run_id, test_id), errors route to the outbox.
+      // Source = 'admin' for spawnTestRun (admin-triggered from /admin/monitoring).
+      if (inserted.length > 0) {
+        const idByKey = new Map<string, number>();
+        for (const r of inserted) {
+          const key = `${r.testId}|${r.status}|${r.message ?? ''}`;
+          if (!idByKey.has(key)) idByKey.set(key, r.id);
+        }
+        for (const row of rows) {
+          if (row.status !== 'fail') continue;
+          const key = `${row.testId}|${row.status}|${row.message ?? ''}`;
+          const resultId = idByKey.get(key) ?? null;
+          await safeOpenTestRunFailureTicket(pool, {
+            runId: id,
+            resultId,
+            testId: row.testId,
+            name: row.name,
+            category: row.category,
+            error: row.message ?? null,
+            source: 'admin',
+            cluster,
+          }).catch((err) =>
+            console.error('[test-runner] safeOpenTestRunFailureTicket failed:', err),
+          );
+        }
+      }
     }
 
     emit('done', JSON.stringify({ code, summary, durationMs }));


### PR DESCRIPTION
## Summary

Two follow-ups from PR #599 (auto-file tickets on Playwright/runner.sh failures + run_id linkback) bundled into a single PR.

### Follow-up 1 — Nightly e2e workflow ingests results

`.github/workflows/e2e.yml` now POSTs the Playwright JSON report to `/api/admin/tests/ingest-e2e` after the suite runs, for both matrix clusters (`mentolder` + `korczewski`). The endpoint already accepts `Authorization: Bearer <token>` (added in #599) and reads `X-Github-Run-Id` for ticket linkage.

- Step runs with `if: always() && steps.playwright.outcome != 'skipped'` so flake/trend matrices reflect both passing AND failing runs.
- Best-effort: missing `E2E_INGEST_TOKEN`, missing JSON report, or non-200 ingest response only emits a workflow `::warning::`. The workflow status stays driven by the Playwright step.
- Payload is wrapped via `jq` to pin a stable `runId` (`gh-<run_id>-<cluster>`) and the cluster label so retried POSTs are idempotent at the test_run level.

### Follow-up 2 — Admin-spawned runs auto-file tickets

`website/src/lib/test-runner.ts::spawnTestRun()` now collects the inserted `test_results.id` rows from `saveTestResults` (which already returns `RETURNING id` after #599) and calls `safeOpenTestRunFailureTicket(...)` for each failing row. Same contract as the ingest-e2e endpoint:
- Dedup by `(run_id, test_id)` via the partial unique index.
- Errors route through `systemtest_failure_outbox` so SSE responses to `/admin/monitoring` are never blocked.
- `source: 'admin'`, cluster forwarded from `CLUSTER_ENV`.

## Manual step after merge

Add `E2E_INGEST_TOKEN` to GitHub repo secrets. Value must match `INTERNAL_API_TOKEN` from the website SealedSecret on whichever cluster you point the workflow at (both clusters share the token in the matrix today — pick one or rotate matched values into both).

## Test plan
- [ ] `cd website && npx astro check` — no NEW errors introduced (verified locally; 18 pre-existing errors unchanged).
- [ ] `npx vitest run src/lib/systemtest/` — passes (4 passed, 25 skipped DB-gated).
- [ ] After merge + secret added: trigger `e2e.yml` via `workflow_dispatch` and confirm the ingest step reports `http_code=200`, `tickets_opened` reflects failures, and the run shows up under `/admin/tests/runs/<id>` on the targeted website.
- [ ] Trigger an admin run from `/admin/monitoring` with a known-failing test ID and verify a bug ticket appears under `/admin/tickets`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)