### PR TITLE
feat(webcrawl): add local bge-m3 embedding support [T000497]

### DIFF
--- a/docs/superpowers/plans/2026-05-19-webcrawl-local-embed.md
+++ b/docs/superpowers/plans/2026-05-19-webcrawl-local-embed.md
@@ -1,0 +1,102 @@
+---
+ticket_id: T000497
+status: staged
+domains: [website, scripts]
+---
+
+# Plan: webcrawl-local-embed
+
+Add local (bge-m3 via llm-router) embedding support to the web crawler.
+Currently `ingest-web.mjs` always calls `callVoyage()`, ignoring the
+collection's `embedding_model` field. Users have no way to create a
+web_crawl collection backed by local embeddings.
+
+## Context
+
+- `knowledge.collections.embedding_model` already stores `'bge-m3'` or
+  `'voyage-multilingual-2'` per collection.
+- `createCollection()` in `knowledge-db.ts` already accepts
+  `embeddingModel` as optional param and defaults based on `LLM_ENABLED`.
+- `embeddings.ts` has a working `callRouter()` for bge-m3 via
+  `llm-router.workspace.svc.cluster.local:4000`.
+- `lib-knowledge-pg.mjs` (used by ingest scripts) has NO local path.
+- `WebCrawlSourceModal.svelte` never sends `embeddingModel` to the API.
+
+## Steps
+
+### 1 — `scripts/knowledge/lib-knowledge-pg.mjs`
+
+Add `callRouter(texts, model)` that mirrors `embeddings.ts`:
+```
+POST ${LLM_ROUTER_URL}/v1/embeddings
+{ model, input: texts }
+→ j.data[].embedding
+```
+Handle bad `LLM_ROUTER_URL` (e.g. unexpanded `${LLM_ROUTER_URL}`):
+```js
+function getRouterUrl() {
+  const u = process.env.LLM_ROUTER_URL;
+  try { new URL(u); return u; } catch {
+    return 'http://llm-router.workspace.svc.cluster.local:4000';
+  }
+}
+```
+
+Update `embedAll(texts, model = 'voyage-multilingual-2', batch = 128)`:
+- If `model === 'bge-m3'`: call `callRouter` in batches of 64
+- Else: existing `callVoyage` path (batch 128)
+
+### 2 — `scripts/knowledge/ingest-web.mjs`
+
+The DB query at startup already fetches `crawl_config`; extend it to also
+select `embedding_model`:
+```js
+const { name: colName, crawl_config, embedding_model } = colRes.rows[0];
+```
+Pass `embedding_model` to `embedAll()`:
+```js
+const embeddings = await embedAll(rawChunks.map(c => c.text), embedding_model);
+```
+
+### 3 — `website/src/components/admin/WebCrawlSourceModal.svelte`
+
+Add state:
+```ts
+let embeddingModel: 'voyage-multilingual-2' | 'bge-m3' = $state('voyage-multilingual-2');
+```
+
+Add a `<label>Einbettungsmodell` select with two options:
+- `voyage-multilingual-2` → "Voyage (Cloud)"
+- `bge-m3` → "Lokal (bge-m3)"
+
+Include in the `collections` POST body:
+```js
+body: JSON.stringify({ ..., embeddingModel }),
+```
+
+### 4 — `website/src/pages/api/admin/knowledge/collections/index.ts`
+
+Read `embeddingModel` from POST body and pass to `createCollection()`:
+```ts
+const body = ... as { ...; embeddingModel?: 'voyage-multilingual-2' | 'bge-m3' };
+...
+const c = await createCollection({
+  ...
+  embeddingModel: body.embeddingModel,  // undefined → auto-detect in knowledge-db.ts
+});
+```
+
+## Verification
+
+- `task test:all` green
+- `task workspace:validate` green
+- `task feature:website` deploys both clusters
+- Create a test collection with model=bge-m3, trigger crawl, confirm chunk_count > 0
+  (requires GPU host reachable on wg-mesh)
+- Existing Voyage crawl still works (Openclaw collection)
+
+## Out of scope
+
+- LLM_ENABLED/LLM_ROUTER_URL envsubst issue (T000493) — separate ticket
+- korczewski has no GPU host — bge-m3 option will still appear but fail if
+  LLM_ROUTER_URL is unreachable; that is acceptable (fails with clear error)

