### PR TITLE
chore(skills): fix 5 ai-ready tooling issues [T000307 T000308 T000309 T000312 T000313]

### DIFF
--- a/.claude/skills/dev-flow-execute/SKILL.md
+++ b/.claude/skills/dev-flow-execute/SKILL.md
@@ -151,7 +151,22 @@ git rebase origin/main
 git submodule update --init --recursive
 ```
 
-> **Nach Rebase — erster Push:** Falls der Branch schon gepusht war, schlägt `git push` fehl ("rejected ... non-fast-forward"). Lösung: `git push --force-with-lease origin <branch>`. `--force-with-lease` ist sicherer als `--force` — schlägt fehl wenn jemand anderes seit dem letzten Fetch gepusht hat.
+> **Nach Rebase — erster Push:** Falls der Branch schon gepusht war (z.B. Prior-Session ließ Stale Commits), schlägt `git push` mit "rejected ... non-fast-forward" fehl. Erkenne und handle automatisch:
+>
+> ```bash
+> BRANCH=$(git branch --show-current)
+> if ! git push -u origin "$BRANCH" 2>/tmp/_push_err.txt; then
+>   if grep -qE "rejected.*non-fast-forward|rejected.*fetch first" /tmp/_push_err.txt; then
+>     echo "Remote divergiert (Stale Commits aus Prior-Session) — wende --force-with-lease an"
+>     git push --force-with-lease origin "$BRANCH"
+>     echo "✓ Force-with-lease push erfolgreich"
+>   else
+>     cat /tmp/_push_err.txt; exit 1
+>   fi
+> fi
+> ```
+>
+> `--force-with-lease` ist sicherer als `--force` — schlägt fehl wenn jemand anderes seit dem letzten Fetch gepusht hat (schützt Fremdarbeit).
 
 Falls `git rebase` Konflikte meldet:
 
@@ -259,6 +274,29 @@ Implementiere dann bis der failing Test (aus `dev-flow-plan` Schritt 3) grün is
 ```bash
 ./tests/runner.sh local <test-id>
 # Ziel: PASS
+```
+
+### Milestone-Checkboxen aktualisieren (Pflicht nach jeder abgeschlossenen Aufgabe)
+
+**Nach jeder abgeschlossenen Milestone / Task-Gruppe den Plan in-place aktualisieren:**
+
+```bash
+PLAN_FILE="docs/superpowers/plans/<date>-<slug>.md"
+
+# Checkbox für abgeschlossene Milestone setzen — z.B. M1
+# Vorher:  - [ ] M1: <titel>
+# Nachher: - [x] M1: <titel>
+sed -i 's/^- \[ \] M1:/- [x] M1:/' "$PLAN_FILE"
+```
+
+**Warum:** Die Plan-Datei ist der einzige persistente State der Implementierung. Bleiben Checkboxen unchecked, kann keine spätere Session (nach `/compact` oder Session-Verlust) den tatsächlichen Fortschritt erkennen — sie liest nur den Plan. Ohne Checkbox-Update muss der Zustand durch Filesystem-Analyse rekonstruiert werden, was fehleranfällig ist und Zeit kostet.
+
+**Wann:** Direkt nach dem Commit jedes Milestones — nicht am Ende gebündelt. Nach `git commit -m "feat(…): complete M1 …"` sofort:
+
+```bash
+sed -i 's/^- \[ \] M1:/- [x] M1:/' "$PLAN_FILE"
+git add "$PLAN_FILE"
+git commit -m "chore(plans): check off M1 in plan"
 ```
 
 ---

--- a/.claude/skills/dev-flow-plan/SKILL.md
+++ b/.claude/skills/dev-flow-plan/SKILL.md
@@ -369,12 +369,20 @@ fi
 ```
 
 ```bash
-# d) Tunnel publishen (run_in_background: true) — STDOUT/STDERR in Log-File schreiben
+# d) Stale SSH-Tunnel töten — verhindert "remote port forwarding failed" bei Wiederverwendung
+# Bracket-Trick [3]2223 verhindert Self-Match des pkill-Kommandos selbst
+pkill -f "ssh.*[3]2223" 2>/dev/null && echo "Stale ssh tunnel(s) killed" || echo "Kein staler Tunnel gefunden"
+sleep 1  # kurze Pause damit der Remote-Forward auf sish freigegeben wird
+```
+
+```bash
+# e) Tunnel publishen (run_in_background: true) — STDOUT/STDERR in Log-File schreiben
 task brainstorm:publish -- $PORT >/tmp/brainstorm-publish.log 2>&1
 ```
 
 ```bash
-# e) Verify — bis zu 15s auf den Tunnel warten. Erst wenn 200/302 kommt, ist die URL benutzbar.
+# f) Verify — bis zu 15s auf den Tunnel warten. Erst wenn 200/302 kommt, ist die URL benutzbar.
+# Zusätzlich: lokalen Listener prüfen — wenn der Companion-Server stirbt, bekommt der User 502.
 for i in $(seq 1 15); do
   CODE=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 3 https://brainstorm.mentolder.de/ || echo 000)
   if [[ "$CODE" == "200" || "$CODE" == "302" || "$CODE" == "301" ]]; then
@@ -393,6 +401,13 @@ if [[ "$CODE" != "200" && "$CODE" != "302" && "$CODE" != "301" ]]; then
   echo "  • sish pod restartet/crashed → 'task brainstorm:status'"
   echo "  • PORT $PORT lauscht nicht lokal → 'ss -ltn | grep $PORT'"
   exit 1
+fi
+# Lokalen Listener noch oben? Wenn nicht, Server neu starten (Companion stirbt manchmal nach verify)
+if ! ss -ltn 2>/dev/null | grep -q ":${PORT} "; then
+  echo "⚠️  Lokaler Listener auf Port $PORT nicht mehr aktiv — Companion-Server neu starten"
+  RESULT=$(bash "$START_SCRIPT" --project-dir /home/patrick/Bachelorprojekt)
+  PORT=$(echo "$RESULT" | jq -r '.port')
+  echo "Companion neu gestartet auf Port $PORT"
 fi
 ```
 
