### PR TITLE
chore(skills): ticket attachments + brainstorm tunnel verify in dev-flow

### DIFF
--- a/.claude/skills/dev-flow-execute/SKILL.md
+++ b/.claude/skills/dev-flow-execute/SKILL.md
@@ -328,6 +328,14 @@ Wenn mehrere Kategorien matchen: workspace → website → brett → livekit →
 
 ## Failure-Handling
 
+- **Beweismaterial ans Ticket hängen (bei jedem Failure-Pfad):** Wenn du einen Failure-Screenshot, Log-Auszug oder Trace-Output hast, frage Patrick nach Pfaden (`.png`/`.log`/`.txt`/`.mp4`) und hänge sie ans Ticket — der Fix-Branch erbt dann sofort den Kontext:
+  ```bash
+  # TICKET_UUID aus dem aktuellen Ticket holen:
+  TICKET_UUID=$(kubectl exec "$PGPOD" -n workspace --context mentolder -- \
+    psql -U website -d website -At -c \
+    "SELECT id FROM tickets.tickets WHERE external_id='$TICKET_ID';")
+  bash scripts/ticket-attach.sh "$TICKET_UUID" /pfad/zu/failure.png /pfad/zu/ci.log
+  ```
 - **CI rot vor Merge:** Diagnose, Fix auf demselben Branch, neu pushen. Keinen zweiten PR aufmachen. Falls nach 2 Versuchen noch rot: Ticket-Kommentar hinterlassen:
   ```bash
   kubectl exec "$PGPOD" -n workspace --context mentolder -- \

--- a/.claude/skills/dev-flow-plan/SKILL.md
+++ b/.claude/skills/dev-flow-plan/SKILL.md
@@ -75,6 +75,30 @@ Falls Worktree bereits existiert: **nicht** `using-git-worktrees` aufrufen — d
 
 Falls kein Worktree existiert: Rufe `superpowers:using-git-worktrees` auf. Branch-Name: `feature/<kurzer-slug>`.
 
+### Schritt 1.5: Optionale Asset-Sammlung
+
+**Bevor du das Brainstorming startest, frage den User aktiv:**
+
+> "Hast du Dateien, die beim Planen helfen würden — Spec-/Notiz-Markdown, HTML-Mockups, Screenshots/Bilder (`.jpg`/`.png`), Tonaufnahmen (`.mp3`), Video-Walkthroughs (`.mp4`)? Wenn ja: nenn mir die Pfade (absolut, leerzeichengetrennt oder einer pro Zeile). Sonst: 'keine'."
+
+Erlaubte Endungen: `.md .html .jpg .jpeg .png .gif .webp .mp3 .wav .mp4 .mov .webm .pdf .txt .log`.
+
+Stash die Pfade in einer Bash-Variable für später:
+
+```bash
+# Beispiel — vom User-Input befüllen:
+ATTACHMENT_PATHS=(
+  "/home/patrick/notes/idea.md"
+  "/home/patrick/Pictures/mockup.png"
+)
+```
+
+Falls die Datei eine `.md`/`.html`/`.txt` ist: zusätzlich den Inhalt vor dem Brainstorming lesen (`Read` Tool) — der Inhalt fließt direkt ins Brainstorming-Kontext ein.
+Falls `.jpg`/`.png`: ebenfalls über `Read` Tool laden — Claude verarbeitet die Bilder multimodal.
+Audio/Video (`.mp3`/`.mp4`) wird nur archiviert (ans Ticket angehängt), nicht inline transkribiert — falls der User Transkription will, gesondert über `task workspace:transcriber-*` oder Whisper anstoßen.
+
+Falls der User "keine" sagt: Array leer lassen und weiter.
+
 ### Schritt 2: Pre-launch Brainstorming-Tunnel
 
 ```bash
