### PR TITLE
chore(infra): allow-llm-gateway-egress netpol + korczewski GPU wg-mesh peer

### DIFF
--- a/environments/korczewski.yaml
+++ b/environments/korczewski.yaml
@@ -47,7 +47,7 @@ env_vars:
   KEYCLOAK_FRONTEND_URL: "https://auth.korczewski.de"
   # System-test failure loop master kill-switch (Task 10).
   SYSTEMTEST_LOOP_ENABLED: "true"
-  LLM_HOST_IP: "10.10.0.3"
+  LLM_HOST_IP: "10.13.14.10"
   LLM_ENABLED: "true"
   # flip LLM_RERANK_ENABLED to true after 24h of stable rollout
   LLM_RERANK_ENABLED: "false"

--- a/k3d/network-policies.yaml
+++ b/k3d/network-policies.yaml
@@ -74,6 +74,42 @@ spec:
         - 172.16.0.0/12
         - 192.168.0.0/16
 ---
+# LLM-Gateway-Hosts auf dem wg-mesh erreichen (192.168.100.x mentolder, 10.13.14.x korczewski)
+# allow-internet-egress blockiert RFC1918 — diese Policy öffnet gezielt die wg-mesh-Subnets.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-llm-gateway-egress
+spec:
+  podSelector: {}
+  policyTypes:
+  - Egress
+  egress:
+  - to:
+    - ipBlock:
+        cidr: 192.168.100.0/24
+    ports:
+    - protocol: TCP
+      port: 1234
+    - protocol: TCP
+      port: 8081
+    - protocol: TCP
+      port: 8082
+    - protocol: TCP
+      port: 11434
+  - to:
+    - ipBlock:
+        cidr: 10.13.14.0/24
+    ports:
+    - protocol: TCP
+      port: 1234
+    - protocol: TCP
+      port: 8081
+    - protocol: TCP
+      port: 8082
+    - protocol: TCP
+      port: 11434
+---
 # Pod-zu-Pod-Kommunikation innerhalb des workspace-Namespace (Eingang) erlauben
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/wireguard/wg-mesh-nodes.yaml
+++ b/wireguard/wg-mesh-nodes.yaml
@@ -114,3 +114,14 @@ korczewski:
       wg_ip: "10.13.14.3"
       schema_key: WG_MESH_PK8
       public_key: "kpWJQzw+p8rurkFq/hPQH/z1gl3/f19SFukOMpPBJS0="
+
+  # GPU host — WSL2 on Windows with LM Studio (RTX 5070 Ti, 16 GB)
+  # wg-korczewski interface on WSL2; iptables DNAT forwards 10.13.14.10:1234 → 10.10.0.3:1234 (LM Studio).
+  # Endpoint is dynamic (WSL2 behind Windows NAT) — the host initiates outbound to Hetzner peers.
+  gpu_hosts:
+    - name: wsl2-gpu-korczewski
+      endpoint: ""        # dynamic NAT (initiates outbound)
+      wg_ip: "10.13.14.10"
+      schema_key: WG_MESH_WSL2_GPU_KORCZEWSKI
+      public_key: "BHYLRcy85XSxC2V7pXXmzY4KtfttPHLgWitAM6PdYnY="
+      keepalive: 25


### PR DESCRIPTION
## Summary
- Add `allow-llm-gateway-egress` NetworkPolicy: opens egress to wg-mesh GPU CIDRs (`192.168.100.0/24` mentolder, `10.13.14.0/24` korczewski) on ports 1234/8081/8082/11434 — these were silently blocked by `allow-internet-egress` which excludes all RFC1918 ranges
- Fix `LLM_HOST_IP` in `environments/korczewski.yaml`: was placeholder `10.10.0.3` (Windows LAN IP, unreachable from Hetzner); corrected to `10.13.14.10` (new `wg-korczewski` mesh peer)
- Document korczewski GPU peer in `wireguard/wg-mesh-nodes.yaml` (`wsl2-gpu-korczewski`, `10.13.14.10`, WSL2 behind NAT, `keepalive: 25`)

## Test plan
- [x] `task test:all` — FAIL=0
- [x] mentolder: `kubectl exec deploy/llm-router -- python3 -c "urllib.request.urlopen('http://llm-gateway-lmstudio:1234/v1/models')"` → models listed
- [x] korczewski: same test on `workspace-korczewski` → `['qwen2.5-14b-instruct-uncensored', ...]`
- [x] wg-korczewski systemd service enabled (`sudo systemctl enable wg-quick@wg-korczewski`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)