### PR TITLE
feat(brett): Phases 4–6 — Mode-Select, Touch, Respawn, Score

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,7 @@ jobs:
       - uses: actions/setup-node@v4
         with: { node-version: '22' }
       - run: npm ci --prefix brett
-      - run: node --test brett/test/ws-reconnect.test.mjs brett/test/physics.test.js brett/test/damage.test.mjs brett/test/pickups.test.mjs
+      - run: node --test brett/test/ws-reconnect.test.mjs brett/test/physics.test.js brett/test/damage.test.mjs brett/test/pickups.test.mjs brett/test/mode-state.test.mjs
 
   arena-proto-drift:
     name: Arena protocol drift guard

--- a/brett/public/assets/combat/controller.mjs
+++ b/brett/public/assets/combat/controller.mjs
@@ -11,6 +11,8 @@ export function startCombat({ scene, camera, players, self, ws, hudRoot }) {
     lastShotAt: 0,
   };
 
+  const scores = new Map(); // player_id → kill count
+
   Hud.mountCombatHud(hudRoot);
   Hud.setHP(hudRoot, self.hp ?? 100);
   Hud.setSlot(hudRoot, 'melee', state.loadout.melee);
@@ -37,11 +39,31 @@ export function startCombat({ scene, camera, players, self, ws, hudRoot }) {
     if (victim.hp <= 0) ws.send({ type: 'death_event', victim_id: victim.id, killer_id: msg.shooter_id });
   });
 
