### PR TITLE
feat(backup): add filen-pull to restore content on a fresh cluster

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1046,6 +1046,18 @@ tasks:
         [ "{{.ENV}}" != "dev" ] && ctx_arg="--context $ENV_CONTEXT"
         bash scripts/backup-restore.sh pvc-list $ctx_arg
 
+  workspace:backup:filen-pull:
+    desc: "Download a backup timestamp from Filen cloud into backup-pvc (usage: task workspace:backup:filen-pull -- <timestamp> [--remote-path <p>]) [ENV=dev|mentolder|korczewski]"
+    vars:
+      ENV: '{{.ENV | default "dev"}}'
+    cmds:
+      - |
+        source scripts/env-resolve.sh "{{.ENV}}"
+        ctx_arg=""
+        [ "{{.ENV}}" != "dev" ] && ctx_arg="--context $ENV_CONTEXT"
+        ns_arg="--namespace ${WORKSPACE_NAMESPACE:-workspace}"
+        bash scripts/backup-restore.sh filen-pull {{.CLI_ARGS}} $ctx_arg $ns_arg
+
   workspace:pvc:restore:
     desc: "List available PVC backups then restore a service (usage: task workspace:pvc:restore -- <service> <timestamp> [ENV=...])"
     vars:

--- a/docs/superpowers/plans/2026-05-30-backup-filen-pull.md
+++ b/docs/superpowers/plans/2026-05-30-backup-filen-pull.md
@@ -1,0 +1,399 @@
+---
+title: Backup Filen-Pull Implementation Plan
+ticket_id: T000331
+domains: [website, infra, db, ops, test, security]
+status: active
+pr_number: null
+---
+
+# Backup Filen-Pull Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `filen-pull <timestamp>` capability that downloads encrypted backup archives from Filen cloud into the in-cluster `backup-pvc`, so a freshly-deployed cluster can restore content using the existing restore tasks.
+
+**Architecture:** New subcommand in `scripts/backup-restore.sh` that spawns a one-shot Kubernetes `Job` (same pattern as the existing `pvc-restore` block) mirroring the `filen-upload` container in `k3d/backup-cronjob.yaml` — `node:22-alpine` + `@filen/cli`, credentials from `workspace-secrets` — but inverted to *download* into `backup-pvc` mounted **writable**. An ENV-aware Taskfile wrapper exposes it as `workspace:backup:filen-pull`.
+
+**Tech Stack:** Bash, kubectl, Kubernetes Job, `@filen/cli` (Node), BATS unit tests.
+
+---
+
+## File Map
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Create | `tests/unit/backup-restore-filen-pull.bats` | Unit test: arg validation, Job manifest shape, remote-path resolution, usage text |
+| Modify | `scripts/backup-restore.sh` | Add `--remote-path` flag parse, `filen-pull` case, usage doc |
+| Modify | `Taskfile.yml` | Add `workspace:backup:filen-pull` ENV-aware task |
+
+---
+
+## Task 1: filen-pull subcommand (TDD)
+
+**Files:**
+- Create: `tests/unit/backup-restore-filen-pull.bats`
+- Modify: `scripts/backup-restore.sh` (flag loop ~line 48–58; usage ~line 9–41; new case before final `esac` ~line 455)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/backup-restore-filen-pull.bats`:
+
+```bash
+#!/usr/bin/env bats
+# backup-restore-filen-pull.bats — unit tests for `backup-restore.sh filen-pull`
+# Stubs kubectl so no live cluster/Filen is required; captures the applied Job YAML.
+
+load test_helper
+
+SCRIPT="${PROJECT_DIR}/scripts/backup-restore.sh"
+
+setup() {
+  FAKE_BIN=$(mktemp -d)
+  export CAPTURE="${BATS_TEST_TMPDIR}/applied.yaml"
+  cat > "${FAKE_BIN}/kubectl" <<EOF
+#!/usr/bin/env bash
+# Capture 'apply -f -' stdin; answer configmap lookups; succeed on wait/logs.
+args="\$*"
+case "\$args" in
+  *"apply"*) cat > "${CAPTURE}" ; exit 0 ;;
+  *"get configmap backup-config"*) echo "/Backup" ; exit 0 ;;
+  *"wait"*) exit 0 ;;
+  *"logs"*) exit 0 ;;
+  *) exit 0 ;;
+esac
+EOF
+  chmod +x "${FAKE_BIN}/kubectl"
+  export PATH="${FAKE_BIN}:${PATH}"
+}
+
+teardown() {
+  rm -rf "$FAKE_BIN"
+}
+
+@test "filen-pull without timestamp fails with usage" {
+  run bash "$SCRIPT" filen-pull
+  assert_failure
+  assert_output --partial "Usage"
+}
+
+@test "filen-pull renders a Job mounting backup-pvc writable" {
+  run bash "$SCRIPT" filen-pull 20260530-020001
+  assert_success
+  run cat "$CAPTURE"
+  assert_output --partial "kind: Job"
+  assert_output --partial "claimName: backup-pvc"
+  assert_output --partial "node:22-alpine"
+  assert_output --partial "/backups/20260530-020001/"
+  # The backups volume must be writable — no readOnly mount anywhere in the Job.
+  refute_output --partial "readOnly: true"
+}
+
+@test "filen-pull resolves remote base path from backup-config configmap" {
+  run bash "$SCRIPT" filen-pull pvc-20260530-030001
+  assert_success
+  run cat "$CAPTURE"
+  assert_output --partial "/Backup/pvc-20260530-030001/"
+}
+
+@test "filen-pull honours --remote-path override" {
+  run bash "$SCRIPT" filen-pull 20260530-020001 --remote-path /custom/path
+  assert_success
+  run cat "$CAPTURE"
+  assert_output --partial "/custom/path/20260530-020001/"
+}
+
+@test "usage lists filen-pull" {
+  run bash "$SCRIPT" --help
+  assert_success
+  assert_output --partial "filen-pull"
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd /tmp/wt-backup-filen-pull && bats tests/unit/backup-restore-filen-pull.bats`
+Expected: FAIL — `filen-pull` is an unknown command (script falls through to its default `*)` case / usage), captured file never written.
+
+- [ ] **Step 3: Add the `--remote-path` flag to the parse loop**
+
+In `scripts/backup-restore.sh`, the flag loop currently reads:
+
+```bash
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --context)   CTX_FLAG="--context $2"; shift 2 ;;
+    --namespace) NS="$2"; shift 2 ;;
+    -y|--yes)    YES=true; shift ;;
+    -h|--help)   usage; exit 0 ;;
+    *) POSITIONAL+=("$1"); shift ;;
+  esac
+done
+```
+
+Add a `--remote-path` case directly after `--namespace`:
+
+```bash
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --context)     CTX_FLAG="--context $2"; shift 2 ;;
+    --namespace)   NS="$2"; shift 2 ;;
+    --remote-path) REMOTE_PATH="$2"; shift 2 ;;
+    -y|--yes)      YES=true; shift ;;
+    -h|--help)     usage; exit 0 ;;
+    *) POSITIONAL+=("$1"); shift ;;
+  esac
+done
+```
+
+- [ ] **Step 4: Document `filen-pull` in `usage()`**
+
+In the `usage()` heredoc, after the `pvc-restore` line in the "Commands (PVC file data)" block, add a new section. Locate:
+
+```
+  pvc-restore <service> <timestamp> Restore PVC data from a backup
+    service:   nextcloud-files | vaultwarden-data | docuseal-data | all
+    timestamp: directory from 'pvc-list' (e.g. pvc-20260427-030001)
+    IMPORTANT: scale down the target service before restoring, e.g.:
+      kubectl scale deploy/nextcloud -n workspace --replicas=0 --context <ctx>
+```
+
+Add immediately below it (still inside the heredoc):
+
+```
+Commands (disaster recovery — fresh cluster):
+  filen-pull <timestamp> [--remote-path <path>]
+                             Download a backup timestamp from Filen cloud into
+                             the in-cluster backup-pvc, so the existing
+                             'restore' / 'pvc-restore' commands can run on a
+                             freshly-deployed cluster (where backup-pvc is empty).
+                             Remote path defaults to backup-config's
+                             FILEN_DEFAULT_UPLOAD_PATH. Timestamps are discovered
+                             out-of-band (Filen web/desktop app or 'filen ls').
+```
+
+- [ ] **Step 5: Add the `filen-pull` case block**
+
+In `scripts/backup-restore.sh`, find the final `esac` (~line 455) that closes the main `case "$CMD" in` dispatch. Add this new case immediately **before** that closing `esac` (after the `pvc-restore)` block ends):
+
+```bash
+  filen-pull)
+    TS="${1:-}"
+    [[ -n "$TS" ]] || _die "Usage: $SCRIPT filen-pull <timestamp> [--remote-path <path>]"
+
+    # Resolve the Filen remote base path: --remote-path wins, else the
+    # backup-config ConfigMap default (mirrors what the upload side uploads to).
+    if [[ -z "${REMOTE_PATH:-}" ]]; then
+      REMOTE_PATH=$($KC get configmap backup-config -n "$NS" \
+        -o jsonpath='{.data.FILEN_DEFAULT_UPLOAD_PATH}' 2>/dev/null || echo "")
+    fi
+    [[ -n "$REMOTE_PATH" ]] || _die "Could not resolve Filen remote path — pass --remote-path <path> or ensure backup-config has FILEN_DEFAULT_UPLOAD_PATH"
+
+    echo "Pulling ${TS} from Filen (${REMOTE_PATH}/${TS}/) into backup-pvc (ns=${NS})..."
+    JOB="filen-pull-$$"
+
+    $KC apply -n "$NS" -f - <<YAML
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ${JOB}
+  namespace: ${NS}
+  labels:
+    app: filen-pull
+spec:
+  ttlSecondsAfterFinished: 600
+  backoffLimit: 0
+  template:
+    spec:
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: filen-pull
+          # Mirrors the filen-upload container in k3d/backup-cronjob.yaml,
+          # inverted to download. @filen/cli is the only working Filen client
+          # (rclone has no Filen backend; webdav.filen.io is desktop-only).
+          image: node:22-alpine
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -e
+              if [ -z "\$FILEN_EMAIL" ] || [ -z "\$FILEN_PASSWORD" ]; then
+                echo "ERROR: FILEN_EMAIL/FILEN_PASSWORD not set in workspace-secrets"; exit 1
+              fi
+              export HOME=/tmp
+              echo "Installing Filen CLI..."
+              npm install -g @filen/cli --prefix /tmp/npm-global --silent 2>&1 | tail -3
+              export PATH="/tmp/npm-global/bin:\$PATH"
+              mkdir -p "/backups/${TS}"
+              echo "Downloading ${REMOTE_PATH}/${TS}/ -> /backups/${TS}/ ..."
+              filen --email "\$FILEN_EMAIL" --password "\$FILEN_PASSWORD" \\
+                download "${REMOTE_PATH}/${TS}/" "/backups/${TS}/"
+              echo "Pulled ${TS} into backup-pvc:/backups/${TS}/"
+              ls -la "/backups/${TS}/"
+          env:
+            - name: FILEN_EMAIL
+              valueFrom:
+                secretKeyRef:
+                  name: workspace-secrets
+                  key: FILEN_EMAIL
+            - name: FILEN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: workspace-secrets
+                  key: FILEN_PASSWORD
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            capabilities:
+              drop: ["ALL"]
+          volumeMounts:
+            - name: backup-storage
+              mountPath: /backups
+          resources:
+            requests:
+              memory: 256Mi
+              cpu: "200m"
+            limits:
+              memory: 1Gi
+              cpu: "1"
+      volumes:
+        - name: backup-storage
+          persistentVolumeClaim:
+            claimName: backup-pvc
+YAML
+
+    echo "Waiting for filen-pull job to complete (up to 10 min)..."
+    if ! $KC wait -n "$NS" job/"$JOB" --for=condition=Complete --timeout=600s 2>/dev/null; then
+      echo "ERROR: filen-pull job did not complete"
+      $KC logs -n "$NS" -l "job-name=${JOB}" --tail=50 2>/dev/null || true
+      exit 1
+    fi
+    $KC logs -n "$NS" -l "job-name=${JOB}" --tail=20 2>/dev/null || true
+    echo ""
+    echo "✓ filen-pull complete. Confirm and restore:"
+    echo "    $SCRIPT list ${CTX_FLAG}        # DB backups now in backup-pvc"
+    echo "    $SCRIPT pvc-list ${CTX_FLAG}    # PVC backups now in backup-pvc"
+    echo "    $SCRIPT restore <db> ${TS} ${CTX_FLAG}"
+    echo "    $SCRIPT pvc-restore <svc> ${TS} ${CTX_FLAG}"
+    ;;
+
+```
+
+> **Note on `filen download` arg order:** the upload side uses
+> `filen ... upload <local> <cloud>`. The download is `filen ... download <cloud> <local>`,
+> which is what is written above. Verify against the installed `@filen/cli`
+> (`filen download --help`) during the first live run; if the CLI expects a
+> different flag form, adjust only the `args:` heredoc line — the Job shape and
+> tests are unaffected.
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+Run: `cd /tmp/wt-backup-filen-pull && bats tests/unit/backup-restore-filen-pull.bats`
+Expected: PASS (6/6).
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /tmp/wt-backup-filen-pull
+git add scripts/backup-restore.sh tests/unit/backup-restore-filen-pull.bats
+git commit -m "feat(backup): add filen-pull to download backups from Filen into backup-pvc"
+```
+
+---
+
+## Task 2: Taskfile wrapper `workspace:backup:filen-pull`
+
+**Files:**
+- Modify: `Taskfile.yml` (add task next to `workspace:backup:pvcs:list`, ~line 1047)
+
+- [ ] **Step 1: Add the ENV-aware task**
+
+In `Taskfile.yml`, after the `workspace:backup:pvcs:list:` task (ends ~line 1047, before `workspace:pvc:restore:`), insert:
+
+```yaml
+  workspace:backup:filen-pull:
+    desc: "Download a backup timestamp from Filen cloud into backup-pvc (usage: task workspace:backup:filen-pull -- <timestamp> [--remote-path <p>]) [ENV=dev|mentolder|korczewski]"
+    vars:
+      ENV: '{{.ENV | default "dev"}}'
+    cmds:
+      - |
+        source scripts/env-resolve.sh "{{.ENV}}"
+        ctx_arg=""
+        [ "{{.ENV}}" != "dev" ] && ctx_arg="--context $ENV_CONTEXT"
+        ns_arg="--namespace ${WORKSPACE_NAMESPACE:-workspace}"
+        bash scripts/backup-restore.sh filen-pull {{.CLI_ARGS}} $ctx_arg $ns_arg
+```
+
+- [ ] **Step 2: Verify the task is registered and dry-runs**
+
+Run: `cd /tmp/wt-backup-filen-pull && task --list 2>/dev/null | grep filen-pull`
+Expected: the `workspace:backup:filen-pull` line appears.
+
+Run: `cd /tmp/wt-backup-filen-pull && task workspace:backup:filen-pull --dry 2>&1 | head -5`
+Expected: prints the resolved command without error (no execution).
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /tmp/wt-backup-filen-pull
+git add Taskfile.yml
+git commit -m "feat(backup): expose workspace:backup:filen-pull task"
+```
+
+---
+
+## Task 3: Full offline suite + inventory
+
+**Files:**
+- Possibly Modify: `website/src/data/test-inventory.json` (if the new BATS file is inventoried)
+
+- [ ] **Step 1: Run the full offline test suite**
+
+Run: `cd /tmp/wt-backup-filen-pull && task test:all`
+Expected: all pass (dev-cluster-dependent tests may skip — that is OK).
+
+- [ ] **Step 2: Regenerate test inventory and check for drift**
+
+Run:
+```bash
+cd /tmp/wt-backup-filen-pull
+task test:inventory
+git diff --exit-code website/src/data/test-inventory.json
+```
+Expected: exit 0 (no diff). If there IS a diff (the new bats file got inventoried), stage and commit it:
+
+```bash
+git add website/src/data/test-inventory.json
+git commit -m "chore(tests): refresh test-inventory for filen-pull"
+```
+
+- [ ] **Step 3: Push the branch**
+
+```bash
+cd /tmp/wt-backup-filen-pull
+git push
+```
+
+---
+
+## Verification (post-merge, live — for dev-flow-execute / operator)
+
+Not part of the offline plan, but the real acceptance check. On a cluster that
+*has* Filen backups uploaded:
+
+```bash
+task workspace:backup:filen-pull -- <known-timestamp> ENV=korczewski
+task workspace:backup:list ENV=korczewski        # timestamp now present locally
+# then the standard restore flow:
+kubectl scale deploy/nextcloud -n workspace-korczewski --replicas=0 --context korczewski
+task workspace:pvc:restore -- all <known-timestamp> ENV=korczewski
+```
+
+Expected: the pulled archives appear in `backup-pvc`, and `list`/`pvc-list`
+report the timestamp that was empty before.

--- a/docs/superpowers/specs/2026-05-30-backup-filen-pull-design.md
+++ b/docs/superpowers/specs/2026-05-30-backup-filen-pull-design.md
@@ -1,0 +1,108 @@
+# Design Spec — Filen-Pull for Fresh-Cluster Restore
+
+**Date:** 2026-05-30
+**Branch:** `feature/backup-filen-pull`
+**Scope decision:** Pull-into-`backup-pvc`-only (composable with existing restore tasks)
+
+## Problem
+
+On a freshly-deployed cluster (e.g. a rebuilt korczewski), the in-cluster
+`backup-pvc` is a brand-new empty volume. Both restore paths
+(`scripts/backup-restore.sh restore` for DBs and `pvc-restore` for file data)
+read **only** from `backup-pvc` at `/backups/<timestamp>/`. The only off-site
+copy of the backups lives in Filen cloud, and the backup pipeline is
+**one-way**: `k3d/backup-cronjob.yaml` and `k3d/pvc-backup-cronjob.yaml` upload
+to Filen via `@filen/cli`, but **no path exists to download them back**.
+
+Result: after a fresh deploy you cannot restore content — `list`/`pvc-list`
+return nothing because `backup-pvc` is empty. This is fresh-deploy blocker #1
+from the 2026-05-30 korczewski dry run.
+
+## Goal
+
+Add a `filen-pull <timestamp>` capability that downloads the encrypted archive
+directory for a given timestamp from Filen into the in-cluster `backup-pvc`,
+so the operator can then run the **existing** restore tasks unchanged:
+
+```bash
+task workspace:backup:filen-pull -- <timestamp> ENV=korczewski
+#   → archives land in backup-pvc:/backups/<timestamp>/
+task workspace:db:restore  -- all <timestamp> ENV=korczewski
+task workspace:pvc:restore -- all <timestamp> ENV=korczewski
+```
+
+## Non-Goals (explicitly out of scope)
+
+- **No one-shot pull+restore chaining.** Download and restore stay separate so
+  the operator keeps the mandatory scale-down safety step before restore.
+- **No remote-list command.** Discovering which timestamps exist in Filen is
+  done out-of-band (Filen web/desktop app, or `@filen/cli ls` manually). The
+  command requires an explicit `<timestamp>` argument. *(Documented limitation;
+  candidate follow-up.)*
+- **No new credentials or storage.** Reuse `workspace-secrets` `FILEN_EMAIL` /
+  `FILEN_PASSWORD` and the `backup-config` `FILEN_DEFAULT_UPLOAD_PATH`.
+- **No change to the backup (upload) side.**
+
+## Design
+
+Mirror the existing `filen-upload` container exactly, inverted to download.
+
+### New subcommand: `scripts/backup-restore.sh filen-pull <timestamp> [--remote-path <path>]`
+
+Spawns a one-shot `Job` (consistent with the existing `pvc-restore` Job pattern
+already in `backup-restore.sh`) that:
+
+1. Mounts `backup-pvc` at `/backups` **writable** (upload mounts it read-only —
+   pull must write).
+2. Image `node:22-alpine`, `npm install -g @filen/cli` (identical to upload).
+3. Resolves the remote base path: `--remote-path` flag wins, else read the
+   `backup-config` ConfigMap key `FILEN_DEFAULT_UPLOAD_PATH` (korczewski=`/Backup`,
+   mentolder per its own patch). Inject it into the Job as an env var resolved by
+   the script before apply.
+4. Auth + download:
+   ```sh
+   filen --email "$FILEN_EMAIL" --password "$FILEN_PASSWORD" \
+     download "<remote-path>/<timestamp>/" "/backups/<timestamp>/"
+   ```
+   *(Verify exact `@filen/cli` download arg order during implementation —
+   `filen download <cloud> <local>`; the upload step uses `upload <local> <cloud>`.)*
+5. Fail loudly (non-zero exit) if `FILEN_EMAIL`/`FILEN_PASSWORD` are unset or the
+   download fails — unlike the upload container which warns-and-continues, the
+   pull is the operator's explicit DR action and must surface failure.
+6. Wait for Job completion, stream logs, report the landing path.
+
+### Taskfile task: `workspace:backup:filen-pull`
+
+ENV-aware wrapper mirroring `workspace:pvc:restore` (sources `env-resolve.sh`,
+adds `--context $ENV_CONTEXT` for non-dev, passes `{{.CLI_ARGS}}`). Lives next to
+the other `workspace:backup:*` tasks (~line 1017–1047 of `Taskfile.yml`).
+
+### Security / namespace
+
+- Job runs in `$WORKSPACE_NAMESPACE` (workspace / workspace-korczewski).
+- Non-root securityContext consistent with the existing restore Job
+  (runAsNonRoot, drop ALL caps, seccomp RuntimeDefault).
+- `BACKUP_PASSPHRASE` is **not** needed here — pull only moves the still-encrypted
+  archives; decryption happens later inside the existing restore Job.
+
+## Acceptance Criteria
+
+- [ ] `task workspace:backup:filen-pull -- <ts> ENV=korczewski` downloads
+      `<ts>/` from Filen into `backup-pvc:/backups/<ts>/`.
+- [ ] Afterwards `bash scripts/backup-restore.sh pvc-list` (and `list`) show the
+      pulled timestamp.
+- [ ] Missing `<timestamp>` arg → usage error, non-zero exit.
+- [ ] Missing Filen creds or failed download → non-zero exit with clear message
+      (no silent success).
+- [ ] BATS test covers: usage/arg-validation, correct Job manifest
+      (writable backup-pvc mount, node:22-alpine, resolved remote path), and the
+      help text lists `filen-pull`.
+- [ ] `usage()` in `backup-restore.sh` documents `filen-pull`.
+- [ ] `task test:all` green.
+
+## Test Strategy
+
+Pure-bash unit test (BATS) — no live Filen/cluster. Stub `kubectl` with a fake
+binary on `PATH` (existing pattern in the repo) and assert the rendered Job
+manifest + arg validation. Add under `tests/unit/` alongside existing
+backup-restore coverage if present; otherwise a new `backup-restore-filen-pull.bats`.

--- a/scripts/backup-restore.sh
+++ b/scripts/backup-restore.sh
@@ -26,6 +26,16 @@ Commands (PVC file data):
     IMPORTANT: scale down the target service before restoring, e.g.:
       kubectl scale deploy/nextcloud -n workspace --replicas=0 --context <ctx>
 
+Commands (disaster recovery — fresh cluster):
+  filen-pull <timestamp> [--remote-path <path>]
+                             Download a backup timestamp from Filen cloud into
+                             the in-cluster backup-pvc, so the existing
+                             'restore' / 'pvc-restore' commands can run on a
+                             freshly-deployed cluster (where backup-pvc is empty).
+                             Remote path defaults to backup-config's
+                             FILEN_DEFAULT_UPLOAD_PATH. Timestamps are discovered
+                             out-of-band (Filen web/desktop app or 'filen ls').
+
 Options:
   --context <ctx>   kubectl context (default: active context)
   --namespace <ns>  Kubernetes namespace (default: workspace)
@@ -47,10 +57,11 @@ YES=false
 POSITIONAL=()
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --context)   CTX_FLAG="--context $2"; shift 2 ;;
-    --namespace) NS="$2"; shift 2 ;;
-    -y|--yes)    YES=true; shift ;;
-    -h|--help)   usage; exit 0 ;;
+    --context)     CTX_FLAG="--context $2"; shift 2 ;;
+    --namespace)   NS="$2"; shift 2 ;;
+    --remote-path) REMOTE_PATH="$2"; shift 2 ;;
+    -y|--yes)      YES=true; shift ;;
+    -h|--help)     usage; exit 0 ;;
     *) POSITIONAL+=("$1"); shift ;;
   esac
 done
@@ -446,6 +457,113 @@ YAML
         docuseal-data)    echo "  kubectl scale deploy/docuseal -n $NS --replicas=1" ;;
       esac
     done
+    ;;
+
+  filen-pull)
+    TS="${1:-}"
+    [[ -n "$TS" ]] || _die "Usage: $SCRIPT filen-pull <timestamp> [--remote-path <path>]"
+
+    # Resolve the Filen remote base path: --remote-path wins, else the
+    # backup-config ConfigMap default (mirrors what the upload side uploads to).
+    if [[ -z "${REMOTE_PATH:-}" ]]; then
+      REMOTE_PATH=$($KC get configmap backup-config -n "$NS" \
+        -o jsonpath='{.data.FILEN_DEFAULT_UPLOAD_PATH}' 2>/dev/null || echo "")
+    fi
+    [[ -n "$REMOTE_PATH" ]] || _die "Could not resolve Filen remote path — pass --remote-path <path> or ensure backup-config has FILEN_DEFAULT_UPLOAD_PATH"
+
+    echo "Pulling ${TS} from Filen (${REMOTE_PATH}/${TS}/) into backup-pvc (ns=${NS})..."
+    JOB="filen-pull-$$"
+
+    $KC apply -n "$NS" -f - <<YAML
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ${JOB}
+  namespace: ${NS}
+  labels:
+    app: filen-pull
+spec:
+  ttlSecondsAfterFinished: 600
+  backoffLimit: 0
+  template:
+    spec:
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: filen-pull
+          # Mirrors the filen-upload container in k3d/backup-cronjob.yaml,
+          # inverted to download. @filen/cli is the only working Filen client
+          # (rclone has no Filen backend; webdav.filen.io is desktop-only).
+          image: node:22-alpine
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -e
+              if [ -z "\$FILEN_EMAIL" ] || [ -z "\$FILEN_PASSWORD" ]; then
+                echo "ERROR: FILEN_EMAIL/FILEN_PASSWORD not set in workspace-secrets"; exit 1
+              fi
+              export HOME=/tmp
+              echo "Installing Filen CLI..."
+              npm install -g @filen/cli --prefix /tmp/npm-global --silent 2>&1 | tail -3
+              export PATH="/tmp/npm-global/bin:\$PATH"
+              mkdir -p "/backups/${TS}"
+              echo "Downloading ${REMOTE_PATH}/${TS}/ -> /backups/${TS}/ ..."
+              filen --email "\$FILEN_EMAIL" --password "\$FILEN_PASSWORD" \\
+                download "${REMOTE_PATH}/${TS}/" "/backups/${TS}/"
+              echo "Pulled ${TS} into backup-pvc:/backups/${TS}/"
+              ls -la "/backups/${TS}/"
+          env:
+            - name: FILEN_EMAIL
+              valueFrom:
+                secretKeyRef:
+                  name: workspace-secrets
+                  key: FILEN_EMAIL
+            - name: FILEN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: workspace-secrets
+                  key: FILEN_PASSWORD
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            capabilities:
+              drop: ["ALL"]
+          volumeMounts:
+            - name: backup-storage
+              mountPath: /backups
+          resources:
+            requests:
+              memory: 256Mi
+              cpu: "200m"
+            limits:
+              memory: 1Gi
+              cpu: "1"
+      volumes:
+        - name: backup-storage
+          persistentVolumeClaim:
+            claimName: backup-pvc
+YAML
+
+    echo "Waiting for filen-pull job to complete (up to 10 min)..."
+    if ! $KC wait -n "$NS" job/"$JOB" --for=condition=Complete --timeout=600s 2>/dev/null; then
+      echo "ERROR: filen-pull job did not complete"
+      $KC logs -n "$NS" -l "job-name=${JOB}" --tail=50 2>/dev/null || true
+      exit 1
+    fi
+    $KC logs -n "$NS" -l "job-name=${JOB}" --tail=20 2>/dev/null || true
+    echo ""
+    echo "✓ filen-pull complete. Confirm and restore:"
+    echo "    $SCRIPT list ${CTX_FLAG}        # DB backups now in backup-pvc"
+    echo "    $SCRIPT pvc-list ${CTX_FLAG}    # PVC backups now in backup-pvc"
+    echo "    $SCRIPT restore <db> ${TS} ${CTX_FLAG}"
+    echo "    $SCRIPT pvc-restore <svc> ${TS} ${CTX_FLAG}"
     ;;
 
   *)

--- a/tests/unit/backup-restore-filen-pull.bats
+++ b/tests/unit/backup-restore-filen-pull.bats
@@ -1,0 +1,68 @@
+#!/usr/bin/env bats
+# backup-restore-filen-pull.bats — unit tests for `backup-restore.sh filen-pull`
+# Stubs kubectl so no live cluster/Filen is required; captures the applied Job YAML.
+
+load test_helper
+
+SCRIPT="${PROJECT_DIR}/scripts/backup-restore.sh"
+
+setup() {
+  FAKE_BIN=$(mktemp -d)
+  export CAPTURE="${BATS_TEST_TMPDIR}/applied.yaml"
+  cat > "${FAKE_BIN}/kubectl" <<EOF
+#!/usr/bin/env bash
+# Capture 'apply -f -' stdin; answer configmap lookups; succeed on wait/logs.
+args="\$*"
+case "\$args" in
+  *"apply"*) cat > "${CAPTURE}" ; exit 0 ;;
+  *"get configmap backup-config"*) echo "/Backup" ; exit 0 ;;
+  *"wait"*) exit 0 ;;
+  *"logs"*) exit 0 ;;
+  *) exit 0 ;;
+esac
+EOF
+  chmod +x "${FAKE_BIN}/kubectl"
+  export PATH="${FAKE_BIN}:${PATH}"
+}
+
+teardown() {
+  rm -rf "$FAKE_BIN"
+}
+
+@test "filen-pull without timestamp fails with usage" {
+  run bash "$SCRIPT" filen-pull
+  assert_failure
+  assert_output --partial "Usage"
+}
+
+@test "filen-pull renders a Job mounting backup-pvc writable" {
+  run bash "$SCRIPT" filen-pull 20260530-020001
+  assert_success
+  run cat "$CAPTURE"
+  assert_output --partial "kind: Job"
+  assert_output --partial "claimName: backup-pvc"
+  assert_output --partial "node:22-alpine"
+  assert_output --partial "/backups/20260530-020001/"
+  # The backups volume must be writable — no readOnly mount anywhere in the Job.
+  refute_output --partial "readOnly: true"
+}
+
+@test "filen-pull resolves remote base path from backup-config configmap" {
+  run bash "$SCRIPT" filen-pull pvc-20260530-030001
+  assert_success
+  run cat "$CAPTURE"
+  assert_output --partial "/Backup/pvc-20260530-030001/"
+}
+
+@test "filen-pull honours --remote-path override" {
+  run bash "$SCRIPT" filen-pull 20260530-020001 --remote-path /custom/path
+  assert_success
+  run cat "$CAPTURE"
+  assert_output --partial "/custom/path/20260530-020001/"
+}
+
+@test "usage lists filen-pull" {
+  run bash "$SCRIPT" --help
+  assert_success
+  assert_output --partial "filen-pull"
+}


### PR DESCRIPTION
## Summary
- On a freshly-deployed cluster the in-cluster `backup-pvc` is empty, and the restore tasks read only from it — but the backup pipeline is **one-way** (uploads to Filen, no download path). So content could not be restored after a fresh deploy. This was blocker #1 from the 2026-05-30 korczewski fresh-deploy dry run.
- Adds `scripts/backup-restore.sh filen-pull <timestamp> [--remote-path <p>]`: a one-shot Job mirroring the existing `filen-upload` container (`node:22-alpine` + `@filen/cli`, creds from `workspace-secrets`), inverted to **download** the timestamp's archives from Filen into `backup-pvc` mounted writable. Fails loudly if creds are missing or the download fails.
- Exposes it as the ENV-aware `task workspace:backup:filen-pull`.
- Composable by design: pull only stages the still-encrypted archives; decryption + the mandatory scale-down stay in the existing `restore` / `pvc-restore` flow. `BACKUP_PASSPHRASE` is intentionally not used here.

New restore flow on a fresh cluster:
```
task workspace:backup:filen-pull -- <ts> ENV=korczewski
task workspace:db:restore  -- all <ts> ENV=korczewski
task workspace:pvc:restore -- all <ts> ENV=korczewski
```

## Test plan
- [x] `tests/unit/backup-restore-filen-pull.bats` → 5/5 (stubs kubectl; asserts arg-validation, Job manifest shape, writable backup-pvc mount, remote-path resolution, usage text)
- [x] `task test:all` → exit 0 (full offline suite green)
- [x] `task workspace:backup:filen-pull --dry` resolves the command cleanly

Closes T000331

Co-Authored-By: Claude Opus 4.8 (1M context)