### PR TITLE
fix(ci): un-pin korczewski deployment before rollout

### DIFF
--- a/.github/workflows/build-website-korczewski.yml
+++ b/.github/workflows/build-website-korczewski.yml
@@ -75,6 +75,10 @@ jobs:
 
       - name: Rollout restart website (korczewski)
         run: |
+          # Un-pin to :latest in case a past `task website:deploy ENV=korczewski`
+          # set the deployment image to a specific digest — otherwise rollout
+          # restart re-pulls the same old digest and the new :latest is ignored.
+          kubectl --context korczewski-ha -n website-korczewski set image deployment/website website=ghcr.io/paddione/korczewski-website:latest
           kubectl --context korczewski-ha -n website-korczewski rollout restart deployment/website
           kubectl --context korczewski-ha -n website-korczewski rollout status deployment/website --timeout=180s
           echo "✓ Website live auf https://web.korczewski.de"


### PR DESCRIPTION
## Summary
- Past `task website:deploy ENV=korczewski` runs pin the deployment image to a specific SHA (Taskfile.yml:2199 — pure-amd64 cluster branch).
- The CI workflow only did `kubectl rollout restart`, which re-pulled the same pinned digest and silently ignored the freshly-pushed `:latest`.
- Add `kubectl set image …:latest` before the restart so the workflow is idempotent and self-heals after a manual `task website:deploy`.

## Why mentolder didn't need this
mentolder has 3 arm64 home workers (`k3w-1/2/3`), so the Taskfile keeps that deployment on `:latest` — `rollout restart` naturally picks up the new image.

## Test plan
- [x] Live verified: `kubectl set image …:latest` + `rollout restart` un-pinned the running pod from `sha256:46faa419…` to `sha256:d93f9434…` (current GHCR `:latest`).
- [ ] Next push to main with website/** changes runs the workflow end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)