@@ -97,11 +121,49 @@ STATE_DIR=$(echo "$RESULT" | jq -r '.state_dir')
 Falls `$PORT` leer: Abbruch. Mitteilen: "brainstorm server konnte nicht gestartet werden."
 
 ```bash
-# c) Tunnel publishen (run_in_background: true)
-task brainstorm:publish -- $PORT
+# c) Vorflug-Check (idempotent, schnell — bricht früh ab wenn Setup kaputt)
+task brainstorm:status >/tmp/brainstorm-status.log 2>&1 || true
+grep -q 'Running' /tmp/brainstorm-status.log || { echo "sish pod not Running — aborting"; cat /tmp/brainstorm-status.log; exit 1; }
+
+# Stelle sicher dass mindestens ein Authorized-Key in der ConfigMap liegt — sonst hängt ssh -R lautlos
+KEY_COUNT=$(kubectl --context mentolder -n workspace get cm brainstorm-sish-authorized-keys \
+  -o jsonpath='{.data.authorized_keys}' 2>/dev/null | grep -c '^ssh-' || echo 0)
+if [[ "$KEY_COUNT" -lt 1 ]]; then
+  echo "⚠️  Keine authorized_keys in der ConfigMap. Patricks Public-Key in environments/.secrets/mentolder.yaml" \
+       "unter DEV_SISH_AUTHORIZED_KEYS ergänzen, dann: task env:seal ENV=mentolder && task brainstorm:_materialise-keys"
+  exit 1
+fi
 ```
 
-Patrick mitteilen: **"Brainstorming-Companion läuft unter https://brainstorm.mentolder.de — jetzt im Browser öffnen."**
+```bash
+# d) Tunnel publishen (run_in_background: true) — STDOUT/STDERR in Log-File schreiben
+task brainstorm:publish -- $PORT >/tmp/brainstorm-publish.log 2>&1
+```
+
+```bash
+# e) Verify — bis zu 15s auf den Tunnel warten. Erst wenn 200/302 kommt, ist die URL benutzbar.
+for i in $(seq 1 15); do
+  CODE=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 3 https://brainstorm.mentolder.de/ || echo 000)
+  if [[ "$CODE" == "200" || "$CODE" == "302" || "$CODE" == "301" ]]; then
+    echo "✓ Tunnel live (HTTP $CODE) nach ${i}s"
+    break
+  fi
+  sleep 1
+done
+if [[ "$CODE" != "200" && "$CODE" != "302" && "$CODE" != "301" ]]; then
+  echo "✗ Tunnel hat nach 15s nicht geantwortet (letzter HTTP-Code: $CODE)"
+  echo "── publish log ──"
+  cat /tmp/brainstorm-publish.log
+  echo "── häufige Ursachen ──"
+  echo "  • SSH key nicht in DEV_SISH_AUTHORIZED_KEYS (siehe Schritt c)"
+  echo "  • ufw blockiert Port 32223 auf gekko-hetzner-2 → 'task brainstorm:firewall:open'"
+  echo "  • sish pod restartet/crashed → 'task brainstorm:status'"
+  echo "  • PORT $PORT lauscht nicht lokal → 'ss -ltn | grep $PORT'"
+  exit 1
+fi
+```
+
+Erst wenn Schritt e) grün ist, Patrick mitteilen: **"Brainstorming-Companion läuft unter https://brainstorm.mentolder.de (HTTP $CODE) — jetzt im Browser öffnen."**
 
 ### Schritt 3: Brainstorming
 
@@ -156,6 +218,18 @@ awk 'NR==1{print; print "ticket_id: '"$TICKET_EXT_ID"'"; next} 1' \
 
 Melde: **"Ticket `$TICKET_EXT_ID` angelegt → https://web.mentolder.de/admin/bugs"**
 
+### Schritt 4.6: Gesammelte Assets ans Ticket hängen
+
+Falls `ATTACHMENT_PATHS` (aus Schritt 1.5) Einträge hat, hochladen:
+
+```bash
+if [[ ${#ATTACHMENT_PATHS[@]} -gt 0 ]]; then
+  bash scripts/ticket-attach.sh "$TICKET_UUID" "${ATTACHMENT_PATHS[@]}"
+fi
+```
+
+`ticket-attach.sh` lehnt unbekannte Endungen ab und kappt inline-Uploads bei 10 MB (`MAX_INLINE_MB=20` o.ä. zum Erhöhen). Dateien > Cap müssen vorher in Nextcloud landen — dann manuell INSERT mit `nc_path` statt `data_url`.
+
 ### Schritt 5: Commit & Push — dann STOPP
 
 ```bash
@@ -176,9 +250,32 @@ Keine Implementation, keine Verifikation, kein PR — das übernimmt `dev-flow-e
 
 Frage den User nach der Ticket-ID (Format: `T######`, z.B. `T000288`).
 
