### PR TITLE
fix(arena): unblock end-to-end solo match flow

### DIFF
--- a/arena-server/src/db/repo.test.ts
+++ b/arena-server/src/db/repo.test.ts
@@ -44,4 +44,31 @@ d('repo (integration)', () => {
     );
     expect(got.rows[0].n).toBe(2);
   });
+
+  it('persists results_jsonb when it is an array (regression for jsonb-array bug)', async () => {
+    const now = new Date();
+    const match: MatchInsert = {
+      lobbyCode: 'TST002',
+      openedAt: new Date(now.getTime() - 60_000),
+      startedAt: new Date(now.getTime() - 30_000),
+      endedAt: now,
+      winnerPlayer: 'user-1@mentolder',
+      botCount: 0, humanCount: 1, forfeitCount: 0,
+      resultsJsonb: [
+        { playerKey: 'user-1@mentolder', displayName: 'patrick', place: 1, kills: 2, deaths: 0, isBot: false, forfeit: false },
+        { playerKey: 'bot_1', displayName: 'Bot 1', place: 2, kills: 0, deaths: 1, isBot: true, forfeit: false },
+      ],
+      players: [
+        { playerKey: 'user-1@mentolder', displayName: 'patrick', brand: 'mentolder',
+          isBot: false, characterId: 'blonde-guy', place: 1, kills: 2, deaths: 0, forfeit: false },
+      ],
+    };
+    const matchId = await repo.insertMatchWithPlayers(match);
+    const got = await pool.query(
+      'SELECT results_jsonb FROM arena.matches WHERE id = $1', [matchId],
+    );
+    expect(Array.isArray(got.rows[0].results_jsonb)).toBe(true);
+    expect(got.rows[0].results_jsonb).toHaveLength(2);
+    expect(got.rows[0].results_jsonb[0].kills).toBe(2);
+  });
 });

