### PR TITLE
chore(website): sidekick submenus mentolder editorial restyle

### DIFF
--- a/website/src/components/assistant/HelpView.svelte
+++ b/website/src/components/assistant/HelpView.svelte
@@ -61,118 +61,184 @@
 </div>
 
 <style>
-  .help-body { flex: 1; overflow-y: auto; display: flex; flex-direction: column; gap: 0; }
+  .help-body {
+    flex: 1;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+    padding-bottom: 28px;
+  }
 
   /* ── Intro block ── */
   .hv-intro {
-    padding: 20px 22px 14px;
-    border-bottom: 1px solid rgba(255,255,255,0.06);
+    padding: 24px 22px 18px;
+    border-bottom: 1px solid var(--line);
     flex-shrink: 0;
   }
   .hv-eyebrow {
-    font-family: var(--font-mono, 'Geist Mono', monospace);
-    font-size: 10px;
+    font-family: var(--mono);
+    font-size: 11px;
     letter-spacing: 0.18em;
     text-transform: uppercase;
-    color: oklch(0.83 0.09 75);
+    color: var(--brass);
     display: inline-flex;
     align-items: center;
     gap: 10px;
   }
   .hv-eyebrow-bar {
-    width: 16px;
+    width: 22px;
     height: 1px;
-    background: oklch(0.83 0.09 75);
-    opacity: 0.85;
+    background: currentColor;
+    opacity: 0.8;
     flex-shrink: 0;
   }
 
   /* ── Content ── */
   .section-title {
-    font-family: var(--font-serif, 'Newsreader', serif);
-    font-size: 18px;
+    font-family: var(--serif);
+    font-size: 24px;
     font-weight: 400;
-    color: oklch(0.87 0.09 75);
-    margin: 16px 22px 4px;
+    line-height: 1.15;
+    letter-spacing: -0.015em;
+    color: var(--fg);
+    margin: 20px 22px 6px;
   }
 
   .section-desc {
-    font-size: 12px;
-    color: #aabbcc;
-    margin: 0 22px 16px;
+    font-size: 14px;
+    color: var(--fg-soft);
+    margin: 0 22px 20px;
     line-height: 1.55;
+    max-width: 50ch;
   }
 
   .section-label {
-    font-size: 10px;
-    font-weight: 600;
+    font-family: var(--mono);
+    font-size: 11px;
+    font-weight: 500;
     text-transform: uppercase;
-    letter-spacing: 0.07em;
-    color: #5566aa;
-    margin: 0 22px 8px;
+    letter-spacing: 0.16em;
+    color: var(--mute);
+    margin: 0 22px 12px;
   }
 
+  /* ── Action list ───────────────────────────────────────── */
   .action-list {
-    margin: 0 22px 16px;
+    margin: 0 22px 22px;
     padding: 0;
     list-style: none;
     display: flex;
     flex-direction: column;
-    gap: 4px;
+    gap: 8px;
   }
   .action-list li {
-    font-size: 12px;
-    color: #aabbcc;
+    font-size: 14px;
+    color: var(--fg-soft);
     display: flex;
     align-items: flex-start;
-    gap: 6px;
-    line-height: 1.5;
+    gap: 10px;
+    line-height: 1.55;
+    padding: 8px 0;
   }
-  .action-dot { color: oklch(0.83 0.09 75); flex-shrink: 0; }
+  .action-dot {
+    color: var(--brass);
+    flex-shrink: 0;
+    font-size: 12px;
+    line-height: 1.7;
+  }
 
-  .guides { display: flex; flex-direction: column; gap: 6px; margin: 0 22px 16px; }
+  /* ── Guides accordion ──────────────────────────────────── */
+  .guides {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    margin: 0 22px 22px;
+  }
 
-  .guide-item { border-radius: 6px; overflow: hidden; }
+  .guide-item {
+    border: 1px solid var(--line);
+    border-radius: var(--radius-md, 12px);
+    overflow: hidden;
+    background: var(--ink-800);
+    transition: border-color 180ms ease;
+  }
+  .guide-item[open] { border-color: var(--brass-d); }
 
   .guide-summary {
-    font-size: 12px;
-    color: oklch(0.83 0.09 75);
-    background: rgba(232,200,112,.06);
-    padding: 7px 10px;
+    font-family: var(--serif);
+    font-size: 15px;
+    font-weight: 400;
+    letter-spacing: -0.005em;
+    color: var(--fg);
+    background: transparent;
+    padding: 14px 16px;
+    min-height: 48px;
     cursor: pointer;
-    border-radius: 6px;
     list-style: none;
     display: flex;
     align-items: center;
-    gap: 6px;
+    gap: 12px;
     user-select: none;
+    transition: background 180ms ease;
   }
+  .guide-summary:hover { background: var(--ink-750); }
   .guide-summary::-webkit-details-marker { display: none; }
 
   .summary-arrow {
+    font-family: var(--mono);
     font-size: 10px;
-    transition: transform 0.15s ease;
+    color: var(--brass);
+    transition: transform 220ms var(--ease-out, ease);
     display: inline-block;
+    line-height: 1;
+    width: 12px;
+    flex-shrink: 0;
   }
 
-  details[open] .summary-arrow {
-    transform: rotate(90deg);
-  }
+  details[open] .summary-arrow { transform: rotate(90deg); }
 
   .guide-steps {
-    margin: 4px 0 0;
-    padding: 8px 10px 8px 28px;
-    background: rgba(232,200,112,.03);
-    border-radius: 0 0 6px 6px;
+    margin: 0;
+    padding: 12px 18px 16px 44px;
+    background: var(--ink-850);
+    border-top: 1px solid var(--line);
     display: flex;
     flex-direction: column;
-    gap: 4px;
+    gap: 8px;
+    counter-reset: step-counter;
   }
   .guide-steps li {
-    font-size: 12px;
-    color: #aabbcc;
-    line-height: 1.5;
+    font-size: 13px;
+    color: var(--fg-soft);
+    line-height: 1.55;
+    position: relative;
+    counter-increment: step-counter;
+  }
+  .guide-steps li::marker {
+    color: var(--brass);
+    font-family: var(--mono);
+    font-size: 11px;
   }
 
-  .empty { font-size: 12px; color: #5566aa; padding: 16px 22px; }
+  .empty {
+    font-family: var(--serif);
+    font-size: 15px;
+    font-style: italic;
+    color: var(--mute);
+    padding: 24px 22px;
+    line-height: 1.55;
+  }
+
+  @media (max-width: 480px) {
+    .hv-intro,
+    .section-title,
+    .section-desc,
+    .section-label,
+    .action-list,
+    .guides,
+    .empty { margin-inline: 18px; }
+    .hv-intro { padding-inline: 18px; margin: 0; }
+    .section-title { font-size: 22px; }
+  }
 </style>

--- a/website/src/components/assistant/InboxSidekickView.svelte
+++ b/website/src/components/assistant/InboxSidekickView.svelte
@@ -123,6 +123,15 @@
 </script>
 
 <div class="view">
+  <!-- Intro -->
+  <div class="iv-intro">
+    <span class="iv-eyebrow">
+      <span class="iv-eyebrow-bar" aria-hidden="true"></span>
+      Postfach
+    </span>
+    <p class="iv-desc">Eingegangene Nachrichten, Buchungen und Anfragen an einem Ort.</p>
+  </div>
+
   <!-- Type filter pills -->
   <div class="pill-row">
     <button
@@ -191,96 +200,156 @@
     padding-bottom: 60px;
   }
 
+  /* ── Intro ──────────────────────────────────────────────── */
+  .iv-intro {
+    padding: 24px 22px 16px;
+    border-bottom: 1px solid var(--line);
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+  .iv-eyebrow {
+    font-family: var(--mono);
+    font-size: 11px;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--brass);
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+  }
+  .iv-eyebrow-bar {
+    width: 22px;
+    height: 1px;
+    background: currentColor;
+    opacity: 0.8;
+    flex-shrink: 0;
+  }
+  .iv-desc {
+    margin: 0;
+    font-size: 13px;
+    color: var(--fg-soft);
+    line-height: 1.55;
+    max-width: 38ch;
+  }
+
+  /* ── Type filter pills ──────────────────────────────────── */
   .pill-row {
     display: flex;
-    gap: 6px;
-    padding: 12px 16px;
+    gap: 8px;
+    padding: 14px 22px;
     overflow-x: auto;
-    border-bottom: 1px solid rgba(232, 200, 112, 0.1);
+    border-bottom: 1px solid var(--line);
     flex-shrink: 0;
+    -webkit-overflow-scrolling: touch;
   }
   .pill-row::-webkit-scrollbar { display: none; }
 
   .pill {
-    display: flex;
+    display: inline-flex;
     align-items: center;
-    gap: 4px;
-    padding: 4px 10px;
-    border-radius: 999px;
-    border: 1px solid #243049;
+    gap: 6px;
+    padding: 8px 14px;
+    min-height: 36px;
+    border-radius: var(--radius-pill, 999px);
+    border: 1px solid var(--line-2);
     background: transparent;
-    color: #8899aa;
+    color: var(--fg-soft);
+    font-family: var(--mono);
     font-size: 11px;
     font-weight: 500;
+    letter-spacing: 0.06em;
     cursor: pointer;
     white-space: nowrap;
-    transition: border-color 0.12s, color 0.12s, background 0.12s;
+    transition: border-color 180ms ease, color 180ms ease, background 180ms ease;
     flex-shrink: 0;
   }
