### PR TITLE
fix(knowledge-ingest): remove non-existent columns from script [T000487]

### DIFF
--- a/docs/superpowers/plans/2026-05-19-knowledge-ingest-schema-fix.md
+++ b/docs/superpowers/plans/2026-05-19-knowledge-ingest-schema-fix.md
@@ -1,0 +1,23 @@
+---
+ticket_id: T000487
+---
+# Plan: Fix Knowledge Ingest Schema Mismatch
+
+The `ingest-prs.mjs` script in `k3d/knowledge-ingest-cronjob.yaml` is querying `body` and `labels` columns from `bachelorprojekt.features`. These columns do not exist in the schema defined in `k3d/website-schema.yaml`.
+
+## Proposed Changes
+
+### Kubernetes Manifests
+- Modify `k3d/knowledge-ingest-cronjob.yaml`:
+    - Update `ingest-prs.mjs` SQL query to remove `body` and `labels`.
+    - Update the text construction logic to remove usage of `row.body` and `row.labels`.
+
+## Verification Plan
+
+### Automated Tests
+- Run `tests/unit/knowledge-ingest-schema.bats` to verify the script no longer contains the problematic column names.
+
+### Manual Verification
+- Deploy to `korczewski` cluster.
+- Trigger `knowledge-ingest-prs` manually.
+- Verify pod completion.

--- a/k3d/knowledge-ingest-cronjob.yaml
+++ b/k3d/knowledge-ingest-cronjob.yaml
@@ -142,7 +142,7 @@ data:
         });
 
         const { rows } = await pool.query(
-          `SELECT pr_number, title, description, body, merged_at, labels
+          `SELECT pr_number, title, description, merged_at
              FROM bachelorprojekt.features
             WHERE merged_at IS NOT NULL
             ORDER BY merged_at DESC`,
@@ -154,8 +154,6 @@ data:
           const text = [
             `PR #${row.pr_number}: ${row.title}`,
             row.description ?? '',
-            row.body ?? '',
-            row.labels?.length ? `Labels: ${row.labels.join(', ')}` : '',
           ].filter(Boolean).join('\n\n');
 
           const hash = sha256(text);

--- a/tests/unit/knowledge-ingest-schema.bats
+++ b/tests/unit/knowledge-ingest-schema.bats
@@ -1,0 +1,18 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup_file() {
+  export MANIFESTS_DIR="${PROJECT_DIR}/k3d"
+  export RENDERED="${BATS_FILE_TMPDIR}/rendered-knowledge-schema.yaml"
+  kubectl kustomize "${MANIFESTS_DIR}" --load-restrictor=LoadRestrictionsNone > "$RENDERED" 2>&1
+}
+
+@test "ingest-prs.mjs does NOT query non-existent columns (body, labels)" {
+  # The broken columns should NOT be found in the SELECT query
+  run grep -A 10 "SELECT pr_number" "$RENDERED"
+  assert_success
+  
+  refute_line --partial "body,"
+  refute_line --partial "labels"
+}


### PR DESCRIPTION
## Summary
- Fixed Knowledge Ingest script trying to query 'body' and 'labels' columns which don't exist in the features table.
- Removed unused text construction logic for these columns.

## Test plan
- [x] task test:all
- [x] ./tests/unit/lib/bats-core/bin/bats tests/unit/knowledge-ingest-schema.bats
- [x] task workspace:validate ENV=korczewski

Closes T000487

Co-Authored-By: Gemini CLI