### PR TITLE
feat(systemtest): test-bracketed purge — fn_purge_test_data() + Playwright globals

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -270,6 +270,8 @@ tasks:
     preconditions:
       - sh: '[ "{{.ENV}}" = "mentolder" ] || [ "{{.ENV}}" = "korczewski" ]'
         msg: "test:e2e requires ENV=mentolder or ENV=korczewski, got ENV={{.ENV}}"
+      - sh: '[ -n "${CRON_SECRET:-}" ]'
+        msg: "test:e2e requires CRON_SECRET in the env (used by the test-data purge bracket)"
     cmds:
       - |
         case "{{.ENV}}" in
@@ -279,7 +281,31 @@ tasks:
         export WEBSITE_URL PROD_DOMAIN
         [ -d node_modules ] || npm ci
         npx playwright install chromium webkit >/dev/null 2>&1 || true
+        # Defense-in-depth purge: BEFORE Playwright runs, hard-purge all
+        # is_test_data=true rows on the prod website DB. Playwright's
+        # globalSetup also calls this; the curl here covers the case where
+        # Playwright crashes before reaching globalSetup, AND it surfaces
+        # auth/network failures with a clear log line. We hard-fail on a
+        # pre-run purge failure (no `|| true`) — broken cleanup is a real
+        # blocker, we want to know.
+        echo "[test:e2e] Pre-run test-data purge against $WEBSITE_URL"
+        curl -fsS -X POST -H "X-Cron-Secret: ${CRON_SECRET}" \
+          "$WEBSITE_URL/api/admin/systemtest/purge-all-test-data"
+        echo
+        # Capture playwright's exit code so a post-run purge failure can't
+        # mask a real test failure.
+        set +e
         npx playwright test {{.CLI_ARGS}}
+        pw_rc=$?
+        set -e
+        # Post-run purge: best-effort. `|| true` so a transient failure here
+        # (e.g. site momentarily down after the suite) doesn't override the
+        # actual playwright result.
+        echo "[test:e2e] Post-run test-data purge against $WEBSITE_URL"
+        curl -fsS -X POST -H "X-Cron-Secret: ${CRON_SECRET}" \
+          "$WEBSITE_URL/api/admin/systemtest/purge-all-test-data" || true
+        echo
+        exit $pw_rc
 
   test:e2e:all-prods:
     desc: "Run Playwright e2e suite against mentolder + korczewski"