-  .pill:hover { border-color: rgba(232,200,112,0.35); color: #c8d0e0; }
-  .pill.active { background: #e8c870; color: #0f1623; border-color: #e8c870; font-weight: 700; }
+  .pill:hover {
+    border-color: var(--brass-d);
+    color: var(--fg);
+  }
+  .pill:focus-visible {
+    outline: 2px solid var(--brass);
+    outline-offset: 2px;
+  }
+  .pill.active {
+    background: var(--brass);
+    color: var(--ink-900);
+    border-color: var(--brass);
+    font-weight: 600;
+  }
 
   .dot {
-    width: 6px;
-    height: 6px;
+    width: 8px;
+    height: 8px;
     border-radius: 50%;
     flex-shrink: 0;
   }
 
+  /* ── Items ──────────────────────────────────────────────── */
   .items {
     flex: 1;
     display: flex;
     flex-direction: column;
-    gap: 8px;
-    padding: 12px 16px;
+    gap: 10px;
+    padding: 14px 22px;
   }
 
   .item {
-    background: #0f1623;
-    border: 1px solid rgba(255,255,255,0.06);
-    border-radius: 8px;
-    padding: 10px 12px;
+    background: var(--ink-800);
+    border: 1px solid var(--line);
+    border-radius: var(--radius-md, 12px);
+    padding: 14px 16px;
     display: flex;
     flex-direction: column;
-    gap: 6px;
-    transition: opacity 0.25s;
+    gap: 8px;
+    transition: opacity 250ms ease, border-color 180ms ease, background 180ms ease;
+    position: relative;
   }
   .item.fading { opacity: 0.4; pointer-events: none; }
-  .item:hover { border-color: rgba(232,200,112,0.2); }
+  .item:hover {
+    border-color: var(--brass-d);
+    background: var(--ink-750);
+  }
 
   .item-header {
     display: flex;
     align-items: center;
-    gap: 7px;
+    gap: 10px;
   }
 
   .type-dot {
-    width: 7px;
-    height: 7px;
+    width: 8px;
+    height: 8px;
     border-radius: 50%;
     flex-shrink: 0;
+    box-shadow: 0 0 0 3px var(--ink-800);
   }
 
   .sender {
-    font-size: 12px;
-    font-weight: 600;
-    color: #c8d0e0;
+    font-family: var(--serif);
+    font-size: 16px;
+    font-weight: 400;
+    color: var(--fg);
     flex: 1;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+    letter-spacing: -0.01em;
   }
 
   .time {
+    font-family: var(--mono);
     font-size: 10px;
-    color: #5566aa;
+    letter-spacing: 0.06em;
+    color: var(--mute-2);
     white-space: nowrap;
     flex-shrink: 0;
   }
 
   .preview {
-    font-size: 11px;
-    color: #6677aa;
+    font-size: 13px;
+    color: var(--fg-soft);
     margin: 0;
     display: -webkit-box;
     -webkit-line-clamp: 2;
@@ -291,60 +360,105 @@
 
   .item-actions {
     display: flex;
-    gap: 6px;
+    gap: 8px;
+    padding-top: 4px;
   }
 
   .act-btn {
+    font-family: var(--mono);
     font-size: 11px;
-    font-weight: 600;
-    padding: 4px 10px;
-    border-radius: 5px;
+    font-weight: 500;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    padding: 8px 14px;
+    min-height: 36px;
+    border-radius: var(--radius-pill, 999px);
     border: 1px solid;
     cursor: pointer;
-    transition: opacity 0.12s;
+    transition: opacity 120ms ease, background 180ms ease, border-color 180ms ease;
   }
   .act-btn:disabled { opacity: 0.4; cursor: not-allowed; }
 
   .act-done {
-    background: rgba(34,197,94,0.1);
-    color: #4ade80;
-    border-color: rgba(34,197,94,0.25);
+    background: oklch(0.80 0.06 160 / 0.1);
+    color: var(--sage);
+    border-color: oklch(0.80 0.06 160 / 0.35);
   }
-  .act-done:not(:disabled):hover { background: rgba(34,197,94,0.18); }
+  .act-done:not(:disabled):hover {
+    background: oklch(0.80 0.06 160 / 0.18);
+    border-color: var(--sage);
+  }
 
   .act-link {
+    font-family: var(--mono);
     font-size: 11px;
-    font-weight: 600;
-    color: #e8c870;
+    font-weight: 500;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--brass);
     text-decoration: none;
-    padding: 4px 0;
+    padding: 8px 0;
+    min-height: 36px;
+    display: inline-flex;
+    align-items: center;
+    transition: color 180ms ease;
   }
-  .act-link:hover { text-decoration: underline; }
+  .act-link:hover { color: var(--brass-2); }
 
   .skeleton {
-    height: 84px;
-    background: linear-gradient(90deg, #1a2235 25%, #1e2a3f 50%, #1a2235 75%);
+    height: 96px;
+    background: linear-gradient(
+      90deg,
+      var(--ink-800) 25%,
+      var(--ink-750) 50%,
+      var(--ink-800) 75%
+    );
     background-size: 200% 100%;
     animation: shimmer 1.4s infinite;
-    border-radius: 8px;
+    border-radius: var(--radius-md, 12px);
   }
-  @keyframes shimmer { 0% { background-position: 200% 0; } 100% { background-position: -200% 0; } }
+  @keyframes shimmer {
+    0% { background-position: 200% 0; }
+    100% { background-position: -200% 0; }
+  }
 
-  .empty { color: #5566aa; font-size: 12px; margin: 0; }
-  .err { color: #f87171; font-size: 11px; margin: 0; }
+  .empty {
+    color: var(--mute);
+    font-size: 13px;
+    margin: 0;
+    font-style: italic;
+  }
+  .err {
+    color: oklch(0.62 0.18 22);
+    font-size: 12px;
+    margin: 0;
+  }
 
   .footer-link {
-    display: block;
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 6px;
     position: sticky;
     bottom: 0;
-    padding: 12px 16px;
-    background: #0f1623;
-    border-top: 1px solid rgba(232, 200, 112, 0.1);
-    font-size: 12px;
-    font-weight: 600;
-    color: #e8c870;
+    padding: 14px 22px;
+    background: linear-gradient(to top, var(--ink-900), var(--ink-900) 70%, transparent);
+    border-top: 1px solid var(--line);
+    font-family: var(--mono);
+    font-size: 11px;
+    font-weight: 500;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--brass);
     text-decoration: none;
-    text-align: right;
+    min-height: 44px;
+    transition: color 180ms ease;
   }
-  .footer-link:hover { text-decoration: underline; }
+  .footer-link:hover { color: var(--brass-2); }
+
+  @media (max-width: 480px) {
+    .iv-intro,
+    .pill-row,
+    .items { padding-inline: 18px; }
+  }
 </style>

--- a/website/src/components/assistant/QuestionnaireView.svelte
+++ b/website/src/components/assistant/QuestionnaireView.svelte
@@ -197,14 +197,22 @@
 <!-- Inner header nav (list ↔ detail), shown when in detail mode -->
 {#if activeId}
   <div class="inner-hdr">
-    <button class="back-btn" onclick={goBack}>← Liste</button>
+    <button class="back-btn" onclick={goBack} aria-label="Zurück zur Liste">
+      <span aria-hidden="true">←</span> Liste
+    </button>
     <span class="hdr-title">{activeAssignment?.template_title ?? 'Fragebogen'}</span>
-    <button class="refresh-btn" onclick={loadAssignments} title="Aktualisieren">↻</button>
+    <button class="refresh-btn" onclick={loadAssignments} title="Aktualisieren" aria-label="Aktualisieren">↻</button>
   </div>
 {:else}
-  <div class="inner-hdr">
-    <span class="hdr-title">Meine Fragebögen</span>
-    <button class="refresh-btn" onclick={loadAssignments} title="Aktualisieren">↻</button>
+  <div class="qv-intro">
+    <span class="qv-eyebrow">
+      <span class="qv-eyebrow-bar" aria-hidden="true"></span>
+      Fragebögen
+    </span>
+    <div class="qv-intro-row">
+      <p class="qv-desc">Meine offenen <em>Aufgaben</em> — beantworten in eigenem Tempo.</p>
+      <button class="refresh-btn-intro" onclick={loadAssignments} title="Aktualisieren" aria-label="Aktualisieren">↻</button>
+    </div>
   </div>
 {/if}
 
@@ -373,102 +381,619 @@
 </div>
 
 <style>
+  /* ── Detail-mode inner header ─────────────────────────── */
   .inner-hdr {
     display: flex;
     align-items: center;
-    gap: 8px;
-    padding: 16px 22px;
-    border-bottom: 1px solid rgba(232, 200, 112, 0.12);
-    font-family: var(--font-mono, 'Geist Mono', monospace);
-    font-size: 10px;
-    font-weight: 500;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-    color: var(--admin-text, #e8e8f0);
+    gap: 12px;
+    padding: 18px 22px;
+    min-height: 56px;
+    border-bottom: 1px solid var(--line);
     flex-shrink: 0;
   }
-  .hdr-title { flex: 1; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-  .back-btn { background: transparent; border: none; color: oklch(0.83 0.09 75); cursor: pointer; font-size: 10px; padding: 0; white-space: nowrap; flex-shrink: 0; font-family: var(--font-mono, 'Geist Mono', monospace); letter-spacing: 0.08em; text-transform: uppercase; }
-  .refresh-btn { background: transparent; border: none; color: #aabbcc; cursor: pointer; font-size: 15px; padding: 0; line-height: 1; flex-shrink: 0; }
+  .hdr-title {
+    flex: 1;
+    font-family: var(--serif);
+    font-size: 16px;
+    line-height: 1.2;
+    letter-spacing: -0.01em;
+    color: var(--fg);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .back-btn {
+    background: transparent;
+    border: none;
+    color: var(--brass);
+    cursor: pointer;
+    font-family: var(--mono);
+    font-size: 11px;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    padding: 8px 0;
+    min-height: 36px;
+    white-space: nowrap;
+    flex-shrink: 0;
+    transition: color 180ms ease;
+  }
+  .back-btn:hover { color: var(--brass-2); }
+  .refresh-btn {
+    background: transparent;
+    border: none;
+    color: var(--mute);
+    cursor: pointer;
+    font-size: 16px;
+    width: 36px;
+    height: 36px;
+    border-radius: var(--radius-pill, 999px);
+    line-height: 1;
+    flex-shrink: 0;
+    transition: color 180ms ease, background 180ms ease;
+  }
+  .refresh-btn:hover {
+    color: var(--brass);
+    background: var(--brass-d);
+  }
 
-  .body { flex: 1; overflow-y: auto; padding: 12px; display: flex; flex-direction: column; gap: 8px; min-height: 0; }
-  .hint { font-size: 12px; color: #8899aa; text-align: center; margin: auto; }
+  /* ── List-mode intro ──────────────────────────────────── */
+  .qv-intro {
+    padding: 24px 22px 18px;
+    border-bottom: 1px solid var(--line);
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    flex-shrink: 0;
+  }
+  .qv-eyebrow {
+    font-family: var(--mono);
+    font-size: 11px;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--brass);
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+  }
+  .qv-eyebrow-bar {
+    width: 22px;
+    height: 1px;
+    background: currentColor;
+    opacity: 0.8;
+    flex-shrink: 0;
+  }
+  .qv-intro-row {
+    display: flex;
+    align-items: flex-end;
+    gap: 12px;
+  }
+  .qv-desc {
+    flex: 1;
+    margin: 0;
+    font-family: var(--serif);
+    font-size: 22px;
+    line-height: 1.15;
+    letter-spacing: -0.015em;
+    color: var(--fg);
+    font-weight: 400;
+  }
+  .qv-desc em {
+    font-style: italic;
+    color: var(--brass-2);
+  }
+  .refresh-btn-intro {
+    background: transparent;
+    border: 1px solid var(--line-2);
+    color: var(--mute);
+    cursor: pointer;
+    font-size: 16px;
+    width: 40px;
+    height: 40px;
+    border-radius: var(--radius-pill, 999px);
+    line-height: 1;
+    flex-shrink: 0;
+    transition: color 180ms ease, background 180ms ease, border-color 180ms ease;
+  }
+  .refresh-btn-intro:hover {
+    color: var(--brass);
+    border-color: var(--brass);
+    background: var(--brass-d);
+  }
 
-  .acard-row { display: flex; align-items: center; gap: 4px; }
-  .acard { flex: 1; min-width: 0; background: #0f1623; border: 1px solid #243049; border-radius: 8px; padding: 12px; cursor: pointer; text-align: left; display: flex; align-items: center; justify-content: space-between; gap: 8px; transition: border-color .15s, background .15s; }
-  .acard:hover { border-color: #e8c870; background: #1e2a3a; }
-  .dismiss-x { flex-shrink: 0; background: transparent; border: none; color: #5566aa; cursor: pointer; font-size: 12px; padding: 4px 6px; border-radius: 4px; line-height: 1; transition: color .15s, background .15s; }
-  .dismiss-x:hover { color: #f87171; background: rgba(248,113,113,.1); }
-  .acard-title { font-size: 13px; color: #e8e8f0; font-weight: 500; flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-  .status-badge { flex-shrink: 0; font-size: 10px; font-weight: 700; padding: 2px 8px; border-radius: 999px; }
-  .status-badge.pending { background: #1e3a5a; color: #60a5fa; }
-  .status-badge.progress { background: #3d2c0a; color: #fbbf24; }
-  .status-badge.done { background: #0d2e1a; color: #4ade80; }
+  /* ── Body ─────────────────────────────────────────────── */
+  .body {
+    flex: 1;
+    overflow-y: auto;
+    padding: 16px 22px 24px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    min-height: 0;
+  }
+  .hint {
+    font-size: 14px;
+    color: var(--mute);
+    text-align: center;
+    margin: auto;
+    font-style: italic;
+  }
 
-  .done-state { display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 8px; flex: 1; padding: 24px; }
-  .done-icon { font-size: 36px; color: #4ade80; }
-  .done-state p { color: #aabbcc; font-size: 13px; }
-  .btn-link { background: transparent; border: none; color: #e8c870; cursor: pointer; font-size: 12px; text-decoration: underline; padding: 0; }
+  /* ── Assignment cards ─────────────────────────────────── */
+  .acard-row {
+    display: flex;
+    align-items: stretch;
+    gap: 8px;
+  }
+  .acard {
+    flex: 1;
+    min-width: 0;
+    min-height: 56px;
+    background: var(--ink-800);
+    border: 1px solid var(--line);
+    border-radius: var(--radius-md, 12px);
+    padding: 14px 16px;
+    cursor: pointer;
+    text-align: left;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    transition: border-color 180ms ease, background 180ms ease;
+  }
+  .acard:hover {
+    border-color: var(--brass);
+    background: var(--ink-750);
+  }
+  .acard:focus-visible {
+    outline: 2px solid var(--brass);
+    outline-offset: 2px;
+  }
+  .dismiss-x {
+    flex-shrink: 0;
+    background: transparent;
+    border: 1px solid var(--line-2);
+    color: var(--mute);
+    cursor: pointer;
+    font-size: 14px;
+    width: 44px;
+    border-radius: var(--radius-md, 12px);
+    line-height: 1;
+    transition: color 180ms ease, background 180ms ease, border-color 180ms ease;
+  }
+  .dismiss-x:hover {
+    color: oklch(0.78 0.14 22);
+    background: oklch(0.62 0.18 22 / 0.12);
+    border-color: oklch(0.62 0.18 22 / 0.4);
+  }
+  .acard-title {
+    font-family: var(--serif);
+    font-size: 16px;
+    color: var(--fg);
+    font-weight: 400;
+    letter-spacing: -0.01em;
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .status-badge {
+    flex-shrink: 0;
+    font-family: var(--mono);
+    font-size: 10px;
+    font-weight: 500;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    padding: 4px 10px;
+    border-radius: var(--radius-pill, 999px);
+    border: 1px solid;
+  }
+  .status-badge.pending {
+    background: rgba(255,255,255,0.04);
+    color: var(--mute);
+    border-color: var(--line-2);
+  }
+  .status-badge.progress {
+    background: var(--brass-d);
+    color: var(--brass);
+    border-color: oklch(0.80 0.09 75 / 0.35);
+  }
+  .status-badge.done {
+    background: oklch(0.80 0.06 160 / 0.12);
+    color: var(--sage);
+    border-color: oklch(0.80 0.06 160 / 0.4);
+  }
 
-  .progress-wrap { height: 3px; background: #243049; border-radius: 99px; overflow: hidden; flex-shrink: 0; }
-  .progress-bar { height: 100%; background: #e8c870; border-radius: 99px; transition: width .3s; }
-  .progress-label { font-size: 10px; color: #5566aa; flex-shrink: 0; }
+  /* ── Done state ────────────────────────────────────────── */
+  .done-state {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 14px;
+    flex: 1;
+    padding: 32px 24px;
+    text-align: center;
+  }
+  .done-icon {
+    font-size: 44px;
+    color: var(--sage);
+    line-height: 1;
+  }
+  .done-state p {
+    font-family: var(--serif);
+    color: var(--fg);
+    font-size: 18px;
+    font-weight: 400;
+    letter-spacing: -0.01em;
+    margin: 0;
+  }
+  .btn-link {
+    background: transparent;
+    border: none;
+    color: var(--brass);
+    cursor: pointer;
+    font-family: var(--mono);
+    font-size: 11px;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    padding: 8px;
+    min-height: 36px;
+    transition: color 180ms ease;
+  }
+  .btn-link:hover { color: var(--brass-2); }
 
-  .instr { font-size: 11px; color: #8899aa; background: #0f1623; border: 1px solid #243049; border-radius: 6px; padding: 8px 10px; line-height: 1.5; flex-shrink: 0; }
+  /* ── Progress ─────────────────────────────────────────── */
+  .progress-wrap {
+    height: 2px;
+    background: var(--line-2);
+    border-radius: 99px;
+    overflow: hidden;
+    flex-shrink: 0;
+  }
+  .progress-bar {
+    height: 100%;
+    background: var(--brass);
+    border-radius: 99px;
+    transition: width 320ms var(--ease-out, ease);
+  }
+  .progress-label {
+    font-family: var(--mono);
+    font-size: 10px;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--mute);
+    flex-shrink: 0;
+  }
 
-  .qcard { background: #0f1623; border: 1px solid #243049; border-radius: 8px; padding: 12px; display: flex; flex-direction: column; gap: 8px; flex-shrink: 0; }
-  .role-badge { display: inline-block; font-size: 10px; font-weight: 700; padding: 2px 8px; border-radius: 999px; }
-  .role-badge.admin { background: rgba(59,130,246,.15); color: #60a5fa; border: 1px solid rgba(59,130,246,.25); }
-  .role-badge.user { background: rgba(52,211,153,.15); color: #34d399; border: 1px solid rgba(52,211,153,.25); }
-  .qlabel { font-size: 10px; color: #5566aa; text-transform: uppercase; letter-spacing: .05em; margin: 0; }
-  .qlabel.mt { margin-top: 2px; }
-  .qtext { font-size: 13px; color: #e8e8f0; font-weight: 500; margin: 0; line-height: 1.5; }
-  .qmuted { font-size: 12px; color: #8899aa; margin: 0; line-height: 1.4; }
-  .expected { background: #1a2235; border: 1px solid #243049; border-radius: 6px; padding: 8px; display: flex; flex-direction: column; gap: 4px; }
-  .fn-link { display: inline-flex; align-items: center; gap: 4px; color: #e8c870; font-size: 12px; text-decoration: none; font-weight: 500; }
-  .fn-link:hover { text-decoration: underline; }
+  /* ── Instruction box ──────────────────────────────────── */
+  .instr {
+    font-size: 13px;
+    color: var(--fg-soft);
+    background: var(--ink-800);
+    border: 1px solid var(--line);
+    border-left: 3px solid var(--brass);
+    border-radius: var(--radius-md, 12px);
+    padding: 12px 14px;
+    line-height: 1.55;
+    flex-shrink: 0;
+  }
 
-  .result-opts { display: flex; flex-direction: column; gap: 4px; }
-  .res-btn { background: #1a2235; border: 1px solid #243049; border-radius: 6px; padding: 6px 10px; font-size: 12px; font-weight: 600; cursor: pointer; text-align: left; transition: all .15s; }
-  .res-btn:disabled { opacity: .5; cursor: not-allowed; }
-  .res-ok { color: #4ade80; }
-  .res-ok.chosen { background: rgba(74,222,128,.1); border-color: #4ade80; }
-  .res-partial { color: #fbbf24; }
-  .res-partial.chosen { background: rgba(251,191,36,.1); border-color: #fbbf24; }
-  .res-fail { color: #f87171; }
-  .res-fail.chosen { background: rgba(248,113,113,.1); border-color: #f87171; }
-  .res-btn:not(.chosen):hover { border-color: #5566aa; }
+  /* ── Question card ────────────────────────────────────── */
+  .qcard {
+    background: var(--ink-800);
+    border: 1px solid var(--line);
+    border-radius: var(--radius-md, 12px);
+    padding: 18px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    flex-shrink: 0;
+  }
+  .role-badge {
+    display: inline-flex;
+    align-items: center;
+    align-self: flex-start;
+    font-family: var(--mono);
+    font-size: 10px;
+    font-weight: 500;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    padding: 4px 10px;
+    border-radius: var(--radius-pill, 999px);
+    border: 1px solid;
+  }
+  .role-badge.admin {
+    background: var(--brass-d);
+    color: var(--brass);
+    border-color: oklch(0.80 0.09 75 / 0.4);
+  }
+  .role-badge.user {
+    background: oklch(0.80 0.06 160 / 0.12);
+    color: var(--sage);
+    border-color: oklch(0.80 0.06 160 / 0.4);
+  }
+  .qlabel {
+    font-family: var(--mono);
+    font-size: 10px;
+    color: var(--mute);
+    text-transform: uppercase;
+    letter-spacing: 0.14em;
+    margin: 0;
+  }
+  .qlabel.mt { margin-top: 4px; }
+  .qtext {
+    font-family: var(--serif);
+    font-size: 18px;
+    font-weight: 400;
+    line-height: 1.35;
+    letter-spacing: -0.01em;
+    color: var(--fg);
+    margin: 0;
+  }
+  .qmuted {
+    font-size: 13px;
+    color: var(--fg-soft);
+    margin: 0;
+    line-height: 1.5;
+  }
+  .expected {
+    background: var(--ink-850);
+    border: 1px solid var(--line);
+    border-radius: var(--radius-md, 12px);
+    padding: 12px 14px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .fn-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    color: var(--brass);
+    font-family: var(--mono);
+    font-size: 11px;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    text-decoration: none;
+    font-weight: 500;
+    padding: 6px 0;
+    transition: color 180ms ease;
+  }
+  .fn-link:hover { color: var(--brass-2); text-decoration: underline; }
 
-  .details-ta { background: #1a2235; color: #e8e8f0; border: 1px solid #374151; border-radius: 6px; padding: 6px 8px; font-size: 12px; resize: none; font-family: inherit; line-height: 1.4; width: 100%; box-sizing: border-box; }
-  .details-ta:focus { outline: none; border-color: #e8c870; }
+  /* ── Answer options (shared) ──────────────────────────── */
+  .result-opts {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+  .res-btn {
+    background: var(--ink-850);
+    border: 1px solid var(--line-2);
+    border-radius: var(--radius-md, 12px);
+    padding: 12px 14px;
+    min-height: 44px;
+    font-family: var(--sans);
+    font-size: 14px;
+    font-weight: 500;
+    color: var(--fg-soft);
+    cursor: pointer;
+    text-align: left;
+    transition: border-color 180ms ease, background 180ms ease, color 180ms ease;
+  }
+  .res-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+  .res-btn:not(.chosen):hover {
+    border-color: var(--brass-d);
+    color: var(--fg);
+  }
+  .res-ok { color: var(--sage); }
+  .res-ok.chosen {
+    background: oklch(0.80 0.06 160 / 0.12);
+    border-color: var(--sage);
+    color: var(--sage);
+  }
+  .res-partial { color: var(--brass); }
+  .res-partial.chosen {
+    background: var(--brass-d);
+    border-color: var(--brass);
+    color: var(--brass);
+  }
+  .res-fail { color: oklch(0.78 0.14 22); }
+  .res-fail.chosen {
+    background: oklch(0.62 0.18 22 / 0.12);
+    border-color: oklch(0.62 0.18 22);
+    color: oklch(0.78 0.14 22);
+  }
 
-  .ab-opts { display: flex; flex-direction: column; gap: 4px; }
-  .ab-btn { background: #1a2235; border: 1px solid #243049; border-radius: 6px; padding: 8px 10px; font-size: 12px; color: #aabbcc; cursor: pointer; text-align: left; transition: all .15s; line-height: 1.4; }
-  .ab-btn:hover { border-color: #e8c870; color: #e8e8f0; }
-  .ab-btn:disabled { opacity: .5; cursor: not-allowed; }
-  .ab-btn.ab-chosen { border-color: #e8c870; background: rgba(232,200,112,.15); color: #e8c870; }
+  .details-ta {
+    background: var(--ink-850);
+    color: var(--fg);
+    border: 1px solid var(--line-2);
+    border-radius: var(--radius-md, 12px);
+    padding: 10px 12px;
+    font-family: var(--sans);
+    font-size: 13px;
+    resize: vertical;
+    min-height: 56px;
+    line-height: 1.5;
+    width: 100%;
+    box-sizing: border-box;
+    transition: border-color 180ms ease;
+  }
+  .details-ta::placeholder { color: var(--mute-2); font-style: italic; }
+  .details-ta:focus { outline: none; border-color: var(--brass); }
 
-  .yn-opts { display: flex; gap: 8px; }
-  .yn-btn { flex: 1; padding: 10px; border: 1px solid #243049; border-radius: 6px; background: #1a2235; color: #aabbcc; cursor: pointer; font-size: 13px; font-weight: 600; transition: all .15s; }
-  .yn-btn:hover { border-color: #e8c870; color: #e8e8f0; }
-  .yn-btn:disabled { opacity: .5; cursor: not-allowed; }
-  .yn-btn.yn-chosen { border-color: #e8c870; background: #e8c870; color: #0f1623; }
+  /* A/B choice */
+  .ab-opts {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+  .ab-btn {
+    background: var(--ink-850);
+    border: 1px solid var(--line-2);
+    border-radius: var(--radius-md, 12px);
+    padding: 14px 16px;
+    min-height: 52px;
+    font-family: var(--serif);
+    font-size: 15px;
+    line-height: 1.4;
+    letter-spacing: -0.005em;
+    color: var(--fg-soft);
+    cursor: pointer;
+    text-align: left;
+    transition: border-color 180ms ease, background 180ms ease, color 180ms ease;
+  }
+  .ab-btn:hover { border-color: var(--brass); color: var(--fg); }
+  .ab-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+  .ab-btn.ab-chosen {
+    border-color: var(--brass);
+    background: var(--brass-d);
+    color: var(--fg);
+  }
 
-  .lk-opts { display: flex; gap: 4px; }
-  .lk-btn { flex: 1; padding: 8px 4px; border: 1px solid #243049; border-radius: 6px; background: #1a2235; color: #aabbcc; cursor: pointer; font-size: 13px; font-weight: 700; transition: all .15s; }
-  .lk-btn:hover { border-color: #e8c870; color: #e8e8f0; }
-  .lk-btn:disabled { opacity: .5; cursor: not-allowed; }
-  .lk-btn.lk-chosen { border-color: #e8c870; background: #e8c870; color: #0f1623; }
-  .lk-labels { display: flex; justify-content: space-between; font-size: 10px; color: #5566aa; }
+  /* Ja / Nein */
+  .yn-opts {
+    display: flex;
+    gap: 10px;
+  }
+  .yn-btn {
+    flex: 1;
+    padding: 14px;
+    min-height: 52px;
+    border: 1px solid var(--line-2);
+    border-radius: var(--radius-md, 12px);
+    background: var(--ink-850);
+    color: var(--fg-soft);
+    cursor: pointer;
+    font-family: var(--serif);
+    font-size: 18px;
+    font-weight: 400;
+    transition: border-color 180ms ease, background 180ms ease, color 180ms ease;
+  }
+  .yn-btn:hover { border-color: var(--brass); color: var(--fg); }
+  .yn-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+  .yn-btn.yn-chosen {
+    border-color: var(--brass);
+    background: var(--brass);
+    color: var(--ink-900);
+    font-weight: 500;
+  }
 
-  .nav { display: flex; justify-content: space-between; align-items: center; flex-shrink: 0; }
-  .btn-prev { background: transparent; border: 1px solid #243049; border-radius: 6px; padding: 6px 12px; font-size: 12px; color: #aabbcc; cursor: pointer; transition: all .15s; }
-  .btn-prev:hover:not(:disabled) { border-color: #5566aa; color: #e8e8f0; }
-  .btn-prev:disabled { opacity: .4; cursor: not-allowed; }
-  .btn-next { background: #e8c870; border: none; border-radius: 6px; padding: 6px 12px; font-size: 12px; font-weight: 700; color: #0f1623; cursor: pointer; transition: opacity .15s; }
-  .btn-next:disabled { opacity: .4; cursor: not-allowed; }
-  .btn-submit { width: 100%; background: #4ade80; border: none; border-radius: 8px; padding: 10px; font-size: 13px; font-weight: 700; color: #0f1623; cursor: pointer; transition: opacity .15s; flex-shrink: 0; }
-  .btn-submit:disabled { opacity: .5; cursor: not-allowed; }
+  /* Likert 1-5 */
+  .lk-opts {
+    display: flex;
+    gap: 6px;
+  }
+  .lk-btn {
+    flex: 1;
+    padding: 12px 4px;
+    min-height: 48px;
+    border: 1px solid var(--line-2);
+    border-radius: var(--radius-md, 12px);
+    background: var(--ink-850);
+    color: var(--fg-soft);
+    cursor: pointer;
+    font-family: var(--serif);
+    font-size: 18px;
+    font-weight: 400;
+    transition: border-color 180ms ease, background 180ms ease, color 180ms ease;
+  }
+  .lk-btn:hover { border-color: var(--brass); color: var(--fg); }
+  .lk-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+  .lk-btn.lk-chosen {
+    border-color: var(--brass);
+    background: var(--brass);
+    color: var(--ink-900);
+    font-weight: 500;
+  }
+  .lk-labels {
+    display: flex;
+    justify-content: space-between;
+    font-family: var(--mono);
+    font-size: 10px;
+    letter-spacing: 0.08em;
+    color: var(--mute);
+    padding-top: 4px;
+  }
 
-  .err { font-size: 11px; color: #f87171; margin: 0; flex-shrink: 0; }
+  /* ── Nav buttons ──────────────────────────────────────── */
+  .nav {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 10px;
+    flex-shrink: 0;
+    padding-top: 4px;
+  }
+  .btn-prev {
+    background: transparent;
+    border: 1px solid var(--line-2);
+    border-radius: var(--radius-pill, 999px);
+    padding: 10px 18px;
+    min-height: 44px;
+    font-family: var(--mono);
+    font-size: 11px;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--fg-soft);
+    cursor: pointer;
+    transition: border-color 180ms ease, color 180ms ease;
+  }
+  .btn-prev:hover:not(:disabled) { border-color: var(--brass); color: var(--fg); }
+  .btn-prev:disabled { opacity: 0.4; cursor: not-allowed; }
+  .btn-next {
+    background: var(--brass);
+    border: none;
+    border-radius: var(--radius-pill, 999px);
+    padding: 10px 18px;
+    min-height: 44px;
+    font-family: var(--mono);
+    font-size: 11px;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    font-weight: 600;
+    color: var(--ink-900);
+    cursor: pointer;
+    transition: background 180ms ease, transform 120ms ease;
+  }
+  .btn-next:not(:disabled):hover {
+    background: var(--brass-2);
+    transform: translateY(-1px);
+  }
+  .btn-next:disabled { opacity: 0.4; cursor: not-allowed; }
+  .btn-submit {
+    width: 100%;
+    background: var(--sage);
+    border: none;
+    border-radius: var(--radius-pill, 999px);
+    padding: 14px;
+    min-height: 48px;
+    font-family: var(--mono);
+    font-size: 12px;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    font-weight: 600;
+    color: var(--ink-900);
+    cursor: pointer;
+    transition: opacity 180ms ease, transform 120ms ease;
+    flex-shrink: 0;
+  }
+  .btn-submit:not(:disabled):hover { transform: translateY(-1px); }
+  .btn-submit:disabled { opacity: 0.5; cursor: not-allowed; }
+
+  .err {
+    font-size: 12px;
+    color: oklch(0.78 0.14 22);
+    margin: 0;
+    flex-shrink: 0;
+  }
+
+  @media (max-width: 480px) {
+    .inner-hdr,
+    .qv-intro,
+    .body { padding-inline: 18px; }
+    .qv-desc { font-size: 20px; }
+  }
 </style>

--- a/website/src/components/assistant/SidekickHome.svelte
+++ b/website/src/components/assistant/SidekickHome.svelte
@@ -89,116 +89,127 @@
 
   /* ── Intro block ── */
   .sk-intro {
-    padding: 28px 22px 8px;
+    padding: 32px 22px 12px;
     display: flex;
     flex-direction: column;
-    gap: 10px;
+    gap: 12px;
   }
 
   .sk-eyebrow {
-    font-family: var(--font-mono, 'Geist Mono', monospace);
-    font-size: 10px;
-    letter-spacing: 0.22em;
+    font-family: var(--mono);
+    font-size: 11px;
+    letter-spacing: 0.18em;
     text-transform: uppercase;
-    color: oklch(0.83 0.09 75);
+    color: var(--brass);
     display: inline-flex;
     align-items: center;
     gap: 10px;
   }
 
   .sk-eyebrow-bar {
-    width: 20px;
+    width: 22px;
     height: 1px;
-    background: oklch(0.83 0.09 75);
-    opacity: 0.85;
+    background: currentColor;
+    opacity: 0.8;
     flex-shrink: 0;
   }
 
   .sk-headline {
     margin: 0;
-    font-family: var(--font-serif, 'Newsreader', serif);
-    font-size: 26px;
-    line-height: 1.1;
+    font-family: var(--serif);
+    font-size: 28px;
+    line-height: 1.08;
     letter-spacing: -0.02em;
     font-weight: 400;
-    color: var(--admin-text, #e8e8f0);
+    color: var(--fg);
   }
 
   .sk-headline em {
     font-style: italic;
-    color: oklch(0.87 0.09 75);
+    font-weight: 400;
+    color: var(--brass-2);
   }
 
   .sk-sub {
     margin: 0;
-    font-size: 13px;
-    line-height: 1.5;
-    color: var(--admin-text-mute, #8899aa);
-    max-width: 34ch;
+    font-size: 14px;
+    line-height: 1.55;
+    color: var(--fg-soft);
+    max-width: 38ch;
   }
 
   /* ── Item list ── */
   .sk-list {
-    margin-top: 20px;
-    border-top: 1px solid rgba(255,255,255,0.08);
+    margin-top: 22px;
+    border-top: 1px solid var(--line);
     display: flex;
     flex-direction: column;
   }
 
   .sk-row {
     display: grid;
-    grid-template-columns: 36px 1fr auto 28px;
+    grid-template-columns: 40px 1fr auto 32px;
     align-items: center;
     gap: 14px;
-    padding: 18px 22px;
+    padding: 20px 22px;
+    min-height: 64px;            /* tap target ≥44px even on smallest items */
     border: none;
-    border-bottom: 1px solid rgba(255,255,255,0.06);
+    border-bottom: 1px solid var(--line);
     background: transparent;
     color: inherit;
     text-align: left;
     cursor: pointer;
     position: relative;
-    transition: background 220ms ease;
+    transition: background 220ms var(--ease-out, ease);
     width: 100%;
+  }
+  .sk-row:focus-visible {
+    outline: 2px solid var(--brass);
+    outline-offset: -2px;
   }
 
   .sk-row--hover {
-    background: linear-gradient(to right, transparent, rgba(232,200,112,.04), transparent);
+    background: linear-gradient(
+      to right,
+      transparent,
+      oklch(0.80 0.09 75 / 0.06),
+      transparent
+    );
   }
 
   .sk-no {
-    font-family: var(--font-mono, 'Geist Mono', monospace);
-    font-size: 10px;
+    font-family: var(--mono);
+    font-size: 11px;
     letter-spacing: 0.18em;
     text-transform: uppercase;
-    color: var(--admin-text-disabled, #445);
-    transition: color 180ms ease;
+    color: var(--mute-2);
+    transition: color 180ms var(--ease-out, ease);
   }
 
   .sk-no--active {
-    color: oklch(0.83 0.09 75);
+    color: var(--brass);
   }
 
   .sk-body {
     display: flex;
     flex-direction: column;
-    gap: 3px;
+    gap: 4px;
     min-width: 0;
   }
 
   .sk-item-title {
-    font-family: var(--font-serif, 'Newsreader', serif);
-    font-size: 19px;
+    font-family: var(--serif);
+    font-size: 20px;
     line-height: 1.15;
-    letter-spacing: -0.01em;
+    letter-spacing: -0.015em;
     font-weight: 400;
-    color: var(--admin-text, #e8e8f0);
+    color: var(--fg);
   }
 
   .sk-item-sub {
-    font-size: 12px;
-    color: var(--admin-text-mute, #8899aa);
-    line-height: 1.4;
+    font-size: 13px;
+    color: var(--mute);
+    line-height: 1.45;
   }
 
   .sk-badge-slot {
@@ -208,14 +219,14 @@
   }
 
   .sk-brass-badge {
-    min-width: 22px;
-    height: 22px;
-    padding: 0 7px;
-    border-radius: 999px;
-    background: oklch(0.83 0.09 75);
-    color: #0b111c;
-    font-family: var(--font-mono, 'Geist Mono', monospace);
-    font-size: 10px;
+    min-width: 24px;
+    height: 24px;
+    padding: 0 8px;
+    border-radius: var(--radius-pill, 999px);
+    background: var(--brass);
+    color: var(--ink-900);
+    font-family: var(--mono);
+    font-size: 11px;
     font-weight: 600;
     letter-spacing: 0.04em;
     display: inline-flex;
@@ -225,22 +236,30 @@
   }
 
   .sk-arrow {
-    width: 26px;
-    height: 26px;
-    border-radius: 999px;
-    border: 1px solid rgba(255,255,255,0.1);
+    width: 30px;
+    height: 30px;
+    border-radius: var(--radius-pill, 999px);
+    border: 1px solid var(--line-2);
     background: transparent;
-    color: var(--admin-text-mute, #8899aa);
+    color: var(--mute);
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    transition: border-color 200ms ease, background 200ms ease, color 200ms ease;
+    transition: border-color 200ms var(--ease-out, ease),
+                background 200ms var(--ease-out, ease),
+                color 200ms var(--ease-out, ease);
     flex-shrink: 0;
   }
 
   .sk-arrow--active {
-    border-color: oklch(0.83 0.09 75);
-    background: oklch(0.83 0.09 75);
-    color: #0b111c;
+    border-color: var(--brass);
+    background: var(--brass);
+    color: var(--ink-900);
+  }
+
+  @media (max-width: 480px) {
+    .sk-intro { padding: 28px 18px 10px; }
+    .sk-headline { font-size: 26px; }
+    .sk-row { padding: 18px; grid-template-columns: 36px 1fr auto 28px; }
   }
 </style>

--- a/website/src/components/assistant/SupportView.svelte
+++ b/website/src/components/assistant/SupportView.svelte
@@ -112,7 +112,8 @@
       <span class="sv-eyebrow-bar" aria-hidden="true"></span>
       Feedback &amp; Support
     </span>
-    <p class="sv-desc">Fehler melden oder Verbesserungen vorschlagen.</p>
+    <p class="sv-headline">Fehler melden oder eine <em>Idee teilen</em>.</p>
+    <p class="sv-desc">Was hat funktioniert, was nicht — wir lesen jede Meldung persönlich.</p>
   </div>
   <form onsubmit={handleSubmit}>
     <div class="field">
@@ -197,113 +198,212 @@
 
   /* ── Intro block ── */
   .sv-intro {
-    padding: 20px 22px 14px;
-    border-bottom: 1px solid rgba(255,255,255,0.06);
+    padding: 24px 22px 20px;
+    border-bottom: 1px solid var(--line);
     display: flex;
     flex-direction: column;
-    gap: 6px;
+    gap: 10px;
   }
   .sv-eyebrow {
-    font-family: var(--font-mono, 'Geist Mono', monospace);
-    font-size: 10px;
+    font-family: var(--mono);
+    font-size: 11px;
     letter-spacing: 0.18em;
     text-transform: uppercase;
-    color: oklch(0.83 0.09 75);
+    color: var(--brass);
     display: inline-flex;
     align-items: center;
     gap: 10px;
   }
   .sv-eyebrow-bar {
-    width: 16px;
+    width: 22px;
     height: 1px;
-    background: oklch(0.83 0.09 75);
-    opacity: 0.85;
+    background: currentColor;
+    opacity: 0.8;
     flex-shrink: 0;
+  }
+  .sv-headline {
+    margin: 0;
+    font-family: var(--serif);
+    font-size: 22px;
+    line-height: 1.15;
+    letter-spacing: -0.015em;
+    color: var(--fg);
+    font-weight: 400;
+  }
+  .sv-headline em {
+    font-style: italic;
+    color: var(--brass-2);
   }
   .sv-desc {
     margin: 0;
-    font-size: 12px;
-    color: var(--admin-text-mute, #8899aa);
-    line-height: 1.5;
+    font-size: 13px;
+    color: var(--fg-soft);
+    line-height: 1.55;
+    max-width: 40ch;
   }
 
-  form { padding: 16px 22px; display: flex; flex-direction: column; gap: 12px; }
+  /* ── Form ─────────────────────────────────────────────── */
+  form {
+    padding: 20px 22px 24px;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+  }
 
-  .field { display: flex; flex-direction: column; gap: 4px; }
-  label { font-size: 12px; font-weight: 600; color: #e8e8f0; }
-  .req { color: #e8c870; }
-  .opt { color: #5566aa; font-weight: 400; }
+  .field { display: flex; flex-direction: column; gap: 6px; }
+  label {
+    font-family: var(--mono);
+    font-size: 10px;
+    font-weight: 500;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--mute);
+  }
+  .req { color: var(--brass); }
+  .opt { color: var(--mute-2); font-weight: 400; letter-spacing: 0.04em; text-transform: none; font-style: italic; }
 
   .inp {
     width: 100%;
-    padding: 8px 10px;
-    border-radius: 6px;
-    border: 1px solid #243049;
-    background: #0f1623;
-    color: #e8e8f0;
-    font-size: 13px;
-    font-family: inherit;
+    padding: 12px 14px;
+    min-height: 44px;
+    border-radius: var(--radius-md, 12px);
+    border: 1px solid var(--line-2);
+    background: var(--ink-850);
+    color: var(--fg);
+    font-family: var(--sans);
+    font-size: 14px;
     box-sizing: border-box;
     outline: none;
-    transition: border-color 0.15s;
+    transition: border-color 180ms ease, background 180ms ease;
     appearance: none;
     -webkit-appearance: none;
   }
-  .inp:focus { border-color: oklch(0.83 0.09 75); }
-  textarea.inp { resize: vertical; min-height: 80px; }
+  .inp::placeholder { color: var(--mute-2); }
+  .inp:hover { border-color: rgba(255,255,255,0.18); }
+  .inp:focus { border-color: var(--brass); background: var(--ink-800); }
+  textarea.inp { resize: vertical; min-height: 110px; line-height: 1.55; }
   select.inp {
-    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%238899aa' stroke-width='2'%3E%3Cpath d='M6 9l6 6 6-6'/%3E%3C/svg%3E");
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%23cda260' stroke-width='2'%3E%3Cpath d='M6 9l6 6 6-6'/%3E%3C/svg%3E");
     background-repeat: no-repeat;
-    background-position: right 10px center;
-    padding-right: 30px;
+    background-position: right 14px center;
+    padding-right: 36px;
   }
 
+  /* ── File picker ─────────────────────────────────────── */
   .file-inp {
     display: block;
     width: 100%;
-    font-size: 12px;
-    color: #8899aa;
+    font-family: var(--sans);
+    font-size: 13px;
+    color: var(--fg-soft);
     cursor: pointer;
     box-sizing: border-box;
+    padding: 4px 0;
   }
   .file-inp::file-selector-button {
-    margin-right: 10px;
-    padding: 4px 10px;
-    border-radius: 4px;
+    margin-right: 12px;
+    padding: 10px 16px;
+    min-height: 40px;
+    border-radius: var(--radius-pill, 999px);
     border: 0;
-    background: #e8c870;
-    color: #0f1623;
-    font-size: 12px;
+    background: var(--brass);
+    color: var(--ink-900);
+    font-family: var(--mono);
+    font-size: 11px;
     font-weight: 600;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
     cursor: pointer;
+    transition: background 180ms ease;
   }
+  .file-inp::file-selector-button:hover { background: var(--brass-2); }
 
-  .file-list { margin: 4px 0 0; padding: 0; list-style: none; display: flex; flex-direction: column; gap: 4px; }
-  .file-list li { display: flex; align-items: center; gap: 8px; font-size: 11px; color: #8899aa; }
-  .rm-btn { background: transparent; border: none; color: #e8c870; font-size: 11px; cursor: pointer; padding: 0; text-decoration: underline; }
+  .file-list {
+    margin: 6px 0 0;
+    padding: 0;
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .file-list li {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-family: var(--mono);
+    font-size: 11px;
+    color: var(--fg-soft);
+    padding: 8px 10px;
+    background: var(--ink-850);
+    border: 1px solid var(--line);
+    border-radius: var(--radius-md, 12px);
+  }
+  .file-list li > span { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .rm-btn {
+    background: transparent;
+    border: none;
+    color: oklch(0.78 0.14 22);
+    font-family: var(--mono);
+    font-size: 11px;
+    letter-spacing: 0.06em;
+    cursor: pointer;
+    padding: 4px 8px;
+    min-height: 28px;
+    transition: color 180ms ease;
+  }
+  .rm-btn:hover { color: oklch(0.85 0.14 22); }
 
-  .err { font-size: 11px; color: #f87171; margin: 2px 0 0; }
+  .err {
+    font-size: 12px;
+    color: oklch(0.78 0.14 22);
+    margin: 4px 0 0;
+  }
 
   .submit-btn {
     width: 100%;
-    padding: 10px;
-    border-radius: 6px;
+    padding: 14px;
+    min-height: 48px;
+    border-radius: var(--radius-pill, 999px);
     border: none;
-    background: #e8c870;
-    color: #0f1623;
-    font-size: 13px;
-    font-weight: 700;
+    background: var(--brass);
+    color: var(--ink-900);
+    font-family: var(--mono);
+    font-size: 12px;
+    font-weight: 600;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
     cursor: pointer;
-    transition: opacity 0.15s;
+    transition: background 180ms ease, transform 120ms ease;
+    margin-top: 4px;
+  }
+  .submit-btn:not(:disabled):hover {
+    background: var(--brass-2);
+    transform: translateY(-1px);
   }
   .submit-btn:disabled { opacity: 0.4; cursor: not-allowed; }
 
   .result {
-    padding: 10px 12px;
-    border-radius: 6px;
-    font-size: 12px;
-    line-height: 1.5;
+    padding: 14px 16px;
+    border-radius: var(--radius-md, 12px);
+    font-family: var(--sans);
+    font-size: 13px;
+    line-height: 1.55;
+    border: 1px solid;
   }
-  .result.success { background: rgba(74,222,128,.08); color: #4ade80; border: 1px solid rgba(74,222,128,.2); }
-  .result.error { background: rgba(248,113,113,.08); color: #f87171; border: 1px solid rgba(248,113,113,.2); }
+  .result.success {
+    background: oklch(0.80 0.06 160 / 0.1);
+    color: var(--sage);
+    border-color: oklch(0.80 0.06 160 / 0.4);
+  }
+  .result.error {
+    background: oklch(0.62 0.18 22 / 0.1);
+    color: oklch(0.78 0.14 22);
+    border-color: oklch(0.62 0.18 22 / 0.4);
+  }
+
+  @media (max-width: 480px) {
+    .sv-intro,
+    form { padding-inline: 18px; }
+    .sv-headline { font-size: 20px; }
+  }
 </style>

--- a/website/src/components/assistant/TicketSidekickView.svelte
+++ b/website/src/components/assistant/TicketSidekickView.svelte
@@ -121,6 +121,15 @@
 </script>
 
 <div class="view">
+  <!-- Intro block -->
+  <div class="tv-intro">
+    <span class="tv-eyebrow">
+      <span class="tv-eyebrow-bar" aria-hidden="true"></span>
+      Anfragen
+    </span>
+    <p class="tv-desc">Tickets erfassen, priorisieren und durch den Workflow bewegen.</p>
+  </div>
+
   <!-- Create accordion -->
   <section class="section">
     <button
@@ -128,8 +137,8 @@
       onclick={() => { createOpen = !createOpen; }}
       aria-expanded={createOpen}
     >
-      <span class="section-title">+ Neues Ticket</span>
-      <span class="chevron" class:rotated={createOpen}>›</span>
+      <span class="section-title">Neues Ticket</span>
+      <span class="chevron" class:rotated={createOpen} aria-hidden="true">＋</span>
     </button>
 
     {#if createOpen}
@@ -236,8 +245,42 @@
     padding-bottom: 60px;
   }
 
+  /* ── Intro ──────────────────────────────────────────────── */
+  .tv-intro {
+    padding: 24px 22px 16px;
+    border-bottom: 1px solid var(--line);
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+  .tv-eyebrow {
+    font-family: var(--mono);
+    font-size: 11px;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--brass);
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+  }
+  .tv-eyebrow-bar {
+    width: 22px;
+    height: 1px;
+    background: currentColor;
+    opacity: 0.8;
+    flex-shrink: 0;
+  }
+  .tv-desc {
+    margin: 0;
+    font-size: 13px;
+    color: var(--fg-soft);
+    line-height: 1.55;
+    max-width: 38ch;
+  }
+
+  /* ── Section accordion / list header ───────────────────── */
   .section {
-    border-bottom: 1px solid rgba(232, 200, 112, 0.1);
+    border-bottom: 1px solid var(--line);
   }
 
   .section-header {
@@ -245,176 +288,224 @@
     align-items: center;
     justify-content: space-between;
     width: 100%;
-    padding: 14px 16px;
+    min-height: 48px;
+    padding: 14px 22px;
     background: transparent;
     border: none;
     cursor: pointer;
-    color: #e8e8f0;
+    color: var(--fg);
+    transition: background 180ms ease;
   }
-  .section-header:hover { background: rgba(255,255,255,0.03); }
+  .section-header:hover { background: rgba(255,255,255,0.025); }
+  .section-header:focus-visible {
+    outline: 2px solid var(--brass);
+    outline-offset: -2px;
+  }
 
   .section-title {
+    font-family: var(--mono);
     font-size: 11px;
-    font-weight: 600;
-    font-family: 'Geist Mono', monospace;
-    letter-spacing: 0.08em;
+    font-weight: 500;
+    letter-spacing: 0.18em;
     text-transform: uppercase;
-    color: #e8c870;
+    color: var(--brass);
   }
 
   .chevron {
-    font-size: 16px;
-    color: #5566aa;
-    transition: transform 0.15s;
+    font-size: 18px;
+    font-weight: 300;
+    color: var(--brass);
+    transition: transform 220ms var(--ease-out, ease);
     display: inline-block;
+    line-height: 1;
+    width: 18px;
+    text-align: center;
   }
-  .chevron.rotated { transform: rotate(90deg); }
+  .chevron.rotated { transform: rotate(45deg); }
 
   .list-header {
     display: flex;
     align-items: center;
-    gap: 8px;
-    padding: 14px 16px 8px;
+    gap: 10px;
+    padding: 18px 22px 10px;
   }
 
   .count-badge {
-    font-size: 10px;
-    font-weight: 700;
-    padding: 1px 6px;
-    border-radius: 999px;
-    background: rgba(232,200,112,0.15);
-    color: #e8c870;
-    font-family: monospace;
+    font-family: var(--mono);
+    font-size: 11px;
+    font-weight: 600;
+    padding: 2px 8px;
+    border-radius: var(--radius-pill, 999px);
+    background: var(--brass-d);
+    color: var(--brass);
+    letter-spacing: 0.04em;
   }
 
+  /* ── Create form ────────────────────────────────────────── */
   .create-form {
     display: flex;
     flex-direction: column;
-    gap: 10px;
-    padding: 0 16px 16px;
+    gap: 12px;
+    padding: 4px 22px 20px;
   }
 
   .row2 {
     display: grid;
     grid-template-columns: 1fr 1fr;
-    gap: 8px;
+    gap: 10px;
   }
 
   .field {
     display: flex;
     flex-direction: column;
-    gap: 4px;
+    gap: 6px;
   }
 
   .field label {
-    font-size: 11px;
+    font-family: var(--mono);
+    font-size: 10px;
     font-weight: 500;
-    color: #8899aa;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--mute);
   }
 
-  .req { color: #e8c870; }
+  .req { color: var(--brass); }
 
   .field input,
   .field select,
   .field textarea {
-    background: #0f1623;
-    border: 1px solid #243049;
-    border-radius: 6px;
-    color: #e8e8f0;
-    font-size: 12px;
-    padding: 7px 9px;
-    font-family: inherit;
+    background: var(--ink-850);
+    border: 1px solid var(--line-2);
+    border-radius: var(--radius-md, 12px);
+    color: var(--fg);
+    font-family: var(--sans);
+    font-size: 14px;
+    padding: 11px 14px;
+    min-height: 44px;
     resize: vertical;
     appearance: none;
     -webkit-appearance: none;
+    transition: border-color 180ms ease, background 180ms ease;
   }
+  .field textarea { min-height: 64px; }
   .field select {
-    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%238899aa' stroke-width='2'%3E%3Cpath d='M6 9l6 6 6-6'/%3E%3C/svg%3E");
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%23cda260' stroke-width='2'%3E%3Cpath d='M6 9l6 6 6-6'/%3E%3C/svg%3E");
     background-repeat: no-repeat;
-    background-position: right 8px center;
-    padding-right: 26px;
+    background-position: right 12px center;
+    padding-right: 32px;
   }
+  .field input::placeholder,
+  .field textarea::placeholder { color: var(--mute-2); }
+  .field input:hover,
+  .field select:hover,
+  .field textarea:hover { border-color: rgba(255,255,255,0.18); }
   .field input:focus,
   .field select:focus,
   .field textarea:focus {
     outline: none;
-    border-color: rgba(232,200,112,0.5);
+    border-color: var(--brass);
+    background: var(--ink-800);
   }
 
   .btn-primary {
-    background: #e8c870;
-    color: #0f1623;
+    background: var(--brass);
+    color: var(--ink-900);
     border: none;
-    border-radius: 6px;
-    font-weight: 700;
+    border-radius: var(--radius-pill, 999px);
+    font-family: var(--mono);
+    font-weight: 600;
     font-size: 12px;
-    padding: 8px 14px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    padding: 12px 22px;
+    min-height: 44px;
     cursor: pointer;
-    transition: background 0.12s;
+    transition: background 180ms ease, transform 120ms ease;
     align-self: flex-end;
   }
-  .btn-primary:disabled { background: #2a3a52; color: #5566aa; cursor: not-allowed; }
-  .btn-primary:not(:disabled):hover { background: #f0d480; }
+  .btn-primary:disabled {
+    background: var(--ink-750);
+    color: var(--mute-2);
+    cursor: not-allowed;
+  }
+  .btn-primary:not(:disabled):hover {
+    background: var(--brass-2);
+    transform: translateY(-1px);
+  }
 
+  /* ── Ticket list ────────────────────────────────────────── */
   .ticket-list {
     list-style: none;
     margin: 0;
-    padding: 0 16px 12px;
+    padding: 0 22px 16px;
     display: flex;
     flex-direction: column;
-    gap: 8px;
+    gap: 10px;
   }
 
   .ticket-row {
-    background: #0f1623;
-    border: 1px solid rgba(255,255,255,0.06);
-    border-radius: 8px;
-    padding: 10px 12px;
+    background: var(--ink-800);
+    border: 1px solid var(--line);
+    border-radius: var(--radius-md, 12px);
+    padding: 14px 16px;
     display: flex;
     flex-direction: column;
-    gap: 6px;
+    gap: 10px;
+    transition: border-color 180ms ease, background 180ms ease;
   }
-  .ticket-row:hover { border-color: rgba(232,200,112,0.2); }
+  .ticket-row:hover {
+    border-color: var(--brass-d);
+    background: var(--ink-750);
+  }
 
   .ticket-meta {
     display: flex;
     align-items: center;
-    gap: 6px;
+    gap: 10px;
   }
 
   .ext-id {
-    font-family: 'Geist Mono', monospace;
-    font-size: 9px;
-    color: #e8c870;
+    font-family: var(--mono);
+    font-size: 10px;
+    color: var(--brass);
     font-weight: 600;
+    letter-spacing: 0.06em;
   }
 
   .type-pill {
-    font-size: 9px;
-    font-weight: 600;
+    font-family: var(--mono);
+    font-size: 10px;
+    font-weight: 500;
+    letter-spacing: 0.12em;
     text-transform: uppercase;
-    padding: 1px 5px;
-    border-radius: 4px;
-    background: rgba(255,255,255,0.06);
-    color: #8899aa;
+    padding: 2px 8px;
+    border-radius: var(--radius-pill, 999px);
+    background: rgba(255,255,255,0.05);
+    color: var(--mute);
+    border: 1px solid var(--line);
   }
 
   .prio-dot {
-    width: 7px;
-    height: 7px;
+    width: 8px;
+    height: 8px;
     border-radius: 50%;
     flex-shrink: 0;
     margin-left: auto;
+    box-shadow: 0 0 0 3px var(--ink-800);
   }
-  .prio-dot.prio-hoch { background: #ef4444; }
-  .prio-dot.prio-mittel { background: #f59e0b; }
-  .prio-dot.prio-niedrig { background: #6b7280; }
+  .prio-dot.prio-hoch { background: oklch(0.62 0.18 22); }
+  .prio-dot.prio-mittel { background: var(--brass); }
+  .prio-dot.prio-niedrig { background: var(--mute-2); }
 
   .ticket-title {
-    font-size: 12px;
-    color: #c8d0e0;
+    font-family: var(--serif);
+    font-size: 16px;
+    font-weight: 400;
+    line-height: 1.35;
+    letter-spacing: -0.01em;
+    color: var(--fg);
     margin: 0;
-    line-height: 1.4;
     display: -webkit-box;
     -webkit-line-clamp: 2;
     -webkit-box-orient: vertical;
@@ -422,61 +513,112 @@
   }
 
   .ticket-actions select {
-    background: #0f1623;
-    border: 1px solid #243049;
-    border-radius: 5px;
-    color: #8899aa;
+    background: var(--ink-900);
+    border: 1px solid var(--line-2);
+    border-radius: var(--radius-pill, 999px);
+    color: var(--fg-soft);
+    font-family: var(--mono);
     font-size: 11px;
-    padding: 4px 22px 4px 6px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    padding: 8px 28px 8px 12px;
+    min-height: 36px;
     cursor: pointer;
-    font-family: inherit;
     appearance: none;
     -webkit-appearance: none;
-    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='10' viewBox='0 0 24 24' fill='none' stroke='%235566aa' stroke-width='2'%3E%3Cpath d='M6 9l6 6 6-6'/%3E%3C/svg%3E");
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='10' viewBox='0 0 24 24' fill='none' stroke='%23cda260' stroke-width='2'%3E%3Cpath d='M6 9l6 6 6-6'/%3E%3C/svg%3E");
     background-repeat: no-repeat;
-    background-position: right 6px center;
+    background-position: right 10px center;
+    transition: border-color 180ms ease, color 180ms ease;
   }
-  .ticket-actions select:focus { outline: none; border-color: rgba(232,200,112,0.4); }
+  .ticket-actions select:hover { color: var(--fg); border-color: var(--brass-d); }
+  .ticket-actions select:focus { outline: none; border-color: var(--brass); }
 
   .skeleton {
-    height: 72px;
-    background: linear-gradient(90deg, #1a2235 25%, #1e2a3f 50%, #1a2235 75%);
+    height: 88px;
+    background: linear-gradient(
+      90deg,
+      var(--ink-800) 25%,
+      var(--ink-750) 50%,
+      var(--ink-800) 75%
+    );
     background-size: 200% 100%;
     animation: shimmer 1.4s infinite;
-    border-radius: 8px;
-    margin: 0 16px 8px;
+    border-radius: var(--radius-md, 12px);
+    margin: 0 22px 10px;
   }
-  @keyframes shimmer { 0% { background-position: 200% 0; } 100% { background-position: -200% 0; } }
+  @keyframes shimmer {
+    0% { background-position: 200% 0; }
+    100% { background-position: -200% 0; }
+  }
 
-  .empty { color: #5566aa; font-size: 12px; padding: 8px 16px 16px; margin: 0; }
-  .err { color: #f87171; font-size: 11px; margin: 0; }
+  .empty {
+    color: var(--mute);
+    font-size: 13px;
+    padding: 12px 22px 20px;
+    margin: 0;
+    font-style: italic;
+  }
+  .err {
+    color: oklch(0.62 0.18 22);
+    font-size: 12px;
+    margin: 0;
+  }
 
   .footer-link {
-    display: block;
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 6px;
     position: sticky;
     bottom: 0;
-    padding: 12px 16px;
-    background: #0f1623;
-    border-top: 1px solid #1e2d42;
-    font-size: 12px;
-    font-weight: 600;
-    color: #e8c870;
+    padding: 14px 22px;
+    background: linear-gradient(to top, var(--ink-900), var(--ink-900) 70%, transparent);
+    border-top: 1px solid var(--line);
+    font-family: var(--mono);
+    font-size: 11px;
+    font-weight: 500;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--brass);
     text-decoration: none;
-    text-align: right;
+    min-height: 44px;
+    transition: color 180ms ease;
   }
-  .footer-link:hover { text-decoration: underline; }
+  .footer-link:hover { color: var(--brass-2); }
 
   .toast {
     position: fixed;
     bottom: 80px;
     right: 16px;
-    padding: 8px 14px;
-    border-radius: 8px;
-    font-size: 12px;
-    font-weight: 600;
+    padding: 10px 16px;
+    border-radius: var(--radius-pill, 999px);
+    font-family: var(--mono);
+    font-size: 11px;
+    font-weight: 500;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
     z-index: 100;
     pointer-events: none;
+    backdrop-filter: blur(8px);
   }
-  .toast-ok { background: rgba(34,197,94,0.15); color: #4ade80; border: 1px solid rgba(34,197,94,0.25); }
-  .toast-err { background: rgba(239,68,68,0.15); color: #f87171; border: 1px solid rgba(239,68,68,0.25); }
+  .toast-ok {
+    background: oklch(0.80 0.06 160 / 0.18);
+    color: var(--sage);
+    border: 1px solid oklch(0.80 0.06 160 / 0.4);
+  }
+  .toast-err {
+    background: oklch(0.62 0.18 22 / 0.18);
+    color: oklch(0.78 0.14 22);
+    border: 1px solid oklch(0.62 0.18 22 / 0.4);
+  }
+
+  @media (max-width: 480px) {
+    .tv-intro,
+    .section-header,
+    .list-header,
+    .create-form,
+    .ticket-list { padding-inline: 18px; }
+    .row2 { grid-template-columns: 1fr; }
+  }
 </style>


### PR DESCRIPTION
## Summary

Restyle alle 5 Sidekick-Screens (Home + Anfragen + Postfach + Fragebögen + Support + Hilfe) im mentolder Editorial-Look. Ersetzt hardcoded Admin-Blau (`#0f1623`/`#243049`/`#8899aa`) durch CSS-Variablen (`--ink-*`, `--brass`, `--sage`, `--fg-*`, `--mute`), bringt Newsreader-Serif für Headlines + Karten-Titel und Geist-Mono Eyebrow-Rails.

**Pro Datei:**

- `SidekickHome.svelte` — Tokens angeglichen (oklch 0.83 → 0.80 via `var(--brass)`), Tap-Targets ≥44px
- `TicketSidekickView.svelte` (Anfragen) — Eyebrow-Intro, ink-800 Karten, Newsreader Ticket-Titel, brass-d Count-Badge, sage Toast
- `InboxSidekickView.svelte` (Postfach) — Eyebrow-Intro, Halo-umrandete Type-Dots, sage „Erledigt"-Action statt grünschrill
- `QuestionnaireView.svelte` (Fragebögen) — Newsreader Intro-Headline mit kursivem Akzent, alle 4 Question-Types (Likert/JaNein/AB/Test-Step) in mentolder-Look, sage Submit-CTA
- `SupportView.svelte` — Editorial-Headline „Fehler melden oder eine *Idee teilen*", pill-shaped Submit, sage Success-Result
- `HelpView.svelte` — ink-800 Accordion-Karten, brass-Arrow, gemarkete Step-Listen

**Mobile:** alle Tap-Targets ≥44px (Memory: mobile-optimization)

## Test plan

- [x] `task test:manifests` — 25/25 ok
- [x] `pnpm exec astro check --minimumSeverity error` — 0 errors in den 6 geänderten Files (10 pre-existing in `ops/health.ts` und `stripe/success.astro`, unbeteiligt)
- [ ] Post-Merge: `task feature:website` → visual smoke an `https://web.mentolder.de` + `https://web.korczewski.de` (Sidekick FAB → durch alle 5 Tabs klicken)

🤖 Generated with [Claude Code](https://claude.com/claude-code)