### PR TITLE
feat(brainstorm): sish tunnel + wss patch for brainstorm.mentolder.de

### DIFF
--- a/.claude/skills/dev-flow/SKILL.md
+++ b/.claude/skills/dev-flow/SKILL.md
@@ -38,6 +38,7 @@ Slug ist kurz und beschreibend. KEIN BR-* in den Branchnamen — das gehört in 
 ### Feature-Pfad
 
 1. **Brainstorming.** Rufe `superpowers:brainstorming` auf. Ergibt eine Spec in `docs/superpowers/specs/`.
+   - Visual-Companion-Artefakte (HTML-Mockups, Diagramme, Vergleichsbilder) werden vom lokalen brainstorming-Server ausgeliefert. Damit Patrick sie im Browser durchklicken kann statt `xdg-open` lokal zu fahren, siehe Sektion **Visual Companion via brainstorm.mentolder.de** unten.
 2. **Plan.** Rufe `superpowers:writing-plans` auf. Ergibt einen Plan in `docs/superpowers/plans/`.
 3. **Frontmatter-Hook.** Führe aus: `bash scripts/plan-frontmatter-hook.sh <plan-datei>` (Pflicht laut CLAUDE.md).
 4. **Implementation.** Bevorzugt: `superpowers:subagent-driven-development` (parallele Agents, schnell). Alternative: `superpowers:executing-plans` (sequenziell).
@@ -96,6 +97,48 @@ Slug ist kurz und beschreibend. KEIN BR-* in den Branchnamen — das gehört in 
 4. **PR.** Titel: `chore(<scope>): <kurze-beschreibung>`. Body: kurzes `## Summary` (1-2 Bullets) + `## Test plan` (was du gelaufen bist).
 5. **Auto-Merge** wenn CI grün ist.
 6. **Post-Merge.** Folge der Sektion **Post-Merge Deploy** unten.
+
+## Visual Companion via brainstorm.mentolder.de
+
+Der `superpowers:brainstorming`-Server bindet per Default `127.0.0.1:<random-port>` und schreibt Klicks aus dem Browser über WebSocket nach `$STATE_DIR/events`. Damit der Klick-Loop auch im Browser des Users funktioniert (und nicht nur auf `localhost`), gibt es eine sish-Reverse-Tunnel-Bridge auf dem mentolder-Cluster.
+
+### Setup einmalig
+
+```bash
+task brainstorm:firewall:open       # ufw 32223/tcp auf gekko-hetzner-2 öffnen
+# Eigenen Public-Key in environments/.secrets/mentolder.yaml unter
+# DEV_SISH_AUTHORIZED_KEYS ergänzen (gleicher Key-Pool wie dev-tunnel).
+task env:seal ENV=mentolder
+task brainstorm:_materialise-keys   # ConfigMap im Cluster aktualisieren + sish rollen
+```
+
+### Pro Session
+
+```bash
+# Terminal A (oder Hintergrund): brainstorming-Server zeigt Port im JSON-Output.
+# Terminal B: Tunnel hochziehen — terminal MUSS offen bleiben für die Session.
+task brainstorm:publish -- <localport>
+# → "Publishing localhost:<port> as https://brainstorm.mentolder.de — leave this terminal open."
+```
+
+Der Browser zeigt dann den Inhalt von `$SCREEN_DIR/*.html` unter `https://brainstorm.mentolder.de`. Klicks gehen per `wss://` durch den Tunnel zurück zum lokalen Server und landen in `$STATE_DIR/events`, das Claude beim nächsten Turn liest.
+
+### `ws://`→`wss://` Auto-Patch
+
+Der upstream-`helper.js` aus dem superpowers-Plugin nutzt `ws://`, was Browser über HTTPS als Mixed Content blocken. `scripts/superpowers-helper-patch.sh` patcht das idempotent zu protocol-aware `wss://`. Ein SessionStart-Hook in `.claude/settings.json` reappliedt nach jeder Claude-Session, falls ein superpowers-Sync den Patch überschreibt. Manuell bei Bedarf:
+
+```bash
+bash scripts/superpowers-helper-patch.sh           # apply
+bash scripts/superpowers-helper-patch.sh --check   # exit 1 if any helper.js still unpatched
+```
+
+### Diagnose
+
+```bash
+task brainstorm:status   # Pod-Status + curl gegen brainstorm.mentolder.de
+```
+
+`502 Bad Gateway` ohne aktiven Tunnel ist erwartet (sish hat kein Backend). `200` mit Waiting-Page = Tunnel steht.
 
 ## Post-Merge Deploy
 

