### PR TITLE
fix(knowledge): fix knowledge:seed-context7 task

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -3162,18 +3162,26 @@ tasks:
         [ "{{.ENV}}" != "dev" ] && ctx_flag="--context $ENV_CONTEXT"
         NS="${WORKSPACE_NAMESPACE:-workspace}"
 
-        kubectl $ctx_flag -n "$NS" port-forward svc/shared-db 5432:5432 \
-          >/tmp/knowledge-context7-pf.log 2>&1 &
-        PF=$!
-        trap 'kill $PF 2>/dev/null' EXIT
-        sleep 3
+        WEBSITE_DB_PASSWORD=$(kubectl $ctx_flag get secret workspace-secrets -n "$NS" \
+          -o jsonpath="{.data.WEBSITE_DB_PASSWORD}" 2>/dev/null | base64 -d)
+        if [ -z "$WEBSITE_DB_PASSWORD" ]; then
+          echo "ERROR: WEBSITE_DB_PASSWORD not found in workspace-secrets" >&2; exit 1
+        fi
+        VOYAGE_API_KEY=$(kubectl $ctx_flag get secret workspace-secrets -n "$NS" \
+          -o jsonpath="{.data.VOYAGE_API_KEY}" 2>/dev/null | base64 -d)
+        export VOYAGE_API_KEY
 
-        PGURL="postgres://website:${WEBSITE_DB_PASSWORD}@localhost:5432/website"
-
-        # Apply SQL migration (idempotent)
+        # Apply SQL migration via kubectl exec as postgres (DDL requires table owner)
         echo "=== Applying context7_docs source migration ==="
-        PGPASSWORD="${WEBSITE_DB_PASSWORD}" psql -h localhost -U website -d website \
-          < scripts/one-shot/20260519-context7-source.sql
+        kubectl $ctx_flag exec -i -n "$NS" deploy/shared-db -- \
+          psql -U postgres -d website < scripts/one-shot/20260519-context7-source.sql
+
+        # Helper: run SQL as website user via kubectl exec (avoids port-forward TCP RST crashes)
+        # -q suppresses command completion tags (INSERT 0 1) that pollute $() captures
+        kexec_psql() {
+          kubectl $ctx_flag exec -i -n "$NS" deploy/shared-db -- \
+            psql -U website -d website -q "$@"
+        }
 
         # Library seed list: name → context7 ID
         declare -A LIBS=(
@@ -3189,28 +3197,53 @@ tasks:
           ["Taskfile (go-task)"]="/go-task/task"
         )
 
-        SUMMARY=""
+        # Phase 1: create all collections via kubectl exec (no port-forward needed)
+        echo "=== Phase 1: ensuring collections ==="
+        declare -A COL_IDS
         for NAME in "${!LIBS[@]}"; do
-          LIB_ID="${LIBS[$NAME]}"
-          echo ""
-          echo "=== $NAME ($LIB_ID) ==="
-
-          # Ensure collection exists (idempotent)
-          COL_ID=$(PGPASSWORD="${WEBSITE_DB_PASSWORD}" psql -h localhost -U website -d website -At -c \
+          COL_ID=$(kexec_psql -At -c \
             "INSERT INTO knowledge.collections (name, source, description)
              VALUES ('context7: $NAME', 'context7_docs', 'context7 docs for $NAME')
              ON CONFLICT (name) DO UPDATE SET description = EXCLUDED.description
              RETURNING id;")
+          COL_IDS["$NAME"]="$COL_ID"
+          echo "  $NAME → $COL_ID"
+        done
 
+        # Phase 2: port-forward for Node.js ingestion (pg-pool keeps connection alive)
+        echo ""
+        echo "=== Phase 2: ingesting via context7 API ==="
+        kubectl $ctx_flag -n "$NS" port-forward svc/shared-db 5432:5432 \
+          >/tmp/knowledge-context7-pf.log 2>&1 &
+        PF=$!
+        trap 'kill $PF 2>/dev/null' EXIT
+        sleep 5
+
+        PGURL="postgres://website:${WEBSITE_DB_PASSWORD}@localhost:5432/website"
+        SUMMARY=""
+        for NAME in "${!LIBS[@]}"; do
+          LIB_ID="${LIBS[$NAME]}"
+          COL_ID="${COL_IDS[$NAME]}"
+          echo ""
+          echo "=== $NAME ($LIB_ID) ==="
           echo "  Collection: $COL_ID"
 
           COLLECTION_ID="$COL_ID" \
           LIBRARY_ID="$LIB_ID" \
           PGURL="$PGURL" \
             node scripts/knowledge/ingest-context7.mjs || echo "  ⚠ Ingest failed for $NAME — continuing"
+        done
 
-          CHUNKS=$(PGPASSWORD="${WEBSITE_DB_PASSWORD}" psql -h localhost -U website -d website -At -c \
-            "SELECT chunk_count FROM knowledge.collections WHERE id = '$COL_ID';")
+        # Phase 3: collect counts via kubectl exec (kill port-forward first)
+        kill $PF 2>/dev/null || true
+        sleep 1
+        echo ""
+        echo "=== Phase 3: chunk counts ==="
+        for NAME in "${!LIBS[@]}"; do
+          COL_ID="${COL_IDS[$NAME]}"
+          CHUNKS=$(kexec_psql -At -c \
+            "SELECT COALESCE(chunk_count, 0) FROM knowledge.collections WHERE id = '$COL_ID';" \
+            2>/dev/null || echo "?")
           SUMMARY="$SUMMARY\n  $NAME: $CHUNKS chunks"
         done
 


### PR DESCRIPTION
## Summary

- Fetch `WEBSITE_DB_PASSWORD` and `VOYAGE_API_KEY` from `workspace-secrets` at runtime — `env-resolve.sh` only exports YAML config vars, not k8s secrets
- Run SQL migration (`DROP/ADD CONSTRAINT`) via `kubectl exec` as `postgres` — the `website` role cannot `ALTER TABLE knowledge.collections` (DDL requires table owner)
- Split into 3 phases: `kubectl exec` for collection create/count, port-forward only for Node.js ingestion (`pg-pool` keeps connection alive; standalone `psql` sends TCP RST on close which crashes port-forward)
- Add `-q` flag to `psql` in `kubectl exec` to suppress command completion tags (`INSERT 0 1`) that polluted `$()` captures
- Add `|| true` to `kill $PF` to prevent exit code 2 when port-forward already died

## Result

Both clusters seeded:
- **mentolder**: 8 collections with chunks, 2 skipped (Keycloak + Anthropic SDK — not on context7)
- **korczewski**: same 8/10

## Test plan

- [x] `task knowledge:seed-context7 ENV=mentolder` — ran successfully, all 10 collections created, 8 ingested
- [x] `task knowledge:seed-context7 ENV=korczewski` — ran successfully, same result

🤖 Generated with [Claude Code](https://claude.com/claude-code)