### PR TITLE
fix(e2e): raise korczewski-setup auth timeout to 60s (T000243)

### DIFF
--- a/tests/e2e/specs/korczewski-auth-setup.spec.ts
+++ b/tests/e2e/specs/korczewski-auth-setup.spec.ts
@@ -58,8 +58,8 @@ setup('authenticate korczewski website admin', async ({ page }) => {
   // waitForURL fires as soon as the URL matches (even on the /api/auth/callback URL), so
   // page.request.get() would queue indefinitely while the subsequent /admin redirect is
   // still in flight. waitForLoadState('load') waits for the final page to settle first.
-  await page.waitForURL(new RegExp(WEBSITE_URL.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')), { timeout: 30_000 });
-  await page.waitForLoadState('load', { timeout: 30_000 });
+  await page.waitForURL(new RegExp(WEBSITE_URL.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')), { timeout: 60_000 });
+  await page.waitForLoadState('load', { timeout: 60_000 });
 
   // Verify we have a session (the /api/auth/me endpoint returns { authenticated: true })
   const meRes = await page.request.get(`${WEBSITE_URL}/api/auth/me`);


### PR DESCRIPTION
## Summary
- Raises `waitForURL` + `waitForLoadState` in `korczewski-auth-setup.spec.ts` from 30s → 60s
- Addresses thundering-herd flake when 4 headed Playwright workers redirect to Keycloak simultaneously
- Setup spec runs once and caches storageState — generous timeout is paid once per session, not per test

## Why this, not Keycloak instrumentation
All 31 real korczewski specs pass once auth state is cached, so the slowness is isolated to concurrent session startup — not a production Keycloak symptom. Raising the timeout converts retry-recovery (retries=1 already in config) into a clean first pass.

Closes T000243.

🤖 Generated with [Claude Code](https://claude.com/claude-code)