### PR TITLE
chore(infra): document WSL2 GPU wg-mesh peer in wg-mesh-nodes.yaml [T000460]

### DIFF
--- a/wireguard/wg-mesh-nodes.yaml
+++ b/wireguard/wg-mesh-nodes.yaml
@@ -39,6 +39,18 @@ mentolder:
       schema_key: WG_MESH_GEKKO4
       public_key: "mHjkm8YbesFZfneadLPZ8gHwyobakn1gRc+Cx82rP0Y="
 
+  # GPU host — WSL2 on Windows with LM Studio (RTX 5070 Ti, 16 GB)
+  # Configured in commit 05dbf9a8. The wg-gpu interface on WSL2 uses 192.168.100.10;
+  # iptables DNAT forwards 192.168.100.10:1234 → 10.10.0.3:1234 (Ollama/LM Studio).
+  # Endpoint is dynamic (WSL2 behind Windows NAT) — the host initiates outbound.
+  gpu_hosts:
+    - name: wsl2-gpu-mentolder
+      endpoint: ""        # dynamic NAT port (observed 45.155.142.74:51883, changes on reconnect)
+      wg_ip: "192.168.100.10"
+      schema_key: WG_MESH_WSL2_GPU
+      public_key: "UIe+lddIq+YgFeE4wltrEPXYnwu3hAY1bsUUD2yNBkE="
+      keepalive: 25
+
   # Proxmox home-LAN worker nodes — behind NAT (FritzBox), no fixed public endpoint.
   # Workers initiate outbound to Hetzner; PersistentKeepalive = 25 keeps NAT mapping alive.
   home_workers:


### PR DESCRIPTION
## Summary
- Adds a `gpu_hosts` section to `wireguard/wg-mesh-nodes.yaml` for the WSL2 GPU host (`wsl2-gpu-mentolder`, IP `192.168.100.10`)
- Resolves T000460: the peer was visible on all Hetzner CPs but not documented — it is the LM Studio GPU host from commit 05dbf9a8
- Public key `UIe+lddIq+YgFeE4wltrEPXYnwu3hAY1bsUUD2yNBkE=`, endpoint dynamic (WSL2 behind Windows NAT)

## Test plan
- [ ] `cat wireguard/wg-mesh-nodes.yaml` — verify `gpu_hosts` section present under `mentolder`, no duplicate comments
- [ ] `task workspace:validate` passes (no manifest changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)