### PR TITLE
chore(deploy): auto-sync DB passwords after shared-db restart [T000196]

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1025,6 +1025,8 @@ tasks:
         fi
         kubectl $ctx rollout status deployment/shared-db -n "$NS" --timeout=120s
         echo "✓ shared-db ready (ENV={{.ENV}}, ns=$NS)"
+      - task: workspace:sync-db-passwords
+        vars: { ENV: "{{.ENV}}" }
 
   workspace:db:drop:
     desc: "Drop a database from shared-db (usage: task workspace:db:drop -- <dbname> [ENV=...])"
@@ -1110,6 +1112,9 @@ tasks:
         NS="${WORKSPACE_NAMESPACE:-workspace}"
         kubectl $CTX rollout restart deployment/{{.CLI_ARGS}} -n "$NS"
         kubectl $CTX rollout status deployment/{{.CLI_ARGS}} -n "$NS" --timeout=120s
+        if [ "{{.CLI_ARGS}}" = "shared-db" ]; then
+          task workspace:sync-db-passwords ENV="{{.ENV}}"
+        fi
 
   # ─────────────────────────────────────────────
   # Multi-Cluster Overview


### PR DESCRIPTION
## Summary
- `workspace:db:start` now calls `workspace:sync-db-passwords` after the pod is ready
- `workspace:restart shared-db` conditionally triggers the same sync

## Why
After a shared-db restart the PG role passwords must match the current SealedSecret. Without this guard a rotated secret leaves service accounts unable to connect until someone runs sync manually.

## Test plan
- [x] `task test:all` — 54 unit + 25 manifest tests green
- No cluster-side deploy needed (Taskfile-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)