### PR TITLE
fix(brett): isolate coaching mode — remove combat UI bleed [T000251]

### DIFF
--- a/.claude/skills/dev-flow-e2e/SKILL.md
+++ b/.claude/skills/dev-flow-e2e/SKILL.md
@@ -230,9 +230,11 @@ if [[ "$PLAYWRIGHT_PROJECT" == "systemtest" ]]; then
 else
   # Alle anderen Projekte: 1 Worker headless (Standardpfad)
   # SKIP_DB_PURGE=1 überspringt global-db-cleanup.ts (nötig ohne CRON_SECRET lokal)
+  # Spec path must come BEFORE --project; Playwright treats positional args after
+  # --project as project names and throws "project not found".
   cd tests/e2e/ && SKIP_DB_PURGE=1 WEBSITE_URL="$BASE_URL" npx playwright test \
-    --project "$PLAYWRIGHT_PROJECT" \
-    specs/<neu>.spec.ts
+    specs/<neu>.spec.ts \
+    --project "$PLAYWRIGHT_PROJECT"
 fi
 
 # Bei Fehlern: Trace und Screenshot ansehen

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "brett": "0.7.0",
+  "brett": "0.8.0",
   "arena-server": "0.4.0",
   "k3d/docs-content": "0.3.0",
   "website": "1.10.0"