--- a/Taskfile.brainstorm.yml
+++ b/Taskfile.brainstorm.yml
@@ -1,0 +1,99 @@
+# Taskfile.brainstorm.yml
+# ─────────────────────────────────────────────────────────────────────────────
+# brainstorm.mentolder.de — reverse-SSH-tunnel broker for the brainstorming
+# visual-companion choice loop. Wraps `ssh -R` against the in-cluster sish
+# Deployment (k3d/brainstorm-sish.yaml) so the operator can publish a local
+# port at https://brainstorm.${PROD_DOMAIN} without poking holes in the
+# home-network NAT.
+#
+# All tasks here pin to the mentolder prod cluster — there is no brainstorm
+# broker on korczewski. ENV= is forced to "mentolder" via the vars block.
+# ─────────────────────────────────────────────────────────────────────────────
+version: "3"
+
+vars:
+  ENV: mentolder
+  CTX_PROD: mentolder
+  NS_PROD: workspace
+  # The sish Deployment is pinned (nodeSelector) to this host; the ufw rule
+  # and the public SSH NodePort target the same machine.
+  NODE: gekko-hetzner-2
+  SSH_PORT: 32223
+
+tasks:
+
+  _materialise-keys:
+    internal: true
+    desc: "[brainstorm] Push DEV_SISH_AUTHORIZED_KEYS into the brainstorm-sish ConfigMap and roll sish"
+    cmds:
+      - |
+        set -euo pipefail
+        source scripts/env-resolve.sh "{{.ENV}}"
+        SECRETS_FILE="environments/.secrets/{{.ENV}}.yaml"
+        if [[ ! -f "$SECRETS_FILE" ]]; then
+          echo "Missing $SECRETS_FILE — run task env:generate ENV={{.ENV}} first." >&2
+          exit 1
+        fi
+        AUTHKEYS=$(yq -r '.DEV_SISH_AUTHORIZED_KEYS // ""' "$SECRETS_FILE")
+        if [[ -z "$AUTHKEYS" ]]; then
+          echo "DEV_SISH_AUTHORIZED_KEYS empty in $SECRETS_FILE — add at least one pubkey before publishing tunnels." >&2
+          exit 1
+        fi
+        kubectl --context {{.CTX_PROD}} -n {{.NS_PROD}} create configmap brainstorm-sish-authorized-keys \
+          --from-literal=authorized_keys="$AUTHKEYS" \
+          --dry-run=client -o yaml | kubectl --context {{.CTX_PROD}} -n {{.NS_PROD}} apply -f -
+        kubectl --context {{.CTX_PROD}} -n {{.NS_PROD}} rollout restart deploy/brainstorm-sish
+        kubectl --context {{.CTX_PROD}} -n {{.NS_PROD}} rollout status deploy/brainstorm-sish --timeout=60s
+
+  publish:
+    desc: "[brainstorm] Publish a local port at https://brainstorm.${PROD_DOMAIN}. Usage: task brainstorm:publish -- <localport>"
+    cmds:
+      - |
+        set -euo pipefail
+        source scripts/env-resolve.sh "{{.ENV}}"
+        PORT=$(echo "{{.CLI_ARGS}}" | awk '{print $1}')
+        if [[ -z "$PORT" ]]; then
+          echo "Usage: task brainstorm:publish -- <localport>" >&2; exit 2
+        fi
+        # Resolve a target host for the SSH connection:
+        #   1. BRAINSTORM_NODE_IP if set (escape hatch — not in schema today)
+        #   2. TURN_PUBLIC_IP    — gekko-hetzner-2 is also TURN_NODE so its
+        #                          public IP is already authoritative there.
+        #   3. {{.NODE}}         — DNS fallback for the same host.
+        TARGET="${BRAINSTORM_NODE_IP:-${TURN_PUBLIC_IP:-{{.NODE}}}}"
+        echo "Publishing localhost:$PORT as https://brainstorm.$PROD_DOMAIN — leave this terminal open."
+        echo "  ssh -p {{.SSH_PORT}} -R brainstorm:80:localhost:$PORT tunnel@$TARGET"
+        exec ssh -p {{.SSH_PORT}} -N \
+          -o ServerAliveInterval=30 \
+          -o ServerAliveCountMax=3 \
+          -o ExitOnForwardFailure=yes \
+          -R "brainstorm:80:localhost:$PORT" \
+          "tunnel@$TARGET"
+
+  firewall:open:
+    desc: "[brainstorm] Open ufw tcp/{{.SSH_PORT}} on {{.NODE}} so operators can reach the sish NodePort"
+    cmds:
+      - |
+        set -euo pipefail
+        ssh "root@{{.NODE}}" "ufw allow {{.SSH_PORT}}/tcp comment 'brainstorm-sish'"
+        ssh "root@{{.NODE}}" "ufw reload && ufw status numbered | grep {{.SSH_PORT}} || true"
+
+  status:
+    desc: "[brainstorm] Show sish pod status and probe the public Ingress"
+    cmds:
+      - |
+        set -euo pipefail
+        source scripts/env-resolve.sh "{{.ENV}}"
+        kubectl --context {{.CTX_PROD}} -n {{.NS_PROD}} get pod -l app=brainstorm-sish -o wide
+        kubectl --context {{.CTX_PROD}} -n {{.NS_PROD}} get svc brainstorm brainstorm-sish 2>/dev/null || true
+        kubectl --context {{.CTX_PROD}} -n {{.NS_PROD}} get ingress brainstorm 2>/dev/null || true
+        echo "── HTTPS probe ────────────────────────────────────────────"
+        curl -sSI --max-time 5 "https://brainstorm.${PROD_DOMAIN}/" || true
+
+  cleanup-scratch:
+    desc: "[brainstorm] Delete the parallel-session's ad-hoc brainstorm-proxy Pod (Service+Ingress are reused by the new manifest)"
+    cmds:
+      - |
+        kubectl --context {{.CTX_PROD}} -n {{.NS_PROD}} delete pod brainstorm-proxy --ignore-not-found
+        # Do NOT delete svc/brainstorm or ingress/brainstorm — the new manifest
+        # owns those names and `kubectl apply` reconciles them in place.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -15,6 +15,11 @@ includes:
   dev:
     taskfile: ./Taskfile.dev-stack.yml
     dir: .
