### PR TITLE
feat(knowledge): web crawler knowledge source (sitemap-first, robots.txt, admin UI)

### DIFF
--- a/.claude/skills/knowledge-reindex/SKILL.md
+++ b/.claude/skills/knowledge-reindex/SKILL.md
@@ -147,6 +147,44 @@ task secrets:sync
 
 ---
 
+## Web-Quellen crawlen
+
+Web-crawl collections are NOT re-indexed via `task knowledge:reindex` — they use a separate task.
+
+### From CLI (with port-forward)
+
+```bash
+# Find the collection UUID:
+task workspace:psql ENV=mentolder -- website <<'SQL'
+SELECT id, name, crawl_config->>'startUrl' AS start_url
+FROM knowledge.collections
+WHERE source = 'web_crawl';
+SQL
+
+# Run the crawler:
+task knowledge:crawl ENV=mentolder COLLECTION_ID=<uuid>
+
+# Optional overrides:
+START_URL=https://other-url.com MAX_PAGES=50 task knowledge:crawl ENV=mentolder COLLECTION_ID=<uuid>
+```
+
+### From Admin UI
+
+Navigate to `/admin/wissensquellen` → "Web-Quellen" table → click **"Crawl starten"** next to the collection.
+
+The crawl runs in the background; the collection's `chunk_count` and `last_indexed_at` update when it finishes.
+
+### Failure modes
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| 0 pages crawled | robots.txt blocks all paths, or URL unreachable | Check robots.txt at `<startUrl>/robots.txt`; verify URL |
+| Script exits with "No startUrl configured" | `crawl_config` not set in DB | Use PATCH `/api/admin/knowledge/collections/<id>/crawl-config` or recreate collection |
+| Embedding error | VOYAGE_API_KEY missing or TEI down | Check env var / GPU host as per embedding model isolation section above |
+| 409 from API | Another crawl already running | Wait for it to finish (check pod logs) |
+
+---
+
 ## When to reindex
 
 | Event | Reindex needed? |

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -3125,6 +3125,32 @@ tasks:
           SOURCE="{{.SOURCE}}" \
           bash scripts/knowledge/reindex.sh
 
+  knowledge:crawl:
+    desc: "Crawl a web_crawl collection (COLLECTION_ID=<uuid>, ENV=dev|mentolder|korczewski)"
+    vars:
+      ENV: '{{.ENV | default "dev"}}'
+    cmds:
+      - |
+        if [ -z "{{.COLLECTION_ID}}" ]; then
+          echo "Usage: task knowledge:crawl COLLECTION_ID=<uuid> ENV=<env>"
+          exit 1
+        fi
+
+        source scripts/env-resolve.sh "{{.ENV}}"
+        ctx_flag=""
+        [ "{{.ENV}}" != "dev" ] && ctx_flag="--context $ENV_CONTEXT"
+        NS="${WORKSPACE_NAMESPACE:-workspace}"
+
+        kubectl $ctx_flag -n "$NS" port-forward svc/shared-db 5432:5432 \
+          >/tmp/knowledge-crawl-pf.log 2>&1 &
+        PF=$!
+        trap 'kill $PF 2>/dev/null' EXIT
+        sleep 3
+
+        COLLECTION_ID="{{.COLLECTION_ID}}" \
+        PGURL="postgres://website:${WEBSITE_DB_PASSWORD}@localhost:5432/website" \
+          node scripts/knowledge/ingest-web.mjs {{.CLI_ARGS}}
+
   coaching:ingest:
     desc: "Ingest a coaching book (PDF/EPUB) into pgvector + coaching.books. Args: -- <file> <slug> [--title=...] [--author=...]"
     cmds:

