### PR TITLE
feat(brett): Controls & Keybinding panel — entry toast, discovery banner, rebind modal

### DIFF
--- a/brett/public/assets/mayhem/controls-panel.js
+++ b/brett/public/assets/mayhem/controls-panel.js
@@ -1,0 +1,260 @@
+// brett/public/assets/mayhem/controls-panel.js
+(function (root) {
+  const TABS = [
+    {
+      id: 'move', label: 'Bewegung',
+      actions: [
+        { action: 'forward',  label: 'Vorwärts' },
+        { action: 'backward', label: 'Rückwärts' },
+        { action: 'left',     label: 'Links' },
+        { action: 'right',    label: 'Rechts' },
+        { action: 'sprint',   label: 'Sprint' },
+        { action: 'jump',     label: 'Springen' },
+      ],
+    },
+    {
+      id: 'combat', label: 'Kampf',
+      actions: [
+        { action: null,         label: 'Schießen', fixed: 'LMB' },
+        { action: 'flail',      label: 'Flegel' },
+        { action: 'prevWeapon', label: 'Vorige Waffe' },
+        { action: 'nextWeapon', label: 'Nächste Waffe' },
+        { action: 'reload',     label: 'Respawn' },
+      ],
+    },
+    {
+      id: 'utility', label: 'Sonstiges',
+      actions: [
+        { action: 'vehicle',      label: 'Fahrzeug spawnen' },
+        { action: 'cycleMode',    label: 'Modus wechseln' },
+        { action: 'toggleMayhem', label: 'Mayhem ein/aus' },
+      ],
+    },
+  ];
+
+  function codeLabel(code) {
+    const map = {
+      'Space': 'Leertaste', 'ShiftLeft': 'Shift L', 'ShiftRight': 'Shift R',
+      'ArrowUp': '↑', 'ArrowDown': '↓', 'ArrowLeft': '←', 'ArrowRight': '→',
+    };
+    if (map[code]) return map[code];
+    if (code.startsWith('Key')) return code.slice(3);
+    if (code.startsWith('Digit')) return code.slice(5);
+    return code;
+  }
+
+  // ── Entry toast ──────────────────────────────────────────────────────────────
+  function showEntryToast() {
+    const kb = root.MayhemKeybindings ? root.MayhemKeybindings.load() : {};
+    const existing = document.getElementById('brett-mayhem-toast');
+    if (existing) existing.remove();
+
+    const el = document.createElement('div');
+    el.id = 'brett-mayhem-toast';
+    el.style.cssText = [
+      'position:fixed', 'top:12px', 'left:50%', 'transform:translateX(-50%)',
+      'background:rgba(0,0,0,.82)', 'border:1px solid #3d2a6e', 'border-radius:6px',
+      'padding:6px 14px', 'font:13px/1.4 monospace', 'color:#a89abb',
+      'z-index:9999', 'cursor:pointer', 'user-select:none',
+      'animation:brett-toast-in .25s ease',
+    ].join(';');
+    el.innerHTML =
+      `<kbd style="color:#c8f76a">${codeLabel(kb.forward||'KeyW')}${codeLabel(kb.backward||'KeyS')}${codeLabel(kb.left||'KeyA')}${codeLabel(kb.right||'KeyD')}</kbd> bewegen · ` +
+      `<kbd style="color:#c8f76a">${codeLabel(kb.jump||'Space')}</kbd> springen · ` +
+      `<kbd style="color:#c8f76a">LMB</kbd> schießen · ` +
+      `<kbd style="color:#c8f76a">⚙</kbd> Controls`;
+    document.body.appendChild(el);
+
+    const timer = setTimeout(() => el.remove(), 4000);
+    el.addEventListener('click', () => { clearTimeout(timer); el.remove(); });
+
+    // Inject CSS once
+    if (!document.getElementById('brett-toast-css')) {
+      const s = document.createElement('style');
+      s.id = 'brett-toast-css';
+      s.textContent = '@keyframes brett-toast-in{from{opacity:0;transform:translateX(-50%) translateY(-8px)}to{opacity:1;transform:translateX(-50%) translateY(0)}}';
+      document.head.appendChild(s);
+    }
+  }
+
+  // ── Discovery banner (once per session) ─────────────────────────────────────
+  function showDiscoveryBanner() {
+    if (sessionStorage.getItem('brett:mayhem-hint-shown')) return;
+    sessionStorage.setItem('brett:mayhem-hint-shown', '1');
+
+    const el = document.createElement('div');
+    el.id = 'brett-mayhem-discovery';
+    el.style.cssText = [
+      'position:fixed', 'bottom:16px', 'left:50%', 'transform:translateX(-50%)',
+      'background:rgba(14,8,28,.92)', 'border:1px solid #5a3a9e', 'border-radius:8px',
+      'padding:10px 20px', 'font:13px/1.5 monospace', 'color:#c0b8d0',
+      'z-index:9998', 'cursor:pointer', 'text-align:center',
+    ].join(';');
+    el.innerHTML =
+      '🤸 <strong style="color:#c8f76a">Mayhem-Modus verfügbar</strong><br>' +
+      'Drücke <kbd style="background:#2a1e4e;padding:1px 5px;border-radius:3px;color:#c8f76a">M</kbd> ' +
+      'oder klicke auf den 🤸 Button, um zu kämpfen.<br>' +
+      '<small style="color:#4a3870">Klicken zum Schließen</small>';
+    document.body.appendChild(el);
+    el.addEventListener('click', () => el.remove());
+    setTimeout(() => el && el.parentNode && el.remove(), 8000);
+  }
+
+  // ── ⚙ Controls modal ────────────────────────────────────────────────────────
+  let _rebinding = null; // { action, chipEl }
+
+  function openControlsPanel() {
+    if (document.getElementById('brett-controls-modal')) return;
+
+    const bindings = root.MayhemKeybindings ? root.MayhemKeybindings.load() : {};
+
+    const overlay = document.createElement('div');
+    overlay.id = 'brett-controls-modal';
+    overlay.style.cssText = [
+      'position:fixed', 'inset:0', 'background:rgba(0,0,0,.78)',
+      'display:flex', 'align-items:center', 'justify-content:center',
+      'z-index:10000', 'font-family:monospace',
+    ].join(';');
+
+    overlay.innerHTML = `
+      <div style="background:#120d1c;border:1px solid #3d2a6e;border-radius:10px;
+                  min-width:340px;max-width:420px;width:90%;padding:20px 24px;">
+        <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:14px">
+          <span style="color:#c8f76a;letter-spacing:.12em;font-size:13px">STEUERUNG</span>
+          <button id="brett-ctrl-close" style="background:none;border:none;color:#6a5a8a;font-size:18px;cursor:pointer;line-height:1">✕</button>
+        </div>
+        <div id="brett-ctrl-tabs" style="display:flex;gap:6px;margin-bottom:14px">
+          ${TABS.map((t, i) => `
+            <button data-tab="${t.id}"
+              style="background:${i===0?'#2a1e4e':'#1a1030'};border:1px solid ${i===0?'#c8f76a':'#2e1f55'};
+                     color:${i===0?'#c8f76a':'#6a5a8a'};border-radius:4px;
+                     padding:4px 12px;font:11px monospace;cursor:pointer;letter-spacing:.08em"
+            >${t.label}</button>
+          `).join('')}
+        </div>
+        <div id="brett-ctrl-content" style="min-height:160px"></div>
+        <div style="margin-top:14px;display:flex;justify-content:space-between;align-items:center">
+          <button id="brett-ctrl-reset"
+            style="background:none;border:none;color:#4a3870;font:11px monospace;cursor:pointer">
+            Zurücksetzen
+          </button>
+          <span id="brett-ctrl-hint" style="font-size:10px;color:#3a2a5e">
+            Klicke eine Taste zum Ändern
+          </span>
+        </div>
+      </div>`;
+
+    document.body.appendChild(overlay);
+
+    let activeTab = TABS[0].id;
+    renderTabContent(activeTab, bindings);
+
+    // Tab switching
+    overlay.querySelector('#brett-ctrl-tabs').addEventListener('click', e => {
+      const btn = e.target.closest('[data-tab]');
+      if (!btn) return;
+      activeTab = btn.dataset.tab;
+      overlay.querySelectorAll('[data-tab]').forEach(b => {
+        const active = b.dataset.tab === activeTab;
+        b.style.background = active ? '#2a1e4e' : '#1a1030';
+        b.style.borderColor = active ? '#c8f76a' : '#2e1f55';
+        b.style.color = active ? '#c8f76a' : '#6a5a8a';
+      });
+      renderTabContent(activeTab, bindings);
+    });
+
+    // Reset
+    overlay.querySelector('#brett-ctrl-reset').addEventListener('click', () => {
+      if (!root.MayhemKeybindings) return;
+      const def = { ...root.MayhemKeybindings.DEFAULT_BINDINGS };
+      root.MayhemKeybindings.save(def);
+      Object.assign(bindings, def);
+      renderTabContent(activeTab, bindings);
+      root.dispatchEvent(new CustomEvent('brett:keybindings-changed'));
+    });
+
+    // Close
+    overlay.querySelector('#brett-ctrl-close').addEventListener('click', () => overlay.remove());
+    overlay.addEventListener('click', e => { if (e.target === overlay) overlay.remove(); });
+
+    // Keydown listener for rebinding
+    const onKeyDown = e => {
+      if (!_rebinding) return;
+      e.preventDefault();
+      if (e.code === 'Escape') {
+        cancelRebind();
+        return;
+      }
+      const { action } = _rebinding;
+      // Conflict check
+      const existing = root.MayhemKeybindings ? root.MayhemKeybindings.getAction(e.code, bindings) : null;
+      if (existing && existing !== action) {
+        // Swap
+        bindings[existing] = bindings[action];
+        if (root.MayhemKeybindings) root.MayhemKeybindings.save(bindings);
+      }
+      bindings[action] = e.code;
+      if (root.MayhemKeybindings) root.MayhemKeybindings.save(bindings);
+      root.dispatchEvent(new CustomEvent('brett:keybindings-changed'));
+      _rebinding = null;
+      renderTabContent(activeTab, bindings);
+      overlay.querySelector('#brett-ctrl-hint').textContent = 'Klicke eine Taste zum Ändern';
+    };
+    window.addEventListener('keydown', onKeyDown);
+
+    // Use MutationObserver to clean up keydown listener when modal removed
+    const observer = new MutationObserver(() => {
+      if (!document.getElementById('brett-controls-modal')) {
+        window.removeEventListener('keydown', onKeyDown);
+        observer.disconnect();
+      }
+    });
+    observer.observe(document.body, { childList: true });
+  }
+
+  function renderTabContent(tabId, bindings) {
+    const tab = TABS.find(t => t.id === tabId);
+    const content = document.getElementById('brett-ctrl-content');
+    if (!content || !tab) return;
+    content.innerHTML = tab.actions.map(row => {
+      if (row.fixed) {
+        return `<div style="display:flex;justify-content:space-between;align-items:center;padding:4px 0;border-bottom:1px solid #1e1640">
+          <span style="color:#c0b8d0;font-size:12px">${row.label}</span>
+          <span style="background:#1e1640;border:1px solid #2e1f55;border-radius:3px;
+                       color:#6a5a8a;padding:2px 10px;font-size:11px">${row.fixed}</span>
+        </div>`;
+      }
+      const code = bindings[row.action] || '—';
+      return `<div style="display:flex;justify-content:space-between;align-items:center;padding:4px 0;border-bottom:1px solid #1e1640">
+        <span style="color:#c0b8d0;font-size:12px">${row.label}</span>
+        <button data-rebind="${row.action}"
+          style="background:#1e1640;border:1px solid #3d2a6e;border-radius:3px;
+                 color:#c8f76a;padding:2px 10px;font:11px monospace;cursor:pointer;min-width:52px">
+          ${codeLabel(code)}
+        </button>
+      </div>`;
+    }).join('');
+
+    content.addEventListener('click', e => {
+      const btn = e.target.closest('[data-rebind]');
+      if (!btn) return;
+      cancelRebind();
+      _rebinding = { action: btn.dataset.rebind, chipEl: btn };
+      btn.style.background = '#4a0a0a';
+      btn.style.borderColor = '#ff4444';
+      btn.style.color = '#fff';
+      btn.textContent = 'Taste drücken…';
+      document.getElementById('brett-ctrl-hint').textContent = 'ESC zum Abbrechen';
+    });
+  }
+
+  function cancelRebind() {
+    if (!_rebinding) return;
+    _rebinding = null;
+    const activeTab = document.querySelector('[data-tab]')?.dataset.tab || TABS[0].id;
+    renderTabContent(activeTab, root.MayhemKeybindings ? root.MayhemKeybindings.load() : {});
+  }
+
+  // ── Public API ───────────────────────────────────────────────────────────────
+  root.MayhemControlsPanel = { showEntryToast, showDiscoveryBanner, openControlsPanel };
+})(typeof globalThis !== 'undefined' ? globalThis : this);

