### PR TITLE
fix(arena): pin bootstrap Job to Hetzner + extend arena_app grants

### DIFF
--- a/k3d/migrations-arena.yaml
+++ b/k3d/migrations-arena.yaml
@@ -62,6 +62,30 @@ data:
     GRANT SELECT, INSERT, UPDATE ON arena.lobbies       TO arena_app;
     ALTER DEFAULT PRIVILEGES IN SCHEMA arena
       GRANT SELECT, INSERT, UPDATE ON TABLES TO arena_app;
+
+  0003_arena_app_ownership.sql: |
+    -- Additional grants for arena_app so the arena-server startup migration
+    -- (which runs `CREATE SCHEMA IF NOT EXISTS arena` and idempotent ALTERs
+    -- as arena_app) succeeds on a clean cluster:
+    --   * CONNECT on the database     -> needed to log in at all
+    --   * CREATE on database + schema -> needed for `CREATE SCHEMA`/tables
+    --   * ownership transfer          -> needed so re-applied ALTER TABLEs
+    --                                    don't fail with "must be owner"
+    --   * default privileges          -> future bootstrap-created objects
+    --                                    inherit the right grants
+    GRANT CONNECT ON DATABASE website TO arena_app;
+    GRANT CREATE  ON DATABASE website TO arena_app;
+    GRANT CREATE  ON SCHEMA   arena   TO arena_app;
+
+    ALTER SCHEMA arena              OWNER TO arena_app;
+    ALTER TABLE  arena.matches      OWNER TO arena_app;
+    ALTER TABLE  arena.match_players OWNER TO arena_app;
+    ALTER TABLE  arena.lobbies      OWNER TO arena_app;
+
+    ALTER DEFAULT PRIVILEGES IN SCHEMA arena
+      GRANT ALL ON TABLES    TO arena_app;
+    ALTER DEFAULT PRIVILEGES IN SCHEMA arena
+      GRANT ALL ON SEQUENCES TO arena_app;
 ---
 apiVersion: batch/v1
 kind: Job
@@ -84,6 +108,7 @@ spec:
               export PGPASSWORD="$SHARED_DB_PASSWORD"
               psql "host=shared-db.workspace.svc.cluster.local user=postgres dbname=website" -v ON_ERROR_STOP=1 -f /sql/0001_init.sql
               psql "host=shared-db.workspace.svc.cluster.local user=postgres dbname=website" -v ON_ERROR_STOP=1 -f /sql/0002_arena_app_grants.sql
+              psql "host=shared-db.workspace.svc.cluster.local user=postgres dbname=website" -v ON_ERROR_STOP=1 -f /sql/0003_arena_app_ownership.sql
               # Apply password from the SealedSecret.
               psql "host=shared-db.workspace.svc.cluster.local user=postgres dbname=website" -v ON_ERROR_STOP=1 -c "ALTER ROLE arena_app WITH PASSWORD '${ARENA_DB_PASSWORD}'"
               echo "arena bootstrap complete"

--- a/prod-mentolder/kustomization.yaml
+++ b/prod-mentolder/kustomization.yaml
@@ -95,5 +95,28 @@ patches:
                         - k3w-1
                         - k3w-2
                         - k3w-3
+  # One-shot Jobs (e.g. arena-bootstrap) also need to stay on Hetzner nodes;
+  # the home workers hit intermittent DNS failures (EAI_AGAIN on
+  # shared-db.workspace.svc.cluster.local), which exhausts backoffLimit and
+  # leaves the cluster without arena_app role + grants.
+  - target:
+      kind: Job
+    patch: |-
+      - op: add
+        path: /spec/template/spec/affinity
+        value:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: kubernetes.io/hostname
+                      operator: NotIn
+                      values:
+                        - k3s-1
+                        - k3s-2
+                        - k3s-3
+                        - k3w-1
+                        - k3w-2
+                        - k3w-3
   - path: patch-backup-config.yaml
   - path: patch-livekit.yaml


### PR DESCRIPTION
## Summary

Two durable fixes for arena-server bootstrap regressions that an earlier agent had to patch live. Without these, a clean re-deploy onto an empty database would re-break in the exact same ways.

### 1. Pin `arena-bootstrap` Job to Hetzner nodes
The existing home-worker-exclusion patch in `prod-mentolder/kustomization.yaml` targets `kind: Deployment` and `kind: CronJob` but **not** `kind: Job`. The `arena-bootstrap` Job (declared in `k3d/migrations-arena.yaml`, only included by the mentolder overlay) could therefore land on `k3s-*` / `k3w-*` home workers, where DNS for `shared-db.workspace.svc.cluster.local` flakes with `EAI_AGAIN`. With `backoffLimit=3`, the Job exhausts retries, gets GC'd after `ttlSecondsAfterFinished=600`, and arena-server then CrashLoops because the `arena_app` role never gets created.

Added a third `target: { kind: Job }` patch block with the same `NotIn` nodeAffinity list (`k3s-1/2/3`, `k3w-1/2/3`).

### 2. Extend arena_app grants in bootstrap SQL
`0002_arena_app_grants.sql` only granted `USAGE` + `SELECT/INSERT/UPDATE` on schema-level objects. Missing privileges that surfaced live:

- `GRANT CONNECT ON DATABASE website TO arena_app` — without this, arena_app cannot log in at all (got `permission denied for database "website"`).
- `GRANT CREATE ON DATABASE website TO arena_app` and `GRANT CREATE ON SCHEMA arena TO arena_app` — arena-server's own startup migration runs `CREATE SCHEMA IF NOT EXISTS arena` as `arena_app`; without these it errors out before the app can serve.
- `ALTER SCHEMA arena OWNER TO arena_app` plus `ALTER TABLE arena.{matches,match_players,lobbies} OWNER TO arena_app` — the idempotent re-apply on second boot otherwise fails with `must be owner of relation` on `ALTER TABLE`.
- `ALTER DEFAULT PRIVILEGES IN SCHEMA arena GRANT ALL ON TABLES, SEQUENCES TO arena_app` — future bootstrap-created tables/sequences inherit the right grants.

Added as a new `0003_arena_app_ownership.sql` key in the `arena-bootstrap-sql` ConfigMap (keeps the historical 0001/0002 keys stable) and wired into the Job's `args` after `0002_*`.

### Live-fix observations that drove this
- arena-bootstrap pod scheduled on `k3w-2` -> `getaddrinfo EAI_AGAIN shared-db.workspace.svc.cluster.local` -> Job exhausted backoffLimit -> GC'd -> `arena_app` role missing.
- After live-creating the role manually: arena-server's startup migration failed with `permission denied for database "website"` (no CONNECT) -> after granting CONNECT, failed on `CREATE SCHEMA` -> after granting CREATE -> failed on `ALTER TABLE` (`must be owner`).

## Test plan

- [x] `task workspace:validate` reports `Manifests are valid`
- [x] `kubectl kustomize --load-restrictor=LoadRestrictionsNone prod-mentolder/` shows the rendered `arena-bootstrap` Job carries the `NotIn` nodeAffinity for home-worker hostnames
- [x] Same render shows `arena-bootstrap-sql` ConfigMap contains `0003_arena_app_ownership.sql` with all five new grant statements
- [x] Same render shows the Job's `args` execute `0001 -> 0002 -> 0003` in order before the password ALTER
- [ ] **Not exercised live** — current cluster is healthy with the live workarounds applied. Re-running the bootstrap on the live cluster risks the idempotent SQL erroring against partially-fixed state. The fix is intended to take effect on the next clean bootstrap / fresh re-deploy.

Generated with Claude Code