### PR TITLE
chore(assets): add Asset Pack 02 — Brett sets, identity, arena HUD

### DIFF
--- a/assets/arena/hud-frame.svg
+++ b/assets/arena/hud-frame.svg
@@ -1,0 +1,120 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1920 1080" width="1920" height="1080" role="img" aria-label="Arena HUD frame">
+  <defs>
+    <linearGradient id="hp-grad" x1="0" x2="1">
+      <stop offset="0%" stop-color="#C8F76A"></stop>
+      <stop offset="100%" stop-color="#7a8b4f"></stop>
+    </linearGradient>
+    <radialGradient id="hud-bg" cx="50%" cy="50%" r="70%">
+      <stop offset="0%" stop-color="#1a1428" stop-opacity="0.0"></stop>
+      <stop offset="80%" stop-color="#120D1C" stop-opacity="0.35"></stop>
+      <stop offset="100%" stop-color="#120D1C" stop-opacity="0.65"></stop>
+    </radialGradient>
+  </defs>
+
+  <rect width="1920" height="1080" fill="url(#hud-bg)"></rect>
+
+  <g stroke="#C8F76A" stroke-width="2" fill="none" stroke-opacity="0.95">
+    <path d="M30 90 L30 30 L90 30"></path>
+    <path d="M1890 90 L1890 30 L1830 30"></path>
+    <path d="M30 990 L30 1050 L90 1050"></path>
+    <path d="M1890 990 L1890 1050 L1830 1050"></path>
+  </g>
+  <g stroke="#C8F76A" stroke-width="1" fill="none" stroke-opacity="0.4">
+    <path d="M60 30 L1860 30"></path>
+    <path d="M60 1050 L1860 1050"></path>
+    <path d="M30 90 L30 990"></path>
+    <path d="M1890 90 L1890 990"></path>
+  </g>
+
+  <g stroke="#C8F76A" stroke-width="1.5" fill="none">
+    <circle cx="960" cy="540" r="16" opacity="0.7"></circle>
+    <line x1="960" y1="514" x2="960" y2="528" opacity="0.9"></line>
+    <line x1="960" y1="552" x2="960" y2="566" opacity="0.9"></line>
+    <line x1="934" y1="540" x2="948" y2="540" opacity="0.9"></line>
+    <line x1="972" y1="540" x2="986" y2="540" opacity="0.9"></line>
+    <circle cx="960" cy="540" r="2" fill="#C8F76A"></circle>
+  </g>
+
+  <g transform="translate(70, 100)">
+    <rect width="340" height="62" fill="#120D1C" fill-opacity="0.78" stroke="#C8F76A" stroke-opacity="0.45"></rect>
+    <circle cx="34" cy="31" r="14" fill="none" stroke="#C8F76A" stroke-opacity="0.6"></circle>
+    <text x="34" y="36" text-anchor="middle" font-family="Geist Mono, monospace" font-size="13" fill="#C8F76A">k</text>
+    <text x="64" y="24" font-family="Geist Mono, monospace" font-size="10" letter-spacing="2.5" fill="#7a8b4f">PLAYER · 01</text>
+    <text x="64" y="48" font-family="Geist, sans-serif" font-weight="600" font-size="20" fill="#eef1f3">korczewski</text>
+    <circle cx="316" cy="31" r="5" fill="#C8F76A"></circle>
+  </g>
+
+  <g transform="translate(70, 188)">
+    <text x="0" y="-6" font-family="Geist Mono, monospace" font-size="10" letter-spacing="2.5" fill="#7a8b4f">HP</text>
+    <rect width="340" height="14" fill="#120D1C" fill-opacity="0.78" stroke="#C8F76A" stroke-opacity="0.35"></rect>
+    <rect x="2" y="2" width="254" height="10" fill="url(#hp-grad)"></rect>
+    <text x="350" y="11" font-family="Geist Mono, monospace" font-size="12" letter-spacing="1.5" fill="#C8F76A">75 / 100</text>
+  </g>
+
+  <g transform="translate(70, 230)">
+    <text x="0" y="-6" font-family="Geist Mono, monospace" font-size="10" letter-spacing="2.5" fill="#7a8b4f">SHIELD</text>
+    <rect width="340" height="10" fill="#120D1C" fill-opacity="0.78" stroke="#5fb8c8" stroke-opacity="0.45"></rect>
+    <rect x="2" y="2" width="200" height="6" fill="#5fb8c8" opacity="0.9"></rect>
+    <text x="350" y="9" font-family="Geist Mono, monospace" font-size="11" letter-spacing="1.5" fill="#5fb8c8">60 / 100</text>
+  </g>
+
+  <g transform="translate(1370, 100)">
+    <rect width="480" height="62" fill="#120D1C" fill-opacity="0.78" stroke="#C8F76A" stroke-opacity="0.45"></rect>
+    <text x="22" y="22" font-family="Geist Mono, monospace" font-size="10" letter-spacing="2.5" fill="#7a8b4f">ROUND · 03 / 10</text>
+    <text x="22" y="50" font-family="Geist Mono, monospace" font-weight="500" font-size="26" letter-spacing="3" fill="#C8F76A">04:32</text>
+    <line x1="170" y1="14" x2="170" y2="48" stroke="#C8F76A" stroke-opacity="0.25"></line>
+    <text x="195" y="22" font-family="Geist Mono, monospace" font-size="10" letter-spacing="2.5" fill="#7a8b4f">SCORE</text>
+    <text x="195" y="50" font-family="Geist Mono, monospace" font-weight="500" font-size="26" letter-spacing="2" fill="#eef1f3">12<tspan fill="#7a8b4f"> : </tspan><tspan fill="#cdd3d9">09</tspan></text>
+    <line x1="350" y1="14" x2="350" y2="48" stroke="#C8F76A" stroke-opacity="0.25"></line>
+    <text x="375" y="22" font-family="Geist Mono, monospace" font-size="10" letter-spacing="2.5" fill="#7a8b4f">PING</text>
+    <text x="375" y="50" font-family="Geist Mono, monospace" font-weight="500" font-size="22" fill="#C8F76A">42<tspan fill="#7a8b4f">ms</tspan></text>
+  </g>
+
+  <g transform="translate(1620, 188)">
+    <rect width="230" height="230" fill="#120D1C" fill-opacity="0.78" stroke="#C8F76A" stroke-opacity="0.4"></rect>
+    <g stroke="#C8F76A" stroke-opacity="0.13" stroke-width="0.5">
+      <line x1="0" y1="46" x2="230" y2="46"></line>
+      <line x1="0" y1="92" x2="230" y2="92"></line>
+      <line x1="0" y1="138" x2="230" y2="138"></line>
+      <line x1="0" y1="184" x2="230" y2="184"></line>
+      <line x1="46" y1="0" x2="46" y2="230"></line>
+      <line x1="92" y1="0" x2="92" y2="230"></line>
+      <line x1="138" y1="0" x2="138" y2="230"></line>
+      <line x1="184" y1="0" x2="184" y2="230"></line>
+    </g>
+    <g fill="#C8F76A" fill-opacity="0.08" stroke="#C8F76A" stroke-opacity="0.45">
+      <rect x="36" y="40" width="64" height="48"></rect>
+      <rect x="130" y="58" width="68" height="40"></rect>
+      <rect x="60" y="128" width="100" height="58"></rect>
+      <rect x="170" y="140" width="36" height="48"></rect>
+    </g>
+    <circle cx="118" cy="115" r="5" fill="#C8F76A"></circle>
+    <circle cx="118" cy="115" r="11" fill="none" stroke="#C8F76A" stroke-opacity="0.55"></circle>
+    <circle cx="178" cy="80" r="3.5" fill="#d77a6e"></circle>
+    <circle cx="80" cy="160" r="3.5" fill="#d77a6e"></circle>
+    <circle cx="190" cy="170" r="3.5" fill="#d77a6e"></circle>
+    <text x="8" y="14" font-family="Geist Mono, monospace" font-size="9" letter-spacing="2" fill="#7a8b4f">MAP · ARENA</text>
+    <text x="222" y="14" text-anchor="end" font-family="Geist Mono, monospace" font-size="9" letter-spacing="2" fill="#C8F76A">3 ◊</text>
+  </g>
+
+  <g transform="translate(70, 880)" font-family="Geist Mono, monospace" font-size="13" letter-spacing="1.5">
+    <text x="0" y="0" font-size="10" letter-spacing="2.5" fill="#7a8b4f">KILL FEED · LIVE</text>
+    <text x="0" y="26"><tspan fill="#eef1f3">[01] korczewski</tspan><tspan fill="#7a8b4f"> » </tspan><tspan fill="#cdd3d9">guest_07</tspan><tspan fill="#7a8b4f">  · rifle</tspan></text>
+    <text x="0" y="48"><tspan fill="#eef1f3">[02] korczewski</tspan><tspan fill="#7a8b4f"> » </tspan><tspan fill="#cdd3d9">guest_03</tspan><tspan fill="#7a8b4f">  · katana</tspan></text>
+    <text x="0" y="70"><tspan fill="#cdd3d9">guest_04</tspan><tspan fill="#7a8b4f"> » </tspan><tspan fill="#cdd3d9">guest_11</tspan><tspan fill="#7a8b4f">  · fireball</tspan></text>
+  </g>
+
+  <g transform="translate(1580, 880)">
+    <rect width="270" height="100" fill="#120D1C" fill-opacity="0.78" stroke="#C8F76A" stroke-opacity="0.45"></rect>
+    <text x="20" y="26" font-family="Geist Mono, monospace" font-size="10" letter-spacing="2.5" fill="#7a8b4f">WEAPON · 02</text>
+    <text x="20" y="62" font-family="Geist, sans-serif" font-weight="600" font-size="22" fill="#eef1f3">Rifle</text>
+    <text x="250" y="62" text-anchor="end" font-family="Geist Mono, monospace" font-weight="500" font-size="26" fill="#C8F76A">24 / 90</text>
+    <g transform="translate(20, 76)" font-family="Geist Mono, monospace" font-size="10" letter-spacing="1.5" fill="#7a8b4f">
+      <text>[1] handgun  [2] rifle  [3] fireball  [4] club  [5] katana</text>
+    </g>
+  </g>
+
+  <g transform="translate(960, 1030)" text-anchor="middle">
+    <text font-family="Geist Mono, monospace" font-size="10" letter-spacing="3.5" fill="#7a8b4f">ARENA-WS.KORCZEWSKI.DE · WSS · COORDINATE-AUDIO ENABLED</text>
+  </g>
+</svg>

--- a/assets/arena/pickup-shield.svg
+++ b/assets/arena/pickup-shield.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" width="256" height="256" role="img" aria-label="Pickup · shield">
+  <defs>
+    <radialGradient id="psh-glow" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#5fb8c8" stop-opacity="0.42"></stop>
+      <stop offset="100%" stop-color="#5fb8c8" stop-opacity="0"></stop>
+    </radialGradient>
+    <linearGradient id="psh-body" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#1f2a3a"></stop>
+      <stop offset="100%" stop-color="#120D1C"></stop>
+    </linearGradient>
+  </defs>
+  <rect width="256" height="256" fill="url(#psh-glow)"></rect>
+  <path d="M128 32 L212 62 L212 122 Q212 188 128 226 Q44 188 44 122 L44 62 Z" fill="url(#psh-body)" stroke="#5fb8c8" stroke-width="3"></path>
+  <path d="M128 56 L192 80 L192 124 Q192 174 128 204 Q64 174 64 124 L64 80 Z" fill="none" stroke="#5fb8c8" stroke-opacity="0.5" stroke-width="1.5"></path>
+  <g stroke="#C8F76A" stroke-width="7" stroke-linecap="round" fill="none">
+    <path d="M128 96 L128 158"></path>
+    <path d="M102 127 L154 127"></path>
+  </g>
+  <text x="128" y="246" text-anchor="middle" font-family="Geist Mono, monospace" font-size="11" letter-spacing="3" fill="#5fb8c8">SHIELD · +50</text>
+</svg>

--- a/assets/arena/pickup-speed.svg
+++ b/assets/arena/pickup-speed.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" width="256" height="256" role="img" aria-label="Pickup · speed">
+  <defs>
+    <radialGradient id="pspd-glow" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#C8F76A" stop-opacity="0.55"></stop>
+      <stop offset="100%" stop-color="#C8F76A" stop-opacity="0"></stop>
+    </radialGradient>
+  </defs>
+  <rect width="256" height="256" fill="url(#pspd-glow)"></rect>
+  <polygon points="128,28 220,80 220,176 128,228 36,176 36,80" fill="#120D1C" stroke="#C8F76A" stroke-width="3"></polygon>
+  <polygon points="128,52 200,92 200,164 128,204 56,164 56,92" fill="none" stroke="#C8F76A" stroke-opacity="0.5" stroke-width="1.5"></polygon>
+  <path d="M142 68 L96 138 L122 138 L108 192 L162 116 L132 116 Z" fill="#C8F76A" stroke="#fff5c8" stroke-width="1.5" stroke-linejoin="round"></path>
+  <g stroke="#C8F76A" stroke-opacity="0.65" stroke-width="2" stroke-linecap="round">
+    <line x1="58" y1="100" x2="80" y2="100"></line>
+    <line x1="58" y1="120" x2="74" y2="120"></line>
+    <line x1="58" y1="140" x2="80" y2="140"></line>
+  </g>
+  <text x="128" y="246" text-anchor="middle" font-family="Geist Mono, monospace" font-size="11" letter-spacing="3" fill="#C8F76A">SPEED · +30%</text>
+</svg>

--- a/assets/audio/spec/audio-sfx-spec.md
+++ b/assets/audio/spec/audio-sfx-spec.md
@@ -1,0 +1,45 @@
+# Audio Spec · Asset Pack 02
+
+Cannot author binary .ogg files inline. The catalog renders this spec; sourcing
+is up to the implementer. All targets: **OGG Vorbis, mono, 44.1 kHz, -14 LUFS**.
+
+## Chat & Messaging
+| File | Duration | Tonality | Freesound tags |
+|------|----------|----------|----------------|
+| message-receive.ogg | 220 ms | Soft bubble-pop / wooden tonal drop, low presence | `bubble pop ui notification soft` |
+| message-send.ogg    | 180 ms | Paper-flick / brush swoosh, airy | `paper swipe whoosh ui send` |
+
+## Brett Collaboration
+| File | Duration | Tonality | Freesound tags |
+|------|----------|----------|----------------|
+| user-join.ogg     | 320 ms  | Single wood tap, warm decay | `wood knock soft tap warm` |
+| piece-place.ogg   | 200 ms  | Wood-on-wood click, very dry, no reverb | `wood click chess piece place` |
+| bell-gong.ogg     | 4-6 s   | Tibetan bell or singing bowl, long sustain | `tibetan bell gong meditation` |
+
+## Monitoring Alerts (Admin Portal)
+| File | Duration | Tonality | Freesound tags |
+|------|----------|----------|----------------|
+| node-degraded.ogg     | 600 ms | Low descending two-tone ping, -minor third | `alert ui warning low descending` |
+| reconcile-success.ogg | 350 ms | Brief upward 2-note chime, clean sine | `success chime ui ascending two notes` |
+
+## Arena Server (terrain coordinate audio)
+| File | Duration | Tonality | Freesound tags |
+|------|----------|----------|----------------|
+| footstep-grass.ogg | 180 ms | Soft brush, organic crunch | `footstep grass soft single` |
+| footstep-mud.ogg   | 220 ms | Wet squelch, low frequency | `footstep mud wet squelch` |
+
+## Sourcing
+- **Freesound.org** — CC0 / CC-BY tags only.
+- **Sonniss GameAudio GDC Bundle** — yearly free royalty-free pack.
+- Normalize loudness to -14 LUFS, dither to 16-bit, encode `oggenc -q 4`.
+
+## Integration (Howler.js)
+```js
+const sfx = {
+  msgRecv: new Howl({ src: ['/sfx/message-receive.ogg'], volume: 0.35 }),
+  msgSend: new Howl({ src: ['/sfx/message-send.ogg'], volume: 0.4 }),
+  gong:    new Howl({ src: ['/sfx/bell-gong.ogg'], volume: 0.55, sprite: { ring: [0, 5800] } }),
+};
+```
+
+Coordinate-audio mapping (arena): `PositionalAudio` w/ refDistance 6, rolloffFactor 1.8.

--- a/assets/branding/korczewski/brett/characters/product-owner.svg
+++ b/assets/branding/korczewski/brett/characters/product-owner.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 320" width="240" height="320" role="img" aria-label="Product owner">
+  <defs>
+    <radialGradient id="gk" cx="50%" cy="40%" r="65%"><stop offset="0%" stop-color="#1c1428"></stop><stop offset="100%" stop-color="#120D1C"></stop></radialGradient>
+    <filter id="grainK"><feTurbulence type="fractalNoise" baseFrequency="1.1" numOctaves="2" seed="7"></feTurbulence><feColorMatrix values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 .07 0"></feColorMatrix></filter>
+  </defs>
+  <rect x="0" y="0" width="240" height="320" fill="url(#gk)"></rect>
+  <rect x="0" y="0" width="240" height="320" filter="url(#grainK)" opacity=".6"></rect>
+  <rect x="14" y="14" width="212" height="292" fill="none" stroke="#7a8b4f" stroke-opacity=".35"></rect>
+  <g stroke="#C8F76A" stroke-opacity=".55" stroke-width="1" fill="none">
+    <path d="M14 24 L14 14 L24 14"></path><path d="M226 24 L226 14 L216 14"></path>
+    <path d="M14 296 L14 306 L24 306"></path><path d="M226 296 L226 306 L216 306"></path>
+  </g>
+  
+  <g fill="#4c4d5b">
+    <ellipse cx="118" cy="74" rx="18" ry="22"></ellipse>
+    <path d="M84 108 Q88 96 106 96 L132 96 Q150 96 156 108 L160 200 L80 200 Z"></path>
+    <path d="M80 130 L62 188 L84 200 L98 158 Z"></path>
+    <path d="M160 130 L178 188 L156 200 L142 158 Z"></path>
+    <rect x="94" y="200" width="20" height="70" rx="4"></rect>
+    <rect x="126" y="200" width="20" height="70" rx="4"></rect>
+  </g>
+  <rect x="62" y="156" width="116" height="56" fill="#1c1428" stroke="#7a8b4f" stroke-width="1"></rect>
+  <g stroke="#7a8b4f" stroke-width="0.4" opacity=".7">
+    <line x1="72" y1="156" x2="72" y2="212"></line><line x1="92" y1="156" x2="92" y2="212"></line>
+    <line x1="112" y1="156" x2="112" y2="212"></line><line x1="132" y1="156" x2="132" y2="212"></line>
+    <line x1="152" y1="156" x2="152" y2="212"></line><line x1="168" y1="156" x2="168" y2="212"></line>
+    <line x1="62" y1="170" x2="178" y2="170"></line><line x1="62" y1="184" x2="178" y2="184"></line>
+    <line x1="62" y1="198" x2="178" y2="198"></line>
+  </g>
+  <rect x="78" y="174" width="40" height="20" fill="none" stroke="#C8F76A" stroke-width="1.2"></rect>
+  <line x1="124" y1="178" x2="166" y2="178" stroke="#C8F76A" stroke-width="1" opacity=".85"></line>
+  <line x1="124" y1="186" x2="158" y2="186" stroke="#C8F76A" stroke-width="1" opacity=".55"></line>
+  <text x="120" y="296" text-anchor="middle" font-family="Geist Mono, monospace" font-size="9" fill="#7a8b4f" letter-spacing="2">PRODUCT · OWNER</text>
+
+</svg>

--- a/assets/branding/korczewski/brett/characters/security-officer.svg
+++ b/assets/branding/korczewski/brett/characters/security-officer.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 320" width="240" height="320" role="img" aria-label="Security officer">
+  <defs>
+    <radialGradient id="gk" cx="50%" cy="40%" r="65%"><stop offset="0%" stop-color="#1c1428"></stop><stop offset="100%" stop-color="#120D1C"></stop></radialGradient>
+    <filter id="grainK"><feTurbulence type="fractalNoise" baseFrequency="1.1" numOctaves="2" seed="7"></feTurbulence><feColorMatrix values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 .07 0"></feColorMatrix></filter>
+  </defs>
+  <rect x="0" y="0" width="240" height="320" fill="url(#gk)"></rect>
+  <rect x="0" y="0" width="240" height="320" filter="url(#grainK)" opacity=".6"></rect>
+  <rect x="14" y="14" width="212" height="292" fill="none" stroke="#7a8b4f" stroke-opacity=".35"></rect>
+  <g stroke="#C8F76A" stroke-opacity=".55" stroke-width="1" fill="none">
+    <path d="M14 24 L14 14 L24 14"></path><path d="M226 24 L226 14 L216 14"></path>
+    <path d="M14 296 L14 306 L24 306"></path><path d="M226 296 L226 306 L216 306"></path>
+  </g>
+  
+  <g fill="#5d5e6c">
+    <path d="M88 74 Q120 50 152 74 L156 116 L84 116 Z"></path>
+    <rect x="92" y="98" width="56" height="6" fill="#120D1C"></rect>
+    <line x1="92" y1="101" x2="148" y2="101" stroke="#C8F76A" stroke-width="0.6" opacity=".95"></line>
+    <path d="M78 122 L82 200 L120 220 L158 200 L162 122 Z"></path>
+    <path d="M64 130 Q60 152 70 174 L82 168 L82 130 Z"></path>
+    <path d="M176 130 Q180 152 170 174 L158 168 L158 130 Z"></path>
+    <rect x="92" y="222" width="22" height="56" rx="3"></rect>
+    <rect x="126" y="222" width="22" height="56" rx="3"></rect>
+  </g>
+  <path d="M120 142 L94 152 L94 198 Q94 212 120 222 Q146 212 146 198 L146 152 Z" fill="#1c1428" stroke="#7a8b4f" stroke-width="1.2"></path>
+  <circle cx="120" cy="178" r="10" fill="none" stroke="#C8F76A" stroke-width="1.5"></circle>
+  <rect x="118" y="186" width="4" height="14" fill="#C8F76A"></rect>
+  <rect x="116" y="194" width="8" height="2" fill="#C8F76A"></rect>
+  <rect x="116" y="198" width="6" height="2" fill="#C8F76A"></rect>
+  <text x="120" y="296" text-anchor="middle" font-family="Geist Mono, monospace" font-size="9" fill="#7a8b4f" letter-spacing="2">SEC · KEYCLOAK</text>
+
+</svg>