--- a/brett/public/assets/mayhem/keybindings.js
+++ b/brett/public/assets/mayhem/keybindings.js
@@ -1,0 +1,40 @@
+// brett/public/assets/mayhem/keybindings.js
+(function (root) {
+  const DEFAULT_BINDINGS = {
+    forward: 'KeyW', backward: 'KeyS', left: 'KeyA', right: 'KeyD',
+    sprint: 'ShiftLeft', jump: 'Space', flail: 'KeyF',
+    prevWeapon: 'KeyQ', nextWeapon: 'KeyE',
+    reload: 'KeyR', vehicle: 'KeyV', cycleMode: 'KeyG', toggleMayhem: 'KeyM',
+  };
+  const STORAGE_KEY = 'brett:keybindings';
+
+  function load() {
+    try {
+      const raw = root.localStorage ? root.localStorage.getItem(STORAGE_KEY) : null;
+      const saved = raw ? JSON.parse(raw) : null;
+      return saved ? { ...DEFAULT_BINDINGS, ...saved } : { ...DEFAULT_BINDINGS };
+    } catch (_) {
+      return { ...DEFAULT_BINDINGS };
+    }
+  }
+
+  function save(bindings) {
+    try {
+      root.localStorage && root.localStorage.setItem(STORAGE_KEY, JSON.stringify(bindings));
+    } catch (_) {}
+  }
+
+  function getAction(code, bindings) {
+    for (const [action, key] of Object.entries(bindings)) {
+      if (key === code) return action;
+    }
+    return null;
+  }
+
+  const api = { DEFAULT_BINDINGS, load, save, getAction };
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = api;
+  } else {
+    root.MayhemKeybindings = api;
+  }
+})(typeof globalThis !== 'undefined' ? globalThis : this);

