### PR TITLE
fix(sse): drop forbidden Connection header from SSE responses

### DIFF
--- a/website/src/pages/api/admin/ops/log-stream/stream.ts
+++ b/website/src/pages/api/admin/ops/log-stream/stream.ts
@@ -64,7 +64,6 @@ export const GET: APIRoute = async ({ request }) => {
       'Content-Type': 'text/event-stream',
       'Cache-Control': 'no-cache',
       'X-Accel-Buffering': 'no',
-      'Connection': 'keep-alive',
     },
   });
 };

--- a/website/src/pages/api/admin/tests/stream/[jobId].ts
+++ b/website/src/pages/api/admin/tests/stream/[jobId].ts
@@ -62,7 +62,6 @@ export const GET: APIRoute = async ({ params, request }) => {
     headers: {
       'Content-Type': 'text/event-stream',
       'Cache-Control': 'no-cache',
-      'Connection': 'keep-alive',
       'X-Accel-Buffering': 'no',
     },
   });

--- a/website/src/pages/api/arena/active.ts
+++ b/website/src/pages/api/arena/active.ts
@@ -47,7 +47,6 @@ export const GET: APIRoute = async ({ request }) => {
       'content-type': 'text/event-stream',
       'cache-control': 'no-cache, no-transform',
       'x-accel-buffering': 'no',
-      'connection': 'keep-alive',
     },
   });
 };


### PR DESCRIPTION
## Summary
- `connection: keep-alive` on a Response is a no-op under HTTP/1.1 (default) and **forbidden under HTTP/2** (RFC 7540 §8.1.2.2)
- Chrome surfaces the violation as `ERR_HTTP2_PROTOCOL_ERROR`, breaking the arena banner SSE plus admin log-stream and test-stream SSEs through Traefik over HTTP/2
- Reproduced on `/portal/arena` after *Start solo match*: PortalLayout mounts `<ArenaBanner client:load />` → opens `/api/arena/active` → response carries the offending header → Chrome aborts the stream

## Test plan
- [ ] After deploy: open `/portal/arena?lobby=<code>` in Chrome, confirm `/api/arena/active` stays open (pending) in DevTools Network instead of failing with `(failed) net::ERR_HTTP2_PROTOCOL_ERROR`
- [ ] Confirm arena banner state updates across `/portal` and other pages still work
- [ ] Confirm admin log-stream (`/admin/ops`) and admin test-runner stream still receive events

🤖 Generated with [Claude Code](https://claude.com/claude-code)