### PR TITLE
chore: ticket-management skill + software_events schema + brett admin fix

### DIFF
--- a/.claude/skills/ticket-management/SKILL.md
+++ b/.claude/skills/ticket-management/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ticket-management
-description: Use when asked to work through, triage, or resolve open tickets in the mentolder ticket database. Covers fetching open tickets, categorizing by actionability, applying fixes autonomously for ai_ready tickets, and routing needs_human tickets with a clear request.
+description: Use when asked to work through, triage, or resolve open tickets in the mentolder ticket database, clean up stale git worktrees and branches, merge open PRs, or fix CI/CD failures. Covers fetching open tickets, categorizing by actionability, applying fixes autonomously for ai_ready tickets, routing needs_human tickets, and full repo hygiene.
 ---
 
 > **Mishap Tracking:** As you execute this skill, maintain a running `MISHAP_LOG`.
@@ -107,6 +107,131 @@ git branch -D <branch>
 
 **Already fixed in referenced PR** — close as `done`/`fixed` with a note citing the PR. No code change needed.
 
+## Repo Hygiene
+
+Run this block **every session** before touching tickets — it surfaces work the DB may not know about.
+
+### 1. Stale Worktrees
+
+```bash
+git worktree list
+```
+
+A worktree is stale when its branch is already merged to `main` or the owning plan/session is gone. Safe to remove:
+
+```bash
+# Verify merged first — never remove an unmerged worktree without checking
+git log main..<branch> --oneline   # empty = fully merged
+git worktree remove .claude/worktrees/<name> --force
+```
+
+**Do not remove** a worktree if:
+- Its branch has unmerged commits (check with `git log main..<branch>`)
+- Another concurrent Claude session may own it (`git stash list`, `git log --all --grep=WIP`)
+
+### 2. Stale Local Branches
+
+```bash
+git branch -vv | grep -v '^\*'
+```
+
+Delete branches that are either:
+- Already merged: `git branch --merged main | grep -v main`
+- Tracking a deleted remote: shows `[gone]` in `-vv` output
+
+```bash
+# Safe batch-delete merged local branches
+git branch --merged main | grep -v 'main' | xargs git branch -d
+
+# Delete a branch whose remote is gone
+git branch -D <branch>
+```
+
+**Never force-delete** a branch with unmerged commits without user confirmation.
+
+### 3. Stale Remote Branches
+
+```bash
+git fetch --prune   # prunes remote-tracking refs for deleted remote branches
+gh pr list --state merged --limit 50 --json headRefName \
+  | jq -r '.[].headRefName' \
+  | xargs -I{} git push origin --delete {} 2>/dev/null || true
+```
+
+Only delete remote branches that: (a) had their PR merged, and (b) have no open PRs referencing them.
+
+## GitHub PR Triage
+
+### Fetch All Open PRs
+
+```bash
+gh pr list --state open --json number,title,headRefName,statusCheckRollup,reviewDecision,isDraft,mergeStateStatus \
+  | jq '.[] | {number, title, branch: .headRefName, ci: (.statusCheckRollup // [] | map(.conclusion) | unique), review: .reviewDecision, draft: .isDraft, mergeState: .mergeStateStatus}'
+```
+
+### Triage Buckets
+
+| Bucket | Condition | Action |
+|--------|-----------|--------|
+| **Merge immediately** | `mergeStateStatus=MERGEABLE`, CI green, not draft | Squash-merge now |
+| **CI failing** | Any check is `FAILURE` or `TIMED_OUT` | Diagnose → fix → re-push |
+| **Needs rebase** | `mergeStateStatus=BEHIND` | `gh pr update-branch <number>` or rebase |
+| **Draft** | `isDraft=true` | Skip — author is not done |
+| **Stale / abandoned** | Open >14 days, no activity, branch stale | Close with a note explaining why |
+
+### Merging a PR
+
+```bash
+# Always squash-merge to keep main history clean (project rule)
+gh pr merge <number> --squash --auto --delete-branch
+```
+
+After merge: verify the branch is gone remotely, then delete the local tracking ref (`git fetch --prune`).
+
+### Diagnosing CI Failures
+
+```bash
+# List failed checks on a PR
+gh pr checks <number> | grep -E 'fail|error' -i
+
+# View the failing job log (get run ID from the check URL or gh run list)
+gh run list --branch <branch> --limit 5
+gh run view <run-id> --log-failed
+```
+
+Common CI failures in this repo and fixes:
+
+| Failure | Likely cause | Fix |
+|---------|-------------|-----|
+| `task test:all` exits non-zero | BATS unit test regression | Run `task test:unit` locally, fix the failing assertion |
+| `test-inventory` diverged | Added/removed a test without regenerating | `task test:inventory` then commit |
+| Arena protocol drift | `messages.ts` ≠ `lobbyTypes.ts` | Copy the canonical file, commit |
+| `kustomize build` fails | Bad patch or missing resource | `task workspace:validate` locally |
+| Image push fails (ghcr.io 403) | `default_workflow_permissions` not set to write | Fix in GitHub repo settings (see memory `reference_ghcr_workflow_permissions`) |
+| Secret scanning alert | Hardcoded credential detected | Remove credential, rotate it, force-push (coordinate with user) |
+
+### Closing a Stale PR
+
+```bash
+gh pr close <number> --comment "Closing as stale — <reason>. Reopen if this work resumes."
+git push origin --delete <branch>  # clean up remote branch
+```
+
+## GitHub Issues Triage
+
+```bash
+# List open issues
+gh issue list --state open --json number,title,labels,assignees,createdAt \
+  | jq '.[] | {number, title, labels: [.labels[].name], age: .createdAt}'
+```
+
+| Issue type | Action |
+|-----------|--------|
+| Already fixed by a merged PR | Close with `gh issue close <n> --comment "Fixed in PR #<m>"` |
+| Duplicate | Close with `gh issue close <n> --comment "Duplicate of #<m>"` and add `duplicate` label |
+| Tracked in DB ticket | Add comment linking ticket ID, then close or leave open per user preference |
+| Genuine open work | Create a DB ticket if it doesn't exist, link the issue in the ticket notes |
+
 ## Ticketing Etiquette
 
 - Always add a dated note (`[ticket-management YYYY-MM-DD]`) — never leave notes blank.
