### PR TITLE
fix(mcp): point postgres MCP at website DB instead of postgres [T000285]

### DIFF
--- a/deploy/mcp-korczewski/patch-monolith.yaml
+++ b/deploy/mcp-korczewski/patch-monolith.yaml
@@ -16,7 +16,7 @@ spec:
                   name: claude-code-secrets
                   key: SHARED_DB_PASSWORD
             - name: DATABASE_URL
-              value: "postgresql://postgres:$(SHARED_DB_PASSWORD)@shared-db.workspace-korczewski.svc.cluster.local:5432/postgres"
+              value: "postgresql://postgres:$(SHARED_DB_PASSWORD)@shared-db.workspace-korczewski.svc.cluster.local:5432/website"
         - name: keycloak
           env:
             - name: KC_URL

--- a/deploy/mcp/claude-code-mcp-monolith.yaml
+++ b/deploy/mcp/claude-code-mcp-monolith.yaml
@@ -97,7 +97,7 @@ spec:
                   name: claude-code-secrets
                   key: SHARED_DB_PASSWORD
             - name: DATABASE_URL
-              value: "postgresql://postgres:$(SHARED_DB_PASSWORD)@shared-db.workspace.svc.cluster.local:5432/postgres"
+              value: "postgresql://postgres:$(SHARED_DB_PASSWORD)@shared-db.workspace.svc.cluster.local:5432/website"
           ports:
             - containerPort: 3001
               name: postgres

--- a/k3d/claude-code-mcp-ops.yaml
+++ b/k3d/claude-code-mcp-ops.yaml
@@ -71,7 +71,7 @@ spec:
               set -e
               npm install -g supergateway @modelcontextprotocol/server-postgres
               exec /tmp/npm-global/bin/supergateway \
-                --stdio "/tmp/npm-global/bin/mcp-server-postgres postgresql://postgres:$(SHARED_DB_PASSWORD)@shared-db:5432/postgres" \
+                --stdio "/tmp/npm-global/bin/mcp-server-postgres postgresql://postgres:$(SHARED_DB_PASSWORD)@shared-db:5432/website" \
                 --outputTransport streamableHttp \
                 --port 3001 \
                 --streamableHttpPath /mcp \


### PR DESCRIPTION
## Summary
The claude-code **postgres MCP server** was wired to the `postgres` maintenance DB rather than the application `website` DB. Queries against app tables (e.g. `tickets.tickets`) hit an empty catalog, forcing `kubectl exec` workarounds.

This flips `DATABASE_URL` from `/postgres` → `/website` in all three MCP manifests:
- `k3d/claude-code-mcp-ops.yaml` (dev)
- `deploy/mcp/claude-code-mcp-monolith.yaml` (mentolder)
- `deploy/mcp-korczewski/patch-monolith.yaml` (korczewski)

## Ticket
Resolves **T000285**.

## Deploy note
These MCP overlays are **not** Flux-managed. After merge, run `task mcp:deploy ENV=mentolder` and `task mcp:deploy ENV=korczewski` to roll the change onto the live MCP pods.

🤖 Generated with [Claude Code](https://claude.com/claude-code)