### PR TITLE
feat(knowledge): wire context7_docs as first-class pgvector ingest source [T000053]

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -3296,7 +3296,7 @@ tasks:
   # Knowledge Base (pgvector RAG)
   # ─────────────────────────────────────────────
   knowledge:reindex:
-    desc: "Re-index knowledge collections (SOURCE=prs|markdown|bugs|all, ENV=dev|mentolder|korczewski)"
+    desc: "Re-index knowledge collections (SOURCE=prs|markdown|bugs|context7|all, ENV=dev|mentolder|korczewski)"
     vars:
       ENV: '{{.ENV | default "dev"}}'
       SOURCE: '{{.SOURCE | default "all"}}'

--- a/docs/superpowers/plans/2026-05-19-context7-ingest-wiring.md
+++ b/docs/superpowers/plans/2026-05-19-context7-ingest-wiring.md
@@ -1,0 +1,83 @@
+---
+ticket_id: T000053
+status: active
+domains: [website, scripts]
+---
+
+# Plan: Wire context7_docs as first-class pgvector ingest source
+
+## Context
+
+`scripts/knowledge/ingest-context7.mjs` and the `context7_docs` CollectionSource type already
+exist. What's missing is the admin surface to use them:
+- No API trigger endpoint (like crawl.ts does for web_crawl)
+- No way to store the libraryId config on the collection
+- `deleteCollection` guards against context7_docs
+- `reindex.sh` has no context7 case
+
+The `crawl_config` JSONB column is reused to store `{ libraryId, tokens }` for
+context7_docs collections — no migration needed.
+
+## Tasks
+
+### 1. knowledge-db.ts — Context7Config type + updateContext7Config + deleteCollection fix
+
+File: `website/src/lib/knowledge-db.ts`
+
+- Add `Context7Config` interface: `{ libraryId: string; tokens?: number }`
+- Extend `Collection` type: `context7_config: Context7Config | null` (read from `crawl_config`
+  when source is `context7_docs` — same DB column, different shape)
+- Add `updateContext7Config(id: string, config: Context7Config): Promise<void>` — writes to
+  `crawl_config` column
+- Fix `deleteCollection`: add `'context7_docs'` to the allowed sources guard
+
+### 2. New API endpoint: context7-config.ts (PATCH)
+
+File: `website/src/pages/api/admin/knowledge/collections/[id]/context7-config.ts`
+
+Mirrors `crawl-config.ts` but for `context7_docs` source:
+- Validates `source === 'context7_docs'`
+- Requires `libraryId` (non-empty string, must start with `/`)
+- Optional `tokens` (positive int, default 20000)
+- Calls `updateContext7Config`
+
+### 3. New API endpoint: context7.ts (POST + GET)
+
+File: `website/src/pages/api/admin/knowledge/collections/[id]/context7.ts`
+
+Mirrors `crawl.ts` exactly, but:
+- Validates `source === 'context7_docs'`
+- Reads `libraryId` + `tokens` from `crawl_config` (via getCollection)
+- Spawns `node scripts/knowledge/ingest-context7.mjs` with env:
+  `COLLECTION_ID`, `LIBRARY_ID`, `TOKENS`, `PGURL`, `VOYAGE_API_KEY`, `LLM_ENABLED`, etc.
+- Module-level `activeIngests` Set for deduplication
+- GET returns `{ running: boolean }`
+
+### 4. reindex.sh — add context7 case
+
+File: `scripts/knowledge/reindex.sh`
+
+Add `context7` case: query DB for all `context7_docs` collections, loop and run
+`ingest-context7.mjs` per collection with `COLLECTION_ID` + `LIBRARY_ID` + `TOKENS` from
+`crawl_config`. Update `all` case to include `run_context7`.
+
+### 5. Taskfile.yml — update knowledge:reindex desc
+
+Add `context7` to the `SOURCE=` doc string on the `knowledge:reindex` task.
+
+## Verification
+
+```bash
+task test:all                        # offline tests must stay green
+task workspace:validate              # no manifest changes, should pass trivially
+# Manual smoke:
+# POST /api/admin/knowledge/collections/<uuid>/context7-config { libraryId: '/withastro/docs' }
+# POST /api/admin/knowledge/collections/<uuid>/context7
+# Check collection chunk_count increases in admin UI
+```
+
+## Out of scope
+
+- Admin UI changes (the existing collections page already has a "Crawl" trigger button
+  pattern; a follow-up can add a "Sync" button for context7_docs in the same pass)
+- context7 MCP `query-docs` integration (separate concern)

