### PR TITLE
chore(infra): stabilize llm-router, systemtest-outbox, and lego webhook

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -2703,6 +2703,25 @@ tasks:
           --set certManager.namespace=cert-manager \
           --set certManager.serviceAccountName=cert-manager \
           --wait --timeout=120s
+      # Pin the lego webhook to Hetzner CPs. The kube-apiserver runs on host
+      # network of the Hetzner CPs and APIService discovery (`/apis/...`) dials
+      # the webhook pod IP directly. From a Hetzner CP host → home-LAN worker
+      # pod CIDR (e.g. 10.42.6.0/24 on k3w-2), the Flannel tunnel route isn't
+      # reliable, so kube-apiserver times out and APIService goes FailedDiscovery.
+      # Same constraint as CoreDNS / ArgoCD: stay on Hetzner nodes.
+      - |
+        kubectl patch deploy -n cert-manager cert-manager-lego-webhook \
+          --type=merge -p '{
+            "spec":{"template":{"spec":{"affinity":{"nodeAffinity":{
+              "requiredDuringSchedulingIgnoredDuringExecution":{
+                "nodeSelectorTerms":[{"matchExpressions":[{
+                  "key":"kubernetes.io/hostname",
+                  "operator":"In",
+                  "values":["gekko-hetzner-2","gekko-hetzner-3","gekko-hetzner-4","pk-hetzner-4","pk-hetzner-6","pk-hetzner-8"]
+                }]}]
+              }
+            }}}}}
+          }' 2>/dev/null || true
       - echo "✓ cert-manager + lego webhook installed"
       - 'echo "Next: run ''task cert:secret -- <your-ipv64-api-key>'' to store credentials"'
 

--- a/k3d/cronjob-systemtest-cleanup.yaml
+++ b/k3d/cronjob-systemtest-cleanup.yaml
@@ -130,9 +130,25 @@ spec:
   failedJobsHistoryLimit: 3
   jobTemplate:
     spec:
+      # Fail-fast: kube-router NetworkPolicy enforcement on cross-node DNS is
+      # racy for kurzlebige Job-Pods. Without backoffLimit:0, the curl exit-6
+      # ("Couldn't resolve host") cascades into a 5-minute CrashLoopBackOff.
+      backoffLimit: 0
+      activeDeadlineSeconds: 25
       template:
         spec:
-          restartPolicy: OnFailure
+          restartPolicy: Never
+          # Hetzner-only pinning: home-LAN workers see intermittent cross-node
+          # DNS REJECTs from kube-router netpol enforcement. Pinning to the
+          # Hetzner CPs (where CoreDNS lives) sidesteps the gotcha entirely.
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: kubernetes.io/hostname
+                        operator: In
+                        values: [gekko-hetzner-2, gekko-hetzner-3, gekko-hetzner-4, pk-hetzner-4, pk-hetzner-6, pk-hetzner-8]
           securityContext:
             runAsNonRoot: true
             runAsUser: 65534

--- a/k3d/llm-router.yaml
+++ b/k3d/llm-router.yaml
@@ -93,7 +93,13 @@ spec:
           # (or check the live cluster's imageID), then update both tag and digest below.
           # Closes #653.
           image: ghcr.io/berriai/litellm:main-stable@sha256:6c82d338a60e7b273ae46bf1d8db814d2856ae010f96c44eeadde574d3893f76
-          args: ["--config", "/app/config.yaml", "--port", "4000", "--num_workers", "2"]
+          # Single worker: under restricted securityContext (runAsUser=1000,
+          # drop ALL caps, allowPrivilegeEscalation=false), LiteLLM's uvicorn
+          # multi-worker fork loop crashes children immediately on this image
+          # digest. Parent stays alive respawning workers but nothing binds
+          # :4000, so liveness probes (correctly) fail and kubelet SIGTERMs.
+          # PR #695's memory bump was a red herring; root cause is the fork.
+          args: ["--config", "/app/config.yaml", "--port", "4000", "--num_workers", "1"]
           ports:
             - containerPort: 4000
           env:

--- a/k3d/website.yaml
+++ b/k3d/website.yaml
@@ -514,6 +514,12 @@ spec:
     - namespaceSelector:
         matchLabels:
           kubernetes.io/metadata.name: kube-system
+    # kube-router netpol enforcement on cross-node CoreDNS occasionally REJECTs
+    # because the flannel.1 tunnel source IP doesn't match the namespaceSelector
+    # IPSet for short-lived Job pods (see reference_kube_router_hostnet_gotcha).
+    # Adding the pod-CIDR ipBlock makes :53 reachable regardless of selector race.
+    - ipBlock:
+        cidr: 10.42.0.0/16
     ports:
     - port: 53
       protocol: UDP


### PR DESCRIPTION
## Summary

Three independent operational fixes bundled as one infra chore:

- **llm-router crashloop (both clusters):** drop `--num_workers` from 2 to 1. Under the restricted securityContext (`runAsUser=1000`, drop ALL caps, `allowPrivilegeEscalation=false`), LiteLLM's uvicorn multi-worker fork loop crashes children immediately on this image digest. The parent stays alive respawning workers but nothing binds `:4000`, so liveness probes correctly fail and kubelet SIGTERMs. PR #695's memory bump was a red herring.
- **systemtest-outbox flapping (mentolder):** pin to Hetzner CPs via `nodeAffinity` and add `backoffLimit: 0` + `activeDeadlineSeconds: 25` to mirror `meeting-reminders`'s fail-fast pattern. Without affinity the Job lands on home-LAN workers where kube-router netpol enforcement intermittently REJECTs cross-node DNS, producing curl exit 6 + 5-minute CrashLoopBackOff cascades.
- **website allow-dns-egress (kube-router IPSet race):** add `ipBlock: 10.42.0.0/16` egress on port 53 alongside the existing `namespaceSelector`. Short-lived Job pods can miss the selector IPSet because their flannel.1 tunnel source IP doesn't match the namespaceSelector lookup — same gotcha already mitigated for ingress via `allow-pod-cidr-ingress`.
- **lego DNS-solver APIService (mentolder):** add an idempotent `kubectl patch` to `task cert:install` that pins `cert-manager-lego-webhook` to the Hetzner CPs. The APIService is dialled from the kube-apiserver host network, and host→remote-pod-CIDR over Flannel isn't reliable on this cluster; pinning to a Hetzner CP keeps the pod reachable via the local `cni0` bridge.

## Test plan

- [x] `task test:all` (manifest structure + unit + dry-run) — green
- [x] `task workspace:validate` — `✓ Manifests are valid`
- [ ] Post-merge: `task feature:deploy` (workspace + post-setup on both prod clusters)
- [ ] Post-merge: verify llm-router pod stays Ready on both clusters
- [ ] Post-merge on mentolder: run `task cert:install` to apply the lego-webhook nodeAffinity patch, then confirm `kubectl get apiservice v1alpha1.lego.dns-solver` shows `Available=True`
- [ ] Observe next 3 `systemtest-outbox` runs end Complete (mentolder)

## Out of scope

- `traefik-qgksc` crashloop on `k3s-1` is **not** an ACME-state-corruption issue. Reproduced after a pod delete — the panic is a Go runtime stack-overflow inside `net.(*ipv6ZoneCache).name()` that fires only on that node. 8/9 DS replicas remain healthy and ingress is unaffected, so this needs a separate node-level investigation (likely a BR ticket).
- Orphan `default/claude-code-mcp-ops-5496bdb4bc` Deployment + Service on mentolder were live-deleted (no manifest in the repo to remove).

🤖 Generated with [Claude Code](https://claude.com/claude-code)