--- a/docs/superpowers/specs/2026-05-18-web-crawler-knowledge-design.md
+++ b/docs/superpowers/specs/2026-05-18-web-crawler-knowledge-design.md
@@ -1,0 +1,252 @@
+# Web-Crawler Knowledge Integration — Design Spec
+
+**Date:** 2026-05-18  
+**Branch:** feature/web-crawler-knowledge  
+**Status:** approved
+
+---
+
+## Overview
+
+Extend the knowledge RAG pipeline to ingest external documentation websites as vectorized knowledge collections. Users configure a start URL (with optional path prefix), trigger crawling manually from the admin UI, and the crawled pages are stored in the existing `knowledge.documents`/`chunks`/`collections` schema — queryable identically to built-in sources.
+
+Simultaneously, the `knowledge-reindex` skill is updated to document the web crawl workflow.
+
+---
+
+## 1. Data Model Changes
+
+### 1a. `knowledge.collections.source` constraint
+
+Add `'web_crawl'` to the existing CHECK constraint:
+
+```sql
+ALTER TABLE knowledge.collections
+  DROP CONSTRAINT collections_source_check;
+
+ALTER TABLE knowledge.collections
+  ADD CONSTRAINT collections_source_check
+    CHECK (source = ANY (ARRAY[
+      'pr_history', 'specs_plans', 'claude_md', 'bug_tickets', 'custom', 'web_crawl'
+    ]));
+```
+
+### 1b. `crawl_config` JSONB column
+
+```sql
+ALTER TABLE knowledge.collections
+  ADD COLUMN crawl_config JSONB;
+```
+
+Only populated when `source = 'web_crawl'`. Shape:
+
+```json
+{
+  "start_url": "https://docs.langchain.com/",
+  "path_prefix": "/api/",
+  "max_pages": 500
+}
+```
+
+- `start_url` — required, absolute URL
+- `path_prefix` — optional, restricts crawling to URLs starting with this path
+- `max_pages` — optional, default 500, safety cap
+
+### 1c. TypeScript type
+
+Add `'web_crawl'` to `CollectionSource` in `website/src/lib/knowledge-db.ts`:
+
+```ts
+export type CollectionSource = 'pr_history' | 'specs_plans' | 'claude_md' | 'bug_tickets' | 'custom' | 'web_crawl';
+```
+
+`createCollection()` accepts an optional `crawlConfig` parameter that is stored in `crawl_config`. `listCollections()` and `getCollection()` return the new column.
+
+---
+
+## 2. Crawler Script
+
+**File:** `scripts/knowledge/ingest-web.mjs`
+
+**Invocation:**
+```bash
+COLLECTION_ID=<uuid> PGURL=postgres://... node scripts/knowledge/ingest-web.mjs
+```
+
+**Dependencies (added to repo-level package.json or as inline imports):**
+- `cheerio` — HTML parsing and text extraction
+- `node-fetch` (or native `fetch` in Node 18+) — HTTP
+- Existing `lib-knowledge-pg.mjs` for DB operations and embedding
+
+**Algorithm:**
+
+1. Load `crawl_config` for `COLLECTION_ID` from DB. Fail fast if missing or `start_url` empty.
+2. **Sitemap-first discovery:**
+   - Fetch `<start_url>/sitemap.xml` (and `<start_url>/sitemap_index.xml`)
+   - Parse `<loc>` entries, filter by `path_prefix` if set
+   - If sitemap yields ≥1 URL → use that list
+3. **Fallback — recursive link-following:**
+   - Start queue with `[start_url]`
+   - Fetch each URL, extract `<a href>` links on the same origin matching `path_prefix`
+   - Max depth 4, max `max_pages` unique URLs
+4. **Per page:**
+   - HTTP GET with `User-Agent: mentolder-knowledge-bot/1.0`
+   - Parse with cheerio
+   - Extract main content: try selectors `main`, `article`, `[role=main]`, `.content`, `.docs-content`, `.md-content` in priority order; fall back to `body`
+   - Strip `nav`, `header`, `footer`, `aside`, `.sidebar`, `script`, `style`
+   - `rawText` = extracted text
+   - `title` = `<title>` tag or first `<h1>`
+   - `sourceUri` = absolute page URL
+   - Skip pages with < 100 characters of extracted text
+   - Respect `robots.txt` — parse once at crawl start, skip disallowed URLs
+5. Chunk via `chunkPlain()`, embed, `upsertDocumentAndChunks()` — identical to existing ingest scripts
+6. `bumpCollectionStats()` after all pages done
+
+**Error handling:**
+- Timeout 10s per page, skip on timeout
+- HTTP 4xx/5xx → skip page, log warning
+- 0 pages successfully crawled → exit code 1 (prevents empty collection)
+
+---
+
+## 3. Taskfile Task
+
+```yaml
+knowledge:crawl:
+  desc: "Crawl a web knowledge source. Args: -- <collection_id> [ENV=mentolder]"
+  vars:
+    ENV: '{{.ENV | default "dev"}}'
+  cmds:
+    - |
+      source scripts/env-resolve.sh "{{.ENV}}"
+      COLLECTION_ID="{{.CLI_ARGS}}"
+      # port-forward shared-db identical to knowledge:reindex
+      kubectl ... port-forward svc/shared-db 5432:5432 &
+      PF=$!; trap 'kill $PF' EXIT; sleep 3
+      PGURL="postgres://website:${WEBSITE_DB_PASSWORD}@localhost:5432/website" \
+        COLLECTION_ID="$COLLECTION_ID" \
+        node scripts/knowledge/ingest-web.mjs
+```
+
+---
+
+## 4. API Endpoints
+
+### `POST /api/admin/knowledge/collections` (extended)
+
+Existing endpoint now accepts `source: 'web_crawl'` and `crawlConfig: { startUrl, pathPrefix?, maxPages? }`. Stores in `crawl_config` column.
+
+### `POST /api/admin/knowledge/collections/[id]/crawl`
+
+Triggers crawl for a `web_crawl` collection:
+
+```ts
+// Auth: admin only
+// Returns 403 if collection.source !== 'web_crawl'
+// Returns 409 if crawl already running (tracked via in-memory Set per process)
+// Spawns: child_process.spawn('node', ['scripts/knowledge/ingest-web.mjs'], { env: { COLLECTION_ID, PGURL } })
+// Returns 202 immediately
+```
+
+Fire-and-forget: the API responds immediately, the crawl runs in background. The admin UI polls `chunk_count` / `last_indexed_at` to detect completion (or the user manually refreshes).
+
+### `DELETE /api/admin/knowledge/collections/[id]` (extended)
+
+Currently only allows `source === 'custom'`. Extend to also allow `source === 'web_crawl'`.
+
+### `PATCH /api/admin/knowledge/collections/[id]/crawl-config`
+
+Updates `crawl_config` (start_url, path_prefix, max_pages) for a `web_crawl` collection.
+
+---
+
+## 5. Admin UI (`/admin/wissensquellen`)
+
+**Changes to `website/src/pages/admin/wissensquellen.astro`:**
+
+- Header area: two buttons — **„+ Neue Web-Quelle"** (green-tinted) and **„+ Neue Wissensquelle"** (existing grey)
+- „Eigene Sammlungen" table gains a **Typ** column with badges:
+  - `web` — green badge for `web_crawl` collections
+  - `manuell` — grey badge for `custom` collections
+- `web_crawl` rows show:
+  - Start-URL displayed as short hostname (full URL on hover/title)
+  - **„▶ Crawl starten"** button (green) → `POST .../crawl`
+  - **„Löschen"** button (red)
+  - No „Re-index" (only built-in collections have that)
+- `custom` rows unchanged
+
+**New modal component `WebCrawlSourceModal.svelte`:**
+
+Fields:
+- **Name** (text, required)
+- **Start-URL** (url input, required, placeholder `https://docs.example.com/`)
+- **Pfad-Präfix** (text, optional, placeholder `/docs/`)
+- **Max. Seiten** (number, optional, default 500)
+
+On submit: `POST /api/admin/knowledge/collections` with `source: 'web_crawl'` + `crawlConfig`.
+
+**„▶ Crawl starten" UX:**
+- Button shows spinner while `POST .../crawl` is in-flight (202 response)
+- After 202: button text becomes „Läuft…" and is disabled
+- Simple polling every 5s on `chunk_count` to detect when crawl finishes (or user refreshes manually)
+
+---
+
+## 6. Skill Update (`knowledge-reindex`)
+
+Add new section **„Web-Quellen crawlen"** before the existing „Phase 1: Pre-checks":
+
+```markdown
+## Web-Quellen (web_crawl collections)
+
+Web-Sammlungen werden über die Admin-UI angelegt und manuell gecrawlt.
+
+### Anlegen
+1. `/admin/wissensquellen` → „+ Neue Web-Quelle"
+2. Name, Start-URL, optionaler Pfad-Präfix eingeben
+3. „Erstellen" → Collection mit `source=web_crawl` wird angelegt
+
+### Crawl anstoßen
+- Admin-UI: „▶ Crawl starten" in der Tabelle
+- CLI-Fallback: `task knowledge:crawl -- <collection_id> ENV=mentolder`
+
+### Pre-checks vor Crawl
+- Start-URL erreichbar: `curl -I <start_url>`
+- Embedding-Service verfügbar (wie Phase 1 der bestehenden Skill-Doku)
+- `robots.txt` konsultieren: crawler respektiert Disallow-Regeln automatisch
+
+### Failure handling
+| Symptom | Ursache | Behebung |
+|---|---|---|
+| 0 Seiten gecrawlt | Start-URL nicht erreichbar oder robots.txt blockiert alles | URL prüfen, ggf. path_prefix anpassen |
+| Chunk-Anzahl sehr niedrig | Hauptinhalt-Selektor trifft nicht | sourceUri in documents prüfen, raw_text kontrollieren |
+| Crawl hängt | Viele langsame Seiten, 10s-Timeout pro Seite | max_pages reduzieren |
+```
+
+---
+
+## 7. Files to Create / Modify
+
+| File | Change |
+|---|---|
+| `scripts/knowledge/ingest-web.mjs` | **New** — sitemap-first web crawler |
+| `scripts/knowledge/reindex.sh` | Extend with `web` source case |
+| `website/src/lib/knowledge-db.ts` | Add `'web_crawl'` to type + `crawlConfig` to createCollection/listCollections |
+| `website/src/pages/admin/wissensquellen.astro` | Extend with Typ-column, two create buttons, crawl triggers |
+| `website/src/components/admin/WebCrawlSourceModal.svelte` | **New** — modal for web source creation |
+| `website/src/pages/api/admin/knowledge/collections/index.ts` | Accept `web_crawl` + `crawlConfig` on POST |
+| `website/src/pages/api/admin/knowledge/collections/[id]/crawl.ts` | **New** — fire-and-forget crawl trigger |
+| `website/src/pages/api/admin/knowledge/collections/[id]/crawl-config.ts` | **New** — PATCH crawl config |
+| `website/src/pages/api/admin/knowledge/collections/[id]/index.ts` | Extend DELETE to allow `web_crawl` |
+| `Taskfile.yml` | Add `knowledge:crawl` task |
+| `db/migrations/` | Migration: add `web_crawl` to source CHECK + `crawl_config` column |
+| `.claude/skills/knowledge-reindex/SKILL.md` | Add web crawl section |
+
+---
+
+## 8. Out of Scope
+
+- Scheduled/automatic crawling (manual only)
+- JavaScript-rendered docs (no Playwright — covers 99% of SSG doc sites)
+- Per-page recrawl delta detection (full recrawl each time, dedup via sha256)
+- Cross-cluster crawl fan-out (run manually per cluster)

