### PR TITLE
feat(brainstorm): persist chosen approach + session ID in superpowers.plans [T000374]

### DIFF
--- a/.claude/skills/dev-flow-plan/SKILL.md
+++ b/.claude/skills/dev-flow-plan/SKILL.md
@@ -216,6 +216,19 @@ awk 'NR==1{print; print "ticket_id: '"$TICKET_EXT_ID"'"; next} 1' \
   mv /tmp/_plan_tmp.md docs/superpowers/plans/<date>-<slug>.md
 ```
 
+Injiziere dann brainstorm_choice + brainstorm_session (best-effort — kein Fehler wenn kein STATE_DIR oder keine Wahl):
+
+```bash
+if [[ -n "${STATE_DIR:-}" ]] && BRAINSTORM_CHOICE=$(bash scripts/brainstorm-extract-choice.sh "$STATE_DIR" 2>/dev/null); then
+  SESSION_ID=$(basename "$(dirname "$STATE_DIR")")
+  awk -v c="$BRAINSTORM_CHOICE" -v s="$SESSION_ID" \
+    'NR==1{print; print "brainstorm_choice: " c; print "brainstorm_session: " s; next} 1' \
+    docs/superpowers/plans/<date>-<slug>.md > /tmp/_plan_tmp.md && \
+    mv /tmp/_plan_tmp.md docs/superpowers/plans/<date>-<slug>.md
+  echo "Brainstorm choice '$BRAINSTORM_CHOICE' (session $SESSION_ID) recorded"
+fi
+```
+
 Melde: **"Ticket `$TICKET_EXT_ID` angelegt → https://web.mentolder.de/admin/bugs"**
 
 ### Schritt 4.6: Gesammelte Assets ans Ticket hängen

--- a/docs/superpowers/plans/2026-05-14-brainstorm-session-db.md
+++ b/docs/superpowers/plans/2026-05-14-brainstorm-session-db.md
@@ -1,0 +1,400 @@
+---
+ticket_id: T000374
+---
+
+# Brainstorm Session Choice Persistence Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When dev-flow-plan commits a plan, the brainstorm-chosen approach (e.g., "A") and session ID are stored in the plan frontmatter and persisted into `superpowers.plans` so the analytics dashboard can show which approach was chosen per plan.
+
+**Architecture:** Four-layer change: (1) a helper script extracts the last `choice` from a brainstorm session events file; (2) dev-flow-plan injects `brainstorm_choice` + `brainstorm_session` into the plan frontmatter; (3) `plans_parse.py` passes these fields through to the pending JSON; (4) `writePlanToDb()` + `ensurePlanSchema()` in `track-pr.mjs` store them in `superpowers.plans`. No new DB table needed — two nullable columns on the existing `superpowers.plans` table.
+
+**Tech Stack:** Bash (`scripts/`), Python 3 (`scripts/plans_parse.py`), Node.js ESM (`scripts/track-pr.mjs`), PostgreSQL
+
+---
+
+## File Map
+
+| File | Change |
+|------|--------|
+| `scripts/brainstorm-extract-choice.sh` | NEW — reads `$STATE_DIR/events` NDJSON, outputs last `choice` value |
+| `.claude/skills/dev-flow-plan/SKILL.md` | Add post-brainstorm step to call the helper and inject frontmatter |
+| `scripts/plans_parse.py` | Read `brainstorm_choice`, `brainstorm_session` from frontmatter, include in JSON output |
+| `scripts/track-pr.mjs` | `ensurePlanSchema()` adds two columns; `writePlanToDb()` persists them |
+
+---
+
+### Task 1: Write `brainstorm-extract-choice.sh`
+
+**Files:**
+- Create: `scripts/brainstorm-extract-choice.sh`
+- Create: `tests/unit/brainstorm-extract-choice.bats`
+
+- [ ] **Step 1: Create the script**
+
+Create `scripts/brainstorm-extract-choice.sh`:
+
+```bash
+#!/usr/bin/env bash
+# Read the last {"choice": "X"} event from a brainstorm session events file.
+# Usage: brainstorm-extract-choice.sh <state_dir>
+# Output: prints the choice label (e.g. "A") or exits 1 if no choice event found.
+set -euo pipefail
+
+STATE_DIR="${1:?Usage: brainstorm-extract-choice.sh <state_dir>}"
+EVENTS_FILE="$STATE_DIR/events"
+
+if [[ ! -f "$EVENTS_FILE" ]]; then
+  echo "no events file at $EVENTS_FILE" >&2
+  exit 1
+fi
+
+CHOICE=$(grep -o '"choice":"[^"]*"' "$EVENTS_FILE" | tail -1 | sed 's/"choice":"//;s/"//')
+if [[ -z "$CHOICE" ]]; then
+  echo "no choice event found in $EVENTS_FILE" >&2
+  exit 1
+fi
+
+echo "$CHOICE"
+```
+
+Then: `chmod +x scripts/brainstorm-extract-choice.sh`
+
+- [ ] **Step 2: Write a BATS test**
+
+Create `tests/unit/brainstorm-extract-choice.bats`:
+
+```bash
+#!/usr/bin/env bats
+# Tests for scripts/brainstorm-extract-choice.sh
+
+setup() {
+  TMPDIR="$(mktemp -d)"
+  export TMPDIR
+}
+
+teardown() {
+  rm -rf "$TMPDIR"
+}
+
+@test "extracts last choice from events file" {
+  echo '{"type":"click","choice":"A","timestamp":1}' > "$TMPDIR/events"
+  echo '{"type":"click","choice":"B","timestamp":2}' >> "$TMPDIR/events"
+  run bash scripts/brainstorm-extract-choice.sh "$TMPDIR"
+  [ "$status" -eq 0 ]
+  [ "$output" = "B" ]
+}
+
+@test "exits 1 when no events file" {
+  run bash scripts/brainstorm-extract-choice.sh "$TMPDIR"
+  [ "$status" -eq 1 ]
+}
+
+@test "exits 1 when no choice event in file" {
+  echo '{"type":"scroll","timestamp":1}' > "$TMPDIR/events"
+  run bash scripts/brainstorm-extract-choice.sh "$TMPDIR"
+  [ "$status" -eq 1 ]
+}
+```
+
+- [ ] **Step 3: Run BATS tests**
+
+```bash
+./tests/unit/lib/bats-core/bin/bats tests/unit/brainstorm-extract-choice.bats
+```
+
+Expected: 3 tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/brainstorm-extract-choice.sh tests/unit/brainstorm-extract-choice.bats
+git commit -m "feat(brainstorm): add brainstorm-extract-choice.sh helper [T000374]"
+```
+
+---
+
+### Task 2: Inject brainstorm fields into plan frontmatter in `dev-flow-plan`
+
+**Files:**
+- Modify: `.claude/skills/dev-flow-plan/SKILL.md`
+
+- [ ] **Step 1: Locate the ticket_id injection block in the skill**
+
+In `.claude/skills/dev-flow-plan/SKILL.md`, find the `awk` block that injects `ticket_id` into the plan frontmatter (in "Schritt 4.5: Ticket anlegen"). It looks like:
+
+```bash
+awk 'NR==1{print; print "ticket_id: '"$TICKET_EXT_ID"'"; next} 1' \
+  docs/superpowers/plans/<date>-<slug>.md > /tmp/_plan_tmp.md && \
+  mv /tmp/_plan_tmp.md docs/superpowers/plans/<date>-<slug>.md
+```
+
+- [ ] **Step 2: Add brainstorm field injection immediately after the ticket_id block**
+
+Insert after the `mv /tmp/_plan_tmp.md ...` line:
+
+```bash
+# Inject brainstorm_choice + brainstorm_session (best-effort — skip if no events)
+if BRAINSTORM_CHOICE=$(bash scripts/brainstorm-extract-choice.sh "$STATE_DIR" 2>/dev/null); then
+  SESSION_ID=$(basename "$(dirname "$STATE_DIR")")
+  awk -v c="$BRAINSTORM_CHOICE" -v s="$SESSION_ID" \
+    'NR==1{print; print "brainstorm_choice: " c; print "brainstorm_session: " s; next} 1' \
+    docs/superpowers/plans/<date>-<slug>.md > /tmp/_plan_tmp.md && \
+    mv /tmp/_plan_tmp.md docs/superpowers/plans/<date>-<slug>.md
+  echo "Brainstorm choice '\''$BRAINSTORM_CHOICE'\'' (session $SESSION_ID) recorded"
+fi
+```
+
+Note: `$STATE_DIR` is already set earlier in the Feature-Pfad from the `start-server.sh` output. `SESSION_ID` is the brainstorm session directory name (parent of `state/`).
+
+- [ ] **Step 3: Verify the edit**
+
+```bash
+grep -c "brainstorm_choice" .claude/skills/dev-flow-plan/SKILL.md
+```
+
+Expected: 1 or more occurrences.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .claude/skills/dev-flow-plan/SKILL.md
+git commit -m "feat(dev-flow-plan): inject brainstorm_choice + brainstorm_session into plan frontmatter [T000374]"
+```
+
+---
+
+### Task 3: Pass `brainstorm_choice` and `brainstorm_session` through `plans_parse.py`
+
+**Files:**
+- Modify: `scripts/plans_parse.py`
+- Create: `scripts/plans_parse.test.py`
+
+- [ ] **Step 1: Write a failing Python test**
+
+Create `scripts/plans_parse.test.py`:
+
+```python
+#!/usr/bin/env python3
+import tempfile, pathlib, sys, os
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from plans_parse import parse_plan
+
+def make_plan(extra=""):
+    content = f"""---
+title: Test Plan
+domains: [website]
+status: active
+{extra}
+---
+
+# Test Plan
+
+## Task 1: Do thing
+
+- [ ] Step 1: Do the thing
+"""
+    f = tempfile.NamedTemporaryFile(suffix='.md', mode='w', delete=False)
+    f.write(content)
+    f.close()
+    return f.name
+
+def test_includes_brainstorm_fields():
+    path = make_plan("brainstorm_choice: B\nbrainstorm_session: 123456-789012")
+    result = parse_plan(path)
+    assert result.get('brainstorm_choice') == 'B', \
+        f"Expected 'B', got {result.get('brainstorm_choice')}"
+    assert result.get('brainstorm_session') == '123456-789012', \
+        f"Got {result.get('brainstorm_session')}"
+    print("PASS: brainstorm fields included")
+
+def test_missing_brainstorm_fields_are_none():
+    path = make_plan()
+    result = parse_plan(path)
+    assert result.get('brainstorm_choice') is None, \
+        f"Expected None, got {result.get('brainstorm_choice')}"
+    assert result.get('brainstorm_session') is None, \
+        f"Expected None, got {result.get('brainstorm_session')}"
+    print("PASS: missing brainstorm fields are None")
+
+test_includes_brainstorm_fields()
+test_missing_brainstorm_fields_are_none()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+python3 scripts/plans_parse.test.py
+```
+
+Expected: `AssertionError` — fields not present in result dict.
+
+- [ ] **Step 3: Add the two fields to `parse_plan()` return dict in `scripts/plans_parse.py`**
+
+Change the `return` statement in `parse_plan()` from:
+
+```python
+    return {
+        'type': 'plan',
+        'slug': slug,
+        'title': fm.get('title', slug),
+        'domains': fm.get('domains', []),
+        'status': fm.get('status', 'active'),
+        'pr_number': fm.get('pr_number'),
+        'file_path': str(path),
+        'sections': sections,
+    }
+```
+
+to:
+
+```python
+    return {
+        'type': 'plan',
+        'slug': slug,
+        'title': fm.get('title', slug),
+        'domains': fm.get('domains', []),
+        'status': fm.get('status', 'active'),
+        'pr_number': fm.get('pr_number'),
+        'file_path': str(path),
+        'sections': sections,
+        'brainstorm_choice': fm.get('brainstorm_choice') or None,
+        'brainstorm_session': fm.get('brainstorm_session') or None,
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+python3 scripts/plans_parse.test.py
+```
+
+Expected:
+```
+PASS: brainstorm fields included
+PASS: missing brainstorm fields are None
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/plans_parse.py scripts/plans_parse.test.py
+git commit -m "feat(plans-parse): include brainstorm_choice + brainstorm_session in plan JSON [T000374]"
+```
+
+---
+
+### Task 4: Store brainstorm fields in `superpowers.plans` DB table
+
+**Files:**
+- Modify: `scripts/track-pr.mjs` (`ensurePlanSchema()` and `writePlanToDb()`)
+
+- [ ] **Step 1: Add ALTER TABLE to `ensurePlanSchema()`**
+
+After the two `CREATE INDEX` statements in `ensurePlanSchema()` (lines 198–199), add:
+
+```js
+  // Self-heal: add brainstorm columns if they don't exist (idempotent ALTER)
+  await pgClient.query(`
+    ALTER TABLE superpowers.plans
+      ADD COLUMN IF NOT EXISTS brainstorm_choice  TEXT,
+      ADD COLUMN IF NOT EXISTS brainstorm_session TEXT
+  `);
+```
+
+- [ ] **Step 2: Update INSERT and ON CONFLICT in `writePlanToDb()`**
+
+Replace the INSERT query in `writePlanToDb()` (lines 203–213):
+
+```js
+  const result = await pgClient.query(
+    `INSERT INTO superpowers.plans
+       (slug, title, domains, status, pr_number, file_path,
+        brainstorm_choice, brainstorm_session)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+     ON CONFLICT (slug) DO UPDATE SET
+       title              = EXCLUDED.title,
+       domains            = EXCLUDED.domains,
+       status             = EXCLUDED.status,
+       pr_number          = EXCLUDED.pr_number,
+       file_path          = EXCLUDED.file_path,
+       brainstorm_choice  = COALESCE(EXCLUDED.brainstorm_choice,
+                                     superpowers.plans.brainstorm_choice),
+       brainstorm_session = COALESCE(EXCLUDED.brainstorm_session,
+                                     superpowers.plans.brainstorm_session)
+     RETURNING id`,
+    [row.slug, row.title, row.domains, row.status, row.pr_number ?? null, row.file_path,
+     row.brainstorm_choice ?? null, row.brainstorm_session ?? null]
+  );
+```
+
+The `COALESCE` pattern means a re-ingest without brainstorm fields won't overwrite an existing non-null value.
+
+- [ ] **Step 3: Syntax check**
+
+```bash
+node --check scripts/track-pr.mjs && echo "OK"
+```
+
+Expected: `OK`
+
+- [ ] **Step 4: Run track-pr unit tests**
+
+```bash
+node --test scripts/track-pr.test.mjs 2>&1 | tail -10
+```
+
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/track-pr.mjs
+git commit -m "feat(plans-db): persist brainstorm_choice + brainstorm_session in superpowers.plans [T000374]"
+```
+
+---
+
+### Task 5: Verification & PR
+
+- [ ] **Step 1: Run all offline unit tests**
+
+```bash
+task test:unit 2>&1 | tail -15
+```
+
+Expected: all pass, including new `brainstorm-extract-choice.bats`.
+
+- [ ] **Step 2: Verify superpowers.plans schema on prod (after first ingest post-deploy)**
+
+```bash
+PGPOD=$(kubectl get pod -n workspace --context mentolder -l app=shared-db -o name | head -1)
+kubectl exec "$PGPOD" -n workspace --context mentolder -- \
+  psql -U website -d website -At -c \
+  "\d superpowers.plans" 2>/dev/null | grep brainstorm
+```
+
+Expected: `brainstorm_choice` and `brainstorm_session` columns present.
+
+- [ ] **Step 3: Create PR via commit-commands:commit-push-pr**
+
+Invoke skill `commit-commands:commit-push-pr`.
+
+Title: `feat(brainstorm): persist chosen approach + session ID in superpowers.plans [T000374]`
+
+Body:
+```
+## Summary
+- New `scripts/brainstorm-extract-choice.sh` reads last `choice` event from brainstorm session events NDJSON
+- `dev-flow-plan` skill injects `brainstorm_choice` + `brainstorm_session` into plan frontmatter after brainstorming
+- `plans_parse.py` passes these fields through to the pending JSON
+- `ensurePlanSchema()` adds two nullable columns; `writePlanToDb()` persists them (COALESCE-safe on re-ingest)
+
+## Test plan
+- [x] `bats tests/unit/brainstorm-extract-choice.bats` passes (3 tests)
+- [x] `python3 scripts/plans_parse.test.py` passes (2 tests)
+- [x] `node --test scripts/track-pr.test.mjs` all pass
+- [x] `task test:unit` green
+- [ ] After merge: next dev-flow-plan session with brainstorming populates the fields on the next plan commit
+```

--- a/docs/superpowers/plans/2026-05-14-timeline-ticket-deeplink.md
+++ b/docs/superpowers/plans/2026-05-14-timeline-ticket-deeplink.md
@@ -1,0 +1,385 @@
+---
+ticket_id: T000373
+---
+
+# Timeline Ticket Deep-Link Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Surface the plan ticket (T-######) on each Kore timeline row so editors can click through to `/admin/tickets/T000xxx` directly from the homepage timeline.
+
+**Architecture:** Three-layer change: (1) `parsePr()` extracts T-###### references from PR bodies; (2) `writeRowToDb()` writes `tickets.ticket_links` rows with `kind='implements'`; (3) `listTimeline()` batch-fetches those links and returns `ticket_external_id`; (4) `Timeline.svelte` renders a clickable badge. No schema migrations needed — `tickets.ticket_links` already has all required columns.
+
+**Tech Stack:** Node.js ESM (`scripts/`), TypeScript/Astro (`website/src/`), Svelte 5, PostgreSQL
+
+---
+
+## File Map
+
+| File | Change |
+|------|--------|
+| `scripts/track-pr.mjs` | Add `TICKET_RE`, extend `parsePr()` return, add ticket link writes to `writeRowToDb()` |
+| `scripts/track-pr.test.mjs` | New tests for T-ref parsing |
+| `website/src/lib/website-db.ts` | Add `ticket_external_id` to `TimelineRow`, extend `listTimeline()` |
+| `website/src/components/Timeline.svelte` | Add `ticket_external_id` to Row type, render badge |
+
+---
+
+### Task 1: Extend `parsePr()` to extract T-###### references
+
+**Files:**
+- Modify: `scripts/track-pr.mjs` (add regex constant + extend return)
+- Modify: `scripts/track-pr.test.mjs` (new tests)
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the end of `scripts/track-pr.test.mjs`:
+
+```js
+test('extracts T-###### ticket references from body', () => {
+  const r = parsePr({
+    number: 751,
+    title: 'feat(tracking): timeline ticket deeplink',
+    body: 'Implements T000373\n\nAlso related to T000001.',
+    mergedAt: '2026-05-14T18:00:00Z',
+  });
+  assert.deepEqual(r.ticket_refs, ['T000373', 'T000001']);
+});
+
+test('returns empty ticket_refs when body has none', () => {
+  const r = parsePr({
+    number: 752,
+    title: 'chore: bump deps',
+    body: 'Updated package.json.',
+    mergedAt: '2026-05-14T18:01:00Z',
+  });
+  assert.deepEqual(r.ticket_refs, []);
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+node --test scripts/track-pr.test.mjs 2>&1 | tail -10
+```
+
+Expected: FAIL — `r.ticket_refs` is undefined.
+
+- [ ] **Step 3: Add `TICKET_RE` constant to `scripts/track-pr.mjs`**
+
+After line 3 (`const REQ_RE = /\b(FA|SA|NFA|AK|L)-\d+\b/i;`), add:
+
+```js
+const TICKET_RE = /\bT\d{6}\b/g;
+```
+
+- [ ] **Step 4: Extract ticket_refs in `parsePr()`**
+
+After `const reqMatch = REQ_RE.exec(body);` (around line 22), add:
+
+```js
+  const ticket_refs = Array.from(new Set((body.match(TICKET_RE) || [])));
+```
+
+- [ ] **Step 5: Include `ticket_refs` in the `parsePr()` return object**
+
+The full return becomes:
+
+```js
+  return {
+    pr_number: pr.number,
+    title,
+    description: body.length > 0 ? body.slice(0, 4000) : null,
+    category,
+    scope,
+    brand,
+    requirement_id,
+    merged_at: pr.mergedAt,
+    merged_by: pr.mergedBy?.login || null,
+    bug_refs,
+    ticket_refs,
+  };
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+```bash
+node --test scripts/track-pr.test.mjs 2>&1 | tail -10
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add scripts/track-pr.mjs scripts/track-pr.test.mjs
+git commit -m "feat(tracking): parsePr() extracts T-###### ticket_refs from PR body [T000373]"
+```
+
+---
+
+### Task 2: Write `ticket_links` rows for T-refs in `writeRowToDb()`
+
+**Files:**
+- Modify: `scripts/track-pr.mjs` (`writeRowToDb()` function body)
+
+- [ ] **Step 1: Add ticket_refs block after the `requirement_id` block**
+
+In `writeRowToDb()`, after the `if (row.requirement_id) { ... }` block (ends around line 79), insert:
+
+```js
+  // 3. T-###### ticket references → ticket_links (kind='implements')
+  for (const extId of (row.ticket_refs ?? [])) {
+    const t = await pgClient.query(
+      `SELECT id FROM tickets.tickets WHERE external_id = $1`,
+      [extId]);
+    if (t.rowCount > 0) {
+      await pgClient.query(
+        `INSERT INTO tickets.ticket_links (from_id, to_id, kind, pr_number)
+         VALUES ($1, $1, 'implements', $2)
+         ON CONFLICT (from_id, to_id, kind) DO NOTHING`,
+        [t.rows[0].id, row.pr_number]);
+    } else {
+      console.log(`skip ticket link ${extId}: ticket not found`);
+    }
+  }
+```
+
+- [ ] **Step 2: Verify syntax**
+
+```bash
+node --check scripts/track-pr.mjs && echo "OK"
+```
+
+Expected: `OK`
+
+- [ ] **Step 3: Run all track-pr tests**
+
+```bash
+node --test scripts/track-pr.test.mjs 2>&1 | tail -10
+```
+
+Expected: all pass (the DB write path is integration-only, covered by live verification in Task 5).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/track-pr.mjs
+git commit -m "feat(tracking): writeRowToDb() writes implements link for T-###### refs [T000373]"
+```
+
+---
+
+### Task 3: Expose `ticket_external_id` in `listTimeline()`
+
+**Files:**
+- Modify: `website/src/lib/website-db.ts` (lines 36–98)
+
+- [ ] **Step 1: Add `ticket_external_id` to `TimelineRow` type**
+
+Replace the `TimelineRow` type definition (lines 36–48):
+
+```ts
+export type TimelineRow = {
+  id: number;
+  day: string;
+  pr_number: number | null;
+  title: string;
+  description: string | null;
+  category: string;
+  scope: string | null;
+  brand: string | null;
+  requirement_id: string | null;
+  requirement_name: string | null;
+  bugs_fixed: number;
+  ticket_external_id: string | null;
+};
+```
+
+- [ ] **Step 2: Batch-fetch implements links in `listTimeline()`**
+
+Replace the section from `const prNumbers = rows.map(...)` to the final `return rows.map(...)` (lines 85–98) with:
+
+```ts
+  const prNumbers = rows.map(r => r.pr_number).filter((n): n is number => n != null);
+  const bugCounts = new Map<number, number>();
+  const ticketIds = new Map<number, string>();
+
+  if (prNumbers.length > 0) {
+    const [counts, links] = await Promise.all([
+      pool.query<{ pr: number; n: number }>(
+        `SELECT pr_number AS pr, COUNT(*)::int AS n
+           FROM tickets.ticket_links
+          WHERE kind = 'fixes' AND pr_number = ANY($1::int[])
+          GROUP BY pr_number`,
+        [prNumbers],
+      ),
+      pool.query<{ pr: number; external_id: string }>(
+        `SELECT tl.pr_number AS pr, t.external_id
+           FROM tickets.ticket_links tl
+           JOIN tickets.tickets t ON t.id = tl.from_id
+          WHERE tl.kind = 'implements' AND tl.pr_number = ANY($1::int[])`,
+        [prNumbers],
+      ),
+    ]);
+    for (const c of counts.rows) bugCounts.set(c.pr, c.n);
+    for (const l of links.rows) ticketIds.set(l.pr, l.external_id);
+  }
+
+  return rows.map(r => ({
+    ...r,
+    bugs_fixed: r.pr_number ? (bugCounts.get(r.pr_number) ?? 0) : 0,
+    ticket_external_id: r.pr_number ? (ticketIds.get(r.pr_number) ?? null) : null,
+  }));
+```
+
+- [ ] **Step 3: TypeScript compile check**
+
+```bash
+cd website
+npx tsc --noEmit 2>&1 | head -20
+```
+
+Expected: 0 errors. If errors about `TimelineRow` elsewhere (missing `ticket_external_id`), add `ticket_external_id: null` to any literal `TimelineRow` objects in those files.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add website/src/lib/website-db.ts
+git commit -m "feat(timeline): expose ticket_external_id via implements link JOIN [T000373]"
+```
+
+---
+
+### Task 4: Render ticket badge in `Timeline.svelte`
+
+**Files:**
+- Modify: `website/src/components/Timeline.svelte`
+
+- [ ] **Step 1: Add `ticket_external_id` to the local Row type**
+
+Replace the `type Row` block (lines 6–11):
+
+```ts
+  type Row = {
+    id: number; day: string; pr_number: number | null;
+    title: string; description: string | null;
+    category: string; scope: string | null; brand: string | null;
+    requirement_id: string | null; bugs_fixed: number;
+    ticket_external_id: string | null;
+  };
+```
+
+- [ ] **Step 2: Add ticket badge to the meta section**
+
+Replace the `<span class="meta">` block (lines 56–59):
+
+```svelte
+      <span class="meta">
+        {#if r.pr_number}<span class="pr">PR #{r.pr_number}</span>{/if}
+        {#if r.bugs_fixed > 0}<span class="bug">+{r.bugs_fixed} fix</span>{/if}
+        {#if r.ticket_external_id}
+          <a class="ticket" href="/admin/tickets/{r.ticket_external_id}">{r.ticket_external_id}</a>
+        {/if}
+      </span>
+```
+
+- [ ] **Step 3: Add `.ticket` CSS rule**
+
+After `.meta .bug { color: var(--sage, #5bd4d0); }` (around line 148), add:
+
+```css
+  .meta .ticket {
+    color: var(--mute);
+    text-decoration: none;
+    border-bottom: 1px dotted var(--mute);
+    transition: color 150ms ease, border-color 150ms ease;
+  }
+  .meta .ticket:hover {
+    color: var(--brass);
+    border-color: var(--brass);
+  }
+```
+
+- [ ] **Step 4: TypeScript check**
+
+```bash
+cd website
+npx tsc --noEmit 2>&1 | head -20
+```
+
+Expected: 0 errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add website/src/components/Timeline.svelte
+git commit -m "feat(timeline): render T-###### ticket badge with deep-link in timeline row [T000373]"
+```
+
+---
+
+### Task 5: Backfill + live verification
+
+- [ ] **Step 1: Check for PRs with T-refs in their existing descriptions**
+
+```bash
+PGPOD=$(kubectl get pod -n workspace --context mentolder -l app=shared-db -o name | head -1)
+kubectl exec "$PGPOD" -n workspace --context mentolder -- \
+  psql -U website -d website -At -c \
+  "SELECT pr_number, title FROM tickets.pr_events
+   WHERE description ~ 'T[0-9]{6}' ORDER BY pr_number DESC LIMIT 10;"
+```
+
+If no rows: skip to Step 4. If rows found: continue.
+
+- [ ] **Step 2: Backfill (if rows found in Step 1)**
+
+```bash
+task tracking:backfill && task tracking:ingest:local
+```
+
+Requires `TRACKING_DB_URL` from `task workspace:port-forward ENV=mentolder` in a separate terminal.
+
+- [ ] **Step 3: Verify implements links were created**
+
+```bash
+kubectl exec "$PGPOD" -n workspace --context mentolder -- \
+  psql -U website -d website -At -c \
+  "SELECT tl.pr_number, t.external_id, tl.kind
+   FROM tickets.ticket_links tl
+   JOIN tickets.tickets t ON t.id = tl.from_id
+   WHERE tl.kind = 'implements' ORDER BY tl.pr_number DESC LIMIT 10;"
+```
+
+Expected: rows showing `implements` links.
+
+- [ ] **Step 4: Run offline tests**
+
+```bash
+cd /home/patrick/Bachelorprojekt
+task test:all 2>&1 | tail -10
+```
+
+Expected: all pass.
+
+- [ ] **Step 5: Create PR via commit-commands:commit-push-pr**
+
+Invoke skill `commit-commands:commit-push-pr`.
+
+Title: `feat(timeline): surface T-###### plan ticket as deep-link on Kore timeline [T000373]`
+
+Body:
+```
+## Summary
+- `parsePr()` now extracts T-###### ticket references from PR bodies
+- `writeRowToDb()` writes `tickets.ticket_links` rows with `kind='implements'`
+- `listTimeline()` batch-fetches implements links and exposes `ticket_external_id`
+- `Timeline.svelte` renders a dotted-underline badge linking to `/admin/tickets/T######`
+
+## Test plan
+- [x] `node --test scripts/track-pr.test.mjs` passes (2 new T-ref tests)
+- [x] `task test:all` green
+- [x] `npx tsc --noEmit` 0 errors
+- [ ] After merge: verify a future PR with T-###### in body shows badge on Kore homepage after CronJob runs
+```

--- a/scripts/brainstorm-extract-choice.sh
+++ b/scripts/brainstorm-extract-choice.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Read the last {"choice": "X"} event from a brainstorm session events file.
+# Usage: brainstorm-extract-choice.sh <state_dir>
+# Output: prints the choice label (e.g. "A") or exits 1 if no choice event found.
+set -euo pipefail
+
+STATE_DIR="${1:?Usage: brainstorm-extract-choice.sh <state_dir>}"
+EVENTS_FILE="$STATE_DIR/events"
+
+if [[ ! -f "$EVENTS_FILE" ]]; then
+  echo "no events file at $EVENTS_FILE" >&2
+  exit 1
+fi
+
+CHOICE=$(grep -o '"choice":"[^"]*"' "$EVENTS_FILE" | tail -1 | sed 's/"choice":"//;s/"//')
+if [[ -z "$CHOICE" ]]; then
+  echo "no choice event found in $EVENTS_FILE" >&2
+  exit 1
+fi
+
+echo "$CHOICE"

--- a/scripts/plans_parse.py
+++ b/scripts/plans_parse.py
@@ -93,5 +93,7 @@ def parse_plan(file_path: str) -> dict:
         'pr_number': fm.get('pr_number'),
         'file_path': str(path),
         'sections': sections,
+        'brainstorm_choice': fm.get('brainstorm_choice') or None,
+        'brainstorm_session': fm.get('brainstorm_session') or None,
     }
 

--- a/scripts/plans_parse.test.py
+++ b/scripts/plans_parse.test.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+import tempfile, sys, os
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from plans_parse import parse_plan
+
+def make_plan(extra=""):
+    content = f"""---
+title: Test Plan
+domains: [website]
+status: active
+{extra}
+---
+
+# Test Plan
+
+## Task 1: Do thing
+
+- [ ] Step 1: Do the thing
+"""
+    f = tempfile.NamedTemporaryFile(suffix='.md', mode='w', delete=False)
+    f.write(content)
+    f.close()
+    return f.name
+
+def test_includes_brainstorm_fields():
+    path = make_plan("brainstorm_choice: B\nbrainstorm_session: 123456-789012")
+    result = parse_plan(path)
+    assert result.get('brainstorm_choice') == 'B', \
+        f"Expected 'B', got {result.get('brainstorm_choice')}"
+    assert result.get('brainstorm_session') == '123456-789012', \
+        f"Got {result.get('brainstorm_session')}"
+    print("PASS: brainstorm fields included")
+
+def test_missing_brainstorm_fields_are_none():
+    path = make_plan()
+    result = parse_plan(path)
+    assert result.get('brainstorm_choice') is None, \
+        f"Expected None, got {result.get('brainstorm_choice')}"
+    assert result.get('brainstorm_session') is None, \
+        f"Expected None, got {result.get('brainstorm_session')}"
+    print("PASS: missing brainstorm fields are None")
+
+test_includes_brainstorm_fields()
+test_missing_brainstorm_fields_are_none()

--- a/scripts/track-pr.mjs
+++ b/scripts/track-pr.mjs
@@ -197,20 +197,32 @@ async function ensurePlanSchema(pgClient) {
   `);
   await pgClient.query(`CREATE INDEX IF NOT EXISTS plans_domains_idx ON superpowers.plans USING GIN(domains)`);
   await pgClient.query(`CREATE INDEX IF NOT EXISTS plans_status_idx ON superpowers.plans(status)`);
+  await pgClient.query(`
+    ALTER TABLE superpowers.plans
+      ADD COLUMN IF NOT EXISTS brainstorm_choice  TEXT,
+      ADD COLUMN IF NOT EXISTS brainstorm_session TEXT
+  `);
 }
 
 async function writePlanToDb(row, pgClient) {
   const result = await pgClient.query(
-    `INSERT INTO superpowers.plans (slug, title, domains, status, pr_number, file_path)
-     VALUES ($1, $2, $3, $4, $5, $6)
+    `INSERT INTO superpowers.plans
+       (slug, title, domains, status, pr_number, file_path,
+        brainstorm_choice, brainstorm_session)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
      ON CONFLICT (slug) DO UPDATE SET
-       title = EXCLUDED.title,
-       domains = EXCLUDED.domains,
-       status = EXCLUDED.status,
-       pr_number = EXCLUDED.pr_number,
-       file_path = EXCLUDED.file_path
+       title              = EXCLUDED.title,
+       domains            = EXCLUDED.domains,
+       status             = EXCLUDED.status,
+       pr_number          = EXCLUDED.pr_number,
+       file_path          = EXCLUDED.file_path,
+       brainstorm_choice  = COALESCE(EXCLUDED.brainstorm_choice,
+                                     superpowers.plans.brainstorm_choice),
+       brainstorm_session = COALESCE(EXCLUDED.brainstorm_session,
+                                     superpowers.plans.brainstorm_session)
      RETURNING id`,
-    [row.slug, row.title, row.domains, row.status, row.pr_number ?? null, row.file_path]
+    [row.slug, row.title, row.domains, row.status, row.pr_number ?? null, row.file_path,
+     row.brainstorm_choice ?? null, row.brainstorm_session ?? null]
   );
   const planId = result.rows[0].id;
 

--- a/tests/unit/brainstorm-extract-choice.bats
+++ b/tests/unit/brainstorm-extract-choice.bats
@@ -1,0 +1,31 @@
+#!/usr/bin/env bats
+# Tests for scripts/brainstorm-extract-choice.sh
+
+SCRIPT="$BATS_TEST_DIRNAME/../../scripts/brainstorm-extract-choice.sh"
+
+setup() {
+  TESTDIR="$(mktemp -d)"
+}
+
+teardown() {
+  rm -rf "$TESTDIR"
+}
+
+@test "extracts last choice from events file" {
+  printf '{"type":"click","choice":"A","timestamp":1}\n' > "$TESTDIR/events"
+  printf '{"type":"click","choice":"B","timestamp":2}\n' >> "$TESTDIR/events"
+  run bash "$SCRIPT" "$TESTDIR"
+  [ "$status" -eq 0 ]
+  [ "$output" = "B" ]
+}
+
+@test "exits 1 when no events file" {
+  run bash "$SCRIPT" "$TESTDIR"
+  [ "$status" -eq 1 ]
+}
+
+@test "exits 1 when no choice event in file" {
+  printf '{"type":"scroll","timestamp":1}\n' > "$TESTDIR/events"
+  run bash "$SCRIPT" "$TESTDIR"
+  [ "$status" -eq 1 ]
+}


### PR DESCRIPTION
## Summary
- New `scripts/brainstorm-extract-choice.sh` reads last `choice` event from brainstorm session events NDJSON
- `dev-flow-plan` skill injects `brainstorm_choice` + `brainstorm_session` into plan frontmatter after brainstorming
- `plans_parse.py` passes these fields through to the pending JSON
- `ensurePlanSchema()` adds two nullable columns; `writePlanToDb()` persists them (COALESCE-safe on re-ingest)

## Test plan
- [x] `bats tests/unit/brainstorm-extract-choice.bats` passes (3 tests)
- [x] `python3 scripts/plans_parse.test.py` passes (2 tests)
- [x] `node --test scripts/track-pr.test.mjs` all pass (7 tests)
- [x] `node --check scripts/track-pr.mjs` syntax OK
- [ ] After merge: next dev-flow-plan session with brainstorming populates the fields on the next plan commit

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>