--- a/assets/branding/korczewski/brett/characters/sysadmin.svg
+++ b/assets/branding/korczewski/brett/characters/sysadmin.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 320" width="240" height="320" role="img" aria-label="Sysadmin">
+  <defs>
+    <radialGradient id="gk" cx="50%" cy="40%" r="65%"><stop offset="0%" stop-color="#1c1428"></stop><stop offset="100%" stop-color="#120D1C"></stop></radialGradient>
+    <filter id="grainK"><feTurbulence type="fractalNoise" baseFrequency="1.1" numOctaves="2" seed="7"></feTurbulence><feColorMatrix values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 .07 0"></feColorMatrix></filter>
+  </defs>
+  <rect x="0" y="0" width="240" height="320" fill="url(#gk)"></rect>
+  <rect x="0" y="0" width="240" height="320" filter="url(#grainK)" opacity=".6"></rect>
+  <rect x="14" y="14" width="212" height="292" fill="none" stroke="#7a8b4f" stroke-opacity=".35"></rect>
+  <g stroke="#C8F76A" stroke-opacity=".55" stroke-width="1" fill="none">
+    <path d="M14 24 L14 14 L24 14"></path><path d="M226 24 L226 14 L216 14"></path>
+    <path d="M14 296 L14 306 L24 306"></path><path d="M226 296 L226 306 L216 306"></path>
+  </g>
+  
+  <g fill="#4c4d5b">
+    <path d="M82 84 Q120 44 158 84 L166 138 Q160 146 152 144 L88 144 Q80 146 74 138 Z"></path>
+    <path d="M74 144 L66 280 L174 280 L166 144 Z"></path>
+    <path d="M84 168 L72 222 L96 232 L110 200 Z"></path>
+    <path d="M156 168 L168 222 L144 232 L130 200 Z"></path>
+  </g>
+  <ellipse cx="120" cy="108" rx="24" ry="20" fill="#120D1C"></ellipse>
+  <rect x="100" y="106" width="14" height="6" rx="1.5" fill="#2a1f3a" stroke="#7a8b4f" stroke-width="0.8"></rect>
+  <rect x="126" y="106" width="14" height="6" rx="1.5" fill="#2a1f3a" stroke="#7a8b4f" stroke-width="0.8"></rect>
+  <line x1="114" y1="109" x2="126" y2="109" stroke="#7a8b4f" stroke-width="0.8"></line>
+  <circle cx="107" cy="109" r="1.4" fill="#C8F76A" opacity=".9"></circle>
+  <circle cx="133" cy="109" r="1.4" fill="#C8F76A" opacity=".9"></circle>
+  <rect x="92" y="208" width="56" height="32" rx="2" fill="#2a1f3a" stroke="#7a8b4f" stroke-width="0.8"></rect>
+  <rect x="96" y="212" width="48" height="22" fill="#120D1C"></rect>
+  <line x1="100" y1="218" x2="120" y2="218" stroke="#C8F76A" stroke-width="0.6" opacity=".9"></line>
+  <line x1="100" y1="222" x2="138" y2="222" stroke="#7a8b4f" stroke-width="0.6"></line>
+  <line x1="100" y1="226" x2="130" y2="226" stroke="#7a8b4f" stroke-width="0.6"></line>
+  <text x="120" y="296" text-anchor="middle" font-family="Geist Mono, monospace" font-size="9" fill="#7a8b4f" letter-spacing="2">SYSADMIN · OPERATOR</text>
+
+</svg>

--- a/assets/branding/korczewski/brett/props/prop-alert.svg
+++ b/assets/branding/korczewski/brett/props/prop-alert.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200" role="img" aria-label="Alert">
+  <defs>
+    <radialGradient id="pgk" cx="50%" cy="45%" r="65%"><stop offset="0%" stop-color="#1c1428"></stop><stop offset="100%" stop-color="#120D1C"></stop></radialGradient>
+    <filter id="pgrainK"><feTurbulence type="fractalNoise" baseFrequency="1.0" numOctaves="2" seed="9"></feTurbulence><feColorMatrix values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 .07 0"></feColorMatrix></filter>
+  </defs>
+  <rect width="200" height="200" fill="url(#pgk)"></rect>
+  <rect width="200" height="200" filter="url(#pgrainK)" opacity=".5"></rect>
+  <rect x="12" y="12" width="176" height="176" fill="none" stroke="#7a8b4f" stroke-opacity=".35"></rect>
+  
+  <path d="M100 32 L168 148 L32 148 Z" fill="#2a1f3a" stroke="#C8F76A" stroke-width="2"></path>
+  <path d="M100 50 L156 144 L44 144 Z" fill="none" stroke="#7a8b4f" stroke-width="0.6" stroke-dasharray="3 2" opacity=".6"></path>
+  <rect x="96" y="68" width="8" height="48" fill="#C8F76A"></rect>
+  <rect x="96" y="124" width="8" height="8" fill="#C8F76A"></rect>
+  <text x="100" y="180" text-anchor="middle" font-family="Geist Mono, monospace" font-size="8" fill="#7a8b4f" letter-spacing="2">ALERT · NODE FAIL</text>
+
+</svg>

--- a/assets/branding/korczewski/brett/props/prop-database.svg
+++ b/assets/branding/korczewski/brett/props/prop-database.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200" role="img" aria-label="Database">
+  <defs>
+    <radialGradient id="pgk" cx="50%" cy="45%" r="65%"><stop offset="0%" stop-color="#1c1428"></stop><stop offset="100%" stop-color="#120D1C"></stop></radialGradient>
+    <filter id="pgrainK"><feTurbulence type="fractalNoise" baseFrequency="1.0" numOctaves="2" seed="9"></feTurbulence><feColorMatrix values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 .07 0"></feColorMatrix></filter>
+  </defs>
+  <rect width="200" height="200" fill="url(#pgk)"></rect>
+  <rect width="200" height="200" filter="url(#pgrainK)" opacity=".5"></rect>
+  <rect x="12" y="12" width="176" height="176" fill="none" stroke="#7a8b4f" stroke-opacity=".35"></rect>
+  
+  <g fill="#4c4d5b" stroke="#7a8b4f" stroke-width="1.2">
+    <ellipse cx="100" cy="48" rx="42" ry="12"></ellipse>
+    <path d="M58 48 L58 142 Q58 154 100 154 Q142 154 142 142 L142 48"></path>
+    <ellipse cx="100" cy="48" rx="42" ry="12" fill="#2a1f3a"></ellipse>
+  </g>
+  <ellipse cx="100" cy="80" rx="42" ry="12" fill="none" stroke="#7a8b4f" stroke-width="0.8" opacity=".7"></ellipse>
+  <ellipse cx="100" cy="112" rx="42" ry="12" fill="none" stroke="#7a8b4f" stroke-width="0.8" opacity=".7"></ellipse>
+  <circle cx="100" cy="48" r="3" fill="#C8F76A"></circle>
+  <text x="100" y="180" text-anchor="middle" font-family="Geist Mono, monospace" font-size="8" fill="#7a8b4f" letter-spacing="2">PV · DATABASE</text>
+
+</svg>

--- a/assets/branding/korczewski/brett/props/prop-firewall.svg
+++ b/assets/branding/korczewski/brett/props/prop-firewall.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200" role="img" aria-label="Firewall">
+  <defs>
+    <radialGradient id="pgk" cx="50%" cy="45%" r="65%"><stop offset="0%" stop-color="#1c1428"></stop><stop offset="100%" stop-color="#120D1C"></stop></radialGradient>
+    <filter id="pgrainK"><feTurbulence type="fractalNoise" baseFrequency="1.0" numOctaves="2" seed="9"></feTurbulence><feColorMatrix values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 .07 0"></feColorMatrix></filter>
+  </defs>
+  <rect width="200" height="200" fill="url(#pgk)"></rect>
+  <rect width="200" height="200" filter="url(#pgrainK)" opacity=".5"></rect>
+  <rect x="12" y="12" width="176" height="176" fill="none" stroke="#7a8b4f" stroke-opacity=".35"></rect>
+  
+  <g fill="#4c4d5b" stroke="#7a8b4f" stroke-width="0.8">
+    <rect x="46" y="44" width="14" height="110"></rect>
+    <rect x="140" y="44" width="14" height="110"></rect>
+    <rect x="46" y="38" width="108" height="14"></rect>
+    <line x1="74" y1="60" x2="74" y2="148" stroke-width="2"></line>
+    <line x1="90" y1="60" x2="90" y2="148" stroke-width="2"></line>
+    <line x1="110" y1="60" x2="110" y2="148" stroke-width="2"></line>
+    <line x1="126" y1="60" x2="126" y2="148" stroke-width="2"></line>
+  </g>
+  <path d="M26 100 L66 100" stroke="#C8F76A" stroke-width="2" stroke-dasharray="4 3"></path>
+  <circle cx="100" cy="100" r="4" fill="#C8F76A"></circle>
+  <text x="100" y="180" text-anchor="middle" font-family="Geist Mono, monospace" font-size="8" fill="#7a8b4f" letter-spacing="2">TRAEFIK · FIREWALL</text>
+
+</svg>

--- a/assets/branding/korczewski/brett/props/prop-pipeline.svg
+++ b/assets/branding/korczewski/brett/props/prop-pipeline.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200" role="img" aria-label="Pipeline">
+  <defs>
+    <radialGradient id="pgk" cx="50%" cy="45%" r="65%"><stop offset="0%" stop-color="#1c1428"></stop><stop offset="100%" stop-color="#120D1C"></stop></radialGradient>
+    <filter id="pgrainK"><feTurbulence type="fractalNoise" baseFrequency="1.0" numOctaves="2" seed="9"></feTurbulence><feColorMatrix values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 .07 0"></feColorMatrix></filter>
+  </defs>
+  <rect width="200" height="200" fill="url(#pgk)"></rect>
+  <rect width="200" height="200" filter="url(#pgrainK)" opacity=".5"></rect>
+  <rect x="12" y="12" width="176" height="176" fill="none" stroke="#7a8b4f" stroke-opacity=".35"></rect>
+  
+  <g fill="#4c4d5b" stroke="#7a8b4f" stroke-width="1">
+    <g transform="translate(72 80)">
+      <g>
+        <rect x="-3" y="-36" width="6" height="10"></rect><rect x="-3" y="26" width="6" height="10"></rect>
+        <rect x="-36" y="-3" width="10" height="6"></rect><rect x="26" y="-3" width="10" height="6"></rect>
+        <rect x="-26" y="-26" width="6" height="10" transform="rotate(45 -23 -21)"></rect>
+        <rect x="20" y="-26" width="6" height="10" transform="rotate(-45 23 -21)"></rect>
+        <rect x="-26" y="16" width="6" height="10" transform="rotate(-45 -23 21)"></rect>
+        <rect x="20" y="16" width="6" height="10" transform="rotate(45 23 21)"></rect>
+      </g>
+      <circle cx="0" cy="0" r="26"></circle>
+      <circle cx="0" cy="0" r="8" fill="#2a1f3a"></circle>
+    </g>
+    <g transform="translate(132 110)">
+      <g>
+        <rect x="-3" y="-30" width="6" height="9"></rect><rect x="-3" y="21" width="6" height="9"></rect>
+        <rect x="-30" y="-3" width="9" height="6"></rect><rect x="21" y="-3" width="9" height="6"></rect>
+      </g>
+      <circle cx="0" cy="0" r="22"></circle>
+      <circle cx="0" cy="0" r="6" fill="#2a1f3a"></circle>
+    </g>
+  </g>
+  <path d="M40 150 L160 150" stroke="#C8F76A" stroke-width="1.5"></path>
+  <path d="M160 150 L154 146 M160 150 L154 154" stroke="#C8F76A" stroke-width="1.5" fill="none"></path>
+  <text x="100" y="180" text-anchor="middle" font-family="Geist Mono, monospace" font-size="8" fill="#7a8b4f" letter-spacing="2">CI · CD · PIPELINE</text>
+
+</svg>

--- a/assets/branding/korczewski/brett/terrain/namespace-boundary.svg
+++ b/assets/branding/korczewski/brett/terrain/namespace-boundary.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 480 240" width="480" height="240" role="img" aria-label="Namespace boundary">
+  <rect width="480" height="240" fill="#120D1C"></rect>
+  <rect x="14" y="14" width="220" height="212" fill="#1c1428" stroke="#7a8b4f" stroke-width="1" stroke-dasharray="6 4"></rect>
+  <text x="26" y="34" font-family="Geist Mono, monospace" font-size="9" fill="#C8F76A" letter-spacing="2">NS · WORKSPACE</text>
+  <rect x="246" y="14" width="220" height="212" fill="#1c1428" stroke="#7a8b4f" stroke-width="1" stroke-dasharray="6 4"></rect>
+  <text x="258" y="34" font-family="Geist Mono, monospace" font-size="9" fill="#C8F76A" letter-spacing="2">NS · WEBSITE</text>
+  <path d="M196 120 L284 120" stroke="#C8F76A" stroke-width="1.5" stroke-dasharray="3 3"></path>
+  <path d="M284 120 L278 116 M284 120 L278 124" stroke="#C8F76A" stroke-width="1.5" fill="none"></path>
+  <g fill="#4c4d5b" stroke="#7a8b4f" stroke-width="0.6">
+    <rect x="40" y="80" width="60" height="40" rx="2"></rect><rect x="118" y="80" width="60" height="40" rx="2"></rect>
+    <rect x="40" y="138" width="60" height="40" rx="2"></rect><rect x="118" y="138" width="60" height="40" rx="2"></rect>
+    <rect x="296" y="80" width="80" height="40" rx="2"></rect><rect x="296" y="138" width="80" height="40" rx="2"></rect>
+  </g>
+</svg>

--- a/assets/branding/korczewski/brett/terrain/subnet-grid.svg
+++ b/assets/branding/korczewski/brett/terrain/subnet-grid.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 480 240" width="480" height="240" role="img" aria-label="Subnet grid">
+  <defs>
+    <pattern id="sg" width="24" height="24" patternUnits="userSpaceOnUse"><rect width="24" height="24" fill="#120D1C"></rect><path d="M24 0 L0 0 0 24" fill="none" stroke="#7a8b4f" stroke-opacity=".35" stroke-width="0.5"></path></pattern>
+    <pattern id="sgBig" width="120" height="120" patternUnits="userSpaceOnUse"><path d="M120 0 L0 0 0 120" fill="none" stroke="#C8F76A" stroke-opacity=".25" stroke-width="0.7"></path></pattern>
+  </defs>
+  <rect width="480" height="240" fill="url(#sg)"></rect>
+  <rect width="480" height="240" fill="url(#sgBig)"></rect>
+  <g fill="#C8F76A"><circle cx="120" cy="120" r="2"></circle><circle cx="240" cy="120" r="2"></circle><circle cx="360" cy="120" r="2"></circle><circle cx="60" cy="60" r="1.5" opacity=".7"></circle><circle cx="420" cy="180" r="1.5" opacity=".7"></circle></g>
+  <text x="14" y="22" font-family="Geist Mono, monospace" font-size="8" fill="#7a8b4f" letter-spacing="1">10.0.0.0/24</text>
+  <text x="200" y="22" font-family="Geist Mono, monospace" font-size="8" fill="#7a8b4f" letter-spacing="1">10.1.0.0/24</text>
+  <text x="380" y="22" font-family="Geist Mono, monospace" font-size="8" fill="#7a8b4f" letter-spacing="1">VPC-PROD</text>
+</svg>

--- a/assets/branding/korczewski/identity/keycloak-bg-korczewski.svg
+++ b/assets/branding/korczewski/identity/keycloak-bg-korczewski.svg
@@ -1,0 +1,69 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1920 1080" width="1920" height="1080" role="img" aria-label="Korczewski Keycloak login background">
+  <defs>
+    <radialGradient id="kbl-lime" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#C8F76A" stop-opacity="0.45"></stop>
+      <stop offset="100%" stop-color="#C8F76A" stop-opacity="0"></stop>
+    </radialGradient>
+    <radialGradient id="kbl-purple" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#6a3b8f" stop-opacity="0.55"></stop>
+      <stop offset="100%" stop-color="#6a3b8f" stop-opacity="0"></stop>
+    </radialGradient>
+    <radialGradient id="kbl-cyan" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#5fb8c8" stop-opacity="0.4"></stop>
+      <stop offset="100%" stop-color="#5fb8c8" stop-opacity="0"></stop>
+    </radialGradient>
+    <filter id="kbl-blur"><feGaussianBlur stdDeviation="45"></feGaussianBlur></filter>
+    <filter id="kbl-grain"><feTurbulence type="fractalNoise" baseFrequency="0.95" numOctaves="2" seed="7"></feTurbulence><feColorMatrix values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.07 0"></feColorMatrix></filter>
+    <pattern id="kbl-scan" width="4" height="4" patternUnits="userSpaceOnUse">
+      <rect width="4" height="1" fill="#C8F76A" opacity="0.04"></rect>
+    </pattern>
+  </defs>
+
+  <rect width="1920" height="1080" fill="#120D1C"></rect>
+  <g filter="url(#kbl-blur)">
+    <circle cx="360" cy="280" r="340" fill="url(#kbl-lime)"></circle>
+    <circle cx="1620" cy="820" r="400" fill="url(#kbl-purple)"></circle>
+    <circle cx="1720" cy="180" r="220" fill="url(#kbl-cyan)"></circle>
+    <circle cx="240" cy="900" r="260" fill="url(#kbl-purple)"></circle>
+  </g>
+  <rect width="1920" height="1080" fill="url(#kbl-scan)"></rect>
+  <rect width="1920" height="1080" filter="url(#kbl-grain)" opacity="0.75"></rect>
+
+  <rect x="80" y="80" width="1760" height="920" fill="none" stroke="#C8F76A" stroke-opacity="0.22"></rect>
+  <g stroke="#C8F76A" stroke-opacity="0.7" stroke-width="1" fill="none">
+    <path d="M80 110 L80 80 L110 80"></path>
+    <path d="M1840 110 L1840 80 L1810 80"></path>
+    <path d="M80 970 L80 1000 L110 1000"></path>
+    <path d="M1840 970 L1840 1000 L1810 1000"></path>
+  </g>
+
+  <g font-family="Geist Mono, monospace" font-size="13" letter-spacing="2.5">
+    <text x="110" y="138" fill="#C8F76A">$ auth --provider oidc</text>
+    <text x="110" y="158" fill="#7a8b4f">CLUSTER · KORCZEWSKI.DE</text>
+  </g>
+  <g font-family="Geist Mono, monospace" font-size="13" letter-spacing="2.5" text-anchor="end">
+    <text x="1810" y="138" fill="#C8F76A">KEYCLOAK · v25.0</text>
+    <text x="1810" y="158" fill="#7a8b4f">[SECURE] · TLS 1.3</text>
+  </g>
+
+  <g transform="translate(960, 440)" text-anchor="middle">
+    <text font-family="Geist Mono, monospace" font-size="13" letter-spacing="4" fill="#7a8b4f">› SYSTEM AUTH GATEWAY</text>
+  </g>
+  <g transform="translate(960, 580)" text-anchor="middle">
+    <text font-family="Geist, sans-serif" font-weight="600" font-size="108" fill="#eef1f3" letter-spacing="-2.5">korczewski<tspan fill="#C8F76A">.de</tspan></text>
+  </g>
+  <g transform="translate(960, 660)" text-anchor="middle">
+    <text font-family="Geist Mono, monospace" font-size="17" letter-spacing="4" fill="#7a8b4f">DEVOPS · PLATFORM · INFRASTRUCTURE</text>
+  </g>
+
+  <g transform="translate(960, 800)" text-anchor="middle">
+    <line x1="-60" y1="0" x2="60" y2="0" stroke="#C8F76A" stroke-opacity="0.55"></line>
+    <text y="36" font-family="Geist, sans-serif" font-weight="300" font-size="20" fill="#cdd3d9">Sign in with your platform account.</text>
+    <text y="68" font-family="Geist Mono, monospace" font-size="12" letter-spacing="2.5" fill="#7a8b4f">— KEYCLOAK FORM INJECTED HERE —</text>
+  </g>
+
+  <g font-family="Geist Mono, monospace" font-size="11" letter-spacing="2.5" fill="#5a6b3f">
+    <text x="110" y="975">© 2026 KORCZEWSKI.DE — INFRASTRUCTURE AS POSITION</text>
+    <text x="1810" y="975" text-anchor="end">CONTAINERIZED · OBSERVABLE · GITOPS</text>
+  </g>
+</svg>

