### PR TITLE
fix(infra): livekit hostNet netpol + register korczewski-ha as ArgoCD spoke

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -196,9 +196,11 @@ separate k3s clusters; verify with `kubectl config get-contexts`.
 
 **ArgoCD federation** still hub-runs on mentolder. Annotations on the cluster Secrets
 (`cluster-mentolder`, `cluster-korczewski-ha`) drive the per-cluster overlay path
-(`prod-mentolder` vs `prod-korczewski`). The historical `argocd-korczewski`
-ServiceAccount + `62.238.9.39:6443` annotation comments in `Taskfile.argocd.yml`
-predate the re-split — refresh them when next touching that file.
+(`prod-mentolder` vs `prod-korczewski`). The spoke RBAC for korczewski-ha lives in
+`argocd/spoke-rbac/korczewski-ha.yaml` (ServiceAccount `argocd-manager` in ns `argocd`,
+cluster-admin binding, long-lived token Secret); `task argocd:cluster:register`
+applies it and bootstraps the `cluster-korczewski-ha` Secret on the hub from the
+SA's CA + bearer token (API server `https://204.168.244.104:6443`).
 
 **WireGuard mesh (`wg-mesh`):** since the partition fix, all mentolder nodes —
 Hetzner CPs and home workers — peer over `wg-mesh` with Flannel pinned to that

--- a/Taskfile.argocd.yml
+++ b/Taskfile.argocd.yml
@@ -154,12 +154,39 @@ tasks:
         fi
       # ── Korczewski (standalone 3-node k3s HA cluster) ──
       # The 2026-05-05 cluster merge was reverted on 2026-05-09 (PRs #621/#622).
-      # korczewski-ha is its own physical cluster on pk-hetzner-4/6/8; web.korczewski.de
-      # routes through that cluster's Traefik (NOT mentolder's). It has its own
-      # shared-db, sealed-secrets controller, cert-manager, and Keycloak realm.
+      # korczewski-ha is its own physical cluster on pk-hetzner-4/6/8 (API server
+      # https://204.168.244.104:6443); web.korczewski.de routes through that
+      # cluster's Traefik (NOT mentolder's). It has its own shared-db,
+      # sealed-secrets controller, cert-manager, and Keycloak realm.
       # workspace-korczewski namespace lives on korczewski-ha; ArgoCD still hub-runs
-      # on mentolder and reaches korczewski-ha via the registered cluster Secret.
+      # on mentolder and reaches korczewski-ha via the registered cluster Secret
+      # `cluster-korczewski-ha` (created by the bootstrap below).
       # No workspace-office / workspace-coturn labels — korczewski shares mentolder's Collabora + coturn.
+      - |
+        # Bootstrap the spoke RBAC + token Secret if missing. Idempotent.
+        kubectl --context korczewski-ha apply -f argocd/spoke-rbac/korczewski-ha.yaml > /dev/null
+        if ! kubectl --context mentolder get secret cluster-korczewski-ha -n argocd > /dev/null 2>&1; then
+          echo "Creating cluster-korczewski-ha Secret on mentolder hub..."
+          TOKEN=$(kubectl --context korczewski-ha -n argocd get secret argocd-manager-token -o jsonpath='{.data.token}' | base64 -d)
+          CA_B64=$(kubectl --context korczewski-ha -n argocd get secret argocd-manager-token -o jsonpath='{.data.ca\.crt}')
+          CONFIG=$(printf '{"bearerToken":"%s","tlsClientConfig":{"insecure":false,"caData":"%s"}}' "$TOKEN" "$CA_B64")
+          kubectl --context mentolder apply -f - <<EOF
+        apiVersion: v1
+        kind: Secret
+        metadata:
+          name: cluster-korczewski-ha
+          namespace: argocd
+          labels:
+            argocd.argoproj.io/secret-type: cluster
+            workspace: "true"
+        type: Opaque
+        stringData:
+          name: korczewski-ha
+          server: https://204.168.244.104:6443
+          config: '${CONFIG}'
+        EOF
+          echo "  ✓ cluster-korczewski-ha Secret created"
+        fi
       - |
         source scripts/env-resolve.sh "korczewski"
         echo "Annotating korczewski cluster secret (targets korczewski-ha)..."

