### PR TITLE
chore(skills): fix Flux kustomization name drift in fleet-ops

### DIFF
--- a/.claude/skills/fleet-ops/SKILL.md
+++ b/.claude/skills/fleet-ops/SKILL.md
@@ -190,10 +190,12 @@ flux reconcile source git flux-system --context korczewski
 
 # Step 2: reconcile the kustomization
 flux reconcile kustomization workspace --context mentolder
-flux reconcile kustomization workspace-korczewski --context korczewski
+flux reconcile kustomization workspace --context korczewski
 ```
 
 > **Why source first?** `flux reconcile kustomization` re-applies whatever revision the GitRepository last fetched. If that's 5 minutes old, the kustomization gets the wrong commit.
+
+> **Kustomization name ≠ git path.** The Flux `Kustomization` resource is named `workspace` on **both** clusters (`metadata.name` in `flux/clusters/<env>/workspace.yaml`); only the `path:` differs (`./prod-mentolder` vs `./prod-korczewski`). Likewise the website kustomization is named `website` on both (paths `./flux/apps/website-mentolder` / `-korczewski`). `flux reconcile kustomization <name>` takes the **name**, not the path — so `flux reconcile kustomization workspace-korczewski` fails with "not found". Always reconcile by the base name and select the cluster with `--context`.
 
 ### Check Flux Status
 


### PR DESCRIPTION
## Summary
- `fleet-ops/SKILL.md` forced-reconcile snippet used `flux reconcile kustomization workspace-korczewski`, which fails with **"not found"** — the Flux `Kustomization` `metadata.name` is `workspace` on **both** clusters (`flux/clusters/<env>/workspace.yaml`); only the `path:` differs (`./prod-mentolder` vs `./prod-korczewski`).
- Corrected line to reconcile `workspace` on both `--context`s.
- Added a clarifying note: `flux reconcile kustomization <name>` takes the resource **name**, not the git path — covers both the `workspace` and `website` kustomizations (the latter is named `website` on both clusters, paths `./flux/apps/website-mentolder` / `-korczewski`).

Context: reported as `website-mentolder`/`website-korczewski` drift in dev-flow-execute Step 8 / the plan template, but those deploy the website via `task feature:website` and contain no `flux reconcile` command. The real instance of the path-vs-name confusion was this `workspace-korczewski` line.

## Test plan
- `task test:all` → green (exit 0, 0 failures).
- Doc-only change to `.claude/skills/` → no deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)