### PR TITLE
fix(korczewski): durable coturn UDP bind + spreed-signaling Janus colocation

### DIFF
--- a/k3d/coturn-stack/coturn.yaml
+++ b/k3d/coturn-stack/coturn.yaml
@@ -43,6 +43,15 @@ spec:
           # only touches ${VAR}, so $(TURN_SECRET) survives build-time.
           command: ["turnserver"]
           args:
+            # coturn 4.9 spawns one UDP worker thread per CPU. Each thread
+            # tries to bind 0.0.0.0:3478 directly without SO_REUSEPORT, so
+            # the first wins and the rest abort with EADDRINUSE, killing
+            # the process every ~60s on multi-core nodes (observed on
+            # korczewski-ha / pk-hetzner-6, 8 cores). Force the legacy
+            # single-threaded net engine — TURN load on this cluster is
+            # tiny (single-host Talk SFU), so the perf hit is irrelevant
+            # and the bind race goes away entirely.
+            - "--net-engine-version=1"
             - "--no-dtls"
             - "--listening-port=3478"
             - "--tls-listening-port=5349"

--- a/k3d/talk-hpb.yaml
+++ b/k3d/talk-hpb.yaml
@@ -135,23 +135,33 @@ spec:
         app: spreed-signaling
       # Bump this to force a rollout whenever the render logic changes.
       annotations:
-        config/hash: "5"
+        config/hash: "6"
     spec:
-      # Soft preference: avoid agent-4 which has transient Janus MCU
-      # connectivity issues (hostNetwork pod reachability via kube-proxy).
       securityContext:
         seccompProfile:
           type: RuntimeDefault
+      # Hard pod-affinity to Janus (in the `coturn` namespace, label app=janus).
+      # Janus runs hostNetwork:true and is pinned to ${TURN_NODE} via its own
+      # nodeSelector. Colocating spreed-signaling on the same node means the
+      # WebSocket connection to ws://janus.coturn:8188 resolves to a hostPort
+      # on the local node and traffic stays on the loopback path, bypassing:
+      #   - kube-proxy DNAT to the node's public IP (37.27.251.38 on korczewski),
+      #     which the allow-signaling-coturn-egress NetworkPolicy does not cover
+      #   - the Hetzner per-host firewall, which blocks 8188 cross-node
+      # Using podAffinity (not a hard nodeSelector on ${TURN_NODE}) means this
+      # auto-tracks Janus wherever it ends up scheduled. The legacy soft
+      # preference NotIn k3d-dev-agent-4 is dropped — that node was a dev-only
+      # workaround for a kube-proxy MCU reachability bug that this colocation
+      # rule fixes structurally.
       affinity:
-        nodeAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 100
-              preference:
-                matchExpressions:
-                  - key: kubernetes.io/hostname
-                    operator: NotIn
-                    values:
-                      - k3d-dev-agent-4
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app: janus
+              namespaces:
+                - coturn
+              topologyKey: kubernetes.io/hostname
       initContainers:
         # Render /shared/server.conf from the template by substituting
         # @@VAR@@ placeholders with values sourced from workspace-secrets.


### PR DESCRIPTION
## Summary

Two manifest-level fixes for korczewski-ha Talk infrastructure. Both were applied as live cluster patches by the ops agent earlier today, but ArgoCD's `selfHeal: true` reverted them on the next sync — so this PR makes both durable.

### Fix 1 — coturn CrashLoop (UDP thread bind race)

**File:** `k3d/coturn-stack/coturn.yaml`

**Symptom:** `coturn` pod in the `coturn` namespace on korczewski-ha crashes every ~60s with:
```
Fatal final failure: cannot bind DTLS/UDP listener socket to addr 0.0.0.0:3478
```
Rolling the pod doesn't help — stale-process theory was ruled out.

**Root cause:** coturn 4.9's default net engine spawns one UDP worker thread per CPU. Each thread independently tries to bind `0.0.0.0:3478` *without* `SO_REUSEPORT`. The first wins, the rest get `EADDRINUSE`, and the process aborts. Fires on any multi-core node; `pk-hetzner-6` has 8 cores so it's deterministic there.

**Fix:** add `--net-engine-version=1` to the turnserver args to force the legacy single-threaded net engine. TURN load on this cluster is a single-host Talk SFU, so the perf hit is irrelevant and the bind race goes away entirely.

### Fix 2 — spreed-signaling can't reach Janus

**File:** `k3d/talk-hpb.yaml`

**Symptom:** `spreed-signaling` Deployment in `workspace-korczewski` ns stuck at `Running 0/1` with:
```
Could not initialize janus MCU (dial tcp 10.43.220.31:8188: connect: connection timed out)
```

**Root cause:** Janus runs `hostNetwork: true` pinned to `pk-hetzner-6`. kube-proxy DNATs `janus.coturn:8188` (ClusterIP) to the node's public IP `37.27.251.38`. Two layers then block the egress:
1. The `allow-signaling-coturn-egress` NetworkPolicy only permits egress to `10.43.0.0/16` (service CIDR) and `172.19.0.0/16` (k3d node net) — neither covers the Hetzner public IP.
2. The Hetzner per-host firewall blocks `8188/tcp` cross-node anyway.

The live workaround was a manual `nodeSelector` pinning spreed-signaling to `pk-hetzner-6` — colocating it with Janus so the WebSocket connection resolves on `lo` and bypasses both layers.

**Fix:** replace the legacy `nodeAffinity NotIn k3d-dev-agent-4` (a stale dev-only workaround for the same kube-proxy MCU reachability bug) with a **hard `podAffinity`** to `app=janus` in the `coturn` namespace via `topologyKey=kubernetes.io/hostname`. This auto-tracks Janus regardless of where it lands:
- mentolder: Janus on `gekko-hetzner-2` → spreed-signaling follows
- korczewski: Janus on `pk-hetzner-6` → spreed-signaling follows

No per-env overlay patch needed. Also bumps `config/hash` to `"6"` to force a rollout.

## Why this is durable (vs the live patches)

Both files are in the base `k3d/` tree, so they flow through `prod-mentolder/` and `prod-korczewski/` overlays + their ArgoCD `ApplicationSets` (`workspace` and `workspace-coturn`). On next sync, ArgoCD's `selfHeal: true` will *enforce* these settings instead of reverting them.

## Test plan

- [x] `task workspace:validate` — all manifests are valid (dry-run apply succeeded)
- [x] `kubectl kustomize --load-restrictor=LoadRestrictionsNone k3d/coturn-stack/` — `--net-engine-version=1` renders as the first arg
- [x] `kubectl kustomize --load-restrictor=LoadRestrictionsNone prod-korczewski/` — `podAffinity` to `app=janus` in `coturn` ns renders correctly on the spreed-signaling Deployment
- [ ] After ArgoCD sync: `kubectl --context korczewski-ha get pods -n coturn` → coturn `Ready 1/1`, no new restarts
- [ ] After ArgoCD sync: `kubectl --context korczewski-ha get pods -n workspace-korczewski -l app=spreed-signaling` → `Ready 1/1`, scheduled on `pk-hetzner-6` (same as Janus)
- [ ] `curl -sI https://signaling.korczewski.de/api/v1/welcome` → still `200`
- [ ] Spot-check mentolder: spreed-signaling re-rolls onto `gekko-hetzner-2` (Janus's node) without disruption

🤖 Generated with [Claude Code](https://claude.com/claude-code)