-**Wenn eine Ticket-ID vorhanden ist:** direkt übernehmen → `TICKET_EXT_ID=T######`.
+**Wenn eine Ticket-ID vorhanden ist:** direkt übernehmen → `TICKET_EXT_ID=T######`. Hole zusätzlich die UUID für etwaige Attachments:
 
-**Wenn keine existiert:** frage nach Titel, Schweregrad und kurzer Beschreibung, lege dann das Ticket via SQL an:
+```bash
+PGPOD=$(kubectl get pod -n workspace --context mentolder -l app=shared-db -o name | head -1)
+TICKET_UUID=$(kubectl exec "$PGPOD" -n workspace --context mentolder -- \
+  psql -U website -d website -At -c \
+  "SELECT id FROM tickets.tickets WHERE external_id='$TICKET_EXT_ID';")
+```
+
+**Optionale Asset-Sammlung (vor Ticket-Anlage oder vor Attachment-Upload):**
+
+Frage den User aktiv:
+
+> "Hast du Belegmaterial — Screenshot vom Bug (`.jpg`/`.png`), Log-Auszug (`.txt`/`.log`/`.md`), Bildschirmaufnahme (`.mp4`/`.webm`), Audio-Wiedergabe (`.mp3`)? Pfade absolut, leerzeichengetrennt. Sonst: 'keine'."
+
+Erlaubte Endungen: `.md .html .jpg .jpeg .png .gif .webp .mp3 .wav .mp4 .mov .webm .pdf .txt .log`.
+
+```bash
+ATTACHMENT_PATHS=(
+  # vom User-Input befüllen
+)
+```
+
+Falls `.txt`/`.log`/`.md`/`.png`/`.jpg`: zusätzlich vor der Ticket-Anlage `Read`en — Inhalt fließt in die Bug-Beschreibung ein (bessere Reproduktion).
+
+**Wenn keine Ticket-ID existiert:** frage nach Titel, Schweregrad und kurzer Beschreibung, lege dann das Ticket via SQL an:
 
 ```bash
 PGPOD=$(kubectl get pod -n workspace --context mentolder \
@@ -202,6 +299,14 @@ TICKET_UUID=$(echo "$TICKET_RESULT"   | cut -d'|' -f2)
 ```
 
 Melde: **"Ticket `$TICKET_EXT_ID` angelegt → https://web.mentolder.de/admin/bugs"**
+
+**Asset-Upload (falls Schritt oben Pfade gesammelt hat):**
+
+```bash
+if [[ ${#ATTACHMENT_PATHS[@]} -gt 0 ]]; then
+  bash scripts/ticket-attach.sh "$TICKET_UUID" "${ATTACHMENT_PATHS[@]}"
+fi
+```
 
 **Ohne Ticket-ID geht der Fix-Pfad nicht weiter.**
 

