### PR TITLE
feat(fleet): Phase 2a dual-brand overlays + isolation (offline mechanism) [T000337]

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1446,6 +1446,37 @@ tasks:
           --personal \
           --components-extra=image-reflector-controller,image-automation-controller
 
+  fleet:platform:
+    desc: "Apply the fleet cluster-singleton platform layer (ClusterIssuer, IngressClass, tls-sync + claude-code-agent RBAC). Apply ONCE before either brand."
+    cmds:
+      - |
+        set -euo pipefail
+        kubectl config use-context fleet
+        # Platform manifests are placeholder-free, so no envsubst is needed here.
+        kustomize build prod-fleet/platform/ --load-restrictor=LoadRestrictionsNone \
+          | kubectl --context fleet apply --server-side --force-conflicts -f -
+
+  fleet:deploy:brand:
+    desc: "Deploy ONE brand to fleet via the standard workspace:deploy path. Usage: task fleet:deploy:brand BRAND=fleet-korczewski"
+    requires:
+      vars: [BRAND]
+    cmds:
+      # Reuse workspace:deploy entirely — the fleet-<brand> env file sets
+      # context=fleet and overlay=prod-fleet/<brand>, so the full prod deploy
+      # path (SealedSecret, ns labels, shared-db ordering, envsubst, separately
+      # applied CronJobs) runs unchanged against the fleet cluster.
+      - task: workspace:deploy
+        vars: { ENV: "{{.BRAND}}" }
+
+  fleet:deploy:
+    desc: "Full Phase 2a deploy: platform once, then both brands (mentolder + korczewski) on the fleet cluster."
+    cmds:
+      - task: fleet:platform
+      - task: fleet:deploy:brand
+        vars: { BRAND: fleet-mentolder }
+      - task: fleet:deploy:brand
+        vars: { BRAND: fleet-korczewski }
+
   workspace:deploy:
     desc: "Deploy workspace to any environment (ENV=dev|mentolder|korczewski|...)"
     vars:

--- a/docs/superpowers/plans/2026-05-30-fleet-phase2a-dual-brand.md
+++ b/docs/superpowers/plans/2026-05-30-fleet-phase2a-dual-brand.md
@@ -19,6 +19,31 @@ pr_number: null
 **Spec:** `docs/superpowers/specs/2026-05-30-fleet-phase2a-dual-brand-design.md`
 **Ticket:** T000337 · **Branch:** `feature/fleet-phase2-cutover`
 
