### PR TITLE
feat(arena): solo mode + fix lobby creation 503

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1551,6 +1551,13 @@ tasks:
     cmds:
       - ENV={{.ENV}} bash scripts/keycloak-sync.sh
 
+  keycloak:ensure-mappers:
+    desc: "Idempotent upsert of protocol mappers that secret-only sync misses (currently: website→audience-arena). ENV=dev|mentolder|korczewski."
+    vars:
+      ENV: '{{.ENV | default "dev"}}'
+    cmds:
+      - ENV={{.ENV}} bash scripts/keycloak-ensure-mappers.sh
+
   workspace:vaultwarden:seed:
     desc: "Seed Vaultwarden with production secret templates (ENV=dev|mentolder|korczewski). Run once after first login — see vaultwarden-seed-credentials.yaml."
     vars:

--- a/arena-server/src/http/routes.ts
+++ b/arena-server/src/http/routes.ts
@@ -37,6 +37,18 @@ export function makeRoutes(deps: { lc: Lifecycle; repo: Repo; auth: AuthMiddlewa
     }
   });
 
+  r.post('/lobby/solo', requireUser, requireAdmin, (req, res) => {
+    try {
+      const out = deps.lc.openSolo({
+        hostKey: req.userKey!,
+        hostName: req.user!.displayName,
+      });
+      res.status(201).json(out);
+    } catch (e: any) {
+      res.status(e.code === 409 ? 409 : 500).json({ error: e.message });
+    }
+  });
+
   r.get('/match/:id', requireUser, async (req, res) => {
     const rows = await deps.repo.getRecentMatches(50);
     const m = rows.find(r => r.id === req.params.id);

--- a/arena-server/src/lobby/lifecycle.test.ts
+++ b/arena-server/src/lobby/lifecycle.test.ts
@@ -43,4 +43,15 @@ describe('Lifecycle', () => {
     lc.join(code, humanSlot('h4@korczewski'));
     expect(registry.getLobby(code)!.phase).toBe('starting');
   });
+
+  it('openSolo fills 3 bots and goes straight to starting', () => {
+    const lc = new Lifecycle({ onBroadcast: () => {}, persist: { insertLobby: async () => {}, updateLobbyPhase: async () => {} } as any, bc: { emitMatchSnapshot: vi.fn(), emitMatchDiff: vi.fn(), emitMatchEvent: vi.fn(), emitMatchEnd: vi.fn() } as any });
+    const { code } = lc.openSolo({ hostKey: 'patrick@mentolder', hostName: 'Patrick' });
+    const lobby = registry.getLobby(code)!;
+    expect(lobby.phase).toBe('starting');
+    expect(lobby.players.size).toBe(4);
+    expect([...lobby.players.values()].filter(p => p.isBot)).toHaveLength(3);
+    vi.advanceTimersByTime(5_001);
+    expect(lobby.phase).toBe('in-match');
+  });
 });

--- a/arena-server/src/lobby/lifecycle.ts
+++ b/arena-server/src/lobby/lifecycle.ts
@@ -52,6 +52,17 @@ export class Lifecycle {
     return { code, expiresAt };
   }
 
+  /**
+   * Solo mode: open a lobby with just the host, fill three bots immediately,
+   * and enter the 5s starting countdown without waiting for the 60s open window.
+   * Used by admins to smoke-test arena features against AI opponents.
+   */
+  openSolo(req: OpenRequest): OpenResult {
+    const out = this.open(req);
+    this.toStarting(out.code);
+    return out;
+  }
+
   join(code: string, slot: PlayerSlot): void {
     const lobby = getLobby(code);
     if (!lobby) throw new Error('404 lobby not found');

--- a/k3d/arena.yaml
+++ b/k3d/arena.yaml
@@ -43,7 +43,7 @@ spec:
           # Pinned by digest. To roll forward: build/push a new arena-server image,
           # then resolve the digest with `gh api /users/paddione/packages/container/arena-server/versions`
           # and update this line. Closes #656.
-          image: ghcr.io/paddione/arena-server@sha256:d87a78fb9037de107e30b5b279c32c4605f7458a274d69647143888ca5812f9d
+          image: ghcr.io/paddione/arena-server@sha256:3cf660f921d092cf9dbc7ff01463293c608bc4efce79cfd4b2d685546c070ed9
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/k3d/realm-workspace-dev.json
+++ b/k3d/realm-workspace-dev.json
@@ -149,6 +149,17 @@
             "claim.name": "preferred_username",
             "jsonType.label": "String"
           }
