### PR TITLE
fix(coaching): Session-Info speichern setzt SessionWizard nicht mehr zurück [T000424]

### DIFF
--- a/website/src/lib/coaching-session-db.test.ts
+++ b/website/src/lib/coaching-session-db.test.ts
@@ -36,6 +36,7 @@ beforeAll(async () => {
       brand TEXT NOT NULL DEFAULT 'mentolder',
       client_id UUID,
       client_name TEXT,
+      ki_config_id INT,
       mode TEXT NOT NULL DEFAULT 'live',
       title TEXT NOT NULL,
       status TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active','paused','completed','abandoned')),
@@ -223,5 +224,18 @@ describe('updateSessionFields', () => {
   it('gibt null zurück bei unbekannter id', async () => {
     const result = await updateSessionFields(pool, '00000000-0000-4000-8000-000000000000', { title: 'X' }, 'coach');
     expect(result).toBeNull();
+  });
+
+  it('gibt Steps zurück wenn die Session Steps hat', async () => {
+    const s = await createSession(pool, {
+      brand: 'mentolder', title: 'Session mit Steps', mode: 'live', createdBy: 'coach',
+    });
+    await upsertStep(pool, {
+      sessionId: s.id, stepNumber: 1, stepName: 'Schritt 1', phase: 'problem_ziel',
+      coachInputs: {}, status: 'pending',
+    });
+    const updated = await updateSessionFields(pool, s.id, { title: 'Geändert' }, 'coach');
+    expect(updated?.steps).toHaveLength(1);
+    expect(updated?.steps[0].stepNumber).toBe(1);
   });
 });

--- a/website/src/lib/coaching-session-db.ts
+++ b/website/src/lib/coaching-session-db.ts
@@ -333,6 +333,10 @@ export async function updateSessionFields(
       return null;
     }
     const row = current.rows[0];
+    const stepsRes = await client.query(
+      `SELECT * FROM coaching.session_steps WHERE session_id = $1 ORDER BY step_number`, [id],
+    );
+    const steps = stepsRes.rows.map(rowToStep);
 
     const sets: string[] = [];
     const vals: unknown[] = [id];
@@ -360,7 +364,7 @@ export async function updateSessionFields(
     }
     if (sets.length === 0) {
       await client.query('ROLLBACK');
-      return rowToSession(row);
+      return rowToSession(row, steps);
     }
 
     const r = await client.query(
@@ -375,7 +379,7 @@ export async function updateSessionFields(
       );
     }
     await client.query('COMMIT');
-    return rowToSession(r.rows[0]);
+    return rowToSession(r.rows[0], steps);
   } catch (e) {
     await client.query('ROLLBACK');
     throw e;


### PR DESCRIPTION
## Summary

- `updateSessionFields` gab `rowToSession()` ohne Steps zurück (`steps: []`)
- Der PATCH-Response hatte dadurch leere Steps, wodurch `SessionWizard` nach dem POST-Reload auf Schritt 1 reinitialisiert wurde statt beim aktuellen Fortschritt zu bleiben
- Fix: Steps innerhalb der Transaktion abfragen und an beide `rowToSession()`-Aufrufe übergeben
- Bonus: `ki_config_id`-Spalte im pg-mem-Testschema ergänzt (fehlte seit KI-Provider-PR, alle 13 bestehenden Tests schlugen seitdem fehl)

## Test plan

- [x] Neuer Unit-Test `gibt Steps zurück wenn die Session Steps hat` — war rot, ist jetzt grün
- [x] Alle 14 Tests in `coaching-session-db.test.ts` grün (`14 passed`)
- [ ] Manuell: laufende Session öffnen → Session-Info bearbeiten (Klient / KI-Provider wechseln) → Speichern → SessionWizard bleibt beim aktuellen Schritt

🤖 Generated with [Claude Code](https://claude.com/claude-code)