### PR TITLE
feat(brett): jump (space) + bounce-on-collision für figuren [T000397]

### DIFF
--- a/brett/public/index.html
+++ b/brett/public/index.html
@@ -140,7 +140,7 @@
   <script src="three.min.js"></script>
   <script>
     // ===== Brett Mannequin Focus =====
-    window.STATE = { figures: [], selectedId: null, stiffness: 0.65, online: 1 };
+    window.STATE = { figures: [], selectedId: null, hoveredId: null, stiffness: 0.65, online: 1 };
 
     const renderer = new THREE.WebGLRenderer({ antialias: true });
     renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
@@ -220,6 +220,12 @@
     'lShoulder','rShoulder','lElbow','rElbow','lWrist','rWrist',
     'lHip','rHip','lKnee','rKnee','lAnkle','rAnkle'
   ];
+  const BODY_RADIUS = 0.30;
+  const JUMP_V0 = 4.5;
+  const GRAVITY = 12.0;
+  const BOUNCE_K_DRAG = 6.0;
+  const BOUNCE_K_LAND = 9.0;
+  const COLLISION_MAX_ITER = 3;
   const CONTACT_POINTS = [
     { bone:'lWrist', color:0xffd84a }, { bone:'rWrist', color:0xffd84a },
     { bone:'lAnkle', color:0x6be0a0 }, { bone:'rAnkle', color:0x6be0a0 },
@@ -317,6 +323,10 @@
       label: 'Figur',
       color: '#b8c0a8',
       facingY: 0,
+      jumping: false,
+      jumpV: 0,
+      jumpY: 0,
+      _lastCollisionCheck: 0,
     };
   }
 
@@ -563,7 +573,62 @@
           }
         }
       }
-      if (minY < 0) fig.root.position.y -= minY; // lift onto floor
+      if (fig.jumping) {
+        fig.jumpY += fig.jumpV * dt;
+        fig.jumpV -= GRAVITY * dt;
+        if (fig.jumpY <= 0) {
+          fig.jumpY = 0;
+          fig.jumpV = 0;
+          fig.jumping = false;
+          resolveCollisions(fig, BOUNCE_K_LAND); // Landungs-Impact
+        }
+        fig.root.position.y = fig.jumpY;
+      } else if (minY < 0) {
+        fig.root.position.y -= minY; // lift onto floor
+      }
+    }
+  }
+
+  function startJump(fig) {
+    fig.jumping = true;
+    fig.jumpV = JUMP_V0;
+    fig.jumpY = 0;
+  }
+
+  function resolveCollisions(movedFig, impulseK) {
+    for (let iter = 0; iter < COLLISION_MAX_ITER; iter++) {
+      let resolved = false;
+      for (const other of STATE.figures) {
+        if (other === movedFig) continue;
+        const dx = other.root.position.x - movedFig.root.position.x;
+        const dz = other.root.position.z - movedFig.root.position.z;
+        const dist = Math.sqrt(dx*dx + dz*dz);
+        const minDist = 2 * BODY_RADIUS;
+        if (dist >= minDist || dist === 0) continue;
+        const nx = dx / dist, nz = dz / dist;
+        const overlap = minDist - dist + 0.02;
+        other.root.position.x += nx * overlap;
+        other.root.position.z += nz * overlap;
+        for (const name of BONE_NAMES) {
+          other.bone[name].velocity.x += impulseK * nx;
+          other.bone[name].velocity.z += impulseK * nz;
+        }
+        sendMove(other.id, other.root.position.x, other.root.position.z, other.facingY);
+        resolved = true;
+      }
+      if (!resolved) break;
+    }
+  }
+
+  function sendMove(figId, x, z, facingY) {
+    if (typeof ws !== 'undefined' && ws && ws.readyState === WebSocket.OPEN) {
+      ws.send(JSON.stringify({ type: 'move', id: figId, x, z, facingY: facingY ?? 0 }));
+    }
+  }
+
+  function sendJump(figId) {
+    if (typeof ws !== 'undefined' && ws && ws.readyState === WebSocket.OPEN) {
+      ws.send(JSON.stringify({ type: 'jump', id: figId }));
     }
   }
 
