### PR TITLE
chore(skills): fix tickets schema drift in dev-flow-execute

### DIFF
--- a/.claude/skills/dev-flow-execute/SKILL.md
+++ b/.claude/skills/dev-flow-execute/SKILL.md
@@ -164,32 +164,21 @@ Co-Authored-By: <model-name>
 
 ---
 
-## Schritt 5.5: PR-Link im Ticket speichern
+## Schritt 5.5: PR-Nummer für Ticket-Abschluss merken
 
 Falls `$TICKET_ID` gesetzt, direkt nach dem PR-Erstellen:
 
 ```bash
 PR_NUM=$(gh pr view --json number -q '.number')
-
-PGPOD=$(kubectl get pod -n workspace --context mentolder \
-  -l app=shared-db -o name | head -1)
-
-TICKET_UUID=$(kubectl exec "$PGPOD" -n workspace --context mentolder -- \
-  psql -U website -d website -At -c \
-  "SELECT id FROM tickets.tickets WHERE external_id = '$TICKET_ID';")
-
-kubectl exec "$PGPOD" -n workspace --context mentolder -- \
-  psql -U website -d website -c \
-  "INSERT INTO tickets.ticket_links (from_id, kind, pr_number)
-   SELECT '$TICKET_UUID', 'pr', $PR_NUM
-   WHERE NOT EXISTS (
-     SELECT 1 FROM tickets.ticket_links
-     WHERE from_id = '$TICKET_UUID' AND kind = 'pr' AND pr_number = $PR_NUM
-   );"
 ```
 
-- `to_id` bleibt NULL (kein NOT NULL-Constraint auf der Spalte).
-- `WHERE NOT EXISTS` macht den Insert idempotent ohne UNIQUE-Constraint.
+Das ist alles — die PR-Nummer landet in Schritt 6.5 als Comment-Body und in Schritt 7 als `ticket_plans.pr_number`.
+
+`tickets.ticket_links` ist **nicht** für PR-Referenzen geeignet:
+- `to_id` ist `NOT NULL` (FK auf `tickets.tickets`), also kein Ticket→PR möglich.
+- `kind`-Check-Constraint erlaubt nur `blocks | blocked_by | duplicate_of | relates_to | fixes | fixed_by`.
+
+`tickets.pr_events` führt PRs unabhängig (kein `ticket_id`-FK) — die Verknüpfung lebt allein über `ticket_plans.pr_number` und den Schluss-Kommentar.
 
 ---
 
@@ -216,8 +205,9 @@ kubectl exec "$PGPOD" -n workspace --context mentolder -- \
      SET status = 'done', resolution = '$RESOLUTION'
    WHERE external_id = '$TICKET_ID';
 
-   INSERT INTO tickets.ticket_comments (ticket_id, body, visibility)
+   INSERT INTO tickets.ticket_comments (ticket_id, author_label, body, visibility)
    SELECT id,
+     'claude-code',
      'PR #$PR_NUM merged. Plan archived to tickets.ticket_plans in Postgres.',
      'internal'
    FROM tickets.tickets WHERE external_id = '$TICKET_ID';"
@@ -340,8 +330,9 @@ Wenn mehrere Kategorien matchen: workspace → website → brett → livekit →
   ```bash
   kubectl exec "$PGPOD" -n workspace --context mentolder -- \
     psql -U website -d website -c \
-    "INSERT INTO tickets.ticket_comments (ticket_id, body, visibility)
+    "INSERT INTO tickets.ticket_comments (ticket_id, author_label, body, visibility)
      SELECT id,
+       'claude-code',
        'CI blockiert nach Diagnose — manuelle Intervention nötig. Branch: fix/<slug>',
        'internal'
      FROM tickets.tickets WHERE external_id = '$TICKET_ID';"


### PR DESCRIPTION
## Summary
- Drop the broken `ticket_links` PR-link insert in Schritt 5.5 — `to_id` is NOT NULL and the `kind` check constraint rejects `'pr'`. PR↔ticket linkage already lives in `ticket_plans.pr_number` and the closing comment.
- Add `author_label = 'claude-code'` to both `ticket_comments` inserts (Schritt 6.5 close-out + Failure-Handling CI-stuck comment) — column is NOT NULL.

Found while running the skill — silent failure required manual workaround. This brings the doc back in sync with the live schema.

## Test plan
- [x] grep verified all three call sites updated
- [ ] next dev-flow-execute run inserts ticket_comments without manual fixup

🤖 Generated with [Claude Code](https://claude.com/claude-code)