### PR TITLE
chore(skills): add Longhorn bootstrap to fresh-deploy runbook [T000318]

### DIFF
--- a/.claude/skills/cluster-deployment/SKILL.md
+++ b/.claude/skills/cluster-deployment/SKILL.md
@@ -24,7 +24,8 @@ When setting up a new environment from scratch, you must execute the steps in th
 3. **Seal secrets** (`env:seal`) must occur *after* fetching the certificate, using the correct keypair.
 4. **Install cert-manager** (`cert:install`) must be done to provision CRDs *before* `workspace:deploy` is called.
 5. **DNS API Secret** (`cert:secret -- <key>`) must be stored in both namespaces *before* deploying to avoid ACME challenge failures.
-6. **Deploy workspace** (`workspace:deploy`) applies SealedSecrets and all other base manifests.
+6. **Install the Longhorn storage provisioner** (`task ha:setup`, or the helm install + `iscsid` enable inside `scripts/setup-ha-cluster.sh`) must exist *before* `workspace:deploy`. The `prod-mentolder/` overlay declares `storageClassName: longhorn` for `livekit-recordings-pvc`, `nextcloud-data-pvc`, `vaultwarden-data-pvc`, and `docuseal-data-pvc` (the last three added by #1165 / T000317). On a fresh cluster these PVCs stay **Pending forever** — and nextcloud, vaultwarden, docuseal, and livekit-egress never start — unless the `longhorn` StorageClass and the host-level `iscsid` service are present first. `local-path` (k3s built-in) does **not** satisfy these claims.
+7. **Deploy workspace** (`workspace:deploy`) applies SealedSecrets and all other base manifests.
 
 ---
 
@@ -70,6 +71,21 @@ task cert:install ENV=<env>
 
 # Install the ipv64 DNS API key (required for ACME challenge)
 task cert:secret -- <ipv64-api-key> ENV=<env>
+```
+
+### Step 1.4b: Install Longhorn Storage Provisioner (mentolder)
+The `prod-mentolder/` overlay binds four PVCs to `storageClassName: longhorn`. Longhorn is **not** part of `workspace:deploy` — it is installed once by the HA bootstrap script. After a true teardown it must be re-installed before the workspace deploy.
+```bash
+# Full HA bootstrap (provisions k3s nodes + Traefik + Longhorn + iscsid)
+task ha:setup
+# ...or, if the k3s cluster already exists and only storage is missing, install Longhorn directly:
+#   helm repo add longhorn https://charts.longhorn.io && helm repo update
+#   helm install longhorn longhorn/longhorn -n longhorn-system --create-namespace
+#   kubectl patch storageclass longhorn -p '{"metadata":{"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
+# iscsid must be enabled on EVERY node or Longhorn volumes fail to attach (see setup-ha-cluster.sh).
+
+# Verify the StorageClass exists before deploying — else longhorn PVCs hang Pending:
+kubectl --context <ctx> get storageclass longhorn
 ```
 
 ### Step 1.5: Workspace Deploy & Flux Bootstrap


### PR DESCRIPTION
## Summary
Closes the fresh-deploy landmine surfaced by a simulated teardown→fresh-deploy of `mentolder`.

`prod-mentolder/` binds **4** PVCs to `storageClassName: longhorn` — `livekit-recordings-pvc` plus `nextcloud-data-pvc`, `vaultwarden-data-pvc`, `docuseal-data-pvc` (the last three added by #1165 / T000317). Longhorn is installed **only** by the run-once `task ha:setup` → `scripts/setup-ha-cluster.sh` (helm + `iscsid`), which is **not** in the `cluster-deployment` runbook, **not** in `workspace:deploy`, and **not** in `flux/`. On a literal fresh cluster all four PVCs stay `Pending` forever and nextcloud/vaultwarden/docuseal/livekit-egress never start.

## Change
Doc-only edit to `.claude/skills/cluster-deployment/SKILL.md`:
- Add the Longhorn storage provisioner as **mandatory-ordering item #6** (before `workspace:deploy`), with the explicit failure mode.
- Add **Step 1.4b**: `task ha:setup` path + standalone helm fallback + `iscsid`-on-every-node requirement + a `kubectl get storageclass longhorn` preflight gate.

## Follow-up (tracked, not in this PR)
T000318 also asks for the deeper fix: wire a Longhorn preflight (or the install) into `workspace:deploy` so the step can't be silently skipped. This PR is the documentation guard; the code wiring stays open on the ticket.

Note: `k3d/docs-content-built/skills/cluster-deployment.html` is regenerated by `scripts/build-docs.js` + `task docs:deploy`; not rebuilt here since docs deploy is a separate action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)