### PR TITLE
fix(knowledge): connection string FQDN for shared-db

### DIFF
--- a/website/src/lib/knowledge-db.ts
+++ b/website/src/lib/knowledge-db.ts
@@ -1,4 +1,5 @@
 import { Pool } from 'pg';
+import { resolve4 } from 'dns';
 import { embedQuery, type EmbeddingModel } from './embeddings';
 
 export class MixedEmbeddingModelError extends Error {
@@ -8,16 +9,23 @@ export class MixedEmbeddingModelError extends Error {
   }
 }
 
+// musl libc's getaddrinfo opens a connected UDP socket which drops CoreDNS
+// responses after kube-proxy DNAT. Node's dns.resolve4 uses an unconnected
+// socket and is unaffected — mirrors website-db.ts.
+function nodeLookup(
+  hostname: string,
+  _opts: unknown,
+  cb: (err: Error | null, addr: string, family: number) => void,
+) {
+  resolve4(hostname, (err, addrs) => cb(err ?? null, addrs?.[0] ?? '', 4));
+}
+
 let _pool: Pool | null = null;
 function p(): Pool {
   if (!_pool) {
-    _pool = new Pool({
-      host:     process.env.PGHOST     ?? 'shared-db',
-      port:     Number(process.env.PGPORT ?? 5432),
-      database: process.env.PGDATABASE ?? 'website',
-      user:     process.env.PGUSER     ?? 'website',
-      password: process.env.PGPASSWORD,
-    });
+    const connectionString = process.env.SESSIONS_DATABASE_URL
+      || 'postgresql://website:devwebsitedb@shared-db.workspace.svc.cluster.local:5432/website';
+    _pool = new Pool({ connectionString, lookup: nodeLookup } as unknown as import('pg').PoolConfig);
   }
   return _pool;
 }

--- a/website/src/pages/api/admin/coaching/books/upload.ts
+++ b/website/src/pages/api/admin/coaching/books/upload.ts
@@ -1,6 +1,5 @@
 import type { APIRoute } from 'astro';
 import { getSession, isAdmin } from '../../../../../lib/auth';
-import { Pool } from 'pg';
 import { writeFile, unlink } from 'node:fs/promises';
 import { join } from 'node:path';
 import { randomUUID } from 'node:crypto';
@@ -15,8 +14,7 @@ import {
   upsertChunks,
   recountChunks,
 } from '../../../../../lib/knowledge-db';
-
-const pool = new Pool();
+import { pool } from '../../../../../lib/website-db';
 
 const json = (body: unknown, status = 200) =>
   new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } });


### PR DESCRIPTION
## Summary

`knowledge-db.ts`'s pool defaulted to `host: shared-db` with no namespace FQDN and read `PGPASSWORD` from env — but the website pod runs in the `website` namespace while shared-db lives in `workspace`, and only `WEBSITE_DB_PASSWORD` / `SESSIONS_DATABASE_URL` are injected. Every call (`listCollections`, `queryNearest`, `ensureCollection`, ...) failed with `ENOTFOUND shared-db`; the `try/catch` in `/admin/wissensquellen` silently rendered an empty table even though the DB already had the `coaching-geissler-ki-coaching` collection (206 chunks since 2026-05-10).

Fix mirrors the working pattern from `website-db.ts`: use `SESSIONS_DATABASE_URL` connection string + `dns.resolve4` lookup to work around musl/CoreDNS DNAT.

Same naked `new Pool()` removed from `api/admin/coaching/books/upload.ts` (shares the website-db pool now).

## Test plan

- [x] `npx vitest run src/lib/knowledge-db.test.ts` — 6/6 pass (uses pg-mem + `__setPoolForTests`)
- [x] `npx vitest run src/lib/assistant/llm.test.ts` — 7/7 pass
- [x] `npx astro check --minimumSeverity error` — no new errors on touched files
- [ ] After deploy: `/admin/wissensquellen` on web.mentolder.de shows the KI-Coaching collection under "Eigene Sammlungen"

🤖 Generated with [Claude Code](https://claude.com/claude-code)