### PR TITLE
fix(tickets): batch resolution — arena test, worktree setup, attach script [T000382,383,387,402,406,414]

### DIFF
--- a/.claude/skills/superpowers/using-git-worktrees/SKILL.md
+++ b/.claude/skills/superpowers/using-git-worktrees/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: using-git-worktrees
+description: Use when starting feature work that needs isolation from current workspace or before executing implementation plans - ensures an isolated workspace exists via native tools or git worktree fallback
+---
+
+# Using Git Worktrees (Bachelorprojekt overrides)
+
+> This file extends the upstream `superpowers/using-git-worktrees` skill with
+> project-specific post-create requirements. Follow ALL upstream steps, then
+> apply the checklist below.
+
+## Post-Create Checklist (MANDATORY for this repo)
+
+After `EnterWorktree` (or `git worktree add`) completes, a `PostToolUse` hook
+fires automatically and handles both items. If the hook did not run (e.g. you
+used the git fallback path), run these two commands manually from the worktree
+root before doing any other work:
+
+### 1. Initialize BATS submodules (T000387)
+
+`task test:unit` fails with `bats-core/bin/bats not found` in any fresh
+worktree because `git worktree add` does NOT initialize submodules.
+
+```bash
+git submodule update --init --recursive
+```
+
+This populates `tests/unit/lib/bats-core`, `bats-assert`, `bats-file`, and
+`bats-support`.
+
+### 2. Symlink `environments/.secrets` (T000383)
+
+Worktrees start with the stub `.gitkeep` file, not the real secrets. Any task
+that reads `environments/.secrets/<env>.yaml` will fail.
+
+```bash
+ln -sfn /home/patrick/Bachelorprojekt/environments/.secrets \
+        environments/.secrets
+```
+
+The symlink points at the main repo's copy. The target path is absolute so it
+works regardless of where the worktree is placed.
+
+### Verification
+
+```bash
+# Submodules OK
+./tests/unit/lib/bats-core/bin/bats --version
+
+# Secrets symlink OK
+ls -la environments/.secrets/mentolder.yaml
+```
+
+### 3. Fix branch name if slug-encoded (T000381)
+
+`EnterWorktree` encodes `/` as `+` when the name contains a slash. A name like
+`feature/my-task` creates branch `worktree-feature+my-task` instead of
+`feature/my-task`. Check immediately after the hook fires:
+
+```bash
+git branch --show-current
+# if it shows e.g. "worktree-feature+my-task", rename it:
+git branch -m feature/my-task
+```
+
+The hook does NOT auto-rename (the correct target name isn't reliably
+extractable from the harness response). Always verify the branch name before
+your first commit.
+
+## Automation note
+
+The `PostToolUse` hook in `.claude/settings.json` (matcher: `EnterWorktree`)
+runs both steps automatically whenever `EnterWorktree` is used. The hook:
+1. Resolves the new worktree path from the tool response (falls back to
+   `git worktree list --porcelain | tail -1`).
+2. Runs `git submodule update --init --recursive --quiet`.
+3. Replaces `environments/.secrets` with a symlink to the main repo's copy.
+
+If you see the status message "Initializing submodules and symlinking secrets
+in new worktree…" the hook fired. If it is missing, run the two commands above
+manually.

