### PR TITLE
fix(infra): LLM gateway → Tailscale 100.102.71.114:1234 + arena-bootstrap immutable fix in workspace:deploy

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1532,6 +1532,9 @@ tasks:
           export LLM_RERANK_ENABLED="${LLM_RERANK_ENABLED:-false}"
           export LLM_ROUTER_URL="${LLM_ROUTER_URL:-http://llm-gateway-lmstudio.workspace.svc.cluster.local:1234}"
           export LLM_EMBED_URL="${LLM_EMBED_URL:-http://llm-gateway-embed.workspace.svc.cluster.local:8081}"
+          # Delete immutable Jobs before re-apply so field changes don't cause
+          # "field is immutable" errors (Jobs cannot be patched in-place).
+          kubectl --context "$ENV_CONTEXT" -n "$_ws_ns" delete job arena-bootstrap --ignore-not-found=true
           kustomize build "$overlay/" --load-restrictor=LoadRestrictionsNone \
             | envsubst "$ENVSUBST_VARS" \
             | sed -E 's/\$\$([a-zA-Z0-9_]|\{)/$\1/g' \

--- a/environments/korczewski.yaml
+++ b/environments/korczewski.yaml
@@ -47,7 +47,7 @@ env_vars:
   KEYCLOAK_FRONTEND_URL: "https://auth.korczewski.de"
   # System-test failure loop master kill-switch (Task 10).
   SYSTEMTEST_LOOP_ENABLED: "true"
-  LLM_HOST_IP: "10.13.14.10"
+  LLM_HOST_IP: "100.102.71.114"
   LLM_ENABLED: "true"
   LLM_RERANK_ENABLED: "false"
   LLM_ROUTER_URL: "http://llm-gateway-lmstudio.workspace-korczewski.svc.cluster.local:1234"

--- a/environments/mentolder.yaml
+++ b/environments/mentolder.yaml
@@ -46,7 +46,7 @@ env_vars:
   KEYCLOAK_FRONTEND_URL: "https://auth.mentolder.de"
   # System-test failure loop master kill-switch (Task 10).
   SYSTEMTEST_LOOP_ENABLED: "true"
-  LLM_HOST_IP: "192.168.100.10"
+  LLM_HOST_IP: "100.102.71.114"
   LLM_ENABLED: "true"
   LLM_RERANK_ENABLED: "false"
   LLM_ROUTER_URL: "http://llm-gateway-lmstudio.workspace.svc.cluster.local:1234"

--- a/package copy.json
+++ b/package copy.json
@@ -1,0 +1,18 @@
+{
+  "name": "bachelorprojekt-scripts",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test:track-pr": "node --test scripts/track-pr.test.mjs",
+    "test:build-docs": "node --test scripts/build-docs.test.js",
+    "build:docs": "node scripts/build-docs.js"
+  },
+  "dependencies": {
+    "pg": "^8.21.0"
+  },
+  "devDependencies": {
+    "@mermaid-js/mermaid-cli": "^11.0.0",
+    "cheerio": "^1.2.0",
+    "marked": "^18.0.3"
+  }
+}


### PR DESCRIPTION
## Summary

- Updates `LLM_HOST_IP` to `100.102.71.114` (Tailscale) in both `environments/mentolder.yaml` and `environments/korczewski.yaml`, so `llm-gateway-lmstudio` Endpoints route to LM Studio on port 1234 instead of Ollama on stale wg-mesh IPs
- Adds `kubectl delete job arena-bootstrap --ignore-not-found=true` before the kustomize overlay apply in `workspace:deploy` — the same immutable-Job fix from PR #915 was only applied to `arena:deploy`; `workspace:deploy` hit the same error on korczewski during this session

## Test plan

- [x] `task workspace:deploy ENV=mentolder` — succeeded
- [x] `task workspace:deploy ENV=korczewski` — succeeded after Taskfile fix
- [x] Both clusters verified: `llm-gateway-lmstudio` Endpoint = `100.102.71.114:1234`

🤖 Generated with [Claude Code](https://claude.com/claude-code)