### PR TITLE
fix(auth): refresh access token by its own JWT exp

### DIFF
--- a/website/src/lib/auth.ts
+++ b/website/src/lib/auth.ts
@@ -220,14 +220,19 @@ export async function getSession(cookieHeader: string | null): Promise<UserSessi
 
     let session = result.rows[0].data as UserSession;
 
-    // Proactively refresh Keycloak access token when it's within 5 minutes of expiry
-    // while keeping the DB session alive for the full SESSION_TTL_MS. Also force a
-    // refresh when the cached access_token was issued before the arena audience
-    // mapper was added — otherwise arena-server rejects the JWT with audience
-    // mismatch and users would have to log out manually.
-    const ACCESS_TOKEN_BUFFER_MS = 5 * 60 * 1000;
+    // Refresh the Keycloak access token when its own JWT `exp` is within a
+    // 60s safety buffer (KC default access-token TTL is 5 minutes), or when the
+    // cached token lacks the arena audience (mapper added later) — otherwise
+    // arena-server rejects the JWT with "exp claim timestamp check failed" or
+    // an audience mismatch. session.expires_at tracks the web-session lifetime
+    // (8h) and is unrelated to the access token's own expiry.
+    const ACCESS_TOKEN_BUFFER_MS = 60 * 1000;
+    const accessClaims = decodeJwtPayload(session.access_token);
+    const accessExpMs = typeof accessClaims?.exp === 'number' ? accessClaims.exp * 1000 : 0;
+    const accessExpired = accessExpMs - Date.now() < ACCESS_TOKEN_BUFFER_MS;
     const missingArenaAud = !tokenHasAudience(session.access_token, 'arena');
-    if (session.expires_at - Date.now() < ACCESS_TOKEN_BUFFER_MS || missingArenaAud) {
+    const webSessionExpiring = session.expires_at - Date.now() < ACCESS_TOKEN_BUFFER_MS;
+    if (accessExpired || missingArenaAud || webSessionExpiring) {
       const refreshed = await refreshTokens(session.refresh_token);
       if (refreshed) {
         const newExpiry = Date.now() + SESSION_TTL_MS;


### PR DESCRIPTION
## Summary
- Previous refresh logic compared the 8h web-session TTL against a 5-minute buffer — but the KC access token expires after ~5 minutes, so once you ran past the first lifetime every subsequent JWT was already expired. Arena-server rejected with `"exp" claim timestamp check failed`.
- Decode the JWT and refresh when the actual `exp` claim is within 60s.

## Test plan
- [x] Build + deploy to mentolder + korczewski
- [ ] Reload `/admin/arena` and hit **Start solo match** — no more 401 with exp-claim error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)