--- a/assets/branding/korczewski/identity/report-header-korczewski.svg
+++ b/assets/branding/korczewski/identity/report-header-korczewski.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1240 220" width="1240" height="220" role="img" aria-label="Korczewski letterhead">
+  <rect width="1240" height="220" fill="#f6f3ee"></rect>
+  <g transform="translate(80, 60)">
+    <rect width="56" height="56" rx="6" fill="#120D1C"></rect>
+    <rect x="6" y="6" width="44" height="44" fill="none" stroke="#C8F76A" stroke-opacity="0.6"></rect>
+    <text x="28" y="40" text-anchor="middle" font-family="Geist Mono, monospace" font-weight="500" font-size="30" fill="#C8F76A">k</text>
+  </g>
+  <g transform="translate(160, 96)">
+    <text font-family="Geist, sans-serif" font-weight="600" font-size="32" fill="#120D1C" letter-spacing="-0.6">korczewski<tspan fill="#6a8538">.de</tspan></text>
+    <text y="26" font-family="Geist Mono, monospace" font-size="11" letter-spacing="2.5" fill="#6a727e">DEVOPS · PLATFORM ENGINEERING · GITOPS · OBSERVABILITY</text>
+  </g>
+  <g transform="translate(1160, 70)" text-anchor="end" font-family="Geist Mono, monospace" font-size="11" letter-spacing="2" fill="#6a727e">
+    <text>GERALD KORCZEWSKI</text>
+    <text y="22">LÜNEBURG · DE · DACH</text>
+    <text y="44">KORCZEWSKI.DE</text>
+  </g>
+  <line x1="80" y1="156" x2="1160" y2="156" stroke="#6a8538" stroke-opacity="0.55" stroke-width="0.6"></line>
+  <line x1="80" y1="158" x2="320" y2="158" stroke="#6a8538" stroke-width="0.6"></line>
+  <g transform="translate(80, 188)" font-family="Geist Mono, monospace" font-size="10" letter-spacing="2.5" fill="#6a8538">
+    <text>INVOICE · CONTRACT · INCIDENT-REPORT · {{ DOC.TYPE }}</text>
+  </g>
+  <g transform="translate(1160, 188)" font-family="Geist Mono, monospace" font-size="10" letter-spacing="2.5" fill="#6a727e" text-anchor="end">
+    <text>{{ DOC.ID }} · {{ DOC.DATE }} · TLS</text>
+  </g>
+</svg>

--- a/assets/branding/mentolder/brett/characters/coachee.figurine.svg
+++ b/assets/branding/mentolder/brett/characters/coachee.figurine.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 320" width="240" height="320" role="img" aria-label="Coachee figurine">
+  <defs>
+    <radialGradient id="g" cx="50%" cy="38%" r="62%">
+      <stop offset="0%" stop-color="#17202e"></stop><stop offset="100%" stop-color="#0b111c"></stop>
+    </radialGradient>
+    <filter id="grain"><feTurbulence type="fractalNoise" baseFrequency=".9" numOctaves="2" seed="3"></feTurbulence><feColorMatrix values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 .06 0"></feColorMatrix></filter>
+  </defs>
+  <rect x="0" y="0" width="240" height="320" fill="url(#g)"></rect>
+  <rect x="0" y="0" width="240" height="320" filter="url(#grain)" opacity=".5"></rect>
+  <rect x="14" y="14" width="212" height="292" fill="none" stroke="#d7b06a" stroke-opacity=".22" stroke-width="1"></rect>
+  <g stroke="#d7b06a" stroke-opacity=".55" stroke-width="1" fill="none">
+    <path d="M14 24 L14 14 L24 14"></path><path d="M226 24 L226 14 L216 14"></path>
+    <path d="M14 296 L14 306 L24 306"></path><path d="M226 296 L226 306 L216 306"></path>
+  </g>
+  
+  <g fill="#e7ead0">
+    <ellipse cx="120" cy="74" rx="20" ry="24"></ellipse>
+    <path d="M84 110 Q88 100 102 98 L138 98 Q152 100 156 110 L162 180 L78 180 Z"></path>
+    <path d="M82 130 Q120 156 158 130 L154 158 Q120 178 86 158 Z" fill="#b8c0a8"></path>
+    <rect x="92" y="180" width="22" height="84" rx="5"></rect>
+    <rect x="126" y="180" width="22" height="84" rx="5"></rect>
+    <ellipse cx="103" cy="270" rx="14" ry="6"></ellipse>
+    <ellipse cx="137" cy="270" rx="14" ry="6"></ellipse>
+  </g>
+  <rect x="84" y="148" width="72" height="2" fill="#d7b06a" opacity=".7"></rect>
+  <text x="120" y="296" text-anchor="middle" font-family="Geist Mono, monospace" font-size="9" fill="#d7b06a" letter-spacing="2">COACHEE · FIGURINE</text>
+
+</svg>

--- a/assets/branding/mentolder/brett/characters/coachee.portrait.svg
+++ b/assets/branding/mentolder/brett/characters/coachee.portrait.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 320" width="240" height="320" role="img" aria-label="Coachee portrait">
+  <defs>
+    <radialGradient id="g" cx="50%" cy="38%" r="62%">
+      <stop offset="0%" stop-color="#17202e"></stop><stop offset="100%" stop-color="#0b111c"></stop>
+    </radialGradient>
+    <filter id="grain"><feTurbulence type="fractalNoise" baseFrequency=".9" numOctaves="2" seed="3"></feTurbulence><feColorMatrix values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 .06 0"></feColorMatrix></filter>
+  </defs>
+  <rect x="0" y="0" width="240" height="320" fill="url(#g)"></rect>
+  <rect x="0" y="0" width="240" height="320" filter="url(#grain)" opacity=".5"></rect>
+  <rect x="14" y="14" width="212" height="292" fill="none" stroke="#d7b06a" stroke-opacity=".22" stroke-width="1"></rect>
+  <g stroke="#d7b06a" stroke-opacity=".55" stroke-width="1" fill="none">
+    <path d="M14 24 L14 14 L24 14"></path><path d="M226 24 L226 14 L216 14"></path>
+    <path d="M14 296 L14 306 L24 306"></path><path d="M226 296 L226 306 L216 306"></path>
+  </g>
+  
+  <g fill="#e7ead0">
+    <ellipse cx="120" cy="140" rx="34" ry="42"></ellipse>
+    <path d="M50 280 Q52 220 80 196 Q98 184 120 184 Q142 184 160 196 Q188 220 190 280 Z"></path>
+    <path d="M70 230 Q120 254 170 230 L168 248 Q120 270 72 248 Z" fill="#b8c0a8" opacity=".55"></path>
+  </g>
+  <circle cx="108" cy="134" r="2" fill="#d7b06a"></circle>
+  <circle cx="132" cy="134" r="2" fill="#d7b06a"></circle>
+  <text x="120" y="296" text-anchor="middle" font-family="Geist Mono, monospace" font-size="9" fill="#d7b06a" letter-spacing="2">COACHEE · PORTRAIT</text>
+
+</svg>

--- a/assets/branding/mentolder/brett/characters/saboteur.svg
+++ b/assets/branding/mentolder/brett/characters/saboteur.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 320" width="240" height="320" role="img" aria-label="Saboteur">
+  <defs>
+    <radialGradient id="g" cx="50%" cy="38%" r="62%">
+      <stop offset="0%" stop-color="#17202e"></stop><stop offset="100%" stop-color="#0b111c"></stop>
+    </radialGradient>
+    <filter id="grain"><feTurbulence type="fractalNoise" baseFrequency=".9" numOctaves="2" seed="3"></feTurbulence><feColorMatrix values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 .06 0"></feColorMatrix></filter>
+  </defs>
+  <rect x="0" y="0" width="240" height="320" fill="url(#g)"></rect>
+  <rect x="0" y="0" width="240" height="320" filter="url(#grain)" opacity=".5"></rect>
+  <rect x="14" y="14" width="212" height="292" fill="none" stroke="#d7b06a" stroke-opacity=".22" stroke-width="1"></rect>
+  <g stroke="#d7b06a" stroke-opacity=".55" stroke-width="1" fill="none">
+    <path d="M14 24 L14 14 L24 14"></path><path d="M226 24 L226 14 L216 14"></path>
+    <path d="M14 296 L14 306 L24 306"></path><path d="M226 296 L226 306 L216 306"></path>
+  </g>
+  
+  <g fill="#1d2736">
+    <path d="M80 78 Q120 36 160 78 L168 134 Q160 144 152 142 L88 142 Q80 144 72 134 Z"></path>
+    <path d="M70 140 L60 282 L180 282 L170 140 Z"></path>
+    <path d="M70 148 L42 240 L58 248 L84 168 Z"></path>
+    <path d="M170 148 L198 240 L182 248 L156 168 Z"></path>
+  </g>
+  <ellipse cx="120" cy="106" rx="26" ry="22" fill="#0b111c"></ellipse>
+  <rect x="100" y="104" width="10" height="3" fill="#d7b06a" opacity=".95"></rect>
+  <rect x="130" y="104" width="10" height="3" fill="#d7b06a" opacity=".95"></rect>
+  <path d="M60 282 L70 274 L82 282 L94 274 L106 282 L118 274 L130 282 L142 274 L154 282 L166 274 L180 282 Z" fill="#1d2736"></path>
+  <text x="120" y="296" text-anchor="middle" font-family="Geist Mono, monospace" font-size="9" fill="#d7b06a" letter-spacing="2">SABOTEUR · SCHATTEN</text>
+
+</svg>

--- a/assets/branding/mentolder/brett/characters/team-member-active.svg
+++ b/assets/branding/mentolder/brett/characters/team-member-active.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 320" width="240" height="320" role="img" aria-label="Team member active">
+  <defs>
+    <radialGradient id="g" cx="50%" cy="38%" r="62%">
+      <stop offset="0%" stop-color="#17202e"></stop><stop offset="100%" stop-color="#0b111c"></stop>
+    </radialGradient>
+    <filter id="grain"><feTurbulence type="fractalNoise" baseFrequency=".9" numOctaves="2" seed="3"></feTurbulence><feColorMatrix values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 .06 0"></feColorMatrix></filter>
+  </defs>
+  <rect x="0" y="0" width="240" height="320" fill="url(#g)"></rect>
+  <rect x="0" y="0" width="240" height="320" filter="url(#grain)" opacity=".5"></rect>
+  <rect x="14" y="14" width="212" height="292" fill="none" stroke="#d7b06a" stroke-opacity=".22" stroke-width="1"></rect>
+  <g stroke="#d7b06a" stroke-opacity=".55" stroke-width="1" fill="none">
+    <path d="M14 24 L14 14 L24 14"></path><path d="M226 24 L226 14 L216 14"></path>
+    <path d="M14 296 L14 306 L24 306"></path><path d="M226 296 L226 306 L216 306"></path>
+  </g>
+  
+  <g fill="#9fb39c">
+    <ellipse cx="124" cy="76" rx="20" ry="24"></ellipse>
+    <path d="M82 122 Q90 105 112 100 L146 100 Q166 108 170 130 L168 192 L74 184 Z"></path>
+    <path d="M152 124 Q186 138 196 168 L184 178 Q160 154 144 142 Z"></path>
+    <path d="M86 130 Q72 152 80 174 L92 168 Q98 150 100 138 Z"></path>
+    <path d="M96 190 L88 268 L106 270 L114 192 Z"></path>
+    <path d="M132 192 L148 268 L160 264 L150 190 Z"></path>
+    <ellipse cx="96" cy="272" rx="12" ry="5"></ellipse>
+    <ellipse cx="154" cy="270" rx="12" ry="5"></ellipse>
+  </g>
+  <path d="M196 168 L210 168 L204 162 M210 168 L204 174" stroke="#d7b06a" stroke-width="2" fill="none"></path>
+  <text x="120" y="296" text-anchor="middle" font-family="Geist Mono, monospace" font-size="9" fill="#d7b06a" letter-spacing="2">TEAM · ACTIVE</text>
+
+</svg>

--- a/assets/branding/mentolder/brett/characters/team-member-passive.svg
+++ b/assets/branding/mentolder/brett/characters/team-member-passive.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 320" width="240" height="320" role="img" aria-label="Team member passive">
+  <defs>
+    <radialGradient id="g" cx="50%" cy="38%" r="62%">
+      <stop offset="0%" stop-color="#17202e"></stop><stop offset="100%" stop-color="#0b111c"></stop>
+    </radialGradient>
+    <filter id="grain"><feTurbulence type="fractalNoise" baseFrequency=".9" numOctaves="2" seed="3"></feTurbulence><feColorMatrix values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 .06 0"></feColorMatrix></filter>
+  </defs>
+  <rect x="0" y="0" width="240" height="320" fill="url(#g)"></rect>
+  <rect x="0" y="0" width="240" height="320" filter="url(#grain)" opacity=".5"></rect>
+  <rect x="14" y="14" width="212" height="292" fill="none" stroke="#d7b06a" stroke-opacity=".22" stroke-width="1"></rect>
+  <g stroke="#d7b06a" stroke-opacity=".55" stroke-width="1" fill="none">
+    <path d="M14 24 L14 14 L24 14"></path><path d="M226 24 L226 14 L216 14"></path>
+    <path d="M14 296 L14 306 L24 306"></path><path d="M226 296 L226 306 L216 306"></path>
+  </g>
+  
+  <g fill="#9fb39c" opacity=".82">
+    <ellipse cx="120" cy="78" rx="20" ry="24"></ellipse>
+    <path d="M88 116 Q92 104 108 102 L132 102 Q148 104 152 116 L154 192 L86 192 Z"></path>
+    <rect x="74" y="118" width="14" height="74" rx="6"></rect>
+    <rect x="152" y="118" width="14" height="74" rx="6"></rect>
+    <rect x="94" y="192" width="20" height="78" rx="5"></rect>
+    <rect x="126" y="192" width="20" height="78" rx="5"></rect>
+    <ellipse cx="104" cy="274" rx="13" ry="5"></ellipse>
+    <ellipse cx="136" cy="274" rx="13" ry="5"></ellipse>
+  </g>
+  <line x1="100" y1="148" x2="140" y2="148" stroke="#d7b06a" stroke-width="1.5" opacity=".6"></line>
+  <text x="120" y="296" text-anchor="middle" font-family="Geist Mono, monospace" font-size="9" fill="#d7b06a" letter-spacing="2">TEAM · PASSIVE</text>
+
+</svg>

--- a/assets/branding/mentolder/brett/props/prop-balance.svg
+++ b/assets/branding/mentolder/brett/props/prop-balance.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200" role="img" aria-label="Balance">
+  <defs>
+    <radialGradient id="pg" cx="50%" cy="45%" r="65%"><stop offset="0%" stop-color="#17202e"></stop><stop offset="100%" stop-color="#0b111c"></stop></radialGradient>
+    <filter id="pgrain"><feTurbulence type="fractalNoise" baseFrequency=".9" numOctaves="2" seed="5"></feTurbulence><feColorMatrix values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 .06 0"></feColorMatrix></filter>
+  </defs>
+  <rect width="200" height="200" fill="url(#pg)"></rect>
+  <rect width="200" height="200" filter="url(#pgrain)" opacity=".4"></rect>
+  <rect x="12" y="12" width="176" height="176" fill="none" stroke="#d7b06a" stroke-opacity=".22"></rect>
+  
+  <line x1="100" y1="30" x2="100" y2="148" stroke="#e7ead0" stroke-width="2"></line>
+  <line x1="36" y1="60" x2="164" y2="60" stroke="#d7b06a" stroke-width="2.5"></line>
+  <circle cx="100" cy="60" r="5" fill="#d7b06a"></circle>
+  <line x1="46" y1="60" x2="46" y2="86" stroke="#e7ead0" stroke-width="0.8" opacity=".7"></line>
+  <line x1="60" y1="60" x2="60" y2="86" stroke="#e7ead0" stroke-width="0.8" opacity=".7"></line>
+  <path d="M30 86 Q53 110 76 86 Z" fill="none" stroke="#e7ead0" stroke-width="2"></path>
+  <line x1="140" y1="60" x2="140" y2="92" stroke="#e7ead0" stroke-width="0.8" opacity=".7"></line>
+  <line x1="154" y1="60" x2="154" y2="92" stroke="#e7ead0" stroke-width="0.8" opacity=".7"></line>
+  <path d="M122 92 Q147 116 170 92 Z" fill="none" stroke="#e7ead0" stroke-width="2"></path>
+  <rect x="84" y="148" width="32" height="6" fill="#e7ead0"></rect>
+  <rect x="76" y="154" width="48" height="4" fill="#e7ead0"></rect>
+  <text x="100" y="180" text-anchor="middle" font-family="Geist Mono, monospace" font-size="8" fill="#d7b06a" letter-spacing="2">WAAGE · BALANCE</text>
+
+</svg>

--- a/assets/branding/mentolder/brett/props/prop-barrier.svg
+++ b/assets/branding/mentolder/brett/props/prop-barrier.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200" role="img" aria-label="Barrier">
+  <defs>
+    <radialGradient id="pg" cx="50%" cy="45%" r="65%"><stop offset="0%" stop-color="#17202e"></stop><stop offset="100%" stop-color="#0b111c"></stop></radialGradient>
+    <filter id="pgrain"><feTurbulence type="fractalNoise" baseFrequency=".9" numOctaves="2" seed="5"></feTurbulence><feColorMatrix values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 .06 0"></feColorMatrix></filter>
+  </defs>
+  <rect width="200" height="200" fill="url(#pg)"></rect>
+  <rect width="200" height="200" filter="url(#pgrain)" opacity=".4"></rect>
+  <rect x="12" y="12" width="176" height="176" fill="none" stroke="#d7b06a" stroke-opacity=".22"></rect>
+  
+  <g fill="#1d2736" stroke="#d7b06a" stroke-opacity=".4" stroke-width="0.8">
+    <rect x="34" y="42" width="44" height="22"></rect><rect x="78" y="42" width="48" height="22"></rect><rect x="126" y="42" width="40" height="22"></rect>
+    <rect x="34" y="64" width="32" height="22"></rect><rect x="66" y="64" width="50" height="22"></rect><rect x="116" y="64" width="50" height="22"></rect>
+    <rect x="34" y="86" width="48" height="22"></rect><rect x="82" y="86" width="46" height="22"></rect><rect x="128" y="86" width="38" height="22"></rect>
+    <rect x="34" y="108" width="40" height="22"></rect><rect x="74" y="108" width="44" height="22"></rect><rect x="118" y="108" width="48" height="22"></rect>
+    <rect x="34" y="130" width="50" height="22"></rect><rect x="84" y="130" width="38" height="22"></rect><rect x="122" y="130" width="44" height="22"></rect>
+  </g>
+  <path d="M82 42 L78 64 L86 86 L78 108 L84 130 L78 152" stroke="#0b111c" stroke-width="2" fill="none"></path>
+  <text x="100" y="172" text-anchor="middle" font-family="Geist Mono, monospace" font-size="8" fill="#d7b06a" letter-spacing="2">BLOCKADE</text>
+
+</svg>

--- a/assets/branding/mentolder/brett/props/prop-shield.svg
+++ b/assets/branding/mentolder/brett/props/prop-shield.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200" role="img" aria-label="Shield">
+  <defs>
+    <radialGradient id="pg" cx="50%" cy="45%" r="65%"><stop offset="0%" stop-color="#17202e"></stop><stop offset="100%" stop-color="#0b111c"></stop></radialGradient>
+    <filter id="pgrain"><feTurbulence type="fractalNoise" baseFrequency=".9" numOctaves="2" seed="5"></feTurbulence><feColorMatrix values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 .06 0"></feColorMatrix></filter>
+  </defs>
+  <rect width="200" height="200" fill="url(#pg)"></rect>
+  <rect width="200" height="200" filter="url(#pgrain)" opacity=".4"></rect>
+  <rect x="12" y="12" width="176" height="176" fill="none" stroke="#d7b06a" stroke-opacity=".22"></rect>
+  
+  <path d="M100 30 L150 44 L150 100 Q150 130 100 156 Q50 130 50 100 L50 44 Z" fill="#1d2736" stroke="#d7b06a" stroke-width="2"></path>
+  <path d="M68 76 L100 56 L132 76 L132 84 L100 64 L68 84 Z" fill="#d7b06a" opacity=".85"></path>
+  <circle cx="100" cy="108" r="6" fill="#d7b06a"></circle>
+  <path d="M82 122 L100 142 L118 122 Z" fill="none" stroke="#d7b06a" stroke-width="1.5"></path>
+  <text x="100" y="180" text-anchor="middle" font-family="Geist Mono, monospace" font-size="8" fill="#d7b06a" letter-spacing="2">SCHILD · GRENZE</text>
+
+</svg>

