### PR TITLE
feat(dev-flow): link PR to ticket + archive plan in postgres

### DIFF
--- a/.claude/skills/dev-flow-execute/SKILL.md
+++ b/.claude/skills/dev-flow-execute/SKILL.md
@@ -139,6 +139,35 @@ Co-Authored-By: <model-name>
 
 ---
 
+## Schritt 5.5: PR-Link im Ticket speichern
+
+Falls `$TICKET_ID` gesetzt, direkt nach dem PR-Erstellen:
+
+```bash
+PR_NUM=$(gh pr view --json number -q '.number')
+
+PGPOD=$(kubectl get pod -n workspace --context mentolder \
+  -l app=shared-db -o name | head -1)
+
+TICKET_UUID=$(kubectl exec "$PGPOD" -n workspace --context mentolder -- \
+  psql -U website -d website -At -c \
+  "SELECT id FROM tickets.tickets WHERE external_id = '$TICKET_ID';")
+
+kubectl exec "$PGPOD" -n workspace --context mentolder -- \
+  psql -U website -d website -c \
+  "INSERT INTO tickets.ticket_links (from_id, kind, pr_number)
+   SELECT '$TICKET_UUID', 'pr', $PR_NUM
+   WHERE NOT EXISTS (
+     SELECT 1 FROM tickets.ticket_links
+     WHERE from_id = '$TICKET_UUID' AND kind = 'pr' AND pr_number = $PR_NUM
+   );"
+```
+
+- `to_id` bleibt NULL (kein NOT NULL-Constraint auf der Spalte).
+- `WHERE NOT EXISTS` macht den Insert idempotent ohne UNIQUE-Constraint.
+
+---
+
 ## Schritt 6: Auto-Merge wenn CI grün
 
 ---
@@ -164,7 +193,7 @@ kubectl exec "$PGPOD" -n workspace --context mentolder -- \
 
    INSERT INTO tickets.ticket_comments (ticket_id, body, visibility)
    SELECT id,
-     'PR #$PR_NUM merged. Plan executed: docs/superpowers/plans/<slug>.md',
+     'PR #$PR_NUM merged. Plan archived to tickets.ticket_plans in Postgres.',
      'internal'
    FROM tickets.tickets WHERE external_id = '$TICKET_ID';"
 
@@ -173,17 +202,49 @@ echo "Ticket $TICKET_ID → done ($RESOLUTION)"
 
 ---
 
-## Schritt 7: Plan archivieren
+## Schritt 7: Plan in Postgres archivieren + Datei löschen
 
-Nach erfolgreichem Merge den Plan in `executed/` verschieben:
+Falls `$TICKET_ID` gesetzt und `$PLAN_FILE` vorhanden:
 
 ```bash
-mkdir -p docs/superpowers/plans/executed
-mv docs/superpowers/plans/<slug>.md docs/superpowers/plans/executed/
-git add docs/superpowers/plans/
-git commit -m "chore(plans): mark <slug> as executed"
+PLAN_FILE="docs/superpowers/plans/<slug>.md"
+SLUG="<slug>"
+BRANCH=$(git branch --show-current)
+PR_NUM=$(gh pr view --json number -q '.number' 2>/dev/null || echo "")
+
+PGPOD=$(kubectl get pod -n workspace --context mentolder \
+  -l app=shared-db -o name | head -1)
+
+TICKET_UUID=$(kubectl exec "$PGPOD" -n workspace --context mentolder -- \
+  psql -U website -d website -At -c \
+  "SELECT id FROM tickets.tickets WHERE external_id = '$TICKET_ID';")
+
+PR_NUM_SQL=$([ -z "$PR_NUM" ] && echo "NULL" || echo "$PR_NUM")
+
+# SQL in temp-Datei schreiben — verhindert Shell-Expansion des Plan-Inhalts
+TMPFILE=$(mktemp /tmp/plan-archive-XXXXXX.sql)
+{
+  printf "INSERT INTO tickets.ticket_plans (ticket_id, slug, branch, content, pr_number)\nVALUES (\n  '%s',\n  '%s',\n  '%s',\n  \$plan\$" \
+    "$TICKET_UUID" "$SLUG" "$BRANCH"
+  cat "$PLAN_FILE"
+  printf "\$plan\$,\n  %s\n);\n" "$PR_NUM_SQL"
+} > "$TMPFILE"
+
+kubectl exec -i "$PGPOD" -n workspace --context mentolder -- \
+  psql -U website -d website -v ON_ERROR_STOP=1 < "$TMPFILE"
+
+rm "$TMPFILE"
+
+# Datei löschen (nicht nach executed/ verschieben)
+rm "$PLAN_FILE"
+git add "$PLAN_FILE"
+git commit -m "chore(plans): archive $SLUG → postgres [$TICKET_ID]"
 git push
 ```
