### PR TITLE
fix(skills): guard dev-flow-plan against committing plans to main [T000321]

### DIFF
--- a/.claude/skills/dev-flow-plan/SKILL.md
+++ b/.claude/skills/dev-flow-plan/SKILL.md
@@ -613,12 +613,20 @@ fi
 ### Schritt 5: Commit & Push — dann STOPP
 
 ```bash
+# Sicherheitscheck: NIEMALS auf main committen [T000321]
+BRANCH=$(git branch --show-current)
+if [[ "$BRANCH" == "main" || -z "$BRANCH" ]]; then
+  echo "ERROR: Auf main-Branch (oder kein Branch). Plan darf nicht auf main committed werden!"
+  echo "→ Schritt 1 (Worktree anlegen) wurde übersprungen oder fehlgeschlagen. Jetzt nachholen:"
+  echo "  git worktree add -b feature/<slug> /tmp/wt-<slug> origin/main && cd /tmp/wt-<slug>"
+  exit 1
+fi
+
 # Die Spec wurde bereits in Schritt 3.7.1.5 committed; git add ist idempotent falls nötig
 git add docs/superpowers/specs/<date>-<slug>-design.md docs/superpowers/plans/<date>-<slug>.md
 git commit -m "chore(plans): stage <slug> for execution [$TICKET_EXT_ID]"
 
 # Push mit automatischer Force-with-lease-Fallback bei divergiertem Remote (Prior-Session Stale Commits)
-BRANCH=$(git branch --show-current)
 if ! git push -u origin "$BRANCH" 2>/tmp/_push_err.txt; then
   if grep -qE "rejected.*non-fast-forward|rejected.*fetch first" /tmp/_push_err.txt; then
     echo "Remote divergiert — wende --force-with-lease an"
@@ -777,6 +785,15 @@ git push
 ### Schritt 5: Commit & Push — dann STOPP
 
 ```bash
+# Sicherheitscheck: NIEMALS auf main committen [T000321]
+BRANCH=$(git branch --show-current)
+if [[ "$BRANCH" == "main" || -z "$BRANCH" ]]; then
+  echo "ERROR: Auf main-Branch (oder kein Branch). Plan darf nicht auf main committed werden!"
+  echo "→ Schritt 1 (Worktree anlegen) wurde übersprungen oder fehlgeschlagen. Jetzt nachholen:"
+  echo "  git worktree add -b fix/<slug> /tmp/wt-<slug> origin/main && cd /tmp/wt-<slug>"
+  exit 1
+fi
+
 # Immer dabei: der failing Test
 git add tests/<relevante-test-datei>
 
@@ -786,7 +803,6 @@ git add docs/superpowers/plans/<slug>.md
 git commit -m "chore(plans): stage <slug> fix for execution [$TICKET_EXT_ID]"
 
 # Push mit automatischer Force-with-lease-Fallback bei divergiertem Remote
-BRANCH=$(git branch --show-current)
 if ! git push -u origin "$BRANCH" 2>/tmp/_push_err.txt; then
   if grep -qE "rejected.*non-fast-forward|rejected.*fetch first" /tmp/_push_err.txt; then
     echo "Remote divergiert — wende --force-with-lease an"


### PR DESCRIPTION
## Summary
- Adds a `BRANCH == main` safety check at the top of Schritt 5 (commit & push) in both the Feature-Pfad and Fix-Pfad of the `dev-flow-plan` skill
- If the worktree creation step (Schritt 1) was skipped or failed, the guard now aborts with a clear error message and recovery instructions instead of silently landing plan files on `main`
- Moves the `BRANCH=$(git branch --show-current)` call to the top of Schritt 5 so it's available for both the guard and the push command (removes duplicate assignment)

**Root cause (T000321):** During the 2026-05-30 cluster-deployment session, the plan was committed directly to main because there was no enforcement that Schritt 1 (worktree creation) had completed successfully before the commit ran.

## Test plan
- [ ] CI passes
- [ ] Manual: run `dev-flow-plan` on main without creating a worktree first — should now abort at Schritt 5 with the `ERROR: Auf main-Branch` message

Closes T000321

🤖 Generated with [Claude Code](https://claude.com/claude-code)