### PR TITLE
fix(tests): repair render-cloud-init.bats missing --wg-listen-port arg

### DIFF
--- a/tests/unit/render-cloud-init.bats
+++ b/tests/unit/render-cloud-init.bats
@@ -34,6 +34,7 @@ _base_args() {
   echo --versions-file "${TMPDIR}/versions.yaml" \
        --template "${TMPDIR}/tpl.yaml" \
        --node-ip 1.2.3.4 \
+       --wg-listen-port 51820 \
        --k3s-url "https://192.168.100.1:6443" \
        --k3s-token "testtoken" \
        --ssh-key "ssh-ed25519 AAAA testkey"
@@ -85,6 +86,7 @@ _base_args() {
     --versions-file "/nonexistent/versions.yaml" \
     --template "${TMPDIR}/tpl.yaml" \
     --node-ip 1.2.3.4 \
+    --wg-listen-port 51820 \
     --k3s-url "https://192.168.100.1:6443" \
     --k3s-token "testtoken" \
     --ssh-key "ssh-ed25519 AAAA testkey"
@@ -97,6 +99,7 @@ _base_args() {
     --versions-file "${TMPDIR}/versions.yaml" \
     --template "/nonexistent/tpl.yaml" \
     --node-ip 1.2.3.4 \
+    --wg-listen-port 51820 \
     --k3s-url "https://192.168.100.1:6443" \
     --k3s-token "testtoken" \
     --ssh-key "ssh-ed25519 AAAA testkey"


### PR DESCRIPTION
## Summary
- `render-cloud-init.sh` made `--wg-listen-port` a required arg in #1178 (d08f3cab), but `tests/unit/render-cloud-init.bats` was never updated.
- The `offline-tests` CI job has been **red on main since d08f3cab**, blocking all PR merges.
- Adds `--wg-listen-port 51820` to `_base_args()` and to the two negative tests that build inline arg lists, so they reach their intended file-existence assertions.

## Test plan
- [x] `./tests/unit/lib/bats-core/bin/bats tests/unit/render-cloud-init.bats` → 8/8 pass
- [x] `task test:all` → exit 0 (full offline suite green)

Closes T000332

Co-Authored-By: Claude Opus 4.8 (1M context)