### PR TITLE
fix(auth): eliminate 401 console noise from /auth/me and inbox/count

### DIFF
--- a/brett/public/index.html
+++ b/brett/public/index.html
@@ -1058,14 +1058,14 @@
   (async function adminBootstrap() {
     try {
       const res = await fetch('/auth/me');
-      if (res.status === 401) {
+      if (!res.ok) return;
+      const me = await res.json();
+      if (!me.authenticated) {
         if (new URLSearchParams(window.location.search).get('admin') === '1') {
           window.location.href = '/auth/login?returnTo=' + encodeURIComponent(window.location.href);
         }
         return;
       }
-      if (!res.ok) return;
-      const me = await res.json();
       if (!me.isAdmin) return;
       window._bretAdmin = me;
       const roomParam = new URLSearchParams(window.location.search).get('room');

--- a/brett/server.js
+++ b/brett/server.js
@@ -164,8 +164,8 @@ app.get('/auth/callback', asyncHandler(async (req, res) => {
 }));
 
 app.get('/auth/me', (req, res) => {
-  if (!req.session.userId) return res.status(401).json({ error: 'not authenticated' });
-  res.json({ userId: req.session.userId, name: req.session.name, isAdmin: !!req.session.isAdmin });
+  if (!req.session.userId) return res.json({ authenticated: false });
+  res.json({ authenticated: true, userId: req.session.userId, name: req.session.name, isAdmin: !!req.session.isAdmin });
 });
 
 function requireAdmin(req, res, next) {

--- a/website/src/pages/api/admin/inbox/count.ts
+++ b/website/src/pages/api/admin/inbox/count.ts
@@ -10,7 +10,7 @@ import { countPendingByType } from '../../../../lib/messaging-db';
 export const GET: APIRoute = async ({ request }) => {
   const session = await getSession(request.headers.get('cookie'));
   if (!session || !isAdmin(session)) {
-    return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 });
+    return new Response(JSON.stringify({ error: 'Forbidden' }), { status: 403 });
   }
 
   const counts = await countPendingByType();


### PR DESCRIPTION
## Summary
- `brett/server.js`: `/auth/me` now returns `200 { authenticated: false }` for anonymous users instead of `401` — Chrome stops logging "Failed to load resource: 401" on every brett page load
- `brett/public/index.html`: `adminBootstrap` checks `me.authenticated` instead of `res.status === 401`; all four flows (anonymous, anonymous+`?admin=1`, logged-in non-admin, admin) behave identically to before
- `website/src/pages/api/admin/inbox/count.ts`: returns `403 Forbidden` (not `401`) for non-admin users — semantically correct and consistent with the tickets endpoint

## Root cause
HTTP 401 tells browsers "retry with credentials", so Chrome always logs it as a console error regardless of whether JavaScript handles it gracefully. 401 should mean "unauthenticated", 403 should mean "authenticated but not authorized".

## Test plan
- [ ] Visit brett page while logged out → no 401 in console, JS still handles gracefully
- [ ] Visit brett page with `?admin=1` while logged out → redirects to login
- [ ] Visit brett page as admin → RoomBrowser still appears
- [ ] Admin page inbox badge still populates for admin users

🤖 Generated with [Claude Code](https://claude.com/claude-code)