--- a/assets/branding/mentolder/brett/props/prop-target.svg
+++ b/assets/branding/mentolder/brett/props/prop-target.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200" role="img" aria-label="Target">
+  <defs>
+    <radialGradient id="pg" cx="50%" cy="45%" r="65%"><stop offset="0%" stop-color="#17202e"></stop><stop offset="100%" stop-color="#0b111c"></stop></radialGradient>
+    <filter id="pgrain"><feTurbulence type="fractalNoise" baseFrequency=".9" numOctaves="2" seed="5"></feTurbulence><feColorMatrix values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 .06 0"></feColorMatrix></filter>
+  </defs>
+  <rect width="200" height="200" fill="url(#pg)"></rect>
+  <rect width="200" height="200" filter="url(#pgrain)" opacity=".4"></rect>
+  <rect x="12" y="12" width="176" height="176" fill="none" stroke="#d7b06a" stroke-opacity=".22"></rect>
+  
+  <circle cx="100" cy="95" r="62" fill="none" stroke="#e7ead0" stroke-width="1.5" opacity=".55"></circle>
+  <circle cx="100" cy="95" r="48" fill="none" stroke="#e7ead0" stroke-width="1.5" opacity=".7"></circle>
+  <circle cx="100" cy="95" r="34" fill="none" stroke="#d7b06a" stroke-width="1.5"></circle>
+  <circle cx="100" cy="95" r="20" fill="none" stroke="#d7b06a" stroke-width="1.8"></circle>
+  <circle cx="100" cy="95" r="6" fill="#d7b06a"></circle>
+  <line x1="100" y1="20" x2="100" y2="38" stroke="#d7b06a" stroke-width="1" opacity=".7"></line>
+  <line x1="100" y1="152" x2="100" y2="170" stroke="#d7b06a" stroke-width="1" opacity=".7"></line>
+  <line x1="25" y1="95" x2="43" y2="95" stroke="#d7b06a" stroke-width="1" opacity=".7"></line>
+  <line x1="157" y1="95" x2="175" y2="95" stroke="#d7b06a" stroke-width="1" opacity=".7"></line>
+  <text x="100" y="186" text-anchor="middle" font-family="Geist Mono, monospace" font-size="8" fill="#d7b06a" letter-spacing="2">ZIELSCHEIBE</text>
+
+</svg>

--- a/assets/branding/mentolder/brett/terrain/focus-circle.svg
+++ b/assets/branding/mentolder/brett/terrain/focus-circle.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 480 240" width="480" height="240" role="img" aria-label="Focus circle terrain">
+  <defs>
+    <radialGradient id="fc1" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#f0d28c" stop-opacity="0.45"></stop>
+      <stop offset="30%" stop-color="#d7b06a" stop-opacity="0.22"></stop>
+      <stop offset="70%" stop-color="#101826" stop-opacity="0"></stop>
+    </radialGradient>
+  </defs>
+  <rect width="480" height="240" fill="#0b111c"></rect>
+  <circle cx="240" cy="120" r="220" fill="url(#fc1)"></circle>
+  <circle cx="240" cy="120" r="80" fill="none" stroke="#d7b06a" stroke-opacity=".55"></circle>
+  <circle cx="240" cy="120" r="120" fill="none" stroke="#d7b06a" stroke-opacity=".22"></circle>
+  <circle cx="240" cy="120" r="3" fill="#d7b06a"></circle>
+</svg>

--- a/assets/branding/mentolder/brett/terrain/fog-wash.svg
+++ b/assets/branding/mentolder/brett/terrain/fog-wash.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 480 240" width="480" height="240" role="img" aria-label="Fog wash terrain">
+  <defs>
+    <radialGradient id="fg1" cx="32%" cy="40%" r="58%"><stop offset="0%" stop-color="#cdd3d9" stop-opacity="0.85"></stop><stop offset="60%" stop-color="#8c96a3" stop-opacity="0.45"></stop><stop offset="100%" stop-color="#17202e" stop-opacity="0.85"></stop></radialGradient>
+    <radialGradient id="fg2" cx="78%" cy="65%" r="48%"><stop offset="0%" stop-color="#cdd3d9" stop-opacity="0.55"></stop><stop offset="100%" stop-color="#17202e" stop-opacity="0"></stop></radialGradient>
+    <filter id="softGrain"><feTurbulence type="fractalNoise" baseFrequency=".6" numOctaves="3" seed="2"></feTurbulence><feColorMatrix values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 .1 0"></feColorMatrix></filter>
+  </defs>
+  <rect width="480" height="240" fill="#101826"></rect>
+  <rect width="480" height="240" fill="url(#fg1)"></rect>
+  <rect width="480" height="240" fill="url(#fg2)"></rect>
+  <rect width="480" height="240" filter="url(#softGrain)" opacity=".5"></rect>
+  <path d="M0 120 Q120 100 240 130 T480 110" fill="none" stroke="#cdd3d9" stroke-width="0.6" opacity=".25"></path>
+  <path d="M0 160 Q140 150 280 168 T480 152" fill="none" stroke="#cdd3d9" stroke-width="0.6" opacity=".2"></path>
+</svg>

--- a/assets/branding/mentolder/identity/keycloak-bg-mentolder.svg
+++ b/assets/branding/mentolder/identity/keycloak-bg-mentolder.svg
@@ -1,0 +1,54 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1920 1080" width="1920" height="1080" role="img" aria-label="Mentolder Keycloak login background">
+  <defs>
+    <radialGradient id="halo-brass" cx="78%" cy="22%" r="55%">
+      <stop offset="0%" stop-color="#d7b06a" stop-opacity="0.16"></stop>
+      <stop offset="100%" stop-color="#d7b06a" stop-opacity="0"></stop>
+    </radialGradient>
+    <radialGradient id="halo-cool" cx="18%" cy="86%" r="60%">
+      <stop offset="0%" stop-color="#3a4a6e" stop-opacity="0.42"></stop>
+      <stop offset="100%" stop-color="#3a4a6e" stop-opacity="0"></stop>
+    </radialGradient>
+    <filter id="m-grain"><feTurbulence type="fractalNoise" baseFrequency="0.9" numOctaves="2" seed="3"></feTurbulence><feColorMatrix values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.05 0"></feColorMatrix></filter>
+  </defs>
+  <rect width="1920" height="1080" fill="#0b111c"></rect>
+  <rect width="1920" height="1080" fill="url(#halo-brass)"></rect>
+  <rect width="1920" height="1080" fill="url(#halo-cool)"></rect>
+  <rect width="1920" height="1080" filter="url(#m-grain)" opacity="0.55"></rect>
+
+  <rect x="80" y="80" width="1760" height="920" fill="none" stroke="#d7b06a" stroke-opacity="0.18"></rect>
+  <g stroke="#d7b06a" stroke-opacity="0.65" stroke-width="1" fill="none">
+    <path d="M80 110 L80 80 L110 80"></path>
+    <path d="M1840 110 L1840 80 L1810 80"></path>
+    <path d="M80 970 L80 1000 L110 1000"></path>
+    <path d="M1840 970 L1840 1000 L1810 1000"></path>
+  </g>
+
+  <g font-family="Geist Mono, monospace" font-size="13" letter-spacing="2.5">
+    <text x="110" y="138" fill="#d7b06a">— GK · ANNO 2026</text>
+    <text x="110" y="158" fill="#8c96a3">LÜNEBURG · DE · IDP</text>
+  </g>
+  <g font-family="Geist Mono, monospace" font-size="13" letter-spacing="2.5" text-anchor="end">
+    <text x="1810" y="138" fill="#d7b06a">KEYCLOAK · OIDC</text>
+    <text x="1810" y="158" fill="#8c96a3">IDENTITÄT &amp; HALTUNG</text>
+  </g>
+
+  <g transform="translate(960, 282)" text-anchor="middle">
+    <text font-family="Newsreader, serif" font-style="italic" font-weight="400" font-size="44" fill="#eef1f3">mentolder<tspan fill="#d7b06a">.</tspan></text>
+  </g>
+
+  <g transform="translate(960, 500)" text-anchor="middle" font-family="Newsreader, serif">
+    <text y="0" font-size="132" font-weight="350" fill="#eef1f3" letter-spacing="-3">Willkommen</text>
+    <text y="130" font-size="132" font-weight="350" font-style="italic" fill="#d7b06a" letter-spacing="-3">zurück.</text>
+  </g>
+
+  <g text-anchor="middle">
+    <line x1="900" y1="780" x2="1020" y2="780" stroke="#d7b06a" stroke-opacity="0.6"></line>
+    <text x="960" y="822" font-family="Geist, sans-serif" font-weight="300" font-size="20" fill="#cdd3d9">Bitte melden Sie sich an, um fortzufahren.</text>
+    <text x="960" y="852" font-family="Geist Mono, monospace" font-size="12" letter-spacing="2.5" fill="#8c96a3">— FORMULARFELDER WERDEN VON KEYCLOAK INJIZIERT —</text>
+  </g>
+
+  <g font-family="Geist Mono, monospace" font-size="11" letter-spacing="2.5" fill="#6a727e">
+    <text x="110" y="975">© 2026 MENTOLDER — ALLE RECHTE VORBEHALTEN</text>
+    <text x="1810" y="975" text-anchor="end">MENSCHEN · PROZESSE · TECHNIK · WIEDER VERBINDEN</text>
+  </g>
+</svg>

--- a/assets/branding/mentolder/identity/report-header-mentolder.svg
+++ b/assets/branding/mentolder/identity/report-header-mentolder.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1240 220" width="1240" height="220" role="img" aria-label="Mentolder letterhead">
+  <rect width="1240" height="220" fill="#f6f3ee"></rect>
+  <g transform="translate(80, 60)">
+    <rect width="56" height="56" rx="8" fill="#d7b06a"></rect>
+    <text x="28" y="42" text-anchor="middle" font-family="Newsreader, serif" font-style="italic" font-weight="600" font-size="38" fill="#1a2030">m</text>
+  </g>
+  <g transform="translate(160, 96)">
+    <text font-family="Newsreader, serif" font-style="italic" font-weight="500" font-size="32" fill="#1a2030">mentolder<tspan fill="#8a6a2a">.</tspan></text>
+    <text y="26" font-family="Geist Mono, monospace" font-size="11" letter-spacing="2.5" fill="#6a727e">DIGITAL COACHING · MENTORING · UNTERNEHMENSBERATUNG</text>
+  </g>
+  <g transform="translate(1160, 70)" text-anchor="end" font-family="Geist Mono, monospace" font-size="11" letter-spacing="2" fill="#6a727e">
+    <text>GERALD KORCZEWSKI</text>
+    <text y="22">LÜNEBURG · DE</text>
+    <text y="44">MENTOLDER.DE</text>
+  </g>
+  <line x1="80" y1="156" x2="1160" y2="156" stroke="#8a6a2a" stroke-opacity="0.55" stroke-width="0.6"></line>
+  <line x1="80" y1="158" x2="320" y2="158" stroke="#8a6a2a" stroke-width="0.6"></line>
+  <g transform="translate(80, 188)" font-family="Geist Mono, monospace" font-size="10" letter-spacing="2.5" fill="#8a6a2a">
+    <text>RECHNUNG · VERTRAG · REPORT · {{ DOC.TYPE }}</text>
+  </g>
+  <g transform="translate(1160, 188)" font-family="Geist Mono, monospace" font-size="10" letter-spacing="2.5" fill="#6a727e" text-anchor="end">
+    <text>{{ DOC.NUMBER }} · {{ DOC.DATE }}</text>
+  </g>
+</svg>

--- a/assets/branding/shared/identity/og-template-docs.svg
+++ b/assets/branding/shared/identity/og-template-docs.svg
@@ -1,0 +1,47 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630" role="img" aria-label="OG share card template — docs">
+  <defs>
+    <radialGradient id="og-brass" cx="85%" cy="15%" r="55%">
+      <stop offset="0%" stop-color="#d7b06a" stop-opacity="0.22"></stop>
+      <stop offset="100%" stop-color="#d7b06a" stop-opacity="0"></stop>
+    </radialGradient>
+    <radialGradient id="og-cool" cx="10%" cy="92%" r="55%">
+      <stop offset="0%" stop-color="#3a4a6e" stop-opacity="0.55"></stop>
+      <stop offset="100%" stop-color="#3a4a6e" stop-opacity="0"></stop>
+    </radialGradient>
+    <filter id="og-grain"><feTurbulence type="fractalNoise" baseFrequency="0.9" numOctaves="2" seed="5"></feTurbulence><feColorMatrix values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.05 0"></feColorMatrix></filter>
+  </defs>
+  <rect width="1200" height="630" fill="#0b111c"></rect>
+  <rect width="1200" height="630" fill="url(#og-brass)"></rect>
+  <rect width="1200" height="630" fill="url(#og-cool)"></rect>
+  <rect width="1200" height="630" filter="url(#og-grain)" opacity="0.5"></rect>
+
+  <rect x="40" y="40" width="1120" height="550" fill="none" stroke="#d7b06a" stroke-opacity="0.22"></rect>
+  <g stroke="#d7b06a" stroke-opacity="0.7" stroke-width="1" fill="none">
+    <path d="M40 60 L40 40 L60 40"></path>
+    <path d="M1160 60 L1160 40 L1140 40"></path>
+    <path d="M40 570 L40 590 L60 590"></path>
+    <path d="M1160 570 L1160 590 L1140 590"></path>
+  </g>
+
+  <g font-family="Geist Mono, monospace" font-size="13" letter-spacing="3">
+    <text x="72" y="90" fill="#d7b06a">— MENTOLDER · DOCS</text>
+    <text x="1128" y="90" fill="#8c96a3" text-anchor="end">{{ section.slug }}</text>
+  </g>
+
+  <g transform="translate(72, 230)">
+    <text font-family="Newsreader, serif" font-weight="350" font-size="72" letter-spacing="-1.8" fill="#eef1f3">{{ doc.title }}</text>
+    <text y="84" font-family="Newsreader, serif" font-weight="350" font-style="italic" font-size="72" letter-spacing="-1.8" fill="#d7b06a">— {{ doc.tagline }}</text>
+  </g>
+
+  <text x="72" y="430" font-family="Geist, sans-serif" font-weight="300" font-size="22" fill="#cdd3d9">{{ doc.lede }}</text>
+
+  <g transform="translate(72, 540)">
+    <rect x="0" y="-32" width="44" height="44" rx="6" fill="#d7b06a"></rect>
+    <text x="22" y="0" text-anchor="middle" font-family="Newsreader, serif" font-style="italic" font-weight="600" font-size="30" fill="#0b111c">m</text>
+    <text x="60" y="-6" font-family="Newsreader, serif" font-style="italic" font-weight="500" font-size="22" fill="#eef1f3">mentolder<tspan fill="#d7b06a">.</tspan></text>
+    <text x="60" y="14" font-family="Geist Mono, monospace" font-size="11" letter-spacing="2.5" fill="#8c96a3">{{ doc.author }} · {{ doc.date }}</text>
+  </g>
+  <g transform="translate(1128, 540)" text-anchor="end">
+    <text font-family="Geist Mono, monospace" font-size="11" letter-spacing="2.5" fill="#8c96a3">{{ doc.reading_time }} MIN · LESEN</text>
+  </g>
+</svg>

--- a/brett/public/assets/sfx/spec/audio-sfx-spec.md
+++ b/brett/public/assets/sfx/spec/audio-sfx-spec.md
@@ -1,0 +1,45 @@
+# Audio Spec · Asset Pack 02
+
+Cannot author binary .ogg files inline. The catalog renders this spec; sourcing
+is up to the implementer. All targets: **OGG Vorbis, mono, 44.1 kHz, -14 LUFS**.
+
+## Chat & Messaging
+| File | Duration | Tonality | Freesound tags |
+|------|----------|----------|----------------|
+| message-receive.ogg | 220 ms | Soft bubble-pop / wooden tonal drop, low presence | `bubble pop ui notification soft` |
+| message-send.ogg    | 180 ms | Paper-flick / brush swoosh, airy | `paper swipe whoosh ui send` |
+
+## Brett Collaboration
+| File | Duration | Tonality | Freesound tags |
+|------|----------|----------|----------------|
+| user-join.ogg     | 320 ms  | Single wood tap, warm decay | `wood knock soft tap warm` |
+| piece-place.ogg   | 200 ms  | Wood-on-wood click, very dry, no reverb | `wood click chess piece place` |
+| bell-gong.ogg     | 4-6 s   | Tibetan bell or singing bowl, long sustain | `tibetan bell gong meditation` |
+
+## Monitoring Alerts (Admin Portal)
+| File | Duration | Tonality | Freesound tags |
+|------|----------|----------|----------------|
+| node-degraded.ogg     | 600 ms | Low descending two-tone ping, -minor third | `alert ui warning low descending` |
+| reconcile-success.ogg | 350 ms | Brief upward 2-note chime, clean sine | `success chime ui ascending two notes` |
+
+## Arena Server (terrain coordinate audio)
+| File | Duration | Tonality | Freesound tags |
+|------|----------|----------|----------------|
+| footstep-grass.ogg | 180 ms | Soft brush, organic crunch | `footstep grass soft single` |
+| footstep-mud.ogg   | 220 ms | Wet squelch, low frequency | `footstep mud wet squelch` |
+
+## Sourcing
+- **Freesound.org** — CC0 / CC-BY tags only.
+- **Sonniss GameAudio GDC Bundle** — yearly free royalty-free pack.
+- Normalize loudness to -14 LUFS, dither to 16-bit, encode `oggenc -q 4`.
+
+## Integration (Howler.js)
+```js
+const sfx = {
+  msgRecv: new Howl({ src: ['/sfx/message-receive.ogg'], volume: 0.35 }),
+  msgSend: new Howl({ src: ['/sfx/message-send.ogg'], volume: 0.4 }),
+  gong:    new Howl({ src: ['/sfx/bell-gong.ogg'], volume: 0.55, sprite: { ring: [0, 5800] } }),
+};
+```
+
+Coordinate-audio mapping (arena): `PositionalAudio` w/ refDistance 6, rolloffFactor 1.8.

--- a/scripts/assets-sync.sh
+++ b/scripts/assets-sync.sh
@@ -16,4 +16,7 @@ echo "→ Syncing assets/branding/ → website/public/brand/"
 # No --delete: only a subset of brand files live in assets/branding/
 rsync -a assets/branding/ website/public/brand/
 
+echo "→ Syncing assets/arena/ → website/public/arena/"
+rsync -a assets/arena/ website/public/arena/
+
 echo "✓ assets:sync complete"

