### PR TITLE
fix(ci): unbreak main — rechtliches.astro import + arena proto drift

### DIFF
--- a/arena-server/src/game/state.ts
+++ b/arena-server/src/game/state.ts
@@ -1,87 +1,10 @@
-import type { LobbyPhase } from '../proto/messages';
-
 export interface Vec2 { x: number; y: number; }
 
-export type WeaponId = 'glock' | 'deagle' | 'm4a1';
-export type ItemKind = 'health-pack' | 'med-syringe' | 'armor-plate' | 'ammo-box' | 'keycard' | 'respect-coin';
-export type PowerupKind = 'shield' | 'speed' | 'damage' | 'emp' | 'cloak';
-
-export interface WeaponState {
-  id: WeaponId;
-  ammo: number;
-  reloading: boolean;
-  reloadRemainingMs: number;
-  fireCooldownRemainingMs: number;
-}
-
-export interface ActivePowerup {
-  kind: PowerupKind;
-  expiresAtTick: number;
-}
-
-export interface PlayerState {
-  key: string;
-  displayName: string;
-  brand: 'mentolder' | 'korczewski' | null;
-  characterId: string;
-  isBot: boolean;
-  x: number; y: number;
-  facing: number;     // aim angle, radians
-  hp: number;
-  armor: number;
-  alive: boolean;
-  forfeit: boolean;
-  dodging: boolean;
-  dodgeCooldownRemainingMs: number;
-  spawnInvulnRemainingMs: number;
-  meleeCooldownRemainingMs: number;
-  weapon: WeaponState;
-  activePowerups: ActivePowerup[];
-  kills: number;
-  deaths: number;
-  respectCoins: number;
-  disconnectedMs: number;
-  place: number | null;   // filled on elimination
-}
-
-export interface GroundItem {
-  id: string;
-  kind: ItemKind;
-  x: number; y: number;
-}
-
-export interface GroundPowerup {
-  id: string;
-  kind: PowerupKind;
-  x: number; y: number;
-}
-
-export interface ZoneState {
-  cx: number; cy: number;
-  radius: number;
-  shrinking: boolean;
-  nextDamageMs: number;
-}
-
-export interface DoorState {
-  id: string;
-  locked: boolean;
-}
-
-export interface MatchState {
-  matchId: string;
-  tick: number;
-  phase: LobbyPhase;
-  startedAt: number;
-  players: Record<string, PlayerState>;
-  items: GroundItem[];
-  powerups: GroundPowerup[];
-  zone: ZoneState;
-  doors: DoorState[];
-  itemSpawnRemainingMs: number;
-  powerupSpawnRemainingMs: number;
-  aliveCount: number;
-  everAliveCount: number;
-  nextItemId: number;
-  eliminationOrder: string[];   // keys in order of elimination (first = 4th place)
-}
+export type {
+  LobbyPhase,
+  WeaponId, ItemKind, PowerupKind,
+  WeaponState, ActivePowerup,
+  PlayerState,
+  GroundItem, GroundPowerup, ZoneState, DoorState,
+  MatchState,
+} from '../proto/messages';

--- a/arena-server/src/proto/messages.ts
+++ b/arena-server/src/proto/messages.ts
@@ -1,47 +1,69 @@
+// Mirrored from arena-server/src/proto/messages.ts — CI diff guard enforces sync.
+// When updating messages.ts, update this file too.
+
 export const PROTOCOL_VERSION = 1;
 
-export type LobbyPhase =
-  | 'open' | 'starting' | 'in-match' | 'slow-mo' | 'results' | 'closed';
+export type LobbyPhase = 'open' | 'starting' | 'in-match' | 'slow-mo' | 'results' | 'closed';
+
+export type WeaponId = 'glock' | 'deagle' | 'm4a1';
+export type ItemKind = 'health-pack' | 'med-syringe' | 'armor-plate' | 'ammo-box' | 'keycard' | 'respect-coin';
+export type PowerupKind = 'shield' | 'speed' | 'damage' | 'emp' | 'cloak';
+
+export interface WeaponState {
+  id: WeaponId; ammo: number; reloading: boolean;
+  reloadRemainingMs: number; fireCooldownRemainingMs: number;
+}
+
+export interface ActivePowerup { kind: PowerupKind; expiresAtTick: number; }
+
+export interface PlayerState {
+  key: string; displayName: string; brand: 'mentolder' | 'korczewski' | null;
+  characterId: string; isBot: boolean;
+  x: number; y: number; facing: number;
+  hp: number; armor: number; alive: boolean; forfeit: boolean;
+  dodging: boolean; dodgeCooldownRemainingMs: number;
+  spawnInvulnRemainingMs: number; meleeCooldownRemainingMs: number;
+  weapon: WeaponState; activePowerups: ActivePowerup[];
+  kills: number; deaths: number; respectCoins: number;
+  disconnectedMs: number; place: number | null;
+}
+
+export interface GroundItem { id: string; kind: ItemKind; x: number; y: number; }
+export interface GroundPowerup { id: string; kind: PowerupKind; x: number; y: number; }
+export interface ZoneState { cx: number; cy: number; radius: number; shrinking: boolean; nextDamageMs: number; }
+export interface DoorState { id: string; locked: boolean; }
+
+export interface MatchState {
+  matchId: string; tick: number; phase: LobbyPhase; startedAt: number;
+  players: Record<string, PlayerState>;
+  items: GroundItem[]; powerups: GroundPowerup[];
+  zone: ZoneState; doors: DoorState[];
+  itemSpawnRemainingMs: number; powerupSpawnRemainingMs: number;
+  aliveCount: number; everAliveCount: number;
+  nextItemId: number; eliminationOrder: string[];
+}
 
 export interface PlayerSlot {
-  key: string;            // sub@brand for humans, bot_<n> for bots
-  displayName: string;
-  brand: 'mentolder' | 'korczewski' | null;
-  characterId: string;
-  isBot: boolean;
-  ready: boolean;
-  alive: boolean;
+  key: string; displayName: string; brand: 'mentolder' | 'korczewski' | null;
+  characterId: string; isBot: boolean; ready: boolean; alive: boolean;
 }
 
 export interface MatchResult {
-  playerKey: string;
-  displayName: string;
-  isBot: boolean;
-  place: number;
-  kills: number;
-  deaths: number;
-  forfeit: boolean;
+  playerKey: string; displayName: string; isBot: boolean;
+  place: number; kills: number; deaths: number; forfeit: boolean;
 }
 
