### PR TITLE
fix(flux): resolve website ConfigMap type coercion and move website-vars to cluster layer

### DIFF
--- a/flux/apps/website-korczewski/kustomization.yaml
+++ b/flux/apps/website-korczewski/kustomization.yaml
@@ -4,9 +4,12 @@ namespace: website-korczewski
 resources:
   - ../../../k3d/website.yaml
   - ../../../k3d/website-seller-config.yaml
-  - website-vars-configmap.yaml
 patches:
   - path: image-tag.yaml
     target:
       kind: Deployment
       name: website
+  - path: website-config-patch.yaml
+    target:
+      kind: ConfigMap
+      name: website-config

--- a/flux/apps/website-korczewski/website-config-patch.yaml
+++ b/flux/apps/website-korczewski/website-config-patch.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: website-config
+data:
+  SMTP_PORT: "587"
+  SMTP_SECURE: "false"
+  LLM_ENABLED: "true"
+  LLM_RERANK_ENABLED: "false"
+  SYSTEMTEST_LOOP_ENABLED: "true"
+  LEGAL_ZIP: "21360"

--- a/flux/apps/website-mentolder/kustomization.yaml
+++ b/flux/apps/website-mentolder/kustomization.yaml
@@ -4,9 +4,12 @@ namespace: website
 resources:
   - ../../../k3d/website.yaml
   - ../../../k3d/website-seller-config.yaml
-  - website-vars-configmap.yaml
 patches:
   - path: image-tag.yaml
     target:
       kind: Deployment
       name: website
+  - path: website-config-patch.yaml
+    target:
+      kind: ConfigMap
+      name: website-config

--- a/flux/apps/website-mentolder/website-config-patch.yaml
+++ b/flux/apps/website-mentolder/website-config-patch.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: website-config
+data:
+  SMTP_PORT: "587"
+  SMTP_SECURE: "false"
+  LLM_ENABLED: "true"
+  LLM_RERANK_ENABLED: "false"
+  SYSTEMTEST_LOOP_ENABLED: "true"
+  LEGAL_ZIP: "20459"

--- a/flux/clusters/korczewski/kustomization.yaml
+++ b/flux/clusters/korczewski/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - vars-configmap.yaml
+  - website-vars-configmap.yaml
+  - website.yaml
+  - workspace.yaml
+  - image-update-automation.yaml

--- a/flux/clusters/korczewski/website-vars-configmap.yaml
+++ b/flux/clusters/korczewski/website-vars-configmap.yaml
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: website-vars
+  namespace: flux-system
+data:
+  WEBSITE_HOST: web.korczewski.de
+  WEBSITE_SITE_URL: https://web.korczewski.de
+  KEYCLOAK_FRONTEND_URL: https://auth.korczewski.de
+  AUTH_EXTERNAL_URL: https://auth.korczewski.de
+  NEXTCLOUD_EXTERNAL_URL: https://files.korczewski.de
+  DOCS_URL: https://docs.korczewski.de
+  VAULT_EXTERNAL_URL: https://vault.korczewski.de
+  WHITEBOARD_EXTERNAL_URL: https://board.korczewski.de
+  TRAEFIK_EXTERNAL_URL: https://traefik.korczewski.de
+  MAIL_EXTERNAL_URL: https://mail.korczewski.de
+  BRETT_DOMAIN: brett.korczewski.de
+  LIVEKIT_DOMAIN: livekit.korczewski.de
+  STREAM_DOMAIN: stream.korczewski.de
+  ARENA_WS_URL: wss://arena-ws.korczewski.de
+  CONTACT_EMAIL: info@korczewski.de
+  CONTACT_NAME: Patrick Korczewski
+  CONTACT_CITY: "Wuppertal"
+  LEGAL_JOBTITLE: Informatiker
+  LEGAL_WEBSITE: korczewski.de
+  CLUSTER_ENV: korczewski
+  SYSTEMTEST_LOOP_ENABLED: "true"
+  LLM_ENABLED: "true"
+  LLM_RERANK_ENABLED: "false"
+  LLM_ROUTER_URL: http://llm-router.workspace-korczewski.svc.cluster.local:4000
+  SMTP_FROM: info@korczewski.de
+  SMTP_HOST: smtp.mailbox.org
+  SMTP_PORT: "587"
+  SMTP_SECURE: "false"
+  SMTP_USER: korczewski@mailbox.org
+  CONTACT_PHONE: ""
+  LEGAL_STREET: "In der Twiet 4"
+  LEGAL_ZIP: "21360"
+  LEGAL_UST_ID: "Kleinunternehmer gem. § 19 Abs. 1 UStG"

--- a/flux/clusters/mentolder/kustomization.yaml
+++ b/flux/clusters/mentolder/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
   - flux-system/
   - image-update-automation.yaml
   - vars-configmap.yaml
+  - website-vars-configmap.yaml
   - website.yaml
   - workspace.yaml
 patches:

--- a/flux/clusters/mentolder/website-vars-configmap.yaml
+++ b/flux/clusters/mentolder/website-vars-configmap.yaml
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: website-vars
+  namespace: flux-system
+data:
+  WEBSITE_HOST: web.mentolder.de
+  WEBSITE_SITE_URL: https://web.mentolder.de
+  KEYCLOAK_FRONTEND_URL: https://auth.mentolder.de
+  AUTH_EXTERNAL_URL: https://auth.mentolder.de
+  NEXTCLOUD_EXTERNAL_URL: https://files.mentolder.de
+  DOCS_URL: https://docs.mentolder.de
+  VAULT_EXTERNAL_URL: https://vault.mentolder.de
+  WHITEBOARD_EXTERNAL_URL: https://board.mentolder.de
+  TRAEFIK_EXTERNAL_URL: https://traefik.mentolder.de
+  MAIL_EXTERNAL_URL: https://mail.mentolder.de
+  BRETT_DOMAIN: brett.mentolder.de
+  LIVEKIT_DOMAIN: livekit.mentolder.de
+  STREAM_DOMAIN: stream.mentolder.de
+  ARENA_WS_URL: wss://arena-ws.korczewski.de
+  CONTACT_EMAIL: info@mentolder.de
+  CONTACT_NAME: Gerald Korczewski
+  CONTACT_CITY: "Lüneburg, Hamburg und Umgebung"
+  LEGAL_JOBTITLE: Coach und digitaler Begleiter
+  LEGAL_WEBSITE: mentolder.de
+  CLUSTER_ENV: mentolder
+  SYSTEMTEST_LOOP_ENABLED: "true"
+  LLM_ENABLED: "true"
+  LLM_RERANK_ENABLED: "false"
+  LLM_ROUTER_URL: http://llm-router.workspace.svc.cluster.local:4000
+  SMTP_FROM: info@mentolder.de
+  SMTP_HOST: smtp.mailbox.org
+  SMTP_PORT: "587"
+  SMTP_SECURE: "false"
+  SMTP_USER: mentolder@mailbox.org
+  CONTACT_PHONE: "+49 151 508 32 601"
+  LEGAL_STREET: "Ludwig-Erhard-Str. 18"
+  LEGAL_ZIP: "20459"
+  LEGAL_UST_ID: "33/023/05100"

--- a/prod-korczewski/dev-db-refresh.sh
+++ b/prod-korczewski/dev-db-refresh.sh
@@ -25,8 +25,8 @@ echo "[dev-refresh] using snapshot $STAMP"
 
 export PGPASSWORD="$DEV_SHARED_DB_PASSWORD"
 
-for DB in "${DBS[@]}"; do
-  SRC="$BACKUP_DIR/$STAMP/${DB}.dump.enc"
+for DB in "$${DBS[@]}"; do
+  SRC="$BACKUP_DIR/$STAMP/$DB.dump.enc"
   if [[ ! -f "$SRC" ]]; then
     echo "[dev-refresh] skip $DB — no $SRC"
     continue

--- a/prod-mentolder/dev-db-refresh.sh
+++ b/prod-mentolder/dev-db-refresh.sh
@@ -26,7 +26,7 @@ echo "[dev-refresh] using snapshot $STAMP"
 export PGPASSWORD="$DEV_SHARED_DB_PASSWORD"
 
 for DB in "$${DBS[@]}"; do
-  SRC="$BACKUP_DIR/$STAMP/${DB}.dump.enc"
+  SRC="$BACKUP_DIR/$STAMP/$DB.dump.enc"
   if [[ ! -f "$SRC" ]]; then
     echo "[dev-refresh] skip $DB — no $SRC"
     continue


### PR DESCRIPTION
## Summary

- **Type coercion bug**: Flux's `postBuild.substituteFrom` operates at YAML-AST level — kustomize strips double-quote node style from `"${VAR}"` before Flux's envsubst replaces it, so `SMTP_PORT: "${SMTP_PORT}"` produces `SMTP_PORT: 587` (integer) and `LLM_ENABLED: "${LLM_ENABLED}"` produces `LLM_ENABLED: true` (boolean), causing Kubernetes SSA dry-run to reject `website-config` with `expected string, got &value.valueUnstructured{Value:587}`
- **Architecture fix**: `website-vars-configmap.yaml` was in `flux/apps/website-{env}/` where kustomize's `namespace: website` override placed it in the wrong namespace; Flux's `substituteFrom` looks in `flux-system` — moved to `flux/clusters/{env}/` (managed by flux-system Kustomization) so git changes to `website-vars` are automatically reflected
- **dev-db-refresh.sh**: escape remaining unescaped `${DB}` → `$DB` (after PR #868 fixed `${DBS[@]}`)

## Changes

- `flux/apps/website-{env}/website-config-patch.yaml` — new kustomize patches that set `SMTP_PORT`, `SMTP_SECURE`, `LLM_ENABLED`, `LLM_RERANK_ENABLED`, `SYSTEMTEST_LOOP_ENABLED`, `LEGAL_ZIP` as literal string values; kustomize's go-yaml serializer quotes them (`"587"`, `"false"`), bypassing Flux envsubst entirely
- `flux/clusters/{env}/website-vars-configmap.yaml` — moved from app layer; now managed by flux-system Kustomization in `flux-system` namespace where it can be found by `substituteFrom`
- `flux/clusters/korczewski/kustomization.yaml` — created (was missing)
- `prod-{env}/dev-db-refresh.sh` — `${DB}` → `$DB`

## Test plan

- [ ] `flux reconcile kustomization website --context mentolder --with-source` — expect `Applied revision: main@sha1:...` with no SSA dry-run errors
- [ ] `kubectl --context mentolder -n website get configmap website-config -o yaml | grep -E 'SMTP_PORT|SMTP_SECURE|LLM_ENABLED|LEGAL_ZIP'` — all values quoted strings
- [ ] `flux reconcile kustomization workspace --context mentolder --with-source` — expect success (no missing closing brace)
- [ ] `kubectl --context mentolder -n flux-system get configmap website-vars` — exists in flux-system

🤖 Generated with [Claude Code](https://claude.com/claude-code)