### PR TITLE
fix(keycloak): restore $$ drone-envsubst escaping in realm entrypoint

### DIFF
--- a/prod/import-entrypoint.sh
+++ b/prod/import-entrypoint.sh
@@ -2,10 +2,10 @@
 # Substituiert Umgebungsvariablen in realm-workspace.json
 # und startet Keycloak mit --import-realm
 #
-# Production-Variante: substituiert alle ${VAR} Platzhalter, die das
+# Production-Variante: substituiert alle $${VAR} Platzhalter, die das
 # Realm-Template referenziert. Die Liste muss vollständig sein, weil
 # kc.sh start --import-realm den Realm nur beim ersten Start einliest.
-# Wenn hier eine Variable fehlt, landet ihr literaler ${VAR}-String in
+# Wenn hier eine Variable fehlt, landet ihr literaler $${VAR}-String in
 # der KC-Datenbank und Auth-Flows scheitern später mit
 # "Invalid client credentials".
 set -e
@@ -15,7 +15,7 @@ OUTPUT="/opt/keycloak/data/import/realm-workspace.json"
 
 mkdir -p "$(dirname "$OUTPUT")"
 
-# Alle ${VAR} Referenzen im JSON durch aktuelle Env-Werte ersetzen (sed-basiert)
+# Alle $${VAR} Referenzen im JSON durch aktuelle Env-Werte ersetzen (sed-basiert)
 cp "$TEMPLATE" "$OUTPUT"
 for var in \
     NEXTCLOUD_OIDC_SECRET \
@@ -42,18 +42,18 @@ for var in \
     BRETT_OIDC_SECRET \
     DEV_DOMAIN \
     DEV_WORKSPACE_OIDC_SECRET; do
-  eval val="\${${var}:-}"
+  eval val="\$${$${var}:-}"
   if [ -z "$val" ]; then
-    echo "[import-entrypoint] WARNUNG: ${var} ist nicht gesetzt!"
+    echo "[import-entrypoint] WARNUNG: $${var} ist nicht gesetzt!"
   else
-    sed -i "s|\${${var}}|${val}|g" "$OUTPUT"
+    sed -i "s|\$${$${var}}|$${val}|g" "$OUTPUT"
   fi
 done
 
-# Sanity check: keine unaufgelösten ${...} Platzhalter mehr im Output
-if grep -q '\${[A-Z_]*}' "$OUTPUT"; then
+# Sanity check: keine unaufgelösten $${...} Platzhalter mehr im Output
+if grep -q '\$${[A-Z_]*}' "$OUTPUT"; then
   echo "[import-entrypoint] FEHLER: Unaufgelöste Platzhalter im Realm-JSON:" >&2
-  grep -o '\${[A-Z_]*}' "$OUTPUT" | sort -u >&2
+  grep -o '\$${[A-Z_]*}' "$OUTPUT" | sort -u >&2
   exit 1
 fi
 

--- a/tests/unit/keycloak-entrypoint-escaping.bats
+++ b/tests/unit/keycloak-entrypoint-escaping.bats
@@ -1,40 +1,49 @@
 #!/usr/bin/env bats
 # ═══════════════════════════════════════════════════════════════════
-# keycloak-entrypoint-escaping.bats — Guard the realm-import entrypoint
-# against doubled-dollar ($$) escaping artifacts. [T000320]
+# keycloak-entrypoint-escaping.bats — Guard the prod realm-import
+# entrypoint's Flux drone-envsubst escaping. [T000320]
 # ═══════════════════════════════════════════════════════════════════
-# prod/import-entrypoint.sh is loaded VERBATIM into the realm-template
-# ConfigMap by the prod-mentolder/prod-korczewski configMapGenerator
-# (behavior: replace). Kustomize does NOT de-escape $$ -> $, and the
-# prod manifest-level envsubst leaves $$ untouched too. So any $$ in
-# this file reaches /bin/sh literally and the runtime expansion
-# `${$${var}:-}` throws "bad substitution" on every Keycloak startup.
+# prod/import-entrypoint.sh is generated into the keycloak-import-script
+# ConfigMap and the prod overlays are reconciled by Flux, whose
+# postBuild.substituteFrom runs drone-style envsubst over the rendered
+# manifest. drone-envsubst treats `$${VAR}` as an ESCAPE that emits a
+# literal `${VAR}`. The script's own shell expansions therefore MUST be
+# doubled (`$$`) so that:
+#   1. drone-envsubst parses the manifest (no "unable to parse variable
+#      name"), and
+#   2. after substitution the embedded script contains correct single-$
+#      shell expansions (e.g. `eval val="\${${var}:-}"`).
 #
