### PR TITLE
fix(tickets): guard systemtest schema migration + raise DocuSeal memory [T000010/T000011]

### DIFF
--- a/prod/patch-docuseal.yaml
+++ b/prod/patch-docuseal.yaml
@@ -37,3 +37,10 @@ spec:
                   key: SMTP_FROM
             - name: MAILER_FROM_NAME
               value: "${BRAND_NAME} Unterschriften"
+          resources:
+            requests:
+              memory: 512Mi
+              cpu: "100m"
+            limits:
+              memory: 2Gi
+              cpu: "500m"

--- a/website/src/lib/systemtest/db.ts
+++ b/website/src/lib/systemtest/db.ts
@@ -89,12 +89,22 @@ export async function ensureSystemtestSchema(pool: Pool): Promise<void> {
   // statement so column adds are safe even on a fresh DB where the
   // referenced tables (questionnaire_test_evidence, tickets.tickets) may
   // not yet have all FK targets in place.
+  // questionnaire_test_status is guarded by an existence check because it is
+  // created by questionnaire-db.ts initDb(), which may not have run yet on
+  // fresh or partially-initialised prod DBs. Without the guard the whole
+  // statement fails and block 3 (source_kind column) never runs.
   await pool.query(`
-    ALTER TABLE questionnaire_test_status
-      ADD COLUMN IF NOT EXISTS evidence_id            UUID,
-      ADD COLUMN IF NOT EXISTS last_failure_ticket_id UUID,
-      ADD COLUMN IF NOT EXISTS retest_pending_at      TIMESTAMPTZ,
-      ADD COLUMN IF NOT EXISTS retest_attempt         INT NOT NULL DEFAULT 0;
+    DO $$ BEGIN
+      IF EXISTS (SELECT 1 FROM information_schema.tables
+                 WHERE table_schema = 'public'
+                   AND table_name   = 'questionnaire_test_status') THEN
+        ALTER TABLE questionnaire_test_status
+          ADD COLUMN IF NOT EXISTS evidence_id            UUID,
+          ADD COLUMN IF NOT EXISTS last_failure_ticket_id UUID,
+          ADD COLUMN IF NOT EXISTS retest_pending_at      TIMESTAMPTZ,
+          ADD COLUMN IF NOT EXISTS retest_attempt         INT NOT NULL DEFAULT 0;
+      END IF;
+    END$$;
 
     ALTER TABLE tickets.tickets
       ADD COLUMN IF NOT EXISTS source_test_assignment_id UUID,


### PR DESCRIPTION
## Summary

- **T000010** — `ensureSystemtestSchema` block 2 now wraps `ALTER TABLE questionnaire_test_status` in a `DO $$ IF EXISTS $$` guard. Without it, the entire multi-statement query fails when `questionnaire_test_status` doesn't exist in prod (it's created by `questionnaire-db.ts initDb()` which may not have run yet), blocking block 3 from adding the `source_kind` column to `systemtest_failure_outbox`.
- **T000011** — DocuSeal was OOM-killed 7× on mentolder (exit 137, limit 1Gi). Added explicit `resources` block to `prod/patch-docuseal.yaml` raising the limit to 2Gi.

## Test plan

- [ ] Verify `systemtest_failure_outbox.source_kind` column appears after next website pod restart (schema runs at startup)
- [ ] Verify DocuSeal pod on mentolder stays stable after `task feature:website` deploys the new limit
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)