### PR TITLE
chore(tickets): remove ArgoCD, add keycloak:sync-admin-password [T000498/T000512/T000520/T000527]

### DIFF
--- a/.claude/agents/bachelorprojekt-infra.md
+++ b/.claude/agents/bachelorprojekt-infra.md
@@ -1,9 +1,9 @@
 ---
 name: bachelorprojekt-infra
 description: >
-  Use for Kubernetes manifest work, Kustomize overlays, Taskfile operations, ArgoCD
-  configuration, environment management, and sealed secrets in the Bachelorprojekt
-  workspace. Triggers on: k3d/, prod*/, manifest, kustomize, overlay, ArgoCD, Taskfile,
+  Use for Kubernetes manifest work, Kustomize overlays, Taskfile operations,
+  environment management, and sealed secrets in the Bachelorprojekt
+  workspace. Triggers on: k3d/, prod*/, manifest, kustomize, overlay, Taskfile,
   ENV=, environments/, deploy (when referring to k8s resources).
 ---
 
@@ -38,13 +38,7 @@ task workspace:deploy ENV=<env>          # deploy to specific env
 task workspace:deploy:all-prods          # deploy to both prod clusters
 task env:seal ENV=<env>                  # encrypt secrets to SealedSecret
 task env:generate ENV=<env>             # generate fresh secrets
-task argocd:status                       # show sync/health across all apps (hub-only, mentolder context)
 ```
-
-## ArgoCD rules
-- All `argocd:*` tasks run exclusively against `--context mentolder`
-- `ENV=korczewski` is silently ignored for ArgoCD tasks
-- Never apply ArgoCD manifests without the `_hub-guard` precondition passing
 
 ## Autonomous operation
 Execute Bash commands and file edits without asking for confirmation.

--- a/.claude/agents/bachelorprojekt-ops.md
+++ b/.claude/agents/bachelorprojekt-ops.md
@@ -19,7 +19,7 @@ Two physical clusters since 2026-05-09 (PRs #621/#622 re-split the brief merge).
 - **`korczewski` context** (3 nodes) — serves `korczewski.de`, namespace `workspace-korczewski`:
   - CP: `pk-hetzner-4`
   - Workers: `pk-hetzner-6`, `pk-hetzner-8`
-- Each cluster runs its own Traefik, `shared-db`, sealed-secrets, cert-manager, and Keycloak. ArgoCD federation hub-runs on mentolder.
+- Each cluster runs its own Traefik, `shared-db`, sealed-secrets, cert-manager, and Keycloak.
 
 ## Key commands
 ```bash
@@ -33,7 +33,7 @@ task clusters:status                        # one-line status across both prod c
 
 ## Important constraints
 - **Read-only filesystem** — diagnose and operate only; do not edit manifests or code
-- On `mentolder`, system pods (CoreDNS, ArgoCD) stay pinned to Hetzner nodes via nodeAffinity; the WireGuard/Flannel partition is fixed (all nodes on `wg-mesh`), but the pinning remains for predictable placement / lower egress latency
+- On `mentolder`, system pods (CoreDNS) stay pinned to Hetzner nodes via nodeAffinity; the WireGuard/Flannel partition is fixed (all nodes on `wg-mesh`), but the pinning remains for predictable placement / lower egress latency
 - LiveKit on `mentolder` runs with `hostNetwork: true` pinned to `gekko-hetzner-3` — check node affinity if stream issues occur
 - `korczewski` is a separate cluster; never assume traffic to `korczewski.de` traverses mentolder Traefik
 

--- a/.claude/skills/deployment-assist/SKILL.md
+++ b/.claude/skills/deployment-assist/SKILL.md
@@ -259,19 +259,6 @@ task health                   # full connectivity check
 
 ---
 
