### PR TITLE
chore(docs): vollständiges Neuschreiben von Admin- und Benutzerhandbuch

### DIFF
--- a/k3d/docs-content/adminhandbuch.md
+++ b/k3d/docs-content/adminhandbuch.md
@@ -9,7 +9,7 @@ Dieses Handbuch richtet sich an Plattform-Administratoren, die den Workspace bet
 | `kubectl` | Kubernetes CLI mit Kontext für den Ziel-Cluster (`mentolder` oder `korczewski`) |
 | `task` (go-task) | Aufgaben-Orchestrierer (`Taskfile.yml`) |
 | `kubeseal` | Erzeugen von SealedSecrets für Produktion |
-| `git` | Quellcode-Verwaltung; alle Änderungen laufen über Pull Requests |
+| `git` + `gh` | Quellcode; alle Änderungen über Pull Requests |
 
 Für lokale Entwicklung zusätzlich Docker und [k3d](https://k3d.io); siehe [Beitragen & CI/CD](contributing.md).
 
@@ -17,15 +17,17 @@ Für lokale Entwicklung zusätzlich Docker und [k3d](https://k3d.io); siehe [Bei
 
 ## Umgebungen
 
-Der Workspace läuft in zwei Produktionsumgebungen, jede auf einem eigenen Hetzner-k3s-Cluster mit eigener Domain. Auswahl erfolgt über die Umgebungsvariable `ENV=` an task-Aufrufen.
+Der Workspace läuft auf **zwei getrennten physischen k3s-Clustern** (seit PR #621/#622, 2026-05-09). Jeder Cluster hat seine eigene Domain, eigene Datenbank und eigene SealedSecrets-Schlüssel. Die Auswahl erfolgt über `ENV=` an task-Aufrufen.
 
-| Umgebung | Cluster | Domain | Secrets |
-|----------|---------|--------|---------|
-| `mentolder` | k3s (Hetzner) | `mentolder.de` | Bitnami Sealed Secrets |
-| `korczewski` | k3s (Hetzner) | `korczewski.de` | Bitnami Sealed Secrets |
-| `dev` | k3d (lokal) | `localhost` | Klartext (nur Entwicklung) |
+| Umgebung | Cluster | Domain | Namespace | Secrets |
+|----------|---------|--------|-----------|---------|
+| `mentolder` | k3s (9 Nodes, Hetzner + Home-LAN via WireGuard) | `mentolder.de` | `workspace` | Bitnami Sealed Secrets |
+| `korczewski` | k3s (3 Nodes, Hetzner) | `korczewski.de` | `workspace-korczewski` | Bitnami Sealed Secrets |
+| `dev` | k3d (lokal, auf `gekko-hetzner-2`) | `dev.mentolder.de` | `workspace-dev` | Klartext (nur Entwicklung) |
 
-> **Wichtig:** Env-sensitive Tasks (`workspace:deploy`, `workspace:post-setup`, `website:deploy`, `docs:deploy`, `workspace:talk-setup`) setzen `ENV=dev` als Default. Der Kontext-Check greift nur bei `ENV != dev`. Setze bei Produktionsarbeit daher **immer explizit** `ENV=mentolder` oder `ENV=korczewski` — sonst landet ein Deploy auf dem aktuell aktiven `kubectl`-Kontext.
+> **Wichtig:** Env-sensitive Tasks setzen `ENV=dev` als Standard-Default. Bei Produktionsarbeit **immer explizit** `ENV=mentolder` oder `ENV=korczewski` setzen — sonst landet der Deploy auf dem aktiven kubectl-Kontext.
+
+> **Keine Cross-Cluster-Propagation:** DB-Passwort-Rotationen, Schema-Änderungen und OIDC-Client-Konfigurationen müssen **explizit auf beiden Clustern** ausgeführt werden. Jeder Cluster hat seinen eigenen `shared-db`.
 
 Details: [Umgebungen](environments.md).
 
@@ -35,23 +37,38 @@ Details: [Umgebungen](environments.md).
 
 ### Produktion (mentolder / korczewski)
 
-Produktionsumgebungen werden manuell via `task workspace:deploy ENV=<env>` ausgerollt. Workloads werden nur dann aktualisiert, wenn du es explizit auslöst (`task feature:*`). Geheimnisse werden separat synchronisiert: `task env:seal ENV=<env>` → `task secrets:sync`. Manuelles initiales Setup eines neuen Cluster-Tenants ist in [Umgebungen → Neue Umgebung einrichten](environments.md#neue-umgebung-einrichten) beschrieben.
+Produktionsumgebungen werden manuell ausgerollt. Workloads werden nur aktualisiert, wenn du es explizit auslöst (`task feature:*`). Die Reihenfolge beim Erstaufbau ist zwingend:
+
+```bash
+task sealed-secrets:install ENV=<env>      # 1. Controller vor allem anderen
+task env:fetch-cert ENV=<env>              # 2. Sealing-Zertifikat holen
+task env:seal ENV=<env>                    # 3. Secrets verschlüsseln
+task cert:install ENV=<env>               # 4. cert-manager + DNS-01 Webhook
+task cert:secret -- <ipv64-key> ENV=<env>  # 5. ACME-Schlüssel speichern
+task workspace:deploy ENV=<env>            # 6. Alles ausrollen
+task workspace:office:deploy ENV=<env>     # 7. Collabora (separates Overlay)
+task workspace:post-setup ENV=<env>        # 8. Nextcloud-Apps aktivieren
+task workspace:talk-setup ENV=<env>        # 9. Talk-HPB + CoTURN konfigurieren
+task workspace:admin-users-setup ENV=<env> # 10. Admin-Benutzer anlegen
+```
+
+Ausführliche Anleitung: [Umgebungen → Neue Umgebung](environments.md#neue-umgebung-einrichten).
 
 ### Lokale Entwicklung (k3d)
 
 ```bash
 git clone https://github.com/Paddione/Bachelorprojekt.git
 cd Bachelorprojekt
-task workspace:up                # Cluster + MVP + Office-Stack + MCP + Billing
+task workspace:up   # Vollautomatisch: Cluster + MVP + Office + MCP + Post-Config
 ```
 
 Schrittweise:
 
 ```bash
-task cluster:create              # k3d-Cluster mit lokaler Registry erstellen
-task workspace:deploy            # Alle Workspace-Services deployen
-task workspace:post-setup        # Nextcloud-Apps aktivieren und konfigurieren
-task workspace:vaultwarden:seed  # Vaultwarden mit Secret-Templates befüllen
+task cluster:create              # k3d-Cluster erstellen
+task workspace:deploy            # Alle Services deployen
+task workspace:post-setup        # Nextcloud-Apps aktivieren
+task workspace:vaultwarden:seed  # Vaultwarden befüllen
 task mcp:deploy                  # MCP-Server für Claude Code deployen
 task website:deploy              # Astro-Website bauen und deployen
 ```
@@ -60,20 +77,21 @@ task website:deploy              # Astro-Website bauen und deployen
 
 ## Dienste-Übersicht mit Admin-Zugängen
 
-In Produktion ist `{DOMAIN}` entweder `mentolder.de` oder `korczewski.de`. Lokal stehen dieselben Endpunkte unter `*.localhost` zur Verfügung.
+`{DOMAIN}` ist `mentolder.de` oder `korczewski.de`. Lokal stehen dieselben Endpunkte unter `*.localhost`.
 
 | Dienst | URL | Admin-Zugang |
 |--------|-----|--------------|
-| Portal & Website | `https://web.{DOMAIN}` | `https://web.{DOMAIN}/admin` (Gruppe `workspace-admins` erforderlich) |
-| Keycloak (SSO) | `https://auth.{DOMAIN}` | `https://auth.{DOMAIN}/admin` (Realm `workspace`) |
+| Portal & Website | `https://web.{DOMAIN}` | `https://web.{DOMAIN}/admin` (Gruppe `workspace-admins`) |
+| Keycloak (SSO) | `https://auth.{DOMAIN}` | `https://auth.{DOMAIN}/admin` → Realm `workspace` |
 | Nextcloud | `https://files.{DOMAIN}` | `https://files.{DOMAIN}/settings/admin` |
 | Collabora | `https://office.{DOMAIN}` | Konfiguration über Nextcloud (WOPI) |
-| Whiteboard | `https://board.{DOMAIN}` | — |
 | Vaultwarden | `https://vault.{DOMAIN}` | `https://vault.{DOMAIN}/admin` (Token-Login) |
+| Whiteboard | `https://board.{DOMAIN}` | — |
+| DocuSeal | `https://sign.{DOMAIN}` | `https://sign.{DOMAIN}` (Admin-Konto) |
 | Dokumentation | `https://docs.{DOMAIN}` | SSO-geschützt (Keycloak) |
-| Mailpit | `http://mail.localhost` | nur in Entwicklung verfügbar |
-
-MCP-Serverstatus (Claude-Code-Backend) läuft intern und ist nicht als Web-UI für Endnutzer vorgesehen — Details: [MCP-Server](claude-code.md).
+| LiveKit | `https://livekit.{DOMAIN}` | Admin-Steuerseite: `https://web.{DOMAIN}/admin/stream` |
+| Arena | `https://arena-ws.korczewski.de` | nur auf korczewski |
+| Mailpit | `http://mail.localhost` | nur in Entwicklung |
 
 ---
 
@@ -81,26 +99,27 @@ MCP-Serverstatus (Claude-Code-Backend) läuft intern und ist nicht als Web-UI f�
 
 ### Keycloak Admin-UI
 
-Alle Benutzerkonten werden zentral in Keycloak gepflegt. Jede Änderung gilt sofort für alle Dienste (Single Sign-On).
+Alle Benutzerkonten werden zentral in Keycloak gepflegt. Änderungen gelten sofort für alle Dienste (Single Sign-On).
 
 Aufruf: `https://auth.mentolder.de/admin` bzw. `https://auth.korczewski.de/admin` → Realm **workspace**
 
 #### Neuen Benutzer anlegen
 
-1. Navigiere zu **Benutzer → Benutzer hinzufügen**
-2. Felder ausfüllen: Benutzername (Kleinbuchstaben, kein Leerzeichen), E-Mail, Vorname, Nachname
+1. **Benutzer → Benutzer hinzufügen**
+2. Felder: Benutzername (Kleinbuchstaben, kein Leerzeichen), E-Mail, Vorname, Nachname
 3. Reiter **Zugangsdaten** → temporäres Passwort vergeben (Pflicht zur Änderung beim ersten Login)
 4. Reiter **Gruppen** → Benutzer zuweisen:
    - `workspace-users` — normaler Mitarbeiter-Zugang
    - `workspace-admins` — Administratorzugang (Website-Admin-Panel, erweiterte Rechte)
+   - `/dev-access` — Zugang zur Dev-Umgebung `dev.mentolder.de`
 
 #### Passwort zurücksetzen
 
-Keycloak Admin → **Benutzer** → Benutzer auswählen → Reiter **Zugangsdaten** → **Passwort zurücksetzen** → temporäres Passwort eingeben → **Temporär: Ja** → Speichern.
+**Benutzer** → Benutzer auswählen → **Zugangsdaten** → **Passwort zurücksetzen** → Temporär: Ja → Speichern.
 
 #### Benutzer deaktivieren
 
-Keycloak Admin → **Benutzer** → Benutzer auswählen → Reiter **Details** → Schalter **Aktiviert** ausschalten → Speichern. Der Benutzer kann sich sofort nicht mehr anmelden; Daten bleiben erhalten.
+**Benutzer** → Benutzer auswählen → **Details** → Schalter **Aktiviert** ausschalten → Speichern. Daten bleiben erhalten.
 
 ### Massenimport via CSV
 
@@ -116,35 +135,53 @@ scripts/import-users.sh --csv users.csv --dry-run
 
 CSV-Format: `username,email,firstname,lastname`
 
-Fehlende Gruppen werden automatisch erstellt. Importierte Benutzer erhalten temporäre Passwörter.
-
 ### Admin-User einrichten
 
 ```bash
-scripts/admin-users-setup.sh
+task workspace:admin-users-setup ENV=<env>
 ```
 
-Provisioniert die in der Umgebung definierten Admin-Benutzer (`KC_USER1`, `KC_USER2`) im workspace-Realm. Idempotent — bei bereits vorhandenen Benutzern wird nur aktualisiert.
+Provisioniert die in der Umgebung definierten Admin-Benutzer (`KC_USER1`, `KC_USER2`). Idempotent — bei bereits vorhandenen Benutzern wird nur aktualisiert.
+
+### Keycloak-Realm synchronisieren
+
+Nach Änderungen an der Realm-JSON oder OIDC-Client-Settings:
+
+```bash
+task keycloak:sync ENV=<env>
+```
+
+Details: [Keycloak](keycloak.md).
 
 ---
 
 ## Website-Admin-Panel
 
-Das Admin-Panel ist erreichbar unter `https://web.mentolder.de/admin` bzw. `https://web.korczewski.de/admin` (Workspace-Login mit Gruppe `workspace-admins` erforderlich). Eine vollständige Referenz aller Bereiche — Kunden, Projekte, Termine, Rechnungen, Meetings, Inhaltsverwaltung — findet sich im separaten [Admin-Webinterface-Handbuch](admin-webinterface.md).
-
-Kurzreferenz der wichtigsten Bereiche:
+Das Admin-Panel ist erreichbar unter `https://web.{DOMAIN}/admin` (Login mit Gruppe `workspace-admins` erforderlich). Eine vollständige Referenz aller Bereiche findet sich im [Admin-Webinterface-Handbuch](admin-webinterface.md).
 
 | Bereich | Pfad | Funktion |
 |---------|------|----------|
 | Inbox | `/admin/inbox` | Eingehende Kontaktanfragen |
-| Nachrichten | `/admin/nachrichten` | Chat-Räume und Direktnachrichten |
-| Kunden | `/admin/clients` | Kundenverwaltung |
+| Nachrichten | `/admin/nachrichten` | Kundenkommunikation und Direktnachrichten |
+| Räume | `/admin/raeume` | Gruppenkanäle verwalten |
+| Kunden | `/admin/clients` | Kundenverwaltung (Keycloak-Integration) |
 | Projekte | `/admin/projekte` | Projektmanagement mit Gantt-Diagramm |
-| Termine | `/admin/termine` | Buchungen und Slot-Whitelist |
-| Rechnungen | `/admin/rechnungen` | ZUGFeRD-PDF und SEPA-Lastschrift |
+| Kalender | `/admin/kalender` | Aufgabenkalender (Monatsansicht) |
+| Termine | `/admin/termine` | Buchungen und Slot-Konfiguration |
+| Follow-ups | `/admin/followups` | Wiedervorlagen und Erinnerungen |
+| Zeiterfassung | `/admin/zeiterfassung` | Arbeitszeiterfassung mit CSV-Export |
+| Rechnungen | `/admin/rechnungen` | ZUGFeRD-PDF, E-Rechnung, SEPA-Lastschrift |
 | Meetings | `/admin/meetings` | Aufgezeichnete Meetings und Transkripte |
-| Monitoring | `/admin/monitoring` | Live-Übersicht: Pod-Status und Ressourcen |
+| Monitoring | `/admin/monitoring` | Live-Kubernetes-Cluster-Übersicht (beide Cluster) |
 | Bugs | `/admin/bugs` | Bug-Reports und Ticket-Tracking |
+| Stream | `/admin/stream` | LiveKit-Livestream-Steuerung |
+| Startseite | `/admin/startseite` | Inhalte der Startseite bearbeiten |
+| Leistungen | `/admin/angebote` | Dienstleistungen und Preise pflegen |
+| Über mich | `/admin/uebermich` | „Über mich"-Seite bearbeiten |
+| Referenzen | `/admin/referenzen` | Kundennachweise verwalten |
+| Kontakt | `/admin/kontakt` | Kontaktseite bearbeiten |
+| FAQ | `/admin/faq` | Häufige Fragen bearbeiten |
+| Rechtliches | `/admin/rechtliches` | Impressum, Datenschutz, AGB, Barrieref. |
 
 ---
 
@@ -162,57 +199,58 @@ kubectl exec -n workspace deploy/nextcloud \
 Nützliche occ-Befehle:
 
 ```bash
-# App aktivieren
-php occ app:enable <app>
-
-# Nutzer-Storage-Limit setzen
-php occ user:setting <user> files quota <limit>
-
-# Wartungsmodus ein-/ausschalten
-php occ maintenance:mode --on
-php occ maintenance:mode --off
-
-# Status anzeigen
-php occ status
+php occ app:enable <app>                         # App aktivieren
+php occ user:setting <user> files quota <limit>  # Speicherlimit setzen
+php occ maintenance:mode --on                    # Wartungsmodus an
+php occ maintenance:mode --off                   # Wartungsmodus aus
+php occ status                                   # Systemstatus anzeigen
 ```
 
 ### Apps nach Deploy aktivieren
 
 ```bash
-task workspace:post-setup
+task workspace:post-setup ENV=<env>
 ```
 
-Aktiviert: calendar, contacts, user_oidc, richdocuments (Collabora), whiteboard, notify_push, talk. Details: [Nextcloud](nextcloud.md).
+Aktiviert: calendar, contacts, user_oidc, richdocuments (Collabora), whiteboard, notify_push, talk.
+
+### Talk-Infrastruktur konfigurieren
+
+```bash
+task workspace:talk-setup ENV=<env>        # HPB-Signaling + CoTURN
+task workspace:recording-setup ENV=<env>   # Aufzeichnungs-Backend
+task workspace:whiteboard-setup ENV=<env>  # Whiteboard-App
+task workspace:systembrett-setup ENV=<env> # Brett-Integration in Talk
+```
+
+Details: [Nextcloud](nextcloud.md) · [Talk HPB](talk-hpb.md).
 
 ---
 
-### E-Rechnung (XRechnung / ZUGFeRD)
+## E-Rechnung (XRechnung / ZUGFeRD)
 
-Drei Profile stehen zur Auswahl beim Versand und Download:
+Drei Profile stehen beim Rechnungsversand und -download zur Auswahl:
 
-| Profil | Verwendung | URL |
-|---|---|---|
+| Profil | Verwendung | Endpoint |
+|--------|-----------|----------|
 | `factur-x-minimum` | B2C / interne Archivierung | `/api/billing/invoice/<id>/pdf?profile=factur-x-minimum` |
 | `xrechnung-cii` | B2G (Bund/Länder), CII-Syntax | `/api/billing/invoice/<id>/pdf?profile=xrechnung-cii` |
-| `xrechnung-ubl` | B2G, UBL-2.1-Syntax (z. B. ZRE/OZG-RE) | `/api/billing/invoice/<id>/pdf?profile=xrechnung-ubl` |
+| `xrechnung-ubl` | B2G, UBL-2.1-Syntax (ZRE/OZG-RE) | `/api/billing/invoice/<id>/pdf?profile=xrechnung-ubl` |
 
-Für `xrechnung-*` muss die **Leitweg-ID** des Empfängers im Kundenstamm gesetzt sein
-(Format `<grob>-[<fein>-]<prüfziffer>` nach KoSIT 2.0.2). Sonst antwortet die API mit HTTP 422.
-
-**Leitweg-ID setzen:** `PATCH /api/admin/billing/customers/<customer-id>/leitweg` mit
-`{ "leitwegId": "991-01234-44" }` oder `{ "leitwegId": null }` zum Entfernen. Validierung
-erfolgt serverseitig.
-
-**XML statt PDF:** `/api/billing/invoice/<id>/zugferd?profile=<profile>` liefert nur das XML.
-
-**Validierung lokaler Dateien:**
+Für `xrechnung-*` muss die **Leitweg-ID** des Empfängers gesetzt sein (Format `<grob>-[<fein>-]<prüfziffer>` nach KoSIT 2.0.2):
 
 ```bash
+# Leitweg-ID setzen
+PATCH /api/admin/billing/customers/<customer-id>/leitweg
+{ "leitwegId": "991-01234-44" }
+
+# Nur XML abrufen
+GET /api/billing/invoice/<id>/zugferd?profile=<profile>
+
+# Lokal validieren
 task billing:validate-einvoice -- ./rechnung.pdf
 task billing:validate-einvoice -- ./factur-x.xml
 ```
-
-Erwartet: `Mustang … is a valid E-Invoice (Factur-X / XRechnung).`
 
 ---
 
@@ -220,38 +258,42 @@ Erwartet: `Mustang … is a valid E-Invoice (Factur-X / XRechnung).`
 
 ### Live-Übersicht im Admin-Panel
 
-Das Admin-Panel unter `https://web.{DOMAIN}/admin/monitoring` zeigt Pod-Status, CPU- und RAM-Auslastung sowie Kubernetes-Events. Die Daten werden über die MCP-Kubernetes-Integration abgerufen. Im lokalen k3d-Cluster ist diese Ansicht nur eingeschränkt nutzbar.
+`https://web.{DOMAIN}/admin/monitoring` zeigt Pod-Status, CPU- und RAM-Auslastung sowie Kubernetes-Events — für beide Cluster. Die Daten werden über die MCP-Kubernetes-Integration abgerufen.
 
 ### Kommandozeile
 
 ```bash
-task workspace:status              # Pods, Services, Ingress, PVCs
-task workspace:logs -- keycloak    # Logs eines Services anzeigen
-task workspace:logs -- nextcloud
-task workspace:logs -- website
+task workspace:status ENV=<env>            # Pods, Services, Ingress, PVCs
+task workspace:logs ENV=<env> -- keycloak  # Logs eines Services
+task workspace:logs ENV=<env> -- nextcloud
+task workspace:logs ENV=<env> -- website
+task health                                # Cross-Cluster-Connectivity beider Cluster
+task clusters:status                       # Einzeiliger Status beider Cluster
 ```
 
 ### Service neu starten
 
 ```bash
-task workspace:restart -- nextcloud
-task workspace:restart -- keycloak
-task workspace:restart -- vaultwarden
+task workspace:restart ENV=<env> -- nextcloud
+task workspace:restart ENV=<env> -- keycloak
+task workspace:restart ENV=<env> -- vaultwarden
 ```
 
 ---
 
 ## Secrets-Management (Produktion)
 
-In den Produktionsumgebungen werden **keine Klartext-Secrets** eingecheckt. Es kommt der Bitnami Sealed Secrets Controller zum Einsatz: Klartext-Secrets werden mit dem öffentlichen Schlüssel des Controllers verschlüsselt und als `SealedSecret`-Ressource in Git abgelegt.
+Produktions-Secrets werden **nie im Klartext** eingecheckt. Der Bitnami Sealed Secrets Controller verschlüsselt sie clusterspezifisch.
 
-**Workflow für ein neues oder rotiertes Secret:**
+> **Wichtig:** Ein SealedSecret ist cluster-spezifisch — eine für `mentolder` verschlüsselte Datei funktioniert **nicht** auf `korczewski`. Jede Rotation muss auf beiden Clustern separat durchgeführt werden.
+
+**Workflow für neue oder rotierte Secrets:**
 
 ```bash
-# 1. Klartext-Secrets generieren oder editieren (schreibt environments/.secrets/<env>.yaml)
+# 1. Klartext-Secrets editieren
 task env:generate ENV=mentolder
 
-# 2. Als SealedSecret verschlüsseln (schreibt environments/sealed-secrets/<env>.yaml)
+# 2. Als SealedSecret verschlüsseln
 task env:seal ENV=mentolder
 
 # 3. Verschlüsselte Datei committen (sicher für Git)
@@ -259,11 +301,12 @@ git add environments/sealed-secrets/mentolder.yaml
 
 # 4. Konfiguration validieren
 task env:validate ENV=mentolder
+
+# 5. Auf den Cluster anwenden (ohne Workload-Roll)
+task secrets:sync
 ```
 
-**Wichtig:** Ein SealedSecret ist cluster- und namespace-spezifisch — eine für `mentolder` verschlüsselte Datei funktioniert nicht auf `korczewski` und umgekehrt. Der private Schlüssel verlässt den jeweiligen Cluster nie.
-
-**Nicht den `$patch: delete`-Block in `prod/kustomization.yaml` entfernen** — er strippt die Dev-Platzhalter aus `k3d/secrets.yaml`, sodass die SealedSecrets-gemanagten Produktions-Secrets bei jedem Deploy erhalten bleiben.
+> **Fußangel:** Den `$patch: delete`-Block in `prod/kustomization.yaml` **niemals entfernen** — er strippt Dev-Platzhalter aus `k3d/secrets.yaml`, sodass SealedSecrets-gemanagte Produktions-Secrets bei jedem Deploy erhalten bleiben.
 
 Details: [Umgebungen](environments.md).
 
@@ -274,32 +317,29 @@ Details: [Umgebungen](environments.md).
 ### Workloads ausrollen
 
 ```bash
-task feature:deploy               # Alle Services auf beiden Clustern ausrollen
+task feature:deploy               # Alle Services auf BEIDEN Clustern (empfohlen)
 task workspace:deploy ENV=mentolder   # Nur mentolder
 task workspace:deploy ENV=korczewski  # Nur korczewski
-task feature:website              # Nur Website (beide Cluster)
+task feature:website              # Website neu bauen + rollen (beide Cluster)
+task feature:brett                # Brett neu bauen + rollen (beide Cluster)
+task feature:livekit              # LiveKit DNS-Pinning + Rollen (beide Cluster)
 ```
 
-### Overlays
+### Kustomize-Overlays
 
-- `prod/` ist Basis für die Umgebungen und enthält den `$patch: delete`-Block — **nicht allein anwenden**
-- `prod-mentolder/` und `prod-korczewski/` sind die tatsächlich applizierbaren Overlays
-- `k3d/office-stack` (Collabora) und `k3d/coturn-stack` werden separat via `task workspace:office:deploy` ausgerollt
+- `prod/` — gemeinsame Patches; **niemals allein anwenden** (enthält den `$patch: delete`-Block)
+- `prod-mentolder/` / `prod-korczewski/` — die tatsächlich applizierbaren Overlays
+- `k3d/office-stack` (Collabora) und `k3d/coturn-stack` werden separat via `task workspace:office:deploy ENV=<env>` ausgerollt
 
-### Geheimnisse synchronisieren
+### Docs-Image aktualisieren
+
+Der Docs-Inhalt ist im Docker-Image eingebaut — nach Änderungen an `k3d/docs-content/` muss das Image neu gebaut werden:
 
 ```bash
-task env:seal ENV=<env>    # Nach Rotation: neu versiegeln
-task secrets:sync          # SealedSecrets auf beide Cluster anwenden (kein Workload-Roll)
+task docs:deploy   # Baut Image, pusht, rollt beide Cluster
 ```
 
-### Docs-ConfigMap aktualisieren
-
-Nach Änderungen an `k3d/docs-content/` den Rollout auf beide Cluster auslösen:
-
-```bash
-task docs:deploy
-```
+> `docs:configmap:apply` hat keine Wirkung auf laufende Pods — immer `docs:deploy` verwenden.
 
 ---
 
@@ -308,18 +348,114 @@ task docs:deploy
 Backups werden automatisch per Kubernetes CronJob erstellt.
 
 ```bash
-# Status prüfen
-kubectl get cronjobs -n workspace
-kubectl get jobs -n workspace | grep backup
+# Sofortiges Backup auslösen
+task workspace:backup ENV=<env>
 
-# Manuelles Backup auslösen
-kubectl create job \
-  --from=cronjob/backup-job \
-  manual-backup-$(date +%Y%m%d) \
-  -n workspace
+# Verfügbare Snapshots auflisten
+task workspace:backup:list ENV=<env>
+
+# Einzelne Datenbank wiederherstellen
+task workspace:restore -- <db> <timestamp> ENV=<env>
+# db: keycloak | nextcloud | vaultwarden | website | docuseal | all
 ```
 
-Backup-Inhalt: PostgreSQL-Dumps (alle Datenbanken), Nextcloud-Daten, Vaultwarden-Vault. Details: [Backup & Wiederherstellung](backup.md).
+Backup-Inhalt: PostgreSQL-Dumps (alle Datenbanken), Nextcloud-Daten, Vaultwarden-Vault.
+
+Details: [Backup & Wiederherstellung](backup.md).
+
+---
+
+## LiveKit — Livestream-Betrieb
+
+LiveKit läuft auf `hostNetwork` und ist via `nodeAffinity` auf die Pin-Node `gekko-hetzner-3` (mentolder) fixiert. Admin-Steuerseite: `https://web.{DOMAIN}/admin/stream`. Zuschauer-Seite: `https://web.{DOMAIN}/portal/stream`.
+
+```bash
+task livekit:status ENV=<env>           # Pods, Services, Ingress, Recordings
+task livekit:logs ENV=<env>             # livekit-server Logs
+task livekit:logs ENV=<env> -- ingress  # RTMP-Ingress Logs
+task livekit:logs ENV=<env> -- egress   # Recording-Egress Logs
+task livekit:recordings ENV=<env>       # MP4-Liste im Egress-PVC
+task livekit:end-stream ENV=<env>       # Notfall: Server neu starten
+task livekit:dns-pin ENV=<env>          # DNS auf Pin-Node zeigen (APPLY=true zum Anwenden)
+task livekit:firewall-open NODE=<ip>    # ufw-Ports öffnen (7880/7881 TCP, 50000-60000/30000-40000 UDP)
+```
+
+> **DNS-Pinning ist erforderlich.** Ohne Pinning treffen Browser-Clients ~66% der Zeit auf einen Nicht-LiveKit-Node → ICE-Fehler, kein Stream.
+
+Details: [Livestream](livestream.md).
+
+---
+
+## Brett (Systembrett)
+
+Brett ist der 3D-Systembrett-Service unter `brett.{DOMAIN}`. Er läuft auf beiden Clustern.
+
+```bash
+task brett:build                  # Image bauen (+ k3d-Import in dev)
+task brett:deploy ENV=<env>       # Bauen, pushen, ausrollen
+task brett:logs ENV=<env>         # Brett-Logs
+task brett:bot-setup ENV=<env>    # /brett Slash-Command in Nextcloud Talk registrieren
+```
+
+Details: [Systembrett](systembrett.md).
+
+---
+
+## Arena-Server (Multiplayer)
+
+Der Arena-Server läuft **ausschließlich auf dem korczewski-Cluster** (`arena-ws.korczewski.de`). Beide Websites können darauf zugreifen; der Server validiert JWT von beiden Keycloak-Realms.
+
+```bash
+task arena:build                  # Image bauen
+task arena:deploy ENV=korczewski  # Bauen, pushen, ausrollen
+task feature:arena                # Kurzform: Build + Deploy auf korczewski
+task arena:status ENV=korczewski  # Pod + Service-Status
+task arena:logs ENV=korczewski    # Logs
+task arena:db ENV=korczewski      # psql in das arena-Schema
+```
+
+> `task arena:deploy ENV=mentolder` bricht mit Erklärung ab — Arena läuft nur auf korczewski.
+
+Details: [Arena](arena.md).
+
+---
+
+## Coaching-Pipeline & Wissensdatenbank
+
+Die Coaching-Pipeline verarbeitet PDF/EPUB-Bücher in Wissens-Chunks und macht sie über pgvector abrufbar.
+
+```bash
+# Buch hochladen und verarbeiten
+task coaching:ingest -- <file.pdf> <slug> --title="Titel" --author="Autor"
+
+# KI-Klassifikation (benötigt Anthropic-API oder lokales Ollama)
+task coaching:classify -- --slug=<slug>
+task coaching:classify -- --all
+
+# Embeddings neu indizieren
+task knowledge:reindex ENV=<env>
+# Mit Quellauswahl: SOURCE=prs|markdown|bugs|all
+```
+
+Entwürfe zur Prüfung: `https://web.mentolder.de/admin/knowledge/drafts`
+
+> **Lokale Klassifikation:** Bei fehlendem Anthropic-API-Schlüssel — lokales Ollama + Docker-LiteLLM als Übersetzer. Details: [Coaching-Pipeline](coaching-pipeline.md).
+
+---
+
+## Datenbankzugang (PostgreSQL)
+
+```bash
+task workspace:psql ENV=<env> -- <db>          # psql-Shell öffnen
+task workspace:port-forward ENV=<env>          # DB auf localhost:5432 forwarden
+task workspace:db:drop -- <dbname> ENV=<env>   # DB löschen (mit Bestätigung)
+task workspace:db:restore -- <db> <ts> ENV=<env>  # Backup einspielen
+task workspace:sync-db-passwords ENV=<env>     # Rollen-Passwörter abgleichen
+```
+
+Verfügbare Datenbanken: `keycloak`, `nextcloud`, `vaultwarden`, `website`, `docuseal`, `arena`, `bachelorprojekt`.
+
+Schema-Diagramm erzeugen: `task db:diagram`
 
 ---
 
@@ -327,18 +463,21 @@ Backup-Inhalt: PostgreSQL-Dumps (alle Datenbanken), Nextcloud-Daten, Vaultwarden
 
 | Aufgabe | Befehl |
 |---------|--------|
-| Cluster starten / stoppen | `task cluster:start` / `task cluster:stop` |
-| Alle Services deployen | `task workspace:deploy ENV=<env>` |
-| Website neu bauen und deployen | `task website:redeploy ENV=<env>` |
+| Alle Services deployen (beide Cluster) | `task feature:deploy` |
+| Nur Website deployen (beide Cluster) | `task feature:website` |
 | Post-Deploy-Setup | `task workspace:post-setup ENV=<env>` |
-| Datenbankshell öffnen | `task workspace:psql -- website` |
-| Vaultwarden-Seed ausführen | `task workspace:vaultwarden:seed` |
+| DB-Shell öffnen | `task workspace:psql ENV=<env> -- website` |
+| Keycloak-Realm synchronisieren | `task keycloak:sync ENV=<env>` |
+| DB-Passwörter abgleichen | `task workspace:sync-db-passwords ENV=<env>` |
 | DSGVO-Compliance prüfen | `task workspace:dsgvo-check` |
-| Erreichbarkeit aller Services prüfen | `task workspace:check-connectivity` |
-| Container-Update-Status prüfen | `task workspace:check-updates` |
+| Beide Cluster prüfen | `task health` |
 | Alle Tests ausführen | `./tests/runner.sh local` |
+| Docs deployen | `task docs:deploy` |
+| Vaultwarden-Seed | `task workspace:vaultwarden:seed` |
+| Nextcloud-Branding neu anwenden | `task workspace:theme ENV=<env>` |
+| Smoke-Tests nach Deploy | `task workspace:verify:all-prods` |
 
-Vollständige Task-Referenz: [Deployment & Taskfile](operations.md).
+Vollständige Task-Referenz: [Operations](operations.md).
 
 ---
 
@@ -347,36 +486,53 @@ Vollständige Task-Referenz: [Deployment & Taskfile](operations.md).
 ### Ein Service startet nicht
 
 ```bash
-task workspace:logs -- <service>
+task workspace:logs ENV=<env> -- <service>
 kubectl describe pod -n workspace -l app=<service>
 kubectl get events -n workspace --sort-by='.lastTimestamp'
 ```
 
-Häufige Ursachen: Datenbankverbindung fehlgeschlagen, fehlendes Secret, unaufgelöste `${VAR}`-Platzhalter in Manifest oder Realm-JSON (Keycloak), unzureichende Ressourcen.
+Häufige Ursachen: Datenbankverbindung fehlgeschlagen, fehlendes Secret, unaufgelöste `${VAR}`-Platzhalter in Manifests oder Realm-JSON, unzureichende Ressourcen.
 
 ### Keycloak-Login funktioniert nicht für einen Dienst
 
-1. Prüfe, ob der Dienst als OIDC-Client in Keycloak registriert ist: `https://auth.{DOMAIN}/admin` → Clients
-2. Prüfe die Redirect-URIs des Clients (exakt, inkl. Protokoll und Pfad)
-3. Dienst neu starten: `task workspace:restart -- <dienst>`
+1. OIDC-Client in Keycloak prüfen: **Clients** → Client auswählen
+2. Redirect-URIs prüfen (exakt, inkl. Protokoll und Pfad)
+3. `task keycloak:sync ENV=<env>` ausführen
+4. Dienst neu starten: `task workspace:restart ENV=<env> -- <dienst>`
 
 Details: [Keycloak & SSO](keycloak.md).
 
-### Wie füge ich eine neue Domain hinzu?
+### Wie füge ich eine neue Domain/Hostname hinzu?
 
-1. `k3d/configmap-domains.yaml` oder die umgebungsspezifischen Overlay-Patches anpassen
+1. `k3d/configmap-domains.yaml` anpassen
 2. Ingress-Regel in `k3d/ingress.yaml` ergänzen
 3. `task workspace:validate` ausführen
-4. Falls ein Envvar neu eingeführt wird: in `environments/schema.yaml` deklarieren und in den `envsubst`-Listen der betroffenen Tasks ergänzen
-5. PR erstellen und nach Merge mit `task feature:deploy` oder `task workspace:deploy ENV=<env>` ausrollen
+4. Falls neuer Envvar: in `environments/schema.yaml` deklarieren und in `envsubst`-Listen der betroffenen Tasks ergänzen
+5. PR erstellen, nach Merge: `task feature:deploy`
 
 ### Wie richte ich eine neue Produktionsumgebung ein?
 
-Schritt-für-Schritt in [Umgebungen → Neue Umgebung einrichten](environments.md#neue-umgebung-einrichten).
+Schritt-für-Schritt: [Umgebungen → Neue Umgebung einrichten](environments.md#neue-umgebung-einrichten).
 
 ### Secrets rotieren
 
-Siehe oben **Secrets-Management** — Klartext in `.secrets/<env>.yaml` aktualisieren, `task env:seal ENV=<env>` ausführen, Commit, dann `task secrets:sync`.
+Klartext in `.secrets/<env>.yaml` aktualisieren → `task env:seal ENV=<env>` → Commit → `task secrets:sync`. Details: oben unter Secrets-Management.
+
+### LiveKit — ICE schlägt fehl / kein Stream
+
+1. `task livekit:dns-pin ENV=<env>` → DNS auf Pin-Node zeigen lassen
+2. Firewall prüfen: 7880/7881 TCP und 50000-60000 UDP + 30000-40000 UDP offen?
+3. `task livekit:status ENV=<env>` → Pods auf der richtigen Node (`gekko-hetzner-3`)?
+
+### Nach Cluster-Reset funktionieren Secrets nicht
+
+Nach jedem Cluster-Reset rotiert der Sealed-Secrets-Controller seinen Keypair. Pflichtschritte:
+
+```bash
+task env:fetch-cert ENV=<env>  # neues Zertifikat holen
+task env:seal ENV=<env>        # Secrets neu verschlüsseln
+# committen + secrets:sync
+```
 
 ---
 
@@ -391,9 +547,12 @@ Siehe oben **Secrets-Management** — Klartext in `.secrets/<env>.yaml` aktualis
 | Nextcloud | [Nextcloud](nextcloud.md) |
 | Admin-Webinterface (vollständig) | [Admin-Webinterface](admin-webinterface.md) |
 | Projektmanagement (API) | [Projekt-Verwaltung](admin-projekte.md) |
-| MCP-Server (Claude Code) | [MCP-Server](claude-code.md) |
+| MCP-Server (Claude Code) | [Claude Code](claude-code.md) |
 | Deployment & Taskfile | [Operations](operations.md) |
 | Sicherheit & DSGVO | [Sicherheit](security.md) · [DSGVO](dsgvo.md) |
-| Skripte & Automatisierung | [Skripte](scripts.md) |
+| Backup & Wiederherstellung | [Backup](backup.md) |
+| Livestream (LiveKit) | [Livestream](livestream.md) |
+| Systembrett (Brett) | [Systembrett](systembrett.md) |
+| Arena-Server | [Arena](arena.md) |
 | Fehlerbehebung | [Fehlerbehebung](troubleshooting.md) |
 | Testframework | [Tests](tests.md) |

--- a/k3d/docs-content/benutzerhandbuch.md
+++ b/k3d/docs-content/benutzerhandbuch.md
@@ -2,23 +2,26 @@
 
 ## Willkommen
 
-Der Workspace ist Deine sichere, betriebsinterne Plattform für die tägliche Zusammenarbeit im Team. Alle Daten werden ausschließlich auf eigenen Servern in Deutschland gespeichert — nichts davon gelangt zu externen Anbietern wie Microsoft, Google oder Dropbox. Die Plattform ist DSGVO-konform aufgebaut.
+Der Workspace ist Deine sichere, betriebsinterne Plattform für die tägliche Zusammenarbeit im Team. Alle Daten werden ausschließlich auf eigenen Servern gespeichert — nichts davon gelangt zu externen Anbietern wie Microsoft, Google oder Dropbox. Die Plattform ist DSGVO-konform aufgebaut.
 
-Du brauchst **nur einen einzigen Account**: ein Login öffnet alle Dienste (Single Sign-On über Keycloak).
+Du brauchst **nur einen einzigen Account**: ein Login öffnet alle Dienste (Single Sign-On).
 
 ### Verfügbare Dienste
 
 | Dienst | Beschreibung | Adresse |
 |--------|-------------|---------|
-| Portal / Nachrichten | Persönliche Startseite, Chat, Direktnachrichten, Inbox | `https://web.{DOMAIN}/portal` |
+| Portal | Persönliche Startseite, Nachrichten, Inbox | `https://web.{DOMAIN}/portal` |
 | Nextcloud | Dateien, Kalender, Kontakte | `https://files.{DOMAIN}` |
-| Nextcloud Talk | Video-Calls und Meetings | in Nextcloud → Talk |
-| Collabora Online | Browser-basiertes Office | öffnet aus Nextcloud |
-| Whiteboard | Kollaboratives Whiteboard | `https://board.{DOMAIN}` |
+| Nextcloud Talk | Video-Calls und Team-Chat | in Nextcloud → Talk |
+| Collabora Online | Office-Suite im Browser | öffnet aus Nextcloud heraus |
+| Whiteboard | Kollaboratives Zeichnen | `https://board.{DOMAIN}` |
 | Vaultwarden | Passwort-Safe | `https://vault.{DOMAIN}` |
+| DocuSeal | Dokumente unterzeichnen | `https://sign.{DOMAIN}` |
+| Livestream | Live-Übertragungen ansehen | `https://web.{DOMAIN}/portal/stream` |
+| Brett (Systembrett) | 3D-Systemisches Brett | `https://brett.{DOMAIN}` |
 | Dokumentation | Dieses Handbuch | `https://docs.{DOMAIN}` |
 
-`{DOMAIN}` ist die Domain Deiner Umgebung — typischerweise **`mentolder.de`** oder **`korczewski.de`**. Beispiel: für mentolder erreichst Du das Portal unter `https://web.mentolder.de/portal`. Frage Deinen Administrator, falls Du unsicher bist, welche Domain für Dich gilt.
+`{DOMAIN}` ist die Domain Deiner Umgebung — typischerweise **`mentolder.de`** oder **`korczewski.de`**. Frage Deinen Administrator, falls Du unsicher bist.
 
 ---
 
@@ -26,37 +29,55 @@ Du brauchst **nur einen einzigen Account**: ein Login öffnet alle Dienste (Sing
 
 ### Schritt-für-Schritt
 
-1. Rufe das Portal in Deinem Browser auf — z. B. `https://web.mentolder.de/portal` oder `https://web.korczewski.de/portal`.
-2. Klicke oben rechts auf **„Anmelden"**.
-3. Du wirst zur zentralen Login-Seite weitergeleitet (Keycloak).
-4. Gib Benutzername und Passwort ein, die Du vom Administrator erhalten hast.
-5. Nach erfolgreichem Login bist Du in allen Diensten automatisch angemeldet (Single Sign-On).
+1. Rufe das Portal in Deinem Browser auf: `https://web.{DOMAIN}/portal`
+2. Klicke auf **„Anmelden"**
+3. Du wirst zur zentralen Login-Seite weitergeleitet (Keycloak)
+4. Gib Benutzername und Passwort ein, die Du vom Administrator erhalten hast
+5. Beim ersten Login wirst Du aufgefordert, ein neues Passwort zu setzen — mindestens 12 Zeichen, sicher und einzigartig
+6. Nach erfolgreichem Login bist Du in allen Diensten automatisch angemeldet
 
-> **Tipp:** Setze ein Lesezeichen auf das Portal — von dort aus erreichst Du alle weiteren Dienste mit einem Klick.
+> **Tipp:** Setze ein Lesezeichen auf das Portal — von dort aus erreichst Du alle weiteren Dienste.
 
 ### Passwort vergessen
 
-Klicke auf der Login-Seite auf **„Passwort vergessen?"**. Du erhältst eine E-Mail mit einem Reset-Link, der nur kurze Zeit gültig ist. Findet sich keine E-Mail im Posteingang, prüfe den Spam-Ordner — andernfalls wende Dich an den Administrator.
+Klicke auf der Login-Seite auf **„Passwort vergessen?"**. Du erhältst eine E-Mail mit einem Reset-Link. Falls keine E-Mail ankommt, prüfe den Spam-Ordner oder wende Dich an den Administrator.
 
 ### Passwort ändern
 
-Rufe `https://auth.{DOMAIN}/realms/workspace/account` auf, melde Dich an und wähle **„Passwort"**. Das neue Passwort gilt sofort für alle Dienste.
+Rufe `https://auth.{DOMAIN}/realms/workspace/account` auf und wähle **„Passwort"**. Das neue Passwort gilt sofort für alle Dienste.
 
-> **Sicherheitshinweis:** Verwende für den Workspace ein einzigartiges, starkes Passwort. Speichere es im Vaultwarden-Tresor (siehe unten), nicht im Browser.
+> **Sicherheitshinweis:** Speichere Dein Workspace-Passwort im Vaultwarden-Tresor, nicht im Browser.
 
 ---
 
 ## Portal — Deine Startseite
 
-Das Portal unter `web.{DOMAIN}/portal` ist Dein zentraler Einstiegspunkt nach dem Login. Es bündelt alle tagesrelevanten Informationen:
+Das Portal unter `https://web.{DOMAIN}/portal` ist Dein zentraler Einstiegspunkt. Es bündelt alle tagesrelevanten Informationen:
 
-- **Übersicht:** Aktuelle Nachrichten, offene Aufgaben, kommende Termine
 - **Nachrichten & Chat:** Direktnachrichten mit Kollegen und Admins, Gruppenräume
-- **Dokumente & Signaturen:** Hochgeladene Dokumente und zu unterzeichnende Verträge
-- **Meetings & Besprechungen:** Geplante und zurückliegende Videomeetings mit Transkripten
+- **Inbox:** Eingehende Anfragen und Benachrichtigungen
 - **Termine:** Buchungen und Kalenderansicht
+- **Dokumente & Signaturen:** Hochgeladene Dokumente und zu unterzeichnende Verträge
+- **Meetings:** Geplante und zurückliegende Videomeetings mit Transkripten
 
-Das Portal ist responsiv und funktioniert sowohl am Desktop als auch am Smartphone.
+Das Portal ist responsiv und funktioniert am Desktop, Tablet und Smartphone.
+
+---
+
+## Nachrichten & Chat
+
+Das integrierte Messaging-System ermöglicht direkte Kommunikation mit dem Team und dem Administrator.
+
+### Direktnachrichten
+
+- Im Portal unter **„Nachrichten"**: auf einen Kontakt klicken und schreiben
+- Nachrichten werden in Echtzeit zugestellt
+- Anhänge (Bilder, Dateien) können direkt im Chat geteilt werden
+
+### Gruppenräume
+
+- Unter **„Räume"** findest Du alle Gruppen, denen Du angehörst
+- Räume eignen sich für projektbezogene oder thematische Kommunikation
 
 ---
 
@@ -66,28 +87,32 @@ Nextcloud ist Dein persönlicher Cloud-Speicher auf eigenem Server. Aufruf: `htt
 
 ### Dateien
 
-- Dateien hochladen: Per Drag & Drop oder über die Schaltfläche **„+"**
-- Ordner erstellen: **„+" → „Neuer Ordner"**
-- Datei freigeben: Rechtsklick → **„Teilen"** → Name des Empfängers eingeben oder öffentlichen Link erstellen
-- Berechtigungen festlegen: nur lesen oder auch bearbeiten
+- **Hochladen:** Dateien per Drag & Drop in den Browser ziehen oder über **„+" → Datei hochladen**
+- **Ordner erstellen:** **„+" → „Neuer Ordner"**
+- **Teilen:** Rechtsklick auf eine Datei → **„Teilen"** → Empfänger eingeben oder öffentlichen Link erstellen
+- **Berechtigungen:** Beim Teilen zwischen „nur lesen" und „bearbeiten" wählen
 
 ### Kalender
 
-- Kalender anlegen: In der Kalender-App auf **„Neuer Kalender"**
-- Termin erstellen: Auf ein Datum klicken → Termindaten eingeben
-- Kalender teilen: Kalender-Einstellungen → **„Teilen"** → Empfänger eingeben
+- **Neuer Termin:** In der Kalender-App auf ein Datum klicken → Termindaten eingeben
+- **Kalender teilen:** Kalender-Einstellungen → **„Teilen"** → Empfänger eingeben
+- **App-Synchronisation:** Der Kalender lässt sich mit mobilen Geräten per CalDAV synchronisieren
 
 ### Kontakte
 
-- Kontakt anlegen: In der Kontakte-App auf **„Neuer Kontakt"**
-- Gruppen anlegen und Kontakte zuordnen
-- vCard-Import: **„Einstellungen" → „Importieren"**
+- **Neuer Kontakt:** In der Kontakte-App auf **„Neuer Kontakt"** klicken
+- **vCard-Import:** **„Einstellungen" → „Importieren"**
+- **CardDAV-Sync:** Kontakte lassen sich mit dem Smartphone synchronisieren
+
+### Nextcloud-App für iOS und Android
+
+Die offizielle Nextcloud-App ermöglicht Zugriff auf Dateien, Kalender und Talk auch unterwegs.
 
 ---
 
 ## Talk — Video-Calls & Chat
 
-Nextcloud Talk ist das integrierte System für Video-Meetings und Chat. Aufruf: `https://files.{DOMAIN}` → **Talk** (linke Seitenleiste).
+Nextcloud Talk ist das integrierte System für Video-Meetings und Chat. Aufruf: `https://files.{DOMAIN}` → **Talk** in der Seitenleiste.
 
 ### Meeting starten
 
@@ -99,67 +124,111 @@ Der Browser fragt beim ersten Mal nach Zugriff auf Kamera und Mikrofon — bitte
 
 ### Im Meeting
 
-- Mikrofon stummschalten: Mikrofon-Symbol in der Steuerleiste
-- Kamera deaktivieren: Kamera-Symbol
-- Bildschirm teilen: Monitor-Symbol → Fenster oder Bildschirm auswählen
-- Chat: Text-Symbol öffnet den Meeting-Chat
+| Aktion | Schaltfläche |
+|--------|-------------|
+| Mikrofon stummschalten | Mikrofon-Symbol |
+| Kamera deaktivieren | Kamera-Symbol |
+| Bildschirm teilen | Monitor-Symbol → Fenster oder Bildschirm auswählen |
+| Meeting-Chat öffnen | Sprechblasen-Symbol |
 
 ### Gäste einladen
 
-Erstelle ein Gespräch → kopiere den Einladungslink → sende ihn an die Person. Gäste benötigen keinen eigenen Account.
+Erstelle ein Gespräch → kopiere den Einladungslink → sende ihn an die Person. Gäste benötigen **keinen eigenen Account**.
 
 ### Aufzeichnung und Transkription
 
-Falls vom Admin aktiviert, können Anrufe aufgezeichnet und automatisch transkribiert werden (Whisper). Die Aufzeichnung erscheint nach Ende des Meetings als Datei im Nextcloud-Ordner des Gastgebers, das Transkript im Admin-Bereich unter **Meetings**.
+Falls vom Administrator aktiviert, können Calls aufgezeichnet und automatisch transkribiert werden. Die Aufzeichnung erscheint nach dem Meeting als Datei im Nextcloud-Ordner des Gastgebers.
 
 ---
 
 ## Collabora Online — Dokumente bearbeiten
 
-Collabora öffnet sich automatisch aus Nextcloud heraus. Klicke in Nextcloud auf eine Datei — sie öffnet sich im Browser-Editor. Kein separates Programm notwendig.
+Collabora öffnet sich automatisch aus Nextcloud heraus — kein separates Programm notwendig.
 
-Unterstützte Formate:
+Klicke in Nextcloud auf eine Datei; sie öffnet sich im Browser-Editor.
 
-| Format | Typ |
-|--------|-----|
-| `.odt`, `.docx` | Textdokumente (Writer) |
-| `.ods`, `.xlsx` | Tabellen (Calc) |
-| `.odp`, `.pptx` | Präsentationen (Impress) |
+| Format | Anwendung |
+|--------|----------|
+| `.odt`, `.docx` | Writer (Textdokument) |
+| `.ods`, `.xlsx` | Calc (Tabelle) |
+| `.odp`, `.pptx` | Impress (Präsentation) |
 
-Neues Dokument erstellen: In Nextcloud **„+" → „Neues Dokument"**.
+**Neues Dokument:** In Nextcloud **„+" → „Neues Dokument"** (je nach Typ wählen).
 
-Gemeinsames Bearbeiten: Mehrere Personen können gleichzeitig am selben Dokument arbeiten. Änderungen sind in Echtzeit sichtbar.
-
----
-
-## Vaultwarden — Passwort-Manager
-
-Vaultwarden ist kompatibel mit dem Bitwarden-Browser-Plugin und den Bitwarden-Apps für iOS und Android.
-
-### Ersteinrichtung
-
-1. Installiere das **Bitwarden**-Browser-Plugin (Chrome, Firefox, Edge)
-2. Öffne die Plugin-Einstellungen → **„Server-URL"**
-3. Trage `https://vault.{DOMAIN}` ein
-4. Erstelle einen Account oder melde Dich mit Deinem Workspace-Konto an
-
-### Passwörter verwalten
-
-- Passwort speichern: Beim Login-Formular erscheint ein Speichern-Dialog im Plugin
-- Automatisch ausfüllen: Das Plugin erkennt Login-Formulare und bietet gespeicherte Zugangsdaten an
-- Passwörter teilen: Geteilte Sammlungen im Vaultwarden-Webinterface (`vault.{DOMAIN}`)
-
-**Wichtig:** Das Vaultwarden-Master-Passwort ist unabhängig vom Workspace-Passwort. Schreibe es sicher auf und verwahre es gut — ein Verlust bedeutet den Verlust aller gespeicherten Passwörter.
+**Gleichzeitig bearbeiten:** Mehrere Personen können parallel am selben Dokument arbeiten — Änderungen sind in Echtzeit sichtbar.
 
 ---
 
 ## Whiteboard
 
-Das Whiteboard ermöglicht gemeinsames Zeichnen und Visualisieren im Browser. Aufruf: `https://board.{DOMAIN}`
+Das Whiteboard ermöglicht gemeinsames Zeichnen und Visualisieren im Browser.
 
-- In Nextcloud öffnen: **„+" → „Neues Whiteboard"**
-- Gemeinsam arbeiten: Teile den Board-Link mit Kolleginnen und Kollegen
-- Werkzeuge: Freihand, Formen, Text, Pfeile, Post-its
+Aufruf in Nextcloud: **„+" → „Neues Whiteboard"** oder direkt unter `https://board.{DOMAIN}`.
+
+Verfügbare Werkzeuge: Freihand, Formen, Text, Pfeile, Post-its, Bilder einfügen.
+
+**Teilen:** Kopiere den Board-Link und sende ihn an Kolleginnen und Kollegen — alle sehen die Änderungen in Echtzeit.
+
+---
+
+## Vaultwarden — Passwort-Manager
+
+Vaultwarden speichert Passwörter sicher und füllt sie automatisch aus. Es ist kompatibel mit dem Bitwarden-Browser-Plugin und den Bitwarden-Apps für iOS und Android.
+
+### Ersteinrichtung
+
+1. Installiere das **Bitwarden**-Browser-Plugin (Chrome, Firefox, Edge)
+2. Öffne die Plugin-Einstellungen → **„Server-URL"**
+3. Trage `https://vault.{DOMAIN}` ein und speichere
+4. Melde Dich mit Deinem Workspace-Konto an
+
+### Passwörter verwalten
+
+- **Speichern:** Beim Ausfüllen eines Login-Formulars erscheint ein Speichern-Dialog im Plugin
+- **Automatisch ausfüllen:** Das Plugin erkennt Login-Formulare und bietet gespeicherte Daten an
+- **Teilen:** Geteilte Sammlungen im Vaultwarden-Webinterface für Team-Passwörter
+
+> **Wichtig:** Das Vaultwarden-Master-Passwort ist unabhängig vom Workspace-Passwort. Notiere es sicher auf — ein Verlust bedeutet den Verlust aller gespeicherten Passwörter.
+
+---
+
+## DocuSeal — Dokumente unterzeichnen
+
+DocuSeal ermöglicht das digitale Unterzeichnen von Dokumenten im Browser. Aufruf: `https://sign.{DOMAIN}`
+
+- Erhältst Du eine Unterzeichnungsanfrage, erscheint ein Link im Portal oder per E-Mail
+- Öffne das Dokument und unterzeichne es digital mit wenigen Klicks
+- Unterzeichnete Dokumente sind im Portal unter **„Signaturen"** abrufbar
+
+---
+
+## Brett — Systemisches Brett (3D)
+
+Das Brett ermöglicht systemische Aufstellungen im Browser — räumlich, interaktiv, dreidimensional. Aufruf: `https://brett.{DOMAIN}`
+
+- Figuren platzieren und im 3D-Raum bewegen
+- Räume für Einzel- oder Gruppenarbeit erstellen
+- Integration in Nextcloud Talk: Slash-Command `/brett` öffnet direkt eine neue Session
+
+---
+
+## Livestream
+
+Über das Portal kannst Du Live-Übertragungen ansehen. Aufruf: `https://web.{DOMAIN}/portal/stream`
+
+- Der Livestream ist an Deinen Workspace-Login gebunden — nur angemeldete Nutzer können zuschauen
+- Eine aktive Übertragung erscheint automatisch auf der Stream-Seite
+- Aufzeichnungen vergangener Streams können vom Administrator bereitgestellt werden
+
+---
+
+## Arena — Multiplayer
+
+Arena ist ein browserbasiertes Multiplayer-Erlebnis, das direkt über das Portal zugänglich ist.
+
+- Gemeinsam im Team spielen oder an interaktiven Szenarien teilnehmen
+- Kein separates Programm notwendig — funktioniert vollständig im Browser
+- Arena läuft zentral und ist von beiden Plattformen (`mentolder.de` und `korczewski.de`) aus erreichbar
 
 ---
 
@@ -167,13 +236,13 @@ Das Whiteboard ermöglicht gemeinsames Zeichnen und Visualisieren im Browser. Au
 
 ### Technisches Problem melden
 
-Nutze das Bug-Report-Formular direkt im Portal — es ist über den Hilfe-Button am Bildschirmrand erreichbar. Tickets gehen automatisch an den Administrator und werden dort zentral bearbeitet.
+Nutze das Bug-Report-Formular direkt im Portal — erreichbar über den Hilfe-Button am Bildschirmrand. Tickets gehen automatisch an den Administrator.
 
-Für nicht-technische Fragen: schreibe eine Nachricht an den Administrator im Portal unter **Nachrichten**.
+Für nicht-technische Fragen: Nachricht an den Administrator im Portal unter **„Nachrichten"** schreiben.
 
 ### Dokumentation
 
-Die vollständige Dokumentation findest Du unter `https://docs.{DOMAIN}` (z. B. `https://docs.mentolder.de`). Der Zugriff ist an Deinen Workspace-Login gekoppelt.
+Die vollständige Dokumentation findest Du unter `https://docs.{DOMAIN}`. Der Zugriff ist an Deinen Workspace-Login gekoppelt.
 
 ---
 
@@ -181,20 +250,20 @@ Die vollständige Dokumentation findest Du unter `https://docs.{DOMAIN}` (z. B. 
 
 ### Ich habe mein Passwort vergessen
 
-Klicke auf der Login-Seite auf **„Passwort vergessen"** und folge den Anweisungen. Falls Du keine E-Mail erhältst, wende Dich an den Administrator.
+Klicke auf der Login-Seite auf **„Passwort vergessen?"** und folge den Anweisungen. Falls keine E-Mail ankommt, wende Dich an den Administrator.
 
 ### Kann ich die Dienste auf dem Smartphone nutzen?
 
 Ja. Empfohlene Apps:
 
-- **Nextcloud**: offizielle App für iOS und Android (Dateien, Kalender, Talk)
-- **Vaultwarden**: Bitwarden-App für iOS und Android
+- **Nextcloud-App** (iOS / Android) — Dateien, Kalender, Kontakte und Talk
+- **Bitwarden-App** (iOS / Android) — für Vaultwarden
 
-Das Portal und alle anderen Dienste sind außerdem als responsive Website im mobilen Browser nutzbar.
+Portal, Whiteboard und alle anderen Dienste sind außerdem als responsive Website im mobilen Browser nutzbar.
 
 ### Wer hat Zugriff auf meine Dateien?
 
-Nur berechtigte Teammitglieder und Administratoren. Die Daten verlassen die eigenen Server nicht. Die Plattform ist DSGVO-konform gestaltet — Details findest Du in der [DSGVO-Dokumentation](dsgvo.md).
+Nur berechtigte Teammitglieder und Administratoren. Die Daten verlassen die eigenen Server nicht. Details in der [DSGVO-Dokumentation](dsgvo.md).
 
 ### Darf ich Verträge oder Kundendaten hochladen?
 
@@ -202,11 +271,15 @@ Ja — das ist der Zweck der Plattform. Da alle Daten auf eigenen Servern liegen
 
 ### Warum sehe ich manche Bereiche nicht?
 
-Administrative Bereiche (z. B. `/admin`) sind nur sichtbar, wenn Dein Konto zur Keycloak-Gruppe `workspace-admins` gehört. Frage bei Bedarf den Administrator.
+Administrative Bereiche (z. B. `/admin`) sind nur für Konten der Gruppe `workspace-admins` sichtbar. Wende Dich bei Bedarf an den Administrator.
+
+### Die Startseite sieht auf mentolder.de und korczewski.de unterschiedlich aus
+
+Richtig — beide Plattformen haben bewusst unterschiedliche Designs und Funktionsschwerpunkte, teilen sich aber dieselbe Infrastruktur und denselben Login.
 
 ### Etwas funktioniert nicht
 
-Schreibe im Portal-Chat eine Nachricht an den Administrator oder nutze das Bug-Report-Formular im Portal.
+Schreibe im Portal eine Nachricht an den Administrator oder nutze das Bug-Report-Formular.
 
 ---
 
@@ -214,11 +287,14 @@ Schreibe im Portal-Chat eine Nachricht an den Administrator oder nutze das Bug-R
 
 | Ich möchte … | Dienst |
 |-------------|--------|
-| Nachricht an einen Kollegen schicken | Portal — Nachrichten |
+| Einer Person eine Nachricht schicken | Portal — Nachrichten |
 | Eine Datei teilen | Nextcloud |
 | Gemeinsam ein Dokument bearbeiten | Nextcloud + Collabora |
-| Ein Meeting starten | Nextcloud Talk |
-| Ideen gemeinsam aufzeichnen | Whiteboard |
+| Ein Video-Meeting starten | Nextcloud Talk |
+| Ideen gemeinsam skizzieren | Whiteboard |
+| Eine systemische Aufstellung machen | Brett |
 | Passwörter sicher aufbewahren | Vaultwarden |
-| Einen Termin mit einem Admin vereinbaren | Portal — Termine |
-| Diese Dokumentation lesen | Docs |
+| Einen Vertrag unterzeichnen | DocuSeal |
+| Einen Livestream ansehen | Portal → Stream |
+| Multiplayer-Aktivitäten | Portal → Arena |
+| Diese Dokumentation lesen | `https://docs.{DOMAIN}` |


### PR DESCRIPTION
## Summary

- **Adminhandbuch:** Aktualisiert auf aktuellen Systemstand — zwei getrennte Cluster (mentolder + korczewski), ArgoCD entfernt, LiveKit/Livestream, Arena, Brett, DocuSeal, Coaching-Pipeline, korrekte Namespace-Referenzen, alle Admin-Panel-Bereiche
- **Benutzerhandbuch:** Vollständig neu geschrieben, nutzerfreundlich ohne Kubernetes-Jargon; neue Dienste (Livestream, Brett, Arena, DocuSeal) erklärt, Kurzübersichtstabelle aktualisiert

## Test plan

- [ ] Docs-only Änderung, kein Code betroffen
- [ ] `task test:all` in main grün (bats-Worktree-Fehler ist bekannte Einschränkung, nicht neu)
- [ ] Nach Merge: `task docs:deploy` um Änderungen auf beide Cluster zu deployen