### PR TITLE
feat(coaching): sidebar 'Wissen' group + drafts inbox actually shows books

### DIFF
--- a/website/src/components/admin/DraftsInbox.svelte
+++ b/website/src/components/admin/DraftsInbox.svelte
@@ -12,7 +12,7 @@
     status: Status;
     created_at: string;
   }
-  interface Book { id: string; title: string; author: string | null }
+  interface Book { id: string; title: string; author: string | null; slug: string }
   interface Detail extends Draft { chunkText: string; page: number | null }
 
   let books: Book[] = [];
@@ -34,20 +34,34 @@
   };
 
   onMount(async () => {
-    const r = await fetch('/api/admin/coaching/books').then((x) => x.json());
-    books = r.books ?? [];
-    if (books.length > 0) selectedBook = books[0].id;
+    try {
+      const r = await fetch('/api/admin/coaching/books').then((x) => x.json());
+      books = Array.isArray(r) ? r : (r.books ?? []);
+      if (books.length > 0) selectedBook = books[0].id;
+    } catch (err) {
+      toast = `Bücher konnten nicht geladen werden: ${err instanceof Error ? err.message : err}`;
+    }
     await refresh();
   });
+
+  $: selectedBookObj = books.find((b) => b.id === selectedBook) ?? null;
 
   async function refresh() {
     const params = new URLSearchParams();
     if (selectedBook) params.set('book_id', selectedBook);
     params.set('status', selectedStatus);
-    const r = await fetch(`/api/admin/coaching/drafts?${params}`).then((x) => x.json());
-    drafts = (r.drafts as Draft[]).filter((d) => selectedKinds.has(d.template_kind));
+    try {
+      const r = await fetch(`/api/admin/coaching/drafts?${params}`).then((x) => x.json());
+      drafts = ((r.drafts ?? []) as Draft[]).filter((d) => selectedKinds.has(d.template_kind));
+    } catch {
+      drafts = [];
+    }
     if (selectedBook) {
-      acceptanceRate = await fetch(`/api/admin/coaching/books/${selectedBook}/acceptance-rate`).then((x) => x.json());
+      try {
+        acceptanceRate = await fetch(`/api/admin/coaching/books/${selectedBook}/acceptance-rate`).then((x) => x.json());
+      } catch {
+        acceptanceRate = null;
+      }
     }
   }
 
