### PR TITLE
fix(keycloak): de-double $$ escaping in realm-import entrypoint

### DIFF
--- a/docs/superpowers/plans/2026-05-30-t000320-keycloak-entrypoint-escaping.md
+++ b/docs/superpowers/plans/2026-05-30-t000320-keycloak-entrypoint-escaping.md
@@ -1,0 +1,67 @@
+---
+title: Fix T000320 — Keycloak realm-import entrypoint: doubled-dollar escaping
+ticket_id: T000320
+domains: [infra, ops, test, security]
+status: active
+pr_number: null
+---
+
+# Fix T000320 — Keycloak realm-import entrypoint: doubled-dollar escaping
+
+**Goal:** Remove the `$$` doubled-dollar escaping artifacts from `prod/import-entrypoint.sh` so the Keycloak realm-import container stops emitting `line 45: ${$${var}:-}: bad substitution` on every startup.
+
+**Root cause:** `prod/import-entrypoint.sh` is loaded **verbatim** into the `realm-template` ConfigMap by the `configMapGenerator` (`behavior: replace`) in both `prod-mentolder/` and `prod-korczewski/` (both inherit base `prod/` — no override). Kustomize does no `$$`→`$` de-escaping, and the prod manifest-level `envsubst` leaves `$$` untouched. So the literal `$${$${var}:-}` reaches `/bin/sh` and throws `bad substitution`. Non-fatal today (KC still boots) but the `sed`/`eval` substitution loop is silently broken, and the file's own header warns that an unsubstituted `${VAR}` landing in the KC DB breaks auth flows later.
+
+The two canonical siblings — `scripts/import-entrypoint.sh` and `k3d/realm-import-entrypoint.sh` — use single `$` and are the known-good reference.
+
+## File Map
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Modify | `prod/import-entrypoint.sh` | De-double all `$$` → `$` (12 occurrences across 9 lines) |
+| (test) | `tests/unit/keycloak-entrypoint-escaping.bats` | Already staged & failing (red) — guards parity with siblings |
+
+## Task 1: De-double the escaping
+
+The fix is a global de-doubling. Verified by dry-run that `sed 's/\$\$/\$/g'` reconstructs the **exact** canonical idiom — e.g. line 45 `\$${$${var}:-}` → `\${${var}:-}`, byte-identical to `scripts/import-entrypoint.sh:27`. The de-double does not touch the prod-specific variable list.
+
+- [ ] **Step 1: Apply the de-double**
+
+```bash
+sed -i 's/\$\$/\$/g' prod/import-entrypoint.sh
+```
+
+- [ ] **Step 2: Verify zero artifacts remain & syntax is valid**
+
+```bash
+grep -c '\$\$' prod/import-entrypoint.sh   # expect 0
+sh -n prod/import-entrypoint.sh            # expect clean exit
+```
+
+- [ ] **Step 3: Confirm the substitution loop now matches the canonical sibling**
+
+```bash
+diff <(sed -n '44,57p' prod/import-entrypoint.sh) <(sed -n '26,40p' scripts/import-entrypoint.sh) || true
+# Differences should be limited to the comment/var-list lines, NOT the
+# eval/sed/grep substitution mechanics.
+```
+
+- [ ] **Step 4: Run the gate test — must go green**
+
+```bash
+tests/unit/lib/bats-core/bin/bats tests/unit/keycloak-entrypoint-escaping.bats
+task test:all
+```
+
+## Verification
+
+- `task test:all` green (includes the new BATS test).
+- `task workspace:validate` (manifests touched indirectly via configMapGenerator input).
+- Post-merge deploy: `task feature:deploy` (both clusters), then confirm the
+  realm-import container logs no `bad substitution` on next Keycloak restart:
+  `task workspace:logs ENV=mentolder -- keycloak` and `ENV=korczewski`.
+
+## Notes
+
+- Single fix covers **both** clusters — `prod/` is the shared base inherited by both overlays.
+- No realm JSON or var-list changes; purely an escaping correction.

--- a/docs/superpowers/plans/2026-05-30-t000320-keycloak-entrypoint-escaping.md
+++ b/docs/superpowers/plans/2026-05-30-t000320-keycloak-entrypoint-escaping.md
@@ -25,7 +25,7 @@ The two canonical siblings — `scripts/import-entrypoint.sh` and `k3d/realm-imp
 
 The fix is a global de-doubling. Verified by dry-run that `sed 's/\$\$/\$/g'` reconstructs the **exact** canonical idiom — e.g. line 45 `\$${$${var}:-}` → `\${${var}:-}`, byte-identical to `scripts/import-entrypoint.sh:27`. The de-double does not touch the prod-specific variable list.
 
-- [ ] **Step 1: Apply the de-double**
+- [x] **Step 1: Apply the de-double**
 
 ```bash
 sed -i 's/\$\$/\$/g' prod/import-entrypoint.sh

--- a/prod/import-entrypoint.sh
+++ b/prod/import-entrypoint.sh
@@ -2,10 +2,10 @@
 # Substituiert Umgebungsvariablen in realm-workspace.json
 # und startet Keycloak mit --import-realm
 #
-# Production-Variante: substituiert alle $${VAR} Platzhalter, die das
+# Production-Variante: substituiert alle ${VAR} Platzhalter, die das
 # Realm-Template referenziert. Die Liste muss vollständig sein, weil
 # kc.sh start --import-realm den Realm nur beim ersten Start einliest.
