### PR TITLE
fix(infra): source OIDC secrets for oauth2-proxy on korczewski [T000171]

### DIFF
--- a/k3d/website.yaml
+++ b/k3d/website.yaml
@@ -54,7 +54,7 @@ data:
   TRAEFIK_EXTERNAL_URL: "${TRAEFIK_EXTERNAL_URL}"
   MAIL_EXTERNAL_URL: "${MAIL_EXTERNAL_URL}"
   # Portal admin
-  PORTAL_ADMIN_USERNAME: "gekko,paddione,quamain"
+  PORTAL_ADMIN_USERNAME: "gekko,paddione,quamain,test-admin"
   CALENDAR_NAME: "personal"
   WORK_START_HOUR: "9"
   WORK_END_HOUR: "17"

--- a/prod-korczewski/kustomization.yaml
+++ b/prod-korczewski/kustomization.yaml
@@ -57,6 +57,10 @@ generatorOptions:
 # pinned to pk-hetzner-6 by patch-livekit.yaml (hostNetwork + STUN
 # discovers the real public IP via TURN_PUBLIC_IP=37.27.251.38).
 patches:
+  # Fix mailpit-auth forwardAuth namespace (base hardcodes "workspace", korczewski
+  # uses "workspace-korczewski", causing Traefik 500 on unauthenticated requests).
+  - path: patch-mailpit-auth-middleware.yaml
+
   # livekit-recordings-pvc uses the base manifest's storage class.
   # Longhorn is NOT installed on korczewski; recordings live on local-path,
   # tied to the livekit pin-node (pk-hetzner-6). This is acceptable because

--- a/prod-korczewski/patch-mailpit-auth-middleware.yaml
+++ b/prod-korczewski/patch-mailpit-auth-middleware.yaml
@@ -1,0 +1,14 @@
+# prod-korczewski/patch-mailpit-auth-middleware.yaml
+# The base mailpit-auth Middleware hardcodes "workspace.svc.cluster.local"
+# as the forwardAuth address. On korczewski the workspace namespace is
+# "workspace-korczewski", so the base address resolves to mentolder's
+# services instead of the local oauth2-proxy-mailpit pod.
+# This patch rewrites the address to the correct namespace.
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: mailpit-auth
+  namespace: workspace
+spec:
+  forwardAuth:
+    address: http://oauth2-proxy-mailpit.workspace-korczewski.svc.cluster.local:4180/oauth2/auth

--- a/prod/patch-oauth2-proxy-brett.yaml
+++ b/prod/patch-oauth2-proxy-brett.yaml
@@ -12,7 +12,7 @@ spec:
             - "--config=/run/config/oauth2-extra.cfg"
             - "--provider=keycloak-oidc"
             - "--client-id=brett"
-            - "--client-secret=${BRETT_OIDC_SECRET}"
+            - "--client-secret=$(BRETT_OIDC_SECRET)"
             - "--redirect-url=https://brett.${PROD_DOMAIN}/oauth2/callback"
             - "--oidc-issuer-url=https://auth.${PROD_DOMAIN}/realms/workspace"
             - "--ssl-insecure-skip-verify=true"

--- a/prod/patch-oauth2-proxy-docs.yaml
+++ b/prod/patch-oauth2-proxy-docs.yaml
@@ -11,7 +11,7 @@ spec:
             - "--config=/run/config/oauth2-extra.cfg"
             - "--provider=keycloak-oidc"
             - "--client-id=docs"
-            - "--client-secret=${DOCS_OIDC_SECRET}"
+            - "--client-secret=$(DOCS_OIDC_SECRET)"
             - "--redirect-url=https://docs.${PROD_DOMAIN}/oauth2/callback"
             - "--oidc-issuer-url=https://auth.${PROD_DOMAIN}/realms/workspace"
             - "--ssl-insecure-skip-verify=true"

--- a/prod/patch-oauth2-proxy-mailpit.yaml
+++ b/prod/patch-oauth2-proxy-mailpit.yaml
@@ -12,7 +12,7 @@ spec:
             - "--config=/run/config/oauth2-extra.cfg"
             - "--provider=keycloak-oidc"
             - "--client-id=mailpit-admin"
-            - "--client-secret=${MAIL_OIDC_SECRET}"
+            - "--client-secret=$(MAIL_OIDC_SECRET)"
             - "--redirect-url=https://mail.${PROD_DOMAIN}/oauth2/callback"
             - "--oidc-issuer-url=https://auth.${PROD_DOMAIN}/realms/workspace"
             - "--ssl-insecure-skip-verify=true"

--- a/prod/patch-oauth2-proxy-traefik.yaml
+++ b/prod/patch-oauth2-proxy-traefik.yaml
@@ -11,7 +11,7 @@ spec:
             - "--config=/run/config/oauth2-extra.cfg"
             - "--provider=keycloak-oidc"
             - "--client-id=traefik-dashboard"
-            - "--client-secret=${TRAEFIK_OIDC_SECRET}"
+            - "--client-secret=$(TRAEFIK_OIDC_SECRET)"
             - "--relative-redirect-url=true"
             - "--oidc-issuer-url=https://auth.${PROD_DOMAIN}/realms/workspace"
             - "--ssl-insecure-skip-verify=true"


### PR DESCRIPTION
## Summary
- Fix oauth2-proxy-brett/docs/mailpit/traefik CrashLoopBackOff: change `${OIDC_SECRET}` in prod patch args from shell envsubst form to Kubernetes `$(VAR)` runtime expansion — the shell var was never exported during deploy so envsubst emitted empty `--client-secret=`
- Add `prod-korczewski/patch-mailpit-auth-middleware.yaml` to fix the forwardAuth address namespace (`workspace` → `workspace-korczewski`), which was causing Traefik 500 on unauthenticated mail requests
- Add `test-admin` to `PORTAL_ADMIN_USERNAME` in `k3d/website.yaml` for korczewski e2e auth setup

## Test plan
- [ ] oauth2-proxy-brett, oauth2-proxy-docs, oauth2-proxy-mailpit, oauth2-proxy-traefik are all Running (0 restarts) after deploy
- [ ] `curl https://brett.korczewski.de/` → 200
- [ ] `curl https://docs.korczewski.de/` → 200
- [ ] `curl https://mail.korczewski.de/` → 401 (proxy working, unauthenticated)
- [ ] test-admin user can authenticate at `web.korczewski.de` and is recognized as admin

🤖 Generated with [Claude Code](https://claude.com/claude-code)