### PR TITLE
chore(skills): harden dev-flow-execute archive step + add cicd-kubeconfig-gen.sh

### DIFF
--- a/.claude/skills/dev-flow-execute/SKILL.md
+++ b/.claude/skills/dev-flow-execute/SKILL.md
@@ -358,8 +358,26 @@ Falls `$TICKET_ID` gesetzt und `$PLAN_FILE` vorhanden:
 > **Wichtig — Worktree-Zustand nach Schritt 6:** `gh pr merge --squash --delete-branch` löscht nicht nur Remote+Local-Branch, sondern führt im Worktree **silent** `git checkout main` aus. Du landest auf `main` am pre-PR HEAD, und die Plan-Datei ist von Disk verschwunden, bis `git pull` läuft. Deshalb **muss** dieser Schritt mit einem Sync starten:
 
 ```bash
+# Parallele-Session-Schutz: Haupt-Repo könnte auf einem anderen Branch liegen (z.B. fix/X).
+# Immer explizit in einen Worktree wechseln, der auf main ist.
+MAIN_REPO="/home/patrick/Bachelorprojekt"
+ARCHIVE_CWD=$(git worktree list --porcelain \
+  | awk '/^worktree/{wt=$2} /^branch refs\/heads\/main$/{print wt; exit}')
+if [[ -z "$ARCHIVE_CWD" ]]; then
+  # Kein Worktree auf main — Haupt-Repo auf main wechseln
+  ARCHIVE_CWD="$MAIN_REPO"
+  (cd "$ARCHIVE_CWD" && git checkout main)
+fi
+cd "$ARCHIVE_CWD"
 git fetch origin main
-git reset --hard origin/main   # Worktree ist jetzt auf der gemergten Revision — Plan-Datei wieder auf Disk
+git reset --hard origin/main   # Plan-Datei ist jetzt auf Disk (gemergter Revision)
+
+# Sicherheitsprüfung: CWD muss auf main sein
+CURRENT_BRANCH=$(git branch --show-current)
+if [[ "$CURRENT_BRANCH" != "main" ]]; then
+  echo "✗ CWD ist auf '$CURRENT_BRANCH' — Abbruch. Bitte Branch prüfen."
+  exit 1
+fi
 ```
 
 ```bash
@@ -443,6 +461,16 @@ git pull --rebase origin main
 ```
 
 **Hinweis Dollar-Quoting:** `$plan$...$plan$` ist psql-Dollar-Quoting; sicher für beliebigen Markdown-Inhalt, solange der Plan selbst nicht den String `$plan$` enthält (praktisch ausgeschlossen).
+
+**kubeconfig für cicd-deploy generieren:** Statt `kubectl config view --raw -o jsonpath '{.clusters[?(@.name=="<hardcoded>")]...}'` (schlägt fehl wenn Context-Name ≠ Cluster-Name) immer das Hilfsskript nutzen:
+
+```bash
+# Erzeugt fertiges kubeconfig für cicd-deploy SA; --minify macht clusters[0] korrekt
+bash scripts/cicd-kubeconfig-gen.sh mentolder workspace | base64 -w0 \
+  | gh secret set MENTOLDER_KUBECONFIG --repo Paddione/Bachelorprojekt
+bash scripts/cicd-kubeconfig-gen.sh korczewski workspace-korczewski | base64 -w0 \
+  | gh secret set KORCZEWSKI_KUBECONFIG --repo Paddione/Bachelorprojekt
+```
 
 ---
 

--- a/scripts/cicd-kubeconfig-gen.sh
+++ b/scripts/cicd-kubeconfig-gen.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Generate a minimal kubeconfig for the cicd-deploy ServiceAccount.
+# Usage: bash scripts/cicd-kubeconfig-gen.sh <context> <namespace>
+# Example (mentolder):  bash scripts/cicd-kubeconfig-gen.sh mentolder workspace
+# Example (korczewski): bash scripts/cicd-kubeconfig-gen.sh korczewski workspace-korczewski
+#
+# Uses --minify so clusters[0] always refers to the right cluster,
+# regardless of the internal cluster name in the kubeconfig file.
+set -euo pipefail
+
+CONTEXT="${1:?Usage: $0 <context> <namespace>}"
+NAMESPACE="${2:?Usage: $0 <context> <namespace>}"
+
+SERVER=$(kubectl config view --minify --context "$CONTEXT" \
+  -o jsonpath='{.clusters[0].cluster.server}')
+CA=$(kubectl config view --minify --context "$CONTEXT" \
+  -o jsonpath='{.clusters[0].cluster.certificate-authority-data}')
+TOKEN=$(kubectl create token cicd-deploy \
+  -n "$NAMESPACE" --context "$CONTEXT" --duration=87600h)
+
+cat <<EOF
+apiVersion: v1
+kind: Config
+clusters:
+- name: ${CONTEXT}
+  cluster:
+    server: ${SERVER}
+    certificate-authority-data: ${CA}
+contexts:
+- name: cicd@${CONTEXT}
+  context:
+    cluster: ${CONTEXT}
+    user: cicd-deploy
+    namespace: ${NAMESPACE}
+current-context: cicd@${CONTEXT}
+users:
+- name: cicd-deploy
+  user:
+    token: ${TOKEN}
+EOF


### PR DESCRIPTION
## Summary
- Step 7 of dev-flow-execute now detects parallel sessions: finds any worktree on `main` before committing the plan archive, rather than blindly committing to whatever branch the main repo has checked out
- Adds safety check that aborts if CWD is not on `main` after the switch
- New `scripts/cicd-kubeconfig-gen.sh`: generates a minimal kubeconfig for `cicd-deploy` SA using `--minify` so `clusters[0]` is always correct, regardless of internal cluster name (fixes the `mentolder` context → `mentolder-ha` cluster name mismatch)
- Adds kubeconfig generation reference to skill for future plan authors

## Context
Mishaps T000091 + T000092 observed during T000089 execution — both fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)