### PR TITLE
fix(knowledge-ingest): fix bugs ingestion schema mismatch [T000488]

### DIFF
--- a/docs/superpowers/plans/2026-05-19-knowledge-ingest-bugs-schema-fix.md
+++ b/docs/superpowers/plans/2026-05-19-knowledge-ingest-bugs-schema-fix.md
@@ -1,0 +1,23 @@
+---
+ticket_id: T000488
+---
+# Plan: Fix Knowledge Ingest Bugs Schema Mismatch
+
+The `ingest-bug-tickets.mjs` script in `k3d/knowledge-ingest-cronjob.yaml` is querying `id` and `title` columns from `bugs.bug_tickets`. These columns do not exist in the actual schema (they are `ticket_id` and the description serves as the main text).
+
+## Proposed Changes
+
+### Kubernetes Manifests
+- Modify `k3d/knowledge-ingest-cronjob.yaml`:
+    - Update `ingest-bug-tickets.mjs` SQL query to use `ticket_id` instead of `id` and `title`.
+    - Update the text construction logic to use `row.ticket_id` as the title.
+
+## Verification Plan
+
+### Automated Tests
+- Run `tests/unit/knowledge-ingest-bugs-schema.bats` to verify the script no longer contains the problematic column names and uses `ticket_id`.
+
+### Manual Verification
+- Deploy to `korczewski` cluster.
+- Trigger `knowledge-ingest-bugs` manually.
+- Verify pod completion.

--- a/k3d/knowledge-ingest-cronjob.yaml
+++ b/k3d/knowledge-ingest-cronjob.yaml
@@ -214,7 +214,7 @@ data:
         });
 
         const { rows } = await pool.query(
-          `SELECT id, title, description, status, brand, created_at, fixed_in_pr
+          `SELECT ticket_id, description, status, brand, created_at, fixed_in_pr
              FROM bugs.bug_tickets
             WHERE brand = $1
             ORDER BY created_at DESC`,
@@ -225,26 +225,26 @@ data:
 
         for (const row of rows) {
           const text = [
-            `${row.id}: ${row.title}`,
+            `${row.ticket_id}: ${row.description.slice(0, 100)}...`,
             `Status: ${row.status}`,
             row.fixed_in_pr ? `Fixed in PR #${row.fixed_in_pr}` : '',
             row.description ?? '',
           ].filter(Boolean).join('\n\n');
 
           const hash = sha256(text);
-          const sourceUri = `bug:${row.id}`;
+          const sourceUri = `bug:${row.ticket_id}`;
           const rawChunks = chunkPlain(text);
           const embeddings = await embedAll(rawChunks.map(c => c.text));
           const chunks = rawChunks.map((c, i) => ({ ...c, embedding: embeddings[i] }));
 
           await upsertDocumentAndChunks(pool, {
             collectionId,
-            title: `${row.id}: ${row.title}`,
+            title: `${row.ticket_id}: ${row.description.slice(0, 100)}...`,
             sourceUri,
             rawText: text,
             hash,
             metadata: {
-              ticket_id: row.id,
+              ticket_id: row.ticket_id,
               status: row.status,
               brand: row.brand,
               fixed_in_pr: row.fixed_in_pr,

--- a/tests/unit/knowledge-ingest-bugs-schema.bats
+++ b/tests/unit/knowledge-ingest-bugs-schema.bats
@@ -1,0 +1,19 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup_file() {
+  export MANIFESTS_DIR="${PROJECT_DIR}/k3d"
+  export RENDERED="${BATS_FILE_TMPDIR}/rendered-knowledge-bugs.yaml"
+  kubectl kustomize "${MANIFESTS_DIR}" --load-restrictor=LoadRestrictionsNone > "$RENDERED" 2>&1
+}
+
+@test "ingest-bug-tickets.mjs does NOT query non-existent columns (id, title)" {
+  # The broken columns should NOT be found in the SELECT query
+  run grep "SELECT id, title" "$RENDERED"
+  assert_failure
+  
+  # ticket_id SHOULD be found
+  run grep "ticket_id," "$RENDERED"
+  assert_success
+}


### PR DESCRIPTION
## Summary
- Fixed Knowledge Ingest script for bug tickets trying to query 'id' and 'title' columns which don't exist in the bug_tickets table.
- Updated to use 'ticket_id' and derived title from description.

## Test plan
- [x] task test:all
- [x] ./tests/unit/lib/bats-core/bin/bats tests/unit/knowledge-ingest-bugs-schema.bats
- [x] task workspace:validate ENV=korczewski

Closes T000488

Co-Authored-By: Gemini CLI