### PR TITLE
fix(db): normalize table ownership to website role in bachelorprojekt/coaching/knowledge schemas [T000152]

### DIFF
--- a/k3d/website-schema.yaml
+++ b/k3d/website-schema.yaml
@@ -165,6 +165,8 @@ data:
 
       -- ── Coaching Knowledge Pipeline ─────────────────────────────────
       CREATE SCHEMA IF NOT EXISTS coaching AUTHORIZATION website;
+      -- Switch to the application role so all objects are owned by website.
+      SET ROLE website;
 
       CREATE TABLE IF NOT EXISTS coaching.books (
         id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -353,9 +355,8 @@ data:
       );
       CREATE INDEX IF NOT EXISTS idx_step_templates_brand ON coaching.step_templates(brand);
 
-      -- Tables are owned by postgres (init script runs as postgres). Grant the
-      -- application role explicit access; ALTER DEFAULT PRIVILEGES covers tables
-      -- added in later migrations.
+      -- Revert to superuser to run GRANTs (website role cannot GRANT to itself).
+      RESET ROLE;
       GRANT USAGE ON SCHEMA coaching TO website;
       GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA coaching TO website;
       GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA coaching TO website;
@@ -811,6 +812,8 @@ data:
 
       -- ── Coaching Knowledge Pipeline ─────────────────────────────────
       CREATE SCHEMA IF NOT EXISTS coaching AUTHORIZATION website;
+      -- Switch to the application role so all objects are owned by website.
+      SET ROLE website;
 
       CREATE TABLE IF NOT EXISTS coaching.books (
         id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -1020,9 +1023,8 @@ data:
       );
       CREATE INDEX IF NOT EXISTS idx_step_templates_brand ON coaching.step_templates(brand);
 
-      -- Tables are owned by postgres (init script runs as postgres). Grant the
-      -- application role explicit access; ALTER DEFAULT PRIVILEGES covers tables
-      -- added in later migrations.
+      -- Revert to superuser to run GRANTs (website role cannot GRANT to itself).
+      RESET ROLE;
       GRANT USAGE ON SCHEMA coaching TO website;
       GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA coaching TO website;
       GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA coaching TO website;
@@ -1363,6 +1365,9 @@ data:
 
     psql -v ON_ERROR_STOP=1 --username "postgres" --dbname website <<-'EOSQL'
       CREATE SCHEMA IF NOT EXISTS bachelorprojekt;
+      ALTER SCHEMA bachelorprojekt OWNER TO website;
+      -- Switch to the application role so all objects are owned by website.
+      SET ROLE website;
 
       CREATE TABLE IF NOT EXISTS bachelorprojekt.requirements (
         id          TEXT PRIMARY KEY,
@@ -1524,6 +1529,8 @@ data:
       CREATE UNIQUE INDEX IF NOT EXISTS uq_components_name
         ON bachelorprojekt.components (lower(name));
 
+      -- Revert to superuser to run GRANTs (website role cannot GRANT to itself).
+      RESET ROLE;
       GRANT USAGE ON SCHEMA bachelorprojekt TO website;
       GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA bachelorprojekt TO website;
       GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA bachelorprojekt TO website;
@@ -1540,6 +1547,8 @@ data:
     psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname website <<-'EOSQL'
       CREATE EXTENSION IF NOT EXISTS vector;
       CREATE SCHEMA IF NOT EXISTS knowledge AUTHORIZATION website;
+      -- Switch to the application role so all objects are owned by website.
+      SET ROLE website;
 
       CREATE TABLE IF NOT EXISTS knowledge.collections (
         id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -1590,6 +1599,8 @@ data:
       CREATE INDEX IF NOT EXISTS chunks_collection ON knowledge.chunks (collection_id);
       CREATE INDEX IF NOT EXISTS documents_collection ON knowledge.documents (collection_id);
 
+      -- Revert to superuser to run GRANTs (website role cannot GRANT to itself).
+      RESET ROLE;
       GRANT USAGE ON SCHEMA knowledge TO website;
       GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA knowledge TO website;
       GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA knowledge TO website;
@@ -1604,6 +1615,8 @@ data:
     psql -v ON_ERROR_STOP=1 --username "postgres" --dbname website <<-'EOSQL'
       CREATE EXTENSION IF NOT EXISTS vector;
       CREATE SCHEMA IF NOT EXISTS knowledge AUTHORIZATION website;
+      -- Switch to the application role so all objects are owned by website.
+      SET ROLE website;
 
       CREATE TABLE IF NOT EXISTS knowledge.collections (
         id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -1654,6 +1667,8 @@ data:
       CREATE INDEX IF NOT EXISTS chunks_collection ON knowledge.chunks (collection_id);
       CREATE INDEX IF NOT EXISTS documents_collection ON knowledge.documents (collection_id);
 
+      -- Revert to superuser to run GRANTs (website role cannot GRANT to itself).
+      RESET ROLE;
       GRANT USAGE ON SCHEMA knowledge TO website;
       GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA knowledge TO website;
       GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA knowledge TO website;


### PR DESCRIPTION
## Summary
- 19 tables in bachelorprojekt.*, coaching.*, and knowledge.* schemas were owned by the postgres superuser instead of the website application role, causing superuser fallbacks during the Phase 5 audit
- Applied live fixes on both mentolder and korczewski clusters (19 tables + 3-4 sequences per cluster)
- Updated all 5 init/ensure scripts in k3d/website-schema.yaml to use SET ROLE website before CREATE TABLE and RESET ROLE before GRANT blocks, ensuring future cluster resets create objects with the correct owner

## Changes
- `k3d/website-schema.yaml`: Add `SET ROLE website` + `RESET ROLE` wrapping in:
  - `init-meetings-schema.sh` coaching block
  - `ensure-meetings-schema.sh` coaching block
  - `ensure-bachelorprojekt-schema.sh` (also adds `ALTER SCHEMA bachelorprojekt OWNER TO website`)
  - `init-knowledge-schema.sh`
  - `ensure-knowledge-schema.sh`

## Test plan
- [ ] Verify `SELECT schemaname, tablename, tableowner FROM pg_tables WHERE tableowner = 'postgres' AND schemaname NOT IN ('pg_catalog','information_schema')` returns 0 rows on both clusters (already confirmed)
- [ ] On next cluster reset, init scripts will create tables owned by website from scratch

🤖 Generated with [Claude Code](https://claude.com/claude-code)