### PR TITLE
fix(ops-agent): require output-trust discipline before diagnosing [T000288]

### DIFF
--- a/.claude/agents/bachelorprojekt-ops.md
+++ b/.claude/agents/bachelorprojekt-ops.md
@@ -10,6 +10,13 @@ tools: [run_shell_command, read_file, glob, grep_search, list_directory]
 
 You are an operations specialist for the Bachelorprojekt Kubernetes platform. You investigate and fix live cluster issues.
 
+## Output trust & shell-session integrity
+Your diagnoses are trusted downstream and acted on. A confident conclusion drawn from a broken shell is more dangerous than the broken shell itself — so verify the session before you believe anything it returns.
+
+1. **Probe before trusting the session.** As the first step of any investigation, run a trivial command with a known-shaped answer — `kubectl get nodes --context mentolder` — and confirm you got real output (an actual node table) rather than the command echoed back at you.
+2. **Recognise corruption signals.** Treat the session as unreliable if `run_shell_command` echoes the input command instead of executing it, if a command returns a stale PTY buffer / stale prompt artifact (e.g. `date` returning a literal like the username instead of a timestamp), or if output is otherwise desynced from the command you ran.
+3. **Fail loud — never fabricate.** If output looks echoed, stale, or suspicious, do NOT draw or narrate a diagnosis from it. Stop, and report the broken / unreliable environment to the orchestrator instead of producing a confident but unverified conclusion. A halted investigation with "the shell session is corrupted" is the correct, safe outcome.
+
 ## Cluster topology
 Two physical clusters since 2026-05-09 (PRs #621/#622 re-split the brief merge). Verify with `kubectl config get-contexts` before any kubectl command.
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -237,6 +237,7 @@ tasks:
       - '[ -f ./tests/unit/lib/bats-core/bin/bats ] || git submodule update --init --recursive'
       - task: test:unit:assert
       - task: test:unit:scripts
+      - task: test:unit:agents
       - task: test:unit:figure-pack
 
   test:unit:assert:
@@ -248,6 +249,11 @@ tasks:
     internal: true
     cmds:
       - ./tests/unit/lib/bats-core/bin/bats tests/unit/scripts.bats
+
+  test:unit:agents:
+    internal: true
+    cmds:
+      - ./tests/unit/lib/bats-core/bin/bats tests/unit/agent-ops-output-trust.bats
 
   test:unit:figure-pack:
     internal: true

--- a/docs/superpowers/plans/2026-05-29-ops-agent-output-trust.md
+++ b/docs/superpowers/plans/2026-05-29-ops-agent-output-trust.md
@@ -1,0 +1,61 @@
+---
+title: Fix T000288 — ops agent: output-trust discipline
+ticket_id: T000288
+domains: []
+status: active
+pr_number: null
+---
+
+# Fix T000288 — ops agent: output-trust discipline
+
+Branch: `fix/ops-agent-output-trust`
+Ticket: T000288 (bug, priority hoch, severity major)
+Test: `tests/unit/agent-ops-output-trust.bats` (already staged, currently RED)
+
+## Problem
+
+The `bachelorprojekt-ops` subagent ran inside a corrupted PTY:
+`run_shell_command` echoed the input command back instead of executing it,
+and `date` returned the literal `patrick` (a stale prompt-buffer artifact).
+Despite the broken shell, the agent narrated a confident, plausible-but-false
+diagnosis. The recoverable failure is the broken shell; the real hazard is the
+agent fabricating an authoritative conclusion from garbage output, because
+downstream actions trust it.
+
+## Fix (agent-prompt only)
+
+Add a new `## Output trust & shell-session integrity` section to
+`.claude/agents/bachelorprojekt-ops.md`. The section must instruct the agent to:
+
+1. **Probe before trusting the session.** At the start of an investigation run a
+   trivial, verifiable command — `kubectl get nodes --context mentolder` — and
+   confirm the output is real (a node table), not the command echoed back.
+2. **Recognise corruption signals.** Output that repeats the input command, a
+   stale prompt buffer (e.g. a command returning a literal like the username
+   instead of real output), or any desynced `run_shell_command` session.
+3. **Fail loud, never fabricate.** If output looks echoed / stale / suspicious,
+   do NOT draw a diagnosis from it. Stop and report the broken/unreliable
+   environment to the orchestrator instead of narrating a confident conclusion.
+
+Wording is free, but the section must satisfy the regression guards in
+`tests/unit/agent-ops-output-trust.bats`:
+- a `##` heading matching output-trust / shell-session / session-integrity
+- mentions echoed input / stale PTY buffer / desync
+- a never/do-not directive against fabricating/concluding/trusting
+- the literal probe `kubectl get nodes --context mentolder`
+- a directive to report/surface/stop on a broken/corrupt/unreliable environment
+
+## Verification
+
+```bash
+./tests/unit/lib/bats-core/bin/bats tests/unit/agent-ops-output-trust.bats   # GREEN
+task test:all                                                                # GREEN (CI parity)
+```
+
+## Out of scope
+
+- The PTY/run_shell_command wrapper fault itself is an environment/harness bug,
+  not fixable in this repo. This fix only hardens the agent against *trusting*
+  corrupted output.
+- No deploy: `.claude/`, `tests/`, and `Taskfile.yml` changes are not deployed
+  to clusters.

--- a/tests/unit/agent-ops-output-trust.bats
+++ b/tests/unit/agent-ops-output-trust.bats
@@ -1,0 +1,46 @@
+#!/usr/bin/env bats
+# ═══════════════════════════════════════════════════════════════════
+# agent-ops-output-trust.bats — Regression guard for T000288
+# ═══════════════════════════════════════════════════════════════════
+# The bachelorprojekt-ops agent once narrated a confident-but-false
+# diagnosis from a corrupted PTY (run_shell_command echoed input;
+# `date` returned the literal username instead of real output).
+#
+# The fixable hazard is the FABRICATION, not the broken shell. These
+# tests assert the agent system prompt carries an explicit
+# output-trust / shell-session-integrity discipline so the guidance
+# cannot be silently dropped by a future edit.
+# ═══════════════════════════════════════════════════════════════════
+
+load test_helper
+
+AGENT_FILE="${PROJECT_DIR}/.claude/agents/bachelorprojekt-ops.md"
+
+@test "bachelorprojekt-ops agent file exists" {
+  [ -f "$AGENT_FILE" ]
+}
+
+@test "ops agent has an output-trust / shell-integrity section" {
+  run grep -qiE '^##[[:space:]].*(output[- ]trust|shell[- ]session|session[- ]integrity)' "$AGENT_FILE"
+  [ "$status" -eq 0 ]
+}
+
+@test "ops agent warns about echoed input / stale PTY buffer" {
+  run grep -qiE '(echo(es|ed|ing)?[[:space:]].*(input|command)|stale[[:space:]].*(buffer|prompt|pty)|desync)' "$AGENT_FILE"
+  [ "$status" -eq 0 ]
+}
+
+@test "ops agent forbids fabricating a diagnosis from unverified output" {
+  run grep -qiE '(never|do not|don.t)[[:space:]].*(fabricat|conclu|diagnos|narrat|trust)' "$AGENT_FILE"
+  [ "$status" -eq 0 ]
+}
+
+@test "ops agent prescribes the trivial verifiable probe" {
+  run grep -qF 'kubectl get nodes --context mentolder' "$AGENT_FILE"
+  [ "$status" -eq 0 ]
+}
+
+@test "ops agent tells the agent to report the broken environment instead" {
+  run grep -qiE '(report|surface|stop|abort|bail).*(broken|corrupt|unreliable|environment|session)' "$AGENT_FILE"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary
- The `bachelorprojekt-ops` subagent once ran inside a corrupted PTY (`run_shell_command` echoed the input back; `date` returned the literal username) yet narrated a confident, **plausible-but-false** diagnosis. Downstream actions trust that conclusion — so the fabrication is the real hazard, not the broken shell.
- Adds an **"Output trust & shell-session integrity"** section to `.claude/agents/bachelorprojekt-ops.md`: probe the session first (`kubectl get nodes --context mentolder`), recognise corruption signals (echoed input / stale PTY buffer / desync), and **fail loud** — report the broken environment instead of fabricating a diagnosis.

The PTY/`run_shell_command` wrapper fault itself is an environment/harness bug, out of scope here. This hardens the agent against *trusting* corrupted output.

## Test plan
- [x] `./tests/unit/lib/bats-core/bin/bats tests/unit/agent-ops-output-trust.bats` — 6/6 PASS (was RED)
- [x] `task test:all` — green (CI parity)

Agent-prompt only (`.claude/`, `tests/`, `Taskfile.yml`) — no cluster deploy.

Closes T000288

🤖 Generated with [Claude Code](https://claude.com/claude-code)