### PR TITLE
fix(tickets): allocate external_id from a global sequence

### DIFF
--- a/tests/unit/ticket-external-id-sequence.bats
+++ b/tests/unit/ticket-external-id-sequence.bats
@@ -1,0 +1,33 @@
+#!/usr/bin/env bats
+# Regression: tickets.fn_assign_external_id must allocate external_id from a
+# GLOBAL sequence, not a per-brand counter. external_id is globally unique, so
+# per-brand counters (tickets.ticket_counters keyed by brand) collide across
+# brands — a fresh korczewski counter regenerated T000001.. and clashed with
+# existing mentolder ids. Fixed 2026-05-30 (T000339).
+
+setup() {
+  load 'lib/bats-support/load'
+  load 'lib/bats-assert/load'
+  REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+  TDB="$REPO_ROOT/website/src/lib/tickets-db.ts"
+}
+
+@test "tickets-db.ts assigns external_id from a global sequence (nextval)" {
+  run grep -E "nextval\('tickets\.external_id_seq'\)" "$TDB"
+  assert_success
+}
+
+@test "fn_assign_external_id does NOT allocate external_id from per-brand ticket_counters" {
+  # The function body (CREATE OR REPLACE FUNCTION ... fn_assign_external_id)
+  # must not INSERT INTO ticket_counters to derive the id. We assert the broken
+  # phrase 'INSERT INTO tickets.ticket_counters (brand, last_value)' is not part
+  # of the external_id trigger function. (The table may still exist for backfill
+  # history, but the trigger must not depend on it.)
+  run grep -n "ON CONFLICT (brand) DO UPDATE SET last_value" "$TDB"
+  assert_failure
+}
+
+@test "external_id sequence is seeded to the current global max on init" {
+  run grep -E "setval\('tickets\.external_id_seq'" "$TDB"
+  assert_success
+}


### PR DESCRIPTION
## Summary
- `tickets.fn_assign_external_id()` drew from a **per-brand** counter (`tickets.ticket_counters`), but `external_id` is **globally unique** — a fresh non-mentolder counter restarted at 1 and regenerated `T000001..`, colliding with existing ids and blocking all korczewski (and any new-brand) ticket creation.
- This DDL lives in app schema-init (`tickets-db.ts`), so it is re-applied on every website boot — a live `CREATE OR REPLACE` hotfix regresses on next deploy. Fixing it here makes it durable.
- Switch to a single global `tickets.external_id_seq` seeded above the current max; rewrite the legacy backfill to number globally instead of per-brand.

## Test plan
- [x] `bats tests/unit/ticket-external-id-sequence.bats` (new regression test, red→green)
- [x] `task test:all` (offline gate)
- [x] `tsc --noEmit` on website project — no tickets-db errors
- [x] live hotfix already applied to mentolder shared-db; verified T000340/T000341 created without collision

Closes T000339

🤖 Generated with [Claude Code](https://claude.com/claude-code)