### PR TITLE
fix(db): close three test-data purge gaps — meetings, templates, billing auth [T000213]

### DIFF
--- a/scripts/one-shot/purge-fn-v4.sql
+++ b/scripts/one-shot/purge-fn-v4.sql
@@ -1,0 +1,341 @@
+-- 2026-05-24 — Migration: tickets.fn_purge_test_data() v4.
+--
+-- Closes three gaps identified in T000213:
+--
+--   Gap 1: meetings rows from booking-flow seeds never swept — meeting_type
+--           LIKE '[TEST]%' rows survive until the hourly CronJob, and also
+--           block the customer allowlist sweep (step 12) via FK guard.
+--           Fix: delete meetings WHERE meeting_type LIKE '[TEST]%' before
+--           the customers sweep.
+--
+--   Gap 2: questionnaire_templates created by fa-fragebogen.spec.ts (titles
+--           'e2e-*') leak permanently if the spec crashes before afterAll.
+--           Fix: delete questionnaire_templates WHERE title LIKE 'e2e-%' as
+--           a new step before questionnaire_assignments (cascade safety).
+--
+-- Note on Gap 3 (billing purge CRON_SECRET): handled in purge.ts, not here.
+--
+-- Ordering rationale:
+--   • questionnaire_templates sweep (new 6b) → before assignments (7) so
+--     any FK from assignment→template is already gone.
+--   • meetings sweep (new 11d) → before customers sweep (12) to unblock
+--     the NOT EXISTS guard on meetings.customer_id.
+--
+-- All other steps are identical to v3.
+
+\set ON_ERROR_STOP on
+BEGIN;
+
+CREATE OR REPLACE FUNCTION tickets.fn_purge_test_data()
+  RETURNS JSONB
+  LANGUAGE plpgsql
+  SECURITY DEFINER
+  SET search_path = public, tickets
+AS $$
+DECLARE
+  result            JSONB := '{}'::jsonb;
+  cnt               INT;
+  has_scores        BOOLEAN;
+  has_answers       BOOLEAN;
+  has_test_results  BOOLEAN;
+  has_test_runs     BOOLEAN;
+  has_pw_reports    BOOLEAN;
+  has_billing_inv   BOOLEAN;
+  has_src_assn_col  BOOLEAN;
+  has_meetings      BOOLEAN;
+  has_qts_evidence  BOOLEAN;
+  has_inbox_flag    BOOLEAN;
+  has_thread_flag   BOOLEAN;
+  has_messages_flag BOOLEAN;
+  keep_emails       TEXT[] := ARRAY[
+                       'patrick@korczewski.de',
+                       'p.korczewski@gmail.com',
+                       'quamain@web.de'
+                     ];
+BEGIN
+  -- Probe optional tables / columns.
+  SELECT EXISTS(SELECT 1 FROM information_schema.tables
+                 WHERE table_schema='public' AND table_name='questionnaire_assignment_scores')
+    INTO has_scores;
+  SELECT EXISTS(SELECT 1 FROM information_schema.tables
+                 WHERE table_schema='public' AND table_name='questionnaire_answers')
+    INTO has_answers;
+  SELECT EXISTS(SELECT 1 FROM information_schema.tables
+                 WHERE table_schema='public' AND table_name='test_results')
+    INTO has_test_results;
+  SELECT EXISTS(SELECT 1 FROM information_schema.tables
+                 WHERE table_schema='public' AND table_name='test_runs')
+    INTO has_test_runs;
+  SELECT EXISTS(SELECT 1 FROM information_schema.tables
+                 WHERE table_schema='public' AND table_name='playwright_reports')
+    INTO has_pw_reports;
+  SELECT EXISTS(SELECT 1 FROM information_schema.tables
+                 WHERE table_schema='public' AND table_name='billing_invoices')
+    INTO has_billing_inv;
+  SELECT EXISTS(SELECT 1 FROM information_schema.tables
+                 WHERE table_schema='public' AND table_name='meetings')
+    INTO has_meetings;
+  SELECT EXISTS(SELECT 1 FROM information_schema.columns
+                 WHERE table_schema='tickets'
+                   AND table_name='tickets'
+                   AND column_name='source_test_assignment_id')
+    INTO has_src_assn_col;
+  SELECT EXISTS(SELECT 1 FROM information_schema.columns
+                 WHERE table_schema='public'
+                   AND table_name='questionnaire_test_status'
+                   AND column_name='evidence_id')
+    INTO has_qts_evidence;
+  SELECT EXISTS(SELECT 1 FROM information_schema.columns
+                 WHERE table_schema='public'
+                   AND table_name='inbox_items'
+                   AND column_name='is_test_data')
+    INTO has_inbox_flag;
+  SELECT EXISTS(SELECT 1 FROM information_schema.columns
+                 WHERE table_schema='public'
+                   AND table_name='message_threads'
+                   AND column_name='is_test_data')
+    INTO has_thread_flag;
+  SELECT EXISTS(SELECT 1 FROM information_schema.columns
+                 WHERE table_schema='public'
+                   AND table_name='messages'
+                   AND column_name='is_test_data')
+    INTO has_messages_flag;
+
+  ----------------------------------------------------------------------------
+  -- 1) Clear FK from questionnaire_test_status to test-data tickets.
+  ----------------------------------------------------------------------------
+  UPDATE questionnaire_test_status
+     SET last_failure_ticket_id = NULL
+   WHERE last_failure_ticket_id IN (
+           SELECT id FROM tickets.tickets WHERE is_test_data = true
+         );
+  GET DIAGNOSTICS cnt = ROW_COUNT;
+  result := result || jsonb_build_object('questionnaire_test_status_cleared', cnt);
+
+  ----------------------------------------------------------------------------
+  -- 2) Null out tickets.source_test_assignment_id refs to test assignments.
+  ----------------------------------------------------------------------------
+  IF has_src_assn_col THEN
+    UPDATE tickets.tickets
+       SET source_test_assignment_id = NULL
+     WHERE source_test_assignment_id IN (
+             SELECT id FROM questionnaire_assignments WHERE is_test_data = true
+           );
+    GET DIAGNOSTICS cnt = ROW_COUNT;
+    result := result || jsonb_build_object('tickets_assignment_ref_cleared', cnt);
+  END IF;
+
+  ----------------------------------------------------------------------------
+  -- 3a) NULL out questionnaire_test_status.evidence_id refs we're about to
+  --     delete.
+  ----------------------------------------------------------------------------
+  IF has_qts_evidence THEN
+    UPDATE questionnaire_test_status
+       SET evidence_id = NULL
+     WHERE evidence_id IN (
+             SELECT id FROM questionnaire_test_evidence
+              WHERE assignment_id IN (
+                      SELECT id FROM questionnaire_assignments WHERE is_test_data = true
+                    )
+           );
+    GET DIAGNOSTICS cnt = ROW_COUNT;
+    result := result || jsonb_build_object('questionnaire_test_status_evidence_cleared', cnt);
+  END IF;
+
+  ----------------------------------------------------------------------------
+  -- 3b) Delete questionnaire_test_evidence for test-data assignments.
+  ----------------------------------------------------------------------------
+  DELETE FROM questionnaire_test_evidence
+   WHERE assignment_id IN (
+           SELECT id FROM questionnaire_assignments WHERE is_test_data = true
+         );
+  GET DIAGNOSTICS cnt = ROW_COUNT;
+  result := result || jsonb_build_object('questionnaire_test_evidence', cnt);
+
+  ----------------------------------------------------------------------------
+  -- 4) Delete questionnaire_test_fixtures for test-data assignments.
+  ----------------------------------------------------------------------------
+  DELETE FROM questionnaire_test_fixtures
+   WHERE assignment_id IN (
+           SELECT id FROM questionnaire_assignments WHERE is_test_data = true
+         );
+  GET DIAGNOSTICS cnt = ROW_COUNT;
+  result := result || jsonb_build_object('questionnaire_test_fixtures', cnt);
+
+  ----------------------------------------------------------------------------
+  -- 5) Delete questionnaire_assignment_scores (if table present).
+  ----------------------------------------------------------------------------
+  IF has_scores THEN
+    DELETE FROM questionnaire_assignment_scores
+     WHERE assignment_id IN (
+             SELECT id FROM questionnaire_assignments WHERE is_test_data = true
+           );
+    GET DIAGNOSTICS cnt = ROW_COUNT;
+    result := result || jsonb_build_object('questionnaire_assignment_scores', cnt);
+  END IF;
+
+  ----------------------------------------------------------------------------
+  -- 6) Delete questionnaire_answers (if table present).
+  ----------------------------------------------------------------------------
+  IF has_answers THEN
+    DELETE FROM questionnaire_answers
+     WHERE assignment_id IN (
+             SELECT id FROM questionnaire_assignments WHERE is_test_data = true
+           );
+    GET DIAGNOSTICS cnt = ROW_COUNT;
+    result := result || jsonb_build_object('questionnaire_answers', cnt);
+  END IF;
+
+  ----------------------------------------------------------------------------
+  -- 6b) ── questionnaire_templates sweep (NEW in v4 / Gap 2). ───────────────
+  --     fa-fragebogen.spec.ts INSERTs templates with title 'e2e-*' and
+  --     deletes them in afterAll — but a crash leaves them permanently.
+  --     Sweep here, before assignments (7), so any FK from assignment →
+  --     template is already resolved.
+  ----------------------------------------------------------------------------
+  DELETE FROM questionnaire_templates WHERE title LIKE 'e2e-%';
+  GET DIAGNOSTICS cnt = ROW_COUNT;
+  result := result || jsonb_build_object('questionnaire_templates', cnt);
+
+  ----------------------------------------------------------------------------
+  -- 7) Delete the test-data assignments themselves.
+  ----------------------------------------------------------------------------
+  DELETE FROM questionnaire_assignments WHERE is_test_data = true;
+  GET DIAGNOSTICS cnt = ROW_COUNT;
+  result := result || jsonb_build_object('questionnaire_assignments', cnt);
+
+  ----------------------------------------------------------------------------
+  -- 8) Drain transient systemtest plumbing.
+  ----------------------------------------------------------------------------
+  DELETE FROM systemtest_failure_outbox;
+  GET DIAGNOSTICS cnt = ROW_COUNT;
+  result := result || jsonb_build_object('systemtest_failure_outbox', cnt);
+
+  DELETE FROM systemtest_magic_tokens;
+  GET DIAGNOSTICS cnt = ROW_COUNT;
+  result := result || jsonb_build_object('systemtest_magic_tokens', cnt);
+
+  ----------------------------------------------------------------------------
+  -- 9) Optional reporting / run-history tables.
+  ----------------------------------------------------------------------------
+  IF has_pw_reports THEN
+    DELETE FROM playwright_reports;
+    GET DIAGNOSTICS cnt = ROW_COUNT;
+    result := result || jsonb_build_object('playwright_reports', cnt);
+  END IF;
+
+  IF has_test_results THEN
+    DELETE FROM test_results;
+    GET DIAGNOSTICS cnt = ROW_COUNT;
+    result := result || jsonb_build_object('test_results', cnt);
+  END IF;
+  IF has_test_runs THEN
+    DELETE FROM test_runs;
+    GET DIAGNOSTICS cnt = ROW_COUNT;
+    result := result || jsonb_build_object('test_runs', cnt);
+  END IF;
+
+  ----------------------------------------------------------------------------
+  -- 10) Delete child test-data tickets (non-project).
+  ----------------------------------------------------------------------------
+  DELETE FROM tickets.tickets
+   WHERE is_test_data = true
+     AND type <> 'project';
+  GET DIAGNOSTICS cnt = ROW_COUNT;
+  result := result || jsonb_build_object('tickets_children', cnt);
+
+  ----------------------------------------------------------------------------
+  -- 11) Delete project (epic) test-data tickets last.
+  ----------------------------------------------------------------------------
+  DELETE FROM tickets.tickets
+   WHERE is_test_data = true
+     AND type = 'project';
+  GET DIAGNOSTICS cnt = ROW_COUNT;
+  result := result || jsonb_build_object('tickets_projects', cnt);
+
+  ----------------------------------------------------------------------------
+  -- 11b) Messaging sweeps.
+  --     Order: messages → message_threads → inbox_items.
+  ----------------------------------------------------------------------------
+  IF has_messages_flag THEN
+    DELETE FROM messages WHERE is_test_data = true;
+    GET DIAGNOSTICS cnt = ROW_COUNT;
+    result := result || jsonb_build_object('messages', cnt);
+  END IF;
+
+  IF has_thread_flag THEN
+    DELETE FROM message_threads WHERE is_test_data = true;
+    GET DIAGNOSTICS cnt = ROW_COUNT;
+    result := result || jsonb_build_object('message_threads', cnt);
+  END IF;
+
+  IF has_inbox_flag THEN
+    DELETE FROM inbox_items WHERE is_test_data = true;
+    GET DIAGNOSTICS cnt = ROW_COUNT;
+    result := result || jsonb_build_object('inbox_items', cnt);
+  END IF;
+
+  ----------------------------------------------------------------------------
+  -- 11c) Knowledge Collections test data sweep.
+  ----------------------------------------------------------------------------
+  DELETE FROM knowledge.collections WHERE name LIKE 'e2e-crawl-%' OR name LIKE 'e2e-webcrawl-%' OR name LIKE 'e2e-%';
+  GET DIAGNOSTICS cnt = ROW_COUNT;
+  result := result || jsonb_build_object('knowledge_collections', cnt);
+
+  ----------------------------------------------------------------------------
+  -- 11d) ── Meetings sweep (NEW in v4 / Gap 1). ─────────────────────────────
+  --     booking-flow.ts seeds meetings with meeting_type '[TEST] systemtest-
+  --     booking'. These are tracked as fixtures but NOT deleted by the bracket
+  --     because fn_purge_test_data had no meetings step — only the hourly
+  --     CronJob could reach them. Meanwhile the customer allowlist sweep
+  --     (step 12) guards with NOT EXISTS (meetings WHERE customer_id = c.id),
+  --     so test customers also leaked.
+  --     Fix: sweep meetings by meeting_type LIKE '[TEST]%' before customers.
+  ----------------------------------------------------------------------------
+  IF has_meetings THEN
+    DELETE FROM meetings WHERE meeting_type LIKE '[TEST]%';
+    GET DIAGNOSTICS cnt = ROW_COUNT;
+    result := result || jsonb_build_object('meetings', cnt);
+  END IF;
+
+  ----------------------------------------------------------------------------
+  -- 12) Customer allowlist sweep.
+  ----------------------------------------------------------------------------
+  DELETE FROM customers c
+   WHERE c.email <> ALL (keep_emails)
+     AND NOT EXISTS (
+           SELECT 1 FROM meetings m WHERE m.customer_id = c.id
+         )
+     AND (
+           NOT has_billing_inv
+           OR NOT EXISTS (
+                SELECT 1 FROM billing_invoices bi
+                 WHERE bi.customer_id = c.id::text
+              )
+         )
+     AND NOT EXISTS (SELECT 1 FROM chat_room_members      WHERE customer_id        = c.id)
+     AND NOT EXISTS (SELECT 1 FROM chat_messages          WHERE sender_customer_id = c.id)
+     AND NOT EXISTS (SELECT 1 FROM chat_message_reads     WHERE customer_id        = c.id)
+     AND NOT EXISTS (SELECT 1 FROM chat_rooms             WHERE direct_customer_id = c.id)
+     AND NOT EXISTS (SELECT 1 FROM document_assignments   WHERE customer_id        = c.id)
+     AND NOT EXISTS (SELECT 1 FROM message_threads        WHERE customer_id        = c.id)
+     AND NOT EXISTS (SELECT 1 FROM messages               WHERE sender_customer_id = c.id)
+     AND NOT EXISTS (SELECT 1 FROM brett_snapshots        WHERE customer_id        = c.id)
+     AND NOT EXISTS (SELECT 1 FROM questionnaire_assignments WHERE customer_id     = c.id)
+     AND NOT EXISTS (SELECT 1 FROM tickets.tickets        WHERE customer_id        = c.id);
+  GET DIAGNOSTICS cnt = ROW_COUNT;
+  result := result || jsonb_build_object('customers', cnt);
+
+  RETURN result;
+END;
+$$;
+
+COMMENT ON FUNCTION tickets.fn_purge_test_data() IS
+  'Idempotent test-data purge. v4 (2026-05-24) adds: meetings sweep '
+  '(meeting_type LIKE ''[TEST]%'') before the customer allowlist sweep, '
+  'and questionnaire_templates sweep (title LIKE ''e2e-%'') before '
+  'questionnaire_assignments. Closes T000213 gaps 1 and 2.';
+
+GRANT EXECUTE ON FUNCTION tickets.fn_purge_test_data() TO website;
+
+COMMIT;