+  # brainstorm.mentolder.de — reverse-SSH-tunnel broker (sish) for the
+  # brainstorming visual companion. See Taskfile.brainstorm.yml.
+  brainstorm:
+    taskfile: ./Taskfile.brainstorm.yml
+    dir: .
 
 vars:
   CLUSTER_NAME: dev

--- a/docs/superpowers/plans/2026-05-13-brainstorm-tunnel.md
+++ b/docs/superpowers/plans/2026-05-13-brainstorm-tunnel.md
@@ -1,0 +1,96 @@
+---
+title: Plan — brainstorm.mentolder.de choice transmission
+domains: []
+status: active
+pr_number: null
+---
+
+# Plan — brainstorm.mentolder.de choice transmission
+
+## Goal
+
+Make the brainstorming visual-companion choice loop work end-to-end via
+`https://brainstorm.mentolder.de`: HTML pushed by Claude → Patrick clicks in
+browser → WebSocket event flows back through the cluster → events file updated
+on Patrick's local machine → Claude reads on the next turn.
+
+## Current state
+
+- Prod-mentolder cluster has an ad-hoc scratch setup (NOT in git) created by a
+  parallel Claude session: `brainstorm-proxy` Pod (`socat TCP-LISTEN:8080,fork
+  → 178.104.169.206:59457`), `brainstorm` Service :80, `brainstorm` Ingress for
+  `brainstorm.mentolder.de` with `mentolder-tls`.
+- DNS works for `brainstorm.mentolder.de` (wildcard `*.mentolder.de` cert
+  covers it; HTTPS request reaches the socat pod and returns empty because the
+  upstream home-server is down).
+- The brainstorm helper.js hardcodes `WS_URL = 'ws://' + window.location.host`
+  (helper.js:2). When the page is served over HTTPS, Chrome/Firefox block the
+  insecure WebSocket as mixed content — clicks never reach the server.
+- The brainstorm server binds `127.0.0.1` by default (server.cjs:77), but with
+  the chosen sish/SSH-`-R` model the loopback bind is fine.
+
+## Design
+
+**Transport:** Add a dedicated sish reverse-SSH-tunnel broker to the prod
+mentolder cluster (workspace ns), same proven mechanism as `dev-stack/sish.yaml`.
+Sish listens on SSH NodePort 32223 (host ufw-opened on `gekko-hetzner-2`) and
+HTTP :80 in-cluster. Traefik routes `brainstorm.mentolder.de` to sish:80.
+Operator runs `task brainstorm:publish -- <localport>`, which wraps:
+
+```bash
+ssh -p 32223 -N -R "brainstorm:80:localhost:<localport>" tunnel@${BRAINSTORM_NODE_IP}
+```
+
+**ws://→wss:// fix:** Patch
+`~/.claude/plugins/cache/claude-plugins-official/superpowers/<ver>/skills/brainstorming/scripts/helper.js`
+to derive the protocol from `window.location.protocol`. Idempotent script in
+`scripts/superpowers-helper-patch.sh`, wired as a SessionStart hook in
+`.claude/settings.json` so plugin re-syncs don't silently break the loop.
+
+**Cleanup:** Once the manifest-tracked sish is live, delete the scratch
+`brainstorm-proxy` Pod + `brainstorm` Service + `brainstorm` Ingress (the new
+manifest re-creates Service + Ingress under git control).
+
+## Files
+
+1. `k3d/brainstorm-sish.yaml` (new) — sish Deployment + Service + Ingress.
+   Pinned to `gekko-hetzner-2` nodeSelector (matches existing scratch pod).
+   Args: `--bind-hosts=brainstorm.${PROD_DOMAIN}`, `--bind-random-subdomains=false`,
+   `--force-requested-subdomains=true`, `--authentication=true`,
+   `--authentication-keys-directory=/keys`.
+   ConfigMap `brainstorm-sish-authorized-keys` materialised by Taskfile (reads
+   `DEV_SISH_AUTHORIZED_KEYS` from `environments/.secrets/mentolder.yaml`).
+2. `prod-mentolder/kustomization.yaml` — add the new resource.
+3. `Taskfile.brainstorm.yml` (new) — `publish`, `firewall:open`, `status`,
+   `_materialise-keys` (mirrors the dev-stack pattern).
+4. `Taskfile.yml` — include `Taskfile.brainstorm.yml` under namespace `brainstorm`.
+5. `scripts/superpowers-helper-patch.sh` (new) — globs all
+   `~/.claude/plugins/cache/**/superpowers/**/skills/brainstorming/scripts/helper.js`
+   and applies an idempotent sed-style patch.
+6. `.claude/settings.json` — SessionStart hook invoking the patcher.
+7. `.claude/skills/dev-flow/SKILL.md` — updated Visual Companion section
+   (remove the stale static-file alternative, document the publish step).
+
+## Tests / verify
+
+- `task workspace:validate` — manifests resolve.
+- `task test:all` — BATS + dry-run.
+- After deploy: `task brainstorm:status ENV=mentolder` shows sish pod ready and
+  ingress responding 502 (no tunnel yet, expected).
+- After publish: `curl -I https://brainstorm.mentolder.de/` returns 200 with
+  the waiting page; browser opens, helper.js loads with `wss://` and the
+  WebSocket Upgrade succeeds; clicks land in `$STATE_DIR/events`.
+
+## Risks
+
+- Hetzner cloud firewall may also block 32223/tcp on top of ufw — verify after
+  the ufw rule is applied; if so, add cloud-init rule like livekit.
+- SSH `-R` connection idle-timeouts: sish is configured with
+  `--idle-connection-timeout=24h`; for shorter sessions a `ServerAliveInterval`
+  flag on the client side is in the wrapper task.
+- Plugin cache wipe after a `claude` upgrade: SessionStart hook re-applies the
+  patch automatically.
+- The existing scratch resources must be deleted by hand the first time (the
+  new manifest replaces Service/Ingress with the same names — kubectl apply
+  reconciles, but the scratch `brainstorm-proxy` Pod stays orphaned and must
+  be deleted explicitly).

