### PR TITLE
feat(promote): add feature:promote task for dev → prod rollouts

### DIFF
--- a/.claude/skills/fleet-ops/SKILL.md
+++ b/.claude/skills/fleet-ops/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: fleet-ops
-description: Use when deploying, verifying, or operating across both prod clusters simultaneously — mentolder and korczewski. Covers task feature:* fan-out, cross-cluster schema changes, cluster status checks, Flux GitOps reconciliation, and the constraint that each cluster has its own independent shared-db and sealed-secrets controller.
+description: Use when deploying, verifying, or operating across both prod clusters simultaneously — mentolder and korczewski. Covers task feature:* fan-out, the feature:promote dev→prod flow with smoke gate and auto-rollback, cross-cluster schema changes, cluster status checks, Flux GitOps reconciliation, and the constraint that each cluster has its own independent shared-db and sealed-secrets controller.
 ---
 
 # fleet-ops — Two-Cluster Fleet Operations
@@ -31,6 +31,73 @@ task clusters:status       # One-line status across both
 ```
 
 Use `task workspace:deploy ENV=mentolder` + `ENV=korczewski` sequentially when you need finer control than the fan-out tasks.
+
+---
+
+## Promotion with Smoke Gate (`feature:promote`)
+
+`task feature:promote` is the dev → prod flow for service-image changes (website, brett, arena, docs). Differs from `feature:website` / `feature:brett` etc. in three ways:
+
+1. **Build-once-deploy-many** — one image tag (`promote-<sha>-<epoch>`) is built and pushed once, then `kubectl set image` applies the *byte-identical* artifact to dev and prod. Exception: `website` is brand-baked at build time, so mentolder + korczewski each build their own image (still build-once within each brand's dev→prod lineage).
+2. **Playwright smoke gate** between dev and prod. Failure aborts before any prod rollout.
+3. **Auto-rollback** — every `kubectl set image` is gated by `rollout status`; failure runs `rollout undo` on that deployment and exits non-zero. Cross-cluster rollback is *not* automatic — clusters that already shipped stay shipped.
+
+### Docs to both clusters
+
+`docs` has no dev stage and ignores `TARGET` (always fans out to both). Full happy path:
+
+```bash
+# 1. Dry-run first to see exactly what would execute.
+DRY_RUN=1 SERVICE=docs TARGET=both task feature:promote
+
+# 2. Real run.
+SERVICE=docs TARGET=both task feature:promote
+```
+
+What it does, in order:
+
+| Phase | Side effect |
+|---|---|
+| 1 | `node scripts/build-docs.js` regenerates `k3d/docs-content-built/` from the Markdown source. |
+| 1 | `docker build -f scripts/docs.Dockerfile .` produces `ghcr.io/paddione/workspace-docs:promote-<sha>-<epoch>`. |
+| 1 | `docker push` uploads that tag to ghcr. |
+| 2-3 | Skipped (docs has no dev cluster mapping). |
+| 4 | `kubectl --context mentolder -n workspace set image deploy/docs docs=<tag>` + `rollout status --timeout=180s`. Failure → `rollout undo`. |
+| 4 | Same against `korczewski` / `workspace-korczewski`. Mentolder failure does *not* roll back korczewski; korczewski failure rolls back korczewski only. |
+
+### Other services
+
+| Service | dev stage? | TARGET behavior |
+|---|---|---|
+| `website` | yes (`workspace-dev` / `workspace-korczewski-dev`) | `both` builds two images (brand-per-cluster); single target builds one |
+| `brett` | yes (same ns as website) | one image shared across clusters |
+| `arena` | korczewski-only | `TARGET=mentolder` rejected; `TARGET=both` downgrades to `korczewski`. Migrations & bootstrap Job are *not* promoted — run `task arena:deploy ENV=korczewski` for those. |
+| `docs` | no | always both, `TARGET` ignored |
+
+### Smoke spec overrides
+
+`feature:promote` resolves the Playwright `--grep` pattern in this order:
+
+1. `SMOKE_GREP` env var (per-run override) — `SMOKE_GREP="fa-46-brett-skins" task feature:promote`
+2. `tests/e2e/smoke/<service>.txt` — one pattern per non-comment line, joined with `|`
+3. Built-in default in `scripts/feature-promote.sh`
+
+The override files live next to the Playwright suite and document the convention in `tests/e2e/smoke/README.md`.
+
+### Useful knobs
+
+| Env var | Purpose |
+|---|---|
+| `DRY_RUN=1` | Echo docker/kubectl/playwright commands without executing |
+| `PROMOTE_TAG=v1.2.3` | Override the auto-generated tag (e.g. for human-meaningful semver) |
+| `ROLLBACK_TIMEOUT=300s` | Raise rollout-status timeout from the default 180s |
+| `SMOKE_GREP=...` | Override Playwright filter for this run only |
+
+### When *not* to use `feature:promote`
+
+- **Manifest or kustomize changes** — `feature:promote` only moves the image bits via `kubectl set image`. If a Deployment YAML, ConfigMap, Service, or kustomize overlay changed, run the full `task <svc>:deploy ENV=…` (or `feature:website` / `feature:brett`) once so the manifest lands.
+- **Schema migrations or bootstrap Jobs** — these run in `*:deploy` tasks, not in `feature:promote`. Arena migrations specifically: `task arena:deploy ENV=korczewski`.
+- **First-time deploy of a service** — the target Deployment must already exist; `kubectl set image` fails if `deploy/<name>` is missing.
 
 ---
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -79,6 +79,12 @@ tasks:
       - task: livekit:dns-pin
         vars: { ENV: "korczewski", APPLY: "true" }
 
+  feature:promote:
+    desc: "Promote a service dev → prod with Playwright smoke gate (SERVICE=website|brett|arena|docs TARGET=mentolder|korczewski|both; prompts if unset)"
+    interactive: true
+    cmds:
+      - bash scripts/feature-promote.sh
+
   health:
     desc: "Cross-cluster health check (status + connectivity + deployment verification)"
     cmds:

--- a/scripts/feature-promote.sh
+++ b/scripts/feature-promote.sh
@@ -1,0 +1,307 @@
+#!/usr/bin/env bash
+# feature-promote.sh — promote a service from dev → prod.
+#
+# Usage:
+#   SERVICE=website TARGET=both bash scripts/feature-promote.sh
+#   bash scripts/feature-promote.sh                  # prompts for SERVICE & TARGET
+#
+# Inputs:
+#   SERVICE             website | brett | arena | docs
+#   TARGET              mentolder | korczewski | both
+#   PROMOTE_TAG         override the auto-generated image tag
+#   SMOKE_GREP          override the Playwright --grep pattern for this run
+#   ROLLBACK_TIMEOUT    kubectl rollout timeout (default: 180s); rollback uses 120s
+#   DRY_RUN=1           print docker/kubectl/task/playwright commands without
+#                       executing them; safe to run against prod.
+#
+# ── Spec ─────────────────────────────────────────────────────────────────────
+#
+# 1. BUILD-ONCE-DEPLOY-MANY
+#    One image tag (PROMOTE_TAG) is built and pushed to ghcr, then applied to
+#    dev *and* prod via `kubectl set image`. No rebuild between stages — what
+#    smoke verifies on dev is byte-for-byte what ships to prod.
+#
+#    Exception: `website` builds per-brand because mentolder and korczewski use
+#    different image names (mentolder-website vs korczewski-website, brand-baked
+#    at build time). For TARGET=both this means two builds, one per brand —
+#    each still build-once within its own dev→prod lineage.
+#
+# 2. CONFIGURABLE SMOKE SPECS
+#    Playwright --grep pattern resolves in this priority:
+#      a) $SMOKE_GREP env var (per-run override)
+#      b) tests/e2e/smoke/<service>.txt (one pattern per non-comment line;
+#         joined with | into a single regex)
+#      c) built-in default below
+#    Empty pattern → smoke skipped (currently the case for `docs`).
+#
+# 3. AUTO-ROLLBACK ON FAILED ROLLOUT
+#    Every `kubectl set image` is followed by `kubectl rollout status` with
+#    $ROLLBACK_TIMEOUT. On failure we run `kubectl rollout undo` against that
+#    same deployment, wait up to 120s for the previous ReplicaSet to come back,
+#    and exit non-zero. Dev failures abort before prod. Prod failures roll back
+#    on the failing cluster only — other clusters already rolled out stay rolled
+#    out (no cross-cluster rollback; that'd need a coordinator and isn't the
+#    scope here).
+#
+# ── Per-service quirks ───────────────────────────────────────────────────────
+#   - arena: korczewski-only (TARGET=mentolder rejected; TARGET=both → korczewski).
+#            Migrations & bootstrap Job are NOT promoted; run `task arena:deploy
+#            ENV=korczewski` for those before/after as needed.
+#   - docs:  no dev stage; image deploys straight to both prods via set-image
+#            on both clusters. TARGET=both is implied.
+
+set -euo pipefail
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO"
+
+SERVICE="${SERVICE:-}"
+TARGET="${TARGET:-}"
+PROMOTE_TAG="${PROMOTE_TAG:-promote-$(git rev-parse --short HEAD 2>/dev/null || echo nogit)-$(date +%s)}"
+ROLLBACK_TIMEOUT="${ROLLBACK_TIMEOUT:-180s}"
+SMOKE_GREP_OVERRIDE="${SMOKE_GREP:-}"
+DRY_RUN="${DRY_RUN:-0}"
+
+# In dry-run mode, side-effect commands are echoed with a [dry-run] prefix
+# instead of executed. Read-only commands (kubectl get, etc.) still run so
+# diagnostic output stays accurate.
+run() {
+  if [[ "$DRY_RUN" == "1" ]]; then
+    echo "  [dry-run] $*"
+  else
+    "$@"
+  fi
+}
+
+# ── Prompts ───────────────────────────────────────────────────────────────────
+if [[ -z "$SERVICE" ]]; then
+  echo "Which service to promote?"
+  PS3=$'\nService: '
+  select s in website brett arena docs; do
+    [[ -n "$s" ]] && SERVICE="$s" && break
+  done
+fi
+if [[ -z "$TARGET" ]]; then
+  echo ""
+  echo "Which prod target?"
+  PS3=$'\nTarget: '
+  select t in mentolder korczewski both; do
+    [[ -n "$t" ]] && TARGET="$t" && break
+  done
+fi
+
+# ── Guards ────────────────────────────────────────────────────────────────────
+case "$SERVICE" in
+  website|brett|arena|docs) ;;
+  *) echo "✗ Unknown SERVICE='$SERVICE'" >&2; exit 1 ;;
+esac
+case "$TARGET" in
+  mentolder|korczewski|both) ;;
+  *) echo "✗ Unknown TARGET='$TARGET'" >&2; exit 1 ;;
+esac
+if [[ "$SERVICE" == "arena" ]]; then
+  [[ "$TARGET" == "mentolder" ]] && { echo "✗ arena is korczewski-only" >&2; exit 1; }
+  [[ "$TARGET" == "both" ]] && { echo "ℹ arena: TARGET=both → korczewski" >&2; TARGET=korczewski; }
+fi
+
+case "$TARGET" in
+  mentolder)  CLUSTERS=(mentolder) ;;
+  korczewski) CLUSTERS=(korczewski) ;;
+  both)       CLUSTERS=(mentolder korczewski) ;;
+esac
+
+# ── Per-service metadata ──────────────────────────────────────────────────────
+svc_image_repo() {
+  local svc="$1" cluster="$2"
+  case "$svc" in
+    website)
+      case "$cluster" in
+        mentolder)  echo "ghcr.io/paddione/mentolder-website" ;;
+        korczewski) echo "ghcr.io/paddione/korczewski-website" ;;
+      esac ;;
+    brett) echo "ghcr.io/paddione/workspace-brett" ;;
+    arena) echo "ghcr.io/paddione/arena-server" ;;
+    docs)  echo "ghcr.io/paddione/workspace-docs" ;;
+  esac
+}
+
+svc_deployment() {
+  case "$1" in
+    website) echo "website" ;;
+    brett)   echo "brett" ;;
+    arena)   echo "arena-server" ;;
+    docs)    echo "docs" ;;
+  esac
+}
+
+# Dev context/namespace per cluster.
+dev_ctx() { case "$1" in mentolder) echo "k3d-mentolder-dev" ;; korczewski) echo "k3d-korczewski-dev" ;; esac; }
+dev_ns()  { case "$1" in mentolder) echo "workspace-dev"    ;; korczewski) echo "workspace-korczewski-dev" ;; esac; }
+
+# Prod context is the bare cluster name; ns depends on service.
+prod_ctx() { echo "$1"; }
+prod_ns() {
+  local svc="$1" cluster="$2"
+  if [[ "$svc" == "website" ]]; then
+    [[ "$cluster" == "mentolder" ]] && echo "website" || echo "website-korczewski"
+  else
+    [[ "$cluster" == "mentolder" ]] && echo "workspace" || echo "workspace-korczewski"
+  fi
+}
+
+# ── Smoke spec resolution (#2) ────────────────────────────────────────────────
+default_smoke_grep() {
+  case "$1" in
+    website) echo 'fa-fragebogen|.*-auth-setup|fa-07-' ;;
+    brett)   echo 'brett-duel-mode|fa-27-brett' ;;
+    arena)   echo 'nfa-10-arena|fa-28-arena|fa-29-arena' ;;
+    docs)    echo '' ;;
+  esac
+}
+resolve_smoke_grep() {
+  local svc="$1" cfg="tests/e2e/smoke/$1.txt"
+  if [[ -n "$SMOKE_GREP_OVERRIDE" ]]; then echo "$SMOKE_GREP_OVERRIDE"; return; fi
+  if [[ -f "$cfg" ]]; then
+    # Lines that aren't blank/comments, joined with | into a single regex.
+    grep -vE '^\s*(#|$)' "$cfg" | paste -sd '|' -
+    return
+  fi
+  default_smoke_grep "$svc"
+}
+
+# ── Build + push the pinned tag (#1) ──────────────────────────────────────────
+# Returns the fully-qualified image (repo:tag) on stdout.
+build_and_push() {
+  local svc="$1" cluster="$2"
+  local repo full
+  repo=$(svc_image_repo "$svc" "$cluster")
+  full="${repo}:${PROMOTE_TAG}"
+
+  echo "▸ Build ${full}" >&2
+  case "$svc" in
+    website) run docker build -t "$full" website/ >&2 ;;
+    brett)   run docker build -t "$full" brett/ >&2 ;;
+    arena)   run docker build -t "$full" arena-server/ >&2 ;;
+    docs)
+      run node scripts/build-docs.js >&2
+      run docker build -t "$full" -f scripts/docs.Dockerfile . >&2
+      ;;
+  esac
+
+  echo "▸ Push ${full}" >&2
+  run docker push "$full" >&2
+  echo "$full"
+}
+
+# ── kubectl set-image with auto-rollback (#3) ─────────────────────────────────
+# Args: <stage:dev|prod> <cluster> <full_image>
+roll() {
+  local stage="$1" cluster="$2" full="$3"
+  local ctx ns deploy=$(svc_deployment "$SERVICE")
+  if [[ "$stage" == "dev" ]]; then
+    ctx=$(dev_ctx "$cluster"); ns=$(dev_ns "$cluster")
+  else
+    ctx=$(prod_ctx "$cluster"); ns=$(prod_ns "$SERVICE" "$cluster")
+  fi
+
+  echo "▸ ${stage}/${cluster}: set image deploy/${deploy} → ${full}"
+  if ! run kubectl --context "$ctx" -n "$ns" set image "deploy/${deploy}" "${deploy}=${full}"; then
+    echo "✗ set image failed on ${stage}/${cluster} (deploy/${deploy} may not exist yet — run full task ${SERVICE}:deploy first)" >&2
+    return 1
+  fi
+
+  if run kubectl --context "$ctx" -n "$ns" rollout status "deploy/${deploy}" --timeout="$ROLLBACK_TIMEOUT"; then
+    return 0
+  fi
+
+  echo "✗ Rollout FAILED on ${stage}/${cluster} — auto-rolling back…" >&2
+  run kubectl --context "$ctx" -n "$ns" rollout undo "deploy/${deploy}" || true
+  run kubectl --context "$ctx" -n "$ns" rollout status "deploy/${deploy}" --timeout=120s || true
+  echo "↩ Rolled back ${stage}/${cluster} to previous ReplicaSet." >&2
+  return 1
+}
+
+# ── Playwright smoke ─────────────────────────────────────────────────────────
+smoke_one() {
+  local cluster="$1" grep_pat="$2"
+  [[ -z "$grep_pat" ]] && return 0
+  local url
+  case "$cluster" in
+    mentolder)  url="https://dev.mentolder.de" ;;
+    korczewski) url="https://dev.korczewski.de" ;;
+  esac
+  echo "▸ Smoke ${url} (grep: ${grep_pat})"
+  if [[ "$DRY_RUN" == "1" ]]; then
+    echo "  [dry-run] (cd tests/e2e && WEBSITE_URL=$url playwright test --grep '$grep_pat' --reporter=line)"
+    return 0
+  fi
+  if [[ ! -d tests/e2e/node_modules ]]; then
+    ( cd tests/e2e && npm ci && ./node_modules/.bin/playwright install chromium )
+  fi
+  ( cd tests/e2e && WEBSITE_URL="$url" \
+      ./node_modules/.bin/playwright test --grep "$grep_pat" --reporter=line )
+}
+
+# ── Orchestration ────────────────────────────────────────────────────────────
+echo "═══ Promote ${SERVICE} → ${TARGET}  tag=${PROMOTE_TAG} ═══"
+
+# Phase 1 — build + push.
+# website builds per-brand; brett/arena/docs share one image across clusters.
+declare -A IMG
+echo ""
+echo "▶ Phase 1/4 — build + push"
+if [[ "$SERVICE" == "website" ]]; then
+  for c in "${CLUSTERS[@]}"; do
+    IMG[$c]=$(build_and_push "$SERVICE" "$c")
+  done
+else
+  shared=$(build_and_push "$SERVICE" "${CLUSTERS[0]}")
+  for c in "${CLUSTERS[@]}"; do IMG[$c]="$shared"; done
+fi
+
+# Phase 2 — dev rollout (skip for docs).
+if [[ "$SERVICE" != "docs" ]]; then
+  echo ""
+  echo "▶ Phase 2/4 — dev rollout"
+  for c in "${CLUSTERS[@]}"; do
+    roll dev "$c" "${IMG[$c]}" || { echo "✗ Dev rollout failed. Aborting." >&2; exit 1; }
+  done
+
+  # Phase 3 — smoke.
+  PW_FILTER=$(resolve_smoke_grep "$SERVICE")
+  echo ""
+  if [[ -n "$PW_FILTER" ]]; then
+    echo "▶ Phase 3/4 — Playwright smoke"
+    for c in "${CLUSTERS[@]}"; do
+      if ! smoke_one "$c" "$PW_FILTER"; then
+        echo "✗ Smoke FAILED on dev/${c}. Aborting before prod." >&2
+        echo "  Dev is still on tag ${PROMOTE_TAG}; revert with: kubectl --context $(dev_ctx "$c") -n $(dev_ns "$c") rollout undo deploy/$(svc_deployment "$SERVICE")" >&2
+        exit 1
+      fi
+    done
+  else
+    echo "▶ Phase 3/4 — smoke skipped (no pattern for ${SERVICE})"
+  fi
+else
+  echo ""
+  echo "▶ Phase 2-3/4 — skipped (docs has no dev stage)"
+fi
+
+# Phase 4 — prod rollout.
+echo ""
+echo "▶ Phase 4/4 — prod rollout"
+PROD_CLUSTERS=("${CLUSTERS[@]}")
+[[ "$SERVICE" == "docs" ]] && PROD_CLUSTERS=(mentolder korczewski)   # docs always both
+
+FAIL=0
+for c in "${PROD_CLUSTERS[@]}"; do
+  roll prod "$c" "${IMG[$c]:-${IMG[${CLUSTERS[0]}]}}" || FAIL=1
+done
+
+if (( FAIL )); then
+  echo ""
+  echo "✗ At least one prod cluster rolled back. Investigate before retrying." >&2
+  exit 1
+fi
+
+echo ""
+echo "✓ Promoted ${SERVICE} → ${TARGET} as ${PROMOTE_TAG}"

