### PR TITLE
feat(brett): singleplayer AI bots fill empty Mayhem slots up to 4 [T000435]

### DIFF
--- a/brett/public/assets/combat/weapons.js
+++ b/brett/public/assets/combat/weapons.js
@@ -1,0 +1,9 @@
+export const WEAPONS = Object.freeze({
+  handgun:  { type: 'ranged', dmg: 25, range: Infinity, cooldownMs: 250,  mag: 12, reloadMs: 1100, slot: 'ranged' },
+  rifle:    { type: 'ranged', dmg: 35, range: Infinity, cooldownMs: 600,  mag: 5,  reloadMs: 1500, slot: 'ranged', pickupOnly: true },
+  fireball: { type: 'ranged', dmg: 70, range: 30,       cooldownMs: 1500, mag: 3,  reloadMs: 0,    slot: 'ranged', pickupOnly: true, burn: { dps: 5, durMs: 3000 } },
+  club:     { type: 'melee',  dmg: 50, range: 2.5,      cooldownMs: 700,  slot: 'melee', knockback: 8 },
+  katana:   { type: 'melee',  dmg: 60, range: 3.0,      cooldownMs: 500,  slot: 'melee', sweepArcDeg: 90 },
+});
+
+export const STARTER_LOADOUT = { melee: 'club', ranged: 'handgun' };

--- a/brett/public/assets/combat/weapons.js
+++ b/brett/public/assets/combat/weapons.js
@@ -1,9 +1,0 @@
-export const WEAPONS = Object.freeze({
-  handgun:  { type: 'ranged', dmg: 25, range: Infinity, cooldownMs: 250,  mag: 12, reloadMs: 1100, slot: 'ranged' },
-  rifle:    { type: 'ranged', dmg: 35, range: Infinity, cooldownMs: 600,  mag: 5,  reloadMs: 1500, slot: 'ranged', pickupOnly: true },
-  fireball: { type: 'ranged', dmg: 70, range: 30,       cooldownMs: 1500, mag: 3,  reloadMs: 0,    slot: 'ranged', pickupOnly: true, burn: { dps: 5, durMs: 3000 } },
-  club:     { type: 'melee',  dmg: 50, range: 2.5,      cooldownMs: 700,  slot: 'melee', knockback: 8 },
-  katana:   { type: 'melee',  dmg: 60, range: 3.0,      cooldownMs: 500,  slot: 'melee', sweepArcDeg: 90 },
-});
-
-export const STARTER_LOADOUT = { melee: 'club', ranged: 'handgun' };

