### PR TITLE
feat(admin): codify menu rules + reshuffle sidemenu + add placement gate

### DIFF
--- a/.claude/skills/dev-flow-execute/SKILL.md
+++ b/.claude/skills/dev-flow-execute/SKILL.md
@@ -160,6 +160,40 @@ task test:all
 
 ---
 
+## Schritt 3.5: Admin-Menu Placement Gate
+
+Falls die Implementierung neue Seiten unter `website/src/pages/admin/` hinzugefügt hat, muss jede statische Route aus dem Sidemenu erreichbar sein (siehe Regel R1–R10 in `docs/superpowers/specs/2026-05-18-admin-menu-rules-design.md`).
+
+```bash
+bash scripts/admin-menu-gate.sh
+```
+
+| Exit | Bedeutung | Aktion |
+|---|---|---|
+| `0` (Gate PASSED) | Alles ok — weiter zu Schritt 4. | — |
+| `1` (Gate FAILED) | Mindestens eine Regel verletzt. | Output lesen, im AdminLayout.astro nachpflegen, erneut laufen. |
+| `2` | Wrong working directory. | In den Worktree wechseln und erneut versuchen. |
+
+### Bypass (nur in Ausnahmefällen)
+
+```bash
+ADMIN_MENU_GATE=skip bash scripts/admin-menu-gate.sh
+```
+
+Wenn der Gate übersprungen wird: **PR-Titel mit `[menu-gate-skip]` prefixen** und im PR-Body begründen (z.B. "absichtlich orphan — dynamic redirect target only, kein Bedarf für Menüplatz"). Reviewer haben damit ein klares Signal.
+
+### Häufige Failure-Modi
+
+| Failure | Typische Ursache | Fix |
+|---|---|---|
+| `R1 orphan` | Neue `/admin/foo.astro` ohne Eintrag in `navGroups`. | Item in passender Gruppe ergänzen, oder Parent-Route in `matches[]` listen. |
+| `R2 label` | `'Neue Session'` o.ä. als `label`. | Item entfernen, Create-Aktion als Button auf der Zielseite. |
+| `R4 group >6` | Zu viele Items in einer Gruppe. | Item in andere Gruppe verschieben, oder Gruppe aufteilen. |
+| `R5 groups >6` | Zu viele Gruppen. | Verwandte Gruppen zusammenführen. |
+| `R7 dashboard orphan` | KPI-Card linkt auf Route die nicht im Sidemenu liegt. | Entweder Route ins Sidemenu, oder Dashboard-Link entfernen. |
+
+---
+
 ## Schritt 4: Pre-Merge Preview auf dev k3d (optional)
 
 > **Status (2026-05-13):** Der k3d-Dev-Cluster läuft aktuell **nicht**. Dieser Schritt ist optional, sobald die Infrastruktur live ist. Bis dahin: lokal verifizieren und direkt auf Prod deployen.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -244,6 +244,11 @@ tasks:
     cmds:
       - ./tests/unit/lib/bats-core/bin/bats tests/unit/manifests.bats
 
+  test:menu-gate:
+    desc: Enforce admin-menu rules (R1, R2, R4, R5, R7)
+    cmds:
+      - bash scripts/admin-menu-gate.sh
+
   test:dry-run:
     desc: Dry-run key tasks to catch Taskfile syntax errors
     cmds:
@@ -269,11 +274,12 @@ tasks:
         echo "Dry-run: All tasks parsed successfully"
 
   test:all:
-    desc: "Run all offline tests: unit + manifests + art-library + dry-run"
+    desc: "Run all offline tests: unit + manifests + art-library + menu-gate + dry-run"
     deps:
       - test:unit
       - test:manifests
       - test:art-library
+      - test:menu-gate
       - test:dry-run
 
   test:inventory:

--- a/docs/superpowers/plans/2026-05-18-admin-menu-rules.md
+++ b/docs/superpowers/plans/2026-05-18-admin-menu-rules.md
@@ -1,0 +1,1032 @@
+---
+title: Admin-Menu Rules & Reshuffle Implementation Plan
+slug: admin-menu-rules
+ticket_id: T000449
+domains: [website]
+status: active
+pr_number: null
+---
+
+# Admin-Menu Rules & Reshuffle Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Codify 10 admin-menu rules, reshuffle `AdminLayout.astro` to comply (6 groups ≤ 6 items, zero orphans), and add a Schritt 3.5 placement gate to `dev-flow-execute` so future PRs that touch `/admin/*` cannot ship orphan routes.
+
+**Architecture:** Three loosely-coupled changes in one branch — (a) `AdminLayout.astro` reshuffle + missing icons fix, (b) standalone bash gate script `scripts/admin-menu-gate.sh` driven by `git diff` and lightweight awk parsing of the Astro file, (c) skill update inserting Schritt 3.5 in `dev-flow-execute` plus a `task test:menu-gate` for CI parity.
+
+**Tech Stack:** Astro + Svelte (website), Bash + awk + jq (gate), go-task (Taskfile), Markdown (skill doc).
+
+---
+
+## File Structure
+
+**Create:**
+- `scripts/admin-menu-gate.sh` — gate executable (parses `AdminLayout.astro` + diffs vs `origin/main`, emits structured report)
+- `tests/scripts/admin-menu-gate.bats` — BATS coverage for orphan detection, R4/R5 caps, R2 label hygiene, R7 dashboard cross-ref
+
+**Modify:**
+- `website/src/layouts/AdminLayout.astro` — replace `navGroups` array, move Dashboard out as a header, add three missing icons (`folder`, `settings`, `chat`)
+- `website/src/pages/admin/coaching/sessions.astro` — surface "Neue Session" as a button on the page (currently linked only via the now-removed sidemenu item)
+- `.claude/skills/dev-flow-execute/SKILL.md` — insert "Schritt 3.5: Admin-Menu Placement Gate" between Schritt 3 and Schritt 5
+- `Taskfile.yml` — add `test:menu-gate` task (called by `test:all`)
+
+**Reference (no code changes, but read during implementation):**
+- `website/src/pages/admin.astro` — confirm KPI hrefs after reshuffle
+- `docs/superpowers/specs/2026-05-18-admin-menu-rules-design.md` — single source of truth for rules
+
+---
+
+## Task 1: Add three missing icons
+
+Pre-existing bug — `folder` and `settings` are referenced in the current `navGroups`, never defined. The new menu also needs `chat` (for Räume).
+
+**Files:**
+- Modify: `website/src/layouts/AdminLayout.astro:35-65` (the `icons` record)
+
+- [ ] **Step 1: Add `folder`, `settings`, `chat` SVG entries**
+
+Insert these three entries inside the `icons` const (alongside the existing entries, preserve alphabetical-ish order — keep them grouped near related icons):
+
+```typescript
+  folder: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M2 4.5a1 1 0 0 1 1-1h3.5l1.5 1.5H13a1 1 0 0 1 1 1V13a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1z"/></svg>`,
+  settings: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="8" r="2.5"/><path d="M8 1.5v2M8 12.5v2M1.5 8h2M12.5 8h2M3.4 3.4l1.4 1.4M11.2 11.2l1.4 1.4M3.4 12.6l1.4-1.4M11.2 4.8l1.4-1.4"/></svg>`,
+  chat: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M2 3.5h9a1 1 0 0 1 1 1v5a1 1 0 0 1-1 1H6L3.5 13v-2.5H3a1 1 0 0 1-1-1z"/><path d="M5.5 5.5h4M5.5 7.5h3"/></svg>`,
+```
+
+- [ ] **Step 2: Verify Astro still type-checks**
+
+Run: `cd website && npx astro check --minimumSeverity error 2>&1 | head -30`
+Expected: no new errors. (Pre-existing warnings are fine; we only fail on `error`.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add website/src/layouts/AdminLayout.astro
+git commit -m "fix(admin): add missing folder/settings/chat icons referenced by Coaching nav"
+```
+
+---
+
+## Task 2: Replace `navGroups` with the target structure
+
+Apply R1–R6 and R8: 6 groups, Dashboard as header, every formerly-orphan static route placed.
+
+**Files:**
+- Modify: `website/src/layouts/AdminLayout.astro:79-161` (the `navGroups` const)
+- Modify: `website/src/layouts/AdminLayout.astro:163-167` (the `isActive` helper — handle the header link case)
+
+- [ ] **Step 1: Replace the `navGroups` literal**
+
+Replace lines 79–161 with this exact array. Note: Dashboard moves OUT of `navGroups` — it'll be rendered as a header link in Task 3.
+
+```typescript
+const navGroups: { label: string; items: NavItem[] }[] = [
+  {
+    label: 'Tagesgeschäft',
+    items: [
+      { href: '/admin/termine',     label: 'Termine',     icon: 'calendar' },
+      { href: '/admin/tickets',     label: 'Tickets',     icon: 'tag' },
+      { href: '/admin/inbox',       label: 'Inbox',       icon: 'inbox',     badge: inboxPending },
+      { href: '/admin/live',        label: 'Live',        icon: 'broadcast', matches: ['/admin/live'] },
+      { href: '/admin/nachrichten', label: 'Nachrichten', icon: 'message' },
+      { href: '/admin/raeume',      label: 'Räume',       icon: 'chat' },
+    ],
+  },
+  {
+    label: 'Klienten',
+    items: [
+      { href: '/admin/clients',   label: 'Klienten',  icon: 'users' },
+      { href: '/admin/projekte',  label: 'Projekte',  icon: 'folder',    matches: ['/admin/projekte'] },
+      { href: '/admin/meetings',  label: 'Meetings',  icon: 'calendar2', matches: ['/admin/meetings'] },
+      { href: '/admin/kalender',  label: 'Kalender',  icon: 'calendar2' },
+      { href: '/admin/followups', label: 'Followups', icon: 'clock' },
+    ],
+  },
+  {
+    label: 'Coaching',
+    items: [
+      { href: '/admin/coaching/sessions',  label: 'Sessions',          icon: 'clipboard', matches: ['/admin/coaching/sessions', '/admin/fragebogen'] },
+      { href: '/admin/coaching/projekte',  label: 'Projekte',          icon: 'folder',    matches: ['/admin/coaching/projekte'] },
+      { href: '/admin/brett',              label: 'Brett',             icon: 'brett',     matches: ['/admin/brett'] },
+      { href: '/admin/coaching/settings',  label: 'KI-Einstellungen',  icon: 'settings',  matches: ['/admin/coaching/settings'] },
+    ],
+  },
+  {
+    label: 'Wissen & Inhalte',
+    items: [
+      {
+        href: '/admin/inhalte',
+        label: 'Website-Inhalte',
+        icon: 'layout',
+        matches: [
+          '/admin/inhalte',
+          '/admin/startseite',
+          '/admin/uebermich',
+          '/admin/angebote',
+          '/admin/faq',
+          '/admin/kontakt',
+          '/admin/referenzen',
+          '/admin/rechtliches',
+          '/admin/dokumente',
+        ],
+      },
+      { href: '/admin/knowledge/books',     label: 'Bücher',   icon: 'book',      matches: ['/admin/knowledge/books'] },
+      { href: '/admin/knowledge/drafts',    label: 'Drafts',   icon: 'edit',      matches: ['/admin/knowledge/drafts', '/admin/knowledge/snippets'], badge: draftsPending },
+      { href: '/admin/wissensquellen',      label: 'Quellen',  icon: 'clipboard' },
+      { href: '/admin/knowledge/templates', label: 'Vorlagen', icon: 'star',      matches: ['/admin/knowledge/templates'] },
+    ],
+  },
+  {
+    label: 'Geld',
+    items: [
+      { href: '/admin/rechnungen',    label: 'Rechnungen',    icon: 'receipt', matches: ['/admin/rechnungen', '/admin/billing'] },
+      { href: '/admin/buchhaltung',   label: 'Buchhaltung',   icon: 'scale' },
+      { href: '/admin/zeiterfassung', label: 'Zeiterfassung', icon: 'clock' },
+      { href: '/admin/steuer',        label: 'Steuer',        icon: 'scale' },
+    ],
+  },
+  {
+    label: 'Plattform',
+    items: [
+      { href: '/admin/monitoring',                       label: 'Monitoring',        icon: 'monitor' },
+      { href: '/admin/software-history',                 label: 'Software-History',  icon: 'clipboard' },
+      { href: '/admin/systemtest/board',                 label: 'Systemtest',        icon: 'clipboard', matches: ['/admin/systemtest'] },
+      { href: '/admin/arena',                            label: 'Arena',             icon: 'broadcast' },
+      { href: '/admin/ops',                              label: 'Cluster-Steuerung', icon: 'server' },
+      { href: '/admin/einstellungen/benachrichtigungen', label: 'Einstellungen',     icon: 'bell',     matches: ['/admin/einstellungen/'] },
+    ],
+  },
+];
+```
+
+- [ ] **Step 2: Adjust `isActive` to handle the standalone Dashboard link**
+
+The Dashboard header link doesn't go through `isActive` anymore (rendered as a separate element in Task 3). Replace the `isActive` function (lines 163–167) with:
+
+```typescript
+function isActive(href: string, matches?: string[]): boolean {
+  if (matches) return matches.some(m => path === m || path.startsWith(m));
+  return path.startsWith(href);
+}
+```
+
+Removed: the `href === '/admin'` exact-match branch (Dashboard is now a header link with its own active-class logic in Task 3).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add website/src/layouts/AdminLayout.astro
+git commit -m "feat(admin): reshuffle sidemenu into 6 task-based groups per menu-rules spec"
+```
+
+---
+
+## Task 3: Render Dashboard as a standalone header link
+
+R5 says Dashboard is a header, not a group of one. Move it above the `{navGroups.map(...)}` block in the template.
+
+**Files:**
+- Modify: `website/src/layouts/AdminLayout.astro` — the `<aside id="admin-sidebar">` template, specifically where `navGroups` is iterated
+
+- [ ] **Step 1: Find the nav rendering block**
+
+Run: `grep -n 'navGroups.map\|<nav' /home/patrick/Bachelorprojekt/.claude/worktrees/feature+admin-menu-rules/website/src/layouts/AdminLayout.astro`
+
+Locate the `{navGroups.map(...)}` block. The Dashboard header link goes immediately *before* it, inside the same `<nav>` (or sibling block — whichever is the sidebar nav container).
+
+- [ ] **Step 2: Insert the Dashboard header link**
+
+Add this block right above `{navGroups.map(...)}`:
+
+```astro
+<a
+  href="/admin"
+  class:list={[
+    'admin-nav-dashboard',
+    { active: path === '/admin' },
+  ]}
+  aria-current={path === '/admin' ? 'page' : undefined}
+>
+  <span class="admin-nav-icon" set:html={icons.dashboard} />
+  <span class="admin-nav-label">Dashboard</span>
+</a>
+```
+
+The classes piggyback on existing `.admin-nav-link` / `.active` styles — re-using the same colour tokens, just without the surrounding group label.
+
+- [ ] **Step 3: Add minimal CSS for the header link**
+
+Find the existing `<style>` block in `AdminLayout.astro` and add this rule (anywhere inside, near the existing nav rules):
+
+```css
+.admin-nav-dashboard {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  margin-bottom: 0.5rem;
+  border-radius: 0.375rem;
+  color: inherit;
+  text-decoration: none;
+  font-weight: 600;
+  border-bottom: 1px solid var(--admin-border, rgba(255,255,255,0.08));
+}
+.admin-nav-dashboard.active {
+  background: var(--admin-nav-active-bg, rgba(255,255,255,0.06));
+}
+.admin-nav-dashboard .admin-nav-icon {
+  width: 1rem;
+  height: 1rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+```
+
+The `var(...)` fallbacks ensure both Mentolder (dark) and Kore (light/brass) brands render correctly without brand-specific overrides.
+
+- [ ] **Step 4: Sanity-check the rendered tree locally**
+
+Run: `cd website && npm run build 2>&1 | tail -20`
+Expected: build succeeds. Any errors here mean the JSX is malformed — fix before moving on.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add website/src/layouts/AdminLayout.astro
+git commit -m "feat(admin): render Dashboard as standalone header link above nav groups"
+```
+
+---
+
+## Task 4: Surface "Neue Session" as a button on the Sessions page
+
+R2 says menu items are nouns. The old `Neue Session` item was an action. After Task 2 it's gone from the menu — we need to make sure the create-flow is still discoverable.
+
+**Files:**
+- Modify: `website/src/pages/admin/coaching/sessions.astro` (or `.svelte` — check which it is)
+
+- [ ] **Step 1: Inspect the Sessions page**
+
+Run: `ls website/src/pages/admin/coaching/`
+Identify the file. Read it.
+
+- [ ] **Step 2: Add a "Neue Session" button**
+
+If a primary-action button already exists on the page, verify it points to `/admin/coaching/sessions/new` and skip to commit. Otherwise, add at the top of the page content (inside the page's `<header>` or alongside the title):
+
+```astro
+<a href="/admin/coaching/sessions/new" class="btn btn-primary">
+  + Neue Session
+</a>
+```
+
+(Match the existing button class convention — search for `btn-primary` usages in nearby pages to confirm the class name.)
+
+- [ ] **Step 3: Verify the page still builds**
+
+Run: `cd website && npm run build 2>&1 | tail -10`
+Expected: build succeeds.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add website/src/pages/admin/coaching/sessions.astro
+git commit -m "feat(admin): surface 'Neue Session' as button on Sessions page (R2 destinations not actions)"
+```
+
+---
+
+## Task 5: Write the gate script
+
+`scripts/admin-menu-gate.sh` enforces R1, R2, R4, R5, R7.
+
+**Files:**
+- Create: `scripts/admin-menu-gate.sh`
+
+- [ ] **Step 1: Create the script**
+
+Write `scripts/admin-menu-gate.sh` with this exact content:
+
+```bash
+#!/usr/bin/env bash
+# admin-menu-gate.sh — enforce admin menu rules (R1, R2, R4, R5, R7).
+#
+# Exits 0 if the menu in website/src/layouts/AdminLayout.astro complies with
+# the rules and every new /admin/* static page added in this branch (vs the
+# base ref) is reachable from the sidemenu.
+#
+# Override: ADMIN_MENU_GATE=skip   — exits 0 with a warning; PR title gets
+#                                    [menu-gate-skip] prefix in dev-flow-execute.
+
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+LAYOUT="website/src/layouts/AdminLayout.astro"
+DASHBOARD="website/src/pages/admin.astro"
+MAX_GROUPS=6
+MAX_ITEMS=6
+
+if [[ "${ADMIN_MENU_GATE:-}" == "skip" ]]; then
+  echo "⚠️  ADMIN_MENU_GATE=skip — gate bypassed (will be flagged in PR title)"
+  exit 0
+fi
+
+if [[ ! -f "$LAYOUT" ]]; then
+  echo "✗ $LAYOUT not found — wrong working directory?" >&2
+  exit 2
+fi
+
+# --- Step 1: extract reach set (hrefs + matches[] prefixes) from AdminLayout ---
+# We use awk on the navGroups literal. The shape is stable enough for this:
+#   { href: '/admin/foo', ..., matches: ['/admin/foo', '/admin/bar'] }
+
+REACH_SET=$(awk '
+  /href: *'\''/ {
+    match($0, /href: *'\''([^'\'']+)'\''/, m)
+    if (m[1]) print m[1]
+  }
+  /matches: *\[/, /\]/ {
+    while (match($0, /'\''([^'\'']+)'\''/, m)) {
+      print m[1]
+      $0 = substr($0, RSTART + RLENGTH)
+    }
+  }
+' "$LAYOUT" | sort -u)
+
+# Always include /admin (Dashboard header link)
+REACH_SET=$(printf '%s\n/admin\n' "$REACH_SET" | sort -u)
+
+# --- Step 2: count groups and items (R4, R5) ---
+GROUP_COUNT=$(awk '/^ *label: *'\''/{c++} END{print c+0}' "$LAYOUT")
+
+# Per-group item count: walk navGroups, count items between '{ href:' lines
+# bracketed by the same group's label..]. A bit ugly; uses braces depth.
+MAX_GROUP_SIZE=$(awk '
+  BEGIN { depth=0; n=0; max=0; in_items=0 }
+  /label: *'\''/ {
+    if (n > max) max = n
+    n = 0
+    in_items = 0
+  }
+  /items: *\[/ { in_items = 1; next }
+  in_items && /^ *\{ *href:/ { n++ }
+  /^ *\],? *$/ && in_items { in_items = 0 }
+  END {
+    if (n > max) max = n
+    print max
+  }
+' "$LAYOUT")
+
+# --- Step 3: collect labels (R2 — destinations not actions) ---
+LABELS=$(awk '
+  /label: *'\''/ {
+    match($0, /label: *'\''([^'\'']+)'\''/, m)
+    if (m[1]) print m[1]
+  }
+' "$LAYOUT")
+
+# --- Step 4: detect new static /admin/* pages added vs base ---
+NEW_ROUTES=$(git diff --name-only --diff-filter=AM "$BASE_REF" \
+  -- 'website/src/pages/admin/**/*.astro' 2>/dev/null \
+  | grep -v '\[' \
+  | grep -v '^website/src/pages/admin\.astro$' \
+  || true)
+
+# --- Step 5: derive canonical hrefs ---
+ROUTE_HREFS=$(printf '%s\n' "$NEW_ROUTES" \
+  | sed -E 's|^website/src/pages||; s|/index\.astro$||; s|\.astro$||' \
+  | grep -v '^$' || true)
+
+# --- Step 6: parse dashboard hrefs for R7 ---
+DASHBOARD_HREFS=""
+if [[ -f "$DASHBOARD" ]]; then
+  DASHBOARD_HREFS=$(grep -oE 'href="/admin[^"]*"' "$DASHBOARD" \
+    | sed -E 's|href="||; s|"$||' \
+    | sort -u || true)
+fi
+
+# --- Run checks ---
+FAILED=0
+echo "Admin-Menu Gate"
+echo "─────────────────────────────────────"
+
+# R5: group count
+if (( GROUP_COUNT > MAX_GROUPS )); then
+  echo "✗ R5  navGroups has $GROUP_COUNT groups (max $MAX_GROUPS)"
+  FAILED=1
+else
+  echo "✓ R5  navGroups = $GROUP_COUNT (≤ $MAX_GROUPS)"
+fi
+
+# R4: max items per group
+if (( MAX_GROUP_SIZE > MAX_ITEMS )); then
+  echo "✗ R4  Largest group has $MAX_GROUP_SIZE items (max $MAX_ITEMS)"
+  FAILED=1
+else
+  echo "✓ R4  Largest group = $MAX_GROUP_SIZE items (≤ $MAX_ITEMS)"
+fi
+
+# R2: label verb hygiene
+BAD_LABELS=$(echo "$LABELS" | grep -iE '^(neu|new|add|erstell|create)' || true)
+if [[ -n "$BAD_LABELS" ]]; then
+  echo "✗ R2  Action-labels in menu (use destinations / nouns):"
+  echo "$BAD_LABELS" | sed 's/^/    - /'
+  FAILED=1
+else
+  echo "✓ R2  All labels are destinations"
+fi
+
+# R1: orphan check on new routes
+ORPHANS=""
+if [[ -n "$ROUTE_HREFS" ]]; then
+  while IFS= read -r route; do
+    [[ -z "$route" ]] && continue
+    if echo "$REACH_SET" | grep -qxF "$route"; then
+      continue
+    fi
+    # Check dynamic-parent reachability: walk up the path
+    parent="$route"
+    matched=""
+    while [[ "$parent" == /admin/* ]]; do
+      parent="${parent%/*}"
+      if echo "$REACH_SET" | grep -qxF "$parent"; then
+        matched="$parent"
+        break
+      fi
+    done
+    if [[ -z "$matched" ]]; then
+      ORPHANS+="    - $route"$'\n'
+    fi
+  done <<< "$ROUTE_HREFS"
+fi
+
+if [[ -n "$ORPHANS" ]]; then
+  echo "✗ R1  New static admin routes not reachable from sidemenu:"
+  printf '%s' "$ORPHANS"
+  echo "      Suggestion: add to navGroups in $LAYOUT, or list parent in matches[]."
+  FAILED=1
+else
+  echo "✓ R1  All new admin routes are reachable"
+fi
+
+# R7: dashboard cross-ref
+DASHBOARD_ORPHANS=""
+if [[ -n "$DASHBOARD_HREFS" ]]; then
+  while IFS= read -r href; do
+    [[ -z "$href" ]] && continue
+    [[ "$href" == /admin ]] && continue
+    if echo "$REACH_SET" | grep -qxF "$href"; then
+      continue
+    fi
+    # check dynamic parent
+    parent="$href"
+    matched=""
+    while [[ "$parent" == /admin/* ]]; do
+      parent="${parent%/*}"
+      if echo "$REACH_SET" | grep -qxF "$parent"; then
+        matched="$parent"
+        break
+      fi
+    done
+    if [[ -z "$matched" ]]; then
+      DASHBOARD_ORPHANS+="    - $href"$'\n'
+    fi
+  done <<< "$DASHBOARD_HREFS"
+fi
+
+if [[ -n "$DASHBOARD_ORPHANS" ]]; then
+  echo "✗ R7  Dashboard links to orphan(s):"
+  printf '%s' "$DASHBOARD_ORPHANS"
+  echo "      Suggestion: either add the target to the sidemenu, or remove from $DASHBOARD."
+  FAILED=1
+else
+  echo "✓ R7  Dashboard hrefs are all reachable"
+fi
+
+echo "─────────────────────────────────────"
+if (( FAILED )); then
+  echo "Gate FAILED. See suggestions above. Set ADMIN_MENU_GATE=skip to bypass (logged)."
+  exit 1
+fi
+echo "Gate PASSED."
+exit 0
+```
+
+- [ ] **Step 2: Make it executable**
+
+Run:
+```bash
+chmod +x /home/patrick/Bachelorprojekt/.claude/worktrees/feature+admin-menu-rules/scripts/admin-menu-gate.sh
+```
+
+- [ ] **Step 3: Smoke-run against the current tree**
+
+```bash
+cd /home/patrick/Bachelorprojekt/.claude/worktrees/feature+admin-menu-rules
+bash scripts/admin-menu-gate.sh
+```
+Expected: `Gate PASSED.` (Tasks 2 + 3 have completed, so the live tree should comply.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/admin-menu-gate.sh
+git commit -m "feat(dev-flow): add admin-menu-gate.sh for orphan + cap enforcement"
+```
+
+---
+
+## Task 6: BATS coverage for the gate
+
+The gate is enforcement infrastructure — it needs its own tests, otherwise a regression silently disables it.
+
+**Files:**
+- Create: `tests/scripts/admin-menu-gate.bats`
+
+- [ ] **Step 1: Locate the BATS test layout**
+
+Run: `ls tests/scripts/ 2>/dev/null | head` to confirm directory convention.
+
+- [ ] **Step 2: Create the BATS test file**
+
+Write `tests/scripts/admin-menu-gate.bats` with this exact content:
+
+```bash
+#!/usr/bin/env bats
+# admin-menu-gate.bats — verifies R1/R2/R4/R5/R7 enforcement.
+
+setup() {
+  TMPDIR=$(mktemp -d)
+  cd "$TMPDIR"
+  git init -q
+  git config user.email "test@example.com"
+  git config user.name "Test"
+  mkdir -p website/src/layouts website/src/pages/admin scripts
+  cp "${BATS_TEST_DIRNAME}/../../scripts/admin-menu-gate.sh" scripts/
+  chmod +x scripts/admin-menu-gate.sh
+}
+
+teardown() {
+  rm -rf "$TMPDIR"
+}
+
+# Helper: write a minimal valid AdminLayout.astro
+write_layout() {
+  cat > website/src/layouts/AdminLayout.astro <<'EOF'
+const navGroups = [
+  {
+    label: 'Tagesgeschäft',
+    items: [
+      { href: '/admin/termine', label: 'Termine', icon: 'calendar' },
+    ],
+  },
+];
+EOF
+}
+
+# Helper: commit a clean baseline (so `origin/main` diff resolves)
+commit_baseline() {
+  write_layout
+  touch website/src/pages/admin.astro
+  git add -A
+  git commit -q -m "baseline"
+  git branch -M main
+  git remote add origin "$TMPDIR" 2>/dev/null || true
+  git update-ref refs/remotes/origin/main HEAD
+}
+
+@test "passes on clean baseline" {
+  commit_baseline
+  run bash scripts/admin-menu-gate.sh
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Gate PASSED"* ]]
+}
+
+@test "R1: fails when a new static admin page has no nav entry" {
+  commit_baseline
+  mkdir -p website/src/pages/admin
+  echo "<h1>Forecasting</h1>" > website/src/pages/admin/forecasting.astro
+  git add -A
+  run bash scripts/admin-menu-gate.sh
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"R1"* ]]
+  [[ "$output" == *"/admin/forecasting"* ]]
+}
+
+@test "R1: passes when new page is added to navGroups" {
+  commit_baseline
+  cat > website/src/layouts/AdminLayout.astro <<'EOF'
+const navGroups = [
+  {
+    label: 'Tagesgeschäft',
+    items: [
+      { href: '/admin/termine',     label: 'Termine',     icon: 'calendar' },
+      { href: '/admin/forecasting', label: 'Forecasting', icon: 'star' },
+    ],
+  },
+];
+EOF
+  mkdir -p website/src/pages/admin
+  echo "<h1>Forecasting</h1>" > website/src/pages/admin/forecasting.astro
+  git add -A
+  run bash scripts/admin-menu-gate.sh
+  [ "$status" -eq 0 ]
+}
+
+@test "R1: dynamic [param] routes are exempt (parent must be in menu)" {
+  commit_baseline
+  mkdir -p website/src/pages/admin/projekte
+  echo "<h1>Detail</h1>" > "website/src/pages/admin/projekte/[id].astro"
+  git add -A
+  # Parent /admin/projekte is not in the menu either, so this should still pass
+  # for the [id] file (excluded by the gate's grep -v '\['), but FAIL only if
+  # the user added a static /admin/projekte.astro without listing it.
+  run bash scripts/admin-menu-gate.sh
+  [ "$status" -eq 0 ]
+}
+
+@test "R2: fails when a label starts with 'Neue'" {
+  cat > website/src/layouts/AdminLayout.astro <<'EOF'
+const navGroups = [
+  {
+    label: 'Coaching',
+    items: [
+      { href: '/admin/coaching/sessions/new', label: 'Neue Session', icon: 'plus' },
+    ],
+  },
+];
+EOF
+  touch website/src/pages/admin.astro
+  git add -A
+  git commit -q -m "baseline"
+  git update-ref refs/remotes/origin/main HEAD
+  run bash scripts/admin-menu-gate.sh
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"R2"* ]]
+  [[ "$output" == *"Neue Session"* ]]
+}
+
+@test "R4: fails when a group has >6 items" {
+  cat > website/src/layouts/AdminLayout.astro <<'EOF'
+const navGroups = [
+  {
+    label: 'Toomany',
+    items: [
+      { href: '/admin/a', label: 'A', icon: 'x' },
+      { href: '/admin/b', label: 'B', icon: 'x' },
+      { href: '/admin/c', label: 'C', icon: 'x' },
+      { href: '/admin/d', label: 'D', icon: 'x' },
+      { href: '/admin/e', label: 'E', icon: 'x' },
+      { href: '/admin/f', label: 'F', icon: 'x' },
+      { href: '/admin/g', label: 'G', icon: 'x' },
+    ],
+  },
+];
+EOF
+  touch website/src/pages/admin.astro
+  git add -A
+  git commit -q -m "baseline"
+  git update-ref refs/remotes/origin/main HEAD
+  run bash scripts/admin-menu-gate.sh
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"R4"* ]]
+}
+
+@test "R5: fails when navGroups has >6 groups" {
+  cat > website/src/layouts/AdminLayout.astro <<'EOF'
+const navGroups = [
+  { label: 'G1', items: [ { href: '/admin/1', label: 'A', icon: 'x' } ] },
+  { label: 'G2', items: [ { href: '/admin/2', label: 'A', icon: 'x' } ] },
+  { label: 'G3', items: [ { href: '/admin/3', label: 'A', icon: 'x' } ] },
+  { label: 'G4', items: [ { href: '/admin/4', label: 'A', icon: 'x' } ] },
+  { label: 'G5', items: [ { href: '/admin/5', label: 'A', icon: 'x' } ] },
+  { label: 'G6', items: [ { href: '/admin/6', label: 'A', icon: 'x' } ] },
+  { label: 'G7', items: [ { href: '/admin/7', label: 'A', icon: 'x' } ] },
+];
+EOF
+  touch website/src/pages/admin.astro
+  git add -A
+  git commit -q -m "baseline"
+  git update-ref refs/remotes/origin/main HEAD
+  run bash scripts/admin-menu-gate.sh
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"R5"* ]]
+}
+
+@test "R7: fails when dashboard links to an orphan" {
+  cat > website/src/layouts/AdminLayout.astro <<'EOF'
+const navGroups = [
+  {
+    label: 'G',
+    items: [
+      { href: '/admin/termine', label: 'Termine', icon: 'calendar' },
+    ],
+  },
+];
+EOF
+  cat > website/src/pages/admin.astro <<'EOF'
+<a href="/admin/projekte">Aktive Projekte</a>
+EOF
+  git add -A
+  git commit -q -m "baseline"
+  git update-ref refs/remotes/origin/main HEAD
+  run bash scripts/admin-menu-gate.sh
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"R7"* ]]
+  [[ "$output" == *"/admin/projekte"* ]]
+}
+
+@test "ADMIN_MENU_GATE=skip bypasses with warning" {
+  commit_baseline
+  mkdir -p website/src/pages/admin
+  echo "<h1>Forecasting</h1>" > website/src/pages/admin/forecasting.astro
+  git add -A
+  ADMIN_MENU_GATE=skip run bash scripts/admin-menu-gate.sh
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"bypassed"* ]]
+}
+```
+
+- [ ] **Step 3: Run the BATS suite**
+
+```bash
+cd /home/patrick/Bachelorprojekt/.claude/worktrees/feature+admin-menu-rules
+bats tests/scripts/admin-menu-gate.bats
+```
+Expected: all 9 tests pass.
+
+- [ ] **Step 4: If any test fails**
+
+The most likely failure points are:
+- `R1: dynamic [param] routes are exempt` — if it fails, the gate's `grep -v '\['` is wrong. Adjust to `grep -v '\[.*\]'`.
+- `R4`/`R5` awk counters — these are the fragilest parts. Add `set -x` near the awk block in `admin-menu-gate.sh` to inspect, then fix.
+
+Iterate until all pass before moving on.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/scripts/admin-menu-gate.bats
+git commit -m "test(admin-menu-gate): BATS coverage for R1, R2, R4, R5, R7"
+```
+
+---
+
+## Task 7: Wire gate into Taskfile
+
+`task test:menu-gate` runs the gate against the working tree. Folded into `test:all` so CI catches drift.
+
+**Files:**
+- Modify: `Taskfile.yml`
+
+- [ ] **Step 1: Find the `test:all` task definition**
+
+Run: `grep -nE '^  test:(all|unit|manifests|menu-gate):' Taskfile.yml`
+Expected: see `test:all`, `test:unit`, `test:manifests`. We're inserting between them.
+
+- [ ] **Step 2: Add `test:menu-gate` task**
+
+Insert (near the other `test:*` tasks):
+
+```yaml
+  test:menu-gate:
+    desc: Enforce admin-menu rules (R1, R2, R4, R5, R7)
+    cmds:
+      - bash scripts/admin-menu-gate.sh
+```
+
+- [ ] **Step 3: Add `test:menu-gate` to `test:all` deps**
+
+Find the `test:all` task and append to its `deps:` list (or `cmds:` if it's a sequence):
+
+```yaml
+  test:all:
+    desc: Run all offline tests
+    deps:
+      - test:unit
+      - test:manifests
+      - test:menu-gate     # NEW
+```
+
+(If `test:all` uses `cmds:` with `task: ...` invocations instead, append `- task: test:menu-gate` in the right ordering.)
+
+- [ ] **Step 4: Verify**
+
+```bash
+cd /home/patrick/Bachelorprojekt/.claude/worktrees/feature+admin-menu-rules
+task test:menu-gate
+```
+Expected: `Gate PASSED.`
+
+```bash
+task test:all
+```
+Expected: all tasks succeed including the new gate.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Taskfile.yml
+git commit -m "ci(taskfile): add test:menu-gate to test:all"
+```
+
+---
+
+## Task 8: Add Schritt 3.5 to dev-flow-execute
+
+Document the gate inside the skill so it's part of every feature/fix branch's verification flow.
+
+**Files:**
+- Modify: `.claude/skills/dev-flow-execute/SKILL.md`
+
+- [ ] **Step 1: Insert Schritt 3.5 between Schritt 3 and Schritt 4**
+
+Find the line `## Schritt 4: Pre-Merge Preview auf dev k3d (optional)` and insert this section *before* it:
+
+````markdown
+## Schritt 3.5: Admin-Menu Placement Gate
+
+Falls die Implementierung neue Seiten unter `website/src/pages/admin/` hinzugefügt hat, muss jede statische Route aus dem Sidemenu erreichbar sein (siehe Regel R1–R10 in `docs/superpowers/specs/2026-05-18-admin-menu-rules-design.md`).
+
+```bash
+bash scripts/admin-menu-gate.sh
+```
+
+| Exit | Bedeutung | Aktion |
+|---|---|---|
+| `0` (Gate PASSED) | Alles ok — weiter zu Schritt 4. | — |
+| `1` (Gate FAILED) | Mindestens eine Regel verletzt. | Output lesen, im AdminLayout.astro nachpflegen, erneut laufen. |
+| `2` | Wrong working directory. | In den Worktree wechseln und erneut versuchen. |
+
+### Bypass (nur in Ausnahmefällen)
+
+```bash
+ADMIN_MENU_GATE=skip bash scripts/admin-menu-gate.sh
+```
+
+Wenn der Gate übersprungen wird: **PR-Titel mit `[menu-gate-skip]` prefixen** und im PR-Body begründen (z.B. "absichtlich orphan — dynamic redirect target only, kein Bedarf für Menüplatz"). Reviewer haben damit ein klares Signal.
+
+### Häufige Failure-Modi
+
+| Failure | Typische Ursache | Fix |
+|---|---|---|
+| `R1 orphan` | Neue `/admin/foo.astro` ohne Eintrag in `navGroups`. | Item in passender Gruppe ergänzen, oder Parent-Route in `matches[]` listen. |
+| `R2 label` | `'Neue Session'` o.ä. als `label`. | Item entfernen, Create-Aktion als Button auf der Zielseite. |
+| `R4 group >6` | Zu viele Items in einer Gruppe. | Item in andere Gruppe verschieben, oder Gruppe aufteilen. |
+| `R5 groups >6` | Zu viele Gruppen. | Verwandte Gruppen zusammenführen. |
+| `R7 dashboard orphan` | KPI-Card linkt auf Route die nicht im Sidemenu liegt. | Entweder Route ins Sidemenu, oder Dashboard-Link entfernen. |
+
+---
+
+````
+
+- [ ] **Step 2: Cross-check the section heading numbers**
+
+The skill currently jumps from Schritt 3 → Schritt 4. After our insert, the flow becomes Schritt 3 → Schritt 3.5 → Schritt 4. No downstream renumbering needed (the existing 4/5/5.5/6/6.5/7/7.5/8 stay as-is).
+
+- [ ] **Step 3: Verify the markdown still renders cleanly**
+
+```bash
+# Quick smell check — no broken tables, balanced code fences
+cd /home/patrick/Bachelorprojekt/.claude/worktrees/feature+admin-menu-rules
+grep -c '^```' .claude/skills/dev-flow-execute/SKILL.md
+```
+Expected: an even number (each open fence has a close).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .claude/skills/dev-flow-execute/SKILL.md
+git commit -m "docs(dev-flow-execute): add Schritt 3.5 — Admin-Menu Placement Gate"
+```
+
+---
+
+## Task 9: Full local verification
+
+End-to-end pass: build the website, run the gate against the post-implementation tree, run the full offline test suite.
+
+- [ ] **Step 1: Website build**
+
+```bash
+cd /home/patrick/Bachelorprojekt/.claude/worktrees/feature+admin-menu-rules/website
+npm run build 2>&1 | tail -20
+```
+Expected: build succeeds; no Astro errors. Warnings about pre-existing things are fine.
+
+- [ ] **Step 2: Gate run**
+
+```bash
+cd /home/patrick/Bachelorprojekt/.claude/worktrees/feature+admin-menu-rules
+bash scripts/admin-menu-gate.sh
+```
+Expected: `Gate PASSED.`
+
+- [ ] **Step 3: Full offline test suite**
+
+```bash
+task test:all
+```
+Expected: all tasks succeed. If `test:inventory` mentions drift in `website/src/data/test-inventory.json`, regenerate per CLAUDE.md note: `task test:inventory` and add the diff to a new commit.
+
+- [ ] **Step 4: Workspace validation (manifests untouched, but cheap and catches accidental damage)**
+
+```bash
+task workspace:validate
+```
+Expected: success.
+
+- [ ] **Step 5: Spot-check the admin sidebar visually (dev server)**
+
+Optional but valuable:
+```bash
+task website:dev   # Astro dev server on localhost
+# Visit http://localhost:4321/admin and confirm:
+#  - Dashboard renders as a standalone header link
+#  - 6 groups in the order: Tagesgeschäft, Klienten, Coaching, Wissen & Inhalte, Geld, Plattform
+#  - draftsPending and inboxPending badges still appear
+#  - Active-state highlighting still works on each group's items
+# Stop with Ctrl+C
+```
+
+- [ ] **Step 6: If anything failed**
+
+- Build failures → fix in `AdminLayout.astro`, re-commit on the same branch.
+- Gate failures → most likely a typo in `navGroups`; check the `awk` output by running `bash -x scripts/admin-menu-gate.sh 2>&1 | head -40`.
+- BATS failures from `test:all` → re-run `bats tests/scripts/admin-menu-gate.bats` standalone, debug.
+
+No new commit needed if everything passes — Task 5–8 commits cover the work.
+
+---
+
+## Task 10: Hand off to PR
+
+This is the final task — push, open PR, let dev-flow-execute Schritt 5 onwards handle the rest.
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+cd /home/patrick/Bachelorprojekt/.claude/worktrees/feature+admin-menu-rules
+git push -u origin feature/admin-menu-rules
+```
+
+- [ ] **Step 2: Open the PR via `gh`**
+
+```bash
+gh pr create \
+  --title "feat(admin): codify menu rules + reshuffle sidemenu + add placement gate" \
+  --body "$(cat <<'EOF'
+## Summary
+- Codifies 10 admin-menu rules (R1–R10) in `docs/superpowers/specs/2026-05-18-admin-menu-rules-design.md`
+- Reshuffles `AdminLayout.astro` into 6 task-based groups (Tagesgeschäft, Klienten, Coaching, Wissen & Inhalte, Geld, Plattform), Dashboard as header link
+- Surfaces all 19 formerly-orphan admin pages (Projekte, Meetings, Followups, Nachrichten, Räume, Buchhaltung, Zeiterfassung, Steuer, Brett, Vorlagen, Systemtest, …)
+- Fixes Dashboard KPI broken-link (`/admin/projekte` now in sidemenu)
+- Adds `scripts/admin-menu-gate.sh` (R1/R2/R4/R5/R7 enforcement) + BATS coverage + `task test:menu-gate`
+- Documents Schritt 3.5 in `dev-flow-execute` so future PRs that add `/admin/*` routes can't ship orphans
+
+## Test plan
+- [x] `task test:all` (includes new `test:menu-gate`)
+- [x] `bats tests/scripts/admin-menu-gate.bats` — 9 tests
+- [x] `bash scripts/admin-menu-gate.sh` against post-implementation tree → PASSED
+- [x] `cd website && npm run build` — builds clean
+- [x] Manual: `task website:dev` → /admin sidebar renders Dashboard header + 6 groups, badges intact
+- [ ] Post-merge: deploy via `task feature:website`, smoke-check web.mentolder.de/admin and web.korczewski.de/admin
+
+Closes T000449
+EOF
+)"
+```
+
+- [ ] **Step 3: Note the PR number**
+
+```bash
+PR_NUM=$(gh pr view --json number -q '.number')
+echo "PR #$PR_NUM"
+```
+
+From here, `dev-flow-execute` Schritt 6 onwards (auto-merge, ticket close, plan archive, deploy via `task feature:website`) takes over.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- R1 (no orphans) — Task 5 (gate) + Task 2 (places every formerly-orphan)
+- R2 (destinations not actions) — Task 4 (Sessions button) + Task 5 (gate label check)
+- R3 (group by task) — Task 2 (new group labels)
+- R4/R5 (caps) — Task 5 (gate enforces both)
+- R6 (frequency order within group) — Task 2 (item order in `navGroups` literal)
+- R7 (dashboard ⊆ sidemenu) — Task 5 (R7 check)
+- R8 (badges on items) — Task 2 (preserves `inboxPending`, `draftsPending`)
+- R9 (brand parity) — implicit; `AdminLayout.astro` has no brand check around `navGroups`
+- R10 (placement gate in workflow) — Task 8 (Schritt 3.5)
+- Dashboard KPI broken-link — Task 2 (puts `/admin/projekte` in Klienten)
+- Missing icons mishap — Task 1 (`folder`, `settings`, `chat`)
+
+**Placeholder scan:** None — every code block contains executable content.
+
+**Type consistency:** `NavItem` interface in `AdminLayout.astro` is unchanged; new items use existing fields (`href`, `label`, `icon`, `matches`, `badge`). Gate output strings ("Gate PASSED.", "R1", "R2", etc.) are checked verbatim by the BATS tests.
+
+**Open question (non-blocking):** Task 4 assumes `sessions.astro` exists in `pages/admin/coaching/`. The Explore agent confirmed `/admin/coaching/sessions` is in the current sidemenu, so the page exists, but the file might be `.svelte` or under a different path. Step 1 of Task 4 handles the discovery.

--- a/docs/superpowers/specs/2026-05-18-admin-menu-rules-design.md
+++ b/docs/superpowers/specs/2026-05-18-admin-menu-rules-design.md
@@ -1,0 +1,173 @@
+---
+slug: admin-menu-rules
+status: draft
+domains: [website]
+brands: [mentolder, korczewski]
+---
+
+# Admin-Menu Rules & Reshuffle — Design
+
+## Context
+
+The admin sidemenu in `website/src/layouts/AdminLayout.astro` currently holds **7 groups / 22 items**, with **19 orphan `/admin/*` routes** that aren't reachable from any menu and **8 redirect-only routes** doing soft fix-ups. The Dashboard KPI links to one of the orphans (`/admin/projekte`), which is the clearest symptom: navigation surfaces disagree on which pages exist.
+
+Three structural problems drive the disorder:
+
+- **No placement gate.** PRs that add `/admin/<route>.astro` can ship without touching `AdminLayout.astro`. Orphans accumulate silently.
+- **Mixed-concept groups.** `System` is a junk drawer (`Cluster-Steuerung`, `Monitoring`, `Arena`, `Inbox` — four orthogonal jobs). `Inhalte` is a single item with eight hidden sub-routes. Accounting is split across one in-menu item (`Rechnungen`) and three orphans (`Buchhaltung`, `Steuer`, `Zeiterfassung`).
+- **Actions in destinations' clothing.** `Neue Session` is a verb sitting in a list of nouns; it adds noise to the Coaching group.
+
+We close all three by codifying menu rules and enforcing the placement gate in `dev-flow-execute`. The reshuffle proves the rules are workable on a real case.
+
+## The 10 Rules
+
+These rules govern every admin menu change going forward. Each rule traces to a problem above; each is checkable in code (the gate enforces R1–R3, R7, R10).
+
+| # | Rule | Source of truth |
+|---|---|---|
+| **R1** | **No orphans.** Every `/admin/*` route is reachable from the sidemenu within 2 clicks — either listed directly as a `NavItem`, or as a `matches[]` sub-route of a listed item, or as a dynamic sub-page (`[param]`) of a listed parent. | Detected by gate diffing `git diff origin/main -- 'website/src/pages/admin/**'`. |
+| **R2** | **Destinations, not actions.** `NavItem.label` is a noun. Create-actions live as buttons on the destination page (`/admin/coaching/sessions/new` is reached from the `Sessions` page, not via the sidebar). | Gate lints labels against a verb blocklist (`/^(neu|new|add|erstell|create)/i`). |
+| **R3** | **Group by user task, not subsystem.** Group label names the kind of work the user does ("Geld", "Plattform"), not the codebase layer ("Billing", "DevOps"). | Editorial — reviewed in PRs, not auto-enforced. |
+| **R4** | **Group size ≤ 6 items.** If a group needs more, split or promote a child page. | Gate counts `items[]` per group. |
+| **R5** | **Functional groups ≤ 6.** Dashboard is a header, not a group. | Gate counts `navGroups[]`; Dashboard rendered as a standalone link above the groups. |
+| **R6** | **Frequency-order within group.** Most-used at top. | Editorial. |
+| **R7** | **Dashboard KPIs / quick-links must target sidemenu items.** No widget references an orphan. | Gate parses `website/src/pages/admin.astro` for `href="/admin/..."` and cross-references against the menu. |
+| **R8** | **Badges live next to their item.** Counts (drafts pending, inbox unread) belong on the item that resolves them. | Already done by `NavItem.badge`. Lifted to a rule to keep it that way. |
+| **R9** | **Brands share the menu by default.** Mentolder and Korczewski use the same `navGroups`. Brand divergence requires an explicit `if (brandId === ...)` block with a comment justifying the split. | Editorial — flagged in review if a brand check appears around the menu without a comment. |
+| **R10** | **Adding a new `/admin/*` page is incomplete until it's placed.** The PR cannot merge until the gate is clean. | Hard gate in `dev-flow-execute` Schritt 3.5. |
+
+## Target Menu (applying R1–R9)
+
+Header (standalone, not a group):
+- **Dashboard** → `/admin`
+
+Then six groups, each within the ≤ 6-items cap:
+
+| Group | Items | Notes |
+|---|---|---|
+| **Tagesgeschäft** (6) | Termine · Tickets · Inbox · Live · Nachrichten · Räume | `Nachrichten`, `Räume` formerly orphan. `Inbox` moved here from "System" (it's communication, not platform admin). |
+| **Klienten** (5) | Klienten · Projekte · Meetings · Kalender · Followups | `Projekte`, `Meetings`, `Followups` formerly orphan. Closes the Dashboard-KPI broken-link (`/admin/projekte`). |
+| **Coaching** (4) | Sessions · Projekte · Brett · KI-Einstellungen | `Brett` formerly orphan (proxy iframe under `/admin/brett`). `Neue Session` removed — surfaced as a button on the Sessions page. The two `Projekte` items are disambiguated by group: "Klienten → Projekte" vs "Coaching → Projekte". |
+| **Wissen & Inhalte** (5) | Website-Inhalte · Bücher · Drafts · Quellen · Vorlagen | `Vorlagen` formerly orphan (`/admin/knowledge/templates`). `draftsPending` badge stays on Drafts. |
+| **Geld** (4) | Rechnungen · Buchhaltung · Zeiterfassung · Steuer | All three formerly-orphans consolidated next to `Rechnungen`. |
+| **Plattform** (6) | Monitoring · Software-History · Systemtest · Arena · Cluster-Steuerung · Einstellungen | `Systemtest` formerly orphan (`/admin/systemtest/board`). Arena is the admin view of a service offering — it belongs alongside Monitoring, not in Tagesgeschäft. |
+
+**Dynamic sub-routes** (exempt from R1 — reached from their parent):
+
+- `/admin/projekte/[id]` ← parent: Klienten/Projekte
+- `/admin/meetings/[id]` ← parent: Klienten/Meetings
+- `/admin/coaching/sessions/[id]`, `/new` ← parent: Coaching/Sessions
+- `/admin/live/sessions/[id]` ← parent: Tagesgeschäft/Live
+- `/admin/fragebogen/[assignmentId]` ← parent: Coaching/Sessions (questionnaire flow)
+- `/admin/billing/elster`, `/admin/billing/[id]/drucken` ← parent: Geld/Rechnungen
+- `/admin/brett/[...path]` ← parent: Coaching/Brett (proxy passthrough)
+- `/admin/knowledge/snippets/[id]/publish` ← parent: Wissen & Inhalte/Drafts
+
+**Redirect routes** kept as-is for backward compatibility (URL preservation): `bugs → tickets`, `stream → live`, `newsletter → dokumente`, and the brand-section redirects (`coaching`, `50plus-digital`, etc.) into `/admin/inhalte?tab=…`.
+
+## dev-flow-execute Integration
+
+A new **Schritt 3.5 — Admin-Menu Placement Gate** sits between Schritt 3 (Lokale Verifikation) and Schritt 5 (PR). It runs `scripts/admin-menu-gate.sh` against the diff vs `origin/main`.
+
+### Gate Logic
+
+```
+1. Enumerate new/modified static admin pages:
+     git diff --name-only origin/main \
+       -- 'website/src/pages/admin/**/*.astro' \
+       | grep -v '\[.*\]'        # exclude dynamic routes
+
+2. For each route, derive canonical href:
+     website/src/pages/admin/foo/bar.astro     -> /admin/foo/bar
+     website/src/pages/admin/foo/index.astro   -> /admin/foo
+
+3. Parse AdminLayout.astro to extract:
+     - navGroups[].items[].href
+     - navGroups[].items[].matches[]
+     Reach set = union of both.
+
+4. For each route, check:
+     - Listed directly       (href in reach set)         -> OK
+     - Listed via matches[]  (any matches[] prefix hits) -> OK
+     - Dynamic parent listed (parent dir has a NavItem)  -> OK
+     - Otherwise                                          -> ORPHAN
+
+5. R4/R5 caps:
+     - len(navGroups) <= 6
+     - max(len(group.items) for group in navGroups) <= 6
+
+6. R7 (dashboard cross-ref):
+     For each href in website/src/pages/admin.astro that starts with /admin/,
+     verify it appears in the reach set.
+
+7. R2 (label hygiene):
+     For each NavItem.label, fail if matches /^(neu|new|add|erstell|create)/i
+
+Exit non-zero with a structured report if any rule fails.
+```
+
+### Failure UX
+
+The gate prints a precise report and exits 1:
+
+```
+✗ Admin-Menu Gate failed (3 issues)
+
+R1 No orphans — 1 new static admin page is not reachable:
+  - /admin/widgetwall (added by this branch)
+    Suggestion: add to Tagesgeschäft, or list parent /admin in matches[].
+
+R4 Group size cap — 'Tagesgeschäft' has 7 items (max 6):
+  - Termine, Tickets, Inbox, Live, Nachrichten, Räume, Widgetwall
+    Suggestion: move 'Widgetwall' to a different group, or split 'Tagesgeschäft'.
+
+R7 Dashboard cross-ref — KPI links to orphan:
+  - admin.astro: href="/admin/forecasting"  (not in sidemenu)
+```
+
+Patrick can override with `ADMIN_MENU_GATE=skip` (logged, but the PR title gets prefixed with `[menu-gate-skip]` so it's reviewable). Default behaviour is hard-fail.
+
+### Where the script lives
+
+- `scripts/admin-menu-gate.sh` — the actual gate (bash + `jq` + minimal awk parsing of `AdminLayout.astro`)
+- `.claude/skills/dev-flow-execute/SKILL.md` — Schritt 3.5 documented, invokes the script
+
+The gate runs:
+- In `dev-flow-execute` Schritt 3.5 (interactive, blocking)
+- As an offline test in `task test:menu-gate` so CI catches drift even when Patrick bypasses `dev-flow-execute`
+
+## Out of Scope
+
+- **Building missing pages.** Every "orphan" already exists as a working page — we're only wiring them into the menu. No new functionality.
+- **Brand divergence.** Mentolder and Korczewski continue to share `navGroups`. The Kore brand only changes typography/styling.
+- **Dashboard redesign.** We only fix `/admin/projekte`'s broken-link symptom. Reorganising KPI cards or service tiles is a separate spec.
+- **Permission gating.** Hide vs. grey-out is a real question, but not for this round. We treat all admin items as visible to anyone reaching `/admin/*` (i.e. anyone in the `dev-access` / admin Keycloak group).
+- **Mobile sidebar UX.** Out of scope.
+- **Icon design system.** We'll fix the two referenced-but-missing icons (`folder`, `settings`) inline, but the broader icon library is untouched.
+
+## Verification
+
+The implementation is considered complete when:
+
+1. **`AdminLayout.astro` renders the target menu.** `Dashboard` is a standalone header link above the groups; 6 groups (`Tagesgeschäft`, `Klienten`, `Coaching`, `Wissen & Inhalte`, `Geld`, `Plattform`), each ≤ 6 items.
+2. **Dashboard KPI for "Aktive Projekte" resolves.** Following `/admin/projekte` returns 200, and the same href appears as a `NavItem` in `Klienten`.
+3. **`scripts/admin-menu-gate.sh` exits 0** on the post-implementation tree.
+4. **`task test:menu-gate` exits 0** offline.
+5. **`task feature:website`** deploys cleanly to both clusters; `https://web.mentolder.de/admin` and `https://web.korczewski.de/admin` show the new menu with all six groups, badges intact (`draftsPending`, `inboxPending`).
+6. **No regressions in `task test:all`.**
+
+Smoke checks against live URLs:
+
+- `web.mentolder.de/admin` — load page, sidebar shows Dashboard + 6 groups, no overflow.
+- `web.mentolder.de/admin/projekte` — page loads (was orphan; now linked).
+- `web.korczewski.de/admin` — same structure, Kore styling intact.
+
+## Mishaps Found During Spec
+
+These are unrelated to the rules but were spotted during the audit:
+
+- **MISHAP (broken):** `AdminLayout.astro` references `icon: 'folder'` and `icon: 'settings'` in the Coaching group, but neither icon is defined in the `icons` record (lines 35–65). The SVG slot renders empty. Fix inline during reshuffle.
+
+## Brainstorm Reference
+
+This design was settled in a brainstorming session on 2026-05-18. The 10 rules were proposed by Claude and accepted by Patrick without modification (response: "do it").

--- a/scripts/admin-menu-gate.sh
+++ b/scripts/admin-menu-gate.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+# admin-menu-gate.sh — enforce admin menu rules (R1, R2, R4, R5, R7).
+#
+# Exits 0 if the menu in website/src/layouts/AdminLayout.astro complies with
+# the rules and every new /admin/* static page added in this branch (vs the
+# base ref) is reachable from the sidemenu.
+#
+# Override: ADMIN_MENU_GATE=skip   — exits 0 with a warning; PR title gets
+#                                    [menu-gate-skip] prefix in dev-flow-execute.
+
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+LAYOUT="website/src/layouts/AdminLayout.astro"
+DASHBOARD="website/src/pages/admin.astro"
+MAX_GROUPS=6
+MAX_ITEMS=6
+
+if [[ "${ADMIN_MENU_GATE:-}" == "skip" ]]; then
+  echo "⚠️  ADMIN_MENU_GATE=skip — gate bypassed (will be flagged in PR title)"
+  exit 0
+fi
+
+if [[ ! -f "$LAYOUT" ]]; then
+  echo "✗ $LAYOUT not found — wrong working directory?" >&2
+  exit 2
+fi
+
+# --- Step 1: extract reach set (hrefs + matches[] prefixes) from AdminLayout ---
+# We use awk on the navGroups literal. The shape is stable enough for this:
+#   { href: '/admin/foo', ..., matches: ['/admin/foo', '/admin/bar'] }
+
+REACH_SET=$(awk '
+  /href: *'\''/ {
+    match($0, /href: *'\''([^'\'']+)'\''/, m)
+    if (m[1]) print m[1]
+  }
+  /matches: *\[/, /\]/ {
+    while (match($0, /'\''([^'\'']+)'\''/, m)) {
+      print m[1]
+      $0 = substr($0, RSTART + RLENGTH)
+    }
+  }
+' "$LAYOUT" | sort -u)
+
+# Always include /admin (Dashboard header link)
+REACH_SET=$(printf '%s\n/admin\n' "$REACH_SET" | sort -u)
+
+# --- Step 2: count groups and items (R4, R5) ---
+GROUP_COUNT=$(awk '/^ *label: *'\''/{c++} END{print c+0}' "$LAYOUT")
+
+# Per-group item count: walk navGroups, count items between '{ href:' lines
+# bracketed by the same group's label..]. A bit ugly; uses braces depth.
+MAX_GROUP_SIZE=$(awk '
+  BEGIN { depth=0; n=0; max=0; in_items=0 }
+  /label: *'\''/ {
+    if (n > max) max = n
+    n = 0
+    in_items = 0
+  }
+  /items: *\[/ { in_items = 1; next }
+  in_items && /^ *\{ *href:/ { n++ }
+  /^ *\],? *$/ && in_items { in_items = 0 }
+  END {
+    if (n > max) max = n
+    print max
+  }
+' "$LAYOUT")
+
+# --- Step 3: collect labels (R2 — destinations not actions) ---
+LABELS=$(awk '
+  /label: *'\''/ {
+    match($0, /label: *'\''([^'\'']+)'\''/, m)
+    if (m[1]) print m[1]
+  }
+' "$LAYOUT")
+
+# --- Step 4: detect new static /admin/* pages added vs base ---
+NEW_ROUTES=$(git diff --name-only --diff-filter=AM "$BASE_REF" \
+  -- 'website/src/pages/admin/**/*.astro' 2>/dev/null \
+  | grep -v '\[' \
+  | grep -v '^website/src/pages/admin\.astro$' \
+  || true)
+
+# --- Step 5: derive canonical hrefs ---
+ROUTE_HREFS=$(printf '%s\n' "$NEW_ROUTES" \
+  | sed -E 's|^website/src/pages||; s|/index\.astro$||; s|\.astro$||' \
+  | grep -v '^$' || true)
+
+# --- Step 6: parse dashboard hrefs for R7 ---
+DASHBOARD_HREFS=""
+if [[ -f "$DASHBOARD" ]]; then
+  DASHBOARD_HREFS=$(grep -oE 'href="/admin[^"]*"' "$DASHBOARD" \
+    | sed -E 's|href="||; s|"$||' \
+    | sort -u || true)
+fi
+
+# --- Run checks ---
+FAILED=0
+echo "Admin-Menu Gate"
+echo "─────────────────────────────────────"
+
+# R5: group count
+if (( GROUP_COUNT > MAX_GROUPS )); then
+  echo "✗ R5  navGroups has $GROUP_COUNT groups (max $MAX_GROUPS)"
+  FAILED=1
+else
+  echo "✓ R5  navGroups = $GROUP_COUNT (≤ $MAX_GROUPS)"
+fi
+
+# R4: max items per group
+if (( MAX_GROUP_SIZE > MAX_ITEMS )); then
+  echo "✗ R4  Largest group has $MAX_GROUP_SIZE items (max $MAX_ITEMS)"
+  FAILED=1
+else
+  echo "✓ R4  Largest group = $MAX_GROUP_SIZE items (≤ $MAX_ITEMS)"
+fi
+
+# R2: label verb hygiene
+BAD_LABELS=$(echo "$LABELS" | grep -iE '^(neu|new|add|erstell|create)' || true)
+if [[ -n "$BAD_LABELS" ]]; then
+  echo "✗ R2  Action-labels in menu (use destinations / nouns):"
+  echo "$BAD_LABELS" | sed 's/^/    - /'
+  FAILED=1
+else
+  echo "✓ R2  All labels are destinations"
+fi
+
+# R1: orphan check on new routes
+ORPHANS=""
+if [[ -n "$ROUTE_HREFS" ]]; then
+  while IFS= read -r route; do
+    [[ -z "$route" ]] && continue
+    if echo "$REACH_SET" | grep -qxF "$route"; then
+      continue
+    fi
+    # Check dynamic-parent reachability: walk up the path
+    parent="$route"
+    matched=""
+    while [[ "$parent" == /admin/* ]]; do
+      parent="${parent%/*}"
+      if echo "$REACH_SET" | grep -qxF "$parent"; then
+        matched="$parent"
+        break
+      fi
+    done
+    if [[ -z "$matched" ]]; then
+      ORPHANS+="    - $route"$'\n'
+    fi
+  done <<< "$ROUTE_HREFS"
+fi
+
+if [[ -n "$ORPHANS" ]]; then
+  echo "✗ R1  New static admin routes not reachable from sidemenu:"
+  printf '%s' "$ORPHANS"
+  echo "      Suggestion: add to navGroups in $LAYOUT, or list parent in matches[]."
+  FAILED=1
+else
+  echo "✓ R1  All new admin routes are reachable"
+fi
+
+# R7: dashboard cross-ref
+DASHBOARD_ORPHANS=""
+if [[ -n "$DASHBOARD_HREFS" ]]; then
+  while IFS= read -r href; do
+    [[ -z "$href" ]] && continue
+    [[ "$href" == /admin ]] && continue
+    if echo "$REACH_SET" | grep -qxF "$href"; then
+      continue
+    fi
+    # check dynamic parent
+    parent="$href"
+    matched=""
+    while [[ "$parent" == /admin/* ]]; do
+      parent="${parent%/*}"
+      if echo "$REACH_SET" | grep -qxF "$parent"; then
+        matched="$parent"
+        break
+      fi
+    done
+    if [[ -z "$matched" ]]; then
+      DASHBOARD_ORPHANS+="    - $href"$'\n'
+    fi
+  done <<< "$DASHBOARD_HREFS"
+fi
+
+if [[ -n "$DASHBOARD_ORPHANS" ]]; then
+  echo "✗ R7  Dashboard links to orphan(s):"
+  printf '%s' "$DASHBOARD_ORPHANS"
+  echo "      Suggestion: either add the target to the sidemenu, or remove from $DASHBOARD."
+  FAILED=1
+else
+  echo "✓ R7  Dashboard hrefs are all reachable"
+fi
+
+echo "─────────────────────────────────────"
+if (( FAILED )); then
+  echo "Gate FAILED. See suggestions above. Set ADMIN_MENU_GATE=skip to bypass (logged)."
+  exit 1
+fi
+echo "Gate PASSED."
+exit 0

--- a/scripts/admin-menu-gate.sh
+++ b/scripts/admin-menu-gate.sh
@@ -47,20 +47,45 @@ REACH_SET=$(awk '
 REACH_SET=$(printf '%s\n/admin\n' "$REACH_SET" | sort -u)
 
 # --- Step 2: count groups and items (R4, R5) ---
-GROUP_COUNT=$(awk '/^ *label: *'\''/{c++} END{print c+0}' "$LAYOUT")
+# A group is uniquely identified by an `items: [` opener, regardless of whether
+# the group is written multi-line or inline.
+GROUP_COUNT=$(awk '/items: *\[/{c++} END{print c+0}' "$LAYOUT")
 
-# Per-group item count: walk navGroups, count items between '{ href:' lines
-# bracketed by the same group's label..]. A bit ugly; uses braces depth.
+# Per-group item count: walk navGroups, counting `href:` occurrences inside
+# every `items: [ ... ]` block. Handles both multi-line and inline shapes.
 MAX_GROUP_SIZE=$(awk '
-  BEGIN { depth=0; n=0; max=0; in_items=0 }
-  /label: *'\''/ {
-    if (n > max) max = n
-    n = 0
-    in_items = 0
+  BEGIN { n=0; max=0; in_items=0 }
+  {
+    if (match($0, /items: *\[/)) {
+      if (n > max) max = n
+      n = 0
+      in_items = 1
+      rest = substr($0, RSTART + RLENGTH)
+      while (match(rest, /href: *'\''/)) {
+        n++
+        rest = substr(rest, RSTART + RLENGTH)
+      }
+      # Inline form closes on the same line
+      if (match($0, /\]/)) {
+        if (n > max) max = n
+        n = 0
+        in_items = 0
+      }
+      next
+    }
+    if (in_items && /^ *\] *,? *$/) {
+      if (n > max) max = n
+      n = 0
+      in_items = 0
+      next
+    }
+    if (in_items) {
+      while (match($0, /href: *'\''/)) {
+        n++
+        $0 = substr($0, RSTART + RLENGTH)
+      }
+    }
   }
-  /items: *\[/ { in_items = 1; next }
-  in_items && /^ *\{ *href:/ { n++ }
-  /^ *\],? *$/ && in_items { in_items = 0 }
   END {
     if (n > max) max = n
     print max
@@ -69,7 +94,7 @@ MAX_GROUP_SIZE=$(awk '
 
 # --- Step 3: collect labels (R2 — destinations not actions) ---
 LABELS=$(awk '
-  /label: *'\''/ {
+  /^ *\{ *href:/ {
     match($0, /label: *'\''([^'\'']+)'\''/, m)
     if (m[1]) print m[1]
   }
@@ -77,7 +102,7 @@ LABELS=$(awk '
 
 # --- Step 4: detect new static /admin/* pages added vs base ---
 NEW_ROUTES=$(git diff --name-only --diff-filter=AM "$BASE_REF" \
-  -- 'website/src/pages/admin/**/*.astro' 2>/dev/null \
+  -- ':(glob)website/src/pages/admin/**/*.astro' 2>/dev/null \
   | grep -v '\[' \
   | grep -v '^website/src/pages/admin\.astro$' \
   || true)
@@ -134,10 +159,12 @@ if [[ -n "$ROUTE_HREFS" ]]; then
     if echo "$REACH_SET" | grep -qxF "$route"; then
       continue
     fi
-    # Check dynamic-parent reachability: walk up the path
+    # Check dynamic-parent reachability: walk up the path. Stop before /admin
+    # itself — the Dashboard header link doesn't count as making every page
+    # reachable; only a true parent like /admin/projekte counts.
     parent="$route"
     matched=""
-    while [[ "$parent" == /admin/* ]]; do
+    while [[ "$parent" == /admin/*/* ]]; do
       parent="${parent%/*}"
       if echo "$REACH_SET" | grep -qxF "$parent"; then
         matched="$parent"
@@ -168,10 +195,10 @@ if [[ -n "$DASHBOARD_HREFS" ]]; then
     if echo "$REACH_SET" | grep -qxF "$href"; then
       continue
     fi
-    # check dynamic parent
+    # check dynamic parent — stop before /admin itself
     parent="$href"
     matched=""
-    while [[ "$parent" == /admin/* ]]; do
+    while [[ "$parent" == /admin/*/* ]]; do
       parent="${parent%/*}"
       if echo "$REACH_SET" | grep -qxF "$parent"; then
         matched="$parent"

--- a/tests/scripts/admin-menu-gate.bats
+++ b/tests/scripts/admin-menu-gate.bats
@@ -1,0 +1,193 @@
+#!/usr/bin/env bats
+# admin-menu-gate.bats — verifies R1/R2/R4/R5/R7 enforcement.
+
+setup() {
+  TMPDIR=$(mktemp -d)
+  cd "$TMPDIR"
+  git init -q
+  git config user.email "test@example.com"
+  git config user.name "Test"
+  mkdir -p website/src/layouts website/src/pages/admin scripts
+  cp "${BATS_TEST_DIRNAME}/../../scripts/admin-menu-gate.sh" scripts/
+  chmod +x scripts/admin-menu-gate.sh
+}
+
+teardown() {
+  rm -rf "$TMPDIR"
+}
+
+# Helper: write a minimal valid AdminLayout.astro
+write_layout() {
+  cat > website/src/layouts/AdminLayout.astro <<'EOF'
+const navGroups = [
+  {
+    label: 'Tagesgeschäft',
+    items: [
+      { href: '/admin/termine', label: 'Termine', icon: 'calendar' },
+    ],
+  },
+];
+EOF
+}
+
+# Helper: commit a clean baseline (so `origin/main` diff resolves)
+commit_baseline() {
+  write_layout
+  touch website/src/pages/admin.astro
+  git add -A
+  git commit -q -m "baseline"
+  git branch -M main
+  git remote add origin "$TMPDIR" 2>/dev/null || true
+  git update-ref refs/remotes/origin/main HEAD
+}
+
+@test "passes on clean baseline" {
+  commit_baseline
+  run bash scripts/admin-menu-gate.sh
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Gate PASSED"* ]]
+}
+
+@test "R1: fails when a new static admin page has no nav entry" {
+  commit_baseline
+  mkdir -p website/src/pages/admin
+  echo "<h1>Forecasting</h1>" > website/src/pages/admin/forecasting.astro
+  git add -A
+  run bash scripts/admin-menu-gate.sh
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"R1"* ]]
+  [[ "$output" == *"/admin/forecasting"* ]]
+}
+
+@test "R1: passes when new page is added to navGroups" {
+  commit_baseline
+  cat > website/src/layouts/AdminLayout.astro <<'EOF'
+const navGroups = [
+  {
+    label: 'Tagesgeschäft',
+    items: [
+      { href: '/admin/termine',     label: 'Termine',     icon: 'calendar' },
+      { href: '/admin/forecasting', label: 'Forecasting', icon: 'star' },
+    ],
+  },
+];
+EOF
+  mkdir -p website/src/pages/admin
+  echo "<h1>Forecasting</h1>" > website/src/pages/admin/forecasting.astro
+  git add -A
+  run bash scripts/admin-menu-gate.sh
+  [ "$status" -eq 0 ]
+}
+
+@test "R1: dynamic [param] routes are exempt (parent must be in menu)" {
+  commit_baseline
+  mkdir -p website/src/pages/admin/projekte
+  echo "<h1>Detail</h1>" > "website/src/pages/admin/projekte/[id].astro"
+  git add -A
+  # Parent /admin/projekte is not in the menu either, so this should still pass
+  # for the [id] file (excluded by the gate's grep -v '\['), but FAIL only if
+  # the user added a static /admin/projekte.astro without listing it.
+  run bash scripts/admin-menu-gate.sh
+  [ "$status" -eq 0 ]
+}
+
+@test "R2: fails when a label starts with 'Neue'" {
+  cat > website/src/layouts/AdminLayout.astro <<'EOF'
+const navGroups = [
+  {
+    label: 'Coaching',
+    items: [
+      { href: '/admin/coaching/sessions/new', label: 'Neue Session', icon: 'plus' },
+    ],
+  },
+];
+EOF
+  touch website/src/pages/admin.astro
+  git add -A
+  git commit -q -m "baseline"
+  git update-ref refs/remotes/origin/main HEAD
+  run bash scripts/admin-menu-gate.sh
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"R2"* ]]
+  [[ "$output" == *"Neue Session"* ]]
+}
+
+@test "R4: fails when a group has >6 items" {
+  cat > website/src/layouts/AdminLayout.astro <<'EOF'
+const navGroups = [
+  {
+    label: 'Toomany',
+    items: [
+      { href: '/admin/a', label: 'A', icon: 'x' },
+      { href: '/admin/b', label: 'B', icon: 'x' },
+      { href: '/admin/c', label: 'C', icon: 'x' },
+      { href: '/admin/d', label: 'D', icon: 'x' },
+      { href: '/admin/e', label: 'E', icon: 'x' },
+      { href: '/admin/f', label: 'F', icon: 'x' },
+      { href: '/admin/g', label: 'G', icon: 'x' },
+    ],
+  },
+];
+EOF
+  touch website/src/pages/admin.astro
+  git add -A
+  git commit -q -m "baseline"
+  git update-ref refs/remotes/origin/main HEAD
+  run bash scripts/admin-menu-gate.sh
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"R4"* ]]
+}
+
+@test "R5: fails when navGroups has >6 groups" {
+  cat > website/src/layouts/AdminLayout.astro <<'EOF'
+const navGroups = [
+  { label: 'G1', items: [ { href: '/admin/1', label: 'A', icon: 'x' } ] },
+  { label: 'G2', items: [ { href: '/admin/2', label: 'A', icon: 'x' } ] },
+  { label: 'G3', items: [ { href: '/admin/3', label: 'A', icon: 'x' } ] },
+  { label: 'G4', items: [ { href: '/admin/4', label: 'A', icon: 'x' } ] },
+  { label: 'G5', items: [ { href: '/admin/5', label: 'A', icon: 'x' } ] },
+  { label: 'G6', items: [ { href: '/admin/6', label: 'A', icon: 'x' } ] },
+  { label: 'G7', items: [ { href: '/admin/7', label: 'A', icon: 'x' } ] },
+];
+EOF
+  touch website/src/pages/admin.astro
+  git add -A
+  git commit -q -m "baseline"
+  git update-ref refs/remotes/origin/main HEAD
+  run bash scripts/admin-menu-gate.sh
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"R5"* ]]
+}
+
+@test "R7: fails when dashboard links to an orphan" {
+  cat > website/src/layouts/AdminLayout.astro <<'EOF'
+const navGroups = [
+  {
+    label: 'G',
+    items: [
+      { href: '/admin/termine', label: 'Termine', icon: 'calendar' },
+    ],
+  },
+];
+EOF
+  cat > website/src/pages/admin.astro <<'EOF'
+<a href="/admin/projekte">Aktive Projekte</a>
+EOF
+  git add -A
+  git commit -q -m "baseline"
+  git update-ref refs/remotes/origin/main HEAD
+  run bash scripts/admin-menu-gate.sh
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"R7"* ]]
+  [[ "$output" == *"/admin/projekte"* ]]
+}
+
+@test "ADMIN_MENU_GATE=skip bypasses with warning" {
+  commit_baseline
+  mkdir -p website/src/pages/admin
+  echo "<h1>Forecasting</h1>" > website/src/pages/admin/forecasting.astro
+  git add -A
+  ADMIN_MENU_GATE=skip run bash scripts/admin-menu-gate.sh
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"bypassed"* ]]
+}

--- a/website/src/layouts/AdminLayout.astro
+++ b/website/src/layouts/AdminLayout.astro
@@ -81,28 +81,41 @@ try {
 
 const navGroups: { label: string; items: NavItem[] }[] = [
   {
-    label: 'Übersicht',
+    label: 'Tagesgeschäft',
     items: [
-      { href: '/admin', label: 'Dashboard', icon: 'dashboard' },
+      { href: '/admin/termine',     label: 'Termine',     icon: 'calendar' },
+      { href: '/admin/tickets',     label: 'Tickets',     icon: 'tag' },
+      { href: '/admin/inbox',       label: 'Inbox',       icon: 'inbox',     badge: inboxPending },
+      { href: '/admin/live',        label: 'Live',        icon: 'broadcast', matches: ['/admin/live'] },
+      { href: '/admin/nachrichten', label: 'Nachrichten', icon: 'message' },
+      { href: '/admin/raeume',      label: 'Räume',       icon: 'chat' },
     ],
   },
   {
-    label: 'Betrieb',
+    label: 'Klienten',
     items: [
-      { href: '/admin/live',          label: 'Live',          icon: 'broadcast' },
-      { href: '/admin/termine',       label: 'Termine',       icon: 'calendar' },
-      { href: '/admin/clients',       label: 'Clients',       icon: 'users' },
-      { href: '/admin/tickets',       label: 'Tickets',       icon: 'tag' },
-      { href: '/admin/rechnungen',    label: 'Rechnungen',    icon: 'receipt' },
-      { href: '/admin/kalender',      label: 'Kalender',      icon: 'calendar2' },
+      { href: '/admin/clients',   label: 'Klienten',  icon: 'users' },
+      { href: '/admin/projekte',  label: 'Projekte',  icon: 'folder',    matches: ['/admin/projekte'] },
+      { href: '/admin/meetings',  label: 'Meetings',  icon: 'calendar2', matches: ['/admin/meetings'] },
+      { href: '/admin/kalender',  label: 'Kalender',  icon: 'calendar2' },
+      { href: '/admin/followups', label: 'Followups', icon: 'clock' },
     ],
   },
   {
-    label: 'Inhalte',
+    label: 'Coaching',
+    items: [
+      { href: '/admin/coaching/sessions',  label: 'Sessions',          icon: 'clipboard', matches: ['/admin/coaching/sessions', '/admin/fragebogen'] },
+      { href: '/admin/coaching/projekte',  label: 'Projekte',          icon: 'folder',    matches: ['/admin/coaching/projekte'] },
+      { href: '/admin/brett',              label: 'Brett',             icon: 'brett',     matches: ['/admin/brett'] },
+      { href: '/admin/coaching/settings',  label: 'KI-Einstellungen',  icon: 'settings',  matches: ['/admin/coaching/settings'] },
+    ],
+  },
+  {
+    label: 'Wissen & Inhalte',
     items: [
       {
         href: '/admin/inhalte',
-        label: 'Inhalte',
+        label: 'Website-Inhalte',
         icon: 'layout',
         matches: [
           '/admin/inhalte',
@@ -116,56 +129,36 @@ const navGroups: { label: string; items: NavItem[] }[] = [
           '/admin/dokumente',
         ],
       },
+      { href: '/admin/knowledge/books',     label: 'Bücher',   icon: 'book',      matches: ['/admin/knowledge/books'] },
+      { href: '/admin/knowledge/drafts',    label: 'Drafts',   icon: 'edit',      matches: ['/admin/knowledge/drafts', '/admin/knowledge/snippets'], badge: draftsPending },
+      { href: '/admin/wissensquellen',      label: 'Quellen',  icon: 'clipboard' },
+      { href: '/admin/knowledge/templates', label: 'Vorlagen', icon: 'star',      matches: ['/admin/knowledge/templates'] },
     ],
   },
   {
-    label: 'Wissen',
+    label: 'Geld',
     items: [
-      { href: '/admin/wissensquellen',     label: 'Quellen', icon: 'clipboard' },
-      { href: '/admin/knowledge/books',    label: 'Bücher',  icon: 'book',
-        matches: ['/admin/knowledge/books'] },
-      { href: '/admin/knowledge/drafts',   label: 'Drafts',  icon: 'edit', badge: draftsPending,
-        matches: ['/admin/knowledge/drafts'] },
+      { href: '/admin/rechnungen',    label: 'Rechnungen',    icon: 'receipt', matches: ['/admin/rechnungen', '/admin/billing'] },
+      { href: '/admin/buchhaltung',   label: 'Buchhaltung',   icon: 'scale' },
+      { href: '/admin/zeiterfassung', label: 'Zeiterfassung', icon: 'clock' },
+      { href: '/admin/steuer',        label: 'Steuer',        icon: 'scale' },
     ],
   },
   {
-    label: 'Coaching',
+    label: 'Plattform',
     items: [
-      { href: '/admin/coaching/projekte',      label: 'Projekte',         icon: 'folder',
-        matches: ['/admin/coaching/projekte'] },
-      { href: '/admin/coaching/sessions',      label: 'Sessions',         icon: 'clipboard',
-        matches: ['/admin/coaching/sessions'] },
-      { href: '/admin/coaching/sessions/new',  label: 'Neue Session',     icon: 'plus' },
-      { href: '/admin/coaching/settings',      label: 'KI-Einstellungen', icon: 'settings',
-        matches: ['/admin/coaching/settings'] },
-    ],
-  },
-  {
-    label: 'System',
-    items: [
-      { href: '/admin/monitoring',       label: 'Monitoring',        icon: 'monitor' },
-      { href: '/admin/software-history', label: 'Software-History',  icon: 'clipboard' },
-      { href: '/admin/arena',            label: 'Arena',             icon: 'broadcast' },
-      { href: '/admin/ops',              label: 'Cluster-Steuerung', icon: 'server' },
-      { href: '/admin/inbox',            label: 'Inbox',             icon: 'inbox', badge: inboxPending },
-    ],
-  },
-  {
-    label: 'Einstellungen',
-    items: [
-      {
-        href: '/admin/einstellungen/benachrichtigungen',
-        label: 'Einstellungen',
-        icon: 'bell',
-        matches: ['/admin/einstellungen/'],
-      },
+      { href: '/admin/monitoring',                       label: 'Monitoring',        icon: 'monitor' },
+      { href: '/admin/software-history',                 label: 'Software-History',  icon: 'clipboard' },
+      { href: '/admin/systemtest/board',                 label: 'Systemtest',        icon: 'clipboard', matches: ['/admin/systemtest'] },
+      { href: '/admin/arena',                            label: 'Arena',             icon: 'broadcast' },
+      { href: '/admin/ops',                              label: 'Cluster-Steuerung', icon: 'server' },
+      { href: '/admin/einstellungen/benachrichtigungen', label: 'Einstellungen',     icon: 'bell',     matches: ['/admin/einstellungen/'] },
     ],
   },
 ];
 
 function isActive(href: string, matches?: string[]): boolean {
   if (matches) return matches.some(m => path === m || path.startsWith(m));
-  if (href === '/admin') return path === '/admin';
   return path.startsWith(href);
 }
 

--- a/website/src/layouts/AdminLayout.astro
+++ b/website/src/layouts/AdminLayout.astro
@@ -238,6 +238,28 @@ const isKore = brandId === 'korczewski';
         width: 16px;
         height: 16px;
       }
+      .admin-nav-dashboard {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        padding: 0.5rem 0.75rem;
+        margin-bottom: 0.5rem;
+        border-radius: 0.375rem;
+        color: inherit;
+        text-decoration: none;
+        font-weight: 600;
+        border-bottom: 1px solid var(--admin-border, rgba(255,255,255,0.08));
+      }
+      .admin-nav-dashboard.active {
+        background: var(--admin-nav-active-bg, rgba(255,255,255,0.06));
+      }
+      .admin-nav-dashboard .admin-nav-icon {
+        width: 1rem;
+        height: 1rem;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+      }
       .sidebar-footer-link:hover {
         background: var(--ink-800);
         color: var(--fg-soft);
@@ -340,6 +362,17 @@ const isKore = brandId === 'korczewski';
       )}
 
       <nav style="flex:1; overflow-y:auto; padding:12px 8px; display:flex; flex-direction:column; gap:20px;">
+        <a
+          href="/admin"
+          class:list={[
+            'admin-nav-dashboard',
+            { active: path === '/admin' },
+          ]}
+          aria-current={path === '/admin' ? 'page' : undefined}
+        >
+          <span class="admin-nav-icon" set:html={icons.dashboard} />
+          <span class="admin-nav-label">Dashboard</span>
+        </a>
         {navGroups.map(group => (
           <div>
             <p class="sidebar-group-label" style="padding:0 10px; margin-bottom:4px; font-family:var(--font-mono); font-size:9px; font-weight:500; color:var(--mute-2); text-transform:uppercase; letter-spacing:0.14em;">{group.label}</p>

--- a/website/src/layouts/AdminLayout.astro
+++ b/website/src/layouts/AdminLayout.astro
@@ -62,6 +62,9 @@ const icons: Record<string, string> = {
   // Brett icon: 3D board
   brett: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M1.5 5l6.5-3.5L14.5 5v6L8 14.5 1.5 11V5z"/><path d="M8 1.5v13M1.5 5l6.5 3 6.5-3"/></svg>`,
   plus: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 3v10M3 8h10"/></svg>`,
+  folder: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M2 4.5a1 1 0 0 1 1-1h3.5l1.5 1.5H13a1 1 0 0 1 1 1V13a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1z"/></svg>`,
+  settings: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="8" r="2.5"/><path d="M8 1.5v2M8 12.5v2M1.5 8h2M12.5 8h2M3.4 3.4l1.4 1.4M11.2 11.2l1.4 1.4M3.4 12.6l1.4-1.4M11.2 4.8l1.4-1.4"/></svg>`,
+  chat: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M2 3.5h9a1 1 0 0 1 1 1v5a1 1 0 0 1-1 1H6L3.5 13v-2.5H3a1 1 0 0 1-1-1z"/><path d="M5.5 5.5h4M5.5 7.5h3"/></svg>`,
 };
 
 let inboxPending = 0;

--- a/website/src/pages/admin/coaching/sessions/index.astro
+++ b/website/src/pages/admin/coaching/sessions/index.astro
@@ -23,7 +23,12 @@ try {
       <span style="margin:0 0.4rem;">›</span>
       Sessions
     </nav>
-    <h1 style="font-size:1.8rem;font-weight:700;color:var(--text-light,#f0f0f0);margin:0 0 1.5rem;padding:0 1.5rem;">Coaching-Sessions</h1>
+    <div style="display:flex;align-items:center;justify-content:space-between;gap:1rem;flex-wrap:wrap;padding:0 1.5rem;margin:0 0 1.5rem;">
+      <h1 style="font-size:1.8rem;font-weight:700;color:var(--text-light,#f0f0f0);margin:0;">Coaching-Sessions</h1>
+      <a href="/admin/coaching/sessions/new" class="btn btn-primary">
+        + Neue Session
+      </a>
+    </div>
     <SessionsOverview client:load {initialResult} />
   </div>
 </AdminLayout>


### PR DESCRIPTION
## Summary
- Codifies 10 admin-menu rules (R1–R10) in `docs/superpowers/specs/2026-05-18-admin-menu-rules-design.md`
- Reshuffles `AdminLayout.astro` into 6 task-based groups (Tagesgeschäft, Klienten, Coaching, Wissen & Inhalte, Geld, Plattform), Dashboard as standalone header link
- Surfaces every formerly-orphan admin page (Projekte, Meetings, Followups, Nachrichten, Räume, Buchhaltung, Zeiterfassung, Steuer, Brett, Vorlagen, Systemtest, …) — 19 → 0 orphans
- Fixes the Dashboard KPI broken-link (`/admin/projekte` was referenced but not in the menu)
- Adds `scripts/admin-menu-gate.sh` enforcing R1, R2, R4, R5, R7 + 9-test BATS coverage + `task test:menu-gate` wired into `test:all`
- Documents Schritt 3.5 in `dev-flow-execute/SKILL.md` so future PRs that add `/admin/*` routes can't ship orphan routes
- Fixes pre-existing bug: `folder` and `settings` icons referenced in Coaching nav were never defined

## Test plan
- [x] `task test:all` exit 0 (includes new `test:menu-gate`)
- [x] `bats tests/scripts/admin-menu-gate.bats` — 9/9 tests pass
- [x] `bash scripts/admin-menu-gate.sh` against post-implementation tree → Gate PASSED
- [x] `cd website && npm run build` → Server built in 13.84s, Complete!
- [x] `task workspace:validate` → Manifests are valid
- [ ] Post-merge: `task feature:website` deploys to mentolder + korczewski, smoke-check `web.mentolder.de/admin` and `web.korczewski.de/admin`

Closes T000449

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>