--- a/k3d/website-schema.yaml
+++ b/k3d/website-schema.yaml
@@ -1546,7 +1546,8 @@ data:
         name            TEXT NOT NULL UNIQUE,
         description     TEXT,
         source          TEXT NOT NULL CHECK (source IN
-                          ('pr_history','specs_plans','claude_md','bug_tickets','custom')),
+                          ('pr_history','specs_plans','claude_md','bug_tickets','custom','web_crawl')),
+        crawl_config    JSONB,
         brand           TEXT REFERENCES public.brands(id) ON UPDATE CASCADE ON DELETE RESTRICT,
         chunk_count     INT NOT NULL DEFAULT 0,
         last_indexed_at TIMESTAMPTZ,
@@ -1609,7 +1610,8 @@ data:
         name            TEXT NOT NULL UNIQUE,
         description     TEXT,
         source          TEXT NOT NULL CHECK (source IN
-                          ('pr_history','specs_plans','claude_md','bug_tickets','custom')),
+                          ('pr_history','specs_plans','claude_md','bug_tickets','custom','web_crawl')),
+        crawl_config    JSONB,
         brand           TEXT REFERENCES public.brands(id) ON UPDATE CASCADE ON DELETE RESTRICT,
         chunk_count     INT NOT NULL DEFAULT 0,
         last_indexed_at TIMESTAMPTZ,

--- a/k3d/website.yaml
+++ b/k3d/website.yaml
@@ -219,6 +219,8 @@ spec:
                   key: WEBSITE_DB_PASSWORD
             - name: SESSIONS_DATABASE_URL
               value: "postgresql://website:$(WEBSITE_DB_PASSWORD)@shared-db.${WORKSPACE_NAMESPACE}.svc.cluster.local:5432/website"
+            - name: REPO_ROOT
+              value: /app
             - name: CRON_SECRET
               valueFrom:
                 secretKeyRef:

--- a/scripts/knowledge/ingest-web.mjs
+++ b/scripts/knowledge/ingest-web.mjs
@@ -1,0 +1,266 @@
+#!/usr/bin/env node
+/**
+ * ingest-web.mjs — Crawl a website and ingest pages into a knowledge collection.
+ *
+ * Required env vars:
+ *   COLLECTION_ID   UUID of the target knowledge.collections row
+ *   PGURL           Full postgres connection string (postgres://user:pass@host:port/db)
+ *   VOYAGE_API_KEY  (or LLM_ENABLED=true + TEI running) for embeddings
+ *
+ * Optional env vars (override crawl_config from DB):
+ *   START_URL       Override the startUrl stored in crawl_config
+ *   MAX_DEPTH       Override maxDepth (default 3)
+ *   MAX_PAGES       Override maxPages (default 200)
+ *   INCLUDE_PATTERN Regex string for URL inclusion filter
+ */
+
+import { sha256, chunkPlain, embedAll, upsertDocumentAndChunks, bumpCollectionStats } from './lib-knowledge-pg.mjs';
+import { load as cheerioLoad } from 'cheerio';
+import robotsParser from 'robots-parser';
+import pg from 'pg';
+
+const { Pool } = pg;
+
+function makePoolFromUrl(pgurl) {
+  const u = new URL(pgurl);
+  return new Pool({
+    host:     u.hostname,
+    port:     Number(u.port || 5432),
+    database: u.pathname.replace(/^\//, ''),
+    user:     u.username,
+    password: decodeURIComponent(u.password),
+  });
+}
+
+const COLLECTION_ID = process.env.COLLECTION_ID;
+if (!COLLECTION_ID) { console.error('COLLECTION_ID is required'); process.exit(1); }
+
+const pgurl = process.env.PGURL;
+if (!pgurl) { console.error('PGURL is required'); process.exit(1); }
+
+const FETCH_TIMEOUT_MS = 10_000;
+const MIN_PAGE_CHARS   = 100;
+const DEFAULT_UA       = 'MentolderKnowledgeBot/1.0 (+https://web.mentolder.de)';
+
+const robotsCache = new Map();
+
+async function getRobots(origin, userAgent) {
+  if (robotsCache.has(origin)) return robotsCache.get(origin);
+  const url = `${origin}/robots.txt`;
+  try {
+    const ctrl = new AbortController();
+    const t = setTimeout(() => ctrl.abort(), FETCH_TIMEOUT_MS);
+    const res = await fetch(url, { signal: ctrl.signal, headers: { 'User-Agent': userAgent } });
+    clearTimeout(t);
+    const text = res.ok ? await res.text() : '';
+    const r = robotsParser(url, text);
+    robotsCache.set(origin, r);
+    return r;
+  } catch {
+    const r = robotsParser(url, '');
+    robotsCache.set(origin, r);
+    return r;
+  }
+}
+
+async function isAllowed(urlStr, userAgent) {
+  try {
+    const u = new URL(urlStr);
+    const robots = await getRobots(u.origin, userAgent);
+    return robots.isAllowed(urlStr, userAgent) !== false;
+  } catch {
+    return false;
+  }
+}
+
+async function fetchSitemapUrls(origin, userAgent) {
+  const candidates = [`${origin}/sitemap.xml`, `${origin}/sitemap_index.xml`];
+  const urls = new Set();
+  for (const sitemapUrl of candidates) {
+    try {
+      const ctrl = new AbortController();
+      const t = setTimeout(() => ctrl.abort(), FETCH_TIMEOUT_MS);
+      const res = await fetch(sitemapUrl, { signal: ctrl.signal, headers: { 'User-Agent': userAgent } });
+      clearTimeout(t);
+      if (!res.ok) continue;
+      const text = await res.text();
+      const locRe = /<loc>\s*(https?:\/\/[^\s<]+)\s*<\/loc>/gi;
+      let m;
+      while ((m = locRe.exec(text)) !== null) {
+        urls.add(m[1].trim());
+      }
+      if (urls.size > 0) break;
+    } catch {
+      // Sitemap unavailable — fall through to link crawl
+    }
+  }
+  return [...urls];
+}
+
+function extractContent($) {
+  $('nav, header, footer, script, style, noscript, [aria-hidden="true"], .sr-only').remove();
+  const main = $('main, article, [role="main"], #content, .content').first();
+  const text = (main.length ? main : $('body')).text();
+  return text.replace(/\s+/g, ' ').trim();
+}
+
+function extractLinks($, baseUrl, includeOrigin) {
+  const links = [];
+  $('a[href]').each((_, el) => {
+    try {
+      const href = $(el).attr('href');
+      const resolved = new URL(href, baseUrl).href;
+      const clean = new URL(resolved);
+      clean.hash = '';
+      if (clean.origin === includeOrigin) {
+        links.push(clean.href);
+      }
+    } catch {
+      // Relative URL resolution failed — skip
+    }
+  });
+  return links;
+}
+
+async function crawl({ startUrl, maxDepth, maxPages, includePattern, userAgent }) {
+  const ua = userAgent || DEFAULT_UA;
+  const origin = new URL(startUrl).origin;
+  const includeRe = includePattern ? new RegExp(includePattern) : null;
+
+  const visited  = new Set();
+  const queue    = [{ url: startUrl, depth: 0 }];
+  const results  = [];
+
+  console.log('Fetching sitemap…');
+  const sitemapUrls = await fetchSitemapUrls(origin, ua);
+  if (sitemapUrls.length > 0) {
+    console.log(`  Sitemap: ${sitemapUrls.length} URLs found — using sitemap mode`);
+    for (const u of sitemapUrls.slice(0, maxPages * 2)) {
+      if (!visited.has(u)) queue.push({ url: u, depth: 1 });
+    }
+  } else {
+    console.log('  No sitemap found — falling back to link crawl');
+  }
+
+  while (queue.length > 0 && results.length < maxPages) {
+    const { url, depth } = queue.shift();
+    if (visited.has(url)) continue;
+    visited.add(url);
+
+    if (includeRe && !includeRe.test(url)) continue;
+
+    if (!(await isAllowed(url, ua))) {
+      console.log(`  [robots] Skip ${url}`);
+      continue;
+    }
+
+    let html;
+    try {
+      const ctrl = new AbortController();
+      const t = setTimeout(() => ctrl.abort(), FETCH_TIMEOUT_MS);
+      const res = await fetch(url, {
+        signal: ctrl.signal,
+        headers: { 'User-Agent': ua, 'Accept': 'text/html' },
+        redirect: 'follow',
+      });
+      clearTimeout(t);
+      if (!res.ok) continue;
+      const ct = res.headers.get('content-type') ?? '';
+      if (!ct.includes('text/html')) continue;
+      html = await res.text();
+    } catch (err) {
+      console.log(`  [fetch error] ${url}: ${err.message}`);
+      continue;
+    }
+
+    const $ = cheerioLoad(html);
+    const title = $('title').text().trim() || $('h1').first().text().trim() || url;
+    const text  = extractContent($);
+
+    if (text.length < MIN_PAGE_CHARS) {
+      console.log(`  [skip short] ${url} (${text.length} chars)`);
+      continue;
+    }
+
+    results.push({ url, title, text });
+    process.stdout.write('.');
+
+    if (depth < maxDepth && sitemapUrls.length === 0) {
+      for (const link of extractLinks($, url, origin)) {
+        if (!visited.has(link)) {
+          queue.push({ url: link, depth: depth + 1 });
+        }
+      }
+    }
+  }
+
+  console.log(`\nCrawled ${results.length} pages (${visited.size} visited).`);
+  return results;
+}
+
+async function main() {
+  const pool = makePoolFromUrl(pgurl);
+
+  try {
+    const colRes = await pool.query(
+      `SELECT name, crawl_config FROM knowledge.collections WHERE id = $1`,
+      [COLLECTION_ID],
+    );
+    if (colRes.rows.length === 0) {
+      console.error(`Collection ${COLLECTION_ID} not found`);
+      process.exit(1);
+    }
+    const { name: colName, crawl_config } = colRes.rows[0];
+    const cfg = crawl_config ?? {};
+
+    const startUrl       = process.env.START_URL    || cfg.startUrl;
+    const maxDepth       = Number(process.env.MAX_DEPTH   || cfg.maxDepth  || 3);
+    const maxPages       = Number(process.env.MAX_PAGES   || cfg.maxPages  || 200);
+    const includePattern = process.env.INCLUDE_PATTERN    || cfg.includePattern || null;
+    const userAgent      = cfg.userAgent || DEFAULT_UA;
+
+    if (!startUrl) {
+      console.error('No startUrl configured. Set crawl_config.startUrl in the collection or pass START_URL env var.');
+      process.exit(1);
+    }
+
+    console.log(`Crawling "${colName}" (id=${COLLECTION_ID})`);
+    console.log(`  startUrl:       ${startUrl}`);
+    console.log(`  maxDepth:       ${maxDepth}`);
+    console.log(`  maxPages:       ${maxPages}`);
+    console.log(`  includePattern: ${includePattern ?? '(none)'}`);
+
+    const pages = await crawl({ startUrl, maxDepth, maxPages, includePattern, userAgent });
+
+    if (pages.length === 0) {
+      console.error('ERROR: 0 pages crawled — aborting without touching the collection.');
+      process.exit(1);
+    }
+
+    console.log(`Embedding ${pages.length} pages…`);
+    for (const page of pages) {
+      const rawChunks = chunkPlain(page.text);
+      const embeddings = await embedAll(rawChunks.map(c => c.text));
+      const chunks = rawChunks.map((c, i) => ({ ...c, embedding: embeddings[i] }));
+
+      await upsertDocumentAndChunks(pool, {
+        collectionId: COLLECTION_ID,
+        title:        page.title,
+        sourceUri:    page.url,
+        rawText:      page.text,
+        hash:         sha256(page.text),
+        metadata:     { url: page.url },
+        chunks,
+      });
+      process.stdout.write('+');
+    }
+
+    console.log('\nBumping collection stats…');
+    await bumpCollectionStats(pool, COLLECTION_ID);
+    console.log('Done.');
+  } finally {
+    await pool.end();
+  }
+}
+
+main().catch(err => { console.error(err); process.exit(1); });

--- a/scripts/knowledge/package-lock.json
+++ b/scripts/knowledge/package-lock.json
@@ -1,0 +1,467 @@
+{
+  "name": "knowledge-scripts",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "knowledge-scripts",
+      "dependencies": {
+        "cheerio": "^1.0.0",
+        "pg": "^8.11.0",
+        "robots-parser": "^3.0.1"
+      }
+    },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "license": "ISC"
+    },
+    "node_modules/cheerio": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.2.0.tgz",
+      "integrity": "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==",
+      "license": "MIT",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "encoding-sniffer": "^0.2.1",
+        "htmlparser2": "^10.1.0",
+        "parse5": "^7.3.0",
+        "parse5-htmlparser2-tree-adapter": "^7.1.0",
+        "parse5-parser-stream": "^7.1.2",
+        "undici": "^7.19.0",
+        "whatwg-mimetype": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.1"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/cheerio-select": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-select": "^5.1.0",
+        "css-what": "^6.1.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/encoding-sniffer": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
+      "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "whatwg-encoding": "^3.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
+      "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-parser-stream": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/pg": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.21.0.tgz",
+      "integrity": "sha512-AUP1EYJuHraQGsVoCQVIcM7TEJVGtDzxWtGFZd8rds9d+CCXlU5Js1rYgfLNvxy9iJrpHjGrRjoi/3BT9fRyiA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.13.0",
+        "pg-pool": "^3.14.0",
+        "pg-protocol": "^1.14.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.4.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
+      "integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.13.0.tgz",
+      "integrity": "sha512-EMnU9E2fSULdsbErBbMaXJvFeD9B4+nPcM3f+4lsiCR0BHLPrLVjv3DbyM2hgQQviKJaTWIRRTjKjWlHg3p2ig==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.14.0.tgz",
+      "integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.14.0.tgz",
+      "integrity": "sha512-n5taZ1kO3s9ngDTVxsEznOqCyToTgz0FLuPq0B33COy5pPpuWJpY3/2oRBVETuOgzdqRXfWpM9HIhp2LBBT1BA==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/robots-parser": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/robots-parser/-/robots-parser-3.0.1.tgz",
+      "integrity": "sha512-s+pyvQeIKIZ0dx5iJiQk1tPLJAWln39+MI5jtM8wnyws+G5azk+dMnMX0qfbqNetKKNgcWWOdi0sfm+FbQbgdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    }
+  }
+}

--- a/scripts/knowledge/package.json
+++ b/scripts/knowledge/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "knowledge-scripts",
+  "type": "module",
+  "private": true,
+  "dependencies": {
+    "cheerio": "^1.0.0",
+    "pg": "^8.11.0",
+    "robots-parser": "^3.0.1"
+  }
+}