@@ -601,7 +616,17 @@ fi
 # Die Spec wurde bereits in Schritt 3.7.1.5 committed; git add ist idempotent falls nötig
 git add docs/superpowers/specs/<date>-<slug>-design.md docs/superpowers/plans/<date>-<slug>.md
 git commit -m "chore(plans): stage <slug> for execution [$TICKET_EXT_ID]"
-git push -u origin feature/<slug>
+
+# Push mit automatischer Force-with-lease-Fallback bei divergiertem Remote (Prior-Session Stale Commits)
+BRANCH=$(git branch --show-current)
+if ! git push -u origin "$BRANCH" 2>/tmp/_push_err.txt; then
+  if grep -qE "rejected.*non-fast-forward|rejected.*fetch first" /tmp/_push_err.txt; then
+    echo "Remote divergiert — wende --force-with-lease an"
+    git push --force-with-lease origin "$BRANCH"
+  else
+    cat /tmp/_push_err.txt; exit 1
+  fi
+fi
 ```
 
 **STOPP.** Sage: "Plan auf Branch `feature/<slug>` gepusht → `docs/superpowers/plans/<date>-<slug>.md` (Ticket: `$TICKET_EXT_ID`). Ruf `dev-flow-execute` auf, wenn du bereit bist zur Implementierung."
@@ -759,7 +784,17 @@ git add tests/<relevante-test-datei>
 git add docs/superpowers/plans/<slug>.md
 
 git commit -m "chore(plans): stage <slug> fix for execution [$TICKET_EXT_ID]"
-git push -u origin fix/<slug>
+
+# Push mit automatischer Force-with-lease-Fallback bei divergiertem Remote
+BRANCH=$(git branch --show-current)
+if ! git push -u origin "$BRANCH" 2>/tmp/_push_err.txt; then
+  if grep -qE "rejected.*non-fast-forward|rejected.*fetch first" /tmp/_push_err.txt; then
+    echo "Remote divergiert — wende --force-with-lease an"
+    git push --force-with-lease origin "$BRANCH"
+  else
+    cat /tmp/_push_err.txt; exit 1
+  fi
+fi
 ```
 
 **STOPP.** Sage: "Failing Test + Plan auf Branch `fix/<slug>` gepusht (Ticket: `$TICKET_EXT_ID`). Ruf `dev-flow-execute` auf, wenn du bereit bist zur Implementierung."

--- a/scripts/plan-frontmatter-hook.sh
+++ b/scripts/plan-frontmatter-hook.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Append YAML frontmatter to a plan file that doesn't have it yet.
 # Usage: scripts/plan-frontmatter-hook.sh <plan.md>
