### PR TITLE
fix(infra): correct LLM_HOST_IP to wg-mesh IP for llm-gateway-lmstudio

### DIFF
--- a/environments/mentolder.yaml
+++ b/environments/mentolder.yaml
@@ -46,7 +46,7 @@ env_vars:
   KEYCLOAK_FRONTEND_URL: "https://auth.mentolder.de"
   # System-test failure loop master kill-switch (Task 10).
   SYSTEMTEST_LOOP_ENABLED: "true"
-  LLM_HOST_IP: "100.102.71.114"
+  LLM_HOST_IP: "192.168.100.10"
   LLM_ENABLED: "true"
   LLM_RERANK_ENABLED: "false"
   LLM_ROUTER_URL: "http://llm-gateway-lmstudio.workspace.svc.cluster.local:1234"

--- a/scripts/seed-lmstudio-ki-config.mjs
+++ b/scripts/seed-lmstudio-ki-config.mjs
@@ -42,7 +42,7 @@ async function run() {
          max_tokens, is_active, enabled_fields)
       VALUES
         ($1, 'custom_lmstudio', 'LM Studio (Qwen 2.5)',
-         'http://100.102.71.114:1234/v1',
+         'http://llm-gateway-lmstudio.workspace.svc.cluster.local:1234/v1',
          'yemiao2745/qwen2.5-14b-instruct-uncensored',
          $2,
          800, true,


### PR DESCRIPTION
## Summary
- `LLM_HOST_IP` was set to the GPU host's Tailscale IP (`100.102.71.114`), which is not routable from Kubernetes pods on Hetzner nodes
- Correct IP is `192.168.100.10` (wg-mesh), where iptables DNAT forwards port 1234 to LM Studio
- Also fixes the seed script endpoint to use the cluster-internal Service URL

## Test plan
- [x] Verified `curl http://192.168.100.10:1234/v1/models` from website pod returns valid response
- [x] Flux will reconcile `llm-gateway-lmstudio` Endpoints to use wg-mesh IP after merge

🤖 Generated with [Claude Code](https://claude.ai/claude-code)