### PR TITLE
feat(coaching): KI-Provider-Profile + Klienten-Dropdown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,3 +126,4 @@ tests/unit/lib/bats-support/test/
 .gemini
 # docs-to-html plugin output
 docs-html-bundles/
+.worktrees/

--- a/docs/superpowers/plans/2026-05-16-ki-custom-provider.md
+++ b/docs/superpowers/plans/2026-05-16-ki-custom-provider.md
@@ -1,0 +1,1329 @@
+---
+ticket_id: T000418
+title: Custom KI-Anbieter Verwaltung — Implementation Plan
+domains: []
+status: active
+pr_number: null
+---
+
+# Custom KI-Anbieter Verwaltung — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Admin kann neue KI-Provider mit benutzerdefiniertem Namen und individuell wählbaren Parameterfeldern anlegen und löschen.
+
+**Architecture:** Die bestehende `coaching.ki_config`-Tabelle wird um `enabled_fields JSONB` erweitert; der `provider`-CHECK-Constraint wird entfernt, damit Custom-Provider-Slugs (`custom_*`) zulässig sind. DB-Layer, API und Svelte-UI werden um Create/Delete-Operationen ergänzt. Custom-Provider unterscheiden sich von Standard-Providern (claude/openai/mistral/lumo) nur durch den Prefix `custom_` im `provider`-Feld und durch ein nicht-NULL `enabled_fields`-Array.
+
+**Tech Stack:** PostgreSQL 16, TypeScript (Astro API Routes), Svelte 5 (runes), pg-mem (Tests), Vitest
+
+---
+
+**Worktree:** `/home/gekko/Bachelorprojekt/.worktrees/feature/coaching-ki-provider-profiles-und-klienten`
+**Branch:** `feature/coaching-ki-provider-profiles-und-klienten`
+**Ticket:** T000418
+
+## File Map
+
+| Datei | Änderung |
+|---|---|
+| `k3d/website-schema.yaml` | Neue Migration: CHECK-Constraint entfernen, `enabled_fields JSONB` hinzufügen |
+| `website/src/lib/coaching-ki-config-db.ts` | `enabledFields` zum Interface, `createKiProvider()`, `deleteKiProvider()` |
+| `website/src/lib/coaching-ki-config-db.test.ts` | Tests für neue Funktionen + Schema-Update |
+| `website/src/pages/api/admin/coaching/ki-config/index.ts` | POST-Handler hinzufügen |
+| `website/src/pages/api/admin/coaching/ki-config/[id].ts` | DELETE-Handler hinzufügen |
+| `website/src/components/admin/coaching/CoachingSettings.svelte` | `showField()` updaten, Anlegen-Formular, Löschen-Button |
+
+---
+
+## Task 1: DB-Migration — CHECK-Constraint entfernen + enabled_fields
+
+**Files:**
+- Modify: `k3d/website-schema.yaml` (nach Zeile 1047, vor Zeile 1049)
+
+Der `provider`-CHECK-Constraint (`provider IN ('claude','openai','mistral','lumo')`) ist inline mit CREATE TABLE definiert und hat einen auto-generierten Namen (`ki_config_provider_check`). Da `ALTER TABLE … DROP CONSTRAINT IF EXISTS` einen exakten Namen braucht, verwenden wir einen dynamischen DO-Block.
+
+- [ ] **Schritt 1: Migration im Schema einfügen**
+
+Öffne `k3d/website-schema.yaml`. Suche den Block der am Ende der KI-Provider-Migration liegt (nach Zeile 1047 `eu_endpoint`), und füge **vor** der Zeile `-- Per-Session KI-Auswahl` ein:
+
+```yaml
+      -- Custom KI-Anbieter: CHECK-Constraint entfernen + enabled_fields (idempotent)
+      DO $$
+      DECLARE v_con text;
+      BEGIN
+        SELECT c.conname INTO v_con
+        FROM pg_constraint c
+        JOIN pg_class t ON c.conrelid = t.oid
+        JOIN pg_namespace n ON t.relnamespace = n.oid
+        WHERE n.nspname = 'coaching' AND t.relname = 'ki_config'
+          AND c.contype = 'c' AND c.conname LIKE '%provider%'
+        LIMIT 1;
+        IF v_con IS NOT NULL THEN
+          EXECUTE 'ALTER TABLE coaching.ki_config DROP CONSTRAINT ' || quote_ident(v_con);
+        END IF;
+      END $$;
+      ALTER TABLE coaching.ki_config ADD COLUMN IF NOT EXISTS enabled_fields JSONB;
+```
+
+- [ ] **Schritt 2: Validierung (kein Cluster nötig)**
+
+```bash
+cd /home/gekko/Bachelorprojekt/.worktrees/feature/coaching-ki-provider-profiles-und-klienten
+task workspace:validate
+```
+
+Erwartung: `kustomize build` ohne Fehler.
+
+- [ ] **Schritt 3: Commit**
+
+```bash
+git add k3d/website-schema.yaml
+git commit -m "feat(coaching): drop provider CHECK, add enabled_fields for custom providers [T000418]"
+```
+
+---
+
+## Task 2: DB-Layer — Interface, createKiProvider, deleteKiProvider
+
+**Files:**
+- Modify: `website/src/lib/coaching-ki-config-db.ts`
+- Modify: `website/src/lib/coaching-ki-config-db.test.ts`
+
+- [ ] **Schritt 1: Failing-Tests schreiben**
+
+Öffne `website/src/lib/coaching-ki-config-db.test.ts`. Ersetze den gesamten Inhalt durch:
+
+```typescript
+import { describe, it, expect, beforeAll } from 'vitest';
+import { newDb } from 'pg-mem';
+import type { Pool } from 'pg';
+import {
+  listKiProviders, getActiveProvider, setActiveProvider,
+  updateKiProvider, createKiProvider, deleteKiProvider,
+  type KiConfig,
+} from './coaching-ki-config-db';
+
+let pool: Pool;
+
+beforeAll(async () => {
+  const db = newDb();
+  db.public.none(`
+    CREATE SCHEMA coaching;
+    CREATE TABLE coaching.ki_config (
+      id SERIAL PRIMARY KEY,
+      brand TEXT NOT NULL,
+      provider TEXT NOT NULL,
+      is_active BOOLEAN NOT NULL DEFAULT false,
+      model_name TEXT,
+      display_name TEXT NOT NULL,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      api_key TEXT,
+      api_endpoint TEXT,
+      temperature NUMERIC(5,3),
+      max_tokens INT,
+      top_p NUMERIC(5,3),
+      system_prompt TEXT,
+      notes TEXT,
+      top_k INT,
+      thinking_mode BOOLEAN NOT NULL DEFAULT false,
+      presence_penalty NUMERIC(5,3),
+      frequency_penalty NUMERIC(5,3),
+      safe_prompt BOOLEAN NOT NULL DEFAULT false,
+      random_seed INT,
+      organization_id TEXT,
+      eu_endpoint BOOLEAN NOT NULL DEFAULT false,
+      enabled_fields JSONB,
+      UNIQUE (brand, provider)
+    );
+    INSERT INTO coaching.ki_config (brand, provider, is_active, model_name, display_name)
+    VALUES
+      ('mentolder', 'claude',  true,  'claude-haiku', 'Claude'),
+      ('mentolder', 'openai',  false, 'gpt-4o-mini',  'ChatGPT'),
+      ('mentolder', 'mistral', false, null,            'Mistral'),
+      ('mentolder', 'lumo',    false, null,            'Lumo');
+  `);
+  const { Pool: PgMemPool } = db.adapters.createPg();
+  pool = new PgMemPool() as unknown as Pool;
+});
+
+describe('listKiProviders', () => {
+  it('gibt alle 4 Provider für eine Brand zurück', async () => {
+    const providers = await listKiProviders(pool, 'mentolder');
+    expect(providers).toHaveLength(4);
+    expect(providers.map(p => p.provider)).toContain('claude');
+  });
+});
+
+describe('getActiveProvider', () => {
+  it('gibt den aktiven Provider zurück', async () => {
+    const p = await getActiveProvider(pool, 'mentolder');
+    expect(p?.provider).toBe('claude');
+    expect(p?.isActive).toBe(true);
+  });
+
+  it('gibt null zurück wenn kein Provider aktiv', async () => {
+    const p = await getActiveProvider(pool, 'unknown-brand');
+    expect(p).toBeNull();
+  });
+});
+
+describe('setActiveProvider', () => {
+  it('wechselt aktiven Provider — genau einer aktiv', async () => {
+    await setActiveProvider(pool, 'mentolder', 'openai');
+    const active = await getActiveProvider(pool, 'mentolder');
+    expect(active?.provider).toBe('openai');
+    const all = await listKiProviders(pool, 'mentolder');
+    expect(all.filter(p => p.isActive)).toHaveLength(1);
+    await setActiveProvider(pool, 'mentolder', 'claude');
+  });
+
+  it('wirft Fehler bei unbekanntem Provider — aktiver bleibt erhalten', async () => {
+    await expect(
+      setActiveProvider(pool, 'mentolder', 'nonexistent'),
+    ).rejects.toThrow("Provider 'nonexistent' not found for brand 'mentolder'");
+    const active = await getActiveProvider(pool, 'mentolder');
+    expect(active).not.toBeNull();
+  });
+});
+
+describe('updateKiProvider', () => {
+  it('aktualisiert modelName und displayName eines Providers', async () => {
+    const before = await listKiProviders(pool, 'mentolder');
+    const mistral = before.find(p => p.provider === 'mistral')!;
+    await updateKiProvider(pool, mistral.id, { modelName: 'mistral-large', displayName: 'Mistral Large' });
+    const after = await listKiProviders(pool, 'mentolder');
+    const updated = after.find(p => p.provider === 'mistral')!;
+    expect(updated.modelName).toBe('mistral-large');
+    expect(updated.displayName).toBe('Mistral Large');
+  });
+
+  it('erlaubt modelName als null (Modell zurücksetzen)', async () => {
+    const providers = await listKiProviders(pool, 'mentolder');
+    const claude = providers.find(p => p.provider === 'claude')!;
+    await updateKiProvider(pool, claude.id, { modelName: null, displayName: 'Claude' });
+    const after = await listKiProviders(pool, 'mentolder');
+    expect(after.find(p => p.provider === 'claude')!.modelName).toBeNull();
+  });
+});
+
+describe('createKiProvider', () => {
+  it('legt neuen Custom-Provider an und gibt ihn zurück', async () => {
+    const p = await createKiProvider(pool, 'mentolder', {
+      displayName: 'Mein GPT',
+      provider: 'custom_my-gpt',
+      enabledFields: ['apiKey', 'apiEndpoint', 'temperature', 'systemPrompt'],
+    });
+    expect(p.provider).toBe('custom_my-gpt');
+    expect(p.displayName).toBe('Mein GPT');
+    expect(p.enabledFields).toEqual(['apiKey', 'apiEndpoint', 'temperature', 'systemPrompt']);
+    expect(p.isActive).toBe(false);
+  });
+
+  it('wirft Fehler bei Duplikat (brand + provider)', async () => {
+    await expect(
+      createKiProvider(pool, 'mentolder', {
+        displayName: 'Duplikat',
+        provider: 'custom_my-gpt',
+        enabledFields: [],
+      }),
+    ).rejects.toThrow();
+  });
+});
+
+describe('deleteKiProvider', () => {
+  it('löscht Custom-Provider', async () => {
+    const p = await createKiProvider(pool, 'mentolder', {
+      displayName: 'Zu löschen',
+      provider: 'custom_to-delete',
+      enabledFields: [],
+    });
+    await deleteKiProvider(pool, p.id);
+    const all = await listKiProviders(pool, 'mentolder');
+    expect(all.find(x => x.id === p.id)).toBeUndefined();
+  });
+
+  it('wirft Fehler beim Löschen eines Standard-Providers', async () => {
+    const all = await listKiProviders(pool, 'mentolder');
+    const claude = all.find(p => p.provider === 'claude')!;
+    await expect(deleteKiProvider(pool, claude.id)).rejects.toThrow('Nur Custom-Provider');
+  });
+});
+```
+
+- [ ] **Schritt 2: Tests laufen lassen — müssen FAIL mit "createKiProvider not found"**
+
+```bash
+cd website && pnpm test coaching-ki-config-db 2>&1 | tail -20
+```
+
+Erwartung: FAIL mit Import-Fehler (`createKiProvider` nicht exportiert).
+
+- [ ] **Schritt 3: DB-Layer implementieren**
+
+Öffne `website/src/lib/coaching-ki-config-db.ts`. Ersetze den gesamten Inhalt durch:
+
+```typescript
+import type { Pool } from 'pg';
+
+const KNOWN_PROVIDERS = new Set(['claude', 'openai', 'mistral', 'lumo']);
+
+export interface KiConfig {
+  id: number;
+  brand: string;
+  provider: string;
+  isActive: boolean;
+  modelName: string | null;
+  displayName: string;
+  createdAt: Date;
+  // Verbindung
+  apiKey: string | null;
+  apiEndpoint: string | null;
+  // Verhalten (gemeinsam)
+  temperature: number | null;
+  maxTokens: number | null;
+  topP: number | null;
+  systemPrompt: string | null;
+  notes: string | null;
+  // Anbieterspezifisch
+  topK: number | null;
+  thinkingMode: boolean;
+  presencePenalty: number | null;
+  frequencyPenalty: number | null;
+  safePrompt: boolean;
+  randomSeed: number | null;
+  organizationId: string | null;
+  euEndpoint: boolean;
+  // Custom-Provider
+  enabledFields: string[] | null;
+}
+
+export type UpdateKiProviderFields = Partial<Omit<KiConfig, 'id' | 'brand' | 'provider' | 'isActive' | 'createdAt' | 'enabledFields'>>;
+
+function rowToKiConfig(row: Record<string, unknown>): KiConfig {
+  return {
+    id: row.id as number,
+    brand: row.brand as string,
+    provider: row.provider as string,
+    isActive: row.is_active as boolean,
+    modelName: (row.model_name as string | null) ?? null,
+    displayName: row.display_name as string,
+    createdAt: row.created_at as Date,
+    apiKey: (row.api_key as string | null) ?? null,
+    apiEndpoint: (row.api_endpoint as string | null) ?? null,
+    temperature: row.temperature != null ? Number(row.temperature) : null,
+    maxTokens: (row.max_tokens as number | null) ?? null,
+    topP: row.top_p != null ? Number(row.top_p) : null,
+    systemPrompt: (row.system_prompt as string | null) ?? null,
+    notes: (row.notes as string | null) ?? null,
+    topK: (row.top_k as number | null) ?? null,
+    thinkingMode: (row.thinking_mode as boolean) ?? false,
+    presencePenalty: row.presence_penalty != null ? Number(row.presence_penalty) : null,
+    frequencyPenalty: row.frequency_penalty != null ? Number(row.frequency_penalty) : null,
+    safePrompt: (row.safe_prompt as boolean) ?? false,
+    randomSeed: (row.random_seed as number | null) ?? null,
+    organizationId: (row.organization_id as string | null) ?? null,
+    euEndpoint: (row.eu_endpoint as boolean) ?? false,
+    enabledFields: Array.isArray(row.enabled_fields)
+      ? (row.enabled_fields as string[])
+      : row.enabled_fields != null
+        ? (JSON.parse(row.enabled_fields as string) as string[])
+        : null,
+  };
+}
+
+export async function listKiProviders(pool: Pool, brand: string): Promise<KiConfig[]> {
+  const r = await pool.query(
+    `SELECT * FROM coaching.ki_config WHERE brand = $1 ORDER BY id`,
+    [brand],
+  );
+  return r.rows.map(rowToKiConfig);
+}
+
+export async function getActiveProvider(pool: Pool, brand: string): Promise<KiConfig | null> {
+  const r = await pool.query(
+    `SELECT * FROM coaching.ki_config WHERE brand = $1 AND is_active = true LIMIT 1`,
+    [brand],
+  );
+  return r.rows[0] ? rowToKiConfig(r.rows[0]) : null;
+}
+
+export async function getKiProviderById(pool: Pool, id: number): Promise<KiConfig | null> {
+  const r = await pool.query(`SELECT * FROM coaching.ki_config WHERE id = $1`, [id]);
+  return r.rows[0] ? rowToKiConfig(r.rows[0]) : null;
+}
+
+export async function setActiveProvider(pool: Pool, brand: string, provider: string): Promise<void> {
+  const exists = await pool.query(
+    `SELECT id FROM coaching.ki_config WHERE brand = $1 AND provider = $2`,
+    [brand, provider],
+  );
+  if (exists.rows.length === 0) {
+    throw new Error(`Provider '${provider}' not found for brand '${brand}'`);
+  }
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+    await client.query(`UPDATE coaching.ki_config SET is_active = false WHERE brand = $1`, [brand]);
+    await client.query(
+      `UPDATE coaching.ki_config SET is_active = true WHERE brand = $1 AND provider = $2`,
+      [brand, provider],
+    );
+    await client.query('COMMIT');
+  } catch (e) {
+    try { await client.query('ROLLBACK'); } catch { /* ignore */ }
+    throw e;
+  } finally {
+    client.release();
+  }
+}
+
+const COLUMN_MAP: Record<string, string> = {
+  modelName: 'model_name', displayName: 'display_name',
+  apiKey: 'api_key', apiEndpoint: 'api_endpoint',
+  temperature: 'temperature', maxTokens: 'max_tokens', topP: 'top_p',
+  systemPrompt: 'system_prompt', notes: 'notes',
+  topK: 'top_k', thinkingMode: 'thinking_mode',
+  presencePenalty: 'presence_penalty', frequencyPenalty: 'frequency_penalty',
+  safePrompt: 'safe_prompt', randomSeed: 'random_seed',
+  organizationId: 'organization_id', euEndpoint: 'eu_endpoint',
+};
+
+export async function updateKiProvider(
+  pool: Pool,
+  id: number,
+  fields: UpdateKiProviderFields,
+): Promise<KiConfig> {
+  const sets: string[] = [];
+  const vals: unknown[] = [];
+  let i = 1;
+  for (const [k, v] of Object.entries(fields)) {
+    const col = COLUMN_MAP[k];
+    if (!col) continue;
+    sets.push(`${col} = $${i++}`);
+    vals.push(v);
+  }
+  if (sets.length === 0) {
+    const r = await pool.query(`SELECT * FROM coaching.ki_config WHERE id = $1`, [id]);
+    if (r.rows.length === 0) throw new Error(`KI-Provider id=${id} nicht gefunden`);
+    return rowToKiConfig(r.rows[0]);
+  }
+  vals.push(id);
+  const r = await pool.query(
+    `UPDATE coaching.ki_config SET ${sets.join(', ')} WHERE id = $${i} RETURNING *`,
+    vals,
+  );
+  if (r.rows.length === 0) throw new Error(`KI-Provider id=${id} nicht gefunden`);
+  return rowToKiConfig(r.rows[0]);
+}
+
+export async function createKiProvider(
+  pool: Pool,
+  brand: string,
+  data: { displayName: string; provider: string; enabledFields: string[] },
+): Promise<KiConfig> {
+  const r = await pool.query(
+    `INSERT INTO coaching.ki_config (brand, provider, display_name, is_active, enabled_fields)
+     VALUES ($1, $2, $3, false, $4)
+     RETURNING *`,
+    [brand, data.provider, data.displayName, JSON.stringify(data.enabledFields)],
+  );
+  return rowToKiConfig(r.rows[0]);
+}
+
+export async function deleteKiProvider(pool: Pool, id: number): Promise<void> {
+  const r = await pool.query(`SELECT provider FROM coaching.ki_config WHERE id = $1`, [id]);
+  if (r.rows.length === 0) throw new Error(`KI-Provider id=${id} nicht gefunden`);
+  const provider = r.rows[0].provider as string;
+  if (KNOWN_PROVIDERS.has(provider)) {
+    throw new Error('Nur Custom-Provider können gelöscht werden');
+  }
+  await pool.query(`DELETE FROM coaching.ki_config WHERE id = $1`, [id]);
+}
+```
+
+- [ ] **Schritt 4: Tests laufen lassen — müssen PASS**
+
+```bash
+cd website && pnpm test coaching-ki-config-db 2>&1 | tail -20
+```
+
+Erwartung: alle Tests PASS.
+
+- [ ] **Schritt 5: Commit**
+
+```bash
+git add website/src/lib/coaching-ki-config-db.ts website/src/lib/coaching-ki-config-db.test.ts
+git commit -m "feat(coaching): createKiProvider + deleteKiProvider + enabledFields [T000418]"
+```
+
+---
+
+## Task 3: API-Endpunkte — POST (Create) + DELETE
+
+**Files:**
+- Modify: `website/src/pages/api/admin/coaching/ki-config/index.ts`
+- Modify: `website/src/pages/api/admin/coaching/ki-config/[id].ts`
+
+Der `provider`-String für Custom-Provider kommt vom Client als Freitext — die API erzwingt den `custom_`-Prefix.
+
+- [ ] **Schritt 1: POST-Handler in index.ts hinzufügen**
+
+Ersetze den gesamten Inhalt von `website/src/pages/api/admin/coaching/ki-config/index.ts`:
+
+```typescript
+import type { APIRoute } from 'astro';
+import { getSession, isAdmin } from '../../../../../lib/auth';
+import { listKiProviders, createKiProvider } from '../../../../../lib/coaching-ki-config-db';
+import { pool } from '../../../../../lib/website-db';
+
+export const prerender = false;
+
+const ALL_FIELDS = [
+  'apiKey', 'apiEndpoint', 'modelName', 'temperature', 'maxTokens', 'topP',
+  'topK', 'thinkingMode', 'presencePenalty', 'frequencyPenalty',
+  'safePrompt', 'randomSeed', 'organizationId', 'euEndpoint',
+  'systemPrompt', 'notes',
+] as const;
+
+export const GET: APIRoute = async ({ request }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) return new Response('Unauthorized', { status: 401 });
+  const brand = process.env.BRAND || 'mentolder';
+  const providers = await listKiProviders(pool, brand);
+  return new Response(JSON.stringify({ providers }), { headers: { 'content-type': 'application/json' } });
+};
+
+export const POST: APIRoute = async ({ request }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) return new Response('Unauthorized', { status: 401 });
+
+  let body: Record<string, unknown>;
+  try { body = await request.json(); } catch {
+    return new Response(JSON.stringify({ error: 'Invalid JSON' }), { status: 400, headers: { 'content-type': 'application/json' } });
+  }
+
+  const displayName = typeof body.displayName === 'string' ? body.displayName.trim() : '';
+  if (!displayName) {
+    return new Response(JSON.stringify({ error: 'displayName darf nicht leer sein' }), { status: 400, headers: { 'content-type': 'application/json' } });
+  }
+
+  const slug = typeof body.slug === 'string' ? body.slug.trim().toLowerCase().replace(/[^a-z0-9-]/g, '-') : '';
+  if (!slug) {
+    return new Response(JSON.stringify({ error: 'slug darf nicht leer sein' }), { status: 400, headers: { 'content-type': 'application/json' } });
+  }
+
+  const rawFields = Array.isArray(body.enabledFields) ? body.enabledFields as string[] : [];
+  const enabledFields = rawFields.filter(f => (ALL_FIELDS as readonly string[]).includes(f));
+
+  const brand = process.env.BRAND || 'mentolder';
+  try {
+    const provider = await createKiProvider(pool, brand, {
+      displayName,
+      provider: `custom_${slug}`,
+      enabledFields,
+    });
+    return new Response(JSON.stringify({ provider }), { status: 201, headers: { 'content-type': 'application/json' } });
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    if (msg.includes('unique') || msg.includes('UNIQUE') || msg.includes('duplicate')) {
+      return new Response(JSON.stringify({ error: `Slug '${slug}' bereits vergeben` }), { status: 409, headers: { 'content-type': 'application/json' } });
+    }
+    throw e;
+  }
+};
+```
+
+- [ ] **Schritt 2: DELETE-Handler in [id].ts hinzufügen**
+
+Ersetze den gesamten Inhalt von `website/src/pages/api/admin/coaching/ki-config/[id].ts`:
+
+```typescript
+import type { APIRoute } from 'astro';
+import { getSession, isAdmin } from '../../../../../lib/auth';
+import { updateKiProvider, deleteKiProvider, type UpdateKiProviderFields } from '../../../../../lib/coaching-ki-config-db';
+import { pool } from '../../../../../lib/website-db';
+
+export const prerender = false;
+
+const ALLOWED_FIELDS: (keyof UpdateKiProviderFields)[] = [
+  'modelName', 'displayName', 'apiKey', 'apiEndpoint',
+  'temperature', 'maxTokens', 'topP', 'systemPrompt', 'notes',
+  'topK', 'thinkingMode', 'presencePenalty', 'frequencyPenalty',
+  'safePrompt', 'randomSeed', 'organizationId', 'euEndpoint',
+];
+
+export const PATCH: APIRoute = async ({ request, params }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) return new Response('Unauthorized', { status: 401 });
+
+  const id = parseInt(params.id ?? '', 10);
+  if (isNaN(id)) return new Response(JSON.stringify({ error: 'Ungültige ID' }), { status: 400, headers: { 'content-type': 'application/json' } });
+
+  let body: Record<string, unknown>;
+  try { body = await request.json(); } catch {
+    return new Response(JSON.stringify({ error: 'Invalid JSON' }), { status: 400, headers: { 'content-type': 'application/json' } });
+  }
+
+  if ('displayName' in body && (typeof body.displayName !== 'string' || (body.displayName as string).trim() === '')) {
+    return new Response(JSON.stringify({ error: 'displayName darf nicht leer sein' }), { status: 400, headers: { 'content-type': 'application/json' } });
+  }
+
+  const fields: UpdateKiProviderFields = {};
+  for (const key of ALLOWED_FIELDS) {
+    if (key in body) {
+      if (key === 'displayName') {
+        fields.displayName = (body.displayName as string).trim();
+      } else {
+        (fields as Record<string, unknown>)[key] = body[key];
+      }
+    }
+  }
+
+  const provider = await updateKiProvider(pool, id, fields);
+  return new Response(JSON.stringify({ provider }), { headers: { 'content-type': 'application/json' } });
+};
+
+export const DELETE: APIRoute = async ({ request, params }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) return new Response('Unauthorized', { status: 401 });
+
+  const id = parseInt(params.id ?? '', 10);
+  if (isNaN(id)) return new Response(JSON.stringify({ error: 'Ungültige ID' }), { status: 400, headers: { 'content-type': 'application/json' } });
+
+  try {
+    await deleteKiProvider(pool, id);
+    return new Response(JSON.stringify({ ok: true }), { headers: { 'content-type': 'application/json' } });
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return new Response(JSON.stringify({ error: msg }), { status: 400, headers: { 'content-type': 'application/json' } });
+  }
+};
+```
+
+- [ ] **Schritt 3: TypeScript-Check**
+
+```bash
+cd website && pnpm tsc --noEmit 2>&1 | grep -E "error TS" | head -20
+```
+
+Erwartung: keine Fehler.
+
+- [ ] **Schritt 4: Commit**
+
+```bash
+git add website/src/pages/api/admin/coaching/ki-config/index.ts \
+        website/src/pages/api/admin/coaching/ki-config/[id].ts
+git commit -m "feat(coaching): POST create + DELETE ki-config API endpoints [T000418]"
+```
+
+---
+
+## Task 4: UI — showField für Custom, Anlegen-Formular, Löschen-Button
+
+**Files:**
+- Modify: `website/src/components/admin/coaching/CoachingSettings.svelte`
+
+Das bestehende Svelte hat bereits das vollständige Bearbeitungsformular für Standard-Provider. Wir ergänzen:
+1. `showField()` für Custom-Provider: `enabledFields`-Array aus DB nutzen
+2. "+ Neuer KI-Anbieter" Button
+3. Anlegen-Formular mit Slug, Name, Feldauswahl-Checkboxen
+4. Löschen-Button auf Provider-Karten für `custom_*`-Provider
+
+- [ ] **Schritt 1: Script-Block aktualisieren**
+
+Öffne `website/src/components/admin/coaching/CoachingSettings.svelte`.
+
+Ersetze den gesamten `<script lang="ts">` Block (Zeilen 1–207) durch:
+
+```svelte
+<script lang="ts">
+  import type { KiConfig } from '../../../lib/coaching-ki-config-db';
+  import type { StepTemplate } from '../../../lib/coaching-templates-db';
+
+  let {
+    initialProviders,
+    initialTemplates,
+  }: {
+    initialProviders: KiConfig[];
+    initialTemplates: StepTemplate[];
+  } = $props();
+
+  let activeTab = $state<'ki' | 'templates'>('ki');
+  let providers = $state<KiConfig[]>(initialProviders);
+  let templates = $state<StepTemplate[]>(initialTemplates);
+  let savingProvider = $state<string | null>(null);
+  let editingTemplate = $state<StepTemplate | null>(null);
+  let editFields = $state({ stepName: '', systemPrompt: '', userPromptTpl: '', keywords: '' });
+
+  // KI-Provider Inline-Edit
+  let editingProvider = $state<KiConfig | null>(null);
+  let providerEditTab = $state<'connection' | 'behavior'>('connection');
+  let savingProviderEdit = $state(false);
+  let showApiKey = $state(false);
+
+  // Custom-Provider Anlegen
+  let creatingProvider = $state(false);
+  let savingNewProvider = $state(false);
+  let newProviderForm = $state({
+    displayName: '',
+    slug: '',
+    enabledFields: [] as string[],
+  });
+
+  const ALL_FIELDS: { key: string; label: string }[] = [
+    { key: 'apiKey',           label: 'API-Key' },
+    { key: 'apiEndpoint',      label: 'API-Endpunkt' },
+    { key: 'modelName',        label: 'Modell' },
+    { key: 'temperature',      label: 'Temperature' },
+    { key: 'maxTokens',        label: 'Max Tokens' },
+    { key: 'topP',             label: 'top_p' },
+    { key: 'topK',             label: 'top_k' },
+    { key: 'thinkingMode',     label: 'Thinking-Modus (Claude)' },
+    { key: 'presencePenalty',  label: 'Presence Penalty' },
+    { key: 'frequencyPenalty', label: 'Frequency Penalty' },
+    { key: 'safePrompt',       label: 'Safe Prompt (Mistral)' },
+    { key: 'randomSeed',       label: 'Random Seed' },
+    { key: 'organizationId',   label: 'Organization ID' },
+    { key: 'euEndpoint',       label: 'EU-Endpunkt (DSGVO)' },
+    { key: 'systemPrompt',     label: 'System-Prompt' },
+    { key: 'notes',            label: 'Notiz / Freitext' },
+  ];
+
+  type ProviderFields = {
+    displayName: string; modelName: string;
+    apiKey: string; apiEndpoint: string;
+    temperature: string; maxTokens: string; topP: string;
+    systemPrompt: string; notes: string;
+    topK: string; thinkingMode: boolean;
+    presencePenalty: string; frequencyPenalty: string;
+    safePrompt: boolean; randomSeed: string;
+    organizationId: string; euEndpoint: boolean;
+  };
+
+  let providerFields = $state<ProviderFields>({
+    displayName: '', modelName: '',
+    apiKey: '', apiEndpoint: '',
+    temperature: '', maxTokens: '', topP: '',
+    systemPrompt: '', notes: '',
+    topK: '', thinkingMode: false,
+    presencePenalty: '', frequencyPenalty: '',
+    safePrompt: false, randomSeed: '',
+    organizationId: '', euEndpoint: false,
+  });
+
+  function parseNum(s: string): number | null {
+    const v = parseFloat(s);
+    return isNaN(v) ? null : v;
+  }
+
+  function parseInt2(s: string): number | null {
+    const v = parseInt(s, 10);
+    return isNaN(v) ? null : v;
+  }
+
+  const KNOWN_FIELD_MAP: Record<string, string[]> = {
+    claude:  ['apiKey', 'apiEndpoint', 'modelName', 'temperature', 'maxTokens', 'topP', 'topK', 'thinkingMode', 'systemPrompt', 'notes'],
+    openai:  ['apiKey', 'apiEndpoint', 'modelName', 'temperature', 'maxTokens', 'topP', 'presencePenalty', 'frequencyPenalty', 'organizationId', 'systemPrompt', 'notes'],
+    mistral: ['apiKey', 'apiEndpoint', 'modelName', 'temperature', 'maxTokens', 'topP', 'topK', 'safePrompt', 'randomSeed', 'euEndpoint', 'systemPrompt', 'notes'],
+    lumo:    ['euEndpoint', 'notes'],
+  };
+
+  function showField(p: KiConfig, field: string): boolean {
+    if (p.enabledFields !== null) return p.enabledFields.includes(field);
+    return (KNOWN_FIELD_MAP[p.provider] ?? []).includes(field);
+  }
+
+  const PROVIDER_BADGE: Record<string, string> = {
+    claude: 'Anthropic', openai: 'OpenAI', mistral: 'Mistral AI', lumo: 'Lumo',
+  };
+
+  function providerBadgeLabel(p: KiConfig): string {
+    return PROVIDER_BADGE[p.provider] ?? (p.displayName || p.provider);
+  }
+
+  function isCustom(p: KiConfig): boolean {
+    return p.provider.startsWith('custom_');
+  }
+
+  function startEditProvider(p: KiConfig) {
+    editingProvider = p;
+    providerEditTab = 'connection';
+    showApiKey = false;
+    providerFields = {
+      displayName: p.displayName,
+      modelName: p.modelName ?? '',
+      apiKey: p.apiKey ?? '',
+      apiEndpoint: p.apiEndpoint ?? '',
+      temperature: p.temperature != null ? String(p.temperature) : '',
+      maxTokens: p.maxTokens != null ? String(p.maxTokens) : '',
+      topP: p.topP != null ? String(p.topP) : '',
+      systemPrompt: p.systemPrompt ?? '',
+      notes: p.notes ?? '',
+      topK: p.topK != null ? String(p.topK) : '',
+      thinkingMode: p.thinkingMode,
+      presencePenalty: p.presencePenalty != null ? String(p.presencePenalty) : '',
+      frequencyPenalty: p.frequencyPenalty != null ? String(p.frequencyPenalty) : '',
+      safePrompt: p.safePrompt,
+      randomSeed: p.randomSeed != null ? String(p.randomSeed) : '',
+      organizationId: p.organizationId ?? '',
+      euEndpoint: p.euEndpoint,
+    };
+  }
+
+  async function saveProviderEdit() {
+    if (!editingProvider) return;
+    savingProviderEdit = true;
+    const p = editingProvider;
+    const payload: Record<string, unknown> = {
+      displayName: providerFields.displayName,
+      modelName: providerFields.modelName.trim() || null,
+      apiKey: providerFields.apiKey.trim() || null,
+      apiEndpoint: providerFields.apiEndpoint.trim() || null,
+      temperature: parseNum(providerFields.temperature),
+      maxTokens: parseInt2(providerFields.maxTokens),
+      topP: parseNum(providerFields.topP),
+      systemPrompt: providerFields.systemPrompt.trim() || null,
+      notes: providerFields.notes.trim() || null,
+    };
+    if (showField(p, 'topK'))            payload.topK = parseInt2(providerFields.topK);
+    if (showField(p, 'thinkingMode'))    payload.thinkingMode = providerFields.thinkingMode;
+    if (showField(p, 'presencePenalty')) payload.presencePenalty = parseNum(providerFields.presencePenalty);
+    if (showField(p, 'frequencyPenalty')) payload.frequencyPenalty = parseNum(providerFields.frequencyPenalty);
+    if (showField(p, 'safePrompt'))      payload.safePrompt = providerFields.safePrompt;
+    if (showField(p, 'randomSeed'))      payload.randomSeed = parseInt2(providerFields.randomSeed);
+    if (showField(p, 'organizationId'))  payload.organizationId = providerFields.organizationId.trim() || null;
+    if (showField(p, 'euEndpoint'))      payload.euEndpoint = providerFields.euEndpoint;
+
+    await fetch(`/api/admin/coaching/ki-config/${p.id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    const res = await fetch('/api/admin/coaching/ki-config');
+    providers = (await res.json()).providers;
+    editingProvider = null;
+    savingProviderEdit = false;
+  }
+
+  async function activateProvider(provider: string) {
+    savingProvider = provider;
+    await fetch('/api/admin/coaching/ki-config/active', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ provider }),
+    });
+    providers = (await (await fetch('/api/admin/coaching/ki-config')).json()).providers;
+    savingProvider = null;
+  }
+
+  function toggleNewField(key: string) {
+    if (newProviderForm.enabledFields.includes(key)) {
+      newProviderForm.enabledFields = newProviderForm.enabledFields.filter(k => k !== key);
+    } else {
+      newProviderForm.enabledFields = [...newProviderForm.enabledFields, key];
+    }
+  }
+
+  async function saveNewProvider() {
+    savingNewProvider = true;
+    const res = await fetch('/api/admin/coaching/ki-config', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        displayName: newProviderForm.displayName.trim(),
+        slug: newProviderForm.slug.trim(),
+        enabledFields: newProviderForm.enabledFields,
+      }),
+    });
+    const data = await res.json();
+    if (!res.ok) { alert(data.error ?? 'Fehler beim Anlegen'); savingNewProvider = false; return; }
+    providers = (await (await fetch('/api/admin/coaching/ki-config')).json()).providers;
+    creatingProvider = false;
+    newProviderForm = { displayName: '', slug: '', enabledFields: [] };
+    savingNewProvider = false;
+  }
+
+  async function deleteProvider(p: KiConfig) {
+    if (!confirm(`Anbieter "${p.displayName}" wirklich löschen?`)) return;
+    const res = await fetch(`/api/admin/coaching/ki-config/${p.id}`, { method: 'DELETE' });
+    const data = await res.json();
+    if (!res.ok) { alert(data.error ?? 'Fehler beim Löschen'); return; }
+    providers = providers.filter(x => x.id !== p.id);
+  }
+
+  // Templates
+  function startEdit(t: StepTemplate) {
+    editingTemplate = t;
+    editFields = {
+      stepName: t.stepName,
+      systemPrompt: t.systemPrompt,
+      userPromptTpl: t.userPromptTpl,
+      keywords: t.keywords.join(', '),
+    };
+  }
+
+  const EMPTY_TEMPLATE: Omit<StepTemplate, 'id' | 'brand' | 'createdAt'> = {
+    stepNumber: 1, stepName: '', phase: 'problem_ziel',
+    systemPrompt: '', userPromptTpl: '', inputSchema: [],
+    keywords: [], isActive: true, sortOrder: 0,
+  };
+
+  function startNewTemplate() {
+    editingTemplate = { ...EMPTY_TEMPLATE, id: '', brand: '', createdAt: new Date() } as StepTemplate;
+    editFields = { stepName: '', systemPrompt: '', userPromptTpl: '', keywords: '' };
+  }
+
+  async function saveTemplate() {
+    if (!editingTemplate) return;
+    const isNew = editingTemplate.id === '';
+    const payload = {
+      stepNumber: editingTemplate.stepNumber,
+      stepName: editFields.stepName,
+      phase: editingTemplate.phase,
+      systemPrompt: editFields.systemPrompt,
+      userPromptTpl: editFields.userPromptTpl,
+      inputSchema: editingTemplate.inputSchema,
+      keywords: editFields.keywords.split(',').map(s => s.trim()).filter(Boolean),
+      isActive: true,
+      sortOrder: editingTemplate.sortOrder,
+    };
+    if (isNew) {
+      await fetch('/api/admin/coaching/step-templates', {
+        method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload),
+      });
+    } else {
+      await fetch(`/api/admin/coaching/step-templates/${editingTemplate.id}`, {
+        method: 'PATCH', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload),
+      });
+    }
+    templates = (await (await fetch('/api/admin/coaching/step-templates')).json()).templates;
+    editingTemplate = null;
+  }
+
+  async function deleteTemplate(id: string) {
+    if (!confirm('Template wirklich löschen?')) return;
+    const res = await fetch(`/api/admin/coaching/step-templates/${id}`, { method: 'DELETE' });
+    const data = await res.json();
+    if (!res.ok) { alert(data.error); return; }
+    templates = templates.filter(t => t.id !== id);
+  }
+</script>
+```
+
+- [ ] **Schritt 2: HTML-Template aktualisieren**
+
+Ersetze den gesamten Bereich zwischen `<div class="settings">` und `</div>` (exkl. äußerstem div) sowie den `<style>`-Block. Ersetze den gesamten Template- und Style-Teil (ab Zeile 209 bis Ende) durch:
+
+```svelte
+<div class="settings">
+  <div class="tabs">
+    <button class="tab {activeTab === 'ki' ? 'active' : ''}" onclick={() => activeTab = 'ki'}>KI-Provider</button>
+    <button class="tab {activeTab === 'templates' ? 'active' : ''}" onclick={() => activeTab = 'templates'}>Prompt-Templates</button>
+  </div>
+
+  {#if activeTab === 'ki'}
+    {#if editingProvider}
+      <div class="edit-panel">
+        <div class="edit-panel-header">
+          <div class="edit-title">
+            <span class="provider-badge {isCustom(editingProvider) ? 'custom' : editingProvider.provider}">{providerBadgeLabel(editingProvider)}</span>
+            <span>{editingProvider.displayName}</span>
+          </div>
+          <button class="btn-sm" onclick={() => editingProvider = null}>✕ Schließen</button>
+        </div>
+
+        <div class="edit-tabs">
+          <button class="edit-tab {providerEditTab === 'connection' ? 'active' : ''}" onclick={() => providerEditTab = 'connection'}>Verbindung</button>
+          <button class="edit-tab {providerEditTab === 'behavior' ? 'active' : ''}" onclick={() => providerEditTab = 'behavior'}>Verhalten</button>
+        </div>
+
+        {#if providerEditTab === 'connection'}
+          <div class="edit-section">
+            <label class="field-label">Name / Label
+              <input type="text" bind:value={providerFields.displayName} />
+            </label>
+            {#if editingProvider.provider === 'lumo'}
+              <div class="lumo-info">
+                <strong>Lumo (Proton)</strong> hat derzeit keine öffentliche API — das Profil dient als Platzhalter.
+              </div>
+              <label class="checkbox-label">
+                <input type="checkbox" bind:checked={providerFields.euEndpoint} />
+                EU-Endpunkt verwenden (DSGVO)
+              </label>
+            {:else}
+              {#if showField(editingProvider, 'modelName')}
+                <label class="field-label">Modell
+                  <input type="text" bind:value={providerFields.modelName} placeholder="leer = Standardmodell" />
+                </label>
+              {/if}
+              {#if showField(editingProvider, 'apiKey')}
+                <label class="field-label">API-Key
+                  <div class="api-key-row">
+                    {#if showApiKey}
+                      <input type="text" bind:value={providerFields.apiKey} placeholder="sk-..." class="api-key-input" />
+                    {:else}
+                      <input type="password" bind:value={providerFields.apiKey} placeholder="sk-..." class="api-key-input" />
+                    {/if}
+                    <button class="btn-icon" onclick={() => showApiKey = !showApiKey}>{showApiKey ? '🙈' : '👁'}</button>
+                  </div>
+                </label>
+              {/if}
+              {#if showField(editingProvider, 'apiEndpoint')}
+                <label class="field-label">API-Endpunkt (optional)
+                  <input type="url" bind:value={providerFields.apiEndpoint} placeholder="https://api.example.com/v1" />
+                </label>
+              {/if}
+              {#if showField(editingProvider, 'organizationId')}
+                <label class="field-label">Organization ID (optional)
+                  <input type="text" bind:value={providerFields.organizationId} placeholder="org-..." />
+                </label>
+              {/if}
+              {#if showField(editingProvider, 'euEndpoint')}
+                <label class="checkbox-label">
+                  <input type="checkbox" bind:checked={providerFields.euEndpoint} />
+                  EU-Endpunkt verwenden
+                </label>
+              {/if}
+            {/if}
+          </div>
+        {:else}
+          <div class="edit-section">
+            {#if editingProvider.provider === 'lumo'}
+              <p class="lumo-info">Lumo unterstützt derzeit keine konfigurierbaren Verhaltenparameter.</p>
+            {:else}
+              <div class="field-row">
+                {#if showField(editingProvider, 'temperature')}
+                  <label class="field-label">Temperature (0.0–2.0)
+                    <input type="number" step="0.01" min="0" max="2" bind:value={providerFields.temperature} placeholder="leer = Standard" />
+                  </label>
+                {/if}
+                {#if showField(editingProvider, 'maxTokens')}
+                  <label class="field-label">Max Tokens
+                    <input type="number" min="1" bind:value={providerFields.maxTokens} placeholder="leer = Standard" />
+                  </label>
+                {/if}
+                {#if showField(editingProvider, 'topP')}
+                  <label class="field-label">top_p
+                    <input type="number" step="0.01" min="0" max="1" bind:value={providerFields.topP} placeholder="leer = Standard" />
+                  </label>
+                {/if}
+              </div>
+              {#if showField(editingProvider, 'topK')}
+                <div class="field-row">
+                  <label class="field-label">top_k
+                    <input type="number" min="1" bind:value={providerFields.topK} placeholder="leer = Standard" />
+                  </label>
+                </div>
+              {/if}
+              {#if showField(editingProvider, 'thinkingMode')}
+                <label class="checkbox-label">
+                  <input type="checkbox" bind:checked={providerFields.thinkingMode} />
+                  Extended Thinking aktivieren (Claude)
+                </label>
+              {/if}
+              {#if showField(editingProvider, 'presencePenalty')}
+                <div class="field-row">
+                  <label class="field-label">Presence Penalty (–2 bis 2)
+                    <input type="number" step="0.01" min="-2" max="2" bind:value={providerFields.presencePenalty} placeholder="leer = Standard" />
+                  </label>
+                  <label class="field-label">Frequency Penalty (–2 bis 2)
+                    <input type="number" step="0.01" min="-2" max="2" bind:value={providerFields.frequencyPenalty} placeholder="leer = Standard" />
+                  </label>
+                </div>
+              {/if}
+              {#if showField(editingProvider, 'safePrompt')}
+                <label class="checkbox-label">
+                  <input type="checkbox" bind:checked={providerFields.safePrompt} />
+                  Safe Prompt aktivieren (Mistral)
+                </label>
+              {/if}
+              {#if showField(editingProvider, 'randomSeed')}
+                <label class="field-label">Random Seed (leer = zufällig)
+                  <input type="number" bind:value={providerFields.randomSeed} placeholder="z.B. 42" />
+                </label>
+              {/if}
+              {#if showField(editingProvider, 'systemPrompt')}
+                <label class="field-label">System-Prompt
+                  <textarea rows="5" bind:value={providerFields.systemPrompt} placeholder="Optionaler System-Prompt…"></textarea>
+                </label>
+              {/if}
+            {/if}
+            {#if showField(editingProvider, 'notes')}
+              <label class="field-label">Notiz / Freitext
+                <textarea rows="2" bind:value={providerFields.notes} placeholder="Interne Beschreibung…"></textarea>
+              </label>
+            {/if}
+          </div>
+        {/if}
+
+        <div class="edit-actions">
+          <button class="btn-primary" onclick={saveProviderEdit} disabled={savingProviderEdit}>
+            {savingProviderEdit ? 'Speichern…' : 'Speichern'}
+          </button>
+          <button class="btn-sm" onclick={() => editingProvider = null}>Abbrechen</button>
+        </div>
+      </div>
+
+    {:else if creatingProvider}
+      <div class="edit-panel">
+        <div class="edit-panel-header">
+          <div class="edit-title">Neuer KI-Anbieter</div>
+          <button class="btn-sm" onclick={() => creatingProvider = false}>✕ Schließen</button>
+        </div>
+        <div class="edit-section">
+          <label class="field-label">Name / Label
+            <input type="text" bind:value={newProviderForm.displayName} placeholder="z.B. Mein eigener GPT" />
+          </label>
+          <label class="field-label">Interner Slug (nur a–z, 0–9, Bindestrich — wird zu <code>custom_&lt;slug&gt;</code>)
+            <input type="text" bind:value={newProviderForm.slug} placeholder="z.B. mein-gpt" />
+          </label>
+          <div class="field-label">Verfügbare Felder auswählen
+            <div class="fields-grid">
+              {#each ALL_FIELDS as f}
+                <label class="checkbox-label">
+                  <input
+                    type="checkbox"
+                    checked={newProviderForm.enabledFields.includes(f.key)}
+                    onchange={() => toggleNewField(f.key)}
+                  />
+                  {f.label}
+                </label>
+              {/each}
+            </div>
+          </div>
+        </div>
+        <div class="edit-actions">
+          <button class="btn-primary" onclick={saveNewProvider} disabled={savingNewProvider}>
+            {savingNewProvider ? 'Anlegen…' : 'Anbieter anlegen'}
+          </button>
+          <button class="btn-sm" onclick={() => creatingProvider = false}>Abbrechen</button>
+        </div>
+      </div>
+
+    {:else}
+      <div class="ki-grid-header">
+        <button class="btn-primary" onclick={() => creatingProvider = true}>+ Neuer KI-Anbieter</button>
+      </div>
+      <div class="ki-grid">
+        {#each providers as p}
+          <div class="provider-card {p.isActive ? 'active' : ''}">
+            <div class="card-head">
+              <span class="provider-badge {isCustom(p) ? 'custom' : p.provider}">{providerBadgeLabel(p)}</span>
+              {#if p.isActive}<span class="active-badge">● Aktiv</span>{/if}
+            </div>
+            <div class="provider-name">{p.displayName}</div>
+            <div class="provider-model">{p.modelName ?? 'kein Modell'}</div>
+            {#if p.apiKey}
+              <div class="provider-key">API-Key gesetzt ✓</div>
+            {:else if p.provider !== 'lumo'}
+              <div class="provider-key warn">kein API-Key</div>
+            {/if}
+            <div class="provider-actions">
+              {#if !p.isActive}
+                <button class="btn-activate" onclick={() => activateProvider(p.provider)} disabled={savingProvider === p.provider}>
+                  {savingProvider === p.provider ? '…' : 'Aktivieren'}
+                </button>
+              {/if}
+              <button class="btn-sm" onclick={() => startEditProvider(p)}>Bearbeiten</button>
+              {#if isCustom(p)}
+                <button class="btn-sm btn-danger" onclick={() => deleteProvider(p)}>🗑</button>
+              {/if}
+            </div>
+          </div>
+        {/each}
+      </div>
+    {/if}
+
+  {:else}
+    <div class="templates-list">
+      {#if editingTemplate}
+        <div class="edit-modal">
+          <h3>{editingTemplate.id === '' ? 'Neues Template' : `Schritt ${editingTemplate.stepNumber}: bearbeiten`}</h3>
+          <label>Schritt-Nr.
+            <input type="number" min="1" bind:value={editingTemplate.stepNumber} />
+          </label>
+          <label>Phase
+            <select bind:value={editingTemplate.phase}>
+              <option value="problem_ziel">Problem & Ziel</option>
+              <option value="analyse">Analyse</option>
+              <option value="ressourcen">Ressourcen</option>
+              <option value="loesungsweg">Lösungsweg</option>
+              <option value="abschluss">Abschluss</option>
+            </select>
+          </label>
+          <label>Name
+            <input type="text" bind:value={editFields.stepName} />
+          </label>
+          <label>System-Prompt
+            <textarea rows="4" bind:value={editFields.systemPrompt}></textarea>
+          </label>
+          <label>Prompt-Template (Platzhalter: &#123;feldname&#125;)
+            <textarea rows="5" bind:value={editFields.userPromptTpl}></textarea>
+          </label>
+          <label>Schlagwörter (kommagetrennt)
+            <input type="text" bind:value={editFields.keywords} />
+          </label>
+          <div class="edit-actions">
+            <button class="btn-primary" onclick={saveTemplate}>Speichern</button>
+            <button class="btn-sm" onclick={() => editingTemplate = null}>Abbrechen</button>
+          </div>
+        </div>
+      {:else}
+        <div class="templates-header">
+          <button class="btn-primary" onclick={startNewTemplate}>+ Neues Template</button>
+        </div>
+        <table class="table">
+          <thead><tr><th>#</th><th>Name</th><th>Phase</th><th>Schlagwörter</th><th></th></tr></thead>
+          <tbody>
+            {#each templates as t (t.id)}
+              <tr>
+                <td>{t.stepNumber}</td>
+                <td>{t.stepName}</td>
+                <td>{t.phase}</td>
+                <td>{t.keywords.join(', ') || '—'}</td>
+                <td>
+                  <button class="btn-sm" onclick={() => startEdit(t)}>✏️ Bearbeiten</button>
+                  <button class="btn-sm btn-danger" onclick={() => deleteTemplate(t.id)}>🗑</button>
+                </td>
+              </tr>
+            {/each}
+          </tbody>
+        </table>
+      {/if}
+    </div>
+  {/if}
+</div>
+
+<style>
+  .settings { max-width: 960px; margin: 0 auto; padding: 1rem 1.5rem 3rem; }
+  .tabs { display: flex; gap: 0.5rem; margin-bottom: 1.5rem; border-bottom: 1px solid var(--line,#333); }
+  .tab { padding: 0.5rem 1rem; background: none; border: none; color: var(--text-muted,#888); cursor: pointer; font-size: 0.9rem; border-bottom: 2px solid transparent; margin-bottom: -1px; }
+  .tab.active { color: var(--gold,#c9a55c); border-bottom-color: var(--gold,#c9a55c); }
+
+  .ki-grid-header { display: flex; justify-content: flex-end; margin-bottom: 0.75rem; }
+  .ki-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(220px, 1fr)); gap: 1rem; }
+  .provider-card { padding: 1.2rem; border: 1px solid var(--line,#333); border-radius: 8px; background: var(--bg-2,#1a1a1a); display: flex; flex-direction: column; gap: 0.4rem; }
+  .provider-card.active { border-color: var(--gold,#c9a55c); }
+  .card-head { display: flex; align-items: center; justify-content: space-between; gap: 0.5rem; }
+  .provider-name { font-weight: 700; color: var(--text-light,#f0f0f0); margin-top: 0.2rem; }
+  .provider-model { font-size: 0.78rem; color: var(--text-muted,#888); }
+  .provider-key { font-size: 0.72rem; color: #4ade80; font-family: monospace; }
+  .provider-key.warn { color: #f97316; }
+  .active-badge { color: var(--gold,#c9a55c); font-size: 0.78rem; font-weight: 600; white-space: nowrap; }
+  .provider-actions { display: flex; gap: 0.4rem; align-items: center; margin-top: 0.5rem; flex-wrap: wrap; }
+  .btn-activate { padding: 0.4rem 0.8rem; background: var(--gold,#c9a55c); color: #111; border: none; border-radius: 4px; cursor: pointer; font-weight: 600; font-size: 0.82rem; }
+  .btn-activate:disabled { opacity: 0.5; cursor: not-allowed; }
+
+  .provider-badge { font-size: 0.7rem; font-weight: 700; padding: 0.15rem 0.5rem; border-radius: 99px; letter-spacing: 0.03em; }
+  .provider-badge.claude  { background: #7c3aed22; color: #a78bfa; border: 1px solid #7c3aed44; }
+  .provider-badge.openai  { background: #16a34a22; color: #4ade80; border: 1px solid #16a34a44; }
+  .provider-badge.mistral { background: #ea580c22; color: #fb923c; border: 1px solid #ea580c44; }
+  .provider-badge.lumo    { background: #0891b222; color: #38bdf8; border: 1px solid #0891b244; }
+  .provider-badge.custom  { background: #52525b22; color: #a1a1aa; border: 1px solid #52525b44; }
+
+  .edit-panel { border: 1px solid var(--gold,#c9a55c); border-radius: 10px; background: var(--bg-2,#1a1a1a); padding: 1.5rem; display: flex; flex-direction: column; gap: 1.25rem; }
+  .edit-panel-header { display: flex; align-items: center; justify-content: space-between; gap: 1rem; }
+  .edit-title { display: flex; align-items: center; gap: 0.75rem; font-weight: 700; color: var(--text-light,#f0f0f0); }
+  .edit-tabs { display: flex; gap: 0.5rem; border-bottom: 1px solid var(--line,#333); }
+  .edit-tab { padding: 0.4rem 1rem; background: none; border: none; color: var(--text-muted,#888); cursor: pointer; font-size: 0.85rem; border-bottom: 2px solid transparent; margin-bottom: -1px; }
+  .edit-tab.active { color: var(--gold,#c9a55c); border-bottom-color: var(--gold,#c9a55c); }
+  .edit-section { display: flex; flex-direction: column; gap: 0.9rem; padding-top: 0.5rem; }
+  .field-label { display: flex; flex-direction: column; gap: 0.3rem; font-size: 0.8rem; color: var(--text-muted,#888); }
+  .field-label input, .field-label textarea, .field-label select {
+    padding: 0.45rem 0.7rem; background: var(--bg-dark,#111); border: 1px solid var(--line,#333);
+    border-radius: 6px; color: var(--text-light,#f0f0f0); font-size: 0.88rem; outline: none; resize: vertical;
+  }
+  .field-label textarea { min-height: 80px; }
+  .field-row { display: flex; gap: 1rem; flex-wrap: wrap; }
+  .field-row .field-label { flex: 1; min-width: 120px; }
+  .checkbox-label { display: flex; align-items: center; gap: 0.5rem; font-size: 0.85rem; color: var(--text-muted,#888); cursor: pointer; }
+  .checkbox-label input[type="checkbox"] { width: 16px; height: 16px; accent-color: var(--gold,#c9a55c); cursor: pointer; }
+  .api-key-row { display: flex; gap: 0.4rem; align-items: center; }
+  .api-key-input { flex: 1; }
+  .btn-icon { padding: 0.4rem 0.6rem; background: var(--bg-2,#1a1a1a); border: 1px solid var(--line,#333); border-radius: 6px; cursor: pointer; font-size: 0.9rem; }
+  .lumo-info { background: #0891b211; border: 1px solid #0891b244; border-radius: 8px; padding: 0.9rem 1rem; color: #38bdf8; font-size: 0.85rem; line-height: 1.5; }
+  .fields-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); gap: 0.4rem 1rem; margin-top: 0.4rem; }
+  code { font-family: monospace; background: var(--bg-dark,#111); padding: 0.1rem 0.3rem; border-radius: 3px; font-size: 0.85em; }
+
+  .edit-actions { display: flex; gap: 0.5rem; }
+  .btn-sm { padding: 0.3rem 0.7rem; border: 1px solid var(--line,#444); border-radius: 4px; font-size: 0.82rem; color: var(--text-muted,#888); background: none; cursor: pointer; }
+  .btn-danger { border-color: #ef4444; color: #ef4444; }
+  .btn-primary { padding: 0.5rem 1.2rem; background: var(--gold,#c9a55c); color: #111; border: none; border-radius: 6px; cursor: pointer; font-weight: 700; font-size: 0.85rem; }
+  .btn-primary:disabled { opacity: 0.5; cursor: not-allowed; }
+
+  .table { width: 100%; border-collapse: collapse; }
+  .table th { text-align: left; padding: 0.5rem 0.75rem; border-bottom: 1px solid var(--line,#333); font-size: 0.82rem; color: var(--text-muted,#888); }
+  .table td { padding: 0.6rem 0.75rem; border-bottom: 1px solid var(--line,#222); font-size: 0.88rem; }
+  .templates-header { display: flex; justify-content: flex-end; margin-bottom: 0.75rem; }
+  .edit-modal { background: var(--bg-2,#1a1a1a); border: 1px solid var(--gold,#c9a55c); border-radius: 8px; padding: 1.5rem; display: flex; flex-direction: column; gap: 1rem; }
+  .edit-modal label { display: flex; flex-direction: column; gap: 0.3rem; font-size: 0.82rem; color: var(--text-muted,#888); }
+  .edit-modal input, .edit-modal textarea { padding: 0.5rem 0.75rem; background: var(--bg-dark,#111); border: 1px solid var(--line,#333); border-radius: 6px; color: var(--text-light,#f0f0f0); font-size: 0.88rem; outline: none; resize: vertical; }
+  .edit-modal select { padding: 0.5rem 0.75rem; background: var(--bg-dark,#111); border: 1px solid var(--line,#333); border-radius: 6px; color: var(--text-light,#f0f0f0); font-size: 0.88rem; }
+</style>
+```
+
+- [ ] **Schritt 3: TypeScript-Check + Build**
+
+```bash
+cd website && pnpm tsc --noEmit 2>&1 | grep "error TS" | head -20
+```
+
+Erwartung: keine TS-Fehler.
+
+- [ ] **Schritt 4: Commit**
+
+```bash
+git add website/src/components/admin/coaching/CoachingSettings.svelte
+git commit -m "feat(coaching): custom provider creation form + field selector + delete [T000418]"
+```
+
+---
+
+## Task 5: Gesamtverifikation
+
+- [ ] **Schritt 1: Alle Unit-Tests laufen lassen**
+
+```bash
+cd website && pnpm test 2>&1 | tail -30
+```
+
+Erwartung: alle Tests PASS, kein `coaching-ki-config-db` FAIL.
+
+- [ ] **Schritt 2: Manifest-Validierung**
+
+```bash
+cd .. && task workspace:validate 2>&1 | tail -5
+```
+
+Erwartung: kein Fehler.
+
+- [ ] **Schritt 3: Push + PR updaten**
+
+```bash
+git push origin feature/coaching-ki-provider-profiles-und-klienten
+```
+
+PR #795 wird automatisch aktualisiert.
+
+---
+
+## Self-Review
+
+**Spec Coverage:**
+- ✅ Formulare je Anbieter (Claude/ChatGPT/Mistral/Lumo) — bereits auf Branch, kein neuer Code nötig
+- ✅ Gemeinsame Felder: Name, API-Endpoint, API-Key (masked), Modell, Temperature, Max Tokens, System-Prompt, Notiz
+- ✅ Anbieterspezifische Felder: top_p/top_k (Claude+Mistral), Thinking-Modus (Claude), presence/frequency penalty + org-id (ChatGPT), safe_prompt/random_seed/EU-Endpoint (Mistral), Hinweistext (Lumo)
+- ✅ Custom-Provider anlegen mit individueller Feldzuordnung
+- ✅ Custom-Provider löschen (Standard-Provider geschützt)
+- ✅ DB-Migration: CHECK-Constraint weg, enabled_fields hinzu
+- ✅ API: POST (create), DELETE (delete)
+- ✅ UI: Anlegen-Formular mit Feldauswahl-Grid, Löschen-Button, Custom-Badge
+
+**Placeholder-Scan:** keine TBDs, alle Code-Blöcke vollständig.
+
+**Typ-Konsistenz:**
+- `KiConfig.provider` ist nun `string` statt Union — `setActiveProvider` akzeptiert `string` ✓
+- `enabledFields: string[] | null` konsistent durch alle Schichten ✓
+- `showField(p: KiConfig, field: string)` — nimmt jetzt `KiConfig` statt `string` für korrekte Custom-Auflösung ✓
+- `createKiProvider` gibt `KiConfig` zurück ✓
+- Test-Import: `createKiProvider, deleteKiProvider` neu im Import ✓

--- a/k3d/website-schema.yaml
+++ b/k3d/website-schema.yaml
@@ -1046,6 +1046,23 @@ data:
       ALTER TABLE coaching.ki_config ADD COLUMN IF NOT EXISTS organization_id TEXT;
       ALTER TABLE coaching.ki_config ADD COLUMN IF NOT EXISTS eu_endpoint BOOLEAN NOT NULL DEFAULT false;
 
+      -- Custom KI-Anbieter: CHECK-Constraint entfernen + enabled_fields (idempotent)
+      DO $$
+      DECLARE v_con text;
+      BEGIN
+        SELECT c.conname INTO v_con
+        FROM pg_constraint c
+        JOIN pg_class t ON c.conrelid = t.oid
+        JOIN pg_namespace n ON t.relnamespace = n.oid
+        WHERE n.nspname = 'coaching' AND t.relname = 'ki_config'
+          AND c.contype = 'c' AND c.conname LIKE '%provider%'
+        LIMIT 1;
+        IF v_con IS NOT NULL THEN
+          EXECUTE 'ALTER TABLE coaching.ki_config DROP CONSTRAINT ' || quote_ident(v_con);
+        END IF;
+      END $$;
+      ALTER TABLE coaching.ki_config ADD COLUMN IF NOT EXISTS enabled_fields JSONB;
+
       -- Per-Session KI-Auswahl
       ALTER TABLE coaching.sessions ADD COLUMN IF NOT EXISTS ki_config_id INT REFERENCES coaching.ki_config(id) ON DELETE SET NULL;
 

--- a/k3d/website-schema.yaml
+++ b/k3d/website-schema.yaml
@@ -1029,6 +1029,26 @@ data:
       ALTER DEFAULT PRIVILEGES IN SCHEMA coaching GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO website;
       ALTER DEFAULT PRIVILEGES IN SCHEMA coaching GRANT USAGE, SELECT ON SEQUENCES TO website;
 
+      -- KI-Provider-Profile: erweiterte Konfigurationsfelder (idempotent)
+      ALTER TABLE coaching.ki_config ADD COLUMN IF NOT EXISTS api_key TEXT;
+      ALTER TABLE coaching.ki_config ADD COLUMN IF NOT EXISTS api_endpoint TEXT;
+      ALTER TABLE coaching.ki_config ADD COLUMN IF NOT EXISTS temperature NUMERIC(5,3);
+      ALTER TABLE coaching.ki_config ADD COLUMN IF NOT EXISTS max_tokens INT;
+      ALTER TABLE coaching.ki_config ADD COLUMN IF NOT EXISTS top_p NUMERIC(5,3);
+      ALTER TABLE coaching.ki_config ADD COLUMN IF NOT EXISTS system_prompt TEXT;
+      ALTER TABLE coaching.ki_config ADD COLUMN IF NOT EXISTS notes TEXT;
+      ALTER TABLE coaching.ki_config ADD COLUMN IF NOT EXISTS top_k INT;
+      ALTER TABLE coaching.ki_config ADD COLUMN IF NOT EXISTS thinking_mode BOOLEAN NOT NULL DEFAULT false;
+      ALTER TABLE coaching.ki_config ADD COLUMN IF NOT EXISTS presence_penalty NUMERIC(5,3);
+      ALTER TABLE coaching.ki_config ADD COLUMN IF NOT EXISTS frequency_penalty NUMERIC(5,3);
+      ALTER TABLE coaching.ki_config ADD COLUMN IF NOT EXISTS safe_prompt BOOLEAN NOT NULL DEFAULT false;
+      ALTER TABLE coaching.ki_config ADD COLUMN IF NOT EXISTS random_seed INT;
+      ALTER TABLE coaching.ki_config ADD COLUMN IF NOT EXISTS organization_id TEXT;
+      ALTER TABLE coaching.ki_config ADD COLUMN IF NOT EXISTS eu_endpoint BOOLEAN NOT NULL DEFAULT false;
+
+      -- Per-Session KI-Auswahl
+      ALTER TABLE coaching.sessions ADD COLUMN IF NOT EXISTS ki_config_id INT REFERENCES coaching.ki_config(id) ON DELETE SET NULL;
+
       CREATE INDEX IF NOT EXISTS idx_meetings_customer ON meetings(customer_id);
       CREATE INDEX IF NOT EXISTS idx_meetings_status ON meetings(status);
       CREATE INDEX IF NOT EXISTS idx_transcripts_meeting ON transcripts(meeting_id);

--- a/website/pnpm-workspace.yaml
+++ b/website/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+allowBuilds:
+  esbuild: set this to true or false
+  sharp: set this to true or false

--- a/website/src/components/admin/coaching/CoachingSettings.svelte
+++ b/website/src/components/admin/coaching/CoachingSettings.svelte
@@ -23,6 +23,34 @@
   let savingProviderEdit = $state(false);
   let showApiKey = $state(false);
 
+  // Custom-Provider Anlegen
+  let creatingProvider = $state(false);
+  let savingNewProvider = $state(false);
+  let newProviderForm = $state({
+    displayName: '',
+    slug: '',
+    enabledFields: [] as string[],
+  });
+
+  const ALL_FIELDS: { key: string; label: string }[] = [
+    { key: 'apiKey',           label: 'API-Key' },
+    { key: 'apiEndpoint',      label: 'API-Endpunkt' },
+    { key: 'modelName',        label: 'Modell' },
+    { key: 'temperature',      label: 'Temperature' },
+    { key: 'maxTokens',        label: 'Max Tokens' },
+    { key: 'topP',             label: 'top_p' },
+    { key: 'topK',             label: 'top_k' },
+    { key: 'thinkingMode',     label: 'Thinking-Modus (Claude)' },
+    { key: 'presencePenalty',  label: 'Presence Penalty' },
+    { key: 'frequencyPenalty', label: 'Frequency Penalty' },
+    { key: 'safePrompt',       label: 'Safe Prompt (Mistral)' },
+    { key: 'randomSeed',       label: 'Random Seed' },
+    { key: 'organizationId',   label: 'Organization ID' },
+    { key: 'euEndpoint',       label: 'EU-Endpunkt (DSGVO)' },
+    { key: 'systemPrompt',     label: 'System-Prompt' },
+    { key: 'notes',            label: 'Notiz / Freitext' },
+  ];
+
   type ProviderFields = {
     displayName: string; modelName: string;
     apiKey: string; apiEndpoint: string;
@@ -55,23 +83,29 @@
     return isNaN(v) ? null : v;
   }
 
-  // Feldsichtbarkeit exakt nach PDF-Tabelle
-  function showField(provider: string, field: string): boolean {
-    const map: Record<string, string[]> = {
-      claude:  ['apiKey', 'apiEndpoint', 'modelName', 'temperature', 'maxTokens', 'topP', 'topK', 'thinkingMode', 'systemPrompt', 'notes'],
-      openai:  ['apiKey', 'apiEndpoint', 'modelName', 'temperature', 'maxTokens', 'topP', 'presencePenalty', 'frequencyPenalty', 'organizationId', 'systemPrompt', 'notes'],
-      mistral: ['apiKey', 'apiEndpoint', 'modelName', 'temperature', 'maxTokens', 'topP', 'topK', 'safePrompt', 'randomSeed', 'euEndpoint', 'systemPrompt', 'notes'],
-      lumo:    ['euEndpoint', 'notes'],
-    };
-    return (map[provider] ?? []).includes(field);
+  const KNOWN_FIELD_MAP: Record<string, string[]> = {
+    claude:  ['apiKey', 'apiEndpoint', 'modelName', 'temperature', 'maxTokens', 'topP', 'topK', 'thinkingMode', 'systemPrompt', 'notes'],
+    openai:  ['apiKey', 'apiEndpoint', 'modelName', 'temperature', 'maxTokens', 'topP', 'presencePenalty', 'frequencyPenalty', 'organizationId', 'systemPrompt', 'notes'],
+    mistral: ['apiKey', 'apiEndpoint', 'modelName', 'temperature', 'maxTokens', 'topP', 'topK', 'safePrompt', 'randomSeed', 'euEndpoint', 'systemPrompt', 'notes'],
+    lumo:    ['euEndpoint', 'notes'],
+  };
+
+  function showField(p: KiConfig, field: string): boolean {
+    if (p.enabledFields !== null) return p.enabledFields.includes(field);
+    return (KNOWN_FIELD_MAP[p.provider] ?? []).includes(field);
   }
 
   const PROVIDER_BADGE: Record<string, string> = {
-    claude:  'Anthropic',
-    openai:  'OpenAI',
-    mistral: 'Mistral AI',
-    lumo:    'Lumo',
+    claude: 'Anthropic', openai: 'OpenAI', mistral: 'Mistral AI', lumo: 'Lumo',
   };
+
+  function providerBadgeLabel(p: KiConfig): string {
+    return PROVIDER_BADGE[p.provider] ?? (p.displayName || p.provider);
+  }
+
+  function isCustom(p: KiConfig): boolean {
+    return p.provider.startsWith('custom_');
+  }
 
   function startEditProvider(p: KiConfig) {
     editingProvider = p;
@@ -101,7 +135,7 @@
   async function saveProviderEdit() {
     if (!editingProvider) return;
     savingProviderEdit = true;
-    const prov = editingProvider.provider;
+    const p = editingProvider;
     const payload: Record<string, unknown> = {
       displayName: providerFields.displayName,
       modelName: providerFields.modelName.trim() || null,
@@ -113,23 +147,21 @@
       systemPrompt: providerFields.systemPrompt.trim() || null,
       notes: providerFields.notes.trim() || null,
     };
-    if (showField(prov, 'topK'))           payload.topK = parseInt2(providerFields.topK);
-    if (showField(prov, 'thinkingMode'))   payload.thinkingMode = providerFields.thinkingMode;
-    if (showField(prov, 'presencePenalty'))  payload.presencePenalty = parseNum(providerFields.presencePenalty);
-    if (showField(prov, 'frequencyPenalty')) payload.frequencyPenalty = parseNum(providerFields.frequencyPenalty);
-    if (showField(prov, 'safePrompt'))     payload.safePrompt = providerFields.safePrompt;
-    if (showField(prov, 'randomSeed'))     payload.randomSeed = parseInt2(providerFields.randomSeed);
-    if (showField(prov, 'organizationId')) payload.organizationId = providerFields.organizationId.trim() || null;
-    if (showField(prov, 'euEndpoint'))     payload.euEndpoint = providerFields.euEndpoint;
+    if (showField(p, 'topK'))             payload.topK = parseInt2(providerFields.topK);
+    if (showField(p, 'thinkingMode'))     payload.thinkingMode = providerFields.thinkingMode;
+    if (showField(p, 'presencePenalty'))  payload.presencePenalty = parseNum(providerFields.presencePenalty);
+    if (showField(p, 'frequencyPenalty')) payload.frequencyPenalty = parseNum(providerFields.frequencyPenalty);
+    if (showField(p, 'safePrompt'))       payload.safePrompt = providerFields.safePrompt;
+    if (showField(p, 'randomSeed'))       payload.randomSeed = parseInt2(providerFields.randomSeed);
+    if (showField(p, 'organizationId'))   payload.organizationId = providerFields.organizationId.trim() || null;
+    if (showField(p, 'euEndpoint'))       payload.euEndpoint = providerFields.euEndpoint;
 
-    await fetch(`/api/admin/coaching/ki-config/${editingProvider.id}`, {
+    await fetch(`/api/admin/coaching/ki-config/${p.id}`, {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload),
     });
-    const res = await fetch('/api/admin/coaching/ki-config');
-    const data = await res.json();
-    providers = data.providers;
+    providers = (await (await fetch('/api/admin/coaching/ki-config')).json()).providers;
     editingProvider = null;
     savingProviderEdit = false;
   }
@@ -141,12 +173,46 @@
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ provider }),
     });
-    const res = await fetch('/api/admin/coaching/ki-config');
-    const data = await res.json();
-    providers = data.providers;
+    providers = (await (await fetch('/api/admin/coaching/ki-config')).json()).providers;
     savingProvider = null;
   }
 
+  function toggleNewField(key: string) {
+    if (newProviderForm.enabledFields.includes(key)) {
+      newProviderForm.enabledFields = newProviderForm.enabledFields.filter(k => k !== key);
+    } else {
+      newProviderForm.enabledFields = [...newProviderForm.enabledFields, key];
+    }
+  }
+
+  async function saveNewProvider() {
+    savingNewProvider = true;
+    const res = await fetch('/api/admin/coaching/ki-config', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        displayName: newProviderForm.displayName.trim(),
+        slug: newProviderForm.slug.trim(),
+        enabledFields: newProviderForm.enabledFields,
+      }),
+    });
+    const data = await res.json();
+    if (!res.ok) { alert(data.error ?? 'Fehler beim Anlegen'); savingNewProvider = false; return; }
+    providers = (await (await fetch('/api/admin/coaching/ki-config')).json()).providers;
+    creatingProvider = false;
+    newProviderForm = { displayName: '', slug: '', enabledFields: [] };
+    savingNewProvider = false;
+  }
+
+  async function deleteProvider(p: KiConfig) {
+    if (!confirm(`Anbieter "${p.displayName}" wirklich löschen?`)) return;
+    const res = await fetch(`/api/admin/coaching/ki-config/${p.id}`, { method: 'DELETE' });
+    const data = await res.json();
+    if (!res.ok) { alert(data.error ?? 'Fehler beim Löschen'); return; }
+    providers = providers.filter(x => x.id !== p.id);
+  }
+
+  // Templates
   function startEdit(t: StepTemplate) {
     editingTemplate = t;
     editFields = {
@@ -191,9 +257,7 @@
         method: 'PATCH', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload),
       });
     }
-    const res = await fetch('/api/admin/coaching/step-templates');
-    const data = await res.json();
-    templates = data.templates;
+    templates = (await (await fetch('/api/admin/coaching/step-templates')).json()).templates;
     editingTemplate = null;
   }
 
@@ -217,7 +281,7 @@
       <div class="edit-panel">
         <div class="edit-panel-header">
           <div class="edit-title">
-            <span class="provider-badge {editingProvider.provider}">{PROVIDER_BADGE[editingProvider.provider] ?? editingProvider.provider}</span>
+            <span class="provider-badge {isCustom(editingProvider) ? 'custom' : editingProvider.provider}">{providerBadgeLabel(editingProvider)}</span>
             <span>{editingProvider.displayName}</span>
           </div>
           <button class="btn-sm" onclick={() => editingProvider = null}>✕ Schließen</button>
@@ -230,54 +294,46 @@
 
         {#if providerEditTab === 'connection'}
           <div class="edit-section">
-            <!-- Name / Label immer sichtbar -->
             <label class="field-label">Name / Label
               <input type="text" bind:value={providerFields.displayName} />
             </label>
-
             {#if editingProvider.provider === 'lumo'}
-              <!-- Lumo: kein API-Key, kein Endpoint, kein Modell — nur Infobox + EU-Endpoint -->
               <div class="lumo-info">
-                <strong>Lumo (Proton)</strong> hat derzeit keine öffentliche API — das Profil dient als Platzhalter. Sobald eine API verfügbar ist, kann sie hier konfiguriert werden.
+                <strong>Lumo (Proton)</strong> hat derzeit keine öffentliche API — das Profil dient als Platzhalter.
               </div>
               <label class="checkbox-label">
                 <input type="checkbox" bind:checked={providerFields.euEndpoint} />
                 EU-Endpunkt verwenden (DSGVO)
               </label>
             {:else}
-              <!-- Modell: Claude, ChatGPT, Mistral -->
-              <label class="field-label">Modell (z.B. claude-sonnet-4-5, gpt-4o, mistral-small-latest)
-                <input type="text" bind:value={providerFields.modelName} placeholder="leer = Standardmodell" />
-              </label>
-
-              <!-- API-Key: Claude, ChatGPT, Mistral -->
-              <label class="field-label">API-Key
-                <div class="api-key-row">
-                  {#if showApiKey}
-                    <input type="text" bind:value={providerFields.apiKey} placeholder="sk-..." class="api-key-input" />
-                  {:else}
-                    <input type="password" bind:value={providerFields.apiKey} placeholder="sk-..." class="api-key-input" />
-                  {/if}
-                  <button class="btn-icon" onclick={() => showApiKey = !showApiKey} title={showApiKey ? 'Verbergen' : 'Anzeigen'}>
-                    {showApiKey ? '🙈' : '👁'}
-                  </button>
-                </div>
-              </label>
-
-              <!-- API-Endpoint: Claude, ChatGPT, Mistral -->
-              <label class="field-label">API-Endpunkt (optional — überschreibt Standard-URL)
-                <input type="url" bind:value={providerFields.apiEndpoint} placeholder="https://api.example.com/v1" />
-              </label>
-
-              <!-- Organization-ID: nur OpenAI/ChatGPT -->
-              {#if showField(editingProvider.provider, 'organizationId')}
+              {#if showField(editingProvider, 'modelName')}
+                <label class="field-label">Modell
+                  <input type="text" bind:value={providerFields.modelName} placeholder="leer = Standardmodell" />
+                </label>
+              {/if}
+              {#if showField(editingProvider, 'apiKey')}
+                <label class="field-label">API-Key
+                  <div class="api-key-row">
+                    {#if showApiKey}
+                      <input type="text" bind:value={providerFields.apiKey} placeholder="sk-..." class="api-key-input" />
+                    {:else}
+                      <input type="password" bind:value={providerFields.apiKey} placeholder="sk-..." class="api-key-input" />
+                    {/if}
+                    <button class="btn-icon" onclick={() => showApiKey = !showApiKey}>{showApiKey ? '🙈' : '👁'}</button>
+                  </div>
+                </label>
+              {/if}
+              {#if showField(editingProvider, 'apiEndpoint')}
+                <label class="field-label">API-Endpunkt (optional)
+                  <input type="url" bind:value={providerFields.apiEndpoint} placeholder="https://api.example.com/v1" />
+                </label>
+              {/if}
+              {#if showField(editingProvider, 'organizationId')}
                 <label class="field-label">Organization ID (optional)
                   <input type="text" bind:value={providerFields.organizationId} placeholder="org-..." />
                 </label>
               {/if}
-
-              <!-- EU-Endpoint Flag: Mistral -->
-              {#if showField(editingProvider.provider, 'euEndpoint')}
+              {#if showField(editingProvider, 'euEndpoint')}
                 <label class="checkbox-label">
                   <input type="checkbox" bind:checked={providerFields.euEndpoint} />
                   EU-Endpunkt verwenden
@@ -285,47 +341,42 @@
               {/if}
             {/if}
           </div>
-
         {:else}
-          <!-- Verhalten-Tab -->
           <div class="edit-section">
             {#if editingProvider.provider === 'lumo'}
               <p class="lumo-info">Lumo unterstützt derzeit keine konfigurierbaren Verhaltenparameter.</p>
             {:else}
-              <!-- Temperature / Max Tokens / top_p: Claude, ChatGPT, Mistral -->
               <div class="field-row">
-                <label class="field-label">Temperature (0.0–2.0)
-                  <input type="number" step="0.01" min="0" max="2" bind:value={providerFields.temperature} placeholder="leer = Standard" />
-                </label>
-                <label class="field-label">Max Tokens
-                  <input type="number" min="1" bind:value={providerFields.maxTokens} placeholder="leer = Standard" />
-                </label>
-                {#if showField(editingProvider.provider, 'topP')}
+                {#if showField(editingProvider, 'temperature')}
+                  <label class="field-label">Temperature (0.0–2.0)
+                    <input type="number" step="0.01" min="0" max="2" bind:value={providerFields.temperature} placeholder="leer = Standard" />
+                  </label>
+                {/if}
+                {#if showField(editingProvider, 'maxTokens')}
+                  <label class="field-label">Max Tokens
+                    <input type="number" min="1" bind:value={providerFields.maxTokens} placeholder="leer = Standard" />
+                  </label>
+                {/if}
+                {#if showField(editingProvider, 'topP')}
                   <label class="field-label">top_p
                     <input type="number" step="0.01" min="0" max="1" bind:value={providerFields.topP} placeholder="leer = Standard" />
                   </label>
                 {/if}
               </div>
-
-              <!-- top_k: Claude + Mistral -->
-              {#if showField(editingProvider.provider, 'topK')}
+              {#if showField(editingProvider, 'topK')}
                 <div class="field-row">
                   <label class="field-label">top_k
                     <input type="number" min="1" bind:value={providerFields.topK} placeholder="leer = Standard" />
                   </label>
                 </div>
               {/if}
-
-              <!-- Extended Thinking: nur Claude -->
-              {#if showField(editingProvider.provider, 'thinkingMode')}
+              {#if showField(editingProvider, 'thinkingMode')}
                 <label class="checkbox-label">
                   <input type="checkbox" bind:checked={providerFields.thinkingMode} />
                   Extended Thinking aktivieren (Claude)
                 </label>
               {/if}
-
-              <!-- Presence- / Frequency-Penalty: nur ChatGPT -->
-              {#if showField(editingProvider.provider, 'presencePenalty')}
+              {#if showField(editingProvider, 'presencePenalty')}
                 <div class="field-row">
                   <label class="field-label">Presence Penalty (–2 bis 2)
                     <input type="number" step="0.01" min="-2" max="2" bind:value={providerFields.presencePenalty} placeholder="leer = Standard" />
@@ -335,32 +386,28 @@
                   </label>
                 </div>
               {/if}
-
-              <!-- Safe Prompt / Random Seed: nur Mistral -->
-              {#if showField(editingProvider.provider, 'safePrompt')}
+              {#if showField(editingProvider, 'safePrompt')}
                 <label class="checkbox-label">
                   <input type="checkbox" bind:checked={providerFields.safePrompt} />
                   Safe Prompt aktivieren (Mistral)
                 </label>
               {/if}
-              {#if showField(editingProvider.provider, 'randomSeed')}
+              {#if showField(editingProvider, 'randomSeed')}
                 <label class="field-label">Random Seed (leer = zufällig)
                   <input type="number" bind:value={providerFields.randomSeed} placeholder="z.B. 42" />
                 </label>
               {/if}
-
-              <!-- System-Prompt: Claude, ChatGPT, Mistral -->
-              {#if showField(editingProvider.provider, 'systemPrompt')}
-                <label class="field-label">System-Prompt (überschreibt den Template-Prompt wenn gesetzt)
-                  <textarea rows="5" bind:value={providerFields.systemPrompt} placeholder="Optionaler System-Prompt für dieses KI-Profil…"></textarea>
+              {#if showField(editingProvider, 'systemPrompt')}
+                <label class="field-label">System-Prompt
+                  <textarea rows="5" bind:value={providerFields.systemPrompt} placeholder="Optionaler System-Prompt…"></textarea>
                 </label>
               {/if}
             {/if}
-
-            <!-- Notiz / Freitext: alle Provider -->
-            <label class="field-label">Notiz / Freitext
-              <textarea rows="2" bind:value={providerFields.notes} placeholder="Interne Beschreibung, Hinweise, Zweck dieses Profils…"></textarea>
-            </label>
+            {#if showField(editingProvider, 'notes')}
+              <label class="field-label">Notiz / Freitext
+                <textarea rows="2" bind:value={providerFields.notes} placeholder="Interne Beschreibung…"></textarea>
+              </label>
+            {/if}
           </div>
         {/if}
 
@@ -372,12 +419,51 @@
         </div>
       </div>
 
+    {:else if creatingProvider}
+      <div class="edit-panel">
+        <div class="edit-panel-header">
+          <div class="edit-title">Neuer KI-Anbieter</div>
+          <button class="btn-sm" onclick={() => creatingProvider = false}>✕ Schließen</button>
+        </div>
+        <div class="edit-section">
+          <label class="field-label">Name / Label
+            <input type="text" bind:value={newProviderForm.displayName} placeholder="z.B. Mein eigener GPT" />
+          </label>
+          <label class="field-label">Interner Slug (nur a–z, 0–9, Bindestrich — wird zu <code>custom_&lt;slug&gt;</code>)
+            <input type="text" bind:value={newProviderForm.slug} placeholder="z.B. mein-gpt" />
+          </label>
+          <div class="field-label">Verfügbare Felder auswählen
+            <div class="fields-grid">
+              {#each ALL_FIELDS as f}
+                <label class="checkbox-label">
+                  <input
+                    type="checkbox"
+                    checked={newProviderForm.enabledFields.includes(f.key)}
+                    onchange={() => toggleNewField(f.key)}
+                  />
+                  {f.label}
+                </label>
+              {/each}
+            </div>
+          </div>
+        </div>
+        <div class="edit-actions">
+          <button class="btn-primary" onclick={saveNewProvider} disabled={savingNewProvider}>
+            {savingNewProvider ? 'Anlegen…' : 'Anbieter anlegen'}
+          </button>
+          <button class="btn-sm" onclick={() => creatingProvider = false}>Abbrechen</button>
+        </div>
+      </div>
+
     {:else}
+      <div class="ki-grid-header">
+        <button class="btn-primary" onclick={() => creatingProvider = true}>+ Neuer KI-Anbieter</button>
+      </div>
       <div class="ki-grid">
         {#each providers as p}
           <div class="provider-card {p.isActive ? 'active' : ''}">
             <div class="card-head">
-              <span class="provider-badge {p.provider}">{PROVIDER_BADGE[p.provider] ?? p.provider}</span>
+              <span class="provider-badge {isCustom(p) ? 'custom' : p.provider}">{providerBadgeLabel(p)}</span>
               {#if p.isActive}<span class="active-badge">● Aktiv</span>{/if}
             </div>
             <div class="provider-name">{p.displayName}</div>
@@ -394,6 +480,9 @@
                 </button>
               {/if}
               <button class="btn-sm" onclick={() => startEditProvider(p)}>Bearbeiten</button>
+              {#if isCustom(p)}
+                <button class="btn-sm btn-danger" onclick={() => deleteProvider(p)}>🗑</button>
+              {/if}
             </div>
           </div>
         {/each}
@@ -466,7 +555,7 @@
   .tab { padding: 0.5rem 1rem; background: none; border: none; color: var(--text-muted,#888); cursor: pointer; font-size: 0.9rem; border-bottom: 2px solid transparent; margin-bottom: -1px; }
   .tab.active { color: var(--gold,#c9a55c); border-bottom-color: var(--gold,#c9a55c); }
 
-  /* Provider cards */
+  .ki-grid-header { display: flex; justify-content: flex-end; margin-bottom: 0.75rem; }
   .ki-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(220px, 1fr)); gap: 1rem; }
   .provider-card { padding: 1.2rem; border: 1px solid var(--line,#333); border-radius: 8px; background: var(--bg-2,#1a1a1a); display: flex; flex-direction: column; gap: 0.4rem; }
   .provider-card.active { border-color: var(--gold,#c9a55c); }
@@ -480,14 +569,13 @@
   .btn-activate { padding: 0.4rem 0.8rem; background: var(--gold,#c9a55c); color: #111; border: none; border-radius: 4px; cursor: pointer; font-weight: 600; font-size: 0.82rem; }
   .btn-activate:disabled { opacity: 0.5; cursor: not-allowed; }
 
-  /* Provider badges */
   .provider-badge { font-size: 0.7rem; font-weight: 700; padding: 0.15rem 0.5rem; border-radius: 99px; letter-spacing: 0.03em; }
   .provider-badge.claude  { background: #7c3aed22; color: #a78bfa; border: 1px solid #7c3aed44; }
   .provider-badge.openai  { background: #16a34a22; color: #4ade80; border: 1px solid #16a34a44; }
   .provider-badge.mistral { background: #ea580c22; color: #fb923c; border: 1px solid #ea580c44; }
   .provider-badge.lumo    { background: #0891b222; color: #38bdf8; border: 1px solid #0891b244; }
+  .provider-badge.custom  { background: #52525b22; color: #a1a1aa; border: 1px solid #52525b44; }
 
-  /* Edit panel */
   .edit-panel { border: 1px solid var(--gold,#c9a55c); border-radius: 10px; background: var(--bg-2,#1a1a1a); padding: 1.5rem; display: flex; flex-direction: column; gap: 1.25rem; }
   .edit-panel-header { display: flex; align-items: center; justify-content: space-between; gap: 1rem; }
   .edit-title { display: flex; align-items: center; gap: 0.75rem; font-weight: 700; color: var(--text-light,#f0f0f0); }
@@ -509,15 +597,15 @@
   .api-key-input { flex: 1; }
   .btn-icon { padding: 0.4rem 0.6rem; background: var(--bg-2,#1a1a1a); border: 1px solid var(--line,#333); border-radius: 6px; cursor: pointer; font-size: 0.9rem; }
   .lumo-info { background: #0891b211; border: 1px solid #0891b244; border-radius: 8px; padding: 0.9rem 1rem; color: #38bdf8; font-size: 0.85rem; line-height: 1.5; }
+  .fields-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); gap: 0.4rem 1rem; margin-top: 0.4rem; }
+  code { font-family: monospace; background: var(--bg-dark,#111); padding: 0.1rem 0.3rem; border-radius: 3px; font-size: 0.85em; }
 
-  /* Actions */
   .edit-actions { display: flex; gap: 0.5rem; }
   .btn-sm { padding: 0.3rem 0.7rem; border: 1px solid var(--line,#444); border-radius: 4px; font-size: 0.82rem; color: var(--text-muted,#888); background: none; cursor: pointer; }
   .btn-danger { border-color: #ef4444; color: #ef4444; }
   .btn-primary { padding: 0.5rem 1.2rem; background: var(--gold,#c9a55c); color: #111; border: none; border-radius: 6px; cursor: pointer; font-weight: 700; font-size: 0.85rem; }
   .btn-primary:disabled { opacity: 0.5; cursor: not-allowed; }
 
-  /* Templates */
   .table { width: 100%; border-collapse: collapse; }
   .table th { text-align: left; padding: 0.5rem 0.75rem; border-bottom: 1px solid var(--line,#333); font-size: 0.82rem; color: var(--text-muted,#888); }
   .table td { padding: 0.6rem 0.75rem; border-bottom: 1px solid var(--line,#222); font-size: 0.88rem; }

--- a/website/src/components/admin/coaching/CoachingSettings.svelte
+++ b/website/src/components/admin/coaching/CoachingSettings.svelte
@@ -55,12 +55,13 @@
     return isNaN(v) ? null : v;
   }
 
+  // Feldsichtbarkeit exakt nach PDF-Tabelle
   function showField(provider: string, field: string): boolean {
     const map: Record<string, string[]> = {
       claude:  ['apiKey', 'apiEndpoint', 'modelName', 'temperature', 'maxTokens', 'topP', 'topK', 'thinkingMode', 'systemPrompt', 'notes'],
       openai:  ['apiKey', 'apiEndpoint', 'modelName', 'temperature', 'maxTokens', 'topP', 'presencePenalty', 'frequencyPenalty', 'organizationId', 'systemPrompt', 'notes'],
-      mistral: ['apiKey', 'apiEndpoint', 'modelName', 'temperature', 'maxTokens', 'topP', 'safePrompt', 'randomSeed', 'euEndpoint', 'systemPrompt', 'notes'],
-      lumo:    ['apiEndpoint', 'modelName', 'temperature', 'maxTokens', 'euEndpoint', 'systemPrompt', 'notes'],
+      mistral: ['apiKey', 'apiEndpoint', 'modelName', 'temperature', 'maxTokens', 'topP', 'topK', 'safePrompt', 'randomSeed', 'euEndpoint', 'systemPrompt', 'notes'],
+      lumo:    ['euEndpoint', 'notes'],
     };
     return (map[provider] ?? []).includes(field);
   }
@@ -229,18 +230,27 @@
 
         {#if providerEditTab === 'connection'}
           <div class="edit-section">
+            <!-- Name / Label immer sichtbar -->
             <label class="field-label">Name / Label
               <input type="text" bind:value={providerFields.displayName} />
             </label>
-            <label class="field-label">Modell
-              <input type="text" bind:value={providerFields.modelName} placeholder="leer = Standard" />
-            </label>
 
             {#if editingProvider.provider === 'lumo'}
+              <!-- Lumo: kein API-Key, kein Endpoint, kein Modell — nur Infobox + EU-Endpoint -->
               <div class="lumo-info">
-                <strong>Lumo</strong> hat noch keine öffentliche API. Sobald eine API verfügbar ist, kann hier der Endpunkt konfiguriert werden.
+                <strong>Lumo (Proton)</strong> hat derzeit keine öffentliche API — das Profil dient als Platzhalter. Sobald eine API verfügbar ist, kann sie hier konfiguriert werden.
               </div>
+              <label class="checkbox-label">
+                <input type="checkbox" bind:checked={providerFields.euEndpoint} />
+                EU-Endpunkt verwenden (DSGVO)
+              </label>
             {:else}
+              <!-- Modell: Claude, ChatGPT, Mistral -->
+              <label class="field-label">Modell (z.B. claude-sonnet-4-5, gpt-4o, mistral-small-latest)
+                <input type="text" bind:value={providerFields.modelName} placeholder="leer = Standardmodell" />
+              </label>
+
+              <!-- API-Key: Claude, ChatGPT, Mistral -->
               <label class="field-label">API-Key
                 <div class="api-key-row">
                   {#if showApiKey}
@@ -253,87 +263,103 @@
                   </button>
                 </div>
               </label>
-            {/if}
 
-            {#if showField(editingProvider.provider, 'apiEndpoint')}
-              <label class="field-label">API-Endpunkt (optional, überschreibt Standard)
+              <!-- API-Endpoint: Claude, ChatGPT, Mistral -->
+              <label class="field-label">API-Endpunkt (optional — überschreibt Standard-URL)
                 <input type="url" bind:value={providerFields.apiEndpoint} placeholder="https://api.example.com/v1" />
               </label>
-            {/if}
 
-            {#if showField(editingProvider.provider, 'organizationId')}
-              <label class="field-label">Organization ID (OpenAI)
-                <input type="text" bind:value={providerFields.organizationId} placeholder="org-..." />
-              </label>
-            {/if}
-
-            {#if showField(editingProvider.provider, 'euEndpoint')}
-              <label class="checkbox-label">
-                <input type="checkbox" bind:checked={providerFields.euEndpoint} />
-                EU-Endpunkt verwenden
-              </label>
-            {/if}
-          </div>
-        {:else}
-          <div class="edit-section">
-            <div class="field-row">
-              <label class="field-label">Temperature
-                <input type="number" step="0.01" min="0" max="2" bind:value={providerFields.temperature} placeholder="leer = Standard" />
-              </label>
-              <label class="field-label">Max Tokens
-                <input type="number" min="1" bind:value={providerFields.maxTokens} placeholder="leer = Standard" />
-              </label>
-              {#if showField(editingProvider.provider, 'topP')}
-                <label class="field-label">top_p
-                  <input type="number" step="0.01" min="0" max="1" bind:value={providerFields.topP} placeholder="leer = Standard" />
+              <!-- Organization-ID: nur OpenAI/ChatGPT -->
+              {#if showField(editingProvider.provider, 'organizationId')}
+                <label class="field-label">Organization ID (optional)
+                  <input type="text" bind:value={providerFields.organizationId} placeholder="org-..." />
                 </label>
               {/if}
-            </div>
 
-            {#if showField(editingProvider.provider, 'topK')}
+              <!-- EU-Endpoint Flag: Mistral -->
+              {#if showField(editingProvider.provider, 'euEndpoint')}
+                <label class="checkbox-label">
+                  <input type="checkbox" bind:checked={providerFields.euEndpoint} />
+                  EU-Endpunkt verwenden
+                </label>
+              {/if}
+            {/if}
+          </div>
+
+        {:else}
+          <!-- Verhalten-Tab -->
+          <div class="edit-section">
+            {#if editingProvider.provider === 'lumo'}
+              <p class="lumo-info">Lumo unterstützt derzeit keine konfigurierbaren Verhaltenparameter.</p>
+            {:else}
+              <!-- Temperature / Max Tokens / top_p: Claude, ChatGPT, Mistral -->
               <div class="field-row">
-                <label class="field-label">top_k (Claude)
-                  <input type="number" min="1" bind:value={providerFields.topK} placeholder="leer = Standard" />
+                <label class="field-label">Temperature (0.0–2.0)
+                  <input type="number" step="0.01" min="0" max="2" bind:value={providerFields.temperature} placeholder="leer = Standard" />
                 </label>
+                <label class="field-label">Max Tokens
+                  <input type="number" min="1" bind:value={providerFields.maxTokens} placeholder="leer = Standard" />
+                </label>
+                {#if showField(editingProvider.provider, 'topP')}
+                  <label class="field-label">top_p
+                    <input type="number" step="0.01" min="0" max="1" bind:value={providerFields.topP} placeholder="leer = Standard" />
+                  </label>
+                {/if}
               </div>
-            {/if}
 
-            {#if showField(editingProvider.provider, 'thinkingMode')}
-              <label class="checkbox-label">
-                <input type="checkbox" bind:checked={providerFields.thinkingMode} />
-                Extended Thinking aktivieren (Claude)
-              </label>
-            {/if}
+              <!-- top_k: Claude + Mistral -->
+              {#if showField(editingProvider.provider, 'topK')}
+                <div class="field-row">
+                  <label class="field-label">top_k
+                    <input type="number" min="1" bind:value={providerFields.topK} placeholder="leer = Standard" />
+                  </label>
+                </div>
+              {/if}
 
-            {#if showField(editingProvider.provider, 'presencePenalty')}
-              <div class="field-row">
-                <label class="field-label">Presence Penalty
-                  <input type="number" step="0.01" min="-2" max="2" bind:value={providerFields.presencePenalty} placeholder="leer = Standard" />
+              <!-- Extended Thinking: nur Claude -->
+              {#if showField(editingProvider.provider, 'thinkingMode')}
+                <label class="checkbox-label">
+                  <input type="checkbox" bind:checked={providerFields.thinkingMode} />
+                  Extended Thinking aktivieren (Claude)
                 </label>
-                <label class="field-label">Frequency Penalty
-                  <input type="number" step="0.01" min="-2" max="2" bind:value={providerFields.frequencyPenalty} placeholder="leer = Standard" />
+              {/if}
+
+              <!-- Presence- / Frequency-Penalty: nur ChatGPT -->
+              {#if showField(editingProvider.provider, 'presencePenalty')}
+                <div class="field-row">
+                  <label class="field-label">Presence Penalty (–2 bis 2)
+                    <input type="number" step="0.01" min="-2" max="2" bind:value={providerFields.presencePenalty} placeholder="leer = Standard" />
+                  </label>
+                  <label class="field-label">Frequency Penalty (–2 bis 2)
+                    <input type="number" step="0.01" min="-2" max="2" bind:value={providerFields.frequencyPenalty} placeholder="leer = Standard" />
+                  </label>
+                </div>
+              {/if}
+
+              <!-- Safe Prompt / Random Seed: nur Mistral -->
+              {#if showField(editingProvider.provider, 'safePrompt')}
+                <label class="checkbox-label">
+                  <input type="checkbox" bind:checked={providerFields.safePrompt} />
+                  Safe Prompt aktivieren (Mistral)
                 </label>
-              </div>
+              {/if}
+              {#if showField(editingProvider.provider, 'randomSeed')}
+                <label class="field-label">Random Seed (leer = zufällig)
+                  <input type="number" bind:value={providerFields.randomSeed} placeholder="z.B. 42" />
+                </label>
+              {/if}
+
+              <!-- System-Prompt: Claude, ChatGPT, Mistral -->
+              {#if showField(editingProvider.provider, 'systemPrompt')}
+                <label class="field-label">System-Prompt (überschreibt den Template-Prompt wenn gesetzt)
+                  <textarea rows="5" bind:value={providerFields.systemPrompt} placeholder="Optionaler System-Prompt für dieses KI-Profil…"></textarea>
+                </label>
+              {/if}
             {/if}
 
-            {#if showField(editingProvider.provider, 'safePrompt')}
-              <label class="checkbox-label">
-                <input type="checkbox" bind:checked={providerFields.safePrompt} />
-                Safe Prompt (Mistral)
-              </label>
-            {/if}
-
-            {#if showField(editingProvider.provider, 'randomSeed')}
-              <label class="field-label">Random Seed (Mistral)
-                <input type="number" bind:value={providerFields.randomSeed} placeholder="leer = zufällig" />
-              </label>
-            {/if}
-
-            <label class="field-label">System-Prompt (überschreibt Template-Prompt)
-              <textarea rows="5" bind:value={providerFields.systemPrompt} placeholder="Optionaler System-Prompt für dieses KI-Profil…"></textarea>
-            </label>
-            <label class="field-label">Notizen / Beschreibung
-              <textarea rows="2" bind:value={providerFields.notes} placeholder="Freitext für interne Notizen…"></textarea>
+            <!-- Notiz / Freitext: alle Provider -->
+            <label class="field-label">Notiz / Freitext
+              <textarea rows="2" bind:value={providerFields.notes} placeholder="Interne Beschreibung, Hinweise, Zweck dieses Profils…"></textarea>
             </label>
           </div>
         {/if}

--- a/website/src/components/admin/coaching/CoachingSettings.svelte
+++ b/website/src/components/admin/coaching/CoachingSettings.svelte
@@ -17,33 +17,114 @@
   let editingTemplate = $state<StepTemplate | null>(null);
   let editFields = $state({ stepName: '', systemPrompt: '', userPromptTpl: '', keywords: '' });
 
-  const ENV_KEY_MAP: Record<string, string> = {
-    claude:  'ANTHROPIC_API_KEY',
-    openai:  'OPENAI_API_KEY',
-    mistral: 'MISTRAL_API_KEY',
-    lumo:    'LUMO_API_KEY',
+  // KI-Provider Inline-Edit
+  let editingProvider = $state<KiConfig | null>(null);
+  let providerEditTab = $state<'connection' | 'behavior'>('connection');
+  let savingProviderEdit = $state(false);
+  let showApiKey = $state(false);
+
+  type ProviderFields = {
+    displayName: string; modelName: string;
+    apiKey: string; apiEndpoint: string;
+    temperature: string; maxTokens: string; topP: string;
+    systemPrompt: string; notes: string;
+    topK: string; thinkingMode: boolean;
+    presencePenalty: string; frequencyPenalty: string;
+    safePrompt: boolean; randomSeed: string;
+    organizationId: string; euEndpoint: boolean;
   };
 
-  // Task 3: Inline-Edit für KI-Provider
-  let editingProvider = $state<KiConfig | null>(null);
-  let providerFields = $state({ displayName: '', modelName: '' });
-  let savingProviderEdit = $state(false);
+  let providerFields = $state<ProviderFields>({
+    displayName: '', modelName: '',
+    apiKey: '', apiEndpoint: '',
+    temperature: '', maxTokens: '', topP: '',
+    systemPrompt: '', notes: '',
+    topK: '', thinkingMode: false,
+    presencePenalty: '', frequencyPenalty: '',
+    safePrompt: false, randomSeed: '',
+    organizationId: '', euEndpoint: false,
+  });
+
+  function parseNum(s: string): number | null {
+    const v = parseFloat(s);
+    return isNaN(v) ? null : v;
+  }
+
+  function parseInt2(s: string): number | null {
+    const v = parseInt(s, 10);
+    return isNaN(v) ? null : v;
+  }
+
+  function showField(provider: string, field: string): boolean {
+    const map: Record<string, string[]> = {
+      claude:  ['apiKey', 'apiEndpoint', 'modelName', 'temperature', 'maxTokens', 'topP', 'topK', 'thinkingMode', 'systemPrompt', 'notes'],
+      openai:  ['apiKey', 'apiEndpoint', 'modelName', 'temperature', 'maxTokens', 'topP', 'presencePenalty', 'frequencyPenalty', 'organizationId', 'systemPrompt', 'notes'],
+      mistral: ['apiKey', 'apiEndpoint', 'modelName', 'temperature', 'maxTokens', 'topP', 'safePrompt', 'randomSeed', 'euEndpoint', 'systemPrompt', 'notes'],
+      lumo:    ['apiEndpoint', 'modelName', 'temperature', 'maxTokens', 'euEndpoint', 'systemPrompt', 'notes'],
+    };
+    return (map[provider] ?? []).includes(field);
+  }
+
+  const PROVIDER_BADGE: Record<string, string> = {
+    claude:  'Anthropic',
+    openai:  'OpenAI',
+    mistral: 'Mistral AI',
+    lumo:    'Lumo',
+  };
 
   function startEditProvider(p: KiConfig) {
     editingProvider = p;
-    providerFields = { displayName: p.displayName, modelName: p.modelName ?? '' };
+    providerEditTab = 'connection';
+    showApiKey = false;
+    providerFields = {
+      displayName: p.displayName,
+      modelName: p.modelName ?? '',
+      apiKey: p.apiKey ?? '',
+      apiEndpoint: p.apiEndpoint ?? '',
+      temperature: p.temperature != null ? String(p.temperature) : '',
+      maxTokens: p.maxTokens != null ? String(p.maxTokens) : '',
+      topP: p.topP != null ? String(p.topP) : '',
+      systemPrompt: p.systemPrompt ?? '',
+      notes: p.notes ?? '',
+      topK: p.topK != null ? String(p.topK) : '',
+      thinkingMode: p.thinkingMode,
+      presencePenalty: p.presencePenalty != null ? String(p.presencePenalty) : '',
+      frequencyPenalty: p.frequencyPenalty != null ? String(p.frequencyPenalty) : '',
+      safePrompt: p.safePrompt,
+      randomSeed: p.randomSeed != null ? String(p.randomSeed) : '',
+      organizationId: p.organizationId ?? '',
+      euEndpoint: p.euEndpoint,
+    };
   }
 
   async function saveProviderEdit() {
     if (!editingProvider) return;
     savingProviderEdit = true;
+    const prov = editingProvider.provider;
+    const payload: Record<string, unknown> = {
+      displayName: providerFields.displayName,
+      modelName: providerFields.modelName.trim() || null,
+      apiKey: providerFields.apiKey.trim() || null,
+      apiEndpoint: providerFields.apiEndpoint.trim() || null,
+      temperature: parseNum(providerFields.temperature),
+      maxTokens: parseInt2(providerFields.maxTokens),
+      topP: parseNum(providerFields.topP),
+      systemPrompt: providerFields.systemPrompt.trim() || null,
+      notes: providerFields.notes.trim() || null,
+    };
+    if (showField(prov, 'topK'))           payload.topK = parseInt2(providerFields.topK);
+    if (showField(prov, 'thinkingMode'))   payload.thinkingMode = providerFields.thinkingMode;
+    if (showField(prov, 'presencePenalty'))  payload.presencePenalty = parseNum(providerFields.presencePenalty);
+    if (showField(prov, 'frequencyPenalty')) payload.frequencyPenalty = parseNum(providerFields.frequencyPenalty);
+    if (showField(prov, 'safePrompt'))     payload.safePrompt = providerFields.safePrompt;
+    if (showField(prov, 'randomSeed'))     payload.randomSeed = parseInt2(providerFields.randomSeed);
+    if (showField(prov, 'organizationId')) payload.organizationId = providerFields.organizationId.trim() || null;
+    if (showField(prov, 'euEndpoint'))     payload.euEndpoint = providerFields.euEndpoint;
+
     await fetch(`/api/admin/coaching/ki-config/${editingProvider.id}`, {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        displayName: providerFields.displayName,
-        modelName: providerFields.modelName.trim() || null,
-      }),
+      body: JSON.stringify(payload),
     });
     const res = await fetch('/api/admin/coaching/ki-config');
     const data = await res.json();
@@ -75,17 +156,10 @@
     };
   }
 
-  // Task 4: Neues Template anlegen
   const EMPTY_TEMPLATE: Omit<StepTemplate, 'id' | 'brand' | 'createdAt'> = {
-    stepNumber: 1,
-    stepName: '',
-    phase: 'problem_ziel',
-    systemPrompt: '',
-    userPromptTpl: '',
-    inputSchema: [],
-    keywords: [],
-    isActive: true,
-    sortOrder: 0,
+    stepNumber: 1, stepName: '', phase: 'problem_ziel',
+    systemPrompt: '', userPromptTpl: '', inputSchema: [],
+    keywords: [], isActive: true, sortOrder: 0,
   };
 
   function startNewTemplate() {
@@ -107,21 +181,15 @@
       isActive: true,
       sortOrder: editingTemplate.sortOrder,
     };
-
     if (isNew) {
       await fetch('/api/admin/coaching/step-templates', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(payload),
+        method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload),
       });
     } else {
       await fetch(`/api/admin/coaching/step-templates/${editingTemplate.id}`, {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(payload),
+        method: 'PATCH', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload),
       });
     }
-
     const res = await fetch('/api/admin/coaching/step-templates');
     const data = await res.json();
     templates = data.templates;
@@ -138,53 +206,173 @@
 </script>
 
 <div class="settings">
-  <!-- Tabs -->
   <div class="tabs">
     <button class="tab {activeTab === 'ki' ? 'active' : ''}" onclick={() => activeTab = 'ki'}>KI-Provider</button>
     <button class="tab {activeTab === 'templates' ? 'active' : ''}" onclick={() => activeTab = 'templates'}>Prompt-Templates</button>
   </div>
 
   {#if activeTab === 'ki'}
-    <div class="ki-grid">
-      {#each providers as p}
-        <div class="provider-card {p.isActive ? 'active' : ''}">
-          {#if editingProvider?.id === p.id}
-            <label class="edit-label">Name
+    {#if editingProvider}
+      <div class="edit-panel">
+        <div class="edit-panel-header">
+          <div class="edit-title">
+            <span class="provider-badge {editingProvider.provider}">{PROVIDER_BADGE[editingProvider.provider] ?? editingProvider.provider}</span>
+            <span>{editingProvider.displayName}</span>
+          </div>
+          <button class="btn-sm" onclick={() => editingProvider = null}>✕ Schließen</button>
+        </div>
+
+        <div class="edit-tabs">
+          <button class="edit-tab {providerEditTab === 'connection' ? 'active' : ''}" onclick={() => providerEditTab = 'connection'}>Verbindung</button>
+          <button class="edit-tab {providerEditTab === 'behavior' ? 'active' : ''}" onclick={() => providerEditTab = 'behavior'}>Verhalten</button>
+        </div>
+
+        {#if providerEditTab === 'connection'}
+          <div class="edit-section">
+            <label class="field-label">Name / Label
               <input type="text" bind:value={providerFields.displayName} />
             </label>
-            <label class="edit-label">Modell (z.B. claude-sonnet-4-5)
+            <label class="field-label">Modell
               <input type="text" bind:value={providerFields.modelName} placeholder="leer = Standard" />
             </label>
-            <div class="edit-actions">
-              <button class="btn-activate" onclick={saveProviderEdit} disabled={savingProviderEdit}>
-                {savingProviderEdit ? '…' : 'Speichern'}
-              </button>
-              <button class="btn-sm" onclick={() => editingProvider = null}>Abbrechen</button>
+
+            {#if editingProvider.provider === 'lumo'}
+              <div class="lumo-info">
+                <strong>Lumo</strong> hat noch keine öffentliche API. Sobald eine API verfügbar ist, kann hier der Endpunkt konfiguriert werden.
+              </div>
+            {:else}
+              <label class="field-label">API-Key
+                <div class="api-key-row">
+                  {#if showApiKey}
+                    <input type="text" bind:value={providerFields.apiKey} placeholder="sk-..." class="api-key-input" />
+                  {:else}
+                    <input type="password" bind:value={providerFields.apiKey} placeholder="sk-..." class="api-key-input" />
+                  {/if}
+                  <button class="btn-icon" onclick={() => showApiKey = !showApiKey} title={showApiKey ? 'Verbergen' : 'Anzeigen'}>
+                    {showApiKey ? '🙈' : '👁'}
+                  </button>
+                </div>
+              </label>
+            {/if}
+
+            {#if showField(editingProvider.provider, 'apiEndpoint')}
+              <label class="field-label">API-Endpunkt (optional, überschreibt Standard)
+                <input type="url" bind:value={providerFields.apiEndpoint} placeholder="https://api.example.com/v1" />
+              </label>
+            {/if}
+
+            {#if showField(editingProvider.provider, 'organizationId')}
+              <label class="field-label">Organization ID (OpenAI)
+                <input type="text" bind:value={providerFields.organizationId} placeholder="org-..." />
+              </label>
+            {/if}
+
+            {#if showField(editingProvider.provider, 'euEndpoint')}
+              <label class="checkbox-label">
+                <input type="checkbox" bind:checked={providerFields.euEndpoint} />
+                EU-Endpunkt verwenden
+              </label>
+            {/if}
+          </div>
+        {:else}
+          <div class="edit-section">
+            <div class="field-row">
+              <label class="field-label">Temperature
+                <input type="number" step="0.01" min="0" max="2" bind:value={providerFields.temperature} placeholder="leer = Standard" />
+              </label>
+              <label class="field-label">Max Tokens
+                <input type="number" min="1" bind:value={providerFields.maxTokens} placeholder="leer = Standard" />
+              </label>
+              {#if showField(editingProvider.provider, 'topP')}
+                <label class="field-label">top_p
+                  <input type="number" step="0.01" min="0" max="1" bind:value={providerFields.topP} placeholder="leer = Standard" />
+                </label>
+              {/if}
             </div>
-          {:else}
+
+            {#if showField(editingProvider.provider, 'topK')}
+              <div class="field-row">
+                <label class="field-label">top_k (Claude)
+                  <input type="number" min="1" bind:value={providerFields.topK} placeholder="leer = Standard" />
+                </label>
+              </div>
+            {/if}
+
+            {#if showField(editingProvider.provider, 'thinkingMode')}
+              <label class="checkbox-label">
+                <input type="checkbox" bind:checked={providerFields.thinkingMode} />
+                Extended Thinking aktivieren (Claude)
+              </label>
+            {/if}
+
+            {#if showField(editingProvider.provider, 'presencePenalty')}
+              <div class="field-row">
+                <label class="field-label">Presence Penalty
+                  <input type="number" step="0.01" min="-2" max="2" bind:value={providerFields.presencePenalty} placeholder="leer = Standard" />
+                </label>
+                <label class="field-label">Frequency Penalty
+                  <input type="number" step="0.01" min="-2" max="2" bind:value={providerFields.frequencyPenalty} placeholder="leer = Standard" />
+                </label>
+              </div>
+            {/if}
+
+            {#if showField(editingProvider.provider, 'safePrompt')}
+              <label class="checkbox-label">
+                <input type="checkbox" bind:checked={providerFields.safePrompt} />
+                Safe Prompt (Mistral)
+              </label>
+            {/if}
+
+            {#if showField(editingProvider.provider, 'randomSeed')}
+              <label class="field-label">Random Seed (Mistral)
+                <input type="number" bind:value={providerFields.randomSeed} placeholder="leer = zufällig" />
+              </label>
+            {/if}
+
+            <label class="field-label">System-Prompt (überschreibt Template-Prompt)
+              <textarea rows="5" bind:value={providerFields.systemPrompt} placeholder="Optionaler System-Prompt für dieses KI-Profil…"></textarea>
+            </label>
+            <label class="field-label">Notizen / Beschreibung
+              <textarea rows="2" bind:value={providerFields.notes} placeholder="Freitext für interne Notizen…"></textarea>
+            </label>
+          </div>
+        {/if}
+
+        <div class="edit-actions">
+          <button class="btn-primary" onclick={saveProviderEdit} disabled={savingProviderEdit}>
+            {savingProviderEdit ? 'Speichern…' : 'Speichern'}
+          </button>
+          <button class="btn-sm" onclick={() => editingProvider = null}>Abbrechen</button>
+        </div>
+      </div>
+
+    {:else}
+      <div class="ki-grid">
+        {#each providers as p}
+          <div class="provider-card {p.isActive ? 'active' : ''}">
+            <div class="card-head">
+              <span class="provider-badge {p.provider}">{PROVIDER_BADGE[p.provider] ?? p.provider}</span>
+              {#if p.isActive}<span class="active-badge">● Aktiv</span>{/if}
+            </div>
             <div class="provider-name">{p.displayName}</div>
             <div class="provider-model">{p.modelName ?? 'kein Modell'}</div>
-            <div class="provider-key">
-              {ENV_KEY_MAP[p.provider] ? `${ENV_KEY_MAP[p.provider]}` : '—'}
-            </div>
+            {#if p.apiKey}
+              <div class="provider-key">API-Key gesetzt ✓</div>
+            {:else if p.provider !== 'lumo'}
+              <div class="provider-key warn">kein API-Key</div>
+            {/if}
             <div class="provider-actions">
-              {#if p.isActive}
-                <span class="active-badge">● Aktiv</span>
-              {:else}
-                <button
-                  class="btn-activate"
-                  onclick={() => activateProvider(p.provider)}
-                  disabled={savingProvider === p.provider}
-                >
+              {#if !p.isActive}
+                <button class="btn-activate" onclick={() => activateProvider(p.provider)} disabled={savingProvider === p.provider}>
                   {savingProvider === p.provider ? '…' : 'Aktivieren'}
                 </button>
               {/if}
-              <button class="btn-sm" onclick={() => startEditProvider(p)}>✏️</button>
+              <button class="btn-sm" onclick={() => startEditProvider(p)}>Bearbeiten</button>
             </div>
-          {/if}
-        </div>
-      {/each}
-    </div>
+          </div>
+        {/each}
+      </div>
+    {/if}
 
   {:else}
     <div class="templates-list">
@@ -247,32 +435,69 @@
 </div>
 
 <style>
-  .settings { max-width: 900px; margin: 0 auto; padding: 1rem 1.5rem 3rem; }
+  .settings { max-width: 960px; margin: 0 auto; padding: 1rem 1.5rem 3rem; }
   .tabs { display: flex; gap: 0.5rem; margin-bottom: 1.5rem; border-bottom: 1px solid var(--line,#333); }
   .tab { padding: 0.5rem 1rem; background: none; border: none; color: var(--text-muted,#888); cursor: pointer; font-size: 0.9rem; border-bottom: 2px solid transparent; margin-bottom: -1px; }
   .tab.active { color: var(--gold,#c9a55c); border-bottom-color: var(--gold,#c9a55c); }
-  .ki-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); gap: 1rem; }
+
+  /* Provider cards */
+  .ki-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(220px, 1fr)); gap: 1rem; }
   .provider-card { padding: 1.2rem; border: 1px solid var(--line,#333); border-radius: 8px; background: var(--bg-2,#1a1a1a); display: flex; flex-direction: column; gap: 0.4rem; }
   .provider-card.active { border-color: var(--gold,#c9a55c); }
-  .provider-name { font-weight: 700; color: var(--text-light,#f0f0f0); }
+  .card-head { display: flex; align-items: center; justify-content: space-between; gap: 0.5rem; }
+  .provider-name { font-weight: 700; color: var(--text-light,#f0f0f0); margin-top: 0.2rem; }
   .provider-model { font-size: 0.78rem; color: var(--text-muted,#888); }
-  .provider-key { font-size: 0.72rem; color: var(--text-muted,#666); font-family: monospace; }
-  .active-badge { color: var(--gold,#c9a55c); font-size: 0.82rem; font-weight: 600; }
-  .btn-activate { margin-top: 0.4rem; padding: 0.4rem 0.8rem; background: var(--gold,#c9a55c); color: #111; border: none; border-radius: 4px; cursor: pointer; font-weight: 600; font-size: 0.82rem; }
+  .provider-key { font-size: 0.72rem; color: #4ade80; font-family: monospace; }
+  .provider-key.warn { color: #f97316; }
+  .active-badge { color: var(--gold,#c9a55c); font-size: 0.78rem; font-weight: 600; white-space: nowrap; }
+  .provider-actions { display: flex; gap: 0.4rem; align-items: center; margin-top: 0.5rem; flex-wrap: wrap; }
+  .btn-activate { padding: 0.4rem 0.8rem; background: var(--gold,#c9a55c); color: #111; border: none; border-radius: 4px; cursor: pointer; font-weight: 600; font-size: 0.82rem; }
   .btn-activate:disabled { opacity: 0.5; cursor: not-allowed; }
-  .provider-actions { display: flex; gap: 0.4rem; align-items: center; margin-top: 0.4rem; flex-wrap: wrap; }
-  .edit-label { display: flex; flex-direction: column; gap: 0.2rem; font-size: 0.78rem; color: var(--text-muted,#888); }
-  .edit-label input { padding: 0.35rem 0.6rem; background: var(--bg-dark,#111); border: 1px solid var(--line,#333); border-radius: 4px; color: var(--text-light,#f0f0f0); font-size: 0.82rem; }
-  .table { width: 100%; border-collapse: collapse; }
-  .table th { text-align: left; padding: 0.5rem 0.75rem; border-bottom: 1px solid var(--line,#333); font-size: 0.82rem; color: var(--text-muted,#888); }
-  .table td { padding: 0.6rem 0.75rem; border-bottom: 1px solid var(--line,#222); font-size: 0.88rem; }
+
+  /* Provider badges */
+  .provider-badge { font-size: 0.7rem; font-weight: 700; padding: 0.15rem 0.5rem; border-radius: 99px; letter-spacing: 0.03em; }
+  .provider-badge.claude  { background: #7c3aed22; color: #a78bfa; border: 1px solid #7c3aed44; }
+  .provider-badge.openai  { background: #16a34a22; color: #4ade80; border: 1px solid #16a34a44; }
+  .provider-badge.mistral { background: #ea580c22; color: #fb923c; border: 1px solid #ea580c44; }
+  .provider-badge.lumo    { background: #0891b222; color: #38bdf8; border: 1px solid #0891b244; }
+
+  /* Edit panel */
+  .edit-panel { border: 1px solid var(--gold,#c9a55c); border-radius: 10px; background: var(--bg-2,#1a1a1a); padding: 1.5rem; display: flex; flex-direction: column; gap: 1.25rem; }
+  .edit-panel-header { display: flex; align-items: center; justify-content: space-between; gap: 1rem; }
+  .edit-title { display: flex; align-items: center; gap: 0.75rem; font-weight: 700; color: var(--text-light,#f0f0f0); }
+  .edit-tabs { display: flex; gap: 0.5rem; border-bottom: 1px solid var(--line,#333); }
+  .edit-tab { padding: 0.4rem 1rem; background: none; border: none; color: var(--text-muted,#888); cursor: pointer; font-size: 0.85rem; border-bottom: 2px solid transparent; margin-bottom: -1px; }
+  .edit-tab.active { color: var(--gold,#c9a55c); border-bottom-color: var(--gold,#c9a55c); }
+  .edit-section { display: flex; flex-direction: column; gap: 0.9rem; padding-top: 0.5rem; }
+  .field-label { display: flex; flex-direction: column; gap: 0.3rem; font-size: 0.8rem; color: var(--text-muted,#888); }
+  .field-label input, .field-label textarea, .field-label select {
+    padding: 0.45rem 0.7rem; background: var(--bg-dark,#111); border: 1px solid var(--line,#333);
+    border-radius: 6px; color: var(--text-light,#f0f0f0); font-size: 0.88rem; outline: none; resize: vertical;
+  }
+  .field-label textarea { min-height: 80px; }
+  .field-row { display: flex; gap: 1rem; flex-wrap: wrap; }
+  .field-row .field-label { flex: 1; min-width: 120px; }
+  .checkbox-label { display: flex; align-items: center; gap: 0.5rem; font-size: 0.85rem; color: var(--text-muted,#888); cursor: pointer; }
+  .checkbox-label input[type="checkbox"] { width: 16px; height: 16px; accent-color: var(--gold,#c9a55c); cursor: pointer; }
+  .api-key-row { display: flex; gap: 0.4rem; align-items: center; }
+  .api-key-input { flex: 1; }
+  .btn-icon { padding: 0.4rem 0.6rem; background: var(--bg-2,#1a1a1a); border: 1px solid var(--line,#333); border-radius: 6px; cursor: pointer; font-size: 0.9rem; }
+  .lumo-info { background: #0891b211; border: 1px solid #0891b244; border-radius: 8px; padding: 0.9rem 1rem; color: #38bdf8; font-size: 0.85rem; line-height: 1.5; }
+
+  /* Actions */
+  .edit-actions { display: flex; gap: 0.5rem; }
   .btn-sm { padding: 0.3rem 0.7rem; border: 1px solid var(--line,#444); border-radius: 4px; font-size: 0.82rem; color: var(--text-muted,#888); background: none; cursor: pointer; }
   .btn-danger { border-color: #ef4444; color: #ef4444; }
   .btn-primary { padding: 0.5rem 1.2rem; background: var(--gold,#c9a55c); color: #111; border: none; border-radius: 6px; cursor: pointer; font-weight: 700; font-size: 0.85rem; }
+  .btn-primary:disabled { opacity: 0.5; cursor: not-allowed; }
+
+  /* Templates */
+  .table { width: 100%; border-collapse: collapse; }
+  .table th { text-align: left; padding: 0.5rem 0.75rem; border-bottom: 1px solid var(--line,#333); font-size: 0.82rem; color: var(--text-muted,#888); }
+  .table td { padding: 0.6rem 0.75rem; border-bottom: 1px solid var(--line,#222); font-size: 0.88rem; }
+  .templates-header { display: flex; justify-content: flex-end; margin-bottom: 0.75rem; }
   .edit-modal { background: var(--bg-2,#1a1a1a); border: 1px solid var(--gold,#c9a55c); border-radius: 8px; padding: 1.5rem; display: flex; flex-direction: column; gap: 1rem; }
   .edit-modal label { display: flex; flex-direction: column; gap: 0.3rem; font-size: 0.82rem; color: var(--text-muted,#888); }
   .edit-modal input, .edit-modal textarea { padding: 0.5rem 0.75rem; background: var(--bg-dark,#111); border: 1px solid var(--line,#333); border-radius: 6px; color: var(--text-light,#f0f0f0); font-size: 0.88rem; outline: none; resize: vertical; }
   .edit-modal select { padding: 0.5rem 0.75rem; background: var(--bg-dark,#111); border: 1px solid var(--line,#333); border-radius: 6px; color: var(--text-light,#f0f0f0); font-size: 0.88rem; }
-  .edit-actions { display: flex; gap: 0.5rem; }
-  .templates-header { display: flex; justify-content: flex-end; margin-bottom: 0.75rem; }
 </style>

--- a/website/src/lib/coaching-ki-config-db.test.ts
+++ b/website/src/lib/coaching-ki-config-db.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect, beforeAll } from 'vitest';
 import { newDb } from 'pg-mem';
 import type { Pool } from 'pg';
-import { listKiProviders, getActiveProvider, setActiveProvider, updateKiProvider, type KiConfig } from './coaching-ki-config-db';
+import {
+  listKiProviders, getActiveProvider, setActiveProvider,
+  updateKiProvider, createKiProvider, deleteKiProvider,
+} from './coaching-ki-config-db';
 
 let pool: Pool;
 
@@ -17,6 +20,22 @@ beforeAll(async () => {
       model_name TEXT,
       display_name TEXT NOT NULL,
       created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      api_key TEXT,
+      api_endpoint TEXT,
+      temperature NUMERIC(5,3),
+      max_tokens INT,
+      top_p NUMERIC(5,3),
+      system_prompt TEXT,
+      notes TEXT,
+      top_k INT,
+      thinking_mode BOOLEAN NOT NULL DEFAULT false,
+      presence_penalty NUMERIC(5,3),
+      frequency_penalty NUMERIC(5,3),
+      safe_prompt BOOLEAN NOT NULL DEFAULT false,
+      random_seed INT,
+      organization_id TEXT,
+      eu_endpoint BOOLEAN NOT NULL DEFAULT false,
+      enabled_fields JSONB,
       UNIQUE (brand, provider)
     );
     INSERT INTO coaching.ki_config (brand, provider, is_active, model_name, display_name)
@@ -58,13 +77,12 @@ describe('setActiveProvider', () => {
     expect(active?.provider).toBe('openai');
     const all = await listKiProviders(pool, 'mentolder');
     expect(all.filter(p => p.isActive)).toHaveLength(1);
-    // Reset
     await setActiveProvider(pool, 'mentolder', 'claude');
   });
 
   it('wirft Fehler bei unbekanntem Provider — aktiver bleibt erhalten', async () => {
     await expect(
-      setActiveProvider(pool, 'mentolder', 'nonexistent' as KiConfig['provider']),
+      setActiveProvider(pool, 'mentolder', 'nonexistent'),
     ).rejects.toThrow("Provider 'nonexistent' not found for brand 'mentolder'");
     const active = await getActiveProvider(pool, 'mentolder');
     expect(active).not.toBeNull();
@@ -87,7 +105,49 @@ describe('updateKiProvider', () => {
     const claude = providers.find(p => p.provider === 'claude')!;
     await updateKiProvider(pool, claude.id, { modelName: null, displayName: 'Claude' });
     const after = await listKiProviders(pool, 'mentolder');
-    const updated = after.find(p => p.provider === 'claude')!;
-    expect(updated.modelName).toBeNull();
+    expect(after.find(p => p.provider === 'claude')!.modelName).toBeNull();
+  });
+});
+
+describe('createKiProvider', () => {
+  it('legt neuen Custom-Provider an und gibt ihn zurück', async () => {
+    const p = await createKiProvider(pool, 'mentolder', {
+      displayName: 'Mein GPT',
+      provider: 'custom_my-gpt',
+      enabledFields: ['apiKey', 'apiEndpoint', 'temperature', 'systemPrompt'],
+    });
+    expect(p.provider).toBe('custom_my-gpt');
+    expect(p.displayName).toBe('Mein GPT');
+    expect(p.enabledFields).toEqual(['apiKey', 'apiEndpoint', 'temperature', 'systemPrompt']);
+    expect(p.isActive).toBe(false);
+  });
+
+  it('wirft Fehler bei Duplikat (brand + provider)', async () => {
+    await expect(
+      createKiProvider(pool, 'mentolder', {
+        displayName: 'Duplikat',
+        provider: 'custom_my-gpt',
+        enabledFields: [],
+      }),
+    ).rejects.toThrow();
+  });
+});
+
+describe('deleteKiProvider', () => {
+  it('löscht Custom-Provider', async () => {
+    const p = await createKiProvider(pool, 'mentolder', {
+      displayName: 'Zu löschen',
+      provider: 'custom_to-delete',
+      enabledFields: [],
+    });
+    await deleteKiProvider(pool, p.id);
+    const all = await listKiProviders(pool, 'mentolder');
+    expect(all.find(x => x.id === p.id)).toBeUndefined();
+  });
+
+  it('wirft Fehler beim Löschen eines Standard-Providers', async () => {
+    const all = await listKiProviders(pool, 'mentolder');
+    const claude = all.find(p => p.provider === 'claude')!;
+    await expect(deleteKiProvider(pool, claude.id)).rejects.toThrow('Nur Custom-Provider');
   });
 });

--- a/website/src/lib/coaching-ki-config-db.ts
+++ b/website/src/lib/coaching-ki-config-db.ts
@@ -1,9 +1,11 @@
 import type { Pool } from 'pg';
 
+const KNOWN_PROVIDERS = new Set(['claude', 'openai', 'mistral', 'lumo']);
+
 export interface KiConfig {
   id: number;
   brand: string;
-  provider: 'claude' | 'openai' | 'mistral' | 'lumo';
+  provider: string;
   isActive: boolean;
   modelName: string | null;
   displayName: string;
@@ -26,34 +28,41 @@ export interface KiConfig {
   randomSeed: number | null;
   organizationId: string | null;
   euEndpoint: boolean;
+  // Custom-Provider
+  enabledFields: string[] | null;
 }
 
-export type UpdateKiProviderFields = Partial<Omit<KiConfig, 'id' | 'brand' | 'provider' | 'isActive' | 'createdAt'>>;
+export type UpdateKiProviderFields = Partial<Omit<KiConfig, 'id' | 'brand' | 'provider' | 'isActive' | 'createdAt' | 'enabledFields'>>;
 
 function rowToKiConfig(row: Record<string, unknown>): KiConfig {
   return {
     id: row.id as number,
     brand: row.brand as string,
-    provider: row.provider as KiConfig['provider'],
+    provider: row.provider as string,
     isActive: row.is_active as boolean,
     modelName: (row.model_name as string | null) ?? null,
     displayName: row.display_name as string,
     createdAt: row.created_at as Date,
     apiKey: (row.api_key as string | null) ?? null,
     apiEndpoint: (row.api_endpoint as string | null) ?? null,
-    temperature: (row.temperature != null ? Number(row.temperature) : null),
+    temperature: row.temperature != null ? Number(row.temperature) : null,
     maxTokens: (row.max_tokens as number | null) ?? null,
-    topP: (row.top_p != null ? Number(row.top_p) : null),
+    topP: row.top_p != null ? Number(row.top_p) : null,
     systemPrompt: (row.system_prompt as string | null) ?? null,
     notes: (row.notes as string | null) ?? null,
     topK: (row.top_k as number | null) ?? null,
     thinkingMode: (row.thinking_mode as boolean) ?? false,
-    presencePenalty: (row.presence_penalty != null ? Number(row.presence_penalty) : null),
-    frequencyPenalty: (row.frequency_penalty != null ? Number(row.frequency_penalty) : null),
+    presencePenalty: row.presence_penalty != null ? Number(row.presence_penalty) : null,
+    frequencyPenalty: row.frequency_penalty != null ? Number(row.frequency_penalty) : null,
     safePrompt: (row.safe_prompt as boolean) ?? false,
     randomSeed: (row.random_seed as number | null) ?? null,
     organizationId: (row.organization_id as string | null) ?? null,
     euEndpoint: (row.eu_endpoint as boolean) ?? false,
+    enabledFields: Array.isArray(row.enabled_fields)
+      ? (row.enabled_fields as string[])
+      : row.enabled_fields != null
+        ? (JSON.parse(row.enabled_fields as string) as string[])
+        : null,
   };
 }
 
@@ -74,14 +83,11 @@ export async function getActiveProvider(pool: Pool, brand: string): Promise<KiCo
 }
 
 export async function getKiProviderById(pool: Pool, id: number): Promise<KiConfig | null> {
-  const r = await pool.query(
-    `SELECT * FROM coaching.ki_config WHERE id = $1`,
-    [id],
-  );
+  const r = await pool.query(`SELECT * FROM coaching.ki_config WHERE id = $1`, [id]);
   return r.rows[0] ? rowToKiConfig(r.rows[0]) : null;
 }
 
-export async function setActiveProvider(pool: Pool, brand: string, provider: KiConfig['provider']): Promise<void> {
+export async function setActiveProvider(pool: Pool, brand: string, provider: string): Promise<void> {
   const exists = await pool.query(
     `SELECT id FROM coaching.ki_config WHERE brand = $1 AND provider = $2`,
     [brand, provider],
@@ -92,10 +98,7 @@ export async function setActiveProvider(pool: Pool, brand: string, provider: KiC
   const client = await pool.connect();
   try {
     await client.query('BEGIN');
-    await client.query(
-      `UPDATE coaching.ki_config SET is_active = false WHERE brand = $1`,
-      [brand],
-    );
+    await client.query(`UPDATE coaching.ki_config SET is_active = false WHERE brand = $1`, [brand]);
     await client.query(
       `UPDATE coaching.ki_config SET is_active = true WHERE brand = $1 AND provider = $2`,
       [brand, provider],
@@ -110,23 +113,14 @@ export async function setActiveProvider(pool: Pool, brand: string, provider: KiC
 }
 
 const COLUMN_MAP: Record<string, string> = {
-  modelName:        'model_name',
-  displayName:      'display_name',
-  apiKey:           'api_key',
-  apiEndpoint:      'api_endpoint',
-  temperature:      'temperature',
-  maxTokens:        'max_tokens',
-  topP:             'top_p',
-  systemPrompt:     'system_prompt',
-  notes:            'notes',
-  topK:             'top_k',
-  thinkingMode:     'thinking_mode',
-  presencePenalty:  'presence_penalty',
-  frequencyPenalty: 'frequency_penalty',
-  safePrompt:       'safe_prompt',
-  randomSeed:       'random_seed',
-  organizationId:   'organization_id',
-  euEndpoint:       'eu_endpoint',
+  modelName: 'model_name', displayName: 'display_name',
+  apiKey: 'api_key', apiEndpoint: 'api_endpoint',
+  temperature: 'temperature', maxTokens: 'max_tokens', topP: 'top_p',
+  systemPrompt: 'system_prompt', notes: 'notes',
+  topK: 'top_k', thinkingMode: 'thinking_mode',
+  presencePenalty: 'presence_penalty', frequencyPenalty: 'frequency_penalty',
+  safePrompt: 'safe_prompt', randomSeed: 'random_seed',
+  organizationId: 'organization_id', euEndpoint: 'eu_endpoint',
 };
 
 export async function updateKiProvider(
@@ -155,4 +149,28 @@ export async function updateKiProvider(
   );
   if (r.rows.length === 0) throw new Error(`KI-Provider id=${id} nicht gefunden`);
   return rowToKiConfig(r.rows[0]);
+}
+
+export async function createKiProvider(
+  pool: Pool,
+  brand: string,
+  data: { displayName: string; provider: string; enabledFields: string[] },
+): Promise<KiConfig> {
+  const r = await pool.query(
+    `INSERT INTO coaching.ki_config (brand, provider, display_name, is_active, enabled_fields)
+     VALUES ($1, $2, $3, false, $4)
+     RETURNING *`,
+    [brand, data.provider, data.displayName, JSON.stringify(data.enabledFields)],
+  );
+  return rowToKiConfig(r.rows[0]);
+}
+
+export async function deleteKiProvider(pool: Pool, id: number): Promise<void> {
+  const r = await pool.query(`SELECT provider FROM coaching.ki_config WHERE id = $1`, [id]);
+  if (r.rows.length === 0) throw new Error(`KI-Provider id=${id} nicht gefunden`);
+  const provider = r.rows[0].provider as string;
+  if (KNOWN_PROVIDERS.has(provider)) {
+    throw new Error('Nur Custom-Provider können gelöscht werden');
+  }
+  await pool.query(`DELETE FROM coaching.ki_config WHERE id = $1`, [id]);
 }

--- a/website/src/lib/coaching-ki-config-db.ts
+++ b/website/src/lib/coaching-ki-config-db.ts
@@ -8,7 +8,27 @@ export interface KiConfig {
   modelName: string | null;
   displayName: string;
   createdAt: Date;
+  // Verbindung
+  apiKey: string | null;
+  apiEndpoint: string | null;
+  // Verhalten (gemeinsam)
+  temperature: number | null;
+  maxTokens: number | null;
+  topP: number | null;
+  systemPrompt: string | null;
+  notes: string | null;
+  // Anbieterspezifisch
+  topK: number | null;
+  thinkingMode: boolean;
+  presencePenalty: number | null;
+  frequencyPenalty: number | null;
+  safePrompt: boolean;
+  randomSeed: number | null;
+  organizationId: string | null;
+  euEndpoint: boolean;
 }
+
+export type UpdateKiProviderFields = Partial<Omit<KiConfig, 'id' | 'brand' | 'provider' | 'isActive' | 'createdAt'>>;
 
 function rowToKiConfig(row: Record<string, unknown>): KiConfig {
   return {
@@ -19,6 +39,21 @@ function rowToKiConfig(row: Record<string, unknown>): KiConfig {
     modelName: (row.model_name as string | null) ?? null,
     displayName: row.display_name as string,
     createdAt: row.created_at as Date,
+    apiKey: (row.api_key as string | null) ?? null,
+    apiEndpoint: (row.api_endpoint as string | null) ?? null,
+    temperature: (row.temperature != null ? Number(row.temperature) : null),
+    maxTokens: (row.max_tokens as number | null) ?? null,
+    topP: (row.top_p != null ? Number(row.top_p) : null),
+    systemPrompt: (row.system_prompt as string | null) ?? null,
+    notes: (row.notes as string | null) ?? null,
+    topK: (row.top_k as number | null) ?? null,
+    thinkingMode: (row.thinking_mode as boolean) ?? false,
+    presencePenalty: (row.presence_penalty != null ? Number(row.presence_penalty) : null),
+    frequencyPenalty: (row.frequency_penalty != null ? Number(row.frequency_penalty) : null),
+    safePrompt: (row.safe_prompt as boolean) ?? false,
+    randomSeed: (row.random_seed as number | null) ?? null,
+    organizationId: (row.organization_id as string | null) ?? null,
+    euEndpoint: (row.eu_endpoint as boolean) ?? false,
   };
 }
 
@@ -34,6 +69,14 @@ export async function getActiveProvider(pool: Pool, brand: string): Promise<KiCo
   const r = await pool.query(
     `SELECT * FROM coaching.ki_config WHERE brand = $1 AND is_active = true LIMIT 1`,
     [brand],
+  );
+  return r.rows[0] ? rowToKiConfig(r.rows[0]) : null;
+}
+
+export async function getKiProviderById(pool: Pool, id: number): Promise<KiConfig | null> {
+  const r = await pool.query(
+    `SELECT * FROM coaching.ki_config WHERE id = $1`,
+    [id],
   );
   return r.rows[0] ? rowToKiConfig(r.rows[0]) : null;
 }
@@ -66,17 +109,49 @@ export async function setActiveProvider(pool: Pool, brand: string, provider: KiC
   }
 }
 
+const COLUMN_MAP: Record<string, string> = {
+  modelName:        'model_name',
+  displayName:      'display_name',
+  apiKey:           'api_key',
+  apiEndpoint:      'api_endpoint',
+  temperature:      'temperature',
+  maxTokens:        'max_tokens',
+  topP:             'top_p',
+  systemPrompt:     'system_prompt',
+  notes:            'notes',
+  topK:             'top_k',
+  thinkingMode:     'thinking_mode',
+  presencePenalty:  'presence_penalty',
+  frequencyPenalty: 'frequency_penalty',
+  safePrompt:       'safe_prompt',
+  randomSeed:       'random_seed',
+  organizationId:   'organization_id',
+  euEndpoint:       'eu_endpoint',
+};
+
 export async function updateKiProvider(
   pool: Pool,
   id: number,
-  fields: { modelName: string | null; displayName: string },
+  fields: UpdateKiProviderFields,
 ): Promise<KiConfig> {
+  const sets: string[] = [];
+  const vals: unknown[] = [];
+  let i = 1;
+  for (const [k, v] of Object.entries(fields)) {
+    const col = COLUMN_MAP[k];
+    if (!col) continue;
+    sets.push(`${col} = $${i++}`);
+    vals.push(v);
+  }
+  if (sets.length === 0) {
+    const r = await pool.query(`SELECT * FROM coaching.ki_config WHERE id = $1`, [id]);
+    if (r.rows.length === 0) throw new Error(`KI-Provider id=${id} nicht gefunden`);
+    return rowToKiConfig(r.rows[0]);
+  }
+  vals.push(id);
   const r = await pool.query(
-    `UPDATE coaching.ki_config
-     SET model_name = $1, display_name = $2
-     WHERE id = $3
-     RETURNING *`,
-    [fields.modelName, fields.displayName, id],
+    `UPDATE coaching.ki_config SET ${sets.join(', ')} WHERE id = $${i} RETURNING *`,
+    vals,
   );
   if (r.rows.length === 0) throw new Error(`KI-Provider id=${id} nicht gefunden`);
   return rowToKiConfig(r.rows[0]);

--- a/website/src/lib/coaching-session-db.ts
+++ b/website/src/lib/coaching-session-db.ts
@@ -5,6 +5,7 @@ export interface Session {
   brand: string;
   clientId: string | null;
   clientName: string | null;
+  kiConfigId: number | null;
   mode: 'live' | 'prep';
   title: string;
   status: 'active' | 'paused' | 'completed' | 'abandoned';
@@ -59,6 +60,7 @@ export interface SessionStep {
 export interface CreateSessionArgs {
   brand: string;
   clientId?: string | null;
+  kiConfigId?: number | null;
   mode: 'live' | 'prep';
   title: string;
   createdBy: string;
@@ -82,6 +84,7 @@ function rowToSession(row: Record<string, unknown>, steps: SessionStep[] = []): 
     brand: row.brand as string,
     clientId: (row.client_id as string | null) ?? null,
     clientName: (row.client_name as string | null) ?? null,
+    kiConfigId: (row.ki_config_id as number | null) ?? null,
     mode: row.mode as 'live' | 'prep',
     title: row.title as string,
     status: row.status as Session['status'],
@@ -111,10 +114,10 @@ function rowToStep(row: Record<string, unknown>): SessionStep {
 
 export async function createSession(pool: Pool, args: CreateSessionArgs): Promise<Session> {
   const r = await pool.query(
-    `INSERT INTO coaching.sessions (brand, client_id, mode, title, created_by)
-     VALUES ($1, $2, $3, $4, $5)
+    `INSERT INTO coaching.sessions (brand, client_id, ki_config_id, mode, title, created_by)
+     VALUES ($1, $2, $3, $4, $5, $6)
      RETURNING *`,
-    [args.brand, args.clientId ?? null, args.mode, args.title, args.createdBy],
+    [args.brand, args.clientId ?? null, args.kiConfigId ?? null, args.mode, args.title, args.createdBy],
   );
   return rowToSession(r.rows[0]);
 }
@@ -318,7 +321,7 @@ export async function updateSessionStatus(
 export async function updateSessionFields(
   pool: Pool,
   id: string,
-  fields: Partial<{ title: string; clientId: string | null; clientName: string | null }>,
+  fields: Partial<{ title: string; clientId: string | null; clientName: string | null; kiConfigId: number | null }>,
   actor: string,
 ): Promise<Session | null> {
   const client = await pool.connect();
@@ -349,6 +352,11 @@ export async function updateSessionFields(
       vals.push(fields.clientName);
       sets.push(`client_name = $${vals.length}`);
       changedFields.push({ field: 'client_name', from: row.client_name, to: fields.clientName });
+    }
+    if (fields.kiConfigId !== undefined && fields.kiConfigId !== row.ki_config_id) {
+      vals.push(fields.kiConfigId);
+      sets.push(`ki_config_id = $${vals.length}`);
+      changedFields.push({ field: 'ki_config_id', from: row.ki_config_id, to: fields.kiConfigId });
     }
     if (sets.length === 0) {
       await client.query('ROLLBACK');

--- a/website/src/pages/admin/coaching/sessions/[id].astro
+++ b/website/src/pages/admin/coaching/sessions/[id].astro
@@ -3,12 +3,14 @@ import AdminLayout from '../../../../layouts/AdminLayout.astro';
 import SessionWizard from '../../../../components/admin/coaching/SessionWizard.svelte';
 import { getSession as getAuthSession, getLoginUrl, isAdmin } from '../../../../lib/auth';
 import { getSession as getCoachingSession, getAuditLog } from '../../../../lib/coaching-session-db';
+import { listKiProviders } from '../../../../lib/coaching-ki-config-db';
 import { pool } from '../../../../lib/website-db';
 
 const authSession = await getAuthSession(Astro.request.headers.get('cookie'));
 if (!authSession) return Astro.redirect(getLoginUrl(Astro.url.pathname));
 if (!isAdmin(authSession)) return Astro.redirect('/admin');
 
+const brand = process.env.BRAND || 'mentolder';
 const id = Astro.params.id as string;
 let coachingSession = null;
 try { coachingSession = await getCoachingSession(pool, id); } catch { /* ignore */ }
@@ -18,6 +20,18 @@ if (!coachingSession) return Astro.redirect('/admin/coaching/sessions');
 let auditLog: Awaited<ReturnType<typeof getAuditLog>> = [];
 try { auditLog = await getAuditLog(pool, id); } catch {}
 
+let customers: { id: string; name: string }[] = [];
+try {
+  const res = await pool.query(
+    `SELECT id, name FROM public.customers WHERE brand = $1 ORDER BY name`,
+    [brand]
+  );
+  customers = res.rows;
+} catch { /* ignore */ }
+
+let kiProviders: { id: number; displayName: string; provider: string; isActive: boolean }[] = [];
+try { kiProviders = await listKiProviders(pool, brand); } catch { /* ignore */ }
+
 let saveOk = false;
 let saveError = '';
 
@@ -26,17 +40,24 @@ if (Astro.request.method === 'POST') {
   const action = form.get('_action')?.toString();
 
   if (action === 'update-meta') {
-    const clientName = form.get('clientName')?.toString().trim() ?? '';
     const title = form.get('title')?.toString().trim() ?? '';
+    const clientId = form.get('clientId')?.toString().trim() || null;
+    const kiConfigIdRaw = form.get('kiConfigId')?.toString().trim();
+    const kiConfigId = kiConfigIdRaw ? parseInt(kiConfigIdRaw, 10) : null;
     const res = await fetch(
       `${Astro.url.origin}/api/admin/coaching/sessions/${id}`,
       {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json', cookie: Astro.request.headers.get('cookie') ?? '' },
-        body: JSON.stringify({ clientName, title }),
+        body: JSON.stringify({ title, clientId, kiConfigId }),
       }
     );
-    if (res.ok) saveOk = true; else saveError = 'Fehler beim Speichern';
+    if (res.ok) {
+      coachingSession = (await res.json()).session;
+      saveOk = true;
+    } else {
+      saveError = 'Fehler beim Speichern';
+    }
   }
 }
 
@@ -70,22 +91,42 @@ const session = coachingSession;
       <SessionWizard sessionId={id} initialSession={coachingSession} client:load />
     )}
 
-    <!-- Klient-Name direkt editierbar -->
-    <div class="bg-dark-light rounded-xl p-5 border border-dark-lighter">
-      <h2 class="text-sm font-semibold text-light mb-4">Klient bearbeiten</h2>
-      <form method="POST" class="space-y-3">
+    <!-- Session-Metadaten editierbar -->
+    <div class="meta-edit-box">
+      <h2 class="meta-edit-title">Session bearbeiten</h2>
+      {saveOk && <p class="save-ok">Gespeichert ✓</p>}
+      {saveError && <p class="save-error">{saveError}</p>}
+      <form method="POST" class="meta-form">
         <input type="hidden" name="_action" value="update-meta" />
-        <div>
-          <label class="block text-xs text-muted mb-1">Klienten-Name</label>
+        <div class="meta-field">
+          <label for="meta-title">Titel</label>
           <input
-            type="text" name="clientName"
-            value={session.clientName ?? ''}
-            class="w-full bg-dark border border-dark-lighter rounded-lg px-3 py-2 text-light text-sm focus:border-gold outline-none"
+            id="meta-title" type="text" name="title"
+            value={coachingSession.title}
+            class="meta-input"
           />
         </div>
-        <button type="submit" class="w-full py-2 bg-gold text-dark rounded-lg text-sm font-semibold hover:bg-gold/80 transition-colors">
-          Speichern
-        </button>
+        <div class="meta-field">
+          <label for="meta-clientId">Klient (optional)</label>
+          <select id="meta-clientId" name="clientId" class="meta-input">
+            <option value="">— kein Klient —</option>
+            {customers.map(c => (
+              <option value={c.id} selected={coachingSession.clientId === c.id}>{c.name}</option>
+            ))}
+          </select>
+        </div>
+        <div class="meta-field">
+          <label for="meta-kiConfigId">KI-Provider</label>
+          <select id="meta-kiConfigId" name="kiConfigId" class="meta-input">
+            <option value="">— Standard (aktiver Provider) —</option>
+            {kiProviders.map(p => (
+              <option value={String(p.id)} selected={coachingSession.kiConfigId === p.id}>
+                {p.displayName}{p.isActive ? ' ★' : ''}
+              </option>
+            ))}
+          </select>
+        </div>
+        <button type="submit" class="meta-save-btn">Speichern</button>
       </form>
     </div>
 
@@ -139,4 +180,14 @@ const session = coachingSession;
   .report-pre { color: var(--text-light,#f0f0f0); line-height: 1.7; white-space: pre-wrap; font-family: inherit; margin: 0; }
   .btn-secondary { padding: 0.5rem 1rem; border: 1px solid var(--line,#444); border-radius: 6px; color: var(--text-muted,#888); background: transparent; cursor: pointer; font-size: 0.85rem; }
   .btn-ghost { color: var(--text-muted,#888); text-decoration: underline; font-size: 0.85rem; }
+  .meta-edit-box { background: var(--bg-2,#1a1a1a); border: 1px solid var(--line,#333); border-radius: 12px; padding: 1.25rem 1.5rem; margin-top: 2rem; }
+  .meta-edit-title { font-size: 0.85rem; font-weight: 600; color: var(--text-light,#f0f0f0); margin: 0 0 1rem; }
+  .meta-form { display: flex; flex-direction: column; gap: 0.9rem; }
+  .meta-field { display: flex; flex-direction: column; gap: 0.3rem; }
+  .meta-field label { font-size: 0.78rem; color: var(--text-muted,#888); }
+  .meta-input { padding: 0.5rem 0.75rem; background: var(--bg-dark,#111); border: 1px solid var(--line,#333); border-radius: 6px; color: var(--text-light,#f0f0f0); font-size: 0.88rem; outline: none; width: 100%; box-sizing: border-box; }
+  .meta-input:focus { border-color: var(--gold,#c9a55c); }
+  .meta-save-btn { align-self: flex-start; padding: 0.5rem 1.25rem; background: var(--gold,#c9a55c); color: #111; border: none; border-radius: 6px; font-weight: 700; font-size: 0.85rem; cursor: pointer; }
+  .save-ok { color: #4ade80; font-size: 0.82rem; margin: 0 0 0.5rem; }
+  .save-error { color: #f87171; font-size: 0.82rem; margin: 0 0 0.5rem; }
 </style>

--- a/website/src/pages/admin/coaching/sessions/new.astro
+++ b/website/src/pages/admin/coaching/sessions/new.astro
@@ -1,19 +1,27 @@
 ---
 import AdminLayout from '../../../../layouts/AdminLayout.astro';
 import { getSession, getLoginUrl, isAdmin } from '../../../../lib/auth';
+import { listKiProviders } from '../../../../lib/coaching-ki-config-db';
 import { pool } from '../../../../lib/website-db';
 
 const session = await getSession(Astro.request.headers.get('cookie'));
 if (!session) return Astro.redirect(getLoginUrl(Astro.url.pathname));
 if (!isAdmin(session)) return Astro.redirect('/admin');
 
+const brand = process.env.BRAND || 'mentolder';
+
 let customers: { id: string; name: string }[] = [];
 try {
   const res = await pool.query(
     `SELECT id, name FROM public.customers WHERE brand = $1 ORDER BY name`,
-    [process.env.BRAND || 'mentolder']
+    [brand]
   );
   customers = res.rows;
+} catch { /* ignore */ }
+
+let kiProviders: { id: number; displayName: string; provider: string; isActive: boolean }[] = [];
+try {
+  kiProviders = await listKiProviders(pool, brand);
 } catch { /* ignore */ }
 
 const today = new Date().toLocaleDateString('de-DE', { day: '2-digit', month: '2-digit', year: 'numeric' });
@@ -37,6 +45,17 @@ const today = new Date().toLocaleDateString('de-DE', { day: '2-digit', month: '2
         <select id="clientId" name="clientId" class="input">
           <option value="">— Vorbereitungsrunde (kein Klient) —</option>
           {customers.map(c => <option value={c.id}>{c.name}</option>)}
+        </select>
+      </div>
+      <div class="field">
+        <label for="kiConfigId">KI-Provider (optional)</label>
+        <select id="kiConfigId" name="kiConfigId" class="input">
+          <option value="">— Standard (aktiver Provider) —</option>
+          {kiProviders.map(p => (
+            <option value={String(p.id)} selected={p.isActive}>
+              {p.displayName}{p.isActive ? ' ★' : ''}
+            </option>
+          ))}
         </select>
       </div>
       <div class="field">
@@ -64,7 +83,12 @@ const today = new Date().toLocaleDateString('de-DE', { day: '2-digit', month: '2
     const res = await fetch('/api/admin/coaching/sessions', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ title: data.title, clientId: data.clientId || null, mode: data.mode }),
+      body: JSON.stringify({
+        title: data.title,
+        clientId: data.clientId || null,
+        kiConfigId: data.kiConfigId ? parseInt(data.kiConfigId as string, 10) : null,
+        mode: data.mode,
+      }),
     });
     const json = await res.json();
     if (res.ok) {

--- a/website/src/pages/api/admin/coaching/ki-config/[id].ts
+++ b/website/src/pages/api/admin/coaching/ki-config/[id].ts
@@ -1,9 +1,16 @@
 import type { APIRoute } from 'astro';
 import { getSession, isAdmin } from '../../../../../lib/auth';
-import { updateKiProvider } from '../../../../../lib/coaching-ki-config-db';
+import { updateKiProvider, type UpdateKiProviderFields } from '../../../../../lib/coaching-ki-config-db';
 import { pool } from '../../../../../lib/website-db';
 
 export const prerender = false;
+
+const ALLOWED_FIELDS: (keyof UpdateKiProviderFields)[] = [
+  'modelName', 'displayName', 'apiKey', 'apiEndpoint',
+  'temperature', 'maxTokens', 'topP', 'systemPrompt', 'notes',
+  'topK', 'thinkingMode', 'presencePenalty', 'frequencyPenalty',
+  'safePrompt', 'randomSeed', 'organizationId', 'euEndpoint',
+];
 
 export const PATCH: APIRoute = async ({ request, params }) => {
   const session = await getSession(request.headers.get('cookie'));
@@ -12,18 +19,26 @@ export const PATCH: APIRoute = async ({ request, params }) => {
   const id = parseInt(params.id ?? '', 10);
   if (isNaN(id)) return new Response(JSON.stringify({ error: 'Ungültige ID' }), { status: 400, headers: { 'content-type': 'application/json' } });
 
-  let body: { modelName?: string | null; displayName?: string };
+  let body: Record<string, unknown>;
   try { body = await request.json(); } catch {
     return new Response(JSON.stringify({ error: 'Invalid JSON' }), { status: 400, headers: { 'content-type': 'application/json' } });
   }
 
-  if (typeof body.displayName !== 'string' || body.displayName.trim() === '') {
+  if ('displayName' in body && (typeof body.displayName !== 'string' || (body.displayName as string).trim() === '')) {
     return new Response(JSON.stringify({ error: 'displayName darf nicht leer sein' }), { status: 400, headers: { 'content-type': 'application/json' } });
   }
 
-  const provider = await updateKiProvider(pool, id, {
-    modelName: body.modelName ?? null,
-    displayName: body.displayName.trim(),
-  });
+  const fields: UpdateKiProviderFields = {};
+  for (const key of ALLOWED_FIELDS) {
+    if (key in body) {
+      if (key === 'displayName') {
+        fields.displayName = (body.displayName as string).trim();
+      } else {
+        (fields as Record<string, unknown>)[key] = body[key];
+      }
+    }
+  }
+
+  const provider = await updateKiProvider(pool, id, fields);
   return new Response(JSON.stringify({ provider }), { headers: { 'content-type': 'application/json' } });
 };

--- a/website/src/pages/api/admin/coaching/ki-config/[id].ts
+++ b/website/src/pages/api/admin/coaching/ki-config/[id].ts
@@ -1,6 +1,6 @@
 import type { APIRoute } from 'astro';
 import { getSession, isAdmin } from '../../../../../lib/auth';
-import { updateKiProvider, type UpdateKiProviderFields } from '../../../../../lib/coaching-ki-config-db';
+import { updateKiProvider, deleteKiProvider, type UpdateKiProviderFields } from '../../../../../lib/coaching-ki-config-db';
 import { pool } from '../../../../../lib/website-db';
 
 export const prerender = false;
@@ -41,4 +41,20 @@ export const PATCH: APIRoute = async ({ request, params }) => {
 
   const provider = await updateKiProvider(pool, id, fields);
   return new Response(JSON.stringify({ provider }), { headers: { 'content-type': 'application/json' } });
+};
+
+export const DELETE: APIRoute = async ({ request, params }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) return new Response('Unauthorized', { status: 401 });
+
+  const id = parseInt(params.id ?? '', 10);
+  if (isNaN(id)) return new Response(JSON.stringify({ error: 'Ungültige ID' }), { status: 400, headers: { 'content-type': 'application/json' } });
+
+  try {
+    await deleteKiProvider(pool, id);
+    return new Response(JSON.stringify({ ok: true }), { headers: { 'content-type': 'application/json' } });
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return new Response(JSON.stringify({ error: msg }), { status: 400, headers: { 'content-type': 'application/json' } });
+  }
 };

--- a/website/src/pages/api/admin/coaching/ki-config/index.ts
+++ b/website/src/pages/api/admin/coaching/ki-config/index.ts
@@ -1,9 +1,16 @@
 import type { APIRoute } from 'astro';
 import { getSession, isAdmin } from '../../../../../lib/auth';
-import { listKiProviders } from '../../../../../lib/coaching-ki-config-db';
+import { listKiProviders, createKiProvider } from '../../../../../lib/coaching-ki-config-db';
 import { pool } from '../../../../../lib/website-db';
 
 export const prerender = false;
+
+const ALL_FIELDS = [
+  'apiKey', 'apiEndpoint', 'modelName', 'temperature', 'maxTokens', 'topP',
+  'topK', 'thinkingMode', 'presencePenalty', 'frequencyPenalty',
+  'safePrompt', 'randomSeed', 'organizationId', 'euEndpoint',
+  'systemPrompt', 'notes',
+] as const;
 
 export const GET: APIRoute = async ({ request }) => {
   const session = await getSession(request.headers.get('cookie'));
@@ -11,4 +18,43 @@ export const GET: APIRoute = async ({ request }) => {
   const brand = process.env.BRAND || 'mentolder';
   const providers = await listKiProviders(pool, brand);
   return new Response(JSON.stringify({ providers }), { headers: { 'content-type': 'application/json' } });
+};
+
+export const POST: APIRoute = async ({ request }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) return new Response('Unauthorized', { status: 401 });
+
+  let body: Record<string, unknown>;
+  try { body = await request.json(); } catch {
+    return new Response(JSON.stringify({ error: 'Invalid JSON' }), { status: 400, headers: { 'content-type': 'application/json' } });
+  }
+
+  const displayName = typeof body.displayName === 'string' ? body.displayName.trim() : '';
+  if (!displayName) {
+    return new Response(JSON.stringify({ error: 'displayName darf nicht leer sein' }), { status: 400, headers: { 'content-type': 'application/json' } });
+  }
+
+  const slug = typeof body.slug === 'string' ? body.slug.trim().toLowerCase().replace(/[^a-z0-9-]/g, '-') : '';
+  if (!slug) {
+    return new Response(JSON.stringify({ error: 'slug darf nicht leer sein' }), { status: 400, headers: { 'content-type': 'application/json' } });
+  }
+
+  const rawFields = Array.isArray(body.enabledFields) ? body.enabledFields as string[] : [];
+  const enabledFields = rawFields.filter(f => (ALL_FIELDS as readonly string[]).includes(f));
+
+  const brand = process.env.BRAND || 'mentolder';
+  try {
+    const provider = await createKiProvider(pool, brand, {
+      displayName,
+      provider: `custom_${slug}`,
+      enabledFields,
+    });
+    return new Response(JSON.stringify({ provider }), { status: 201, headers: { 'content-type': 'application/json' } });
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    if (msg.includes('unique') || msg.includes('UNIQUE') || msg.includes('duplicate')) {
+      return new Response(JSON.stringify({ error: `Slug '${slug}' bereits vergeben` }), { status: 409, headers: { 'content-type': 'application/json' } });
+    }
+    throw e;
+  }
 };

--- a/website/src/pages/api/admin/coaching/sessions/[id]/index.ts
+++ b/website/src/pages/api/admin/coaching/sessions/[id]/index.ts
@@ -19,7 +19,7 @@ export const GET: APIRoute = async ({ request, params }) => {
 export const PATCH: APIRoute = async ({ request, params }) => {
   const session = await getSession(request.headers.get('cookie'));
   if (!session || !isAdmin(session)) return new Response('Unauthorized', { status: 401 });
-  let body: { title?: string; clientId?: string | null; clientName?: string | null };
+  let body: { title?: string; clientId?: string | null; clientName?: string | null; kiConfigId?: number | null };
   try { body = await request.json(); } catch {
     return new Response(JSON.stringify({ error: 'Invalid JSON' }), { status: 400, headers: { 'content-type': 'application/json' } });
   }

--- a/website/src/pages/api/admin/coaching/sessions/[id]/steps/[n]/generate.ts
+++ b/website/src/pages/api/admin/coaching/sessions/[id]/steps/[n]/generate.ts
@@ -1,8 +1,8 @@
 import type { APIRoute } from 'astro';
 import Anthropic from '@anthropic-ai/sdk';
 import { getSession, isAdmin } from '../../../../../../../../lib/auth';
-import { upsertStep, appendAuditLog } from '../../../../../../../../lib/coaching-session-db';
-import { getActiveProvider } from '../../../../../../../../lib/coaching-ki-config-db';
+import { getSession as getCoachingSession, upsertStep, appendAuditLog } from '../../../../../../../../lib/coaching-session-db';
+import { getActiveProvider, getKiProviderById } from '../../../../../../../../lib/coaching-ki-config-db';
 import { getStepTemplate, buildPromptFromTemplate } from '../../../../../../../../lib/coaching-templates-db';
 import { getStepDef, buildUserPrompt } from '../../../../../../../../lib/coaching-session-prompts';
 import { pool } from '../../../../../../../../lib/website-db';
@@ -25,7 +25,12 @@ export const POST: APIRoute = async ({ request, params }) => {
   }
 
   const brand = process.env.BRAND || 'mentolder';
-  const activeProvider = await getActiveProvider(pool, brand);
+
+  // Session-spezifischen KI-Provider laden oder auf aktiven zurückfallen
+  const coachingSession = await getCoachingSession(pool, sessionId);
+  const activeProvider = coachingSession?.kiConfigId
+    ? (await getKiProviderById(pool, coachingSession.kiConfigId)) ?? await getActiveProvider(pool, brand)
+    : await getActiveProvider(pool, brand);
   const providerName = activeProvider?.provider ?? 'claude';
 
   const dbTemplate = await getStepTemplate(pool, brand, stepNumber);
@@ -50,37 +55,62 @@ export const POST: APIRoute = async ({ request, params }) => {
   const startMs = Date.now();
   let aiResponse: string;
 
+  // System-Prompt aus KI-Profil überschreibt Template-Prompt, wenn gesetzt
+  const effectiveSystem = activeProvider?.systemPrompt || systemPrompt;
+
   try {
     if (providerName === 'claude') {
-      const apiKey = process.env.ANTHROPIC_API_KEY;
+      const apiKey = activeProvider?.apiKey ?? process.env.ANTHROPIC_API_KEY;
       if (!apiKey) return new Response(JSON.stringify({ error: 'ANTHROPIC_API_KEY nicht konfiguriert' }), { status: 503, headers: { 'content-type': 'application/json' } });
-      const client = new Anthropic({ apiKey });
+      const clientOpts: ConstructorParameters<typeof Anthropic>[0] = { apiKey };
+      if (activeProvider?.apiEndpoint) clientOpts.baseURL = activeProvider.apiEndpoint;
+      const client = new Anthropic(clientOpts);
       const model = activeProvider?.modelName ?? process.env.COACHING_SESSION_MODEL ?? 'claude-haiku-4-5-20251001';
       const msg = await client.messages.create({
-        model, max_tokens: 600, system: systemPrompt,
+        model,
+        max_tokens: activeProvider?.maxTokens ?? 600,
+        system: effectiveSystem,
+        temperature: activeProvider?.temperature ?? undefined,
+        top_p: activeProvider?.topP ?? undefined,
+        top_k: activeProvider?.topK ?? undefined,
         messages: [{ role: 'user', content: userPrompt }],
-      });
+      } as Parameters<typeof client.messages.create>[0]);
       aiResponse = msg.content.filter((b): b is Anthropic.TextBlock => b.type === 'text').map(b => b.text).join('');
     } else if (providerName === 'openai') {
-      const apiKey = process.env.OPENAI_API_KEY;
+      const apiKey = activeProvider?.apiKey ?? process.env.OPENAI_API_KEY;
       if (!apiKey) return new Response(JSON.stringify({ error: 'OPENAI_API_KEY nicht konfiguriert' }), { status: 503, headers: { 'content-type': 'application/json' } });
       const { default: OpenAI } = await import('openai');
-      const client = new OpenAI({ apiKey });
+      const clientOpts: ConstructorParameters<typeof OpenAI>[0] = { apiKey };
+      if (activeProvider?.apiEndpoint) clientOpts.baseURL = activeProvider.apiEndpoint;
+      if (activeProvider?.organizationId) clientOpts.organization = activeProvider.organizationId;
+      const client = new OpenAI(clientOpts);
       const model = activeProvider?.modelName ?? 'gpt-4o-mini';
       const resp = await client.chat.completions.create({
-        model, max_tokens: 600,
-        messages: [{ role: 'system', content: systemPrompt }, { role: 'user', content: userPrompt }],
+        model,
+        max_tokens: activeProvider?.maxTokens ?? 600,
+        temperature: activeProvider?.temperature ?? undefined,
+        top_p: activeProvider?.topP ?? undefined,
+        presence_penalty: activeProvider?.presencePenalty ?? undefined,
+        frequency_penalty: activeProvider?.frequencyPenalty ?? undefined,
+        messages: [{ role: 'system', content: effectiveSystem }, { role: 'user', content: userPrompt }],
       });
       aiResponse = resp.choices[0]?.message.content ?? '';
     } else if (providerName === 'mistral') {
-      const apiKey = process.env.MISTRAL_API_KEY;
+      const apiKey = activeProvider?.apiKey ?? process.env.MISTRAL_API_KEY;
       if (!apiKey) return new Response(JSON.stringify({ error: 'MISTRAL_API_KEY nicht konfiguriert' }), { status: 503, headers: { 'content-type': 'application/json' } });
       const { Mistral } = await import('@mistralai/mistralai');
-      const client = new Mistral({ apiKey });
+      const clientOpts: ConstructorParameters<typeof Mistral>[0] = { apiKey };
+      if (activeProvider?.apiEndpoint) clientOpts.serverURL = activeProvider.apiEndpoint;
+      const client = new Mistral(clientOpts);
       const model = activeProvider?.modelName ?? 'mistral-small-latest';
       const resp = await client.chat.complete({
         model,
-        messages: [{ role: 'system', content: systemPrompt }, { role: 'user', content: userPrompt }],
+        maxTokens: activeProvider?.maxTokens ?? undefined,
+        temperature: activeProvider?.temperature ?? undefined,
+        topP: activeProvider?.topP ?? undefined,
+        randomSeed: activeProvider?.randomSeed ?? undefined,
+        safePrompt: activeProvider?.safePrompt ?? false,
+        messages: [{ role: 'system', content: effectiveSystem }, { role: 'user', content: userPrompt }],
       });
       aiResponse = (resp.choices?.[0]?.message.content as string) ?? '';
     } else if (providerName === 'lumo') {

--- a/website/src/pages/api/admin/coaching/sessions/index.ts
+++ b/website/src/pages/api/admin/coaching/sessions/index.ts
@@ -27,7 +27,7 @@ export const POST: APIRoute = async ({ request }) => {
   const session = await getSession(request.headers.get('cookie'));
   if (!session || !isAdmin(session)) return new Response('Unauthorized', { status: 401 });
   const brand = process.env.BRAND || 'mentolder';
-  let body: { title: string; clientId?: string | null; clientName?: string | null; mode?: 'live' | 'prep' };
+  let body: { title: string; clientId?: string | null; clientName?: string | null; kiConfigId?: number | null; mode?: 'live' | 'prep' };
   try { body = await request.json(); } catch {
     return new Response(JSON.stringify({ error: 'Invalid JSON' }), { status: 400, headers: { 'content-type': 'application/json' } });
   }
@@ -36,7 +36,7 @@ export const POST: APIRoute = async ({ request }) => {
   }
   const created = await createSession(pool, {
     brand, title: body.title, createdBy: session.preferred_username,
-    clientId: body.clientId ?? null, mode: body.mode ?? 'live',
+    clientId: body.clientId ?? null, kiConfigId: body.kiConfigId ?? null, mode: body.mode ?? 'live',
   });
   return new Response(JSON.stringify({ session: created }), { status: 201, headers: { 'content-type': 'application/json' } });
 };


### PR DESCRIPTION
## Summary

- **DB**: 15 neue Spalten in `coaching.ki_config` (API-Key, Endpunkt, Temperature, Max Tokens, top_p, System-Prompt, Notizen, top_k, thinking_mode, presence_/frequency_penalty, safe_prompt, random_seed, organization_id, eu_endpoint) + `ki_config_id` FK auf `coaching.sessions`
- **KI-Config-API** (`PATCH /api/admin/coaching/ki-config/[id]`): alle neuen Felder per PATCH bearbeitbar
- **generate.ts**: session-spezifischen Provider laden, pro Provider korrekte SDK-Parameter übergeben; System-Prompt aus KI-Profil überschreibt Template-Prompt
- **CoachingSettings.svelte**: erweitertes Edit-Panel mit Verbindung/Verhalten-Tabs, Provider-Badges (Claude/OpenAI/Mistral/Lumo), maskierter API-Key mit Show/Hide, Lumo-Infobox, provider-spezifische Felder per `showField()`
- **sessions/new.astro**: KI-Provider-Dropdown beim Anlegen einer Session
- **sessions/[id].astro**: `clientName`-Textfeld → `clientId`-Dropdown aus Kunden-DB; KI-Provider-Dropdown zum nachträglichen Ändern

## Test plan

- [ ] Neuen KI-Provider anlegen und Felder in beiden Tabs (Verbindung/Verhalten) ausfüllen/speichern
- [ ] API-Key maskierung und Show/Hide Button testen
- [ ] Lumo-Provider öffnen → Infobox statt API-Key-Feld sichtbar
- [ ] Neue Session: Klienten-Dropdown und KI-Provider-Dropdown befüllen, absenden → Session in DB mit client_id + ki_config_id
- [ ] Bestehende Session: Klient und KI-Provider wechseln, speichern
- [ ] Session-Schritt generieren → KI-Anfrage verwendet den session-spezifischen Provider
- [ ] `task workspace:validate` — grün

🤖 Generated with [Claude Code](https://claude.com/claude-code)