### PR TITLE
feat(admin): rechtliches save API + RechtlichesSection wiring

### DIFF
--- a/website/src/pages/admin/rechtliches.astro
+++ b/website/src/pages/admin/rechtliches.astro
@@ -1,7 +1,9 @@
 ---
 import AdminLayout from '../../layouts/AdminLayout.astro';
+import RechtlichesSection from '../../components/admin/inhalte/RechtlichesSection.svelte';
 import { getSession, getLoginUrl, isAdmin } from '../../lib/auth';
 import { getLegalPage } from '../../lib/website-db';
+import { getDefaultDatenschutz, getDefaultAgb, getDefaultBarrierefreiheit, getDefaultImpressumZusatz } from '../../lib/legal-defaults';
 
 const session = await getSession(Astro.request.headers.get('cookie'));
 if (!session) return Astro.redirect(getLoginUrl(Astro.url.pathname));
@@ -9,23 +11,32 @@ if (!isAdmin(session)) return Astro.redirect('/admin');
 
 const BRAND = process.env.BRAND || 'mentolder';
 
-// Hilfsfunktion: holt DB-Inhalt oder gibt leeren String zurück
-async function getOrEmpty(key: string): Promise<string> {
-  return await getLegalPage(BRAND, key).catch(() => null) ?? '';
-}
-
-// Lade alle rechtlichen Inhalte aus der DB für die Admin-Anzeige
-const [datenschutz, agb, barrierefreiheit, impressumZusatz] = await Promise.all([
-  getOrEmpty('datenschutz'),
-  getOrEmpty('agb'),
-  getOrEmpty('barrierefreiheit'),
-  getOrEmpty('impressum-zusatz'),
+const [dbImpressum, dbDatenschutz, dbAgb, dbBarrierefreiheit] = await Promise.all([
+  getLegalPage(BRAND, 'impressum-zusatz').catch(() => null),
+  getLegalPage(BRAND, 'datenschutz').catch(() => null),
+  getLegalPage(BRAND, 'agb').catch(() => null),
+  getLegalPage(BRAND, 'barrierefreiheit').catch(() => null),
 ]);
 
-const pages = [
-  { key: 'datenschutz', label: 'Datenschutzerklärung', value: datenschutz },
-  { key: 'agb', label: 'AGB', value: agb },
-  { key: 'barrierefreiheit', label: 'Barrierefreiheit', value: barrierefreiheit },
-  { key: 'impressum-zusatz', label: 'Impressum-Zusatz', value: impressumZusatz },
-];
+const initialData = {
+  'impressum-zusatz': dbImpressum ?? getDefaultImpressumZusatz(),
+  'datenschutz':      dbDatenschutz ?? getDefaultDatenschutz(),
+  'agb':              dbAgb ?? getDefaultAgb(),
+  'barrierefreiheit': dbBarrierefreiheit ?? getDefaultBarrierefreiheit(),
+};
+
+const rechtlichesHasCustom = {
+  'impressum-zusatz': dbImpressum !== null,
+  'datenschutz':      dbDatenschutz !== null,
+  'agb':              dbAgb !== null,
+  'barrierefreiheit': dbBarrierefreiheit !== null,
+};
 ---
+
+<AdminLayout title="Admin — Rechtliches">
+  <section class="pt-0 pb-0 bg-dark min-h-screen">
+    <div class="px-8 pt-8">
+      <RechtlichesSection {initialData} {rechtlichesHasCustom} client:load />
+    </div>
+  </section>
+</AdminLayout>

--- a/website/src/pages/api/admin/legal/[key]/save.ts
+++ b/website/src/pages/api/admin/legal/[key]/save.ts
@@ -1,0 +1,45 @@
+import type { APIRoute } from 'astro';
+import { getSession, isAdmin } from '../../../../../lib/auth';
+import { saveLegalPage } from '../../../../../lib/website-db';
+
+const ALLOWED = ['impressum-zusatz', 'datenschutz', 'agb', 'barrierefreiheit'] as const;
+type LegalKey = typeof ALLOWED[number];
+
+export const POST: APIRoute = async ({ request, params }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) return new Response('Forbidden', { status: 403 });
+
+  const key = params.key as string;
+  if (!ALLOWED.includes(key as LegalKey)) {
+    return new Response(JSON.stringify({ error: 'Invalid key' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const BRAND = process.env.BRAND || 'mentolder';
+
+  let content: string;
+  try {
+    const body = await request.json() as { content: string };
+    content = body.content ?? '';
+  } catch {
+    return new Response(JSON.stringify({ error: 'Invalid JSON' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  try {
+    await saveLegalPage(BRAND, key, content);
+    return new Response(JSON.stringify({ ok: true }), {
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (err) {
+    console.error('[legal/save] DB error:', err);
+    return new Response(JSON.stringify({ error: 'DB error' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+};


### PR DESCRIPTION
## Summary
- Adds `POST /api/admin/legal/[key]/save` endpoint (keys: impressum-zusatz, datenschutz, agb, barrierefreiheit)
- `rechtliches.astro` now loads `initialData` from DB and passes `rechtlichesHasCustom` flag to the existing `RechtlichesSection` Svelte component
- Legal page edits are now persisted to the database

## Test plan
- [ ] Navigate to `/admin/rechtliches`, edit a legal field, save — verify content persists on reload
- [ ] Invalid key returns 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)