### PR TITLE
chore(skills): harden dev-flow toolchain (test-gate, branch-guard, worktree merge, enum)

### DIFF
--- a/.claude/skills/dev-flow-execute/SKILL.md
+++ b/.claude/skills/dev-flow-execute/SKILL.md
@@ -130,6 +130,21 @@ Kein Blocker — nur Warnung und Bestätigung vom User, wenn Überschneidung erk
 
 Bevor irgendein Agent Code schreibt, Branch auf `origin/main` rebsen — verhindert Merge-Konflikte im PR.
 
+**Branch-Guard VOR jeder destruktiven Git-Op (parallel-session safety):** Eine parallele Claude-Session kann zwischen Schritt 0 und hier den ausgecheckten Branch im selben Repo gewechselt haben (Merge + `--delete-branch` einer anderen Session lässt den primären Worktree silent auf `main` zurück). Der `git stash`/`git rebase` unten würde dann auf dem falschen Branch laufen und Arbeit zerstören. Verifiziere den Branch **bevor** irgendetwas gestasht oder rebased wird:
+
+```bash
+EXPECTED_BRANCH="<feature-or-fix-branch>"   # der Branch aus Schritt 0
+ACTUAL_BRANCH=$(git branch --show-current)
+if [[ "$ACTUAL_BRANCH" != "$EXPECTED_BRANCH" ]]; then
+  echo "🛑 HALT: Branch-Mismatch VOR rebase/stash!"
+  echo "  Erwartet: $EXPECTED_BRANCH"
+  echo "  Aktuell:  $ACTUAL_BRANCH"
+  echo "  Eine parallele Session hat den Branch gewechselt. KEIN stash/rebase. Abbrechen und prüfen."
+  exit 1
+fi
+echo "✓ Branch bestätigt: $ACTUAL_BRANCH — sicher zu rebasen."
+```
+
 ```bash
 git fetch origin main
 git rebase origin/main
@@ -226,7 +241,20 @@ Ohne diese Anweisung schreiben Sub-Agents in das Haupt-Repo statt in den Worktre
 
 ### Fix
 
-Implementiere bis der failing Test (aus `dev-flow-plan` Schritt 3) grün ist. Pflicht: red → green → refactor.
+**Test-Gate (Pflicht — vor jeder Implementierung):** Der Fix-Pfad setzt voraus, dass `dev-flow-plan` Schritt 3 einen *failing* Regressionstest gestaged hat. Verifiziere das, **bevor** du Implementierungscode schreibst — fehlt der Test, ist die red→green-Disziplin verletzt (genau die Lücke, durch die PR #1134 testlos shipte). Dann: NICHT implementieren, sondern zuerst den failing Test schreiben (zurück zu `dev-flow-plan` Fix-Pfad Schritt 3).
+
+```bash
+# Test-Diff gegenüber main prüfen — der Fix-Branch MUSS mindestens eine Test-Datei berühren
+TEST_TOUCHED=$(git diff --name-only origin/main...HEAD | grep -E '^tests/|\.test\.(ts|js|mjs)$|\.spec\.ts$|\.bats$' | head -5)
+if [[ -z "$TEST_TOUCHED" ]]; then
+  echo "🛑 HALT: Fix-Branch hat keinen Test angefasst. Kein Regressionstest = kein Merge."
+  echo "  Schreibe zuerst einen failing Test (dev-flow-plan Fix-Pfad Schritt 3), dann implementiere."
+  exit 1
+fi
+echo "✓ Regressionstest vorhanden:"; echo "$TEST_TOUCHED"
+```
+
+Implementiere dann bis der failing Test (aus `dev-flow-plan` Schritt 3) grün ist. Pflicht: red → green → refactor.
 
 ```bash
 ./tests/runner.sh local <test-id>
