### PR TITLE
fix(e2e): ENV in log dir + broaden selfpatch trivial classifier [T000232]

### DIFF
--- a/scripts/e2e-skill-selfpatch.sh
+++ b/scripts/e2e-skill-selfpatch.sh
@@ -28,7 +28,7 @@ _psql() {
 }
 
 _is_trivial() {
-  echo "$1" | grep -qiE 'command|flag|example|typo|wrong.*path|missing.*step|exit.?code|add.*check'
+  echo "$1" | grep -qiE 'command|flag|example|typo|wrong.*path|missing.*step|exit.?code|add.*check|directory|collision|env.*var|variable|export|propagat|not.*read|never.*read|fix:|include|rename'
 }
 
 case "${1:-}" in

--- a/scripts/systemtest-fanout.sh
+++ b/scripts/systemtest-fanout.sh
@@ -53,7 +53,7 @@ fi
 
 E2E_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/tests/e2e"
 TS="$(date +%Y%m%d-%H%M%S)"
-LOG_DIR="$E2E_DIR/results/systemtest-cycle-$CYCLE-$TS"
+LOG_DIR="$E2E_DIR/results/systemtest-cycle-$CYCLE-$ENVIRONMENT-$TS"
 mkdir -p "$LOG_DIR"
 
 echo "==> Fanning out 3 Playwright sessions for cycle $CYCLE against $WEBSITE_URL"


### PR DESCRIPTION
## Summary
- **`scripts/systemtest-fanout.sh`**: append `$ENVIRONMENT` to log directory name (`systemtest-cycle-$CYCLE-$ENV-$TS`) to prevent path collision when mentolder and korczewski cycle-1 start within the same clock second (T000232)
- **`scripts/e2e-skill-selfpatch.sh`**: extend `_is_trivial()` regex to recognise natural-language keywords (`directory`, `collision`, `env var`, `propagat`, `fix:`, `include`, `rename`) so process tickets written in plain English get auto-classified for the self-patch loop

## Test plan
- [ ] `bash scripts/systemtest-fanout.sh --list-trivial` (smoke) — no error
- [ ] Run `task systemtest:all:headed:both-prods` — verify separate log dirs per cluster per cycle
- [ ] T000232 + T000233 self-patch loop picks up tickets on next cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)