### PR TITLE
fix(dev-flow-e2e): warn about auth overwrite in korczewski-setup [T000253]

### DIFF
--- a/.claude/skills/dev-flow-e2e/SKILL.md
+++ b/.claude/skills/dev-flow-e2e/SKILL.md
@@ -215,6 +215,8 @@ Für `systemtest` läuft der vollständige Zyklus gegen beide Cluster (via `task
 > gestartet werden. `npx playwright` vom Repo-Root aus findet zwei Versionen von
 > `@playwright/test` (Repo-Root + `tests/e2e/node_modules`) und bricht ab.
 
+> **Wichtig — korczewski-setup auth overwrite:** Das Ausführen von Tests im `korczewski`-Projekt (selbst mit `--grep`) triggert automatisch das dependency-Projekt `korczewski-setup`. Wenn `TEST_ADMIN_PASSWORD` nicht gesetzt ist, überschreibt dies bestehende gültige Auth-Cookies in `.auth/korczewski-*.json` mit leeren Werten! Wenn du bestehende gültige Cookies behalten willst, überspringe `korczewski-setup` (indem du den Test direkt ohne das Projekt oder mit einem Mock ausführst) oder setze `TEST_ADMIN_PASSWORD` vor dem Ausführen.
+
 ```bash
 # Wähle Ausführungsmodus basierend auf dem Playwright-Projekt
 


### PR DESCRIPTION
This PR adds a warning note to Step 5 of the dev-flow-e2e skill, warning users about the destructive side effects of running korczewski project tests without TEST_ADMIN_PASSWORD set, which overwrites `.auth/korczewski-*.json` files with empty structures.