### PR TITLE
feat(skills): add mishap-tracker — automatic anomaly ticketing from skill executions

### DIFF
--- a/.claude/skills/backup-check/SKILL.md
+++ b/.claude/skills/backup-check/SKILL.md
@@ -3,6 +3,12 @@ name: backup-check
 description: Use when asked to audit, test, or fix the database backup/restore process on the Bachelorprojekt platform. Covers setup verification, triggering a live backup, verifying encrypted files, running a safe restore-to-temp-db test, and fixing any issues found.
 ---
 
+> **Mishap Tracking:** As you execute this skill, maintain a running `MISHAP_LOG`.
+> For every anomaly, unexpected state, broken component, security concern, or
+> configuration drift you notice — even if unrelated to the current task — add
+> an entry with: `type` (broken/degraded/suspicious/security/drift), `title`,
+> `description`, and `component`. Invoke `mishap-tracker` at the very end.
+
 # Backup Check
 
 End-to-end audit of the backup system: verify setup → trigger live backup → verify files → test restore safely → fix issues.
@@ -292,3 +298,10 @@ Script: `scripts/backup-restore.sh restore <db> <timestamp> --context <ctx>`
 - Requires `SHARED_DB_PASSWORD` (postgres superuser) in `workspace-secrets`
 
 **Gotcha:** `backup-restore.sh trigger` creates jobs from `cronjob/db-backup`. If the old `backup-postgres` CronJob is the only one present, trigger fails silently. Fix Phase 1.1 first.
+
+
+## Post-Execution: Mishap Report
+
+After completing all steps in this skill, invoke `mishap-tracker` with your
+accumulated `MISHAP_LOG`. If no mishaps were found, `mishap-tracker` exits
+cleanly with "No mishaps found."

--- a/.claude/skills/deployment-assist/SKILL.md
+++ b/.claude/skills/deployment-assist/SKILL.md
@@ -3,6 +3,12 @@ name: deployment-assist
 description: Use when the user wants to deploy, set up, or diagnose the workspace platform — after a fresh clone or on a partially-deployed environment. Guides through environment selection, credential check, status assessment, and sequential task execution until everything is running.
 ---
 
+> **Mishap Tracking:** As you execute this skill, maintain a running `MISHAP_LOG`.
+> For every anomaly, unexpected state, broken component, security concern, or
+> configuration drift you notice — even if unrelated to the current task — add
+> an entry with: `type` (broken/degraded/suspicious/security/drift), `title`,
+> `description`, and `component`. Invoke `mishap-tracker` at the very end.
+
 # deployment-assist
 
 Interactive deployment guide. Runs a phased assessment of what exists, what's missing, and what credentials are needed, then offers to execute required tasks in order.
@@ -264,3 +270,10 @@ task health                   # full connectivity check
 | App `OutOfSync` with `${VAR}` literal in error (e.g. `${DEV_NODE}`, `${LLM_HOST_IP}`) | Env var not in cluster Secret annotations. Patch the Secret and add the annotation to `argocd/applicationset.yaml` template + `Taskfile.argocd.yml` cluster:register patches, then re-apply: `kubectl apply -f argocd/applicationset.yaml` |
 | Deployment stuck with old pod `Running` and new pod `Pending` (hostPort deadlock) | Rolling update deadlock — old pod holds the hostPort on the node. Delete the old pod manually: `kubectl delete pod -n <ns> <old-pod>` — the new pod will claim the port |
 | ArgoCD cached error persists after fix | Force re-evaluation: `argocd app get <app> --hard-refresh --grpc-web` |
+
+
+## Post-Execution: Mishap Report
+
+After completing all steps in this skill, invoke `mishap-tracker` with your
+accumulated `MISHAP_LOG`. If no mishaps were found, `mishap-tracker` exits
+cleanly with "No mishaps found."

