### PR TITLE
fix(website): add NOT VALID to brand FK constraints + /login route + spec fixes

### DIFF
--- a/tests/e2e/specs/fa-26-bug-report-form.spec.ts
+++ b/tests/e2e/specs/fa-26-bug-report-form.spec.ts
@@ -46,7 +46,7 @@ test.describe('FA-26: Bug report API', () => {
     expect(res.status()).toBe(200);
     const body = await res.json();
     expect(body.success).toBe(true);
-    expect(body.ticketId).toMatch(/^BR-\d{8}-[0-9a-f]{4}$/);
+    expect(body.ticketId).toMatch(/^T\d+$/);
   });
 
   test('POST /api/bug-report with description too long returns 400', async ({ request }) => {
@@ -61,8 +61,8 @@ test.describe('FA-26: Bug report API', () => {
   });
 
   test('GET /api/status with valid ticket format — API responds correctly', async ({ request }) => {
-    // Verify the ticket status API works (uses same BR-format)
-    const res = await request.get(`${BASE}/api/status?id=BR-20260101-0000`);
+    // Verify the ticket status API works (uses T-format IDs)
+    const res = await request.get(`${BASE}/api/status?id=T000001`);
     expect([200, 404]).toContain(res.status());
     const body = await res.json();
     expect(typeof body).toBe('object');

--- a/website/src/lib/website-db.ts
+++ b/website/src/lib/website-db.ts
@@ -862,7 +862,7 @@ export async function initServiceConfigTable(): Promise<void> {
       DO $$
       BEGIN
         IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'service_config_brand_fkey') THEN
-          ALTER TABLE service_config ADD CONSTRAINT service_config_brand_fkey FOREIGN KEY (brand) REFERENCES public.brands(id) ON UPDATE CASCADE ON DELETE RESTRICT;
+          ALTER TABLE service_config ADD CONSTRAINT service_config_brand_fkey FOREIGN KEY (brand) REFERENCES public.brands(id) ON UPDATE CASCADE ON DELETE RESTRICT NOT VALID;
         END IF;
       END $$;
   `);
@@ -900,7 +900,7 @@ export async function initLeistungenConfigTable(): Promise<void> {
       DO $$
       BEGIN
         IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'leistungen_config_brand_fkey') THEN
-          ALTER TABLE leistungen_config ADD CONSTRAINT leistungen_config_brand_fkey FOREIGN KEY (brand) REFERENCES public.brands(id) ON UPDATE CASCADE ON DELETE RESTRICT;
+          ALTER TABLE leistungen_config ADD CONSTRAINT leistungen_config_brand_fkey FOREIGN KEY (brand) REFERENCES public.brands(id) ON UPDATE CASCADE ON DELETE RESTRICT NOT VALID;
         END IF;
       END $$;
   `);
@@ -940,7 +940,7 @@ export async function initSiteSettingsTable(): Promise<void> {
       DO $$
       BEGIN
         IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'site_settings_brand_fkey') THEN
-          ALTER TABLE site_settings ADD CONSTRAINT site_settings_brand_fkey FOREIGN KEY (brand) REFERENCES public.brands(id) ON UPDATE CASCADE ON DELETE RESTRICT;
+          ALTER TABLE site_settings ADD CONSTRAINT site_settings_brand_fkey FOREIGN KEY (brand) REFERENCES public.brands(id) ON UPDATE CASCADE ON DELETE RESTRICT NOT VALID;
         END IF;
       END $$;
   `);
@@ -1004,7 +1004,7 @@ export async function initLegalPagesTable(): Promise<void> {
       DO $$
       BEGIN
         IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'legal_pages_brand_fkey') THEN
-          ALTER TABLE legal_pages ADD CONSTRAINT legal_pages_brand_fkey FOREIGN KEY (brand) REFERENCES public.brands(id) ON UPDATE CASCADE ON DELETE RESTRICT;
+          ALTER TABLE legal_pages ADD CONSTRAINT legal_pages_brand_fkey FOREIGN KEY (brand) REFERENCES public.brands(id) ON UPDATE CASCADE ON DELETE RESTRICT NOT VALID;
         END IF;
       END $$;
   `);
@@ -1064,7 +1064,7 @@ export async function initReferenzenTable(): Promise<void> {
       DO $$
       BEGIN
         IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'referenzen_config_brand_fkey') THEN
-          ALTER TABLE referenzen_config ADD CONSTRAINT referenzen_config_brand_fkey FOREIGN KEY (brand) REFERENCES public.brands(id) ON UPDATE CASCADE ON DELETE RESTRICT;
+          ALTER TABLE referenzen_config ADD CONSTRAINT referenzen_config_brand_fkey FOREIGN KEY (brand) REFERENCES public.brands(id) ON UPDATE CASCADE ON DELETE RESTRICT NOT VALID;
         END IF;
       END $$;
   `);
@@ -2554,7 +2554,7 @@ async function initBookingProjectLinks(): Promise<void> {
       DO $$
       BEGIN
         IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'booking_project_links_brand_fkey') THEN
-          ALTER TABLE booking_project_links ADD CONSTRAINT booking_project_links_brand_fkey FOREIGN KEY (brand) REFERENCES public.brands(id) ON UPDATE CASCADE ON DELETE RESTRICT;
+          ALTER TABLE booking_project_links ADD CONSTRAINT booking_project_links_brand_fkey FOREIGN KEY (brand) REFERENCES public.brands(id) ON UPDATE CASCADE ON DELETE RESTRICT NOT VALID;
         END IF;
       END $$;
   `);
@@ -2582,7 +2582,7 @@ async function initBookingInvoiceLinksTable(): Promise<void> {
       DO $$
       BEGIN
         IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'booking_invoice_links_brand_fkey') THEN
-          ALTER TABLE booking_invoice_links ADD CONSTRAINT booking_invoice_links_brand_fkey FOREIGN KEY (brand) REFERENCES public.brands(id) ON UPDATE CASCADE ON DELETE RESTRICT;
+          ALTER TABLE booking_invoice_links ADD CONSTRAINT booking_invoice_links_brand_fkey FOREIGN KEY (brand) REFERENCES public.brands(id) ON UPDATE CASCADE ON DELETE RESTRICT NOT VALID;
         END IF;
       END $$;
   `);
@@ -2705,7 +2705,7 @@ async function initSlotWhitelistTable(): Promise<void> {
       DO $$
       BEGIN
         IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'slot_whitelist_brand_fkey') THEN
-          ALTER TABLE slot_whitelist ADD CONSTRAINT slot_whitelist_brand_fkey FOREIGN KEY (brand) REFERENCES public.brands(id) ON UPDATE CASCADE ON DELETE RESTRICT;
+          ALTER TABLE slot_whitelist ADD CONSTRAINT slot_whitelist_brand_fkey FOREIGN KEY (brand) REFERENCES public.brands(id) ON UPDATE CASCADE ON DELETE RESTRICT NOT VALID;
         END IF;
       END $$;
   `);
