### PR TITLE
fix(infra): exclude nextcloud-data-pvc from Longhorn patch [T000317]

### DIFF
--- a/prod-mentolder/patch-data-pvc-storage.yaml
+++ b/prod-mentolder/patch-data-pvc-storage.yaml
@@ -2,13 +2,9 @@
 # local-path PVCs are node-pinned RWO; pvc-backup cannot mount PVCs from two nodes.
 # Longhorn is distributed — any Hetzner node can access the volume.
 # NOTE: storageClass is immutable on existing PVCs. Apply this patch AFTER manual migration.
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: nextcloud-data-pvc
-spec:
-  storageClassName: longhorn
----
+# NOTE: nextcloud-data-pvc (50Gi) is excluded — Longhorn cluster lacks sufficient
+# disk headroom on Hetzner nodes (~15–25 GB free vs 3×50 GB required for 3 replicas).
+# See T000317 follow-up for nextcloud backup strategy.
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/tests/local/SA-07.sh
+++ b/tests/local/SA-07.sh
@@ -69,7 +69,8 @@ assert_contains "$RESTORE_HELP" "pvc-restore" "SA-07" "T10" "backup-restore.sh u
 # This is a manifest-level test: checks kustomize build output, no cluster access needed.
 PROJECT_DIR="${PROJECT_DIR:-$(cd "${SCRIPT_DIR}/.." && pwd)}"
 KUSTOMIZE_OUT=$(kustomize build "${PROJECT_DIR}/prod-mentolder" 2>/dev/null)
-for pvc in nextcloud-data-pvc vaultwarden-data-pvc docuseal-data-pvc; do
+# nextcloud-data-pvc excluded: Longhorn lacks disk headroom for 50Gi on 3 replicas (T000317)
+for pvc in vaultwarden-data-pvc docuseal-data-pvc; do
   # Extract storageClassName from the built manifest for this specific PVC
   SC=$(echo "$KUSTOMIZE_OUT" \
     | python3 -c "


### PR DESCRIPTION
## Summary
- Remove `nextcloud-data-pvc` from `patch-data-pvc-storage.yaml` — Longhorn cluster lacks disk headroom: Hetzner nodes have only 15–25 GB free, but a 50 Gi volume with 3 replicas would require 150 GB total
- Update SA-07/T11 to only assert `vaultwarden-data-pvc` and `docuseal-data-pvc` use Longhorn
- nextcloud-data-pvc remains on `local-path` (gekko-hetzner-4) until Longhorn capacity is expanded

## Follow-up required
- **T000317 scope change**: pvc-backup CronJob still can't backup vaultwarden+docuseal while services run (Longhorn RWO Multi-Attach constraint) — needs backup script to scale down services before mounting PVCs, or use VolumeSnapshots
- **Disk drift**: postgres user passwords for nextcloud/vaultwarden/docuseal were stale vs workspace-secrets sealed passwords; manually reset during migration — root cause in T000317 comments

## Test plan
- [x] SA-07/T11 passes (2 assertions: vaultwarden + docuseal)
- [x] vaultwarden-data-pvc → longhorn ✓ (live)
- [x] docuseal-data-pvc → longhorn ✓ (live)
- [x] All services healthy: nextcloud 3/3, vaultwarden 1/1, docuseal 1/1

Closes T000317

🤖 Generated with [Claude Code](https://claude.com/claude-code)