### PR TITLE
chore(skills): fill 8 skill gaps + 2 quality fixes

### DIFF
--- a/.claude/skills/coaching-pipeline/SKILL.md
+++ b/.claude/skills/coaching-pipeline/SKILL.md
@@ -1,0 +1,174 @@
+---
+name: coaching-pipeline
+description: Use when ingesting coaching books/PDFs, classifying knowledge chunks, reviewing draft knowledge items, or debugging the coaching content pipeline. Covers task coaching:ingest, task coaching:classify, /admin/knowledge/drafts, and local LLM requirements.
+---
+
+> **Mishap Tracking:** As you execute this skill, maintain a running `MISHAP_LOG`.
+> For every anomaly, unexpected state, broken component, security concern, or
+> configuration drift you notice — even if unrelated to the current task — add
+> an entry with: `type` (broken/degraded/suspicious/security/drift), `title`,
+> `description`, and `component`. Invoke `mishap-tracker` at the very end.
+
+# coaching-pipeline
+
+End-to-end workflow for getting coaching content from source files into the live knowledge base.
+
+---
+
+## Pipeline overview
+
+```
+Source file (PDF/EPUB)
+    ↓  task coaching:ingest
+Chunks stored in pgvector (status: UNCLASSIFIED)
+    ↓  task coaching:classify
+Chunks classified by LLM (status: DRAFT)
+    ↓  /admin/knowledge/drafts review
+Chunks promoted to PUBLISHED
+    ↓  available to coaching assistant
+```
+
+---
+
+## Phase 1: Ingest a source file
+
+```bash
+task coaching:ingest -- <file> <slug> [--title="..."] [--author="..."]
+```
+
+Examples:
+```bash
+task coaching:ingest -- /home/patrick/books/my-book.pdf systemic-basics \
+  --title="Systemische Grundlagen" --author="Max Mustermann"
+
+task coaching:ingest -- /home/patrick/books/handbook.epub coaching-handbook \
+  --title="Coaching Handbuch"
+```
+
+**What this does:**
+- Splits the source into chunks
+- Embeds chunks using the configured embedding model (see below)
+- Stores in `coaching.chunks` with `status = 'UNCLASSIFIED'`
+- Registers the book in `coaching.books`
+
+**Verify ingestion:**
+```bash
+task workspace:psql ENV=mentolder -- website <<'SQL'
+SELECT slug, title, chunk_count, created_at::date
+FROM coaching.books
+ORDER BY created_at DESC
+LIMIT 10;
+SQL
+```
+
+---
+
+## Phase 2: Classify chunks
+
+```bash
+# Classify by slug:
+task coaching:classify -- --slug=<slug>
+
+# Classify all UNCLASSIFIED chunks:
+task coaching:classify -- --all
+```
+
+**Classification assigns:**
+- A topic category
+- A confidence score
+- A DRAFT status (ready for review)
+
+### LLM requirements for classify
+
+Classification uses a chat-class LLM. Two paths:
+
+**Path A — Cluster llm-router (preferred in prod):**
+- Requires `LLM_ENABLED=true` and `LLM_HOST_IP` set in `environments/<env>.yaml`
+- The GPU host must be reachable on the `wg-mesh` network
+- Models: llama3.2, gemma3 (via Ollama on the GPU host)
+
+**Path B — Anthropic API fallback:**
+- Used if `LLM_ENABLED=false` or GPU host is unreachable
+- Requires a valid `ANTHROPIC_API_KEY` in the SealedSecret
+- Check API key validity: if classify returns `401 Unauthorized` from Claude, the key needs rotation (see memory: `project_anthropic_key_rotation`)
+
+**Path C — Local WSL Ollama (development workaround):**
+- Run Ollama locally on WSL2, expose via LiteLLM as Anthropic translator
+- See memory: `reference_local_llm_classify_workflow`
+- Use when the cluster llm-router path is broken from Hetzner pods
+
+**Embedding model selection** — this is critical:
+- `bge-m3` collections use TEI on `llm-gateway-embed:8081`
+- `voyage-multilingual-2` collections use Voyage AI directly
+- **These never fall back across vector spaces.** A `bge-m3` collection fails closed if TEI is down — do not try to substitute Voyage embeddings. `MixedEmbeddingModelError` is thrown for cross-model queries.
+
+Check which model a collection uses:
+```bash
+task workspace:psql ENV=mentolder -- website <<'SQL'
+SELECT collection_name, embedding_model
+FROM knowledge.collections;
+SQL
+```
+
+---
+
+## Phase 3: Review drafts
+
+Navigate to: `https://web.mentolder.de/admin/knowledge/drafts`
+
+For each draft chunk:
+- Read the content and proposed classification
+- **Approve** → promotes to `PUBLISHED` (available to coaching assistant)
+- **Reject** → marks as `REJECTED` (won't appear in queries)
+- **Edit** → correct category or content before publishing
+
+Bulk operations from psql (use carefully):
+```bash
+task workspace:psql ENV=mentolder -- website <<'SQL'
+-- Approve all DRAFT chunks for a specific book slug
+UPDATE coaching.chunks
+SET status = 'PUBLISHED', reviewed_at = now()
+WHERE book_id = (SELECT id FROM coaching.books WHERE slug = '<slug>')
+  AND status = 'DRAFT';
+SQL
+```
+
+---
+
+## Phase 4: Verify availability
+
+After publishing, verify chunks are queryable:
+
+```bash
+task workspace:psql ENV=mentolder -- website <<'SQL'
+SELECT status, COUNT(*) FROM coaching.chunks
+WHERE book_id = (SELECT id FROM coaching.books WHERE slug = '<slug>')
+GROUP BY status;
+SQL
+```
+
+Expected: a mix of `PUBLISHED` chunks, zero `UNCLASSIFIED`.
+
+Test a retrieval query via the coaching assistant at `https://web.mentolder.de/portal/coaching`.
+
+---
+
+## Common issues
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `classify` hangs or times out | GPU host unreachable | Check `task workspace:logs ENV=mentolder -- llm-router`; use Path C (local Ollama) |
+| `401` from classify | Anthropic API key invalid | Rotate key (see `secret-rotation` skill) |
+| `MixedEmbeddingModelError` | Cross-model query attempted | Never mix bge-m3 and voyage collections in same query |
+| TEI returns 503 | GPU host not running or overloaded | SSH to GPU host, check Ollama process |
+| Chunks stuck at `UNCLASSIFIED` | classify never ran | Run `task coaching:classify -- --slug=<slug>` |
+| Drafts page shows 0 items | All classified but not yet in DRAFT | Check `classify` exit code; re-run with `--slug` |
+| Ingestion fails with encoding error | PDF has unusual encoding | Try converting to text first with `pdftotext` |
+
+---
+
+## Post-Execution: Mishap Report
+
+After completing all steps in this skill, invoke `mishap-tracker` with your
+accumulated `MISHAP_LOG`. If no mishaps were found, `mishap-tracker` exits
+cleanly with "No mishaps found."

--- a/.claude/skills/db-migration/SKILL.md
+++ b/.claude/skills/db-migration/SKILL.md
@@ -1,0 +1,221 @@
+---
+name: db-migration
+description: Use when adding new tables, columns, indexes, schemas, or roles to the shared PostgreSQL database — guides through writing migration SQL, applying to both clusters, re-granting permissions, verifying schema, and updating the ER diagram. Prevents the common mistake of applying only to one cluster.
+---
+
+> **Mishap Tracking:** As you execute this skill, maintain a running `MISHAP_LOG`.
+> For every anomaly, unexpected state, broken component, security concern, or
+> configuration drift you notice — even if unrelated to the current task — add
+> an entry with: `type` (broken/degraded/suspicious/security/drift), `title`,
+> `description`, and `component`. Invoke `mishap-tracker` at the very end.
+
+# db-migration
+
+Safe database schema migration across both production clusters.
+
+---
+
+## ⚠️ Both clusters are independent
+
+mentolder and korczewski each have their own `shared-db`. A migration applied to one cluster does **not** propagate to the other. Always apply to both explicitly.
+
+---
+
+## Phase 1: Write the migration
+
+Create a migration SQL file in `scripts/` or `scripts/datamodel/`:
+
+```bash
+# Example: scripts/datamodel/0042_add_coaching_sessions.sql
+```
+
+Migration conventions:
+- Use `IF NOT EXISTS` for CREATE TABLE/INDEX/SCHEMA — makes migrations idempotent
+- Use `IF EXISTS` for DROP statements
+- Always wrap in a transaction:
+
+```sql
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS coaching.sessions (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id TEXT NOT NULL,
+    started_at TIMESTAMPTZ DEFAULT now(),
+    ended_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_coaching_sessions_user_id
+    ON coaching.sessions(user_id);
+
+COMMIT;
+```
+
+- Never `DROP TABLE` in a migration that runs on prod without a confirmed backup
+- For destructive changes: always `task workspace:backup` first
+
+---
+
+## Phase 2: Test on dev (if available)
+
+```bash
+task workspace:psql ENV=dev -- website < scripts/datamodel/<migration>.sql
+```
+
+Verify the result:
+```bash
+task workspace:psql ENV=dev -- website <<'SQL'
+\d coaching.sessions
+SQL
+```
+
+---
+
+## Phase 3: Apply to mentolder
+
+```bash
+# Backup first for any destructive or large migration
+task workspace:backup
+
+# Apply
+task workspace:psql ENV=mentolder -- website < scripts/datamodel/<migration>.sql
+
+# Verify
+task workspace:psql ENV=mentolder -- website <<'SQL'
+\d <schema>.<table>
+SQL
+```
+
+---
+
+## Phase 4: Apply to korczewski
+
+```bash
+# Apply
+task workspace:psql ENV=korczewski -- website < scripts/datamodel/<migration>.sql
+
+# Verify
+task workspace:psql ENV=korczewski -- website <<'SQL'
+\d <schema>.<table>
+SQL
+```
+
+---
+
+## Phase 5: Re-grant permissions
+
+After any schema or table creation, service roles may need explicit grants. Run:
+
+```bash
+task workspace:fix-tickets-grants ENV=mentolder
+task workspace:fix-tickets-grants ENV=korczewski
+```
+
+For custom schemas or roles, check what grants the relevant services expect:
+
+```bash
+task workspace:psql ENV=mentolder -- website <<'SQL'
+-- Check existing grants on a table
+SELECT grantee, privilege_type
+FROM information_schema.role_table_grants
+WHERE table_schema = '<schema>' AND table_name = '<table>';
+SQL
+```
+
+If a service role (e.g. `website`, `brett`, `tracking`) needs access to the new table:
+```sql
+GRANT SELECT, INSERT, UPDATE, DELETE ON <schema>.<table> TO <role>;
+GRANT USAGE ON SEQUENCE <schema>.<table>_id_seq TO <role>;  -- if using sequences
+```
+
+Apply the grant to both clusters.
+
+---
+
+## Phase 6: Update ER diagram
+
+```bash
+task db:diagram
+```
+
+Commit the updated diagram file alongside the migration SQL.
+
+---
+
+## Phase 7: Commit migration
+
+```bash
+git add scripts/datamodel/<migration>.sql
+git add <diagram-output-path>
+git commit -m "chore(db): add <table/column description> [<ticket-id>]"
+```
+
+---
+
+## Common patterns
+
+### Add a column with a default
+
+```sql
+ALTER TABLE coaching.chunks
+    ADD COLUMN IF NOT EXISTS reviewed_by TEXT;
+
+ALTER TABLE coaching.chunks
+    ADD COLUMN IF NOT EXISTS quality_score FLOAT DEFAULT 0.0 NOT NULL;
+```
+
+### Create a new schema with role access
+
+```sql
+CREATE SCHEMA IF NOT EXISTS analytics;
+
+GRANT USAGE ON SCHEMA analytics TO website;
+ALTER DEFAULT PRIVILEGES IN SCHEMA analytics
+    GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO website;
+```
+
+### Create a view
+
+```sql
+CREATE OR REPLACE VIEW bachelorprojekt.v_coaching_summary AS
+SELECT ...;
+
+GRANT SELECT ON bachelorprojekt.v_coaching_summary TO website;
+```
+
+### Migration already applied (idempotency check)
+
+```sql
+-- Check if column exists before adding
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'coaching' AND table_name = 'chunks'
+          AND column_name = 'quality_score'
+    ) THEN
+        ALTER TABLE coaching.chunks ADD COLUMN quality_score FLOAT DEFAULT 0.0;
+    END IF;
+END $$;
+```
+
+---
+
+## Rollback
+
+PostgreSQL DDL is transactional — a `BEGIN`/`COMMIT` wrapped migration that errors is automatically rolled back. For already-applied migrations:
+
+```sql
+BEGIN;
+ALTER TABLE coaching.chunks DROP COLUMN IF EXISTS quality_score;
+COMMIT;
+```
+
+For dropped tables: restore from backup (`task workspace:restore -- <db> <timestamp>`).
+
+---
+
+## Post-Execution: Mishap Report
+
+After completing all steps in this skill, invoke `mishap-tracker` with your
+accumulated `MISHAP_LOG`. If no mishaps were found, `mishap-tracker` exits
+cleanly with "No mishaps found."

--- a/.claude/skills/dev-flow-plan/SKILL.md
+++ b/.claude/skills/dev-flow-plan/SKILL.md
@@ -463,6 +463,14 @@ Rufe `commit-commands:commit-push-pr` auf.
 - Titel: `chore(<scope>): <kurze-beschreibung>`
 - Body: kurzes `## Summary` (1-2 Bullets) + `## Test plan` (was du gelaufen bist)
 
+> **Fallback** (falls `commit-commands` nicht verfügbar — z.B. Plugin deinstalliert):
+> ```bash
+> git add -p  # nur relevante Dateien
+> git commit -m "chore(<scope>): <kurze-beschreibung>"
+> git push -u origin chore/<slug>
+> gh pr create --title "chore(<scope>): <kurze-beschreibung>" --body "## Summary\n- ...\n\n## Test plan\n- ..."
+> ```
+
 ### Schritt 6: Auto-Merge wenn CI grün
 
 ### Schritt 7: Post-Merge Deploy

--- a/.claude/skills/incident-response/SKILL.md
+++ b/.claude/skills/incident-response/SKILL.md
@@ -1,0 +1,206 @@
+---
+name: incident-response
+description: Use when something is broken or degraded in production — guides through triage, ticket creation, root cause analysis, fix or rollback, verification, and post-mortem. Triggers on: "something is broken", "X is down", "users can't log in", "pod is crashing", 500 errors, health check failures.
+---
+
+> **Mishap Tracking:** As you execute this skill, maintain a running `MISHAP_LOG`.
+> For every anomaly, unexpected state, broken component, security concern, or
+> configuration drift you notice — even if unrelated to the current task — add
+> an entry with: `type` (broken/degraded/suspicious/security/drift), `title`,
+> `description`, and `component`. Invoke `mishap-tracker` at the very end.
+
+# incident-response
+
+Structured production incident triage for the Bachelorprojekt platform.
+
+---
+
+## Phase 1: Scope the incident (< 2 min)
+
+Answer these before doing anything else:
+
+1. **Which service(s)?** (Keycloak, Nextcloud, website, brett, arena, vaultwarden, docs, livekit, shared-db…)
+2. **Which cluster(s)?** mentolder / korczewski / both
+3. **Since when?** (last known good deploy, git log, or user report)
+4. **Blast radius?** All users / specific users / specific feature only
+
+Ask the user if any of these are unknown.
+
+---
+
+## Phase 2: Create an incident ticket
+
+```bash
+PGPOD=$(kubectl get pod -n workspace --context mentolder \
+  -l app=shared-db -o name | head -1)
+
+TICKET_RESULT=$(kubectl exec "$PGPOD" -n workspace --context mentolder -- \
+  psql -U website -d website -At -c \
+  "INSERT INTO tickets.tickets (type, brand, title, description, status, severity, priority)
+   VALUES (
+     'bug', 'mentolder',
+     'Incident: <one-line description>',
+     'Affected: <services>\nCluster: <env>\nSince: <time>\nSymptoms: <what users see>',
+     'in_progress',
+     '<critical|major|minor>',
+     'hoch'
+   )
+   RETURNING external_id, id;")
+
+TICKET_EXT_ID=$(echo "$TICKET_RESULT" | cut -d'|' -f1)
+TICKET_UUID=$(echo "$TICKET_RESULT"   | cut -d'|' -f2)
+echo "Ticket $TICKET_EXT_ID → https://web.mentolder.de/admin/bugs"
+```
+
+Use severity `critical` if users cannot log in or data is at risk. Use `major` for degraded functionality. Use `minor` for cosmetic issues or single-user impact.
+
+---
+
+## Phase 3: Diagnose
+
+### Pod status
+
+```bash
+task workspace:status ENV=mentolder
+task workspace:status ENV=korczewski  # if both clusters affected
+```
+
+Look for: `CrashLoopBackOff`, `Error`, `Pending`, `OOMKilled`, low `READY` counts.
+
+### Logs
+
+```bash
+task workspace:logs ENV=<env> -- <service>
+# For website pod:
+task workspace:logs ENV=<env> -- website
+# For shared-db:
+task workspace:logs ENV=<env> -- shared-db
+```
+
+Common error signatures:
+| Log pattern | Likely cause |
+|---|---|
+| `password authentication failed` | DB password drift → use `secret-rotation` Type A |
+| `ECONNREFUSED` / `connection refused` | Service dependency not running or wrong port |
+| `certificate verify failed` | TLS cert expired or wrong issuer |
+| `401 Unauthorized` from Keycloak | OIDC client secret rotated without service update |
+| `OOMKilled` | Memory limit too low — check pod resource requests |
+| `ImagePullBackOff` | Image not pushed to registry or wrong tag |
+| `cannot connect to cluster` | Keycloak/DB not yet ready — wait and retry |
+
+### Events
+
+```bash
+kubectl get events -n workspace --context <ctx> --sort-by='.lastTimestamp' | tail -30
+```
+
+### Recent deploys
+
+```bash
+git log --oneline -10
+```
+
+Did the incident start right after a deploy? If yes, a rollback may be faster than a fix.
+
+---
+
+## Phase 4: Decide — fix or rollback?
+
+| Situation | Decision |
+|---|---|
+| Introduced by the last deploy, no DB migration | **Rollback** — faster, lower risk |
+| Config drift or secret rotation issue | **Fix in place** — rollback won't help |
+| DB schema change involved | **Fix only** — never roll back a migration |
+| Unknown cause | **Diagnose further** before deciding |
+
+### Rollback path
+
+```bash
+# Find the last good image digest from git log
+PREV_SHA=$(git log --oneline -5 | awk 'NR==2{print $1}')
+
+# For website: redeploy previous commit's image
+# (CI builds images tagged with commit SHA — check ghcr.io)
+kubectl set image deployment/website website=ghcr.io/paddione/workspace-website:<PREV_SHA> \
+  -n <WORKSPACE_NS> --context <CTX>
+
+# Verify
+task workspace:status ENV=<env>
+```
+
+For full cluster rollback:
+```bash
+git checkout <PREV_SHA> -- k3d/ prod/ prod-mentolder/ prod-korczewski/
+task workspace:deploy ENV=<env>
+git checkout HEAD -- k3d/ prod/ prod-mentolder/ prod-korczewski/
+```
+
+### Fix path
+
+Open a `fix/<slug>` branch via `dev-flow-plan` Fix-Pfad with the incident ticket ID. Implement, PR, merge, deploy.
+
+---
+
+## Phase 5: Verify resolution
+
+```bash
+# All pods healthy
+task workspace:status ENV=<env>
+
+# Health checks pass
+task workspace:verify ENV=<env>
+
+# SSO login works (manual browser test)
+# open https://web.<domain>, log in, verify core flow
+
+# No new errors in logs for 2 min
+task workspace:logs ENV=<env> -- <affected-service>
+```
+
+---
+
+## Phase 6: Close ticket + post-mortem note
+
+```bash
+PGPOD=$(kubectl get pod -n workspace --context mentolder \
+  -l app=shared-db -o name | head -1)
+
+kubectl exec "$PGPOD" -n workspace --context mentolder -- \
+  psql -U website -d website -c \
+  "UPDATE tickets.tickets
+     SET status = 'done', resolution = 'fixed', done_at = now(),
+         notes = COALESCE(notes || E'\n\n', '') ||
+           '[incident-response $(date +%Y-%m-%d)] Root cause: <1 sentence>. Fix: <1 sentence>. Duration: <X> min.'
+   WHERE external_id = '$TICKET_EXT_ID';"
+```
+
+Post-mortem note must answer:
+1. **What broke** — the specific component and failure mode
+2. **Why it broke** — root cause (config drift, bad deploy, secret mismatch, etc.)
+3. **How it was fixed** — PR number or command run
+4. **How to prevent it** — action item (skill gap, test, alert, etc.)
+
+If a skill gap contributed to the incident, open a chore ticket to close it.
+
+---
+
+## Quick-reference: common service fixes
+
+| Symptom | Quick fix |
+|---|---|
+| Keycloak not starting | `task workspace:restart ENV=<env> -- keycloak` |
+| DB not accepting connections | `task workspace:db:start ENV=<env>` |
+| Website 503 | Check website pod + ingress: `kubectl get ingress -n website-ns --context <ctx>` |
+| Nextcloud 500 | Check Nextcloud + shared-db connectivity |
+| Talk not connecting | Check HPB + Janus + coturn (`task workspace:logs ENV=<env> -- talk-hpb`) |
+| LiveKit ICE failure | Check DNS pin + ufw rules: `task livekit:dns-pin ENV=<env>` — use `livekit-setup` skill |
+| Secret-related 401/403 | Use `secret-rotation` skill |
+| Keycloak realm drift | Use `keycloak-realm-sync` skill |
+
+---
+
+## Post-Execution: Mishap Report
+
+After completing all steps in this skill, invoke `mishap-tracker` with your
+accumulated `MISHAP_LOG`. If no mishaps were found, `mishap-tracker` exits
+cleanly with "No mishaps found."

--- a/.claude/skills/keycloak-realm-sync/SKILL.md
+++ b/.claude/skills/keycloak-realm-sync/SKILL.md
@@ -1,0 +1,204 @@
+---
+name: keycloak-realm-sync
+description: Use when Keycloak realm configuration needs to be reconciled — OIDC client settings, realm JSON changes, group mappings, mapper configuration, or SSO login failures that stem from realm drift. Covers running keycloak:sync, post-sync verification, and testing SSO flows.
+---
+
+> **Mishap Tracking:** As you execute this skill, maintain a running `MISHAP_LOG`.
+> For every anomaly, unexpected state, broken component, security concern, or
+> configuration drift you notice — even if unrelated to the current task — add
+> an entry with: `type` (broken/degraded/suspicious/security/drift), `title`,
+> `description`, and `component`. Invoke `mishap-tracker` at the very end.
+
+# keycloak-realm-sync
+
+Reconcile Keycloak realm configuration from the checked-in realm JSON files. Covers both clusters.
+
+---
+
+## When to use this skill
+
+- SSO login is broken or redirecting to wrong URLs
+- A new OIDC client was added/updated in the realm JSON and needs pushing
+- Group memberships or attribute mappers are out of sync
+- After a fresh workspace deploy (realm may not match the latest JSON)
+- After Keycloak pod restart that cleared in-memory state
+
+---
+
+## Realm JSON locations
+
+| Env | File |
+|---|---|
+| dev | `k3d/realm-workspace-dev.json` |
+| mentolder | `prod-mentolder/realm-workspace-mentolder.json` |
+| korczewski | `prod-korczewski/realm-workspace-korczewski.json` |
+
+**Never edit realm state directly in the Keycloak admin UI without also updating the JSON.** The sync overwrites UI changes that aren't in the JSON.
+
+---
+
+## Phase 1: Pre-sync check
+
+```bash
+# Confirm Keycloak is running and reachable
+task workspace:status ENV=<env>
+# Look for keycloak pod: 1/1 Running
+
+# Tail Keycloak logs — watch for errors before touching realm config
+task workspace:logs ENV=<env> -- keycloak
+```
+
+If Keycloak is not running, start it first:
+```bash
+task workspace:restart ENV=<env> -- keycloak
+# Wait ~60s for startup
+task workspace:logs ENV=<env> -- keycloak
+# Wait for: "Keycloak X.Y.Z on JVM ... started"
+```
+
+---
+
+## Phase 2: Edit realm JSON (if needed)
+
+If you're making realm config changes (not just re-syncing):
+
+1. Edit the appropriate realm JSON file
+2. Key sections to know:
+
+```json
+// OIDC client — check redirectUris and webOrigins
+"clients": [
+  {
+    "clientId": "website",
+    "redirectUris": ["https://web.<domain>/*"],
+    "webOrigins": ["https://web.<domain>"]
+  }
+]
+
+// Protocol mappers — for passing user attributes to services
+"protocolMappers": [...]
+
+// Groups — for access control (e.g. /dev-access for dev cluster)
+"groups": [...]
+
+// Required actions / browser flows
+"browserFlow": "browser"
+```
+
+3. Validate JSON syntax:
+```bash
+python3 -c "import json; json.load(open('prod-mentolder/realm-workspace-mentolder.json'))" && echo "valid"
+```
+
+---
+
+## Phase 3: Run sync
+
+```bash
+task keycloak:sync ENV=mentolder
+# For korczewski:
+task keycloak:sync ENV=korczewski
+```
+
+The sync script (`scripts/keycloak-sync.sh`) uses the Keycloak admin REST API to:
+- Import/update the realm from the JSON file
+- Reconcile clients, scopes, and mappers
+- Apply role and group structure
+
+Watch for errors in the output. Common failures:
+| Error | Cause | Fix |
+|---|---|---|
+| `401 Unauthorized` | Admin credentials wrong or Keycloak not ready | Check `keycloak-admin` secret, wait for pod |
+| `404 Not Found` on realm | Realm was deleted; full import needed | Check Keycloak admin UI |
+| `409 Conflict` on client | Client already exists with conflicting ID | Update instead of create — check script logic |
+
+---
+
+## Phase 4: Ensure protocol mappers
+
+```bash
+bash scripts/keycloak-ensure-mappers.sh <env>
+```
+
+This applies any mapper definitions that `keycloak:sync` doesn't automatically handle (e.g. custom claim mappers for the website JWT). Run after every realm sync.
+
+---
+
+## Phase 5: Verify OIDC clients
+
+For each service that uses SSO, confirm the client config is correct:
+
+```bash
+# List all clients
+task workspace:psql ENV=<env> -- keycloak
+```
+
+Or use the Keycloak admin UI at `https://auth.<domain>/admin`:
+
+| Service | Client ID | Check |
+|---|---|---|
+| Website | `website` | redirect URIs include `https://web.<domain>/*` |
+| Nextcloud | `nextcloud` | redirect URIs, client secret matches `nextcloud-oidc-*.php` |
+| Vaultwarden | `vaultwarden` | redirect URIs include `https://vault.<domain>/identity/connect/oidc-signin` |
+| DocuSeal | `docuseal` | redirect URIs correct |
+| Tracking | `tracking` | redirect URIs correct |
+| Claude Code | `claude-code` | redirect URIs correct |
+| Arena | `arena` | redirect URIs for both `web.mentolder.de` and `web.korczewski.de` |
+
+---
+
+## Phase 6: Test SSO flow
+
+Verify login end-to-end for the most critical services:
+
+```bash
+# Use Playwright for automated SSO check
+# Or manually:
+# 1. Open https://web.<domain> in incognito
+# 2. Click "Anmelden" / login
+# 3. Verify redirect to auth.<domain>
+# 4. Log in with test credentials
+# 5. Verify redirect back and successful session
+```
+
+For Nextcloud specifically:
+```bash
+# Check OIDC config is mounted
+kubectl exec -n <WORKSPACE_NS> --context <ctx> \
+  deployment/nextcloud -- cat /var/www/html/config/oidc.php
+```
+
+---
+
+## Phase 7: Check group memberships
+
+If the sync changed group structure, verify that users still have the right memberships via Keycloak admin UI:
+- `https://auth.<domain>/admin` → Users → select user → Groups tab
+
+Key groups:
+- `/dev-access` — required for dev.mentolder.de access (enforced by oauth2-proxy)
+- Any custom groups for role-based access
+
+---
+
+## Common post-sync issues
+
+**Website login loop after sync:**
+- Usually wrong `redirectUris` or `webOrigins` in the `website` client
+- Check CORS settings: `webOrigins` must include the website domain exactly
+
+**Nextcloud OIDC error after sync:**
+- The `nextcloud-oidc-*.php` file is applied as a ConfigMap — if its client secret was reset, re-seal and redeploy
+- Check: `task workspace:logs ENV=<env> -- nextcloud | grep -i oidc`
+
+**"Invalid client secret" from any service:**
+- The client secret in the realm JSON may not match the service's SealedSecret
+- Use `secret-rotation` skill to re-align
+
+---
+
+## Post-Execution: Mishap Report
+
+After completing all steps in this skill, invoke `mishap-tracker` with your
+accumulated `MISHAP_LOG`. If no mishaps were found, `mishap-tracker` exits
+cleanly with "No mishaps found."

--- a/.claude/skills/knowledge-reindex/SKILL.md
+++ b/.claude/skills/knowledge-reindex/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: knowledge-reindex
+description: Use when re-indexing knowledge collections after source data changes — covers task knowledge:reindex, SOURCE options, embedding model selection, pre-checks for LLM availability, and failure mode handling. Critical: bge-m3 and voyage collections fail closed and must never be mixed.
+---
+
+> **Mishap Tracking:** As you execute this skill, maintain a running `MISHAP_LOG`.
+> For every anomaly, unexpected state, broken component, security concern, or
+> configuration drift you notice — even if unrelated to the current task — add
+> an entry with: `type` (broken/degraded/suspicious/security/drift), `title`,
+> `description`, and `component`. Invoke `mishap-tracker` at the very end.
+
+# knowledge-reindex
+
+Re-index knowledge collections in the mentolder platform.
+
+---
+
+## ⚠️ Embedding model isolation — read this first
+
+The knowledge system uses **two separate embedding spaces** that are never interchangeable:
+
+| Model | Service | Used for |
+|---|---|---|
+| `bge-m3` | TEI on `llm-gateway-embed:8081` | bge-m3 collections — requires GPU host running |
+| `voyage-multilingual-2` | Voyage AI cloud API | voyage collections — requires `VOYAGE_API_KEY` |
+
+**These fail closed.** If TEI is down, `bge-m3` collections return errors — they do not fall back to Voyage. If you see `MixedEmbeddingModelError`, a cross-model query was attempted somewhere; find and fix the collection config, not the query.
+
+Never "fix" a model mismatch by switching which model a collection uses after it has been indexed — all existing vectors would need to be discarded and re-indexed.
+
+---
+
+## Phase 1: Pre-checks
+
+### Check which collections exist and their models
+
+```bash
+task workspace:psql ENV=mentolder -- website <<'SQL'
+SELECT collection_name, embedding_model, document_count, updated_at::date
+FROM knowledge.collections
+ORDER BY collection_name;
+SQL
+```
+
+### Check LLM availability
+
+For `bge-m3` collections:
+```bash
+# Is the GPU host reachable?
+task workspace:logs ENV=mentolder -- llm-router | tail -20
+
+# Direct TEI health check:
+kubectl exec -n workspace --context mentolder \
+  deployment/llm-gateway -- curl -s http://localhost:8081/health
+```
+
+For `voyage-multilingual-2` collections:
+```bash
+# Voyage uses an API key — check it's present in the SealedSecret
+kubectl get secret workspace-secrets -n workspace --context mentolder \
+  -o jsonpath='{.data.VOYAGE_API_KEY}' | base64 -d | wc -c
+# Should return > 10 (non-empty key)
+```
+
+If the required embedding service is unavailable, **do not run reindex** — it will index 0 documents and silently destroy the existing collection content.
+
+---
+
+## Phase 2: Run reindex
+
+```bash
+# Reindex specific source type:
+task knowledge:reindex ENV=mentolder SOURCE=prs
+task knowledge:reindex ENV=mentolder SOURCE=markdown
+task knowledge:reindex ENV=mentolder SOURCE=bugs
+task knowledge:reindex ENV=mentolder SOURCE=all
+
+# Apply to korczewski if that cluster also has a knowledge service:
+task knowledge:reindex ENV=korczewski SOURCE=<source>
+```
+
+`SOURCE` values:
+| Value | What it indexes |
+|---|---|
+| `prs` | GitHub PR descriptions and comments |
+| `markdown` | Docs and markdown files in the repo |
+| `bugs` | Ticket database (tickets.tickets) |
+| `all` | All of the above |
+
+---
+
+## Phase 3: Verify
+
+After reindex, check document counts increased (or stayed the same for unchanged sources):
+
+```bash
+task workspace:psql ENV=mentolder -- website <<'SQL'
+SELECT collection_name, document_count, updated_at
+FROM knowledge.collections
+ORDER BY updated_at DESC;
+SQL
+```
+
+Test a retrieval query via the coaching/knowledge assistant UI to confirm results are returning.
+
+---
+
+## Phase 4: Failure handling
+
+### "0 documents indexed"
+
+Cause: TEI or Voyage API was unavailable during index, so the collection was cleared but not repopulated.
+
+```bash
+# Immediately stop — do not commit the empty state
+# 1. Restore from backup:
+task workspace:restore -- website <latest-timestamp>
+
+# 2. Fix the embedding service issue
+
+# 3. Re-run reindex only after the service is healthy
+```
+
+### `MixedEmbeddingModelError`
+
+A query is mixing vectors from `bge-m3` and `voyage` collections. This is a code bug — find the query that spans both collections and split it.
+
+### TEI returns 503
+
+GPU host is unreachable or Ollama is not running. SSH to the GPU host and check:
+```bash
+ssh <gpu-host-ip> "systemctl status ollama || docker ps | grep tei"
+```
+
+TEI (Text Embeddings Inference) runs as a Docker container on the GPU host. Restart if needed:
+```bash
+ssh <gpu-host-ip> "docker restart tei-embed"
+```
+
+### `VOYAGE_API_KEY` invalid
+
+Rotate the key in `environments/.secrets/mentolder.yaml`, re-seal, apply:
+```bash
+task env:seal ENV=mentolder
+task secrets:sync
+```
+
+---
+
+## When to reindex
+
+| Event | Reindex needed? |
+|---|---|
+| New PRs merged | Yes — `SOURCE=prs` |
+| Docs content updated (`k3d/docs-content/`) | Yes — `SOURCE=markdown` |
+| New tickets/bugs added | Yes — `SOURCE=bugs` (or auto via CronJob) |
+| Coaching book ingested | No — coaching:ingest handles its own embedding |
+| Workspace redeployed | No — collections persist in shared-db |
+| shared-db restored from backup | Only if collection data was in the restored DB |
+
+---
+
+## Post-Execution: Mishap Report
+
+After completing all steps in this skill, invoke `mishap-tracker` with your
+accumulated `MISHAP_LOG`. If no mishaps were found, `mishap-tracker` exits
+cleanly with "No mishaps found."

--- a/.claude/skills/livekit-setup/SKILL.md
+++ b/.claude/skills/livekit-setup/SKILL.md
@@ -1,0 +1,191 @@
+---
+name: livekit-setup
+description: Use when setting up, repairing, or debugging LiveKit — covers DNS pinning, ufw firewall rules, node affinity, ICE failure diagnosis, and stream/recording verification. Triggers on: LiveKit ICE fails, stream not working, RTMP ingestion broken, recording failing, livekit pod issues.
+---
+
+> **Mishap Tracking:** As you execute this skill, maintain a running `MISHAP_LOG`.
+> For every anomaly, unexpected state, broken component, security concern, or
+> configuration drift you notice — even if unrelated to the current task — add
+> an entry with: `type` (broken/degraded/suspicious/security/drift), `title`,
+> `description`, and `component`. Invoke `mishap-tracker` at the very end.
+
+# livekit-setup
+
+Setup and repair guide for the LiveKit WebRTC streaming stack on mentolder.
+
+**mentolder-only:** LiveKit runs on the mentolder cluster only (`livekit.mentolder.de`, `stream.mentolder.de`). The arena-server on korczewski uses a separate WebRTC path.
+
+---
+
+## Architecture quick-reference
+
+| Component | Runs on | Note |
+|---|---|---|
+| `livekit-server` | `gekko-hetzner-3` (46.225.125.59) | `hostNetwork: true`, pinned via `nodeAffinity` |
+| `livekit-ingress` | `gekko-hetzner-3` | RTMP intake for OBS |
+| `livekit-egress` | any node | Recording to PVC |
+| DNS `livekit.<domain>` | → `46.225.125.59` | Must pin — browsers hit random node otherwise |
+| DNS `stream.<domain>` | → `46.225.125.59` | RTMP also needs pin-node IP |
+
+**Why node pinning matters:** `hostNetwork: true` binds ICE candidates to the host's IP. If a browser connects to a non-LiveKit node via DNS, ICE silently fails (~66% of the time with 3 nodes). The DNS pin forces all connections to the node where LiveKit actually listens.
+
+---
+
+## Phase 1: Check current status
+
+```bash
+task livekit:status ENV=mentolder
+```
+
+Expected output:
+- `livekit-server` pod: `1/1 Running` on `gekko-hetzner-3`
+- `livekit-ingress` pod: `1/1 Running` on `gekko-hetzner-3`
+- `livekit.mentolder.de` and `stream.mentolder.de` DNS → `46.225.125.59`
+
+---
+
+## Phase 2: DNS pinning
+
+LiveKit and stream DNS **must** point to the pin node (`46.225.125.59`). Verify:
+
+```bash
+dig livekit.mentolder.de +short
+dig stream.mentolder.de +short
+```
+
+Both should return `46.225.125.59`. If not:
+
+```bash
+# Print the API calls that would fix DNS (dry-run)
+task livekit:dns-pin ENV=mentolder
+
+# Apply them:
+task livekit:dns-pin ENV=mentolder APPLY=true
+```
+
+`livekit:dns-pin` updates the ipv64 DDNS A records for `livekit.<domain>` and `stream.<domain>` via the ipv64 API. It also covers `turn.<domain>` (used by Janus coturn).
+
+After changing DNS, allow up to 60s for propagation before testing.
+
+---
+
+## Phase 3: Firewall rules
+
+The Hetzner host firewall blocks all ports except 80/443 by default. LiveKit needs additional ports open on `gekko-hetzner-3`:
+
+| Protocol | Ports | Purpose |
+|---|---|---|
+| TCP | 7880 | LiveKit signaling (WebSocket) |
+| TCP | 7881 | RTMP → LiveKit ingress |
+| UDP | 50000-60000 | ICE media (browser ↔ server) |
+| UDP | 30000-40000 | Ingress/egress media |
+
+Check if ports are open:
+```bash
+ssh root@gekko-hetzner-3 "ufw status numbered | grep -E '7880|7881|50000|30000'"
+```
+
+Open missing ports:
+```bash
+task livekit:firewall-open NODE=46.225.125.59
+```
+
+This SSHes to the node and runs the ufw rules. Requires SSH access to `root@gekko-hetzner-3`.
+
+**Note:** Janus TURN uses `20000-20200/udp` — this range is NOT included in `livekit:firewall-open`. If coturn is broken, open it separately:
+```bash
+ssh root@gekko-hetzner-3 "ufw allow 20000:20200/udp && ufw reload"
+```
+
+---
+
+## Phase 4: Node affinity verification
+
+`livekit-server` must run on `gekko-hetzner-3`. Check:
+
+```bash
+kubectl get pod -n workspace --context mentolder \
+  -l app=livekit-server -o wide
+```
+
+If it's on a different node, the `nodeAffinity` in `k3d/livekit-server.yaml` is not matching. Check the node labels:
+
+```bash
+kubectl get nodes --context mentolder --show-labels | grep gekko-hetzner-3
+```
+
+The affinity selector requires a specific label. If the label is missing:
+```bash
+kubectl label node gekko-hetzner-3 \
+  livekit-pin-node=true --context mentolder
+```
+
+---
+
+## Phase 5: Test the stream
+
+### RTMP/OBS path
+
+1. Open `https://web.mentolder.de/admin/stream`
+2. Create a room and copy the stream key
+3. In OBS: Settings → Stream → Server: `rtmp://stream.mentolder.de/live`, Key: `<stream-key>`
+4. Start streaming
+5. Open `https://web.mentolder.de/portal/stream` to verify viewer side
+
+### Browser WebRTC path
+
+The `Room.connect()` call in the website JavaScript **must run from a user gesture** (button click). Chrome blocks `AudioContext` creation otherwise — the room connects but audio is silently muted.
+
+Common debugging:
+```bash
+# Check livekit-server logs for connection attempts
+task livekit:logs ENV=mentolder
+
+# Check ingress logs (RTMP)
+task livekit:logs ENV=mentolder -- ingress
+
+# Check egress logs (recording)
+task livekit:logs ENV=mentolder -- egress
+
+# List recordings in PVC
+task livekit:recordings ENV=mentolder
+```
+
+---
+
+## Phase 6: Recording
+
+Recordings are saved as MP4 to the egress PVC. To list:
+```bash
+task livekit:recordings ENV=mentolder
+```
+
+If recording is failing, check `livekit-egress` logs:
+```bash
+task livekit:logs ENV=mentolder -- egress
+```
+
+Common egress failure: PVC out of space. Check:
+```bash
+kubectl exec -n workspace --context mentolder \
+  deployment/livekit-egress -- df -h /recordings
+```
+
+---
+
+## Emergency: force-close a room
+
+If a stream is stuck (e.g. OBS crashed but room is still "live"):
+```bash
+task livekit:end-stream ENV=mentolder
+```
+
+This restarts `livekit-server`, which closes all active rooms.
+
+---
+
+## Post-Execution: Mishap Report
+
+After completing all steps in this skill, invoke `mishap-tracker` with your
+accumulated `MISHAP_LOG`. If no mishaps were found, `mishap-tracker` exits
+cleanly with "No mishaps found."

--- a/.claude/skills/new-environment/SKILL.md
+++ b/.claude/skills/new-environment/SKILL.md
@@ -1,0 +1,205 @@
+---
+name: new-environment
+description: Use when setting up a new cluster/environment from scratch — guides through the mandatory bring-up order for sealed secrets, cert-manager, and workspace deploy. Also covers scaffolding a new environments/*.yaml from schema. Prevents the silent credential-overwrite footgun that occurs when steps are run out of order.
+---
+
+> **Mishap Tracking:** As you execute this skill, maintain a running `MISHAP_LOG`.
+> For every anomaly, unexpected state, broken component, security concern, or
+> configuration drift you notice — even if unrelated to the current task — add
+> an entry with: `type` (broken/degraded/suspicious/security/drift), `title`,
+> `description`, and `component`. Invoke `mishap-tracker` at the very end.
+
+# new-environment
+
+Bring up a new Kubernetes environment from scratch. This skill enforces the mandatory step ordering that prevents production credentials from being silently overwritten.
+
+---
+
+## ⚠️ Mandatory ordering — never skip steps
+
+The ordering below is not optional. Specifically:
+- `workspace:deploy` **must not** run before `env:seal` — it would apply dev placeholder secrets
+- `env:seal` **must not** run before `env:fetch-cert` after a cluster reset — it uses the wrong keypair
+- `cert-manager` CRDs **must** exist before `workspace:deploy` — ClusterIssuer resource will fail otherwise
+
+---
+
+## Step 0: Scaffold environment config
+
+If the environment YAML doesn't exist yet:
+
+```bash
+# Create from schema template
+task env:init ENV=<new-env-name>
+
+# Edit the scaffolded file — fill in required fields:
+#   PROD_DOMAIN, BRAND_NAME, CONTACT_EMAIL, ENV_CONTEXT (kubectl context name),
+#   ENV_OVERLAY (e.g. prod-mentolder), BRAND_ID, SMTP settings
+$EDITOR environments/<new-env-name>.yaml
+
+# Validate against schema
+task env:validate ENV=<new-env-name>
+```
+
+Required `environments/<env>.yaml` fields — check `environments/schema.yaml` for the full list:
+- `PROD_DOMAIN` — e.g. `mentolder.de`
+- `BRAND_NAME` — e.g. `mentolder`
+- `BRAND_ID` — e.g. `mentolder`
+- `ENV_CONTEXT` — kubectl context name (matches `kubectl config get-contexts`)
+- `ENV_OVERLAY` — kustomize overlay path (e.g. `prod-mentolder`)
+- `WORKSPACE_NAMESPACE` — e.g. `workspace` (mentolder) or `workspace-korczewski` (korczewski)
+
+---
+
+## Step 1: Install Sealed Secrets controller
+
+The controller must exist **before** any SealedSecret resource is applied.
+
+```bash
+task sealed-secrets:install ENV=<env>
+task sealed-secrets:status  ENV=<env>
+```
+
+Wait for the controller pod to be `Running` before proceeding:
+```bash
+kubectl get pod -n kube-system --context <ctx> | grep sealed-secrets
+```
+
+---
+
+## Step 2: Fetch cluster sealing certificate
+
+The sealing cert is unique to each cluster's sealed-secrets keypair.
+
+```bash
+task env:fetch-cert ENV=<env>
+# Writes: environments/certs/<env>.pem
+```
+
+Commit the cert (safe to commit — public key only):
+```bash
+git add environments/certs/<env>.pem
+git commit -m "chore(env): add sealing cert for <env>"
+```
+
+---
+
+## Step 3: Generate secrets
+
+```bash
+# Only if environments/.secrets/<env>.yaml doesn't exist or is stale
+task env:generate ENV=<env>
+# Output: environments/.secrets/<env>.yaml (gitignored)
+```
+
+Review the generated file — replace any `MANAGED_EXTERNALLY` placeholders with real values (e.g. signaling/TURN secrets from `talk-hpb-setup.sh` checks).
+
+---
+
+## Step 4: Seal secrets
+
+```bash
+task env:seal ENV=<env>
+# Uses: environments/.secrets/<env>.yaml + environments/certs/<env>.pem
+# Writes: environments/sealed-secrets/<env>.yaml
+```
+
+Commit the sealed file:
+```bash
+git add environments/sealed-secrets/<env>.yaml
+git commit -m "chore(env): initial sealed secrets for <env>"
+```
+
+---
+
+## Step 5: Install cert-manager
+
+Cert-manager CRDs must exist before `workspace:deploy` (the ClusterIssuer and Certificate resources will fail otherwise).
+
+```bash
+task cert:install ENV=<env>
+```
+
+Store the ipv64 DNS API key (needed for DNS-01 ACME challenge):
+```bash
+task cert:secret -- <ipv64-api-key> ENV=<env>
+```
+
+This creates the secret in **both** `cert-manager` and `$WORKSPACE_NAMESPACE` — both are required.
+
+---
+
+## Step 6: Deploy workspace
+
+```bash
+task workspace:deploy ENV=<env>
+```
+
+This applies the SealedSecret first (inside the kustomize overlay), then all other resources.
+
+---
+
+## Step 7: Post-deploy setup
+
+Run in order — each step depends on the previous one completing:
+
+```bash
+# Deploy Collabora (office suite) — separate overlay
+task workspace:office:deploy ENV=<env>
+
+# Configure Nextcloud apps (OIDC, Calendar, Contacts, Collabora)
+task workspace:post-setup ENV=<env>
+
+# Configure Nextcloud Talk HPB signaling + coturn
+task workspace:talk-setup ENV=<env>
+
+# Configure recording backend
+task workspace:recording-setup ENV=<env>
+
+# Create default admin users
+task workspace:admin-users-setup ENV=<env>
+
+# Apply Nextcloud branding (logos, colors, app order)
+task workspace:theme ENV=<env>
+```
+
+---
+
+## Step 8: Verify
+
+```bash
+task workspace:verify ENV=<env>
+task workspace:status ENV=<env>
+```
+
+Check that all pods are `Running` and SSO login works (open `https://web.<domain>` in browser).
+
+---
+
+## Step 9: Keycloak realm sync
+
+```bash
+task keycloak:sync ENV=<env>
+bash scripts/keycloak-ensure-mappers.sh <env>
+```
+
+See `keycloak-realm-sync` skill for detailed verification steps.
+
+---
+
+## New vs. reset: the difference
+
+| Situation | What's different |
+|---|---|
+| **New server** (hcloud create) | cloud-init runs automatically — `hetzner-node` skill handles provisioning |
+| **Rescue Mode reset** | No cloud-init; run setup script manually — `hetzner-node` skill handles provisioning |
+| **Cluster reset with new keypair** | Steps 1-4 above are mandatory; old sealed files don't decrypt |
+| **knowledge-secrets conflict** | If overlay has a `secretGenerator`-managed Secret with same name as SealedSecret, delete the plain Secret first: `kubectl delete secret knowledge-secrets -n <ns> --context <ctx>` |
+
+---
+
+## Post-Execution: Mishap Report
+
+After completing all steps in this skill, invoke `mishap-tracker` with your
+accumulated `MISHAP_LOG`. If no mishaps were found, `mishap-tracker` exits
+cleanly with "No mishaps found."

--- a/.claude/skills/secret-rotation/SKILL.md
+++ b/.claude/skills/secret-rotation/SKILL.md
@@ -1,0 +1,206 @@
+---
+name: secret-rotation
+description: Use when rotating secrets across clusters — DB passwords, API keys, sealed-secrets keypair refresh after a cluster reset, claude-code tokens, or generating/sealing a new env. Covers the mandatory ordering that prevents silent overwrite of production secrets.
+---
+
+> **Mishap Tracking:** As you execute this skill, maintain a running `MISHAP_LOG`.
+> For every anomaly, unexpected state, broken component, security concern, or
+> configuration drift you notice — even if unrelated to the current task — add
+> an entry with: `type` (broken/degraded/suspicious/security/drift), `title`,
+> `description`, and `component`. Invoke `mishap-tracker` at the very end.
+
+# secret-rotation
+
+Safe, ordered secret rotation across the mentolder and korczewski clusters.
+
+---
+
+## Scope — pick the rotation type
+
+| Type | When |
+|---|---|
+| **A. DB password drift** | A service can't connect to shared-db after a re-seal/redeploy |
+| **B. Generate + seal new secrets** | First-time env setup, periodic rotation, or stale `.secrets/` file |
+| **C. SealedSecrets keypair refresh** | After cluster reset — old sealed files can't decrypt |
+| **D. Claude Code token rotation** | Auth-proxy or agent tokens need cycling |
+| **E. Nextcloud/service token** | Individual service credential changed |
+
+Ask the user which type(s) apply before proceeding.
+
+---
+
+## ⚠️ Critical ordering constraint
+
+**Never run `task workspace:deploy` before `task env:seal ENV=<env>`.** The deploy applies sealed secrets first — if sealed files are stale, the deploy silently overwrites production credentials with dev placeholder values.
+
+The safe order is always:
+```
+sealed-secrets:install (if controller reset) →
+env:fetch-cert (if keypair changed) →
+env:generate (if new secrets needed) →
+env:seal →
+workspace:deploy
+```
+
+---
+
+## Type A — DB password drift
+
+Symptoms: pod logs show `password authentication failed for user "<role>"` after a re-seal.
+
+```bash
+# 1. Check what password the SealedSecret decrypts to
+kubectl get secret workspace-secrets -n <WORKSPACE_NS> --context <CTX> \
+  -o jsonpath='{.data.<KEY>}' | base64 -d
+
+# 2. Compare to what Postgres has
+task workspace:psql ENV=<env> -- <db>
+# In psql: \du  (list roles — can't see password, but can reset it)
+
+# 3. Sync DB role passwords to match current SealedSecret
+task workspace:sync-db-passwords ENV=<env>
+```
+
+`sync-db-passwords` runs `ALTER ROLE <role> PASSWORD '<password>'` for every role whose SealedSecret value has drifted from the DB. Run for each affected env:
+
+```bash
+task workspace:sync-db-passwords ENV=mentolder
+task workspace:sync-db-passwords ENV=korczewski
+```
+
+Verify by restarting the affected pod and tailing logs:
+```bash
+task workspace:restart ENV=<env> -- <service>
+task workspace:logs ENV=<env> -- <service>
+```
+
+---
+
+## Type B — Generate + seal new secrets
+
+```bash
+# 1. Generate fresh secrets for the env
+task env:generate ENV=<env>
+# Output written to environments/.secrets/<env>.yaml (gitignored)
+
+# 2. Seal them with the cluster's public cert
+task env:seal ENV=<env>
+# Output: environments/sealed-secrets/<env>.yaml (committed)
+
+# 3. Apply sealed secrets to cluster — workloads are NOT restarted
+task secrets:sync
+# (equivalent to: kubectl apply -f environments/sealed-secrets/<env>.yaml --context <ctx>)
+
+# 4. Restart workloads that read the changed secrets
+task workspace:restart ENV=<env> -- <service>
+```
+
+Commit the new sealed file:
+```bash
+git add environments/sealed-secrets/<env>.yaml
+git commit -m "chore(secrets): rotate <env> secrets"
+```
+
+---
+
+## Type C — SealedSecrets keypair refresh (after cluster reset)
+
+After any cluster reset the controller generates a new keypair. Old sealed files cannot be decrypted. Mandatory order:
+
+```bash
+# 1. Install (or verify) the Sealed Secrets controller
+task sealed-secrets:install ENV=<env>
+task sealed-secrets:status  ENV=<env>
+
+# 2. Fetch the new cluster sealing certificate
+task env:fetch-cert ENV=<env>
+# Writes: environments/certs/<env>.pem
+
+# 3. Re-seal plaintext secrets with the new cert
+#    (plaintext must already exist in environments/.secrets/<env>.yaml)
+task env:seal ENV=<env>
+
+# 4. Commit the re-sealed file
+git add environments/sealed-secrets/<env>.yaml environments/certs/<env>.pem
+git commit -m "chore(secrets): re-seal <env> after keypair reset"
+
+# 5. Deploy (sealed secrets are applied first inside workspace:deploy)
+task workspace:deploy ENV=<env>
+```
+
+**If `.secrets/<env>.yaml` is missing:** run `task env:generate ENV=<env>` before step 3.
+
+---
+
+## Type D — Claude Code token rotation
+
+```bash
+task claude-code:rotate-tokens
+```
+
+This updates:
+- The `auth-proxy` bearer token in `claude-code-secrets`
+- The per-agent tokens
+
+After rotation, users must re-run `task claude-code:setup -- <role>` to get fresh `settings.json` files.
+
+Verify the proxy is healthy:
+```bash
+task mcp:status
+task mcp:logs -- keycloak
+```
+
+---
+
+## Type E — Individual service credential
+
+1. Update the value in `environments/.secrets/<env>.yaml`
+2. Re-seal: `task env:seal ENV=<env>`
+3. Apply: `task secrets:sync`
+4. Restart the affected service: `task workspace:restart ENV=<env> -- <service>`
+5. Commit the updated sealed file
+
+---
+
+## Cross-cluster checklist
+
+Each cluster has its own sealed-secrets controller, sealing cert, and shared-db. Any secret rotation that touches both clusters must be applied independently:
+
+```bash
+task env:fetch-cert ENV=mentolder
+task env:seal ENV=mentolder
+task workspace:deploy ENV=mentolder
+
+task env:fetch-cert ENV=korczewski
+task env:seal ENV=korczewski
+task workspace:deploy ENV=korczewski
+```
+
+Do not assume a mentolder-sealed file works on korczewski — the certs are different.
+
+---
+
+## Verification
+
+After any rotation, confirm:
+
+```bash
+# All pods running
+task workspace:status ENV=<env>
+
+# No auth errors in logs
+task workspace:logs ENV=<env> -- keycloak
+task workspace:logs ENV=<env> -- nextcloud
+task workspace:logs ENV=<env> -- website
+
+# SSO login works
+# (open https://web.<domain> in browser, attempt login)
+```
+
+---
+
+## Post-Execution: Mishap Report
+
+After completing all steps in this skill, invoke `mishap-tracker` with your
+accumulated `MISHAP_LOG`. If no mishaps were found, `mishap-tracker` exits
+cleanly with "No mishaps found."

--- a/.claude/skills/ticket-management/SKILL.md
+++ b/.claude/skills/ticket-management/SKILL.md
@@ -3,6 +3,12 @@ name: ticket-management
 description: Use when asked to work through, triage, or resolve open tickets in the mentolder ticket database. Covers fetching open tickets, categorizing by actionability, applying fixes autonomously for ai_ready tickets, and routing needs_human tickets with a clear request.
 ---
 
+> **Mishap Tracking:** As you execute this skill, maintain a running `MISHAP_LOG`.
+> For every anomaly, unexpected state, broken component, security concern, or
+> configuration drift you notice — even if unrelated to the current task — add
+> an entry with: `type` (broken/degraded/suspicious/security/drift), `title`,
+> `description`, and `component`. Invoke `mishap-tracker` at the very end.
+
 # Ticket Management
 
 ## Overview
@@ -128,3 +134,9 @@ git branch -D <branch>
 | Writing vague human-needed notes | Include the specific question or action the human must take |
 | Fixing tests by changing the assertion | Find the source of the regression; fix the logic |
 | Acting on tickets before presenting categorization to user | Always confirm the triage grouping first |
+
+## Post-Execution: Mishap Report
+
+After completing all steps in this skill, invoke `mishap-tracker` with your
+accumulated `MISHAP_LOG`. If no mishaps were found, `mishap-tracker` exits
+cleanly with "No mishaps found."


### PR DESCRIPTION
## Summary

- **8 new skills** covering operational gaps identified in the skill audit: `secret-rotation`, `incident-response`, `keycloak-realm-sync`, `coaching-pipeline`, `livekit-setup`, `new-environment`, `db-migration`, `knowledge-reindex`
- **2 quality fixes**: `ticket-management` was the only operational skill missing mishap tracking; `dev-flow-plan` chore path now has a fallback for when the `commit-commands` plugin is not installed

## New Skills

| Skill | Gap it closes |
|---|---|
| `secret-rotation` | Mandatory ordering for DB password drift, SealedSecrets keypair refresh after cluster reset, cross-cluster checklist |
| `incident-response` | No procedure existed for prod breakage — now: triage → ticket → diagnose → fix/rollback → verify → post-mortem |
| `keycloak-realm-sync` | Realm JSON sync, mapper reconciliation, OIDC client verification per-service, SSO flow testing |
| `coaching-pipeline` | Ingest → classify → drafts review; LLM path selection (cluster/Anthropic/local WSL); embedding model isolation |
| `livekit-setup` | DNS pinning, ufw port matrix, node affinity, ICE debug, recording PVC, emergency room-close |
| `new-environment` | Enforces the 6-step mandatory bring-up order that prevents silent credential overwrite |
| `db-migration` | Idempotent SQL patterns, both-cluster apply, permission re-grant, ER diagram update |
| `knowledge-reindex` | SOURCE options, pre-checks, bge-m3/voyage isolation (fails closed), "0 docs indexed" recovery |

## Test plan

- `task test:all` passes (no manifests or code changed — skill files only)
- All 10 files verified present in git diff
- KEIN Deploy required (changes are entirely in `.claude/skills/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)