### PR TITLE
fix(tickets): repoint inbox_items FK to tickets.tickets (stop orphan-creep)

### DIFF
--- a/k3d/website-schema.yaml
+++ b/k3d/website-schema.yaml
@@ -270,7 +270,11 @@ data:
         status          TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending','actioned','archived')),
         reference_id    TEXT,
         reference_table TEXT,
-        bug_ticket_id   TEXT REFERENCES bugs.bug_tickets(ticket_id) ON DELETE SET NULL,
+        -- bug_ticket_id keeps the tickets.tickets(external_id) slug (e.g. T000287,
+        -- BR-YYYYMMDD-xxxx). The FK is installed *after* tickets.tickets exists,
+        -- below — bootstrap-safe on fresh DBs where tickets-db.ts has not yet
+        -- run.
+        bug_ticket_id   TEXT,
         payload         JSONB,
         created_at      TIMESTAMPTZ DEFAULT now(),
         actioned_at     TIMESTAMPTZ,
@@ -280,6 +284,40 @@ data:
       CREATE INDEX IF NOT EXISTS idx_inbox_items_status ON inbox_items(status, created_at DESC);
       CREATE INDEX IF NOT EXISTS idx_inbox_items_is_test_data
         ON inbox_items (is_test_data) WHERE is_test_data = true;
