### PR TITLE
fix(website): replace undefined contact var with stammdaten in homepage SSR [T000311]

### DIFF
--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -166,14 +166,14 @@ const processSteps = homepage.processSteps ?? [];
       <!-- FAQ -->
       <FAQ items={faq.map((item) => ({
         ...item,
-        answer: item.answer.replace('{city}', contact.city),
+        answer: item.answer.replace('{city}', stammdaten.city),
       }))} client:visible />
 
       <!-- CTA -->
       <CallToAction
         client:visible
-        secondaryText={stammdaten?.email || contact.email}
-        secondaryHref={`mailto:${stammdaten?.email || contact.email}`}
+        secondaryText={stammdaten?.email}
+        secondaryHref={`mailto:${stammdaten?.email}`}
       />
     </Fragment>
   )}


### PR DESCRIPTION
## Summary
- `contact` is a JSX prop expression inside the `isKore` branch (line 65), never a standalone variable
- The mentolder branch referenced `contact.city` and `contact.email` → `ReferenceError: contact is not defined` thrown mid-SSR stream
- Traefik closes the HTTP/2 connection with `INTERNAL_ERROR`, which Chrome surfaces as `ERR_HTTP2_PROTOCOL_ERROR` (white screen)
- Fix: replace with `stammdaten.city` / `stammdaten.email` (same data, already available)

## Test plan
- [ ] CI passes (website build + type-check)
- [ ] `https://web.mentolder.de` renders without white screen after deploy
- [ ] FAQ city substitution and CTA email link both render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)