--- a/scripts/ticket-attach.sh
+++ b/scripts/ticket-attach.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# ticket-attach.sh — attach local files to a ticket via tickets.ticket_attachments.
+#
+# Usage:
+#   scripts/ticket-attach.sh <ticket-uuid> <file> [<file> ...]
+#
+# Behavior:
+#   - Validates extension is one of: md html jpg jpeg png gif webp mp3 wav mp4 mov webm pdf txt log
+#   - Files <= MAX_INLINE_MB (default 10) are base64-encoded into data_url
+#   - Larger files are skipped with a warning (upload to Nextcloud first, then INSERT manually with nc_path)
+#   - Inserts one row per file into tickets.ticket_attachments on the mentolder cluster
+#
+# Requires kubectl context `mentolder` reachable.
+
+set -euo pipefail
+
+MAX_INLINE_MB="${MAX_INLINE_MB:-10}"
+MAX_BYTES=$(( MAX_INLINE_MB * 1024 * 1024 ))
+CTX="${TICKET_CTX:-mentolder}"
+NS="${TICKET_NS:-workspace}"
+
+if [[ $# -lt 2 ]]; then
+  echo "Usage: $0 <ticket-uuid> <file> [<file> ...]" >&2
+  exit 2
+fi
+
+TICKET_UUID="$1"; shift
+
+if ! [[ "$TICKET_UUID" =~ ^[0-9a-fA-F-]{36}$ ]]; then
+  echo "ERROR: first arg must be a ticket UUID (got: $TICKET_UUID)" >&2
+  exit 2
+fi
+
+PGPOD=$(kubectl get pod -n "$NS" --context "$CTX" -l app=shared-db -o name 2>/dev/null | head -1)
+if [[ -z "$PGPOD" ]]; then
+  echo "ERROR: no shared-db pod found in ns=$NS ctx=$CTX" >&2
+  exit 1
+fi
+
+mime_for() {
+  case "${1,,}" in
+    *.md)            echo "text/markdown" ;;
+    *.html|*.htm)    echo "text/html" ;;
+    *.txt|*.log)     echo "text/plain" ;;
+    *.jpg|*.jpeg)    echo "image/jpeg" ;;
+    *.png)           echo "image/png" ;;
+    *.gif)           echo "image/gif" ;;
+    *.webp)          echo "image/webp" ;;
+    *.mp3)           echo "audio/mpeg" ;;
+    *.wav)           echo "audio/wav" ;;
+    *.mp4)           echo "video/mp4" ;;
+    *.mov)           echo "video/quicktime" ;;
+    *.webm)          echo "video/webm" ;;
+    *.pdf)           echo "application/pdf" ;;
+    *)               echo "" ;;
+  esac
+}
+
+attached=0
+skipped=0
+
+for f in "$@"; do
+  if [[ ! -f "$f" ]]; then
+    echo "SKIP: not a file: $f" >&2
+    skipped=$((skipped+1))
+    continue
+  fi
+
+  mime=$(mime_for "$f")
+  if [[ -z "$mime" ]]; then
+    echo "SKIP: unsupported extension: $f" >&2
+    skipped=$((skipped+1))
+    continue
+  fi
+
+  size=$(stat -c %s "$f" 2>/dev/null || stat -f %z "$f")
+  if (( size > MAX_BYTES )); then
+    echo "SKIP: $f is ${size} bytes (>${MAX_INLINE_MB} MB inline cap). Upload to Nextcloud and INSERT with nc_path instead." >&2
+    skipped=$((skipped+1))
+    continue
+  fi
+
+  filename=$(basename -- "$f")
+  b64=$(base64 -w0 < "$f")
+  data_url="data:${mime};base64,${b64}"
+
+  kubectl exec -i "$PGPOD" -n "$NS" --context "$CTX" -- \
+    psql -U website -d website -v ON_ERROR_STOP=1 \
+    -v ticket="$TICKET_UUID" \
+    -v fname="$filename" \
+    -v mime="$mime" \
+    -v size="$size" \
+    -v data="$data_url" \
+    -c "INSERT INTO tickets.ticket_attachments (ticket_id, filename, mime_type, file_size, data_url)
+        VALUES (:'ticket'::uuid, :'fname', :'mime', :'size'::bigint, :'data');" >/dev/null
+
+  echo "  ✓ attached $filename (${mime}, ${size} bytes)"
+  attached=$((attached+1))
+done
+
+echo "Done: $attached attached, $skipped skipped"


### PR DESCRIPTION
## Summary
- `dev-flow-plan` now asks for supporting files (`.md/.html/.jpg/.png/.mp3/.mp4`) before brainstorming and attaches them to the ticket on creation (feature + fix paths).
- `dev-flow-plan` Schritt 2 now verifies the brainstorm tunnel is actually reachable (authorized_keys check + HTTP probe with 15s timeout) before telling the operator to open the URL — root cause of the recent "couldn't access the tunnel" hang.
- `dev-flow-execute` Failure-Handling hints to attach failure screenshots/logs to the ticket.
- New `scripts/ticket-attach.sh` helper: base64-encodes files into `tickets.ticket_attachments.data_url` (10 MB inline cap, override via `MAX_INLINE_MB`).

## Test plan
- [x] `bash -n scripts/ticket-attach.sh`
- [x] `task brainstorm:status` shows pod Running + ingress healthy
- [ ] Next `dev-flow-plan` run exercises the new asset-collection + tunnel verify steps end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)