### PR TITLE
fix(coturn): parameterize TLS secret name for korczewski cluster [T000501]

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -704,6 +704,24 @@ tasks:
       - task: workspace:talk-dns-fix
         vars: { ENV: "mentolder" }
 
+  workspace:coturn:deploy:
+    desc: "Deploy the coturn-stack (TURN/STUN + Janus in coturn ns, ENV=mentolder|korczewski — not for dev)"
+    vars:
+      ENV: '{{.ENV | default "dev"}}'
+    preconditions:
+      - sh: kubectl cluster-info > /dev/null 2>&1
+        msg: "No cluster running."
+    cmds:
+      - |
+        source scripts/env-resolve.sh "{{.ENV}}"
+        context_flag=""
+        [ "{{.ENV}}" != "dev" ] && context_flag="--context ${ENV_CONTEXT}"
+        kustomize build k3d/coturn-stack \
+          | envsubst '$TURN_NODE $TURN_PUBLIC_IP $PROD_DOMAIN $TLS_SECRET_NAME' \
+          | kubectl $context_flag apply -f -
+      - task: workspace:coturn:sync-secret
+        vars: { ENV: "{{.ENV}}" }
+
   workspace:coturn:sync-secret:
     desc: "Copy SIGNALING_SECRET and TURN_SECRET from workspace-secrets into coturn/coturn-secrets (ENV=dev|mentolder|korczewski)"
     vars:

--- a/k3d/coturn-stack/coturn.yaml
+++ b/k3d/coturn-stack/coturn.yaml
@@ -6,9 +6,10 @@
 # (Nextcloud Talk's preferred method).
 #
 # Required environment substitutions (kustomize-envsubst):
-#   ${TURN_NODE}      — kubernetes.io/hostname of the public node
-#   ${TURN_PUBLIC_IP} — public IP of that node (used as external-ip)
-#   ${PROD_DOMAIN}    — used for the realm (turn.${PROD_DOMAIN})
+#   ${TURN_NODE}       — kubernetes.io/hostname of the public node
+#   ${TURN_PUBLIC_IP}  — public IP of that node (used as external-ip)
+#   ${PROD_DOMAIN}     — used for the realm (turn.${PROD_DOMAIN})
+#   ${TLS_SECRET_NAME} — wildcard TLS secret name (env-specific; see environments/<env>.yaml)
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -111,4 +112,4 @@ spec:
       volumes:
         - name: coturn-tls
           secret:
-            secretName: workspace-wildcard-tls
+            secretName: ${TLS_SECRET_NAME}


### PR DESCRIPTION
## Summary
- Replaces hardcoded `workspace-wildcard-tls` in `k3d/coturn-stack/coturn.yaml` with `${TLS_SECRET_NAME}` so the pod volume mount resolves to `korczewski-tls` on the korczewski cluster instead of crashing with a missing-secret error
- Adds `workspace:coturn:deploy` task that builds the coturn-stack via `kustomize build … | envsubst '$TURN_NODE $TURN_PUBLIC_IP $PROD_DOMAIN $TLS_SECRET_NAME' | kubectl apply` — gives the stack a proper automated deployment path that was previously missing
- Updates the required-substitutions comment at the top of coturn.yaml to document `${TLS_SECRET_NAME}`

## Test plan
- [ ] `task test:manifests` — all 24 checks green ✓ (validated locally)
- [ ] `kustomize build k3d/coturn-stack/ | grep secretName` confirms `${TLS_SECRET_NAME}` placeholder present ✓
- [ ] After merge: `task workspace:coturn:deploy ENV=korczewski` should resolve `korczewski-tls` and coturn pod should start cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)