--- a/website/public/arena/hud-frame.svg
+++ b/website/public/arena/hud-frame.svg
@@ -1,0 +1,120 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1920 1080" width="1920" height="1080" role="img" aria-label="Arena HUD frame">
+  <defs>
+    <linearGradient id="hp-grad" x1="0" x2="1">
+      <stop offset="0%" stop-color="#C8F76A"></stop>
+      <stop offset="100%" stop-color="#7a8b4f"></stop>
+    </linearGradient>
+    <radialGradient id="hud-bg" cx="50%" cy="50%" r="70%">
+      <stop offset="0%" stop-color="#1a1428" stop-opacity="0.0"></stop>
+      <stop offset="80%" stop-color="#120D1C" stop-opacity="0.35"></stop>
+      <stop offset="100%" stop-color="#120D1C" stop-opacity="0.65"></stop>
+    </radialGradient>
+  </defs>
+
+  <rect width="1920" height="1080" fill="url(#hud-bg)"></rect>
+
+  <g stroke="#C8F76A" stroke-width="2" fill="none" stroke-opacity="0.95">
+    <path d="M30 90 L30 30 L90 30"></path>
+    <path d="M1890 90 L1890 30 L1830 30"></path>
+    <path d="M30 990 L30 1050 L90 1050"></path>
+    <path d="M1890 990 L1890 1050 L1830 1050"></path>
+  </g>
+  <g stroke="#C8F76A" stroke-width="1" fill="none" stroke-opacity="0.4">
+    <path d="M60 30 L1860 30"></path>
+    <path d="M60 1050 L1860 1050"></path>
+    <path d="M30 90 L30 990"></path>
+    <path d="M1890 90 L1890 990"></path>
+  </g>
+
+  <g stroke="#C8F76A" stroke-width="1.5" fill="none">
+    <circle cx="960" cy="540" r="16" opacity="0.7"></circle>
+    <line x1="960" y1="514" x2="960" y2="528" opacity="0.9"></line>
+    <line x1="960" y1="552" x2="960" y2="566" opacity="0.9"></line>
+    <line x1="934" y1="540" x2="948" y2="540" opacity="0.9"></line>
+    <line x1="972" y1="540" x2="986" y2="540" opacity="0.9"></line>
+    <circle cx="960" cy="540" r="2" fill="#C8F76A"></circle>
+  </g>
+
+  <g transform="translate(70, 100)">
+    <rect width="340" height="62" fill="#120D1C" fill-opacity="0.78" stroke="#C8F76A" stroke-opacity="0.45"></rect>
+    <circle cx="34" cy="31" r="14" fill="none" stroke="#C8F76A" stroke-opacity="0.6"></circle>
+    <text x="34" y="36" text-anchor="middle" font-family="Geist Mono, monospace" font-size="13" fill="#C8F76A">k</text>
+    <text x="64" y="24" font-family="Geist Mono, monospace" font-size="10" letter-spacing="2.5" fill="#7a8b4f">PLAYER · 01</text>
+    <text x="64" y="48" font-family="Geist, sans-serif" font-weight="600" font-size="20" fill="#eef1f3">korczewski</text>
+    <circle cx="316" cy="31" r="5" fill="#C8F76A"></circle>
+  </g>
+
+  <g transform="translate(70, 188)">
+    <text x="0" y="-6" font-family="Geist Mono, monospace" font-size="10" letter-spacing="2.5" fill="#7a8b4f">HP</text>
+    <rect width="340" height="14" fill="#120D1C" fill-opacity="0.78" stroke="#C8F76A" stroke-opacity="0.35"></rect>
+    <rect x="2" y="2" width="254" height="10" fill="url(#hp-grad)"></rect>
+    <text x="350" y="11" font-family="Geist Mono, monospace" font-size="12" letter-spacing="1.5" fill="#C8F76A">75 / 100</text>
+  </g>
+
+  <g transform="translate(70, 230)">
+    <text x="0" y="-6" font-family="Geist Mono, monospace" font-size="10" letter-spacing="2.5" fill="#7a8b4f">SHIELD</text>
+    <rect width="340" height="10" fill="#120D1C" fill-opacity="0.78" stroke="#5fb8c8" stroke-opacity="0.45"></rect>
+    <rect x="2" y="2" width="200" height="6" fill="#5fb8c8" opacity="0.9"></rect>
+    <text x="350" y="9" font-family="Geist Mono, monospace" font-size="11" letter-spacing="1.5" fill="#5fb8c8">60 / 100</text>
+  </g>
+
+  <g transform="translate(1370, 100)">
+    <rect width="480" height="62" fill="#120D1C" fill-opacity="0.78" stroke="#C8F76A" stroke-opacity="0.45"></rect>
+    <text x="22" y="22" font-family="Geist Mono, monospace" font-size="10" letter-spacing="2.5" fill="#7a8b4f">ROUND · 03 / 10</text>
+    <text x="22" y="50" font-family="Geist Mono, monospace" font-weight="500" font-size="26" letter-spacing="3" fill="#C8F76A">04:32</text>
+    <line x1="170" y1="14" x2="170" y2="48" stroke="#C8F76A" stroke-opacity="0.25"></line>
+    <text x="195" y="22" font-family="Geist Mono, monospace" font-size="10" letter-spacing="2.5" fill="#7a8b4f">SCORE</text>
+    <text x="195" y="50" font-family="Geist Mono, monospace" font-weight="500" font-size="26" letter-spacing="2" fill="#eef1f3">12<tspan fill="#7a8b4f"> : </tspan><tspan fill="#cdd3d9">09</tspan></text>
+    <line x1="350" y1="14" x2="350" y2="48" stroke="#C8F76A" stroke-opacity="0.25"></line>
+    <text x="375" y="22" font-family="Geist Mono, monospace" font-size="10" letter-spacing="2.5" fill="#7a8b4f">PING</text>
+    <text x="375" y="50" font-family="Geist Mono, monospace" font-weight="500" font-size="22" fill="#C8F76A">42<tspan fill="#7a8b4f">ms</tspan></text>
+  </g>
+
+  <g transform="translate(1620, 188)">
+    <rect width="230" height="230" fill="#120D1C" fill-opacity="0.78" stroke="#C8F76A" stroke-opacity="0.4"></rect>
+    <g stroke="#C8F76A" stroke-opacity="0.13" stroke-width="0.5">
+      <line x1="0" y1="46" x2="230" y2="46"></line>
+      <line x1="0" y1="92" x2="230" y2="92"></line>
+      <line x1="0" y1="138" x2="230" y2="138"></line>
+      <line x1="0" y1="184" x2="230" y2="184"></line>
+      <line x1="46" y1="0" x2="46" y2="230"></line>
+      <line x1="92" y1="0" x2="92" y2="230"></line>
+      <line x1="138" y1="0" x2="138" y2="230"></line>
+      <line x1="184" y1="0" x2="184" y2="230"></line>
+    </g>
+    <g fill="#C8F76A" fill-opacity="0.08" stroke="#C8F76A" stroke-opacity="0.45">
+      <rect x="36" y="40" width="64" height="48"></rect>
+      <rect x="130" y="58" width="68" height="40"></rect>
+      <rect x="60" y="128" width="100" height="58"></rect>
+      <rect x="170" y="140" width="36" height="48"></rect>
+    </g>
+    <circle cx="118" cy="115" r="5" fill="#C8F76A"></circle>
+    <circle cx="118" cy="115" r="11" fill="none" stroke="#C8F76A" stroke-opacity="0.55"></circle>
+    <circle cx="178" cy="80" r="3.5" fill="#d77a6e"></circle>
+    <circle cx="80" cy="160" r="3.5" fill="#d77a6e"></circle>
+    <circle cx="190" cy="170" r="3.5" fill="#d77a6e"></circle>
+    <text x="8" y="14" font-family="Geist Mono, monospace" font-size="9" letter-spacing="2" fill="#7a8b4f">MAP · ARENA</text>
+    <text x="222" y="14" text-anchor="end" font-family="Geist Mono, monospace" font-size="9" letter-spacing="2" fill="#C8F76A">3 ◊</text>
+  </g>
+
+  <g transform="translate(70, 880)" font-family="Geist Mono, monospace" font-size="13" letter-spacing="1.5">
+    <text x="0" y="0" font-size="10" letter-spacing="2.5" fill="#7a8b4f">KILL FEED · LIVE</text>
+    <text x="0" y="26"><tspan fill="#eef1f3">[01] korczewski</tspan><tspan fill="#7a8b4f"> » </tspan><tspan fill="#cdd3d9">guest_07</tspan><tspan fill="#7a8b4f">  · rifle</tspan></text>
+    <text x="0" y="48"><tspan fill="#eef1f3">[02] korczewski</tspan><tspan fill="#7a8b4f"> » </tspan><tspan fill="#cdd3d9">guest_03</tspan><tspan fill="#7a8b4f">  · katana</tspan></text>
+    <text x="0" y="70"><tspan fill="#cdd3d9">guest_04</tspan><tspan fill="#7a8b4f"> » </tspan><tspan fill="#cdd3d9">guest_11</tspan><tspan fill="#7a8b4f">  · fireball</tspan></text>
+  </g>
+
+  <g transform="translate(1580, 880)">
+    <rect width="270" height="100" fill="#120D1C" fill-opacity="0.78" stroke="#C8F76A" stroke-opacity="0.45"></rect>
+    <text x="20" y="26" font-family="Geist Mono, monospace" font-size="10" letter-spacing="2.5" fill="#7a8b4f">WEAPON · 02</text>
+    <text x="20" y="62" font-family="Geist, sans-serif" font-weight="600" font-size="22" fill="#eef1f3">Rifle</text>
+    <text x="250" y="62" text-anchor="end" font-family="Geist Mono, monospace" font-weight="500" font-size="26" fill="#C8F76A">24 / 90</text>
+    <g transform="translate(20, 76)" font-family="Geist Mono, monospace" font-size="10" letter-spacing="1.5" fill="#7a8b4f">
+      <text>[1] handgun  [2] rifle  [3] fireball  [4] club  [5] katana</text>
+    </g>
+  </g>
+
+  <g transform="translate(960, 1030)" text-anchor="middle">
+    <text font-family="Geist Mono, monospace" font-size="10" letter-spacing="3.5" fill="#7a8b4f">ARENA-WS.KORCZEWSKI.DE · WSS · COORDINATE-AUDIO ENABLED</text>
+  </g>
+</svg>

--- a/website/public/arena/pickup-shield.svg
+++ b/website/public/arena/pickup-shield.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" width="256" height="256" role="img" aria-label="Pickup · shield">
+  <defs>
+    <radialGradient id="psh-glow" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#5fb8c8" stop-opacity="0.42"></stop>
+      <stop offset="100%" stop-color="#5fb8c8" stop-opacity="0"></stop>
+    </radialGradient>
+    <linearGradient id="psh-body" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#1f2a3a"></stop>
+      <stop offset="100%" stop-color="#120D1C"></stop>
+    </linearGradient>
+  </defs>
+  <rect width="256" height="256" fill="url(#psh-glow)"></rect>
+  <path d="M128 32 L212 62 L212 122 Q212 188 128 226 Q44 188 44 122 L44 62 Z" fill="url(#psh-body)" stroke="#5fb8c8" stroke-width="3"></path>
+  <path d="M128 56 L192 80 L192 124 Q192 174 128 204 Q64 174 64 124 L64 80 Z" fill="none" stroke="#5fb8c8" stroke-opacity="0.5" stroke-width="1.5"></path>
+  <g stroke="#C8F76A" stroke-width="7" stroke-linecap="round" fill="none">
+    <path d="M128 96 L128 158"></path>
+    <path d="M102 127 L154 127"></path>
+  </g>
+  <text x="128" y="246" text-anchor="middle" font-family="Geist Mono, monospace" font-size="11" letter-spacing="3" fill="#5fb8c8">SHIELD · +50</text>
+</svg>

--- a/website/public/arena/pickup-speed.svg
+++ b/website/public/arena/pickup-speed.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" width="256" height="256" role="img" aria-label="Pickup · speed">
+  <defs>
+    <radialGradient id="pspd-glow" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#C8F76A" stop-opacity="0.55"></stop>
+      <stop offset="100%" stop-color="#C8F76A" stop-opacity="0"></stop>
+    </radialGradient>
+  </defs>
+  <rect width="256" height="256" fill="url(#pspd-glow)"></rect>
+  <polygon points="128,28 220,80 220,176 128,228 36,176 36,80" fill="#120D1C" stroke="#C8F76A" stroke-width="3"></polygon>
+  <polygon points="128,52 200,92 200,164 128,204 56,164 56,92" fill="none" stroke="#C8F76A" stroke-opacity="0.5" stroke-width="1.5"></polygon>
+  <path d="M142 68 L96 138 L122 138 L108 192 L162 116 L132 116 Z" fill="#C8F76A" stroke="#fff5c8" stroke-width="1.5" stroke-linejoin="round"></path>
+  <g stroke="#C8F76A" stroke-opacity="0.65" stroke-width="2" stroke-linecap="round">
+    <line x1="58" y1="100" x2="80" y2="100"></line>
+    <line x1="58" y1="120" x2="74" y2="120"></line>
+    <line x1="58" y1="140" x2="80" y2="140"></line>
+  </g>
+  <text x="128" y="246" text-anchor="middle" font-family="Geist Mono, monospace" font-size="11" letter-spacing="3" fill="#C8F76A">SPEED · +30%</text>
+</svg>

--- a/website/public/brand/korczewski/brett/characters/product-owner.svg
+++ b/website/public/brand/korczewski/brett/characters/product-owner.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 320" width="240" height="320" role="img" aria-label="Product owner">
+  <defs>
+    <radialGradient id="gk" cx="50%" cy="40%" r="65%"><stop offset="0%" stop-color="#1c1428"></stop><stop offset="100%" stop-color="#120D1C"></stop></radialGradient>
+    <filter id="grainK"><feTurbulence type="fractalNoise" baseFrequency="1.1" numOctaves="2" seed="7"></feTurbulence><feColorMatrix values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 .07 0"></feColorMatrix></filter>
+  </defs>
+  <rect x="0" y="0" width="240" height="320" fill="url(#gk)"></rect>
+  <rect x="0" y="0" width="240" height="320" filter="url(#grainK)" opacity=".6"></rect>
+  <rect x="14" y="14" width="212" height="292" fill="none" stroke="#7a8b4f" stroke-opacity=".35"></rect>
+  <g stroke="#C8F76A" stroke-opacity=".55" stroke-width="1" fill="none">
+    <path d="M14 24 L14 14 L24 14"></path><path d="M226 24 L226 14 L216 14"></path>
+    <path d="M14 296 L14 306 L24 306"></path><path d="M226 296 L226 306 L216 306"></path>
+  </g>
+  
+  <g fill="#4c4d5b">
+    <ellipse cx="118" cy="74" rx="18" ry="22"></ellipse>
+    <path d="M84 108 Q88 96 106 96 L132 96 Q150 96 156 108 L160 200 L80 200 Z"></path>
+    <path d="M80 130 L62 188 L84 200 L98 158 Z"></path>
+    <path d="M160 130 L178 188 L156 200 L142 158 Z"></path>
+    <rect x="94" y="200" width="20" height="70" rx="4"></rect>
+    <rect x="126" y="200" width="20" height="70" rx="4"></rect>
+  </g>
+  <rect x="62" y="156" width="116" height="56" fill="#1c1428" stroke="#7a8b4f" stroke-width="1"></rect>
+  <g stroke="#7a8b4f" stroke-width="0.4" opacity=".7">
+    <line x1="72" y1="156" x2="72" y2="212"></line><line x1="92" y1="156" x2="92" y2="212"></line>
+    <line x1="112" y1="156" x2="112" y2="212"></line><line x1="132" y1="156" x2="132" y2="212"></line>
+    <line x1="152" y1="156" x2="152" y2="212"></line><line x1="168" y1="156" x2="168" y2="212"></line>
+    <line x1="62" y1="170" x2="178" y2="170"></line><line x1="62" y1="184" x2="178" y2="184"></line>
+    <line x1="62" y1="198" x2="178" y2="198"></line>
+  </g>
+  <rect x="78" y="174" width="40" height="20" fill="none" stroke="#C8F76A" stroke-width="1.2"></rect>
+  <line x1="124" y1="178" x2="166" y2="178" stroke="#C8F76A" stroke-width="1" opacity=".85"></line>
+  <line x1="124" y1="186" x2="158" y2="186" stroke="#C8F76A" stroke-width="1" opacity=".55"></line>
+  <text x="120" y="296" text-anchor="middle" font-family="Geist Mono, monospace" font-size="9" fill="#7a8b4f" letter-spacing="2">PRODUCT · OWNER</text>
+
+</svg>

--- a/website/public/brand/korczewski/brett/characters/security-officer.svg
+++ b/website/public/brand/korczewski/brett/characters/security-officer.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 320" width="240" height="320" role="img" aria-label="Security officer">
+  <defs>
+    <radialGradient id="gk" cx="50%" cy="40%" r="65%"><stop offset="0%" stop-color="#1c1428"></stop><stop offset="100%" stop-color="#120D1C"></stop></radialGradient>
+    <filter id="grainK"><feTurbulence type="fractalNoise" baseFrequency="1.1" numOctaves="2" seed="7"></feTurbulence><feColorMatrix values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 .07 0"></feColorMatrix></filter>
+  </defs>
+  <rect x="0" y="0" width="240" height="320" fill="url(#gk)"></rect>
+  <rect x="0" y="0" width="240" height="320" filter="url(#grainK)" opacity=".6"></rect>
+  <rect x="14" y="14" width="212" height="292" fill="none" stroke="#7a8b4f" stroke-opacity=".35"></rect>
+  <g stroke="#C8F76A" stroke-opacity=".55" stroke-width="1" fill="none">
+    <path d="M14 24 L14 14 L24 14"></path><path d="M226 24 L226 14 L216 14"></path>
+    <path d="M14 296 L14 306 L24 306"></path><path d="M226 296 L226 306 L216 306"></path>
+  </g>
+  
+  <g fill="#5d5e6c">
+    <path d="M88 74 Q120 50 152 74 L156 116 L84 116 Z"></path>
+    <rect x="92" y="98" width="56" height="6" fill="#120D1C"></rect>
+    <line x1="92" y1="101" x2="148" y2="101" stroke="#C8F76A" stroke-width="0.6" opacity=".95"></line>
+    <path d="M78 122 L82 200 L120 220 L158 200 L162 122 Z"></path>
+    <path d="M64 130 Q60 152 70 174 L82 168 L82 130 Z"></path>
+    <path d="M176 130 Q180 152 170 174 L158 168 L158 130 Z"></path>
+    <rect x="92" y="222" width="22" height="56" rx="3"></rect>
+    <rect x="126" y="222" width="22" height="56" rx="3"></rect>
+  </g>
+  <path d="M120 142 L94 152 L94 198 Q94 212 120 222 Q146 212 146 198 L146 152 Z" fill="#1c1428" stroke="#7a8b4f" stroke-width="1.2"></path>
+  <circle cx="120" cy="178" r="10" fill="none" stroke="#C8F76A" stroke-width="1.5"></circle>
+  <rect x="118" y="186" width="4" height="14" fill="#C8F76A"></rect>
+  <rect x="116" y="194" width="8" height="2" fill="#C8F76A"></rect>
+  <rect x="116" y="198" width="6" height="2" fill="#C8F76A"></rect>
+  <text x="120" y="296" text-anchor="middle" font-family="Geist Mono, monospace" font-size="9" fill="#7a8b4f" letter-spacing="2">SEC · KEYCLOAK</text>
+
+</svg>

--- a/website/public/brand/korczewski/brett/characters/sysadmin.svg
+++ b/website/public/brand/korczewski/brett/characters/sysadmin.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 320" width="240" height="320" role="img" aria-label="Sysadmin">
+  <defs>
+    <radialGradient id="gk" cx="50%" cy="40%" r="65%"><stop offset="0%" stop-color="#1c1428"></stop><stop offset="100%" stop-color="#120D1C"></stop></radialGradient>
+    <filter id="grainK"><feTurbulence type="fractalNoise" baseFrequency="1.1" numOctaves="2" seed="7"></feTurbulence><feColorMatrix values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 .07 0"></feColorMatrix></filter>
+  </defs>
+  <rect x="0" y="0" width="240" height="320" fill="url(#gk)"></rect>
+  <rect x="0" y="0" width="240" height="320" filter="url(#grainK)" opacity=".6"></rect>
+  <rect x="14" y="14" width="212" height="292" fill="none" stroke="#7a8b4f" stroke-opacity=".35"></rect>
+  <g stroke="#C8F76A" stroke-opacity=".55" stroke-width="1" fill="none">
+    <path d="M14 24 L14 14 L24 14"></path><path d="M226 24 L226 14 L216 14"></path>
+    <path d="M14 296 L14 306 L24 306"></path><path d="M226 296 L226 306 L216 306"></path>
+  </g>
+  
+  <g fill="#4c4d5b">
+    <path d="M82 84 Q120 44 158 84 L166 138 Q160 146 152 144 L88 144 Q80 146 74 138 Z"></path>
+    <path d="M74 144 L66 280 L174 280 L166 144 Z"></path>
+    <path d="M84 168 L72 222 L96 232 L110 200 Z"></path>
+    <path d="M156 168 L168 222 L144 232 L130 200 Z"></path>
+  </g>
+  <ellipse cx="120" cy="108" rx="24" ry="20" fill="#120D1C"></ellipse>
+  <rect x="100" y="106" width="14" height="6" rx="1.5" fill="#2a1f3a" stroke="#7a8b4f" stroke-width="0.8"></rect>
+  <rect x="126" y="106" width="14" height="6" rx="1.5" fill="#2a1f3a" stroke="#7a8b4f" stroke-width="0.8"></rect>
+  <line x1="114" y1="109" x2="126" y2="109" stroke="#7a8b4f" stroke-width="0.8"></line>
+  <circle cx="107" cy="109" r="1.4" fill="#C8F76A" opacity=".9"></circle>
+  <circle cx="133" cy="109" r="1.4" fill="#C8F76A" opacity=".9"></circle>
+  <rect x="92" y="208" width="56" height="32" rx="2" fill="#2a1f3a" stroke="#7a8b4f" stroke-width="0.8"></rect>
+  <rect x="96" y="212" width="48" height="22" fill="#120D1C"></rect>
+  <line x1="100" y1="218" x2="120" y2="218" stroke="#C8F76A" stroke-width="0.6" opacity=".9"></line>
+  <line x1="100" y1="222" x2="138" y2="222" stroke="#7a8b4f" stroke-width="0.6"></line>
+  <line x1="100" y1="226" x2="130" y2="226" stroke="#7a8b4f" stroke-width="0.6"></line>
+  <text x="120" y="296" text-anchor="middle" font-family="Geist Mono, monospace" font-size="9" fill="#7a8b4f" letter-spacing="2">SYSADMIN · OPERATOR</text>
+
+</svg>

--- a/website/public/brand/korczewski/brett/props/prop-alert.svg
+++ b/website/public/brand/korczewski/brett/props/prop-alert.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200" role="img" aria-label="Alert">
+  <defs>
+    <radialGradient id="pgk" cx="50%" cy="45%" r="65%"><stop offset="0%" stop-color="#1c1428"></stop><stop offset="100%" stop-color="#120D1C"></stop></radialGradient>
+    <filter id="pgrainK"><feTurbulence type="fractalNoise" baseFrequency="1.0" numOctaves="2" seed="9"></feTurbulence><feColorMatrix values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 .07 0"></feColorMatrix></filter>
+  </defs>
+  <rect width="200" height="200" fill="url(#pgk)"></rect>
+  <rect width="200" height="200" filter="url(#pgrainK)" opacity=".5"></rect>
+  <rect x="12" y="12" width="176" height="176" fill="none" stroke="#7a8b4f" stroke-opacity=".35"></rect>
+  
+  <path d="M100 32 L168 148 L32 148 Z" fill="#2a1f3a" stroke="#C8F76A" stroke-width="2"></path>
+  <path d="M100 50 L156 144 L44 144 Z" fill="none" stroke="#7a8b4f" stroke-width="0.6" stroke-dasharray="3 2" opacity=".6"></path>
+  <rect x="96" y="68" width="8" height="48" fill="#C8F76A"></rect>
+  <rect x="96" y="124" width="8" height="8" fill="#C8F76A"></rect>
+  <text x="100" y="180" text-anchor="middle" font-family="Geist Mono, monospace" font-size="8" fill="#7a8b4f" letter-spacing="2">ALERT · NODE FAIL</text>
+
+</svg>