-# Prompts for domains interactively; non-interactive falls back to empty array.
+# Derives domains from plan content; interactive mode allows manual override.
 set -euo pipefail
 
 FILE="${1:?Usage: plan-frontmatter-hook.sh <plan.md>}"
@@ -12,20 +12,43 @@ if head -1 "$FILE" | grep -q '^---'; then
     exit 0
 fi
 
-VALID_DOMAINS="infra website db ops test security"
+# Derive domains from plan content — mirrors CLAUDE.md agent routing signals.
+# Interactive mode shows the derived set and allows override.
+_derive_domains() {
+    local file="$1"
+    local content
+    content=$(cat "$file")
+    local domains=()
+
+    echo "$content" | grep -qiE 'website/|astro|svelte|component|homepage|kore|brand|css|ui|frontend' \
+        && domains+=(website)
+    echo "$content" | grep -qiE 'k3d/|prod[-/]|manifest|kustomize|overlay|Taskfile|environments/|flux/|deploy.*k8s' \
+        && domains+=(infra)
+    echo "$content" | grep -qiE 'database|postgresql|psql|schema|query|backup.*db|restore.*db|tickets\.|v_timeline' \
+        && domains+=(db)
+    echo "$content" | grep -qiE 'pod |logs |kubectl|deployment|crash|CrashLoop|health.*check' \
+        && domains+=(ops)
+    echo "$content" | grep -qiE 'tests/|\.bats|\.spec\.ts|playwright|runner\.sh|BATS|FA-|SA-|NFA-|AK-' \
+        && domains+=(test)
+    echo "$content" | grep -qiE 'SealedSecret|Keycloak|OIDC|DSGVO|credentials|rotate|certificate|secret' \
+        && domains+=(security)
+
+    printf '%s\n' "${domains[@]}"
+}
+
+derived_domains=$(_derive_domains "$FILE" | tr '\n' ' ' | sed 's/ $//')
+domains_input="$derived_domains"
 
 if [[ -t 0 ]]; then
-    echo "Enter domains for $(basename "$FILE") (space-separated from: $VALID_DOMAINS):"
-    read -r domains_input
-elif read -r -t 1 domains_input 2>/dev/null; then
-    : # piped stdin was read successfully
-else
-    domains_input=""
+    echo "Derived domains for $(basename "$FILE"): [${derived_domains:-none}]"
+    echo "Press Enter to accept, or type override (space-separated from: infra website db ops test security):"
+    read -r override_input
+    [[ -n "$override_input" ]] && domains_input="$override_input"
 fi
 
 # Convert "infra db" → "[infra, db]"
 if [[ -n "$domains_input" ]]; then
-    domains_yaml="[$(echo "$domains_input" | tr ' ' '\n' | sed 's/.*/, &/' | tr -d '\n' | sed 's/^, //')]"
+    domains_yaml="[$(echo "$domains_input" | tr ' ' '\n' | grep -v '^$' | sed 's/.*/, &/' | tr -d '\n' | sed 's/^, //')]"
 else
     domains_yaml="[]"
 fi

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -187,13 +187,13 @@
       }
     },
     "node_modules/@astrojs/language-server": {
-      "version": "2.16.8",
-      "resolved": "https://registry.npmjs.org/@astrojs/language-server/-/language-server-2.16.8.tgz",
-      "integrity": "sha512-yg1pZF6hs9FaKr2fgXMOGbW7pDLgFexFjuhWilPAc8VybTU+WSnbfbhYaUL1exm6dAK4sM3aKXGcfVwss+HXbg==",
+      "version": "2.16.10",
+      "resolved": "https://registry.npmjs.org/@astrojs/language-server/-/language-server-2.16.10.tgz",
+      "integrity": "sha512-87VQ/5GSdHlRnUA+hGuerYyIGAj+9RbZmATyuKLEUePinUXhQ5YkRnRrHhOD9sSi5JOErLjrLkHnfZFEvGrV8w==",
       "license": "MIT",
       "dependencies": {
         "@astrojs/compiler": "^2.13.1",
-        "@astrojs/yaml2ts": "^0.2.3",
+        "@astrojs/yaml2ts": "^0.2.4",
         "@jridgewell/sourcemap-codec": "^1.5.5",
         "@volar/kit": "~2.4.28",
         "@volar/language-core": "~2.4.28",
@@ -341,12 +341,12 @@
       }
     },
     "node_modules/@astrojs/yaml2ts": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@astrojs/yaml2ts/-/yaml2ts-0.2.3.tgz",