--- a/scripts/knowledge/reindex.sh
+++ b/scripts/knowledge/reindex.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Run the appropriate knowledge ingestion script.
-# Usage: SOURCE=prs|markdown|bugs|all PGHOST=... PGPASSWORD=... bash reindex.sh
+# Usage: SOURCE=prs|markdown|bugs|context7|all PGURL=... bash reindex.sh
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -11,17 +11,33 @@ run() {
   node "${SCRIPT_DIR}/ingest-${1}.mjs"
 }
 
+run_context7() {
+  echo "[knowledge/reindex] running context7 ingest for all context7_docs collections..."
+  psql "${PGURL}" -At -c \
+    "SELECT id || '|' || (crawl_config->>'libraryId') || '|' || COALESCE(crawl_config->>'tokens', '20000')
+       FROM knowledge.collections
+      WHERE source = 'context7_docs'
+        AND crawl_config->>'libraryId' IS NOT NULL" \
+  | while IFS='|' read -r col_id lib_id tokens; do
+      echo "[knowledge/reindex] context7: ${lib_id} → ${col_id}"
+      COLLECTION_ID="${col_id}" LIBRARY_ID="${lib_id}" TOKENS="${tokens}" \
+        node "${SCRIPT_DIR}/ingest-context7.mjs"
+    done
+}
+
 case "$SOURCE" in
   prs)      run prs ;;
   markdown) run markdown ;;
   bugs)     run bug-tickets ;;
+  context7) run_context7 ;;
   all)
     run prs
     run markdown
     run bug-tickets
+    run_context7
     ;;
   *)
-    echo "Unknown SOURCE='$SOURCE'. Use: prs|markdown|bugs|all" >&2
+    echo "Unknown SOURCE='$SOURCE'. Use: prs|markdown|bugs|context7|all" >&2
     exit 1
     ;;
 esac

--- a/website/src/lib/knowledge-db.ts
+++ b/website/src/lib/knowledge-db.ts
@@ -42,6 +42,11 @@ export interface CrawlConfig {
   userAgent?: string;
 }
 