--- a/brett/public/assets/mayhem/ai-bot.js
+++ b/brett/public/assets/mayhem/ai-bot.js
@@ -1,0 +1,187 @@
+'use strict';
+// Simple AI bot for singleplayer Mayhem mode.
+// The bot lives in remoteAvatars so projectile/vehicle/flail collisions work for free.
+// Instead of being driven by setNetState() from the network, its own AI brain
+// writes netTarget directly each tick.
+
+const BOT_SPEED         = 2.2;    // m/s — slightly slower than the player walk speed
+const BOT_CHASE_RANGE   = 14;     // m — start chasing when target is within this distance
+const BOT_MELEE_RANGE   = 2.0;    // m — switch to flailing when this close
+const BOT_SHOOT_RANGE   = 12;     // m — fire weapon when target is within this distance
+const BOT_SHOOT_RATE    = 1.8;    // seconds between shots (slower than max weapon rate)
+const BOT_WANDER_SECS   = [2, 4]; // random wander-target hold time range
+const ARENA_HALF        = 8.5;    // clamp bots within the playable area
+const DEATHMATCH_RESPAWN_S = 4;
+
+const BOT_COLORS = ['#e74c3c', '#3498db', '#2ecc71', '#f1c40f'];
+
+class MayhemAIBot {
+  // callbacks: { onFire(weaponDef, originPos, dirVec, shooterId),
+  //              onDeath(botId, killerId),
+  //              getGameMode() }
+  constructor({ id, mannequin, colorIndex = 0, callbacks }) {
+    this.id     = id;
+    this.avatar = new window.MayhemPlayerAvatar({
+      id, mannequin, local: false, color: BOT_COLORS[colorIndex % BOT_COLORS.length],
+    });
+
+    this._x = mannequin.root.position.x;
+    this._z = mannequin.root.position.z;
+    this._facingY    = Math.random() * Math.PI * 2;
+    this._aiState    = 'wander';
+    this._wanderDx   = 0;
+    this._wanderDz   = 1;
+    this._wanderTtl  = 0;
+    this._shootTimer = Math.random() * BOT_SHOOT_RATE; // stagger initial shots
+
+    this._onFire    = callbacks.onFire;
+    this._onDeath   = callbacks.onDeath;
+    this._getMode   = callbacks.getGameMode;
+  }
+
+  // allAvatars — Map<id, PlayerAvatar> of every other combatant (incl. local player)
+  tick(dt, allAvatars) {
+    if (this._aiState === 'dead') return;
+
+    const target = this._findNearest(allAvatars);
+    const dist   = target ? this._dist(target) : Infinity;
+
+    // State transitions
+    if (dist <= BOT_MELEE_RANGE) {
+      this._aiState = 'melee';
+    } else if (dist <= BOT_CHASE_RANGE) {
+      this._aiState = 'chase';
+    } else {
+      this._aiState = 'wander';
+    }
+
+    let moveX = 0, moveZ = 0;
+
+    if (this._aiState === 'chase' || this._aiState === 'melee') {
+      const tx = target.mannequin.root.position.x - this._x;
+      const tz = target.mannequin.root.position.z - this._z;
+      const m  = Math.hypot(tx, tz) || 1;
+      moveX = tx / m;
+      moveZ = tz / m;
+      this._facingY = Math.atan2(moveX, moveZ);
+    } else {
+      this._wanderTtl -= dt;
+      if (this._wanderTtl <= 0) {
+        const angle = Math.random() * Math.PI * 2;
+        this._wanderDx  = Math.sin(angle);
+        this._wanderDz  = Math.cos(angle);
+        this._wanderTtl = BOT_WANDER_SECS[0] + Math.random() * (BOT_WANDER_SECS[1] - BOT_WANDER_SECS[0]);
+        this._facingY   = angle;
+      }
+      moveX = this._wanderDx;
+      moveZ = this._wanderDz;
+    }
+
+    // Move and clamp
+    this._x = Math.max(-ARENA_HALF, Math.min(ARENA_HALF, this._x + moveX * BOT_SPEED * dt));
+    this._z = Math.max(-ARENA_HALF, Math.min(ARENA_HALF, this._z + moveZ * BOT_SPEED * dt));
+
+    // Drive the avatar via the same setNetState path real network messages use
+    const moving = moveX !== 0 || moveZ !== 0;
+    // Set netTarget so the outer mayhem.js remoteAvatars loop handles interpolation
+    this.avatar.setNetState({
+      x: this._x, y: 0, z: this._z,
+      yaw: this._facingY,
+      anim: moving ? 'running' : 'idle',
+      flailing: this._aiState === 'melee',
+    });
+
+    // Shooting
+    if (target && dist <= BOT_SHOOT_RANGE && this._aiState !== 'melee') {
+      this._shootTimer -= dt;
+      if (this._shootTimer <= 0) {
+        this._shoot(target);
+        this._shootTimer = BOT_SHOOT_RATE;
+      }
+    }
+  }
+
+  // Called by mayhem.js when this bot is the victim of a hit.
+  processHit(weaponKey, impulse, shooterId, weaponSystem) {
+    if (this.avatar.isDead) return;
+
+    const weaponDef = weaponSystem ? weaponSystem.getWeaponDef(weaponKey) : null;
+    const damage = weaponDef ? weaponDef.damage
+                 : weaponKey === 'vehicle' ? 30 : 15;
+
+    this.avatar.applyDamage(damage);
+    this.avatar.applyHit(impulse, weaponKey || 'flail');
+
+    if (this.avatar.isDead) {
+      this._aiState = 'dead';
+      this._onDeath(this.id, shooterId);
+
+      const mode = this._getMode ? this._getMode() : 'warmup';
+      if (mode === 'deathmatch') {
+        setTimeout(() => this._respawn(), DEATHMATCH_RESPAWN_S * 1000);
+      }
+    }
+  }
+
+  _respawn() {
+    const pos = MayhemAIBot.randomEdgeSpawn();
+    this._x = pos.x;
+    this._z = pos.z;
+    this.avatar.mannequin.root.position.set(pos.x, 0, pos.z);
+    this.avatar.resetHp();
+    this.avatar.state = window.MayhemPlayerAvatar.STATE.IDLE;
+    this._aiState = 'wander';
+    this._shootTimer = Math.random() * BOT_SHOOT_RATE;
+  }
+
+  _findNearest(allAvatars) {
+    let best = null, bestDist = Infinity;
+    for (const [id, av] of allAvatars) {
+      if (id === this.id || av.isDead) continue;
+      const d = this._dist(av);
+      if (d < bestDist) { best = av; bestDist = d; }
+    }
+    return best;
+  }
+
+  _dist(avatar) {
+    const dx = avatar.mannequin.root.position.x - this._x;
+    const dz = avatar.mannequin.root.position.z - this._z;
+    return Math.hypot(dx, dz);
+  }
+
+  _shoot(target) {
+    const dx = target.mannequin.root.position.x - this._x;
+    const dz = target.mannequin.root.position.z - this._z;
+    const m  = Math.hypot(dx, dz) || 1;
+    // Imperfect aim — bots aren't pixel-precise
+    const spread = 0.12;
+    const dir = {
+      x: dx / m + (Math.random() - 0.5) * spread,
+      y: 0.05,
+      z: dz / m + (Math.random() - 0.5) * spread,
+    };
+    const dlen = Math.hypot(dir.x, dir.y, dir.z) || 1;
+    dir.x /= dlen; dir.y /= dlen; dir.z /= dlen;
+
+    const handgunDef = window.MayhemWeapons ? window.MayhemWeapons.WEAPONS.handgun : { key: 'handgun', damage: 25, projectileSpeed: 18, projectileType: 'bullet' };
+    this._onFire(handgunDef, { x: this._x, y: 1.2, z: this._z }, dir, this.id);
+  }
+
+  remove(scene) {
+    this.avatar.remove(scene);
+  }
+
+  static randomEdgeSpawn() {
+    const edge = Math.floor(Math.random() * 4);
+    const r = 4;
+    if (edge === 0) return { x: -r, z: (Math.random() - 0.5) * 2 * r };
+    if (edge === 1) return { x:  r, z: (Math.random() - 0.5) * 2 * r };
+    if (edge === 2) return { x: (Math.random() - 0.5) * 2 * r, z: -r };
+    return { x: (Math.random() - 0.5) * 2 * r, z: r };
+  }
+}
+
+MayhemAIBot.COLORS = BOT_COLORS;
+
+if (typeof window !== 'undefined') window.MayhemAIBot = MayhemAIBot;