+
+      -- inbox_items.bug_ticket_id FK repoint (2026-05-12).
+      -- Pre-sunset, this column FK'd into bugs.bug_tickets(ticket_id). Sunset
+      -- dropped that FK, leaving inbox_items orphan-prone after
+      -- tickets.fn_purge_test_data() deletes from tickets.tickets directly.
+      -- Re-add the FK against the new authoritative store with CASCADE.
+      -- Guarded so a partial fresh-DB run (tickets schema not yet bootstrapped)
+      -- doesn't abort the whole schema init.
+      DO $inbox_fk$
+      BEGIN
+        IF to_regclass('tickets.tickets') IS NOT NULL THEN
+          ALTER TABLE inbox_items
+            DROP CONSTRAINT IF EXISTS inbox_items_bug_ticket_id_fkey;
+          IF NOT EXISTS (
+            SELECT 1 FROM pg_constraint
+             WHERE conname = 'inbox_items_bug_ticket_fkey'
+               AND conrelid = 'public.inbox_items'::regclass
+          ) THEN
+            -- NULL out orphans first so the FK can attach.
+            UPDATE inbox_items
+               SET bug_ticket_id = NULL
+             WHERE bug_ticket_id IS NOT NULL
+               AND NOT EXISTS (
+                     SELECT 1 FROM tickets.tickets t
+                      WHERE t.external_id = inbox_items.bug_ticket_id
+                   );
+            ALTER TABLE inbox_items
+              ADD CONSTRAINT inbox_items_bug_ticket_fkey
+              FOREIGN KEY (bug_ticket_id)
+              REFERENCES tickets.tickets(external_id)
+              ON DELETE CASCADE;
+          END IF;
+        END IF;
+      END $inbox_fk$;
 
       CREATE TABLE IF NOT EXISTS message_threads (
         id              SERIAL PRIMARY KEY,
@@ -763,7 +801,11 @@ data:
         status          TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending','actioned','archived')),
         reference_id    TEXT,
         reference_table TEXT,
-        bug_ticket_id   TEXT REFERENCES bugs.bug_tickets(ticket_id) ON DELETE SET NULL,
+        -- bug_ticket_id keeps the tickets.tickets(external_id) slug (e.g. T000287,
+        -- BR-YYYYMMDD-xxxx). The FK is installed *after* tickets.tickets exists,
+        -- below — bootstrap-safe on fresh DBs where tickets-db.ts has not yet
+        -- run.
+        bug_ticket_id   TEXT,
         payload         JSONB,
         created_at      TIMESTAMPTZ DEFAULT now(),
         actioned_at     TIMESTAMPTZ,
@@ -773,6 +815,40 @@ data:
       CREATE INDEX IF NOT EXISTS idx_inbox_items_status ON inbox_items(status, created_at DESC);
       CREATE INDEX IF NOT EXISTS idx_inbox_items_is_test_data
         ON inbox_items (is_test_data) WHERE is_test_data = true;
+
+      -- inbox_items.bug_ticket_id FK repoint (2026-05-12).
+      -- Pre-sunset, this column FK'd into bugs.bug_tickets(ticket_id). Sunset
+      -- dropped that FK, leaving inbox_items orphan-prone after
+      -- tickets.fn_purge_test_data() deletes from tickets.tickets directly.
+      -- Re-add the FK against the new authoritative store with CASCADE.
+      -- Guarded so a partial fresh-DB run (tickets schema not yet bootstrapped)
+      -- doesn't abort the whole schema init.
+      DO $inbox_fk$
+      BEGIN
+        IF to_regclass('tickets.tickets') IS NOT NULL THEN
+          ALTER TABLE inbox_items
+            DROP CONSTRAINT IF EXISTS inbox_items_bug_ticket_id_fkey;
+          IF NOT EXISTS (
+            SELECT 1 FROM pg_constraint
+             WHERE conname = 'inbox_items_bug_ticket_fkey'
+               AND conrelid = 'public.inbox_items'::regclass
+          ) THEN
+            -- NULL out orphans first so the FK can attach.
+            UPDATE inbox_items
+               SET bug_ticket_id = NULL
+             WHERE bug_ticket_id IS NOT NULL
+               AND NOT EXISTS (
+                     SELECT 1 FROM tickets.tickets t
+                      WHERE t.external_id = inbox_items.bug_ticket_id
+                   );
+            ALTER TABLE inbox_items
+              ADD CONSTRAINT inbox_items_bug_ticket_fkey
+              FOREIGN KEY (bug_ticket_id)
+              REFERENCES tickets.tickets(external_id)
+              ON DELETE CASCADE;
+          END IF;
+        END IF;
+      END $inbox_fk$;
 
       CREATE TABLE IF NOT EXISTS message_threads (
         id              SERIAL PRIMARY KEY,

--- a/scripts/one-shot/2026-05-12-inbox-fk-repoint-tickets.sql
+++ b/scripts/one-shot/2026-05-12-inbox-fk-repoint-tickets.sql
@@ -1,0 +1,73 @@
+-- 2026-05-12 — Migration: repoint inbox_items.bug_ticket_id FK to tickets.tickets.
+--
+-- Background
+-- ----------
+-- Before the tickets sunset (PR1–3 → scripts/tickets-sunset.mjs), the
+-- canonical bug ticket store was `bugs.bug_tickets(ticket_id)` and
+-- `inbox_items.bug_ticket_id` had a foreign key into it. The sunset
+-- migration drops the FK and (eventually) the legacy table, but never
+-- added a replacement FK. The new source of truth is
+-- `tickets.tickets(external_id)` — the same string format
+-- (`T000NNN` / `BR-YYYYMMDD-xxxx` slugs) that already lives in
+-- `inbox_items.bug_ticket_id` on the live clusters.
+--
+-- Symptom: direct deletes from `tickets.tickets` — notably
+-- `tickets.fn_purge_test_data()` — don't cascade into inbox_items, so
+-- inbox rows with a now-dead bug_ticket_id silently orphan.
+--
+-- This migration
+-- --------------
+-- 1. Drops the legacy FK `inbox_items_bug_ticket_id_fkey` if it
+--    still exists (idempotent — `tickets-sunset.mjs` already drops it
+--    on clusters that ran sunset; this catches any cluster that hasn't).
+-- 2. Drops the new FK by name if it already exists (so the migration
+--    is safe to re-run).
+-- 3. NULLs any inbox_items.bug_ticket_id whose value doesn't match a
+--    current tickets.tickets.external_id. Audit-safe default — the
+--    payload JSONB still records what was there. On 2026-05-12 both
+--    clusters had ZERO such rows; this guard exists for replays /
+--    fresh clones that drift back into orphans.
+-- 4. Adds the new FK `inbox_items_bug_ticket_fkey` pointing at
+--    tickets.tickets(external_id) ON DELETE CASCADE. CASCADE is the
+--    chosen behaviour (see PR description / brainstorm) so the
+--    fn_purge_test_data() ticket deletes fan out automatically and
+--    inbox no longer accrues orphans.
+--
+-- Idempotent — safe to apply repeatedly.
+-- Wrap in a transaction so partial state never leaks.
+
+\set ON_ERROR_STOP on
+BEGIN;
+
+-- 1) Drop the legacy FK if still present (older clusters / fresh clones
+--    where tickets-sunset never ran with --apply).
+ALTER TABLE public.inbox_items
+  DROP CONSTRAINT IF EXISTS inbox_items_bug_ticket_id_fkey;
+
+-- 2) Drop the new FK by predictable name so re-runs replace cleanly.
+ALTER TABLE public.inbox_items
+  DROP CONSTRAINT IF EXISTS inbox_items_bug_ticket_fkey;
+
+-- 3) NULL any orphan refs. Audit-safe — preserves the inbox row + its
+--    JSONB payload. Required so the FK in step 4 can be created.
+WITH orphaned AS (
+  UPDATE public.inbox_items i
+     SET bug_ticket_id = NULL
+   WHERE i.bug_ticket_id IS NOT NULL
+     AND NOT EXISTS (
+           SELECT 1 FROM tickets.tickets t
+            WHERE t.external_id = i.bug_ticket_id
+         )
+  RETURNING i.id
+)
+SELECT 'orphan_inbox_rows_nulled' AS metric, COUNT(*) AS n FROM orphaned;
+
+-- 4) Add the new FK with CASCADE so ticket deletes (incl.
+--    tickets.fn_purge_test_data) fan out to inbox_items.
+ALTER TABLE public.inbox_items
+  ADD CONSTRAINT inbox_items_bug_ticket_fkey
+  FOREIGN KEY (bug_ticket_id)
+  REFERENCES tickets.tickets(external_id)
+  ON DELETE CASCADE;
+
+COMMIT;


