### PR TITLE
feat(fragebogen): archive submitted as frozen KPI datapoint + replay surface

### DIFF
--- a/docs/superpowers/plans/2026-05-08-fragebogen-archive.md
+++ b/docs/superpowers/plans/2026-05-08-fragebogen-archive.md
@@ -1,0 +1,2143 @@
+# Fragebogen Archive Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let admins archive a submitted/reviewed Fragebogen as a frozen historical KPI datapoint, hide archived items from active views, surface the rrweb video proof on the archived detail page, and reassign the same template without resetting the previous result.
+
+**Architecture:** Single transactional `archiveQAssignment` writes a snapshot of dimension scores into a new `questionnaire_assignment_scores` table while flipping the assignment to `archived`. A new `reassignQAssignment` creates a fresh assignment row, leaving the archived original untouched. A SQL view `bachelorprojekt.v_questionnaire_kpi` joins the snapshot to the assignment + evidence aggregates for KPI consumers. The admin detail page wires the existing `SystemtestReplayDrawer` per `test_step` row that has evidence; both list views split active vs archived with a toggle.
+
+**Tech Stack:** Astro 4 + Svelte 5 (frontend), Astro API routes (Node), PostgreSQL 16 (`shared-db`), `pg` driver, vitest 4 (unit), Playwright (e2e), rrweb (existing recorder).
+
+---
+
+## File Structure
+
+**Modify:**
+- `website/src/lib/questionnaire-db.ts` — schema bootstrap (initDb), `archiveQAssignment`, `reassignQAssignment`, `listArchivedScores`, `listEvidenceByAssignment`; reroute `updateQAssignment` archived branch; export `DimensionScore` re-import
+- `website/src/lib/compute-scores.ts` — add `getDisplayScores` shim selecting snapshot vs computed
+- `website/src/pages/admin/fragebogen/[assignmentId].astro` — archive button gating, reassign button, replay button per test_step
+- `website/src/components/admin/ClientQuestionnairesPanel.svelte` — split active/archived + toggle
+- `website/src/components/admin/ProjectQuestionnairesPanel.astro` — split active/archived `<details>` block; use `getDisplayScores` for archived
+- `website/src/pages/admin/projekte/[id].astro` — pass snapshot scores into the panel for archived rows
+- `website/src/pages/admin/tickets/[id].astro` — same as above
+
+**Create:**
+- `website/src/pages/api/admin/questionnaires/assignments/[id]/archive.ts` — POST endpoint
+- `website/src/pages/api/admin/questionnaires/assignments/[id]/reassign.ts` — POST endpoint
+- `website/src/lib/questionnaire-archive.test.ts` — unit tests for archive + reassign + listEvidenceByAssignment + listArchivedScores + view shape
+- `website/src/pages/api/admin/questionnaires/assignments/[id]/archive.test.ts` — API tests for archive endpoint
+- `website/src/pages/api/admin/questionnaires/assignments/[id]/reassign.test.ts` — API tests for reassign endpoint
+- `tests/e2e/specs/fa-fragebogen-archive.spec.ts` — Playwright archive→reassign→replay flow
+
+---
+
+## Task 1: Snapshot table + KPI view + schema bootstrap
+
+**Files:**
+- Modify: `website/src/lib/questionnaire-db.ts:174-279` (the `initDb()` function)
+- Create: `website/src/lib/questionnaire-archive.test.ts`
+
+- [ ] **Step 1: Write the failing test for schema bootstrap**
+
+Create `website/src/lib/questionnaire-archive.test.ts`:
+
+```ts
+import { describe, it, expect, beforeAll } from 'vitest';
+import { pool } from './website-db';
+
+const dbAvailable = !!(
+  process.env.DATABASE_URL ||
+  process.env.WEBSITE_DATABASE_URL ||
+  process.env.SESSIONS_DATABASE_URL
+);
+
+describe.skipIf(!dbAvailable)('archive schema', () => {
+  beforeAll(async () => {
+    // initDb in questionnaire-db.ts runs at module load via top-level await
+    await import('./questionnaire-db');
+  });
+
+  it('creates questionnaire_assignment_scores table', async () => {
+    const r = await pool.query(
+      `SELECT to_regclass('public.questionnaire_assignment_scores') AS t`,
+    );
+    expect(r.rows[0].t).toBe('questionnaire_assignment_scores');
+  });
+
+  it('table has expected columns', async () => {
+    const r = await pool.query(
+      `SELECT column_name FROM information_schema.columns
+       WHERE table_name='questionnaire_assignment_scores'
+       ORDER BY ordinal_position`,
+    );
+    const cols = r.rows.map((x: { column_name: string }) => x.column_name);
+    expect(cols).toEqual([
+      'id', 'assignment_id', 'dimension_id', 'dimension_name',
+      'final_score', 'threshold_mid', 'threshold_high', 'level', 'snapshot_at',
+    ]);
+  });
+
+  it('table has unique (assignment_id, dimension_id) constraint', async () => {
+    const r = await pool.query(
+      `SELECT indexdef FROM pg_indexes
+       WHERE tablename='questionnaire_assignment_scores'
+         AND indexdef ILIKE '%UNIQUE%'`,
+    );
+    expect(r.rows.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('creates bachelorprojekt.v_questionnaire_kpi view', async () => {
+    const r = await pool.query(
+      `SELECT to_regclass('bachelorprojekt.v_questionnaire_kpi') AS t`,
+    );
+    expect(r.rows[0].t).toBe('bachelorprojekt.v_questionnaire_kpi');
+  });
+
+  it('view exposes evidence_count + latest_evidence_id columns', async () => {
+    const r = await pool.query(
+      `SELECT column_name FROM information_schema.columns
+       WHERE table_schema='bachelorprojekt' AND table_name='v_questionnaire_kpi'`,
+    );
+    const cols = r.rows.map((x: { column_name: string }) => x.column_name);
+    expect(cols).toContain('evidence_count');
+    expect(cols).toContain('latest_evidence_id');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd website && SESSIONS_DATABASE_URL=postgresql://website:devwebsitedb@localhost:5432/website npx vitest run src/lib/questionnaire-archive.test.ts`
+Expected: FAIL — `to_regclass(...)` returns NULL for the new table/view.
+
+(If a local PG isn't reachable, the test auto-skips; the `task workspace:port-forward ENV=mentolder` task forwards `shared-db` to localhost:5432 — see `CLAUDE.md` "Database Management".)
+
+- [ ] **Step 3: Add schema bootstrap to initDb()**
+
+Append to the body of `initDb()` in `website/src/lib/questionnaire-db.ts`, immediately before the `await ensureSystemtestSchema(pool);` line at the end:
+
+```ts
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS questionnaire_assignment_scores (
+      id             UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      assignment_id  UUID NOT NULL REFERENCES questionnaire_assignments(id) ON DELETE CASCADE,
+      dimension_id   UUID NOT NULL,
+      dimension_name TEXT NOT NULL,
+      final_score    INTEGER NOT NULL,
+      threshold_mid  INTEGER,
+      threshold_high INTEGER,
+      level          TEXT,
+      snapshot_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+      CONSTRAINT uq_qas_assignment_dimension UNIQUE (assignment_id, dimension_id)
+    )
+  `);
+  await pool.query(
+    `CREATE INDEX IF NOT EXISTS idx_qas_assignment ON questionnaire_assignment_scores(assignment_id)`,
+  );
+  await pool.query(`CREATE SCHEMA IF NOT EXISTS bachelorprojekt`);
+  await pool.query(`
+    CREATE OR REPLACE VIEW bachelorprojekt.v_questionnaire_kpi AS
+    SELECT
+      a.id              AS assignment_id,
+      a.customer_id,
+      a.template_id,
+      t.title           AS template_title,
+      t.is_system_test,
+      a.assigned_at,
+      a.submitted_at,
+      a.archived_at,
+      s.dimension_id,
+      s.dimension_name,
+      s.final_score,
+      s.threshold_mid,
+      s.threshold_high,
+      s.level,
+      ev.evidence_count,
+      ev.latest_evidence_id
+    FROM questionnaire_assignments a
+    JOIN questionnaire_templates t ON t.id = a.template_id
+    JOIN questionnaire_assignment_scores s ON s.assignment_id = a.id
+    LEFT JOIN LATERAL (
+      SELECT
+        COUNT(*)::int AS evidence_count,
+        (ARRAY_AGG(e.id ORDER BY e.attempt DESC, e.created_at DESC))[1] AS latest_evidence_id
+      FROM questionnaire_test_evidence e
+      WHERE e.assignment_id = a.id
+    ) ev ON true
+    WHERE a.status = 'archived'
+  `);
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd website && SESSIONS_DATABASE_URL=postgresql://website:devwebsitedb@localhost:5432/website npx vitest run src/lib/questionnaire-archive.test.ts`
+Expected: 5 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add website/src/lib/questionnaire-db.ts website/src/lib/questionnaire-archive.test.ts
+git commit -m "feat(questionnaire): add archive snapshot table + KPI view
+
+Adds questionnaire_assignment_scores (one row per dimension per archived
+assignment, snapshotted at archive time) and bachelorprojekt.v_questionnaire_kpi
+view that joins assignments, snapshots, and evidence aggregates."
+```
+
+---
+
+## Task 2: archiveQAssignment helper
+
+**Files:**
+- Modify: `website/src/lib/questionnaire-db.ts` — add new function after `dismissQAssignment` (around line 576)
+- Modify: `website/src/lib/questionnaire-archive.test.ts` — add archive test cases
+
+- [ ] **Step 1: Write failing tests for archiveQAssignment**
+
+Append to `website/src/lib/questionnaire-archive.test.ts`:
+
+```ts
+import {
+  createQTemplate, upsertQDimension, upsertQQuestion, replaceQAnswerOptions,
+  createQAssignment, updateQAssignment, upsertQAnswer, getQAssignment,
+} from './questionnaire-db';
+// archiveQAssignment is imported below so test failure cleanly indicates "not exported"
+import { archiveQAssignment } from './questionnaire-db';
+import { randomUUID } from 'crypto';
+
+describe.skipIf(!dbAvailable)('archiveQAssignment', () => {
+  async function seedSubmittedAssignment() {
+    const tpl = await createQTemplate({
+      title: `archive-test-${randomUUID().slice(0, 8)}`,
+      description: '', instructions: '',
+    });
+    const dim = await upsertQDimension({
+      templateId: tpl.id, name: 'TestDim', position: 0,
+      thresholdMid: 5, thresholdHigh: 10,
+    });
+    const q = await upsertQQuestion({
+      templateId: tpl.id, position: 0,
+      questionText: 'q?', questionType: 'likert_5',
+    });
+    await replaceQAnswerOptions(q.id, [
+      { optionKey: '5', label: 'high', dimensionId: dim.id, weight: 1 },
+    ]);
+    const a = await createQAssignment({
+      customerId: randomUUID(), templateId: tpl.id,
+    });
+    await upsertQAnswer({
+      assignmentId: a.id, questionId: q.id, optionKey: '5',
+    });
+    await updateQAssignment(a.id, { status: 'submitted' });
+    return { tpl, dim, q, a };
+  }
+
+  it('writes one snapshot row per dimension and flips status to archived', async () => {
+    const { dim, a } = await seedSubmittedAssignment();
+    const result = await archiveQAssignment(a.id);
+    expect('assignment' in result).toBe(true);
+    if (!('assignment' in result)) return;
+    expect(result.assignment.status).toBe('archived');
+    expect(result.assignment.archived_at).not.toBeNull();
+    const snap = await pool.query(
+      `SELECT dimension_id, dimension_name, final_score, level
+         FROM questionnaire_assignment_scores
+        WHERE assignment_id = $1`,
+      [a.id],
+    );
+    expect(snap.rows.length).toBe(1);
+    expect(snap.rows[0].dimension_id).toBe(dim.id);
+    expect(snap.rows[0].dimension_name).toBe('TestDim');
+    expect(snap.rows[0].final_score).toBe(5); // weight 1 * key 5 * multiplier 1
+    expect(snap.rows[0].level).toBe('mittel');
+  });
+
+  it('rejects non-archivable statuses with a reason', async () => {
+    const tpl = await createQTemplate({
+      title: `reject-${randomUUID().slice(0, 8)}`, description: '', instructions: '',
+    });
+    const a = await createQAssignment({
+      customerId: randomUUID(), templateId: tpl.id,
+    }); // status='pending'
+    const result = await archiveQAssignment(a.id);
+    expect('reason' in result).toBe(true);
+    if ('reason' in result) {
+      expect(result.reason).toBe('not_archivable');
+      expect(result.status).toBe('pending');
+    }
+  });
+
+  it('returns not_found for missing id', async () => {
+    const result = await archiveQAssignment(randomUUID());
+    expect('reason' in result && result.reason).toBe('not_found');
+  });
+
+  it('is idempotent: re-archiving an archived row leaves snapshot intact', async () => {
+    const { a } = await seedSubmittedAssignment();
+    await archiveQAssignment(a.id);
+    const before = await pool.query(
+      `SELECT id, snapshot_at FROM questionnaire_assignment_scores
+        WHERE assignment_id = $1`,
+      [a.id],
+    );
+    const result2 = await archiveQAssignment(a.id);
+    expect('assignment' in result2).toBe(true);
+    const after = await pool.query(
+      `SELECT id, snapshot_at FROM questionnaire_assignment_scores
+        WHERE assignment_id = $1`,
+      [a.id],
+    );
+    expect(after.rows.map(r => r.id).sort()).toEqual(before.rows.map(r => r.id).sort());
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd website && SESSIONS_DATABASE_URL=postgresql://website:devwebsitedb@localhost:5432/website npx vitest run src/lib/questionnaire-archive.test.ts`
+Expected: FAIL — `archiveQAssignment` is not exported from `./questionnaire-db`.
+
+- [ ] **Step 3: Implement archiveQAssignment**
+
+Add to `website/src/lib/questionnaire-db.ts`, immediately after `dismissQAssignment`:
+
+```ts
+import { computeScores } from './compute-scores';
+
+const ARCHIVABLE_STATUSES: AssignmentStatus[] = ['submitted', 'reviewed', 'archived'];
+
+/**
+ * Freeze a submitted/reviewed assignment as a permanent KPI datapoint.
+ *
+ * Single transaction: locks the assignment row, flips status → 'archived',
+ * stamps `archived_at`, and snapshots one row per dimension into
+ * `questionnaire_assignment_scores`. Already-archived assignments are a no-op
+ * (returns the row unchanged) so retries are safe.
+ *
+ * coach_notes are preserved verbatim; the snapshot is computed from the
+ * current dimensions/answer_options/answers and persisted denormalized so
+ * later template edits don't shift historical KPIs.
+ */
+export async function archiveQAssignment(id: string): Promise<
+  | { assignment: QAssignment }
+  | { reason: 'not_found' | 'not_archivable'; status?: AssignmentStatus }
+> {
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+    const a = await client.query<{ template_id: string; status: AssignmentStatus }>(
+      `SELECT template_id, status FROM questionnaire_assignments
+        WHERE id = $1 FOR UPDATE`,
+      [id],
+    );
+    if (a.rows.length === 0) {
+      await client.query('ROLLBACK');
+      return { reason: 'not_found' };
+    }
+    const status = a.rows[0].status;
+    if (!ARCHIVABLE_STATUSES.includes(status)) {
+      await client.query('ROLLBACK');
+      return { reason: 'not_archivable', status };
+    }
+    const templateId = a.rows[0].template_id;
+
+    if (status !== 'archived') {
+      await client.query(
+        `UPDATE questionnaire_assignments
+            SET status = 'archived', archived_at = now()
+          WHERE id = $1`,
+        [id],
+      );
+    }
+
+    const dimsRes = await client.query<QDimension>(
+      `SELECT id, template_id, name, position, threshold_mid, threshold_high,
+              score_multiplier, created_at
+         FROM questionnaire_dimensions WHERE template_id = $1 ORDER BY position`,
+      [templateId],
+    );
+    const optsRes = await client.query<QAnswerOption>(
+      `SELECT ao.id, ao.question_id, ao.option_key, ao.label, ao.dimension_id, ao.weight
+         FROM questionnaire_answer_options ao
+         JOIN questionnaire_questions q ON q.id = ao.question_id
+        WHERE q.template_id = $1`,
+      [templateId],
+    );
+    const ansRes = await client.query<QAnswer>(
+      `SELECT id, assignment_id, question_id, option_key, details_text, saved_at
+         FROM questionnaire_answers WHERE assignment_id = $1`,
+      [id],
+    );
+
+    const scores = computeScores(dimsRes.rows, optsRes.rows, ansRes.rows);
+    for (const s of scores) {
+      await client.query(
+        `INSERT INTO questionnaire_assignment_scores
+           (assignment_id, dimension_id, dimension_name, final_score,
+            threshold_mid, threshold_high, level)
+         VALUES ($1, $2, $3, $4, $5, $6, $7)
+         ON CONFLICT ON CONSTRAINT uq_qas_assignment_dimension DO NOTHING`,
+        [id, s.dimension_id, s.name, s.final_score,
+         s.threshold_mid, s.threshold_high, s.level],
+      );
+    }
+
+    await client.query('COMMIT');
+    const updated = await getQAssignment(id);
+    if (!updated) return { reason: 'not_found' };
+    return { assignment: updated };
+  } catch (err) {
+    await client.query('ROLLBACK').catch(() => {});
+    throw err;
+  } finally {
+    client.release();
+  }
+}
+```
+
+Add the import at the top of `questionnaire-db.ts` (after the existing imports, around line 5):
+
+```ts
+import { computeScores } from './compute-scores';
+```
+
+(There is currently no import of `compute-scores.ts` in `questionnaire-db.ts`. `compute-scores.ts` already imports types from `questionnaire-db`; adding the reverse import would create a cycle. Workaround: convert the import to a deferred dynamic import inside `archiveQAssignment`:
+
+```ts
+const { computeScores } = await import('./compute-scores');
+```
+
+Use the dynamic-import form. This avoids the cycle without restructuring the type module.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd website && SESSIONS_DATABASE_URL=postgresql://website:devwebsitedb@localhost:5432/website npx vitest run src/lib/questionnaire-archive.test.ts`
+Expected: 9 PASS (5 schema + 4 archive).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add website/src/lib/questionnaire-db.ts website/src/lib/questionnaire-archive.test.ts
+git commit -m "feat(questionnaire): archiveQAssignment with score snapshot
+
+Single-transaction archive: locks the row, flips status to archived,
+stamps archived_at, and snapshots one row per dimension via computeScores
+into questionnaire_assignment_scores. Idempotent for retries."
+```
+
+---
+
+## Task 3: reassignQAssignment helper
+
+**Files:**
+- Modify: `website/src/lib/questionnaire-db.ts` — add `reassignQAssignment` after `archiveQAssignment`
+- Modify: `website/src/lib/questionnaire-archive.test.ts` — add reassign tests
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `website/src/lib/questionnaire-archive.test.ts`:
+
+```ts
+import { reassignQAssignment } from './questionnaire-db';
+
+describe.skipIf(!dbAvailable)('reassignQAssignment', () => {
+  it('creates a new pending assignment for the same template + customer; source untouched', async () => {
+    const tpl = await createQTemplate({
+      title: `reassign-${randomUUID().slice(0, 8)}`, description: '', instructions: '',
+    });
+    const customerId = randomUUID();
+    const src = await createQAssignment({ customerId, templateId: tpl.id });
+    await updateQAssignment(src.id, { status: 'submitted' });
+    await archiveQAssignment(src.id);
+
+    const result = await reassignQAssignment(src.id);
+    expect('assignment' in result).toBe(true);
+    if (!('assignment' in result)) return;
+    expect(result.assignment.id).not.toBe(src.id);
+    expect(result.assignment.status).toBe('pending');
+    expect(result.assignment.template_id).toBe(tpl.id);
+    expect(result.assignment.customer_id).toBe(customerId);
+    expect(result.assignment.archived_at).toBeNull();
+    expect(result.assignment.submitted_at).toBeNull();
+    expect(result.assignment.coach_notes).toBe('');
+
+    const before = await getQAssignment(src.id);
+    expect(before?.status).toBe('archived');
+    expect(before?.archived_at).not.toBeNull();
+  });
+
+  it('returns not_found for missing id', async () => {
+    const result = await reassignQAssignment(randomUUID());
+    expect('reason' in result && result.reason).toBe('not_found');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd website && SESSIONS_DATABASE_URL=postgresql://website:devwebsitedb@localhost:5432/website npx vitest run src/lib/questionnaire-archive.test.ts`
+Expected: FAIL — `reassignQAssignment` is not exported.
+
+- [ ] **Step 3: Implement reassignQAssignment**
+
+Add to `website/src/lib/questionnaire-db.ts` immediately after `archiveQAssignment`:
+
+```ts
+/**
+ * Create a brand-new assignment row for the same template + customer (+project)
+ * as the source assignment. The source row is not touched — used after archive
+ * so the historical datapoint stays intact while the next datapoint runs fresh.
+ */
+export async function reassignQAssignment(id: string): Promise<
+  | { assignment: QAssignment }
+  | { reason: 'not_found' }
+> {
+  const src = await getQAssignment(id);
+  if (!src) return { reason: 'not_found' };
+  const created = await createQAssignment({
+    customerId: src.customer_id,
+    templateId: src.template_id,
+    projectId: src.project_id ?? undefined,
+  });
+  return { assignment: created };
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd website && SESSIONS_DATABASE_URL=postgresql://website:devwebsitedb@localhost:5432/website npx vitest run src/lib/questionnaire-archive.test.ts`
+Expected: 11 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add website/src/lib/questionnaire-db.ts website/src/lib/questionnaire-archive.test.ts
+git commit -m "feat(questionnaire): reassignQAssignment creates new datapoint
+
+Allocates a fresh pending assignment for the source's template+customer
+(+project), leaving the source row untouched so it can serve as a frozen
+historical datapoint."
+```
+
+---
+
+## Task 4: listEvidenceByAssignment + listArchivedScores helpers
+
+**Files:**
+- Modify: `website/src/lib/questionnaire-db.ts` — add both helpers near the bottom
+- Modify: `website/src/lib/questionnaire-archive.test.ts` — add helper tests
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `website/src/lib/questionnaire-archive.test.ts`:
+
+```ts
+import { listArchivedScores, listEvidenceByAssignment } from './questionnaire-db';
+
+describe.skipIf(!dbAvailable)('listArchivedScores', () => {
+  it('returns snapshot rows for an archived assignment', async () => {
+    const tpl = await createQTemplate({
+      title: `lsnap-${randomUUID().slice(0, 8)}`, description: '', instructions: '',
+    });
+    const dim = await upsertQDimension({
+      templateId: tpl.id, name: 'X', position: 0, thresholdMid: 5, thresholdHigh: 10,
+    });
+    const q = await upsertQQuestion({
+      templateId: tpl.id, position: 0, questionText: 'q', questionType: 'likert_5',
+    });
+    await replaceQAnswerOptions(q.id, [
+      { optionKey: '3', label: 'm', dimensionId: dim.id, weight: 1 },
+    ]);
+    const a = await createQAssignment({ customerId: randomUUID(), templateId: tpl.id });
+    await upsertQAnswer({ assignmentId: a.id, questionId: q.id, optionKey: '3' });
+    await updateQAssignment(a.id, { status: 'submitted' });
+    await archiveQAssignment(a.id);
+
+    const rows = await listArchivedScores(a.id);
+    expect(rows.length).toBe(1);
+    expect(rows[0].dimension_id).toBe(dim.id);
+    expect(rows[0].final_score).toBe(3);
+  });
+
+  it('returns empty array for non-archived assignment', async () => {
+    const tpl = await createQTemplate({
+      title: `lsnap-empty-${randomUUID().slice(0, 8)}`, description: '', instructions: '',
+    });
+    const a = await createQAssignment({ customerId: randomUUID(), templateId: tpl.id });
+    const rows = await listArchivedScores(a.id);
+    expect(rows).toEqual([]);
+  });
+});
+
+describe.skipIf(!dbAvailable)('listEvidenceByAssignment', () => {
+  it('returns latest-attempt evidence per question with count', async () => {
+    const tpl = await createQTemplate({
+      title: `evid-${randomUUID().slice(0, 8)}`, description: '', instructions: '',
+    });
+    const q = await upsertQQuestion({
+      templateId: tpl.id, position: 0, questionText: 's', questionType: 'test_step',
+    });
+    const a = await createQAssignment({ customerId: randomUUID(), templateId: tpl.id });
+    const e1 = await pool.query<{ id: string }>(
+      `INSERT INTO questionnaire_test_evidence
+         (assignment_id, question_id, attempt, replay_path)
+       VALUES ($1, $2, 0, '/tmp/r0') RETURNING id`,
+      [a.id, q.id],
+    );
+    const e2 = await pool.query<{ id: string }>(
+      `INSERT INTO questionnaire_test_evidence
+         (assignment_id, question_id, attempt, replay_path)
+       VALUES ($1, $2, 1, '/tmp/r1') RETURNING id`,
+      [a.id, q.id],
+    );
+
+    const rows = await listEvidenceByAssignment(a.id);
+    expect(rows.length).toBe(1);
+    expect(rows[0].question_id).toBe(q.id);
+    expect(rows[0].latest_evidence_id).toBe(e2.rows[0].id);
+    expect(rows[0].latest_attempt).toBe(1);
+    expect(rows[0].evidence_count).toBe(2);
+  });
+
+  it('returns empty array when there is no evidence', async () => {
+    const tpl = await createQTemplate({
+      title: `evid-empty-${randomUUID().slice(0, 8)}`, description: '', instructions: '',
+    });
+    const a = await createQAssignment({ customerId: randomUUID(), templateId: tpl.id });
+    const rows = await listEvidenceByAssignment(a.id);
+    expect(rows).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd website && SESSIONS_DATABASE_URL=postgresql://website:devwebsitedb@localhost:5432/website npx vitest run src/lib/questionnaire-archive.test.ts`
+Expected: FAIL — `listArchivedScores` and `listEvidenceByAssignment` not exported.
+
+- [ ] **Step 3: Implement both helpers**
+
+Add to `website/src/lib/questionnaire-db.ts`, near the bottom of the file (after the existing `listTestStatusesForMonitoring` function):
+
+```ts
+export interface QArchivedScore {
+  assignment_id: string;
+  dimension_id: string;
+  dimension_name: string;
+  final_score: number;
+  threshold_mid: number | null;
+  threshold_high: number | null;
+  level: 'förderlich' | 'mittel' | 'kritisch' | null;
+  snapshot_at: string;
+}
+
+export async function listArchivedScores(assignmentId: string): Promise<QArchivedScore[]> {
+  const r = await pool.query(
+    `SELECT assignment_id, dimension_id, dimension_name, final_score,
+            threshold_mid, threshold_high, level, snapshot_at
+       FROM questionnaire_assignment_scores
+      WHERE assignment_id = $1
+      ORDER BY dimension_name`,
+    [assignmentId],
+  );
+  return r.rows;
+}
+
+export interface QEvidenceForQuestion {
+  question_id: string;
+  latest_evidence_id: string;
+  latest_attempt: number;
+  evidence_count: number;
+}
+
+export async function listEvidenceByAssignment(
+  assignmentId: string,
+): Promise<QEvidenceForQuestion[]> {
+  const r = await pool.query(
+    `SELECT question_id,
+            (ARRAY_AGG(id ORDER BY attempt DESC, created_at DESC))[1] AS latest_evidence_id,
+            MAX(attempt)::int                                          AS latest_attempt,
+            COUNT(*)::int                                              AS evidence_count
+       FROM questionnaire_test_evidence
+      WHERE assignment_id = $1
+      GROUP BY question_id`,
+    [assignmentId],
+  );
+  return r.rows;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd website && SESSIONS_DATABASE_URL=postgresql://website:devwebsitedb@localhost:5432/website npx vitest run src/lib/questionnaire-archive.test.ts`
+Expected: 15 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add website/src/lib/questionnaire-db.ts website/src/lib/questionnaire-archive.test.ts
+git commit -m "feat(questionnaire): listArchivedScores + listEvidenceByAssignment
+
+Two read helpers: snapshot rows for an archived assignment, and
+latest-attempt evidence pointer per question (with attempt count) for
+the assignment detail page."
+```
+
+---
+
+## Task 5: getDisplayScores shim
+
+**Files:**
+- Modify: `website/src/lib/compute-scores.ts` — add `getDisplayScores` at the bottom
+- Modify: `website/src/lib/questionnaire-archive.test.ts` — add shim test
+
+- [ ] **Step 1: Write failing test**
+
+Append to `website/src/lib/questionnaire-archive.test.ts`:
+
+```ts
+import { getDisplayScores } from './compute-scores';
+
+describe.skipIf(!dbAvailable)('getDisplayScores', () => {
+  it('uses snapshot for archived; falls back to compute for non-archived', async () => {
+    const tpl = await createQTemplate({
+      title: `gds-${randomUUID().slice(0, 8)}`, description: '', instructions: '',
+    });
+    const dim = await upsertQDimension({
+      templateId: tpl.id, name: 'D', position: 0, thresholdMid: 5, thresholdHigh: 10,
+    });
+    const q = await upsertQQuestion({
+      templateId: tpl.id, position: 0, questionText: 'q', questionType: 'likert_5',
+    });
+    await replaceQAnswerOptions(q.id, [
+      { optionKey: '4', label: 'x', dimensionId: dim.id, weight: 1 },
+    ]);
+    const a = await createQAssignment({ customerId: randomUUID(), templateId: tpl.id });
+    await upsertQAnswer({ assignmentId: a.id, questionId: q.id, optionKey: '4' });
+    await updateQAssignment(a.id, { status: 'submitted' });
+
+    const live = await getDisplayScores(await getQAssignment(a.id) as any);
+    expect(live[0].final_score).toBe(4);
+    expect(live[0].name).toBe('D');
+
+    await archiveQAssignment(a.id);
+    // Mutate the dim weight and threshold AFTER archive — snapshot must not shift.
+    await upsertQDimension({
+      id: dim.id, templateId: tpl.id, name: 'D-renamed', position: 0,
+      thresholdMid: 1, thresholdHigh: 2,
+    });
+    const frozen = await getDisplayScores(await getQAssignment(a.id) as any);
+    expect(frozen[0].final_score).toBe(4); // from snapshot
+    expect(frozen[0].name).toBe('D');      // snapshot dimension_name, not the renamed one
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd website && SESSIONS_DATABASE_URL=postgresql://website:devwebsitedb@localhost:5432/website npx vitest run src/lib/questionnaire-archive.test.ts`
+Expected: FAIL — `getDisplayScores` is not exported.
+
+- [ ] **Step 3: Implement getDisplayScores**
+
+Append to `website/src/lib/compute-scores.ts`:
+
+```ts
+import type { QAssignment } from './questionnaire-db';
+
+/**
+ * Render-time scores for an assignment. Archived assignments read from the
+ * frozen snapshot table so KPI numbers don't drift after template edits.
+ * Non-archived assignments compute live from the current dimensions/options/
+ * answers via `computeScores`.
+ */
+export async function getDisplayScores(assignment: QAssignment): Promise<DimensionScore[]> {
+  const {
+    listArchivedScores, listQDimensions, listQAnswerOptionsForTemplate, listQAnswers,
+  } = await import('./questionnaire-db');
+
+  if (assignment.status === 'archived') {
+    const snap = await listArchivedScores(assignment.id);
+    return snap.map((s, i) => ({
+      dimension_id: s.dimension_id,
+      name: s.dimension_name,
+      position: i, // snapshot ordering matches insertion (alphabetical by name); positions are display-only
+      raw_score: s.final_score,
+      final_score: s.final_score,
+      threshold_mid: s.threshold_mid,
+      threshold_high: s.threshold_high,
+      level: s.level,
+    }));
+  }
+  const [dims, opts, answers] = await Promise.all([
+    listQDimensions(assignment.template_id),
+    listQAnswerOptionsForTemplate(assignment.template_id),
+    listQAnswers(assignment.id),
+  ]);
+  return computeScores(dims, opts, answers);
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd website && SESSIONS_DATABASE_URL=postgresql://website:devwebsitedb@localhost:5432/website npx vitest run src/lib/questionnaire-archive.test.ts`
+Expected: 16 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add website/src/lib/compute-scores.ts website/src/lib/questionnaire-archive.test.ts
+git commit -m "feat(questionnaire): getDisplayScores selects snapshot vs live
+
+Shim that returns DimensionScore[] from the frozen snapshot for
+archived assignments and from live computeScores for everything else."
+```
+
+---
+
+## Task 6: Reroute updateQAssignment archived branch through archiveQAssignment
+
+**Files:**
+- Modify: `website/src/lib/questionnaire-db.ts:545-572` (`updateQAssignment`)
+- Modify: `website/src/lib/questionnaire-archive.test.ts` — add reroute test
+
+- [ ] **Step 1: Write failing test**
+
+Append to `website/src/lib/questionnaire-archive.test.ts`:
+
+```ts
+describe.skipIf(!dbAvailable)('updateQAssignment archived reroute', () => {
+  it('writes a snapshot when status is set to archived via updateQAssignment', async () => {
+    const tpl = await createQTemplate({
+      title: `reroute-${randomUUID().slice(0, 8)}`, description: '', instructions: '',
+    });
+    const dim = await upsertQDimension({
+      templateId: tpl.id, name: 'R', position: 0, thresholdMid: 5, thresholdHigh: 10,
+    });
+    const q = await upsertQQuestion({
+      templateId: tpl.id, position: 0, questionText: 'q', questionType: 'likert_5',
+    });
+    await replaceQAnswerOptions(q.id, [
+      { optionKey: '2', label: 'y', dimensionId: dim.id, weight: 1 },
+    ]);
+    const a = await createQAssignment({ customerId: randomUUID(), templateId: tpl.id });
+    await upsertQAnswer({ assignmentId: a.id, questionId: q.id, optionKey: '2' });
+    await updateQAssignment(a.id, { status: 'submitted' });
+
+    await updateQAssignment(a.id, { status: 'archived' });
+    const snap = await pool.query(
+      `SELECT count(*)::int AS n FROM questionnaire_assignment_scores
+        WHERE assignment_id = $1`,
+      [a.id],
+    );
+    expect(snap.rows[0].n).toBe(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd website && SESSIONS_DATABASE_URL=postgresql://website:devwebsitedb@localhost:5432/website npx vitest run src/lib/questionnaire-archive.test.ts`
+Expected: FAIL — `updateQAssignment` writes status but does not snapshot.
+
+- [ ] **Step 3: Reroute updateQAssignment**
+
+In `website/src/lib/questionnaire-db.ts`, replace the body of `updateQAssignment` (currently at lines ~545-572) with:
+
+```ts
+export async function updateQAssignment(id: string, params: {
+  status?: AssignmentStatus; coachNotes?: string; dismissReason?: string;
+}): Promise<QAssignment | null> {
+  // Status transitions to 'archived' must go through archiveQAssignment so the
+  // snapshot is written transactionally. Coach notes / dismiss reason updates
+  // can still be combined with the archive call.
+  if (params.status === 'archived') {
+    if (params.coachNotes !== undefined || params.dismissReason !== undefined) {
+      const sets: string[] = [];
+      const vals: unknown[] = [];
+      if (params.coachNotes !== undefined) {
+        vals.push(params.coachNotes); sets.push(`coach_notes = $${vals.length}`);
+      }
+      if (params.dismissReason !== undefined) {
+        vals.push(params.dismissReason); sets.push(`dismiss_reason = $${vals.length}`);
+      }
+      vals.push(id);
+      await pool.query(
+        `UPDATE questionnaire_assignments SET ${sets.join(', ')}
+         WHERE id = $${vals.length}`,
+        vals,
+      );
+    }
+    const result = await archiveQAssignment(id);
+    if ('reason' in result) return null;
+    return result.assignment;
+  }
+
+  const sets: string[] = [];
+  const vals: unknown[] = [];
+  if (params.status !== undefined) {
+    vals.push(params.status); sets.push(`status = $${vals.length}`);
+    if (params.status === 'submitted') sets.push(`submitted_at = now()`);
+    if (params.status === 'reviewed') sets.push(`reviewed_at = now()`);
+    if (params.status === 'dismissed') sets.push(`dismissed_at = now()`);
+  }
+  if (params.dismissReason !== undefined) {
+    vals.push(params.dismissReason); sets.push(`dismiss_reason = $${vals.length}`);
+  }
+  if (params.coachNotes !== undefined) {
+    vals.push(params.coachNotes); sets.push(`coach_notes = $${vals.length}`);
+  }
+  if (sets.length === 0) return getQAssignment(id);
+  vals.push(id);
+  const r = await pool.query(
+    `UPDATE questionnaire_assignments SET ${sets.join(', ')}
+     WHERE id = $${vals.length}
+     RETURNING id, customer_id, template_id, status, coach_notes, assigned_at,
+               submitted_at, reviewed_at, archived_at, dismissed_at, dismiss_reason, project_id`,
+    vals,
+  );
+  const row = r.rows[0];
+  if (!row) return null;
+  const tpl = await getQTemplate(row.template_id);
+  return { ...row, template_title: tpl?.title ?? '' };
+}
+```
+
+- [ ] **Step 4: Run all archive tests to verify**
+
+Run: `cd website && SESSIONS_DATABASE_URL=postgresql://website:devwebsitedb@localhost:5432/website npx vitest run src/lib/questionnaire-archive.test.ts`
+Expected: 17 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add website/src/lib/questionnaire-db.ts website/src/lib/questionnaire-archive.test.ts
+git commit -m "refactor(questionnaire): route updateQAssignment archived through archive helper
+
+PUT /api/admin/questionnaires/assignments/[id] with status='archived' now
+writes the score snapshot transactionally. The legacy archived_at-only
+branch is removed so the snapshot is the single source of truth."
+```
+
+---
+
+## Task 7: POST /api/admin/questionnaires/assignments/[id]/archive
+
+**Files:**
+- Create: `website/src/pages/api/admin/questionnaires/assignments/[id]/archive.ts`
+- Create: `website/src/pages/api/admin/questionnaires/assignments/[id]/archive.test.ts`
+
+- [ ] **Step 1: Write failing API tests**
+
+Create `website/src/pages/api/admin/questionnaires/assignments/[id]/archive.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { POST } from './archive';
+
+vi.mock('../../../../../../lib/auth', () => ({
+  getSession: vi.fn(),
+  isAdmin: vi.fn(),
+}));
+vi.mock('../../../../../../lib/questionnaire-db', () => ({
+  archiveQAssignment: vi.fn(),
+}));
+
+import { getSession, isAdmin } from '../../../../../../lib/auth';
+import { archiveQAssignment } from '../../../../../../lib/questionnaire-db';
+
+function req(): Request {
+  return new Request('http://x', { method: 'POST', headers: { cookie: 'k=v' } });
+}
+
+beforeEach(() => {
+  vi.mocked(getSession).mockReset();
+  vi.mocked(isAdmin).mockReset();
+  vi.mocked(archiveQAssignment).mockReset();
+});
+
+describe('POST /api/admin/questionnaires/assignments/[id]/archive', () => {
+  it('401 when no session', async () => {
+    vi.mocked(getSession).mockResolvedValue(null);
+    const r = await POST({ request: req(), params: { id: 'a' } } as any);
+    expect(r.status).toBe(401);
+  });
+
+  it('401 when not admin', async () => {
+    vi.mocked(getSession).mockResolvedValue({ user: { sub: 'u' } } as any);
+    vi.mocked(isAdmin).mockReturnValue(false);
+    const r = await POST({ request: req(), params: { id: 'a' } } as any);
+    expect(r.status).toBe(401);
+  });
+
+  it('400 when id missing', async () => {
+    vi.mocked(getSession).mockResolvedValue({ user: { sub: 'u' } } as any);
+    vi.mocked(isAdmin).mockReturnValue(true);
+    const r = await POST({ request: req(), params: {} } as any);
+    expect(r.status).toBe(400);
+  });
+
+  it('404 when archive helper returns not_found', async () => {
+    vi.mocked(getSession).mockResolvedValue({ user: { sub: 'u' } } as any);
+    vi.mocked(isAdmin).mockReturnValue(true);
+    vi.mocked(archiveQAssignment).mockResolvedValue({ reason: 'not_found' } as any);
+    const r = await POST({ request: req(), params: { id: 'a' } } as any);
+    expect(r.status).toBe(404);
+  });
+
+  it('409 when status not archivable', async () => {
+    vi.mocked(getSession).mockResolvedValue({ user: { sub: 'u' } } as any);
+    vi.mocked(isAdmin).mockReturnValue(true);
+    vi.mocked(archiveQAssignment).mockResolvedValue({
+      reason: 'not_archivable', status: 'pending',
+    } as any);
+    const r = await POST({ request: req(), params: { id: 'a' } } as any);
+    expect(r.status).toBe(409);
+    const body = await r.json();
+    expect(body.status).toBe('pending');
+  });
+
+  it('200 with assignment on success', async () => {
+    vi.mocked(getSession).mockResolvedValue({ user: { sub: 'u' } } as any);
+    vi.mocked(isAdmin).mockReturnValue(true);
+    vi.mocked(archiveQAssignment).mockResolvedValue({
+      assignment: { id: 'a', status: 'archived' } as any,
+    });
+    const r = await POST({ request: req(), params: { id: 'a' } } as any);
+    expect(r.status).toBe(200);
+    const body = await r.json();
+    expect(body.assignment.id).toBe('a');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd website && npx vitest run src/pages/api/admin/questionnaires/assignments/\[id\]/archive.test.ts`
+Expected: FAIL — `./archive` module does not exist.
+
+- [ ] **Step 3: Implement the endpoint**
+
+Create `website/src/pages/api/admin/questionnaires/assignments/[id]/archive.ts`:
+
+```ts
+import type { APIRoute } from 'astro';
+import { getSession, isAdmin } from '../../../../../../lib/auth';
+import { archiveQAssignment } from '../../../../../../lib/questionnaire-db';
+
+export const POST: APIRoute = async ({ request, params }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) {
+    return new Response('Unauthorized', { status: 401 });
+  }
+  if (!params.id) {
+    return new Response(JSON.stringify({ error: 'id missing' }), { status: 400 });
+  }
+
+  const result = await archiveQAssignment(params.id);
+  if ('reason' in result) {
+    if (result.reason === 'not_found') {
+      return new Response(JSON.stringify({ error: 'Nicht gefunden.' }), { status: 404 });
+    }
+    return new Response(JSON.stringify({
+      error: `Fragebogen kann im Status '${result.status}' nicht archiviert werden.`,
+      status: result.status,
+    }), { status: 409, headers: { 'Content-Type': 'application/json' } });
+  }
+  return new Response(JSON.stringify({ assignment: result.assignment }), {
+    status: 200, headers: { 'Content-Type': 'application/json' },
+  });
+};
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd website && npx vitest run src/pages/api/admin/questionnaires/assignments/\[id\]/archive.test.ts`
+Expected: 6 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add website/src/pages/api/admin/questionnaires/assignments/\[id\]/archive.ts website/src/pages/api/admin/questionnaires/assignments/\[id\]/archive.test.ts
+git commit -m "feat(api): POST /admin/questionnaires/assignments/[id]/archive
+
+Wraps archiveQAssignment. 200 on success, 404 if missing, 409 with
+status payload when not archivable, 401 for non-admin."
+```
+
+---
+
+## Task 8: POST /api/admin/questionnaires/assignments/[id]/reassign
+
+**Files:**
+- Create: `website/src/pages/api/admin/questionnaires/assignments/[id]/reassign.ts`
+- Create: `website/src/pages/api/admin/questionnaires/assignments/[id]/reassign.test.ts`
+
+- [ ] **Step 1: Write failing API tests**
+
+Create `website/src/pages/api/admin/questionnaires/assignments/[id]/reassign.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { POST } from './reassign';
+
+vi.mock('../../../../../../lib/auth', () => ({
+  getSession: vi.fn(),
+  isAdmin: vi.fn(),
+}));
+vi.mock('../../../../../../lib/questionnaire-db', () => ({
+  reassignQAssignment: vi.fn(),
+}));
+
+import { getSession, isAdmin } from '../../../../../../lib/auth';
+import { reassignQAssignment } from '../../../../../../lib/questionnaire-db';
+
+function req(): Request {
+  return new Request('http://x', { method: 'POST', headers: { cookie: 'k=v' } });
+}
+
+beforeEach(() => {
+  vi.mocked(getSession).mockReset();
+  vi.mocked(isAdmin).mockReset();
+  vi.mocked(reassignQAssignment).mockReset();
+  delete process.env.PROD_DOMAIN;
+});
+
+describe('POST /api/admin/questionnaires/assignments/[id]/reassign', () => {
+  it('401 when not admin', async () => {
+    vi.mocked(getSession).mockResolvedValue(null);
+    const r = await POST({ request: req(), params: { id: 'a' } } as any);
+    expect(r.status).toBe(401);
+  });
+
+  it('400 when id missing', async () => {
+    vi.mocked(getSession).mockResolvedValue({} as any);
+    vi.mocked(isAdmin).mockReturnValue(true);
+    const r = await POST({ request: req(), params: {} } as any);
+    expect(r.status).toBe(400);
+  });
+
+  it('404 when source missing', async () => {
+    vi.mocked(getSession).mockResolvedValue({} as any);
+    vi.mocked(isAdmin).mockReturnValue(true);
+    vi.mocked(reassignQAssignment).mockResolvedValue({ reason: 'not_found' } as any);
+    const r = await POST({ request: req(), params: { id: 'a' } } as any);
+    expect(r.status).toBe(404);
+  });
+
+  it('200 with portalUrl (relative when PROD_DOMAIN unset)', async () => {
+    vi.mocked(getSession).mockResolvedValue({} as any);
+    vi.mocked(isAdmin).mockReturnValue(true);
+    vi.mocked(reassignQAssignment).mockResolvedValue({
+      assignment: { id: 'newId' } as any,
+    });
+    const r = await POST({ request: req(), params: { id: 'a' } } as any);
+    expect(r.status).toBe(200);
+    const body = await r.json();
+    expect(body.assignment.id).toBe('newId');
+    expect(body.portalUrl).toBe('/portal/fragebogen/newId');
+  });
+
+  it('200 with absolute portalUrl when PROD_DOMAIN set', async () => {
+    process.env.PROD_DOMAIN = 'mentolder.de';
+    vi.mocked(getSession).mockResolvedValue({} as any);
+    vi.mocked(isAdmin).mockReturnValue(true);
+    vi.mocked(reassignQAssignment).mockResolvedValue({
+      assignment: { id: 'newId' } as any,
+    });
+    const r = await POST({ request: req(), params: { id: 'a' } } as any);
+    const body = await r.json();
+    expect(body.portalUrl).toBe('https://web.mentolder.de/portal/fragebogen/newId');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd website && npx vitest run src/pages/api/admin/questionnaires/assignments/\[id\]/reassign.test.ts`
+Expected: FAIL — `./reassign` does not exist.
+
+- [ ] **Step 3: Implement the endpoint**
+
+Create `website/src/pages/api/admin/questionnaires/assignments/[id]/reassign.ts`:
+
+```ts
+import type { APIRoute } from 'astro';
+import { getSession, isAdmin } from '../../../../../../lib/auth';
+import { reassignQAssignment } from '../../../../../../lib/questionnaire-db';
+
+export const POST: APIRoute = async ({ request, params }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) {
+    return new Response('Unauthorized', { status: 401 });
+  }
+  if (!params.id) {
+    return new Response(JSON.stringify({ error: 'id missing' }), { status: 400 });
+  }
+
+  const result = await reassignQAssignment(params.id);
+  if ('reason' in result) {
+    return new Response(JSON.stringify({ error: 'Nicht gefunden.' }), { status: 404 });
+  }
+  const PROD_DOMAIN = process.env.PROD_DOMAIN || '';
+  const portalUrl = PROD_DOMAIN
+    ? `https://web.${PROD_DOMAIN}/portal/fragebogen/${result.assignment.id}`
+    : `/portal/fragebogen/${result.assignment.id}`;
+  return new Response(JSON.stringify({
+    assignment: result.assignment, portalUrl,
+  }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+};
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd website && npx vitest run src/pages/api/admin/questionnaires/assignments/\[id\]/reassign.test.ts`
+Expected: 5 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add website/src/pages/api/admin/questionnaires/assignments/\[id\]/reassign.ts website/src/pages/api/admin/questionnaires/assignments/\[id\]/reassign.test.ts
+git commit -m "feat(api): POST /admin/questionnaires/assignments/[id]/reassign
+
+Wraps reassignQAssignment. Returns the new assignment plus portalUrl
+(relative in dev, absolute https://web.\$PROD_DOMAIN/... in prod)."
+```
+
+---
+
+## Task 9: Admin detail page — archive button gating + reassign + replay
+
+**Files:**
+- Modify: `website/src/pages/admin/fragebogen/[assignmentId].astro`
+
+- [ ] **Step 1: Load evidence + display scores in frontmatter**
+
+Replace the frontmatter block (lines 1-62) of `website/src/pages/admin/fragebogen/[assignmentId].astro` with:
+
+```astro
+---
+// website/src/pages/admin/fragebogen/[assignmentId].astro
+import AdminLayout from '../../../layouts/AdminLayout.astro';
+import { getSession, getLoginUrl, isAdmin } from '../../../lib/auth';
+import {
+  getQAssignment, listQDimensions, listQQuestions,
+  listQAnswerOptionsForTemplate, listQAnswers, getQTemplate,
+  listEvidenceByAssignment,
+} from '../../../lib/questionnaire-db';
+import { getDisplayScores } from '../../../lib/compute-scores';
+import { isSystemtestLoopEnabled } from '../../../lib/systemtest/feature-flag';
+import SystemtestReplayDrawer from '../../../components/SystemtestReplayDrawer.svelte';
+
+const session = await getSession(Astro.request.headers.get('cookie'));
+if (!session) return Astro.redirect(getLoginUrl(Astro.url.pathname));
+if (!isAdmin(session)) return Astro.redirect('/admin');
+
+const { assignmentId } = Astro.params;
+if (!assignmentId) return Astro.redirect('/admin');
+
+const assignment = await getQAssignment(assignmentId).catch(() => null);
+if (!assignment) return Astro.redirect('/admin');
+
+const [dimensions, questions, allOptions, answers, evidenceList] = await Promise.all([
+  listQDimensions(assignment.template_id),
+  listQQuestions(assignment.template_id),
+  listQAnswerOptionsForTemplate(assignment.template_id),
+  listQAnswers(assignment.id),
+  listEvidenceByAssignment(assignment.id),
+]);
+
+const tpl = await getQTemplate(assignment.template_id).catch(() => null);
+const isSystemTest = tpl?.is_system_test ?? false;
+const systemtestLoopEnabled = isSystemTest && isSystemtestLoopEnabled();
+void systemtestLoopEnabled;
+
+const scores = await getDisplayScores(assignment);
+const answerMap = new Map(answers.map(a => [a.question_id, a]));
+const evidenceMap = new Map(evidenceList.map(e => [e.question_id, e]));
+
+function levelColor(level: string | null) {
+  if (level === 'kritisch') return '#ef4444';
+  if (level === 'mittel') return '#f59e0b';
+  if (level === 'förderlich') return '#22c55e';
+  return '#b8a06a';
+}
+
+function fmtDate(d: string | null) {
+  if (!d) return '—';
+  return new Date(d).toLocaleDateString('de-DE', { day: '2-digit', month: '2-digit', year: 'numeric' });
+}
+
+const maxScore = Math.max(...scores.map(s => s.threshold_high ?? s.final_score ?? 1), 1);
+---
+```
+
+- [ ] **Step 2: Add per-step replay button**
+
+In the same file, find the test_step rendering block (around lines 224-243) and modify the button row. Find:
+
+```astro
+                    {canFileBug && (
+                      <button
+                        class="file-bug-btn px-2.5 py-1 text-xs border border-red-500/30 text-red-400 rounded hover:bg-red-500/10 transition-colors flex-shrink-0"
+                        data-desc={bugDesc}
+                        data-step-id={q.id}
+                      >
+                        Bug erfassen
+                      </button>
+                    )}
+```
+
+Insert immediately above it:
+
+```astro
+                    {isSystemTest && evidenceMap.has(q.id) && (
+                      <button
+                        type="button"
+                        class="replay-btn px-2.5 py-1 text-xs border border-blue-500/30 text-blue-400 rounded hover:bg-blue-500/10 transition-colors flex-shrink-0"
+                        data-evidence-id={evidenceMap.get(q.id)!.latest_evidence_id}
+                      >
+                        ▶ Replay ansehen
+                        <span class="ml-1 text-blue-300/70">(Versuch {evidenceMap.get(q.id)!.latest_attempt})</span>
+                      </button>
+                    )}
+```
+
+- [ ] **Step 3: Update archive + reassign button gating**
+
+In the same file, find the action buttons block (around lines 321-340). Replace with:
+
+```astro
+          {(assignment.status === 'submitted' || assignment.status === 'reviewed') && (
+            <button id="archive-btn"
+              class="px-4 py-2 bg-dark border border-dark-lighter text-muted rounded-lg text-sm hover:border-gold/40 hover:text-light transition-colors">
+              Archivieren
+            </button>
+          )}
+          {assignment.status === 'archived' && (
+            <button id="reassign-btn"
+              data-testid="reassign-questionnaire"
+              class="px-4 py-2 bg-emerald-700 text-white rounded-lg text-sm font-semibold hover:bg-emerald-600 transition-colors"
+              title="Gleichen Fragebogen neu zuweisen — der archivierte Datenpunkt bleibt erhalten.">
+              Erneut zuweisen ➕
+            </button>
+          )}
+          {(assignment.status === 'submitted' || assignment.status === 'reviewed' || assignment.status === 'dismissed') && (
+            <button id="reopen-btn"
+              data-testid="reopen-questionnaire"
+              class="px-4 py-2 bg-amber-700 text-white rounded-lg text-sm font-semibold hover:bg-amber-600 transition-colors"
+              title={isSystemTest ? 'Antworten löschen, retest_attempt hochzählen, Fragebogen erneut starten.' : 'Antworten löschen und Fragebogen erneut zuweisen.'}>
+              Erneut durchführen ↻
+            </button>
+          )}
+```
+
+- [ ] **Step 4: Mount the replay drawer container + reassign script**
+
+At the bottom of the page, immediately before `</AdminLayout>`, add:
+
+```astro
+      <div id="replay-drawer-mount"></div>
+```
+
+In the existing `<script define:vars={{ assignmentId }}>` block, replace the entire archive button handler (lines ~432-440) with:
+
+```js
+  // Archive — calls the dedicated endpoint, snapshots scores transactionally
+  document.getElementById('archive-btn')?.addEventListener('click', async () => {
+    if (!window.confirm(
+      'Diese Auswertung als historischen Datenpunkt sichern? '
+      + 'Werte werden eingefroren und der Fragebogen verschwindet aus den aktiven Listen.',
+    )) return;
+    const r = await fetch(
+      `/api/admin/questionnaires/assignments/${assignmentId}/archive`,
+      { method: 'POST' },
+    );
+    if (r.ok) {
+      window.location.reload();
+    } else {
+      const d = await r.json().catch(() => ({}));
+      msgEl.textContent = d.error || 'Fehler beim Archivieren.';
+      msgEl.className = 'text-xs mt-2 text-red-400';
+      msgEl.classList.remove('hidden');
+    }
+  });
+
+  // Reassign — creates a fresh pending assignment, redirects to portal wizard
+  document.getElementById('reassign-btn')?.addEventListener('click', async () => {
+    if (!window.confirm(
+      'Gleichen Fragebogen erneut zuweisen? Der archivierte Datenpunkt bleibt unverändert; '
+      + 'eine neue Zuweisung wird angelegt.',
+    )) return;
+    const btn = document.getElementById('reassign-btn');
+    btn.disabled = true;
+    btn.textContent = '…';
+    try {
+      const r = await fetch(
+        `/api/admin/questionnaires/assignments/${assignmentId}/reassign`,
+        { method: 'POST' },
+      );
+      const d = await r.json().catch(() => ({}));
+      if (r.ok) {
+        window.location.href = d.portalUrl;
+      } else {
+        btn.disabled = false;
+        btn.textContent = 'Erneut zuweisen ➕';
+        msgEl.textContent = d.error || 'Fehler beim Zuweisen.';
+        msgEl.className = 'text-xs mt-2 text-red-400';
+        msgEl.classList.remove('hidden');
+      }
+    } catch {
+      btn.disabled = false;
+      btn.textContent = 'Erneut zuweisen ➕';
+      msgEl.textContent = 'Netzwerkfehler.';
+      msgEl.className = 'text-xs mt-2 text-red-400';
+      msgEl.classList.remove('hidden');
+    }
+  });
+
+  // Replay drawer — lazy-mount Svelte component on first click
+  let replayMount = null;
+  let replayDrawer = null;
+  document.querySelectorAll('.replay-btn').forEach(btn => {
+    btn.addEventListener('click', async () => {
+      const evidenceId = btn.dataset.evidenceId;
+      if (!evidenceId) return;
+      if (!replayDrawer) {
+        const { default: Drawer } = await import(
+          '../../../components/SystemtestReplayDrawer.svelte'
+        );
+        replayMount = document.getElementById('replay-drawer-mount');
+        replayDrawer = new Drawer({
+          target: replayMount,
+          props: { evidenceId },
+        });
+        replayDrawer.$on('close', () => {
+          replayDrawer.$destroy();
+          replayDrawer = null;
+        });
+      } else {
+        replayDrawer.$set({ evidenceId });
+      }
+    });
+  });
+```
+
+- [ ] **Step 5: Manual smoke check**
+
+Run dev server and exercise the flows:
+
+```bash
+cd website && npm run dev
+```
+
+Visit `http://localhost:4321/admin/fragebogen/<id>` for an existing submitted Fragebogen. Verify:
+- "Archivieren" button is present, clicking shows the confirm dialog and archives.
+- After archive, the page now shows "Erneut zuweisen ➕" instead of "Erneut durchführen".
+- For an archived system-test assignment with seeded evidence, "▶ Replay ansehen (Versuch n)" appears next to the result chip; clicking opens `SystemtestReplayDrawer`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add website/src/pages/admin/fragebogen/\[assignmentId\].astro
+git commit -m "feat(admin/fragebogen): archive from submitted, reassign for archived, inline replay
+
+- 'Archivieren' button now shows for status in {submitted, reviewed}.
+- For archived: replace 'Erneut durchführen' with 'Erneut zuweisen ➕' that
+  creates a fresh assignment via the new reassign endpoint.
+- Each test_step row with rrweb evidence gets an inline 'Replay ansehen
+  (Versuch n)' button that lazy-mounts SystemtestReplayDrawer.
+- Score bars now read from the snapshot for archived assignments via
+  getDisplayScores, so KPI numbers don't drift after template edits."
+```
+
+---
+
+## Task 10: ClientQuestionnairesPanel — split active/archived + toggle
+
+**Files:**
+- Modify: `website/src/components/admin/ClientQuestionnairesPanel.svelte`
+
+- [ ] **Step 1: Add archived split + toggle to script**
+
+Replace the `<script lang="ts">` block in `website/src/components/admin/ClientQuestionnairesPanel.svelte` with:
+
+```svelte
+<script lang="ts">
+  type Props = { keycloakUserId: string };
+  const { keycloakUserId }: Props = $props();
+
+  type Assignment = { id: string; template_title: string; status: string; assigned_at: string; submitted_at: string | null };
+  type Template = { id: string; title: string };
+
+  let assignments: Assignment[] = $state([]);
+  let templates: Template[] = $state([]);
+  let selectedTemplateId = $state('');
+  let assigning = $state(false);
+  let assignMsg = $state('');
+  let archivedVisible = $state(false);
+
+  const active = $derived(assignments.filter(a => a.status !== 'archived'));
+  const archived = $derived(assignments.filter(a => a.status === 'archived'));
+
+  async function loadData() {
+    const [aRes, tRes] = await Promise.all([
+      fetch(`/api/admin/questionnaires/assignments?keycloakUserId=${keycloakUserId}`),
+      fetch('/api/admin/questionnaires/templates'),
+    ]);
+    assignments = aRes.ok ? await aRes.json() : [];
+    const allTpls: Template[] = tRes.ok ? await tRes.json() : [];
+    templates = allTpls.filter((t: any) => t.status === 'published');
+  }
+
+  $effect(() => { loadData(); });
+
+  async function assign() {
+    if (!selectedTemplateId) { assignMsg = 'Bitte eine Vorlage wählen.'; return; }
+    assigning = true; assignMsg = '';
+    try {
+      const r = await fetch('/api/admin/questionnaires/assign', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ templateId: selectedTemplateId, keycloakUserId }),
+      });
+      const data = await r.json();
+      if (r.ok) {
+        assignMsg = 'Fragebogen zugewiesen.';
+        selectedTemplateId = '';
+        await loadData();
+      } else {
+        assignMsg = data.error ?? 'Fehler.';
+      }
+    } finally { assigning = false; }
+  }
+
+  function statusBadge(s: string) {
+    if (s === 'submitted' || s === 'reviewed') return 'bg-green-500/10 text-green-400 border-green-500/20';
+    if (s === 'in_progress') return 'bg-blue-500/10 text-blue-400 border-blue-500/20';
+    if (s === 'dismissed') return 'bg-red-500/10 text-red-400 border-red-500/20';
+    if (s === 'archived') return 'bg-slate-500/10 text-slate-400 border-slate-500/20';
+    return 'bg-yellow-500/10 text-yellow-400 border-yellow-500/20';
+  }
+
+  function statusLabel(s: string) {
+    if (s === 'reviewed') return 'Besprochen';
+    if (s === 'submitted') return 'Eingereicht';
+    if (s === 'in_progress') return 'In Bearbeitung';
+    if (s === 'dismissed') return 'Abgelehnt';
+    if (s === 'archived') return 'Archiviert';
+    return 'Ausstehend';
+  }
+
+  function fmtDate(d: string | null) {
+    if (!d) return '—';
+    return new Date(d).toLocaleDateString('de-DE', { day: '2-digit', month: '2-digit', year: 'numeric' });
+  }
+</script>
+```
+
+- [ ] **Step 2: Update the markup to render active by default + archived behind toggle**
+
+Replace the assignments block (the `{#if assignments.length > 0}` block) with:
+
+```svelte
+  {#if active.length > 0}
+    <div class="flex flex-col gap-2">
+      {#each active as a}
+        <div class="flex items-center justify-between gap-3 p-3 bg-dark rounded-lg border border-dark-lighter">
+          <div class="flex-1 min-w-0">
+            <p class="text-light text-sm truncate">{a.template_title}</p>
+            <p class="text-muted text-xs mt-0.5">
+              Zugewiesen: {fmtDate(a.assigned_at)}
+              {a.submitted_at ? ` · Eingereicht: ${fmtDate(a.submitted_at)}` : ''}
+            </p>
+          </div>
+          <div class="flex items-center gap-2 flex-shrink-0">
+            <span class={`px-2 py-0.5 rounded border text-xs ${statusBadge(a.status)}`}>
+              {statusLabel(a.status)}
+            </span>
+            {#if a.status === 'submitted' || a.status === 'reviewed'}
+              <a href={`/admin/fragebogen/${a.id}`} class="text-xs text-gold hover:underline">Auswertung →</a>
+            {/if}
+          </div>
+        </div>
+      {/each}
+    </div>
+  {/if}
+
+  {#if archived.length > 0}
+    <button
+      type="button"
+      onclick={() => (archivedVisible = !archivedVisible)}
+      class="mt-3 text-xs text-muted hover:text-light flex items-center gap-1"
+    >
+      <span>{archivedVisible ? '▾' : '▸'}</span>
+      Archiv anzeigen ({archived.length})
+    </button>
+    {#if archivedVisible}
+      <div class="flex flex-col gap-2 mt-2 opacity-60">
+        {#each archived as a}
+          <div class="flex items-center justify-between gap-3 p-3 bg-dark rounded-lg border border-dark-lighter">
+            <div class="flex-1 min-w-0">
+              <p class="text-light text-sm truncate">{a.template_title}</p>
+              <p class="text-muted text-xs mt-0.5">
+                Zugewiesen: {fmtDate(a.assigned_at)}
+                {a.submitted_at ? ` · Eingereicht: ${fmtDate(a.submitted_at)}` : ''}
+              </p>
+            </div>
+            <div class="flex items-center gap-2 flex-shrink-0">
+              <span class={`px-2 py-0.5 rounded border text-xs ${statusBadge(a.status)}`}>
+                {statusLabel(a.status)}
+              </span>
+              <a href={`/admin/fragebogen/${a.id}`} class="text-xs text-gold hover:underline">Auswertung →</a>
+            </div>
+          </div>
+        {/each}
+      </div>
+    {/if}
+  {/if}
+```
+
+- [ ] **Step 3: Manual smoke check**
+
+Reload an admin client view (`/admin/clients/<id>`-style page that mounts this panel). Verify only non-archived Fragebögen appear; the "Archiv anzeigen (n)" toggle reveals the archived ones with `opacity-60`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add website/src/components/admin/ClientQuestionnairesPanel.svelte
+git commit -m "feat(admin/clients): hide archived Fragebögen behind toggle
+
+Default view shows only active assignments. 'Archiv anzeigen ({n})'
+button toggles archived rows muted at opacity-60 with the same row
+markup."
+```
+
+---
+
+## Task 11: ProjectQuestionnairesPanel — split + use snapshot scores
+
+**Files:**
+- Modify: `website/src/components/admin/ProjectQuestionnairesPanel.astro`
+- Modify: `website/src/pages/admin/projekte/[id].astro:60-80` (where bundles are built)
+- Modify: `website/src/pages/admin/tickets/[id].astro:30-55` (same)
+
+- [ ] **Step 1: Switch bundle builder to getDisplayScores in projekte/[id].astro**
+
+In `website/src/pages/admin/projekte/[id].astro`, find the bundle-building loop (look for `await Promise.all(assignments.map(async a =>`) and replace `computeScores(...)` with `await getDisplayScores(a)`. Also change the import: replace any `import { computeScores } ...` with `import { getDisplayScores } from '../../../lib/compute-scores';`. The `dimensions` and `options` you already fetch can stay (they're used by the panel for option-label lookup).
+
+The relevant snippet should look like:
+
+```astro
+import { getDisplayScores } from '../../../lib/compute-scores';
+// ...
+questionnaireBundles = await Promise.all(assignments.map(async a => {
+  const [questions, options, answers] = await Promise.all([
+    listQQuestions(a.template_id),
+    listQAnswerOptionsForTemplate(a.template_id),
+    listQAnswers(a.id),
+  ]);
+  const scores = await getDisplayScores(a);
+  return { assignment: a, questions, options, answers, scores };
+}));
+```
+
+- [ ] **Step 2: Same change in tickets/[id].astro**
+
+Apply the identical change to `website/src/pages/admin/tickets/[id].astro` (the bundle loop is structurally the same).
+
+- [ ] **Step 3: Split panel into active vs archived `<details>`**
+
+In `website/src/components/admin/ProjectQuestionnairesPanel.astro`, replace the entire body between `const { assignments } = Astro.props;` and the `</section>` close with:
+
+```astro
+const { assignments } = Astro.props;
+
+const active = assignments.filter(b => b.assignment.status !== 'archived');
+const archived = assignments.filter(b => b.assignment.status === 'archived');
+
+function fmtDate(d: string | Date | null): string {
+  if (!d) return '—';
+  return new Date(d).toLocaleDateString('de-DE', { day: '2-digit', month: '2-digit', year: 'numeric' });
+}
+
+function levelColor(level: string | null): string {
+  if (level === 'kritisch') return '#ef4444';
+  if (level === 'mittel') return '#f59e0b';
+  if (level === 'förderlich') return '#22c55e';
+  return '#b8a06a';
+}
+
+const STATUS_CLS: Record<string, string> = {
+  pending:     'bg-yellow-500/10 text-yellow-400 border-yellow-500/20',
+  in_progress: 'bg-yellow-500/10 text-yellow-400 border-yellow-500/20',
+  submitted:   'bg-blue-500/10 text-blue-400 border-blue-500/20',
+  reviewed:    'bg-green-500/10 text-green-400 border-green-500/20',
+  archived:    'bg-slate-500/10 text-slate-400 border-slate-500/20',
+  dismissed:   'bg-red-500/10 text-red-400 border-red-500/20',
+};
+
+const STATUS_LABEL: Record<string, string> = {
+  pending:     'Wartend',
+  in_progress: 'In Bearbeitung',
+  submitted:   'Eingereicht',
+  reviewed:    'Besprochen',
+  archived:    'Archiviert',
+  dismissed:   'Abgelehnt',
+};
+---
+
+{(active.length > 0 || archived.length > 0) && (
+  <section class="bg-dark-light rounded-2xl border border-dark-lighter p-6 mb-6" id="questionnaires-panel">
+    <h2 class="text-sm font-semibold text-light mb-4 font-serif uppercase tracking-wide">
+      Fragebögen ({active.length})
+    </h2>
+
+    {active.length > 0 && (
+      <div class="flex flex-col gap-6">
+        {active.map((bundle) => <Fragment set:html={renderCard(bundle, false)} />)}
+      </div>
+    )}
+
+    {archived.length > 0 && (
+      <details class="mt-6">
+        <summary class="cursor-pointer text-sm text-muted hover:text-light select-none">
+          Archivierte Fragebögen ({archived.length}) anzeigen
+        </summary>
+        <div class="flex flex-col gap-6 mt-4">
+          {archived.map((bundle) => <Fragment set:html={renderCard(bundle, true)} />)}
+        </div>
+      </details>
+    )}
+  </section>
+)}
+```
+
+Astro `Fragment set:html` is awkward for this rendering — instead, refactor into an inline named function or a sub-component. The cleanest path is to move the per-card markup into its own small Astro component. Replace the strategy above with:
+
+Create `website/src/components/admin/QuestionnaireBundleCard.astro`:
+
+```astro
+---
+import type { AssignmentBundle } from './ProjectQuestionnairesPanel.astro';
+
+interface Props {
+  bundle: AssignmentBundle;
+  muted?: boolean;
+}
+const { bundle, muted = false } = Astro.props;
+const { assignment, questions, options, answers, scores } = bundle;
+const answerMap = new Map(answers.map(a => [a.question_id, a]));
+const optionMap = new Map(options.map(o => [`${o.question_id}:${o.option_key}`, o]));
+const showQA = ['in_progress', 'submitted', 'reviewed', 'archived'].includes(assignment.status);
+const showScores = scores.length > 0 && ['submitted', 'reviewed', 'archived'].includes(assignment.status);
+const dateLabel = assignment.submitted_at
+  ? `Eingereicht ${new Date(assignment.submitted_at).toLocaleDateString('de-DE', { day: '2-digit', month: '2-digit', year: 'numeric' })}`
+  : `Zugewiesen ${new Date(assignment.assigned_at).toLocaleDateString('de-DE', { day: '2-digit', month: '2-digit', year: 'numeric' })}`;
+const maxScore = Math.max(...scores.map(s => s.threshold_high ?? s.final_score ?? 1), 1);
+
+function levelColor(level: string | null): string {
+  if (level === 'kritisch') return '#ef4444';
+  if (level === 'mittel') return '#f59e0b';
+  if (level === 'förderlich') return '#22c55e';
+  return '#b8a06a';
+}
+
+const STATUS_CLS: Record<string, string> = {
+  pending: 'bg-yellow-500/10 text-yellow-400 border-yellow-500/20',
+  in_progress: 'bg-yellow-500/10 text-yellow-400 border-yellow-500/20',
+  submitted: 'bg-blue-500/10 text-blue-400 border-blue-500/20',
+  reviewed: 'bg-green-500/10 text-green-400 border-green-500/20',
+  archived: 'bg-slate-500/10 text-slate-400 border-slate-500/20',
+  dismissed: 'bg-red-500/10 text-red-400 border-red-500/20',
+};
+const STATUS_LABEL: Record<string, string> = {
+  pending: 'Wartend', in_progress: 'In Bearbeitung', submitted: 'Eingereicht',
+  reviewed: 'Besprochen', archived: 'Archiviert', dismissed: 'Abgelehnt',
+};
+---
+<div class={`border border-dark-lighter rounded-xl p-5 ${muted ? 'opacity-60' : ''}`}>
+  <div class="flex items-start justify-between gap-3 flex-wrap mb-3">
+    <div class="min-w-0">
+      <h3 class="text-light font-medium">{assignment.template_title}</h3>
+      <p class="text-muted text-xs mt-0.5">{dateLabel}</p>
+    </div>
+    <span class={`px-2.5 py-0.5 rounded-full border text-xs ${STATUS_CLS[assignment.status] ?? ''}`}>
+      {STATUS_LABEL[assignment.status] ?? assignment.status}
+    </span>
+  </div>
+
+  {assignment.status === 'dismissed' && assignment.dismiss_reason && (
+    <p class="text-xs text-muted italic mb-3">Abgelehnt: {assignment.dismiss_reason}</p>
+  )}
+
+  {showScores && (
+    <div class="mb-4">
+      <div class="flex flex-col gap-3">
+        {scores.map(score => {
+          const pct = Math.min((score.final_score / Math.max(maxScore, 1)) * 100, 100);
+          const color = levelColor(score.level);
+          return (
+            <div>
+              <div class="flex justify-between items-baseline mb-1">
+                <span class="text-light text-xs">{score.name}</span>
+                <span class="text-xs font-mono" style={`color: ${color}`}>
+                  {score.final_score}{score.level && ` · ${score.level}`}
+                </span>
+              </div>
+              <div class="h-1.5 bg-dark rounded-full overflow-hidden">
+                <div class="h-full rounded-full" style={`width: ${pct}%; background-color: ${color}`}></div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  )}
+
+  {assignment.coach_notes && assignment.coach_notes.trim().length > 0 && (
+    <div class="mb-4 p-3 bg-dark rounded border border-dark-lighter">
+      <p class="text-xs text-muted uppercase tracking-wide mb-1">Coach-Notizen</p>
+      <p class="text-sm text-light/90 whitespace-pre-wrap">{assignment.coach_notes}</p>
+    </div>
+  )}
+
+  {showQA && questions.length > 0 && (
+    <details class="mt-2">
+      <summary class="cursor-pointer text-xs text-gold hover:text-gold-light select-none">
+        Fragen &amp; Antworten anzeigen ({answers.length}/{questions.length})
+      </summary>
+      <div class="mt-3 flex flex-col gap-3">
+        {questions.map((q, i) => {
+          const ans = answerMap.get(q.id);
+          const chosen = ans?.option_key ?? null;
+          const opt = chosen ? optionMap.get(`${q.id}:${chosen}`) : null;
+          const label = opt?.label ?? chosen;
+          return (
+            <div class="border-b border-dark-lighter/50 pb-2 last:border-0 last:pb-0">
+              <p class="text-muted text-xs mb-0.5">Frage {i + 1}</p>
+              <p class="text-light text-sm whitespace-pre-line mb-1">{q.question_text}</p>
+              {chosen === 'skipped' ? (
+                <span class="inline-block px-2 py-0.5 bg-amber-500/10 text-amber-400 border border-amber-500/20 rounded text-xs">
+                  Übersprungen
+                </span>
+              ) : chosen ? (
+                <span class="inline-block px-2 py-0.5 bg-gold/10 text-gold border border-gold/20 rounded text-xs">
+                  {label}
+                </span>
+              ) : (
+                <span class="text-muted text-xs italic">Nicht beantwortet</span>
+              )}
+              {ans?.details_text && (
+                <p class="text-muted text-xs mt-1 whitespace-pre-line">{ans.details_text}</p>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </details>
+  )}
+
+  <div class="mt-3 flex justify-end">
+    <a href={`/admin/fragebogen/${assignment.id}`}
+      class="text-xs text-gold/80 hover:text-gold underline">
+      Volle Review öffnen →
+    </a>
+  </div>
+</div>
+```
+
+Then simplify `ProjectQuestionnairesPanel.astro` to:
+
+```astro
+---
+import type { QAssignment, QQuestion, QAnswer, QAnswerOption } from '../../lib/questionnaire-db';
+import type { DimensionScore } from '../../lib/compute-scores';
+import QuestionnaireBundleCard from './QuestionnaireBundleCard.astro';
+
+export interface AssignmentBundle {
+  assignment: QAssignment;
+  questions: QQuestion[];
+  options: QAnswerOption[];
+  answers: QAnswer[];
+  scores: DimensionScore[];
+}
+
+interface Props { assignments: AssignmentBundle[]; }
+const { assignments } = Astro.props;
+
+const active = assignments.filter(b => b.assignment.status !== 'archived');
+const archived = assignments.filter(b => b.assignment.status === 'archived');
+---
+
+{(active.length > 0 || archived.length > 0) && (
+  <section class="bg-dark-light rounded-2xl border border-dark-lighter p-6 mb-6" id="questionnaires-panel">
+    <h2 class="text-sm font-semibold text-light mb-4 font-serif uppercase tracking-wide">
+      Fragebögen ({active.length})
+    </h2>
+
+    {active.length > 0 && (
+      <div class="flex flex-col gap-6">
+        {active.map(bundle => <QuestionnaireBundleCard bundle={bundle} muted={false} />)}
+      </div>
+    )}
+
+    {archived.length > 0 && (
+      <details class="mt-6">
+        <summary class="cursor-pointer text-sm text-muted hover:text-light select-none">
+          Archivierte Fragebögen ({archived.length}) anzeigen
+        </summary>
+        <div class="flex flex-col gap-6 mt-4">
+          {archived.map(bundle => <QuestionnaireBundleCard bundle={bundle} muted={true} />)}
+        </div>
+      </details>
+    )}
+  </section>
+)}
+```
+
+- [ ] **Step 4: Manual smoke check**
+
+Reload `/admin/projekte/<id>` and `/admin/tickets/<id>` for a project that has an archived Fragebogen. Verify the active panel shows non-archived; the `<details>Archivierte Fragebögen (n) anzeigen</details>` block renders the archived ones below with `opacity-60`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add website/src/components/admin/ProjectQuestionnairesPanel.astro website/src/components/admin/QuestionnaireBundleCard.astro website/src/pages/admin/projekte/\[id\].astro website/src/pages/admin/tickets/\[id\].astro
+git commit -m "feat(admin/projekte+tickets): hide archived Fragebögen behind <details>
+
+Active assignments render as before. Archived ones move into a
+collapsed <details> block at the bottom of the panel and use the
+frozen snapshot scores via getDisplayScores. Card markup extracted
+into QuestionnaireBundleCard.astro to keep the panel readable."
+```
+
+---
+
+## Task 12: Playwright E2E — archive → reassign → replay
+
+**Files:**
+- Create: `tests/e2e/specs/fa-fragebogen-archive.spec.ts`
+
+- [ ] **Step 1: Write the spec**
+
+Create `tests/e2e/specs/fa-fragebogen-archive.spec.ts`:
+
+```ts
+import { test, expect } from '@playwright/test';
+import { Pool } from 'pg';
+
+const BASE = process.env.WEBSITE_URL || 'http://localhost:4321';
+const DB_URL = process.env.SESSIONS_DATABASE_URL
+  || 'postgresql://website:devwebsitedb@localhost:5432/website';
+
+test.describe('FA: Fragebogen archive → reassign → replay', () => {
+  test.use({ storageState: 'tests/e2e/.auth/admin.json' });
+
+  test('archive turns submitted into frozen datapoint; reassign creates new row', async ({ page, request }) => {
+    const pool = new Pool({ connectionString: DB_URL });
+    const customerId = (await pool.query(`SELECT gen_random_uuid() AS u`)).rows[0].u;
+    const tpl = (await pool.query(
+      `INSERT INTO questionnaire_templates (title, description, instructions, status)
+       VALUES ('e2e-archive', '', '', 'published') RETURNING id`,
+    )).rows[0].id;
+    const dim = (await pool.query(
+      `INSERT INTO questionnaire_dimensions (template_id, name, position, threshold_mid, threshold_high)
+       VALUES ($1, 'D', 0, 5, 10) RETURNING id`,
+      [tpl],
+    )).rows[0].id;
+    const q = (await pool.query(
+      `INSERT INTO questionnaire_questions (template_id, position, question_text, question_type)
+       VALUES ($1, 0, 'q', 'likert_5') RETURNING id`,
+      [tpl],
+    )).rows[0].id;
+    await pool.query(
+      `INSERT INTO questionnaire_answer_options (question_id, option_key, label, dimension_id, weight)
+       VALUES ($1, '4', 'x', $2, 1)`,
+      [q, dim],
+    );
+    const a = (await pool.query(
+      `INSERT INTO questionnaire_assignments (customer_id, template_id, status, submitted_at)
+       VALUES ($1, $2, 'submitted', now()) RETURNING id`,
+      [customerId, tpl],
+    )).rows[0].id;
+    await pool.query(
+      `INSERT INTO questionnaire_answers (assignment_id, question_id, option_key)
+       VALUES ($1, $2, '4')`,
+      [a, q],
+    );
+
+    // Archive via UI
+    await page.goto(`${BASE}/admin/fragebogen/${a}`);
+    page.on('dialog', dlg => dlg.accept());
+    await page.click('#archive-btn');
+    await page.waitForLoadState('networkidle');
+    await expect(page.locator('text=Archiviert').first()).toBeVisible();
+
+    // Snapshot row exists
+    const snap = await pool.query(
+      `SELECT count(*)::int AS n FROM questionnaire_assignment_scores WHERE assignment_id = $1`,
+      [a],
+    );
+    expect(snap.rows[0].n).toBe(1);
+
+    // KPI view returns the archived row
+    const kpi = await pool.query(
+      `SELECT assignment_id, dimension_name, final_score, level
+         FROM bachelorprojekt.v_questionnaire_kpi
+        WHERE assignment_id = $1`,
+      [a],
+    );
+    expect(kpi.rows.length).toBe(1);
+    expect(kpi.rows[0].dimension_name).toBe('D');
+    expect(kpi.rows[0].final_score).toBe(4);
+
+    // Reassign — confirms via dialog, navigates to new wizard
+    await page.click('[data-testid="reassign-questionnaire"]');
+    await page.waitForURL(/\/portal\/fragebogen\/[0-9a-f-]+/);
+    const newId = page.url().split('/').pop()!.split('?')[0];
+    expect(newId).not.toBe(a);
+
+    // Source preserved, new row pending
+    const rows = await pool.query(
+      `SELECT id, status, archived_at FROM questionnaire_assignments
+        WHERE customer_id = $1 ORDER BY assigned_at`,
+      [customerId],
+    );
+    expect(rows.rows.length).toBe(2);
+    expect(rows.rows[0].status).toBe('archived');
+    expect(rows.rows[0].archived_at).not.toBeNull();
+    expect(rows.rows[1].status).toBe('pending');
+    expect(rows.rows[1].archived_at).toBeNull();
+
+    await pool.end();
+  });
+
+  test('replay button surfaces and opens drawer for archived system-test with evidence', async ({ page }) => {
+    const pool = new Pool({ connectionString: DB_URL });
+    const customerId = (await pool.query(`SELECT gen_random_uuid() AS u`)).rows[0].u;
+    const tpl = (await pool.query(
+      `INSERT INTO questionnaire_templates (title, description, instructions, status, is_system_test)
+       VALUES ('e2e-replay', '', '', 'published', true) RETURNING id`,
+    )).rows[0].id;
+    const q = (await pool.query(
+      `INSERT INTO questionnaire_questions (template_id, position, question_text, question_type)
+       VALUES ($1, 0, 'step', 'test_step') RETURNING id`,
+      [tpl],
+    )).rows[0].id;
+    const a = (await pool.query(
+      `INSERT INTO questionnaire_assignments (customer_id, template_id, status, submitted_at, archived_at)
+       VALUES ($1, $2, 'archived', now(), now()) RETURNING id`,
+      [customerId, tpl],
+    )).rows[0].id;
+    await pool.query(
+      `INSERT INTO questionnaire_answers (assignment_id, question_id, option_key)
+       VALUES ($1, $2, 'erfüllt')`,
+      [a, q],
+    );
+    await pool.query(
+      `INSERT INTO questionnaire_test_evidence (assignment_id, question_id, attempt, replay_path)
+       VALUES ($1, $2, 0, '/tmp/replay-0')`,
+      [a, q],
+    );
+
+    await page.goto(`${BASE}/admin/fragebogen/${a}`);
+    const replayBtn = page.locator('.replay-btn').first();
+    await expect(replayBtn).toBeVisible();
+    await expect(replayBtn).toContainText('Versuch 0');
+
+    await pool.end();
+  });
+});
+```
+
+- [ ] **Step 2: Run the spec**
+
+Run: `cd tests/e2e && npx playwright test specs/fa-fragebogen-archive.spec.ts --reporter=list`
+Expected: 2 PASS (assumes admin auth state at `tests/e2e/.auth/admin.json` — same fixture other admin specs use; the base `WEBSITE_URL` defaults to dev).
+
+If the admin auth fixture is missing, run the auth setup the e2e suite uses (check `tests/e2e/playwright.config.ts` for the global setup project). The repo's `./tests/runner.sh local` orchestrates the full pipeline including auth.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/e2e/specs/fa-fragebogen-archive.spec.ts
+git commit -m "test(e2e): cover archive → reassign → replay flow
+
+Two specs: (1) submit → archive via UI → snapshot row + KPI view
+populated → reassign creates new pending row, archive untouched;
+(2) archived system-test with evidence shows 'Replay ansehen
+(Versuch n)' button on the detail page."
+```
+
+---
+
+## Task 13: Final integration — run unit + manifest + e2e suites
+
+**Files:**
+- None modified.
+
+- [ ] **Step 1: Run all questionnaire unit tests**
+
+Run: `cd website && SESSIONS_DATABASE_URL=postgresql://website:devwebsitedb@localhost:5432/website npx vitest run src/lib/questionnaire-archive.test.ts src/pages/api/admin/questionnaires/`
+Expected: all tests PASS.
+
+- [ ] **Step 2: Validate manifests still build**
+
+Run: `task workspace:validate`
+Expected: dry-run kustomize build succeeds for all overlays.
+
+- [ ] **Step 3: Push branch + open PR per the project workflow**
+
+Per CLAUDE.md "Development Rules", changes go via PR with squash-and-merge. Use `task feature:website` afterwards to roll the website on both prod clusters once merged.
+
+```bash
+git push -u origin feature/fragebogen-archive
+gh pr create --title "feat(fragebogen): archive submitted as frozen KPI datapoint + replay surface" --body "$(cat <<'EOF'
+## Summary
+- Archive submitted/reviewed Fragebögen into a frozen `questionnaire_assignment_scores` snapshot, exposed via `bachelorprojekt.v_questionnaire_kpi`.
+- Reassign creates a new pending assignment for the same template+customer; archived row stays as a permanent datapoint.
+- Detail page wires the existing `SystemtestReplayDrawer` per `test_step` row that has rrweb evidence.
+- Active list views split active vs archived: customer panel toggle, project/ticket panel `<details>` block.
+
+## Test plan
+- [ ] `cd website && npx vitest run src/lib/questionnaire-archive.test.ts src/pages/api/admin/questionnaires/`
+- [ ] `cd tests/e2e && npx playwright test specs/fa-fragebogen-archive.spec.ts`
+- [ ] Manually archive a submitted Fragebogen on dev and verify it disappears from `ClientQuestionnairesPanel` until "Archiv anzeigen" is toggled.
+- [ ] Manually reassign and verify the portal wizard opens with a fresh assignment id.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage check:**
+- Snapshot table → Task 1 ✓
+- KPI view (with evidence_count + latest_evidence_id) → Task 1 ✓
+- `archiveQAssignment` (transactional snapshot) → Task 2 ✓
+- `reassignQAssignment` → Task 3 ✓
+- Evidence preservation (no copy/move) → covered by absence of any evidence-table mutation in archive ✓
+- `listEvidenceByAssignment` → Task 4 ✓
+- `listArchivedScores` + `getDisplayScores` → Tasks 4 + 5 ✓
+- Reroute `updateQAssignment` archived → Task 6 ✓
+- Archive API → Task 7 ✓
+- Reassign API → Task 8 ✓
+- Admin detail UI: archive button gating, reassign button, inline replay button per test_step → Task 9 ✓
+- `ClientQuestionnairesPanel` split + toggle → Task 10 ✓
+- `ProjectQuestionnairesPanel` split + `<details>` + snapshot scores → Task 11 ✓
+- Playwright E2E (archive → reassign → replay) → Task 12 ✓
+- Unit tests for all new helpers + view shape → Tasks 1-5 ✓
+- API tests (archive + reassign) → Tasks 7-8 ✓
+
+**Placeholder scan:** none — every step has runnable code or commands.
+
+**Type/signature consistency:**
+- `QArchivedScore`, `QEvidenceForQuestion` are new types defined in Task 4 and consumed by `getDisplayScores` (Task 5) and the detail page (Task 9).
+- `archiveQAssignment` return type `{ assignment } | { reason: 'not_found' | 'not_archivable'; status?: AssignmentStatus }` matches the API endpoint's narrowing in Task 7.
+- `reassignQAssignment` return type `{ assignment } | { reason: 'not_found' }` matches Task 8.
+- `getDisplayScores` returns `DimensionScore[]` (the existing `compute-scores.ts` type), so the panel + detail page code stays unchanged.
+- `ARCHIVABLE_STATUSES` includes `'archived'` so re-archiving is a no-op (idempotent test in Task 2). The API never returns 409 for an already-archived row — that is intentional.

--- a/docs/superpowers/specs/2026-05-08-fragebogen-archive-design.md
+++ b/docs/superpowers/specs/2026-05-08-fragebogen-archive-design.md
@@ -1,0 +1,166 @@
+# Fragebogen Archive — Frozen KPI Datapoints
+
+**Date:** 2026-05-08
+**Status:** Draft
+
+## Problem
+
+Today an admin can mark a submitted Fragebogen as `reviewed` and then "Archivieren". But the workflow has three gaps:
+
+1. The "Archivieren" button is only shown after `reviewed`, not directly on `submitted` ("Abgegeben").
+2. Archived assignments still appear inline in admin views (just muted via `opacity-60`), so they aren't out of view.
+3. The "Erneut durchführen" button calls `reopenQAssignment(id)` which **deletes the answers** and clears `archived_at`. After re-running, the historical datapoint is destroyed — there is no way to keep the old result and create a new one for KPI work.
+
+A coach needs to be able to (a) freeze a submitted Fragebogen as a permanent historical datapoint, (b) get it out of the active list, and (c) reassign the same template to the same customer for the next datapoint without resetting the previous one.
+
+## Non-goals
+
+- Replacing or refactoring the existing destructive `reopenQAssignment` behavior — it is still needed for systemtest retest_attempt and pre-archive resets.
+- A bulk archive UI.
+- Per-user customizable archive views.
+- Unarchiving (i.e., turning an archived row back into `reviewed`). If a user wants to act on an archived row, they reassign — they don't unarchive.
+
+## Approach
+
+One archive action per assignment freezes the result into an immutable datapoint. A separate "Erneut zuweisen" action creates a brand-new assignment row for the same template+customer (+project), leaving the archived one untouched. KPI consumers read a SQL view that flattens snapshotted dimension scores per archived assignment.
+
+### Data model
+
+New table `questionnaire_assignment_scores` snapshots dimension scores at archive time. Without this, edits to `questionnaire_dimensions` (weights, thresholds) or `questionnaire_answer_options` would retroactively shift historical KPIs.
+
+```sql
+CREATE TABLE IF NOT EXISTS questionnaire_assignment_scores (
+  id             UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  assignment_id  UUID NOT NULL REFERENCES questionnaire_assignments(id) ON DELETE CASCADE,
+  dimension_id   UUID NOT NULL,         -- soft reference, no FK (see note)
+  dimension_name TEXT NOT NULL,
+  final_score    INTEGER NOT NULL,
+  threshold_mid  INTEGER,
+  threshold_high INTEGER,
+  level          TEXT, -- 'förderlich' | 'mittel' | 'kritisch' | NULL
+  snapshot_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (assignment_id, dimension_id)
+);
+CREATE INDEX IF NOT EXISTS idx_qas_assignment ON questionnaire_assignment_scores(assignment_id);
+```
+
+`dimension_id` intentionally has **no** foreign key constraint — historical snapshots must outlive template edits and deletions, and the dimension UUID is only stored for traceability. `dimension_name` is denormalized so KPI consumers don't need a join back to (possibly mutated) `questionnaire_dimensions`. `assignment_id` keeps its FK with `ON DELETE CASCADE` so deleting a customer's data wipes their snapshots cleanly. Synthetic `id` PK avoids the nullable-PK contradiction; uniqueness on `(assignment_id, dimension_id)` is what idempotency relies on.
+
+The view consumed by KPI tooling:
+
+```sql
+CREATE OR REPLACE VIEW bachelorprojekt.v_questionnaire_kpi AS
+SELECT
+  a.id              AS assignment_id,
+  a.customer_id,
+  a.template_id,
+  t.title           AS template_title,
+  t.is_system_test,
+  a.assigned_at,
+  a.submitted_at,
+  a.archived_at,
+  s.dimension_id,
+  s.dimension_name,
+  s.final_score,
+  s.threshold_mid,
+  s.threshold_high,
+  s.level
+FROM questionnaire_assignments a
+JOIN questionnaire_templates t ON t.id = a.template_id
+JOIN questionnaire_assignment_scores s ON s.assignment_id = a.id
+WHERE a.status = 'archived';
+```
+
+The `bachelorprojekt` schema already exists per the project tracking layer (`v_timeline`); reusing it for KPI views is consistent. No view-level filtering on `is_system_test` — let consumers decide.
+
+### Backend
+
+New `archiveQAssignment(id)` in `website/src/lib/questionnaire-db.ts`. Single transaction:
+
+1. `SELECT FOR UPDATE` the assignment; reject if status not in `{submitted, reviewed}` (return `{ reason: 'not_archivable', status }`); reject if not found.
+2. `UPDATE` status to `archived`, set `archived_at = now()`.
+3. Compute scores via the existing `computeScores(dimensions, options, answers)` helper (loaded inside the transaction from the same client).
+4. `INSERT` one row per dimension into `questionnaire_assignment_scores` with `ON CONFLICT (assignment_id, dimension_id) DO NOTHING` for idempotency.
+5. Return the updated `QAssignment`. `coach_notes` are preserved verbatim on the source row — they are part of the historical datapoint.
+
+New `reassignQAssignment(id)` in the same module:
+
+1. Load the source row (any status — `archived` is the typical case but reassign-from-reviewed can be useful too).
+2. Call `createQAssignment({ customerId, templateId, projectId })` — this already exists.
+3. Return the new `QAssignment`. Do not touch the source.
+
+The existing `updateQAssignment(id, { status: 'archived' })` path is rerouted to call `archiveQAssignment` internally so that any older client (or the existing `PUT [id]` API) still produces the snapshot. The legacy `archived_at` setter branch is removed from `updateQAssignment` to keep the snapshot path single-source-of-truth.
+
+### API endpoints
+
+- `POST /api/admin/questionnaires/assignments/[id]/archive`
+  - 200 → `{ assignment: QAssignment }` on success
+  - 404 → not found
+  - 409 → `{ error, status }` when status is not in `{submitted, reviewed}`
+- `POST /api/admin/questionnaires/assignments/[id]/reassign`
+  - 200 → `{ assignment: QAssignment, portalUrl: string }`
+  - 404 → not found
+  - The endpoint allows reassign from any source status because it never mutates the source row. The UI only exposes the button on `archived`. Coach notes on the source are not copied — the new assignment starts with an empty `coach_notes`.
+
+Both gated by `isAdmin(session)` like the sibling `reopen.ts`.
+
+### Admin UI
+
+`website/src/pages/admin/fragebogen/[assignmentId].astro`:
+
+- "Archivieren" button shown for `status ∈ {submitted, reviewed}` (was: only `reviewed`).
+- Archive button confirms via dialog: *"Diese Auswertung als historischen Datenpunkt sichern? Werte werden eingefroren und der Fragebogen verschwindet aus den aktiven Listen."*
+- For `status === 'archived'`: the destructive "Erneut durchführen ↻" button is replaced by **"Erneut zuweisen ➕"** which calls the new reassign endpoint and redirects to `portalUrl` (= `/portal/fragebogen/<newId>`).
+- For `status ∈ {submitted, reviewed, dismissed}`: "Erneut durchführen" stays — destructive reopen via `/reopen` is still useful for resets and systemtest retest_attempt.
+
+`website/src/components/admin/ClientQuestionnairesPanel.svelte` (admin sidebar, per customer):
+
+- Split client-side: `active = status !== 'archived'`, `archived = status === 'archived'`.
+- Render only `active` by default. Below, a small text button `Archiv anzeigen ({n})` toggles `archivedVisible = true`. When toggled, render the archived rows muted (opacity-60) with the same row markup, each linking to `/admin/fragebogen/<id>`.
+
+`website/src/components/admin/ProjectQuestionnairesPanel.astro` (project + ticket pages):
+
+- Same split. Active list renders normally. Archived items go into a `<details>` block at the bottom: `<summary>Archivierte Fragebögen ({n}) anzeigen</summary>`. Inside, render the existing card with score bars (now sourced from snapshot, see below) and Q&A details.
+
+For both panels, archived score bars must read from the snapshot, not recompute. Add a server-side helper `listArchivedScores(assignmentId)` that returns the snapshot rows, and route the panel rendering through a small `getDisplayScores(assignment, dimensions, options, answers)` shim that picks the snapshot when `status === 'archived'` and falls back to `computeScores(...)` otherwise.
+
+### Tests
+
+Unit (vitest, alongside existing `questionnaire-db` patterns):
+
+- `archiveQAssignment` writes one score row per dimension; values match `computeScores` output at archive time; rerunning is a no-op (idempotent).
+- `archiveQAssignment` rejects `pending`, `in_progress`, `dismissed` with `{ reason: 'not_archivable' }`.
+- `archiveQAssignment` rolls back the status update if the score INSERT fails (transactional integrity).
+- `reassignQAssignment` creates a new row with `status='pending'`, fresh `assigned_at`, no `submitted_at`/`archived_at`; source row unchanged.
+- View `v_questionnaire_kpi` returns one row per `(archived assignment, dimension)`; excludes non-archived assignments.
+
+API:
+
+- `archive` endpoint: 200 on submitted/reviewed; 409 on pending/in_progress/dismissed; 404 on missing; 401 for non-admin.
+- `reassign` endpoint: 200 on archived (primary path); 200 on any other source status (no validation — UI just doesn't expose the button); 404 on missing; 401 for non-admin. New row's `coach_notes` is empty.
+
+End-to-end (Playwright, `tests/e2e/admin/`):
+
+1. Admin assigns template T to user U.
+2. User submits.
+3. Admin opens detail, clicks "Archivieren", confirms.
+4. Verify the assignment row no longer appears in `ClientQuestionnairesPanel` default render.
+5. Toggle "Archiv anzeigen" — row visible, muted.
+6. Click into archive detail → "Erneut zuweisen ➕" → redirected to portal wizard with a new id.
+7. Verify DB: two rows for `(customer=U, template=T)`; original `archived_at IS NOT NULL`, `questionnaire_assignment_scores` has snapshot rows; new row `status='pending'`, `archived_at IS NULL`.
+
+## Migration
+
+Schema changes are additive and live in `initDb()` in `questionnaire-db.ts`:
+
+- `CREATE TABLE IF NOT EXISTS questionnaire_assignment_scores ...`
+- `CREATE INDEX IF NOT EXISTS idx_qas_assignment ...`
+- `CREATE OR REPLACE VIEW bachelorprojekt.v_questionnaire_kpi ...`
+
+No backfill of existing archived rows is needed for the MVP — historical archived assignments without snapshot rows would simply not appear in the KPI view (the `JOIN` filters them out). If desired later, a one-shot backfill script in `scripts/one-shot/` can iterate existing `archived` rows and call `archiveQAssignment` (idempotent) to populate snapshots from current dimension/option state.
+
+## Risks
+
+- **Stale snapshot if `computeScores` logic changes:** if the scoring algorithm itself is updated post-archive, historical snapshots reflect the old algorithm. Acceptable: that's the entire point. If a future scoring algorithm change needs to apply retroactively, that's a separate one-shot recompute script.
+- **Score column drift:** `level` is a string today, not an enum. Keeping it `TEXT` matches `compute-scores.ts` and avoids coupling.
+- **Reassign without project_id:** if the source archive had a `project_id` that's since been deleted, `createQAssignment` will fail FK on `tickets.tickets`. The reassign helper passes `projectId` directly; if the FK fails, it surfaces as a 500 — acceptable edge case (project gone = manual fix).

--- a/docs/superpowers/specs/2026-05-08-fragebogen-archive-design.md
+++ b/docs/superpowers/specs/2026-05-08-fragebogen-archive-design.md
@@ -10,8 +10,9 @@ Today an admin can mark a submitted Fragebogen as `reviewed` and then "Archivier
 1. The "Archivieren" button is only shown after `reviewed`, not directly on `submitted` ("Abgegeben").
 2. Archived assignments still appear inline in admin views (just muted via `opacity-60`), so they aren't out of view.
 3. The "Erneut durchführen" button calls `reopenQAssignment(id)` which **deletes the answers** and clears `archived_at`. After re-running, the historical datapoint is destroyed — there is no way to keep the old result and create a new one for KPI work.
+4. For `is_system_test` Fragebögen, rrweb replays land in `questionnaire_test_evidence` per `(assignment_id, question_id, attempt)`, but the replay drawer (`SystemtestReplayDrawer.svelte`) is currently only mounted on `/admin/systemtest/board`. The `/admin/fragebogen/[assignmentId]` detail page does not surface the videoproof, so an archived datapoint is not inspectable end-to-end.
 
-A coach needs to be able to (a) freeze a submitted Fragebogen as a permanent historical datapoint, (b) get it out of the active list, and (c) reassign the same template to the same customer for the next datapoint without resetting the previous one.
+A coach needs to be able to (a) freeze a submitted Fragebogen as a permanent historical datapoint, (b) get it out of the active list, (c) reassign the same template to the same customer for the next datapoint without resetting the previous one, and (d) for system-test runs, see the rrweb video proof attached to the archived datapoint.
 
 ## Non-goals
 
@@ -46,6 +47,20 @@ CREATE INDEX IF NOT EXISTS idx_qas_assignment ON questionnaire_assignment_scores
 
 `dimension_id` intentionally has **no** foreign key constraint — historical snapshots must outlive template edits and deletions, and the dimension UUID is only stored for traceability. `dimension_name` is denormalized so KPI consumers don't need a join back to (possibly mutated) `questionnaire_dimensions`. `assignment_id` keeps its FK with `ON DELETE CASCADE` so deleting a customer's data wipes their snapshots cleanly. Synthetic `id` PK avoids the nullable-PK contradiction; uniqueness on `(assignment_id, dimension_id)` is what idempotency relies on.
 
+### Video proof / rrweb evidence
+
+The recording pipeline already exists: `questionnaire_test_evidence` (one row per `assignment_id, question_id, attempt`) holds `replay_path`, console + network logs, and recording timestamps; `SystemtestReplayDrawer.svelte` renders rrweb playbacks; `/api/admin/evidence/[id]/replay` serves the payload. The recorder boot in the portal wizard is part of the parallel system-test loop spec (`2026-05-08-systemtest-failure-loop`) and is not in scope here.
+
+What this spec adds for the archive flow:
+
+- **Preservation is automatic.** `questionnaire_test_evidence.assignment_id` has `ON DELETE CASCADE`, but archive never deletes the assignment row — it only mutates status. So evidence rows survive the archive transition unchanged. `archiveQAssignment` does **not** copy or move replay payloads; the archived assignment continues to point at the same evidence rows. This is intentional: replay payloads are immutable content addressed by `evidence.id`, so a snapshot would just duplicate storage.
+- **Reassign creates an evidence-free new row.** The reassigned (new) assignment starts at `attempt=0` with no evidence rows. As soon as the wizard records its run (once the recorder boot lands), evidence accumulates against the new assignment id. The archived original keeps its old evidence rows untouched.
+- **Surface on archive detail page.** The detail page (`/admin/fragebogen/[assignmentId].astro`) wires the existing `SystemtestReplayDrawer.svelte` into each `test_step` row that has at least one `questionnaire_test_evidence` row. Rendered as an inline "Replay ansehen" button next to the result chip; click opens the drawer with the latest-attempt evidence id. Multiple attempts: the button surfaces the highest-attempt evidence; a small `(Versuch n)` tag indicates which attempt is being replayed. The drawer itself already supports navigation across attempts. Only rendered for `is_system_test` templates with a non-empty evidence row for that question — coaching Fragebögen show no button.
+
+A new server helper `listEvidenceByAssignment(assignmentId)` returns rows of `{ question_id, latest_evidence_id, latest_attempt, evidence_count }` aggregated per question. The detail page consumes this once at render time and threads `latest_evidence_id` into each `test_step` row. No extra round-trip per click.
+
+### KPI view
+
 The view consumed by KPI tooling:
 
 ```sql
@@ -64,10 +79,20 @@ SELECT
   s.final_score,
   s.threshold_mid,
   s.threshold_high,
-  s.level
+  s.level,
+  ev.evidence_count,
+  ev.latest_evidence_id
 FROM questionnaire_assignments a
 JOIN questionnaire_templates t ON t.id = a.template_id
 JOIN questionnaire_assignment_scores s ON s.assignment_id = a.id
+LEFT JOIN LATERAL (
+  SELECT
+    COUNT(*)::int                                       AS evidence_count,
+    (ARRAY_AGG(e.id ORDER BY e.attempt DESC, e.created_at DESC))[1]
+                                                        AS latest_evidence_id
+  FROM questionnaire_test_evidence e
+  WHERE e.assignment_id = a.id
+) ev ON true
 WHERE a.status = 'archived';
 ```
 
@@ -112,6 +137,7 @@ Both gated by `isAdmin(session)` like the sibling `reopen.ts`.
 - Archive button confirms via dialog: *"Diese Auswertung als historischen Datenpunkt sichern? Werte werden eingefroren und der Fragebogen verschwindet aus den aktiven Listen."*
 - For `status === 'archived'`: the destructive "Erneut durchführen ↻" button is replaced by **"Erneut zuweisen ➕"** which calls the new reassign endpoint and redirects to `portalUrl` (= `/portal/fragebogen/<newId>`).
 - For `status ∈ {submitted, reviewed, dismissed}`: "Erneut durchführen" stays — destructive reopen via `/reopen` is still useful for resets and systemtest retest_attempt.
+- For each `test_step` question on a system-test template that has at least one evidence row, an inline **"Replay ansehen"** button is rendered next to the result chip. Click opens `SystemtestReplayDrawer` with `latest_evidence_id`. A small `Versuch {n}` tag annotates which attempt the latest evidence belongs to.
 
 `website/src/components/admin/ClientQuestionnairesPanel.svelte` (admin sidebar, per customer):
 
@@ -132,7 +158,9 @@ Unit (vitest, alongside existing `questionnaire-db` patterns):
 - `archiveQAssignment` rejects `pending`, `in_progress`, `dismissed` with `{ reason: 'not_archivable' }`.
 - `archiveQAssignment` rolls back the status update if the score INSERT fails (transactional integrity).
 - `reassignQAssignment` creates a new row with `status='pending'`, fresh `assigned_at`, no `submitted_at`/`archived_at`; source row unchanged.
-- View `v_questionnaire_kpi` returns one row per `(archived assignment, dimension)`; excludes non-archived assignments.
+- View `v_questionnaire_kpi` returns one row per `(archived assignment, dimension)`; excludes non-archived assignments. `evidence_count` matches the number of `questionnaire_test_evidence` rows for the assignment; `latest_evidence_id` is null when there is no evidence.
+- Archive transition does **not** delete or duplicate `questionnaire_test_evidence` rows for the assignment.
+- `listEvidenceByAssignment` returns the highest-attempt evidence row per question with the correct `evidence_count`.
 
 API:
 
@@ -148,6 +176,7 @@ End-to-end (Playwright, `tests/e2e/admin/`):
 5. Toggle "Archiv anzeigen" — row visible, muted.
 6. Click into archive detail → "Erneut zuweisen ➕" → redirected to portal wizard with a new id.
 7. Verify DB: two rows for `(customer=U, template=T)`; original `archived_at IS NOT NULL`, `questionnaire_assignment_scores` has snapshot rows; new row `status='pending'`, `archived_at IS NULL`.
+8. For a system-test seeded run with at least one evidence row inserted, repeat the archive flow and verify the archived detail page renders the "Replay ansehen" button on the corresponding test_step row, and clicking it opens `SystemtestReplayDrawer`.
 
 ## Migration
 

--- a/tests/e2e/pg.d.ts
+++ b/tests/e2e/pg.d.ts
@@ -1,0 +1,7 @@
+declare module 'pg' {
+  export class Pool {
+    constructor(config: { connectionString: string });
+    query<T = Record<string, unknown>>(sql: string, params?: unknown[]): Promise<{ rows: T[] }>;
+    end(): Promise<void>;
+  }
+}

--- a/tests/e2e/specs/fa-fragebogen-archive.spec.ts
+++ b/tests/e2e/specs/fa-fragebogen-archive.spec.ts
@@ -1,0 +1,117 @@
+// tests/e2e/specs/fa-fragebogen-archive.spec.ts
+//
+// FA: Fragebogen archive → reassign → replay
+//
+// Covers:
+//   1. Archive via UI turns a submitted assignment into a frozen datapoint
+//      (snapshot row + KPI view populated); reassign creates a new pending row.
+//   2. Replay button is visible on archived system-test assignments with evidence.
+//
+// Both tests require an authenticated admin session and seed data in the DB.
+// DB seeding is done via the admin API (POST /api/admin/fragebogen/seed-e2e)
+// when available, or skips gracefully when E2E_ADMIN_PASS is unset or the
+// seed endpoint is absent (CI without secrets / cluster without feature).
+//
+// The pg module is NOT available in this test package — all seeding goes
+// through the application's own API endpoints.
+
+import { test, expect, type Page } from '@playwright/test';
+
+const BASE       = process.env.WEBSITE_URL    ?? 'http://localhost:4321';
+const ADMIN_USER = process.env.E2E_ADMIN_USER ?? 'patrick';
+const ADMIN_PASS = process.env.E2E_ADMIN_PASS;
+
+async function loginAsAdmin(page: Page, returnTo = '/admin/fragebogen'): Promise<void> {
+  await page.goto(`${BASE}/api/auth/login?returnTo=${encodeURIComponent(returnTo)}`);
+  await page.waitForURL(/realms\/workspace/, { timeout: 20_000 });
+  await page.locator('#username, input[name="username"]').first().fill(ADMIN_USER);
+  await page.locator('#password, input[name="password"]').first().fill(ADMIN_PASS!);
+  await page.locator('#kc-login, input[type="submit"]').first().click();
+  await page.waitForURL(new RegExp(returnTo.replace(/\//g, '\\/')), { timeout: 20_000 });
+}
+
+test.describe('FA: Fragebogen archive → reassign → replay', () => {
+  test.beforeEach(({ }, testInfo) => {
+    if (!ADMIN_PASS) {
+      testInfo.skip(true, 'E2E_ADMIN_PASS not set — skipping admin-required archive specs');
+    }
+  });
+
+  // ── Test 1: archive + reassign flow ──────────────────────────────────────
+  //
+  // Seed a submitted assignment via the admin seed API.
+  // Archive it through the detail UI.
+  // Assert snapshot row and KPI view are populated (via /api/admin/fragebogen/:id/kpi).
+  // Reassign via the [data-testid="reassign-questionnaire"] button.
+  // Assert navigation to new pending assignment.
+  test('archive turns submitted into frozen datapoint; reassign creates new row', async ({ page }) => {
+    // Seed a submitted assignment — skip if the seed endpoint is unavailable.
+    const seedRes = await page.request.post(`${BASE}/api/admin/fragebogen/seed-e2e`, {
+      data: { scenario: 'submitted' },
+    });
+    test.skip(
+      seedRes.status() === 404,
+      'Seed endpoint /api/admin/fragebogen/seed-e2e not available — skipping',
+    );
+    test.skip(
+      !seedRes.ok(),
+      `Seed endpoint returned ${seedRes.status()} — skipping`,
+    );
+    const { assignmentId } = await seedRes.json() as { assignmentId: string };
+
+    await loginAsAdmin(page, `/admin/fragebogen/${assignmentId}`);
+
+    // Archive via the #archive-btn button; accept the confirmation dialog.
+    page.on('dialog', dlg => dlg.accept());
+    const archiveBtn = page.locator('#archive-btn');
+    await expect(archiveBtn).toBeVisible({ timeout: 10_000 });
+    await archiveBtn.click();
+    await page.waitForLoadState('networkidle');
+
+    // UI confirms archived state.
+    await expect(page.locator('text=Archiviert').first()).toBeVisible({ timeout: 10_000 });
+
+    // KPI API returns snapshot row for the archived assignment.
+    const kpiRes = await page.request.get(`${BASE}/api/admin/fragebogen/${assignmentId}/kpi`);
+    expect(kpiRes.ok()).toBeTruthy();
+    const kpi = await kpiRes.json() as Array<{ dimension_name: string; final_score: number; level: string }>;
+    expect(kpi.length).toBeGreaterThanOrEqual(1);
+
+    // Reassign — click the button, accept dialog if present, navigate to new wizard.
+    const reassignBtn = page.locator('[data-testid="reassign-questionnaire"]');
+    await expect(reassignBtn).toBeVisible({ timeout: 10_000 });
+    page.on('dialog', dlg => dlg.accept());
+    await reassignBtn.click();
+    await page.waitForURL(/\/portal\/fragebogen\/[0-9a-f-]+/, { timeout: 20_000 });
+
+    const newId = page.url().split('/').pop()!.split('?')[0];
+    expect(newId).not.toBe(assignmentId);
+    expect(newId).toMatch(/^[0-9a-f-]{36}$/);
+  });
+
+  // ── Test 2: replay button visibility ─────────────────────────────────────
+  //
+  // Seed an archived system-test assignment with evidence via the seed API.
+  // Navigate to the admin detail page.
+  // Assert .replay-btn is visible and contains the attempt number.
+  test('replay button surfaces for archived system-test with evidence', async ({ page }) => {
+    const seedRes = await page.request.post(`${BASE}/api/admin/fragebogen/seed-e2e`, {
+      data: { scenario: 'archived-with-evidence' },
+    });
+    test.skip(
+      seedRes.status() === 404,
+      'Seed endpoint /api/admin/fragebogen/seed-e2e not available — skipping',
+    );
+    test.skip(
+      !seedRes.ok(),
+      `Seed endpoint returned ${seedRes.status()} — skipping`,
+    );
+    const { assignmentId } = await seedRes.json() as { assignmentId: string };
+
+    await loginAsAdmin(page, `/admin/fragebogen/${assignmentId}`);
+
+    const replayBtn = page.locator('.replay-btn').first();
+    await expect(replayBtn).toBeVisible({ timeout: 10_000 });
+    await expect(replayBtn).toContainText('Versuch');
+  });
+});

--- a/tests/e2e/specs/fa-fragebogen-archive.spec.ts
+++ b/tests/e2e/specs/fa-fragebogen-archive.spec.ts
@@ -7,27 +7,24 @@
 //      (snapshot row + KPI view populated); reassign creates a new pending row.
 //   2. Replay button is visible on archived system-test assignments with evidence.
 //
-// Both tests require an authenticated admin session and seed data in the DB.
-// DB seeding is done via the admin API (POST /api/admin/fragebogen/seed-e2e)
-// when available, or skips gracefully when E2E_ADMIN_PASS is unset or the
-// seed endpoint is absent (CI without secrets / cluster without feature).
-//
-// The pg module is NOT available in this test package — all seeding goes
-// through the application's own API endpoints.
+// Skips gracefully when E2E_ADMIN_PASS is unset (CI without secrets).
 
 import { test, expect, type Page } from '@playwright/test';
+import { Pool } from 'pg';
 
-const BASE       = process.env.WEBSITE_URL    ?? 'http://localhost:4321';
+const BASE       = process.env.WEBSITE_URL         ?? 'http://localhost:4321';
+const DB_URL     = process.env.SESSIONS_DATABASE_URL
+                || 'postgresql://website:devwebsitedb@localhost:5432/website';
 const ADMIN_USER = process.env.E2E_ADMIN_USER ?? 'patrick';
 const ADMIN_PASS = process.env.E2E_ADMIN_PASS;
 
-async function loginAsAdmin(page: Page, returnTo = '/admin/fragebogen'): Promise<void> {
+async function loginAsAdmin(page: Page, returnTo: string): Promise<void> {
   await page.goto(`${BASE}/api/auth/login?returnTo=${encodeURIComponent(returnTo)}`);
   await page.waitForURL(/realms\/workspace/, { timeout: 20_000 });
   await page.locator('#username, input[name="username"]').first().fill(ADMIN_USER);
   await page.locator('#password, input[name="password"]').first().fill(ADMIN_PASS!);
   await page.locator('#kc-login, input[type="submit"]').first().click();
-  await page.waitForURL(new RegExp(returnTo.replace(/\//g, '\\/')), { timeout: 20_000 });
+  await page.waitForURL(new RegExp(returnTo.replace(/[-[\]/{}()*+?.\\^$|]/g, '\\$&')), { timeout: 20_000 });
 }
 
 test.describe('FA: Fragebogen archive → reassign → replay', () => {
@@ -37,81 +34,122 @@ test.describe('FA: Fragebogen archive → reassign → replay', () => {
     }
   });
 
-  // ── Test 1: archive + reassign flow ──────────────────────────────────────
-  //
-  // Seed a submitted assignment via the admin seed API.
-  // Archive it through the detail UI.
-  // Assert snapshot row and KPI view are populated (via /api/admin/fragebogen/:id/kpi).
-  // Reassign via the [data-testid="reassign-questionnaire"] button.
-  // Assert navigation to new pending assignment.
   test('archive turns submitted into frozen datapoint; reassign creates new row', async ({ page }) => {
-    // Seed a submitted assignment — skip if the seed endpoint is unavailable.
-    const seedRes = await page.request.post(`${BASE}/api/admin/fragebogen/seed-e2e`, {
-      data: { scenario: 'submitted' },
-    });
-    test.skip(
-      seedRes.status() === 404,
-      'Seed endpoint /api/admin/fragebogen/seed-e2e not available — skipping',
+    const pool = new Pool({ connectionString: DB_URL });
+    const customerId = (await pool.query(`SELECT gen_random_uuid() AS u`)).rows[0].u;
+    const tpl = (await pool.query(
+      `INSERT INTO questionnaire_templates (title, description, instructions, status)
+       VALUES ('e2e-archive', '', '', 'published') RETURNING id`,
+    )).rows[0].id;
+    const dim = (await pool.query(
+      `INSERT INTO questionnaire_dimensions (template_id, name, position, threshold_mid, threshold_high)
+       VALUES ($1, 'D', 0, 5, 10) RETURNING id`,
+      [tpl],
+    )).rows[0].id;
+    const q = (await pool.query(
+      `INSERT INTO questionnaire_questions (template_id, position, question_text, question_type)
+       VALUES ($1, 0, 'q', 'likert_5') RETURNING id`,
+      [tpl],
+    )).rows[0].id;
+    await pool.query(
+      `INSERT INTO questionnaire_answer_options (question_id, option_key, label, dimension_id, weight)
+       VALUES ($1, '4', 'x', $2, 1)`,
+      [q, dim],
     );
-    test.skip(
-      !seedRes.ok(),
-      `Seed endpoint returned ${seedRes.status()} — skipping`,
+    const a = (await pool.query(
+      `INSERT INTO questionnaire_assignments (customer_id, template_id, status, submitted_at)
+       VALUES ($1, $2, 'submitted', now()) RETURNING id`,
+      [customerId, tpl],
+    )).rows[0].id;
+    await pool.query(
+      `INSERT INTO questionnaire_answers (assignment_id, question_id, option_key)
+       VALUES ($1, $2, '4')`,
+      [a, q],
     );
-    const { assignmentId } = await seedRes.json() as { assignmentId: string };
 
-    await loginAsAdmin(page, `/admin/fragebogen/${assignmentId}`);
+    await loginAsAdmin(page, `/admin/fragebogen/${a}`);
 
-    // Archive via the #archive-btn button; accept the confirmation dialog.
+    // Archive via UI
     page.on('dialog', dlg => dlg.accept());
-    const archiveBtn = page.locator('#archive-btn');
-    await expect(archiveBtn).toBeVisible({ timeout: 10_000 });
-    await archiveBtn.click();
+    await expect(page.locator('#archive-btn')).toBeVisible({ timeout: 10_000 });
+    await page.click('#archive-btn');
     await page.waitForLoadState('networkidle');
-
-    // UI confirms archived state.
     await expect(page.locator('text=Archiviert').first()).toBeVisible({ timeout: 10_000 });
 
-    // KPI API returns snapshot row for the archived assignment.
-    const kpiRes = await page.request.get(`${BASE}/api/admin/fragebogen/${assignmentId}/kpi`);
-    expect(kpiRes.ok()).toBeTruthy();
-    const kpi = await kpiRes.json() as Array<{ dimension_name: string; final_score: number; level: string }>;
-    expect(kpi.length).toBeGreaterThanOrEqual(1);
+    // Snapshot row exists
+    const snap = await pool.query(
+      `SELECT count(*)::int AS n FROM questionnaire_assignment_scores WHERE assignment_id = $1`,
+      [a],
+    );
+    expect(snap.rows[0].n).toBe(1);
 
-    // Reassign — click the button, accept dialog if present, navigate to new wizard.
-    const reassignBtn = page.locator('[data-testid="reassign-questionnaire"]');
-    await expect(reassignBtn).toBeVisible({ timeout: 10_000 });
-    page.on('dialog', dlg => dlg.accept());
-    await reassignBtn.click();
+    // KPI view returns the archived row
+    const kpi = await pool.query(
+      `SELECT assignment_id, dimension_name, final_score, level
+         FROM bachelorprojekt.v_questionnaire_kpi
+        WHERE assignment_id = $1`,
+      [a],
+    );
+    expect(kpi.rows.length).toBe(1);
+    expect(kpi.rows[0].dimension_name).toBe('D');
+    expect(kpi.rows[0].final_score).toBe(4);
+
+    // Reassign — confirms via dialog, navigates to new wizard
+    await expect(page.locator('[data-testid="reassign-questionnaire"]')).toBeVisible({ timeout: 10_000 });
+    await page.click('[data-testid="reassign-questionnaire"]');
     await page.waitForURL(/\/portal\/fragebogen\/[0-9a-f-]+/, { timeout: 20_000 });
-
     const newId = page.url().split('/').pop()!.split('?')[0];
-    expect(newId).not.toBe(assignmentId);
-    expect(newId).toMatch(/^[0-9a-f-]{36}$/);
+    expect(newId).not.toBe(a);
+
+    // Source preserved, new row pending
+    const rows = await pool.query(
+      `SELECT id, status, archived_at FROM questionnaire_assignments
+        WHERE customer_id = $1 ORDER BY assigned_at`,
+      [customerId],
+    );
+    expect(rows.rows.length).toBe(2);
+    expect(rows.rows[0].status).toBe('archived');
+    expect(rows.rows[0].archived_at).not.toBeNull();
+    expect(rows.rows[1].status).toBe('pending');
+    expect(rows.rows[1].archived_at).toBeNull();
+
+    await pool.end();
   });
 
-  // ── Test 2: replay button visibility ─────────────────────────────────────
-  //
-  // Seed an archived system-test assignment with evidence via the seed API.
-  // Navigate to the admin detail page.
-  // Assert .replay-btn is visible and contains the attempt number.
-  test('replay button surfaces for archived system-test with evidence', async ({ page }) => {
-    const seedRes = await page.request.post(`${BASE}/api/admin/fragebogen/seed-e2e`, {
-      data: { scenario: 'archived-with-evidence' },
-    });
-    test.skip(
-      seedRes.status() === 404,
-      'Seed endpoint /api/admin/fragebogen/seed-e2e not available — skipping',
+  test('replay button surfaces and shows attempt number for archived system-test with evidence', async ({ page }) => {
+    const pool = new Pool({ connectionString: DB_URL });
+    const customerId = (await pool.query(`SELECT gen_random_uuid() AS u`)).rows[0].u;
+    const tpl = (await pool.query(
+      `INSERT INTO questionnaire_templates (title, description, instructions, status, is_system_test)
+       VALUES ('e2e-replay', '', '', 'published', true) RETURNING id`,
+    )).rows[0].id;
+    const q = (await pool.query(
+      `INSERT INTO questionnaire_questions (template_id, position, question_text, question_type)
+       VALUES ($1, 0, 'step', 'test_step') RETURNING id`,
+      [tpl],
+    )).rows[0].id;
+    const a = (await pool.query(
+      `INSERT INTO questionnaire_assignments (customer_id, template_id, status, submitted_at, archived_at)
+       VALUES ($1, $2, 'archived', now(), now()) RETURNING id`,
+      [customerId, tpl],
+    )).rows[0].id;
+    await pool.query(
+      `INSERT INTO questionnaire_answers (assignment_id, question_id, option_key)
+       VALUES ($1, $2, 'erfüllt')`,
+      [a, q],
     );
-    test.skip(
-      !seedRes.ok(),
-      `Seed endpoint returned ${seedRes.status()} — skipping`,
+    await pool.query(
+      `INSERT INTO questionnaire_test_evidence (assignment_id, question_id, attempt, replay_path)
+       VALUES ($1, $2, 0, '/tmp/replay-0')`,
+      [a, q],
     );
-    const { assignmentId } = await seedRes.json() as { assignmentId: string };
 
-    await loginAsAdmin(page, `/admin/fragebogen/${assignmentId}`);
+    await loginAsAdmin(page, `/admin/fragebogen/${a}`);
 
     const replayBtn = page.locator('.replay-btn').first();
     await expect(replayBtn).toBeVisible({ timeout: 10_000 });
-    await expect(replayBtn).toContainText('Versuch');
+    await expect(replayBtn).toContainText('Versuch 0');
+
+    await pool.end();
   });
 });

--- a/website/src/components/admin/ClientQuestionnairesPanel.svelte
+++ b/website/src/components/admin/ClientQuestionnairesPanel.svelte
@@ -11,6 +11,10 @@
   let selectedTemplateId = $state('');
   let assigning = $state(false);
   let assignMsg = $state('');
+  let archivedVisible = $state(false);
+
+  const active = $derived(assignments.filter(a => a.status !== 'archived'));
+  const archived = $derived(assignments.filter(a => a.status === 'archived'));
 
   async function loadData() {
     const [aRes, tRes] = await Promise.all([
@@ -48,6 +52,7 @@
     if (s === 'submitted' || s === 'reviewed') return 'bg-green-500/10 text-green-400 border-green-500/20';
     if (s === 'in_progress') return 'bg-blue-500/10 text-blue-400 border-blue-500/20';
     if (s === 'dismissed') return 'bg-red-500/10 text-red-400 border-red-500/20';
+    if (s === 'archived') return 'bg-slate-500/10 text-slate-400 border-slate-500/20';
     return 'bg-yellow-500/10 text-yellow-400 border-yellow-500/20';
   }
 
@@ -56,6 +61,7 @@
     if (s === 'submitted') return 'Eingereicht';
     if (s === 'in_progress') return 'In Bearbeitung';
     if (s === 'dismissed') return 'Abgelehnt';
+    if (s === 'archived') return 'Archiviert';
     return 'Ausstehend';
   }
 
@@ -92,9 +98,9 @@
     </p>
   {/if}
 
-  {#if assignments.length > 0}
+  {#if active.length > 0}
     <div class="flex flex-col gap-2">
-      {#each assignments as a}
+      {#each active as a}
         <div class="flex items-center justify-between gap-3 p-3 bg-dark rounded-lg border border-dark-lighter">
           <div class="flex-1 min-w-0">
             <p class="text-light text-sm truncate">{a.template_title}</p>
@@ -114,5 +120,37 @@
         </div>
       {/each}
     </div>
+  {/if}
+
+  {#if archived.length > 0}
+    <button
+      type="button"
+      onclick={() => (archivedVisible = !archivedVisible)}
+      class="mt-3 text-xs text-muted hover:text-light flex items-center gap-1"
+    >
+      <span>{archivedVisible ? '▾' : '▸'}</span>
+      Archiv anzeigen ({archived.length})
+    </button>
+    {#if archivedVisible}
+      <div class="flex flex-col gap-2 mt-2 opacity-60">
+        {#each archived as a}
+          <div class="flex items-center justify-between gap-3 p-3 bg-dark rounded-lg border border-dark-lighter">
+            <div class="flex-1 min-w-0">
+              <p class="text-light text-sm truncate">{a.template_title}</p>
+              <p class="text-muted text-xs mt-0.5">
+                Zugewiesen: {fmtDate(a.assigned_at)}
+                {a.submitted_at ? ` · Eingereicht: ${fmtDate(a.submitted_at)}` : ''}
+              </p>
+            </div>
+            <div class="flex items-center gap-2 flex-shrink-0">
+              <span class={`px-2 py-0.5 rounded border text-xs ${statusBadge(a.status)}`}>
+                {statusLabel(a.status)}
+              </span>
+              <a href={`/admin/fragebogen/${a.id}`} class="text-xs text-gold hover:underline">Auswertung →</a>
+            </div>
+          </div>
+        {/each}
+      </div>
+    {/if}
   {/if}
 </div>

--- a/website/src/components/admin/ProjectQuestionnairesPanel.astro
+++ b/website/src/components/admin/ProjectQuestionnairesPanel.astro
@@ -3,12 +3,11 @@
 //
 // Shared section for /admin/projekte/[id] and /admin/tickets/[id].
 // Renders nothing when `assignments` is empty.
-//
-// Score-bar rendering mirrors /admin/fragebogen/[assignmentId].astro lines 84–117
-// so the panel matches the full review page visually.
+// Active assignments are shown directly; archived ones are collapsed in a <details> block.
 
 import type { QAssignment, QQuestion, QAnswer, QAnswerOption } from '../../lib/questionnaire-db';
 import type { DimensionScore } from '../../lib/compute-scores';
+import QuestionnaireBundleCard from './QuestionnaireBundleCard.astro';
 
 export interface AssignmentBundle {
   assignment: QAssignment;
@@ -18,160 +17,34 @@ export interface AssignmentBundle {
   scores: DimensionScore[];
 }
 
-interface Props {
-  assignments: AssignmentBundle[];
-}
-
+interface Props { assignments: AssignmentBundle[]; }
 const { assignments } = Astro.props;
 
-function fmtDate(d: string | Date | null): string {
-  if (!d) return '—';
-  return new Date(d).toLocaleDateString('de-DE', { day: '2-digit', month: '2-digit', year: 'numeric' });
-}
-
-function levelColor(level: string | null): string {
-  if (level === 'kritisch') return '#ef4444';
-  if (level === 'mittel') return '#f59e0b';
-  if (level === 'förderlich') return '#22c55e';
-  return '#b8a06a';
-}
-
-const STATUS_CLS: Record<string, string> = {
-  pending:     'bg-yellow-500/10 text-yellow-400 border-yellow-500/20',
-  in_progress: 'bg-yellow-500/10 text-yellow-400 border-yellow-500/20',
-  submitted:   'bg-blue-500/10 text-blue-400 border-blue-500/20',
-  reviewed:    'bg-green-500/10 text-green-400 border-green-500/20',
-  archived:    'bg-slate-500/10 text-slate-400 border-slate-500/20',
-  dismissed:   'bg-red-500/10 text-red-400 border-red-500/20',
-};
-
-const STATUS_LABEL: Record<string, string> = {
-  pending:     'Wartend',
-  in_progress: 'In Bearbeitung',
-  submitted:   'Eingereicht',
-  reviewed:    'Besprochen',
-  archived:    'Archiviert',
-  dismissed:   'Abgelehnt',
-};
+const active = assignments.filter(b => b.assignment.status !== 'archived');
+const archived = assignments.filter(b => b.assignment.status === 'archived');
 ---
 
-{assignments.length > 0 && (
+{(active.length > 0 || archived.length > 0) && (
   <section class="bg-dark-light rounded-2xl border border-dark-lighter p-6 mb-6" id="questionnaires-panel">
     <h2 class="text-sm font-semibold text-light mb-4 font-serif uppercase tracking-wide">
-      Fragebögen ({assignments.length})
+      Fragebögen ({active.length})
     </h2>
 
-    <div class="flex flex-col gap-6">
-      {assignments.map(({ assignment, questions, options, answers, scores }) => {
-        const answerMap = new Map(answers.map(a => [a.question_id, a]));
-        const optionMap = new Map(options.map(o => [`${o.question_id}:${o.option_key}`, o]));
-        const isMuted   = assignment.status === 'archived' || assignment.status === 'dismissed';
-        const showQA    = ['in_progress', 'submitted', 'reviewed', 'archived'].includes(assignment.status);
-        const showScores = scores.length > 0 && ['submitted', 'reviewed', 'archived'].includes(assignment.status);
-        const dateLabel = assignment.submitted_at
-          ? `Eingereicht ${fmtDate(assignment.submitted_at)}`
-          : `Zugewiesen ${fmtDate(assignment.assigned_at)}`;
-        const maxScore = Math.max(...scores.map(s => s.threshold_high ?? s.final_score ?? 1), 1);
+    {active.length > 0 && (
+      <div class="flex flex-col gap-6">
+        {active.map(bundle => <QuestionnaireBundleCard bundle={bundle} muted={false} />)}
+      </div>
+    )}
 
-        return (
-          <div class={`border border-dark-lighter rounded-xl p-5 ${isMuted ? 'opacity-60' : ''}`}>
-            {/* Header */}
-            <div class="flex items-start justify-between gap-3 flex-wrap mb-3">
-              <div class="min-w-0">
-                <h3 class="text-light font-medium">{assignment.template_title}</h3>
-                <p class="text-muted text-xs mt-0.5">{dateLabel}</p>
-              </div>
-              <span class={`px-2.5 py-0.5 rounded-full border text-xs ${STATUS_CLS[assignment.status] ?? ''}`}>
-                {STATUS_LABEL[assignment.status] ?? assignment.status}
-              </span>
-            </div>
-
-            {/* Dismissed reason */}
-            {assignment.status === 'dismissed' && assignment.dismiss_reason && (
-              <p class="text-xs text-muted italic mb-3">Abgelehnt: {assignment.dismiss_reason}</p>
-            )}
-
-            {/* Score bars */}
-            {showScores && (
-              <div class="mb-4">
-                <div class="flex flex-col gap-3">
-                  {scores.map(score => {
-                    const pct = Math.min((score.final_score / Math.max(maxScore, 1)) * 100, 100);
-                    const color = levelColor(score.level);
-                    return (
-                      <div>
-                        <div class="flex justify-between items-baseline mb-1">
-                          <span class="text-light text-xs">{score.name}</span>
-                          <span class="text-xs font-mono" style={`color: ${color}`}>
-                            {score.final_score}{score.level && ` · ${score.level}`}
-                          </span>
-                        </div>
-                        <div class="h-1.5 bg-dark rounded-full overflow-hidden">
-                          <div class="h-full rounded-full"
-                            style={`width: ${pct}%; background-color: ${color}`}></div>
-                        </div>
-                      </div>
-                    );
-                  })}
-                </div>
-              </div>
-            )}
-
-            {/* Coach notes preview */}
-            {assignment.coach_notes && assignment.coach_notes.trim().length > 0 && (
-              <div class="mb-4 p-3 bg-dark rounded border border-dark-lighter">
-                <p class="text-xs text-muted uppercase tracking-wide mb-1">Coach-Notizen</p>
-                <p class="text-sm text-light/90 whitespace-pre-wrap">{assignment.coach_notes}</p>
-              </div>
-            )}
-
-            {/* Q&A list — collapsible */}
-            {showQA && questions.length > 0 && (
-              <details class="mt-2">
-                <summary class="cursor-pointer text-xs text-gold hover:text-gold-light select-none">
-                  Fragen &amp; Antworten anzeigen ({answers.length}/{questions.length})
-                </summary>
-                <div class="mt-3 flex flex-col gap-3">
-                  {questions.map((q, i) => {
-                    const ans = answerMap.get(q.id);
-                    const chosen = ans?.option_key ?? null;
-                    const opt = chosen ? optionMap.get(`${q.id}:${chosen}`) : null;
-                    const label = opt?.label ?? chosen;
-                    return (
-                      <div class="border-b border-dark-lighter/50 pb-2 last:border-0 last:pb-0">
-                        <p class="text-muted text-xs mb-0.5">Frage {i + 1}</p>
-                        <p class="text-light text-sm whitespace-pre-line mb-1">{q.question_text}</p>
-                        {chosen === 'skipped' ? (
-                          <span class="inline-block px-2 py-0.5 bg-amber-500/10 text-amber-400 border border-amber-500/20 rounded text-xs">
-                            Übersprungen
-                          </span>
-                        ) : chosen ? (
-                          <span class="inline-block px-2 py-0.5 bg-gold/10 text-gold border border-gold/20 rounded text-xs">
-                            {label}
-                          </span>
-                        ) : (
-                          <span class="text-muted text-xs italic">Nicht beantwortet</span>
-                        )}
-                        {ans?.details_text && (
-                          <p class="text-muted text-xs mt-1 whitespace-pre-line">{ans.details_text}</p>
-                        )}
-                      </div>
-                    );
-                  })}
-                </div>
-              </details>
-            )}
-
-            {/* Link to full review */}
-            <div class="mt-3 flex justify-end">
-              <a href={`/admin/fragebogen/${assignment.id}`}
-                class="text-xs text-gold/80 hover:text-gold underline">
-                Volle Review öffnen →
-              </a>
-            </div>
-          </div>
-        );
-      })}
-    </div>
+    {archived.length > 0 && (
+      <details class="mt-6">
+        <summary class="cursor-pointer text-sm text-muted hover:text-light select-none">
+          Archivierte Fragebögen ({archived.length}) anzeigen
+        </summary>
+        <div class="flex flex-col gap-6 mt-4">
+          {archived.map(bundle => <QuestionnaireBundleCard bundle={bundle} muted={true} />)}
+        </div>
+      </details>
+    )}
   </section>
 )}

--- a/website/src/components/admin/QuestionnaireBundleCard.astro
+++ b/website/src/components/admin/QuestionnaireBundleCard.astro
@@ -1,0 +1,136 @@
+---
+import type { QAssignment, QQuestion, QAnswer, QAnswerOption } from '../../lib/questionnaire-db';
+import type { DimensionScore } from '../../lib/compute-scores';
+
+export interface AssignmentBundle {
+  assignment: QAssignment;
+  questions: QQuestion[];
+  options: QAnswerOption[];
+  answers: QAnswer[];
+  scores: DimensionScore[];
+}
+
+interface Props {
+  bundle: AssignmentBundle;
+  muted?: boolean;
+}
+const { bundle, muted = false } = Astro.props;
+const { assignment, questions, options, answers, scores } = bundle;
+const answerMap = new Map(answers.map(a => [a.question_id, a]));
+const optionMap = new Map(options.map(o => [`${o.question_id}:${o.option_key}`, o]));
+const showQA = ['in_progress', 'submitted', 'reviewed', 'archived'].includes(assignment.status);
+const showScores = scores.length > 0 && ['submitted', 'reviewed', 'archived'].includes(assignment.status);
+const dateLabel = assignment.submitted_at
+  ? `Eingereicht ${new Date(assignment.submitted_at).toLocaleDateString('de-DE', { day: '2-digit', month: '2-digit', year: 'numeric' })}`
+  : `Zugewiesen ${new Date(assignment.assigned_at).toLocaleDateString('de-DE', { day: '2-digit', month: '2-digit', year: 'numeric' })}`;
+const maxScore = Math.max(...scores.map(s => s.threshold_high ?? s.final_score ?? 1), 1);
+
+function levelColor(level: string | null): string {
+  if (level === 'kritisch') return '#ef4444';
+  if (level === 'mittel') return '#f59e0b';
+  if (level === 'förderlich') return '#22c55e';
+  return '#b8a06a';
+}
+
+const STATUS_CLS: Record<string, string> = {
+  pending: 'bg-yellow-500/10 text-yellow-400 border-yellow-500/20',
+  in_progress: 'bg-yellow-500/10 text-yellow-400 border-yellow-500/20',
+  submitted: 'bg-blue-500/10 text-blue-400 border-blue-500/20',
+  reviewed: 'bg-green-500/10 text-green-400 border-green-500/20',
+  archived: 'bg-slate-500/10 text-slate-400 border-slate-500/20',
+  dismissed: 'bg-red-500/10 text-red-400 border-red-500/20',
+};
+const STATUS_LABEL: Record<string, string> = {
+  pending: 'Wartend', in_progress: 'In Bearbeitung', submitted: 'Eingereicht',
+  reviewed: 'Besprochen', archived: 'Archiviert', dismissed: 'Abgelehnt',
+};
+---
+<div class={`border border-dark-lighter rounded-xl p-5 ${muted ? 'opacity-60' : ''}`}>
+  <div class="flex items-start justify-between gap-3 flex-wrap mb-3">
+    <div class="min-w-0">
+      <h3 class="text-light font-medium">{assignment.template_title}</h3>
+      <p class="text-muted text-xs mt-0.5">{dateLabel}</p>
+    </div>
+    <span class={`px-2.5 py-0.5 rounded-full border text-xs ${STATUS_CLS[assignment.status] ?? ''}`}>
+      {STATUS_LABEL[assignment.status] ?? assignment.status}
+    </span>
+  </div>
+
+  {assignment.status === 'dismissed' && assignment.dismiss_reason && (
+    <p class="text-xs text-muted italic mb-3">Abgelehnt: {assignment.dismiss_reason}</p>
+  )}
+
+  {showScores && (
+    <div class="mb-4">
+      <div class="flex flex-col gap-3">
+        {scores.map(score => {
+          const pct = Math.min((score.final_score / Math.max(maxScore, 1)) * 100, 100);
+          const color = levelColor(score.level);
+          return (
+            <div>
+              <div class="flex justify-between items-baseline mb-1">
+                <span class="text-light text-xs">{score.name}</span>
+                <span class="text-xs font-mono" style={`color: ${color}`}>
+                  {score.final_score}{score.level && ` · ${score.level}`}
+                </span>
+              </div>
+              <div class="h-1.5 bg-dark rounded-full overflow-hidden">
+                <div class="h-full rounded-full" style={`width: ${pct}%; background-color: ${color}`}></div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  )}
+
+  {assignment.coach_notes && assignment.coach_notes.trim().length > 0 && (
+    <div class="mb-4 p-3 bg-dark rounded border border-dark-lighter">
+      <p class="text-xs text-muted uppercase tracking-wide mb-1">Coach-Notizen</p>
+      <p class="text-sm text-light/90 whitespace-pre-wrap">{assignment.coach_notes}</p>
+    </div>
+  )}
+
+  {showQA && questions.length > 0 && (
+    <details class="mt-2">
+      <summary class="cursor-pointer text-xs text-gold hover:text-gold-light select-none">
+        Fragen &amp; Antworten anzeigen ({answers.length}/{questions.length})
+      </summary>
+      <div class="mt-3 flex flex-col gap-3">
+        {questions.map((q, i) => {
+          const ans = answerMap.get(q.id);
+          const chosen = ans?.option_key ?? null;
+          const opt = chosen ? optionMap.get(`${q.id}:${chosen}`) : null;
+          const label = opt?.label ?? chosen;
+          return (
+            <div class="border-b border-dark-lighter/50 pb-2 last:border-0 last:pb-0">
+              <p class="text-muted text-xs mb-0.5">Frage {i + 1}</p>
+              <p class="text-light text-sm whitespace-pre-line mb-1">{q.question_text}</p>
+              {chosen === 'skipped' ? (
+                <span class="inline-block px-2 py-0.5 bg-amber-500/10 text-amber-400 border border-amber-500/20 rounded text-xs">
+                  Übersprungen
+                </span>
+              ) : chosen ? (
+                <span class="inline-block px-2 py-0.5 bg-gold/10 text-gold border border-gold/20 rounded text-xs">
+                  {label}
+                </span>
+              ) : (
+                <span class="text-muted text-xs italic">Nicht beantwortet</span>
+              )}
+              {ans?.details_text && (
+                <p class="text-muted text-xs mt-1 whitespace-pre-line">{ans.details_text}</p>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </details>
+  )}
+
+  <div class="mt-3 flex justify-end">
+    <a href={`/admin/fragebogen/${assignment.id}`}
+      class="text-xs text-gold/80 hover:text-gold underline">
+      Volle Review öffnen →
+    </a>
+  </div>
+</div>

--- a/website/src/lib/compute-scores.ts
+++ b/website/src/lib/compute-scores.ts
@@ -1,4 +1,4 @@
-import type { QDimension, QAnswerOption, QAnswer } from './questionnaire-db.ts';
+import type { QDimension, QAnswerOption, QAnswer, QAssignment } from './questionnaire-db.ts';
 
 export interface DimensionScore {
   dimension_id: string;
@@ -53,4 +53,30 @@ export function computeScores(
       level,
     };
   }).sort((a, b) => a.position - b.position);
+}
+
+export async function getDisplayScores(assignment: QAssignment): Promise<DimensionScore[]> {
+  const {
+    listArchivedScores, listQDimensions, listQAnswerOptionsForTemplate, listQAnswers,
+  } = await import('./questionnaire-db');
+
+  if (assignment.status === 'archived') {
+    const snap = await listArchivedScores(assignment.id);
+    return snap.map((s) => ({
+      dimension_id: s.dimension_id,
+      name: s.dimension_name,
+      position: 0,
+      raw_score: s.final_score,
+      final_score: s.final_score,
+      threshold_mid: s.threshold_mid,
+      threshold_high: s.threshold_high,
+      level: s.level,
+    }));
+  }
+  const [dims, opts, answers] = await Promise.all([
+    listQDimensions(assignment.template_id),
+    listQAnswerOptionsForTemplate(assignment.template_id),
+    listQAnswers(assignment.id),
+  ]);
+  return computeScores(dims, opts, answers);
 }

--- a/website/src/lib/questionnaire-archive.test.ts
+++ b/website/src/lib/questionnaire-archive.test.ts
@@ -229,7 +229,7 @@ describe.skipIf(!dbAvailable)('listEvidenceByAssignment', () => {
       templateId: tpl.id, position: 0, questionText: 's', questionType: 'test_step',
     });
     const a = await createQAssignment({ customerId: randomUUID(), templateId: tpl.id });
-    const e1 = await pool.query<{ id: string }>(
+    await pool.query<{ id: string }>(
       `INSERT INTO questionnaire_test_evidence
          (assignment_id, question_id, attempt, replay_path)
        VALUES ($1, $2, 0, '/tmp/r0') RETURNING id`,

--- a/website/src/lib/questionnaire-archive.test.ts
+++ b/website/src/lib/questionnaire-archive.test.ts
@@ -293,3 +293,31 @@ describe.skipIf(!dbAvailable)('getDisplayScores', () => {
     expect(frozen[0].name).toBe('D');
   });
 });
+
+describe.skipIf(!dbAvailable)('updateQAssignment archived reroute', () => {
+  it('writes a snapshot when status is set to archived via updateQAssignment', async () => {
+    const tpl = await createQTemplate({
+      title: `reroute-${randomUUID().slice(0, 8)}`, description: '', instructions: '',
+    });
+    const dim = await upsertQDimension({
+      templateId: tpl.id, name: 'R', position: 0, thresholdMid: 5, thresholdHigh: 10,
+    });
+    const q = await upsertQQuestion({
+      templateId: tpl.id, position: 0, questionText: 'q', questionType: 'likert_5',
+    });
+    await replaceQAnswerOptions(q.id, [
+      { optionKey: '2', label: 'y', dimensionId: dim.id, weight: 1 },
+    ]);
+    const a = await createQAssignment({ customerId: randomUUID(), templateId: tpl.id });
+    await upsertQAnswer({ assignmentId: a.id, questionId: q.id, optionKey: '2' });
+    await updateQAssignment(a.id, { status: 'submitted' });
+
+    await updateQAssignment(a.id, { status: 'archived' });
+    const snap = await pool.query(
+      `SELECT count(*)::int AS n FROM questionnaire_assignment_scores
+        WHERE assignment_id = $1`,
+      [a.id],
+    );
+    expect(snap.rows[0].n).toBe(1);
+  });
+});

--- a/website/src/lib/questionnaire-archive.test.ts
+++ b/website/src/lib/questionnaire-archive.test.ts
@@ -6,6 +6,7 @@ import {
   listArchivedScores, listEvidenceByAssignment,
 } from './questionnaire-db';
 import { archiveQAssignment, reassignQAssignment } from './questionnaire-db';
+import { getDisplayScores } from './compute-scores';
 import { randomUUID } from 'crypto';
 
 const dbAvailable = !!(
@@ -257,5 +258,38 @@ describe.skipIf(!dbAvailable)('listEvidenceByAssignment', () => {
     const a = await createQAssignment({ customerId: randomUUID(), templateId: tpl.id });
     const rows = await listEvidenceByAssignment(a.id);
     expect(rows).toEqual([]);
+  });
+});
+
+describe.skipIf(!dbAvailable)('getDisplayScores', () => {
+  it('uses snapshot for archived; falls back to compute for non-archived', async () => {
+    const tpl = await createQTemplate({
+      title: `gds-${randomUUID().slice(0, 8)}`, description: '', instructions: '',
+    });
+    const dim = await upsertQDimension({
+      templateId: tpl.id, name: 'D', position: 0, thresholdMid: 5, thresholdHigh: 10,
+    });
+    const q = await upsertQQuestion({
+      templateId: tpl.id, position: 0, questionText: 'q', questionType: 'likert_5',
+    });
+    await replaceQAnswerOptions(q.id, [
+      { optionKey: '4', label: 'x', dimensionId: dim.id, weight: 1 },
+    ]);
+    const a = await createQAssignment({ customerId: randomUUID(), templateId: tpl.id });
+    await upsertQAnswer({ assignmentId: a.id, questionId: q.id, optionKey: '4' });
+    await updateQAssignment(a.id, { status: 'submitted' });
+
+    const live = await getDisplayScores(await getQAssignment(a.id) as any);
+    expect(live[0].final_score).toBe(4);
+    expect(live[0].name).toBe('D');
+
+    await archiveQAssignment(a.id);
+    await upsertQDimension({
+      id: dim.id, templateId: tpl.id, name: 'D-renamed', position: 0,
+      thresholdMid: 1, thresholdHigh: 2,
+    });
+    const frozen = await getDisplayScores(await getQAssignment(a.id) as any);
+    expect(frozen[0].final_score).toBe(4);
+    expect(frozen[0].name).toBe('D');
   });
 });

--- a/website/src/lib/questionnaire-archive.test.ts
+++ b/website/src/lib/questionnaire-archive.test.ts
@@ -4,7 +4,7 @@ import {
   createQTemplate, upsertQDimension, upsertQQuestion, replaceQAnswerOptions,
   createQAssignment, updateQAssignment, upsertQAnswer, getQAssignment,
 } from './questionnaire-db';
-import { archiveQAssignment } from './questionnaire-db';
+import { archiveQAssignment, reassignQAssignment } from './questionnaire-db';
 import { randomUUID } from 'crypto';
 
 const dbAvailable = !!(
@@ -149,5 +149,37 @@ describe.skipIf(!dbAvailable)('archiveQAssignment', () => {
       [a.id],
     );
     expect(after.rows.map(r => r.id).sort()).toEqual(before.rows.map(r => r.id).sort());
+  });
+});
+
+describe.skipIf(!dbAvailable)('reassignQAssignment', () => {
+  it('creates a new pending assignment for the same template + customer; source untouched', async () => {
+    const tpl = await createQTemplate({
+      title: `reassign-${randomUUID().slice(0, 8)}`, description: '', instructions: '',
+    });
+    const customerId = randomUUID();
+    const src = await createQAssignment({ customerId, templateId: tpl.id });
+    await updateQAssignment(src.id, { status: 'submitted' });
+    await archiveQAssignment(src.id);
+
+    const result = await reassignQAssignment(src.id);
+    expect('assignment' in result).toBe(true);
+    if (!('assignment' in result)) return;
+    expect(result.assignment.id).not.toBe(src.id);
+    expect(result.assignment.status).toBe('pending');
+    expect(result.assignment.template_id).toBe(tpl.id);
+    expect(result.assignment.customer_id).toBe(customerId);
+    expect(result.assignment.archived_at).toBeNull();
+    expect(result.assignment.submitted_at).toBeNull();
+    expect(result.assignment.coach_notes).toBe('');
+
+    const before = await getQAssignment(src.id);
+    expect(before?.status).toBe('archived');
+    expect(before?.archived_at).not.toBeNull();
+  });
+
+  it('returns not_found for missing id', async () => {
+    const result = await reassignQAssignment(randomUUID());
+    expect('reason' in result && result.reason).toBe('not_found');
   });
 });

--- a/website/src/lib/questionnaire-archive.test.ts
+++ b/website/src/lib/questionnaire-archive.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { pool } from './website-db';
+
+const dbAvailable = !!(
+  process.env.DATABASE_URL ||
+  process.env.WEBSITE_DATABASE_URL ||
+  process.env.SESSIONS_DATABASE_URL
+);
+
+describe.skipIf(!dbAvailable)('archive schema', () => {
+  beforeAll(async () => {
+    // initDb in questionnaire-db.ts runs at module load via top-level await
+    await import('./questionnaire-db');
+  });
+
+  it('creates questionnaire_assignment_scores table', async () => {
+    const r = await pool.query(
+      `SELECT to_regclass('public.questionnaire_assignment_scores') AS t`,
+    );
+    expect(r.rows[0].t).toBe('questionnaire_assignment_scores');
+  });
+
+  it('table has expected columns', async () => {
+    const r = await pool.query(
+      `SELECT column_name FROM information_schema.columns
+       WHERE table_name='questionnaire_assignment_scores'
+       ORDER BY ordinal_position`,
+    );
+    const cols = r.rows.map((x: { column_name: string }) => x.column_name);
+    expect(cols).toEqual([
+      'id', 'assignment_id', 'dimension_id', 'dimension_name',
+      'final_score', 'threshold_mid', 'threshold_high', 'level', 'snapshot_at',
+    ]);
+  });
+
+  it('table has unique (assignment_id, dimension_id) constraint', async () => {
+    const r = await pool.query(
+      `SELECT indexdef FROM pg_indexes
+       WHERE tablename='questionnaire_assignment_scores'
+         AND indexdef ILIKE '%UNIQUE%'`,
+    );
+    expect(r.rows.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('creates bachelorprojekt.v_questionnaire_kpi view', async () => {
+    const r = await pool.query(
+      `SELECT to_regclass('bachelorprojekt.v_questionnaire_kpi') AS t`,
+    );
+    expect(r.rows[0].t).toBe('bachelorprojekt.v_questionnaire_kpi');
+  });
+
+  it('view exposes evidence_count + latest_evidence_id columns', async () => {
+    const r = await pool.query(
+      `SELECT column_name FROM information_schema.columns
+       WHERE table_schema='bachelorprojekt' AND table_name='v_questionnaire_kpi'`,
+    );
+    const cols = r.rows.map((x: { column_name: string }) => x.column_name);
+    expect(cols).toContain('evidence_count');
+    expect(cols).toContain('latest_evidence_id');
+  });
+});

--- a/website/src/lib/questionnaire-archive.test.ts
+++ b/website/src/lib/questionnaire-archive.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, beforeAll } from 'vitest';
 import { pool } from './website-db';
+import {
+  createQTemplate, upsertQDimension, upsertQQuestion, replaceQAnswerOptions,
+  createQAssignment, updateQAssignment, upsertQAnswer, getQAssignment,
+} from './questionnaire-db';
+import { archiveQAssignment } from './questionnaire-db';
+import { randomUUID } from 'crypto';
 
 const dbAvailable = !!(
   process.env.DATABASE_URL ||
@@ -57,5 +63,91 @@ describe.skipIf(!dbAvailable)('archive schema', () => {
     const cols = r.rows.map((x: { column_name: string }) => x.column_name);
     expect(cols).toContain('evidence_count');
     expect(cols).toContain('latest_evidence_id');
+  });
+});
+
+describe.skipIf(!dbAvailable)('archiveQAssignment', () => {
+  async function seedSubmittedAssignment() {
+    const tpl = await createQTemplate({
+      title: `archive-test-${randomUUID().slice(0, 8)}`,
+      description: '', instructions: '',
+    });
+    const dim = await upsertQDimension({
+      templateId: tpl.id, name: 'TestDim', position: 0,
+      thresholdMid: 5, thresholdHigh: 10,
+    });
+    const q = await upsertQQuestion({
+      templateId: tpl.id, position: 0,
+      questionText: 'q?', questionType: 'likert_5',
+    });
+    await replaceQAnswerOptions(q.id, [
+      { optionKey: '5', label: 'high', dimensionId: dim.id, weight: 1 },
+    ]);
+    const a = await createQAssignment({
+      customerId: randomUUID(), templateId: tpl.id,
+    });
+    await upsertQAnswer({
+      assignmentId: a.id, questionId: q.id, optionKey: '5',
+    });
+    await updateQAssignment(a.id, { status: 'submitted' });
+    return { tpl, dim, q, a };
+  }
+
+  it('writes one snapshot row per dimension and flips status to archived', async () => {
+    const { dim, a } = await seedSubmittedAssignment();
+    const result = await archiveQAssignment(a.id);
+    expect('assignment' in result).toBe(true);
+    if (!('assignment' in result)) return;
+    expect(result.assignment.status).toBe('archived');
+    expect(result.assignment.archived_at).not.toBeNull();
+    const snap = await pool.query(
+      `SELECT dimension_id, dimension_name, final_score, level
+         FROM questionnaire_assignment_scores
+        WHERE assignment_id = $1`,
+      [a.id],
+    );
+    expect(snap.rows.length).toBe(1);
+    expect(snap.rows[0].dimension_id).toBe(dim.id);
+    expect(snap.rows[0].dimension_name).toBe('TestDim');
+    expect(snap.rows[0].final_score).toBe(5);
+    expect(snap.rows[0].level).toBe('mittel');
+  });
+
+  it('rejects non-archivable statuses with a reason', async () => {
+    const tpl = await createQTemplate({
+      title: `reject-${randomUUID().slice(0, 8)}`, description: '', instructions: '',
+    });
+    const a = await createQAssignment({
+      customerId: randomUUID(), templateId: tpl.id,
+    });
+    const result = await archiveQAssignment(a.id);
+    expect('reason' in result).toBe(true);
+    if ('reason' in result) {
+      expect(result.reason).toBe('not_archivable');
+      expect(result.status).toBe('pending');
+    }
+  });
+
+  it('returns not_found for missing id', async () => {
+    const result = await archiveQAssignment(randomUUID());
+    expect('reason' in result && result.reason).toBe('not_found');
+  });
+
+  it('is idempotent: re-archiving an archived row leaves snapshot intact', async () => {
+    const { a } = await seedSubmittedAssignment();
+    await archiveQAssignment(a.id);
+    const before = await pool.query(
+      `SELECT id, snapshot_at FROM questionnaire_assignment_scores
+        WHERE assignment_id = $1`,
+      [a.id],
+    );
+    const result2 = await archiveQAssignment(a.id);
+    expect('assignment' in result2).toBe(true);
+    const after = await pool.query(
+      `SELECT id, snapshot_at FROM questionnaire_assignment_scores
+        WHERE assignment_id = $1`,
+      [a.id],
+    );
+    expect(after.rows.map(r => r.id).sort()).toEqual(before.rows.map(r => r.id).sort());
   });
 });

--- a/website/src/lib/questionnaire-archive.test.ts
+++ b/website/src/lib/questionnaire-archive.test.ts
@@ -3,6 +3,7 @@ import { pool } from './website-db';
 import {
   createQTemplate, upsertQDimension, upsertQQuestion, replaceQAnswerOptions,
   createQAssignment, updateQAssignment, upsertQAnswer, getQAssignment,
+  listArchivedScores, listEvidenceByAssignment,
 } from './questionnaire-db';
 import { archiveQAssignment, reassignQAssignment } from './questionnaire-db';
 import { randomUUID } from 'crypto';
@@ -181,5 +182,80 @@ describe.skipIf(!dbAvailable)('reassignQAssignment', () => {
   it('returns not_found for missing id', async () => {
     const result = await reassignQAssignment(randomUUID());
     expect('reason' in result && result.reason).toBe('not_found');
+  });
+});
+
+describe.skipIf(!dbAvailable)('listArchivedScores', () => {
+  it('returns snapshot rows for an archived assignment', async () => {
+    const tpl = await createQTemplate({
+      title: `lsnap-${randomUUID().slice(0, 8)}`, description: '', instructions: '',
+    });
+    const dim = await upsertQDimension({
+      templateId: tpl.id, name: 'X', position: 0, thresholdMid: 5, thresholdHigh: 10,
+    });
+    const q = await upsertQQuestion({
+      templateId: tpl.id, position: 0, questionText: 'q', questionType: 'likert_5',
+    });
+    await replaceQAnswerOptions(q.id, [
+      { optionKey: '3', label: 'm', dimensionId: dim.id, weight: 1 },
+    ]);
+    const a = await createQAssignment({ customerId: randomUUID(), templateId: tpl.id });
+    await upsertQAnswer({ assignmentId: a.id, questionId: q.id, optionKey: '3' });
+    await updateQAssignment(a.id, { status: 'submitted' });
+    await archiveQAssignment(a.id);
+
+    const rows = await listArchivedScores(a.id);
+    expect(rows.length).toBe(1);
+    expect(rows[0].dimension_id).toBe(dim.id);
+    expect(rows[0].final_score).toBe(3);
+  });
+
+  it('returns empty array for non-archived assignment', async () => {
+    const tpl = await createQTemplate({
+      title: `lsnap-empty-${randomUUID().slice(0, 8)}`, description: '', instructions: '',
+    });
+    const a = await createQAssignment({ customerId: randomUUID(), templateId: tpl.id });
+    const rows = await listArchivedScores(a.id);
+    expect(rows).toEqual([]);
+  });
+});
+
+describe.skipIf(!dbAvailable)('listEvidenceByAssignment', () => {
+  it('returns latest-attempt evidence per question with count', async () => {
+    const tpl = await createQTemplate({
+      title: `evid-${randomUUID().slice(0, 8)}`, description: '', instructions: '',
+    });
+    const q = await upsertQQuestion({
+      templateId: tpl.id, position: 0, questionText: 's', questionType: 'test_step',
+    });
+    const a = await createQAssignment({ customerId: randomUUID(), templateId: tpl.id });
+    const e1 = await pool.query<{ id: string }>(
+      `INSERT INTO questionnaire_test_evidence
+         (assignment_id, question_id, attempt, replay_path)
+       VALUES ($1, $2, 0, '/tmp/r0') RETURNING id`,
+      [a.id, q.id],
+    );
+    const e2 = await pool.query<{ id: string }>(
+      `INSERT INTO questionnaire_test_evidence
+         (assignment_id, question_id, attempt, replay_path)
+       VALUES ($1, $2, 1, '/tmp/r1') RETURNING id`,
+      [a.id, q.id],
+    );
+
+    const rows = await listEvidenceByAssignment(a.id);
+    expect(rows.length).toBe(1);
+    expect(rows[0].question_id).toBe(q.id);
+    expect(rows[0].latest_evidence_id).toBe(e2.rows[0].id);
+    expect(rows[0].latest_attempt).toBe(1);
+    expect(rows[0].evidence_count).toBe(2);
+  });
+
+  it('returns empty array when there is no evidence', async () => {
+    const tpl = await createQTemplate({
+      title: `evid-empty-${randomUUID().slice(0, 8)}`, description: '', instructions: '',
+    });
+    const a = await createQAssignment({ customerId: randomUUID(), templateId: tpl.id });
+    const rows = await listEvidenceByAssignment(a.id);
+    expect(rows).toEqual([]);
   });
 });

--- a/website/src/lib/questionnaire-db.ts
+++ b/website/src/lib/questionnaire-db.ts
@@ -594,17 +594,42 @@ export async function getQAssignment(id: string): Promise<QAssignment | null> {
 export async function updateQAssignment(id: string, params: {
   status?: AssignmentStatus; coachNotes?: string; dismissReason?: string;
 }): Promise<QAssignment | null> {
+  if (params.status === 'archived') {
+    if (params.coachNotes !== undefined || params.dismissReason !== undefined) {
+      const sets: string[] = [];
+      const vals: unknown[] = [];
+      if (params.coachNotes !== undefined) {
+        vals.push(params.coachNotes); sets.push(`coach_notes = $${vals.length}`);
+      }
+      if (params.dismissReason !== undefined) {
+        vals.push(params.dismissReason); sets.push(`dismiss_reason = $${vals.length}`);
+      }
+      vals.push(id);
+      await pool.query(
+        `UPDATE questionnaire_assignments SET ${sets.join(', ')}
+         WHERE id = $${vals.length}`,
+        vals,
+      );
+    }
+    const result = await archiveQAssignment(id);
+    if ('reason' in result) return null;
+    return result.assignment;
+  }
+
   const sets: string[] = [];
   const vals: unknown[] = [];
   if (params.status !== undefined) {
     vals.push(params.status); sets.push(`status = $${vals.length}`);
     if (params.status === 'submitted') sets.push(`submitted_at = now()`);
     if (params.status === 'reviewed') sets.push(`reviewed_at = now()`);
-    if (params.status === 'archived') sets.push(`archived_at = now()`);
     if (params.status === 'dismissed') sets.push(`dismissed_at = now()`);
   }
-  if (params.dismissReason !== undefined) { vals.push(params.dismissReason); sets.push(`dismiss_reason = $${vals.length}`); }
-  if (params.coachNotes !== undefined) { vals.push(params.coachNotes); sets.push(`coach_notes = $${vals.length}`); }
+  if (params.dismissReason !== undefined) {
+    vals.push(params.dismissReason); sets.push(`dismiss_reason = $${vals.length}`);
+  }
+  if (params.coachNotes !== undefined) {
+    vals.push(params.coachNotes); sets.push(`coach_notes = $${vals.length}`);
+  }
   if (sets.length === 0) return getQAssignment(id);
   vals.push(id);
   const r = await pool.query(

--- a/website/src/lib/questionnaire-db.ts
+++ b/website/src/lib/questionnaire-db.ts
@@ -624,6 +624,85 @@ export async function dismissQAssignment(id: string, reason: string): Promise<QA
   return updateQAssignment(id, { status: 'dismissed', dismissReason: reason });
 }
 
+const ARCHIVABLE_STATUSES: AssignmentStatus[] = ['submitted', 'reviewed', 'archived'];
+
+export async function archiveQAssignment(id: string): Promise<
+  | { assignment: QAssignment }
+  | { reason: 'not_found' | 'not_archivable'; status?: AssignmentStatus }
+> {
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+    const a = await client.query<{ template_id: string; status: AssignmentStatus }>(
+      `SELECT template_id, status FROM questionnaire_assignments
+        WHERE id = $1 FOR UPDATE`,
+      [id],
+    );
+    if (a.rows.length === 0) {
+      await client.query('ROLLBACK');
+      return { reason: 'not_found' };
+    }
+    const status = a.rows[0].status;
+    if (!ARCHIVABLE_STATUSES.includes(status)) {
+      await client.query('ROLLBACK');
+      return { reason: 'not_archivable', status };
+    }
+    const templateId = a.rows[0].template_id;
+
+    if (status !== 'archived') {
+      await client.query(
+        `UPDATE questionnaire_assignments
+            SET status = 'archived', archived_at = now()
+          WHERE id = $1`,
+        [id],
+      );
+    }
+
+    const dimsRes = await client.query<QDimension>(
+      `SELECT id, template_id, name, position, threshold_mid, threshold_high,
+              score_multiplier, created_at
+         FROM questionnaire_dimensions WHERE template_id = $1 ORDER BY position`,
+      [templateId],
+    );
+    const optsRes = await client.query<QAnswerOption>(
+      `SELECT ao.id, ao.question_id, ao.option_key, ao.label, ao.dimension_id, ao.weight
+         FROM questionnaire_answer_options ao
+         JOIN questionnaire_questions q ON q.id = ao.question_id
+        WHERE q.template_id = $1`,
+      [templateId],
+    );
+    const ansRes = await client.query<QAnswer>(
+      `SELECT id, assignment_id, question_id, option_key, details_text, saved_at
+         FROM questionnaire_answers WHERE assignment_id = $1`,
+      [id],
+    );
+
+    const { computeScores } = await import('./compute-scores');
+    const scores = computeScores(dimsRes.rows, optsRes.rows, ansRes.rows);
+    for (const s of scores) {
+      await client.query(
+        `INSERT INTO questionnaire_assignment_scores
+           (assignment_id, dimension_id, dimension_name, final_score,
+            threshold_mid, threshold_high, level)
+         VALUES ($1, $2, $3, $4, $5, $6, $7)
+         ON CONFLICT ON CONSTRAINT uq_qas_assignment_dimension DO NOTHING`,
+        [id, s.dimension_id, s.name, s.final_score,
+         s.threshold_mid, s.threshold_high, s.level],
+      );
+    }
+
+    await client.query('COMMIT');
+    const updated = await getQAssignment(id);
+    if (!updated) return { reason: 'not_found' };
+    return { assignment: updated };
+  } catch (err) {
+    await client.query('ROLLBACK').catch(() => {});
+    throw err;
+  } finally {
+    client.release();
+  }
+}
+
 /**
  * Reset a finished assignment so it can be filled out again.
  *

--- a/website/src/lib/questionnaire-db.ts
+++ b/website/src/lib/questionnaire-db.ts
@@ -703,6 +703,20 @@ export async function archiveQAssignment(id: string): Promise<
   }
 }
 
+export async function reassignQAssignment(id: string): Promise<
+  | { assignment: QAssignment }
+  | { reason: 'not_found' }
+> {
+  const src = await getQAssignment(id);
+  if (!src) return { reason: 'not_found' };
+  const created = await createQAssignment({
+    customerId: src.customer_id,
+    templateId: src.template_id,
+    projectId: src.project_id ?? undefined,
+  });
+  return { assignment: created };
+}
+
 /**
  * Reset a finished assignment so it can be filled out again.
  *

--- a/website/src/lib/questionnaire-db.ts
+++ b/website/src/lib/questionnaire-db.ts
@@ -274,6 +274,55 @@ async function initDb() {
       END IF;
     END$$
   `);
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS questionnaire_assignment_scores (
+      id             UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      assignment_id  UUID NOT NULL REFERENCES questionnaire_assignments(id) ON DELETE CASCADE,
+      dimension_id   UUID NOT NULL,
+      dimension_name TEXT NOT NULL,
+      final_score    INTEGER NOT NULL,
+      threshold_mid  INTEGER,
+      threshold_high INTEGER,
+      level          TEXT,
+      snapshot_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+      CONSTRAINT uq_qas_assignment_dimension UNIQUE (assignment_id, dimension_id)
+    )
+  `);
+  await pool.query(
+    `CREATE INDEX IF NOT EXISTS idx_qas_assignment ON questionnaire_assignment_scores(assignment_id)`,
+  );
+  await pool.query(`CREATE SCHEMA IF NOT EXISTS bachelorprojekt`);
+  await pool.query(`
+    CREATE OR REPLACE VIEW bachelorprojekt.v_questionnaire_kpi AS
+    SELECT
+      a.id              AS assignment_id,
+      a.customer_id,
+      a.template_id,
+      t.title           AS template_title,
+      t.is_system_test,
+      a.assigned_at,
+      a.submitted_at,
+      a.archived_at,
+      s.dimension_id,
+      s.dimension_name,
+      s.final_score,
+      s.threshold_mid,
+      s.threshold_high,
+      s.level,
+      ev.evidence_count,
+      ev.latest_evidence_id
+    FROM questionnaire_assignments a
+    JOIN questionnaire_templates t ON t.id = a.template_id
+    JOIN questionnaire_assignment_scores s ON s.assignment_id = a.id
+    LEFT JOIN LATERAL (
+      SELECT
+        COUNT(*)::int AS evidence_count,
+        (ARRAY_AGG(e.id ORDER BY e.attempt DESC, e.created_at DESC))[1] AS latest_evidence_id
+      FROM questionnaire_test_evidence e
+      WHERE e.assignment_id = a.id
+    ) ev ON true
+    WHERE a.status = 'archived'
+  `);
   await ensureSystemtestSchema(pool);
   await seedSystemTestTemplates();
 }

--- a/website/src/lib/questionnaire-db.ts
+++ b/website/src/lib/questionnaire-db.ts
@@ -943,3 +943,49 @@ export async function listTestStatusesForMonitoring(): Promise<{
   }
   return Array.from(byTemplate.values());
 }
+
+export interface QArchivedScore {
+  assignment_id: string;
+  dimension_id: string;
+  dimension_name: string;
+  final_score: number;
+  threshold_mid: number | null;
+  threshold_high: number | null;
+  level: 'förderlich' | 'mittel' | 'kritisch' | null;
+  snapshot_at: string;
+}
+
+export async function listArchivedScores(assignmentId: string): Promise<QArchivedScore[]> {
+  const r = await pool.query(
+    `SELECT assignment_id, dimension_id, dimension_name, final_score,
+            threshold_mid, threshold_high, level, snapshot_at
+       FROM questionnaire_assignment_scores
+      WHERE assignment_id = $1
+      ORDER BY dimension_name`,
+    [assignmentId],
+  );
+  return r.rows;
+}
+
+export interface QEvidenceForQuestion {
+  question_id: string;
+  latest_evidence_id: string;
+  latest_attempt: number;
+  evidence_count: number;
+}
+
+export async function listEvidenceByAssignment(
+  assignmentId: string,
+): Promise<QEvidenceForQuestion[]> {
+  const r = await pool.query(
+    `SELECT question_id,
+            (ARRAY_AGG(id ORDER BY attempt DESC, created_at DESC))[1] AS latest_evidence_id,
+            MAX(attempt)::int                                          AS latest_attempt,
+            COUNT(*)::int                                              AS evidence_count
+       FROM questionnaire_test_evidence
+      WHERE assignment_id = $1
+      GROUP BY question_id`,
+    [assignmentId],
+  );
+  return r.rows;
+}

--- a/website/src/pages/admin/fragebogen/[assignmentId].astro
+++ b/website/src/pages/admin/fragebogen/[assignmentId].astro
@@ -1,13 +1,14 @@
 ---
-// website/src/pages/admin/fragebogen/[assignmentId].astro
 import AdminLayout from '../../../layouts/AdminLayout.astro';
 import { getSession, getLoginUrl, isAdmin } from '../../../lib/auth';
 import {
   getQAssignment, listQDimensions, listQQuestions,
   listQAnswerOptionsForTemplate, listQAnswers, getQTemplate,
+  listEvidenceByAssignment,
 } from '../../../lib/questionnaire-db';
-import { computeScores } from '../../../lib/compute-scores';
+import { getDisplayScores } from '../../../lib/compute-scores';
 import { isSystemtestLoopEnabled } from '../../../lib/systemtest/feature-flag';
+import SystemtestReplayDrawer from '../../../components/SystemtestReplayDrawer.svelte';
 
 const session = await getSession(Astro.request.headers.get('cookie'));
 if (!session) return Astro.redirect(getLoginUrl(Astro.url.pathname));
@@ -19,32 +20,22 @@ if (!assignmentId) return Astro.redirect('/admin');
 const assignment = await getQAssignment(assignmentId).catch(() => null);
 if (!assignment) return Astro.redirect('/admin');
 
-const [dimensions, questions, allOptions, answers] = await Promise.all([
+const [dimensions, questions, allOptions, answers, evidenceList] = await Promise.all([
   listQDimensions(assignment.template_id),
   listQQuestions(assignment.template_id),
   listQAnswerOptionsForTemplate(assignment.template_id),
   listQAnswers(assignment.id),
+  listEvidenceByAssignment(assignment.id),
 ]);
 
 const tpl = await getQTemplate(assignment.template_id).catch(() => null);
 const isSystemTest = tpl?.is_system_test ?? false;
-
-// Task 10: when the rrweb recorder boot and the "Seed test data" button get
-// wired into this page, gate them on `isSystemtestLoopEnabled()`. The sticky
-// guidance panel below is rendered unconditionally for system-test templates
-// — it's harmless and tester-useful regardless of rollout state.
-//
-// Today neither the seed button nor the recorder boot exist in the
-// questionnaire UI (they ship in a follow-up). The flag is imported here so
-// the moment those land, gating is a one-line change: wrap the boot/render
-// in `{systemtestLoopEnabled && (...)}`.
 const systemtestLoopEnabled = isSystemTest && isSystemtestLoopEnabled();
-// `systemtestLoopEnabled` is intentionally computed but unused at this
-// rollout stage — the seed button + recorder boot land in a follow-up PR.
 void systemtestLoopEnabled;
 
-const scores = computeScores(dimensions, allOptions, answers);
+const scores = await getDisplayScores(assignment);
 const answerMap = new Map(answers.map(a => [a.question_id, a]));
+const evidenceMap = new Map(evidenceList.map(e => [e.question_id, e]));
 
 function levelColor(level: string | null) {
   if (level === 'kritisch') return '#ef4444';
@@ -221,6 +212,16 @@ const maxScore = Math.max(...scores.map(s => s.threshold_high ?? s.final_score ?
                     ) : (
                       <span class="text-muted text-xs italic flex-1">Noch nicht getestet</span>
                     )}
+                    {isSystemTest && evidenceMap.has(q.id) && (
+                      <button
+                        type="button"
+                        class="replay-btn px-2.5 py-1 text-xs border border-blue-500/30 text-blue-400 rounded hover:bg-blue-500/10 transition-colors flex-shrink-0"
+                        data-evidence-id={evidenceMap.get(q.id)?.latest_evidence_id}
+                      >
+                        ▶ Replay ansehen
+                        <span class="ml-1 text-blue-300/70">(Versuch {evidenceMap.get(q.id)?.latest_attempt})</span>
+                      </button>
+                    )}
                     {canFileBug && (
                       <button
                         class="file-bug-btn px-2.5 py-1 text-xs border border-red-500/30 text-red-400 rounded hover:bg-red-500/10 transition-colors flex-shrink-0"
@@ -324,13 +325,21 @@ const maxScore = Math.max(...scores.map(s => s.threshold_high ?? s.final_score ?
               Als besprochen markieren ✓
             </button>
           )}
-          {assignment.status === 'reviewed' && (
+          {(assignment.status === 'submitted' || assignment.status === 'reviewed') && (
             <button id="archive-btn"
               class="px-4 py-2 bg-dark border border-dark-lighter text-muted rounded-lg text-sm hover:border-gold/40 hover:text-light transition-colors">
               Archivieren
             </button>
           )}
-          {(assignment.status === 'submitted' || assignment.status === 'reviewed' || assignment.status === 'archived' || assignment.status === 'dismissed') && (
+          {assignment.status === 'archived' && (
+            <button id="reassign-btn"
+              data-testid="reassign-questionnaire"
+              class="px-4 py-2 bg-emerald-700 text-white rounded-lg text-sm font-semibold hover:bg-emerald-600 transition-colors"
+              title="Gleichen Fragebogen neu zuweisen — der archivierte Datenpunkt bleibt erhalten.">
+              Erneut zuweisen ➕
+            </button>
+          )}
+          {(assignment.status === 'submitted' || assignment.status === 'reviewed' || assignment.status === 'dismissed') && (
             <button id="reopen-btn"
               data-testid="reopen-questionnaire"
               class="px-4 py-2 bg-amber-700 text-white rounded-lg text-sm font-semibold hover:bg-amber-600 transition-colors"
@@ -344,6 +353,7 @@ const maxScore = Math.max(...scores.map(s => s.threshold_high ?? s.final_score ?
 
     </div>
   </section>
+  <div id="replay-drawer-mount"></div>
 </AdminLayout>
 
 <script define:vars={{ assignmentId }}>
@@ -431,12 +441,80 @@ const maxScore = Math.max(...scores.map(s => s.threshold_high ?? s.final_score ?
 
   // Archive
   document.getElementById('archive-btn')?.addEventListener('click', async () => {
-    const r = await fetch(`/api/admin/questionnaires/assignments/${assignmentId}`, {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ status: 'archived' }),
+    if (!window.confirm(
+      'Diese Auswertung als historischen Datenpunkt sichern? '
+      + 'Werte werden eingefroren und der Fragebogen verschwindet aus den aktiven Listen.',
+    )) return;
+    const r = await fetch(
+      `/api/admin/questionnaires/assignments/${assignmentId}/archive`,
+      { method: 'POST' },
+    );
+    if (r.ok) {
+      window.location.reload();
+    } else {
+      const d = await r.json().catch(() => ({}));
+      msgEl.textContent = d.error || 'Fehler beim Archivieren.';
+      msgEl.className = 'text-xs mt-2 text-red-400';
+      msgEl.classList.remove('hidden');
+    }
+  });
+
+  // Reassign — create a fresh assignment, keep the archived datapoint
+  document.getElementById('reassign-btn')?.addEventListener('click', async () => {
+    if (!window.confirm(
+      'Gleichen Fragebogen erneut zuweisen? Der archivierte Datenpunkt bleibt unverändert; '
+      + 'eine neue Zuweisung wird angelegt.',
+    )) return;
+    const btn = document.getElementById('reassign-btn');
+    btn.disabled = true;
+    btn.textContent = '…';
+    try {
+      const r = await fetch(
+        `/api/admin/questionnaires/assignments/${assignmentId}/reassign`,
+        { method: 'POST' },
+      );
+      const d = await r.json().catch(() => ({}));
+      if (r.ok) {
+        window.location.href = d.portalUrl;
+      } else {
+        btn.disabled = false;
+        btn.textContent = 'Erneut zuweisen ➕';
+        msgEl.textContent = d.error || 'Fehler beim Zuweisen.';
+        msgEl.className = 'text-xs mt-2 text-red-400';
+        msgEl.classList.remove('hidden');
+      }
+    } catch {
+      btn.disabled = false;
+      btn.textContent = 'Erneut zuweisen ➕';
+      msgEl.textContent = 'Netzwerkfehler.';
+      msgEl.className = 'text-xs mt-2 text-red-400';
+      msgEl.classList.remove('hidden');
+    }
+  });
+
+  // Replay drawer — lazy-mount SystemtestReplayDrawer
+  let replayDrawer = null;
+  document.querySelectorAll('.replay-btn').forEach(btn => {
+    btn.addEventListener('click', async () => {
+      const evidenceId = btn.dataset.evidenceId;
+      if (!evidenceId) return;
+      if (!replayDrawer) {
+        const { default: Drawer } = await import(
+          '../../../components/SystemtestReplayDrawer.svelte'
+        );
+        const replayMount = document.getElementById('replay-drawer-mount');
+        replayDrawer = new Drawer({
+          target: replayMount,
+          props: { evidenceId },
+        });
+        replayDrawer.$on('close', () => {
+          replayDrawer.$destroy();
+          replayDrawer = null;
+        });
+      } else {
+        replayDrawer.$set({ evidenceId });
+      }
     });
-    if (r.ok) window.location.reload();
   });
 
   // Reopen — wipe answers + reset to pending, then jump to portal wizard

--- a/website/src/pages/admin/projekte/[id].astro
+++ b/website/src/pages/admin/projekte/[id].astro
@@ -14,9 +14,8 @@ import {
   listQQuestions,
   listQAnswerOptionsForTemplate,
   listQAnswers,
-  listQDimensions,
 } from '../../../lib/questionnaire-db';
-import { computeScores } from '../../../lib/compute-scores';
+import { getDisplayScores } from '../../../lib/compute-scores';
 import ProjectQuestionnairesPanel, { type AssignmentBundle } from '../../../components/admin/ProjectQuestionnairesPanel.astro';
 
 const session = await getSession(Astro.request.headers.get('cookie'));
@@ -64,13 +63,13 @@ try {
       try {
         const assignments = await listQAssignmentsForProject(id);
         questionnaireBundles = await Promise.all(assignments.map(async a => {
-          const [questions, options, answers, dimensions] = await Promise.all([
+          const [questions, options, answers] = await Promise.all([
             listQQuestions(a.template_id),
             listQAnswerOptionsForTemplate(a.template_id),
             listQAnswers(a.id),
-            listQDimensions(a.template_id),
           ]);
-          return { assignment: a, questions, options, answers, scores: computeScores(dimensions, options, answers) };
+          const scores = await getDisplayScores(a);
+          return { assignment: a, questions, options, answers, scores };
         }));
       } catch (err) {
         console.error('[admin/projekte/[id]] questionnaire fetch failed:', err);

--- a/website/src/pages/admin/tickets/[id].astro
+++ b/website/src/pages/admin/tickets/[id].astro
@@ -9,9 +9,8 @@ import {
   listQQuestions,
   listQAnswerOptionsForTemplate,
   listQAnswers,
-  listQDimensions,
 } from '../../../lib/questionnaire-db';
-import { computeScores } from '../../../lib/compute-scores';
+import { getDisplayScores } from '../../../lib/compute-scores';
 import ProjectQuestionnairesPanel, { type AssignmentBundle } from '../../../components/admin/ProjectQuestionnairesPanel.astro';
 
 const session = await getSession(Astro.request.headers.get('cookie'));
@@ -36,13 +35,13 @@ if (ticket.type === 'project') {
   try {
     const assignments = await listQAssignmentsForProject(ticket.id);
     questionnaireBundles = await Promise.all(assignments.map(async a => {
-      const [questions, options, answers, dimensions] = await Promise.all([
+      const [questions, options, answers] = await Promise.all([
         listQQuestions(a.template_id),
         listQAnswerOptionsForTemplate(a.template_id),
         listQAnswers(a.id),
-        listQDimensions(a.template_id),
       ]);
-      return { assignment: a, questions, options, answers, scores: computeScores(dimensions, options, answers) };
+      const scores = await getDisplayScores(a);
+      return { assignment: a, questions, options, answers, scores };
     }));
   } catch (err) {
     console.error('[admin/tickets/[id]] questionnaire fetch failed:', err);

--- a/website/src/pages/api/admin/questionnaires/assignments/[id]/archive.test.ts
+++ b/website/src/pages/api/admin/questionnaires/assignments/[id]/archive.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { POST } from './archive';
+
+vi.mock('../../../../../../lib/auth', () => ({
+  getSession: vi.fn(),
+  isAdmin: vi.fn(),
+}));
+vi.mock('../../../../../../lib/questionnaire-db', () => ({
+  archiveQAssignment: vi.fn(),
+}));
+
+import { getSession, isAdmin } from '../../../../../../lib/auth';
+import { archiveQAssignment } from '../../../../../../lib/questionnaire-db';
+
+function req(): Request {
+  return new Request('http://x', { method: 'POST', headers: { cookie: 'k=v' } });
+}
+
+beforeEach(() => {
+  vi.mocked(getSession).mockReset();
+  vi.mocked(isAdmin).mockReset();
+  vi.mocked(archiveQAssignment).mockReset();
+});
+
+describe('POST /api/admin/questionnaires/assignments/[id]/archive', () => {
+  it('401 when no session', async () => {
+    vi.mocked(getSession).mockResolvedValue(null);
+    const r = await POST({ request: req(), params: { id: 'a' } } as any);
+    expect(r.status).toBe(401);
+  });
+
+  it('401 when not admin', async () => {
+    vi.mocked(getSession).mockResolvedValue({ user: { sub: 'u' } } as any);
+    vi.mocked(isAdmin).mockReturnValue(false);
+    const r = await POST({ request: req(), params: { id: 'a' } } as any);
+    expect(r.status).toBe(401);
+  });
+
+  it('400 when id missing', async () => {
+    vi.mocked(getSession).mockResolvedValue({ user: { sub: 'u' } } as any);
+    vi.mocked(isAdmin).mockReturnValue(true);
+    const r = await POST({ request: req(), params: {} } as any);
+    expect(r.status).toBe(400);
+  });
+
+  it('404 when archive helper returns not_found', async () => {
+    vi.mocked(getSession).mockResolvedValue({ user: { sub: 'u' } } as any);
+    vi.mocked(isAdmin).mockReturnValue(true);
+    vi.mocked(archiveQAssignment).mockResolvedValue({ reason: 'not_found' } as any);
+    const r = await POST({ request: req(), params: { id: 'a' } } as any);
+    expect(r.status).toBe(404);
+  });
+
+  it('409 when status not archivable', async () => {
+    vi.mocked(getSession).mockResolvedValue({ user: { sub: 'u' } } as any);
+    vi.mocked(isAdmin).mockReturnValue(true);
+    vi.mocked(archiveQAssignment).mockResolvedValue({
+      reason: 'not_archivable', status: 'pending',
+    } as any);
+    const r = await POST({ request: req(), params: { id: 'a' } } as any);
+    expect(r.status).toBe(409);
+    const body = await r.json();
+    expect(body.status).toBe('pending');
+  });
+
+  it('200 with assignment on success', async () => {
+    vi.mocked(getSession).mockResolvedValue({ user: { sub: 'u' } } as any);
+    vi.mocked(isAdmin).mockReturnValue(true);
+    vi.mocked(archiveQAssignment).mockResolvedValue({
+      assignment: { id: 'a', status: 'archived' } as any,
+    });
+    const r = await POST({ request: req(), params: { id: 'a' } } as any);
+    expect(r.status).toBe(200);
+    const body = await r.json();
+    expect(body.assignment.id).toBe('a');
+  });
+});

--- a/website/src/pages/api/admin/questionnaires/assignments/[id]/archive.ts
+++ b/website/src/pages/api/admin/questionnaires/assignments/[id]/archive.ts
@@ -1,0 +1,27 @@
+import type { APIRoute } from 'astro';
+import { getSession, isAdmin } from '../../../../../../lib/auth';
+import { archiveQAssignment } from '../../../../../../lib/questionnaire-db';
+
+export const POST: APIRoute = async ({ request, params }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) {
+    return new Response('Unauthorized', { status: 401 });
+  }
+  if (!params.id) {
+    return new Response(JSON.stringify({ error: 'id missing' }), { status: 400 });
+  }
+
+  const result = await archiveQAssignment(params.id);
+  if ('reason' in result) {
+    if (result.reason === 'not_found') {
+      return new Response(JSON.stringify({ error: 'Nicht gefunden.' }), { status: 404 });
+    }
+    return new Response(JSON.stringify({
+      error: `Fragebogen kann im Status '${result.status}' nicht archiviert werden.`,
+      status: result.status,
+    }), { status: 409, headers: { 'Content-Type': 'application/json' } });
+  }
+  return new Response(JSON.stringify({ assignment: result.assignment }), {
+    status: 200, headers: { 'Content-Type': 'application/json' },
+  });
+};

--- a/website/src/pages/api/admin/questionnaires/assignments/[id]/reassign.test.ts
+++ b/website/src/pages/api/admin/questionnaires/assignments/[id]/reassign.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { POST } from './reassign';
+
+vi.mock('../../../../../../lib/auth', () => ({
+  getSession: vi.fn(),
+  isAdmin: vi.fn(),
+}));
+vi.mock('../../../../../../lib/questionnaire-db', () => ({
+  reassignQAssignment: vi.fn(),
+}));
+
+import { getSession, isAdmin } from '../../../../../../lib/auth';
+import { reassignQAssignment } from '../../../../../../lib/questionnaire-db';
+
+function req(): Request {
+  return new Request('http://x', { method: 'POST', headers: { cookie: 'k=v' } });
+}
+
+beforeEach(() => {
+  vi.mocked(getSession).mockReset();
+  vi.mocked(isAdmin).mockReset();
+  vi.mocked(reassignQAssignment).mockReset();
+  delete process.env.PROD_DOMAIN;
+});
+
+describe('POST /api/admin/questionnaires/assignments/[id]/reassign', () => {
+  it('401 when not admin', async () => {
+    vi.mocked(getSession).mockResolvedValue(null);
+    const r = await POST({ request: req(), params: { id: 'a' } } as any);
+    expect(r.status).toBe(401);
+  });
+
+  it('400 when id missing', async () => {
+    vi.mocked(getSession).mockResolvedValue({} as any);
+    vi.mocked(isAdmin).mockReturnValue(true);
+    const r = await POST({ request: req(), params: {} } as any);
+    expect(r.status).toBe(400);
+  });
+
+  it('404 when source missing', async () => {
+    vi.mocked(getSession).mockResolvedValue({} as any);
+    vi.mocked(isAdmin).mockReturnValue(true);
+    vi.mocked(reassignQAssignment).mockResolvedValue({ reason: 'not_found' } as any);
+    const r = await POST({ request: req(), params: { id: 'a' } } as any);
+    expect(r.status).toBe(404);
+  });
+
+  it('200 with portalUrl (relative when PROD_DOMAIN unset)', async () => {
+    vi.mocked(getSession).mockResolvedValue({} as any);
+    vi.mocked(isAdmin).mockReturnValue(true);
+    vi.mocked(reassignQAssignment).mockResolvedValue({
+      assignment: { id: 'newId' } as any,
+    });
+    const r = await POST({ request: req(), params: { id: 'a' } } as any);
+    expect(r.status).toBe(200);
+    const body = await r.json();
+    expect(body.assignment.id).toBe('newId');
+    expect(body.portalUrl).toBe('/portal/fragebogen/newId');
+  });
+
+  it('200 with absolute portalUrl when PROD_DOMAIN set', async () => {
+    process.env.PROD_DOMAIN = 'mentolder.de';
+    vi.mocked(getSession).mockResolvedValue({} as any);
+    vi.mocked(isAdmin).mockReturnValue(true);
+    vi.mocked(reassignQAssignment).mockResolvedValue({
+      assignment: { id: 'newId' } as any,
+    });
+    const r = await POST({ request: req(), params: { id: 'a' } } as any);
+    const body = await r.json();
+    expect(body.portalUrl).toBe('https://web.mentolder.de/portal/fragebogen/newId');
+  });
+});

--- a/website/src/pages/api/admin/questionnaires/assignments/[id]/reassign.ts
+++ b/website/src/pages/api/admin/questionnaires/assignments/[id]/reassign.ts
@@ -1,0 +1,25 @@
+import type { APIRoute } from 'astro';
+import { getSession, isAdmin } from '../../../../../../lib/auth';
+import { reassignQAssignment } from '../../../../../../lib/questionnaire-db';
+
+export const POST: APIRoute = async ({ request, params }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) {
+    return new Response('Unauthorized', { status: 401 });
+  }
+  if (!params.id) {
+    return new Response(JSON.stringify({ error: 'id missing' }), { status: 400 });
+  }
+
+  const result = await reassignQAssignment(params.id);
+  if ('reason' in result) {
+    return new Response(JSON.stringify({ error: 'Nicht gefunden.' }), { status: 404 });
+  }
+  const PROD_DOMAIN = process.env.PROD_DOMAIN || '';
+  const portalUrl = PROD_DOMAIN
+    ? `https://web.${PROD_DOMAIN}/portal/fragebogen/${result.assignment.id}`
+    : `/portal/fragebogen/${result.assignment.id}`;
+  return new Response(JSON.stringify({
+    assignment: result.assignment, portalUrl,
+  }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+};


### PR DESCRIPTION
## Summary
- Archive submitted/reviewed Fragebögen into a frozen `questionnaire_assignment_scores` snapshot, exposed via `bachelorprojekt.v_questionnaire_kpi`
- Reassign creates a new pending assignment for the same template+customer; archived row stays as a permanent datapoint
- Detail page wires the existing `SystemtestReplayDrawer` per `test_step` row that has rrweb evidence
- Active list views split active vs archived: customer panel toggle, project/ticket panel `<details>` block
- Score bars on archived assignments read from snapshot via `getDisplayScores` so KPI numbers don't drift after template edits

## Test plan
- [ ] `cd website && npx vitest run src/lib/questionnaire-archive.test.ts src/pages/api/admin/questionnaires/assignments/`
- [ ] `cd tests/e2e && npx playwright test specs/fa-fragebogen-archive.spec.ts`
- [ ] Manually archive a submitted Fragebogen on dev and verify it disappears from `ClientQuestionnairesPanel` until "Archiv anzeigen" is toggled
- [ ] Manually reassign and verify the portal wizard opens with a fresh assignment id
- [ ] On an archived system-test with evidence, verify "▶ Replay ansehen (Versuch n)" button appears and opens the replay drawer

🤖 Generated with [Claude Code](https://claude.com/claude-code)