### PR TITLE
feat(brett): UX overhaul — sprint, teleport, character-editor panel

### DIFF
--- a/brett/public/index.html
+++ b/brett/public/index.html
@@ -26,6 +26,71 @@
       border-radius:20px; font-size:13px; pointer-events:none; z-index:10;
     }
     canvas { display:block; }
+
+    /* ── Character-Editor Panel ─────────────────────────────────── */
+    #fig-panel-wrap { position: relative; display: inline-flex; align-items: center; }
+
+    #fig-panel-btn {
+      background: transparent; color: inherit;
+      border: 1px solid rgba(231,234,208,0.18);
+      border-radius: 4px; padding: 4px 10px;
+      font: inherit; cursor: pointer; white-space: nowrap;
+    }
+    #fig-panel-btn:hover, #fig-panel-btn.open { background: rgba(231,234,208,0.12); }
+
+    #fig-panel {
+      position: absolute; top: calc(100% + 8px); right: 0;
+      z-index: 200;
+      background: #161a22; border: 1px solid rgba(200,169,110,0.35);
+      border-radius: 10px; padding: 12px 14px;
+      width: 240px; display: flex; flex-direction: column; gap: 10px;
+      box-shadow: 0 8px 32px rgba(0,0,0,0.6);
+    }
+
+    #fig-panel-header {
+      display: flex; justify-content: space-between; align-items: center;
+    }
+    #fig-panel-title {
+      font-size: 10px; font-weight: 600; color: #c8a96e;
+      text-transform: uppercase; letter-spacing: 0.1em;
+    }
+    #fig-panel-close {
+      background: none; border: none; color: rgba(231,234,208,0.4);
+      cursor: pointer; font-size: 14px; padding: 0 2px; line-height: 1;
+    }
+    #fig-panel-close:hover { color: #e7ead0; }
+
+    .fig-panel-label {
+      font-size: 10px; color: rgba(231,234,208,0.5);
+      text-transform: uppercase; letter-spacing: 0.08em;
+    }
+
+    #fig-panel-colors { display: flex; gap: 6px; flex-wrap: wrap; align-items: center; }
+
+    .fig-color-swatch {
+      width: 22px; height: 22px; border-radius: 50%; cursor: pointer;
+      border: 2px solid transparent; transition: border-color 0.15s, transform 0.1s;
+    }
+    .fig-color-swatch:hover { transform: scale(1.15); }
+    .fig-color-swatch.active { border-color: #c8a96e; }
+
+    #fig-label-input {
+      background: rgba(231,234,208,0.06); border: 1px solid rgba(231,234,208,0.18);
+      border-radius: 5px; color: #e7ead0; font: inherit; font-size: 12px;
+      padding: 5px 8px; width: 100%;
+    }
+    #fig-label-input:focus { outline: none; border-color: rgba(200,169,110,0.5); }
+    #fig-label-input::placeholder { color: rgba(231,234,208,0.3); }
+
+    #fig-panel-add {
+      background: #c8a96e; color: #0a0a14;
+      border: none; border-radius: 6px;
+      padding: 7px 10px; font-size: 12px; font-weight: 600;
+      cursor: pointer; width: 100%;
+    }
+    #fig-panel-add:hover { filter: brightness(1.1); }
+
+    body.placing-figure { cursor: crosshair !important; }
   </style>
 </head>
 <body>
@@ -46,7 +111,28 @@
     </div>
     <div class="sep"></div>
     <div class="group" style="margin-left:auto;">
-      <button id="add-figure" class="icon-btn">+ Figur</button>
+      <div id="fig-panel-wrap">
+        <button id="fig-panel-btn" aria-expanded="false" aria-controls="fig-panel">＋ Figur ▾</button>
+        <div id="fig-panel" hidden role="dialog" aria-label="Figur-Editor">
+          <div id="fig-panel-header">
+            <span id="fig-panel-title">NEUE FIGUR</span>
+            <button id="fig-panel-close" aria-label="Panel schließen">✕</button>
+          </div>
+          <span class="fig-panel-label">Farbe</span>
+          <div id="fig-panel-colors">
+            <div class="fig-color-swatch active" data-color="#b8c0a8" style="background:#b8c0a8;" title="Standard"></div>
+            <div class="fig-color-swatch" data-color="#e06b6b" style="background:#e06b6b;" title="Rot"></div>
+            <div class="fig-color-swatch" data-color="#6ba8e0" style="background:#6ba8e0;" title="Blau"></div>
+            <div class="fig-color-swatch" data-color="#6be0a0" style="background:#6be0a0;" title="Grün"></div>
+            <div class="fig-color-swatch" data-color="#e0c06b" style="background:#e0c06b;" title="Gelb"></div>
+            <div class="fig-color-swatch" data-color="#c06be0" style="background:#c06be0;" title="Lila"></div>
+            <div class="fig-color-swatch" data-color="#e0906b" style="background:#e0906b;" title="Orange"></div>
+          </div>
+          <span class="fig-panel-label">Name</span>
+          <input id="fig-label-input" type="text" placeholder="Figur benennen …" maxlength="40" />
+          <button id="fig-panel-add">＋ Auf Brett setzen</button>
+        </div>
+      </div>
       <span id="online-indicator">● <span id="online-count">1</span> online</span>
     </div>
   </div>

--- a/brett/public/index.html
+++ b/brett/public/index.html
@@ -50,7 +50,7 @@
       <span id="online-indicator">● <span id="online-count">1</span> online</span>
     </div>
   </div>
-  <div id="status-pill">Klick = Figur wählen · Doppelklick Boden = neue Figur</div>
+  <div id="status-pill">Klick = Figur wählen · Doppelklick Boden = Figur teleportieren / neue Figur</div>
   <script src="three.min.js"></script>
   <script>
     // ===== Brett Mannequin Focus =====
@@ -588,15 +588,28 @@
 
   // ----- Walking -----
   const WALK_SPEED = 2.0;          // units/s
+  const SPRINT_MULT = 3.0;         // Shift-sprint multiplier
   const TURN_RATE  = 8.0;          // rad/s
   const ARRIVE_EPS = 0.3;          // distance threshold
-  const wasdKeys = { w:false, a:false, s:false, d:false };
+  const wasdKeys = { w:false, a:false, s:false, d:false, shift:false };
 
   window.addEventListener('keydown', (e) => {
-    if (e.key.length === 1 && wasdKeys.hasOwnProperty(e.key.toLowerCase())) wasdKeys[e.key.toLowerCase()] = true;
+    if (e.key === 'Shift') { wasdKeys.shift = true; return; }
+    const k = e.key.toLowerCase();
+    if (wasdKeys.hasOwnProperty(k)) wasdKeys[k] = true;
+    if (e.key === 'ArrowUp')    { wasdKeys.w = true; e.preventDefault(); }
+    if (e.key === 'ArrowDown')  { wasdKeys.s = true; e.preventDefault(); }
+    if (e.key === 'ArrowLeft')  { wasdKeys.a = true; e.preventDefault(); }
+    if (e.key === 'ArrowRight') { wasdKeys.d = true; e.preventDefault(); }
   });
   window.addEventListener('keyup', (e) => {
-    if (e.key.length === 1 && wasdKeys.hasOwnProperty(e.key.toLowerCase())) wasdKeys[e.key.toLowerCase()] = false;
+    if (e.key === 'Shift') { wasdKeys.shift = false; return; }
+    const k = e.key.toLowerCase();
+    if (wasdKeys.hasOwnProperty(k)) wasdKeys[k] = false;
+    if (e.key === 'ArrowUp')    wasdKeys.w = false;
+    if (e.key === 'ArrowDown')  wasdKeys.s = false;
+    if (e.key === 'ArrowLeft')  wasdKeys.a = false;
+    if (e.key === 'ArrowRight') wasdKeys.d = false;
   });
 
   function tickWalkAnimation(fig, t) {
@@ -626,8 +639,9 @@
           dx /= mag; dz /= mag;
           fig.walkTarget = null;
           fig.walking = true;
-          fig.root.position.x += dx * WALK_SPEED * dt;
-          fig.root.position.z += dz * WALK_SPEED * dt;
+          const speed = WALK_SPEED * (wasdKeys.shift ? SPRINT_MULT : 1);
+          fig.root.position.x += dx * speed * dt;
+          fig.root.position.z += dz * speed * dt;
           const want = Math.atan2(dx, dz);
           const diff = ((want - fig.facingY + Math.PI*3) % (Math.PI*2)) - Math.PI;
           fig.facingY += Math.max(-TURN_RATE*dt, Math.min(TURN_RATE*dt, diff));
@@ -668,7 +682,7 @@
     if (dragging) { pillEl.textContent = '● Drag … · Loslassen = resume'; return; }
     if (!fig) { pillEl.textContent = 'Klick = Figur wählen · Doppelklick Boden = neue Figur'; return; }
     if (fig.walking) { pillEl.textContent = '→ Ziel … · Klick = neues Ziel · ESC = stop'; return; }
-    pillEl.textContent = '🚶 WALK · WASD / Klick Boden = Ziel · Tab = nächste';
+    pillEl.textContent = '🚶 WASD/↑↓←→ = laufen · Shift = Sprint · Klick Boden = Ziel · Tab = nächste';
   }
 
   // ----- WebSocket sync -----

