### PR TITLE
fix(website): admin sidebar Systembrett link → brett.mentolder.de direct

### DIFF
--- a/website/src/layouts/AdminLayout.astro
+++ b/website/src/layouts/AdminLayout.astro
@@ -5,6 +5,9 @@ import { config } from '../config/index';
 import TicketWidgetBar from '../components/TicketWidgetBar.astro';
 import AssistantWidget from '../components/assistant/AssistantWidget.svelte';
 const ASSISTANT_ENABLED = (process.env.ENABLE_ASSISTANT_ADMIN ?? 'false') === 'true';
+const brettDomain = process.env.BRETT_DOMAIN ?? 'brett.localhost';
+const brettProto = brettDomain.includes('localhost') ? 'http' : 'https';
+const BRETT_URL = `${brettProto}://${brettDomain}/?admin=1`;
 import PortalSidekick from '../components/PortalSidekick.svelte';
 import SessionExpiryWarning from '../components/SessionExpiryWarning.svelte';
 import { countPendingByType } from '../lib/messaging-db';
@@ -20,6 +23,7 @@ interface NavItem {
   icon: string;
   matches?: string[];
   badge?: number;
+  external?: boolean;
 }
 
 const { title } = Astro.props;
@@ -104,7 +108,7 @@ const navGroups: { label: string; iconClass: string; items: NavItem[] }[] = [
     iconClass: 'nav-icon-coaching',
     items: [
       { href: '/admin/coaching/sessions',  label: 'Sitzungen',   icon: 'clipboard', matches: ['/admin/coaching/sessions', '/admin/fragebogen'] },
-      { href: '/admin/brett',              label: 'Systembrett', icon: 'brett' },
+      { href: BRETT_URL,                    label: 'Systembrett', icon: 'brett', external: true },
       { href: '/admin/arena',              label: 'Arena',       icon: 'arena' },
     ],
   },
@@ -265,6 +269,8 @@ const isKore = brandId === 'korczewski';
                   'sidebar-nav-item',
                   { 'is-active': isActive(item.href, item.matches) }
                 ]}
+                target={item.external ? '_blank' : undefined}
+                rel={item.external ? 'noopener noreferrer' : undefined}
               >
                 <span class={`nav-icon ${group.iconClass}`} set:html={icons[item.icon]} />
                 <span class="sidebar-label" style="margin-left:12px; flex:1;">{item.label}</span>

--- a/website/src/pages/admin/brett/[...path].astro
+++ b/website/src/pages/admin/brett/[...path].astro
@@ -11,6 +11,13 @@ if (!isAdmin(session)) return new Response('Forbidden', { status: 403 });
 const BRETT_INTERNAL = process.env.BRETT_INTERNAL_URL || 'http://brett.workspace.svc.cluster.local:3000';
 const path = Astro.params.path || '';
 
+// Empty path means index — redirect to the Brett service admin console
+if (!path) {
+  const brettDomain = process.env.BRETT_DOMAIN ?? 'brett.localhost';
+  const proto = brettDomain.includes('localhost') ? 'http' : 'https';
+  return Astro.redirect(`${proto}://${brettDomain}/?admin=1`);
+}
+
 // Nur erlaubte Pfade proxyen
 const allowed = [
   /^api\//,


### PR DESCRIPTION
## Root cause

The admin sidebar nav item for **Systembrett** linked to `/admin/brett` — an internal Astro SSR route that was supposed to redirect to the external Brett service. Two bugs caused the 404:

1. **Trailing-slash ambiguity**: When navigating to `/admin/brett/` (with slash), Astro's catch-all `[...path].astro` matched with `path = ''`. The proxy's allow-list check (`/^api\//`, `/^auth\//`, etc.) rejects the empty string and returns `new Response('Not Found', { status: 404 })`.

2. **Wrong link type**: The sidebar should link directly to the external Brett service (`brett.mentolder.de`), not to an internal Astro redirect page. The `BRETT_DOMAIN` env var is already in the website pod's ConfigMap.

## Fix

- **`AdminLayout.astro`**: reads `process.env.BRETT_DOMAIN` at render time, builds the full external URL (`https://brett.mentolder.de/?admin=1`), and uses it directly as the sidebar nav `href` with `target="_blank" rel="noopener noreferrer"`. Added `external?: boolean` to the `NavItem` interface.

- **`[...path].astro`** (safety net): empty path now redirects to the Brett admin console instead of 404ing, consistent with what `index.astro` does.

## Test plan

- [ ] Click Systembrett in the admin sidebar on `web.mentolder.de` — should open `brett.mentolder.de/?admin=1` in a new tab
- [ ] Confirm the Brett app shows the admin bootstrap (room browser / mayhem panel) after Keycloak login
- [ ] Direct navigation to `web.mentolder.de/admin/brett/` should no longer 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)