@@ -117,13 +242,24 @@ git branch -D <branch>
 
 ## Session Workflow
 
-1. Fetch all open tickets
-2. Present categorization to user for confirmation before acting (especially for `needs_human` judgment calls)
-3. Batch-close the "already resolved" group first (quick wins, no code risk)
-4. Set `ai_ready` on fixable tickets, then fan out fixes in parallel (use Agent tool for independent tasks)
-5. Set `needs_human` with specific asks for blocked tickets
-6. Commit code changes → PR → auto-merge
-7. Close fixed tickets in DB after the PR is up
+**Phase 0 — Repo hygiene (always first)**
+1. `git worktree list` → identify and remove stale worktrees (branch merged to main)
+2. `git branch --merged main` → delete merged local branches
+3. `git fetch --prune` → clean remote-tracking refs
+4. `gh pr list --state open` → triage all open PRs (merge ready ones immediately)
+5. `gh issue list --state open` → close issues that are already fixed or duplicate
+6. Fix any CI failures on mergeable PRs before touching tickets
+
+**Phase 1 — Ticket triage**
+7. Fetch all open tickets
+8. Present categorization to user for confirmation before acting (especially for `needs_human` judgment calls)
+
+**Phase 2 — Execute**
+9. Batch-close the "already resolved" group first (quick wins, no code risk)
+10. Set `ai_ready` on fixable tickets, then fan out fixes in parallel (use Agent tool for independent tasks)
+11. Set `needs_human` with specific asks for blocked tickets
+12. Commit code changes → PR → auto-merge
+13. Close fixed tickets in DB after the PR is up
 
 ## Common Mistakes
 
@@ -134,6 +270,11 @@ git branch -D <branch>
 | Writing vague human-needed notes | Include the specific question or action the human must take |
 | Fixing tests by changing the assertion | Find the source of the regression; fix the logic |
 | Acting on tickets before presenting categorization to user | Always confirm the triage grouping first |
+| Deleting a worktree/branch without checking for unmerged commits | Always run `git log main..<branch> --oneline` first — empty = safe |
+| Force-deleting an unmerged branch without user confirmation | Only `git branch -D` with user consent; prefer `git branch -d` (safe delete) |
+| Merging a PR without squash | Project rule: always `--squash`; regular merge pollutes main history |
+| Ignoring CI failures on a PR before merge | Fix CI first — a red PR is blocked; never merge with failing checks |
+| Closing a GitHub issue without a comment explaining why | Always leave a comment — it's the public audit trail |
 
 ## Post-Execution: Mishap Report
 

--- a/k3d/website-schema.yaml
+++ b/k3d/website-schema.yaml
@@ -1457,6 +1457,55 @@ data:
         LEFT JOIN bachelorprojekt.requirements r ON r.id = f.requirement_id
        ORDER BY f.merged_at DESC;
 
