### PR TITLE
fix(questionnaire): hide dismissed assignments from widget + admin panel

### DIFF
--- a/website/src/components/ChatWidget.svelte
+++ b/website/src/components/ChatWidget.svelte
@@ -2,7 +2,7 @@
   type Assignment = {
     id: string;
     template_title: string;
-    status: 'pending' | 'in_progress' | 'submitted' | 'reviewed';
+    status: 'pending' | 'in_progress' | 'submitted' | 'reviewed' | 'dismissed' | 'archived';
     assigned_at: string;
     submitted_at: string | null;
   };
@@ -68,7 +68,10 @@
     const res = await fetch('/api/portal/questionnaires');
     if (res.ok) {
       const data = await res.json() as Assignment[];
-      assignments = Array.isArray(data) ? data : [];
+      // Defense-in-depth: API already filters, but never show dismissed/archived in widget.
+      assignments = Array.isArray(data)
+        ? data.filter(a => a.status !== 'dismissed' && a.status !== 'archived')
+        : [];
     }
   }
 

--- a/website/src/components/admin/ClientQuestionnairesPanel.svelte
+++ b/website/src/components/admin/ClientQuestionnairesPanel.svelte
@@ -13,8 +13,8 @@
   let assignMsg = $state('');
   let archivedVisible = $state(false);
 
-  const active = $derived(assignments.filter(a => a.status !== 'archived'));
-  const archived = $derived(assignments.filter(a => a.status === 'archived'));
+  const active = $derived(assignments.filter(a => a.status !== 'archived' && a.status !== 'dismissed'));
+  const archived = $derived(assignments.filter(a => a.status === 'archived' || a.status === 'dismissed'));
 
   async function loadData() {
     const [aRes, tRes] = await Promise.all([
@@ -129,7 +129,7 @@
       class="mt-3 text-xs text-muted hover:text-light flex items-center gap-1"
     >
       <span>{archivedVisible ? '▾' : '▸'}</span>
-      Archiv anzeigen ({archived.length})
+      Archiv & Abgelehnte anzeigen ({archived.length})
     </button>
     {#if archivedVisible}
       <div class="flex flex-col gap-2 mt-2 opacity-60">
@@ -146,7 +146,9 @@
               <span class={`px-2 py-0.5 rounded border text-xs ${statusBadge(a.status)}`}>
                 {statusLabel(a.status)}
               </span>
-              <a href={`/admin/fragebogen/${a.id}`} class="text-xs text-gold hover:underline">Auswertung →</a>
+              {#if a.submitted_at}
+                <a href={`/admin/fragebogen/${a.id}`} class="text-xs text-gold hover:underline">Auswertung →</a>
+              {/if}
             </div>
           </div>
         {/each}

--- a/website/src/pages/api/portal/questionnaires/index.ts
+++ b/website/src/pages/api/portal/questionnaires/index.ts
@@ -11,5 +11,8 @@ export const GET: APIRoute = async ({ request }) => {
   if (!customer) return new Response(JSON.stringify([]), { headers: { 'Content-Type': 'application/json' } });
 
   const assignments = await listQAssignmentsForCustomer(customer.id);
-  return new Response(JSON.stringify(assignments), { headers: { 'Content-Type': 'application/json' } });
+  // Chat widget only — hide dismissed/archived so they don't reappear after reload.
+  // FragebogenSection.astro receives assignments directly (server-side props), not from this endpoint.
+  const active = assignments.filter(a => a.status !== 'dismissed' && a.status !== 'archived');
+  return new Response(JSON.stringify(active), { headers: { 'Content-Type': 'application/json' } });
 };


### PR DESCRIPTION
## Summary

Two related bugs around dismissed Fragebögen — the user could no longer get rid of them:

- **Widget:** `/api/portal/questionnaires` returned every assignment regardless of status; the chat widget then re-rendered dismissed items as fresh "Ausstehend" because `statusLabel()` falls through to that label for unknown statuses. The local-mutation `filter` on dismiss was wiped on every reload.
- **Admin Client panel:** The `active` filter only excluded `'archived'`, so `dismissed` assignments stayed in the active list forever as a red "Abgelehnt" badge with no way to clean them up.

## Changes

- `website/src/pages/api/portal/questionnaires/index.ts` — filter out `dismissed` and `archived` (this endpoint is only consumed by `ChatWidget.svelte`; `FragebogenSection.astro` receives assignments via server-side props and is unaffected).
- `website/src/components/ChatWidget.svelte` — expand `Assignment.status` type to honestly include `'dismissed' | 'archived'`, and defense-in-depth filter in `loadAssignments()`.
- `website/src/components/admin/ClientQuestionnairesPanel.svelte` — `active` excludes both `archived` and `dismissed`; `archived` collapsible now contains both (relabel: "Archiv & Abgelehnte anzeigen"); hide the "Auswertung →" link when there's no `submitted_at` (dismissed assignments have nothing to evaluate).

The dismiss API route, dismiss DB function, and `QuestionnaireWizard.svelte` are untouched per the bug report constraints. The archive flow (active plan) is also untouched.

## Test plan

- [x] `cd website && npm test` — all questionnaire-related tests pass; pre-existing failures (calendar slots, register UTF-8, reminders) are unrelated.
- [x] `cd website && npm run build` — type-check + Astro build green.
- [x] `task feature:website` — deployed to mentolder (workspace ns) and korczewski-ha (workspace-korczewski ns).
- [x] `curl https://web.mentolder.de/api/portal/questionnaires` and korczewski twin both return 401 without session (route alive on both clusters).
- [ ] User-facing smoke: open chat widget on web.mentolder.de, dismiss a Fragebogen, refresh — it should not reappear. In `/admin/clients/<id>` the dismissed entries should now live under "Archiv & Abgelehnte anzeigen".

🤖 Generated with [Claude Code](https://claude.com/claude-code)