--- a/tests/unit/purge-fn-gaps.bats
+++ b/tests/unit/purge-fn-gaps.bats
@@ -1,0 +1,72 @@
+#!/usr/bin/env bats
+# ═══════════════════════════════════════════════════════════════════
+# purge-fn-gaps.bats — Static regression tests for the three gaps
+#   identified in the test-data purge pipeline (T000213):
+#
+#   Gap 1: meetings leak from booking-flow seeds
+#   Gap 2: questionnaire_templates leak from fa-fragebogen
+#   Gap 3: /api/admin/testdata/purge.ts lacks CRON_SECRET auth
+#
+# Runs entirely offline — no database required.
+# ═══════════════════════════════════════════════════════════════════
+
+load test_helper
+
+PROJECT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+
+# ── Gap 1: meetings sweep ─────────────────────────────────────────
+
+@test "gap1: latest purge-fn migration sweeps meetings with [TEST]% meeting_type before customers" {
+  local latest
+  latest=$(ls -1 "$PROJECT_DIR/scripts/one-shot/"purge-fn-v*.sql 2>/dev/null | sort -V | tail -1)
+  [ -n "$latest" ] || fail "no purge-fn-v*.sql found in scripts/one-shot/"
+  grep -q "meeting_type LIKE '\[TEST\]%'" "$latest"
+}
+
+@test "gap1: meetings sweep appears before customer allowlist sweep in purge function" {
+  local latest
+  latest=$(ls -1 "$PROJECT_DIR/scripts/one-shot/"purge-fn-v*.sql 2>/dev/null | sort -V | tail -1)
+  [ -n "$latest" ] || fail "no purge-fn-v*.sql found"
+  local meetings_line customers_line
+  meetings_line=$(grep -n "meeting_type LIKE" "$latest" | head -1 | cut -d: -f1)
+  customers_line=$(grep -n "Customer allowlist sweep\|DELETE FROM customers" "$latest" | head -1 | cut -d: -f1)
+  [ -n "$meetings_line" ] || fail "meetings sweep line not found"
+  [ -n "$customers_line" ] || fail "customers sweep line not found"
+  [ "$meetings_line" -lt "$customers_line" ]
+}
+
+# ── Gap 2: questionnaire_templates sweep ──────────────────────────
+
+@test "gap2: latest purge-fn migration sweeps questionnaire_templates with e2e-% title" {
+  local latest
+  latest=$(ls -1 "$PROJECT_DIR/scripts/one-shot/"purge-fn-v*.sql 2>/dev/null | sort -V | tail -1)
+  [ -n "$latest" ] || fail "no purge-fn-v*.sql found"
+  grep -q "questionnaire_templates" "$latest"
+  grep -q "title LIKE 'e2e-%" "$latest"
+}
+
+@test "gap2: questionnaire_templates sweep appears before questionnaire_assignments step" {
+  local latest
+  latest=$(ls -1 "$PROJECT_DIR/scripts/one-shot/"purge-fn-v*.sql 2>/dev/null | sort -V | tail -1)
+  [ -n "$latest" ] || fail "no purge-fn-v*.sql found"
+  local templates_line assignments_line
+  templates_line=$(grep -n "DELETE FROM questionnaire_templates" "$latest" | head -1 | cut -d: -f1)
+  assignments_line=$(grep -n "DELETE FROM questionnaire_assignments WHERE is_test_data" "$latest" | head -1 | cut -d: -f1)
+  [ -n "$templates_line" ] || fail "questionnaire_templates sweep not found"
+  [ -n "$assignments_line" ] || fail "questionnaire_assignments sweep not found"
+  [ "$templates_line" -lt "$assignments_line" ]
+}
+
+# ── Gap 3: CRON_SECRET auth in purge.ts ───────────────────────────
+
+@test "gap3: /api/admin/testdata/purge.ts accepts X-Cron-Secret auth" {
+  local f="$PROJECT_DIR/website/src/pages/api/admin/testdata/purge.ts"
+  [ -f "$f" ] || fail "purge.ts not found"
+  grep -q "X-Cron-Secret" "$f"
+}
+
+@test "gap3: purge.ts CRON_SECRET check mirrors pattern from purge-all-test-data.ts" {
+  local f="$PROJECT_DIR/website/src/pages/api/admin/testdata/purge.ts"
+  [ -f "$f" ] || fail "purge.ts not found"
+  grep -q "CRON_SECRET" "$f"
+}

