### PR TITLE
fix(brett): use replace not add for BRETT_DEFAULT_MODE overlay on korczewski

### DIFF
--- a/prod-korczewski/kustomization.yaml
+++ b/prod-korczewski/kustomization.yaml
@@ -113,17 +113,15 @@ patches:
             - pk-hetzner-8
 
   # brett Deployment — flip default mode to mayhem on korczewski.
-  # Base sets BRETT_DEFAULT_MODE=coaching; this overrides via JSON Patch
-  # add-to-env-array. mentolder keeps the base default (coaching only).
+  # Base sets BRETT_DEFAULT_MODE=coaching at env index 11; replace the value here.
+  # mentolder keeps the base default (coaching only).
   - target:
       kind: Deployment
       name: brett
     patch: |-
-      - op: add
-        path: /spec/template/spec/containers/0/env/-
-        value:
-          name: BRETT_DEFAULT_MODE
-          value: mayhem
+      - op: replace
+        path: /spec/template/spec/containers/0/env/11/value
+        value: mayhem
 
   # CronJobs that pin to mentolder Hetzner CPs:
   #   - tests-retention      (k3d/tests-retention-cronjob.yaml — applied separately, not via kustomize)


### PR DESCRIPTION
## Summary
- K8s API server rejects duplicate env var names (even if last-wins works at runtime)
- Switch from `op: add /env/-` to `op: replace /env/11/value` (index 11 = BRETT_DEFAULT_MODE in base)
- Resolves Flux dry-run failure: `duplicate entries for key [name="BRETT_DEFAULT_MODE"]`

## Test plan
- [x] `kubectl kustomize prod-korczewski/` renders single BRETT_DEFAULT_MODE=mayhem
- [ ] Flux workspace kustomization applies cleanly on korczewski

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>