### PR TITLE
fix(db): enable pg_stat_statements on shared-db [T000151]

### DIFF
--- a/k3d/shared-db.yaml
+++ b/k3d/shared-db.yaml
@@ -148,6 +148,8 @@ spec:
             - "ssl_cert_file=/etc/postgresql/certs/server.crt"
             - "-c"
             - "ssl_key_file=/etc/postgresql/certs/server.key"
+            - "-c"
+            - "shared_preload_libraries=pg_stat_statements"
           env:
             - name: PGDATA
               value: /var/lib/postgresql/data/pgdata


### PR DESCRIPTION
## Summary
- Adds `shared_preload_libraries=pg_stat_statements` to the `shared-db` Deployment args so the query stats extension can be created on both clusters
- After merge + pod restart, `CREATE EXTENSION IF NOT EXISTS pg_stat_statements` needs to run in each database

## Closes
T000151

## Test plan
- [ ] `task workspace:validate` passes
- [ ] After deploy, `SHOW shared_preload_libraries;` returns `pg_stat_statements`
- [ ] `CREATE EXTENSION IF NOT EXISTS pg_stat_statements` succeeds in website DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)