### PR TITLE
chore(env): fix DEV_NODE hostname for korczewski dev stack on PK-Desktop

### DIFF
--- a/environments/korczewski.yaml
+++ b/environments/korczewski.yaml
@@ -54,8 +54,8 @@ env_vars:
   LLM_ROUTER_URL: "http://llm-gateway-lmstudio.workspace-korczewski.svc.cluster.local:1234"
   LLM_EMBED_URL: "http://llm-gateway-embed.workspace-korczewski.svc.cluster.local:8081"
   ARENA_WS_URL: https://arena-ws.korczewski.de
-  # Dev stack — k3d-korczewski-dev on PK-L-1 (local WSL2 workstation).
-  DEV_NODE: pk-l-1
+  # Dev stack — k3d-korczewski-dev on PK-Desktop (local WSL2 workstation).
+  DEV_NODE: pk-desktop
   DEV_SSH_USER: patrick
   DEV_DOMAIN: dev.korczewski.de
   DEV_WEBSITE_HOST: web.dev.korczewski.de


### PR DESCRIPTION
## Summary
- Fixes `DEV_NODE: pk-l-1` → `pk-desktop` in `environments/korczewski.yaml`
- The dev-stack `cluster:create` task compares `hostname -s` to `DEV_NODE` to determine local vs SSH execution; the old name caused it to try SSH-ing to `pk-l-1` instead of creating the k3d cluster locally
- Updates the comment to reflect current machine name

## Test plan
- `task workspace:validate` — manifests valid ✓
- `task test:all` — all offline tests pass ✓
- `source scripts/env-resolve.sh korczewski && echo $DEV_NODE` → `pk-desktop` ✓