### PR TITLE
fix(brett): IIFE-wrap mayhem JS to fix duplicate const SyntaxErrors [T000438]

### DIFF
--- a/brett/public/assets/mayhem/player-avatar.js
+++ b/brett/public/assets/mayhem/player-avatar.js
@@ -1,3 +1,4 @@
+(function () {
 'use strict';
 const STATE = Object.freeze({
   IDLE: 'idle', RUNNING: 'running', FLAILING: 'flailing',
@@ -255,3 +256,4 @@ class PlayerAvatar {
 
 PlayerAvatar.STATE = STATE;
 if (typeof window !== 'undefined') window.MayhemPlayerAvatar = PlayerAvatar;
+})();

--- a/brett/public/assets/mayhem/projectiles.js
+++ b/brett/public/assets/mayhem/projectiles.js
@@ -1,3 +1,4 @@
+(function () {
 'use strict';
 // Projectile manager.
 // Handles: spawn, per-frame movement, AABB/capsule collision, network hit emission.
@@ -158,3 +159,4 @@ class ProjectileManager {
 if (typeof window !== 'undefined') {
   window.MayhemProjectiles = { ProjectileManager };
 }
+})();


### PR DESCRIPTION
## Summary
- `player-avatar.js` declared `const WALK_SPEED` and `projectiles.js` declared `const GRAVITY` at the top level of plain `<script>` files
- The same names exist in the large inline `<script>` block in `index.html` (lines 243 and 934), which shares the global lexical environment
- Browser threw `SyntaxError: Identifier already declared` on every page load, blocking the Mayhem module

## Fix
Wrap both files in an IIFE `(function(){ 'use strict'; ... })()` so their constants are function-scoped and never reach the global lexical environment. Public API (`window.MayhemPlayerAvatar`, `window.MayhemProjectiles`) still escapes via explicit `window.Xxx =` assignments inside the IIFE.

## Test plan
- [ ] `task feature:brett` after merge to confirm no build errors
- [ ] Open `https://brett.mentolder.de` — DevTools console should show no `SyntaxError: Identifier already declared` for `WALK_SPEED` or `GRAVITY`
- [ ] Mayhem mode should load and run normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)