### PR TITLE
fix(tests): skip prod-incompatible e2e tests on korczewski [T000160]

### DIFF
--- a/tests/e2e/lib/systemtest-runner.ts
+++ b/tests/e2e/lib/systemtest-runner.ts
@@ -27,8 +27,13 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 const BASE       = process.env.WEBSITE_URL    ?? 'http://localhost:4321';
-const ADMIN_USER = process.env.E2E_ADMIN_USER ?? 'paddione';
-const ADMIN_PASS = process.env.E2E_ADMIN_PASS;
+const isKorczewski = BASE.includes('korczewski.de');
+const ADMIN_USER = isKorczewski
+  ? (process.env.TEST_ADMIN_USER ?? process.env.E2E_ADMIN_USER ?? 'test-admin')
+  : (process.env.E2E_ADMIN_USER ?? 'paddione');
+const ADMIN_PASS = isKorczewski
+  ? (process.env.TEST_ADMIN_PASSWORD ?? process.env.E2E_ADMIN_PASS)
+  : process.env.E2E_ADMIN_PASS;
 
 export type TestOption = 'erfüllt' | 'teilweise' | 'nicht_erfüllt';
 

--- a/tests/e2e/specs/fa-03-video.spec.ts
+++ b/tests/e2e/specs/fa-03-video.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test';
 
 const NC_URL = process.env.TEST_NC_URL || (process.env.NC_DOMAIN
   ? `https://${process.env.NC_DOMAIN}`
-  : 'http://files.localhost');
+  : null);
 
 const SIGNALING_URL = process.env.TEST_SIGNALING_URL || (process.env.SIGNALING_DOMAIN
   ? `https://${process.env.SIGNALING_DOMAIN}`

--- a/tests/e2e/specs/fa-27-brett.spec.ts
+++ b/tests/e2e/specs/fa-27-brett.spec.ts
@@ -15,6 +15,7 @@ test.describe('FA-27: Systemisches Brett', () => {
   });
 
   test('T3: /api/state returns JSON figures array for unknown room', async ({ request }) => {
+    test.skip(!!process.env.PROD_DOMAIN, 'Brett API requires auth in prod (oauth2-proxy)');
     const res = await request.get(`${BRETT_URL}/api/state?room=e2e-probe-${Date.now()}`);
     expect(res.status()).toBe(200);
     const body = await res.json();
@@ -28,6 +29,7 @@ test.describe('FA-27: Systemisches Brett', () => {
   });
 
   test('T5: POST /api/snapshots creates a snapshot (current schema)', async ({ request }) => {
+    test.skip(!!process.env.PROD_DOMAIN, 'Brett API requires auth in prod (oauth2-proxy)');
     const room_token = `e2e-snap-${Date.now()}`;
     const res = await request.post(`${BRETT_URL}/api/snapshots`, {
       data: { room_token, name: 'e2e-test-snapshot', state: { figures: [] } },
@@ -38,6 +40,7 @@ test.describe('FA-27: Systemisches Brett', () => {
   });
 
   test('T6: GET /api/snapshots without params returns 400', async ({ request }) => {
+    test.skip(!!process.env.PROD_DOMAIN, 'Brett API requires auth in prod (oauth2-proxy)');
     const res = await request.get(`${BRETT_URL}/api/snapshots`);
     expect(res.status()).toBe(400);
     const body = await res.json();
@@ -45,6 +48,7 @@ test.describe('FA-27: Systemisches Brett', () => {
   });
 
   test('T7: GET /api/snapshots with room param returns array', async ({ request }) => {
+    test.skip(!!process.env.PROD_DOMAIN, 'Brett API requires auth in prod (oauth2-proxy)');
     const res = await request.get(`${BRETT_URL}/api/snapshots?room=e2e-snap-list-${Date.now()}`);
     expect(res.status()).toBe(200);
     const body = await res.json();
@@ -52,11 +56,13 @@ test.describe('FA-27: Systemisches Brett', () => {
   });
 
   test('T8: GET /api/snapshots/:id returns 404 for unknown UUID', async ({ request }) => {
+    test.skip(!!process.env.PROD_DOMAIN, 'Brett API requires auth in prod (oauth2-proxy)');
     const res = await request.get(`${BRETT_URL}/api/snapshots/00000000-0000-0000-0000-000000000000`);
     expect(res.status()).toBe(404);
   });
 
   test('T9: POST /api/snapshots validates missing state.figures', async ({ request }) => {
+    test.skip(!!process.env.PROD_DOMAIN, 'Brett API requires auth in prod (oauth2-proxy)');
     const res = await request.post(`${BRETT_URL}/api/snapshots`, {
       data: { name: 'bad-payload' },
     });
@@ -66,6 +72,7 @@ test.describe('FA-27: Systemisches Brett', () => {
   });
 
   test('T10: GET /api/customers returns array', async ({ request }) => {
+    test.skip(!!process.env.PROD_DOMAIN, 'Brett API requires auth in prod (oauth2-proxy)');
     const res = await request.get(`${BRETT_URL}/api/customers`);
     expect(res.status()).toBe(200);
     const body = await res.json();
@@ -73,6 +80,7 @@ test.describe('FA-27: Systemisches Brett', () => {
   });
 
   test('T11: GET /presets returns array', async ({ request }) => {
+    test.skip(!!process.env.PROD_DOMAIN, 'Brett API requires auth in prod (oauth2-proxy)');
     const res = await request.get(`${BRETT_URL}/presets`);
     expect(res.status()).toBe(200);
     const body = await res.json();
@@ -80,6 +88,7 @@ test.describe('FA-27: Systemisches Brett', () => {
   });
 
   test('T12: POST /presets creates preset and DELETE removes it', async ({ request }) => {
+    test.skip(!!process.env.PROD_DOMAIN, 'Brett API requires auth in prod (oauth2-proxy)');
     const createRes = await request.post(`${BRETT_URL}/presets`, {
       data: { name: 'e2e-preset', appearance: { face: undefined, accessories: [] } },
     });
@@ -96,6 +105,7 @@ test.describe('FA-27: Systemisches Brett', () => {
   });
 
   test('T13: POST /presets validates name length', async ({ request }) => {
+    test.skip(!!process.env.PROD_DOMAIN, 'Brett API requires auth in prod (oauth2-proxy)');
     const res = await request.post(`${BRETT_URL}/presets`, {
       data: { name: 'x'.repeat(101), appearance: {} },
     });

--- a/tests/e2e/specs/fa-fragebogen.spec.ts
+++ b/tests/e2e/specs/fa-fragebogen.spec.ts
@@ -67,6 +67,9 @@ test.describe('FA-Fragebogen: Fill flow', () => {
 
   test.beforeEach(({ }, testInfo) => {
     if (!ADMIN_PASS) testInfo.skip(true, 'E2E_ADMIN_PASS not set');
+    if (isProd && !process.env.SESSIONS_DATABASE_URL) {
+      testInfo.skip(true, 'Direct DB access requires SESSIONS_DATABASE_URL (run: task workspace:port-forward ENV=<env>)');
+    }
   });
 
   test.afterAll(async () => {
@@ -178,6 +181,9 @@ test.describe('FA-Fragebogen: Admin view', () => {
 
   test.beforeEach(({ }, testInfo) => {
     if (!ADMIN_PASS) testInfo.skip(true, 'E2E_ADMIN_PASS not set');
+    if (isProd && !process.env.SESSIONS_DATABASE_URL) {
+      testInfo.skip(true, 'Direct DB access requires SESSIONS_DATABASE_URL (run: task workspace:port-forward ENV=<env>)');
+    }
   });
 
   test.afterAll(async () => {
@@ -226,6 +232,9 @@ test.describe('FA-Fragebogen: Archive → reassign → replay', () => {
 
   test.beforeEach(({ }, testInfo) => {
     if (!ADMIN_PASS) testInfo.skip(true, 'E2E_ADMIN_PASS not set');
+    if (isProd && !process.env.SESSIONS_DATABASE_URL) {
+      testInfo.skip(true, 'Direct DB access requires SESSIONS_DATABASE_URL (run: task workspace:port-forward ENV=<env>)');
+    }
   });
 
   test.afterAll(async () => {
@@ -368,6 +377,9 @@ test.describe('FA-Fragebogen: Real-user handoff', () => {
   test.beforeEach(({ }, testInfo) => {
     if (!ADMIN_PASS) testInfo.skip(true, 'E2E_ADMIN_PASS not set');
     if (!isProd) testInfo.skip(true, 'Real-user handoff only runs against prod (WEBSITE_URL must contain mentolder.de or korczewski.de)');
+    if (isProd && !process.env.SESSIONS_DATABASE_URL) {
+      testInfo.skip(true, 'Direct DB access requires SESSIONS_DATABASE_URL (run: task workspace:port-forward ENV=<env>)');
+    }
   });
 
   test('T1: assign systemtest-04 fragebogen template to admin user in prod', async ({ page }) => {

--- a/tests/e2e/specs/fa-ios-talk.spec.ts
+++ b/tests/e2e/specs/fa-ios-talk.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test';
 
 const NC_URL = process.env.TEST_NC_URL || (process.env.NC_DOMAIN
   ? `https://${process.env.NC_DOMAIN}`
-  : 'http://files.localhost');
+  : null);
 
 test.describe('FA-iOS: Nextcloud Talk + notify_push (iPhone WebKit)', () => {
   test('T1: Talk-Oberfläche auf iPhone erreichbar', async ({ page }) => {

--- a/tests/e2e/specs/wissensquellen.spec.ts
+++ b/tests/e2e/specs/wissensquellen.spec.ts
@@ -1,8 +1,13 @@
 import { test, expect } from '@playwright/test';
 
 const BASE = process.env.WEBSITE_URL ?? 'https://web.mentolder.de';
-const ADMIN_USER = process.env.E2E_ADMIN_USER ?? 'paddione';
-const ADMIN_PASS = process.env.E2E_ADMIN_PASS;
+const isKorczewski = BASE.includes('korczewski.de');
+const ADMIN_USER = isKorczewski
+  ? (process.env.TEST_ADMIN_USER ?? process.env.E2E_ADMIN_USER ?? 'test-admin')
+  : (process.env.E2E_ADMIN_USER ?? 'paddione');
+const ADMIN_PASS = isKorczewski
+  ? (process.env.TEST_ADMIN_PASSWORD ?? process.env.E2E_ADMIN_PASS)
+  : process.env.E2E_ADMIN_PASS;
 
 async function loginAsAdmin(page: import('@playwright/test').Page) {
   await page.goto(`${BASE}/api/auth/login?returnTo=/admin/wissensquellen`);


### PR DESCRIPTION
## Summary
- **fa-fragebogen**: 4 DB-dependent `beforeEach` blocks now skip in prod when `SESSIONS_DATABASE_URL` is absent (previously crashed with `ECONNREFUSED 127.0.0.1:5432`)
- **wissensquellen + systemtest-runner**: use `TEST_ADMIN_USER`/`TEST_ADMIN_PASSWORD` on `korczewski.de` instead of `E2E_ADMIN_USER`/`E2E_ADMIN_PASS` (paddione's mentolder credentials don't work on korczewski Keycloak)
- **fa-03-video + fa-ios-talk**: `NC_URL` defaults to `null` instead of `'http://files.localhost'` so `test.skip(!NC_URL)` properly fires when `TEST_NC_URL`/`NC_DOMAIN` aren't set
- **fa-27-brett**: skip T3 and T5–T13 in prod — Brett API endpoints require oauth2-proxy auth; unauthenticated requests get 302→HTML not JSON

## Test plan
- [ ] Rerun targeted korczewski suite with `TEST_ADMIN_PASSWORD='...'` — all 47 failures should become skips or passes
- [ ] Verify dev suite still passes (NC_URL=null means Talk tests skip in dev too, which is correct)

🤖 Generated with [Claude Code](https://claude.com/claude-code)