--- a/website/public/brand/korczewski/brett/props/prop-database.svg
+++ b/website/public/brand/korczewski/brett/props/prop-database.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200" role="img" aria-label="Database">
+  <defs>
+    <radialGradient id="pgk" cx="50%" cy="45%" r="65%"><stop offset="0%" stop-color="#1c1428"></stop><stop offset="100%" stop-color="#120D1C"></stop></radialGradient>
+    <filter id="pgrainK"><feTurbulence type="fractalNoise" baseFrequency="1.0" numOctaves="2" seed="9"></feTurbulence><feColorMatrix values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 .07 0"></feColorMatrix></filter>
+  </defs>
+  <rect width="200" height="200" fill="url(#pgk)"></rect>
+  <rect width="200" height="200" filter="url(#pgrainK)" opacity=".5"></rect>
+  <rect x="12" y="12" width="176" height="176" fill="none" stroke="#7a8b4f" stroke-opacity=".35"></rect>
+  
+  <g fill="#4c4d5b" stroke="#7a8b4f" stroke-width="1.2">
+    <ellipse cx="100" cy="48" rx="42" ry="12"></ellipse>
+    <path d="M58 48 L58 142 Q58 154 100 154 Q142 154 142 142 L142 48"></path>
+    <ellipse cx="100" cy="48" rx="42" ry="12" fill="#2a1f3a"></ellipse>
+  </g>
+  <ellipse cx="100" cy="80" rx="42" ry="12" fill="none" stroke="#7a8b4f" stroke-width="0.8" opacity=".7"></ellipse>
+  <ellipse cx="100" cy="112" rx="42" ry="12" fill="none" stroke="#7a8b4f" stroke-width="0.8" opacity=".7"></ellipse>
+  <circle cx="100" cy="48" r="3" fill="#C8F76A"></circle>
+  <text x="100" y="180" text-anchor="middle" font-family="Geist Mono, monospace" font-size="8" fill="#7a8b4f" letter-spacing="2">PV · DATABASE</text>
+
+</svg>

--- a/website/public/brand/korczewski/brett/props/prop-firewall.svg
+++ b/website/public/brand/korczewski/brett/props/prop-firewall.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200" role="img" aria-label="Firewall">
+  <defs>
+    <radialGradient id="pgk" cx="50%" cy="45%" r="65%"><stop offset="0%" stop-color="#1c1428"></stop><stop offset="100%" stop-color="#120D1C"></stop></radialGradient>
+    <filter id="pgrainK"><feTurbulence type="fractalNoise" baseFrequency="1.0" numOctaves="2" seed="9"></feTurbulence><feColorMatrix values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 .07 0"></feColorMatrix></filter>
+  </defs>
+  <rect width="200" height="200" fill="url(#pgk)"></rect>
+  <rect width="200" height="200" filter="url(#pgrainK)" opacity=".5"></rect>
+  <rect x="12" y="12" width="176" height="176" fill="none" stroke="#7a8b4f" stroke-opacity=".35"></rect>
+  
+  <g fill="#4c4d5b" stroke="#7a8b4f" stroke-width="0.8">
+    <rect x="46" y="44" width="14" height="110"></rect>
+    <rect x="140" y="44" width="14" height="110"></rect>
+    <rect x="46" y="38" width="108" height="14"></rect>
+    <line x1="74" y1="60" x2="74" y2="148" stroke-width="2"></line>
+    <line x1="90" y1="60" x2="90" y2="148" stroke-width="2"></line>
+    <line x1="110" y1="60" x2="110" y2="148" stroke-width="2"></line>
+    <line x1="126" y1="60" x2="126" y2="148" stroke-width="2"></line>
+  </g>
+  <path d="M26 100 L66 100" stroke="#C8F76A" stroke-width="2" stroke-dasharray="4 3"></path>
+  <circle cx="100" cy="100" r="4" fill="#C8F76A"></circle>
+  <text x="100" y="180" text-anchor="middle" font-family="Geist Mono, monospace" font-size="8" fill="#7a8b4f" letter-spacing="2">TRAEFIK · FIREWALL</text>
+
+</svg>

--- a/website/public/brand/korczewski/brett/props/prop-pipeline.svg
+++ b/website/public/brand/korczewski/brett/props/prop-pipeline.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200" role="img" aria-label="Pipeline">
+  <defs>
+    <radialGradient id="pgk" cx="50%" cy="45%" r="65%"><stop offset="0%" stop-color="#1c1428"></stop><stop offset="100%" stop-color="#120D1C"></stop></radialGradient>
+    <filter id="pgrainK"><feTurbulence type="fractalNoise" baseFrequency="1.0" numOctaves="2" seed="9"></feTurbulence><feColorMatrix values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 .07 0"></feColorMatrix></filter>
+  </defs>
+  <rect width="200" height="200" fill="url(#pgk)"></rect>
+  <rect width="200" height="200" filter="url(#pgrainK)" opacity=".5"></rect>
+  <rect x="12" y="12" width="176" height="176" fill="none" stroke="#7a8b4f" stroke-opacity=".35"></rect>
+  
+  <g fill="#4c4d5b" stroke="#7a8b4f" stroke-width="1">
+    <g transform="translate(72 80)">
+      <g>
+        <rect x="-3" y="-36" width="6" height="10"></rect><rect x="-3" y="26" width="6" height="10"></rect>
+        <rect x="-36" y="-3" width="10" height="6"></rect><rect x="26" y="-3" width="10" height="6"></rect>
+        <rect x="-26" y="-26" width="6" height="10" transform="rotate(45 -23 -21)"></rect>
+        <rect x="20" y="-26" width="6" height="10" transform="rotate(-45 23 -21)"></rect>
+        <rect x="-26" y="16" width="6" height="10" transform="rotate(-45 -23 21)"></rect>
+        <rect x="20" y="16" width="6" height="10" transform="rotate(45 23 21)"></rect>
+      </g>
+      <circle cx="0" cy="0" r="26"></circle>
+      <circle cx="0" cy="0" r="8" fill="#2a1f3a"></circle>
+    </g>
+    <g transform="translate(132 110)">
+      <g>
+        <rect x="-3" y="-30" width="6" height="9"></rect><rect x="-3" y="21" width="6" height="9"></rect>
+        <rect x="-30" y="-3" width="9" height="6"></rect><rect x="21" y="-3" width="9" height="6"></rect>
+      </g>
+      <circle cx="0" cy="0" r="22"></circle>
+      <circle cx="0" cy="0" r="6" fill="#2a1f3a"></circle>
+    </g>
+  </g>
+  <path d="M40 150 L160 150" stroke="#C8F76A" stroke-width="1.5"></path>
+  <path d="M160 150 L154 146 M160 150 L154 154" stroke="#C8F76A" stroke-width="1.5" fill="none"></path>
+  <text x="100" y="180" text-anchor="middle" font-family="Geist Mono, monospace" font-size="8" fill="#7a8b4f" letter-spacing="2">CI · CD · PIPELINE</text>
+
+</svg>

--- a/website/public/brand/korczewski/brett/terrain/namespace-boundary.svg
+++ b/website/public/brand/korczewski/brett/terrain/namespace-boundary.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 480 240" width="480" height="240" role="img" aria-label="Namespace boundary">
+  <rect width="480" height="240" fill="#120D1C"></rect>
+  <rect x="14" y="14" width="220" height="212" fill="#1c1428" stroke="#7a8b4f" stroke-width="1" stroke-dasharray="6 4"></rect>
+  <text x="26" y="34" font-family="Geist Mono, monospace" font-size="9" fill="#C8F76A" letter-spacing="2">NS · WORKSPACE</text>
+  <rect x="246" y="14" width="220" height="212" fill="#1c1428" stroke="#7a8b4f" stroke-width="1" stroke-dasharray="6 4"></rect>
+  <text x="258" y="34" font-family="Geist Mono, monospace" font-size="9" fill="#C8F76A" letter-spacing="2">NS · WEBSITE</text>
+  <path d="M196 120 L284 120" stroke="#C8F76A" stroke-width="1.5" stroke-dasharray="3 3"></path>
+  <path d="M284 120 L278 116 M284 120 L278 124" stroke="#C8F76A" stroke-width="1.5" fill="none"></path>
+  <g fill="#4c4d5b" stroke="#7a8b4f" stroke-width="0.6">
+    <rect x="40" y="80" width="60" height="40" rx="2"></rect><rect x="118" y="80" width="60" height="40" rx="2"></rect>
+    <rect x="40" y="138" width="60" height="40" rx="2"></rect><rect x="118" y="138" width="60" height="40" rx="2"></rect>
+    <rect x="296" y="80" width="80" height="40" rx="2"></rect><rect x="296" y="138" width="80" height="40" rx="2"></rect>
+  </g>
+</svg>

--- a/website/public/brand/korczewski/brett/terrain/subnet-grid.svg
+++ b/website/public/brand/korczewski/brett/terrain/subnet-grid.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 480 240" width="480" height="240" role="img" aria-label="Subnet grid">
+  <defs>
+    <pattern id="sg" width="24" height="24" patternUnits="userSpaceOnUse"><rect width="24" height="24" fill="#120D1C"></rect><path d="M24 0 L0 0 0 24" fill="none" stroke="#7a8b4f" stroke-opacity=".35" stroke-width="0.5"></path></pattern>
+    <pattern id="sgBig" width="120" height="120" patternUnits="userSpaceOnUse"><path d="M120 0 L0 0 0 120" fill="none" stroke="#C8F76A" stroke-opacity=".25" stroke-width="0.7"></path></pattern>
+  </defs>
+  <rect width="480" height="240" fill="url(#sg)"></rect>
+  <rect width="480" height="240" fill="url(#sgBig)"></rect>
+  <g fill="#C8F76A"><circle cx="120" cy="120" r="2"></circle><circle cx="240" cy="120" r="2"></circle><circle cx="360" cy="120" r="2"></circle><circle cx="60" cy="60" r="1.5" opacity=".7"></circle><circle cx="420" cy="180" r="1.5" opacity=".7"></circle></g>
+  <text x="14" y="22" font-family="Geist Mono, monospace" font-size="8" fill="#7a8b4f" letter-spacing="1">10.0.0.0/24</text>
+  <text x="200" y="22" font-family="Geist Mono, monospace" font-size="8" fill="#7a8b4f" letter-spacing="1">10.1.0.0/24</text>
+  <text x="380" y="22" font-family="Geist Mono, monospace" font-size="8" fill="#7a8b4f" letter-spacing="1">VPC-PROD</text>
+</svg>

--- a/website/public/brand/korczewski/identity/keycloak-bg-korczewski.svg
+++ b/website/public/brand/korczewski/identity/keycloak-bg-korczewski.svg
@@ -1,0 +1,69 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1920 1080" width="1920" height="1080" role="img" aria-label="Korczewski Keycloak login background">
+  <defs>
+    <radialGradient id="kbl-lime" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#C8F76A" stop-opacity="0.45"></stop>
+      <stop offset="100%" stop-color="#C8F76A" stop-opacity="0"></stop>
+    </radialGradient>
+    <radialGradient id="kbl-purple" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#6a3b8f" stop-opacity="0.55"></stop>
+      <stop offset="100%" stop-color="#6a3b8f" stop-opacity="0"></stop>
+    </radialGradient>
+    <radialGradient id="kbl-cyan" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#5fb8c8" stop-opacity="0.4"></stop>
+      <stop offset="100%" stop-color="#5fb8c8" stop-opacity="0"></stop>
+    </radialGradient>
+    <filter id="kbl-blur"><feGaussianBlur stdDeviation="45"></feGaussianBlur></filter>
+    <filter id="kbl-grain"><feTurbulence type="fractalNoise" baseFrequency="0.95" numOctaves="2" seed="7"></feTurbulence><feColorMatrix values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.07 0"></feColorMatrix></filter>
+    <pattern id="kbl-scan" width="4" height="4" patternUnits="userSpaceOnUse">
+      <rect width="4" height="1" fill="#C8F76A" opacity="0.04"></rect>
+    </pattern>
+  </defs>
+
+  <rect width="1920" height="1080" fill="#120D1C"></rect>
+  <g filter="url(#kbl-blur)">
+    <circle cx="360" cy="280" r="340" fill="url(#kbl-lime)"></circle>
+    <circle cx="1620" cy="820" r="400" fill="url(#kbl-purple)"></circle>
+    <circle cx="1720" cy="180" r="220" fill="url(#kbl-cyan)"></circle>
+    <circle cx="240" cy="900" r="260" fill="url(#kbl-purple)"></circle>
+  </g>
+  <rect width="1920" height="1080" fill="url(#kbl-scan)"></rect>
+  <rect width="1920" height="1080" filter="url(#kbl-grain)" opacity="0.75"></rect>
+
+  <rect x="80" y="80" width="1760" height="920" fill="none" stroke="#C8F76A" stroke-opacity="0.22"></rect>
+  <g stroke="#C8F76A" stroke-opacity="0.7" stroke-width="1" fill="none">
+    <path d="M80 110 L80 80 L110 80"></path>
+    <path d="M1840 110 L1840 80 L1810 80"></path>
+    <path d="M80 970 L80 1000 L110 1000"></path>
+    <path d="M1840 970 L1840 1000 L1810 1000"></path>
+  </g>
+
+  <g font-family="Geist Mono, monospace" font-size="13" letter-spacing="2.5">
+    <text x="110" y="138" fill="#C8F76A">$ auth --provider oidc</text>
+    <text x="110" y="158" fill="#7a8b4f">CLUSTER · KORCZEWSKI.DE</text>
+  </g>
+  <g font-family="Geist Mono, monospace" font-size="13" letter-spacing="2.5" text-anchor="end">
+    <text x="1810" y="138" fill="#C8F76A">KEYCLOAK · v25.0</text>
+    <text x="1810" y="158" fill="#7a8b4f">[SECURE] · TLS 1.3</text>
+  </g>
+
+  <g transform="translate(960, 440)" text-anchor="middle">
+    <text font-family="Geist Mono, monospace" font-size="13" letter-spacing="4" fill="#7a8b4f">› SYSTEM AUTH GATEWAY</text>
+  </g>
+  <g transform="translate(960, 580)" text-anchor="middle">
+    <text font-family="Geist, sans-serif" font-weight="600" font-size="108" fill="#eef1f3" letter-spacing="-2.5">korczewski<tspan fill="#C8F76A">.de</tspan></text>
+  </g>
+  <g transform="translate(960, 660)" text-anchor="middle">
+    <text font-family="Geist Mono, monospace" font-size="17" letter-spacing="4" fill="#7a8b4f">DEVOPS · PLATFORM · INFRASTRUCTURE</text>
+  </g>
+
+  <g transform="translate(960, 800)" text-anchor="middle">
+    <line x1="-60" y1="0" x2="60" y2="0" stroke="#C8F76A" stroke-opacity="0.55"></line>
+    <text y="36" font-family="Geist, sans-serif" font-weight="300" font-size="20" fill="#cdd3d9">Sign in with your platform account.</text>
+    <text y="68" font-family="Geist Mono, monospace" font-size="12" letter-spacing="2.5" fill="#7a8b4f">— KEYCLOAK FORM INJECTED HERE —</text>
+  </g>
+
+  <g font-family="Geist Mono, monospace" font-size="11" letter-spacing="2.5" fill="#5a6b3f">
+    <text x="110" y="975">© 2026 KORCZEWSKI.DE — INFRASTRUCTURE AS POSITION</text>
+    <text x="1810" y="975" text-anchor="end">CONTAINERIZED · OBSERVABLE · GITOPS</text>
+  </g>
+</svg>

--- a/website/public/brand/korczewski/identity/report-header-korczewski.svg
+++ b/website/public/brand/korczewski/identity/report-header-korczewski.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1240 220" width="1240" height="220" role="img" aria-label="Korczewski letterhead">
+  <rect width="1240" height="220" fill="#f6f3ee"></rect>
+  <g transform="translate(80, 60)">
+    <rect width="56" height="56" rx="6" fill="#120D1C"></rect>
+    <rect x="6" y="6" width="44" height="44" fill="none" stroke="#C8F76A" stroke-opacity="0.6"></rect>
+    <text x="28" y="40" text-anchor="middle" font-family="Geist Mono, monospace" font-weight="500" font-size="30" fill="#C8F76A">k</text>
+  </g>
+  <g transform="translate(160, 96)">
+    <text font-family="Geist, sans-serif" font-weight="600" font-size="32" fill="#120D1C" letter-spacing="-0.6">korczewski<tspan fill="#6a8538">.de</tspan></text>
+    <text y="26" font-family="Geist Mono, monospace" font-size="11" letter-spacing="2.5" fill="#6a727e">DEVOPS · PLATFORM ENGINEERING · GITOPS · OBSERVABILITY</text>
+  </g>
+  <g transform="translate(1160, 70)" text-anchor="end" font-family="Geist Mono, monospace" font-size="11" letter-spacing="2" fill="#6a727e">
+    <text>GERALD KORCZEWSKI</text>
+    <text y="22">LÜNEBURG · DE · DACH</text>
+    <text y="44">KORCZEWSKI.DE</text>
+  </g>
+  <line x1="80" y1="156" x2="1160" y2="156" stroke="#6a8538" stroke-opacity="0.55" stroke-width="0.6"></line>
+  <line x1="80" y1="158" x2="320" y2="158" stroke="#6a8538" stroke-width="0.6"></line>
+  <g transform="translate(80, 188)" font-family="Geist Mono, monospace" font-size="10" letter-spacing="2.5" fill="#6a8538">
+    <text>INVOICE · CONTRACT · INCIDENT-REPORT · {{ DOC.TYPE }}</text>
+  </g>
+  <g transform="translate(1160, 188)" font-family="Geist Mono, monospace" font-size="10" letter-spacing="2.5" fill="#6a727e" text-anchor="end">
+    <text>{{ DOC.ID }} · {{ DOC.DATE }} · TLS</text>
+  </g>
+</svg>

--- a/website/public/brand/mentolder/brett/characters/coachee.figurine.svg
+++ b/website/public/brand/mentolder/brett/characters/coachee.figurine.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 320" width="240" height="320" role="img" aria-label="Coachee figurine">
+  <defs>
+    <radialGradient id="g" cx="50%" cy="38%" r="62%">
+      <stop offset="0%" stop-color="#17202e"></stop><stop offset="100%" stop-color="#0b111c"></stop>
+    </radialGradient>
+    <filter id="grain"><feTurbulence type="fractalNoise" baseFrequency=".9" numOctaves="2" seed="3"></feTurbulence><feColorMatrix values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 .06 0"></feColorMatrix></filter>
+  </defs>
+  <rect x="0" y="0" width="240" height="320" fill="url(#g)"></rect>
+  <rect x="0" y="0" width="240" height="320" filter="url(#grain)" opacity=".5"></rect>
+  <rect x="14" y="14" width="212" height="292" fill="none" stroke="#d7b06a" stroke-opacity=".22" stroke-width="1"></rect>
+  <g stroke="#d7b06a" stroke-opacity=".55" stroke-width="1" fill="none">
+    <path d="M14 24 L14 14 L24 14"></path><path d="M226 24 L226 14 L216 14"></path>
+    <path d="M14 296 L14 306 L24 306"></path><path d="M226 296 L226 306 L216 306"></path>
+  </g>
+  
+  <g fill="#e7ead0">
+    <ellipse cx="120" cy="74" rx="20" ry="24"></ellipse>
+    <path d="M84 110 Q88 100 102 98 L138 98 Q152 100 156 110 L162 180 L78 180 Z"></path>
+    <path d="M82 130 Q120 156 158 130 L154 158 Q120 178 86 158 Z" fill="#b8c0a8"></path>
+    <rect x="92" y="180" width="22" height="84" rx="5"></rect>
+    <rect x="126" y="180" width="22" height="84" rx="5"></rect>
+    <ellipse cx="103" cy="270" rx="14" ry="6"></ellipse>
+    <ellipse cx="137" cy="270" rx="14" ry="6"></ellipse>
+  </g>
+  <rect x="84" y="148" width="72" height="2" fill="#d7b06a" opacity=".7"></rect>
+  <text x="120" y="296" text-anchor="middle" font-family="Geist Mono, monospace" font-size="9" fill="#d7b06a" letter-spacing="2">COACHEE · FIGURINE</text>
+
+</svg>