--- a/brett/public/index.html
+++ b/brett/public/index.html
@@ -315,6 +315,7 @@
       walking: false,
       boneOverrides: {},
       label: 'Figur',
+      color: '#b8c0a8',
       facingY: 0,
     };
   }
@@ -325,6 +326,36 @@
     STATE.figures.push(fig);
     selectFigure(id);
     return fig;
+  }
+
+  // ── Panel state ──────────────────────────────────────────────────────────────
+  let panelColor = '#b8c0a8'; // default body color for new figures
+
+  function recolorFigure(fig, hexColor) {
+    const threeColor = new THREE.Color(hexColor);
+    fig.root.traverse(o => {
+      if (o.isMesh && !o.userData.isContact && o !== fig.ring) {
+        if (o.material) o.material.color.set(threeColor);
+      }
+    });
+    fig.color = hexColor;
+  }
+
+  function syncPanelToSelection(id) {
+    const title  = document.getElementById('fig-panel-title');
+    const addBtn = document.getElementById('fig-panel-add');
+    const input  = document.getElementById('fig-label-input');
+    if (!title) return;
+    const fig = STATE.figures.find(f => f.id === id);
+    if (fig) {
+      title.textContent = 'FIGUR BEARBEITEN';
+      if (addBtn) addBtn.hidden = true;
+      if (input) input.value = fig.label || '';
+    } else {
+      title.textContent = 'NEUE FIGUR';
+      if (addBtn) addBtn.hidden = false;
+      if (input) input.value = '';
+    }
   }
 
   function selectFigure(id) {
@@ -340,10 +371,61 @@
         }
       });
     }
+    syncPanelToSelection(id);
   }
 
-  document.getElementById('add-figure').addEventListener('click', () => {
-    addFigure({ x: (Math.random()-0.5)*2, z: (Math.random()-0.5)*2 });
+  // ── Panel toggle ─────────────────────────────────────────────────────────────
+  const figPanelBtn   = document.getElementById('fig-panel-btn');
+  const figPanel      = document.getElementById('fig-panel');
+  const figPanelClose = document.getElementById('fig-panel-close');
+
+  function openFigPanel()  {
+    figPanel.hidden = false;
+    figPanelBtn.classList.add('open');
+    figPanelBtn.setAttribute('aria-expanded', 'true');
+    syncPanelToSelection(STATE.selectedId);
+  }
+  function closeFigPanel() {
+    figPanel.hidden = true;
+    figPanelBtn.classList.remove('open');
+    figPanelBtn.setAttribute('aria-expanded', 'false');
+  }
+
+  figPanelBtn.addEventListener('click', () => {
+    figPanel.hidden ? openFigPanel() : closeFigPanel();
+  });
+  figPanelClose.addEventListener('click', closeFigPanel);
+  document.addEventListener('click', e => {
+    if (!figPanel.hidden && !figPanel.contains(e.target) && e.target !== figPanelBtn) {
+      closeFigPanel();
+    }
+  });
+
+  // ── Color swatches ────────────────────────────────────────────────────────────
+  document.getElementById('fig-panel-colors').addEventListener('click', e => {
+    const swatch = e.target.closest('.fig-color-swatch');
+    if (!swatch) return;
+    document.querySelectorAll('.fig-color-swatch').forEach(s => s.classList.remove('active'));
+    swatch.classList.add('active');
+    panelColor = swatch.dataset.color;
+    const fig = STATE.figures.find(f => f.id === STATE.selectedId);
+    if (fig) recolorFigure(fig, panelColor);
+  });
+
+  // ── Label input ────────────────────────────────────────────────────────────────
+  document.getElementById('fig-label-input').addEventListener('input', e => {
+    const fig = STATE.figures.find(f => f.id === STATE.selectedId);
+    if (fig) fig.label = e.target.value;
+  });
+
+  // ── Add button ─────────────────────────────────────────────────────────────────
+  document.getElementById('fig-panel-add').addEventListener('click', () => {
+    const label = document.getElementById('fig-label-input').value.trim();
+    const x = (Math.random() - 0.5) * 4, z = (Math.random() - 0.5) * 4;
+    const fig = addFigure({ x, z });
+    recolorFigure(fig, panelColor);
+    if (label) fig.label = label;
+    closeFigPanel();
   });
   // ----- Pose presets (target rotations in radians; only x and z used) -----
   // Each value is { x: pitch, z: roll } applied via group.rotation.x / .z.

--- a/brett/public/index.html
+++ b/brett/public/index.html
@@ -559,9 +559,34 @@
     }
   });
 
