### PR TITLE
feat(brett): mayhem duel-hero completion — 7 bug fixes [T000268]

### DIFF
--- a/brett/public/assets/mayhem/ai-bot.js
+++ b/brett/public/assets/mayhem/ai-bot.js
@@ -262,11 +262,12 @@ function _heroDecide(heroId, dist, hasLos, botHp) {
 }
 
 class AIBot {
-  constructor({ id, heroId, pos, scene, THREE, obstacles, weaponSystem }) {
+  constructor({ id, heroId, pos, scene, THREE, obstacles, weaponSystem, onDeath = () => {} }) {
     this.id = id;
     this.heroId = heroId;
     this.hp = 100;
     this.weaponSystem = weaponSystem;
+    this._onDeath = onDeath;
     this.obstacles = obstacles;
 
     const color = window.MayhemHeroes?.HEROES[heroId]?.color || 0x888888;

--- a/brett/public/assets/mayhem/effects.js
+++ b/brett/public/assets/mayhem/effects.js
@@ -220,6 +220,77 @@ class EffectsManager {
     requestAnimationFrame(animate);
   }
 
+  // ── Martina minion: shield ring ───────────────────────────────────────────────
+  spawnShieldRing(targetMesh) {
+    if (!targetMesh || !this._THREE) return;
+    this.removeShieldRing(targetMesh);
+    const geo = new this._THREE.TorusGeometry(0.35, 0.04, 8, 24);
+    const mat = new this._THREE.MeshLambertMaterial({ color: 0xd7b06a, transparent: true, opacity: 0.85 });
+    const ring = new this._THREE.Mesh(geo, mat);
+    ring.rotation.x = Math.PI / 2;
+    targetMesh.add(ring);
+    targetMesh._shieldRing = ring;
+  }
+
+  removeShieldRing(targetMesh) {
+    if (targetMesh && targetMesh._shieldRing) {
+      targetMesh.remove(targetMesh._shieldRing);
+      targetMesh._shieldRing.geometry.dispose();
+      targetMesh._shieldRing.material.dispose();
+      targetMesh._shieldRing = null;
+    }
+  }
+
+  // ── Martina minion: frenzy particles ─────────────────────────────────────────
+  spawnFrenzyParticles(targetMesh) {
+    if (!targetMesh || !this._THREE) return;
+    this.clearFrenzyParticles(targetMesh, this._scene);
+    const particles = [];
+    for (let i = 0; i < 5; i++) {
+      const geo = new this._THREE.SphereGeometry(0.04, 4, 4);
+      const mat = new this._THREE.MeshLambertMaterial({ color: 0xff6622, transparent: true, opacity: 0.9 });
+      const mesh = new this._THREE.Mesh(geo, mat);
+      const angle = (i / 5) * Math.PI * 2;
+      mesh.position.set(Math.cos(angle) * 0.3, 0.5, Math.sin(angle) * 0.3);
+      this._scene.add(mesh);
+      particles.push({ mesh, angle, baseAngle: angle });
+    }
+    targetMesh._frenzyParticles = particles;
+    const start = performance.now();
+    const duration = 3000;
+    const animate = (now) => {
+      const elapsed = now - start;
+      if (elapsed >= duration || !targetMesh._frenzyParticles) {
+        this.clearFrenzyParticles(targetMesh, this._scene);
+        return;
+      }
+      const worldPos = new this._THREE.Vector3();
+      targetMesh.getWorldPosition(worldPos);
+      for (const p of particles) {
+        p.angle += 0.04;
+        p.mesh.position.set(
+          worldPos.x + Math.cos(p.angle) * 0.3,
+          worldPos.y + 0.5,
+          worldPos.z + Math.sin(p.angle) * 0.3,
+        );
+        p.mesh.material.opacity = Math.max(0, 0.9 * (1 - elapsed / duration));
+      }
+      requestAnimationFrame(animate);
+    };
+    requestAnimationFrame(animate);
+  }
+
+  clearFrenzyParticles(targetMesh) {
+    if (targetMesh && targetMesh._frenzyParticles) {
+      for (const p of targetMesh._frenzyParticles) {
+        this._scene.remove(p.mesh);
+        p.mesh.geometry.dispose();
+        p.mesh.material.dispose();
+      }
+      targetMesh._frenzyParticles = null;
+    }
+  }
+
   // ── Per-frame update ─────────────────────────────────────────────────────────
   update(dt) {
     for (const p of this._particles) p.update(dt);

--- a/brett/public/assets/mayhem/heroes.js
+++ b/brett/public/assets/mayhem/heroes.js
@@ -85,7 +85,9 @@ class MinionManager {
 
   shieldOldest() {
     const oldest = this._minions.values().next().value;
-    if (oldest) oldest.shielded = true;
+    if (!oldest) return;
+    oldest.shielded = true;
+    if (oldest.mesh) window.MayhemEffects?.spawnShieldRing(oldest.mesh);
   }
 
   frenzyOldest() {
@@ -94,6 +96,7 @@ class MinionManager {
     oldest.frenzied   = true;
     oldest.speedMult  = 2;
     oldest._frenzyEnd = Date.now() + 3000;
+    if (oldest.mesh) window.MayhemEffects?.spawnFrenzyParticles(oldest.mesh);
   }
 
   tick(dt, nowMs) {
@@ -126,7 +129,11 @@ class MinionManager {
   takeDamage(minionId, dmg) {
     const m = this._minions.get(minionId);
     if (!m) return;
-    if (m.shielded) { m.shielded = false; return; }  // absorb
+    if (m.shielded) {
+      m.shielded = false;
+      if (m.mesh) window.MayhemEffects?.removeShieldRing(m.mesh);
+      return;  // absorb
+    }
     m.hp -= dmg;
     if (m.hp <= 0) this._killMinion(minionId);
   }

--- a/brett/public/assets/mayhem/mayhem.js
+++ b/brett/public/assets/mayhem/mayhem.js
@@ -57,6 +57,8 @@ const Mayhem = (() => {
   let _myHeroId     = null;
   let _opponentHeroId = null;
   let _duelRoundPause = false;
+  let _duelHpFillA  = null;   // HP bar DOM element for duel playerA
+  let _duelHpFillB  = null;   // HP bar DOM element for duel playerB
 
   let _specTarget = null;
   let _specMode   = 'follow';
@@ -474,6 +476,7 @@ const Mayhem = (() => {
               const newVehicle = window.MayhemVehicle.Vehicle.spawn(nextType, localAvatar.mannequin.root.position, scene);
               localAvatar._vehicle = newVehicle;
               window.MayhemAudio.onFire('vehicle-switch');
+              send({ type: 'vehicle_switch', playerId, vehicleType: nextType });
               if (nextType === 'car') {
                 window._autoTurret = new window.MayhemVehicle.AutoTurret({
                   vehicle: newVehicle, scene, THREE: window.THREE,
@@ -491,6 +494,7 @@ const Mayhem = (() => {
                 v.hp = Math.min(v.maxHp, (v.hp || 0) + 40);
                 effectsMgr?.spawnSmokePuff(scene, v.mesh ? v.mesh.position : localAvatar.mannequin.root.position);
                 window.MayhemAudio.onFire('vehicle-repair');
+                send({ type: 'vehicle_repair', playerId, amount: 40 });
               }
               return;
             }
@@ -500,6 +504,7 @@ const Mayhem = (() => {
                 v.speedMult = 2.5;
                 v.damagesOnContact = true;
                 window.MayhemAudio.onFire('motorcycle-engine');
+                send({ type: 'motorcycle_sprint', playerId, durationMs: 1500 });
                 setTimeout(() => { v.speedMult = 1; v.damagesOnContact = false; }, 1500);
               }
               return;
@@ -586,11 +591,27 @@ const Mayhem = (() => {
           }
           if (projectileMgr) projectileMgr.spawn(w, origin, dir, id);
         }),
+      onDeath: () => { _handleBotDeath(); },
     });
     bot.hp      = 100;
     bot.heroId  = heroId;
     window._pvAiBot = bot;
+    aiBots.set(botId, bot);
     remoteAvatars.set(botId, bot.avatar);  // so spectators can follow
+  }
+
+  function _handleBotDeath() {
+    if (!isHost || _duelRoundPause) return;
+    const result = gameMode.handleDuelDeath('bot-pvai');
+    const winsA  = gameMode.duelState.winsA;
+    const winsB  = gameMode.duelState.winsB;
+    if (result.matchOver) {
+      send({ type: 'duel_match_end', winner: result.matchWinner, winsA, winsB });
+      _onDuelEnd({ matchWinner: result.matchWinner, reason: null, winsA, winsB });
+    } else {
+      send({ type: 'duel_round_end', winner: result.roundWinner, winsA, winsB });
+      _onDuelRoundEnd({ winner: result.roundWinner, winsA, winsB });
+    }
   }
 
   function _onDuelRoundEnd({ winner, winsA, winsB }) {
@@ -615,38 +636,78 @@ const Mayhem = (() => {
           }
         }
         localRespawn();
+        _buildDuelHud(winsA, winsB);
+        if (_duelHpFillA) _duelHpFillA.style.width = '100%';
+        if (_duelHpFillB) _duelHpFillB.style.width = '100%';
         _duelRoundPause = false;
       }
     }, 3000);
   }
 
-  function _onDuelEnd({ matchWinner, reason }) {
-    _showDuelMatchResult(matchWinner, reason);
+  function _onDuelEnd({ matchWinner, reason, winsA, winsB }) {
+    const resolvedWinsA = winsA ?? gameMode?.duelState?.winsA ?? 0;
+    const resolvedWinsB = winsB ?? gameMode?.duelState?.winsB ?? 0;
+    _showDuelMatchResult(matchWinner, reason, resolvedWinsA, resolvedWinsB);
     // After 5s return to warmup
     setTimeout(() => {
       const resultOverlay = document.getElementById('duel-match-result-overlay');
       if (resultOverlay) resultOverlay.remove();
       const scoreHud = document.getElementById('duel-score-hud');
       if (scoreHud) scoreHud.remove();
+      _duelHpFillA = null;
+      _duelHpFillB = null;
       if (isHost && gameMode) {
         send({ type: 'game_mode_change', mode: 'warmup' });
       }
     }, 5000);
   }
 
-  function _buildDuelHud() {
+  function _buildDuelHud(winsA, winsB) {
     const existing = document.getElementById('duel-score-hud');
     if (existing) existing.remove();
-    const hud = document.createElement('div');
-    hud.id = 'duel-score-hud';
-    hud.style.cssText = `
-      position: fixed; top: 44px; left: 50%; transform: translateX(-50%);
-      font-family: 'Geist Mono', monospace; font-size: 12px;
-      color: #d7b06a; letter-spacing: 0.12em;
-      pointer-events: none; text-align: center; z-index: 1000;
+    _duelHpFillA = null;
+    _duelHpFillB = null;
+
+    const ds = gameMode?.duelState || {};
+    const resolvedWinsA = winsA ?? ds.winsA ?? 0;
+    const resolvedWinsB = winsB ?? ds.winsB ?? 0;
+    const round = resolvedWinsA + resolvedWinsB + 1;
+
+    const HEROES = window.MayhemHeroes?.HEROES || {};
+    const nameA = HEROES[_myHeroId]?.name || 'A';
+    const nameB = _pvAiMode
+      ? (HEROES[_opponentHeroId]?.name || 'KI')
+      : (HEROES[_opponentHeroId]?.name || 'B');
+
+    const bar = document.createElement('div');
+    bar.id = 'duel-score-hud';
+    bar.style.cssText = `
+      position: fixed; top: 12px; left: 50%; transform: translateX(-50%);
+      display: flex; align-items: center; gap: 16px;
+      background: rgba(0,0,0,.55); padding: 6px 14px; border-radius: 8px;
+      font-family: 'Geist Mono', monospace; color: #d7b06a; font-size: 11px;
+      pointer-events: none; z-index: 1000;
     `;
-    hud.textContent = `RUNDE ${gameMode.duelState.winsA + gameMode.duelState.winsB + 1}`;
-    document.body.appendChild(hud);
+    bar.innerHTML = `
+      <div style="display:flex;flex-direction:column;align-items:flex-end;gap:2px;min-width:80px">
+        <span style="letter-spacing:0.1em">${nameA}</span>
+        <div style="width:80px;height:6px;background:#333;border-radius:3px;overflow:hidden">
+          <div id="duel-hp-fill-a" style="height:100%;width:100%;background:#d7b06a;transition:width 0.15s;border-radius:3px;"></div>
+        </div>
+      </div>
+      <div style="text-align:center;letter-spacing:0.14em;white-space:nowrap">
+        RUNDE ${round} · ${resolvedWinsA}—${resolvedWinsB}
+      </div>
+      <div style="display:flex;flex-direction:column;align-items:flex-start;gap:2px;min-width:80px">
+        <span style="letter-spacing:0.1em">${nameB}</span>
+        <div style="width:80px;height:6px;background:#333;border-radius:3px;overflow:hidden">
+          <div id="duel-hp-fill-b" style="height:100%;width:100%;background:#a0aec0;transition:width 0.15s;border-radius:3px;"></div>
+        </div>
+      </div>
+    `;
+    document.body.appendChild(bar);
+    _duelHpFillA = document.getElementById('duel-hp-fill-a');
+    _duelHpFillB = document.getElementById('duel-hp-fill-b');
   }
 
   function _showDuelRoundResult(winnerId, winsA, winsB) {
@@ -670,7 +731,7 @@ const Mayhem = (() => {
     setTimeout(() => overlay.remove(), 3000);
   }
 
-  function _showDuelMatchResult(matchWinnerId, reason) {
+  function _showDuelMatchResult(matchWinnerId, reason, winsA, winsB) {
     const overlay = document.createElement('div');
     overlay.id = 'duel-match-result-overlay';
     overlay.style.cssText = `
@@ -679,11 +740,27 @@ const Mayhem = (() => {
       background: rgba(11,17,28,0.88); z-index: 2000;
       font-family: 'Geist Mono', monospace;
     `;
-    const isWin  = matchWinnerId === playerId;
-    const label  = reason === 'disconnect' ? 'UNENTSCHIEDEN' : isWin ? 'SIEG' : 'NIEDERLAGE';
-    const color  = reason === 'disconnect' ? '#b9bda3' : isWin ? '#d7b06a' : '#a83a30';
+    const HEROES   = window.MayhemHeroes?.HEROES || {};
+    const myName   = HEROES[_myHeroId]?.name || 'Du';
+    let label, color;
+    if (reason === 'disconnect') {
+      label = 'UNENTSCHIEDEN';
+      color = '#b9bda3';
+    } else if (_pvAiMode && matchWinnerId === 'bot-pvai') {
+      label = 'NIEDERLAGE';
+      color = '#a83a30';
+    } else if (matchWinnerId === playerId) {
+      label = `SIEG — ${myName}!`;
+      color = '#d7b06a';
+    } else {
+      const oppName = HEROES[_opponentHeroId]?.name || 'Gegner';
+      label = `${oppName} GEWINNT!`;
+      color = '#a83a30';
+    }
+    const scoreStr = (winsA != null && winsB != null) ? `<div style="font-size:16px;color:#b9bda3;margin-top:10px;letter-spacing:0.14em;">${winsA} : ${winsB}</div>` : '';
     overlay.innerHTML = `
       <div style="font-size: 32px; color: ${color}; letter-spacing: 0.2em;">${label}</div>
+      ${scoreStr}
     `;
     document.body.appendChild(overlay);
   }
@@ -1079,7 +1156,7 @@ const Mayhem = (() => {
         break;
 
       case 'duel_match_end':
-        _onDuelEnd({ matchWinner: msg.winner, reason: msg.reason });
+        _onDuelEnd({ matchWinner: msg.winner, reason: msg.reason, winsA: msg.winsA, winsB: msg.winsB });
         break;
 
       case 'hero_stealth':
@@ -1155,6 +1232,17 @@ const Mayhem = (() => {
         { const al = remoteAvatars.get(msg.playerId); if (al) { al.remove(scene); remoteAvatars.delete(msg.playerId); } }
         break;
 
+      case 'vehicle_switch': {
+        const av = remoteAvatars.get(msg.playerId);
+        if (av && av.netTarget) av.netTarget.vehicleType = msg.vehicleType;
+        break;
+      }
+
+      case 'vehicle_repair':
+      case 'motorcycle_sprint':
+        // Visual-only relay — remote movement speed changes are evident from player_state interpolation
+        break;
+
       case 'hit':
         // Apply visual ragdoll for non-victim remote players
         if (msg.victimId !== playerId) {
@@ -1172,6 +1260,15 @@ const Mayhem = (() => {
         } else {
           const av = remoteAvatars.get(msg.playerId);
           if (av) av.hp = msg.hp;
+        }
+        if (_duelHpFillA || _duelHpFillB) {
+          const ds = gameMode?.duelState;
+          const pct = Math.max(0, msg.hp);
+          if (ds?.playerA === msg.playerId && _duelHpFillA) {
+            _duelHpFillA.style.width = pct + '%';
+          } else if (ds?.playerB === msg.playerId && _duelHpFillB) {
+            _duelHpFillB.style.width = pct + '%';
+          }
         }
         updateHud();
         break;
@@ -1261,6 +1358,20 @@ const Mayhem = (() => {
       <span id="mhud-weapon" style="color:#fc8">Handgun</span>
       <span id="mhud-kills" style="color:#fa0;display:none"></span>
       <span id="mhud-respawn" style="color:#ff4;display:none">Press R to respawn</span>
+      <div id="mhud-cooldowns" style="display:none;gap:6px;align-items:center;">
+        <div style="display:flex;flex-direction:column;align-items:center;gap:1px;">
+          <span style="font-size:9px;color:#888">4</span>
+          <div style="width:28px;height:4px;background:#333;border-radius:2px;overflow:hidden">
+            <div id="mhud-stealth-cd" style="height:100%;width:100%;background:#d7b06a;border-radius:2px;"></div>
+          </div>
+        </div>
+        <div style="display:flex;flex-direction:column;align-items:center;gap:1px;">
+          <span style="font-size:9px;color:#888">5</span>
+          <div style="width:28px;height:4px;background:#333;border-radius:2px;overflow:hidden">
+            <div id="mhud-teleport-cd" style="height:100%;width:100%;background:#d7b06a;border-radius:2px;"></div>
+          </div>
+        </div>
+      </div>
     `;
     document.body.appendChild(div);
     return div;
@@ -1339,6 +1450,27 @@ const Mayhem = (() => {
       respawnEl.style.display = '';
     } else {
       respawnEl.style.display = 'none';
+    }
+
+    if (_pvAiMode && window._pvAiBot && _duelHpFillB) {
+      _duelHpFillB.style.width = Math.max(0, window._pvAiBot.hp) + '%';
+    }
+
+    const cooldownsEl = document.getElementById('mhud-cooldowns');
+    if (cooldownsEl) {
+      const isPatrick = _myHeroId === 'patrick';
+      cooldownsEl.style.display = isPatrick ? 'flex' : 'none';
+      if (isPatrick) {
+        const nowMs = Date.now();
+        const stealthEl = document.getElementById('mhud-stealth-cd');
+        const teleEl    = document.getElementById('mhud-teleport-cd');
+        if (stealthEl) {
+          stealthEl.style.width = Math.min(1, (nowMs - (_specialCooldowns['stealth'] || 0)) / 8000) * 100 + '%';
+        }
+        if (teleEl) {
+          teleEl.style.width = Math.min(1, (nowMs - (_specialCooldowns['teleport'] || 0)) / 6000) * 100 + '%';
+        }
+      }
     }
   }
 

--- a/brett/server.js
+++ b/brett/server.js
@@ -355,6 +355,7 @@ const RELAY_TYPES = [
   'wave_start','wave_complete','coop_win','coop_lose','coop_wave_sync',
   'hero_select', 'duel_start', 'duel_round_end', 'duel_match_end',
   'hero_stealth', 'hero_teleport', 'minion_spawn', 'minion_update', 'minion_die', 'hero_slow',
+  'vehicle_switch', 'vehicle_repair', 'motorcycle_sprint',
 ];
 
 const TRANSIENT_TYPES = new Set([
@@ -362,6 +363,7 @@ const TRANSIENT_TYPES = new Set([
   'hp_update','player_death','player_respawn',
   'wave_start','wave_complete','coop_win','coop_lose','coop_wave_sync',
   'hero_select', 'duel_start', 'hero_stealth', 'hero_teleport', 'minion_update', 'hero_slow',
+  'vehicle_switch', 'vehicle_repair', 'motorcycle_sprint',
 ]);
 
 const lmsAlive  = new Map(); // roomToken -> Set<playerId>

--- a/docs/superpowers/plans/2026-05-24-mayhem-duel-hero-completion.md
+++ b/docs/superpowers/plans/2026-05-24-mayhem-duel-hero-completion.md
@@ -1,0 +1,247 @@
+---
+title: Mayhem Duel-Hero Completion — 7 Bug Fixes
+date: 2026-05-24
+ticket_id: T000268
+status: active
+domains: [brett, game, frontend]
+pr_number: null
+spec: docs/superpowers/specs/2026-05-24-mayhem-duel-heroes-design.md
+---
+
+# Mayhem Duel-Hero Completion — 7 Bug Fixes
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix 7 identified gaps in the Duel-Hero implementation shipped in PR #1046. After these fixes, PvAI duels complete, round counters update, HP bars show for both fighters, the match winner is named, Oskar's vehicles sync to all clients, and Martina's minion shield/frenzy have visual feedback.
+
+**Architecture:** All changes are confined to `brett/public/assets/mayhem/`. Server (`brett/server.js`) gets minimal additions for Oskar vehicle relay types. No new files required — only modifications to existing modules.
+
+---
+
+## Phase 1 — PvAI Bot Death & Round-End (Critical)
+
+All files are under `brett/public/assets/`.
+
+### 1.1 — Fix `AIBot` to accept and store `_onDeath` callback
+
+**File:** `mayhem/ai-bot.js`
+
+Find the `AIBot` class constructor. It currently takes `(heroId, difficulty, scene, getPos, getAvatars, getObstacles, sendHit)`. Add `onDeath` as the last parameter and store it:
+
+- [ ] Add `onDeath` as final constructor param with default `() => {}`
+- [ ] Store as `this._onDeath = onDeath`
+- [ ] In `processHit(damage)` — already calls `this._onDeath()` — verify the call is there; if not, add it after `this._hp` drops to ≤ 0
+
+### 1.2 — Fix `_spawnPvAiBot()` in `mayhem.js`
+
+**File:** `mayhem/mayhem.js`
+
+The current call creates `new window.MayhemAiBot.AIBot(...)` without `_onDeath` and adds the bot to `remoteAvatars` but NOT `aiBots`. Fix:
+
+- [ ] Pass an `onDeath` callback as the last argument to `new window.MayhemAiBot.AIBot(...)`:
+  ```js
+  () => {
+    // Treat as a player death — host handles round logic
+    this._handleBotDeath();
+  }
+  ```
+- [ ] Add `this.aiBots.set('bot-pvai', pvAiBot)` immediately after construction so `applyHitLocally` can find it
+
+### 1.3 — Add `_handleBotDeath()` to `mayhem.js`
+
+- [ ] Create method `_handleBotDeath()`:
+  ```js
+  _handleBotDeath() {
+    if (!this._isHost) return;
+    const result = this.gameMode.handleDuelDeath('bot-pvai');
+    if (result.matchOver) {
+      this._sendMsg({ type: 'duel_match_end', winner: this._myId, winsA: result.winsA, winsB: result.winsB });
+      this._showDuelMatchResult(this._myId);
+    } else {
+      this._sendMsg({ type: 'duel_round_end', winner: this._myId, winsA: result.winsA, winsB: result.winsB });
+      this._onDuelRoundEnd({ winner: this._myId, winsA: result.winsA, winsB: result.winsB });
+    }
+  }
+  ```
+
+### 1.4 — Fix `applyHitLocally()` bot routing
+
+**File:** `mayhem/mayhem.js`, function `applyHitLocally(victimId, ...)`
+
+Currently checks only `aiBots.get(victimId)`. After 1.2, `bot-pvai` IS in `aiBots`, so the existing path will work. Verify this — no extra change needed if 1.2 is done correctly.
+
+- [ ] Confirm `aiBots.get('bot-pvai')` resolves correctly after the fix and damage is applied
+
+---
+
+## Phase 2 — Dual HP Bar HUD + Round Counter Refresh
+
+### 2.1 — Extend `_buildDuelHud()` with HP bars for both fighters
+
+**File:** `mayhem/mayhem.js`
+
+Currently `_buildDuelHud()` creates only a round-number `<div>`. Replace with a full layout:
+
+```
+[HeroA Portrait] [████░░ 60HP]    RUNDE 2 · A 1—0 B    [████░░ 90HP] [HeroB Portrait]
+```
+
+- [ ] Wrap existing round-counter element inside a parent `#duel-hud-bar` flex container
+- [ ] Add left HP block: `#duel-hp-a` containing hero name label + `<div class="duel-hp-fill">` (width as % of max HP)
+- [ ] Add right HP block: `#duel-hp-b` — mirror of left
+- [ ] Update round counter text to include both win counts: `RUNDE ${round} · ${heroNameA} ${winsA}—${winsB} ${heroNameB}`
+- [ ] Store references as `this._duelHpFillA`, `this._duelHpFillB` for live updates
+- [ ] CSS (inline style or existing `<style>` block in `index.html`):
+  - `.duel-hp-fill { height: 6px; background: var(--brass-game); transition: width 0.15s; border-radius: 3px; }`
+  - `#duel-hud-bar { position: fixed; top: 12px; left: 50%; transform: translateX(-50%); display: flex; align-items: center; gap: 16px; background: rgba(0,0,0,.55); padding: 6px 14px; border-radius: 8px; font-family: 'Geist Mono', monospace; color: var(--parchment-2); font-size: 11px; }`
+
+### 2.2 — Wire `hp_update` message to HP bar
+
+**File:** `mayhem/mayhem.js`, `onMessage()` handler for `hp_update`
+
+- [ ] After updating `avatar.hp`, also update the duel HUD bars:
+  ```js
+  if (this._duelHpFillA && victimId === this.gameMode.duelState.playerA) {
+    this._duelHpFillA.style.width = Math.max(0, (hp / maxHp) * 100) + '%';
+  } else if (this._duelHpFillB && victimId === this.gameMode.duelState.playerB) {
+    this._duelHpFillB.style.width = Math.max(0, (hp / maxHp) * 100) + '%';
+  }
+  ```
+- [ ] Also update local player's own HP bar when local HP changes (hits received locally)
+
+### 2.3 — Refresh HUD on round end
+
+**File:** `mayhem/mayhem.js`, `_onDuelRoundEnd()`
+
+Currently this resets positions but never refreshes the HUD. After the 3-second pause:
+
+- [ ] Call `_buildDuelHud()` again with updated `winsA`/`winsB` from the round-end message
+- [ ] Reset HP bar fills to full width (100%) since new round starts at full HP
+
+---
+
+## Phase 3 — Named Match Winner
+
+### 3.1 — Pass winner name to `_showDuelMatchResult()`
+
+**File:** `mayhem/mayhem.js`
+
+- [ ] Change signature to `_showDuelMatchResult(winnerId, winsA, winsB)` if not already
+- [ ] Look up the winner's hero: `const heroId = remoteAvatars.get(winnerId)?.heroId ?? _myHeroId`; then `const heroName = HEROES[heroId]?.name ?? 'Unbekannt'`
+- [ ] For display: if `winnerId === this._myId` → "DU GEWINNST!" (or "SIEG — [HeroName]!"); else → "[HeroName] GEWINNT!"
+- [ ] Show full score: `${winsA} : ${winsB}`
+- [ ] In PvAI mode (`_pvAiMode`), `winnerId === 'bot-pvai'` → show "KI GEWINNT!" or "NIEDERLAGE"
+
+---
+
+## Phase 4 — Ability Cooldown Display (Patrick Specials)
+
+### 4.1 — Add cooldown indicator elements for Digit4 / Digit5
+
+**File:** `mayhem/mayhem.js` — wherever the existing weapon-slot HUD is built
+
+- [ ] Add two small cooldown bars (or key-badge overlays) for stealth (4) and teleport (5) — only visible when `_myHeroId === 'patrick'`
+- [ ] Track cooldown timestamps: `_stealthLastUsedAt = 0`, `_teleportLastUsedAt = 0` (already tracked implicitly via WeaponSystem but exposed via `weaponSystem.canFire(key)`)
+- [ ] In the render loop `tick()`, update the cooldown bar width:
+  ```js
+  if (this._stealthCooldownEl) {
+    const elapsed = performance.now() - this._stealthLastUsedAt;
+    const frac = Math.min(1, elapsed / 8000);
+    this._stealthCooldownEl.style.width = (frac * 100) + '%';
+  }
+  // same for teleport / 6000ms
+  ```
+- [ ] CSS: small bar underneath the "4" / "5" key badge, brass-game colour, same style as HP fill
+
+---
+
+## Phase 5 — Oskar Vehicle Sync
+
+### 5.1 — Add vehicle relay types to `brett/server.js`
+
+**File:** `brett/server.js`
+
+- [ ] Find the `RELAY_TYPES` array / set and add: `'vehicle_switch'`, `'vehicle_repair'`, `'motorcycle_sprint'`
+- [ ] Add these to `TRANSIENT_TYPES` (no DB persist needed): `'vehicle_switch'`, `'motorcycle_sprint'`
+- [ ] `vehicle_repair` can also be transient (it's a one-shot heal, not state)
+
+### 5.2 — Send WS messages from Oskar ability handlers in `mayhem.js`
+
+**File:** `mayhem/mayhem.js`, inside `_showHeroSelectModal()` where onFire callbacks are wired for Oskar's weapons:
+
+- [ ] `vehicle_switch` onFire → after local vehicle switch logic, send:
+  ```js
+  this._sendMsg({ type: 'vehicle_switch', playerId: this._myId, vehicleType: newVehicleType });
+  ```
+- [ ] `vehicle_repair` onFire → send:
+  ```js
+  this._sendMsg({ type: 'vehicle_repair', playerId: this._myId, amount: 40 });
+  ```
+- [ ] `motorcycle_sprint` onFire → send:
+  ```js
+  this._sendMsg({ type: 'motorcycle_sprint', playerId: this._myId, durationMs: 1500 });
+  ```
+
+### 5.3 — Handle vehicle messages in `onMessage()`
+
+**File:** `mayhem/mayhem.js`
+
+- [ ] `vehicle_switch`: find remote avatar by `msg.playerId`; call `vehicle.switch(msg.vehicleType)` on their avatar if `vehicle.js` exposes such an API; otherwise update `avatar.vehicleType` and visually swap the mesh
+- [ ] `vehicle_repair`: find remote avatar; update their displayed HP or vehicle HP
+- [ ] `motorcycle_sprint`: find remote avatar; apply `speedMultiplier = 2.5` for `durationMs` ms (visual only — damage-on-contact is host-authoritative)
+
+---
+
+## Phase 6 — Minion Shield & Frenzy Visuals
+
+### 6.1 — Add `spawnShieldRing()` to `effects.js`
+
+**File:** `mayhem/effects.js`
+
+- [ ] Add function `spawnShieldRing(targetMesh, scene, THREE)`:
+  - Creates `TorusGeometry(0.35, 0.04, 8, 24)` in brass-game colour
+  - Parents it to `targetMesh` (add as child)
+  - Stores ref on `targetMesh._shieldRing = torusMesh`
+  - Slow rotation animation in the existing `tick()` loop (or just static)
+- [ ] Add function `removeShieldRing(targetMesh)`:
+  - `targetMesh._shieldRing && targetMesh.remove(targetMesh._shieldRing)`
+
+### 6.2 — Add `spawnFrenzyParticles()` to `effects.js`
+
+**File:** `mayhem/effects.js`
+
+- [ ] Add function `spawnFrenzyParticles(targetMesh, scene, THREE)`:
+  - Spawns 4–6 small `SphereGeometry(0.04)` in a warm-orange colour (`0xff6622`)
+  - Animates them orbiting `targetMesh` position over 3000ms then auto-removes
+  - Stores ref array on `targetMesh._frenzyParticles`
+- [ ] Add function `clearFrenzyParticles(targetMesh, scene)` to clean up before 3000ms if frenzy ends early
+
+### 6.3 — Call visual functions from `MinionManager` in `heroes.js`
+
+**File:** `mayhem/heroes.js`, `MinionManager` class
+
+- [ ] In `shieldOldest()`: after setting `minion.shielded = true`, call `window.MayhemEffects?.spawnShieldRing(minion.mesh, scene, THREE)`
+- [ ] In `MinionManager.takeDamage(minionId)`: when `minion.shielded` absorbs a hit, call `window.MayhemEffects?.removeShieldRing(minion.mesh)`
+- [ ] In `frenzyOldest()`: after boosting stats, call `window.MayhemEffects?.spawnFrenzyParticles(minion.mesh, scene, THREE)`; schedule `clearFrenzyParticles` via `setTimeout(3000)`
+- [ ] `MinionManager` needs access to `scene` and `THREE` — pass them in constructor if not already present
+
+---
+
+## Verification Checklist
+
+- [ ] PvAI duel: kill the bot → round-end fires → after 3s new round starts → after 2 wins match-end fires correctly
+- [ ] Round counter in HUD updates from "RUNDE 1" to "RUNDE 2" after first round ends
+- [ ] Both fighters' HP bars visible in HUD and decrease on hits in real-time
+- [ ] Match-over screen names the winner by hero name (not just SIEG/NIEDERLAGE)
+- [ ] Patrick stealth (4) and teleport (5) cooldown bars visible and drain/refill correctly
+- [ ] Oskar vehicle switch: second player connected sees Oskar's vehicle change
+- [ ] Shielded Martina minion shows brass ring; frenzied minion shows orange particles
+- [ ] No console errors in any of the above scenarios
+
+---
+
+## Notes
+
+- PvAI bot health (`_hp`) is tracked inside `AIBot.processHit()` — the bot's HP is NOT in the `remoteAvatars` HP system, so `hp_update` messages do NOT apply to it. The PvAI HP bar (Phase 2) should read from `pvAiBot._hp` directly each frame rather than from `hp_update`.
+- Oskar vehicle sync (Phase 5) is intentionally shallow: remote clients get the visual change but collision-on-contact damage remains host-authoritative only.
+- Minion visuals (Phase 6) are client-side only — the host still controls `shielded` / frenzy state; visual functions are called after the authoritative state change, not in response to WS messages.


### PR DESCRIPTION
## Summary
- **Phase 1 (Critical):** PvAI bot death now triggers round/match-end — `AIBot` stores `onDeath` callback, `bot-pvai` registered in `aiBots` map, `_handleBotDeath()` drives the duel state machine
- **Phase 2:** Dual HP bar HUD replaces plain round counter; bot HP polled each frame; bars reset on new round
- **Phase 3:** Match-over screen shows hero name ("SIEG — Patrick!", "Martina GEWINNT!") and final score instead of generic SIEG/NIEDERLAGE
- **Phase 4:** Patrick stealth (4) and teleport (5) cooldown bars visible in bottom HUD, filled from `_specialCooldowns` each frame
- **Phase 5:** Oskar vehicle-switch/repair/sprint relay types added to server; `vehicle_switch` updates remote avatar vehicle visual via `netTarget.vehicleType`
- **Phase 6:** `EffectsManager` gains shield-ring and frenzy-particle helpers; `MinionManager` calls them via `window.MayhemEffects?.` optional chaining (no Three.js dep in heroes.js)

## Test plan
- [x] `node --test brett/test/*.mjs brett/test/*.js` — 26 pass
- [x] `task test:all` — green (second run, transient exit-128 race on first is known [T000218])
- [x] `./scripts/tests/systembrett-template.test.sh` — all checks passed

Closes T000268

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>