--- a/tests/e2e/smoke/README.md
+++ b/tests/e2e/smoke/README.md
@@ -1,0 +1,23 @@
+# Smoke spec overrides
+
+`scripts/feature-promote.sh` runs a curated Playwright subset between dev and
+prod rollouts to gate promotion. Override the built-in pattern per service by
+dropping a file here:
+
+    tests/e2e/smoke/<service>.txt
+
+One pattern per line, blanks and `#` comments ignored. Lines are joined with
+`|` into a single Playwright `--grep` regex.
+
+Example (`website.txt`):
+
+    fa-fragebogen
+    mentolder-auth-setup
+    korczewski-auth-setup
+    fa-07-
+
+Resolution priority inside the script:
+
+1. `SMOKE_GREP` env var (per-run override)
+2. `tests/e2e/smoke/<service>.txt`
+3. Built-in default in `feature-promote.sh`


### PR DESCRIPTION
## Summary

- New `task feature:promote` (SERVICE=website|brett|arena|docs, TARGET=mentolder|korczewski|both) drives a single image tag through dev rollout, Playwright smoke gate, then prod rollout
- **Build-once-deploy-many**: one \`PROMOTE_TAG\` (git SHA + epoch) pushed to ghcr, then \`kubectl set image\` on dev and prod — byte-identical artifact ships to both. Website still builds per-brand (different image names per cluster).
- **Auto-rollback** on failed \`rollout status\`; dev failure aborts before prod, prod failure rolls back the failing cluster only.
- **Configurable smoke specs** via 3-tier waterfall: \`SMOKE_GREP\` env → \`tests/e2e/smoke/<svc>.txt\` → built-in default.
- \`DRY_RUN=1\` echoes side-effect commands without executing — safe to run against prod for verification.

## Files

- \`scripts/feature-promote.sh\` (+307) — orchestration script
- \`Taskfile.yml\` (+6) — thin \`feature:promote\` task entry with \`interactive: true\`
- \`tests/e2e/smoke/README.md\` (+23) — convention docs for per-service spec overrides
- \`.claude/skills/fleet-ops/SKILL.md\` (+68) — documented dev→prod flow with docs→both worked example, per-service quirks, env knobs, \"when NOT to use\" guidance

## Service quirks (documented in skill + script header)

- **arena**: korczewski-only. \`TARGET=mentolder\` rejected; \`TARGET=both\` downgrades to korczewski. Migrations/bootstrap not promoted — run \`arena:deploy\` for those.
- **docs**: no dev stage; always fans out to both prods, \`TARGET\` ignored.

## When NOT to use \`feature:promote\`

- Manifest/kustomize changes (only image bits move; run \`*:deploy\` for manifests)
- Schema migrations or bootstrap Jobs
- First-time deploy of a service (\`kubectl set image\` fails if the Deployment doesn't exist)

## Test plan

- [x] \`bash -n scripts/feature-promote.sh\` clean
- [x] \`task --summary feature:promote\` resolves
- [x] \`DRY_RUN=1 SERVICE=docs TARGET=both task feature:promote\` enumerates expected commands with correct contexts/namespaces (mentolder→workspace, korczewski→workspace-korczewski)
- [ ] After merge: real \`SERVICE=docs TARGET=both task feature:promote\` against both prods
- [ ] Verify auto-rollback by intentionally pushing a broken image to a dev deploy