### PR TITLE
feat(style): restore mentolder ink/brass design tokens in admin

### DIFF
--- a/website/src/styles/admin-premium.css
+++ b/website/src/styles/admin-premium.css
@@ -1,28 +1,26 @@
 :root {
-  --admin-bg: #0a0a0c;
-  --admin-sidebar-bg: rgba(18, 18, 22, 0.8);
-  --admin-surface: rgba(255, 255, 255, 0.03);
-  --admin-surface-hover: rgba(255, 255, 255, 0.06);
-  --admin-border: rgba(255, 255, 255, 0.08);
-  --admin-border-bright: rgba(255, 255, 255, 0.15);
-  
-  --admin-primary: #d4af37; /* Premium Brass */
-  --admin-primary-muted: rgba(212, 175, 55, 0.2);
-  --admin-accent: #6366f1; /* Indigo */
-  
-  --admin-text: #e4e4e7;
-  --admin-text-mute: #a1a1aa;
-  --admin-text-disabled: #52525b;
-  
-  --glass-blur: 12px;
+  --admin-bg: #0b111c;              /* mentolder ink-900 */
+  --admin-sidebar-bg: #101826;      /* mentolder ink-850 — flat, no glass */
+  --admin-surface: rgba(255, 255, 255, 0.04);
+  --admin-surface-hover: rgba(255, 255, 255, 0.07);
+  --admin-border: rgba(255, 255, 255, 0.07);      /* same as --line */
+  --admin-border-bright: rgba(255, 255, 255, 0.12);
+
+  --admin-primary: oklch(0.80 0.09 75);           /* mentolder brass */
+  --admin-primary-muted: oklch(0.80 0.09 75 / 0.15);
+  --admin-accent: #818cf8;                        /* indigo */
+
+  --admin-text: #eef1f3;            /* mentolder fg */
+  --admin-text-mute: #8c96a3;       /* mentolder mute */
+  --admin-text-disabled: #4a5568;
+
   --sidebar-width: 16rem;
   --sidebar-collapsed-width: 4rem;
 }
 
 #admin-sidebar {
   width: var(--sidebar-width);
-  backdrop-filter: blur(var(--glass-blur));
-  background: var(--admin-sidebar-bg);
+  background: var(--admin-sidebar-bg);   /* flat ink-850 — no backdrop-filter */
   border-right: 1px solid var(--admin-border);
   transition: width 0.3s cubic-bezier(0.4, 0, 0.2, 1);
 }
@@ -97,10 +95,9 @@ html.sidebar-collapsed #admin-sidebar {
   border-radius: 10px;
 }
 
-/* Glassmorphism Cards */
+/* Cards */
 .admin-card {
   background: var(--admin-surface);
-  backdrop-filter: blur(8px);
   border: 1px solid var(--admin-border);
   border-radius: 16px;
   padding: 1.5rem;
@@ -135,7 +132,6 @@ html.sidebar-collapsed #icon-expand   { display: block; }
     position: fixed; top: 0; left: 0; right: 0;
     height: 60px;
     background: var(--admin-sidebar-bg);
-    backdrop-filter: blur(var(--glass-blur));
     border-bottom: 1px solid var(--admin-border);
     z-index: 40;
     padding: 0 16px;


### PR DESCRIPTION
## Summary
- Reverts admin glassmorphism/premium CSS (from PR #883) back to standard mentolder ink/brass tokens
- Removes all `backdrop-filter: blur()` from sidebar, cards, and mobile topbar
- Aligns `--admin-bg`, `--admin-sidebar-bg`, `--admin-primary`, `--admin-text*` with `--ink-900`, `--ink-850`, `oklch(0.80 0.09 75)` (brass), `--fg`, `--mute`
- No layout, component, or behaviour changes — CSS variables only

## Test plan
- [x] task test:all
- [x] bash scripts/admin-menu-gate.sh

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>