### PR TITLE
fix(tickets): repair brand-FK SQL syntax + add is_test_data ALTER

### DIFF
--- a/website/src/lib/tickets-db.ts
+++ b/website/src/lib/tickets-db.ts
@@ -50,17 +50,21 @@ export async function initTicketsSchema(): Promise<void> {
       CONSTRAINT resolution_only_when_closed CHECK (
         (resolution IS NULL AND status NOT IN ('done','archived'))
         OR status IN ('done','archived')
-      );
-      DO $$
-      BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'tickets_brand_fkey') THEN
-          ALTER TABLE tickets.tickets ADD CONSTRAINT tickets_brand_fkey FOREIGN KEY (brand) REFERENCES public.brands(id) ON UPDATE CASCADE ON DELETE RESTRICT;
-        END IF;
-      END $$;
+      )
     )
   `);
 
+  await pool.query(`
+    DO $$
+    BEGIN
+      IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'tickets_brand_fkey') THEN
+        ALTER TABLE tickets.tickets ADD CONSTRAINT tickets_brand_fkey FOREIGN KEY (brand) REFERENCES public.brands(id) ON UPDATE CASCADE ON DELETE RESTRICT;
+      END IF;
+    END $$
+  `);
+
   await pool.query(`ALTER TABLE tickets.tickets ADD COLUMN IF NOT EXISTS notes TEXT`);
+  await pool.query(`ALTER TABLE tickets.tickets ADD COLUMN IF NOT EXISTS is_test_data BOOLEAN NOT NULL DEFAULT false`);
 
   await pool.query(`
     ALTER TABLE tickets.tickets


### PR DESCRIPTION
## Summary
- Phase 2 brands-FK migration (#a5e46671) inlined `DO $$ ... END $$;` inside the `CREATE TABLE tickets.tickets (...)` parens — invalid SQL, broke `initTicketsSchema()` on every load.
- Symptom on mentolder: `/admin/tickets` rendered "Datenbankfehler beim Laden der Tickets" because every `listAdminTickets` call awaited the failing schema init.
- Move the brand-FK ALTER into its own `pool.query()` so the CREATE TABLE stays well-formed.
- Add the long-missing `is_test_data BOOLEAN NOT NULL DEFAULT false` ALTER that admin filter queries (`t.is_test_data = false`) already referenced.

Live fix on mentolder also required restarting `shared-db` so the `subPath`-mounted `ensure-meetings-schema.sh` re-mounted with the brands DDL — that part is environmental, not code.

## Test plan
- [x] `task feature:website` rolls out on both clusters
- [x] `https://web.mentolder.de/admin/tickets` lists tickets without DB error
- [x] `https://web.korczewski.de/admin/tickets` still loads (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)