### PR TITLE
fix(brett): WebSocket reconnect + Mayhem button always wired

### DIFF
--- a/brett/public/index.html
+++ b/brett/public/index.html
@@ -1034,28 +1034,44 @@
   // ----- WebSocket sync -----
   const roomFromUrl = new URLSearchParams(location.search).get("room") || "default";
   const wsProto = location.protocol === "https:" ? "wss:" : "ws:";
-  const ws = new WebSocket(`${wsProto}//${location.host}/sync`);
-  let wsReady = false;
+  let ws, wsReady = false;
 
-  ws.addEventListener("open", () => {
-  // --- Mayhem mode wiring ---
-  if (window.Mayhem) {
-    const mayhemSend = (msg) => { try { ws.send(JSON.stringify(msg)); } catch (e) { /* ignore */ } };
-    window.Mayhem.init({
-      scene, camera, canvas: renderer.domElement,
-      makeMannequin: (id, pos) => makeMannequin(id, pos),
-      sendMessage: mayhemSend,
-      roomToken: roomFromUrl,
+  const mayhemSend = (msg) => {
+    if (!ws || ws.readyState !== WebSocket.OPEN) return;
+    try { ws.send(JSON.stringify(msg)); } catch (e) { /* ignore */ }
+  };
+
+  function connectWS() {
+    ws = new WebSocket(`${wsProto}//${location.host}/sync`);
+
+    ws.addEventListener("open", () => {
+      if (window.Mayhem && !window.Mayhem._initialized) {
+        window.Mayhem.init({
+          scene, camera, canvas: renderer.domElement,
+          makeMannequin: (id, pos) => makeMannequin(id, pos),
+          sendMessage: mayhemSend,
+          roomToken: roomFromUrl,
+        });
+        window.Mayhem._initialized = true;
+      }
+
+      wsReady = true;
+      ws.send(JSON.stringify({ type: "join", room: roomFromUrl }));
     });
-    document.getElementById("mayhem-btn").addEventListener("click", () => window.Mayhem.toggle());
+
+    ws.addEventListener("close", () => {
+      wsReady = false;
+      setTimeout(connectWS, 2000);
+    });
+
+    ws.addEventListener("message", onWsMessage);
   }
 
-    wsReady = true;
-    ws.send(JSON.stringify({ type: "join", room: roomFromUrl }));
-  });
-  ws.addEventListener("close", () => { wsReady = false; });
+  connectWS();
 
-  ws.addEventListener("message", (evt) => {
+  document.getElementById("mayhem-btn")?.addEventListener("click", () => window.Mayhem?.toggle());
+
+  function onWsMessage(evt) {
     let msg; try { msg = JSON.parse(evt.data); } catch { return; }
     switch (msg.type) {
       case "snapshot":
@@ -1133,7 +1149,7 @@
         document.getElementById("online-count").textContent = String(STATE.online);
         break;
     }
-  });
+  }
 
   // Replace the placeholders defined earlier
   window.sendUpdate = function(fig, changes) {


### PR DESCRIPTION
## Summary
- Auto-reconnects the WebSocket after drop/timeout (2s backoff) so the Mayhem button works again after any connection interruption
- Guards `mayhemSend` with a `readyState` check — no more console error on a closed socket
- Moves the Mayhem button listener outside the `ws open` handler so it's attached immediately on page load
- Adds `_initialized` flag to prevent duplicate `Mayhem.init()` calls on reconnect

## Test Plan
- [ ] Open Brett, wait for WS to drop (or force-close via DevTools Network tab), verify it reconnects within ~2s
- [ ] Click 🤸 Mayhem button — game should start without console errors
- [ ] Reload page and click button immediately — should work once WS connects