### PR TITLE
fix(tickets): prevent double-render by moving table into TicketsTableBody

### DIFF
--- a/website/src/components/admin/TicketsTableBody.svelte
+++ b/website/src/components/admin/TicketsTableBody.svelte
@@ -143,6 +143,28 @@
   }
 </script>
 
+<table class="w-full">
+  <thead>
+    <tr class="border-b border-dark-lighter">
+      <th class="text-left px-4 py-3 text-xs text-muted uppercase tracking-wide font-medium">ID</th>
+      <th class="text-left px-4 py-3 text-xs text-muted uppercase tracking-wide font-medium">Typ</th>
+      <th class="text-left px-4 py-3 text-xs text-muted uppercase tracking-wide font-medium">Titel</th>
+      <th class="text-left px-4 py-3 text-xs text-muted uppercase tracking-wide font-medium">Status</th>
+      <th class="text-left px-4 py-3 text-xs text-muted uppercase tracking-wide font-medium">Prio</th>
+      <th class="text-left px-4 py-3 text-xs text-muted uppercase tracking-wide font-medium">Zuständig</th>
+      <th class="text-left px-4 py-3 text-xs text-muted uppercase tracking-wide font-medium">Kunde</th>
+      <th class="text-left px-4 py-3 text-xs text-muted uppercase tracking-wide font-medium">Fällig</th>
+      <th class="text-right px-4 py-3 text-xs text-muted uppercase tracking-wide font-medium">Aktion</th>
+    </tr>
+  </thead>
+  <tbody>
+{#if tickets.length === 0}
+  <tr>
+    <td colspan="9" class="px-4 py-10 text-center text-muted text-sm">
+      Keine Tickets für diese Filterauswahl.
+    </td>
+  </tr>
+{:else}
 {#each tickets as t (t.id)}
   {@const rs = row(t.id)}
   {@const showWidget = rs.attentionMode === 'needs_human' && !!t.aiQuestion}
@@ -302,3 +324,6 @@
     </tr>
   {/if}
 {/each}
+{/if}
+  </tbody>
+</table>

--- a/website/src/pages/admin/tickets.astro
+++ b/website/src/pages/admin/tickets.astro
@@ -204,38 +204,15 @@ const SAVED_VIEWS: { label: string; href: string }[] = [
         <a href="/admin/tickets" class="px-3 py-1.5 text-sm text-muted hover:text-light">↺ Reset</a>
       </form>
 
-      {/* Table */}
+      {/* Table — TicketsTableBody owns the full <table> to avoid Astro island
+           being placed inside <tbody>, which the browser foster-parents out of
+           the table and causes Svelte hydration to double-render every row. */}
       <div class="bg-dark-light rounded-2xl border border-dark-lighter overflow-hidden">
-        <table class="w-full">
-          <thead>
-            <tr class="border-b border-dark-lighter">
-              <th class="text-left px-4 py-3 text-xs text-muted uppercase tracking-wide font-medium">ID</th>
-              <th class="text-left px-4 py-3 text-xs text-muted uppercase tracking-wide font-medium">Typ</th>
-              <th class="text-left px-4 py-3 text-xs text-muted uppercase tracking-wide font-medium">Titel</th>
-              <th class="text-left px-4 py-3 text-xs text-muted uppercase tracking-wide font-medium">Status</th>
-              <th class="text-left px-4 py-3 text-xs text-muted uppercase tracking-wide font-medium">Prio</th>
-              <th class="text-left px-4 py-3 text-xs text-muted uppercase tracking-wide font-medium">Zuständig</th>
-              <th class="text-left px-4 py-3 text-xs text-muted uppercase tracking-wide font-medium">Kunde</th>
-              <th class="text-left px-4 py-3 text-xs text-muted uppercase tracking-wide font-medium">Fällig</th>
-              <th class="text-right px-4 py-3 text-xs text-muted uppercase tracking-wide font-medium">Aktion</th>
-            </tr>
-          </thead>
-          <tbody>
-            {tickets.length === 0 ? (
-              <tr>
-                <td colspan="9" class="px-4 py-10 text-center text-muted text-sm">
-                  Keine Tickets für diese Filterauswahl.
-                </td>
-              </tr>
-            ) : (
-              <TicketsTableBody
-                client:load
-                tickets={tickets}
-                admins={admins}
-              />
-            )}
-          </tbody>
-        </table>
+        <TicketsTableBody
+          client:load
+          tickets={tickets}
+          admins={admins}
+        />
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Root Cause

`<TicketsTableBody client:load>` was placed inside `<tbody>` in `tickets.astro`. Astro wraps island components in an `<astro-island>` custom element. The browser's HTML table parser treats unknown elements inside `<tbody>` as invalid and **foster parents** them — moving `<astro-island>` and its SSR content outside the `<table>` entirely.

Svelte 5's `hydrate()` then finds a DOM structure that doesn't match the component's expected output: the `<tr>` rows were wrapped in an implicit `<table><tbody>` by the browser's parser. Hydration falls back to a fresh `mount()` without clearing the existing SSR HTML, leaving **both** the SSR rows and the newly mounted rows in the DOM — every ticket appeared twice.

## Fix

`TicketsTableBody.svelte` now owns the complete `<table>`, `<thead>`, and `<tbody>`. The `tickets.astro` page places the island directly inside a `<div>` wrapper (no `<table>` in the Astro page). The `<astro-island>` wrapper now sits outside any table element, so the browser's table parser never touches it, hydration succeeds on the correct DOM, and no duplication occurs.

## Test plan

- [ ] Open `/admin/tickets` — each ticket appears exactly once
- [ ] Column headers and table styling are unchanged
- [ ] Empty state ("Keine Tickets für diese Filterauswahl.") shows correctly when no tickets match filters
- [ ] Inline status select, AI/Human pill, and answer widget rows still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)