### PR TITLE
fix(skills+db): skill fixes T000149/157/158/159 + domains cleanup + pentest note

### DIFF
--- a/.claude/skills/db-migration/SKILL.md
+++ b/.claude/skills/db-migration/SKILL.md
@@ -72,6 +72,13 @@ SQL
 
 ## Phase 3: Apply to mentolder
 
+> **⚠️ Rollen-Eigentumshinweis:** `task workspace:psql` verbindet als `website`-Rolle. DDL auf `bachelorprojekt`, `coaching`, und `knowledge` Schemas (Tabellen gehören `postgres`) schlägt mit "must be owner of table" fehl. Für DDL auf diesen Schemas direkt mit `-U postgres` verbinden:
+> ```bash
+> PGPOD=$(kubectl get pod -n workspace --context mentolder -l app=shared-db -o name | head -1)
+> kubectl exec -i "$PGPOD" -n workspace --context mentolder -- psql -U postgres -d website < migration.sql
+> ```
+> Für `public`-Schema DDL ist `task workspace:psql` ausreichend.
+
 ```bash
 # Backup first for any destructive or large migration
 task workspace:backup

--- a/.claude/skills/dev-flow-execute/SKILL.md
+++ b/.claude/skills/dev-flow-execute/SKILL.md
@@ -90,6 +90,8 @@ git rebase origin/main
 git submodule update --init --recursive
 ```
 
+> **Nach Rebase — erster Push:** Falls der Branch schon gepusht war, schlägt `git push` fehl ("rejected ... non-fast-forward"). Lösung: `git push --force-with-lease origin <branch>`. `--force-with-lease` ist sicherer als `--force` — schlägt fehl wenn jemand anderes seit dem letzten Fetch gepusht hat.
+
 Falls `git rebase` Konflikte meldet:
 
 ```bash
@@ -314,14 +316,12 @@ Das ist alles — die PR-Nummer landet in Schritt 6.5 als Comment-Body und in Sc
 ## Schritt 6: Auto-Merge wenn CI grün
 
 ```bash
-gh pr merge --squash --delete-branch
+# Im Haupt-Repo ausführen — vermeidet den harmlosen "main already used by worktree" Git-Fehler
+MAIN_REPO=$(git worktree list --porcelain | awk '/^worktree/{print $2; exit}')
+(cd "$MAIN_REPO" && gh pr merge --squash --delete-branch)
 ```
 
-> **Bekannte Fehler-Meldung (kein echter Fehler):**
-> ```
-> fatal: 'main' is already used by worktree at '/home/patrick/Bachelorprojekt'
-> ```
-> Diese Meldung erscheint, wenn `gh` nach dem Merge versucht, `git checkout main` im sekundären Worktree auszuführen, und der Haupt-Repo bereits `main` ausgecheckt hat. **Der PR ist trotzdem erfolgreich gemergt** — nur der lokale Checkout-Seiteneffekt scheitert. Prüfen mit:
+> **Falls der Merge-Fehler auftritt:** Prüfen ob der Merge trotzdem durchging:
 > ```bash
 > gh pr view --json mergedAt -q '.mergedAt'   # leer = noch offen, Zeitstempel = gemergt
 > ```
@@ -379,7 +379,17 @@ if [[ -z "$ARCHIVE_CWD" ]]; then
 fi
 cd "$ARCHIVE_CWD"
 git fetch origin main
+# Parallel-Session-Schutz: Unstaged-Änderungen aus anderen Sessions sichern vor reset
+STASHED_PLAN=0
+if ! git diff --quiet; then
+  echo "Unstaged Änderungen erkannt — stashe vor reset..."
+  git stash
+  STASHED_PLAN=1
+fi
 git reset --hard origin/main   # Plan-Datei ist jetzt auf Disk (gemergter Revision)
+if [[ "$STASHED_PLAN" == "1" ]]; then
+  git stash pop || echo "⚠️  Stash-Pop-Konflikte — bitte manuell auflösen."
+fi
 
 # Sicherheitsprüfung: CWD muss auf main sein
 CURRENT_BRANCH=$(git branch --show-current)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,8 @@ task workspace:db:drop -- <dbname> ENV=<env>             # Drop a database (asks
 task workspace:db:restore -- <db> <timestamp> ENV=<env>  # List backups then restore (db: keycloak|nextcloud|vaultwarden|website|docuseal|all)
 ```
 