-# Wenn hier eine Variable fehlt, landet ihr literaler $${VAR}-String in
+# Wenn hier eine Variable fehlt, landet ihr literaler ${VAR}-String in
 # der KC-Datenbank und Auth-Flows scheitern später mit
 # "Invalid client credentials".
 set -e
@@ -15,7 +15,7 @@ OUTPUT="/opt/keycloak/data/import/realm-workspace.json"
 
 mkdir -p "$(dirname "$OUTPUT")"
 
-# Alle $${VAR} Referenzen im JSON durch aktuelle Env-Werte ersetzen (sed-basiert)
+# Alle ${VAR} Referenzen im JSON durch aktuelle Env-Werte ersetzen (sed-basiert)
 cp "$TEMPLATE" "$OUTPUT"
 for var in \
     NEXTCLOUD_OIDC_SECRET \
@@ -42,18 +42,18 @@ for var in \
     BRETT_OIDC_SECRET \
     DEV_DOMAIN \
     DEV_WORKSPACE_OIDC_SECRET; do
-  eval val="\$${$${var}:-}"
+  eval val="\${${var}:-}"
   if [ -z "$val" ]; then
-    echo "[import-entrypoint] WARNUNG: $${var} ist nicht gesetzt!"
+    echo "[import-entrypoint] WARNUNG: ${var} ist nicht gesetzt!"
   else
-    sed -i "s|\$${$${var}}|$${val}|g" "$OUTPUT"
+    sed -i "s|\${${var}}|${val}|g" "$OUTPUT"
   fi
 done
 
-# Sanity check: keine unaufgelösten $${...} Platzhalter mehr im Output
-if grep -q '\$${[A-Z_]*}' "$OUTPUT"; then
+# Sanity check: keine unaufgelösten ${...} Platzhalter mehr im Output
+if grep -q '\${[A-Z_]*}' "$OUTPUT"; then
   echo "[import-entrypoint] FEHLER: Unaufgelöste Platzhalter im Realm-JSON:" >&2
-  grep -o '\$${[A-Z_]*}' "$OUTPUT" | sort -u >&2
+  grep -o '\${[A-Z_]*}' "$OUTPUT" | sort -u >&2
   exit 1
 fi
 

--- a/tests/unit/keycloak-entrypoint-escaping.bats
+++ b/tests/unit/keycloak-entrypoint-escaping.bats
@@ -1,0 +1,40 @@
+#!/usr/bin/env bats
+# ═══════════════════════════════════════════════════════════════════
+# keycloak-entrypoint-escaping.bats — Guard the realm-import entrypoint
+# against doubled-dollar ($$) escaping artifacts. [T000320]
+# ═══════════════════════════════════════════════════════════════════
+# prod/import-entrypoint.sh is loaded VERBATIM into the realm-template
+# ConfigMap by the prod-mentolder/prod-korczewski configMapGenerator
+# (behavior: replace). Kustomize does NOT de-escape $$ -> $, and the
+# prod manifest-level envsubst leaves $$ untouched too. So any $$ in
+# this file reaches /bin/sh literally and the runtime expansion
+# `${$${var}:-}` throws "bad substitution" on every Keycloak startup.
+#
+# The canonical siblings (scripts/import-entrypoint.sh,
+# k3d/realm-import-entrypoint.sh) use single $ and must stay $$-free.
+# This test fails while the artifact is present (red) and passes once
+# the escaping is de-doubled (green).
+# ═══════════════════════════════════════════════════════════════════
+
+load test_helper
+
+@test "prod/import-entrypoint.sh has no doubled-dollar (\$\$) escaping artifacts" {
+  local f="${PROJECT_DIR}/prod/import-entrypoint.sh"
+  [[ -f "$f" ]] || { echo "missing: $f"; return 1; }
+  if grep -nF '$$' "$f"; then
+    echo "Found doubled-dollar (\$\$) in $f — kustomize embeds this file"
+    echo "verbatim, so \$\$ reaches /bin/sh and triggers 'bad substitution'."
+    return 1
+  fi
+}
+
+@test "canonical entrypoint siblings stay free of doubled-dollar artifacts" {
+  for f in "${PROJECT_DIR}/scripts/import-entrypoint.sh" \
+           "${PROJECT_DIR}/k3d/realm-import-entrypoint.sh"; do
+    [[ -f "$f" ]] || continue
+    if grep -nF '$$' "$f"; then
+      echo "Unexpected doubled-dollar in canonical file $f"
+      return 1
+    fi
+  done
+}


### PR DESCRIPTION
## Summary
- `prod/import-entrypoint.sh` carried 12 doubled-dollar (`$$`) escaping artifacts; kustomize `configMapGenerator` embeds the file verbatim, so the literal `${$${var}:-}` reached `/bin/sh` and threw `line 45: bad substitution` on every Keycloak startup.
- De-doubled to the canonical single-`$` idiom — substitution lines now byte-identical to `scripts/import-entrypoint.sh` and `k3d/realm-import-entrypoint.sh`.
- One file fixes **both clusters**: `prod/` is the shared base inherited by `prod-mentolder/` and `prod-korczewski/` (no override).

## Test plan
- [x] `tests/unit/keycloak-entrypoint-escaping.bats` — red→green regression guard (asserts no `$$`, siblings stay clean)
- [x] `task test:all` (93 assertions, exit 0)
- [x] `task workspace:validate`
- [x] `task test:inventory` — inventory unchanged
- [x] `sh -n` syntax clean + diff parity vs canonical sibling

Closes T000320

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>