### PR TITLE
chore(skills): commit fix-path plan immediately after writing it

### DIFF
--- a/.claude/skills/dev-flow-plan/SKILL.md
+++ b/.claude/skills/dev-flow-plan/SKILL.md
@@ -725,13 +725,21 @@ sed -i "s/^ticket_id: null$/ticket_id: $TICKET_EXT_ID/" \
   docs/superpowers/plans/<slug>.md
 ```
 
+Plan sofort committen — damit er nach einem Cache-Reset oder Session-Verlust via `git` auffindbar ist:
+
+```bash
+git add docs/superpowers/plans/<slug>.md
+git commit -m "chore(plans): add <slug> fix plan [$TICKET_EXT_ID]"
+git push
+```
+
 ### Schritt 5: Commit & Push — dann STOPP
 
 ```bash
 # Immer dabei: der failing Test
 git add tests/<relevante-test-datei>
 
-# Falls ein Plan geschrieben wurde:
+# Plan wurde bereits in Schritt 4 committed; git add ist idempotent falls nötig
 git add docs/superpowers/plans/<slug>.md
 
 git commit -m "chore(plans): stage <slug> fix for execution [$TICKET_EXT_ID]"


### PR DESCRIPTION
## Summary
- In the fix path (Step 4), the plan file is now committed to the branch immediately after `plan-frontmatter-hook.sh` + `ticket_id` substitution
- Mirrors the feature-path spec-commit (step 3.7.1.5) — plan survives any session or cache loss before Step 5
- Step 5's `git add` on an already-committed file is idempotent

## Test plan
- [ ] Run `/dev-flow-plan` on a non-trivial bug fix; verify `docs/superpowers/plans/*.md` is committed on the fix branch right after it is written (before Step 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)