### PR TITLE
fix(test): auto-init BATS submodules in worktrees [T000107]

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -227,13 +227,11 @@ tasks:
   # ─────────────────────────────────────────────
   test:unit:
     desc: Run BATS unit tests (assertion lib, scripts, configs)
-    preconditions:
-      - sh: '[ -f ./tests/unit/lib/bats-core/bin/bats ]'
-        msg: "bats-core not found — run: git submodule update --init --recursive"
-    deps:
-      - test:unit:assert
-      - test:unit:scripts
-      - test:unit:figure-pack
+    cmds:
+      - '[ -f ./tests/unit/lib/bats-core/bin/bats ] || git submodule update --init --recursive'
+      - task: test:unit:assert
+      - task: test:unit:scripts
+      - task: test:unit:figure-pack
 
   test:unit:assert:
     internal: true
@@ -253,12 +251,14 @@ tasks:
   test:art-library:
     desc: "Validate every art-library/sets/* manifest"
     cmds:
+      - '[ -f ./tests/unit/lib/bats-core/bin/bats ] || git submodule update --init --recursive'
       - cd art-library/_tooling && npm install --silent
       - ./tests/unit/lib/bats-core/bin/bats tests/unit/test_art_library_manifest.bats
 
   test:manifests:
     desc: Validate kustomize output structure (no cluster needed)
     cmds:
+      - '[ -f ./tests/unit/lib/bats-core/bin/bats ] || git submodule update --init --recursive'
       - ./tests/unit/lib/bats-core/bin/bats tests/unit/manifests.bats
 
   test:menu-gate:


### PR DESCRIPTION
## Summary
- `test:unit`, `test:manifests`, and `test:art-library` now auto-run `git submodule update --init --recursive` when bats-core binary is absent
- Converts hard-fail `preconditions` block in `test:unit` to a self-healing `cmds` guard
- Applies the same guard to `test:manifests` and `test:art-library` which previously had no check at all

Fixes T000107.

## Test plan
- [ ] `task test:unit` in a fresh worktree (bats-core absent) should succeed by auto-initialising submodules
- [ ] `task test:unit` in normal repo with submodules already present skips the init (no-op)
- [ ] CI `task test:all` continues to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)