### PR TITLE
fix(flux): add missing website-vars and escape shell ${} in dev-db-refresh

### DIFF
--- a/flux/apps/website-korczewski/website-vars-configmap.yaml
+++ b/flux/apps/website-korczewski/website-vars-configmap.yaml
@@ -24,8 +24,16 @@ data:
   LEGAL_JOBTITLE: Informatiker
   LEGAL_WEBSITE: korczewski.de
   CLUSTER_ENV: korczewski
-  SYSTEMTEST_LOOP_ENABLED: "false"
-  LLM_ENABLED: "false"
+  SYSTEMTEST_LOOP_ENABLED: "true"
+  LLM_ENABLED: "true"
   LLM_RERANK_ENABLED: "false"
   LLM_ROUTER_URL: http://llm-router.workspace-korczewski.svc.cluster.local:4000
   SMTP_FROM: info@korczewski.de
+  SMTP_HOST: smtp.mailbox.org
+  SMTP_PORT: "587"
+  SMTP_SECURE: "false"
+  SMTP_USER: korczewski@mailbox.org
+  CONTACT_PHONE: ""
+  LEGAL_STREET: "In der Twiet 4"
+  LEGAL_ZIP: "21360"
+  LEGAL_UST_ID: "Kleinunternehmer gem. § 19 Abs. 1 UStG"

--- a/flux/apps/website-mentolder/website-vars-configmap.yaml
+++ b/flux/apps/website-mentolder/website-vars-configmap.yaml
@@ -24,8 +24,16 @@ data:
   LEGAL_JOBTITLE: Coach und digitaler Begleiter
   LEGAL_WEBSITE: mentolder.de
   CLUSTER_ENV: mentolder
-  SYSTEMTEST_LOOP_ENABLED: "false"
-  LLM_ENABLED: "false"
+  SYSTEMTEST_LOOP_ENABLED: "true"
+  LLM_ENABLED: "true"
   LLM_RERANK_ENABLED: "false"
   LLM_ROUTER_URL: http://llm-router.workspace.svc.cluster.local:4000
   SMTP_FROM: info@mentolder.de
+  SMTP_HOST: smtp.mailbox.org
+  SMTP_PORT: "587"
+  SMTP_SECURE: "false"
+  SMTP_USER: mentolder@mailbox.org
+  CONTACT_PHONE: "+49 151 508 32 601"
+  LEGAL_STREET: "Ludwig-Erhard-Str. 18"
+  LEGAL_ZIP: "20459"
+  LEGAL_UST_ID: "33/023/05100"

--- a/prod-korczewski/dev-db-refresh.sh
+++ b/prod-korczewski/dev-db-refresh.sh
@@ -44,7 +44,7 @@ done
 
 # Re-align role password (in case the prod dump altered the role definition).
 psql -h "$PGHOST" -p "$PGPORT" -U postgres -d postgres -v ON_ERROR_STOP=1 <<-SQL
-  ALTER ROLE website WITH PASSWORD '${DEV_WEBSITE_DB_PASSWORD}';
+  ALTER ROLE website WITH PASSWORD '$${DEV_WEBSITE_DB_PASSWORD}';
 SQL
 
 echo "[dev-refresh] done."

--- a/prod-mentolder/dev-db-refresh.sh
+++ b/prod-mentolder/dev-db-refresh.sh
@@ -44,7 +44,7 @@ done
 
 # Re-align role password (in case the prod dump altered the role definition).
 psql -h "$PGHOST" -p "$PGPORT" -U postgres -d postgres -v ON_ERROR_STOP=1 <<-SQL
-  ALTER ROLE website WITH PASSWORD '${DEV_WEBSITE_DB_PASSWORD}';
+  ALTER ROLE website WITH PASSWORD '$${DEV_WEBSITE_DB_PASSWORD}';
 SQL
 
 echo "[dev-refresh] done."


### PR DESCRIPTION
## Summary
- **website-vars ConfigMaps** (both clusters): add 8 missing vars (`SMTP_HOST`, `SMTP_PORT`, `SMTP_SECURE`, `SMTP_USER`, `CONTACT_PHONE`, `LEGAL_STREET`, `LEGAL_ZIP`, `LEGAL_UST_ID`) that were causing Flux to leave `${VAR}` unexpanded in `website-config`. All boolean/numeric values are quoted strings to prevent YAML type coercion (`SMTP_SECURE: "false"`, `SMTP_PORT: "587"`). Also corrects `LLM_ENABLED` and `SYSTEMTEST_LOOP_ENABLED` from `"false"` → `"true"` to match `environments/*.yaml`.
- **dev-db-refresh.sh** (both clusters): escape `${DEV_WEBSITE_DB_PASSWORD}` → `$${DEV_WEBSITE_DB_PASSWORD}` so Flux's `substituteFrom` passes it through unchanged; the `${}` → `${}` reduction at reconcile time leaves the correct shell variable for the running pod. Shell default-value patterns like `${VAR:=default}` are unaffected (Flux skips non-identifier content inside `{}`).

## Test plan
- [ ] Flux website Kustomization reconciles cleanly on mentolder after merge
- [ ] Flux website Kustomization reconciles cleanly on korczewski after merge
- [ ] `kubectl get configmap website-config -n website --context mentolder -o yaml | grep -E "SMTP_SECURE|LLM_ENABLED"` shows `"false"` and `"true"` (strings, not bare booleans)
- [ ] `kubectl get configmap website-config -n website-korczewski --context korczewski -o yaml | grep SMTP_SECURE` shows `"false"`
- [ ] dev-db-refresh CronJob next run sets the website role password correctly (not empty string)

🤖 Generated with [Claude Code](https://claude.com/claude-code)