### PR TITLE
chore(resilience): add initContainer + liveness probes to reduce restarts

### DIFF
--- a/k3d/coturn-stack/janus.yaml
+++ b/k3d/coturn-stack/janus.yaml
@@ -88,6 +88,17 @@ spec:
             - name: config
               mountPath: /etc/janus/janus.plugin.videoroom.jcfg
               subPath: janus.plugin.videoroom.jcfg
+          startupProbe:
+            tcpSocket:
+              port: 8188
+            failureThreshold: 30
+            periodSeconds: 5
+          livenessProbe:
+            tcpSocket:
+              port: 8188
+            initialDelaySeconds: 15
+            periodSeconds: 30
+            failureThreshold: 3
           resources:
             requests:
               memory: 128Mi

--- a/k3d/vaultwarden.yaml
+++ b/k3d/vaultwarden.yaml
@@ -37,6 +37,18 @@ spec:
         fsGroup: 65534
         seccompProfile:
           type: RuntimeDefault
+      initContainers:
+        - name: wait-for-db
+          image: busybox:1.37
+          command: ['sh', '-c', 'until nc -w1 -z shared-db 5432 2>/dev/null; do echo "waiting for shared-db..."; sleep 3; done']
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            runAsUser: 65534
+            capabilities:
+              drop: [ALL]
+            seccompProfile:
+              type: RuntimeDefault
       containers:
         - name: vaultwarden
           image: vaultwarden/server:1.35.3-alpine


### PR DESCRIPTION
## Summary

- **Vaultwarden**: `initContainer` (`busybox:1.37`) wartet auf `shared-db:5432` bevor der Hauptcontainer startet — verhindert den Crash-Loop (34 Restarts, Exit 1) der entsteht wenn PostgreSQL beim Pod-Start noch nicht bereit ist
- **Janus**: `startupProbe` (150s Fenster, TCP Port 8188) + `livenessProbe` (alle 30s) hinzugefügt — Kubernetes erkennt jetzt auch Hänge-Zustände zusätzlich zu SIGSEGV-Exits und startet prompt neu

## Kontext

Aus dem Health-Summary vom 2026-05-19:
- Vaultwarden 34 Restarts (Exit Code 1 = `shared-db connection refused`)
- Janus SIGSEGV (Exit 139) — kein Liveness-Probe vorhanden

## Test plan

- `task workspace:validate` ✓ (Manifests valid)
- Nach Deploy: `kubectl get pod -n workspace vaultwarden -w` — kein Crash-Loop mehr beim nächsten DB-Neustart
- Nach Deploy: `kubectl get pod -n coturn janus -o jsonpath='{.spec.containers[0].livenessProbe}'` — Probe vorhanden