--- a/website/src/pages/api/admin/testdata/purge.ts
+++ b/website/src/pages/api/admin/testdata/purge.ts
@@ -9,8 +9,10 @@ function jsonError(msg: string, status: number) {
 }
 
 export const DELETE: APIRoute = async ({ request }) => {
+  const cronSecret = request.headers.get('X-Cron-Secret');
+  const isCron = !!cronSecret && cronSecret === process.env.CRON_SECRET;
   const session = await getSession(request.headers.get('cookie'));
-  if (!session || !isAdmin(session)) return jsonError('Nicht autorisiert', 401);
+  if (!isCron && (!session || !isAdmin(session))) return jsonError('Nicht autorisiert', 401);
 
   try {
     const client = await pool.connect();


### PR DESCRIPTION
## Summary

- **Gap 1**: `fn_purge_test_data` v4 adds a meetings sweep (`meeting_type LIKE '[TEST]%'`) before the customer allowlist check (step 12) — booking-flow seeds tracked meetings via fixtures but the bracket never deleted them, which also blocked orphan-customer cleanup via FK guard
- **Gap 2**: `fn_purge_test_data` v4 adds a `questionnaire_templates` sweep (`title LIKE 'e2e-%'`) before assignments (step 7) — `fa-fragebogen.spec.ts` relied on `afterAll` cleanup that wouldn't run on crash
- **Gap 3**: `/api/admin/testdata/purge.ts` now accepts `X-Cron-Secret` auth alongside admin sessions, matching the pattern in `purge-all-test-data.ts` and `cleanup-fixtures.ts` — billing cleanup is now callable from the bracket

## Migration

`scripts/one-shot/purge-fn-v4.sql` applied to both clusters immediately (mentolder + korczewski). Function comment confirms v4.

## Test plan

- [x] 6 new static BATS tests in `tests/unit/purge-fn-gaps.bats` — all green
- [x] Full unit test suite (`npx bats tests/unit/`) — no new failures
- [x] Function comment on both clusters confirms v4 applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)