### PR TITLE
feat: local-first LLM pipeline (TEI + Ollama + LiteLLM)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -409,3 +409,11 @@ The Kore homepage shows a live PR-driven timeline:
 To backfill historical PRs: `task tracking:backfill && task tracking:ingest:local` (the latter requires `TRACKING_DB_URL` from a port-forward to shared-db).
 
 The env var is `BRAND` in the Kubernetes ConfigMap (`k3d/website.yaml`) and `BRAND_ID` in local dev — `index.astro` reads both with `process.env.BRAND_ID ?? process.env.BRAND ?? 'mentolder'`.
+
+### Local-first LLM pipeline
+
+- **The GPU host is a single, user-provided box on `wg-mesh`** (RTX 5070 Ti, 16 GB). Both prod clusters share it via three Services (`llm-gateway-embed:8081`, `llm-gateway-rerank:8082`, `llm-gateway-chat:11434`) that point at the same `${LLM_HOST_IP}`. Losing the host stalls embedding indexing on `bge-m3` collections and falls back chat-class workloads to Anthropic per call. Voyage-tagged collections are unaffected.
+- **Embeddings/rerank NEVER fall back across vector spaces.** A `bge-m3` collection always queries with bge-m3 and **fails closed** if TEI is down. A `voyage-multilingual-2` collection always queries with Voyage. The `MixedEmbeddingModelError` rejects multi-collection queries that span both. Don't "fix" this by adding silent fallback — vectors from different spaces in the same `<=>` query mean garbage retrieval.
+- **`llm-gpu.yaml` and `llm-router.yaml` are in `prod/` overlay only.** Dev (k3d) has no GPU and no router; `embeddings.ts` falls through to direct Voyage when `LLM_ENABLED=false`. Don't add them to `k3d/kustomization.yaml`.
+- **`LLM_HOST_IP` is required when `LLM_ENABLED=true`.** Set it in `environments/<env>.yaml` to the GPU host's wg-mesh IP. The `llm:deploy` task aborts if unset.
+- **Model swap costs ~3-6s on first call after idle.** Ollama's `OLLAMA_KEEP_ALIVE=5m` evicts idle models; the next request pays the swap. Router's chat-class timeout is 30s — beyond that, it falls back to Anthropic. Don't set the timeout below ~10s without testing all four models cold.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ task cluster:delete                        # Destroy cluster
 task cluster:start                         # Start stopped cluster
 task cluster:stop                          # Stop cluster (preserves state)
 task cluster:status                        # Show cluster status, nodes, resource usage
-task workspace:up                          # Full automated setup (Cluster + MVP + Office + MCP + Billing + post-config)
+task workspace:up                          # Full automated setup (Cluster → MVP → Office → MCP → post-config). For ENV-aware variant on an existing cluster: `task workspace:setup ENV=<env>`.
 task workspace:deploy                      # Deploy workspace (default ENV=dev)
 task workspace:deploy ENV=mentolder        # Deploy to mentolder prod cluster
 task workspace:deploy ENV=korczewski       # Deploy to korczewski prod cluster
@@ -105,7 +105,6 @@ task workspace:systembrett-setup          # Set up Brett (Systembrett) integrati
 task workspace:admin-users-setup          # Create default admin users
 task workspace:transcriber-setup          # Set up talk-transcriber bot + Whisper
 task workspace:transcriber-build          # Build talk-transcriber Docker image
-task workspace:stripe-setup               # Configure Stripe payment gateway
 task workspace:vaultwarden:seed           # Seed Vaultwarden with production secret templates
 task workspace:dsgvo-check                # Run DSGVO compliance verification (NFA-01)
 task claude-code:setup -- cluster         # Generate Claude Code settings.json for platform admin
@@ -171,10 +170,6 @@ task argocd:diff -- <app>        # Show diff between git and live state
 ArgoCD files: `argocd/install/` (CMP sidecar, Ingress), `argocd/project.yaml`, `argocd/applicationset.yaml`.
 Cluster config lives as annotations on ArgoCD cluster Secrets — set via `task argocd:cluster:register`.
 
-### Optional Services
-```bash
-```
-
 ### Brett (Systembrett)
 ```bash
 task brett:build                 # Build Brett image (and import into k3d in dev)
@@ -184,25 +179,33 @@ task brett:bot-setup ENV=<env>   # Register /brett slash command in Nextcloud Ta
 task brett:logs ENV=<env>        # Tail Brett logs
 ```
 
-### Unified Cluster (High Availability — 12 nodes)
-The mentolder cluster is the single unified production cluster. The separate korczewski
-cluster was disbanded (2026-05-05) and all its nodes joined mentolder.
+### Production clusters (two physical clusters since PR #621/#622, 2026-05-09)
+The earlier "unified" merge (2026-05-05) was reverted. Production now runs as two
+separate k3s clusters; verify with `kubectl config get-contexts`.
 
-**Node layout:**
-- Control-planes (6): `gekko-hetzner-2/3/4` (Hetzner Helsinki) + `pk-hetzner/pk-hetzner-2/3` (Hetzner Helsinki)
-- Workers (6): `k3s-1/2/3` + `k3w-1/2/3` (home LAN via WireGuard through pk-hetzner hub)
+**`mentolder` cluster (9 nodes, serves `mentolder.de`):**
+- Control-planes (3): `gekko-hetzner-2/3/4` (Hetzner Helsinki)
+- Workers (6): `k3s-1/2/3` + `k3w-1/2/3` (home LAN, joined via WireGuard mesh `wg-mesh`)
+- Workspace lives in the `workspace` namespace.
 
-**WireGuard mesh:** pk-hetzner (192.168.100.1) is the hub. All home workers use 192.168.100.x.
-k3s-1=.20, k3s-2=.11, k3s-3=.12, k3w-1=.4(.11 old), k3w-2=.3, k3w-3=.13, pk-hetzner-2=.21, pk-hetzner-3=.22.
-The mentolder Hetzner nodes reach home workers via wg0 tunnel through pk-hetzner.
+**`korczewski-ha` cluster (3 nodes, serves `korczewski.de`):**
+- Control-plane (1): `pk-hetzner-4`
+- Workers (2): `pk-hetzner-6`, `pk-hetzner-8`
+- Workspace lives in the `workspace-korczewski` namespace, with `WEBSITE_NAMESPACE=website-korczewski`.
+- Has its own `shared-db` — DB password rotations on one cluster never propagate to the other.
 
-**CNI partition:** Flannel VXLAN does NOT route between Hetzner nodes and home workers.
-Mitigation: keep system pods (CoreDNS, ArgoCD, etc.) on Hetzner nodes via nodeAffinity.
-Home workers host user workloads only — pod-to-pod across the WireGuard double-hop is broken.
+**ArgoCD federation** still hub-runs on mentolder. Annotations on the cluster Secrets
+(`cluster-mentolder`, `cluster-korczewski-ha`) drive the per-cluster overlay path
+(`prod-mentolder` vs `prod-korczewski`). The historical `argocd-korczewski`
+ServiceAccount + `62.238.9.39:6443` annotation comments in `Taskfile.argocd.yml`
+predate the re-split — refresh them when next touching that file.
 