--- a/scripts/knowledge/ingest-web.mjs
+++ b/scripts/knowledge/ingest-web.mjs
@@ -203,14 +203,14 @@ async function main() {
 
   try {
     const colRes = await pool.query(
-      `SELECT name, crawl_config FROM knowledge.collections WHERE id = $1`,
+      `SELECT name, crawl_config, embedding_model FROM knowledge.collections WHERE id = $1`,
       [COLLECTION_ID],
     );
     if (colRes.rows.length === 0) {
       console.error(`Collection ${COLLECTION_ID} not found`);
       process.exit(1);
     }
-    const { name: colName, crawl_config } = colRes.rows[0];
+    const { name: colName, crawl_config, embedding_model } = colRes.rows[0];
     const cfg = crawl_config ?? {};
 
     const startUrl       = process.env.START_URL    || cfg.startUrl;
@@ -240,7 +240,7 @@ async function main() {
     console.log(`Embedding ${pages.length} pages…`);
     for (const page of pages) {
       const rawChunks = chunkPlain(page.text);
-      const embeddings = await embedAll(rawChunks.map(c => c.text));
+      const embeddings = await embedAll(rawChunks.map(c => c.text), embedding_model);
       const chunks = rawChunks.map((c, i) => ({ ...c, embedding: embeddings[i] }));
 
       await upsertDocumentAndChunks(pool, {

--- a/scripts/knowledge/lib-knowledge-pg.mjs
+++ b/scripts/knowledge/lib-knowledge-pg.mjs
@@ -87,8 +87,39 @@ export async function callVoyage(inputs, inputType = 'document') {
   return { embeddings: j.data.map(d => d.embedding), tokens: j.usage.total_tokens };
 }
 
-export async function embedAll(texts, batch = 128) {
+function getRouterUrl() {
+  const u = process.env.LLM_ROUTER_URL;
+  try {
+    new URL(u);
+    return u;
+  } catch {
+    return 'http://llm-router.workspace.svc.cluster.local:4000';
+  }
+}
+
+export async function callRouter(texts, model = 'bge-m3') {
+  const url = getRouterUrl();
+  const r = await fetch(`${url}/v1/embeddings`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ model, input: texts }),
+  });
+  if (!r.ok) throw new Error(`router ${r.status} ${await r.text()}`);
+  const j = await r.json();
+  return { embeddings: j.data.map(d => d.embedding) };
+}
+
+export async function embedAll(texts, model = 'voyage-multilingual-2', batch = 128) {
   const out = [];
+  if (model === 'bge-m3') {
+    const bgeBatch = 64;
+    for (let i = 0; i < texts.length; i += bgeBatch) {
+      const r = await callRouter(texts.slice(i, i + bgeBatch), model);
+      out.push(...r.embeddings);
+    }
+    return out;
+  }
+
   for (let i = 0; i < texts.length; i += batch) {
     const r = await callVoyage(texts.slice(i, i + batch), 'document');
     out.push(...r.embeddings);

--- a/website/src/components/admin/WebCrawlSourceModal.svelte
+++ b/website/src/components/admin/WebCrawlSourceModal.svelte
@@ -15,6 +15,7 @@
   let maxDepth    = $state(3);
   let maxPages    = $state(200);
   let includePattern = $state('');
+  let embeddingModel: 'voyage-multilingual-2' | 'bge-m3' = $state('voyage-multilingual-2');
   let busy        = $state(false);
   let error       = $state<string | null>(null);
   let info        = $state<string | null>(null);
@@ -30,6 +31,7 @@
     maxDepth = 3;
     maxPages = 200;
     includePattern = '';
+    embeddingModel = 'voyage-multilingual-2';
   }
 
   function closeModal() {
@@ -69,6 +71,7 @@
           description: description.trim() || undefined,
           brand:       brand === 'beide' ? null : brand,
           source:      'web_crawl',
+          embeddingModel,
           crawlConfig,
         }),
       });
@@ -108,6 +111,13 @@
         <option value="beide">beide</option>
         <option value="mentolder">mentolder</option>
         <option value="korczewski">korczewski</option>
+      </select>
+    </label>
+
+    <label>Einbettungsmodell
+      <select bind:value={embeddingModel}>
+        <option value="voyage-multilingual-2">Voyage (Cloud)</option>
+        <option value="bge-m3">Lokal (bge-m3)</option>
       </select>
     </label>
 

--- a/website/src/pages/api/admin/knowledge/collections/index.ts
+++ b/website/src/pages/api/admin/knowledge/collections/index.ts
@@ -18,6 +18,7 @@ export const POST: APIRoute = async ({ request }) => {
     description?: string;
     brand?: string | null;
     source?: string;
+    embeddingModel?: 'voyage-multilingual-2' | 'bge-m3';
     crawlConfig?: CrawlConfig;
   };
 
@@ -48,6 +49,7 @@ export const POST: APIRoute = async ({ request }) => {
       source,
       description: body.description?.trim(),
       brand:       body.brand ?? null,
+      embeddingModel: body.embeddingModel,
       crawlConfig: source === 'web_crawl' ? (body.crawlConfig ?? null) : null,
     });
     return new Response(JSON.stringify(c), { status: 201, headers: { 'Content-Type': 'application/json' } });


### PR DESCRIPTION
## Summary
- Added local (bge-m3 via llm-router) embedding support to the web crawler.
- Users can now choose between Voyage (Cloud) and Local (bge-m3) when creating a web crawl source.

## Test plan
- [x] task test:all
- [x] task workspace:validate
- [x] manual check of UI fields

Closes T000497

Co-Authored-By: Gemini CLI