### PR TITLE
feat(coaching): batch-ingest pipeline with dedup, DOC support, interactive review

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -3156,6 +3156,12 @@ tasks:
     cmds:
       - source scripts/env-resolve.sh "${ENV:-dev}" && cd website && npx tsx ../scripts/coaching/ingest-book.mts {{.CLI_ARGS}}
 
+  coaching:batch-ingest:
+    desc: "Batch-ingest a directory of coaching PDFs/DOCs — Usage: task coaching:batch-ingest -- <dir> <kurs-slug> [--dry-run] [--yes] [--classify]"
+    cmds:
+      - source scripts/env-resolve.sh "{{.ENV | default "mentolder"}}"
+      - cd scripts/coaching && npx tsx batch-ingest-dir.mts {{.CLI_ARGS}}
+
   coaching:classify:
     desc: "Run AI classifier over UNCLASSIFIED chunks of a coaching book. Args: -- --slug=<slug> | --all"
     cmds:

--- a/docs/superpowers/plans/2026-05-18-coaching-batch-ingest.md
+++ b/docs/superpowers/plans/2026-05-18-coaching-batch-ingest.md
@@ -1,4 +1,5 @@
 ---
+ticket_id: T000473
 title: Coaching Batch-Ingest Pipeline Implementation Plan
 domains: []
 status: active

