### PR TITLE
fix(knowledge): correct context7 library IDs + fix ingest-context7 task

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -3188,11 +3188,11 @@ tasks:
           ["Astro"]="/withastro/docs"
           ["Svelte"]="/sveltejs/svelte"
           ["Playwright"]="/microsoft/playwright"
-          ["Keycloak"]="/keycloak/keycloak-documentation"
+          ["Keycloak"]="/keycloak/keycloak"
           ["LiveKit"]="/websites/livekit_io"
           ["Kubernetes"]="/kubernetes/website"
           ["SealedSecrets"]="/bitnami-labs/sealed-secrets"
-          ["Anthropic SDK (TS)"]="/anthropic-ai/anthropic-sdk-typescript"
+          ["Anthropic SDK (TS)"]="/anthropics/anthropic-sdk-typescript"
           ["pgvector"]="/pgvector/pgvector"
           ["Taskfile (go-task)"]="/go-task/task"
         )
@@ -3267,11 +3267,17 @@ tasks:
         [ "{{.ENV}}" != "dev" ] && ctx_flag="--context $ENV_CONTEXT"
         NS="${WORKSPACE_NAMESPACE:-workspace}"
 
+        WEBSITE_DB_PASSWORD=$(kubectl $ctx_flag get secret workspace-secrets -n "$NS" \
+          -o jsonpath="{.data.WEBSITE_DB_PASSWORD}" 2>/dev/null | base64 -d)
+        VOYAGE_API_KEY=$(kubectl $ctx_flag get secret workspace-secrets -n "$NS" \
+          -o jsonpath="{.data.VOYAGE_API_KEY}" 2>/dev/null | base64 -d)
+        export VOYAGE_API_KEY
+
         kubectl $ctx_flag -n "$NS" port-forward svc/shared-db 5432:5432 \
           >/tmp/knowledge-context7-pf.log 2>&1 &
         PF=$!
-        trap 'kill $PF 2>/dev/null' EXIT
-        sleep 3
+        trap 'kill $PF 2>/dev/null || true' EXIT
+        sleep 5
 
         COLLECTION_ID="{{.COLLECTION_ID}}" \
         LIBRARY_ID="{{.LIBRARY_ID}}" \


### PR DESCRIPTION
## Summary

- Keycloak: `/keycloak/keycloak-documentation` → `/keycloak/keycloak` (correct ID, 1905 snippets vs 404)
- Anthropic SDK TS: `/anthropic-ai/anthropic-sdk-typescript` → `/anthropics/anthropic-sdk-typescript` (org typo)
- Fix `knowledge:ingest-context7` single-library task: fetch `WEBSITE_DB_PASSWORD` + `VOYAGE_API_KEY` from `workspace-secrets` (same fix as #842 for the bulk seed task)

## Result

All 10/10 collections now seeded on both clusters:
- Keycloak: 29 chunks
- Anthropic SDK (TS): 39 chunks
- (other 8 already seeded in #842)

## Test plan

- [x] `task knowledge:ingest-context7 LIBRARY_ID=/keycloak/keycloak ... ENV=mentolder` — 29 chunks ✓
- [x] `task knowledge:ingest-context7 LIBRARY_ID=/anthropics/anthropic-sdk-typescript ... ENV=mentolder` — 39 chunks ✓
- [x] Same on korczewski ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)