### PR TITLE
fix(cronjob): use node-location=hetzner affinity for tests-retention on all clusters

### DIFF
--- a/k3d/tests-retention-cronjob.yaml
+++ b/k3d/tests-retention-cronjob.yaml
@@ -18,9 +18,9 @@ spec:
               requiredDuringSchedulingIgnoredDuringExecution:
                 nodeSelectorTerms:
                   - matchExpressions:
-                      - key: kubernetes.io/hostname
+                      - key: node-location
                         operator: In
-                        values: [gekko-hetzner-2, gekko-hetzner-3, gekko-hetzner-4, pk-hetzner, pk-hetzner-2, pk-hetzner-3]
+                        values: [hetzner]
           containers:
             - name: prune
               # alpine/k8s ships kubectl + /bin/sh on Alpine; matches the k3s


### PR DESCRIPTION
## Summary
- Replaces hardcoded hostname affinity (`gekko-hetzner-2/3/4`, `pk-hetzner/2/3`) with `node-location=hetzner` label selector in `k3d/tests-retention-cronjob.yaml`
- The korczewski-ha nodes (`pk-hetzner-4/6/8`) were never in the old list, causing the pod to stay `Pending` indefinitely (191 scheduling failures over 16h)
- All nodes on both clusters already carry `node-location=hetzner` — no label changes needed

## Test plan
- [x] Stuck job `tests-results-retention-29639700` deleted from `workspace-korczewski`
- [ ] `task workspace:deploy ENV=korczewski` — redeploys CronJob with new affinity
- [ ] `task workspace:deploy ENV=mentolder` — confirm no regression on mentolder
- [ ] Next scheduled run (03:00) schedules on any korczewski-ha node

🤖 Generated with [Claude Code](https://claude.com/claude-code)