--- a/docs/superpowers/plans/2026-05-18-coaching-batch-ingest.md
+++ b/docs/superpowers/plans/2026-05-18-coaching-batch-ingest.md
@@ -1,0 +1,742 @@
+---
+title: Coaching Batch-Ingest Pipeline Implementation Plan
+domains: []
+status: active
+pr_number: null
+---
+
+# Coaching Batch-Ingest Pipeline Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Batch-ingest-Skript für Coaching-PDF/DOC-Verzeichnisse mit Dedup, interaktiver Review und Dual-Collection-Ingest in pgvector.
+
+**Architecture:** Vier-Phasen-Pipeline in `scripts/coaching/batch-ingest-dir.mts`: Scan+Dedup via SHA256 → Text-Extraktion (PDF+DOC/DOCX) → interaktive Terminal-Review → upsertDocumentAndChunks in Block- und Kurs-Collection. Jede Phase ist eine pure oder fast-pure Funktion, die unabhängig testbar ist.
+
+**Tech Stack:** Node.js (tsx/ESM), `mammoth` (DOC/DOCX), `pdf-parse` (bestehend), `node:readline/promises` (interaktive Review), `pg` (pgvector via bestehende lib-knowledge-pg.mjs).
+
+---
+
+## File Map
+
+| Datei | Aktion | Verantwortung |
+|-------|--------|---------------|
+| `scripts/coaching/package.json` | Ändern | mammoth als Dependency |
+| `scripts/coaching/lib-extract.mjs` | Ändern | DOC/DOCX-Extraktion via mammoth |
+| `scripts/coaching/lib-extract.test.mjs` | Ändern | Test-Fix für .docx + neuer DOC-Test |
+| `scripts/coaching/batch-ingest-dir.mts` | Neu | Hauptskript: Scan, Dedup, Review, Ingest |
+| `scripts/coaching/batch-ingest-dir.test.mts` | Neu | Unit-Tests für scanAndDedup, deriveMetadata |
+| `Taskfile.yml` | Ändern | `coaching:batch-ingest` Task |
+
+---
+
+## Task 1: mammoth-Dependency hinzufügen
+
+**Files:**
+- Modify: `scripts/coaching/package.json`
+
+- [ ] **Schritt 1: mammoth in package.json eintragen**
+
+Datei `scripts/coaching/package.json` — `dependencies`-Block:
+
+```json
+{
+  "name": "bachelorprojekt-coaching-scripts",
+  "private": true,
+  "type": "module",
+  "description": "Coaching ingest pipeline scripts. node_modules is symlinked to ../../website/node_modules to avoid duplicate installs.",
+  "dependencies": {
+    "epub2": "3.0.2",
+    "mammoth": "^1.8.0",
+    "pdf-parse": "^2.4.5"
+  }
+}
+```
+
+- [ ] **Schritt 2: installieren**
+
+```bash
+cd scripts/coaching && npm install
+```
+
+Erwartete Ausgabe: `added N packages` (ohne Fehler).
+
+- [ ] **Schritt 3: Commit**
+
+```bash
+git add scripts/coaching/package.json scripts/coaching/package-lock.json
+git commit -m "chore(coaching): add mammoth for DOC/DOCX extraction"
+```
+
+---
+
+## Task 2: DOC/DOCX-Extraktion in lib-extract.mjs
+
+**Files:**
+- Modify: `scripts/coaching/lib-extract.mjs`
+- Modify: `scripts/coaching/lib-extract.test.mjs`
+
+- [ ] **Schritt 1: Bestehenden Test reparieren (er testet mit .docx — bricht nach Änderung)**
+
+`scripts/coaching/lib-extract.test.mjs` — ersten Test anpassen (`.docx` → `.xyz`):
+
+```js
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { extractText } from './lib-extract.mjs';
+
+test('extractText rejects unknown extension', async () => {
+  await assert.rejects(
+    () => extractText('/tmp/nope.xyz'),
+    /Unsupported extension/,
+  );
+});
+
+test('extractText reads a tiny PDF', async () => {
+  const fixture = process.env.PDF_FIXTURE ?? new URL('./fixtures/sample.pdf', import.meta.url).pathname;
+  try {
+    const { text, pageCount } = await extractText(fixture);
+    assert.ok(text.length > 0, 'should return non-empty text');
+    assert.ok(pageCount >= 1, 'should report page count');
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      console.warn('skipping PDF fixture test — sample.pdf not present');
+      return;
+    }
+    throw err;
+  }
+});
+
+test('extractText reads a DOCX file', async () => {
+  const fixture = process.env.DOCX_FIXTURE ?? new URL('./fixtures/sample.docx', import.meta.url).pathname;
+  try {
+    const { text, pageCount, format } = await extractText(fixture);
+    assert.ok(text.length > 0, 'should return non-empty text');
+    assert.strictEqual(pageCount, null, 'DOC pageCount should be null');
+    assert.strictEqual(format, 'docx');
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      console.warn('skipping DOCX fixture test — sample.docx not present');
+      return;
+    }
+    throw err;
+  }
+});
+```
+
+- [ ] **Schritt 2: Test laufen lassen — erwartet: 1 PASS, 1 PASS/SKIP, 1 FAIL (DOCX not yet implemented)**
+
+```bash
+cd scripts/coaching && node --test lib-extract.test.mjs
+```
+
+Erwartete Ausgabe: `extractText rejects unknown extension` PASS, `extractText reads a DOCX file` FAIL mit `Unsupported extension`.
+
+- [ ] **Schritt 3: extractDoc in lib-extract.mjs implementieren**
+
+`scripts/coaching/lib-extract.mjs` — vollständige neue Version:
+
+```js
+import { readFile } from 'node:fs/promises';
+import { extname } from 'node:path';
+import pdfParse from 'pdf-parse/lib/pdf-parse.js';
+import EPub from 'epub2';
+import mammoth from 'mammoth';
+
+export async function extractText(filePath) {
+  const ext = extname(filePath).toLowerCase();
+  if (ext === '.pdf')  return extractPdf(filePath);
+  if (ext === '.epub') return extractEpub(filePath);
+  if (ext === '.docx') return extractDoc(filePath, 'docx');
+  if (ext === '.doc')  return extractDoc(filePath, 'doc');
+  throw new Error(`Unsupported extension: ${ext}`);
+}
+
+async function extractPdf(filePath) {
+  const buf = await readFile(filePath);
+  const pageMap = [];
+  let cursor = 0;
+  const data = await pdfParse(buf, {
+    pagerender: (pageData) => pageData.getTextContent().then((tc) => {
+      const pageText = tc.items.map((it) => it.str).join(' ');
+      pageMap.push({ page: pageData.pageNumber, charStart: cursor });
+      cursor += pageText.length + 1;
+      return pageText;
+    }),
+  });
+  return { text: data.text, pageCount: data.numpages, pageMap, format: 'pdf' };
+}
+
+async function extractEpub(filePath) {
+  const epub = await EPub.createAsync(filePath);
+  const chapters = [];
+  for (const item of epub.flow) {
+    const html = await new Promise((res, rej) =>
+      epub.getChapter(item.id, (err, txt) => (err ? rej(err) : res(txt))),
+    );
+    const text = stripHtml(html);
+    if (text.trim()) chapters.push(text);
+  }
+  return { text: chapters.join('\n\n'), pageCount: chapters.length, pageMap: null, format: 'epub' };
+}
+
+async function extractDoc(filePath, format) {
+  const result = await mammoth.extractRawText({ path: filePath });
+  if (result.messages.length > 0) {
+    for (const msg of result.messages) {
+      if (msg.type === 'warning') console.warn(`[extract] ${format} warning in ${filePath}: ${msg.message}`);
+    }
+  }
+  return { text: result.value, pageCount: null, pageMap: null, format };
+}
+
+function stripHtml(html) {
+  return html
+    .replace(/<style[\s\S]*?<\/style>/gi, '')
+    .replace(/<script[\s\S]*?<\/script>/gi, '')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+```
+
+- [ ] **Schritt 4: Tests laufen lassen — alle PASS (DOCX-Test SKIP wenn kein Fixture)**
+
+```bash
+cd scripts/coaching && node --test lib-extract.test.mjs
+```
+
+Erwartete Ausgabe: alle Tests PASS oder SKIP.
+
+- [ ] **Schritt 5: Commit**
+
+```bash
+git add scripts/coaching/lib-extract.mjs scripts/coaching/lib-extract.test.mjs
+git commit -m "feat(coaching): add DOC/DOCX extraction via mammoth"
+```
+
+---
+
+## Task 3: scanAndDedup + deriveMetadata mit Tests
+
+**Files:**
+- Create: `scripts/coaching/batch-ingest-dir.mts`
+- Create: `scripts/coaching/batch-ingest-dir.test.mts`
+
+- [ ] **Schritt 1: Tests schreiben (failing)**
+
+`scripts/coaching/batch-ingest-dir.test.mts`:
+
+```ts
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { writeFile, mkdir, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { scanAndDedup, deriveMetadata } from './batch-ingest-dir.mts';
+
+// ── deriveMetadata ────────────────────────────────────────────────────────────
+
+test('deriveMetadata: file in blockN subdir', () => {
+  const m = deriveMetadata('/input/ki/block3/some-file.pdf', '/input/ki', 'co2-2023');
+  assert.strictEqual(m.blockSlug, 'block3');
+  assert.strictEqual(m.blockCollection, 'coaching-co2-2023-block3');
+  assert.strictEqual(m.courseCollection, 'coaching-co2-2023');
+});
+
+test('deriveMetadata: file in root dir (no block)', () => {
+  const m = deriveMetadata('/input/ki/overview.pdf', '/input/ki', 'co2-2023');
+  assert.strictEqual(m.blockSlug, null);
+  assert.strictEqual(m.blockCollection, null);
+  assert.strictEqual(m.courseCollection, 'coaching-co2-2023');
+});
+
+test('deriveMetadata: nested deeper than block', () => {
+  const m = deriveMetadata('/input/ki2/block1/sub/file.pdf', '/input/ki2', 'grundkurs-lg29');
+  assert.strictEqual(m.blockSlug, 'block1');
+  assert.strictEqual(m.blockCollection, 'coaching-grundkurs-lg29-block1');
+});
+
+// ── scanAndDedup ──────────────────────────────────────────────────────────────
+
+test('scanAndDedup: deduplicates identical content, prefers clean name', async () => {
+  const dir = join(tmpdir(), `dedup-test-${Date.now()}`);
+  await mkdir(dir);
+  try {
+    await writeFile(join(dir, 'clean.pdf'), 'same content');
+    await writeFile(join(dir, 'clean_abcdef1234567890abcdef1234567890.pdf'), 'same content');
+    await writeFile(join(dir, 'unique.pdf'), 'different content');
+
+    const results = await scanAndDedup(dir);
+    assert.strictEqual(results.length, 2, 'should have 2 unique files');
+    const names = results.map((r) => r.filename);
+    assert.ok(names.includes('clean.pdf'), 'should keep clean name');
+    assert.ok(!names.includes('clean_abcdef1234567890abcdef1234567890.pdf'), 'should drop hash-suffix duplicate');
+    assert.ok(names.includes('unique.pdf'), 'should keep unique file');
+  } finally {
+    await rm(dir, { recursive: true });
+  }
+});
+
+test('scanAndDedup: skips images and .mm files', async () => {
+  const dir = join(tmpdir(), `skip-test-${Date.now()}`);
+  await mkdir(dir);
+  try {
+    await writeFile(join(dir, 'photo.jpg'), 'image data');
+    await writeFile(join(dir, 'map.mm'), '<map></map>');
+    await writeFile(join(dir, 'doc.pdf'), 'pdf content');
+
+    const results = await scanAndDedup(dir);
+    assert.strictEqual(results.length, 1);
+    assert.strictEqual(results[0].filename, 'doc.pdf');
+  } finally {
+    await rm(dir, { recursive: true });
+  }
+});
+```
+
+- [ ] **Schritt 2: Tests laufen lassen — erwartet: FAIL (Modul nicht gefunden)**
+
+```bash
+cd scripts/coaching && node --test batch-ingest-dir.test.mts
+```
+
+Erwartete Ausgabe: Import-Fehler, da `batch-ingest-dir.mts` noch nicht existiert.
+
+- [ ] **Schritt 3: scanAndDedup + deriveMetadata implementieren (Datei-Skeleton)**
+
+`scripts/coaching/batch-ingest-dir.mts` — nur die zwei exportierten Funktionen, kein main():
+
+```ts
+import { createHash } from 'node:crypto';
+import { readFile, readdir, stat } from 'node:fs/promises';
+import { join, relative, extname, basename, dirname } from 'node:path';
+
+const SUPPORTED_EXTS = new Set(['.pdf', '.doc', '.docx', '.epub']);
+const HASH_SUFFIX_RE = /_[0-9a-f]{32}(\.[^.]+)$/i;
+
+export interface FileCandidate {
+  filePath: string;
+  filename: string;
+  sha256: string;
+  relPath: string;        // relative to input dir
+  blockSlug: string | null;
+  blockCollection: string | null;
+  courseCollection: string;
+  preview: string | null; // first 300 chars of extracted text, set in main()
+}
+
+export interface FileMetadata {
+  blockSlug: string | null;
+  blockCollection: string | null;
+  courseCollection: string;
+}
+
+export function deriveMetadata(filePath: string, inputDir: string, courseSlug: string): FileMetadata {
+  const rel = relative(inputDir, filePath);
+  const parts = rel.split('/');
+  // parts[0] is either a blockN folder or a filename (if in root)
+  const blockMatch = parts.length > 1 ? parts[0].match(/^block(\d+)$/i) : null;
+  const blockSlug = blockMatch ? parts[0].toLowerCase() : null;
+  const courseCollection = `coaching-${courseSlug}`;
+  const blockCollection = blockSlug ? `${courseCollection}-${blockSlug}` : null;
+  return { blockSlug, blockCollection, courseCollection };
+}
+
+export async function scanAndDedup(dir: string): Promise<Omit<FileCandidate, 'blockSlug' | 'blockCollection' | 'courseCollection'>[]> {
+  const allFiles = await collectFiles(dir);
+  const supported = allFiles.filter((f) => SUPPORTED_EXTS.has(extname(f).toLowerCase()));
+
+  // Hash all files
+  const hashed = await Promise.all(supported.map(async (f) => {
+    const buf = await readFile(f);
+    const hash = createHash('sha256').update(buf).digest('hex');
+    return { filePath: f, filename: basename(f), sha256: hash };
+  }));
+
+  // Dedup: per hash, prefer clean name (no _<32hex> suffix)
+  const byHash = new Map<string, typeof hashed[0]>();
+  for (const entry of hashed) {
+    const existing = byHash.get(entry.sha256);
+    if (!existing) {
+      byHash.set(entry.sha256, entry);
+    } else {
+      const currentIsClean = !HASH_SUFFIX_RE.test(existing.filename);
+      const newIsClean = !HASH_SUFFIX_RE.test(entry.filename);
+      if (newIsClean && !currentIsClean) byHash.set(entry.sha256, entry);
+    }
+  }
+
+  return Array.from(byHash.values());
+}
+
+async function collectFiles(dir: string): Promise<string[]> {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const results: string[] = [];
+  for (const entry of entries) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...await collectFiles(full));
+    } else if (entry.isFile()) {
+      results.push(full);
+    }
+  }
+  return results;
+}
+```
+
+- [ ] **Schritt 4: Tests laufen lassen — alle PASS**
+
+```bash
+cd scripts/coaching && node --test batch-ingest-dir.test.mts
+```
+
+Erwartete Ausgabe: 5 Tests PASS.
+
+- [ ] **Schritt 5: Commit**
+
+```bash
+git add scripts/coaching/batch-ingest-dir.mts scripts/coaching/batch-ingest-dir.test.mts
+git commit -m "feat(coaching): scanAndDedup + deriveMetadata with tests"
+```
+
+---
+
+## Task 4: Interaktive Review + Vollständiges CLI
+
+**Files:**
+- Modify: `scripts/coaching/batch-ingest-dir.mts` (main() + interactiveReview() hinzufügen)
+
+- [ ] **Schritt 1: interactiveReview() + main() an batch-ingest-dir.mts anhängen**
+
+Füge am Ende von `scripts/coaching/batch-ingest-dir.mts` hinzu (nach den bestehenden exports):
+
+```ts
+import { createInterface } from 'node:readline/promises';
+import { stdin as input, stdout as output } from 'node:process';
+import { extractText } from './lib-extract.mjs';
+import {
+  makePool, sha256, ensureCollection, upsertDocumentAndChunks, bumpCollectionStats,
+} from '../knowledge/lib-knowledge-pg.mjs';
+import { chunkText } from '../../website/src/lib/chunking.ts';
+import { embedBatch } from '../../website/src/lib/embeddings.ts';
+
+interface CliFlags {
+  dryRun: boolean;
+  yes: boolean;
+  classify: boolean;
+  courseSlug: string;
+  inputDir: string;
+}
+
+async function interactiveReview(candidates: FileCandidate[]): Promise<FileCandidate[]> {
+  const rl = createInterface({ input, output });
+  const confirmed: FileCandidate[] = [];
+  let acceptAll = false;
+
+  for (const c of candidates) {
+    if (acceptAll) { confirmed.push(c); continue; }
+
+    console.log('\n─────────────────────────────────────────');
+    console.log(`📄 ${c.relPath}`);
+    console.log(`   Block: ${c.blockSlug ?? '(root)'} · Collection: ${c.blockCollection ?? c.courseCollection}`);
+    console.log(`   Preview: ${c.preview ?? '(no text extracted)'}`);
+    console.log('─────────────────────────────────────────');
+
+    let answer = '';
+    while (!['y','n','a','q'].includes(answer)) {
+      answer = (await rl.question('  Ingestieren? [y]es / [n]o / [a]ll / [q]uit: ')).trim().toLowerCase();
+    }
+
+    if (answer === 'q') { rl.close(); return confirmed; }
+    if (answer === 'a') { acceptAll = true; confirmed.push(c); continue; }
+    if (answer === 'y') confirmed.push(c);
+  }
+
+  rl.close();
+  return confirmed;
+}
+
+async function ingestDual(
+  pool: ReturnType<typeof makePool>,
+  candidate: FileCandidate,
+  text: string,
+  pageCount: number | null,
+  format: string,
+  opts: { dryRun: boolean },
+): Promise<void> {
+  const textHash = sha256(text);
+  const chunks = chunkText(text, { mode: 'plain', targetTokens: 600, overlapTokens: 80 });
+
+  if (opts.dryRun) {
+    console.log(`  [dry-run] would embed ${chunks.length} chunks into:`);
+    if (candidate.blockCollection) console.log(`    - ${candidate.blockCollection}`);
+    console.log(`    - ${candidate.courseCollection}`);
+    return;
+  }
+
+  const { embeddings, tokens } = await embedBatch(
+    chunks.map((c) => c.text),
+    { model: process.env.LLM_ENABLED === 'true' ? 'bge-m3' : 'voyage-multilingual-2', purpose: 'index' },
+  );
+  console.log(`  embedded ${chunks.length} chunks (${tokens} tokens)`);
+
+  const chunksWithEmbeddings = chunks.map((c, i) => ({
+    position: c.position,
+    text: c.text,
+    embedding: embeddings[i],
+    metadata: pageCount && pageCount > 0
+      ? { page: Math.min(Math.floor((i * pageCount) / chunks.length) + 1, pageCount) }
+      : {},
+  }));
+
+  const collectionsToIngest: string[] = [];
+  if (candidate.blockCollection) collectionsToIngest.push(candidate.blockCollection);
+  collectionsToIngest.push(candidate.courseCollection);
+
+  for (const collName of collectionsToIngest) {
+    const collectionId = await ensureCollection(pool, {
+      name: collName, source: 'custom', brand: 'mentolder', description: collName,
+    });
+    await upsertDocumentAndChunks(pool, {
+      collectionId,
+      title: candidate.filename,
+      sourceUri: `file://${candidate.filename}`,
+      rawText: text,
+      hash: textHash,
+      metadata: { format, pageCount },
+      chunks: chunksWithEmbeddings,
+    });
+    await bumpCollectionStats(pool, collectionId);
+    console.log(`  ✓ ${collName}`);
+  }
+}
+
+function parseArgs(): CliFlags {
+  const args = process.argv.slice(2);
+  if (args.length < 2) {
+    console.error('Usage: batch-ingest-dir.mts <dir> <kurs-slug> [--dry-run] [--yes] [--classify]');
+    process.exit(2);
+  }
+  return {
+    inputDir: args[0],
+    courseSlug: args[1],
+    dryRun: args.includes('--dry-run'),
+    yes: args.includes('--yes'),
+    classify: args.includes('--classify'),
+  };
+}
+
+async function main() {
+  const flags = parseArgs();
+  console.log(`[batch-ingest] scanning ${flags.inputDir}…`);
+
+  const rawCandidates = await scanAndDedup(flags.inputDir);
+  console.log(`[batch-ingest] ${rawCandidates.length} unique files after dedup`);
+
+  // Attach metadata + extract text for preview
+  const candidates: FileCandidate[] = await Promise.all(
+    rawCandidates.map(async (c) => {
+      const meta = deriveMetadata(c.filePath, flags.inputDir, flags.courseSlug);
+      let preview: string | null = null;
+      try {
+        const { text } = await extractText(c.filePath);
+        preview = text.slice(0, 300).replace(/\s+/g, ' ').trim();
+      } catch {
+        preview = null;
+      }
+      return {
+        ...c,
+        relPath: relative(flags.inputDir, c.filePath),
+        ...meta,
+        preview,
+      };
+    }),
+  );
+
+  const toIngest = flags.yes ? candidates : await interactiveReview(candidates);
+  console.log(`\n[batch-ingest] ${toIngest.length} files confirmed for ingest`);
+
+  if (flags.dryRun) {
+    console.log('[batch-ingest] --dry-run: no DB writes');
+    for (const c of toIngest) {
+      const { text, pageCount, format } = await extractText(c.filePath);
+      await ingestDual(null as any, c, text, pageCount ?? null, format, { dryRun: true });
+    }
+    return;
+  }
+
+  const pool = makePool();
+  try {
+    let i = 0;
+    for (const c of toIngest) {
+      i++;
+      console.log(`\n[${i}/${toIngest.length}] ${c.relPath}`);
+      try {
+        const { text, pageCount, format } = await extractText(c.filePath);
+        if (text.trim().length < 100) {
+          console.warn(`  ⚠ very short text (${text.trim().length} chars) — possible scan-only PDF, skipping`);
+          continue;
+        }
+        await ingestDual(pool, c, text, pageCount ?? null, format, { dryRun: false });
+      } catch (err) {
+        console.error(`  ✗ failed: ${err instanceof Error ? err.message : err}`);
+      }
+    }
+  } finally {
+    await pool.end();
+  }
+
+  if (flags.classify) {
+    console.log('\n[batch-ingest] running classifier (--classify)…');
+    const { spawn } = await import('node:child_process');
+    const child = spawn('npx', ['tsx', new URL('./classify-book.mts', import.meta.url).pathname, `--slug=${flags.courseSlug}`], { stdio: 'inherit' });
+    const code: number = await new Promise((r) => child.on('exit', (c) => r(c ?? 1)));
+    if (code !== 0) { console.error(`classifier exited ${code}`); process.exit(code); }
+  }
+
+  console.log('\n[batch-ingest] done.');
+}
+
+main().catch((err) => { console.error(err); process.exit(1); });
+```
+
+- [ ] **Schritt 2: Smoke-Test mit --dry-run**
+
+```bash
+cd scripts/coaching && npx tsx batch-ingest-dir.mts \
+  /mnt/c/Users/PatrickKorczewski/Downloads/ki co2-2023 --dry-run --yes 2>&1 | head -40
+```
+
+Erwartete Ausgabe: Scan-Ausgabe mit ~77 Dateien, dedup auf ~50, dann `[dry-run] would embed N chunks into: coaching-co2-2023-block1` etc. — **kein** DB-Zugriff, kein Fehler.
+
+- [ ] **Schritt 3: Unit-Tests laufen lassen (scanAndDedup + deriveMetadata müssen weiterhin PASS)**
+
+```bash
+cd scripts/coaching && node --test batch-ingest-dir.test.mts
+```
+
+Erwartete Ausgabe: alle 5 Tests PASS.
+
+- [ ] **Schritt 4: Commit**
+
+```bash
+git add scripts/coaching/batch-ingest-dir.mts
+git commit -m "feat(coaching): add interactive review + full CLI to batch-ingest-dir"
+```
+
+---
+
+## Task 5: Taskfile-Task hinzufügen
+
+**Files:**
+- Modify: `Taskfile.yml`
+
+- [ ] **Schritt 1: Bestehenden `coaching:ingest`-Task finden**
+
+```bash
+grep -n "coaching:ingest" Taskfile.yml | head -5
+```
+
+Notiere die Zeilennummer des Tasks.
+
+- [ ] **Schritt 2: `coaching:batch-ingest`-Task einfügen (direkt nach `coaching:ingest`)**
+
+Den folgenden Block nach dem `coaching:ingest`-Task einfügen:
+
+```yaml
+  coaching:batch-ingest:
+    desc: "Batch-ingest a directory of coaching PDFs/DOCs — Usage: task coaching:batch-ingest -- <dir> <kurs-slug> [--dry-run] [--yes] [--classify]"
+    cmds:
+      - source scripts/env-resolve.sh "{{.ENV | default "mentolder"}}"
+      - cd scripts/coaching && npx tsx batch-ingest-dir.mts {{.CLI_ARGS}}
+```
+
+- [ ] **Schritt 3: Task-Listing prüfen**
+
+```bash
+task --list | grep coaching
+```
+
+Erwartete Ausgabe: `coaching:batch-ingest` erscheint in der Liste.
+
+- [ ] **Schritt 4: Dry-run via task**
+
+```bash
+task coaching:batch-ingest -- /mnt/c/Users/PatrickKorczewski/Downloads/ki co2-2023 --dry-run --yes 2>&1 | tail -20
+```
+
+Erwartete Ausgabe: `[batch-ingest] done.` ohne Fehler.
+
+- [ ] **Schritt 5: Commit**
+
+```bash
+git add Taskfile.yml
+git commit -m "feat(coaching): add coaching:batch-ingest Taskfile task"
+```
+
+---
+
+## Task 6: PR erstellen
+
+- [ ] **Schritt 1: Alle Tests laufen lassen**
+
+```bash
+cd scripts/coaching && node --test lib-extract.test.mjs batch-ingest-dir.test.mts
+```
+
+Erwartete Ausgabe: alle Tests PASS oder SKIP.
+
+- [ ] **Schritt 2: Push**
+
+```bash
+git push -u origin feature/coaching-batch-ingest
+```
+
+- [ ] **Schritt 3: PR erstellen**
+
+```bash
+gh pr create \
+  --title "feat(coaching): batch-ingest pipeline with dedup, DOC support, interactive review" \
+  --body "$(cat <<'EOF'
+## Summary
+- Adds `scripts/coaching/batch-ingest-dir.mts`: 4-phase pipeline (scan+dedup → extract → interactive review → dual-collection ingest)
+- Extends `lib-extract.mjs` with DOC/DOCX support via mammoth
+- 96 unique files from ki/ and ki2/ ingestible in one run; 69 content-duplicates eliminated via SHA256
+- Dual-collection ingest: each file goes into block-level collection AND course-level collection
+- `--dry-run` mode for safe preview; `--yes` to skip interactive review
+
+## Test plan
+- [ ] `node --test lib-extract.test.mjs` — all pass
+- [ ] `node --test batch-ingest-dir.test.mts` — all pass
+- [ ] `task coaching:batch-ingest -- <ki-dir> co2-2023 --dry-run --yes` — no errors, shows chunk counts
+EOF
+)"
+```
+
+- [ ] **Schritt 4: PR mergen (nach CI grün)**
+
+```bash
+gh pr merge --squash --auto
+```
+
+---
+
+## Aufruf nach Merge
+
+```bash
+# ki/ (Co2 2023) ingestieren
+task coaching:batch-ingest -- /mnt/c/Users/PatrickKorczewski/Downloads/ki co2-2023
+
+# ki2/ (Grundkurs LG29) ingestieren
+task coaching:batch-ingest -- /mnt/c/Users/PatrickKorczewski/Downloads/ki2 grundkurs-lg29
+
+# Beide mit Auto-Klassifizierung (ohne Review)
+task coaching:batch-ingest -- /mnt/c/Users/PatrickKorczewski/Downloads/ki co2-2023 --yes --classify
+task coaching:batch-ingest -- /mnt/c/Users/PatrickKorczewski/Downloads/ki2 grundkurs-lg29 --yes --classify
+```

--- a/docs/superpowers/specs/2026-05-18-coaching-batch-ingest-design.md
+++ b/docs/superpowers/specs/2026-05-18-coaching-batch-ingest-design.md
@@ -1,0 +1,145 @@
+# Coaching Batch-Ingest Pipeline — Design Spec
+
+**Date:** 2026-05-18  
+**Branch:** feature/coaching-batch-ingest  
+**Status:** approved
+
+## Kontext
+
+Zwei Verzeichnisse mit Coaching-Ausbildungsunterlagen sollen in pgvector ingestiert werden:
+
+- `ki/` — Coachingausbildung Co2 2023 (Block 1–5), 77 Dateien
+- `ki2/` — Grundkurs LG29 2022–2023 (Block 1–6), 88 Dateien
+
+**Problem:** 165 Dateien gesamt, aber nur 96 einzigartige Inhalte (69 Duplikate), davon 38 mit Nextcloud-Hash-Suffix (`_abcd1234ef...`). Zusätzlich enthalten die Verzeichnisse nicht-Coaching-Inhalte (Kontoauszug, Router-Manual), Bilder (JPG/PNG) und DOC/DOCX-Dateien, die `lib-extract.mjs` noch nicht unterstützt.
+
+Das bestehende `ingest-book.mts` ist ein Single-File-Ingest — es gibt keinen Batch-Mechanismus, keine Dedup-Logik und keine interaktive Prüfung vor dem Ingest.
+
+## Ziele
+
+1. **Keine verschwendete Embedding-Kapazität** — jeder einzigartige Text-Inhalt wird genau einmal eingebettet
+2. **DOC/DOCX-Support** — `lib-extract.mjs` wird um `.doc`/`.docx`-Extraktion erweitert
+3. **Interaktive Review** — User bestätigt jeden Kandidaten vor dem Ingest, mit Text-Vorschau
+4. **Dual-Collection-Ingest** — jede Datei landet in Block-Collection UND Kurs-Collection
+5. **Idempotenz** — Re-Run ohne Doppelingest via SHA256-Hash
+
+## Architektur
+
+### 4-Phasen-Pipeline in `scripts/coaching/batch-ingest-dir.mts`
+
+```
+Verzeichnis-Input
+    │
+    ▼
+Phase 1: Scan & Dedup
+  - Rekursiv alle PDF, DOC, DOCX einlesen
+  - SHA256 pro Datei
+  - Duplikate eliminieren: bei Hashkollision bevorzuge clean name (ohne _[0-9a-f]{32})
+  - Bilder (jpg/png/gif), MM-Dateien → übersprungen (geloggt)
+    │
+    ▼
+Phase 2: Text-Extraktion
+  - PDF → pdf-parse (bestehend, mit Seiten-Anchor)
+  - DOC/DOCX → mammoth (neu, reines Node.js)
+  - Leerer oder sehr kurzer Text (<100 Zeichen) → Warnung, User entscheidet
+    │
+    ▼
+Phase 3: Interaktive Review (überspringbar via --yes oder --dry-run)
+  - Pro Datei: Dateiname, Block, Kurs, erste ~300 Zeichen extrahierter Text
+  - Prompt: y (ingestieren) | n (überspringen) | a (alle restlichen) | q (abbrechen)
+  - --dry-run: zeigt alles, schreibt nichts in DB
+    │
+    ▼
+Phase 4: Dual-Collection Ingest
+  - Pro bestätigter Datei: upsertDocumentAndChunks in Block-Collection UND Kurs-Collection
+  - Block-Collection: coaching-<kurs-slug>-block<N>  (z.B. coaching-co2-block1)
+  - Kurs-Collection:  coaching-<kurs-slug>            (z.B. coaching-co2-2023)
+  - Idempotenz: SHA256-Hash verhindert Doppel-Embedding bei Re-Run
+```
+
+### Metadaten-Ableitung aus Verzeichnisstruktur
+
+| Verzeichnispfad | kurs-slug | block | Block-Collection | Kurs-Collection |
+|----------------|-----------|-------|-----------------|-----------------|
+| `ki/block1/…`  | `co2` | 1 | `coaching-co2-block1` | `coaching-co2-2023` |
+| `ki/block2/…`  | `co2` | 2 | `coaching-co2-block2` | `coaching-co2-2023` |
+| `ki2/block3/…` | `grundkurs-lg29` | 3 | `coaching-grundkurs-lg29-block3` | `coaching-grundkurs-lg29` |
+| `ki/` (root)   | `co2` | – | — | `coaching-co2-2023` (nur Kurs-Collection) |
+
+Dateien im Wurzelverzeichnis (kein `blockN`-Unterordner) werden nur in die Kurs-Collection ingestiert.
+
+## Geänderte / neue Dateien
+
+### 1. `scripts/coaching/lib-extract.mjs` (geändert)
+
+```
+extractText(filePath):
+  .pdf  → bestehende extractPdf()
+  .epub → bestehende extractEpub()
+  .doc  → NEU: extractDoc() via mammoth
+  .docx → NEU: extractDocx() via mammoth
+  else  → Error: Unsupported extension
+```
+
+`mammoth` gibt direkt plain text zurück (`mammoth.extractRawText()`). `pageCount` = `null` für DOC-Dateien (mammoth hat kein Seitenkonzept).
+
+### 2. `scripts/coaching/batch-ingest-dir.mts` (neu)
+
+CLI-Interface:
+```
+Usage: batch-ingest-dir.mts <dir> <kurs-slug> [--dry-run] [--yes] [--classify]
+  dir         Eingabeverzeichnis (ki/ oder ki2/)
+  kurs-slug   z.B. co2-2023 oder grundkurs-lg29
+  --dry-run   Keine DB-Schreiboperationen, zeigt Review-Vorschau
+  --yes       Überspringt interaktive Review (alle ingestieren)
+  --classify  Startet nach Ingest den Classifier (wie in ingest-book.mts)
+```
+
+Interne Struktur:
+- `scanAndDedup(dir)` → `FileCandidate[]`
+- `extractWithPreview(candidate)` → `{text, preview, pageCount, format}`
+- `interactiveReview(candidates)` → `FileCandidate[]` (bestätigt)
+- `ingestDual(candidate, pool, opts)` → ingestiert in Block + Kurs Collection
+
+### 3. `Taskfile.yml` (geändert)
+
+Neuer Task `coaching:batch-ingest`:
+```yaml
+coaching:batch-ingest:
+  desc: Batch-ingest a directory of coaching PDFs/DOCs into pgvector
+  cmds:
+    - source scripts/env-resolve.sh "{{.ENV | default "mentolder"}}"
+    - npx tsx scripts/coaching/batch-ingest-dir.mts {{.CLI_ARGS}}
+```
+
+### 4. `scripts/coaching/package.json` (geändert)
+
+Neue Abhängigkeit: `mammoth` (für DOC/DOCX-Extraktion).
+
+## Nicht im Scope
+
+- Bilder (JPG/PNG) — kein OCR, werden übersprungen
+- FreeMind Mind Maps (.mm) — werden übersprungen
+- EPUB (bereits unterstützt, kein Handlungsbedarf)
+- Web-UI für Review (Terminal-Prompt reicht für einmaligen Batch)
+- Automatische Klassifizierung nach Ingest (über `--classify` Flag opt-in)
+
+## Fehlerbehandlung
+
+- Scan-PDF (kein extrahierbarer Text): Review zeigt Warnung, User kann n drücken
+- 429 bei Voyage API: bestehender Retry-Mechanismus aus `ingest-book.mts` wird übernommen
+- Datei nicht lesbar: in Review als FEHLER markiert, automatisch übersprungen
+- `q` im Review: bereits ingestierte Dateien bleiben erhalten (partial run ist ok)
+
+## Aufruf-Beispiel (post-implementation)
+
+```bash
+# Dry-run: was würde ingestiert werden?
+task coaching:batch-ingest -- /mnt/c/Users/PatrickKorczewski/Downloads/ki co2-2023 --dry-run
+
+# Interaktiver Ingest mit Review
+task coaching:batch-ingest -- /mnt/c/Users/PatrickKorczewski/Downloads/ki co2-2023
+
+# Alles ohne Review + direkt klassifizieren
+task coaching:batch-ingest -- /mnt/c/Users/PatrickKorczewski/Downloads/ki2 grundkurs-lg29 --yes --classify
+```

--- a/scripts/coaching/batch-ingest-dir.mts
+++ b/scripts/coaching/batch-ingest-dir.mts
@@ -1,0 +1,72 @@
+import { createHash } from 'node:crypto';
+import { readFile, readdir } from 'node:fs/promises';
+import { join, relative, extname, basename } from 'node:path';
+
+const SUPPORTED_EXTS = new Set(['.pdf', '.doc', '.docx', '.epub']);
+const HASH_SUFFIX_RE = /_[0-9a-f]{32}(\.[^.]+)$/i;
+
+export interface FileCandidate {
+  filePath: string;
+  filename: string;
+  sha256: string;
+  relPath: string;
+  blockSlug: string | null;
+  blockCollection: string | null;
+  courseCollection: string;
+  preview: string | null;
+}
+
+export interface FileMetadata {
+  blockSlug: string | null;
+  blockCollection: string | null;
+  courseCollection: string;
+}
+
+export function deriveMetadata(filePath: string, inputDir: string, courseSlug: string): FileMetadata {
+  const rel = relative(inputDir, filePath);
+  const parts = rel.split('/');
+  const blockMatch = parts.length > 1 ? parts[0].match(/^block(\d+)$/i) : null;
+  const blockSlug = blockMatch ? parts[0].toLowerCase() : null;
+  const courseCollection = `coaching-${courseSlug}`;
+  const blockCollection = blockSlug ? `${courseCollection}-${blockSlug}` : null;
+  return { blockSlug, blockCollection, courseCollection };
+}
+
+export async function scanAndDedup(dir: string): Promise<Omit<FileCandidate, 'relPath' | 'blockSlug' | 'blockCollection' | 'courseCollection' | 'preview'>[]> {
+  const allFiles = await collectFiles(dir);
+  const supported = allFiles.filter((f) => SUPPORTED_EXTS.has(extname(f).toLowerCase()));
+
+  const hashed = await Promise.all(supported.map(async (f) => {
+    const buf = await readFile(f);
+    const hash = createHash('sha256').update(buf).digest('hex');
+    return { filePath: f, filename: basename(f), sha256: hash };
+  }));
+
+  const byHash = new Map<string, typeof hashed[0]>();
+  for (const entry of hashed) {
+    const existing = byHash.get(entry.sha256);
+    if (!existing) {
+      byHash.set(entry.sha256, entry);
+    } else {
+      const currentIsClean = !HASH_SUFFIX_RE.test(existing.filename);
+      const newIsClean = !HASH_SUFFIX_RE.test(entry.filename);
+      if (newIsClean && !currentIsClean) byHash.set(entry.sha256, entry);
+    }
+  }
+
+  return Array.from(byHash.values());
+}
+
+async function collectFiles(dir: string): Promise<string[]> {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const results: string[] = [];
+  for (const entry of entries) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...await collectFiles(full));
+    } else if (entry.isFile()) {
+      results.push(full);
+    }
+  }
+  return results;
+}

--- a/scripts/coaching/batch-ingest-dir.mts
+++ b/scripts/coaching/batch-ingest-dir.mts
@@ -214,9 +214,16 @@ async function main() {
 
   if (flags.dryRun) {
     console.log('[batch-ingest] --dry-run: no DB writes');
+    let i = 0;
     for (const c of toIngest) {
-      const { text, pageCount, format } = await extractText(c.filePath);
-      await ingestDual(null as any, c, text, pageCount ?? null, format, { dryRun: true });
+      i++;
+      console.log(`\n[${i}/${toIngest.length}] ${c.relPath}`);
+      try {
+        const { text, pageCount, format } = await extractText(c.filePath);
+        await ingestDual(null as any, c, text, pageCount ?? null, format, { dryRun: true });
+      } catch (err) {
+        console.error(`  failed: ${err instanceof Error ? err.message : err}`);
+      }
     }
     return;
   }

--- a/scripts/coaching/batch-ingest-dir.mts
+++ b/scripts/coaching/batch-ingest-dir.mts
@@ -1,6 +1,8 @@
 import { createHash } from 'node:crypto';
 import { readFile, readdir } from 'node:fs/promises';
 import { join, relative, extname, basename } from 'node:path';
+import { createInterface } from 'node:readline/promises';
+import { stdin as input, stdout as output } from 'node:process';
 
 const SUPPORTED_EXTS = new Set(['.pdf', '.doc', '.docx', '.epub']);
 const HASH_SUFFIX_RE = /_[0-9a-f]{32}(\.[^.]+)$/i;
@@ -69,4 +71,191 @@ async function collectFiles(dir: string): Promise<string[]> {
     }
   }
   return results;
+}
+
+// ── CLI-only code (imports resolved lazily to avoid test-runner breakage) ─────
+
+interface CliFlags {
+  dryRun: boolean;
+  yes: boolean;
+  classify: boolean;
+  courseSlug: string;
+  inputDir: string;
+}
+
+async function interactiveReview(candidates: FileCandidate[]): Promise<FileCandidate[]> {
+  const rl = createInterface({ input, output });
+  const confirmed: FileCandidate[] = [];
+  let acceptAll = false;
+
+  for (const c of candidates) {
+    if (acceptAll) { confirmed.push(c); continue; }
+
+    console.log('\n─────────────────────────────────────────');
+    console.log(`  ${c.relPath}`);
+    console.log(`   Block: ${c.blockSlug ?? '(root)'} · Collection: ${c.blockCollection ?? c.courseCollection}`);
+    console.log(`   Preview: ${c.preview ?? '(no text extracted)'}`);
+    console.log('─────────────────────────────────────────');
+
+    let answer = '';
+    while (!['y', 'n', 'a', 'q'].includes(answer)) {
+      answer = (await rl.question('  Ingestieren? [y]es / [n]o / [a]ll / [q]uit: ')).trim().toLowerCase();
+    }
+
+    if (answer === 'q') { rl.close(); return confirmed; }
+    if (answer === 'a') { acceptAll = true; confirmed.push(c); continue; }
+    if (answer === 'y') confirmed.push(c);
+  }
+
+  rl.close();
+  return confirmed;
+}
+
+async function ingestDual(
+  pool: import('pg').Pool,
+  candidate: FileCandidate,
+  text: string,
+  pageCount: number | null,
+  format: string,
+  opts: { dryRun: boolean },
+): Promise<void> {
+  const { sha256, ensureCollection, upsertDocumentAndChunks, bumpCollectionStats } =
+    await import('../knowledge/lib-knowledge-pg.mjs') as any;
+  const { chunkText } = await import('../../website/src/lib/chunking.ts') as any;
+  const { embedBatch } = await import('../../website/src/lib/embeddings.ts') as any;
+
+  const textHash = sha256(text);
+  const chunks = chunkText(text, { mode: 'plain', targetTokens: 600, overlapTokens: 80 });
+
+  if (opts.dryRun) {
+    console.log(`  [dry-run] would embed ${chunks.length} chunks into:`);
+    if (candidate.blockCollection) console.log(`    - ${candidate.blockCollection}`);
+    console.log(`    - ${candidate.courseCollection}`);
+    return;
+  }
+
+  const { embeddings, tokens } = await embedBatch(
+    chunks.map((c: any) => c.text),
+    { model: process.env.LLM_ENABLED === 'true' ? 'bge-m3' : 'voyage-multilingual-2', purpose: 'index' },
+  );
+  console.log(`  embedded ${chunks.length} chunks (${tokens} tokens)`);
+
+  const chunksWithEmbeddings = chunks.map((c: any, i: number) => ({
+    position: c.position,
+    text: c.text,
+    embedding: embeddings[i],
+    metadata: pageCount && pageCount > 0
+      ? { page: Math.min(Math.floor((i * pageCount) / chunks.length) + 1, pageCount) }
+      : {},
+  }));
+
+  const collectionsToIngest: string[] = [];
+  if (candidate.blockCollection) collectionsToIngest.push(candidate.blockCollection);
+  collectionsToIngest.push(candidate.courseCollection);
+
+  for (const collName of collectionsToIngest) {
+    const collectionId = await ensureCollection(pool, {
+      name: collName, source: 'custom', brand: 'mentolder', description: collName,
+    });
+    await upsertDocumentAndChunks(pool, {
+      collectionId,
+      title: candidate.filename,
+      sourceUri: `file://${candidate.filename}`,
+      rawText: text,
+      hash: textHash,
+      metadata: { format, pageCount },
+      chunks: chunksWithEmbeddings,
+    });
+    await bumpCollectionStats(pool, collectionId);
+    console.log(`  ✓ ${collName}`);
+  }
+}
+
+function parseArgs(): CliFlags {
+  const args = process.argv.slice(2);
+  if (args.length < 2) {
+    console.error('Usage: batch-ingest-dir.mts <dir> <kurs-slug> [--dry-run] [--yes] [--classify]');
+    process.exit(2);
+  }
+  return {
+    inputDir: args[0],
+    courseSlug: args[1],
+    dryRun: args.includes('--dry-run'),
+    yes: args.includes('--yes'),
+    classify: args.includes('--classify'),
+  };
+}
+
+async function main() {
+  const flags = parseArgs();
+  console.log(`[batch-ingest] scanning ${flags.inputDir}...`);
+
+  const rawCandidates = await scanAndDedup(flags.inputDir);
+  console.log(`[batch-ingest] ${rawCandidates.length} unique files after dedup`);
+
+  const { extractText } = await import('./lib-extract.mjs') as any;
+
+  const candidates: FileCandidate[] = await Promise.all(
+    rawCandidates.map(async (c) => {
+      const meta = deriveMetadata(c.filePath, flags.inputDir, flags.courseSlug);
+      let preview: string | null = null;
+      try {
+        const { text } = await extractText(c.filePath);
+        preview = text.slice(0, 300).replace(/\s+/g, ' ').trim();
+      } catch {
+        preview = null;
+      }
+      return { ...c, relPath: relative(flags.inputDir, c.filePath), ...meta, preview };
+    }),
+  );
+
+  const toIngest = flags.yes ? candidates : await interactiveReview(candidates);
+  console.log(`\n[batch-ingest] ${toIngest.length} files confirmed for ingest`);
+
+  if (flags.dryRun) {
+    console.log('[batch-ingest] --dry-run: no DB writes');
+    for (const c of toIngest) {
+      const { text, pageCount, format } = await extractText(c.filePath);
+      await ingestDual(null as any, c, text, pageCount ?? null, format, { dryRun: true });
+    }
+    return;
+  }
+
+  const { makePool } = await import('../knowledge/lib-knowledge-pg.mjs') as any;
+  const pool = makePool();
+  try {
+    let i = 0;
+    for (const c of toIngest) {
+      i++;
+      console.log(`\n[${i}/${toIngest.length}] ${c.relPath}`);
+      try {
+        const { text, pageCount, format } = await extractText(c.filePath);
+        if (text.trim().length < 100) {
+          console.warn(`  very short text (${text.trim().length} chars) — possible scan-only PDF, skipping`);
+          continue;
+        }
+        await ingestDual(pool, c, text, pageCount ?? null, format, { dryRun: false });
+      } catch (err) {
+        console.error(`  failed: ${err instanceof Error ? err.message : err}`);
+      }
+    }
+  } finally {
+    await pool.end();
+  }
+
+  if (flags.classify) {
+    console.log('\n[batch-ingest] running classifier (--classify)...');
+    const { spawn } = await import('node:child_process');
+    const child = spawn('npx', ['tsx', new URL('./classify-book.mts', import.meta.url).pathname, `--slug=${flags.courseSlug}`], { stdio: 'inherit' });
+    const code: number = await new Promise((r) => child.on('exit', (c: number | null) => r(c ?? 1)));
+    if (code !== 0) { console.error(`classifier exited ${code}`); process.exit(code); }
+  }
+
+  console.log('\n[batch-ingest] done.');
+}
+
+// Only run main() when invoked directly, not when imported by test runner
+import { pathToFileURL } from 'node:url';
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((err) => { console.error(err); process.exit(1); });
 }

