### PR TITLE
feat(arena): input loop — WASD/aim/fire/melee + entry toast + Controls rebinding panel

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -45,6 +45,7 @@
         "@types/nodemailer": "^7.0.11",
         "@types/pdfkit": "^0.17.6",
         "@types/qrcode": "^1.5.6",
+        "jsdom": "^29.1.1",
         "pg-mem": "^3.0.14",
         "tailwindcss": "^4.1.0",
         "tsx": "^4.22.2",
@@ -72,6 +73,57 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@astrojs/check": {
       "version": "0.9.9",
@@ -602,6 +654,19 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
     "node_modules/@bufbuild/protobuf": {
       "version": "1.10.1",
       "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.10.1.tgz",
@@ -646,6 +711,146 @@
       },
       "engines": {
         "node": ">= 20.12.0"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.1.tgz",
+      "integrity": "sha512-eZ5XOtyhK+mggRafYUWzA0tvaYOFgdY8AkgQiCJF9qNAePnUo/zmsqqYubBBb3sQ8uNUaSKTY9s9klfRaAXL0g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.4.tgz",
+      "integrity": "sha512-wgsqt92b7C7tQhIdPNxj0n9zuUbQlvAuI1exyzeNrOKOi62SD7ren8zqszmpVREjAOqg8cD2FqYhQfAuKjk4sw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@emmetio/abbreviation": {
@@ -1127,6 +1332,24 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@fontsource/inter": {
@@ -3576,6 +3799,16 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -4093,6 +4326,20 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -4118,6 +4365,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/decode-named-character-reference": {
       "version": "1.3.0",
@@ -5148,6 +5402,19 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
@@ -5281,6 +5548,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-reference": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
@@ -5365,6 +5639,73 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/jsdom/node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/jsesc": {
@@ -5816,9 +6157,9 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "11.2.7",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
-      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "version": "11.5.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.0.tgz",
+      "integrity": "sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -7507,6 +7848,16 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/qrcode": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
@@ -8132,6 +8483,19 @@
         "node": ">=11.0.0"
       }
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -8500,6 +8864,13 @@
         "url": "https://opencollective.com/svgo"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tailwindcss": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
@@ -8587,6 +8958,26 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.0.30",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.30.tgz",
+      "integrity": "sha512-ELrFxuqsDdHUwoh0XxDbxuLD3Wnz49Z57IFvTtvWy1hJdcMZjXLIuonjilCiWHlT2GbE4Wlv1wKVTzDFnXH1aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.30"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.30",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.30.tgz",
+      "integrity": "sha512-uiHN8PIB1VmWyS98eZYja4xzlYqeFZVjb4OuYlJQnZAuJhMw4PbKQOKgHKhBdJR3FE/t5mUQ1Kd80++B+qhD1Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -8594,6 +8985,32 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/trim-lines": {
@@ -9207,6 +9624,16 @@
       "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
       "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
       "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
     },
     "node_modules/undici-types": {
       "version": "7.18.2",
@@ -9981,6 +10408,19 @@
       "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
       "license": "MIT"
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/web-namespaces": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
@@ -9989,6 +10429,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/webrtc-adapter": {
@@ -10002,6 +10452,31 @@
       "engines": {
         "node": ">=6.0.0",
         "npm": ">=3.10.0"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/which-module": {
@@ -10057,6 +10532,16 @@
         }
       }
     },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/xml2js": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
@@ -10078,6 +10563,13 @@
       "engines": {
         "node": ">=4.0"
       }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/xmlhttprequest-ssl": {
       "version": "2.1.2",

--- a/website/package.json
+++ b/website/package.json
@@ -50,6 +50,7 @@
     "@types/nodemailer": "^7.0.11",
     "@types/pdfkit": "^0.17.6",
     "@types/qrcode": "^1.5.6",
+    "jsdom": "^29.1.1",
     "pg-mem": "^3.0.14",
     "tailwindcss": "^4.1.0",
     "tsx": "^4.22.2",