-  ws.on('death_event', _msg => {
-    // Score tracking comes in Phase 6
+  ws.on('death_event', msg => {
+    if (msg.killer_id) {
+      scores.set(msg.killer_id, (scores.get(msg.killer_id) ?? 0) + 1);
+    }
+    const sorted = [...scores.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .map(([id, kills]) => ({ name: id.slice(0, 8), kills }));
+    Hud.setScores(hudRoot, sorted);
+    if (msg.victim_id === self.id) {
+      import('./respawn.mjs').then(({ showRespawnOverlay }) => {
+        const killer = msg.killer_id?.slice(0, 8);
+        showRespawnOverlay({ killerName: killer }).then(() => {
+          self.hp = 100;
+          Hud.setHP(hudRoot, 100);
+        });
+      });
+    }
   });
 
-  return state;
+  return {
+    ...state,
+    startFire: () => fire(state, { scene, camera, players, ws, hudRoot }),
+    stopFire: () => {},
+    reload: () => reload(state, { hudRoot }),
+  };
 }
 
 function fire(state, { scene, camera, players, ws, hudRoot }) {

--- a/brett/public/assets/combat/respawn.mjs
+++ b/brett/public/assets/combat/respawn.mjs
@@ -1,0 +1,21 @@
+// brett/public/assets/combat/respawn.mjs
+export function showRespawnOverlay({ killerName, durationMs = 3000 }) {
+  return new Promise(resolve => {
+    const el = document.createElement('div');
+    el.className = 'respawn-overlay';
+    el.innerHTML = `
+      <div class="card">
+        <div class="msg">Eliminiert${killerName ? ' von ' + killerName : ''}</div>
+        <div class="countdown">3</div>
+      </div>
+    `;
+    document.body.appendChild(el);
+    const cdEl = el.querySelector('.countdown');
+    let left = Math.ceil(durationMs / 1000);
+    const tick = setInterval(() => {
+      left--;
+      if (left <= 0) { clearInterval(tick); el.remove(); resolve(); }
+      else cdEl.textContent = left;
+    }, 1000);
+  });
+}

--- a/brett/public/assets/loadout-modal.mjs
+++ b/brett/public/assets/loadout-modal.mjs
@@ -1,0 +1,48 @@
+// brett/public/assets/loadout-modal.mjs
+const MELEE = ['club', 'katana'];
+const RANGED = ['handgun'];
+
+export function showLoadoutModal(modeState) {
+  const current = modeState.loadout();
+  return new Promise(resolve => {
+    const el = document.createElement('div');
+    el.className = 'mode-select-overlay';
+    el.innerHTML = `
+      <div class="mode-select-card">
+        <h2>Wähle deine Startausrüstung</h2>
+        <div class="loadout-cols">
+          <div>
+            <h3>Nahkampf</h3>
+            ${MELEE.map(w => `<button class="weapon-pick ${current.melee===w?'active':''}" data-slot="melee" data-w="${w}">
+              <img src="assets/hud/icon-${w}.png" alt="${w}">
+              <span>${w}</span>
+            </button>`).join('')}
+          </div>
+          <div>
+            <h3>Fernkampf</h3>
+            ${RANGED.map(w => `<button class="weapon-pick ${current.ranged===w?'active':''}" data-slot="ranged" data-w="${w}">
+              <img src="assets/hud/icon-${w}.png" alt="${w}">
+              <span>${w}</span>
+            </button>`).join('')}
+          </div>
+        </div>
+        <button class="confirm">Spielen</button>
+      </div>
+    `;
+    document.body.appendChild(el);
+    const sel = { ...current };
+    el.addEventListener('click', e => {
+      const w = e.target.closest('.weapon-pick');
+      if (w) {
+        sel[w.dataset.slot] = w.dataset.w;
+        el.querySelectorAll(`[data-slot="${w.dataset.slot}"]`).forEach(b => b.classList.toggle('active', b === w));
+        return;
+      }
+      if (e.target.classList.contains('confirm')) {
+        modeState.setLoadout(sel);
+        el.remove();
+        resolve(sel);
+      }
+    });
+  });
+}

--- a/brett/public/assets/main.js
+++ b/brett/public/assets/main.js
@@ -1,8 +1,8 @@
-// brett/public/assets/main.js — ESM entry, Phase 1.
-// scene.js still runs as classic <script> (IIFE) and owns the canvas; this
-// module layers on cross-cutting concerns (WS reconnect-banner) that will
-// expand in later phases.
+// brett/public/assets/main.js — ESM entry, Phase 4: full mode-select→loadout→combat flow.
 import { connect } from './ws.mjs';
+import { createModeState } from './mode-state.mjs';
+import { showModeSelect } from './mode-select.mjs';
+import { showLoadoutModal } from './loadout-modal.mjs';
 
 const ws = connect();
 
@@ -16,17 +16,58 @@ ws.on('open', () => { if (banner) banner.hidden = true; });
 
 window.__brettWs = ws;
 
-// Debug toggle: ?combat=1 activates FFA combat without mode-select
-if (new URLSearchParams(location.search).get('combat') === '1') {
-  const overlayRoot = document.getElementById('overlay-root');
-  import('./combat/controller.mjs').then(C => {
-    C.startCombat({
-      scene: window.scene,
-      camera: window.camera,
-      players: window.figures || [],
-      self: window.localPlayer || { id: 'local', hp: 100 },
-      ws,
-      hudRoot: overlayRoot,
-    });
+const modeState = createModeState();
+let combatCtl = null;
+const overlayRoot = document.getElementById('overlay-root');
+
+modeState.on('change', async mode => {
+  if (mode === 'ffa') {
+    await startFFA();
+  } else if (mode === 'coaching') {
+    stopCombat();
+  }
+});
+
+async function startFFA() {
+  await showLoadoutModal(modeState);
+  const loadout = modeState.loadout();
+
+  const { startCombat } = await import('./combat/controller.mjs');
+  combatCtl = startCombat({
+    scene: window.scene,
+    camera: window.camera,
+    players: window.figures || [],
+    self: window.localPlayer || { id: 'local', hp: 100 },
+    ws,
+    hudRoot: overlayRoot,
+    loadout,
   });
+
+  const isTouch = matchMedia('(pointer: coarse)').matches;
+  if (isTouch) {
+    const { mountJoystick } = await import('./touch/joystick.mjs');
+    const { mountTouchHud } = await import('./touch/touch-hud.mjs');
+    mountJoystick({
+      side: 'left',
+      onMove: ({ x, y }) => window.localPlayer?.setMoveInput?.(x, y),
+    });
+    mountJoystick({
+      side: 'right',
+      onMove: ({ x, y }) => window.localPlayer?.setAimDelta?.(x, y),
+    });
+    mountTouchHud({
+      onFireStart: () => combatCtl?.startFire?.(),
+      onFireEnd: () => combatCtl?.stopFire?.(),
+      onReload: () => combatCtl?.reload?.(),
+    });
+  }
 }
+
+function stopCombat() {
+  if (!overlayRoot) return;
+  const hud = overlayRoot.querySelector('#combat-hud');
+  if (hud) hud.hidden = true;
+}
+
+// Show mode selector on load
+showModeSelect(modeState);

--- a/brett/public/assets/mode-select.mjs
+++ b/brett/public/assets/mode-select.mjs
@@ -1,0 +1,39 @@
+// brett/public/assets/mode-select.mjs
+export function showModeSelect(modeState) {
+  return new Promise(resolve => {
+    const el = document.createElement('div');
+    el.className = 'mode-select-overlay';
+    el.innerHTML = `
+      <div class="mode-select-card">
+        <h2>Wähle deinen Modus</h2>
+        <div class="mode-grid">
+          <button class="mode-card" data-mode="coaching">
+            <div class="title">Coaching</div>
+            <div class="sub">Systemische Aufstellung</div>
+          </button>
+          <button class="mode-card" data-mode="ffa">
+            <div class="title">FFA</div>
+            <div class="sub">Jeder gegen jeden</div>
+          </button>
+          <button class="mode-card disabled" data-mode="teams" disabled>
+            <div class="title">Teams</div>
+            <div class="sub">Coming soon</div>
+          </button>
+          <button class="mode-card disabled" data-mode="coop" disabled>
+            <div class="title">Coop</div>
+            <div class="sub">Coming soon</div>
+          </button>
+        </div>
+      </div>
+    `;
+    document.body.appendChild(el);
+    el.addEventListener('click', e => {
+      const card = e.target.closest('.mode-card');
+      if (!card || card.disabled) return;
+      const mode = card.dataset.mode;
+      modeState.setMode(mode);
+      el.remove();
+      resolve(mode);
+    });
+  });
+}

--- a/brett/public/assets/mode-state.mjs
+++ b/brett/public/assets/mode-state.mjs
@@ -1,0 +1,35 @@
+// brett/public/assets/mode-state.mjs
+const VALID = new Set(['coaching', 'ffa', 'mode-select']);
+const STUB = new Set(['teams', 'coop']);
+const KEY_LOADOUT = 'brett.loadout';
+
+export function createModeState({ storage = window.localStorage } = {}) {
+  let mode = 'coaching';
+  const listeners = new Map();
+  function emit(type, payload) { (listeners.get(type) || []).forEach(fn => fn(payload)); }
+
+  function readLoadout() {
+    try { return JSON.parse(storage.get?.(KEY_LOADOUT) ?? storage.getItem?.(KEY_LOADOUT)); } catch { return null; }
+  }
+  function writeLoadout(l) {
+    const v = JSON.stringify(l);
+    storage.set ? storage.set(KEY_LOADOUT, v) : storage.setItem(KEY_LOADOUT, v);
+  }
+
+  return {
+    current: () => mode,
+    setMode(m) {
+      if (STUB.has(m)) { emit('stub-attempted', m); return false; }
+      if (!VALID.has(m)) return false;
+      mode = m;
+      emit('change', mode);
+      return true;
+    },
+    loadout: () => readLoadout() ?? { melee: 'club', ranged: 'handgun' },
+    setLoadout(l) { writeLoadout(l); emit('loadout-change', l); },
+    on(type, fn) {
+      const arr = listeners.get(type) || [];
+      arr.push(fn); listeners.set(type, arr);
+    },
+  };
+}

--- a/brett/public/assets/style.css
+++ b/brett/public/assets/style.css
@@ -202,3 +202,52 @@
   padding: 10px 24px; border-radius: 6px; cursor: pointer; font-weight: 600;
 }
 .confirm:hover { background: var(--brass-hi); }
+
+/* ── Touch Joystick ──────────────────────────────────────────── */
+.joystick {
+  position: fixed; width: 140px; height: 140px;
+  background: rgba(11,17,28,0.4); border: 1px solid var(--brass-mute);
+  border-radius: 50%; pointer-events: auto; touch-action: none;
+  display: none;
+}
+.joystick.visible { display: block; }
+.joystick-left { bottom: 24px; left: 24px; display: block; }
+.joystick-right { bottom: 24px; right: 112px; display: block; }
+.joystick .ring { position: absolute; inset: 10px; border: 1px dashed var(--brass-mute); border-radius: 50%; }
+.joystick .knob {
+  position: absolute; top: 50%; left: 50%; width: 50px; height: 50px;
+  margin: -25px 0 0 -25px; background: var(--brass); border-radius: 50%;
+  transition: transform 60ms ease-out;
+}
+@media (pointer: fine) { .joystick { display: none !important; } }
+
+/* ── Touch HUD (fire + reload buttons) ───────────────────────── */
+#touch-hud { pointer-events: none; }
+#touch-hud .fire-btn {
+  position: fixed; bottom: 200px; right: 32px;
+  width: 80px; height: 80px; border-radius: 50%;
+  background: var(--brass); color: var(--ink-900);
+  border: 0; font-size: 24px; pointer-events: auto; touch-action: none;
+}
+#touch-hud .reload-btn {
+  position: fixed; bottom: 290px; right: 50px;
+  width: 50px; height: 50px; border-radius: 50%;
+  background: var(--ink-800); color: var(--brass-hi);
+  border: 1px solid var(--brass); pointer-events: auto;
+}
+@media (pointer: fine) { #touch-hud { display: none; } }
+
+/* ── Mobile Bottom-Sheet for Fig-Panel ───────────────────────── */
+@media (pointer: coarse) {
+  #fig-panel {
+    position: fixed; bottom: 0; left: 0; right: 0; top: auto;
+    border-radius: 16px 16px 0 0; max-height: 60vh; overflow-y: auto;
+    transform: translateY(100%); transition: transform 200ms ease-out;
+    z-index: 50;
+  }
+  #fig-panel.open { transform: translateY(0); }
+  #fig-panel::before {
+    content: ''; display: block; width: 40px; height: 4px;
+    margin: 8px auto; background: var(--brass-mute); border-radius: 2px;
+  }
+}

--- a/brett/public/assets/style.css
+++ b/brett/public/assets/style.css
@@ -163,3 +163,42 @@
   position: absolute; inset: 0; display: grid; place-items: center;
   font-size: 18px; color: var(--brass); opacity: 0.6;
 }
+
+/* ── Mode Select + Loadout Modal ───────────────────────────────── */
+.mode-select-overlay {
+  position: fixed; inset: 0; background: rgba(11,17,28,0.85);
+  display: grid; place-items: center; z-index: 100;
+}
+.mode-select-card {
+  background: var(--ink-800); border: 1px solid var(--brass-mute);
+  padding: 32px; border-radius: 12px; max-width: 720px; width: 90%;
+}
+.mode-select-card h2 { margin-top: 0; color: var(--brass-hi); }
+.mode-grid {
+  display: grid; grid-template-columns: repeat(2, 1fr); gap: 16px;
+  margin-top: 24px;
+}
+.mode-card {
+  background: var(--ink-900); border: 1px solid var(--brass-mute);
+  border-radius: 8px; padding: 24px; cursor: pointer; color: inherit;
+  text-align: left; transition: border-color 120ms, transform 120ms;
+}
+.mode-card:hover:not(.disabled) { border-color: var(--brass-hi); transform: translateY(-2px); }
+.mode-card.disabled { opacity: 0.4; cursor: not-allowed; }
+.mode-card .title { font-size: 20px; color: var(--brass-hi); }
+.mode-card .sub { font-size: 13px; color: var(--brass); margin-top: 4px; }
+.loadout-cols { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; margin: 16px 0; }
+.loadout-cols h3 { color: var(--brass); font-size: 13px; letter-spacing: 0.1em; text-transform: uppercase; }
+.weapon-pick {
+  display: flex; gap: 12px; align-items: center; width: 100%;
+  background: var(--ink-900); border: 1px solid var(--brass-mute);
+  padding: 8px 12px; margin: 4px 0; border-radius: 6px;
+  cursor: pointer; color: inherit;
+}
+.weapon-pick.active { border-color: var(--brass-hi); background: var(--ink-800); }
+.weapon-pick img { width: 32px; height: 32px; }
+.confirm {
+  background: var(--brass); color: var(--ink-900); border: 0;
+  padding: 10px 24px; border-radius: 6px; cursor: pointer; font-weight: 600;
+}
+.confirm:hover { background: var(--brass-hi); }

--- a/brett/public/assets/style.css
+++ b/brett/public/assets/style.css
@@ -251,3 +251,15 @@
     margin: 8px auto; background: var(--brass-mute); border-radius: 2px;
   }
 }
