### PR TITLE
feat: deploy MCP monolith to workspace-korczewski

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1653,13 +1653,21 @@ tasks:
       - sh: kubectl cluster-info > /dev/null 2>&1
         msg: "No cluster running. Run 'task cluster:create' first."
     cmds:
-      - 'echo "Deploying Claude Code MCP monolith..."'
+      - 'echo "Deploying Claude Code MCP monolith (ENV={{.ENV}})..."'
       - |
         source scripts/env-resolve.sh "{{.ENV}}"
         # Pull runtime secrets from workspace-secrets so claude-code-secrets stays in sync.
         # Falls back to placeholders on a fresh cluster before workspace-secrets exists.
         CTX="${ENV_CONTEXT:+--context $ENV_CONTEXT}"
         NS="${WORKSPACE_NAMESPACE:-workspace}"
+        # mentolder/dev → deploy/mcp/ (default ns); korczewski → deploy/mcp-korczewski/ (workspace-korczewski ns)
+        if [ "{{.ENV}}" = "korczewski" ]; then
+          OVERLAY="deploy/mcp-korczewski"
+          MCP_NS="$NS"
+        else
+          OVERLAY="deploy/mcp"
+          MCP_NS="default"
+        fi
         SHARED_DB_PASSWORD=$(kubectl $CTX get secret workspace-secrets -n "$NS" \
           -o jsonpath='{.data.SHARED_DB_PASSWORD}' 2>/dev/null | base64 -d || echo "devshareddb")
         GITHUB_PAT=$(kubectl $CTX get secret workspace-secrets -n "$NS" \
@@ -1667,22 +1675,29 @@ tasks:
         KEYCLOAK_ADMIN_PASSWORD=$(kubectl $CTX get secret workspace-secrets -n "$NS" \
           -o jsonpath='{.data.KEYCLOAK_ADMIN_PASSWORD}' 2>/dev/null | base64 -d || echo "admin")
         export SHARED_DB_PASSWORD GITHUB_PAT KEYCLOAK_ADMIN_PASSWORD
-        kustomize build deploy/mcp/ | envsubst "\$PROD_DOMAIN \$INFRA_NAMESPACE \$TLS_SECRET_NAME \$SHARED_DB_PASSWORD \$GITHUB_PAT \$KEYCLOAK_ADMIN_PASSWORD" | kubectl $CTX apply -f -
+        kustomize build "$OVERLAY" | envsubst "\$PROD_DOMAIN \$INFRA_NAMESPACE \$TLS_SECRET_NAME \$SHARED_DB_PASSWORD \$GITHUB_PAT \$KEYCLOAK_ADMIN_PASSWORD" | kubectl $CTX apply -f -
         # Create mcp-tokens only on first deploy — never overwrite real tokens
-        if ! kubectl $CTX get secret mcp-tokens -n default &>/dev/null; then
-          kubectl $CTX create secret generic mcp-tokens \
+        if ! kubectl $CTX get secret mcp-tokens -n "$MCP_NS" &>/dev/null; then
+          kubectl $CTX -n "$MCP_NS" create secret generic mcp-tokens \
             --from-literal="CLUSTER_TOKEN=dev-cluster-token-placeholder" \
             --from-literal="BUSINESS_TOKEN=dev-business-token-placeholder"
-          echo "⚠ mcp-tokens created with placeholders — run 'task claude-code:rotate-tokens ENV={{.ENV}}' to set real tokens"
+          echo "⚠ mcp-tokens created in $MCP_NS with placeholders — run 'task claude-code:rotate-tokens ENV={{.ENV}}' to set real tokens"
         fi
       - 'echo "Waiting for pods to roll out..."'
       - |
         source scripts/env-resolve.sh "{{.ENV}}"
         CTX="${ENV_CONTEXT:+--context $ENV_CONTEXT}"
-        kubectl $CTX rollout status deployment/claude-code-mcp-monolith --timeout=300s
-        kubectl $CTX rollout status deployment/mcp-auth-proxy --timeout=120s
+        if [ "{{.ENV}}" = "korczewski" ]; then
+          MCP_NS="${WORKSPACE_NAMESPACE:-workspace-korczewski}"
+        else
+          MCP_NS="default"
+        fi
+        kubectl $CTX -n "$MCP_NS" rollout status deployment/claude-code-mcp-monolith --timeout=300s
+        kubectl $CTX -n "$MCP_NS" rollout status deployment/mcp-auth-proxy --timeout=120s
       - 'echo "✓ MCP monolith deployed (1 pod + auth proxy)"'
       - task: mcp:status
+        vars:
+          ENV: '{{.ENV}}'
       - 'echo ""'
       - 'echo "  Next → task workspace:post-setup ENV={{.ENV}}"'
 
@@ -1694,17 +1709,23 @@ tasks:
       - |
         source scripts/env-resolve.sh "{{.ENV}}"
         CTX="${ENV_CONTEXT:+--context $ENV_CONTEXT}"
-        echo "=== MCP Pods ==="
-        kubectl $CTX get pods -l 'app in (claude-code-mcp-monolith,mcp-auth-proxy)' -o wide
+        if [ "{{.ENV}}" = "korczewski" ]; then
+          NS_FLAG="-n ${WORKSPACE_NAMESPACE:-workspace-korczewski}"
+        else
+          NS_FLAG="-n default"
+        fi
+        echo "=== MCP Pods ($NS_FLAG) ==="
+        kubectl $CTX $NS_FLAG get pods -l 'app in (claude-code-mcp-monolith,mcp-auth-proxy)' -o wide
         echo ""
         echo "=== Container Status (per pod) ==="
-        for pod in $(kubectl $CTX get pods -l 'app in (claude-code-mcp-monolith,mcp-auth-proxy)' -o name 2>/dev/null); do
+        for pod in $(kubectl $CTX $NS_FLAG get pods -l 'app in (claude-code-mcp-monolith,mcp-auth-proxy)' --field-selector=status.phase=Running -o name 2>/dev/null); do
           echo "  $pod:"
-          kubectl $CTX get $pod -o jsonpath='{range .status.containerStatuses[*]}    {.name}: ready={.ready} restarts={.restartCount}{"\n"}{end}'
+          kubectl $CTX $NS_FLAG get $pod -o jsonpath='{range .status.containerStatuses[*]}    {.name}: ready={.ready} restarts={.restartCount}{"\n"}{end}' 2>/dev/null || true
+          echo
         done
         echo ""
         echo "=== MCP Endpoints ==="
-        kubectl $CTX get configmap claude-code-config -o yaml 2>/dev/null | grep "MCP_.*_URL"
+        kubectl $CTX $NS_FLAG get configmap claude-code-config -o yaml 2>/dev/null | grep "MCP_.*_URL"
 
   mcp:logs:
     desc: "Tail logs for a container in the MCP monolith (usage: task mcp:logs -- <container>, e.g. postgres|browser|github|keycloak|kubernetes)"
@@ -1714,11 +1735,16 @@ tasks:
       - |
         source scripts/env-resolve.sh "{{.ENV}}"
         CTX="${ENV_CONTEXT:+--context $ENV_CONTEXT}"
+        if [ "{{.ENV}}" = "korczewski" ]; then
+          NS_FLAG="-n ${WORKSPACE_NAMESPACE:-workspace-korczewski}"
+        else
+          NS_FLAG="-n default"
+        fi
         CONTAINER="{{.CLI_ARGS}}"
         if [ -z "$CONTAINER" ]; then
-          kubectl $CTX logs deployment/claude-code-mcp-monolith -f --tail=50 --all-containers
+          kubectl $CTX $NS_FLAG logs deployment/claude-code-mcp-monolith -f --tail=50 --all-containers
         else
-          kubectl $CTX logs deployment/claude-code-mcp-monolith -c "$CONTAINER" -f --tail=50
+          kubectl $CTX $NS_FLAG logs deployment/claude-code-mcp-monolith -c "$CONTAINER" -f --tail=50
         fi
 
   mcp:restart:
@@ -1729,8 +1755,13 @@ tasks:
       - |
         source scripts/env-resolve.sh "{{.ENV}}"
         CTX="${ENV_CONTEXT:+--context $ENV_CONTEXT}"
-        kubectl $CTX rollout restart deployment/claude-code-mcp-monolith
-        kubectl $CTX rollout status deployment/claude-code-mcp-monolith --timeout=120s
+        if [ "{{.ENV}}" = "korczewski" ]; then
+          NS_FLAG="-n ${WORKSPACE_NAMESPACE:-workspace-korczewski}"
+        else
+          NS_FLAG="-n default"
+        fi
+        kubectl $CTX $NS_FLAG rollout restart deployment/claude-code-mcp-monolith
+        kubectl $CTX $NS_FLAG rollout status deployment/claude-code-mcp-monolith --timeout=120s
 
   mcp:set-github-pat:
     desc: Update GITHUB_PAT in claude-code-secrets
@@ -1775,8 +1806,13 @@ tasks:
         fi
 
         # Read token from k8s Secret (production context)
+        if [ "{{.ENV}}" = "korczewski" ]; then
+          MCP_NS="${WORKSPACE_NAMESPACE:-workspace-korczewski}"
+        else
+          MCP_NS="default"
+        fi
         TOKEN_KEY="$(echo ${ROLE} | tr '[:lower:]' '[:upper:]')_TOKEN"
-        TOKEN=$(kubectl --context "${ENV_CONTEXT}" get secret mcp-tokens -o jsonpath="{.data.${TOKEN_KEY}}" 2>/dev/null | base64 -d)
+        TOKEN=$(kubectl --context "${ENV_CONTEXT}" -n "$MCP_NS" get secret mcp-tokens -o jsonpath="{.data.${TOKEN_KEY}}" 2>/dev/null | base64 -d)
         if [ -z "$TOKEN" ]; then
           echo "ERROR: Could not read ${TOKEN_KEY} from mcp-tokens Secret"
           echo "Deploy MCP first: task mcp:deploy ENV={{.ENV}}"
@@ -1816,9 +1852,14 @@ tasks:
         # Read token from k8s Secret
         context_flag=""
         [ "{{.ENV}}" != "dev" ] && context_flag="--context $ENV_CONTEXT"
-        
+        if [ "{{.ENV}}" = "korczewski" ]; then
+          MCP_NS="${WORKSPACE_NAMESPACE:-workspace-korczewski}"
+        else
+          MCP_NS="default"
+        fi
+
         TOKEN_KEY="$(echo ${ROLE} | tr '[:lower:]' '[:upper:]')_TOKEN"
-        TOKEN=$(kubectl $context_flag get secret mcp-tokens -o jsonpath="{.data.${TOKEN_KEY}}" 2>/dev/null | base64 -d)
+        TOKEN=$(kubectl $context_flag -n "$MCP_NS" get secret mcp-tokens -o jsonpath="{.data.${TOKEN_KEY}}" 2>/dev/null | base64 -d)
         
         if [ -z "$TOKEN" ]; then
           echo "ERROR: Could not read ${TOKEN_KEY} from mcp-tokens Secret"
@@ -1878,8 +1919,13 @@ tasks:
         fi
 
         # Read token from k8s Secret (production context)
+        if [ "{{.ENV}}" = "korczewski" ]; then
+          MCP_NS="${WORKSPACE_NAMESPACE:-workspace-korczewski}"
+        else
+          MCP_NS="default"
+        fi
         TOKEN_KEY="$(echo ${ROLE} | tr '[:lower:]' '[:upper:]')_TOKEN"
-        TOKEN=$(kubectl --context "${ENV_CONTEXT}" get secret mcp-tokens -o jsonpath="{.data.${TOKEN_KEY}}" 2>/dev/null | base64 -d)
+        TOKEN=$(kubectl --context "${ENV_CONTEXT}" -n "$MCP_NS" get secret mcp-tokens -o jsonpath="{.data.${TOKEN_KEY}}" 2>/dev/null | base64 -d)
         if [ -z "$TOKEN" ]; then
           echo "ERROR: Could not read ${TOKEN_KEY} from mcp-tokens Secret"
           echo "Deploy MCP first: task mcp:deploy ENV={{.ENV}}"
@@ -1925,8 +1971,13 @@ tasks:
         fi
 
         # Read token from k8s Secret (production context)
+        if [ "{{.ENV}}" = "korczewski" ]; then
+          MCP_NS="${WORKSPACE_NAMESPACE:-workspace-korczewski}"
+        else
+          MCP_NS="default"
+        fi
         TOKEN_KEY="$(echo ${ROLE} | tr '[:lower:]' '[:upper:]')_TOKEN"
-        TOKEN=$(kubectl --context "${ENV_CONTEXT}" get secret mcp-tokens -o jsonpath="{.data.${TOKEN_KEY}}" 2>/dev/null | base64 -d)
+        TOKEN=$(kubectl --context "${ENV_CONTEXT}" -n "$MCP_NS" get secret mcp-tokens -o jsonpath="{.data.${TOKEN_KEY}}" 2>/dev/null | base64 -d)
         if [ -z "$TOKEN" ]; then
           echo "ERROR: Could not read ${TOKEN_KEY} from mcp-tokens Secret"
           echo "Deploy MCP first: task mcp:deploy ENV={{.ENV}}"
@@ -1968,16 +2019,21 @@ tasks:
     cmds:
       - |
         source scripts/env-resolve.sh "{{.ENV}}"
+        if [ "{{.ENV}}" = "korczewski" ]; then
+          MCP_NS="${WORKSPACE_NAMESPACE:-workspace-korczewski}"
+        else
+          MCP_NS="default"
+        fi
         NEW_CLUSTER=$(openssl rand -hex 32)
         NEW_BUSINESS=$(openssl rand -hex 32)
 
-        kubectl --context "${ENV_CONTEXT}" delete secret mcp-tokens 2>/dev/null || true
-        kubectl --context "${ENV_CONTEXT}" create secret generic mcp-tokens \
+        kubectl --context "${ENV_CONTEXT}" -n "$MCP_NS" delete secret mcp-tokens 2>/dev/null || true
+        kubectl --context "${ENV_CONTEXT}" -n "$MCP_NS" create secret generic mcp-tokens \
           --from-literal="CLUSTER_TOKEN=$NEW_CLUSTER" \
           --from-literal="BUSINESS_TOKEN=$NEW_BUSINESS"
 
-        kubectl --context "${ENV_CONTEXT}" rollout restart deployment/mcp-auth-proxy
-        kubectl --context "${ENV_CONTEXT}" rollout status deployment/mcp-auth-proxy --timeout=60s
+        kubectl --context "${ENV_CONTEXT}" -n "$MCP_NS" rollout restart deployment/mcp-auth-proxy
+        kubectl --context "${ENV_CONTEXT}" -n "$MCP_NS" rollout status deployment/mcp-auth-proxy --timeout=60s
 
         echo "MCP tokens rotated"
         echo ""

--- a/deploy/mcp-korczewski/kustomization.yaml
+++ b/deploy/mcp-korczewski/kustomization.yaml
@@ -1,0 +1,76 @@
+# ════════════════════════════════════════════════════════════════════
+# Korczewski MCP monolith — second copy of deploy/mcp/ pinned at
+# the workspace-korczewski namespace, serving https://mcp.korczewski.de.
+#
+# The mentolder copy lives in `default` ns and serves https://mcp.mentolder.de
+# (see deploy/mcp/). Cluster-scoped RBAC is owned by mentolder; this overlay
+# strips it from its output so we don't clobber the existing ClusterRoleBinding
+# (which already has both namespaces' SAs as subjects).
+# ════════════════════════════════════════════════════════════════════
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: workspace-korczewski
+
+resources:
+  - ../mcp
+
+patches:
+  # ── ClusterRole/ClusterRoleBinding live in the mentolder overlay; the
+  # binding's subjects already include workspace-korczewski/claude-code-agent.
+  # Re-applying from this overlay would overwrite that and lose mentolder.
+  - target:
+      kind: ClusterRole
+      name: claude-code-agent
+    patch: |
+      $patch: delete
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: claude-code-agent
+  - target:
+      kind: ClusterRoleBinding
+      name: claude-code-agent
+    patch: |
+      $patch: delete
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: claude-code-agent
+
+  # ── claude-code-config CM is owned by the workspace-korczewski ArgoCD
+  # Application (it documents the in-cluster split MCPs at claude-code-mcp-ops/
+  # claude-code-mcp-auth). The monolith pod doesn't consume it, so strip it
+  # to avoid an ArgoCD sync conflict.
+  - target:
+      kind: ConfigMap
+      name: claude-code-config
+    patch: |
+      $patch: delete
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: claude-code-config
+
+  # ── Retarget MCP monolith env vars to workspace-korczewski services ──
+  - path: patch-monolith.yaml
+
+  # ── Ingress: only mcp.korczewski.de + ForwardAuth in this namespace ──
+  - path: patch-ingress.yaml
+
+  # ── Pin auth-proxy to Hetzner CPs (CNI partition; CoreDNS lives there) ──
+  - target:
+      kind: Deployment
+      name: mcp-auth-proxy
+    patch: |-
+      - op: add
+        path: /spec/template/spec/affinity
+        value:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: node-location
+                      operator: In
+                      values:
+                        - hetzner

--- a/deploy/mcp-korczewski/patch-ingress.yaml
+++ b/deploy/mcp-korczewski/patch-ingress.yaml
@@ -1,0 +1,57 @@
+# ForwardAuth in this overlay calls the workspace-korczewski auth proxy
+# (the base referenced default.svc.cluster.local).
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: mcp-forwardauth
+spec:
+  forwardAuth:
+    address: http://mcp-auth-proxy.workspace-korczewski.svc.cluster.local:80/auth
+    authResponseHeaders:
+      - X-MCP-Role
+---
+# Match only mcp.korczewski.de; mentolder ingress (in default ns) handles mcp.mentolder.de.
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: mcp-gateway
+spec:
+  entryPoints:
+    - web
+    - websecure
+  routes:
+    - kind: Rule
+      match: Host(`mcp.korczewski.de`) && PathPrefix(`/kubernetes`)
+      middlewares:
+        - name: mcp-chain
+      services:
+        - name: claude-code-mcp-monolith
+          port: 8080
+    - kind: Rule
+      match: Host(`mcp.korczewski.de`) && PathPrefix(`/postgres`)
+      middlewares:
+        - name: mcp-chain
+      services:
+        - name: claude-code-mcp-monolith
+          port: 3001
+    - kind: Rule
+      match: Host(`mcp.korczewski.de`) && PathPrefix(`/keycloak`)
+      middlewares:
+        - name: mcp-chain
+      services:
+        - name: claude-code-mcp-monolith
+          port: 8081
+    - kind: Rule
+      match: Host(`mcp.korczewski.de`) && PathPrefix(`/browser`)
+      middlewares:
+        - name: mcp-chain
+      services:
+        - name: claude-code-mcp-monolith
+          port: 3000
+    - kind: Rule
+      match: Host(`mcp.korczewski.de`) && PathPrefix(`/github`)
+      middlewares:
+        - name: mcp-chain
+      services:
+        - name: claude-code-mcp-monolith
+          port: 3002

--- a/deploy/mcp-korczewski/patch-monolith.yaml
+++ b/deploy/mcp-korczewski/patch-monolith.yaml
@@ -1,0 +1,40 @@
+# Retarget the monolith's external service references from `workspace`
+# to `workspace-korczewski` so this copy reads korczewski's data.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: claude-code-mcp-monolith
+spec:
+  template:
+    spec:
+      containers:
+        - name: postgres
+          env:
+            - name: SHARED_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: claude-code-secrets
+                  key: SHARED_DB_PASSWORD
+            - name: DATABASE_URL
+              value: "postgresql://postgres:$(SHARED_DB_PASSWORD)@shared-db.workspace-korczewski.svc.cluster.local:5432/postgres"
+        - name: keycloak
+          env:
+            - name: KC_URL
+              value: "http://keycloak.workspace-korczewski.svc.cluster.local:8080"
+            - name: KC_REALM
+              value: "master"
+            - name: OIDC_CLIENT_ID
+              value: "admin-cli"
+            - name: QUARKUS_HTTP_PORT
+              value: "8081"
+            - name: QUARKUS_HTTP_AUTH_PERMISSION_MCP_POLICY
+              value: "permit"
+            - name: QUARKUS_KEYCLOAK_ADMIN_CLIENT_USERNAME
+              value: "admin"
+            - name: QUARKUS_KEYCLOAK_ADMIN_CLIENT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: claude-code-secrets
+                  key: KEYCLOAK_ADMIN_PASSWORD
+            - name: QUARKUS_KEYCLOAK_ADMIN_CLIENT_GRANT_TYPE
+              value: "PASSWORD"

--- a/deploy/mcp/ingress.yaml
+++ b/deploy/mcp/ingress.yaml
@@ -1,10 +1,11 @@
-# MCP Gateway — dual-domain Traefik IngressRoute for all MCP servers
-# Access: https://mcp.mentolder.de/{service}/mcp  (deployed once, serves both brands)
-#         https://mcp.korczewski.de/{service}/mcp
+# MCP Gateway — Traefik IngressRoute for the mentolder MCP monolith.
+# Access: https://mcp.mentolder.de/{service}/mcp
 # Security: Token-based auth via mcp-auth-proxy (ForwardAuth)
 #
-# Requires DNS: mcp.mentolder.de  → 217.195.149.75
-#               mcp.korczewski.de → 217.195.149.75 (same cluster, same IP)
+# The korczewski MCP monolith runs in `workspace-korczewski` ns
+# (deploy/mcp-korczewski/) and serves https://mcp.korczewski.de.
+#
+# Requires DNS: mcp.mentolder.de → cluster ingress IP
 
 # ── ForwardAuth — validate MCP tokens via mcp-auth-proxy ────────
 apiVersion: traefik.io/v1alpha1
@@ -64,7 +65,7 @@ spec:
   routes:
     # ── Kubernetes MCP ────────────────────────────────────────────
     - kind: Rule
-      match: (Host(`mcp.mentolder.de`) || Host(`mcp.korczewski.de`)) && PathPrefix(`/kubernetes`)
+      match: Host(`mcp.mentolder.de`) && PathPrefix(`/kubernetes`)
       middlewares:
         - name: mcp-chain
       services:
@@ -73,7 +74,7 @@ spec:
 
     # ── PostgreSQL MCP ────────────────────────────────────────────
     - kind: Rule
-      match: (Host(`mcp.mentolder.de`) || Host(`mcp.korczewski.de`)) && PathPrefix(`/postgres`)
+      match: Host(`mcp.mentolder.de`) && PathPrefix(`/postgres`)
       middlewares:
         - name: mcp-chain
       services:
@@ -82,7 +83,7 @@ spec:
 
     # ── Keycloak MCP (SSE transport) ──────────────────────────────
     - kind: Rule
-      match: (Host(`mcp.mentolder.de`) || Host(`mcp.korczewski.de`)) && PathPrefix(`/keycloak`)
+      match: Host(`mcp.mentolder.de`) && PathPrefix(`/keycloak`)
       middlewares:
         - name: mcp-chain
       services:
@@ -91,7 +92,7 @@ spec:
 
     # ── Browser MCP (Playwright) ──────────────────────────────────
     - kind: Rule
-      match: (Host(`mcp.mentolder.de`) || Host(`mcp.korczewski.de`)) && PathPrefix(`/browser`)
+      match: Host(`mcp.mentolder.de`) && PathPrefix(`/browser`)
       middlewares:
         - name: mcp-chain
       services:
@@ -100,7 +101,7 @@ spec:
 
     # ── GitHub MCP ────────────────────────────────────────────────
     - kind: Rule
-      match: (Host(`mcp.mentolder.de`) || Host(`mcp.korczewski.de`)) && PathPrefix(`/github`)
+      match: Host(`mcp.mentolder.de`) && PathPrefix(`/github`)
       middlewares:
         - name: mcp-chain
       services:

--- a/website/src/data/test-inventory.json
+++ b/website/src/data/test-inventory.json
@@ -240,6 +240,12 @@
     "kind": "playwright"
   },
   {
+    "id": "E2E:wissensquellen",
+    "file": "tests/e2e/specs/wissensquellen.spec.ts",
+    "category": "E2E",
+    "kind": "playwright"
+  },
+  {
     "id": "FA-01",
     "file": "tests/local/FA-01.sh",
     "category": "FA",


### PR DESCRIPTION
## Summary
- Adds a second copy of `deploy/mcp/` pinned at `workspace-korczewski` so `mcp.korczewski.de` serves korczewski's own DB/Keycloak/etc. instead of mentolder's. The mentolder copy in `default` ns continues to serve `mcp.mentolder.de` unchanged.
- New overlay `deploy/mcp-korczewski/` retargets `DATABASE_URL`/`KC_URL` to `*.workspace-korczewski.svc`, scopes the Traefik IngressRoute to `mcp.korczewski.de` only, points ForwardAuth at the local auth-proxy, and pins `mcp-auth-proxy` to Hetzner CPs (per the CNI-partition gotcha).
- Strips `ClusterRole`/`ClusterRoleBinding` (mentolder-managed; binding already lists both namespace SAs as subjects) and the `claude-code-config` CM (owned by the `workspace-korczewski` ArgoCD App) from the overlay output to avoid clobbering / sync conflicts.
- `deploy/mcp/ingress.yaml`: drop `mcp.korczewski.de` from the mentolder IngressRoute matchers.
- `Taskfile.yml`: `mcp:deploy/status/logs/restart` plus `claude-code:rotate-tokens/setup/export/invite` and `gemini:setup` now switch target namespace by `ENV` (`workspace-korczewski` for korczewski, `default` otherwise).

## Test plan
- [x] `kustomize build deploy/mcp-korczewski/` produces correct namespace + URL substitutions, with cluster-scoped resources and `claude-code-config` stripped
- [x] `task mcp:deploy ENV=korczewski` rolls out cleanly: monolith pod 5/5 ready on `pk-hetzner-3`, auth-proxy 1/1 ready on `pk-hetzner-2`
- [x] `mcp.korczewski.de/{postgres,kubernetes,browser,github,keycloak}/mcp` returns 200 with cluster token (initialize handshake confirmed for postgres MCP)
- [x] Postgres MCP in `workspace-korczewski` connects to `shared-db.workspace-korczewski` (`10.42.3.89`); mentolder copy still hits `shared-db.workspace` (`10.42.1.47`)
- [x] `mcp.mentolder.de/postgres/mcp` still returns 200 after stripping `mcp.korczewski.de` from the mentolder IngressRoute
- [x] `ClusterRoleBinding/claude-code-agent` still has both namespace SAs as subjects after re-apply
- [ ] Follow-up by maintainer: `task claude-code:rotate-tokens ENV=korczewski` to replace the placeholder `mcp-tokens` secret

🤖 Generated with [Claude Code](https://claude.com/claude-code)