### PR TITLE
fix(deps): scope Renovate to managed packages, silence whisper digest error

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,14 @@
   "extends": ["config:recommended"],
   "schedule": ["before 9am on Monday"],
   "minimumReleaseAge": "3 days",
+  "ignorePaths": [
+    "**/node_modules/**",
+    "art-library/**",
+    "scripts/coaching/**",
+    "scripts/knowledge/**",
+    "tests/e2e/**",
+    "tests/unit/**"
+  ],
   "packageRules": [
     {
       "matchManagers": ["npm"],
@@ -43,6 +51,10 @@
     },
     {
       "matchPackagePatterns": ["^ghcr.io/paddione/"],
+      "enabled": false
+    },
+    {
+      "matchPackageNames": ["fedirz/faster-whisper-server"],
       "enabled": false
     }
   ],


### PR DESCRIPTION
## Summary
- Adds `ignorePaths` to exclude unmanaged npm packages (art-library, scripts/coaching, scripts/knowledge, tests/e2e, tests/unit) — fixes "updating multiple lock files is deprecated" warning and removes the hidden Unicode detection (which was in art-library/_tooling/node_modules/iconv-lite)
- Disables `fedirz/faster-whisper-server` in packageRules — the image is digest-pinned without a tag, so Renovate cannot look up newer digests; managed manually

## Root cause
Renovate auto-discovered 8+ npm lock files including art-library/_tooling, which has node_modules containing legitimate multibyte charset data (iconv-lite encoding tables). Renovate flagged those as "hidden Unicode."

## Test plan
- [x] JSON validates cleanly
- [ ] After next Renovate run: no "multiple lock files" warning, no hidden Unicode warning, no whisper lookup error

🤖 Generated with [Claude Code](https://claude.com/claude-code)