--- a/k3d/brainstorm-sish.yaml
+++ b/k3d/brainstorm-sish.yaml
@@ -1,0 +1,141 @@
+# ════════════════════════════════════════════════════════════════════
+# brainstorm-sish — reverse-SSH tunnel broker for brainstorm.${PROD_DOMAIN}
+# ════════════════════════════════════════════════════════════════════
+# Mirrors k3d/dev-stack/sish.yaml but pinned to a single hostname and
+# exposed on a dedicated NodePort (32223) so operators can publish
+# their local brainstorming visual-companion at
+# https://brainstorm.${PROD_DOMAIN}.
+#
+# authorized_keys is materialised at deploy time from
+# environments/.secrets/mentolder.yaml → DEV_SISH_AUTHORIZED_KEYS
+# (see task brainstorm:_materialise-keys in Taskfile.brainstorm.yml).
+# Lives in the prod-mentolder overlay only — there is no brainstorm
+# broker on korczewski.
+# ════════════════════════════════════════════════════════════════════
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: brainstorm-sish-authorized-keys
+data:
+  authorized_keys: |
+    # placeholder — overwritten by `task brainstorm:_materialise-keys`
+    # from the unsealed value of DEV_SISH_AUTHORIZED_KEYS at apply time.
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: brainstorm-sish
+  labels:
+    app: brainstorm-sish
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: brainstorm-sish
+  template:
+    metadata:
+      labels:
+        app: brainstorm-sish
+    spec:
+      # Pin to gekko-hetzner-2 — same node the scratch brainstorm-proxy
+      # used and the host whose ufw the firewall:open task targets.
+      nodeSelector:
+        kubernetes.io/hostname: gekko-hetzner-2
+      containers:
+        - name: sish
+          image: antoniomika/sish:latest
+          args:
+            - --domain=${PROD_DOMAIN}
+            - --ssh-address=:2222
+            - --http-address=:80
+            - --authentication=true
+            - --authentication-keys-directory=/keys
+            - --bind-random-subdomains=false
+            - --bind-random-ports=false
+            - --force-requested-subdomains=true
+            - --idle-connection-timeout=24h
+            - --service-console=false
+            - --tcp-aliases=false
+            - --bind-hosts=brainstorm.${PROD_DOMAIN}
+          ports:
+            - containerPort: 2222
+              name: ssh
+            - containerPort: 80
+              name: http
+          volumeMounts:
+            - name: keys
+              mountPath: /keys
+              readOnly: true
+          resources:
+            requests:
+              memory: 64Mi
+              cpu: 50m
+            limits:
+              memory: 256Mi
+              cpu: 500m
+      volumes:
+        - name: keys
+          configMap:
+            name: brainstorm-sish-authorized-keys
+            items:
+              - key: authorized_keys
+                path: authorized_keys
+---
+# NodePort Service — exposes the SSH endpoint on every node at :32223 so
+# `ssh -R` from the operator's laptop has a stable target. The HTTP port
+# is reachable in-cluster only; Traefik fronts it via the Ingress below.
+apiVersion: v1
+kind: Service
+metadata:
+  name: brainstorm-sish
+spec:
+  type: NodePort
+  selector:
+    app: brainstorm-sish
+  ports:
+    - name: ssh
+      port: 2222
+      targetPort: 2222
+      nodePort: 32223
+    - name: http
+      port: 80
+      targetPort: 80
+---
+# ClusterIP alias service — the Ingress backend references this name so
+# that the existing scratch `brainstorm` Service can be deleted and
+# replaced under git control. Selector matches the same sish pod.
+apiVersion: v1
+kind: Service
+metadata:
+  name: brainstorm
+spec:
+  type: ClusterIP
+  selector:
+    app: brainstorm-sish
+  ports:
+    - name: http
+      port: 80
+      targetPort: 80
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: brainstorm
+  annotations:
+    traefik.ingress.kubernetes.io/router.middlewares: "${WORKSPACE_NAMESPACE}-redirect-https@kubernetescrd,${WORKSPACE_NAMESPACE}-hsts-headers@kubernetescrd,${WORKSPACE_NAMESPACE}-security-headers@kubernetescrd"
+spec:
+  tls:
+    - hosts:
+        - brainstorm.${PROD_DOMAIN}
+      secretName: ${TLS_SECRET_NAME}
+  rules:
+    - host: brainstorm.${PROD_DOMAIN}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: brainstorm
+                port:
+                  number: 80

