### PR TITLE
feat(coaching): KI-Projektverwaltung v2 — Kundennummer-Anonymisierung + Projektseiten

### DIFF
--- a/scripts/one-shot/20260517-coaching-projects.sql
+++ b/scripts/one-shot/20260517-coaching-projects.sql
@@ -1,0 +1,38 @@
+-- scripts/one-shot/20260517-coaching-projects.sql
+
+-- 1) Projekttabelle
+CREATE TABLE IF NOT EXISTS coaching.projects (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  brand           TEXT NOT NULL,
+  client_id       UUID REFERENCES customers(id),
+  customer_number TEXT NOT NULL,
+  display_alias   TEXT,
+  ki_context      TEXT,
+  notes           TEXT,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at      TIMESTAMPTZ NOT NULL DEFAULT now() -- kein Trigger; wird manuell via SET updated_at = now() in UPDATE-Queries gesetzt
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS coaching_projects_brand_client_idx
+  ON coaching.projects (brand, client_id);
+
+-- 2) Neue Spalte in sessions
+ALTER TABLE coaching.sessions
+  ADD COLUMN IF NOT EXISTS project_id UUID REFERENCES coaching.projects(id);
+
+-- 3) Backfill: Projekte für bestehende Sessions mit client_id anlegen
+INSERT INTO coaching.projects (brand, client_id, customer_number)
+SELECT DISTINCT s.brand, s.client_id,
+  COALESCE(c.customer_number, s.client_id::text)
+FROM coaching.sessions s
+JOIN customers c ON c.id = s.client_id
+WHERE s.client_id IS NOT NULL
+ON CONFLICT (brand, client_id) DO NOTHING;
+
+-- 4) Bestehende Sessions mit project_id verknüpfen
+UPDATE coaching.sessions s
+SET project_id = p.id
+FROM coaching.projects p
+WHERE s.client_id = p.client_id
+  AND s.brand = p.brand
+  AND s.project_id IS NULL;