--- a/website/src/components/arena/game/ControlsPanel.tsx
+++ b/website/src/components/arena/game/ControlsPanel.tsx
@@ -1,0 +1,178 @@
+// website/src/components/arena/game/ControlsPanel.tsx
+import React, { useState, useEffect, useCallback } from 'react';
+import {
+  type ArenaBindings, DEFAULT_BINDINGS,
+  loadBindings, saveBinding,
+} from './input';
+
+type Tab = 'move' | 'combat' | 'utility';
+
+interface ActionRow {
+  action: keyof ArenaBindings | null;
+  label: string;
+  fixed?: string;
+}
+
+const TABS: { id: Tab; label: string; rows: ActionRow[] }[] = [
+  {
+    id: 'move', label: 'Bewegung',
+    rows: [
+      { action: 'up',    label: 'Vorwärts' },
+      { action: 'down',  label: 'Rückwärts' },
+      { action: 'left',  label: 'Links' },
+      { action: 'right', label: 'Rechts' },
+      { action: 'dodge', label: 'Ausweichen' },
+    ],
+  },
+  {
+    id: 'combat', label: 'Kampf',
+    rows: [
+      { action: null,    label: 'Schießen',  fixed: 'LMB' },
+      { action: 'melee', label: 'Nahkampf' },
+      { action: 'pickup', label: 'Aufheben' },
+    ],
+  },
+  {
+    id: 'utility', label: 'Sonstiges',
+    rows: [
+      { action: null, label: 'Nachladen', fixed: 'automatisch' },
+    ],
+  },
+];
+
+function codeLabel(code: string): string {
+  const map: Record<string, string> = {
+    Space: 'Leertaste', ShiftLeft: 'Shift L', ShiftRight: 'Shift R',
+    Mouse0: 'LMB', ArrowUp: '↑', ArrowDown: '↓', ArrowLeft: '←', ArrowRight: '→',
+  };
+  if (map[code]) return map[code];
+  if (code.startsWith('Key')) return code.slice(3);
+  if (code.startsWith('Digit')) return code.slice(5);
+  return code;
+}
+
+interface Props {
+  onClose: () => void;
+}
+
+export function ControlsPanel({ onClose }: Props) {
+  const [activeTab, setActiveTab] = useState<Tab>('move');
+  const [bindings, setBindings] = useState<ArenaBindings>(loadBindings);
+  const [rebinding, setRebinding] = useState<keyof ArenaBindings | null>(null);
+
+  const handleChipClick = useCallback((action: keyof ArenaBindings) => {
+    setRebinding(action);
+  }, []);
+
+  const handleReset = useCallback(() => {
+    Object.keys(DEFAULT_BINDINGS).forEach(k => {
+      saveBinding(k as keyof ArenaBindings, DEFAULT_BINDINGS[k as keyof ArenaBindings]);
+    });
+    setBindings(loadBindings());
+    setRebinding(null);
+    window.dispatchEvent(new CustomEvent('arena:keybindings-changed'));
+  }, []);
+
+  useEffect(() => {
+    if (!rebinding) return;
+    const onKey = (e: KeyboardEvent) => {
+      e.preventDefault();
+      if (e.code === 'Escape') { setRebinding(null); return; }
+      const conflicting = (Object.keys(bindings) as (keyof ArenaBindings)[])
+        .find(k => k !== rebinding && bindings[k] === e.code);
+      if (conflicting) saveBinding(conflicting, bindings[rebinding]);
+      saveBinding(rebinding, e.code);
+      const updated = loadBindings();
+      setBindings(updated);
+      setRebinding(null);
+      window.dispatchEvent(new CustomEvent('arena:keybindings-changed'));
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [rebinding, bindings]);
+
+  const tab = TABS.find(t => t.id === activeTab)!;
+
+  return (
+    <div
+      onClick={e => { if (e.target === e.currentTarget) onClose(); }}
+      style={{
+        position: 'absolute', inset: 0, background: 'rgba(0,0,0,.78)',
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+        zIndex: 30, fontFamily: 'monospace',
+      }}
+    >
+      <div style={{
+        background: '#120d1c', border: '1px solid #3d2a6e', borderRadius: 10,
+        minWidth: 320, maxWidth: 400, width: '90%', padding: '20px 24px',
+      }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 14 }}>
+          <span style={{ color: '#c8f76a', letterSpacing: '.12em', fontSize: 13 }}>STEUERUNG</span>
+          <button
+            onClick={onClose}
+            style={{ background: 'none', border: 'none', color: '#6a5a8a', fontSize: 18, cursor: 'pointer', lineHeight: 1 }}
+          >✕</button>
+        </div>
+
+        <div style={{ display: 'flex', gap: 6, marginBottom: 14 }}>
+          {TABS.map(t => (
+            <button
+              key={t.id}
+              onClick={() => setActiveTab(t.id)}
+              style={{
+                background: t.id === activeTab ? '#2a1e4e' : '#1a1030',
+                border: `1px solid ${t.id === activeTab ? '#c8f76a' : '#2e1f55'}`,
+                color: t.id === activeTab ? '#c8f76a' : '#6a5a8a',
+                borderRadius: 4, padding: '4px 12px',
+                font: '11px monospace', cursor: 'pointer', letterSpacing: '.08em',
+              }}
+            >{t.label}</button>
+          ))}
+        </div>
+
+        <div style={{ minHeight: 140 }}>
+          {tab.rows.map(row => (
+            <div
+              key={row.label}
+              style={{
+                display: 'flex', justifyContent: 'space-between', alignItems: 'center',
+                padding: '5px 0', borderBottom: '1px solid #1e1640',
+              }}
+            >
+              <span style={{ color: '#c0b8d0', fontSize: 12 }}>{row.label}</span>
+              {row.fixed ? (
+                <span style={{
+                  background: '#1e1640', border: '1px solid #2e1f55', borderRadius: 3,
+                  color: '#6a5a8a', padding: '2px 10px', fontSize: 11,
+                }}>{row.fixed}</span>
+              ) : (
+                <button
+                  onClick={() => row.action && handleChipClick(row.action)}
+                  style={{
+                    background: rebinding === row.action ? '#4a0a0a' : '#1e1640',
+                    border: `1px solid ${rebinding === row.action ? '#ff4444' : '#3d2a6e'}`,
+                    borderRadius: 3,
+                    color: rebinding === row.action ? '#fff' : '#c8f76a',
+                    padding: '2px 10px', font: '11px monospace', cursor: 'pointer', minWidth: 52,
+                  }}
+                >
+                  {rebinding === row.action ? 'Taste drücken…' : codeLabel(bindings[row.action!])}
+                </button>
+              )}
+            </div>
+          ))}
+        </div>
+
+        <div style={{ marginTop: 14, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+          <button
+            onClick={handleReset}
+            style={{ background: 'none', border: 'none', color: '#4a3870', font: '11px monospace', cursor: 'pointer' }}
+          >Zurücksetzen</button>
+          <span style={{ fontSize: 10, color: '#3a2a5e' }}>
+            {rebinding ? 'ESC zum Abbrechen' : 'Klicke eine Taste zum Ändern'}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/website/src/components/arena/game/input.test.ts
+++ b/website/src/components/arena/game/input.test.ts
@@ -1,0 +1,98 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from 'vitest';
+import { computeWasd, computeAim, loadBindings, saveBinding, DEFAULT_BINDINGS } from './input';
+
+describe('computeWasd — 9-direction enum mirroring server WASD_DX/DY', () => {
+  it('returns 0 when no keys pressed', () => {
+    expect(computeWasd(false, false, false, false)).toBe(0);
+  });
+  it('returns 1 for up (W) only', () => {
+    expect(computeWasd(true, false, false, false)).toBe(1);
+  });
+  it('returns 2 for up-right (W+D)', () => {
+    expect(computeWasd(true, false, false, true)).toBe(2);
+  });
+  it('returns 3 for right (D) only', () => {
+    expect(computeWasd(false, false, false, true)).toBe(3);
+  });
+  it('returns 4 for down-right (S+D)', () => {
+    expect(computeWasd(false, true, false, true)).toBe(4);
+  });
+  it('returns 5 for down (S) only', () => {
+    expect(computeWasd(false, true, false, false)).toBe(5);
+  });
+  it('returns 6 for down-left (S+A)', () => {
+    expect(computeWasd(false, true, true, false)).toBe(6);
+  });
+  it('returns 7 for left (A) only', () => {
+    expect(computeWasd(false, false, true, false)).toBe(7);
+  });
+  it('returns 8 for up-left (W+A)', () => {
+    expect(computeWasd(true, false, true, false)).toBe(8);
+  });
+  it('returns 0 when up+down cancel', () => {
+    expect(computeWasd(true, true, false, false)).toBe(0);
+  });
+  it('returns 0 when left+right cancel', () => {
+    expect(computeWasd(false, false, true, true)).toBe(0);
+  });
+  it('returns 0 when all four keys pressed', () => {
+    expect(computeWasd(true, true, true, true)).toBe(0);
+  });
+});
+
+describe('computeAim', () => {
+  it('returns ~0 for mouse directly right of center', () => {
+    expect(computeAim(100, 0, 0, 0)).toBeCloseTo(0);
+  });
+  it('returns ~PI/2 for mouse directly below center', () => {
+    expect(computeAim(0, 100, 0, 0)).toBeCloseTo(Math.PI / 2);
+  });
+  it('returns ~PI for mouse directly left of center', () => {
+    expect(computeAim(-100, 0, 0, 0)).toBeCloseTo(Math.PI);
+  });
+  it('returns ~-PI/2 for mouse directly above center', () => {
+    expect(computeAim(0, -100, 0, 0)).toBeCloseTo(-Math.PI / 2);
+  });
+  it('handles non-zero canvas origin', () => {
+    expect(computeAim(150, 50, 50, 50)).toBeCloseTo(0);
+  });
+});
+
+describe('loadBindings / saveBinding', () => {
+  beforeEach(() => localStorage.clear());
+
+  it('returns defaults when nothing stored', () => {
+    const b = loadBindings();
+    expect(b.up).toBe('KeyW');
+    expect(b.down).toBe('KeyS');
+    expect(b.left).toBe('KeyA');
+    expect(b.right).toBe('KeyD');
+    expect(b.fire).toBe('Mouse0');
+    expect(b.melee).toBe('KeyE');
+    expect(b.pickup).toBe('KeyF');
+    expect(b.dodge).toBe('Space');
+  });
+
+  it('returns defaults when localStorage contains invalid JSON', () => {
+    localStorage.setItem('arena:keybindings', 'bad{json');
+    const b = loadBindings();
+    expect(b.up).toBe('KeyW');
+  });
+
+  it('merges saved override onto defaults', () => {
+    saveBinding('up', 'ArrowUp');
+    const b = loadBindings();
+    expect(b.up).toBe('ArrowUp');
+    expect(b.down).toBe('KeyS'); // default preserved
+  });
+
+  it('reflects multiple saved bindings', () => {
+    saveBinding('melee', 'KeyG');
+    saveBinding('dodge', 'ShiftLeft');
+    const b = loadBindings();
+    expect(b.melee).toBe('KeyG');
+    expect(b.dodge).toBe('ShiftLeft');
+    expect(b.pickup).toBe('KeyF'); // default preserved
+  });
+});

--- a/website/src/components/arena/game/input.ts
+++ b/website/src/components/arena/game/input.ts
@@ -1,0 +1,150 @@
+// website/src/components/arena/game/input.ts
+
+export interface ArenaBindings {
+  up: string; down: string; left: string; right: string;
+  fire: string; melee: string; pickup: string; dodge: string;
+}
+
+export const DEFAULT_BINDINGS: ArenaBindings = {
+  up: 'KeyW', down: 'KeyS', left: 'KeyA', right: 'KeyD',
+  fire: 'Mouse0', melee: 'KeyE', pickup: 'KeyF', dodge: 'Space',
+};
+
+const STORAGE_KEY = 'arena:keybindings';
+
+export function loadBindings(): ArenaBindings {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    const saved = raw ? JSON.parse(raw) : null;
+    return saved ? { ...DEFAULT_BINDINGS, ...saved } : { ...DEFAULT_BINDINGS };
+  } catch {
+    return { ...DEFAULT_BINDINGS };
+  }
+}
+
+export function saveBinding(action: keyof ArenaBindings, code: string): void {
+  const current = loadBindings();
+  current[action] = code;
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(current));
+}
+
+/**
+ * Maps boolean key states to the server's 9-direction WASD enum.
+ * 0=none, 1=up, 2=up-right, 3=right, 4=down-right,
+ * 5=down, 6=down-left, 7=left, 8=up-left
+ */
+export function computeWasd(up: boolean, down: boolean, left: boolean, right: boolean): number {
+  const u = up && !down;
+  const d = down && !up;
+  const l = left && !right;
+  const r = right && !left;
+  if (u && r) return 2;
+  if (d && r) return 4;
+  if (d && l) return 6;
+  if (u && l) return 8;
+  if (u) return 1;
+  if (r) return 3;
+  if (d) return 5;
+  if (l) return 7;
+  return 0;
+}
+
+/** Returns aim angle in radians (atan2 of mouse position relative to canvas center). */
+export function computeAim(
+  mouseX: number, mouseY: number,
+  canvasCenterX: number, canvasCenterY: number
+): number {
+  return Math.atan2(mouseY - canvasCenterY, mouseX - canvasCenterX);
+}
+
+interface InputLoopOptions {
+  socket: { emit: (event: string, data: unknown) => void };
+  canvas: HTMLCanvasElement;
+  getServerTick: () => number;
+  getPlayerFacing: () => number;
+}
+
+/**
+ * Starts the 30 Hz input loop. Returns a cleanup function to call on unmount.
+ * Edge-triggered actions (melee, pickup, dodge) are sent once per keypress.
+ */
+export function start(opts: InputLoopOptions): () => void {
+  const { socket, canvas, getServerTick, getPlayerFacing } = opts;
+  let bindings = loadBindings();
+  let seq = 0;
+
+  const keys = new Set<string>();
+  let mouseX = 0;
+  let mouseY = 0;
+  let lastMouseMove = 0;
+  let fire = false;
+  let melee = false;
+  let pickup = false;
+  let dodge = false;
+
+  const getCanvasCenter = () => {
+    const r = canvas.getBoundingClientRect();
+    return { cx: r.left + r.width / 2, cy: r.top + r.height / 2 };
+  };
+
+  const onKeyDown = (e: KeyboardEvent) => {
+    keys.add(e.code);
+    if (e.code === bindings.melee)  melee  = true;
+    if (e.code === bindings.pickup) pickup = true;
+    if (e.code === bindings.dodge)  dodge  = true;
+  };
+  const onKeyUp   = (e: KeyboardEvent) => keys.delete(e.code);
+  const onMouseMove = (e: MouseEvent) => {
+    mouseX = e.clientX; mouseY = e.clientY; lastMouseMove = Date.now();
+  };
+  const onMouseDown = (e: MouseEvent) => { if (e.button === 0) fire = true; };
+  const onMouseUp   = (e: MouseEvent) => { if (e.button === 0) fire = false; };
+
+  const onVisChange = () => {
+    if (document.hidden) {
+      keys.clear();
+      fire = false; melee = false; pickup = false; dodge = false;
+      socket.emit('msg', { t: 'input', seq: seq++, wasd: 0, aim: getPlayerFacing(),
+        fire: false, melee: false, pickup: false, dodge: false, tick: getServerTick() });
+    }
+  };
+
+  window.addEventListener('keydown', onKeyDown);
+  window.addEventListener('keyup', onKeyUp);
+  canvas.addEventListener('mousemove', onMouseMove);
+  window.addEventListener('mousedown', onMouseDown);
+  window.addEventListener('mouseup', onMouseUp);
+  document.addEventListener('visibilitychange', onVisChange);
+
+  const onBindingsChange = () => { bindings = loadBindings(); };
+  window.addEventListener('arena:keybindings-changed', onBindingsChange);
+
+  const interval = setInterval(() => {
+    const up    = keys.has(bindings.up);
+    const down  = keys.has(bindings.down);
+    const left  = keys.has(bindings.left);
+    const right = keys.has(bindings.right);
+
+    const wasd = computeWasd(up, down, left, right);
+
+    const { cx, cy } = getCanvasCenter();
+    const aimFromMouse = computeAim(mouseX, mouseY, cx, cy);
+    const aim = Date.now() - lastMouseMove < 200 ? aimFromMouse : getPlayerFacing();
+
+    socket.emit('msg', { t: 'input', seq: seq++, wasd, aim, fire, melee, pickup, dodge,
+      tick: getServerTick() });
+
+    melee = false; pickup = false; dodge = false;
+  }, 1000 / 30);
+
+  return () => {
+    clearInterval(interval);
+    window.removeEventListener('keydown', onKeyDown);
+    window.removeEventListener('keyup', onKeyUp);
+    canvas.removeEventListener('mousemove', onMouseMove);
+    window.removeEventListener('mousedown', onMouseDown);
+    window.removeEventListener('mouseup', onMouseUp);
+    document.removeEventListener('visibilitychange', onVisChange);
+    window.removeEventListener('arena:keybindings-changed', onBindingsChange);
+  };
+}

--- a/website/src/components/arena/hud/Hud.tsx
+++ b/website/src/components/arena/hud/Hud.tsx
@@ -14,9 +14,10 @@ interface Props {
   onForfeit: () => void;
   isMuted: boolean;
   onMuteToggle: () => void;
+  onControls: () => void;
 }
 
-export function Hud({ state, myKey, events, ping, onForfeit, isMuted, onMuteToggle }: Props) {
+export function Hud({ state, myKey, events, ping, onForfeit, isMuted, onMuteToggle, onControls }: Props) {
   const me = state.players[myKey];
   if (!me) return null;
 
@@ -33,8 +34,8 @@ export function Hud({ state, myKey, events, ping, onForfeit, isMuted, onMuteTogg
         <span style={{ marginLeft: 16, opacity: 0.5 }}>{ping}ms</span>
       </div>
 
-      {/* Top-right: mute button */}
-      <div style={{ position: 'absolute', top: 12, right: 12, pointerEvents: 'auto' }}>
+      {/* Top-right: mute button + controls button */}
+      <div style={{ position: 'absolute', top: 12, right: 12, pointerEvents: 'auto', display: 'flex', gap: 4 }}>
         <button
           onClick={onMuteToggle}
           title={isMuted ? 'Unmute SFX' : 'Mute SFX'}
@@ -47,6 +48,15 @@ export function Hud({ state, myKey, events, ping, onForfeit, isMuted, onMuteTogg
         >
           {isMuted ? '🔇' : '🔊'}
         </button>
+        <button
+          onClick={onControls}
+          title="Controls"
+          style={{
+            background: 'rgba(0,0,0,.5)', border: '1px solid #3d2a6e', borderRadius: 4,
+            color: '#6a5a8a', fontSize: 14, padding: '2px 8px', cursor: 'pointer',
+            fontFamily: 'monospace', marginLeft: 4,
+          }}
+        >⚙</button>
       </div>
 
       {/* Bottom-left: HP + ammo + powerups */}

--- a/website/src/components/arena/scenes/MatchScene.tsx
+++ b/website/src/components/arena/scenes/MatchScene.tsx
@@ -6,6 +6,8 @@ import { Renderer } from '../game/Renderer';
 import { Hud } from '../hud/Hud';
 import * as sfx from '../game/sfx';
 import { MAP_H } from '../game/mapData';
+import { start as startInputLoop } from '../game/input';
+import { ControlsPanel } from '../game/ControlsPanel';
 
 interface Props {
   socket: Socket;
@@ -29,6 +31,8 @@ export function MatchScene({ socket, initialState, myKey }: Props) {
     sfx.toggleMute();
     setIsMuted(sfx.isMuted);
   }, []);
+  const [showControls, setShowControls] = useState(false);
+  const [showToast, setShowToast] = useState(true);
 
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -102,12 +106,34 @@ export function MatchScene({ socket, initialState, myKey }: Props) {
     return () => { socket.off('msg', onMsg); };
   }, [socket]);
 
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const stop = startInputLoop({
+      socket,
+      canvas,
+      getServerTick: () => stateRef.current.tick,
+      getPlayerFacing: () => {
+        const player = stateRef.current.players[myKey];
+        return (player as { facing?: number })?.facing ?? 0;
+      },
+    });
+    return stop;
+  }, [socket, myKey]);
+
+  useEffect(() => {
+    if (!showToast) return;
+    const t = setTimeout(() => setShowToast(false), 4000);
+    return () => clearTimeout(t);
+  }, [showToast]);
+
   const handleForfeit = useCallback(() => {
     socket.emit('msg', { t: 'forfeit' });
   }, [socket]);
 
   return (
     <div style={{ position: 'relative', width: '100%', maxWidth: 960, margin: '0 auto', userSelect: 'none' }}>
+      <style>{`@keyframes arenaToastIn{from{opacity:0;transform:translateX(-50%) translateY(-8px)}to{opacity:1;transform:translateX(-50%) translateY(0)}}`}</style>
       <canvas
         ref={canvasRef}
         style={{ display: 'block', width: '100%', aspectRatio: '960/540', background: '#120d1c' }}
@@ -122,7 +148,35 @@ export function MatchScene({ socket, initialState, myKey }: Props) {
           pointerEvents: 'none',
         }}
       />
-      <Hud state={hudState} myKey={myKey} events={events} ping={ping} onForfeit={handleForfeit} isMuted={isMuted} onMuteToggle={handleMuteToggle} />
+      <Hud
+        state={hudState}
+        myKey={myKey}
+        events={events}
+        ping={ping}
+        onForfeit={handleForfeit}
+        isMuted={isMuted}
+        onMuteToggle={handleMuteToggle}
+        onControls={() => setShowControls(true)}
+      />
+      {showToast && (
+        <div
+          onClick={() => setShowToast(false)}
+          style={{
+            position: 'absolute', top: 10, left: '50%', transform: 'translateX(-50%)',
+            background: 'rgba(0,0,0,.82)', border: '1px solid #3d2a6e', borderRadius: 6,
+            padding: '5px 14px', fontFamily: 'monospace', fontSize: 12, color: '#a89abb',
+            zIndex: 20, cursor: 'pointer', whiteSpace: 'nowrap', userSelect: 'none',
+            animation: 'arenaToastIn .25s ease',
+          }}
+        >
+          <span style={{ color: '#c8f76a' }}>WASD</span> move ·{' '}
+          <span style={{ color: '#c8f76a' }}>LMB</span> fire ·{' '}
+          <span style={{ color: '#c8f76a' }}>E</span> melee ·{' '}
+          <span style={{ color: '#c8f76a' }}>Space</span> dodge ·{' '}
+          <span style={{ color: '#c8f76a' }}>⚙</span> controls
+        </div>
+      )}
+      {showControls && <ControlsPanel onClose={() => setShowControls(false)} />}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Adds `input.ts` — pure WASD encoding, aim math, keybinding load/save, 30 Hz input loop that emits socket `input` messages; clears on tab-hidden
- Adds `ControlsPanel.tsx` — tabbed rebinding modal (Bewegung/Kampf/Sonstiges) with conflict swap, ESC cancel, Zurücksetzen; persists in `arena:keybindings` localStorage
- Updates `Hud.tsx` — adds ⚙ Controls button that opens the panel via callback
- Updates `MatchScene.tsx` — mounts/unmounts input loop in useEffect, shows 4s entry toast on match start, renders ControlsPanel overlay

## Test plan
- [x] `npx vitest run src/components/arena/game/input.test.ts` — 21 tests pass
- [x] `npx vitest run src/components/arena` — all 30 arena tests pass
- [x] `npx tsc --noEmit` — no arena-specific type errors (pre-existing errors in admin/platform APIs unrelated to this PR)
- [x] Proto drift guard — `arena-server/src/proto/messages.ts` and `website/src/components/arena/shared/lobbyTypes.ts` are identical
- [x] Entry toast appears and auto-dismisses after 4s
- [x] ⚙ button opens ControlsPanel, rebinding works, ESC cancels, Zurücksetzen restores defaults

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>