### PR TITLE
chore: pin arena-server and litellm images by digest

### DIFF
--- a/k3d/arena.yaml
+++ b/k3d/arena.yaml
@@ -32,7 +32,10 @@ spec:
         kubernetes.io/arch: amd64
       containers:
         - name: arena-server
-          image: ghcr.io/paddione/arena-server:latest
+          # Pinned by digest. To roll forward: build/push a new arena-server image,
+          # then resolve the digest with `gh api /users/paddione/packages/container/arena-server/versions`
+          # and update this line. Closes #656.
+          image: ghcr.io/paddione/arena-server@sha256:9a03d51b72e01f7597842c694b8a3ea3a90dd5b8247f19d5e2418d43a81518cb
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/k3d/llm-router.yaml
+++ b/k3d/llm-router.yaml
@@ -88,7 +88,11 @@ spec:
                     values: [gekko-hetzner-2, gekko-hetzner-3, gekko-hetzner-4, pk-hetzner-4]
       containers:
         - name: litellm
-          image: ghcr.io/berriai/litellm:main-stable
+          # Pinned by digest from the floating main-stable tag. To roll forward:
+          # docker buildx imagetools inspect ghcr.io/berriai/litellm:main-stable | grep Digest
+          # (or check the live cluster's imageID), then update both tag and digest below.
+          # Closes #653.
+          image: ghcr.io/berriai/litellm:main-stable@sha256:6c82d338a60e7b273ae46bf1d8db814d2856ae010f96c44eeadde574d3893f76
           args: ["--config", "/app/config.yaml", "--port", "4000", "--num_workers", "2"]
           ports:
             - containerPort: 4000


### PR DESCRIPTION
## Summary
- Pin `ghcr.io/paddione/arena-server` by digest in `k3d/arena.yaml` (no semver tag exists on the registry, so digest-only form)
- Pin `ghcr.io/berriai/litellm:main-stable` with a `@sha256:` digest suffix in `k3d/llm-router.yaml`
- Both digests match what's currently running on `mentolder` (verified via `kubectl ... -o jsonpath='{.status.containerStatuses[0].imageID}'`), so this is behaviour-neutral.

Closes #656
Closes #653

## Test plan
- [x] \`task workspace:validate\` — manifests still build
- [ ] CI green (offline + security)