--- a/website/src/components/admin/coaching/ProjectDetail.svelte
+++ b/website/src/components/admin/coaching/ProjectDetail.svelte
@@ -1,0 +1,160 @@
+<script lang="ts">
+  import type { CoachingProject } from '../../../lib/coaching-project-db';
+  import type { Session } from '../../../lib/coaching-session-db';
+
+  let {
+    project: initialProject,
+    sessions: initialSessions,
+  }: { project: CoachingProject; sessions: Session[] } = $props();
+
+  let project = $state<CoachingProject>(initialProject);
+  let sessions = $state<Session[]>(initialSessions);
+
+  let kiContext = $state(project.kiContext ?? '');
+  let notes = $state(project.notes ?? '');
+  let displayAlias = $state(project.displayAlias ?? '');
+
+  let savingContext = $state(false);
+  let savingNotes = $state(false);
+  let msgContext = $state('');
+  let msgNotes = $state('');
+
+  async function saveContext() {
+    savingContext = true; msgContext = '';
+    const res = await fetch(`/api/admin/coaching/projects/${project.id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ kiContext, displayAlias }),
+    });
+    if (res.ok) {
+      const json = await res.json();
+      project = json.project;
+      msgContext = 'Gespeichert.';
+    } else {
+      msgContext = 'Fehler beim Speichern.';
+    }
+    savingContext = false;
+  }
+
+  async function saveNotes() {
+    savingNotes = true; msgNotes = '';
+    const res = await fetch(`/api/admin/coaching/projects/${project.id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ notes }),
+    });
+    if (res.ok) { msgNotes = 'Gespeichert.'; }
+    else { msgNotes = 'Fehler beim Speichern.'; }
+    savingNotes = false;
+  }
+
+  function fmtDate(d: Date | string | null | undefined) {
+    if (!d) return '—';
+    return new Date(d).toLocaleDateString('de-DE', { day: '2-digit', month: '2-digit', year: 'numeric' });
+  }
+
+  const STATUS_LABELS: Record<string, string> = {
+    active: 'Läuft', paused: 'Pause', completed: 'Abgeschlossen', abandoned: 'Abgebrochen',
+  };
+</script>
+
+<div class="detail">
+  <div class="header">
+    <div class="header-left">
+      <span class="kunden-nr">{project.customerNumber}</span>
+      <span class="session-count">{sessions.length} {sessions.length === 1 ? 'Session' : 'Sessions'}</span>
+    </div>
+    <a href="/admin/coaching/sessions/new" class="btn-primary">+ Neue Session</a>
+  </div>
+
+  <!-- KI-Kontext -->
+  <section class="card">
+    <h2 class="card-title">KI-Kontext <span class="hint">(wird an KI übergeben — nur anonym formulieren)</span></h2>
+    <div class="field">
+      <label class="label" for="display-alias">Interner Bezeichner (nur für Coach)</label>
+      <input id="display-alias" class="input" type="text" bind:value={displayAlias} placeholder="z.B. Firma Müller oder leer lassen" />
+    </div>
+    <div class="field">
+      <label class="label" for="ki-context">Dauerhafter Kontext für die KI</label>
+      <textarea id="ki-context" class="textarea" rows={5} bind:value={kiContext}
+        placeholder="z.B. Klient befindet sich in einer beruflichen Neuorientierung. Schwerpunkt: Entscheidungsfindung."
+      ></textarea>
+    </div>
+    {#if msgContext}<div class="msg">{msgContext}</div>{/if}
+    <button class="btn-save" onclick={saveContext} disabled={savingContext}>
+      {savingContext ? 'Speichere…' : 'KI-Kontext speichern'}
+    </button>
+  </section>
+
+  <!-- Coach-Notizen -->
+  <section class="card">
+    <h2 class="card-title">Coach-Notizen <span class="hint">(privat — nie an KI übergeben)</span></h2>
+    <div class="field">
+      <textarea class="textarea" rows={4} bind:value={notes}
+        placeholder="Interne Beobachtungen, Hintergrundinformationen, Erinnerungen…"
+      ></textarea>
+    </div>
+    {#if msgNotes}<div class="msg">{msgNotes}</div>{/if}
+    <button class="btn-save" onclick={saveNotes} disabled={savingNotes}>
+      {savingNotes ? 'Speichere…' : 'Notizen speichern'}
+    </button>
+  </section>
+
+  <!-- Sessions -->
+  <section class="card">
+    <h2 class="card-title">Sessions</h2>
+    {#if sessions.length === 0}
+      <p class="empty">Noch keine Sessions für dieses Projekt.</p>
+    {:else}
+      <table class="table">
+        <thead>
+          <tr>
+            <th>Titel</th>
+            <th>Datum</th>
+            <th>Status</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {#each sessions as s (s.id)}
+            <tr>
+              <td><a href={`/admin/coaching/sessions/${s.id}`}>{s.title}</a></td>
+              <td>{fmtDate(s.createdAt)}</td>
+              <td><span class="badge badge-{s.status}">{STATUS_LABELS[s.status] ?? s.status}</span></td>
+              <td><a href={`/admin/coaching/sessions/${s.id}`} class="btn-sm">Öffnen</a></td>
+            </tr>
+          {/each}
+        </tbody>
+      </table>
+    {/if}
+  </section>
+</div>
+
+<style>
+  .detail { max-width: 800px; margin: 0 auto; padding: 1rem 1.5rem 3rem; display: flex; flex-direction: column; gap: 1.5rem; }
+  .header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 0.5rem; }
+  .header-left { display: flex; align-items: center; gap: 1rem; }
+  .kunden-nr { font-family: monospace; font-size: 1.5rem; font-weight: 700; color: var(--gold,#c9a55c); }
+  .session-count { font-size: 0.85rem; color: var(--text-muted,#888); }
+  .btn-primary { padding: 0.5rem 1.2rem; background: var(--gold,#c9a55c); color: #111; font-weight: 700; border-radius: 6px; text-decoration: none; font-size: 0.85rem; }
+  .card { background: var(--bg-2,#1a1a1a); border: 1px solid var(--line,#333); border-radius: 8px; padding: 1.25rem; display: flex; flex-direction: column; gap: 0.75rem; }
+  .card-title { font-size: 1rem; font-weight: 700; color: var(--text-light,#f0f0f0); margin: 0; }
+  .hint { font-size: 0.75rem; color: var(--text-muted,#888); font-weight: 400; }
+  .field { display: flex; flex-direction: column; gap: 0.35rem; }
+  .label { font-size: 0.78rem; color: var(--text-muted,#888); }
+  .input, .textarea { background: var(--bg,#111); border: 1px solid var(--line,#333); border-radius: 6px; padding: 0.55rem 0.75rem; color: var(--text-light,#f0f0f0); font-size: 0.88rem; outline: none; width: 100%; box-sizing: border-box; }
+  .textarea { resize: vertical; font-family: inherit; }
+  .input:focus, .textarea:focus { border-color: var(--gold,#c9a55c); }
+  .btn-save { align-self: flex-start; padding: 0.45rem 1.1rem; background: var(--gold,#c9a55c); color: #111; font-weight: 700; border: none; border-radius: 6px; cursor: pointer; font-size: 0.85rem; }
+  .btn-save:disabled { opacity: 0.5; cursor: default; }
+  .msg { font-size: 0.82rem; color: var(--gold,#c9a55c); }
+  .table { width: 100%; border-collapse: collapse; }
+  .table th { text-align: left; padding: 0.4rem 0.6rem; font-size: 0.78rem; color: var(--text-muted,#888); border-bottom: 1px solid var(--line,#333); }
+  .table td { padding: 0.55rem 0.6rem; font-size: 0.88rem; border-bottom: 1px solid var(--line,#222); }
+  .table a { color: var(--gold,#c9a55c); text-decoration: none; }
+  .badge { font-size: 0.72rem; padding: 0.2rem 0.5rem; border-radius: 4px; font-weight: 600; }
+  .badge-active { color: #60a5fa; } .badge-paused { color: #f59e0b; }
+  .badge-completed { color: #4ade80; } .badge-abandoned { color: #94a3b8; }
+  .btn-sm { padding: 0.3rem 0.7rem; border: 1px solid var(--line,#444); border-radius: 4px; font-size: 0.82rem; color: var(--text-muted,#888); text-decoration: none; }
+  .empty { color: var(--text-muted,#888); font-size: 0.88rem; }
+</style>

--- a/website/src/components/admin/coaching/ProjectsOverview.svelte
+++ b/website/src/components/admin/coaching/ProjectsOverview.svelte
@@ -1,0 +1,106 @@
+<script lang="ts">
+  import type { CoachingProject, ListProjectsResult } from '../../../lib/coaching-project-db';
+
+  let { initialResult }: { initialResult: ListProjectsResult } = $props();
+
+  let projects = $state<CoachingProject[]>(initialResult.projects);
+  let total = $state(initialResult.total);
+  let page = $state(initialResult.page);
+  const pageSize = initialResult.pageSize;
+  let q = $state('');
+  let loading = $state(false);
+  let searchTimeout: ReturnType<typeof setTimeout> | null = null;
+
+  async function load(p = page) {
+    loading = true;
+    const params = new URLSearchParams({ q, page: String(p), pageSize: String(pageSize) });
+    const res = await fetch(`/api/admin/coaching/projects?${params}`);
+    const data: ListProjectsResult = await res.json();
+    projects = data.projects;
+    total = data.total;
+    page = data.page;
+    loading = false;
+  }
+
+  function onSearch() {
+    if (searchTimeout) clearTimeout(searchTimeout);
+    searchTimeout = setTimeout(() => load(1), 300);
+  }
+
+  function fmtDate(d: Date | string | null | undefined) {
+    if (!d) return '—';
+    return new Date(d).toLocaleDateString('de-DE', { day: '2-digit', month: '2-digit', year: 'numeric' });
+  }
+
+  const totalPages = $derived(Math.ceil(total / pageSize));
+</script>
+
+<div class="overview">
+  <div class="toolbar">
+    <input
+      class="search-input"
+      type="text"
+      placeholder="Kundennummer oder Bezeichnung suchen…"
+      bind:value={q}
+      oninput={onSearch}
+    />
+    <a href="/admin/coaching/sessions/new" class="btn-primary">+ Neue Session</a>
+  </div>
+
+  {#if loading}
+    <div class="loading">Laden…</div>
+  {:else if projects.length === 0}
+    <div class="empty">Keine Projekte gefunden.</div>
+  {:else}
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Kundennummer</th>
+          <th>Bezeichnung</th>
+          <th>Sessions</th>
+          <th>Letzter Kontakt</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+        {#each projects as p (p.id)}
+          <tr>
+            <td><span class="kunden-nr">{p.customerNumber}</span></td>
+            <td>{p.displayAlias ?? '—'}</td>
+            <td>{p.sessionCount ?? 0}</td>
+            <td>{fmtDate(p.lastSessionAt)}</td>
+            <td class="actions">
+              <a href={`/admin/coaching/projekte/${p.id}`} class="btn-sm">Öffnen</a>
+            </td>
+          </tr>
+        {/each}
+      </tbody>
+    </table>
+
+    {#if totalPages > 1}
+      <div class="pagination">
+        {#each Array.from({length: totalPages}, (_, i) => i + 1) as pg}
+          <button class="page-btn {pg === page ? 'active' : ''}" onclick={() => load(pg)}>{pg}</button>
+        {/each}
+      </div>
+    {/if}
+  {/if}
+</div>
+
+<style>
+  .overview { max-width: 900px; margin: 0 auto; padding: 1rem 1.5rem 3rem; }
+  .toolbar { display: flex; align-items: center; gap: 1rem; margin-bottom: 1rem; }
+  .search-input { flex: 1; padding: 0.5rem 0.75rem; background: var(--bg-2,#1a1a1a); border: 1px solid var(--line,#333); border-radius: 6px; color: var(--text-light,#f0f0f0); font-size: 0.9rem; outline: none; }
+  .search-input:focus { border-color: var(--gold,#c9a55c); }
+  .btn-primary { padding: 0.5rem 1.2rem; background: var(--gold,#c9a55c); color: #111; font-weight: 700; border-radius: 6px; text-decoration: none; font-size: 0.85rem; white-space: nowrap; }
+  .table { width: 100%; border-collapse: collapse; }
+  .table th { text-align: left; padding: 0.5rem 0.75rem; border-bottom: 1px solid var(--line,#333); font-size: 0.82rem; color: var(--text-muted,#888); }
+  .table td { padding: 0.6rem 0.75rem; border-bottom: 1px solid var(--line,#222); font-size: 0.9rem; }
+  .kunden-nr { font-family: monospace; color: var(--gold,#c9a55c); font-size: 0.88rem; }
+  .actions { display: flex; gap: 0.4rem; }
+  .btn-sm { padding: 0.3rem 0.7rem; border: 1px solid var(--line,#444); border-radius: 4px; font-size: 0.82rem; color: var(--text-muted,#888); text-decoration: none; background: none; cursor: pointer; }
+  .pagination { display: flex; gap: 0.4rem; margin-top: 1rem; justify-content: center; }
+  .page-btn { padding: 0.3rem 0.6rem; border: 1px solid var(--line,#444); border-radius: 4px; background: none; color: var(--text-muted,#888); cursor: pointer; font-size: 0.82rem; }
+  .page-btn.active { border-color: var(--gold,#c9a55c); color: var(--gold,#c9a55c); }
+  .loading, .empty { text-align: center; color: var(--text-muted,#888); padding: 2rem; }
+</style>

--- a/website/src/components/admin/coaching/SessionsOverview.svelte
+++ b/website/src/components/admin/coaching/SessionsOverview.svelte
@@ -163,7 +163,13 @@
         {#each sessions as s (s.id)}
           <tr class={s.archivedAt ? 'archived-row' : ''}>
             <td><a href={`/admin/coaching/sessions/${s.id}`}>{s.title}</a></td>
-            <td>{s.clientName ?? s.clientId ?? '—'}</td>
+            <td>
+              {#if s.clientName}
+                {s.clientName}{#if s.customerNumber} <span class="customer-number">({s.customerNumber})</span>{/if}
+              {:else}
+                —
+              {/if}
+            </td>
             <td>{fmtDate(s.createdAt)}</td>
             <td>
               {#if !s.archivedAt}
@@ -244,4 +250,5 @@
   .page-btn { padding: 0.3rem 0.6rem; border: 1px solid var(--line,#444); border-radius: 4px; background: none; color: var(--text-muted,#888); cursor: pointer; font-size: 0.82rem; }
   .page-btn.active { border-color: var(--gold,#c9a55c); color: var(--gold,#c9a55c); }
   .loading, .empty { text-align: center; color: var(--text-muted,#888); padding: 2rem; }
+  .customer-number { font-size: 0.75rem; color: var(--text-muted,#888); }
 </style>

--- a/website/src/layouts/AdminLayout.astro
+++ b/website/src/layouts/AdminLayout.astro
@@ -128,10 +128,12 @@ const navGroups: { label: string; items: NavItem[] }[] = [
   {
     label: 'Coaching',
     items: [
-      { href: '/admin/coaching/sessions',     label: 'Sessions',     icon: 'clipboard',
+      { href: '/admin/coaching/projekte',      label: 'Projekte',         icon: 'folder',
+        matches: ['/admin/coaching/projekte'] },
+      { href: '/admin/coaching/sessions',      label: 'Sessions',         icon: 'clipboard',
         matches: ['/admin/coaching/sessions'] },
-      { href: '/admin/coaching/sessions/new', label: 'Neue Session', icon: 'plus' },
-      { href: '/admin/coaching/settings',     label: 'KI-Einstellungen', icon: 'settings',
+      { href: '/admin/coaching/sessions/new',  label: 'Neue Session',     icon: 'plus' },
+      { href: '/admin/coaching/settings',      label: 'KI-Einstellungen', icon: 'settings',
         matches: ['/admin/coaching/settings'] },
     ],
   },

--- a/website/src/lib/coaching-project-db.test.ts
+++ b/website/src/lib/coaching-project-db.test.ts
@@ -1,0 +1,152 @@
+// website/src/lib/coaching-project-db.test.ts
+import { describe, it, expect, beforeAll } from 'vitest';
+import { newDb } from 'pg-mem';
+import type { Pool } from 'pg';
+import {
+  findOrCreateProject,
+  getProject,
+  listProjects,
+  updateProject,
+} from './coaching-project-db';
+
+let pool: Pool;
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+beforeAll(async () => {
+  const db = newDb();
+  db.public.registerFunction({
+    name: 'gen_random_uuid',
+    returns: 'uuid',
+    impure: true,
+    implementation: () =>
+      'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, c => {
+        const r = (Math.random() * 16) | 0;
+        return (c === 'x' ? r : (r & 0x3) | 0x8).toString(16);
+      }),
+  });
+  db.public.none(`
+    CREATE TABLE customers (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      name TEXT NOT NULL,
+      email TEXT,
+      customer_number TEXT
+    );
+    CREATE SCHEMA coaching;
+    CREATE TABLE coaching.projects (
+      id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      brand           TEXT NOT NULL,
+      client_id       UUID REFERENCES customers(id),
+      customer_number TEXT NOT NULL,
+      display_alias   TEXT,
+      ki_context      TEXT,
+      notes           TEXT,
+      created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+      updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+    );
+    CREATE UNIQUE INDEX coaching_projects_brand_client_idx
+      ON coaching.projects (brand, client_id);
+    CREATE TABLE coaching.sessions (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      brand TEXT NOT NULL DEFAULT 'mentolder',
+      client_id UUID,
+      project_id UUID REFERENCES coaching.projects(id),
+      title TEXT NOT NULL,
+      status TEXT NOT NULL DEFAULT 'active',
+      mode TEXT NOT NULL DEFAULT 'live',
+      created_by TEXT NOT NULL,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      archived_at TIMESTAMPTZ
+    );
+  `);
+  const { Pool: PgMemPool } = db.adapters.createPg();
+  pool = new PgMemPool() as unknown as Pool;
+});
+
+describe('findOrCreateProject', () => {
+  it('legt Projekt an wenn keins existiert', async () => {
+    const clientR = await pool.query(
+      `INSERT INTO customers (name, customer_number) VALUES ('Müller GmbH', 'K-0001') RETURNING id`,
+    );
+    const clientId = clientR.rows[0].id as string;
+    const p = await findOrCreateProject(pool, 'mentolder', clientId);
+    expect(p.id).toMatch(UUID_REGEX);
+    expect(p.customerNumber).toBe('K-0001');
+    expect(p.clientId).toBe(clientId);
+    expect(p.brand).toBe('mentolder');
+  });
+
+  it('gibt bestehendes Projekt zurück beim zweiten Aufruf', async () => {
+    const clientR = await pool.query(
+      `INSERT INTO customers (name, customer_number) VALUES ('Meier AG', 'K-0002') RETURNING id`,
+    );
+    const clientId = clientR.rows[0].id as string;
+    const p1 = await findOrCreateProject(pool, 'mentolder', clientId);
+    const p2 = await findOrCreateProject(pool, 'mentolder', clientId);
+    expect(p1.id).toBe(p2.id);
+  });
+
+  it('fällt auf client_id zurück wenn customer_number fehlt', async () => {
+    const clientR = await pool.query(
+      `INSERT INTO customers (name) VALUES ('Ohne Nummer') RETURNING id`,
+    );
+    const clientId = clientR.rows[0].id as string;
+    const p = await findOrCreateProject(pool, 'mentolder', clientId);
+    expect(p.customerNumber).toBe(clientId);
+  });
+});
+
+describe('getProject', () => {
+  it('gibt null zurück für unbekannte ID', async () => {
+    const r = await getProject(pool, '00000000-0000-4000-8000-000000000000');
+    expect(r).toBeNull();
+  });
+
+  it('gibt Projekt mit session_count zurück', async () => {
+    const clientR = await pool.query(
+      `INSERT INTO customers (name, customer_number) VALUES ('Schmidt', 'K-0010') RETURNING id`,
+    );
+    const clientId = clientR.rows[0].id as string;
+    const proj = await findOrCreateProject(pool, 'mentolder', clientId);
+    await pool.query(
+      `INSERT INTO coaching.sessions (brand, client_id, project_id, title, created_by)
+       VALUES ('mentolder', $1, $2, 'Session A', 'coach')`,
+      [clientId, proj.id],
+    );
+    const r = await getProject(pool, proj.id);
+    expect(r).not.toBeNull();
+    expect(r!.sessionCount).toBe(1);
+  });
+});
+
+describe('listProjects', () => {
+  it('gibt ListProjectsResult zurück', async () => {
+    const r = await listProjects(pool, 'mentolder');
+    expect(r).toHaveProperty('projects');
+    expect(r).toHaveProperty('total');
+    expect(r).toHaveProperty('page');
+    expect(r).toHaveProperty('pageSize');
+    expect(Array.isArray(r.projects)).toBe(true);
+  });
+});
+
+describe('updateProject', () => {
+  it('aktualisiert ki_context und notes', async () => {
+    const clientR = await pool.query(
+      `INSERT INTO customers (name, customer_number) VALUES ('Update-Test', 'K-0020') RETURNING id`,
+    );
+    const clientId = clientR.rows[0].id as string;
+    const proj = await findOrCreateProject(pool, 'mentolder', clientId);
+    const updated = await updateProject(pool, proj.id, {
+      kiContext: 'Klient K-0020 befindet sich in Phase 2.',
+      notes: 'Interne Notiz',
+    });
+    expect(updated?.kiContext).toBe('Klient K-0020 befindet sich in Phase 2.');
+    expect(updated?.notes).toBe('Interne Notiz');
+  });
+
+  it('gibt null zurück für unbekannte ID', async () => {
+    const r = await updateProject(pool, '00000000-0000-4000-8000-000000000000', { notes: 'x' });
+    expect(r).toBeNull();
+  });
+});

--- a/website/src/lib/coaching-project-db.test.ts
+++ b/website/src/lib/coaching-project-db.test.ts
@@ -128,6 +128,18 @@ describe('listProjects', () => {
     expect(r).toHaveProperty('pageSize');
     expect(Array.isArray(r.projects)).toBe(true);
   });
+
+  it('filtert nach Kundennummer via q', async () => {
+    // Kunden mit einzigartigen Kundennummern anlegen
+    const brand = 'test-search-brand';
+    const c1 = await pool.query(`INSERT INTO customers (name, customer_number) VALUES ('Such-A', 'SEARCH-001') RETURNING id`);
+    const c2 = await pool.query(`INSERT INTO customers (name, customer_number) VALUES ('Such-B', 'SEARCH-002') RETURNING id`);
+    await findOrCreateProject(pool, brand, c1.rows[0].id as string);
+    await findOrCreateProject(pool, brand, c2.rows[0].id as string);
+    const r = await listProjects(pool, brand, { q: 'SEARCH-001' });
+    expect(r.total).toBe(1);
+    expect(r.projects[0].customerNumber).toBe('SEARCH-001');
+  });
 });
 
 describe('updateProject', () => {

--- a/website/src/lib/coaching-project-db.ts
+++ b/website/src/lib/coaching-project-db.ts
@@ -100,8 +100,12 @@ export async function listProjects(
   let p = 2;
 
   if (opts.q) {
+    const hasSpecial = /[%_\\]/.test(opts.q);
     const pattern = `%${opts.q.replace(/[%_\\]/g, c => `\\${c}`)}%`;
-    whereParts.push(`(p.customer_number ILIKE $${p} ESCAPE '\\\\' OR p.display_alias ILIKE $${p} ESCAPE '\\\\')`);
+    const ilike = hasSpecial
+      ? `(p.customer_number ILIKE $${p} ESCAPE '\\\\' OR p.display_alias ILIKE $${p} ESCAPE '\\\\')`
+      : `(p.customer_number ILIKE $${p} OR p.display_alias ILIKE $${p})`;
+    whereParts.push(ilike);
     params.push(pattern);
     p++;
   }

--- a/website/src/lib/coaching-project-db.ts
+++ b/website/src/lib/coaching-project-db.ts
@@ -1,0 +1,155 @@
+// website/src/lib/coaching-project-db.ts
+import type { Pool } from 'pg';
+
+export interface CoachingProject {
+  id: string;
+  brand: string;
+  clientId: string | null;
+  customerNumber: string;
+  displayAlias: string | null;
+  kiContext: string | null;
+  notes: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+  sessionCount?: number;
+  lastSessionAt?: Date | null;
+}
+
+export interface ListProjectsOpts {
+  q?: string;
+  page?: number;
+  pageSize?: number;
+}
+
+export interface ListProjectsResult {
+  projects: CoachingProject[];
+  total: number;
+  page: number;
+  pageSize: number;
+}
+
+function rowToProject(row: Record<string, unknown>): CoachingProject {
+  return {
+    id: row.id as string,
+    brand: row.brand as string,
+    clientId: (row.client_id as string | null) ?? null,
+    customerNumber: row.customer_number as string,
+    displayAlias: (row.display_alias as string | null) ?? null,
+    kiContext: (row.ki_context as string | null) ?? null,
+    notes: (row.notes as string | null) ?? null,
+    createdAt: row.created_at as Date,
+    updatedAt: row.updated_at as Date,
+    sessionCount: row.session_count != null ? Number(row.session_count) : undefined,
+    lastSessionAt: (row.last_session_at as Date | null) ?? null,
+  };
+}
+
+export async function findOrCreateProject(
+  pool: Pool,
+  brand: string,
+  clientId: string,
+): Promise<CoachingProject> {
+  const existing = await pool.query(
+    `SELECT * FROM coaching.projects WHERE brand = $1 AND client_id = $2`,
+    [brand, clientId],
+  );
+  if (existing.rows[0]) return rowToProject(existing.rows[0]);
+
+  const customer = await pool.query(
+    `SELECT customer_number FROM customers WHERE id = $1`,
+    [clientId],
+  );
+  const customerNumber = (customer.rows[0]?.customer_number as string | null) ?? clientId;
+
+  const r = await pool.query(
+    `INSERT INTO coaching.projects (brand, client_id, customer_number)
+     VALUES ($1, $2, $3)
+     ON CONFLICT (brand, client_id) DO UPDATE SET updated_at = now()
+     RETURNING *`,
+    [brand, clientId, customerNumber],
+  );
+  return rowToProject(r.rows[0]);
+}
+
+export async function getProject(pool: Pool, id: string): Promise<CoachingProject | null> {
+  const r = await pool.query(
+    `SELECT p.id, p.brand, p.client_id, p.customer_number, p.display_alias,
+       p.ki_context, p.notes, p.created_at, p.updated_at,
+       COUNT(s.id)::int AS session_count,
+       MAX(s.created_at) AS last_session_at
+     FROM coaching.projects p
+     LEFT JOIN coaching.sessions s ON s.project_id = p.id
+     WHERE p.id = $1
+     GROUP BY p.id, p.brand, p.client_id, p.customer_number, p.display_alias,
+       p.ki_context, p.notes, p.created_at, p.updated_at`,
+    [id],
+  );
+  return r.rows[0] ? rowToProject(r.rows[0]) : null;
+}
+
+export async function listProjects(
+  pool: Pool,
+  brand: string,
+  opts: ListProjectsOpts = {},
+): Promise<ListProjectsResult> {
+  const page = Math.max(1, opts.page ?? 1);
+  const pageSize = Math.min(100, Math.max(1, opts.pageSize ?? 20));
+  const offset = (page - 1) * pageSize;
+  const params: unknown[] = [brand];
+  const whereParts = [`p.brand = $1`];
+  let p = 2;
+
+  if (opts.q) {
+    const pattern = `%${opts.q.replace(/[%_\\]/g, c => `\\${c}`)}%`;
+    whereParts.push(`(p.customer_number ILIKE $${p} ESCAPE '\\\\' OR p.display_alias ILIKE $${p} ESCAPE '\\\\')`);
+    params.push(pattern);
+    p++;
+  }
+
+  const where = whereParts.join(' AND ');
+
+  const countR = await pool.query(
+    `SELECT COUNT(*)::int AS total FROM coaching.projects p WHERE ${where}`,
+    params,
+  );
+  const total = Number(countR.rows[0]?.total ?? 0);
+
+  const dataParams = [...params, pageSize, offset];
+  const r = await pool.query(
+    `SELECT p.id, p.brand, p.client_id, p.customer_number, p.display_alias,
+       p.ki_context, p.notes, p.created_at, p.updated_at,
+       COUNT(s.id)::int AS session_count,
+       MAX(s.created_at) AS last_session_at
+     FROM coaching.projects p
+     LEFT JOIN coaching.sessions s ON s.project_id = p.id
+     WHERE ${where}
+     GROUP BY p.id, p.brand, p.client_id, p.customer_number, p.display_alias,
+       p.ki_context, p.notes, p.created_at, p.updated_at
+     ORDER BY MAX(s.created_at) DESC NULLS LAST, p.created_at DESC
+     LIMIT $${p} OFFSET $${p + 1}`,
+    dataParams,
+  );
+
+  return { projects: r.rows.map(rowToProject), total, page, pageSize };
+}
+
+export async function updateProject(
+  pool: Pool,
+  id: string,
+  fields: Partial<{ kiContext: string | null; notes: string | null; displayAlias: string | null }>,
+): Promise<CoachingProject | null> {
+  const sets: string[] = [`updated_at = now()`];
+  const vals: unknown[] = [];
+  let i = 1;
+
+  if ('kiContext' in fields) { sets.push(`ki_context = $${i++}`); vals.push(fields.kiContext); }
+  if ('notes' in fields)     { sets.push(`notes = $${i++}`);      vals.push(fields.notes); }
+  if ('displayAlias' in fields) { sets.push(`display_alias = $${i++}`); vals.push(fields.displayAlias); }
+
+  vals.push(id);
+  const r = await pool.query(
+    `UPDATE coaching.projects SET ${sets.join(', ')} WHERE id = $${i} RETURNING *`,
+    vals,
+  );
+  return r.rows[0] ? rowToProject(r.rows[0]) : null;
+}

--- a/website/src/lib/coaching-session-db.test.ts
+++ b/website/src/lib/coaching-session-db.test.ts
@@ -31,12 +31,31 @@ beforeAll(async () => {
       }),
   });
   db.public.none(`
+    CREATE TABLE customers (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      name TEXT NOT NULL,
+      customer_number TEXT
+    );
     CREATE SCHEMA coaching;
+    CREATE TABLE coaching.projects (
+      id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      brand           TEXT NOT NULL,
+      client_id       UUID REFERENCES customers(id),
+      customer_number TEXT NOT NULL,
+      display_alias   TEXT,
+      ki_context      TEXT,
+      notes           TEXT,
+      created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+      updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+    );
+    CREATE UNIQUE INDEX coaching_projects_brand_client_idx
+      ON coaching.projects (brand, client_id);
     CREATE TABLE coaching.sessions (
       id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
       brand TEXT NOT NULL DEFAULT 'mentolder',
       client_id UUID,
       client_name TEXT,
+      project_id UUID REFERENCES coaching.projects(id),
       ki_config_id INT,
       mode TEXT NOT NULL DEFAULT 'live',
       title TEXT NOT NULL,
@@ -255,5 +274,16 @@ describe('deleteSession', () => {
   it('gibt false zurück bei unbekannter id', async () => {
     const result = await deleteSession(pool, '00000000-0000-4000-8000-000000000099');
     expect(result).toBe(false);
+  });
+});
+
+describe('Session mit project_id', () => {
+  it('speichert und liest projectId + clientName', async () => {
+    const s = await createSession(pool, {
+      brand: 'mentolder', title: 'Projekt-Test', createdBy: 'coach',
+      mode: 'live', clientName: 'Müller, Max', projectId: null,
+    });
+    expect(s.clientName).toBe('Müller, Max');
+    expect(s.projectId).toBeNull();
   });
 });

--- a/website/src/lib/coaching-session-db.ts
+++ b/website/src/lib/coaching-session-db.ts
@@ -5,6 +5,8 @@ export interface Session {
   brand: string;
   clientId: string | null;
   clientName: string | null;
+  customerNumber: string | null;
+  projectId: string | null;
   kiConfigId: number | null;
   mode: 'live' | 'prep';
   title: string;
@@ -60,6 +62,8 @@ export interface SessionStep {
 export interface CreateSessionArgs {
   brand: string;
   clientId?: string | null;
+  clientName?: string | null;
+  projectId?: string | null;
   kiConfigId?: number | null;
   mode: 'live' | 'prep';
   title: string;
@@ -84,6 +88,8 @@ function rowToSession(row: Record<string, unknown>, steps: SessionStep[] = []): 
     brand: row.brand as string,
     clientId: (row.client_id as string | null) ?? null,
     clientName: (row.client_name as string | null) ?? null,
+    customerNumber: (row.project_customer_number as string | null) ?? null,
+    projectId: (row.project_id as string | null) ?? null,
     kiConfigId: (row.ki_config_id as number | null) ?? null,
     mode: row.mode as 'live' | 'prep',
     title: row.title as string,
@@ -114,10 +120,15 @@ function rowToStep(row: Record<string, unknown>): SessionStep {
 
 export async function createSession(pool: Pool, args: CreateSessionArgs): Promise<Session> {
   const r = await pool.query(
-    `INSERT INTO coaching.sessions (brand, client_id, ki_config_id, mode, title, created_by)
-     VALUES ($1, $2, $3, $4, $5, $6)
+    `INSERT INTO coaching.sessions
+       (brand, client_id, client_name, project_id, ki_config_id, mode, title, created_by)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
      RETURNING *`,
-    [args.brand, args.clientId ?? null, args.kiConfigId ?? null, args.mode, args.title, args.createdBy],
+    [
+      args.brand, args.clientId ?? null, args.clientName ?? null,
+      args.projectId ?? null, args.kiConfigId ?? null,
+      args.mode, args.title, args.createdBy,
+    ],
   );
   return rowToSession(r.rows[0]);
 }
@@ -186,8 +197,9 @@ export async function listSessions(
   const offsetIdx = p + 1;
 
   const r = await pool.query(
-    `SELECT s.*
+    `SELECT s.*, p.customer_number AS project_customer_number
      FROM coaching.sessions s
+     LEFT JOIN coaching.projects p ON p.id = s.project_id
      WHERE ${whereClause}
      ORDER BY ${sortCol} ${sortDir}
      LIMIT $${limitIdx} OFFSET $${offsetIdx}`,

--- a/website/src/pages/admin/coaching/projekte/[id].astro
+++ b/website/src/pages/admin/coaching/projekte/[id].astro
@@ -1,0 +1,34 @@
+---
+import AdminLayout from '../../../../layouts/AdminLayout.astro';
+import { getSession, getLoginUrl, isAdmin } from '../../../../lib/auth';
+import { getProject } from '../../../../lib/coaching-project-db';
+import { listSessions } from '../../../../lib/coaching-session-db';
+import { pool } from '../../../../lib/website-db';
+import ProjectDetail from '../../../../components/admin/coaching/ProjectDetail.svelte';
+
+const session = await getSession(Astro.request.headers.get('cookie'));
+if (!session) return Astro.redirect(getLoginUrl(Astro.url.pathname));
+if (!isAdmin(session)) return Astro.redirect('/admin');
+
+const { id } = Astro.params;
+const brand = process.env.BRAND || 'mentolder';
+
+const project = id ? await getProject(pool, id) : null;
+if (!project) return Astro.redirect('/admin/coaching/projekte');
+
+const sessionsResult = await listSessions(pool, brand, { pageSize: 100 });
+const sessions = sessionsResult.sessions.filter(s => s.projectId === id);
+---
+
+<AdminLayout title={`Projekt ${project.customerNumber}`}>
+  <div style="padding: 1rem 0;">
+    <nav style="font-size:0.78rem;color:var(--text-muted,#888);margin-bottom:0.4rem;padding:0 1.5rem;">
+      <a href="/admin" style="color:var(--text-muted,#888);text-decoration:none;">Admin</a>
+      <span style="margin:0 0.4rem;">›</span>
+      <a href="/admin/coaching/projekte" style="color:var(--text-muted,#888);text-decoration:none;">Projekte</a>
+      <span style="margin:0 0.4rem;">›</span>
+      {project.customerNumber}
+    </nav>
+    <ProjectDetail client:load {project} {sessions} />
+  </div>
+</AdminLayout>

--- a/website/src/pages/admin/coaching/projekte/index.astro
+++ b/website/src/pages/admin/coaching/projekte/index.astro
@@ -1,0 +1,29 @@
+---
+import AdminLayout from '../../../../layouts/AdminLayout.astro';
+import { getSession, getLoginUrl, isAdmin } from '../../../../lib/auth';
+import { listProjects } from '../../../../lib/coaching-project-db';
+import { pool } from '../../../../lib/website-db';
+import ProjectsOverview from '../../../../components/admin/coaching/ProjectsOverview.svelte';
+
+const session = await getSession(Astro.request.headers.get('cookie'));
+if (!session) return Astro.redirect(getLoginUrl(Astro.url.pathname));
+if (!isAdmin(session)) return Astro.redirect('/admin');
+
+const brand = process.env.BRAND || 'mentolder';
+let initialResult = { projects: [], total: 0, page: 1, pageSize: 20 };
+try {
+  initialResult = await listProjects(pool, brand, { page: 1, pageSize: 20 });
+} catch { /* coaching schema existiert noch nicht */ }
+---
+
+<AdminLayout title="Coaching-Projekte">
+  <div style="padding: 1rem 0;">
+    <nav style="font-size:0.78rem;color:var(--text-muted,#888);margin-bottom:0.4rem;padding:0 1.5rem;">
+      <a href="/admin" style="color:var(--text-muted,#888);text-decoration:none;">Admin</a>
+      <span style="margin:0 0.4rem;">›</span>
+      Projekte
+    </nav>
+    <h1 style="font-size:1.8rem;font-weight:700;color:var(--text-light,#f0f0f0);margin:0 0 1.5rem;padding:0 1.5rem;">Coaching-Projekte</h1>
+    <ProjectsOverview client:load {initialResult} />
+  </div>
+</AdminLayout>

--- a/website/src/pages/api/admin/coaching/projects/[id].ts
+++ b/website/src/pages/api/admin/coaching/projects/[id].ts
@@ -1,0 +1,42 @@
+import type { APIRoute } from 'astro';
+import { getSession, isAdmin } from '../../../../../lib/auth';
+import { getProject, updateProject } from '../../../../../lib/coaching-project-db';
+import { listSessions } from '../../../../../lib/coaching-session-db';
+import { pool } from '../../../../../lib/website-db';
+
+export const prerender = false;
+
+export const GET: APIRoute = async ({ request, params }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) return new Response('Unauthorized', { status: 401 });
+
+  const id = params.id as string;
+  const brand = process.env.BRAND || 'mentolder';
+  const project = await getProject(pool, id);
+  if (!project) return new Response(JSON.stringify({ error: 'not found' }), { status: 404, headers: { 'content-type': 'application/json' } });
+
+  const sessionsResult = await listSessions(pool, brand, { pageSize: 100 });
+  const sessions = sessionsResult.sessions.filter(s => s.projectId === id);
+
+  return new Response(JSON.stringify({ project, sessions }), { headers: { 'content-type': 'application/json' } });
+};
+
+export const PATCH: APIRoute = async ({ request, params }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) return new Response('Unauthorized', { status: 401 });
+
+  const id = params.id as string;
+  let body: { kiContext?: string | null; notes?: string | null; displayAlias?: string | null };
+  try { body = await request.json(); } catch {
+    return new Response(JSON.stringify({ error: 'Invalid JSON' }), { status: 400, headers: { 'content-type': 'application/json' } });
+  }
+
+  const updated = await updateProject(pool, id, {
+    ...(body.kiContext !== undefined ? { kiContext: body.kiContext } : {}),
+    ...(body.notes !== undefined ? { notes: body.notes } : {}),
+    ...(body.displayAlias !== undefined ? { displayAlias: body.displayAlias } : {}),
+  });
+  if (!updated) return new Response(JSON.stringify({ error: 'not found' }), { status: 404, headers: { 'content-type': 'application/json' } });
+
+  return new Response(JSON.stringify({ project: updated }), { headers: { 'content-type': 'application/json' } });
+};

--- a/website/src/pages/api/admin/coaching/projects/index.ts
+++ b/website/src/pages/api/admin/coaching/projects/index.ts
@@ -1,0 +1,19 @@
+import type { APIRoute } from 'astro';
+import { getSession, isAdmin } from '../../../../../lib/auth';
+import { listProjects } from '../../../../../lib/coaching-project-db';
+import { pool } from '../../../../../lib/website-db';
+
+export const prerender = false;
+
+export const GET: APIRoute = async ({ request, url }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) return new Response('Unauthorized', { status: 401 });
+
+  const brand = process.env.BRAND || 'mentolder';
+  const q = url.searchParams.get('q') ?? undefined;
+  const page = parseInt(url.searchParams.get('page') ?? '1', 10);
+  const pageSize = parseInt(url.searchParams.get('pageSize') ?? '20', 10);
+
+  const result = await listProjects(pool, brand, { q, page, pageSize });
+  return new Response(JSON.stringify(result), { headers: { 'content-type': 'application/json' } });
+};

--- a/website/src/pages/api/admin/coaching/sessions/[id]/steps/[n]/generate.ts
+++ b/website/src/pages/api/admin/coaching/sessions/[id]/steps/[n]/generate.ts
@@ -5,6 +5,7 @@ import { getSession as getCoachingSession, upsertStep, appendAuditLog } from '..
 import { getActiveProvider, getKiProviderById } from '../../../../../../../../lib/coaching-ki-config-db';
 import { getStepTemplate, buildPromptFromTemplate } from '../../../../../../../../lib/coaching-templates-db';
 import { getStepDef, buildUserPrompt } from '../../../../../../../../lib/coaching-session-prompts';
+import { getProject } from '../../../../../../../../lib/coaching-project-db';
 import { pool } from '../../../../../../../../lib/website-db';
 
 export const prerender = false;
@@ -28,6 +29,18 @@ export const POST: APIRoute = async ({ request, params }) => {
 
   // Session-spezifischen KI-Provider laden oder auf aktiven zurückfallen
   const coachingSession = await getCoachingSession(pool, sessionId);
+
+  // Projekt-Kontext und Anonymisierung
+  let customerNumber: string | null = null;
+  let projectKiContext: string | null = null;
+  if (coachingSession?.projectId) {
+    try {
+      const project = await getProject(pool, coachingSession.projectId);
+      customerNumber = project?.customerNumber ?? null;
+      projectKiContext = project?.kiContext ?? null;
+    } catch { /* Projekt-Fehler blockieren keine KI-Anfrage */ }
+  }
+
   const activeProvider = coachingSession?.kiConfigId
     ? (await getKiProviderById(pool, coachingSession.kiConfigId)) ?? await getActiveProvider(pool, brand)
     : await getActiveProvider(pool, brand);
@@ -56,7 +69,17 @@ export const POST: APIRoute = async ({ request, params }) => {
   let aiResponse: string;
 
   // System-Prompt aus KI-Profil überschreibt Template-Prompt, wenn gesetzt
-  const effectiveSystem = activeProvider?.systemPrompt || systemPrompt;
+  let effectiveSystem = activeProvider?.systemPrompt || systemPrompt;
+  if (customerNumber) {
+    effectiveSystem = effectiveSystem.replace(/\{\{KLIENT_ID\}\}/g, customerNumber);
+  }
+  if (projectKiContext) {
+    effectiveSystem = `${projectKiContext}\n\n${effectiveSystem}`;
+  }
+
+  const anonymizedUserPrompt = customerNumber
+    ? `Klient ${customerNumber}:\n${userPrompt}`
+    : userPrompt;
 
   try {
     if (providerName === 'claude') {
@@ -73,7 +96,7 @@ export const POST: APIRoute = async ({ request, params }) => {
         temperature: activeProvider?.temperature ?? undefined,
         top_p: activeProvider?.topP ?? undefined,
         top_k: activeProvider?.topK ?? undefined,
-        messages: [{ role: 'user', content: userPrompt }],
+        messages: [{ role: 'user', content: anonymizedUserPrompt }],
       } as Parameters<typeof client.messages.create>[0]);
       aiResponse = msg.content.filter((b): b is Anthropic.TextBlock => b.type === 'text').map(b => b.text).join('');
     } else if (providerName === 'openai') {
@@ -92,7 +115,7 @@ export const POST: APIRoute = async ({ request, params }) => {
         top_p: activeProvider?.topP ?? undefined,
         presence_penalty: activeProvider?.presencePenalty ?? undefined,
         frequency_penalty: activeProvider?.frequencyPenalty ?? undefined,
-        messages: [{ role: 'system', content: effectiveSystem }, { role: 'user', content: userPrompt }],
+        messages: [{ role: 'system', content: effectiveSystem }, { role: 'user', content: anonymizedUserPrompt }],
       });
       aiResponse = resp.choices[0]?.message.content ?? '';
     } else if (providerName === 'mistral') {
@@ -110,7 +133,7 @@ export const POST: APIRoute = async ({ request, params }) => {
         topP: activeProvider?.topP ?? undefined,
         randomSeed: activeProvider?.randomSeed ?? undefined,
         safePrompt: activeProvider?.safePrompt ?? false,
-        messages: [{ role: 'system', content: effectiveSystem }, { role: 'user', content: userPrompt }],
+        messages: [{ role: 'system', content: effectiveSystem }, { role: 'user', content: anonymizedUserPrompt }],
       });
       aiResponse = (resp.choices?.[0]?.message.content as string) ?? '';
     } else if (providerName === 'lumo') {
@@ -127,13 +150,13 @@ export const POST: APIRoute = async ({ request, params }) => {
 
   const step = await upsertStep(pool, {
     sessionId, stepNumber, stepName, phase,
-    coachInputs: body.coachInputs, aiPrompt: userPrompt, aiResponse, status: 'generated',
+    coachInputs: body.coachInputs, aiPrompt: anonymizedUserPrompt, aiResponse, status: 'generated',
   });
 
   await appendAuditLog(pool, {
     sessionId, eventType: 'ai_request', actor: session.preferred_username,
     stepNumber,
-    payload: { provider: providerName, model: activeProvider?.modelName ?? '?', prompt: userPrompt, response: aiResponse, duration_ms: durationMs },
+    payload: { provider: providerName, model: activeProvider?.modelName ?? '?', prompt: anonymizedUserPrompt, response: aiResponse, duration_ms: durationMs },
   });
 
   return new Response(JSON.stringify({ step }), { headers: { 'content-type': 'application/json' } });

--- a/website/src/pages/api/admin/coaching/sessions/index.ts
+++ b/website/src/pages/api/admin/coaching/sessions/index.ts
@@ -1,6 +1,7 @@
 import type { APIRoute } from 'astro';
 import { getSession, isAdmin } from '../../../../../lib/auth';
 import { createSession, listSessions } from '../../../../../lib/coaching-session-db';
+import { findOrCreateProject } from '../../../../../lib/coaching-project-db';
 import { pool } from '../../../../../lib/website-db';
 
 export const prerender = false;
@@ -34,9 +35,29 @@ export const POST: APIRoute = async ({ request }) => {
   if (!body.title?.trim()) {
     return new Response(JSON.stringify({ error: 'title required' }), { status: 400, headers: { 'content-type': 'application/json' } });
   }
+
+  // Klientenname nachschlagen
+  let clientName: string | null = body.clientName ?? null;
+  if (body.clientId && !clientName) {
+    try {
+      const cr = await pool.query(`SELECT name FROM customers WHERE id = $1`, [body.clientId]);
+      clientName = (cr.rows[0]?.name as string | null) ?? null;
+    } catch { /* ignore */ }
+  }
+
+  // Projekt auto-anlegen oder finden
+  let projectId: string | null = null;
+  if (body.clientId) {
+    try {
+      const project = await findOrCreateProject(pool, brand, body.clientId);
+      projectId = project.id;
+    } catch { /* projekt-fehler blockieren keine Session */ }
+  }
+
   const created = await createSession(pool, {
     brand, title: body.title, createdBy: session.preferred_username,
-    clientId: body.clientId ?? null, kiConfigId: body.kiConfigId ?? null, mode: body.mode ?? 'live',
+    clientId: body.clientId ?? null, clientName, projectId,
+    kiConfigId: body.kiConfigId ?? null, mode: body.mode ?? 'live',
   });
   return new Response(JSON.stringify({ session: created }), { status: 201, headers: { 'content-type': 'application/json' } });
 };


### PR DESCRIPTION
## Summary

- Neue Tabelle `coaching.projects` (1:1 pro Klient+Brand) mit `customer_number` als anonymisierter KI-Kennung
- `coaching.sessions` bekommt `project_id`-FK; Session-POST legt Projekt automatisch an
- `generate.ts` injiziert `ki_context` + Kundennummer in KI-Prompts (kein Klarnamen an KI)
- Neue Admin-Seiten `/admin/coaching/projekte/` (Liste + Detailseite mit Coach-Notizen)
- AdminLayout: "Projekte"-Eintrag in Coaching-Nav

## Test plan

- [x] 26 Unit-Tests grün (coaching-project-db + coaching-session-db)
- [x] TypeScript-Check: keine Fehler in Coaching-Dateien
- [x] task test:unit — alle BATS-Tests grün
- [x] task test:manifests — alle Manifest-Tests grün
- [x] DB-Migration auf mentolder + korczewski angewendet (CREATE TABLE, CREATE INDEX, ALTER TABLE OK)

Closes T000429

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>