--- a/scripts/one-shot/2026-05-08-flag-systemtest-stragglers.sql
+++ b/scripts/one-shot/2026-05-08-flag-systemtest-stragglers.sql
@@ -1,0 +1,27 @@
+-- 2026-05-08 — Flag systemtest "stragglers" as is_test_data=true.
+--
+-- Symptom: ~13–36 tickets matching '^(System-?Test|Systemtest:|\[TEST\])'
+-- never picked up the is_test_data flag (the failure-bridge bug that left
+-- earlier batches unflagged was already fixed by
+-- 2026-05-08-tickets-dedup-and-group.sql, but a residue of older auto-tickets
+-- was either created before the flag column existed or under conditions
+-- where the source assignment couldn't be looked up).
+--
+-- Idempotent. Wraps in a transaction; RETURNING the affected external_ids
+-- so an operator can paste the result back as evidence.
+--
+-- Run with:
+--   task workspace:psql ENV=mentolder -- website \
+--     < scripts/one-shot/2026-05-08-flag-systemtest-stragglers.sql
+
+\set ON_ERROR_STOP on
+BEGIN;
+
+UPDATE tickets.tickets
+   SET is_test_data = true,
+       updated_at   = now()
+ WHERE is_test_data = false
+   AND title ~* '^(System-?Test|Systemtest:|\[TEST\])'
+RETURNING external_id, type, status, title;
+
+COMMIT;

--- a/scripts/one-shot/2026-05-08-purge-test-data.sql
+++ b/scripts/one-shot/2026-05-08-purge-test-data.sql
@@ -1,0 +1,285 @@
+-- 2026-05-08 — Migration: tickets.fn_purge_test_data() PG function.
+--
+-- One-stop "wipe all test-data scaffolding" routine, intended to be called
+-- from /api/admin/systemtest/purge-all-test-data (the Playwright bracketing
+-- endpoint). Complements website/src/lib/systemtest/cleanup.ts which sweeps
+-- in-flight fixtures with a grace period — this function ignores the grace
+-- and tears down everything tagged is_test_data=true plus orphaned testing
+-- side-tables.
+--
+-- Design rules:
+--   • Idempotent (CREATE OR REPLACE FUNCTION; running twice on a clean DB
+--     returns all-zero counts).
+--   • Defense-in-depth: every DELETE is gated on is_test_data=true wherever
+--     the column exists. Tables without it (questionnaire_*_evidence /
+--     _fixtures / _scores / _answers, systemtest_*) only delete rows that
+--     join back to is_test_data=true through assignment_id.
+--   • Resilience: probes information_schema before touching optional tables
+--     (test_runs, test_results, playwright_reports, billing_invoices,
+--     questionnaire_assignment_scores, questionnaire_answers) so a fresh DB
+--     schema doesn't hard-fail.
+--   • Customer allowlist: deletes customers NOT in the keep-list whose id is
+--     not referenced by any meetings or billing_invoices row. Customers with
+--     real engagement (meetings, invoices) survive even if they look stale —
+--     the existing fixture-row cleanup is the path for those.
+--   • Returns JSONB with per-table delete counts for the API response.
+--
+-- SECURITY DEFINER + EXECUTE TO website so the website runtime (which is the
+-- pool owner anyway) can call it without superuser privileges.
+
+\set ON_ERROR_STOP on
+BEGIN;
+
+CREATE OR REPLACE FUNCTION tickets.fn_purge_test_data()
+  RETURNS JSONB
+  LANGUAGE plpgsql
+  SECURITY DEFINER
+  SET search_path = public, tickets
+AS $$
+DECLARE
+  result            JSONB := '{}'::jsonb;
+  cnt               INT;
+  has_scores        BOOLEAN;
+  has_answers       BOOLEAN;
+  has_test_results  BOOLEAN;
+  has_test_runs     BOOLEAN;
+  has_pw_reports    BOOLEAN;
+  has_billing_inv   BOOLEAN;
+  has_src_assn_col  BOOLEAN;
+  has_meetings      BOOLEAN;
+  has_qts_evidence  BOOLEAN;
+  keep_emails       TEXT[] := ARRAY[
+                       'patrick@korczewski.de',
+                       'p.korczewski@gmail.com',
+                       'quamain@web.de'
+                     ];
+BEGIN
+  -- Probe optional tables / columns. (information_schema returns NULL for
+  -- a missing relation; COALESCE the EXISTS to false.)
+  SELECT EXISTS(SELECT 1 FROM information_schema.tables
+                 WHERE table_schema='public' AND table_name='questionnaire_assignment_scores')
+    INTO has_scores;
+  SELECT EXISTS(SELECT 1 FROM information_schema.tables
+                 WHERE table_schema='public' AND table_name='questionnaire_answers')
+    INTO has_answers;
+  SELECT EXISTS(SELECT 1 FROM information_schema.tables
+                 WHERE table_schema='public' AND table_name='test_results')
+    INTO has_test_results;
+  SELECT EXISTS(SELECT 1 FROM information_schema.tables
+                 WHERE table_schema='public' AND table_name='test_runs')
+    INTO has_test_runs;
+  SELECT EXISTS(SELECT 1 FROM information_schema.tables
+                 WHERE table_schema='public' AND table_name='playwright_reports')
+    INTO has_pw_reports;
+  SELECT EXISTS(SELECT 1 FROM information_schema.tables
+                 WHERE table_schema='public' AND table_name='billing_invoices')
+    INTO has_billing_inv;
+  SELECT EXISTS(SELECT 1 FROM information_schema.tables
+                 WHERE table_schema='public' AND table_name='meetings')
+    INTO has_meetings;
+  SELECT EXISTS(SELECT 1 FROM information_schema.columns
+                 WHERE table_schema='tickets'
+                   AND table_name='tickets'
+                   AND column_name='source_test_assignment_id')
+    INTO has_src_assn_col;
+  SELECT EXISTS(SELECT 1 FROM information_schema.columns
+                 WHERE table_schema='public'
+                   AND table_name='questionnaire_test_status'
+                   AND column_name='evidence_id')
+    INTO has_qts_evidence;
+
+  ----------------------------------------------------------------------------
+  -- 1) Clear FK from questionnaire_test_status to test-data tickets.
+  ----------------------------------------------------------------------------
+  UPDATE questionnaire_test_status
+     SET last_failure_ticket_id = NULL
+   WHERE last_failure_ticket_id IN (
+           SELECT id FROM tickets.tickets WHERE is_test_data = true
+         );
+  GET DIAGNOSTICS cnt = ROW_COUNT;
+  result := result || jsonb_build_object('questionnaire_test_status_cleared', cnt);
+
+  ----------------------------------------------------------------------------
+  -- 2) Null out tickets.source_test_assignment_id refs to test assignments.
+  --    Only do this if the column exists.
+  ----------------------------------------------------------------------------
+  IF has_src_assn_col THEN
+    UPDATE tickets.tickets
+       SET source_test_assignment_id = NULL
+     WHERE source_test_assignment_id IN (
+             SELECT id FROM questionnaire_assignments WHERE is_test_data = true
+           );
+    GET DIAGNOSTICS cnt = ROW_COUNT;
+    result := result || jsonb_build_object('tickets_assignment_ref_cleared', cnt);
+  END IF;
+
+  ----------------------------------------------------------------------------
+  -- 3a) NULL out questionnaire_test_status.evidence_id refs that point at
+  --     evidence rows we're about to delete. Without this, the evidence
+  --     DELETE below trips qts_evidence_id_fk.
+  ----------------------------------------------------------------------------
+  IF has_qts_evidence THEN
+    UPDATE questionnaire_test_status
+       SET evidence_id = NULL
+     WHERE evidence_id IN (
+             SELECT id FROM questionnaire_test_evidence
+              WHERE assignment_id IN (
+                      SELECT id FROM questionnaire_assignments WHERE is_test_data = true
+                    )
+           );
+    GET DIAGNOSTICS cnt = ROW_COUNT;
+    result := result || jsonb_build_object('questionnaire_test_status_evidence_cleared', cnt);
+  END IF;
+
+  ----------------------------------------------------------------------------
+  -- 3b) Delete questionnaire_test_evidence for test-data assignments.
+  ----------------------------------------------------------------------------
+  DELETE FROM questionnaire_test_evidence
+   WHERE assignment_id IN (
+           SELECT id FROM questionnaire_assignments WHERE is_test_data = true
+         );
+  GET DIAGNOSTICS cnt = ROW_COUNT;
+  result := result || jsonb_build_object('questionnaire_test_evidence', cnt);
+
+  ----------------------------------------------------------------------------
+  -- 4) Delete questionnaire_test_fixtures for test-data assignments.
+  ----------------------------------------------------------------------------
+  DELETE FROM questionnaire_test_fixtures
+   WHERE assignment_id IN (
+           SELECT id FROM questionnaire_assignments WHERE is_test_data = true
+         );
+  GET DIAGNOSTICS cnt = ROW_COUNT;
+  result := result || jsonb_build_object('questionnaire_test_fixtures', cnt);
+
+  ----------------------------------------------------------------------------
+  -- 5) Delete questionnaire_assignment_scores (if table present).
+  ----------------------------------------------------------------------------
+  IF has_scores THEN
+    DELETE FROM questionnaire_assignment_scores
+     WHERE assignment_id IN (
+             SELECT id FROM questionnaire_assignments WHERE is_test_data = true
+           );
+    GET DIAGNOSTICS cnt = ROW_COUNT;
+    result := result || jsonb_build_object('questionnaire_assignment_scores', cnt);
+  END IF;
+
+  ----------------------------------------------------------------------------
+  -- 6) Delete questionnaire_answers (if table present).
+  ----------------------------------------------------------------------------
+  IF has_answers THEN
+    DELETE FROM questionnaire_answers
+     WHERE assignment_id IN (
+             SELECT id FROM questionnaire_assignments WHERE is_test_data = true
+           );
+    GET DIAGNOSTICS cnt = ROW_COUNT;
+    result := result || jsonb_build_object('questionnaire_answers', cnt);
+  END IF;
+
+  ----------------------------------------------------------------------------
+  -- 7) Delete the test-data assignments themselves.
+  ----------------------------------------------------------------------------
+  DELETE FROM questionnaire_assignments WHERE is_test_data = true;
+  GET DIAGNOSTICS cnt = ROW_COUNT;
+  result := result || jsonb_build_object('questionnaire_assignments', cnt);
+
+  ----------------------------------------------------------------------------
+  -- 8) Drain transient systemtest plumbing. These are bounded operational
+  --    side-tables (failure outbox + magic-link tokens) created exclusively
+  --    by the test loop. Always-truncate-able.
+  ----------------------------------------------------------------------------
+  DELETE FROM systemtest_failure_outbox;
+  GET DIAGNOSTICS cnt = ROW_COUNT;
+  result := result || jsonb_build_object('systemtest_failure_outbox', cnt);
+
+  DELETE FROM systemtest_magic_tokens;
+  GET DIAGNOSTICS cnt = ROW_COUNT;
+  result := result || jsonb_build_object('systemtest_magic_tokens', cnt);
+
+  ----------------------------------------------------------------------------
+  -- 9) Optional reporting / run-history tables. These hold ONLY test
+  --    artifacts so a full delete is safe; they don't carry is_test_data.
+  ----------------------------------------------------------------------------
+  IF has_pw_reports THEN
+    DELETE FROM playwright_reports;
+    GET DIAGNOSTICS cnt = ROW_COUNT;
+    result := result || jsonb_build_object('playwright_reports', cnt);
+  END IF;
+
+  IF has_test_results THEN
+    DELETE FROM test_results;
+    GET DIAGNOSTICS cnt = ROW_COUNT;
+    result := result || jsonb_build_object('test_results', cnt);
+  END IF;
+  IF has_test_runs THEN
+    DELETE FROM test_runs;
+    GET DIAGNOSTICS cnt = ROW_COUNT;
+    result := result || jsonb_build_object('test_runs', cnt);
+  END IF;
+
+  ----------------------------------------------------------------------------
+  -- 10) Delete child test-data tickets (non-project).
+  ----------------------------------------------------------------------------
+  DELETE FROM tickets.tickets
+   WHERE is_test_data = true
+     AND type <> 'project';
+  GET DIAGNOSTICS cnt = ROW_COUNT;
+  result := result || jsonb_build_object('tickets_children', cnt);
+
+  ----------------------------------------------------------------------------
+  -- 11) Delete project (epic) test-data tickets last.
+  ----------------------------------------------------------------------------
+  DELETE FROM tickets.tickets
+   WHERE is_test_data = true
+     AND type = 'project';
+  GET DIAGNOSTICS cnt = ROW_COUNT;
+  result := result || jsonb_build_object('tickets_projects', cnt);
+
+  ----------------------------------------------------------------------------
+  -- 12) Customer allowlist sweep.
+  --     Delete customers NOT in the keep-list whose id is not referenced
+  --     by any meetings or billing_invoices row. Other FK refs (chat_*,
+  --     brett_snapshots, document_assignments, message_threads, messages,
+  --     tickets.customer_id, questionnaire_assignments) would block the
+  --     delete with a FK violation — we treat any presence in those as
+  --     "engagement" and skip the customer to avoid surprise breakage.
+  ----------------------------------------------------------------------------
+  DELETE FROM customers c
+   WHERE c.email <> ALL (keep_emails)
+     AND NOT EXISTS (
+           SELECT 1 FROM meetings m WHERE m.customer_id = c.id
+         )
+     AND (
+           NOT has_billing_inv
+           OR NOT EXISTS (
+                -- billing_invoices.customer_id is TEXT (not UUID) — cast to align.
+                SELECT 1 FROM billing_invoices bi
+                 WHERE bi.customer_id = c.id::text
+              )
+         )
+     -- Defense: also skip if any other table FK-references this customer.
+     AND NOT EXISTS (SELECT 1 FROM chat_room_members      WHERE customer_id        = c.id)
+     AND NOT EXISTS (SELECT 1 FROM chat_messages          WHERE sender_customer_id = c.id)
+     AND NOT EXISTS (SELECT 1 FROM chat_message_reads     WHERE customer_id        = c.id)
+     AND NOT EXISTS (SELECT 1 FROM chat_rooms             WHERE direct_customer_id = c.id)
+     AND NOT EXISTS (SELECT 1 FROM document_assignments   WHERE customer_id        = c.id)
+     AND NOT EXISTS (SELECT 1 FROM message_threads        WHERE customer_id        = c.id)
+     AND NOT EXISTS (SELECT 1 FROM messages               WHERE sender_customer_id = c.id)
+     AND NOT EXISTS (SELECT 1 FROM brett_snapshots        WHERE customer_id        = c.id)
+     AND NOT EXISTS (SELECT 1 FROM questionnaire_assignments WHERE customer_id     = c.id)
+     AND NOT EXISTS (SELECT 1 FROM tickets.tickets        WHERE customer_id        = c.id);
+  GET DIAGNOSTICS cnt = ROW_COUNT;
+  result := result || jsonb_build_object('customers', cnt);
+
+  RETURN result;
+END;
+$$;
+
+COMMENT ON FUNCTION tickets.fn_purge_test_data() IS
+  'Idempotent test-data purge. Wipes is_test_data=true rows + associated '
+  'side-tables. Customer-safe (allowlist + FK-presence guards). Called '
+  'from /api/admin/systemtest/purge-all-test-data before/after Playwright '
+  'runs. Returns JSONB of per-table delete counts.';
+
+GRANT EXECUTE ON FUNCTION tickets.fn_purge_test_data() TO website;
+
+COMMIT;

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -7,6 +7,13 @@ export default defineConfig({
   timeout: 45_000,
   retries: 1,
   workers: 1,
+  // Test-bracketed prod DB purge. Both hooks POST to
+  // /api/admin/systemtest/purge-all-test-data with X-Cron-Secret. See
+  // ./specs/global-db-cleanup.ts. The Taskfile's `test:e2e` target wraps
+  // `npx playwright test` with curl calls to the same endpoint as
+  // defense-in-depth in case Playwright lifecycle crashes skip these hooks.
+  globalSetup: require.resolve('./specs/global-db-cleanup.ts'),
+  globalTeardown: require.resolve('./specs/global-db-cleanup-teardown.ts'),
   reporter: [
     ['line'],
     ['json', { outputFile: '../results/.tmp-e2e-results.json' }],

--- a/tests/e2e/specs/global-db-cleanup-teardown.ts
+++ b/tests/e2e/specs/global-db-cleanup-teardown.ts
@@ -1,0 +1,11 @@
+// tests/e2e/specs/global-db-cleanup-teardown.ts
+//
+// Tiny shim so Playwright's `globalTeardown` config option can point at a
+// file whose default export IS the teardown function. The actual logic lives
+// in `./global-db-cleanup.ts`'s `teardown` named export — we import + re-
+// expose it as default here to satisfy Playwright's "default export = the
+// hook" contract for globalTeardown.
+
+import { teardown } from './global-db-cleanup';
+
+export default teardown;

--- a/tests/e2e/specs/global-db-cleanup.ts
+++ b/tests/e2e/specs/global-db-cleanup.ts
@@ -1,0 +1,70 @@
+// tests/e2e/specs/global-db-cleanup.ts
+//
+// Playwright globalSetup + globalTeardown that brackets every Playwright run
+// with a hard test-data purge against the prod website DB. Both hooks call
+// POST /api/admin/systemtest/purge-all-test-data with the X-Cron-Secret
+// header that the in-cluster CRON_SECRET also uses.
+//
+// Wired in tests/e2e/playwright.config.ts as:
+//   globalSetup:    require.resolve('./specs/global-db-cleanup.ts')
+//   globalTeardown: require.resolve('./specs/global-db-cleanup.ts')
+//
+// Playwright supports a single file exporting both hooks: the runner calls
+// `default` once at suite start and `teardown` once at suite end.
+//
+// Failure policy: BOTH hooks throw on any non-2xx response. We *want* the
+// run to fail loudly if the purge endpoint is broken — silently skipping
+// would let test-data accumulate undetected, which is exactly the regression
+// this infrastructure exists to prevent.
+//
+// The Taskfile wraps `npx playwright test` with curl calls to the same
+// endpoint as defense-in-depth (in case Playwright crashes before reaching
+// globalTeardown), with `|| true` after the test command so an extra failure
+// doesn't mask a real test failure.
+
+import type { FullConfig } from '@playwright/test';
+
+const PURGE_PATH = '/api/admin/systemtest/purge-all-test-data';
+
+function purgeUrl(): string {
+  // Prefer the dedicated E2E_BASE_URL override, then fall back to WEBSITE_URL
+  // (set by the Taskfile based on ENV=mentolder|korczewski), then prod.
+  const base = process.env.E2E_BASE_URL
+    || process.env.WEBSITE_URL
+    || 'https://web.mentolder.de';
+  return base.replace(/\/+$/, '') + PURGE_PATH;
+}
+
+async function callPurge(label: 'setup' | 'teardown'): Promise<void> {
+  const secret = process.env.CRON_SECRET;
+  if (!secret) {
+    throw new Error(
+      `[global-db-cleanup:${label}] CRON_SECRET not set — cannot bracket Playwright run with prod DB purge`,
+    );
+  }
+  const url = purgeUrl();
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'X-Cron-Secret': secret },
+  });
+  const text = await res.text();
+  if (!res.ok) {
+    throw new Error(
+      `[global-db-cleanup:${label}] POST ${url} → ${res.status}: ${text.slice(0, 500)}`,
+    );
+  }
+  // Best-effort log of the per-table counts. The endpoint returns
+  // { ok: true, counts: {...} } on success.
+  let counts: unknown = null;
+  try { counts = JSON.parse(text); } catch { counts = text; }
+  // eslint-disable-next-line no-console
+  console.log(`[global-db-cleanup:${label}] ${url} ← 200`, counts);
+}
+
+export default async function globalSetup(_config: FullConfig): Promise<void> {
+  await callPurge('setup');
+}
+
+export async function teardown(_config: FullConfig): Promise<void> {
+  await callPurge('teardown');
+}

