### PR TITLE
feat(ui): admin + portal visual polish — colored icon tints, premium dashboard

### DIFF
--- a/website/src/layouts/AdminLayout.astro
+++ b/website/src/layouts/AdminLayout.astro
@@ -80,9 +80,10 @@ try {
   draftsPending = r.rows[0]?.n ?? 0;
 } catch { /* coaching schema may not exist yet */ }
 
-const navGroups: { label: string; items: NavItem[] }[] = [
+const navGroups: { label: string; iconClass: string; items: NavItem[] }[] = [
   {
     label: 'Kern',
+    iconClass: 'nav-icon-kern',
     items: [
       { href: '/admin/termine',     label: 'Kalender',     icon: 'calendar' },
       { href: '/admin/tickets',     label: 'Anfragen',     icon: 'tag' },
@@ -92,6 +93,7 @@ const navGroups: { label: string; items: NavItem[] }[] = [
   },
   {
     label: 'CRM',
+    iconClass: 'nav-icon-crm',
     items: [
       { href: '/admin/clients',   label: 'Klienten',  icon: 'users' },
       { href: '/admin/projekte',  label: 'Mandate',   icon: 'folder' },
@@ -99,31 +101,35 @@ const navGroups: { label: string; items: NavItem[] }[] = [
   },
   {
     label: 'Coaching',
+    iconClass: 'nav-icon-coaching',
     items: [
-      { href: '/admin/coaching/sessions',  label: 'Sitzungen',  icon: 'clipboard', matches: ['/admin/coaching/sessions', '/admin/fragebogen'] },
+      { href: '/admin/coaching/sessions',  label: 'Sitzungen',   icon: 'clipboard', matches: ['/admin/coaching/sessions', '/admin/fragebogen'] },
       { href: '/admin/brett',              label: 'Systembrett', icon: 'brett' },
     ],
   },
   {
     label: 'Redaktion',
+    iconClass: 'nav-icon-redaktion',
     items: [
-      { href: '/admin/inhalte',         label: 'Content Hub', icon: 'layout', matches: ['/admin/inhalte', '/admin/startseite', '/admin/uebermich', '/admin/angebote', '/admin/faq', '/admin/kontakt', '/admin/referenzen', '/admin/rechtliches', '/admin/dokumente'] },
-      { href: '/admin/knowledge/drafts', label: 'Entwürfe',    icon: 'edit',   badge: draftsPending },
-      { href: '/admin/assets',           label: 'Assets',      icon: 'palette' },
+      { href: '/admin/inhalte',           label: 'Content Hub', icon: 'layout', matches: ['/admin/inhalte', '/admin/startseite', '/admin/uebermich', '/admin/angebote', '/admin/faq', '/admin/kontakt', '/admin/referenzen', '/admin/rechtliches', '/admin/dokumente'] },
+      { href: '/admin/knowledge/drafts',  label: 'Entwürfe',    icon: 'edit',   badge: draftsPending },
+      { href: '/admin/assets',            label: 'Assets',      icon: 'palette' },
     ],
   },
   {
     label: 'Kapital',
+    iconClass: 'nav-icon-kapital',
     items: [
-      { href: '/admin/rechnungen',    label: 'Fakturierung',  icon: 'receipt', matches: ['/admin/rechnungen', '/admin/billing'] },
-      { href: '/admin/buchhaltung',   label: 'Kontierung',    icon: 'scale' },
+      { href: '/admin/rechnungen',  label: 'Fakturierung', icon: 'receipt', matches: ['/admin/rechnungen', '/admin/billing'] },
+      { href: '/admin/buchhaltung', label: 'Kontierung',   icon: 'scale' },
     ],
   },
   {
     label: 'Kontrollzentrum',
+    iconClass: 'nav-icon-kontrolle',
     items: [
-      { href: '/admin/platform',   label: 'Plattform Hub', icon: 'monitor', matches: ['/admin/monitoring', '/admin/ops', '/admin/platform'] },
-      { href: '/admin/einstellungen/benachrichtigungen', label: 'System-Setup', icon: 'settings', matches: ['/admin/einstellungen/'] },
+      { href: '/admin/platform',                            label: 'Plattform Hub', icon: 'monitor', matches: ['/admin/monitoring', '/admin/ops', '/admin/platform'] },
+      { href: '/admin/einstellungen/benachrichtigungen',    label: 'System-Setup',  icon: 'settings', matches: ['/admin/einstellungen/'] },
     ],
   },
 ];
@@ -228,7 +234,7 @@ const isKore = brandId === 'korczewski';
             { 'is-active': path === '/admin' },
           ]}
         >
-          <span class="nav-icon" set:html={icons.dashboard} />
+          <span class="nav-icon nav-icon-kern" set:html={icons.dashboard} />
           <span class="sidebar-label" style="margin-left:12px;">Dashboard</span>
         </a>
 
@@ -243,7 +249,7 @@ const isKore = brandId === 'korczewski';
                   { 'is-active': isActive(item.href, item.matches) }
                 ]}
               >
-                <span class="nav-icon" set:html={icons[item.icon]} />
+                <span class={`nav-icon ${group.iconClass}`} set:html={icons[item.icon]} />
                 <span class="sidebar-label" style="margin-left:12px; flex:1;">{item.label}</span>
                 {item.badge ? (
                   <span class="sidebar-label" style="padding:2px 6px; border-radius:6px; background:var(--admin-primary); color:var(--admin-bg); font-size:10px; font-weight:800;">{item.badge}</span>

--- a/website/src/layouts/PortalLayout.astro
+++ b/website/src/layouts/PortalLayout.astro
@@ -20,14 +20,14 @@ interface Props {
 const { title, section, session, pendingSignatures, pendingQuestionnaires = 0 } = Astro.props;
 
 const icons: Record<string, string> = {
-  overview:       `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="2" width="5" height="5" rx="0.5"/><rect x="9" y="2" width="5" height="5" rx="0.5"/><rect x="2" y="9" width="5" height="5" rx="0.5"/><rect x="9" y="9" width="5" height="5" rx="0.5"/></svg>`,
-  dateien:        `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 2h5.5L13 5.5V14H4V2z"/><path d="M9.5 2v3.5H13"/><path d="M6 8h4M6 10.5h4M6 13h2.5"/></svg>`,
-  unterschriften: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"><path d="M2.5 10.5c1-2 2-4 3-3s0 3 1.5 2 2-3 3-2"/><path d="M2.5 13.5h11"/></svg>`,
-  fragebögen:     `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"><rect x="2.5" y="1.5" width="11" height="13" rx="1"/><path d="M5.5 5.5h5M5.5 8h3"/><circle cx="8" cy="11.5" r="0.75" fill="currentColor" stroke="none"/></svg>`,
-  kalender:       `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="12" height="11" rx="1"/><path d="M2 7h12M5.5 1.5v3M10.5 1.5v3M5.5 10h1M8 10h1M10.5 10h1"/></svg>`,
-  rechnungen:     `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 1.5h8v13l-2-1.5-2 1.5-2-1.5-2 1.5z"/><path d="M6 6h4M6 8.5h4M6 11h2"/></svg>`,
-  buchung:        `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="8" r="5.5"/><path d="M8 5.5v2.5l1.5 1.5"/></svg>`,
-  konto:          `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="5" r="3"/><path d="M2.5 14.5a5.5 5.5 0 0 1 11 0"/></svg>`,
+  overview:       `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="2" width="5" height="5" rx="0.5"/><rect x="9" y="2" width="5" height="5" rx="0.5"/><rect x="2" y="9" width="5" height="5" rx="0.5"/><rect x="9" y="9" width="5" height="5" rx="0.5"/></svg>`,
+  dateien:        `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M4 2h5.5L13 5.5V14H4V2z"/><path d="M9.5 2v3.5H13"/><path d="M6 8h4M6 10.5h4M6 13h2.5"/></svg>`,
+  unterschriften: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M2.5 10.5c1-2 2-4 3-3s0 3 1.5 2 2-3 3-2"/><path d="M2.5 13.5h11"/></svg>`,
+  fragebögen:     `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="2.5" y="1.5" width="11" height="13" rx="1"/><path d="M5.5 5.5h5M5.5 8h3"/><circle cx="8" cy="11.5" r="0.75" fill="currentColor" stroke="none"/></svg>`,
+  kalender:       `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="12" height="11" rx="1"/><path d="M2 7h12M5.5 1.5v3M10.5 1.5v3M5.5 10h1M8 10h1M10.5 10h1"/></svg>`,
+  rechnungen:     `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M4 1.5h8v13l-2-1.5-2 1.5-2-1.5-2 1.5z"/><path d="M6 6h4M6 8.5h4M6 11h2"/></svg>`,
+  buchung:        `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="8" r="5.5"/><path d="M8 5.5v2.5l1.5 1.5"/></svg>`,
+  konto:          `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="5" r="3"/><path d="M2.5 14.5a5.5 5.5 0 0 1 11 0"/></svg>`,
 };
 
 interface NavItem {
@@ -47,6 +47,17 @@ const navItems: NavItem[] = [
   { id: 'rechnungen',  label: 'Rechnungen',  icon: 'rechnungen' },
   { id: 'buchung',     label: 'Buchung',     icon: 'buchung' },
 ];
+
+const portalIconColors: Record<string, string> = {
+  overview:       'var(--brass)',
+  dateien:        '#38bdf8',
+  'fragebögen':   '#a78bfa',
+  vertraege:      '#34d399',
+  kalender:       'var(--brass)',
+  rechnungen:     '#34d399',
+  buchung:        '#2dd4bf',
+  konto:          'var(--brass)',
+};
 
 const avatarInitial = (session.given_name || session.name || session.preferred_username || '?')[0].toUpperCase();
 const displayName   = session.given_name || session.name || session.preferred_username;
@@ -184,13 +195,17 @@ const isKore        = brandId === 'korczewski';
                 href={`/portal?section=${item.id}`}
                 class={`portal-nav-item${active ? ' is-active' : ''}`}
                 aria-current={active ? 'page' : undefined}
-                style={`display:flex; align-items:center; gap:9px; padding:7px 9px; border-radius:7px; text-decoration:none; font-size:12.5px; font-weight:500; transition:background 0.1s ease, color 0.1s ease; ${
+                style={`display:flex; align-items:center; gap:10px; padding:8px 10px; border-radius:7px; text-decoration:none; font-size:12.5px; font-weight:500; transition:background 0.1s ease, color 0.1s ease; ${
                   active ? 'background:var(--brass-d); color:var(--brass);' : 'color:var(--mute);'
                 }`}
               >
                 <span
                   class="nav-icon"
-                  style={`width:15px; height:15px; display:flex; align-items:center; justify-content:center; flex-shrink:0; transition:color 0.1s ease; ${active ? 'color:var(--brass);' : 'color:var(--mute);'}`}
+                  style={`width:20px; height:20px; display:flex; align-items:center; justify-content:center; flex-shrink:0; transition:color 0.1s ease, background 0.1s ease; border-radius:8px; padding:5px; ${
+                    active
+                      ? 'background:transparent; color:var(--brass);'
+                      : `background:color-mix(in srgb, ${portalIconColors[item.id] ?? 'var(--brass)'} 12%, transparent); color:color-mix(in srgb, ${portalIconColors[item.id] ?? 'var(--brass)'} 70%, transparent);`
+                  }`}
                   set:html={icons[item.icon]}
                 />
                 <span style="flex:1; white-space:nowrap; overflow:hidden; text-overflow:ellipsis;">{item.label}</span>
@@ -233,7 +248,11 @@ const isKore        = brandId === 'korczewski';
         >
           <span
             class="nav-icon"
-            style={`flex-shrink:0; width:14px; height:14px; display:flex; align-items:center; justify-content:center; ${section === 'konto' ? 'color:var(--brass);' : 'color:var(--mute);'}`}
+            style={`flex-shrink:0; width:20px; height:20px; display:flex; align-items:center; justify-content:center; transition:color 0.1s ease, background 0.1s ease; border-radius:8px; padding:5px; ${
+              section === 'konto'
+                ? 'background:transparent; color:var(--brass);'
+                : `background:color-mix(in srgb, var(--brass) 12%, transparent); color:color-mix(in srgb, var(--brass) 70%, transparent);`
+            }`}
             set:html={icons['konto']}
           />
           <span>Konto</span>

--- a/website/src/pages/admin.astro
+++ b/website/src/pages/admin.astro
@@ -5,7 +5,6 @@ import { listBugTickets, listProjects, listAdminShortcuts } from '../lib/website
 import type { AdminShortcut } from '../lib/website-db';
 import { getAllBillingInvoices } from '../lib/stripe-billing';
 import { getAvailableSlots } from '../lib/caldav';
-import ServiceLinks from '../components/ServiceLinks.astro';
 import AdminShortcuts from '../components/admin/AdminShortcuts.svelte';
 
 const session = await getSession(Astro.request.headers.get('cookie'));
@@ -73,21 +72,21 @@ const SVG = {
 };
 
 const adminLinks = [
-  { href: '/admin/inbox', label: 'Inbox', icon: SVG.inbox },
+  { href: '/admin/inbox',                                        label: 'Inbox',      icon: SVG.inbox,    color: 'oklch(0.80 0.09 75)' },
   ...(ncBase ? [
-    { href: `${ncBase}/apps/files/`,    label: 'Dateien',  icon: SVG.folder },
-    { href: `${ncBase}/apps/calendar/`, label: 'Kalender', icon: SVG.calendar },
-    { href: `${ncBase}/apps/contacts/`, label: 'Kontakte', icon: SVG.contacts },
-    { href: `${ncBase}/apps/spreed/`,   label: 'Talk',     icon: SVG.video },
+    { href: `${ncBase}/apps/files/`,    label: 'Dateien',  icon: SVG.folder,   color: '#38bdf8' },
+    { href: `${ncBase}/apps/calendar/`, label: 'Kalender', icon: SVG.calendar, color: 'oklch(0.80 0.09 75)' },
+    { href: `${ncBase}/apps/contacts/`, label: 'Kontakte', icon: SVG.contacts, color: '#2dd4bf' },
+    { href: `${ncBase}/apps/spreed/`,   label: 'Talk',     icon: SVG.video,    color: '#a78bfa' },
   ] : []),
-  ...(bretUrl  ? [{ href: bretUrl, label: 'Brett', icon: SVG.brett }] : []),
-  { href: '/portal/arena', label: 'Arena', icon: SVG.arena },
-  { href: '/admin/rechnungen', label: 'Abrechnung', icon: SVG.receipt },
-  ...(vaultUrl   ? [{ href: vaultUrl,                                 label: 'Passwörter', icon: SVG.lock }] : []),
-  ...(authUrl    ? [{ href: `${authUrl}/admin/workspace/console/`,    label: 'Keycloak',   icon: SVG.key }] : []),
-  ...(docsUrl    ? [{ href: docsUrl,                                  label: 'Docs',       icon: SVG.book }] : []),
-  { href: '/admin/monitoring',                                          label: 'Monitoring', icon: SVG.dashboard },
-  ...(mailUrl    ? [{ href: mailUrl,                                  label: 'Mailpit',    icon: SVG.mail }] : []),
+  ...(bretUrl  ? [{ href: bretUrl,                               label: 'Brett',      icon: SVG.brett,    color: '#a78bfa' }] : []),
+  { href: '/portal/arena',                                       label: 'Arena',      icon: SVG.arena,    color: '#818cf8' },
+  { href: '/admin/rechnungen',                                   label: 'Abrechnung', icon: SVG.receipt,  color: '#34d399' },
+  ...(vaultUrl ? [{ href: vaultUrl,                              label: 'Passwörter', icon: SVG.lock,     color: '#34d399' }] : []),
+  ...(authUrl  ? [{ href: `${authUrl}/admin/workspace/console/`, label: 'Keycloak',   icon: SVG.key,      color: '#818cf8' }] : []),
+  ...(docsUrl  ? [{ href: docsUrl,                               label: 'Docs',       icon: SVG.book,     color: '#38bdf8' }] : []),
+  { href: '/admin/monitoring',                                   label: 'Monitoring', icon: SVG.dashboard, color: 'oklch(0.80 0.09 75)' },
+  ...(mailUrl  ? [{ href: mailUrl,                               label: 'Mailpit',    icon: SVG.mail,     color: '#2dd4bf' }] : []),
 ];
 
 const isKore = BRAND === 'korczewski';
@@ -175,32 +174,61 @@ const kpis = [
       </section>
     </main>
   ) : (
-    <section class="pt-10 pb-20 bg-dark min-h-screen">
-      <div class="max-w-5xl mx-auto px-6">
+    <section style="padding:2.5rem 0 5rem; min-height:100vh;">
+      <div style="max-width:56rem; margin:0 auto; padding:0 1.5rem;">
 
-        <div class="mb-10">
-          <h1 class="text-3xl font-bold text-light font-serif">Admin</h1>
-          <p class="text-muted mt-1">Verwaltung & Werkzeuge</p>
+        <!-- Header -->
+        <div style="margin-bottom:2.5rem;">
+          <p style="font-family:var(--font-mono); font-size:0.7rem; color:var(--admin-text-disabled); text-transform:uppercase; letter-spacing:0.15em; margin:0 0 4px;">
+            Verwaltung &amp; Werkzeuge
+          </p>
+          <h1 style="font-family:var(--font-serif); font-size:2rem; font-weight:700; color:var(--admin-text); letter-spacing:-0.02em; margin:0;">Admin</h1>
         </div>
 
         <!-- KPI Banner -->
-        <div class="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-8">
-          {[
-            { label: 'Aktive Projekte',   value: String(activeProjects),           href: '/admin/projekte',  cls: 'border-yellow-800' },
-            { label: 'Offene Rechnungen', value: openInvoices > 0 ? `${openInvoices} (${fmtCurrency(openInvoiceAmount)})` : '0', href: '/admin/rechnungen', cls: openInvoices > 0 ? 'border-yellow-800' : 'border-dark-lighter' },
-            { label: 'Überfällige Bugs',   value: String(openBugCount),             href: '/admin/bugs',      cls: openBugCount > 0 ? 'border-red-800' : 'border-dark-lighter' },
-            { label: 'Freie Slots (7 T)', value: String(freeSlots),                href: '/admin/termine',   cls: freeSlots > 0 ? 'border-green-800' : 'border-dark-lighter' },
-          ].map(k => (
-            <a href={k.href} class={`p-4 bg-dark-light rounded-xl border hover:border-gold/40 transition-colors ${k.cls}`}>
-              <div class="text-xl font-bold text-light">{k.value}</div>
-              <div class="text-xs text-muted mt-0.5">{k.label}</div>
+        <div style="display:grid; grid-template-columns:repeat(auto-fill, minmax(11rem, 1fr)); gap:0.75rem; margin-bottom:2rem;">
+          {kpis.map(k => (
+            <a href={k.href} class="admin-card" style={`text-decoration:none; display:block; border-left:3px solid ${
+              k.state === 'is-ok'   ? '#34d399' :
+              k.state === 'is-warn' ? 'oklch(0.80 0.09 75)' :
+              k.state === 'is-fail' ? '#f87171' :
+              'var(--admin-border)'
+            };`}>
+              <div style="font-size:1.5rem; font-weight:700; color:var(--admin-text); line-height:1.2;">{k.value}</div>
+              {k.unit && <div style="font-size:0.85rem; font-weight:600; color:var(--admin-text); margin-top:2px;">{k.unit}</div>}
+              <div style="font-size:0.7rem; color:var(--admin-text-mute); margin-top:4px;">{k.label}</div>
+              <div style="font-size:0.75rem; color:var(--admin-text-disabled); margin-top:2px;">{k.suffix}</div>
             </a>
           ))}
         </div>
 
-        <ServiceLinks links={adminLinks} heading="Dienste" />
+        <!-- Service Links -->
+        <div class="admin-card" style="margin-bottom:1.5rem;">
+          <p style="font-family:var(--font-mono); font-size:0.65rem; color:var(--admin-text-disabled); text-transform:uppercase; letter-spacing:0.12em; margin:0 0 1rem;">Dienste</p>
+          <div style="display:grid; grid-template-columns:repeat(auto-fill, minmax(7rem, 1fr)); gap:0.75rem;">
+            {adminLinks.map(l => (
+              <a
+                href={l.href}
+                target={l.href.startsWith('http') ? '_blank' : undefined}
+                rel={l.href.startsWith('http') ? 'noopener' : undefined}
+                class="admin-card"
+                style="display:flex; flex-direction:column; align-items:center; gap:8px; text-decoration:none; text-align:center; padding:1rem;"
+              >
+                <span
+                  style={`width:20px; height:20px; display:flex; align-items:center; justify-content:center; border-radius:8px; padding:5px; background:color-mix(in srgb, ${l.color} 12%, transparent); color:${l.color};`}
+                  set:html={l.icon}
+                />
+                <span style="font-size:11px; color:var(--admin-text-mute);">{l.label}</span>
+              </a>
+            ))}
+          </div>
+        </div>
 
-        <AdminShortcuts client:load links={shortcuts} />
+        <!-- Custom Shortcuts -->
+        <div class="admin-card">
+          <p style="font-family:var(--font-mono); font-size:0.65rem; color:var(--admin-text-disabled); text-transform:uppercase; letter-spacing:0.12em; margin:0 0 1rem;">Schnellzugriffe</p>
+          <AdminShortcuts client:load links={shortcuts} />
+        </div>
 
       </div>
     </section>

--- a/website/src/styles/admin-premium.css
+++ b/website/src/styles/admin-premium.css
@@ -74,6 +74,27 @@ html.sidebar-collapsed #admin-sidebar {
   transform: scale(1.1);
 }
 
+/* Per-group icon tint containers */
+.nav-icon-kern      { --ni-color: oklch(0.80 0.09 75); }
+.nav-icon-crm       { --ni-color: #2dd4bf; }
+.nav-icon-coaching  { --ni-color: #a78bfa; }
+.nav-icon-redaktion { --ni-color: #38bdf8; }
+.nav-icon-kapital   { --ni-color: #34d399; }
+.nav-icon-kontrolle { --ni-color: #818cf8; }
+
+[class*="nav-icon-"] {
+  border-radius: 8px;
+  padding: 5px;
+  background: color-mix(in srgb, var(--ni-color) 12%, transparent);
+  color: color-mix(in srgb, var(--ni-color) 70%, transparent);
+}
+
+.sidebar-nav-item:hover [class*="nav-icon-"],
+.sidebar-nav-item.is-active [class*="nav-icon-"] {
+  background: color-mix(in srgb, var(--ni-color) 18%, transparent);
+  color: var(--ni-color);
+}
+
 .sidebar-group-label {
   padding: 1.5rem 1.25rem 0.5rem;
   font-size: 0.7rem;


### PR DESCRIPTION
## Summary
- Admin sidebar icons get per-group tint containers (brass/teal/violet/sky/emerald/indigo) via new `.nav-icon-*` CSS classes in `admin-premium.css`
- Portal sidebar icons bumped from 15px → 20px, stroke-width 1.2 → 1.5, tint containers added inline with matching palette
- Mentolder admin dashboard rewritten with `admin-premium` tokens: serif header, colored KPI card left-borders, service tiles with tinted icon containers
- Kore brand unchanged

## Test plan
- [x] `task test:all` passes (no logic changes)
- [x] Admin-menu gate PASSED (6 groups × ≤6 items each, all routes reachable)
- [ ] Admin sidebar: each group shows distinct tinted icon color at rest, brightens on hover/active
- [ ] Portal sidebar: icons visibly larger, colored per section
- [ ] Admin dashboard: KPI left-border color matches state (green=ok, brass=warn, red=fail)
- [ ] No regression on Kore admin dashboard

Closes T000068

🤖 Generated with [Claude Code](https://claude.com/claude-code)