### PR TITLE
feat(auth): grant paddione + gekko/quamain admin in all applications

### DIFF
--- a/k3d/nextcloud-oidc-dev.php
+++ b/k3d/nextcloud-oidc-dev.php
@@ -23,6 +23,8 @@ $CONFIG = [
   'oidc_login_scope'             => 'openid email profile',
   'oidc_login_disable_registration' => false,
   'oidc_login_tls_verify'        => false,
+  'oidc_login_groups_attribute'  => 'roles',
+  'oidc_login_admin_group'       => 'admin',
   'allow_user_to_change_display_name' => false,
   'lost_password_link'           => 'disabled',
 ];

--- a/k3d/realm-workspace-dev.json
+++ b/k3d/realm-workspace-dev.json
@@ -24,7 +24,8 @@
       "firstName": "Patrick",
       "lastName": "Korczewski",
       "realmRoles": [
-        "default-roles-workspace"
+        "default-roles-workspace",
+        "admin"
       ],
       "clientRoles": {
         "realm-management": [
@@ -40,7 +41,8 @@
       "firstName": "Gekko",
       "lastName": "Admin",
       "realmRoles": [
-        "default-roles-workspace"
+        "default-roles-workspace",
+        "admin"
       ],
       "clientRoles": {
         "realm-management": [
@@ -100,6 +102,21 @@
             "access.token.claim": "true",
             "claim.name": "preferred_username",
             "jsonType.label": "String"
+          }
+        },
+        {
+          "name": "realm roles",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-realm-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "roles",
+            "access.token.claim": "true",
+            "claim.name": "roles",
+            "jsonType.label": "String",
+            "id.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "multivalued": "true"
           }
         }
       ]
@@ -487,5 +504,16 @@
         }
       ]
     }
-  ]
+  ],
+  "roles": {
+    "realm": [
+      {
+        "name": "admin",
+        "description": "Platform administrator",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "workspace"
+      }
+    ]
+  }
 }

--- a/k3d/website.yaml
+++ b/k3d/website.yaml
@@ -54,7 +54,7 @@ data:
   TRAEFIK_EXTERNAL_URL: "${TRAEFIK_EXTERNAL_URL}"
   MAIL_EXTERNAL_URL: "${MAIL_EXTERNAL_URL}"
   # Portal admin
-  PORTAL_ADMIN_USERNAME: "gekko,paddione"
+  PORTAL_ADMIN_USERNAME: "gekko,paddione,quamain"
   CALENDAR_NAME: "personal"
   WORK_START_HOUR: "9"
   WORK_END_HOUR: "17"

--- a/prod-korczewski/realm-workspace-korczewski.json
+++ b/prod-korczewski/realm-workspace-korczewski.json
@@ -35,7 +35,8 @@
       "firstName": "Patrick",
       "lastName": "Korczewski",
       "realmRoles": [
-        "default-roles-workspace"
+        "default-roles-workspace",
+        "admin"
       ],
       "clientRoles": {
         "realm-management": [
@@ -51,7 +52,8 @@
       "firstName": "Gekko",
       "lastName": "Admin",
       "realmRoles": [
-        "default-roles-workspace"
+        "default-roles-workspace",
+        "admin"
       ],
       "clientRoles": {
         "realm-management": [
@@ -109,6 +111,21 @@
             "access.token.claim": "true",
             "claim.name": "preferred_username",
             "jsonType.label": "String"
+          }
+        },
+        {
+          "name": "realm roles",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-realm-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "roles",
+            "access.token.claim": "true",
+            "claim.name": "roles",
+            "jsonType.label": "String",
+            "id.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "multivalued": "true"
           }
         }
       ]
@@ -608,6 +625,13 @@
       {
         "name": "arena_admin",
         "description": "Allowed to host an Arena match",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "workspace"
+      },
+      {
+        "name": "admin",
+        "description": "Platform administrator",
         "composite": false,
         "clientRole": false,
         "containerId": "workspace"

--- a/prod-mentolder/realm-workspace-mentolder.json
+++ b/prod-mentolder/realm-workspace-mentolder.json
@@ -36,7 +36,8 @@
       "lastName": "Korczewski",
       "realmRoles": [
         "default-roles-workspace",
-        "arena_admin"
+        "arena_admin",
+        "admin"
       ],
       "clientRoles": {
         "realm-management": [
@@ -52,7 +53,8 @@
       "firstName": "Gerald",
       "lastName": "Korczewski",
       "realmRoles": [
-        "default-roles-workspace"
+        "default-roles-workspace",
+        "admin"
       ],
       "clientRoles": {
         "realm-management": [
@@ -109,6 +111,21 @@
             "access.token.claim": "true",
             "claim.name": "preferred_username",
             "jsonType.label": "String"
+          }
+        },
+        {
+          "name": "realm roles",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-realm-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "roles",
+            "access.token.claim": "true",
+            "claim.name": "roles",
+            "jsonType.label": "String",
+            "id.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "multivalued": "true"
           }
         }
       ]
@@ -610,6 +627,13 @@
       {
         "name": "arena_admin",
         "description": "Allowed to host an Arena match",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "workspace"
+      },
+      {
+        "name": "admin",
+        "description": "Platform administrator",
         "composite": false,
         "clientRole": false,
         "containerId": "workspace"

--- a/prod/nextcloud-oidc-prod.php
+++ b/prod/nextcloud-oidc-prod.php
@@ -22,6 +22,8 @@ $CONFIG = [
   'oidc_login_scope'             => 'openid email profile',
   'oidc_login_disable_registration' => false,
   'oidc_login_tls_verify'        => true,
+  'oidc_login_groups_attribute'  => 'roles',
+  'oidc_login_admin_group'       => 'admin',
   'allow_user_to_change_display_name' => false,
   'lost_password_link'           => 'disabled',
 ];


### PR DESCRIPTION
## Summary
- **Keycloak realm roles** (all 3 realms): define `admin` realm role + assign to both admin users — fixes brett admin (which checks `realm_access.roles`)
- **Nextcloud OIDC mapping**: add realm roles mapper to NC Keycloak client + `oidc_login_admin_group=admin` in both PHP configs — Nextcloud auto-promotes on next login
- **Website ConfigMap**: add `quamain` to `PORTAL_ADMIN_USERNAME` — Gekko's mentolder username was missing

## User mapping
| User | mentolder | korczewski | dev |
|------|-----------|-----------|-----|
| Patrick | `paddione` | `paddione` | `Paddione` |
| Gekko | `quamain` | `gekko` | `gekko` |

## Deploy after merge
```bash
task keycloak:sync ENV=mentolder && task keycloak:sync ENV=korczewski
task workspace:restart ENV=mentolder -- nextcloud
task workspace:restart ENV=korczewski -- nextcloud
task feature:website
```

## Test plan
- [ ] Log into brett as paddione → admin panel visible
- [ ] Log into brett as gekko/quamain → admin panel visible
- [ ] Log into Nextcloud as paddione → Settings shows Admin group
- [ ] Log into Nextcloud as gekko/quamain → Settings shows Admin group
- [ ] Website /admin routes accessible for both users

🤖 Generated with [Claude Code](https://claude.com/claude-code)