--- a/website/src/lib/systemtest/purge-all.ts
+++ b/website/src/lib/systemtest/purge-all.ts
@@ -1,0 +1,36 @@
+// website/src/lib/systemtest/purge-all.ts
+//
+// Test-bracketed purge — wipes ALL is_test_data=true rows + side-tables
+// (questionnaire scaffolding, systemtest plumbing, optional test_run history,
+// and a customer allowlist sweep). Designed to run BEFORE and AFTER every
+// Playwright lifecycle on prod via Playwright globalSetup/globalTeardown +
+// Taskfile defense-in-depth curl wrappers.
+//
+// Complementary to `cleanup.ts`'s `purgeFixturesFor`: that one is the hourly
+// "soft" CronJob that respects a grace window for in-flight assignments;
+// this one is the "hard" bracket — every is_test_data=true row, no grace,
+// every run.
+//
+// All heavy lifting lives in PG: `tickets.fn_purge_test_data()` (see
+// scripts/one-shot/2026-05-08-purge-test-data.sql). This module is a thin
+// caller that returns the JSONB counts to the API/Taskfile layer.
+
+import type { Pool } from 'pg';
+
+/** Per-table delete counts returned by tickets.fn_purge_test_data(). Keys
+ *  are dynamic so we type as a record. */
+export type PurgeAllCounts = Record<string, number>;
+
+/**
+ * Invoke `tickets.fn_purge_test_data()` and return the parsed JSONB counts.
+ *
+ * Idempotent — running twice on a clean DB returns all-zero counts. Errors
+ * propagate; callers (the API endpoint and the Playwright globalSetup) want
+ * the failure to surface so a broken purge doesn't silently corrupt a run.
+ */
+export async function purgeAllTestData(pool: Pool): Promise<PurgeAllCounts> {
+  const r = await pool.query<{ fn_purge_test_data: PurgeAllCounts }>(
+    'SELECT tickets.fn_purge_test_data() AS fn_purge_test_data',
+  );
+  return r.rows[0]?.fn_purge_test_data ?? {};
+}

