### PR TITLE
fix(arena): drop self-fetch loop in /api/arena/start

### DIFF
--- a/website/src/lib/arena-token.ts
+++ b/website/src/lib/arena-token.ts
@@ -1,0 +1,36 @@
+const ISSUER_BY_BRAND: Record<string, string> = {
+  mentolder:  'https://auth.mentolder.de/realms/workspace',
+  korczewski: 'https://auth.korczewski.de/realms/workspace',
+};
+
+export interface ArenaToken {
+  token: string;
+  expiresIn: number;
+}
+
+export type ArenaTokenError =
+  | { kind: 'token-exchange-failed'; status: number };
+
+export async function mintArenaToken(userAccessToken: string): Promise<ArenaToken | ArenaTokenError> {
+  const brand = (process.env.BRAND_ID ?? process.env.BRAND ?? 'mentolder') as 'mentolder' | 'korczewski';
+  const issuer = ISSUER_BY_BRAND[brand];
+
+  const res = await fetch(`${issuer}/protocol/openid-connect/token`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      grant_type: 'urn:ietf:params:oauth:grant-type:token-exchange',
+      client_id: 'arena',
+      subject_token: userAccessToken,
+      subject_token_type: 'urn:ietf:params:oauth:token-type:access_token',
+      audience: 'arena',
+    }),
+  });
+
+  if (!res.ok) {
+    return { kind: 'token-exchange-failed', status: res.status };
+  }
+
+  const json = await res.json() as { access_token: string; expires_in: number };
+  return { token: json.access_token, expiresIn: json.expires_in };
+}

--- a/website/src/pages/api/arena/start.ts
+++ b/website/src/pages/api/arena/start.ts
@@ -1,5 +1,6 @@
 import type { APIRoute } from 'astro';
 import { getSession } from '../../../lib/auth';
+import { mintArenaToken } from '../../../lib/arena-token';
 
 const UPSTREAM = (process.env.ARENA_WS_URL ?? 'http://localhost:8090')
   .replace(/^wss:/, 'https:').replace(/^ws:/, 'http:');
@@ -8,17 +9,16 @@ export const POST: APIRoute = async (ctx) => {
   const user = await getSession(ctx.request.headers.get('cookie'));
   if (!user) return new Response('unauthorised', { status: 401 });
 
-  // Mint an arena-scoped access token (re-uses /api/arena/token logic via internal fetch).
-  const tokenRes = await fetch(`${ctx.url.origin}/api/arena/token`, {
-    method: 'POST',
-    headers: { cookie: ctx.request.headers.get('cookie') ?? '' },
-  });
-  if (!tokenRes.ok) return new Response('token-mint-failed', { status: 502 });
-  const { token } = await tokenRes.json() as { token: string };
+  const tokenResult = await mintArenaToken(user.access_token);
+  if ('kind' in tokenResult) {
+    return new Response(JSON.stringify({ error: tokenResult.kind, status: tokenResult.status }), {
+      status: 502, headers: { 'content-type': 'application/json' },
+    });
+  }
 
   const upstream = await fetch(`${UPSTREAM}/lobby/open`, {
     method: 'POST',
-    headers: { authorization: `Bearer ${token}` },
+    headers: { authorization: `Bearer ${tokenResult.token}` },
   });
   return new Response(await upstream.text(), {
     status: upstream.status,

--- a/website/src/pages/api/arena/token.ts
+++ b/website/src/pages/api/arena/token.ts
@@ -1,42 +1,19 @@
 import type { APIRoute } from 'astro';
 import { getSession } from '../../../lib/auth';
-
-const ISSUER_BY_BRAND: Record<string, string> = {
-  mentolder:  'https://auth.mentolder.de/realms/workspace',
-  korczewski: 'https://auth.korczewski.de/realms/workspace',
-};
+import { mintArenaToken } from '../../../lib/arena-token';
 
 export const POST: APIRoute = async (ctx) => {
   const user = await getSession(ctx.request.headers.get('cookie'));
   if (!user) return new Response('unauthorised', { status: 401 });
 
-  const brand = (process.env.BRAND_ID ?? process.env.BRAND ?? 'mentolder') as 'mentolder' | 'korczewski';
-  const issuer = ISSUER_BY_BRAND[brand];
-
-  // Token exchange against the user's home realm, requesting aud=arena.
-  const tokenUrl = `${issuer}/protocol/openid-connect/token`;
-  const body = new URLSearchParams({
-    grant_type: 'urn:ietf:params:oauth:grant-type:token-exchange',
-    client_id: 'arena',
-    subject_token: user.access_token,
-    subject_token_type: 'urn:ietf:params:oauth:token-type:access_token',
-    audience: 'arena',
-  });
-
-  const res = await fetch(tokenUrl, {
-    method: 'POST',
-    headers: { 'content-type': 'application/x-www-form-urlencoded' },
-    body,
-  });
-
-  if (!res.ok) {
-    return new Response(JSON.stringify({ error: 'token-exchange-failed', status: res.status }), {
+  const result = await mintArenaToken(user.access_token);
+  if ('kind' in result) {
+    return new Response(JSON.stringify({ error: result.kind, status: result.status }), {
       status: 502, headers: { 'content-type': 'application/json' },
     });
   }
 
-  const json = await res.json() as { access_token: string; expires_in: number };
-  return new Response(JSON.stringify({ token: json.access_token, expiresIn: json.expires_in }), {
+  return new Response(JSON.stringify(result), {
     status: 200, headers: { 'content-type': 'application/json' },
   });
 };


### PR DESCRIPTION
## Summary
- The admin **Open lobby** button on `/admin/arena` failed with what the user reported as a 404. Root cause: `/api/arena/start` did a server-side `fetch(\`${ctx.url.origin}/api/arena/token\`)` — i.e. the website pod tried to reach itself via the public hostname. From inside the workspace, `https://web.mentolder.de` is unreachable (curl from the pod returns status `000`), so undici raised `TypeError: fetch failed` and Astro returned an error response.
- Extracted the Keycloak token-exchange into `website/src/lib/arena-token.ts` and called it directly from both `/api/arena/token` (browser-facing) and `/api/arena/start` (server-side). The session already holds `access_token`, so no HTTP round-trip is needed.

## Test plan
- [x] Confirm endpoint surface unchanged: `POST /api/arena/token` still returns `{ token, expiresIn }` on 200, 502 on token-exchange failure, 401 unauth — matches what `ArenaIsland.tsx` expects from the browser.
- [ ] Deploy via `task website:deploy ENV=mentolder` then `ENV=korczewski`.
- [ ] Click **Open lobby** on `https://web.mentolder.de/admin/arena` while signed in as an `arena_admin` mentolder user → expect redirect to `/portal/arena?lobby=<code>` and the banner appearing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)