### PR TITLE
chore(maintenance): admin-actions resources + schema allowlist (closes #1100 #1106 #1107)

### DIFF
--- a/environments/schema.yaml
+++ b/environments/schema.yaml
@@ -379,6 +379,9 @@ secrets:
   #      ARCH                (k3d/nextcloud.yaml — set via `uname -m`)
   #      BACKUP_DIR, STAMP, PASS, UPLOAD_PATH, FILEN_PATH, DUMP, SIZE
   #                          (k3d/backup-cronjob.yaml — script-local)
+  #      DOMAIN, IP, IP_4, IP_6, IP_8, STATUS, FAILED
+  #                          (prod-korczewski/ddns-updater.yaml — script-local
+  #                           shell vars inside the ipv64 DDNS CronJob)
   #
   # 3. Pod env vars sourced from a ConfigMap/Secret reference (not
   #    envsubst — the `${VAR}` in the script reads the container env):

--- a/k3d/admin-actions-cronjobs.yaml
+++ b/k3d/admin-actions-cronjobs.yaml
@@ -19,6 +19,13 @@ spec:
           containers:
             - name: psql
               image: postgres:16-alpine
+              resources:
+                requests:
+                  cpu: "50m"
+                  memory: "64Mi"
+                limits:
+                  cpu: "200m"
+                  memory: "128Mi"
               env:
                 - name: PGPASSWORD
                   valueFrom: { secretKeyRef: { name: workspace-secrets, key: WEBSITE_DB_PASSWORD } }
@@ -62,6 +69,13 @@ spec:
           containers:
             - name: psql
               image: postgres:16-alpine
+              resources:
+                requests:
+                  cpu: "50m"
+                  memory: "64Mi"
+                limits:
+                  cpu: "200m"
+                  memory: "128Mi"
               env:
                 - name: PGPASSWORD
                   valueFrom: { secretKeyRef: { name: workspace-secrets, key: WEBSITE_DB_PASSWORD } }


### PR DESCRIPTION
## Summary
- Add `resources.requests`/`limits` to `psql` containers in `CronJob/admin-actions-cleanup` and `CronJob/admin-actions-prune` (50m/64Mi requests, 200m/128Mi limits) — scheduler-aware placement + protection from runaway jobs.
- Extend the audit-allowlist comment block in `environments/schema.yaml` with the 7 shell-local script vars from `prod-korczewski/ddns-updater.yaml` (`DOMAIN`, `IP`, `IP_4`, `IP_6`, `IP_8`, `STATUS`, `FAILED`).

Closes #1100, #1106, #1107.

## Test plan
- [x] `task workspace:validate` — manifests build clean
- [x] `task test:all` — all offline tests pass
- [ ] CI green