--- a/scripts/one-shot/20260518-web-crawl-source.sql
+++ b/scripts/one-shot/20260518-web-crawl-source.sql
@@ -1,0 +1,18 @@
+-- scripts/one-shot/20260518-web-crawl-source.sql
+-- Adds web_crawl as a valid source and crawl_config JSONB column to knowledge.collections.
+-- Run on BOTH clusters after deploy:
+--   task workspace:psql ENV=mentolder -- website < scripts/one-shot/20260518-web-crawl-source.sql
+--   task workspace:psql ENV=korczewski -- website < scripts/one-shot/20260518-web-crawl-source.sql
+
+-- Drop the old CHECK constraint (name matches what PostgreSQL auto-generated).
+ALTER TABLE knowledge.collections
+  DROP CONSTRAINT IF EXISTS collections_source_check;
+
+-- Re-add with web_crawl included.
+ALTER TABLE knowledge.collections
+  ADD CONSTRAINT collections_source_check
+    CHECK (source IN ('pr_history','specs_plans','claude_md','bug_tickets','custom','web_crawl'));
+
+-- Add crawl_config column (idempotent).
+ALTER TABLE knowledge.collections
+  ADD COLUMN IF NOT EXISTS crawl_config JSONB;

--- a/website/Dockerfile
+++ b/website/Dockerfile
@@ -34,6 +34,10 @@ COPY --from=build /app/src/assets ./src/assets
 COPY --chown=node:node tests ./tests
 RUN chmod +x tests/runner.sh tests/lib/*.sh tests/local/*.sh 2>/dev/null || true
 
+# Include knowledge crawler scripts for the web-crawl API route
+COPY scripts/knowledge/ /app/scripts/knowledge/
+RUN cd /app/scripts/knowledge && npm install --production 2>/dev/null || true
+
 ENV HOST=0.0.0.0
 ENV PORT=4321
 EXPOSE 4321

--- a/website/src/components/admin/WebCrawlSourceModal.svelte
+++ b/website/src/components/admin/WebCrawlSourceModal.svelte
@@ -1,0 +1,156 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+
+  let {
+    onCreated,
+  }: {
+    onCreated?: (id: string) => void;
+  } = $props();
+
+  let open        = $state(false);
+  let name        = $state('');
+  let description = $state('');
+  let brand: 'mentolder' | 'korczewski' | 'beide' = $state('beide');
+  let startUrl    = $state('');
+  let maxDepth    = $state(3);
+  let maxPages    = $state(200);
+  let includePattern = $state('');
+  let busy        = $state(false);
+  let error       = $state<string | null>(null);
+  let info        = $state<string | null>(null);
+
+  function openModal() {
+    open = true;
+    error = null;
+    info = null;
+    name = '';
+    description = '';
+    brand = 'beide';
+    startUrl = '';
+    maxDepth = 3;
+    maxPages = 200;
+    includePattern = '';
+  }
+
+  function closeModal() {
+    if (busy) return;
+    open = false;
+  }
+
+  const canSubmit = $derived(
+    !busy && !!name.trim() && !!startUrl.trim(),
+  );
+
+  async function submit() {
+    busy = true; error = null; info = null;
+    try {
+      let parsedUrl: URL;
+      try { parsedUrl = new URL(startUrl.trim()); } catch {
+        error = 'Bitte eine gültige URL eingeben (z.B. https://example.com).';
+        return;
+      }
+      if (parsedUrl.protocol !== 'https:' && parsedUrl.protocol !== 'http:') {
+        error = 'Nur http:// und https:// URLs sind erlaubt.';
+        return;
+      }
+
+      const crawlConfig = {
+        startUrl:       parsedUrl.href,
+        maxDepth:       Number(maxDepth) || 3,
+        maxPages:       Number(maxPages) || 200,
+        includePattern: includePattern.trim() || undefined,
+      };
+
+      const colRes = await fetch('/api/admin/knowledge/collections', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name:        name.trim(),
+          description: description.trim() || undefined,
+          brand:       brand === 'beide' ? null : brand,
+          source:      'web_crawl',
+          crawlConfig,
+        }),
+      });
+
+      if (!colRes.ok) {
+        error = (await colRes.json()).error ?? 'Fehler beim Anlegen';
+        return;
+      }
+
+      const col = await colRes.json();
+      info = `Sammlung "${col.name}" angelegt. Crawl kann jetzt in der Tabelle gestartet werden.`;
+      onCreated?.(col.id);
+    } finally {
+      busy = false;
+    }
+  }
+
+  onMount(() => {
+    const handler = () => openModal();
+    window.addEventListener('open-web-crawl-modal', handler);
+    return () => window.removeEventListener('open-web-crawl-modal', handler);
+  });
+</script>
+
+{#if open}
+<!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
+<div class="modal-bg" onclick={closeModal}>
+  <div class="modal" onclick={(e: MouseEvent) => e.stopPropagation()}>
+    <h3>Neue Web-Quelle</h3>
+    {#if error}<p class="err">{error}</p>{/if}
+    {#if info}<p class="info">{info}</p>{/if}
+
+    <label>Name<input bind:value={name} required placeholder="z.B. Firma Website" /></label>
+    <label>Beschreibung<textarea bind:value={description} rows="2"></textarea></label>
+    <label>Marke
+      <select bind:value={brand}>
+        <option value="beide">beide</option>
+        <option value="mentolder">mentolder</option>
+        <option value="korczewski">korczewski</option>
+      </select>
+    </label>
+
+    <label>Start-URL (Pflichtfeld)
+      <input bind:value={startUrl} required type="url"
+             placeholder="https://example.com" />
+    </label>
+
+    <div class="row">
+      <label>Max. Tiefe
+        <input bind:value={maxDepth} type="number" min="1" max="10" />
+      </label>
+      <label>Max. Seiten
+        <input bind:value={maxPages} type="number" min="1" max="5000" />
+      </label>
+    </div>
+
+    <label>URL-Filter (Regex, optional)
+      <input bind:value={includePattern} type="text"
+             placeholder="z.B. /blog/ oder https://example.com/docs/.*" />
+      <span class="hint">Nur URLs die diesem Muster entsprechen werden gecrawlt.</span>
+    </label>
+
+    <div class="actions">
+      <button onclick={closeModal} disabled={busy}>{info ? 'Schließen' : 'Abbrechen'}</button>
+      <button onclick={submit} disabled={!canSubmit}>{busy ? '…' : 'Anlegen'}</button>
+    </div>
+  </div>
+</div>
+{/if}
+
+<style>
+  .modal-bg { position: fixed; inset: 0; background: rgba(0,0,0,0.6); display: flex; align-items: center; justify-content: center; z-index: 50; }
+  .modal { background: var(--ink-800); border: 1px solid var(--ink-750); padding: 1.25rem; border-radius: 10px; min-width: 480px; max-width: 600px; display: flex; flex-direction: column; gap: 0.6rem; color: var(--fg); }
+  h3 { margin: 0; font-size: 1rem; font-weight: 700; }
+  label { display: flex; flex-direction: column; gap: 0.25rem; font-size: 12px; color: var(--fg-soft); text-transform: uppercase; letter-spacing: 0.04em; }
+  input, textarea, select { background: var(--ink-900); border: 1px solid var(--ink-750); color: var(--fg); border-radius: 6px; padding: 0.5rem; font-family: inherit; font-size: 13px; }
+  .row { display: grid; grid-template-columns: 1fr 1fr; gap: 0.6rem; }
+  .actions { display: flex; justify-content: flex-end; gap: 0.5rem; margin-top: 0.5rem; }
+  button { background: var(--brass); color: var(--ink-900); border: none; padding: 0.55rem 1rem; border-radius: 6px; font-weight: 600; cursor: pointer; }
+  .actions button:first-of-type { background: transparent; color: var(--fg); border: 1px solid var(--ink-750); }
+  button:disabled { opacity: 0.5; cursor: not-allowed; }
+  .err  { color: #c96e6e; margin: 0; font-size: 13px; }
+  .info { color: var(--brass); background: rgba(201,165,92,0.08); border: 1px solid rgba(201,165,92,0.3); border-radius: 6px; padding: 0.5rem 0.75rem; font-size: 12px; margin: 0; }
+  .hint { color: var(--fg-soft); font-size: 11px; text-transform: none; letter-spacing: 0; font-weight: 400; }
+</style>

--- a/website/src/lib/knowledge-db.ts
+++ b/website/src/lib/knowledge-db.ts
@@ -32,7 +32,15 @@ function p(): Pool {
 
 export function __setPoolForTests(testPool: Pool): void { _pool = testPool; }
 
-export type CollectionSource = 'pr_history' | 'specs_plans' | 'claude_md' | 'bug_tickets' | 'custom';
+export type CollectionSource = 'pr_history' | 'specs_plans' | 'claude_md' | 'bug_tickets' | 'custom' | 'web_crawl';
+
+export interface CrawlConfig {
+  startUrl: string;
+  maxDepth?: number;
+  maxPages?: number;
+  includePattern?: string;
+  userAgent?: string;
+}
 
 export interface Collection {
   id: string;
@@ -44,6 +52,7 @@ export interface Collection {
   last_indexed_at: Date | null;
   embedding_model: string;
   created_at: Date;
+  crawl_config: CrawlConfig | null;
 }
 
 export interface Document {
@@ -60,7 +69,7 @@ export interface ChunkInput { position: number; text: string; embedding: number[
 export async function listCollections(): Promise<Collection[]> {
   const r = await p().query(
     `SELECT id, name, description, source, brand, chunk_count,
-            last_indexed_at, embedding_model, created_at
+            last_indexed_at, embedding_model, created_at, crawl_config
        FROM knowledge.collections
       ORDER BY source, name`,
   );
@@ -70,7 +79,7 @@ export async function listCollections(): Promise<Collection[]> {
 export async function getCollection(id: string): Promise<Collection | null> {
   const r = await p().query(
     `SELECT id, name, description, source, brand, chunk_count,
-            last_indexed_at, embedding_model, created_at
+            last_indexed_at, embedding_model, created_at, crawl_config
        FROM knowledge.collections WHERE id = $1`,
     [id],
   );
@@ -79,16 +88,20 @@ export async function getCollection(id: string): Promise<Collection | null> {
 
 export async function createCollection(args: {
   name: string; source: CollectionSource; description?: string; brand?: string | null;
-  createdBy?: string | null; embeddingModel?: EmbeddingModel;
+  createdBy?: string | null; embeddingModel?: EmbeddingModel; crawlConfig?: CrawlConfig | null;
 }): Promise<Collection> {
   const model: EmbeddingModel = args.embeddingModel
     ?? (process.env.LLM_ENABLED === 'true' ? 'bge-m3' : 'voyage-multilingual-2');
   const r = await p().query(
-    `INSERT INTO knowledge.collections (name, source, description, brand, created_by, embedding_model)
-     VALUES ($1, $2, $3, $4, $5, $6)
+    `INSERT INTO knowledge.collections (name, source, description, brand, created_by, embedding_model, crawl_config)
+     VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb)
      RETURNING id, name, description, source, brand, chunk_count,
-               last_indexed_at, embedding_model, created_at`,
-    [args.name, args.source, args.description ?? null, args.brand ?? null, args.createdBy ?? null, model],
+               last_indexed_at, embedding_model, created_at, crawl_config`,
+    [
+      args.name, args.source, args.description ?? null, args.brand ?? null,
+      args.createdBy ?? null, model,
+      args.crawlConfig ? JSON.stringify(args.crawlConfig) : null,
+    ],
   );
   return r.rows[0];
 }
@@ -96,8 +109,17 @@ export async function createCollection(args: {
 export async function deleteCollection(id: string): Promise<void> {
   const c = await getCollection(id);
   if (!c) throw new Error('not_found');
-  if (c.source !== 'custom') throw new Error('cannot delete non-custom collection');
+  if (c.source !== 'custom' && c.source !== 'web_crawl')
+    throw new Error('cannot delete non-custom collection');
   await p().query('DELETE FROM knowledge.collections WHERE id = $1', [id]);
+}
+
+export async function updateCrawlConfig(id: string, config: CrawlConfig): Promise<void> {
+  const result = await p().query(
+    `UPDATE knowledge.collections SET crawl_config = $2::jsonb WHERE id = $1`,
+    [id, JSON.stringify(config)],
+  );
+  if (result.rowCount === 0) throw new Error('not_found');
 }
 
 export async function addDocument(args: {

--- a/website/src/pages/admin/wissensquellen.astro
+++ b/website/src/pages/admin/wissensquellen.astro
@@ -1,6 +1,7 @@
 ---
 import AdminLayout from '../../layouts/AdminLayout.astro';
 import KnowledgeSourceModal from '../../components/admin/KnowledgeSourceModal.svelte';
+import WebCrawlSourceModal from '../../components/admin/WebCrawlSourceModal.svelte';
 import { listCollections } from '../../lib/knowledge-db';
 import { getSession, getLoginUrl, isAdmin } from '../../lib/auth';
 
@@ -15,14 +16,18 @@ try {
   // DB may not have knowledge schema yet in dev — show empty state
 }
 
-const builtins = collections.filter(c => c.source !== 'custom');
-const customs  = collections.filter(c => c.source === 'custom');
+const builtins  = collections.filter(c => c.source !== 'custom' && c.source !== 'web_crawl');
+const customs   = collections.filter(c => c.source === 'custom');
+const webCrawls = collections.filter(c => c.source === 'web_crawl');
 ---
 <AdminLayout title="Wissensquellen">
   <div class="page">
     <header class="page-head">
       <h1>Wissensquellen</h1>
-      <button id="new-btn" class="primary">+ Neue Wissensquelle</button>
+      <div class="head-actions">
+        <button id="new-crawl-btn" class="secondary">+ Web-Quelle</button>
+        <button id="new-btn" class="primary">+ Neue Wissensquelle</button>
+      </div>
     </header>
 
     <h2>Eingebaut</h2>
@@ -47,16 +52,47 @@ const customs  = collections.filter(c => c.source === 'custom');
       )
     }
 
+    <h2>Web-Quellen</h2>
+    {webCrawls.length === 0
+      ? <p class="muted">Noch keine Web-Quellen angelegt.</p>
+      : (
+        <table class="table">
+          <thead><tr><th>Name</th><th>Start-URL</th><th>Marke</th><th>Chunks</th><th>Letzter Crawl</th><th></th></tr></thead>
+          <tbody>
+            {webCrawls.map(c => (
+              <tr>
+                <td>{c.name}</td>
+                <td class="url-cell">
+                  {c.crawl_config?.startUrl
+                    ? <a href={c.crawl_config.startUrl} target="_blank" rel="noopener">{c.crawl_config.startUrl}</a>
+                    : <span class="muted">—</span>
+                  }
+                </td>
+                <td>{c.brand ?? 'beide'}</td>
+                <td>{c.chunk_count}</td>
+                <td>{c.last_indexed_at ? new Date(c.last_indexed_at).toLocaleString('de-DE') : '—'}</td>
+                <td class="actions-cell">
+                  <button data-crawl={c.id} class="action">Crawl starten</button>
+                  <button data-delete={c.id} class="danger">Löschen</button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )
+    }
+
     <h2>Eigene Sammlungen</h2>
     {customs.length === 0
       ? <p class="muted">Noch keine eigenen Sammlungen.</p>
       : (
         <table class="table">
-          <thead><tr><th>Name</th><th>Marke</th><th>Chunks</th><th>Erstellt</th><th></th></tr></thead>
+          <thead><tr><th>Name</th><th>Typ</th><th>Marke</th><th>Chunks</th><th>Erstellt</th><th></th></tr></thead>
           <tbody>
             {customs.map(c => (
               <tr>
                 <td>{c.name}</td>
+                <td><code>custom</code></td>
                 <td>{c.brand ?? 'beide'}</td>
                 <td>{c.chunk_count}</td>
                 <td>{new Date(c.created_at).toLocaleDateString('de-DE')}</td>
@@ -69,12 +105,17 @@ const customs  = collections.filter(c => c.source === 'custom');
     }
 
     <KnowledgeSourceModal client:load onCreated={() => location.reload()} />
+    <WebCrawlSourceModal client:load onCreated={() => location.reload()} />
   </div>
 
   <script is:inline>
     document.getElementById('new-btn').addEventListener('click', () => {
       window.dispatchEvent(new CustomEvent('open-wissensquellen-modal'));
     });
+    document.getElementById('new-crawl-btn').addEventListener('click', () => {
+      window.dispatchEvent(new CustomEvent('open-web-crawl-modal'));
+    });
+
     document.querySelectorAll('[data-reindex]').forEach(btn => {
       btn.addEventListener('click', async () => {
         const id = btn.dataset.reindex;
@@ -87,6 +128,29 @@ const customs  = collections.filter(c => c.source === 'custom');
         }
       });
     });
+
+    document.querySelectorAll('[data-crawl]').forEach(btn => {
+      btn.addEventListener('click', async () => {
+        const id = btn.dataset.crawl;
+        btn.disabled = true;
+        btn.textContent = 'Crawling…';
+        try {
+          const r = await fetch(`/api/admin/knowledge/collections/${id}/crawl`, { method: 'POST' });
+          const j = await r.json().catch(() => ({}));
+          if (r.status === 409) {
+            alert('Crawl läuft bereits.');
+          } else if (r.ok) {
+            alert('Crawl gestartet. Die Sammlung wird im Hintergrund aktualisiert.');
+          } else {
+            alert(j.error ?? `Fehler (${r.status})`);
+          }
+        } finally {
+          btn.disabled = false;
+          btn.textContent = 'Crawl starten';
+        }
+      });
+    });
+
     document.querySelectorAll('[data-delete]').forEach(btn => {
       btn.addEventListener('click', async () => {
         if (!confirm('Wirklich löschen?')) return;
@@ -99,16 +163,23 @@ const customs  = collections.filter(c => c.source === 'custom');
   </script>
 
   <style>
-    .page { padding: 2rem 1.5rem; max-width: 960px; }
+    .page { padding: 2rem 1.5rem; max-width: 1000px; }
     .page-head { display: flex; justify-content: space-between; align-items: center; margin-bottom: 1.5rem; }
+    .head-actions { display: flex; gap: 0.5rem; }
     h1 { font-size: 1.75rem; font-weight: 700; color: var(--fg); }
     h2 { font-size: 1rem; font-weight: 600; color: var(--fg-soft); text-transform: uppercase; letter-spacing: 0.06em; margin: 1.5rem 0 0.5rem; }
     .table { width: 100%; border-collapse: collapse; font-size: 13px; margin-bottom: 1.5rem; }
     .table th, .table td { padding: 0.5rem 0.6rem; border-bottom: 1px solid var(--ink-750); text-align: left; color: var(--fg); }
     .table th { color: var(--fg-soft); font-size: 11px; text-transform: uppercase; letter-spacing: 0.04em; }
+    .url-cell { max-width: 280px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 12px; }
+    .url-cell a { color: var(--brass); text-decoration: none; }
+    .url-cell a:hover { text-decoration: underline; }
+    .actions-cell { display: flex; gap: 0.4rem; white-space: nowrap; }
     .primary { background: var(--brass); color: var(--ink-900); border: none; padding: 0.55rem 1rem; border-radius: 6px; font-weight: 600; cursor: pointer; font-size: 13px; }
+    .secondary { background: transparent; color: var(--brass); border: 1px solid var(--brass); padding: 0.55rem 1rem; border-radius: 6px; font-weight: 600; cursor: pointer; font-size: 13px; }
     .action { background: transparent; color: var(--fg-soft); border: 1px solid var(--ink-750); padding: 0.3rem 0.6rem; border-radius: 4px; cursor: pointer; font-size: 12px; }
     .action:hover { color: var(--fg); border-color: var(--fg-soft); }
+    .action:disabled { opacity: 0.5; cursor: not-allowed; }
     .danger { background: transparent; color: #c96e6e; border: 1px solid #c96e6e; padding: 0.3rem 0.6rem; border-radius: 4px; cursor: pointer; font-size: 12px; }
     .muted { color: var(--fg-soft); font-style: italic; font-size: 13px; }
     code { font-family: monospace; font-size: 11px; background: var(--ink-900); padding: 0.1rem 0.3rem; border-radius: 3px; }

--- a/website/src/pages/api/admin/knowledge/collections/[id]/crawl-config.ts
+++ b/website/src/pages/api/admin/knowledge/collections/[id]/crawl-config.ts
@@ -1,0 +1,47 @@
+import type { APIRoute } from 'astro';
+import { getSession, isAdmin } from '../../../../../../lib/auth';
+import { getCollection, updateCrawlConfig, type CrawlConfig } from '../../../../../../lib/knowledge-db';
+
+export const PATCH: APIRoute = async ({ request, params }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) return new Response('Unauthorized', { status: 401 });
+
+  const id = params.id!;
+  const c = await getCollection(id);
+  if (!c) return new Response(JSON.stringify({ error: 'not_found' }), { status: 404 });
+  if (c.source !== 'web_crawl') {
+    return new Response(
+      JSON.stringify({ error: 'crawl_config ist nur für web_crawl-Sammlungen relevant' }),
+      { status: 400 },
+    );
+  }
+
+  const body = await request.json() as Partial<CrawlConfig>;
+
+  if (!body.startUrl?.trim()) {
+    return new Response(JSON.stringify({ error: 'startUrl erforderlich' }), { status: 400 });
+  }
+
+  try { new URL(body.startUrl); } catch {
+    return new Response(JSON.stringify({ error: 'startUrl ist keine gültige URL' }), { status: 400 });
+  }
+
+  const config: CrawlConfig = {
+    startUrl:       body.startUrl.trim(),
+    maxDepth:       body.maxDepth   ?? c.crawl_config?.maxDepth   ?? 3,
+    maxPages:       body.maxPages   ?? c.crawl_config?.maxPages   ?? 200,
+    includePattern: body.includePattern ?? c.crawl_config?.includePattern ?? undefined,
+    userAgent:      body.userAgent  ?? c.crawl_config?.userAgent  ?? undefined,
+  };
+
+  try {
+    await updateCrawlConfig(id, config);
+    return new Response(JSON.stringify({ ok: true, crawl_config: config }), {
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (err: unknown) {
+    if (err instanceof Error && err.message === 'not_found')
+      return new Response(JSON.stringify({ error: 'not_found' }), { status: 404 });
+    throw err;
+  }
+};

--- a/website/src/pages/api/admin/knowledge/collections/[id]/crawl.ts
+++ b/website/src/pages/api/admin/knowledge/collections/[id]/crawl.ts
@@ -1,0 +1,82 @@
+import type { APIRoute } from 'astro';
+import { spawn } from 'node:child_process';
+import { resolve } from 'node:path';
+import { getSession, isAdmin } from '../../../../../../lib/auth';
+import { getCollection } from '../../../../../../lib/knowledge-db';
+
+// Module-level set: tracks collection IDs currently being crawled.
+// Cleared when the spawned process exits.
+const activeCrawls = new Set<string>();
+
+export const POST: APIRoute = async ({ request, params }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) return new Response('Unauthorized', { status: 401 });
+
+  const id = params.id!;
+
+  const c = await getCollection(id);
+  if (!c) return new Response(JSON.stringify({ error: 'not_found' }), { status: 404 });
+  if (c.source !== 'web_crawl') {
+    return new Response(
+      JSON.stringify({ error: 'Nur web_crawl-Sammlungen können gecrawlt werden' }),
+      { status: 400 },
+    );
+  }
+  if (!c.crawl_config?.startUrl) {
+    return new Response(
+      JSON.stringify({ error: 'Keine startUrl konfiguriert. Bitte erst Crawl-Konfiguration speichern.' }),
+      { status: 422 },
+    );
+  }
+
+  if (activeCrawls.has(id)) {
+    return new Response(
+      JSON.stringify({ error: 'Crawl läuft bereits für diese Sammlung' }),
+      { status: 409 },
+    );
+  }
+
+  const repoRoot   = process.env.REPO_ROOT ?? resolve(new URL(import.meta.url).pathname, '../../../../../../../../../');
+  const scriptPath = resolve(repoRoot, 'scripts/knowledge/ingest-web.mjs');
+
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    COLLECTION_ID: id,
+    PGURL: process.env.SESSIONS_DATABASE_URL
+        ?? 'postgresql://website:devwebsitedb@shared-db.workspace.svc.cluster.local:5432/website',
+  };
+
+  activeCrawls.add(id);
+  const child = spawn('node', [scriptPath], {
+    env,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    detached: false,
+  });
+
+  child.stdout.on('data', (d: Buffer) => process.stdout.write(`[crawl:${id.slice(0,8)}] ${d}`));
+  child.stderr.on('data', (d: Buffer) => process.stderr.write(`[crawl:${id.slice(0,8)}] ${d}`));
+
+  child.on('close', (code: number | null) => {
+    activeCrawls.delete(id);
+    if (code !== 0) {
+      console.error(`[crawl] ${id} exited with code ${code}`);
+    } else {
+      console.log(`[crawl] ${id} completed successfully`);
+    }
+  });
+
+  return new Response(
+    JSON.stringify({ message: 'Crawl gestartet', collectionId: id }),
+    { status: 202, headers: { 'Content-Type': 'application/json' } },
+  );
+};
+
+export const GET: APIRoute = async ({ request, params }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) return new Response('Unauthorized', { status: 401 });
+  const id = params.id!;
+  return new Response(
+    JSON.stringify({ running: activeCrawls.has(id) }),
+    { headers: { 'Content-Type': 'application/json' } },
+  );
+};

--- a/website/src/pages/api/admin/knowledge/collections/[id]/index.ts
+++ b/website/src/pages/api/admin/knowledge/collections/[id]/index.ts
@@ -17,7 +17,7 @@ export const DELETE: APIRoute = async ({ request, params }) => {
     await deleteCollection(params.id!);
     return new Response(null, { status: 204 });
   } catch (err: unknown) {
-    if (err instanceof Error && /custom/i.test(err.message))
+    if (err instanceof Error && err.message.startsWith('cannot delete'))
       return new Response(JSON.stringify({ error: err.message }), { status: 403 });
     if (err instanceof Error && err.message === 'not_found')
       return new Response(JSON.stringify({ error: err.message }), { status: 404 });

--- a/website/src/pages/api/admin/knowledge/collections/index.ts
+++ b/website/src/pages/api/admin/knowledge/collections/index.ts
@@ -1,6 +1,6 @@
 import type { APIRoute } from 'astro';
 import { getSession, isAdmin } from '../../../../../lib/auth';
-import { createCollection, listCollections } from '../../../../../lib/knowledge-db';
+import { createCollection, listCollections, type CrawlConfig } from '../../../../../lib/knowledge-db';
 
 export const GET: APIRoute = async ({ request }) => {
   const session = await getSession(request.headers.get('cookie'));
@@ -12,16 +12,43 @@ export const GET: APIRoute = async ({ request }) => {
 export const POST: APIRoute = async ({ request }) => {
   const session = await getSession(request.headers.get('cookie'));
   if (!session || !isAdmin(session)) return new Response('Unauthorized', { status: 401 });
-  const body = await request.json() as { name?: string; description?: string; brand?: string | null; };
+
+  const body = await request.json() as {
+    name?: string;
+    description?: string;
+    brand?: string | null;
+    source?: string;
+    crawlConfig?: CrawlConfig;
+  };
+
   if (!body.name?.trim()) {
     return new Response(JSON.stringify({ error: 'name erforderlich' }), { status: 400 });
   }
+
+  const source = body.source === 'web_crawl' ? 'web_crawl' : 'custom';
+
+  if (source === 'web_crawl') {
+    if (!body.crawlConfig?.startUrl?.trim()) {
+      return new Response(
+        JSON.stringify({ error: 'crawlConfig.startUrl erforderlich für web_crawl' }),
+        { status: 400 },
+      );
+    }
+    try { new URL(body.crawlConfig.startUrl); } catch {
+      return new Response(
+        JSON.stringify({ error: 'crawlConfig.startUrl ist keine gültige URL' }),
+        { status: 400 },
+      );
+    }
+  }
+
   try {
     const c = await createCollection({
-      name: body.name.trim(),
-      source: 'custom',
+      name:        body.name.trim(),
+      source,
       description: body.description?.trim(),
-      brand: body.brand ?? null,
+      brand:       body.brand ?? null,
+      crawlConfig: source === 'web_crawl' ? (body.crawlConfig ?? null) : null,
     });
     return new Response(JSON.stringify(c), { status: 201, headers: { 'Content-Type': 'application/json' } });
   } catch (err: unknown) {


### PR DESCRIPTION
## Summary
- Adds `web_crawl` as a new knowledge collection source — admins point the platform at any URL, click "Crawl starten", and pages appear as queryable knowledge chunks
- One-shot SQL migration adds `web_crawl` to the CHECK constraint and a `crawl_config` JSONB column; same change applied to both `website-schema.yaml` init blocks
- New `scripts/knowledge/ingest-web.mjs` handles sitemap-first/link crawl using cheerio + robots-parser; bundled into the website Docker image via `COPY scripts/knowledge/` + `npm install`

## Test plan
- [x] `task workspace:validate` — manifests valid
- [x] Admin-Menu Gate PASSED (all 5 rules)
- [x] TypeScript errors in changed files: none (pre-existing arena/scripts TS errors unrelated)
- [ ] Post-merge: `task workspace:psql ENV=mentolder -- website < scripts/one-shot/20260518-web-crawl-source.sql` + same for korczewski
- [ ] Manual browser test on `/admin/wissensquellen`: "+ Web-Quelle" modal → anlegen → crawl starten → chunk_count > 0 after background crawl

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>