--- a/scripts/coaching/batch-ingest-dir.test.mts
+++ b/scripts/coaching/batch-ingest-dir.test.mts
@@ -1,0 +1,65 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { writeFile, mkdir, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { scanAndDedup, deriveMetadata } from './batch-ingest-dir.mts';
+
+// ── deriveMetadata ────────────────────────────────────────────────────────────
+
+test('deriveMetadata: file in blockN subdir', () => {
+  const m = deriveMetadata('/input/ki/block3/some-file.pdf', '/input/ki', 'co2-2023');
+  assert.strictEqual(m.blockSlug, 'block3');
+  assert.strictEqual(m.blockCollection, 'coaching-co2-2023-block3');
+  assert.strictEqual(m.courseCollection, 'coaching-co2-2023');
+});
+
+test('deriveMetadata: file in root dir (no block)', () => {
+  const m = deriveMetadata('/input/ki/overview.pdf', '/input/ki', 'co2-2023');
+  assert.strictEqual(m.blockSlug, null);
+  assert.strictEqual(m.blockCollection, null);
+  assert.strictEqual(m.courseCollection, 'coaching-co2-2023');
+});
+
+test('deriveMetadata: nested deeper than block', () => {
+  const m = deriveMetadata('/input/ki2/block1/sub/file.pdf', '/input/ki2', 'grundkurs-lg29');
+  assert.strictEqual(m.blockSlug, 'block1');
+  assert.strictEqual(m.blockCollection, 'coaching-grundkurs-lg29-block1');
+});
+
+// ── scanAndDedup ──────────────────────────────────────────────────────────────
+
+test('scanAndDedup: deduplicates identical content, prefers clean name', async () => {
+  const dir = join(tmpdir(), `dedup-test-${Date.now()}`);
+  await mkdir(dir);
+  try {
+    await writeFile(join(dir, 'clean.pdf'), 'same content');
+    await writeFile(join(dir, 'clean_abcdef1234567890abcdef1234567890.pdf'), 'same content');
+    await writeFile(join(dir, 'unique.pdf'), 'different content');
+
+    const results = await scanAndDedup(dir);
+    assert.strictEqual(results.length, 2, 'should have 2 unique files');
+    const names = results.map((r) => r.filename);
+    assert.ok(names.includes('clean.pdf'), 'should keep clean name');
+    assert.ok(!names.includes('clean_abcdef1234567890abcdef1234567890.pdf'), 'should drop hash-suffix duplicate');
+    assert.ok(names.includes('unique.pdf'), 'should keep unique file');
+  } finally {
+    await rm(dir, { recursive: true });
+  }
+});
+
+test('scanAndDedup: skips images and .mm files', async () => {
+  const dir = join(tmpdir(), `skip-test-${Date.now()}`);
+  await mkdir(dir);
+  try {
+    await writeFile(join(dir, 'photo.jpg'), 'image data');
+    await writeFile(join(dir, 'map.mm'), '<map></map>');
+    await writeFile(join(dir, 'doc.pdf'), 'pdf content');
+
+    const results = await scanAndDedup(dir);
+    assert.strictEqual(results.length, 1);
+    assert.strictEqual(results[0].filename, 'doc.pdf');
+  } finally {
+    await rm(dir, { recursive: true });
+  }
+});

--- a/scripts/coaching/lib-extract.mjs
+++ b/scripts/coaching/lib-extract.mjs
@@ -1,41 +1,35 @@
-import { readFile } from 'node:fs/promises';
 import { extname } from 'node:path';
-// Import the inner module directly — pdf-parse's index.js triggers a debug-mode
-// fixture read when `module.parent` is undefined (which is always the case under ESM).
-// Types live in scripts/coaching/types.d.ts.
-import pdfParse from 'pdf-parse/lib/pdf-parse.js';
+import { PDFParse } from 'pdf-parse';
 import EPub from 'epub2';
+import mammoth from 'mammoth';
 
 /**
- * Extracts plain text from a PDF or EPUB file.
+ * Extracts plain text from a PDF, EPUB, DOC, or DOCX file.
  * Returns { text, pageCount, pageMap?, format }.
  * pageMap is an array of { page, charStart } anchors when available (PDF only).
  */
 export async function extractText(filePath) {
   const ext = extname(filePath).toLowerCase();
-  if (ext === '.pdf') return extractPdf(filePath);
+  if (ext === '.pdf')  return extractPdf(filePath);
   if (ext === '.epub') return extractEpub(filePath);
+  if (ext === '.docx') return extractDoc(filePath, 'docx');
+  if (ext === '.doc')  return extractDoc(filePath, 'doc');
   throw new Error(`Unsupported extension: ${ext}`);
 }
 
 async function extractPdf(filePath) {
-  const buf = await readFile(filePath);
+  const parser = new PDFParse({ url: filePath });
+  const result = await parser.getText();
+
+  // Build pageMap (charStart per page) from the per-page text array
   const pageMap = [];
   let cursor = 0;
-  const data = await pdfParse(buf, {
-    pagerender: (pageData) => pageData.getTextContent().then((tc) => {
-      const pageText = tc.items.map((it) => it.str).join(' ');
-      pageMap.push({ page: pageData.pageNumber, charStart: cursor });
-      cursor += pageText.length + 1;
-      return pageText;
-    }),
-  });
-  return {
-    text: data.text,
-    pageCount: data.numpages,
-    pageMap,
-    format: 'pdf',
-  };
+  for (const p of result.pages) {
+    pageMap.push({ page: p.num, charStart: cursor });
+    cursor += p.text.length + 2; // +2 for '\n\n' separator added by getText()
+  }
+
+  return { text: result.text, pageCount: result.total, pageMap, format: 'pdf' };
 }
 
 async function extractEpub(filePath) {
@@ -48,12 +42,17 @@ async function extractEpub(filePath) {
     const text = stripHtml(html);
     if (text.trim()) chapters.push(text);
   }
-  return {
-    text: chapters.join('\n\n'),
-    pageCount: chapters.length,
-    pageMap: null,
-    format: 'epub',
-  };
+  return { text: chapters.join('\n\n'), pageCount: chapters.length, pageMap: null, format: 'epub' };
+}
+
+async function extractDoc(filePath, format) {
+  const result = await mammoth.extractRawText({ path: filePath });
+  for (const msg of result.messages) {
+    if (msg.type === 'warning') {
+      console.warn(`[extract] ${format} warning in ${filePath}: ${msg.message}`);
+    }
+  }
+  return { text: result.value, pageCount: null, pageMap: null, format };
 }
 
 function stripHtml(html) {

--- a/scripts/coaching/lib-extract.test.mjs
+++ b/scripts/coaching/lib-extract.test.mjs
@@ -4,21 +4,36 @@ import { extractText } from './lib-extract.mjs';
 
 test('extractText rejects unknown extension', async () => {
   await assert.rejects(
-    () => extractText('/tmp/nope.docx'),
+    () => extractText('/tmp/nope.xyz'),
     /Unsupported extension/,
   );
 });
 
 test('extractText reads a tiny PDF', async () => {
-  // Skip if test fixture not present; CI provides it via `task test:coaching:fixtures`
   const fixture = process.env.PDF_FIXTURE ?? new URL('./fixtures/sample.pdf', import.meta.url).pathname;
   try {
     const { text, pageCount } = await extractText(fixture);
     assert.ok(text.length > 0, 'should return non-empty text');
     assert.ok(pageCount >= 1, 'should report page count');
   } catch (err) {
-    if (err.code === 'ENOENT') {
+    if (err.code === 'ENOENT' || err.missing === true) {
       console.warn('skipping PDF fixture test — sample.pdf not present');
+      return;
+    }
+    throw err;
+  }
+});
+
+test('extractText reads a DOCX file', async () => {
+  const fixture = process.env.DOCX_FIXTURE ?? new URL('./fixtures/sample.docx', import.meta.url).pathname;
+  try {
+    const { text, pageCount, format } = await extractText(fixture);
+    assert.ok(text.length > 0, 'should return non-empty text');
+    assert.strictEqual(pageCount, null, 'DOC pageCount should be null');
+    assert.strictEqual(format, 'docx');
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      console.warn('skipping DOCX fixture test — sample.docx not present');
       return;
     }
     throw err;

--- a/scripts/coaching/package-lock.json
+++ b/scripts/coaching/package-lock.json
@@ -7,6 +7,7 @@
       "name": "bachelorprojekt-coaching-scripts",
       "dependencies": {
         "epub2": "3.0.2",
+        "mammoth": "^1.8.0",
         "pdf-parse": "^2.4.5"
       }
     },
@@ -218,6 +219,15 @@
         "undici-types": ">=7.24.0 <7.24.7"
       }
     },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.8.13",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
+      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/adm-zip": {
       "version": "0.5.17",
       "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
@@ -225,6 +235,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.0"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
       }
     },
     "node_modules/array-hyper-unique": {
@@ -237,10 +256,36 @@
         "lodash": "^4.17.23"
       }
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
       "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+      "license": "MIT"
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "license": "MIT"
     },
     "node_modules/crlf-normalize": {
@@ -264,6 +309,21 @@
         "node": ">=6"
       }
     },
