### PR TITLE
chore(llm): add LM Studio as parallel chat backend

### DIFF
--- a/k3d/llm-gpu.yaml
+++ b/k3d/llm-gpu.yaml
@@ -1,9 +1,10 @@
 # ─────────────────────────────────────────────────────────────────────────────
-# llm-gpu: external GPU peer (TEI embed, TEI rerank, Ollama chat)
+# llm-gpu: external GPU peer (TEI embed, TEI rerank, Ollama chat, LM Studio chat)
 #
-# The GPU box runs on the wg-mesh overlay. Three Services + Endpoints route
+# The GPU box runs on the wg-mesh overlay. Four Services + Endpoints route
 # traffic to it from inside the cluster. ${LLM_HOST_IP} is filled by envsubst
-# at deploy time from environments/<env>.yaml.
+# at deploy time from environments/<env>.yaml. Ollama (11434) and LM Studio
+# (1234) run side-by-side as parallel OpenAI-compatible chat backends.
 # ─────────────────────────────────────────────────────────────────────────────
 
 # ── Embeddings (TEI bge-m3) ──────────────────────────────────────────────────
@@ -71,3 +72,25 @@ subsets:
     ports:
       - name: http
         port: 11434
+---
+# ── Chat (LM Studio — parallel OpenAI-compatible backend) ────────────────────
+apiVersion: v1
+kind: Service
+metadata:
+  name: llm-gateway-lmstudio
+spec:
+  ports:
+    - name: http
+      port: 1234
+      targetPort: 1234
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: llm-gateway-lmstudio
+subsets:
+  - addresses:
+      - ip: ${LLM_HOST_IP}
+    ports:
+      - name: http
+        port: 1234

--- a/k3d/llm-router.yaml
+++ b/k3d/llm-router.yaml
@@ -57,6 +57,36 @@ data:
           api_base: http://llm-gateway-chat:11434
           timeout: 30
 
+      # ── LM Studio chat backend (parallel to Ollama, OpenAI-compatible) ────
+      # Named Qwen aliases — adjust the right-hand `model:` to the exact ID
+      # that `curl http://${LLM_HOST_IP}:1234/v1/models` reports.
+      - model_name: lmstudio-code-14b
+        litellm_params:
+          model: openai/qwen2.5-coder-14b-instruct
+          api_base: http://llm-gateway-lmstudio:1234/v1
+          api_key: "lm-studio"
+          timeout: 60
+      - model_name: lmstudio-code-7b
+        litellm_params:
+          model: openai/qwen2.5-coder-7b-instruct
+          api_base: http://llm-gateway-lmstudio:1234/v1
+          api_key: "lm-studio"
+          timeout: 60
+      - model_name: lmstudio-reasoning-14b
+        litellm_params:
+          model: openai/qwen3-14b
+          api_base: http://llm-gateway-lmstudio:1234/v1
+          api_key: "lm-studio"
+          timeout: 60
+      # Passthrough: callers using `lmstudio/<any-model>` are forwarded
+      # verbatim, so swapping models inside LM Studio needs no ConfigMap roll.
+      - model_name: lmstudio/*
+        litellm_params:
+          model: openai/*
+          api_base: http://llm-gateway-lmstudio:1234/v1
+          api_key: "lm-studio"
+          timeout: 60
+
     litellm_settings:
       drop_params: true
       set_verbose: false


### PR DESCRIPTION
## Summary
- New `llm-gateway-lmstudio` Service+Endpoints (port 1234) → LM Studio on the wg-mesh GPU host, side-by-side with Ollama
- LiteLLM router gains three named Qwen aliases (`lmstudio-code-14b`, `lmstudio-code-7b`, `lmstudio-reasoning-14b`) + passthrough `lmstudio/*` for runtime model swaps without ConfigMap rolls
- Additive only — Ollama paths (`workspace-chat`, `workspace-code`, `workspace-vision`, `workspace-fast`) untouched

## Test plan
- [x] `task workspace:validate` — server-side dry-run on full prod overlay, all resources green
- [ ] Post-merge: `task llm:deploy ENV=mentolder` then `ENV=korczewski` (or wait for ArgoCD sync; CMP envsubsts `${LLM_HOST_IP}` from cluster annotation)
- [ ] Verify reachability: `kubectl exec -n workspace deploy/llm-router -- curl -s http://llm-gateway-lmstudio:1234/v1/models`
- [ ] Verify routing: `curl -H "Authorization: Bearer sk-llm-router-internal" http://llm-router.workspace:4000/v1/models | grep lmstudio`

## Notes
- The named Qwen `model:` IDs in `litellm-config` (e.g. `qwen2.5-coder-14b-instruct`) assume LM Studio reports them with that exact slug. If `/v1/models` reports different IDs (e.g. HF repo paths), update those lines — or just use the `lmstudio/<exact-id>` passthrough.
- LM Studio must be enabled to serve on the wg-mesh interface (not just localhost) for in-cluster pods to reach it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)