+
+Falls `$TICKET_ID` leer (Chore ohne Ticket): SQL-Archivierung überspringen — nur `rm "$PLAN_FILE"` + commit.
+
+**Hinweis Dollar-Quoting:** `$plan$...$plan$` ist psql-Dollar-Quoting; sicher für beliebigen Markdown-Inhalt, solange der Plan selbst nicht den String `$plan$` enthält (praktisch ausgeschlossen).
 
 ---
 

--- a/docs/superpowers/plans/2026-05-14-dev-flow-pr-link-plan-archive.md
+++ b/docs/superpowers/plans/2026-05-14-dev-flow-pr-link-plan-archive.md
@@ -1,0 +1,310 @@
+---
+ticket_id: T000290
+title: Dev-Flow PR-Link + Plan-Archiv in Postgres
+domains: [skills]
+status: active
+pr_number: null
+---
+
+# Dev-Flow PR-Link + Plan-Archiv in Postgres — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Zwei Lücken in `dev-flow-execute` schließen: (1) GitHub-PR-Nummer nach PR-Erstellung in `tickets.ticket_links` speichern; (2) Plan-Markdown nach Merge in Postgres (`tickets.ticket_plans`) archivieren und die `.md`-Datei löschen.
+
+**Architecture:** Einmalige Schema-Migration legt `tickets.ticket_plans` an. `dev-flow-execute/SKILL.md` bekommt einen neuen Block nach Schritt 5 (PR-Link) und Schritt 7 wird durch Postgres-Archivierung ersetzt. Kein Anwendungscode, keine neuen Abhängigkeiten — nur Skill-Text + SQL.
+
+**Tech Stack:** `kubectl exec psql` gegen mentolder-Cluster, `gh` CLI, Bash.
+
+**Spec reference:** `docs/superpowers/specs/2026-05-14-dev-flow-pr-link-plan-archive-design.md`
+
+**Branch:** `feature/dev-flow-pr-link-plan-archive`
+
+---
+
+## Pre-flight
+
+- [ ] **Worktree:** bereits aktiv auf Branch `feature/dev-flow-pr-link-plan-archive`
+- [ ] **Cluster erreichbar:** `kubectl get pod -n workspace --context mentolder -l app=shared-db` gibt mindestens einen Pod zurück
+
+---
+
+## Task 1: Schema-Migration — `tickets.ticket_plans` anlegen
+
+**Files:**
+- Kein File: Migration direkt gegen Cluster-DB ausführen
+
+- [ ] **Schritt 1: Tabelle anlegen**
+
+```bash
+PGPOD=$(kubectl get pod -n workspace --context mentolder \
+  -l app=shared-db -o name | head -1)
+
+kubectl exec "$PGPOD" -n workspace --context mentolder -- \
+  psql -U website -d website -v ON_ERROR_STOP=1 -c "
+CREATE TABLE IF NOT EXISTS tickets.ticket_plans (
+  id          BIGSERIAL PRIMARY KEY,
+  ticket_id   UUID        NOT NULL REFERENCES tickets.tickets(id),
+  slug        TEXT        NOT NULL,
+  branch      TEXT,
+  content     TEXT        NOT NULL,
+  pr_number   INTEGER,
+  archived_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+"
+```
+
+Erwartete Ausgabe: `CREATE TABLE`
+
+- [ ] **Schritt 2: Tabelle verifizieren**
+
+```bash
+kubectl exec "$PGPOD" -n workspace --context mentolder -- \
+  psql -U website -d website -c "\d tickets.ticket_plans"
+```
+
+Erwartete Ausgabe: Tabelle mit Spalten `id, ticket_id, slug, branch, content, pr_number, archived_at`.
+
+- [ ] **Schritt 3: Commit (kein Code-File — Migration-Nachweis in Commit-Message)**
+
+```bash
+git commit --allow-empty -m "chore(db): create tickets.ticket_plans on mentolder cluster"
+```
+
+---
+
+## Task 2: Schritt 5.5 in SKILL.md einfügen — PR-Link in ticket_links
+
+**Files:**
+- Modify: `.claude/skills/dev-flow-execute/SKILL.md` (nach dem `---` hinter Schritt 5, vor `## Schritt 6`)
+
+Der neue Block kommt zwischen dem abschließenden `---` nach dem Body-Template (aktuell Zeile 140) und `## Schritt 6: Auto-Merge wenn CI grün` (Zeile 142).
+
+- [ ] **Schritt 1: Block einfügen**
+
+Ersetze in `.claude/skills/dev-flow-execute/SKILL.md` den Abschnitt:
+
+```
+---
+
+## Schritt 6: Auto-Merge wenn CI grün
+```
+
+durch:
+
+```
+---
+
+## Schritt 5.5: PR-Link im Ticket speichern
+
+Falls `$TICKET_ID` gesetzt, direkt nach dem PR-Erstellen:
+
+```bash
+PR_NUM=$(gh pr view --json number -q '.number')
+
+PGPOD=$(kubectl get pod -n workspace --context mentolder \
+  -l app=shared-db -o name | head -1)
+
+TICKET_UUID=$(kubectl exec "$PGPOD" -n workspace --context mentolder -- \
+  psql -U website -d website -At -c \
+  "SELECT id FROM tickets.tickets WHERE external_id = '$TICKET_ID';")
+
+kubectl exec "$PGPOD" -n workspace --context mentolder -- \
+  psql -U website -d website -c \
+  "INSERT INTO tickets.ticket_links (from_id, kind, pr_number)
+   SELECT '$TICKET_UUID', 'pr', $PR_NUM
+   WHERE NOT EXISTS (
+     SELECT 1 FROM tickets.ticket_links
+     WHERE from_id = '$TICKET_UUID' AND kind = 'pr' AND pr_number = $PR_NUM
+   );"
+```
+
+- `to_id` bleibt NULL (kein NOT NULL-Constraint auf der Spalte).
+- `WHERE NOT EXISTS` macht den Insert idempotent ohne UNIQUE-Constraint.
+
+---
+
+## Schritt 6: Auto-Merge wenn CI grün
+```
+
+- [ ] **Schritt 2: Diff prüfen**
+
+```bash
+git diff .claude/skills/dev-flow-execute/SKILL.md
+```
+
+Erwartete Ausgabe: Neuer Abschnitt `## Schritt 5.5` zwischen Schritt 5 und Schritt 6 eingefügt, kein sonstiger Verlust.
+
+- [ ] **Schritt 3: Commit**
+
+```bash
+git add .claude/skills/dev-flow-execute/SKILL.md
+git commit -m "feat(dev-flow): store PR link in ticket_links after PR creation"
+```
+
+---
+
+## Task 3: Schritt 7 in SKILL.md ersetzen — Plan-Archivierung in Postgres
+
+**Files:**
+- Modify: `.claude/skills/dev-flow-execute/SKILL.md` (Schritt 6.5-Kommentar + Schritt 7 komplett)
+
+Zwei Stellen:
+
+**A) Schritt 6.5 — Kommentar aktualisieren** (Zeile 167): Der Text `Plan executed: docs/superpowers/plans/<slug>.md` stimmt nach der Änderung nicht mehr, weil die Datei gelöscht wird.
+
+**B) Schritt 7 — Inhalt ersetzen** (Zeilen 176–187): `mv executed/`-Logik durch Postgres-Archivierung + `rm`.
+
+- [ ] **Schritt 1: Schritt 6.5-Kommentar aktualisieren**
+
+Ersetze in `.claude/skills/dev-flow-execute/SKILL.md`:
+
+```
+     'PR #$PR_NUM merged. Plan executed: docs/superpowers/plans/<slug>.md',
+```
+
+durch:
+
+```
+     'PR #$PR_NUM merged. Plan archived to tickets.ticket_plans in Postgres.',
+```
+
+- [ ] **Schritt 2: Schritt 7 ersetzen**
+
+Ersetze den gesamten Schritt-7-Block:
+
+```
+## Schritt 7: Plan archivieren
+
+Nach erfolgreichem Merge den Plan in `executed/` verschieben:
+
+```bash
+mkdir -p docs/superpowers/plans/executed
+mv docs/superpowers/plans/<slug>.md docs/superpowers/plans/executed/
+git add docs/superpowers/plans/
+git commit -m "chore(plans): mark <slug> as executed"
+git push
+```
+```
+
+durch:
+
+````
+## Schritt 7: Plan in Postgres archivieren + Datei löschen
+
+Falls `$TICKET_ID` gesetzt und `$PLAN_FILE` vorhanden:
+
+```bash
+PLAN_FILE="docs/superpowers/plans/<slug>.md"
+SLUG="<slug>"
+BRANCH=$(git branch --show-current)
+PR_NUM=$(gh pr view --json number -q '.number' 2>/dev/null || echo "")
+
+PGPOD=$(kubectl get pod -n workspace --context mentolder \
+  -l app=shared-db -o name | head -1)
+
+TICKET_UUID=$(kubectl exec "$PGPOD" -n workspace --context mentolder -- \
+  psql -U website -d website -At -c \
+  "SELECT id FROM tickets.tickets WHERE external_id = '$TICKET_ID';")
+
+PR_NUM_SQL=$([ -z "$PR_NUM" ] && echo "NULL" || echo "$PR_NUM")
+
+# SQL in temp-Datei schreiben — verhindert Shell-Expansion des Plan-Inhalts
+TMPFILE=$(mktemp /tmp/plan-archive-XXXXXX.sql)
+{
+  printf "INSERT INTO tickets.ticket_plans (ticket_id, slug, branch, content, pr_number)\nVALUES (\n  '%s',\n  '%s',\n  '%s',\n  \$plan\$" \
+    "$TICKET_UUID" "$SLUG" "$BRANCH"
+  cat "$PLAN_FILE"
+  printf "\$plan\$,\n  %s\n);\n" "$PR_NUM_SQL"
+} > "$TMPFILE"
+
+kubectl exec -i "$PGPOD" -n workspace --context mentolder -- \
+  psql -U website -d website -v ON_ERROR_STOP=1 < "$TMPFILE"
+
+rm "$TMPFILE"
+
+# Datei löschen (nicht nach executed/ verschieben)
+rm "$PLAN_FILE"
+git add "$PLAN_FILE"
+git commit -m "chore(plans): archive $SLUG → postgres [$TICKET_ID]"
+git push
+```
+
+Falls `$TICKET_ID` leer (Chore ohne Ticket): SQL-Archivierung überspringen — nur `rm "$PLAN_FILE"` + commit.
+
+**Hinweis Dollar-Quoting:** `$plan$...$plan$` ist psql-Dollar-Quoting; sicher für beliebigen Markdown-Inhalt, solange der Plan selbst nicht den String `$plan$` enthält (praktisch ausgeschlossen).
+````
+
+- [ ] **Schritt 3: Diff prüfen**
+
+```bash
+git diff .claude/skills/dev-flow-execute/SKILL.md
+```
+
+Prüfe:
+- Schritt 6.5-Kommentar zeigt "Archived to tickets.ticket_plans in Postgres."
+- Schritt 7 enthält `mktemp`, `kubectl exec -i`, `rm "$PLAN_FILE"`, kein `mv executed/` mehr
+
+- [ ] **Schritt 4: Commit**
+
+```bash
+git add .claude/skills/dev-flow-execute/SKILL.md
+git commit -m "feat(dev-flow): archive plan to postgres and delete md file on merge"
+```
+
+---
+
+## Task 4: Verifikation + PR
+
+- [ ] **Schritt 1: SKILL.md auf Vollständigkeit prüfen**
+
+```bash
+grep -n "Schritt 5.5\|ticket_links\|ticket_plans\|rm.*PLAN_FILE\|executed/" \
+  .claude/skills/dev-flow-execute/SKILL.md
+```
+
+Erwartete Ausgabe:
+- Treffer für `Schritt 5.5` und `ticket_links` (PR-Link-Block)
+- Treffer für `ticket_plans` und `rm.*PLAN_FILE` (Archivierungs-Block)
+- **Kein** Treffer für `executed/` (alter Move-Befehl ist weg)
+
+- [ ] **Schritt 2: Offline-Tests laufen lassen**
+
+```bash
+task test:all
+```
+
+Erwartete Ausgabe: grün — Skill-Änderungen berühren keine BATS- oder Kustomize-Tests.
+
+- [ ] **Schritt 3: Smoke-Test der neuen DB-Tabelle**
+
+```bash
+PGPOD=$(kubectl get pod -n workspace --context mentolder \
+  -l app=shared-db -o name | head -1)
+
+kubectl exec "$PGPOD" -n workspace --context mentolder -- \
+  psql -U website -d website -c \
+  "SELECT COUNT(*) FROM tickets.ticket_plans;"
+```
+
+Erwartete Ausgabe: `count = 0` (Tabelle leer, existiert aber).
+
+- [ ] **Schritt 4: Push + PR erstellen**
+
+```bash
+git push -u origin feature/dev-flow-pr-link-plan-archive
+```
+
+Dann `commit-commands:commit-push-pr` aufrufen mit:
+- Titel: `feat(dev-flow): link PR to ticket + archive plan in postgres`
+- Body:
+  ```
+  ## Summary
+  - Speichert die GitHub-PR-Nummer nach PR-Erstellung in tickets.ticket_links (kind='pr')
+  - Archiviert den Markdown-Plan nach Merge in tickets.ticket_plans und löscht die .md-Datei
+
+  ## Test plan
+  - [x] task test:all
+  - [x] tickets.ticket_plans Tabelle auf mentolder-Cluster verifiziert
+  - [x] SKILL.md grep-Check: kein executed/-Move, neuer 5.5-Block vorhanden
+  ```