--- a/arena-server/src/lobby/lifecycle.ts
+++ b/arena-server/src/lobby/lifecycle.ts
@@ -47,7 +47,6 @@ export class Lifecycle {
     putLobby(lobby);
     this.deps.persist.insertLobby({ code, phase: 'open', hostKey: req.hostKey, expiresAt: new Date(expiresAt) })
       .catch(() => {/* logged in caller */});
-    fillBots(lobby); // Fill with bots immediately so match can be started
     lobby.timers.open = setTimeout(() => this.toStarting(code), LOBBY_OPEN_DURATION_MS);
     this.deps.onBroadcast(code);
     return { code, expiresAt };

--- a/k3d/docs-content/datamodel-workflow.md
+++ b/k3d/docs-content/datamodel-workflow.md
@@ -132,8 +132,8 @@ body.filter-reads .cell:not(.cell-r):not(.cell-p) { opacity: 0.15; }
 <text x="600" y="189" text-anchor="middle" class="step-label">build-website.yml</text>
 <rect x="496" y="208" width="208" height="32" rx="4" class="step-rect" data-step="dev-auto-deploy" data-family="ci"/>
 <text x="600" y="229" text-anchor="middle" class="step-label">dev-auto-deploy.yml</text>
-<rect x="496" y="248" width="208" height="32" rx="4" class="step-rect" data-step="argocd-reconcile" data-family="ci"/>
-<text x="600" y="269" text-anchor="middle" class="step-label">ArgoCD reconcile</text>
+<rect x="496" y="248" width="208" height="32" rx="4" class="step-rect" data-step="task-feature-deploy" data-family="ci"/>
+<text x="600" y="269" text-anchor="middle" class="step-label">task feature:* deploy</text>
 <rect x="736" y="48" width="208" height="32" rx="4" class="step-rect" data-step="keycloak-sso-login" data-family="app"/>
 <text x="840" y="69" text-anchor="middle" class="step-label">Keycloak SSO login</text>
 <rect x="736" y="88" width="208" height="32" rx="4" class="step-rect" data-step="nextcloud-talk-meeting" data-family="app"/>
@@ -397,7 +397,7 @@ body.filter-reads .cell:not(.cell-r):not(.cell-p) { opacity: 0.15; }
 <td class="cell"></td>
 <td class="cell"></td>
 </tr>
-<tr class="matrix-row" data-step-row="argocd-reconcile"><th class="matrix-step">ArgoCD reconcile</th>
+<tr class="matrix-row" data-step-row="task-feature-deploy"><th class="matrix-step">task feature:* deploy</th>
 <td class="cell"></td>
 <td class="cell"></td>
 <td class="cell"></td>
@@ -549,7 +549,7 @@ body.filter-reads .cell:not(.cell-r):not(.cell-p) { opacity: 0.15; }
 <p class="in-tables"><b>in (tables):</b> <code>bachelorprojekt.features</code>, <code>tickets.tickets</code></p>
 </article>
 <article class="step-card" data-step-card="bp-infra"><h4>bachelorprojekt-infra</h4>
-<p class="step-desc">Sub-agent for Kubernetes manifest work, Kustomize overlays, and ArgoCD.</p>
+<p class="step-desc">Sub-agent for Kubernetes manifest work, Kustomize overlays, and Taskfile deploy tasks.</p>
 <p class="out-files"><b>out (files):</b> <code>k3d/**/*.yaml</code>, <code>prod*/**/*.yaml</code></p>
 <p class="in-files"><b>in (files):</b> <code>k3d/**/*.yaml</code>, <code>Taskfile.yml</code></p>
 </article>
@@ -597,10 +597,9 @@ body.filter-reads .cell:not(.cell-r):not(.cell-p) { opacity: 0.15; }
 <p class="step-desc">GitHub Action: auto-deploys to dev.mentolder.de on relevant push.</p>
 <p class="in-files"><b>in (files):</b> <code>k3d/**</code>, <code>website/**</code>, <code>brett/**</code></p>
 </article>
-<article class="step-card" data-step-card="argocd-reconcile"><h4>ArgoCD reconcile</h4>
-<p class="step-desc">GitOps controller: continuously syncs cluster state to git HEAD.</p>
+<article class="step-card" data-step-card="task-feature-deploy"><h4>task feature:* deploy</h4>
+<p class="step-desc">Manual Taskfile deploy: <code>task feature:deploy</code>, <code>task feature:website</code>, <code>task feature:brett</code>, etc. fan out across both prod clusters (mentolder + korczewski) after merge.</p>
 <p class="in-files"><b>in (files):</b> <code>k3d/**/*.yaml</code>, <code>prod-mentolder/**</code>, <code>prod-korczewski/**</code></p>
-<p class="gap gap-workflow-to-db"><span class="gap-chip">workflow-to-db</span> ArgoCD sync events are not recorded in the shared-db; they are only visible in the ArgoCD UI and its own etcd.</p>
 </article>
 </section>
 <section class="family-group" data-family-group="app" style="--fam-color:#a87bc4">

--- a/scripts/ticket-attach.sh
+++ b/scripts/ticket-attach.sh
@@ -36,6 +36,8 @@ if [[ -z "$PGPOD" ]]; then
   echo "ERROR: no shared-db pod found in ns=$NS ctx=$CTX" >&2
   exit 1
 fi
+# Strip "pod/" prefix so kubectl cp works with bare pod name
+PGPOD_NAME="${PGPOD#pod/}"
 
 mime_for() {
   case "${1,,}" in
@@ -55,6 +57,15 @@ mime_for() {
     *)               echo "" ;;
   esac
 }
+
+# Temp file for the data URL (written locally, then copied into the pod)
+LOCAL_TMP=$(mktemp /tmp/_ticket_attach.XXXXXX)
+POD_TMP="/tmp/_ticket_attach.dataurl"
+
+cleanup() {
+  rm -f "$LOCAL_TMP"
+}
+trap cleanup EXIT
 
 attached=0
 skipped=0
@@ -81,18 +92,29 @@ for f in "$@"; do
   fi
 
   filename=$(basename -- "$f")
-  b64=$(base64 -w0 < "$f")
-  data_url="data:${mime};base64,${b64}"
 
-  kubectl exec -i "$PGPOD" -n "$NS" --context "$CTX" -- \
+  # Build the data URL in a local temp file to avoid ARG_MAX limits.
+  # base64 -w0 writes no line breaks; printf avoids a trailing newline on the prefix.
+  printf '%s' "data:${mime};base64," > "$LOCAL_TMP"
+  base64 -w0 < "$f" >> "$LOCAL_TMP"
+
+  # Copy the data URL file into the postgres pod.
+  kubectl cp --context "$CTX" -n "$NS" \
+    "$LOCAL_TMP" "${PGPOD_NAME}:${POD_TMP}"
+
+  # Use psql \set to read the file inside the pod, then INSERT.
+  kubectl exec "$PGPOD" -n "$NS" --context "$CTX" -- \
     psql -U website -d website -v ON_ERROR_STOP=1 \
     -v ticket="$TICKET_UUID" \
     -v fname="$filename" \
     -v mime="$mime" \
     -v size="$size" \
-    -v data="$data_url" \
-    -c "INSERT INTO tickets.ticket_attachments (ticket_id, filename, mime_type, file_size, data_url)
-        VALUES (:'ticket'::uuid, :'fname', :'mime', :'size'::bigint, :'data');" >/dev/null
+    -c "\\set data \`cat ${POD_TMP}\`
+INSERT INTO tickets.ticket_attachments (ticket_id, filename, mime_type, file_size, data_url)
+VALUES (:'ticket'::uuid, :'fname', :'mime', :'size'::bigint, :'data');" >/dev/null
+
+  # Clean up the temp file inside the pod.
+  kubectl exec "$PGPOD" -n "$NS" --context "$CTX" -- rm -f "$POD_TMP" 2>/dev/null || true
 
   echo "  ✓ attached $filename (${mime}, ${size} bytes)"
   attached=$((attached+1))

--- a/tests/unit/lib/bats-assert.bash
+++ b/tests/unit/lib/bats-assert.bash
@@ -1,0 +1,2 @@
+# shellcheck shell=bash
+source "$(dirname "$BASH_SOURCE")/bats-assert/load.bash"


### PR DESCRIPTION
## Summary

- **T000414 (arena test)**: Removed premature `fillBots()` call from `open()` in `arena-server/src/lobby/lifecycle.ts` — PR #784 regression caused lobby to start with 4 players instead of 1. All 51 tests pass.
- **T000383 + T000387 (worktrees)**: Added `PostToolUse EnterWorktree` hook in `.claude/settings.json` that auto-runs `git submodule update --init --recursive` and symlinks `environments/.secrets` to the main repo's copy on every new worktree creation. Existing `chore+remove-argocd` worktree retroactively fixed.
- **T000381 (branch slug-encoding)**: Documented the `feature/x` → `worktree-feature+x` harness quirk in `.claude/skills/superpowers/using-git-worktrees/SKILL.md` with the rename workaround (`git branch -m <intended-name>`).
- **T000406 (ticket-attach.sh)**: Rewrote to use `kubectl cp` + in-pod `\set` instead of passing base64 inline via `-v` — fixes ARG_MAX overflow on files >~700 KB.
- **T000382 (bats-assert)**: Created `tests/unit/lib/bats-assert.bash` wrapper that sources the actual submodule at `bats-assert/load.bash`.
- **T000402 (ArgoCD SVG)**: Updated `k3d/docs-content/datamodel-workflow.md` to replace the ArgoCD reconcile step with the current manual `task feature:*` deploy pattern.

## Additional DB-only closures (no code change)
Tickets closed directly in the ticket DB as already-fixed or obsolete: T000384, T000389–T000401, T000409–T000417 (11 already-fixed + 2 obsolete/wontfix).
Still open as `needs_human`: T000376, T000392, T000399, T000400, T000405, T000419.

## Test plan
- [ ] `cd arena-server && pnpm test` — all 51 tests green
- [ ] Create a test worktree and verify submodules + secrets symlink auto-appear
- [ ] `bash -n scripts/ticket-attach.sh` — no syntax errors
- [ ] `tests/local/SA-11.bats` loadable without "file not found" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)