@@ -2786,7 +2786,7 @@ async function initFreeTimeWindowsTable(): Promise<void> {
       DO $$
       BEGIN
         IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'free_time_windows_brand_fkey') THEN
-          ALTER TABLE free_time_windows ADD CONSTRAINT free_time_windows_brand_fkey FOREIGN KEY (brand) REFERENCES public.brands(id) ON UPDATE CASCADE ON DELETE RESTRICT;
+          ALTER TABLE free_time_windows ADD CONSTRAINT free_time_windows_brand_fkey FOREIGN KEY (brand) REFERENCES public.brands(id) ON UPDATE CASCADE ON DELETE RESTRICT NOT VALID;
         END IF;
       END $$;
   `);
@@ -3157,7 +3157,7 @@ async function initInvoiceCountersTable(): Promise<void> {
       DO $$
       BEGIN
         IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'invoice_counters_brand_fkey') THEN
-          ALTER TABLE invoice_counters ADD CONSTRAINT invoice_counters_brand_fkey FOREIGN KEY (brand) REFERENCES public.brands(id) ON UPDATE CASCADE ON DELETE RESTRICT;
+          ALTER TABLE invoice_counters ADD CONSTRAINT invoice_counters_brand_fkey FOREIGN KEY (brand) REFERENCES public.brands(id) ON UPDATE CASCADE ON DELETE RESTRICT NOT VALID;
         END IF;
       END $$;
   `);
@@ -3684,7 +3684,7 @@ export async function initBillingTables(): Promise<void> {
       DO $$
       BEGIN
         IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'billing_customers_brand_fkey') THEN
