### PR TITLE
fix(coaching): Session speichern crasht nicht mehr + Session-Löschfunktion [T000426, T000427]

### DIFF
--- a/website/src/components/admin/coaching/SessionsOverview.svelte
+++ b/website/src/components/admin/coaching/SessionsOverview.svelte
@@ -94,6 +94,19 @@
     await load();
   }
 
+  let confirmDeleteId = $state<string | null>(null);
+
+  async function doDelete(id: string) {
+    const res = await fetch(`/api/admin/coaching/sessions/${id}`, { method: 'DELETE' });
+    if (res.ok) {
+      sessions = sessions.filter(s => s.id !== id);
+      total = total - 1;
+    } else {
+      alert('Fehler beim Löschen');
+    }
+    confirmDeleteId = null;
+  }
+
   function fmtDate(d: Date | string | null) {
     if (!d) return '—';
     return new Date(d).toLocaleDateString('de-DE', { day: '2-digit', month: '2-digit', year: 'numeric' });
@@ -178,6 +191,12 @@
                 <button class="btn-sm" onclick={() => confirmArchiveId = null}>Abbruch</button>
               {:else}
                 <button class="btn-sm" onclick={() => confirmArchiveId = s.id} title="Archivieren">📦</button>
+              {/if}
+              {#if confirmDeleteId === s.id}
+                <button class="btn-sm btn-danger" onclick={() => doDelete(s.id)}>Sicher?</button>
+                <button class="btn-sm" onclick={() => confirmDeleteId = null}>Abbruch</button>
+              {:else}
+                <button class="btn-sm btn-danger" onclick={() => confirmDeleteId = s.id} title="Löschen">×</button>
               {/if}
             </td>
           </tr>

--- a/website/src/lib/coaching-session-db.test.ts
+++ b/website/src/lib/coaching-session-db.test.ts
@@ -13,6 +13,7 @@ import {
   unarchiveSession,
   getAuditLog,
   updateSessionFields,
+  deleteSession,
 } from './coaching-session-db';
 
 let pool: Pool;
@@ -237,5 +238,22 @@ describe('updateSessionFields', () => {
     const updated = await updateSessionFields(pool, s.id, { title: 'Geändert' }, 'coach');
     expect(updated?.steps).toHaveLength(1);
     expect(updated?.steps[0].stepNumber).toBe(1);
+  });
+});
+
+describe('deleteSession', () => {
+  it('löscht eine Session und gibt true zurück', async () => {
+    const s = await createSession(pool, {
+      brand: 'mentolder', title: 'Zu löschen', mode: 'live', createdBy: 'coach',
+    });
+    const result = await deleteSession(pool, s.id);
+    expect(result).toBe(true);
+    const fetched = await getSession(pool, s.id);
+    expect(fetched).toBeNull();
+  });
+
+  it('gibt false zurück bei unbekannter id', async () => {
+    const result = await deleteSession(pool, '00000000-0000-4000-8000-000000000099');
+    expect(result).toBe(false);
   });
 });

--- a/website/src/lib/coaching-session-db.ts
+++ b/website/src/lib/coaching-session-db.ts
@@ -432,6 +432,11 @@ export async function unarchiveSession(pool: Pool, id: string, actor: string): P
   }
 }
 