@@ -686,7 +751,12 @@
   });
 
   window.addEventListener('mousemove', (e) => {
-    if (!dragging) return;
+    if (!dragging) {
+      // Hover-Tracking für Space-Jump-Fallback
+      const fig = pickMannequinBody(e);
+      STATE.hoveredId = fig ? fig.id : null;
+      return;
+    }
     setNdc(e);
     raycaster.setFromCamera(ndc, camera);
     const target = new THREE.Vector3();
@@ -696,6 +766,11 @@
     if (!fig) return;
     ccdIK(fig, dragging.boneName, target, 6);
     sendUpdate(fig, { boneOverrides: fig.boneOverrides });
+    const now = performance.now();
+    if (now - (fig._lastCollisionCheck || 0) > 33) {
+      fig._lastCollisionCheck = now;
+      resolveCollisions(fig, BOUNCE_K_DRAG);
+    }
   });
 
   window.addEventListener('mouseup', () => {
@@ -755,6 +830,19 @@
     } else {
       addFigure({ x: floorPt.x, z: floorPt.z });
     }
+  });
+
+  document.addEventListener('keydown', (e) => {
+    if (e.code !== 'Space') return;
+    const tag = (e.target && e.target.tagName) || '';
+    if (tag === 'INPUT' || tag === 'TEXTAREA' || e.target?.isContentEditable) return;
+    const id = STATE.selectedId || STATE.hoveredId;
+    if (!id) return;
+    const fig = STATE.figures.find(f => f.id === id);
+    if (!fig || fig.jumping) return;
+    e.preventDefault();
+    startJump(fig);
+    sendJump(fig.id);
   });
 
   window.addEventListener('keydown', (e) => {
@@ -839,6 +927,7 @@
           const diff = ((want - fig.facingY + Math.PI*3) % (Math.PI*2)) - Math.PI;
           fig.facingY += Math.max(-TURN_RATE*dt, Math.min(TURN_RATE*dt, diff));
           fig.root.rotation.y = fig.facingY;
+          resolveCollisions(fig, BOUNCE_K_DRAG);
         }
       }
       // Click-to-walk target
@@ -857,6 +946,7 @@
           fig.facingY += Math.max(-TURN_RATE*dt, Math.min(TURN_RATE*dt, diff));
           fig.root.rotation.y = fig.facingY;
           fig.walking = true;
+          resolveCollisions(fig, BOUNCE_K_DRAG);
         } else {
           fig.walking = false;
         }
@@ -875,7 +965,7 @@
     if (dragging) { pillEl.textContent = '● Drag … · Loslassen = resume'; return; }
     if (!fig) { pillEl.textContent = 'Klick = Figur wählen · Doppelklick Boden = neue Figur hinzufügen'; return; }
     if (fig.walking) { pillEl.textContent = '→ Ziel … · Klick = neues Ziel · Doppelklick = Teleport · ESC = stop'; return; }
-    pillEl.textContent = '🚶 WASD/↑↓←→ = laufen · Shift = Sprint · Klick Boden = Ziel · Tab = nächste';
+    pillEl.textContent = '🚶 WASD/↑↓←→ = laufen · Shift = Sprint · Space = Sprung · Klick Boden = Ziel · Tab = nächste';
   }
 
   // ----- WebSocket sync -----
@@ -944,6 +1034,12 @@
         if (!fig) break;
         fig.root.position.x = msg.x; fig.root.position.z = msg.z;
         if (typeof msg.facingY === "number") { fig.facingY = msg.facingY; fig.root.rotation.y = fig.facingY; }