-          ALTER TABLE billing_customers ADD CONSTRAINT billing_customers_brand_fkey FOREIGN KEY (brand) REFERENCES public.brands(id) ON UPDATE CASCADE ON DELETE RESTRICT;
+          ALTER TABLE billing_customers ADD CONSTRAINT billing_customers_brand_fkey FOREIGN KEY (brand) REFERENCES public.brands(id) ON UPDATE CASCADE ON DELETE RESTRICT NOT VALID;
         END IF;
       END $$;
   `);
@@ -3768,7 +3768,7 @@ export async function initBillingTables(): Promise<void> {
       DO $$
       BEGIN
         IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'billing_invoices_brand_fkey') THEN
-          ALTER TABLE billing_invoices ADD CONSTRAINT billing_invoices_brand_fkey FOREIGN KEY (brand) REFERENCES public.brands(id) ON UPDATE CASCADE ON DELETE RESTRICT;
+          ALTER TABLE billing_invoices ADD CONSTRAINT billing_invoices_brand_fkey FOREIGN KEY (brand) REFERENCES public.brands(id) ON UPDATE CASCADE ON DELETE RESTRICT NOT VALID;
         END IF;
       END $$;
   `);
@@ -3815,7 +3815,7 @@ export async function initBillingTables(): Promise<void> {
       DO $$
       BEGIN
         IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'billing_invoice_dunnings_brand_fkey') THEN
-          ALTER TABLE billing_invoice_dunnings ADD CONSTRAINT billing_invoice_dunnings_brand_fkey FOREIGN KEY (brand) REFERENCES public.brands(id) ON UPDATE CASCADE ON DELETE RESTRICT;
+          ALTER TABLE billing_invoice_dunnings ADD CONSTRAINT billing_invoice_dunnings_brand_fkey FOREIGN KEY (brand) REFERENCES public.brands(id) ON UPDATE CASCADE ON DELETE RESTRICT NOT VALID;
         END IF;
       END $$;
   `);
@@ -3846,7 +3846,7 @@ export async function initBillingTables(): Promise<void> {
       DO $$
       BEGIN
         IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'billing_invoice_payments_brand_fkey') THEN
-          ALTER TABLE billing_invoice_payments ADD CONSTRAINT billing_invoice_payments_brand_fkey FOREIGN KEY (brand) REFERENCES public.brands(id) ON UPDATE CASCADE ON DELETE RESTRICT;
+          ALTER TABLE billing_invoice_payments ADD CONSTRAINT billing_invoice_payments_brand_fkey FOREIGN KEY (brand) REFERENCES public.brands(id) ON UPDATE CASCADE ON DELETE RESTRICT NOT VALID;
         END IF;
       END $$;
   `);
@@ -3873,7 +3873,7 @@ export async function initBillingTables(): Promise<void> {
       DO $$
       BEGIN
         IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'billing_quotes_brand_fkey') THEN
-          ALTER TABLE billing_quotes ADD CONSTRAINT billing_quotes_brand_fkey FOREIGN KEY (brand) REFERENCES public.brands(id) ON UPDATE CASCADE ON DELETE RESTRICT;
+          ALTER TABLE billing_quotes ADD CONSTRAINT billing_quotes_brand_fkey FOREIGN KEY (brand) REFERENCES public.brands(id) ON UPDATE CASCADE ON DELETE RESTRICT NOT VALID;
         END IF;
       END $$;
   `);
@@ -3901,7 +3901,7 @@ export async function initBillingTables(): Promise<void> {
       DO $$
       BEGIN
         IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'billing_nachweis_brand_fkey') THEN
-          ALTER TABLE billing_nachweis ADD CONSTRAINT billing_nachweis_brand_fkey FOREIGN KEY (brand) REFERENCES public.brands(id) ON UPDATE CASCADE ON DELETE RESTRICT;
+          ALTER TABLE billing_nachweis ADD CONSTRAINT billing_nachweis_brand_fkey FOREIGN KEY (brand) REFERENCES public.brands(id) ON UPDATE CASCADE ON DELETE RESTRICT NOT VALID;
         END IF;
       END $$;
   `);
@@ -3940,7 +3940,7 @@ export async function initBillingTables(): Promise<void> {
       DO $$
       BEGIN
         IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'billing_suppliers_brand_fkey') THEN
