### PR TITLE
chore(korczewski): restore whisper deployment for korczewski-ha only

### DIFF
--- a/prod-korczewski/kustomization.yaml
+++ b/prod-korczewski/kustomization.yaml
@@ -7,6 +7,11 @@ resources:
   - ../prod
   - ddns-updater.yaml
   - netpol-cross-namespace.yaml
+  # Whisper (faster-whisper transcription) — korczewski-only.
+  # Removed from the shared base in #623 because mentolder couldn't
+  # spare the 2-CPU request after the cluster split. korczewski-ha
+  # has 3× 8-CPU nodes, so transcription stays alive here.
+  - whisper.yaml
 
 # Override realm with korczewski-specific config
 configMapGenerator:

--- a/prod-korczewski/whisper.yaml
+++ b/prod-korczewski/whisper.yaml
@@ -1,0 +1,65 @@
+# Whisper transcription service — korczewski only.
+# Mentolder doesn't have the spare CPU for the 2-core request, so this
+# manifest lives under prod-korczewski/ rather than the shared base.
+# korczewski-ha has 3× 8-CPU nodes, plenty of headroom.
+# faster-whisper-server is amd64-only; nodeSelector enforces that.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: whisper
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: whisper
+  template:
+    metadata:
+      labels:
+        app: whisper
+    spec:
+      nodeSelector:
+        kubernetes.io/arch: amd64
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: whisper
+          image: fedirz/faster-whisper-server@sha256:760e5e43d427dc6cfbbc4731934b908b7de9c7e6d5309c6a1f0c8c923a5b6030
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+          ports:
+            - containerPort: 8000
+          resources:
+            requests:
+              memory: "4Gi"
+              cpu: "2"
+            limits:
+              memory: "8Gi"
+              cpu: "8"
+          # Model download can take a few minutes on first start
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            failureThreshold: 30
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            periodSeconds: 30
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: whisper
+spec:
+  selector:
+    app: whisper
+  ports:
+    - port: 8000
+      targetPort: 8000


### PR DESCRIPTION
## Summary

PR #623 stripped whisper everywhere because mentolder couldn't schedule the 2-CPU / 4 GiB request after the cluster split. korczewski-ha (3× 8-CPU nodes, 16 GiB each) has plenty of headroom, so transcription stays alive there.

This PR puts whisper back as a **korczewski-only** overlay resource so it can't accidentally bleed into mentolder.

## Changes

- **New** `prod-korczewski/whisper.yaml` — combines the original base Deployment + Service with the prod CPU sizing (request=2, limit=8) and the amd64 nodeSelector inline. No separate patches needed; korczewski IS prod for this resource.
- **`prod-korczewski/kustomization.yaml`** — adds `whisper.yaml` to resources, with a comment explaining why it's korczewski-only.
- Base `k3d/` stays whisper-free. mentolder stays whisper-free.

## Note

`talk-transcriber` is still in the shared base, so it ships to both clusters. On korczewski it now has a real backend; on mentolder it stays running but its transcription calls fail (same state as since #623). Cleaning up the broken-on-mentolder side is a separate decision — flagging here for awareness.

## Test plan

- [x] `kubectl kustomize --load-restrictor=LoadRestrictionsNone prod-korczewski` → whisper Deployment + Service in `workspace-korczewski` (+2 kinds vs main = 162)
- [x] `kubectl kustomize --load-restrictor=LoadRestrictionsNone prod-mentolder` → zero whisper resources (unchanged from main)
- [x] Live whisper on korczewski-ha (pk-hetzner-8) currently 1/1 Running, `/health` returning 200 — this PR makes that survive the next `task workspace:deploy ENV=korczewski`
- [ ] After merge, run `task workspace:deploy ENV=korczewski` once and confirm whisper is preserved (no change in pod age)

🤖 Generated with [Claude Code](https://claude.com/claude-code)