### PR TITLE
fix(ci): raise commitlint header-max-length to 150, surface kustomize errors

### DIFF
--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -1,1 +1,8 @@
-module.exports = { extends: ['@commitlint/config-conventional'] };
+module.exports = {
+  extends: ['@commitlint/config-conventional'],
+  rules: {
+    // dev-flow commits append ticket refs like [T000235,T000236,T000237] which
+    // can push a descriptive subject past the default 100-char limit.
+    'header-max-length': [2, 'always', 150],
+  },
+};

--- a/tests/unit/manifests.bats
+++ b/tests/unit/manifests.bats
@@ -40,7 +40,11 @@ YAML
   # expand them here with dev defaults so host/image assertions still
   # see literal strings.
   export RENDERED="${BATS_FILE_TMPDIR}/rendered.yaml"
-  kubectl kustomize "${MANIFESTS_DIR}" --load-restrictor=LoadRestrictionsNone > "$RENDERED" 2>&1
+  if ! kubectl kustomize "${MANIFESTS_DIR}" --load-restrictor=LoadRestrictionsNone > "$RENDERED" 2>&1; then
+    echo "kubectl kustomize failed — output:" >&2
+    cat "$RENDERED" >&2
+    return 1
+  fi
   printf '\n---\n' >> "$RENDERED"
   (
     export PROD_DOMAIN=localhost


### PR DESCRIPTION
## Root cause

Two recurring CI failure patterns found over the last 100 runs (16% failure rate overall):

### 1. Conventional Commits lint (recurring — now fixed)

`header-max-length` was set to the default **100 chars** from `@commitlint/config-conventional`. The dev-flow skill consistently appends ticket refs like `[T000235,T000236,T000237]` (up to 26 chars) to the commit subject. Combined with a descriptive scope, this reliably pushes subjects past 100 chars.

Examples that failed:
- `fix(skills/dev-flow-e2e): fix Playwright run dir, SKIP_DB_PURGE, korczewski creds [T000235,T000236,T000237]` — 107 chars
- `fix(systemtest+openclaw): korczewski auth, SKIP_DB_PURGE export, openclaw fallback [T000231,T000233,T000216]` — 108 chars

**Fix:** Override `header-max-length` to **150** in `commitlint.config.cjs`.

### 2. `test:manifests` kustomize failures (historical — already fixed in #1018)

`kubectl kustomize` was failing because `docs-content/*.md` files referenced in the configMapGenerator no longer existed. Those references were removed in #1018. Not recurring.

**Improvement:** `manifests.bats` `setup_file` was swallowing the kustomize error into `$RENDERED` silently. Future kustomize failures will now print the error to stderr immediately.

## Test plan

- [ ] Conventional Commits CI job passes on this PR (commit subject is 75 chars — well within new 150 limit)
- [ ] Offline Tests job passes (manifests.bats change is defensive only, no logic change when kustomize succeeds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)