### PR TITLE
fix(dev-db-refresh): allow dev-node hostNetwork ingress to shared-db [T000286]

### DIFF
--- a/prod-mentolder/dev-db-refresh-netpol.yaml
+++ b/prod-mentolder/dev-db-refresh-netpol.yaml
@@ -1,0 +1,41 @@
+# ════════════════════════════════════════════════════════════════════
+# allow-devnode-hostnet-to-shared-db-ingress (mentolder, T000286)
+#
+# The dev-db-refresh CronJob runs with hostNetwork:true pinned to the dev
+# node ($DEV_NODE = k3s-1) so it can reach the k3d-published dev Postgres
+# NodePort at 127.0.0.1:15432. Since #1130 it pulls a live pg_dump from the
+# prod shared-db Service over the cluster network instead of mounting the
+# (un-attachable) Longhorn backup-pvc.
+#
+# shared-db sits behind default-deny-ingress + per-client allow policies.
+# A hostNetwork pod has NO pod IP, so podSelector/namespaceSelector rules
+# (incl. allow-intra-namespace-ingress) can never match it — its traffic
+# arrives at shared-db with the source IP of the dev node's flannel VTEP
+# (10.42.3.0 for k3s-1's 10.42.3.0/24 podCIDR), exactly like the Traefik
+# hostNetwork case handled by allow-traefik-ingress (10.42.0.0/32).
+# We therefore whitelist the dev node's VTEP and node IP on 5432 only.
+#
+# Scoped to k3s-1 alone (not the whole pod CIDR) to preserve shared-db's
+# least-privilege ingress. mentolder-only: this overlay is not applied to
+# korczewski, which has no dev node.
+# ════════════════════════════════════════════════════════════════════
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-devnode-hostnet-to-shared-db-ingress
+  namespace: workspace
+spec:
+  podSelector:
+    matchLabels:
+      app: shared-db
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - ipBlock:
+            cidr: 10.42.3.0/32       # k3s-1 flannel VTEP (hostNetwork src after encap)
+        - ipBlock:
+            cidr: 192.168.100.20/32  # k3s-1 node InternalIP (belt-and-suspenders, no-masquerade path)
+      ports:
+        - port: 5432
+          protocol: TCP

--- a/prod-mentolder/kustomization.yaml
+++ b/prod-mentolder/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
   - oauth2-proxy-dev-middleware.yaml
   - dev-ingress.yaml
   - dev-db-refresh-cron.yaml
+  - dev-db-refresh-netpol.yaml  # T000286: allow dev-node hostNetwork → shared-db:5432
   # ── brainstorm.mentolder.de reverse-SSH broker (sish) ─────────────
   - brainstorm-sish.yaml
   # Whisper + Talk-Transcriber — now also on mentolder.


### PR DESCRIPTION
## Summary
Follow-up to #1130. That PR removed the Longhorn `backup-pvc` mount (which couldn't attach on the `k3s-1` dev-node) and switched `dev-db-refresh` to a **live `pg_dump` from the prod `shared-db` Service**. A manual smoke run (`kubectl create job --from=cronjob/dev-db-refresh`) proved the Longhorn crash is gone — but the new path is **blocked by `shared-db`'s `default-deny-ingress`**.

## Root cause
The `dev-db-refresh` pod runs `hostNetwork: true` (pinned to `k3s-1` so it can reach the k3d dev Postgres at `127.0.0.1:15432`). A hostNetwork pod has **no pod IP**, so `podSelector`/`namespaceSelector` ingress rules — including `allow-intra-namespace-ingress` — can never match it. Its traffic reaches `shared-db` with the source IP of the dev node's **flannel VTEP** (`10.42.3.0`, from `k3s-1`'s `10.42.3.0/24` podCIDR). Verified: `shared-db:5432` is `connection refused` (RST) from an unprivileged probe; an *allowed* client (the MCP monolith) connects fine.

## Fix
Add `allow-devnode-hostnet-to-shared-db-ingress` (prod-mentolder overlay) whitelisting **only** `k3s-1`'s VTEP `10.42.3.0/32` + node IP `192.168.100.20/32` on port **5432**, mirroring the existing `allow-traefik-ingress` hostNetwork pattern (`10.42.0.0/32`). Scoped to one node to preserve `shared-db`'s least-privilege ingress; **mentolder-only** (korczewski has no dev node).

## Validation
- `kubectl kustomize prod-mentolder/` builds clean; policy renders scoped to `k3s-1`.
- ⚠️ **End-to-end smoke still pending**: the dev k3d cluster's dest `127.0.0.1:15432` was down during investigation, so the full refresh couldn't be verified. After merge + deploy, re-run `kubectl create job --from=cronjob/dev-db-refresh dev-db-refresh-smoke -n workspace --context mentolder` **with the dev cluster up** and confirm `website` is refreshed.

## Deploy
Flux-managed (`prod-mentolder` overlay) — reconcile after merge, or `task workspace:deploy ENV=mentolder`.

Refs **T000286**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)