### PR TITLE
fix(mcp): grant business role full MCP access + pin auth-proxy to Hetzner

### DIFF
--- a/deploy/mcp-korczewski/kustomization.yaml
+++ b/deploy/mcp-korczewski/kustomization.yaml
@@ -57,20 +57,3 @@ patches:
 
   # ── Ingress: only mcp.korczewski.de + ForwardAuth in this namespace ──
   - path: patch-ingress.yaml
-
-  # ── Pin auth-proxy to Hetzner CPs (CNI partition; CoreDNS lives there) ──
-  - target:
-      kind: Deployment
-      name: mcp-auth-proxy
-    patch: |-
-      - op: add
-        path: /spec/template/spec/affinity
-        value:
-          nodeAffinity:
-            requiredDuringSchedulingIgnoredDuringExecution:
-              nodeSelectorTerms:
-                - matchExpressions:
-                    - key: node-location
-                      operator: In
-                      values:
-                        - hetzner

--- a/deploy/mcp/mcp-auth-proxy.yaml
+++ b/deploy/mcp/mcp-auth-proxy.yaml
@@ -56,18 +56,7 @@ data:
             return 200 '{"status":"ok","role":"cluster"}\n';
           }
 
-          # Business role: check allowed paths
-          set $uri_path $http_x_forwarded_uri;
-          set $allowed "";
-
-          if ($uri_path ~ "^/nextcloud(/|$)") {
-            set $allowed "yes";
-          }
-
-          if ($allowed != "yes") {
-            return 403 '{"error":"forbidden: business role cannot access this path"}\n';
-          }
-
+          # Business role: full access to all gateway-routed MCP servers.
           add_header X-MCP-Role "business" always;
           return 200 '{"status":"ok","role":"business"}\n';
         }
@@ -88,6 +77,17 @@ spec:
       labels:
         app: mcp-auth-proxy
     spec:
+      # Pin to Hetzner CPs: home workers are unreachable from Traefik over the
+      # WireGuard double-hop (Flannel VXLAN partition). Forward-auth would hang.
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node-location
+                    operator: In
+                    values:
+                      - hetzner
       containers:
         - name: nginx
           image: nginx:1.27-alpine-perl


### PR DESCRIPTION
## Summary
- Business token previously only matched `/nextcloud` — but the MCP gateway routes 5 services (`kubernetes`, `postgres`, `keycloak`, `browser`, `github`) and never had a `/nextcloud` route. Result: `BUSINESS_TOKEN` returned 403 on every real endpoint.
- Drop the path allowlist for the business role so it equals cluster across the 5 actually-served MCP servers. The two roles still exist as distinct rotation slots, but functionally have the same authorization surface (since we don't have nextcloud MCP).
- Pin `mcp-auth-proxy` to Hetzner CPs via `nodeAffinity`. Without it, a rollout-restart can schedule the pod on a home worker (k3s-1/2/3, k3w-1/2/3) where the WireGuard double-hop + Flannel VXLAN partition break pod-to-pod from Traefik. forward-auth then hangs and every gated request times out.
- Remove the now-redundant `nodeAffinity` JSON patch from `deploy/mcp-korczewski/kustomization.yaml`.

## Test plan
- [x] `task mcp:deploy ENV=mentolder` → auth-proxy lands on `gekko-hetzner-4`
- [x] `task mcp:deploy ENV=korczewski` → auth-proxy lands on `pk-hetzner-4`
- [x] `POST https://mcp.mentolder.de/{kubernetes,postgres,browser,github}/mcp` with `BUSINESS_TOKEN` → 200
- [x] `POST https://mcp.mentolder.de/kubernetes/mcp` with bogus token → 401
- [x] `POST https://mcp.mentolder.de/kubernetes/mcp` no auth header → 401
- [ ] `mcp.korczewski.de` is on a separate DNS issue (`62.238.9.39` is unreachable from public internet) — out of scope here, fix separately

🤖 Generated with [Claude Code](https://claude.com/claude-code)