+> ## Execution status (dev-flow-execute)
+> **Offline tasks COMPLETE & committed (CI-validatable):** Task 1 (platform overlay),
+> Task 2 (fleet-common, + platform now owns claude-code-agent RBAC), Task 3 (brand
+> wrappers), Task 4 (env files, `overlay:` repointed to `prod-fleet/<brand>`),
+> Task 5 (backup-restore ns guard, TDD), Task 6 (`fleet:deploy` → reuses
+> `workspace:deploy`), Task 11 CODE (test renamed **SA-22**, SA-08 was taken;
+> deny-cross-brand netpol enforced on shared-db ingress). `task test:all` green.
+>
+> **Plan corrections found during execution** (vs. the drafted plan):
+> - Platform `reflector.yaml` carried a `${WORKSPACE_NAMESPACE}` placeholder + a
+>   single-subject CRB → replaced with trimmed `reflector-rbac.yaml` (dual-subject).
+> - fleet-common's website/website-monitoring patches targeted objects NOT in the
+>   overlay (website is a separate ns) → dropped; node-affinity repoints deferred
+>   to Task 8 runtime (as the plan's own NOTE intends).
+> - `claude-code-agent` CR/CRB collide cross-brand but had no owner → platform owns.
+> - `fleet:deploy:brand` reimplemented deploy crudely → delegates to `workspace:deploy`.
+> - **SA-08 id is taken** (Keycloak OIDC) → isolation test is **SA-22**.
+>
+> **RUNTIME tasks GATED (need operator assets):** Task 7 (seal — needs
+> `environments/.secrets/fleet-{mentolder,korczewski}.yaml`), Task 8 (platform
+> install + dry-run + deploy + Pending-pod/affinity resolution + capacity), Task 9
+> (Filen restore — needs confirmed snapshot timestamps), Task 10 (pvc-backup green),
+> Task 12 (DoD + SA-22 PASS). Assets: (1) Filen timestamps both brands, (2)
+> pk-hetzner-4 public IP for fleet-mentolder TURN_PUBLIC_IP, (3) capacity check.
+
 ---
 
 ## File Map

--- a/docs/superpowers/plans/2026-05-30-fleet-phase2a-dual-brand.md
+++ b/docs/superpowers/plans/2026-05-30-fleet-phase2a-dual-brand.md
@@ -37,12 +37,24 @@ pr_number: null
 > - `fleet:deploy:brand` reimplemented deploy crudely → delegates to `workspace:deploy`.
 > - **SA-08 id is taken** (Keycloak OIDC) → isolation test is **SA-22**.
 >
-> **RUNTIME tasks GATED (need operator assets):** Task 7 (seal — needs
-> `environments/.secrets/fleet-{mentolder,korczewski}.yaml`), Task 8 (platform
-> install + dry-run + deploy + Pending-pod/affinity resolution + capacity), Task 9
-> (Filen restore — needs confirmed snapshot timestamps), Task 10 (pvc-backup green),
-> Task 12 (DoD + SA-22 PASS). Assets: (1) Filen timestamps both brands, (2)
-> pk-hetzner-4 public IP for fleet-mentolder TURN_PUBLIC_IP, (3) capacity check.
+> **Task 8 SAFE-VALIDATION DONE (live fleet cluster, no operator assets):**
+> cert-manager installed; `task fleet:platform` applied clean (no placeholder
+> errors); server-side dry-run of BOTH brands passes. Empirical fixes committed to
+> `prod-fleet/mentolder`: excluded the 8 dev.mentolder.de resources (dev Ingress/
+> Cert Invalid w/ blank DEV_*, dev-db-refresh CronJob dangerous) + repointed the 3
+> In-pinned workloads (brainstorm-sish, livekit-server→pk-4 single, whisper) to
+> fleet pk nodes; the blanket NotIn[home-workers] for the rest already schedules
+> on pk. korczewski needed nothing (already pk-pinned).
+>
+> **STILL GATED — real deploy + restore (need operator assets):** Task 7 (seal —
+> place `environments/.secrets/fleet-{mentolder,korczewski}.yaml`, then
+> sealed-secrets:install + env:fetch-cert + env:seal), Task 8 real deploy (cert:secret
+> ipv64 key + Longhorn install + `task fleet:deploy`), Task 9 (Filen restore — needs
+> confirmed snapshot timestamps + Filen creds in the sealed secrets), Task 10
+> (pvc-backup green), Task 12 (DoD + SA-22 PASS + DNS for fleet test hosts).
+> Assets: (1) Filen timestamps both brands, (2) pk-hetzner-4 public IP for
+> fleet-mentolder TURN_PUBLIC_IP, (3) capacity check, (4) DNS records for
+> web.fleet.korczewski.de / web.fleet-m.korczewski.de → a fleet pk node IP.
 
 ---
 

--- a/docs/superpowers/plans/2026-05-30-fleet-phase2a-dual-brand.md
+++ b/docs/superpowers/plans/2026-05-30-fleet-phase2a-dual-brand.md
@@ -1,0 +1,782 @@
+---
+title: fleet Phase 2a — Dual-Brand on the 3 pk Nodes — Implementation Plan
+ticket_id: T000337
+domains: [website, infra, db, ops, test, security]
+status: active
+pr_number: null
+---
+
+# fleet Phase 2a — Dual-Brand on the 3 pk Nodes — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the empty `fleet` cluster (3-CP HA on pk-hetzner-4/6/8) host BOTH brands — mentolder (ns `workspace`) and korczewski (ns `workspace-korczewski`) — as self-contained per-brand stacks, with data restored from Filen and brand isolation proven by a NetworkPolicy test, on `*.korczewski.de` test hostnames.
+
+**Architecture:** Approach 1. A one-time `prod-fleet/platform/` overlay owns the cluster-scoped singletons. The existing `prod-mentolder/` + `prod-korczewski/` overlays are reused, each wrapped by a thin `prod-fleet/<brand>/` kustomization that pulls in a shared `fleet-common` component (deletes singletons + repoints node-affinity to pk nodes). Two new `environments/fleet-<brand>.yaml` files carry per-brand env_vars (context=fleet, test domains). A new `task fleet:deploy` fans out: platform once → mentolder → korczewski. envsubst forces two separate render passes, so each brand is its own deploy.
+
+**Tech Stack:** Kustomize (overlays + components), kubectl (server-side apply), envsubst, k3s v1.36.1, cert-manager (DNS-01/ipv64), SealedSecrets, Longhorn, BATS, Bash.
+
+**Spec:** `docs/superpowers/specs/2026-05-30-fleet-phase2a-dual-brand-design.md`
+**Ticket:** T000337 · **Branch:** `feature/fleet-phase2-cutover`
+
+---
+
+## File Map
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Create | `prod-fleet/platform/kustomization.yaml` | Cluster singletons applied once: ClusterIssuer, IngressClass, tls-sync ClusterRole/Binding |
+| Create | `prod-fleet/platform/cluster-issuer.yaml` | Copy of `prod/cluster-issuer.yaml` (letsencrypt-prod, ipv64 DNS-01) |
+| Create | `prod-fleet/platform/ingressclass.yaml` | Copy of `prod/ingressclass.yaml` (traefik) |
+| Create | `prod-fleet/components/fleet-common/kustomization.yaml` | Component: `$patch: delete` singletons + repoint node-affinity to pk-4/6/8 |
+| Create | `prod-fleet/mentolder/kustomization.yaml` | Wraps `../../prod-mentolder` + `fleet-common` component, ns workspace |
+| Create | `prod-fleet/korczewski/kustomization.yaml` | Wraps `../../prod-korczewski` + `fleet-common` component, ns workspace-korczewski |
+| Create | `environments/fleet-mentolder.yaml` | mentolder brand env_vars, context=fleet, domain fleet-m.korczewski.de |
+| Create | `environments/fleet-korczewski.yaml` | korczewski brand env_vars, context=fleet, domain fleet.korczewski.de |
+| Modify | `scripts/backup-restore.sh` | Honor `--namespace` everywhere (close ns-hardcode gap) |
+| Create | `tests/unit/backup-restore-namespace.bats` | BATS: every kubectl/secret ref respects `--namespace` |
+| Modify | `Taskfile.yml` | Add `fleet:deploy`, `fleet:platform`, `fleet:deploy:brand` tasks |
+| Create | `tests/local/SA-08.sh` | Cross-brand NetworkPolicy isolation test (negative) |
+| Modify | `tests/local/SA-08.sh` registration | Register SA-08 in the runner/inventory |
+
+---
+
+## Task 1: Platform overlay — cluster singletons applied once
+
+**Files:**
+- Create: `prod-fleet/platform/kustomization.yaml`
+- Create: `prod-fleet/platform/cluster-issuer.yaml`
+- Create: `prod-fleet/platform/ingressclass.yaml`
+
+- [ ] **Step 1: Copy the two pure cluster-scoped manifests**
+
+```bash
+cd /tmp/wt-fleet-phase2
+mkdir -p prod-fleet/platform
+cp prod/cluster-issuer.yaml prod-fleet/platform/cluster-issuer.yaml
+cp prod/ingressclass.yaml   prod-fleet/platform/ingressclass.yaml
+```
+
+- [ ] **Step 2: Write the platform kustomization**
+
+`prod-fleet/platform/kustomization.yaml`:
+
+```yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# fleet platform layer — cluster-scoped singletons applied ONCE to the fleet
+# cluster. Per-brand overlays delete their own copies via the fleet-common
+# component so only this layer owns them (avoids the SharedResourceWarning that
+# reverted the 2026-05 merge). The tls-sync ClusterRole/Binding is pulled from
+# prod/reflector.yaml; sealed-secrets controller + cert-manager + Longhorn are
+# installed via tasks, not here.
+resources:
+  - cluster-issuer.yaml
+  - ingressclass.yaml
+  - ../../prod/reflector.yaml
+```
+
+- [ ] **Step 3: Validate the build**
+
+Run:
+```bash
+cd /tmp/wt-fleet-phase2
+kustomize build prod-fleet/platform/ | grep -E "^kind:|^  name:"
+```
+Expected: exactly `ClusterIssuer letsencrypt-prod`, `IngressClass traefik`, `ClusterRole tls-sync`, `ClusterRoleBinding tls-sync`, plus the reflector Deployment/SA in the `kube-system`/reflector ns. No error.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add prod-fleet/platform/
+git commit -m "feat(fleet): add prod-fleet/platform cluster-singleton overlay [T000337]"
+```
+
+---
+
+## Task 2: fleet-common component — delete singletons + pin to pk nodes
+
+The component does two jobs every brand needs on fleet: (a) `$patch: delete` the cluster-scoped objects the platform layer now owns, and (b) repoint node-affinity to `pk-hetzner-4/6/8` (the korczewski overlay already pins here, so this is idempotent for korczewski and required for mentolder).
+
+**Files:**
+- Create: `prod-fleet/components/fleet-common/kustomization.yaml`
+
+- [ ] **Step 1: Write the component**
+
+`prod-fleet/components/fleet-common/kustomization.yaml`:
+
+```yaml
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+# Shared fleet behavior for BOTH brand overlays:
+#  1. Delete cluster-scoped singletons now owned by prod-fleet/platform.
+#  2. Repoint node-affinity of base-pinned workloads to the fleet pk nodes.
+# Namespaced ClusterRoles (${WEBSITE_NAMESPACE}-monitoring-reader) differ per
+# brand and are NOT deleted. Namespace objects are handled by each brand's
+# `namespace:` directive.
+
+patches:
+  # ── (1) delete singletons owned by the platform layer ──────────────
+  - target: { group: cert-manager.io, version: v1, kind: ClusterIssuer, name: letsencrypt-prod }
+    patch: |-
+      $patch: delete
+      apiVersion: cert-manager.io/v1
+      kind: ClusterIssuer
+      metadata:
+        name: letsencrypt-prod
+  - target: { group: networking.k8s.io, version: v1, kind: IngressClass, name: traefik }
+    patch: |-
+      $patch: delete
+      apiVersion: networking.k8s.io/v1
+      kind: IngressClass
+      metadata:
+        name: traefik
+  - target: { group: rbac.authorization.k8s.io, kind: ClusterRole, name: tls-sync }
+    patch: |-
+      $patch: delete
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata: { name: tls-sync }
+  - target: { group: rbac.authorization.k8s.io, kind: ClusterRoleBinding, name: tls-sync }
+    patch: |-
+      $patch: delete
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata: { name: tls-sync }
+  - target: { group: rbac.authorization.k8s.io, kind: ClusterRole, name: claude-code-agent }
+    patch: |-
+      $patch: delete
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata: { name: claude-code-agent }
+  - target: { group: rbac.authorization.k8s.io, kind: ClusterRoleBinding, name: claude-code-agent }
+    patch: |-
+      $patch: delete
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata: { name: claude-code-agent }
+  - target: { group: rbac.authorization.k8s.io, kind: ClusterRole, name: website-monitoring-clusterrole }
+    patch: |-
+      $patch: delete
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata: { name: website-monitoring-clusterrole }
+  - target: { group: rbac.authorization.k8s.io, kind: ClusterRoleBinding, name: website-monitoring-clusterrolebinding }
+    patch: |-
+      $patch: delete
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata: { name: website-monitoring-clusterrolebinding }
+
+  # ── (2) repoint node-affinity to the fleet pk nodes ────────────────
+  # website Deployment — base pins gekko-hetzner-2/3 (mentolder home nodes).
+  - target: { kind: Deployment, name: website }
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/affinity/nodeAffinity/requiredDuringSchedulingIgnoredDuringExecution/nodeSelectorTerms/0/matchExpressions/0/values
+        value: [pk-hetzner-4, pk-hetzner-6, pk-hetzner-8]
+```
+
+> NOTE: This is the KNOWN-static collision/pin set. Task 8 runs a server-side
+> dry-run that empirically surfaces any remaining cluster-scoped collisions or
+> `Pending` pods; add precise delete/repoint patches here for whatever it finds.
+> Do not guess beyond this list now — let the dry-run drive additions.
+
+- [ ] **Step 2: Verify component syntax via a throwaway wrapper build (deferred)**
+
+The component is exercised by Task 3's brand kustomizations. No standalone build (components aren't buildable alone). Proceed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add prod-fleet/components/fleet-common/
+git commit -m "feat(fleet): add fleet-common component (delete singletons + pin pk nodes) [T000337]"
+```
+
+---
+
+## Task 3: Per-brand fleet wrapper kustomizations
+
+**Files:**
+- Create: `prod-fleet/mentolder/kustomization.yaml`
+- Create: `prod-fleet/korczewski/kustomization.yaml`
+
+- [ ] **Step 1: mentolder wrapper**
+
+`prod-fleet/mentolder/kustomization.yaml`:
+
+```yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# mentolder brand on fleet — reuse the existing prod-mentolder overlay, then
+# apply fleet-common (delete singletons + pin pk nodes). Namespace stays
+# workspace (set by prod-mentolder/k3d base).
+resources:
+  - ../../prod-mentolder
+components:
+  - ../components/fleet-common
+```
+
+- [ ] **Step 2: korczewski wrapper**
+
+`prod-fleet/korczewski/kustomization.yaml`:
+
+```yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# korczewski brand on fleet — reuse the existing prod-korczewski overlay (already
+# pins pk nodes), then apply fleet-common to delete the singletons the platform
+# layer owns. Namespace stays workspace-korczewski.
+resources:
+  - ../../prod-korczewski
+components:
+  - ../components/fleet-common
+```
+
+- [ ] **Step 3: Validate both builds (no cluster-scoped singletons remain)**
+
+Run:
+```bash
+cd /tmp/wt-fleet-phase2
+for b in mentolder korczewski; do
+  echo "== $b =="
+  kustomize build --load-restrictor=LoadRestrictionsNone prod-fleet/$b/ \
+    | grep -E "^kind: (ClusterIssuer|IngressClass)$|name: (letsencrypt-prod|traefik|tls-sync|claude-code-agent|website-monitoring-clusterrole)$" \
+    || echo "  ✓ no platform singletons present"
+done
+```
+Expected: `✓ no platform singletons present` for both brands.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add prod-fleet/mentolder/ prod-fleet/korczewski/
+git commit -m "feat(fleet): add per-brand fleet wrapper kustomizations [T000337]"
+```
+
+---
+
+## Task 4: New per-brand env files (`fleet-mentolder`, `fleet-korczewski`)
+
+Copy the live brand env files, then override context + domains + node-affinity for fleet 2a test hosts. Keep all other vars identical so `env:validate` passes against `environments/schema.yaml`.
+
+**Files:**
+- Create: `environments/fleet-mentolder.yaml`
+- Create: `environments/fleet-korczewski.yaml`
+
+- [ ] **Step 1: Generate fleet-korczewski.yaml from the live file**
+
+```bash
+cd /tmp/wt-fleet-phase2
+cp environments/korczewski.yaml environments/fleet-korczewski.yaml
+```
+Then edit `environments/fleet-korczewski.yaml`, changing ONLY:
+- `environment: fleet-korczewski`
+- `context: fleet`
+- `domain: fleet.korczewski.de`
+- `env_vars.PROD_DOMAIN: fleet.korczewski.de`
+- `env_vars.CLUSTER_ENV: fleet-korczewski`
+- every `*.korczewski.de` host var (WEBSITE_HOST, AUTH_EXTERNAL_URL, DOCS_URL, VAULT_EXTERNAL_URL, NEXTCLOUD_EXTERNAL_URL, BRETT_DOMAIN, LIVEKIT_DOMAIN, STREAM_DOMAIN, MAIL_EXTERNAL_URL, TRAEFIK_EXTERNAL_URL, KEYCLOAK_FRONTEND_URL, WEBSITE_SITE_URL, ARENA_WS_URL) → prefix host with `fleet.` (e.g. `web.fleet.korczewski.de`, `auth.fleet.korczewski.de`)
+- leave `WEBSITE_NODE_AFFINITY`, `WORKSPACE_NAMESPACE: workspace-korczewski`, `WEBSITE_NAMESPACE: website-korczewski` unchanged (already pk + correct ns)
+- remove/blank the `DEV_*` block (dev migration is 2c)
+
+- [ ] **Step 2: Generate fleet-mentolder.yaml from the live file**
+
+```bash
+cp environments/mentolder.yaml environments/fleet-mentolder.yaml
+```
+Then edit, changing ONLY:
+- `environment: fleet-mentolder`, `context: fleet`, `domain: fleet-m.korczewski.de`
+- `env_vars.PROD_DOMAIN: fleet-m.korczewski.de`, `CLUSTER_ENV: fleet-mentolder`
+- every host var → prefix host with `fleet-` and re-root onto `korczewski.de`
+  (e.g. `web.fleet-m.korczewski.de`, `auth.fleet-m.korczewski.de`)
+- `WEBSITE_NODE_AFFINITY: '["pk-hetzner-4","pk-hetzner-6","pk-hetzner-8"]'`
+- keep `WORKSPACE_NAMESPACE: workspace`, `WEBSITE_NAMESPACE: website`
+- remove/blank the `DEV_*` block
+
+- [ ] **Step 3: Validate both env files against the schema**
+
+Run:
+```bash
+cd /tmp/wt-fleet-phase2
+for e in fleet-mentolder fleet-korczewski; do
+  echo "== $e =="; bash -c "source scripts/env-resolve.sh $e && echo OK: ctx=\$ENV_CONTEXT dom=\$PROD_DOMAIN ns=\$WORKSPACE_NAMESPACE"
+done
+```
+Expected: `OK: ctx=fleet dom=fleet.korczewski.de ns=workspace-korczewski` and `OK: ctx=fleet dom=fleet-m.korczewski.de ns=workspace`. No schema error.
+
+- [ ] **Step 4: Run env:validate if present**
+
+Run: `task env:validate ENV=fleet-korczewski 2>&1 | tail -5 || true`
+Expected: passes, or task absent (then skip). Fix any missing-var complaints.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add environments/fleet-mentolder.yaml environments/fleet-korczewski.yaml
+git commit -m "feat(fleet): add fleet-mentolder + fleet-korczewski env files [T000337]"
+```
+
+---
+
+## Task 5: Fix the backup-restore.sh namespace hardcode (TDD)
+
+`scripts/backup-restore.sh` defaults `NS=workspace` and accepts `--namespace`, but several spots hardcode `-n workspace` and the `workspace-secrets` Secret name. korczewski restore into `workspace-korczewski` needs every reference parameterized.
+
+**Files:**
+- Test: `tests/unit/backup-restore-namespace.bats`
+- Modify: `scripts/backup-restore.sh`
+
+- [ ] **Step 1: Write the failing test**
+
+`tests/unit/backup-restore-namespace.bats`:
+
+```bash
+#!/usr/bin/env bats
+# Verify backup-restore.sh fully honors --namespace (no workspace hardcodes leak
+# into rendered kubectl args / secret refs when a non-default ns is passed).
+
+setup() {
+  SCRIPT="${BATS_TEST_DIRNAME}/../../scripts/backup-restore.sh"
+}
+
+@test "no hardcoded '-n workspace' remains outside the NS default assignment" {
+  # Allow the single default assignment 'NS=workspace'; forbid literal '-n workspace'
+  run grep -nE -- '-n workspace([^-]|$)' "$SCRIPT"
+  [ "$status" -ne 0 ]
+}
+
+@test "secret references use the NS variable, not literal workspace-secrets in a fixed ns" {
+  # workspace-secrets is a Secret NAME (fine); ensure its lookups pass -n "$NS"
+  # Fail if a 'kubectl ... secret workspace-secrets' line lacks -n "$NS".
+  run bash -c "grep -nE 'workspace-secrets' '$SCRIPT' | grep -vE 'NS|name: workspace-secrets|secretKeyRef|valueFrom' || true"
+  [ -z "$output" ]
+}
+```
+
+- [ ] **Step 2: Run the test — expect FAIL**
+
+Run: `bats tests/unit/backup-restore-namespace.bats`
+Expected: FAIL (literal `-n workspace` occurrences exist today).
+
+- [ ] **Step 3: Parameterize every hardcoded namespace**
+
+In `scripts/backup-restore.sh`, replace every literal `-n workspace` (kubectl scale/exec/get/apply/delete invocations) with `-n "$NS"`. Keep the single default `NS=workspace` assignment and the `name: workspace-secrets` references inside YAML heredocs (those are Secret NAMES, correct in any ns since the Secret is materialized per-namespace). For the example-usage comment block at the top, update `-n workspace` → `-n "$NS"` for accuracy.
+
+Verify the scan is clean:
+```bash
+grep -nE -- '-n workspace([^-]|$)' scripts/backup-restore.sh
+```
+Expected: no output.
+
+- [ ] **Step 4: Run the test — expect PASS**
+
+Run: `bats tests/unit/backup-restore-namespace.bats`
+Expected: 2 passing.
+
+- [ ] **Step 5: Run the full offline suite to catch regressions**
+
+Run: `task test:all 2>&1 | tail -15`
+Expected: green (BATS + kustomize structure + Taskfile dry-run).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/backup-restore.sh tests/unit/backup-restore-namespace.bats
+git commit -m "fix(backup): honor --namespace throughout backup-restore.sh [T000337]"
+```
+
+---
+
+## Task 6: `task fleet:deploy` orchestration
+
+Adds tasks that (a) apply the platform layer once and (b) deploy each brand by sourcing its `fleet-<brand>.yaml`, building `prod-fleet/<brand>`, envsubst-ing, and applying to `--context fleet`. Mirror the existing prod deploy's ENVSUBST_VARS list (Taskfile.yml ~line 1552).
+
+**Files:**
+- Modify: `Taskfile.yml`
+
+- [ ] **Step 1: Add the three tasks**
+
+In `Taskfile.yml` under the `workspace:`/`feature:` task area, add:
+
+```yaml
+  fleet:platform:
+    desc: "Apply the fleet cluster-singleton platform layer (once)."
+    cmds:
+      - |
+        set -euo pipefail
+        kubectl config use-context fleet
+        kustomize build prod-fleet/platform/ --load-restrictor=LoadRestrictionsNone \
+          | kubectl --context fleet apply --server-side --force-conflicts -f -
+
+  fleet:deploy:brand:
+    desc: "Deploy ONE brand to fleet. Usage: task fleet:deploy:brand BRAND=fleet-korczewski"
+    requires:
+      vars: [BRAND]
+    cmds:
+      - |
+        set -euo pipefail
+        source scripts/env-resolve.sh "{{.BRAND}}"
+        [[ "$ENV_CONTEXT" == "fleet" ]] || { echo "ENV_CONTEXT must be fleet (got $ENV_CONTEXT)"; exit 1; }
+        # Reuse the SAME ENVSUBST_VARS list as the prod deploy (keep in sync).
+        ENVSUBST_VARS="\$PROD_DOMAIN \$BRAND_NAME \$CONTACT_EMAIL \$INFRA_NAMESPACE \$TLS_SECRET_NAME"
+        ENVSUBST_VARS="$ENVSUBST_VARS \$SMTP_FROM \$SMTP_HOST \$MAIL_FROM_LOCAL \$MAIL_FROM_DOMAIN"
+        ENVSUBST_VARS="$ENVSUBST_VARS \$WEBSITE_IMAGE \$TURN_PUBLIC_IP \$TURN_NODE \$BRAND_ID"
+        ENVSUBST_VARS="$ENVSUBST_VARS \$KC_USER1_USERNAME \$KC_USER1_EMAIL \$KC_USER2_USERNAME \$KC_USER2_EMAIL"
+        ENVSUBST_VARS="$ENVSUBST_VARS \$BRETT_DOMAIN \$LIVEKIT_DOMAIN \$STREAM_DOMAIN"
+        ENVSUBST_VARS="$ENVSUBST_VARS \$WORKSPACE_NAMESPACE \$WEBSITE_NAMESPACE \$SYSTEMTEST_LOOP_ENABLED"
+        ENVSUBST_VARS="$ENVSUBST_VARS \$LLM_HOST_IP \$LLM_ENABLED \$LLM_RERANK_ENABLED \$LLM_ROUTER_URL \$LLM_EMBED_URL"
+        ENVSUBST_VARS="$ENVSUBST_VARS \$COMFY_HOST_IP \$COMFY_PORT \$ARENA_WS_URL \$ARENA_IMAGE"
+        overlay="prod-fleet/$(echo "{{.BRAND}}" | sed 's/^fleet-//')"
+        echo "Deploying {{.BRAND}} via $overlay -> ns $WORKSPACE_NAMESPACE on context fleet"
+        kustomize build "$overlay/" --load-restrictor=LoadRestrictionsNone \
+          | envsubst "$ENVSUBST_VARS" \
+          | sed -E 's/\$\$([a-zA-Z0-9_]|\{)/$\1/g' \
+          | kubectl --context fleet apply --server-side --force-conflicts -f -
+
+  fleet:deploy:
+    desc: "Full Phase 2a deploy: platform once, then both brands."
+    cmds:
+      - task: fleet:platform
+      - task: fleet:deploy:brand
+        vars: { BRAND: fleet-mentolder }
+      - task: fleet:deploy:brand
+        vars: { BRAND: fleet-korczewski }
+```
+
+- [ ] **Step 2: Dry-run the Taskfile parse**
+
+Run: `task --list 2>&1 | grep fleet`
+Expected: `fleet:platform`, `fleet:deploy:brand`, `fleet:deploy` listed. No YAML parse error.
+
+- [ ] **Step 3: Confirm offline suite still green (Taskfile dry-run job)**
+
+Run: `task test:all 2>&1 | tail -8`
+Expected: green.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Taskfile.yml
+git commit -m "feat(fleet): add fleet:deploy orchestration (platform + both brands) [T000337]"
+```
+
+---
+
+## Task 7: Re-seal both brands' secrets against the fleet keypair
+
+Phase 1 rotated the sealing keypair; old sealed files won't decrypt on fleet. Re-seal each brand's plaintext secrets against fleet's cert. (The plaintext `environments/.secrets/*.yaml` are gitignored and off-limits to read/echo — operate via the seal task only.)
+
+**Files:**
+- Create (committed): `environments/sealed-secrets/fleet-mentolder.yaml`
+- Create (committed): `environments/sealed-secrets/fleet-korczewski.yaml`
+
+- [ ] **Step 1: Fetch the fleet sealing cert**
+
+Run: `task env:fetch-cert ENV=fleet`
+Expected: writes `environments/certs/fleet.pem`. (Requires the fleet sealed-secrets controller — installed in Task 8 Step 1; if not yet installed, run this after that step and return here.)
+
+- [ ] **Step 2: Seal each brand's secrets against the fleet cert**
+
+The seal task reads `environments/.secrets/<env>.yaml`. Ensure `environments/.secrets/fleet-mentolder.yaml` and `fleet-korczewski.yaml` exist (copy from the live brand secrets — done by the operator, not committed). Then:
+
+```bash
+task env:seal ENV=fleet-mentolder
+task env:seal ENV=fleet-korczewski
+```
+Expected: writes `environments/sealed-secrets/fleet-mentolder.yaml` + `fleet-korczewski.yaml`.
+
+- [ ] **Step 3: Commit the sealed (encrypted) outputs only**
+
+```bash
+git add environments/sealed-secrets/fleet-mentolder.yaml environments/sealed-secrets/fleet-korczewski.yaml
+git commit -m "feat(fleet): seal both brands' secrets against fleet keypair [T000337]"
+```
+
+> If `env:seal` keys off `WORKSPACE_NAMESPACE`, confirm each sealed Secret targets
+> the right ns (workspace vs workspace-korczewski). A SealedSecret is namespace-scoped.
+
+---
+
+## Task 8: Platform bring-up + deploy both brands to fleet (runtime)
+
+Runtime task against the live fleet cluster. Follows the mandated fresh-cluster ordering (CLAUDE.md). **Backup-verify gate first** (do not proceed until both brands' Filen snapshots are confirmed restorable — Task 9 consumes them).
+
+- [ ] **Step 1: Install the platform stack in mandated order**
+
+```bash
+task sealed-secrets:install ENV=fleet
+task env:fetch-cert ENV=fleet          # (Task 7 Step 1 if not done)
+task cert:install ENV=fleet
+task cert:secret -- "$IPV64_KEY" ENV=fleet   # ACME DNS-01 key, both cert-manager + ns
+# Longhorn + iscsid on all 3 pk nodes:
+task longhorn:install ENV=fleet   # or the documented Helm/iscsid path from cluster-deployment skill
+```
+Expected: sealed-secrets controller Running; cert-manager CRDs present; Longhorn `default` StorageClass present; `iscsid` active on pk-4/6/8. Verify:
+```bash
+kubectl --context fleet get pods -n sealed-secrets -n cert-manager -n longhorn-system 2>/dev/null
+kubectl --context fleet get sc
+```
+
+- [ ] **Step 2: Apply the SealedSecrets for both brands**
+
+```bash
+kubectl --context fleet apply -f environments/sealed-secrets/fleet-mentolder.yaml
+kubectl --context fleet apply -f environments/sealed-secrets/fleet-korczewski.yaml
+```
+Expected: SealedSecrets accepted; controller materializes `workspace-secrets` in `workspace` and `workspace-korczewski`. Verify both unsealed:
+```bash
+kubectl --context fleet get secret workspace-secrets -n workspace
+kubectl --context fleet get secret workspace-secrets -n workspace-korczewski
+```
+
+- [ ] **Step 3: Server-side dry-run BOTH brands — surface remaining collisions**
+
+```bash
+cd /tmp/wt-fleet-phase2
+task fleet:platform
+for b in fleet-mentolder fleet-korczewski; do
+  source scripts/env-resolve.sh "$b"
+  overlay="prod-fleet/$(echo "$b" | sed 's/^fleet-//')"
+  kustomize build "$overlay/" --load-restrictor=LoadRestrictionsNone \
+    | envsubst | sed -E 's/\$\$([a-zA-Z0-9_]|\{)/$\1/g' \
+    | kubectl --context fleet apply --server-side --force-conflicts --dry-run=server -f - 2>&1 | tee /tmp/fleet-dryrun-$b.log
+done
+grep -iE "conflict|already exists|SharedResource|is forbidden" /tmp/fleet-dryrun-*.log || echo "✓ no collisions"
+```
+Expected: `✓ no collisions`. **If collisions appear**, add the precise `$patch: delete` (cluster-scoped) entry to `prod-fleet/components/fleet-common/kustomization.yaml`, recommit Task 2, and re-run this step until clean.
+
+- [ ] **Step 4: Real deploy of both brands**
+
+Run: `task fleet:deploy`
+Expected: platform applied; mentolder + korczewski stacks created. Then watch rollout:
+```bash
+kubectl --context fleet get pods -n workspace -w
+kubectl --context fleet get pods -n workspace-korczewski
+```
+
+- [ ] **Step 5: Resolve any `Pending` pods (node-affinity gaps)**
+
+```bash
+kubectl --context fleet get pods -A --field-selector=status.phase=Pending
+kubectl --context fleet describe pod <pending-pod> -n <ns> | grep -A5 "Events:"
+```
+If a pod is Pending on an unsatisfiable nodeAffinity (a base gekko/pk-2/pk-3 pin not covered by the fleet-common website patch), add the matching repoint patch to `fleet-common` (Task 2 part 2), recommit, re-run `task fleet:deploy`. Repeat until zero Pending.
+
+- [ ] **Step 6: Capacity sanity-check**
+
+```bash
+kubectl --context fleet top nodes
+```
+Expected: no node > ~85% CPU/mem with both stacks up. If pressured, note which non-essential workloads to scale down (record in the ticket; do not block).
+
+- [ ] **Step 7: Commit any fleet-common additions from Steps 3/5**
+
+```bash
+git add prod-fleet/components/fleet-common/kustomization.yaml
+git commit -m "fix(fleet): add empirically-found collision/affinity patches [T000337]" || echo "no changes"
+```
+
+---
+
+## Task 9: Restore both brands' data from Filen + verify
+
+**PRE-GATE:** confirmed restorable Filen snapshot timestamps for both brands (the asset). Record them in the ticket before starting.
+
+- [ ] **Step 1: Pull both brands' backup bundles**
+
+```bash
+# mentolder bundle into workspace backup-pvc
+bash scripts/backup-restore.sh filen-pull "<MENTOLDER_TS>" --namespace workspace --context fleet
+# korczewski bundle into workspace-korczewski backup-pvc
+bash scripts/backup-restore.sh filen-pull "<KORCZEWSKI_TS>" --namespace workspace-korczewski --context fleet
+```
+Expected: each `filen-pull` job completes; bundle present in the respective `backup-pvc`.
+
+- [ ] **Step 2: Restore mentolder (DB + 4 PVCs)**
+
+Per the backup-restore.sh restore subcommands: scale apps to 0, restore each DB + PVC, scale up. Use `--namespace workspace --context fleet`. Restore set: DB dumps + `nextcloud-data`, `vaultwarden-data`, `docuseal-data`, `livekit-recordings`.
+Expected: restore jobs complete without error.
+
+- [ ] **Step 3: Restore korczewski (DB + 4 PVCs)**
+
+Same with `--namespace workspace-korczewski --context fleet`. This is the path the Task 5 fix unblocks — watch that every kubectl call lands in `workspace-korczewski`, not `workspace`.
+
+- [ ] **Step 4: Verify both brands' data**
+
+```bash
+# DB rows (mentolder website DB)
+PGM=$(kubectl --context fleet get pod -n workspace -l app=shared-db -o name | head -1)
+kubectl --context fleet exec "$PGM" -n workspace -- psql -U website -d website -At -c \
+  "SELECT count(*) FROM site_settings;"
+# DB rows (korczewski)
+PGK=$(kubectl --context fleet get pod -n workspace-korczewski -l app=shared-db -o name | head -1)
+kubectl --context fleet exec "$PGK" -n workspace-korczewski -- psql -U website -d website -At -c \
+  "SELECT count(*) FROM site_settings;"
+# Nextcloud files present (both ns)
+kubectl --context fleet exec deploy/nextcloud -n workspace -- ls -la /var/www/html/data | head
+kubectl --context fleet exec deploy/nextcloud -n workspace-korczewski -- ls -la /var/www/html/data | head
+```
+Expected: non-zero row counts; Nextcloud data dirs show restored user files. Record counts in the ticket.
+
+- [ ] **Step 5: No commit (runtime-only).** Record results in T000337.
+
+---
+
+## Task 10: pvc-backup green on fleet (both brands)
+
+- [ ] **Step 1: Confirm the pvc-backup CronJob exists per brand**
+
+```bash
+kubectl --context fleet get cronjob -n workspace | grep pvc-backup
+kubectl --context fleet get cronjob -n workspace-korczewski | grep pvc-backup
+```
+Expected: present in both (came in via the brand overlays' `patch-backup-config`).
+
+- [ ] **Step 2: Trigger a manual backup per brand and watch Filen upload**
+
+```bash
+kubectl --context fleet create job --from=cronjob/pvc-backup pvc-backup-manual-m -n workspace
+kubectl --context fleet create job --from=cronjob/pvc-backup pvc-backup-manual-k -n workspace-korczewski
+kubectl --context fleet logs -f job/pvc-backup-manual-m -n workspace | tail -20
+kubectl --context fleet logs -f job/pvc-backup-manual-k -n workspace-korczewski | tail -20
+```
+Expected: each job ends `✓ Filen upload` success (the backup-cronjob fails loud on upload error per PR #1182). Record in ticket.
+
+- [ ] **Step 3: No commit (runtime-only).**
+
+---
+
+## Task 11: Cross-brand isolation NetworkPolicy test (SA-08)
+
+**Files:**
+- Create: `tests/local/SA-08.sh`
+- Modify: test inventory (regenerate)
+
+- [ ] **Step 1: Write the failing test**
+
+`tests/local/SA-08.sh` (follow the existing `tests/local/SA-07.sh` harness conventions):
+
+```bash
+#!/usr/bin/env bash
+# SA-08 — Cross-brand isolation: a pod in workspace-korczewski must NOT reach a
+# mentolder (workspace) Service, and vice-versa. Proves DSGVO logical isolation.
+set -uo pipefail
+CTX="${FLEET_CONTEXT:-fleet}"
+fail=0
+
+probe() {  # probe <from-ns> <to-service-fqdn> <expect: blocked|open>
+  local from_ns="$1" target="$2" expect="$3"
+  kubectl --context "$CTX" run netcheck-$$ -n "$from_ns" --rm -i --restart=Never \
+    --image=busybox:1.36 --quiet -- \
+    sh -c "nc -z -w4 $target 2>/dev/null && echo OPEN || echo BLOCKED" \
+    2>/dev/null | grep -qE 'OPEN|BLOCKED' || { echo "probe error"; return 2; }
+}
+
+# korczewski pod -> mentolder shared-db (5432) must be BLOCKED
+res=$(kubectl --context "$CTX" run netcheck-k2m-$$ -n workspace-korczewski --rm -i --restart=Never \
+  --image=busybox:1.36 --quiet -- \
+  sh -c "nc -z -w4 shared-db.workspace.svc.cluster.local 5432 && echo OPEN || echo BLOCKED" 2>/dev/null)
+echo "korczewski->mentolder shared-db: $res"
+[[ "$res" == *BLOCKED* ]] || { echo "FAIL: cross-brand reach not blocked (k->m)"; fail=1; }
+
+# mentolder pod -> korczewski shared-db must be BLOCKED
+res=$(kubectl --context "$CTX" run netcheck-m2k-$$ -n workspace --rm -i --restart=Never \
+  --image=busybox:1.36 --quiet -- \
+  sh -c "nc -z -w4 shared-db.workspace-korczewski.svc.cluster.local 5432 && echo OPEN || echo BLOCKED" 2>/dev/null)
+echo "mentolder->korczewski shared-db: $res"
+[[ "$res" == *BLOCKED* ]] || { echo "FAIL: cross-brand reach not blocked (m->k)"; fail=1; }
+
+[[ "$fail" -eq 0 ]] && echo "SA-08 PASS" || { echo "SA-08 FAIL"; exit 1; }
+```
+
+- [ ] **Step 2: Run it — expect FAIL (no cross-brand NetworkPolicy yet)**
+
+Run: `FLEET_CONTEXT=fleet bash tests/local/SA-08.sh`
+Expected: FAIL — cross-namespace reach is OPEN (default-allow), proving the gap.
+
+- [ ] **Step 3: Add a default-deny-cross-brand NetworkPolicy to each brand overlay's fleet wrapper**
+
+Create `prod-fleet/components/fleet-common/netpol-deny-cross-brand.yaml` and reference it from the component `resources:`. The policy: in each workspace ns, default-deny ingress from OTHER namespaces, allow same-ns + required system ns (kube-system DNS, ingress). Model it on the existing `prod-korczewski/netpol-cross-namespace.yaml`. Because the component is namespaced via each brand's directive, one policy definition lands correctly in both namespaces.
+
+- [ ] **Step 4: Redeploy and re-run — expect PASS**
+
+```bash
+cd /tmp/wt-fleet-phase2 && task fleet:deploy
+FLEET_CONTEXT=fleet bash tests/local/SA-08.sh
+```
+Expected: `SA-08 PASS` (both directions BLOCKED).
+
+- [ ] **Step 5: Regenerate the test inventory**
+
+Run:
+```bash
+task test:inventory
+git diff --exit-code website/src/data/test-inventory.json || echo "inventory changed — staging"
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/local/SA-08.sh prod-fleet/components/fleet-common/netpol-deny-cross-brand.yaml \
+        prod-fleet/components/fleet-common/kustomization.yaml website/src/data/test-inventory.json
+git commit -m "test(fleet): add SA-08 cross-brand isolation + deny-cross-brand netpol [T000337]"
+```
+
+---
+
+## Task 12: DoD verification sweep
+
+- [ ] **Step 1: Nodes + pods healthy**
+
+```bash
+kubectl --context fleet get nodes
+kubectl --context fleet get pods -n workspace        | grep -v Running | grep -v Completed || echo "✓ mentolder all Running"
+kubectl --context fleet get pods -n workspace-korczewski | grep -v Running | grep -v Completed || echo "✓ korczewski all Running"
+```
+Expected: 3 CP Ready; both namespaces all Running/Completed.
+
+- [ ] **Step 2: Both brands load over real TLS**
+
+```bash
+for h in web.fleet.korczewski.de web.fleet-m.korczewski.de; do
+  echo -n "$h -> "; curl -sS -o /dev/null -w '%{http_code} (cert: %{ssl_verify_result})\n' "https://$h/"
+done
+```
+Expected: both `200` with `ssl_verify_result: 0` (valid LE cert). DNS records for the two test hosts must point at a fleet pk node IP first.
+
+- [ ] **Step 3: Keycloak SSO both brands**
+
+Browser (or document manual check): log into `https://web.fleet.korczewski.de` and `https://web.fleet-m.korczewski.de` admin via Keycloak; confirm redirect + token. Record outcome in ticket.
+
+- [ ] **Step 4: Re-confirm restore + backup + isolation gates**
+
+```bash
+FLEET_CONTEXT=fleet bash tests/local/SA-08.sh        # PASS
+# DB row counts (Task 9 Step 4) still non-zero
+# pvc-backup manual jobs (Task 10) succeeded
+```
+Expected: SA-08 PASS; data present; backups green.
+
+- [ ] **Step 5: Idempotency check**
+
+Run: `cd /tmp/wt-fleet-phase2 && task fleet:deploy` (second time)
+Expected: clean re-apply, no errors, no resource churn beyond server-side no-ops.
+
+- [ ] **Step 6: Final offline suite + push**
+
+```bash
+task test:all 2>&1 | tail -10
+git push
+```
+Expected: green; branch pushed. Ready for PR via dev-flow-execute's later steps.
+
+---
+
+## Self-Review Notes (coverage check vs. spec)
+
+- Platform layer (singletons once) → Task 1. Per-brand reuse + omit/pin component → Tasks 2-3. Env files → Task 4. backup-restore ns fix → Task 5. fleet:deploy → Task 6. Re-seal → Task 7. Platform install + deploy + empirical collision/affinity resolution → Task 8. Restore + verify → Task 9. pvc-backup green → Task 10. Isolation test → Task 11. DoD sweep + idempotency → Task 12.
+- Every spec acceptance criterion maps to a Task 12 step or its source task. LLM reachability + capacity are runtime checks folded into Task 8. Wildcard certs come free from the brand overlays (PROD_DOMAIN) — no separate task needed.
+- Runtime tasks (8-12) are command-driven with expected output rather than TDD code, appropriate for live-cluster infra; the two genuinely code-testable units (backup-restore ns fix, SA-08 isolation) use red→green TDD.

--- a/docs/superpowers/specs/2026-05-30-fleet-phase2a-dual-brand-design.md
+++ b/docs/superpowers/specs/2026-05-30-fleet-phase2a-dual-brand-design.md
@@ -1,0 +1,182 @@
+---
+title: "fleet Phase 2a — both brands on the 3 pk nodes (platform layer + dual-brand restore)"
+date: 2026-05-30
+status: approved
+domains: [infra]
+ticket: T000337
+follows: docs/superpowers/specs/2026-05-30-fleet-unified-cluster-design.md
+---
+
+# fleet Phase 2a — Both Brands on the 3 pk Nodes
+
+## Goal
+
+Make the empty `fleet` cluster (3-CP HA on `pk-hetzner-4/6/8`, stood up in Phase 1)
+**host both brands** — `mentolder` and `korczewski` — each as a self-contained stack in
+its own namespace, with data restored from Filen and brand isolation proven by tests, all
+on `*.korczewski.de` **test hostnames**.
+
+This is the first executable slice of the full cutover. It deliberately stops short of:
+- **DNS cutover** of the real domains (Phase 2b),
+- **worker-node absorption** of mentolder's gekko/k3s/RPi nodes + arm64 taints (Phase 2c),
+- **decommission** of the old clusters and the `dev.mentolder.de` migration (Phase 2c).
+
+Done when fleet serves both brands on test hosts, data verified, isolation test green —
+**without touching either live cluster**.
+
+## Context & grounding facts (verified 2026-05-30)
+
+- Phase 1 left an **empty** healthy 3-CP fleet: `wg-fleet 10.20.0.0/24:51820`, k3s
+  `v1.36.1+k3s1`, fresh sealed-secrets keypair, `environments/fleet.yaml` scaffold +
+  `environments/.secrets/fleet.yaml` (3 WG keys + k3s token). **korczewski was wiped in
+  Phase 1** (its old pk nodes are now fleet CPs) → korczewski is **restore-only**.
+- **mentolder is still live** on `gekko-hetzner-2/3/4` + `k3s-1/2/3` + `k3w-1/2/3` (arm64).
+  Those nodes are NOT touched in 2a.
+- The deploy pipeline is `kustomize build $overlay | envsubst "$ENVSUBST_VARS" | kubectl
+  apply --server-side --force-conflicts`, driven by per-env `env_vars` in
+  `environments/<env>.yaml`. **`envsubst` substitutes one global env_var set per render
+  pass** → two brands ⇒ two separate render+apply passes (a single composite overlay is
+  impossible under this model).
+- Each brand overlay sets `namespace: <brand-ns>` and pulls in `../prod`, which carries
+  **cluster-scoped singletons**: `IngressClass` (traefik), `ClusterIssuer`
+  (letsencrypt-prod), shared `ClusterRole`/`Binding`s. The k3d base also defines
+  `Namespace` objects + several ClusterRoles. Applying *both* brand overlays to one cluster
+  collides on exactly these — this is what sank the reverted 2026-05 merge (PRs #621/#622).
+- `prod/llm-gpu.yaml` is just `Service` + `Endpoints` pointing at external `${LLM_HOST_IP}`
+  — **namespaced**, so each brand already gets its own LLM gateway. LLM is per-brand, NOT a
+  platform singleton.
+- `scripts/backup-restore.sh` defaults `NS=workspace` and mostly honors `--namespace`, but
+  several spots hardcode `-n workspace` / `workspace-secrets` (the known ns-hardcode gap).
+- pk nodes are 3× 8-CPU (per the korczewski overlay comment). Data is small
+  (~246 MB Nextcloud), so capacity for 2× stacks on 3 nodes is plausible but must be checked.
+
+## Decisions (locked during brainstorming, 2026-05-30)
+
+| Decision | Choice |
+|---|---|
+| Spec scope | **Phase 2a only** (platform + dual-brand overlay + restore + isolation). 2b/2c are separate specs. |
+| Brand isolation | **Separate namespaces, one shared-db pod per brand** (physical isolation; reuses existing overlays). |
+| Overlay architecture | **Approach 1** — `prod-fleet/platform/` owns singletons once; existing brand overlays reused + a `fleet-omit-singletons` component; new `fleet-<brand>.yaml` env files. |
+| Test hostnames | Both brands under korczewski.de: korczewski=`*.fleet.korczewski.de`, mentolder=`*.fleet-m.korczewski.de` (avoids mentolder.de DNS dependency until 2b). |
+| Keycloak | Separate KC instance + realm **per brand** (automatic from per-namespace overlays). |
+| LLM/GPU | Per-brand gateway Services → shared external GPU host; reuse existing `LLM_HOST_IP`. wg-fleet GPU join deferrable. |
+| Live clusters | **Untouched** during 2a. |
+
+## Architecture
+
+### 1. Platform layer — `prod-fleet/platform/` (applied once)
+
+Cluster-scoped, brand-agnostic, applied a single time to the fleet cluster:
+
+- `IngressClass` (traefik), `ClusterIssuer` letsencrypt-prod (DNS-01), shared
+  `ClusterRole`/`ClusterRoleBinding`s (tls-sync, claude-code-agent, etc.).
+- Two wildcard `Certificate`s: `*.fleet.korczewski.de` and `*.fleet-m.korczewski.de`.
+- Install-once via existing tasks, in mandated order:
+  `sealed-secrets:install` → `env:fetch-cert` → cert-manager (`cert:install`) → DNS-01
+  secret (`cert:secret`) → Longhorn (+ `iscsid`/`open-iscsi` on all 3 pk nodes).
+
+### 2. Per-brand workloads (reuse existing overlays, retargeted to `context=fleet`)
+
+| Brand | Namespaces | Test hosts |
+|---|---|---|
+| mentolder | `workspace` (+ `website`) | `*.fleet-m.korczewski.de` |
+| korczewski | `workspace-korczewski` (+ `website-korczewski`) | `*.fleet.korczewski.de` |
+
+- Each reuses its **existing** `prod-mentolder/` / `prod-korczewski/` overlay for the
+  namespaced workload.
+- Each gains a new kustomize **component** `prod-fleet/components/fleet-omit-singletons/`
+  that `$patch: delete`s the cluster-scoped objects (ClusterIssuer, IngressClass, shared
+  ClusterRoles/Bindings) and the base `Namespace` resources, so **only the platform layer
+  owns them**. This is the explicit, symmetric fix for the SharedResourceWarning that
+  doomed the reverted merge.
+- Each brand keeps its **own** shared-db pod + PVC, Keycloak instance + realm, and
+  llm-gateway Services. No cross-namespace DB access; no shared Postgres process.
+
+### 3. Env identity
+
+- `environments/fleet.yaml` — cluster identity only (context, k3s token, mesh). Already
+  scaffolded; `domain` placeholder stays (per-brand domains live in the brand env files).
+- **NEW** `environments/fleet-mentolder.yaml` and `environments/fleet-korczewski.yaml` —
+  brand `env_vars` copied from the live `mentolder.yaml`/`korczewski.yaml`, with:
+  - `context: fleet`
+  - node-affinity lists → `pk-hetzner-4/6/8`
+  - domains → the 2a test hostnames (`*.fleet[-m].korczewski.de`)
+  - dev-stack vars disabled (dev migration is 2c)
+- Both brands' plaintext secrets re-sealed against **fleet's** sealing cert →
+  `environments/sealed-secrets/fleet-mentolder.yaml` + `fleet-korczewski.yaml`.
+  (Phase-1 keypair rotation means old sealed files won't decrypt — re-seal is mandatory.)
+
+### 4. Data restore (both brands, from Filen)
+
+- `scripts/backup-restore.sh filen-pull <timestamp>` pulls each brand's latest bundle into
+  `backup-pvc`.
+- **Fix the ns-hardcode gap** in `backup-restore.sh`: every `-n workspace` /
+  `workspace-secrets` reference must respect `--namespace`, so korczewski restores into
+  `workspace-korczewski`. A BATS test covers the parameterization.
+- Per-brand sequence: deploy stack (creates empty PVCs/DBs) → scale apps to 0 → restore DB
+  (`psql` from dump) + restore the 4 Longhorn PVCs (nextcloud/vaultwarden/docuseal/
+  livekit-recordings) via the mounter-pod pattern → scale apps up → **verify**.
+- **Verification:** DB row counts non-zero for key tables; Nextcloud file listing shows
+  restored files; Vaultwarden/DocuSeal reachable.
+
+### 5. Backup infra on fleet
+
+- `pvc-backup` CronJob deployed per brand (via `patch-backup-config`), re-pointed at the
+  fleet cluster, Filen credentials sealed for fleet. A manual trigger must produce a green
+  Filen upload for both brands.
+
+### 6. Isolation tests (DSGVO proof; formal audit deferred)
+
+- **NetworkPolicy negative test:** a pod in `workspace-korczewski` cannot reach a
+  `workspace` (mentolder) Service (e.g. `shared-db` or `keycloak`) — connection refused/timed
+  out. The reverse also holds.
+- Keycloak realms independent: a token from one brand's realm is rejected by the other.
+- These run as new test IDs in the `tests/` framework (SA-class, services project).
+
+### 7. Deploy orchestration
+
+- **NEW** `task fleet:deploy` (in `Taskfile.yml`) fans out:
+  1. `prod-fleet/platform/` applied once (after the platform install tasks).
+  2. brand **mentolder**: source `fleet-mentolder.yaml` → build `prod-mentolder` + omit
+     component → envsubst → `kubectl apply --context fleet`.
+  3. brand **korczewski**: same with `fleet-korczewski.yaml` → `prod-korczewski`.
+- Honors the `ENV != dev` context-mismatch guard; aborts if the active context ≠ fleet.
+
+## Acceptance criteria (DoD)
+
+- [ ] Both brands' workloads `Running` on fleet (3 pk nodes).
+- [ ] `web.fleet.korczewski.de` AND `web.fleet-m.korczewski.de` load over real TLS.
+- [ ] Keycloak SSO login works for both brands on the test hosts.
+- [ ] Both brands' data restored + verified (DB rows + Nextcloud files visible).
+- [ ] `pvc-backup` CronJob green on fleet (Filen upload succeeds) for both brands.
+- [ ] Isolation netpol test green (cross-namespace block, both directions).
+- [ ] `task fleet:deploy` is idempotent (second run is a no-op / clean re-apply).
+- [ ] `backup-restore.sh --namespace` parameterization covered by a BATS test.
+
+## Out of scope (this spec)
+
+DNS cutover of real domains (2b); worker-node absorption + arm64 taints + dev.mentolder.de
+migration + decommission (2c); OpenClaw; application code changes (Website/Brett/arena —
+deploy only); formal DSGVO audit/documentation.
+
+## Risks & mitigations
+
+- **Capacity** — 2× full stacks on 3 nodes. Data is tiny but pod count doubles. Mitigation:
+  capacity sanity-check (`kubectl top nodes`) after each brand deploy; scale down
+  non-essential workloads if pressured.
+- **backup-restore.sh ns-hardcode** — korczewski restore fails into the wrong ns if not
+  fixed. Mitigation: explicit parameterization task + BATS coverage before the korczewski
+  restore step.
+- **Sealed-secrets keypair rotation** — old sealed files won't decrypt on fleet.
+  Mitigation: re-seal both brands against the fleet cert (mandated ordering).
+- **LLM reachability** — `LLM_HOST_IP` is a tailscale IP; verify fleet nodes reach it,
+  else `LLM_ENABLED=false` temporarily for 2a (korczewski bge-m3 indexing degraded but not
+  blocking). wg-fleet GPU join is a later refinement.
+- **flannel-over-wg** — already proven healthy in Phase 1 with `--flannel-iface=wg-fleet`;
+  adding workloads should not regress it. Abort criterion: pod-to-pod across nodes fails.
+
+## Assets still to procure (carried into the plan)
+
+- [ ] Confirmed restorable Filen snapshot timestamps for **both** brands (DB + 4 PVCs each).
+- [ ] Verify fleet nodes can reach `LLM_HOST_IP` (tailscale) before enabling LLM.
+- [ ] Capacity check: 3 pk nodes hosting both stacks through the 2a window.

--- a/environments/fleet-korczewski.yaml
+++ b/environments/fleet-korczewski.yaml
@@ -66,7 +66,10 @@ env_vars:
   # Dev stack intentionally omitted — dev migration is Phase 2c.
   DEV_SSH_ALLOWLIST: ""
 
-overlay: prod-korczewski
+# overlay points at the fleet wrapper (reuses prod-korczewski + deletes the
+# platform-owned cluster singletons via the fleet-common component). workspace:deploy
+# reads this as ENV_OVERLAY and builds it, so the full prod deploy path is reused.
+overlay: prod-fleet/korczewski
 workspace_namespace: workspace-korczewski
 website_namespace: website-korczewski
 secrets_ref: sealed-secrets/fleet-korczewski.yaml

--- a/environments/fleet-korczewski.yaml
+++ b/environments/fleet-korczewski.yaml
@@ -1,0 +1,92 @@
+# environments/fleet-korczewski.yaml
+# korczewski brand on the fleet cluster (Phase 2a). Derived from korczewski.yaml:
+# only context, domain, and *.korczewski.de routing hosts change (host segment
+# gets a `fleet.` infix so test hosts live under fleet.korczewski.de and never
+# touch the live korczewski.de records). Namespaces, legal/contact/SMTP identity,
+# internal cluster-DNS service URLs, and node-affinity are unchanged.
+environment: fleet-korczewski
+context: fleet
+domain: fleet.korczewski.de
+
+env_vars:
+  PROD_DOMAIN: fleet.korczewski.de
+  CLUSTER_ENV: fleet-korczewski
+  BRAND_NAME: "KORE"
+  BRAND_ID: korczewski
+  CONTACT_EMAIL: info@korczewski.de
+  CONTACT_PHONE: ""
+  CONTACT_CITY: "Lüneburg"
+  CONTACT_NAME: "Patrick Korczewski"
+  LEGAL_STREET: "In der Twiet 4"
+  LEGAL_ZIP: "21360"
+  LEGAL_JOBTITLE: "Software Engineer, IT-Security-Berater"
+  LEGAL_UST_ID: "Kleinunternehmer gem. § 19 Abs. 1 UStG"
+  LEGAL_WEBSITE: korczewski.de
+  WEBSITE_IMAGE: korczewski-website
+  DOCS_IMAGE: korczewski-docs
+  WEBSITE_NAMESPACE: website-korczewski
+  WORKSPACE_NAMESPACE: workspace-korczewski
+  WEBSITE_NODE_AFFINITY: '["pk-hetzner-4","pk-hetzner-6","pk-hetzner-8"]'
+  INFRA_NAMESPACE: korczewski-infra
+  TLS_SECRET_NAME: korczewski-tls
+  SMTP_FROM: korczewski@mailbox.org
+  SMTP_USER: korczewski@mailbox.org
+  SMTP_HOST: smtp.mailbox.org
+  SMTP_PORT: "587"
+  SMTP_SECURE: "false"
+  # Infra IPs/nodes inherited from korczewski.yaml; pk-hetzner-6 is on fleet so
+  # these are valid. TURN/LiveKit reachability is a Phase-2b/runtime concern.
+  TURN_PUBLIC_IP: "37.27.251.38"
+  TURN_NODE: "pk-hetzner-6"
+  NEXTCLOUD_EXTERNAL_URL: "https://files.fleet.korczewski.de"
+  DOCS_URL: "https://docs.fleet.korczewski.de"
+  AUTH_EXTERNAL_URL: "https://auth.fleet.korczewski.de"
+  VAULT_EXTERNAL_URL: "https://vault.fleet.korczewski.de"
+  WHITEBOARD_EXTERNAL_URL: "https://files.fleet.korczewski.de/apps/files"
+  TRAEFIK_EXTERNAL_URL: "https://traefik.fleet.korczewski.de"
+  MAIL_EXTERNAL_URL: "https://mail.fleet.korczewski.de"
+  BRETT_DOMAIN: brett.fleet.korczewski.de
+  LIVEKIT_DOMAIN: livekit.fleet.korczewski.de
+  LIVEKIT_PIN_IP: "37.27.251.38"
+  STREAM_DOMAIN: stream.fleet.korczewski.de
+  NEXTCLOUD_DB_HOST: nextcloud-db.workspace-korczewski.svc.cluster.local
+  WEBSITE_HOST: web.fleet.korczewski.de
+  WEBSITE_SITE_URL: "https://web.fleet.korczewski.de"
+  KEYCLOAK_FRONTEND_URL: "https://auth.fleet.korczewski.de"
+  # System-test failure loop master kill-switch.
+  SYSTEMTEST_LOOP_ENABLED: "true"
+  LLM_HOST_IP: "100.102.71.114"
+  COMFY_HOST_IP: "10.13.14.10"
+  COMFY_PORT: "8189"
+  LLM_ENABLED: "true"
+  LLM_RERANK_ENABLED: "false"
+  LLM_ROUTER_URL: "http://llm-gateway-lmstudio.workspace-korczewski.svc.cluster.local:1234"
+  LLM_EMBED_URL: "http://llm-gateway-embed.workspace-korczewski.svc.cluster.local:8081"
+  ARENA_WS_URL: https://arena-ws.fleet.korczewski.de
+  # Dev stack intentionally omitted — dev migration is Phase 2c.
+  DEV_SSH_ALLOWLIST: ""
+
+overlay: prod-korczewski
+workspace_namespace: workspace-korczewski
+website_namespace: website-korczewski
+secrets_ref: sealed-secrets/fleet-korczewski.yaml
+
+setup_vars:
+  KC_USER1_USERNAME: paddione
+  KC_USER1_EMAIL: patrick@korczewski.de
+  KC_USER1_PASSWORD: SEALED
+  KC_USER2_USERNAME: gekko
+  KC_USER2_EMAIL: quamain@web.de
+  KC_USER2_PASSWORD: SEALED
+  # wg-mesh Hetzner CP keys — private keys sealed in .secrets/fleet-korczewski.yaml
+  WG_MESH_PK4_PRIVATE_KEY: SEALED
+  WG_MESH_PK4_PUBLIC_KEY: "WkEiNOdF3D66KVnGRMHdtnWZV/Czr6hlwpTE/u3ZxRE="
+  WG_MESH_PK6_PRIVATE_KEY: SEALED
+  WG_MESH_PK6_PUBLIC_KEY: "wXcvWH86uYyxWNM0l9Romml7Mq1Wegb3eWsVjf/R/HE="
+  WG_MESH_PK8_PRIVATE_KEY: SEALED
+  WG_MESH_PK8_PUBLIC_KEY: "kpWJQzw+p8rurkFq/hPQH/z1gl3/f19SFukOMpPBJS0="
+  # SSH identity keys — private keys sealed in .secrets/fleet-korczewski.yaml
+  PATRICK_SSH_PRIVATE_KEY: SEALED
+  PATRICK_SSH_PUBLIC_KEY: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFN75CnuOz7YXaJipTFxWMVDgm35heu64JKN1QL+Z84+ patrick@korczewski.de"
+  GEKKO_SSH_PRIVATE_KEY: SEALED
+  GEKKO_SSH_PUBLIC_KEY: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIH43aUqN4w9u7DIt3gUREOJY4pmVIWvIbqFsG/fPSlV0 gekko@mentolder-20260513"

--- a/environments/fleet-mentolder.yaml
+++ b/environments/fleet-mentolder.yaml
@@ -1,0 +1,92 @@
+# environments/fleet-mentolder.yaml
+# mentolder brand on the fleet cluster (Phase 2a). Derived from mentolder.yaml:
+# routing hosts are re-rooted off mentolder.de onto fleet-m.korczewski.de so the
+# test hosts never touch live mentolder.de records. Namespaces stay
+# workspace/website; node-affinity repointed to the fleet pk nodes.
+environment: fleet-mentolder
+context: fleet
+domain: fleet-m.korczewski.de
+
+env_vars:
+  PROD_DOMAIN: fleet-m.korczewski.de
+  CLUSTER_ENV: fleet-mentolder
+  BRAND_NAME: "Mentolder"
+  BRAND_ID: mentolder
+  CONTACT_EMAIL: info@mentolder.de
+  CONTACT_PHONE: "+49 151 508 32 601"
+  CONTACT_CITY: "Hamburg"
+  CONTACT_NAME: "Gerald Korczewski"
+  LEGAL_STREET: "Ludwig-Erhard-Str. 18"
+  LEGAL_ZIP: "20459"
+  LEGAL_JOBTITLE: "Coach und digitaler Begleiter"
+  LEGAL_UST_ID: "33/023/05100"
+  LEGAL_WEBSITE: mentolder.de
+  WEBSITE_IMAGE: mentolder-website
+  DOCS_IMAGE: mentolder-docs
+  WEBSITE_NAMESPACE: website
+  WORKSPACE_NAMESPACE: workspace
+  WEBSITE_NODE_AFFINITY: '["pk-hetzner-4","pk-hetzner-6","pk-hetzner-8"]'
+  INFRA_NAMESPACE: mentolder-infra
+  TLS_SECRET_NAME: workspace-wildcard-tls
+  SMTP_FROM: mentolder@mailbox.org
+  SMTP_USER: mentolder@mailbox.org
+  SMTP_HOST: smtp.mailbox.org
+  SMTP_PORT: "587"
+  SMTP_SECURE: "false"
+  # TURN_NODE repointed to a fleet node (gekko-hetzner-2 does not exist on fleet).
+  # TURN_PUBLIC_IP still the inherited gekko IP — must be set to pk-hetzner-4's
+  # public IP at deploy time (runtime asset: IP reachability check).
+  TURN_PUBLIC_IP: "178.104.169.206"
+  TURN_NODE: "pk-hetzner-4"
+  NEXTCLOUD_EXTERNAL_URL: "https://files.fleet-m.korczewski.de"
+  DOCS_URL: "https://docs.fleet-m.korczewski.de"
+  AUTH_EXTERNAL_URL: "https://auth.fleet-m.korczewski.de"
+  VAULT_EXTERNAL_URL: "https://vault.fleet-m.korczewski.de"
+  WHITEBOARD_EXTERNAL_URL: "https://files.fleet-m.korczewski.de/apps/files"
+  TRAEFIK_EXTERNAL_URL: "https://traefik.fleet-m.korczewski.de"
+  MAIL_EXTERNAL_URL: "https://mail.fleet-m.korczewski.de"
+  BRETT_DOMAIN: brett.fleet-m.korczewski.de
+  LIVEKIT_DOMAIN: livekit.fleet-m.korczewski.de
+  # Inherited mentolder pin IP; re-pin at runtime via task livekit:dns-pin (2b).
+  LIVEKIT_PIN_IP: "46.225.125.59"
+  STREAM_DOMAIN: stream.fleet-m.korczewski.de
+  WEBSITE_HOST: web.fleet-m.korczewski.de
+  WEBSITE_SITE_URL: "https://web.fleet-m.korczewski.de"
+  KEYCLOAK_FRONTEND_URL: "https://auth.fleet-m.korczewski.de"
+  # System-test failure loop master kill-switch.
+  SYSTEMTEST_LOOP_ENABLED: "true"
+  LLM_HOST_IP: "100.102.71.114"
+  COMFY_HOST_IP: "192.168.100.10"
+  COMFY_PORT: "8189"
+  LLM_ENABLED: "true"
+  LLM_RERANK_ENABLED: "false"
+  LLM_ROUTER_URL: "http://llm-gateway-lmstudio.workspace.svc.cluster.local:1234"
+  LLM_EMBED_URL: "http://llm-gateway-embed.workspace.svc.cluster.local:8081"
+  ARENA_WS_URL: https://arena-ws.fleet-m.korczewski.de
+  # Dev stack intentionally omitted — dev migration is Phase 2c.
+  DEV_SSH_ALLOWLIST: ""
+
+overlay: prod-mentolder
+workspace_namespace: workspace
+website_namespace: website
+secrets_ref: sealed-secrets/fleet-mentolder.yaml
+
+setup_vars:
+  KC_USER1_USERNAME: paddione
+  KC_USER1_EMAIL: patrick@korczewski.de
+  KC_USER1_PASSWORD: SEALED
+  KC_USER2_USERNAME: gekko
+  KC_USER2_EMAIL: quamain@web.de
+  KC_USER2_PASSWORD: SEALED
+  # wg-mesh fleet CP keys — private keys sealed in .secrets/fleet-mentolder.yaml
+  WG_MESH_PK4_PRIVATE_KEY: SEALED
+  WG_MESH_PK4_PUBLIC_KEY: "WkEiNOdF3D66KVnGRMHdtnWZV/Czr6hlwpTE/u3ZxRE="
+  WG_MESH_PK6_PRIVATE_KEY: SEALED
+  WG_MESH_PK6_PUBLIC_KEY: "wXcvWH86uYyxWNM0l9Romml7Mq1Wegb3eWsVjf/R/HE="
+  WG_MESH_PK8_PRIVATE_KEY: SEALED
+  WG_MESH_PK8_PUBLIC_KEY: "kpWJQzw+p8rurkFq/hPQH/z1gl3/f19SFukOMpPBJS0="
+  # SSH identity keys — private keys sealed in .secrets/fleet-mentolder.yaml
+  PATRICK_SSH_PRIVATE_KEY: SEALED
+  PATRICK_SSH_PUBLIC_KEY: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFN75CnuOz7YXaJipTFxWMVDgm35heu64JKN1QL+Z84+ patrick@korczewski.de"
+  GEKKO_SSH_PRIVATE_KEY: SEALED
+  GEKKO_SSH_PUBLIC_KEY: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIH43aUqN4w9u7DIt3gUREOJY4pmVIWvIbqFsG/fPSlV0 gekko@mentolder-20260513"

--- a/environments/fleet-mentolder.yaml
+++ b/environments/fleet-mentolder.yaml
@@ -66,7 +66,10 @@ env_vars:
   # Dev stack intentionally omitted — dev migration is Phase 2c.
   DEV_SSH_ALLOWLIST: ""
 
-overlay: prod-mentolder
+# overlay points at the fleet wrapper (reuses prod-mentolder + deletes the
+# platform-owned cluster singletons via the fleet-common component). workspace:deploy
+# reads this as ENV_OVERLAY and builds it, so the full prod deploy path is reused.
+overlay: prod-fleet/mentolder
 workspace_namespace: workspace
 website_namespace: website
 secrets_ref: sealed-secrets/fleet-mentolder.yaml

--- a/prod-fleet/components/fleet-common/kustomization.yaml
+++ b/prod-fleet/components/fleet-common/kustomization.yaml
@@ -1,0 +1,67 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+# Shared fleet behavior applied to BOTH brand overlays.
+#
+# Job: $patch: delete the cluster-scoped singletons now owned ONCE by
+# prod-fleet/platform, so the two reused brand overlays don't both try to own
+# them (the cross-brand SharedResource conflict that reverted the 2026-05 merge).
+#
+# The delete list below is the EMPIRICALLY-VERIFIED set of cluster-scoped objects
+# that (a) both prod-mentolder and prod-korczewski actually emit AND (b) the
+# platform layer owns. Confirmed via `kustomize build prod-<brand>`:
+#   ClusterIssuer/letsencrypt-prod, IngressClass/traefik,
+#   ClusterRole+Binding/tls-sync, ClusterRole+Binding/claude-code-agent.
+# The per-namespace ServiceAccounts (tls-sync, claude-code-agent) and CronJob
+# (tls-sync) are NOT deleted — they are correct per-brand and don't collide.
+# website / website-monitoring objects live in the separate `website` namespace
+# (k3d/website.yaml, deployed independently) and are NOT in these overlays, so
+# they are intentionally absent here — patching them would error.
+#
+# NODE-AFFINITY repoints: workspace-ns workloads pinned to gekko / pk-2 / pk-3
+# (e.g. livekit-server) will go Pending on the fleet pk-4/6/8 nodes. Those pins
+# are driven by envsubst vars and only resolve at deploy time, so the precise
+# repoint patches are added HERE during Task 8 (server-side dry-run + Pending-pod
+# resolution), not guessed offline. website node-affinity is handled by the
+# WEBSITE_NODE_AFFINITY env var in environments/fleet-<brand>.yaml, not a patch.
+
+patches:
+  # ── delete cluster singletons owned by prod-fleet/platform ──────────
+  - target: { group: cert-manager.io, version: v1, kind: ClusterIssuer, name: letsencrypt-prod }
+    patch: |-
+      $patch: delete
+      apiVersion: cert-manager.io/v1
+      kind: ClusterIssuer
+      metadata:
+        name: letsencrypt-prod
+  - target: { group: networking.k8s.io, version: v1, kind: IngressClass, name: traefik }
+    patch: |-
+      $patch: delete
+      apiVersion: networking.k8s.io/v1
+      kind: IngressClass
+      metadata:
+        name: traefik
+  - target: { group: rbac.authorization.k8s.io, kind: ClusterRole, name: tls-sync }
+    patch: |-
+      $patch: delete
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata: { name: tls-sync }
+  - target: { group: rbac.authorization.k8s.io, kind: ClusterRoleBinding, name: tls-sync }
+    patch: |-
+      $patch: delete
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata: { name: tls-sync }
+  - target: { group: rbac.authorization.k8s.io, kind: ClusterRole, name: claude-code-agent }
+    patch: |-
+      $patch: delete
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata: { name: claude-code-agent }
+  - target: { group: rbac.authorization.k8s.io, kind: ClusterRoleBinding, name: claude-code-agent }
+    patch: |-
+      $patch: delete
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata: { name: claude-code-agent }

--- a/prod-fleet/components/fleet-common/kustomization.yaml
+++ b/prod-fleet/components/fleet-common/kustomization.yaml
@@ -1,6 +1,11 @@
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 
+# Cross-brand DB-isolation NetworkPolicy (SA-22) — lands in each brand's
+# workspace ns via the ${WORKSPACE_NAMESPACE} field, resolved at deploy.
+resources:
+  - netpol-deny-cross-brand.yaml
+
 # Shared fleet behavior applied to BOTH brand overlays.
 #
 # Job: $patch: delete the cluster-scoped singletons now owned ONCE by

--- a/prod-fleet/components/fleet-common/netpol-deny-cross-brand.yaml
+++ b/prod-fleet/components/fleet-common/netpol-deny-cross-brand.yaml
@@ -1,0 +1,36 @@
+# Cross-brand DB isolation for the fleet cluster (Phase 2a) — verified by SA-22.
+#
+# Both brands share one physical cluster, so a pod in workspace-korczewski could
+# otherwise reach shared-db in workspace (and vice-versa), breaking DSGVO logical
+# isolation. Enforcement is on the TARGET's ingress, NOT the source's egress,
+# because NetworkPolicy is additive (allow-only): the leftover
+# prod-korczewski/allow-egress-to-workspace policy — inert on the standalone
+# korczewski cluster but live on fleet — cannot override a target ingress deny.
+#
+# Selecting shared-db with this ingress policy puts it in default-deny-ingress
+# mode, so any source NOT listed here (notably the other brand's namespace) is
+# dropped, while same-namespace clients and this brand's own website namespace
+# stay allowed. ${WORKSPACE_NAMESPACE} / ${WEBSITE_NAMESPACE} are resolved per
+# brand by the deploy-time envsubst (both are in workspace:deploy's var list).
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: shared-db-same-brand-only
+  namespace: ${WORKSPACE_NAMESPACE}
+spec:
+  podSelector:
+    matchLabels:
+      app: shared-db
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        # same-namespace clients (keycloak, nextcloud, etc.)
+        - podSelector: {}
+        # this brand's own website namespace (website / website-korczewski)
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ${WEBSITE_NAMESPACE}
+      ports:
+        - port: 5432
+          protocol: TCP

--- a/prod-fleet/korczewski/kustomization.yaml
+++ b/prod-fleet/korczewski/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# korczewski brand on fleet — reuse the existing prod-korczewski overlay (already
+# pins pk nodes), then apply fleet-common to delete the cluster singletons the
+# platform layer owns. Namespace stays workspace-korczewski.
+resources:
+  - ../../prod-korczewski
+components:
+  - ../components/fleet-common

--- a/prod-fleet/mentolder/kustomization.yaml
+++ b/prod-fleet/mentolder/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# mentolder brand on fleet — reuse the existing prod-mentolder overlay, then
+# apply fleet-common (delete the cluster singletons now owned by
+# prod-fleet/platform). Namespace stays workspace (set by the prod-mentolder/k3d
+# base). Node-affinity repoints for fleet pk nodes are added to fleet-common at
+# deploy time (Task 8); website affinity comes from WEBSITE_NODE_AFFINITY in
+# environments/fleet-mentolder.yaml.
+resources:
+  - ../../prod-mentolder
+components:
+  - ../components/fleet-common

--- a/prod-fleet/mentolder/kustomization.yaml
+++ b/prod-fleet/mentolder/kustomization.yaml
@@ -10,3 +10,122 @@ resources:
   - ../../prod-mentolder
 components:
   - ../components/fleet-common
+
+# Exclude the dev.mentolder.de stack from fleet Phase 2a (dev migration is 2c).
+# prod-mentolder renders these dev resources; with DEV_* blanked in
+# environments/fleet-mentolder.yaml they would either be invalid (the dev
+# Ingress/Certificate render with empty hosts -> "*." / null dnsNames, rejected
+# by the API — surfaced by the Task 8 server-side dry-run) or dangerous (the
+# dev-db-refresh CronJob drops + recreates databases). Delete them here in the
+# mentolder wrapper (NOT fleet-common — korczewski has no equivalents, so a shared
+# delete would error). The harmless *.localhost dev IngressRoutes are left intact.
+patches:
+  - target: { group: networking.k8s.io, version: v1, kind: Ingress, name: workspace-ingress-dev }
+    patch: |-
+      $patch: delete
+      apiVersion: networking.k8s.io/v1
+      kind: Ingress
+      metadata: { name: workspace-ingress-dev }
+  - target: { group: cert-manager.io, version: v1, kind: Certificate, name: workspace-dev-wildcard-tls }
+    patch: |-
+      $patch: delete
+      apiVersion: cert-manager.io/v1
+      kind: Certificate
+      metadata: { name: workspace-dev-wildcard-tls }
+  - target: { group: batch, version: v1, kind: CronJob, name: dev-db-refresh }
+    patch: |-
+      $patch: delete
+      apiVersion: batch/v1
+      kind: CronJob
+      metadata: { name: dev-db-refresh }
+  - target: { version: v1, kind: ConfigMap, name: dev-db-refresh-script }
+    patch: |-
+      $patch: delete
+      apiVersion: v1
+      kind: ConfigMap
+      metadata: { name: dev-db-refresh-script }
+  - target: { group: networking.k8s.io, version: v1, kind: NetworkPolicy, name: allow-devnode-hostnet-to-shared-db-ingress }
+    patch: |-
+      $patch: delete
+      apiVersion: networking.k8s.io/v1
+      kind: NetworkPolicy
+      metadata: { name: allow-devnode-hostnet-to-shared-db-ingress }
+  - target: { version: v1, kind: Service, name: oauth2-proxy-dev }
+    patch: |-
+      $patch: delete
+      apiVersion: v1
+      kind: Service
+      metadata: { name: oauth2-proxy-dev }
+  - target: { group: apps, version: v1, kind: Deployment, name: oauth2-proxy-dev }
+    patch: |-
+      $patch: delete
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata: { name: oauth2-proxy-dev }
+  - target: { group: traefik.io, version: v1alpha1, kind: Middleware, name: oauth2-proxy-dev }
+    patch: |-
+      $patch: delete
+      apiVersion: traefik.io/v1alpha1
+      kind: Middleware
+      metadata: { name: oauth2-proxy-dev }
+
+  # ── node-affinity repoints to fleet pk nodes (Task 8 empirical findings) ──
+  # The blanket prod-mentolder NotIn [home workers] is already satisfied on the
+  # fleet pk nodes, so most workloads schedule fine. These 3 are the only ones
+  # In-pinned to nodes that do NOT exist on fleet (server-side dry-run + scan):
+  #   brainstorm-sish -> gekko-hetzner-2, livekit-server -> gekko-hetzner-3,
+  #   whisper -> k3s home workers. Repoint to the fleet pk pool so they schedule.
+  # (Kept in the mentolder wrapper, NOT fleet-common: korczewski deliberately
+  # pins livekit-server to pk-hetzner-6 for its hostNetwork DNS-pin and must not
+  # be broadened.) livekit-server keeps a single-node pin (hostNetwork).
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: livekit-server
+      spec:
+        template:
+          spec:
+            affinity:
+              nodeAffinity:
+                requiredDuringSchedulingIgnoredDuringExecution:
+                  nodeSelectorTerms:
+                    - matchExpressions:
+                        - key: kubernetes.io/hostname
+                          operator: In
+                          values: [pk-hetzner-4]
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: brainstorm-sish
+      spec:
+        template:
+          spec:
+            affinity:
+              nodeAffinity:
+                requiredDuringSchedulingIgnoredDuringExecution:
+                  nodeSelectorTerms:
+                    - matchExpressions:
+                        - key: kubernetes.io/hostname
+                          operator: In
+                          values: [pk-hetzner-4, pk-hetzner-6, pk-hetzner-8]
+  # whisper needs a GPU node on mentolder (k3s home workers); fleet pk nodes have
+  # no GPU, so transcription is best-effort here — repoint so the pod at least
+  # schedules instead of staying Pending (flag for Phase 2b capacity review).
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: whisper
+      spec:
+        template:
+          spec:
+            affinity:
+              nodeAffinity:
+                requiredDuringSchedulingIgnoredDuringExecution:
+                  nodeSelectorTerms:
+                    - matchExpressions:
+                        - key: kubernetes.io/hostname
+                          operator: In
+                          values: [pk-hetzner-4, pk-hetzner-6, pk-hetzner-8]

--- a/prod-fleet/platform/claude-code-agent-rbac.yaml
+++ b/prod-fleet/platform/claude-code-agent-rbac.yaml
@@ -1,0 +1,63 @@
+# fleet platform layer — cluster-scoped claude-code-agent RBAC, owned ONCE.
+#
+# Both brand overlays emit a byte-identical claude-code-agent ClusterRole and a
+# ClusterRoleBinding that already lists BOTH brand SAs (workspace +
+# workspace-korczewski). On a shared cluster that is a single logical singleton,
+# so the platform layer owns it and each brand's fleet-common component
+# $patch: deletes its copy — avoiding the cross-brand SharedResource conflict.
+# The per-namespace claude-code-agent ServiceAccount stays brand-owned (created
+# by each brand overlay in its own namespace); only the cluster-scoped CR/CRB
+# live here.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: claude-code-agent
+rules:
+  - apiGroups: [""]
+    resources:
+      - pods
+      - pods/log
+      - services
+      - endpoints
+      - configmaps
+      - persistentvolumeclaims
+      - namespaces
+      - nodes
+      - events
+      - replicationcontrollers
+      - serviceaccounts
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["deployments", "replicasets", "statefulsets", "daemonsets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["batch"]
+    resources: ["jobs", "cronjobs"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["ingresses", "networkpolicies"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["autoscaling"]
+    resources: ["horizontalpodautoscalers"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["patch", "update"]
+  - apiGroups: ["apps"]
+    resources: ["deployments/scale"]
+    verbs: ["get", "patch", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: claude-code-agent
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: claude-code-agent
+subjects:
+  - kind: ServiceAccount
+    name: claude-code-agent
+    namespace: workspace
+  - kind: ServiceAccount
+    name: claude-code-agent
+    namespace: workspace-korczewski

--- a/prod-fleet/platform/cluster-issuer.yaml
+++ b/prod-fleet/platform/cluster-issuer.yaml
@@ -1,0 +1,24 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-prod
+spec:
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    email: noreply-bachelorprojekt@mailbox.org
+    privateKeySecretRef:
+      name: letsencrypt-prod-key
+    solvers:
+      - dns01:
+          webhook:
+            # cert-manager-lego-webhook — install via: task cert:install
+            # Docs: https://github.com/yxwuxuanl/cert-manager-lego-webhook
+            groupName: lego.dns-solver
+            solverName: lego-solver
+            config:
+              provider: ipv64
+              env:
+                IPV64_API_KEY:
+                  secretKeyRef:
+                    name: ipv64-api-key
+                    key: IPV64_API_KEY

--- a/prod-fleet/platform/ingressclass.yaml
+++ b/prod-fleet/platform/ingressclass.yaml
@@ -1,0 +1,6 @@
+apiVersion: networking.k8s.io/v1
+kind: IngressClass
+metadata:
+  name: traefik
+spec:
+  controller: traefik.io/ingress-controller

--- a/prod-fleet/platform/kustomization.yaml
+++ b/prod-fleet/platform/kustomization.yaml
@@ -13,3 +13,4 @@ resources:
   - cluster-issuer.yaml
   - ingressclass.yaml
   - reflector-rbac.yaml
+  - claude-code-agent-rbac.yaml

--- a/prod-fleet/platform/kustomization.yaml
+++ b/prod-fleet/platform/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# fleet platform layer — cluster-scoped singletons applied ONCE to the fleet
+# cluster. Per-brand overlays delete their own copies via the fleet-common
+# component so only this layer owns them (avoids the SharedResource conflict that
+# reverted the 2026-05 merge). The tls-sync ClusterRole/Binding come from the
+# trimmed reflector-rbac.yaml (NOT the full prod/reflector.yaml — that one carries
+# a namespaced SA + CronJob with a ${WORKSPACE_NAMESPACE} placeholder this
+# no-envsubst apply can't resolve; those stay owned per-brand). sealed-secrets
+# controller + cert-manager + Longhorn are installed via tasks, not here.
+resources:
+  - cluster-issuer.yaml
+  - ingressclass.yaml
+  - reflector-rbac.yaml

--- a/prod-fleet/platform/reflector-rbac.yaml
+++ b/prod-fleet/platform/reflector-rbac.yaml
@@ -1,0 +1,40 @@
+# fleet platform layer — cluster-scoped tls-sync RBAC, owned ONCE.
+#
+# Trimmed from prod/reflector.yaml on purpose: that file bundles the
+# cluster-scoped ClusterRole/Binding together with a namespaced ServiceAccount
+# and CronJob that carry a ${WORKSPACE_NAMESPACE} placeholder. The fleet:platform
+# task applies WITHOUT envsubst, so pulling the whole file would apply a literal
+# "${WORKSPACE_NAMESPACE}" namespace and fail. The namespaced SA + CronJob stay
+# owned by each brand overlay (via its ../prod base); only these two
+# cluster-singletons live here so both brands' fleet-common component can
+# $patch: delete them and avoid the SharedResource conflict that reverted the
+# 2026-05 merge.
+#
+# The ClusterRoleBinding lists BOTH brand SAs (workspace + workspace-korczewski)
+# so the per-namespace tls-sync CronJob in EITHER brand is authorized. The fleet
+# brand namespaces are fixed for Phase 2a, so they are hardcoded here rather than
+# templated.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: tls-sync
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "create", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: tls-sync
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tls-sync
+subjects:
+  - kind: ServiceAccount
+    name: tls-sync
+    namespace: workspace
+  - kind: ServiceAccount
+    name: tls-sync
+    namespace: workspace-korczewski

--- a/scripts/backup-restore.sh
+++ b/scripts/backup-restore.sh
@@ -24,7 +24,7 @@ Commands (PVC file data):
     service:   nextcloud-files | vaultwarden-data | docuseal-data | all
     timestamp: directory from 'pvc-list' (e.g. pvc-20260427-030001)
     IMPORTANT: scale down the target service before restoring, e.g.:
-      kubectl scale deploy/nextcloud -n workspace --replicas=0 --context <ctx>
+      kubectl scale deploy/nextcloud -n <ns> --replicas=0 --context <ctx>
 
 Commands (disaster recovery — fresh cluster):
   filen-pull <timestamp> [--remote-path <path>]

--- a/tests/local/SA-22.sh
+++ b/tests/local/SA-22.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# SA-22: Cross-brand isolation on the fleet cluster — a pod in one brand's
+# namespace must NOT reach the other brand's shared-db. Proves DSGVO logical
+# isolation between mentolder (ns workspace) and korczewski (ns
+# workspace-korczewski) when both brands share one physical cluster.
+#
+# NOTE: numbered SA-22 (not SA-08 as the plan/spec drafted) — SA-08 is the
+# existing Keycloak OIDC SSO test. Highest prior SA id is SA-21.
+#
+# T1: korczewski pod -> mentolder shared-db:5432  must be BLOCKED
+# T2: mentolder pod  -> korczewski shared-db:5432 must be BLOCKED
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "${SCRIPT_DIR}/lib/assert.sh"
+
+CTX="${FLEET_CONTEXT:-fleet}"
+KUBECTL="kubectl --context ${CTX}"
+
+# Probe TCP reachability from a throwaway busybox pod. Prints OPEN or BLOCKED.
+# A 4s nc timeout means a NetworkPolicy drop surfaces as BLOCKED, not a hang.
+probe() {  # probe <from-ns> <target-fqdn> <port>
+  local from_ns="$1" target="$2" port="$3" name="netcheck-${RANDOM}"
+  $KUBECTL run "$name" -n "$from_ns" --rm -i --restart=Never \
+    --image=busybox:1.36 --quiet -- \
+    sh -c "nc -z -w4 ${target} ${port} >/dev/null 2>&1 && echo OPEN || echo BLOCKED" \
+    2>/dev/null | tr -d '\r\n'
+}
+
+# T1: korczewski -> mentolder shared-db must be blocked
+RES_K2M=$(probe workspace-korczewski shared-db.workspace.svc.cluster.local 5432)
+assert_eq "$RES_K2M" "BLOCKED" "SA-22" "T1" \
+  "korczewski pod cannot reach mentolder shared-db (cross-brand isolation)"
+
+# T2: mentolder -> korczewski shared-db must be blocked
+RES_M2K=$(probe workspace shared-db.workspace-korczewski.svc.cluster.local 5432)
+assert_eq "$RES_M2K" "BLOCKED" "SA-22" "T2" \
+  "mentolder pod cannot reach korczewski shared-db (cross-brand isolation)"

--- a/tests/unit/backup-restore-namespace.bats
+++ b/tests/unit/backup-restore-namespace.bats
@@ -1,0 +1,23 @@
+#!/usr/bin/env bats
+# Verify backup-restore.sh fully honors --namespace (no workspace hardcodes leak
+# into rendered kubectl args / secret refs when a non-default ns is passed).
+
+setup() {
+  SCRIPT="${BATS_TEST_DIRNAME}/../../scripts/backup-restore.sh"
+}
+
+@test "no hardcoded '-n workspace' remains outside the NS default assignment" {
+  # Allow the single default assignment 'NS=workspace'; forbid literal '-n workspace'
+  run grep -nE -- '-n workspace([^-]|$)' "$SCRIPT"
+  [ "$status" -ne 0 ]
+}
+
+@test "kubectl secret lookups for workspace-secrets pass -n \$NS" {
+  # 'workspace-secrets' is a Secret NAME, correct in any namespace, so its
+  # appearances inside YAML heredocs (name: workspace-secrets / secretKeyRef) and
+  # in echo/ERROR message strings are fine. The real invariant: any actual kubectl
+  # ($KC) command that reads/writes the workspace-secrets Secret must carry
+  # -n "$NS" so a korczewski restore lands in workspace-korczewski, not workspace.
+  run bash -c "grep -nE '(kubectl|\\\$KC)[^#]*secret[^#]*workspace-secrets' '$SCRIPT' | grep -v -- '-n \"\$NS\"' || true"
+  [ -z "$output" ]
+}

--- a/tests/unit/manifests.bats
+++ b/tests/unit/manifests.bats
@@ -276,8 +276,14 @@ all_images() {
 import subprocess, sys, yaml, glob, os
 from concurrent.futures import ThreadPoolExecutor
 
-overlays = sorted(glob.glob('${PROJECT_DIR}/prod*'))
-overlays = [o for o in overlays if os.path.isdir(o)]
+def _is_overlay(d):
+    return os.path.isdir(d) and any(
+        os.path.exists(os.path.join(d, k))
+        for k in ('kustomization.yaml', 'kustomization.yml', 'Kustomization'))
+
+# Skip container dirs (e.g. prod-fleet/) that hold nested overlays but have no
+# top-level kustomization of their own.
+overlays = sorted(o for o in glob.glob('${PROJECT_DIR}/prod*') if _is_overlay(o))
 
 def check_overlay(overlay):
     try:
@@ -323,7 +329,11 @@ print('OK: no workspace-secrets Secret in prod overlays')
   run python3 - "${PROJECT_DIR}" <<'PY'
 import subprocess, sys, yaml, glob, os
 project = sys.argv[1]
-overlays = sorted(d for d in glob.glob(os.path.join(project, 'prod-*')) if os.path.isdir(d))
+overlays = sorted(
+    d for d in glob.glob(os.path.join(project, 'prod-*'))
+    if os.path.isdir(d) and any(
+        os.path.exists(os.path.join(d, k))
+        for k in ('kustomization.yaml', 'kustomization.yml', 'Kustomization')))
 SPLIT = {'claude-code-mcp-ops', 'claude-code-mcp-auth', 'mcp-browser', 'mcp-github'}
 bad = []
 for ov in overlays:
@@ -364,7 +374,11 @@ PY
   run python3 - "${PROJECT_DIR}" <<'PY'
 import subprocess, sys, yaml, glob, os
 project = sys.argv[1]
-overlays = sorted(d for d in glob.glob(os.path.join(project, 'prod-*')) if os.path.isdir(d))
+overlays = sorted(
+    d for d in glob.glob(os.path.join(project, 'prod-*'))
+    if os.path.isdir(d) and any(
+        os.path.exists(os.path.join(d, k))
+        for k in ('kustomization.yaml', 'kustomization.yml', 'Kustomization')))
 bad = []
 for ov in overlays:
     r = subprocess.run(

--- a/website/src/data/test-inventory.json
+++ b/website/src/data/test-inventory.json
@@ -1300,5 +1300,11 @@
     "file": "tests/e2e/specs/sa-21-admin-actions.spec.ts",
     "category": "SA",
     "kind": "playwright"
+  },
+  {
+    "id": "SA-22",
+    "file": "tests/local/SA-22.sh",
+    "category": "SA",
+    "kind": "shell"
   }
 ]


### PR DESCRIPTION
## Summary
Phase 2a makes the empty `fleet` cluster (3-CP HA on pk-hetzner-4/6/8) able to host **both** brands — mentolder (`workspace`) and korczewski (`workspace-korczewski`) — as self-contained stacks, using a symmetric Kustomize design that avoids the cross-brand SharedResource conflict that reverted the 2026-05 merge.

This PR contains the **offline, CI-validatable mechanism** (Tasks 1–6 + Task 11 code). The live-cluster bring-up + Filen restore + SA-22 PASS (Tasks 7–12) are gated on operator assets and run separately on this branch.

### What's here
- **`prod-fleet/platform/`** — owns the cluster-scoped singletons ONCE: ClusterIssuer, IngressClass, and the `tls-sync` + `claude-code-agent` ClusterRole/Binding (trimmed to drop namespaced objects with unresolvable placeholders; dual-subject CRBs serve both brands).
- **`prod-fleet/components/fleet-common`** — `$patch: delete`s those singletons from each reused brand overlay (empirically-verified delete set) + the **SA-22 cross-brand DB-isolation NetworkPolicy** (enforced on `shared-db` ingress, templated per brand).
- **`prod-fleet/{mentolder,korczewski}`** — thin wrappers = reused `prod-<brand>` overlay + `fleet-common`.
- **`environments/fleet-{mentolder,korczewski}.yaml`** — per-brand env files (context=fleet, test hosts under `*.korczewski.de`, `overlay:` → `prod-fleet/<brand>`).
- **`fleet:deploy`** Taskfile orchestration — platform once → both brands, delegating to the battle-tested `workspace:deploy`.
- **`scripts/backup-restore.sh`** — `--namespace` regression guard (TDD) protecting the korczewski restore path.
- **`tests/local/SA-22.sh`** — cross-brand isolation test (renamed from the plan's SA-08, which is the existing Keycloak OIDC test).

### Plan corrections found during execution
Several drafted-plan specifics were wrong against the actual builds and were corrected (placeholder leaks, website objects not in overlay, claude-code-agent ownership gap, crude deploy reimplementation, SA-08 id collision). Details in the plan status block.

## Test plan
- [x] `task test:all` (BATS units + kustomize structure + Taskfile dry-run) — green
- [x] `kustomize build prod-fleet/{platform,mentolder,korczewski}` — zero cluster-singletons remain in brands; per-brand SAs intact; netpol resolves to correct ns per brand via envsubst
- [x] `bats tests/unit/backup-restore-namespace.bats` — red→green
- [ ] **Runtime (gated):** platform install, two-brand deploy, Filen restore, SA-22 PASS, DoD sweep — pending operator assets (Filen timestamps, pk-hetzner-4 IP, capacity check)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>