### PR TITLE
chore(skills): add CI-critical extra checks to dev-flow verification steps

### DIFF
--- a/.claude/skills/dev-flow-execute/SKILL.md
+++ b/.claude/skills/dev-flow-execute/SKILL.md
@@ -159,6 +159,20 @@ task workspace:validate
 task test:all
 ```
 
+### CI-kritische Zusatzchecks
+
+`task test:all` deckt nur den `offline-tests`-Job ab. Die folgenden Checks haben **eigene CI-Jobs** — CI kann rot werden, auch wenn `task test:all` grün ist. Führe sie aus, wenn die entsprechenden Dateien geändert wurden:
+
+| Geänderte Dateien | Lokaler Check | CI-Job |
+|---|---|---|
+| `tests/**` oder neue/geänderte Test-IDs | `task test:inventory && git diff --exit-code website/src/data/test-inventory.json` — bei Abweichung committen | `offline-tests` |
+| `brett/**` | `npm ci --prefix brett && node --test brett/test/ws-reconnect.test.mjs brett/test/physics.test.js brett/test/damage.test.mjs brett/test/pickups.test.mjs brett/test/mode-state.test.mjs` | `brett-server-test` |
+| `brett/**` (Whiteboard-Template) | `./scripts/tests/systembrett-template.test.sh` | `offline-tests` |
+| `arena-server/**` | `cd arena-server && pnpm install --frozen-lockfile && pnpm test && pnpm build` | `arena-server` |
+| `arena-server/src/proto/messages.ts` ODER `website/src/components/arena/shared/lobbyTypes.ts` | `diff arena-server/src/proto/messages.ts website/src/components/arena/shared/lobbyTypes.ts` — bei Abweichung: `cp arena-server/src/proto/messages.ts website/src/components/arena/shared/lobbyTypes.ts` | `arena-proto-drift` |
+
+> Alle fünf CI-Jobs müssen grün sein vor dem Merge.
+
 ---
 
 ## Schritt 3.5: Admin-Menu Placement Gate

--- a/.claude/skills/dev-flow-plan/SKILL.md
+++ b/.claude/skills/dev-flow-plan/SKILL.md
@@ -474,6 +474,15 @@ task workspace:validate      # falls Manifests betroffen
 task website:dev             # falls website/src/ betroffen — Smoke-Test
 ```
 
+**CI-kritische Zusatzchecks** — `task test:all` deckt nur den `offline-tests`-CI-Job ab; die folgenden haben eigene Jobs:
+
+| Geänderte Dateien | Zusätzlicher Check |
+|---|---|
+| `tests/**` oder neue Test-IDs | `task test:inventory && git diff --exit-code website/src/data/test-inventory.json` — bei Abweichung committen |
+| `brett/**` | `npm ci --prefix brett && node --test brett/test/ws-reconnect.test.mjs brett/test/physics.test.js brett/test/damage.test.mjs brett/test/pickups.test.mjs brett/test/mode-state.test.mjs` + `./scripts/tests/systembrett-template.test.sh` |
+| `arena-server/**` | `cd arena-server && pnpm install --frozen-lockfile && pnpm test && pnpm build` |
+| `arena-server/src/proto/messages.ts` ODER `website/src/components/arena/shared/lobbyTypes.ts` | `diff arena-server/src/proto/messages.ts website/src/components/arena/shared/lobbyTypes.ts` — bei Abweichung sync-copy |
+
 ### Schritt 5: PR
 
 Rufe `commit-commands:commit-push-pr` auf.


### PR DESCRIPTION
## Summary
- `task test:all` only covers the `offline-tests` CI job; four additional CI jobs were completely invisible to both skill verification steps
- Added a conditional check table to `dev-flow-execute` Schritt 3 and `dev-flow-plan` chore Schritt 4 listing the missing checks and which CI job each belongs to
- Affected: `brett-server-test` (node --test), `arena-server` (pnpm test + build), `arena-proto-drift` (byte-diff of two files), and `test:inventory` freshness check

## Test plan
- [x] `task test:all` — green (FAIL=0)
- [x] Only `.claude/skills/**` changed — no deploy needed

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>