### PR TITLE
fix(website): surface realmRoles + brand on session

### DIFF
--- a/website/src/lib/auth.ts
+++ b/website/src/lib/auth.ts
@@ -25,10 +25,28 @@ export interface UserSession {
   preferred_username: string;
   given_name?: string;
   family_name?: string;
+  realmRoles: string[];
+  brand: string | null;
   access_token: string;
   refresh_token: string;
   expires_at: number;
 }
+
+function decodeRealmRoles(accessToken: string): string[] {
+  try {
+    const payload = accessToken.split('.')[1];
+    if (!payload) return [];
+    const padded = payload + '='.repeat((4 - (payload.length % 4)) % 4);
+    const json = Buffer.from(padded.replace(/-/g, '+').replace(/_/g, '/'), 'base64').toString('utf8');
+    const claims = JSON.parse(json) as { realm_access?: { roles?: unknown } };
+    const roles = claims.realm_access?.roles;
+    return Array.isArray(roles) ? roles.filter((r): r is string => typeof r === 'string') : [];
+  } catch {
+    return [];
+  }
+}
+
+const BRAND = process.env.BRAND_ID ?? process.env.BRAND ?? null;
 
 // PostgreSQL session store (survives container restarts)
 import pg from 'pg';
@@ -148,6 +166,8 @@ export async function exchangeCode(code: string): Promise<{ sessionId: string; u
     preferred_username: userInfo.preferred_username,
     given_name: userInfo.given_name,
     family_name: userInfo.family_name,
+    realmRoles: decodeRealmRoles(tokens.access_token),
+    brand: BRAND,
     access_token: tokens.access_token,
     refresh_token: tokens.refresh_token,
     expires_at: sessionExpiry,
@@ -199,6 +219,8 @@ export async function getSession(cookieHeader: string | null): Promise<UserSessi
           ...session,
           access_token: refreshed.access_token,
           refresh_token: refreshed.refresh_token,
+          realmRoles: decodeRealmRoles(refreshed.access_token),
+          brand: BRAND,
           expires_at: newExpiry,
         };
         await sessionPool.query(

--- a/website/src/lib/auth/magic-link.ts
+++ b/website/src/lib/auth/magic-link.ts
@@ -114,6 +114,8 @@ export async function redeemMagicToken(token: string): Promise<RedeemedToken | R
     email: sessionUser.email,
     name: sessionUser.name,
     preferred_username: sessionUser.preferred_username,
+    realmRoles: [],
+    brand: process.env.BRAND_ID ?? process.env.BRAND ?? null,
     // No real Keycloak tokens for seeded test sessions. The website's
     // refresh path in lib/auth will null out and force re-auth once these
     // empty strings hit Keycloak; for the system-test loop the session


### PR DESCRIPTION
## Summary
- `UserSession` was missing `realmRoles` and `brand`, so `/admin/arena` (and any other role-gated page) silently rejected everyone — the Keycloak role exists, the website just never read it.
- `exchangeCode` now decodes `realm_access.roles` from the access-token JWT and sets `brand` from `BRAND_ID` / `BRAND` (per-deployment brand convention).
- `getSession` refresh path re-decodes on token rotation so role changes propagate without a full re-login.
- `magic-link` redeem defaults both fields so seeded test sessions still satisfy the type.

## Test plan
- [x] tsc (`npx tsc --noEmit`) shows no new errors introduced by this diff (pre-existing brand/test errors unchanged).
- [ ] After deploy: log out and back in on `web.mentolder.de`, open `/admin/arena`, "Open lobby" button is visible (paddione has the `arena_admin` role assigned in Keycloak).

🤖 Generated with [Claude Code](https://claude.com/claude-code)