### PR TITLE
fix(website): use Recreate strategy to avoid PVC Multi-Attach deadlock

### DIFF
--- a/k3d/website.yaml
+++ b/k3d/website.yaml
@@ -145,6 +145,10 @@ metadata:
   namespace: ${WEBSITE_NAMESPACE}
 spec:
   replicas: 1
+  # evidence-pvc is RWO; rolling update would deadlock on Multi-Attach. Recreate
+  # terminates the old pod first (~30s downtime) so the new pod can attach.
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: website


### PR DESCRIPTION
## Summary
The website Deployment mounts `evidence-pvc` (RWO) for systemtest rrweb recordings. With the default RollingUpdate strategy and `replicas: 1`, rollouts deadlock — the new pod can't attach the volume while the old pod still holds it (`Warning: FailedAttachVolume: Multi-Attach error`).

Discovered while deploying #595–#602: the new pod sat in `ContainerCreating` for 13 minutes with `Multi-Attach error for volume "pvc-c27dd1cc-..."`. The workaround was a live `kubectl patch` to set strategy=Recreate on both clusters; this commit makes it permanent in the manifest.

## Trade-off
~30 seconds of downtime per deploy (acceptable — admins get redirected to the maintenance page or 502, but full-page is brief).

## Test plan
- [x] Live-patched on mentolder + korczewski; rollout completed cleanly on both
- [ ] Verify next \`task feature:website\` rolls without intervention