--- a/argocd/spoke-rbac/korczewski-ha.yaml
+++ b/argocd/spoke-rbac/korczewski-ha.yaml
@@ -1,0 +1,51 @@
+# ═══════════════════════════════════════════════════════════════════
+# ArgoCD spoke RBAC — korczewski-ha cluster
+# ═══════════════════════════════════════════════════════════════════
+# Applied with: kubectl --context korczewski-ha apply -f argocd/spoke-rbac/korczewski-ha.yaml
+#
+# Creates a ServiceAccount + long-lived token Secret that the ArgoCD
+# hub (running on mentolder) uses to manage workloads on this cluster.
+#
+# The 2026-05-09 cluster re-split (PRs #621/#622) gave korczewski.de
+# its own physical k3s cluster (pk-hetzner-4/6/8). ArgoCD still runs
+# only on mentolder; this RBAC lets it reach in.
+#
+# cluster-admin is intentional: the same scope ArgoCD has on its own
+# in-cluster context. Tighten only if/when we narrow what ArgoCD
+# applies on this spoke.
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: argocd
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: argocd-manager
+  namespace: argocd
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: argocd-manager-role-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: argocd-manager
+    namespace: argocd
+---
+# Long-lived token Secret (k8s 1.24+ stopped auto-creating these).
+# ArgoCD reads .data.token + .data.ca\.crt from here to build the
+# kube client; rotating just means recreating this Secret.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: argocd-manager-token
+  namespace: argocd
+  annotations:
+    kubernetes.io/service-account.name: argocd-manager
+type: kubernetes.io/service-account-token

--- a/k3d/livekit.yaml
+++ b/k3d/livekit.yaml
@@ -58,6 +58,29 @@ spec:
     - port: 6379
       targetPort: 6379
 ---
+# livekit-server runs with hostNetwork: true; its SYNs to livekit-redis arrive
+# at the destination node sourced from the flannel.1 tunnel IP (10.42.x.0), not
+# from a pod IP — so kube-router's allow-intra-namespace-ingress (podSelector:{})
+# doesn't match and default-deny-ingress rejects with icmp-port-unreachable.
+# Permit the cluster pod CIDR explicitly so hostNetwork peers can reach redis.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-hostnet-to-livekit-redis-ingress
+spec:
+  podSelector:
+    matchLabels:
+      app: livekit-redis
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - ipBlock:
+            cidr: 10.42.0.0/16
+      ports:
+        - port: 6379
+          protocol: TCP
+---
 
 # ── LiveKit Server config ─────────────────────────────────────────
 apiVersion: v1


### PR DESCRIPTION
## Summary

Two unrelated infra fixes from a triage session.

### Livekit hostNetwork ↔ redis NetworkPolicy gap

`livekit-server` on **mentolder** was CrashLooping for hours with `dial tcp 10.43.45.234:6379: connect: connection refused`. Diagnosis (full trail in memory `reference_kube_router_hostnet_gotcha.md`):

- livekit-server runs `hostNetwork: true`, pinned to `gekko-hetzner-3`. livekit-redis lands on `gekko-hetzner-4`.
- Cross-node SYNs to redis arrive at the destination sourced from the flannel.1 tunnel IP `10.42.x.0`, **not** a pod IP.
- kube-router's `allow-intra-namespace-ingress` uses `podSelector: {}` which only matches pod-IP sources. Falls through to `default-deny-ingress` → `REJECT --reject-with icmp-port-unreachable`.
- Source side sees ICMP-translated "Connection refused" in ~1ms with no conntrack entry — looks deceptively like the wg-mesh CNI partition issue but isn't.

Fix: `allow-hostnet-to-livekit-redis-ingress` NetworkPolicy with `ipBlock: 10.42.0.0/16` → port 6379. Applied to both clusters as defense-in-depth; korczewski-ha wasn't visibly affected because its livekit-server + livekit-redis happened to co-locate on `pk-hetzner-6` (same-node hits the `ADDRTYPE match src-type LOCAL ACCEPT` rule).

Post-fix: `livekit.mentolder.de` returns HTTP 200, server `Running 1/1`, no restarts.

### Register korczewski-ha as an ArgoCD spoke

`korczewski-ha` was unregistered, requiring manual `task workspace:deploy ENV=korczewski` to deliver manifests. Added:

- `argocd/spoke-rbac/korczewski-ha.yaml` — Namespace/ServiceAccount/ClusterRoleBinding/token Secret on the spoke.
- Idempotent bootstrap block in `task argocd:cluster:register` that applies the spoke RBAC and creates `cluster-korczewski-ha` Secret on the mentolder hub from the SA's token+CA.
- CLAUDE.md refresh: stale comment about needing to update Taskfile.argocd.yml manually is now obsolete.

ApplicationSet now generates `workspace-korczewski-ha` → `https://204.168.244.104:6443` ns `workspace-korczewski`. There's a pre-existing `argocd-redis ↔ argocd-repo-server` connectivity issue keeping all 4 apps at `Sync=Unknown` (out of scope here, same wg-mesh fingerprint as livekit).

## Test plan

- [x] `nc -zv 10.42.2.208 6379` from gekko-hetzner-3 host succeeds post-policy
- [x] `livekit-server` Pod stays Running 1/1 after bounce
- [x] `curl -sSI https://livekit.mentolder.de` returns HTTP 200
- [x] `kubectl --context mentolder get applications -n argocd` shows `workspace-korczewski-ha` generated
- [x] `kubectl --context korczewski-ha get pods -n workspace-korczewski` healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)