--- a/website/public/brand/mentolder/brett/characters/coachee.portrait.svg
+++ b/website/public/brand/mentolder/brett/characters/coachee.portrait.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 320" width="240" height="320" role="img" aria-label="Coachee portrait">
+  <defs>
+    <radialGradient id="g" cx="50%" cy="38%" r="62%">
+      <stop offset="0%" stop-color="#17202e"></stop><stop offset="100%" stop-color="#0b111c"></stop>
+    </radialGradient>
+    <filter id="grain"><feTurbulence type="fractalNoise" baseFrequency=".9" numOctaves="2" seed="3"></feTurbulence><feColorMatrix values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 .06 0"></feColorMatrix></filter>
+  </defs>
+  <rect x="0" y="0" width="240" height="320" fill="url(#g)"></rect>
+  <rect x="0" y="0" width="240" height="320" filter="url(#grain)" opacity=".5"></rect>
+  <rect x="14" y="14" width="212" height="292" fill="none" stroke="#d7b06a" stroke-opacity=".22" stroke-width="1"></rect>
+  <g stroke="#d7b06a" stroke-opacity=".55" stroke-width="1" fill="none">
+    <path d="M14 24 L14 14 L24 14"></path><path d="M226 24 L226 14 L216 14"></path>
+    <path d="M14 296 L14 306 L24 306"></path><path d="M226 296 L226 306 L216 306"></path>
+  </g>
+  
+  <g fill="#e7ead0">
+    <ellipse cx="120" cy="140" rx="34" ry="42"></ellipse>
+    <path d="M50 280 Q52 220 80 196 Q98 184 120 184 Q142 184 160 196 Q188 220 190 280 Z"></path>
+    <path d="M70 230 Q120 254 170 230 L168 248 Q120 270 72 248 Z" fill="#b8c0a8" opacity=".55"></path>
+  </g>
+  <circle cx="108" cy="134" r="2" fill="#d7b06a"></circle>
+  <circle cx="132" cy="134" r="2" fill="#d7b06a"></circle>
+  <text x="120" y="296" text-anchor="middle" font-family="Geist Mono, monospace" font-size="9" fill="#d7b06a" letter-spacing="2">COACHEE · PORTRAIT</text>
+
+</svg>

--- a/website/public/brand/mentolder/brett/characters/saboteur.svg
+++ b/website/public/brand/mentolder/brett/characters/saboteur.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 320" width="240" height="320" role="img" aria-label="Saboteur">
+  <defs>
+    <radialGradient id="g" cx="50%" cy="38%" r="62%">
+      <stop offset="0%" stop-color="#17202e"></stop><stop offset="100%" stop-color="#0b111c"></stop>
+    </radialGradient>
+    <filter id="grain"><feTurbulence type="fractalNoise" baseFrequency=".9" numOctaves="2" seed="3"></feTurbulence><feColorMatrix values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 .06 0"></feColorMatrix></filter>
+  </defs>
+  <rect x="0" y="0" width="240" height="320" fill="url(#g)"></rect>
+  <rect x="0" y="0" width="240" height="320" filter="url(#grain)" opacity=".5"></rect>
+  <rect x="14" y="14" width="212" height="292" fill="none" stroke="#d7b06a" stroke-opacity=".22" stroke-width="1"></rect>
+  <g stroke="#d7b06a" stroke-opacity=".55" stroke-width="1" fill="none">
+    <path d="M14 24 L14 14 L24 14"></path><path d="M226 24 L226 14 L216 14"></path>
+    <path d="M14 296 L14 306 L24 306"></path><path d="M226 296 L226 306 L216 306"></path>
+  </g>
+  
+  <g fill="#1d2736">
+    <path d="M80 78 Q120 36 160 78 L168 134 Q160 144 152 142 L88 142 Q80 144 72 134 Z"></path>
+    <path d="M70 140 L60 282 L180 282 L170 140 Z"></path>
+    <path d="M70 148 L42 240 L58 248 L84 168 Z"></path>
+    <path d="M170 148 L198 240 L182 248 L156 168 Z"></path>
+  </g>
+  <ellipse cx="120" cy="106" rx="26" ry="22" fill="#0b111c"></ellipse>
+  <rect x="100" y="104" width="10" height="3" fill="#d7b06a" opacity=".95"></rect>
+  <rect x="130" y="104" width="10" height="3" fill="#d7b06a" opacity=".95"></rect>
+  <path d="M60 282 L70 274 L82 282 L94 274 L106 282 L118 274 L130 282 L142 274 L154 282 L166 274 L180 282 Z" fill="#1d2736"></path>
+  <text x="120" y="296" text-anchor="middle" font-family="Geist Mono, monospace" font-size="9" fill="#d7b06a" letter-spacing="2">SABOTEUR · SCHATTEN</text>
+
+</svg>

--- a/website/public/brand/mentolder/brett/characters/team-member-active.svg
+++ b/website/public/brand/mentolder/brett/characters/team-member-active.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 320" width="240" height="320" role="img" aria-label="Team member active">
+  <defs>
+    <radialGradient id="g" cx="50%" cy="38%" r="62%">
+      <stop offset="0%" stop-color="#17202e"></stop><stop offset="100%" stop-color="#0b111c"></stop>
+    </radialGradient>
+    <filter id="grain"><feTurbulence type="fractalNoise" baseFrequency=".9" numOctaves="2" seed="3"></feTurbulence><feColorMatrix values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 .06 0"></feColorMatrix></filter>
+  </defs>
+  <rect x="0" y="0" width="240" height="320" fill="url(#g)"></rect>
+  <rect x="0" y="0" width="240" height="320" filter="url(#grain)" opacity=".5"></rect>
+  <rect x="14" y="14" width="212" height="292" fill="none" stroke="#d7b06a" stroke-opacity=".22" stroke-width="1"></rect>
+  <g stroke="#d7b06a" stroke-opacity=".55" stroke-width="1" fill="none">
+    <path d="M14 24 L14 14 L24 14"></path><path d="M226 24 L226 14 L216 14"></path>
+    <path d="M14 296 L14 306 L24 306"></path><path d="M226 296 L226 306 L216 306"></path>
+  </g>
+  
+  <g fill="#9fb39c">
+    <ellipse cx="124" cy="76" rx="20" ry="24"></ellipse>
+    <path d="M82 122 Q90 105 112 100 L146 100 Q166 108 170 130 L168 192 L74 184 Z"></path>
+    <path d="M152 124 Q186 138 196 168 L184 178 Q160 154 144 142 Z"></path>
+    <path d="M86 130 Q72 152 80 174 L92 168 Q98 150 100 138 Z"></path>
+    <path d="M96 190 L88 268 L106 270 L114 192 Z"></path>
+    <path d="M132 192 L148 268 L160 264 L150 190 Z"></path>
+    <ellipse cx="96" cy="272" rx="12" ry="5"></ellipse>
+    <ellipse cx="154" cy="270" rx="12" ry="5"></ellipse>
+  </g>
+  <path d="M196 168 L210 168 L204 162 M210 168 L204 174" stroke="#d7b06a" stroke-width="2" fill="none"></path>
+  <text x="120" y="296" text-anchor="middle" font-family="Geist Mono, monospace" font-size="9" fill="#d7b06a" letter-spacing="2">TEAM · ACTIVE</text>
+
+</svg>

--- a/website/public/brand/mentolder/brett/characters/team-member-passive.svg
+++ b/website/public/brand/mentolder/brett/characters/team-member-passive.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 320" width="240" height="320" role="img" aria-label="Team member passive">
+  <defs>
+    <radialGradient id="g" cx="50%" cy="38%" r="62%">
+      <stop offset="0%" stop-color="#17202e"></stop><stop offset="100%" stop-color="#0b111c"></stop>
+    </radialGradient>
+    <filter id="grain"><feTurbulence type="fractalNoise" baseFrequency=".9" numOctaves="2" seed="3"></feTurbulence><feColorMatrix values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 .06 0"></feColorMatrix></filter>
+  </defs>
+  <rect x="0" y="0" width="240" height="320" fill="url(#g)"></rect>
+  <rect x="0" y="0" width="240" height="320" filter="url(#grain)" opacity=".5"></rect>
+  <rect x="14" y="14" width="212" height="292" fill="none" stroke="#d7b06a" stroke-opacity=".22" stroke-width="1"></rect>
+  <g stroke="#d7b06a" stroke-opacity=".55" stroke-width="1" fill="none">
+    <path d="M14 24 L14 14 L24 14"></path><path d="M226 24 L226 14 L216 14"></path>
+    <path d="M14 296 L14 306 L24 306"></path><path d="M226 296 L226 306 L216 306"></path>
+  </g>
+  
+  <g fill="#9fb39c" opacity=".82">
+    <ellipse cx="120" cy="78" rx="20" ry="24"></ellipse>
+    <path d="M88 116 Q92 104 108 102 L132 102 Q148 104 152 116 L154 192 L86 192 Z"></path>
+    <rect x="74" y="118" width="14" height="74" rx="6"></rect>
+    <rect x="152" y="118" width="14" height="74" rx="6"></rect>
+    <rect x="94" y="192" width="20" height="78" rx="5"></rect>
+    <rect x="126" y="192" width="20" height="78" rx="5"></rect>
+    <ellipse cx="104" cy="274" rx="13" ry="5"></ellipse>
+    <ellipse cx="136" cy="274" rx="13" ry="5"></ellipse>
+  </g>
+  <line x1="100" y1="148" x2="140" y2="148" stroke="#d7b06a" stroke-width="1.5" opacity=".6"></line>
+  <text x="120" y="296" text-anchor="middle" font-family="Geist Mono, monospace" font-size="9" fill="#d7b06a" letter-spacing="2">TEAM · PASSIVE</text>
+
+</svg>

--- a/website/public/brand/mentolder/brett/props/prop-balance.svg
+++ b/website/public/brand/mentolder/brett/props/prop-balance.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200" role="img" aria-label="Balance">
+  <defs>
+    <radialGradient id="pg" cx="50%" cy="45%" r="65%"><stop offset="0%" stop-color="#17202e"></stop><stop offset="100%" stop-color="#0b111c"></stop></radialGradient>
+    <filter id="pgrain"><feTurbulence type="fractalNoise" baseFrequency=".9" numOctaves="2" seed="5"></feTurbulence><feColorMatrix values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 .06 0"></feColorMatrix></filter>
+  </defs>
+  <rect width="200" height="200" fill="url(#pg)"></rect>
+  <rect width="200" height="200" filter="url(#pgrain)" opacity=".4"></rect>
+  <rect x="12" y="12" width="176" height="176" fill="none" stroke="#d7b06a" stroke-opacity=".22"></rect>
+  
+  <line x1="100" y1="30" x2="100" y2="148" stroke="#e7ead0" stroke-width="2"></line>
+  <line x1="36" y1="60" x2="164" y2="60" stroke="#d7b06a" stroke-width="2.5"></line>
+  <circle cx="100" cy="60" r="5" fill="#d7b06a"></circle>
+  <line x1="46" y1="60" x2="46" y2="86" stroke="#e7ead0" stroke-width="0.8" opacity=".7"></line>
+  <line x1="60" y1="60" x2="60" y2="86" stroke="#e7ead0" stroke-width="0.8" opacity=".7"></line>
+  <path d="M30 86 Q53 110 76 86 Z" fill="none" stroke="#e7ead0" stroke-width="2"></path>
+  <line x1="140" y1="60" x2="140" y2="92" stroke="#e7ead0" stroke-width="0.8" opacity=".7"></line>
+  <line x1="154" y1="60" x2="154" y2="92" stroke="#e7ead0" stroke-width="0.8" opacity=".7"></line>
+  <path d="M122 92 Q147 116 170 92 Z" fill="none" stroke="#e7ead0" stroke-width="2"></path>
+  <rect x="84" y="148" width="32" height="6" fill="#e7ead0"></rect>
+  <rect x="76" y="154" width="48" height="4" fill="#e7ead0"></rect>
+  <text x="100" y="180" text-anchor="middle" font-family="Geist Mono, monospace" font-size="8" fill="#d7b06a" letter-spacing="2">WAAGE · BALANCE</text>
+
+</svg>

--- a/website/public/brand/mentolder/brett/props/prop-barrier.svg
+++ b/website/public/brand/mentolder/brett/props/prop-barrier.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200" role="img" aria-label="Barrier">
+  <defs>
+    <radialGradient id="pg" cx="50%" cy="45%" r="65%"><stop offset="0%" stop-color="#17202e"></stop><stop offset="100%" stop-color="#0b111c"></stop></radialGradient>
+    <filter id="pgrain"><feTurbulence type="fractalNoise" baseFrequency=".9" numOctaves="2" seed="5"></feTurbulence><feColorMatrix values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 .06 0"></feColorMatrix></filter>
+  </defs>
+  <rect width="200" height="200" fill="url(#pg)"></rect>
+  <rect width="200" height="200" filter="url(#pgrain)" opacity=".4"></rect>
+  <rect x="12" y="12" width="176" height="176" fill="none" stroke="#d7b06a" stroke-opacity=".22"></rect>
+  
+  <g fill="#1d2736" stroke="#d7b06a" stroke-opacity=".4" stroke-width="0.8">
+    <rect x="34" y="42" width="44" height="22"></rect><rect x="78" y="42" width="48" height="22"></rect><rect x="126" y="42" width="40" height="22"></rect>
+    <rect x="34" y="64" width="32" height="22"></rect><rect x="66" y="64" width="50" height="22"></rect><rect x="116" y="64" width="50" height="22"></rect>
+    <rect x="34" y="86" width="48" height="22"></rect><rect x="82" y="86" width="46" height="22"></rect><rect x="128" y="86" width="38" height="22"></rect>
+    <rect x="34" y="108" width="40" height="22"></rect><rect x="74" y="108" width="44" height="22"></rect><rect x="118" y="108" width="48" height="22"></rect>
+    <rect x="34" y="130" width="50" height="22"></rect><rect x="84" y="130" width="38" height="22"></rect><rect x="122" y="130" width="44" height="22"></rect>
+  </g>
+  <path d="M82 42 L78 64 L86 86 L78 108 L84 130 L78 152" stroke="#0b111c" stroke-width="2" fill="none"></path>
+  <text x="100" y="172" text-anchor="middle" font-family="Geist Mono, monospace" font-size="8" fill="#d7b06a" letter-spacing="2">BLOCKADE</text>
+
+</svg>

--- a/website/public/brand/mentolder/brett/props/prop-shield.svg
+++ b/website/public/brand/mentolder/brett/props/prop-shield.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200" role="img" aria-label="Shield">
+  <defs>
+    <radialGradient id="pg" cx="50%" cy="45%" r="65%"><stop offset="0%" stop-color="#17202e"></stop><stop offset="100%" stop-color="#0b111c"></stop></radialGradient>
+    <filter id="pgrain"><feTurbulence type="fractalNoise" baseFrequency=".9" numOctaves="2" seed="5"></feTurbulence><feColorMatrix values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 .06 0"></feColorMatrix></filter>
+  </defs>
+  <rect width="200" height="200" fill="url(#pg)"></rect>
+  <rect width="200" height="200" filter="url(#pgrain)" opacity=".4"></rect>
+  <rect x="12" y="12" width="176" height="176" fill="none" stroke="#d7b06a" stroke-opacity=".22"></rect>
+  
+  <path d="M100 30 L150 44 L150 100 Q150 130 100 156 Q50 130 50 100 L50 44 Z" fill="#1d2736" stroke="#d7b06a" stroke-width="2"></path>
+  <path d="M68 76 L100 56 L132 76 L132 84 L100 64 L68 84 Z" fill="#d7b06a" opacity=".85"></path>
+  <circle cx="100" cy="108" r="6" fill="#d7b06a"></circle>
+  <path d="M82 122 L100 142 L118 122 Z" fill="none" stroke="#d7b06a" stroke-width="1.5"></path>
+  <text x="100" y="180" text-anchor="middle" font-family="Geist Mono, monospace" font-size="8" fill="#d7b06a" letter-spacing="2">SCHILD · GRENZE</text>
+
+</svg>

--- a/website/public/brand/mentolder/brett/props/prop-target.svg
+++ b/website/public/brand/mentolder/brett/props/prop-target.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200" role="img" aria-label="Target">
+  <defs>
+    <radialGradient id="pg" cx="50%" cy="45%" r="65%"><stop offset="0%" stop-color="#17202e"></stop><stop offset="100%" stop-color="#0b111c"></stop></radialGradient>
+    <filter id="pgrain"><feTurbulence type="fractalNoise" baseFrequency=".9" numOctaves="2" seed="5"></feTurbulence><feColorMatrix values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 .06 0"></feColorMatrix></filter>
+  </defs>
+  <rect width="200" height="200" fill="url(#pg)"></rect>
+  <rect width="200" height="200" filter="url(#pgrain)" opacity=".4"></rect>
+  <rect x="12" y="12" width="176" height="176" fill="none" stroke="#d7b06a" stroke-opacity=".22"></rect>
+  
+  <circle cx="100" cy="95" r="62" fill="none" stroke="#e7ead0" stroke-width="1.5" opacity=".55"></circle>
+  <circle cx="100" cy="95" r="48" fill="none" stroke="#e7ead0" stroke-width="1.5" opacity=".7"></circle>
+  <circle cx="100" cy="95" r="34" fill="none" stroke="#d7b06a" stroke-width="1.5"></circle>
+  <circle cx="100" cy="95" r="20" fill="none" stroke="#d7b06a" stroke-width="1.8"></circle>
+  <circle cx="100" cy="95" r="6" fill="#d7b06a"></circle>
+  <line x1="100" y1="20" x2="100" y2="38" stroke="#d7b06a" stroke-width="1" opacity=".7"></line>
+  <line x1="100" y1="152" x2="100" y2="170" stroke="#d7b06a" stroke-width="1" opacity=".7"></line>
+  <line x1="25" y1="95" x2="43" y2="95" stroke="#d7b06a" stroke-width="1" opacity=".7"></line>
+  <line x1="157" y1="95" x2="175" y2="95" stroke="#d7b06a" stroke-width="1" opacity=".7"></line>
+  <text x="100" y="186" text-anchor="middle" font-family="Geist Mono, monospace" font-size="8" fill="#d7b06a" letter-spacing="2">ZIELSCHEIBE</text>
+
+</svg>

--- a/website/public/brand/mentolder/brett/terrain/focus-circle.svg
+++ b/website/public/brand/mentolder/brett/terrain/focus-circle.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 480 240" width="480" height="240" role="img" aria-label="Focus circle terrain">
+  <defs>
+    <radialGradient id="fc1" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#f0d28c" stop-opacity="0.45"></stop>
+      <stop offset="30%" stop-color="#d7b06a" stop-opacity="0.22"></stop>
+      <stop offset="70%" stop-color="#101826" stop-opacity="0"></stop>
+    </radialGradient>
+  </defs>
+  <rect width="480" height="240" fill="#0b111c"></rect>
+  <circle cx="240" cy="120" r="220" fill="url(#fc1)"></circle>
+  <circle cx="240" cy="120" r="80" fill="none" stroke="#d7b06a" stroke-opacity=".55"></circle>
+  <circle cx="240" cy="120" r="120" fill="none" stroke="#d7b06a" stroke-opacity=".22"></circle>
+  <circle cx="240" cy="120" r="3" fill="#d7b06a"></circle>
+</svg>

--- a/website/public/brand/mentolder/brett/terrain/fog-wash.svg
+++ b/website/public/brand/mentolder/brett/terrain/fog-wash.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 480 240" width="480" height="240" role="img" aria-label="Fog wash terrain">
+  <defs>
+    <radialGradient id="fg1" cx="32%" cy="40%" r="58%"><stop offset="0%" stop-color="#cdd3d9" stop-opacity="0.85"></stop><stop offset="60%" stop-color="#8c96a3" stop-opacity="0.45"></stop><stop offset="100%" stop-color="#17202e" stop-opacity="0.85"></stop></radialGradient>
+    <radialGradient id="fg2" cx="78%" cy="65%" r="48%"><stop offset="0%" stop-color="#cdd3d9" stop-opacity="0.55"></stop><stop offset="100%" stop-color="#17202e" stop-opacity="0"></stop></radialGradient>
+    <filter id="softGrain"><feTurbulence type="fractalNoise" baseFrequency=".6" numOctaves="3" seed="2"></feTurbulence><feColorMatrix values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 .1 0"></feColorMatrix></filter>
+  </defs>
+  <rect width="480" height="240" fill="#101826"></rect>
+  <rect width="480" height="240" fill="url(#fg1)"></rect>
+  <rect width="480" height="240" fill="url(#fg2)"></rect>
+  <rect width="480" height="240" filter="url(#softGrain)" opacity=".5"></rect>
+  <path d="M0 120 Q120 100 240 130 T480 110" fill="none" stroke="#cdd3d9" stroke-width="0.6" opacity=".25"></path>
+  <path d="M0 160 Q140 150 280 168 T480 152" fill="none" stroke="#cdd3d9" stroke-width="0.6" opacity=".2"></path>
+</svg>