-          ALTER TABLE billing_suppliers ADD CONSTRAINT billing_suppliers_brand_fkey FOREIGN KEY (brand) REFERENCES public.brands(id) ON UPDATE CASCADE ON DELETE RESTRICT;
+          ALTER TABLE billing_suppliers ADD CONSTRAINT billing_suppliers_brand_fkey FOREIGN KEY (brand) REFERENCES public.brands(id) ON UPDATE CASCADE ON DELETE RESTRICT NOT VALID;
         END IF;
       END $$;
   `);
@@ -3968,7 +3968,7 @@ export async function initBillingTables(): Promise<void> {
       DO $$
       BEGIN
         IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'supplier_invoices_brand_fkey') THEN
-          ALTER TABLE supplier_invoices ADD CONSTRAINT supplier_invoices_brand_fkey FOREIGN KEY (brand) REFERENCES public.brands(id) ON UPDATE CASCADE ON DELETE RESTRICT;
+          ALTER TABLE supplier_invoices ADD CONSTRAINT supplier_invoices_brand_fkey FOREIGN KEY (brand) REFERENCES public.brands(id) ON UPDATE CASCADE ON DELETE RESTRICT NOT VALID;
         END IF;
       END $$;
   `);
@@ -4114,7 +4114,7 @@ export async function initTaxMonitorTables(): Promise<void> {
       DO $$
       BEGIN
         IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'tax_mode_changes_brand_fkey') THEN
-          ALTER TABLE tax_mode_changes ADD CONSTRAINT tax_mode_changes_brand_fkey FOREIGN KEY (brand) REFERENCES public.brands(id) ON UPDATE CASCADE ON DELETE RESTRICT;
+          ALTER TABLE tax_mode_changes ADD CONSTRAINT tax_mode_changes_brand_fkey FOREIGN KEY (brand) REFERENCES public.brands(id) ON UPDATE CASCADE ON DELETE RESTRICT NOT VALID;
         END IF;
       END $$;
   `);
@@ -4141,7 +4141,7 @@ export async function initEurTables(): Promise<void> {
       DO $$
       BEGIN
         IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'eur_bookings_brand_fkey') THEN
-          ALTER TABLE eur_bookings ADD CONSTRAINT eur_bookings_brand_fkey FOREIGN KEY (brand) REFERENCES public.brands(id) ON UPDATE CASCADE ON DELETE RESTRICT;
+          ALTER TABLE eur_bookings ADD CONSTRAINT eur_bookings_brand_fkey FOREIGN KEY (brand) REFERENCES public.brands(id) ON UPDATE CASCADE ON DELETE RESTRICT NOT VALID;
         END IF;
       END $$;
   `);
@@ -4167,7 +4167,7 @@ export async function initEurTables(): Promise<void> {
       DO $$
       BEGIN
         IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'assets_brand_fkey') THEN
-          ALTER TABLE assets ADD CONSTRAINT assets_brand_fkey FOREIGN KEY (brand) REFERENCES public.brands(id) ON UPDATE CASCADE ON DELETE RESTRICT;
+          ALTER TABLE assets ADD CONSTRAINT assets_brand_fkey FOREIGN KEY (brand) REFERENCES public.brands(id) ON UPDATE CASCADE ON DELETE RESTRICT NOT VALID;
         END IF;
       END $$;
   `);

--- a/website/src/pages/login.astro
+++ b/website/src/pages/login.astro
@@ -1,0 +1,9 @@
+---
+// Force-redirect to Keycloak SSO — /login is a stable public entry point
+// that SA-02 T4 and any external link can use.
+import type { APIContext } from 'astro';
+export const prerender = false;
+
+const { redirect } = Astro;
+return redirect('/api/auth/login', 302);
+---


### PR DESCRIPTION
## Summary

- **Billing/booking 500 on cold start**: 21 `ALTER TABLE ADD CONSTRAINT ... REFERENCES public.brands(id)` calls were failing with FK violation when test-brand rows existed in billing/booking/config tables. Changed all to `NOT VALID` — existing rows skip validation, new writes are still enforced. Fixes `GET /api/admin/billing/drafts`, `GET /api/admin/billing/draft-count`, and `POST /api/booking` returning 500 after every pod restart.
- **SA-02 T4**: Added `website/src/pages/login.astro` that redirects to `/api/auth/login` (302). The `/login` route was missing entirely, returning 404.
- **FA-26 spec**: Updated `ticketId` regex from `^BR-\d{8}-[0-9a-f]{4}$` → `^T\d+$` after the ticket system migrated to internal T-format IDs.

## Test plan
- [ ] Deploy to mentolder: `task feature:website`
- [ ] `GET /api/admin/billing/drafts` returns 200 (not 500) after deploy
- [ ] `POST /api/booking` with a past slot returns 409 (not 500)
- [ ] `GET /login` redirects to Keycloak OIDC endpoint
- [ ] Re-run E2E: `SA-02`, `FA-16`, `FA-26` should all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)