### PR TITLE
fix(tests): fix korczewski admin username — don't fall back to E2E_ADMIN_USER [T000160]

### DIFF
--- a/tests/e2e/lib/systemtest-runner.ts
+++ b/tests/e2e/lib/systemtest-runner.ts
@@ -29,7 +29,7 @@ import * as path from 'path';
 const BASE       = process.env.WEBSITE_URL    ?? 'http://localhost:4321';
 const isKorczewski = BASE.includes('korczewski.de');
 const ADMIN_USER = isKorczewski
-  ? (process.env.TEST_ADMIN_USER ?? process.env.E2E_ADMIN_USER ?? 'test-admin')
+  ? (process.env.TEST_ADMIN_USER ?? 'test-admin')
   : (process.env.E2E_ADMIN_USER ?? 'paddione');
 const ADMIN_PASS = isKorczewski
   ? (process.env.TEST_ADMIN_PASSWORD ?? process.env.E2E_ADMIN_PASS)

--- a/tests/e2e/specs/wissensquellen.spec.ts
+++ b/tests/e2e/specs/wissensquellen.spec.ts
@@ -3,7 +3,7 @@ import { test, expect } from '@playwright/test';
 const BASE = process.env.WEBSITE_URL ?? 'https://web.mentolder.de';
 const isKorczewski = BASE.includes('korczewski.de');
 const ADMIN_USER = isKorczewski
-  ? (process.env.TEST_ADMIN_USER ?? process.env.E2E_ADMIN_USER ?? 'test-admin')
+  ? (process.env.TEST_ADMIN_USER ?? 'test-admin')
   : (process.env.E2E_ADMIN_USER ?? 'paddione');
 const ADMIN_PASS = isKorczewski
   ? (process.env.TEST_ADMIN_PASSWORD ?? process.env.E2E_ADMIN_PASS)


### PR DESCRIPTION
## Summary
- `E2E_ADMIN_USER='paddione'` is exported in the shell, so `TEST_ADMIN_USER ?? E2E_ADMIN_USER ?? 'test-admin'` resolved to `'paddione'` on korczewski (wrong credential)
- Fix: korczewski branch no longer falls back to `E2E_ADMIN_USER` — defaults directly to `'test-admin'`
- Affected files: `wissensquellen.spec.ts`, `systemtest-runner.ts`

## Test plan
- [ ] Rerun korczewski wissensquellen tests with `TEST_ADMIN_PASSWORD` — login should succeed as `test-admin`

🤖 Generated with [Claude Code](https://claude.com/claude-code)