### PR TITLE
chore(skills): fix worktree path — use /tmp/wt- instead of .claude/worktrees/ [T000061]

### DIFF
--- a/.claude/skills/dev-flow-plan/SKILL.md
+++ b/.claude/skills/dev-flow-plan/SKILL.md
@@ -125,9 +125,11 @@ Falls kein Worktree existiert: Rufe `superpowers:using-git-worktrees` auf. Branc
 
 > **Branch-Naming-Warnung:** Das native `EnterWorktree` Tool mangelt den Branch-Namen — aus `feature/admin-menu-rules` wird `worktree-feature+admin-menu-rules` (Slash → Plus, Prefix `worktree-`). Das verletzt die Repo-Konvention `feature/*`. Verifiziere nach dem Anlegen mit `git branch --show-current` und benenne ggf. um: `git branch -m feature/<slug>` (oder pushe direkt ohne Umbennung, dann `git push -u origin feature/<slug>:feature/<slug>`). Der vorhersagbarere Pfad ist die manuelle Form:
 > ```bash
-> git worktree add -b feature/<slug> .claude/worktrees/<slug> origin/main
-> cd .claude/worktrees/<slug> && git submodule update --init --recursive
+> git worktree add -b feature/<slug> /tmp/wt-<slug> origin/main
+> cd /tmp/wt-<slug> && git submodule update --init --recursive
 > ```
+>
+> **⚠️ KEIN `.claude/worktrees/` verwenden** — dieses Verzeichnis ist in `.gitignore` eingetragen. Git-Worktrees in gitignorierten Pfaden können die Branch-Erkennung (`git branch --show-current`) brechen und staged Files können ungewollt in den Haupt-Index bluten. Immer `/tmp/wt-<slug>` (außerhalb des Repos) verwenden.
 
 ### Schritt 1.5: Optionale Asset-Sammlung
 
@@ -397,9 +399,11 @@ Falls kein Worktree existiert: Rufe `superpowers:using-git-worktrees` auf. Branc
 
 > **Branch-Naming-Warnung:** Das native `EnterWorktree` Tool mangelt den Branch-Namen (Slash → Plus, Prefix `worktree-`). Verifiziere mit `git branch --show-current` und benenne ggf. um: `git branch -m fix/<slug>`. Vorhersagbar:
 > ```bash
-> git worktree add -b fix/<slug> .claude/worktrees/<slug> origin/main
-> cd .claude/worktrees/<slug> && git submodule update --init --recursive
+> git worktree add -b fix/<slug> /tmp/wt-<slug> origin/main
+> cd /tmp/wt-<slug> && git submodule update --init --recursive
 > ```
+>
+> **⚠️ KEIN `.claude/worktrees/` verwenden** — gitignorierter Pfad, bricht Branch-Erkennung. Immer `/tmp/wt-<slug>` verwenden.
 
 ### Schritt 3: Failing Test schreiben
 
@@ -493,9 +497,11 @@ Falls kein Worktree existiert: Rufe `superpowers:using-git-worktrees` auf. Branc
 
 > **Branch-Naming-Warnung:** Das native `EnterWorktree` Tool mangelt den Branch-Namen (Slash → Plus, Prefix `worktree-`). Verifiziere mit `git branch --show-current` und benenne ggf. um: `git branch -m chore/<slug>`. Vorhersagbar:
 > ```bash
-> git worktree add -b chore/<slug> .claude/worktrees/<slug> origin/main
-> cd .claude/worktrees/<slug> && git submodule update --init --recursive
+> git worktree add -b chore/<slug> /tmp/wt-<slug> origin/main
+> cd /tmp/wt-<slug> && git submodule update --init --recursive
 > ```
+>
+> **⚠️ KEIN `.claude/worktrees/` verwenden** — gitignorierter Pfad, bricht Branch-Erkennung. Immer `/tmp/wt-<slug>` verwenden.
 
 ### Schritt 3: Änderung machen
 

--- a/.claude/skills/ticket-management/SKILL.md
+++ b/.claude/skills/ticket-management/SKILL.md
@@ -95,9 +95,10 @@ Set this before starting the fix. After the fix is complete, close with `done` +
 
 **Stale worktree/branch** (type=task, trivial):
 ```bash
-git worktree remove .claude/worktrees/<name> --force
+git worktree remove <path> --force   # path is /tmp/wt-<slug> (new convention) or .claude/worktrees/<name> (legacy)
 git branch -D <branch>
 ```
+**Note:** New worktrees use `/tmp/wt-<slug>` — `.claude/worktrees/` is gitignored and causes branch-detection failures.
 
 **Bash script bug** — fix the script, verify with `bash -n <script>`.
 
@@ -122,7 +123,7 @@ A worktree is stale when its branch is already merged to `main` or the owning pl
 ```bash
 # Verify merged first — never remove an unmerged worktree without checking
 git log main..<branch> --oneline   # empty = fully merged
-git worktree remove .claude/worktrees/<name> --force
+git worktree remove <path> --force  # path from `git worktree list` (new: /tmp/wt-<slug>, legacy: .claude/worktrees/<name>)
 ```
 
 **Do not remove** a worktree if:


### PR DESCRIPTION
## Summary
- `.claude/worktrees/` is in `.gitignore` — git worktrees created there break `git branch --show-current` (reports `main`) and can leak staged files into the parent repo index (confirmed by stale `test-ignore` worktree found this session)
- Updated all worktree-add examples in `dev-flow-plan` (feature/fix/chore paths) to use `/tmp/wt-<slug>` with an explicit warning
- Updated cleanup examples in `ticket-management` to be path-agnostic with a convention note

## Test plan
- [ ] No manifests or code changed — only `.claude/skills/` SKILL.md files
- [ ] `task test:all` not required (skill-only change per Chore-Pfad Schritt 4 table)

🤖 Generated with [Claude Code](https://claude.com/claude-code)