### PR TITLE
fix(website): add NEXTCLOUD_DB_HOST to website pod manifest [T000113]

### DIFF
--- a/k3d/website.yaml
+++ b/k3d/website.yaml
@@ -328,6 +328,8 @@ spec:
             # to find rooms with active calls (OCS API is user-scoped and only
             # lists rooms the configured admin is a participant of, which misses
             # most ongoing calls). Read-only query against oc_talk_rooms.
+            - name: NEXTCLOUD_DB_HOST
+              value: "nextcloud-db.${WORKSPACE_NAMESPACE}.svc.cluster.local"
             - name: NEXTCLOUD_DB_PASSWORD
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
## Summary

- `nextcloud-talk-db.ts` reads `NEXTCLOUD_DB_HOST` to connect to the Nextcloud PostgreSQL database for listing active call rooms
- The env var was never set in `k3d/website.yaml`, so it defaulted to `nextcloud-db.workspace.svc.cluster.local` — wrong for korczewski (namespace is `workspace-korczewski`)
- Fix: add an explicit `env:` entry using `${WORKSPACE_NAMESPACE}` substitution, which the `workspace:deploy` `envsubst` pipeline already handles

## Test plan
- [ ] `task workspace:deploy ENV=korczewski` — verify pod gets `NEXTCLOUD_DB_HOST=nextcloud-db.workspace-korczewski.svc.cluster.local`
- [ ] No more `ENOTFOUND nextcloud-db.workspace.svc.cluster.local` errors in website logs
- [ ] `/api/live/state` returns rooms correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)