### PR TITLE
feat(brett): separate coaching from mayhem; remove fill-bots

### DIFF
--- a/brett/public/assets/main.js
+++ b/brett/public/assets/main.js
@@ -17,5 +17,17 @@ window.__brettWs = ws;
 
 const modeState = createModeState();
 
-// Show mode selector on load
-showModeSelect(modeState);
+const cfg = await fetch('/api/config')
+  .then(r => r.json())
+  .catch(() => ({ defaultMode: 'coaching', availableModes: ['coaching'] }));
+
+// Remove Mayhem toolbar button when Mayhem is not available on this cluster
+if (!cfg.availableModes.includes('mayhem')) {
+  document.getElementById('mayhem-btn')?.remove();
+}
+
+const chosen = await showModeSelect(modeState, cfg);
+if (chosen === 'mayhem') {
+  // Mayhem boot is idempotent — main.js owns enabling it post-select
+  window.Mayhem?.setEnabled(true);
+}

--- a/brett/public/assets/mayhem/mayhem.js
+++ b/brett/public/assets/mayhem/mayhem.js
@@ -215,36 +215,6 @@ const Mayhem = (() => {
     chaseCam.attach(localAvatar.mannequin.root);
     send({ type: 'player_join', playerId, color });
 
-    // Fill remaining slots with AI bots so there are always MAX_PLAYERS combatants
-    const humanCount = remoteAvatars.size + 1; // +1 for local player
-    for (let i = humanCount; i < MAX_PLAYERS; i++) spawnAIBot(i - humanCount);
-  }
-
-  // ── AI Bots ───────────────────────────────────────────────────────────────
-  function spawnAIBot(colorIndex) {
-    if (!window.MayhemAIBot) return; // guard: ai-bot.js not loaded
-    const botId = 'bot-' + crypto.randomUUID();
-    const pos = nextSpawnPoint();
-    const botMannequin = makeMannequin(botId, pos);
-    const bot = new window.MayhemAIBot({
-      id: botId,
-      mannequin: botMannequin,
-      colorIndex,
-      callbacks: {
-        onFire: (weaponDef, originPos, dirVec, shooterId) => {
-          if (projectileMgr) projectileMgr.spawn(weaponDef, originPos, dirVec, shooterId);
-        },
-        onDeath: (id, killerId) => {
-          gameMode?.handleDeath(id, false);
-          if (killerId && killerId !== id) gameMode?.handleKill(killerId);
-          updateHud();
-        },
-        getGameMode: () => gameMode?.mode || 'warmup',
-      },
-    });
-    if (bot.avatar && bot.weaponDef) bot.avatar.setWeapon(bot.weaponDef);
-    aiBots.set(botId, bot);
-    remoteAvatars.set(botId, bot.avatar);
   }
 
   // ── Co-op wave spawning ───────────────────────────────────────────────────
@@ -535,14 +505,6 @@ const Mayhem = (() => {
       case 'player_join':
         if (msg.playerId === playerId) return;
         if (remoteAvatars.has(msg.playerId)) return;
-        // Retire one bot to make room for the real player
-        if (aiBots.size > 0) {
-          const [firstBotId] = aiBots.keys();
-          const firstBot = aiBots.get(firstBotId);
-          aiBots.delete(firstBotId);
-          remoteAvatars.delete(firstBotId);
-          firstBot.remove(scene);
-        }
         { const m = makeMannequin(msg.playerId, { x: 0, z: 0 });
           remoteAvatars.set(msg.playerId,
             new window.MayhemPlayerAvatar({ id: msg.playerId, mannequin: m, local: false, color: msg.color || '#888' })); }

--- a/brett/public/assets/mode-select.mjs
+++ b/brett/public/assets/mode-select.mjs
@@ -1,8 +1,17 @@
 // brett/public/assets/mode-select.mjs
-export function showModeSelect(modeState) {
+export function showModeSelect(modeState, cfg = { defaultMode: 'coaching', availableModes: ['coaching'] }) {
+  const modes = cfg.availableModes || ['coaching'];
+
+  // Single mode → skip overlay, auto-enter
+  if (modes.length === 1) {
+    modeState.setMode(modes[0]);
+    return Promise.resolve(modes[0]);
+  }
+
   return new Promise(resolve => {
     const el = document.createElement('div');
     el.className = 'mode-select-overlay';
+    const isMayhemDefault = cfg.defaultMode === 'mayhem';
     el.innerHTML = `
       <div class="mode-select-card">
         <h2>Wähle deinen Modus</h2>
@@ -10,6 +19,10 @@ export function showModeSelect(modeState) {
           <button class="mode-card" data-mode="coaching">
             <div class="title">Coaching</div>
             <div class="sub">Systemische Aufstellung</div>
+          </button>
+          <button class="mode-card mode-card-mayhem${isMayhemDefault ? ' mode-card-default' : ''}" data-mode="mayhem">
+            <div class="title">🤸 Mayhem${isMayhemDefault ? ' <span class="badge">Standard</span>' : ''}</div>
+            <div class="sub">3D Kampfmodus · Waffen · Fahrzeuge</div>
           </button>
         </div>
       </div>

--- a/brett/public/assets/mode-state.mjs
+++ b/brett/public/assets/mode-state.mjs
@@ -1,5 +1,5 @@
 // brett/public/assets/mode-state.mjs
-const VALID = new Set(['coaching', 'mode-select']);
+const VALID = new Set(['coaching', 'mode-select', 'mayhem']);
 
 export function createModeState({ storage = window.localStorage } = {}) {
   let mode = 'coaching';

--- a/brett/public/assets/style.css
+++ b/brett/public/assets/style.css
@@ -263,3 +263,23 @@
 }
 .respawn-overlay .msg { color: var(--brass-hi); font-size: 18px; margin-bottom: 12px; }
 .respawn-overlay .countdown { color: var(--brass); font-size: 64px; font-weight: 700; }
+
+/* Mode-select Mayhem highlight */
+.mode-card-mayhem {
+  border: 2px solid #e07a3a;
+  box-shadow: 0 0 12px rgba(224, 122, 58, 0.35);
+}
+.mode-card-mayhem.mode-card-default {
+  background: linear-gradient(135deg, rgba(224, 122, 58, 0.12), transparent);
+}
+.mode-card-mayhem .badge {
+  display: inline-block;
+  margin-left: 6px;
+  padding: 1px 6px;
+  font-size: 0.7em;
+  font-weight: 600;
+  color: #1a1a1a;
+  background: #e07a3a;
+  border-radius: 4px;
+  vertical-align: middle;
+}

--- a/brett/public/index.html
+++ b/brett/public/index.html
@@ -1650,5 +1650,6 @@
 <script src="assets/mayhem/mayhem.js"></script>
 <script src="assets/room-browser.js"></script>
 <script src="assets/admin-panel.js"></script>
+<script type="module" src="assets/main.js"></script>
 </body>
 </html>

--- a/brett/server.js
+++ b/brett/server.js
@@ -144,6 +144,16 @@ app.use(express.static('public', {
 
 app.get('/healthz', (_req, res) => res.type('text/plain').send('ok'));
 
+function buildConfig(env) {
+  const mode = env.BRETT_DEFAULT_MODE === 'mayhem' ? 'mayhem' : 'coaching';
+  return {
+    defaultMode: mode,
+    availableModes: mode === 'mayhem' ? ['coaching', 'mayhem'] : ['coaching'],
+  };
+}
+
+app.get('/api/config', (_req, res) => res.json(buildConfig(process.env)));
+
 // ─── Auth (OIDC / Keycloak) ───────────────────────────────────────────────────
 const BRETT_PUBLIC_URL = process.env.BRETT_PUBLIC_URL || 'http://brett.localhost';
 
@@ -829,4 +839,5 @@ module.exports = {
   pickupState, ensurePickups, spawnPickup,
   isAdminFromClaims,
   validateAppearance,
+  buildConfig,
 };

--- a/brett/test/mode-state.test.mjs
+++ b/brett/test/mode-state.test.mjs
@@ -21,3 +21,9 @@ test('invalid modes do not change state', () => {
   assert.equal(result, false);
   assert.equal(ms.current(), 'coaching');
 });
+
+test('setMode("mayhem") is accepted', () => {
+  const state = createModeState({ storage: { getItem: () => null, setItem: () => {} } });
+  assert.strictEqual(state.setMode('mayhem'), true);
+  assert.strictEqual(state.current(), 'mayhem');
+});

--- a/brett/test/server-config.test.js
+++ b/brett/test/server-config.test.js
@@ -1,0 +1,33 @@
+'use strict';
+process.env.MOCK_DB = 'true';
+const test = require('node:test');
+const assert = require('node:assert');
+const { buildConfig } = require('../server.js');
+
+test('buildConfig: defaults to coaching when env var unset', () => {
+  assert.deepStrictEqual(buildConfig({}), {
+    defaultMode: 'coaching',
+    availableModes: ['coaching'],
+  });
+});
+
+test('buildConfig: coaching mode exposes only coaching', () => {
+  assert.deepStrictEqual(buildConfig({ BRETT_DEFAULT_MODE: 'coaching' }), {
+    defaultMode: 'coaching',
+    availableModes: ['coaching'],
+  });
+});
+
+test('buildConfig: mayhem mode exposes both', () => {
+  assert.deepStrictEqual(buildConfig({ BRETT_DEFAULT_MODE: 'mayhem' }), {
+    defaultMode: 'mayhem',
+    availableModes: ['coaching', 'mayhem'],
+  });
+});
+
+test('buildConfig: unknown value falls back to coaching', () => {
+  assert.deepStrictEqual(buildConfig({ BRETT_DEFAULT_MODE: 'bogus' }), {
+    defaultMode: 'coaching',
+    availableModes: ['coaching'],
+  });
+});

--- a/docs/superpowers/plans/2026-05-24-brett-mode-separation.md
+++ b/docs/superpowers/plans/2026-05-24-brett-mode-separation.md
@@ -1,0 +1,606 @@
+---
+domains: [website, infra]
+status: staged
+---
+
+# Brett Mode Separation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Separate Coaching (figure-only) from Mayhem (3D combat) in the Systembrett: remove AI fill-bots, drive mode selection from server config, and default mentolder to coaching-only / korczewski to mayhem via env var.
+
+**Architecture:** Server exposes `GET /api/config` returning `{ defaultMode, availableModes }` derived from a single `BRETT_DEFAULT_MODE` env var. Client fetches config at boot, conditionally renders the mode-select overlay (auto-skips when only one mode is available), and removes the Mayhem toolbar button from the DOM when Mayhem is not in `availableModes`. Per-cluster behavior is configured by a Kustomize JSON Patch in `prod-korczewski/`.
+
+**Tech Stack:** Node.js + Express (server), vanilla ES modules (client), Kustomize (K8s), `node --test` (tests).
+
+**Spec:** [`docs/superpowers/specs/2026-05-24-brett-mode-separation-design.md`](../specs/2026-05-24-brett-mode-separation-design.md)
+
+---
+
+## File Map
+
+| File | Responsibility |
+|---|---|
+| `brett/server.js` | Add `buildConfig(env)` helper + `GET /api/config` route, export helper |
+| `brett/test/server-config.test.js` | Unit-test `buildConfig` for all env-var combinations |
+| `brett/public/assets/mode-state.mjs` | Add `'mayhem'` to VALID set |
+| `brett/test/mode-state.test.mjs` | Add `setMode('mayhem')` assertion |
+| `brett/public/assets/mode-select.mjs` | Accept `cfg`; auto-skip single mode; render two-card UI for multi-mode |
+| `brett/public/assets/main.js` | Fetch `/api/config` (with fallback), pass to `showModeSelect`, hide `#mayhem-btn`, enable Mayhem after select |
+| `brett/public/assets/style.css` | Styles for `.mode-card[data-mode="mayhem"]` highlight + Standard badge |
+| `brett/public/assets/mayhem/mayhem.js` | Remove fill-bot loop, `spawnAIBot()`, bot-retire on join |
+| `k3d/brett.yaml` | Add `BRETT_DEFAULT_MODE: "coaching"` env var (base default) |
+| `prod-korczewski/kustomization.yaml` | JSON Patch overriding `BRETT_DEFAULT_MODE: mayhem` |
+
+---
+
+## Task 1: Server config helper + endpoint
+
+**Files:**
+- Modify: `brett/server.js` (add helper above route block at line ~145; extend `module.exports` at line 824)
+- Create: `brett/test/server-config.test.js`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `brett/test/server-config.test.js`:
+
+```js
+'use strict';
+process.env.MOCK_DB = 'true';
+const test = require('node:test');
+const assert = require('node:assert');
+const { buildConfig } = require('../server.js');
+
+test('buildConfig: defaults to coaching when env var unset', () => {
+  assert.deepStrictEqual(buildConfig({}), {
+    defaultMode: 'coaching',
+    availableModes: ['coaching'],
+  });
+});
+
+test('buildConfig: coaching mode exposes only coaching', () => {
+  assert.deepStrictEqual(buildConfig({ BRETT_DEFAULT_MODE: 'coaching' }), {
+    defaultMode: 'coaching',
+    availableModes: ['coaching'],
+  });
+});
+
+test('buildConfig: mayhem mode exposes both', () => {
+  assert.deepStrictEqual(buildConfig({ BRETT_DEFAULT_MODE: 'mayhem' }), {
+    defaultMode: 'mayhem',
+    availableModes: ['coaching', 'mayhem'],
+  });
+});
+
+test('buildConfig: unknown value falls back to coaching', () => {
+  assert.deepStrictEqual(buildConfig({ BRETT_DEFAULT_MODE: 'bogus' }), {
+    defaultMode: 'coaching',
+    availableModes: ['coaching'],
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd brett && npm test -- --test-name-pattern='buildConfig'
+```
+
+Expected: FAIL — `buildConfig is not a function` (not yet exported).
+
+- [ ] **Step 3: Add `buildConfig` helper + route in `brett/server.js`**
+
+Insert immediately after the `/healthz` route (currently line 145):
+
+```js
+function buildConfig(env) {
+  const mode = env.BRETT_DEFAULT_MODE === 'mayhem' ? 'mayhem' : 'coaching';
+  return {
+    defaultMode: mode,
+    availableModes: mode === 'mayhem' ? ['coaching', 'mayhem'] : ['coaching'],
+  };
+}
+
+app.get('/api/config', (_req, res) => res.json(buildConfig(process.env)));
+```
+
+Then extend the existing `module.exports` block (line 824) to include `buildConfig`:
+
+```js
+module.exports = {
+  app, server, pool, wss,
+  applyMutation, buildStateFromMutations, figureMaps,
+  handleDisconnect,
+  RELAY_TYPES, TRANSIENT_TYPES, lmsAlive, handleLmsDeath,
+  pickupState, ensurePickups, spawnPickup,
+  isAdminFromClaims,
+  validateAppearance,
+  buildConfig,
+};
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+cd brett && npm test -- --test-name-pattern='buildConfig'
+```
+
+Expected: PASS — 4 tests pass.
+
+- [ ] **Step 5: Run full brett test suite to confirm nothing else broke**
+
+```bash
+cd brett && npm test
+```
+
+Expected: All tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add brett/server.js brett/test/server-config.test.js
+git commit -m "feat(brett): add /api/config endpoint driven by BRETT_DEFAULT_MODE"
+```
+
+---
+
+## Task 2: Extend mode-state VALID set
+
+**Files:**
+- Modify: `brett/public/assets/mode-state.mjs:2`
+- Modify: `brett/test/mode-state.test.mjs` (append test)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `brett/test/mode-state.test.mjs`:
+
+```js
+test('setMode("mayhem") is accepted', () => {
+  const state = createModeState({ storage: { getItem: () => null, setItem: () => {} } });
+  assert.strictEqual(state.setMode('mayhem'), true);
+  assert.strictEqual(state.current(), 'mayhem');
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd brett && npm test -- --test-name-pattern='mayhem'
+```
+
+Expected: FAIL — `setMode('mayhem')` returns `false` because `'mayhem'` is not in VALID.
+
+- [ ] **Step 3: Add `'mayhem'` to VALID set in `brett/public/assets/mode-state.mjs`**
+
+Change line 2:
+
+```js
+const VALID = new Set(['coaching', 'mode-select', 'mayhem']);
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+cd brett && npm test -- --test-name-pattern='mayhem'
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add brett/public/assets/mode-state.mjs brett/test/mode-state.test.mjs
+git commit -m "feat(brett): add 'mayhem' to mode-state VALID set"
+```
+
+---
+
+## Task 3: Mode-select overlay — accept config, auto-skip, two-card UI
+
+**Files:**
+- Modify: `brett/public/assets/mode-select.mjs` (full rewrite)
+- Modify: `brett/public/assets/style.css` (append styles)
+
+- [ ] **Step 1: Rewrite `brett/public/assets/mode-select.mjs`**
+
+Replace entire file with:
+
+```js
+// brett/public/assets/mode-select.mjs
+export function showModeSelect(modeState, cfg = { defaultMode: 'coaching', availableModes: ['coaching'] }) {
+  const modes = cfg.availableModes || ['coaching'];
+
+  // Single mode → skip overlay, auto-enter
+  if (modes.length === 1) {
+    modeState.setMode(modes[0]);
+    return Promise.resolve(modes[0]);
+  }
+
+  return new Promise(resolve => {
+    const el = document.createElement('div');
+    el.className = 'mode-select-overlay';
+    const isMayhemDefault = cfg.defaultMode === 'mayhem';
+    el.innerHTML = `
+      <div class="mode-select-card">
+        <h2>Wähle deinen Modus</h2>
+        <div class="mode-grid">
+          <button class="mode-card" data-mode="coaching">
+            <div class="title">Coaching</div>
+            <div class="sub">Systemische Aufstellung</div>
+          </button>
+          <button class="mode-card mode-card-mayhem${isMayhemDefault ? ' mode-card-default' : ''}" data-mode="mayhem">
+            <div class="title">🤸 Mayhem${isMayhemDefault ? ' <span class="badge">Standard</span>' : ''}</div>
+            <div class="sub">3D Kampfmodus · Waffen · Fahrzeuge</div>
+          </button>
+        </div>
+      </div>
+    `;
+    document.body.appendChild(el);
+    el.addEventListener('click', e => {
+      const card = e.target.closest('.mode-card');
+      if (!card || card.disabled) return;
+      const mode = card.dataset.mode;
+      modeState.setMode(mode);
+      el.remove();
+      resolve(mode);
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Append styles to `brett/public/assets/style.css`**
+
+Append at end of file:
+
+```css
+/* Mode-select Mayhem highlight */
+.mode-card-mayhem {
+  border: 2px solid #e07a3a;
+  box-shadow: 0 0 12px rgba(224, 122, 58, 0.35);
+}
+.mode-card-mayhem.mode-card-default {
+  background: linear-gradient(135deg, rgba(224, 122, 58, 0.12), transparent);
+}
+.mode-card-mayhem .badge {
+  display: inline-block;
+  margin-left: 6px;
+  padding: 1px 6px;
+  font-size: 0.7em;
+  font-weight: 600;
+  color: #1a1a1a;
+  background: #e07a3a;
+  border-radius: 4px;
+  vertical-align: middle;
+}
+```
+
+- [ ] **Step 3: Verify no test regressions**
+
+```bash
+cd brett && npm test
+```
+
+Expected: All tests pass (no test covers `mode-select.mjs` directly — visual flow is verified in Task 6).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add brett/public/assets/mode-select.mjs brett/public/assets/style.css
+git commit -m "feat(brett): mode-select supports mayhem card + single-mode auto-skip"
+```
+
+---
+
+## Task 4: Wire main.js to fetch config and gate Mayhem UI
+
+**Files:**
+- Modify: `brett/public/assets/main.js` (replace line 21 block)
+- Modify: `brett/public/index.html:1297` area (entry now driven by main.js, not inline)
+
+- [ ] **Step 1: Read current `main.js` and `index.html` Mayhem trigger context**
+
+Inspect:
+- `brett/public/assets/main.js:21` — currently `showModeSelect(modeState);`
+- `brett/public/index.html:1297` — `window.Mayhem.setEnabled(true);` (look at the surrounding 10 lines to know what triggers it today)
+
+- [ ] **Step 2: Replace bottom of `brett/public/assets/main.js`**
+
+Replace line 21 (`showModeSelect(modeState);`) with:
+
+```js
+const cfg = await fetch('/api/config')
+  .then(r => r.json())
+  .catch(() => ({ defaultMode: 'coaching', availableModes: ['coaching'] }));
+
+// Remove Mayhem toolbar button when Mayhem is not available on this cluster
+if (!cfg.availableModes.includes('mayhem')) {
+  document.getElementById('mayhem-btn')?.remove();
+}
+
+const chosen = await showModeSelect(modeState, cfg);
+if (chosen === 'mayhem') {
+  // Mayhem boot is idempotent — main.js owns enabling it post-select
+  window.Mayhem?.setEnabled(true);
+}
+```
+
+(Top-level `await` is allowed because `main.js` is loaded as a module — its `import` statements at line 1-4 already require module context.)
+
+- [ ] **Step 3: Verify `index.html` still loads `main.js` as a module**
+
+Run:
+
+```bash
+grep -n 'src="assets/main.js"' brett/public/index.html
+```
+
+Expected: a line like `<script type="module" src="assets/main.js"></script>`. If `type="module"` is missing, add it — top-level await will otherwise throw.
+
+- [ ] **Step 4: Manual smoke test (dev)**
+
+Start brett locally and open in a browser:
+
+```bash
+cd brett && MOCK_DB=true npm start
+# Then in another shell:
+curl -s http://localhost:3000/api/config
+```
+
+Expected: `{"defaultMode":"coaching","availableModes":["coaching"]}`.
+
+Open `http://localhost:3000` — overlay should NOT appear (auto-enters coaching), and the `🤸 Mayhem` button should be removed from the toolbar.
+
+- [ ] **Step 5: Manual smoke test (mayhem default)**
+
+```bash
+cd brett && MOCK_DB=true BRETT_DEFAULT_MODE=mayhem npm start
+```
+
+Open `http://localhost:3000` — overlay should show two cards (Coaching + Mayhem). Mayhem card has the orange border + "Standard" badge. The `🤸 Mayhem` button is still visible in the toolbar. Clicking Mayhem auto-enables it.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add brett/public/assets/main.js brett/public/index.html
+git commit -m "feat(brett): bootstrap config fetch + gate Mayhem button on availableModes"
+```
+
+---
+
+## Task 5: Remove AI fill-bots from Mayhem
+
+**Files:**
+- Modify: `brett/public/assets/mayhem/mayhem.js` (3 ranges per spec)
+
+- [ ] **Step 1: Remove fill-bot loop in `start()`**
+
+In `brett/public/assets/mayhem/mayhem.js`, find the block at lines 218-220:
+
+```js
+    // Fill remaining slots with AI bots so there are always MAX_PLAYERS combatants
+    const humanCount = remoteAvatars.size + 1; // +1 for local player
+    for (let i = humanCount; i < MAX_PLAYERS; i++) spawnAIBot(i - humanCount);
+```
+
+Delete those 3 lines entirely (keep the blank line above the `// ── AI Bots ──` comment).
+
+- [ ] **Step 2: Remove `spawnAIBot()` function**
+
+Delete the entire `spawnAIBot(colorIndex)` function and the `// ── AI Bots ──` header comment block (lines 223-248 inclusive — function declaration through the closing `}`). The next block (`// ── Co-op wave spawning ──` at line 250) remains untouched.
+
+- [ ] **Step 3: Remove bot-retire on `player_join`**
+
+In the `case 'player_join':` handler (around line 538-545), delete only the bot-retire block:
+
+```js
+        // Retire one bot to make room for the real player
+        if (aiBots.size > 0) {
+          const [firstBotId] = aiBots.keys();
+          const firstBot = aiBots.get(firstBotId);
+          aiBots.delete(firstBotId);
+          remoteAvatars.delete(firstBotId);
+          firstBot.remove(scene);
+        }
+```
+
+The mannequin-creation block below stays.
+
+- [ ] **Step 4: Verify `spawnWave()` and `aiBots` Map are still used**
+
+Run:
+
+```bash
+grep -n 'spawnAIBot\|aiBots' brett/public/assets/mayhem/mayhem.js
+```
+
+Expected: `spawnAIBot` returns ZERO matches; `aiBots` still appears in `spawnWave()` and its cleanup (those references must remain — co-op wave bots use the same Map).
+
+- [ ] **Step 5: Run brett tests**
+
+```bash
+cd brett && npm test
+```
+
+Expected: All tests pass. `server-mayhem.test.js` should be unaffected (it tests room-state mutations, not client-side spawning).
+
+- [ ] **Step 6: Add regression test — no fill-bots in a fresh Mayhem room**
+
+Read `brett/test/server-mayhem.test.js` to find the existing pattern for spinning up a room and inspecting state. Append a test asserting that after enabling mayhem mode for a single player, the room snapshot contains zero `bot-` prefixed avatars (only the human player). Use the same imports and helper style as the surrounding tests.
+
+If the existing tests work purely on `applyMutation`/`buildStateFromMutations` and don't touch the client-side spawn logic at all, skip this step — the manual smoke test in Step 7 is the verification.
+
+- [ ] **Step 7: Manual smoke test**
+
+```bash
+cd brett && MOCK_DB=true BRETT_DEFAULT_MODE=mayhem npm start
+```
+
+Open `http://localhost:3000`, select Mayhem. Expected: only the local player avatar appears. No bots wandering around. Wave-based co-op bots only spawn when a wave is triggered (unchanged).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add brett/public/assets/mayhem/mayhem.js brett/test/server-mayhem.test.js
+git commit -m "fix(brett): remove AI fill-bots from Mayhem (co-op waves preserved)"
+```
+
+---
+
+## Task 6: Base K8s manifest — add BRETT_DEFAULT_MODE env
+
+**Files:**
+- Modify: `k3d/brett.yaml` (env block around line 55-82)
+
+- [ ] **Step 1: Add env var to brett container spec**
+
+In `k3d/brett.yaml`, locate the brett Deployment's container `env:` block (starts ~line 55, contains `BRETT_KC_CLIENT_ID`, `BRETT_PUBLIC_URL`, etc.). Append a new entry — placement at end of the block is fine:
+
+```yaml
+            - name: BRETT_DEFAULT_MODE
+              value: "coaching"
+```
+
+Match the indentation of the surrounding entries exactly (12 spaces before `-`).
+
+- [ ] **Step 2: Validate manifest**
+
+```bash
+task workspace:validate
+```
+
+Expected: No errors (env var addition is a simple field append).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add k3d/brett.yaml
+git commit -m "feat(brett): add BRETT_DEFAULT_MODE=coaching to base manifest"
+```
+
+---
+
+## Task 7: korczewski overlay — override to mayhem
+
+**Files:**
+- Modify: `prod-korczewski/kustomization.yaml` (append to existing brett patch block at line ~101)
+
+- [ ] **Step 1: Append a new patch entry under `patches:`**
+
+In `prod-korczewski/kustomization.yaml`, after the existing brett affinity patch (ends around line 113 with the `- pk-hetzner-8` line), add a new patch block:
+
+```yaml
+  # brett Deployment — flip default mode to mayhem on korczewski.
+  # Base sets BRETT_DEFAULT_MODE=coaching; this overrides via JSON Patch
+  # add-to-env-array. mentolder keeps the base default (coaching only).
+  - target:
+      kind: Deployment
+      name: brett
+    patch: |-
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: BRETT_DEFAULT_MODE
+          value: mayhem
+```
+
+Note: this adds a SECOND `BRETT_DEFAULT_MODE` entry. The last one wins in Kubernetes env resolution, so the overlay value takes precedence. (Kustomize strategic-merge would dedupe by name, but JSON Patch on array elements does not — that's why we use `add` to `/env/-`, matching the spec.)
+
+- [ ] **Step 2: Verify the rendered manifest**
+
+```bash
+kubectl kustomize prod-korczewski/ | grep -A1 "BRETT_DEFAULT_MODE"
+```
+
+Expected: TWO env entries — first `value: coaching` (from base), then `value: mayhem` (from overlay). The runtime container env will resolve to `mayhem` (last entry wins).
+
+- [ ] **Step 3: Validate full workspace**
+
+```bash
+task workspace:validate
+```
+
+Expected: clean validation.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add prod-korczewski/kustomization.yaml
+git commit -m "feat(brett): korczewski sets BRETT_DEFAULT_MODE=mayhem via overlay"
+```
+
+---
+
+## Task 8: PR + deploy + post-merge verification
+
+- [ ] **Step 1: Push branch and open PR**
+
+```bash
+git push -u origin feature/brett-mode-separation
+gh pr create --title "feat(brett): separate coaching from mayhem; remove fill-bots" \
+  --body "$(cat <<'EOF'
+## Summary
+- Remove AI fill-bots from Mayhem (co-op wave-bots preserved)
+- Add `GET /api/config` returning `{ defaultMode, availableModes }` from `BRETT_DEFAULT_MODE` env
+- Mode-select auto-skips when only one mode is available; Mayhem card highlighted as default on korczewski
+- Mayhem toolbar button removed from DOM when not in `availableModes`
+- `BRETT_DEFAULT_MODE=coaching` in base; korczewski overlay overrides to `mayhem`
+
+Spec: `docs/superpowers/specs/2026-05-24-brett-mode-separation-design.md`
+
+## Test plan
+- [ ] CI green (offline tests + manifest validation)
+- [ ] mentolder: `https://brett.<mentolder-domain>` — no mode overlay, no Mayhem button
+- [ ] korczewski: `https://brett.<korczewski-domain>` — mode overlay shows both cards, Mayhem highlighted; selecting Mayhem starts with only the local player (no bots)
+EOF
+)"
+```
+
+- [ ] **Step 2: Wait for CI, then squash-merge**
+
+After CI green, squash-merge via GitHub UI (or `gh pr merge --squash`).
+
+- [ ] **Step 3: Build + push brett image, roll out on both clusters**
+
+```bash
+task feature:brett
+```
+
+(This task builds `ghcr.io/paddione/brett:latest` and restarts the brett Deployment on both mentolder and korczewski.)
+
+- [ ] **Step 4: Verify live — mentolder**
+
+Open `https://brett.<mentolder-prod-domain>` in a browser. Expected:
+- No mode-select overlay
+- Toolbar has no `🤸 Mayhem` button
+- `curl https://brett.<mentolder-prod-domain>/api/config` returns `{"defaultMode":"coaching","availableModes":["coaching"]}`
+
+- [ ] **Step 5: Verify live — korczewski**
+
+Open `https://brett.<korczewski-prod-domain>` in a browser. Expected:
+- Mode-select overlay shows two cards
+- Mayhem card has orange border + "Standard" badge
+- Click Mayhem → game starts with only your avatar (no bots)
+- `curl https://brett.<korczewski-prod-domain>/api/config` returns `{"defaultMode":"mayhem","availableModes":["coaching","mayhem"]}`
+
+- [ ] **Step 6: Verify Flux reconciliation picked up the manifest change**
+
+```bash
+flux reconcile source git flux-system --context korczewski
+flux reconcile kustomization workspace --context korczewski
+kubectl --context korczewski -n workspace-korczewski get deploy brett -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="BRETT_DEFAULT_MODE")].value}{"\n"}'
+```
+
+Expected: prints `coaching\nmayhem` (both entries, last one wins at runtime — pod env will resolve to `mayhem`).
+
+- [ ] **Step 7: Invoke dev-flow-e2e if regression tests are desired**
+
+The dev-flow-e2e skill can author Playwright specs hitting both `brett.<domain>` URLs and asserting the overlay presence/absence. Optional — manual verification above covers the acceptance criteria.
+
+---
+
+## Non-Goals (from spec)
+
+- Restructuring the Mayhem scripts loading in `index.html` (all stay loaded, just unused in coaching)
+- Removing `ai-bot.js` (still needed for co-op wave enemies)
+- Admin override mechanism for Mayhem on mentolder
+- Persisting mode choice across sessions

--- a/docs/superpowers/specs/2026-05-24-brett-mode-separation-design.md
+++ b/docs/superpowers/specs/2026-05-24-brett-mode-separation-design.md
@@ -1,0 +1,218 @@
+# Brett Mode Separation Design
+
+**Date:** 2026-05-24  
+**Branch:** feature/brett-mode-separation  
+**Scope:** Remove AI fill-bots from Mayhem mode; clearly separate Coaching (figure-only) from Mayhem (combat); configure default mode per cluster via env var.
+
+---
+
+## Problem
+
+The Systembrett currently mixes two fundamentally different use cases in a single UI:
+
+1. **Coaching / Systemische Aufstellung** — therapists and coaches place, drag, rotate, and click-to-move figures on a shared board. No combat, no weapons.
+2. **Mayhem** — 3D multiplayer combat game (weapons, vehicles, physics). Currently overlaid on top of the coaching board via a toggle button.
+
+Additional issue: Mayhem auto-fills empty player slots with AI bots, making multiplayer unintentional and noisy in single-player sessions.
+
+**Per-cluster intent:**
+- `mentolder` → Coaching only (no Mayhem accessible)
+- `korczewski` → Both modes, Mayhem pre-selected
+
+---
+
+## Solution Overview
+
+Three independent changes:
+
+1. **Remove AI fill-bots** from Mayhem (co-op wave-bots stay)
+2. **Mode-Select driven by server config** — `GET /api/config` returns `{ defaultMode, availableModes }`
+3. **`BRETT_DEFAULT_MODE` env var** differentiates clusters at the K8s level
+
+---
+
+## Change 1: Remove AI Fill-Bots
+
+### What changes
+
+In `brett/public/assets/mayhem/mayhem.js`:
+
+| Location | Action |
+|---|---|
+| Lines 218-220 | Remove fill-bot loop in `start()` |
+| Lines 224-248 | Remove `spawnAIBot()` function entirely |
+| Lines 538-545 | Remove bot-retire block in `player_join` handler |
+
+### What stays
+
+- `spawnWave()` (lines 251-284) and all co-op wave-bot logic — these are intentional enemies, not fill-bots
+- `brett/public/assets/mayhem/ai-bot.js` — still required by `spawnWave()`
+
+### Result
+
+Mayhem starts with only the local player. Additional real players can join up to `MAX_PLAYERS`. No AI fills empty slots.
+
+---
+
+## Change 2: Config API + Bootstrap
+
+### Server (`brett/server.js`)
+
+New env var `BRETT_DEFAULT_MODE` (values: `'coaching'` | `'mayhem'`, default: `'coaching'`).
+
+New endpoint added after `/healthz`:
+
+```js
+const BRETT_DEFAULT_MODE = process.env.BRETT_DEFAULT_MODE || 'coaching';
+const BRETT_AVAILABLE_MODES = BRETT_DEFAULT_MODE === 'mayhem'
+  ? ['coaching', 'mayhem']
+  : ['coaching'];
+
+app.get('/api/config', (_req, res) => res.json({
+  defaultMode: BRETT_DEFAULT_MODE,
+  availableModes: BRETT_AVAILABLE_MODES,
+}));
+```
+
+No auth required — config is non-sensitive. Error-safe: returns 200 JSON always.
+
+### Client bootstrap (`brett/public/assets/main.js`)
+
+Config is fetched before mode-select is shown. Runs in parallel with existing `/auth/me` fetch (no extra blocking):
+
+```js
+const cfg = await fetch('/api/config').then(r => r.json())
+  .catch(() => ({ defaultMode: 'coaching', availableModes: ['coaching'] }));
+showModeSelect(modeState, cfg);
+```
+
+Fail-safe: network error falls back to `coaching`-only.
+
+### `mode-state.mjs`
+
+Add `'mayhem'` to the `VALID` set (currently only `'coaching'` and `'mode-select'`).
+
+---
+
+## Change 3: Mode-Select UI
+
+### `mode-select.mjs`
+
+Signature changes to accept config: `showModeSelect(modeState, cfg)`.
+
+**Single-mode case** (`availableModes: ['coaching']` — mentolder):  
+Skip the overlay entirely and auto-enter coaching immediately. No UI shown.
+
+**Multi-mode case** (`availableModes: ['coaching', 'mayhem']` — korczewski):  
+Show two cards:
+
+```
+┌─────────────────────────────────────────────┐
+│        Wähle deinen Modus                   │
+│                                             │
+│  ┌──────────────────┐  ┌──────────────────┐ │
+│  │  Coaching        │  │  🤸 Mayhem  ★   │ │
+│  │  Systemische     │  │  3D Kampfmodus   │ │
+│  │  Aufstellung     │  │  Waffen · Fahr-  │ │
+│  │                  │  │  zeuge           │ │
+│  └──────────────────┘  └──────────────────┘ │
+│                          ↑ Standard          │
+└─────────────────────────────────────────────┘
+```
+
+- Mayhem-Karte ist visuell hervorgehoben (farbiger Border, "Standard"-Badge)
+- Klick → `modeState.setMode(mode)` → overlay entfernen → `resolve(mode)`
+- Wenn `mode === 'mayhem'`: nach resolve wird `Mayhem.setEnabled(true)` in `main.js` aufgerufen
+
+### Mayhem-Button in `index.html`
+
+Der `#mayhem-btn` in der Toolbar wird nach dem Config-Fetch per JS versteckt wenn `availableModes` kein `'mayhem'` enthält:
+
+```js
+if (!cfg.availableModes.includes('mayhem')) {
+  document.getElementById('mayhem-btn')?.remove();
+}
+```
+
+Damit ist der Button auf mentolder komplett aus dem DOM entfernt — kein CSS-Hack, kein verstecktes Element.
+
+---
+
+## Change 4: Kubernetes Per-Cluster Config
+
+### Base manifest (`k3d/brett.yaml`)
+
+New env var added to container spec:
+
+```yaml
+- name: BRETT_DEFAULT_MODE
+  value: "coaching"
+```
+
+### korczewski overlay (`prod-korczewski/kustomization.yaml`)
+
+JSON Patch appended to existing brett patch block:
+
+```yaml
+- target:
+    kind: Deployment
+    name: brett
+  patch: |-
+    - op: add
+      path: /spec/template/spec/containers/0/env/-
+      value:
+        name: BRETT_DEFAULT_MODE
+        value: mayhem
+```
+
+### mentolder overlay
+
+No change — base default `coaching` applies.
+
+### Dev (k3d)
+
+No change — base default `coaching` applies.
+
+---
+
+## Testing
+
+### Unit tests (`brett/test/`)
+
+New test file `server-config.test.js`:
+- `GET /api/config` with `BRETT_DEFAULT_MODE=coaching` → `{ defaultMode: 'coaching', availableModes: ['coaching'] }`
+- `GET /api/config` with `BRETT_DEFAULT_MODE=mayhem` → `{ defaultMode: 'mayhem', availableModes: ['coaching', 'mayhem'] }`
+- `GET /api/config` with no env var → defaults to coaching
+
+Existing `server-mayhem.test.js`:
+- Verify no bots appear in room snapshot after `mayhem_mode` enable (no `bot-` prefixed avatars)
+
+### Manual verification
+
+- Dev: open `http://brett.localhost` → mode-select shows only Coaching → enter coaching → no Mayhem button visible
+- Simulate korczewski: set `BRETT_DEFAULT_MODE=mayhem` locally → mode-select shows both cards, Mayhem highlighted → Mayhem auto-starts on select → no fill-bots appear
+
+---
+
+## File Change Summary
+
+| File | Change |
+|---|---|
+| `brett/public/assets/mayhem/mayhem.js` | Remove fill-bot loop + `spawnAIBot()` + bot-retire |
+| `brett/server.js` | Add `BRETT_DEFAULT_MODE` env var + `GET /api/config` |
+| `brett/public/assets/main.js` | Fetch `/api/config` before `showModeSelect` |
+| `brett/public/assets/mode-state.mjs` | Add `'mayhem'` to VALID set |
+| `brett/public/assets/mode-select.mjs` | Accept config param, render conditionally, auto-skip if single mode |
+| `brett/public/index.html` | Remove `#mayhem-btn` from DOM if mode not available |
+| `k3d/brett.yaml` | Add `BRETT_DEFAULT_MODE: "coaching"` env var |
+| `prod-korczewski/kustomization.yaml` | JSON Patch to set `BRETT_DEFAULT_MODE: mayhem` |
+| `brett/test/server-config.test.js` | New: config endpoint tests |
+
+---
+
+## Non-Goals
+
+- Restructuring the Mayhem scripts loading in `index.html` (all stay, just unused in coaching)
+- Removing `ai-bot.js` (still needed for co-op wave enemies)
+- Admin override mechanism for Mayhem on mentolder
+- Persisting mode choice across sessions

--- a/k3d/brett.yaml
+++ b/k3d/brett.yaml
@@ -84,6 +84,8 @@ spec:
                 secretKeyRef:
                   name: workspace-secrets
                   key: BRETT_OIDC_SECRET
+            - name: BRETT_DEFAULT_MODE
+              value: "coaching"
           ports:
             - containerPort: 3000
           readinessProbe:

--- a/prod-korczewski/kustomization.yaml
+++ b/prod-korczewski/kustomization.yaml
@@ -112,6 +112,19 @@ patches:
             - pk-hetzner-6
             - pk-hetzner-8
 
+  # brett Deployment — flip default mode to mayhem on korczewski.
+  # Base sets BRETT_DEFAULT_MODE=coaching; this overrides via JSON Patch
+  # add-to-env-array. mentolder keeps the base default (coaching only).
+  - target:
+      kind: Deployment
+      name: brett
+    patch: |-
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: BRETT_DEFAULT_MODE
+          value: mayhem
+
   # CronJobs that pin to mentolder Hetzner CPs:
   #   - tests-retention      (k3d/tests-retention-cronjob.yaml — applied separately, not via kustomize)
   #   - knowledge-ingest     (init + main containers both pinned)


### PR DESCRIPTION
## Summary
- Remove AI fill-bots from Mayhem start (co-op wave-bots preserved via `aiBots` Map)
- Add `GET /api/config` returning `{ defaultMode, availableModes }` driven by `BRETT_DEFAULT_MODE` env var
- Mode-select overlay auto-skips when only one mode available; Mayhem card highlighted as default on korczewski
- Mayhem toolbar button removed from DOM when not in `availableModes`
- `BRETT_DEFAULT_MODE=coaching` in base k3d manifest; korczewski overlay overrides to `mayhem` via JSON Patch

Spec: `docs/superpowers/specs/2026-05-24-brett-mode-separation-design.md`

## Test plan
- [x] 58/58 brett unit tests pass (`npm test`)
- [x] All three Kustomize overlays validate cleanly
- [x] Systembrett template validator passes
- [ ] mentolder: `https://brett.mentolder.de` — no mode overlay, no Mayhem button
- [ ] korczewski: `https://brett.korczewski.de` — mode overlay shows both cards, Mayhem highlighted; selecting Mayhem starts with only the local player (no bots)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>