### PR TITLE
fix(billing): point dunning CronJob at website namespace on mentolder [T000295]

### DIFF
--- a/k3d/cronjob-dunning-detection.yaml
+++ b/k3d/cronjob-dunning-detection.yaml
@@ -16,7 +16,10 @@ spec:
             command:
             - /bin/sh
             - -c
-            - "curl -s -X POST http://website.workspace.svc.cluster.local/api/admin/billing/dunning/run -H \"X-Cron-Secret: ${CRON_SECRET}\" || exit 1"
+            # website Deployment lives in the `website` namespace (not `workspace`).
+            # -fsS: fail on HTTP errors and surface them, instead of silently exiting 0.
+            # korczewski overrides this URL to website-korczewski via prod-korczewski/patch-cronjob-urls.yaml.
+            - "curl -fsS -X POST http://website.website.svc.cluster.local/api/admin/billing/dunning/run -H \"X-Cron-Secret: ${CRON_SECRET}\" || exit 1"
             resources:
               requests:
                 cpu: 10m

--- a/tests/unit/manifests.bats
+++ b/tests/unit/manifests.bats
@@ -341,6 +341,51 @@ PY
   assert_success
 }
 
+# ── billing-dunning-detection targets the website namespace (T000295) ──
+# The website Deployment lives in its own `website` (mentolder) /
+# `website-korczewski` namespace — never in `workspace`. The base
+# k3d/cronjob-dunning-detection.yaml curls website.workspace.svc.cluster.local,
+# which does not resolve on either prod cluster, so curl -s exits non-zero
+# and the daily Job fails forever (silently — lastSuccessfulTime never set).
+# Its sibling cronjobs (notify-unread, monthly-billing) already use the
+# correct website.website* target. Assert no prod overlay renders the dunning
+# job pointed at the workspace namespace.
+@test "prod overlays: billing-dunning-detection does not target workspace ns [T000295]" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 not installed"
+  fi
+  run python3 - "${PROJECT_DIR}" <<'PY'
+import subprocess, sys, yaml, glob, os
+project = sys.argv[1]
+overlays = sorted(d for d in glob.glob(os.path.join(project, 'prod-*')) if os.path.isdir(d))
+bad = []
+for ov in overlays:
+    r = subprocess.run(
+        ['kubectl', 'kustomize', ov, '--load-restrictor=LoadRestrictionsNone'],
+        capture_output=True, text=True)
+    if r.returncode != 0:
+        print(f'kustomize build failed for {ov}: {r.stderr}', file=sys.stderr)
+        sys.exit(2)
+    for doc in yaml.safe_load_all(r.stdout):
+        if not doc:
+            continue
+        if doc.get('kind') == 'CronJob' and \
+                doc.get('metadata', {}).get('name') == 'billing-dunning-detection':
+            cmd = ' '.join(
+                doc['spec']['jobTemplate']['spec']['template']['spec']
+                   ['containers'][0].get('command', []))
+            if 'website.workspace.svc' in cmd:
+                bad.append(f"{os.path.basename(ov)}: {cmd}")
+if bad:
+    print('dunning CronJob still targets the workspace ns (website lives elsewhere):')
+    for b in bad:
+        print('  ' + b)
+    sys.exit(1)
+print('OK: dunning CronJob targets the website namespace in all prod overlays')
+PY
+  assert_success
+}
+
 @test "Taskfile.yml does not corrupt native Kubernetes expansions with sed" {
   run grep -F 'sed '\''s/\$(\([^)]*\))/\${\1}/g'\''' "${PROJECT_DIR}/Taskfile.yml"
   # We expect grep to fail (not find the pattern), meaning the breaking sed is gone.


### PR DESCRIPTION
## Summary
- `billing-dunning-detection` has **never succeeded on mentolder** — the base CronJob curled `website.workspace.svc.cluster.local`, but the website Deployment lives in the **`website`** namespace. DNS resolution failed → `curl -s … || exit 1` exited non-zero → daily 06:00 Job failed forever (`lastSuccessfulTime` always empty), so overdue-payment dunning detection silently never ran.
- Root cause was a lone outlier: sibling base cronjobs (`notify-unread`, `monthly-billing`) already use the correct `website.website.*` target, and `notify-unread` succeeds on mentolder — proving the workspace→website network path works.
- korczewski was unaffected (`prod-korczewski/patch-cronjob-urls.yaml` overrides the URL to `website-korczewski`).

## Changes
- Correct base URL → `website.website.svc.cluster.local`.
- Harden `curl -s` → `curl -fsS` so backend HTTP 5xx also fails the Job loudly (`-s` alone returns 0 on HTTP errors — the original silent-failure trap).
- Add a prod-overlay manifest test (`tests/unit/manifests.bats`) asserting the dunning CronJob never targets the `workspace` namespace in any `prod-*` overlay.

## Test plan
- `tests/unit/manifests.bats` — new test fails on `main` (red), passes after the fix (green); full suite 28/28 green.
- `task workspace:validate` — ✓ Manifests are valid.
- Rendered URLs verified: `prod-mentolder` → `website.website.svc.cluster.local` (`-fsS`); `prod-korczewski` → `website.website-korczewski.svc.cluster.local` (unchanged).
- Post-merge: trigger a manual Job from the cronjob on mentolder and confirm it Completes.

Ticket: T000295