### PR TITLE
chore(ci): fix track-pr grep pipeline crash under set -e

### DIFF
--- a/.github/workflows/track-pr.yml
+++ b/.github/workflows/track-pr.yml
@@ -46,11 +46,13 @@ jobs:
             | sed 's/^[a-z]*: //')
 
           # Extract T000xxx ticket refs and BR-YYYYMMDD-xxxx bug refs from body
+          # Use `{ grep ... || true; }` so grep's non-zero exit (no matches)
+          # is swallowed before piping to sort — prevents set -e from aborting.
           TICKET_REFS=$(printf '%s' "$PR_BODY" \
-            | grep -oE 'T[0-9]{6}' | sort -u \
+            | { grep -oE 'T[0-9]{6}' || true; } | sort -u \
             | jq -R . | jq -sc . 2>/dev/null || echo '[]')
           BUG_REFS=$(printf '%s' "$PR_BODY" \
-            | grep -oE 'BR-[0-9]{8}-[A-Za-z0-9]+' | sort -u \
+            | { grep -oE 'BR-[0-9]{8}-[A-Za-z0-9]+' || true; } | sort -u \
             | jq -R . | jq -sc . 2>/dev/null || echo '[]')
 
           # Truncate body to avoid huge files (keep first 4000 chars)


### PR DESCRIPTION
## Problem

When a PR body contains no `T000xxx` or `BR-*` refs (e.g. a chore/fix PR), `grep` exits 1. Under `set -euo pipefail` this aborts the entire pipeline **before** the `|| echo '[]'` fallback fires, leaving `jq --argjson` with empty/invalid JSON → exit 2.

Observed on PR #925 (`track-pr` check failure).

## Fix

Wrap each `grep` in a brace group so its non-zero exit is neutralised within the pipeline stage:
```bash
# Before (broken when grep finds nothing):
| grep -oE 'T[0-9]{6}' | sort -u | jq -R . | jq -sc . || echo '[]'

# After (safe):
| { grep -oE 'T[0-9]{6}' || true; } | sort -u | jq -R . | jq -sc . || echo '[]'
```

## Validation
Tested locally under `set -euo pipefail` for both empty-body and populated-body cases — both produce valid JSON arrays.