### PR TITLE
chore(backup): fail loudly on unreachable DB or empty pg_dump output

### DIFF
--- a/k3d/backup-cronjob.yaml
+++ b/k3d/backup-cronjob.yaml
@@ -109,10 +109,22 @@ spec:
               # by the container shell at runtime — NOT Taskfile envsubst targets.
               args:
                 - |
-                  set -e
+                  # fail-loud: -e exits on any error, -u catches missing env vars,
+                  # -o pipefail propagates pg_dump failures through redirects/pipes.
+                  set -euo pipefail
                   # Wait for pod network to settle; ClusterIP routes via kube-proxy
                   # take a few seconds to become active for newly started pods.
                   sleep 15
+
+                  # Pre-flight: refuse to start if shared-db isn't reachable.
+                  # Without this, pg_dump's `> file` redirect creates an empty file
+                  # before pg_dump can fail, leaving a 0-byte "backup" on disk.
+                  echo "Pre-flight: pg_isready against shared-db..."
+                  if ! pg_isready -h shared-db -t 30 -q; then
+                    echo "FATAL: shared-db is not reachable — refusing to write empty dumps." >&2
+                    exit 1
+                  fi
+
                   STAMP=$(date +%Y%m%d-%H%M%S)
                   BACKUP_DIR=/backups/${STAMP}
                   mkdir -p "${BACKUP_DIR}"
@@ -126,10 +138,20 @@ spec:
                       website)     PASS="${WEBSITE_DB_PASSWORD}" ;;
                       docuseal)    PASS="${DOCUSEAL_DB_PASSWORD}" ;;
                     esac
+                    DUMP="${BACKUP_DIR}/${db}.dump"
                     echo "Backing up ${db}..."
                     PGPASSWORD="${PASS}" pg_dump -Fc \
                       -h shared-db -U "${db}" -d "${db}" \
-                      > "${BACKUP_DIR}/${db}.dump"
+                      > "${DUMP}"
+                    # Post-flight: every pg_dump -Fc starts with the literal "PGDMP" magic.
+                    # An empty file or any other content here means the dump is unusable —
+                    # fail the Job rather than encrypt and publish garbage.
+                    SIZE=$(wc -c < "${DUMP}")
+                    if [ "${SIZE}" -lt 200 ] || ! head -c 5 "${DUMP}" | grep -q '^PGDMP'; then
+                      echo "FATAL: ${db}.dump is ${SIZE} bytes and not a valid pg_dump archive." >&2
+                      exit 1
+                    fi
+                    echo "  ${db}.dump OK (${SIZE} bytes)"
                   done
 
                   # Encrypt with AES-256 using BACKUP_PASSPHRASE from workspace-secrets


### PR DESCRIPTION
## Summary

- The `db-backup` CronJob silently produced **0-byte dumps for 4 days** during the gekko-hetzner-3 outage: `shared-db` was Pending, pg_dump failed to connect, but the `> file` redirect had already created an empty file before pg_dump exited. Job-level `succeeded=true` was reported and `/admin/monitoring` showed no failure.
- Two-layer defense: **pg_isready preflight** (refuses to start when shared-db is unreachable) + **per-dump validation** (size ≥ 200 bytes AND starts with the literal `PGDMP` magic that `pg_dump -Fc` writes as its archive header). Either failure exits the Job non-zero so the dashboard surfaces it.
- Also adds `-u` and `-o pipefail` so missing env vars or piped command failures can no longer be silently swallowed.

No behaviour change in the happy path.

## Test plan

- [x] `task workspace:validate` — kustomize build clean, db-backup CronJob still present
- [x] `task test:all` — BATS unit + manifest + Taskfile dry-run all green (exit 0)
- [ ] Post-merge: `task feature:deploy` to fan out to mentolder + korczewski; verify next `db-backup` Job either succeeds (data path back) or shows up Failed on `/admin/monitoring` (no silent zero-byte backups)

🤖 Generated with [Claude Code](https://claude.com/claude-code)