### PR TITLE
chore(backup): fail loud on Filen upload error + document 2FA-off invariant

### DIFF
--- a/.claude/skills/database-ops/SKILL.md
+++ b/.claude/skills/database-ops/SKILL.md
@@ -132,6 +132,17 @@ STAMP=<latest-timestamp>
    DROP DATABASE website_restore_test;
    ```
 
+### Step 2.5: Filen remote-backup invariant (2FA must stay OFF)
+
+The `filen-upload` sidecar in `k3d/backup-cronjob.yaml` and the `filen-pull` restore job in `scripts/backup-restore.sh` both shell out to the official `@filen/cli` with raw `FILEN_EMAIL` + `FILEN_PASSWORD` (sealed per-cluster in `environments/sealed-secrets/{mentolder,korczewski}.yaml`). The CLI performs the full Filen auth-v2 flow internally — PBKDF2-200k key derivation, login-password/master-key split, `/v3/login`, master-key fetch — so we deliberately do **not** reimplement any of that crypto.
+
+**Hard invariant: 2FA is disabled on both Filen accounts (mentolder and korczewski).** The CLI invocation passes no TOTP code, so an enabled 2FA would fail login permanently. If you rotate Filen credentials, store the *plaintext account password* (not a pre-derived hash) and keep 2FA off, then `task env:seal ENV=<env>`.
+
+**Failure surfacing:** the upload no longer swallows errors. On failure it exits non-zero → `restartPolicy: OnFailure` retries transients in-pod → a permanent break (bad creds / 2FA enabled) escalates to a Failed Job, kept visible by `failedJobsHistoryLimit`. The local encrypted backup on `backup-pvc` is always written first and stays intact regardless of remote-upload outcome. To check the remote leg:
+```bash
+kubectl get jobs -n <ns> --context <ctx> -l app=db-backup   # any Failed → inspect filen-upload logs
+```
+
 ---
 
 ## Troubleshooting & Common Blockers
@@ -141,6 +152,7 @@ STAMP=<latest-timestamp>
 | Migration fails with "must be owner of table" | Run via `task workspace:psql` (website role) instead of the `postgres` superuser | Connect directly to the postgres pod using the superuser credentials (`psql -U postgres`). |
 | Backup trigger fails with "cronjob not found" | Name-drift: CronJob named `backup-postgres` instead of `db-backup` | Deploy `k3d/backup-cronjob.yaml` and delete the old `backup-postgres` CronJob. |
 | Restore test fails: "pg_restore: exit code 1" | Schema conflicts / sequences already exist | Always restore to a fresh, temporary test database rather than an active one. |
+| `db-backup` Job shows Failed but local dumps exist | `filen-upload` sidecar failed remote upload (bad `FILEN_EMAIL`/`FILEN_PASSWORD`, or 2FA was enabled on the Filen account) | Check `filen-upload` container logs. Confirm 2FA is OFF and creds are correct, re-seal (`task env:seal ENV=<env>`). Local backup on `backup-pvc` is unaffected. See Step 2.5. |
 
 ---
 

--- a/k3d/backup-cronjob.yaml
+++ b/k3d/backup-cronjob.yaml
@@ -222,9 +222,20 @@ spec:
                   export PATH="/tmp/npm-global/bin:$$PATH"
 
                   echo "Uploading $${STAMP} to Filen: $${UPLOAD_PATH}/$${STAMP}/"
-                  filen --email "$${FILEN_EMAIL}" --password "$${FILEN_PASSWORD}" \
-                    upload "/backups/$${STAMP}/" "$${UPLOAD_PATH}/$${STAMP}/" \
-                    || echo "WARNING: Filen upload failed — local backup intact"
+                  # @filen/cli authenticates with raw email+password; it derives the
+                  # PBKDF2 key / master keys / API token internally (Filen auth v2).
+                  # This invocation passes NO 2FA code, so it assumes 2FA is OFF on the
+                  # Filen account — an invariant that holds for both mentolder and
+                  # korczewski. If 2FA is ever enabled, login fails permanently here.
+                  if ! filen --email "$${FILEN_EMAIL}" --password "$${FILEN_PASSWORD}" \
+                       upload "/backups/$${STAMP}/" "$${UPLOAD_PATH}/$${STAMP}/"; then
+                    echo "ERROR: Filen remote upload failed for $${STAMP} — the LOCAL encrypted backup on backup-pvc is intact."
+                    echo "       Likely cause: invalid FILEN_EMAIL/FILEN_PASSWORD, or 2FA was enabled on the Filen account (this job requires 2FA OFF)."
+                    echo "       Exiting non-zero so the broken remote backup surfaces as a Failed Job instead of being silently swallowed."
+                    # restartPolicy: OnFailure retries transients in-pod; a permanent
+                    # failure escalates to a Failed Job (failedJobsHistoryLimit keeps it visible).
+                    exit 1
+                  fi
 
                   echo "Filen upload done"
               env:


### PR DESCRIPTION
## Summary
- **Surface Filen remote-backup failures** in `k3d/backup-cronjob.yaml`: the `filen-upload` sidecar previously swallowed errors (`|| echo WARNING`), so a permanent break (bad creds, or 2FA enabled on the account) would silently produce no remote backups indefinitely. It now exits non-zero → `restartPolicy: OnFailure` retries transients in-pod → a permanent failure escalates to a Failed Job (kept visible by `failedJobsHistoryLimit`). The local encrypted dump on `backup-pvc` is written first and stays intact regardless.
- **Document the implicit 2FA-off invariant** (database-ops runbook Step 2.5 + troubleshooting row): both `@filen/cli` call sites (upload sidecar + `filen-pull` restore) pass raw email/password with no TOTP code, so 2FA must stay disabled on both clusters' Filen accounts. Confirmed OFF for mentolder and korczewski today.

No behavior change to the local backup; remote-upload semantics change from silent-swallow to fail-loud.

## Test plan
- `task test:all` — PASS (offline structural validation incl. manifest checks)
- `kubectl kustomize k3d` + `kubectl kustomize prod-mentolder` — both build; verified rendered `filen-upload` block contains the new fail-loud logic with `$$`/`$${...}` runtime escapes intact
- SA-07 T7 (filen-upload uses node image) unaffected — assertion is on the container image, not the shell logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)