### PR TITLE
chore: mark unified-ticketing PR1-PR5 plans as completed

### DIFF
--- a/docs/superpowers/plans/2026-05-08-unified-ticketing-pr1.md
+++ b/docs/superpowers/plans/2026-05-08-unified-ticketing-pr1.md
@@ -1,8 +1,8 @@
 ---
 title: Unified Ticketing PR1 — Schema, Bug Migration, Close-Mail Fix
 domains: [website, db]
-status: active
-pr_number: null
+status: completed
+pr_number: 562
 ---
 
 # Unified Ticketing PR1 — Schema, Bug Migration, Close-Mail Fix

--- a/docs/superpowers/plans/2026-05-08-unified-ticketing-pr2.md
+++ b/docs/superpowers/plans/2026-05-08-unified-ticketing-pr2.md
@@ -1,8 +1,8 @@
 ---
 title: Unified Ticketing PR2/5 — features + requirements migration, PR ledger rename
 domains: [website, db]
-status: active
-pr_number: null
+status: completed
+pr_number: 565
 ---
 
 # Unified Ticketing PR2/5 — features + requirements migration, PR ledger rename

--- a/docs/superpowers/plans/2026-05-08-unified-ticketing-pr3.md
+++ b/docs/superpowers/plans/2026-05-08-unified-ticketing-pr3.md
@@ -1,8 +1,8 @@
 ---
 title: Unified Ticketing PR3/5 — projects/sub_projects/tasks migration
 domains: [website, db]
-status: active
-pr_number: null
+status: completed
+pr_number: 567
 ---
 
 # Unified Ticketing PR3/5 — projects/sub_projects/tasks migration

--- a/docs/superpowers/plans/2026-05-08-unified-ticketing-pr4.md
+++ b/docs/superpowers/plans/2026-05-08-unified-ticketing-pr4.md
@@ -1,8 +1,8 @@
 ---
 title: Unified Ticketing PR4/5 — `/admin/tickets` UI + admin API
 domains: [website, db]
-status: active
-pr_number: null
+status: completed
+pr_number: 571
 ---
 
 # Unified Ticketing PR4/5 — `/admin/tickets` UI + admin API

--- a/docs/superpowers/plans/2026-05-08-unified-ticketing-pr5.md
+++ b/docs/superpowers/plans/2026-05-08-unified-ticketing-pr5.md
@@ -1,8 +1,8 @@
 ---
 title: Unified Ticketing PR5 — Sunset Legacy Tables
 domains: [website, db]
-status: active
-pr_number: null
+status: completed
+pr_number: 628
 ---
 
 # Unified Ticketing PR5 — Sunset Legacy Tables


### PR DESCRIPTION
## Summary
- Flip `status: active` -> `status: completed` for all 5 unified-ticketing plans.
- Link each to its merged PR: PR1=#562, PR2=#565, PR3=#567, PR4=#571, PR5=#628.

Now that the korczewski-ha cluster has the full `tickets.*` schema and the legacy `bachelorprojekt.*` / `bugs.bug_tickets` / `public.project*` objects are sunset on both clusters, the arc is complete on every brand.

## Test plan
- [x] `git diff --stat` shows 5 files, 10/10 line edits.
- [x] No content changes outside the YAML frontmatter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)