### PR TITLE
chore(ci): fix brett test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,11 +122,13 @@ jobs:
     name: Brett Server Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with: { node-version: '22' }
       - run: npm ci --prefix brett
-      - run: node --test brett/test/ws-reconnect.test.mjs brett/test/physics.test.js brett/test/damage.test.mjs brett/test/pickups.test.mjs brett/test/mode-state.test.mjs
+      - run: node --test brett/test/*.test.js brett/test/*.test.mjs
+        env:
+          MOCK_DB: 'true'
 
   arena-proto-drift:
     name: Arena protocol drift guard

--- a/brett/package.json
+++ b/brett/package.json
@@ -6,7 +6,7 @@
   "type": "commonjs",
   "scripts": {
     "start": "node server.js",
-    "test": "node --test test/*.test.js"
+    "test": "MOCK_DB=true node --test test/*.test.js test/*.test.mjs"
   },
   "dependencies": {
     "express": "^5.2.1",

--- a/brett/public/assets/combat/damage.mjs
+++ b/brett/public/assets/combat/damage.mjs
@@ -23,3 +23,30 @@ export function validateDamageEvent({ weapon, shooter, victim, shooterPos, now }
   }
   return { ok: true };
 }
+
+// Returns true when target falls within the forward-facing cone — used for katana sweep hit detection.
+// facingX/facingZ must be a unit vector; arcDeg is the full cone width (half on each side).
+export function sweepArcContains({ selfX, selfZ, targetX, targetZ, facingX, facingZ, arcDeg }) {
+  const dx = targetX - selfX;
+  const dz = targetZ - selfZ;
+  const len = Math.hypot(dx, dz);
+  if (len === 0) return true;
+  const dot = (dx / len) * facingX + (dz / len) * facingZ;
+  return dot >= Math.cos((arcDeg / 2) * Math.PI / 180);
+}
+
+// Interval between fire-damage ticks (ms).
+export const BURN_TICK_MS = 500;
+
+// Fires callback(tickIndex) every BURN_TICK_MS for durMs total duration.
+// tickIndex starts at 1. Returns the interval ID so the caller can cancel early.
+export function startBurnTimer(durMs, callback) {
+  const totalTicks = Math.round(durMs / BURN_TICK_MS);
+  let tick = 0;
+  const id = setInterval(() => {
+    tick++;
+    callback(tick);
+    if (tick >= totalTicks) clearInterval(id);
+  }, BURN_TICK_MS);
+  return id;
+}


### PR DESCRIPTION
## Summary

- **Fixes CI breakage**: `damage.test.mjs` imported `sweepArcContains`, `startBurnTimer`, and `BURN_TICK_MS` from `damage.mjs`, but these were never implemented — causing a `SyntaxError` at module load time that silently failed the entire file
- **Implements the missing exports** in `brett/public/assets/combat/damage.mjs` (katana arc detection + fire burn timer)
- **Adds 14 previously excluded server tests** to CI: `server-admin.test.js` (admin auth, state mutations) and `server-mayhem.test.js` (disconnect handling, LMS game mode, winner/draw logic) were never in the hardcoded CI file list
- Switches the CI step from a hardcoded file list to a glob (`*.test.js *.test.mjs`) with `MOCK_DB=true` env
- Fixes `actions/checkout@v4` → `@v5` to match all other jobs
- Fixes `npm test` in `brett/package.json` to include `.mjs` test files

## Test plan

- [x] `MOCK_DB=true node --test brett/test/*.test.js brett/test/*.test.mjs` — 43/43 pass locally
- [x] All 7 brett test files now covered (was 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)