--- a/website/public/brand/mentolder/identity/keycloak-bg-mentolder.svg
+++ b/website/public/brand/mentolder/identity/keycloak-bg-mentolder.svg
@@ -1,0 +1,54 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1920 1080" width="1920" height="1080" role="img" aria-label="Mentolder Keycloak login background">
+  <defs>
+    <radialGradient id="halo-brass" cx="78%" cy="22%" r="55%">
+      <stop offset="0%" stop-color="#d7b06a" stop-opacity="0.16"></stop>
+      <stop offset="100%" stop-color="#d7b06a" stop-opacity="0"></stop>
+    </radialGradient>
+    <radialGradient id="halo-cool" cx="18%" cy="86%" r="60%">
+      <stop offset="0%" stop-color="#3a4a6e" stop-opacity="0.42"></stop>
+      <stop offset="100%" stop-color="#3a4a6e" stop-opacity="0"></stop>
+    </radialGradient>
+    <filter id="m-grain"><feTurbulence type="fractalNoise" baseFrequency="0.9" numOctaves="2" seed="3"></feTurbulence><feColorMatrix values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.05 0"></feColorMatrix></filter>
+  </defs>
+  <rect width="1920" height="1080" fill="#0b111c"></rect>
+  <rect width="1920" height="1080" fill="url(#halo-brass)"></rect>
+  <rect width="1920" height="1080" fill="url(#halo-cool)"></rect>
+  <rect width="1920" height="1080" filter="url(#m-grain)" opacity="0.55"></rect>
+
+  <rect x="80" y="80" width="1760" height="920" fill="none" stroke="#d7b06a" stroke-opacity="0.18"></rect>
+  <g stroke="#d7b06a" stroke-opacity="0.65" stroke-width="1" fill="none">
+    <path d="M80 110 L80 80 L110 80"></path>
+    <path d="M1840 110 L1840 80 L1810 80"></path>
+    <path d="M80 970 L80 1000 L110 1000"></path>
+    <path d="M1840 970 L1840 1000 L1810 1000"></path>
+  </g>
+
+  <g font-family="Geist Mono, monospace" font-size="13" letter-spacing="2.5">
+    <text x="110" y="138" fill="#d7b06a">— GK · ANNO 2026</text>
+    <text x="110" y="158" fill="#8c96a3">LÜNEBURG · DE · IDP</text>
+  </g>
+  <g font-family="Geist Mono, monospace" font-size="13" letter-spacing="2.5" text-anchor="end">
+    <text x="1810" y="138" fill="#d7b06a">KEYCLOAK · OIDC</text>
+    <text x="1810" y="158" fill="#8c96a3">IDENTITÄT &amp; HALTUNG</text>
+  </g>
+
+  <g transform="translate(960, 282)" text-anchor="middle">
+    <text font-family="Newsreader, serif" font-style="italic" font-weight="400" font-size="44" fill="#eef1f3">mentolder<tspan fill="#d7b06a">.</tspan></text>
+  </g>
+
+  <g transform="translate(960, 500)" text-anchor="middle" font-family="Newsreader, serif">
+    <text y="0" font-size="132" font-weight="350" fill="#eef1f3" letter-spacing="-3">Willkommen</text>
+    <text y="130" font-size="132" font-weight="350" font-style="italic" fill="#d7b06a" letter-spacing="-3">zurück.</text>
+  </g>
+
+  <g text-anchor="middle">
+    <line x1="900" y1="780" x2="1020" y2="780" stroke="#d7b06a" stroke-opacity="0.6"></line>
+    <text x="960" y="822" font-family="Geist, sans-serif" font-weight="300" font-size="20" fill="#cdd3d9">Bitte melden Sie sich an, um fortzufahren.</text>
+    <text x="960" y="852" font-family="Geist Mono, monospace" font-size="12" letter-spacing="2.5" fill="#8c96a3">— FORMULARFELDER WERDEN VON KEYCLOAK INJIZIERT —</text>
+  </g>
+
+  <g font-family="Geist Mono, monospace" font-size="11" letter-spacing="2.5" fill="#6a727e">
+    <text x="110" y="975">© 2026 MENTOLDER — ALLE RECHTE VORBEHALTEN</text>
+    <text x="1810" y="975" text-anchor="end">MENSCHEN · PROZESSE · TECHNIK · WIEDER VERBINDEN</text>
+  </g>
+</svg>

--- a/website/public/brand/mentolder/identity/report-header-mentolder.svg
+++ b/website/public/brand/mentolder/identity/report-header-mentolder.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1240 220" width="1240" height="220" role="img" aria-label="Mentolder letterhead">
+  <rect width="1240" height="220" fill="#f6f3ee"></rect>
+  <g transform="translate(80, 60)">
+    <rect width="56" height="56" rx="8" fill="#d7b06a"></rect>
+    <text x="28" y="42" text-anchor="middle" font-family="Newsreader, serif" font-style="italic" font-weight="600" font-size="38" fill="#1a2030">m</text>
+  </g>
+  <g transform="translate(160, 96)">
+    <text font-family="Newsreader, serif" font-style="italic" font-weight="500" font-size="32" fill="#1a2030">mentolder<tspan fill="#8a6a2a">.</tspan></text>
+    <text y="26" font-family="Geist Mono, monospace" font-size="11" letter-spacing="2.5" fill="#6a727e">DIGITAL COACHING · MENTORING · UNTERNEHMENSBERATUNG</text>
+  </g>
+  <g transform="translate(1160, 70)" text-anchor="end" font-family="Geist Mono, monospace" font-size="11" letter-spacing="2" fill="#6a727e">
+    <text>GERALD KORCZEWSKI</text>
+    <text y="22">LÜNEBURG · DE</text>
+    <text y="44">MENTOLDER.DE</text>
+  </g>
+  <line x1="80" y1="156" x2="1160" y2="156" stroke="#8a6a2a" stroke-opacity="0.55" stroke-width="0.6"></line>
+  <line x1="80" y1="158" x2="320" y2="158" stroke="#8a6a2a" stroke-width="0.6"></line>
+  <g transform="translate(80, 188)" font-family="Geist Mono, monospace" font-size="10" letter-spacing="2.5" fill="#8a6a2a">
+    <text>RECHNUNG · VERTRAG · REPORT · {{ DOC.TYPE }}</text>
+  </g>
+  <g transform="translate(1160, 188)" font-family="Geist Mono, monospace" font-size="10" letter-spacing="2.5" fill="#6a727e" text-anchor="end">
+    <text>{{ DOC.NUMBER }} · {{ DOC.DATE }}</text>
+  </g>
+</svg>

--- a/website/public/brand/shared/identity/og-template-docs.svg
+++ b/website/public/brand/shared/identity/og-template-docs.svg
@@ -1,0 +1,47 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630" role="img" aria-label="OG share card template — docs">
+  <defs>
+    <radialGradient id="og-brass" cx="85%" cy="15%" r="55%">
+      <stop offset="0%" stop-color="#d7b06a" stop-opacity="0.22"></stop>
+      <stop offset="100%" stop-color="#d7b06a" stop-opacity="0"></stop>
+    </radialGradient>
+    <radialGradient id="og-cool" cx="10%" cy="92%" r="55%">
+      <stop offset="0%" stop-color="#3a4a6e" stop-opacity="0.55"></stop>
+      <stop offset="100%" stop-color="#3a4a6e" stop-opacity="0"></stop>
+    </radialGradient>
+    <filter id="og-grain"><feTurbulence type="fractalNoise" baseFrequency="0.9" numOctaves="2" seed="5"></feTurbulence><feColorMatrix values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.05 0"></feColorMatrix></filter>
+  </defs>
+  <rect width="1200" height="630" fill="#0b111c"></rect>
+  <rect width="1200" height="630" fill="url(#og-brass)"></rect>
+  <rect width="1200" height="630" fill="url(#og-cool)"></rect>
+  <rect width="1200" height="630" filter="url(#og-grain)" opacity="0.5"></rect>
+
+  <rect x="40" y="40" width="1120" height="550" fill="none" stroke="#d7b06a" stroke-opacity="0.22"></rect>
+  <g stroke="#d7b06a" stroke-opacity="0.7" stroke-width="1" fill="none">
+    <path d="M40 60 L40 40 L60 40"></path>
+    <path d="M1160 60 L1160 40 L1140 40"></path>
+    <path d="M40 570 L40 590 L60 590"></path>
+    <path d="M1160 570 L1160 590 L1140 590"></path>
+  </g>
+
+  <g font-family="Geist Mono, monospace" font-size="13" letter-spacing="3">
+    <text x="72" y="90" fill="#d7b06a">— MENTOLDER · DOCS</text>
+    <text x="1128" y="90" fill="#8c96a3" text-anchor="end">{{ section.slug }}</text>
+  </g>
+
+  <g transform="translate(72, 230)">
+    <text font-family="Newsreader, serif" font-weight="350" font-size="72" letter-spacing="-1.8" fill="#eef1f3">{{ doc.title }}</text>
+    <text y="84" font-family="Newsreader, serif" font-weight="350" font-style="italic" font-size="72" letter-spacing="-1.8" fill="#d7b06a">— {{ doc.tagline }}</text>
+  </g>
+
+  <text x="72" y="430" font-family="Geist, sans-serif" font-weight="300" font-size="22" fill="#cdd3d9">{{ doc.lede }}</text>
+
+  <g transform="translate(72, 540)">
+    <rect x="0" y="-32" width="44" height="44" rx="6" fill="#d7b06a"></rect>
+    <text x="22" y="0" text-anchor="middle" font-family="Newsreader, serif" font-style="italic" font-weight="600" font-size="30" fill="#0b111c">m</text>
+    <text x="60" y="-6" font-family="Newsreader, serif" font-style="italic" font-weight="500" font-size="22" fill="#eef1f3">mentolder<tspan fill="#d7b06a">.</tspan></text>
+    <text x="60" y="14" font-family="Geist Mono, monospace" font-size="11" letter-spacing="2.5" fill="#8c96a3">{{ doc.author }} · {{ doc.date }}</text>
+  </g>
+  <g transform="translate(1128, 540)" text-anchor="end">
+    <text font-family="Geist Mono, monospace" font-size="11" letter-spacing="2.5" fill="#8c96a3">{{ doc.reading_time }} MIN · LESEN</text>
+  </g>
+</svg>

--- a/website/src/components/admin/AssetGallery.svelte
+++ b/website/src/components/admin/AssetGallery.svelte
@@ -51,10 +51,13 @@
   }
 
   // Map registry file_path to a public URL if one exists in the website build.
-  // branding/korczewski/* → /brand/korczewski/*, branding/mentolder/* → /brand/mentolder/*
+  // branding/* → /brand/*, arena/* → /arena/*
   function publicUrl(filePath: string): string | null {
     if (filePath.startsWith('branding/')) {
       return '/' + filePath.replace(/^branding\//, 'brand/');
+    }
+    if (filePath.startsWith('arena/')) {
+      return '/' + filePath;
     }
     return null;
   }

--- a/website/src/db/migrations/20260520_seed_asset_pack_02.sql
+++ b/website/src/db/migrations/20260520_seed_asset_pack_02.sql
@@ -1,0 +1,138 @@
+-- Asset Pack 02: Brett sets, identity assets, arena SVGs
+-- file_path is relative to assets/ root (same convention as assets-index.sh)
+
+INSERT INTO assets.registry (name, type, file_path, tags, metadata) VALUES
+
+-- ── Brett set: mentolder / characters ──────────────────────────────────────
+('coachee.portrait.svg',    'image', 'branding/mentolder/brett/characters/coachee.portrait.svg',
+  ARRAY['brett','mentolder','character','coaching'],
+  '{"brand":"mentolder","set":"brett","category":"character","width":240,"height":320,"pack":"02"}'::jsonb),
+
+('coachee.figurine.svg',    'image', 'branding/mentolder/brett/characters/coachee.figurine.svg',
+  ARRAY['brett','mentolder','character','coaching'],
+  '{"brand":"mentolder","set":"brett","category":"character","width":240,"height":320,"pack":"02"}'::jsonb),
+
+('team-member-active.svg',  'image', 'branding/mentolder/brett/characters/team-member-active.svg',
+  ARRAY['brett','mentolder','character','coaching'],
+  '{"brand":"mentolder","set":"brett","category":"character","width":240,"height":320,"pack":"02"}'::jsonb),
+
+('team-member-passive.svg', 'image', 'branding/mentolder/brett/characters/team-member-passive.svg',
+  ARRAY['brett','mentolder','character','coaching'],
+  '{"brand":"mentolder","set":"brett","category":"character","width":240,"height":320,"pack":"02"}'::jsonb),
+
+('saboteur.svg',            'image', 'branding/mentolder/brett/characters/saboteur.svg',
+  ARRAY['brett','mentolder','character','coaching'],
+  '{"brand":"mentolder","set":"brett","category":"character","width":240,"height":320,"pack":"02"}'::jsonb),
+
+-- ── Brett set: mentolder / props ────────────────────────────────────────────
+('prop-target.svg',  'image', 'branding/mentolder/brett/props/prop-target.svg',
+  ARRAY['brett','mentolder','prop','coaching'],
+  '{"brand":"mentolder","set":"brett","category":"prop","width":200,"height":200,"pack":"02"}'::jsonb),
+
+('prop-barrier.svg', 'image', 'branding/mentolder/brett/props/prop-barrier.svg',
+  ARRAY['brett','mentolder','prop','coaching'],
+  '{"brand":"mentolder","set":"brett","category":"prop","width":200,"height":200,"pack":"02"}'::jsonb),
+
+('prop-balance.svg', 'image', 'branding/mentolder/brett/props/prop-balance.svg',
+  ARRAY['brett','mentolder','prop','coaching'],
+  '{"brand":"mentolder","set":"brett","category":"prop","width":200,"height":200,"pack":"02"}'::jsonb),
+
+('prop-shield.svg',  'image', 'branding/mentolder/brett/props/prop-shield.svg',
+  ARRAY['brett','mentolder','prop','coaching'],
+  '{"brand":"mentolder","set":"brett","category":"prop","width":200,"height":200,"pack":"02"}'::jsonb),
+
+-- ── Brett set: mentolder / terrain ──────────────────────────────────────────
+('fog-wash.svg',     'image', 'branding/mentolder/brett/terrain/fog-wash.svg',
+  ARRAY['brett','mentolder','terrain','coaching'],
+  '{"brand":"mentolder","set":"brett","category":"terrain","pack":"02"}'::jsonb),
+
+('focus-circle.svg', 'image', 'branding/mentolder/brett/terrain/focus-circle.svg',
+  ARRAY['brett','mentolder','terrain','coaching'],
+  '{"brand":"mentolder","set":"brett","category":"terrain","pack":"02"}'::jsonb),
+
+-- ── Brett set: korczewski / characters ─────────────────────────────────────
+('sysadmin.svg',         'image', 'branding/korczewski/brett/characters/sysadmin.svg',
+  ARRAY['brett','korczewski','character','devops'],
+  '{"brand":"korczewski","set":"brett","category":"character","width":240,"height":320,"pack":"02"}'::jsonb),
+
+('security-officer.svg', 'image', 'branding/korczewski/brett/characters/security-officer.svg',
+  ARRAY['brett','korczewski','character','devops'],
+  '{"brand":"korczewski","set":"brett","category":"character","width":240,"height":320,"pack":"02"}'::jsonb),
+
+('product-owner.svg',    'image', 'branding/korczewski/brett/characters/product-owner.svg',
+  ARRAY['brett','korczewski','character','devops'],
+  '{"brand":"korczewski","set":"brett","category":"character","width":240,"height":320,"pack":"02"}'::jsonb),
+
+-- ── Brett set: korczewski / props ───────────────────────────────────────────
+('prop-database.svg', 'image', 'branding/korczewski/brett/props/prop-database.svg',
+  ARRAY['brett','korczewski','prop','devops'],
+  '{"brand":"korczewski","set":"brett","category":"prop","width":200,"height":200,"pack":"02"}'::jsonb),
+
+('prop-pipeline.svg', 'image', 'branding/korczewski/brett/props/prop-pipeline.svg',
+  ARRAY['brett','korczewski','prop','devops'],
+  '{"brand":"korczewski","set":"brett","category":"prop","width":200,"height":200,"pack":"02"}'::jsonb),
+
+('prop-firewall.svg', 'image', 'branding/korczewski/brett/props/prop-firewall.svg',
+  ARRAY['brett','korczewski','prop','devops'],
+  '{"brand":"korczewski","set":"brett","category":"prop","width":200,"height":200,"pack":"02"}'::jsonb),
+
+('prop-alert.svg',    'image', 'branding/korczewski/brett/props/prop-alert.svg',
+  ARRAY['brett','korczewski','prop','devops'],
+  '{"brand":"korczewski","set":"brett","category":"prop","width":200,"height":200,"pack":"02"}'::jsonb),
+
+-- ── Brett set: korczewski / terrain ─────────────────────────────────────────
+('subnet-grid.svg',        'image', 'branding/korczewski/brett/terrain/subnet-grid.svg',
+  ARRAY['brett','korczewski','terrain','devops'],
+  '{"brand":"korczewski","set":"brett","category":"terrain","pack":"02"}'::jsonb),
+
+('namespace-boundary.svg', 'image', 'branding/korczewski/brett/terrain/namespace-boundary.svg',
+  ARRAY['brett','korczewski','terrain','devops'],
+  '{"brand":"korczewski","set":"brett","category":"terrain","pack":"02"}'::jsonb),
+
+-- ── Identity: Keycloak backgrounds ──────────────────────────────────────────
+('keycloak-bg-mentolder.svg', 'image', 'branding/mentolder/identity/keycloak-bg-mentolder.svg',
+  ARRAY['identity','mentolder','keycloak','login'],
+  '{"brand":"mentolder","category":"identity","width":1920,"height":1080,"usage":"keycloak-login-bg","pack":"02"}'::jsonb),
+
+('keycloak-bg-korczewski.svg', 'image', 'branding/korczewski/identity/keycloak-bg-korczewski.svg',
+  ARRAY['identity','korczewski','keycloak','login'],
+  '{"brand":"korczewski","category":"identity","width":1920,"height":1080,"usage":"keycloak-login-bg","pack":"02"}'::jsonb),
+
+-- ── Identity: Report letterheads ────────────────────────────────────────────
+('report-header-mentolder.svg', 'image', 'branding/mentolder/identity/report-header-mentolder.svg',
+  ARRAY['identity','mentolder','letterhead','report'],
+  '{"brand":"mentolder","category":"identity","width":1240,"height":220,"usage":"docuseal-letterhead","pack":"02"}'::jsonb),
+
+('report-header-korczewski.svg', 'image', 'branding/korczewski/identity/report-header-korczewski.svg',
+  ARRAY['identity','korczewski','letterhead','report'],
+  '{"brand":"korczewski","category":"identity","width":1240,"height":220,"usage":"docuseal-letterhead","pack":"02"}'::jsonb),
+
+-- ── Identity: Shared OG template ────────────────────────────────────────────
+('og-template-docs.svg', 'image', 'branding/shared/identity/og-template-docs.svg',
+  ARRAY['identity','shared','og','social'],
+  '{"brand":"shared","category":"identity","width":1200,"height":630,"usage":"og-social-card","pack":"02"}'::jsonb),
+
+-- ── Arena: HUD & pickups ────────────────────────────────────────────────────
+('hud-frame.svg',    'image', 'arena/hud-frame.svg',
+  ARRAY['arena','hud','korczewski','game'],
+  '{"category":"arena","width":1920,"height":1080,"usage":"arena-hud-overlay","pack":"02"}'::jsonb),
+
+('pickup-shield.svg', 'image', 'arena/pickup-shield.svg',
+  ARRAY['arena','pickup','korczewski','game'],
+  '{"category":"arena","width":256,"height":256,"usage":"arena-pickup","effect":"+50 shield","pack":"02"}'::jsonb),
+
+('pickup-speed.svg',  'image', 'arena/pickup-speed.svg',
+  ARRAY['arena','pickup','korczewski','game'],
+  '{"category":"arena","width":256,"height":256,"usage":"arena-pickup","effect":"+30% sprint","pack":"02"}'::jsonb),
+
+-- ── Audio: SFX spec document ────────────────────────────────────────────────
+('audio-sfx-spec.md', 'document', 'audio/spec/audio-sfx-spec.md',
+  ARRAY['audio','spec','sfx','howlerjs'],
+  '{"category":"audio","pack":"02","note":"procurement-spec-only-no-binaries"}'::jsonb)
+
+ON CONFLICT (file_path) DO UPDATE
+  SET name       = EXCLUDED.name,
+      type       = EXCLUDED.type,
+      tags       = EXCLUDED.tags,
+      metadata   = EXCLUDED.metadata,
+      updated_at = now();


### PR DESCRIPTION
## Summary
- **29 new SVGs** added to central asset library covering 4 design sections from handoff bundle
- **Brett set extension** (Section 01): mentolder coaching characters (Coachee×2, Team-member×2, Saboteur), props (Target, Barrier, Balance, Shield), terrain (Fog-wash, Focus-circle) + korczewski DevOps set (Sysadmin, Security-Officer, Product-Owner chars; Database, Pipeline, Firewall, Alert props; Subnet-grid, Namespace-boundary terrain)
- **Audio SFX spec** (Section 02): 9-sound procurement spec in `assets/audio/spec/` — no binaries, spec-only for Howler.js / Three.js PositionalAudio
- **Identity assets** (Section 03): Keycloak login backgrounds (1920×1080), DocuSeal letterheads (1240×220), shared OG template (1200×630)
- **Arena HUD** (Section 04): Full-screen HUD frame overlay + Shield/Speed pickup SVGs (256×256)

## Code changes
- `scripts/assets-sync.sh`: add `assets/arena/ → website/public/arena/` sync rule
- `AssetGallery.svelte`: `publicUrl()` now resolves `arena/*` file paths to `/arena/*` public URLs so arena SVGs display previews in the admin gallery
- `20260520_seed_asset_pack_02.sql`: 29 `assets.registry` upserts with tags (`brett`, `mentolder`, `korczewski`, `identity`, `arena`, `coaching`, `devops`) and metadata (brand, dimensions, usage, pack)

## Test plan
- [x] `task test:all` — all offline tests green
- [ ] After merge: run `task feature:website` to rebuild both clusters (picks up new `public/` files)
- [ ] After website deploy: run `task assets:index ENV=mentolder` + `ENV=korczewski` (or apply migration) to seed assets.registry — then `/admin/assets` shows all 29 new entries with preview thumbnails

🤖 Generated with [Claude Code](https://claude.com/claude-code)