-# The canonical siblings (scripts/import-entrypoint.sh,
-# k3d/realm-import-entrypoint.sh) use single $ and must stay $$-free.
-# This test fails while the artifact is present (red) and passes once
-# the escaping is de-doubled (green).
+# Regression context: PR #1168 de-doubled these to single-$ to silence a
+# runtime "bad substitution" seen only on the manual GNU-envsubst deploy
+# path. That broke Flux reconciliation on BOTH prod clusters ("unable to
+# parse variable name"). This test pins the Flux contract so the revert
+# cannot be undone by mistake. The dev/k3d entrypoints (no Flux) keep
+# single-$ and are intentionally NOT covered here.
 # ═══════════════════════════════════════════════════════════════════
 
 load test_helper
 
-@test "prod/import-entrypoint.sh has no doubled-dollar (\$\$) escaping artifacts" {
-  local f="${PROJECT_DIR}/prod/import-entrypoint.sh"
-  [[ -f "$f" ]] || { echo "missing: $f"; return 1; }
-  if grep -nF '$$' "$f"; then
-    echo "Found doubled-dollar (\$\$) in $f — kustomize embeds this file"
-    echo "verbatim, so \$\$ reaches /bin/sh and triggers 'bad substitution'."
-    return 1
-  fi
+PROD_ENTRYPOINT="${PROJECT_DIR}/prod/import-entrypoint.sh"
+
+@test "prod/import-entrypoint.sh survives Flux drone-envsubst (flux CLI)" {
+  command -v flux >/dev/null 2>&1 || skip "flux CLI not available"
+  run flux envsubst < "$PROD_ENTRYPOINT"
+  [ "$status" -eq 0 ]
+  # After Flux substitution the indirect-expansion line must be valid
+  # single-$ shell — proves the $$ escaping resolved correctly.
+  echo "$output" | grep -qF 'eval val="\${${var}:-}"'
 }
 
-@test "canonical entrypoint siblings stay free of doubled-dollar artifacts" {
-  for f in "${PROJECT_DIR}/scripts/import-entrypoint.sh" \
-           "${PROJECT_DIR}/k3d/realm-import-entrypoint.sh"; do
-    [[ -f "$f" ]] || continue
-    if grep -nF '$$' "$f"; then
-      echo "Unexpected doubled-dollar in canonical file $f"
-      return 1
-    fi
-  done
+@test "prod/import-entrypoint.sh keeps the \$\$ escaping the Flux contract needs" {
+  # CI-safe guard (no flux dependency): the escaped indirect-expansion
+  # line must be present in its doubled form. Single-$ here means the
+  # Flux-breaking regression has returned.
+  grep -qF 'eval val="\$${$${var}:-}"' "$PROD_ENTRYPOINT"
+}
+
+@test "prod/import-entrypoint.sh is valid POSIX sh after de-escaping" {
+  # Simulate Flux's $$ -> $ collapse, then syntax-check the result so a
+  # de-escaped script can never ship a shell syntax error.
+  sed 's/\$\$/\$/g' "$PROD_ENTRYPOINT" | sh -n
 }


### PR DESCRIPTION
## Summary
- **Regression fix for PR #1168.** That PR de-doubled `prod/import-entrypoint.sh` to single-`$` to silence a runtime `bad substitution` — but that error only occurs on the manual `task feature:deploy` (GNU envsubst) path.
- Prod reconciles via **Flux**, whose `postBuild` drone-envsubst requires `$${VAR}` escaping. Single-`$` makes it fail `unable to parse variable name`, which **froze the workspace Kustomization on BOTH prod clusters** (mentolder + korczewski).
- Restores the `$$` form from b20dcc58. Verified: `flux envsubst` exits 0 and yields correct `eval val="\${${var}:-}"` shell.
- Test rewritten to pin the **real** contract (survives `flux envsubst` + valid POSIX sh after de-escape) instead of the incorrect 'no $$' assertion.

## Test plan
- [x] `flux envsubst < prod/import-entrypoint.sh` → exit 0, correct shell
- [x] `tests/unit/keycloak-entrypoint-escaping.bats` (3/3 green)
- [x] `task test:all` (93 ok, 0 failures)

Closes T000320

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>