--- a/website/src/pages/api/admin/systemtest/purge-all-test-data.ts
+++ b/website/src/pages/api/admin/systemtest/purge-all-test-data.ts
@@ -1,0 +1,53 @@
+// POST /api/admin/systemtest/purge-all-test-data
+//
+// Test-bracketed purge endpoint. Called by Playwright globalSetup +
+// globalTeardown (and by the Taskfile's `test:e2e` wrapper as defense-
+// in-depth) to fully wipe is_test_data=true rows + their associated side
+// tables. Complementary to /cleanup-fixtures (which respects a grace window
+// for in-flight assignments) — this one ignores the grace.
+//
+// Auth: identical to /cleanup-fixtures — either an X-Cron-Secret header
+// matching CRON_SECRET, or an admin-authenticated browser session. 405 on
+// non-POST so casual GETs from the browser return cleanly.
+
+import type { APIRoute } from 'astro';
+
+import { pool } from '../../../../lib/website-db';
+import { getSession, isAdmin } from '../../../../lib/auth';
+import { purgeAllTestData } from '../../../../lib/systemtest/purge-all';
+
+export const POST: APIRoute = async ({ request }) => {
+  const cronSecret = request.headers.get('X-Cron-Secret');
+  const session = await getSession(request.headers.get('cookie'));
+  const isCron = !!cronSecret && cronSecret === process.env.CRON_SECRET;
+  if (!isCron && (!session || !isAdmin(session))) {
+    return new Response('Forbidden', { status: 403 });
+  }
+
+  try {
+    const counts = await purgeAllTestData(pool);
+    return new Response(
+      JSON.stringify({ ok: true, counts }),
+      { headers: { 'Content-Type': 'application/json' } },
+    );
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    console.error('[systemtest/purge-all-test-data] failed:', msg);
+    return new Response(JSON.stringify({ ok: false, error: msg }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+};
+
+export const ALL: APIRoute = async ({ request }) => {
+  if (request.method !== 'POST') {
+    return new Response('Method Not Allowed', {
+      status: 405,
+      headers: { Allow: 'POST' },
+    });
+  }
+  // Should not be reachable — POST is handled above. Defensive 405 for any
+  // other verb (HEAD, OPTIONS, etc.) so we never accidentally serve content.
+  return new Response('Method Not Allowed', { status: 405 });
+};


### PR DESCRIPTION
## Summary

Brackets every Playwright run on prod with a hard purge of `is_test_data=true` rows + side-tables, and a customer allowlist sweep. Complements the existing hourly fixture-cleanup CronJob (`cleanup-fixtures`) which respects a grace window — this one ignores the grace, every run.

- New PG function `tickets.fn_purge_test_data()` (idempotent, JSONB counts) — applied to mentolder prod via `task workspace:psql`.
- New API `POST /api/admin/systemtest/purge-all-test-data` (X-Cron-Secret OR admin session).
- Playwright `globalSetup` + `globalTeardown` POST to that endpoint and throw loudly on failure.
- Taskfile `test:e2e` wraps `npx playwright test` with curl bracket calls as defense-in-depth in case Playwright lifecycle crashes skip the global hooks.
- One-shot SQL flagged 13 unflagged "Systemtest:"-style stragglers (`T000067-T000072`, `T000161-T000163`, `T000170-T000175`); first purge wiped 64 child + 12 project test-data tickets, 47 test assignments, 12 evidence rows, 4 test_runs, 1 playwright_report.

## Test plan
- [x] `tickets.fn_purge_test_data()` returns all-zero counts on second invocation (idempotency)
- [x] After first run: `SELECT count(*) FROM tickets.tickets WHERE is_test_data=true` → 0
- [x] Customers retained: `patrick@korczewski.de`, `p.korczewski@gmail.com`, `quamain@web.de`, plus 2 stale customers preserved due to FK refs in `meetings` (intended behavior)
- [ ] After deploy: `curl -X POST https://web.mentolder.de/api/admin/systemtest/purge-all-test-data -H "X-Cron-Secret: $CRON_SECRET"` → 200 with counts JSONB
- [ ] Second curl returns all-zero counts
- [ ] Next `task test:e2e ENV=mentolder` run shows pre+post curl bracket lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)