### PR TITLE
chore(brainstorm): allow ingress to sish NodePort

### DIFF
--- a/k3d/brainstorm-sish.yaml
+++ b/k3d/brainstorm-sish.yaml
@@ -139,3 +139,28 @@ spec:
                 name: brainstorm
                 port:
                   number: 80
+---
+# Allow ingress from anywhere to sish — the workspace ns runs kube-router
+# netpol with default-deny-ingress, so without this rule the public NodePort
+# 32223 (SSH) gets RST'd before reaching the pod and operators cannot publish
+# tunnels at all. HTTP :80 is also opened so cluster-internal Traefik can
+# reach the pod for the browser side of the loop.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-brainstorm-sish-ingress
+spec:
+  podSelector:
+    matchLabels:
+      app: brainstorm-sish
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+      ports:
+        - port: 2222
+          protocol: TCP
+        - port: 80
+          protocol: TCP


### PR DESCRIPTION
## Summary
- Follow-up to #702. The workspace namespace runs kube-router netpol with default-deny-ingress, so without an explicit allow-policy the public NodePort 32223 was RST'd before reaching the brainstorm-sish pod (tcpdump confirmed the SYN arrived, then kube-router rejected).
- Add `allow-brainstorm-sish-ingress` NetworkPolicy permitting tcp/2222 + tcp/80 from `0.0.0.0/0` so operators can actually open `ssh -R` tunnels at `brainstorm.mentolder.de`.

## Test plan
- [x] `kubectl apply` to mentolder cluster → policy created
- [x] `nc -vz -w 5 178.104.169.206 32223` from outside the cluster → succeeded (was `Connection refused` before the policy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)