### PR TITLE
fix(dev-build): prevent OOM crashes in Astro build on dev node [T000315]

### DIFF
--- a/Taskfile.dev-stack.yml
+++ b/Taskfile.dev-stack.yml
@@ -145,6 +145,11 @@ tasks:
     desc: "[dev] Build the website image and import it into the dev k3d cluster"
     cmds:
       - |
+        # Kill any stale docker build from a previous timed-out SSH session (T000315).
+        # Without this, two concurrent Astro+pixi.js builds exhaust dev-node memory.
+        pkill -f "docker.*website/Dockerfile" 2>/dev/null || true
+        sleep 1
+      - |
         source scripts/env-resolve.sh "{{.ENV}}"
         docker build -t ghcr.io/paddione/workspace-website:dev \
           -f website/Dockerfile \

--- a/tests/unit/dev-build-safety.bats
+++ b/tests/unit/dev-build-safety.bats
@@ -1,0 +1,74 @@
+#!/usr/bin/env bats
+# ═══════════════════════════════════════════════════════════════════
+# dev-build-safety.bats — Guard against OOM crashes in dev Astro build
+# ═══════════════════════════════════════════════════════════════════
+# The pixi.js + Astro build is memory-hungry. Without an explicit
+# Node.js heap cap, docker build on the dev node (k3s-1) crashes with
+# SIGSEGV or esbuild memory-corruption parse errors (T000315).
+# Stale docker build processes from timed-out SSH sessions compound
+# the problem by running two concurrent builds simultaneously.
+# ═══════════════════════════════════════════════════════════════════
+
+load test_helper
+
+# ── Dockerfile heap cap ──────────────────────────────────────────
+
+@test "website/Dockerfile build stage sets NODE_OPTIONS with max-old-space-size" {
+  # Without this, Node.js has no explicit heap limit and crashes with
+  # SIGSEGV on the memory-constrained dev node when building pixi.js+Astro.
+  local dockerfile="${PROJECT_DIR}/website/Dockerfile"
+  [[ -f "$dockerfile" ]] || fail "website/Dockerfile not found"
+
+  run grep -E "NODE_OPTIONS.*max-old-space-size" "$dockerfile"
+  assert_success
+  assert_output --partial "max-old-space-size"
+}
+
+@test "website/Dockerfile NODE_OPTIONS heap limit is at least 2048 MB" {
+  local dockerfile="${PROJECT_DIR}/website/Dockerfile"
+  [[ -f "$dockerfile" ]] || fail "website/Dockerfile not found"
+
+  # Extract the numeric value from --max-old-space-size=<N>
+  local value
+  value=$(grep -oE "max-old-space-size=[0-9]+" "$dockerfile" | grep -oE "[0-9]+" | head -1)
+  [[ -n "$value" ]] || fail "max-old-space-size not found in Dockerfile"
+  (( value >= 2048 )) || fail "max-old-space-size=${value} is below minimum 2048 MB"
+}
+
+@test "website/Dockerfile NODE_OPTIONS is set in the build stage (before runtime stage)" {
+  local dockerfile="${PROJECT_DIR}/website/Dockerfile"
+  [[ -f "$dockerfile" ]] || fail "website/Dockerfile not found"
+
+  # The flag must appear BEFORE the "runtime stage" comment/FROM line
+  # so it only affects the build, not the running container.
+  local build_line runtime_line node_opts_line
+  build_line=$(grep -n "Build stage\|AS build" "$dockerfile" | head -1 | cut -d: -f1)
+  runtime_line=$(grep -n "Runtime stage\|AS runtime" "$dockerfile" | head -1 | cut -d: -f1)
+  node_opts_line=$(grep -n "NODE_OPTIONS.*max-old-space-size" "$dockerfile" | head -1 | cut -d: -f1)
+
+  [[ -n "$build_line" ]]     || fail "Build stage marker not found in Dockerfile"
+  [[ -n "$runtime_line" ]]   || fail "Runtime stage marker not found in Dockerfile"
+  [[ -n "$node_opts_line" ]] || fail "NODE_OPTIONS line not found in Dockerfile"
+
+  (( node_opts_line < runtime_line )) || \
+    fail "NODE_OPTIONS (line $node_opts_line) must be in build stage (before runtime at line $runtime_line)"
+}
+
+# ── Taskfile stale-build guard ───────────────────────────────────
+
+@test "Taskfile.dev-stack.yml build:website kills stale docker builds before starting" {
+  # When a previous SSH session times out (20m), docker build keeps running
+  # on k3s-1. The next push starts a second concurrent build -> OOM.
+  local taskfile="${PROJECT_DIR}/Taskfile.dev-stack.yml"
+  [[ -f "$taskfile" ]] || fail "Taskfile.dev-stack.yml not found"
+
+  # The build:website task must contain a stale-process cleanup before docker build.
+  # We look for a kill/pkill/buildx-prune pattern inside the build:website block.
+  run awk '/^  build:website:/{ found=1; next } found && /^  [a-zA-Z]/ && !/^    /{ exit } found{ print }' "$taskfile"
+  assert_success
+
+  local task_block="$output"
+  if ! echo "$task_block" | grep -qE "(pkill|killall|buildx prune|docker.*kill).*docker|docker.*(pkill|kill|prune)"; then
+    fail "build:website task must kill stale docker builds before starting (pkill/buildx prune pattern missing)"
+  fi
+}

--- a/website/Dockerfile
+++ b/website/Dockerfile
@@ -8,6 +8,10 @@ RUN npm ci
 
 COPY website/ .
 
+# Cap Node.js heap to force GC before hitting kernel OOM (T000315).
+# The pixi.js + Astro build is memory-hungry; without an explicit limit,
+# the dev node (k3s-1) crashes with SIGSEGV or esbuild memory-corruption.
+ENV NODE_OPTIONS=--max-old-space-size=3072
 RUN npm run build
 
 # ── Runtime stage ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **`website/Dockerfile`**: Cap Node.js heap at 3 072 MB (`NODE_OPTIONS=--max-old-space-size=3072`) in the build stage so Node.js GCs aggressively instead of hitting kernel OOM — fixes the intermittent SIGSEGV crash and the esbuild memory-corruption parse error (`Expected ";" but found "resourceѳ"` in `ArenaIsland.js`)
- **`Taskfile.dev-stack.yml`**: Kill any stale `docker build` processes before starting a new one — when the previous SSH session times out (20 m), the build keeps running on k3s-1; the next push then launches a second concurrent Astro+pixi.js build which exhausts dev-node memory

## Root cause

The pixi.js + Astro island build (introduced with the Arena feature) is memory-hungry. On the dev node (k3s-1), three failure modes were observed:

1. **SIGSEGV** — Node.js OOM hard crash during `npm run build`
2. **esbuild parse error** — `Expected ";" but found "resourceѳ"` — pixi.js uses the Cyrillic Fita character (`ѳ`) as an internal symbol name; memory-corrupted intermediate files cause esbuild to misread valid JS
3. **20-minute SSH timeout** — build swaps to disk; prod builds on GitHub-hosted runners (7 GB RAM) always succeed

## Test plan

- [ ] `tests/unit/lib/bats-core/bin/bats tests/unit/dev-build-safety.bats` — 4 new tests pass (Dockerfile heap cap + Taskfile stale-kill guard)
- [ ] `task test:all` — full offline suite green
- [ ] `task workspace:validate` — manifests valid
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)