+        },
+        {
+          "name": "audience-arena",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "consentRequired": false,
+          "config": {
+            "included.client.audience": "arena",
+            "access.token.claim": "true",
+            "id.token.claim": "false"
+          }
         }
       ]
     },

--- a/prod-korczewski/realm-workspace-korczewski.json
+++ b/prod-korczewski/realm-workspace-korczewski.json
@@ -158,6 +158,17 @@
             "claim.name": "preferred_username",
             "jsonType.label": "String"
           }
+        },
+        {
+          "name": "audience-arena",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "consentRequired": false,
+          "config": {
+            "included.client.audience": "arena",
+            "access.token.claim": "true",
+            "id.token.claim": "false"
+          }
         }
       ]
     },

--- a/prod-mentolder/realm-workspace-mentolder.json
+++ b/prod-mentolder/realm-workspace-mentolder.json
@@ -160,6 +160,17 @@
             "claim.name": "preferred_username",
             "jsonType.label": "String"
           }
+        },
+        {
+          "name": "audience-arena",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "consentRequired": false,
+          "config": {
+            "included.client.audience": "arena",
+            "access.token.claim": "true",
+            "id.token.claim": "false"
+          }
         }
       ]
     },

--- a/scripts/keycloak-ensure-mappers.sh
+++ b/scripts/keycloak-ensure-mappers.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# ═══════════════════════════════════════════════════════════════════════
+# keycloak-ensure-mappers.sh — Idempotent upsert of protocol mappers
+# that keycloak-sync.sh's secret-only PUT does NOT cover.
+#
+# Currently ensures:
+#   - website client → "audience-arena" oidc-audience-mapper
+#     (so user session tokens carry aud=arena and the arena-server's
+#      audience check passes without token-exchange).
+#
+# Usage:
+#   ENV=mentolder bash scripts/keycloak-ensure-mappers.sh
+# ═══════════════════════════════════════════════════════════════════════
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+ENV="${ENV:-dev}"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/env-resolve.sh" "$ENV" "$SCRIPT_DIR/../environments"
+
+KC_NAMESPACE="${KC_NAMESPACE:-${WORKSPACE_NAMESPACE:-workspace}}"
+KC_REALM="${KC_REALM:-workspace}"
+
+if [[ "$ENV" == "dev" ]]; then
+  KC_URL="http://auth.localhost"
+else
+  KC_URL="https://auth.${PROD_DOMAIN}"
+fi
+
+CONTEXT_FLAG=""
+[[ "$ENV" != "dev" ]] && CONTEXT_FLAG="--context ${ENV_CONTEXT}"
+
+GREEN='\033[0;32m'; YELLOW='\033[1;33m'; RED='\033[0;31m'; NC='\033[0m'
+log()  { echo -e "${GREEN}[KC-MAPPER]${NC} $*"; }
+warn() { echo -e "${YELLOW}[KC-MAPPER]${NC} $*"; }
+err()  { echo -e "${RED}[KC-MAPPER]${NC} $*"; }
+
+# ── Admin-Token ──────────────────────────────────────────────────────
+# shellcheck disable=SC2086
+KC_ADMIN_PASS=$(kubectl $CONTEXT_FLAG get secret workspace-secrets \
+  -n "$KC_NAMESPACE" \
+  -o jsonpath='{.data.KEYCLOAK_ADMIN_PASSWORD}' 2>/dev/null \
+  | base64 -d 2>/dev/null || echo "devadmin")
+
+log "Hole Admin-Token von ${KC_URL}..."
+ADMIN_TOKEN=$(curl -sk \
+  -X POST "${KC_URL}/realms/master/protocol/openid-connect/token" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  --data-urlencode "grant_type=password" \
+  --data-urlencode "client_id=admin-cli" \
+  --data-urlencode "username=admin" \
+  --data-urlencode "password=${KC_ADMIN_PASS}" \
+  | jq -r '.access_token // empty')
+
+if [[ -z "$ADMIN_TOKEN" ]]; then
+  err "Admin-Token konnte nicht geholt werden — Abbruch."
+  exit 1
+fi
+
+# ── ensure_audience_mapper CLIENT_ID NAME AUD ────────────────────────
+ensure_audience_mapper() {
+  local client_id="$1"
+  local mapper_name="$2"
+  local audience="$3"
+
+  local client_uuid
+  client_uuid=$(curl -sk \
+    "${KC_URL}/admin/realms/${KC_REALM}/clients?clientId=${client_id}&search=false" \
+    -H "Authorization: Bearer ${ADMIN_TOKEN}" \
+    | jq -r '.[0].id // empty')
+
+  if [[ -z "$client_uuid" ]]; then
+    err "  ✗ Client '${client_id}' nicht gefunden im Realm '${KC_REALM}'."
+    return 1
+  fi
+
+  local existing
+  existing=$(curl -sk \
+    "${KC_URL}/admin/realms/${KC_REALM}/clients/${client_uuid}/protocol-mappers/models" \
+    -H "Authorization: Bearer ${ADMIN_TOKEN}" \
+    | jq -r ".[] | select(.name==\"${mapper_name}\") | .id // empty")
+
+  local body
+  body=$(jq -n \
+    --arg name "$mapper_name" \
+    --arg aud  "$audience" \
+    '{name: $name, protocol: "openid-connect", protocolMapper: "oidc-audience-mapper",
+      consentRequired: false,
+      config: { "included.client.audience": $aud,
+                "access.token.claim": "true",
+                "id.token.claim": "false" }}')
+
+  if [[ -n "$existing" ]]; then
+    local status
+    status=$(curl -sk -o /dev/null -w "%{http_code}" \
+      -X PUT "${KC_URL}/admin/realms/${KC_REALM}/clients/${client_uuid}/protocol-mappers/models/${existing}" \
+      -H "Authorization: Bearer ${ADMIN_TOKEN}" \
+      -H "Content-Type: application/json" \
+      -d "$(echo "$body" | jq --arg id "$existing" '. + {id: $id}')")
+    if [[ "$status" =~ ^2 ]]; then
+      log "  ✓ ${client_id} / ${mapper_name} (updated, aud=${audience})"
+    else
+      err "  ✗ ${client_id} / ${mapper_name}: PUT HTTP ${status}"
+      return 1
+    fi
+  else
+    local status
+    status=$(curl -sk -o /dev/null -w "%{http_code}" \
+      -X POST "${KC_URL}/admin/realms/${KC_REALM}/clients/${client_uuid}/protocol-mappers/models" \
+      -H "Authorization: Bearer ${ADMIN_TOKEN}" \
+      -H "Content-Type: application/json" \
+      -d "$body")
+    if [[ "$status" =~ ^2 ]]; then
+      log "  + ${client_id} / ${mapper_name} (created, aud=${audience})"
+    else
+      err "  ✗ ${client_id} / ${mapper_name}: POST HTTP ${status}"
+      return 1
+    fi
+  fi
+}
+
+log "Stelle Protocol-Mapper im Realm '${KC_REALM}' sicher..."
+ensure_audience_mapper "website" "audience-arena" "arena"
+
+log "Fertig."

