### PR TITLE
chore(skills): commit spec before /compact in dev-flow-plan

### DIFF
--- a/.claude/skills/dev-flow-plan/SKILL.md
+++ b/.claude/skills/dev-flow-plan/SKILL.md
@@ -470,6 +470,18 @@ echo "Tickets: ${REINJECT_TICKETS[*]:-keine}"
 echo "═══════════════════════════════════════════"
 ```
 
+**1.5. Spec auf Branch committen (vor dem Reset!):**
+
+Damit die Spec nach dem `/compact` — auch in einer neuen Session oder nach Worktree-Verlust — via `git` auffindbar ist:
+
+```bash
+git add docs/superpowers/specs/<date>-<slug>-design.md
+git commit -m "chore(specs): add <slug> design spec"
+git push
+```
+
+Dieser Commit ist idempotent gegenüber Schritt 5 — `git add` einer bereits committeten Datei ist ein No-op.
+
 **2. ⚡ STOP — führe diese Befehle jetzt aus (in dieser Reihenfolge):**
 
 ```
@@ -586,6 +598,7 @@ fi
 ### Schritt 5: Commit & Push — dann STOPP
 
 ```bash
+# Die Spec wurde bereits in Schritt 3.7.1.5 committed; git add ist idempotent falls nötig
 git add docs/superpowers/specs/<date>-<slug>-design.md docs/superpowers/plans/<date>-<slug>.md
 git commit -m "chore(plans): stage <slug> for execution [$TICKET_EXT_ID]"
 git push -u origin feature/<slug>


### PR DESCRIPTION
## Summary
- Adds step 3.7.1.5 to `dev-flow-plan`: commit the spec file to the feature branch immediately before the `/compact` context reset
- The spec is now durable on the remote branch before the context is cleared, so `writing-plans` can always find it via `git` even after cache loss, session restart, or worktree recreation
- The final Step 5 commit is unchanged in behavior (idempotent re-add)

## Test plan
- [ ] Run `/dev-flow-plan` on a new feature request; verify `docs/superpowers/specs/*.md` is committed on the feature branch before `/compact` is issued
- [ ] Verify Step 5 completes without error (no duplicate commit noise)

🤖 Generated with [Claude Code](https://claude.com/claude-code)