### PR TITLE
fix(comfy): correct COMFY_HOST_IP to WSL2 wg-mesh IPs

### DIFF
--- a/environments/korczewski.yaml
+++ b/environments/korczewski.yaml
@@ -49,7 +49,7 @@ env_vars:
   # System-test failure loop master kill-switch (Task 10).
   SYSTEMTEST_LOOP_ENABLED: "true"
   LLM_HOST_IP: "100.102.71.114"
-  COMFY_HOST_IP: "100.102.71.114"
+  COMFY_HOST_IP: "10.13.14.10"
   COMFY_PORT: "8189"
   LLM_ENABLED: "true"
   LLM_RERANK_ENABLED: "false"

--- a/environments/mentolder.yaml
+++ b/environments/mentolder.yaml
@@ -47,7 +47,7 @@ env_vars:
   # System-test failure loop master kill-switch (Task 10).
   SYSTEMTEST_LOOP_ENABLED: "true"
   LLM_HOST_IP: "100.102.71.114"
-  COMFY_HOST_IP: "100.102.71.114"
+  COMFY_HOST_IP: "192.168.100.10"
   COMFY_PORT: "8189"
   LLM_ENABLED: "true"
   LLM_RERANK_ENABLED: "false"


### PR DESCRIPTION
## Summary
- Fixes 502 Bad Gateway on `comfy.korczewski.de` (and `comfy.mentolder.de`)
- ComfyUI runs on WSL2 (PK-Desktop), not on the Windows GPU box — corrects `COMFY_HOST_IP` to the WSL2 wg-mesh IP per cluster
  - mentolder: `100.102.71.114` → `192.168.100.10`
  - korczewski: `100.102.71.114` → `10.13.14.10`
- `LLM_HOST_IP` is unchanged (Windows GPU box still runs Ollama/TEI)

## Root cause
PR #1101 introduced `COMFY_HOST_IP` pointing to the Windows GPU box IP. ComfyUI actually runs on WSL2, which has a different wg-mesh address.

🤖 Generated with [Claude Code](https://claude.com/claude-code)