### PR TITLE
fix(knowledge-ingest): bump node:20-alpine → node:22-alpine

### DIFF
--- a/k3d/knowledge-ingest-cronjob.yaml
+++ b/k3d/knowledge-ingest-cronjob.yaml
@@ -296,7 +296,7 @@ spec:
                         values: [gekko-hetzner-2, gekko-hetzner-3, gekko-hetzner-4, pk-hetzner, pk-hetzner-2, pk-hetzner-3]
           initContainers:
             - name: npm-install
-              image: node:20-alpine
+              image: node:22-alpine
               imagePullPolicy: IfNotPresent
               command: [sh, -c, "cd /scripts && npm install pg --no-package-lock --silent"]
               volumeMounts:
@@ -312,7 +312,7 @@ spec:
                   memory: 256Mi
           containers:
             - name: ingest
-              image: node:20-alpine
+              image: node:22-alpine
               imagePullPolicy: IfNotPresent
               command: [node, /scripts/ingest-prs.mjs]
               env:
@@ -379,7 +379,7 @@ spec:
                         values: [gekko-hetzner-2, gekko-hetzner-3, gekko-hetzner-4, pk-hetzner, pk-hetzner-2, pk-hetzner-3]
           containers:
             - name: ingest
-              image: node:20-alpine
+              image: node:22-alpine
               imagePullPolicy: IfNotPresent
               command: [node, /scripts/ingest-markdown.mjs]
               volumeMounts:
@@ -425,7 +425,7 @@ spec:
                         values: [gekko-hetzner-2, gekko-hetzner-3, gekko-hetzner-4, pk-hetzner, pk-hetzner-2, pk-hetzner-3]
           initContainers:
             - name: npm-install
-              image: node:20-alpine
+              image: node:22-alpine
               imagePullPolicy: IfNotPresent
               command: [sh, -c, "cd /scripts && npm install pg --no-package-lock --silent"]
               volumeMounts:
@@ -441,7 +441,7 @@ spec:
                   memory: 256Mi
           containers:
             - name: ingest
-              image: node:20-alpine
+              image: node:22-alpine
               imagePullPolicy: IfNotPresent
               command: [node, /scripts/ingest-bug-tickets.mjs]
               env:
@@ -510,7 +510,7 @@ spec:
                         values: [gekko-hetzner-2, gekko-hetzner-3, gekko-hetzner-4, pk-hetzner, pk-hetzner-2, pk-hetzner-3]
           initContainers:
             - name: npm-install
-              image: node:20-alpine
+              image: node:22-alpine
               imagePullPolicy: IfNotPresent
               command: [sh, -c, "cd /scripts && npm install pg --no-package-lock --silent"]
               volumeMounts:
@@ -526,7 +526,7 @@ spec:
                   memory: 256Mi
           containers:
             - name: ingest
-              image: node:20-alpine
+              image: node:22-alpine
               imagePullPolicy: IfNotPresent
               command:
                 - sh


### PR DESCRIPTION
## Summary

- Bumps all 7 `node:20-alpine` image references in `k3d/knowledge-ingest-cronjob.yaml` to `node:22-alpine`
- Node.js 20 Active LTS ended April 2026 and is now in maintenance/security-only mode
- Aligns with every other node init/sidecar container in the repo (`backup-cronjob.yaml`, `claude-code-mcp-ops.yaml`, `vaultwarden-seed-job.yaml`) which already use `node:22-alpine`
- Closes #792

## Test plan

- [x] `kustomize build k3d/` still produces clean output after the change
- [ ] Verify knowledge-ingest CronJob completes successfully on next scheduled run (uses `pg` npm package — no breaking API changes between Node 20 and 22)

https://claude.ai/code/session_01YCFJ3kxFmofVQXzTHPoiRx

---
_Generated by [Claude Code](https://claude.ai/code/session_01YCFJ3kxFmofVQXzTHPoiRx)_