### PR TITLE
fix(mcp): TLS for korczewski, explicit chrome path, token query param fallback

### DIFF
--- a/deploy/mcp-korczewski/patch-ingress.yaml
+++ b/deploy/mcp-korczewski/patch-ingress.yaml
@@ -19,6 +19,8 @@ spec:
   entryPoints:
     - web
     - websecure
+  tls:
+    secretName: korczewski-tls
   routes:
     - kind: Rule
       match: Host(`mcp.korczewski.de`) && PathPrefix(`/kubernetes`)

--- a/deploy/mcp/claude-code-mcp-monolith.yaml
+++ b/deploy/mcp/claude-code-mcp-monolith.yaml
@@ -157,9 +157,10 @@ spec:
             - |
               echo "Installing MCP playwright bridge..."
               npm install -g supergateway @playwright/mcp 2>&1 | tail -3
-              echo "Starting supergateway on :3000/mcp..."
+              CHROME=$(find /ms-playwright -name "chrome" -path "*/chrome-linux/chrome" ! -path "*/headless*" | head -1)
+              echo "Starting supergateway on :3000/mcp (chrome: $CHROME)..."
               exec supergateway \
-                --stdio "playwright-mcp" \
+                --stdio "playwright-mcp --browser chrome --executable-path $CHROME --headless" \
                 --outputTransport streamableHttp \
                 --port 3000 \
                 --streamableHttpPath /mcp \

--- a/deploy/mcp/mcp-auth-proxy.yaml
+++ b/deploy/mcp/mcp-auth-proxy.yaml
@@ -16,6 +16,13 @@ data:
     http {
       perl_set $cluster_token 'sub { return $ENV{"CLUSTER_TOKEN"} // "" }';
       perl_set $business_token 'sub { return $ENV{"BUSINESS_TOKEN"} // "" }';
+      # Fallback: extract ?token= from original request URI forwarded by Traefik ForwardAuth
+      perl_set $bearer_from_uri 'sub {
+        my $r = shift;
+        my $uri = $r->header_in("X-Forwarded-Uri") // "";
+        if ($uri =~ /[?&]token=([^&]+)/) { return $1; }
+        return "";
+      }';
 
       server {
         listen 80;
@@ -29,6 +36,11 @@ data:
           set $bearer "";
           if ($http_authorization ~* "^Bearer\s+(.+)$") {
             set $bearer $1;
+          }
+
+          # Fallback: token query param (for clients like claude.ai web that cannot set headers)
+          if ($bearer = "") {
+            set $bearer $bearer_from_uri;
           }
 
           # No token provided


### PR DESCRIPTION
## Summary
- **`deploy/mcp-korczewski/patch-ingress.yaml`**: Add `tls.secretName: korczewski-tls` so `mcp.korczewski.de` gets HTTPS termination (was HTTP-only, causing 308 redirect loops for MCP clients)
- **`deploy/mcp/claude-code-mcp-monolith.yaml`**: Resolve the chrome binary path explicitly via `find` rather than relying on `playwright-mcp` default resolution — avoids `headless-shell` being picked instead of the full chrome
- **`deploy/mcp/mcp-auth-proxy.yaml`**: Extract bearer token from `?token=` query param as fallback when `Authorization` header is absent — needed for claude.ai web which cannot set custom headers on MCP requests

## Test plan
- [ ] `task mcp:deploy ENV=mentolder` → redeploy auth-proxy + monolith
- [ ] `task mcp:deploy ENV=korczewski` → redeploy with TLS ingress patch
- [ ] `https://mcp.korczewski.de/kubernetes/mcp` with `?token=<CLUSTER_TOKEN>` → 200
- [ ] `https://mcp.mentolder.de/kubernetes/mcp?token=<CLUSTER_TOKEN>` → 200
- [ ] Browser MCP connects with explicit chrome (check pod logs for `chrome:` line)

🤖 Generated with [Claude Code](https://claude.com/claude-code)