### PR TITLE
chore(ci): seed public.brands before arena integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,9 @@ jobs:
         working-directory: arena-server
         run: pnpm install --frozen-lockfile
 
+      - name: Seed public.brands for arena FK
+        run: psql postgresql://arena_test:arena_test@localhost:5432/arena_test -c "CREATE TABLE IF NOT EXISTS public.brands (id text PRIMARY KEY);"
+
       - name: Test (unit + integration via TEST_DB_URL)
         working-directory: arena-server
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,10 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Seed public.brands for arena FK
-        run: psql postgresql://arena_test:arena_test@localhost:5432/arena_test -c "CREATE TABLE IF NOT EXISTS public.brands (id text PRIMARY KEY);"
+        run: |
+          psql postgresql://arena_test:arena_test@localhost:5432/arena_test \
+            -c "CREATE TABLE IF NOT EXISTS public.brands (id text PRIMARY KEY);" \
+            -c "INSERT INTO public.brands (id) VALUES ('mentolder'),('korczewski') ON CONFLICT DO NOTHING;"
 
       - name: Test (unit + integration via TEST_DB_URL)
         working-directory: arena-server


### PR DESCRIPTION
## Summary

- Behebt den Arena-CI-Fehler `relation "public.brands" does not exist`
- Commit `a5e46671` fügte einen FK auf `public.brands` in `0001_init.sql` ein, aber das CI-Postgres startet ohne diese Tabelle
- Neuer Step `Seed public.brands for arena FK` erstellt die Tabelle vor den Tests

## Test plan

- [ ] CI auf diesem PR grün (arena-server + alle anderen Jobs)
- [ ] Nach Merge: PR #763 neu auslösen → arena-server Job soll grün sein

🤖 Generated with [Claude Code](https://claude.ai/claude-code)