### PR TITLE
fix(dev-stack): auto-restart dev k3d cluster on host boot [T000290]

### DIFF
--- a/Taskfile.dev-stack.yml
+++ b/Taskfile.dev-stack.yml
@@ -86,6 +86,19 @@ tasks:
     cmds:
       - kubectl --context {{.CTX_DEV}} get pods,svc,ing -n {{.NS_DEV}}
 
+  cluster:autostart:
+    desc: "[dev] Install a systemd unit on $DEV_NODE so the k3d cluster restarts on host boot (T000290)"
+    deps: [_node-guard]
+    cmds:
+      - |
+        set -euo pipefail
+        source scripts/env-resolve.sh "{{.ENV}}"
+        if [[ "$(hostname -s 2>/dev/null | tr '[:upper:]' '[:lower:]')" == "${DEV_NODE%%.*}" ]]; then
+          CLUSTER_NAME={{.CLUSTER_NAME}} bash scripts/dev-cluster-autostart.sh
+        else
+          ssh ${DEV_SSH_USER:-root}@$DEV_NODE "CLUSTER_NAME={{.CLUSTER_NAME}} bash -s" < scripts/dev-cluster-autostart.sh
+        fi
+
   logs:
     desc: "[dev] Tail logs of a pod (usage: task dev:logs -- website|brett|shared-db-dev|sish)"
     cmds:

--- a/scripts/dev-cluster-autostart.sh
+++ b/scripts/dev-cluster-autostart.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Install a systemd unit that starts the dev k3d cluster on host boot.
+#
+# Fixes T000290 (recurrence of T000013): the mentolder-dev k3d cluster did not
+# come back after a k3s-1 host reboot, taking dev.mentolder.de offline and
+# breaking the published 127.0.0.1:15432 db port that the nightly
+# dev-db-refresh CronJob consumes — until someone manually ran
+# `k3d cluster start mentolder-dev`.
+#
+# The container restart policy alone (unless-stopped) is insufficient: it does
+# NOT restart containers that were already exited at reboot, nor undo an
+# explicit `k3d cluster stop`. A boot-time oneshot covers both gaps.
+#
+# Idempotent. Run ON the dev node — it needs sudo + the local docker/k3d.
+# Invoked by `task dev:cluster:autostart` (locally or over SSH).
+#   CLUSTER_NAME=mentolder-dev bash scripts/dev-cluster-autostart.sh
+set -euo pipefail
+
+CLUSTER_NAME="${CLUSTER_NAME:-mentolder-dev}"
+K3D_BIN="$(command -v k3d || echo /usr/local/bin/k3d)"
+UNIT="/etc/systemd/system/k3d-${CLUSTER_NAME}.service"
+
+sudo tee "$UNIT" >/dev/null <<UNITFILE
+[Unit]
+Description=Start k3d ${CLUSTER_NAME} cluster on boot
+Documentation=ticket:T000290
+After=docker.service
+Requires=docker.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=true
+# Idempotent: no-op if the cluster is already running. Never \`create\` here —
+# that would lose the load-bearing port mappings (18080/2222/15432). Only
+# start/stop.
+ExecStart=${K3D_BIN} cluster start ${CLUSTER_NAME}
+ExecStop=${K3D_BIN} cluster stop ${CLUSTER_NAME}
+
+[Install]
+WantedBy=multi-user.target
+UNITFILE
+
+sudo systemctl daemon-reload
+sudo systemctl enable --now "k3d-${CLUSTER_NAME}.service"
+echo "✓ Installed and enabled k3d-${CLUSTER_NAME}.service"
+sudo systemctl is-enabled "k3d-${CLUSTER_NAME}.service"


### PR DESCRIPTION
## Problem

The `mentolder-dev` k3d cluster on `k3s-1` did **not** come back after a host reboot (found `SERVERS 0/1`, containers `Exited`), taking `dev.mentolder.de` offline and breaking the published `127.0.0.1:15432` db port that the nightly `dev-db-refresh` CronJob consumes — until someone manually ran `k3d cluster start mentolder-dev`. This is a recurrence of **T000013**, which was closed with only a one-shot `start` and no persistence fix.

## Why the restart policy isn't enough

The dev containers already carry `restart=unless-stopped`, but that:
- does **not** restart containers that were *already exited* at the time of the reboot (exactly the observed state), and
- does **not** undo an explicit `k3d cluster stop`.

## Fix

A boot-time **systemd oneshot** on the dev node that runs `k3d cluster start <cluster>` after `docker.service`:
- **Idempotent** — no-op if the cluster is already running.
- **Never `create`** — only `start`/`stop`, so the load-bearing port mappings (`18080`/`2222`/`15432`) survive.

- `scripts/dev-cluster-autostart.sh` — installs + enables the unit (run on the node; needs sudo + local docker/k3d).
- `task dev:cluster:autostart` — installs it locally or over SSH to `$DEV_NODE`; also wired for the `dev-korczewski:` namespace.

## Verification

The unit is **already installed and enabled on k3s-1** (`systemctl is-enabled` → `enabled`; idempotent start logged "All servers already running"; cluster intact `1/1`). This PR makes that host state reproducible so the manually-managed dev cluster no longer silently drifts.

- `bash -n scripts/dev-cluster-autostart.sh` ✓
- `task dev:cluster:autostart --dry` ✓
- `task --list` shows the new task under `dev:` and `dev-korczewski:` ✓

Resolves T000290.

🤖 Generated with [Claude Code](https://claude.com/claude-code)