### PR TITLE
fix(brainstorm): make tunnel reliable across ArgoCD syncs and pod restarts [T000380]

### DIFF
--- a/.claude/skills/dev-flow-plan/SKILL.md
+++ b/.claude/skills/dev-flow-plan/SKILL.md
@@ -143,7 +143,7 @@ KEY_COUNT=$(kubectl --context mentolder -n workspace get cm brainstorm-sish-auth
   -o jsonpath='{.data.authorized_keys}' 2>/dev/null | grep -c '^ssh-' || echo 0)
 if [[ "$KEY_COUNT" -lt 1 ]]; then
   echo "⚠️  Keine authorized_keys in der ConfigMap. Patricks Public-Key in environments/.secrets/mentolder.yaml" \
-       "unter DEV_SISH_AUTHORIZED_KEYS ergänzen, dann: task env:seal ENV=mentolder && task brainstorm:_materialise-keys"
+       "unter DEV_SISH_AUTHORIZED_KEYS ergänzen, dann: task env:seal ENV=mentolder && task brainstorm:materialise-keys"
   exit 1
 fi
 ```
@@ -490,7 +490,7 @@ Diese Sektion ist für Diagnose und manuelle Eingriffe. Der Feature-Pfad (Schrit
 task brainstorm:firewall:open
 # Public-Key in environments/.secrets/mentolder.yaml unter DEV_SISH_AUTHORIZED_KEYS ergänzen
 task env:seal ENV=mentolder
-task brainstorm:_materialise-keys
+task brainstorm:materialise-keys
 ```
 
 ### `ws://`→`wss://` Auto-Patch

--- a/.gemini/skills/dev-flow-plan/SKILL.md
+++ b/.gemini/skills/dev-flow-plan/SKILL.md
@@ -130,7 +130,7 @@ KEY_COUNT=$(kubectl --context mentolder -n workspace get cm brainstorm-sish-auth
   -o jsonpath='{.data.authorized_keys}' 2>/dev/null | grep -c '^ssh-' || echo 0)
 if [[ "$KEY_COUNT" -lt 1 ]]; then
   echo "⚠️  Keine authorized_keys in der ConfigMap. Patricks Public-Key in environments/.secrets/mentolder.yaml" \
-       "unter DEV_SISH_AUTHORIZED_KEYS ergänzen, dann: task env:seal ENV=mentolder && task brainstorm:_materialise-keys"
+       "unter DEV_SISH_AUTHORIZED_KEYS ergänzen, dann: task env:seal ENV=mentolder && task brainstorm:materialise-keys"
   exit 1
 fi
 ```
@@ -464,7 +464,7 @@ Diese Sektion ist für Diagnose und manuelle Eingriffe. Der Feature-Pfad (Schrit
 task brainstorm:firewall:open
 # Public-Key in environments/.secrets/mentolder.yaml unter DEV_SISH_AUTHORIZED_KEYS ergänzen
 task env:seal ENV=mentolder
-task brainstorm:_materialise-keys
+task brainstorm:materialise-keys
 ```
 
 ### `ws://`→`wss://` Auto-Patch

--- a/Taskfile.brainstorm.yml
+++ b/Taskfile.brainstorm.yml
@@ -22,8 +22,13 @@ vars:
 
 tasks:
 
-  _materialise-keys:
-    internal: true
+  setup:
+    desc: "[brainstorm] One-time setup: open firewall on the sish node + materialise authorized_keys"
+    cmds:
+      - task: firewall:open
+      - task: materialise-keys
+
+  materialise-keys:
     desc: "[brainstorm] Push DEV_SISH_AUTHORIZED_KEYS into the brainstorm-sish ConfigMap and roll sish"
     cmds:
       - |

--- a/argocd/applicationset.yaml
+++ b/argocd/applicationset.yaml
@@ -126,6 +126,16 @@ spec:
           kind: StatefulSet
           jsonPointers:
             - /status/terminatingReplicas
+        # brainstorm-sish authorized_keys is operator-managed via
+        # `task brainstorm:materialise-keys` (sourced from the sealed
+        # DEV_SISH_AUTHORIZED_KEYS). Without this carve-out ArgoCD reverts
+        # .data back to the placeholder in k3d/brainstorm-sish.yaml and the
+        # SSH tunnel breaks within seconds of every sync. T000380.
+        - group: ""
+          kind: ConfigMap
+          name: brainstorm-sish-authorized-keys
+          jsonPointers:
+            - /data
         - group: autoscaling
           kind: HorizontalPodAutoscaler
           jsonPointers:

--- a/k3d/brainstorm-sish.yaml
+++ b/k3d/brainstorm-sish.yaml
@@ -57,6 +57,9 @@ spec:
             - --service-console=false
             - --tcp-aliases=false
             - --bind-hosts=brainstorm.${PROD_DOMAIN}
