### PR TITLE
fix(arena-server): decouple http middleware from module-load config

### DIFF
--- a/arena-server/src/http/middleware.ts
+++ b/arena-server/src/http/middleware.ts
@@ -1,30 +1,36 @@
 import type { RequestHandler } from 'express';
-import { verifyArenaJwt, playerKey, type ArenaClaims } from '../auth/jwt';
-import { loadConfig } from '../config';
-
-const cfg = loadConfig();
+import { verifyArenaJwt, playerKey, type ArenaClaims, type TrustedIssuer } from '../auth/jwt';
 
 declare global {
   namespace Express { interface Request { user?: ArenaClaims; userKey?: string; } }
 }
 
-export const requireUser: RequestHandler = async (req, res, next) => {
-  const h = req.header('authorization');
-  if (!h || !h.startsWith('Bearer ')) { res.status(401).json({ error: 'missing bearer' }); return; }
-  try {
-    const claims = await verifyArenaJwt(h.slice(7), { trustedIssuers: cfg.issuers });
-    req.user = claims;
-    req.userKey = playerKey(claims);
-    next();
-  } catch (e: any) {
-    res.status(401).json({ error: 'invalid token', detail: e.message });
-  }
-};
+export interface AuthMiddleware {
+  requireUser: RequestHandler;
+  requireAdmin: RequestHandler;
+}
 
-export const requireAdmin: RequestHandler = (req, res, next) => {
-  if (!req.user) { res.status(401).json({ error: 'unauthenticated' }); return; }
-  if (req.user.brand !== 'mentolder' || !req.user.realmRoles.includes('arena_admin')) {
-    res.status(403).json({ error: 'arena_admin role required' }); return;
-  }
-  next();
-};
+export function makeAuthMiddleware(opts: { issuers: TrustedIssuer[] }): AuthMiddleware {
+  const requireUser: RequestHandler = async (req, res, next) => {
+    const h = req.header('authorization');
+    if (!h || !h.startsWith('Bearer ')) { res.status(401).json({ error: 'missing bearer' }); return; }
+    try {
+      const claims = await verifyArenaJwt(h.slice(7), { trustedIssuers: opts.issuers });
+      req.user = claims;
+      req.userKey = playerKey(claims);
+      next();
+    } catch (e: any) {
+      res.status(401).json({ error: 'invalid token', detail: e.message });
+    }
+  };
+
+  const requireAdmin: RequestHandler = (req, res, next) => {
+    if (!req.user) { res.status(401).json({ error: 'unauthenticated' }); return; }
+    if (req.user.brand !== 'mentolder' || !req.user.realmRoles.includes('arena_admin')) {
+      res.status(403).json({ error: 'arena_admin role required' }); return;
+    }
+    next();
+  };
+
+  return { requireUser, requireAdmin };
+}

--- a/arena-server/src/http/routes.test.ts
+++ b/arena-server/src/http/routes.test.ts
@@ -2,14 +2,16 @@ import { describe, it, expect } from 'vitest';
 import express from 'express';
 import request from 'supertest';
 import { makeRoutes } from './routes';
+import { makeAuthMiddleware } from './middleware';
 
 const lcStub: any = { open: () => ({ code: 'ZK4M9X', expiresAt: 0 }) };
 const repoStub: any = { getRecentMatches: async () => [] };
+const auth = makeAuthMiddleware({ issuers: [] });
 
 describe('routes', () => {
   it('/healthz returns ok', async () => {
     const app = express();
-    app.use(makeRoutes({ lc: lcStub, repo: repoStub }));
+    app.use(makeRoutes({ lc: lcStub, repo: repoStub, auth }));
     const res = await request(app).get('/healthz');
     expect(res.status).toBe(200);
     expect(res.body.ok).toBe(true);
@@ -17,7 +19,7 @@ describe('routes', () => {
 
   it('/lobby/active without bearer → 401', async () => {
     const app = express();
-    app.use(makeRoutes({ lc: lcStub, repo: repoStub }));
+    app.use(makeRoutes({ lc: lcStub, repo: repoStub, auth }));
     const res = await request(app).get('/lobby/active');
     expect(res.status).toBe(401);
   });

--- a/arena-server/src/http/routes.ts
+++ b/arena-server/src/http/routes.ts
@@ -1,11 +1,12 @@
 import { Router } from 'express';
-import { requireUser, requireAdmin } from './middleware';
+import type { AuthMiddleware } from './middleware';
 import type { Lifecycle } from '../lobby/lifecycle';
 import { activeLobby } from '../lobby/registry';
 import type { Repo } from '../db/repo';
 
-export function makeRoutes(deps: { lc: Lifecycle; repo: Repo }) {
+export function makeRoutes(deps: { lc: Lifecycle; repo: Repo; auth: AuthMiddleware }) {
   const r = Router();
+  const { requireUser, requireAdmin } = deps.auth;
 
   r.get('/healthz', (_req, res) => {
     res.json({ ok: true, ts: Date.now() });

--- a/arena-server/src/index.ts
+++ b/arena-server/src/index.ts
@@ -9,6 +9,7 @@ import { runMigrations } from './db/migrate';
 import { makeRepo } from './db/repo';
 import { Lifecycle } from './lobby/lifecycle';
 import { makeRoutes } from './http/routes';
+import { makeAuthMiddleware } from './http/middleware';
 import { startWs } from './ws/server';
 import { makeBroadcasters } from './ws/broadcasters';
 
@@ -35,7 +36,8 @@ async function main() {
   (httpServer as any)._arenaLc = lc;
   io.use((socket, next) => { (socket as any).lc = lc; next(); });
 
-  app.use('/', makeRoutes({ lc, repo }));
+  const auth = makeAuthMiddleware({ issuers: cfg.issuers });
+  app.use('/', makeRoutes({ lc, repo, auth }));
 
   httpServer.listen(cfg.port, () => log.info({ port: cfg.port }, 'arena-server listening'));
 


### PR DESCRIPTION
## Summary
- `routes.test.ts` failed in CI with `Missing required env var: DB_URL` because `middleware.ts` called `loadConfig()` at module-load time, and the import chain `routes → middleware → config` ran the moment tests imported `makeRoutes`. CI only sets `TEST_DB_URL`.
- Refactor `middleware.ts` into a `makeAuthMiddleware({ issuers })` factory; `routes.ts` receives it via `deps.auth`; `index.ts` wires it from `cfg.issuers`.
- Tests now construct routes with `makeAuthMiddleware({ issuers: [] })` — no env required.

## Test plan
- [x] `pnpm test` locally: 13 passed, 1 skipped (the `repo.test.ts` skip is preexisting, unrelated)
- [x] `pnpm build` locally: clean
- [ ] CI `arena-server (build + tests)` green
- [ ] CI `Arena protocol drift guard` still green (proto files untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)