@@ -143,7 +157,18 @@
 
   <section class="list">
     {#if drafts.length === 0}
-      <p class="empty">Noch keine Drafts. Lauf <code>task coaching:classify -- --slug=&lt;slug&gt;</code> nach dem ersten Buch-Ingest.</p>
+      {#if books.length === 0}
+        <p class="empty">
+          Noch keine Bücher hochgeladen.
+          <a href="/admin/knowledge/books">Zur Bücher-Seite →</a>
+        </p>
+      {:else}
+        <p class="empty">
+          Buch <strong>{selectedBookObj?.title ?? ''}</strong> hat noch keine Drafts.<br />
+          Lauf lokal: <code>task coaching:classify -- --slug={selectedBookObj?.slug ?? ''}</code><br />
+          <small>(206-Chunk-Bücher brauchen ~5–10 min · Claude Haiku API-Token werden verbraucht.)</small>
+        </p>
+      {/if}
     {:else}
       {#each Object.entries(groupedByKind) as [kind, list]}
         <h2>{KIND_LABEL[kind as Kind]} <span class="count">{list.length}</span></h2>

--- a/website/src/layouts/AdminLayout.astro
+++ b/website/src/layouts/AdminLayout.astro
@@ -9,6 +9,7 @@ const ASSISTANT_ENABLED = (process.env.ENABLE_ASSISTANT_ADMIN ?? 'false') === 't
 import ChatWidget from '../components/ChatWidget.svelte';
 import SessionExpiryWarning from '../components/SessionExpiryWarning.svelte';
 import { countPendingByType } from '../lib/messaging-db';
+import { pool } from '../lib/website-db';
 
 interface Props {
   title: string;
@@ -58,6 +59,8 @@ const icons: Record<string, string> = {
   inbox: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3.5" width="12" height="10" rx="1"/><path d="M2 10h3.5l1.5 2 1.5-2H12"/></svg>`,
   palette: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 1.5a6.5 6.5 0 1 0 2.5 12.5c.6-.3.5-1.1 0-1.5a1.5 1.5 0 0 1 1.1-2.5H13a2 2 0 0 0 2-2 6.5 6.5 0 0 0-7-6.5z"/><circle cx="5" cy="6.5" r=".75" fill="currentColor" stroke="none"/><circle cx="8" cy="4.5" r=".75" fill="currentColor" stroke="none"/><circle cx="11" cy="6.5" r=".75" fill="currentColor" stroke="none"/></svg>`,
   broadcast: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 8a6 6 0 0 1 0 8"/><path d="M6 8a6 6 0 0 0 0 8"/><circle cx="12" cy="12" r="2"/><path d="M21 5a11 11 0 0 1 0 14"/><path d="M3 5a11 11 0 0 0 0 14"/></svg>`,
+  book: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M3 2.5h7.5a2 2 0 0 1 2 2v9.5H5a2 2 0 0 1-2-2V2.5z"/><path d="M3 12a2 2 0 0 1 2-2h7.5"/><path d="M6 5.5h4M6 7.5h3"/></svg>`,
+  edit: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M11.5 1.8l2.7 2.7L5 13.7l-3.2.5.5-3.2z"/><path d="M10 3.3l2.7 2.7"/></svg>`,
 };
 
 let inboxPending = 0;
@@ -65,6 +68,12 @@ try {
   const counts = await countPendingByType();
   inboxPending = Object.values(counts).reduce((a, b) => a + b, 0);
 } catch { /* ignore if messaging-db unavailable */ }
+
+let draftsPending = 0;
+try {
+  const r = await pool.query(`SELECT count(*)::int AS n FROM coaching.drafts WHERE status = 'open'`);
+  draftsPending = r.rows[0]?.n ?? 0;
+} catch { /* coaching schema may not exist yet */ }
 
 const navGroups: { label: string; items: NavItem[] }[] = [
   {
@@ -103,15 +112,16 @@ const navGroups: { label: string; items: NavItem[] }[] = [
           '/admin/dokumente',
         ],
       },
-      {
-        href: '/admin/wissensquellen',
-        label: 'Wissen',
-        icon: 'clipboard',
-        matches: [
-          '/admin/wissensquellen',
-          '/admin/knowledge',
-        ],
-      },
+    ],
+  },
+  {
+    label: 'Wissen',
+    items: [
+      { href: '/admin/wissensquellen',     label: 'Quellen', icon: 'clipboard' },
+      { href: '/admin/knowledge/books',    label: 'Bücher',  icon: 'book',
+        matches: ['/admin/knowledge/books'] },
+      { href: '/admin/knowledge/drafts',   label: 'Drafts',  icon: 'edit', badge: draftsPending,
+        matches: ['/admin/knowledge/drafts'] },
     ],
   },
   {

--- a/website/src/lib/coaching-db.ts
+++ b/website/src/lib/coaching-db.ts
@@ -9,6 +9,7 @@ export interface Book {
   licenseNote: string | null;
   ingestedAt: Date;
   chunkCount?: number;
+  slug: string;
 }
 
 export interface Snippet {
@@ -66,7 +67,7 @@ export interface ChunkRow {
 
 export async function listBooks(pool: Pool): Promise<Book[]> {
   const r = await pool.query(`
-    SELECT b.*, c.chunk_count
+    SELECT b.*, c.chunk_count, c.name AS collection_name
     FROM coaching.books b
     JOIN knowledge.collections c ON c.id = b.knowledge_collection_id
     ORDER BY b.ingested_at DESC
@@ -76,7 +77,7 @@ export async function listBooks(pool: Pool): Promise<Book[]> {
 
 export async function getBook(pool: Pool, id: string): Promise<Book | null> {
   const r = await pool.query(
-    `SELECT b.*, c.chunk_count
+    `SELECT b.*, c.chunk_count, c.name AS collection_name
        FROM coaching.books b
        JOIN knowledge.collections c ON c.id = b.knowledge_collection_id
       WHERE b.id = $1`,
@@ -368,6 +369,7 @@ export async function markTemplatePublished(
 }
 
 function rowToBook(r: Record<string, unknown>): Book {
+  const collectionName = (r.collection_name ?? '') as string;
   return {
     id: r.id as string,
     knowledgeCollectionId: r.knowledge_collection_id as string,
@@ -377,6 +379,7 @@ function rowToBook(r: Record<string, unknown>): Book {
     licenseNote: (r.license_note ?? null) as string | null,
     ingestedAt: r.ingested_at as Date,
     chunkCount: (r.chunk_count ?? undefined) as number | undefined,
+    slug: collectionName.startsWith('coaching-') ? collectionName.slice('coaching-'.length) : collectionName,
   };
 }
 

--- a/website/src/pages/api/admin/coaching/books/index.ts
+++ b/website/src/pages/api/admin/coaching/books/index.ts
@@ -11,8 +11,14 @@ export const GET: APIRoute = async ({ request }) => {
     return new Response('Unauthorized', { status: 401 });
   }
 
-  const books = await listBooks(pool);
-  return new Response(JSON.stringify(books), {
+  let books: Awaited<ReturnType<typeof listBooks>> = [];
+  try {
+    books = await listBooks(pool);
+  } catch (err) {
+    // coaching schema may not exist on this cluster yet — return empty list
+    console.warn('[api/admin/coaching/books] listBooks failed:', err instanceof Error ? err.message : err);
+  }
+  return new Response(JSON.stringify({ books }), {
     status: 200,
     headers: { 'Content-Type': 'application/json' },
   });


### PR DESCRIPTION
## Why

Gekko opened `/admin/knowledge/drafts` on web.mentolder.de and saw an empty book dropdown — even though one coaching book is already ingested (Geißler "KI-Coaching", 206 chunks). The page also had no sidebar link, so it was only reachable by typing the URL.

## What changed

- **AdminLayout** — new "Wissen" group with three entries: Quellen, Bücher, Drafts. The Drafts entry carries an open-drafts pending badge (parallel to the Inbox badge). Removed the orphan "Wissen" link that previously lived under "Inhalte".
- **`/api/admin/coaching/books`** — response now wraps the array as `{ books: [...] }` to match the existing convention from `/drafts`, `/snippets`. Also fail-safe when the `coaching` schema doesn't exist (returns empty list instead of 500).
- **DraftsInbox.svelte** — accepts either response shape; fetches are now try/catch; empty state distinguishes the two real cases (no books yet → link to /admin/knowledge/books; book exists but classification hasn't run → shows the actual `--slug=…` and a chunk-volume hint).
- **coaching-db** — `Book.slug` derived from the `coaching-<slug>` collection name; surfaced through `listBooks` / `getBook`.

## Korczewski

The `coaching` schema was missing on korczewski's shared-db because its postStart subPath mount cached pre-coaching scripts. Bootstrapped manually by running the current ConfigMap `ensure-meetings-schema.sh` against the pod (6 tables created). Deployed website to both clusters.

## Outstanding (separate from this PR)

The Anthropic API key in mentolder's SealedSecret currently returns `401 invalid x-api-key`. Once rotated, `task coaching:classify -- --slug=geissler-ki-coaching` (via a kubectl port-forward to shared-db) will generate the first batch of drafts for review.

## Test plan
- [ ] /admin sidebar shows the Wissen group with three entries
- [ ] /admin/knowledge/drafts loads; book dropdown lists "KI-Coaching"
- [ ] Empty state shows the actual slug (`geissler-ki-coaching`), not the `<slug>` placeholder
- [ ] korczewski /admin/knowledge/drafts loads with empty state (no crash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)