### PR TITLE
chore(task-oracle): switch Hermes to Qwen3-4B-Instruct-2507 via LM Studio

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,7 @@ bash scripts/task-oracle.sh 'run all offline tests'
 bash scripts/task-oracle.sh 'create a fresh k3d cluster'
 ```
 
-Routes to Hermes (local `qwen3-coder:30b-a3b-q4_K_M`, free) → OpenClaw `task-runner` agent (Claude fallback) → error with `task --list` hint.
+Routes to Hermes (local `qwen/qwen3-4b-2507` via LM Studio at `100.102.71.114:1234`, free) → OpenClaw `task-runner` agent (Claude fallback) → error with `task --list` hint.
 
 ## Architecture
 

--- a/scripts/task-oracle.sh
+++ b/scripts/task-oracle.sh
@@ -5,7 +5,8 @@ set -euo pipefail
 
 GOAL="${*:?Usage: task-oracle.sh '<goal>'}"
 REPO="/home/patrick/Bachelorprojekt"
-MODEL="qwen3-14b"
+MODEL="qwen/qwen3-4b-2507"
+HERMES="${HERMES:-$HOME/.local/bin/hermes}"
 
 # ── Infer target environment from goal keywords ───────────────────────────
 infer_env() {
@@ -21,12 +22,12 @@ infer_env() {
 
 # ── Wrapper: call Hermes, strip session_id noise ──────────────────────────
 ask_hermes() {
-  hermes chat -q "$1" -m "${MODEL}" --quiet 2>/dev/null \
+  "${HERMES}" chat -q "$1" -m "${MODEL}" --quiet 2>/dev/null \
     | grep -v "^session_id:" || true
 }
 
 # ── Primary: Hermes (local model, no API cost) ────────────────────────────
-if hermes status 2>/dev/null | grep -q "Model:"; then
+if [[ -x "${HERMES}" ]] && "${HERMES}" status 2>/dev/null | grep -q "Model:"; then
 
   # Full task list — no truncation
   set +o pipefail


### PR DESCRIPTION
## Summary

- Switches the task-oracle's Hermes model from `qwen3-14b` to `qwen/qwen3-4b-2507` — the Qwen3-4B-Instruct-2507 Q4_K_M GGUF downloaded to LM Studio (~2.4 GB, full GPU offload on RTX 5070 Ti)
- Fixes hermes PATH lookup: script now resolves the binary via `$HERMES` (`$HOME/.local/bin/hermes`) instead of relying on `hermes` being in the non-interactive shell's PATH, which caused silent fallthrough to the OpenClaw fallback
- Updates CLAUDE.md to document the new model and endpoint

## What changed

| File | Change |
|------|--------|
| `scripts/task-oracle.sh` | `MODEL` → `qwen/qwen3-4b-2507`, add `HERMES` path var, use `[[ -x ]]` guard |
| `CLAUDE.md` | Update task-oracle model reference |

## Why

The 4B model is ~4× faster than the 14B for the simple namespace/task-routing prompts the oracle sends (all fit in <4K tokens). LM Studio already served as the backend via `100.102.71.114:1234` — this just swaps in the lighter model and fixes the PATH issue that was silently bypassing Hermes entirely.

## Test plan

- [x] `hermes status` shows `qwen/qwen3-4b-2507` as active model
- [x] `bash scripts/task-oracle.sh 'show pod status for mentolder'` → correctly routes to `workspace:status` and executes
- [ ] CI offline tests (`task test:all`) — no manifest changes, should pass unchanged

🤖 Generated with [Claude Code](https://claude.ai/claude-code)