### PR TITLE
chore(docs): trim sidebar from 42 to 29 entries

### DIFF
--- a/k3d/docs-content/_sidebar.md
+++ b/k3d/docs-content/_sidebar.md
@@ -7,41 +7,31 @@
   - [Keycloak (SSO)](keycloak)
   - [Nextcloud + Talk](nextcloud)
   - [Collabora (Office)](collabora)
-  - [Talk HPB (Signaling)](talk-hpb)
-  - [Livestream (LiveKit)](livestream)
-  - [E-Invoice (ZUGFeRD & XRechnung)](einvoice)
-  - [MCP-Server (Claude Code)](claude-code)
   - [Vaultwarden (Passwörter)](vaultwarden)
   - [Website (Astro & Svelte)](website)
-  - [Whiteboard](whiteboard)
-  - [Mailpit (Dev-Mail)](mailpit)
-  - [Monitoring (Prometheus & Grafana)](monitoring)
-  - [PostgreSQL (shared-db)](shared-db)
+  - [Livestream (LiveKit)](livestream)
+  - [MCP-Server (Claude Code)](claude-code)
 
 - **Betrieb**
   - [Deployment & Taskfile](operations)
   - [Umgebungen & Secrets](environments)
   - [Backup & Wiederherstellung](backup)
+  - [Monitoring](monitoring)
 
 - **Sicherheit**
   - [Sicherheitsarchitektur](security)
-  - [Sicherheitsbericht](security-report)
   - [DSGVO / Datenschutz](dsgvo)
   - [Verarbeitungsverzeichnis](verarbeitungsverzeichnis)
 
 - **Entwicklung**
-  - [Beitragen & CI/CD](contributing)
   - [Architektur](architecture)
+  - [Beitragen & CI/CD](contributing)
   - [Tests](tests)
-  - [Skripte-Referenz](scripts)
-  - [Migration](migration)
-  - [Anforderungen](requirements)
   - [Fehlerbehebung](troubleshooting)
 
 - **Administration**
   - [Adminhandbuch](adminhandbuch)
   - [Admin-Webinterface](admin-webinterface)
-  - [Projekt-Verwaltung](admin-projekte)
   - [Tickets (Unified Inbox)](admin-tickets)
 
 - **Benutzerhandbuch**
@@ -50,10 +40,5 @@
   - [Systemisches Brett (3D)](systemisches-brett)
 
 - **Referenz**
-  - [Datamodel × Workflow](datamodel-workflow)
   - [Glossar](glossary)
-  - [Decision-Log](decisions)
   - [DB-Schema (ER-Diagramm)](db-schema)
-
-- **Agent Skills**
-  - [🧠 Skill-Übersicht](skills-overview)


### PR DESCRIPTION
## Summary
- Reduce docs sidebar from 42 to 29 entries (-31%) by removing rarely-accessed and dead-link items
- All removed pages remain fully accessible via Docsify search or direct URL
- Monitoring moved from Services → Betrieb for more logical grouping

**Removed from sidebar (pages still exist):**
- Services: Talk HPB, E-Invoice, Whiteboard, Mailpit, PostgreSQL (shared-db)
- Sicherheit: Sicherheitsbericht
- Entwicklung: Skripte-Referenz, Migration, Anforderungen
- Administration: Projekt-Verwaltung
- Referenz: Datamodel×Workflow, Decision-Log
- Agent Skills section (skills-overview page does not exist — dead link)

## Test plan
- [ ] `task docs:deploy` after merge — verify sidebar at docs.mentolder.de + docs.korczewski.de
- [ ] Confirm removed entries are still reachable via sidebar search (Docsify full-text search)