### PR DESCRIPTION
## Summary

- The ticket sunset migration (`scripts/tickets-sunset.mjs`) dropped the legacy `inbox_items_bug_ticket_id_fkey` → `bugs.bug_tickets(ticket_id)` without installing a replacement. Direct deletes from the new authoritative store `tickets.tickets` (notably `tickets.fn_purge_test_data()`) therefore stopped cascading into `inbox_items`, so orphan inbox rows would silently accrue every purge cycle.
- Adds `inbox_items_bug_ticket_fkey FOREIGN KEY (bug_ticket_id) REFERENCES tickets.tickets(external_id) ON DELETE CASCADE` so the cascade is restored.
- Bootstrap-safe: the schema YAML guards the FK install on `to_regclass('tickets.tickets')` and NULLs any orphans before attaching the constraint.

## Files

- `scripts/one-shot/2026-05-12-inbox-fk-repoint-tickets.sql` — idempotent, transaction-wrapped migration (drop legacy FK → NULL orphans → add new FK).
- `k3d/website-schema.yaml` — both `CREATE TABLE IF NOT EXISTS inbox_items (...)` blocks now omit the inline `REFERENCES bugs.bug_tickets` and add a guarded `DO` block that installs `inbox_items_bug_ticket_fkey` once `tickets.tickets` exists, so fresh deploys converge to the new FK without ordering hacks.

## Live state — applied before merge

| cluster | orphans before | orphans nulled | FK after |
|---|---|---|---|
| mentolder | 0 (12 inbox rows, all `bug_ticket_id` already match `tickets.tickets.external_id`) | 0 | `inbox_items_bug_ticket_fkey → tickets.tickets(external_id) ON DELETE CASCADE` |
| korczewski-ha | 0 (no inbox rows with `bug_ticket_id`) | 0 | `inbox_items_bug_ticket_fkey → tickets.tickets(external_id) ON DELETE CASCADE` |

Cascade proven on mentolder via `BEGIN; DELETE FROM tickets.tickets WHERE external_id='T000073'; … ROLLBACK;`:
- inbox rows referencing `T000073` BEFORE: 1
- after `DELETE FROM tickets.tickets`: 0
- after `ROLLBACK`: 1 (restored)

## Test plan

- [x] `task workspace:validate` passes (kustomize manifest dry-run).
- [x] Migration applied to mentolder shared-db, FK confirmed via `\d inbox_items`.
- [x] Migration applied to korczewski-ha shared-db, FK confirmed via `\d inbox_items`.
- [x] Cascade fires (transaction-rollback proof on mentolder).
- [x] Backups triggered on both clusters before apply (defense-in-depth — no rows actually deleted, only NULL'd 0 rows).
- [ ] CI: `task test:all` (offline tests).

(Supersedes #681 — that branch had pre-squash arena commits that conflicted with main; cherry-picked the single fix commit onto a fresh branch off origin/main.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)