### PR TITLE
fix(backup): use alpine/k8s image and install openssl for backup encryption [T000322]

### DIFF
--- a/k3d/pvc-backup-cronjob.yaml
+++ b/k3d/pvc-backup-cronjob.yaml
@@ -41,7 +41,7 @@ spec:
               type: RuntimeDefault
           containers:
             - name: orchestrator
-              image: rancher/kubectl:v1.30.2
+              image: alpine/k8s:1.30.4
               imagePullPolicy: IfNotPresent
               securityContext:
                 allowPrivilegeEscalation: false
@@ -141,6 +141,7 @@ spec:
                           runAsNonRoot: true
                           runAsUser: 65534
                           fsGroup: 65534
+                          supplementalGroups: [33]
                           seccompProfile: { type: RuntimeDefault }
                         containers:
                           - name: backup
@@ -166,6 +167,7 @@ spec:
                             args:
                               - |
                                 set -euo pipefail
+                                apk add -q --no-cache openssl >/dev/null 2>&1
                                 sleep 5
                                 STAMP=\$(date +%Y%m%d-%H%M%S)
                                 BACKUP_DIR=/backups/pvc-\${STAMP}


### PR DESCRIPTION
## Summary
- Switch orchestrator image from `rancher/kubectl:v1.30.2` to `alpine/k8s:1.30.4` — the rancher image has no package manager so `apk add openssl` fails silently at runtime
- Add `apk add -q --no-cache openssl` in the backup container init — required by the `openssl enc -aes-256-cbc -salt -pbkdf2` encryption step in the backup script
- Add `supplementalGroups: [33]` (www-data GID) so the backup container can read Nextcloud volume data owned by gid 33

These changes were left uncommitted from the T000317 Longhorn clone fix session (PR #1171).

## Test plan
- [ ] Verify `task test:all` passes offline
- [ ] Confirm backup CronJob succeeds on next 3 AM run (or trigger manually via `kubectl create job --from=cronjob/pvc-backup`)
- [ ] Check backup files contain valid AES-256-CBC encrypted data

Closes T000322

🤖 Generated with [Claude Code](https://claude.com/claude-code)