### PR TITLE
fix(coturn): use --ne=1 (long form unsupported in coturn 4.9-alpine)

### DIFF
--- a/k3d/coturn-stack/coturn.yaml
+++ b/k3d/coturn-stack/coturn.yaml
@@ -50,8 +50,11 @@ spec:
             # korczewski-ha / pk-hetzner-6, 8 cores). Force the legacy
             # single-threaded net engine — TURN load on this cluster is
             # tiny (single-host Talk SFU), so the perf hit is irrelevant
-            # and the bind race goes away entirely.
-            - "--net-engine-version=1"
+            # and the bind race goes away entirely. coturn 4.9-alpine
+            # only recognises the short form `--ne=N`; the long form
+            # `--net-engine-version=N` is not parsed and crashes the
+            # process at startup (prints usage and exits).
+            - "--ne=1"
             - "--no-dtls"
             - "--listening-port=3478"
             - "--tls-listening-port=5349"


### PR DESCRIPTION
## Summary

Follow-up to #661. The `--net-engine-version=1` long-form flag added there is **not parsed** by turnserver in `coturn:4.9-alpine` — at startup it prints `unrecognized option: net-engine-version=1`, dumps its usage, and exits. The pod then CrashLoops.

The short form `--ne=N` *is* recognised (the help output explicitly documents `--ne=[1|2|3]`). Switch to it.

## How this was caught

Verified live on korczewski-ha right after #661 merged:

```
$ kubectl --context korczewski-ha logs deploy/coturn -n coturn --tail=2 | head -1
turnserver: unrecognized option: net-engine-version=1
```

After this PR, the pod should start cleanly with the single-threaded net engine and stop CrashLooping on the UDP bind race that motivated #661.

## Test plan

- [x] Local kustomize verified: `kubectl kustomize --load-restrictor=LoadRestrictionsNone k3d/coturn-stack/` renders `--ne=1` as the first arg
- [ ] After merge + apply: `kubectl --context korczewski-ha get pods -n coturn -l app=coturn` → `Ready 1/1`, restart count stable for >2 min
- [ ] `kubectl --context korczewski-ha logs deploy/coturn -n coturn | head -5` → starts with the coturn banner, not a usage dump
- [ ] `curl -sI https://signaling.korczewski.de/api/v1/welcome` → still `200`

🤖 Generated with [Claude Code](https://claude.com/claude-code)