### PR TITLE
chore(infra): pin antoniomika/sish to v2.22.1

### DIFF
--- a/k3d/brainstorm-sish.yaml
+++ b/k3d/brainstorm-sish.yaml
@@ -43,7 +43,7 @@ spec:
         kubernetes.io/hostname: gekko-hetzner-2
       containers:
         - name: sish
-          image: antoniomika/sish:latest
+          image: antoniomika/sish:v2.22.1
           args:
             - --domain=${PROD_DOMAIN}
             - --ssh-address=:2222

--- a/k3d/dev-stack/sish.yaml
+++ b/k3d/dev-stack/sish.yaml
@@ -32,7 +32,7 @@ spec:
     spec:
       containers:
         - name: sish
-          image: antoniomika/sish:latest
+          image: antoniomika/sish:v2.22.1
           args:
             - --domain=${DEV_DOMAIN}
             - --ssh-address=:2222


### PR DESCRIPTION
## Summary
- Pins `antoniomika/sish` from `:latest` to `v2.22.1` in both `k3d/brainstorm-sish.yaml` and `k3d/dev-stack/sish.yaml`
- Makes deployments reproducible and prevents uncontrolled updates on pod restart

## Test plan
- [x] `task workspace:validate` — manifests valid
- No runtime-level test available; image tag change only

Closes #707

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>