### PR TITLE
fix(skills): harden plan-archive + document worktree caveats

### DIFF
--- a/.claude/skills/dev-flow-execute/SKILL.md
+++ b/.claude/skills/dev-flow-execute/SKILL.md
@@ -299,11 +299,26 @@ echo "Ticket $TICKET_ID → done ($RESOLUTION)"
 
 Falls `$TICKET_ID` gesetzt und `$PLAN_FILE` vorhanden:
 
+> **Wichtig — Worktree-Zustand nach Schritt 6:** `gh pr merge --squash --delete-branch` löscht nicht nur Remote+Local-Branch, sondern führt im Worktree **silent** `git checkout main` aus. Du landest auf `main` am pre-PR HEAD, und die Plan-Datei ist von Disk verschwunden, bis `git pull` läuft. Deshalb **muss** dieser Schritt mit einem Sync starten:
+
+```bash
+git fetch origin main
+git reset --hard origin/main   # Worktree ist jetzt auf der gemergten Revision — Plan-Datei wieder auf Disk
+```
+
 ```bash
 PLAN_FILE="docs/superpowers/plans/<slug>.md"
 SLUG="<slug>"
-BRANCH=$(git branch --show-current)
+BRANCH="feature/<slug>"   # oder fix/<slug> — Branch wurde durch --delete-branch bereits gelöscht, also nicht aus `git branch --show-current` lesen
 PR_NUM=$(gh pr view --json number -q '.number' 2>/dev/null || echo "")
+
+# Precheck: Plan-Datei muss existieren UND nicht leer sein, sonst archivieren wir leere Bytes
+if [[ ! -s "$PLAN_FILE" ]]; then
+  echo "✗ Plan-Datei fehlt oder ist leer: $PLAN_FILE"
+  echo "  Möglicherweise wurde 'git pull/reset' oben übersprungen, oder der Plan wurde manuell gelöscht."
+  echo "  Abbruch — kein Archiv, kein Commit."
+  exit 1
+fi
 
 PGPOD=$(kubectl get pod -n workspace --context mentolder \
   -l app=shared-db -o name | head -1)
@@ -322,6 +337,15 @@ TMPFILE=$(mktemp /tmp/plan-archive-XXXXXX.sql)
   cat "$PLAN_FILE"
   printf "\$plan\$,\n  %s\n);\n" "$PR_NUM_SQL"
 } > "$TMPFILE"
+
+# Sanity-Check: Datei sollte mehr als das nackte SQL-Gerüst enthalten
+ARCHIVE_BYTES=$(wc -c < "$TMPFILE")
+if (( ARCHIVE_BYTES < 200 )); then
+  echo "✗ Archiv-SQL ist verdächtig klein ($ARCHIVE_BYTES bytes) — vermutlich Plan-Inhalt verloren."
+  cat "$TMPFILE"
+  rm "$TMPFILE"
+  exit 1
+fi
 
 kubectl exec -i "$PGPOD" -n workspace --context mentolder -- \
   psql -U website -d website -v ON_ERROR_STOP=1 < "$TMPFILE"

--- a/.claude/skills/dev-flow-plan/SKILL.md
+++ b/.claude/skills/dev-flow-plan/SKILL.md
@@ -88,6 +88,11 @@ Falls Worktree bereits existiert: **nicht** `using-git-worktrees` aufrufen — d
 
 Falls kein Worktree existiert: Rufe `superpowers:using-git-worktrees` auf. Branch-Name: `feature/<kurzer-slug>`.
 
+> **Branch-Naming-Warnung:** Das native `EnterWorktree` Tool mangelt den Branch-Namen — aus `feature/admin-menu-rules` wird `worktree-feature+admin-menu-rules` (Slash → Plus, Prefix `worktree-`). Das verletzt die Repo-Konvention `feature/*`. Verifiziere nach dem Anlegen mit `git branch --show-current` und benenne ggf. um: `git branch -m feature/<slug>` (oder pushe direkt ohne Umbennung, dann `git push -u origin feature/<slug>:feature/<slug>`). Der vorhersagbarere Pfad ist die manuelle Form:
+> ```bash
+> git worktree add -b feature/<slug> .claude/worktrees/<slug> origin/main
+> ```
+
 ### Schritt 1.5: Optionale Asset-Sammlung
 
 **Bevor du das Brainstorming startest, frage den User aktiv:**
@@ -354,6 +359,8 @@ Falls Worktree bereits existiert: **nicht** `using-git-worktrees` aufrufen — d
 
 Falls kein Worktree existiert: Rufe `superpowers:using-git-worktrees` auf. Branch-Name: `fix/<kurzer-slug>`.
 
+> **Branch-Naming-Warnung:** Das native `EnterWorktree` Tool mangelt den Branch-Namen (Slash → Plus, Prefix `worktree-`). Verifiziere mit `git branch --show-current` und benenne ggf. um: `git branch -m fix/<slug>`. Vorhersagbar: `git worktree add -b fix/<slug> .claude/worktrees/<slug> origin/main`.
+
 ### Schritt 3: Failing Test schreiben
 
 Schreibe einen Test, der den Bug beweist (red-green-refactor — Pflicht):
@@ -443,6 +450,8 @@ fi
 Falls Worktree bereits existiert: **nicht** `using-git-worktrees` aufrufen — direkt in den vorhandenen Worktree wechseln.
 
 Falls kein Worktree existiert: Rufe `superpowers:using-git-worktrees` auf. Branch-Name: `chore/<kurzer-slug>`.
+
+> **Branch-Naming-Warnung:** Das native `EnterWorktree` Tool mangelt den Branch-Namen (Slash → Plus, Prefix `worktree-`). Verifiziere mit `git branch --show-current` und benenne ggf. um: `git branch -m chore/<slug>`. Vorhersagbar: `git worktree add -b chore/<slug> .claude/worktrees/<slug> origin/main`.
 
 ### Schritt 3: Änderung machen
 


### PR DESCRIPTION
## Summary
Three skill fixes from the latent-bugs ticket sweep ([T000450](https://web.mentolder.de/admin/bugs), [T000451](https://web.mentolder.de/admin/bugs), [T000453](https://web.mentolder.de/admin/bugs)):

- **dev-flow-execute Schritt 7** — `gh pr merge --delete-branch` silently checks out main, so the plan file is off-disk by the time Schritt 7 runs. Added `git fetch + reset --hard origin/main` to resync, plus a `[[ -s "$PLAN_FILE" ]]` precheck and a 200-byte SQL-size sanity check so the next time `cat` fails, the run aborts loudly instead of writing zero bytes to `tickets.ticket_plans.content`.
- **dev-flow-plan Schritte 1/2/2** — Native `EnterWorktree` mangles slash → plus and prefixes `worktree-`, so `feature/admin-menu-rules` becomes `worktree-feature+admin-menu-rules`. Documented in all three path sections (feature/fix/chore), plus offered the predictable manual `git worktree add -b feature/<slug>` as the recommended form.

## Test plan
- [x] `git diff --stat` shows only the two intended SKILL.md files changed
- [x] Skill markdown still renders (no broken codefences after edits)
- [ ] Next plan-archive run exercises the new precheck path (will validate on next `dev-flow-execute` invocation)

Closes T000450
Closes T000451
Closes T000453

🤖 Generated with [Claude Code](https://claude.com/claude-code)