### PR TITLE
feat(systemtest): inbox/messages test-data flag + Löschen escape hatch

### DIFF
--- a/k3d/website-schema.yaml
+++ b/k3d/website-schema.yaml
@@ -173,7 +173,10 @@ data:
         actioned_at     TIMESTAMPTZ,
         actioned_by     TEXT
       );
+      ALTER TABLE inbox_items ADD COLUMN IF NOT EXISTS is_test_data BOOLEAN NOT NULL DEFAULT false;
       CREATE INDEX IF NOT EXISTS idx_inbox_items_status ON inbox_items(status, created_at DESC);
+      CREATE INDEX IF NOT EXISTS idx_inbox_items_is_test_data
+        ON inbox_items (is_test_data) WHERE is_test_data = true;
 
       CREATE TABLE IF NOT EXISTS message_threads (
         id              SERIAL PRIMARY KEY,
@@ -182,6 +185,9 @@ data:
         created_at      TIMESTAMPTZ DEFAULT now(),
         last_message_at TIMESTAMPTZ DEFAULT now()
       );
+      ALTER TABLE message_threads ADD COLUMN IF NOT EXISTS is_test_data BOOLEAN NOT NULL DEFAULT false;
+      CREATE INDEX IF NOT EXISTS idx_message_threads_is_test_data
+        ON message_threads (is_test_data) WHERE is_test_data = true;
 
       CREATE TABLE IF NOT EXISTS messages (
         id                   SERIAL PRIMARY KEY,
@@ -195,7 +201,10 @@ data:
         notification_sent_at TIMESTAMPTZ,
         CHECK (sender_role = 'admin' OR sender_customer_id IS NOT NULL)
       );
+      ALTER TABLE messages ADD COLUMN IF NOT EXISTS is_test_data BOOLEAN NOT NULL DEFAULT false;
       CREATE INDEX IF NOT EXISTS idx_messages_thread ON messages(thread_id, id ASC);
+      CREATE INDEX IF NOT EXISTS idx_messages_is_test_data
+        ON messages (is_test_data) WHERE is_test_data = true;
 
       CREATE TABLE IF NOT EXISTS chat_rooms (
         id                  SERIAL PRIMARY KEY,
@@ -554,7 +563,10 @@ data:
         actioned_at     TIMESTAMPTZ,
         actioned_by     TEXT
       );
+      ALTER TABLE inbox_items ADD COLUMN IF NOT EXISTS is_test_data BOOLEAN NOT NULL DEFAULT false;
       CREATE INDEX IF NOT EXISTS idx_inbox_items_status ON inbox_items(status, created_at DESC);
+      CREATE INDEX IF NOT EXISTS idx_inbox_items_is_test_data
+        ON inbox_items (is_test_data) WHERE is_test_data = true;
 
       CREATE TABLE IF NOT EXISTS message_threads (
         id              SERIAL PRIMARY KEY,
@@ -563,6 +575,9 @@ data:
         created_at      TIMESTAMPTZ DEFAULT now(),
         last_message_at TIMESTAMPTZ DEFAULT now()
       );
+      ALTER TABLE message_threads ADD COLUMN IF NOT EXISTS is_test_data BOOLEAN NOT NULL DEFAULT false;
+      CREATE INDEX IF NOT EXISTS idx_message_threads_is_test_data
+        ON message_threads (is_test_data) WHERE is_test_data = true;
 
       CREATE TABLE IF NOT EXISTS messages (
         id                   SERIAL PRIMARY KEY,
@@ -576,7 +591,10 @@ data:
         notification_sent_at TIMESTAMPTZ,
         CHECK (sender_role = 'admin' OR sender_customer_id IS NOT NULL)
       );
+      ALTER TABLE messages ADD COLUMN IF NOT EXISTS is_test_data BOOLEAN NOT NULL DEFAULT false;
       CREATE INDEX IF NOT EXISTS idx_messages_thread ON messages(thread_id, id ASC);
