### PR TITLE
chore(gemini): symlink .gemini/agents+skills to .claude

### DIFF
--- a/.gemini/agents
+++ b/.gemini/agents
@@ -1,0 +1,1 @@
+../.claude/agents

--- a/.gemini/skills/dev-flow
+++ b/.gemini/skills/dev-flow
@@ -1,0 +1,1 @@
+../../.claude/skills/dev-flow

--- a/.gemini/skills/dev-flow-execute
+++ b/.gemini/skills/dev-flow-execute
@@ -1,0 +1,1 @@
+../../.claude/skills/dev-flow-execute

--- a/.gemini/skills/dev-flow-plan
+++ b/.gemini/skills/dev-flow-plan
@@ -1,0 +1,1 @@
+../../.claude/skills/dev-flow-plan


### PR DESCRIPTION
## Summary
- Replace the duplicate copies under `.gemini/agents/` and `.gemini/skills/dev-flow*` with relative symlinks pointing at the canonical `.claude/agents` and `.claude/skills/dev-flow*` trees.
- Lets Gemini CLI and Claude Code share a single source of truth — the stale `.gemini` copy of `dev-flow-execute/SKILL.md` (which still carried the "Schritt 7.5: Worktree & Branch bereinigen" section dropped in #724) is now automatically in sync.

## Test plan
- [x] `ls -la .gemini/{agents,skills/dev-flow*}` shows mode `120000` symlinks resolving to `.claude/...`
- [x] `diff -rq .gemini/agents/ .claude/agents/` and same for each skill subdir → empty (in sync)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)