### PR TITLE
fix(brett): set Cache-Control per asset type

### DIFF
--- a/brett/server.js
+++ b/brett/server.js
@@ -48,7 +48,15 @@ if (process.env.MOCK_DB === 'true') {
 
 const app = express();
 app.use(express.json({ limit: '1mb' }));
-app.use(express.static('public', { maxAge: '5m' }));
+app.use(express.static('public', {
+  setHeaders: (res, path) => {
+    if (path.endsWith('.html')) {
+      res.setHeader('Cache-Control', 'no-cache');
+    } else {
+      res.setHeader('Cache-Control', 'public, max-age=300'); // 5m
+    }
+  }
+}));
 
 app.get('/healthz', (_req, res) => res.type('text/plain').send('ok'));
 


### PR DESCRIPTION
## Summary
- HTML responses now served with `Cache-Control: no-cache` so index updates are picked up immediately
- Other static assets keep the existing 5-minute max-age

## Test plan
- [ ] `task brett:deploy ENV=mentolder` (and korczewski) — confirm assets still load
- [ ] `curl -I https://brett.mentolder.de/index.html` shows `Cache-Control: no-cache`
- [ ] `curl -I https://brett.mentolder.de/<some-asset>.js` shows `max-age=300`

🤖 Generated with [Claude Code](https://claude.com/claude-code)