--- a/website/src/lib/arena-token.ts
+++ b/website/src/lib/arena-token.ts
@@ -1,36 +1,13 @@
-const ISSUER_BY_BRAND: Record<string, string> = {
-  mentolder:  'https://auth.mentolder.de/realms/workspace',
-  korczewski: 'https://auth.korczewski.de/realms/workspace',
-};
+// The website OIDC client carries an `oidc-audience-mapper` for the arena
+// audience (see realm-workspace-*.json → website.protocolMappers), so the
+// user's existing session access_token already has `aud: arena` and is
+// directly accepted by arena-server's verifyArenaJwt. No token-exchange
+// roundtrip needed.
 
 export interface ArenaToken {
   token: string;
-  expiresIn: number;
 }
 
-export type ArenaTokenError =
-  | { kind: 'token-exchange-failed'; status: number };
-
-export async function mintArenaToken(userAccessToken: string): Promise<ArenaToken | ArenaTokenError> {
-  const brand = (process.env.BRAND_ID ?? process.env.BRAND ?? 'mentolder') as 'mentolder' | 'korczewski';
-  const issuer = ISSUER_BY_BRAND[brand];
-
-  const res = await fetch(`${issuer}/protocol/openid-connect/token`, {
-    method: 'POST',
-    headers: { 'content-type': 'application/x-www-form-urlencoded' },
-    body: new URLSearchParams({
-      grant_type: 'urn:ietf:params:oauth:grant-type:token-exchange',
-      client_id: 'arena',
-      subject_token: userAccessToken,
-      subject_token_type: 'urn:ietf:params:oauth:token-type:access_token',
-      audience: 'arena',
-    }),
-  });
-
-  if (!res.ok) {
-    return { kind: 'token-exchange-failed', status: res.status };
-  }
-
-  const json = await res.json() as { access_token: string; expires_in: number };
-  return { token: json.access_token, expiresIn: json.expires_in };
+export function mintArenaToken(userAccessToken: string): ArenaToken {
+  return { token: userAccessToken };
 }

--- a/website/src/lib/auth.ts
+++ b/website/src/lib/auth.ts
@@ -32,18 +32,30 @@ export interface UserSession {
   expires_at: number;
 }
 
-function decodeRealmRoles(accessToken: string): string[] {
+function decodeJwtPayload(accessToken: string): Record<string, unknown> | null {
   try {
     const payload = accessToken.split('.')[1];
-    if (!payload) return [];
+    if (!payload) return null;
     const padded = payload + '='.repeat((4 - (payload.length % 4)) % 4);
     const json = Buffer.from(padded.replace(/-/g, '+').replace(/_/g, '/'), 'base64').toString('utf8');
-    const claims = JSON.parse(json) as { realm_access?: { roles?: unknown } };
-    const roles = claims.realm_access?.roles;
-    return Array.isArray(roles) ? roles.filter((r): r is string => typeof r === 'string') : [];
+    return JSON.parse(json) as Record<string, unknown>;
   } catch {
-    return [];
+    return null;
   }
+}
+
+function decodeRealmRoles(accessToken: string): string[] {
+  const claims = decodeJwtPayload(accessToken);
+  const roles = (claims?.realm_access as { roles?: unknown } | undefined)?.roles;
+  return Array.isArray(roles) ? roles.filter((r): r is string => typeof r === 'string') : [];
+}
+
+function tokenHasAudience(accessToken: string, audience: string): boolean {
+  const claims = decodeJwtPayload(accessToken);
+  const aud = claims?.aud;
+  if (typeof aud === 'string') return aud === audience;
+  if (Array.isArray(aud)) return aud.includes(audience);
+  return false;
 }
 
 const BRAND = process.env.BRAND_ID ?? process.env.BRAND ?? null;
@@ -209,9 +221,13 @@ export async function getSession(cookieHeader: string | null): Promise<UserSessi
     let session = result.rows[0].data as UserSession;
 
     // Proactively refresh Keycloak access token when it's within 5 minutes of expiry
-    // while keeping the DB session alive for the full SESSION_TTL_MS.
+    // while keeping the DB session alive for the full SESSION_TTL_MS. Also force a
+    // refresh when the cached access_token was issued before the arena audience
+    // mapper was added — otherwise arena-server rejects the JWT with audience
+    // mismatch and users would have to log out manually.
     const ACCESS_TOKEN_BUFFER_MS = 5 * 60 * 1000;
-    if (session.expires_at - Date.now() < ACCESS_TOKEN_BUFFER_MS) {
+    const missingArenaAud = !tokenHasAudience(session.access_token, 'arena');
+    if (session.expires_at - Date.now() < ACCESS_TOKEN_BUFFER_MS || missingArenaAud) {
       const refreshed = await refreshTokens(session.refresh_token);
       if (refreshed) {
         const newExpiry = Date.now() + SESSION_TTL_MS;

--- a/website/src/pages/admin/arena.astro
+++ b/website/src/pages/admin/arena.astro
@@ -15,8 +15,11 @@ const isAdmin = (user.realmRoles ?? []).includes('arena_admin') && user.brand ==
       <p class="warn">This page requires the <code>arena_admin</code> realm role on the mentolder Keycloak realm.</p>
     ) : (
       <>
-        <button id="open-lobby" class="primary">Open lobby</button>
-        <p class="hint">A 6-character code is generated and a banner appears across both brands for 60 seconds.</p>
+        <div class="actions">
+          <button id="open-lobby" class="primary">Open lobby</button>
+          <button id="start-solo" class="secondary" title="Start immediately against 3 AI bots — for testing">Start solo match</button>
+        </div>
+        <p class="hint"><strong>Open lobby</strong>: a 6-character code is generated and a banner appears across both brands for 60 seconds. <strong>Start solo match</strong>: skip the wait and drop straight into a 5-second countdown against 3 AI bots.</p>
         <h2>Recent matches</h2>
         <table id="recent">
           <thead><tr><th>Started</th><th>Code</th><th>Winner</th><th>Humans</th><th>Bots</th></tr></thead>
@@ -29,15 +32,32 @@ const isAdmin = (user.realmRoles ?? []).includes('arena_admin') && user.brand ==
 
 <script>
   const btn = document.getElementById('open-lobby') as HTMLButtonElement | null;
+  const soloBtn = document.getElementById('start-solo') as HTMLButtonElement | null;
   const tbody = document.querySelector('#recent tbody') as HTMLElement | null;
 
-  btn?.addEventListener('click', async () => {
-    btn.disabled = true;
-    const res = await fetch('/api/arena/start', { method: 'POST' });
-    if (!res.ok) { alert('failed: ' + res.status); btn.disabled = false; return; }
-    const { code } = await res.json() as { code: string };
-    window.location.href = `/portal/arena?lobby=${encodeURIComponent(code)}`;
-  });
+  async function postAndJoin(endpoint: string, source: HTMLButtonElement) {
+    source.disabled = true;
+    if (btn) btn.disabled = true;
+    if (soloBtn) soloBtn.disabled = true;
+    try {
+      const res = await fetch(endpoint, { method: 'POST' });
+      if (!res.ok) {
+        let detail = '';
+        try { detail = await res.text(); } catch {}
+        alert(`failed: ${res.status}${detail ? ' — ' + detail.slice(0, 200) : ''}`);
+        return;
+      }
+      const { code } = await res.json() as { code: string };
+      window.location.href = `/portal/arena?lobby=${encodeURIComponent(code)}`;
+    } finally {
+      source.disabled = false;
+      if (btn) btn.disabled = false;
+      if (soloBtn) soloBtn.disabled = false;
+    }
+  }
+
+  btn?.addEventListener('click', () => postAndJoin('/api/arena/start', btn));
+  soloBtn?.addEventListener('click', () => postAndJoin('/api/arena/solo', soloBtn));
 
   async function loadMatches() {
     if (!tbody) return;
@@ -84,10 +104,16 @@ const isAdmin = (user.realmRoles ?? []).includes('arena_admin') && user.brand ==
 <style>
   .arena-admin { padding: 32px; max-width: 960px; }
   h1 { font-family: 'Instrument Serif', Georgia, serif; }
+  .actions { display: flex; gap: 10px; flex-wrap: wrap; }
   .primary {
     padding: 10px 22px; background: #c8ff3f; color: #1a0e22;
     border: none; font-weight: 600; cursor: pointer;
   }
+  .secondary {
+    padding: 10px 22px; background: transparent; color: #c8ff3f;
+    border: 1px solid #c8ff3f; font-weight: 600; cursor: pointer;
+  }
+  .primary:disabled, .secondary:disabled { opacity: 0.5; cursor: not-allowed; }
   .hint { color: #888; font-size: 13px; }
   .warn { color: #b00020; }
   table { width: 100%; border-collapse: collapse; margin-top: 18px; font-size: 13px; }

--- a/website/src/pages/api/arena/matches.ts
+++ b/website/src/pages/api/arena/matches.ts
@@ -1,5 +1,6 @@
 import type { APIRoute } from 'astro';
 import { getSession } from '../../../lib/auth';
+import { mintArenaToken } from '../../../lib/arena-token';
 
 const UPSTREAM_BASE = (process.env.ARENA_WS_URL ?? 'http://localhost:8090')
   .replace(/^wss:\/\//, 'https://').replace(/^ws:\/\//, 'http://');
@@ -8,15 +9,7 @@ export const GET: APIRoute = async (ctx) => {
   const user = await getSession(ctx.request.headers.get('cookie'));
   if (!user) return new Response('unauthorised', { status: 401 });
 
-  const tokenRes = await fetch(`${ctx.url.origin}/api/arena/token`, {
-    method: 'POST',
-    headers: { cookie: ctx.request.headers.get('cookie') ?? '' },
-  }).catch(() => null);
-
-  if (!tokenRes?.ok) {
-    return new Response('[]', { status: 200, headers: { 'content-type': 'application/json' } });
-  }
-  const { token } = await tokenRes.json() as { token: string };
+  const { token } = mintArenaToken(user.access_token);
 
   const upstream = await fetch(`${UPSTREAM_BASE}/match`, {
     headers: { authorization: `Bearer ${token}` },

--- a/website/src/pages/api/arena/solo.ts
+++ b/website/src/pages/api/arena/solo.ts
@@ -11,7 +11,7 @@ export const POST: APIRoute = async (ctx) => {
 
   const { token } = mintArenaToken(user.access_token);
 
-  const upstream = await fetch(`${UPSTREAM}/lobby/open`, {
+  const upstream = await fetch(`${UPSTREAM}/lobby/solo`, {
     method: 'POST',
     headers: { authorization: `Bearer ${token}` },
   });

--- a/website/src/pages/api/arena/token.ts
+++ b/website/src/pages/api/arena/token.ts
@@ -6,13 +6,7 @@ export const POST: APIRoute = async (ctx) => {
   const user = await getSession(ctx.request.headers.get('cookie'));
   if (!user) return new Response('unauthorised', { status: 401 });
 
-  const result = await mintArenaToken(user.access_token);
-  if ('kind' in result) {
-    return new Response(JSON.stringify({ error: result.kind, status: result.status }), {
-      status: 502, headers: { 'content-type': 'application/json' },
-    });
-  }
-
+  const result = mintArenaToken(user.access_token);
   return new Response(JSON.stringify(result), {
     status: 200, headers: { 'content-type': 'application/json' },
   });


### PR DESCRIPTION
## Summary

- **503 fix**: Keycloak rejected the existing token-exchange call (`Standard token exchange is not enabled for the requested client`). Drop the round-trip entirely by adding an `oidc-audience-mapper` on the `website` KC client so session access tokens already carry `aud=arena`. `mintArenaToken` becomes a pass-through. Existing sessions are force-refreshed in `getSession()` so users don't have to log out.
- **Solo mode**: admin can now start a match immediately against 3 AI bots from `/admin/arena` for testing — new `Lifecycle.openSolo()` + `POST /lobby/solo` on arena-server, new `POST /api/arena/solo` on the website, new "Start solo match" button next to "Open lobby".
- **`scripts/keycloak-ensure-mappers.sh` + `task keycloak:ensure-mappers`**: idempotent upsert of protocol mappers that `keycloak-sync.sh` (secret-only) doesn't reconcile.

## Test plan
- [x] `arena-server` vitest: new `openSolo` lifecycle test + full suite (50 passed, 1 skipped)
- [x] `astro check` clean on changed files (24 pre-existing unrelated errors remain)
- [x] arena-server image built, pushed to `ghcr.io/paddione/arena-server@sha256:3cf660f9…`, deployment rolled on mentolder, `/lobby/solo` returns 401 without auth as expected
- [x] `task keycloak:ensure-mappers ENV=mentolder` and `ENV=korczewski` both created the `website/audience-arena` mapper
- [x] `task website:deploy` rolled to both clusters; admin/arena bundle contains the `Start solo match` button and the `tokenHasAudience` refresh path
- [ ] Browser smoke: log in as `paddione` on `web.mentolder.de/admin/arena`, click **Start solo match**, verify redirect to `/portal/arena?lobby=XXXXXX`, 5s countdown, match starts with player + 3 bots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)