### PR TITLE
fix(backup): use alpine/k8s image in mounter container [T000323]

### DIFF
--- a/k3d/pvc-backup-cronjob.yaml
+++ b/k3d/pvc-backup-cronjob.yaml
@@ -145,7 +145,7 @@ spec:
                           seccompProfile: { type: RuntimeDefault }
                         containers:
                           - name: backup
-                            image: alpine:3
+                            image: alpine/k8s:1.30.4
                             imagePullPolicy: IfNotPresent
                             securityContext:
                               allowPrivilegeEscalation: false
@@ -163,11 +163,10 @@ spec:
                                 valueFrom: { secretKeyRef: { name: workspace-secrets, key: FILEN_EMAIL, optional: true } }
                               - name: FILEN_PASSWORD
                                 valueFrom: { secretKeyRef: { name: workspace-secrets, key: FILEN_PASSWORD, optional: true } }
-                            command: ["/bin/sh", "-c"]
+                            command: ["/bin/bash", "-c"]
                             args:
                               - |
                                 set -euo pipefail
-                                apk add -q --no-cache openssl >/dev/null 2>&1
                                 sleep 5
                                 STAMP=\$(date +%Y%m%d-%H%M%S)
                                 BACKUP_DIR=/backups/pvc-\${STAMP}


### PR DESCRIPTION
## Summary
- Replace `alpine:3` with `alpine/k8s:1.30.4` in the pvc-backup mounter's `backup` container
- Remove `apk add openssl` — `alpine/k8s` ships openssl pre-installed
- Switch shell from `/bin/sh` to `/bin/bash` since `set -o pipefail` requires bash (busybox ash doesn't support it)

**Root cause:** `alpine:3` ran `apk add --no-cache openssl` as `runAsUser=65534` (nobody). apk cannot write to `/var/log/apk/` as non-root → exits 99. The error was suppressed by `>/dev/null 2>&1`, so `set -e` then killed the script before any backup ran. ALL PVC backups (Nextcloud, Vaultwarden, DocuSeal) have silently failed since deployment.

## Test plan
- [ ] Manifest validates: `task workspace:validate`
- [ ] Trigger a manual backup run and confirm backup container exits 0
- [ ] Verify encrypted `.enc` files appear in `/backups/pvc-*`

🤖 Generated with [Claude Code](https://claude.com/claude-code)