### PR TITLE
feat(assistant): book knowledge RAG — upload, index, toggle, badge

### DIFF
--- a/docs/superpowers/plans/2026-05-10-book-knowledge-rag.md
+++ b/docs/superpowers/plans/2026-05-10-book-knowledge-rag.md
@@ -1,0 +1,1122 @@
+# Book Knowledge RAG Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Gekko can upload third-party coaching books via the admin UI, then flip a toggle in the AI assistant so every reply draws on indexed book content via vector search + Claude.
+
+**Architecture:** Five sequential tasks wire the backend (Claude LLM + RAG into `llm.ts`, `chat.ts`), then three tasks build the frontend (toggle in `AssistantChat.svelte`, badge in `AssistantMessage.svelte`, upload form in `BookUploadForm.svelte` + `books/index.astro`), and finally one task adds the upload endpoint. Build order: backend first so the toggle works even if no upload UI exists yet (books can still be added via CLI for smoke-testing).
+
+**Tech Stack:** TypeScript + Astro + Svelte 5 (runes), Anthropic SDK (`@anthropic-ai/sdk`), pgvector (`queryNearest` in `lib/knowledge-db.ts`), pdf-parse (`pdf-parse/lib/pdf-parse.js`), epub2, vitest for unit tests.
+
+**Spec:** `docs/superpowers/specs/2026-05-10-book-knowledge-rag-design.md`
+
+---
+
+## File Map
+
+| File | Change |
+|------|--------|
+| `website/src/lib/assistant/llm.ts` | Replace body — add Claude call, keep keyword fallback when no API key |
+| `website/src/lib/assistant/llm.test.ts` | Extend — add mock tests for Claude path + RAG injection |
+| `website/src/lib/assistant/types.ts` | Modify — add `sourcesUsed?: number` to `AssistantChatResult` |
+| `website/src/lib/assistant/coaching-collections.ts` | NEW — resolves coaching book collection IDs with 60s cache |
+| `website/src/pages/api/assistant/chat.ts` | Modify — accept `useBooks`, return `sourcesUsed` |
+| `website/src/components/assistant/AssistantChat.svelte` | Modify — add `useBooks` toggle + pass to API |
+| `website/src/components/assistant/AssistantMessage.svelte` | Modify — accept `sourcesUsed` prop, show badge |
+| `website/src/pages/api/admin/coaching/books/upload.ts` | NEW — multipart PDF/EPUB upload + ingestion |
+| `website/src/components/admin/BookUploadForm.svelte` | NEW — drag-drop upload form with progress |
+| `website/src/pages/admin/knowledge/books/index.astro` | Modify — embed `BookUploadForm` |
+
+---
+
+## Task 1: Extend AssistantChatResult type
+
+**Files:**
+- Modify: `website/src/lib/assistant/types.ts`
+
+- [ ] **Step 1: Find `AssistantChatResult` in types.ts**
+
+```bash
+grep -n "AssistantChatResult\|proposedAction" website/src/lib/assistant/types.ts
+```
+
+- [ ] **Step 2: Add `sourcesUsed` field**
+
+Open `website/src/lib/assistant/types.ts`. Find the `AssistantChatResult` interface and add the optional field:
+
+```typescript
+export interface AssistantChatResult {
+  reply: string;
+  proposedAction?: ProposedAction;
+  sourcesUsed?: number;
+}
+```
+
+- [ ] **Step 3: Verify no TypeScript errors**
+
+```bash
+cd website && npx tsc --noEmit 2>&1 | head -20
+```
+
+Expected: no errors (the field is optional, nothing breaks).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add website/src/lib/assistant/types.ts
+git commit -m "feat(assistant): add sourcesUsed to AssistantChatResult"
+```
+
+---
+
+## Task 2: Coaching collection ID resolver
+
+**Files:**
+- Create: `website/src/lib/assistant/coaching-collections.ts`
+
+This module resolves all coaching book collection IDs from the DB and caches them for 60 seconds, avoiding a DB round trip on every chat message.
+
+- [ ] **Step 1: Write the failing test**
+
+Open `website/src/lib/assistant/llm.test.ts` and append:
+
+```typescript
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { resolveCoachingCollectionIds, __resetCacheForTests } from './coaching-collections';
+import { Pool } from 'pg';
+
+describe('resolveCoachingCollectionIds', () => {
+  beforeEach(() => {
+    __resetCacheForTests();
+  });
+
+  it('returns collection IDs from coaching.books joined to knowledge.collections', async () => {
+    const mockPool = {
+      query: vi.fn().mockResolvedValue({
+        rows: [{ collection_id: 'abc-123' }, { collection_id: 'def-456' }],
+      }),
+    } as unknown as Pool;
+
+    const ids = await resolveCoachingCollectionIds(mockPool);
+    expect(ids).toEqual(['abc-123', 'def-456']);
+    expect(mockPool.query).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses cached result on second call within 60s', async () => {
+    const mockPool = {
+      query: vi.fn().mockResolvedValue({ rows: [{ collection_id: 'abc-123' }] }),
+    } as unknown as Pool;
+
+    await resolveCoachingCollectionIds(mockPool);
+    await resolveCoachingCollectionIds(mockPool);
+    expect(mockPool.query).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns empty array when no books exist', async () => {
+    const mockPool = {
+      query: vi.fn().mockResolvedValue({ rows: [] }),
+    } as unknown as Pool;
+
+    const ids = await resolveCoachingCollectionIds(mockPool);
+    expect(ids).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run to confirm fail**
+
+```bash
+cd website && npx vitest run src/lib/assistant/llm.test.ts 2>&1 | tail -15
+```
+
+Expected: FAIL — `resolveCoachingCollectionIds` not found.
+
+- [ ] **Step 3: Create the module**
+
+Create `website/src/lib/assistant/coaching-collections.ts`:
+
+```typescript
+import { Pool } from 'pg';
+
+interface Cache {
+  ids: string[];
+  expiresAt: number;
+}
+
+let _cache: Cache | null = null;
+
+export function __resetCacheForTests(): void {
+  _cache = null;
+}
+
+export async function resolveCoachingCollectionIds(pool: Pool): Promise<string[]> {
+  if (_cache && Date.now() < _cache.expiresAt) return _cache.ids;
+
+  const r = await pool.query(`
+    SELECT b.knowledge_collection_id AS collection_id
+      FROM coaching.books b
+      JOIN knowledge.collections c ON c.id = b.knowledge_collection_id
+     WHERE c.source = 'custom'
+  `);
+  const ids = r.rows.map((row: { collection_id: string }) => row.collection_id);
+  _cache = { ids, expiresAt: Date.now() + 60_000 };
+  return ids;
+}
+```
+
+- [ ] **Step 4: Run tests — expect pass**
+
+```bash
+cd website && npx vitest run src/lib/assistant/llm.test.ts 2>&1 | tail -15
+```
+
+Expected: all tests pass (existing keyword tests + new resolver tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add website/src/lib/assistant/coaching-collections.ts website/src/lib/assistant/llm.test.ts
+git commit -m "feat(assistant): add coaching collection ID resolver with 60s cache"
+```
+
+---
+
+## Task 3: Wire Claude + RAG into llm.ts
+
+**Files:**
+- Modify: `website/src/lib/assistant/llm.ts`
+- Modify: `website/src/lib/assistant/llm.test.ts`
+
+- [ ] **Step 1: Add mock tests for Claude path**
+
+Append to the `describe` block in `website/src/lib/assistant/llm.test.ts`:
+
+```typescript
+import { assistantChat } from './llm';
+
+// These run with mocked Anthropic — the module is already imported above.
+// Re-require happens via vi.mock hoisting.
+
+describe('assistantChat — Claude path', () => {
+  it('returns Claude reply when ANTHROPIC_API_KEY is set', async () => {
+    process.env.ANTHROPIC_API_KEY = 'test-key';
+    const result = await assistantChat({
+      profile: 'admin',
+      userSub: 'u',
+      messages: [{ role: 'user', content: 'Wie geht Geissler mit Abwehr um?' }],
+      context: { currentRoute: '/admin' },
+    });
+    expect(result.reply).toBe('mocked claude response');
+    expect(result.sourcesUsed).toBe(0);
+    delete process.env.ANTHROPIC_API_KEY;
+  });
+});
+```
+
+Add the Anthropic mock at the **top** of `llm.test.ts`, before any imports:
+
+```typescript
+import { vi } from 'vitest';
+
+vi.mock('@anthropic-ai/sdk', () => ({
+  default: vi.fn().mockImplementation(() => ({
+    messages: {
+      create: vi.fn().mockResolvedValue({
+        content: [{ type: 'text', text: 'mocked claude response' }],
+      }),
+    },
+  })),
+}));
+```
+
+- [ ] **Step 2: Run to confirm fail**
+
+```bash
+cd website && npx vitest run src/lib/assistant/llm.test.ts 2>&1 | tail -15
+```
+
+Expected: FAIL — Claude path not implemented.
+
+- [ ] **Step 3: Replace llm.ts body**
+
+Replace the entire contents of `website/src/lib/assistant/llm.ts`:
+
+```typescript
+import Anthropic from '@anthropic-ai/sdk';
+import { Pool } from 'pg';
+import type { AssistantProfile, Message, ProposedAction } from './types';
+import { searchHelp, formatHit, noMatchReply } from './search';
+import { queryNearest } from '../knowledge-db';
+import { resolveCoachingCollectionIds } from './coaching-collections';
+
+export interface AssistantChatInput {
+  profile: AssistantProfile;
+  userSub: string;
+  messages: Array<Pick<Message, 'role' | 'content'>>;
+  context: AssistantContext;
+}
+
+export interface AssistantContext {
+  currentRoute: string;
+  counts?: Record<string, number>;
+  [k: string]: unknown;
+}
+
+export interface AssistantChatResult {
+  reply: string;
+  proposedAction?: ProposedAction;
+  sourcesUsed?: number;
+}
+
+let _pool: Pool | null = null;
+function getPool(): Pool {
+  if (!_pool) _pool = new Pool();
+  return _pool;
+}
+
+const SYSTEM_PROMPT = `Du bist der interne Assistent von ${process.env.BRAND_NAME ?? 'Mentolder'}. Du hilfst dem Coach bei seiner Arbeit — Klientenvorbereitung, Terminplanung, Gesprächsreflexion und Wissensarbeit. Antworte präzise und auf Deutsch. Wenn du Buchpassagen erhältst, zitiere konkret und nenne Seite wenn vorhanden.`;
+
+export async function assistantChat(input: AssistantChatInput): Promise<AssistantChatResult> {
+  const lastUser = [...input.messages].reverse().find((m) => m.role === 'user');
+  if (!lastUser?.content.trim()) {
+    return { reply: 'Frag mich etwas — ich bin für dich da.' };
+  }
+
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) {
+    // Fallback: keyword search (dev without API key)
+    const hit = searchHelp(lastUser.content, input.profile);
+    if (!hit) return { reply: noMatchReply(input.profile) };
+    return { reply: formatHit(hit) };
+  }
+
+  let sourcesUsed = 0;
+  let systemPrompt = SYSTEM_PROMPT;
+
+  const useBooks = input.context.useBooks === true;
+  if (useBooks) {
+    const collectionIds = await resolveCoachingCollectionIds(getPool());
+    if (collectionIds.length > 0) {
+      const chunks = await queryNearest({
+        collectionIds,
+        queryText: lastUser.content,
+        limit: 4,
+        threshold: 0.62,
+      });
+      if (chunks.length > 0) {
+        sourcesUsed = chunks.length;
+        const passages = chunks
+          .map((c, i) => `[${i + 1}] ${c.text}`)
+          .join('\n\n');
+        systemPrompt += `\n\n<Quellenpassagen>\n${passages}\n</Quellenpassagen>`;
+      }
+    }
+  }
+
+  const client = new Anthropic({ apiKey });
+  const response = await client.messages.create({
+    model: 'claude-sonnet-4-6',
+    max_tokens: 1024,
+    system: systemPrompt,
+    messages: input.messages.map((m) => ({
+      role: m.role as 'user' | 'assistant',
+      content: m.content,
+    })),
+  });
+
+  const reply = response.content
+    .filter((b): b is Anthropic.TextBlock => b.type === 'text')
+    .map((b) => b.text)
+    .join('');
+
+  return { reply, sourcesUsed };
+}
+```
+
+- [ ] **Step 4: Run all tests — expect pass**
+
+```bash
+cd website && npx vitest run src/lib/assistant/llm.test.ts 2>&1 | tail -20
+```
+
+Expected: all tests pass. The existing keyword tests still pass because they run without `ANTHROPIC_API_KEY` set.
+
+- [ ] **Step 5: Check TypeScript**
+
+```bash
+cd website && npx tsc --noEmit 2>&1 | head -20
+```
+
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add website/src/lib/assistant/llm.ts website/src/lib/assistant/llm.test.ts
+git commit -m "feat(assistant): wire Claude LLM + RAG into assistantChat"
+```
+
+---
+
+## Task 4: Thread useBooks through chat.ts + return sourcesUsed
+
+**Files:**
+- Modify: `website/src/pages/api/assistant/chat.ts`
+
+- [ ] **Step 1: Open the file**
+
+```bash
+cat website/src/pages/api/assistant/chat.ts
+```
+
+- [ ] **Step 2: Add useBooks to body parsing and response**
+
+Replace the entire file contents:
+
+```typescript
+import type { APIRoute } from 'astro';
+import { getSession, isAdmin } from '../../../lib/auth';
+import {
+  getOrCreateActiveConversation,
+  appendMessage,
+  loadHistory,
+} from '../../../lib/assistant/conversations';
+import { assistantChat } from '../../../lib/assistant/llm';
+import type { AssistantProfile } from '../../../lib/assistant/types';
+
+const json = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } });
+
+export const POST: APIRoute = async ({ request }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session) return json({ error: 'unauthorized' }, 401);
+
+  let body: { profile: AssistantProfile; content: string; currentRoute?: string; useBooks?: boolean };
+  try { body = await request.json(); } catch { return json({ error: 'bad json' }, 400); }
+
+  const { profile, content, currentRoute = '/', useBooks = false } = body;
+  if (profile !== 'admin' && profile !== 'portal') return json({ error: 'invalid profile' }, 400);
+  if (profile === 'admin' && !isAdmin(session)) return json({ error: 'forbidden' }, 403);
+  if (typeof content !== 'string' || !content.trim()) return json({ error: 'empty content' }, 400);
+
+  const conv = await getOrCreateActiveConversation(session.sub, profile);
+  await appendMessage(conv.id, 'user', content);
+  const history = await loadHistory(conv.id);
+
+  const result = await assistantChat({
+    profile,
+    userSub: session.sub,
+    messages: history.map((m) => ({ role: m.role, content: m.content })),
+    context: { currentRoute, useBooks },
+  });
+
+  const stored = await appendMessage(conv.id, 'assistant', result.reply, result.proposedAction);
+
+  return json({ message: stored, sourcesUsed: result.sourcesUsed ?? 0 });
+};
+```
+
+- [ ] **Step 3: Verify TypeScript**
+
+```bash
+cd website && npx tsc --noEmit 2>&1 | head -20
+```
+
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add website/src/pages/api/assistant/chat.ts
+git commit -m "feat(assistant): pass useBooks flag through chat API, return sourcesUsed"
+```
+
+---
+
+## Task 5: Toggle button in AssistantChat.svelte
+
+**Files:**
+- Modify: `website/src/components/assistant/AssistantChat.svelte`
+
+- [ ] **Step 1: Read the current file**
+
+```bash
+cat website/src/components/assistant/AssistantChat.svelte
+```
+
+- [ ] **Step 2: Add useBooks state with sessionStorage persistence**
+
+In the `<script>` block, after the existing state declarations, add:
+
+```typescript
+let useBooks = $state(sessionStorage.getItem('assistant-use-books') === '1');
+
+function toggleBooks() {
+  useBooks = !useBooks;
+  sessionStorage.setItem('assistant-use-books', useBooks ? '1' : '0');
+}
+```
+
+- [ ] **Step 3: Pass useBooks in the fetch call**
+
+In the `send` function, update the fetch body:
+
+```typescript
+body: JSON.stringify({ profile, content, currentRoute: location.pathname, useBooks }),
+```
+
+Also update the response handling to capture `sourcesUsed`:
+
+```typescript
+const data = await res.json();
+if (data?.message) {
+  messages = [
+    ...messages,
+    { id: 'optimistic-' + Date.now(), conversationId: '', role: 'user', content, createdAt: new Date().toISOString() },
+    { ...data.message, sourcesUsed: data.sourcesUsed ?? 0 },
+  ];
+}
+```
+
+Update the messages type annotation at the top:
+
+```typescript
+let messages = $state<(Message & { sourcesUsed?: number })[]>([]);
+```
+
+- [ ] **Step 4: Add the toggle button to the form**
+
+After the `<input>` in the `<form>`, and before the closing `</form>` tag, add:
+
+```svelte
+<div style="display: flex; justify-content: flex-end; margin-top: 4px;">
+  <button
+    type="button"
+    onclick={toggleBooks}
+    style="display: flex; align-items: center; gap: 4px; padding: 2px 8px;
+           background: {useBooks ? 'rgba(215,176,106,.15)' : 'transparent'};
+           border: 1px solid {useBooks ? '#d7b06a' : 'var(--line)'};
+           border-radius: 12px; font-size: 10px; cursor: pointer;
+           color: {useBooks ? '#d7b06a' : 'var(--mute)'}; font-family: inherit;"
+    title="Coaching-Bücher in die Antwort einbeziehen"
+  >
+    {#if useBooks}
+      <span style="width: 6px; height: 6px; background: #d7b06a; border-radius: 50%; display: inline-block;"></span>
+    {/if}
+    📚 {useBooks ? 'Bücher aktiv' : 'Bücher'}
+  </button>
+</div>
+```
+
+- [ ] **Step 5: Pass sourcesUsed to AssistantMessage**
+
+In the `{#each messages as m (m.id)}` loop, update the `<AssistantMessage>` line:
+
+```svelte
+<AssistantMessage message={m} sourcesUsed={m.sourcesUsed ?? 0} />
+```
+
+- [ ] **Step 6: Verify TypeScript**
+
+```bash
+cd website && npx tsc --noEmit 2>&1 | head -20
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add website/src/components/assistant/AssistantChat.svelte
+git commit -m "feat(assistant): add Bücher-toggle button with sessionStorage persistence"
+```
+
+---
+
+## Task 6: Sources badge in AssistantMessage.svelte
+
+**Files:**
+- Modify: `website/src/components/assistant/AssistantMessage.svelte`
+
+- [ ] **Step 1: Add sourcesUsed prop and badge**
+
+Replace the entire file:
+
+```svelte
+<script lang="ts">
+  import type { Message } from '../../lib/assistant/types';
+  let { message, sourcesUsed = 0 }: { message: Message; sourcesUsed?: number } = $props();
+  const isUser = $derived(message.role === 'user');
+</script>
+
+<div
+  class="msg"
+  class:in={!isUser}
+  class:out={isUser}
+  style="font-size: 12px; line-height: 1.45; padding: 7px 10px; border-radius: 8px; max-width: 80%;
+         font-family: var(--font-sans); color: var(--fg);"
+>
+  {#if !isUser && sourcesUsed > 0}
+    <div style="font-size: 10px; color: #d7b06a; margin-bottom: 4px; opacity: .85;">
+      📚 {sourcesUsed} {sourcesUsed === 1 ? 'Passage' : 'Passagen'} aus Coaching-Büchern
+    </div>
+  {/if}
+  {message.content}
+</div>
+
+<style>
+  .msg.in  { background: var(--ink-900); border: 1px solid var(--line); align-self: flex-start; border-radius: 8px 8px 8px 2px; }
+  .msg.out { background: rgba(215,176,106,.16); border: 1px solid #d7b06a; align-self: flex-end; border-radius: 8px 8px 2px 8px; }
+</style>
+```
+
+- [ ] **Step 2: Verify TypeScript**
+
+```bash
+cd website && npx tsc --noEmit 2>&1 | head -20
+```
+
+- [ ] **Step 3: Smoke test — start dev server and open assistant**
+
+```bash
+cd website && npm run dev &
+# Open http://localhost:4321/admin in browser
+# Open assistant widget, send a message without toggle → no badge
+# Enable toggle → badge should appear with chunk count once books are indexed
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add website/src/components/assistant/AssistantMessage.svelte
+git commit -m "feat(assistant): show Passagen-badge when RAG sources were used"
+```
+
+---
+
+## Task 7: Book upload endpoint
+
+**Files:**
+- Create: `website/src/pages/api/admin/coaching/books/upload.ts`
+
+This endpoint accepts a PDF or EPUB file upload, extracts text, chunks it, embeds it, and stores it in `coaching.books` + `knowledge.collections/chunks`. It mirrors `scripts/coaching/ingest-book.mts` using the same shared library functions.
+
+- [ ] **Step 1: Create the endpoint**
+
+Create `website/src/pages/api/admin/coaching/books/upload.ts`:
+
+```typescript
+import type { APIRoute } from 'astro';
+import { getSession, isAdmin } from '../../../../../../lib/auth';
+import { Pool } from 'pg';
+import { writeFile, unlink } from 'node:fs/promises';
+import { join } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { createHash } from 'node:crypto';
+import pdfParse from 'pdf-parse/lib/pdf-parse.js';
+import EPub from 'epub2';
+import { chunkText } from '../../../../../../lib/chunking';
+import { embedBatch } from '../../../../../../lib/embeddings';
+import {
+  ensureCollection,
+  addDocument,
+  upsertChunks,
+  recountChunks,
+} from '../../../../../../lib/knowledge-db';
+
+const pool = new Pool();
+
+const json = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } });
+
+export const prerender = false;
+
+export const POST: APIRoute = async ({ request }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) return json({ error: 'unauthorized' }, 401);
+
+  let formData: FormData;
+  try { formData = await request.formData(); } catch { return json({ error: 'invalid multipart' }, 400); }
+
+  const file = formData.get('file') as File | null;
+  const title = (formData.get('title') as string | null)?.trim() || '';
+  const author = (formData.get('author') as string | null)?.trim() || null;
+  const licenseNote = (formData.get('licenseNote') as string | null)?.trim() || null;
+
+  if (!file || !file.name) return json({ error: 'missing file' }, 400);
+  if (!title) return json({ error: 'missing title' }, 400);
+
+  const ext = file.name.split('.').pop()?.toLowerCase() ?? '';
+  if (ext !== 'pdf' && ext !== 'epub') return json({ error: 'unsupported format — only PDF or EPUB' }, 400);
+
+  const tmpPath = join('/tmp', `book-upload-${randomUUID()}.${ext}`);
+  try {
+    const buf = Buffer.from(await file.arrayBuffer());
+    await writeFile(tmpPath, buf);
+
+    // Extract text
+    let text: string;
+    let pageCount: number;
+    if (ext === 'pdf') {
+      const data = await pdfParse(buf);
+      text = data.text;
+      pageCount = data.numpages;
+    } else {
+      const epub = await EPub.createAsync(tmpPath);
+      const chapters: string[] = [];
+      for (const item of epub.flow) {
+        const html = await new Promise<string>((res, rej) =>
+          epub.getChapter(item.id, (err: Error | null, txt: string) => (err ? rej(err) : res(txt))),
+        );
+        const clean = html
+          .replace(/<style[\s\S]*?<\/style>/gi, '')
+          .replace(/<script[\s\S]*?<\/script>/gi, '')
+          .replace(/<[^>]+>/g, ' ')
+          .replace(/&nbsp;/g, ' ')
+          .replace(/\s+/g, ' ')
+          .trim();
+        if (clean) chapters.push(clean);
+      }
+      text = chapters.join('\n\n');
+      pageCount = chapters.length;
+    }
+
+    if (!text.trim()) return json({ error: 'no text could be extracted from the file' }, 422);
+
+    // Slug from title
+    const slug = title.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+
+    // Ensure collection
+    const collection = await ensureCollection({
+      name: `coaching-${slug}`,
+      source: 'custom',
+      brand: process.env.BRAND ?? 'mentolder',
+      description: title,
+    });
+
+    // Chunk
+    const chunks = chunkText(text, { mode: 'plain', targetTokens: 600, overlapTokens: 80 });
+
+    // Embed
+    const model = process.env.LLM_ENABLED === 'true' ? 'bge-m3' : 'voyage-multilingual-2';
+    const { embeddings } = await embedBatch(chunks.map((c) => c.text), { model, purpose: 'index' });
+
+    // Page approximation
+    const totalChunks = chunks.length;
+    const pageFor = (i: number): number | null =>
+      pageCount < 1 ? null : Math.min(Math.floor((i * pageCount) / totalChunks) + 1, pageCount);
+
+    // Store document + chunks
+    const sha256 = createHash('sha256').update(text).digest('hex');
+    const doc = await addDocument({
+      collectionId: collection.id,
+      title,
+      sourceUri: `file://${file.name}`,
+      rawText: text,
+      sha256,
+      metadata: { format: ext, pageCount },
+    });
+
+    await upsertChunks(
+      collection.id,
+      doc.id,
+      chunks.map((c, i) => ({
+        position: c.position,
+        text: c.text,
+        embedding: embeddings[i],
+        metadata: { page: pageFor(i) },
+      })),
+    );
+
+    await recountChunks(collection.id);
+
+    // Upsert coaching.books row
+    await pool.query(
+      `INSERT INTO coaching.books (knowledge_collection_id, title, author, source_filename, license_note)
+       VALUES ($1, $2, $3, $4, $5)
+       ON CONFLICT (knowledge_collection_id) DO UPDATE
+         SET title = EXCLUDED.title,
+             author = EXCLUDED.author,
+             source_filename = EXCLUDED.source_filename,
+             license_note = EXCLUDED.license_note`,
+      [collection.id, title, author, file.name, licenseNote],
+    );
+
+    const bookRes = await pool.query(
+      `SELECT b.*, c.chunk_count
+         FROM coaching.books b
+         JOIN knowledge.collections c ON c.id = b.knowledge_collection_id
+        WHERE b.knowledge_collection_id = $1`,
+      [collection.id],
+    );
+
+    return json({ book: bookRes.rows[0] });
+  } catch (err) {
+    console.error('[upload] book ingestion failed:', err);
+    const msg = err instanceof Error ? err.message : 'internal error';
+    if (msg.includes('voyage') && msg.includes('429')) {
+      return json({ error: 'Embedding-Dienst überlastet — bitte in 60 Sekunden erneut versuchen.' }, 429);
+    }
+    return json({ error: msg }, 500);
+  } finally {
+    await unlink(tmpPath).catch(() => {});
+  }
+};
+```
+
+- [ ] **Step 2: Verify TypeScript**
+
+```bash
+cd website && npx tsc --noEmit 2>&1 | head -20
+```
+
+Expected: no errors. If `epub2` types are missing, add `as any` to the `EPub.createAsync` call.
+
+- [ ] **Step 3: Quick manual test with curl (needs dev server running)**
+
+```bash
+# Start dev server first: cd website && npm run dev
+curl -s -X POST http://localhost:4321/api/admin/coaching/books/upload \
+  -H "Cookie: <paste your admin session cookie>" \
+  -F "file=@coaching-sources/Geissler/KI-Coaching.pdf" \
+  -F "title=KI-Coaching" \
+  -F "author=Geissler" \
+  | python3 -m json.tool | head -20
+```
+
+Expected: `{ "book": { "id": "...", "title": "KI-Coaching", "chunkCount": ... } }`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add website/src/pages/api/admin/coaching/books/upload.ts
+git commit -m "feat(coaching): book upload endpoint with PDF/EPUB ingestion"
+```
+
+---
+
+## Task 8: Upload form UI
+
+**Files:**
+- Create: `website/src/components/admin/BookUploadForm.svelte`
+- Modify: `website/src/pages/admin/knowledge/books/index.astro`
+
+- [ ] **Step 1: Create BookUploadForm.svelte**
+
+Create `website/src/components/admin/BookUploadForm.svelte`:
+
+```svelte
+<script lang="ts">
+  let { onUploaded }: { onUploaded: (book: Record<string, unknown>) => void } = $props();
+
+  let file = $state<File | null>(null);
+  let title = $state('');
+  let author = $state('');
+  let licenseNote = $state('');
+  let uploading = $state(false);
+  let error = $state('');
+  let showForm = $state(false);
+
+  function onFileChange(e: Event) {
+    const input = e.target as HTMLInputElement;
+    file = input.files?.[0] ?? null;
+    if (file && !title) {
+      title = file.name.replace(/\.[^.]+$/, '').replace(/[-_]/g, ' ');
+    }
+  }
+
+  function onDrop(e: DragEvent) {
+    e.preventDefault();
+    const f = e.dataTransfer?.files?.[0];
+    if (f) {
+      file = f;
+      if (!title) title = f.name.replace(/\.[^.]+$/, '').replace(/[-_]/g, ' ');
+    }
+  }
+
+  async function upload() {
+    if (!file || !title.trim()) return;
+    uploading = true;
+    error = '';
+    try {
+      const fd = new FormData();
+      fd.append('file', file);
+      fd.append('title', title.trim());
+      fd.append('author', author.trim());
+      fd.append('licenseNote', licenseNote.trim());
+      const res = await fetch('/api/admin/coaching/books/upload', { method: 'POST', body: fd });
+      const data = await res.json();
+      if (!res.ok) { error = data.error ?? 'Fehler beim Hochladen.'; return; }
+      onUploaded(data.book);
+      file = null; title = ''; author = ''; licenseNote = ''; showForm = false;
+    } catch {
+      error = 'Verbindungsfehler.';
+    } finally {
+      uploading = false;
+    }
+  }
+</script>
+
+{#if !showForm}
+  <button onclick={() => showForm = true} class="btn-primary">+ Buch hochladen</button>
+{:else}
+  <div class="upload-box">
+    <div
+      class="dropzone"
+      ondragover={(e) => e.preventDefault()}
+      ondrop={onDrop}
+      role="region"
+      aria-label="Datei ablegen"
+    >
+      {#if file}
+        <p class="filename">📄 {file.name}</p>
+        <button type="button" onclick={() => file = null} class="btn-ghost">Andere Datei wählen</button>
+      {:else}
+        <p>PDF oder EPUB hier ablegen</p>
+        <label class="btn-secondary">
+          Datei auswählen
+          <input type="file" accept=".pdf,.epub" onchange={onFileChange} hidden />
+        </label>
+      {/if}
+    </div>
+
+    <div class="fields">
+      <label>
+        Titel <span class="required">*</span>
+        <input type="text" bind:value={title} placeholder="z.B. KI-Coaching" />
+      </label>
+      <label>
+        Autor
+        <input type="text" bind:value={author} placeholder="z.B. Geissler" />
+      </label>
+      <label>
+        Lizenzhinweis
+        <input type="text" bind:value={licenseNote} placeholder="z.B. Privatkopie zum internen Gebrauch" />
+      </label>
+    </div>
+
+    {#if error}
+      <p class="error">{error}</p>
+    {/if}
+
+    <div class="actions">
+      <button type="button" onclick={() => { showForm = false; error = ''; }} class="btn-ghost" disabled={uploading}>
+        Abbrechen
+      </button>
+      <button type="button" onclick={upload} class="btn-primary" disabled={uploading || !file || !title.trim()}>
+        {uploading ? 'Wird eingelesen…' : 'Hochladen & Einlesen'}
+      </button>
+    </div>
+    {#if uploading}
+      <p class="hint">Das Einlesen dauert 30–120 Sekunden — bitte nicht schließen.</p>
+    {/if}
+  </div>
+{/if}
+
+<style>
+  .upload-box { border: 1px solid var(--line, #ddd); border-radius: 8px; padding: 1.25rem; margin-bottom: 1.5rem; }
+  .dropzone { border: 2px dashed var(--brass, #c9a55c); border-radius: 6px; padding: 1.25rem; text-align: center; background: var(--bg-2, #f7f5f2); margin-bottom: 1rem; }
+  .dropzone p { color: var(--text-muted, #888); font-size: .875rem; margin: 0 0 .5rem; }
+  .filename { color: var(--text, #1a1a1a) !important; font-weight: 500; }
+  .fields { display: grid; grid-template-columns: 1fr 1fr; gap: .75rem; margin-bottom: 1rem; }
+  .fields label:last-child { grid-column: 1 / -1; }
+  label { display: flex; flex-direction: column; font-size: .8rem; color: var(--text-muted, #666); gap: .25rem; }
+  input[type=text] { padding: .35rem .6rem; border: 1px solid var(--line, #ddd); border-radius: 4px; font-size: .875rem; }
+  .required { color: var(--brass, #c9a55c); }
+  .actions { display: flex; justify-content: flex-end; gap: .5rem; }
+  .error { color: #c00; font-size: .8rem; margin: .5rem 0; }
+  .hint { color: var(--text-muted, #888); font-size: .78rem; margin-top: .5rem; text-align: center; }
+  .btn-primary { padding: .4rem 1rem; background: var(--brass, #c9a55c); color: #fff; border: none; border-radius: 6px; font-size: .85rem; font-weight: 600; cursor: pointer; }
+  .btn-primary:disabled { opacity: .5; cursor: not-allowed; }
+  .btn-secondary { display: inline-block; padding: .3rem .7rem; border: 1px solid var(--line, #ddd); border-radius: 4px; font-size: .8rem; cursor: pointer; background: var(--bg, #fff); }
+  .btn-ghost { background: none; border: 1px solid var(--line, #ddd); border-radius: 4px; padding: .3rem .6rem; font-size: .8rem; cursor: pointer; color: var(--text-muted, #666); }
+</style>
+```
+
+- [ ] **Step 2: Embed form in books/index.astro**
+
+Open `website/src/pages/admin/knowledge/books/index.astro`.
+
+Add the import in the frontmatter (after existing imports):
+
+```astro
+---
+// existing imports...
+// add at end of frontmatter:
+---
+```
+
+Replace the `<header class="page-head">` block's button — the page currently has no "Hochladen" button. Add `BookUploadForm` as a Svelte island after the `<header>` block.
+
+Replace the current `{books.length === 0 ? ...}` section with a structure that handles both empty and non-empty state, and always shows the upload form:
+
+```astro
+---
+import AdminLayout from '../../../../layouts/AdminLayout.astro';
+import { Pool } from 'pg';
+import { listBooks } from '../../../../lib/coaching-db';
+import { getSession, getLoginUrl, isAdmin } from '../../../../lib/auth';
+import BookUploadForm from '../../../../components/admin/BookUploadForm.svelte';
+
+const session = await getSession(Astro.request.headers.get('cookie'));
+if (!session) return Astro.redirect(getLoginUrl(Astro.url.pathname));
+if (!isAdmin(session)) return Astro.redirect('/admin');
+
+const pool = new Pool();
+let books: Awaited<ReturnType<typeof listBooks>> = [];
+try {
+  books = await listBooks(pool);
+} catch {
+  // coaching schema may not yet exist in dev — show empty state
+}
+---
+<AdminLayout title="Coaching-Bücher">
+  <div class="page">
+    <header class="page-head">
+      <nav class="crumbs">
+        <a href="/admin">Admin</a>
+        <span class="sep">›</span>
+        <a href="/admin/wissensquellen">Wissen</a>
+        <span class="sep">›</span>
+        Bücher
+      </nav>
+      <h1>Coaching-Bücher</h1>
+      <p class="subtitle">Bücher anderer Autoren — deren Wissen wird von der KI absorbiert.</p>
+    </header>
+
+    <BookUploadForm
+      client:load
+      onUploaded="window.location.reload()"
+    />
+
+    {books.length === 0 ? (
+      <p class="empty-hint">Noch keine Bücher hochgeladen.</p>
+    ) : (
+      <table class="books-table">
+        <thead>
+          <tr>
+            <th>Titel</th>
+            <th>Autor</th>
+            <th class="num">Chunks</th>
+            <th>Hochgeladen</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {books.map((b) => (
+            <tr>
+              <td><a href={`/admin/knowledge/books/${b.id}`}>{b.title}</a></td>
+              <td>{b.author ?? '—'}</td>
+              <td class="num">{b.chunkCount ?? 0}</td>
+              <td>{b.ingestedAt instanceof Date ? b.ingestedAt.toLocaleDateString('de-DE') : String(b.ingestedAt)}</td>
+              <td><a class="btn-secondary" href={`/admin/knowledge/books/${b.id}`}>Öffnen</a></td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    )}
+  </div>
+</AdminLayout>
+```
+
+**Note on `onUploaded`:** Astro cannot pass a function prop across the server boundary. Change the Svelte component's prop type to call `window.location.reload()` internally on success, removing the `onUploaded` prop entirely. Update `BookUploadForm.svelte` — replace the `onUploaded` prop with a `location.reload()` call directly in the `upload()` function on success:
+
+```typescript
+// In BookUploadForm.svelte upload() function, replace:
+onUploaded(data.book);
+// With:
+window.location.reload();
+```
+
+And remove `let { onUploaded }...` prop declaration entirely.
+
+- [ ] **Step 3: Verify TypeScript**
+
+```bash
+cd website && npx tsc --noEmit 2>&1 | head -20
+```
+
+- [ ] **Step 4: Manual smoke test**
+
+```bash
+cd website && npm run dev
+# Navigate to http://localhost:4321/admin/knowledge/books
+# Click "+ Buch hochladen"
+# Upload coaching-sources/Geissler/KI-Coaching.pdf
+# Fill in Title: KI-Coaching, Author: Geissler
+# Click "Hochladen & Einlesen"
+# Wait ~60s (embedding via Voyage)
+# Page reloads — book appears in table with chunk count
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add website/src/components/admin/BookUploadForm.svelte website/src/pages/admin/knowledge/books/index.astro
+git commit -m "feat(coaching): web-based book upload UI with PDF/EPUB drag-drop"
+```
+
+---
+
+## Task 9: End-to-end smoke test
+
+- [ ] **Step 1: Run unit tests**
+
+```bash
+cd website && npx vitest run 2>&1 | tail -20
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 2: Ingest the Geissler book (if not done in Task 8)**
+
+Either via UI (as in Task 8 step 4) or via CLI for speed:
+
+```bash
+ENV=dev task coaching:ingest -- coaching-sources/Geissler/KI-Coaching.pdf geissler --title="KI-Coaching" --author="Geissler"
+```
+
+- [ ] **Step 3: Open admin assistant and test toggle OFF**
+
+```
+Navigate to http://localhost:4321/admin
+Open assistant widget
+Type: "Was weißt du über Coaching?"
+Expected: Claude response WITHOUT book badge (toggle is off)
+```
+
+- [ ] **Step 4: Enable toggle and test RAG**
+
+```
+Click "📚 Bücher" button — should turn amber
+Type: "Wie geht Geissler mit Abwehr im Coaching-Gespräch um?"
+Expected: response with "📚 N Passagen aus Coaching-Büchern" badge, 
+          and Claude cites content from the KI-Coaching book
+```
+
+- [ ] **Step 5: Final commit + deploy prep**
+
+```bash
+git add -A
+git status  # verify nothing unexpected
+```
+
+---
+
+## Self-Review Checklist
+
+**Spec coverage:**
+- ✅ Upload endpoint: Task 7
+- ✅ Upload UI (drag-drop, title/author/licenseNote, progress): Task 8
+- ✅ LLM wiring (Claude, keyword fallback without API key): Task 3
+- ✅ RAG injection with useBooks flag: Task 3 + Task 4
+- ✅ Toggle button with sessionStorage: Task 5
+- ✅ Sources badge: Task 6
+- ✅ Collection ID resolver with 60s cache: Task 2
+- ✅ `sourcesUsed` through response chain: Tasks 1, 4, 5, 6
+- ✅ Voyage 429 propagated to UI: Task 7 (catch block)
+- ✅ No API key → keyword fallback: Task 3
+
+**Type consistency:**
+- `AssistantChatResult.sourcesUsed?: number` — defined Task 1, used Tasks 3, 4, 5, 6 ✅
+- `resolveCoachingCollectionIds(pool)` — defined Task 2, called Task 3 ✅
+- `chunkText`, `embedBatch`, `ensureCollection`, `addDocument`, `upsertChunks`, `recountChunks` — all imported from existing libs in Task 7 ✅
+- `useBooks` in context — `AssistantContext` has `[k: string]: unknown` so no type change needed ✅

--- a/docs/superpowers/specs/2026-05-10-book-knowledge-rag-design.md
+++ b/docs/superpowers/specs/2026-05-10-book-knowledge-rag-design.md
@@ -1,0 +1,168 @@
+# Book Knowledge RAG — Design Spec
+
+**Date:** 2026-05-10  
+**Status:** approved  
+**Branch target:** feature/book-knowledge-rag
+
+## Problem
+
+Books by third-party authors (e.g. Geissler's *KI-Coaching*) sit in `coaching-sources/` and can only be ingested via CLI. The AI assistant (`AssistantChat.svelte → /api/assistant/chat → llm.ts`) falls back to keyword search — Claude is never called. The vector store and `queryNearest()` exist but are never wired into the chat path.
+
+Gekko (the coach/admin) cannot feel the system working.
+
+## Goal
+
+1. Gekko can upload a PDF/EPUB via the admin UI; the system automatically chunks, embeds, and indexes it.
+2. Gekko can flip a "📚 Bücher aktiv" toggle in the assistant; when on, every message searches indexed book chunks and Claude uses them as context.
+
+## Scope — what is NOT in scope
+
+- Client-facing RAG (portal users do not get book knowledge)
+- Streaming responses (word-by-word typing effect) — deferred
+- Auto-classification of new book chunks into coaching drafts — already works via `task coaching:classify`, not changed
+- Multi-collection selection UI — single toggle activates all coaching books
+
+---
+
+## Architecture
+
+### 1. Book Upload Endpoint
+
+**File:** `website/src/pages/api/admin/coaching/books/upload.ts` (new)
+
+- Accepts `POST multipart/form-data` with fields: `file` (binary), `title` (string), `author` (string, optional), `licenseNote` (string, optional).
+- Auth: admin only.
+- Saves file to a temp path (`/tmp/book-upload-<uuid>.<ext>`).
+- Derives a slug from the title: lowercase, alphanumeric + hyphens.
+- Runs the ingestion logic inline (not via child process): imports `chunkText` from `lib/chunking.ts`, `embedBatch` from `lib/embeddings.ts`, and the knowledge DB helpers. Mirrors what `scripts/coaching/ingest-book.mts` does — no duplication of logic where avoidable, but the script is a Node CLI so we call the shared library functions directly.
+- For PDF extraction, uses `pdf-parse` (already used in `lib-extract.mjs`) — import it directly.
+- Returns `{ book: Book }` on success, or `{ error: string }` with appropriate HTTP status.
+- Embedding can take 30–120 seconds for a large book. The endpoint runs synchronously and holds the connection; the client shows a progress indicator. (Async job queue is deferred — Voyage rate limits are the slow path, not the server.)
+
+**Error cases:**
+- Unsupported format → 400
+- Voyage/bge-m3 unreachable → 502 with message
+- Duplicate slug → upsert (ON CONFLICT already in `ingest-book.mts` pattern)
+
+### 2. Upload UI
+
+**File:** `website/src/pages/admin/knowledge/books/index.astro` (modify)
+
+Replace the CLI hint in the empty state with a drag-drop upload zone. The zone is always visible (not just on empty state). Fields: PDF/EPUB file picker, Titel, Autor, Lizenzhinweis (optional). Submit button: "Hochladen & Einlesen". While uploading, show a spinner and disable the form. On success, append the new book to the table without full-page reload (fetch + JSON parse + prepend row). On error, show the server's error message inline.
+
+No new page — stays on `index.astro` with a Svelte island for the upload form interactivity (`BookUploadForm.svelte`, new).
+
+### 3. LLM Wiring — `llm.ts`
+
+**File:** `website/src/lib/assistant/llm.ts` (replace body)
+
+Current implementation: keyword search fallback, no LLM.
+
+New implementation:
+
+```
+assistantChat(input):
+  if ANTHROPIC_API_KEY unset → fall back to existing searchHelp keyword path (keeps dev working without key)
+  build system prompt (see below)
+  if input.useBooks === true:
+    chunks = queryNearest({ collectionIds: all coaching book collection IDs, queryText: last user message, limit: 4, threshold: 0.62 })
+    if chunks.length > 0: inject chunks as <Quellenpassagen> block into system prompt
+  call Anthropic messages.create (claude-sonnet-4-6, max_tokens: 1024)
+  return { reply: text }
+```
+
+**System prompt (German, Gekko's voice):**
+```
+Du bist der interne Assistent von ${process.env.BRAND_NAME ?? 'Mentolder'}. Du hilfst dem Coach bei seiner Arbeit — 
+Klientenvorbereitung, Terminplanung, Gesprächsreflexion und Wissensarbeit.
+Antworte präzise und auf Deutsch. Wenn du Buchpassagen erhältst, zitiere konkret 
+und nenne Seite/Kapitel wenn vorhanden.
+```
+
+**`collectionIds` resolution:** query `coaching.books` joined to `knowledge.collections` to get all collection IDs where `source = 'custom'` and `brand = 'mentolder'` (or brand IS NULL). Cache result in module scope for 60 seconds to avoid per-message DB round trips.
+
+### 4. Chat API — `useBooks` flag
+
+**File:** `website/src/pages/api/assistant/chat.ts` (modify)
+
+Accept `useBooks?: boolean` in the request body. Pass it through to `assistantChat()` as `context.useBooks`. The function signature already accepts `context: AssistantContext` with `[k: string]: unknown` — no type change needed.
+
+`assistantChat()` returns `{ reply, sourcesUsed?: number }`. The chat route adds `sourcesUsed` to the JSON response alongside `message`: `return json({ message: stored, sourcesUsed: result.sourcesUsed ?? 0 })`. The Svelte component reads it from the fetch response, not from the stored message row.
+
+### 5. Assistant Toggle — `AssistantChat.svelte`
+
+**File:** `website/src/components/assistant/AssistantChat.svelte` (modify)
+
+Add `let useBooks = $state(false)` (persisted in `sessionStorage` so it survives widget open/close within the same tab).
+
+In the form footer, add a pill button right-aligned:
+- Off state: `📚 Bücher` — muted border, grey text
+- On state: `📚 Bücher aktiv` — amber border + dot indicator (`#c9a55c`)
+
+Pass `useBooks` in the fetch body to `/api/assistant/chat`.
+
+When the AI reply contains chunks (indicated by the `<Quellenpassagen>` block being used), the API response should include a `sourcesUsed: number` field so the widget can show "📚 3 Passagen verwendet" as a sub-line under the AI bubble — done in `AssistantMessage.svelte`.
+
+---
+
+## Data Flow
+
+```
+Gekko uploads PDF
+  → POST /api/admin/coaching/books/upload
+  → pdf-parse extracts text
+  → chunkText() splits into ~600-token chunks
+  → embedBatch() gets vectors (Voyage or bge-m3)
+  → knowledge.collections + knowledge.chunks upserted
+  → coaching.books row inserted
+  → { book } returned to UI
+
+Gekko asks question with toggle ON
+  → POST /api/assistant/chat { content, useBooks: true }
+  → chat.ts passes context.useBooks = true to assistantChat()
+  → llm.ts resolves coaching collection IDs (60s cache)
+  → queryNearest() returns top-4 chunks (cosine similarity ≥ 0.62)
+  → chunks injected into Claude system prompt as <Quellenpassagen>
+  → Claude responds in German with source-aware answer
+  → { message, sourcesUsed: 4 } returned
+  → AssistantChat shows "📚 4 Passagen verwendet" badge
+```
+
+---
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `website/src/pages/api/admin/coaching/books/upload.ts` | NEW |
+| `website/src/components/admin/BookUploadForm.svelte` | NEW |
+| `website/src/lib/assistant/llm.ts` | Replace body |
+| `website/src/pages/api/assistant/chat.ts` | Add `useBooks` passthrough |
+| `website/src/components/assistant/AssistantChat.svelte` | Add toggle |
+| `website/src/components/assistant/AssistantMessage.svelte` | Add sources badge |
+| `website/src/pages/admin/knowledge/books/index.astro` | Embed upload form |
+
+---
+
+## Environment Variables
+
+- `ANTHROPIC_API_KEY` — already present in prod (used for meeting insights in `claude.ts`). No new secrets needed.
+- `VOYAGE_API_KEY` / `LLM_ENABLED` / `LLM_ROUTER_URL` — existing, drive embedding model selection.
+
+---
+
+## Error Handling
+
+- No `ANTHROPIC_API_KEY` → graceful fallback to keyword search (dev environment stays usable).
+- `queryNearest()` returns 0 results → Claude called without injection, no badge shown.
+- Upload endpoint: Voyage rate limit during embedding → 429 propagated to UI with "Bitte erneut versuchen".
+- Upload timeout (>5 min): return 504; user retries.
+
+---
+
+## Out of scope / future
+
+- Streaming SSE responses
+- Per-book toggle granularity (currently: all coaching books or none)
+- Client portal RAG access
+- Auto-classify newly uploaded chunks (use existing `task coaching:classify` after upload)

--- a/website/src/components/admin/BookUploadForm.svelte
+++ b/website/src/components/admin/BookUploadForm.svelte
@@ -1,0 +1,122 @@
+<script lang="ts">
+  let file = $state<File | null>(null);
+  let title = $state('');
+  let author = $state('');
+  let licenseNote = $state('');
+  let uploading = $state(false);
+  let error = $state('');
+  let showForm = $state(false);
+
+  function onFileChange(e: Event) {
+    const input = e.target as HTMLInputElement;
+    file = input.files?.[0] ?? null;
+    if (file && !title) {
+      title = file.name.replace(/\.[^.]+$/, '').replace(/[-_]/g, ' ');
+    }
+  }
+
+  function onDrop(e: DragEvent) {
+    e.preventDefault();
+    const f = e.dataTransfer?.files?.[0];
+    if (f) {
+      file = f;
+      if (!title) title = f.name.replace(/\.[^.]+$/, '').replace(/[-_]/g, ' ');
+    }
+  }
+
+  async function upload() {
+    if (!file || !title.trim()) return;
+    uploading = true;
+    error = '';
+    try {
+      const fd = new FormData();
+      fd.append('file', file);
+      fd.append('title', title.trim());
+      fd.append('author', author.trim());
+      fd.append('licenseNote', licenseNote.trim());
+      const res = await fetch('/api/admin/coaching/books/upload', { method: 'POST', body: fd });
+      const data = await res.json();
+      if (!res.ok) { error = data.error ?? 'Fehler beim Hochladen.'; return; }
+      window.location.reload();
+    } catch {
+      error = 'Verbindungsfehler.';
+    } finally {
+      uploading = false;
+    }
+  }
+</script>
+
+{#if !showForm}
+  <button onclick={() => showForm = true} class="btn-primary">+ Buch hochladen</button>
+{:else}
+  <div class="upload-box">
+    <div
+      class="dropzone"
+      ondragover={(e) => e.preventDefault()}
+      ondrop={onDrop}
+      role="region"
+      aria-label="Datei ablegen"
+    >
+      {#if file}
+        <p class="filename">📄 {file.name}</p>
+        <button type="button" onclick={() => file = null} class="btn-ghost">Andere Datei wählen</button>
+      {:else}
+        <p>PDF oder EPUB hier ablegen</p>
+        <label class="btn-secondary">
+          Datei auswählen
+          <input type="file" accept=".pdf,.epub" onchange={onFileChange} hidden />
+        </label>
+      {/if}
+    </div>
+
+    <div class="fields">
+      <label>
+        Titel <span class="required">*</span>
+        <input type="text" bind:value={title} placeholder="z.B. KI-Coaching" />
+      </label>
+      <label>
+        Autor
+        <input type="text" bind:value={author} placeholder="z.B. Geissler" />
+      </label>
+      <label>
+        Lizenzhinweis
+        <input type="text" bind:value={licenseNote} placeholder="z.B. Privatkopie zum internen Gebrauch" />
+      </label>
+    </div>
+
+    {#if error}
+      <p class="error">{error}</p>
+    {/if}
+
+    <div class="actions">
+      <button type="button" onclick={() => { showForm = false; error = ''; }} class="btn-ghost" disabled={uploading}>
+        Abbrechen
+      </button>
+      <button type="button" onclick={upload} class="btn-primary" disabled={uploading || !file || !title.trim()}>
+        {uploading ? 'Wird eingelesen…' : 'Hochladen & Einlesen'}
+      </button>
+    </div>
+    {#if uploading}
+      <p class="hint">Das Einlesen dauert 30–120 Sekunden — bitte nicht schließen.</p>
+    {/if}
+  </div>
+{/if}
+
+<style>
+  .upload-box { border: 1px solid var(--line, #ddd); border-radius: 8px; padding: 1.25rem; margin-bottom: 1.5rem; }
+  .dropzone { border: 2px dashed var(--brass, #c9a55c); border-radius: 6px; padding: 1.25rem; text-align: center; background: var(--bg-2, #f7f5f2); margin-bottom: 1rem; }
+  .dropzone p { color: var(--text-muted, #888); font-size: .875rem; margin: 0 0 .5rem; }
+  .filename { color: var(--text, #1a1a1a) !important; font-weight: 500; }
+  .fields { display: grid; grid-template-columns: 1fr 1fr; gap: .75rem; margin-bottom: 1rem; }
+  .fields label:last-child { grid-column: 1 / -1; }
+  label { display: flex; flex-direction: column; font-size: .8rem; color: var(--text-muted, #666); gap: .25rem; }
+  input[type=text] { padding: .35rem .6rem; border: 1px solid var(--line, #ddd); border-radius: 4px; font-size: .875rem; }
+  .required { color: var(--brass, #c9a55c); }
+  .actions { display: flex; justify-content: flex-end; gap: .5rem; }
+  .error { color: #c00; font-size: .8rem; margin: .5rem 0; }
+  .hint { color: var(--text-muted, #888); font-size: .78rem; margin-top: .5rem; text-align: center; }
+  .btn-primary { padding: .4rem 1rem; background: var(--brass, #c9a55c); color: #fff; border: none; border-radius: 6px; font-size: .85rem; font-weight: 600; cursor: pointer; }
+  .btn-primary:disabled { opacity: .5; cursor: not-allowed; }
+  .btn-secondary { display: inline-block; padding: .3rem .7rem; border: 1px solid var(--line, #ddd); border-radius: 4px; font-size: .8rem; cursor: pointer; background: var(--bg, #fff); }
+  .btn-ghost { background: none; border: 1px solid var(--line, #ddd); border-radius: 4px; padding: .3rem .6rem; font-size: .8rem; cursor: pointer; color: var(--text-muted, #666); }
+</style>

--- a/website/src/components/assistant/AssistantChat.svelte
+++ b/website/src/components/assistant/AssistantChat.svelte
@@ -101,6 +101,7 @@
         style="flex: 1; background: var(--ink-850); border: 1px solid var(--line); border-radius: 16px; padding: 6px 12px; font-size: 12px; color: var(--fg); font-family: inherit;"
       />
     </div>
+    {#if profile === 'admin'}
     <div style="display: flex; justify-content: flex-end; margin-top: 4px;">
       <button
         type="button"
@@ -118,5 +119,6 @@
         📚 {useBooks ? 'Bücher aktiv' : 'Bücher'}
       </button>
     </div>
+    {/if}
   </form>
 </section>

--- a/website/src/components/assistant/AssistantChat.svelte
+++ b/website/src/components/assistant/AssistantChat.svelte
@@ -5,10 +5,17 @@
 
   let { profile, onClose }: { profile: AssistantProfile; onClose?: () => void } = $props();
 
-  let messages = $state<Message[]>([]);
+  let messages = $state<(Message & { sourcesUsed?: number })[]>([]);
   let input = $state('');
   let sending = $state(false);
   let busyAction = $state<string | null>(null);
+
+  let useBooks = $state(sessionStorage.getItem('assistant-use-books') === '1');
+
+  function toggleBooks() {
+    useBooks = !useBooks;
+    sessionStorage.setItem('assistant-use-books', useBooks ? '1' : '0');
+  }
 
   async function send(content: string) {
     sending = true;
@@ -16,14 +23,14 @@
       const res = await fetch('/api/assistant/chat', {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ profile, content, currentRoute: location.pathname }),
+        body: JSON.stringify({ profile, content, currentRoute: location.pathname, useBooks }),
       });
       const data = await res.json();
       if (data?.message) {
         messages = [
           ...messages,
           { id: 'optimistic-' + Date.now(), conversationId: '', role: 'user', content, createdAt: new Date().toISOString() },
-          data.message,
+          { ...data.message, sourcesUsed: data.sourcesUsed ?? 0 },
         ];
       }
     } finally {
@@ -70,7 +77,7 @@
   </header>
   <div style="flex: 1; overflow-y: auto; padding: 10px; display: flex; flex-direction: column; gap: 8px;">
     {#each messages as m (m.id)}
-      <AssistantMessage message={m} />
+      <AssistantMessage message={m} sourcesUsed={m.sourcesUsed ?? 0} />
       {#if m.role === 'assistant' && m.proposedAction}
         <AssistantConfirmCard
           action={m.proposedAction}
@@ -83,15 +90,33 @@
   </div>
   <form
     onsubmit={(e) => { e.preventDefault(); if (input.trim()) send(input.trim()); }}
-    style="padding: 8px 10px; border-top: 1px solid var(--line); display: flex; gap: 6px; background: var(--ink-900);"
+    style="padding: 8px 10px; border-top: 1px solid var(--line); display: flex; flex-direction: column; gap: 6px; background: var(--ink-900);"
   >
-    <input
-      bind:value={input}
-      type="text"
-      placeholder="Nachricht eingeben…"
-      disabled={sending}
-      style="flex: 1; background: var(--ink-850); border: 1px solid var(--line); border-radius: 16px; padding: 6px 12px; font-size: 12px; color: var(--fg); font-family: inherit;"
-    />
+    <div style="display: flex; gap: 6px;">
+      <input
+        bind:value={input}
+        type="text"
+        placeholder="Nachricht eingeben…"
+        disabled={sending}
+        style="flex: 1; background: var(--ink-850); border: 1px solid var(--line); border-radius: 16px; padding: 6px 12px; font-size: 12px; color: var(--fg); font-family: inherit;"
+      />
+    </div>
+    <div style="display: flex; justify-content: flex-end; margin-top: 4px;">
+      <button
+        type="button"
+        onclick={toggleBooks}
+        style="display: flex; align-items: center; gap: 4px; padding: 2px 8px;
+               background: {useBooks ? 'rgba(215,176,106,.15)' : 'transparent'};
+               border: 1px solid {useBooks ? '#d7b06a' : 'var(--line)'};
+               border-radius: 12px; font-size: 10px; cursor: pointer;
+               color: {useBooks ? '#d7b06a' : 'var(--mute)'}; font-family: inherit;"
+        title="Coaching-Bücher in die Antwort einbeziehen"
+      >
+        {#if useBooks}
+          <span style="width: 6px; height: 6px; background: #d7b06a; border-radius: 50%; display: inline-block;"></span>
+        {/if}
+        📚 {useBooks ? 'Bücher aktiv' : 'Bücher'}
+      </button>
+    </div>
   </form>
 </section>
-

--- a/website/src/components/assistant/AssistantMessage.svelte
+++ b/website/src/components/assistant/AssistantMessage.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { Message } from '../../lib/assistant/types';
-  let { message }: { message: Message } = $props();
+  let { message, sourcesUsed = 0 }: { message: Message; sourcesUsed?: number } = $props();
   const isUser = $derived(message.role === 'user');
 </script>
 
@@ -11,6 +11,11 @@
   style="font-size: 12px; line-height: 1.45; padding: 7px 10px; border-radius: 8px; max-width: 80%;
          font-family: var(--font-sans); color: var(--fg);"
 >
+  {#if !isUser && sourcesUsed > 0}
+    <div style="font-size: 10px; color: #d7b06a; margin-bottom: 4px; opacity: .85;">
+      📚 {sourcesUsed} {sourcesUsed === 1 ? 'Passage' : 'Passagen'} aus Coaching-Büchern
+    </div>
+  {/if}
   {message.content}
 </div>
 

--- a/website/src/lib/assistant/coaching-collections.ts
+++ b/website/src/lib/assistant/coaching-collections.ts
@@ -1,0 +1,26 @@
+import { Pool } from 'pg';
+
+interface Cache {
+  ids: string[];
+  expiresAt: number;
+}
+
+let _cache: Cache | null = null;
+
+export function __resetCacheForTests(): void {
+  _cache = null;
+}
+
+export async function resolveCoachingCollectionIds(pool: Pool): Promise<string[]> {
+  if (_cache && Date.now() < _cache.expiresAt) return _cache.ids;
+
+  const r = await pool.query(`
+    SELECT b.knowledge_collection_id AS collection_id
+      FROM coaching.books b
+      JOIN knowledge.collections c ON c.id = b.knowledge_collection_id
+     WHERE c.source = 'custom'
+  `);
+  const ids = r.rows.map((row: { collection_id: string }) => row.collection_id);
+  _cache = { ids, expiresAt: Date.now() + 60_000 };
+  return ids;
+}

--- a/website/src/lib/assistant/coaching-collections.ts
+++ b/website/src/lib/assistant/coaching-collections.ts
@@ -14,12 +14,14 @@ export function __resetCacheForTests(): void {
 export async function resolveCoachingCollectionIds(pool: Pool): Promise<string[]> {
   if (_cache && Date.now() < _cache.expiresAt) return _cache.ids;
 
+  const brand = process.env.BRAND ?? process.env.BRAND_ID ?? 'mentolder';
   const r = await pool.query(`
     SELECT b.knowledge_collection_id AS collection_id
       FROM coaching.books b
       JOIN knowledge.collections c ON c.id = b.knowledge_collection_id
      WHERE c.source = 'custom'
-  `);
+       AND (c.brand = $1 OR c.brand IS NULL)
+  `, [brand]);
   const ids = r.rows.map((row: { collection_id: string }) => row.collection_id);
   _cache = { ids, expiresAt: Date.now() + 60_000 };
   return ids;

--- a/website/src/lib/assistant/llm.test.ts
+++ b/website/src/lib/assistant/llm.test.ts
@@ -50,7 +50,7 @@ describe('assistantChat (no-LLM keyword fallback)', () => {
   });
 });
 
-import { vi, beforeEach } from 'vitest';
+import { beforeEach } from 'vitest';
 import { resolveCoachingCollectionIds, __resetCacheForTests } from './coaching-collections';
 import { Pool } from 'pg';
 

--- a/website/src/lib/assistant/llm.test.ts
+++ b/website/src/lib/assistant/llm.test.ts
@@ -35,3 +35,44 @@ describe('assistantChat (no-LLM keyword fallback)', () => {
     expect(result.reply).toMatch(/Frag mich/);
   });
 });
+
+import { vi, beforeEach } from 'vitest';
+import { resolveCoachingCollectionIds, __resetCacheForTests } from './coaching-collections';
+import { Pool } from 'pg';
+
+describe('resolveCoachingCollectionIds', () => {
+  beforeEach(() => {
+    __resetCacheForTests();
+  });
+
+  it('returns collection IDs from coaching.books joined to knowledge.collections', async () => {
+    const mockPool = {
+      query: vi.fn().mockResolvedValue({
+        rows: [{ collection_id: 'abc-123' }, { collection_id: 'def-456' }],
+      }),
+    } as unknown as Pool;
+
+    const ids = await resolveCoachingCollectionIds(mockPool);
+    expect(ids).toEqual(['abc-123', 'def-456']);
+    expect(mockPool.query).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses cached result on second call within 60s', async () => {
+    const mockPool = {
+      query: vi.fn().mockResolvedValue({ rows: [{ collection_id: 'abc-123' }] }),
+    } as unknown as Pool;
+
+    await resolveCoachingCollectionIds(mockPool);
+    await resolveCoachingCollectionIds(mockPool);
+    expect(mockPool.query).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns empty array when no books exist', async () => {
+    const mockPool = {
+      query: vi.fn().mockResolvedValue({ rows: [] }),
+    } as unknown as Pool;
+
+    const ids = await resolveCoachingCollectionIds(mockPool);
+    expect(ids).toEqual([]);
+  });
+});

--- a/website/src/lib/assistant/llm.test.ts
+++ b/website/src/lib/assistant/llm.test.ts
@@ -1,4 +1,18 @@
-import { describe, it, expect } from 'vitest';
+import { vi, describe, it, expect } from 'vitest';
+
+vi.mock('@anthropic-ai/sdk', () => {
+  const mockCreate = vi.fn().mockResolvedValue({
+    content: [{ type: 'text', text: 'mocked claude response' }],
+  });
+  class MockAnthropic {
+    messages = { create: mockCreate };
+  }
+  return {
+    default: MockAnthropic,
+    Anthropic: MockAnthropic
+  };
+});
+
 import { assistantChat } from './llm';
 
 describe('assistantChat (no-LLM keyword fallback)', () => {
@@ -74,5 +88,20 @@ describe('resolveCoachingCollectionIds', () => {
 
     const ids = await resolveCoachingCollectionIds(mockPool);
     expect(ids).toEqual([]);
+  });
+});
+
+describe('assistantChat — Claude path', () => {
+  it('returns Claude reply when ANTHROPIC_API_KEY is set', async () => {
+    process.env.ANTHROPIC_API_KEY = 'test-key';
+    const result = await assistantChat({
+      profile: 'admin',
+      userSub: 'u',
+      messages: [{ role: 'user', content: 'Wie geht Geissler mit Abwehr um?' }],
+      context: { currentRoute: '/admin' },
+    });
+    expect(result.reply).toBe('mocked claude response');
+    expect(result.sourcesUsed).toBe(0);
+    delete process.env.ANTHROPIC_API_KEY;
   });
 });

--- a/website/src/lib/assistant/llm.ts
+++ b/website/src/lib/assistant/llm.ts
@@ -1,6 +1,6 @@
 import Anthropic from '@anthropic-ai/sdk';
 import { Pool } from 'pg';
-import type { AssistantProfile, Message, ProposedAction } from './types';
+import type { AssistantProfile, AssistantChatResult, Message } from './types';
 import { searchHelp, formatHit, noMatchReply } from './search';
 import { queryNearest } from '../knowledge-db';
 import { resolveCoachingCollectionIds } from './coaching-collections';
@@ -16,12 +16,6 @@ export interface AssistantContext {
   currentRoute: string;
   counts?: Record<string, number>;
   [k: string]: unknown;
-}
-
-export interface AssistantChatResult {
-  reply: string;
-  proposedAction?: ProposedAction;
-  sourcesUsed?: number;
 }
 
 let _pool: Pool | null = null;
@@ -51,21 +45,25 @@ export async function assistantChat(input: AssistantChatInput): Promise<Assistan
 
   const useBooks = input.context.useBooks === true;
   if (useBooks) {
-    const collectionIds = await resolveCoachingCollectionIds(getPool());
-    if (collectionIds.length > 0) {
-      const chunks = await queryNearest({
-        collectionIds,
-        queryText: lastUser.content,
-        limit: 4,
-        threshold: 0.62,
-      });
-      if (chunks.length > 0) {
-        sourcesUsed = chunks.length;
-        const passages = chunks
-          .map((c, i) => `[${i + 1}] ${c.text}`)
-          .join('\n\n');
-        systemPrompt += `\n\n<Quellenpassagen>\n${passages}\n</Quellenpassagen>`;
+    try {
+      const collectionIds = await resolveCoachingCollectionIds(getPool());
+      if (collectionIds.length > 0) {
+        const chunks = await queryNearest({
+          collectionIds,
+          queryText: lastUser.content,
+          limit: 4,
+          threshold: 0.62,
+        });
+        if (chunks.length > 0) {
+          sourcesUsed = chunks.length;
+          const passages = chunks
+            .map((c, i) => `[${i + 1}] ${c.text}`)
+            .join('\n\n');
+          systemPrompt += `\n\n<Quellenpassagen>\n${passages}\n</Quellenpassagen>`;
+        }
       }
+    } catch (err) {
+      console.error('[assistantChat] RAG lookup failed, proceeding without passages:', err);
     }
   }
 

--- a/website/src/lib/assistant/llm.ts
+++ b/website/src/lib/assistant/llm.ts
@@ -1,5 +1,9 @@
+import Anthropic from '@anthropic-ai/sdk';
+import { Pool } from 'pg';
 import type { AssistantProfile, Message, ProposedAction } from './types';
 import { searchHelp, formatHit, noMatchReply } from './search';
+import { queryNearest } from '../knowledge-db';
+import { resolveCoachingCollectionIds } from './coaching-collections';
 
 export interface AssistantChatInput {
   profile: AssistantProfile;
@@ -17,25 +21,69 @@ export interface AssistantContext {
 export interface AssistantChatResult {
   reply: string;
   proposedAction?: ProposedAction;
+  sourcesUsed?: number;
 }
 
-// No LLM is wired here by design — the user owns that decision (DSGVO,
-// model choice, key handling). Until they wire one, the assistant falls
-// back to a deterministic keyword search over lib/helpContent.ts so it
-// stays useful for "wo finde ich X?" / "wie mache ich Y?" questions.
-//
-// To wire a real LLM later, replace the body of this function. You can
-// still call searchHelp() as a tool or as a low-confidence fallback.
+let _pool: Pool | null = null;
+function getPool(): Pool {
+  if (!_pool) _pool = new Pool();
+  return _pool;
+}
+
+const SYSTEM_PROMPT = `Du bist der interne Assistent von ${process.env.BRAND_NAME ?? 'Mentolder'}. Du hilfst dem Coach bei seiner Arbeit — Klientenvorbereitung, Terminplanung, Gesprächsreflexion und Wissensarbeit. Antworte präzise und auf Deutsch. Wenn du Buchpassagen erhältst, zitiere konkret und nenne Seite wenn vorhanden.`;
+
 export async function assistantChat(input: AssistantChatInput): Promise<AssistantChatResult> {
   const lastUser = [...input.messages].reverse().find((m) => m.role === 'user');
-  if (!lastUser || !lastUser.content.trim()) {
-    return {
-      reply: 'Frag mich etwas — ich suche dir die passende Stelle in der Hilfe.',
-    };
+  if (!lastUser?.content.trim()) {
+    return { reply: 'Frag mich etwas — ich bin für dich da.' };
   }
-  const hit = searchHelp(lastUser.content, input.profile);
-  if (!hit) {
-    return { reply: noMatchReply(input.profile) };
+
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) {
+    // Fallback: keyword search (dev without API key)
+    const hit = searchHelp(lastUser.content, input.profile);
+    if (!hit) return { reply: noMatchReply(input.profile) };
+    return { reply: formatHit(hit) };
   }
-  return { reply: formatHit(hit) };
+
+  let sourcesUsed = 0;
+  let systemPrompt = SYSTEM_PROMPT;
+
+  const useBooks = input.context.useBooks === true;
+  if (useBooks) {
+    const collectionIds = await resolveCoachingCollectionIds(getPool());
+    if (collectionIds.length > 0) {
+      const chunks = await queryNearest({
+        collectionIds,
+        queryText: lastUser.content,
+        limit: 4,
+        threshold: 0.62,
+      });
+      if (chunks.length > 0) {
+        sourcesUsed = chunks.length;
+        const passages = chunks
+          .map((c, i) => `[${i + 1}] ${c.text}`)
+          .join('\n\n');
+        systemPrompt += `\n\n<Quellenpassagen>\n${passages}\n</Quellenpassagen>`;
+      }
+    }
+  }
+
+  const client = new Anthropic({ apiKey });
+  const response = await client.messages.create({
+    model: 'claude-sonnet-4-6',
+    max_tokens: 1024,
+    system: systemPrompt,
+    messages: input.messages.map((m) => ({
+      role: m.role as 'user' | 'assistant',
+      content: m.content,
+    })),
+  });
+
+  const reply = response.content
+    .filter((b): b is Anthropic.TextBlock => b.type === 'text')
+    .map((b) => b.text)
+    .join('');
+
+  return { reply, sourcesUsed };
 }

--- a/website/src/lib/assistant/types.ts
+++ b/website/src/lib/assistant/types.ts
@@ -35,3 +35,9 @@ export interface ActionResult {
   message: string;
   data?: Record<string, unknown>;
 }
+
+export interface AssistantChatResult {
+  reply: string;
+  proposedAction?: ProposedAction;
+  sourcesUsed?: number;
+}

--- a/website/src/pages/admin/knowledge/books/index.astro
+++ b/website/src/pages/admin/knowledge/books/index.astro
@@ -3,6 +3,7 @@ import AdminLayout from '../../../../layouts/AdminLayout.astro';
 import { Pool } from 'pg';
 import { listBooks } from '../../../../lib/coaching-db';
 import { getSession, getLoginUrl, isAdmin } from '../../../../lib/auth';
+import BookUploadForm from '../../../../components/admin/BookUploadForm.svelte';
 
 const session = await getSession(Astro.request.headers.get('cookie'));
 if (!session) return Astro.redirect(getLoginUrl(Astro.url.pathname));
@@ -27,14 +28,13 @@ try {
         Bücher
       </nav>
       <h1>Coaching-Bücher</h1>
-      <p class="subtitle">Ingestierte Bücher für Themen-Browser und Snippet-Kuration. Ingest läuft via <code>task coaching:ingest</code>.</p>
+      <p class="subtitle">Bücher anderer Autoren — deren Wissen wird von der KI absorbiert.</p>
     </header>
 
+    <BookUploadForm client:load />
+
     {books.length === 0 ? (
-      <div class="empty">
-        <p>Noch keine Bücher ingestiert.</p>
-        <pre><code>ENV=&lt;env&gt; task coaching:ingest -- coaching-sources/&lt;file&gt; &lt;slug&gt; --title="…" --author="…"</code></pre>
-      </div>
+      <p class="empty-hint">Noch keine Bücher hochgeladen.</p>
     ) : (
       <table class="books-table">
         <thead>
@@ -42,7 +42,7 @@ try {
             <th>Titel</th>
             <th>Autor</th>
             <th class="num">Chunks</th>
-            <th>Ingestiert</th>
+            <th>Hochgeladen</th>
             <th></th>
           </tr>
         </thead>
@@ -72,9 +72,7 @@ try {
   .subtitle { color: var(--text-muted, #888); margin: 0.4rem 0 0; }
   .subtitle code { background: var(--bg-2, #f3f0ec); padding: 0.1rem 0.4rem; border-radius: 3px; font-size: 0.85em; }
 
-  .empty { background: var(--bg-2, #f7f5f2); border: 1px solid var(--line, #e5e2dd); border-radius: 8px; padding: 1.5rem; }
-  .empty p { margin: 0 0 0.75rem; color: var(--text-muted, #888); }
-  .empty pre { background: var(--bg, #fff); padding: 0.75rem; border-radius: 4px; overflow-x: auto; margin: 0; font-size: 0.85em; }
+  .empty-hint { background: var(--bg-2, #f7f5f2); border: 1px solid var(--line, #e5e2dd); border-radius: 8px; padding: 1.5rem; color: var(--text-muted, #888); }
 
   .books-table { width: 100%; border-collapse: collapse; }
   .books-table th { text-align: left; padding: 0.5rem 0.75rem; border-bottom: 1px solid var(--line, #ddd); font-weight: 500; font-size: 0.85rem; color: var(--text-muted, #666); }

--- a/website/src/pages/api/admin/coaching/books/upload.ts
+++ b/website/src/pages/api/admin/coaching/books/upload.ts
@@ -36,6 +36,7 @@ export const POST: APIRoute = async ({ request }) => {
   const licenseNote = (formData.get('licenseNote') as string | null)?.trim() || null;
 
   if (!file || !file.name) return json({ error: 'missing file' }, 400);
+  if (file.size > 50 * 1024 * 1024) return json({ error: 'Datei zu groß — max. 50 MB.' }, 413);
   if (!title) return json({ error: 'missing title' }, 400);
 
   const ext = file.name.split('.').pop()?.toLowerCase() ?? '';

--- a/website/src/pages/api/admin/coaching/books/upload.ts
+++ b/website/src/pages/api/admin/coaching/books/upload.ts
@@ -1,0 +1,156 @@
+import type { APIRoute } from 'astro';
+import { getSession, isAdmin } from '../../../../../lib/auth';
+import { Pool } from 'pg';
+import { writeFile, unlink } from 'node:fs/promises';
+import { join } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { createHash } from 'node:crypto';
+import pdfParse from 'pdf-parse/lib/pdf-parse.js';
+import EPub from 'epub2';
+import { chunkText } from '../../../../../lib/chunking';
+import { embedBatch } from '../../../../../lib/embeddings';
+import {
+  ensureCollection,
+  addDocument,
+  upsertChunks,
+  recountChunks,
+} from '../../../../../lib/knowledge-db';
+
+const pool = new Pool();
+
+const json = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } });
+
+export const prerender = false;
+
+export const POST: APIRoute = async ({ request }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) return json({ error: 'unauthorized' }, 401);
+
+  let formData: FormData;
+  try { formData = await request.formData(); } catch { return json({ error: 'invalid multipart' }, 400); }
+
+  const file = formData.get('file') as File | null;
+  const title = (formData.get('title') as string | null)?.trim() || '';
+  const author = (formData.get('author') as string | null)?.trim() || null;
+  const licenseNote = (formData.get('licenseNote') as string | null)?.trim() || null;
+
+  if (!file || !file.name) return json({ error: 'missing file' }, 400);
+  if (!title) return json({ error: 'missing title' }, 400);
+
+  const ext = file.name.split('.').pop()?.toLowerCase() ?? '';
+  if (ext !== 'pdf' && ext !== 'epub') return json({ error: 'unsupported format — only PDF or EPUB' }, 400);
+
+  const tmpPath = join('/tmp', `book-upload-${randomUUID()}.${ext}`);
+  try {
+    const buf = Buffer.from(await file.arrayBuffer());
+    await writeFile(tmpPath, buf);
+
+    // Extract text
+    let text: string;
+    let pageCount: number;
+    if (ext === 'pdf') {
+      const data = await pdfParse(buf);
+      text = data.text;
+      pageCount = data.numpages;
+    } else {
+      const epub = await (EPub as any).createAsync(tmpPath);
+      const chapters: string[] = [];
+      for (const item of epub.flow) {
+        const html = await new Promise<string>((res, rej) =>
+          epub.getChapter(item.id, (err: Error | null, txt: string) => (err ? rej(err) : res(txt))),
+        );
+        const clean = html
+          .replace(/<style[\s\S]*?<\/style>/gi, '')
+          .replace(/<script[\s\S]*?<\/script>/gi, '')
+          .replace(/<[^>]+>/g, ' ')
+          .replace(/&nbsp;/g, ' ')
+          .replace(/\s+/g, ' ')
+          .trim();
+        if (clean) chapters.push(clean);
+      }
+      text = chapters.join('\n\n');
+      pageCount = chapters.length;
+    }
+
+    if (!text.trim()) return json({ error: 'no text could be extracted from the file' }, 422);
+
+    // Slug from title
+    const slug = title.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+
+    // Ensure collection
+    const collection = await ensureCollection({
+      name: `coaching-${slug}`,
+      source: 'custom',
+      brand: process.env.BRAND ?? 'mentolder',
+      description: title,
+    });
+
+    // Chunk
+    const chunks = chunkText(text, { mode: 'plain', targetTokens: 600, overlapTokens: 80 });
+
+    // Embed
+    const model = process.env.LLM_ENABLED === 'true' ? 'bge-m3' : 'voyage-multilingual-2';
+    const { embeddings } = await embedBatch(chunks.map((c) => c.text), { model, purpose: 'index' });
+
+    // Page approximation
+    const totalChunks = chunks.length;
+    const pageFor = (i: number): number | null =>
+      pageCount < 1 ? null : Math.min(Math.floor((i * pageCount) / totalChunks) + 1, pageCount);
+
+    // Store document + chunks
+    const sha256 = createHash('sha256').update(text).digest('hex');
+    const doc = await addDocument({
+      collectionId: collection.id,
+      title,
+      sourceUri: `file://${file.name}`,
+      rawText: text,
+      sha256,
+      metadata: { format: ext, pageCount },
+    });
+
+    await upsertChunks(
+      collection.id,
+      doc.id,
+      chunks.map((c, i) => ({
+        position: c.position,
+        text: c.text,
+        embedding: embeddings[i],
+        metadata: { page: pageFor(i) },
+      })),
+    );
+
+    await recountChunks(collection.id);
+
+    // Upsert coaching.books row
+    await pool.query(
+      `INSERT INTO coaching.books (knowledge_collection_id, title, author, source_filename, license_note)
+       VALUES ($1, $2, $3, $4, $5)
+       ON CONFLICT (knowledge_collection_id) DO UPDATE
+         SET title = EXCLUDED.title,
+             author = EXCLUDED.author,
+             source_filename = EXCLUDED.source_filename,
+             license_note = EXCLUDED.license_note`,
+      [collection.id, title, author, file.name, licenseNote],
+    );
+
+    const bookRes = await pool.query(
+      `SELECT b.*, c.chunk_count
+         FROM coaching.books b
+         JOIN knowledge.collections c ON c.id = b.knowledge_collection_id
+        WHERE b.knowledge_collection_id = $1`,
+      [collection.id],
+    );
+
+    return json({ book: bookRes.rows[0] });
+  } catch (err) {
+    console.error('[upload] book ingestion failed:', err);
+    const msg = err instanceof Error ? err.message : 'internal error';
+    if (msg.includes('voyage') && msg.includes('429')) {
+      return json({ error: 'Embedding-Dienst überlastet — bitte in 60 Sekunden erneut versuchen.' }, 429);
+    }
+    return json({ error: msg }, 500);
+  } finally {
+    await unlink(tmpPath).catch(() => {});
+  }
+};

--- a/website/src/pages/api/assistant/chat.ts
+++ b/website/src/pages/api/assistant/chat.ts
@@ -18,7 +18,8 @@ export const POST: APIRoute = async ({ request }) => {
   let body: { profile: AssistantProfile; content: string; currentRoute?: string; useBooks?: boolean };
   try { body = await request.json(); } catch { return json({ error: 'bad json' }, 400); }
 
-  const { profile, content, currentRoute = '/', useBooks = false } = body;
+  const { profile, content, currentRoute = '/' } = body;
+  const useBooks = profile === 'admin' ? (body.useBooks ?? false) : false;
   if (profile !== 'admin' && profile !== 'portal') return json({ error: 'invalid profile' }, 400);
   if (profile === 'admin' && !isAdmin(session)) return json({ error: 'forbidden' }, 403);
   if (typeof content !== 'string' || !content.trim()) return json({ error: 'empty content' }, 400);

--- a/website/src/pages/api/assistant/chat.ts
+++ b/website/src/pages/api/assistant/chat.ts
@@ -15,10 +15,10 @@ export const POST: APIRoute = async ({ request }) => {
   const session = await getSession(request.headers.get('cookie'));
   if (!session) return json({ error: 'unauthorized' }, 401);
 
-  let body: { profile: AssistantProfile; content: string; currentRoute?: string };
+  let body: { profile: AssistantProfile; content: string; currentRoute?: string; useBooks?: boolean };
   try { body = await request.json(); } catch { return json({ error: 'bad json' }, 400); }
 
-  const { profile, content, currentRoute = '/' } = body;
+  const { profile, content, currentRoute = '/', useBooks = false } = body;
   if (profile !== 'admin' && profile !== 'portal') return json({ error: 'invalid profile' }, 400);
   if (profile === 'admin' && !isAdmin(session)) return json({ error: 'forbidden' }, 403);
   if (typeof content !== 'string' || !content.trim()) return json({ error: 'empty content' }, 400);
@@ -31,10 +31,10 @@ export const POST: APIRoute = async ({ request }) => {
     profile,
     userSub: session.sub,
     messages: history.map((m) => ({ role: m.role, content: m.content })),
-    context: { currentRoute },
+    context: { currentRoute, useBooks },
   });
 
   const stored = await appendMessage(conv.id, 'assistant', result.reply, result.proposedAction);
 
-  return json({ message: stored });
+  return json({ message: stored, sourcesUsed: result.sourcesUsed ?? 0 });
 };


### PR DESCRIPTION
## Summary

- **Upload endpoint** (`/api/admin/coaching/books/upload`): multipart PDF/EPUB ingestion — chunks, embeds via Voyage/bge-m3, stores in pgvector + `coaching.books`; 50 MB guard, Voyage 429 surfaced as German error
- **RAG in LLM** (`llm.ts`): when admin toggles Bücher, nearest 4 passages (threshold 0.62) from coaching collections are injected as `<Quellenpassagen>` into the Claude claude-sonnet-4-6 system prompt; gracefully falls back to Claude-without-passages if embedding service is down
- **Collection resolver** (`coaching-collections.ts`): 60s cache for coaching book collection IDs with brand filter (`c.brand = $1 OR c.brand IS NULL`)
- **Chat API** (`chat.ts`): `useBooks` is accepted but forced to `false` for non-admin profiles; `sourcesUsed` returned in response
- **Bücher toggle** (`AssistantChat.svelte`): admin-only toggle with sessionStorage persistence; hidden from portal users
- **Passagen badge** (`AssistantMessage.svelte`): shows passage count when `sourcesUsed > 0`
- **Admin upload form** (`BookUploadForm.svelte` + `books/index.astro`): drag-drop UI with progress, accept PDF/EPUB

## Test Plan

- [ ] Upload a PDF as admin → book appears in list, chunk_count > 0
- [ ] Enable Bücher toggle → assistant reply mentions book content, badge shows passage count
- [ ] Disable toggle → reply is pure Claude, no badge
- [ ] Portal user POST with `useBooks: true` → `sourcesUsed: 0` in response (server enforces)
- [ ] Upload file > 50 MB → 413 returned immediately
- [ ] Upload with embedding service down → chat still works, no badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)