### PR TITLE
fix(arena): move ARENA_WS_URL from setup_vars to env_vars in all envs

### DIFF
--- a/environments/dev.yaml
+++ b/environments/dev.yaml
@@ -11,6 +11,7 @@ env_vars:
   LLM_ENABLED: "false"
   LLM_RERANK_ENABLED: "false"
   LLM_HOST_IP: ""
+  ARENA_WS_URL: http://arena.localhost
 
 # Dev secrets: generated from schema defaults at deploy time.
 secrets_mode: plaintext
@@ -19,4 +20,3 @@ setup_vars:
   KC_USER1_USERNAME: admin
   KC_USER1_EMAIL: admin@localhost
   KC_USER1_PASSWORD: DevAdmin123!
-  ARENA_WS_URL: http://arena.localhost

--- a/environments/korczewski.yaml
+++ b/environments/korczewski.yaml
@@ -51,6 +51,7 @@ env_vars:
   # flip LLM_RERANK_ENABLED to true after 24h of stable rollout
   LLM_RERANK_ENABLED: "false"
   LLM_ROUTER_URL: "http://llm-router.workspace-korczewski.svc.cluster.local:4000"
+  ARENA_WS_URL: https://arena-ws.mentolder.de
 
 overlay: prod-korczewski
 workspace_namespace: workspace-korczewski
@@ -64,4 +65,3 @@ setup_vars:
   KC_USER2_USERNAME: gekko
   KC_USER2_EMAIL: quamain@web.de
   KC_USER2_PASSWORD: SEALED
-  ARENA_WS_URL: https://arena-ws.mentolder.de

--- a/environments/mentolder.yaml
+++ b/environments/mentolder.yaml
@@ -50,6 +50,7 @@ env_vars:
   # flip LLM_RERANK_ENABLED to true after 24h of stable rollout
   LLM_RERANK_ENABLED: "false"
   LLM_ROUTER_URL: "http://llm-router.workspace.svc.cluster.local:4000"
+  ARENA_WS_URL: https://arena-ws.mentolder.de
 
 overlay: prod-mentolder
 workspace_namespace: workspace
@@ -63,4 +64,3 @@ setup_vars:
   KC_USER2_USERNAME: gekko
   KC_USER2_EMAIL: quamain@web.de
   KC_USER2_PASSWORD: SEALED
-  ARENA_WS_URL: https://arena-ws.mentolder.de


### PR DESCRIPTION
## Summary
4th gap surfaced during the redeploy after #657: \`schema.yaml\` declares \`ARENA_WS_URL\` as an \`env_vars\` entry, but all three env files (\`mentolder.yaml\`, \`korczewski.yaml\`, \`dev.yaml\`) placed it in \`setup_vars\`. \`scripts/env-resolve.sh\` iterates \`schema.env_vars\` against \`env_file.env_vars\`, so the section mismatch meant the variable was never exported — \`envsubst \"\$ARENA_WS_URL\"\` then expanded to the empty string, and the prod \`website-config\` ConfigMap landed with \`ARENA_WS_URL: \"\"\`.

After this PR + redeploy:
- mentolder ConfigMap: \`ARENA_WS_URL=https://arena-ws.mentolder.de\`
- korczewski ConfigMap: \`ARENA_WS_URL=https://arena-ws.mentolder.de\` (same — points at mentolder)
- dev ConfigMap: \`ARENA_WS_URL=http://arena.localhost\`

\`task env:validate:all\` passes on all three envs.

## Test plan
- [ ] \`task website:deploy ENV=mentolder\` then \`ENV=korczewski\`
- [ ] \`kubectl --context mentolder -n website get cm website-config -o jsonpath='{.data.ARENA_WS_URL}'\` returns the URL (not empty)
- [ ] Same on korczewski-ha
- [ ] Website pod \`printenv ARENA_WS_URL\` returns the URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)