+export async function deleteSession(pool: Pool, id: string): Promise<boolean> {
+  const r = await pool.query(`DELETE FROM coaching.sessions WHERE id = $1`, [id]);
+  return (r.rowCount ?? 0) > 0;
+}
+
 export async function getAuditLog(pool: Pool, sessionId: string, limit = 50): Promise<AuditEntry[]> {
   const r = await pool.query(
     `SELECT * FROM coaching.session_audit_log WHERE session_id = $1

--- a/website/src/pages/admin/coaching/sessions/[id].astro
+++ b/website/src/pages/admin/coaching/sessions/[id].astro
@@ -2,7 +2,7 @@
 import AdminLayout from '../../../../layouts/AdminLayout.astro';
 import SessionWizard from '../../../../components/admin/coaching/SessionWizard.svelte';
 import { getSession as getAuthSession, getLoginUrl, isAdmin } from '../../../../lib/auth';
-import { getSession as getCoachingSession, getAuditLog } from '../../../../lib/coaching-session-db';
+import { getSession as getCoachingSession, getAuditLog, updateSessionFields } from '../../../../lib/coaching-session-db';
 import { listKiProviders } from '../../../../lib/coaching-ki-config-db';
 import { pool } from '../../../../lib/website-db';
 
@@ -41,18 +41,17 @@ if (Astro.request.method === 'POST') {
     const clientId = form.get('clientId')?.toString().trim() || null;
     const kiConfigIdRaw = form.get('kiConfigId')?.toString().trim();
     const kiConfigId = kiConfigIdRaw ? parseInt(kiConfigIdRaw, 10) : null;
-    const res = await fetch(
-      `${Astro.url.origin}/api/admin/coaching/sessions/${id}`,
-      {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json', cookie: Astro.request.headers.get('cookie') ?? '' },
-        body: JSON.stringify({ title, clientId, kiConfigId }),
+    try {
+      const updated = await updateSessionFields(
+        pool, id, { title, clientId, kiConfigId }, authSession.preferred_username
+      );
+      if (updated) {
+        coachingSession = updated;
+        saveOk = true;
+      } else {
+        saveError = 'Session nicht gefunden';
       }
-    );
-    if (res.ok) {
-      coachingSession = (await res.json()).session;
-      saveOk = true;
-    } else {
+    } catch {
       saveError = 'Fehler beim Speichern';
     }
   }
@@ -139,6 +138,7 @@ const displayKi = kiProviders.find(p => p.id === coachingSession.kiConfigId)?.di
         <div class="meta-actions">
           <button type="submit" class="meta-save-btn">Speichern</button>
           <button type="button" id="meta-cancel-btn" class="meta-cancel-btn">Abbrechen</button>
+          <button id="meta-delete-btn" class="meta-delete-btn" type="button">Löschen</button>
         </div>
       </form>
     </div>
@@ -195,6 +195,17 @@ const displayKi = kiProviders.find(p => p.id === coachingSession.kiConfigId)?.di
     view.style.display = 'grid';
     editBtn.style.display = '';
   });
+
+  document.getElementById('meta-delete-btn')?.addEventListener('click', async () => {
+    if (!confirm('Session wirklich löschen? Diese Aktion kann nicht rückgängig gemacht werden.')) return;
+    const id = window.location.pathname.split('/').at(-1);
+    const res = await fetch(`/api/admin/coaching/sessions/${id}`, { method: 'DELETE' });
+    if (res.ok) {
+      window.location.href = '/admin/coaching/sessions';
+    } else {
+      alert('Fehler beim Löschen');
+    }
+  });
 </script>
 
 <style>
@@ -226,6 +237,8 @@ const displayKi = kiProviders.find(p => p.id === coachingSession.kiConfigId)?.di
   .meta-actions { display: flex; gap: 0.5rem; align-items: center; }
   .meta-save-btn { padding: 0.5rem 1.25rem; background: var(--gold,#c9a55c); color: #111; border: none; border-radius: 6px; font-weight: 700; font-size: 0.85rem; cursor: pointer; }
   .meta-cancel-btn { padding: 0.5rem 0.9rem; border: 1px solid var(--line,#444); border-radius: 6px; color: var(--text-muted,#888); background: none; font-size: 0.85rem; cursor: pointer; }
+  .meta-delete-btn { padding: 0.5rem 0.9rem; border: 1px solid #ef4444; border-radius: 6px; color: #ef4444; background: none; font-size: 0.85rem; cursor: pointer; margin-left: auto; }
+  .meta-delete-btn:hover { background: #ef444420; }
   .save-ok { color: #4ade80; font-size: 0.82rem; }
   .save-error { color: #f87171; font-size: 0.82rem; }
 </style>

--- a/website/src/pages/api/admin/coaching/sessions/[id]/index.ts
+++ b/website/src/pages/api/admin/coaching/sessions/[id]/index.ts
@@ -3,6 +3,7 @@ import { getSession, isAdmin } from '../../../../../../lib/auth';
 import {
   getSession as getCoachingSession,
   updateSessionFields,
+  deleteSession,
 } from '../../../../../../lib/coaching-session-db';
 import { pool } from '../../../../../../lib/website-db';
 
@@ -26,4 +27,12 @@ export const PATCH: APIRoute = async ({ request, params }) => {
   const updated = await updateSessionFields(pool, params.id as string, body, session.preferred_username);
   if (!updated) return new Response(JSON.stringify({ error: 'Not found' }), { status: 404, headers: { 'content-type': 'application/json' } });
   return new Response(JSON.stringify({ session: updated }), { headers: { 'content-type': 'application/json' } });
+};
+
+export const DELETE: APIRoute = async ({ request, params }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) return new Response('Unauthorized', { status: 401 });
+  const deleted = await deleteSession(pool, params.id as string);
+  if (!deleted) return new Response(JSON.stringify({ error: 'Not found' }), { status: 404, headers: { 'content-type': 'application/json' } });
+  return new Response(JSON.stringify({ ok: true }), { headers: { 'content-type': 'application/json' } });
 };


### PR DESCRIPTION
## Summary

- **T000426 (Critical Bug):** `[id].astro` POST-Handler machte einen `fetch()` zur eigenen Astro-URL — in K8s lief das durch Traefik und konnte mit Network-Error werfen (kein try/catch). Jetzt wird `updateSessionFields()` direkt aufgerufen, kein HTTP-Round-Trip mehr.
- **T000427 (Feature):** `deleteSession()` in der DB-Schicht, `DELETE`-Endpunkt in der API, roter Löschen-Button mit `confirm()`-Dialog auf der Session-Detailseite, `×`-Button pro Zeile in der Sessions-Übersicht.

## Test plan

- [x] 16/16 Unit-Tests grün (`coaching-session-db.test.ts`, inkl. 2 neue für `deleteSession`)
- [x] Alle 5 geänderten Dateien überprüft
- [ ] Manuell: Session-Info bearbeiten (Klient / KI wechseln) → Speichern → kein Crash, Seite bleibt auf aktuellem Schritt
- [ ] Manuell: Session-Detailseite → Löschen-Button → Bestätigung → Redirect zur Übersicht
- [ ] Manuell: Sessions-Übersicht → `×` bei einer Session → Session verschwindet aus Liste

🤖 Generated with [Claude Code](https://claude.com/claude-code)