### PR TITLE
feat(brett): Mayhem Solo mode — private room with 3 AI bots

### DIFF
--- a/brett/public/assets/main.js
+++ b/brett/public/assets/main.js
@@ -23,6 +23,8 @@ const overlayRoot = document.getElementById('overlay-root');
 modeState.on('change', async mode => {
   if (mode === 'ffa') {
     await startFFA();
+  } else if (mode === 'mayhem-solo') {
+    startMayhemSolo();
   } else if (mode === 'coaching') {
     stopCombat();
   }
@@ -67,6 +69,14 @@ function stopCombat() {
   if (!overlayRoot) return;
   const hud = overlayRoot.querySelector('#combat-hud');
   if (hud) hud.hidden = true;
+}
+
+function startMayhemSolo() {
+  // Create a private room that no other player can find or join via the room browser
+  const soloRoomId = 'solo-' + crypto.randomUUID();
+  // Signal to the page: auto-enable Mayhem as soon as the WS snapshot arrives
+  sessionStorage.setItem('brett_solo_mayhem', '1');
+  window.location.href = `/?room=${encodeURIComponent(soloRoomId)}`;
 }
 
 // Show mode selector on load

--- a/brett/public/assets/mayhem/mayhem.js
+++ b/brett/public/assets/mayhem/mayhem.js
@@ -636,8 +636,12 @@ const Mayhem = (() => {
       'border-radius:10px', 'font:13px sans-serif', 'z-index:1001',
       'pointer-events:none', 'user-select:none',
     ].join(';');
+    const soloKiBadge = room && room.startsWith('solo-')
+      ? '<span id="mhud-solo-badge" style="background:rgba(124,58,237,0.25);color:#a78bfa;border:1px solid rgba(124,58,237,0.4);border-radius:4px;padding:1px 7px;font-size:10px;font-weight:700;">🤖 vs. KI</span>'
+      : '';
     div.innerHTML = `
       <span id="mhud-mode" style="color:#aaa;text-transform:uppercase;font-size:11px"></span>
+      ${soloKiBadge}
       <div style="width:120px;height:12px;background:#333;border-radius:6px;overflow:hidden">
         <div id="mhud-hp-fill" style="height:100%;width:100%;background:#4c4;transition:width 0.15s,background 0.3s"></div>
       </div>

--- a/brett/public/assets/mode-select.mjs
+++ b/brett/public/assets/mode-select.mjs
@@ -15,6 +15,10 @@ export function showModeSelect(modeState) {
             <div class="title">FFA</div>
             <div class="sub">Jeder gegen jeden</div>
           </button>
+          <button class="mode-card" data-mode="mayhem-solo">
+            <div class="title">🥊 Mayhem — Solo</div>
+            <div class="sub">1 Spieler vs. 3 KI-Gegner · Sofort starten</div>
+          </button>
           <button class="mode-card disabled" data-mode="teams" disabled>
             <div class="title">Teams</div>
             <div class="sub">Coming soon</div>

--- a/brett/public/assets/mode-state.mjs
+++ b/brett/public/assets/mode-state.mjs
@@ -1,5 +1,5 @@
 // brett/public/assets/mode-state.mjs
-const VALID = new Set(['coaching', 'ffa', 'mode-select']);
+const VALID = new Set(['coaching', 'ffa', 'mode-select', 'mayhem-solo']);
 const STUB = new Set(['teams', 'coop']);
 const KEY_LOADOUT = 'brett.loadout';
 

--- a/brett/public/assets/room-browser.js
+++ b/brett/public/assets/room-browser.js
@@ -73,11 +73,13 @@ window.RoomBrowser = (() => {
     const list = document.getElementById('rb-list');
     if (!list) return;
     list.innerHTML = '';
-    if (rooms.length === 0) {
+    // Solo AI rooms are private — never show them in the browser
+    const visible = rooms.filter(r => !r.token?.startsWith('solo-'));
+    if (visible.length === 0) {
       list.innerHTML = '<p style="color:#6b7280;font-size:12px;text-align:center;padding:20px">Keine aktiven Räume</p>';
       return;
     }
-    for (const r of rooms) {
+    for (const r of visible) {
       const div = document.createElement('div');
       div.className = 'rb-room';
       div.innerHTML = `

--- a/brett/public/index.html
+++ b/brett/public/index.html
@@ -1159,6 +1159,14 @@
           STATE.stiffness = msg.stiffness; stiffSlider.value = String(msg.stiffness);
         }
         if (STATE.figures[0]) selectFigure(STATE.figures[0].id);
+        // Solo AI Mayhem: auto-enable if triggered from mode-select
+        if (sessionStorage.getItem('brett_solo_mayhem') === '1') {
+          sessionStorage.removeItem('brett_solo_mayhem');
+          if (window.Mayhem && !window.Mayhem._internal.localAvatar) {
+            window.Mayhem.setEnabled(true);
+          }
+        }
+        if (window.Mayhem) window.Mayhem.onSnapshot(msg);
         break;
       case "stiffness":
         STATE.stiffness = msg.value; stiffSlider.value = String(msg.value);

--- a/brett/test/mode-state.test.mjs
+++ b/brett/test/mode-state.test.mjs
@@ -27,3 +27,13 @@ test('stub modes do not change state', () => {
   assert.equal(result, false);
   assert.equal(ms.current(), 'coaching');
 });
+
+test('mayhem-solo is a valid mode', () => {
+  let last = null;
+  const ms = createModeState({ storage: new Map() });
+  ms.on('change', m => { last = m; });
+  const result = ms.setMode('mayhem-solo');
+  assert.equal(result, true);
+  assert.equal(ms.current(), 'mayhem-solo');
+  assert.equal(last, 'mayhem-solo');
+});

--- a/docs/superpowers/plans/2026-05-20-brett-ai-mayhem-solo.md
+++ b/docs/superpowers/plans/2026-05-20-brett-ai-mayhem-solo.md
@@ -1,0 +1,166 @@
+---
+brainstorm_choice: A — Quick Solo-Start Button (empfohlen)
+brainstorm_session: 1278992-1779301538
+ticket_id: T000121
+title: "Brett Solo AI Mayhem — 1P vs 3 KI Quick-Start Button"
+date: 2026-05-20
+status: staged
+domains: [brett, website]
+branch: feature/brett-ai-mayhem-mode
+spec: docs/superpowers/specs/2026-05-20-brett-ai-mayhem-solo-design.md
+---
+
+# Plan: Brett Solo AI Mayhem — 1P vs 3 KI Quick-Start Button
+
+## Ziel
+
+Einen "Mayhem Solo"-Button in den Brett Mode-Select Screen einfügen, der sofort Mayhem mit 3 KI-Gegnern startet — ohne Warten auf Mitspieler, minimaler Eingriff in die bestehende Codebasis.
+
+## Hintergrund
+
+Die `MayhemAIBot`-Infrastruktur ist bereits vollständig implementiert und füllt automatisch auf `MAX_PLAYERS=4` auf. Es fehlt lediglich ein Einstiegspunkt, der ohne Multiplayer-Lobby-Flow direkt Mayhem startet.
+
+**Brainstorming-Wahl:** Option A (Quick Solo-Start Button) — ~2h, minimaler Eingriff.
+
+---
+
+## Schritt 1 — `mode-state.mjs`: `'mayhem-solo'` in VALID aufnehmen
+
+**Datei:** `brett/public/assets/mode-state.mjs`
+
+```diff
+-const VALID = new Set(['coaching', 'ffa', 'mode-select']);
++const VALID = new Set(['coaching', 'ffa', 'mode-select', 'mayhem-solo']);
+```
+
+**Test:** `mode-state.test.mjs` — neuer Case: `setMode('mayhem-solo')` gibt `true` zurück.
+
+---
+
+## Schritt 2 — `mode-select.mjs`: Solo-Card hinzufügen
+
+**Datei:** `brett/public/assets/mode-select.mjs`
+
+Neue Mode-Card-Schaltfläche nach der FFA-Card:
+
+```html
+<button class="mode-card" data-mode="mayhem-solo">
+  <span class="mode-icon">🥊</span>
+  <span class="mode-title">Mayhem — Solo</span>
+  <span class="mode-desc">1 Spieler vs. 3 KI-Gegner · Sofort starten</span>
+</button>
+```
+
+Kein neues Routing nötig — die bestehende `data-mode`-Click-Handler-Logik übernimmt das automatisch via `modeState.setMode(btn.dataset.mode)`.
+
+---
+
+## Schritt 3 — `main.js`: Routing für `'mayhem-solo'`
+
+**Datei:** `brett/public/assets/main.js`
+
+```diff
+ if (mode === 'ffa') {
+   startMayhem({ ... });
+ }
++if (mode === 'mayhem-solo') {
++  startMayhemSolo();
++}
+```
+
+---
+
+## Schritt 4 — `mayhem.js`: `startMayhemSolo()` implementieren
+
+**Datei:** `brett/public/assets/mayhem/mayhem.js`
+
+Neue exportierte Funktion `startMayhemSolo()`:
+
+```js
+function startMayhemSolo() {
+  // Privaten Room mit zufälliger ID erstellen — kein anderer kennt den Code
+  const soloRoomId = 'solo-' + crypto.randomUUID();
+  // Bestehenden start()-Flow aufrufen; Bot-Fill läuft automatisch da humanCount=1
+  start({ roomId: soloRoomId, isSolo: true });
+}
+```
+
+Anpassung in `start()`:
+- `isSolo`-Flag → Room-Browser versteckt diesen Room (nicht joinbar)
+- Modus: startet direkt mit `deathmatch` statt `warmup` (oder konfigurierbar)
+- HUD: Badge "vs. KI" wenn `isSolo`
+
+---
+
+## Schritt 5 — `room-browser.js`: Solo-Rooms ausblenden
+
+**Datei:** `brett/public/assets/room-browser.js`
+
+Rooms deren ID mit `'solo-'` beginnt werden in der Room-Liste nicht angezeigt:
+
+```diff
+ rooms.filter(r => /* ... existierende Filter ... */)
++      .filter(r => !r.id.startsWith('solo-'))
+```
+
+---
+
+## Schritt 6 — HUD (optional): "vs. KI" Badge
+
+**Datei:** `brett/public/assets/hud/` (je nach HUD-Implementierung)
+
+Im Solo-Modus einen kleinen "🤖 vs. KI"-Indikator im HUD anzeigen.
+
+---
+
+## Verifikation
+
+### Automatisiert
+
+```bash
+# Brett-Unit-Tests inkl. neuem mode-state Case
+npm ci --prefix brett && node --test brett/test/mode-state.test.mjs
+
+# Alle Brett-Tests
+node --test brett/test/ws-reconnect.test.mjs brett/test/physics.test.js brett/test/damage.test.mjs brett/test/pickups.test.mjs brett/test/mode-state.test.mjs
+
+# Template-Test
+./scripts/tests/systembrett-template.test.sh
+```
+
+### Manuell
+
+1. `task brett:deploy ENV=dev` (oder `brett:build` + lokaler Server)
+2. Brett öffnen → Mode-Select → "🥊 Mayhem Solo" Button sichtbar
+3. Klick → sofort im Spiel, 3 Bots gespawnt, kein Lobby-Warten
+4. Bots bewegen sich, schießen, sterben und respawnen
+5. Bots erscheinen **nicht** im Room-Browser
+
+### Regressions-Check
+
+```bash
+task test:all
+```
+
+---
+
+## Dateien
+
+| Datei | Änderung |
+|---|---|
+| `brett/public/assets/mode-state.mjs` | `'mayhem-solo'` in VALID |
+| `brett/public/assets/mode-select.mjs` | Neue Solo-Card |
+| `brett/public/assets/main.js` | Routing `'mayhem-solo'` → `startMayhemSolo()` |
+| `brett/public/assets/mayhem/mayhem.js` | `startMayhemSolo()` + `isSolo`-Flag |
+| `brett/public/assets/room-browser.js` | Solo-Rooms ausfiltern |
+| `brett/test/mode-state.test.mjs` | Neuer Test für `'mayhem-solo'` |
+
+---
+
+## Deploy
+
+```bash
+task feature:brett
+```
+
+Verify: `https://brett.mentolder.de` + `https://brett.korczewski.de`

--- a/docs/superpowers/specs/2026-05-20-brett-ai-mayhem-solo-design.md
+++ b/docs/superpowers/specs/2026-05-20-brett-ai-mayhem-solo-design.md
@@ -1,0 +1,96 @@
+# Spec: Brett Solo AI Mayhem — 1 Spieler vs. 3 KI
+
+**Datum:** 2026-05-20  
+**Brainstorming-Wahl:** Option A — Quick Solo-Start Button  
+**Branch:** `feature/brett-ai-mayhem-mode`
+
+---
+
+## Problem
+
+Mayhem-Modus in Brett ist aktuell ausschließlich über einen Multiplayer-WebSocket-Room erreichbar. Ein Spieler muss erst einen Room öffnen und warten — oder alleine im Room sitzen. Es gibt keinen direkten "Alleine spielen"-Einstieg, obwohl die KI-Bot-Infrastruktur (`MayhemAIBot`) bereits vollständig implementiert ist und Bots automatisch auf `MAX_PLAYERS=4` auffüllen.
+
+## Ziel
+
+Einen **"Alleine spielen"**-Button (Solo-Modus) hinzufügen, der sofort Mayhem mit 3 KI-Gegnern startet — ohne Warten auf andere Spieler, ohne sichtbaren Room-Join-Flow.
+
+## Bestandsaufnahme
+
+```
+brett/public/assets/
+├── mayhem/
+│   ├── ai-bot.js          ✅ MayhemAIBot (215 Zeilen, voll funktional)
+│   ├── game-mode.js       ✅ warmup/deathmatch/lms/coop
+│   ├── mayhem.js          ✅ Haupt-Engine, MAX_PLAYERS=4, spawnAIBot()
+│   └── ...
+├── mode-select.mjs        ✅ coaching / ffa Cards
+├── mode-state.mjs         ✅ VALID = {coaching, ffa, mode-select}
+└── main.js                ✅ mode === 'ffa' → startMayhem()
+```
+
+**Was fehlt:**
+- Mode `'mayhem-solo'` ist nicht in `VALID` in `mode-state.mjs`
+- Kein Button in `mode-select.mjs` für Solo
+- `main.js` kennt kein `'mayhem-solo'`-Routing
+- Kein privater/isolierter Room-Start ohne Join-Möglichkeit
+
+## Lösung (Option A)
+
+### 1. `mode-state.mjs` — Solo-Mode validieren
+
+```js
+const VALID = new Set(['coaching', 'ffa', 'mode-select', 'mayhem-solo']);
+```
+
+### 2. `mode-select.mjs` — Solo-Button hinzufügen
+
+Neue Mode-Card neben coaching/ffa:
+
+```html
+<button class="mode-card" data-mode="mayhem-solo">
+  <span class="mode-icon">🥊</span>
+  <span class="mode-title">Mayhem — Solo</span>
+  <span class="mode-desc">1 Spieler vs. 3 KI-Gegner · Sofort starten</span>
+</button>
+```
+
+### 3. `main.js` — Routing für `'mayhem-solo'`
+
+```js
+if (mode === 'mayhem-solo') {
+  startMayhemSolo();
+}
+```
+
+### 4. `mayhem.js` — `startMayhemSolo()` Funktion
+
+Startet einen privaten Room (`solo-` + UUID), joined diesen sofort als Host, startet dann `start()` mit `isHost=true`. Da kein anderer den Room-Code kennt, bleibt der Spieler alleine und Bots füllen die 3 freien Slots.
+
+Alternativ: WebSocket-Verbindung komplett überspringen, Bot-Tick direkt im Client ohne WS-Sync.
+
+**Entscheidung:** WS-Verbindung bleibt (minimaler Eingriff), aber Room-ID ist UUID-basiert + nicht joinbar über Room-Browser.
+
+### 5. HUD-Anpassung (optional, bonus)
+
+Im Solo-Modus: HUD zeigt "vs. KI" Badge statt Spielerzahl.
+
+## User Flow
+
+```
+Mode-Select → [🥊 Mayhem Solo] → Sofort im Spiel
+                                  3 Bots gespawnt
+                                  Modus: Deathmatch (default)
+                                  R zum Respawn nach Tod
+```
+
+## Out of Scope
+
+- KI-Schwierigkeitsstufen (Option D — separates Feature)
+- Offline-Modus ohne WebSocket (Option B)
+- Einladungs-Link für Freunde (Option C)
+
+## Verifikation
+
+- `node --test brett/test/mode-state.test.mjs` — `mayhem-solo` im VALID-Set
+- Manuell: Brett öffnen → Solo-Button → sofort Mayhem mit 3 Bots
+- Bestehende Tests bleiben grün


### PR DESCRIPTION
## Summary
- Adds **🥊 Mayhem Solo** card to mode-select — one click starts a private `solo-<uuid>` room with AI bots, no server-side changes needed
- Uses `sessionStorage` flag (`brett_solo_mayhem`) to auto-enable Mayhem immediately after the first WS snapshot arrives
- HUD shows **🤖 vs. KI** badge when room token starts with `solo-`; solo rooms are hidden from the room browser

## Test plan
- [x] `node --test brett/test/mode-state.test.mjs` — new `mayhem-solo is a valid mode` test passes (30/30 total)
- [x] All Brett tests green: `ws-reconnect`, `physics`, `damage`, `pickups`, `mode-state`
- [ ] Manual check on brett.mentolder.de — click "🥊 Mayhem Solo", confirm bots spawn and HUD badge shows

Closes T000121

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>