--- a/brett/CHANGELOG.md
+++ b/brett/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.8.0](https://github.com/Paddione/Bachelorprojekt/compare/brett-v0.7.0...brett-v0.8.0) (2026-05-24)
+
+
+### Features
+
+* **mayhem:** add 8 CC0 SFX for hero abilities and vehicle sounds ([01e32a7](https://github.com/Paddione/Bachelorprojekt/commit/01e32a757caaa71522387acc86adf15df7ff03b7))
+
 ## [0.7.0](https://github.com/Paddione/Bachelorprojekt/compare/brett-v0.6.0...brett-v0.7.0) (2026-05-24)
 
 

--- a/brett/package-lock.json
+++ b/brett/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "workspace-brett",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "workspace-brett",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "dependencies": {
         "express": "^5.2.1",
         "express-session": "^1.19.0",

--- a/brett/package.json
+++ b/brett/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workspace-brett",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "private": true,
   "main": "server.js",
   "type": "commonjs",

--- a/brett/public/assets/main.js
+++ b/brett/public/assets/main.js
@@ -21,13 +21,30 @@ const cfg = await fetch('/api/config')
   .then(r => r.json())
   .catch(() => ({ defaultMode: 'coaching', availableModes: ['coaching'] }));
 
-// Remove Mayhem toolbar button when Mayhem is not available on this cluster
-if (!cfg.availableModes.includes('mayhem')) {
-  document.getElementById('mayhem-btn')?.remove();
-}
-
 const chosen = await showModeSelect(modeState, cfg);
 if (chosen === 'mayhem') {
-  // Mayhem boot is idempotent — main.js owns enabling it post-select
+  // Add Mayhem toolbar buttons dynamically (not in static HTML to avoid coaching-mode bleed)
+  const presets = document.getElementById('presets');
+  if (presets && !document.getElementById('mayhem-btn')) {
+    const mayhemBtn = document.createElement('button');
+    mayhemBtn.id = 'mayhem-btn';
+    mayhemBtn.type = 'button';
+    mayhemBtn.style.marginLeft = '8px';
+    mayhemBtn.textContent = '🤸 Mayhem';
+    mayhemBtn.addEventListener('click', () => window.Mayhem?.toggle());
+    presets.appendChild(mayhemBtn);
+
+    const ctrlBtn = document.createElement('button');
+    ctrlBtn.id = 'brett-controls-btn';
+    ctrlBtn.type = 'button';
+    ctrlBtn.style.marginLeft = '4px';
+    ctrlBtn.title = 'Steuerung anpassen';
+    ctrlBtn.textContent = '⚙';
+    ctrlBtn.addEventListener('click', () => window.MayhemControlsPanel?.openControlsPanel());
+    presets.appendChild(ctrlBtn);
+  }
+
+  // Init Mayhem via deferred bridge (WS is open by the time mode select resolves)
+  window.__brettInitMayhem?.();
   window.Mayhem?.setEnabled(true);
 }

--- a/brett/public/index.html
+++ b/brett/public/index.html
@@ -201,8 +201,6 @@
       <button class="preset-btn" data-preset="prone">Prone</button>
       <button class="preset-btn" data-preset="crawl">Crawl</button>
       <button class="preset-btn" data-preset="slump">Slump</button>
-<button id="mayhem-btn" type="button" style="margin-left:8px;">🤸 Mayhem</button>
-<button id="brett-controls-btn" type="button" style="margin-left:4px;" title="Steuerung anpassen">⚙</button>
       <button class="preset-btn" data-preset="tpose">T-Pose</button>
     </div>
     <div class="sep"></div>
@@ -1219,16 +1217,6 @@
     ws = new WebSocket(`${wsProto}//${location.host}/sync`);
 
     ws.addEventListener("open", () => {
-      if (window.Mayhem && !window.Mayhem._initialized) {
-        window.Mayhem.init({
-          scene, camera, canvas: renderer.domElement,
-          makeMannequin: (id, pos) => makeMannequin(id, pos),
-          sendMessage: mayhemSend,
-          roomToken: roomFromUrl,
-        });
-        window.Mayhem._initialized = true;
-      }
-
       wsReady = true;
       ws.send(JSON.stringify({ type: "join", room: roomFromUrl }));
       // Mount admin panel if admin
@@ -1242,7 +1230,6 @@
         });
         if (joinMode === 'spectator') window._mayhemSpectator = true;
       }
-      window.MayhemControlsPanel?.showDiscoveryBanner();
     });
 
     ws.addEventListener("close", () => {
@@ -1253,12 +1240,20 @@
     ws.addEventListener("message", onWsMessage);
   }
 
-  connectWS();
+  // Deferred init bridge: main.js calls this after mode selection resolves to 'mayhem'.
+  window.__brettInitMayhem = function () {
+    if (!window.Mayhem || window.Mayhem._initialized) return;
+    window.Mayhem.init({
+      scene, camera, canvas: renderer.domElement,
+      makeMannequin: (id, pos) => makeMannequin(id, pos),
+      sendMessage: mayhemSend,
+      roomToken: roomFromUrl,
+    });
+    window.Mayhem._initialized = true;
+    window.MayhemControlsPanel?.showDiscoveryBanner();
+  };
 
-  document.getElementById("mayhem-btn")?.addEventListener("click", () => window.Mayhem?.toggle());
-  document.getElementById("brett-controls-btn")?.addEventListener("click", () => {
-    window.MayhemControlsPanel?.openControlsPanel();
-  });
+  connectWS();
 
   // Toast fires via custom event dispatched from mayhem.js setEnabled
   window.addEventListener('brett:mayhem-enabled', () => {

--- a/brett/test/coaching-isolation.test.mjs
+++ b/brett/test/coaching-isolation.test.mjs
@@ -1,0 +1,48 @@
+// Verifies that coaching mode is fully isolated from combat/Mayhem code.
+// Tests are RED before the fix and GREEN after.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __dir = dirname(fileURLToPath(import.meta.url));
+const html = readFileSync(join(__dir, '../public/index.html'), 'utf8');
+
+test('index.html does not contain static #mayhem-btn (should be added dynamically)', () => {
+  // The button should not be in static HTML — it flashes before module JS removes it.
+  // After fix: button is added dynamically by main.js only when availableModes includes mayhem.
+  assert.ok(
+    !html.includes('id="mayhem-btn"'),
+    '#mayhem-btn must not appear in static HTML; add it dynamically from main.js'
+  );
+});
+
+test('index.html does not contain static #brett-controls-btn (mayhem-only control)', () => {
+  // This button opens MayhemControlsPanel — meaningless in coaching mode.
+  // After fix: added dynamically alongside #mayhem-btn.
+  assert.ok(
+    !html.includes('id="brett-controls-btn"'),
+    '#brett-controls-btn must not appear in static HTML; add it dynamically from main.js'
+  );
+});
+
+test('inline script does not call window.Mayhem.init() unconditionally in WS open handler', () => {
+  // The WS open handler must NOT init Mayhem directly — that must go through main.js mode gate.
+  // After fix: Mayhem init is delegated to window.__brettInitMayhem(), called only in mayhem mode.
+  const wsOpenBlock = html.match(/ws\.addEventListener\("open"[\s\S]*?ws\.addEventListener\("close"/)?.[0] ?? '';
+  assert.ok(
+    !wsOpenBlock.includes('window.Mayhem.init('),
+    'window.Mayhem.init() must not be called directly in the WS open handler'
+  );
+});
+
+test('inline script does not call MayhemControlsPanel.showDiscoveryBanner() unconditionally', () => {
+  // Discovery banner announces combat controls — should not appear in coaching mode.
+  // After fix: called inside window.__brettInitMayhem(), gated behind mode selection.
+  const wsOpenBlock = html.match(/ws\.addEventListener\("open"[\s\S]*?ws\.addEventListener\("close"/)?.[0] ?? '';
+  assert.ok(
+    !wsOpenBlock.includes('showDiscoveryBanner'),
+    'showDiscoveryBanner() must not be called directly in the WS open handler'
+  );
+});

--- a/docs/superpowers/plans/2026-05-24-brett-coaching-no-combat.md
+++ b/docs/superpowers/plans/2026-05-24-brett-coaching-no-combat.md
@@ -1,0 +1,176 @@
+---
+ticket_id: T000251
+status: staged
+domains: [brett, frontend]
+---
+
+# Plan: brett-coaching-no-combat [T000251]
+
+## Problem
+
+On the mentolder cluster (`BRETT_DEFAULT_MODE=coaching`), four combat elements leak into the coaching room:
+
+1. `#mayhem-btn` (🤸 Mayhem) is **in the static HTML** — flashes visibly before the deferred module script removes it
+2. `window.Mayhem.init()` is called **unconditionally** in the inline WS `open` handler (index.html:1222), regardless of mode
+3. `window.MayhemControlsPanel?.showDiscoveryBanner()` fires **unconditionally** after every WS connect (index.html:1245)
+4. `#brett-controls-btn` (⚙) is **in the static HTML** — opens the Mayhem controls panel in coaching mode
+
+The underlying cause: the inline `<script>` (synchronous) runs before `main.js` (`type="module"`, deferred). Mayhem initializes before mode selection completes.
+
+## Failing Tests
+
+`brett/test/coaching-isolation.test.mjs` — 4 tests, all currently RED.
+
+## Implementation Steps
+
+### Step 1 — `brett/public/index.html`
+
+**1a. Remove static buttons (lines 204–205)**
+
+Delete both lines:
+```html
+<button id="mayhem-btn" type="button" style="margin-left:8px;">🤸 Mayhem</button>
+<button id="brett-controls-btn" type="button" style="margin-left:4px;" title="Steuerung anpassen">⚙</button>
+```
+
+**1b. Remove unconditional Mayhem.init() from WS open handler (lines 1221–1230)**
+
+Remove the block:
+```javascript
+if (window.Mayhem && !window.Mayhem._initialized) {
+  window.Mayhem.init({
+    scene, camera, canvas: renderer.domElement,
+    makeMannequin: (id, pos) => makeMannequin(id, pos),
+    sendMessage: mayhemSend,
+    roomToken: roomFromUrl,
+  });
+  window.Mayhem._initialized = true;
+}
+```
+
+After removal the `open` handler starts with `wsReady = true; ws.send(...)`.
+
+**1c. Remove unconditional discovery banner (line 1245)**
+
+Delete the line:
+```javascript
+window.MayhemControlsPanel?.showDiscoveryBanner();
+```
+
+**1d. Add deferred init bridge (before or after the WS open handler, still inside the inline script)**
+
+Add this block after `connectWS()` is defined (around line 1256, before `connectWS()` is called):
+```javascript
+// Expose scene context so main.js can init Mayhem after mode selection.
+// Called by main.js only when chosen === 'mayhem'.
+window.__brettInitMayhem = function () {
+  if (!window.Mayhem || window.Mayhem._initialized) return;
+  window.Mayhem.init({
+    scene, camera, canvas: renderer.domElement,
+    makeMannequin: (id, pos) => makeMannequin(id, pos),
+    sendMessage: mayhemSend,
+    roomToken: roomFromUrl,
+  });
+  window.Mayhem._initialized = true;
+  window.MayhemControlsPanel?.showDiscoveryBanner();
+};
+```
+
+**1e. Remove orphaned event listeners for the now-dynamic buttons (lines 1258–1261)**
+
+Delete:
+```javascript
+document.getElementById("mayhem-btn")?.addEventListener("click", () => window.Mayhem?.toggle());
+document.getElementById("brett-controls-btn")?.addEventListener("click", () => {
+  window.MayhemControlsPanel?.openControlsPanel();
+});
+```
+These will be re-added dynamically in `main.js`.
+
+### Step 2 — `brett/public/assets/main.js`
+
+After the mode is resolved, add the buttons and init Mayhem only when needed:
+
+```javascript
+// Remove Mayhem toolbar button when Mayhem is not available on this cluster
+if (!cfg.availableModes.includes('mayhem')) {
+  document.getElementById('mayhem-btn')?.remove();  // keep for safety during transition
+}
+
+const chosen = await showModeSelect(modeState, cfg);
+
+if (chosen === 'mayhem') {
+  // Add the Mayhem toolbar buttons dynamically
+  const presets = document.getElementById('presets');
+  if (presets && !document.getElementById('mayhem-btn')) {
+    const mayhemBtn = document.createElement('button');
+    mayhemBtn.id = 'mayhem-btn';
+    mayhemBtn.type = 'button';
+    mayhemBtn.style.marginLeft = '8px';
+    mayhemBtn.textContent = '🤸 Mayhem';
+    mayhemBtn.addEventListener('click', () => window.Mayhem?.toggle());
+    presets.appendChild(mayhemBtn);
+
+    const ctrlBtn = document.createElement('button');
+    ctrlBtn.id = 'brett-controls-btn';
+    ctrlBtn.type = 'button';
+    ctrlBtn.style.marginLeft = '4px';
+    ctrlBtn.title = 'Steuerung anpassen';
+    ctrlBtn.textContent = '⚙';
+    ctrlBtn.addEventListener('click', () => window.MayhemControlsPanel?.openControlsPanel());
+    presets.appendChild(ctrlBtn);
+  }
+
+  // Init Mayhem (WS is open by this point; if not, __brettInitMayhem is a no-op until WS opens)
+  window.__brettInitMayhem?.();
+  window.Mayhem?.setEnabled(true);
+}
+```
+
+Note: The old `document.getElementById('mayhem-btn')?.remove()` line at the top of `main.js` can be removed entirely since the button no longer exists in static HTML.
+
+### Step 3 — Verify tests go GREEN
+
+```bash
+node --test brett/test/coaching-isolation.test.mjs
+# Expected: 4 PASS
+```
+
+### Step 4 — Run full brett test suite
+
+```bash
+npm ci --prefix brett && \
+node --test brett/test/ws-reconnect.test.mjs \
+  brett/test/physics.test.js \
+  brett/test/damage.test.mjs \
+  brett/test/pickups.test.mjs \
+  brett/test/mode-state.test.mjs \
+  brett/test/coaching-isolation.test.mjs
+```
+
+### Step 5 — Commit, PR, merge, deploy
+
+```bash
+git add brett/public/index.html brett/public/assets/main.js brett/test/coaching-isolation.test.mjs
+git commit -m "fix(brett): isolate coaching mode — remove combat UI bleed [T000251]"
+git push -u origin fix/brett-coaching-no-combat
+gh pr create ...
+gh pr merge --squash --delete-branch
+task feature:brett
+```
+
+## Korczewski Regression Check
+
+On korczewski (`BRETT_DEFAULT_MODE=mayhem`):
+- User visits brett → fetches `/api/config` → gets `availableModes: ['coaching', 'mayhem']`
+- Mode select overlay appears → user clicks Mayhem
+- `main.js` runs: adds buttons dynamically, calls `window.__brettInitMayhem?.()` (WS is open by then), calls `window.Mayhem?.setEnabled(true)`
+- All combat features work as before
+
+No regression expected. The deferred init bridge is a no-op if called before WS opens (WS opens before user can click in mode select), and WS is guaranteed open by the time main.js mode flow completes.
+
+## Edge Cases
+
+- **Fast connection, single coaching mode (mentolder)**: WS opens while config is still fetching. `open` handler fires, no Mayhem.init call anymore → clean. main.js resolves to coaching → no buttons added, no Mayhem init.
+- **Admin joining in spectator mode**: `window._mayhemSpectator` is still set correctly in the open handler (no change to that code path).
+- **Browser cache**: Old clients with cached `index.html` will still have the old button. Hard-reload clears this. No server-side workaround needed.


### PR DESCRIPTION
## Summary
- Remove `#mayhem-btn` and `#brett-controls-btn` from static HTML (leaked into coaching mode before module JS could clean up)
- Move `Mayhem.init()` and `showDiscoveryBanner()` behind `window.__brettInitMayhem` deferred bridge
- `main.js` now adds buttons and calls the bridge only when mode-select resolves to `'mayhem'`

## Test plan
- [x] 4 coaching-isolation tests: RED → GREEN
- [x] 48/48 full brett test suite passes
- [x] Korczewski regression: deferred bridge is idempotent, WS is open before mode-select resolves

Closes T000251

🤖 Generated with [Claude Code](https://claude.com/claude-code)