-**korczewski workloads** (`korczewski.de`) run in `workspace-korczewski` namespace on the same
-cluster, managed by ArgoCD via the `cluster-korczewski` secret pointing to `62.238.9.39:6443`
-(pk-hetzner's API endpoint) using the `argocd-korczewski` ServiceAccount.
+**WireGuard mesh (`wg-mesh`):** since the partition fix, all mentolder nodes —
+Hetzner CPs and home workers — peer over `wg-mesh` with Flannel pinned to that
+interface (`flannel-iface=wg-mesh` on Hetzner CPs, `node-ip=<public>` for the
+control-planes). VXLAN now traverses correctly; system-pod nodeAffinity to
+Hetzner nodes is no longer load-bearing for connectivity (it remains for
+predictable placement of CoreDNS/ArgoCD/etc.).
 
 ```bash
 task ha:setup                    # Bootstrap 3-node k3s HA cluster on Hetzner (run once — historical)
@@ -228,6 +231,27 @@ task env:generate ENV=<env>      # Generate fresh secrets into environments/.sec
 task env:seal ENV=<env>          # Encrypt .secrets/<env>.yaml → environments/sealed-secrets/<env>.yaml
 task env:fetch-cert ENV=<env>    # Fetch a cluster's sealing cert into environments/certs/<env>.pem
 task config:show ENV=<env>       # Show resolved PROD_DOMAIN/BRAND_NAME/CONTACT_EMAIL for an env
+```
+
+### Tracking, tickets, theming, and other day-to-day tasks
+```bash
+task tracking:psql ENV=<env>             # psql into the bachelorprojekt tracking schema
+task tracking:backfill                   # Re-emit tracking JSON for historical PRs into tracking/pending/
+task tracking:backfill:dry               # Dry-run of tracking:backfill (prints what would be written)
+task tracking:ingest:local               # Drain tracking/pending/ into bachelorprojekt.features (needs TRACKING_DB_URL)
+task keycloak:sync ENV=<env>             # Reconcile Keycloak realm + client config from JSON
+task workspace:sync-db-passwords ENV=<env>  # Reconcile shared-db role passwords against the current SealedSecret
+task workspace:fix-tickets-grants ENV=<env> # Re-grant ticket-schema permissions to service roles
+task tickets:sunset:audit ENV=<env>      # Report ticket-system migrations still pending
+task tickets:sunset ENV=<env>            # Apply pending ticket-sunset migrations
+task workspace:theme ENV=<env>           # Re-apply Nextcloud branding (logos, colours, app order)
+task workspace:verify ENV=<env>          # Post-deploy smoke probes (per env)
+task workspace:verify:all-prods          # Same, fanned out across both prod clusters
+task db:diagram                          # Render a current schema ER diagram
+task gemini:setup:all                    # Generate Gemini CLI configs for all roles in one go
+task claude-code:export                  # Export the current Claude Code agent definitions
+task claude-code:invite                  # Mint an invite token for a Claude Code business user
+task claude-code:rotate-tokens           # Rotate the auth-proxy + agent tokens
 ```
 
 ### Testing
@@ -326,8 +350,12 @@ graph TB
 
 GitHub Actions (`.github/workflows/ci.yml`) runs on every PR:
 - Offline tests: `task test:all` (BATS unit tests, kustomize manifest structure, Taskfile dry-run)
-- Systembrett template validation
+- **Test inventory check**: re-runs `task test:inventory` and fails the job if `website/src/data/test-inventory.json` differs from the committed version — regenerate it locally and commit alongside any test additions.
+- Systembrett template validation (`scripts/tests/systembrett-template.test.sh`)
 - Security scan: image-pin advisory + hardcoded-secret detection in `k3d/*.yaml`
+- E2E smoke (`continue-on-error: true`): a Playwright `--project=smoke --grep '@smoke'` run against `web.mentolder.de` with a 10-min timeout. JUnit + traces are uploaded as the `e2e-smoke-results` artifact.
+
+Other workflows: `e2e.yml` (full Playwright), `track-pr.yml` (PR → tracking JSON), `tracking.yml` (drain into DB), `track-plans.yml`, `build-collabora.yml`, `build-tracking.yml`, `build-transcriber.yml`.
 
 ## Development Rules
 
@@ -347,12 +375,11 @@ Non-obvious repo behaviors. Violating these silently breaks things or hits the w
 - **`ENV=` is always explicit.** Env-sensitive tasks (`workspace:deploy`, `workspace:office:deploy`, `workspace:post-setup`, `docs:deploy`, `workspace:talk-setup`, etc.) default to `ENV=dev` when unset. The kubectl context mismatch check only runs when `ENV != dev`, so a missing `ENV=` + wrong active context silently deploys to whatever cluster is current. Always pass `ENV=mentolder` or `ENV=korczewski` for live work — or use the `feature:*` / `*:all-prods` umbrellas which fan out across both prod clusters explicitly.
 - **All workspace tasks now honour `WORKSPACE_NAMESPACE`.** Earlier the Taskfile and several `scripts/*.sh` hardcoded `-n workspace`, which silently wrote korczewski-targeted post-config (theming, OIDC redirects, talk signaling) into mentolder's `workspace` namespace. After 2026-05-05 every ENV-aware task sources `env-resolve.sh` and uses `${WORKSPACE_NAMESPACE:-workspace}` (mentolder=`workspace`, korczewski=`workspace-korczewski`); scripts default to `${NAMESPACE:-${WORKSPACE_NAMESPACE:-workspace}}` and the Taskfile call sites export the env var before invoking. If you add a new task that touches workspace resources, follow this pattern.
 - **ArgoCD tasks are hub-only and enforce it.** All `argocd:*` tasks live in `Taskfile.argocd.yml` and have a `_hub-guard` precondition that aborts with a clear error if the `mentolder` context is unreachable. `ENV=korczewski` is silently ignored — it does NOT redirect kubectl to korczewski.
-- **korczewski context still exists but points to the same physical cluster.** The `korczewski` kubeconfig context (62.238.9.39:6443 = pk-hetzner) now resolves to the unified mentolder cluster. `ENV=korczewski` in Taskfile tasks routes correctly. korczewski workloads land in `workspace-korczewski` namespace, not `workspace`.
+- **`mentolder` and `korczewski-ha` are two physical clusters.** The 2026-05-05 merge was reverted on 2026-05-09 (PRs #621/#622). The `korczewski-ha` context targets a standalone 3-node cluster on `pk-hetzner-4/6/8`; korczewski.de no longer routes through mentolder Traefik. Each cluster has its own `shared-db`, sealed-secrets controller, cert-manager, and Keycloak realm — anything cross-cluster (DB password rotation, OIDC client tweaks, schema changes) must be applied to **both** explicitly.
 
-### Unified cluster node placement
-- **System pods (CoreDNS, ArgoCD, etc.) must run on Hetzner nodes.** Home workers (k3s-1/2/3, k3w-1/2/3) have a CNI partition: Flannel VXLAN from Hetzner nodes cannot route to home worker pod IPs (192.168.100.x VTEPs require a WireGuard double-hop through pk-hetzner that iptables FORWARD allows but VXLAN encapsulation doesn't traverse correctly). CoreDNS is pinned to Hetzner nodes via nodeAffinity in the deployment. If CoreDNS drifts to a home worker, cluster DNS fails from Hetzner pods.
-- **pk-hetzner is the WireGuard hub for home workers.** Do not remove pk-hetzner from the cluster or change its wg0 config without updating all home worker peers. Its wg0 IP (192.168.100.1) is the gateway for k3s-1/2/3/k3w-1/2/3.
-- **korczewski.de ingresses route via Traefik on mentolder.** The `workspace-korczewski` namespace on mentolder serves korczewski.de. Traefik on the mentolder Hetzner nodes handles ingress for both domains.
+### Cluster node placement (mentolder)
+- **System pods are pinned to Hetzner nodes by nodeAffinity, even though the CNI partition is fixed.** Pre-2026-05-05 Flannel VXLAN couldn't traverse the WireGuard double-hop; the fix moved every mentolder node onto the `wg-mesh` overlay with `flannel-iface=wg-mesh` (and `node-ip=<public>` on the Hetzner CPs). Connectivity now works end-to-end, but CoreDNS/ArgoCD/etc. stay pinned to `gekko-hetzner-*` for predictable placement and lower egress latency. Removing the affinity won't break DNS today — but unpinning without thinking about it loses the deliberate locality.
+- **`wg-mesh` membership is load-bearing for mentolder.** Adding a node without joining the mesh + setting `flannel-iface=wg-mesh` will silently break pod-to-pod traffic from that node. See `wireguard/` for the peer config and the partition-fix memory for the gory details.
 
 ### Kustomize overlays
 - **Apply `prod-mentolder/` or `prod-korczewski/`, never base `prod/` alone.** The base `prod/` exists to be consumed by the env-specific overlays. It also contains a `$patch: delete` on the `workspace-secrets` Secret — applying `prod/` directly relies on the sealed secret existing and can leave the cluster without credentials.

--- a/Taskfile.llm.yml
+++ b/Taskfile.llm.yml
@@ -1,0 +1,101 @@
+# Taskfile.llm.yml
+# ─────────────────────────────────────────────────────────────────────────────
+# Local-first LLM pipeline operations.
+# Included from Taskfile.yml under the "llm" namespace.
+# ─────────────────────────────────────────────────────────────────────────────
+version: "3"
+
+tasks:
+
+  bootstrap-host:
+    desc: "Bootstrap the GPU host (Docker, systemd units, ufw). HOST=<wg-mesh-ip>"
+    preconditions:
+      - sh: '[ -n "{{.HOST}}" ]'
+        msg: "HOST=<wg-mesh-ip> is required."
+    cmds:
+      - scripts/llm-host-setup.sh {{.HOST}}
+
+  pull-models:
+    desc: "Pull all 4 Ollama models + warm TEI HF cache. HOST=<wg-mesh-ip>"
+    preconditions:
+      - sh: '[ -n "{{.HOST}}" ]'
+        msg: "HOST=<wg-mesh-ip> is required."
+    cmds:
+      - scripts/llm-pull-models.sh {{.HOST}}
+
+  deploy:
+    desc: "Apply llm-gpu Endpoints + llm-router Deployment to ENV={{.ENV}}"
+    vars:
+      ENV: '{{.ENV | default "mentolder"}}'
+    cmds:
+      - |
+        source scripts/env-resolve.sh "{{.ENV}}"
+        : "${LLM_HOST_IP:?LLM_HOST_IP unset — configure in environments/{{.ENV}}.yaml}"
+        envsubst '$LLM_HOST_IP' < k3d/llm-gpu.yaml \
+          | kubectl --context "$ENV_CONTEXT" -n "${WORKSPACE_NAMESPACE:-workspace}" apply -f -
+        kubectl --context "$ENV_CONTEXT" -n "${WORKSPACE_NAMESPACE:-workspace}" apply -f k3d/llm-router.yaml
+        kubectl --context "$ENV_CONTEXT" -n "${WORKSPACE_NAMESPACE:-workspace}" rollout status deployment/llm-router --timeout=120s
+
+  redeploy-router:
+    desc: "Roll the llm-router Deployment (e.g. after config.yaml change). ENV=<env>"
+    vars:
+      ENV: '{{.ENV | default "mentolder"}}'
+    cmds:
+      - |
+        source scripts/env-resolve.sh "{{.ENV}}"
+        kubectl --context "$ENV_CONTEXT" -n "${WORKSPACE_NAMESPACE:-workspace}" rollout restart deployment/llm-router
+        kubectl --context "$ENV_CONTEXT" -n "${WORKSPACE_NAMESPACE:-workspace}" rollout status deployment/llm-router --timeout=120s
+
+  status:
+    desc: "Show LLM pipeline status (router pod, gateway endpoints, model availability). ENV=<env>"
+    vars:
+      ENV: '{{.ENV | default "mentolder"}}'
+    cmds:
+      - |
+        source scripts/env-resolve.sh "{{.ENV}}"
+        ns="${WORKSPACE_NAMESPACE:-workspace}"
+        echo "── llm-router pod ──"
+        kubectl --context "$ENV_CONTEXT" -n "$ns" get deploy/llm-router -o wide
+        echo "── llm-gateway endpoints ──"
+        kubectl --context "$ENV_CONTEXT" -n "$ns" get endpoints llm-gateway-embed llm-gateway-rerank llm-gateway-chat
+        echo "── /health ──"
+        kubectl --context "$ENV_CONTEXT" -n "$ns" exec deploy/llm-router -- \
+          curl -fsS http://localhost:4000/health | head -c 500 || true
+
+  logs:
+    desc: "Tail llm-router logs. ENV=<env>"
+    vars:
+      ENV: '{{.ENV | default "mentolder"}}'
+    cmds:
+      - |
+        source scripts/env-resolve.sh "{{.ENV}}"
+        kubectl --context "$ENV_CONTEXT" -n "${WORKSPACE_NAMESPACE:-workspace}" logs deploy/llm-router -f --tail=200
+
+  test:
+    desc: "Smoke-test all four router routes (embed bge-m3, embed voyage, rerank, chat). ENV=<env>"
+    vars:
+      ENV: '{{.ENV | default "mentolder"}}'
+    cmds:
+      - |
+        source scripts/env-resolve.sh "{{.ENV}}"
+        ns="${WORKSPACE_NAMESPACE:-workspace}"
+        echo "── bge-m3 embed ──"
+        kubectl --context "$ENV_CONTEXT" -n "$ns" exec deploy/llm-router -- \
+          curl -fsS -X POST http://localhost:4000/v1/embeddings \
+            -H "Content-Type: application/json" \
+            -d '{"model":"bge-m3","input":"hallo welt"}' | jq '.data[0].embedding | length'
+        echo "── voyage-multilingual-2 embed ──"
+        kubectl --context "$ENV_CONTEXT" -n "$ns" exec deploy/llm-router -- \
+          curl -fsS -X POST http://localhost:4000/v1/embeddings \
+            -H "Content-Type: application/json" \
+            -d '{"model":"voyage-multilingual-2","input":"hallo welt"}' | jq '.data[0].embedding | length'
+        echo "── rerank ──"
+        kubectl --context "$ENV_CONTEXT" -n "$ns" exec deploy/llm-router -- \
+          curl -fsS -X POST http://localhost:4000/v1/rerank \
+            -H "Content-Type: application/json" \
+            -d '{"model":"workspace-rerank","query":"capital of germany","documents":["paris","berlin","hamburg"]}' | jq '.results[0]'
+        echo "── chat ──"
+        kubectl --context "$ENV_CONTEXT" -n "$ns" exec deploy/llm-router -- \
+          curl -fsS -X POST http://localhost:4000/v1/chat/completions \
+            -H "Content-Type: application/json" \
+            -d '{"model":"workspace-chat","messages":[{"role":"user","content":"Sag Hallo auf Deutsch."}],"max_tokens":20}' | jq '.choices[0].message.content'

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -7,6 +7,9 @@ includes:
   argocd:
     taskfile: ./Taskfile.argocd.yml
     dir: .
+  llm:
+    taskfile: ./Taskfile.llm.yml
+    dir: .
 
 vars:
   CLUSTER_NAME: dev
@@ -1346,10 +1349,15 @@ tasks:
           ENVSUBST_VARS="$ENVSUBST_VARS \$LIVEKIT_DOMAIN \$STREAM_DOMAIN"
           ENVSUBST_VARS="$ENVSUBST_VARS \$WORKSPACE_NAMESPACE"
           ENVSUBST_VARS="$ENVSUBST_VARS \$SYSTEMTEST_LOOP_ENABLED"
+          ENVSUBST_VARS="$ENVSUBST_VARS \$LLM_HOST_IP \$LLM_ENABLED \$LLM_RERANK_ENABLED \$LLM_ROUTER_URL"
           # Default to "false" so prod env files that haven't yet adopted
           # the flag don't leak the literal "${SYSTEMTEST_LOOP_ENABLED}"
           # into the rendered website-config ConfigMap.
           export SYSTEMTEST_LOOP_ENABLED="${SYSTEMTEST_LOOP_ENABLED:-false}"
+          export LLM_HOST_IP="${LLM_HOST_IP:-}"
+          export LLM_ENABLED="${LLM_ENABLED:-false}"
+          export LLM_RERANK_ENABLED="${LLM_RERANK_ENABLED:-false}"
+          export LLM_ROUTER_URL="${LLM_ROUTER_URL:-http://llm-router.workspace.svc.cluster.local:4000}"
           kustomize build "$overlay/" --load-restrictor=LoadRestrictionsNone \
             | envsubst "$ENVSUBST_VARS" \
             | kubectl --context "$ENV_CONTEXT" apply --server-side --force-conflicts -f -

--- a/claude-code/gekko-android-mcp-guide.md
+++ b/claude-code/gekko-android-mcp-guide.md
@@ -1,0 +1,146 @@
+# Claude auf dem Handy mit den MCP-Servern verbinden
+
+> Anleitung für Gekko (Android & iOS). Das Dokument ist absichtlich
+> ohne Fachbegriffe geschrieben — einfach Schritt für Schritt durchgehen.
+>
+> **Vor dem Verschicken:** Patrick muss an einer Stelle (Schritt 2) den
+> Bearer-Token einsetzen. Anweisung dafür ganz unten.
+
+---
+
+## Voraussetzung
+
+Du brauchst die Claude-App **mit Pro- oder Max-Abo**. Mit dem kostenlosen
+Plan sind eigene Server-Verbindungen ("Connectors") gesperrt.
+
+- **Pro:** ca. 18 €/Monat — reicht für deine Zwecke
+- Wechsel in der App über Profil oben rechts → **Upgrade**
+
+---
+
+## Schritt 1 — Claude-App installieren
+
+1. Öffne den **Google Play Store** (auf iPhone: **App Store**)
+2. Suche nach **"Claude"** (von **Anthropic**)
+3. Tippe **Installieren**
+4. Öffne die App, melde dich mit deinem Anthropic-Konto an
+
+---
+
+## Schritt 2 — Den ersten Server hinzufügen
+
+1. In der App tippe oben links auf das **Menü-Symbol** (☰)
+2. Tippe unten auf dein **Profil**
+3. Tippe auf **Settings** / **Einstellungen**
+4. Tippe auf **Connectors** (manchmal "Verbindungen" oder "Tools")
+5. Tippe auf **"+ Add custom connector"** / **"Eigenen Connector hinzufügen"**
+
+Es erscheint ein Formular. Fülle es so aus:
+
+| Feld | Wert |
+|---|---|
+| **Name** | `Kubernetes` |
+| **Server URL** | `https://mcp.mentolder.de/kubernetes/mcp` |
+| **Authentication** | "Bearer Token" auswählen |
+| **Token** | *{{HIER FÜGT PATRICK DEN TOKEN EIN}}* |
+
+Tippe **Add** / **Hinzufügen**.
+→ Es sollte ein grünes Häkchen ✓ erscheinen.
+
+---
+
+## Schritt 3 — Die anderen vier Server hinzufügen
+
+Genauso wie Schritt 2, aber mit anderen Daten.
+**Der Token ist jedes Mal derselbe** — nur Name und URL ändern sich:
+
+| Name | Server URL |
+|---|---|
+| `Postgres` | `https://mcp.mentolder.de/postgres/mcp` |
+| `Keycloak` | `https://mcp.mentolder.de/keycloak/mcp/sse` |
+| `Browser` | `https://mcp.mentolder.de/browser/mcp` |
+| `GitHub` | `https://mcp.mentolder.de/github/mcp` |
+
+Bei jedem: **Bearer Token** auswählen, **denselben Token** einfügen,
+**Add** tippen.
+
+---
+
+## Schritt 4 — Testen
+
+Geh zurück in einen normalen Chat in der App. Tippe auf das
+**Werkzeug-Symbol** unten neben dem Texteingabefeld 🛠️ — du solltest
+deine 5 Connectors aufgelistet sehen, jeder mit einem Schalter.
+
+Schreib zum Testen:
+
+> *"Welche Pods laufen gerade im workspace-Namespace?"*
+
+Wenn Claude eine Liste mit Pod-Namen zurückgibt → läuft alles. 🎉
+
+---
+
+## Wenn etwas schiefläuft
+
+| Problem | Lösung |
+|---|---|
+| Kein "Connectors"-Menü | Du brauchst **Claude Pro**. Profil oben rechts → Upgrade. |
+| "Authentication failed" / 401 | Token falsch eingefügt. Connector löschen und neu anlegen — Token komplett markieren und einfügen. |
+| "Connection timed out" | WLAN-/Mobilfunkverbindung kurz prüfen. Wenn andere Connectors funktionieren aber einer hängt: Patrick anschreiben. |
+| Connector erscheint nicht beim 🛠️-Symbol | Einstellungen → Connectors → Schalter daneben **anschalten**. |
+| Token läuft nicht mehr | Patrick muss `task claude-code:rotate-tokens ENV=mentolder` ausführen und dir den neuen Token schicken. |
+
+---
+
+## Was du **nicht** brauchst
+
+- Kein Terminal, kein Computer
+- Keine Installation außer der Claude-App
+- Kein kubectl, kein SSH, kein VPN
+- Keine geheimen Befehle aus dem Internet
+
+---
+
+## Erwartung — was geht, was nicht
+
+Die Claude-App auf dem Handy ist super für:
+- "Schau mal nach, wie viele neue Anmeldungen wir gestern hatten"
+- "Lies mir die letzten 5 Pull Requests vor"
+- "Welche Pods sind gerade nicht gesund?"
+
+Schwächer ist sie bei sehr komplexen Mehrschritt-Aufgaben — die laufen
+flüssiger im Claude Code im Terminal. Für den Alltag auf dem Handy
+reicht's aber locker.
+
+Bei Fragen: einfach Patrick anrufen 😄
+
+---
+
+# 📦 Anleitung für Patrick — Token rausholen und schicken
+
+So bekommst du den Bearer-Token, den du oben in Schritt 2 einsetzen musst:
+
+```bash
+kubectl --context mentolder -n default get secret mcp-tokens \
+  -o jsonpath='{.data.BUSINESS_TOKEN}' | base64 -d; echo
+```
+
+Output ist eine 64-stellige Zeichenfolge wie `459ce7e6...`.
+
+Schick Gekko über einen **sicheren Kanal** (Vaultwarden Send, Signal):
+
+1. Den **Token** (allein, ohne weiteren Text — leichter zu kopieren)
+2. Diese Anleitung als zweite Nachricht
+
+Bitte **nicht** über E-Mail oder normales WhatsApp — der Token gibt
+Vollzugriff auf alle 5 MCP-Server der Plattform, das ist ein Passwort.
+
+## Token rotieren (falls geleakt)
+
+```bash
+task claude-code:rotate-tokens ENV=mentolder
+```
+
+Danach Gekko den neuen Token schicken — alte Tokens sind sofort ungültig
+und alle bestehenden Connectors in seiner App müssen einmal aktualisiert
+werden (Connector öffnen → Token ersetzen → Speichern).

--- a/environments/dev.yaml
+++ b/environments/dev.yaml
@@ -8,6 +8,9 @@ env_vars:
   # Dev uses default_dev from schema.yaml for most values.
   # Override only where the dev default differs from schema:
   WEBSITE_IMAGE: workspace-website
+  LLM_ENABLED: "false"
+  LLM_RERANK_ENABLED: "false"
+  LLM_HOST_IP: ""
 
 # Dev secrets: generated from schema defaults at deploy time.
 secrets_mode: plaintext

--- a/environments/korczewski.yaml
+++ b/environments/korczewski.yaml
@@ -46,6 +46,12 @@ env_vars:
   KEYCLOAK_FRONTEND_URL: "https://auth.korczewski.de"
   # System-test failure loop master kill-switch (Task 10).
   SYSTEMTEST_LOOP_ENABLED: "true"
+  # ← replace LLM_HOST_IP with actual wg-mesh IP at deploy time
+  LLM_HOST_IP: "10.0.0.99"
+  LLM_ENABLED: "true"
+  # flip LLM_RERANK_ENABLED to true after 24h of stable rollout
+  LLM_RERANK_ENABLED: "false"
+  LLM_ROUTER_URL: "http://llm-router.workspace-korczewski.svc.cluster.local:4000"
 
 overlay: prod-korczewski
 workspace_namespace: workspace-korczewski

--- a/environments/mentolder.yaml
+++ b/environments/mentolder.yaml
@@ -45,6 +45,12 @@ env_vars:
   KEYCLOAK_FRONTEND_URL: "https://auth.mentolder.de"
   # System-test failure loop master kill-switch (Task 10).
   SYSTEMTEST_LOOP_ENABLED: "true"
+  # ← replace LLM_HOST_IP with actual wg-mesh IP at deploy time
+  LLM_HOST_IP: "10.0.0.99"
+  LLM_ENABLED: "true"
+  # flip LLM_RERANK_ENABLED to true after 24h of stable rollout
+  LLM_RERANK_ENABLED: "false"
+  LLM_ROUTER_URL: "http://llm-router.workspace.svc.cluster.local:4000"
 
 overlay: prod-mentolder
 workspace_namespace: workspace

--- a/environments/schema.yaml
+++ b/environments/schema.yaml
@@ -187,6 +187,28 @@ env_vars:
     required: true
     default_dev: "http://auth.localhost"
 
+  - name: LLM_HOST_IP
+    required: false
+    default_dev: ""
+    description: "Mesh IP of the GPU host running TEI + Ollama. Required when LLM_ENABLED=true. Empty in dev."
+
+  - name: LLM_ENABLED
+    required: true
+    default_dev: "false"
+    description: "If true, the website uses the in-cluster LiteLLM router for embeddings/rerank/chat. If false, embeddings.ts calls Voyage directly (legacy path)."
+    validate: "^(true|false)$"
+
+  - name: LLM_RERANK_ENABLED
+    required: true
+    default_dev: "false"
+    description: "If true, knowledge query path runs results through the bge-reranker-v2-m3 service. Requires LLM_ENABLED=true."
+    validate: "^(true|false)$"
+
+  - name: LLM_ROUTER_URL
+    required: true
+    default_dev: "http://llm-router.workspace.svc.cluster.local:4000"
+    description: "Cluster-internal URL of the LiteLLM router. Constant per namespace; only varies if WORKSPACE_NAMESPACE differs."
+
 secrets:
   - name: SHARED_DB_PASSWORD
     required: true
@@ -512,6 +534,16 @@ secrets:
     extra_namespaces:
       - namespace: workspace
         secret: knowledge-secrets
+
+  - name: ANTHROPIC_API_KEY
+    required: false
+    generate: false
+    description: "Anthropic API key. Used by (a) the website for meeting insights (claude.ts), (b) the llm-router for chat-class fallback when the local Ollama is unreachable. Required in prod when LLM_ENABLED=true."
+    extra_namespaces:
+      - namespace: workspace
+        secret: knowledge-secrets
+      - namespace: website
+        secret: website-secrets
 
 setup_vars:
   - name: KC_USER1_USERNAME

--- a/k3d/llm-gpu.yaml
+++ b/k3d/llm-gpu.yaml
@@ -1,19 +1,73 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# llm-gpu: external GPU peer (TEI embed, TEI rerank, Ollama chat)
+#
+# The GPU box runs on the wg-mesh overlay. Three Services + Endpoints route
+# traffic to it from inside the cluster. ${LLM_HOST_IP} is filled by envsubst
+# at deploy time from environments/<env>.yaml.
+# ─────────────────────────────────────────────────────────────────────────────
+
+# ── Embeddings (TEI bge-m3) ──────────────────────────────────────────────────
 apiVersion: v1
 kind: Service
 metadata:
-  name: llm-gateway
+  name: llm-gateway-embed
 spec:
-  # No selector: manually managed Endpoints point to external GPU worker
   ports:
-    - port: 11434
+    - name: http
+      port: 8081
+      targetPort: 8081
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: llm-gateway-embed
+subsets:
+  - addresses:
+      - ip: ${LLM_HOST_IP}
+    ports:
+      - name: http
+        port: 8081
+---
+# ── Reranker (TEI bge-reranker-v2-m3) ────────────────────────────────────────
+apiVersion: v1
+kind: Service
+metadata:
+  name: llm-gateway-rerank
+spec:
+  ports:
+    - name: http
+      port: 8082
+      targetPort: 8082
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: llm-gateway-rerank
+subsets:
+  - addresses:
+      - ip: ${LLM_HOST_IP}
+    ports:
+      - name: http
+        port: 8082
+---
+# ── Chat (Ollama) ────────────────────────────────────────────────────────────
+apiVersion: v1
+kind: Service
+metadata:
+  name: llm-gateway-chat
+spec:
+  ports:
+    - name: http
+      port: 11434
       targetPort: 11434
 ---
 apiVersion: v1
 kind: Endpoints
 metadata:
-  name: llm-gateway
+  name: llm-gateway-chat
 subsets:
   - addresses:
-      - ip: __HOST_IP__
+      - ip: ${LLM_HOST_IP}
     ports:
-      - port: 11434
+      - name: http
+        port: 11434

--- a/k3d/llm-router.yaml
+++ b/k3d/llm-router.yaml
@@ -1,0 +1,163 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# llm-router: in-cluster LiteLLM proxy
+#
+# Exposes one OpenAI-compatible URL (port 4000). Encodes the local-first /
+# cloud-fallback policy declaratively in litellm-config. Embeddings and
+# reranking NEVER fall back across vector spaces — see docs spec for the
+# invariant. Chat-class aliases fall back to Anthropic per call.
+# ─────────────────────────────────────────────────────────────────────────────
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: litellm-config
+data:
+  config.yaml: |
+    model_list:
+      # ── Embedding aliases (no fallback — vector-space integrity) ──────────
+      - model_name: bge-m3
+        litellm_params:
+          model: huggingface/BAAI/bge-m3
+          api_base: http://llm-gateway-embed:8081
+          timeout: 60
+      - model_name: voyage-multilingual-2
+        litellm_params:
+          model: voyage/voyage-multilingual-2
+          api_key: os.environ/VOYAGE_API_KEY
+          timeout: 60
+
+      # ── Rerank alias (no fallback — caller skips on 503) ──────────────────
+      - model_name: workspace-rerank
+        litellm_params:
+          model: huggingface/BAAI/bge-reranker-v2-m3
+          api_base: http://llm-gateway-rerank:8082
+          timeout: 30
+
+      # ── Chat-class aliases — primary local, fallback Anthropic ────────────
+      - model_name: workspace-chat
+        litellm_params:
+          model: ollama/qwen2.5:14b-instruct-q4_K_M
+          api_base: http://llm-gateway-chat:11434
+          timeout: 30
+      - model_name: workspace-chat-fallback
+        litellm_params:
+          model: anthropic/claude-sonnet-4-6
+          api_key: os.environ/ANTHROPIC_API_KEY
+          timeout: 30
+
+      - model_name: workspace-code
+        litellm_params:
+          model: ollama/qwen2.5-coder:14b-instruct-q4_K_M
+          api_base: http://llm-gateway-chat:11434
+          timeout: 30
+      - model_name: workspace-code-fallback
+        litellm_params:
+          model: anthropic/claude-sonnet-4-6
+          api_key: os.environ/ANTHROPIC_API_KEY
+          timeout: 30
+
+      - model_name: workspace-vision
+        litellm_params:
+          model: ollama/qwen2.5vl:7b-instruct-q4_K_M
+          api_base: http://llm-gateway-chat:11434
+          timeout: 30
+      - model_name: workspace-vision-fallback
+        litellm_params:
+          model: anthropic/claude-sonnet-4-6
+          api_key: os.environ/ANTHROPIC_API_KEY
+          timeout: 30
+
+      - model_name: workspace-fast
+        litellm_params:
+          model: ollama/llama3.2:3b-instruct-q4_K_M
+          api_base: http://llm-gateway-chat:11434
+          timeout: 30
+      - model_name: workspace-fast-fallback
+        litellm_params:
+          model: anthropic/claude-haiku-4-5
+          api_key: os.environ/ANTHROPIC_API_KEY
+          timeout: 30
+
+    litellm_settings:
+      drop_params: true
+      set_verbose: false
+      fallbacks:
+        - workspace-chat: ["workspace-chat-fallback"]
+        - workspace-code: ["workspace-code-fallback"]
+        - workspace-vision: ["workspace-vision-fallback"]
+        - workspace-fast: ["workspace-fast-fallback"]
+      success_callback: []
+      failure_callback: []
+
+    general_settings:
+      master_key: os.environ/LITELLM_MASTER_KEY
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: llm-router
+spec:
+  replicas: 1
+  selector:
+    matchLabels: { app: llm-router }
+  template:
+    metadata:
+      labels: { app: llm-router }
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/hostname
+                    operator: In
+                    values: [gekko-hetzner-2, gekko-hetzner-3, gekko-hetzner-4, pk-hetzner-4]
+      containers:
+        - name: litellm
+          image: ghcr.io/berriai/litellm:main-stable
+          args: ["--config", "/app/config.yaml", "--port", "4000", "--num_workers", "2"]
+          ports:
+            - containerPort: 4000
+          env:
+            - name: VOYAGE_API_KEY
+              valueFrom:
+                secretKeyRef: { name: workspace-secrets, key: VOYAGE_API_KEY }
+            - name: ANTHROPIC_API_KEY
+              valueFrom:
+                secretKeyRef: { name: workspace-secrets, key: ANTHROPIC_API_KEY }
+            - name: LITELLM_MASTER_KEY
+              value: "sk-llm-router-internal"
+          volumeMounts:
+            - name: config
+              mountPath: /app/config.yaml
+              subPath: config.yaml
+          readinessProbe:
+            httpGet: { path: /health/readiness, port: 4000 }
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          livenessProbe:
+            httpGet: { path: /health/liveliness, port: 4000 }
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          resources:
+            requests: { cpu: 100m, memory: 256Mi }
+            limits:   { cpu: 1000m, memory: 1Gi }
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities: { drop: [ALL] }
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile: { type: RuntimeDefault }
+      volumes:
+        - name: config
+          configMap: { name: litellm-config }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: llm-router
+spec:
+  selector: { app: llm-router }
+  ports:
+    - name: http
+      port: 4000
+      targetPort: 4000

--- a/k3d/website.yaml
+++ b/k3d/website.yaml
@@ -64,7 +64,10 @@ data:
   MIN_ADVANCE_HOURS: "24"
   # Whisper
   WHISPER_URL: "http://whisper.${WORKSPACE_NAMESPACE}.svc.cluster.local:8000"
-  ANTHROPIC_API_KEY: ""
+  # LLM router (local-first pipeline)
+  LLM_ROUTER_URL: "${LLM_ROUTER_URL}"
+  LLM_ENABLED: "${LLM_ENABLED}"
+  LLM_RERANK_ENABLED: "${LLM_RERANK_ENABLED}"
   # Mentolder-Assistent (no-LLM keyword-search mode for now)
   ENABLE_ASSISTANT_ADMIN: "true"
   ENABLE_ASSISTANT_PORTAL: "true"
@@ -363,6 +366,12 @@ spec:
               value: "46.225.125.59"
             - name: LIVEKIT_PIN_IP_KORCZEWSKI
               value: "37.27.251.38"
+            - name: ANTHROPIC_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: website-secrets
+                  key: ANTHROPIC_API_KEY
+                  optional: true
             - name: EVIDENCE_ROOT
               value: "/var/evidence"
           volumeMounts:

--- a/prod/kustomization.yaml
+++ b/prod/kustomization.yaml
@@ -6,6 +6,8 @@ namespace: workspace
 resources:
   - ../k3d
   # Production-only (no equivalent in base)
+  - ../k3d/llm-gpu.yaml
+  - ../k3d/llm-router.yaml
   - cluster-issuer.yaml
   - reflector.yaml
   - wildcard-certificate.yaml

--- a/scripts/coaching/ingest-book.mts
+++ b/scripts/coaching/ingest-book.mts
@@ -53,7 +53,10 @@ async function main() {
       let r: { embeddings: number[][]; tokens: number } | null = null;
       for (let attempt = 1; attempt <= 5; attempt++) {
         try {
-          r = await embedBatch(slice);
+          r = await embedBatch(slice, {
+            model: process.env.LLM_ENABLED === 'true' ? 'bge-m3' : 'voyage-multilingual-2',
+            purpose: 'index',
+          });
           break;
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err);

--- a/scripts/llm-host-setup.sh
+++ b/scripts/llm-host-setup.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# ════════════════════════════════════════════════════════════════════
+# llm-host-setup.sh — bootstrap the GPU host (TEI + Ollama + ufw)
+# ════════════════════════════════════════════════════════════════════
+# Idempotent: re-running upgrades systemd units and Docker images
+# without re-pulling Ollama models. Models are pulled by
+# scripts/llm-pull-models.sh.
+#
+# Prereqs on the host:
+#   - Ubuntu 24.04 with NVIDIA driver ≥ 555 (Blackwell sm_120 needs CUDA 12.8)
+#   - The host has joined wg-mesh (interface name "wg-mesh")
+#   - SSH key in ~/.ssh/id_ed25519_hetzner allows passwordless root
+#
+# Usage:
+#   scripts/llm-host-setup.sh <ssh-host>
+# ════════════════════════════════════════════════════════════════════
+set -euo pipefail
+
+HOST="${1:?Usage: llm-host-setup.sh <ssh-host>}"
+SSH_KEY="${SSH_KEY:-$HOME/.ssh/id_ed25519_hetzner}"
+SSH_OPTS=(-i "$SSH_KEY" -o StrictHostKeyChecking=accept-new)
+
+echo "[1/6] Verify connectivity to ${HOST}..."
+ssh "${SSH_OPTS[@]}" "${HOST}" "echo connected; nvidia-smi --query-gpu=name,memory.total --format=csv,noheader"
+
+echo "[2/6] Install Docker + NVIDIA Container Toolkit if missing..."
+ssh "${SSH_OPTS[@]}" "${HOST}" "bash -s" <<'REMOTE'
+set -euo pipefail
+if ! command -v docker >/dev/null; then
+  curl -fsSL https://get.docker.com | sh
+fi
+if ! dpkg -l | grep -q nvidia-container-toolkit; then
+  curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg
+  curl -s -L https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list | \
+    sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' \
+    > /etc/apt/sources.list.d/nvidia-container-toolkit.list
+  apt-get update && apt-get install -y nvidia-container-toolkit
+  nvidia-ctk runtime configure --runtime=docker
+  systemctl restart docker
+fi
+REMOTE
+
+echo "[3/6] Install Ollama if missing..."
+ssh "${SSH_OPTS[@]}" "${HOST}" "bash -s" <<'REMOTE'
+set -euo pipefail
+if ! command -v ollama >/dev/null; then
+  curl -fsSL https://ollama.com/install.sh | sh
+fi
+id ollama >/dev/null 2>&1 || useradd -r -m -d /var/lib/ollama -s /sbin/nologin ollama
+mkdir -p /var/lib/llm/hf-cache
+chown -R ollama:ollama /var/lib/ollama
+REMOTE
+
+echo "[4/6] Copy systemd units..."
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+scp "${SSH_OPTS[@]}" \
+  "${SCRIPT_DIR}/llm/ollama.service" \
+  "${SCRIPT_DIR}/llm/tei-embed.service" \
+  "${SCRIPT_DIR}/llm/tei-rerank.service" \
+  "${HOST}:/etc/systemd/system/"
+
+echo "[5/6] Enable and (re)start services..."
+ssh "${SSH_OPTS[@]}" "${HOST}" "bash -s" <<'REMOTE'
+set -euo pipefail
+systemctl daemon-reload
+systemctl enable --now ollama.service
+systemctl enable --now tei-embed.service
+systemctl enable --now tei-rerank.service
+REMOTE
+
+echo "[6/6] Open ufw on wg-mesh interface only..."
+ssh "${SSH_OPTS[@]}" "${HOST}" "bash -s" <<'REMOTE'
+set -euo pipefail
+ufw allow in on wg-mesh to any port 8081 proto tcp comment "tei-embed"
+ufw allow in on wg-mesh to any port 8082 proto tcp comment "tei-rerank"
+ufw allow in on wg-mesh to any port 11434 proto tcp comment "ollama"
+ufw status numbered | grep -E "wg-mesh.*(8081|8082|11434)"
+REMOTE
+
+echo "Done. Now run: scripts/llm-pull-models.sh ${HOST}"

--- a/scripts/llm-pull-models.sh
+++ b/scripts/llm-pull-models.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# ════════════════════════════════════════════════════════════════════
+# llm-pull-models.sh — pull all required models to the GPU host
+# ════════════════════════════════════════════════════════════════════
+# Idempotent: ollama pull is content-addressed, hf download skips
+# files already on disk. ~40 GB of downloads on first run.
+# ════════════════════════════════════════════════════════════════════
+set -euo pipefail
+
+HOST="${1:?Usage: llm-pull-models.sh <ssh-host>}"
+SSH_KEY="${SSH_KEY:-$HOME/.ssh/id_ed25519_hetzner}"
+SSH_OPTS=(-i "$SSH_KEY" -o StrictHostKeyChecking=accept-new)
+
+echo "[1/3] Pulling Ollama models (~32 GB)..."
+ssh "${SSH_OPTS[@]}" "${HOST}" "bash -s" <<'REMOTE'
+set -euo pipefail
+ollama pull qwen2.5:14b-instruct-q4_K_M
+ollama pull qwen2.5-coder:14b-instruct-q4_K_M
+ollama pull qwen2.5vl:7b-instruct-q4_K_M
+ollama pull llama3.2:3b-instruct-q4_K_M
+ollama list
+REMOTE
+
+echo "[2/3] Restarting TEI to pick up cached HF files (downloads run inside the container on first call)..."
+ssh "${SSH_OPTS[@]}" "${HOST}" "systemctl restart tei-embed tei-rerank"
+
+echo "[3/3] Probing endpoints..."
+ssh "${SSH_OPTS[@]}" "${HOST}" "bash -s" <<'REMOTE'
+set -euo pipefail
+for i in $(seq 1 30); do
+  curl -fsS http://127.0.0.1:8081/health > /dev/null && break || sleep 5
+done
+for i in $(seq 1 30); do
+  curl -fsS http://127.0.0.1:8082/health > /dev/null && break || sleep 5
+done
+echo "TEI embed:  $(curl -s http://127.0.0.1:8081/info | head -c 200)"
+echo "TEI rerank: $(curl -s http://127.0.0.1:8082/info | head -c 200)"
+echo "Ollama:     $(curl -s http://127.0.0.1:11434/api/version)"
+REMOTE
+
+echo "Done."

--- a/scripts/llm/ollama.service
+++ b/scripts/llm/ollama.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Ollama (local LLM swap pool)
+After=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/ollama serve
+Environment=OLLAMA_HOST=0.0.0.0:11434
+Environment=OLLAMA_KEEP_ALIVE=5m
+Environment=OLLAMA_FLASH_ATTENTION=1
+Restart=on-failure
+RestartSec=5
+User=ollama
+Group=ollama
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/llm/tei-embed.service
+++ b/scripts/llm/tei-embed.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=TEI Embeddings (bge-m3)
+After=network-online.target docker.service
+Requires=docker.service
+
+[Service]
+Type=simple
+ExecStartPre=-/usr/bin/docker rm -f tei-embed
+ExecStart=/usr/bin/docker run --rm --name tei-embed \
+  --gpus all \
+  -p 8081:80 \
+  -v /var/lib/llm/hf-cache:/data \
+  ghcr.io/huggingface/text-embeddings-inference:1.5 \
+  --model-id BAAI/bge-m3 \
+  --port 80
+ExecStop=/usr/bin/docker stop tei-embed
+Restart=on-failure
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/llm/tei-rerank.service
+++ b/scripts/llm/tei-rerank.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=TEI Reranker (bge-reranker-v2-m3)
+After=network-online.target docker.service
+Requires=docker.service
+
+[Service]
+Type=simple
+ExecStartPre=-/usr/bin/docker rm -f tei-rerank
+ExecStart=/usr/bin/docker run --rm --name tei-rerank \
+  --gpus all \
+  -p 8082:80 \
+  -v /var/lib/llm/hf-cache:/data \
+  ghcr.io/huggingface/text-embeddings-inference:1.5 \
+  --model-id BAAI/bge-reranker-v2-m3 \
+  --port 80
+ExecStop=/usr/bin/docker stop tei-rerank
+Restart=on-failure
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target

--- a/tests/local/FA-32.sh
+++ b/tests/local/FA-32.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# FA-32: LLM router returns 1024-dim bge-m3 vectors when TEI is up.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "${SCRIPT_DIR}/lib/assert.sh"
+
+NS="${NS:-workspace}"
+
+# T1: llm-router pod is Ready
+READY=$(kubectl -n "$NS" get deploy/llm-router -o jsonpath='{.status.readyReplicas}' 2>/dev/null || echo "")
+if [[ "$READY" == "1" ]]; then
+  _log_result "FA-32" "T1" "llm-router pod is Ready" "pass" "0"
+else
+  _log_result "FA-32" "T1" "llm-router pod is Ready" "fail" "0" "readyReplicas=${READY:-0}"
+fi
+
+# T2: bge-m3 embedding round-trip returns 1024-dim vector
+RESPONSE=$(kubectl -n "$NS" exec deploy/llm-router -- \
+  curl -fsS -X POST http://localhost:4000/v1/embeddings \
+    -H 'Content-Type: application/json' \
+    -d '{"model":"bge-m3","input":"hallo welt"}' 2>/dev/null || echo "")
+DIM=$(echo "$RESPONSE" | jq '.data[0].embedding | length' 2>/dev/null || echo "0")
+if [[ "$DIM" == "1024" ]]; then
+  _log_result "FA-32" "T2" "bge-m3 embedding round-trip returns 1024-dim vector" "pass" "0"
+else
+  _log_result "FA-32" "T2" "bge-m3 embedding round-trip returns 1024-dim vector" "fail" "0" "dim=${DIM}"
+fi

--- a/tests/local/FA-33.sh
+++ b/tests/local/FA-33.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# FA-33: voyage-multilingual-2 model passes through the router and returns
+#        Voyage vectors regardless of TEI state.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "${SCRIPT_DIR}/lib/assert.sh"
+
+NS="${NS:-workspace}"
+
+# T1: voyage-multilingual-2 returns 1024-dim vector
+RESPONSE=$(kubectl -n "$NS" exec deploy/llm-router -- \
+  curl -fsS -X POST http://localhost:4000/v1/embeddings \
+    -H 'Content-Type: application/json' \
+    -d '{"model":"voyage-multilingual-2","input":"capital of germany"}' 2>/dev/null || echo "")
+DIM=$(echo "$RESPONSE" | jq '.data[0].embedding | length' 2>/dev/null || echo "0")
+if [[ "$DIM" == "1024" ]]; then
+  _log_result "FA-33" "T1" "voyage-multilingual-2 returns 1024-dim vector" "pass" "0"
+else
+  _log_result "FA-33" "T1" "voyage-multilingual-2 returns 1024-dim vector" "fail" "0" "dim=${DIM}"
+fi
+
+# T2: voyage path produces a valid embedding object
+EMBEDDING=$(echo "$RESPONSE" | jq -r '.data[0].embedding' 2>/dev/null || echo "")
+if [[ -n "$EMBEDDING" && "$EMBEDDING" != "null" ]]; then
+  _log_result "FA-33" "T2" "voyage path produces valid embedding object" "pass" "0"
+else
+  _log_result "FA-33" "T2" "voyage path produces valid embedding object" "fail" "0" "no embedding in response"
+fi

--- a/tests/local/FA-34.sh
+++ b/tests/local/FA-34.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# FA-34: With TEI down and model=bge-m3 + purpose=index, the router returns 5xx —
+#        it must NEVER silently fall back to Voyage.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "${SCRIPT_DIR}/lib/assert.sh"
+
+NS="${NS:-workspace}"
+
+_restore_endpoints() {
+  if [[ -f /tmp/llm-gateway-embed.bak ]]; then
+    kubectl -n "$NS" apply -f /tmp/llm-gateway-embed.bak >/dev/null 2>&1 || true
+    rm -f /tmp/llm-gateway-embed.bak
+  fi
+}
+trap _restore_endpoints EXIT
+
+# T1: bge-m3 + purpose=index fails closed when TEI Endpoints is empty
+kubectl -n "$NS" get endpoints llm-gateway-embed -o yaml > /tmp/llm-gateway-embed.bak 2>/dev/null || true
+kubectl -n "$NS" patch endpoints llm-gateway-embed --type=json \
+  -p='[{"op":"replace","path":"/subsets/0/addresses/0/ip","value":"127.0.0.42"}]' >/dev/null 2>&1 || true
+sleep 2
+
+STATUS=$(kubectl -n "$NS" exec deploy/llm-router -- \
+  curl -s -o /tmp/r.json -w '%{http_code}' \
+    -H 'Content-Type: application/json' -H 'X-LLM-Purpose: index' \
+    -d '{"model":"bge-m3","input":"hello"}' \
+    http://localhost:4000/v1/embeddings 2>/dev/null || echo "000")
+RESP=$(kubectl -n "$NS" exec deploy/llm-router -- cat /tmp/r.json 2>/dev/null || echo '{}')
+
+if [[ "$STATUS" -ge 500 ]]; then
+  HAS_EMBED=$(echo "$RESP" | jq 'has("data")' 2>/dev/null || echo "false")
+  if [[ "$HAS_EMBED" == "true" ]]; then
+    _log_result "FA-34" "T1" "bge-m3 fails closed when TEI is down (no Voyage fallback)" "fail" "0" "router silently fell back to Voyage"
+  else
+    _log_result "FA-34" "T1" "bge-m3 fails closed when TEI is down (no Voyage fallback)" "pass" "0"
+  fi
+else
+  _log_result "FA-34" "T1" "bge-m3 fails closed when TEI is down (no Voyage fallback)" "fail" "0" "expected 5xx got ${STATUS}"
+fi

--- a/tests/local/FA-35.sh
+++ b/tests/local/FA-35.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# FA-35: Querying a bge-m3 collection with a Voyage-tagged collection in the
+#        same call must throw MixedEmbeddingModelError.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "${SCRIPT_DIR}/lib/assert.sh"
+
+WEBSITE_NS="${WEBSITE_NS:-website}"
+
+# T1: queryNearest rejects mixed embedding_model collections
+OUT=$(kubectl -n "$WEBSITE_NS" exec deploy/website -- node -e '
+  const { createPool } = require("pg");
+  // We test the client-side error, not via live DB. Use a direct import check instead.
+  // Since the website is SSR-compiled, check the error class is exported correctly.
+  try {
+    // Minimal import check: the class exists and has the right name.
+    const m = require("/app/dist/server/chunks/knowledge-db.mjs") ||
+              require("/app/dist/lib/knowledge-db.js") || {};
+    const E = m.MixedEmbeddingModelError;
+    if (E && new E(["bge-m3","voyage-multilingual-2"]).message.includes("MixedEmbeddingModelError")) {
+      console.log("ERR:MixedEmbeddingModelError");
+    } else {
+      console.log("NOT_FOUND");
+    }
+  } catch(e) {
+    console.log("IMPORT_ERR:" + e.message);
+  }
+' 2>/dev/null || echo "POD_ERR")
+
+if echo "$OUT" | grep -q "MixedEmbeddingModelError"; then
+  _log_result "FA-35" "T1" "MixedEmbeddingModelError is exported and functional" "pass" "0"
+else
+  _log_result "FA-35" "T1" "MixedEmbeddingModelError is exported and functional" "fail" "0" "$OUT"
+fi

--- a/tests/local/FA-36.sh
+++ b/tests/local/FA-36.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# FA-36: /v1/rerank returns sorted results; correct top-1 on a fixture set.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "${SCRIPT_DIR}/lib/assert.sh"
+
+NS="${NS:-workspace}"
+
+# T1: rerank places 'berlin' first for 'capital of germany'
+RESPONSE=$(kubectl -n "$NS" exec deploy/llm-router -- \
+  curl -fsS -X POST http://localhost:4000/v1/rerank \
+    -H 'Content-Type: application/json' \
+    -d '{"model":"workspace-rerank","query":"capital of germany","documents":["paris","berlin","hamburg","munich"]}' \
+  2>/dev/null || echo "")
+TOP=$(echo "$RESPONSE" | jq -r '.results[0].index' 2>/dev/null || echo "")
+# 'berlin' is index 1 in the documents array
+if [[ "$TOP" == "1" ]]; then
+  _log_result "FA-36" "T1" "rerank places 'berlin' first for 'capital of germany'" "pass" "0"
+else
+  _log_result "FA-36" "T1" "rerank places 'berlin' first for 'capital of germany'" "fail" "0" "top index=${TOP}"
+fi

--- a/tests/local/FA-37.sh
+++ b/tests/local/FA-37.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# FA-37: workspace-chat round-trips a 200-token German prompt successfully.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "${SCRIPT_DIR}/lib/assert.sh"
+
+NS="${NS:-workspace}"
+
+# T1: workspace-chat returns non-empty content
+RESPONSE=$(kubectl -n "$NS" exec deploy/llm-router -- \
+  curl -fsS --max-time 90 -X POST http://localhost:4000/v1/chat/completions \
+    -H 'Content-Type: application/json' \
+    -d '{"model":"workspace-chat","messages":[{"role":"user","content":"Beschreibe die Stadt Hamburg in zwei Sätzen."}],"max_tokens":120}' \
+  2>/dev/null || echo "")
+CONTENT=$(echo "$RESPONSE" | jq -r '.choices[0].message.content' 2>/dev/null || echo "")
+if [[ -n "$CONTENT" && "${#CONTENT}" -gt 30 ]]; then
+  _log_result "FA-37" "T1" "workspace-chat returns non-empty German content" "pass" "0"
+else
+  _log_result "FA-37" "T1" "workspace-chat returns non-empty German content" "fail" "0" "content='${CONTENT}'"
+fi

--- a/tests/local/FA-38.sh
+++ b/tests/local/FA-38.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# FA-38: With Ollama unreachable, workspace-chat returns successfully via Anthropic.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "${SCRIPT_DIR}/lib/assert.sh"
+
+NS="${NS:-workspace}"
+
+_restore_chat() {
+  if [[ -f /tmp/llm-gateway-chat.bak ]]; then
+    kubectl -n "$NS" apply -f /tmp/llm-gateway-chat.bak >/dev/null 2>&1 || true
+    rm -f /tmp/llm-gateway-chat.bak
+  fi
+}
+trap _restore_chat EXIT
+
+# T1: workspace-chat falls back to Anthropic when Ollama Endpoints is down
+kubectl -n "$NS" get endpoints llm-gateway-chat -o yaml > /tmp/llm-gateway-chat.bak 2>/dev/null || true
+kubectl -n "$NS" patch endpoints llm-gateway-chat --type=json \
+  -p='[{"op":"replace","path":"/subsets/0/addresses/0/ip","value":"127.0.0.42"}]' >/dev/null 2>&1 || true
+sleep 2
+
+RESPONSE=$(kubectl -n "$NS" exec deploy/llm-router -- \
+  curl -fsS --max-time 60 -X POST http://localhost:4000/v1/chat/completions \
+    -H 'Content-Type: application/json' \
+    -d '{"model":"workspace-chat","messages":[{"role":"user","content":"Sag Hallo."}],"max_tokens":20}' \
+  2>/dev/null || echo "")
+CONTENT=$(echo "$RESPONSE" | jq -r '.choices[0].message.content' 2>/dev/null || echo "")
+MODEL=$(echo "$RESPONSE" | jq -r '.model' 2>/dev/null || echo "")
+
+if [[ -n "$CONTENT" ]] && (echo "$MODEL" | grep -qiE "anthropic|claude"); then
+  _log_result "FA-38" "T1" "workspace-chat falls back to Anthropic when Ollama is down" "pass" "0"
+elif [[ -n "$CONTENT" ]]; then
+  _log_result "FA-38" "T1" "workspace-chat falls back to Anthropic when Ollama is down" "fail" "0" "got content but model=${MODEL}"
+else
+  _log_result "FA-38" "T1" "workspace-chat falls back to Anthropic when Ollama is down" "fail" "0" "no content returned"
+fi

--- a/tests/local/NFA-10.sh
+++ b/tests/local/NFA-10.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# NFA-10: Cloud-fallback for chat-class requests completes within 5x the local p95.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "${SCRIPT_DIR}/lib/assert.sh"
+
+NS="${NS:-workspace}"
+
+_restore_chat() {
+  if [[ -f /tmp/llm-gateway-chat.bak ]]; then
+    kubectl -n "$NS" apply -f /tmp/llm-gateway-chat.bak >/dev/null 2>&1 || true
+    rm -f /tmp/llm-gateway-chat.bak
+  fi
+}
+trap _restore_chat EXIT
+
+# Measure 5 local samples
+LOCAL_TIMES=()
+for i in 1 2 3 4 5; do
+  T=$({ time kubectl -n "$NS" exec deploy/llm-router -- \
+    curl -fsS -o /dev/null --max-time 30 -X POST http://localhost:4000/v1/chat/completions \
+      -H 'Content-Type: application/json' \
+      -d '{"model":"workspace-chat","messages":[{"role":"user","content":"hi"}],"max_tokens":10}' \
+    2>/dev/null; } 2>&1 | awk '/real/{print $2}' | sed 's/m/\* 60 + /; s/s//' | bc 2>/dev/null || echo "30")
+  LOCAL_TIMES+=("$T")
+done
+
+# p95 ≈ max of 5 samples
+P95=$(printf '%s\n' "${LOCAL_TIMES[@]}" | sort -n | tail -1)
+
+# Measure one fallback sample
+kubectl -n "$NS" get endpoints llm-gateway-chat -o yaml > /tmp/llm-gateway-chat.bak 2>/dev/null || true
+kubectl -n "$NS" patch endpoints llm-gateway-chat --type=json \
+  -p='[{"op":"replace","path":"/subsets/0/addresses/0/ip","value":"127.0.0.42"}]' >/dev/null 2>&1 || true
+sleep 2
+
+FALLBACK=$({ time kubectl -n "$NS" exec deploy/llm-router -- \
+  curl -fsS -o /dev/null --max-time 60 -X POST http://localhost:4000/v1/chat/completions \
+    -H 'Content-Type: application/json' \
+    -d '{"model":"workspace-chat","messages":[{"role":"user","content":"hi"}],"max_tokens":10}' \
+  2>/dev/null; } 2>&1 | awk '/real/{print $2}' | sed 's/m/\* 60 + /; s/s//' | bc 2>/dev/null || echo "999")
+
+# T1: fallback latency ≤ 5× p95
+THRESHOLD=$(echo "5 * $P95" | bc 2>/dev/null || echo "0")
+if awk -v f="$FALLBACK" -v t="$THRESHOLD" 'BEGIN{ exit !(f+0 <= t+0) }'; then
+  _log_result "NFA-10" "T1" "Fallback latency ≤ 5× local p95 (fallback=${FALLBACK}s, p95=${P95}s, threshold=${THRESHOLD}s)" "pass" "0"
+else
+  _log_result "NFA-10" "T1" "Fallback latency ≤ 5× local p95" "fail" "0" "fallback=${FALLBACK}s > threshold=${THRESHOLD}s (p95=${P95}s)"
+fi

--- a/tests/local/NFA-11.sh
+++ b/tests/local/NFA-11.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# NFA-11: After all four Ollama models are touched in sequence, VRAM stays
+#         under 14 GB and TEI services are still responsive.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "${SCRIPT_DIR}/lib/assert.sh"
+
+LLM_HOST_IP="${LLM_HOST_IP:-10.0.0.99}"
+LLM_HOST="${LLM_HOST:-root@${LLM_HOST_IP}}"
+SSH_KEY="${SSH_KEY:-$HOME/.ssh/id_ed25519_hetzner}"
+
+# T1: rotate through all 4 Ollama models, then verify TEI + VRAM
+for m in qwen2.5:14b-instruct-q4_K_M qwen2.5-coder:14b-instruct-q4_K_M qwen2.5vl:7b-instruct-q4_K_M llama3.2:3b-instruct-q4_K_M; do
+  ssh -i "$SSH_KEY" -o StrictHostKeyChecking=accept-new "$LLM_HOST" \
+    "curl -fsS -X POST http://127.0.0.1:11434/api/generate -d '{\"model\":\"$m\",\"prompt\":\"hi\",\"stream\":false,\"options\":{\"num_predict\":1}}'" \
+    >/dev/null 2>&1 || true
+done
+
+USED_MIB=$(ssh -i "$SSH_KEY" "$LLM_HOST" \
+  "nvidia-smi --query-gpu=memory.used --format=csv,noheader,nounits" 2>/dev/null || echo "99999")
+
+# 14 GB ≈ 14336 MiB
+if [[ "$USED_MIB" -lt 14336 ]]; then
+  _log_result "NFA-11" "T1" "VRAM under 14 GB after model rotation (${USED_MIB} MiB used)" "pass" "0"
+else
+  _log_result "NFA-11" "T1" "VRAM under 14 GB after model rotation" "fail" "0" "VRAM=${USED_MIB} MiB ≥ 14336 MiB"
+fi
+
+# T2: TEI embed still responsive
+TEI_EMBED=$(ssh -i "$SSH_KEY" "$LLM_HOST" "curl -fsS http://127.0.0.1:8081/health" 2>/dev/null && echo "ok" || echo "fail")
+if [[ "$TEI_EMBED" == "ok" ]]; then
+  _log_result "NFA-11" "T2" "TEI embed (bge-m3) still responsive after rotation" "pass" "0"
+else
+  _log_result "NFA-11" "T2" "TEI embed (bge-m3) still responsive after rotation" "fail" "0" "TEI embed health check failed"
+fi
+
+# T3: TEI rerank still responsive
+TEI_RERANK=$(ssh -i "$SSH_KEY" "$LLM_HOST" "curl -fsS http://127.0.0.1:8082/health" 2>/dev/null && echo "ok" || echo "fail")
+if [[ "$TEI_RERANK" == "ok" ]]; then
+  _log_result "NFA-11" "T3" "TEI rerank (bge-reranker-v2-m3) still responsive after rotation" "pass" "0"
+else
+  _log_result "NFA-11" "T3" "TEI rerank (bge-reranker-v2-m3) still responsive after rotation" "fail" "0" "TEI rerank health check failed"
+fi

--- a/website/src/data/test-inventory.json
+++ b/website/src/data/test-inventory.json
@@ -588,6 +588,48 @@
     "kind": "shell"
   },
   {
+    "id": "FA-32",
+    "file": "tests/local/FA-32.sh",
+    "category": "FA",
+    "kind": "shell"
+  },
+  {
+    "id": "FA-33",
+    "file": "tests/local/FA-33.sh",
+    "category": "FA",
+    "kind": "shell"
+  },
+  {
+    "id": "FA-34",
+    "file": "tests/local/FA-34.sh",
+    "category": "FA",
+    "kind": "shell"
+  },
+  {
+    "id": "FA-35",
+    "file": "tests/local/FA-35.sh",
+    "category": "FA",
+    "kind": "shell"
+  },
+  {
+    "id": "FA-36",
+    "file": "tests/local/FA-36.sh",
+    "category": "FA",
+    "kind": "shell"
+  },
+  {
+    "id": "FA-37",
+    "file": "tests/local/FA-37.sh",
+    "category": "FA",
+    "kind": "shell"
+  },
+  {
+    "id": "FA-38",
+    "file": "tests/local/FA-38.sh",
+    "category": "FA",
+    "kind": "shell"
+  },
+  {
     "id": "NFA-01",
     "file": "tests/local/NFA-01.sh",
     "category": "NFA",
@@ -662,6 +704,18 @@
   {
     "id": "NFA-09",
     "file": "tests/local/NFA-09.sh",
+    "category": "NFA",
+    "kind": "shell"
+  },
+  {
+    "id": "NFA-10",
+    "file": "tests/local/NFA-10.sh",
+    "category": "NFA",
+    "kind": "shell"
+  },
+  {
+    "id": "NFA-11",
+    "file": "tests/local/NFA-11.sh",
     "category": "NFA",
     "kind": "shell"
   },

--- a/website/src/lib/embeddings.test.ts
+++ b/website/src/lib/embeddings.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeEach, vi } from 'vitest';
+import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest';
 import { embedQuery, embedBatch, costCentsForTokens, ANTHROPIC_FALLBACK_MODEL_DIM } from './embeddings';
 
 const ORIGINAL_FETCH = global.fetch;
@@ -41,5 +41,72 @@ describe('embeddings client', () => {
 
   test('ANTHROPIC_FALLBACK_MODEL_DIM is 1024 for voyage-multilingual-2', () => {
     expect(ANTHROPIC_FALLBACK_MODEL_DIM).toBe(1024);
+  });
+});
+
+describe('embeddings client — router mode (LLM_ENABLED=true)', () => {
+  const ORIGINAL_ENV = process.env.LLM_ENABLED;
+  const ORIGINAL_URL = process.env.LLM_ROUTER_URL;
+
+  beforeEach(() => {
+    process.env.LLM_ENABLED = 'true';
+    process.env.LLM_ROUTER_URL = 'http://llm-router.test:4000';
+    global.fetch = ORIGINAL_FETCH;
+  });
+  afterEach(() => {
+    process.env.LLM_ENABLED = ORIGINAL_ENV;
+    process.env.LLM_ROUTER_URL = ORIGINAL_URL;
+  });
+
+  test('routes bge-m3 query to LLM_ROUTER_URL with X-LLM-Purpose=query', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(
+      JSON.stringify({ data: [{ embedding: Array(1024).fill(0.02) }], usage: { total_tokens: 8 } }),
+      { status: 200 },
+    ));
+    global.fetch = fetchMock;
+
+    const r = await embedQuery('hallo', { model: 'bge-m3', purpose: 'query' });
+    expect(r.embedding).toHaveLength(1024);
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(String(url)).toBe('http://llm-router.test:4000/v1/embeddings');
+    expect((init as RequestInit).headers).toMatchObject({ 'X-LLM-Purpose': 'query' });
+    const body = JSON.parse((init as RequestInit).body as string);
+    expect(body.model).toBe('bge-m3');
+  });
+
+  test('routes voyage-multilingual-2 model through the router (no direct voyage call)', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(
+      JSON.stringify({ data: [{ embedding: Array(1024).fill(0.03) }], usage: { total_tokens: 9 } }),
+      { status: 200 },
+    ));
+    global.fetch = fetchMock;
+    await embedQuery('hi', { model: 'voyage-multilingual-2', purpose: 'query' });
+    expect(String(fetchMock.mock.calls[0][0])).toContain('llm-router.test');
+  });
+
+  test('purpose=index, router 503 → throws EmbeddingIndexError (no fallback)', async () => {
+    global.fetch = vi.fn().mockResolvedValue(new Response('upstream down', { status: 503 }));
+    await expect(
+      embedBatch(['a', 'b'], { model: 'bge-m3', purpose: 'index', maxAttempts: 1, baseDelayMs: 1 }),
+    ).rejects.toThrow(/EmbeddingIndexError/);
+  });
+
+  test('purpose=query, router 503 → throws EmbeddingQueryError (no fallback)', async () => {
+    global.fetch = vi.fn().mockResolvedValue(new Response('down', { status: 503 }));
+    await expect(
+      embedQuery('q', { model: 'bge-m3', purpose: 'query', maxAttempts: 1, baseDelayMs: 1 }),
+    ).rejects.toThrow(/EmbeddingQueryError/);
+  });
+
+  test('LLM_ENABLED=false ignores model param and uses direct voyage call', async () => {
+    process.env.LLM_ENABLED = 'false';
+    const fetchMock = vi.fn().mockResolvedValue(new Response(
+      JSON.stringify({ data: [{ embedding: Array(1024).fill(0) }], usage: { total_tokens: 1 } }),
+      { status: 200 },
+    ));
+    global.fetch = fetchMock;
+    await embedQuery('x', { model: 'bge-m3', purpose: 'query' });
+    expect(String(fetchMock.mock.calls[0][0])).toContain('voyageai.com');
   });
 });

--- a/website/src/lib/embeddings.ts
+++ b/website/src/lib/embeddings.ts
@@ -5,24 +5,43 @@ const VOYAGE_DOLLARS_PER_M_TOKENS = 0.06;
 
 export const ANTHROPIC_FALLBACK_MODEL_DIM = 1024;
 
+export type EmbeddingModel = 'bge-m3' | 'voyage-multilingual-2';
+export type EmbeddingPurpose = 'index' | 'query';
+
 export interface EmbedResult { embedding: number[]; tokens: number; }
 export interface BatchResult  { embeddings: number[][]; tokens: number; }
-export interface EmbedOpts    { maxAttempts?: number; baseDelayMs?: number; signal?: AbortSignal; }
+export interface EmbedOpts {
+  maxAttempts?: number;
+  baseDelayMs?: number;
+  signal?: AbortSignal;
+  model?: EmbeddingModel;
+  purpose?: EmbeddingPurpose;
+}
 
-const apiKey = () => {
+export class EmbeddingIndexError extends Error {
+  constructor(msg: string) { super(`EmbeddingIndexError: ${msg}`); this.name = 'EmbeddingIndexError'; }
+}
+export class EmbeddingQueryError extends Error {
+  constructor(msg: string) { super(`EmbeddingQueryError: ${msg}`); this.name = 'EmbeddingQueryError'; }
+}
+
+const voyageKey = () => {
   const k = process.env.VOYAGE_API_KEY;
   if (!k) throw new Error('VOYAGE_API_KEY is unset');
   return k;
 };
 
-async function callVoyage(inputs: string[], inputType: 'query' | 'document', opts: EmbedOpts) {
+const isLlmEnabled = () => process.env.LLM_ENABLED === 'true';
+const routerUrl = () => process.env.LLM_ROUTER_URL ?? 'http://llm-router.workspace.svc.cluster.local:4000';
+
+async function callVoyageDirect(inputs: string[], inputType: 'query' | 'document', opts: EmbedOpts) {
   const max = opts.maxAttempts ?? 4;
   const base = opts.baseDelayMs ?? 250;
   let lastErr: unknown;
   for (let attempt = 1; attempt <= max; attempt++) {
     const r = await fetch(VOYAGE_URL, {
       method: 'POST',
-      headers: { 'Authorization': `Bearer ${apiKey()}`, 'Content-Type': 'application/json' },
+      headers: { 'Authorization': `Bearer ${voyageKey()}`, 'Content-Type': 'application/json' },
       body: JSON.stringify({ input: inputs, model: VOYAGE_MODEL, input_type: inputType }),
       signal: opts.signal,
     });
@@ -40,17 +59,55 @@ async function callVoyage(inputs: string[], inputType: 'query' | 'document', opt
   throw lastErr instanceof Error ? lastErr : new Error('voyage retry exhausted');
 }
 
+async function callRouter(inputs: string[], opts: Required<Pick<EmbedOpts, 'model' | 'purpose'>> & EmbedOpts) {
+  const max = opts.maxAttempts ?? 4;
+  const base = opts.baseDelayMs ?? 250;
+  let lastErr: unknown;
+  for (let attempt = 1; attempt <= max; attempt++) {
+    const r = await fetch(`${routerUrl()}/v1/embeddings`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'X-LLM-Purpose': opts.purpose },
+      body: JSON.stringify({ model: opts.model, input: inputs }),
+      signal: opts.signal,
+    });
+    if (r.ok) {
+      const j = await r.clone().json() as { data: Array<{ embedding: number[] }>; usage?: { total_tokens?: number } };
+      return { embeddings: j.data.slice(0, inputs.length).map(d => d.embedding), tokens: j.usage?.total_tokens ?? 0 };
+    }
+    if (r.status === 429 || r.status >= 500) {
+      lastErr = new Error(`router ${r.status} ${await r.clone().text().catch(() => '')}`);
+      await new Promise(res => setTimeout(res, base * 2 ** (attempt - 1)));
+      continue;
+    }
+    throw opts.purpose === 'index'
+      ? new EmbeddingIndexError(`router ${r.status} ${await r.clone().text().catch(() => '')}`)
+      : new EmbeddingQueryError(`router ${r.status} ${await r.clone().text().catch(() => '')}`);
+  }
+  throw opts.purpose === 'index'
+    ? new EmbeddingIndexError(lastErr instanceof Error ? lastErr.message : 'router retry exhausted')
+    : new EmbeddingQueryError(lastErr instanceof Error ? lastErr.message : 'router retry exhausted');
+}
+
 export async function embedQuery(text: string, opts: EmbedOpts = {}): Promise<EmbedResult> {
-  const r = await callVoyage([text], 'query', opts);
+  const purpose: EmbeddingPurpose = opts.purpose ?? 'query';
+  if (isLlmEnabled()) {
+    const model: EmbeddingModel = opts.model ?? 'bge-m3';
+    const r = await callRouter([text], { ...opts, model, purpose });
+    return { embedding: r.embeddings[0], tokens: r.tokens };
+  }
+  const r = await callVoyageDirect([text], 'query', opts);
   return { embedding: r.embeddings[0], tokens: r.tokens };
 }
 
 export async function embedBatch(texts: string[], opts: EmbedOpts = {}): Promise<BatchResult> {
+  const purpose: EmbeddingPurpose = opts.purpose ?? 'index';
   const out: number[][] = [];
   let totalTokens = 0;
   for (let i = 0; i < texts.length; i += VOYAGE_BATCH) {
     const slice = texts.slice(i, i + VOYAGE_BATCH);
-    const r = await callVoyage(slice, 'document', opts);
+    const r = isLlmEnabled()
+      ? await callRouter(slice, { ...opts, model: opts.model ?? 'bge-m3', purpose })
+      : await callVoyageDirect(slice, 'document', opts);
     out.push(...r.embeddings);
     totalTokens += r.tokens;
   }

--- a/website/src/lib/knowledge-db.test.ts
+++ b/website/src/lib/knowledge-db.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { describe, test, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
 import { newDb } from 'pg-mem';
 import * as kdb from './knowledge-db';
 
@@ -86,5 +86,50 @@ describe('knowledge-db', () => {
   test('deleteCollection refuses non-custom', async () => {
     const c = await kdb.createCollection({ name: 'test', source: 'pr_history' });
     await expect(kdb.deleteCollection(c.id)).rejects.toThrow(/custom/i);
+  });
+});
+
+describe('knowledge-db — model-aware query path', () => {
+  const ORIGINAL_LLM_ENABLED = process.env.LLM_ENABLED;
+
+  beforeEach(async () => {
+    await (pool as any).query('TRUNCATE knowledge.chunks');
+    await (pool as any).query('TRUNCATE knowledge.documents');
+    await (pool as any).query('TRUNCATE knowledge.collections');
+    process.env.LLM_ENABLED = 'false';
+  });
+
+  afterAll(() => {
+    process.env.LLM_ENABLED = ORIGINAL_LLM_ENABLED;
+  });
+
+  test('queryNearest reads embedding_model from collection and passes to embedQuery', async () => {
+    const c = await kdb.createCollection({ name: 'kn-bge', source: 'custom', embeddingModel: 'bge-m3' });
+    const calls: Array<{ text: string; model?: string; purpose?: string }> = [];
+    const embedMod = await import('./embeddings');
+    vi.spyOn(embedMod, 'embedQuery').mockImplementationOnce(async (text, opts) => {
+      calls.push({ text, model: opts?.model, purpose: opts?.purpose });
+      return { embedding: Array(1024).fill(0.01), tokens: 1 };
+    });
+    await kdb.queryNearest({ collectionIds: [c.id], queryText: 'hallo' }).catch(() => {});
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({ text: 'hallo', model: 'bge-m3', purpose: 'query' });
+    vi.restoreAllMocks();
+  });
+
+  test('queryNearest throws MixedEmbeddingModelError when collectionIds disagree on model', async () => {
+    const a = await kdb.createCollection({ name: 'kn-bge-x', source: 'custom', embeddingModel: 'bge-m3' });
+    const b = await kdb.createCollection({ name: 'kn-vy-x',  source: 'custom', embeddingModel: 'voyage-multilingual-2' });
+    await expect(kdb.queryNearest({ collectionIds: [a.id, b.id], queryText: 'q' }))
+      .rejects.toThrow(/MixedEmbeddingModelError/);
+  });
+
+  test('createCollection defaults to bge-m3 when LLM_ENABLED=true, voyage-multilingual-2 otherwise', async () => {
+    process.env.LLM_ENABLED = 'true';
+    const a = await kdb.createCollection({ name: 'kn-default-bge', source: 'custom' });
+    expect(a.embedding_model).toBe('bge-m3');
+    process.env.LLM_ENABLED = 'false';
+    const b = await kdb.createCollection({ name: 'kn-default-voyage', source: 'custom' });
+    expect(b.embedding_model).toBe('voyage-multilingual-2');
   });
 });

--- a/website/src/lib/knowledge-db.ts
+++ b/website/src/lib/knowledge-db.ts
@@ -1,4 +1,12 @@
 import { Pool } from 'pg';
+import { embedQuery, type EmbeddingModel } from './embeddings';
+
+export class MixedEmbeddingModelError extends Error {
+  constructor(models: string[]) {
+    super(`MixedEmbeddingModelError: collections span multiple embedding models (${models.join(', ')}); cross-space queries are not allowed`);
+    this.name = 'MixedEmbeddingModelError';
+  }
+}
 
 let _pool: Pool | null = null;
 function p(): Pool {
@@ -63,14 +71,16 @@ export async function getCollection(id: string): Promise<Collection | null> {
 
 export async function createCollection(args: {
   name: string; source: CollectionSource; description?: string; brand?: string | null;
-  createdBy?: string | null;
+  createdBy?: string | null; embeddingModel?: EmbeddingModel;
 }): Promise<Collection> {
+  const model: EmbeddingModel = args.embeddingModel
+    ?? (process.env.LLM_ENABLED === 'true' ? 'bge-m3' : 'voyage-multilingual-2');
   const r = await p().query(
-    `INSERT INTO knowledge.collections (name, source, description, brand, created_by)
-     VALUES ($1, $2, $3, $4, $5)
+    `INSERT INTO knowledge.collections (name, source, description, brand, created_by, embedding_model)
+     VALUES ($1, $2, $3, $4, $5, $6)
      RETURNING id, name, description, source, brand, chunk_count,
                last_indexed_at, embedding_model, created_at`,
-    [args.name, args.source, args.description ?? null, args.brand ?? null, args.createdBy ?? null],
+    [args.name, args.source, args.description ?? null, args.brand ?? null, args.createdBy ?? null, model],
   );
   return r.rows[0];
 }
@@ -128,10 +138,28 @@ export async function recountChunks(collectionId: string): Promise<void> {
 }
 
 export async function queryNearest(args: {
-  collectionIds: string[]; queryEmbedding: number[]; limit?: number; threshold?: number;
+  collectionIds: string[]; queryText: string; limit?: number; threshold?: number; signal?: AbortSignal;
 }): Promise<Array<{ id: string; text: string; collection_id: string; document_id: string; score: number }>> {
   const limit  = args.limit     ?? 6;
   const thresh = args.threshold ?? 0.65;
+
+  if (args.collectionIds.length === 0) return [];
+
+  const placeholders = args.collectionIds.map((_, i) => `$${i + 1}`).join(',');
+  const modelsRes = await p().query(
+    `SELECT DISTINCT embedding_model FROM knowledge.collections WHERE id IN (${placeholders})`,
+    args.collectionIds,
+  );
+  const models = modelsRes.rows.map((r: { embedding_model: string }) => r.embedding_model);
+  if (models.length > 1) throw new MixedEmbeddingModelError(models);
+  if (models.length === 0) return [];
+
+  const { embedding } = await embedQuery(args.queryText, {
+    model: models[0] as EmbeddingModel,
+    purpose: 'query',
+    signal: args.signal,
+  });
+
   const r = await p().query(
     `SELECT id, text, collection_id, document_id,
             1 - (embedding <=> $1) AS score
@@ -139,7 +167,7 @@ export async function queryNearest(args: {
       WHERE collection_id = ANY($2::uuid[])
       ORDER BY embedding <=> $1
       LIMIT $3`,
-    [vecLiteral(args.queryEmbedding), args.collectionIds, limit],
+    [vecLiteral(embedding), args.collectionIds, limit],
   );
   return r.rows.filter((row: { score: number }) => row.score >= thresh);
 }

--- a/website/src/lib/rerank.test.ts
+++ b/website/src/lib/rerank.test.ts
@@ -1,0 +1,55 @@
+import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest';
+import { rerankCandidates } from './rerank';
+
+const ORIGINAL_FETCH = global.fetch;
+const ORIGINAL_ENABLED = process.env.LLM_RERANK_ENABLED;
+const ORIGINAL_URL = process.env.LLM_ROUTER_URL;
+
+describe('rerank client', () => {
+  beforeEach(() => {
+    process.env.LLM_RERANK_ENABLED = 'true';
+    process.env.LLM_ROUTER_URL = 'http://llm-router.test:4000';
+    global.fetch = ORIGINAL_FETCH;
+  });
+  afterEach(() => {
+    process.env.LLM_RERANK_ENABLED = ORIGINAL_ENABLED;
+    process.env.LLM_ROUTER_URL = ORIGINAL_URL;
+  });
+
+  test('returns docs sorted descending by score on happy path', async () => {
+    global.fetch = vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      results: [
+        { index: 1, relevance_score: 0.9 },
+        { index: 0, relevance_score: 0.4 },
+        { index: 2, relevance_score: 0.1 },
+      ],
+    }), { status: 200 }));
+    const out = await rerankCandidates('q', ['a', 'b', 'c']);
+    expect(out).toEqual([
+      { doc: 'b', score: 0.9 },
+      { doc: 'a', score: 0.4 },
+      { doc: 'c', score: 0.1 },
+    ]);
+  });
+
+  test('returns input docs with score=0 when LLM_RERANK_ENABLED=false', async () => {
+    process.env.LLM_RERANK_ENABLED = 'false';
+    global.fetch = vi.fn();
+    const out = await rerankCandidates('q', ['a', 'b']);
+    expect(out).toEqual([{ doc: 'a', score: 0 }, { doc: 'b', score: 0 }]);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  test('on router 503 returns input docs with score=0 (graceful)', async () => {
+    global.fetch = vi.fn().mockResolvedValue(new Response('down', { status: 503 }));
+    const out = await rerankCandidates('q', ['a', 'b']);
+    expect(out).toEqual([{ doc: 'a', score: 0 }, { doc: 'b', score: 0 }]);
+  });
+
+  test('empty docs returns empty array without calling fetch', async () => {
+    global.fetch = vi.fn();
+    const out = await rerankCandidates('q', []);
+    expect(out).toEqual([]);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+});

--- a/website/src/lib/rerank.ts
+++ b/website/src/lib/rerank.ts
@@ -1,0 +1,29 @@
+const routerUrl = () => process.env.LLM_ROUTER_URL ?? 'http://llm-router.workspace.svc.cluster.local:4000';
+const rerankEnabled = () => process.env.LLM_RERANK_ENABLED === 'true';
+
+export interface RerankResult { doc: string; score: number; }
+
+export async function rerankCandidates(
+  query: string,
+  docs: string[],
+  opts: { signal?: AbortSignal } = {},
+): Promise<RerankResult[]> {
+  if (docs.length === 0) return [];
+  if (!rerankEnabled()) return docs.map(doc => ({ doc, score: 0 }));
+
+  try {
+    const r = await fetch(`${routerUrl()}/v1/rerank`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model: 'workspace-rerank', query, documents: docs }),
+      signal: opts.signal,
+    });
+    if (!r.ok) return docs.map(doc => ({ doc, score: 0 }));
+    const j = await r.json() as { results: Array<{ index: number; relevance_score: number }> };
+    return j.results
+      .map(({ index, relevance_score }) => ({ doc: docs[index], score: relevance_score }))
+      .sort((a, b) => b.score - a.score);
+  } catch {
+    return docs.map(doc => ({ doc, score: 0 }));
+  }
+}

--- a/website/src/pages/api/admin/knowledge/collections/[id]/documents.ts
+++ b/website/src/pages/api/admin/knowledge/collections/[id]/documents.ts
@@ -91,7 +91,10 @@ export const POST: APIRoute = async ({ request, params }) => {
     }), { status: 202 });
   }
 
-  const { embeddings } = await embedBatch(chunks.map(c => c.text));
+  const { embeddings } = await embedBatch(chunks.map(c => c.text), {
+    model: collection.embedding_model as 'bge-m3' | 'voyage-multilingual-2',
+    purpose: 'index',
+  });
   await upsertChunks(collection.id, doc.id, chunks.map((c, i) => ({
     position: c.position, text: c.text, embedding: embeddings[i],
   })));


### PR DESCRIPTION
## Summary

- **GPU peer on wg-mesh**: Three K8s Services/Endpoints pointing at the RTX 5070 Ti host — `llm-gateway-embed` (TEI bge-m3, port 8081), `llm-gateway-rerank` (TEI bge-reranker-v2-m3, port 8082), `llm-gateway-chat` (Ollama 4-model pool, port 11434)
- **LiteLLM router** (`llm-router`): OpenAI-compatible proxy in-cluster; routes `workspace-chat/code/vision/fast` to Ollama with Anthropic claude-sonnet-4-6 fallback; embedding/rerank aliases have **no fallback** (fail closed on 5xx)
- **Vector space integrity**: `embeddings.ts` gains `model` + `purpose` params; `knowledge-db.ts` enforces single-model queries via `MixedEmbeddingModelError`; `rerank.ts` gracefully degrades when `LLM_RERANK_ENABLED=false`
- **Env/schema**: 4 new env vars (`LLM_HOST_IP`, `LLM_ENABLED`, `LLM_RERANK_ENABLED`, `LLM_ROUTER_URL`) + `ANTHROPIC_API_KEY` secret in both workspace and website namespaces
- **Integration tests**: FA-32..FA-38 + NFA-10..NFA-11 cover embedding dims, fail-closed on TEI outage, rerank top-1, Ollama chat, Anthropic fallback, VRAM budget, fallback latency

## Operational next steps (not in this PR)

- [ ] Fill in real `ANTHROPIC_API_KEY` in `environments/.secrets/{mentolder,korczewski}.yaml` and run `task env:seal ENV=mentolder && task env:seal ENV=korczewski`
- [ ] Set actual wg-mesh IP for `LLM_HOST_IP` in both env files
- [ ] `task llm:bootstrap-host HOST=<gpu-ip>` → `task llm:pull-models HOST=<gpu-ip>`
- [ ] `task llm:deploy ENV=mentolder` → `task llm:test ENV=mentolder` → `task website:redeploy ENV=mentolder`
- [ ] After 24h stable: `task llm:deploy ENV=korczewski` + flip `LLM_RERANK_ENABLED: "true"`

## Test plan

- [x] `npx vitest run src/lib/embeddings.test.ts src/lib/rerank.test.ts src/lib/knowledge-db.test.ts` — 20/20 pass
- [x] `task env:validate:all` — all env files pass schema
- [x] `task workspace:validate` (dry-run kustomize) passes
- [ ] `./tests/runner.sh local FA-32` through `FA-38` + `NFA-10` + `NFA-11` — requires live cluster with GPU host

🤖 Generated with [Claude Code](https://claude.com/claude-code)