--- a/brett/public/assets/mayhem/mayhem.js
+++ b/brett/public/assets/mayhem/mayhem.js
@@ -5,10 +5,13 @@ const Mayhem = (() => {
   const VEHICLE_COOLDOWN_MS = 5000;
   const MODES_CYCLE = ['warmup', 'deathmatch', 'lms'];
 
+  const MAX_PLAYERS = 4;
+
   let scene, camera, canvas, makeMannequin, send, room;
   let enabled = false;
   let localAvatar = null;
   const remoteAvatars = new Map();
+  const aiBots = new Map();         // botId → MayhemAIBot (subset of remoteAvatars)
   const vehicles = new Map();
   let chaseCam    = null;
   let banner      = null;
@@ -134,6 +137,36 @@ const Mayhem = (() => {
     localAvatar = new window.MayhemPlayerAvatar({ id: playerId, mannequin, local: true, color });
     chaseCam.attach(localAvatar.mannequin.root);
     send({ type: 'player_join', playerId, color });
+
+    // Fill remaining slots with AI bots so there are always MAX_PLAYERS combatants
+    const humanCount = remoteAvatars.size + 1; // +1 for local player
+    for (let i = humanCount; i < MAX_PLAYERS; i++) spawnAIBot(i - humanCount);
+  }
+
+  // ── AI Bots ───────────────────────────────────────────────────────────────
+  function spawnAIBot(colorIndex) {
+    if (!window.MayhemAIBot) return; // guard: ai-bot.js not loaded
+    const botId = 'bot-' + crypto.randomUUID();
+    const pos = randomEdgeSpawn();
+    const botMannequin = makeMannequin(botId, pos);
+    const bot = new window.MayhemAIBot({
+      id: botId,
+      mannequin: botMannequin,
+      colorIndex,
+      callbacks: {
+        onFire: (weaponDef, originPos, dirVec, shooterId) => {
+          if (projectileMgr) projectileMgr.spawn(weaponDef, originPos, dirVec, shooterId);
+        },
+        onDeath: (id, killerId) => {
+          gameMode?.handleDeath(id, false);
+          if (killerId && killerId !== id) gameMode?.handleKill(killerId);
+          updateHud();
+        },
+        getGameMode: () => gameMode?.mode || 'warmup',
+      },
+    });
+    aiBots.set(botId, bot);
+    remoteAvatars.set(botId, bot.avatar);
   }
 
   function stop() {
@@ -144,6 +177,8 @@ const Mayhem = (() => {
       localAvatar.remove(scene);
       localAvatar = null;
     }
+    for (const bot of aiBots.values()) { bot.remove(scene); remoteAvatars.delete(bot.id); }
+    aiBots.clear();
     for (const a of remoteAvatars.values()) a.remove(scene);
     remoteAvatars.clear();
     for (const v of vehicles.values()) v.remove(scene);
@@ -193,6 +228,11 @@ const Mayhem = (() => {
     if (victimId === playerId && localAvatar) {
       processLocalHit(weaponKey, impulse, shooterId);
     } else {
+      const bot = aiBots.get(victimId);
+      if (bot) {
+        bot.processHit(weaponKey, impulse, shooterId, weaponSystem);
+        return;
+      }
       const a = remoteAvatars.get(victimId);
       if (a) a.applyHit(impulse, weaponKey || 'flail');
     }
@@ -282,6 +322,13 @@ const Mayhem = (() => {
       weaponSystem?.tick();
     }
 
+    // Tick AI bots — they drive their own avatars (already in remoteAvatars)
+    if (aiBots.size > 0) {
+      const allCombatants = new Map(remoteAvatars);
+      if (localAvatar) allCombatants.set(playerId, localAvatar);
+      for (const bot of aiBots.values()) bot.tick(dt, allCombatants);
+    }
+
     for (const a of remoteAvatars.values()) a.update(dt, 0);
     for (const v of vehicles.values()) {
       v.update(dt);
@@ -348,9 +395,17 @@ const Mayhem = (() => {
       case 'player_join':
         if (msg.playerId === playerId) return;
         if (remoteAvatars.has(msg.playerId)) return;
-        const m = makeMannequin(msg.playerId, { x: 0, z: 0 });
-        remoteAvatars.set(msg.playerId,
-          new window.MayhemPlayerAvatar({ id: msg.playerId, mannequin: m, local: false, color: msg.color || '#888' }));
+        // Retire one bot to make room for the real player
+        if (aiBots.size > 0) {
+          const [firstBotId] = aiBots.keys();
+          const firstBot = aiBots.get(firstBotId);
+          aiBots.delete(firstBotId);
+          remoteAvatars.delete(firstBotId);
+          firstBot.remove(scene);
+        }
+        { const m = makeMannequin(msg.playerId, { x: 0, z: 0 });
+          remoteAvatars.set(msg.playerId,
+            new window.MayhemPlayerAvatar({ id: msg.playerId, mannequin: m, local: false, color: msg.color || '#888' })); }
         break;
 
       case 'player_state':

--- a/brett/public/assets/mayhem/weapons.js
+++ b/brett/public/assets/mayhem/weapons.js
@@ -1,0 +1,143 @@
+'use strict';
+// Weapons registry — pure data + timing logic, no Three.js dependency.
+// Projectile creation and effects live in projectiles.js / effects.js.
+
+const WEAPONS = {
+  handgun: {
+    key:        'handgun',
+    label:      'Handgun',
+    damage:     25,
+    cooldownMs: 600,
+    spread:     0.04,
+    projectileSpeed: 18,
+    projectileType: 'bullet',
+  },
+  rifle: {
+    key:        'rifle',
+    label:      'Burst Rifle',
+    damage:     18,
+    cooldownMs: 900,
+    burstCount: 3,
+    burstIntervalMs: 80,
+    spread:     0.07,
+    projectileSpeed: 22,
+    projectileType: 'bullet',
+  },
+  fireball: {
+    key:        'fireball',
+    label:      'Fireball',
+    damage:     10,
+    cooldownMs: 1200,
+    spread:     0.0,
+    projectileSpeed: 10,
+    projectileType: 'fireball',
+    burnDamagePerSec: 8,
+    burnDurationSec:  4,
+  },
+  club: {
+    key:        'club',
+    label:      'Club',
+    damage:     40,
+    cooldownMs: 800,
+    melee:      true,
+    meleeRange: 1.4,
+    meleeArc:   Math.PI * 0.6,
+  },
+  katana: {
+    key:        'katana',
+    label:      'Katana',
+    damage:     30,
+    cooldownMs: 350,
+    melee:      true,
+    meleeRange: 1.8,
+    meleeArc:   Math.PI * 0.45,
+  },
+};
+
+const WEAPON_ORDER = ['handgun', 'rifle', 'fireball', 'club', 'katana'];
+
+class WeaponSystem {
+  constructor(onFire) {
+    this._onFire     = onFire;
+    this._cooldowns  = {};
+    this._burstState = null;
+    this.currentIndex = 0;
+    this.current = WEAPONS[WEAPON_ORDER[0]];
+  }
+
+  select(indexOrKey) {
+    if (typeof indexOrKey === 'string') {
+      const idx = WEAPON_ORDER.indexOf(indexOrKey);
+      if (idx < 0) return;
+      this.currentIndex = idx;
+    } else {
+      this.currentIndex = ((indexOrKey % WEAPON_ORDER.length) + WEAPON_ORDER.length) % WEAPON_ORDER.length;
+    }
+    this.current = WEAPONS[WEAPON_ORDER[this.currentIndex]];
+  }
+
+  next() { this.select(this.currentIndex + 1); }
+  prev() { this.select(this.currentIndex - 1); }
+
+  tryFire(originPos, dirVec, shooterId) {
+    const now = performance.now();
+    const w = this.current;
+    const last = this._cooldowns[w.key] || 0;
+    if (now - last < w.cooldownMs) return false;
+    this._cooldowns[w.key] = now;
+
+    if (w.melee) {
+      this._onFire(w, originPos, dirVec, shooterId);
+      return true;
+    }
+
+    if (w.burstCount && w.burstCount > 1) {
+      this._fireSingle(w, originPos, dirVec, shooterId);
+      this._burstState = {
+        weaponKey:  w.key,
+        remaining:  w.burstCount - 1,
+        nextAt:     now + w.burstIntervalMs,
+        originPos:  { ...originPos },
+        dirVec:     { ...dirVec },
+        shooterId,
+      };
+    } else {
+      this._fireSingle(w, originPos, dirVec, shooterId);
+    }
+    return true;
+  }
+
+  tick() {
+    if (!this._burstState) return;
+    const now = performance.now();
+    const b = this._burstState;
+    if (now < b.nextAt) return;
+    const w = WEAPONS[b.weaponKey];
+    this._fireSingle(w, b.originPos, b.dirVec, b.shooterId);
+    b.remaining--;
+    if (b.remaining <= 0) {
+      this._burstState = null;
+    } else {
+      b.nextAt = now + w.burstIntervalMs;
+    }
+  }
+
+  _fireSingle(w, originPos, dirVec, shooterId) {
+    const spread = w.spread || 0;
+    const dir = {
+      x: dirVec.x + (Math.random() - 0.5) * spread,
+      y: dirVec.y + (Math.random() - 0.5) * spread * 0.5,
+      z: dirVec.z + (Math.random() - 0.5) * spread,
+    };
+    const len = Math.hypot(dir.x, dir.y, dir.z) || 1;
+    dir.x /= len; dir.y /= len; dir.z /= len;
+    this._onFire(w, originPos, dir, shooterId);
+  }
+
+  getWeaponDef(key) { return WEAPONS[key] || null; }
+  getAllWeapons()    { return WEAPON_ORDER.map(k => WEAPONS[k]); }
+}
+
+if (typeof window !== 'undefined') {
+  window.MayhemWeapons = { WeaponSystem, WEAPONS, WEAPON_ORDER };
+}

--- a/brett/public/index.html
+++ b/brett/public/index.html
@@ -1188,6 +1188,7 @@
 <script src="assets/mayhem/projectiles.js"></script>
 <script src="assets/mayhem/effects.js"></script>
 <script src="assets/mayhem/game-mode.js"></script>
+<script src="assets/mayhem/ai-bot.js"></script>
 <script src="assets/mayhem/mayhem.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

- **Restores `mayhem/weapons.js`** — deleted by the Phase 2+3 rebase, making Mayhem mode's weapon system (`WeaponSystem`) completely broken (broken reference in `index.html`). File recovered from git history.
- **New `ai-bot.js`** — `MayhemAIBot` class with a 3-state FSM (wander → chase → melee) and imperfect aim spread. Bots are registered in `remoteAvatars`, so projectile hit detection, vehicle collisions, and flail punches all target them for free.
- **Mayhem fills empty slots** — on start, up to 3 bots are spawned to reach 4 total combatants. When a real player joins, one bot is retired.
- **Damage routing** — bot hits go through `bot.processHit()` with deathmatch auto-respawn after 4 s.

## Test plan

- [ ] Open brett, click 🤸 Mayhem — 3 AI opponents spawn at edges
- [ ] Bots wander when player is far, chase when within 14 m, flail when within 2 m
- [ ] Shooting a bot ragdolls it; 3 hits with handgun kills it
- [ ] In deathmatch mode: dead bots respawn after 4 s
- [ ] When a second browser joins: one bot retires to keep player count at 4
- [ ] Weapon switching (1-5/QE) still works; HUD updates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)