+export interface Context7Config {
+  libraryId: string;
+  tokens?: number;
+}
+
 export interface Collection {
   id: string;
   name: string;
@@ -109,9 +114,17 @@ export async function createCollection(args: {
 export async function deleteCollection(id: string): Promise<void> {
   const c = await getCollection(id);
   if (!c) throw new Error('not_found');
-  if (c.source !== 'custom' && c.source !== 'web_crawl')
+  if (c.source !== 'custom' && c.source !== 'web_crawl' && c.source !== 'context7_docs')
     throw new Error('cannot delete non-custom collection');
   await p().query('DELETE FROM knowledge.collections WHERE id = $1', [id]);
+}
+
+export async function updateContext7Config(id: string, config: Context7Config): Promise<void> {
+  const result = await p().query(
+    `UPDATE knowledge.collections SET crawl_config = $2::jsonb WHERE id = $1`,
+    [id, JSON.stringify(config)],
+  );
+  if (result.rowCount === 0) throw new Error('not_found');
 }
 
 export async function updateCrawlConfig(id: string, config: CrawlConfig): Promise<void> {

--- a/website/src/pages/api/admin/knowledge/collections/[id]/context7-config.ts
+++ b/website/src/pages/api/admin/knowledge/collections/[id]/context7-config.ts
@@ -1,0 +1,49 @@
+import type { APIRoute } from 'astro';
+import { getSession, isAdmin } from '../../../../../../lib/auth';
+import { getCollection, updateContext7Config, type Context7Config } from '../../../../../../lib/knowledge-db';
+
+export const PATCH: APIRoute = async ({ request, params }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) return new Response('Unauthorized', { status: 401 });
+
+  const id = params.id!;
+  const c = await getCollection(id);
+  if (!c) return new Response(JSON.stringify({ error: 'not_found' }), { status: 404 });
+  if (c.source !== 'context7_docs') {
+    return new Response(
+      JSON.stringify({ error: 'context7_config ist nur für context7_docs-Sammlungen relevant' }),
+      { status: 400 },
+    );
+  }
+
+  const body = await request.json() as Partial<Context7Config>;
+
+  if (!body.libraryId?.trim()) {
+    return new Response(JSON.stringify({ error: 'libraryId erforderlich' }), { status: 400 });
+  }
+  if (!body.libraryId.startsWith('/')) {
+    return new Response(
+      JSON.stringify({ error: 'libraryId muss mit / beginnen (z.B. /withastro/docs)' }),
+      { status: 400 },
+    );
+  }
+  if (body.tokens !== undefined && (typeof body.tokens !== 'number' || body.tokens < 1)) {
+    return new Response(JSON.stringify({ error: 'tokens muss eine positive Zahl sein' }), { status: 400 });
+  }
+
+  const config: Context7Config = {
+    libraryId: body.libraryId.trim(),
+    tokens: body.tokens ?? 20000,
+  };
+
+  try {
+    await updateContext7Config(id, config);
+    return new Response(JSON.stringify({ ok: true, context7_config: config }), {
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (err: unknown) {
+    if (err instanceof Error && err.message === 'not_found')
+      return new Response(JSON.stringify({ error: 'not_found' }), { status: 404 });
+    throw err;
+  }
+};

--- a/website/src/pages/api/admin/knowledge/collections/[id]/context7.ts
+++ b/website/src/pages/api/admin/knowledge/collections/[id]/context7.ts
@@ -1,0 +1,84 @@
+import type { APIRoute } from 'astro';
+import { spawn } from 'node:child_process';
+import { resolve } from 'node:path';
+import { getSession, isAdmin } from '../../../../../../lib/auth';
+import { getCollection } from '../../../../../../lib/knowledge-db';
+
+const activeIngests = new Set<string>();
+
+export const POST: APIRoute = async ({ request, params }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) return new Response('Unauthorized', { status: 401 });
+
+  const id = params.id!;
+
+  const c = await getCollection(id);
+  if (!c) return new Response(JSON.stringify({ error: 'not_found' }), { status: 404 });
+  if (c.source !== 'context7_docs') {
+    return new Response(
+      JSON.stringify({ error: 'Nur context7_docs-Sammlungen können über diesen Endpunkt indiziert werden' }),
+      { status: 400 },
+    );
+  }
+
+  const cfg = c.crawl_config as { libraryId?: string; tokens?: number } | null;
+  if (!cfg?.libraryId) {
+    return new Response(
+      JSON.stringify({ error: 'Keine libraryId konfiguriert. Bitte erst Context7-Konfiguration speichern.' }),
+      { status: 422 },
+    );
+  }
+
+  if (activeIngests.has(id)) {
+    return new Response(
+      JSON.stringify({ error: 'Indizierung läuft bereits für diese Sammlung' }),
+      { status: 409 },
+    );
+  }
+
+  const repoRoot   = process.env.REPO_ROOT ?? resolve(new URL(import.meta.url).pathname, '../../../../../../../../../');
+  const scriptPath = resolve(repoRoot, 'scripts/knowledge/ingest-context7.mjs');
+
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    COLLECTION_ID: id,
+    LIBRARY_ID:    cfg.libraryId,
+    TOKENS:        String(cfg.tokens ?? 20000),
+    PGURL: process.env.SESSIONS_DATABASE_URL
+        ?? 'postgresql://website:devwebsitedb@shared-db.workspace.svc.cluster.local:5432/website',
+  };
+
+  activeIngests.add(id);
+  const child = spawn('node', [scriptPath], {
+    env,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    detached: false,
+  });
+
+  child.stdout.on('data', (d: Buffer) => process.stdout.write(`[context7:${id.slice(0,8)}] ${d}`));
+  child.stderr.on('data', (d: Buffer) => process.stderr.write(`[context7:${id.slice(0,8)}] ${d}`));
+
+  child.on('close', (code: number | null) => {
+    activeIngests.delete(id);
+    if (code !== 0) {
+      console.error(`[context7] ${id} exited with code ${code}`);
+    } else {
+      console.log(`[context7] ${id} completed successfully`);
+    }
+  });
+
+  return new Response(
+    JSON.stringify({ message: 'Indizierung gestartet', collectionId: id, libraryId: cfg.libraryId }),
+    { status: 202, headers: { 'Content-Type': 'application/json' } },
+  );
+};
+
+export const GET: APIRoute = async ({ request, params }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) return new Response('Unauthorized', { status: 401 });
+  const id = params.id!;
+  return new Response(
+    JSON.stringify({ running: activeIngests.has(id) }),
+    { headers: { 'Content-Type': 'application/json' } },
+  );
+};


### PR DESCRIPTION
## Summary
- Adds `POST /api/admin/knowledge/collections/[id]/context7` to trigger `ingest-context7.mjs` (mirrors existing `crawl.ts` pattern — spawns child process, returns 202, deduplicates concurrent runs via `activeIngests` Set)
- Adds `PATCH /api/admin/knowledge/collections/[id]/context7-config` to store `{ libraryId, tokens }` in the existing `crawl_config` jsonb column
- Adds `Context7Config` interface and `updateContext7Config` to `knowledge-db.ts`; also allows `deleteCollection` for `context7_docs` source
- Adds `context7` case to `scripts/knowledge/reindex.sh` — queries DB for all `context7_docs` collections and loops `ingest-context7.mjs` per collection; included in `SOURCE=all`

## Test plan
- [x] `task test:all` — all tests green
- [x] `task workspace:validate` — manifests valid
- [x] Admin menu gate — PASSED (new routes are `/api/` endpoints, not admin pages)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>