### PR TITLE
fix(brett): spawn spacing, weapon models on mannequins, AI weapon variety

### DIFF
--- a/brett/public/assets/mayhem/ai-bot.js
+++ b/brett/public/assets/mayhem/ai-bot.js
@@ -37,6 +37,13 @@ class MayhemAIBot {
     this._onFire    = callbacks.onFire;
     this._onDeath   = callbacks.onDeath;
     this._getMode   = callbacks.getGameMode;
+
+    // Bots use ranged weapons so they can attack outside melee-AI state
+    const rangedKeys = ['handgun', 'rifle', 'fireball'];
+    const weaponKey  = rangedKeys[colorIndex % rangedKeys.length];
+    this.weaponDef = window.MayhemWeapons
+      ? window.MayhemWeapons.WEAPONS[weaponKey]
+      : { key: 'handgun', damage: 25, projectileSpeed: 18, projectileType: 'bullet' };
   }
 
   // allAvatars — Map<id, PlayerAvatar> of every other combatant (incl. local player)
@@ -164,8 +171,7 @@ class MayhemAIBot {
     const dlen = Math.hypot(dir.x, dir.y, dir.z) || 1;
     dir.x /= dlen; dir.y /= dlen; dir.z /= dlen;
 
-    const handgunDef = window.MayhemWeapons ? window.MayhemWeapons.WEAPONS.handgun : { key: 'handgun', damage: 25, projectileSpeed: 18, projectileType: 'bullet' };
-    this._onFire(handgunDef, { x: this._x, y: 1.2, z: this._z }, dir, this.id);
+    this._onFire(this.weaponDef, { x: this._x, y: 1.2, z: this._z }, dir, this.id);
   }
 
   remove(scene) {
@@ -174,11 +180,11 @@ class MayhemAIBot {
 
   static randomEdgeSpawn() {
     const edge = Math.floor(Math.random() * 4);
-    const r = 4;
-    if (edge === 0) return { x: -r, z: (Math.random() - 0.5) * 2 * r };
-    if (edge === 1) return { x:  r, z: (Math.random() - 0.5) * 2 * r };
-    if (edge === 2) return { x: (Math.random() - 0.5) * 2 * r, z: -r };
-    return { x: (Math.random() - 0.5) * 2 * r, z: r };
+    const r = 7;
+    if (edge === 0) return { x: -r, z: (Math.random() - 0.5) * 2.4 };
+    if (edge === 1) return { x:  r, z: (Math.random() - 0.5) * 2.4 };
+    if (edge === 2) return { x: (Math.random() - 0.5) * 2.4, z: -r };
+    return { x: (Math.random() - 0.5) * 2.4, z: r };
   }
 }
 

--- a/brett/public/assets/mayhem/mayhem.js
+++ b/brett/public/assets/mayhem/mayhem.js
@@ -7,6 +7,20 @@ const Mayhem = (() => {
 
   const MAX_PLAYERS = 4;
 
+  // Cardinal spawn slots — north/east/south/west at r=7, clear of obstacles
+  const SPAWN_SLOTS = [
+    { x:  0, z:  7 },
+    { x:  7, z:  0 },
+    { x:  0, z: -7 },
+    { x: -7, z:  0 },
+  ];
+  let _spawnSlot = 0;
+  function nextSpawnPoint() {
+    const pt = SPAWN_SLOTS[_spawnSlot % SPAWN_SLOTS.length];
+    _spawnSlot = (_spawnSlot + 1) % SPAWN_SLOTS.length;
+    return { x: pt.x + (Math.random() - 0.5) * 1.2, z: pt.z + (Math.random() - 0.5) * 1.2 };
+  }
+
   let scene, camera, canvas, makeMannequin, send, room;
   let enabled = false;
   let localAvatar = null;
@@ -24,6 +38,7 @@ const Mayhem = (() => {
   let effectsMgr  = null;
   let hud         = null;
   let playerId    = null;
+  let _lastWeaponKey = null;
 
   const input = {
     forward: false, backward: false, left: false, right: false,
@@ -130,11 +145,15 @@ const Mayhem = (() => {
     // HUD
     hud = buildHud();
 
-    // Spawn local player
+    // Spawn local player — slot 0 (north)
+    _spawnSlot = 0;
+    _lastWeaponKey = null;
     const color = '#' + Math.floor(Math.random() * 0xffffff).toString(16).padStart(6, '0');
-    const edge = randomEdgeSpawn();
-    const mannequin = makeMannequin(playerId, edge);
+    const spawnPos = nextSpawnPoint();
+    const mannequin = makeMannequin(playerId, spawnPos);
     localAvatar = new window.MayhemPlayerAvatar({ id: playerId, mannequin, local: true, color });
+    localAvatar.setWeapon(weaponSystem.current);
+    _lastWeaponKey = weaponSystem.current?.key || null;
     chaseCam.attach(localAvatar.mannequin.root);
     send({ type: 'player_join', playerId, color });
 
@@ -147,7 +166,7 @@ const Mayhem = (() => {
   function spawnAIBot(colorIndex) {
     if (!window.MayhemAIBot) return; // guard: ai-bot.js not loaded
     const botId = 'bot-' + crypto.randomUUID();
-    const pos = randomEdgeSpawn();
+    const pos = nextSpawnPoint();
     const botMannequin = makeMannequin(botId, pos);
     const bot = new window.MayhemAIBot({
       id: botId,
@@ -165,6 +184,7 @@ const Mayhem = (() => {
         getGameMode: () => gameMode?.mode || 'warmup',
       },
     });
+    if (bot.avatar && bot.weaponDef) bot.avatar.setWeapon(bot.weaponDef);
     aiBots.set(botId, bot);
     remoteAvatars.set(botId, bot.avatar);
   }
@@ -198,7 +218,7 @@ const Mayhem = (() => {
   // ── Respawn ───────────────────────────────────────────────────────────────
   function localRespawn() {
     if (!localAvatar) return;
-    const pos = randomEdgeSpawn();
+    const pos = nextSpawnPoint();
     localAvatar.mannequin.root.position.set(pos.x, 0, pos.z);
     localAvatar.resetHp();
     localAvatar.state = window.MayhemPlayerAvatar.STATE.IDLE;
@@ -320,6 +340,13 @@ const Mayhem = (() => {
         weaponSystem.tryFire({ x: pos.x, y: pos.y, z: pos.z }, dir, playerId);
       }
       weaponSystem?.tick();
+
+      // Sync weapon model when selection changes
+      const curWeaponKey = weaponSystem?.current?.key || null;
+      if (curWeaponKey !== _lastWeaponKey) {
+        _lastWeaponKey = curWeaponKey;
+        if (weaponSystem?.current) localAvatar.setWeapon(weaponSystem.current);
+      }
     }
 
     // Tick AI bots — they drive their own avatars (already in remoteAvatars)
@@ -575,14 +602,6 @@ const Mayhem = (() => {
     document.body.appendChild(banner);
   }
   function hideBanner() { if (banner) { banner.remove(); banner = null; } }
-
-  function randomEdgeSpawn() {
-    const edge = Math.floor(Math.random() * 4), r = 4;
-    if (edge === 0) return { x: -r, z: (Math.random() - 0.5) * 2 * r };
-    if (edge === 1) return { x:  r, z: (Math.random() - 0.5) * 2 * r };
-    if (edge === 2) return { x: (Math.random() - 0.5) * 2 * r, z: -r };
-    return { x: (Math.random() - 0.5) * 2 * r, z:  r };
-  }
 
   return {
     init, toggle, setEnabled, onSnapshot, onMessage, tick,

--- a/brett/public/assets/mayhem/player-avatar.js
+++ b/brett/public/assets/mayhem/player-avatar.js
@@ -30,6 +30,7 @@ class PlayerAvatar {
     this._t = 0;
     this.hp = 100;
     this.burnInterval = null;
+    this._weaponMesh = null;
     this._applyColor();
   }
   _applyColor() {
@@ -251,6 +252,69 @@ class PlayerAvatar {
   }
   remove(scene) {
     scene.remove(this.mannequin.root);
+  }
+
+  setWeapon(weaponDef) {
+    const rWrist = this.mannequin.bones && this.mannequin.bones.rWrist;
+    if (!rWrist) return;
+    if (this._weaponMesh) { rWrist.remove(this._weaponMesh); this._weaponMesh = null; }
+    if (!weaponDef) return;
+    this._weaponMesh = PlayerAvatar._mkWeaponMesh(weaponDef.key, window.THREE);
+    if (this._weaponMesh) rWrist.add(this._weaponMesh);
+  }
+
+  static _mkWeaponMesh(key, THREE) {
+    if (!THREE) return null;
+    switch (key) {
+      case 'handgun': {
+        const g = new THREE.Group();
+        const barrel = new THREE.Mesh(new THREE.BoxGeometry(0.05, 0.05, 0.22), new THREE.MeshLambertMaterial({ color: 0x333333 }));
+        barrel.position.set(0.04, -0.06, -0.06);
+        const grip = new THREE.Mesh(new THREE.BoxGeometry(0.05, 0.13, 0.07), new THREE.MeshLambertMaterial({ color: 0x222222 }));
+        grip.position.set(0.04, -0.15, 0.01);
+        g.add(barrel, grip);
+        return g;
+      }
+      case 'rifle': {
+        const g = new THREE.Group();
+        const body = new THREE.Mesh(new THREE.BoxGeometry(0.05, 0.06, 0.52), new THREE.MeshLambertMaterial({ color: 0x3a3a3a }));
+        body.position.set(0.04, -0.08, -0.16);
+        const stock = new THREE.Mesh(new THREE.BoxGeometry(0.04, 0.10, 0.14), new THREE.MeshLambertMaterial({ color: 0x8B6914 }));
+        stock.position.set(0.04, -0.10, 0.10);
+        g.add(body, stock);
+        return g;
+      }
+      case 'fireball': {
+        const g = new THREE.Group();
+        const staff = new THREE.Mesh(new THREE.CylinderGeometry(0.025, 0.03, 0.42, 6), new THREE.MeshLambertMaterial({ color: 0x8B4513 }));
+        staff.position.set(0, -0.21, 0);
+        const orb = new THREE.Mesh(new THREE.SphereGeometry(0.09, 7, 7), new THREE.MeshBasicMaterial({ color: 0xff6600 }));
+        orb.position.set(0, 0.06, 0);
+        const glow = new THREE.Mesh(new THREE.SphereGeometry(0.055, 5, 5), new THREE.MeshBasicMaterial({ color: 0xffee00 }));
+        orb.add(glow);
+        g.add(staff, orb);
+        return g;
+      }
+      case 'club': {
+        const g = new THREE.Group();
+        const handle = new THREE.Mesh(new THREE.CylinderGeometry(0.03, 0.03, 0.32, 6), new THREE.MeshLambertMaterial({ color: 0x8B6914 }));
+        handle.position.set(0, -0.16, 0);
+        const head = new THREE.Mesh(new THREE.SphereGeometry(0.095, 7, 6), new THREE.MeshLambertMaterial({ color: 0x5C4000 }));
+        head.position.set(0, 0.07, 0);
+        g.add(handle, head);
+        return g;
+      }
+      case 'katana': {
+        const g = new THREE.Group();
+        const blade = new THREE.Mesh(new THREE.BoxGeometry(0.016, 0.016, 0.68), new THREE.MeshLambertMaterial({ color: 0xd0d0d0 }));
+        blade.position.set(0.04, -0.08, -0.28);
+        const guard = new THREE.Mesh(new THREE.BoxGeometry(0.12, 0.016, 0.025), new THREE.MeshLambertMaterial({ color: 0xcc9900 }));
+        guard.position.set(0.04, -0.08, 0.06);
+        g.add(blade, guard);
+        return g;
+      }
+      default: return null;
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

- **Spawn spacing**: replaced `r=4` random-edge spawning with 4 cardinal slots at `r=7` (N/E/S/W) — players and bots now start on opposite sides of the 9 m arena instead of potentially clustering on the same edge
- **Weapon models**: added `PlayerAvatar.setWeapon()` + `_mkWeaponMesh()` — each weapon now has distinct Three.js geometry attached to the `rWrist` bone (handgun: dark box+grip, rifle: long body+wooden stock, fireball: brown staff+glowing orb, club: cylinder+ball head, katana: silver blade+gold guard); weapon mesh swaps automatically when the player switches weapons
- **AI weapon variety**: bots are assigned `handgun`/`rifle`/`fireball` by `colorIndex` instead of all using handgun; `bot.weaponDef` is exposed so the matching mesh is set on the bot's avatar at spawn

## Test plan

- [ ] Enter Mayhem mode — all 4 combatants (player + 3 bots) spawn at cardinal corners, not bunched together
- [ ] Press `1`–`5` / `Q`/`E` / scroll wheel — weapon mesh in right hand updates each time
- [ ] Verify each weapon looks distinct: handgun (small grey box), rifle (long body + brown stock), fireball (staff + orange orb), club (cylinder + dark ball), katana (silver blade + gold guard)
- [ ] Observe bot projectiles: bot 0 fires bullets, bot 1 fires burst rifle, bot 2 fires fireballs

🤖 Generated with [Claude Code](https://claude.com/claude-code)