### PR TITLE
fix(dev): remove redundant ForwardAuth middleware from dev-ingress [T000260]

### DIFF
--- a/prod-mentolder/dev-ingress.yaml
+++ b/prod-mentolder/dev-ingress.yaml
@@ -4,7 +4,7 @@ metadata:
   name: workspace-ingress-dev
   namespace: ${WORKSPACE_NAMESPACE}
   annotations:
-    traefik.ingress.kubernetes.io/router.middlewares: "${WORKSPACE_NAMESPACE}-redirect-https@kubernetescrd,${WORKSPACE_NAMESPACE}-hsts-headers@kubernetescrd,${WORKSPACE_NAMESPACE}-security-headers@kubernetescrd,${WORKSPACE_NAMESPACE}-oauth2-proxy-dev@kubernetescrd"
+    traefik.ingress.kubernetes.io/router.middlewares: "${WORKSPACE_NAMESPACE}-redirect-https@kubernetescrd,${WORKSPACE_NAMESPACE}-hsts-headers@kubernetescrd,${WORKSPACE_NAMESPACE}-security-headers@kubernetescrd"
 spec:
   tls:
     - hosts:

--- a/prod-mentolder/oauth2-proxy-dev.yaml
+++ b/prod-mentolder/oauth2-proxy-dev.yaml
@@ -1,11 +1,11 @@
 # ════════════════════════════════════════════════════════════════════
 # oauth2-proxy-dev — SSO gate for *.dev.${PROD_DOMAIN}.
 # Upstream is the k3d HTTP loadbalancer bound to 127.0.0.1:18080 on
-# the gekko-hetzner-2 node, reached via hostNetwork + nodeSelector.
-# Same pod serves both the ForwardAuth /oauth2/auth probe (called by
-# the Traefik Middleware in prod-mentolder/oauth2-proxy-dev-middleware.yaml)
-# AND the reverse-proxy data path (proxying authenticated requests to
-# 127.0.0.1:18080).
+# the k3s-1 node, reached via hostNetwork + nodeSelector.
+# Acts as a full reverse proxy: unauthenticated requests are redirected
+# to Keycloak; authenticated requests are proxied to 127.0.0.1:18080.
+# The ForwardAuth Middleware in oauth2-proxy-dev-middleware.yaml is
+# kept for services that need header injection but NOT on dev-ingress.
 # ════════════════════════════════════════════════════════════════════
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
## Summary
- Removes the `oauth2-proxy-dev` ForwardAuth middleware annotation from `prod-mentolder/dev-ingress.yaml` — it was short-circuiting unauthenticated requests with 401 before the oauth2-proxy backend (which handles the Keycloak redirect) was ever reached
- Fixes `dev-tls.1` and `dev-tls.2` smoke tests — `web.dev.mentolder.de` and `brett.dev.mentolder.de` now return 302 → `auth.mentolder.de` for anonymous requests
- Corrects stale comment in `oauth2-proxy-dev.yaml` (said `gekko-hetzner-2`, is actually `k3s-1`)

## Remaining smoke failures
`dev-sso.*` and `dev-tunnel.*` require these GitHub Actions secrets to be added:
- `KC_TEST_USER` — a Keycloak user in the `/dev-access` group
- `KC_TEST_PASSWORD`
- `KC_TEST_CLIENT_SECRET` — secret for the `workspace-dev-test` OIDC client
- `SISH_TEST_KEY` — SSH key in `DEV_SISH_AUTHORIZED_KEYS`

## Test plan
- [x] `curl -sI https://web.dev.mentolder.de` → `HTTP/2 302` → `location: https://auth.mentolder.de/...`
- [x] `curl -sI https://brett.dev.mentolder.de` → same redirect
- [ ] Run `gh workflow run dev-smoke.yml` after merging to verify `dev-tls.*` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)