### PR TITLE
chore(skills): ensure submodules are initialized in worktrees (take 2)

### DIFF
--- a/.claude/skills/dev-flow-execute/SKILL.md
+++ b/.claude/skills/dev-flow-execute/SKILL.md
@@ -51,6 +51,7 @@ Bevor irgendein Agent Code schreibt, Branch auf `origin/main` rebsen — verhind
 ```bash
 git fetch origin main
 git rebase origin/main
+git submodule update --init --recursive
 ```
 
 Falls `git rebase` Konflikte meldet:

--- a/.claude/skills/dev-flow-plan/SKILL.md
+++ b/.claude/skills/dev-flow-plan/SKILL.md
@@ -91,6 +91,7 @@ Falls kein Worktree existiert: Rufe `superpowers:using-git-worktrees` auf. Branc
 > **Branch-Naming-Warnung:** Das native `EnterWorktree` Tool mangelt den Branch-Namen — aus `feature/admin-menu-rules` wird `worktree-feature+admin-menu-rules` (Slash → Plus, Prefix `worktree-`). Das verletzt die Repo-Konvention `feature/*`. Verifiziere nach dem Anlegen mit `git branch --show-current` und benenne ggf. um: `git branch -m feature/<slug>` (oder pushe direkt ohne Umbennung, dann `git push -u origin feature/<slug>:feature/<slug>`). Der vorhersagbarere Pfad ist die manuelle Form:
 > ```bash
 > git worktree add -b feature/<slug> .claude/worktrees/<slug> origin/main
+> cd .claude/worktrees/<slug> && git submodule update --init --recursive
 > ```
 
 ### Schritt 1.5: Optionale Asset-Sammlung
@@ -359,7 +360,11 @@ Falls Worktree bereits existiert: **nicht** `using-git-worktrees` aufrufen — d
 
 Falls kein Worktree existiert: Rufe `superpowers:using-git-worktrees` auf. Branch-Name: `fix/<kurzer-slug>`.
 
-> **Branch-Naming-Warnung:** Das native `EnterWorktree` Tool mangelt den Branch-Namen (Slash → Plus, Prefix `worktree-`). Verifiziere mit `git branch --show-current` und benenne ggf. um: `git branch -m fix/<slug>`. Vorhersagbar: `git worktree add -b fix/<slug> .claude/worktrees/<slug> origin/main`.
+> **Branch-Naming-Warnung:** Das native `EnterWorktree` Tool mangelt den Branch-Namen (Slash → Plus, Prefix `worktree-`). Verifiziere mit `git branch --show-current` und benenne ggf. um: `git branch -m fix/<slug>`. Vorhersagbar:
+> ```bash
+> git worktree add -b fix/<slug> .claude/worktrees/<slug> origin/main
+> cd .claude/worktrees/<slug> && git submodule update --init --recursive
+> ```
 
 ### Schritt 3: Failing Test schreiben
 
@@ -451,7 +456,11 @@ Falls Worktree bereits existiert: **nicht** `using-git-worktrees` aufrufen — d
 
 Falls kein Worktree existiert: Rufe `superpowers:using-git-worktrees` auf. Branch-Name: `chore/<kurzer-slug>`.
 
-> **Branch-Naming-Warnung:** Das native `EnterWorktree` Tool mangelt den Branch-Namen (Slash → Plus, Prefix `worktree-`). Verifiziere mit `git branch --show-current` und benenne ggf. um: `git branch -m chore/<slug>`. Vorhersagbar: `git worktree add -b chore/<slug> .claude/worktrees/<slug> origin/main`.
+> **Branch-Naming-Warnung:** Das native `EnterWorktree` Tool mangelt den Branch-Namen (Slash → Plus, Prefix `worktree-`). Verifiziere mit `git branch --show-current` und benenne ggf. um: `git branch -m chore/<slug>`. Vorhersagbar:
+> ```bash
+> git worktree add -b chore/<slug> .claude/worktrees/<slug> origin/main
+> cd .claude/worktrees/<slug> && git submodule update --init --recursive
+> ```
 
 ### Schritt 3: Änderung machen
 


### PR DESCRIPTION
## Summary
- Added `git submodule update --init --recursive` to dev-flow-plan (all paths) and dev-flow-execute.
- Addresses T000482 (bats-core missing in worktrees).

Closes T000482