### PR TITLE
fix(live/rechnungen): polls closed_at→locked_at, surface tokens, dialog centering [T000110, T000113]

### DIFF
--- a/environments/korczewski.yaml
+++ b/environments/korczewski.yaml
@@ -42,6 +42,7 @@ env_vars:
   LIVEKIT_DOMAIN: livekit.korczewski.de
   LIVEKIT_PIN_IP: "37.27.251.38"
   STREAM_DOMAIN: stream.korczewski.de
+  NEXTCLOUD_DB_HOST: nextcloud-db.workspace-korczewski.svc.cluster.local
   WEBSITE_HOST: web.korczewski.de
   WEBSITE_SITE_URL: "https://web.korczewski.de"
   KEYCLOAK_FRONTEND_URL: "https://auth.korczewski.de"

--- a/website/src/lib/live-state.ts
+++ b/website/src/lib/live-state.ts
@@ -61,7 +61,7 @@ async function fetchStreamStatus(): Promise<StreamLiveStatus> {
 async function fetchActivePoll(): Promise<ActivePoll | null> {
   try {
     const r = await pool.query<{ id: string; question: string; kind: 'multiple_choice' | 'text' }>(
-      `SELECT id, question, kind FROM polls WHERE closed_at IS NULL ORDER BY created_at DESC LIMIT 1`
+      `SELECT id, question, kind FROM polls WHERE locked_at IS NULL ORDER BY created_at DESC LIMIT 1`
     );
     return r.rows[0] ?? null;
   } catch (err) {

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -32,6 +32,11 @@
   /* Sage accent */
   --color-sage: oklch(0.80 0.06 160);
 
+  /* UI surface tokens */
+  --color-surface: #101826;
+  --color-surface-hover: #17202e;
+  --color-border: rgba(255, 255, 255, 0.10);
+
   /* Hairlines */
   --color-line: rgba(255, 255, 255, 0.07);
   --color-line-2: rgba(255, 255, 255, 0.12);
@@ -109,6 +114,15 @@ section {
   0%   { box-shadow: 0 0 0 0 oklch(0.80 0.06 160 / 0.6); }
   70%  { box-shadow: 0 0 0 10px oklch(0.80 0.06 160 / 0); }
   100% { box-shadow: 0 0 0 0 oklch(0.80 0.06 160 / 0); }
+}
+
+/* Native dialog centering */
+dialog {
+  position: fixed;
+  inset: 0;
+  margin: auto;
+  max-height: calc(100dvh - 2rem);
+  overflow-y: auto;
 }
 
 /* Prose overrides for dark theme (impressum, datenschutz) */


### PR DESCRIPTION
## Summary

- **live-state.ts**: `fetchActivePoll` queried `closed_at IS NULL` but the column is `locked_at` on both clusters — silent error on every `/api/live/state` call fixed
- **global.css**: Added missing `surface`, `surface-hover`, `border` Tailwind v4 color tokens — `bg-surface`/`border-border` classes in `rechnungen.astro` generated no CSS, making the invoice edit dialog transparent/unstyled
- **global.css**: Added `dialog { position: fixed; margin: auto }` for correct centering across browsers
- **environments/korczewski.yaml**: Added `NEXTCLOUD_DB_HOST` pointing to `workspace-korczewski` namespace (was falling back to hardcoded `workspace` default, causing ENOTFOUND errors)

Closes T000110 (korczewski) and T000113 (korczewski).

## Test plan

- [ ] `/admin/live` on korczewski loads without "Cockpit nicht erreichbar" error
- [ ] Stream status shows "offline" / Launchpad state correctly
- [ ] `/admin/rechnungen` on korczewski — click "Bearbeiten" on a draft invoice — dialog appears with proper dark background and borders
- [ ] Check browser console for no `column "closed_at" does not exist` errors in logs after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)