### PR TITLE
fix(tickets): defensive ADD COLUMN for source_test_{assignment,question}_id in initTicketsSchema

### DIFF
--- a/website/src/lib/tickets-db.ts
+++ b/website/src/lib/tickets-db.ts
@@ -57,14 +57,19 @@ export async function initTicketsSchema(): Promise<void> {
   await pool.query(`ALTER TABLE tickets.tickets ADD COLUMN IF NOT EXISTS notes TEXT`);
 
   // Test-run linkback columns. Mirrored in `systemtest/db.ts` (the canonical
-  // owner — that module also installs FKs to test_runs/test_results once those
-  // tables exist). We add the columns here too so a tickets-only init path
-  // doesn't break the failure-bridge: the FKs are deferred to ensureSystemtestSchema.
+  // owner — that module also installs FKs to test_runs/test_results /
+  // questionnaire_questions once those tables exist). We add the columns here
+  // too so a tickets-only init path doesn't break: the unique indexes below
+  // reference source_test_question_id and source_test_run_id+source_test_id,
+  // and on a fresh DB ensureSystemtestSchema has not yet run. The FKs are
+  // deferred to ensureSystemtestSchema.
   await pool.query(`
     ALTER TABLE tickets.tickets
-      ADD COLUMN IF NOT EXISTS source_test_run_id    TEXT,
-      ADD COLUMN IF NOT EXISTS source_test_result_id BIGINT,
-      ADD COLUMN IF NOT EXISTS source_test_id        TEXT
+      ADD COLUMN IF NOT EXISTS source_test_assignment_id UUID,
+      ADD COLUMN IF NOT EXISTS source_test_question_id   UUID,
+      ADD COLUMN IF NOT EXISTS source_test_run_id        TEXT,
+      ADD COLUMN IF NOT EXISTS source_test_result_id     BIGINT,
+      ADD COLUMN IF NOT EXISTS source_test_id            TEXT
   `);
 
   await pool.query(`CREATE INDEX IF NOT EXISTS tickets_status_idx ON tickets.tickets (status) WHERE status NOT IN ('done','archived')`);


### PR DESCRIPTION
## Summary
- `initTicketsSchema` creates a UNIQUE INDEX on `source_test_question_id` at L84-88, but the column is canonically owned by `ensureSystemtestSchema` in `systemtest/db.ts`.
- On a fresh DB where systemtest schema init hasn't yet run, the index creation throws (`column does not exist`), aborting the rest of `initTicketsSchema`. tickets.tickets ends up created, but ticket_links / ticket_activity / ticket_comments / ticket_attachments / ticket_watchers / tags / ticket_tags / pr_events / counters all silently fail.
- Discovered while bringing up korczewski-ha (PRs #621/#622). `/api/timeline` returned `fetch_failed` because `tickets.ticket_links` was missing.

## Fix
Add `source_test_assignment_id UUID` + `source_test_question_id UUID` to the existing defensive `ADD COLUMN IF NOT EXISTS` ALTER. Idempotent — has no effect on clusters where `ensureSystemtestSchema` already ran. The FK to `questionnaire_questions` is unchanged (still owned by ensureSystemtestSchema, applied later when questionnaire_questions exists).

## Test plan
- [ ] After merge, `task website:deploy ENV=korczewski` causes the website pod on korczewski-ha to cold-start, run initTicketsSchema, and create the 7 missing tables.
- [ ] `kubectl --context korczewski-ha -n workspace-korczewski exec deploy/shared-db -- psql -U postgres -d website -c "\dt tickets.*"` should list 10 tables.
- [ ] `curl https://web.korczewski.de/api/timeline?limit=1` should return `{"rows":[…]}` instead of `{"rows":[],"error":"fetch_failed"}`.
- [ ] `task website:deploy ENV=mentolder` should be a no-op for schema (mentolder already has all columns).

🤖 Generated with [Claude Code](https://claude.com/claude-code)