### PR TITLE
fix(brett): mayhem button toggle state + disable event

### DIFF
--- a/brett/public/assets/main.js
+++ b/brett/public/assets/main.js
@@ -29,7 +29,7 @@ if (chosen === 'mayhem') {
     const mayhemBtn = document.createElement('button');
     mayhemBtn.id = 'mayhem-btn';
     mayhemBtn.type = 'button';
-    mayhemBtn.style.marginLeft = '8px';
+    mayhemBtn.style.cssText = 'margin-left:8px;border:1px solid rgba(231,234,208,0.18);border-radius:4px;padding:4px 10px;background:transparent;color:inherit;font:inherit;cursor:pointer;';
     mayhemBtn.textContent = '🤸 Mayhem';
     mayhemBtn.addEventListener('click', () => window.Mayhem?.toggle());
     presets.appendChild(mayhemBtn);
@@ -42,6 +42,15 @@ if (chosen === 'mayhem') {
     ctrlBtn.textContent = '⚙';
     ctrlBtn.addEventListener('click', () => window.MayhemControlsPanel?.openControlsPanel());
     presets.appendChild(ctrlBtn);
+
+    // Reflect Mayhem on/off state visually on the toggle button
+    const setMayhemBtnActive = (on) => {
+      mayhemBtn.style.borderColor = on ? '#c8f76a' : 'rgba(231,234,208,0.18)';
+      mayhemBtn.style.color = on ? '#c8f76a' : 'inherit';
+      mayhemBtn.title = on ? 'Mayhem beenden (M)' : 'Mayhem starten (M)';
+    };
+    window.addEventListener('brett:mayhem-enabled',  () => setMayhemBtnActive(true));
+    window.addEventListener('brett:mayhem-disabled', () => setMayhemBtnActive(false));
   }
 
   // Init Mayhem via deferred bridge (WS is open by the time mode select resolves)

--- a/brett/public/assets/mayhem/mayhem.js
+++ b/brett/public/assets/mayhem/mayhem.js
@@ -227,6 +227,7 @@ const Mayhem = (() => {
       window.dispatchEvent(new CustomEvent('brett:mayhem-enabled'));
     } else {
       stop();
+      window.dispatchEvent(new CustomEvent('brett:mayhem-disabled'));
     }
   }
   function toggle() {

--- a/brett/public/index.html
+++ b/brett/public/index.html
@@ -1253,7 +1253,6 @@
       roomToken: roomFromUrl,
     });
     window.Mayhem._initialized = true;
-    window.MayhemControlsPanel?.showDiscoveryBanner();
   };
 
   connectWS();


### PR DESCRIPTION
## Summary

- Dispatch `brett:mayhem-disabled` event from `mayhem.js` when Mayhem is stopped (pairs with existing `brett:mayhem-enabled`)
- Listen to both events in `main.js` to apply active/inactive visual style to the 🤸 Mayhem toolbar button (green border + text when on, neutral when off)
- Remove misleading `showDiscoveryBanner()` call from `__brettInitMayhem`: the banner says "click to fight" but Mayhem auto-starts immediately after mode selection, so the hint was confusing

**Root cause of the broken button**: Mayhem is started automatically via `setEnabled(true)` right after `__brettInitMayhem()`. So when the user first clicks 🤸 Mayhem, `enabled` is already `true` and `toggle()` turns it **off** — opposite of what's expected. The fix provides clear visual feedback (button lights up green when Mayhem is running) so the user always knows the current state.

## Test plan

- [ ] Select Mayhem from mode select → 🤸 Mayhem button should appear **green/highlighted** (Mayhem already running)
- [ ] Click 🤸 Mayhem → Mayhem stops, button returns to neutral style
- [ ] Click 🤸 Mayhem again → Mayhem restarts, button turns green
- [ ] Press `M` key → same toggle, button state updates correctly
- [ ] Discovery banner should NOT appear on mode entry (removed from auto-start path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)