+**Note on `pentest` database:** An empty `pentest` database (owned by `pentest` role) exists on both clusters. It is intentional — a CTF target defined in `k3d/pentest-flags.yaml` and `k3d/shared-db.yaml`. Do not flag it as anomalous during audits.
+
 ### Post-Deploy Setup
 ```bash
 task workspace:office:deploy ENV=<env>    # Deploy Collabora (separate overlay — required for full bring-up)

--- a/scripts/datamodel/2026-05-23-questionnaire-schema-korczewski.sql
+++ b/scripts/datamodel/2026-05-23-questionnaire-schema-korczewski.sql
@@ -1,0 +1,239 @@
+-- Schema drift fix: entire questionnaire schema missing on korczewski
+-- Root cause: the questionnaire/systemtest feature was built on mentolder
+-- but the DB migrations never applied to korczewski.
+-- Effect: all 4 systemtest CronJobs fail with exit-22 (HTTP 500).
+--
+-- DDL generated from mentolder pg_dump --schema-only --no-owner --no-acl
+-- Idempotent: CREATE TABLE IF NOT EXISTS + CREATE INDEX IF NOT EXISTS.
+-- Apply with: kubectl exec -i <pgpod> -n workspace-korczewski -- psql -U postgres -d website < <this-file>
+
+SET search_path = public;
+
+BEGIN;
+
+-- Tables (dependency order: parents before children)
+CREATE TABLE IF NOT EXISTS public.questionnaire_templates (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    title text NOT NULL,
+    description text DEFAULT ''::text NOT NULL,
+    instructions text DEFAULT ''::text NOT NULL,
+    status text DEFAULT 'draft'::text NOT NULL,
+    created_at timestamptz DEFAULT now() NOT NULL,
+    updated_at timestamptz DEFAULT now() NOT NULL,
+    is_system_test boolean DEFAULT false NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS public.questionnaire_dimensions (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    template_id uuid NOT NULL,
+    name text NOT NULL,
+    "position" integer DEFAULT 0 NOT NULL,
+    threshold_mid integer,
+    threshold_high integer,
+    score_multiplier integer DEFAULT 1 NOT NULL,
+    created_at timestamptz DEFAULT now() NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS public.questionnaire_questions (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    template_id uuid NOT NULL,
+    "position" integer DEFAULT 0 NOT NULL,
+    question_text text NOT NULL,
+    question_type text DEFAULT 'ab_choice'::text NOT NULL,
+    created_at timestamptz DEFAULT now() NOT NULL,
+    test_expected_result text,
+    test_function_url text,
+    test_menu_path text,
+    test_role text
+);
+
+CREATE TABLE IF NOT EXISTS public.questionnaire_answer_options (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    question_id uuid NOT NULL,
+    option_key text NOT NULL,
+    label text DEFAULT ''::text NOT NULL,
+    dimension_id uuid,
+    weight integer DEFAULT 1 NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS public.questionnaire_assignments (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    customer_id uuid NOT NULL,
+    template_id uuid NOT NULL,
+    status text DEFAULT 'pending'::text NOT NULL,
+    coach_notes text DEFAULT ''::text NOT NULL,
+    assigned_at timestamptz DEFAULT now() NOT NULL,
+    submitted_at timestamptz,
+    reviewed_at timestamptz,
+    dismissed_at timestamptz,
+    dismiss_reason text,
+    project_id uuid,
+    archived_at timestamptz,
+    is_test_data boolean DEFAULT false NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS public.questionnaire_answers (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    assignment_id uuid NOT NULL,
+    question_id uuid NOT NULL,
+    option_key text NOT NULL,
+    saved_at timestamptz DEFAULT now() NOT NULL,
+    details_text text
+);
+
+CREATE TABLE IF NOT EXISTS public.questionnaire_assignment_scores (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    assignment_id uuid NOT NULL,
+    dimension_id uuid NOT NULL,
+    final_score integer NOT NULL,
+    threshold_mid integer,
+    threshold_high integer,
+    level text,
+    snapshot_at timestamptz DEFAULT now() NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS public.questionnaire_test_evidence (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    assignment_id uuid NOT NULL,
+    question_id uuid NOT NULL,
+    attempt integer DEFAULT 0 NOT NULL,
+    replay_path text,
+    partial boolean DEFAULT false NOT NULL,
+    console_log jsonb,
+    network_log jsonb,
+    recorded_from timestamptz,
+    recorded_to timestamptz,
+    created_at timestamptz DEFAULT now() NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS public.questionnaire_test_fixtures (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    assignment_id uuid NOT NULL,
+    question_id uuid NOT NULL,
+    attempt integer NOT NULL,
+    table_name text NOT NULL,
+    row_id uuid NOT NULL,
+    created_at timestamptz DEFAULT now() NOT NULL,
+    purged_at timestamptz,
+    purge_error text
+);
+
+CREATE TABLE IF NOT EXISTS public.questionnaire_test_seed_registry (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    template_id uuid NOT NULL,
+    question_id uuid,
+    seed_module text NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS public.questionnaire_test_status (
+    question_id uuid NOT NULL,
+    last_result text NOT NULL,
+    last_result_at timestamptz NOT NULL,
+    last_success_at timestamptz,
+    last_assignment_id uuid,
+    evidence_id uuid,
+    last_failure_ticket_id uuid,
+    retest_pending_at timestamptz,
+    retest_attempt integer DEFAULT 0 NOT NULL,
+    CONSTRAINT questionnaire_test_status_last_result_check
+        CHECK ((last_result = ANY (ARRAY['erfüllt'::text, 'teilweise'::text, 'nicht_erfüllt'::text])))
+);
+
+-- Primary keys
+ALTER TABLE ONLY public.questionnaire_templates
+    ADD CONSTRAINT questionnaire_templates_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.questionnaire_dimensions
+    ADD CONSTRAINT questionnaire_dimensions_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.questionnaire_questions
+    ADD CONSTRAINT questionnaire_questions_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.questionnaire_answer_options
+    ADD CONSTRAINT questionnaire_answer_options_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.questionnaire_assignments
+    ADD CONSTRAINT questionnaire_assignments_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.questionnaire_answers
+    ADD CONSTRAINT questionnaire_answers_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.questionnaire_answers
+    ADD CONSTRAINT questionnaire_answers_assignment_id_question_id_key UNIQUE (assignment_id, question_id);
+ALTER TABLE ONLY public.questionnaire_assignment_scores
+    ADD CONSTRAINT questionnaire_assignment_scores_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.questionnaire_assignment_scores
+    ADD CONSTRAINT uq_qas_assignment_dimension UNIQUE (assignment_id, dimension_id);
+ALTER TABLE ONLY public.questionnaire_test_evidence
+    ADD CONSTRAINT questionnaire_test_evidence_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.questionnaire_test_fixtures
+    ADD CONSTRAINT questionnaire_test_fixtures_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.questionnaire_test_seed_registry
+    ADD CONSTRAINT questionnaire_test_seed_registry_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.questionnaire_test_status
+    ADD CONSTRAINT questionnaire_test_status_pkey PRIMARY KEY (question_id);
+
+-- Indexes
+CREATE INDEX IF NOT EXISTS idx_questionnaire_dimensions__template_id ON public.questionnaire_dimensions(template_id);
+CREATE INDEX IF NOT EXISTS idx_questionnaire_questions__template_id ON public.questionnaire_questions(template_id);
+CREATE INDEX IF NOT EXISTS idx_questionnaire_answer_options__question_id ON public.questionnaire_answer_options(question_id);
+CREATE INDEX IF NOT EXISTS idx_questionnaire_answer_options__dimension_id ON public.questionnaire_answer_options(dimension_id);
+CREATE INDEX IF NOT EXISTS idx_questionnaire_assignments__template_id ON public.questionnaire_assignments(template_id);
+CREATE INDEX IF NOT EXISTS idx_questionnaire_assignments__project_id ON public.questionnaire_assignments(project_id);
+CREATE INDEX IF NOT EXISTS idx_questionnaire_answers__question_id ON public.questionnaire_answers(question_id);
+CREATE INDEX IF NOT EXISTS idx_qas_assignment ON public.questionnaire_assignment_scores(assignment_id);
+CREATE INDEX IF NOT EXISTS idx_questionnaire_test_evidence__question_id ON public.questionnaire_test_evidence(question_id);
+CREATE INDEX IF NOT EXISTS ix_evidence_assignment_question ON public.questionnaire_test_evidence(assignment_id, question_id, attempt);
+CREATE INDEX IF NOT EXISTS idx_questionnaire_test_fixtures__question_id ON public.questionnaire_test_fixtures(question_id);
+CREATE INDEX IF NOT EXISTS ix_fixtures_unpurged ON public.questionnaire_test_fixtures(assignment_id) WHERE (purged_at IS NULL);
+CREATE INDEX IF NOT EXISTS idx_questionnaire_test_seed_registry__question_id ON public.questionnaire_test_seed_registry(question_id);
+CREATE UNIQUE INDEX IF NOT EXISTS uq_seed_registry_scope ON public.questionnaire_test_seed_registry(template_id, COALESCE(question_id, '00000000-0000-0000-0000-000000000000'::uuid));
+CREATE INDEX IF NOT EXISTS idx_questionnaire_test_status__evidence_id ON public.questionnaire_test_status(evidence_id);
+CREATE INDEX IF NOT EXISTS idx_questionnaire_test_status__last_failure_ticket_id ON public.questionnaire_test_status(last_failure_ticket_id);
+
+-- Foreign key constraints
+ALTER TABLE ONLY public.questionnaire_dimensions
+    ADD CONSTRAINT questionnaire_dimensions_template_id_fkey FOREIGN KEY (template_id) REFERENCES public.questionnaire_templates(id) ON DELETE CASCADE;
+ALTER TABLE ONLY public.questionnaire_questions
+    ADD CONSTRAINT questionnaire_questions_template_id_fkey FOREIGN KEY (template_id) REFERENCES public.questionnaire_templates(id) ON DELETE CASCADE;
+ALTER TABLE ONLY public.questionnaire_answer_options
+    ADD CONSTRAINT questionnaire_answer_options_question_id_fkey FOREIGN KEY (question_id) REFERENCES public.questionnaire_questions(id) ON DELETE CASCADE;
+ALTER TABLE ONLY public.questionnaire_answer_options
+    ADD CONSTRAINT questionnaire_answer_options_dimension_id_fkey FOREIGN KEY (dimension_id) REFERENCES public.questionnaire_dimensions(id) ON DELETE SET NULL;
+ALTER TABLE ONLY public.questionnaire_assignments
+    ADD CONSTRAINT questionnaire_assignments_template_id_fkey FOREIGN KEY (template_id) REFERENCES public.questionnaire_templates(id);
+ALTER TABLE ONLY public.questionnaire_assignments
+    ADD CONSTRAINT questionnaire_assignments_project_id_fkey FOREIGN KEY (project_id) REFERENCES tickets.tickets(id) ON DELETE SET NULL;
+ALTER TABLE ONLY public.questionnaire_answers
+    ADD CONSTRAINT questionnaire_answers_assignment_id_fkey FOREIGN KEY (assignment_id) REFERENCES public.questionnaire_assignments(id) ON DELETE CASCADE;
+ALTER TABLE ONLY public.questionnaire_answers
+    ADD CONSTRAINT questionnaire_answers_question_id_fkey FOREIGN KEY (question_id) REFERENCES public.questionnaire_questions(id);
+ALTER TABLE ONLY public.questionnaire_assignment_scores
+    ADD CONSTRAINT questionnaire_assignment_scores_assignment_id_fkey FOREIGN KEY (assignment_id) REFERENCES public.questionnaire_assignments(id) ON DELETE CASCADE;
+ALTER TABLE ONLY public.questionnaire_test_evidence
+    ADD CONSTRAINT questionnaire_test_evidence_assignment_id_fkey FOREIGN KEY (assignment_id) REFERENCES public.questionnaire_assignments(id) ON DELETE CASCADE;
+ALTER TABLE ONLY public.questionnaire_test_evidence
+    ADD CONSTRAINT questionnaire_test_evidence_question_id_fkey FOREIGN KEY (question_id) REFERENCES public.questionnaire_questions(id);
+ALTER TABLE ONLY public.questionnaire_test_fixtures
+    ADD CONSTRAINT questionnaire_test_fixtures_assignment_id_fkey FOREIGN KEY (assignment_id) REFERENCES public.questionnaire_assignments(id) ON DELETE CASCADE;
+ALTER TABLE ONLY public.questionnaire_test_fixtures
+    ADD CONSTRAINT questionnaire_test_fixtures_question_id_fkey FOREIGN KEY (question_id) REFERENCES public.questionnaire_questions(id);
+ALTER TABLE ONLY public.questionnaire_test_seed_registry
+    ADD CONSTRAINT questionnaire_test_seed_registry_template_id_fkey FOREIGN KEY (template_id) REFERENCES public.questionnaire_templates(id) ON DELETE CASCADE;
+ALTER TABLE ONLY public.questionnaire_test_seed_registry
+    ADD CONSTRAINT questionnaire_test_seed_registry_question_id_fkey FOREIGN KEY (question_id) REFERENCES public.questionnaire_questions(id) ON DELETE CASCADE;
+ALTER TABLE ONLY public.questionnaire_test_status
+    ADD CONSTRAINT questionnaire_test_status_question_id_fkey FOREIGN KEY (question_id) REFERENCES public.questionnaire_questions(id) ON DELETE CASCADE;
+ALTER TABLE ONLY public.questionnaire_test_status
+    ADD CONSTRAINT qts_evidence_id_fk FOREIGN KEY (evidence_id) REFERENCES public.questionnaire_test_evidence(id);
+ALTER TABLE ONLY public.questionnaire_test_status
+    ADD CONSTRAINT qts_failure_ticket_fk FOREIGN KEY (last_failure_ticket_id) REFERENCES tickets.tickets(id);
+
+-- Grants (website role — full access matching mentolder)
+GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER ON public.questionnaire_templates TO website;
+GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER ON public.questionnaire_dimensions TO website;
+GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER ON public.questionnaire_questions TO website;
+GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER ON public.questionnaire_answer_options TO website;
+GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER ON public.questionnaire_assignments TO website;
+GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER ON public.questionnaire_answers TO website;
+GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER ON public.questionnaire_assignment_scores TO website;
+GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER ON public.questionnaire_test_evidence TO website;
+GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER ON public.questionnaire_test_fixtures TO website;
+GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER ON public.questionnaire_test_seed_registry TO website;
+GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER ON public.questionnaire_test_status TO website;
+
+COMMIT;

--- a/scripts/datamodel/2026-05-23-questionnaire-test-tables-korczewski.sql
+++ b/scripts/datamodel/2026-05-23-questionnaire-test-tables-korczewski.sql
@@ -1,0 +1,121 @@
+-- Schema drift fix: questionnaire_test_* tables missing on korczewski
+-- All 4 tables exist on mentolder but were never created on korczewski.
+-- Root cause: the Playwright/systemtest feature only landed in DB migrations
+-- on mentolder. This caused all systemtest CronJobs on korczewski to return
+-- 500/exit-22: drain-outbox, cleanup-fixtures, purge-all-test-data.
+--
+-- Creation order is dependency-driven:
+--   1. questionnaire_test_evidence (referenced by questionnaire_test_status)
+--   2. questionnaire_test_fixtures (no inter-table deps)
+--   3. questionnaire_test_seed_registry (no inter-table deps)
+--   4. questionnaire_test_status (refs evidence + tickets.tickets)
+--
+-- Idempotent (CREATE TABLE IF NOT EXISTS). Safe on populated DB.
+-- Apply with: kubectl exec ... psql -U postgres -d website < <this-file>
+
+BEGIN;
+
+-- 1. questionnaire_test_evidence
+CREATE TABLE IF NOT EXISTS public.questionnaire_test_evidence (
+    id            uuid        NOT NULL DEFAULT gen_random_uuid(),
+    assignment_id uuid        NOT NULL,
+    question_id   uuid        NOT NULL,
+    attempt       integer     NOT NULL DEFAULT 0,
+    replay_path   text,
+    partial       boolean     NOT NULL DEFAULT false,
+    console_log   jsonb,
+    network_log   jsonb,
+    recorded_from timestamptz,
+    recorded_to   timestamptz,
+    created_at    timestamptz NOT NULL DEFAULT now(),
+    CONSTRAINT questionnaire_test_evidence_pkey PRIMARY KEY (id),
+    CONSTRAINT questionnaire_test_evidence_assignment_id_fkey
+        FOREIGN KEY (assignment_id) REFERENCES questionnaire_assignments(id) ON DELETE CASCADE,
+    CONSTRAINT questionnaire_test_evidence_question_id_fkey
+        FOREIGN KEY (question_id) REFERENCES questionnaire_questions(id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_questionnaire_test_evidence__question_id
+    ON public.questionnaire_test_evidence(question_id);
+CREATE INDEX IF NOT EXISTS ix_evidence_assignment_question
+    ON public.questionnaire_test_evidence(assignment_id, question_id, attempt);
+
+-- 2. questionnaire_test_fixtures
+CREATE TABLE IF NOT EXISTS public.questionnaire_test_fixtures (
+    id            uuid        NOT NULL DEFAULT gen_random_uuid(),
+    assignment_id uuid        NOT NULL,
+    question_id   uuid        NOT NULL,
+    attempt       integer     NOT NULL,
+    table_name    text        NOT NULL,
+    row_id        uuid        NOT NULL,
+    created_at    timestamptz NOT NULL DEFAULT now(),
+    purged_at     timestamptz,
+    purge_error   text,
+    CONSTRAINT questionnaire_test_fixtures_pkey PRIMARY KEY (id),
+    CONSTRAINT questionnaire_test_fixtures_assignment_id_fkey
+        FOREIGN KEY (assignment_id) REFERENCES questionnaire_assignments(id) ON DELETE CASCADE,
+    CONSTRAINT questionnaire_test_fixtures_question_id_fkey
+        FOREIGN KEY (question_id) REFERENCES questionnaire_questions(id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_questionnaire_test_fixtures__question_id
+    ON public.questionnaire_test_fixtures(question_id);
+CREATE INDEX IF NOT EXISTS ix_fixtures_unpurged
+    ON public.questionnaire_test_fixtures(assignment_id) WHERE purged_at IS NULL;
+
+-- 3. questionnaire_test_seed_registry
+CREATE TABLE IF NOT EXISTS public.questionnaire_test_seed_registry (
+    id          uuid NOT NULL DEFAULT gen_random_uuid(),
+    template_id uuid NOT NULL,
+    question_id uuid,
+    seed_module text NOT NULL,
+    CONSTRAINT questionnaire_test_seed_registry_pkey PRIMARY KEY (id),
+    CONSTRAINT uq_seed_registry_scope
+        UNIQUE (template_id, COALESCE(question_id, '00000000-0000-0000-0000-000000000000'::uuid)),
+    CONSTRAINT questionnaire_test_seed_registry_question_id_fkey
+        FOREIGN KEY (question_id) REFERENCES questionnaire_questions(id) ON DELETE CASCADE,
+    CONSTRAINT questionnaire_test_seed_registry_template_id_fkey
+        FOREIGN KEY (template_id) REFERENCES questionnaire_templates(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_questionnaire_test_seed_registry__question_id
+    ON public.questionnaire_test_seed_registry(question_id);
+
+-- 4. questionnaire_test_status
+CREATE TABLE IF NOT EXISTS public.questionnaire_test_status (
+    question_id            uuid    NOT NULL,
+    last_result            text    NOT NULL,
+    last_result_at         timestamptz NOT NULL,
+    last_success_at        timestamptz,
+    last_assignment_id     uuid,
+    evidence_id            uuid,
+    last_failure_ticket_id uuid,
+    retest_pending_at      timestamptz,
+    retest_attempt         integer NOT NULL DEFAULT 0,
+    CONSTRAINT questionnaire_test_status_pkey PRIMARY KEY (question_id),
+    CONSTRAINT questionnaire_test_status_last_result_check
+        CHECK (last_result = ANY (ARRAY['erfüllt'::text, 'teilweise'::text, 'nicht_erfüllt'::text])),
+    CONSTRAINT qts_evidence_id_fk
+        FOREIGN KEY (evidence_id) REFERENCES questionnaire_test_evidence(id),
+    CONSTRAINT qts_failure_ticket_fk
+        FOREIGN KEY (last_failure_ticket_id) REFERENCES tickets.tickets(id),
+    CONSTRAINT questionnaire_test_status_question_id_fkey
+        FOREIGN KEY (question_id) REFERENCES questionnaire_questions(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_questionnaire_test_status__evidence_id
+    ON public.questionnaire_test_status(evidence_id);
+CREATE INDEX IF NOT EXISTS idx_questionnaire_test_status__last_failure_ticket_id
+    ON public.questionnaire_test_status(last_failure_ticket_id);
+
+-- Grants: website role needs full access (matches mentolder grants)
+GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER
+    ON public.questionnaire_test_evidence TO website;
+GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER
+    ON public.questionnaire_test_fixtures TO website;
+GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER
+    ON public.questionnaire_test_seed_registry TO website;
+GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER
+    ON public.questionnaire_test_status TO website;
+
+COMMIT;

--- a/scripts/datamodel/domains.py
+++ b/scripts/datamodel/domains.py
@@ -43,7 +43,8 @@ DOMAINS: dict[str, dict[str, list[str]]] = {
             "ticket_links", "ticket_tags", "ticket_watchers", "ticket_counters",
             "tags", "pr_events",
         ],
-        "public": ["bug_tickets", "inbox_items"],
+        "bugs": ["bug_tickets"],
+        "public": ["inbox_items"],
     },
     "Platform & Config": {
         "public": [
@@ -57,7 +58,7 @@ DOMAINS: dict[str, dict[str, list[str]]] = {
     "Testing & CI": {
         "public": [
             "test_runs", "test_results", "systemtest_failure_outbox",
-            "systemtest_magic_tokens", "playwright_reports",
+            "systemtest_magic_tokens",
         ],
     },
     "AI Assistant": {
@@ -68,7 +69,6 @@ DOMAINS: dict[str, dict[str, list[str]]] = {
     },
     "Bachelorprojekt & Superpowers": {
         "bachelorprojekt": ["requirements", "features", "pipeline", "test_results"],
-        "superpowers": ["plans", "plan_sections"],
     },
 }
 


### PR DESCRIPTION
## Summary
- **dev-flow-execute (T000149):** Add stash guard before `git reset --hard origin/main` in Schritt 7 — prevents discarding unstaged changes from parallel sessions
- **dev-flow-execute (T000157):** Document `--force-with-lease` requirement after rebase when branch was previously pushed
- **dev-flow-execute (T000158):** Run `gh pr merge` from main repo CWD to suppress harmless "main already used by worktree" error
- **db-migration (T000159):** Add role-ownership note — `task workspace:psql` connects as `website` role; DDL on `bachelorprojekt/coaching/knowledge` schemas requires `-U postgres`
- **domains.py (T000155):** Move `bug_tickets` to `bugs` schema (correct), remove non-existent `playwright_reports` and `superpowers.plans/plan_sections` refs
- **CLAUDE.md (T000156):** Document `pentest` database as intentional CTF target to prevent future audit confusion
- **Questionnaire schema migration SQL (T000153):** Applied live to korczewski to fix all 4 systemtest CronJob failures (exit-22/HTTP 500)

## Test plan
- [x] `task test:all` (offline tests, no deploy needed for skill/docs changes)
- [x] `task workspace:validate` (no manifest changes)
- [x] Verified systemtest endpoints on korczewski return 200 after schema fix

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>