+      CREATE INDEX IF NOT EXISTS idx_messages_is_test_data
+        ON messages (is_test_data) WHERE is_test_data = true;
 
       CREATE TABLE IF NOT EXISTS chat_rooms (
         id                  SERIAL PRIMARY KEY,

--- a/scripts/one-shot/2026-05-09-inbox-test-data-flag.sql
+++ b/scripts/one-shot/2026-05-09-inbox-test-data-flag.sql
@@ -1,0 +1,44 @@
+-- 2026-05-09 — Add is_test_data flag to messaging tables.
+--
+-- Closes the "purge ignores inbox" gap left by 2026-05-08-purge-test-data.sql:
+-- inbox_items / messages / message_threads had no is_test_data column, so
+-- tickets.fn_purge_test_data() couldn't reach them and stale [TEST]-bracketed
+-- contact-form/booking submissions accumulated across Playwright runs.
+--
+-- Idempotent: ADD COLUMN IF NOT EXISTS + CREATE INDEX IF NOT EXISTS so a
+-- re-run on a cluster that already has the column is a no-op (PG raises a
+-- NOTICE for existing-column adds, no DDL fires for existing indexes).
+--
+-- Index strategy: small partial indexes WHERE is_test_data = true. Total
+-- expected rows under that predicate are bounded (one Playwright cycle's
+-- worth, dropped at the next bracket), so a partial index is the cheapest
+-- way to make `DELETE FROM <t> WHERE is_test_data = true` an index scan.
+
+\set ON_ERROR_STOP on
+BEGIN;
+
+-- ── inbox_items ─────────────────────────────────────────────────────────────
+ALTER TABLE inbox_items
+  ADD COLUMN IF NOT EXISTS is_test_data BOOLEAN NOT NULL DEFAULT false;
+
+CREATE INDEX IF NOT EXISTS idx_inbox_items_is_test_data
+  ON inbox_items (is_test_data)
+  WHERE is_test_data = true;
+
+-- ── message_threads ─────────────────────────────────────────────────────────
+ALTER TABLE message_threads
+  ADD COLUMN IF NOT EXISTS is_test_data BOOLEAN NOT NULL DEFAULT false;
+
+CREATE INDEX IF NOT EXISTS idx_message_threads_is_test_data
+  ON message_threads (is_test_data)
+  WHERE is_test_data = true;
+
+-- ── messages ────────────────────────────────────────────────────────────────
+ALTER TABLE messages
+  ADD COLUMN IF NOT EXISTS is_test_data BOOLEAN NOT NULL DEFAULT false;
+
+CREATE INDEX IF NOT EXISTS idx_messages_is_test_data
+  ON messages (is_test_data)
+  WHERE is_test_data = true;
+
+COMMIT;

--- a/scripts/one-shot/2026-05-09-purge-fn-v2.sql
+++ b/scripts/one-shot/2026-05-09-purge-fn-v2.sql
@@ -1,0 +1,306 @@
+-- 2026-05-09 — Migration: tickets.fn_purge_test_data() v2.
+--
+-- Adds inbox/message sweeps right before the customers allowlist sweep. The
+-- new DELETE blocks gate on `is_test_data = true` (column added in
+-- 2026-05-09-inbox-test-data-flag.sql) and feed counts back into the JSONB
+-- response, so the bracketing endpoint can confirm rows were actually
+-- removed.
+--
+-- Defensive style identical to v1: probes information_schema for the new
+-- column before touching each table so a deploy that runs the function
+-- before the column-add migration applies still returns cleanly (with
+-- the new keys absent from the count map rather than aborting).
+--
+-- Ordering note: the customers sweep already runs LAST and re-checks every
+-- FK-bearing table (including message_threads, messages). By draining the
+-- test-data rows BEFORE the customers sweep we widen the set of stale
+-- customers that become removable in the same call — chronologically
+-- equivalent to the existing questionnaire_assignments → customers chain.
+
+\set ON_ERROR_STOP on
+BEGIN;
+
+CREATE OR REPLACE FUNCTION tickets.fn_purge_test_data()
+  RETURNS JSONB
+  LANGUAGE plpgsql
+  SECURITY DEFINER
+  SET search_path = public, tickets
+AS $$
+DECLARE
+  result            JSONB := '{}'::jsonb;
+  cnt               INT;
+  has_scores        BOOLEAN;
+  has_answers       BOOLEAN;
+  has_test_results  BOOLEAN;
+  has_test_runs     BOOLEAN;
+  has_pw_reports    BOOLEAN;
+  has_billing_inv   BOOLEAN;
+  has_src_assn_col  BOOLEAN;
+  has_meetings      BOOLEAN;
+  has_qts_evidence  BOOLEAN;
+  has_inbox_flag    BOOLEAN;
+  has_thread_flag   BOOLEAN;
+  has_messages_flag BOOLEAN;
+  keep_emails       TEXT[] := ARRAY[
+                       'patrick@korczewski.de',
+                       'p.korczewski@gmail.com',
+                       'quamain@web.de'
+                     ];
+BEGIN
+  -- Probe optional tables / columns.
+  SELECT EXISTS(SELECT 1 FROM information_schema.tables
+                 WHERE table_schema='public' AND table_name='questionnaire_assignment_scores')
+    INTO has_scores;
+  SELECT EXISTS(SELECT 1 FROM information_schema.tables
+                 WHERE table_schema='public' AND table_name='questionnaire_answers')
+    INTO has_answers;
+  SELECT EXISTS(SELECT 1 FROM information_schema.tables
+                 WHERE table_schema='public' AND table_name='test_results')
+    INTO has_test_results;
+  SELECT EXISTS(SELECT 1 FROM information_schema.tables
+                 WHERE table_schema='public' AND table_name='test_runs')
+    INTO has_test_runs;
+  SELECT EXISTS(SELECT 1 FROM information_schema.tables
+                 WHERE table_schema='public' AND table_name='playwright_reports')
+    INTO has_pw_reports;
+  SELECT EXISTS(SELECT 1 FROM information_schema.tables
+                 WHERE table_schema='public' AND table_name='billing_invoices')
+    INTO has_billing_inv;
+  SELECT EXISTS(SELECT 1 FROM information_schema.tables
+                 WHERE table_schema='public' AND table_name='meetings')
+    INTO has_meetings;
+  SELECT EXISTS(SELECT 1 FROM information_schema.columns
+                 WHERE table_schema='tickets'
+                   AND table_name='tickets'
+                   AND column_name='source_test_assignment_id')
+    INTO has_src_assn_col;
+  SELECT EXISTS(SELECT 1 FROM information_schema.columns
+                 WHERE table_schema='public'
+                   AND table_name='questionnaire_test_status'
+                   AND column_name='evidence_id')
+    INTO has_qts_evidence;
+  SELECT EXISTS(SELECT 1 FROM information_schema.columns
+                 WHERE table_schema='public'
+                   AND table_name='inbox_items'
+                   AND column_name='is_test_data')
+    INTO has_inbox_flag;
+  SELECT EXISTS(SELECT 1 FROM information_schema.columns
+                 WHERE table_schema='public'
+                   AND table_name='message_threads'
+                   AND column_name='is_test_data')
+    INTO has_thread_flag;
+  SELECT EXISTS(SELECT 1 FROM information_schema.columns
+                 WHERE table_schema='public'
+                   AND table_name='messages'
+                   AND column_name='is_test_data')
+    INTO has_messages_flag;
+
+  ----------------------------------------------------------------------------
+  -- 1) Clear FK from questionnaire_test_status to test-data tickets.
+  ----------------------------------------------------------------------------
+  UPDATE questionnaire_test_status
+     SET last_failure_ticket_id = NULL
+   WHERE last_failure_ticket_id IN (
+           SELECT id FROM tickets.tickets WHERE is_test_data = true
+         );
+  GET DIAGNOSTICS cnt = ROW_COUNT;
+  result := result || jsonb_build_object('questionnaire_test_status_cleared', cnt);
+
+  ----------------------------------------------------------------------------
+  -- 2) Null out tickets.source_test_assignment_id refs to test assignments.
+  ----------------------------------------------------------------------------
+  IF has_src_assn_col THEN
+    UPDATE tickets.tickets
+       SET source_test_assignment_id = NULL
+     WHERE source_test_assignment_id IN (
+             SELECT id FROM questionnaire_assignments WHERE is_test_data = true
+           );
+    GET DIAGNOSTICS cnt = ROW_COUNT;
+    result := result || jsonb_build_object('tickets_assignment_ref_cleared', cnt);
+  END IF;
+
+  ----------------------------------------------------------------------------
+  -- 3a) NULL out questionnaire_test_status.evidence_id refs we're about to
+  --     delete.
+  ----------------------------------------------------------------------------
+  IF has_qts_evidence THEN
+    UPDATE questionnaire_test_status
+       SET evidence_id = NULL
+     WHERE evidence_id IN (
+             SELECT id FROM questionnaire_test_evidence
+              WHERE assignment_id IN (
+                      SELECT id FROM questionnaire_assignments WHERE is_test_data = true
+                    )
+           );
+    GET DIAGNOSTICS cnt = ROW_COUNT;
+    result := result || jsonb_build_object('questionnaire_test_status_evidence_cleared', cnt);
+  END IF;
+
+  ----------------------------------------------------------------------------
+  -- 3b) Delete questionnaire_test_evidence for test-data assignments.
+  ----------------------------------------------------------------------------
+  DELETE FROM questionnaire_test_evidence
+   WHERE assignment_id IN (
+           SELECT id FROM questionnaire_assignments WHERE is_test_data = true
+         );
+  GET DIAGNOSTICS cnt = ROW_COUNT;
+  result := result || jsonb_build_object('questionnaire_test_evidence', cnt);
+
+  ----------------------------------------------------------------------------
+  -- 4) Delete questionnaire_test_fixtures for test-data assignments.
+  ----------------------------------------------------------------------------
+  DELETE FROM questionnaire_test_fixtures
+   WHERE assignment_id IN (
+           SELECT id FROM questionnaire_assignments WHERE is_test_data = true
+         );
+  GET DIAGNOSTICS cnt = ROW_COUNT;
+  result := result || jsonb_build_object('questionnaire_test_fixtures', cnt);
+
+  ----------------------------------------------------------------------------
+  -- 5) Delete questionnaire_assignment_scores (if table present).
+  ----------------------------------------------------------------------------
+  IF has_scores THEN
+    DELETE FROM questionnaire_assignment_scores
+     WHERE assignment_id IN (
+             SELECT id FROM questionnaire_assignments WHERE is_test_data = true
+           );
+    GET DIAGNOSTICS cnt = ROW_COUNT;
+    result := result || jsonb_build_object('questionnaire_assignment_scores', cnt);
+  END IF;
+
+  ----------------------------------------------------------------------------
+  -- 6) Delete questionnaire_answers (if table present).
+  ----------------------------------------------------------------------------
+  IF has_answers THEN
+    DELETE FROM questionnaire_answers
+     WHERE assignment_id IN (
+             SELECT id FROM questionnaire_assignments WHERE is_test_data = true
+           );
+    GET DIAGNOSTICS cnt = ROW_COUNT;
+    result := result || jsonb_build_object('questionnaire_answers', cnt);
+  END IF;
+
+  ----------------------------------------------------------------------------
+  -- 7) Delete the test-data assignments themselves.
+  ----------------------------------------------------------------------------
+  DELETE FROM questionnaire_assignments WHERE is_test_data = true;
+  GET DIAGNOSTICS cnt = ROW_COUNT;
+  result := result || jsonb_build_object('questionnaire_assignments', cnt);
+
+  ----------------------------------------------------------------------------
+  -- 8) Drain transient systemtest plumbing.
+  ----------------------------------------------------------------------------
+  DELETE FROM systemtest_failure_outbox;
+  GET DIAGNOSTICS cnt = ROW_COUNT;
+  result := result || jsonb_build_object('systemtest_failure_outbox', cnt);
+
+  DELETE FROM systemtest_magic_tokens;
+  GET DIAGNOSTICS cnt = ROW_COUNT;
+  result := result || jsonb_build_object('systemtest_magic_tokens', cnt);
+
+  ----------------------------------------------------------------------------
+  -- 9) Optional reporting / run-history tables.
+  ----------------------------------------------------------------------------
+  IF has_pw_reports THEN
+    DELETE FROM playwright_reports;
+    GET DIAGNOSTICS cnt = ROW_COUNT;
+    result := result || jsonb_build_object('playwright_reports', cnt);
+  END IF;
+
+  IF has_test_results THEN
+    DELETE FROM test_results;
+    GET DIAGNOSTICS cnt = ROW_COUNT;
+    result := result || jsonb_build_object('test_results', cnt);
+  END IF;
+  IF has_test_runs THEN
+    DELETE FROM test_runs;
+    GET DIAGNOSTICS cnt = ROW_COUNT;
+    result := result || jsonb_build_object('test_runs', cnt);
+  END IF;
+
+  ----------------------------------------------------------------------------
+  -- 10) Delete child test-data tickets (non-project).
+  ----------------------------------------------------------------------------
+  DELETE FROM tickets.tickets
+   WHERE is_test_data = true
+     AND type <> 'project';
+  GET DIAGNOSTICS cnt = ROW_COUNT;
+  result := result || jsonb_build_object('tickets_children', cnt);
+
+  ----------------------------------------------------------------------------
+  -- 11) Delete project (epic) test-data tickets last.
+  ----------------------------------------------------------------------------
+  DELETE FROM tickets.tickets
+   WHERE is_test_data = true
+     AND type = 'project';
+  GET DIAGNOSTICS cnt = ROW_COUNT;
+  result := result || jsonb_build_object('tickets_projects', cnt);
+
+  ----------------------------------------------------------------------------
+  -- 11b) ── Messaging sweeps (NEW in v2). ───────────────────────────────────
+  --     Order: messages → message_threads → inbox_items.
+  --
+  --     `messages.thread_id` is NOT NULL, so any test-data thread would have
+  --     orphan-FK rows if we deleted threads first. inbox_items has no FK
+  --     to either, so order between (messages|threads) and inbox_items is
+  --     free — keep it last so future cross-table FKs from inbox to threads
+  --     stay satisfied.
+  ----------------------------------------------------------------------------
+  IF has_messages_flag THEN
+    DELETE FROM messages WHERE is_test_data = true;
+    GET DIAGNOSTICS cnt = ROW_COUNT;
+    result := result || jsonb_build_object('messages', cnt);
+  END IF;
+
+  IF has_thread_flag THEN
+    DELETE FROM message_threads WHERE is_test_data = true;
+    GET DIAGNOSTICS cnt = ROW_COUNT;
+    result := result || jsonb_build_object('message_threads', cnt);
+  END IF;
+
+  IF has_inbox_flag THEN
+    DELETE FROM inbox_items WHERE is_test_data = true;
+    GET DIAGNOSTICS cnt = ROW_COUNT;
+    result := result || jsonb_build_object('inbox_items', cnt);
+  END IF;
+
+  ----------------------------------------------------------------------------
+  -- 12) Customer allowlist sweep.
+  ----------------------------------------------------------------------------
+  DELETE FROM customers c
+   WHERE c.email <> ALL (keep_emails)
+     AND NOT EXISTS (
+           SELECT 1 FROM meetings m WHERE m.customer_id = c.id
+         )
+     AND (
+           NOT has_billing_inv
+           OR NOT EXISTS (
+                SELECT 1 FROM billing_invoices bi
+                 WHERE bi.customer_id = c.id::text
+              )
+         )
+     AND NOT EXISTS (SELECT 1 FROM chat_room_members      WHERE customer_id        = c.id)
+     AND NOT EXISTS (SELECT 1 FROM chat_messages          WHERE sender_customer_id = c.id)
+     AND NOT EXISTS (SELECT 1 FROM chat_message_reads     WHERE customer_id        = c.id)
+     AND NOT EXISTS (SELECT 1 FROM chat_rooms             WHERE direct_customer_id = c.id)
+     AND NOT EXISTS (SELECT 1 FROM document_assignments   WHERE customer_id        = c.id)
+     AND NOT EXISTS (SELECT 1 FROM message_threads        WHERE customer_id        = c.id)
+     AND NOT EXISTS (SELECT 1 FROM messages               WHERE sender_customer_id = c.id)
+     AND NOT EXISTS (SELECT 1 FROM brett_snapshots        WHERE customer_id        = c.id)
+     AND NOT EXISTS (SELECT 1 FROM questionnaire_assignments WHERE customer_id     = c.id)
+     AND NOT EXISTS (SELECT 1 FROM tickets.tickets        WHERE customer_id        = c.id);
+  GET DIAGNOSTICS cnt = ROW_COUNT;
+  result := result || jsonb_build_object('customers', cnt);
+
+  RETURN result;
+END;
+$$;
+
+COMMENT ON FUNCTION tickets.fn_purge_test_data() IS
+  'Idempotent test-data purge. v2 (2026-05-09) extends v1 by sweeping '
+  'inbox_items/message_threads/messages WHERE is_test_data=true before the '
+  'customers allowlist sweep. Returns JSONB of per-table delete counts.';
+
+GRANT EXECUTE ON FUNCTION tickets.fn_purge_test_data() TO website;
+
+COMMIT;

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -64,6 +64,7 @@ export default defineConfig({
         '**/fa-bugs-notifications.spec.ts',     // bug-report → admin resolve → reporter email (FA-bug-notify)
         '**/fa-admin-tickets.spec.ts',          // unified admin /admin/tickets index + detail (PR4/5)
         '**/fa-admin-inbox.spec.ts',            // /admin/inbox two-pane rework (spec 2026-05-08)
+        '**/fa-admin-inbox-delete.spec.ts',     // Löschen escape hatch (2026-05-09)
         '**/fa-admin-live.spec.ts',  // unified live cockpit
         '**/fa-30-systemtest-failure-loop.spec.ts',  // system-test failure kanban (Task 7)
       ],

--- a/tests/e2e/specs/fa-admin-inbox-delete.spec.ts
+++ b/tests/e2e/specs/fa-admin-inbox-delete.spec.ts
@@ -1,0 +1,170 @@
+// tests/e2e/specs/fa-admin-inbox-delete.spec.ts
+//
+// FA-admin-inbox-delete — covers the "Löschen" escape hatch added 2026-05-09
+// to /admin/inbox. The hatch lets admins clear inbox rows regardless of
+// status (pending/actioned/archived) — previously rows that left `pending`
+// had no remediation, which left paddione with 27 stuck rows.
+//
+// Flow:
+//   1. Seed a contact-form row with `is_test_data=true` via POST /api/contact
+//      using the X-E2E-Test + X-Cron-Secret header pair (option-A from the
+//      design discussion). This avoids the "every email containing the word
+//      test gets reaped" false-positive risk of pattern-matching.
+//   2. Log in as admin, open /admin/inbox.
+//   3. Locate the seeded row, select it, dismiss the window.confirm() that
+//      `deleteItem` raises, click the Löschen button, accept the confirm,
+//      and assert the row vanishes from the list.
+//   4. Verify the underlying inbox row is gone via GET /api/admin/inbox
+//      (defense in depth — the visual disappearance is necessary but not
+//      sufficient).
+//
+// Cleanup is automatic: globalSetup/globalTeardown both POST
+// /api/admin/systemtest/purge-all-test-data, which (after PR #608) sweeps
+// inbox_items WHERE is_test_data=true. Even if this spec aborts mid-flight,
+// the next run's globalSetup wipes the seeded row.
+
+import { test, expect, type Page, type APIRequestContext } from '@playwright/test';
+
+const BASE        = process.env.WEBSITE_URL ?? 'http://localhost:4321';
+const ADMIN_USER  = process.env.E2E_ADMIN_USER ?? 'patrick';
+const ADMIN_PASS  = process.env.E2E_ADMIN_PASS;
+const CRON_SECRET = process.env.CRON_SECRET;
+
+async function loginAsAdmin(page: Page, returnTo = '/admin/inbox'): Promise<void> {
+  await page.goto(`${BASE}/api/auth/login?returnTo=${encodeURIComponent(returnTo)}`);
+  await page.waitForURL(/realms\/workspace/, { timeout: 20_000 });
+  await page.locator('#username, input[name="username"]').first().fill(ADMIN_USER);
+  await page.locator('#password, input[name="password"]').first().fill(ADMIN_PASS!);
+  await page.locator('#kc-login, input[type="submit"]').first().click();
+  await page.waitForURL(/\/admin\/inbox/, { timeout: 20_000 });
+}
+
+/**
+ * Seed a `contact` inbox row tagged as test-data via the public API. The
+ * X-E2E-Test + X-Cron-Secret header pair tells the endpoint to stamp
+ * `is_test_data=true`, which has two effects:
+ *   1. The purge function reaps it on the next bracket (defense in depth).
+ *   2. We can identify it later via the unique seed name without a payload
+ *      ID round-trip (since /api/contact returns 200 with no body).
+ *
+ * Returns the unique seed name we used so the test can locate the row.
+ */
+async function seedTestContactRow(api: APIRequestContext): Promise<string> {
+  const seedName = `[TEST] inbox-delete ${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+  const res = await api.post(`${BASE}/api/contact`, {
+    headers: {
+      'Content-Type': 'application/json',
+      'X-E2E-Test': '1',
+      'X-Cron-Secret': CRON_SECRET!,
+    },
+    data: {
+      name: seedName,
+      email: 'fa-admin-inbox-delete@example.invalid',
+      type: 'allgemein',
+      message: 'systemtest seed for fa-admin-inbox-delete; safe to purge',
+    },
+  });
+  expect(res.status()).toBe(200);
+  return seedName;
+}
+
+test.describe('FA-admin-inbox-delete: Löschen escape hatch', () => {
+  test.beforeEach(({ }, testInfo) => {
+    if (!ADMIN_PASS) {
+      testInfo.skip(true, 'E2E_ADMIN_PASS not set — skipping admin inbox delete spec');
+    }
+    if (!CRON_SECRET) {
+      testInfo.skip(true, 'CRON_SECRET not set — cannot seed test rows');
+    }
+  });
+
+  test('löschen-button: seeded row appears, can be deleted, vanishes', async ({ page, request }) => {
+    // 1. Seed a fresh row tagged is_test_data=true.
+    const seedName = await seedTestContactRow(request);
+
+    // 2. Log in and load the inbox.
+    await loginAsAdmin(page);
+    const root = page.locator('[data-testid="inbox-app"]');
+    await expect(root).toBeVisible({ timeout: 10_000 });
+
+    // 3. Filter to `contact` so we can locate the seeded row by its
+    //    unique name in the list. The seed name appears in the row's
+    //    payload, which renders into the row's text content.
+    await root
+      .locator('[data-testid="inbox-sidebar-item"][data-type="contact"]')
+      .click();
+    await page.waitForTimeout(200);
+
+    const list = root.locator('[data-testid="inbox-list"]');
+    const seededRow = list.locator(`[data-testid="inbox-list-row"]`, {
+      hasText: seedName,
+    }).first();
+
+    await expect(seededRow).toBeVisible({ timeout: 10_000 });
+
+    // 4. Select the row → detail pane shows it.
+    await seededRow.click();
+    const detail = root.locator('[data-testid="inbox-detail"][data-type="contact"]');
+    await expect(detail).toBeVisible({ timeout: 5_000 });
+
+    // 5. The Löschen button must be present on every row regardless of status.
+    const deleteBtn = detail.locator('[data-testid="inbox-action-delete"]');
+    await expect(deleteBtn).toBeVisible();
+    await expect(deleteBtn).toBeEnabled();
+
+    // 6. Auto-accept the window.confirm() that deleteItem() raises.
+    page.once('dialog', (d) => { void d.accept(); });
+
+    // 7. Click → row vanishes from the list. Track the row count by name
+    //    so we don't false-positive on other unrelated contact rows.
+    const beforeCount = await list
+      .locator('[data-testid="inbox-list-row"]', { hasText: seedName })
+      .count();
+    expect(beforeCount).toBeGreaterThanOrEqual(1);
+
+    await deleteBtn.click();
+    await expect(
+      list.locator('[data-testid="inbox-list-row"]', { hasText: seedName }),
+    ).toHaveCount(0, { timeout: 5_000 });
+
+    // 8. Defense in depth: verify the row is gone server-side too. The
+    //    admin inbox endpoint requires a session — reuse the page's cookies.
+    const cookies = await page.context().cookies();
+    const cookieHeader = cookies.map((c) => `${c.name}=${c.value}`).join('; ');
+    const res = await request.get(`${BASE}/api/admin/inbox?status=pending`, {
+      headers: { cookie: cookieHeader },
+    });
+    expect(res.ok()).toBeTruthy();
+    const data = await res.json() as {
+      items: Array<{ payload: Record<string, unknown> }>;
+    };
+    const stillPresent = data.items.some(
+      (it) => typeof it.payload?.name === 'string' && it.payload.name === seedName,
+    );
+    expect(stillPresent).toBe(false);
+  });
+
+  test('löschen-button: present on archived rows too (escape hatch contract)', async ({ page }) => {
+    // The hatch's whole point is that it works on rows that already left
+    // `pending`. We can't reliably guarantee the live archive has rows on
+    // every cluster — when it doesn't, we skip rather than failing.
+    await loginAsAdmin(page, '/admin/inbox?status=archived');
+    const root = page.locator('[data-testid="inbox-app"]');
+    await expect(root).toBeVisible({ timeout: 10_000 });
+
+    const list = root.locator('[data-testid="inbox-list"]');
+    const firstRow = list.locator('[data-testid="inbox-list-row"]').first();
+    const hasRow = (await firstRow.count()) > 0;
+    test.skip(!hasRow, 'archive is empty on this cluster — escape hatch contract is unobservable');
+
+    await firstRow.click();
+    const detail = root.locator('[data-testid="inbox-detail"]');
+    await expect(detail).toBeVisible({ timeout: 5_000 });
+
+    // The delete button MUST be visible AND enabled on archived rows —
+    // that's the contract this whole feature exists for.
+    const deleteBtn = detail.locator('[data-testid="inbox-action-delete"]');
+    await expect(deleteBtn).toBeVisible();
+    await expect(deleteBtn).toBeEnabled();
+  });
+});

--- a/website/src/components/inbox/InboxApp.svelte
+++ b/website/src/components/inbox/InboxApp.svelte
@@ -238,9 +238,12 @@
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ action, note }),
       });
-      const data = await res.json().catch(() => ({})) as { error?: string };
+      // 204 No Content (used by `delete`) returns no JSON body — guard the parse.
+      const data = res.status === 204
+        ? {}
+        : (await res.json().catch(() => ({}))) as { error?: string };
       if (!res.ok) {
-        actionError = data.error ?? `Fehler (${res.status})`;
+        actionError = (data as { error?: string }).error ?? `Fehler (${res.status})`;
         return false;
       }
       // remove the actioned item, advance selection, decrement count
@@ -310,6 +313,21 @@
     if (!it || busy) return;
     if (it.type === 'registration') await postAction(it, 'decline_registration');
     else if (it.type === 'booking') await postAction(it, 'decline_booking');
+  }
+
+  // Hard-delete escape hatch. Visible on EVERY row regardless of status
+  // (pending/actioned/archived) so admins can clear rows that have no
+  // other path off the queue — e.g. an `archived` contact, an `actioned`
+  // booking that was already cleaned up, or a stale [TEST] item from a
+  // pre-purge regression. Confirms via window.confirm() before firing.
+  async function deleteItem(): Promise<void> {
+    const it = selected;
+    if (!it || busy) return;
+    if (typeof window !== 'undefined' && typeof window.confirm === 'function') {
+      const ok = window.confirm('Diesen Eintrag dauerhaft löschen? Die Aktion kann nicht rückgängig gemacht werden.');
+      if (!ok) return;
+    }
+    await postAction(it, 'delete');
   }
 
   async function sendReply(): Promise<void> {
@@ -436,6 +454,7 @@
         onNext={() => moveSelection(+1)}
         onPrimary={runPrimary}
         onSecondary={runSecondary}
+        onDelete={deleteItem}
         onReplyChange={(v) => { replyBody = v; }}
         onSendReply={sendReply}
         onBugNoteChange={(v) => { bugNote = v; }}

--- a/website/src/components/inbox/InboxDetail.svelte
+++ b/website/src/components/inbox/InboxDetail.svelte
@@ -20,6 +20,9 @@
     onNext: () => void;
     onPrimary: () => void;
     onSecondary: () => void;
+    /** Hard-delete escape hatch — visible on every row regardless of status
+     *  so admins can clear rows that already left the `pending` queue. */
+    onDelete: () => void;
     onReplyChange: (v: string) => void;
     onSendReply: () => void;
     onBugNoteChange: (v: string) => void;
@@ -29,7 +32,7 @@
     item, counts, busy, error,
     threadMessages, threadLoading, replyBody, replySending, bugNote,
     bindReplyTextarea,
-    onPrev, onNext, onPrimary, onSecondary,
+    onPrev, onNext, onPrimary, onSecondary, onDelete,
     onReplyChange, onSendReply, onBugNoteChange,
   }: Props = $props();
 
@@ -356,6 +359,7 @@
                 disabled={busy} onclick={onSecondary}>
           ✗ Ablehnen <span class="ksk">D</span>
         </button>
+        <span class="spacer"></span>
 
       {:else if item.type === 'booking'}
         <button type="button" class="btn btn-ok" data-testid="inbox-action-primary"
@@ -366,6 +370,7 @@
                 disabled={busy} onclick={onSecondary}>
           ✗ Ablehnen <span class="ksk">D</span>
         </button>
+        <span class="spacer"></span>
 
       {:else if item.type === 'contact'}
         <button type="button" class="btn btn-no" data-testid="inbox-action-primary"
@@ -415,6 +420,21 @@
           </a>
         {/if}
       {/if}
+
+      <!-- Universal hard-delete escape hatch. Visible on every row regardless
+           of status so admins can clear rows stuck in `actioned`/`archived`
+           that have no other path to deletion. Confirms via the parent's
+           window.confirm() before firing. -->
+      <button
+        type="button"
+        class="btn btn-danger"
+        data-testid="inbox-action-delete"
+        disabled={busy}
+        onclick={onDelete}
+        title="Diesen Eintrag dauerhaft löschen"
+      >
+        🗑 Löschen
+      </button>
     </footer>
   {/if}
 </section>
@@ -747,6 +767,19 @@
     padding: 7px 10px;
   }
   .btn-ghost:hover { color: var(--brass); }
+
+  /* Hard-delete escape hatch — muted red so it's clearly destructive but
+     not visually competing with the per-type primary action. */
+  .btn-danger {
+    background: transparent;
+    color: oklch(0.75 0.13 25);
+    border: 1px solid oklch(0.55 0.12 25 / 0.5);
+  }
+  .btn-danger:hover:not(:disabled) {
+    background: oklch(0.55 0.13 25 / 0.16);
+    color: oklch(0.85 0.13 25);
+    border-color: oklch(0.65 0.13 25);
+  }
 
   .ksk {
     font: 600 9.5px var(--font-mono);

--- a/website/src/lib/e2e-marker.ts
+++ b/website/src/lib/e2e-marker.ts
@@ -1,0 +1,40 @@
+// website/src/lib/e2e-marker.ts
+//
+// Detects whether an inbound HTTP request is a Playwright E2E call so the
+// form endpoints (/api/contact, /api/booking, /api/bug-report,
+// /api/portal/messages) can stamp `is_test_data=true` on the rows they
+// create — the purge function then sweeps them at the next bracket.
+//
+// Contract (chosen over option B = pattern-match on email/subject because
+// option B yields false positives — real users with the substring "test" in
+// their email get reaped):
+//
+//   - Request must carry `X-E2E-Test: 1` (any truthy value).
+//   - Request must ALSO carry `X-Cron-Secret` matching `process.env.CRON_SECRET`.
+//
+// The double check matters: a public-Internet user could send the header by
+// hand, but they can't forge the cron secret (it's a SealedSecret, only the
+// website pod's env reads it). Without the secret the marker is ignored —
+// fail-closed.
+//
+// CRON_SECRET is the same gate used by /api/admin/systemtest/purge-all-test-data
+// and the cleanup-fixtures CronJob, so propagating it from the Playwright
+// runner is already a solved-problem (env var on the runner, then forwarded
+// per-request).
+
+export function isE2ETestRequest(request: Request): boolean {
+  const e2e = request.headers.get('X-E2E-Test');
+  if (!e2e) return false;
+  const provided = request.headers.get('X-Cron-Secret');
+  const expected = process.env.CRON_SECRET;
+  if (!expected) return false;
+  // Constant-time-ish compare. Length mismatch short-circuits (which leaks
+  // length, but the secret is high-entropy so that's fine in this attack
+  // surface).
+  if (!provided || provided.length !== expected.length) return false;
+  let diff = 0;
+  for (let i = 0; i < provided.length; i++) {
+    diff |= provided.charCodeAt(i) ^ expected.charCodeAt(i);
+  }
+  return diff === 0;
+}

--- a/website/src/lib/messaging-db.ts
+++ b/website/src/lib/messaging-db.ts
@@ -36,6 +36,7 @@ export interface InboxItem {
   created_at: Date;
   actioned_at: Date | null;
   actioned_by: string | null;
+  is_test_data: boolean;
 }
 
 // ── Inbox ─────────────────────────────────────────────────────────────────────
@@ -46,14 +47,40 @@ export async function createInboxItem(params: {
   referenceTable?: string;
   bugTicketId?: string;
   payload: Record<string, unknown>;
+  /** When true, stamps the row as test-data so
+   *  tickets.fn_purge_test_data() reaps it on the next bracket. Set by
+   *  the public form endpoints (/api/contact, /api/booking, /api/bug-report,
+   *  /api/portal/messages) when the request carries the X-E2E-Test header
+   *  + valid X-Cron-Secret. Defaults to false. */
+  isTestData?: boolean;
 }): Promise<InboxItem> {
   const { rows } = await pool.query<InboxItem>(
-    `INSERT INTO inbox_items (type, reference_id, reference_table, bug_ticket_id, payload)
-     VALUES ($1, $2, $3, $4, $5)
+    `INSERT INTO inbox_items (type, reference_id, reference_table, bug_ticket_id, payload, is_test_data)
+     VALUES ($1, $2, $3, $4, $5, $6)
      RETURNING *`,
-    [params.type, params.referenceId ?? null, params.referenceTable ?? null, params.bugTicketId ?? null, params.payload],
+    [
+      params.type,
+      params.referenceId ?? null,
+      params.referenceTable ?? null,
+      params.bugTicketId ?? null,
+      params.payload,
+      params.isTestData === true,
+    ],
   );
   return rows[0];
+}
+
+/**
+ * Hard-delete an inbox row regardless of status. Used by the admin "Löschen"
+ * escape hatch — rows that have already been actioned/archived have no other
+ * path to disappear from the queue, and over time these accumulate (paddione
+ * had 27 such rows on mentolder before this lever existed).
+ *
+ * Returns the number of rows affected (0 if id was unknown).
+ */
+export async function deleteInboxItem(id: number): Promise<number> {
+  const r = await pool.query('DELETE FROM inbox_items WHERE id = $1', [id]);
+  return r.rowCount ?? 0;
 }
 
 export async function listInboxItems(filter: {
@@ -119,6 +146,7 @@ export interface MessageThread {
   subject: string | null;
   created_at: Date;
   last_message_at: Date;
+  is_test_data?: boolean;
   customer_name?: string;
   customer_email?: string;
   unread_count?: number;
@@ -133,6 +161,7 @@ export interface Message {
   body: string;
   created_at: Date;
   read_at: Date | null;
+  is_test_data?: boolean;
 }
 
 // ── Room types ────────────────────────────────────────────────────────────────
@@ -173,15 +202,18 @@ export async function listThreadsForAdmin(): Promise<MessageThread[]> {
   return rows;
 }
 
-export async function getOrCreateThreadForCustomer(customerId: string): Promise<MessageThread> {
+export async function getOrCreateThreadForCustomer(
+  customerId: string,
+  opts: { isTestData?: boolean } = {},
+): Promise<MessageThread> {
   const existing = await pool.query<MessageThread>(
     'SELECT * FROM message_threads WHERE customer_id = $1 LIMIT 1',
     [customerId],
   );
   if (existing.rows.length) return existing.rows[0];
   const { rows } = await pool.query<MessageThread>(
-    'INSERT INTO message_threads (customer_id) VALUES ($1) RETURNING *',
-    [customerId],
+    'INSERT INTO message_threads (customer_id, is_test_data) VALUES ($1, $2) RETURNING *',
+    [customerId, opts.isTestData === true],
   );
   return rows[0];
 }
@@ -211,18 +243,38 @@ export async function addMessage(params: {
   senderRole: 'admin' | 'user';
   senderCustomerId?: string;
   body: string;
+  /** When true, stamps the message row (and its parent thread, if not yet
+   *  stamped) so the test-data purge reaps both. */
+  isTestData?: boolean;
 }): Promise<Message> {
   const client = await pool.connect();
   try {
     await client.query('BEGIN');
     const { rows } = await client.query<Message>(
-      `INSERT INTO messages (thread_id, sender_id, sender_role, sender_customer_id, body) VALUES ($1, $2, $3, $4, $5) RETURNING *`,
-      [params.threadId, params.senderId, params.senderRole, params.senderCustomerId ?? null, params.body],
+      `INSERT INTO messages (thread_id, sender_id, sender_role, sender_customer_id, body, is_test_data)
+       VALUES ($1, $2, $3, $4, $5, $6) RETURNING *`,
+      [
+        params.threadId,
+        params.senderId,
+        params.senderRole,
+        params.senderCustomerId ?? null,
+        params.body,
+        params.isTestData === true,
+      ],
     );
     await client.query(
       'UPDATE message_threads SET last_message_at = now() WHERE id = $1',
       [params.threadId],
     );
+    if (params.isTestData === true) {
+      // Promote the parent thread's flag so the purge sweep reaps it via
+      // `WHERE is_test_data = true` rather than a join through messages.
+      await client.query(
+        `UPDATE message_threads SET is_test_data = true
+         WHERE id = $1 AND is_test_data = false`,
+        [params.threadId],
+      );
+    }
     await client.query('COMMIT');
     return rows[0];
   } catch (e) {

--- a/website/src/pages/api/admin/inbox/[id]/action.ts
+++ b/website/src/pages/api/admin/inbox/[id]/action.ts
@@ -1,7 +1,7 @@
 // website/src/pages/api/admin/inbox/[id]/action.ts
 import type { APIRoute } from 'astro';
 import { getSession, isAdmin } from '../../../../../lib/auth';
-import { getInboxItem, updateInboxItemStatus } from '../../../../../lib/messaging-db';
+import { getInboxItem, updateInboxItemStatus, deleteInboxItem } from '../../../../../lib/messaging-db';
 import { createUser, sendPasswordResetEmail } from '../../../../../lib/keycloak';
 import { createCalendarEvent } from '../../../../../lib/caldav';
 import { createTalkRoom, inviteGuestByEmail, sendChatMessage } from '../../../../../lib/talk';
@@ -30,12 +30,25 @@ export const POST: APIRoute = async ({ request, params }) => {
   if (!item) {
     return new Response(JSON.stringify({ error: 'Not found' }), { status: 404 });
   }
-  if (item.status !== 'pending') {
-    return new Response(JSON.stringify({ error: 'Already actioned' }), { status: 409 });
-  }
 
   const body = await request.json() as { action: string; note?: string };
   const { action, note } = body;
+
+  // `delete` is the unconditional escape hatch — it bypasses the
+  // "Already actioned" lock so admins can clear rows stuck in `actioned`
+  // or `archived` (the only paths that previously had no remediation).
+  // It deletes the row outright; nothing else changes for it.
+  if (action === 'delete') {
+    const deleted = await deleteInboxItem(id);
+    if (deleted === 0) {
+      return new Response(JSON.stringify({ error: 'Not found' }), { status: 404 });
+    }
+    return new Response(null, { status: 204 });
+  }
+
+  if (item.status !== 'pending') {
+    return new Response(JSON.stringify({ error: 'Already actioned' }), { status: 409 });
+  }
 
   try {
     switch (action) {

--- a/website/src/pages/api/admin/messages.ts
+++ b/website/src/pages/api/admin/messages.ts
@@ -18,6 +18,13 @@ export const POST: APIRoute = async ({ request }) => {
     return new Response(JSON.stringify({ error: 'customerId and body required' }), { status: 400 });
   }
   const thread = await getOrCreateThreadForCustomer(customerId);
-  const msg = await addMessage({ threadId: thread.id, senderId: session.sub, senderRole: 'admin', body: body.trim() });
+  // Admin-side messages inherit the thread's is_test_data flag — admin
+  // never creates new threads here (getOrCreateThreadForCustomer reuses an
+  // existing thread when the customer has one), so the existing flag is
+  // authoritative.
+  const msg = await addMessage({
+    threadId: thread.id, senderId: session.sub, senderRole: 'admin', body: body.trim(),
+    isTestData: thread.is_test_data === true,
+  });
   return new Response(JSON.stringify({ thread, message: msg }), { status: 201, headers: { 'Content-Type': 'application/json' } });
 };

--- a/website/src/pages/api/admin/messages/[threadId].ts
+++ b/website/src/pages/api/admin/messages/[threadId].ts
@@ -24,6 +24,12 @@ export const POST: APIRoute = async ({ request, params }) => {
   if (isNaN(threadId)) return new Response(JSON.stringify({ error: 'Invalid ID' }), { status: 400 });
   const { body } = await request.json() as { body: string };
   if (!body?.trim()) return new Response(JSON.stringify({ error: 'body required' }), { status: 400 });
-  const msg = await addMessage({ threadId, senderId: session.sub, senderRole: 'admin', body: body.trim() });
+  // Inherit the thread's is_test_data flag — if the parent thread was created
+  // by an E2E run the reply belongs to that run too, so the purge sweeps both.
+  const parent = await getThread(threadId);
+  const msg = await addMessage({
+    threadId, senderId: session.sub, senderRole: 'admin', body: body.trim(),
+    isTestData: parent?.is_test_data === true,
+  });
   return new Response(JSON.stringify({ message: msg }), { headers: { 'Content-Type': 'application/json' } });
 };

--- a/website/src/pages/api/admin/testdata/seed.ts
+++ b/website/src/pages/api/admin/testdata/seed.ts
@@ -85,6 +85,7 @@ export const POST: APIRoute = async ({ request }) => {
     // 5. Inbox bookings (Termine)
     await createInboxItem({
       type: 'booking',
+      isTestData: true,
       payload: {
         name: '[TEST] Max Mustermann',
         email: 'test-max@test.invalid',
@@ -100,6 +101,7 @@ export const POST: APIRoute = async ({ request }) => {
     });
     await createInboxItem({
       type: 'booking',
+      isTestData: true,
       payload: {
         name: '[TEST] Erika Musterfrau',
         email: 'test-erika@test.invalid',

--- a/website/src/pages/api/booking.ts
+++ b/website/src/pages/api/booking.ts
@@ -4,6 +4,7 @@ import { sendEmail } from '../../lib/email';
 import { sendAdminNotification } from '../../lib/notifications';
 import { isSlotInAnyWindow } from '../../lib/website-db';
 import { checkRateLimit, getClientIp } from '../../lib/rate-limit';
+import { isE2ETestRequest } from '../../lib/e2e-marker';
 
 const BRAND_NAME = process.env.BRAND_NAME || 'Workspace';
 
@@ -73,6 +74,7 @@ export const POST: APIRoute = async ({ request }) => {
         serviceKey: serviceKey ?? null, message: message ?? null,
         projectId: projectId ?? null, leistungKey: leistungKey ?? null,
       },
+      isTestData: isE2ETestRequest(request),
     });
 
     // Confirmation email to user

--- a/website/src/pages/api/bug-report.ts
+++ b/website/src/pages/api/bug-report.ts
@@ -4,6 +4,7 @@ import { createInboxItem } from '../../lib/messaging-db';
 import { checkRateLimit, getClientIp } from '../../lib/rate-limit';
 import { config } from '../../config/index.js';
 import { linkReporterByEmail } from '../../lib/tickets/reporter-link';
+import { isE2ETestRequest } from '../../lib/e2e-marker';
 
 const MAX_BYTES = 5 * 1024 * 1024;
 const ALLOWED_MIME = new Set(['image/png', 'image/jpeg', 'image/webp']);
@@ -103,6 +104,7 @@ export const POST: APIRoute = async ({ request }) => {
         url,
         brand: BRAND,
       },
+      isTestData: isE2ETestRequest(request),
     });
 
     return new Response(

--- a/website/src/pages/api/contact.ts
+++ b/website/src/pages/api/contact.ts
@@ -2,6 +2,7 @@ import type { APIRoute } from 'astro';
 import { createInboxItem } from '../../lib/messaging-db';
 import { sendAdminNotification } from '../../lib/notifications';
 import { checkRateLimit, getClientIp } from '../../lib/rate-limit';
+import { isE2ETestRequest } from '../../lib/e2e-marker';
 const BRAND_NAME = process.env.BRAND_NAME || 'Workspace';
 
 const TYPE_LABELS: Record<string, string> = {
@@ -45,6 +46,7 @@ export const POST: APIRoute = async ({ request }) => {
     await createInboxItem({
       type: 'contact',
       payload: { name, email, phone: phone ?? null, type, typeLabel, message },
+      isTestData: isE2ETestRequest(request),
     });
 
     // Admin notification is best-effort — inbox item is the authoritative record

--- a/website/src/pages/api/portal/messages.ts
+++ b/website/src/pages/api/portal/messages.ts
@@ -3,6 +3,7 @@ import type { APIRoute } from 'astro';
 import { getSession } from '../../../lib/auth';
 import { getThreadByCustomerId, getOrCreateThreadForCustomer, addMessage, createInboxItem } from '../../../lib/messaging-db';
 import { upsertCustomer } from '../../../lib/website-db';
+import { isE2ETestRequest } from '../../../lib/e2e-marker';
 
 export const GET: APIRoute = async ({ request }) => {
   const session = await getSession(request.headers.get('cookie'));
@@ -18,13 +19,15 @@ export const POST: APIRoute = async ({ request }) => {
   const customer = await upsertCustomer({ name: session.name, email: session.email, keycloakUserId: session.sub });
   const { body } = await request.json() as { body: string };
   if (!body?.trim()) return new Response(JSON.stringify({ error: 'body required' }), { status: 400 });
-  const thread = await getOrCreateThreadForCustomer(customer.id);
-  const msg = await addMessage({ threadId: thread.id, senderId: session.sub, senderRole: 'user', senderCustomerId: customer.id, body: body.trim() });
+  const isTest = isE2ETestRequest(request);
+  const thread = await getOrCreateThreadForCustomer(customer.id, { isTestData: isTest });
+  const msg = await addMessage({ threadId: thread.id, senderId: session.sub, senderRole: 'user', senderCustomerId: customer.id, body: body.trim(), isTestData: isTest });
   await createInboxItem({
     type: 'user_message',
     referenceId: String(thread.id),
     referenceTable: 'message_threads',
     payload: { senderName: customer.name, senderEmail: customer.email, message: body.trim().slice(0, 120) },
+    isTestData: isTest,
   });
   return new Response(JSON.stringify({ thread, message: msg }), { status: 201, headers: { 'Content-Type': 'application/json' } });
 };

--- a/website/src/pages/api/portal/messages/[threadId].ts
+++ b/website/src/pages/api/portal/messages/[threadId].ts
@@ -3,6 +3,7 @@ import type { APIRoute } from 'astro';
 import { getSession } from '../../../../lib/auth';
 import { getThread, getThreadMessages, addMessage, markThreadRead } from '../../../../lib/messaging-db';
 import { upsertCustomer } from '../../../../lib/website-db';
+import { isE2ETestRequest } from '../../../../lib/e2e-marker';
 
 export const GET: APIRoute = async ({ request, params }) => {
   const session = await getSession(request.headers.get('cookie'));
@@ -27,6 +28,9 @@ export const POST: APIRoute = async ({ request, params }) => {
   if (!thread || thread.customer_id !== customer.id) return new Response(JSON.stringify({ error: 'Not found' }), { status: 404 });
   const { body } = await request.json() as { body: string };
   if (!body?.trim()) return new Response(JSON.stringify({ error: 'body required' }), { status: 400 });
-  const msg = await addMessage({ threadId, senderId: session.sub, senderRole: 'user', senderCustomerId: customer.id, body: body.trim() });
+  const msg = await addMessage({
+    threadId, senderId: session.sub, senderRole: 'user', senderCustomerId: customer.id,
+    body: body.trim(), isTestData: isE2ETestRequest(request),
+  });
   return new Response(JSON.stringify({ message: msg }), { headers: { 'Content-Type': 'application/json' } });
 };


### PR DESCRIPTION
## Summary

Closes two gaps left by #607:

- **Gap 1**: `tickets.fn_purge_test_data()` ignored `inbox_items` / `message_threads` / `messages`. Adds `is_test_data BOOLEAN NOT NULL DEFAULT false` (idempotent + partial index) to all three tables and extends the function to sweep them before the customers allowlist. New keys (`messages`, `message_threads`, `inbox_items`) appear in the JSONB response so the bracketing endpoint can verify reaping happened.
- **Gap 2**: `/admin/inbox` couldn't delete rows that already left `pending`. Adds a `delete` action to `[id]/action.ts` that bypasses the lock, plus a "🗑 Löschen" button in `InboxDetail` visible on every row regardless of status (paddione had 27 stuck `archived`/`actioned` rows this lever now clears).

## Approach for stamping at write-time (chosen: option A)

Public form endpoints (`/api/contact`, `/api/booking`, `/api/bug-report`, `/api/portal/messages` + its `[threadId]` reply) call `isE2ETestRequest(request)` which checks BOTH:
- `X-E2E-Test: 1` header
- `X-Cron-Secret` matching `process.env.CRON_SECRET` (constant-time compare)

Only when both match do they stamp `is_test_data=true`. The cron secret is a SealedSecret only the website pod's env reads, so a public-Internet user can't forge it — fail-closed.

Pattern-matching (option b) was rejected: real users with "test" in their email would get reaped. Trigger + GUC (the alternative I floated) was overkill at this size and would still need the same secret distribution to set the GUC.

Admin-side replies inherit the parent thread's flag (no header needed) so test-bracketed conversations stay self-contained.

## Migrations

- `scripts/one-shot/2026-05-09-inbox-test-data-flag.sql` — applied to mentolder + korczewski before this PR landed.
- `scripts/one-shot/2026-05-09-purge-fn-v2.sql` — applied to mentolder + korczewski before this PR landed.

Both are idempotent (`ADD COLUMN IF NOT EXISTS` + `CREATE INDEX IF NOT EXISTS` + `CREATE OR REPLACE FUNCTION`).

## Verification on prod

```
mentolder: SELECT tickets.fn_purge_test_data();
→ {"messages":0,"inbox_items":0,"message_threads":0, ...19 keys}
   41 real BR-* inbox rows preserved (all is_test_data=false)
korczewski: SELECT tickets.fn_purge_test_data();
→ same 19 keys returned
```

## Test plan

- [ ] After merge, run `task feature:website` (or `task website:deploy ENV=mentolder` then `ENV=korczewski`) to ship the API/UI changes
- [ ] Manually open `/admin/inbox` on `web.mentolder.de`, switch to "Erledigt" or "Archiv" tab, click any row, click "🗑 Löschen", confirm — row disappears
- [ ] Run `npx playwright test --project=website -g fa-admin-inbox-delete` once `CRON_SECRET` + `E2E_ADMIN_PASS` are exported
- [ ] Next nightly Playwright run: globalSetup purge counts should show non-zero `inbox_items` after the prior night's bracketed E2E populated them, and zero on the immediate re-call

🤖 Generated with [Claude Code](https://claude.com/claude-code)