-## ArgoCD-Specific Blockers & Fixes
-
-| Symptom | Fix |
-|---------|-----|
-| `argocd` CLI not found | Install to `~/.local/bin` (no sudo needed): `curl -sSL -o ~/.local/bin/argocd https://github.com/argoproj/argo-cd/releases/latest/download/argocd-linux-amd64 && chmod +x ~/.local/bin/argocd` |
-| `task argocd:login` fails with port-forward connection reset | Log in via the public Ingress instead: `argocd login argocd.mentolder.de --username admin --password <pw> --grpc-web` |
-| App `Degraded` with `yaml: invalid map key ... nil` in ComparisonError | A cluster Secret annotation is missing/nil — the CMP substitutes it as empty string and YAML breaks. Patch the missing annotation on the cluster Secret in the `argocd` namespace, then do a hard refresh: `argocd app get <app> --hard-refresh --grpc-web` |
-| App `Unknown` with `field not declared in schema: .status.terminatingReplicas` | ArgoCD's static schema doesn't include a field present in k8s 1.35+. Add `/status/terminatingReplicas` to `ignoreDifferences` for Deployment/StatefulSet in `argocd/applicationset.yaml` |
-| App `OutOfSync` with `${VAR}` literal in error (e.g. `${DEV_NODE}`, `${LLM_HOST_IP}`) | Env var not in cluster Secret annotations. Patch the Secret and add the annotation to `argocd/applicationset.yaml` template + `Taskfile.argocd.yml` cluster:register patches, then re-apply: `kubectl apply -f argocd/applicationset.yaml` |
-| Deployment stuck with old pod `Running` and new pod `Pending` (hostPort deadlock) | Rolling update deadlock — old pod holds the hostPort on the node. Delete the old pod manually: `kubectl delete pod -n <ns> <old-pod>` — the new pod will claim the port |
-| ArgoCD cached error persists after fix | Force re-evaluation: `argocd app get <app> --hard-refresh --grpc-web` |
-
-
 ## Post-Execution: Mishap Report
 
 After completing all steps in this skill, invoke `mishap-tracker` with your

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -23,7 +23,6 @@ Kubernetes-based self-hosted collaboration platform (bachelor thesis). Two prod 
 
 **Infrastructure:**
 *   k3d (Dev) + k3s (Prod). Kustomize ist das alleinige Build-Tool.
-*   ArgoCD-Federation: Hub auf `mentolder`, Spoke `cluster-korczewski`.
 *   SealedSecrets (bitnami) pro Cluster; Secrets-Pipeline via `task env:seal ENV=<env>`.
 
 ## Building and Running

--- a/IDENTITY.md
+++ b/IDENTITY.md
@@ -8,6 +8,6 @@
 
 ---
 
-This workspace is a Kubernetes-based self-hosted collaboration platform (bachelor thesis by Patrick Korczewski). My job is to help build, maintain, and operate it — from manifest changes to live cluster debugging to ArgoCD wrangling.
+This workspace is a Kubernetes-based self-hosted collaboration platform (bachelor thesis by Patrick Korczewski). My job is to help build, maintain, and operate it — from manifest changes to live cluster debugging.
 
 I replaced Openclaw in April 2026. All prior Openclaw context still applies; the tools and workflow are the same.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ task workspace:post-setup      # Nextcloud-Apps + OIDC
 
 ## Produktion
 
