### PR TITLE
fix(kore): fix Svelte onerror syntax + missing CSS link + starters

### DIFF
--- a/website/public/brand/korczewski/starters/invoice.html
+++ b/website/public/brand/korczewski/starters/invoice.html
@@ -1,0 +1,207 @@
+<!doctype html>
+<html lang="de">
+<head>
+<meta charset="utf-8">
+<title>Korczewski — Rechnung {{INVOICE_NUMBER}}</title>
+<link rel="stylesheet" href="/brand/korczewski/colors_and_type.css">
+<link rel="stylesheet" href="/brand/korczewski/app.css">
+<style>
+  body{padding:48px 28px 96px;}
+  .doc-wrap{position:relative; z-index:2;}
+  .crumbs{max-width:880px; margin:0 auto 24px; display:flex; align-items:center; gap:14px; font-family:var(--mono); font-size:10.5px; letter-spacing:.18em; text-transform:uppercase; color:var(--mute); flex-wrap:wrap;}
+  .crumbs .copper{color:var(--copper);}
+  .crumbs .actions{margin-left:auto; display:flex; gap:8px;}
+
+  .invoice{max-width:880px; margin:0 auto; background:var(--paper); color:var(--ink-text); border-radius:var(--r-paper); box-shadow:var(--shadow-paper); position:relative; overflow:hidden;}
+  .invoice::before{content:""; position:absolute; inset:0; pointer-events:none; background:radial-gradient(50% 35% at 100% 0%, rgba(200,247,106,.18), transparent 60%), radial-gradient(45% 35% at 0% 100%, rgba(91,212,208,.12), transparent 60%); z-index:0;}
+  .invoice > *{position:relative; z-index:1;}
+
+  /* Punch-hole tape strip — printerly detail */
+  .tape{height:6px; background:repeating-linear-gradient(90deg, var(--copper-print) 0 12px, transparent 12px 24px); opacity:.65;}
+
+  .head{padding:48px 56px 32px; display:flex; justify-content:space-between; align-items:flex-start; gap:32px; border-bottom:1px solid var(--line-paper);}
+  .head .from img{display:block;}
+  .head .from .ent{margin-top:18px; font-family:var(--mono); font-size:10.5px; line-height:1.7; color:var(--ink-mute); letter-spacing:.04em;}
+  .head .id{text-align:right; min-width:280px;}
+  .head .id .lab{font-family:var(--mono); font-size:10px; letter-spacing:.2em; text-transform:uppercase; color:var(--copper-print);}
+  .head .id .num{font-family:var(--serif); font-size:42px; margin-top:6px; letter-spacing:-0.01em; line-height:1;}
+  .head .id .num em{font-style:italic; color:var(--copper-print);}
+  .head .id .due{margin-top:12px; font-family:var(--mono); font-size:11px; color:var(--ink-mute); letter-spacing:.04em;}
+  .head .id .pill-paid{display:inline-flex; align-items:center; gap:6px; padding:5px 12px; border-radius:999px; font-family:var(--mono); font-size:10px; letter-spacing:.16em; text-transform:uppercase; background:rgba(91,212,208,.18); color:#2C8682; border:1px solid rgba(44,134,130,.4); margin-top:14px;}
+  .head .id .pill-paid .dot{width:6px; height:6px; border-radius:50%; background:#2C8682;}
+
+  .who-grid{display:grid; grid-template-columns:1fr 1fr 1fr; gap:32px; padding:28px 56px; border-bottom:1px solid var(--line-paper);}
+  .who-grid .lab{font-family:var(--mono); font-size:10px; letter-spacing:.2em; text-transform:uppercase; color:var(--ink-mute);}
+  .who-grid .v{font-family:var(--serif); font-size:22px; margin-top:6px; letter-spacing:-0.01em; line-height:1.2;}
+  .who-grid .v em{font-style:italic; color:var(--copper-print);}
+  .who-grid .s{font-family:var(--sans); font-size:13px; color:var(--ink-soft); margin-top:8px; line-height:1.55;}
+
+  .lines{padding:28px 56px;}
+  table{width:100%; border-collapse:collapse;}
+  th{font-family:var(--mono); font-size:10px; letter-spacing:.2em; text-transform:uppercase; color:var(--ink-mute); font-weight:500; padding:10px 0; border-bottom:1px solid var(--line-paper); text-align:left;}
+  th.r{text-align:right;}
+  td{padding:14px 0; border-bottom:1px dashed rgba(15,23,36,.16); vertical-align:top;}
+  td .desc-t{font-family:var(--sans); font-size:14.5px; color:var(--ink-text);}
+  td .desc-s{font-family:var(--mono); font-size:11px; color:var(--ink-mute); margin-top:3px; letter-spacing:.04em;}
+  td.num{text-align:right; font-family:var(--mono); font-size:13px; color:var(--ink-soft); font-variant-numeric:tabular-nums;}
+  td.amt{text-align:right; font-family:var(--serif); font-size:18px; color:var(--ink-text); letter-spacing:-0.005em;}
+
+  .totals{padding:24px 56px 12px; display:grid; grid-template-columns:1fr 320px; gap:32px; align-items:start;}
+  .totals .note{font-family:var(--mono); font-size:11px; line-height:1.7; color:var(--ink-mute); letter-spacing:.02em;}
+  .totals .calc{display:flex; flex-direction:column; gap:8px;}
+  .totals .row{display:flex; justify-content:space-between; align-items:baseline; font-family:var(--sans); font-size:14px; color:var(--ink-soft);}
+  .totals .row .v{font-family:var(--mono); font-size:13px; color:var(--ink-text);}
+  .totals .row.grand{padding-top:14px; margin-top:6px; border-top:1px solid var(--line-paper);}
+  .totals .row.grand span:first-child{font-family:var(--mono); font-size:11px; letter-spacing:.2em; text-transform:uppercase; color:var(--ink-mute);}
+  .totals .row.grand .v{font-family:var(--serif); font-size:36px; color:var(--ink-text); letter-spacing:-0.01em; white-space:nowrap;}
+  .totals .row.grand .v em{font-style:italic; color:var(--copper-print);}
+
+  .pay{padding:24px 56px 48px; display:grid; grid-template-columns:1fr 1fr; gap:32px; border-top:1px solid var(--line-paper); margin-top:8px;}
+  .pay h4{font-family:var(--mono); font-size:10px; letter-spacing:.2em; text-transform:uppercase; color:var(--ink-mute); margin:0 0 12px;}
+  .pay .kv{display:grid; grid-template-columns:max-content 1fr; column-gap:18px; row-gap:6px; font-family:var(--mono); font-size:12px; color:var(--ink-soft);}
+  .pay .kv dt{color:var(--ink-mute);}
+  .pay .kv dd{margin:0; color:var(--ink-text);}
+  .pay .stamp{align-self:end; justify-self:end; padding:18px 22px; border:2px solid var(--copper-print); border-radius:8px; transform:rotate(-4deg); font-family:var(--mono); font-size:13px; letter-spacing:.18em; text-transform:uppercase; color:var(--copper-print); text-align:center; line-height:1.4;}
+  .pay .stamp b{display:block; font-family:var(--serif); font-style:italic; font-size:24px; letter-spacing:-0.01em;}
+
+  .foot-rule{padding:18px 56px 24px; border-top:1px solid var(--line-paper); display:flex; justify-content:space-between; gap:18px; font-family:var(--mono); font-size:9.5px; letter-spacing:.18em; text-transform:uppercase; color:var(--ink-mute);}
+
+  @media print {
+    body{padding:0;}
+    .crumbs{display:none;}
+    .invoice{box-shadow:none;}
+  }
+</style>
+</head>
+<body>
+<main>
+  <div class="doc-wrap">
+    <div class="crumbs">
+      <span class="copper">Rechnung</span><span>·</span><span>{{INVOICE_NUMBER}}</span>
+      <div class="actions">
+        <button class="btn ghost sm" onclick="window.print()">Drucken →</button>
+      </div>
+    </div>
+
+    <article class="invoice">
+      <div class="tape"></div>
+
+      <div class="head">
+        <div class="from">
+          <img src="/brand/korczewski/kore-assets/logo-lockup-light.svg" width="200" height="60" alt="Korczewski">
+          <div class="ent">
+            PATRICK KORCZEWSKI<br>
+            {{LEGAL_STREET}} · {{LEGAL_ZIP}} {{LEGAL_CITY}}<br>
+            USt-IdNr.: {{LEGAL_UST_ID}}
+          </div>
+        </div>
+        <div class="id">
+          <div class="lab">Rechnung</div>
+          <div class="num">{{INVOICE_NUMBER_DISPLAY}}-<em>{{INVOICE_SEQ}}</em></div>
+          <div class="due">Ausgestellt {{ISSUE_DATE}} · Fällig {{DUE_DATE}} · Netto 14</div>
+          {{#if PAID}}
+          <span class="pill-paid"><span class="dot"></span>Bezahlt · {{PAID_DATE}}</span>
+          {{/if}}
+        </div>
+      </div>
+
+      <div class="who-grid">
+        <div>
+          <div class="lab">Rechnungsempfänger</div>
+          <div class="v">{{CLIENT_NAME}} <em>{{CLIENT_LEGAL_FORM}}</em></div>
+          <div class="s">{{CLIENT_CONTACT_NAME}}<br>{{CLIENT_ADDRESS}}</div>
+        </div>
+        <div>
+          <div class="lab">Zeitraum</div>
+          <div class="v">{{PERIOD_MONTH}} <em>{{PERIOD_YEAR}}</em></div>
+          <div class="s">{{SERVICE_DESCRIPTION}}<br>Vertrag {{CONTRACT_REF}}</div>
+        </div>
+        <div>
+          <div class="lab">Bestellnummer</div>
+          <div class="v">{{PO_NUMBER}}</div>
+          <div class="s">Genehmigt {{PO_DATE}}<br>von {{PO_APPROVER}}</div>
+        </div>
+      </div>
+
+      <div class="lines">
+        <table>
+          <thead>
+            <tr>
+              <th>Position</th>
+              <th class="r">Stunden</th>
+              <th class="r">Stundensatz</th>
+              <th class="r">Betrag</th>
+            </tr>
+          </thead>
+          <tbody>
+            <!-- Leistungsposition 1 -->
+            <tr>
+              <td>
+                <div class="desc-t">{{LINE_1_TITLE}}</div>
+                <div class="desc-s">{{LINE_1_REF}} · {{LINE_1_DETAIL}}</div>
+              </td>
+              <td class="num">{{LINE_1_HOURS}}</td>
+              <td class="num">{{LINE_1_RATE}} €</td>
+              <td class="amt">{{LINE_1_AMOUNT}} €</td>
+            </tr>
+            <!-- Leistungsposition 2 (optional — löschen falls nicht benötigt) -->
+            <tr>
+              <td>
+                <div class="desc-t">{{LINE_2_TITLE}}</div>
+                <div class="desc-s">{{LINE_2_REF}}</div>
+              </td>
+              <td class="num">{{LINE_2_HOURS}}</td>
+              <td class="num">{{LINE_2_RATE}} €</td>
+              <td class="amt">{{LINE_2_AMOUNT}} €</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <div class="totals">
+        <div class="note">
+          Kleinunternehmerregelung nach §19 UStG.<br>
+          Es wird keine Umsatzsteuer ausgewiesen.<br>
+          Zahlung fällig innerhalb von 14 Tagen nach Rechnungsstellung.<br>
+          Verzugszinsen ab Fälligkeit gemäß §288 BGB.
+        </div>
+        <div class="calc">
+          <div class="row"><span>Nettobetrag</span><span class="v">{{SUBTOTAL}} €</span></div>
+          <div class="row"><span>Umsatzsteuer (§19 UStG)</span><span class="v">0,00 €</span></div>
+          <div class="row grand">
+            <span>Gesamtbetrag</span>
+            <span class="v">{{TOTAL}},<em>00 €</em></span>
+          </div>
+        </div>
+      </div>
+
+      <div class="pay">
+        <div>
+          <h4>Bankverbindung</h4>
+          <dl class="kv">
+            <dt>Inhaber</dt><dd>Patrick Korczewski</dd>
+            <dt>Bank</dt><dd>{{BANK_NAME}}</dd>
+            <dt>IBAN</dt><dd>{{IBAN}}</dd>
+            <dt>BIC</dt><dd>{{BIC}}</dd>
+            <dt>Verwendungszweck</dt><dd>{{INVOICE_NUMBER}} · {{CLIENT_SHORT}}</dd>
+          </dl>
+        </div>
+        {{#if PAID}}
+        <div class="stamp">
+          Bezahlt<br>
+          <b>{{PAID_DATE_SHORT}}</b>
+          REF · {{PAYMENT_REF}}
+        </div>
+        {{/if}}
+      </div>
+
+      <div class="foot-rule">
+        <span>Seite 1 / 1</span>
+        <span>Erstellt von Korczewski · Software Engineering</span>
+        <span>{{GENERATED_AT}}</span>
+      </div>
+    </article>
+  </div>
+</main>
+</body>
+</html>

--- a/website/public/brand/korczewski/starters/newsletter.html
+++ b/website/public/brand/korczewski/starters/newsletter.html
@@ -1,0 +1,243 @@
+<!doctype html>
+<html lang="de">
+<head>
+<meta charset="utf-8">
+<title>Korczewski — {{NEWSLETTER_TITLE}}</title>
+<link rel="stylesheet" href="/brand/korczewski/colors_and_type.css">
+<link rel="stylesheet" href="/brand/korczewski/app.css">
+<style>
+  body{padding:48px 28px 96px;}
+  .nl{max-width:760px; margin:0 auto; position:relative; z-index:2;}
+
+  .masthead{display:flex; align-items:flex-end; justify-content:space-between; gap:24px; padding-bottom:22px; border-bottom:1px solid var(--line-2);}
+  .masthead .brand{display:flex; align-items:center; gap:14px; font-family:var(--serif); font-size:30px; letter-spacing:-0.01em;}
+  .masthead .brand .dot{color:var(--copper);}
+  .masthead .meta{font-family:var(--mono); font-size:10.5px; letter-spacing:.18em; text-transform:uppercase; color:var(--mute); text-align:right; line-height:1.7;}
+
+  .issue{font-family:var(--mono); font-size:10.5px; letter-spacing:.18em; text-transform:uppercase; color:var(--copper); margin-top:48px;}
+  h1.title{font-family:var(--serif); font-weight:400; font-size:64px; line-height:1.02; letter-spacing:-0.025em; margin:14px 0 0; max-width:14ch;}
+  h1.title em{font-style:italic; color:var(--copper-2);}
+  p.lede{font-family:var(--sans); font-size:18px; color:var(--fg-soft); line-height:1.55; margin:24px 0 0; max-width:60ch;}
+  .by{font-family:var(--mono); font-size:10.5px; letter-spacing:.16em; text-transform:uppercase; color:var(--mute); margin-top:24px;}
+  .by b{color:var(--fg); font-weight:500;}
+  .hr{height:1px; background:var(--line); margin:48px 0;}
+
+  /* Table of contents */
+  .toc{display:grid; grid-template-columns:repeat(3,1fr); gap:8px; margin-top:32px;}
+  .toc a{display:flex; flex-direction:column; gap:4px; padding:14px 16px; border:1px solid var(--line); border-radius:12px; background:var(--ink-850); text-decoration:none; transition:all 200ms var(--ease);}
+  .toc a:hover{border-color:var(--copper); background:var(--ink-800);}
+  .toc .n{font-family:var(--mono); font-size:9.5px; letter-spacing:.18em; text-transform:uppercase; color:var(--copper);}
+  .toc .t{font-family:var(--serif); font-size:18px; color:var(--fg); letter-spacing:-0.005em;}
+
+  /* Section headings */
+  h2.sec{font-family:var(--serif); font-weight:400; font-size:34px; letter-spacing:-0.02em; margin:0 0 6px;}
+  h2.sec em{font-style:italic; color:var(--copper-2);}
+  .sec-eye{display:flex; align-items:baseline; gap:14px; margin-bottom:18px;}
+  .sec-eye .num{font-family:var(--mono); font-size:11px; letter-spacing:.18em; color:var(--copper); text-transform:uppercase;}
+
+  /* Change log entries */
+  .change{display:grid; grid-template-columns:80px 1fr; gap:18px; padding:22px 0; border-top:1px solid var(--line);}
+  .change .tag{font-family:var(--mono); font-size:9.5px; letter-spacing:.16em; text-transform:uppercase; padding:3px 8px; border-radius:6px; height:fit-content; text-align:center; line-height:1.4;}
+  .change .tag.add{background:rgba(200,247,106,.12); color:var(--copper); border:1px solid rgba(200,247,106,.3);}
+  .change .tag.fix{background:rgba(91,212,208,.10); color:var(--teal); border:1px solid rgba(91,212,208,.25);}
+  .change .tag.brk{background:rgba(226,107,107,.10); color:#E26B6B; border:1px solid rgba(226,107,107,.25);}
+  .change .tag.dep{background:rgba(255,255,255,.04); color:var(--mute); border:1px solid var(--line-2);}
+  .change h3{font-family:var(--serif); font-weight:400; font-size:21px; letter-spacing:-0.01em; margin:0 0 6px;}
+  .change h3 em{font-style:italic; color:var(--copper-2);}
+  .change p{font-family:var(--sans); font-size:15px; line-height:1.55; color:var(--fg-soft); margin:0;}
+  .change code{font-family:var(--mono); font-size:12.5px; padding:1px 6px; background:var(--ink-850); border:1px solid var(--line); border-radius:4px; color:var(--copper-2);}
+  .change .who{margin-top:8px; font-family:var(--mono); font-size:10.5px; letter-spacing:.06em; color:var(--mute);}
+
+  /* Pull quote */
+  .pull{padding:28px 32px; border:1px solid var(--line); border-radius:16px; background:var(--ink-850); position:relative; overflow:hidden; margin:32px 0;}
+  .pull::after{content:""; position:absolute; inset:0; pointer-events:none; background:radial-gradient(70% 80% at 100% 0%, rgba(200,247,106,.08), transparent 60%);}
+  .pull > *{position:relative;}
+  .pull blockquote{font-family:var(--serif); font-style:italic; font-size:22px; line-height:1.45; color:var(--fg); margin:0 0 14px; padding-left:18px; border-left:2px solid var(--copper);}
+  .pull .who{font-family:var(--mono); font-size:10.5px; letter-spacing:.16em; text-transform:uppercase; color:var(--mute);}
+
+  /* Stats row */
+  .stats{display:grid; grid-template-columns:repeat(4,1fr); gap:10px; margin:24px 0;}
+  .stat{padding:18px; background:var(--ink-800); border-radius:12px; box-shadow:inset 0 1px 0 var(--copper);}
+  .stat .lab{font-family:var(--mono); font-size:9.5px; letter-spacing:.18em; text-transform:uppercase; color:var(--mute);}
+  .stat .v{font-family:var(--serif); font-size:28px; color:var(--fg); margin-top:6px; letter-spacing:-0.01em; line-height:1;}
+  .stat .v em{font-style:italic; color:var(--copper-2);}
+  .stat .v .u{font-family:var(--mono); font-size:11px; color:var(--mute); margin-left:3px;}
+
+  /* Code snippet block */
+  .upgrade{padding:28px 32px; border:1px solid var(--line-2); border-radius:14px; background:var(--ink-900); margin-top:18px;}
+  .upgrade .lab{font-family:var(--mono); font-size:10px; letter-spacing:.18em; color:var(--copper); text-transform:uppercase;}
+  .upgrade pre{font-family:var(--mono); font-size:13px; line-height:1.7; color:var(--fg-soft); margin:14px 0 0; padding:18px; background:var(--ink-850); border-radius:10px; border:1px solid var(--line); overflow-x:auto;}
+  .upgrade pre b{color:var(--copper); font-weight:500;}
+
+  /* Body text */
+  .body-text{font-family:var(--sans); font-size:15px; line-height:1.65; color:var(--fg-soft); margin:16px 0;}
+  .body-text a{color:var(--copper); text-decoration:none;}
+  .body-text a:hover{text-decoration:underline; text-underline-offset:4px;}
+
+  /* Footer */
+  .foot{margin-top:64px; padding-top:32px; border-top:1px solid var(--line); display:grid; grid-template-columns:1.4fr 1fr 1fr; gap:32px;}
+  .foot .col h5{font-family:var(--mono); font-size:10px; letter-spacing:.18em; text-transform:uppercase; color:var(--mute); margin:0 0 12px;}
+  .foot .col a{display:block; font-family:var(--sans); font-size:13.5px; color:var(--fg-soft); padding:4px 0; text-decoration:none;}
+  .foot .col a:hover{color:var(--copper);}
+  .foot .signoff{font-family:var(--serif); font-style:italic; font-size:18px; color:var(--fg-soft); line-height:1.5;}
+  .foot .signoff em{color:var(--copper-2);}
+  .foot .sig{margin-top:14px; font-family:var(--mono); font-size:10.5px; letter-spacing:.14em; text-transform:uppercase; color:var(--mute);}
+  .foot .sig b{color:var(--fg-soft);}
+</style>
+</head>
+<body>
+<main>
+  <article class="nl">
+
+    <!-- Masthead -->
+    <header class="masthead">
+      <div class="brand">
+        <img src="/brand/korczewski/kore-assets/logo-mark.svg" width="40" height="40" alt="Korczewski">
+        Korczewski<span class="dot">.</span> Notizen
+      </div>
+      <div class="meta">
+        Ausgabe {{ISSUE_NUMBER}}<br>
+        {{ISSUE_DATE}}<br>
+        Lüneburg · Remote
+      </div>
+    </header>
+
+    <!-- Hero -->
+    <div class="issue">[ Ausgabe {{ISSUE_NUMBER}} — {{ISSUE_TOPIC}} ]</div>
+    <h1 class="title">{{NEWSLETTER_HEADLINE}} <em>{{NEWSLETTER_HEADLINE_EM}}</em></h1>
+    <p class="lede">{{NEWSLETTER_LEDE}}</p>
+    <p class="by">Von <b>Patrick Korczewski</b> · {{ISSUE_DATE}}</p>
+
+    <div class="hr"></div>
+
+    <!-- Inhaltsverzeichnis -->
+    <div class="toc">
+      <a href="#section-1">
+        <span class="n">01</span>
+        <span class="t">{{TOC_1}}</span>
+      </a>
+      <a href="#section-2">
+        <span class="n">02</span>
+        <span class="t">{{TOC_2}}</span>
+      </a>
+      <a href="#section-3">
+        <span class="n">03</span>
+        <span class="t">{{TOC_3}}</span>
+      </a>
+    </div>
+
+    <div class="hr"></div>
+
+    <!-- Abschnitt 1 -->
+    <section id="section-1">
+      <div class="sec-eye">
+        <span class="num">01</span>
+      </div>
+      <h2 class="sec">{{SECTION_1_TITLE}} <em>{{SECTION_1_TITLE_EM}}</em></h2>
+
+      <!-- Einträge mit Tags: add / fix / brk / dep -->
+      <div class="change">
+        <span class="tag add">Neu</span>
+        <div>
+          <h3>{{CHANGE_1_TITLE}} <em>{{CHANGE_1_EM}}</em></h3>
+          <p>{{CHANGE_1_BODY}}</p>
+          <p class="who">{{CHANGE_1_META}}</p>
+        </div>
+      </div>
+
+      <div class="change">
+        <span class="tag fix">Fix</span>
+        <div>
+          <h3>{{CHANGE_2_TITLE}}</h3>
+          <p>{{CHANGE_2_BODY}} Betrifft <code>{{CHANGE_2_CODE}}</code>.</p>
+          <p class="who">{{CHANGE_2_META}}</p>
+        </div>
+      </div>
+    </section>
+
+    <!-- Pull Quote -->
+    <div class="pull">
+      <blockquote>
+        {{PULL_QUOTE}}
+      </blockquote>
+      <p class="who">— {{PULL_QUOTE_ATTRIBUTION}}</p>
+    </div>
+
+    <!-- Abschnitt 2 -->
+    <section id="section-2">
+      <div class="sec-eye">
+        <span class="num">02</span>
+      </div>
+      <h2 class="sec">{{SECTION_2_TITLE}} <em>{{SECTION_2_TITLE_EM}}</em></h2>
+
+      <!-- Statistiken -->
+      <div class="stats">
+        <div class="stat">
+          <div class="lab">{{STAT_1_LAB}}</div>
+          <div class="v">{{STAT_1_VAL}}<span class="u">{{STAT_1_UNIT}}</span></div>
+        </div>
+        <div class="stat">
+          <div class="lab">{{STAT_2_LAB}}</div>
+          <div class="v"><em>{{STAT_2_VAL}}</em></div>
+        </div>
+        <div class="stat">
+          <div class="lab">{{STAT_3_LAB}}</div>
+          <div class="v">{{STAT_3_VAL}}<span class="u">{{STAT_3_UNIT}}</span></div>
+        </div>
+        <div class="stat">
+          <div class="lab">{{STAT_4_LAB}}</div>
+          <div class="v">{{STAT_4_VAL}}<span class="u">{{STAT_4_UNIT}}</span></div>
+        </div>
+      </div>
+
+      <p class="body-text">{{SECTION_2_BODY}}</p>
+    </section>
+
+    <!-- Abschnitt 3 — Code-Snippet / Upgrade-Hinweis -->
+    <section id="section-3">
+      <div class="sec-eye">
+        <span class="num">03</span>
+      </div>
+      <h2 class="sec">{{SECTION_3_TITLE}} <em>{{SECTION_3_TITLE_EM}}</em></h2>
+
+      <p class="body-text">{{SECTION_3_BODY}}</p>
+
+      <div class="upgrade">
+        <span class="lab">[ {{SNIPPET_LABEL}} ]</span>
+        <pre>{{SNIPPET_CODE}}</pre>
+      </div>
+    </section>
+
+    <div class="hr"></div>
+
+    <!-- Footer / Signatur -->
+    <footer class="foot">
+      <div>
+        <p class="signoff">
+          Bis zur nächsten Ausgabe —<br>
+          <em>bleibt die Infrastruktur ruhig.</em>
+        </p>
+        <p class="sig">Patrick Korczewski · <b>Lüneburg</b></p>
+        <div style="margin-top:18px; display:flex; gap:10px;">
+          <a class="btn primary sm" href="/kontakt">Anfragen →</a>
+          <a class="btn ghost sm" href="/impressum">Abmelden</a>
+        </div>
+      </div>
+      <div class="col">
+        <h5>Leistungen</h5>
+        <a href="/ki-beratung">KI-Integration</a>
+        <a href="/software-dev">Software</a>
+        <a href="/deployment">Kubernetes</a>
+      </div>
+      <div class="col">
+        <h5>Studio</h5>
+        <a href="/ueber-mich">Über mich</a>
+        <a href="/kontakt">Kontakt</a>
+        <a href="/impressum">Impressum</a>
+      </div>
+    </footer>
+
+  </article>
+</main>
+</body>
+</html>

--- a/website/src/components/kore/KoreHomepage.svelte
+++ b/website/src/components/kore/KoreHomepage.svelte
@@ -1,0 +1,389 @@
+<script lang="ts">
+  import Timeline from '../Timeline.svelte';
+  import type { DaySlots } from '../../lib/caldav';
+
+  export let services: any[] = [];
+  export let homepage: any = {};
+  export let contact: any = {};
+  export let legal: any = {};
+  export let footerColumns: any[] = [];
+  export let footerCopyright: string = '';
+  export let nextDay: DaySlots | null = null;
+  export let initialTimeline: any[] = [];
+  export let wantsTimeline: boolean = false;
+
+  // Nav active section
+  let activeSection = 'leistungen';
+
+  // Booking slot picker
+  let pickedSlot: string | null = null;
+
+  $: bookingSlots = nextDay
+    ? nextDay.slots.slice(0, 6).map((s, i) => ({
+        id: `slot-${i}`,
+        day: nextDay!.weekday,
+        date: nextDay!.date,
+        display: s.display,
+        time: s.start.substring(11, 16),
+      }))
+    : [];
+
+  // Service glyphs — inline SVGs matching the Kore 1.5px-stroke line style
+  const serviceGlyphs: Record<string, string> = {
+    'ki-beratung': `<svg width="34" height="34" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2a9 9 0 0 1 9 9c0 3.18-1.66 5.97-4.15 7.56L16 21H8l-.85-2.44A9 9 0 0 1 12 2z"/><path d="M9 17v1a3 3 0 0 0 6 0v-1"/><path d="M9 11h6M12 8v6"/></svg>`,
+    'software-dev': `<svg width="34" height="34" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>`,
+    'deployment': `<svg width="34" height="34" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M12 1v3M12 20v3M4.22 4.22l2.12 2.12M17.66 17.66l2.12 2.12M1 12h3M20 12h3M4.22 19.78l2.12-2.12M17.66 6.34l2.12-2.12"/></svg>`,
+  };
+
+  // Milestones used in the "Ausgewählte Arbeit" section
+  const milestones = [
+    {
+      eye: 'IT-Management · Früher',
+      title: 'Systeme betrieben,<br><em>bevor ich sie baute.</em>',
+      body: 'Jahrelang die IT großer und kleiner Unternehmen gemanaged — Server, Netzwerke, Helpdesk, Strategie. Technik, die wirklich funktionieren muss.',
+      stat1lab: 'Erfahrung',
+      stat1val: '10',
+      stat1unit: 'Jahre',
+      stat1sub: 'Betrieb & Beratung',
+      stat2lab: 'Fokus',
+      stat2val: 'IT',
+      stat2sub: 'Management & Support',
+      tags: 'WINDOWS · LINUX · NETZWERK',
+    },
+    {
+      eye: 'IT-Sicherheit · Studium',
+      title: 'Security als<br><em>Grundhaltung.</em>',
+      body: 'B.Sc. IT-Sicherheit: Penetration Testing, Kryptographie, sichere Architekturen. Was bleibt: ein tiefes Misstrauen gegenüber "haben wir immer so gemacht".',
+      stat1lab: 'Abschluss',
+      stat1val: 'B.Sc.',
+      stat1unit: '',
+      stat1sub: 'IT-Sicherheit',
+      stat2lab: 'Schwerpunkt',
+      stat2val: 'PenTest',
+      stat2sub: 'Kryptographie · Auth',
+      tags: 'OWASP · PKI · PENTEST',
+    },
+  ];
+</script>
+
+<!-- ═══════════════════════════════ HERO ═══════════════════════════════════ -->
+<section class="w-hero">
+  <span class="w-ticker">
+    <span class="dot"></span>
+    <b>Lüneburg / Remote</b>&nbsp;·
+    <span style="color:var(--mute)">KI · Kubernetes · Security</span>
+  </span>
+
+  <span class="eyebrow no-rule">[ Software Engineering ]</span>
+
+  <h1>Kubernetes & KI,<br><em>ruhig betrieben.</em></h1>
+
+  <p class="lede">
+    {legal.tagline ?? homepage.servicesSubheadline}
+    Ich bringe Architektur, Security und KI zusammen — ohne Buzzwords, ohne Vendor-Lock-in.
+  </p>
+
+  <div class="cta-row">
+    <a class="btn primary" href="/kontakt">Kennenlerngespräch →</a>
+    <a class="btn ghost" href="#leistungen">Leistungen ansehen</a>
+  </div>
+
+  <div class="meta-row">
+    {#each homepage.stats ?? [] as stat}
+      <div>
+        <div class="lab">{stat.label}</div>
+        <div class="v">{stat.value}</div>
+        <div class="s">&nbsp;</div>
+      </div>
+    {/each}
+  </div>
+</section>
+
+<!-- ═══════════════════════════════ SERVICES ══════════════════════════════ -->
+<section class="w-section" id="leistungen">
+  <div class="head">
+    <span class="num">01 / 04</span>
+    <h2>Was ich tue, <em>und wie.</em></h2>
+    <span class="hint">{services.length} Leistungen</span>
+  </div>
+
+  <div class="w-services">
+    {#each services as svc}
+      <article class="w-svc">
+        <div class="glyph">
+          {@html serviceGlyphs[svc.slug] ?? serviceGlyphs['deployment']}
+        </div>
+        <h3>{svc.title.split(' ')[0]} <em>{svc.title.split(' ').slice(1).join(' ')}</em></h3>
+        <p>{svc.description}</p>
+        <div class="tags">
+          {#each (svc.features ?? []).slice(0, 3) as f}
+            <span>{f.split(' ').slice(0,2).join(' ').toUpperCase()}</span>
+          {/each}
+        </div>
+        <a class="btn ghost sm" style="margin-top:auto" href="/{svc.slug}">Mehr erfahren →</a>
+      </article>
+    {/each}
+  </div>
+</section>
+
+<!-- ═══════════════════════════════ WORK / CASES ══════════════════════════ -->
+<section class="w-section" id="ansatz">
+  <div class="head">
+    <span class="num">02 / 04</span>
+    <h2>Gelebte Praxis, <em>kein Lernprojekt.</em></h2>
+    <span class="hint">Erfahrung</span>
+  </div>
+
+  <div class="w-cases">
+    {#each milestones as m, i}
+      <article class="w-case {i === 0 ? 'lg' : ''}">
+        <span class="eye">{m.eye}</span>
+        <h3>{@html m.title}</h3>
+        <p style="color:var(--fg-soft); margin-top:14px; font-size:14.5px; line-height:1.55">
+          {m.body}
+        </p>
+        {#if i === 0}
+          <div class="stats">
+            <div class="stat">
+              <div class="lab">{m.stat1lab}</div>
+              <div class="v">
+                {m.stat1val}{#if m.stat1unit}<span class="u">{m.stat1unit}</span>{/if}
+              </div>
+              <div class="s">{m.stat1sub}</div>
+            </div>
+            <div class="stat">
+              <div class="lab">{m.stat2lab}</div>
+              <div class="v">{m.stat2val}</div>
+              <div class="s">{m.stat2sub}</div>
+            </div>
+          </div>
+        {/if}
+        <div class="small-meta">{m.tags}</div>
+      </article>
+    {/each}
+  </div>
+</section>
+
+<!-- ═══════════════════════════════ TEAM / PERSON ════════════════════════ -->
+<section class="w-section" id="ueber">
+  <div class="head">
+    <span class="num">03 / 04</span>
+    <h2>Ein Mensch <em>macht die Arbeit.</em></h2>
+    <span class="hint">Solo · seit 2022</span>
+  </div>
+
+  <div class="w-team">
+    <div class="who">
+      <div class="portrait">
+        <img
+          src="/brand/korczewski/kore-assets/portrait.jpg"
+          alt="Patrick Korczewski"
+          style="width:100%;height:100%;object-fit:cover;position:absolute;inset:0;border-radius:14px;"
+          on:error={(e) => { (e.currentTarget as HTMLElement).style.display = 'none'; }}
+        />
+        <div class="id">
+          <b>Patrick Korczewski</b><br>
+          {legal.jobtitle ?? 'Software Engineering & IT-Security'}
+        </div>
+      </div>
+    </div>
+
+    <div>
+      <span class="role">Operator · Inhaber</span>
+      <h3>Patrick <em>Korczewski</em></h3>
+      <p class="bio">
+        Manche Leute finden ihren Weg geradlinig. Ich habe meinen eher im Zickzack gefunden —
+        und bin überzeugt, dass genau das der Grund ist, warum ich heute gute Beratung machen kann.
+      </p>
+      <p class="bio">
+        B.Sc. IT-Sicherheit. Seit Tag 1 von ChatGPT mit KI in echten Projekten.
+        Kubernetes in Produktion — multi-tenant, multi-cluster, mit GitOps.
+        Ich baue Systeme, die ich hinterher selbst betreibe.
+      </p>
+
+      <dl class="credits">
+        <dt>Studium</dt>
+        <dd>B.Sc. IT-Sicherheit</dd>
+        <dt>Expertise</dt>
+        <dd>Kubernetes · KI-Integration · <em>Security</em></dd>
+        <dt>Standort</dt>
+        <dd>Lüneburg · Remote EU-weit</dd>
+        <dt>Arbeitet mit</dt>
+        <dd>Claude Code · FluxCD · k3s · Astro · Go</dd>
+      </dl>
+    </div>
+  </div>
+</section>
+
+<!-- ═══════════════════════════════ CONTACT ═══════════════════════════════ -->
+<section class="w-section" id="kontakt">
+  <div class="head">
+    <span class="num">04 / 04</span>
+    <h2>Gespräch innerhalb <em>einer Woche.</em></h2>
+    <span class="hint">Kein Formular, kein Funnel</span>
+  </div>
+
+  <div class="w-contact">
+    <div class="panel">
+      <h3>Der direkte <em>Weg.</em></h3>
+      <p>E-Mail oder Kontaktformular. Antwort innerhalb eines Werktages.</p>
+
+      {#if contact.email}
+        <div class="row">
+          <span class="lab">E-Mail</span>
+          <span class="v">
+            <a href="mailto:{contact.email}">{contact.email}</a>
+          </span>
+        </div>
+      {/if}
+      {#if contact.phone}
+        <div class="row">
+          <span class="lab">Telefon</span>
+          <span class="v">{contact.phone}</span>
+        </div>
+      {/if}
+      {#if contact.city}
+        <div class="row">
+          <span class="lab">Standort</span>
+          <span class="v">
+            {contact.city}
+            <span class="small">Remote-Zusammenarbeit bevorzugt</span>
+          </span>
+        </div>
+      {/if}
+      <div class="row">
+        <span class="lab">Kontakt</span>
+        <span class="v">
+          <a href="/kontakt" style="color:var(--copper)">Kontaktformular →</a>
+          <span class="small">Alle Anfragen, direkt und ohne CRM-Overhead</span>
+        </span>
+      </div>
+    </div>
+
+    <div class="booker">
+      <span class="lab">Kennenlerngespräch</span>
+      <h3>30 Minuten, <em>20 Euro.</em></h3>
+
+      {#if bookingSlots.length > 0}
+        <div class="slots">
+          {#each bookingSlots as slot}
+            <button
+              type="button"
+              class="slot {pickedSlot === slot.id ? 'sel' : ''}"
+              style={pickedSlot === slot.id ? 'border-color:var(--copper);background:var(--copper-tint)' : ''}
+              on:click={() => pickedSlot = slot.id}
+            >
+              <span class="day">{slot.day}</span>
+              <span class="time">{slot.time}</span>
+            </button>
+          {/each}
+        </div>
+        {#if pickedSlot}
+          <a class="btn primary" style="width:100%;margin-top:18px;justify-content:center" href="/termin">
+            Termin bestätigen →
+          </a>
+        {:else}
+          <p class="note">Alle Zeiten Europe/Berlin. Ich sende eine Kalendereinladung innerhalb einer Stunde.</p>
+        {/if}
+      {:else}
+        <p class="note" style="margin-top:22px">
+          Aktuell keine Slots verfügbar — schreiben Sie mir direkt per
+          <a href="/kontakt" style="color:var(--copper)">Kontaktformular</a>.
+        </p>
+        <a class="btn primary" style="margin-top:18px" href="/kontakt">Anfrage senden →</a>
+      {/if}
+    </div>
+  </div>
+</section>
+
+<!-- ═══════════════════════════════ TIMELINE ══════════════════════════════ -->
+{#if wantsTimeline}
+  <section class="timeline-kore" id="timeline">
+    <div class="tl-head">
+      <span class="eyebrow no-rule">Live aus der Entwicklung</span>
+      <h2>Implementierte Features.</h2>
+      <p class="lede" style="margin-top:14px">
+        Jede gemergte Pull Request landet hier — direkt aus der Datenbank, ohne Filter.
+      </p>
+    </div>
+    <Timeline initialRows={initialTimeline} />
+  </section>
+{/if}
+
+<!-- ═══════════════════════════════ FOOTER ════════════════════════════════ -->
+<footer class="w-foot">
+  <div class="w-foot-inner">
+    <div>
+      <div class="brand">
+        Korczewski<span class="dot">.</span>
+      </div>
+      <p style="color:var(--mute);font-size:13px;margin-top:14px;font-family:var(--mono);line-height:1.6">
+        Software Engineering & IT-Security.<br>
+        {contact.city ?? 'Lüneburg'} · Remote EU-weit.
+      </p>
+    </div>
+
+    {#each footerColumns as col}
+      <div class="col">
+        <h5>{col.heading}</h5>
+        {#each col.links as link}
+          <a href={link.href}>{link.label}</a>
+        {/each}
+      </div>
+    {/each}
+  </div>
+
+  <div class="legal">
+    <span>{footerCopyright}</span>
+    <span>
+      <a href="/impressum" style="color:inherit;text-decoration:none">Impressum</a>
+      &nbsp;·&nbsp;
+      <a href="/datenschutz" style="color:inherit;text-decoration:none">Datenschutz</a>
+    </span>
+  </div>
+</footer>
+
+<style>
+  /* Timeline section — Kore-styled wrapper */
+  .timeline-kore {
+    max-width: 1280px;
+    margin: 0 auto;
+    padding: 80px 28px;
+    border-top: 1px solid var(--line);
+  }
+
+  .tl-head {
+    margin-bottom: 48px;
+    padding-bottom: 24px;
+    border-bottom: 1px solid var(--line);
+  }
+
+  .tl-head h2 {
+    font-family: var(--serif);
+    font-weight: 400;
+    font-size: 38px;
+    letter-spacing: -0.02em;
+    margin: 12px 0 0;
+    color: var(--fg);
+  }
+
+  /* Slot button — override default button reset */
+  .slot {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding: 14px 16px;
+    border: 1px solid var(--line-2);
+    border-radius: 12px;
+    cursor: pointer;
+    transition: all 200ms var(--ease);
+    background: rgba(255, 255, 255, 0.02);
+    text-align: left;
+    width: 100%;
+  }
+
+  .slot:hover {
+    border-color: var(--copper);
+    background: var(--copper-tint);
+  }
+</style>

--- a/website/src/layouts/Layout.astro
+++ b/website/src/layouts/Layout.astro
@@ -52,6 +52,7 @@ const pageTitle = rawTitle ? title : `${title} | ${config.meta.siteTitle}`;
     {isKore && <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />}
     <title>{pageTitle}</title>
     {isKore && <link rel="stylesheet" href="/brand/korczewski/colors_and_type.css" />}
+    {isKore && <link rel="stylesheet" href="/brand/korczewski/app.css" />}
     {isKore && <link rel="stylesheet" href="/brand/korczewski/kore-website.css" />}
   </head>
   <body class={`min-h-screen flex flex-col${isKore ? ' kore' : ''}`} style="background:var(--ink-900); color:var(--fg);">

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -7,7 +7,7 @@ import FAQ from '../components/FAQ.svelte';
 import WhyMe from '../components/WhyMe.svelte';
 import Process from '../components/Process.astro';
 import SlotWidget from '../components/SlotWidget.astro';
-import Timeline from '../components/Timeline.svelte';
+import KoreHomepage from '../components/kore/KoreHomepage.svelte';
 import { config } from '../config/index';
 import type { DaySlots } from '../lib/caldav';
 import { getAvailableSlots } from '../lib/caldav';
@@ -52,124 +52,125 @@ const processSteps = homepage.processSteps ?? [];
 ---
 
 <Layout title={pageTitle} rawTitle={!isKore} description={metaDescription} brand={layoutBrand}>
-  <!-- Hero with Portrait -->
-  <Hero
-    client:load
-    title={homepage.hero.title}
-    titleEmphasis={homepage.hero.titleEmphasis}
-    subtitle={homepage.hero.subtitle}
-    tagline={homepage.hero.tagline}
-    avatarType={homepage.avatarType}
-    avatarSrc={homepage.avatarSrc}
-    avatarInitials={homepage.avatarInitials}
-    personName={contact.name}
-    personRole={config.legal.jobtitle}
-  />
+  {isKore ? (
+    <KoreHomepage
+      client:load
+      services={services}
+      homepage={config.homepage}
+      contact={config.contact}
+      legal={config.legal}
+      footerColumns={config.footer?.columns ?? []}
+      footerCopyright={config.footer?.copyright ?? ''}
+      nextDay={nextDay}
+      initialTimeline={initialTimeline}
+      wantsTimeline={wantsTimeline}
+    />
+  ) : (
+    <Fragment>
+      <!-- Hero with Portrait -->
+      <Hero
+        client:load
+        title={homepage.hero.title}
+        titleEmphasis={homepage.hero.titleEmphasis}
+        subtitle={homepage.hero.subtitle}
+        tagline={homepage.hero.tagline}
+        avatarType={homepage.avatarType}
+        avatarSrc={homepage.avatarSrc}
+        avatarInitials={homepage.avatarInitials}
+        personName={contact.name}
+        personRole={config.legal.jobtitle}
+      />
 
-  <!-- Stats + Availability strip -->
-  <div class="strip" role="region" aria-label="Eckdaten und Verfügbarkeit">
-    <!-- Stats -->
-    <div class="stats" aria-label="Kennzahlen">
-      {homepage.stats.map((stat) => (
-        <div class="stat">
-          <span class="stat-num" set:html={stat.value.replace(/([+]|KI|K8s|B\.Sc\.)/, '<em>$1</em>')}></span>
-          <span class="stat-lab">{stat.label}</span>
+      <!-- Stats + Availability strip -->
+      <div class="strip" role="region" aria-label="Eckdaten und Verfügbarkeit">
+        <!-- Stats -->
+        <div class="stats" aria-label="Kennzahlen">
+          {homepage.stats.map((stat) => (
+            <div class="stat">
+              <span class="stat-num" set:html={stat.value.replace(/([+]|KI|K8s|B\.Sc\.)/, '<em>$1</em>')}></span>
+              <span class="stat-lab">{stat.label}</span>
+            </div>
+          ))}
         </div>
-      ))}
-    </div>
 
-    <!-- Availability -->
-    {nextDay
-      ? <SlotWidget day={nextDay} />
-      : (
-        <div class="availability-placeholder">
-          <p style="color:var(--mute); font-size:14px;">
-            <a href="/termin" style="color:var(--brass); text-decoration:none;">Termine ansehen →</a>
-          </p>
-        </div>
-      )
-    }
-  </div>
-
-  <!-- Offers -->
-  <section id="angebote" class="section" aria-labelledby="offers-heading">
-    <div class="wrap">
-      <div class="section-head">
-        <div>
-          <p class="eyebrow">Meine Angebote</p>
-          <h2 id="offers-heading">{homepage.servicesHeadline}</h2>
-        </div>
-        <p class="section-intro">{homepage.servicesSubheadline}</p>
+        <!-- Availability -->
+        {nextDay
+          ? <SlotWidget day={nextDay} />
+          : (
+            <div class="availability-placeholder">
+              <p style="color:var(--mute); font-size:14px;">
+                <a href="/termin" style="color:var(--brass); text-decoration:none;">Termine ansehen →</a>
+              </p>
+            </div>
+          )
+        }
       </div>
 
-      <div class="offers" role="list" aria-label="Angebote">
-        {services.map((service, i) => (
-          <div role="listitem">
-            <ServiceRow
-              num={String(i + 1).padStart(2, '0')}
-              title={service.title}
-              meta={service.meta}
-              description={service.description}
-              features={service.features}
-              price={service.price}
-              href={`/${service.slug}`}
-              icon={service.icon}
-              iconSpriteId={service.iconSpriteId}
-              iconSpriteBrand={BRAND_ID}
-              stripeServiceKey={service.stripeServiceKey}
-              client:visible
-            />
+      <!-- Offers -->
+      <section id="angebote" class="section" aria-labelledby="offers-heading">
+        <div class="wrap">
+          <div class="section-head">
+            <div>
+              <p class="eyebrow">Meine Angebote</p>
+              <h2 id="offers-heading">{homepage.servicesHeadline}</h2>
+            </div>
+            <p class="section-intro">{homepage.servicesSubheadline}</p>
           </div>
-        ))}
-      </div>
-    </div>
-  </section>
 
-  <!-- Why Me + Quote -->
-  <WhyMe
-    client:visible
-    headline={homepage.whyMeHeadline}
-    intro={homepage.whyMeIntro}
-    points={homepage.whyMePoints}
-    quote={homepage.quote}
-    quoteName={homepage.quoteName}
-    quoteRole={config.legal.jobtitle}
-  />
-
-  <!-- Process -->
-  <Process
-    steps={processSteps}
-    eyebrow={homepage.processEyebrow}
-    headline={homepage.processHeadline}
-  />
-
-  <!-- FAQ -->
-  <FAQ items={faq.map((item) => ({
-    ...item,
-    answer: item.answer.replace('{city}', contact.city),
-  }))} client:visible />
-
-  <!-- CTA -->
-  <CallToAction
-    client:visible
-    secondaryText={contact.email}
-    secondaryHref={`mailto:${contact.email}`}
-  />
-
-  <!-- Live PR-feed Timeline (korczewski only, gated by BrandConfig.homepage.timeline) -->
-  {wantsTimeline && (
-    <section class="section timeline-section" id="timeline" aria-labelledby="timeline-heading">
-      <div class="wrap">
-        <div class="section-head">
-          <div>
-            <p class="eyebrow">Live aus der Timeline</p>
-            <h2 id="timeline-heading">Implementierte Features.</h2>
+          <div class="offers" role="list" aria-label="Angebote">
+            {services.map((service, i) => (
+              <div role="listitem">
+                <ServiceRow
+                  num={String(i + 1).padStart(2, '0')}
+                  title={service.title}
+                  meta={service.meta}
+                  description={service.description}
+                  features={service.features}
+                  price={service.price}
+                  href={`/${service.slug}`}
+                  icon={service.icon}
+                  iconSpriteId={service.iconSpriteId}
+                  iconSpriteBrand={BRAND_ID}
+                  stripeServiceKey={service.stripeServiceKey}
+                  client:visible
+                />
+              </div>
+            ))}
           </div>
-          <p class="section-intro">Jede merged Pull Request landet hier — direkt aus der Datenbank, ohne Filter.</p>
         </div>
-        <Timeline client:load initialRows={initialTimeline} />
-      </div>
-    </section>
+      </section>
+
+      <!-- Why Me + Quote -->
+      <WhyMe
+        client:visible
+        headline={homepage.whyMeHeadline}
+        intro={homepage.whyMeIntro}
+        points={homepage.whyMePoints}
+        quote={homepage.quote}
+        quoteName={homepage.quoteName}
+        quoteRole={config.legal.jobtitle}
+      />
+
+      <!-- Process -->
+      <Process
+        steps={processSteps}
+        eyebrow={homepage.processEyebrow}
+        headline={homepage.processHeadline}
+      />
+
+      <!-- FAQ -->
+      <FAQ items={faq.map((item) => ({
+        ...item,
+        answer: item.answer.replace('{city}', contact.city),
+      }))} client:visible />
+
+      <!-- CTA -->
+      <CallToAction
+        client:visible
+        secondaryText={contact.email}
+        secondaryHref={`mailto:${contact.email}`}
+      />
+    </Fragment>
   )}
 </Layout>
 


### PR DESCRIPTION
## Summary

- `KoreHomepage.svelte`: replace invalid `onerror=""` HTML attribute (not valid Svelte syntax) with `on:error` event handler — this was blocking the Docker build
- `Layout.astro`: add `app.css` stylesheet link for kore brand
- `index.astro`: kore homepage component wiring
- `public/brand/korczewski/starters/`: add invoice.html + newsletter.html starter templates

## Test plan
- [ ] `task feature:website` builds and deploys without error
- [ ] `web.korczewski.de` renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)