### PR TITLE
chore(arena): remove mentolder-only brand gate from admin page

### DIFF
--- a/website/src/pages/admin/arena.astro
+++ b/website/src/pages/admin/arena.astro
@@ -5,14 +5,14 @@ import { getSession, getLoginUrl } from '../../lib/auth';
 const user = await getSession(Astro.request.headers.get('cookie'));
 if (!user) return Astro.redirect(getLoginUrl(Astro.url.pathname));
 
-const isAdmin = (user.realmRoles ?? []).includes('arena_admin') && user.brand === 'mentolder';
+const isAdmin = (user.realmRoles ?? []).includes('arena_admin');
 ---
 
 <AdminLayout title="Arena">
   <section class="arena-admin">
     <h1>Arena · admin</h1>
     {!isAdmin ? (
-      <p class="warn">This page requires the <code>arena_admin</code> realm role on the mentolder Keycloak realm.</p>
+      <p class="warn">This page requires the <code>arena_admin</code> realm role.</p>
     ) : (
       <>
         <div class="actions">


### PR DESCRIPTION
## Summary
- Removes `&& user.brand === 'mentolder'` from the `isAdmin` check in `website/src/pages/admin/arena.astro`
- The `arena_admin` realm role is the correct and sufficient gate — the brand check was redundant and blocked korczewski admins
- Updated the error message to no longer reference mentolder specifically

## Test plan
- `task test:all` passes
- Admin with `arena_admin` role on korczewski realm can now access `/admin/arena` on korczewski