--- a/prod-mentolder/kustomization.yaml
+++ b/prod-mentolder/kustomization.yaml
@@ -13,6 +13,8 @@ resources:
   - oauth2-proxy-dev-middleware.yaml
   - dev-ingress.yaml
   - dev-db-refresh-cron.yaml
+  # ── brainstorm.mentolder.de reverse-SSH broker (sish) ─────────────
+  - ../k3d/brainstorm-sish.yaml
 
 # Override realm with mentolder-specific config
 configMapGenerator:

--- a/scripts/superpowers-helper-patch.sh
+++ b/scripts/superpowers-helper-patch.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# scripts/superpowers-helper-patch.sh — make the brainstorming visual-companion
+# WebSocket protocol-aware so the click loop survives when the page is served
+# over HTTPS (mixed-content blocks `ws://` from `https://` pages).
+#
+# Why: superpowers' brainstorming/scripts/helper.js hardcodes
+#   const WS_URL = 'ws://' + window.location.host;
+# Through https://brainstorm.mentolder.de the browser refuses the insecure
+# upgrade and the click never reaches the server. Patching to a
+# protocol-aware expression lets the loop work over both http and https.
+#
+# Idempotent: re-runs only re-apply against files that still have the old
+# hardcoded `ws://` literal. Safe to wire as a SessionStart hook.
+#
+# Usage:
+#   bash scripts/superpowers-helper-patch.sh         # patch + report
+#   bash scripts/superpowers-helper-patch.sh --check # exit 1 if any file unpatched
+
+set -euo pipefail
+
+MODE="${1:-apply}"
+
+OLD_LINE="const WS_URL = 'ws://' + window.location.host;"
+NEW_LINE="const WS_URL = (window.location.protocol === 'https:' ? 'wss://' : 'ws://') + window.location.host;"
+
+shopt -s nullglob globstar
+
+patched=0
+already=0
+unpatched=0
+missing_root=1
+
+for root in \
+  "$HOME/.claude/plugins/cache" \
+  "$HOME/.config/claude/plugins/cache"
+do
+  [[ -d "$root" ]] || continue
+  missing_root=0
+  for helper in "$root"/**/superpowers/**/skills/brainstorming/scripts/helper.js; do
+    [[ -f "$helper" ]] || continue
+    if grep -qF "$NEW_LINE" "$helper"; then
+      already=$((already+1))
+      continue
+    fi
+    if ! grep -qF "$OLD_LINE" "$helper"; then
+      # Some other unexpected content — don't touch.
+      echo "skip (unrecognised content): $helper" >&2
+      unpatched=$((unpatched+1))
+      continue
+    fi
+    if [[ "$MODE" == "--check" ]]; then
+      echo "unpatched: $helper" >&2
+      unpatched=$((unpatched+1))
+      continue
+    fi
+    # In-place replacement, no backup file (the plugin cache is regenerated
+    # from upstream on every superpowers sync — there's nothing to roll back
+    # to that the upstream tarball doesn't already hold).
+    sed -i "s|${OLD_LINE}|${NEW_LINE}|" "$helper"
+    patched=$((patched+1))
+    echo "patched: $helper"
+  done
+done
+
+if [[ "$missing_root" -eq 1 ]]; then
+  echo "no claude plugin cache directories found — nothing to patch" >&2
+  exit 0
+fi
+
+if [[ "$MODE" == "--check" ]]; then
+  if [[ "$unpatched" -gt 0 ]]; then
+    echo "${unpatched} helper.js file(s) still need patching — run without --check" >&2
+    exit 1
+  fi
+  echo "all helper.js files are patched (${already} ok)"
+  exit 0
+fi
+
+echo "superpowers helper.js: ${patched} patched, ${already} already-ok, ${unpatched} skipped"


