### PR TITLE
chore(ui): remove arena from mentolder menu, mayhem from brett mode-select

### DIFF
--- a/brett/public/assets/mode-select.mjs
+++ b/brett/public/assets/mode-select.mjs
@@ -15,10 +15,6 @@ export function showModeSelect(modeState) {
             <div class="title">FFA</div>
             <div class="sub">Jeder gegen jeden</div>
           </button>
-          <button class="mode-card" data-mode="mayhem-solo">
-            <div class="title">🥊 Mayhem — Solo</div>
-            <div class="sub">1 Spieler vs. 3 KI-Gegner · Sofort starten</div>
-          </button>
           <button class="mode-card disabled" data-mode="teams" disabled>
             <div class="title">Teams</div>
             <div class="sub">Coming soon</div>

--- a/website/src/layouts/AdminLayout.astro
+++ b/website/src/layouts/AdminLayout.astro
@@ -90,6 +90,9 @@ try {
 
 const adminInitials = ((adminGivenName[0] ?? '') + (adminFamilyName[0] ?? '')).toUpperCase() || '?';
 
+const brandId = (process.env.BRAND_ID ?? process.env.BRAND ?? 'mentolder').toLowerCase();
+const isKore = brandId === 'korczewski';
+
 const navGroups: { label: string; iconClass: string; items: NavItem[] }[] = [
   {
     label: 'Kern',
@@ -115,7 +118,7 @@ const navGroups: { label: string; iconClass: string; items: NavItem[] }[] = [
     items: [
       { href: '/admin/coaching/sessions',  label: 'Sitzungen',   icon: 'clipboard', matches: ['/admin/coaching/sessions', '/admin/fragebogen'] },
       { href: BRETT_URL,                    label: 'Systembrett', icon: 'brett', external: true },
-      { href: '/admin/arena',              label: 'Arena',       icon: 'arena' },
+      ...(isKore ? [{ href: '/admin/arena', label: 'Arena',       icon: 'arena' }] : []),
     ],
   },
   {
@@ -151,8 +154,6 @@ function isActive(href: string, matches?: string[]): boolean {
 }
 
 const brandWord = config.meta.siteTitle.replace(/\.de$/i, '').toLowerCase();
-const brandId = (process.env.BRAND_ID ?? process.env.BRAND ?? 'mentolder').toLowerCase();
-const isKore = brandId === 'korczewski';
 ---
 
 <!doctype html>

--- a/website/src/pages/admin.astro
+++ b/website/src/pages/admin.astro
@@ -80,7 +80,7 @@ const adminLinks = [
     { href: `${ncBase}/apps/spreed/`,   label: 'Talk',     icon: SVG.video,    color: '#a78bfa' },
   ] : []),
   ...(bretUrl  ? [{ href: bretUrl,                               label: 'Brett',      icon: SVG.brett,    color: '#a78bfa' }] : []),
-  { href: '/portal/arena',                                       label: 'Arena',      icon: SVG.arena,    color: '#818cf8' },
+  ...(BRAND === 'korczewski' ? [{ href: '/portal/arena',         label: 'Arena',      icon: SVG.arena,    color: '#818cf8' }] : []),
   { href: '/admin/rechnungen',                                   label: 'Abrechnung', icon: SVG.receipt,  color: '#34d399' },
   ...(vaultUrl ? [{ href: vaultUrl,                              label: 'Passwörter', icon: SVG.lock,     color: '#34d399' }] : []),
   ...(authUrl  ? [{ href: `${authUrl}/admin/workspace/console/`, label: 'Keycloak',   icon: SVG.key,      color: '#818cf8' }] : []),


### PR DESCRIPTION
## Summary
- Arena links in `admin.astro` quick-launch grid and `AdminLayout` sidebar now gated on `BRAND === 'korczewski'` — mentolder users no longer see the arena entry
- Removed `mayhem-solo` button from brett's mode-select overlay; underlying mode-state logic unchanged (mode still valid, just not reachable from UI)
- Hoisted `brandId`/`isKore` declarations in AdminLayout before `navGroups` to make the conditional spread work

## Test plan
- [x] `task test:all` — all offline tests green (BATS unit + manifests + dry-run)
- [x] Admin-menu gate passed: 6 groups, ≤4 items each, all hrefs reachable
- [x] Brett tests: 29/29 pass including `mode-state.test.mjs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)