### PR TITLE
fix(livekit): pin turn.<domain> alongside livekit/stream in livekit:dns-pin

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -48,7 +48,7 @@ tasks:
       - task: arena:deploy:all-prods
 
   feature:livekit:
-    desc: "Re-pin livekit/stream subdomains to the LiveKit node on BOTH prod clusters"
+    desc: "Re-pin livekit/stream → LiveKit node and turn → TURN node on BOTH prod clusters"
     cmds:
       - task: livekit:dns-pin
         vars: { ENV: "mentolder", APPLY: "true" }
@@ -2581,7 +2581,7 @@ tasks:
         kubectl $CTX_FLAG -n "$NS" rollout status deployment/livekit-server --timeout=120s
 
   livekit:dns-pin:
-    desc: "Print the ipv64 API calls that pin livekit/stream subdomains to a single node (run with APPLY=true to actually invoke). ENV=dev|mentolder|korczewski. PIN_IP overrides env default."
+    desc: "Print the ipv64 API calls that pin livekit/stream → LIVEKIT_PIN_IP and turn → TURN_PUBLIC_IP (run with APPLY=true to actually invoke). ENV=dev|mentolder|korczewski. PIN_IP overrides livekit/stream only; turn always tracks TURN_PUBLIC_IP."
     vars:
       ENV: '{{.ENV | default "mentolder"}}'
       PIN_IP: '{{.PIN_IP | default ""}}'
@@ -2593,19 +2593,30 @@ tasks:
         [ -f "$SECRETS" ] || { echo "Plaintext secrets not found at $SECRETS — cannot read IPV64_UPDATE_HASH" >&2; exit 1; }
         KEY=$(awk -F': ' '/^IPV64_UPDATE_HASH:/ {gsub(/"/,"",$2); print $2}' "$SECRETS")
         [ -n "$KEY" ] || { echo "IPV64_UPDATE_HASH missing from $SECRETS (this is the domain_update_hash from ipv64.net, not the account API key)" >&2; exit 1; }
-        RESOLVED_IP="{{.PIN_IP}}"
-        RESOLVED_IP="${RESOLVED_IP:-${LIVEKIT_PIN_IP:-46.225.125.59}}"
-        echo "Pinning livekit.${PROD_DOMAIN} and stream.${PROD_DOMAIN} → ${RESOLVED_IP}"
+        LK_IP="{{.PIN_IP}}"
+        LK_IP="${LK_IP:-${LIVEKIT_PIN_IP:-46.225.125.59}}"
+        TURN_IP="${TURN_PUBLIC_IP:-}"
+        echo "Pinning livekit.${PROD_DOMAIN} and stream.${PROD_DOMAIN} → ${LK_IP}"
+        if [ -n "$TURN_IP" ]; then
+          echo "Pinning turn.${PROD_DOMAIN} → ${TURN_IP}"
+        else
+          echo "Skipping turn.${PROD_DOMAIN} (TURN_PUBLIC_IP unset for ENV={{.ENV}})"
+        fi
         echo "(set APPLY=true to actually run the calls; otherwise this just prints them)"
-        for SUB in livekit stream; do
-          URL="https://ipv64.net/update.php?key=$KEY&domain=${SUB}.${PROD_DOMAIN}&ip=${RESOLVED_IP}"
-          REDACTED=$(echo "$URL" | sed "s/key=$KEY/key=***REDACTED***/")
-          echo "  curl -sS \"$REDACTED\""
+        pin_one() {
+          local sub="$1" ip="$2"
+          [ -z "$ip" ] && return 0
+          local url="https://ipv64.net/update.php?key=$KEY&domain=${sub}.${PROD_DOMAIN}&ip=${ip}"
+          local redacted="${url/key=$KEY/key=***REDACTED***}"
+          echo "  curl -sS \"$redacted\""
           if [ "{{.APPLY}}" = "true" ]; then
-            curl -sS "$URL"
+            curl -sS "$url"
             echo
           fi
-        done
+        }
+        pin_one livekit "$LK_IP"
+        pin_one stream  "$LK_IP"
+        pin_one turn    "$TURN_IP"
         if [ "{{.APPLY}}" != "true" ]; then
           echo ""
           echo "Re-run with APPLY=true to invoke."


### PR DESCRIPTION
## Summary

- `livekit:dns-pin` now pins **three** subdomains in one call:
  - `livekit.<domain>` → `LIVEKIT_PIN_IP`
  - `stream.<domain>`  → `LIVEKIT_PIN_IP`
  - `turn.<domain>`    → `TURN_PUBLIC_IP` *(new)*
- `PIN_IP=` override still applies to `livekit`/`stream` only; `turn` always tracks the env's `TURN_PUBLIC_IP` since the two pins target different nodes on mentolder (livekit on `gekko-hetzner-3`/46.225.125.59, turn on `gekko-hetzner-2`/178.104.169.206).
- `turn` is skipped gracefully when `TURN_PUBLIC_IP` is unset (e.g. `ENV=dev`).
- `feature:livekit` description updated.

## Why

Janus' `turn.<domain>` was the one DNS record the existing pin tooling didn't touch — it was kept in sync by hand against `TURN_PUBLIC_IP` and silently drifted whenever the TURN node moved (most recently the korczewski-ha re-split, 2026-05-09). Extending the same task to cover it removes a class of "Talk works locally but ICE times out in prod" failures.

The Janus `20000-20200/udp` ufw range is still a manual node-side step; that one isn't a DNS gap so it stays out of this PR.

## Test plan

Dry-run output verified on both envs (no live DNS calls made):

- [x] `task livekit:dns-pin ENV=mentolder` → prints curls for livekit/stream → 46.225.125.59 and turn → 178.104.169.206
- [x] `task livekit:dns-pin ENV=korczewski` → prints curls for all three → 37.27.251.38 (same node serves all subdomains on korczewski-ha)
- [x] `task workspace:validate` still green
- [x] Current live DNS already matches target IPs on both clusters — change is preventive

🤖 Generated with [Claude Code](https://claude.com/claude-code)