--- a/docs/superpowers/specs/2026-05-14-dev-flow-pr-link-plan-archive-design.md
+++ b/docs/superpowers/specs/2026-05-14-dev-flow-pr-link-plan-archive-design.md
@@ -1,0 +1,141 @@
+# Dev-Flow: PR-Link + Plan-Archiv in Postgres
+
+**Datum:** 2026-05-14
+**Branch:** `feature/dev-flow-pr-link-plan-archive`
+**Scope:** `.claude/skills/dev-flow-execute/SKILL.md`, Schema-Migration `tickets.ticket_plans`
+
+---
+
+## Problemstellung
+
+Der aktuelle `dev-flow-execute`-Flow hat zwei Lücken:
+
+1. **Kein PR-Link im Ticket:** Nach dem Erstellen eines Pull Requests kennt das Ticket in der DB nicht, welcher GitHub-PR dazugehört. `tickets.ticket_links` hat bereits eine `pr_number`-Spalte, wird aber nie befüllt.
+
+2. **Plan-Archivierung nur als Datei:** Nach erfolgreichem Merge landet der Plan per `mv` in `docs/superpowers/plans/executed/`. Der Markdown-Inhalt ist nie in Postgres gespeichert — kein strukturierter Zugriff, kein DB-seitiger Bezug zum Ticket.
+
+---
+
+## Design
+
+### ① Schema-Migration — `tickets.ticket_plans`
+
+Neue Tabelle im `tickets`-Schema:
+
+```sql
+CREATE TABLE tickets.ticket_plans (
+  id          BIGSERIAL PRIMARY KEY,
+  ticket_id   UUID NOT NULL REFERENCES tickets.tickets(id),
+  slug        TEXT NOT NULL,
+  branch      TEXT,
+  content     TEXT NOT NULL,
+  pr_number   INTEGER,
+  archived_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+```
+
+- `slug`: Dateiname ohne Extension und Datumspräfix (z.B. `dev-flow-pr-link-plan-archive`)
+- `branch`: vollständiger Branch-Name (z.B. `feature/dev-flow-pr-link-plan-archive`)
+- `content`: vollständiger Markdown-Inhalt der Plan-Datei zum Zeitpunkt der Archivierung
+- `pr_number`: GitHub-PR-Nummer, die diesen Plan umgesetzt hat
+- Kein FK auf `ticket_links` — `pr_number` ist reine Referenz, kein harter Constraint
+
+Kein Index erforderlich für MVP; `ticket_id`-Lookup reicht über Seq-Scan bei kleinem Tabellenvolumen.
+
+---
+
+### ② dev-flow-execute Schritt 5 — PR-Link nach PR-Erstellung
+
+**Einfügepunkt:** direkt nach `commit-commands:commit-push-pr` (sobald PR-Nummer verfügbar).
+
+```bash
+PR_NUM=$(gh pr view --json number -q '.number')
+
+PGPOD=$(kubectl get pod -n workspace --context mentolder \
+  -l app=shared-db -o name | head -1)
+
+# ticket_uuid aus external_id auflösen
+TICKET_UUID=$(kubectl exec "$PGPOD" -n workspace --context mentolder -- \
+  psql -U website -d website -At -c \
+  "SELECT id FROM tickets.tickets WHERE external_id = '$TICKET_ID';")
+
+# PR-Link in ticket_links eintragen (idempotent via WHERE NOT EXISTS)
+kubectl exec "$PGPOD" -n workspace --context mentolder -- \
+  psql -U website -d website -c \
+  "INSERT INTO tickets.ticket_links (from_id, kind, pr_number)
+   SELECT '$TICKET_UUID', 'pr', $PR_NUM
+   WHERE NOT EXISTS (
+     SELECT 1 FROM tickets.ticket_links
+     WHERE from_id = '$TICKET_UUID' AND kind = 'pr' AND pr_number = $PR_NUM
+   );"
+```
+
+- Nur ausführen wenn `$TICKET_ID` gesetzt (wie bisher bei Ticket-Operationen)
+- `WHERE NOT EXISTS` verhindert Duplikate bei Retry (kein UNIQUE-Constraint auf der Tabelle)
+- `to_id` bleibt NULL — `ticket_links` erlaubt das, da kein NOT NULL-Constraint
+
+---
+
+### ③ dev-flow-execute Schritt 7 — Plan-Archivierung in Postgres (ersetzt `executed/`-Move)
+
+**Ersetzt:** `mv docs/superpowers/plans/<slug>.md docs/superpowers/plans/executed/`
+
+```bash
+PLAN_FILE="docs/superpowers/plans/<slug>.md"
+PLAN_CONTENT=$(cat "$PLAN_FILE")
+
+PGPOD=$(kubectl get pod -n workspace --context mentolder \
+  -l app=shared-db -o name | head -1)
+
+TICKET_UUID=$(kubectl exec "$PGPOD" -n workspace --context mentolder -- \
+  psql -U website -d website -At -c \
+  "SELECT id FROM tickets.tickets WHERE external_id = '$TICKET_ID';")
+
+PR_NUM=$(gh pr view --json number -q '.number' 2>/dev/null || echo "NULL")
+
+# Plan-Inhalt in Postgres archivieren
+kubectl exec "$PGPOD" -n workspace --context mentolder -- \
+  psql -U website -d website -c \
+  "INSERT INTO tickets.ticket_plans (ticket_id, slug, branch, content, pr_number)
+   VALUES (
+     '$TICKET_UUID',
+     '<slug>',
+     '$(git branch --show-current)',
+     \$plan\$$PLAN_CONTENT\$plan\$,
+     $([ "$PR_NUM" = "NULL" ] && echo "NULL" || echo "$PR_NUM")
+   );"
+
+# .md-Datei löschen (nicht nach executed/ verschieben)
+rm "$PLAN_FILE"
+git add "$PLAN_FILE"
+git commit -m "chore(plans): archive <slug> → postgres [$TICKET_ID]"
+git push
+```
+
+- Dollar-Quoting (`$plan$...$plan$`) verhindert SQL-Injection durch Markdown-Sonderzeichen
+- **Implementierungshinweis:** `PLAN_CONTENT` via Shell-Variable in `kubectl exec -c` ist bei Newlines/Quotes riskant. Besser: Plan-Datei per `kubectl cp` in den Pod kopieren und dort per `psql -f` oder `\lo_import` einspielen — oder Inhalt in eine temporäre SQL-Datei schreiben und via `kubectl exec ... -- psql -f -` pipen.
+- Falls `$TICKET_ID` leer (z.B. bei Chores ohne Ticket): Archivierung überspringen, nur `rm` + commit
+- Das `executed/`-Verzeichnis entfällt komplett — bestehende Dateien dort bleiben unberührt (kein Cleanup im Scope)
+
+---
+
+## Abgrenzung
+
+**In Scope:**
+- Schema-Migration `tickets.ticket_plans` (einmalig, manuell via `kubectl exec psql`)
+- Anpassung `dev-flow-execute/SKILL.md` an zwei Stellen (Schritt 5 + Schritt 7)
+
+**Out of Scope:**
+- Admin-UI zum Anzeigen archivierter Pläne
+- Backfill bereits archivierter Pläne aus `executed/`
+- Cleanup des `executed/`-Verzeichnisses
+- Änderungen an `dev-flow-plan/SKILL.md`
+
+---
+
+## Verifikation
+
+- Schema-Migration läuft sauber durch: `\d tickets.ticket_plans` zeigt die Tabelle
+- Nach einem Test-PR: `SELECT pr_number FROM tickets.ticket_links WHERE kind='pr'` gibt Treffer
+- Nach Plan-Archivierung: `SELECT slug, archived_at FROM tickets.ticket_plans` zeigt Eintrag, `.md`-Datei ist weg
+- `task test:all` bleibt grün (Skill-Änderungen berühren keine getestete Logik)


### PR DESCRIPTION
## Summary
- Speichert die GitHub-PR-Nummer nach PR-Erstellung in `tickets.ticket_links` (kind='pr') — neuer Schritt 5.5 in dev-flow-execute
- Archiviert den Markdown-Plan nach Merge in `tickets.ticket_plans` und löscht die `.md`-Datei (Schritt 7 ersetzt `mv executed/`)
- Schema-Migration: `tickets.ticket_plans` (id, ticket_id, slug, branch, content, pr_number, archived_at) auf mentolder-Cluster angelegt

## Test plan
- [x] `task test:all` (Dry-run + workspace:validate grün; BATS-Submodule im Worktree nicht verfügbar — keine BATS-Tests betroffen)
- [x] `tickets.ticket_plans` Tabelle auf mentolder-Cluster verifiziert (`count = 0`)
- [x] SKILL.md grep-Check: kein `mv executed/` mehr, Schritt 5.5 + ticket_links vorhanden, ticket_plans + rm PLAN_FILE vorhanden

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>