### PR TITLE
feat(knowledge): add context7 docs ingest with markdown-aware chunking

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -3151,6 +3151,100 @@ tasks:
         PGURL="postgres://website:${WEBSITE_DB_PASSWORD}@localhost:5432/website" \
           node scripts/knowledge/ingest-web.mjs {{.CLI_ARGS}}
 
+  knowledge:seed-context7:
+    desc: "Create + ingest all 10 context7 library collections (ENV=mentolder|korczewski)"
+    vars:
+      ENV: '{{.ENV | default "mentolder"}}'
+    cmds:
+      - |
+        source scripts/env-resolve.sh "{{.ENV}}"
+        ctx_flag=""
+        [ "{{.ENV}}" != "dev" ] && ctx_flag="--context $ENV_CONTEXT"
+        NS="${WORKSPACE_NAMESPACE:-workspace}"
+
+        kubectl $ctx_flag -n "$NS" port-forward svc/shared-db 5432:5432 \
+          >/tmp/knowledge-context7-pf.log 2>&1 &
+        PF=$!
+        trap 'kill $PF 2>/dev/null' EXIT
+        sleep 3
+
+        PGURL="postgres://website:${WEBSITE_DB_PASSWORD}@localhost:5432/website"
+
+        # Apply SQL migration (idempotent)
+        echo "=== Applying context7_docs source migration ==="
+        PGPASSWORD="${WEBSITE_DB_PASSWORD}" psql -h localhost -U website -d website \
+          < scripts/one-shot/20260519-context7-source.sql
+
+        # Library seed list: name → context7 ID
+        declare -A LIBS=(
+          ["Astro"]="/withastro/docs"
+          ["Svelte"]="/sveltejs/svelte"
+          ["Playwright"]="/microsoft/playwright"
+          ["Keycloak"]="/keycloak/keycloak-documentation"
+          ["LiveKit"]="/websites/livekit_io"
+          ["Kubernetes"]="/kubernetes/website"
+          ["SealedSecrets"]="/bitnami-labs/sealed-secrets"
+          ["Anthropic SDK (TS)"]="/anthropic-ai/anthropic-sdk-typescript"
+          ["pgvector"]="/pgvector/pgvector"
+          ["Taskfile (go-task)"]="/go-task/task"
+        )
+
+        SUMMARY=""
+        for NAME in "${!LIBS[@]}"; do
+          LIB_ID="${LIBS[$NAME]}"
+          echo ""
+          echo "=== $NAME ($LIB_ID) ==="
+
+          # Ensure collection exists (idempotent)
+          COL_ID=$(PGPASSWORD="${WEBSITE_DB_PASSWORD}" psql -h localhost -U website -d website -At -c \
+            "INSERT INTO knowledge.collections (name, source, description)
+             VALUES ('context7: $NAME', 'context7_docs', 'context7 docs for $NAME')
+             ON CONFLICT (name) DO UPDATE SET description = EXCLUDED.description
+             RETURNING id;")
+
+          echo "  Collection: $COL_ID"
+
+          COLLECTION_ID="$COL_ID" \
+          LIBRARY_ID="$LIB_ID" \
+          PGURL="$PGURL" \
+            node scripts/knowledge/ingest-context7.mjs || echo "  ⚠ Ingest failed for $NAME — continuing"
+
+          CHUNKS=$(PGPASSWORD="${WEBSITE_DB_PASSWORD}" psql -h localhost -U website -d website -At -c \
+            "SELECT chunk_count FROM knowledge.collections WHERE id = '$COL_ID';")
+          SUMMARY="$SUMMARY\n  $NAME: $CHUNKS chunks"
+        done
+
+        echo ""
+        echo "=== Summary ==="
+        echo -e "$SUMMARY"
+
+  knowledge:ingest-context7:
+    desc: "Ingest a single context7 library (LIBRARY_ID=/org/repo COLLECTION_ID=<uuid> ENV=...)"
+    vars:
+      ENV: '{{.ENV | default "mentolder"}}'
+    cmds:
+      - |
+        if [ -z "{{.LIBRARY_ID}}" ] || [ -z "{{.COLLECTION_ID}}" ]; then
+          echo "Usage: task knowledge:ingest-context7 LIBRARY_ID=/org/repo COLLECTION_ID=<uuid> ENV=<env>"
+          exit 1
+        fi
+
+        source scripts/env-resolve.sh "{{.ENV}}"
+        ctx_flag=""
+        [ "{{.ENV}}" != "dev" ] && ctx_flag="--context $ENV_CONTEXT"
+        NS="${WORKSPACE_NAMESPACE:-workspace}"
+
+        kubectl $ctx_flag -n "$NS" port-forward svc/shared-db 5432:5432 \
+          >/tmp/knowledge-context7-pf.log 2>&1 &
+        PF=$!
+        trap 'kill $PF 2>/dev/null' EXIT
+        sleep 3
+
+        COLLECTION_ID="{{.COLLECTION_ID}}" \
+        LIBRARY_ID="{{.LIBRARY_ID}}" \
+        PGURL="postgres://website:${WEBSITE_DB_PASSWORD}@localhost:5432/website" \
+          node scripts/knowledge/ingest-context7.mjs
+
   coaching:ingest:
     desc: "Ingest a coaching book (PDF/EPUB) into pgvector + coaching.books. Args: -- <file> <slug> [--title=...] [--author=...]"
     cmds:

--- a/docs/superpowers/plans/2026-05-19-context7-knowledge-ingest.md
+++ b/docs/superpowers/plans/2026-05-19-context7-knowledge-ingest.md
@@ -1,0 +1,134 @@
+---
+ticket_id: T000479
+title: Context7 Knowledge Ingest — Implementation Plan
+domains: []
+status: active
+pr_number: null
+---
+
+# Context7 Knowledge Ingest — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Index documentation for 10 key project libraries (from the context7 MCP) into the pgvector knowledge system, so coding agents can RAG-query up-to-date library docs alongside existing PR history, specs, and bug tickets.
+
+**Architecture:**
+- New `source` value `context7_docs` added to the `knowledge.collections` CHECK constraint
+- New `scripts/knowledge/ingest-context7.mjs` that fetches markdown from `https://context7.com/api/v1/{libraryId}?tokens=20000` and ingests it with a markdown-aware chunker (split at `##`/`###` headers, not plain text)
+- New `knowledge:seed-context7` Taskfile task: port-forwards shared-db, creates the 10 collections (idempotent), runs ingest for each
+- `CollectionSource` TypeScript type updated in `website/src/lib/knowledge-db.ts`
+
+**Why markdown chunking matters:** context7 returns structured markdown with H2/H3 section headers. Splitting at header boundaries keeps each chunk topically coherent (e.g. "Room.connect() options" stays together), producing far better RAG recall than the existing `chunkPlain` (which cuts at arbitrary character boundaries).
+
+---
+
+## Library Seed List
+
+| Library | context7 ID | Benchmark | Snippets |
+|---------|-------------|-----------|---------|
+| Astro | `/withastro/docs` | 85.67 | 2711 |
+| Svelte | `/sveltejs/svelte` | — | — |
+| Playwright | `/microsoft/playwright` | — | — |
+| Keycloak | `/keycloak/keycloak-documentation` | — | — |
+| LiveKit | `/websites/livekit_io` | 80.92 | 39K |
+| Kubernetes | `/kubernetes/website` | — | — |
+| SealedSecrets | `/bitnami-labs/sealed-secrets` | 82.25 | 626 |
+| Anthropic SDK (TS) | `/anthropic-ai/anthropic-sdk-typescript` | — | — |
+| pgvector | `/pgvector/pgvector` | — | — |
+| Taskfile (go-task) | `/go-task/task` | — | — |
+
+> IDs that show `—` are well-known slugs; the ingest script validates at runtime (404 → skip + warn).
+
+---
+
+## File Map
+
+| Action | Path |
+|--------|------|
+| Create | `scripts/one-shot/20260519-context7-source.sql` |
+| Create | `scripts/knowledge/ingest-context7.mjs` |
+| Modify | `website/src/lib/knowledge-db.ts` |
+| Modify | `Taskfile.yml` |
+
+---
+
+## Implementation Steps
+
+- [ ] **Step 1 — SQL migration** (`scripts/one-shot/20260519-context7-source.sql`)
+  - Drop `collections_source_check` and re-add with `context7_docs` appended
+  - Also add `crawl_config` idempotently (may already exist)
+  - Header comment: run on BOTH clusters after deploy
+
+- [ ] **Step 2 — TypeScript type** (`website/src/lib/knowledge-db.ts`)
+  - Add `'context7_docs'` to the `CollectionSource` union type
+  - No other changes needed (the type flows into `createCollection` / `listCollections` automatically)
+
+- [ ] **Step 3 — Ingest script** (`scripts/knowledge/ingest-context7.mjs`)
+
+  Required env vars:
+  - `COLLECTION_ID` — UUID of target collection
+  - `LIBRARY_ID` — context7 library ID (e.g. `/withastro/docs`)
+  - `PGURL` — full postgres connection string
+  - `VOYAGE_API_KEY` or `LLM_ENABLED=true` for embeddings
+
+  Algorithm:
+  1. `GET https://context7.com/api/v1${LIBRARY_ID}?tokens=20000` — raw markdown response
+  2. `chunkMarkdown(text)` — split at `\n## ` and `\n### ` boundaries; if a section > 1200 chars, sub-chunk at paragraph breaks; prepend the section header to each sub-chunk for context
+  3. Embed all chunks via existing `embedAll()` from `lib-knowledge-pg.mjs`
+  4. `upsertDocumentAndChunks()` — one document per library, `source_uri = https://context7.com${LIBRARY_ID}`
+  5. `bumpCollectionStats()`
+
+  Error handling:
+  - 404 from context7 API → exit 0 with warning (don't fail the seed loop)
+  - Empty response (<200 chars) → same
+  - Embed failure → exit 1 (propagate so caller can retry)
+
+- [ ] **Step 4 — Taskfile tasks** (add to `Taskfile.yml` after `knowledge:crawl`)
+
+  ```
+  knowledge:seed-context7:
+    desc: "Create + ingest all 10 context7 library collections (ENV=mentolder|korczewski)"
+  ```
+
+  The task:
+  1. Port-forwards `shared-db` to `localhost:5432` (same pattern as `knowledge:crawl`)
+  2. Runs the SQL migration (idempotent)
+  3. For each of the 10 libraries: INSERT collection ON CONFLICT DO NOTHING, then calls `ingest-context7.mjs`
+  4. Prints a summary table of chunk counts on completion
+
+  Also add:
+  ```
+  knowledge:ingest-context7:
+    desc: "Ingest a single context7 library (LIBRARY_ID=/org/repo COLLECTION_ID=<uuid> ENV=...)"
+  ```
+  For ad-hoc re-ingestion of a single library without recreating all 10.
+
+- [ ] **Step 5 — Verification**
+  - `task test:all` → green (TS type change is additive; no test touches `CollectionSource` enum)
+  - `task knowledge:seed-context7 ENV=mentolder` — dry-run check: confirm port-forward connects, SQL runs, at least one ingest succeeds (Astro or SealedSecrets as smoke test)
+
+---
+
+## Post-Deploy
+
+Apply the SQL migration to both clusters:
+```bash
+task workspace:psql ENV=mentolder -- website < scripts/one-shot/20260519-context7-source.sql
+task workspace:psql ENV=korczewski -- website < scripts/one-shot/20260519-context7-source.sql
+```
+
+Then seed:
+```bash
+task knowledge:seed-context7 ENV=mentolder
+task knowledge:seed-context7 ENV=korczewski
+```
+
+No rollout needed — the ingest runs locally via port-forward.
+
+---
+
+## Not In Scope
+
+- A scheduled CronJob for weekly re-ingestion (future work; can be added once the collections exist)
+- A UI toggle in `/admin/knowledge` for context7 collections (collections are visible there already via `listCollections`)
+- Ingesting context7 docs directly from within the cluster (no Ingress for context7 → keep it as a local-run script)

--- a/docs/superpowers/plans/2026-05-19-context7-knowledge-ingest.md
+++ b/docs/superpowers/plans/2026-05-19-context7-knowledge-ingest.md
@@ -54,16 +54,16 @@ pr_number: null
 
 ## Implementation Steps
 
-- [ ] **Step 1 — SQL migration** (`scripts/one-shot/20260519-context7-source.sql`)
+- [x] **Step 1 — SQL migration** (`scripts/one-shot/20260519-context7-source.sql`)
   - Drop `collections_source_check` and re-add with `context7_docs` appended
   - Also add `crawl_config` idempotently (may already exist)
   - Header comment: run on BOTH clusters after deploy
 
-- [ ] **Step 2 — TypeScript type** (`website/src/lib/knowledge-db.ts`)
+- [x] **Step 2 — TypeScript type** (`website/src/lib/knowledge-db.ts`)
   - Add `'context7_docs'` to the `CollectionSource` union type
   - No other changes needed (the type flows into `createCollection` / `listCollections` automatically)
 
-- [ ] **Step 3 — Ingest script** (`scripts/knowledge/ingest-context7.mjs`)
+- [x] **Step 3 — Ingest script** (`scripts/knowledge/ingest-context7.mjs`)
 
   Required env vars:
   - `COLLECTION_ID` — UUID of target collection
@@ -83,7 +83,7 @@ pr_number: null
   - Empty response (<200 chars) → same
   - Embed failure → exit 1 (propagate so caller can retry)
 
-- [ ] **Step 4 — Taskfile tasks** (add to `Taskfile.yml` after `knowledge:crawl`)
+- [x] **Step 4 — Taskfile tasks** (add to `Taskfile.yml` after `knowledge:crawl`)
 
   ```
   knowledge:seed-context7:
@@ -103,7 +103,7 @@ pr_number: null
   ```
   For ad-hoc re-ingestion of a single library without recreating all 10.
 
-- [ ] **Step 5 — Verification**
+- [x] **Step 5 — Verification**
   - `task test:all` → green (TS type change is additive; no test touches `CollectionSource` enum)
   - `task knowledge:seed-context7 ENV=mentolder` — dry-run check: confirm port-forward connects, SQL runs, at least one ingest succeeds (Astro or SealedSecrets as smoke test)
 

--- a/scripts/knowledge/ingest-context7.mjs
+++ b/scripts/knowledge/ingest-context7.mjs
@@ -1,0 +1,192 @@
+#!/usr/bin/env node
+/**
+ * ingest-context7.mjs — Fetch markdown docs from context7 API and ingest into
+ * a pgvector knowledge collection with markdown-aware chunking.
+ *
+ * Required env vars:
+ *   COLLECTION_ID   UUID of the target knowledge.collections row
+ *   LIBRARY_ID      context7 library path (e.g. /withastro/docs)
+ *   PGURL           Full postgres connection string
+ *   VOYAGE_API_KEY  (or LLM_ENABLED=true + TEI running) for embeddings
+ *
+ * Optional env vars:
+ *   TOKENS          Max tokens to request from context7 (default 20000)
+ */
+
+import { sha256, embedAll, upsertDocumentAndChunks, bumpCollectionStats } from './lib-knowledge-pg.mjs';
+import pg from 'pg';
+
+const { Pool } = pg;
+
+const COLLECTION_ID = process.env.COLLECTION_ID;
+const LIBRARY_ID    = process.env.LIBRARY_ID;
+const PGURL         = process.env.PGURL;
+const TOKENS        = Number(process.env.TOKENS || 20000);
+
+if (!COLLECTION_ID) { console.error('COLLECTION_ID is required'); process.exit(1); }
+if (!LIBRARY_ID)    { console.error('LIBRARY_ID is required');    process.exit(1); }
+if (!PGURL)         { console.error('PGURL is required');         process.exit(1); }
+
+const CONTEXT7_BASE = 'https://context7.com/api/v1';
+const FETCH_TIMEOUT = 30_000;
+const MIN_CONTENT_CHARS = 200;
+const MAX_CHUNK_CHARS = 1200;
+
+function makePoolFromUrl(pgurl) {
+  const u = new URL(pgurl);
+  return new Pool({
+    host:     u.hostname,
+    port:     Number(u.port || 5432),
+    database: u.pathname.replace(/^\//, ''),
+    user:     u.username,
+    password: decodeURIComponent(u.password),
+  });
+}
+
+/**
+ * Markdown-aware chunker: splits at ## / ### boundaries, preserving the heading
+ * in each chunk for context. Oversized sections get sub-chunked at paragraph
+ * breaks (\n\n).
+ */
+function chunkMarkdown(text) {
+  const HEADING_RE = /^#{2,3}\s/m;
+  const sections = [];
+  let currentHeading = '';
+  let buf = '';
+
+  for (const line of text.split('\n')) {
+    if (HEADING_RE.test(line) && buf.length > 0) {
+      sections.push({ heading: currentHeading, text: buf.trim() });
+      currentHeading = line;
+      buf = '';
+    } else if (HEADING_RE.test(line)) {
+      currentHeading = line;
+    }
+    buf += line + '\n';
+  }
+  if (buf.trim().length > 0) {
+    sections.push({ heading: currentHeading, text: buf.trim() });
+  }
+
+  const chunks = [];
+  let pos = 0;
+
+  for (const section of sections) {
+    if (section.text.length <= MAX_CHUNK_CHARS) {
+      chunks.push({ position: pos++, text: section.text });
+      continue;
+    }
+
+    // Sub-chunk at paragraph breaks
+    const paragraphs = section.text.split(/\n\n+/);
+    let subBuf = section.heading ? section.heading + '\n\n' : '';
+
+    for (const para of paragraphs) {
+      if (subBuf.length + para.length + 2 > MAX_CHUNK_CHARS && subBuf.trim().length > 0) {
+        chunks.push({ position: pos++, text: subBuf.trim() });
+        // Prepend heading to next sub-chunk for context
+        subBuf = section.heading ? section.heading + ' (cont.)\n\n' : '';
+      }
+      subBuf += para + '\n\n';
+    }
+    if (subBuf.trim().length > 0) {
+      chunks.push({ position: pos++, text: subBuf.trim() });
+    }
+  }
+
+  return chunks;
+}
+
+async function fetchContext7(libraryId, tokens) {
+  const url = `${CONTEXT7_BASE}${libraryId}?tokens=${tokens}`;
+  console.log(`  GET ${url}`);
+
+  const ctrl = new AbortController();
+  const t = setTimeout(() => ctrl.abort(), FETCH_TIMEOUT);
+  try {
+    const res = await fetch(url, {
+      signal: ctrl.signal,
+      headers: { 'Accept': 'text/plain, text/markdown' },
+    });
+    clearTimeout(t);
+
+    if (res.status === 404) {
+      console.warn(`  ⚠ 404 — library "${libraryId}" not found on context7. Skipping.`);
+      return null;
+    }
+    if (!res.ok) {
+      throw new Error(`context7 HTTP ${res.status}: ${await res.text()}`);
+    }
+
+    const text = await res.text();
+    if (text.length < MIN_CONTENT_CHARS) {
+      console.warn(`  ⚠ Response too short (${text.length} chars). Skipping.`);
+      return null;
+    }
+
+    return text;
+  } catch (err) {
+    clearTimeout(t);
+    if (err.name === 'AbortError') {
+      throw new Error(`context7 request timed out after ${FETCH_TIMEOUT}ms`);
+    }
+    throw err;
+  }
+}
+
+async function main() {
+  const pool = makePoolFromUrl(PGURL);
+
+  try {
+    // Verify collection exists
+    const colRes = await pool.query(
+      `SELECT name FROM knowledge.collections WHERE id = $1`,
+      [COLLECTION_ID],
+    );
+    if (colRes.rows.length === 0) {
+      console.error(`Collection ${COLLECTION_ID} not found`);
+      process.exit(1);
+    }
+    const colName = colRes.rows[0].name;
+
+    console.log(`Ingesting context7 library: ${LIBRARY_ID}`);
+    console.log(`  Collection: "${colName}" (${COLLECTION_ID})`);
+    console.log(`  Tokens: ${TOKENS}`);
+
+    const markdown = await fetchContext7(LIBRARY_ID, TOKENS);
+    if (!markdown) {
+      console.log('  Nothing to ingest — exiting cleanly.');
+      process.exit(0);
+    }
+
+    console.log(`  Fetched ${markdown.length} chars`);
+
+    const rawChunks = chunkMarkdown(markdown);
+    console.log(`  Split into ${rawChunks.length} chunks`);
+
+    console.log('  Embedding…');
+    const embeddings = await embedAll(rawChunks.map(c => c.text));
+
+    const chunks = rawChunks.map((c, i) => ({ ...c, embedding: embeddings[i] }));
+
+    const sourceUri = `https://context7.com${LIBRARY_ID}`;
+
+    await upsertDocumentAndChunks(pool, {
+      collectionId: COLLECTION_ID,
+      title:        `context7: ${LIBRARY_ID}`,
+      sourceUri,
+      rawText:      markdown,
+      hash:         sha256(markdown),
+      metadata:     { libraryId: LIBRARY_ID, tokens: TOKENS },
+      chunks,
+    });
+
+    console.log('  Bumping collection stats…');
+    await bumpCollectionStats(pool, COLLECTION_ID);
+    console.log('  ✓ Done.');
+  } finally {
+    await pool.end();
+  }
+}
+
+main().catch(err => { console.error(err); process.exit(1); });

--- a/scripts/one-shot/20260519-context7-source.sql
+++ b/scripts/one-shot/20260519-context7-source.sql
@@ -1,0 +1,14 @@
+-- scripts/one-shot/20260519-context7-source.sql
+-- Adds context7_docs as a valid source for knowledge.collections.
+-- Run on BOTH clusters after deploy:
+--   task workspace:psql ENV=mentolder -- website < scripts/one-shot/20260519-context7-source.sql
+--   task workspace:psql ENV=korczewski -- website < scripts/one-shot/20260519-context7-source.sql
+
+-- Drop the old CHECK constraint.
+ALTER TABLE knowledge.collections
+  DROP CONSTRAINT IF EXISTS collections_source_check;
+
+-- Re-add with context7_docs included.
+ALTER TABLE knowledge.collections
+  ADD CONSTRAINT collections_source_check
+    CHECK (source IN ('pr_history','specs_plans','claude_md','bug_tickets','custom','web_crawl','context7_docs'));

--- a/website/src/lib/knowledge-db.ts
+++ b/website/src/lib/knowledge-db.ts
@@ -32,7 +32,7 @@ function p(): Pool {
 
 export function __setPoolForTests(testPool: Pool): void { _pool = testPool; }
 
-export type CollectionSource = 'pr_history' | 'specs_plans' | 'claude_md' | 'bug_tickets' | 'custom' | 'web_crawl';
+export type CollectionSource = 'pr_history' | 'specs_plans' | 'claude_md' | 'bug_tickets' | 'custom' | 'web_crawl' | 'context7_docs';
 
 export interface CrawlConfig {
   startUrl: string;


### PR DESCRIPTION
## Summary
- New `context7_docs` source type for the knowledge system
- Markdown-aware chunker splits at H2/H3 boundaries → topically coherent chunks for better RAG recall
- Ingest script fetches from context7 API (`/api/v1/{libraryId}?tokens=20000`)
- Seeds 10 key project libraries: Astro, Svelte, Playwright, Keycloak, LiveKit, Kubernetes, SealedSecrets, Anthropic SDK (TS), pgvector, Taskfile
- Taskfile tasks for batch seed (`knowledge:seed-context7`) and single re-ingest (`knowledge:ingest-context7`)

## Test plan
- [x] `node --check scripts/knowledge/ingest-context7.mjs` — syntax ok
- [x] `bash scripts/admin-menu-gate.sh` — Gate PASSED
- [x] TypeScript type change is additive (no existing code touches `CollectionSource` enum values)
- [ ] `task knowledge:seed-context7 ENV=mentolder` — post-merge smoke test

## Post-Deploy
```bash
task workspace:psql ENV=mentolder -- website < scripts/one-shot/20260519-context7-source.sql
task workspace:psql ENV=korczewski -- website < scripts/one-shot/20260519-context7-source.sql
task knowledge:seed-context7 ENV=mentolder
task knowledge:seed-context7 ENV=korczewski
```

Co-Authored-By: claude-opus-4-6