### PR TITLE
fix(k3d): align busybox to 1.37 and harden dunning cronjob [T000294] [T000299]

### DIFF
--- a/k3d/cronjob-dunning-detection.yaml
+++ b/k3d/cronjob-dunning-detection.yaml
@@ -10,9 +10,21 @@ spec:
     spec:
       template:
         spec:
+          restartPolicy: OnFailure
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            seccompProfile:
+              type: RuntimeDefault
           containers:
           - name: detector
             image: curlimages/curl:8.7.1
+            securityContext:
+              allowPrivilegeEscalation: false
+              runAsNonRoot: true
+              runAsUser: 65534
+              capabilities:
+                drop: ["ALL"]
             command:
             - /bin/sh
             - -c
@@ -32,4 +44,3 @@ spec:
                 secretKeyRef:
                   name: workspace-secrets
                   key: CRON_SECRET
-          restartPolicy: OnFailure

--- a/k3d/nextcloud.yaml
+++ b/k3d/nextcloud.yaml
@@ -46,7 +46,7 @@ spec:
           type: RuntimeDefault
       initContainers:
         - name: fix-data-perms
-          image: busybox:1.36
+          image: busybox:1.37
           imagePullPolicy: Always
           # Nextcloud refuses to start (HTTP 503) when the data dir is
           # world-readable. local-path provisions PVCs as 2777, so we
@@ -72,7 +72,7 @@ spec:
             - name: data
               mountPath: /var/www/html/data
         - name: fix-config-perms
-          image: busybox:1.36
+          image: busybox:1.37
           imagePullPolicy: Always
           securityContext:
             runAsNonRoot: true

--- a/k3d/oauth2-proxy-brett.yaml
+++ b/k3d/oauth2-proxy-brett.yaml
@@ -25,7 +25,7 @@ spec:
           type: RuntimeDefault
       initContainers:
         - name: write-cookie-secret
-          image: busybox:1.36
+          image: busybox:1.37
           imagePullPolicy: Always
           command: ["/bin/sh", "-c"]
           args:

--- a/k3d/oauth2-proxy-comfy.yaml
+++ b/k3d/oauth2-proxy-comfy.yaml
@@ -25,7 +25,7 @@ spec:
           type: RuntimeDefault
       initContainers:
         - name: write-cookie-secret
-          image: busybox:1.36
+          image: busybox:1.37
           imagePullPolicy: Always
           command: ["/bin/sh", "-c"]
           args:

--- a/k3d/oauth2-proxy-docs.yaml
+++ b/k3d/oauth2-proxy-docs.yaml
@@ -25,7 +25,7 @@ spec:
           type: RuntimeDefault
       initContainers:
         - name: write-cookie-secret
-          image: busybox:1.36
+          image: busybox:1.37
           imagePullPolicy: Always
           # Write a TOML config with the cookie_secret truncated to 32 bytes.
           # env-generate produces a 64-char hex string which is too long for AES.

--- a/k3d/oauth2-proxy-mailpit.yaml
+++ b/k3d/oauth2-proxy-mailpit.yaml
@@ -36,7 +36,7 @@ spec:
           type: RuntimeDefault
       initContainers:
         - name: write-cookie-secret
-          image: busybox:1.36
+          image: busybox:1.37
           imagePullPolicy: Always
           command: ["/bin/sh", "-c"]
           args:

--- a/k3d/oauth2-proxy-traefik.yaml
+++ b/k3d/oauth2-proxy-traefik.yaml
@@ -37,7 +37,7 @@ spec:
           type: RuntimeDefault
       initContainers:
         - name: write-cookie-secret
-          image: busybox:1.36
+          image: busybox:1.37
           imagePullPolicy: Always
           command: ["/bin/sh", "-c"]
           args:

--- a/k3d/talk-hpb.yaml
+++ b/k3d/talk-hpb.yaml
@@ -168,7 +168,7 @@ spec:
         # Uses busybox sed (POSIX, no external tools) and `|` as the sed
         # delimiter so base64-safe secret values don't collide.
         - name: render-config
-          image: busybox:1.36
+          image: busybox:1.37
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
This PR resolves T000294 and T000299 by aligning all busybox initContainers to version 1.37 and hardening billing-dunning-detection CronJob with standard PodSecurity restricted settings.