### PR TITLE
chore: address maintenance findings 2026-05-09 (#626)

### DIFF
--- a/prod-korczewski/ddns-updater.yaml
+++ b/prod-korczewski/ddns-updater.yaml
@@ -25,8 +25,15 @@ spec:
           restartPolicy: OnFailure
           containers:
             - name: updater
-              image: curlimages/curl:latest
+              image: curlimages/curl:8.7.1
               imagePullPolicy: IfNotPresent
+              resources:
+                requests:
+                  cpu: "10m"
+                  memory: "32Mi"
+                limits:
+                  cpu: "200m"
+                  memory: "64Mi"
               env:
                 - name: IPV64_API_KEY
                   valueFrom:

--- a/prod-korczewski/talk-transcriber.yaml
+++ b/prod-korczewski/talk-transcriber.yaml
@@ -35,8 +35,8 @@ spec:
           type: RuntimeDefault
       containers:
         - name: transcriber
-          image: ghcr.io/paddione/talk-transcriber:latest
-          imagePullPolicy: Always
+          image: ghcr.io/paddione/talk-transcriber@sha256:8ac351f10e4b8fbc121fb57f21088d5b5359524e7f909760444b283ea3ace55f
+          imagePullPolicy: IfNotPresent
           env:
             - name: NC_DOMAIN
               value: "files.${PROD_DOMAIN}"


### PR DESCRIPTION
Closes #626.

## Summary
- Pin `prod-korczewski/ddns-updater.yaml` curl image from `:latest` to `:8.7.1` (matches existing pins elsewhere in the repo) and add `resources.requests`/`limits` (`10m/32Mi` requests, `200m/64Mi` limits per the issue's recommendation).
- Pin `prod-korczewski/talk-transcriber.yaml` from `:latest` to digest `sha256:8ac351f1…` (digest currently running on korczewski-ha) + switch `imagePullPolicy: Always` → `IfNotPresent` since digests are immutable.

## Test plan
- [ ] `kubectl kustomize prod-korczewski/ --load-restrictor=LoadRestrictionsNone` builds clean (verified locally — `curlimages/curl:8.7.1` and `talk-transcriber@sha256:8ac351f1…` appear in output).
- [ ] Next ArgoCD sync on korczewski-ha applies the digest pin without restarting the pod (image SHA is unchanged from running state).
- [ ] DDNS cron's first run after rollout creates a pod with `Guaranteed`/`Burstable` QoS class instead of `BestEffort`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)