### PR TITLE
fix(systemtest): wire rrweb recorder into QuestionnaireWizard

### DIFF
--- a/website/src/components/portal/QuestionnaireWizard.svelte
+++ b/website/src/components/portal/QuestionnaireWizard.svelte
@@ -17,8 +17,64 @@
     instructions: string;
     questions: QuestionData[];
     initialAnswers: Array<{ question_id: string; option_key: string; details_text?: string | null }>;
+    recordEvidence?: boolean;
+    attemptByQuestion?: Record<string, number>;
   };
-  const { assignmentId, title, instructions, questions, initialAnswers }: Props = $props();
+  const {
+    assignmentId,
+    title,
+    instructions,
+    questions,
+    initialAnswers,
+    recordEvidence = false,
+    attemptByQuestion = {},
+  }: Props = $props();
+
+  // rrweb recorder for system-test runs. Lazy-loaded so the rrweb bundle is
+  // only fetched when an admin-led system-test session needs it. The recorder
+  // patches window.fetch and console — running two at once would corrupt
+  // those globals (a stale wrapper outlives the patch chain), so all
+  // start/finalize operations are serialized on `recorderChain`.
+  type RecorderHandle = {
+    finalize(): Promise<{ evidenceId: string | null; partial: boolean }>;
+    cancel(): void;
+  };
+  let activeRecorder: RecorderHandle | null = null;
+  let recorderChain: Promise<void> = Promise.resolve();
+
+  async function startEvidenceRecorderInner(questionId: string) {
+    try {
+      const mod = await import('../../lib/systemtest/recorder');
+      activeRecorder = mod.startRecorder({
+        assignmentId,
+        questionId,
+        attempt: attemptByQuestion[questionId] ?? 0,
+      });
+    } catch (e) {
+      // Recording is best-effort; never block the wizard if the bundle
+      // fails to load (e.g. offline). The user can still complete the test.
+      console.warn('[wizard] failed to start evidence recorder', e);
+    }
+  }
+
+  async function finalizeEvidenceRecorderInner() {
+    const rec = activeRecorder;
+    activeRecorder = null;
+    if (!rec) return;
+    try {
+      await rec.finalize();
+    } catch (e) {
+      console.warn('[wizard] evidence finalize failed', e);
+    }
+  }
+
+  function queueRecorderTransition(nextQuestionId: string | null) {
+    recorderChain = recorderChain.then(async () => {
+      await finalizeEvidenceRecorderInner();
+      if (nextQuestionId) await startEvidenceRecorderInner(nextQuestionId);
+    });
+    return recorderChain;
+  }
 
   let answers = $state<Record<string, string>>(
     Object.fromEntries(initialAnswers.map(a => [a.question_id, a.option_key]))
@@ -75,6 +131,24 @@
   $effect(() => {
     const qId = questions[currentIndex]?.id;
     pendingTestOption = qId ? (answers[qId] ?? '') : '';
+  });
+
+  // Recorder lifecycle: start when entering a test_step on a recordable run,
+  // finalize when leaving. Reads `phase` so the intro/done/dismissed screens
+  // never hold a recorder. Transitions are serialized via `recorderChain` so
+  // the previous recorder's fetch/console patches are restored before the
+  // next recorder installs its own.
+  $effect(() => {
+    const q = questions[currentIndex];
+    const shouldRecord =
+      recordEvidence
+      && phase === 'question'
+      && q?.question_type === 'test_step';
+    void queueRecorderTransition(shouldRecord && q ? q.id : null);
+    return () => {
+      // Component teardown — queue one last finalize.
+      void queueRecorderTransition(null);
+    };
   });
 
   const current = $derived(questions[currentIndex]);
@@ -171,6 +245,9 @@
 
   async function confirmDismiss() {
     dismissing = true; dismissError = '';
+    // Finalize before the dismiss POST so the last chunk lands on the
+    // assignment that's about to leave the active state.
+    await queueRecorderTransition(null);
     try {
       const r = await fetch(`/api/portal/questionnaires/${assignmentId}/dismiss`, {
         method: 'POST',
@@ -194,6 +271,9 @@
 
   async function submit() {
     submitting = true; error = '';
+    // Finalize the active recorder (if any) before submit so the last test
+    // step's evidence is durable before the assignment leaves 'pending'.
+    await queueRecorderTransition(null);
     try {
       const r = await fetch(`/api/portal/questionnaires/${assignmentId}/submit`, { method: 'POST' });
       if (r.ok) {

--- a/website/src/data/test-inventory.json
+++ b/website/src/data/test-inventory.json
@@ -48,6 +48,12 @@
     "kind": "playwright"
   },
   {
+    "id": "E2E:fa-admin-inbox-delete",
+    "file": "tests/e2e/specs/fa-admin-inbox-delete.spec.ts",
+    "category": "E2E",
+    "kind": "playwright"
+  },
+  {
     "id": "E2E:fa-admin-inhalte",
     "file": "tests/e2e/specs/fa-admin-inhalte.spec.ts",
     "category": "E2E",
@@ -162,6 +168,24 @@
     "kind": "playwright"
   },
   {
+    "id": "E2E:systemtest-01-auth",
+    "file": "tests/e2e/specs/systemtest-01-auth.spec.ts",
+    "category": "E2E",
+    "kind": "playwright"
+  },
+  {
+    "id": "E2E:systemtest-02-admin-crm",
+    "file": "tests/e2e/specs/systemtest-02-admin-crm.spec.ts",
+    "category": "E2E",
+    "kind": "playwright"
+  },
+  {
+    "id": "E2E:systemtest-03-kommunikation",
+    "file": "tests/e2e/specs/systemtest-03-kommunikation.spec.ts",
+    "category": "E2E",
+    "kind": "playwright"
+  },
+  {
     "id": "E2E:systemtest-04-fragebogen",
     "file": "tests/e2e/specs/systemtest-04-fragebogen.spec.ts",
     "category": "E2E",
@@ -176,6 +200,42 @@
   {
     "id": "E2E:systemtest-06-steuer",
     "file": "tests/e2e/specs/systemtest-06-steuer.spec.ts",
+    "category": "E2E",
+    "kind": "playwright"
+  },
+  {
+    "id": "E2E:systemtest-07-rechnungen",
+    "file": "tests/e2e/specs/systemtest-07-rechnungen.spec.ts",
+    "category": "E2E",
+    "kind": "playwright"
+  },
+  {
+    "id": "E2E:systemtest-08-buchhaltung",
+    "file": "tests/e2e/specs/systemtest-08-buchhaltung.spec.ts",
+    "category": "E2E",
+    "kind": "playwright"
+  },
+  {
+    "id": "E2E:systemtest-09-monitoring",
+    "file": "tests/e2e/specs/systemtest-09-monitoring.spec.ts",
+    "category": "E2E",
+    "kind": "playwright"
+  },
+  {
+    "id": "E2E:systemtest-10-externe",
+    "file": "tests/e2e/specs/systemtest-10-externe.spec.ts",
+    "category": "E2E",
+    "kind": "playwright"
+  },
+  {
+    "id": "E2E:systemtest-11-livekit",
+    "file": "tests/e2e/specs/systemtest-11-livekit.spec.ts",
+    "category": "E2E",
+    "kind": "playwright"
+  },
+  {
+    "id": "E2E:systemtest-12-projektmanagement",
+    "file": "tests/e2e/specs/systemtest-12-projektmanagement.spec.ts",
     "category": "E2E",
     "kind": "playwright"
   },

--- a/website/src/lib/questionnaire-db.ts
+++ b/website/src/lib/questionnaire-db.ts
@@ -1014,3 +1014,25 @@ export async function listEvidenceByAssignment(
   );
   return r.rows;
 }
+
+// Per-question retest_attempt for the rrweb recorder. Rows in
+// questionnaire_test_status are keyed by question_id; the row only belongs to
+// THIS assignment if last_assignment_id matches. Questions without a status
+// row (or where last_assignment_id is a sibling assignment) are fresh runs at
+// attempt 0.
+export async function listTestStepAttempts(
+  assignmentId: string,
+): Promise<Record<string, number>> {
+  const r = await pool.query(
+    `SELECT question_id, retest_attempt
+       FROM questionnaire_test_status
+      WHERE last_assignment_id = $1`,
+    [assignmentId],
+  );
+  return Object.fromEntries(
+    r.rows.map((row: { question_id: string; retest_attempt: number | null }) => [
+      row.question_id,
+      row.retest_attempt ?? 0,
+    ]),
+  );
+}

--- a/website/src/pages/portal/fragebogen/[assignmentId].astro
+++ b/website/src/pages/portal/fragebogen/[assignmentId].astro
@@ -1,13 +1,15 @@
 ---
 // website/src/pages/portal/fragebogen/[assignmentId].astro
 import PortalLayout from '../../../layouts/PortalLayout.astro';
-import { getSession, getLoginUrl } from '../../../lib/auth';
+import { getSession, getLoginUrl, isAdmin } from '../../../lib/auth';
 import { getCustomerByEmail } from '../../../lib/website-db';
 import {
   getQAssignment, getQTemplate,
   listQQuestions, listQAnswers,
   countPendingQAssignmentsForCustomer,
+  listTestStepAttempts,
 } from '../../../lib/questionnaire-db';
+import { isSystemtestLoopEnabled } from '../../../lib/systemtest/feature-flag';
 import QuestionnaireWizard from '../../../components/portal/QuestionnaireWizard.svelte';
 
 const session = await getSession(Astro.request.headers.get('cookie'));
@@ -32,6 +34,15 @@ const [questions, answers] = await Promise.all([
   listQAnswers(assignment.id),
 ]);
 const pendingCount = await countPendingQAssignmentsForCustomer(customer.id).catch(() => 0);
+
+// rrweb evidence captured only on admin-led system-test runs: the upload
+// endpoint is admin-gated and the failure-loop kanban only consumes evidence
+// for is_system_test templates. The flag is the master kill-switch.
+const isSystemTest = tpl?.is_system_test ?? false;
+const recordEvidence = isSystemTest && isSystemtestLoopEnabled() && isAdmin(session);
+const attemptByQuestion = recordEvidence
+  ? await listTestStepAttempts(assignmentId).catch(() => ({} as Record<string, number>))
+  : {};
 ---
 
 <PortalLayout
@@ -50,6 +61,8 @@ const pendingCount = await countPendingQAssignmentsForCustomer(customer.id).catc
         instructions={tpl?.instructions ?? ''}
         questions={questions}
         initialAnswers={answers}
+        recordEvidence={recordEvidence}
+        attemptByQuestion={attemptByQuestion}
       />
     </div>
   </section>


### PR DESCRIPTION
## Summary

PR #590 shipped the rrweb recorder module, upload endpoint, evidence PVC, schema, and kanban — but never wired `startRecorder()` into the actual wizard. Result: both prod clusters had empty `/var/evidence` PVCs and zero rows in `questionnaire_test_evidence` since the feature shipped on 2026-05-08.

This wires the recorder lifecycle into `QuestionnaireWizard.svelte`:

- `portal/fragebogen/[assignmentId].astro` passes `recordEvidence` (`isSystemTest && SYSTEMTEST_LOOP_ENABLED && isAdmin`) and per-question `attemptByQuestion` (from `questionnaire_test_status.retest_attempt`) to the wizard.
- Wizard lazy-imports `lib/systemtest/recorder` when entering a `test_step` question on a recordable run — the rrweb bundle (~71 kB gzipped 24 kB) only ships to admin-led system-test sessions.
- Transitions are serialized on a single `recorderChain` promise so the previous recorder's `window.fetch` / `console` patches are restored before the next recorder installs its own (otherwise concurrent patches cross-pollute).
- `submit()` and `confirmDismiss()` await `queueRecorderTransition(null)` before the state-change POST, so the last chunk lands while the assignment is still `pending` (cleanup CronJob otherwise might purge fixtures before the final flush).

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx astro build` clean — `recorder.*.js` chunk lazy-loaded out of the wizard bundle
- [x] `npx vitest run src/lib/systemtest/` passes
- [ ] Deploy to mentolder + korczewski
- [ ] Run a system-test questionnaire as admin → verify `.rrweb` files appear in `/var/evidence/<assignmentId>/<questionId>/<attempt>.rrweb`
- [ ] Verify `questionnaire_test_evidence` row created
- [ ] Open the failure-loop board → click Replay button on the new evidence

🤖 Generated with [Claude Code](https://claude.com/claude-code)