+
+/* ── Respawn Overlay ─────────────────────────────────────────── */
+.respawn-overlay {
+  position: fixed; inset: 0; background: rgba(168,58,48,0.15);
+  backdrop-filter: blur(4px); display: grid; place-items: center; z-index: 200;
+}
+.respawn-overlay .card {
+  background: var(--ink-800); border: 1px solid var(--brass);
+  padding: 32px 64px; border-radius: 12px; text-align: center;
+}
+.respawn-overlay .msg { color: var(--brass-hi); font-size: 18px; margin-bottom: 12px; }
+.respawn-overlay .countdown { color: var(--brass); font-size: 64px; font-weight: 700; }

--- a/brett/public/assets/touch/joystick.mjs
+++ b/brett/public/assets/touch/joystick.mjs
@@ -1,0 +1,61 @@
+// brett/public/assets/touch/joystick.mjs
+export function mountJoystick({ side, onMove, onSprint, onTap }) {
+  const el = document.createElement('div');
+  el.className = `joystick joystick-${side}`;
+  el.innerHTML = `<div class="ring"></div><div class="knob"></div>`;
+  document.body.appendChild(el);
+  const knob = el.querySelector('.knob');
+
+  let active = null;
+  let originX = 0, originY = 0;
+  const radius = 60;
+  let sprintTimer = 0;
+  let lastTap = 0;
+
+  function onStart(e) {
+    if (active !== null) return;
+    const t = e.touches?.[0] ?? e;
+    active = t.identifier ?? 'mouse';
+    originX = t.clientX; originY = t.clientY;
+    el.style.left = (originX - 70) + 'px';
+    el.style.top = (originY - 70) + 'px';
+    el.classList.add('visible');
+    sprintTimer = Date.now();
+    e.preventDefault();
+  }
+  function onMoveEvt(e) {
+    if (active === null) return;
+    const t = [...(e.touches ?? [e])].find(x => (x.identifier ?? 'mouse') === active);
+    if (!t) return;
+    let dx = t.clientX - originX, dy = t.clientY - originY;
+    const d = Math.hypot(dx, dy);
+    if (d > radius) { dx = dx/d * radius; dy = dy/d * radius; }
+    knob.style.transform = `translate(${dx}px, ${dy}px)`;
+    const nx = dx / radius, ny = dy / radius;
+    onMove?.({ x: nx, y: ny });
+    if (d >= radius * 0.95 && Date.now() - sprintTimer > 1500) onSprint?.(true);
+    e.preventDefault();
+  }
+  function onEnd(e) {
+    const t = [...(e.changedTouches ?? [e])].find(x => (x.identifier ?? 'mouse') === active);
+    if (!t || active === null) return;
+    knob.style.transform = '';
+    onMove?.({ x: 0, y: 0 });
+    onSprint?.(false);
+    const dur = Date.now() - sprintTimer;
+    if (dur < 200) {
+      if (Date.now() - lastTap < 300) onTap?.({ doubleTap: true });
+      else onTap?.({ doubleTap: false });
+      lastTap = Date.now();
+    }
+    active = null;
+    el.classList.remove('visible');
+  }
+
+  el.addEventListener('touchstart', onStart, { passive: false });
+  el.addEventListener('touchmove', onMoveEvt, { passive: false });
+  el.addEventListener('touchend', onEnd);
+  el.addEventListener('touchcancel', onEnd);
+
+  return { destroy: () => el.remove() };
+}

