### PR TITLE
chore(skills): Playwright project gate + worktree tsc guidance [T000209][T000210]

### DIFF
--- a/.claude/skills/dev-flow-execute/SKILL.md
+++ b/.claude/skills/dev-flow-execute/SKILL.md
@@ -226,6 +226,15 @@ task workspace:validate
 task test:all
 ```
 
+> **TypeScript-Check in Worktrees:** `tests/e2e/` hat im Worktree kein `node_modules`. Niemals `tsc` blank aufrufen — das schlägt mit "Cannot find module" fehl. Immer absoluten Pfad nutzen:
+> ```bash
+> # Im Worktree: tsc mit absolutem tsconfig-Pfad
+> tsc --project /home/patrick/Bachelorprojekt/tests/e2e/tsconfig.json --noEmit
+> # Alternativ: system-tsc mit explizitem Projekt-Pfad
+> npx --prefix /home/patrick/Bachelorprojekt/tests/e2e tsc --noEmit
+> ```
+> `node_modules` nicht in den Worktree symlinken — das funktioniert nur im nächsten Prozess, nicht wiederholbar. Der `--project <abs-path>` Ansatz ist worktree-agnostisch.
+
 ### CI-kritische Zusatzchecks
 
 `task test:all` deckt nur den `offline-tests`-Job ab. Die folgenden Checks haben **eigene CI-Jobs** — CI kann rot werden, auch wenn `task test:all` grün ist. Führe sie aus, wenn die entsprechenden Dateien geändert wurden:

--- a/.claude/skills/dev-flow-plan/SKILL.md
+++ b/.claude/skills/dev-flow-plan/SKILL.md
@@ -271,6 +271,31 @@ Rufe `superpowers:brainstorming` auf. Voranstellen vor dem ersten Brainstorming-
 
 Ergebnis: Spec in `docs/superpowers/specs/<date>-<slug>-design.md`.
 
+### Schritt 3.5: Playwright-Projekt-Gate (falls neue E2E-Specs geplant)
+
+Falls das Feature neue Playwright-Spec-Dateien umfasst, **muss** die Spec (und der daraus entstehende Plan) für jede neue Datei explizit angeben:
+
+1. **Dateiname** (z.B. `sa-15-cross-cluster-health.spec.ts`)
+2. **Playwright-Projekt(e)**, zu dem die Datei gehört (Mehrfachnennung möglich!)
+3. **Endpunkte / Routen**: aus dem Quellcode ableiten, nie annehmen
+
+**Projekt-Zuweisung (aus `tests/e2e/playwright.config.ts`):**
+
+| Spec-Typ | Playwright-Projekt | Begründung |
+|---|---|---|
+| Nicht-auth SA-*/NFA-*/cross-cluster/arena-DB | `services` | Kein Login nötig; kein `storageState` |
+| Authentifizierte FA-* (mentolder Login) | `mentolder` | Braucht `storageState: .auth/mentolder-website-admin.json` |
+| Authentifizierte FA-* (Website-Flows) | `website` | Braucht Login-Setup-Dependency |
+| Korczewski-spezifische Tests | `korczewski` | Eigene Auth-State + Korczewski-Domain |
+| Kombiniert (z.B. Cross-Cluster ohne Auth) | `services` **und** ggf. `korczewski` | Immer beide Projekte explizit nennen |
+
+**Endpunkte aus Source ableiten (Pflicht):**
+```bash
+# Beispiel: Arena health route verifizieren bevor in Spec schreiben
+grep -n "r\.\(get\|post\|put\)(" arena-server/src/http/routes.ts | head -20
+```
+Niemals Endpfad annehmen (z.B. `/health`) ohne im Quellcode verifiziert zu haben (z.B. tatsächlich `/healthz`). Test schlägt sonst mit 404 fehl und erzeugt unnötige Fix-Tickets.
+
 ### Schritt 4: Plan schreiben
 
 Rufe `superpowers:writing-plans` auf. Führe danach sofort aus:


### PR DESCRIPTION
## Summary

- **dev-flow-plan**: New Schritt 3.5 gate — when a plan includes new E2E spec files, the spec must explicitly list which Playwright project(s) each file belongs to and must verify endpoint paths from source code. Prevents "No tests found" (wrong project assignment) and 404-on-first-run (assumed endpoints like `/health` vs actual `/healthz`).
- **dev-flow-execute**: Added note that `tsc` inside a worktree must use `tsc --project <abs-path>` because `tests/e2e/` has no `node_modules` in worktrees.

Closes T000209, T000210.

## Test plan
- [ ] Skill files parse correctly (no broken markdown)
- [ ] Future E2E plans reference Playwright project table

🤖 Generated with [Claude Code](https://claude.com/claude-code)