### PR TITLE
fix(flux): correct LLM_HOST_IP to wg-mesh IP in mentolder cluster-vars

### DIFF
--- a/flux/clusters/mentolder/vars-configmap.yaml
+++ b/flux/clusters/mentolder/vars-configmap.yaml
@@ -11,7 +11,7 @@ data:
   BRAND_NAME: Mentolder
   BRAND_ID: mentolder
   WEBSITE_IMAGE: mentolder-website
-  LLM_HOST_IP: "100.102.71.114"
+  LLM_HOST_IP: "192.168.100.10"
   # TLS / cert-manager
   TLS_SECRET_NAME: workspace-wildcard-tls
   INFRA_NAMESPACE: mentolder-infra


### PR DESCRIPTION
## Summary
- Fixes the `LLM_HOST_IP` in `flux/clusters/mentolder/vars-configmap.yaml` from Tailscale IP (`100.102.71.114`) to wg-mesh IP (`192.168.100.10`)
- Without this, Flux reverts the `llm-gateway-lmstudio` Endpoints on every reconciliation cycle, causing ECONNREFUSED from pods on Hetzner nodes
- The GPU host's iptables DNAT rule forwards `192.168.100.10:1234 → 10.10.0.3:1234` (LM Studio/Ollama)

## Test plan
- [x] Manually patched ConfigMap + verified Endpoints updated to `192.168.100.10`
- [x] Confirmed `curl http://192.168.100.10:1234/v1/models` returns valid response from website pod

🤖 Generated with [Claude Code](https://claude.ai/claude-code)