### PR DESCRIPTION
## Summary
- Replace the parallel-session's in-cluster scratch socat-to-home pod with a manifest-tracked sish reverse-SSH broker on the mentolder cluster, terminating `brainstorm.mentolder.de` via Traefik on the existing `*.mentolder.de` wildcard cert.
- Add `task brainstorm:publish -- <localport>` so any Claude session can expose its local brainstorming visual-companion server through `ssh -R` against NodePort 32223 — no home port-forward or static home IP needed.
- Fix the actual reason clicks never made it back: `superpowers` ships `helper.js` with a hardcoded `ws://`, which browsers block as mixed content under HTTPS. `scripts/superpowers-helper-patch.sh` rewrites it to protocol-aware `wss://` idempotently, and a SessionStart hook re-applies after plugin syncs.
- Document the full loop in `.claude/skills/dev-flow/SKILL.md` (one-time setup + per-session usage + diagnose).

## Test plan
- [x] `task workspace:validate ENV=mentolder` — manifests resolve to a valid kustomize output
- [x] `task test:all` — BATS unit + manifest tests + Taskfile dry-run all green
- [x] `bash scripts/superpowers-helper-patch.sh --check` — both 5.0.7 + 5.1.0 helper.js files patched
- [ ] Post-merge manual smoke: deploy → open ufw → materialise keys → `task brainstorm:publish -- <port>` → click an option in the browser → confirm event in `$STATE_DIR/events`

Plan: `docs/superpowers/plans/2026-05-13-brainstorm-tunnel.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)