### PR TITLE
fix(flux): add COMFY_HOST_IP to cluster-vars on both clusters

### DIFF
--- a/flux/clusters/korczewski/vars-configmap.yaml
+++ b/flux/clusters/korczewski/vars-configmap.yaml
@@ -12,6 +12,7 @@ data:
   BRAND_ID: korczewski
   WEBSITE_IMAGE: korczewski-website
   LLM_HOST_IP: "10.13.14.10"
+  COMFY_HOST_IP: "10.13.14.10"
   # TLS / cert-manager
   TLS_SECRET_NAME: korczewski-tls
   INFRA_NAMESPACE: korczewski-infra

--- a/flux/clusters/mentolder/vars-configmap.yaml
+++ b/flux/clusters/mentolder/vars-configmap.yaml
@@ -12,6 +12,7 @@ data:
   BRAND_ID: mentolder
   WEBSITE_IMAGE: mentolder-website
   LLM_HOST_IP: "192.168.100.10"
+  COMFY_HOST_IP: "192.168.100.10"
   # TLS / cert-manager
   TLS_SECRET_NAME: workspace-wildcard-tls
   INFRA_NAMESPACE: mentolder-infra


### PR DESCRIPTION
## Summary

- `${COMFY_HOST_IP}` was used in `prod/comfy-gpu.yaml` (introduced in #1101) but never added to the Flux `cluster-vars` ConfigMap
- Flux's `postBuild.substituteFrom` silently replaces unknown variables with empty string → korczewski Endpoint IP became `""` → hard validation failure → workspace Kustomization stuck `False`
- On mentolder the Endpoints IP happened to match the stale `LLM_HOST_IP` value so it didn't hard-fail, but was pointing at the wrong host

## Fix

Added per-cluster values:
- `mentolder`: `COMFY_HOST_IP: "192.168.100.10"` (wsl2-gpu-mentolder wg-mesh)
- `korczewski`: `COMFY_HOST_IP: "10.13.14.10"` (wsl2-gpu-korczewski wg-mesh)

The `cluster-vars` ConfigMap on both live clusters has already been patched imperatively to unblock reconciliation while this PR merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)