### PR TITLE
feat(arena+brett): 1v3 lobby mode + co-op wave survival

### DIFF
--- a/arena-server/src/game/tick.ts
+++ b/arena-server/src/game/tick.ts
@@ -37,6 +37,8 @@ export interface TickInit {
   matchId: string;
   players: Map<string, PlayerSlot>;
   bots: Map<string, BotAI>;
+  oneVsThree?: boolean;
+  hostKey?: string;
 }
 
 const WASD_DX = [0, 0, 0.707, 1, 0.707, 0, -0.707, -1, -0.707];
@@ -51,10 +53,14 @@ export class Tick {
   private readonly matchId: string;
   private matchElapsedMs = 0;
   private stopped = false;
+  private readonly oneVsThree: boolean;
+  private readonly hostKey: string | undefined;
 
   constructor(init: TickInit, private deps: TickDeps) {
     this.matchId = init.matchId;
     this.bots = init.bots;
+    this.oneVsThree = init.oneVsThree ?? false;
+    this.hostKey = init.hostKey;
 
     const spawns = CONCRETE_ARENA.spawns;
     const players: Record<string, PlayerState> = {};
@@ -257,6 +263,19 @@ export class Tick {
 
     // --- Phase 5: Win condition ---
     const alivePlayers = Object.values(this.state.players).filter(p => p.alive);
+
+    // 1v3: host death = immediate defeat (bots win)
+    if (this.oneVsThree && this.hostKey &&
+        this.state.everAliveCount >= 2 &&
+        !this.state.players[this.hostKey]?.alive) {
+      events.push({ e: 'slow-mo' });
+      if (events.length > 0) this.deps.broadcastEvent(this.matchId, events);
+      const results = this.buildResults(null);
+      this.stop();
+      this.deps.onEnd(null, results);
+      return;
+    }
+
     if (alivePlayers.length <= 1 && this.state.everAliveCount >= 2) {
       const winner = alivePlayers[0]?.key ?? null;
       events.push({ e: 'slow-mo' });

--- a/arena-server/src/http/routes.ts
+++ b/arena-server/src/http/routes.ts
@@ -41,6 +41,15 @@ export function makeRoutes(deps: { lc: Lifecycle; repo: Repo; auth: AuthMiddlewa
     res.status(201).json(out);
   });
 
+  r.post('/lobby/open-1v3', requireUser, requireAdmin, (req, res) => {
+    const out = deps.lc.open({
+      hostKey: req.userKey!,
+      hostName: req.user!.displayName,
+      mode: 'one-v-three',
+    });
+    res.status(201).json(out);
+  });
+
   r.get('/match/:id', requireUser, async (req, res) => {
     const rows = await deps.repo.getRecentMatches(50);
     const m = rows.find(r => r.id === req.params.id);

--- a/arena-server/src/lobby/lifecycle.test.ts
+++ b/arena-server/src/lobby/lifecycle.test.ts
@@ -44,12 +44,12 @@ describe('Lifecycle', () => {
     expect(registry.getLobby(code)!.phase).toBe('starting');
   });
 
-  it('openSolo marks lobby as solo and holds at open until host starts it', () => {
+  it('openSolo marks lobby as one-v-three and holds at open until host starts it', () => {
     const lc = new Lifecycle({ onBroadcast: () => {}, persist: { insertLobby: async () => {}, updateLobbyPhase: async () => {} } as any, bc: { emitMatchSnapshot: vi.fn(), emitMatchDiff: vi.fn(), emitMatchEvent: vi.fn(), emitMatchEnd: vi.fn() } as any });
     const { code } = lc.openSolo({ hostKey: 'patrick@mentolder', hostName: 'Patrick' });
     const lobby = registry.getLobby(code)!;
     expect(lobby.phase).toBe('open');
-    expect(lobby.solo).toBe(true);
+    expect(lobby.mode).toBe('one-v-three');
     expect(lobby.players.size).toBe(1);
     lc.startSolo(code);
     expect(lobby.phase).toBe('starting');

--- a/arena-server/src/lobby/lifecycle.test.ts
+++ b/arena-server/src/lobby/lifecycle.test.ts
@@ -65,4 +65,44 @@ describe('Lifecycle', () => {
     lc.startSolo(code);
     expect(registry.getLobby(code)!.phase).toBe('open');
   });
+
+  describe('1v3 mode', () => {
+    function makeLc() {
+      return new Lifecycle({
+        onBroadcast: () => {},
+        persist: { insertLobby: async () => {}, updateLobbyPhase: async () => {} } as any,
+        bc: { emitMatchSnapshot: vi.fn(), emitMatchDiff: vi.fn(), emitMatchEvent: vi.fn(), emitMatchEnd: vi.fn() } as any,
+      });
+    }
+
+    it('open() with mode one-v-three sets lobby.mode', () => {
+      const lc = makeLc();
+      const { code } = lc.open({ hostKey: 'patrick@mentolder', hostName: 'Patrick', mode: 'one-v-three' });
+      expect(registry.getLobby(code)!.mode).toBe('one-v-three');
+    });
+
+    it('openSolo() sets mode one-v-three (backwards compat)', () => {
+      const lc = makeLc();
+      const { code } = lc.openSolo({ hostKey: 'patrick@mentolder', hostName: 'Patrick' });
+      expect(registry.getLobby(code)!.mode).toBe('one-v-three');
+    });
+
+    it('open() defaults to ffa when no mode given', () => {
+      const lc = makeLc();
+      const { code } = lc.open({ hostKey: 'patrick@mentolder', hostName: 'Patrick' });
+      expect(registry.getLobby(code)!.mode).toBe('ffa');
+    });
+
+    it('1v3 lobby fills 3 bots on toStarting', () => {
+      const lc = makeLc();
+      const { code } = lc.openSolo({ hostKey: 'patrick@mentolder', hostName: 'Patrick' });
+      const lobby = registry.getLobby(code)!;
+      expect(lobby.players.size).toBe(1);
+      lc.startSolo(code);
+      expect(lobby.phase).toBe('starting');
+      expect(lobby.players.size).toBe(4);
+      const bots = [...lobby.players.values()].filter(p => p.isBot);
+      expect(bots).toHaveLength(3);
+    });
+  });
 });

--- a/arena-server/src/lobby/lifecycle.ts
+++ b/arena-server/src/lobby/lifecycle.ts
@@ -19,7 +19,7 @@ export interface LifecycleDeps {
   bc: Broadcasters;
 }
 
-export interface OpenRequest { hostKey: string; hostName: string; }
+export interface OpenRequest { hostKey: string; hostName: string; mode?: 'ffa' | 'one-v-three'; }
 export interface OpenResult { code: string; expiresAt: number; }
 
 export class Lifecycle {
@@ -43,6 +43,7 @@ export class Lifecycle {
       openedAt: now, expiresAt,
       players: new Map([[host.key, host]]),
       rematchYes: new Set(), timers: {},
+      mode: req.mode ?? 'ffa',
     };
     putLobby(lobby);
     this.deps.persist.insertLobby({ code, phase: 'open', hostKey: req.hostKey, expiresAt: new Date(expiresAt) })
@@ -53,16 +54,13 @@ export class Lifecycle {
   }
 
   /**
-   * Solo mode: open a lobby with just the host and a `solo` flag.
+   * Solo mode: open a lobby with just the host in one-v-three mode.
    * The 5s starting countdown is held until the host's WS connects
    * (see `startSolo`), so the client has time to render the lobby
    * scene and the match snapshot.
    */
   openSolo(req: OpenRequest): OpenResult {
-    const out = this.open(req);
-    const lobby = getLobby(out.code);
-    if (lobby) lobby.solo = true;
-    return out;
+    return this.open({ ...req, mode: 'one-v-three' });
   }
 
   /**
@@ -80,7 +78,7 @@ export class Lifecycle {
    */
   startSolo(code: string): void {
     const lobby = getLobby(code);
-    if (!lobby || !lobby.solo || lobby.phase !== 'open') return;
+    if (!lobby || lobby.mode !== 'one-v-three' || lobby.phase !== 'open') return;
     this.toStarting(code);
   }
 

--- a/arena-server/src/lobby/lifecycle.ts
+++ b/arena-server/src/lobby/lifecycle.ts
@@ -134,8 +134,12 @@ export class Lifecycle {
       if (player.isBot) bots.set(player.key, new BotAI(player.key, grid));
     }
 
+    const nonHostPlayers = [...lobby.players.values()].filter(p => p.key !== lobby.hostKey);
+    const allBots = nonHostPlayers.every(p => p.isBot);
+    const isOneVsThree = lobby.mode === 'one-v-three' && allBots;
+
     const tick = new Tick(
-      { matchId, players: lobby.players, bots },
+      { matchId, players: lobby.players, bots, oneVsThree: isOneVsThree, hostKey: lobby.hostKey },
       {
         broadcastSnapshot: (mid, state) => this.deps.bc.emitMatchSnapshot(code, mid, state),
         broadcastDiff: (mid, t, ops) => this.deps.bc.emitMatchDiff(code, mid, t, ops),

--- a/arena-server/src/lobby/registry.ts
+++ b/arena-server/src/lobby/registry.ts
@@ -10,7 +10,7 @@ export interface Lobby {
   players: Map<string, PlayerSlot>;     // key = sub@brand or bot_<n>
   rematchYes: Set<string>;
   spectators?: Set<string>;
-  solo?: boolean;
+  mode: 'ffa' | 'one-v-three';
   timers: { [k: string]: NodeJS.Timeout | undefined };
   tick?: Tick;
 }

--- a/arena-server/src/proto/messages.test.ts
+++ b/arena-server/src/proto/messages.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { PROTOCOL_VERSION, type ClientMsg, type ServerMsg, isClientMsg } from './messages';
 
 describe('protocol', () => {
-  it('exposes version 1', () => {
-    expect(PROTOCOL_VERSION).toBe(1);
+  it('exposes version 2', () => {
+    expect(PROTOCOL_VERSION).toBe(2);
   });
 
   it('round-trips a lobby:join client message', () => {
@@ -17,7 +17,7 @@ describe('protocol', () => {
   it('round-trips a server lobby:state', () => {
     const msg: ServerMsg = {
       t: 'lobby:state', code: 'ZK4M9X', phase: 'open',
-      players: [], expiresAt: Date.now() + 60_000,
+      players: [], expiresAt: Date.now() + 60_000, mode: 'ffa',
     };
     expect(JSON.parse(JSON.stringify(msg)).t).toBe('lobby:state');
   });

--- a/arena-server/src/proto/messages.ts
+++ b/arena-server/src/proto/messages.ts
@@ -1,7 +1,7 @@
 // Mirrored from arena-server/src/proto/messages.ts — CI diff guard enforces sync.
 // When updating messages.ts, update this file too.
 
-export const PROTOCOL_VERSION = 1;
+export const PROTOCOL_VERSION = 2;
 
 export type LobbyPhase = 'open' | 'starting' | 'in-match' | 'slow-mo' | 'results' | 'closed';
 
@@ -69,7 +69,7 @@ export type GameEvent =
   | { e: 'powerup-expire'; player: string; kind: string };
 
 export type ClientMsg =
-  | { t: 'lobby:open' }
+  | { t: 'lobby:open'; mode?: 'ffa' | 'one-v-three' }
   | { t: 'lobby:join'; code: string }
   | { t: 'lobby:ready'; ready: boolean }
   | { t: 'lobby:start' }
@@ -85,7 +85,7 @@ export type ClientMsg =
 
 export type ServerMsg =
   | { t: 'lobby:state'; code: string; phase: LobbyPhase;
-        players: PlayerSlot[]; expiresAt?: number; countdownMs?: number }
+        players: PlayerSlot[]; expiresAt?: number; countdownMs?: number; mode: 'ffa' | 'one-v-three' }
   | { t: 'match:full-snapshot'; tick: number; state: MatchState }
   | { t: 'match:diff'; tick: number; ops: DiffOp[] }
   | { t: 'match:event'; events: GameEvent[] }

--- a/arena-server/src/ws/broadcasters.ts
+++ b/arena-server/src/ws/broadcasters.ts
@@ -14,6 +14,7 @@ export function makeBroadcasters(io: Server) {
         phase: l.phase,
         players: [...l.players.values()],
         expiresAt: l.expiresAt,
+        mode: l.mode,
       };
       to(code).emit('msg', msg);
     },

--- a/arena-server/src/ws/handlers.ts
+++ b/arena-server/src/ws/handlers.ts
@@ -23,6 +23,7 @@ export function attachHandlers(socket: Socket, deps: { lc: Lifecycle; user: Aren
             const stateMsg: ServerMsg = {
               t: 'lobby:state', code: m.code, phase: targetLobby.phase,
               players: [...targetLobby.players.values()], expiresAt: targetLobby.expiresAt,
+              mode: targetLobby.mode,
             };
             socket.emit('msg', stateMsg);
             if ((targetLobby.phase === 'in-match' || targetLobby.phase === 'slow-mo') && targetLobby.tick) {
@@ -30,8 +31,8 @@ export function attachHandlers(socket: Socket, deps: { lc: Lifecycle; user: Aren
               const snap: ServerMsg = { t: 'match:full-snapshot', tick: state.tick, state };
               socket.emit('msg', snap);
             }
-            // Solo lobbies wait for the host's WS connect before counting down.
-            if (targetLobby.solo && targetLobby.phase === 'open' && targetLobby.hostKey === key) {
+            // one-v-three (and legacy solo) lobbies wait for the host's WS connect before counting down.
+            if (targetLobby.mode === 'one-v-three' && targetLobby.phase === 'open' && targetLobby.hostKey === key) {
               deps.lc.startSolo(m.code);
             }
             break;
@@ -42,6 +43,7 @@ export function attachHandlers(socket: Socket, deps: { lc: Lifecycle; user: Aren
             const stateMsg: ServerMsg = {
               t: 'lobby:state', code: m.code, phase: targetLobby.phase,
               players: [...targetLobby.players.values()], expiresAt: targetLobby.expiresAt,
+              mode: targetLobby.mode,
             };
             socket.emit('msg', stateMsg);
             break;

--- a/brett/public/assets/mayhem/ai-bot.js
+++ b/brett/public/assets/mayhem/ai-bot.js
@@ -19,12 +19,23 @@ class MayhemAIBot {
   // callbacks: { onFire(weaponDef, originPos, dirVec, shooterId),
   //              onDeath(botId, killerId),
   //              getGameMode() }
-  constructor({ id, mannequin, colorIndex = 0, callbacks }) {
-    this.id     = id;
+  constructor({ id, mannequin, colorIndex = 0, bossMultiplier = null, callbacks }) {
+    this.isBoss = !!bossMultiplier;
+    const color = bossMultiplier ? '#e74c3c' : BOT_COLORS[colorIndex % BOT_COLORS.length];
     this.avatar = new window.MayhemPlayerAvatar({
-      id, mannequin, local: false, color: BOT_COLORS[colorIndex % BOT_COLORS.length],
+      id, mannequin, local: false, color,
     });
 
+    // Scale boss mannequin root
+    if (bossMultiplier && bossMultiplier.scale && bossMultiplier.scale !== 1.0) {
+      mannequin.root.scale.setScalar(bossMultiplier.scale);
+    }
+
+    this._hp         = bossMultiplier ? bossMultiplier.hp : 1;
+    this._shootRate  = bossMultiplier ? BOT_SHOOT_RATE / bossMultiplier.shootRate : BOT_SHOOT_RATE;
+    this._speed      = bossMultiplier ? BOT_SPEED * bossMultiplier.speed : BOT_SPEED;
+
+    this.id     = id;
     this._x = mannequin.root.position.x;
     this._z = mannequin.root.position.z;
     this._facingY    = Math.random() * Math.PI * 2;
@@ -32,7 +43,7 @@ class MayhemAIBot {
     this._wanderDx   = 0;
     this._wanderDz   = 1;
     this._wanderTtl  = 0;
-    this._shootTimer = Math.random() * BOT_SHOOT_RATE; // stagger initial shots
+    this._shootTimer = Math.random() * this._shootRate; // stagger initial shots
 
     this._onFire    = callbacks.onFire;
     this._onDeath   = callbacks.onDeath;
@@ -85,8 +96,8 @@ class MayhemAIBot {
     }
 
     // Move and clamp
-    this._x = Math.max(-ARENA_HALF, Math.min(ARENA_HALF, this._x + moveX * BOT_SPEED * dt));
-    this._z = Math.max(-ARENA_HALF, Math.min(ARENA_HALF, this._z + moveZ * BOT_SPEED * dt));
+    this._x = Math.max(-ARENA_HALF, Math.min(ARENA_HALF, this._x + moveX * this._speed * dt));
+    this._z = Math.max(-ARENA_HALF, Math.min(ARENA_HALF, this._z + moveZ * this._speed * dt));
 
     // Drive the avatar via the same setNetState path real network messages use
     const moving = moveX !== 0 || moveZ !== 0;
@@ -103,7 +114,7 @@ class MayhemAIBot {
       this._shootTimer -= dt;
       if (this._shootTimer <= 0) {
         this._shoot(target);
-        this._shootTimer = BOT_SHOOT_RATE;
+        this._shootTimer = this._shootRate;
       }
     }
   }
@@ -116,17 +127,25 @@ class MayhemAIBot {
     const damage = weaponDef ? weaponDef.damage
                  : weaponKey === 'vehicle' ? 30 : 15;
 
-    this.avatar.applyDamage(damage);
     this.avatar.applyHit(impulse, weaponKey || 'flail');
 
-    if (this.avatar.isDead) {
-      this._aiState = 'dead';
-      this._onDeath(this.id, shooterId);
+    if (this.isBoss) {
+      // Boss bots track HP as an integer hit-point pool; ignore avatar HP
+      this._hp -= 1;
+      if (this._hp > 0) return; // still alive
+    } else {
+      this.avatar.applyDamage(damage);
+      if (!this.avatar.isDead) return; // still alive
+    }
 
-      const mode = this._getMode ? this._getMode() : 'warmup';
-      if (mode === 'deathmatch') {
-        setTimeout(() => this._respawn(), DEATHMATCH_RESPAWN_S * 1000);
-      }
+    // Bot is dead
+    this._aiState = 'dead';
+    this.avatar.applyDamage(this.avatar.hp); // ensure avatar.isDead === true
+    this._onDeath(this.id, shooterId);
+
+    const mode = this._getMode ? this._getMode() : 'warmup';
+    if (mode === 'deathmatch') {
+      setTimeout(() => this._respawn(), DEATHMATCH_RESPAWN_S * 1000);
     }
   }
 
@@ -138,13 +157,16 @@ class MayhemAIBot {
     this.avatar.resetHp();
     this.avatar.state = window.MayhemPlayerAvatar.STATE.IDLE;
     this._aiState = 'wander';
-    this._shootTimer = Math.random() * BOT_SHOOT_RATE;
+    this._shootTimer = Math.random() * this._shootRate;
   }
 
   _findNearest(allAvatars) {
+    const inCoop = this._getMode && this._getMode() === 'coop';
     let best = null, bestDist = Infinity;
     for (const [id, av] of allAvatars) {
       if (id === this.id || av.isDead) continue;
+      // In co-op, bots only target human players (not other bots)
+      if (inCoop && id.startsWith('bot-')) continue;
       const d = this._dist(av);
       if (d < bestDist) { best = av; bestDist = d; }
     }

--- a/brett/public/assets/mayhem/game-mode.js
+++ b/brett/public/assets/mayhem/game-mode.js
@@ -3,9 +3,23 @@
 // Warmup   — no elimination, manual respawn (R key), death is ragdoll only
 // Deathmatch — auto respawn after 3 s, kill counter HUD
 // LMS (Last Man Standing) — no respawn; last survivor wins; spectator cam on death
+// Coop — co-operative wave survival; bots attack humans only; 10-wave escalation
 
-const MODES = Object.freeze({ WARMUP: 'warmup', DEATHMATCH: 'deathmatch', LMS: 'lms' });
+const MODES = Object.freeze({ WARMUP: 'warmup', DEATHMATCH: 'deathmatch', LMS: 'lms', COOP: 'coop' });
 const DEATHMATCH_RESPAWN_MS = 3000;
+
+const WAVE_DEFS = [
+  { wave: 1,  boss: false, count: 2 },
+  { wave: 2,  boss: false, count: 3 },
+  { wave: 3,  boss: false, count: 3 },
+  { wave: 4,  boss: false, count: 4 },
+  { wave: 5,  boss: true,  count: 1, multiplier: { hp: 3, shootRate: 1.5, speed: 1.2, scale: 1.0 } },
+  { wave: 6,  boss: false, count: 3 },
+  { wave: 7,  boss: false, count: 4 },
+  { wave: 8,  boss: false, count: 4 },
+  { wave: 9,  boss: false, count: 5 },
+  { wave: 10, boss: true,  count: 1, multiplier: { hp: 6, shootRate: 2.0, speed: 1.3, scale: 1.5 } },
+];
 
 class GameModeManager {
   // onRespawn(playerId)    — called when a player should be respawned
@@ -21,6 +35,15 @@ class GameModeManager {
     this._deadSet      = new Set();
     this._spectating   = false;
     this._canRespawn   = false;       // Warmup: toggled by R key
+    // Co-op wave state
+    this._wave          = 0;
+    this._enemiesAlive  = new Set();
+    this._deadPlayers   = new Set();
+    this._coopPhase     = 'idle';
+    this._onWaveStart   = null;
+    this._onWaveComplete = null;
+    this._onCoopWin     = null;
+    this._onCoopLose    = null;
   }
 
   setMode(mode) {
@@ -32,6 +55,11 @@ class GameModeManager {
     this._deadSet.clear();
     this._spectating = false;
     this._canRespawn = false;
+    // Clear co-op state on any mode change
+    this._wave = 0;
+    this._enemiesAlive.clear();
+    this._deadPlayers.clear();
+    this._coopPhase = 'idle';
     this._onModeChange(mode);
   }
 
@@ -84,6 +112,65 @@ class GameModeManager {
   isSpectating()   { return this._spectating; }
   getKills(id)     { return this._killCounts.get(id) || 0; }
 
+  // ── Co-op ──────────────────────────────────────────────────────────────────
+
+  setCoopCallbacks({ onWaveStart, onWaveComplete, onCoopWin, onCoopLose }) {
+    this._onWaveStart    = onWaveStart    || (() => {});
+    this._onWaveComplete = onWaveComplete || (() => {});
+    this._onCoopWin      = onCoopWin      || (() => {});
+    this._onCoopLose     = onCoopLose     || (() => {});
+  }
+
+  startCoop() {
+    if (this.mode !== MODES.COOP || this._coopPhase !== 'idle') return;
+    this._startWave(1);
+  }
+
+  _startWave(n) {
+    if (n > WAVE_DEFS.length) {
+      this._coopPhase = 'won';
+      this._onCoopWin && this._onCoopWin();
+      return;
+    }
+    this._wave = n;
+    this._enemiesAlive.clear();
+    this._deadPlayers.clear();
+    this._coopPhase = 'in-wave';
+    const def = WAVE_DEFS[n - 1];
+    this._onWaveStart && this._onWaveStart({ wave: n, def });
+  }
+
+  handleEnemyDeath(botId) {
+    this._enemiesAlive.delete(botId);
+    if (this._coopPhase !== 'in-wave') return;
+    if (this._enemiesAlive.size === 0) {
+      this._coopPhase = 'between';
+      this._onWaveComplete && this._onWaveComplete({ wave: this._wave });
+      setTimeout(() => this._startWave(this._wave + 1), 3000);
+    }
+  }
+
+  handlePlayerDeathCoop(playerId, allHumanIds) {
+    this._deadPlayers.add(playerId);
+    if (this._coopPhase !== 'in-wave') return;
+    const allDead = allHumanIds.every(id => this._deadPlayers.has(id));
+    if (allDead) {
+      this._coopPhase = 'lost';
+      this._onCoopLose && this._onCoopLose();
+    }
+  }
+
+  registerEnemy(botId) {
+    this._enemiesAlive.add(botId);
+  }
+
+  getCoopWaveDef() {
+    return WAVE_DEFS[this._wave - 1] ?? null;
+  }
+
+  getCoopPhase() { return this._coopPhase; }
+  getCoopWave()  { return this._wave; }
+
   // Returns HUD data for rendering.
   getHudData(avatars) {
     const entries = [];
@@ -101,5 +188,5 @@ class GameModeManager {
 }
 
 if (typeof window !== 'undefined') {
-  window.MayhemGameMode = { GameModeManager, MODES };
+  window.MayhemGameMode = { GameModeManager, MODES, WAVE_DEFS };
 }

--- a/brett/public/assets/mayhem/mayhem.js
+++ b/brett/public/assets/mayhem/mayhem.js
@@ -39,6 +39,9 @@ const Mayhem = (() => {
   let hud         = null;
   let playerId    = null;
   let _lastWeaponKey = null;
+  let isHost      = false;
+  let deadHumans  = new Set();
+  let coopStartTimer = null;
 
   const input = {
     forward: false, backward: false, left: false, right: false,
@@ -133,6 +136,9 @@ const Mayhem = (() => {
       (victimId, weaponKey, shooterId) => sendWeaponHit(victimId, weaponKey, shooterId),
     );
 
+    // Determine if this client is the host (first to join — no remote humans yet)
+    isHost = [...remoteAvatars.keys()].filter(id => !id.startsWith('bot-')).length === 0;
+
     // Game mode
     gameMode = new window.MayhemGameMode.GameModeManager({
       onRespawn: (pid) => {
@@ -140,6 +146,28 @@ const Mayhem = (() => {
       },
       onModeChange: (mode) => updateHud(),
       onLmsEnd: (result) => showLmsResult(result),
+    });
+
+    // Co-op callbacks (only host drives wave progression)
+    gameMode.setCoopCallbacks({
+      onWaveStart: ({ wave, def }) => {
+        deadHumans.clear();
+        spawnWave(def);
+        send({ type: 'wave_start', wave, enemyCount: def.count, boss: def.boss ?? false });
+        updateHud();
+      },
+      onWaveComplete: ({ wave }) => {
+        send({ type: 'wave_complete', wave });
+        setTimeout(() => {
+          for (const id of deadHumans) {
+            if (id === playerId) localRespawn();
+          }
+          deadHumans.clear();
+          updateHud();
+        }, 3000);
+      },
+      onCoopWin:  () => { send({ type: 'coop_win' });  showCoopBanner('YOU WIN — all waves cleared!'); },
+      onCoopLose: () => { send({ type: 'coop_lose' }); showCoopBanner('DEFEATED'); },
     });
 
     // HUD
@@ -189,9 +217,48 @@ const Mayhem = (() => {
     remoteAvatars.set(botId, bot.avatar);
   }
 
+  // ── Co-op wave spawning ───────────────────────────────────────────────────
+  function spawnWave(def) {
+    // Remove existing bots
+    for (const bot of aiBots.values()) { bot.remove(scene); remoteAvatars.delete(bot.id); }
+    aiBots.clear();
+
+    for (let i = 0; i < def.count; i++) {
+      const botId = 'bot-' + crypto.randomUUID();
+      const pos   = nextSpawnPoint();
+      const botMannequin = makeMannequin(botId, pos);
+      const bot = new window.MayhemAIBot({
+        id: botId,
+        mannequin: botMannequin,
+        colorIndex: i,
+        bossMultiplier: def.boss ? (def.multiplier || null) : null,
+        callbacks: {
+          onFire: (weaponDef, originPos, dirVec, shooterId) => {
+            if (projectileMgr) projectileMgr.spawn(weaponDef, originPos, dirVec, shooterId);
+          },
+          onDeath: (id, killerId) => {
+            aiBots.delete(id);
+            remoteAvatars.delete(id);
+            if (killerId && killerId !== id) gameMode?.handleKill(killerId);
+            gameMode?.handleEnemyDeath(id);
+            updateHud();
+          },
+          getGameMode: () => gameMode?.mode || 'warmup',
+        },
+      });
+      if (bot.avatar && bot.weaponDef) bot.avatar.setWeapon(bot.weaponDef);
+      aiBots.set(botId, bot);
+      remoteAvatars.set(botId, bot.avatar);
+      gameMode?.registerEnemy(botId);
+    }
+  }
+
   function stop() {
     hideBanner();
     destroyHud();
+    deadHumans.clear();
+    if (coopStartTimer) { clearTimeout(coopStartTimer); coopStartTimer = null; }
+    isHost = false;
     if (localAvatar) {
       send({ type: 'player_leave', playerId });
       localAvatar.remove(scene);
@@ -245,6 +312,12 @@ const Mayhem = (() => {
   }
 
   function applyHitLocally(victimId, weaponKey, impulse, shooterId) {
+    // Co-op: no friendly fire between human players
+    if (gameMode?.mode === 'coop') {
+      const shooterIsHuman = shooterId && !shooterId.startsWith('bot-');
+      const victimIsHuman  = victimId  && !victimId.startsWith('bot-');
+      if (shooterIsHuman && victimIsHuman) return;
+    }
     if (victimId === playerId && localAvatar) {
       processLocalHit(weaponKey, impulse, shooterId);
     } else {
@@ -279,8 +352,14 @@ const Mayhem = (() => {
 
     if (localAvatar.isDead) {
       send({ type: 'player_death', playerId, killerId: shooterId });
-      gameMode?.handleDeath(playerId, true);
       if (shooterId && shooterId !== playerId) gameMode?.handleKill(shooterId);
+      if (gameMode?.mode === 'coop') {
+        deadHumans.add(playerId);
+        const allHumanIds = [playerId, ...[...remoteAvatars.keys()].filter(id => !id.startsWith('bot-'))];
+        gameMode.handlePlayerDeathCoop(playerId, allHumanIds);
+      } else {
+        gameMode?.handleDeath(playerId, true);
+      }
     }
     updateHud();
   }
@@ -416,6 +495,10 @@ const Mayhem = (() => {
 
       case 'game_mode_change':
         if (gameMode && msg.mode) gameMode.setMode(msg.mode);
+        if (msg.mode === 'coop' && isHost) {
+          if (coopStartTimer) clearTimeout(coopStartTimer);
+          coopStartTimer = setTimeout(() => gameMode?.startCoop(), 3000);
+        }
         updateHud();
         break;
 
@@ -491,6 +574,27 @@ const Mayhem = (() => {
 
       case 'vehicle_spawn':
         if (!vehicles.has(msg.vehicleId)) spawnVehicleFromMsg(msg);
+        break;
+
+      case 'wave_start':
+        // Non-host clients spawn their own copy of the wave bots
+        if (!isHost && gameMode) {
+          const def = window.MayhemGameMode.WAVE_DEFS[msg.wave - 1];
+          if (def) {
+            deadHumans.clear();
+            spawnWave(def);
+            updateHud();
+          }
+        }
+        break;
+
+      case 'coop_wave_sync':
+        // Late-join sync: spawn bots for the current wave
+        if (gameMode && msg.wave > 0) {
+          const def = window.MayhemGameMode.WAVE_DEFS[msg.wave - 1];
+          if (def) spawnWave(def);
+          updateHud();
+        }
         break;
     }
   }
@@ -588,6 +692,16 @@ const Mayhem = (() => {
   }
 
   // ── Helpers ───────────────────────────────────────────────────────────────
+  function showCoopBanner(text) {
+    const div = document.createElement('div');
+    div.style.cssText = 'position:fixed;top:50%;left:50%;transform:translate(-50%,-50%);' +
+      'background:#1a1a2e;border:2px solid #c9aa71;color:#c9aa71;font-family:monospace;' +
+      'font-size:32px;padding:24px 48px;z-index:9999;text-align:center;border-radius:8px;';
+    div.textContent = text;
+    document.body.appendChild(div);
+    setTimeout(() => div.remove(), 5000);
+  }
+
   function showBanner() {
     if (banner) return;
     banner = document.createElement('div');

--- a/brett/public/assets/mayhem/mayhem.js
+++ b/brett/public/assets/mayhem/mayhem.js
@@ -632,6 +632,36 @@ const Mayhem = (() => {
   function updateHud() {
     if (!hud) return;
     updateHudFrame();
+    updateCoopHud();
+  }
+
+  function updateCoopHud() {
+    const hudEl = document.getElementById('coop-hud');
+    if (!hudEl || !gameMode) return;
+    const isCoop = gameMode.mode === 'coop';
+    hudEl.style.display = isCoop ? 'flex' : 'none';
+    if (!isCoop) return;
+    const wave    = gameMode.getCoopWave();
+    const enemies = gameMode._enemiesAlive.size;
+    const def     = gameMode.getCoopWaveDef();
+    const waveLabel = document.getElementById('coop-wave-label');
+    const enemyCount = document.getElementById('coop-enemy-count');
+    const progressBar = document.getElementById('coop-progress-bar');
+    if (waveLabel)   waveLabel.textContent = `WELLE ${wave} / 10`;
+    if (enemyCount)  enemyCount.innerHTML  = `Feinde: <strong>${enemies}</strong>`;
+    if (progressBar) progressBar.style.width = `${(wave / 10) * 100}%`;
+    const bossWrap = document.getElementById('boss-hp-wrap');
+    const bossBar  = document.getElementById('boss-hp-bar');
+    const isBossWave = def && def.boss;
+    if (bossWrap) bossWrap.style.display = isBossWave ? 'block' : 'none';
+    if (isBossWave && def && bossBar) {
+      const maxHp = def.multiplier.hp;
+      let currentHp = 0;
+      for (const bot of aiBots.values()) {
+        if (bot.isBoss) { currentHp = bot._hp; break; }
+      }
+      bossBar.style.width = `${Math.max(0, (currentHp / maxHp) * 100)}%`;
+    }
   }
 
   function updateHudFrame() {

--- a/brett/public/index.html
+++ b/brett/public/index.html
@@ -155,6 +155,28 @@
     </div>
   </div>
   <div id="status-pill">Klick = Figur wählen · Doppelklick Boden = Figur teleportieren / neue Figur</div>
+
+  <!-- Co-op Wave HUD -->
+  <div id="coop-hud" style="display:none;position:fixed;top:12px;left:50%;transform:translateX(-50%);
+    background:rgba(10,10,20,.82);border:1px solid #4a7;border-radius:8px;
+    padding:8px 20px;font-family:monospace;color:#ccd;font-size:13px;
+    flex-direction:column;gap:4px;min-width:220px;z-index:200;">
+    <div style="display:flex;justify-content:space-between;align-items:center;">
+      <span style="color:#c9aa71;font-weight:bold;letter-spacing:.1em;">CO-OP</span>
+      <span id="coop-wave-label" style="font-size:15px;font-weight:bold;color:#fff;">WELLE 1 / 10</span>
+      <span id="coop-enemy-count" style="color:#e87;">Feinde: <strong>0</strong></span>
+    </div>
+    <div style="background:#1e1e1e;border-radius:4px;overflow:hidden;height:4px;">
+      <div id="coop-progress-bar" style="width:10%;height:100%;background:linear-gradient(90deg,#4a7,#c9aa71);transition:width .5s;"></div>
+    </div>
+    <div id="boss-hp-wrap" style="display:none;margin-top:4px;">
+      <div style="color:#f44;font-size:11px;margin-bottom:2px;">&#9888; BOSS HP</div>
+      <div style="background:#1e1e1e;border-radius:4px;overflow:hidden;height:6px;">
+        <div id="boss-hp-bar" style="width:100%;height:100%;background:#f44;transition:width .3s;"></div>
+      </div>
+    </div>
+  </div>
+
   <script src="three.min.js"></script>
   <script>
     // ===== Brett Mannequin Focus =====

--- a/brett/server.js
+++ b/brett/server.js
@@ -335,14 +335,17 @@ const RELAY_TYPES = [
   'damage_event','death_event','pickup_request','pickup_taken','pickup_spawned',
   'snapshot','request_state_snapshot',
   'bot_spawn','bot_despawn','round_reset',
+  'wave_start','wave_complete','coop_win','coop_lose','coop_wave_sync',
 ];
 
 const TRANSIENT_TYPES = new Set([
   'jump','player_join','player_state','player_leave','hit','vehicle_spawn',
   'hp_update','player_death','player_respawn',
+  'wave_start','wave_complete','coop_win','coop_lose','coop_wave_sync',
 ]);
 
-const lmsAlive = new Map(); // roomToken -> Set<playerId>
+const lmsAlive  = new Map(); // roomToken -> Set<playerId>
+const roomMeta  = new Map(); // roomToken -> { coopWave: number }
 
 function handleLmsDeath(room, victimId) {
   const alive = lmsAlive.get(room);
@@ -592,6 +595,11 @@ wss.on('connection', (ws, req) => {
 
         const state = buildStateFromMutations(msg.room);
         ws.send(JSON.stringify({ type: 'snapshot', figures: state.figures, optik: state.optik, stiffness: state.stiffness ?? 0.65 }));
+        // Sync co-op wave state to the newly joined client
+        const meta = roomMeta.get(msg.room);
+        if (meta && meta.coopWave > 0) {
+          try { ws.send(JSON.stringify({ type: 'coop_wave_sync', wave: meta.coopWave })); } catch {}
+        }
         broadcastInfo(msg.room);
         return;
       }
@@ -621,6 +629,9 @@ wss.on('connection', (ws, req) => {
           if (winner !== null || draw) {
             broadcast(room, draw ? { type: 'lms_draw' } : { type: 'lms_winner', playerId: winner });
           }
+        } else if (msg.type === 'wave_start' && typeof msg.wave === 'number') {
+          if (!roomMeta.has(room)) roomMeta.set(room, { coopWave: 0 });
+          roomMeta.get(room).coopWave = msg.wave;
         } else if (msg.type === 'clear') {
           flushImmediate(room).catch(err => console.error('[brett] flush:', err));
         }
@@ -648,7 +659,7 @@ wss.on('connection', (ws, req) => {
             break;
           }
           case 'admin_mode_set': {
-            if (!['warmup','deathmatch','lms'].includes(msg.mode)) return;
+            if (!['warmup','deathmatch','lms','coop'].includes(msg.mode)) return;
             const inner = { type: 'game_mode_change', mode: msg.mode };
             applyMutation(adminRoom, inner);
             broadcast(adminRoom, inner);

--- a/docs/superpowers/plans/2026-05-20-arena-brett-1v3.md
+++ b/docs/superpowers/plans/2026-05-20-arena-brett-1v3.md
@@ -1,0 +1,1244 @@
+---
+ticket_id: T000076
+title: Arena 1v3 + Brett Co-op Waves Implementation Plan
+domains: []
+status: active
+pr_number: null
+---
+
+# Arena 1v3 + Brett Co-op Waves Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a 1v3-vs-bots lobby mode to arena-server (korczewski) and a 10-wave co-op mode to Brett (mentolder).
+
+**Architecture:** Arena 1v3 extends the existing lobby/tick pipeline with a new `mode` field and an early-exit win condition when the host dies. Brett co-op adds a wave state machine to `GameModeManager` and three small bot-system changes (boss multiplier, team targeting, friendly-fire skip), all synced via server-relay.
+
+**Tech Stack:** TypeScript/Express/Socket.IO (arena-server), vanilla JS/Three.js (brett), React/TSX (website), Astro (website pages), vitest (arena tests), Node built-in test runner (brett)
+
+---
+
+## Part 1 — Arena 1v3
+
+### Task 1: Protocol + Registry — add `mode` field
+
+**Files:**
+- Modify: `arena-server/src/proto/messages.ts`
+- Modify: `arena-server/src/lobby/registry.ts`
+- Modify: `website/src/components/arena/shared/lobbyTypes.ts`
+
+- [ ] **Step 1: Bump PROTOCOL_VERSION and add mode type to messages.ts**
+
+In `arena-server/src/proto/messages.ts`, make these exact changes:
+
+```typescript
+// line 4 — change:
+export const PROTOCOL_VERSION = 2;
+
+// ClientMsg — change the lobby:open variant (line ~82):
+  | { t: 'lobby:open'; mode?: 'ffa' | 'one-v-three' }
+
+// ServerMsg — change the lobby:state variant (line ~95):
+  | { t: 'lobby:state'; code: string; phase: LobbyPhase;
+        players: PlayerSlot[]; expiresAt?: number; countdownMs?: number;
+        mode: 'ffa' | 'one-v-three' }
+```
+
+- [ ] **Step 2: Replace `solo?` with `mode` in Lobby registry**
+
+In `arena-server/src/lobby/registry.ts`:
+
+```typescript
+export interface Lobby {
+  code: string;
+  phase: 'open' | 'starting' | 'in-match' | 'slow-mo' | 'results' | 'closed';
+  hostKey: string;
+  openedAt: number;
+  expiresAt: number;
+  players: Map<string, PlayerSlot>;
+  rematchYes: Set<string>;
+  spectators?: Set<string>;
+  mode: 'ffa' | 'one-v-three';   // replaces solo?: boolean
+  timers: { [k: string]: NodeJS.Timeout | undefined };
+  tick?: Tick;
+}
+```
+
+- [ ] **Step 3: Mirror changes in lobbyTypes.ts (CI diff-guard)**
+
+In `website/src/components/arena/shared/lobbyTypes.ts`:
+
+```typescript
+// line 4:
+export const PROTOCOL_VERSION = 2;
+
+// ClientMsg — change lobby:open variant:
+  | { t: 'lobby:open'; mode?: 'ffa' | 'one-v-three' }
+
+// ServerMsg — change lobby:state variant:
+  | { t: 'lobby:state'; code: string; phase: LobbyPhase;
+        players: PlayerSlot[]; expiresAt?: number; countdownMs?: number;
+        mode: 'ffa' | 'one-v-three' }
+```
+
+- [ ] **Step 4: Verify CI diff-guard passes**
+
+```bash
+cd /tmp/wt-arena-brett-1v3
+diff arena-server/src/proto/messages.ts website/src/components/arena/shared/lobbyTypes.ts
+```
+
+Expected: exit 0 (no diff).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /tmp/wt-arena-brett-1v3
+git add arena-server/src/proto/messages.ts arena-server/src/lobby/registry.ts \
+  website/src/components/arena/shared/lobbyTypes.ts
+git commit -m "feat(arena): add mode field to protocol + lobby registry (PROTOCOL_VERSION 2)"
+```
+
+---
+
+### Task 2: Lifecycle — open() accepts mode, broadcasters emit mode
+
+**Files:**
+- Modify: `arena-server/src/lobby/lifecycle.ts`
+- Modify: `arena-server/src/ws/broadcasters.ts`
+
+- [ ] **Step 1: Update OpenRequest and open() to accept mode**
+
+In `arena-server/src/lobby/lifecycle.ts`:
+
+```typescript
+// Change OpenRequest:
+export interface OpenRequest {
+  hostKey: string;
+  hostName: string;
+  mode?: 'ffa' | 'one-v-three';
+}
+
+// In open(), change the Lobby construction (around line 41-46):
+    const lobby: Lobby = {
+      code, phase: 'open', hostKey: req.hostKey,
+      openedAt: now, expiresAt,
+      players: new Map([[host.key, host]]),
+      rematchYes: new Set(), timers: {},
+      mode: req.mode ?? 'ffa',
+    };
+```
+
+- [ ] **Step 2: Replace openSolo() to use mode instead of solo flag**
+
+In `arena-server/src/lobby/lifecycle.ts`, replace the `openSolo` method (lines 61-66):
+
+```typescript
+  openSolo(req: OpenRequest): OpenResult {
+    return this.open({ ...req, mode: 'one-v-three' });
+  }
+```
+
+And update `startSolo` to check `mode` instead of `solo`:
+
+```typescript
+  startSolo(code: string): void {
+    const lobby = getLobby(code);
+    if (!lobby || lobby.mode !== 'one-v-three' || lobby.phase !== 'open') return;
+    this.toStarting(code);
+  }
+```
+
+- [ ] **Step 3: Include mode in lobby state broadcasts**
+
+In `arena-server/src/ws/broadcasters.ts`, update `emitLobbyState`:
+
+```typescript
+    emitLobbyState(code: string) {
+      const l = getLobby(code);
+      if (!l) return;
+      const msg: ServerMsg = {
+        t: 'lobby:state', code,
+        phase: l.phase,
+        players: [...l.players.values()],
+        expiresAt: l.expiresAt,
+        mode: l.mode,
+      };
+      to(code).emit('msg', msg);
+    },
+```
+
+- [ ] **Step 4: Run existing lifecycle tests to confirm no regression**
+
+```bash
+cd /tmp/wt-arena-brett-1v3/arena-server
+pnpm test -- lifecycle
+```
+
+Expected: all existing lifecycle tests pass. If `openSolo` test checks `lobby.solo === true`, update it to check `lobby.mode === 'one-v-three'`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /tmp/wt-arena-brett-1v3
+git add arena-server/src/lobby/lifecycle.ts arena-server/src/ws/broadcasters.ts
+git commit -m "feat(arena): open() accepts mode, broadcasters emit mode in lobby:state"
+```
+
+---
+
+### Task 3: Tick — 1v3 host-death triggers immediate match end
+
+**Files:**
+- Modify: `arena-server/src/game/tick.ts`
+
+- [ ] **Step 1: Add oneVsThree and hostKey to TickInit**
+
+In `arena-server/src/game/tick.ts`, update the `TickInit` interface (around line 36):
+
+```typescript
+export interface TickInit {
+  matchId: string;
+  players: Map<string, PlayerSlot>;
+  bots: Map<string, BotAI>;
+  oneVsThree?: boolean;
+  hostKey?: string;
+}
+```
+
+Also store it on the class — add to the class body after line 54 (`private readonly matchId: string;`):
+
+```typescript
+  private readonly oneVsThree: boolean;
+  private readonly hostKey: string | undefined;
+```
+
+And initialise in the constructor (after `this.matchId = init.matchId;`):
+
+```typescript
+    this.oneVsThree = init.oneVsThree ?? false;
+    this.hostKey = init.hostKey;
+```
+
+- [ ] **Step 2: Add 1v3 early-exit check to phase 5 win condition**
+
+In `processTick()`, find the Phase 5 block (around line 255) that starts:
+
+```typescript
+    // --- Phase 5: Win condition ---
+    const alivePlayers = Object.values(this.state.players).filter(p => p.alive);
+    if (alivePlayers.length <= 1 && this.state.everAliveCount >= 2) {
+```
+
+Insert the 1v3 check **before** the existing `if`:
+
+```typescript
+    // --- Phase 5: Win condition ---
+    const alivePlayers = Object.values(this.state.players).filter(p => p.alive);
+
+    // 1v3: host death = immediate defeat (bots win)
+    if (this.oneVsThree && this.hostKey &&
+        this.state.everAliveCount >= 2 &&
+        !this.state.players[this.hostKey]?.alive) {
+      events.push({ e: 'slow-mo' });
+      if (events.length > 0) this.deps.broadcastEvent(this.matchId, events);
+      const results = this.buildResults(null);
+      this.stop();
+      this.deps.onEnd(null, results);
+      return;
+    }
+
+    if (alivePlayers.length <= 1 && this.state.everAliveCount >= 2) {
+```
+
+- [ ] **Step 3: Pass oneVsThree + hostKey from lifecycle.toInMatch()**
+
+In `arena-server/src/lobby/lifecycle.ts`, inside `toInMatch()`, find where `new Tick(...)` is constructed (around line 139). Update:
+
+```typescript
+    // Determine if this is still a 1v3-vs-bots match or has converted to FFA.
+    // It stays 1v3 only if all non-host players are bots.
+    const nonHostPlayers = [...lobby.players.values()].filter(p => p.key !== lobby.hostKey);
+    const allBots = nonHostPlayers.every(p => p.isBot);
+    const isOneVsThree = lobby.mode === 'one-v-three' && allBots;
+
+    const tick = new Tick(
+      { matchId, players: lobby.players, bots,
+        oneVsThree: isOneVsThree, hostKey: lobby.hostKey },
+      {
+```
+
+- [ ] **Step 4: Run full arena test suite**
+
+```bash
+cd /tmp/wt-arena-brett-1v3/arena-server
+pnpm test
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /tmp/wt-arena-brett-1v3
+git add arena-server/src/game/tick.ts arena-server/src/lobby/lifecycle.ts
+git commit -m "feat(arena): 1v3 host-death triggers immediate match end in tick.ts"
+```
+
+---
+
+### Task 4: Tests — 1v3 lifecycle win conditions
+
+**Files:**
+- Modify: `arena-server/src/lobby/lifecycle.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Add to `arena-server/src/lobby/lifecycle.test.ts` (after the last existing `it` block):
+
+```typescript
+  describe('1v3 mode', () => {
+    function makeLc() {
+      return new Lifecycle({
+        onBroadcast: vi.fn(),
+        persist: { insertLobby: async () => {}, updateLobbyPhase: async () => {} } as any,
+        bc: { emitMatchSnapshot: vi.fn(), emitMatchDiff: vi.fn(), emitMatchEvent: vi.fn(), emitMatchEnd: vi.fn() } as any,
+      });
+    }
+
+    it('open() with mode one-v-three sets lobby.mode', () => {
+      const lc = makeLc();
+      const { code } = lc.open({ hostKey: 'p@korczewski', hostName: 'P', mode: 'one-v-three' });
+      const lobby = registry.getLobby(code)!;
+      expect(lobby.mode).toBe('one-v-three');
+    });
+
+    it('openSolo() sets mode one-v-three (backwards compat)', () => {
+      const lc = makeLc();
+      const { code } = lc.openSolo({ hostKey: 'p@korczewski', hostName: 'P' });
+      expect(registry.getLobby(code)!.mode).toBe('one-v-three');
+    });
+
+    it('open() defaults to ffa when no mode given', () => {
+      const lc = makeLc();
+      const { code } = lc.open({ hostKey: 'p@korczewski', hostName: 'P' });
+      expect(registry.getLobby(code)!.mode).toBe('ffa');
+    });
+
+    it('1v3 lobby fills 3 bots on toStarting', () => {
+      const lc = makeLc();
+      const { code } = lc.open({ hostKey: 'p@korczewski', hostName: 'P', mode: 'one-v-three' });
+      vi.advanceTimersByTime(60_001);
+      const lobby = registry.getLobby(code)!;
+      expect(lobby.players.size).toBe(4);
+      expect([...lobby.players.values()].filter(p => p.isBot)).toHaveLength(3);
+    });
+  });
+```
+
+- [ ] **Step 2: Run to confirm tests fail**
+
+```bash
+cd /tmp/wt-arena-brett-1v3/arena-server
+pnpm test -- lifecycle
+```
+
+Expected: the four new tests FAIL (because `open()` doesn't accept `mode` yet — but we already implemented it in Task 2). If Task 2 is done, they should PASS here.
+
+- [ ] **Step 3: Run full suite to confirm all pass**
+
+```bash
+cd /tmp/wt-arena-brett-1v3/arena-server
+pnpm test
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /tmp/wt-arena-brett-1v3
+git add arena-server/src/lobby/lifecycle.test.ts
+git commit -m "test(arena): 1v3 mode lifecycle tests"
+```
+
+---
+
+### Task 5: HTTP route + UI — 1v3 lobby button
+
+**Files:**
+- Modify: `arena-server/src/http/routes.ts`
+- Create: `website/src/pages/api/arena/1v3.ts`
+- Modify: `website/src/pages/admin/arena.astro`
+- Modify: `website/src/components/arena/ArenaIsland.tsx`
+- Modify: `website/src/components/arena/scenes/LobbyScene.tsx`
+
+- [ ] **Step 1: Add /lobby/open-1v3 HTTP route to arena-server**
+
+In `arena-server/src/http/routes.ts`, after the existing `r.post('/lobby/solo', ...)` block (around line 43):
+
+```typescript
+  r.post('/lobby/open-1v3', requireUser, requireAdmin, (req, res) => {
+    const out = deps.lc.open({
+      hostKey: req.userKey!,
+      hostName: req.user!.displayName,
+      mode: 'one-v-three',
+    });
+    res.status(201).json(out);
+  });
+```
+
+- [ ] **Step 2: Create website API proxy for 1v3**
+
+Create `website/src/pages/api/arena/1v3.ts`:
+
+```typescript
+import type { APIRoute } from 'astro';
+import { getSession } from '../../../lib/auth';
+import { mintArenaToken } from '../../../lib/arena-token';
+
+const UPSTREAM = (process.env.ARENA_WS_URL ?? 'http://localhost:8090')
+  .replace(/^wss:/, 'https:').replace(/^ws:/, 'http:');
+
+export const POST: APIRoute = async (ctx) => {
+  const user = await getSession(ctx.request.headers.get('cookie'));
+  if (!user) return new Response('unauthorised', { status: 401 });
+
+  const { token } = mintArenaToken(user.access_token);
+
+  const upstream = await fetch(`${UPSTREAM}/lobby/open-1v3`, {
+    method: 'POST',
+    headers: { authorization: `Bearer ${token}` },
+  });
+  return new Response(await upstream.text(), {
+    status: upstream.status,
+    headers: { 'content-type': 'application/json' },
+  });
+};
+```
+
+- [ ] **Step 3: Add 1v3 button to admin/arena.astro**
+
+In `website/src/pages/admin/arena.astro`, find the `<div class="actions">` section and add a third button:
+
+```html
+<div class="actions">
+  <button id="open-lobby" class="primary">Open lobby (FFA)</button>
+  <button id="open-1v3" class="primary" style="background:#c9aa71;border-color:#c9aa71;" title="Open a 1v3 lobby — host vs 3 AI bots, real players can join converting to FFA">1v3 vs Bots</button>
+  <button id="start-solo" class="secondary" title="Start immediately against 3 AI bots — for testing">Start solo match</button>
+</div>
+```
+
+And in the `<script>` block, add after the `soloBtn?.addEventListener(...)` line:
+
+```typescript
+  const btn1v3 = document.getElementById('open-1v3') as HTMLButtonElement | null;
+  btn1v3?.addEventListener('click', () => postAndJoin('/api/arena/1v3', btn1v3));
+```
+
+- [ ] **Step 4: Store and expose mode in ArenaIsland**
+
+In `website/src/components/arena/ArenaIsland.tsx`:
+
+Add a mode state variable (after the existing `useState` declarations, around line 23):
+
+```typescript
+  const [lobbyMode, setLobbyMode] = useState<'ffa' | 'one-v-three'>('ffa');
+```
+
+In the `socket.on('msg', ...)` handler, in the `case 'lobby:state':` branch, add:
+
+```typescript
+          if (m.mode) setLobbyMode(m.mode);
+```
+
+Pass `lobbyMode` to `LobbyScene` in the render (find the `<LobbyScene` JSX element, around line 152):
+
+```tsx
+        <LobbyScene
+          code={lobbyCode}
+          players={lobbyPlayers}
+          phase={lobbyPhase}
+          countdownMs={countdown}
+          myKey={myKey}
+          isHost={isHost}
+          mode={lobbyMode}
+          onCharacter={handleCharacter}
+          onLeave={handleLeave}
+          onStart={handleStart}
+        />
+```
+
+- [ ] **Step 5: Show 1v3 badge in LobbyScene**
+
+In `website/src/components/arena/scenes/LobbyScene.tsx`:
+
+Add `mode` to Props interface:
+
+```typescript
+interface Props {
+  code: string;
+  players: PlayerSlot[];
+  phase: 'open' | 'starting';
+  countdownMs: number;
+  myKey: string;
+  isHost: boolean;
+  mode: 'ffa' | 'one-v-three';
+  onCharacter: (characterId: CharacterId) => void;
+  onLeave: () => void;
+  onStart: () => void;
+}
+```
+
+Update destructuring:
+
+```typescript
+export function LobbyScene({ code, players, phase, countdownMs, myKey, isHost, mode, onCharacter, onLeave, onStart }: Props) {
+```
+
+Add mode badge after the `<div>` containing the "Arena · Lobby {code}" header (after the closing `</h2>` of the starting/waiting message):
+
+```tsx
+        {mode === 'one-v-three' && (
+          <div style={{ display: 'inline-block', marginTop: 8, padding: '3px 10px',
+            background: 'rgba(201,170,113,.15)', border: '1px solid #c9aa71',
+            borderRadius: 3, fontFamily: 'var(--font-mono, monospace)',
+            fontSize: 11, letterSpacing: '.14em', color: '#c9aa71' }}>
+            1v3 · HOST vs BOTS — real players can join
+          </div>
+        )}
+```
+
+- [ ] **Step 6: Run arena-server tests**
+
+```bash
+cd /tmp/wt-arena-brett-1v3/arena-server
+pnpm test
+```
+
+Expected: all pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /tmp/wt-arena-brett-1v3
+git add arena-server/src/http/routes.ts \
+  website/src/pages/api/arena/1v3.ts \
+  website/src/pages/admin/arena.astro \
+  website/src/components/arena/ArenaIsland.tsx \
+  website/src/components/arena/scenes/LobbyScene.tsx
+git commit -m "feat(arena): 1v3 HTTP endpoint + admin UI button + lobby badge"
+```
+
+---
+
+## Part 2 — Brett Co-op Waves
+
+### Task 6: Brett server — relay types + coop mode + coopWave state
+
+**Files:**
+- Modify: `brett/server.js`
+
+- [ ] **Step 1: Add wave relay types**
+
+In `brett/server.js`, find the `RELAY_TYPES` array (around line 331):
+
+```javascript
+// Change:
+'mayhem_mode','player_join','player_state','player_leave',
+// Add wave events to the relay list:
+'mayhem_mode','player_join','player_state','player_leave',
+'wave_start','wave_complete','coop_win','coop_lose',
+```
+
+- [ ] **Step 2: Allow 'coop' in admin_mode_set**
+
+In `brett/server.js`, find the validation line (around line 651):
+
+```javascript
+// Change:
+if (!['warmup','deathmatch','lms'].includes(msg.mode)) return;
+// To:
+if (!['warmup','deathmatch','lms','coop'].includes(msg.mode)) return;
+```
+
+- [ ] **Step 3: Track coopWave per room**
+
+In `brett/server.js`, find where room state is stored/initialised. Rooms are stored in a Map (search for the `rooms` or `figs` Map). Find the per-room data structure and add `coopWave: 0`.
+
+Specifically, find where `wave_start` relay happens (it will be in the RELAY_TYPES loop) and add tracking. After the `RELAY_TYPES` relay block, add a special-case for `wave_start`:
+
+```javascript
+// After the RELAY_TYPES relay loop (around the switch/case section),
+// add inside the message handler where RELAY_TYPES are processed:
+if (RELAY_TYPES.includes(msg.type)) {
+  broadcast(room, msg, ws);
+  // Track wave number for reconnecting clients
+  if (msg.type === 'wave_start' && typeof msg.wave === 'number') {
+    const roomState = rooms.get(room) ?? {};
+    roomState.coopWave = msg.wave;
+    rooms.set(room, roomState);
+  }
+}
+```
+
+Note: look at the actual relay code in the server to find the exact location. The pattern is a `switch` or `if (RELAY_TYPES.includes(...))` block in the WebSocket message handler.
+
+- [ ] **Step 4: Send coopWave to reconnecting clients**
+
+Find where the server sends the initial snapshot to a newly joined client (search for `onSnapshot` or the initial state send). Add:
+
+```javascript
+// In the snapshot/join response, include coopWave:
+const roomState = rooms.get(room) ?? {};
+ws.send(JSON.stringify({
+  type: 'coop_wave_sync',
+  wave: roomState.coopWave ?? 0,
+}));
+```
+
+Also add `'coop_wave_sync'` to `RELAY_TYPES` so it can be broadcast if needed, or handle it as a direct send.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /tmp/wt-arena-brett-1v3
+git add brett/server.js
+git commit -m "feat(brett): server relay for wave events + coop mode validation + coopWave tracking"
+```
+
+---
+
+### Task 7: Brett GameModeManager — COOP mode + wave state machine
+
+**Files:**
+- Modify: `brett/public/assets/mayhem/game-mode.js`
+
+- [ ] **Step 1: Add COOP to MODES and wave definitions**
+
+In `brett/public/assets/mayhem/game-mode.js`, add after the existing `MODES` constant:
+
+```javascript
+const MODES = Object.freeze({ WARMUP: 'warmup', DEATHMATCH: 'deathmatch', LMS: 'lms', COOP: 'coop' });
+
+// Wave definitions: normal waves have count, boss waves have boss:true + multipliers
+const WAVE_DEFS = [
+  { wave: 1,  boss: false, count: 2 },
+  { wave: 2,  boss: false, count: 3 },
+  { wave: 3,  boss: false, count: 3 },
+  { wave: 4,  boss: false, count: 4 },
+  { wave: 5,  boss: true,  count: 1, multiplier: { hp: 3, shootRate: 1.5, speed: 1.2, scale: 1.0 } },
+  { wave: 6,  boss: false, count: 3 },
+  { wave: 7,  boss: false, count: 4 },
+  { wave: 8,  boss: false, count: 4 },
+  { wave: 9,  boss: false, count: 5 },
+  { wave: 10, boss: true,  count: 1, multiplier: { hp: 6, shootRate: 2.0, speed: 1.3, scale: 1.5 } },
+];
+```
+
+- [ ] **Step 2: Add wave state to GameModeManager constructor**
+
+In the `GameModeManager` constructor, add after the existing fields:
+
+```javascript
+    // Co-op wave state
+    this._wave        = 0;
+    this._enemiesAlive = new Set();
+    this._deadPlayers  = new Set();
+    this._coopPhase    = 'idle'; // 'idle' | 'in-wave' | 'between' | 'won' | 'lost'
+    this._onWaveStart  = null;
+    this._onWaveComplete = null;
+    this._onCoopWin   = null;
+    this._onCoopLose  = null;
+```
+
+Also update `setMode()` to clear coop state:
+
+```javascript
+  setMode(mode) {
+    if (!Object.values(MODES).includes(mode)) return;
+    this.mode = mode;
+    this._killCounts.clear();
+    this._deathTimers.forEach(t => clearTimeout(t));
+    this._deathTimers.clear();
+    this._deadSet.clear();
+    this._spectating = false;
+    this._canRespawn = false;
+    // Reset co-op state on mode change
+    this._wave = 0;
+    this._enemiesAlive.clear();
+    this._deadPlayers.clear();
+    this._coopPhase = 'idle';
+    this._onModeChange(mode);
+  }
+```
+
+- [ ] **Step 3: Add co-op callback registration and startCoop()**
+
+Add these methods to the `GameModeManager` class (before the closing `}`):
+
+```javascript
+  // Register co-op callbacks — called by mayhem.js after creating the manager
+  setCoopCallbacks({ onWaveStart, onWaveComplete, onCoopWin, onCoopLose }) {
+    this._onWaveStart    = onWaveStart    || (() => {});
+    this._onWaveComplete = onWaveComplete || (() => {});
+    this._onCoopWin      = onCoopWin      || (() => {});
+    this._onCoopLose     = onCoopLose     || (() => {});
+  }
+
+  // Called by mayhem.js 3 s after game_mode_change {mode:'coop'} (host only)
+  startCoop() {
+    if (this.mode !== MODES.COOP || this._coopPhase !== 'idle') return;
+    this._startWave(1);
+  }
+
+  _startWave(n) {
+    if (n > WAVE_DEFS.length) {
+      this._coopPhase = 'won';
+      this._onCoopWin && this._onCoopWin();
+      return;
+    }
+    this._wave = n;
+    this._enemiesAlive.clear();
+    this._deadPlayers.clear();
+    this._coopPhase = 'in-wave';
+    const def = WAVE_DEFS[n - 1];
+    this._onWaveStart && this._onWaveStart({ wave: n, def });
+  }
+
+  // Called by mayhem.js when an enemy bot dies (pass the bot's id)
+  handleEnemyDeath(botId) {
+    this._enemiesAlive.delete(botId);
+    if (this._coopPhase !== 'in-wave') return;
+    if (this._enemiesAlive.size === 0) {
+      this._coopPhase = 'between';
+      this._onWaveComplete && this._onWaveComplete({ wave: this._wave });
+      // Advance after 3 s — mayhem.js will respawn dead players on wave_complete
+      setTimeout(() => this._startWave(this._wave + 1), 3000);
+    }
+  }
+
+  // Called by mayhem.js when a human player dies during co-op
+  handlePlayerDeathCoop(playerId, allHumanIds) {
+    this._deadPlayers.add(playerId);
+    if (this._coopPhase !== 'in-wave') return;
+    const allDead = allHumanIds.every(id => this._deadPlayers.has(id));
+    if (allDead) {
+      this._coopPhase = 'lost';
+      this._onCoopLose && this._onCoopLose();
+    }
+  }
+
+  // Register an enemy bot spawned this wave
+  registerEnemy(botId) {
+    this._enemiesAlive.add(botId);
+  }
+
+  getCoopWaveDef() {
+    return WAVE_DEFS[this._wave - 1] ?? null;
+  }
+
+  getCoopPhase() { return this._coopPhase; }
+  getCoopWave()  { return this._wave; }
+```
+
+- [ ] **Step 4: Update the window export**
+
+At the bottom of `game-mode.js`, update the export to include WAVE_DEFS:
+
+```javascript
+if (typeof window !== 'undefined') {
+  window.MayhemGameMode = { GameModeManager, MODES, WAVE_DEFS };
+}
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /tmp/wt-arena-brett-1v3
+git add brett/public/assets/mayhem/game-mode.js
+git commit -m "feat(brett): GameModeManager COOP mode + wave state machine"
+```
+
+---
+
+### Task 8: Brett ai-bot.js — boss multiplier + team targeting
+
+**Files:**
+- Modify: `brett/public/assets/mayhem/ai-bot.js`
+
+- [ ] **Step 1: Add bossMultiplier to constructor**
+
+In `brett/public/assets/mayhem/ai-bot.js`, update the constructor to accept and apply `bossMultiplier`:
+
+```javascript
+  // callbacks: { onFire(weaponDef, originPos, dirVec, shooterId),
+  //              onDeath(botId, killerId),
+  //              getGameMode() }
+  // bossMultiplier?: { hp: number, shootRate: number, speed: number, scale: number }
+  constructor({ id, mannequin, colorIndex = 0, callbacks, bossMultiplier = null }) {
+    this.id     = id;
+    this.isBoss = !!bossMultiplier;
+    this.avatar = new window.MayhemPlayerAvatar({
+      id, mannequin, local: false,
+      color: bossMultiplier ? '#e74c3c' : BOT_COLORS[colorIndex % BOT_COLORS.length],
+    });
+
+    // Boss: scale the 3D model
+    if (bossMultiplier && bossMultiplier.scale && bossMultiplier.scale !== 1.0) {
+      mannequin.root.scale.setScalar(bossMultiplier.scale);
+    }
+
+    this._x = mannequin.root.position.x;
+    this._z = mannequin.root.position.z;
+    this._facingY    = Math.random() * Math.PI * 2;
+    this._aiState    = 'wander';
+    this._wanderDx   = 0;
+    this._wanderDz   = 1;
+    this._wanderTtl  = 0;
+
+    // Boss has increased HP tracked separately (normal bots are one-shot)
+    this._hp         = bossMultiplier ? bossMultiplier.hp : 1;
+    this._shootTimer = Math.random() * BOT_SHOOT_RATE;
+    this._shootRate  = bossMultiplier ? BOT_SHOOT_RATE / bossMultiplier.shootRate : BOT_SHOOT_RATE;
+    this._speed      = bossMultiplier ? BOT_SPEED * bossMultiplier.speed : BOT_SPEED;
+
+    this._onFire    = callbacks.onFire;
+    this._onDeath   = callbacks.onDeath;
+    this._getMode   = callbacks.getGameMode;
+```
+
+- [ ] **Step 2: Add processHit to handle multi-hit boss HP**
+
+The existing `processHit` method handles taking damage. Update it to respect `_hp`:
+
+Find the existing `processHit` method and update it so bosses require multiple hits:
+
+```javascript
+  processHit(weaponKey, impulse, shooterId, weaponSystem) {
+    if (this._aiState === 'dead') return;
+    const weaponDef = weaponSystem ? weaponSystem.getWeaponDef(weaponKey) : null;
+    const damage    = weaponDef ? (weaponDef.damage / 100) : 0.25; // normalised hit
+
+    this._hp -= damage;
+    this.avatar.applyHit(impulse, weaponKey || 'flail');
+
+    if (this._hp <= 0) {
+      this._aiState = 'dead';
+      this.avatar.die();
+      this._onDeath(this.id, shooterId);
+    }
+  }
+```
+
+Note: if the existing `processHit` already calls `_onDeath` unconditionally, replace it with this version that checks `_hp`.
+
+- [ ] **Step 3: Add team-targeting filter to _findNearest()**
+
+Find the `_findNearest(allAvatars)` method and add a human-only filter when in coop mode:
+
+```javascript
+  _findNearest(allAvatars) {
+    const inCoop = this._getMode() === 'coop';
+    let nearest = null, minDist = Infinity;
+    for (const [id, av] of allAvatars) {
+      if (id === this.id) continue;
+      if (av.isDead || av.state === window.MayhemPlayerAvatar?.STATE?.RAGDOLL) continue;
+      // In co-op mode, only target human avatars (IDs that don't start with 'bot-')
+      if (inCoop && id.startsWith('bot-')) continue;
+      const dist = this._dist(av);
+      if (dist < minDist) { minDist = dist; nearest = av; }
+    }
+    return nearest;
+  }
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /tmp/wt-arena-brett-1v3
+git add brett/public/assets/mayhem/ai-bot.js
+git commit -m "feat(brett): ai-bot bossMultiplier (HP tracking + scale + color) + team targeting"
+```
+
+---
+
+### Task 9: Brett mayhem.js — wave spawning, friendly fire, dead-human tracking
+
+**Files:**
+- Modify: `brett/public/assets/mayhem/mayhem.js`
+
+- [ ] **Step 1: Add deadHumans set and co-op callbacks setup**
+
+At the top of the `start()` function body in `mayhem.js` (after the existing local variable declarations), add:
+
+```javascript
+    let deadHumans = new Set(); // tracks dead human IDs for between-wave respawn
+    let coopStartTimer = null;  // setTimeout handle for auto-starting wave 1
+```
+
+After `gameMode` is created (the `new window.MayhemGameMode.GameModeManager(...)` call), register co-op callbacks:
+
+```javascript
+    gameMode.setCoopCallbacks({
+      onWaveStart: ({ wave, def }) => {
+        deadHumans.clear();
+        // Spawn enemies for this wave
+        spawnWave(def);
+        // Broadcast wave_start so all clients sync
+        send({ type: 'wave_start', wave, enemyCount: def.count, boss: def.boss ?? false });
+        updateHud();
+      },
+      onWaveComplete: ({ wave }) => {
+        send({ type: 'wave_complete', wave });
+        // Respawn dead humans after 3 s (matches the _startWave timeout)
+        setTimeout(() => {
+          for (const id of deadHumans) {
+            if (id === playerId) localRespawn();
+          }
+          deadHumans.clear();
+          updateHud();
+        }, 3000);
+      },
+      onCoopWin:  () => { send({ type: 'coop_win' });  showCoopBanner('YOU WIN — all waves cleared!'); },
+      onCoopLose: () => { send({ type: 'coop_lose' }); showCoopBanner('DEFEATED'); },
+    });
+```
+
+- [ ] **Step 2: Add spawnWave() function**
+
+Add `spawnWave(def)` as a new function near `spawnAIBot()`:
+
+```javascript
+  function spawnWave(def) {
+    // Remove any leftover bots from previous wave
+    for (const bot of aiBots.values()) { bot.remove(scene); remoteAvatars.delete(bot.id); }
+    aiBots.clear();
+
+    for (let i = 0; i < def.count; i++) {
+      const botId = 'bot-' + crypto.randomUUID();
+      const pos   = nextSpawnPoint();
+      const botMannequin = makeMannequin(botId, pos);
+      const bot = new window.MayhemAIBot({
+        id: botId,
+        mannequin: botMannequin,
+        colorIndex: i,
+        bossMultiplier: def.boss ? def.multiplier : null,
+        callbacks: {
+          onFire: (weaponDef, originPos, dirVec, shooterId) => {
+            if (projectileMgr) projectileMgr.spawn(weaponDef, originPos, dirVec, shooterId);
+          },
+          onDeath: (id, killerId) => {
+            aiBots.delete(id);
+            remoteAvatars.delete(id);
+            if (killerId && killerId !== id) gameMode?.handleKill(killerId);
+            gameMode?.handleEnemyDeath(id);
+            updateHud();
+          },
+          getGameMode: () => gameMode?.mode || 'warmup',
+        },
+      });
+      if (bot.avatar && bot.weaponDef) bot.avatar.setWeapon(bot.weaponDef);
+      aiBots.set(botId, bot);
+      remoteAvatars.set(botId, bot.avatar);
+      gameMode?.registerEnemy(botId);
+    }
+  }
+```
+
+- [ ] **Step 3: Add friendly-fire skip in applyHitLocally()**
+
+In `applyHitLocally(victimId, weaponKey, impulse, shooterId)`, add a friendly-fire check at the very top of the function:
+
+```javascript
+  function applyHitLocally(victimId, weaponKey, impulse, shooterId) {
+    // In co-op mode, skip damage between human players (no friendly fire)
+    if (gameMode?.mode === 'coop') {
+      const shooterIsHuman = shooterId && !shooterId.startsWith('bot-');
+      const victimIsHuman  = victimId  && !victimId.startsWith('bot-');
+      if (shooterIsHuman && victimIsHuman) return;
+    }
+    // ... rest of existing function unchanged
+```
+
+- [ ] **Step 4: Track dead humans and call handlePlayerDeathCoop**
+
+In `processLocalHit()`, find the block that handles `localAvatar.isDead` (around "player_death" send). Update it for co-op:
+
+```javascript
+    if (localAvatar.isDead) {
+      send({ type: 'player_death', playerId, killerId: shooterId });
+      if (gameMode?.mode === 'coop') {
+        deadHumans.add(playerId);
+        // Collect all known human IDs (local + any non-bot remote avatars)
+        const allHumanIds = [playerId, ...[...remoteAvatars.keys()].filter(id => !id.startsWith('bot-'))];
+        gameMode.handlePlayerDeathCoop(playerId, allHumanIds);
+      } else {
+        gameMode?.handleDeath(playerId, true);
+      }
+      if (shooterId && shooterId !== playerId) gameMode?.handleKill(shooterId);
+    }
+```
+
+- [ ] **Step 5: Auto-start wave 1 after co-op mode set (host only)**
+
+In the `game_mode_change` handler in `onMessage()` (around line where `gameMode.setMode(msg.mode)` is called), add the co-op auto-start:
+
+```javascript
+      case 'game_mode_change':
+        if (gameMode && msg.mode) gameMode.setMode(msg.mode);
+        updateHud();
+        // Host auto-starts wave 1 after 3 s when co-op mode is set
+        if (msg.mode === 'coop' && isHost) {
+          if (coopStartTimer) clearTimeout(coopStartTimer);
+          coopStartTimer = setTimeout(() => gameMode?.startCoop(), 3000);
+        }
+        break;
+```
+
+Note: `isHost` must be available in this scope. Check if there's an existing `isHost` variable in `mayhem.js`; if not, derive it from the room's admin state or pass it as a parameter to `start()`.
+
+- [ ] **Step 6: Handle wave_start received from server (non-host clients)**
+
+In the `onMessage` switch, add a new case for clients that receive wave events relayed from the server:
+
+```javascript
+      case 'wave_start':
+        // Non-host clients: spawn enemies for this wave
+        if (!isHost && gameMode) {
+          const def = window.MayhemGameMode.WAVE_DEFS[msg.wave - 1];
+          if (def) {
+            deadHumans.clear();
+            spawnWave(def);
+            updateHud();
+          }
+        }
+        break;
+
+      case 'coop_wave_sync':
+        // Sent by server on reconnect — catch up to current wave
+        if (gameMode && msg.wave > 0) {
+          const def = window.MayhemGameMode.WAVE_DEFS[msg.wave - 1];
+          if (def) spawnWave(def);
+          updateHud();
+        }
+        break;
+```
+
+- [ ] **Step 7: Add showCoopBanner helper**
+
+Add a simple function near the other banner/display helpers:
+
+```javascript
+  function showCoopBanner(text) {
+    const div = document.createElement('div');
+    div.style.cssText = 'position:fixed;top:50%;left:50%;transform:translate(-50%,-50%);' +
+      'background:#1a1a2e;border:2px solid #c9aa71;color:#c9aa71;font-family:monospace;' +
+      'font-size:32px;padding:24px 48px;z-index:9999;text-align:center;border-radius:8px;';
+    div.textContent = text;
+    document.body.appendChild(div);
+    setTimeout(() => div.remove(), 5000);
+  }
+```
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd /tmp/wt-arena-brett-1v3
+git add brett/public/assets/mayhem/mayhem.js
+git commit -m "feat(brett): wave spawning, friendly fire skip, dead-human tracking in mayhem.js"
+```
+
+---
+
+### Task 10: Brett HUD — co-op wave counter + enemy count + boss HP bar
+
+**Files:**
+- Modify: `brett/public/index.html`
+
+- [ ] **Step 1: Add co-op HUD HTML**
+
+In `brett/public/index.html`, find the existing HUD section (search for `id="hud"` or the score/kill display). Add the co-op HUD element **after** the existing HUD, hidden by default:
+
+```html
+<!-- Co-op Wave HUD (shown only in coop mode) -->
+<div id="coop-hud" style="display:none;position:fixed;top:12px;left:50%;transform:translateX(-50%);
+  background:rgba(10,10,20,.82);border:1px solid #4a7;border-radius:8px;
+  padding:8px 20px;font-family:monospace;color:#ccd;font-size:13px;
+  display:none;flex-direction:column;gap:4px;min-width:220px;z-index:200;">
+  <div style="display:flex;justify-content:space-between;align-items:center;">
+    <span style="color:#c9aa71;font-weight:bold;letter-spacing:.1em;">CO-OP</span>
+    <span id="coop-wave-label" style="font-size:15px;font-weight:bold;color:#fff;">WELLE 1 / 10</span>
+    <span id="coop-enemy-count" style="color:#e87;">Feinde: <strong>0</strong></span>
+  </div>
+  <div style="background:#1e1e1e;border-radius:4px;overflow:hidden;height:4px;">
+    <div id="coop-progress-bar" style="width:10%;height:100%;background:linear-gradient(90deg,#4a7,#c9aa71);transition:width .5s;"></div>
+  </div>
+  <div id="boss-hp-wrap" style="display:none;margin-top:4px;">
+    <div style="color:#f44;font-size:11px;margin-bottom:2px;">⚠ BOSS HP</div>
+    <div style="background:#1e1e1e;border-radius:4px;overflow:hidden;height:6px;">
+      <div id="boss-hp-bar" style="width:100%;height:100%;background:#f44;transition:width .3s;"></div>
+    </div>
+  </div>
+</div>
+```
+
+- [ ] **Step 2: Update the co-op HUD on wave_start and enemy death**
+
+In the `onMessage` handler (in the `<script>` in `index.html`, or in `mayhem.js` if the HUD updates are centralised), add HUD update calls. Find the `updateHud()` or equivalent function and add:
+
+```javascript
+function updateCoopHud() {
+  const hud = document.getElementById('coop-hud');
+  if (!hud || !gameMode) return;
+
+  const isCoop = gameMode.mode === 'coop';
+  hud.style.display = isCoop ? 'flex' : 'none';
+  if (!isCoop) return;
+
+  const wave     = gameMode.getCoopWave();
+  const enemies  = gameMode._enemiesAlive.size;
+  const def      = gameMode.getCoopWaveDef();
+
+  document.getElementById('coop-wave-label').textContent = `WELLE ${wave} / 10`;
+  document.getElementById('coop-enemy-count').innerHTML  = `Feinde: <strong>${enemies}</strong>`;
+  document.getElementById('coop-progress-bar').style.width = `${(wave / 10) * 100}%`;
+
+  const bossWrap = document.getElementById('boss-hp-wrap');
+  const bossBar  = document.getElementById('boss-hp-bar');
+  const isBossWave = def && def.boss;
+  bossWrap.style.display = isBossWave ? 'block' : 'none';
+
+  // Boss HP: find the boss bot and read its _hp vs max hp
+  if (isBossWave && def) {
+    const maxHp = def.multiplier.hp;
+    let currentHp = 0;
+    for (const bot of aiBots.values()) {
+      if (bot.isBoss) { currentHp = bot._hp; break; }
+    }
+    bossBar.style.width = `${Math.max(0, (currentHp / maxHp) * 100)}%`;
+  }
+}
+```
+
+Call `updateCoopHud()` at the end of `updateHud()` (or wherever the main HUD is refreshed).
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /tmp/wt-arena-brett-1v3
+git add brett/public/index.html
+git commit -m "feat(brett): co-op HUD — wave counter, enemy count, boss HP bar"
+```
+
+---
+
+### Task 11: Verification + Deploy
+
+**Files:** none (test + deploy only)
+
+- [ ] **Step 1: Run all offline tests**
+
+```bash
+cd /tmp/wt-arena-brett-1v3
+task test:all
+```
+
+Expected: all pass. Fix any failures before continuing.
+
+- [ ] **Step 2: Run arena server tests**
+
+```bash
+cd /tmp/wt-arena-brett-1v3/arena-server
+pnpm test
+```
+
+Expected: all pass.
+
+- [ ] **Step 3: Run brett unit tests**
+
+```bash
+cd /tmp/wt-arena-brett-1v3
+npm ci --prefix brett
+node --test brett/test/ws-reconnect.test.mjs brett/test/physics.test.js brett/test/damage.test.mjs brett/test/pickups.test.mjs brett/test/mode-state.test.mjs
+```
+
+Expected: all pass.
+
+- [ ] **Step 4: Validate kustomize manifests**
+
+```bash
+cd /tmp/wt-arena-brett-1v3
+task workspace:validate
+```
+
+Expected: no errors.
+
+- [ ] **Step 5: Check CI diff-guard (proto sync)**
+
+```bash
+cd /tmp/wt-arena-brett-1v3
+diff arena-server/src/proto/messages.ts website/src/components/arena/shared/lobbyTypes.ts
+```
+
+Expected: exit 0.
+
+- [ ] **Step 6: Create PR from the feature branch**
+
+```bash
+cd /tmp/wt-arena-brett-1v3
+git push -u origin feature/arena-brett-1v3
+gh pr create \
+  --title "feat(arena+brett): 1v3 lobby mode + co-op wave survival" \
+  --body "$(cat <<'EOF'
+## Summary
+- Arena 1v3: host vs 3 AI bots, real players can join converting to FFA; host death = immediate game over vs bots
+- Brett Co-op: 10-wave survival mode with mid-boss (W5, HP×3) and final boss (W10, HP×6); no friendly fire; between-wave respawn; server-relayed wave sync
+
+## Test plan
+- [ ] Arena: open 1v3 lobby via admin button → 3 bots fill, badge shows
+- [ ] Arena: kill all 3 bots → host wins; die as host → immediate game over
+- [ ] Arena: real player joins → bot displaced, badge disappears, FFA win condition
+- [ ] Brett: set mode `coop` as admin → wave 1 starts after 3 s, 2 bots spawn
+- [ ] Brett: kill all wave 1 bots → wave 2 starts after 3 s pause
+- [ ] Brett: die mid-wave → no respawn; all dead → coop_lose
+- [ ] Brett: wave 5 boss → red, larger, more HP required
+- [ ] Brett: survive all 10 → coop_win banner
+- [ ] Brett: human shoots human → no damage
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 7: Deploy arena to korczewski**
+
+```bash
+task feature:arena
+```
+
+Expected: arena-server image builds and rolls out on korczewski. Verify: `task arena:status ENV=korczewski`
+
+- [ ] **Step 8: Deploy website to both clusters (arena UI + brett unchanged)**
+
+```bash
+task feature:website
+```
+
+Expected: website rolls on both clusters. Verify: `task workspace:verify:all-prods`
+
+- [ ] **Step 9: Deploy brett to both clusters**
+
+```bash
+task feature:brett
+```
+
+Expected: brett image builds and rolls on both clusters. Verify: `task brett:logs ENV=mentolder`
+
+- [ ] **Step 10: Merge PR**
+
+```bash
+gh pr merge --squash --delete-branch
+git checkout main
+git pull --rebase origin main
+```

--- a/docs/superpowers/specs/2026-05-20-arena-brett-1v3-design.md
+++ b/docs/superpowers/specs/2026-05-20-arena-brett-1v3-design.md
@@ -1,0 +1,188 @@
+# Arena 1v3 + Brett Co-op Waves — Design Spec
+
+## Overview
+
+Two new game modes deployed to their respective clusters:
+
+- **Arena 1v3** — korczewski: host plays solo against 3 AI bots; real players can join and displace bots, converting to FFA
+- **Brett Co-op Waves** — mentolder: up to 3 human players cooperate against 10 waves of AI enemies (mid-boss at W5, final boss at W10)
+
+---
+
+## Arena 1v3 (korczewski)
+
+### Concept
+
+Underdog mode — identical stats for all players, pure skill. Host opens a 1v3 lobby; 3 bots fill immediately. Real players can join at any time, displacing bots one-for-one. When all 3 bot slots are filled by real players the match becomes standard FFA with no further distinction.
+
+### Protocol Changes
+
+**`arena-server/src/proto/messages.ts`** — bump `PROTOCOL_VERSION` to `2`:
+- `ClientMsg` `lobby:open` gains optional `mode?: 'ffa' | 'one-v-three'` (default `'ffa'`)
+- Lobby state broadcast includes `mode: 'ffa' | 'one-v-three'`
+
+**`arena-server/src/lobby/registry.ts`**:
+- Remove `solo?: boolean`
+- Add `mode: 'ffa' | 'one-v-three'`
+
+**`website/src/components/arena/shared/lobbyTypes.ts`** — mirror the same `mode` field (CI diff-guard enforces sync).
+
+### Win-Condition Logic (`lifecycle.ts`)
+
+| Mode | Opponents | Match ends when | Winner |
+|---|---|---|---|
+| `one-v-three` | 3 bots | Host eliminated | Bots |
+| `one-v-three` | 3 bots | All 3 bots eliminated | Host 🏆 |
+| `one-v-three` → FFA | Any real player has joined | Last survivor | Standard FFA |
+
+"Any real player joined" switches the win-condition immediately and permanently for that match — there is no revert back to 1v3 semantics even if the real player disconnects.
+
+### Bot Fill Behaviour
+
+No change to `botfill.ts`. Existing behaviour already:
+- Fills slots up to 4 when host is alone
+- Retires one bot when a real player joins (`// Retire one bot to make room for the real player`)
+
+1v3 mode uses this as-is.
+
+### UI Changes
+
+**`website/src/components/arena/LobbyScreen.svelte`**:
+- Lobby-open screen gains a two-state toggle: **"1v3 vs Bots"** (default) / **"FFA"**
+- Selected mode is passed to `lobby:open` message
+
+**`website/src/components/arena/HUD.svelte`**:
+- When `mode === 'one-v-three'` and all opponents are bots: show small badge **"1v3"**
+- When real players have joined: badge disappears (standard FFA HUD)
+
+### Affected Files
+
+```
+arena-server/src/proto/messages.ts          PROTOCOL_VERSION 1→2, mode type
+arena-server/src/lobby/registry.ts          mode field (replaces solo?)
+arena-server/src/lobby/lifecycle.ts         open() accepts mode, win-condition branch
+website/src/components/arena/shared/lobbyTypes.ts   mirror mode field (CI-sync)
+website/src/components/arena/LobbyScreen.svelte     mode toggle
+website/src/components/arena/HUD.svelte             1v3 badge
+```
+
+---
+
+## Brett Co-op Waves (mentolder)
+
+### Concept
+
+3 human players cooperate against 10 waves of AI enemies. Waves 1–4 and 6–9 are normal bots (count ramps up). Wave 5 is a mid-boss (3× HP, faster). Wave 10 is the final boss (6× HP, faster, visually larger). Players do not respawn mid-wave; all dead players respawn between waves. If all humans die mid-wave it is `coop_lose`. Surviving all 10 waves is `coop_win`.
+
+### Wave Definitions
+
+| Wave | Type | Enemy count | Boss multipliers |
+|---|---|---|---|
+| 1 | Normal | 2 | — |
+| 2 | Normal | 3 | — |
+| 3 | Normal | 3 | — |
+| 4 | Normal | 4 | — |
+| 5 | **Mid-boss** | 1 | HP×3, shoot rate×1.5, speed×1.2 |
+| 6 | Normal | 3 | — |
+| 7 | Normal | 4 | — |
+| 8 | Normal | 4 | — |
+| 9 | Normal | 5 | — |
+| 10 | **Final boss** | 1 | HP×6, shoot rate×2, speed×1.3, scale×1.5, red tint |
+
+### Game-Mode State Machine (`game-mode.js`)
+
+New constant: `COOP: 'coop'` added to `MODES`.
+
+`GameModeManager` gains wave state:
+```
+_wave: 0            // current wave (0 = not started)
+_enemiesAlive: Set  // bot IDs still alive this wave
+_phase: 'idle' | 'in-wave' | 'between' | 'won' | 'lost'
+```
+
+Public API additions:
+- `startCoop()` — sets phase to `in-wave`, emits `wave_start {wave:1}` — called automatically by the host client 3 s after `game_mode_change { mode: 'coop' }` is received (same pattern as LMS; non-host clients wait for the relayed `wave_start` from the server)
+- `handleEnemyDeath(botId)` — removes from `_enemiesAlive`; if empty → emits `wave_complete`
+- `handlePlayerDeath(playerId)` — adds to `_deadPlayers`; checks if all human IDs are in `_deadPlayers` → emits `coop_lose`
+- `_advanceWave()` — 3 s pause, emits `wave_start` for next wave (triggering respawn callback for each entry in `_deadPlayers`, then clears it)
+
+### Server Changes (`server.js`)
+
+Add to `RELAY_TYPES`:
+```
+'wave_start', 'wave_complete', 'coop_win', 'coop_lose'
+```
+
+Add `'coop'` to the allowed-modes list in `admin_mode_set` validation:
+```js
+if (!['warmup','deathmatch','lms','coop'].includes(msg.mode)) return;
+```
+
+Add per-room `coopWave: number` (default 0) to room state, updated on each `wave_start` relay — used to inform reconnecting players of the current wave.
+
+### AI Bot Changes (`ai-bot.js`)
+
+**Team targeting:** `MayhemAIBot.tick()` receives a `teamMode` flag when `gameMode === 'coop'`. When set, `_findNearest()` filters `allAvatars` to human-controlled avatars only — human IDs do **not** start with `bot-` (existing ID convention). Bot IDs always match `/^bot-/`.
+
+**Boss option:** Constructor accepts `bossMultiplier?: { hp: number; shootRate: number; speed: number; scale: number }`. When provided:
+- `this._hp = BASE_HP * bossMultiplier.hp` — `_hp` is a new instance field (not previously tracked; normal bots are one-shot in the current LMS mode, but bosses need multi-hit tracking)
+- `BOT_SHOOT_RATE` overridden locally by `bossMultiplier.shootRate`
+- `BOT_SPEED` overridden locally by `bossMultiplier.speed`
+- `mannequin.root.scale.setScalar(bossMultiplier.scale)` called immediately after spawn
+
+### Mayhem Changes (`mayhem.js`)
+
+**Friendly fire:** In projectile hit-detection, if `gameMode === 'coop'` and both shooter and target IDs do **not** match `/^bot-/` (i.e. both are human), skip damage.
+
+**Wave spawning:** `spawnWave(waveDef)` replaces the single `spawnAIBot` loop:
+- Reads `waveDef.count`, `waveDef.boss` flag, `waveDef.bossMultiplier`
+- Passes `bossMultiplier` to `MayhemAIBot` when spawning boss
+- Registers spawned bot IDs with `GameModeManager._enemiesAlive`
+
+**Dead-player tracking:** `mayhem.js` maintains a `Set<string> deadHumans` — players added on death, cleared on wave start. `GameModeManager.handlePlayerDeath()` receives the player ID from this set.
+
+**Between-wave respawn:** On `wave_complete` relay received, after 3 s: iterate `deadHumans`, call `onRespawn(id)` for each (existing respawn callback), then clear `deadHumans`.
+
+### HUD Changes (`index.html`)
+
+New co-op HUD element (hidden by default, shown when `mode === 'coop'`):
+- **Wave counter:** "WELLE 7 / 10" — updates on `wave_start`
+- **Enemy counter:** "Feinde: 3" — decrements on each enemy death
+- **Boss HP bar:** visible only during wave 5 and wave 10; tracks boss HP as percentage
+
+### Affected Files
+
+```
+brett/public/assets/mayhem/game-mode.js     COOP mode + wave state machine
+brett/public/assets/mayhem/ai-bot.js        bossMultiplier + team-targeting
+brett/public/assets/mayhem/mayhem.js        wave spawning + friendly-fire check + respawn
+brett/public/index.html                     co-op HUD section
+brett/server.js                             RELAY_TYPES + coop mode validation + coopWave state
+```
+
+---
+
+## Testing
+
+### Arena 1v3
+- Open a `one-v-three` lobby → verify 3 bots spawn
+- Kill all 3 bots → verify host-wins result screen
+- Die as host → verify immediate game-over (not "waiting for last survivor")
+- Join as real player → verify bot is displaced, mode shows FFA
+- All 3 real players join → verify standard FFA win condition
+
+### Brett Co-op
+- Set mode `coop`, start → wave 1 spawns 2 bots
+- Kill all → wave_complete fires, 3s pause, wave 2 spawns 3 bots
+- Die mid-wave → no respawn until wave ends
+- All humans die → coop_lose fires
+- Complete all 10 waves → coop_win fires
+- Wave 5 boss → verify HP×3, faster shooting, standard bot at wave 6
+- Wave 10 boss → verify HP×6, scale×1.5, red tint
+- Friendly fire: human shoots human → no damage
+- Reconnect mid-wave → coopWave state restored from server
+
+## Deployment
+
+- Arena 1v3: `task feature:arena` (builds + deploys arena-server to korczewski; website deploys via `task feature:website`)
+- Brett Co-op: `task feature:brett` (builds + deploys brett to both clusters; co-op only surfaced on mentolder via mode availability in admin UI — no korczewski-specific gating needed at this stage)

--- a/website/src/components/arena/ArenaIsland.tsx
+++ b/website/src/components/arena/ArenaIsland.tsx
@@ -21,6 +21,7 @@ export function ArenaIsland({ wsUrl, lobbyCode, myKey }: Props) {
   const [error, setError] = useState<string | null>(null);
   const [players, setPlayers] = useState<PlayerSlot[]>([]);
   const [lobbyPhase, setLobbyPhase] = useState<'open' | 'starting'>('open');
+  const [lobbyMode, setLobbyMode] = useState<'ffa' | 'one-v-three'>('ffa');
   const [countdownMs, setCountdownMs] = useState(0);
   const [initialMatchState, setInitialMatchState] = useState<MatchState | null>(null);
   const [results, setResults] = useState<{ results: MatchResult[]; matchId: string } | null>(null);
@@ -65,6 +66,7 @@ export function ArenaIsland({ wsUrl, lobbyCode, myKey }: Props) {
       switch (m.t) {
         case 'lobby:state': {
           setPlayers(m.players as PlayerSlot[]);
+          if (m.mode) setLobbyMode(m.mode);
           if (m.phase === 'in-match') {
             const playerKeys = new Set((m.players as PlayerSlot[]).map(p => p.key));
             if (!playerKeys.has(myKey)) {
@@ -159,6 +161,7 @@ export function ArenaIsland({ wsUrl, lobbyCode, myKey }: Props) {
         countdownMs={countdownMs}
         myKey={myKey}
         isHost={isHost}
+        mode={lobbyMode}
         onCharacter={handleCharacter}
         onLeave={handleLeave}
         onStart={handleStart}

--- a/website/src/components/arena/scenes/LobbyScene.tsx
+++ b/website/src/components/arena/scenes/LobbyScene.tsx
@@ -18,12 +18,13 @@ interface Props {
   countdownMs: number;
   myKey: string;
   isHost: boolean;
+  mode: 'ffa' | 'one-v-three';
   onCharacter: (characterId: CharacterId) => void;
   onLeave: () => void;
   onStart: () => void;
 }
 
-export function LobbyScene({ code, players, phase, countdownMs, myKey, isHost, onCharacter, onLeave, onStart }: Props) {
+export function LobbyScene({ code, players, phase, countdownMs, myKey, isHost, mode, onCharacter, onLeave, onStart }: Props) {
   const [charIdx, setCharIdx] = useState(0);
 
   function cycleChar(delta: 1 | -1) {
@@ -49,6 +50,14 @@ export function LobbyScene({ code, players, phase, countdownMs, myKey, isHost, o
           <h2 style={{ fontFamily: 'var(--font-serif, Georgia, serif)', fontSize: 36, margin: '12px 0 0' }}>
             Waiting for players &mdash; <em style={{ color: '#C8F76A' }}>{players.filter(p => !p.isBot).length} / 4</em>
           </h2>
+        )}
+        {mode === 'one-v-three' && (
+          <div style={{ display: 'inline-block', marginTop: 8, padding: '3px 10px',
+            background: 'rgba(201,170,113,.15)', border: '1px solid #c9aa71',
+            borderRadius: 3, fontFamily: 'var(--font-mono, monospace)',
+            fontSize: 11, letterSpacing: '.14em', color: '#c9aa71' }}>
+            1v3 · HOST vs BOTS — real players can join
+          </div>
         )}
       </div>
 

--- a/website/src/components/arena/shared/lobbyTypes.ts
+++ b/website/src/components/arena/shared/lobbyTypes.ts
@@ -1,7 +1,7 @@
 // Mirrored from arena-server/src/proto/messages.ts — CI diff guard enforces sync.
 // When updating messages.ts, update this file too.
 
-export const PROTOCOL_VERSION = 1;
+export const PROTOCOL_VERSION = 2;
 
 export type LobbyPhase = 'open' | 'starting' | 'in-match' | 'slow-mo' | 'results' | 'closed';
 
@@ -69,7 +69,7 @@ export type GameEvent =
   | { e: 'powerup-expire'; player: string; kind: string };
 
 export type ClientMsg =
-  | { t: 'lobby:open' }
+  | { t: 'lobby:open'; mode?: 'ffa' | 'one-v-three' }
   | { t: 'lobby:join'; code: string }
   | { t: 'lobby:ready'; ready: boolean }
   | { t: 'lobby:start' }
@@ -85,7 +85,7 @@ export type ClientMsg =
 
 export type ServerMsg =
   | { t: 'lobby:state'; code: string; phase: LobbyPhase;
-        players: PlayerSlot[]; expiresAt?: number; countdownMs?: number }
+        players: PlayerSlot[]; expiresAt?: number; countdownMs?: number; mode: 'ffa' | 'one-v-three' }
   | { t: 'match:full-snapshot'; tick: number; state: MatchState }
   | { t: 'match:diff'; tick: number; ops: DiffOp[] }
   | { t: 'match:event'; events: GameEvent[] }

--- a/website/src/layouts/AdminLayout.astro
+++ b/website/src/layouts/AdminLayout.astro
@@ -105,6 +105,7 @@ const navGroups: { label: string; iconClass: string; items: NavItem[] }[] = [
     items: [
       { href: '/admin/coaching/sessions',  label: 'Sitzungen',   icon: 'clipboard', matches: ['/admin/coaching/sessions', '/admin/fragebogen'] },
       { href: '/admin/brett',              label: 'Systembrett', icon: 'brett' },
+      { href: '/admin/arena',              label: 'Arena',       icon: 'arena' },
     ],
   },
   {

--- a/website/src/pages/admin/arena.astro
+++ b/website/src/pages/admin/arena.astro
@@ -18,8 +18,9 @@ const isAdmin = (user.realmRoles ?? []).includes('arena_admin') && user.brand ==
         <div class="actions">
           <button id="open-lobby" class="primary">Open lobby</button>
           <button id="start-solo" class="secondary" title="Start immediately against 3 AI bots — for testing">Start solo match</button>
+          <button id="start-1v3" class="secondary" title="1v3 — you vs 3 bots, defeat means instant loss" style="background:#c9aa71;border-color:#c9aa71;color:#1a0e22;">1v3 vs Bots</button>
         </div>
-        <p class="hint"><strong>Open lobby</strong>: a 6-character code is generated and a banner appears across both brands for 60 seconds. <strong>Start solo match</strong>: skip the wait and drop straight into a 5-second countdown against 3 AI bots.</p>
+        <p class="hint"><strong>Open lobby</strong>: a 6-character code is generated and a banner appears across both brands for 60 seconds. <strong>Start solo match</strong>: skip the wait and drop straight into a 5-second countdown against 3 AI bots. <strong>1v3 vs Bots</strong>: same as solo, but your death ends the match immediately.</p>
         <h2>Recent matches</h2>
         <table id="recent">
           <thead><tr><th>Started</th><th>Code</th><th>Winner</th><th>Humans</th><th>Bots</th></tr></thead>
@@ -33,12 +34,14 @@ const isAdmin = (user.realmRoles ?? []).includes('arena_admin') && user.brand ==
 <script>
   const btn = document.getElementById('open-lobby') as HTMLButtonElement | null;
   const soloBtn = document.getElementById('start-solo') as HTMLButtonElement | null;
+  const btn1v3 = document.getElementById('start-1v3') as HTMLButtonElement | null;
   const tbody = document.querySelector('#recent tbody') as HTMLElement | null;
 
   async function postAndJoin(endpoint: string, source: HTMLButtonElement) {
     source.disabled = true;
     if (btn) btn.disabled = true;
     if (soloBtn) soloBtn.disabled = true;
+    if (btn1v3) btn1v3.disabled = true;
     try {
       const res = await fetch(endpoint, { method: 'POST' });
       if (!res.ok) {
@@ -53,11 +56,13 @@ const isAdmin = (user.realmRoles ?? []).includes('arena_admin') && user.brand ==
       source.disabled = false;
       if (btn) btn.disabled = false;
       if (soloBtn) soloBtn.disabled = false;
+      if (btn1v3) btn1v3.disabled = false;
     }
   }
 
   btn?.addEventListener('click', () => postAndJoin('/api/arena/start', btn));
   soloBtn?.addEventListener('click', () => postAndJoin('/api/arena/solo', soloBtn));
+  btn1v3?.addEventListener('click', () => postAndJoin('/api/arena/1v3', btn1v3));
 
   async function loadMatches() {
     if (!tbody) return;

--- a/website/src/pages/api/arena/1v3.ts
+++ b/website/src/pages/api/arena/1v3.ts
@@ -1,0 +1,22 @@
+import type { APIRoute } from 'astro';
+import { getSession } from '../../../lib/auth';
+import { mintArenaToken } from '../../../lib/arena-token';
+
+const UPSTREAM = (process.env.ARENA_WS_URL ?? 'http://localhost:8090')
+  .replace(/^wss:/, 'https:').replace(/^ws:/, 'http:');
+
+export const POST: APIRoute = async (ctx) => {
+  const user = await getSession(ctx.request.headers.get('cookie'));
+  if (!user) return new Response('unauthorised', { status: 401 });
+
+  const { token } = mintArenaToken(user.access_token);
+
+  const upstream = await fetch(`${UPSTREAM}/lobby/open-1v3`, {
+    method: 'POST',
+    headers: { authorization: `Bearer ${token}` },
+  });
+  return new Response(await upstream.text(), {
+    status: upstream.status,
+    headers: { 'content-type': 'application/json' },
+  });
+};


### PR DESCRIPTION
## Summary
- **Arena 1v3:** New lobby mode where host plays against 3 AI bots; real players can join converting the lobby to FFA. Host death triggers immediate match-over vs bots. Admin UI gets a gold "1v3 vs Bots" button. Lobby badge shows mode. PROTOCOL_VERSION bumped to 2 with `mode` field in `lobby:open` and `lobby:state`.
- **Brett Co-op:** 10-wave survival mode with team-only bot targeting, no friendly fire, between-wave respawn. Wave 5 is a mid-boss (HP×3, faster) and wave 10 is the final boss (HP×6, larger). Wave state relayed via server for multi-client sync. Co-op HUD shows wave/10, enemy count, and boss HP bar.

## Test plan
- [x] Proto diff-guard: `diff messages.ts lobbyTypes.ts` → exit 0
- [x] `task test:all` — all offline tests pass (admin-menu gate, manifests, scripts, unit, dry-run)
- [x] `pnpm test` in arena-server — 55 tests pass
- [x] Brett unit tests — 22 tests pass
- [x] `pnpm build` — TypeScript clean
- [ ] Arena: open 1v3 lobby via admin button → 3 bots fill, badge shows
- [ ] Arena: kill all 3 bots → host wins; die as host → immediate game over
- [ ] Brett: set mode `coop` as admin → wave 1 starts after 3s
- [ ] Brett: survive all 10 waves → coop_win banner
- [ ] Brett: human shoots human → no damage

🤖 Generated with [Claude Code](https://claude.com/claude-code)