### PR TITLE
fix(knowledge-ingest): fix read-only mount in init container [T000485]

### DIFF
--- a/docs/superpowers/plans/2026-05-19-knowledge-ingest-readonly-fix.md
+++ b/docs/superpowers/plans/2026-05-19-knowledge-ingest-readonly-fix.md
@@ -1,0 +1,22 @@
+---
+ticket_id: T000485
+---
+# Plan: Knowledge Ingest Read-Only Fix
+
+The `knowledge-ingest` CronJobs are failing because their `npm-install` init container attempts to run `npm install` in `/scripts`, which is a read-only ConfigMap mount.
+
+## Proposed Changes
+
+### Kubernetes Manifests
+- Modify `k3d/knowledge-ingest-cronjob.yaml` to change the `npm-install` command.
+- Instead of `cd /scripts && npm install`, it will run `npm install --prefix /tmp` and then copy the `node_modules` to the expected location.
+
+## Verification Plan
+
+### Automated Tests
+- Run `tests/unit/knowledge-ingest-manifest.bats` to verify the manifest contains the correct fix and no longer contains the broken command.
+
+### Manual Verification
+- Deploy to `korczewski` cluster.
+- Trigger one of the jobs manually: `kubectl create job --from=cronjob/knowledge-ingest-prs knowledge-ingest-manual-fix -n workspace --context korczewski`
+- Verify the pod succeeds.

--- a/k3d/knowledge-ingest-cronjob.yaml
+++ b/k3d/knowledge-ingest-cronjob.yaml
@@ -298,7 +298,7 @@ spec:
             - name: npm-install
               image: node:22-alpine
               imagePullPolicy: IfNotPresent
-              command: [sh, -c, "cd /scripts && npm install pg --no-package-lock --silent"]
+              command: [sh, -c, "npm install pg --no-package-lock --silent --prefix /tmp && cp -r /tmp/node_modules/* /scripts/node_modules/"]
               volumeMounts:
                 - name: scripts
                   mountPath: /scripts
@@ -427,7 +427,7 @@ spec:
             - name: npm-install
               image: node:22-alpine
               imagePullPolicy: IfNotPresent
-              command: [sh, -c, "cd /scripts && npm install pg --no-package-lock --silent"]
+              command: [sh, -c, "npm install pg --no-package-lock --silent --prefix /tmp && cp -r /tmp/node_modules/* /scripts/node_modules/"]
               volumeMounts:
                 - name: scripts
                   mountPath: /scripts
@@ -512,7 +512,7 @@ spec:
             - name: npm-install
               image: node:22-alpine
               imagePullPolicy: IfNotPresent
-              command: [sh, -c, "cd /scripts && npm install pg --no-package-lock --silent"]
+              command: [sh, -c, "npm install pg --no-package-lock --silent --prefix /tmp && cp -r /tmp/node_modules/* /scripts/node_modules/"]
               volumeMounts:
                 - name: scripts
                   mountPath: /scripts

--- a/tests/unit/knowledge-ingest-manifest.bats
+++ b/tests/unit/knowledge-ingest-manifest.bats
@@ -1,0 +1,24 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup_file() {
+  export MANIFESTS_DIR="${PROJECT_DIR}/k3d"
+  export RENDERED="${BATS_FILE_TMPDIR}/rendered-knowledge.yaml"
+  kubectl kustomize "${MANIFESTS_DIR}" --load-restrictor=LoadRestrictionsNone > "$RENDERED" 2>&1
+}
+
+@test "knowledge-ingest init containers do NOT install directly in /scripts (readonly mount)" {
+  # The broken command should NOT be found
+  run grep -F "cd /scripts && npm install pg --no-package-lock --silent" "$RENDERED"
+  assert_failure
+}
+
+@test "knowledge-ingest init containers use prefix /tmp for npm install" {
+  # The fix command SHOULD be found
+  run grep -F -e "--prefix /tmp" "$RENDERED"
+  assert_success
+  
+  run grep -F "cp -r /tmp/node_modules/*" "$RENDERED"
+  assert_success
+}


### PR DESCRIPTION
## Summary
- Fixed knowledge-ingest CronJobs failing due to read-only ConfigMap mount in /scripts.
- Updated init container to use /tmp for npm install and copy results to node_modules.

## Test plan
- [x] task test:all (includes new unit test)
- [x] ./tests/unit/lib/bats-core/bin/bats tests/unit/knowledge-ingest-manifest.bats
- [x] task workspace:validate ENV=korczewski

Closes T000485

Co-Authored-By: Gemini CLI