--- a/.claude/skills/dev-flow-execute/SKILL.md
+++ b/.claude/skills/dev-flow-execute/SKILL.md
@@ -3,6 +3,12 @@ name: dev-flow-execute
 description: Use when on a feature/* or fix/* branch that has a staged plan in docs/superpowers/plans/ ready to implement. Invoke after dev-flow-plan has committed and pushed the plan to the branch.
 ---
 
+> **Mishap Tracking:** As you execute this skill, maintain a running `MISHAP_LOG`.
+> For every anomaly, unexpected state, broken component, security concern, or
+> configuration drift you notice — even if unrelated to the current task — add
+> an entry with: `type` (broken/degraded/suspicious/security/drift), `title`,
+> `description`, and `component`. Invoke `mishap-tracker` at the very end.
+
 # dev-flow-execute — Plan-Ausführung & PR
 
 ## Wann diese Skill greift
@@ -377,3 +383,10 @@ Jeder Pfad delegiert Spezialarbeit an die passenden Sub-Agents (siehe CLAUDE.md 
 - SealedSecrets/Keycloak/OIDC → `bachelorprojekt-security`
 
 **Pflicht vor jedem Sub-Agent-Dispatch:** `bash scripts/plan-context.sh <role>` ausführen und die Ausgabe in `<active-plans>` Tags an den Prompt voranstellen (Details in CLAUDE.md).
+
+
+## Post-Execution: Mishap Report
+
+After completing all steps in this skill, invoke `mishap-tracker` with your
+accumulated `MISHAP_LOG`. If no mishaps were found, `mishap-tracker` exits
+cleanly with "No mishaps found."

--- a/.claude/skills/dev-flow-plan/SKILL.md
+++ b/.claude/skills/dev-flow-plan/SKILL.md
@@ -3,6 +3,12 @@ name: dev-flow-plan
 description: Use when beginning any repo change — feature, bug fix, or chore. Entry point for all development work in this repo. Routes to the correct path (feature/fix/chore) and produces a committed, pushed plan on the branch ready for dev-flow-execute. Chores complete inline without a separate execution step.
 ---
 
+> **Mishap Tracking:** As you execute this skill, maintain a running `MISHAP_LOG`.
+> For every anomaly, unexpected state, broken component, security concern, or
+> configuration drift you notice — even if unrelated to the current task — add
+> an entry with: `type` (broken/degraded/suspicious/security/drift), `title`,
+> `description`, and `component`. Invoke `mishap-tracker` at the very end.
+
 # dev-flow-plan — Pfad-Wahl, Brainstorming & Plan
 
 ## Wann diese Skill greift
@@ -514,3 +520,10 @@ Jeder Pfad delegiert Spezialarbeit an die passenden Sub-Agents (siehe CLAUDE.md 
 - SealedSecrets/Keycloak/OIDC → `bachelorprojekt-security`
 
 **Pflicht vor jedem Sub-Agent-Dispatch:** `bash scripts/plan-context.sh <role>` ausführen und die Ausgabe in `<active-plans>` Tags an den Prompt voranstellen (Details in CLAUDE.md).
+
+
+## Post-Execution: Mishap Report
+
+After completing all steps in this skill, invoke `mishap-tracker` with your
+accumulated `MISHAP_LOG`. If no mishaps were found, `mishap-tracker` exits
+cleanly with "No mishaps found."

--- a/.claude/skills/dev-flow/SKILL.md
+++ b/.claude/skills/dev-flow/SKILL.md
@@ -3,6 +3,11 @@ name: dev-flow
 description: RETIRED — use dev-flow-plan (planning phase) and dev-flow-execute (implementation phase) instead.
 ---
 
+> **Mishap Tracking:** If this skill is ever invoked despite being RETIRED,
+> maintain a `MISHAP_LOG` and invoke `mishap-tracker` at the end. Log the
+> invocation itself as `type: suspicious`, `title: "retired dev-flow skill
+> invoked"`, `component: skill-routing`.
+
 # dev-flow — RETIRED
 
 This skill has been split into two:

--- a/.claude/skills/hetzner-node/SKILL.md
+++ b/.claude/skills/hetzner-node/SKILL.md
@@ -3,6 +3,12 @@ name: hetzner-node
 description: Use when provisioning a new Hetzner node or resetting an existing one — guides through key management, cloud-config generation, Rescue Mode reinstall, and k3s cluster join. WireGuard mesh is wired automatically so the node reconnects without peer updates on every future reset.
 ---
 
+> **Mishap Tracking:** As you execute this skill, maintain a running `MISHAP_LOG`.
+> For every anomaly, unexpected state, broken component, security concern, or
+> configuration drift you notice — even if unrelated to the current task — add
+> an entry with: `type` (broken/degraded/suspicious/security/drift), `title`,
+> `description`, and `component`. Invoke `mishap-tracker` at the very end.
+
 # hetzner-node
 
 Interactive runbook for provisioning or resetting a Hetzner server. Handles all three k3s roles (control-plane-init, control-plane-join, worker) and both modes (new server, Rescue Mode reset).
@@ -555,3 +561,10 @@ If this is a permanent new node (not replacing an existing one):
 | Handshakes not forming | Public key mismatch — re-derive: `echo "<PRIVATE_KEY>" \| wg pubkey` and compare |
 | `wg set` fails on existing peers | `sudo modprobe wireguard` if module not loaded |
 | Node appears in cluster but pods `Pending` | wg-mesh peer missing for a home-LAN worker — add peer entry manually |
+
+
+## Post-Execution: Mishap Report
+
+After completing all steps in this skill, invoke `mishap-tracker` with your
+accumulated `MISHAP_LOG`. If no mishaps were found, `mishap-tracker` exits
+cleanly with "No mishaps found."

--- a/.claude/skills/mishap-tracker/SKILL.md
+++ b/.claude/skills/mishap-tracker/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: mishap-tracker
+description: Invoked at the end of any local skill execution to convert MISHAP_LOG entries into tickets in the mentolder postgres database. Never invoke directly — always called from another skill's Post-Execution section.
+---
+
+# mishap-tracker
+
+Convert the calling skill's `MISHAP_LOG` into `tickets.tickets` records on the mentolder cluster.
+
+## Step 1: Check MISHAP_LOG
+
+If `MISHAP_LOG` is empty or has no entries → print "No mishaps found." and stop. Do not make any DB call.
+
+## Step 2: Severity mapping
+
+Map each entry's `type` to DB fields before inserting:
+
+| type | tickets.type | tickets.severity |
+|---|---|---|
+| broken | bug | major |
+| security | bug | critical |
+| degraded | bug | minor |
+| suspicious | task | minor |
+| drift | task | trivial |
+
+If an entry has no `component`, use `skill-execution` as the value.
+
+## Step 3: Insert tickets
+
+For each entry in `MISHAP_LOG`, run the following — substituting the mapped values:
+
+```bash
+PGPOD=$(kubectl get pod -n workspace --context mentolder \
+  -l app=shared-db -o name | head -1)
+
+TICKET_EXT=$(kubectl exec "$PGPOD" -n workspace --context mentolder -- \
+  psql -U website -d website -At -c \
+  "INSERT INTO tickets.tickets (type, brand, title, description, severity, status, component)
+   VALUES (
+     '<tickets.type>',
+     'mentolder',
+     '<title>',
+     '<description>',
+     '<tickets.severity>',
+     'triage',
+     '<component>'
+   )
+   RETURNING external_id;")
+```
+
+Collect each returned `external_id` for the summary.
+
+## Step 4: Print summary
+
+After all inserts, print:
+
+```
+Mishap report — N ticket(s) created:
+  T000312 [broken/major]      shared-db: no backup found in last 24h
+  T000313 [security/critical] keycloak: realm export missing MFA policy
+  T000314 [drift/trivial]     livekit: DNS pin node differs from nodeAffinity
+→ https://web.mentolder.de/admin/bugs
+```
+
+## Step 5: DB unreachable fallback
+
+If `kubectl get pod` returns empty, or `psql` exits non-zero:
+
+1. Print all `MISHAP_LOG` entries formatted:
+
+```
+⚠️  DB unreachable — mishaps NOT ticketed. Create manually:
+
+  [broken/major]      shared-db: no backup found in last 24h
+    shared-db pod did not respond to pg_dump trigger at 03:30 UTC.
+    component: backup
+
+  [security/critical] keycloak: realm export missing MFA policy
+    realm-workspace-mentolder.json has no browserSecurityHeaders.contentSecurityPolicy.
+    component: keycloak
+```
+
+2. Print: "→ Create tickets manually at https://web.mentolder.de/admin/bugs"
+3. Exit cleanly — do NOT propagate an error to the parent skill.

--- a/docs/superpowers/plans/2026-05-15-skill-mishap-tracker.md
+++ b/docs/superpowers/plans/2026-05-15-skill-mishap-tracker.md
@@ -1,4 +1,5 @@
 ---
+ticket_id: T000378
 title: Skill Mishap Tracker — Implementation Plan
 domains: []
 status: active

--- a/docs/superpowers/plans/2026-05-15-skill-mishap-tracker.md
+++ b/docs/superpowers/plans/2026-05-15-skill-mishap-tracker.md
@@ -1,0 +1,483 @@
+---
+title: Skill Mishap Tracker — Implementation Plan
+domains: []
+status: active
+pr_number: null
+---
+
+# Skill Mishap Tracker — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add automatic mishap logging to all active local skills, with a shared `mishap-tracker` skill that converts findings into `tickets.tickets` records on mentolder at the end of each skill execution.
+
+**Architecture:** A new `mishap-tracker` skill holds all DB-insertion logic. Each of the 5 active local skills gets a header block (instructs Claude to maintain a `MISHAP_LOG` during execution) and a footer block (invokes `mishap-tracker` at the end). The retired `dev-flow` skill gets a header block only.
+
+**Tech Stack:** Markdown skill files, `kubectl exec` + `psql` against mentolder `shared-db`, `tickets.tickets` schema.
+
+---
+
+### Task 1: Create `mishap-tracker` skill
+
+**Files:**
+- Create: `.claude/skills/mishap-tracker/SKILL.md`
+
+- [ ] **Step 1: Create the skill directory and file**
+
+```bash
+mkdir -p /home/patrick/Bachelorprojekt/.worktrees/feature/skill-mishap-tracker/.claude/skills/mishap-tracker
+```
+
+- [ ] **Step 2: Write `.claude/skills/mishap-tracker/SKILL.md`**
+
+Full content:
+
+```markdown
+---
+name: mishap-tracker
+description: Invoked at the end of any local skill execution to convert MISHAP_LOG entries into tickets in the mentolder postgres database. Never invoke directly — always called from another skill's Post-Execution section.
+---
+
+# mishap-tracker
+
+Convert the calling skill's `MISHAP_LOG` into `tickets.tickets` records on the mentolder cluster.
+
+## Step 1: Check MISHAP_LOG
+
+If `MISHAP_LOG` is empty or has no entries → print "No mishaps found." and stop. Do not make any DB call.
+
+## Step 2: Severity mapping
+
+Map each entry's `type` to DB fields before inserting:
+
+| type | tickets.type | tickets.severity |
+|---|---|---|
+| broken | bug | major |
+| security | bug | critical |
+| degraded | bug | minor |
+| suspicious | task | minor |
+| drift | task | trivial |
+
+If an entry has no `component`, use `skill-execution` as the value.
+
+## Step 3: Insert tickets
+
+For each entry in `MISHAP_LOG`, run the following — substituting the mapped values:
+
+```bash
+PGPOD=$(kubectl get pod -n workspace --context mentolder \
+  -l app=shared-db -o name | head -1)
+
+TICKET_EXT=$(kubectl exec "$PGPOD" -n workspace --context mentolder -- \
+  psql -U website -d website -At -c \
+  "INSERT INTO tickets.tickets (type, brand, title, description, severity, status, component)
+   VALUES (
+     '<tickets.type>',
+     'mentolder',
+     '<title>',
+     '<description>',
+     '<tickets.severity>',
+     'triage',
+     '<component>'
+   )
+   RETURNING external_id;")
+```
+
+Collect each returned `external_id` for the summary.
+
+## Step 4: Print summary
+
+After all inserts, print:
+
+```
+Mishap report — N ticket(s) created:
+  T000312 [broken/major]      shared-db: no backup found in last 24h
+  T000313 [security/critical] keycloak: realm export missing MFA policy
+  T000314 [drift/trivial]     livekit: DNS pin node differs from nodeAffinity
+→ https://web.mentolder.de/admin/bugs
+```
+
+## Step 5: DB unreachable fallback
+
+If `kubectl get pod` returns empty, or `psql` exits non-zero:
+
+1. Print all `MISHAP_LOG` entries formatted:
+
+```
+⚠️  DB unreachable — mishaps NOT ticketed. Create manually:
+
+  [broken/major]      shared-db: no backup found in last 24h
+    shared-db pod did not respond to pg_dump trigger at 03:30 UTC.
+    component: backup
+
+  [security/critical] keycloak: realm export missing MFA policy
+    realm-workspace-mentolder.json has no browserSecurityHeaders.contentSecurityPolicy.
+    component: keycloak
+```
+
+2. Print: "→ Create tickets manually at https://web.mentolder.de/admin/bugs"
+3. Exit cleanly — do NOT propagate an error to the parent skill.
+```
+
+- [ ] **Step 3: Verify file exists and has correct structure**
+
+```bash
+head -6 /home/patrick/Bachelorprojekt/.worktrees/feature/skill-mishap-tracker/.claude/skills/mishap-tracker/SKILL.md
+```
+
+Expected first 6 lines:
+```
+---
+name: mishap-tracker
+description: Invoked at the end of any local skill execution...
+---
+
+# mishap-tracker
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /home/patrick/Bachelorprojekt/.worktrees/feature/skill-mishap-tracker
+git add .claude/skills/mishap-tracker/SKILL.md
+git commit -m "feat(skills): add mishap-tracker shared skill"
+```
+
+---
+
+### Task 2: Add mishap tracking to `backup-check`
+
+**Files:**
+- Modify: `.claude/skills/backup-check/SKILL.md` (lines 1–5 header, append footer)
+
+The header block goes after the closing `---` of the frontmatter (line 4). The footer goes at the very end of the file (after line 294).
+
+- [ ] **Step 1: Insert header block after frontmatter**
+
+Open `.claude/skills/backup-check/SKILL.md`. After line 4 (`---`), insert a blank line followed by:
+
+```markdown
+
+> **Mishap Tracking:** As you execute this skill, maintain a running `MISHAP_LOG`.
+> For every anomaly, unexpected state, broken component, security concern, or
+> configuration drift you notice — even if unrelated to the current task — add
+> an entry with: `type` (broken/degraded/suspicious/security/drift), `title`,
+> `description`, and `component`. Invoke `mishap-tracker` at the very end.
+
+```
+
+- [ ] **Step 2: Append footer block**
+
+At the very end of the file, after the last line, append:
+
+```markdown
+
+## Post-Execution: Mishap Report
+
+After completing all steps in this skill, invoke `mishap-tracker` with your
+accumulated `MISHAP_LOG`. If no mishaps were found, `mishap-tracker` exits
+cleanly with "No mishaps found."
+```
+
+- [ ] **Step 3: Verify**
+
+```bash
+head -12 /home/patrick/Bachelorprojekt/.worktrees/feature/skill-mishap-tracker/.claude/skills/backup-check/SKILL.md
+tail -8 /home/patrick/Bachelorprojekt/.worktrees/feature/skill-mishap-tracker/.claude/skills/backup-check/SKILL.md
+```
+
+Expected head: frontmatter `---` block, then the `> **Mishap Tracking:**` blockquote.
+Expected tail: `## Post-Execution: Mishap Report` section.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /home/patrick/Bachelorprojekt/.worktrees/feature/skill-mishap-tracker
+git add .claude/skills/backup-check/SKILL.md
+git commit -m "feat(skills): add mishap tracking to backup-check"
+```
+
+---
+
+### Task 3: Add mishap tracking to `deployment-assist`
+
+**Files:**
+- Modify: `.claude/skills/deployment-assist/SKILL.md`
+
+- [ ] **Step 1: Insert header block after frontmatter**
+
+After the closing `---` of the frontmatter in `.claude/skills/deployment-assist/SKILL.md`, insert:
+
+```markdown
+
+> **Mishap Tracking:** As you execute this skill, maintain a running `MISHAP_LOG`.
+> For every anomaly, unexpected state, broken component, security concern, or
+> configuration drift you notice — even if unrelated to the current task — add
+> an entry with: `type` (broken/degraded/suspicious/security/drift), `title`,
+> `description`, and `component`. Invoke `mishap-tracker` at the very end.
+
+```
+
+- [ ] **Step 2: Append footer block**
+
+```markdown
+
+## Post-Execution: Mishap Report
+
+After completing all steps in this skill, invoke `mishap-tracker` with your
+accumulated `MISHAP_LOG`. If no mishaps were found, `mishap-tracker` exits
+cleanly with "No mishaps found."
+```
+
+- [ ] **Step 3: Verify**
+
+```bash
+head -12 /home/patrick/Bachelorprojekt/.worktrees/feature/skill-mishap-tracker/.claude/skills/deployment-assist/SKILL.md
+tail -8 /home/patrick/Bachelorprojekt/.worktrees/feature/skill-mishap-tracker/.claude/skills/deployment-assist/SKILL.md
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /home/patrick/Bachelorprojekt/.worktrees/feature/skill-mishap-tracker
+git add .claude/skills/deployment-assist/SKILL.md
+git commit -m "feat(skills): add mishap tracking to deployment-assist"
+```
+
+---
+
+### Task 4: Add mishap tracking to `dev-flow-execute`
+
+**Files:**
+- Modify: `.claude/skills/dev-flow-execute/SKILL.md`
+
+- [ ] **Step 1: Insert header block after frontmatter**
+
+After the closing `---` of the frontmatter, insert:
+
+```markdown
+
+> **Mishap Tracking:** As you execute this skill, maintain a running `MISHAP_LOG`.
+> For every anomaly, unexpected state, broken component, security concern, or
+> configuration drift you notice — even if unrelated to the current task — add
+> an entry with: `type` (broken/degraded/suspicious/security/drift), `title`,
+> `description`, and `component`. Invoke `mishap-tracker` at the very end.
+
+```
+
+- [ ] **Step 2: Append footer block**
+
+```markdown
+
+## Post-Execution: Mishap Report
+
+After completing all steps in this skill, invoke `mishap-tracker` with your
+accumulated `MISHAP_LOG`. If no mishaps were found, `mishap-tracker` exits
+cleanly with "No mishaps found."
+```
+
+- [ ] **Step 3: Verify**
+
+```bash
+head -12 /home/patrick/Bachelorprojekt/.worktrees/feature/skill-mishap-tracker/.claude/skills/dev-flow-execute/SKILL.md
+tail -8 /home/patrick/Bachelorprojekt/.worktrees/feature/skill-mishap-tracker/.claude/skills/dev-flow-execute/SKILL.md
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /home/patrick/Bachelorprojekt/.worktrees/feature/skill-mishap-tracker
+git add .claude/skills/dev-flow-execute/SKILL.md
+git commit -m "feat(skills): add mishap tracking to dev-flow-execute"
+```
+
+---
+
+### Task 5: Add mishap tracking to `dev-flow-plan`
+
+**Files:**
+- Modify: `.claude/skills/dev-flow-plan/SKILL.md`
+
+- [ ] **Step 1: Insert header block after frontmatter**
+
+After the closing `---` of the frontmatter, insert:
+
+```markdown
+
+> **Mishap Tracking:** As you execute this skill, maintain a running `MISHAP_LOG`.
+> For every anomaly, unexpected state, broken component, security concern, or
+> configuration drift you notice — even if unrelated to the current task — add
+> an entry with: `type` (broken/degraded/suspicious/security/drift), `title`,
+> `description`, and `component`. Invoke `mishap-tracker` at the very end.
+
+```
+
+- [ ] **Step 2: Append footer block**
+
+```markdown
+
+## Post-Execution: Mishap Report
+
+After completing all steps in this skill, invoke `mishap-tracker` with your
+accumulated `MISHAP_LOG`. If no mishaps were found, `mishap-tracker` exits
+cleanly with "No mishaps found."
+```
+
+- [ ] **Step 3: Verify**
+
+```bash
+head -12 /home/patrick/Bachelorprojekt/.worktrees/feature/skill-mishap-tracker/.claude/skills/dev-flow-plan/SKILL.md
+tail -8 /home/patrick/Bachelorprojekt/.worktrees/feature/skill-mishap-tracker/.claude/skills/dev-flow-plan/SKILL.md
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /home/patrick/Bachelorprojekt/.worktrees/feature/skill-mishap-tracker
+git add .claude/skills/dev-flow-plan/SKILL.md
+git commit -m "feat(skills): add mishap tracking to dev-flow-plan"
+```
+
+---
+
+### Task 6: Add mishap tracking to `hetzner-node`
+
+**Files:**
+- Modify: `.claude/skills/hetzner-node/SKILL.md`
+
+- [ ] **Step 1: Insert header block after frontmatter**
+
+After the closing `---` of the frontmatter, insert:
+
+```markdown
+
+> **Mishap Tracking:** As you execute this skill, maintain a running `MISHAP_LOG`.
+> For every anomaly, unexpected state, broken component, security concern, or
+> configuration drift you notice — even if unrelated to the current task — add
+> an entry with: `type` (broken/degraded/suspicious/security/drift), `title`,
+> `description`, and `component`. Invoke `mishap-tracker` at the very end.
+
+```
+
+- [ ] **Step 2: Append footer block**
+
+```markdown
+
+## Post-Execution: Mishap Report
+
+After completing all steps in this skill, invoke `mishap-tracker` with your
+accumulated `MISHAP_LOG`. If no mishaps were found, `mishap-tracker` exits
+cleanly with "No mishaps found."
+```
+
+- [ ] **Step 3: Verify**
+
+```bash
+head -12 /home/patrick/Bachelorprojekt/.worktrees/feature/skill-mishap-tracker/.claude/skills/hetzner-node/SKILL.md
+tail -8 /home/patrick/Bachelorprojekt/.worktrees/feature/skill-mishap-tracker/.claude/skills/hetzner-node/SKILL.md
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /home/patrick/Bachelorprojekt/.worktrees/feature/skill-mishap-tracker
+git add .claude/skills/hetzner-node/SKILL.md
+git commit -m "feat(skills): add mishap tracking to hetzner-node"
+```
+
+---
+
+### Task 7: Add header-only block to retired `dev-flow`
+
+**Files:**
+- Modify: `.claude/skills/dev-flow/SKILL.md`
+
+The retired skill has no execution steps, so it gets only the header block (no footer).
+
+- [ ] **Step 1: Insert header block after frontmatter**
+
+After the closing `---` of the frontmatter, insert:
+
+```markdown
+
+> **Mishap Tracking:** If this skill is ever invoked despite being RETIRED,
+> maintain a `MISHAP_LOG` and invoke `mishap-tracker` at the end. Log the
+> invocation itself as `type: suspicious`, `title: "retired dev-flow skill
+> invoked"`, `component: skill-routing`.
+
+```
+
+- [ ] **Step 2: Verify**
+
+```bash
+cat /home/patrick/Bachelorprojekt/.worktrees/feature/skill-mishap-tracker/.claude/skills/dev-flow/SKILL.md
+```
+
+Expected: frontmatter, then the blockquote, then the existing RETIRED notice.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /home/patrick/Bachelorprojekt/.worktrees/feature/skill-mishap-tracker
+git add .claude/skills/dev-flow/SKILL.md
+git commit -m "feat(skills): add mishap header to retired dev-flow skill"
+```
+
+---
+
+### Task 8: Create tracking ticket in DB + push branch
+
+- [ ] **Step 1: Create ticket in mentolder**
+
+```bash
+PGPOD=$(kubectl get pod -n workspace --context mentolder \
+  -l app=shared-db -o name | head -1)
+
+TICKET_RESULT=$(kubectl exec "$PGPOD" -n workspace --context mentolder -- \
+  psql -U website -d website -At -c \
+  "INSERT INTO tickets.tickets (type, brand, title, description, status)
+   VALUES (
+     'task', 'mentolder',
+     'feat: skill mishap tracker',
+     'Branch: feature/skill-mishap-tracker' || E'\n' ||
+     'Plan: docs/superpowers/plans/2026-05-15-skill-mishap-tracker.md' || E'\n' ||
+     'Spec: docs/superpowers/specs/2026-05-15-skill-mishap-tracker-design.md',
+     'triage'
+   )
+   RETURNING external_id, id;")
+
+TICKET_EXT_ID=$(echo "$TICKET_RESULT" | cut -d'|' -f1)
+echo "Ticket: $TICKET_EXT_ID → https://web.mentolder.de/admin/bugs"
+```
+
+- [ ] **Step 2: Push branch**
+
+```bash
+cd /home/patrick/Bachelorprojekt/.worktrees/feature/skill-mishap-tracker
+git push -u origin feature/skill-mishap-tracker
+```
+
+- [ ] **Step 3: Verify all skill files have the tracking blocks**
+
+```bash
+for skill in backup-check deployment-assist dev-flow-execute dev-flow-plan hetzner-node; do
+  echo "=== $skill ==="
+  grep -c "Mishap Tracking" /home/patrick/Bachelorprojekt/.worktrees/feature/skill-mishap-tracker/.claude/skills/$skill/SKILL.md
+  grep -c "Post-Execution" /home/patrick/Bachelorprojekt/.worktrees/feature/skill-mishap-tracker/.claude/skills/$skill/SKILL.md
+done
+```
+
+Expected: each skill shows `1` for both grep counts.
+
+```bash
+echo "=== dev-flow (retired) ==="
+grep -c "Mishap Tracking" /home/patrick/Bachelorprojekt/.worktrees/feature/skill-mishap-tracker/.claude/skills/dev-flow/SKILL.md
+grep -c "Post-Execution" /home/patrick/Bachelorprojekt/.worktrees/feature/skill-mishap-tracker/.claude/skills/dev-flow/SKILL.md
+```
+
+Expected: `1` for Mishap Tracking, `0` for Post-Execution (header only, no footer).
+
+```bash
+echo "=== mishap-tracker skill exists ==="
+ls -la /home/patrick/Bachelorprojekt/.worktrees/feature/skill-mishap-tracker/.claude/skills/mishap-tracker/SKILL.md
+```

--- a/docs/superpowers/specs/2026-05-15-skill-mishap-tracker-design.md
+++ b/docs/superpowers/specs/2026-05-15-skill-mishap-tracker-design.md
@@ -1,0 +1,119 @@
+# Skill Mishap Tracker — Design Spec
+
+**Date:** 2026-05-15
+**Branch:** feature/skill-mishap-tracker
+**Scope:** Local project skills only (`.claude/skills/`)
+
+---
+
+## Overview
+
+All active local skills gain automatic mishap logging. During execution Claude
+maintains a `MISHAP_LOG`; at the end it invokes a shared `mishap-tracker` skill
+that converts every log entry into a ticket in `tickets.tickets` (mentolder).
+
+---
+
+## Components
+
+### 1. New skill: `mishap-tracker`
+
+**Path:** `.claude/skills/mishap-tracker/SKILL.md`
+
+**Purpose:** Shared utility invoked at the end of any local skill. Accepts the
+calling skill's `MISHAP_LOG` from context, inserts one ticket per entry, and
+reports the created `external_id`s.
+
+**Flow:**
+
+1. If `MISHAP_LOG` is empty → print "No mishaps found." and exit. No DB call.
+2. For each entry run via `kubectl exec` on the mentolder `shared-db` pod:
+
+```sql
+INSERT INTO tickets.tickets (type, brand, title, description, severity, status, component)
+VALUES ('<type>', 'mentolder', '<title>', '<description>', '<severity>', 'triage', '<component>')
+RETURNING external_id;
+```
+
+3. Collect all `external_id`s and print summary:
+
+```
+Mishap report — N tickets created:
+  T000312 [broken/major]     shared-db: no backup in last 24h
+  T000313 [security/critical] keycloak: realm export missing MFA policy
+→ https://web.mentolder.de/admin/bugs
+```
+
+4. **DB unreachable** (pod missing, psql fails, offline): print formatted log
+   to stdout with note to create tickets manually. Do not abort the parent
+   skill — the mishap report is advisory.
+
+**Missing `component`:** default to `skill-execution`.
+
+### 2. MISHAP_LOG entry schema
+
+| Field | Values | Required |
+|---|---|---|
+| `type` | `broken` \| `degraded` \| `suspicious` \| `security` \| `drift` | yes |
+| `title` | one-line summary | yes |
+| `description` | what was found, where, context | yes |
+| `component` | subsystem name (e.g. `backup`, `shared-db`, `keycloak`) | no |
+
+### 3. Severity mapping
+
+| Mishap type | `tickets.type` | `tickets.severity` |
+|---|---|---|
+| `broken` | `bug` | `major` |
+| `security` | `bug` | `critical` |
+| `degraded` | `bug` | `minor` |
+| `suspicious` | `task` | `minor` |
+| `drift` | `task` | `trivial` |
+
+### 4. Skill modifications
+
+**5 active local skills** receive two standard blocks each:
+
+**Header block** (after frontmatter `---`, before first heading):
+
+```markdown
+> **Mishap Tracking:** As you execute this skill, maintain a running `MISHAP_LOG`.
+> For every anomaly, unexpected state, broken component, security concern, or
+> configuration drift you notice — even if unrelated to the current task — add
+> an entry with: `type` (broken/degraded/suspicious/security/drift), `title`,
+> `description`, and `component`. Invoke `mishap-tracker` at the very end.
+```
+
+**Footer block** (last section):
+
+```markdown
+## Post-Execution: Mishap Report
+
+After completing all steps in this skill, invoke `mishap-tracker` with your
+accumulated `MISHAP_LOG`. If no mishaps were found, `mishap-tracker` exits
+cleanly with "No mishaps found."
+```
+
+**Files modified:**
+- `.claude/skills/backup-check/SKILL.md`
+- `.claude/skills/deployment-assist/SKILL.md`
+- `.claude/skills/dev-flow-execute/SKILL.md`
+- `.claude/skills/dev-flow-plan/SKILL.md`
+- `.claude/skills/hetzner-node/SKILL.md`
+
+**RETIRED skill** (`.claude/skills/dev-flow/SKILL.md`): header block only,
+no footer (no execution steps).
+
+---
+
+## Signal threshold
+
+All findings are ticketed — every anomaly, unexpected state, or degraded
+condition, regardless of severity.
+
+---
+
+## Out of scope
+
+- Superpowers plugin skills (would be overwritten on plugin update)
+- Third-party plugin skills (hookify, huggingface, etc.)
+- Automatic hook-based triggering (requires shell, can't capture Claude's judgment)


### PR DESCRIPTION
## Summary
- Adds a new shared `mishap-tracker` sub-skill that converts a calling skill's `MISHAP_LOG` into `tickets.tickets` records on mentolder
- Injects a Mishap Tracking header block (instructs Claude to maintain MISHAP_LOG during execution) and a Post-Execution footer block (invokes mishap-tracker) into all 5 active local skills: `backup-check`, `deployment-assist`, `dev-flow-execute`, `dev-flow-plan`, `hetzner-node`
- Adds a header-only block to the retired `dev-flow` skill that flags its invocation as `type: suspicious`

## Test plan
- [x] task test:all (FAIL=0)
- [x] Verified all 5 active skills have MishapTracking=1 and PostExecution=1
- [x] Verified dev-flow (retired) has MishapTracking=1 and PostExecution=0
- [x] mishap-tracker SKILL.md created with correct frontmatter and DB insertion logic

Closes T000378

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>