### PR TITLE
fix(livekit): disable built-in TURN to free UDP:3478 for coturn

### DIFF
--- a/k3d/livekit.yaml
+++ b/k3d/livekit.yaml
@@ -85,7 +85,14 @@ data:
     redis:
       address: livekit-redis:6379
     turn:
-      enabled: true
+      # Disabled so coturn (in namespace "coturn", hostPort 3478/UDP) can bind
+      # UDP:3478 on the same node. LiveKit-server runs with hostNetwork: true
+      # and is pinned (gekko-hetzner-3 on mentolder, pk-hetzner-6 on
+      # korczewski) — with turn.enabled=true it grabs UDP:3478 first and
+      # coturn CrashLoops with "bind: Address in use". Janus+Coturn already
+      # provide TURN for Talk; LiveKit clients fall back to srflx via STUN
+      # (use_external_ip + public 7881/tcp + 50000-60000/udp are open).
+      enabled: false
       domain: ""
       tls_port: 0
       udp_port: 3478


### PR DESCRIPTION
## Summary
- Flip `turn.enabled` from `true` to `false` in `k3d/livekit.yaml` so coturn can bind UDP:3478 on the same pin-node.
- LiveKit-server runs with `hostNetwork: true` and is pinned to `gekko-hetzner-3` (mentolder) / `pk-hetzner-6` (korczewski). With `turn.enabled: true` it grabbed UDP:3478 first and coturn (namespace `coturn`, `hostPort: 3478/UDP`) CrashLooped with `bind: Address in use`.
- Janus + Coturn already provide TURN for Nextcloud Talk, so LiveKit's built-in TURN is redundant. LiveKit clients fall back to srflx candidates via STUN — `use_external_ip: true` plus public 7881/tcp and 50000-60000/udp are open on every node (`prod/cloud-init.yaml`).

## Context
Follow-up to #661/#662 which fixed the worker-thread race but could not address the port conflict between livekit-server and coturn.

Verified before flipping:
- `k3d/livekit.yaml` is the only source of the TURN config — no overlay patches `turn:`.
- `k3d/coturn-stack/coturn.yaml` binds `hostPort: 3478` (UDP + TCP).
- `website/src/` has zero references to LiveKit's TURN URL or explicit `iceServers` — clients receive ICE candidates from the server, so flipping the switch is transparent to the website.
- `k3d/website.yaml` env only injects `LIVEKIT_DOMAIN`, API/secret, RTMP key, service URL, pin IPs — no TURN URL.

## Test plan
- [x] `task workspace:validate` (dry-run kustomize build + apply)
- [ ] ArgoCD sync `workspace-mentolder`, roll `livekit-server`, restart coturn, watch `ss -ulnp | grep 3478` on `gekko-hetzner-3`
- [ ] `task workspace:deploy ENV=korczewski`, same dance on `pk-hetzner-6`
- [ ] `web.korczewski.de/portal/stream` viewer join works
- [ ] `curl -sI https://signaling.korczewski.de/api/v1/welcome` still 200

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>