+        resolveCollisions(fig, BOUNCE_K_DRAG);
+        break;
+      }
+      case "jump": {
+        const fig = STATE.figures.find(f => f.id === msg.id);
+        if (fig && !fig.jumping) startJump(fig);
         break;
       }
       case "delete": {

--- a/brett/server.js
+++ b/brett/server.js
@@ -310,10 +310,8 @@ function applyMutation(room, msg) {
         figs.set('__stiffness__', { id: '__stiffness__', value: msg.value });
       }
       break;
-    case 'stiffness':
-      if (typeof msg.value === 'number') {
-        figs.set('__stiffness__', { id: '__stiffness__', value: msg.value });
-      }
+    case 'jump':
+      // transient — no persisted state
       break;
   }
 }
@@ -389,12 +387,12 @@ wss.on('connection', (ws) => {
       const room = ws._room;
       if (!room) return;
 
-      if (['add','move','update','delete','clear','optik','stiffness'].includes(msg.type)) {
+      if (['add','move','update','delete','clear','optik','stiffness','jump'].includes(msg.type)) {
         applyMutation(room, msg);
         broadcast(room, msg, ws);
         if (msg.type === 'clear') {
           flushImmediate(room).catch(err => console.error('[brett] flush:', err));
-        } else {
+        } else if (msg.type !== 'jump') {
           schedulePersist(room);
         }
       }

--- a/docs/superpowers/plans/2026-05-15-brett-jump-collision.md
+++ b/docs/superpowers/plans/2026-05-15-brett-jump-collision.md
@@ -1,0 +1,196 @@
+---
+ticket_id: T000397
+title: Brett Jump + Collision — Implementation Plan
+domains: []
+status: active
+pr_number: null
+---
+
+# Brett Jump + Collision — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add Spring-Mechanik (Leertaste) und Inter-Figur-Kollision mit Impuls-Bounce in `brett/public/index.html`, mit Sync via neuem `jump`-Event über den bestehenden `brett/server.js` WebSocket.
+
+**Spec:** [`docs/superpowers/specs/2026-05-15-brett-jump-collision-design.md`](../specs/2026-05-15-brett-jump-collision-design.md).
+
+**Tech-Stack:** Vanilla Three.js (geladen über `three.min.js`), bestehender Bone-Spring-Loop, Node.js + `ws` Server, Postgres-persisted Brett-State (unverändert).
+
+---
+
+## Task 1 — Konstanten + Figur-State erweitern
+
+**Datei:** `brett/public/index.html`
+
+- [ ] Konstanten-Block einfügen (am Anfang von `<script>`, direkt nach `BONE_NAMES`):
+  ```js
+  const BODY_RADIUS = 0.30;
+  const JUMP_V0 = 4.5;
+  const GRAVITY = 12.0;
+  const BOUNCE_K_DRAG = 6.0;
+  const BOUNCE_K_LAND = 9.0;
+  const COLLISION_MAX_ITER = 3;
+  ```
+- [ ] In `makeMannequin()` (Line 309 ff.) im zurückgegebenen Objekt zusätzlich:
+  ```js
+  jumping: false,
+  jumpV: 0,
+  jumpY: 0,
+  ```
+
+## Task 2 — Jump-Trigger (Leertaste)
+
+**Datei:** `brett/public/index.html`
+
+- [ ] Globaler Keydown-Listener (nach dem bestehenden `addEventListener('click', …)`-Block für Panel-Toggle, ≈ Line 405):
+  ```js
+  document.addEventListener('keydown', (e) => {
+    if (e.code !== 'Space') return;
+    const tag = (e.target && e.target.tagName) || '';
+    if (tag === 'INPUT' || tag === 'TEXTAREA' || e.target?.isContentEditable) return;
+    const id = STATE.selectedId || STATE.hoveredId;
+    if (!id) return;
+    const fig = STATE.figures.find(f => f.id === id);
+    if (!fig || fig.jumping) return;
+    e.preventDefault();
+    startJump(fig);
+    sendJump(fig.id);
+  });
+  ```
+- [ ] `STATE.hoveredId` initialisieren (Line 143): `window.STATE = { figures: [], selectedId: null, hoveredId: null, stiffness: 0.65, online: 1 };`
+- [ ] Im Hover-Handler des bestehenden Pointermove-Codes `STATE.hoveredId` setzen (suche `hits = raycaster.intersectObject(fig.root, true)` ≈ Line 615).
+
+## Task 3 — Jump-Animation im Frame-Loop
+
+**Datei:** `brett/public/index.html`
+
+- [ ] `function startJump(fig)` einfügen (vor dem Frame-Loop ≈ Line 525):
+  ```js
+  function startJump(fig) {
+    fig.jumping = true;
+    fig.jumpV = JUMP_V0;
+    fig.jumpY = 0;
+  }
+  ```
+- [ ] Im Frame-Loop (Line 531 ff.) **vor** dem Floor-Clamp `if (minY < 0) …` einfügen:
+  ```js
+  if (fig.jumping) {
+    fig.jumpY += fig.jumpV * dt;
+    fig.jumpV -= GRAVITY * dt;
+    if (fig.jumpY <= 0) {
+      fig.jumpY = 0;
+      fig.jumpV = 0;
+      fig.jumping = false;
+      resolveCollisions(fig, BOUNCE_K_LAND); // Landungs-Impact
+    }
+    fig.root.position.y = fig.jumpY;
+  }
+  ```
+- [ ] Floor-Clamp (Line 566) modifizieren: nur greifen wenn `!fig.jumping`.
+
+## Task 4 — Collision-Resolution
+
+**Datei:** `brett/public/index.html`
+
+- [ ] `function resolveCollisions(movedFig, impulseK)` einfügen (nahe dem Spring-Block, ≈ Line 525):
+  ```js
+  function resolveCollisions(movedFig, impulseK) {
+    for (let iter = 0; iter < COLLISION_MAX_ITER; iter++) {
+      let resolved = false;
+      for (const other of STATE.figures) {
+        if (other === movedFig) continue;
+        const dx = other.root.position.x - movedFig.root.position.x;
+        const dz = other.root.position.z - movedFig.root.position.z;
+        const dist = Math.sqrt(dx*dx + dz*dz);
+        const minDist = 2 * BODY_RADIUS;
+        if (dist >= minDist || dist === 0) continue;
+        const nx = dx / dist, nz = dz / dist;
+        const overlap = minDist - dist + 0.02;
+        other.root.position.x += nx * overlap;
+        other.root.position.z += nz * overlap;
+        // Bone-Impuls
+        for (const name of BONE_NAMES) {
+          other.bone[name].velocity.x += impulseK * nx;
+          other.bone[name].velocity.z += impulseK * nz;
+        }
+        // Broadcast neue Position
+        sendMove(other.id, other.root.position.x, other.root.position.z);
+        resolved = true;
+      }
+      if (!resolved) break;
+    }
+  }
+  ```
+- [ ] Im Drag-Handler (≈ Line 695, wo `fig.root.position.x = …` während Drag passiert) nach jeder Position-Änderung `resolveCollisions(fig, BOUNCE_K_DRAG)` aufrufen — aber gedrosselt auf ~30 Hz via `if (now - fig._lastCollisionCheck > 33) { … }`.
+- [ ] Nach Walk-Tween-Schritt (Line 736-737) ebenfalls `resolveCollisions(fig, BOUNCE_K_DRAG)`.
+
+## Task 5 — Network: Send-Helpers + Jump-Event
+
+**Datei:** `brett/public/index.html`
+
+- [ ] Suche nach bestehendem `sendMove` o.ä. Helper (`grep -n 'ws.send\|wsSend' brett/public/index.html`). Wenn keine `sendJump`-Funktion existiert, neue Helper neben den anderen anlegen:
+  ```js
+  function sendJump(figId) {
+    if (ws && ws.readyState === WebSocket.OPEN) {
+      ws.send(JSON.stringify({ type: 'jump', id: figId }));
+    }
+  }
+  ```
+- [ ] Im WS-`onmessage`-Handler (suche `case 'move'` analog) Case ergänzen:
+  ```js
+  case 'jump': {
+    const fig = STATE.figures.find(f => f.id === msg.id);
+    if (fig && !fig.jumping) startJump(fig);
+    break;
+  }
+  ```
+- [ ] Bei eingehendem `move`-Event nach dem Anwenden zusätzlich `resolveCollisions(fig, BOUNCE_K_DRAG)` aufrufen, damit auch Empfänger-Clients lokal kippen sehen.
+
+## Task 6 — Server: Jump-Event akzeptieren + broadcasten
+
+**Datei:** `brett/server.js`
+
+- [ ] In der Liste der erlaubten Mutation-Types (Line 392) `'jump'` ergänzen:
+  ```js
+  if (['add','move','update','delete','clear','optik','stiffness','jump'].includes(msg.type)) {
+  ```
+- [ ] In `applyMutation` keinen State-Eintrag schreiben für `jump` — Event ist transient. Einfach `case 'jump': break;` am Ende des `switch`.
+- [ ] Stelle sicher dass `broadcast(room, msg, ws)` (Line 394) wie heute weiterläuft — keine Änderung nötig, das `jump`-Event geht so an alle anderen Clients.
+
+## Task 7 — UI-Hinweis (Nice-to-have)
+
+**Datei:** `brett/public/index.html`
+
+- [ ] Im Figur-Panel (`#fig-panel`) eine kleine Zeile "**Space** = Sprung" als `<small>` nahe den Preset-Buttons einfügen. Wenn die Stelle nicht offensichtlich ist, in einem Kommentar als Follow-up markieren statt blind anzunehmen.
+
+## Task 8 — Tests + Verifikation
+
+- [ ] Lokal: `task brett:build` (importiert Image in k3d) erfolgreich.
+- [ ] Lokal: `task workspace:validate` bleibt grün.
+- [ ] Manuelle Smoke-Tests (in zwei Browsern, gleicher Raum):
+  - Selektiere Figur A, drücke Leertaste → A springt sichtbar.
+  - Drücke Leertaste über A, während A direkt neben B steht → bei Landung wird B verschoben und schlackert.
+  - Ziehe A langsam in B hinein → B wird sanft weggeschoben (kein Hard-Stop, keine Überlappung dauerhaft).
+  - Im zweiten Browser sind beide Aktionen sichtbar.
+- [ ] Performance-Check in der Browser-DevTools-Console (200 Figuren): Frame-Time bleibt < 16 ms.
+- [ ] Smoke gegen Production: nach `task feature:brett` einmal `https://brett.mentolder.de` und `https://brett.korczewski.de` öffnen, dasselbe testen.
+
+## Task 9 — PR
+
+- [ ] PR-Titel: `feat(brett): jump (space) + bounce-on-collision für figuren [TICKET_ID]`
+- [ ] PR-Body: 2-Bullet-Summary + Test plan (was manuell getestet wurde).
+- [ ] Squash-Merge nach grünem CI.
+
+## Task 10 — Post-Merge Deploy
+
+- [ ] `task feature:brett` (rebuild + roll auf mentolder + korczewski).
+- [ ] Verify: beide Brett-URLs im Browser, Jump+Collision funktioniert.
+
+---
+
+## Out-of-Scope / Follow-Ups
+
+- Sound-FX für Sprung und Bounce.
+- Charge-Jump / Double-Jump.
+- Wand/Boundary-Kollision (Brett hat heute keine Wände — separate Design-Frage).
+- Friction-Modell für Bounce (heute: Empfänger stoppt sofort).

--- a/docs/superpowers/specs/2026-05-15-brett-jump-collision-design.md
+++ b/docs/superpowers/specs/2026-05-15-brett-jump-collision-design.md
@@ -1,0 +1,76 @@
+# Brett: Jump + Collision für Figuren — Design
+
+**Datum:** 2026-05-15
+**Branch:** `feature/brett-jump-collision`
+**Pfad:** feature
+**Path-Wahl-Begründung:** Neues, für Nutzer sichtbares Verhalten (Sprung-Mechanik + Inter-Figur-Kollision) in `brett.${PROD_DOMAIN}`.
+
+## Intent
+
+Brett-Figuren (Mannequins) bekommen zwei neue Verhalten:
+
+1. **Jump:** Selektierte/hovered Figur springt parabolisch (Leertaste-Trigger).
+2. **Collision (Bounce mit Impuls):** Figuren kollidieren beim Bewegen und beim Landen — angerempelte Figuren werden weggestoßen und kippen sichtbar (Bone-Impuls).
+
+Beide Verhalten sind über den bestehenden Brett-WebSocket (`brett/server.js`) zwischen allen Teilnehmern eines Raums synchronisiert.
+
+## User-Story
+
+> Als Coach im Systembrett-Raum möchte ich eine Figur per Leertaste springen lassen und sehe, wie sie beim Landen eine benachbarte Figur anrempelt, die daraufhin wegrollt und kurz schlackert — damit Bewegung in der Aufstellung erlebbar wird, statt nur statisches Repositionieren per Drag.
+
+## Funktionale Anforderungen
+
+### Jump
+- Trigger: `Space` (Keydown), wenn `STATE.selectedId` gesetzt ist **und** kein Input/Textarea fokussiert ist.
+- Verhalten: einzelner Sprung (kein Hold-to-charge, kein Double-Jump).
+- Physik: parabolisch, lokale Variable pro Figur (`jumpV`, `jumpY` in `fig`).
+  - `v0 = 4.5 m/s`, `g = 12 m/s²` → Höhe ≈ 0.85, Dauer ≈ 0.75 s.
+  - Pro Frame: `jumpY += jumpV * dt; jumpV -= g * dt; if (jumpY <= 0) { jumpY=0; jumpV=0; jumping=false; }`
+- Während Flug: keine erneute Drag-Move-Verarbeitung für diese Figur. Bone-Stiffness bleibt unverändert (Klassik-Variante laut Brainstorming).
+- Visualisierung: `root.position.y = baseY + jumpY` (statt der bestehenden Floor-Clamp-Logik bei Line 566).
+
+### Collision (Inter-Figur)
+- Geometrie: jede Figur ist ein vertikaler Zylinder im XZ-Plane mit Radius `BODY_RADIUS = 0.30` (≈ Schulterbreite des Mannequins).
+- Detektion: pro Frame, pairwise (n²/2). Bei `n ≤ 200` (server-cap) ist das ~20k Vergleiche — vertretbar.
+- Auslöser für Bounce:
+  1. Drag — wenn die geraderaiselbe Drag-Bewegung zwei Figuren überlappen würde.
+  2. Landung — wenn der Lande-Footprint (XZ-Position bei `jumpY → 0`) eine andere Figur überlappt.
+- Impuls-Modell:
+  - Separation-Vektor: `n = (B.pos - A.pos)` normalisiert in XZ.
+  - Overlap: `o = 2*BODY_RADIUS - |B.pos - A.pos|`.
+  - Position-Korrektur: angreifende Figur stoppt; getroffene Figur wird um `o + 0.02` entlang `n` verschoben.
+  - Kipp-Impuls: alle Bones der getroffenen Figur bekommen `velocity.x += K * n.x`, `velocity.z += K * n.z` mit `K = 6.0` (Tunable). Das nutzt den existierenden Bone-Springer-Loop (`brett/public/index.html:516-549`) — keine neue Physics-Schleife.
+  - Bei Landungs-Impact: zusätzlich `K_LAND = 9.0` (stärker als Drag-Push).
+- Cascade: wenn die getroffene Figur durch die Position-Korrektur eine dritte berührt, wird in derselben Iteration weiterpropagiert (max. 3 Iterationen pro Frame, dann clip).
+
+### Netzwerk-Sync
+- **Neues Event `jump`:** Client sendet `{ type: 'jump', id: '<figId>' }` beim Trigger. Server broadcastet an Raum (nicht persistiert — Jump ist transient).
+- **Bestehende `move`-Messages** werden während Drag und nach Bounce gesendet (wie heute), führen auf Empfängerseite zusätzlich zum Kipp-Impuls auf benachbarte Figuren (lokale Collision-Resolution auf jedem Client).
+- **Authoritative Position:** der Anstoßende sendet `move` für die getroffene Figur(en). Der Server-State (`figureMaps`) übernimmt das letzte `move`. Race-Conditions (zwei Clients schubsen gleichzeitig) sind akzeptabel — last-write-wins, das ist konsistent mit dem heutigen Verhalten.
+
+## Nicht-Ziele
+
+- Kein Wand-/Floor-Kollisionssystem (Floor-Y bleibt existierend, Brett hat keine Wände).
+- Kein Friction-/Rolling-Model: getroffene Figur stoppt sofort nach Position-Korrektur.
+- Kein Charge-Jump, kein Mehrfach-Bounce des Springers (nur eine Parabel).
+- Kein Sound-FX (separater Feature-Wunsch).
+
+## Akzeptanzkriterien
+
+1. Selektierte Figur springt bei Leertaste sichtbar (Höhe ≥ 0.5 Einheiten, Dauer 0.5–1.0 s).
+2. Springende Figur landet wieder auf `y=0` und friert nicht in der Luft.
+3. Lädt die Figur direkt über eine andere, wird die getroffene um ≥ `2*BODY_RADIUS` versetzt **und** die Bones kippen sichtbar (>0.1 rad max amplitude) für >0.3 s.
+4. Im zweiten Browser (gleicher Raum) sieht man dieselbe Animation samt Bounce-Versatz innerhalb von <500 ms.
+5. Keine Figur überlappt nach Drag-Stop dauerhaft mit einer anderen (Position-Korrektur ist persistent).
+6. `task brett:build` und `task test:all` bleiben grün.
+
+## Risiken
+
+- **Race-Condition bei gleichzeitigem Bounce zweier Clients:** akzeptiert als last-write-wins. Würde bei häufigem Bounce-Spam zu Jitter führen — Tunable: niedrigere Throttle-Frequenz für Bounce-Moves (z.B. 30 Hz statt jeder Frame).
+- **n²-Kollisions-Check bei vielen Figuren:** bei 200 Figuren ≈ 20k Distanzen/Frame. Auf Modern Hardware unkritisch, sollte aber gemessen werden (`performance.now()`).
+- **Browser-Event-Fokus:** Leertaste kollidiert mit Scroll-Verhalten. Lösung: `preventDefault()` wenn Brett-Canvas Fokus hat oder kein Input fokussiert.
+
+## Offene Fragen
+
+- Soll auch eine **nicht-selektierte, aber gehoverte** Figur springen? Brainstorming-Antwort war "während Hover/Selection" — wir implementieren beide, mit Selection als Priorität (Hover als Fallback).
+- Visualisierungs-Hint im UI, dass Space springt? → kurzer Tooltip "Space = Sprung" am Figur-Panel. Nice-to-have, nicht akzeptanzkritisch.


### PR DESCRIPTION
## Summary
- **Space-Sprung** für die selektierte (oder gehoverte) Figur — Parabel-Bahn via `JUMP_V0`/`GRAVITY`, Landungs-Impact löst Kollision aus.
- **Inter-Figur-Kollision**: Kreis-AABB (`BODY_RADIUS=0.30`), Overlap-Resolution mit iterativem Push + Bone-Impuls für sichtbares Schlackern beim Reinlaufen oder Auflanden.
- **Sync** via neuem transientem `jump`-WS-Event (broadcast-only, kein Persist im Server-State).

## Test plan
- [x] `task test:all` grün
- [x] `task workspace:validate` grün
- [x] `node --check brett/server.js` + Inline-JS-Syntaxcheck in `index.html`
- [ ] Manueller Smoke: zwei Browser im gleichen Raum, Figur A, Space → Sprung; Landung neben B → B wird verschoben + schlackert; Drag A in B hinein → B wird sanft weggeschoben.
- [ ] Performance-Check (200 Figuren, Frame-Time < 16 ms).

Closes T000397

🤖 Generated with [Claude Code](https://claude.com/claude-code)