### PR TITLE
chore(dev-stack): skip self-SSH when image import runs on the dev node

### DIFF
--- a/Taskfile.dev-stack.yml
+++ b/Taskfile.dev-stack.yml
@@ -121,12 +121,16 @@ tasks:
           .
       - |
         source scripts/env-resolve.sh "{{.ENV}}"
-        ssh-keyscan -H "$DEV_NODE" >> ~/.ssh/known_hosts 2>/dev/null
         TMP_TAR=$(mktemp /tmp/website-dev-XXXXXX.tar)
         trap "rm -f $TMP_TAR" EXIT
         docker save ghcr.io/paddione/workspace-website:dev > "$TMP_TAR"
-        scp "$TMP_TAR" ${DEV_SSH_USER:-root}@$DEV_NODE:/tmp/website-dev-import.tar
-        ssh ${DEV_SSH_USER:-root}@$DEV_NODE "k3d image import /tmp/website-dev-import.tar -c {{.CLUSTER_NAME}} && rm -f /tmp/website-dev-import.tar"
+        if [[ "$(hostname -s 2>/dev/null)" == "${DEV_NODE%%.*}" ]]; then
+          k3d image import "$TMP_TAR" -c {{.CLUSTER_NAME}}
+        else
+          ssh-keyscan -H "$DEV_NODE" >> ~/.ssh/known_hosts 2>/dev/null
+          scp "$TMP_TAR" ${DEV_SSH_USER:-root}@$DEV_NODE:/tmp/website-dev-import.tar
+          ssh ${DEV_SSH_USER:-root}@$DEV_NODE "k3d image import /tmp/website-dev-import.tar -c {{.CLUSTER_NAME}} && rm -f /tmp/website-dev-import.tar"
+        fi
 
   build:brett:
     desc: "[dev] Build the brett image and import it into the dev k3d cluster"
@@ -134,12 +138,16 @@ tasks:
       - docker build -t ghcr.io/paddione/workspace-brett:dev -f brett/Dockerfile brett/
       - |
         source scripts/env-resolve.sh "{{.ENV}}"
-        ssh-keyscan -H "$DEV_NODE" >> ~/.ssh/known_hosts 2>/dev/null
         TMP_TAR=$(mktemp /tmp/brett-dev-XXXXXX.tar)
         trap "rm -f $TMP_TAR" EXIT
         docker save ghcr.io/paddione/workspace-brett:dev > "$TMP_TAR"
-        scp "$TMP_TAR" ${DEV_SSH_USER:-root}@$DEV_NODE:/tmp/brett-dev-import.tar
-        ssh ${DEV_SSH_USER:-root}@$DEV_NODE "k3d image import /tmp/brett-dev-import.tar -c {{.CLUSTER_NAME}} && rm -f /tmp/brett-dev-import.tar"
+        if [[ "$(hostname -s 2>/dev/null)" == "${DEV_NODE%%.*}" ]]; then
+          k3d image import "$TMP_TAR" -c {{.CLUSTER_NAME}}
+        else
+          ssh-keyscan -H "$DEV_NODE" >> ~/.ssh/known_hosts 2>/dev/null
+          scp "$TMP_TAR" ${DEV_SSH_USER:-root}@$DEV_NODE:/tmp/brett-dev-import.tar
+          ssh ${DEV_SSH_USER:-root}@$DEV_NODE "k3d image import /tmp/brett-dev-import.tar -c {{.CLUSTER_NAME}} && rm -f /tmp/brett-dev-import.tar"
+        fi
 
   apply:
     desc: "[dev] Apply the dev-stack overlay to the dev k3d cluster (no image build)"


### PR DESCRIPTION
## Summary
- `build:website` and `build:brett` tasks were failing in CI because they tried to SCP to `gekko@gekko-hetzner-2` from within a session already running on that node
- Detect "already on dev node" via `hostname -s` vs `${DEV_NODE%%.*}` and import the tar directly with `k3d image import` — no SSH/SCP needed when already local
- Remote (laptop→node) path is unchanged; the `else` branch still does the SSH/SCP

## Test plan
- `task test:all` passes (all 31 BATS + manifest + dry-run checks green)
- CI will re-run `dev-auto-deploy` on next `website/` or `brett/` push to main — self-SSH branch will no longer be hit