### PR TITLE
fix(platform): fix korczewski Platform Control Center cluster connectivity

### DIFF
--- a/website/src/components/admin/PlatformHub.svelte
+++ b/website/src/components/admin/PlatformHub.svelte
@@ -60,15 +60,15 @@
       <HealthTab {cluster} />
     {:else if activeTab === 'dienste'}
       <div class="admin-card">
-        <DienstTab />
+        <DienstTab {cluster} />
       </div>
     {:else if activeTab === 'logs'}
       <div class="admin-card">
-        <LogsTab />
+        <LogsTab {cluster} />
       </div>
     {:else if activeTab === 'db'}
       <div class="admin-card">
-        <DatenbankTab />
+        <DatenbankTab {cluster} />
       </div>
     {:else if activeTab === 'dns'}
       <div class="admin-card">

--- a/website/src/components/admin/ops/DatenbankTab.svelte
+++ b/website/src/components/admin/ops/DatenbankTab.svelte
@@ -3,7 +3,7 @@
 
   type BackupJob = { name: string; trigger: string; startTime: string | null; completionTime: string | null; succeeded: boolean; failed: boolean };
 
-  let cluster = 'mentolder';
+  export let cluster: string = 'mentolder';
   let jobs: BackupJob[] = [];
   let jobsLoading = false;
   let triggerLoading = false;

--- a/website/src/components/admin/ops/DienstTab.svelte
+++ b/website/src/components/admin/ops/DienstTab.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import { onMount, onDestroy } from 'svelte';
 
+  export let cluster: string = 'mentolder';
+
   type Deployment = { ns: string; nsLabel: string; name: string; desired: number; ready: number; status: string };
   type Action = { type: 'restart' | 'scale'; deployment: Deployment };
 

--- a/website/src/components/admin/ops/LogsTab.svelte
+++ b/website/src/components/admin/ops/LogsTab.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import { onMount, onDestroy, tick } from 'svelte';
 
+  export let cluster: string = 'mentolder';
+
   const NAMESPACES = [
     { id: 'workspace',            label: 'mentolder (workspace)' },
     { id: 'workspace-korczewski', label: 'korczewski (workspace-korczewski)' },
@@ -10,7 +12,7 @@
 
   type Pod = { name: string; phase: string; ready: boolean; restarts: number; containers: string[] };
 
-  let ns = 'workspace';
+  let ns = cluster === 'korczewski' ? 'workspace-korczewski' : 'workspace';
   let pods: Pod[] = [];
   let selectedPod = '';
   let selectedContainer = '';

--- a/website/src/components/admin/platform/FluxCDTab.svelte
+++ b/website/src/components/admin/platform/FluxCDTab.svelte
@@ -82,10 +82,6 @@
       <div class="h-24 bg-admin-surface rounded-xl"></div>
       <div class="h-24 bg-admin-surface rounded-xl"></div>
     </div>
-  {:else if cluster !== 'mentolder'}
-    <div class="p-8 text-center bg-admin-surface rounded-2xl border border-dashed border-admin-border">
-      <p class="text-admin-text-mute italic">FluxCD Management läuft primär auf dem Mentolder Cluster.</p>
-    </div>
   {:else if data && data.flux.error && !data.flux.kustomizations?.length}
     <div class="p-4 bg-red-500/10 border border-red-500/20 rounded-xl text-red-500 text-sm">
       {data.flux.error}

--- a/website/src/pages/api/admin/deployments.ts
+++ b/website/src/pages/api/admin/deployments.ts
@@ -26,8 +26,11 @@ export const GET: APIRoute = async ({ request }) => {
     );
   }
 
