### PR TITLE
fix(brett): fix test runner — glob pattern, MOCK_DB guard, no-listen when required

### DIFF
--- a/brett/package.json
+++ b/brett/package.json
@@ -6,7 +6,7 @@
   "type": "commonjs",
   "scripts": {
     "start": "node server.js",
-    "test": "node --test test/"
+    "test": "node --test test/*.test.js"
   },
   "dependencies": {
     "express": "^4.22.1",

--- a/brett/server.js
+++ b/brett/server.js
@@ -215,7 +215,7 @@ app.use((err, _req, res, _next) => {
 
 const server = require.main === module
   ? app.listen(PORT, () => { console.log(`brett listening on :${PORT}`); })
-  : app.listen(0);
+  : (() => { const s = require('http').createServer(app); if (process.env.MOCK_DB !== 'true') s.listen(0); return s; })();
 
 // ─── WebSocket sync ──────────────────────────────────────────────
 const WebSocket = require('ws');

--- a/brett/test/server-mayhem.test.js
+++ b/brett/test/server-mayhem.test.js
@@ -1,4 +1,5 @@
 'use strict';
+process.env.MOCK_DB = 'true';
 const test = require('node:test');
 const assert = require('node:assert');
 const { applyMutation, buildStateFromMutations, RELAY_TYPES, lmsAlive, handleLmsDeath } = require('../server.js');


### PR DESCRIPTION
## Summary
- Fixes `npm test` in `brett/` which was broken: `node --test test/` resolves `test/` as a module and fails; changed to `test/*.test.js` glob
- Prevents test process from hanging: when `server.js` is `require()`d by tests, `app.listen(0)` kept the event loop alive; now uses an unbound `http.createServer` when `MOCK_DB=true`
- Sets `MOCK_DB=true` in `server-mayhem.test.js` before requiring `server.js` so the port-bind guard fires

The underlying mayhem feature (T000388) was already implemented in PR #778. This PR only fixes the test infrastructure so `npm test` passes cleanly with all 17 tests (9 physics + 8 server-mayhem) and exits.

## Test plan
- [x] `cd brett && npm test` — 17 tests pass, process exits (was hanging before)
- [x] `task workspace:validate` — manifest dry-run clean
- [x] `task test:all` — all offline tests pass

Closes T000388

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>