+      CREATE TABLE IF NOT EXISTS bachelorprojekt.software_events (
+        id             BIGSERIAL PRIMARY KEY,
+        pr_number      INTEGER NOT NULL REFERENCES bachelorprojekt.features(pr_number) ON DELETE CASCADE,
+        service        TEXT    NOT NULL,
+        area           TEXT    NOT NULL,
+        kind           TEXT    NOT NULL CHECK (kind IN ('added','removed','changed','irrelevant')),
+        confidence     NUMERIC(3,2) NOT NULL DEFAULT 1.0 CHECK (confidence >= 0 AND confidence <= 1),
+        classifier     TEXT    NOT NULL,
+        classified_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+        notes          TEXT
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_software_events_pr      ON bachelorprojekt.software_events (pr_number);
+      CREATE INDEX IF NOT EXISTS idx_software_events_service ON bachelorprojekt.software_events (service);
+      CREATE INDEX IF NOT EXISTS idx_software_events_kind    ON bachelorprojekt.software_events (kind);
+
+      CREATE OR REPLACE VIEW bachelorprojekt.v_software_stack AS
+      WITH last_event AS (
+        SELECT DISTINCT ON (service)
+          service, area, kind, classified_at, pr_number
+        FROM bachelorprojekt.software_events
+        WHERE kind <> 'irrelevant'
+        ORDER BY service, classified_at DESC, id DESC
+      )
+      SELECT service, area, classified_at AS as_of, pr_number AS last_pr
+      FROM last_event
+      WHERE kind <> 'removed'
+      ORDER BY area, service;
+
+      CREATE OR REPLACE VIEW bachelorprojekt.v_software_history AS
+      SELECT
+        e.id,
+        e.pr_number,
+        f.merged_at,
+        f.title,
+        f.brand,
+        f.merged_by,
+        e.service,
+        e.area,
+        e.kind,
+        e.confidence,
+        e.classifier,
+        e.classified_at,
+        e.notes
+      FROM bachelorprojekt.software_events e
+      JOIN bachelorprojekt.features f ON f.pr_number = e.pr_number
+      WHERE e.kind <> 'irrelevant'
+      ORDER BY f.merged_at DESC, e.id DESC;
+
       GRANT USAGE ON SCHEMA bachelorprojekt TO website;
       GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA bachelorprojekt TO website;
       GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA bachelorprojekt TO website;

--- a/k3d/website.yaml
+++ b/k3d/website.yaml
@@ -219,8 +219,6 @@ spec:
                   key: WEBSITE_DB_PASSWORD
             - name: SESSIONS_DATABASE_URL
               value: "postgresql://website:$(WEBSITE_DB_PASSWORD)@shared-db.${WORKSPACE_NAMESPACE}.svc.cluster.local:5432/website"
-            - name: TRACKING_DB_URL
-              value: "postgresql://website:$(WEBSITE_DB_PASSWORD)@shared-db.${WORKSPACE_NAMESPACE}.svc.cluster.local:5432/postgres"
             - name: CRON_SECRET
               valueFrom:
                 secretKeyRef:

--- a/website/src/lib/software-history-db.ts
+++ b/website/src/lib/software-history-db.ts
@@ -1,19 +1,8 @@
-import { Pool, type PoolClient } from 'pg';
-import { resolve4 } from 'node:dns';
+import { type Pool, type PoolClient } from 'pg';
+import { pool as trackingPool } from './website-db';
 import type { Event } from './software-history-classifier';
 
-function nodeLookup(
-  hostname: string,
-  _opts: unknown,
-  cb: (err: Error | null, addr: string, family: number) => void,
-) {
-  resolve4(hostname, (err, addrs) => cb(err ?? null, addrs?.[0] ?? '', 4));
-}
-
-export const trackingPool = new Pool({
-  connectionString: (process.env.SESSIONS_DATABASE_URL ?? '').replace(/\/website$/, '/postgres'),
-  lookup: nodeLookup,
-} as unknown as import('pg').PoolConfig);
+export { trackingPool };
 
 export interface StackRow {
   service: string;

--- a/website/src/pages/admin/brett/index.astro
+++ b/website/src/pages/admin/brett/index.astro
@@ -1,9 +1,12 @@
 ---
-// Redirect /admin/brett/index -> /admin/brett
+// Redirect admin to the Brett service's admin console (?admin=1 triggers KC OIDC + room browser).
 import { getSession, isAdmin, getLoginUrl } from '../../../lib/auth';
 
 const session = await getSession(Astro.request.headers.get('cookie'));
 if (!session) return Astro.redirect(getLoginUrl('/admin/brett'));
 if (!isAdmin(session)) return Astro.redirect('/admin');
-return Astro.redirect('/admin/brett');
+
+const brettDomain = process.env.BRETT_DOMAIN ?? 'brett.localhost';
+const proto = brettDomain.includes('localhost') ? 'http' : 'https';
+return Astro.redirect(`${proto}://${brettDomain}/?admin=1`);
 ---


### PR DESCRIPTION
## Summary

- **ticket-management skill**: expanded with Repo Hygiene, GitHub PR Triage, and GitHub Issues Triage sections; session workflow restructured into 3 phases; 5 new Common Mistakes entries
- **software_events schema**: adds `bachelorprojekt.software_events` table + `v_software_stack` / `v_software_history` views to the website-schema migration
- **trackingPool consolidation**: `software-history-db.ts` now re-exports the shared pool from `website-db` instead of creating a second `pg.Pool`; removes duplicate `TRACKING_DB_URL` env var from `website.yaml`
- **brett admin redirect**: `/admin/brett` now forwards authenticated admins to `https://brett.<domain>/?admin=1` (KC OIDC-protected room browser) instead of looping back to `/admin/brett`

## Test plan

- [ ] CI passes (kustomize validate, BATS unit tests, test-inventory check)
- [ ] `task website:deploy ENV=mentolder` deploys cleanly
- [ ] `/admin/brett` redirects to the brett service admin console
- [ ] `bachelorprojekt.software_events` table exists after schema migration (verify via `task workspace:psql ENV=mentolder -- website`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)