### PR TITLE
feat(tickets/pr5): sunset legacy back-compat schema + migrate v_timeline reader

### DIFF
--- a/scripts/tickets-sunset.mjs
+++ b/scripts/tickets-sunset.mjs
@@ -20,6 +20,39 @@ async function exists(schema, name) {
   return r.rowCount > 0;
 }
 
+/**
+ * Returns the kind keyword for DROP statements based on pg_class.relkind:
+ *   'r' (ordinary table) | 'p' (partitioned table)        → 'TABLE'
+ *   'v' (view)                                            → 'VIEW'
+ *   'm' (materialized view)                               → 'MATERIALIZED VIEW'
+ * Returns null if the object doesn't exist.
+ *
+ * Required because the legacy bachelorprojekt back-compat scaffolding shipped
+ * inconsistently across clusters: on live shared-db several "expected views"
+ * are actually base TABLEs (requirements, features, bugs.bug_tickets), so a
+ * blind `DROP VIEW` errors out.
+ */
+async function relKind(schema, name) {
+  const r = await client.query(
+    `SELECT relkind FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace
+      WHERE n.nspname=$1 AND c.relname=$2`,
+    [schema, name]
+  );
+  if (r.rowCount === 0) return null;
+  switch (r.rows[0].relkind) {
+    case 'r': case 'p': return 'TABLE';
+    case 'v':           return 'VIEW';
+    case 'm':           return 'MATERIALIZED VIEW';
+    default:            return null;
+  }
+}
+
+async function dropAuto(schema, name, opts = '') {
+  const kind = await relKind(schema, name);
+  if (!kind) return; // already gone
+  await drop(kind, `${schema}.${name}`, opts);
+}
+
 async function isSchemaEmpty(schema) {
   const r = await client.query(
     `SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace
@@ -46,12 +79,10 @@ try {
   else        console.log('\n=== tickets-sunset APPLYING ===\n');
 
   // ── 1. bugs schema ─────────────────────────────────────────────────────────
-  if (await exists('bugs', 'bug_tickets')) {
-    await drop('VIEW', 'bugs.bug_tickets');
-  }
-  if (await exists('bugs', 'bug_ticket_comments_legacy')) {
-    await drop('TABLE', 'bugs.bug_ticket_comments_legacy');
-  }
+  // bugs.bug_tickets ships as a VIEW on most clusters but as a TABLE on the
+  // unified shared-db; dropAuto() picks the right keyword from pg_class.
+  await dropAuto('bugs', 'bug_tickets', 'CASCADE');
+  await dropAuto('bugs', 'bug_ticket_comments_legacy', 'CASCADE');
   // Drop the inbox_items FK that points at bugs.bug_tickets_legacy (leftover from migration)
   if (apply) {
     await client.query(`ALTER TABLE public.inbox_items DROP CONSTRAINT IF EXISTS inbox_items_bug_ticket_id_fkey`);
@@ -59,49 +90,36 @@ try {
   } else {
     console.log('  [dry-run] ALTER TABLE public.inbox_items DROP CONSTRAINT IF EXISTS inbox_items_bug_ticket_id_fkey');
   }
-  if (await exists('bugs', 'bug_tickets_legacy')) {
-    await drop('TABLE', 'bugs.bug_tickets_legacy');
-  }
+  await dropAuto('bugs', 'bug_tickets_legacy', 'CASCADE');
   if (apply && await isSchemaEmpty('bugs')) {
     await client.query('DROP SCHEMA IF EXISTS bugs');
     console.log('  DROPPED SCHEMA bugs');
   }
 
   // ── 2. bachelorprojekt schema ───────────────────────────────────────────────
-  // Drop views first (some depend on the legacy tables below)
-  for (const view of ['requirements', 'features', 'v_latest_tests', 'v_open_issues', 'v_pipeline_status', 'v_progress_summary', 'v_timeline']) {
-    if (await exists('bachelorprojekt', view)) {
-      await drop('VIEW', `bachelorprojekt.${view}`, 'CASCADE');
-    }
+  // On live shared-db: requirements, features, pipeline, test_results are
+  // base TABLEs; v_timeline + v_* are VIEWs. dropAuto() handles both.
+  // Drop views first (they may depend on the tables below).
+  for (const obj of ['v_timeline', 'v_latest_tests', 'v_open_issues', 'v_pipeline_status', 'v_progress_summary']) {
+    await dropAuto('bachelorprojekt', obj, 'CASCADE');
   }
-  if (await exists('bachelorprojekt', 'requirements_legacy')) {
-    await drop('TABLE', 'bachelorprojekt.requirements_legacy', 'CASCADE');
-  }
-  if (await exists('bachelorprojekt', 'pipeline')) {
-    await drop('TABLE', 'bachelorprojekt.pipeline', 'CASCADE');
-  }
-  if (await exists('bachelorprojekt', 'features_legacy')) {
-    await drop('TABLE', 'bachelorprojekt.features_legacy', 'CASCADE');
+  for (const obj of ['requirements', 'features', 'requirements_legacy', 'features_legacy', 'pipeline']) {
+    await dropAuto('bachelorprojekt', obj, 'CASCADE');
   }
   if (await exists('bachelorprojekt', 'test_results')) {
     const r = await client.query('SELECT count(*) AS n FROM bachelorprojekt.test_results');
     if (Number(r.rows[0].n) === 0) {
-      await drop('TABLE', 'bachelorprojekt.test_results', 'CASCADE');
+      await dropAuto('bachelorprojekt', 'test_results', 'CASCADE');
     } else {
       console.log(`  SKIP bachelorprojekt.test_results — ${r.rows[0].n} rows (historical record; drop manually)`);
     }
   }
 
   // ── 3. public schema — project* views + legacy tables ─────────────────────
-  for (const view of ['project_attachments', 'project_tasks', 'sub_projects', 'projects']) {
-    if (await exists('public', view)) {
-      await drop('VIEW', `public.${view}`, 'CASCADE');
-    }
-  }
-  for (const tbl of ['project_attachments_legacy', 'project_tasks_legacy', 'sub_projects_legacy', 'projects_legacy']) {
-    if (await exists('public', tbl)) {
-      await drop('TABLE', `public.${tbl}`, 'CASCADE');
-    }
+  for (const obj of ['project_attachments', 'project_tasks', 'sub_projects', 'projects',
+                     'project_attachments_legacy', 'project_tasks_legacy',
+                     'sub_projects_legacy', 'projects_legacy']) {
+    await dropAuto('public', obj, 'CASCADE');
   }
 
   console.log('');

--- a/tests/unit/tickets-migration.bats
+++ b/tests/unit/tickets-migration.bats
@@ -86,6 +86,8 @@ db_available() {
 }
 
 @test "runtime: every bugs.bug_tickets row produces one tickets.tickets row" {
+  psql "$PGURL" -c "SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace WHERE n.nspname='bugs' AND c.relname='bug_tickets'" 2>/dev/null | grep -q '1 row' || \
+    skip "bugs.bug_tickets does not exist (sunset already applied)"
   if ! db_available; then skip "No database available (set TRACKING_DB_URL)"; fi
   psql "$PGURL" -c "SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace WHERE n.nspname='bugs' AND c.relname='bug_tickets'" 2>/dev/null | grep -q '1 row' || \
     skip "bugs.bug_tickets does not exist (sunset already applied)"
@@ -96,6 +98,8 @@ db_available() {
 }
 
 @test "runtime: status mapping is correct (open->triage, resolved->done+fixed)" {
+  psql "$PGURL" -c "SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace WHERE n.nspname='bugs' AND c.relname='bug_tickets'" 2>/dev/null | grep -q '1 row' || \
+    skip "bugs.bug_tickets does not exist (sunset already applied)"
   if ! db_available; then skip "No database available (set TRACKING_DB_URL)"; fi
   psql "$PGURL" -c "SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace WHERE n.nspname='bugs' AND c.relname='bug_tickets'" 2>/dev/null | grep -q '1 row' || \
     skip "bugs.bug_tickets does not exist (sunset already applied)"
@@ -108,6 +112,8 @@ db_available() {
 }
 
 @test "runtime: archived rows map to status=archived resolution=fixed" {
+  psql "$PGURL" -c "SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace WHERE n.nspname='bugs' AND c.relname='bug_tickets'" 2>/dev/null | grep -q '1 row' || \
+    skip "bugs.bug_tickets does not exist (sunset already applied)"
   if ! db_available; then skip "No database available (set TRACKING_DB_URL)"; fi
   psql "$PGURL" -c "SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace WHERE n.nspname='bugs' AND c.relname='bug_tickets'" 2>/dev/null | grep -q '1 row' || \
     skip "bugs.bug_tickets does not exist (sunset already applied)"
@@ -117,6 +123,8 @@ db_available() {
 }
 
 @test "runtime: category tags are created (kind:bug for fehler rows)" {
+  psql "$PGURL" -c "SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace WHERE n.nspname='bugs' AND c.relname='bug_tickets'" 2>/dev/null | grep -q '1 row' || \
+    skip "bugs.bug_tickets does not exist (sunset already applied)"
   if ! db_available; then skip "No database available (set TRACKING_DB_URL)"; fi
   psql "$PGURL" -c "SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace WHERE n.nspname='bugs' AND c.relname='bug_tickets'" 2>/dev/null | grep -q '1 row' || \
     skip "bugs.bug_tickets does not exist (sunset already applied)"
@@ -132,6 +140,8 @@ db_available() {
 }
 
 @test "runtime: resolution_note rows produce a status_change comment" {
+  psql "$PGURL" -c "SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace WHERE n.nspname='bugs' AND c.relname='bug_tickets'" 2>/dev/null | grep -q '1 row' || \
+    skip "bugs.bug_tickets does not exist (sunset already applied)"
   if ! db_available; then skip "No database available (set TRACKING_DB_URL)"; fi
   psql "$PGURL" -c "SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace WHERE n.nspname='bugs' AND c.relname='bug_tickets'" 2>/dev/null | grep -q '1 row' || \
     skip "bugs.bug_tickets does not exist (sunset already applied)"
@@ -144,6 +154,8 @@ db_available() {
 }
 
 @test "runtime: idempotent — second run does not duplicate" {
+  psql "$PGURL" -c "SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace WHERE n.nspname='bugs' AND c.relname='bug_tickets'" 2>/dev/null | grep -q '1 row' || \
+    skip "bugs.bug_tickets does not exist (sunset already applied)"
   if ! db_available; then skip "No database available"; fi
   psql "$PGURL" -c "SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace WHERE n.nspname='bugs' AND c.relname='bug_tickets'" 2>/dev/null | grep -q '1 row' || \
     skip "bugs.bug_tickets does not exist (sunset already applied)"
@@ -155,6 +167,8 @@ db_available() {
 }
 
 @test "runtime: idempotent — second run reports all rows as skipped" {
+  psql "$PGURL" -c "SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace WHERE n.nspname='bugs' AND c.relname='bug_tickets'" 2>/dev/null | grep -q '1 row' || \
+    skip "bugs.bug_tickets does not exist (sunset already applied)"
   if ! db_available; then skip "No database available (set TRACKING_DB_URL)"; fi
   psql "$PGURL" -c "SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace WHERE n.nspname='bugs' AND c.relname='bug_tickets'" 2>/dev/null | grep -q '1 row' || \
     skip "bugs.bug_tickets does not exist (sunset already applied)"
@@ -165,6 +179,8 @@ db_available() {
 }
 
 @test "runtime: dry-run (default) makes no changes to tickets table" {
+  psql "$PGURL" -c "SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace WHERE n.nspname='bugs' AND c.relname='bug_tickets'" 2>/dev/null | grep -q '1 row' || \
+    skip "bugs.bug_tickets does not exist (sunset already applied)"
   if ! db_available; then skip "No database available (set TRACKING_DB_URL)"; fi
   psql "$PGURL" -c "SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace WHERE n.nspname='bugs' AND c.relname='bug_tickets'" 2>/dev/null | grep -q '1 row' || \
     skip "bugs.bug_tickets does not exist (sunset already applied)"
@@ -175,6 +191,8 @@ db_available() {
 }
 
 @test "runtime: dry-run output JSON has mode=dry-run" {
+  psql "$PGURL" -c "SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace WHERE n.nspname='bugs' AND c.relname='bug_tickets'" 2>/dev/null | grep -q '1 row' || \
+    skip "bugs.bug_tickets does not exist (sunset already applied)"
   if ! db_available; then skip "No database available (set TRACKING_DB_URL)"; fi
   psql "$PGURL" -c "SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace WHERE n.nspname='bugs' AND c.relname='bug_tickets'" 2>/dev/null | grep -q '1 row' || \
     skip "bugs.bug_tickets does not exist (sunset already applied)"
@@ -188,6 +206,8 @@ print('OK')
 }
 
 @test "runtime: comments are copied" {
+  psql "$PGURL" -c "SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace WHERE n.nspname='bugs' AND c.relname='bug_tickets'" 2>/dev/null | grep -q '1 row' || \
+    skip "bugs.bug_tickets does not exist (sunset already applied)"
   if ! psql "$PGURL" -c "SELECT 1" >/dev/null 2>&1; then skip "No database available"; fi
   psql "$PGURL" -c "SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace WHERE n.nspname='bugs' AND c.relname='bug_tickets'" 2>/dev/null | grep -q '1 row' || \
     skip "bugs.bug_tickets does not exist (sunset already applied)"
@@ -201,6 +221,8 @@ print('OK')
 }
 
 @test "runtime: fixed_in_pr → ticket_links" {
+  psql "$PGURL" -c "SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace WHERE n.nspname='bugs' AND c.relname='bug_tickets'" 2>/dev/null | grep -q '1 row' || \
+    skip "bugs.bug_tickets does not exist (sunset already applied)"
   if ! psql "$PGURL" -c "SELECT 1" >/dev/null 2>&1; then skip "No database available"; fi
   psql "$PGURL" -c "SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace WHERE n.nspname='bugs' AND c.relname='bug_tickets'" 2>/dev/null | grep -q '1 row' || \
     skip "bugs.bug_tickets does not exist (sunset already applied)"
@@ -226,6 +248,8 @@ print('OK')
 }
 
 @test "runtime: bugs.bug_tickets is a view after migration" {
+  psql "$PGURL" -c "SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace WHERE n.nspname='bugs' AND c.relname='bug_tickets'" 2>/dev/null | grep -q '1 row' || \
+    skip "bugs.bug_tickets does not exist (sunset already applied)"
   if ! psql "$PGURL" -c "SELECT 1" >/dev/null 2>&1; then skip "No database available"; fi
   psql "$PGURL" -c "SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace WHERE n.nspname='bugs' AND c.relname='bug_tickets'" 2>/dev/null | grep -q '1 row' || \
     skip "bugs.bug_tickets does not exist (sunset already applied)"
@@ -238,6 +262,8 @@ print('OK')
 }
 
 @test "runtime: legacy fixed_in_pr JOIN still works against the view" {
+  psql "$PGURL" -c "SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace WHERE n.nspname='bugs' AND c.relname='bug_tickets'" 2>/dev/null | grep -q '1 row' || \
+    skip "bugs.bug_tickets does not exist (sunset already applied)"
   if ! psql "$PGURL" -c "SELECT 1" >/dev/null 2>&1; then skip "No database available"; fi
   psql "$PGURL" -c "SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace WHERE n.nspname='bugs' AND c.relname='bug_tickets'" 2>/dev/null | grep -q '1 row' || \
     skip "bugs.bug_tickets does not exist (sunset already applied)"
@@ -250,6 +276,8 @@ print('OK')
 }
 
 @test "runtime: re-running migration is idempotent (view not corrupted)" {
+  psql "$PGURL" -c "SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace WHERE n.nspname='bugs' AND c.relname='bug_tickets'" 2>/dev/null | grep -q '1 row' || \
+    skip "bugs.bug_tickets does not exist (sunset already applied)"
   if ! psql "$PGURL" -c "SELECT 1" >/dev/null 2>&1; then skip "No database available"; fi
   psql "$PGURL" -c "SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace WHERE n.nspname='bugs' AND c.relname='bug_tickets'" 2>/dev/null | grep -q '1 row' || \
     skip "bugs.bug_tickets does not exist (sunset already applied)"

--- a/tests/unit/tickets-sunset.bats
+++ b/tests/unit/tickets-sunset.bats
@@ -38,6 +38,11 @@ setup() {
   grep -q "process.argv.includes('--apply')" "${PROJECT_DIR}/scripts/tickets-sunset.mjs"
 }
 
+@test "static: sunset script picks DROP kind from pg_class.relkind" {
+  # Required so DROP works whether the legacy object is a base TABLE or VIEW.
+  grep -q 'relKind\|relkind' "${PROJECT_DIR}/scripts/tickets-sunset.mjs"
+}
+
 # ── Runtime checks ─────────────────────────────────────────────────
 
 object_gone() {
@@ -57,8 +62,20 @@ object_gone() {
   object_gone bugs bug_tickets_legacy
 }
 
-@test "runtime: bachelorprojekt.requirements view is gone" {
+@test "runtime: bachelorprojekt.requirements is gone (was view or table)" {
   object_gone bachelorprojekt requirements
+}
+
+@test "runtime: bachelorprojekt.features is gone" {
+  object_gone bachelorprojekt features
+}
+
+@test "runtime: bachelorprojekt.v_timeline view is gone" {
+  object_gone bachelorprojekt v_timeline
+}
+
+@test "runtime: bachelorprojekt.pipeline table is gone" {
+  object_gone bachelorprojekt pipeline
 }
 
 @test "runtime: public.projects view is gone" {

--- a/website/src/lib/website-db.test.ts
+++ b/website/src/lib/website-db.test.ts
@@ -1,0 +1,80 @@
+// PR5: confirm listTimeline reads from tickets.pr_events (the source of
+// truth after the bachelorprojekt.v_timeline sunset).
+//
+// DB-backed: skipped unless DATABASE_URL/SESSIONS_DATABASE_URL is set.
+import { describe, it, expect, beforeAll } from 'vitest';
+import { listTimeline, pool } from './website-db';
+
+const dbAvailable = !!(process.env.DATABASE_URL || process.env.SESSIONS_DATABASE_URL);
+
+describe.skipIf(!dbAvailable)('listTimeline (DB-backed)', () => {
+  beforeAll(async () => {
+    // Ensure the source-of-truth table exists. tickets.pr_events is created
+    // by the unified ticketing schema migration; if running in isolation we
+    // create a minimal version sufficient for these tests.
+    await pool.query(`CREATE SCHEMA IF NOT EXISTS tickets`);
+    await pool.query(`
+      CREATE TABLE IF NOT EXISTS tickets.pr_events (
+        pr_number   integer PRIMARY KEY,
+        title       text NOT NULL,
+        description text,
+        category    text NOT NULL,
+        scope       text,
+        brand       text,
+        merged_at   timestamptz NOT NULL,
+        merged_by   text,
+        status      text NOT NULL DEFAULT 'shipped',
+        created_at  timestamptz NOT NULL DEFAULT now()
+      )`);
+    await pool.query(`
+      CREATE TABLE IF NOT EXISTS tickets.ticket_links (
+        ticket_id  text NOT NULL,
+        kind       text NOT NULL,
+        pr_number  integer
+      )`);
+  });
+
+  it('returns rows shaped like TimelineRow from tickets.pr_events', async () => {
+    const probePr = 999_999_001;
+    await pool.query(
+      `INSERT INTO tickets.pr_events (pr_number, title, description, category, scope, brand, merged_at)
+       VALUES ($1, $2, $3, $4, $5, $6, $7)
+       ON CONFLICT (pr_number) DO UPDATE SET title=EXCLUDED.title`,
+      [probePr, 'PR5 listTimeline probe', 'desc', 'feat', 'tickets', 'mentolder', '2026-05-09T12:00:00Z'],
+    );
+
+    const rows = await listTimeline({ limit: 50 });
+    const probe = rows.find(r => r.pr_number === probePr);
+    expect(probe).toBeDefined();
+    expect(probe!.title).toBe('PR5 listTimeline probe');
+    expect(probe!.category).toBe('feat');
+    expect(probe!.brand).toBe('mentolder');
+    expect(probe!.day).toBe('2026-05-09');
+    // Requirement linkage no longer applies — both fields are NULL.
+    expect(probe!.requirement_id).toBeNull();
+    expect(probe!.requirement_name).toBeNull();
+    expect(typeof probe!.bugs_fixed).toBe('number');
+
+    await pool.query(`DELETE FROM tickets.pr_events WHERE pr_number = $1`, [probePr]);
+  });
+
+  it('filters by brand (returns null-brand rows + matching brand)', async () => {
+    const ids = [999_999_101, 999_999_102, 999_999_103];
+    await pool.query(`DELETE FROM tickets.pr_events WHERE pr_number = ANY($1)`, [ids]);
+    await pool.query(
+      `INSERT INTO tickets.pr_events (pr_number, title, category, brand, merged_at) VALUES
+       ($1, 'mentolder-only', 'feat', 'mentolder', now()),
+       ($2, 'korczewski-only', 'feat', 'korczewski', now()),
+       ($3, 'no-brand', 'feat', NULL, now())`,
+      ids,
+    );
+
+    const mentolder = await listTimeline({ brand: 'mentolder', limit: 100 });
+    const titles = mentolder.map(r => r.title);
+    expect(titles).toContain('mentolder-only');
+    expect(titles).toContain('no-brand');
+    expect(titles).not.toContain('korczewski-only');
+
+    await pool.query(`DELETE FROM tickets.pr_events WHERE pr_number = ANY($1)`, [ids]);
+  });
+});

--- a/website/src/lib/website-db.ts
+++ b/website/src/lib/website-db.ts
@@ -28,19 +28,10 @@ function nodeLookup(
 const poolConfig = { connectionString: MEETINGS_DB_URL, lookup: nodeLookup } as unknown as import('pg').PoolConfig;
 export const pool = new Pool(poolConfig);
 
-// ── Tracking DB (bachelorprojekt schema) ────────────────────────────────────
-
-let trackingPool: import('pg').Pool | null = null;
-
-function getTrackingPool(): import('pg').Pool {
-  if (trackingPool) return trackingPool;
-  const url = process.env.TRACKING_DB_URL
-    || process.env.SESSIONS_DATABASE_URL
-    || process.env.DATABASE_URL?.replace(/\/[^/?]+(\?|$)/, '/postgres$1');
-  if (!url) throw new Error('TRACKING_DB_URL not set');
-  trackingPool = new Pool({ connectionString: url, lookup: nodeLookup, max: 4 } as unknown as import('pg').PoolConfig);
-  return trackingPool;
-}
+// ── Timeline (PR5: reads from tickets.pr_events on the same DB) ─────────────
+// Historical note: an earlier implementation used a separate tracking pool
+// against bachelorprojekt.v_timeline. That view + its source tables were
+// sunset in PR5; we now read PR activity from tickets.pr_events on `pool`.
 
 export type TimelineRow = {
   id: number;
@@ -65,7 +56,11 @@ export async function listTimeline(opts: {
   const limit = Math.min(opts.limit ?? 20, 100);
   const offset = opts.offset ?? 0;
 
-  const tPool = getTrackingPool();
+  // Read from tickets.pr_events (the unified ticketing source of truth).
+  // PR5 migration: bachelorprojekt.v_timeline + features/requirements tables
+  // are sunset; tickets.pr_events carries all PR activity going forward.
+  // Requirement linkage no longer applies (no rows of type='requirement' exist
+  // in tickets.tickets), so requirement_id/_name are NULL here.
   const where: string[] = [];
   const params: unknown[] = [];
   if (opts.category) { params.push(opts.category); where.push(`category = $${params.length}`); }
@@ -73,10 +68,14 @@ export async function listTimeline(opts: {
   const whereSql = where.length ? `WHERE ${where.join(' AND ')}` : '';
   params.push(limit, offset);
 
-  const rows = (await tPool.query(
-    `SELECT id, to_char(day,'YYYY-MM-DD') AS day, pr_number, title, description,
-            category, scope, brand, requirement_id, requirement_name
-       FROM bachelorprojekt.v_timeline
+  const rows = (await pool.query(
+    `SELECT pr_number AS id,
+            to_char(merged_at AT TIME ZONE 'UTC', 'YYYY-MM-DD') AS day,
+            pr_number, title, description,
+            category, scope, brand,
+            NULL::text AS requirement_id,
+            NULL::text AS requirement_name
+       FROM tickets.pr_events
        ${whereSql}
       ORDER BY merged_at DESC
       LIMIT $${params.length - 1} OFFSET $${params.length}`,


### PR DESCRIPTION
## Summary

Final piece of the unified-ticketing migration arc. Retires the bachelorprojekt back-compat scaffolding (views + base tables) and points the homepage timeline at the source of truth, `tickets.pr_events`.

## What changed

- **`website/src/lib/website-db.ts`** — `listTimeline()` now reads `tickets.pr_events` instead of the soon-dropped `bachelorprojekt.v_timeline`. Removed the orphan `trackingPool`. Requirement linkage no longer applies (no `type='requirement'` rows), so `requirement_id` / `requirement_name` return `NULL`.
- **`scripts/tickets-sunset.mjs`** — Added a `dropAuto()` helper that resolves the right `DROP TABLE` / `DROP VIEW` keyword from `pg_class.relkind`. Required because on live shared-db `bachelorprojekt.{requirements,features}` and `bugs.bug_tickets` ship as base TABLEs, not VIEWs (the original script's blind `DROP VIEW` would error). Also added `v_timeline` + the four `v_*` status views to the drop list.
- **`tests/unit/tickets-sunset.bats`** — Extra asserts for `features`, `v_timeline`, `pipeline`; static check confirming the script picks the DROP keyword from `pg_class.relkind`.
- **`website/src/lib/website-db.test.ts`** *(new)* — Vitest for the migrated reader, including brand filtering. DB-backed; skipped when `DATABASE_URL` is unset.

## Sunset audit (live shared-db, dry-run)

```
bugs.bug_tickets (table)                 → DROP TABLE CASCADE
bachelorprojekt.v_timeline (view)        → DROP VIEW CASCADE
bachelorprojekt.v_{latest_tests,open_issues,pipeline_status,progress_summary} → DROP VIEW CASCADE
bachelorprojekt.{requirements,features,pipeline,test_results} (tables) → DROP TABLE CASCADE
inbox_items_bug_ticket_id_fkey            → ALTER TABLE DROP CONSTRAINT
```

All affected tables are 0 rows except `bugs.bug_tickets` (2 historical rows already migrated into `tickets.tickets`). Audit treats those rows' stale `pg_stat_user_tables` UPDATE counter as historic, not active write traffic.

## Test plan

- [x] `task test:unit` — 54 BATS passing, 0 failing
- [x] `cd website && pnpm test` (vitest) — 284 passing, 91 skipped (DB-backed)
- [x] `tsc --noEmit` clean (no new errors)
- [x] Sunset script dry-run executed against live shared-db; correctly picks TABLE vs VIEW
- [ ] After merge: `task website:deploy ENV=mentolder`, then `ENV=korczewski`
- [ ] Run sunset script `--apply` against live; verify schemas gone via `pg_class`
- [ ] Smoke `/api/timeline` on both brands

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>