### PR TITLE
fix(website): run schema-init once, not per request [T000304]

### DIFF
--- a/docs/superpowers/plans/2026-05-29-admin-save-schema-init-race.md
+++ b/docs/superpowers/plans/2026-05-29-admin-save-schema-init-race.md
@@ -1,0 +1,283 @@
+---
+title: Admin Save Schema-Init Race — Implementation Plan
+ticket_id: T000304
+domains: []
+status: active
+pr_number: null
+---
+
+# Admin Save Schema-Init Race — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop the website DB layer from running schema-init DDL on every read/write request, so admin content saves (homepage, prices/Leistungen, services) persist reliably instead of silently failing after a `tuple concurrently updated` catalog race poisons a pooled connection.
+
+**Architecture:** Introduce a process-level run-once guard (`ensureSchemaOnce`) that memoises each schema-init promise, and wrap the actual DDL in a Postgres transaction-scoped advisory lock so concurrent requests/replicas on a cold database serialise instead of racing the system catalog. Apply it to every `init*` function currently invoked on the request hot path in `website/src/lib/website-db.ts` and `website/src/lib/tickets-db.ts`. No schema changes; behaviour-preserving for callers.
+
+**Tech Stack:** TypeScript, `pg` (node-postgres) Pool, Astro SSR endpoints, vitest + pg-mem (unit tests).
+
+**Ticket:** T000304
+
+**Background (forensic summary):**
+- `site_settings` / `leistungen_config` / `service_config` were empty across all 30 days of `db-backup` snapshots; the DB itself accepts writes (probe insert as the `website` role succeeded, full grants, no RLS, FK to `brands` satisfied).
+- Prod log showed `error: tuple concurrently updated at initTicketsSchema` at pod startup. `getSiteSetting`/`setSiteSetting` call `initSiteSettingsTable()` on every call; `initTicketsSchema()` is called per-request at ~5 sites.
+- A pod restart at ~19:12 UTC cleared the poisoned pool; the next save (19:25) persisted — confirming a fix-on-restart bug, not data deletion.
+
+---
+
+## Task 0: Failing test (ALREADY WRITTEN — verify only)
+
+The failing regression test was authored on this branch before planning.
+
+**Files:**
+- Test (exists): `website/src/lib/website-db-init-hotpath.test.ts`
+
+- [ ] **Step 1: Confirm the test exists and is RED against current code**
+
+Run:
+```bash
+cd /tmp/wt-admin-save-schema-init-race/website && node_modules/.bin/vitest run src/lib/website-db-init-hotpath.test.ts
+```
+Expected: FAIL — `AssertionError: expected 3 to be less than or equal to 1` on the two hot-path-init invariant tests (`site_settings` init DDL runs once per call → 3 calls = 3 inits). The third test (`persists the value`) passes.
+
+The test asserts the structural invariant: schema-init DDL for `site_settings` must run **at most once** across N read/write calls. pg-mem cannot reproduce the real Postgres catalog race (single-threaded), so this invariant is the faithful, deterministic proxy for the fix.
+
+---
+
+## Task 1: Add `ensureSchemaOnce` guard and apply to `initSiteSettingsTable`
+
+**Files:**
+- Modify: `website/src/lib/website-db.ts` (add helper near the top after the `pool` export; modify `initSiteSettingsTable` ~line 931)
+- Test: `website/src/lib/website-db-init-hotpath.test.ts` (already RED)
+
+- [ ] **Step 1: Add the run-once helper**
+
+Add immediately after `export const pool = new Pool(poolConfig);` (around line 30):
+
+```ts
+// Schema initialisation must run ONCE per process, not on every request.
+// Running idempotent DDL (CREATE TABLE IF NOT EXISTS / ALTER ... ADD CONSTRAINT)
+// on the hot path races concurrent requests on the Postgres system catalog,
+// throwing "tuple concurrently updated" and poisoning the pooled connection
+// (every later save then fails until the pod restarts). The map memoises the
+// init promise per logical schema key; a rejected init is evicted so a later
+// request can retry. See ticket T000304.
+const _schemaInitOnce = new Map<string, Promise<void>>();
+export function ensureSchemaOnce(key: string, init: () => Promise<void>): Promise<void> {
+  let p = _schemaInitOnce.get(key);
+  if (!p) {
+    p = init().catch((err) => {
+      _schemaInitOnce.delete(key);
+      throw err;
+    });
+    _schemaInitOnce.set(key, p);
+  }
+  return p;
+}
+
+// Test-only: reset the run-once cache so each test starts cold.
+export function __resetSchemaInitCacheForTests(): void {
+  _schemaInitOnce.clear();
+}
+```
+
+- [ ] **Step 2: Wrap `initSiteSettingsTable` body in `ensureSchemaOnce` + advisory lock**
+
+Replace the current `initSiteSettingsTable` (~line 931) with:
+
+```ts
+export async function initSiteSettingsTable(): Promise<void> {
+  return ensureSchemaOnce('site_settings', async () => {
+    // Transaction-scoped advisory lock serialises concurrent processes/replicas
+    // racing the same DDL on a cold DB. The lock auto-releases at COMMIT/ROLLBACK.
+    await pool.query(`
+      BEGIN;
+      SELECT pg_advisory_xact_lock(hashtext('init:site_settings'));
+      CREATE TABLE IF NOT EXISTS site_settings (
+        brand      TEXT REFERENCES public.brands(id) ON UPDATE CASCADE ON DELETE RESTRICT,
+        key        TEXT,
+        value      TEXT NOT NULL,
+        updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+        PRIMARY KEY (brand, key)
+      );
+      DO $$
+      BEGIN
+        IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'site_settings_brand_fkey') THEN
+          ALTER TABLE site_settings ADD CONSTRAINT site_settings_brand_fkey FOREIGN KEY (brand) REFERENCES public.brands(id) ON UPDATE CASCADE ON DELETE RESTRICT NOT VALID;
+        END IF;
+      END $$;
+      COMMIT;
+    `);
+  });
+}
+```
+
+> Note: pg-mem does not implement `pg_advisory_xact_lock`. The existing test mock (`CountingPool`) already swallows `site_settings` init DDL, so this is fine for unit tests; the advisory lock only matters against real Postgres. If a future test executes this DDL against pg-mem directly, stub the lock call.
+
+- [ ] **Step 3: Run the hot-path test to verify it passes**
+
+Run:
+```bash
+cd /tmp/wt-admin-save-schema-init-race/website && node_modules/.bin/vitest run src/lib/website-db-init-hotpath.test.ts
+```
+Expected: PASS (3/3). `setSiteSetting`/`getSiteSetting` called N times now trigger init DDL once.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /tmp/wt-admin-save-schema-init-race
+git add website/src/lib/website-db.ts website/src/lib/website-db-init-hotpath.test.ts
+git commit -m "fix(website): run site_settings schema-init once, not per request [T000304]"
+```
+
+---
+
+## Task 2: Apply the guard to the other per-request `init*` functions in website-db.ts
+
+The same hot-path pattern exists for the other content tables. Apply `ensureSchemaOnce` so none re-run DDL per call.
+
+**Files:**
+- Modify: `website/src/lib/website-db.ts`
+
+- [ ] **Step 1: Identify every per-request init function**
+
+Run:
+```bash
+cd /tmp/wt-admin-save-schema-init-race/website
+grep -nE "export async function init[A-Za-z]+\(\): Promise<void>" src/lib/website-db.ts
+```
+Expected to include at least: `initServiceConfigTable` (~855), `initLeistungenConfigTable` (~893), `initSiteSettingsTable` (done in Task 1), `initLegalPagesTable` (~995), `initReferenzenConfigTable` (~1057). Treat the full list from the grep output as the work set.
+
+- [ ] **Step 2: Wrap each remaining init function body in `ensureSchemaOnce`**
+
+For each `initXxxTable`, wrap its existing `await pool.query(...)` DDL in `ensureSchemaOnce('<table>', async () => { ... })`, using the table name as the key. Pattern (example for `initLeistungenConfigTable`):
+
+```ts
+export async function initLeistungenConfigTable(): Promise<void> {
+  return ensureSchemaOnce('leistungen_config', async () => {
+    await pool.query(`
+      /* existing CREATE TABLE IF NOT EXISTS leistungen_config ... DDL, unchanged */
+    `);
+  });
+}
+```
+
+Do NOT change the DDL text — only wrap it. Keep one `ensureSchemaOnce` key per table.
+
+- [ ] **Step 3: Run the full website unit suite**
+
+Run:
+```bash
+cd /tmp/wt-admin-save-schema-init-race/website && node_modules/.bin/vitest run
+```
+Expected: PASS (no regressions; the hot-path test still green).
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /tmp/wt-admin-save-schema-init-race
+git add website/src/lib/website-db.ts
+git commit -m "fix(website): memoise remaining content-table schema-init off the hot path [T000304]"
+```
+
+---
+
+## Task 3: Apply the guard to `initTicketsSchema` (the function that threw in prod)
+
+`initTicketsSchema` lives in `tickets-db.ts` and is the exact function the prod log named. It is called per-request at ~5 sites in website-db.ts.
+
+**Files:**
+- Modify: `website/src/lib/tickets-db.ts`
+
+- [ ] **Step 1: Inspect `initTicketsSchema`**
+
+Run:
+```bash
+cd /tmp/wt-admin-save-schema-init-race/website
+grep -n "export async function initTicketsSchema" src/lib/tickets-db.ts
+```
+
+- [ ] **Step 2: Import the guard and wrap the body**
+
+At the top of `tickets-db.ts`, import the helper from `website-db`:
+
+```ts
+import { ensureSchemaOnce } from './website-db';
+```
+
+> If this creates a circular import (website-db imports tickets-db at line 7), instead move `ensureSchemaOnce` + `_schemaInitOnce` into a new leaf module `website/src/lib/schema-init.ts` and import it from BOTH website-db.ts and tickets-db.ts. Prefer the leaf module if `grep -n "from './website-db'" src/lib/tickets-db.ts` shows any existing import cycle risk.
+
+Wrap the existing `initTicketsSchema` DDL body in `ensureSchemaOnce('tickets', async () => { ... })`, wrapping the DDL in the same `BEGIN; SELECT pg_advisory_xact_lock(hashtext('init:tickets')); ... COMMIT;` envelope.
+
+- [ ] **Step 3: Run the full suite + typecheck**
+
+```bash
+cd /tmp/wt-admin-save-schema-init-race/website
+node_modules/.bin/vitest run
+npx tsc --noEmit
+```
+Expected: tests PASS, no type errors (resolve any circular-import type error by using the leaf module from Step 2).
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /tmp/wt-admin-save-schema-init-race
+git add website/src/lib/tickets-db.ts website/src/lib/website-db.ts website/src/lib/schema-init.ts 2>/dev/null
+git commit -m "fix(website): run tickets schema-init once, not per request [T000304]"
+```
+
+---
+
+## Task 4: Build verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Production build**
+
+```bash
+cd /tmp/wt-admin-save-schema-init-race/website && npm run build
+```
+Expected: build succeeds (the dist server bundles without error).
+
+- [ ] **Step 2: Run the repo offline test suite for affected areas**
+
+```bash
+cd /tmp/wt-admin-save-schema-init-race && task test:all
+```
+Expected: green.
+
+---
+
+## Task 5: Post-merge live verification (run during dev-flow-execute deploy step)
+
+These confirm the user's actual goal: saved changes persist and reach backups.
+
+- [ ] **Step 1: Deploy website to both prod clusters** via `task feature:website` (per CLAUDE.md post-merge deploy table for `website/src/**`).
+
+- [ ] **Step 2: On web.mentolder.de admin, save the Startseite tab and the Angebote/Leistungen tab.**
+
+- [ ] **Step 3: Confirm rows persisted, including `site_settings` key `homepage`:**
+
+```bash
+kubectl --context mentolder -n workspace exec deploy/shared-db -- \
+  psql -U postgres -d website -c \
+  "SELECT brand, key, updated_at FROM site_settings ORDER BY updated_at DESC;"
+```
+Expected: a `homepage` row appears (it was missing after the 19:25 partial save), plus `price_list_url`.
+
+- [ ] **Step 4: Confirm no schema-init error after a fresh rollout:**
+
+```bash
+kubectl --context mentolder -n website logs deploy/website --since=10m | grep -i "tuple concurrently updated" || echo "clean"
+```
+Expected: `clean`.
+
+- [ ] **Step 5: Hand off to dev-flow-e2e** for a Playwright save-persistence regression on web.mentolder.de admin (authenticated `mentolder` project).
+
+---
+
+## Self-Review notes
+
+- **Coverage:** Tasks 1–3 cover every per-request `init*` site named in the forensic analysis (`site_settings`, the other content tables, and `initTicketsSchema`). Task 5 closes the `homepage`-key gap observed in prod.
+- **Type consistency:** Helper is `ensureSchemaOnce(key, init)` everywhere; reset helper is `__resetSchemaInitCacheForTests()`. If extracted to a leaf module, import path is `./schema-init` in both files.
+- **No new schema/behaviour:** DDL text is unchanged; only its invocation cadence (once per process) and concurrency safety (advisory lock) change. Callers' signatures are untouched.

--- a/website/src/lib/tickets-db.ts
+++ b/website/src/lib/tickets-db.ts
@@ -1,5 +1,5 @@
 // website/src/lib/tickets-db.ts
-import { pool } from './website-db';
+import { pool, ensureSchemaOnce } from './website-db';
 
 let schemaReady = false;
 
@@ -9,6 +9,11 @@ let schemaReady = false;
 // to permission denied. See Ticket T000028.
 export async function initTicketsSchema(): Promise<void> {
   if (schemaReady) return;
+  return ensureSchemaOnce('tickets', async () => {
+    const client = await pool.connect();
+    try {
+      await client.query(`SELECT pg_advisory_lock(hashtext('init:tickets'))`);
+      try {
 
   await pool.query(`CREATE SCHEMA IF NOT EXISTS tickets AUTHORIZATION website`);
 
@@ -477,6 +482,13 @@ export async function initTicketsSchema(): Promise<void> {
       ) sub
      WHERE tc.brand = sub.brand AND tc.last_value < sub.max_v
   `);
+      } finally {
+        await client.query(`SELECT pg_advisory_unlock(hashtext('init:tickets'))`);
+      }
+    } finally {
+      client.release();
+    }
 
-  schemaReady = true;
+    schemaReady = true;
+  });
 }

--- a/website/src/lib/website-db-init-hotpath.test.ts
+++ b/website/src/lib/website-db-init-hotpath.test.ts
@@ -1,0 +1,160 @@
+// Regression test for T000304 — admin content saves silently stopped
+// persisting for ~30 days on web.mentolder.de (homepage, prices/Leistungen).
+//
+// ROOT CAUSE: website-db.ts runs idempotent schema-init DDL on the REQUEST HOT
+// PATH. getSiteSetting()/setSiteSetting() each call initSiteSettingsTable()
+// first, which runs `CREATE TABLE IF NOT EXISTS site_settings ...` plus a
+// `DO $$ ... ALTER TABLE ADD CONSTRAINT ... $$` block on EVERY call. Under
+// concurrent admin requests those multi-statement DDL ops race on the Postgres
+// system catalog ("tuple concurrently updated"); the failed multi-statement
+// DDL then leaves the pooled pg connection in an aborted-transaction state, so
+// every subsequent save on that pooled connection fails until the pod restarts.
+//
+// pg-mem is single-threaded JS and CANNOT reproduce the real Postgres
+// concurrent-catalog race. So instead of trying to trigger "tuple concurrently
+// updated", this test asserts the STRUCTURAL INVARIANT the fix must establish:
+//
+//   Schema-initialization DDL must NOT run on every read/write request.
+//   Calling setSiteSetting()/getSiteSetting() N times must trigger the
+//   site_settings table/constraint init AT MOST ONCE (ideally zero times after
+//   a one-time/startup init), NOT once per call.
+//
+// TODAY (current code, which calls initSiteSettingsTable on every call) this
+// FAILS — three saves run the init DDL three times. After the planned fix
+// (run-once guard / init moved off the hot path) it will PASS.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// --- Test scaffolding (NOT the fix) -----------------------------------------
+// We mock the `pg` module BEFORE website-db.ts imports it, so its module-level
+// `export const pool = new Pool(...)` gets a pg-mem backed pool whose `query`
+// is wrapped to TALLY how many times schema-init DDL for `site_settings` runs.
+//
+// vi.mock factories are hoisted above the imports, so everything the factory
+// needs (pg-mem, the shared db, the counter) is created INSIDE the factory and
+// the counter is exposed as a static on the returned Pool class. The test body
+// reads it via that class.
+//
+// This is a TEST SEAM ONLY: it observes the SQL the production code already
+// emits. The fix lives in website-db.ts (a run-once guard or moving init off
+// the hot path) — this file must NOT be the thing that changes to make it pass.
+
+vi.mock('pg', () => {
+  // require() is available inside a vi.mock factory (it runs in CJS-interop
+  // context); pg-mem is single-threaded but fine for observing emitted SQL.
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { newDb } = require('pg-mem') as typeof import('pg-mem');
+
+  const mem = newDb();
+  // Pre-create the real schema (brands + site_settings) so the read/write
+  // queries succeed without relying on the production init DDL. pg-mem has
+  // limited DDL coverage, so we DO NOT run the production init SQL through it —
+  // instead we count it and swallow it (see CountingPool.query below). This is
+  // exactly the structural property the fix establishes: init is decoupled from
+  // the hot path.
+  mem.public.none(`
+    CREATE TABLE public.brands (
+      id   text PRIMARY KEY,
+      name text NOT NULL
+    );
+    INSERT INTO public.brands (id, name) VALUES ('mentolder', 'mentolder');
+
+    CREATE TABLE site_settings (
+      brand      text REFERENCES public.brands(id) ON UPDATE CASCADE ON DELETE RESTRICT,
+      key        text,
+      value      text NOT NULL,
+      updated_at timestamptz NOT NULL DEFAULT now(),
+      PRIMARY KEY (brand, key)
+    );
+  `);
+
+  const { Pool: MemPool } = mem.adapters.createPg();
+
+  // Detects the schema-init DDL that initSiteSettingsTable() emits:
+  // CREATE TABLE ... site_settings, ALTER TABLE site_settings ..., or the
+  // DO $$ ... site_settings_brand_fkey ... $$ guard block.
+  function isSiteSettingsInitDdl(sql: string): boolean {
+    const s = sql.toLowerCase();
+    const mentionsSiteSettings =
+      s.includes('site_settings') || s.includes('site_settings_brand_fkey');
+    const isDdl =
+      s.includes('create table') ||
+      s.includes('alter table') ||
+      s.includes('do $$');
+    return mentionsSiteSettings && isDdl;
+  }
+
+  class CountingPool extends (MemPool as unknown as new (...a: unknown[]) => {
+    query(t: unknown, v?: unknown): Promise<unknown>;
+  }) {
+    // Exposed to the test body. Reset in beforeEach.
+    static siteSettingsInitDdlCount = 0;
+
+    async query(textOrConfig: unknown, values?: unknown): Promise<unknown> {
+      const sql =
+        typeof textOrConfig === 'string'
+          ? textOrConfig
+          : (textOrConfig as { text?: string })?.text ?? '';
+
+      // Count AND swallow the production schema-init DDL. The table already
+      // exists in the seeded pg-mem db, and pg-mem can't execute the
+      // multi-statement CREATE TABLE + DO $$ block anyway. Swallowing it keeps
+      // the harness focused on the invariant: how MANY times init runs.
+      if (isSiteSettingsInitDdl(sql)) {
+        CountingPool.siteSettingsInitDdlCount += 1;
+        return { rows: [], rowCount: 0 };
+      }
+      return super.query(textOrConfig, values);
+    }
+  }
+
+  return { default: { Pool: CountingPool }, Pool: CountingPool };
+});
+
+// initTicketsSchema is also called per-request from other website-db functions
+// but is irrelevant to the site_settings invariant under test — stub it out so
+// it can't touch the DB or skew counts.
+vi.mock('./tickets-db', () => ({
+  initTicketsSchema: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('./tickets/transition', () => ({
+  transitionTicket: vi.fn().mockResolvedValue(undefined),
+}));
+
+// Import AFTER the mocks are registered. website-db's module-level
+// `new Pool(...)` is now our CountingPool.
+import { setSiteSetting, getSiteSetting, pool } from './website-db';
+
+// The pool instance is a CountingPool; reach its constructor to read/reset the
+// static counter without re-importing the mocked module.
+const CountingPool = (pool as unknown as { constructor: { siteSettingsInitDdlCount: number } })
+  .constructor;
+
+describe('website-db site_settings schema init is NOT on the hot path (T000304)', () => {
+  beforeEach(() => {
+    CountingPool.siteSettingsInitDdlCount = 0;
+  });
+
+  it('runs site_settings init DDL at most once across multiple setSiteSetting calls', async () => {
+    await setSiteSetting('mentolder', 'hero_title', 'Willkommen');
+    await setSiteSetting('mentolder', 'hero_title', 'Willkommen v2');
+    await setSiteSetting('mentolder', 'price_block', '60 EUR');
+
+    // RED today: current code runs initSiteSettingsTable() on every call → 3.
+    // GREEN after the fix: a run-once guard / startup init → <= 1.
+    expect(CountingPool.siteSettingsInitDdlCount).toBeLessThanOrEqual(1);
+  });
+
+  it('runs site_settings init DDL at most once across mixed get/set calls', async () => {
+    await getSiteSetting('mentolder', 'hero_title');
+    await setSiteSetting('mentolder', 'hero_title', 'X');
+    await getSiteSetting('mentolder', 'hero_title');
+
+    expect(CountingPool.siteSettingsInitDdlCount).toBeLessThanOrEqual(1);
+  });
+
+  it('persists the value (sanity: the save path still works under the harness)', async () => {
+    await setSiteSetting('mentolder', 'sanity_key', 'sanity_value');
+    expect(await getSiteSetting('mentolder', 'sanity_key')).toBe('sanity_value');
+  });
+});

--- a/website/src/lib/website-db-init-hotpath.test.ts
+++ b/website/src/lib/website-db-init-hotpath.test.ts
@@ -123,7 +123,7 @@ vi.mock('./tickets/transition', () => ({
 
 // Import AFTER the mocks are registered. website-db's module-level
 // `new Pool(...)` is now our CountingPool.
-import { setSiteSetting, getSiteSetting, pool } from './website-db';
+import { setSiteSetting, getSiteSetting, pool, __resetSchemaInitCacheForTests } from './website-db';
 
 // The pool instance is a CountingPool; reach its constructor to read/reset the
 // static counter without re-importing the mocked module.
@@ -133,6 +133,7 @@ const CountingPool = (pool as unknown as { constructor: { siteSettingsInitDdlCou
 describe('website-db site_settings schema init is NOT on the hot path (T000304)', () => {
   beforeEach(() => {
     CountingPool.siteSettingsInitDdlCount = 0;
+    __resetSchemaInitCacheForTests();
   });
 
   it('runs site_settings init DDL at most once across multiple setSiteSetting calls', async () => {

--- a/website/src/lib/website-db.ts
+++ b/website/src/lib/website-db.ts
@@ -879,19 +879,21 @@ export interface LeistungCategoryOverride {
 }
 
 export async function initServiceConfigTable(): Promise<void> {
-  await pool.query(`
-    CREATE TABLE IF NOT EXISTS service_config (
-      brand        TEXT REFERENCES public.brands(id) ON UPDATE CASCADE ON DELETE RESTRICT PRIMARY KEY,
-      services_json JSONB NOT NULL,
-      updated_at   TIMESTAMPTZ NOT NULL DEFAULT now()
-    );
+  return ensureSchemaOnce('service_config', async () => {
+    await pool.query(`
+      CREATE TABLE IF NOT EXISTS service_config (
+        brand        TEXT REFERENCES public.brands(id) ON UPDATE CASCADE ON DELETE RESTRICT PRIMARY KEY,
+        services_json JSONB NOT NULL,
+        updated_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+      );
       DO $$
       BEGIN
         IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'service_config_brand_fkey') THEN
           ALTER TABLE service_config ADD CONSTRAINT service_config_brand_fkey FOREIGN KEY (brand) REFERENCES public.brands(id) ON UPDATE CASCADE ON DELETE RESTRICT NOT VALID;
         END IF;
       END $$;
-  `);
+    `);
+  });
 }
 
 export async function getServiceConfig(brand: string): Promise<ServiceOverride[] | null> {
@@ -917,19 +919,21 @@ export async function saveServiceConfig(brand: string, overrides: ServiceOverrid
 // ── Leistungen Config (Preistabelle Overrides) ───────────────────────────────
 
 export async function initLeistungenConfigTable(): Promise<void> {
-  await pool.query(`
-    CREATE TABLE IF NOT EXISTS leistungen_config (
-      brand            TEXT REFERENCES public.brands(id) ON UPDATE CASCADE ON DELETE RESTRICT PRIMARY KEY,
-      categories_json  JSONB NOT NULL,
-      updated_at       TIMESTAMPTZ NOT NULL DEFAULT now()
-    );
+  return ensureSchemaOnce('leistungen_config', async () => {
+    await pool.query(`
+      CREATE TABLE IF NOT EXISTS leistungen_config (
+        brand            TEXT REFERENCES public.brands(id) ON UPDATE CASCADE ON DELETE RESTRICT PRIMARY KEY,
+        categories_json  JSONB NOT NULL,
+        updated_at       TIMESTAMPTZ NOT NULL DEFAULT now()
+      );
       DO $$
       BEGIN
         IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'leistungen_config_brand_fkey') THEN
           ALTER TABLE leistungen_config ADD CONSTRAINT leistungen_config_brand_fkey FOREIGN KEY (brand) REFERENCES public.brands(id) ON UPDATE CASCADE ON DELETE RESTRICT NOT VALID;
         END IF;
       END $$;
-  `);
+    `);
+  });
 }
 
 export async function getLeistungenConfig(brand: string): Promise<LeistungCategoryOverride[] | null> {
@@ -1026,21 +1030,23 @@ export async function saveVacationPeriods(brand: string, periods: VacationPeriod
 // ── Legal Pages (admin-editable HTML content) ────────────────────────────────
 
 export async function initLegalPagesTable(): Promise<void> {
-  await pool.query(`
-    CREATE TABLE IF NOT EXISTS legal_pages (
-      brand        TEXT REFERENCES public.brands(id) ON UPDATE CASCADE ON DELETE RESTRICT,
-      page_key     TEXT,
-      content_html TEXT NOT NULL,
-      updated_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
-      PRIMARY KEY (brand, page_key)
-    );
+  return ensureSchemaOnce('legal_pages', async () => {
+    await pool.query(`
+      CREATE TABLE IF NOT EXISTS legal_pages (
+        brand        TEXT REFERENCES public.brands(id) ON UPDATE CASCADE ON DELETE RESTRICT,
+        page_key     TEXT,
+        content_html TEXT NOT NULL,
+        updated_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+        PRIMARY KEY (brand, page_key)
+      );
       DO $$
       BEGIN
         IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'legal_pages_brand_fkey') THEN
           ALTER TABLE legal_pages ADD CONSTRAINT legal_pages_brand_fkey FOREIGN KEY (brand) REFERENCES public.brands(id) ON UPDATE CASCADE ON DELETE RESTRICT NOT VALID;
         END IF;
       END $$;
-  `);
+    `);
+  });
 }
 
 export async function getLegalPage(brand: string, pageKey: string): Promise<string | null> {
@@ -1088,19 +1094,21 @@ export interface ReferenzenConfig {
 }
 
 export async function initReferenzenTable(): Promise<void> {
-  await pool.query(`
-    CREATE TABLE IF NOT EXISTS referenzen_config (
-      brand      TEXT REFERENCES public.brands(id) ON UPDATE CASCADE ON DELETE RESTRICT PRIMARY KEY,
-      items_json JSONB NOT NULL,
-      updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
-    );
+  return ensureSchemaOnce('referenzen_config', async () => {
+    await pool.query(`
+      CREATE TABLE IF NOT EXISTS referenzen_config (
+        brand      TEXT REFERENCES public.brands(id) ON UPDATE CASCADE ON DELETE RESTRICT PRIMARY KEY,
+        items_json JSONB NOT NULL,
+        updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+      );
       DO $$
       BEGIN
         IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'referenzen_config_brand_fkey') THEN
           ALTER TABLE referenzen_config ADD CONSTRAINT referenzen_config_brand_fkey FOREIGN KEY (brand) REFERENCES public.brands(id) ON UPDATE CASCADE ON DELETE RESTRICT NOT VALID;
         END IF;
       END $$;
-  `);
+    `);
+  });
 }
 
 function normalizeReferenzen(raw: unknown): ReferenzenConfig {

--- a/website/src/lib/website-db.ts
+++ b/website/src/lib/website-db.ts
@@ -28,6 +28,32 @@ function nodeLookup(
 const poolConfig = { connectionString: MEETINGS_DB_URL, lookup: nodeLookup } as unknown as import('pg').PoolConfig;
 export const pool = new Pool(poolConfig);
 
+// Schema initialisation must run ONCE per process, not on every request.
+// Running idempotent DDL (CREATE TABLE IF NOT EXISTS / ALTER ... ADD CONSTRAINT)
+// on the hot path races concurrent requests on the Postgres system catalog,
+// throwing "tuple concurrently updated" and poisoning the pooled connection
+// (every later save then fails until the pod restarts). The map memoises the
+// init promise per logical schema key; a rejected init is evicted so a later
+// request can retry. See ticket T000304.
+const _schemaInitOnce = new Map<string, Promise<void>>();
+export function ensureSchemaOnce(key: string, init: () => Promise<void>): Promise<void> {
+  let p = _schemaInitOnce.get(key);
+  if (!p) {
+    p = init().catch((err) => {
+      _schemaInitOnce.delete(key);
+      throw err;
+    });
+    _schemaInitOnce.set(key, p);
+  }
+  return p;
+}
+
+// Test-only: reset the run-once cache so each test starts cold.
+export function __resetSchemaInitCacheForTests(): void {
+  _schemaInitOnce.clear();
+}
+
+
 // ── Timeline (PR5: reads from tickets.pr_events on the same DB) ─────────────
 // Historical note: an earlier implementation used a separate tracking pool
 // against bachelorprojekt.v_timeline. That view + its source tables were
@@ -929,21 +955,28 @@ export async function saveLeistungenConfig(brand: string, categories: LeistungCa
 // ── Site Settings (key/value store per brand) ────────────────────────────────
 
 export async function initSiteSettingsTable(): Promise<void> {
-  await pool.query(`
-    CREATE TABLE IF NOT EXISTS site_settings (
-      brand      TEXT REFERENCES public.brands(id) ON UPDATE CASCADE ON DELETE RESTRICT,
-      key        TEXT,
-      value      TEXT NOT NULL,
-      updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
-      PRIMARY KEY (brand, key)
-    );
+  return ensureSchemaOnce('site_settings', async () => {
+    // Transaction-scoped advisory lock serialises concurrent processes/replicas
+    // racing the same DDL on a cold DB. The lock auto-releases at COMMIT/ROLLBACK.
+    await pool.query(`
+      BEGIN;
+      SELECT pg_advisory_xact_lock(hashtext('init:site_settings'));
+      CREATE TABLE IF NOT EXISTS site_settings (
+        brand      TEXT REFERENCES public.brands(id) ON UPDATE CASCADE ON DELETE RESTRICT,
+        key        TEXT,
+        value      TEXT NOT NULL,
+        updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+        PRIMARY KEY (brand, key)
+      );
       DO $$
       BEGIN
         IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'site_settings_brand_fkey') THEN
           ALTER TABLE site_settings ADD CONSTRAINT site_settings_brand_fkey FOREIGN KEY (brand) REFERENCES public.brands(id) ON UPDATE CASCADE ON DELETE RESTRICT NOT VALID;
         END IF;
       END $$;
-  `);
+      COMMIT;
+    `);
+  });
 }
 
 export async function getSiteSetting(brand: string, key: string): Promise<string | null> {


### PR DESCRIPTION
## Summary
- Prevents idempotent schema-init DDL from running on every request hot path in website-db and tickets-db.
- Introduces process-level memoization (`ensureSchemaOnce`) and Postgres advisory lock concurrency safety to prevent pooled connection poisoning from concurrent catalog races.

## Test plan
- [x] task test:all
- [x] task workspace:validate
- [x] vitest run src/lib/website-db-init-hotpath.test.ts

Closes T000304

Co-Authored-By: Antigravity