-import type { MatchState, Vec2, WeaponId, WeaponState,
-              ItemKind, PowerupKind, PlayerState,
-              GroundItem, GroundPowerup, ZoneState, DoorState } from '../game/state';
-
-export type { MatchState, Vec2, WeaponId, WeaponState,
-         ItemKind, PowerupKind, PlayerState,
-         GroundItem, GroundPowerup, ZoneState,
-         DoorState };
-
 export type DiffOp = { p: string; v: unknown };
+
 export type GameEvent =
-  | { e: 'kill';           killer: string; victim: string; weapon: string }
-  | { e: 'kill-zone';      victim: string }
-  | { e: 'pickup-item';    player: string; kind: string }
+  | { e: 'kill'; killer: string; victim: string; weapon: string }
+  | { e: 'kill-zone'; victim: string }
+  | { e: 'pickup-item'; player: string; kind: string }
   | { e: 'pickup-powerup'; player: string; kind: string }
-  | { e: 'door-open';      doorId: string; by: string }
-  | { e: 'dodge';          player: string }
-  | { e: 'forfeit';        player: string }
-  | { e: 'disconnect';     player: string }
+  | { e: 'door-open'; doorId: string; by: string }
+  | { e: 'dodge'; player: string }
+  | { e: 'forfeit'; player: string }
+  | { e: 'disconnect'; player: string }
   | { e: 'slow-mo' }
   | { e: 'zone-shrink-start' }
   | { e: 'powerup-expire'; player: string; kind: string };

--- a/website/src/components/arena/shared/lobbyTypes.ts
+++ b/website/src/components/arena/shared/lobbyTypes.ts
@@ -73,6 +73,7 @@ export type ClientMsg =
   | { t: 'lobby:join'; code: string }
   | { t: 'lobby:ready'; ready: boolean }
   | { t: 'lobby:leave' }
+  | { t: 'lobby:character'; characterId: string }
   | { t: 'input'; seq: number; wasd: number; aim: number;
         fire: boolean; melee: boolean; pickup: boolean; dodge: boolean; tick: number }
   | { t: 'spectator:follow'; target: string | null }
@@ -91,7 +92,7 @@ export type ServerMsg =
   | { t: 'error'; code: string; message: string };
 
 const CLIENT_TYPES = new Set([
-  'lobby:open','lobby:join','lobby:ready','lobby:leave','input',
+  'lobby:open','lobby:join','lobby:ready','lobby:leave','lobby:character','input',
   'spectator:follow','spectator:join','rematch:vote','forfeit','auth:refresh',
 ]);
 

--- a/website/src/pages/admin/rechtliches.astro
+++ b/website/src/pages/admin/rechtliches.astro
@@ -1,7 +1,7 @@
 ---
-import AdminLayout from '../../../layouts/AdminLayout.astro';
-import { getSession, getLoginUrl, isAdmin } from '../../../lib/auth';
-import { getLegalPage } from '../../../lib/website-db';
+import AdminLayout from '../../layouts/AdminLayout.astro';
+import { getSession, getLoginUrl, isAdmin } from '../../lib/auth';
+import { getLegalPage } from '../../lib/website-db';
 
 const session = await getSession(Astro.request.headers.get('cookie'));
 if (!session) return Astro.redirect(getLoginUrl(Astro.url.pathname));


### PR DESCRIPTION
## Summary
Main CI has been red on every push since 169f9ab2. Two independent breakages:

- **Website build failed** — `website/src/pages/admin/rechtliches.astro` imported from `../../../lib/auth` and `../../../lib/website-db`. From `src/pages/admin/` those paths resolve to `website/lib/*` which doesn't exist. Top-level admin pages already use `../../lib/*`; `../../../` is only correct for `admin/<subfolder>/`. Fixed all three relative imports (`auth`, `website-db`, `AdminLayout.astro`).

- **CI / Arena protocol drift guard failed** — `arena-server/src/proto/messages.ts` re-exported `MatchState` et al. from `'../game/state'`, while the website mirror `lobbyTypes.ts` inlined those types in 1f671ea5 ("mirror full MatchState + GameEvent in website lobbyTypes"). On top, server added a `lobby:character` message that the website mirror didn't have. Inlined the types in both files so they are byte-identical (including `lobby:character` + `isClientMsg`). `arena-server/src/game/state.ts` is now a thin re-export from `proto/messages` to avoid duplicate type declarations; `Vec2` stays defined there since it's only used inside arena-server.

The stale closed-without-merging PR #681 branch (`fix/inbox-items-fk-tickets-sunset`) is being deleted separately — the actual ticket fix shipped as PR #682.

## Test plan
- [x] `npx tsc --noEmit` in `arena-server/` passes
- [x] `npx astro build` in `website/` succeeds (was failing on rechtliches.astro)
- [x] `diff -u arena-server/src/proto/messages.ts website/src/components/arena/shared/lobbyTypes.ts` is empty
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)