### PR TITLE
fix(coaching): share DNS-fixed pool across admin/coaching surfaces

### DIFF
--- a/website/src/lib/assistant/llm.ts
+++ b/website/src/lib/assistant/llm.ts
@@ -1,9 +1,9 @@
 import Anthropic from '@anthropic-ai/sdk';
-import { Pool } from 'pg';
 import type { AssistantProfile, AssistantChatResult, Message } from './types';
 import { searchHelp, formatHit, noMatchReply } from './search';
 import { queryNearest } from '../knowledge-db';
 import { resolveCoachingCollectionIds } from './coaching-collections';
+import { pool } from '../website-db';
 
 export interface AssistantChatInput {
   profile: AssistantProfile;
@@ -16,12 +16,6 @@ export interface AssistantContext {
   currentRoute: string;
   counts?: Record<string, number>;
   [k: string]: unknown;
-}
-
-let _pool: Pool | null = null;
-function getPool(): Pool {
-  if (!_pool) _pool = new Pool();
-  return _pool;
 }
 
 const SYSTEM_PROMPT = `Du bist der interne Assistent von ${process.env.BRAND_NAME ?? 'Mentolder'}. Du hilfst dem Coach bei seiner Arbeit — Klientenvorbereitung, Terminplanung, Gesprächsreflexion und Wissensarbeit. Antworte präzise und auf Deutsch. Wenn du Buchpassagen erhältst, zitiere konkret und nenne Seite wenn vorhanden.`;
@@ -46,7 +40,7 @@ export async function assistantChat(input: AssistantChatInput): Promise<Assistan
   const useBooks = input.context.useBooks === true;
   if (useBooks) {
     try {
-      const collectionIds = await resolveCoachingCollectionIds(getPool());
+      const collectionIds = await resolveCoachingCollectionIds(pool);
       if (collectionIds.length > 0) {
         const chunks = await queryNearest({
           collectionIds,

--- a/website/src/pages/admin/knowledge/books/[id].astro
+++ b/website/src/pages/admin/knowledge/books/[id].astro
@@ -1,16 +1,15 @@
 ---
 import AdminLayout from '../../../../layouts/AdminLayout.astro';
 import BookReader from '../../../../components/admin/BookReader.svelte';
-import { Pool } from 'pg';
 import { getBook, listClusters, listSnippets } from '../../../../lib/coaching-db';
 import { getSession, getLoginUrl, isAdmin } from '../../../../lib/auth';
+import { pool } from '../../../../lib/website-db';
 
 const session = await getSession(Astro.request.headers.get('cookie'));
 if (!session) return Astro.redirect(getLoginUrl(Astro.url.pathname));
 if (!isAdmin(session)) return Astro.redirect('/admin');
 
 const id = Astro.params.id as string;
-const pool = new Pool();
 
 let book: Awaited<ReturnType<typeof getBook>> = null;
 let clusters: Awaited<ReturnType<typeof listClusters>> = [];

--- a/website/src/pages/admin/knowledge/books/index.astro
+++ b/website/src/pages/admin/knowledge/books/index.astro
@@ -1,15 +1,13 @@
 ---
 import AdminLayout from '../../../../layouts/AdminLayout.astro';
-import { Pool } from 'pg';
 import { listBooks } from '../../../../lib/coaching-db';
 import { getSession, getLoginUrl, isAdmin } from '../../../../lib/auth';
 import BookUploadForm from '../../../../components/admin/BookUploadForm.svelte';
+import { pool } from '../../../../lib/website-db';
 
 const session = await getSession(Astro.request.headers.get('cookie'));
 if (!session) return Astro.redirect(getLoginUrl(Astro.url.pathname));
 if (!isAdmin(session)) return Astro.redirect('/admin');
-
-const pool = new Pool();
 let books: Awaited<ReturnType<typeof listBooks>> = [];
 try {
   books = await listBooks(pool);

--- a/website/src/pages/admin/knowledge/snippets/[id]/publish.astro
+++ b/website/src/pages/admin/knowledge/snippets/[id]/publish.astro
@@ -1,16 +1,15 @@
 ---
 import AdminLayout from '../../../../../layouts/AdminLayout.astro';
 import PublishEditor from '../../../../../components/admin/PublishEditor.svelte';
-import { Pool } from 'pg';
 import { listSnippets, getBook } from '../../../../../lib/coaching-db';
 import { getSession, getLoginUrl, isAdmin } from '../../../../../lib/auth';
+import { pool } from '../../../../../lib/website-db';
 
 const session = await getSession(Astro.request.headers.get('cookie'));
 if (!session) return Astro.redirect(getLoginUrl(Astro.url.pathname));
 if (!isAdmin(session)) return Astro.redirect('/admin');
 
 const id = Astro.params.id as string;
-const pool = new Pool();
 
 const snippets = await listSnippets(pool, {});
 const snippet = snippets.find((s) => s.id === id);

--- a/website/src/pages/admin/knowledge/templates/index.astro
+++ b/website/src/pages/admin/knowledge/templates/index.astro
@@ -1,8 +1,8 @@
 ---
 import AdminLayout from '../../../../layouts/AdminLayout.astro';
-import { Pool } from 'pg';
 import { listTemplates, type TargetSurface, type TemplateStatus } from '../../../../lib/coaching-db';
 import { getSession, getLoginUrl, isAdmin } from '../../../../lib/auth';
+import { pool } from '../../../../lib/website-db';
 
 const session = await getSession(Astro.request.headers.get('cookie'));
 if (!session) return Astro.redirect(getLoginUrl(Astro.url.pathname));
@@ -10,8 +10,6 @@ if (!isAdmin(session)) return Astro.redirect('/admin');
 
 const surfaceParam = Astro.url.searchParams.get('surface') as TargetSurface | null;
 const statusParam = Astro.url.searchParams.get('status') as TemplateStatus | null;
-
-const pool = new Pool();
 let templates: Awaited<ReturnType<typeof listTemplates>> = [];
 try {
   templates = await listTemplates(pool, {

--- a/website/src/pages/api/admin/coaching/books/[id]/acceptance-rate.ts
+++ b/website/src/pages/api/admin/coaching/books/[id]/acceptance-rate.ts
@@ -1,10 +1,9 @@
 // website/src/pages/api/admin/coaching/books/[id]/acceptance-rate.ts
 import type { APIRoute } from 'astro';
-import { Pool } from 'pg';
 import { getSession, isAdmin } from '../../../../../../lib/auth';
 import { acceptanceRateByBook } from '../../../../../../lib/coaching-db';
+import { pool } from '../../../../../../lib/website-db';
 
-const pool = new Pool();
 export const prerender = false;
 
 export const GET: APIRoute = async ({ request, params }) => {

--- a/website/src/pages/api/admin/coaching/books/[id]/chunks.ts
+++ b/website/src/pages/api/admin/coaching/books/[id]/chunks.ts
@@ -1,9 +1,7 @@
 import type { APIRoute } from 'astro';
-import { Pool } from 'pg';
 import { getSession, isAdmin } from '../../../../../../lib/auth';
 import { listChunksForBook } from '../../../../../../lib/coaching-db';
-
-const pool = new Pool();
+import { pool } from '../../../../../../lib/website-db';
 
 export const prerender = false;
 

--- a/website/src/pages/api/admin/coaching/books/[id]/index.ts
+++ b/website/src/pages/api/admin/coaching/books/[id]/index.ts
@@ -1,9 +1,7 @@
 import type { APIRoute } from 'astro';
-import { Pool } from 'pg';
 import { getSession, isAdmin } from '../../../../../../lib/auth';
 import { getBook } from '../../../../../../lib/coaching-db';
-
-const pool = new Pool();
+import { pool } from '../../../../../../lib/website-db';
 
 export const prerender = false;
 

--- a/website/src/pages/api/admin/coaching/books/index.ts
+++ b/website/src/pages/api/admin/coaching/books/index.ts
@@ -1,9 +1,7 @@
 import type { APIRoute } from 'astro';
-import { Pool } from 'pg';
 import { getSession, isAdmin } from '../../../../../lib/auth';
 import { listBooks } from '../../../../../lib/coaching-db';
-
-const pool = new Pool();
+import { pool } from '../../../../../lib/website-db';
 
 export const prerender = false;
 

--- a/website/src/pages/api/admin/coaching/clusters/index.ts
+++ b/website/src/pages/api/admin/coaching/clusters/index.ts
@@ -1,9 +1,7 @@
 import type { APIRoute } from 'astro';
-import { Pool } from 'pg';
 import { getSession, isAdmin } from '../../../../../lib/auth';
 import { createCluster, listClusters } from '../../../../../lib/coaching-db';
-
-const pool = new Pool();
+import { pool } from '../../../../../lib/website-db';
 
 export const prerender = false;
 

--- a/website/src/pages/api/admin/coaching/drafts/[id].ts
+++ b/website/src/pages/api/admin/coaching/drafts/[id].ts
@@ -1,9 +1,8 @@
 import type { APIRoute } from 'astro';
-import { Pool } from 'pg';
 import { getSession, isAdmin } from '../../../../../lib/auth';
 import { getDraft } from '../../../../../lib/coaching-db';
+import { pool } from '../../../../../lib/website-db';
 
-const pool = new Pool();
 export const prerender = false;
 
 export const GET: APIRoute = async ({ request, params }) => {

--- a/website/src/pages/api/admin/coaching/drafts/[id]/accept.ts
+++ b/website/src/pages/api/admin/coaching/drafts/[id]/accept.ts
@@ -1,9 +1,8 @@
 import type { APIRoute } from 'astro';
-import { Pool } from 'pg';
 import { getSession, isAdmin } from '../../../../../../lib/auth';
 import { acceptDraft } from '../../../../../../lib/coaching-db';
+import { pool } from '../../../../../../lib/website-db';
 
-const pool = new Pool();
 export const prerender = false;
 
 export const POST: APIRoute = async ({ request, params, url }) => {

--- a/website/src/pages/api/admin/coaching/drafts/[id]/reject.ts
+++ b/website/src/pages/api/admin/coaching/drafts/[id]/reject.ts
@@ -1,9 +1,8 @@
 import type { APIRoute } from 'astro';
-import { Pool } from 'pg';
 import { getSession, isAdmin } from '../../../../../../lib/auth';
 import { rejectDraft } from '../../../../../../lib/coaching-db';
+import { pool } from '../../../../../../lib/website-db';
 
-const pool = new Pool();
 export const prerender = false;
 
 export const POST: APIRoute = async ({ request, params }) => {

--- a/website/src/pages/api/admin/coaching/drafts/index.ts
+++ b/website/src/pages/api/admin/coaching/drafts/index.ts
@@ -1,9 +1,8 @@
 import type { APIRoute } from 'astro';
-import { Pool } from 'pg';
 import { getSession, isAdmin } from '../../../../../lib/auth';
 import { listDrafts, type DraftFilter, type DraftKind, type DraftStatus } from '../../../../../lib/coaching-db';
+import { pool } from '../../../../../lib/website-db';
 
-const pool = new Pool();
 export const prerender = false;
 
 export const GET: APIRoute = async ({ request, url }) => {

--- a/website/src/pages/api/admin/coaching/snippets/[id].ts
+++ b/website/src/pages/api/admin/coaching/snippets/[id].ts
@@ -1,9 +1,7 @@
 import type { APIRoute } from 'astro';
-import { Pool } from 'pg';
 import { getSession, isAdmin } from '../../../../../lib/auth';
 import { updateSnippet, deleteSnippet } from '../../../../../lib/coaching-db';
-
-const pool = new Pool();
+import { pool } from '../../../../../lib/website-db';
 
 export const prerender = false;
 

--- a/website/src/pages/api/admin/coaching/snippets/[id]/draft-template.ts
+++ b/website/src/pages/api/admin/coaching/snippets/[id]/draft-template.ts
@@ -1,9 +1,8 @@
 import type { APIRoute } from 'astro';
-import { Pool } from 'pg';
 import { getSession, isAdmin } from '../../../../../../lib/auth';
 import { createTemplateDraft, type TargetSurface } from '../../../../../../lib/coaching-db';
+import { pool } from '../../../../../../lib/website-db';
 
-const pool = new Pool();
 export const prerender = false;
 
 const SURFACES: TargetSurface[] = ['questionnaire', 'brett', 'chatroom', 'assistant'];

--- a/website/src/pages/api/admin/coaching/snippets/index.ts
+++ b/website/src/pages/api/admin/coaching/snippets/index.ts
@@ -1,9 +1,7 @@
 import type { APIRoute } from 'astro';
-import { Pool } from 'pg';
 import { getSession, isAdmin } from '../../../../../lib/auth';
 import { createSnippet, listSnippets } from '../../../../../lib/coaching-db';
-
-const pool = new Pool();
+import { pool } from '../../../../../lib/website-db';
 
 export const prerender = false;
 

--- a/website/src/pages/api/admin/coaching/templates/[id].ts
+++ b/website/src/pages/api/admin/coaching/templates/[id].ts
@@ -1,9 +1,8 @@
 import type { APIRoute } from 'astro';
-import { Pool } from 'pg';
 import { getSession, isAdmin } from '../../../../../lib/auth';
 import { getTemplate, createTemplateDraft } from '../../../../../lib/coaching-db';
+import { pool } from '../../../../../lib/website-db';
 
-const pool = new Pool();
 export const prerender = false;
 
 export const GET: APIRoute = async ({ request, params }) => {

--- a/website/src/pages/api/admin/coaching/templates/[id]/publish.ts
+++ b/website/src/pages/api/admin/coaching/templates/[id]/publish.ts
@@ -1,10 +1,9 @@
 import type { APIRoute } from 'astro';
-import { Pool } from 'pg';
 import { getSession, isAdmin } from '../../../../../../lib/auth';
 import { getTemplate } from '../../../../../../lib/coaching-db';
 import { publishTemplate } from '../../../../../../lib/coaching-publish';
+import { pool } from '../../../../../../lib/website-db';
 
-const pool = new Pool();
 export const prerender = false;
 
 export const POST: APIRoute = async ({ request, params }) => {

--- a/website/src/pages/api/admin/coaching/templates/[id]/versions.ts
+++ b/website/src/pages/api/admin/coaching/templates/[id]/versions.ts
@@ -1,9 +1,8 @@
 import type { APIRoute } from 'astro';
-import { Pool } from 'pg';
 import { getSession, isAdmin } from '../../../../../../lib/auth';
 import { getTemplate, listTemplateVersions } from '../../../../../../lib/coaching-db';
+import { pool } from '../../../../../../lib/website-db';
 
-const pool = new Pool();
 export const prerender = false;
 
 export const GET: APIRoute = async ({ request, params }) => {

--- a/website/src/pages/api/admin/coaching/templates/index.ts
+++ b/website/src/pages/api/admin/coaching/templates/index.ts
@@ -1,9 +1,8 @@
 import type { APIRoute } from 'astro';
-import { Pool } from 'pg';
 import { getSession, isAdmin } from '../../../../../lib/auth';
 import { listTemplates, type TargetSurface, type TemplateStatus } from '../../../../../lib/coaching-db';
+import { pool } from '../../../../../lib/website-db';
 
-const pool = new Pool();
 export const prerender = false;
 
 const SURFACES: TargetSurface[] = ['questionnaire', 'brett', 'chatroom', 'assistant'];


### PR DESCRIPTION
## Summary
- 20 admin coaching/knowledge surfaces + `lib/assistant/llm.ts` constructed bare `new Pool()` from PG* env vars — same musl-libc / ClusterIP DNAT bug that #678 fixed for the knowledge wissensquellen page.
- Every surface (Bücher, Templates, Snippets, Drafts, Cluster, Assistant) silently swallowed the connect failure and rendered an empty state.
- Switch all of them to the shared `pool` export from `lib/website-db.ts`, which already uses `dns.resolve4` + the correct `SESSIONS_DATABASE_URL`.

## Out of scope (separate follow-ups)
- `pages/api/cron/notify-unread.ts` — same bug class, but server-side cron, not user-clickable.
- `lib/nextcloud-talk-db.ts` — different DB (`nextcloud-db`, not `shared-db`).

## Test plan
- [x] `pnpm exec astro check` — no new errors (pre-existing `getLoginUrl` unused-warnings + pg-mem `uuid` type errors are unrelated)
- [x] `pnpm test:unit` — 347 passed, 91 skipped, 0 failures
- [ ] Deploy to mentolder + korczewski-ha and click through `/admin/coaching/books`, `/admin/knowledge/templates`, `/admin/knowledge/books`, snippet publish, draft accept/reject — verify no ENOTFOUND in pod logs and surfaces populate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)