-Zwei k3s-Cluster mit ArgoCD-Federation (Hub auf `mentolder`, Spoke `korczewski`). Jede ENV-aware Task akzeptiert `ENV=mentolder` oder `ENV=korczewski`:
+Zwei k3s-Cluster. Jede ENV-aware Task akzeptiert `ENV=mentolder` oder `ENV=korczewski`:
 
 ```bash
 task workspace:deploy ENV=mentolder
@@ -94,7 +94,6 @@ graph TB
 - `k3d/` — Kubernetes-Basis-Manifeste (Kustomize, einziger Deployment-Pfad)
 - `prod/`, `prod-mentolder/`, `prod-korczewski/` — Produktions-Overlays
 - `environments/` — Per-Env Config + SealedSecrets
-- `argocd/` — ApplicationSets + AppProject (Hub auf mentolder)
 - `website/` — Astro + Svelte (Brand-aware: mentolder + korczewski)
 - `brett/` — Node.js Systembrett-Service
 - `arena-server/` — Multiplayer-Backend (nur korczewski)

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1671,6 +1671,83 @@ tasks:
     cmds:
       - ENV={{.ENV}} bash scripts/keycloak-ensure-mappers.sh
 
+  keycloak:sync-admin-password:
+    desc: "Reset Keycloak admin password to match workspace-secrets (uses KC bootstrap admin backdoor, Keycloak 26+). ENV=dev|mentolder|korczewski"
+    vars:
+      ENV: '{{.ENV | default "dev"}}'
+    cmds:
+      - |
+        set -euo pipefail
+        source scripts/env-resolve.sh "{{.ENV}}"
+        CTX="${ENV_CONTEXT:+--context $ENV_CONTEXT}"
+        NS="${WORKSPACE_NAMESPACE:-workspace}"
+        KC_URL="https://auth.${PROD_DOMAIN}"
+        [[ "{{.ENV}}" == "dev" ]] && KC_URL="http://auth.localhost"
+
+        DESIRED_PASS=$(kubectl $CTX get secret workspace-secrets -n "$NS" \
+          -o jsonpath='{.data.KEYCLOAK_ADMIN_PASSWORD}' 2>/dev/null | base64 -d || echo "")
+        if [[ -z "$DESIRED_PASS" ]]; then
+          echo "ERROR: KEYCLOAK_ADMIN_PASSWORD not found in workspace-secrets/$NS" >&2; exit 1
+        fi
+
+        TOKEN=$(curl -sk -X POST "${KC_URL}/realms/master/protocol/openid-connect/token" \
+          --data-urlencode "grant_type=password" \
+          --data-urlencode "client_id=admin-cli" \
+          --data-urlencode "username=admin" \
+          --data-urlencode "password=${DESIRED_PASS}" \
+          | grep -o '"access_token":"[^"]*"' | cut -d'"' -f4 || true)
+
+        if [[ -n "$TOKEN" ]]; then
+          echo "✓ Keycloak admin password already matches workspace-secrets — no action needed."
+          exit 0
+        fi
+
+        echo "Admin password mismatch — resetting via KC 26 bootstrap admin..."
+        BOOT_PASS="KcReset$(date +%s)$(openssl rand -hex 4)!"
+
+        kubectl $CTX set env deployment/keycloak -n "$NS" \
+          KC_BOOTSTRAP_ADMIN_USERNAME=kc-recovery-admin \
+          KC_BOOTSTRAP_ADMIN_PASSWORD="${BOOT_PASS}"
+        echo "Waiting for Keycloak rollout with recovery admin..."
+        kubectl $CTX rollout status deployment/keycloak -n "$NS" --timeout=180s
+
+        for i in $(seq 1 20); do
+          curl -sk --max-time 5 "${KC_URL}/realms/master" | grep -q '"realm"' && break; sleep 5
+        done
+
+        BOOT_TOKEN=$(curl -sk -X POST "${KC_URL}/realms/master/protocol/openid-connect/token" \
+          --data-urlencode "grant_type=password" \
+          --data-urlencode "client_id=admin-cli" \
+          --data-urlencode "username=kc-recovery-admin" \
+          --data-urlencode "password=${BOOT_PASS}" \
+          | grep -o '"access_token":"[^"]*"' | cut -d'"' -f4 || true)
+
+        if [[ -z "$BOOT_TOKEN" ]]; then
+          echo "ERROR: Could not auth with bootstrap admin — rolling back." >&2
+          kubectl $CTX set env deployment/keycloak -n "$NS" \
+            KC_BOOTSTRAP_ADMIN_USERNAME- KC_BOOTSTRAP_ADMIN_PASSWORD- || true
+          exit 1
+        fi
+
+        ADMIN_ID=$(curl -sk -H "Authorization: Bearer $BOOT_TOKEN" \
+          "${KC_URL}/admin/realms/master/users?username=admin&exact=true" \
+          | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4 || true)
+        [[ -z "$ADMIN_ID" ]] && { echo "ERROR: admin user not found in master realm." >&2; exit 1; }
+
+        HTTP=$(curl -sk -o /dev/null -w "%{http_code}" -X PUT \
+          -H "Authorization: Bearer $BOOT_TOKEN" \
+          -H "Content-Type: application/json" \
+          "${KC_URL}/admin/realms/master/users/${ADMIN_ID}/reset-password" \
+          -d "{\"type\":\"password\",\"value\":\"${DESIRED_PASS}\",\"temporary\":false}")
+        [[ "$HTTP" != "204" ]] && { echo "ERROR: reset-password returned HTTP $HTTP" >&2; exit 1; }
+        echo "✓ Admin password reset to match workspace-secrets"
+
+        kubectl $CTX set env deployment/keycloak -n "$NS" \
+          KC_BOOTSTRAP_ADMIN_USERNAME- KC_BOOTSTRAP_ADMIN_PASSWORD-
+        echo "Waiting for Keycloak rollout after removing recovery admin..."
+        kubectl $CTX rollout status deployment/keycloak -n "$NS" --timeout=180s
+        echo "✓ Keycloak admin password synced."
+
   workspace:vaultwarden:seed:
     desc: "Seed Vaultwarden with production secret templates (ENV=dev|mentolder|korczewski). Run once after first login — see vaultwarden-seed-credentials.yaml."
     vars:

--- a/USER.md
+++ b/USER.md
@@ -11,8 +11,8 @@
 
 Patrick is writing his bachelor thesis — this repo IS the thesis project: a self-hosted Kubernetes collaboration platform for small teams. He runs two live production clusters:
 
-- **mentolder** — Hetzner VPS, ArgoCD hub, hosts mentolder.de (his dad's coaching platform, Astro+Svelte)
-- **korczewski** — spoke cluster managed by mentolder ArgoCD
+- **mentolder** — Hetzner VPS, hosts mentolder.de (his dad's coaching platform, Astro+Svelte)
+- **korczewski** — separate k3s cluster, hosts korczewski.de
 
 He prefers direct, concise communication. No filler, no step-by-step narration. Merge PRs immediately after creating (PRs are for history, not review). Always work against live environments (mentolder/korczewski), never k3d-dev for production changes.
 

--- a/deploy/mcp-korczewski/kustomization.yaml
+++ b/deploy/mcp-korczewski/kustomization.yaml
@@ -38,10 +38,8 @@ patches:
       metadata:
         name: claude-code-agent
 
-  # ── claude-code-config CM is owned by the workspace-korczewski ArgoCD
-  # Application (it documents the in-cluster split MCPs at claude-code-mcp-ops/
-  # claude-code-mcp-auth). The monolith pod doesn't consume it, so strip it
-  # to avoid an ArgoCD sync conflict.
+  # ── claude-code-config CM documents the in-cluster split MCPs at claude-code-mcp-ops/
+  # claude-code-mcp-auth. The monolith pod doesn't consume it, so strip it.
   - target:
       kind: ConfigMap
       name: claude-code-config

--- a/docs/superpowers/specs/2026-05-14-datamodel-workflow-overview-design.md
+++ b/docs/superpowers/specs/2026-05-14-datamodel-workflow-overview-design.md
@@ -26,7 +26,7 @@ Not in audience: end users, external reviewers, anyone needing a narrative tour.
 |---|---|
 | Dev-Flow Skills | `brainstorming`, `writing-plans`, `dev-flow-plan`, `dev-flow-execute`, `plan-context.sh`, `plan-frontmatter-hook.sh`, `using-git-worktrees` |
 | Agent Dispatch | `bachelorprojekt-{db,infra,ops,website,test,security}` from CLAUDE.md routing |
-| CI/CD Pipeline | `track-pr.yml`, `track-plans.yml`, `build-website.yml`, `dev-auto-deploy.yml`, `tracking-import` CronJob, ArgoCD reconcile |
+| CI/CD Pipeline | `track-pr.yml`, `track-plans.yml`, `build-website.yml`, `dev-auto-deploy.yml`, `tracking-import` CronJob |
 | App Data Flows | Keycloak SSO, Nextcloud Talk pipeline, Tickets/Bugs APIs, Coaching ingest, Arena gameplay, Brett snapshots |
 
 | DB domain | Anchor schemas |
@@ -273,7 +273,7 @@ Manual cadence: regenerate before any `docs:deploy` that follows a schema change
 
 3. **Mermaid pre-render cost.** The Domain Deep-dive section embeds 8 `erDiagram` blocks. `mmdc` runs serially today — building this page alone could add ~10–15 s to `task docs:build`. **Mitigation:** the existing `--fast` flag in `docs:build` already skips Mermaid pre-rendering (verified in `Taskfile.yml`); the developer iterates with `task docs:build FAST=true` and runs the full render only before deploy.
 
-4. **Schema introspection requires shared-db access.** The generator depends on the mentolder cluster being reachable. **Mitigation:** the task fails loudly if `kubectl --context mentolder` can't list the `shared-db` pod; documentation says "run after `task argocd:status` or any other cluster-reachable command."
+4. **Schema introspection requires shared-db access.** The generator depends on the mentolder cluster being reachable. **Mitigation:** the task fails loudly if `kubectl --context mentolder` can't list the `shared-db` pod; documentation says "run after `kubectl cluster-info --context mentolder` to verify cluster is reachable."
 
 5. **Sidebar conflict.** `_sidebar.md` is appended to by multiple PRs; merge conflicts likely if multiple in-flight branches add entries. **Mitigation:** none beyond normal rebase. The entry is one line.
 

--- a/k3s/kustomization.yaml
+++ b/k3s/kustomization.yaml
@@ -40,9 +40,8 @@ patches:
       name: nextcloud
     path: patches/nextcloud.yaml
 
-  # Collabora is deployed via the separate office-stack ArgoCD
-  # Application (k3d/office-stack + argocd/applicationset-office.yaml)
-  # because it needs CAP_SYS_ADMIN in a dedicated privileged ns.
+  # Collabora is deployed via the separate office-stack overlay
+  # (k3d/office-stack) because it needs CAP_SYS_ADMIN in a dedicated privileged ns.
 
   # ── Vaultwarden: production DOMAIN + SSO authority ──────────────
   - target:

--- a/prod-mentolder/patch-livekit.yaml
+++ b/prod-mentolder/patch-livekit.yaml
@@ -3,7 +3,7 @@
 # ever reschedules to a different node the pod stays Pending. longhorn replicates
 # across nodes so the volume is always accessible.
 # One-time live migration: delete livekit-recordings-pvc on the cluster, then
-# re-sync (ArgoCD will recreate it with longhorn). Existing recordings are lost.
+# re-apply (it will be recreated with longhorn). Existing recordings are lost.
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/scripts/keycloak-sync.sh
+++ b/scripts/keycloak-sync.sh
@@ -88,10 +88,9 @@ ADMIN_TOKEN=$(curl -sk \
 
 if [[ -z "$ADMIN_TOKEN" ]]; then
   warn "Admin-Token nicht erhältlich — Sync wird übersprungen."
-  warn "Hinweis: Admin-Passwort in workspace-secrets muss mit dem Passwort des 'admin'-Users im"
-  warn "Keycloak-Realm 'master' übereinstimmen. Bei Drift: Passwort in Keycloak zurücksetzen"
-  warn "(kcadm.sh set-password -r master --username admin --new-password \$NEU) oder"
-  warn "workspace-secrets auf den alten Wert zurücksetzen."
+  warn "Passwort-Drift erkannt: workspace-secrets-Passwort stimmt nicht mit dem live admin-User überein."
+  warn "Lösung: task keycloak:sync-admin-password ENV=${ENV}"
+  warn "Danach erneut: task keycloak:sync ENV=${ENV}"
   exit 0
 fi
 

--- a/scripts/t.sh
+++ b/scripts/t.sh
@@ -12,7 +12,7 @@ if ! command -v fzf &>/dev/null; then
 fi
 
 # ENV-sensitive task name patterns: tasks that accept ENV=
-ENV_PATTERN='workspace:|website:|brett:|arena:|livekit:|cert:|dev:|llm:|mcp:|keycloak:|docs:|argocd:|ha:|feature:'
+ENV_PATTERN='workspace:|website:|brett:|arena:|livekit:|cert:|dev:|llm:|mcp:|keycloak:|docs:|ha:|feature:'
 
 # Build list: "<name>  <description>"
 TASK_LIST=$(cd "$ROOT" && task --list-all 2>/dev/null \


### PR DESCRIPTION
## Summary

- **T000520** — ArgoCD fully removed: deleted all ApplicationSets + Applications from cluster; removed ArgoCD references from all live agent/skill/doc files (IDENTITY.md, USER.md, README.md, GEMINI.md, agents, skills, specs)
- **T000527** — New `keycloak:sync-admin-password ENV=<env>` task: uses Keycloak 26's `KC_BOOTSTRAP_ADMIN_*` backdoor to reset the admin password to match `workspace-secrets` without needing the current live password; `keycloak-sync.sh` now prints `task keycloak:sync-admin-password` when auth fails
- **T000498** — brainstorm sish authorized_keys were already in `.secrets/mentolder.yaml`; `task brainstorm:materialise-keys` was run to push them into the ConfigMap
- **T000512** — Confirmed Traefik DaemonSet runs only on `pk-hetzner-4/6/8` via nodeAffinity; `pk-l-1` was never scheduled

## Test plan

- [ ] `task test:all` green
- [ ] After korczewski workspace redeploy: `task keycloak:sync-admin-password ENV=korczewski` resets admin password
- [ ] `task keycloak:sync ENV=<env>` prints `task keycloak:sync-admin-password` when auth fails (no longer just skips silently)
- [ ] `kubectl get applicationsets,applications -A --context mentolder` returns empty
- [ ] `task brainstorm:status` shows brainstorm-sish pod with 2 authorized keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)