--- a/brett/public/assets/mayhem/mayhem.js
+++ b/brett/public/assets/mayhem/mayhem.js
@@ -60,26 +60,40 @@ const Mayhem = (() => {
 
   // ── Key / mouse bindings ──────────────────────────────────────────────────
   function bindKeys() {
-    const movMap = {
-      'KeyW': 'forward', 'KeyS': 'backward', 'KeyA': 'left', 'KeyD': 'right',
-      'ShiftLeft': 'sprint', 'ShiftRight': 'sprint', 'Space': 'jump', 'KeyF': 'flail',
-    };
+    let _b = window.MayhemKeybindings ? window.MayhemKeybindings.load() : null;
+    function b() { return _b || {}; }
+
     const weaponIdx = { 'Digit1': 0, 'Digit2': 1, 'Digit3': 2, 'Digit4': 3, 'Digit5': 4 };
 
     window.addEventListener('keydown', (e) => {
       if (!enabled) return;
-      if (movMap[e.code]) { input[movMap[e.code]] = true; e.preventDefault(); }
-      if (weaponIdx[e.code] !== undefined) weaponSystem?.select(weaponIdx[e.code]);
-      if (e.code === 'KeyQ') weaponSystem?.prev();
-      if (e.code === 'KeyE') weaponSystem?.next();
-      if (e.code === 'KeyR') gameMode?.onRespawnKey(playerId);
-      if (e.code === 'KeyV') spawnVehicleLocal();
-      if (e.code === 'KeyG') cycleMode();
-      if (e.code === 'KeyM') toggle();
+      const kb = b();
+      const code = e.code;
+      if (code === kb.forward)      { input.forward  = true; e.preventDefault(); }
+      if (code === kb.backward)     { input.backward = true; e.preventDefault(); }
+      if (code === kb.left)         { input.left     = true; e.preventDefault(); }
+      if (code === kb.right)        { input.right    = true; e.preventDefault(); }
+      if (code === kb.sprint || code === 'ShiftRight') { input.sprint = true; }
+      if (code === kb.jump)         { input.jump     = true; e.preventDefault(); }
+      if (code === kb.flail)        input.flail    = true;
+      if (weaponIdx[code] !== undefined) weaponSystem?.select(weaponIdx[code]);
+      if (code === kb.prevWeapon)   weaponSystem?.prev();
+      if (code === kb.nextWeapon)   weaponSystem?.next();
+      if (code === kb.reload)       gameMode?.onRespawnKey(playerId);
+      if (code === kb.vehicle)      spawnVehicleLocal();
+      if (code === kb.cycleMode)    cycleMode();
+      if (code === kb.toggleMayhem) toggle();
     });
     window.addEventListener('keyup', (e) => {
-      if (movMap[e.code]) input[movMap[e.code]] = false;
-      if (e.code === 'MouseLeft') input.fire = false;
+      const kb = b();
+      const code = e.code;
+      if (code === kb.forward)  input.forward  = false;
+      if (code === kb.backward) input.backward = false;
+      if (code === kb.left)     input.left     = false;
+      if (code === kb.right)    input.right    = false;
+      if (code === kb.sprint || code === 'ShiftRight') input.sprint = false;
+      if (code === kb.jump)     input.jump     = false;
+      if (code === kb.flail)    input.flail    = false;
     });
     canvas.addEventListener('mousedown', (e) => {
       if (!enabled) return;
@@ -92,13 +106,25 @@ const Mayhem = (() => {
       if (!enabled) return;
       if (e.deltaY < 0) weaponSystem?.prev(); else weaponSystem?.next();
     }, { passive: true });
+
+    // Allow controls-panel to notify mayhem to reload bindings after rebind
+    window.addEventListener('brett:keybindings-changed', () => {
+      if (window.MayhemKeybindings) _b = window.MayhemKeybindings.load();
+      // Clear all movement keys to avoid stuck states
+      Object.keys(input).forEach(k => { input[k] = false; });
+    });
   }
 
   // ── Enable / toggle ───────────────────────────────────────────────────────
   function setEnabled(on) {
     if (on === enabled) return;
     enabled = on;
-    if (on) start(); else stop();
+    if (on) {
+      start();
+      window.dispatchEvent(new CustomEvent('brett:mayhem-enabled'));
+    } else {
+      stop();
+    }
   }
   function toggle() { send({ type: 'mayhem_mode', enabled: !enabled }); }
 

--- a/brett/public/index.html
+++ b/brett/public/index.html
@@ -111,6 +111,7 @@
       <button class="preset-btn" data-preset="crawl">Crawl</button>
       <button class="preset-btn" data-preset="slump">Slump</button>
 <button id="mayhem-btn" type="button" style="margin-left:8px;">🤸 Mayhem</button>
+<button id="brett-controls-btn" type="button" style="margin-left:4px;" title="Steuerung anpassen">⚙</button>
       <button class="preset-btn" data-preset="tpose">T-Pose</button>
     </div>
     <div class="sep"></div>
@@ -1111,6 +1112,7 @@
         });
         if (joinMode === 'spectator') window._mayhemSpectator = true;
       }
+      window.MayhemControlsPanel?.showDiscoveryBanner();
     });
 
     ws.addEventListener("close", () => {
@@ -1124,6 +1126,14 @@
   connectWS();
 
   document.getElementById("mayhem-btn")?.addEventListener("click", () => window.Mayhem?.toggle());
+  document.getElementById("brett-controls-btn")?.addEventListener("click", () => {
+    window.MayhemControlsPanel?.openControlsPanel();
+  });
+
+  // Toast fires via custom event dispatched from mayhem.js setEnabled
+  window.addEventListener('brett:mayhem-enabled', () => {
+    window.MayhemControlsPanel?.showEntryToast();
+  });
 
   function onWsMessage(evt) {
     let msg; try { msg = JSON.parse(evt.data); } catch { return; }
@@ -1260,6 +1270,8 @@
 <script src="assets/mayhem/effects.js"></script>
 <script src="assets/mayhem/game-mode.js"></script>
 <script src="assets/mayhem/ai-bot.js"></script>
+<script src="assets/mayhem/keybindings.js"></script>
+<script src="assets/mayhem/controls-panel.js"></script>
 <script src="assets/mayhem/mayhem.js"></script>
 <script src="assets/room-browser.js"></script>
 <script src="assets/admin-panel.js"></script>

--- a/brett/test/keybindings.test.js
+++ b/brett/test/keybindings.test.js
@@ -1,0 +1,63 @@
+'use strict';
+const test = require('node:test');
+const assert = require('node:assert');
+
+// Mock localStorage for Node
+let _store = {};
+global.localStorage = {
+  getItem: k => _store[k] ?? null,
+  setItem: (k, v) => { _store[k] = v; },
+  removeItem: k => { delete _store[k]; },
+};
+
+const { DEFAULT_BINDINGS, load, save, getAction } = require('../public/assets/mayhem/keybindings.js');
+
+test('load returns defaults when nothing stored', () => {
+  _store = {};
+  const b = load();
+  assert.strictEqual(b.forward, 'KeyW');
+  assert.strictEqual(b.backward, 'KeyS');
+  assert.strictEqual(b.jump, 'Space');
+  assert.strictEqual(b.toggleMayhem, 'KeyM');
+});
+
+test('load merges stored overrides onto defaults', () => {
+  _store = {};
+  save({ forward: 'ArrowUp', jump: 'KeyX' });
+  const b = load();
+  assert.strictEqual(b.forward, 'ArrowUp');
+  assert.strictEqual(b.jump, 'KeyX');
+  assert.strictEqual(b.backward, 'KeyS'); // default preserved
+  assert.strictEqual(b.reload, 'KeyR');   // default preserved
+});
+
+test('load returns defaults when localStorage contains invalid JSON', () => {
+  _store = { 'brett:keybindings': 'not-json{' };
+  const b = load();
+  assert.strictEqual(b.forward, 'KeyW');
+});
+
+test('getAction finds action for a default key code', () => {
+  const b = { ...DEFAULT_BINDINGS };
+  assert.strictEqual(getAction('KeyW', b), 'forward');
+  assert.strictEqual(getAction('Space', b), 'jump');
+  assert.strictEqual(getAction('KeyM', b), 'toggleMayhem');
+});
+
+test('getAction returns null for unmapped key', () => {
+  assert.strictEqual(getAction('KeyZ', { ...DEFAULT_BINDINGS }), null);
+});
+
+test('getAction reflects custom bindings', () => {
+  const b = { ...DEFAULT_BINDINGS, forward: 'ArrowUp' };
+  assert.strictEqual(getAction('ArrowUp', b), 'forward');
+  assert.strictEqual(getAction('KeyW', b), null);
+});
+
+test('save persists and load retrieves', () => {
+  _store = {};
+  const custom = { ...DEFAULT_BINDINGS, jump: 'KeyJ' };
+  save(custom);
+  const b = load();
+  assert.strictEqual(b.jump, 'KeyJ');
+});


### PR DESCRIPTION
## Summary
- Adds `keybindings.js` — localStorage-backed keybinding storage (UMD, Node-testable)
- Updates `mayhem.js` — `bindKeys()` reads from `MayhemKeybindings`, dispatches `brett:mayhem-enabled` on enable
- Adds `controls-panel.js` — entry toast on mayhem enable, discovery banner on room join (sessionStorage-guarded), ⚙ modal with three tabs and per-action rebinding with conflict swap
- Wires everything into `index.html` — new script tags, ⚙ button in toolbar, listeners for toast and discovery banner

## Test plan
- [x] `MOCK_DB=true node --test brett/test/keybindings.test.js` — 7 tests pass
- [x] `MOCK_DB=true node --test brett/test/*.test.js` — all pass (no regressions)
- [x] Discovery banner: appears once per session on WebSocket open
- [x] Entry toast: appears on mayhem enable, auto-dismisses in 4s
- [x] ⚙ Controls modal: tabs, rebind flow, conflict swap, Zurücksetzen, ESC cancel
- [x] WASD still works after rebinding exercise

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>