+  const brand = (process.env.BRAND_ID ?? process.env.BRAND ?? 'mentolder').toLowerCase();
+  const ns = brand === 'korczewski' ? 'workspace-korczewski' : 'workspace';
+
   try {
-    const data = await k8s.get('/apis/apps/v1/namespaces/workspace/deployments');
+    const data = await k8s.get(`/apis/apps/v1/namespaces/${ns}/deployments`);
     const deployments = (data.items ?? []).map((d: any) => {
       const desired: number = d.spec.replicas ?? 1;
       const ready: number = d.status.readyReplicas ?? 0;

--- a/website/src/pages/api/admin/deployments/[name]/restart.ts
+++ b/website/src/pages/api/admin/deployments/[name]/restart.ts
@@ -29,8 +29,11 @@ export const POST: APIRoute = async ({ request, params }) => {
     });
   }
 
+  const brand = (process.env.BRAND_ID ?? process.env.BRAND ?? 'mentolder').toLowerCase();
+  const ns = brand === 'korczewski' ? 'workspace-korczewski' : 'workspace';
+
   try {
-    await k8s.patch(`/apis/apps/v1/namespaces/workspace/deployments/${name}`, {
+    await k8s.patch(`/apis/apps/v1/namespaces/${ns}/deployments/${name}`, {
       spec: {
         template: {
           metadata: {

--- a/website/src/pages/api/admin/deployments/[name]/scale.ts
+++ b/website/src/pages/api/admin/deployments/[name]/scale.ts
@@ -47,8 +47,11 @@ export const POST: APIRoute = async ({ request, params }) => {
     });
   }
 
+  const brand = (process.env.BRAND_ID ?? process.env.BRAND ?? 'mentolder').toLowerCase();
+  const ns = brand === 'korczewski' ? 'workspace-korczewski' : 'workspace';
+
   try {
-    await k8s.patch(`/apis/apps/v1/namespaces/workspace/deployments/${name}`, {
+    await k8s.patch(`/apis/apps/v1/namespaces/${ns}/deployments/${name}`, {
       spec: { replicas },
     });
     return new Response(JSON.stringify({ ok: true, replicas }), {

--- a/website/src/pages/api/admin/monitoring.ts
+++ b/website/src/pages/api/admin/monitoring.ts
@@ -32,12 +32,15 @@ export const GET: APIRoute = async ({ request }) => {
     );
   }
 
+  const brand = (process.env.BRAND_ID ?? process.env.BRAND ?? 'mentolder').toLowerCase();
+  const ns = brand === 'korczewski' ? 'workspace-korczewski' : 'workspace';
+
   try {
     const [podsData, eventsData, podMetricsResult, nodeMetricsResult, nodeCapacityResult] =
       await Promise.allSettled([
-        k8s.get('/api/v1/namespaces/workspace/pods'),
-        k8s.get('/api/v1/namespaces/workspace/events'),
-        k8s.get('/apis/metrics.k8s.io/v1beta1/namespaces/workspace/pods'),
+        k8s.get(`/api/v1/namespaces/${ns}/pods`),
+        k8s.get(`/api/v1/namespaces/${ns}/events`),
+        k8s.get(`/apis/metrics.k8s.io/v1beta1/namespaces/${ns}/pods`),
         k8s.get('/apis/metrics.k8s.io/v1beta1/nodes'),
         k8s.get('/api/v1/nodes'),
       ]);

--- a/website/src/pages/api/admin/platform/status.ts
+++ b/website/src/pages/api/admin/platform/status.ts
@@ -34,28 +34,26 @@ export const GET: APIRoute = async ({ request }) => {
     results.health.error = (e as Error).message;
   }
 
-  // FluxCD Status (Mentolder only)
-  if (results.cluster === 'mentolder') {
-    try {
-      const ks = await k8s.get('/apis/kustomize.toolkit.fluxcd.io/v1/kustomizations');
-      results.flux.kustomizations = ks.items.map((item: any) => ({
-        name: item.metadata.name,
-        namespace: item.metadata.namespace,
-        status: item.status?.conditions?.find((c: any) => c.type === 'Ready')?.status === 'True' ? 'ready' : 'error',
-        message: item.status?.conditions?.find((c: any) => c.type === 'Ready')?.message,
-        lastAttempt: item.status?.lastHandledReconcileAt || item.status?.lastAppliedRevision
-      }));
+  // FluxCD Status (both clusters run FluxCD)
+  try {
+    const ks = await k8s.get('/apis/kustomize.toolkit.fluxcd.io/v1/kustomizations');
+    results.flux.kustomizations = ks.items.map((item: any) => ({
+      name: item.metadata.name,
+      namespace: item.metadata.namespace,
+      status: item.status?.conditions?.find((c: any) => c.type === 'Ready')?.status === 'True' ? 'ready' : 'error',
+      message: item.status?.conditions?.find((c: any) => c.type === 'Ready')?.message,
+      lastAttempt: item.status?.lastHandledReconcileAt || item.status?.lastAppliedRevision
+    }));
 
-      const ip = await k8s.get('/apis/image.toolkit.fluxcd.io/v1/imagepolicies');
-      results.flux.imagePolicies = ip.items.map((item: any) => ({
-        name: item.metadata.name,
-        namespace: item.metadata.namespace,
-        latestImage: item.status?.latestImage,
-        status: item.status?.conditions?.find((c: any) => c.type === 'Ready')?.status === 'True' ? 'ready' : 'error'
-      }));
-    } catch (e) {
-      results.flux.error = 'FluxCD resources not available or error fetching';
-    }
+    const ip = await k8s.get('/apis/image.toolkit.fluxcd.io/v1/imagepolicies');
+    results.flux.imagePolicies = ip.items.map((item: any) => ({
+      name: item.metadata.name,
+      namespace: item.metadata.namespace,
+      latestImage: item.status?.latestImage,
+      status: item.status?.conditions?.find((c: any) => c.type === 'Ready')?.status === 'True' ? 'ready' : 'error'
+    }));
+  } catch (e) {
+    results.flux.error = 'FluxCD resources not available or error fetching';
   }
 
   return new Response(JSON.stringify(results), {


### PR DESCRIPTION
## Summary

- `monitoring.ts`, `deployments.ts`, `scale.ts`, `restart.ts`: replaced hardcoded `/namespaces/workspace/` with brand-derived namespace (`workspace-korczewski` when `BRAND_ID=korczewski`)
- `platform/status.ts`: removed `cluster === 'mentolder'` gate on FluxCD queries — both clusters run FluxCD; `try/catch` already handles absent CRDs
- `FluxCDTab.svelte`: removed `cluster !== 'mentolder'` placeholder block so korczewski FluxCD kustomizations are rendered
- `PlatformHub.svelte`: passes `{cluster}` prop to `DienstTab`, `LogsTab`, `DatenbankTab` (previously called without props)
- `LogsTab.svelte`: initial namespace now derived from `cluster` prop instead of hardcoded `'workspace'`
- `DatenbankTab.svelte`, `DienstTab.svelte`: added `export let cluster` prop for correct defaults

## Root cause

`createK8sClient()` always connects to the local cluster's API (`kubernetes.default.svc.cluster.local`). The korczewski website pod's k8s API has no `workspace` namespace — only `workspace-korczewski`. All API routes that hardcoded `workspace` returned 404/500 on korczewski.

## Test plan

- [ ] Deploy to korczewski: `task feature:website`
- [ ] Visit `web.korczewski.de/admin/platform` → GitOps tab should show korczewski FluxCD kustomizations
- [ ] Logs tab should default to `workspace-korczewski` namespace and list pods without error
- [ ] Dienste tab should list korczewski deployments
- [ ] Datenbank tab should default to korczewski cluster
- [ ] Verify mentolder platform page unchanged at `web.mentolder.de/admin/platform`

🤖 Generated with [Claude Code](https://claude.com/claude-code)