+  function easeFigure(fig, tx, tz, durationMs) {
+    const sx = fig.root.position.x, sz = fig.root.position.z;
+    const start = performance.now();
+    function step() {
+      const t = Math.min(1, (performance.now() - start) / durationMs);
+      const e = 1 - Math.pow(1 - t, 3); // ease-out-cubic
+      fig.root.position.x = sx + (tx - sx) * e;
+      fig.root.position.z = sz + (tz - sz) * e;
+      if (t < 1) { requestAnimationFrame(step); }
+      else {
+        fig.root.position.x = tx; fig.root.position.z = tz;
+        if (wsReady) ws.send(JSON.stringify({ type: 'move', id: fig.id, x: tx, z: tz, facingY: fig.facingY }));
+      }
+    }
+    fig.walkTarget = null; fig.walking = false;
+    requestAnimationFrame(step);
+  }
+  window.easeFigure = easeFigure;
+
   renderer.domElement.addEventListener('dblclick', (e) => {
     const floorPt = pickFloor(e);
-    if (floorPt) addFigure({ x: floorPt.x, z: floorPt.z });
+    if (!floorPt) return;
+    const fig = STATE.figures.find(f => f.id === STATE.selectedId);
+    if (fig) {
+      easeFigure(fig, floorPt.x, floorPt.z, 300);
+    } else {
+      addFigure({ x: floorPt.x, z: floorPt.z });
+    }
   });
 
   window.addEventListener('keydown', (e) => {
@@ -680,8 +705,8 @@
     const fig = STATE.figures.find(f => f.id === STATE.selectedId);
     if (STATE.stiffness < 0.3) { pillEl.textContent = 'zu schlaff zum Laufen — Slider nach rechts'; return; }
     if (dragging) { pillEl.textContent = '● Drag … · Loslassen = resume'; return; }
-    if (!fig) { pillEl.textContent = 'Klick = Figur wählen · Doppelklick Boden = neue Figur'; return; }
-    if (fig.walking) { pillEl.textContent = '→ Ziel … · Klick = neues Ziel · ESC = stop'; return; }
+    if (!fig) { pillEl.textContent = 'Klick = Figur wählen · Doppelklick Boden = neue Figur hinzufügen'; return; }
+    if (fig.walking) { pillEl.textContent = '→ Ziel … · Klick = neues Ziel · Doppelklick = Teleport · ESC = stop'; return; }
     pillEl.textContent = '🚶 WASD/↑↓←→ = laufen · Shift = Sprint · Klick Boden = Ziel · Tab = nächste';
   }
 

--- a/docs/superpowers/plans/2026-05-14-brett-ux-overhaul.md
+++ b/docs/superpowers/plans/2026-05-14-brett-ux-overhaul.md
@@ -1,0 +1,1000 @@
+---
+ticket_id: T000377
+title: Brett UX Overhaul Implementation Plan
+domains: []
+status: active
+pr_number: null
+---
+
+# Brett UX Overhaul Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix hollow SVG character heads, replace scattered toolbar controls with a foldable character-editor panel, remove ctrlBall, add WASD+sprint and double-click-teleport movement.
+
+**Architecture:** All changes live in two locations — `brett/public/art-library/*.svg` (head fill fix) and `brett/public/index.html` (UI + JS). The monolithic `index.html` is modified in place; no new files are created. JS changes are additive (new functions + extended handlers) except for ctrlBall deletion.
+
+**Tech Stack:** Vanilla JS, Three.js (already loaded), CSS in `<style>` block, SVG assets, Playwright for E2E tests.
+
+---
+
+## Files
+
+| File | Change |
+|------|--------|
+| `brett/public/art-library/mann.svg` | head circle: `fill="none"` → `fill="#C8F76A"` |
+| `brett/public/art-library/frau.svg` | same |
+| `brett/public/art-library/person.svg` | same |
+| `brett/public/art-library/nonbinary.svg` | same (head circle only — largest r) |
+| `brett/public/art-library/senior.svg` | same |
+| `brett/public/art-library/baby.svg` | same |
+| `brett/public/art-library/fuehrungskraft.svg` | same |
+| `brett/public/art-library/mitarbeiter.svg` | same |
+| `brett/public/art-library/kunde.svg` | same |
+| `brett/public/art-library/berater.svg` | same |
+| `brett/public/art-library/kind.svg` | head circle: `fill="none"` → `fill="#5BD4D0"` |
+| `brett/public/index.html` | all JS + HTML + CSS changes |
+| `tests/e2e/specs/brett-controls.spec.ts` | new test suites for WASD + panel + teleport |
+
+---
+
+## Task 1: Fix SVG head circles (11 files)
+
+**Files:** `brett/public/art-library/*.svg` (11 files listed above)
+
+- [ ] **Step 1: Understand what to change**
+
+  Each affected SVG has exactly one head circle near the top of the viewBox (the character's head). It currently reads `fill="none"` which makes it transparent. We change it to match its `stroke` attribute so the head is opaque.
+
+  Reference table:
+  | SVG | head element selector | fill to set |
+  |-----|----------------------|-------------|
+  | mann.svg | `<circle cx="120" cy="68" r="42" fill="none" stroke="#C8F76A" .../>` | `#C8F76A` |
+  | frau.svg | `<circle cx="120" cy="68" r="42" fill="none" stroke="#C8F76A" .../>` | `#C8F76A` |
+  | person.svg | `<circle cx="120" cy="68" r="42" fill="none" stroke="#C8F76A" .../>` | `#C8F76A` |
+  | nonbinary.svg | first circle `r="42"` only — ignore the second `r="18"` circle | `#C8F76A` |
+  | senior.svg | `<circle cx="126" cy="70" r="40" fill="none" stroke="#C8F76A" .../>` | `#C8F76A` |
+  | baby.svg | `<circle cx="120" cy="136" r="58" fill="none" stroke="#C8F76A" .../>` | `#C8F76A` |
+  | fuehrungskraft.svg | `<circle cx="120" cy="84" r="40" fill="none" stroke="#C8F76A" .../>` | `#C8F76A` |
+  | mitarbeiter.svg | `<circle cx="120" cy="68" r="42" fill="none" stroke="#C8F76A" .../>` | `#C8F76A` |
+  | kunde.svg | `<circle cx="120" cy="68" r="42" fill="none" stroke="#C8F76A" .../>` | `#C8F76A` |
+  | berater.svg | `<circle cx="108" cy="68" r="40" fill="none" stroke="#C8F76A" .../>` | `#C8F76A` |
+  | kind.svg | `<circle cx="120" cy="148" r="30" fill="none" stroke="#5BD4D0" .../>` | `#5BD4D0` |
+
+- [ ] **Step 2: Apply the change with sed**
+
+  ```bash
+  cd brett/public/art-library
+
+  # All C8F76A stroke files — change fill="none" to fill="#C8F76A" on the FIRST circle only
+  for f in mann.svg frau.svg person.svg senior.svg baby.svg fuehrungskraft.svg mitarbeiter.svg kunde.svg berater.svg; do
+    # Use perl for reliable first-match-only substitution
+    perl -i '0,/fill="none"/ s/fill="none"/fill="#C8F76A"/' "$f"
+  done
+
+  # nonbinary.svg: same — change only the FIRST fill="none" (the head, r=42)
+  perl -i '0,/fill="none"/ s/fill="none"/fill="#C8F76A"/' nonbinary.svg
+
+  # kind.svg: stroke is #5BD4D0
+  perl -i '0,/fill="none"/ s/fill="none"/fill="#5BD4D0"/' kind.svg
+  ```
+
+- [ ] **Step 3: Verify the changes**
+
+  ```bash
+  # Check each file has fill= the right color on its first circle
+  for f in mann.svg frau.svg person.svg nonbinary.svg senior.svg baby.svg \
+            fuehrungskraft.svg mitarbeiter.svg kunde.svg berater.svg; do
+    echo -n "$f: "
+    grep -m1 '<circle' "$f" | grep -o 'fill="[^"]*"'
+  done
+  # Expected: fill="#C8F76A" for all
+
+  echo -n "kind.svg: "
+  grep -m1 '<circle' kind.svg | grep -o 'fill="[^"]*"'
+  # Expected: fill="#5BD4D0"
+
+  # nonbinary.svg: second circle must STILL have fill="none"
+  echo "nonbinary second circle:"
+  grep '<circle' nonbinary.svg | tail -1 | grep -o 'fill="[^"]*"'
+  # Expected: fill="none"
+  ```
+
+- [ ] **Step 4: Commit**
+
+  ```bash
+  cd /home/patrick/Bachelorprojekt
+  git add brett/public/art-library/
+  git commit -m "fix(brett): fill character head circles to fix hollow-head bug"
+  ```
+
+---
+
+## Task 2: Remove ctrlBall
+
+**Files:** `brett/public/index.html`
+
+The ctrlBall is a golden sphere that appears when you click empty board. It served no complete feature and is the "click to move" interaction the user wants removed.
+
+- [ ] **Step 1: Delete ctrlBall variable declarations and functions (lines ~1704–1743)**
+
+  Find and delete the block:
+  ```js
+  let ctrlBall = null, ctrlBallActive = false, ctrlBallDrag = false;
+  let ctrlBallStart = { x: 0, y: 0 };
+  let ctrlBallShowTime = 0;
+
+  function showCtrlBall(wx, wz) { ... }   // entire function
+
+  function hideCtrlBall() { ... }          // entire function
+
+  function pickBall(ndc) { ... }           // entire function
+  ```
+
+  These are lines 1704–1743 in the current file. Delete all of them.
+
+- [ ] **Step 2: Remove ctrlBall references in the V tool mousedown handler (lines ~2443–2460)**
+
+  Current code in the `case 'V':` block:
+  ```js
+  case 'V':
+    if (fig) {
+      const now = Date.now();
+      if (lastClick.fig === fig && now - lastClick.time < 380) { openLabelModal(fig); lastClick.fig = null; return; }
+      lastClick = { fig, time: now };
+      selectFigure(fig);
+      drag = { on: true, fig };
+      if (ctrlBallActive) hideCtrlBall();     // ← DELETE this line
+    } else {
+      selectFigure(null);
+      lastClick.fig = null;
+      const bpos = pickBoard(ndc);
+      if (bpos) {
+        if (ctrlBallActive) hideCtrlBall();   // ← DELETE these two lines
+        else showCtrlBall(bpos.x, bpos.z);   // ← DELETE
+      }
+    }
+    break;
+  ```
+
+  Replace the entire `case 'V':` block with:
+  ```js
+  case 'V':
+    if (fig) {
+      const now = Date.now();
+      if (lastClick.fig === fig && now - lastClick.time < 380) { openLabelModal(fig); lastClick.fig = null; return; }
+      lastClick = { fig, time: now };
+      selectFigure(fig);
+      drag = { on: true, fig };
+    } else {
+      selectFigure(null);
+      lastClick.fig = null;
+    }
+    break;
+  ```
+
+- [ ] **Step 3: Remove ctrlBall fade from animate() (lines ~3377–3382)**
+
+  Find and delete this block inside `animate()`:
+  ```js
+  if (ctrlBall && ctrlBallActive) {
+    const tFade = Math.min(1, (Date.now() - ctrlBallShowTime) / 150);
+    ctrlBall.children.forEach((c, i) => {
+      if (c.material) c.material.opacity = tFade * (i === 0 ? 0.72 : 0.9);
+    });
+  }
+  ```
+
+- [ ] **Step 4: Verify no remaining ctrlBall references**
+
+  ```bash
+  grep -n "ctrlBall" brett/public/index.html
+  # Expected: no output
+  ```
+
+- [ ] **Step 5: Commit**
+
+  ```bash
+  git add brett/public/index.html
+  git commit -m "fix(brett): remove ctrlBall click-to-move mechanism"
+  ```
+
+---
+
+## Task 3: WASD + Shift-sprint movement
+
+**Files:** `brett/public/index.html`, `tests/e2e/specs/brett-controls.spec.ts`
+
+Figures move in real-time while WASD/arrow keys are held, with Shift for sprint (3× speed). Uses per-frame RAF tick — no keydown repeat delay.
+
+- [ ] **Step 1: Add wasdHeld state and key listeners**
+
+  Find the line `const flyKeys = { ... };` (around line 2933). Add this block BEFORE it:
+
+  ```js
+  // ── WASD figure movement ──────────────────────────────────────────────────────
+  const wasdHeld = { w: false, a: false, s: false, d: false,
+                     ArrowUp: false, ArrowLeft: false, ArrowDown: false, ArrowRight: false,
+                     Shift: false };
+  const WASD_KEYS = new Set(['w','a','s','d','W','A','S','D',
+                              'ArrowUp','ArrowLeft','ArrowDown','ArrowRight']);
+
+  document.addEventListener('keydown', e => {
+    if (isAnyModalOpen() || isTypingTarget(document.activeElement)) return;
+    if (!WASD_KEYS.has(e.key) && e.key !== 'Shift') return;
+    if (e.key === 'Shift') { wasdHeld.Shift = true; return; }
+    const k = e.key.toLowerCase().replace('arrow', 'Arrow');
+    const norm = e.key.startsWith('Arrow') ? e.key : e.key.toLowerCase();
+    if (norm === 'w' || e.key === 'ArrowUp')    { wasdHeld.w = true; e.preventDefault(); return; }
+    if (norm === 's' || e.key === 'ArrowDown')  { wasdHeld.s = true; e.preventDefault(); return; }
+    if (norm === 'a' || e.key === 'ArrowLeft')  { wasdHeld.a = true; e.preventDefault(); return; }
+    if (norm === 'd' || e.key === 'ArrowRight') { wasdHeld.d = true; e.preventDefault(); return; }
+  }, true); // capture phase — runs before other keydown handlers, allows preventDefault
+
+  document.addEventListener('keyup', e => {
+    if (e.key === 'Shift') { wasdHeld.Shift = false; return; }
+    const norm = e.key.startsWith('Arrow') ? e.key : e.key.toLowerCase();
+    if (norm === 'w' || e.key === 'ArrowUp')    wasdHeld.w = false;
+    if (norm === 's' || e.key === 'ArrowDown')  wasdHeld.s = false;
+    if (norm === 'a' || e.key === 'ArrowLeft')  wasdHeld.a = false;
+    if (norm === 'd' || e.key === 'ArrowRight') wasdHeld.d = false;
+    // Send final position on key release
+    if (WASD_KEYS.has(e.key) && selectedFigure && !applyingRemote) {
+      send({ type: 'move', id: selectedFigure.id,
+             x: selectedFigure.mesh.position.x, z: selectedFigure.mesh.position.z });
+    }
+  });
+
+  function tickWASD(dt) {
+    if (!selectedFigure || isAnyModalOpen()) return;
+    let dx = 0, dz = 0;
+    if (wasdHeld.w) dz -= 1;
+    if (wasdHeld.s) dz += 1;
+    if (wasdHeld.a) dx -= 1;
+    if (wasdHeld.d) dx += 1;
+    if (dx === 0 && dz === 0) return;
+    const len = Math.sqrt(dx * dx + dz * dz);
+    const speed = (wasdHeld.Shift ? 12 : 4) * dt;
+    dx = dx / len * speed;
+    dz = dz / len * speed;
+    const HW = BW / 2 - 1, HD = BD / 2 - 1;
+    selectedFigure.mesh.position.x = Math.max(-HW, Math.min(HW, selectedFigure.mesh.position.x + dx));
+    selectedFigure.mesh.position.z = Math.max(-HD, Math.min(HD, selectedFigure.mesh.position.z + dz));
+    if (!applyingRemote) sendMoveThrottled(selectedFigure);
+  }
+  window.wasdHeld = wasdHeld; // expose for tests
+  ```
+
+  > **Note on `{ capture: true }`:** The WASD keydown listener uses capture phase so it intercepts the event before the main keydown handler (registered without capture). `e.preventDefault()` on W/A/S/D when a figure is selected prevents the 'A' key from triggering auto-orbit toggle.
+
+- [ ] **Step 2: Call tickWASD in the animate loop**
+
+  Inside `function animate()`, find the line:
+  ```js
+  const dt = tickAutoOrbit();
+  ```
+
+  Add `tickWASD(dt);` immediately after:
+  ```js
+  const dt = tickAutoOrbit();
+  tickWASD(dt);
+  tickFreeFly(dt);
+  tickOrbitKeys(dt);
+  ```
+
+- [ ] **Step 3: Update the V-tool hint text**
+
+  Find:
+  ```js
+  V: 'Tap = auswählen · Drag = Figur ziehen · Doppel-Tap = Beschriftung',
+  ```
+
+  Replace with:
+  ```js
+  V: 'Tap = auswählen · Drag = ziehen · WASD/↑↓←→ = bewegen · Shift = Sprint · Doppelklick = Teleport',
+  ```
+
+- [ ] **Step 4: Write Playwright test**
+
+  Add this test suite to `tests/e2e/specs/brett-controls.spec.ts`:
+
+  ```typescript
+  test.describe('Brett Controls — WASD movement', () => {
+    test('W key moves selected figure in -Z direction', async ({ page }) => {
+      await page.goto(`${BRETT_URL}?room=e2e-wasd-${Date.now()}`);
+      await page.waitForFunction(() => typeof (window as W).addFigure === 'function', { timeout: 5000 });
+
+      // Add a pawn figure at centre, select it
+      const figId = await page.evaluate(() => {
+        const fig = (window as W).addFigure('pawn', '#e06b6b', 0, 0, '', 1.0, 0);
+        (window as W).selectFigure(fig);
+        return fig.id;
+      });
+
+      const zBefore = await page.evaluate((id) =>
+        (window as W).figures.find((f: W) => f.id === id).mesh.position.z, figId);
+
+      // Hold W for 300ms
+      await page.keyboard.down('w');
+      await page.waitForTimeout(300);
+      await page.keyboard.up('w');
+
+      const zAfter = await page.evaluate((id) =>
+        (window as W).figures.find((f: W) => f.id === id).mesh.position.z, figId);
+
+      expect(zAfter).toBeLessThan(zBefore); // W = -Z
+    });
+
+    test('Shift+W moves figure faster than W alone', async ({ page }) => {
+      await page.goto(`${BRETT_URL}?room=e2e-sprint-${Date.now()}`);
+      await page.waitForFunction(() => typeof (window as W).addFigure === 'function', { timeout: 5000 });
+
+      // Normal speed: hold W 200ms, measure dZ
+      const dNormal = await page.evaluate(async () => {
+        const fig = (window as W).addFigure('pawn', '#e06b6b', 0, 5, '', 1.0, 0);
+        (window as W).selectFigure(fig);
+        return fig.mesh.position.z;
+      });
+
+      await page.keyboard.down('w');
+      await page.waitForTimeout(200);
+      await page.keyboard.up('w');
+      const zNormal = await page.evaluate((id) =>
+        (window as W).figures.find((f: W) => f.id === id).mesh.position.z, await page.evaluate(() => (window as W).figures.at(-1).id));
+
+      // Sprint speed
+      await page.evaluate(() => {
+        const fig = (window as W).addFigure('pawn', '#6ba8e0', 0, 5, '', 1.0, 0);
+        (window as W).selectFigure(fig);
+      });
+      await page.keyboard.down('Shift');
+      await page.keyboard.down('w');
+      await page.waitForTimeout(200);
+      await page.keyboard.up('w');
+      await page.keyboard.up('Shift');
+      const zSprint = await page.evaluate(() => (window as W).figures.at(-1).mesh.position.z);
+
+      expect(Math.abs(zSprint - 5)).toBeGreaterThan(Math.abs(zNormal - 5));
+    });
+  });
+  ```
+
+- [ ] **Step 5: Run tests (skip if no local cluster)**
+
+  ```bash
+  # If brett.localhost is running:
+  cd tests && npx playwright test brett-controls --grep "WASD" 2>&1 | tail -20
+  # Otherwise, skip — CI will catch regressions
+  ```
+
+- [ ] **Step 6: Commit**
+
+  ```bash
+  git add brett/public/index.html tests/e2e/specs/brett-controls.spec.ts
+  git commit -m "feat(brett): add WASD/arrow-key movement with Shift-sprint"
+  ```
+
+---
+
+## Task 4: Double-click teleport
+
+**Files:** `brett/public/index.html`, `tests/e2e/specs/brett-controls.spec.ts`
+
+Double-clicking on an empty board position teleports the previously-selected figure there with a 300 ms ease-out-cubic animation.
+
+- [ ] **Step 1: Add easeFigure function and lastBoardClick state**
+
+  Find the line `let currentColor = '#e06b6b';` (around line 1746). Add before it:
+
+  ```js
+  let lastBoardClick = { time: 0, fig: null };
+
+  function easeFigure(fig, tx, tz, durationMs) {
+    const sx = fig.mesh.position.x, sz = fig.mesh.position.z;
+    const start = performance.now();
+    function step() {
+      const t = Math.min(1, (performance.now() - start) / durationMs);
+      const e = 1 - Math.pow(1 - t, 3); // ease-out-cubic
+      fig.mesh.position.x = sx + (tx - sx) * e;
+      fig.mesh.position.z = sz + (tz - sz) * e;
+      if (t < 1) { requestAnimationFrame(step); }
+      else {
+        fig.mesh.position.x = tx;
+        fig.mesh.position.z = tz;
+        if (!applyingRemote) send({ type: 'move', id: fig.id, x: tx, z: tz });
+      }
+    }
+    requestAnimationFrame(step);
+  }
+  window.easeFigure = easeFigure; // expose for tests
+  ```
+
+- [ ] **Step 2: Update the V tool mousedown else-branch**
+
+  After Task 2 the else-branch of `case 'V':` reads:
+  ```js
+  } else {
+    selectFigure(null);
+    lastClick.fig = null;
+  }
+  ```
+
+  Replace it with:
+  ```js
+  } else {
+    const bpos = pickBoard(ndc);
+    const now = Date.now();
+    if (bpos && lastBoardClick.fig && now - lastBoardClick.time < 380) {
+      // Double-click on empty board: teleport the previously-selected figure
+      easeFigure(lastBoardClick.fig, bpos.x, bpos.z, 300);
+      selectFigure(lastBoardClick.fig);
+      lastBoardClick = { time: 0, fig: null };
+    } else {
+      // Single click: remember which figure was selected, then deselect
+      lastBoardClick = { time: now, fig: selectedFigure };
+      selectFigure(null);
+      lastClick.fig = null;
+    }
+  }
+  ```
+
+- [ ] **Step 3: Write Playwright test**
+
+  Add to `tests/e2e/specs/brett-controls.spec.ts`:
+
+  ```typescript
+  test.describe('Brett Controls — double-click teleport', () => {
+    test('double-click on board teleports selected figure', async ({ page }) => {
+      await page.goto(`${BRETT_URL}?room=e2e-teleport-${Date.now()}`);
+      await page.waitForFunction(() => typeof (window as W).easeFigure === 'function', { timeout: 5000 });
+
+      // Place a figure at (-5, -5), select it
+      const figId = await page.evaluate(() => {
+        const fig = (window as W).addFigure('pawn', '#e06b6b', -5, -5, '', 1.0, 0);
+        (window as W).selectFigure(fig);
+        return fig.id;
+      });
+
+      // Simulate double-click: click empty board twice via JS (avoids canvas coordinate math)
+      await page.evaluate(() => {
+        const fig = (window as W).figures.find((f: W) => f.id !== undefined);
+        // First click: deselect, record lastBoardClick
+        (window as W).lastBoardClick = { time: Date.now(), fig };
+        // Second click: teleport
+        (window as W).easeFigure(fig, 3, 3, 300);
+        (window as W).selectFigure(fig);
+        (window as W).lastBoardClick = { time: 0, fig: null };
+      });
+
+      await page.waitForTimeout(400); // animation completes
+
+      const pos = await page.evaluate((id) => {
+        const f = (window as W).figures.find((f: W) => f.id === id);
+        return { x: f.mesh.position.x, z: f.mesh.position.z };
+      }, figId);
+
+      expect(pos.x).toBeCloseTo(3, 0);
+      expect(pos.z).toBeCloseTo(3, 0);
+    });
+  });
+  ```
+
+  Note: `lastBoardClick` must be exposed on `window` for this test. Add `window.lastBoardClick = lastBoardClick;` after the variable declaration in Step 1. But since it's an object, we expose it by reference and can mutate it from the test.
+
+  Actually — `lastBoardClick` is a primitive-containing object that gets *replaced* (`lastBoardClick = { time:..., fig:... }`). The window reference won't stay in sync after replacement. Expose a getter instead:
+
+  After `let lastBoardClick = ...;` add:
+  ```js
+  Object.defineProperty(window, 'lastBoardClick', {
+    get: () => lastBoardClick,
+    set: v => { lastBoardClick = v; },
+  });
+  ```
+
+- [ ] **Step 4: Commit**
+
+  ```bash
+  git add brett/public/index.html tests/e2e/specs/brett-controls.spec.ts
+  git commit -m "feat(brett): add double-click-teleport figure movement"
+  ```
+
+---
+
+## Task 5: Character-editor panel — HTML + CSS
+
+**Files:** `brett/public/index.html`
+
+Replace the scattered toolbar controls with a `＋ Figur ▾` toggle button and a floating dropdown panel.
+
+- [ ] **Step 1: Add panel CSS**
+
+  Inside the `<style>` block (before `</style>`), add:
+
+  ```css
+  /* ── Character-Editor Panel ─────────────────────────────────── */
+  #fig-panel-wrap { position: relative; display: inline-flex; align-items: center; }
+
+  #fig-panel-btn {
+    background: rgba(200,169,110,0.12);
+    border: 1px solid var(--bc-brass);
+    color: var(--bc-brass);
+    border-radius: 6px;
+    padding: 5px 10px;
+    font-size: 12px;
+    cursor: pointer;
+    white-space: nowrap;
+  }
+  #fig-panel-btn:hover, #fig-panel-btn.open { background: rgba(200,169,110,0.24); }
+
+  #fig-panel {
+    position: absolute;
+    top: calc(100% + 6px);
+    left: 0;
+    z-index: 200;
+    background: var(--bc-panel);
+    border: 1px solid var(--bc-brass);
+    border-radius: 10px;
+    padding: 10px 12px;
+    width: 280px;
+    max-height: 70vh;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    box-shadow: 0 8px 32px rgba(0,0,0,0.5);
+  }
+
+  #fig-panel-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+  #fig-panel-title {
+    font-size: 10px;
+    font-weight: 600;
+    color: var(--bc-brass);
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+  }
+  #fig-panel-close {
+    background: none;
+    border: none;
+    color: var(--bc-dim);
+    cursor: pointer;
+    font-size: 14px;
+    padding: 0 2px;
+  }
+  #fig-panel-close:hover { color: var(--bc-text); }
+
+  .fig-panel-label {
+    font-size: 10px;
+    color: var(--bc-dim);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+  }
+
+  #fig-panel #category-tabs {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+  }
+
+  #fig-panel #figure-buttons {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 5px;
+  }
+
+  #fig-panel .color-swatch {
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    cursor: pointer;
+    border: 2px solid transparent;
+    transition: border-color 0.15s;
+  }
+  #fig-panel .color-swatch.active { border-color: var(--bc-brass); }
+
+  #fig-panel-colors { display: flex; gap: 5px; flex-wrap: wrap; align-items: center; }
+
+  #fig-panel #scale-section { display: flex; gap: 5px; align-items: center; flex-wrap: wrap; }
+
+  #fig-panel-setzen {
+    background: var(--bc-brass);
+    color: #0a0a1a;
+    border: none;
+    border-radius: 7px;
+    padding: 8px 12px;
+    font-size: 12px;
+    font-weight: 600;
+    cursor: pointer;
+    margin-top: 4px;
+    width: 100%;
+  }
+  #fig-panel-setzen:hover { filter: brightness(1.1); }
+  #fig-panel-setzen:disabled { opacity: 0.4; cursor: default; }
+
+  body.placing-figure { cursor: crosshair !important; }
+  ```
+
+- [ ] **Step 2: Replace toolbar controls with panel HTML**
+
+  In `<div id="toolbar">`, remove these existing sections and replace with the panel wrapper. The toolbar currently contains (after the constellation-type select):
+  - `<div class="sep"></div>`
+  - `<div id="category-tabs"></div>`
+  - `<div class="sep"></div>`
+  - `<div id="figure-buttons" style="display:flex;gap:6px;"></div>`
+  - `<div class="sep"></div>`
+  - `<span class="tlabel">Farbe</span>`
+  - colour swatches div
+  - `<div class="sep"></div>`
+  - `<span class="tlabel">Größe</span>`
+  - `<div id="scale-section">` … `</div>`
+  - `<div class="sep"></div>`
+  - `<span class="tlabel">Drehen</span>`
+  - `<div id="rot-section">` … `</div>`
+  - `<div class="sep"></div>`
+
+  Replace all of the above (from the first `<div class="sep"></div>` after `constellation-type` through the `rot-section` separator) with:
+
+  ```html
+  <div class="sep"></div>
+  <div id="fig-panel-wrap">
+    <button id="fig-panel-btn" aria-expanded="false" aria-controls="fig-panel">＋ Figur ▾</button>
+    <div id="fig-panel" hidden role="dialog" aria-label="Figur-Editor">
+      <div id="fig-panel-header">
+        <span id="fig-panel-title">NEUE FIGUR</span>
+        <button id="fig-panel-close" aria-label="Panel schließen">✕</button>
+      </div>
+      <span class="fig-panel-label">Kategorie</span>
+      <div id="category-tabs"></div>
+      <span class="fig-panel-label">Typ</span>
+      <div id="figure-buttons"></div>
+      <span class="fig-panel-label">Farbe</span>
+      <div id="fig-panel-colors">
+        <div class="color-swatch active" data-color="#e06b6b" style="background:#e06b6b;"></div>
+        <div class="color-swatch" data-color="#6ba8e0" style="background:#6ba8e0;"></div>
+        <div class="color-swatch" data-color="#6be0a0" style="background:#6be0a0;"></div>
+        <div class="color-swatch" data-color="#e0c06b" style="background:#e0c06b;"></div>
+        <div class="color-swatch" data-color="#c06be0" style="background:#c06be0;"></div>
+        <div class="color-swatch" data-color="#e0906b" style="background:#e0906b;"></div>
+        <div class="color-swatch" data-color="#e0e0e0" style="background:#e0e0e0;"></div>
+      </div>
+      <span class="fig-panel-label">Größe</span>
+      <div id="scale-section">
+        <button class="size-btn" data-scale="0.6">S</button>
+        <button class="size-btn" data-scale="1.0">M</button>
+        <button class="size-btn" data-scale="1.5">L</button>
+        <input type="range" id="scale-slider" min="0.3" max="2.5" step="0.05" value="1.0">
+        <span id="scale-val">1.0×</span>
+      </div>
+      <button id="fig-panel-setzen">＋ Auf Brett setzen</button>
+    </div>
+  </div>
+  <div class="sep"></div>
+  ```
+
+  > The `id`s `category-tabs`, `figure-buttons`, `scale-slider`, `scale-val` are preserved — all existing JS that targets them by ID continues to work without changes.
+
+- [ ] **Step 3: Verify HTML structure**
+
+  Open the Brett URL in a browser. The toolbar should now show only:
+  `[Aufstellung ▾] | [＋ Figur ▾] | [✕ Löschen] | [↓ Speichern] [↑ Laden] [Brett leeren] | [🗺 Übersicht] | [▾] | [🎨 Optik]`
+
+  The figure buttons and colour swatches are no longer in the toolbar row (they're inside the hidden panel).
+
+- [ ] **Step 4: Commit**
+
+  ```bash
+  git add brett/public/index.html
+  git commit -m "feat(brett): add character-editor panel HTML + CSS"
+  ```
+
+---
+
+## Task 6: Character-editor panel — JS wiring
+
+**Files:** `brett/public/index.html`, `tests/e2e/specs/brett-controls.spec.ts`
+
+Wire the panel toggle, dual-mode (new figure / edit selected), `retypeFigure`, and crosshair placement mode.
+
+- [ ] **Step 1: Add retypeFigure function**
+
+  Find `function recolorFigure(fig, color) {` (around line 1990). Add immediately before it:
+
+  ```js
+  function retypeFigure(fig, newType) {
+    fig.type = newType;
+    const newMesh = buildFigure(newType, fig.color);
+    newMesh.position.copy(fig.mesh.position);
+    newMesh.rotation.y = fig.rotY;
+    newMesh.scale.setScalar(fig.scale);
+    scene.remove(fig.mesh);
+    scene.add(newMesh);
+    fig.mesh = newMesh;
+    if (fig.label) attachLabel(fig);
+    if (selectedFigure === fig) { clearSelRing(); showSelRing(fig); }
+    if (!applyingRemote) send({ type: 'update', id: fig.id, changes: { type: newType } });
+  }
+  ```
+
+- [ ] **Step 2: Add type handling to the remote update handler**
+
+  Find the `'update'` message branch (around line 1064):
+  ```js
+  if (msg.changes.color !== undefined) recolorFigure(f, msg.changes.color);
+  ```
+
+  Add after it:
+  ```js
+  if (msg.changes.type  !== undefined) retypeFigure(f, msg.changes.type);
+  ```
+
+- [ ] **Step 3: Add panel state variables**
+
+  Find `let currentColor = '#e06b6b';`. Add after it:
+
+  ```js
+  let panelFigType = 'person'; // selected type in the panel (for new figures)
+  let placingMode  = false;    // crosshair placement active
+  window.placingMode_get = () => placingMode; // test hook
+  ```
+
+- [ ] **Step 4: Add updateFigPanel helper**
+
+  Find `function selectFigure(fig) {` and add before it:
+
+  ```js
+  function updateFigPanel(fig) {
+    const title   = document.getElementById('fig-panel-title');
+    const setzen  = document.getElementById('fig-panel-setzen');
+    if (!title) return;
+    if (fig) {
+      title.textContent = 'FIGUR BEARBEITEN';
+      if (setzen) setzen.hidden = true;
+    } else {
+      title.textContent = 'NEUE FIGUR';
+      if (setzen) setzen.hidden = false;
+    }
+  }
+  ```
+
+  At the END of `selectFigure(fig)` (before the closing `}`), add:
+  ```js
+  updateFigPanel(fig);
+  ```
+
+- [ ] **Step 5: Wire panel toggle and close**
+
+  Find the section that starts `// ── Toolbar wiring ──` (around line 1969). Add a new section after the existing toolbar wiring:
+
+  ```js
+  // ── Figure-editor panel ───────────────────────────────────────────────────────
+  const figPanelBtn   = document.getElementById('fig-panel-btn');
+  const figPanel      = document.getElementById('fig-panel');
+  const figPanelClose = document.getElementById('fig-panel-close');
+
+  function openFigPanel()  {
+    figPanel.hidden = false;
+    figPanelBtn.classList.add('open');
+    figPanelBtn.setAttribute('aria-expanded', 'true');
+  }
+  function closeFigPanel() {
+    figPanel.hidden = true;
+    figPanelBtn.classList.remove('open');
+    figPanelBtn.setAttribute('aria-expanded', 'false');
+  }
+
+  figPanelBtn.addEventListener('click', () => {
+    figPanel.hidden ? openFigPanel() : closeFigPanel();
+  });
+  figPanelClose.addEventListener('click', closeFigPanel);
+
+  // Close on outside click
+  document.addEventListener('click', e => {
+    if (!figPanel.hidden && !figPanel.contains(e.target) && e.target !== figPanelBtn) {
+      closeFigPanel();
+    }
+  });
+  ```
+
+- [ ] **Step 6: Wire colour swatches inside the panel**
+
+  The original colour-swatch wiring used `document.querySelectorAll('.color-swatch')`. Since the swatches are now inside the panel, this still works. Verify the existing wiring still fires by checking for this block (around line 1981):
+
+  ```js
+  document.querySelectorAll('.color-swatch').forEach(sw => {
+    sw.addEventListener('click', () => {
+      document.querySelectorAll('.color-swatch').forEach(s => s.classList.remove('active'));
+      sw.classList.add('active');
+      currentColor = sw.dataset.color;
+      if (selectedFigure) recolorFigure(selectedFigure, currentColor);
+    });
+  });
+  ```
+
+  This block is unchanged — it still works because `.color-swatch` elements are in the DOM (just inside the panel now).
+
+- [ ] **Step 7: Wire figure-button clicks in the panel (dual-mode)**
+
+  The figure buttons are rendered dynamically by `renderTabContent()` which calls `container.appendChild(btn)` with click handlers that call `addFigure(...)`. We need to change those click handlers so that in the panel context:
+  - If no figure selected → update `panelFigType` and highlight the button (don't add a figure yet)
+  - If figure selected → call `retypeFigure(selectedFigure, type)` immediately
+
+  Find `renderTabContent` (around line 1591). Find the `btn.addEventListener('click', () => {` inside it (around line 1614):
+
+  ```js
+  btn.addEventListener('click', () => {
+    const x = (Math.random()-0.5)*(BW-4);
+    const z = (Math.random()-0.5)*(BD-4);
+    const fig = addFigure(btn.dataset.type, currentColor, x, z, '', 1.0, 0);
+    send({ type: 'add', fig: figToJSON(fig) });
+    selectFigure(fig);
+    openLabelModal(fig);
+  });
+  ```
+
+  Replace with:
+  ```js
+  btn.addEventListener('click', () => {
+    const type = btn.dataset.type;
+    if (selectedFigure) {
+      retypeFigure(selectedFigure, type);
+    } else {
+      panelFigType = type;
+      document.querySelectorAll('#figure-buttons .figure-btn')
+        .forEach(b => b.classList.toggle('active', b.dataset.type === type));
+    }
+  });
+  ```
+
+  There is a second identical block in the legacy v1 path (around line 1668). Apply the same replacement there too.
+
+- [ ] **Step 8: Wire Setzen button and crosshair placement mode**
+
+  Find `document.getElementById('bc-collapse-top')?.addEventListener(...)` and add before it:
+
+  ```js
+  document.getElementById('fig-panel-setzen').addEventListener('click', () => {
+    closeFigPanel();
+    placingMode = true;
+    document.body.classList.add('placing-figure');
+    const hint = document.getElementById('bc-hint');
+    if (hint) { hint.textContent = 'Klick auf das Brett zum Platzieren — Esc zum Abbrechen'; hint.classList.remove('bc-fade'); }
+  });
+  ```
+
+  In the main `keydown` handler (around line 3267), inside the `if (e.key === 'Escape') {` block, add at the very top (before the help-overlay check):
+
+  ```js
+  if (placingMode) {
+    placingMode = false;
+    document.body.classList.remove('placing-figure');
+    updateHint();
+    e.preventDefault(); return;
+  }
+  ```
+
+  In the canvas `mousedown` handler (around line 2404), add at the very top of the handler body (before `if (isAnyModalOpen()) return;`):
+
+  ```js
+  if (placingMode) {
+    const bpos = pickBoard(getNDC(e));
+    if (bpos) {
+      const s = parseFloat(document.getElementById('scale-slider').value);
+      const fig = addFigure(panelFigType, currentColor, bpos.x, bpos.z, '', s, 0);
+      send({ type: 'add', fig: figToJSON(fig) });
+      selectFigure(fig);
+      openLabelModal(fig);
+    }
+    placingMode = false;
+    document.body.classList.remove('placing-figure');
+    updateHint();
+    e.preventDefault();
+    return;
+  }
+  ```
+
+- [ ] **Step 9: Write Playwright test for the panel**
+
+  Add to `tests/e2e/specs/brett-controls.spec.ts`:
+
+  ```typescript
+  test.describe('Brett Controls — character editor panel', () => {
+    test('fig-panel-btn toggles the panel', async ({ page }) => {
+      await page.goto(`${BRETT_URL}?room=e2e-panel-${Date.now()}`);
+      await page.waitForFunction(() => !!document.getElementById('fig-panel-btn'), { timeout: 5000 });
+
+      const panelHidden = await page.$eval('#fig-panel', (el: HTMLElement) => el.hidden);
+      expect(panelHidden).toBe(true);
+
+      await page.click('#fig-panel-btn');
+      const panelVisible = await page.$eval('#fig-panel', (el: HTMLElement) => el.hidden);
+      expect(panelVisible).toBe(false);
+
+      await page.click('#fig-panel-close');
+      const panelHidden2 = await page.$eval('#fig-panel', (el: HTMLElement) => el.hidden);
+      expect(panelHidden2).toBe(true);
+    });
+
+    test('panel title changes to FIGUR BEARBEITEN when figure is selected', async ({ page }) => {
+      await page.goto(`${BRETT_URL}?room=e2e-panel2-${Date.now()}`);
+      await page.waitForFunction(() => typeof (window as W).addFigure === 'function', { timeout: 5000 });
+
+      await page.evaluate(() => {
+        const fig = (window as W).addFigure('pawn', '#e06b6b', 0, 0, '', 1.0, 0);
+        (window as W).selectFigure(fig);
+      });
+
+      await page.click('#fig-panel-btn');
+      const title = await page.$eval('#fig-panel-title', (el: HTMLElement) => el.textContent);
+      expect(title).toBe('FIGUR BEARBEITEN');
+    });
+
+    test('Setzen button enters placing mode', async ({ page }) => {
+      await page.goto(`${BRETT_URL}?room=e2e-panel3-${Date.now()}`);
+      await page.waitForFunction(() => typeof (window as W).placingMode_get === 'function', { timeout: 5000 });
+
+      await page.click('#fig-panel-btn');
+      await page.click('#fig-panel-setzen');
+
+      const placing = await page.evaluate(() => (window as W).placingMode_get());
+      expect(placing).toBe(true);
+
+      // Escape cancels
+      await page.keyboard.press('Escape');
+      const placing2 = await page.evaluate(() => (window as W).placingMode_get());
+      expect(placing2).toBe(false);
+    });
+  });
+  ```
+
+- [ ] **Step 10: Commit**
+
+  ```bash
+  git add brett/public/index.html tests/e2e/specs/brett-controls.spec.ts
+  git commit -m "feat(brett): wire character-editor panel JS — dual-mode, placement, retypeFigure"
+  ```
+
+---
+
+## Task 7: Final verification and push
+
+- [ ] **Step 1: Run offline tests**
+
+  ```bash
+  task test:all
+  # Expected: all BATS + manifest tests pass
+  ```
+
+- [ ] **Step 2: Manual smoke check**
+
+  Start Brett locally:
+  ```bash
+  task brett:build  # or: cd brett && node server.js
+  ```
+  Open `http://brett.localhost` (or `http://localhost:3000` depending on local setup) and verify:
+
+  1. **Head fix:** Add a "Mann" or "Frau" figure — head circle is solid green, not transparent
+  2. **Panel:** Click "＋ Figur ▾" — panel opens with category tabs, figure grid, colour swatches, size slider, "＋ Auf Brett setzen"
+  3. **Panel close:** Click ✕, click outside panel, click button again — all close the panel
+  4. **Placement mode:** Click "Auf Brett setzen" → cursor becomes crosshair → click on board → figure placed → label modal opens
+  5. **Escape cancels:** In placement mode, Escape restores normal cursor
+  6. **Edit mode:** Click a figure to select → open panel → title shows "FIGUR BEARBEITEN", Setzen button hidden; change colour in panel → figure recolours live; click different figure type → figure rebuilds in new type
+  7. **WASD:** Select a figure, press W/A/S/D → figure moves; hold Shift+W → moves faster
+  8. **Arrow keys:** Same as WASD
+  9. **Double-click teleport:** Select figure, click empty board (deselects), immediately click another empty spot → figure slides to new position
+  10. **No ctrlBall:** Clicking empty board shows NO golden sphere
+
+- [ ] **Step 3: Push branch**
+
+  ```bash
+  git push -u origin feature/brett-ux-overhaul
+  ```
+
+- [ ] **Step 4: Deploy to dev for live verification (optional)**
+
+  ```bash
+  task dev:redeploy:brett
+  # Then open https://brett.dev.mentolder.de and repeat smoke checks
+  ```

--- a/docs/superpowers/specs/2026-05-14-brett-ux-overhaul-design.md
+++ b/docs/superpowers/specs/2026-05-14-brett-ux-overhaul-design.md
@@ -1,0 +1,186 @@
+# Brett UX Overhaul — Design Spec
+
+**Branch:** `feature/brett-ux-overhaul`  
+**Date:** 2026-05-14  
+**Status:** Approved
+
+---
+
+## Scope
+
+Three self-contained changes to `brett/public/index.html` plus SVG asset fixes:
+
+1. **Head-bug fix** — SVG character heads are transparent (fill:none), board shows through
+2. **Character-editor panel** — foldable dropdown in the top toolbar replacing the current scattered controls
+3. **Movement overhaul** — remove ctrlBall, add WASD+sprint and double-click-teleport
+
+---
+
+## 1 — Head-Bug Fix (SVG Assets)
+
+### Problem
+
+All person-category SVGs have `fill="none"` on their head circle element. In Three.js, the sprite is rendered with `transparent: true`, so the transparent interior of the circle shows the board behind it — the head looks hollow or absent.
+
+### Fix
+
+For every person/role SVG that contains a head circle, change `fill="none"` to `fill` matching the element's `stroke` color. This makes the head fully opaque without requiring any JS change.
+
+**Affected files (11):**
+
+| File | Current stroke | New fill |
+|------|---------------|----------|
+| `mann.svg` | `#C8F76A` | `#C8F76A` |
+| `frau.svg` | `#C8F76A` | `#C8F76A` |
+| `person.svg` | `#C8F76A` | `#C8F76A` |
+| `nonbinary.svg` | `#C8F76A` | `#C8F76A` |
+| `senior.svg` | `#C8F76A` | `#C8F76A` |
+| `baby.svg` | `#C8F76A` | `#C8F76A` |
+| `fuehrungskraft.svg` | `#C8F76A` | `#C8F76A` |
+| `mitarbeiter.svg` | `#C8F76A` | `#C8F76A` |
+| `kunde.svg` | `#C8F76A` | `#C8F76A` |
+| `berater.svg` | `#C8F76A` | `#C8F76A` |
+| `kind.svg` | `#5BD4D0` | `#5BD4D0` |
+
+`nonbinary.svg` has two circles (head + body detail) — only the **first** circle (the head, largest r) gets the fill. Symbol SVGs (herz, stern, kreuz, etc.) have no head circle and are not touched.
+
+### Caching
+
+`loadCharacterTexture` caches by id in `characterTextures`. Since the fix is in the SVG source files, the cache is invalidated automatically on reload (no JS changes needed).
+
+---
+
+## 2 — Character-Editor Panel
+
+### Current state
+
+Controls are scattered across the top toolbar in a fixed horizontal row: category tabs → figure buttons → colour swatches → size S/M/L + slider → rotation buttons → delete. These cannot be hidden and take permanent toolbar space.
+
+### New behaviour
+
+**A `＋ Figur ▾` button** is added to the toolbar (replacing the scattered controls). Clicking it toggles a floating dropdown panel directly below.
+
+#### Panel layout
+
+```
+┌─ Toolbar ─────────────────────────────────────────────────┐
+│ [Aufstellung ▾]  [＋ Figur ▾]  ...  [Optik]  [Speichern] │
+└──────────────┬────────────────────────────────────────────┘
+               ↓ (panel opens below button)
+   ┌───────────────────────────────┐
+   │  NEUE FIGUR              [✕] │
+   │  ── Kategorie ─────────────  │
+   │  [👤 Personen] [🏢 Rollen]…  │
+   │  ── Typ ───────────────────  │
+   │  [Mann] [Frau] [Kind] …      │
+   │  ── Farbe ─────────────────  │
+   │  🔴 🔵 🟢 🟡 🟣 🟠 ⚪      │
+   │  ── Größe ─────────────────  │
+   │  [S] [M] [L]  ──────── 1.0× │
+   │                               │
+   │  [＋ Auf Brett setzen]        │
+   └───────────────────────────────┘
+```
+
+#### Dual mode
+
+| State | Panel title | "Setzen"-Button | Changes apply to |
+|-------|-------------|-----------------|-----------------|
+| No figure selected | **NEUE FIGUR** | Visible — triggers crosshair placement | New figure created on click |
+| Figure selected | **FIGUR BEARBEITEN** | Hidden | Selected figure immediately (live recolor/rescale/retype) |
+
+When switching from "edit" mode back to "new" mode (user deselects figure), panel reverts to NEUE FIGUR title and re-shows the Setzen button; pending settings (colour, size) are preserved as the default for the next new figure.
+
+#### Crosshair placement mode
+
+After clicking "Auf Brett setzen":
+1. Panel closes
+2. Cursor changes to `crosshair`
+3. A hint appears: _"Klick auf das Brett zum Platzieren — Esc zum Abbrechen"_
+4. First click on the board → `addFigure(...)` at raycasted board position, send WebSocket `add`, open label modal
+5. Escape or click on empty non-board area cancels placement, cursor restored
+
+#### Closing the panel
+
+- Click the ✕ button inside the panel
+- Click the `＋ Figur ▾` button again (toggle)
+- Click anywhere outside the panel
+- Entering crosshair mode (auto-closes)
+
+#### Toolbar cleanup
+
+The following elements are **removed** from the toolbar DOM:
+- `#category-tabs` div
+- `#figure-buttons` div
+- `.color-swatch` elements and their label
+- `#scale-section` (S/M/L buttons + slider + value span)
+- `#rot-section` (rotate buttons) — rotation stays accessible via context menu and keyboard shortcuts (↺/↻ already work via the `R` tool + drag)
+
+The `btn-delete`, save/load/reset buttons, sync-status, optik-wrap, and collapse/minimap buttons remain in the toolbar.
+
+---
+
+## 3 — Movement Overhaul
+
+### Removed
+
+**ctrlBall** — the golden sphere+ring that appeared on click-on-empty-board — is removed entirely:
+- `showCtrlBall`, `hideCtrlBall`, `pickBall` functions deleted
+- `ctrlBall`, `ctrlBallActive`, `ctrlBallDrag`, `ctrlBallStart`, `ctrlBallShowTime` variables deleted
+- The `else` branch in the `'V'` tool mousedown handler that called `showCtrlBall` is replaced with a no-op (selecting null still happens)
+
+### Kept
+
+**Drag-to-move** remains unchanged: click figure + drag → figure follows cursor → mouseup sends WebSocket `move`.
+
+### New: WASD / Arrow-key movement
+
+Implemented as a per-frame RAF tick (no `keydown` repeat delay).
+
+```
+keydown  → set held[key] = true
+keyup    → set held[key] = false, send WebSocket move for final position
+RAF tick → if selectedFigure && any WASD/arrow held:
+             speed = held[Shift] ? 12 : 4   (units/second)
+             dx/dz from held keys, normalized for diagonal
+             clamp to board bounds (±BW/2+1, ±BD/2+1)
+             update mesh.position
+             sendMoveThrottled (16ms throttle, reuse existing)
+```
+
+Keys: `W`/`ArrowUp` = −Z, `S`/`ArrowDown` = +Z, `A`/`ArrowLeft` = −X, `D`/`ArrowRight` = +X.  
+Diagonal movement is normalized (√2 factor removed).  
+Keys are ignored when any modal is open (`isAnyModalOpen()`).  
+Keys are ignored when focus is in a text input/textarea.
+
+Hint text for V tool updated: _"Tap = auswählen · Drag = ziehen · WASD = bewegen · Shift = Sprint · Doppelklick = Teleport"_
+
+### New: Double-click teleport
+
+On `mousedown` with fast double-click detection (< 380 ms gap):
+
+- **Double-click ON a figure** → existing behaviour: open label modal (unchanged)
+- **Double-click on empty board** → if `selectedFigure` exists:
+  - Raycast board position
+  - Animate figure position from current to target over 300 ms (ease-out-cubic, same easer already used for camera)
+  - Send WebSocket `move` at animation end
+
+The existing single-click double-click detection (`lastClick` object) is extended with a `boardPos` field to distinguish figure vs board double-clicks cleanly.
+
+---
+
+## Out of Scope
+
+- Touch-specific sprint (no Shift key on mobile) — can be added later
+- Rotation controls in the panel (rotation remains via `R` tool + keyboard shortcuts)
+- Custom figure colours beyond the existing 7 swatches
+- Animation for WASD movement (figures slide vs teleport)
+
+---
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `brett/public/art-library/mann.svg` … (11 SVGs) | `fill="none"` → `fill=<stroke-color>` on head circle |
+| `brett/public/index.html` | Panel HTML+CSS, panel JS, movement JS, ctrlBall removal |


### PR DESCRIPTION
## Summary

- **Shift-sprint**: holding Shift while using WASD/arrow keys moves the selected mannequin at 3× speed
- **Arrow key movement**: ↑↓←→ now work identically to WASD for figure movement
- **Double-click teleport**: double-clicking the floor with a figure selected ease-animates it to that position (300 ms ease-out-cubic); double-click with no selection still adds a new figure
- **Character-editor panel**: replaces the bare "+ Figur" button with a foldable "＋ Figur ▾" dropdown containing 7 colour swatches, a name/label input, and an "Auf Brett setzen" button; opening the panel while a figure is selected switches it to edit mode (live recolor, live label rename)

## Test Plan

- [ ] Hold W — mannequin walks forward; hold Shift+W — noticeably faster
- [ ] Arrow keys move the selected figure as expected
- [ ] Double-click empty floor with figure selected → figure slides to that spot
- [ ] Double-click with no selection → new figure added at click point
- [ ] Click "＋ Figur ▾" → panel opens with colour swatches, name field, add button
- [ ] Click ✕ or outside panel → panel closes
- [ ] Select a colour, then click "Auf Brett setzen" → figure added in that colour
- [ ] Select an existing figure, open panel → title shows "FIGUR BEARBEITEN", add button hidden; change colour → figure recolours live
- [ ] Type in label field with figure selected → `fig.label` updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)