+            # Persist the SSH hostkey on the pinned node so operators
+            # don't have to re-accept it after every pod restart. T000380.
+            - --private-keys-directory=/etc/sish-hostkey
           ports:
             - containerPort: 2222
               name: ssh
@@ -66,6 +69,8 @@ spec:
             - name: keys
               mountPath: /keys
               readOnly: true
+            - name: hostkey
+              mountPath: /etc/sish-hostkey
           resources:
             requests:
               memory: 64Mi
@@ -80,6 +85,13 @@ spec:
             items:
               - key: authorized_keys
                 path: authorized_keys
+        # hostPath on gekko-hetzner-2 (the deployment is nodeSelector-pinned
+        # there). Survives pod restarts; sish generates the ED25519 hostkey
+        # on first start when the directory is empty.
+        - name: hostkey
+          hostPath:
+            path: /var/lib/brainstorm-sish/hostkeys
+            type: DirectoryOrCreate
 ---
 # NodePort Service — exposes the SSH endpoint on every node at :32223 so
 # `ssh -R` from the operator's laptop has a stable target. The HTTP port

--- a/tests/local/NFA-12.bats
+++ b/tests/local/NFA-12.bats
@@ -9,8 +9,6 @@
 # SealedSecret) and a persistent SSH hostkey is wired up so known_hosts
 # stays valid across pod restarts.
 
-load ../unit/lib/bats-assert.bash
-
 CTX="${BRAINSTORM_CTX:-mentolder}"
 NS="${BRAINSTORM_NS:-workspace}"
 CM="brainstorm-sish-authorized-keys"
@@ -55,12 +53,12 @@ setup() {
   echo "$VOLS" | tr ' ' '\n' | grep -qE '^(hostkey|hostkeys|ssh-host-keys)$'
 }
 
-# T3: task brainstorm:_materialise-keys must be invokable from CLI
+# T3: task brainstorm:materialise-keys must be invokable from CLI
 #     (skill documents direct invocation; internal: true breaks that).
-@test "NFA-12 T3: brainstorm:_materialise-keys is invokable from CLI" {
+@test "NFA-12 T3: brainstorm:materialise-keys is invokable from CLI" {
   cd "$BATS_TEST_DIRNAME/../.."
   command -v task >/dev/null || skip "go-task required"
-  run task --summary brainstorm:_materialise-keys 2>&1
+  run task --summary brainstorm:materialise-keys 2>&1
   # internal tasks are rejected by go-task with "Task X is internal"
   ! echo "$output" | grep -q 'is internal'
 }


### PR DESCRIPTION
## Summary

Three independent fixes that together make `dev-flow-plan`'s brainstorm visual-companion come up reliably:

1. **ArgoCD no longer reverts `brainstorm-sish-authorized-keys`** — added per-resource `ignoreDifferences` on `.data` so the CM is treated as operator-managed (it's populated by `task brainstorm:materialise-keys` from the sealed `DEV_SISH_AUTHORIZED_KEYS`).
2. **sish hostkey persists across pod restarts** — mounted `/etc/sish-hostkey` from a `hostPath` on `gekko-hetzner-2` (the deployment is already `nodeSelector`-pinned there). Operators no longer have to clear `~/.ssh/known_hosts` after every rollout.
3. **`brainstorm:_materialise-keys` is no longer `internal: true`** — renamed to `brainstorm:materialise-keys` and added a `brainstorm:setup` umbrella that ties it together with `firewall:open`. The dev-flow-plan skill called the internal name and silently failed.

## Test plan

- [x] NFA-12 baseline (before any fix): T1/T2/T3 all FAIL
- [x] After Task 2 commit: T3 PASS (`brainstorm:materialise-keys is invokable from CLI`)
- [x] After Task 3 commit: T1 PASS (`ArgoCD does not revert brainstorm-sish authorized_keys` — verified with the live mentolder cluster, CM stayed populated through the 60s window)
- [ ] T2 (`brainstorm-sish persists SSH hostkey across restarts`) — currently FAILs in live cluster because ArgoCD reverts the deployment manifest back to git/main until this PR is merged. Manifest verified offline via `kustomize build` / `envsubst`: deployment renders with `--private-keys-directory=/etc/sish-hostkey`, `volumeMount: hostkey → /etc/sish-hostkey`, `volume: hostkey → hostPath /var/lib/brainstorm-sish/hostkeys (DirectoryOrCreate)`. Re-run `bats tests/local/NFA-12.bats` after merge to confirm T2 passes against live state.
- [x] Manual smoke during Task 3 verify: `task brainstorm:materialise-keys ENV=mentolder` → CM materialised → 60s wait → CM still populated → SSH tunnel auth would succeed.

Closes T000380.