### PR TITLE
fix(mcp): raise monolith container memory limits to stop OOM cycles

### DIFF
--- a/deploy/mcp/claude-code-mcp-monolith.yaml
+++ b/deploy/mcp/claude-code-mcp-monolith.yaml
@@ -107,7 +107,7 @@ spec:
             periodSeconds: 10
           resources:
             requests: { memory: 128Mi, cpu: 50m }
-            limits:   { memory: 512Mi }
+            limits:   { memory: 768Mi }
 
         # ── Keycloak MCP (port 8081 - overridden to avoid conflict with kubernetes on 8080) ─────────
         - name: keycloak
@@ -174,7 +174,7 @@ spec:
             periodSeconds: 10
           resources:
             requests: { memory: 512Mi, cpu: 100m }
-            limits:   { memory: 1Gi, cpu: 500m }
+            limits:   { memory: 4Gi, cpu: 500m }
 
         # ── GitHub MCP (port 3002) ──────────────────────────────────
         # Uses stdio mode via supergateway to bypass the HTTP-mode OAuth
@@ -208,7 +208,7 @@ spec:
             periodSeconds: 10
           resources:
             requests: { memory: 128Mi, cpu: 50m }
-            limits:   { memory: 256Mi }
+            limits:   { memory: 512Mi }
           volumeMounts:
             - name: github-bin
               mountPath: /github-bin


### PR DESCRIPTION
## Summary
- Gekko reported `mcp.mentolder.de` browser MCP "not working properly". Root cause: the `playwright` (browser), `github`, and `postgres` containers in `claude-code-mcp-monolith` were OOMKilled in a chronic cycle on mentolder (3 kills today alone). Headless Chrome navigation routinely pushed `playwright` past its 1Gi cap; whenever Chrome died, `mcp.mentolder.de/browser` hung/502'd for ~45s until kubelet restarted it.
- Bumps: `playwright` 1Gi → 4Gi (matches the proven standalone `mcp-browser`), `github` 256Mi → 512Mi, `postgres` 512Mi → 768Mi. Requests unchanged so scheduling stays put.
- Already applied to mentolder live via `kubectl apply` (Deployment is not ArgoCD-managed). New pod healthy, idle memory comfortably under new ceilings. This PR exists so the next `task mcp:deploy` doesn't revert the live state.

## Test plan
- [x] `kubectl --context mentolder -n default rollout status deploy/claude-code-mcp-monolith` → Ready
- [x] `kubectl describe pod` confirms new limits: playwright 4Gi, github 512Mi, postgres 768Mi
- [x] `curl https://mcp.mentolder.de/browser` → 401 (auth required = routing intact)
- [x] `kubectl top` post-rollout: playwright 58Mi idle (was 754Mi/1Gi)
- [ ] Gekko retries browser MCP end-to-end against a heavy SPA

🤖 Generated with [Claude Code](https://claude.com/claude-code)