### PR TITLE
chore(ci): drop redundant E2E smoke job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,52 +68,6 @@ jobs:
           fi
           echo "No hardcoded secrets detected"
 
-  e2e-smoke:
-    name: E2E Smoke (prod)
-    runs-on: ubuntu-latest
-    needs: offline-tests
-    continue-on-error: true
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@v5
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          cache: 'npm'
-          cache-dependency-path: tests/e2e/package-lock.json
-
-      - name: Install Playwright
-        working-directory: tests/e2e
-        run: |
-          npm ci
-          npx playwright install chromium --with-deps
-
-      - name: Run @smoke specs against prod
-        working-directory: tests/e2e
-        env:
-          WEBSITE_URL: https://web.mentolder.de
-          CI: 'true'
-        run: npx playwright test --project=smoke --grep '@smoke'
-
-      - name: Upload JUnit + traces
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: e2e-smoke-results
-          path: |
-            tests/results/junit.xml
-            tests/results/playwright-traces/
-          if-no-files-found: warn
-
-      - name: Publish JUnit summary
-        if: always()
-        uses: mikepenz/action-junit-report@v4
-        with:
-          report_paths: 'tests/results/junit.xml'
-          require_tests: false
-
   arena-server:
     name: arena-server (build + tests)
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -355,9 +355,8 @@ GitHub Actions (`.github/workflows/ci.yml`) runs on every PR:
 - **Test inventory check**: re-runs `task test:inventory` and fails the job if `website/src/data/test-inventory.json` differs from the committed version — regenerate it locally and commit alongside any test additions.
 - Systembrett template validation (`scripts/tests/systembrett-template.test.sh`)
 - Security scan: image-pin advisory + hardcoded-secret detection in `k3d/*.yaml`
-- E2E smoke (`continue-on-error: true`): a Playwright `--project=smoke --grep '@smoke'` run against `web.mentolder.de` with a 10-min timeout. JUnit + traces are uploaded as the `e2e-smoke-results` artifact.
 
-Other workflows: `e2e.yml` (full Playwright), `track-pr.yml` (PR → tracking JSON), `tracking.yml` (drain into DB), `track-plans.yml`, `build-collabora.yml`, `build-tracking.yml`, `build-transcriber.yml`.
+Other workflows: `e2e.yml` (nightly Playwright against both prod clusters), `track-pr.yml` (PR → tracking JSON), `tracking.yml` (drain into DB), `track-plans.yml`, `build-collabora.yml`, `build-tracking.yml`, `build-transcriber.yml`.
 
 ## Development Rules
 


### PR DESCRIPTION
## Summary
- Removes the `e2e-smoke` job from `.github/workflows/ci.yml`. It always fails because `CRON_SECRET` is not available to the CI workflow — `global-db-cleanup.ts` brackets every Playwright run with prod DB purges and refuses to start without it. The job was `continue-on-error: true`, so it never blocked PRs, but it produced a permanent failure marker on every commit.
- Updates the CI section in `CLAUDE.md` to drop the smoke-job description and re-label `e2e.yml` as the nightly Playwright workflow.
- The nightly `e2e.yml` already runs the full Playwright suite against both prod clusters with the right credentials, so dropping the smoke job loses no signal.

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` — workflow YAML still parses
- [ ] CI on this PR shows offline-tests + arena-server + security-scan + arena-proto-drift; no more red `E2E Smoke (prod)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)