@@ -394,6 +422,17 @@ Das ist alles — die PR-Nummer landet in Schritt 6.5 als Comment-Body und in Sc
 MAIN_REPO=$(git worktree list --porcelain | awk '/^worktree/{print $2; exit}')
 (cd "$MAIN_REPO" && gh pr merge --squash --delete-branch)
 ```
+
+> **`--auto` aus einem Worktree no-oppt silent (CI noch nicht grün):** Wenn CI noch läuft und du `gh pr merge <n> --squash --delete-branch --auto` brauchst, darf das **nicht** aus dem `/tmp/wt-*`-Worktree laufen — dort scheitert es entweder mit `fatal: 'main' is already used by worktree at <primary>`, oder ein Re-Run aus einem neutralen Verzeichnis exit-0t, ohne den Auto-Merge tatsächlich zu setzen (silent no-op). Zwei sichere Varianten:
+> ```bash
+> # A) --auto immer mit --repo aus dem Haupt-Repo (außerhalb jedes Worktrees):
+> (cd "$MAIN_REPO" && gh pr merge <n> --squash --delete-branch --auto --repo Paddione/Bachelorprojekt)
+>
+> # B) Fallback ohne --auto: CI grün pollen, dann direkt mergen:
+> until [[ "$(gh pr checks <n> --json state -q '[.[]|select(.state!="SUCCESS"and .state!="SKIPPED")]|length')" == "0" ]]; do sleep 20; done
+> (cd "$MAIN_REPO" && gh pr merge <n> --squash --delete-branch)
+> ```
+> Danach immer per Zeitstempel verifizieren (siehe unten), nie per Exit-Code. [T000298]
 
 > **Erwarteter Exit-1 nach Squash-Merge — kein echter Fehler:** Nach einem Squash-Merge weicht der lokale Branch vom Remote-main ab (neuer Squash-Commit ≠ lokale Commit-Historie). `gh pr merge` schlägt dann mit `not possible to fast-forward` fehl (exit 1), obwohl der PR erfolgreich gemergt wurde. Das ist **normales Verhalten**, kein Bug.
 >

--- a/.claude/skills/dev-flow-plan/SKILL.md
+++ b/.claude/skills/dev-flow-plan/SKILL.md
@@ -704,7 +704,7 @@ Falls kein Worktree existiert: Rufe `superpowers:using-git-worktrees` auf. Branc
 
 ### Schritt 3: Failing Test schreiben
 
-Schreibe einen Test, der den Bug beweist (red-green-refactor — Pflicht):
+Schreibe einen Test, der den Bug beweist (red-green-refactor — Pflicht). Dieser Test ist **harte Voraussetzung** für den Fix-Pfad: ohne gestageten failing Test darf `dev-flow-execute` weder implementieren noch mergen (es prüft den Test-Diff und HALTet sonst). Der Test wird in Schritt 5 zusammen mit dem Plan committed — nie nachträglich als Follow-up (genau das passierte bei PR #1134/#1135 und ist der Grund für dieses Gate).
 
 ```bash
 ./tests/runner.sh local <neue-test-id>
@@ -867,7 +867,7 @@ git checkout main
 git pull --rebase origin main
 ```
 
-> **Falls branch protection CI-Checks verlangt:** `gh pr merge --squash --delete-branch --auto` nutzen — `gh` wartet dann auf grüne Checks, bevor es mergt.
+> **Falls branch protection CI-Checks verlangt:** `gh pr merge --squash --delete-branch --auto` nutzen — `gh` wartet dann auf grüne Checks, bevor es mergt. **Aus einem `/tmp/wt-*`-Worktree no-oppt `--auto` silent** (oder scheitert an `'main' is already used by worktree`). Dann `--auto` mit `--repo Paddione/Bachelorprojekt` aus dem Haupt-Repo (außerhalb jedes Worktrees) aufrufen, oder CI grün pollen und ohne `--auto` mergen. [T000298]
 
 ### Schritt 7: Post-Merge Deploy
 

--- a/.claude/skills/operations-management/SKILL.md
+++ b/.claude/skills/operations-management/SKILL.md
@@ -27,7 +27,7 @@ GitHub **PRs are the CI/CD merge mechanism** and link back to a ticket by conven
 Never use `tickets.ticket_links` for PR references — it is ticket→ticket only (`to_id` is `NOT NULL`, `kind ∈ blocks|blocked_by|duplicate_of|relates_to|fixes|fixed_by`).
 
 **Enum reference** (closing a ticket with an out-of-set value fails the CHECK constraint):
-`priority ∈ {hoch,mittel,niedrig}` · `severity ∈ {critical,major,minor,trivial}` · `status ∈ {triage,in_progress,done,archived,blocked}` · `resolution ∈ {fixed,shipped,obsolete}` · `attention_mode ∈ {ai_ready,needs_human}`.
+`priority ∈ {hoch,mittel,niedrig}` · `severity ∈ {critical,major,minor,trivial}` · `status ∈ {triage,in_progress,done,archived,blocked}` · `resolution ∈ {fixed,shipped,obsolete}` · `attention_mode ∈ {auto,ai_ready,needs_human}` (default `auto`).
 
 All SQL below assumes:
 ```bash


### PR DESCRIPTION
## Summary
Hardens the dev-flow skill toolchain against the failure modes surfaced by recent ops tickets — all edits are to `.claude/skills/*.md` (process/instruction only, no app code, no deploy).

- **T000291** — `dev-flow-execute` fix-path now gates on a regression test: the fix branch must touch a test file or it HALTs (no merge). Reinforces in `dev-flow-plan` that the failing test is a hard precondition. Closes the gap that let PR #1134 ship testless (test retrofitted as #1135).
- **T000292** — branch-equality guard added at the **top** of `dev-flow-execute` Schritt 0.5, before any `stash`/`rebase`, so a parallel-session branch hijack is caught before destructive git ops (previously guarded only at Schritt 0 and Schritt 5).
- **T000298** — documents that `gh pr merge --auto` silently no-ops from a `/tmp/wt-*` worktree; prescribes `--repo` from the main repo or a CI-poll fallback. Applied to both `dev-flow-execute` Schritt 6 and `dev-flow-plan` chore Schritt 6.
- **T000300** — `operations-management` enum reference now lists `attention_mode = auto` (matches the live CHECK constraint; default is `auto`).

## Test plan
- [x] `task test:all` → EXIT=0, FAIL=0
- [x] `git diff --stat` confirms only the three skill files changed
- No deploy: `.claude/**` is in the KEIN-Deploy row of the post-merge table.

Closes T000291, T000292, T000298, T000300

🤖 Generated with [Claude Code](https://claude.com/claude-code)