### PR TITLE
fix(inbox): sync admin inbox status when tickets transition to done/archived

### DIFF
--- a/website/src/lib/tickets/transition.ts
+++ b/website/src/lib/tickets/transition.ts
@@ -94,6 +94,21 @@ export async function transitionTicket(
       );
     }
 
+    // Keep the global admin inbox in sync. Bug rows reach the inbox via
+    // /api/bug-report → createInboxItem({ bugTicketId: external_id }); without
+    // this, closing a bug from /admin/tickets/* leaves the inbox row stuck
+    // in 'pending' forever and the bell badge never clears.
+    if (after.type === 'bug' && after.external_id &&
+        (p.status === 'done' || p.status === 'archived')) {
+      const next = p.status === 'done' ? 'actioned' : 'archived';
+      await client.query(
+        `UPDATE inbox_items
+            SET status = $1, actioned_at = COALESCE(actioned_at, NOW())
+          WHERE bug_ticket_id = $2 AND status = 'pending'`,
+        [next, after.external_id]
+      );
+    }
+
     await client.query('COMMIT');
 
     let emailSent = false;

--- a/website/src/lib/website-db.ts
+++ b/website/src/lib/website-db.ts
@@ -658,9 +658,6 @@ export async function resolveBugTicket(
     note: resolutionNote, noteVisibility: 'public',
     actor,
   });
-  await pool.query(
-    `UPDATE inbox_items SET status = 'actioned', actioned_at = NOW()
-      WHERE bug_ticket_id = $1 AND status = 'pending'`, [ticketId]);
 }
 
 export async function archiveBugTicket(
@@ -672,9 +669,6 @@ export async function archiveBugTicket(
   await transitionTicket(id, {
     status: 'archived', resolution: 'obsolete', actor,
   });
-  await pool.query(
-    `UPDATE inbox_items SET status = 'archived', actioned_at = NOW()
-      WHERE bug_ticket_id = $1 AND status = 'pending'`, [ticketId]);
 }
 
 export interface BugTicketStatus {


### PR DESCRIPTION
## Summary
- Move the `inbox_items` status flip into `transitionTicket` so every path that closes or archives a bug (admin UI, PR linker, future automations) keeps the admin bell badge consistent.
- Drop the now-redundant UPDATEs from `resolveBugTicket` / `archiveBugTicket`.

## Background
The admin inbox (`/admin/inbox`) was accumulating `pending` bug rows forever when bugs were closed via the new `/admin/tickets/*` UI. Only the legacy `/api/admin/bugs/{resolve,archive}` flow flipped the inbox row, because the UPDATE lived in the wrappers — not in `transitionTicket` itself. Result on mentolder: paddione had 47 pending bug rows, **zero** of them pointing at an actually-open ticket (35 orphans, 12 against already-done/archived tickets).

## Cleanup
The 86 existing orphan/stale rows on mentolder were reaped via a one-shot SQL alongside this fix.

## Test plan
- [x] One-shot SQL applied on mentolder; post-cleanup snapshot shows 0 pending bug rows
- [ ] After deploy, transition a fresh bug ticket via `/admin/tickets/*` → its inbox row flips to `actioned`