+    "node_modules/dingbat-to-unicode": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dingbat-to-unicode/-/dingbat-to-unicode-1.0.1.tgz",
+      "integrity": "sha512-98l0sW87ZT58pU4i61wa2OHwxbiYSbuxsCBozaVnYX2iCnr3bLM3fIes1/ej7h1YdOKuKt/MLs706TVnALA65w==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/duck": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/duck/-/duck-0.1.12.tgz",
+      "integrity": "sha512-wkctla1O6VfP89gQ+J/yDesM0S7B7XLXjKGzXxMDVFg7uEn706niAtyYovKbyq1oT9YwDcly721/iUWoc8MVRg==",
+      "license": "BSD",
+      "dependencies": {
+        "underscore": "^1.13.1"
+      }
+    },
     "node_modules/epub2": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/epub2/-/epub2-3.0.2.tgz",
@@ -278,11 +338,121 @@
         "xml2js": "^0.6.2"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
     "node_modules/lodash": {
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
+    },
+    "node_modules/lop": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/lop/-/lop-0.4.2.tgz",
+      "integrity": "sha512-RefILVDQ4DKoRZsJ4Pj22TxE3omDO47yFpkIBoDKzkqPRISs5U1cnAdg/5583YPkWPaLIYHOKRMQSvjFsO26cw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "duck": "^0.1.12",
+        "option": "~0.2.1",
+        "underscore": "^1.13.1"
+      }
+    },
+    "node_modules/mammoth": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/mammoth/-/mammoth-1.12.0.tgz",
+      "integrity": "sha512-cwnK1RIcRdDMi2HRx2EXGYlxqIEh0Oo3bLhorgnsVJi2UkbX1+jKxuBNR9PC5+JaX7EkmJxFPmo6mjLpqShI2w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@xmldom/xmldom": "^0.8.6",
+        "argparse": "~1.0.3",
+        "base64-js": "^1.5.1",
+        "bluebird": "~3.4.0",
+        "dingbat-to-unicode": "^1.0.1",
+        "jszip": "^3.7.1",
+        "lop": "^0.4.2",
+        "path-is-absolute": "^1.0.0",
+        "underscore": "^1.13.1",
+        "xmlbuilder": "^10.0.0"
+      },
+      "bin": {
+        "mammoth": "bin/mammoth"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/mammoth/node_modules/bluebird": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
+      "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
+      "license": "MIT"
+    },
+    "node_modules/mammoth/node_modules/xmlbuilder": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-10.1.1.tgz",
+      "integrity": "sha512-OyzrcFLL/nb6fMGHbiRDuPup9ljBycsdCypwuyg5AAHvyWzGfChJpCXMG88AGTIMFhGZ9RccFN1e6lhg3hkwKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/option": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/option/-/option-0.2.4.tgz",
+      "integrity": "sha512-pkEqbDyl8ou5cpq+VsnQbe/WlEy5qS7xPzMS1U55OCG9KPvwFD46zDbxQIj3egJSFc3D+XhYOPUzz49zQAVy7A==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/pdf-parse": {
       "version": "2.4.5",
@@ -316,6 +486,33 @@
         "@napi-rs/canvas": "^0.1.80"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
     "node_modules/sax": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
@@ -323,6 +520,27 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=11.0.0"
+      }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/ts-toolbelt": {
@@ -367,10 +585,22 @@
       "integrity": "sha512-Ka0DBegjuV9IPYFT1h0Qqk5U4pccebNIJCGl8C5uU7xtOs+jpJvKGAY4fHGK25hTmXZOEUl9Cnsg5cS6K/b5DA==",
       "license": "MIT"
     },
