### PR TITLE
fix(mentolder): preserve podAffinity through overlay patch

### DIFF
--- a/prod-mentolder/kustomization.yaml
+++ b/prod-mentolder/kustomization.yaml
@@ -56,67 +56,91 @@ generatorOptions:
 # joined the unified cluster. The CNI partition breaks DNS and ClusterIP routing
 # from those nodes. livekit-* are exempt: patch-livekit.yaml pins them to
 # gekko-hetzner-3 explicitly, overriding this blanket affinity.
+#
+# IMPORTANT: these use strategic-merge (no `target:`) instead of a JSON 6902
+# `op: add` patch. JSON `add` on an existing object REPLACES it wholesale —
+# any Deployment that already declares an `affinity` block (e.g. spreed-signaling
+# with its podAffinity to Janus from PR #661) gets that block clobbered. The
+# strategic-merge variants below only set `affinity.nodeAffinity`, leaving any
+# existing `podAffinity` / `podAntiAffinity` siblings intact.
 patches:
-  - target:
+  - patch: |-
+      apiVersion: apps/v1
       kind: Deployment
-    patch: |-
-      - op: add
-        path: /spec/template/spec/affinity
-        value:
-          nodeAffinity:
-            requiredDuringSchedulingIgnoredDuringExecution:
-              nodeSelectorTerms:
-                - matchExpressions:
-                    - key: kubernetes.io/hostname
-                      operator: NotIn
-                      values:
-                        - k3s-1
-                        - k3s-2
-                        - k3s-3
-                        - k3w-1
-                        - k3w-2
-                        - k3w-3
-  - target:
+      metadata:
+        name: _placeholder_
+      spec:
+        template:
+          spec:
+            affinity:
+              nodeAffinity:
+                requiredDuringSchedulingIgnoredDuringExecution:
+                  nodeSelectorTerms:
+                    - matchExpressions:
+                        - key: kubernetes.io/hostname
+                          operator: NotIn
+                          values:
+                            - k3s-1
+                            - k3s-2
+                            - k3s-3
+                            - k3w-1
+                            - k3w-2
+                            - k3w-3
+    target:
+      kind: Deployment
+  - patch: |-
+      apiVersion: batch/v1
       kind: CronJob
-    patch: |-
-      - op: add
-        path: /spec/jobTemplate/spec/template/spec/affinity
-        value:
-          nodeAffinity:
-            requiredDuringSchedulingIgnoredDuringExecution:
-              nodeSelectorTerms:
-                - matchExpressions:
-                    - key: kubernetes.io/hostname
-                      operator: NotIn
-                      values:
-                        - k3s-1
-                        - k3s-2
-                        - k3s-3
-                        - k3w-1
-                        - k3w-2
-                        - k3w-3
+      metadata:
+        name: _placeholder_
+      spec:
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                affinity:
+                  nodeAffinity:
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      nodeSelectorTerms:
+                        - matchExpressions:
+                            - key: kubernetes.io/hostname
+                              operator: NotIn
+                              values:
+                                - k3s-1
+                                - k3s-2
+                                - k3s-3
+                                - k3w-1
+                                - k3w-2
+                                - k3w-3
+    target:
+      kind: CronJob
   # One-shot Jobs (e.g. arena-bootstrap) also need to stay on Hetzner nodes;
   # the home workers hit intermittent DNS failures (EAI_AGAIN on
   # shared-db.workspace.svc.cluster.local), which exhausts backoffLimit and
   # leaves the cluster without arena_app role + grants.
-  - target:
+  - patch: |-
+      apiVersion: batch/v1
       kind: Job
-    patch: |-
-      - op: add
-        path: /spec/template/spec/affinity
-        value:
-          nodeAffinity:
-            requiredDuringSchedulingIgnoredDuringExecution:
-              nodeSelectorTerms:
-                - matchExpressions:
-                    - key: kubernetes.io/hostname
-                      operator: NotIn
-                      values:
-                        - k3s-1
-                        - k3s-2
-                        - k3s-3
-                        - k3w-1
-                        - k3w-2
-                        - k3w-3
+      metadata:
+        name: _placeholder_
+      spec:
+        template:
+          spec:
+            affinity:
+              nodeAffinity:
+                requiredDuringSchedulingIgnoredDuringExecution:
+                  nodeSelectorTerms:
+                    - matchExpressions:
+                        - key: kubernetes.io/hostname
+                          operator: NotIn
+                          values:
+                            - k3s-1
+                            - k3s-2
+                            - k3s-3
+                            - k3w-1
+                            - k3w-2
+                            - k3w-3
+    target:
+      kind: Job
   - path: patch-backup-config.yaml
   - path: patch-livekit.yaml


### PR DESCRIPTION
## Summary

The blanket affinity patch in `prod-mentolder/kustomization.yaml` used a JSON 6902 `op: add` on `/spec/template/spec/affinity`. JSON `add` on an existing path **REPLACES** the value wholesale rather than merging. Any Deployment that already declared an `affinity` block had it silently clobbered on the mentolder overlay.

This bit `spreed-signaling`'s `podAffinity` to Janus, introduced in #661 to keep the `ws://janus.coturn:8188` hop on the local loopback path:

- **Before this PR** on mentolder:
  - `spreed-signaling` → `gekko-hetzner-4`
  - `janus` (coturn ns) → `gekko-hetzner-2`
  - Colocation defeated. Currently harmless (wg-mesh works inside Hetzner, no per-host firewall blocks 8188 on mentolder today) but the structural fix from #661 only protected korczewski.

korczewski was not affected because its overlay does not carry this blanket patch.

## Fix — Option A: strategic merge

Switch all three blanket patches (`Deployment` / `CronJob` / `Job`) from JSON 6902 `add` to strategic-merge form. Strategic merge sets `affinity.nodeAffinity` only and leaves any sibling `podAffinity` / `podAntiAffinity` intact. Future Deployments that grow a `podAffinity` will keep working automatically — no per-Deployment exception needed.

## Verification

`kubectl kustomize prod-mentolder/` after the change:

- `spreed-signaling` Deployment now contains **both** `nodeAffinity` (`NotIn` `k3s-*` / `k3w-*`) **and** `podAffinity` to `app=janus` in the `coturn` namespace.
- `keycloak`, `nats`, `nextcloud` and the rest of the Deployments still carry the home-worker exclusion.
- `livekit-server` still keeps its `patch-livekit.yaml` override (`In: gekko-hetzner-3`).
- An existing CronJob with a preferred `podAffinity` to `shared-db` retains it alongside the new strategic-merge `nodeAffinity`.

`task workspace:validate` is green.

## Test plan

- [x] `kubectl kustomize prod-mentolder/` renders without error
- [x] `spreed-signaling` rendered affinity contains BOTH `nodeAffinity` and `podAffinity`
- [x] 3+ other Deployments still get the home-worker exclusion
- [x] `livekit-server` override (pin to `gekko-hetzner-3`) still wins
- [x] `task workspace:validate` passes
- [ ] After merge: `task argocd:sync -- workspace-mentolder` and confirm `spreed-signaling` co-locates with the Janus pod

🤖 Generated with [Claude Code](https://claude.com/claude-code)