--- a/arena-server/src/db/repo.ts
+++ b/arena-server/src/db/repo.ts
@@ -53,7 +53,7 @@ export function makeRepo(pool: Pool) {
            VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)
            RETURNING id`,
           [m.lobbyCode, m.openedAt, m.startedAt, m.endedAt, m.winnerPlayer,
-           m.botCount, m.humanCount, m.forfeitCount, m.resultsJsonb],
+           m.botCount, m.humanCount, m.forfeitCount, JSON.stringify(m.resultsJsonb)],
         );
         const matchId = rows[0].id as string;
         for (const p of m.players) {

--- a/arena-server/src/lobby/lifecycle.test.ts
+++ b/arena-server/src/lobby/lifecycle.test.ts
@@ -44,14 +44,25 @@ describe('Lifecycle', () => {
     expect(registry.getLobby(code)!.phase).toBe('starting');
   });
 
-  it('openSolo fills 3 bots and goes straight to starting', () => {
+  it('openSolo marks lobby as solo and holds at open until host starts it', () => {
     const lc = new Lifecycle({ onBroadcast: () => {}, persist: { insertLobby: async () => {}, updateLobbyPhase: async () => {} } as any, bc: { emitMatchSnapshot: vi.fn(), emitMatchDiff: vi.fn(), emitMatchEvent: vi.fn(), emitMatchEnd: vi.fn() } as any });
     const { code } = lc.openSolo({ hostKey: 'patrick@mentolder', hostName: 'Patrick' });
     const lobby = registry.getLobby(code)!;
+    expect(lobby.phase).toBe('open');
+    expect(lobby.solo).toBe(true);
+    expect(lobby.players.size).toBe(1);
+    lc.startSolo(code);
     expect(lobby.phase).toBe('starting');
     expect(lobby.players.size).toBe(4);
     expect([...lobby.players.values()].filter(p => p.isBot)).toHaveLength(3);
     vi.advanceTimersByTime(5_001);
     expect(lobby.phase).toBe('in-match');
+  });
+
+  it('startSolo is a no-op when called on a non-solo lobby', () => {
+    const lc = new Lifecycle({ onBroadcast: () => {}, persist: { insertLobby: async () => {}, updateLobbyPhase: async () => {} } as any, bc: { emitMatchSnapshot: vi.fn(), emitMatchDiff: vi.fn(), emitMatchEvent: vi.fn(), emitMatchEnd: vi.fn() } as any });
+    const { code } = lc.open({ hostKey: 'h1@mentolder', hostName: 'h1' });
+    lc.startSolo(code);
+    expect(registry.getLobby(code)!.phase).toBe('open');
   });
 });

--- a/arena-server/src/lobby/lifecycle.ts
+++ b/arena-server/src/lobby/lifecycle.ts
@@ -53,14 +53,26 @@ export class Lifecycle {
   }
 
   /**
-   * Solo mode: open a lobby with just the host, fill three bots immediately,
-   * and enter the 5s starting countdown without waiting for the 60s open window.
-   * Used by admins to smoke-test arena features against AI opponents.
+   * Solo mode: open a lobby with just the host and a `solo` flag.
+   * The 5s starting countdown is held until the host's WS connects
+   * (see `startSolo`), so the client has time to render the lobby
+   * scene and the match snapshot.
    */
   openSolo(req: OpenRequest): OpenResult {
     const out = this.open(req);
-    this.toStarting(out.code);
+    const lobby = getLobby(out.code);
+    if (lobby) lobby.solo = true;
     return out;
+  }
+
+  /**
+   * Trigger the starting countdown for a solo lobby once the host
+   * has actually connected. Idempotent: only fires when phase is 'open'.
+   */
+  startSolo(code: string): void {
+    const lobby = getLobby(code);
+    if (!lobby || !lobby.solo || lobby.phase !== 'open') return;
+    this.toStarting(code);
   }
 
   join(code: string, slot: PlayerSlot): void {

--- a/arena-server/src/lobby/registry.ts
+++ b/arena-server/src/lobby/registry.ts
@@ -10,6 +10,7 @@ export interface Lobby {
   players: Map<string, PlayerSlot>;     // key = sub@brand or bot_<n>
   rematchYes: Set<string>;
   spectators?: Set<string>;
+  solo?: boolean;
   timers: { [k: string]: NodeJS.Timeout | undefined };
   tick?: Tick;
 }

--- a/arena-server/src/ws/handlers.ts
+++ b/arena-server/src/ws/handlers.ts
@@ -16,20 +16,42 @@ export function attachHandlers(socket: Socket, deps: { lc: Lifecycle; user: Aren
       switch (m.t) {
         case 'lobby:join': {
           const targetLobby = getLobby(m.code);
-          if (targetLobby && (targetLobby.phase === 'in-match' || targetLobby.phase === 'slow-mo')) {
+          if (!targetLobby) { sendError(socket, 'not-found', 'lobby not found'); break; }
+          // Existing player reconnecting (e.g. solo host) — send current state and, if mid-match, the live snapshot.
+          if (targetLobby.players.has(key)) {
             socket.join(`lobby:${m.code}`);
             const stateMsg: ServerMsg = {
               t: 'lobby:state', code: m.code, phase: targetLobby.phase,
               players: [...targetLobby.players.values()], expiresAt: targetLobby.expiresAt,
             };
             socket.emit('msg', stateMsg);
-          } else {
-            deps.lc.join(m.code, {
-              key, displayName: deps.user.displayName, brand: deps.user.brand,
-              characterId: 'blonde-guy', isBot: false, ready: false, alive: true,
-            });
-            socket.join(`lobby:${m.code}`);
+            if ((targetLobby.phase === 'in-match' || targetLobby.phase === 'slow-mo') && targetLobby.tick) {
+              const state = targetLobby.tick.getState();
+              const snap: ServerMsg = { t: 'match:full-snapshot', tick: state.tick, state };
+              socket.emit('msg', snap);
+            }
+            // Solo lobbies wait for the host's WS connect before counting down.
+            if (targetLobby.solo && targetLobby.phase === 'open' && targetLobby.hostKey === key) {
+              deps.lc.startSolo(m.code);
+            }
+            break;
           }
+          // Late spectator join: a non-player connecting mid-match.
+          if (targetLobby.phase === 'in-match' || targetLobby.phase === 'slow-mo') {
+            socket.join(`lobby:${m.code}`);
+            const stateMsg: ServerMsg = {
+              t: 'lobby:state', code: m.code, phase: targetLobby.phase,
+              players: [...targetLobby.players.values()], expiresAt: targetLobby.expiresAt,
+            };
+            socket.emit('msg', stateMsg);
+            break;
+          }
+          // Fresh join into an open lobby.
+          deps.lc.join(m.code, {
+            key, displayName: deps.user.displayName, brand: deps.user.brand,
+            characterId: 'blonde-guy', isBot: false, ready: false, alive: true,
+          });
+          socket.join(`lobby:${m.code}`);
           break;
         }
         case 'lobby:leave':

--- a/arena-server/src/ws/server.ts
+++ b/arena-server/src/ws/server.ts
@@ -40,7 +40,9 @@ export function startWs(server: HttpServer, cfg: Config, lc: Lifecycle): Server 
   io.on('connection', (socket) => {
     const user = (socket.data as any).user;
     log.info({ sub: user.sub, brand: user.brand }, 'ws connected');
-    attachHandlers(socket, { lc, user });
+    // Late-bound: index.ts attaches the real Lifecycle to each socket via io.use.
+    const effectiveLc: Lifecycle = (socket as any).lc ?? lc;
+    attachHandlers(socket, { lc: effectiveLc, user });
   });
 
   return io;

--- a/k3d/arena.yaml
+++ b/k3d/arena.yaml
@@ -43,7 +43,7 @@ spec:
           # Pinned by digest. To roll forward: build/push a new arena-server image,
           # then resolve the digest with `gh api /users/paddione/packages/container/arena-server/versions`
           # and update this line. Closes #656.
-          image: ghcr.io/paddione/arena-server@sha256:3cf660f921d092cf9dbc7ff01463293c608bc4efce79cfd4b2d685546c070ed9
+          image: ghcr.io/paddione/arena-server@sha256:dd06fee5f30c585441ac83843e1c68c44fbbbfdd63c0755c9e8346f45e5ab336
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/website/src/components/arena/game/Renderer.ts
+++ b/website/src/components/arena/game/Renderer.ts
@@ -51,17 +51,22 @@ export class Renderer {
   private powerupSprites = new Map<string, Graphics>();
   private textures = new Map<string, Texture>();
   private ready = false;
+  private destroyed = false;
   private followTarget: string | null = null;
+  private initPromise: Promise<void>;
 
   constructor(canvas: HTMLCanvasElement) {
     this.app = new Application();
-    this.app.init({
+    this.initPromise = this.app.init({
       canvas,
       width: MAP_W,
       height: MAP_H,
       backgroundColor: KORE.floor,
       antialias: false,
-    }).then(() => this.initScene());
+    }).then(() => {
+      if (this.destroyed) return;
+      this.initScene();
+    });
   }
 
   private initScene() {
@@ -238,9 +243,12 @@ export class Renderer {
   }
 
   startTicker(getState: () => MatchState | null, myKey: string) {
-    this.app.ticker.add(() => {
-      const s = getState();
-      if (s) this.drawFrame(s, myKey);
+    this.initPromise.then(() => {
+      if (this.destroyed) return;
+      this.app.ticker.add(() => {
+        const s = getState();
+        if (s) this.drawFrame(s, myKey);
+      });
     });
   }
 
@@ -249,10 +257,16 @@ export class Renderer {
   }
 
   setTickerSpeed(speed: number): void {
-    this.app.ticker.speed = speed;
+    this.initPromise.then(() => {
+      if (this.destroyed) return;
+      this.app.ticker.speed = speed;
+    });
   }
 
   destroy() {
-    this.app.destroy(false, { children: true });
+    this.destroyed = true;
+    this.initPromise.then(() => {
+      try { this.app.destroy(false, { children: true }); } catch { /* not initialized */ }
+    });
   }
 }

--- a/website/src/pages/admin/arena.astro
+++ b/website/src/pages/admin/arena.astro
@@ -1,9 +1,9 @@
 ---
 import AdminLayout from '../../layouts/AdminLayout.astro';
-import { getSession } from '../../lib/auth';
+import { getSession, getLoginUrl } from '../../lib/auth';
 
 const user = await getSession(Astro.request.headers.get('cookie'));
-if (!user) return Astro.redirect('/auth/login?return=/admin/arena');
+if (!user) return Astro.redirect(getLoginUrl(Astro.url.pathname));
 
 const isAdmin = (user.realmRoles ?? []).includes('arena_admin') && user.brand === 'mentolder';
 ---
@@ -61,7 +61,7 @@ const isAdmin = (user.realmRoles ?? []).includes('arena_admin') && user.brand ==
 
   async function loadMatches() {
     if (!tbody) return;
-    let rows: Array<{ started_at: string; code?: string; winner_player?: string; human_count?: number; bot_count?: number }>;
+    let rows: Array<{ started_at: string; lobby_code?: string; winner_player?: string; human_count?: number; bot_count?: number }>;
     try {
       const res = await fetch('/api/arena/matches');
       rows = res.ok ? await res.json() : [];
@@ -83,8 +83,8 @@ const isAdmin = (user.realmRoles ?? []).includes('arena_admin') && user.brand ==
       const whenStr = new Date(m.started_at).toLocaleString('de-DE', { dateStyle: 'short', timeStyle: 'short' });
       const cells = [
         whenStr,
-        m.code ?? '',
-        m.winner_player ? m.winner_player.split('@')[0] : '',
+        m.lobby_code ?? '',
+        m.winner_player ? m.winner_player.split('@')[0] : '—',
         String(m.human_count ?? 0),
         String(m.bot_count ?? 0),
       ];

--- a/website/src/pages/api/arena/active.ts
+++ b/website/src/pages/api/arena/active.ts
@@ -13,9 +13,13 @@ export const GET: APIRoute = async ({ request }) => {
       const encoder = new TextEncoder();
       let lastBody = '';
       let cancelled = false;
+      let timer: NodeJS.Timeout | null = null;
 
       const send = (data: string) => {
-        controller.enqueue(encoder.encode(`data: ${data}\n\n`));
+        if (cancelled) return;
+        try {
+          controller.enqueue(encoder.encode(`data: ${data}\n\n`));
+        } catch { cancelled = true; }
       };
 
       const tick = async () => {
@@ -29,15 +33,17 @@ export const GET: APIRoute = async ({ request }) => {
         } catch (e: any) {
           send(JSON.stringify({ active: false, error: e.message }));
         }
-        setTimeout(tick, 2000);
+        if (!cancelled) timer = setTimeout(tick, 2000);
       };
 
       send(JSON.stringify({ active: false })); // initial
       tick();
 
       request.signal.addEventListener('abort', () => {
+        if (cancelled) return;
         cancelled = true;
-        controller.close();
+        if (timer) clearTimeout(timer);
+        try { controller.close(); } catch { /* already closed */ }
       });
     },
   });

--- a/website/src/pages/portal/arena.astro
+++ b/website/src/pages/portal/arena.astro
@@ -1,19 +1,19 @@
 ---
 import PortalLayout from '../../layouts/PortalLayout.astro';
-import { getSession } from '../../lib/auth';
+import { getSession, getLoginUrl } from '../../lib/auth';
 import { ArenaIsland } from '../../components/arena/ArenaIsland';
 
 const user = await getSession(Astro.request.headers.get('cookie'));
-if (!user) return Astro.redirect('/auth/login?return=/portal/arena');
+if (!user) return Astro.redirect(getLoginUrl(Astro.url.pathname));
 
 const lobbyCode = Astro.url.searchParams.get('lobby');
 if (!lobbyCode) return Astro.redirect('/portal');
 
-const wsUrl = import.meta.env.ARENA_WS_URL ?? 'http://arena.localhost';
+const wsUrl = process.env.ARENA_WS_URL ?? 'http://arena.localhost';
 const userKey = `${user.sub}@${user.brand ?? 'mentolder'}`;
 ---
 
-<PortalLayout title="Arena">
+<PortalLayout title="Arena" section="overview" session={user} pendingSignatures={0}>
   <ArenaIsland client:load wsUrl={wsUrl} lobbyCode={lobbyCode} myKey={userKey} />
 </PortalLayout>
 


### PR DESCRIPTION
## Summary
- Tested arena's solo match flow end-to-end with headed Playwright against `web.mentolder.de` and fixed every failure surfaced along the way: a broken `/auth/login` redirect, an SSR crash on the portal page, a build-time vs runtime env-var mismatch, a pg jsonb-array serialisation bug that made every match insert fail, an SSE controller that crashed the whole node process, a ws `lobby:join` that rejected the host's own reconnect, an arena-server boot-order bug that left `lc` permanently `null` in ws handlers, a Pixi v8 async-init race in `Renderer`, and a few UX wires in `/admin/arena`.
- The full Solo flow now works: open `/admin/arena` → "Start solo match" → `/portal/arena` lands on the lobby/match → match runs against 3 bots → results scene shows the winner. The match row now also persists to `arena.matches` and renders in the recent-matches table with the correct lobby code.

## Test plan
- [x] `cd arena-server && npx vitest run` — 51 passed, 2 skipped
- [x] `task arena:deploy ENV=mentolder` + `task website:deploy ENV=mentolder` + `task website:deploy ENV=korczewski` rolled out cleanly
- [x] Logged into `web.mentolder.de/admin/arena` as `paddione`, clicked **Start solo match**, watched the portal render LobbyScene → MatchScene (HUD, kill-feed, weapon/HP) → ResultsScene ("paddione wins"). DB confirms `arena.matches` rows now persist with non-null `results_jsonb`.
- [x] Recent-matches table on `/admin/arena` now lists the new lobby codes
- [ ] Spot-check open-lobby flow with two browsers (banner + 60s window) — not exercised in this pass; covered by existing FA tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)