### PR TITLE
fix(netpol): add port 8189 to allow-llm-gateway-egress for ComfyUI

### DIFF
--- a/k3d/network-policies.yaml
+++ b/k3d/network-policies.yaml
@@ -96,6 +96,8 @@ spec:
     - protocol: TCP
       port: 8082
     - protocol: TCP
+      port: 8189
+    - protocol: TCP
       port: 11434
   - to:
     - ipBlock:
@@ -107,6 +109,8 @@ spec:
       port: 8081
     - protocol: TCP
       port: 8082
+    - protocol: TCP
+      port: 8189
     - protocol: TCP
       port: 11434
 ---


### PR DESCRIPTION
## Summary

- `oauth2-proxy-comfy` → `comfy-gateway:8189` was blocked by `default-deny-egress`
- `allow-llm-gateway-egress` only permitted LLM ports (1234, 8081, 8082, 11434) — missing ComfyUI port 8189
- Both wg-mesh CIDRs (192.168.100.0/24 mentolder, 10.13.14.0/24 korczewski) now allow port 8189

The fix has been applied imperatively to both clusters already; this PR makes it durable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)