-      "integrity": "sha512-PJzRmgQzUxI2uwpdX2lXSHtP4G8ocp24/t+bZyf5Fy0SZLSF9f9KXZoMlFM/XCGue+B0nH/2IZ7FpBYQATBsCg==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@astrojs/yaml2ts/-/yaml2ts-0.2.4.tgz",
+      "integrity": "sha512-8oddpOae35pJsXPQXhTkM0ypfKPskVsh2bCxRtbf7e+/Epw2nReakFYpLKjZMEr75CsoF203PMnCocpfz0s69A==",
       "license": "MIT",
       "dependencies": {
-        "yaml": "^2.8.2"
+        "yaml": "^2.8.3"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2002,9 +2002,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2020,9 +2017,6 @@
       "integrity": "sha512-1XbCOz/ymhj24lFaIXtWnwv/6eFHXDrjP0jYkc6iHQ9q8oXKzUX1Lc6bu+wuGiLhGh2GS/2JlfORC5ZcXimRcg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2040,9 +2034,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2059,9 +2050,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2077,9 +2065,6 @@
       "integrity": "sha512-x0XvZWdHbkgdgucJsRxprX/4o4sEed7qo9rCQA9ugiS9qE2QvP0RIiEugtZhfLH3cyI+jIRFJHV4Fuz+1BHHMg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2841,9 +2826,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2861,9 +2843,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2881,9 +2860,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2901,9 +2877,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4588,15 +4561,15 @@
       }
     },
     "node_modules/engine.io-client": {
-      "version": "6.6.4",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.4.tgz",
-      "integrity": "sha512-+kjUJnZGwzewFDw951CDWcwj35vMNf2fcj7xQWOctq1F2i1jkDdVvdFG9kM/BEChymCH36KgjnW0NsL58JYRxw==",
+      "version": "6.6.5",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.5.tgz",
+      "integrity": "sha512-QCwxUDULPlXv8F6tqMMKx5dNkTe6OaBYRMPYeXKBlyOoKvAmE0ac6pW7fFhSscJ/5SI7666/U/B+MElbsrJlIg==",
       "license": "MIT",
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.4.1",
         "engine.io-parser": "~5.2.1",
-        "ws": "~8.18.3",
+        "ws": "~8.20.1",
         "xmlhttprequest-ssl": "~2.1.1"
       }
     },
@@ -10454,9 +10427,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -10553,9 +10526,9 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
@@ -10594,18 +10567,6 @@
       "resolved": "https://registry.npmjs.org/request-light/-/request-light-0.5.8.tgz",
       "integrity": "sha512-3Zjgh+8b5fhRJBQZoy+zbVKpAQGLyka0MPgW3zruTF4dFFJ8Fqcfu9YsAvi/rvdcaTeWG3MkbZv4WKxAn/84Lg==",
       "license": "MIT"
-    },
-    "node_modules/yaml-language-server/node_modules/yaml": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.1.tgz",
-      "integrity": "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==",
-      "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/website/package.json
+++ b/website/package.json
@@ -56,5 +56,8 @@
     "tsx": "^4.22.3",
     "typescript": "^6.0.3",
     "vitest": "^4.1.7"
+  },
+  "overrides": {
+    "yaml": "^2.8.3"
   }
 }


### PR DESCRIPTION
## Summary
- **T000307** — kill stale ssh brainstorm tunnels before `brainstorm:publish`; verify local listener post-verify (fixes "remote port forwarding failed" + 502 gateway)
- **T000308** — `plan-frontmatter-hook.sh` now derives domains from plan content (grep on CLAUDE.md routing signals) instead of always writing `[]` in non-interactive mode
- **T000309** — zero npm audit vulnerabilities in website: 2 fixed non-breaking, 5 remaining `yaml-language-server` chain resolved via `overrides: {yaml: "^2.8.3"}` (avoids downgrading `@astrojs/check`)
- **T000312** — `--force-with-lease` push is now automatic in both `dev-flow-plan` and `dev-flow-execute` when rejection is detected; no longer requires manual intervention
- **T000313** — `dev-flow-execute` Schritt 2 now has explicit milestone checkbox update instruction with in-place `sed` after each milestone commit

## Test plan
- [x] `task test:all` (29 manifests + unit tests green)
- [x] `plan-frontmatter-hook.sh` smoke test: plan touching `website/` + db + tests correctly derives `[website, db, test]`
- [x] `npm audit` in `website/` → 0 vulnerabilities
- No k8s manifests changed — no deploy needed