### PR TITLE
fix(infra): delete arena-bootstrap Job before re-apply [T000077]

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -2878,6 +2878,7 @@ tasks:
             fi
           fi
           envsubst "\$WORKSPACE_NAMESPACE \$PROD_DOMAIN \$ARENA_IMAGE" < prod-korczewski/arena.yaml | kubectl $CTX_ARG apply -f -
+          kubectl $CTX_ARG -n "$WORKSPACE_NAMESPACE" delete job arena-bootstrap --ignore-not-found=true
           envsubst "\$WORKSPACE_NAMESPACE" < prod-korczewski/migrations-arena.yaml | kubectl $CTX_ARG apply -f -
           kubectl $CTX_ARG -n "$WORKSPACE_NAMESPACE" rollout restart deployment/arena-server || true
       - echo "✓ arena deployed to {{.ENV}}"


### PR DESCRIPTION
## Summary
- Adds `kubectl delete job arena-bootstrap --ignore-not-found=true` before `kubectl apply` of `migrations-arena.yaml` in the `arena:deploy` task
- Prevents the `field is immutable` error that occurs when the Job already exists (e.g. previous run finished < 10 min ago, or deploy runs while job is still running)
- `ttlSecondsAfterFinished: 600` on the Job is not a reliable guard since deploys can happen within that window

## Test plan
- [ ] `task workspace:validate` passes (verified locally)
- [ ] `task arena:deploy ENV=korczewski` succeeds on second run without immutable-field error

🤖 Generated with [Claude Code](https://claude.com/claude-code)