### PR TITLE
chore(ci): widen dev-auto-deploy timeouts and guard commit subject-case

### DIFF
--- a/.claude/skills/dev-flow-execute/SKILL.md
+++ b/.claude/skills/dev-flow-execute/SKILL.md
@@ -372,6 +372,7 @@ Rufe `commit-commands:commit-push-pr` auf.
 
 - Feature: `feat(<scope>): <kurze-beschreibung>`
 - Fix: `fix(<scope>): <kurze-beschreibung>` — Body **MUSS** `Closes $TICKET_ID` (z.B. `Closes T000301`) enthalten, sonst Push blockieren und nochmal nachfragen.
+- **Subject startet kleingeschrieben** (gilt für **jeden** Commit auf dem Branch, nicht nur den PR-Titel): commitlint (`subject-case`) lehnt Subjects ab, die mit einem Großbuchstaben/Akronym/Konstante beginnen — z.B. `feat(brett): BRETT_BRAND env …` ❌ oder `fix(sse): OIDC redirect …` ❌. Umformulieren, sodass ein kleingeschriebenes Wort führt: `feat(brett): add BRETT_BRAND env …` ✅, `fix(sse): repair OIDC redirect …` ✅.
 
 Beispiele:
 

--- a/.github/workflows/dev-auto-deploy.yml
+++ b/.github/workflows/dev-auto-deploy.yml
@@ -25,7 +25,9 @@ concurrency:
 jobs:
   redeploy:
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    # 45m backstop: a push touching both website/ and brett/ runs both 20m
+    # command_timeout steps sequentially (20 + 20 + SSH/checkout overhead).
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v5
         with:
@@ -70,7 +72,10 @@ jobs:
           proxy_host: ${{ secrets.DEV_PROXY_HOST }}
           proxy_username: ${{ secrets.DEV_PROXY_USER }}
           proxy_key: ${{ secrets.DEV_PROXY_SSH_KEY }}
-          command_timeout: 10m
+          # 20m matches the full-deploy step: website is the heaviest image to
+          # build + docker save + k3d image import, and a recovering/slow dev
+          # node can exceed 10m (see the 18:16 2026-05-29 spurious timeout).
+          command_timeout: 20m
           script: |
             set -e
             cd ~/Bachelorprojekt
@@ -89,7 +94,10 @@ jobs:
           proxy_host: ${{ secrets.DEV_PROXY_HOST }}
           proxy_username: ${{ secrets.DEV_PROXY_USER }}
           proxy_key: ${{ secrets.DEV_PROXY_SSH_KEY }}
-          command_timeout: 10m
+          # 20m matches the full-deploy step: the brett image now carries a large
+          # SFX/GLB asset bundle, so build + docker save + k3d image import can
+          # exceed 10m on a slow/recovering dev node.
+          command_timeout: 20m
           script: |
             set -e
             cd ~/Bachelorprojekt


### PR DESCRIPTION
## Summary
Two CI/CD hardening fixes surfaced while reviewing the brett-coaching merge (PR #1144).

**1. dev-auto-deploy spurious timeouts.** The earlier-today failures were collateral from the dev k3d node (k3s-1) being down/recovering during the ~15:42–18:16 maintenance window (k3d restart + shared-db-dev drift fix). They self-resolved — the last runs are green. The one *latent* bug: the website-only and brett-only SSH steps capped at `command_timeout: 10m`, while the full-deploy step gets `20m` — even though website is the heaviest image to `docker build` + `docker save` + `k3d image import`. That produced a spurious 10m timeout at 18:16. This bumps both to `20m` and raises the job-level `timeout-minutes` 25 → 45 (a push touching both `website/` and `brett/` runs both steps sequentially).

**2. commitlint `subject-case` footgun.** PR #1144's only red check was Conventional Commits: the commit `feat(brett): BRETT_BRAND env (...)` failed `subject-case` because the subject leads with an all-caps token. Squash-merge hid it on `main`, but it shows red on every PR branch. Adds a rule to `dev-flow-execute` requiring per-commit subjects to start lowercase.

## Test plan
- [x] `task test:all` (exit 0)
- [x] `python3 yaml.safe_load` on dev-auto-deploy.yml

🤖 Generated with [Claude Code](https://claude.com/claude-code)