--- a/brett/public/assets/touch/touch-hud.mjs
+++ b/brett/public/assets/touch/touch-hud.mjs
@@ -1,0 +1,17 @@
+// brett/public/assets/touch/touch-hud.mjs
+export function mountTouchHud({ onFireStart, onFireEnd, onReload, onWeaponSwitch }) {
+  const wrap = document.createElement('div');
+  wrap.id = 'touch-hud';
+  wrap.innerHTML = `
+    <button class="fire-btn" aria-label="Feuer">●</button>
+    <button class="reload-btn" aria-label="Nachladen">R</button>
+  `;
+  document.body.appendChild(wrap);
+
+  const fire = wrap.querySelector('.fire-btn');
+  fire.addEventListener('touchstart', e => { onFireStart?.(); e.preventDefault(); }, { passive: false });
+  fire.addEventListener('touchend', e => { onFireEnd?.(); e.preventDefault(); }, { passive: false });
+  wrap.querySelector('.reload-btn').addEventListener('touchend', () => onReload?.());
+
+  return { destroy: () => wrap.remove() };
+}

--- a/brett/test/mode-state.test.mjs
+++ b/brett/test/mode-state.test.mjs
@@ -1,0 +1,29 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createModeState } from '../public/assets/mode-state.mjs';
+
+test('default mode is coaching', () => {
+  const ms = createModeState({ storage: new Map() });
+  assert.equal(ms.current(), 'coaching');
+});
+
+test('persisted loadout overrides defaults', () => {
+  const storage = new Map([['brett.loadout', JSON.stringify({ melee: 'katana', ranged: 'handgun' })]]);
+  const ms = createModeState({ storage });
+  assert.equal(ms.loadout().melee, 'katana');
+});
+
+test('setMode emits change event', () => {
+  let last = null;
+  const ms = createModeState({ storage: new Map() });
+  ms.on('change', m => { last = m; });
+  ms.setMode('ffa');
+  assert.equal(last, 'ffa');
+});
+
+test('stub modes do not change state', () => {
+  const ms = createModeState({ storage: new Map() });
+  const result = ms.setMode('teams');
+  assert.equal(result, false);
+  assert.equal(ms.current(), 'coaching');
+});


### PR DESCRIPTION
## Summary
- **Phase 4 (Mode-Select):** `createModeState` (coaching/ffa/stub modes) + mode-select overlay + loadout modal with weapon picker + localStorage persistence. Wired into main.js — mode-select shows on page load, FFA triggers loadout then combat.
- **Phase 5 (Touch):** Dual-joystick component + fire/reload touch HUD (hidden on desktop via `pointer: fine`). Bottom-sheet CSS for mobile fig-panel. Lazy-imported when `pointer: coarse` detected.
- **Phase 6 (Polish/CI):** Respawn overlay (countdown + red vignette), kill-score tracking per player, score updates in combat HUD. `mode-state.test.mjs` added to `brett-server-test` CI job.

## Test plan
- [x] `node --test brett/test/` — 22/22 pass (damage, pickups, ws-reconnect, physics, mode-state)
- [x] `task workspace:validate` — manifests valid
- [ ] Browser smoke: Mode-Select → FFA → Loadout → HUD visible (needs brett deploy)
- [ ] Mobile smoke: Joystick + fire button visible on touch device
- [ ] CI green on this PR

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>