+    "node_modules/underscore": {
+      "version": "1.13.8",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
+      "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
+      "license": "MIT"
+    },
     "node_modules/undici-types": {
       "version": "7.24.6",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
       "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "license": "MIT"
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
     },
     "node_modules/xml2js": {

--- a/scripts/coaching/package.json
+++ b/scripts/coaching/package.json
@@ -5,6 +5,7 @@
   "description": "Coaching ingest pipeline scripts. node_modules is symlinked to ../../website/node_modules to avoid duplicate installs.",
   "dependencies": {
     "epub2": "3.0.2",
+    "mammoth": "^1.8.0",
     "pdf-parse": "^2.4.5"
   }
 }


### PR DESCRIPTION
## Summary
- Adds `scripts/coaching/batch-ingest-dir.mts`: 4-phase pipeline (scan+dedup → extract → interactive review → dual-collection ingest)
- Extends `lib-extract.mjs` with DOC/DOCX support via mammoth + upgrades to pdf-parse v2 API (PDFParse class)
- 56 unique files from ki/ deduped via SHA256; corrupt DOCX files handled gracefully (skip + log)
- Dual-collection ingest: each file goes into block-level collection AND course-level collection
- `--dry-run` mode for safe preview; `--yes` to skip interactive review; `--classify` to auto-classify after ingest

## Test plan
- [x] `node --test lib-extract.test.mjs` — all pass
- [x] `node --test batch-ingest-dir.test.mts` — all pass (8 tests)
- [x] `task coaching:batch-ingest -- <ki-dir> co2-2023 --dry-run --yes` — 56 files, no crash
- [x] `task workspace:validate` — manifests valid

Closes T000473

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>