### PR TITLE
fix(infra): resolve dev-node scheduling conflicts on k3s-1

### DIFF
--- a/prod-mentolder/kustomization.yaml
+++ b/prod-mentolder/kustomization.yaml
@@ -141,6 +141,21 @@ patches:
           operator: In
           values:
             - k3s-1
+  # dev-db-refresh CronJob: must run on DEV_NODE (k3s-1) — uses hostNetwork to
+  # reach the k3d Postgres at 127.0.0.1:15432. Override the global CronJob
+  # NotIn patch so k3s-1 is allowed. The JSON path includes jobTemplate because
+  # CronJob wraps the PodSpec one level deeper than a Deployment.
+  - target:
+      kind: CronJob
+      name: dev-db-refresh
+    patch: |-
+      - op: replace
+        path: /spec/jobTemplate/spec/template/spec/affinity/nodeAffinity/requiredDuringSchedulingIgnoredDuringExecution/nodeSelectorTerms/0/matchExpressions/0
+        value:
+          key: kubernetes.io/hostname
+          operator: In
+          values:
+            - k3s-1
   - target:
       kind: Deployment
       name: brett

--- a/prod-mentolder/oauth2-proxy-dev.yaml
+++ b/prod-mentolder/oauth2-proxy-dev.yaml
@@ -16,6 +16,8 @@ metadata:
     app: oauth2-proxy-dev
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: oauth2-proxy-dev


### PR DESCRIPTION
## Summary

- **`dev-db-refresh` CronJob** has been stuck Pending for 5+ days: the global CronJob `NotIn: [k3s-1,...]` affinity patch contradicted its `nodeSelector: k3s-1`. Added a JSON patch override (`In: [k3s-1]`) — same pattern as the existing `oauth2-proxy-dev` override, but using the CronJob path (`/spec/jobTemplate/spec/template/...`) which has one extra nesting level vs Deployment.
- **`oauth2-proxy-dev` Deployment** now has `strategy: type: Recreate` so rolling updates don't deadlock on `hostPort: 4181` (only one pod per node can hold a hostPort at a time).

## Test plan
- [ ] Verify `dev-db-refresh` pod schedules on k3s-1 after Flux reconciles
- [ ] Verify `oauth2-proxy-dev` rolls over cleanly (Recreate: old pod terminates first)
- [ ] `kubectl kustomize prod-mentolder/` shows `In: [k3s-1]` for dev-db-refresh and `strategy: Recreate` for oauth2-proxy-dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)