### PR TITLE
fix(skills): T000254 lockfile note, T000255 ticket_id placeholder [T000254] [T000255] [T000256]

### DIFF
--- a/.claude/skills/dev-flow-execute/SKILL.md
+++ b/.claude/skills/dev-flow-execute/SKILL.md
@@ -256,6 +256,8 @@ task test:all
 
 > **`npm ci` in frischen Worktrees:** `brett/` und `arena-server/` haben ihre eigene `package.json`, aber kein `node_modules/` im Worktree. Vor dem ersten `npm test`/`node --test` explizit ausführen: `npm ci --prefix brett` bzw. `cd arena-server && pnpm install --frozen-lockfile`. [T000245]
 
+> **Lockfile-Update nach neuer Dependency:** Wenn `arena-server/package.json` geändert wurde (neue Dep hinzugefügt), schlägt `pnpm install --frozen-lockfile` mit "lockfile-specifier mismatch" fehl. Erst `pnpm install` (ohne Flag) ausführen, dann das aktualisierte Lockfile committen — danach `pnpm install --frozen-lockfile` zur Verifikation. [T000254]
+
 ### CI-kritische Zusatzchecks
 
 `task test:all` deckt nur den `offline-tests`-Job ab. Die folgenden Checks haben **eigene CI-Jobs** — CI kann rot werden, auch wenn `task test:all` grün ist. Führe sie aus, wenn die entsprechenden Dateien geändert wurden:
@@ -265,7 +267,7 @@ task test:all
 | `tests/**` oder neue/geänderte Test-IDs | `task test:inventory && git diff --exit-code website/src/data/test-inventory.json` — bei Abweichung committen | `offline-tests` |
 | `brett/**` | `npm ci --prefix brett && node --test brett/test/ws-reconnect.test.mjs brett/test/physics.test.js brett/test/damage.test.mjs brett/test/pickups.test.mjs brett/test/mode-state.test.mjs` | `brett-server-test` |
 | `brett/**` (Whiteboard-Template) | `./scripts/tests/systembrett-template.test.sh` | `offline-tests` |
-| `arena-server/**` | `cd arena-server && pnpm install --frozen-lockfile && pnpm test && pnpm build` | `arena-server` |
+| `arena-server/**` | Wenn `package.json` geändert: `cd arena-server && pnpm install && git add pnpm-lock.yaml && git commit -m "chore: update pnpm lockfile"`. Dann: `cd arena-server && pnpm install --frozen-lockfile && pnpm test && pnpm build` | `arena-server` |
 | `arena-server/src/proto/messages.ts` ODER `website/src/components/arena/shared/lobbyTypes.ts` | `diff arena-server/src/proto/messages.ts website/src/components/arena/shared/lobbyTypes.ts` — bei Abweichung: `cp arena-server/src/proto/messages.ts website/src/components/arena/shared/lobbyTypes.ts` | `arena-proto-drift` |
 
 > Alle fünf CI-Jobs müssen grün sein vor dem Merge.

--- a/.claude/skills/dev-flow-plan/SKILL.md
+++ b/.claude/skills/dev-flow-plan/SKILL.md
@@ -543,12 +543,17 @@ TICKET_EXT_ID=$(echo "$TICKET_RESULT" | cut -d'|' -f1)   # z.B. T000301
 TICKET_UUID=$(echo "$TICKET_RESULT"   | cut -d'|' -f2)
 ```
 
-Trage `ticket_id` in das Plan-Frontmatter ein (nach der ersten `---`-Zeile):
+Ersetze den `ticket_id: null` Platzhalter im Frontmatter (den `plan-frontmatter-hook.sh` immer einfügt):
 
 ```bash
-awk 'NR==1{print; print "ticket_id: '"$TICKET_EXT_ID"'"; next} 1' \
-  docs/superpowers/plans/<date>-<slug>.md > /tmp/_plan_tmp.md && \
-  mv /tmp/_plan_tmp.md docs/superpowers/plans/<date>-<slug>.md
+sed -i "s/^ticket_id: null$/ticket_id: $TICKET_EXT_ID/" \
+  docs/superpowers/plans/<date>-<slug>.md
+```
+
+Verifiziere anschließend:
+```bash
+grep '^ticket_id:' docs/superpowers/plans/<date>-<slug>.md
+# Erwartete Ausgabe: ticket_id: T000XXX (kein "null")
 ```
 
 Injiziere dann brainstorm_choice + brainstorm_session (best-effort — kein Fehler wenn kein STATE_DIR oder keine Wahl):
@@ -702,10 +707,9 @@ Bei nicht-trivialem Fix: Rufe `superpowers:writing-plans` auf. Führe danach sof
 ```bash
 bash scripts/plan-frontmatter-hook.sh docs/superpowers/plans/<slug>.md
 
-# ticket_id ins Frontmatter eintragen
-awk 'NR==1{print; print "ticket_id: '"$TICKET_EXT_ID"'"; next} 1' \
-  docs/superpowers/plans/<slug>.md > /tmp/_plan_tmp.md && \
-  mv /tmp/_plan_tmp.md docs/superpowers/plans/<slug>.md
+# ticket_id Platzhalter ersetzen
+sed -i "s/^ticket_id: null$/ticket_id: $TICKET_EXT_ID/" \
+  docs/superpowers/plans/<slug>.md
 ```
 
 ### Schritt 5: Commit & Push — dann STOPP

--- a/scripts/plan-frontmatter-hook.sh
+++ b/scripts/plan-frontmatter-hook.sh
@@ -35,6 +35,7 @@ title=$(grep -m1 '^# ' "$FILE" | sed 's/^# //' || echo "$slug")
 
 FRONTMATTER="---
 title: $title
+ticket_id: null
 domains: $domains_yaml
 status: active
 pr_number: null


### PR DESCRIPTION
## Summary
- **T000254**: Added note in dev-flow-execute that `pnpm install` (without `--frozen-lockfile`) must run first when `package.json` gains a new dependency, before lockfile verification
- **T000255**: `plan-frontmatter-hook.sh` now always emits `ticket_id: null` placeholder; dev-flow-plan Schritt 4.5 now uses `sed` replacement instead of awk-insert (avoids duplicate field); verification grep added
- **T000256**: Already fixed — both MAIN_REPO awk patterns in dev-flow-execute already use `print $2`; closing ticket, no code change needed

## Test plan
- [ ] Verify `plan-frontmatter-hook.sh` produces `ticket_id: null` in new plan frontmatter
- [ ] Verify sed replacement in Schritt 4.5 correctly sets the ticket_id

🤖 Generated with [Claude Code](https://claude.com/claude-code)