### PR TITLE
feat(coaching): add triadisches KI-Coaching session wizard

### DIFF
--- a/docs/superpowers/plans/2026-05-14-ki-coaching-session.md
+++ b/docs/superpowers/plans/2026-05-14-ki-coaching-session.md
@@ -1,0 +1,1617 @@
+---
+title: KI-Coaching Session-Wizard Implementation Plan
+domains: []
+status: active
+pr_number: null
+---
+
+# KI-Coaching Session-Wizard Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Einen geführten 10-Schritt-Wizard für "Triadisches KI-Coaching" im Admin-Bereich bauen, der pro Schritt KI-Vorschläge via Anthropic generiert und ein vollständiges Sitzungsprotokoll speichert.
+
+**Architecture:** Linearer Stepper (SessionWizard.svelte, client:load) auf `/admin/coaching/sessions/[id]`. Zwei neue DB-Tabellen (`coaching.sessions`, `coaching.session_steps`) in `k3d/website-schema.yaml`. 5 API-Routen unter `/api/admin/coaching/sessions/`. KI-Aufrufe serverseitig via Anthropic SDK (Haiku 4.5).
+
+**Tech Stack:** Astro 5, Svelte 5 (Runes), PostgreSQL (`pg-mem` für Tests), Anthropic SDK (`@anthropic-ai/sdk`), Vitest.
+
+---
+
+## Datei-Übersicht
+
+| Datei | Aktion | Zweck |
+|---|---|---|
+| `k3d/website-schema.yaml` | Modify | +2 CREATE TABLE für coaching.sessions + session_steps |
+| `website/src/lib/coaching-session-db.ts` | Create | DB-Funktionen für Sessions + Steps |
+| `website/src/lib/coaching-session-db.test.ts` | Create | Unit-Tests mit pg-mem |
+| `website/src/lib/coaching-session-prompts.ts` | Create | 10 Schritt-Definitionen + System-Prompts |
+| `website/src/pages/api/admin/coaching/sessions/index.ts` | Create | GET (Liste) + POST (anlegen) |
+| `website/src/pages/api/admin/coaching/sessions/[id]/index.ts` | Create | GET (Session + Schritte) |
+| `website/src/pages/api/admin/coaching/sessions/[id]/steps/[n]/index.ts` | Create | PATCH (Eingaben/Notiz speichern) |
+| `website/src/pages/api/admin/coaching/sessions/[id]/steps/[n]/generate.ts` | Create | POST (KI aufrufen) |
+| `website/src/pages/api/admin/coaching/sessions/[id]/complete.ts` | Create | POST (abschließen + Bericht) |
+| `website/src/components/admin/coaching/SessionWizard.svelte` | Create | Haupt-Wizard-Komponente |
+| `website/src/pages/admin/coaching/sessions/index.astro` | Create | Sessions-Liste |
+| `website/src/pages/admin/coaching/sessions/new.astro` | Create | Neue Session anlegen |
+| `website/src/pages/admin/coaching/sessions/[id].astro` | Create | Wizard-Seite |
+| `website/src/layouts/AdminLayout.astro` | Modify | +Coaching-Navigationsgruppe |
+
+---
+
+## Task 1: DB-Schema — neue Tabellen in website-schema.yaml
+
+**Files:**
+- Modify: `k3d/website-schema.yaml`
+
+- [ ] **Schritt 1.1: Tabellen nach dem letzten coaching-Block einfügen**
+
+Öffne `k3d/website-schema.yaml`. Suche nach der Zeile:
+```
+      CREATE INDEX IF NOT EXISTS idx_drafts_chunk ON coaching.drafts(knowledge_chunk_id);
+```
+Direkt dahinter (vor der nächsten Leerzeile oder vor `GRANT USAGE`) folgende SQL-Blöcke einfügen:
+
+```yaml
+      CREATE TABLE IF NOT EXISTS coaching.sessions (
+        id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        brand         TEXT NOT NULL DEFAULT 'mentolder',
+        client_id     UUID REFERENCES public.customers(id) ON DELETE SET NULL,
+        mode          TEXT NOT NULL DEFAULT 'live' CHECK (mode IN ('live','prep')),
+        title         TEXT NOT NULL,
+        status        TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active','completed','abandoned')),
+        created_by    TEXT NOT NULL,
+        created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+        completed_at  TIMESTAMPTZ
+      );
+      CREATE INDEX IF NOT EXISTS idx_sessions_brand ON coaching.sessions(brand);
+      CREATE INDEX IF NOT EXISTS idx_sessions_client ON coaching.sessions(client_id);
+
+      CREATE TABLE IF NOT EXISTS coaching.session_steps (
+        id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        session_id    UUID NOT NULL REFERENCES coaching.sessions(id) ON DELETE CASCADE,
+        step_number   INT NOT NULL,
+        step_name     TEXT NOT NULL,
+        phase         TEXT NOT NULL CHECK (phase IN ('problem_ziel','analyse','loesung','umsetzung')),
+        coach_inputs  JSONB NOT NULL DEFAULT '{}',
+        ai_prompt     TEXT,
+        ai_response   TEXT,
+        coach_notes   TEXT,
+        status        TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending','generated','accepted','skipped')),
+        generated_at  TIMESTAMPTZ,
+        UNIQUE (session_id, step_number)
+      );
+      CREATE INDEX IF NOT EXISTS idx_session_steps_session ON coaching.session_steps(session_id);
+```
+
+- [ ] **Schritt 1.2: Schema auf Produktionsdatenbank anwenden**
+
+```bash
+PGPOD=$(kubectl get pod -n workspace --context mentolder -l app=shared-db -o name | head -1)
+
+kubectl exec "$PGPOD" -n workspace --context mentolder -- psql -U website -d website -c "
+CREATE TABLE IF NOT EXISTS coaching.sessions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  brand TEXT NOT NULL DEFAULT 'mentolder',
+  client_id UUID REFERENCES public.customers(id) ON DELETE SET NULL,
+  mode TEXT NOT NULL DEFAULT 'live' CHECK (mode IN ('live','prep')),
+  title TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active','completed','abandoned')),
+  created_by TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  completed_at TIMESTAMPTZ
+);
+CREATE TABLE IF NOT EXISTS coaching.session_steps (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  session_id UUID NOT NULL REFERENCES coaching.sessions(id) ON DELETE CASCADE,
+  step_number INT NOT NULL,
+  step_name TEXT NOT NULL,
+  phase TEXT NOT NULL CHECK (phase IN ('problem_ziel','analyse','loesung','umsetzung')),
+  coach_inputs JSONB NOT NULL DEFAULT '{}',
+  ai_prompt TEXT,
+  ai_response TEXT,
+  coach_notes TEXT,
+  status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending','generated','accepted','skipped')),
+  generated_at TIMESTAMPTZ,
+  UNIQUE (session_id, step_number)
+);
+"
+```
+
+Erwartet: `CREATE TABLE` zweimal — keine Fehler.
+
+- [ ] **Schritt 1.3: Gleiches für korczewski**
+
+```bash
+PGPOD=$(kubectl get pod -n workspace-korczewski --context korczewski-ha -l app=shared-db -o name | head -1)
+# Selbes SQL wie oben — beide Cluster müssen synchron sein
+kubectl exec "$PGPOD" -n workspace-korczewski --context korczewski-ha -- psql -U website -d website -c "... (selbes SQL)"
+```
+
+- [ ] **Schritt 1.4: Commit**
+
+```bash
+cd /home/gekko/Bachelorprojekt/.claude/worktrees/feature+ki-coaching-session
+git add k3d/website-schema.yaml
+git commit -m "feat(db): add coaching.sessions + session_steps tables"
+```
+
+---
+
+## Task 2: coaching-session-prompts.ts — 10 Schritt-Definitionen
+
+**Files:**
+- Create: `website/src/lib/coaching-session-prompts.ts`
+
+- [ ] **Schritt 2.1: Datei erstellen**
+
+```typescript
+// website/src/lib/coaching-session-prompts.ts
+
+export type Phase = 'problem_ziel' | 'analyse' | 'loesung' | 'umsetzung';
+
+export interface StepInput {
+  key: string;
+  label: string;
+  required: boolean;
+  multiline?: boolean;
+}
+
+export interface StepDefinition {
+  stepNumber: number;
+  stepName: string;
+  phase: Phase;
+  phaseLabel: string;
+  inputs: StepInput[];
+  systemPrompt: string;
+  userTemplate: string;
+}
+
+const BASE_SYSTEM = `Du bist ein erfahrener Coaching-Assistent (Triadisches KI-Coaching nach Geißler).
+Deine Aufgabe: basierend auf den Coach-Eingaben eine präzise, handlungsorientierte Gesprächsintervention vorschlagen.
+Sprache: Deutsch. Maximal 250 Wörter. Kein wörtliches Buchzitat. Keine allgemeinen Ratschläge — konkret zur Situation.`;
+
+export const STEP_DEFINITIONS: StepDefinition[] = [
+  {
+    stepNumber: 1,
+    stepName: 'Erstanamnese',
+    phase: 'problem_ziel',
+    phaseLabel: 'Phase 1: Problem & Ziel',
+    inputs: [
+      { key: 'anlass', label: 'Anlass der Session', required: true, multiline: true },
+      { key: 'vorerfahrung', label: 'Vorerfahrung mit Coaching', required: false },
+      { key: 'situation', label: 'Aktuelle Situation (in Worten des Klienten)', required: true, multiline: true },
+    ],
+    systemPrompt: BASE_SYSTEM,
+    userTemplate: `Erstanamnese:
+Anlass: {anlass}
+Vorerfahrung: {vorerfahrung}
+Aktuelle Situation: {situation}
+
+Schlage eine einfühlsame Eröffnungsintervention vor, die die Situation würdigt und den Klienten einlädt, tiefer zu gehen.`,
+  },
+  {
+    stepNumber: 2,
+    stepName: 'Schlüsselaffekt',
+    phase: 'problem_ziel',
+    phaseLabel: 'Phase 1: Problem & Ziel',
+    inputs: [
+      { key: 'hauptgefuehl', label: 'Hauptgefühl des Klienten', required: true },
+      { key: 'koerperreaktion', label: 'Körperliche Reaktion / wo spürbar', required: false },
+      { key: 'ausloeser', label: 'Auslöser / Trigger', required: true },
+    ],
+    systemPrompt: BASE_SYSTEM,
+    userTemplate: `Schlüsselaffekt-Arbeit:
+Hauptgefühl: {hauptgefuehl}
+Körperreaktion: {koerperreaktion}
+Auslöser: {ausloeser}
+
+Schlage eine Intervention vor, die den Klienten mit dem Schlüsselaffekt in Kontakt bringt, ohne ihn zu überwältigen.`,
+  },
+  {
+    stepNumber: 3,
+    stepName: 'Zielformulierung',
+    phase: 'problem_ziel',
+    phaseLabel: 'Phase 1: Problem & Ziel',
+    inputs: [
+      { key: 'wunschzustand', label: 'Wunschzustand des Klienten', required: true, multiline: true },
+      { key: 'ressourcen', label: 'Bereits vorhandene Ressourcen', required: false },
+      { key: 'erste_schritte', label: 'Erste Ideen für Schritte', required: false },
+    ],
+    systemPrompt: BASE_SYSTEM,
+    userTemplate: `Zielformulierung:
+Wunschzustand: {wunschzustand}
+Ressourcen: {ressourcen}
+Erste Ideen: {erste_schritte}
+
+Hilf dabei, ein SMART-Ziel zu formulieren und die Brücke zwischen aktuellem Zustand und Wunschzustand zu bauen.`,
+  },
+  {
+    stepNumber: 4,
+    stepName: 'Teufelskreislauf',
+    phase: 'analyse',
+    phaseLabel: 'Phase 2: Analyse',
+    inputs: [
+      { key: 'ausloeser', label: 'Auslöser des Musters', required: true },
+      { key: 'reaktion', label: 'Automatische Reaktion des Klienten', required: true, multiline: true },
+      { key: 'konsequenz', label: 'Konsequenz / was sich dadurch verschlimmert', required: true },
+    ],
+    systemPrompt: BASE_SYSTEM,
+    userTemplate: `Teufelskreislauf-Analyse:
+Auslöser: {ausloeser}
+Automatische Reaktion: {reaktion}
+Konsequenz: {konsequenz}
+
+Beschreibe den Teufelskreislauf und schlage einen Interventionspunkt vor, an dem der Klient aussteigen könnte.`,
+  },
+  {
+    stepNumber: 5,
+    stepName: 'Ressourcenanalyse',
+    phase: 'analyse',
+    phaseLabel: 'Phase 2: Analyse',
+    inputs: [
+      { key: 'staerken', label: 'Stärken und Fähigkeiten des Klienten', required: true, multiline: true },
+      { key: 'bisherige_versuche', label: 'Was hat der Klient bisher versucht?', required: false },
+      { key: 'externe_unterstuetzung', label: 'Externe Unterstützung / Netzwerk', required: false },
+    ],
+    systemPrompt: BASE_SYSTEM,
+    userTemplate: `Ressourcenanalyse:
+Stärken: {staerken}
+Bisherige Versuche: {bisherige_versuche}
+Externes Netzwerk: {externe_unterstuetzung}
+
+Schlage vor, wie der Klient seine Ressourcen gezielt für das Ziel aktivieren kann.`,
+  },
+  {
+    stepNumber: 6,
+    stepName: 'Komplementärkräfte',
+    phase: 'analyse',
+    phaseLabel: 'Phase 2: Analyse',
+    inputs: [
+      { key: 'gegensatz', label: 'Gegensatz zum Problem / was fehlt', required: true },
+      { key: 'polaritaet', label: 'Polarität (z.B. Kontrolle ↔ Loslassen)', required: false },
+      { key: 'verborgene_staerke', label: 'Verborgene Stärke im Problem', required: false },
+    ],
+    systemPrompt: BASE_SYSTEM,
+    userTemplate: `Komplementärkräfte:
+Gegensatz: {gegensatz}
+Polarität: {polaritaet}
+Verborgene Stärke: {verborgene_staerke}
+
+Zeige auf, wie die Komplementärkräfte zur Lösungsentwicklung genutzt werden können.`,
+  },
+  {
+    stepNumber: 7,
+    stepName: 'Lösungsentwicklung / Bildarbeit',
+    phase: 'loesung',
+    phaseLabel: 'Phase 3: Lösung',
+    inputs: [
+      { key: 'bild_metapher', label: 'Bild oder Metapher des Klienten für die Lösung', required: true, multiline: true },
+      { key: 'koerperliche_empfindung', label: 'Körperliche Empfindung beim Bild', required: false },
+      { key: 'verknuepfung', label: 'Verknüpfung zur aktuellen Situation', required: false },
+    ],
+    systemPrompt: BASE_SYSTEM,
+    userTemplate: `Immersive Bildarbeit:
+Bild/Metapher: {bild_metapher}
+Körperliche Empfindung: {koerperliche_empfindung}
+Verknüpfung: {verknuepfung}
+
+Begleite den Klienten tiefer in das Lösungsbild hinein. Schlage Fragen vor, die das Bild lebendig machen.`,
+  },
+  {
+    stepNumber: 8,
+    stepName: 'Erfolgsimagination',
+    phase: 'loesung',
+    phaseLabel: 'Phase 3: Lösung',
+    inputs: [
+      { key: 'erfolgsbild', label: 'Wie sieht Erfolg aus (konkret)?', required: true, multiline: true },
+      { key: 'gefuehl_bei_erfolg', label: 'Wie fühlt sich das an?', required: false },
+      { key: 'veraenderung', label: 'Was hat sich verändert (Verhalten, Beziehungen)?', required: false },
+    ],
+    systemPrompt: BASE_SYSTEM,
+    userTemplate: `Erfolgsimagination:
+Erfolgsbild: {erfolgsbild}
+Gefühl: {gefuehl_bei_erfolg}
+Veränderung: {veraenderung}
+
+Verankere die Erfolgsimagination und leite über zur konkreten Umsetzungsplanung.`,
+  },
+  {
+    stepNumber: 9,
+    stepName: 'Goldstücks-Aktivität',
+    phase: 'umsetzung',
+    phaseLabel: 'Phase 4: Umsetzung',
+    inputs: [
+      { key: 'konkrete_schritte', label: 'Konkrete nächste Schritte', required: true, multiline: true },
+      { key: 'ressourcen_dafuer', label: 'Benötigte Ressourcen', required: false },
+      { key: 'zeitplan', label: 'Zeitplan / bis wann', required: false },
+    ],
+    systemPrompt: BASE_SYSTEM,
+    userTemplate: `Goldstücks-Aktivität (Umsetzungsplanung):
+Konkrete Schritte: {konkrete_schritte}
+Ressourcen: {ressourcen_dafuer}
+Zeitplan: {zeitplan}
+
+Identifiziere die eine "Goldstücks-Aktivität" — den einzelnen Schritt mit dem größten Hebel — und formuliere ihn als konkreten Auftrag.`,
+  },
+  {
+    stepNumber: 10,
+    stepName: 'Transfersicherung',
+    phase: 'umsetzung',
+    phaseLabel: 'Phase 4: Umsetzung',
+    inputs: [
+      { key: 'hindernisse', label: 'Mögliche Hindernisse', required: true, multiline: true },
+      { key: 'unterstuetzung', label: 'Wer/was unterstützt?', required: false },
+      { key: 'naechster_termin', label: 'Nächster Termin / Nachverfolgung', required: false },
+    ],
+    systemPrompt: BASE_SYSTEM,
+    userTemplate: `Transfersicherung:
+Hindernisse: {hindernisse}
+Unterstützung: {unterstuetzung}
+Nächster Termin: {naechster_termin}
+
+Erstelle einen Sicherungsplan: wie überwindet der Klient die Hindernisse? Welche Notfallstrategie gibt es?`,
+  },
+];
+
+export function getStepDef(stepNumber: number): StepDefinition {
+  const def = STEP_DEFINITIONS.find(s => s.stepNumber === stepNumber);
+  if (!def) throw new Error(`Step ${stepNumber} not found`);
+  return def;
+}
+
+export function buildUserPrompt(def: StepDefinition, inputs: Record<string, string>): string {
+  return def.userTemplate.replace(/\{(\w+)\}/g, (_, key) => inputs[key] ?? '—');
+}
+```
+
+- [ ] **Schritt 2.2: Commit**
+
+```bash
+cd /home/gekko/Bachelorprojekt/.claude/worktrees/feature+ki-coaching-session
+git add website/src/lib/coaching-session-prompts.ts
+git commit -m "feat(coaching): add 10-step session prompt definitions"
+```
+
+---
+
+## Task 3: coaching-session-db.ts + Tests
+
+**Files:**
+- Create: `website/src/lib/coaching-session-db.ts`
+- Create: `website/src/lib/coaching-session-db.test.ts`
+
+- [ ] **Schritt 3.1: Failing Test schreiben**
+
+```typescript
+// website/src/lib/coaching-session-db.test.ts
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
+import { newDb } from 'pg-mem';
+import type { Pool } from 'pg';
+import {
+  createSession,
+  getSession,
+  listSessions,
+  upsertStep,
+  getStep,
+  completeSession,
+} from './coaching-session-db';
+
+let pool: Pool;
+
+beforeAll(async () => {
+  const db = newDb();
+  db.public.registerFunction({
+    name: 'gen_random_uuid',
+    returns: 'uuid',
+    impure: true,
+    implementation: () =>
+      'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, c => {
+        const r = (Math.random() * 16) | 0;
+        return (c === 'x' ? r : (r & 0x3) | 0x8).toString(16);
+      }),
+  });
+  db.public.none(`
+    CREATE SCHEMA coaching;
+    CREATE TABLE coaching.sessions (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      brand TEXT NOT NULL DEFAULT 'mentolder',
+      client_id UUID,
+      mode TEXT NOT NULL DEFAULT 'live',
+      title TEXT NOT NULL,
+      status TEXT NOT NULL DEFAULT 'active',
+      created_by TEXT NOT NULL,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      completed_at TIMESTAMPTZ
+    );
+    CREATE TABLE coaching.session_steps (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      session_id UUID NOT NULL REFERENCES coaching.sessions(id) ON DELETE CASCADE,
+      step_number INT NOT NULL,
+      step_name TEXT NOT NULL,
+      phase TEXT NOT NULL,
+      coach_inputs JSONB NOT NULL DEFAULT '{}',
+      ai_prompt TEXT,
+      ai_response TEXT,
+      coach_notes TEXT,
+      status TEXT NOT NULL DEFAULT 'pending',
+      generated_at TIMESTAMPTZ,
+      UNIQUE (session_id, step_number)
+    );
+  `);
+  pool = db.adapters.createPg().Pool() as unknown as Pool;
+});
+
+describe('createSession', () => {
+  it('creates a session and returns it', async () => {
+    const s = await createSession(pool, {
+      brand: 'mentolder', title: 'Test-Session', createdBy: 'coach1', mode: 'live',
+    });
+    expect(s.id).toBeTruthy();
+    expect(s.title).toBe('Test-Session');
+    expect(s.status).toBe('active');
+    expect(s.clientId).toBeNull();
+  });
+});
+
+describe('getSession', () => {
+  it('returns session with steps', async () => {
+    const s = await createSession(pool, {
+      brand: 'mentolder', title: 'Mit Steps', createdBy: 'coach1', mode: 'prep',
+    });
+    await upsertStep(pool, {
+      sessionId: s.id, stepNumber: 1, stepName: 'Erstanamnese', phase: 'problem_ziel',
+      coachInputs: { anlass: 'Stress' },
+    });
+    const result = await getSession(pool, s.id);
+    expect(result).not.toBeNull();
+    expect(result!.steps).toHaveLength(1);
+    expect(result!.steps[0].coachInputs).toEqual({ anlass: 'Stress' });
+  });
+});
+
+describe('upsertStep', () => {
+  it('updates an existing step on second call', async () => {
+    const s = await createSession(pool, {
+      brand: 'mentolder', title: 'Upsert-Test', createdBy: 'coach1', mode: 'live',
+    });
+    await upsertStep(pool, {
+      sessionId: s.id, stepNumber: 1, stepName: 'Erstanamnese', phase: 'problem_ziel',
+      coachInputs: { anlass: 'alt' },
+    });
+    await upsertStep(pool, {
+      sessionId: s.id, stepNumber: 1, stepName: 'Erstanamnese', phase: 'problem_ziel',
+      coachInputs: { anlass: 'neu' }, aiResponse: 'KI sagt...', status: 'generated',
+    });
+    const step = await getStep(pool, s.id, 1);
+    expect(step!.coachInputs).toEqual({ anlass: 'neu' });
+    expect(step!.aiResponse).toBe('KI sagt...');
+    expect(step!.status).toBe('generated');
+  });
+});
+
+describe('completeSession', () => {
+  it('sets status to completed and stores report', async () => {
+    const s = await createSession(pool, {
+      brand: 'mentolder', title: 'Abschluss-Test', createdBy: 'coach1', mode: 'live',
+    });
+    await completeSession(pool, s.id, '# Bericht\nZusammenfassung...');
+    const result = await getSession(pool, s.id);
+    expect(result!.status).toBe('completed');
+    expect(result!.completedAt).not.toBeNull();
+    const report = result!.steps.find(s => s.stepNumber === 0);
+    expect(report!.aiResponse).toContain('Zusammenfassung');
+  });
+});
+```
+
+- [ ] **Schritt 3.2: Test laufen lassen — erwartet FAIL**
+
+```bash
+cd /home/gekko/Bachelorprojekt/website
+npx vitest run src/lib/coaching-session-db.test.ts 2>&1 | tail -20
+```
+
+Erwartet: `Cannot find module './coaching-session-db'`
+
+- [ ] **Schritt 3.3: coaching-session-db.ts implementieren**
+
+```typescript
+// website/src/lib/coaching-session-db.ts
+import type { Pool } from 'pg';
+
+export interface Session {
+  id: string;
+  brand: string;
+  clientId: string | null;
+  mode: 'live' | 'prep';
+  title: string;
+  status: 'active' | 'completed' | 'abandoned';
+  createdBy: string;
+  createdAt: Date;
+  completedAt: Date | null;
+  steps: SessionStep[];
+}
+
+export interface SessionStep {
+  id: string;
+  sessionId: string;
+  stepNumber: number;
+  stepName: string;
+  phase: string;
+  coachInputs: Record<string, string>;
+  aiPrompt: string | null;
+  aiResponse: string | null;
+  coachNotes: string | null;
+  status: 'pending' | 'generated' | 'accepted' | 'skipped';
+  generatedAt: Date | null;
+}
+
+export interface CreateSessionArgs {
+  brand: string;
+  clientId?: string | null;
+  mode: 'live' | 'prep';
+  title: string;
+  createdBy: string;
+}
+
+export interface UpsertStepArgs {
+  sessionId: string;
+  stepNumber: number;
+  stepName: string;
+  phase: string;
+  coachInputs?: Record<string, string>;
+  aiPrompt?: string | null;
+  aiResponse?: string | null;
+  coachNotes?: string | null;
+  status?: 'pending' | 'generated' | 'accepted' | 'skipped';
+}
+
+function rowToSession(row: Record<string, unknown>, steps: SessionStep[] = []): Session {
+  return {
+    id: row.id as string,
+    brand: row.brand as string,
+    clientId: (row.client_id as string | null) ?? null,
+    mode: row.mode as 'live' | 'prep',
+    title: row.title as string,
+    status: row.status as Session['status'],
+    createdBy: row.created_by as string,
+    createdAt: row.created_at as Date,
+    completedAt: (row.completed_at as Date | null) ?? null,
+    steps,
+  };
+}
+
+function rowToStep(row: Record<string, unknown>): SessionStep {
+  return {
+    id: row.id as string,
+    sessionId: row.session_id as string,
+    stepNumber: row.step_number as number,
+    stepName: row.step_name as string,
+    phase: row.phase as string,
+    coachInputs: (row.coach_inputs as Record<string, string>) ?? {},
+    aiPrompt: (row.ai_prompt as string | null) ?? null,
+    aiResponse: (row.ai_response as string | null) ?? null,
+    coachNotes: (row.coach_notes as string | null) ?? null,
+    status: row.status as SessionStep['status'],
+    generatedAt: (row.generated_at as Date | null) ?? null,
+  };
+}
+
+export async function createSession(pool: Pool, args: CreateSessionArgs): Promise<Session> {
+  const r = await pool.query(
+    `INSERT INTO coaching.sessions (brand, client_id, mode, title, created_by)
+     VALUES ($1, $2, $3, $4, $5)
+     RETURNING *`,
+    [args.brand, args.clientId ?? null, args.mode, args.title, args.createdBy],
+  );
+  return rowToSession(r.rows[0]);
+}
+
+export async function getSession(pool: Pool, id: string): Promise<Session | null> {
+  const [sessionRes, stepsRes] = await Promise.all([
+    pool.query(`SELECT * FROM coaching.sessions WHERE id = $1`, [id]),
+    pool.query(`SELECT * FROM coaching.session_steps WHERE session_id = $1 ORDER BY step_number`, [id]),
+  ]);
+  if (!sessionRes.rows[0]) return null;
+  return rowToSession(sessionRes.rows[0], stepsRes.rows.map(rowToStep));
+}
+
+export async function listSessions(pool: Pool, brand: string): Promise<Session[]> {
+  const r = await pool.query(
+    `SELECT s.*, c.name AS client_name
+     FROM coaching.sessions s
+     LEFT JOIN public.customers c ON c.id = s.client_id
+     WHERE s.brand = $1
+     ORDER BY s.created_at DESC`,
+    [brand],
+  );
+  return r.rows.map(row => rowToSession(row));
+}
+
+export async function upsertStep(pool: Pool, args: UpsertStepArgs): Promise<SessionStep> {
+  const r = await pool.query(
+    `INSERT INTO coaching.session_steps
+       (session_id, step_number, step_name, phase, coach_inputs, ai_prompt, ai_response, coach_notes, status, generated_at)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+     ON CONFLICT (session_id, step_number) DO UPDATE SET
+       coach_inputs  = COALESCE(EXCLUDED.coach_inputs, coaching.session_steps.coach_inputs),
+       ai_prompt     = COALESCE(EXCLUDED.ai_prompt,    coaching.session_steps.ai_prompt),
+       ai_response   = COALESCE(EXCLUDED.ai_response,  coaching.session_steps.ai_response),
+       coach_notes   = COALESCE(EXCLUDED.coach_notes,  coaching.session_steps.coach_notes),
+       status        = EXCLUDED.status,
+       generated_at  = COALESCE(EXCLUDED.generated_at, coaching.session_steps.generated_at)
+     RETURNING *`,
+    [
+      args.sessionId, args.stepNumber, args.stepName, args.phase,
+      JSON.stringify(args.coachInputs ?? {}),
+      args.aiPrompt ?? null, args.aiResponse ?? null, args.coachNotes ?? null,
+      args.status ?? 'pending',
+      args.aiResponse ? new Date() : null,
+    ],
+  );
+  return rowToStep(r.rows[0]);
+}
+
+export async function getStep(pool: Pool, sessionId: string, stepNumber: number): Promise<SessionStep | null> {
+  const r = await pool.query(
+    `SELECT * FROM coaching.session_steps WHERE session_id = $1 AND step_number = $2`,
+    [sessionId, stepNumber],
+  );
+  return r.rows[0] ? rowToStep(r.rows[0]) : null;
+}
+
+export async function completeSession(pool: Pool, sessionId: string, reportMarkdown: string): Promise<void> {
+  await pool.query(
+    `UPDATE coaching.sessions SET status = 'completed', completed_at = now() WHERE id = $1`,
+    [sessionId],
+  );
+  await upsertStep(pool, {
+    sessionId,
+    stepNumber: 0,
+    stepName: 'Abschlussbericht',
+    phase: 'umsetzung',
+    coachInputs: {},
+    aiResponse: reportMarkdown,
+    status: 'accepted',
+  });
+}
+```
+
+- [ ] **Schritt 3.4: Tests laufen lassen — erwartet PASS**
+
+```bash
+cd /home/gekko/Bachelorprojekt/website
+npx vitest run src/lib/coaching-session-db.test.ts 2>&1 | tail -20
+```
+
+Erwartet: alle Tests grün, keine Fehler.
+
+- [ ] **Schritt 3.5: Commit**
+
+```bash
+cd /home/gekko/Bachelorprojekt/.claude/worktrees/feature+ki-coaching-session
+git add website/src/lib/coaching-session-db.ts website/src/lib/coaching-session-db.test.ts
+git commit -m "feat(coaching): coaching-session-db with unit tests"
+```
+
+---
+
+## Task 4: API-Routen
+
+**Files:**
+- Create: `website/src/pages/api/admin/coaching/sessions/index.ts`
+- Create: `website/src/pages/api/admin/coaching/sessions/[id]/index.ts`
+- Create: `website/src/pages/api/admin/coaching/sessions/[id]/steps/[n]/index.ts`
+- Create: `website/src/pages/api/admin/coaching/sessions/[id]/steps/[n]/generate.ts`
+- Create: `website/src/pages/api/admin/coaching/sessions/[id]/complete.ts`
+
+- [ ] **Schritt 4.1: sessions/index.ts (GET Liste + POST Anlegen)**
+
+```typescript
+// website/src/pages/api/admin/coaching/sessions/index.ts
+import type { APIRoute } from 'astro';
+import { getSession, isAdmin } from '../../../../../lib/auth';
+import { createSession, listSessions } from '../../../../../lib/coaching-session-db';
+import { pool } from '../../../../../lib/website-db';
+
+export const prerender = false;
+
+export const GET: APIRoute = async ({ request }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) return new Response('Unauthorized', { status: 401 });
+  const brand = process.env.BRAND || 'mentolder';
+  const sessions = await listSessions(pool, brand);
+  return new Response(JSON.stringify({ sessions }), { headers: { 'content-type': 'application/json' } });
+};
+
+export const POST: APIRoute = async ({ request }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) return new Response('Unauthorized', { status: 401 });
+  const brand = process.env.BRAND || 'mentolder';
+  let body: { title: string; clientId?: string | null; mode?: 'live' | 'prep' };
+  try { body = await request.json(); } catch {
+    return new Response(JSON.stringify({ error: 'Invalid JSON' }), { status: 400, headers: { 'content-type': 'application/json' } });
+  }
+  if (!body.title?.trim()) {
+    return new Response(JSON.stringify({ error: 'title required' }), { status: 400, headers: { 'content-type': 'application/json' } });
+  }
+  const created = await createSession(pool, {
+    brand, title: body.title, createdBy: session.username,
+    clientId: body.clientId ?? null, mode: body.mode ?? 'live',
+  });
+  return new Response(JSON.stringify({ session: created }), { status: 201, headers: { 'content-type': 'application/json' } });
+};
+```
+
+- [ ] **Schritt 4.2: sessions/[id]/index.ts (GET Session + Steps)**
+
+```typescript
+// website/src/pages/api/admin/coaching/sessions/[id]/index.ts
+import type { APIRoute } from 'astro';
+import { getSession, isAdmin } from '../../../../../../lib/auth';
+import { getSession as getCoachingSession } from '../../../../../../lib/coaching-session-db';
+import { pool } from '../../../../../../lib/website-db';
+
+export const prerender = false;
+
+export const GET: APIRoute = async ({ request, params }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) return new Response('Unauthorized', { status: 401 });
+  const coachingSession = await getCoachingSession(pool, params.id as string);
+  if (!coachingSession) return new Response(JSON.stringify({ error: 'Not found' }), { status: 404, headers: { 'content-type': 'application/json' } });
+  return new Response(JSON.stringify({ session: coachingSession }), { headers: { 'content-type': 'application/json' } });
+};
+```
+
+- [ ] **Schritt 4.3: steps/[n]/index.ts (PATCH Eingaben/Notiz)**
+
+```typescript
+// website/src/pages/api/admin/coaching/sessions/[id]/steps/[n]/index.ts
+import type { APIRoute } from 'astro';
+import { getSession, isAdmin } from '../../../../../../../lib/auth';
+import { upsertStep } from '../../../../../../../lib/coaching-session-db';
+import { getStepDef } from '../../../../../../../lib/coaching-session-prompts';
+import { pool } from '../../../../../../../lib/website-db';
+
+export const prerender = false;
+
+export const PATCH: APIRoute = async ({ request, params }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) return new Response('Unauthorized', { status: 401 });
+  const sessionId = params.id as string;
+  const stepNumber = parseInt(params.n as string, 10);
+  if (isNaN(stepNumber) || stepNumber < 1 || stepNumber > 10) {
+    return new Response(JSON.stringify({ error: 'Invalid step number' }), { status: 400, headers: { 'content-type': 'application/json' } });
+  }
+  let body: { coachInputs?: Record<string, string>; coachNotes?: string; status?: 'pending' | 'generated' | 'accepted' | 'skipped' };
+  try { body = await request.json(); } catch {
+    return new Response(JSON.stringify({ error: 'Invalid JSON' }), { status: 400, headers: { 'content-type': 'application/json' } });
+  }
+  const def = getStepDef(stepNumber);
+  const step = await upsertStep(pool, {
+    sessionId, stepNumber, stepName: def.stepName, phase: def.phase,
+    coachInputs: body.coachInputs, coachNotes: body.coachNotes, status: body.status,
+  });
+  return new Response(JSON.stringify({ step }), { headers: { 'content-type': 'application/json' } });
+};
+```
+
+- [ ] **Schritt 4.4: steps/[n]/generate.ts (POST KI aufrufen)**
+
+```typescript
+// website/src/pages/api/admin/coaching/sessions/[id]/steps/[n]/generate.ts
+import type { APIRoute } from 'astro';
+import Anthropic from '@anthropic-ai/sdk';
+import { getSession, isAdmin } from '../../../../../../../lib/auth';
+import { upsertStep } from '../../../../../../../lib/coaching-session-db';
+import { getStepDef, buildUserPrompt } from '../../../../../../../lib/coaching-session-prompts';
+import { pool } from '../../../../../../../lib/website-db';
+
+export const prerender = false;
+
+export const POST: APIRoute = async ({ request, params }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) return new Response('Unauthorized', { status: 401 });
+
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) return new Response(JSON.stringify({ error: 'KI nicht konfiguriert (ANTHROPIC_API_KEY fehlt)' }), { status: 503, headers: { 'content-type': 'application/json' } });
+
+  const sessionId = params.id as string;
+  const stepNumber = parseInt(params.n as string, 10);
+  if (isNaN(stepNumber) || stepNumber < 1 || stepNumber > 10) {
+    return new Response(JSON.stringify({ error: 'Invalid step number' }), { status: 400, headers: { 'content-type': 'application/json' } });
+  }
+
+  let body: { coachInputs: Record<string, string> };
+  try { body = await request.json(); } catch {
+    return new Response(JSON.stringify({ error: 'Invalid JSON' }), { status: 400, headers: { 'content-type': 'application/json' } });
+  }
+
+  const def = getStepDef(stepNumber);
+  const userPrompt = buildUserPrompt(def, body.coachInputs);
+  const model = process.env.COACHING_SESSION_MODEL || 'claude-haiku-4-5-20251001';
+
+  let aiResponse: string;
+  try {
+    const client = new Anthropic({ apiKey });
+    const msg = await client.messages.create({
+      model,
+      max_tokens: 600,
+      system: def.systemPrompt,
+      messages: [{ role: 'user', content: userPrompt }],
+    });
+    aiResponse = msg.content.filter((b): b is Anthropic.TextBlock => b.type === 'text').map(b => b.text).join('');
+  } catch (err) {
+    console.error('[coaching/generate] Anthropic error:', err);
+    return new Response(JSON.stringify({ error: 'KI-Anfrage fehlgeschlagen' }), { status: 502, headers: { 'content-type': 'application/json' } });
+  }
+
+  const step = await upsertStep(pool, {
+    sessionId, stepNumber, stepName: def.stepName, phase: def.phase,
+    coachInputs: body.coachInputs, aiPrompt: userPrompt, aiResponse, status: 'generated',
+  });
+
+  return new Response(JSON.stringify({ step }), { headers: { 'content-type': 'application/json' } });
+};
+```
+
+- [ ] **Schritt 4.5: sessions/[id]/complete.ts (POST Abschließen + Bericht)**
+
+```typescript
+// website/src/pages/api/admin/coaching/sessions/[id]/complete.ts
+import type { APIRoute } from 'astro';
+import Anthropic from '@anthropic-ai/sdk';
+import { getSession, isAdmin } from '../../../../../../lib/auth';
+import { getSession as getCoachingSession, completeSession } from '../../../../../../lib/coaching-session-db';
+import { pool } from '../../../../../../lib/website-db';
+
+export const prerender = false;
+
+export const POST: APIRoute = async ({ request, params }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) return new Response('Unauthorized', { status: 401 });
+
+  const sessionId = params.id as string;
+  const coachingSession = await getCoachingSession(pool, sessionId);
+  if (!coachingSession) return new Response(JSON.stringify({ error: 'Not found' }), { status: 404, headers: { 'content-type': 'application/json' } });
+
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  let report = '# Abschlussbericht\n\n*(KI nicht verfügbar — bitte manuell ergänzen)*';
+
+  if (apiKey) {
+    const stepsText = coachingSession.steps
+      .filter(s => s.stepNumber > 0)
+      .map(s => `## Schritt ${s.stepNumber}: ${s.stepName}\n**Eingaben:** ${JSON.stringify(s.coachInputs)}\n**KI:** ${s.aiResponse ?? '—'}\n**Coach-Notiz:** ${s.coachNotes ?? '—'}`)
+      .join('\n\n');
+
+    try {
+      const client = new Anthropic({ apiKey });
+      const msg = await client.messages.create({
+        model: process.env.COACHING_SESSION_MODEL || 'claude-haiku-4-5-20251001',
+        max_tokens: 1200,
+        system: `Du bist ein Coaching-Protokollant. Erstelle aus den 10 Schritten einer Coaching-Session eine strukturierte Zusammenfassung auf Deutsch.
+Abschnitte: ## Ausgangslage, ## Analyse, ## Lösungsansatz, ## Vereinbarte Schritte, ## Bewertung.
+Maximal 600 Wörter. Konkret und handlungsorientiert.`,
+        messages: [{ role: 'user', content: stepsText }],
+      });
+      report = msg.content.filter((b): b is Anthropic.TextBlock => b.type === 'text').map(b => b.text).join('');
+    } catch (err) {
+      console.error('[coaching/complete] Report generation failed:', err);
+    }
+  }
+
+  await completeSession(pool, sessionId, report);
+  return new Response(JSON.stringify({ ok: true, sessionId }), { headers: { 'content-type': 'application/json' } });
+};
+```
+
+- [ ] **Schritt 4.6: Commit**
+
+```bash
+cd /home/gekko/Bachelorprojekt/.claude/worktrees/feature+ki-coaching-session
+git add website/src/pages/api/admin/coaching/sessions/
+git commit -m "feat(coaching): add 5 API routes for session wizard"
+```
+
+---
+
+## Task 5: SessionWizard.svelte
+
+**Files:**
+- Create: `website/src/components/admin/coaching/SessionWizard.svelte`
+
+- [ ] **Schritt 5.1: Komponente erstellen**
+
+```svelte
+<!-- website/src/components/admin/coaching/SessionWizard.svelte -->
+<script lang="ts">
+  import { STEP_DEFINITIONS } from '../../../lib/coaching-session-prompts';
+  import type { Session, SessionStep } from '../../../lib/coaching-session-db';
+
+  let { sessionId, initialSession }: { sessionId: string; initialSession: Session } = $props();
+
+  const PHASE_COLORS: Record<string, string> = {
+    problem_ziel: 'bg-blue-500',
+    analyse:      'bg-orange-500',
+    loesung:      'bg-green-500',
+    umsetzung:    'bg-purple-500',
+  };
+  const PHASE_TEXT: Record<string, string> = {
+    problem_ziel: 'text-blue-400',
+    analyse:      'text-orange-400',
+    loesung:      'text-green-400',
+    umsetzung:    'text-purple-400',
+  };
+
+  let session = $state<Session>(initialSession);
+  let currentStep = $state(getInitialStep());
+  let inputs = $state<Record<string, string>>({});
+  let coachNotes = $state('');
+  let loading = $state(false);
+  let error = $state('');
+
+  function getInitialStep(): number {
+    const firstPending = session.steps.find(s => s.status === 'pending' || s.status === 'generated');
+    return firstPending?.stepNumber ?? 1;
+  }
+
+  function getStepData(n: number): SessionStep | undefined {
+    return session.steps.find(s => s.stepNumber === n);
+  }
+
+  $effect(() => {
+    const existing = getStepData(currentStep);
+    inputs = existing?.coachInputs ? { ...existing.coachInputs } : {};
+    coachNotes = existing?.coachNotes ?? '';
+  });
+
+  const def = $derived(STEP_DEFINITIONS.find(s => s.stepNumber === currentStep)!);
+  const stepData = $derived(getStepData(currentStep));
+  const canGenerate = $derived(
+    def?.inputs.filter(i => i.required).every(i => (inputs[i.key] ?? '').trim().length > 0) ?? false
+  );
+  const isCompleted = $derived(session.status === 'completed');
+
+  async function saveInputs() {
+    await fetch(`/api/admin/coaching/sessions/${sessionId}/steps/${currentStep}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ coachInputs: inputs, coachNotes }),
+    });
+  }
+
+  async function generate() {
+    loading = true; error = '';
+    try {
+      await saveInputs();
+      const res = await fetch(`/api/admin/coaching/sessions/${sessionId}/steps/${currentStep}/generate`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ coachInputs: inputs }),
+      });
+      const json = await res.json();
+      if (!res.ok) { error = json.error ?? 'Fehler bei KI-Anfrage'; return; }
+      session = {
+        ...session,
+        steps: session.steps.find(s => s.stepNumber === currentStep)
+          ? session.steps.map(s => s.stepNumber === currentStep ? json.step : s)
+          : [...session.steps, json.step],
+      };
+    } catch { error = 'Verbindungsfehler'; }
+    finally { loading = false; }
+  }
+
+  async function accept() {
+    loading = true; error = '';
+    try {
+      await fetch(`/api/admin/coaching/sessions/${sessionId}/steps/${currentStep}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ coachInputs: inputs, coachNotes, status: 'accepted' }),
+      });
+      session = {
+        ...session,
+        steps: session.steps.map(s => s.stepNumber === currentStep ? { ...s, status: 'accepted', coachNotes } : s),
+      };
+      if (currentStep < 10) { currentStep++; }
+    } catch { error = 'Fehler beim Speichern'; }
+    finally { loading = false; }
+  }
+
+  async function reject() {
+    session = {
+      ...session,
+      steps: session.steps.map(s => s.stepNumber === currentStep ? { ...s, status: 'pending', aiResponse: null } : s),
+    };
+    await fetch(`/api/admin/coaching/sessions/${sessionId}/steps/${currentStep}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ coachInputs: inputs, status: 'pending' }),
+    });
+  }
+
+  async function skip() {
+    loading = true;
+    try {
+      await fetch(`/api/admin/coaching/sessions/${sessionId}/steps/${currentStep}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ coachInputs: inputs, coachNotes, status: 'skipped' }),
+      });
+      session = {
+        ...session,
+        steps: session.steps.map(s => s.stepNumber === currentStep ? { ...s, status: 'skipped' } : s),
+      };
+      if (currentStep < 10) { currentStep++; }
+    } catch { error = 'Fehler'; }
+    finally { loading = false; }
+  }
+
+  async function completeSession() {
+    loading = true; error = '';
+    try {
+      const res = await fetch(`/api/admin/coaching/sessions/${sessionId}/complete`, { method: 'POST' });
+      const json = await res.json();
+      if (!res.ok) { error = json.error ?? 'Fehler beim Abschließen'; return; }
+      window.location.href = `/admin/coaching/sessions/${sessionId}`;
+    } catch { error = 'Verbindungsfehler'; }
+    finally { loading = false; }
+  }
+
+  function stepStatus(n: number): 'done' | 'current' | 'pending' {
+    if (n === currentStep) return 'current';
+    const s = getStepData(n);
+    if (s?.status === 'accepted' || s?.status === 'skipped') return 'done';
+    return 'pending';
+  }
+</script>
+
+<div class="wizard">
+  <!-- Fortschrittsbalken -->
+  <div class="progress-bar" aria-label="Fortschritt">
+    {#each STEP_DEFINITIONS as s}
+      {@const status = stepStatus(s.stepNumber)}
+      <button
+        class="progress-step {PHASE_COLORS[s.phase]} {status === 'current' ? 'ring-2 ring-white scale-110' : ''} {status === 'done' ? 'opacity-100' : 'opacity-40'}"
+        onclick={() => { currentStep = s.stepNumber; }}
+        title="Schritt {s.stepNumber}: {s.stepName}"
+        aria-current={status === 'current' ? 'step' : undefined}
+      >
+        {#if status === 'done'}✓{:else}{s.stepNumber}{/if}
+      </button>
+    {/each}
+  </div>
+
+  <!-- Schritt-Header -->
+  <div class="step-header">
+    <span class="phase-label {PHASE_TEXT[def.phase]}">{def.phaseLabel}</span>
+    <h2 class="step-title">Schritt {currentStep}/10 — {def.stepName}</h2>
+  </div>
+
+  {#if error}
+    <div class="error-box">{error}</div>
+  {/if}
+
+  <!-- Eingabefelder -->
+  <div class="inputs-section">
+    {#each def.inputs as input}
+      <div class="input-group">
+        <label class="input-label" for={input.key}>
+          {input.label}{#if input.required}<span class="required">*</span>{/if}
+        </label>
+        {#if input.multiline}
+          <textarea
+            id={input.key}
+            bind:value={inputs[input.key]}
+            rows={3}
+            class="input-field"
+            placeholder={input.required ? 'Pflichtfeld' : 'Optional'}
+            disabled={isCompleted}
+          ></textarea>
+        {:else}
+          <input
+            id={input.key}
+            type="text"
+            bind:value={inputs[input.key]}
+            class="input-field"
+            placeholder={input.required ? 'Pflichtfeld' : 'Optional'}
+            disabled={isCompleted}
+          />
+        {/if}
+      </div>
+    {/each}
+  </div>
+
+  <!-- KI befragen Button -->
+  {#if !isCompleted && stepData?.status !== 'accepted'}
+    <button
+      class="btn-primary"
+      onclick={generate}
+      disabled={!canGenerate || loading}
+    >
+      {loading ? 'KI antwortet…' : 'KI befragen →'}
+    </button>
+  {/if}
+
+  <!-- KI-Antwort -->
+  {#if stepData?.aiResponse}
+    <div class="ai-response-box">
+      <p class="ai-label">KI-Vorschlag</p>
+      <p class="ai-text">{stepData.aiResponse}</p>
+    </div>
+
+    <!-- Notizfeld -->
+    <div class="input-group">
+      <label class="input-label" for="coach-notes">Meine Notiz (optional)</label>
+      <textarea
+        id="coach-notes"
+        bind:value={coachNotes}
+        rows={2}
+        class="input-field"
+        placeholder="Eigene Gedanken, Ergänzungen, Korrekturen…"
+        disabled={isCompleted}
+      ></textarea>
+    </div>
+
+    <!-- Aktions-Buttons -->
+    {#if !isCompleted && stepData.status !== 'accepted'}
+      <div class="action-buttons">
+        {#if currentStep > 1}
+          <button class="btn-secondary" onclick={() => { currentStep--; }}>← Zurück</button>
+        {/if}
+        <button class="btn-ghost" onclick={reject} disabled={loading}>Verwerfen & neu</button>
+        <button class="btn-ghost" onclick={skip} disabled={loading}>Überspringen</button>
+        <button class="btn-primary" onclick={accept} disabled={loading}>Akzeptieren →</button>
+      </div>
+    {/if}
+  {:else if stepData?.status !== 'accepted'}
+    <div class="action-buttons">
+      {#if currentStep > 1}
+        <button class="btn-secondary" onclick={() => { currentStep--; }}>← Zurück</button>
+      {/if}
+      <button class="btn-ghost" onclick={skip} disabled={loading || isCompleted}>Schritt überspringen</button>
+    </div>
+  {:else}
+    <!-- Schritt abgeschlossen -->
+    <div class="accepted-badge">✓ Abgeschlossen</div>
+    <div class="action-buttons">
+      {#if currentStep > 1}
+        <button class="btn-secondary" onclick={() => { currentStep--; }}>← Zurück</button>
+      {/if}
+      {#if currentStep < 10}
+        <button class="btn-primary" onclick={() => { currentStep++; }}>Weiter →</button>
+      {:else if !isCompleted}
+        <button class="btn-complete" onclick={completeSession} disabled={loading}>
+          {loading ? 'Bericht wird erstellt…' : 'Session abschließen & Bericht generieren'}
+        </button>
+      {/if}
+    </div>
+  {/if}
+</div>
+
+<style>
+  .wizard { max-width: 760px; margin: 0 auto; display: flex; flex-direction: column; gap: 1.5rem; }
+  .progress-bar { display: flex; gap: 0.4rem; flex-wrap: wrap; padding: 1rem 0; }
+  .progress-step { width: 2rem; height: 2rem; border-radius: 50%; font-size: 0.75rem; font-weight: 700; color: white; border: none; cursor: pointer; display: flex; align-items: center; justify-content: center; transition: all 0.15s; }
+  .step-header { border-bottom: 1px solid var(--line, #333); padding-bottom: 0.75rem; }
+  .phase-label { font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.08em; font-weight: 600; }
+  .step-title { font-size: 1.4rem; font-weight: 700; color: var(--text-light, #f0f0f0); margin: 0.25rem 0 0; }
+  .inputs-section { display: flex; flex-direction: column; gap: 1rem; }
+  .input-group { display: flex; flex-direction: column; gap: 0.3rem; }
+  .input-label { font-size: 0.8rem; color: var(--text-muted, #888); }
+  .required { color: #f87171; margin-left: 0.2rem; }
+  .input-field { background: var(--bg-2, #1a1a1a); border: 1px solid var(--line, #333); border-radius: 6px; padding: 0.6rem 0.75rem; color: var(--text-light, #f0f0f0); font-size: 0.9rem; width: 100%; resize: vertical; }
+  .input-field:focus { outline: none; border-color: var(--gold, #c9a55c); }
+  .ai-response-box { background: var(--bg-2, #1a1a1a); border: 1px solid var(--gold, #c9a55c); border-radius: 8px; padding: 1rem; }
+  .ai-label { font-size: 0.7rem; text-transform: uppercase; letter-spacing: 0.1em; color: var(--gold, #c9a55c); margin: 0 0 0.5rem; }
+  .ai-text { color: var(--text-light, #f0f0f0); font-size: 0.9rem; line-height: 1.6; white-space: pre-wrap; margin: 0; }
+  .action-buttons { display: flex; gap: 0.75rem; flex-wrap: wrap; align-items: center; }
+  .btn-primary { padding: 0.6rem 1.4rem; background: var(--gold, #c9a55c); color: #111; font-weight: 700; border: none; border-radius: 6px; cursor: pointer; font-size: 0.9rem; }
+  .btn-primary:disabled { opacity: 0.5; cursor: not-allowed; }
+  .btn-secondary { padding: 0.5rem 1rem; background: transparent; color: var(--text-muted, #888); border: 1px solid var(--line, #444); border-radius: 6px; cursor: pointer; font-size: 0.85rem; }
+  .btn-ghost { padding: 0.5rem 1rem; background: transparent; color: var(--text-muted, #888); border: none; cursor: pointer; font-size: 0.85rem; text-decoration: underline; }
+  .btn-complete { padding: 0.7rem 1.6rem; background: #22c55e; color: #111; font-weight: 700; border: none; border-radius: 6px; cursor: pointer; }
+  .btn-complete:disabled { opacity: 0.5; cursor: not-allowed; }
+  .accepted-badge { display: inline-block; background: #22c55e20; color: #22c55e; border: 1px solid #22c55e40; border-radius: 4px; padding: 0.3rem 0.75rem; font-size: 0.8rem; font-weight: 600; }
+  .error-box { background: #ef444420; border: 1px solid #ef444440; border-radius: 6px; padding: 0.75rem; color: #f87171; font-size: 0.85rem; }
+</style>
+```
+
+- [ ] **Schritt 5.2: Commit**
+
+```bash
+cd /home/gekko/Bachelorprojekt/.claude/worktrees/feature+ki-coaching-session
+git add website/src/components/admin/coaching/SessionWizard.svelte
+git commit -m "feat(coaching): SessionWizard Svelte 5 component"
+```
+
+---
+
+## Task 6: Astro-Seiten
+
+**Files:**
+- Create: `website/src/pages/admin/coaching/sessions/index.astro`
+- Create: `website/src/pages/admin/coaching/sessions/new.astro`
+- Create: `website/src/pages/admin/coaching/sessions/[id].astro`
+
+- [ ] **Schritt 6.1: Sessions-Liste**
+
+```astro
+---
+// website/src/pages/admin/coaching/sessions/index.astro
+import AdminLayout from '../../../../layouts/AdminLayout.astro';
+import { getSession, getLoginUrl, isAdmin } from '../../../../lib/auth';
+import { listSessions } from '../../../../lib/coaching-session-db';
+import { pool } from '../../../../lib/website-db';
+
+const session = await getSession(Astro.request.headers.get('cookie'));
+if (!session) return Astro.redirect(getLoginUrl(Astro.url.pathname));
+if (!isAdmin(session)) return Astro.redirect('/admin');
+
+const brand = process.env.BRAND || 'mentolder';
+let sessions: Awaited<ReturnType<typeof listSessions>> = [];
+try { sessions = await listSessions(pool, brand); } catch { /* coaching schema may not exist yet */ }
+
+function fmtDate(d: Date | string | null) {
+  if (!d) return '—';
+  return new Date(d).toLocaleDateString('de-DE', { day: '2-digit', month: '2-digit', year: 'numeric' });
+}
+const statusLabel: Record<string, string> = { active: 'Läuft', completed: 'Abgeschlossen', abandoned: 'Abgebrochen' };
+---
+
+<AdminLayout title="Coaching-Sessions">
+  <div class="page">
+    <header class="page-head">
+      <nav class="crumbs">
+        <a href="/admin">Admin</a><span class="sep">›</span>
+        <a href="/admin/coaching/sessions">Coaching</a><span class="sep">›</span>Sessions
+      </nav>
+      <div class="head-row">
+        <h1>Coaching-Sessions</h1>
+        <a href="/admin/coaching/sessions/new" class="btn-primary">+ Neue Session</a>
+      </div>
+    </header>
+
+    {sessions.length === 0 ? (
+      <div class="empty">
+        <p>Noch keine Sessions. Starte deine erste triadische KI-Coaching-Session.</p>
+        <a href="/admin/coaching/sessions/new" class="btn-primary">Erste Session starten →</a>
+      </div>
+    ) : (
+      <table class="table">
+        <thead><tr><th>Titel</th><th>Klient</th><th>Datum</th><th>Status</th><th></th></tr></thead>
+        <tbody>
+          {sessions.map(s => (
+            <tr>
+              <td><a href={`/admin/coaching/sessions/${s.id}`}>{s.title}</a></td>
+              <td>{s.clientId ? '–' : 'Vorbereitung'}</td>
+              <td>{fmtDate(s.createdAt)}</td>
+              <td><span class={`badge ${s.status}`}>{statusLabel[s.status] ?? s.status}</span></td>
+              <td><a href={`/admin/coaching/sessions/${s.id}`} class="btn-sm">Öffnen</a></td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    )}
+  </div>
+</AdminLayout>
+
+<style>
+  .page { max-width: 1000px; margin: 0 auto; padding: 1rem 1.5rem 3rem; }
+  .page-head { margin-bottom: 1.5rem; }
+  .crumbs { font-size: 0.78rem; color: var(--text-muted,#888); margin-bottom: 0.4rem; }
+  .crumbs a { color: var(--text-muted,#888); text-decoration: none; }
+  .crumbs .sep { margin: 0 0.4rem; }
+  .head-row { display: flex; align-items: center; justify-content: space-between; gap: 1rem; }
+  h1 { font-size: 1.8rem; font-weight: 700; color: var(--text-light,#f0f0f0); margin: 0; }
+  .btn-primary { padding: 0.55rem 1.2rem; background: var(--gold,#c9a55c); color: #111; font-weight: 700; border-radius: 6px; text-decoration: none; font-size: 0.85rem; }
+  .btn-sm { padding: 0.3rem 0.7rem; border: 1px solid var(--line,#444); border-radius: 4px; font-size: 0.82rem; color: var(--text-muted,#888); text-decoration: none; }
+  .empty { background: var(--bg-2,#1a1a1a); border: 1px solid var(--line,#333); border-radius: 8px; padding: 2rem; text-align: center; color: var(--text-muted,#888); display: flex; flex-direction: column; gap: 1rem; align-items: center; }
+  .table { width: 100%; border-collapse: collapse; }
+  .table th { text-align: left; padding: 0.5rem 0.75rem; border-bottom: 1px solid var(--line,#333); font-size: 0.82rem; color: var(--text-muted,#888); }
+  .table td { padding: 0.6rem 0.75rem; border-bottom: 1px solid var(--line,#222); }
+  .table a { color: var(--gold,#c9a55c); text-decoration: none; }
+  .badge { font-size: 0.72rem; padding: 0.2rem 0.5rem; border-radius: 4px; font-weight: 600; }
+  .badge.active { background: #3b82f620; color: #60a5fa; }
+  .badge.completed { background: #22c55e20; color: #4ade80; }
+  .badge.abandoned { background: #64748b20; color: #94a3b8; }
+</style>
+```
+
+- [ ] **Schritt 6.2: Neue Session anlegen**
+
+```astro
+---
+// website/src/pages/admin/coaching/sessions/new.astro
+import AdminLayout from '../../../../layouts/AdminLayout.astro';
+import { getSession, getLoginUrl, isAdmin } from '../../../../lib/auth';
+import { listCustomers } from '../../../../lib/website-db';
+
+const session = await getSession(Astro.request.headers.get('cookie'));
+if (!session) return Astro.redirect(getLoginUrl(Astro.url.pathname));
+if (!isAdmin(session)) return Astro.redirect('/admin');
+
+let customers: { id: string; name: string }[] = [];
+try {
+  const all = await listCustomers({ brand: process.env.BRAND || 'mentolder' });
+  customers = all.map(c => ({ id: c.id, name: c.name }));
+} catch { /* ignore */ }
+
+const today = new Date().toLocaleDateString('de-DE', { day: '2-digit', month: '2-digit', year: 'numeric' });
+---
+
+<AdminLayout title="Neue Coaching-Session">
+  <div class="page">
+    <nav class="crumbs">
+      <a href="/admin">Admin</a><span class="sep">›</span>
+      <a href="/admin/coaching/sessions">Sessions</a><span class="sep">›</span>Neu
+    </nav>
+    <h1>Neue Session</h1>
+
+    <form class="form" id="new-session-form">
+      <div class="field">
+        <label for="title">Titel der Session</label>
+        <input id="title" name="title" type="text" value={`Session ${today}`} required class="input" />
+      </div>
+      <div class="field">
+        <label for="clientId">Klient (optional)</label>
+        <select id="clientId" name="clientId" class="input">
+          <option value="">— Vorbereitungsrunde (kein Klient) —</option>
+          {customers.map(c => <option value={c.id}>{c.name}</option>)}
+        </select>
+      </div>
+      <div class="field">
+        <label>Modus</label>
+        <div class="radio-group">
+          <label><input type="radio" name="mode" value="live" checked /> Live-Session (mit Klient)</label>
+          <label><input type="radio" name="mode" value="prep" /> Vorbereitung</label>
+        </div>
+      </div>
+      <div id="form-error" class="error" style="display:none"></div>
+      <button type="submit" class="btn-primary" id="submit-btn">Session starten →</button>
+    </form>
+  </div>
+</AdminLayout>
+
+<script>
+  document.getElementById('new-session-form')?.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const btn = document.getElementById('submit-btn') as HTMLButtonElement;
+    const errEl = document.getElementById('form-error') as HTMLElement;
+    btn.disabled = true; btn.textContent = 'Erstelle…';
+    errEl.style.display = 'none';
+    const form = e.target as HTMLFormElement;
+    const data = Object.fromEntries(new FormData(form));
+    const res = await fetch('/api/admin/coaching/sessions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: data.title, clientId: data.clientId || null, mode: data.mode }),
+    });
+    const json = await res.json();
+    if (res.ok) {
+      window.location.href = `/admin/coaching/sessions/${json.session.id}`;
+    } else {
+      errEl.textContent = json.error ?? 'Fehler'; errEl.style.display = 'block';
+      btn.disabled = false; btn.textContent = 'Session starten →';
+    }
+  });
+</script>
+
+<style>
+  .page { max-width: 560px; margin: 0 auto; padding: 1rem 1.5rem 3rem; }
+  .crumbs { font-size: 0.78rem; color: var(--text-muted,#888); margin-bottom: 0.4rem; }
+  .crumbs a { color: var(--text-muted,#888); text-decoration: none; }
+  .crumbs .sep { margin: 0 0.4rem; }
+  h1 { font-size: 1.8rem; font-weight: 700; color: var(--text-light,#f0f0f0); margin: 0 0 2rem; }
+  .form { display: flex; flex-direction: column; gap: 1.25rem; }
+  .field { display: flex; flex-direction: column; gap: 0.4rem; }
+  label { font-size: 0.82rem; color: var(--text-muted,#888); }
+  .input { background: var(--bg-2,#1a1a1a); border: 1px solid var(--line,#333); border-radius: 6px; padding: 0.6rem 0.75rem; color: var(--text-light,#f0f0f0); font-size: 0.9rem; }
+  .radio-group { display: flex; gap: 1.5rem; color: var(--text-light,#f0f0f0); font-size: 0.9rem; }
+  .btn-primary { align-self: flex-start; padding: 0.65rem 1.5rem; background: var(--gold,#c9a55c); color: #111; font-weight: 700; border: none; border-radius: 6px; cursor: pointer; font-size: 0.9rem; }
+  .btn-primary:disabled { opacity: 0.5; }
+  .error { color: #f87171; font-size: 0.85rem; padding: 0.5rem 0.75rem; background: #ef444415; border-radius: 4px; }
+</style>
+```
+
+- [ ] **Schritt 6.3: Wizard-Seite [id].astro**
+
+```astro
+---
+// website/src/pages/admin/coaching/sessions/[id].astro
+import AdminLayout from '../../../../layouts/AdminLayout.astro';
+import SessionWizard from '../../../../components/admin/coaching/SessionWizard.svelte';
+import { getSession as getAuthSession, getLoginUrl, isAdmin } from '../../../../lib/auth';
+import { getSession as getCoachingSession } from '../../../../lib/coaching-session-db';
+import { pool } from '../../../../lib/website-db';
+
+const authSession = await getAuthSession(Astro.request.headers.get('cookie'));
+if (!authSession) return Astro.redirect(getLoginUrl(Astro.url.pathname));
+if (!isAdmin(authSession)) return Astro.redirect('/admin');
+
+const sessionId = Astro.params.id as string;
+let coachingSession = null;
+try { coachingSession = await getCoachingSession(pool, sessionId); } catch { /* ignore */ }
+
+if (!coachingSession) return Astro.redirect('/admin/coaching/sessions');
+
+// Abgeschlossene Session: Bericht anzeigen
+const report = coachingSession.status === 'completed'
+  ? coachingSession.steps.find(s => s.stepNumber === 0)
+  : null;
+---
+
+<AdminLayout title={`Session: ${coachingSession.title}`}>
+  <div class="page">
+    <nav class="crumbs">
+      <a href="/admin">Admin</a><span class="sep">›</span>
+      <a href="/admin/coaching/sessions">Sessions</a><span class="sep">›</span>
+      {coachingSession.title}
+    </nav>
+
+    {report ? (
+      <div class="report">
+        <div class="report-head">
+          <h1>Abgeschlossen: {coachingSession.title}</h1>
+          <a href="#report-text" id="download-btn" class="btn-secondary">Bericht herunterladen</a>
+        </div>
+        <div id="report-text" class="report-body prose">
+          <div set:html={report.aiResponse?.replace(/\n/g, '<br>') ?? ''} />
+        </div>
+        <a href="/admin/coaching/sessions" class="btn-ghost">← Zur Übersicht</a>
+      </div>
+    ) : (
+      <SessionWizard sessionId={sessionId} initialSession={coachingSession} client:load />
+    )}
+  </div>
+</AdminLayout>
+
+<script>
+  document.getElementById('download-btn')?.addEventListener('click', (e) => {
+    e.preventDefault();
+    const text = document.getElementById('report-text')?.innerText ?? '';
+    const blob = new Blob([text], { type: 'text/markdown' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a'); a.href = url; a.download = 'coaching-bericht.md'; a.click();
+    URL.revokeObjectURL(url);
+  });
+</script>
+
+<style>
+  .page { max-width: 800px; margin: 0 auto; padding: 1rem 1.5rem 3rem; }
+  .crumbs { font-size: 0.78rem; color: var(--text-muted,#888); margin-bottom: 1rem; }
+  .crumbs a { color: var(--text-muted,#888); text-decoration: none; }
+  .crumbs .sep { margin: 0 0.4rem; }
+  .report { display: flex; flex-direction: column; gap: 1.5rem; }
+  .report-head { display: flex; align-items: center; justify-content: space-between; gap: 1rem; }
+  h1 { font-size: 1.5rem; font-weight: 700; color: var(--text-light,#f0f0f0); margin: 0; }
+  .report-body { background: var(--bg-2,#1a1a1a); border: 1px solid var(--line,#333); border-radius: 8px; padding: 1.5rem; color: var(--text-light,#f0f0f0); line-height: 1.7; }
+  .btn-secondary { padding: 0.5rem 1rem; border: 1px solid var(--line,#444); border-radius: 6px; color: var(--text-muted,#888); text-decoration: none; font-size: 0.85rem; }
+  .btn-ghost { color: var(--text-muted,#888); text-decoration: underline; font-size: 0.85rem; }
+</style>
+```
+
+- [ ] **Schritt 6.4: Commit**
+
+```bash
+cd /home/gekko/Bachelorprojekt/.claude/worktrees/feature+ki-coaching-session
+git add website/src/pages/admin/coaching/
+git commit -m "feat(coaching): add 3 Astro pages for session wizard"
+```
+
+---
+
+## Task 7: AdminLayout Navigation
+
+**Files:**
+- Modify: `website/src/layouts/AdminLayout.astro`
+
+- [ ] **Schritt 7.1: Neue Navigationsgruppe einfügen**
+
+In `AdminLayout.astro` nach der `Wissen`-Gruppe (suche nach `label: 'Wissen'`):
+
+```typescript
+// VORHER (Ende der Wissen-Gruppe):
+    },
+  },
+  {
+    label: 'System',
+
+// NACHHER:
+    },
+  },
+  {
+    label: 'Coaching',
+    items: [
+      { href: '/admin/coaching/sessions',     label: 'Sessions',     icon: 'clipboard',
+        matches: ['/admin/coaching/sessions'] },
+      { href: '/admin/coaching/sessions/new', label: 'Neue Session', icon: 'plus' },
+    ],
+  },
+  {
+    label: 'System',
+```
+
+- [ ] **Schritt 7.2: Commit**
+
+```bash
+cd /home/gekko/Bachelorprojekt/.claude/worktrees/feature+ki-coaching-session
+git add website/src/layouts/AdminLayout.astro
+git commit -m "feat(coaching): add Coaching navigation group to AdminLayout"
+```
+
+---
+
+## Task 8: Smoke Test + listCustomers prüfen
+
+**Files:**
+- Check: `website/src/lib/website-db.ts` (listCustomers export)
+
+- [ ] **Schritt 8.1: listCustomers prüfen**
+
+```bash
+grep -n "listCustomers\|export.*function.*listCustomers\|export.*listCustomers" \
+  /home/gekko/Bachelorprojekt/.claude/worktrees/feature+ki-coaching-session/website/src/lib/website-db.ts
+```
+
+Falls `listCustomers` nicht exportiert: Import in `new.astro` anpassen. Alternativer Query:
+
+```typescript
+// Falls listCustomers fehlt — direkt ersetzen in new.astro Frontmatter:
+const customersRes = await pool.query(
+  `SELECT id, name FROM public.customers WHERE brand = $1 AND enrollment_declined = false ORDER BY name`,
+  [process.env.BRAND || 'mentolder']
+);
+customers = customersRes.rows;
+```
+
+- [ ] **Schritt 8.2: Offline Tests laufen lassen**
+
+```bash
+cd /home/gekko/Bachelorprojekt/.claude/worktrees/feature+ki-coaching-session
+task test:all 2>&1 | tail -30
+```
+
+Erwartet: alle Tests grün.
+
+- [ ] **Schritt 8.3: Dev-Server starten und manuell testen**
+
+```bash
+cd /home/gekko/Bachelorprojekt/.claude/worktrees/feature+ki-coaching-session/website
+task website:dev
+```
+
+Prüfen:
+1. `/admin/coaching/sessions` — leere Tabelle mit „Erste Session starten"-CTA
+2. `/admin/coaching/sessions/new` — Formular mit Titel + Klient-Dropdown
+3. Nach Submit: Redirect auf `/admin/coaching/sessions/[id]` mit Wizard
+4. Schritt 1 Eingaben ausfüllen → „KI befragen" → Antwort erscheint
+5. „Akzeptieren" → nächster Schritt
+
+- [ ] **Schritt 8.4: Final Commit + Push**
+
+```bash
+cd /home/gekko/Bachelorprojekt/.claude/worktrees/feature+ki-coaching-session
+git add -A
+git status  # Überprüfen: nur erwartete Dateien
+git commit -m "feat(coaching): triadisches KI-Coaching session wizard complete"
+git push -u origin feature/ki-coaching-session
+```
+
+---
+
+## Self-Review Ergebnis
+
+**Spec-Abdeckung:**
+- [x] coaching.sessions + session_steps DB — Task 1
+- [x] coaching-session-db.ts + Tests — Task 3
+- [x] 10 Schritt-Definitionen mit Prompts — Task 2
+- [x] 5 API-Routen — Task 4
+- [x] SessionWizard.svelte (Stepper, Fortschrittsbalken, Human-in-the-loop) — Task 5
+- [x] Sessions-Liste, Neu-Formular, Wizard-Seite — Task 6
+- [x] AdminLayout Navigation — Task 7
+- [x] Abschlussbericht + Markdown-Export — Tasks 4.5 + 6.3
+- [x] `mode: 'prep'` für Vorbereitungsrunde — Tasks 1, 4.1, 6.2
+- [x] Fehlerbehandlung KI fehlt → 503 — Task 4.4
+
+**Typ-Konsistenz:** `Session`, `SessionStep`, `CreateSessionArgs`, `UpsertStepArgs` in `coaching-session-db.ts` definiert und konsistent in API-Routen und Svelte-Komponente verwendet.

--- a/docs/superpowers/plans/2026-05-14-ki-coaching-session.md
+++ b/docs/superpowers/plans/2026-05-14-ki-coaching-session.md
@@ -1,4 +1,5 @@
 ---
+ticket_id: T000370
 title: KI-Coaching Session-Wizard Implementation Plan
 domains: []
 status: active

--- a/docs/superpowers/specs/2026-05-14-ki-coaching-session-design.md
+++ b/docs/superpowers/specs/2026-05-14-ki-coaching-session-design.md
@@ -1,0 +1,210 @@
+---
+title: Triadisches KI-Coaching — Session-Wizard
+status: draft
+created: 2026-05-14
+domains: [website, db]
+related_pr: null
+---
+
+# Triadisches KI-Coaching — Session-Wizard Spec
+
+## Zweck
+
+Gekko (Coach) soll das "Triadische KI-Coaching"-Verfahren (10 Mega-Prompts, 4 Phasen) direkt auf der Plattform durchführen können. Ein geführter 10-Schritt-Wizard im Admin-Bereich leitet durch die Phasen, generiert pro Schritt einen KI-Vorschlag via Anthropic API, und speichert ein vollständiges Sitzungsprotokoll. Zunächst admin-only; Klienten-Ansicht ist als späteres Feature vorgesehen.
+
+## Quelle
+
+Basis ist das Dokument `uploads/coaching-mit-ki.PDF` ("Triadisches KI-Coaching", Geißler). Die 10 Mega-Prompts sind in 4 Phasen gegliedert:
+
+| Phase | Schritte | Themen |
+|---|---|---|
+| 1 — Problem & Ziel | 1–3 | Erstanamnese, Schlüsselaffekt, Zielformulierung |
+| 2 — Analyse | 4–6 | Teufelskreislauf, Ressourcenanalyse, Komplementärkräfte |
+| 3 — Lösung | 7–8 | Lösungsentwicklung/Bildarbeit, Erfolgsimagination |
+| 4 — Umsetzung | 9–10 | Goldstücks-Aktivität, Transfersicherung |
+
+## Nicht-Ziele
+
+- Kein direkter Klienten-Zugang in dieser Phase — alles läuft durch den Coach.
+- Keine Echtzeit-Synchronisation Coach ↔ Klient.
+- Keine automatische Veröffentlichung von KI-Antworten in andere Surfaces (Brett, Fragebogen etc.) — das bleibt dem bestehenden Publish-Pfad vorbehalten.
+- Kein Ersatz für die bestehende Meetings/Besprechungs-Infrastruktur.
+
+## Datenmodell
+
+Zwei neue Tabellen im `coaching`-Schema:
+
+### `coaching.sessions`
+
+```sql
+id            uuid PRIMARY KEY DEFAULT gen_random_uuid()
+brand         text NOT NULL                    -- 'mentolder' | 'korczewski'
+client_id     uuid REFERENCES customers(id)     -- NULL = Vorbereitungsrunde
+mode          text NOT NULL DEFAULT 'live'     -- 'live' | 'prep'
+title         text NOT NULL                    -- z.B. "Session Max M. – 14.05."
+status        text NOT NULL DEFAULT 'active'   -- 'active' | 'completed' | 'abandoned'
+created_by    text NOT NULL                    -- Keycloak-Username
+created_at    timestamptz NOT NULL DEFAULT now()
+completed_at  timestamptz
+```
+
+### `coaching.session_steps`
+
+```sql
+id            uuid PRIMARY KEY DEFAULT gen_random_uuid()
+session_id    uuid NOT NULL REFERENCES coaching.sessions(id) ON DELETE CASCADE
+step_number   int NOT NULL                     -- 1–10 (0 = Abschlussbericht)
+step_name     text NOT NULL                    -- "Erstanamnese", "Schlüsselaffekt", …
+phase         text NOT NULL                    -- 'problem_ziel' | 'analyse' | 'loesung' | 'umsetzung'
+coach_inputs  jsonb NOT NULL DEFAULT '{}'      -- Freitextfelder des Coaches
+ai_prompt     text                             -- generierter Prompt (Transparenz)
+ai_response   text                             -- KI-Antwort
+coach_notes   text                             -- Notiz des Coaches neben KI-Antwort
+status        text NOT NULL DEFAULT 'pending'  -- 'pending' | 'generated' | 'accepted' | 'skipped'
+generated_at  timestamptz
+UNIQUE (session_id, step_number)
+```
+
+`step_number = 0` reserviert für den automatisch generierten Abschlussbericht.
+
+## Architektur
+
+```
+/admin/coaching/sessions           ← Liste aller Sessions
+/admin/coaching/sessions/new       ← Neue Session anlegen (Klient + Titel)
+/admin/coaching/sessions/[id]      ← Wizard (SessionWizard.svelte, client:load)
+
+API:
+POST   /api/admin/coaching/sessions
+GET    /api/admin/coaching/sessions/[id]
+PATCH  /api/admin/coaching/sessions/[id]/steps/[n]
+POST   /api/admin/coaching/sessions/[id]/steps/[n]/generate
+POST   /api/admin/coaching/sessions/[id]/complete
+
+Lib:
+website/src/lib/coaching-session-db.ts      ← DB-Funktionen
+website/src/lib/coaching-session-prompts.ts ← 10 Schritt-Prompts
+```
+
+## UI-Komponente: SessionWizard
+
+Svelte 5 Komponente unter `website/src/components/admin/coaching/SessionWizard.svelte`.
+
+### Fortschrittsbalken
+
+10 Segmente, nach Phase eingefärbt:
+- Blau: Schritte 1–3 (Problem & Ziel)
+- Orange: Schritte 4–6 (Analyse)
+- Grün: Schritte 7–8 (Lösung)
+- Lila: Schritte 9–10 (Umsetzung)
+
+Abgeschlossene Schritte (status = `accepted` | `skipped`) zeigen ein Häkchen. Aktueller Schritt ist hervorgehoben.
+
+### Schritt-Zustandsmaschine
+
+```
+pending → [KI befragen] → generated → [Akzeptieren] → accepted (→ nächster Schritt)
+                                    ↘ [Verwerfen & neu] → pending
+```
+
+Der Coach kann außerdem jeden Schritt überspringen (`skipped`) — z.B. wenn der Klient spontan ein Thema abschließt.
+
+### Pro Schritt sichtbar
+
+1. Schritttitel + Phasenbezeichnung
+2. Eingabefelder (schritt-spezifisch, aus `STEP_DEFINITIONS`)
+3. Button „KI befragen →" (disabled solange Pflichtfelder leer)
+4. KI-Antwort-Box (erscheint nach Generierung, readonly)
+5. Notizfeld des Coaches (immer editierbar)
+6. Aktions-Buttons: „← Zurück" | „Verwerfen & neu" | „Akzeptieren →"
+
+### Session-Abschluss
+
+Nach Schritt 10 erscheint ein „Session abschließen"-Button. Der `/complete`-Endpunkt:
+1. Setzt `sessions.status = 'completed'`, `completed_at = now()`
+2. Ruft Anthropic API mit allen 10 Schritten auf → generiert Markdown-Zusammenfassung
+3. Speichert Bericht als `session_steps`-Eintrag mit `step_number = 0`
+4. Gibt die Session-ID zurück → UI leitet auf `/admin/coaching/sessions/[id]` (Detailansicht mit Export-Button)
+
+## KI-Integration
+
+### Modell
+
+`claude-haiku-4-5-20251001` als Default. Über `COACHING_SESSION_MODEL` in der Umgebungsvariablen überschreibbar.
+
+### Prompt-Struktur (Datei: `coaching-session-prompts.ts`)
+
+Jeder der 10 Schritte hat einen eigenen System-Prompt und eine Menge benannter Eingabefelder (`STEP_DEFINITIONS`). Beispiel Schritt 1:
+
+```typescript
+{
+  stepNumber: 1,
+  stepName: 'Erstanamnese',
+  phase: 'problem_ziel',
+  inputs: [
+    { key: 'anlass', label: 'Anlass der Session', required: true },
+    { key: 'vorerfahrung', label: 'Vorerfahrung mit Coaching', required: false },
+    { key: 'situation', label: 'Aktuelle Situation', required: true },
+  ],
+  systemPrompt: `Du bist ein erfahrener Coaching-Assistent (Triadisches KI-Coaching nach Geißler).
+Deine Aufgabe: basierend auf den Coach-Eingaben eine präzise Gesprächsintervention
+vorschlagen. Auf Deutsch. Maximal 250 Wörter. Kein wörtliches Buchzitat.`,
+  userTemplate: `Anlass: {anlass}\nVorerfahrung: {vorerfahrung}\nAktuelle Situation: {situation}`,
+}
+```
+
+Die Coach-Eingaben werden **serverseitig** in den Prompt interpoliert. Der Client überträgt nur die Rohwerte. Der fertige Prompt wird in `session_steps.ai_prompt` gespeichert.
+
+### Fehlerbehandlung
+
+- Schlägt die Anthropic-Anfrage fehl: Schritt bleibt auf `pending`, Coach sieht Toast-Fehlermeldung, kann erneut versuchen oder überspringen.
+- `ANTHROPIC_API_KEY` nicht gesetzt: `/generate`-Endpoint gibt 503 zurück, UI zeigt Hinweis.
+
+## Abschlussbericht
+
+Endpunkt `POST /api/admin/coaching/sessions/[id]/complete` ruft Anthropic ein zweites Mal auf:
+
+```
+System: Du bist ein Coaching-Protokollant. Erstelle aus den 10 Schritten einer
+        Coaching-Session eine strukturierte Zusammenfassung auf Deutsch.
+        Abschnitte: Ausgangslage, Analyse, Lösungsansatz, Vereinbarte Schritte, Bewertung.
+
+User:   [alle 10 Schritte mit Coach-Eingaben + KI-Antworten + Coach-Notizen]
+```
+
+Export: Der Coach kann den Bericht als Markdown herunterladen. PDF-Export ist Folgearbeit.
+
+## Navigation
+
+`AdminLayout.astro` erhält eine neue Navigationsgruppe **„Coaching"** (unterhalb von „Wissen"):
+
+```typescript
+{
+  label: 'Coaching',
+  items: [
+    { href: '/admin/coaching/sessions',     label: 'Sessions',      icon: 'clipboard' },
+    { href: '/admin/coaching/sessions/new', label: 'Neue Session',  icon: 'plus' },
+  ],
+}
+```
+
+## Sessions-Liste
+
+`/admin/coaching/sessions` zeigt eine Tabelle: Titel, Klient (oder „Vorbereitung"), Datum, Status, Link zur Session. Leer-Zustand mit CTA „Erste Session starten →".
+
+## Klienten-Ansicht (späteres Feature)
+
+Nicht in diesem Prototyp. Vorgesehen: ein separates Read-only-View unter `/portal/coaching/sessions/[id]`, das der Coach per Toggle freischaltet. Technisch: ein `shared_with_client`-Flag auf `coaching.sessions`.
+
+## Test-Strategie
+
+- **Unit:** `coaching-session-prompts.ts` — alle 10 Schritt-Definitionen vollständig (keys, labels, required-Felder vorhanden)
+- **Integration:** Session anlegen → Schritt 1 generieren → Schritt akzeptieren → Session abschließen → Bericht vorhanden
+- **Privacy:** `/generate`-Endpoint wirft 403 ohne Admin-Session
+- **Fehlerfall:** Anthropic-Key fehlt → 503, kein 500
+
+## Offene Punkte
+
+- PDF-Export des Abschlussberichts: Folgearbeit (puppeteer oder browser-print).
+- Klienten-Ansicht: separates Feature-Ticket nach Prototyp-Abnahme.
+- Welche der 10 Schritt-Eingabefelder sind `required`? Im Prototyp mindestens ein Pflichtfeld pro Schritt — finale Liste im Implementierungsplan.

--- a/k3d/website-schema.yaml
+++ b/k3d/website-schema.yaml
@@ -244,6 +244,36 @@ data:
       CREATE INDEX IF NOT EXISTS idx_drafts_kind_status ON coaching.drafts(template_kind, status);
       CREATE INDEX IF NOT EXISTS idx_drafts_chunk ON coaching.drafts(knowledge_chunk_id);
 
+      CREATE TABLE IF NOT EXISTS coaching.sessions (
+        id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        brand         TEXT NOT NULL DEFAULT 'mentolder',
+        client_id     UUID REFERENCES public.customers(id) ON DELETE SET NULL,
+        mode          TEXT NOT NULL DEFAULT 'live' CHECK (mode IN ('live','prep')),
+        title         TEXT NOT NULL,
+        status        TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active','completed','abandoned')),
+        created_by    TEXT NOT NULL,
+        created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+        completed_at  TIMESTAMPTZ
+      );
+      CREATE INDEX IF NOT EXISTS idx_sessions_brand ON coaching.sessions(brand);
+      CREATE INDEX IF NOT EXISTS idx_sessions_client ON coaching.sessions(client_id);
+
+      CREATE TABLE IF NOT EXISTS coaching.session_steps (
+        id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        session_id    UUID NOT NULL REFERENCES coaching.sessions(id) ON DELETE CASCADE,
+        step_number   INT NOT NULL,
+        step_name     TEXT NOT NULL,
+        phase         TEXT NOT NULL CHECK (phase IN ('problem_ziel','analyse','loesung','umsetzung')),
+        coach_inputs  JSONB NOT NULL DEFAULT '{}',
+        ai_prompt     TEXT,
+        ai_response   TEXT,
+        coach_notes   TEXT,
+        status        TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending','generated','accepted','skipped')),
+        generated_at  TIMESTAMPTZ,
+        UNIQUE (session_id, step_number)
+      );
+      CREATE INDEX IF NOT EXISTS idx_session_steps_session ON coaching.session_steps(session_id);
+
       -- Tables are owned by postgres (init script runs as postgres). Grant the
       -- application role explicit access; ALTER DEFAULT PRIVILEGES covers tables
       -- added in later migrations.
@@ -777,6 +807,36 @@ data:
       CREATE INDEX IF NOT EXISTS idx_drafts_book_status ON coaching.drafts(book_id, status);
       CREATE INDEX IF NOT EXISTS idx_drafts_kind_status ON coaching.drafts(template_kind, status);
       CREATE INDEX IF NOT EXISTS idx_drafts_chunk ON coaching.drafts(knowledge_chunk_id);
+
+      CREATE TABLE IF NOT EXISTS coaching.sessions (
+        id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        brand         TEXT NOT NULL DEFAULT 'mentolder',
+        client_id     UUID REFERENCES public.customers(id) ON DELETE SET NULL,
+        mode          TEXT NOT NULL DEFAULT 'live' CHECK (mode IN ('live','prep')),
+        title         TEXT NOT NULL,
+        status        TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active','completed','abandoned')),
+        created_by    TEXT NOT NULL,
+        created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+        completed_at  TIMESTAMPTZ
+      );
+      CREATE INDEX IF NOT EXISTS idx_sessions_brand ON coaching.sessions(brand);
+      CREATE INDEX IF NOT EXISTS idx_sessions_client ON coaching.sessions(client_id);
+
+      CREATE TABLE IF NOT EXISTS coaching.session_steps (
+        id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        session_id    UUID NOT NULL REFERENCES coaching.sessions(id) ON DELETE CASCADE,
+        step_number   INT NOT NULL,
+        step_name     TEXT NOT NULL,
+        phase         TEXT NOT NULL CHECK (phase IN ('problem_ziel','analyse','loesung','umsetzung')),
+        coach_inputs  JSONB NOT NULL DEFAULT '{}',
+        ai_prompt     TEXT,
+        ai_response   TEXT,
+        coach_notes   TEXT,
+        status        TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending','generated','accepted','skipped')),
+        generated_at  TIMESTAMPTZ,
+        UNIQUE (session_id, step_number)
+      );
+      CREATE INDEX IF NOT EXISTS idx_session_steps_session ON coaching.session_steps(session_id);
 
       -- Tables are owned by postgres (init script runs as postgres). Grant the
       -- application role explicit access; ALTER DEFAULT PRIVILEGES covers tables

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -1290,9 +1290,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1308,9 +1305,6 @@
       "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1328,9 +1322,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1347,9 +1338,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1365,9 +1353,6 @@
       "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1401,9 +1386,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1436,9 +1418,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1460,9 +1439,6 @@
       "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1486,9 +1462,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1511,9 +1484,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1535,9 +1505,6 @@
       "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1582,9 +1549,6 @@
       "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1932,9 +1896,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1947,9 +1908,6 @@
       "integrity": "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1964,9 +1922,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1979,9 +1934,6 @@
       "integrity": "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1996,9 +1948,6 @@
       "cpu": [
         "loong64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2011,9 +1960,6 @@
       "integrity": "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==",
       "cpu": [
         "loong64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2028,9 +1974,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2043,9 +1986,6 @@
       "integrity": "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2060,9 +2000,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2076,9 +2013,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2091,9 +2025,6 @@
       "integrity": "sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -2489,9 +2420,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2509,9 +2437,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5532,9 +5457,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5554,9 +5476,6 @@
       "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,

--- a/website/src/components/admin/coaching/SessionWizard.svelte
+++ b/website/src/components/admin/coaching/SessionWizard.svelte
@@ -1,0 +1,291 @@
+<script lang="ts">
+  import { STEP_DEFINITIONS } from '../../../lib/coaching-session-prompts';
+  import type { Session, SessionStep } from '../../../lib/coaching-session-db';
+
+  let { sessionId, initialSession }: { sessionId: string; initialSession: Session } = $props();
+
+  const PHASE_COLORS: Record<string, string> = {
+    problem_ziel: 'bg-blue-500',
+    analyse:      'bg-orange-500',
+    loesung:      'bg-green-500',
+    umsetzung:    'bg-purple-500',
+  };
+  const PHASE_TEXT: Record<string, string> = {
+    problem_ziel: 'text-blue-400',
+    analyse:      'text-orange-400',
+    loesung:      'text-green-400',
+    umsetzung:    'text-purple-400',
+  };
+
+  let session = $state<Session>(initialSession);
+  let currentStep = $state(getInitialStep());
+  let inputs = $state<Record<string, string>>({});
+  let coachNotes = $state('');
+  let loading = $state(false);
+  let error = $state('');
+
+  function getInitialStep(): number {
+    const firstPending = initialSession.steps.find(s => s.status === 'pending' || s.status === 'generated');
+    return firstPending?.stepNumber ?? 1;
+  }
+
+  function getStepData(n: number): SessionStep | undefined {
+    return session.steps.find(s => s.stepNumber === n);
+  }
+
+  $effect(() => {
+    const existing = getStepData(currentStep);
+    inputs = existing?.coachInputs ? { ...existing.coachInputs } : {};
+    coachNotes = existing?.coachNotes ?? '';
+  });
+
+  const def = $derived(STEP_DEFINITIONS.find(s => s.stepNumber === currentStep)!);
+  const stepData = $derived(getStepData(currentStep));
+  const canGenerate = $derived(
+    def?.inputs.filter(i => i.required).every(i => (inputs[i.key] ?? '').trim().length > 0) ?? false
+  );
+  const isCompleted = $derived(session.status === 'completed');
+
+  async function saveInputs() {
+    await fetch(`/api/admin/coaching/sessions/${sessionId}/steps/${currentStep}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ coachInputs: inputs, coachNotes }),
+    });
+  }
+
+  async function generate() {
+    loading = true; error = '';
+    try {
+      await saveInputs();
+      const res = await fetch(`/api/admin/coaching/sessions/${sessionId}/steps/${currentStep}/generate`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ coachInputs: inputs }),
+      });
+      const json = await res.json();
+      if (!res.ok) { error = json.error ?? 'Fehler bei KI-Anfrage'; return; }
+      session = {
+        ...session,
+        steps: session.steps.find(s => s.stepNumber === currentStep)
+          ? session.steps.map(s => s.stepNumber === currentStep ? json.step : s)
+          : [...session.steps, json.step],
+      };
+    } catch { error = 'Verbindungsfehler'; }
+    finally { loading = false; }
+  }
+
+  async function accept() {
+    loading = true; error = '';
+    try {
+      await fetch(`/api/admin/coaching/sessions/${sessionId}/steps/${currentStep}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ coachInputs: inputs, coachNotes, status: 'accepted' }),
+      });
+      session = {
+        ...session,
+        steps: session.steps.map(s => s.stepNumber === currentStep ? { ...s, status: 'accepted', coachNotes } : s),
+      };
+      if (currentStep < 10) { currentStep++; }
+    } catch { error = 'Fehler beim Speichern'; }
+    finally { loading = false; }
+  }
+
+  async function reject() {
+    session = {
+      ...session,
+      steps: session.steps.map(s => s.stepNumber === currentStep ? { ...s, status: 'pending', aiResponse: null } : s),
+    };
+    await fetch(`/api/admin/coaching/sessions/${sessionId}/steps/${currentStep}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ coachInputs: inputs, status: 'pending' }),
+    });
+  }
+
+  async function skip() {
+    loading = true;
+    try {
+      await fetch(`/api/admin/coaching/sessions/${sessionId}/steps/${currentStep}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ coachInputs: inputs, coachNotes, status: 'skipped' }),
+      });
+      session = {
+        ...session,
+        steps: session.steps.map(s => s.stepNumber === currentStep ? { ...s, status: 'skipped' } : s),
+      };
+      if (currentStep < 10) { currentStep++; }
+    } catch { error = 'Fehler'; }
+    finally { loading = false; }
+  }
+
+  async function completeSession() {
+    loading = true; error = '';
+    try {
+      const res = await fetch(`/api/admin/coaching/sessions/${sessionId}/complete`, { method: 'POST' });
+      const json = await res.json();
+      if (!res.ok) { error = json.error ?? 'Fehler beim Abschließen'; return; }
+      window.location.href = `/admin/coaching/sessions/${sessionId}`;
+    } catch { error = 'Verbindungsfehler'; }
+    finally { loading = false; }
+  }
+
+  function stepStatus(n: number): 'done' | 'current' | 'pending' {
+    if (n === currentStep) return 'current';
+    const s = getStepData(n);
+    if (s?.status === 'accepted' || s?.status === 'skipped') return 'done';
+    return 'pending';
+  }
+</script>
+
+<div class="wizard">
+  <!-- Fortschrittsbalken -->
+  <div class="progress-bar" aria-label="Fortschritt">
+    {#each STEP_DEFINITIONS as s}
+      {@const status = stepStatus(s.stepNumber)}
+      <button
+        class="progress-step {PHASE_COLORS[s.phase]} {status === 'current' ? 'ring-2 ring-white scale-110' : ''} {status === 'done' ? 'opacity-100' : 'opacity-40'}"
+        onclick={() => { currentStep = s.stepNumber; }}
+        title="Schritt {s.stepNumber}: {s.stepName}"
+        aria-current={status === 'current' ? 'step' : undefined}
+      >
+        {#if status === 'done'}&#x2713;{:else}{s.stepNumber}{/if}
+      </button>
+    {/each}
+  </div>
+
+  <!-- Schritt-Header -->
+  <div class="step-header">
+    <span class="phase-label {PHASE_TEXT[def.phase]}">{def.phaseLabel}</span>
+    <h2 class="step-title">Schritt {currentStep}/10 &mdash; {def.stepName}</h2>
+  </div>
+
+  {#if error}
+    <div class="error-box">{error}</div>
+  {/if}
+
+  <!-- Eingabefelder -->
+  <div class="inputs-section">
+    {#each def.inputs as input}
+      <div class="input-group">
+        <label class="input-label" for={input.key}>
+          {input.label}{#if input.required}<span class="required">*</span>{/if}
+        </label>
+        {#if input.multiline}
+          <textarea
+            id={input.key}
+            bind:value={inputs[input.key]}
+            rows={3}
+            class="input-field"
+            placeholder={input.required ? 'Pflichtfeld' : 'Optional'}
+            disabled={isCompleted}
+          ></textarea>
+        {:else}
+          <input
+            id={input.key}
+            type="text"
+            bind:value={inputs[input.key]}
+            class="input-field"
+            placeholder={input.required ? 'Pflichtfeld' : 'Optional'}
+            disabled={isCompleted}
+          />
+        {/if}
+      </div>
+    {/each}
+  </div>
+
+  <!-- KI befragen Button -->
+  {#if !isCompleted && stepData?.status !== 'accepted'}
+    <button
+      class="btn-primary"
+      onclick={generate}
+      disabled={!canGenerate || loading}
+    >
+      {loading ? 'KI antwortet…' : 'KI befragen →'}
+    </button>
+  {/if}
+
+  <!-- KI-Antwort -->
+  {#if stepData?.aiResponse}
+    <div class="ai-response-box">
+      <p class="ai-label">KI-Vorschlag</p>
+      <p class="ai-text">{stepData.aiResponse}</p>
+    </div>
+
+    <!-- Notizfeld -->
+    <div class="input-group">
+      <label class="input-label" for="coach-notes">Meine Notiz (optional)</label>
+      <textarea
+        id="coach-notes"
+        bind:value={coachNotes}
+        rows={2}
+        class="input-field"
+        placeholder="Eigene Gedanken, Ergänzungen, Korrekturen…"
+        disabled={isCompleted}
+      ></textarea>
+    </div>
+
+    <!-- Aktions-Buttons -->
+    {#if !isCompleted && stepData.status !== 'accepted'}
+      <div class="action-buttons">
+        {#if currentStep > 1}
+          <button class="btn-secondary" onclick={() => { currentStep--; }}>&larr; Zurück</button>
+        {/if}
+        <button class="btn-ghost" onclick={reject} disabled={loading}>Verwerfen &amp; neu</button>
+        <button class="btn-ghost" onclick={skip} disabled={loading}>Überspringen</button>
+        <button class="btn-primary" onclick={accept} disabled={loading}>Akzeptieren &rarr;</button>
+      </div>
+    {/if}
+  {:else if stepData?.status !== 'accepted'}
+    <div class="action-buttons">
+      {#if currentStep > 1}
+        <button class="btn-secondary" onclick={() => { currentStep--; }}>&larr; Zurück</button>
+      {/if}
+      <button class="btn-ghost" onclick={skip} disabled={loading || isCompleted}>Schritt überspringen</button>
+    </div>
+  {:else}
+    <!-- Schritt abgeschlossen -->
+    <div class="accepted-badge">&#x2713; Abgeschlossen</div>
+    <div class="action-buttons">
+      {#if currentStep > 1}
+        <button class="btn-secondary" onclick={() => { currentStep--; }}>&larr; Zurück</button>
+      {/if}
+      {#if currentStep < 10}
+        <button class="btn-primary" onclick={() => { currentStep++; }}>Weiter &rarr;</button>
+      {:else if !isCompleted}
+        <button class="btn-complete" onclick={completeSession} disabled={loading}>
+          {loading ? 'Bericht wird erstellt…' : 'Session abschließen &amp; Bericht generieren'}
+        </button>
+      {/if}
+    </div>
+  {/if}
+</div>
+
+<style>
+  .wizard { max-width: 760px; margin: 0 auto; display: flex; flex-direction: column; gap: 1.5rem; }
+  .progress-bar { display: flex; gap: 0.4rem; flex-wrap: wrap; padding: 1rem 0; }
+  .progress-step { width: 2rem; height: 2rem; border-radius: 50%; font-size: 0.75rem; font-weight: 700; color: white; border: none; cursor: pointer; display: flex; align-items: center; justify-content: center; transition: all 0.15s; }
+  .step-header { border-bottom: 1px solid var(--line, #333); padding-bottom: 0.75rem; }
+  .phase-label { font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.08em; font-weight: 600; }
+  .step-title { font-size: 1.4rem; font-weight: 700; color: var(--text-light, #f0f0f0); margin: 0.25rem 0 0; }
+  .inputs-section { display: flex; flex-direction: column; gap: 1rem; }
+  .input-group { display: flex; flex-direction: column; gap: 0.3rem; }
+  .input-label { font-size: 0.8rem; color: var(--text-muted, #888); }
+  .required { color: #f87171; margin-left: 0.2rem; }
+  .input-field { background: var(--bg-2, #1a1a1a); border: 1px solid var(--line, #333); border-radius: 6px; padding: 0.6rem 0.75rem; color: var(--text-light, #f0f0f0); font-size: 0.9rem; width: 100%; resize: vertical; }
+  .input-field:focus { outline: none; border-color: var(--gold, #c9a55c); }
+  .ai-response-box { background: var(--bg-2, #1a1a1a); border: 1px solid var(--gold, #c9a55c); border-radius: 8px; padding: 1rem; }
+  .ai-label { font-size: 0.7rem; text-transform: uppercase; letter-spacing: 0.1em; color: var(--gold, #c9a55c); margin: 0 0 0.5rem; }
+  .ai-text { color: var(--text-light, #f0f0f0); font-size: 0.9rem; line-height: 1.6; white-space: pre-wrap; margin: 0; }
+  .action-buttons { display: flex; gap: 0.75rem; flex-wrap: wrap; align-items: center; }
+  .btn-primary { padding: 0.6rem 1.4rem; background: var(--gold, #c9a55c); color: #111; font-weight: 700; border: none; border-radius: 6px; cursor: pointer; font-size: 0.9rem; }
+  .btn-primary:disabled { opacity: 0.5; cursor: not-allowed; }
+  .btn-secondary { padding: 0.5rem 1rem; background: transparent; color: var(--text-muted, #888); border: 1px solid var(--line, #444); border-radius: 6px; cursor: pointer; font-size: 0.85rem; }
+  .btn-ghost { padding: 0.5rem 1rem; background: transparent; color: var(--text-muted, #888); border: none; cursor: pointer; font-size: 0.85rem; text-decoration: underline; }
+  .btn-complete { padding: 0.7rem 1.6rem; background: #22c55e; color: #111; font-weight: 700; border: none; border-radius: 6px; cursor: pointer; }
+  .btn-complete:disabled { opacity: 0.5; cursor: not-allowed; }
+  .accepted-badge { display: inline-block; background: #22c55e20; color: #22c55e; border: 1px solid #22c55e40; border-radius: 4px; padding: 0.3rem 0.75rem; font-size: 0.8rem; font-weight: 600; }
+  .error-box { background: #ef444420; border: 1px solid #ef444440; border-radius: 6px; padding: 0.75rem; color: #f87171; font-size: 0.85rem; }
+</style>

--- a/website/src/components/admin/coaching/SessionWizard.svelte
+++ b/website/src/components/admin/coaching/SessionWizard.svelte
@@ -19,8 +19,8 @@
 
   let session = $state<Session>(initialSession);
   let currentStep = $state(getInitialStep());
-  let inputs = $state<Record<string, string>>({});
-  let coachNotes = $state('');
+  let inputs = $state<Record<string, string>>(getStepInputs(getInitialStep()));
+  let coachNotes = $state(getStepNotes(getInitialStep()));
   let loading = $state(false);
   let error = $state('');
 
@@ -29,15 +29,25 @@
     return firstPending?.stepNumber ?? 1;
   }
 
+  function getStepInputs(stepNum: number): Record<string, string> {
+    const s = initialSession.steps.find(st => st.stepNumber === stepNum);
+    return s?.coachInputs ? { ...s.coachInputs } : {};
+  }
+
+  function getStepNotes(stepNum: number): string {
+    return initialSession.steps.find(st => st.stepNumber === stepNum)?.coachNotes ?? '';
+  }
+
   function getStepData(n: number): SessionStep | undefined {
     return session.steps.find(s => s.stepNumber === n);
   }
 
-  $effect(() => {
-    const existing = getStepData(currentStep);
-    inputs = existing?.coachInputs ? { ...existing.coachInputs } : {};
-    coachNotes = existing?.coachNotes ?? '';
-  });
+  function navigateTo(n: number) {
+    currentStep = n;
+    const step = session.steps.find(s => s.stepNumber === n);
+    inputs = step?.coachInputs ? { ...step.coachInputs } : {};
+    coachNotes = step?.coachNotes ?? '';
+  }
 
   const def = $derived(STEP_DEFINITIONS.find(s => s.stepNumber === currentStep)!);
   const stepData = $derived(getStepData(currentStep));
@@ -87,21 +97,32 @@
         ...session,
         steps: session.steps.map(s => s.stepNumber === currentStep ? { ...s, status: 'accepted', coachNotes } : s),
       };
-      if (currentStep < 10) { currentStep++; }
+      if (currentStep < 10) { navigateTo(currentStep + 1); }
     } catch { error = 'Fehler beim Speichern'; }
     finally { loading = false; }
   }
 
   async function reject() {
+    loading = true; error = '';
+    const prev = session.steps.find(s => s.stepNumber === currentStep);
     session = {
       ...session,
-      steps: session.steps.map(s => s.stepNumber === currentStep ? { ...s, status: 'pending', aiResponse: null } : s),
+      steps: session.steps.map(s => s.stepNumber === currentStep ? { ...s, status: 'pending' as const, aiResponse: null } : s),
     };
-    await fetch(`/api/admin/coaching/sessions/${sessionId}/steps/${currentStep}`, {
-      method: 'PATCH',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ coachInputs: inputs, status: 'pending' }),
-    });
+    try {
+      await fetch(`/api/admin/coaching/sessions/${sessionId}/steps/${currentStep}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ coachInputs: inputs, status: 'pending' }),
+      });
+    } catch {
+      if (prev) {
+        session = { ...session, steps: session.steps.map(s => s.stepNumber === currentStep ? prev : s) };
+      }
+      error = 'Fehler beim Verwerfen';
+    } finally {
+      loading = false;
+    }
   }
 
   async function skip() {
@@ -116,7 +137,7 @@
         ...session,
         steps: session.steps.map(s => s.stepNumber === currentStep ? { ...s, status: 'skipped' } : s),
       };
-      if (currentStep < 10) { currentStep++; }
+      if (currentStep < 10) { navigateTo(currentStep + 1); }
     } catch { error = 'Fehler'; }
     finally { loading = false; }
   }
@@ -147,7 +168,7 @@
       {@const status = stepStatus(s.stepNumber)}
       <button
         class="progress-step {PHASE_COLORS[s.phase]} {status === 'current' ? 'ring-2 ring-white scale-110' : ''} {status === 'done' ? 'opacity-100' : 'opacity-40'}"
-        onclick={() => { currentStep = s.stepNumber; }}
+        onclick={() => { navigateTo(s.stepNumber); }}
         title="Schritt {s.stepNumber}: {s.stepName}"
         aria-current={status === 'current' ? 'step' : undefined}
       >
@@ -231,7 +252,7 @@
     {#if !isCompleted && stepData.status !== 'accepted'}
       <div class="action-buttons">
         {#if currentStep > 1}
-          <button class="btn-secondary" onclick={() => { currentStep--; }}>&larr; Zurück</button>
+          <button class="btn-secondary" onclick={() => { navigateTo(currentStep - 1); }}>&larr; Zurück</button>
         {/if}
         <button class="btn-ghost" onclick={reject} disabled={loading}>Verwerfen &amp; neu</button>
         <button class="btn-ghost" onclick={skip} disabled={loading}>Überspringen</button>
@@ -241,7 +262,7 @@
   {:else if stepData?.status !== 'accepted'}
     <div class="action-buttons">
       {#if currentStep > 1}
-        <button class="btn-secondary" onclick={() => { currentStep--; }}>&larr; Zurück</button>
+        <button class="btn-secondary" onclick={() => { navigateTo(currentStep - 1); }}>&larr; Zurück</button>
       {/if}
       <button class="btn-ghost" onclick={skip} disabled={loading || isCompleted}>Schritt überspringen</button>
     </div>
@@ -250,10 +271,10 @@
     <div class="accepted-badge">&#x2713; Abgeschlossen</div>
     <div class="action-buttons">
       {#if currentStep > 1}
-        <button class="btn-secondary" onclick={() => { currentStep--; }}>&larr; Zurück</button>
+        <button class="btn-secondary" onclick={() => { navigateTo(currentStep - 1); }}>&larr; Zurück</button>
       {/if}
       {#if currentStep < 10}
-        <button class="btn-primary" onclick={() => { currentStep++; }}>Weiter &rarr;</button>
+        <button class="btn-primary" onclick={() => { navigateTo(currentStep + 1); }}>Weiter &rarr;</button>
       {:else if !isCompleted}
         <button class="btn-complete" onclick={completeSession} disabled={loading}>
           {loading ? 'Bericht wird erstellt…' : 'Session abschließen &amp; Bericht generieren'}

--- a/website/src/data/test-inventory.json
+++ b/website/src/data/test-inventory.json
@@ -96,6 +96,12 @@
     "kind": "playwright"
   },
   {
+    "id": "E2E:fa-bug-t000368",
+    "file": "tests/e2e/specs/fa-bug-t000368.spec.ts",
+    "category": "E2E",
+    "kind": "playwright"
+  },
+  {
     "id": "E2E:fa-bugs-notifications",
     "file": "tests/e2e/specs/fa-bugs-notifications.spec.ts",
     "category": "E2E",
@@ -811,25 +817,25 @@
   },
   {
     "id": "SA-08",
-    "file": "tests/local/SA-08-sso.sh",
-    "category": "SA",
-    "kind": "shell"
-  },
-  {
-    "id": "SA-08",
     "file": "tests/local/SA-08.sh",
     "category": "SA",
     "kind": "shell"
   },
   {
     "id": "SA-08",
-    "file": "tests/prod/SA-08-sso.sh",
+    "file": "tests/local/SA-08-sso.sh",
     "category": "SA",
     "kind": "shell"
   },
   {
     "id": "SA-08",
     "file": "tests/prod/SA-08.sh",
+    "category": "SA",
+    "kind": "shell"
+  },
+  {
+    "id": "SA-08",
+    "file": "tests/prod/SA-08-sso.sh",
     "category": "SA",
     "kind": "shell"
   },

--- a/website/src/layouts/AdminLayout.astro
+++ b/website/src/layouts/AdminLayout.astro
@@ -127,6 +127,14 @@ const navGroups: { label: string; items: NavItem[] }[] = [
     ],
   },
   {
+    label: 'Coaching',
+    items: [
+      { href: '/admin/coaching/sessions',     label: 'Sessions',     icon: 'clipboard',
+        matches: ['/admin/coaching/sessions'] },
+      { href: '/admin/coaching/sessions/new', label: 'Neue Session', icon: 'plus' },
+    ],
+  },
+  {
     label: 'System',
     items: [
       { href: '/admin/monitoring',       label: 'Monitoring',        icon: 'monitor' },

--- a/website/src/layouts/AdminLayout.astro
+++ b/website/src/layouts/AdminLayout.astro
@@ -63,6 +63,7 @@ const icons: Record<string, string> = {
   edit: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M11.5 1.8l2.7 2.7L5 13.7l-3.2.5.5-3.2z"/><path d="M10 3.3l2.7 2.7"/></svg>`,
   // Brett icon: 3D board
   brett: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M1.5 5l6.5-3.5L14.5 5v6L8 14.5 1.5 11V5z"/><path d="M8 1.5v13M1.5 5l6.5 3 6.5-3"/></svg>`,
+  plus: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 3v10M3 8h10"/></svg>`,
 };
 
 let inboxPending = 0;

--- a/website/src/lib/coaching-session-db.test.ts
+++ b/website/src/lib/coaching-session-db.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { newDb } from 'pg-mem';
+import type { Pool } from 'pg';
+import {
+  createSession,
+  getSession,
+  listSessions,
+  upsertStep,
+  getStep,
+  completeSession,
+} from './coaching-session-db';
+
+let pool: Pool;
+
+beforeAll(async () => {
+  const db = newDb();
+  db.public.registerFunction({
+    name: 'gen_random_uuid',
+    returns: 'uuid',
+    impure: true,
+    implementation: () =>
+      'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, c => {
+        const r = (Math.random() * 16) | 0;
+        return (c === 'x' ? r : (r & 0x3) | 0x8).toString(16);
+      }),
+  });
+  db.public.none(`
+    CREATE SCHEMA coaching;
+    CREATE TABLE coaching.sessions (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      brand TEXT NOT NULL DEFAULT 'mentolder',
+      client_id UUID,
+      mode TEXT NOT NULL DEFAULT 'live',
+      title TEXT NOT NULL,
+      status TEXT NOT NULL DEFAULT 'active',
+      created_by TEXT NOT NULL,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      completed_at TIMESTAMPTZ
+    );
+    CREATE TABLE coaching.session_steps (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      session_id UUID NOT NULL REFERENCES coaching.sessions(id) ON DELETE CASCADE,
+      step_number INT NOT NULL,
+      step_name TEXT NOT NULL,
+      phase TEXT NOT NULL,
+      coach_inputs JSONB NOT NULL DEFAULT '{}',
+      ai_prompt TEXT,
+      ai_response TEXT,
+      coach_notes TEXT,
+      status TEXT NOT NULL DEFAULT 'pending',
+      generated_at TIMESTAMPTZ,
+      UNIQUE (session_id, step_number)
+    );
+  `);
+  const { Pool: PgMemPool } = db.adapters.createPg();
+  pool = new PgMemPool() as unknown as Pool;
+});
+
+describe('createSession', () => {
+  it('creates a session and returns it', async () => {
+    const s = await createSession(pool, {
+      brand: 'mentolder', title: 'Test-Session', createdBy: 'coach1', mode: 'live',
+    });
+    expect(s.id).toBeTruthy();
+    expect(s.title).toBe('Test-Session');
+    expect(s.status).toBe('active');
+    expect(s.clientId).toBeNull();
+  });
+});
+
+describe('getSession', () => {
+  it('returns session with steps', async () => {
+    const s = await createSession(pool, {
+      brand: 'mentolder', title: 'Mit Steps', createdBy: 'coach1', mode: 'prep',
+    });
+    await upsertStep(pool, {
+      sessionId: s.id, stepNumber: 1, stepName: 'Erstanamnese', phase: 'problem_ziel',
+      coachInputs: { anlass: 'Stress' },
+    });
+    const result = await getSession(pool, s.id);
+    expect(result).not.toBeNull();
+    expect(result!.steps).toHaveLength(1);
+    expect(result!.steps[0].coachInputs).toEqual({ anlass: 'Stress' });
+  });
+});
+
+describe('upsertStep', () => {
+  it('updates an existing step on second call', async () => {
+    const s = await createSession(pool, {
+      brand: 'mentolder', title: 'Upsert-Test', createdBy: 'coach1', mode: 'live',
+    });
+    await upsertStep(pool, {
+      sessionId: s.id, stepNumber: 1, stepName: 'Erstanamnese', phase: 'problem_ziel',
+      coachInputs: { anlass: 'alt' },
+    });
+    await upsertStep(pool, {
+      sessionId: s.id, stepNumber: 1, stepName: 'Erstanamnese', phase: 'problem_ziel',
+      coachInputs: { anlass: 'neu' }, aiResponse: 'KI sagt...', status: 'generated',
+    });
+    const step = await getStep(pool, s.id, 1);
+    expect(step!.coachInputs).toEqual({ anlass: 'neu' });
+    expect(step!.aiResponse).toBe('KI sagt...');
+    expect(step!.status).toBe('generated');
+  });
+});
+
+describe('completeSession', () => {
+  it('sets status to completed and stores report', async () => {
+    const s = await createSession(pool, {
+      brand: 'mentolder', title: 'Abschluss-Test', createdBy: 'coach1', mode: 'live',
+    });
+    await completeSession(pool, s.id, '# Bericht\nZusammenfassung...');
+    const result = await getSession(pool, s.id);
+    expect(result!.status).toBe('completed');
+    expect(result!.completedAt).not.toBeNull();
+    const report = result!.steps.find(s => s.stepNumber === 0);
+    expect(report!.aiResponse).toContain('Zusammenfassung');
+  });
+});

--- a/website/src/lib/coaching-session-db.ts
+++ b/website/src/lib/coaching-session-db.ts
@@ -1,0 +1,157 @@
+import type { Pool } from 'pg';
+
+export interface Session {
+  id: string;
+  brand: string;
+  clientId: string | null;
+  mode: 'live' | 'prep';
+  title: string;
+  status: 'active' | 'completed' | 'abandoned';
+  createdBy: string;
+  createdAt: Date;
+  completedAt: Date | null;
+  steps: SessionStep[];
+}
+
+export interface SessionStep {
+  id: string;
+  sessionId: string;
+  stepNumber: number;
+  stepName: string;
+  phase: string;
+  coachInputs: Record<string, string>;
+  aiPrompt: string | null;
+  aiResponse: string | null;
+  coachNotes: string | null;
+  status: 'pending' | 'generated' | 'accepted' | 'skipped';
+  generatedAt: Date | null;
+}
+
+export interface CreateSessionArgs {
+  brand: string;
+  clientId?: string | null;
+  mode: 'live' | 'prep';
+  title: string;
+  createdBy: string;
+}
+
+export interface UpsertStepArgs {
+  sessionId: string;
+  stepNumber: number;
+  stepName: string;
+  phase: string;
+  coachInputs?: Record<string, string>;
+  aiPrompt?: string | null;
+  aiResponse?: string | null;
+  coachNotes?: string | null;
+  status?: 'pending' | 'generated' | 'accepted' | 'skipped';
+}
+
+function rowToSession(row: Record<string, unknown>, steps: SessionStep[] = []): Session {
+  return {
+    id: row.id as string,
+    brand: row.brand as string,
+    clientId: (row.client_id as string | null) ?? null,
+    mode: row.mode as 'live' | 'prep',
+    title: row.title as string,
+    status: row.status as Session['status'],
+    createdBy: row.created_by as string,
+    createdAt: row.created_at as Date,
+    completedAt: (row.completed_at as Date | null) ?? null,
+    steps,
+  };
+}
+
+function rowToStep(row: Record<string, unknown>): SessionStep {
+  return {
+    id: row.id as string,
+    sessionId: row.session_id as string,
+    stepNumber: row.step_number as number,
+    stepName: row.step_name as string,
+    phase: row.phase as string,
+    coachInputs: (row.coach_inputs as Record<string, string>) ?? {},
+    aiPrompt: (row.ai_prompt as string | null) ?? null,
+    aiResponse: (row.ai_response as string | null) ?? null,
+    coachNotes: (row.coach_notes as string | null) ?? null,
+    status: row.status as SessionStep['status'],
+    generatedAt: (row.generated_at as Date | null) ?? null,
+  };
+}
+
+export async function createSession(pool: Pool, args: CreateSessionArgs): Promise<Session> {
+  const r = await pool.query(
+    `INSERT INTO coaching.sessions (brand, client_id, mode, title, created_by)
+     VALUES ($1, $2, $3, $4, $5)
+     RETURNING *`,
+    [args.brand, args.clientId ?? null, args.mode, args.title, args.createdBy],
+  );
+  return rowToSession(r.rows[0]);
+}
+
+export async function getSession(pool: Pool, id: string): Promise<Session | null> {
+  const [sessionRes, stepsRes] = await Promise.all([
+    pool.query(`SELECT * FROM coaching.sessions WHERE id = $1`, [id]),
+    pool.query(`SELECT * FROM coaching.session_steps WHERE session_id = $1 ORDER BY step_number`, [id]),
+  ]);
+  if (!sessionRes.rows[0]) return null;
+  return rowToSession(sessionRes.rows[0], stepsRes.rows.map(rowToStep));
+}
+
+export async function listSessions(pool: Pool, brand: string): Promise<Session[]> {
+  const r = await pool.query(
+    `SELECT s.*
+     FROM coaching.sessions s
+     WHERE s.brand = $1
+     ORDER BY s.created_at DESC`,
+    [brand],
+  );
+  return r.rows.map(row => rowToSession(row));
+}
+
+export async function upsertStep(pool: Pool, args: UpsertStepArgs): Promise<SessionStep> {
+  const r = await pool.query(
+    `INSERT INTO coaching.session_steps
+       (session_id, step_number, step_name, phase, coach_inputs, ai_prompt, ai_response, coach_notes, status, generated_at)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+     ON CONFLICT (session_id, step_number) DO UPDATE SET
+       coach_inputs  = EXCLUDED.coach_inputs,
+       ai_prompt     = CASE WHEN EXCLUDED.ai_prompt IS NOT NULL THEN EXCLUDED.ai_prompt ELSE coaching.session_steps.ai_prompt END,
+       ai_response   = CASE WHEN EXCLUDED.ai_response IS NOT NULL THEN EXCLUDED.ai_response ELSE coaching.session_steps.ai_response END,
+       coach_notes   = CASE WHEN EXCLUDED.coach_notes IS NOT NULL THEN EXCLUDED.coach_notes ELSE coaching.session_steps.coach_notes END,
+       status        = EXCLUDED.status,
+       generated_at  = CASE WHEN EXCLUDED.generated_at IS NOT NULL THEN EXCLUDED.generated_at ELSE coaching.session_steps.generated_at END
+     RETURNING *`,
+    [
+      args.sessionId, args.stepNumber, args.stepName, args.phase,
+      JSON.stringify(args.coachInputs ?? {}),
+      args.aiPrompt ?? null, args.aiResponse ?? null, args.coachNotes ?? null,
+      args.status ?? 'pending',
+      args.aiResponse ? new Date() : null,
+    ],
+  );
+  return rowToStep(r.rows[0]);
+}
+
+export async function getStep(pool: Pool, sessionId: string, stepNumber: number): Promise<SessionStep | null> {
+  const r = await pool.query(
+    `SELECT * FROM coaching.session_steps WHERE session_id = $1 AND step_number = $2`,
+    [sessionId, stepNumber],
+  );
+  return r.rows[0] ? rowToStep(r.rows[0]) : null;
+}
+
+export async function completeSession(pool: Pool, sessionId: string, reportMarkdown: string): Promise<void> {
+  await pool.query(
+    `UPDATE coaching.sessions SET status = 'completed', completed_at = now() WHERE id = $1`,
+    [sessionId],
+  );
+  await upsertStep(pool, {
+    sessionId,
+    stepNumber: 0,
+    stepName: 'Abschlussbericht',
+    phase: 'umsetzung',
+    coachInputs: {},
+    aiResponse: reportMarkdown,
+    status: 'accepted',
+  });
+}

--- a/website/src/lib/coaching-session-prompts.ts
+++ b/website/src/lib/coaching-session-prompts.ts
@@ -1,0 +1,215 @@
+export type Phase = 'problem_ziel' | 'analyse' | 'loesung' | 'umsetzung';
+
+export interface StepInput {
+  key: string;
+  label: string;
+  required: boolean;
+  multiline?: boolean;
+}
+
+export interface StepDefinition {
+  stepNumber: number;
+  stepName: string;
+  phase: Phase;
+  phaseLabel: string;
+  inputs: StepInput[];
+  systemPrompt: string;
+  userTemplate: string;
+}
+
+const BASE_SYSTEM = `Du bist ein erfahrener Coaching-Assistent (Triadisches KI-Coaching nach Geißler).
+Deine Aufgabe: basierend auf den Coach-Eingaben eine präzise, handlungsorientierte Gesprächsintervention vorschlagen.
+Sprache: Deutsch. Maximal 250 Wörter. Kein wörtliches Buchzitat. Keine allgemeinen Ratschläge — konkret zur Situation.`;
+
+export const STEP_DEFINITIONS: StepDefinition[] = [
+  {
+    stepNumber: 1,
+    stepName: 'Erstanamnese',
+    phase: 'problem_ziel',
+    phaseLabel: 'Phase 1: Problem & Ziel',
+    inputs: [
+      { key: 'anlass', label: 'Anlass der Session', required: true, multiline: true },
+      { key: 'vorerfahrung', label: 'Vorerfahrung mit Coaching', required: false },
+      { key: 'situation', label: 'Aktuelle Situation (in Worten des Klienten)', required: true, multiline: true },
+    ],
+    systemPrompt: BASE_SYSTEM,
+    userTemplate: `Erstanamnese:
+Anlass: {anlass}
+Vorerfahrung: {vorerfahrung}
+Aktuelle Situation: {situation}
+
+Schlage eine einfühlsame Eröffnungsintervention vor, die die Situation würdigt und den Klienten einlädt, tiefer zu gehen.`,
+  },
+  {
+    stepNumber: 2,
+    stepName: 'Schlüsselaffekt',
+    phase: 'problem_ziel',
+    phaseLabel: 'Phase 1: Problem & Ziel',
+    inputs: [
+      { key: 'hauptgefuehl', label: 'Hauptgefühl des Klienten', required: true },
+      { key: 'koerperreaktion', label: 'Körperliche Reaktion / wo spürbar', required: false },
+      { key: 'ausloeser', label: 'Auslöser / Trigger', required: true },
+    ],
+    systemPrompt: BASE_SYSTEM,
+    userTemplate: `Schlüsselaffekt-Arbeit:
+Hauptgefühl: {hauptgefuehl}
+Körperreaktion: {koerperreaktion}
+Auslöser: {ausloeser}
+
+Schlage eine Intervention vor, die den Klienten mit dem Schlüsselaffekt in Kontakt bringt, ohne ihn zu überwältigen.`,
+  },
+  {
+    stepNumber: 3,
+    stepName: 'Zielformulierung',
+    phase: 'problem_ziel',
+    phaseLabel: 'Phase 1: Problem & Ziel',
+    inputs: [
+      { key: 'wunschzustand', label: 'Wunschzustand des Klienten', required: true, multiline: true },
+      { key: 'ressourcen', label: 'Bereits vorhandene Ressourcen', required: false },
+      { key: 'erste_schritte', label: 'Erste Ideen für Schritte', required: false },
+    ],
+    systemPrompt: BASE_SYSTEM,
+    userTemplate: `Zielformulierung:
+Wunschzustand: {wunschzustand}
+Ressourcen: {ressourcen}
+Erste Ideen: {erste_schritte}
+
+Hilf dabei, ein SMART-Ziel zu formulieren und die Brücke zwischen aktuellem Zustand und Wunschzustand zu bauen.`,
+  },
+  {
+    stepNumber: 4,
+    stepName: 'Teufelskreislauf',
+    phase: 'analyse',
+    phaseLabel: 'Phase 2: Analyse',
+    inputs: [
+      { key: 'ausloeser', label: 'Auslöser des Musters', required: true },
+      { key: 'reaktion', label: 'Automatische Reaktion des Klienten', required: true, multiline: true },
+      { key: 'konsequenz', label: 'Konsequenz / was sich dadurch verschlimmert', required: true },
+    ],
+    systemPrompt: BASE_SYSTEM,
+    userTemplate: `Teufelskreislauf-Analyse:
+Auslöser: {ausloeser}
+Automatische Reaktion: {reaktion}
+Konsequenz: {konsequenz}
+
+Beschreibe den Teufelskreislauf und schlage einen Interventionspunkt vor, an dem der Klient aussteigen könnte.`,
+  },
+  {
+    stepNumber: 5,
+    stepName: 'Ressourcenanalyse',
+    phase: 'analyse',
+    phaseLabel: 'Phase 2: Analyse',
+    inputs: [
+      { key: 'staerken', label: 'Stärken und Fähigkeiten des Klienten', required: true, multiline: true },
+      { key: 'bisherige_versuche', label: 'Was hat der Klient bisher versucht?', required: false },
+      { key: 'externe_unterstuetzung', label: 'Externe Unterstützung / Netzwerk', required: false },
+    ],
+    systemPrompt: BASE_SYSTEM,
+    userTemplate: `Ressourcenanalyse:
+Stärken: {staerken}
+Bisherige Versuche: {bisherige_versuche}
+Externes Netzwerk: {externe_unterstuetzung}
+
+Schlage vor, wie der Klient seine Ressourcen gezielt für das Ziel aktivieren kann.`,
+  },
+  {
+    stepNumber: 6,
+    stepName: 'Komplementärkräfte',
+    phase: 'analyse',
+    phaseLabel: 'Phase 2: Analyse',
+    inputs: [
+      { key: 'gegensatz', label: 'Gegensatz zum Problem / was fehlt', required: true },
+      { key: 'polaritaet', label: 'Polarität (z.B. Kontrolle ↔ Loslassen)', required: false },
+      { key: 'verborgene_staerke', label: 'Verborgene Stärke im Problem', required: false },
+    ],
+    systemPrompt: BASE_SYSTEM,
+    userTemplate: `Komplementärkräfte:
+Gegensatz: {gegensatz}
+Polarität: {polaritaet}
+Verborgene Stärke: {verborgene_staerke}
+
+Zeige auf, wie die Komplementärkräfte zur Lösungsentwicklung genutzt werden können.`,
+  },
+  {
+    stepNumber: 7,
+    stepName: 'Lösungsentwicklung / Bildarbeit',
+    phase: 'loesung',
+    phaseLabel: 'Phase 3: Lösung',
+    inputs: [
+      { key: 'bild_metapher', label: 'Bild oder Metapher des Klienten für die Lösung', required: true, multiline: true },
+      { key: 'koerperliche_empfindung', label: 'Körperliche Empfindung beim Bild', required: false },
+      { key: 'verknuepfung', label: 'Verknüpfung zur aktuellen Situation', required: false },
+    ],
+    systemPrompt: BASE_SYSTEM,
+    userTemplate: `Immersive Bildarbeit:
+Bild/Metapher: {bild_metapher}
+Körperliche Empfindung: {koerperliche_empfindung}
+Verknüpfung: {verknuepfung}
+
+Begleite den Klienten tiefer in das Lösungsbild hinein. Schlage Fragen vor, die das Bild lebendig machen.`,
+  },
+  {
+    stepNumber: 8,
+    stepName: 'Erfolgsimagination',
+    phase: 'loesung',
+    phaseLabel: 'Phase 3: Lösung',
+    inputs: [
+      { key: 'erfolgsbild', label: 'Wie sieht Erfolg aus (konkret)?', required: true, multiline: true },
+      { key: 'gefuehl_bei_erfolg', label: 'Wie fühlt sich das an?', required: false },
+      { key: 'veraenderung', label: 'Was hat sich verändert (Verhalten, Beziehungen)?', required: false },
+    ],
+    systemPrompt: BASE_SYSTEM,
+    userTemplate: `Erfolgsimagination:
+Erfolgsbild: {erfolgsbild}
+Gefühl: {gefuehl_bei_erfolg}
+Veränderung: {veraenderung}
+
+Verankere die Erfolgsimagination und leite über zur konkreten Umsetzungsplanung.`,
+  },
+  {
+    stepNumber: 9,
+    stepName: 'Goldstücks-Aktivität',
+    phase: 'umsetzung',
+    phaseLabel: 'Phase 4: Umsetzung',
+    inputs: [
+      { key: 'konkrete_schritte', label: 'Konkrete nächste Schritte', required: true, multiline: true },
+      { key: 'ressourcen_dafuer', label: 'Benötigte Ressourcen', required: false },
+      { key: 'zeitplan', label: 'Zeitplan / bis wann', required: false },
+    ],
+    systemPrompt: BASE_SYSTEM,
+    userTemplate: `Goldstücks-Aktivität (Umsetzungsplanung):
+Konkrete Schritte: {konkrete_schritte}
+Ressourcen: {ressourcen_dafuer}
+Zeitplan: {zeitplan}
+
+Identifiziere die eine "Goldstücks-Aktivität" — den einzelnen Schritt mit dem größten Hebel — und formuliere ihn als konkreten Auftrag.`,
+  },
+  {
+    stepNumber: 10,
+    stepName: 'Transfersicherung',
+    phase: 'umsetzung',
+    phaseLabel: 'Phase 4: Umsetzung',
+    inputs: [
+      { key: 'hindernisse', label: 'Mögliche Hindernisse', required: true, multiline: true },
+      { key: 'unterstuetzung', label: 'Wer/was unterstützt?', required: false },
+      { key: 'naechster_termin', label: 'Nächster Termin / Nachverfolgung', required: false },
+    ],
+    systemPrompt: BASE_SYSTEM,
+    userTemplate: `Transfersicherung:
+Hindernisse: {hindernisse}
+Unterstützung: {unterstuetzung}
+Nächster Termin: {naechster_termin}
+
+Erstelle einen Sicherungsplan: wie überwindet der Klient die Hindernisse? Welche Notfallstrategie gibt es?`,
+  },
+];
+
+export function getStepDef(stepNumber: number): StepDefinition {
+  const def = STEP_DEFINITIONS.find(s => s.stepNumber === stepNumber);
+  if (!def) throw new Error(`Step ${stepNumber} not found`);
+  return def;
+}
+
+export function buildUserPrompt(def: StepDefinition, inputs: Record<string, string>): string {
+  return def.userTemplate.replace(/\{(\w+)\}/g, (_, key) => inputs[key] ?? '—');
+}

--- a/website/src/pages/admin/coaching/sessions/[id].astro
+++ b/website/src/pages/admin/coaching/sessions/[id].astro
@@ -1,0 +1,70 @@
+---
+import AdminLayout from '../../../../layouts/AdminLayout.astro';
+import SessionWizard from '../../../../components/admin/coaching/SessionWizard.svelte';
+import { getSession as getAuthSession, getLoginUrl, isAdmin } from '../../../../lib/auth';
+import { getSession as getCoachingSession } from '../../../../lib/coaching-session-db';
+import { pool } from '../../../../lib/website-db';
+
+const authSession = await getAuthSession(Astro.request.headers.get('cookie'));
+if (!authSession) return Astro.redirect(getLoginUrl(Astro.url.pathname));
+if (!isAdmin(authSession)) return Astro.redirect('/admin');
+
+const sessionId = Astro.params.id as string;
+let coachingSession = null;
+try { coachingSession = await getCoachingSession(pool, sessionId); } catch { /* ignore */ }
+
+if (!coachingSession) return Astro.redirect('/admin/coaching/sessions');
+
+const report = coachingSession.status === 'completed'
+  ? coachingSession.steps.find(s => s.stepNumber === 0)
+  : null;
+---
+
+<AdminLayout title={`Session: ${coachingSession.title}`}>
+  <div class="page">
+    <nav class="crumbs">
+      <a href="/admin">Admin</a><span class="sep">›</span>
+      <a href="/admin/coaching/sessions">Sessions</a><span class="sep">›</span>
+      {coachingSession.title}
+    </nav>
+
+    {report ? (
+      <div class="report">
+        <div class="report-head">
+          <h1>Abgeschlossen: {coachingSession.title}</h1>
+          <button id="download-btn" class="btn-secondary">Bericht herunterladen</button>
+        </div>
+        <div id="report-text" class="report-body">
+          <pre class="report-pre">{report.aiResponse}</pre>
+        </div>
+        <a href="/admin/coaching/sessions" class="btn-ghost">← Zur Übersicht</a>
+      </div>
+    ) : (
+      <SessionWizard sessionId={sessionId} initialSession={coachingSession} client:load />
+    )}
+  </div>
+</AdminLayout>
+
+<script>
+  document.getElementById('download-btn')?.addEventListener('click', () => {
+    const text = document.getElementById('report-text')?.innerText ?? '';
+    const blob = new Blob([text], { type: 'text/markdown' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a'); a.href = url; a.download = 'coaching-bericht.md'; a.click();
+    URL.revokeObjectURL(url);
+  });
+</script>
+
+<style>
+  .page { max-width: 800px; margin: 0 auto; padding: 1rem 1.5rem 3rem; }
+  .crumbs { font-size: 0.78rem; color: var(--text-muted,#888); margin-bottom: 1rem; }
+  .crumbs a { color: var(--text-muted,#888); text-decoration: none; }
+  .crumbs .sep { margin: 0 0.4rem; }
+  .report { display: flex; flex-direction: column; gap: 1.5rem; }
+  .report-head { display: flex; align-items: center; justify-content: space-between; gap: 1rem; }
+  h1 { font-size: 1.5rem; font-weight: 700; color: var(--text-light,#f0f0f0); margin: 0; }
+  .report-body { background: var(--bg-2,#1a1a1a); border: 1px solid var(--line,#333); border-radius: 8px; padding: 1.5rem; }
+  .report-pre { color: var(--text-light,#f0f0f0); line-height: 1.7; white-space: pre-wrap; font-family: inherit; margin: 0; }
+  .btn-secondary { padding: 0.5rem 1rem; border: 1px solid var(--line,#444); border-radius: 6px; color: var(--text-muted,#888); background: transparent; cursor: pointer; font-size: 0.85rem; }
+  .btn-ghost { color: var(--text-muted,#888); text-decoration: underline; font-size: 0.85rem; }
+</style>

--- a/website/src/pages/admin/coaching/sessions/index.astro
+++ b/website/src/pages/admin/coaching/sessions/index.astro
@@ -1,0 +1,78 @@
+---
+import AdminLayout from '../../../../layouts/AdminLayout.astro';
+import { getSession, getLoginUrl, isAdmin } from '../../../../lib/auth';
+import { listSessions } from '../../../../lib/coaching-session-db';
+import { pool } from '../../../../lib/website-db';
+
+const session = await getSession(Astro.request.headers.get('cookie'));
+if (!session) return Astro.redirect(getLoginUrl(Astro.url.pathname));
+if (!isAdmin(session)) return Astro.redirect('/admin');
+
+const brand = process.env.BRAND || 'mentolder';
+let sessions: Awaited<ReturnType<typeof listSessions>> = [];
+try { sessions = await listSessions(pool, brand); } catch { /* coaching schema may not exist yet */ }
+
+function fmtDate(d: Date | string | null) {
+  if (!d) return '—';
+  return new Date(d).toLocaleDateString('de-DE', { day: '2-digit', month: '2-digit', year: 'numeric' });
+}
+const statusLabel: Record<string, string> = { active: 'Läuft', completed: 'Abgeschlossen', abandoned: 'Abgebrochen' };
+---
+
+<AdminLayout title="Coaching-Sessions">
+  <div class="page">
+    <header class="page-head">
+      <nav class="crumbs">
+        <a href="/admin">Admin</a><span class="sep">›</span>
+        <a href="/admin/coaching/sessions">Coaching</a><span class="sep">›</span>Sessions
+      </nav>
+      <div class="head-row">
+        <h1>Coaching-Sessions</h1>
+        <a href="/admin/coaching/sessions/new" class="btn-primary">+ Neue Session</a>
+      </div>
+    </header>
+
+    {sessions.length === 0 ? (
+      <div class="empty">
+        <p>Noch keine Sessions. Starte deine erste triadische KI-Coaching-Session.</p>
+        <a href="/admin/coaching/sessions/new" class="btn-primary">Erste Session starten →</a>
+      </div>
+    ) : (
+      <table class="table">
+        <thead><tr><th>Titel</th><th>Modus</th><th>Datum</th><th>Status</th><th></th></tr></thead>
+        <tbody>
+          {sessions.map(s => (
+            <tr>
+              <td><a href={`/admin/coaching/sessions/${s.id}`}>{s.title}</a></td>
+              <td>{s.mode === 'prep' ? 'Vorbereitung' : 'Live'}</td>
+              <td>{fmtDate(s.createdAt)}</td>
+              <td><span class={`badge ${s.status}`}>{statusLabel[s.status] ?? s.status}</span></td>
+              <td><a href={`/admin/coaching/sessions/${s.id}`} class="btn-sm">Öffnen</a></td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    )}
+  </div>
+</AdminLayout>
+
+<style>
+  .page { max-width: 1000px; margin: 0 auto; padding: 1rem 1.5rem 3rem; }
+  .page-head { margin-bottom: 1.5rem; }
+  .crumbs { font-size: 0.78rem; color: var(--text-muted,#888); margin-bottom: 0.4rem; }
+  .crumbs a { color: var(--text-muted,#888); text-decoration: none; }
+  .crumbs .sep { margin: 0 0.4rem; }
+  .head-row { display: flex; align-items: center; justify-content: space-between; gap: 1rem; }
+  h1 { font-size: 1.8rem; font-weight: 700; color: var(--text-light,#f0f0f0); margin: 0; }
+  .btn-primary { padding: 0.55rem 1.2rem; background: var(--gold,#c9a55c); color: #111; font-weight: 700; border-radius: 6px; text-decoration: none; font-size: 0.85rem; }
+  .btn-sm { padding: 0.3rem 0.7rem; border: 1px solid var(--line,#444); border-radius: 4px; font-size: 0.82rem; color: var(--text-muted,#888); text-decoration: none; }
+  .empty { background: var(--bg-2,#1a1a1a); border: 1px solid var(--line,#333); border-radius: 8px; padding: 2rem; text-align: center; color: var(--text-muted,#888); display: flex; flex-direction: column; gap: 1rem; align-items: center; }
+  .table { width: 100%; border-collapse: collapse; }
+  .table th { text-align: left; padding: 0.5rem 0.75rem; border-bottom: 1px solid var(--line,#333); font-size: 0.82rem; color: var(--text-muted,#888); }
+  .table td { padding: 0.6rem 0.75rem; border-bottom: 1px solid var(--line,#222); }
+  .table a { color: var(--gold,#c9a55c); text-decoration: none; }
+  .badge { font-size: 0.72rem; padding: 0.2rem 0.5rem; border-radius: 4px; font-weight: 600; }
+  .badge.active { background: #3b82f620; color: #60a5fa; }
+  .badge.completed { background: #22c55e20; color: #4ade80; }
+  .badge.abandoned { background: #64748b20; color: #94a3b8; }
+</style>

--- a/website/src/pages/admin/coaching/sessions/new.astro
+++ b/website/src/pages/admin/coaching/sessions/new.astro
@@ -1,0 +1,93 @@
+---
+import AdminLayout from '../../../../layouts/AdminLayout.astro';
+import { getSession, getLoginUrl, isAdmin } from '../../../../lib/auth';
+import { pool } from '../../../../lib/website-db';
+
+const session = await getSession(Astro.request.headers.get('cookie'));
+if (!session) return Astro.redirect(getLoginUrl(Astro.url.pathname));
+if (!isAdmin(session)) return Astro.redirect('/admin');
+
+let customers: { id: string; name: string }[] = [];
+try {
+  const res = await pool.query(
+    `SELECT id, name FROM public.customers WHERE brand = $1 ORDER BY name`,
+    [process.env.BRAND || 'mentolder']
+  );
+  customers = res.rows;
+} catch { /* ignore */ }
+
+const today = new Date().toLocaleDateString('de-DE', { day: '2-digit', month: '2-digit', year: 'numeric' });
+---
+
+<AdminLayout title="Neue Coaching-Session">
+  <div class="page">
+    <nav class="crumbs">
+      <a href="/admin">Admin</a><span class="sep">›</span>
+      <a href="/admin/coaching/sessions">Sessions</a><span class="sep">›</span>Neu
+    </nav>
+    <h1>Neue Session</h1>
+
+    <form class="form" id="new-session-form">
+      <div class="field">
+        <label for="title">Titel der Session</label>
+        <input id="title" name="title" type="text" value={`Session ${today}`} required class="input" />
+      </div>
+      <div class="field">
+        <label for="clientId">Klient (optional)</label>
+        <select id="clientId" name="clientId" class="input">
+          <option value="">— Vorbereitungsrunde (kein Klient) —</option>
+          {customers.map(c => <option value={c.id}>{c.name}</option>)}
+        </select>
+      </div>
+      <div class="field">
+        <label>Modus</label>
+        <div class="radio-group">
+          <label><input type="radio" name="mode" value="live" checked /> Live-Session (mit Klient)</label>
+          <label><input type="radio" name="mode" value="prep" /> Vorbereitung</label>
+        </div>
+      </div>
+      <div id="form-error" class="error" style="display:none"></div>
+      <button type="submit" class="btn-primary" id="submit-btn">Session starten →</button>
+    </form>
+  </div>
+</AdminLayout>
+
+<script>
+  document.getElementById('new-session-form')?.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const btn = document.getElementById('submit-btn') as HTMLButtonElement;
+    const errEl = document.getElementById('form-error') as HTMLElement;
+    btn.disabled = true; btn.textContent = 'Erstelle…';
+    errEl.style.display = 'none';
+    const form = e.target as HTMLFormElement;
+    const data = Object.fromEntries(new FormData(form));
+    const res = await fetch('/api/admin/coaching/sessions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: data.title, clientId: data.clientId || null, mode: data.mode }),
+    });
+    const json = await res.json();
+    if (res.ok) {
+      window.location.href = `/admin/coaching/sessions/${json.session.id}`;
+    } else {
+      errEl.textContent = json.error ?? 'Fehler'; errEl.style.display = 'block';
+      btn.disabled = false; btn.textContent = 'Session starten →';
+    }
+  });
+</script>
+
+<style>
+  .page { max-width: 560px; margin: 0 auto; padding: 1rem 1.5rem 3rem; }
+  .crumbs { font-size: 0.78rem; color: var(--text-muted,#888); margin-bottom: 0.4rem; }
+  .crumbs a { color: var(--text-muted,#888); text-decoration: none; }
+  .crumbs .sep { margin: 0 0.4rem; }
+  h1 { font-size: 1.8rem; font-weight: 700; color: var(--text-light,#f0f0f0); margin: 0 0 2rem; }
+  .form { display: flex; flex-direction: column; gap: 1.25rem; }
+  .field { display: flex; flex-direction: column; gap: 0.4rem; }
+  label { font-size: 0.82rem; color: var(--text-muted,#888); }
+  .input { background: var(--bg-2,#1a1a1a); border: 1px solid var(--line,#333); border-radius: 6px; padding: 0.6rem 0.75rem; color: var(--text-light,#f0f0f0); font-size: 0.9rem; }
+  .radio-group { display: flex; gap: 1.5rem; color: var(--text-light,#f0f0f0); font-size: 0.9rem; }
+  .btn-primary { align-self: flex-start; padding: 0.65rem 1.5rem; background: var(--gold,#c9a55c); color: #111; font-weight: 700; border: none; border-radius: 6px; cursor: pointer; font-size: 0.9rem; }
+  .btn-primary:disabled { opacity: 0.5; }
+  .error { color: #f87171; font-size: 0.85rem; padding: 0.5rem 0.75rem; background: #ef444415; border-radius: 4px; }
+</style>

--- a/website/src/pages/api/admin/coaching/sessions/[id]/complete.ts
+++ b/website/src/pages/api/admin/coaching/sessions/[id]/complete.ts
@@ -1,0 +1,44 @@
+import type { APIRoute } from 'astro';
+import Anthropic from '@anthropic-ai/sdk';
+import { getSession, isAdmin } from '../../../../../../lib/auth';
+import { getSession as getCoachingSession, completeSession } from '../../../../../../lib/coaching-session-db';
+import { pool } from '../../../../../../lib/website-db';
+
+export const prerender = false;
+
+export const POST: APIRoute = async ({ request, params }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) return new Response('Unauthorized', { status: 401 });
+
+  const sessionId = params.id as string;
+  const coachingSession = await getCoachingSession(pool, sessionId);
+  if (!coachingSession) return new Response(JSON.stringify({ error: 'Not found' }), { status: 404, headers: { 'content-type': 'application/json' } });
+
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  let report = '# Abschlussbericht\n\n*(KI nicht verfügbar — bitte manuell ergänzen)*';
+
+  if (apiKey) {
+    const stepsText = coachingSession.steps
+      .filter(s => s.stepNumber > 0)
+      .map(s => `## Schritt ${s.stepNumber}: ${s.stepName}\n**Eingaben:** ${JSON.stringify(s.coachInputs)}\n**KI:** ${s.aiResponse ?? '—'}\n**Coach-Notiz:** ${s.coachNotes ?? '—'}`)
+      .join('\n\n');
+
+    try {
+      const client = new Anthropic({ apiKey });
+      const msg = await client.messages.create({
+        model: process.env.COACHING_SESSION_MODEL || 'claude-haiku-4-5-20251001',
+        max_tokens: 1200,
+        system: `Du bist ein Coaching-Protokollant. Erstelle aus den 10 Schritten einer Coaching-Session eine strukturierte Zusammenfassung auf Deutsch.
+Abschnitte: ## Ausgangslage, ## Analyse, ## Lösungsansatz, ## Vereinbarte Schritte, ## Bewertung.
+Maximal 600 Wörter. Konkret und handlungsorientiert.`,
+        messages: [{ role: 'user', content: stepsText }],
+      });
+      report = msg.content.filter((b): b is Anthropic.TextBlock => b.type === 'text').map(b => b.text).join('');
+    } catch (err) {
+      console.error('[coaching/complete] Report generation failed:', err);
+    }
+  }
+
+  await completeSession(pool, sessionId, report);
+  return new Response(JSON.stringify({ ok: true, sessionId }), { headers: { 'content-type': 'application/json' } });
+};

--- a/website/src/pages/api/admin/coaching/sessions/[id]/index.ts
+++ b/website/src/pages/api/admin/coaching/sessions/[id]/index.ts
@@ -1,0 +1,14 @@
+import type { APIRoute } from 'astro';
+import { getSession, isAdmin } from '../../../../../../lib/auth';
+import { getSession as getCoachingSession } from '../../../../../../lib/coaching-session-db';
+import { pool } from '../../../../../../lib/website-db';
+
+export const prerender = false;
+
+export const GET: APIRoute = async ({ request, params }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) return new Response('Unauthorized', { status: 401 });
+  const coachingSession = await getCoachingSession(pool, params.id as string);
+  if (!coachingSession) return new Response(JSON.stringify({ error: 'Not found' }), { status: 404, headers: { 'content-type': 'application/json' } });
+  return new Response(JSON.stringify({ session: coachingSession }), { headers: { 'content-type': 'application/json' } });
+};

--- a/website/src/pages/api/admin/coaching/sessions/[id]/steps/[n]/generate.ts
+++ b/website/src/pages/api/admin/coaching/sessions/[id]/steps/[n]/generate.ts
@@ -1,0 +1,53 @@
+import type { APIRoute } from 'astro';
+import Anthropic from '@anthropic-ai/sdk';
+import { getSession, isAdmin } from '../../../../../../../../lib/auth';
+import { upsertStep } from '../../../../../../../../lib/coaching-session-db';
+import { getStepDef, buildUserPrompt } from '../../../../../../../../lib/coaching-session-prompts';
+import { pool } from '../../../../../../../../lib/website-db';
+
+export const prerender = false;
+
+export const POST: APIRoute = async ({ request, params }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) return new Response('Unauthorized', { status: 401 });
+
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) return new Response(JSON.stringify({ error: 'KI nicht konfiguriert (ANTHROPIC_API_KEY fehlt)' }), { status: 503, headers: { 'content-type': 'application/json' } });
+
+  const sessionId = params.id as string;
+  const stepNumber = parseInt(params.n as string, 10);
+  if (isNaN(stepNumber) || stepNumber < 1 || stepNumber > 10) {
+    return new Response(JSON.stringify({ error: 'Invalid step number' }), { status: 400, headers: { 'content-type': 'application/json' } });
+  }
+
+  let body: { coachInputs: Record<string, string> };
+  try { body = await request.json(); } catch {
+    return new Response(JSON.stringify({ error: 'Invalid JSON' }), { status: 400, headers: { 'content-type': 'application/json' } });
+  }
+
+  const def = getStepDef(stepNumber);
+  const userPrompt = buildUserPrompt(def, body.coachInputs);
+  const model = process.env.COACHING_SESSION_MODEL || 'claude-haiku-4-5-20251001';
+
+  let aiResponse: string;
+  try {
+    const client = new Anthropic({ apiKey });
+    const msg = await client.messages.create({
+      model,
+      max_tokens: 600,
+      system: def.systemPrompt,
+      messages: [{ role: 'user', content: userPrompt }],
+    });
+    aiResponse = msg.content.filter((b): b is Anthropic.TextBlock => b.type === 'text').map(b => b.text).join('');
+  } catch (err) {
+    console.error('[coaching/generate] Anthropic error:', err);
+    return new Response(JSON.stringify({ error: 'KI-Anfrage fehlgeschlagen' }), { status: 502, headers: { 'content-type': 'application/json' } });
+  }
+
+  const step = await upsertStep(pool, {
+    sessionId, stepNumber, stepName: def.stepName, phase: def.phase,
+    coachInputs: body.coachInputs, aiPrompt: userPrompt, aiResponse, status: 'generated',
+  });
+
+  return new Response(JSON.stringify({ step }), { headers: { 'content-type': 'application/json' } });
+};

--- a/website/src/pages/api/admin/coaching/sessions/[id]/steps/[n]/index.ts
+++ b/website/src/pages/api/admin/coaching/sessions/[id]/steps/[n]/index.ts
@@ -1,0 +1,27 @@
+import type { APIRoute } from 'astro';
+import { getSession, isAdmin } from '../../../../../../../../lib/auth';
+import { upsertStep } from '../../../../../../../../lib/coaching-session-db';
+import { getStepDef } from '../../../../../../../../lib/coaching-session-prompts';
+import { pool } from '../../../../../../../../lib/website-db';
+
+export const prerender = false;
+
+export const PATCH: APIRoute = async ({ request, params }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) return new Response('Unauthorized', { status: 401 });
+  const sessionId = params.id as string;
+  const stepNumber = parseInt(params.n as string, 10);
+  if (isNaN(stepNumber) || stepNumber < 0 || stepNumber > 10) {
+    return new Response(JSON.stringify({ error: 'Invalid step number' }), { status: 400, headers: { 'content-type': 'application/json' } });
+  }
+  let body: { coachInputs?: Record<string, string>; coachNotes?: string; status?: 'pending' | 'generated' | 'accepted' | 'skipped' };
+  try { body = await request.json(); } catch {
+    return new Response(JSON.stringify({ error: 'Invalid JSON' }), { status: 400, headers: { 'content-type': 'application/json' } });
+  }
+  const def = stepNumber > 0 ? getStepDef(stepNumber) : { stepName: 'Abschlussbericht', phase: 'umsetzung' };
+  const step = await upsertStep(pool, {
+    sessionId, stepNumber, stepName: def.stepName, phase: def.phase,
+    coachInputs: body.coachInputs, coachNotes: body.coachNotes, status: body.status,
+  });
+  return new Response(JSON.stringify({ step }), { headers: { 'content-type': 'application/json' } });
+};

--- a/website/src/pages/api/admin/coaching/sessions/index.ts
+++ b/website/src/pages/api/admin/coaching/sessions/index.ts
@@ -1,0 +1,32 @@
+import type { APIRoute } from 'astro';
+import { getSession, isAdmin } from '../../../../../lib/auth';
+import { createSession, listSessions } from '../../../../../lib/coaching-session-db';
+import { pool } from '../../../../../lib/website-db';
+
+export const prerender = false;
+
+export const GET: APIRoute = async ({ request }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) return new Response('Unauthorized', { status: 401 });
+  const brand = process.env.BRAND || 'mentolder';
+  const sessions = await listSessions(pool, brand);
+  return new Response(JSON.stringify({ sessions }), { headers: { 'content-type': 'application/json' } });
+};
+
+export const POST: APIRoute = async ({ request }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) return new Response('Unauthorized', { status: 401 });
+  const brand = process.env.BRAND || 'mentolder';
+  let body: { title: string; clientId?: string | null; mode?: 'live' | 'prep' };
+  try { body = await request.json(); } catch {
+    return new Response(JSON.stringify({ error: 'Invalid JSON' }), { status: 400, headers: { 'content-type': 'application/json' } });
+  }
+  if (!body.title?.trim()) {
+    return new Response(JSON.stringify({ error: 'title required' }), { status: 400, headers: { 'content-type': 'application/json' } });
+  }
+  const created = await createSession(pool, {
+    brand, title: body.title, createdBy: session.preferred_username,
+    clientId: body.clientId ?? null, mode: body.mode ?? 'live',
+  });
+  return new Response(JSON.stringify({ session: created }), { status: 201, headers: { 'content-type': 'application/json' } });
+};


### PR DESCRIPTION
## Summary
- Implements the \"Triadisches KI-Coaching\" (Geißler) 10-step guided wizard in the admin area under `/admin/coaching/sessions`
- Adds two new DB tables (`coaching.sessions`, `coaching.session_steps`), five API routes, three Astro pages, and a Svelte 5 `SessionWizard` component with per-step Anthropic API generation (claude-haiku-4-5-20251001)
- Session protocol is fully persisted; coach can accept/reject/skip each AI response and export the auto-generated Markdown summary report

## Test plan
- [x] `task test:all` (unit + manifests + dry-run)
- [x] Vitest: 4 test suites for `coaching-session-db.ts` all green (pg-mem v3)
- [x] `task test:inventory` regenerated and committed
- [x] Manual review: API routes, SessionWizard state machine, AdminLayout nav group

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>