### PR TITLE
chore(korczewski): remove dev-stack manifests from overlay [T000190]

### DIFF
--- a/prod-korczewski/kustomization.yaml
+++ b/prod-korczewski/kustomization.yaml
@@ -18,12 +18,6 @@ resources:
   # Moved out of the shared base because the bot is useless without
   # a whisper backend, and whisper only lives on korczewski.
   - talk-transcriber.yaml
-  # ── dev.korczewski.de stack (prod-side SSO gate + TLS) ─────────────
-  - cert-dev-wildcard.yaml
-  - oauth2-proxy-dev.yaml
-  - oauth2-proxy-dev-middleware.yaml
-  - dev-ingress.yaml
-  - dev-db-refresh-cron.yaml
 
 # Override realm with korczewski-specific config
 configMapGenerator:
@@ -35,11 +29,6 @@ configMapGenerator:
     behavior: replace
     files:
       - zz-extra.config.php=nextcloud-extra-config-korczewski.php
-  # ── dev.korczewski.de — mount dev-db-refresh.sh as ConfigMap ──
-  - name: dev-db-refresh-script
-    namespace: workspace-korczewski
-    files:
-      - dev-db-refresh.sh
 generatorOptions:
   disableNameSuffixHash: true
 


### PR DESCRIPTION
## Summary
- Removes `oauth2-proxy-dev`, `oauth2-proxy-dev-middleware`, `dev-ingress`, `cert-dev-wildcard`, `dev-db-refresh-cron`, and the `dev-db-refresh-script` ConfigMap from the korczewski kustomize overlay
- These resources have been Pending/erroring for 3+ days because `pk-l-1` (DEV_NODE) does not exist in the korczewski cluster
- Tickets T000180 and T000182 closed as `wontfix` — the dev stack is not planned for korczewski

## Test plan
- [x] `task workspace:validate ENV=korczewski` passes (dry run)
- [ ] Deploy to korczewski — pending resources should disappear
- [ ] Verify no regressions on workspace-korczewski production services

Closes T000190

🤖 Generated with [Claude Code](https://claude.com/claude-code)