### PR TITLE
chore(docs): include skill visualization HTML in docs build

### DIFF
--- a/k3d/docs-content/_sidebar.md
+++ b/k3d/docs-content/_sidebar.md
@@ -54,3 +54,6 @@
   - [Glossar](glossary)
   - [Decision-Log](decisions)
   - [DB-Schema (ER-Diagramm)](db-schema)
+
+- **Agent Skills**
+  - [🧠 Skill-Übersicht](skills-overview)

--- a/scripts/build-docs.js
+++ b/scripts/build-docs.js
@@ -1,6 +1,6 @@
 // scripts/build-docs.js
 import { readFileSync, writeFileSync, mkdirSync, readdirSync,
-         existsSync, mkdtempSync, rmSync } from 'node:fs';
+         existsSync, mkdtempSync, rmSync, copyFileSync, cpSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { execFileSync } from 'node:child_process';
@@ -413,6 +413,18 @@ async function main() {
   // Asset Pass
   writeFileSync(join(OUT_DIR, 'style.css'), getPageCss(), 'utf8');
   writeFileSync(join(OUT_DIR, 'app.js'), getPageJs(), 'utf8');
+
+  // Copy skills visualization (standalone HTML — served at /skills-overview.html)
+  const SKILLS_OVERVIEW_SRC = join(__dirname, '../docs/skills-overview.html');
+  const SKILLS_DIR_SRC = join(__dirname, '../docs/skills');
+  if (existsSync(SKILLS_OVERVIEW_SRC)) {
+    copyFileSync(SKILLS_OVERVIEW_SRC, join(OUT_DIR, 'skills-overview.html'));
+    console.log('  → skills-overview.html ✓');
+  }
+  if (existsSync(SKILLS_DIR_SRC)) {
+    cpSync(SKILLS_DIR_SRC, join(OUT_DIR, 'skills'), { recursive: true });
+    console.log('  → skills/ ✓');
+  }
 
   // First pass: MD → raw HTML, collect titles for search index
   const pages = [];


### PR DESCRIPTION
## Summary
- Adds `cpSync` call in `build-docs.js` to copy `docs/skills-overview.html` and `docs/skills/` into the built output during every docs build
- Adds **Agent Skills** sidebar section with a link to the skill overview page
- The visualization is served as a standalone HTML at `/skills-overview.html` on both `docs.mentolder.de` and `docs.korczewski.de`

## Test plan
- [x] `node scripts/build-docs.js --fast` completes with `skills-overview.html ✓` and `skills/ ✓`
- [x] All 20 skill HTML files + `style.css` present in `k3d/docs-content-built/skills/`
- [x] Sidebar link in generated `index.html` references `skills-overview`
- [x] 54 unit tests pass, 0 failures
- [x] Manifest tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)