### PR TITLE
docs(fleet): Stage 2 runbook — verified topology + Filen-free restore [T000338]

### DIFF
--- a/docs/fleet-stage2-cutover-runbook.md
+++ b/docs/fleet-stage2-cutover-runbook.md
@@ -1,37 +1,77 @@
-# Fleet Stage 2 — DNS Cutover Runbook
+# Fleet Stage 2 — Cutover Runbook
 
 Spec: `docs/superpowers/specs/2026-05-30-fleet-stage2-dns-cutover-design.md`
-Order: **mentolder** (reversible canary) → same-day soak → **korczewski** (irreversible).
+Order: **fleet platform deploy** → **mentolder** (data copy + reversible DNS flip) →
+same-day soak → **korczewski** (fresh deploy + DNS cleanup).
 
-> Topology reality: the `fleet` cluster runs on the SAME physical hosts as
-> korczewski-standalone (pk-hetzner-4/6/8). mentolder-standalone is on separate
-> gekko hardware. So mentolder is a reversible DNS flip; korczewski is an in-place
-> ingress handover (no warm fallback).
+> ## Verified topology (2026-05-30) — read before acting
+> - The `fleet` cluster (3-CP k3s on pk-hetzner-4/6/8, wg-fleet 10.20.0.0/24) is reached
+>   via the tunnelled context `fleet` (server `127.0.0.1:16443`). It runs cert-manager +
+>   Traefik but **no brand workloads yet**; namespaces `workspace` and
+>   `workspace-korczewski` exist but are EMPTY.
+> - **korczewski-standalone has already been torn down.** Fleet's k3s now occupies the pk
+>   hosts. The old `korczewski` kubeconfig context (server `204.168.244.104:6443`) is DEAD —
+>   it returns x509 because that IP now presents fleet's k3s CA. **Operate the korczewski
+>   brand via the `fleet` context, namespace `workspace-korczewski`** — do NOT try to "fix"
+>   the `korczewski` context (ticket T000340). korczewski.de currently returns HTTP 404
+>   behind the TRAEFIK DEFAULT CERT — down-but-expected until the fleet deploy runs.
+> - **mentolder-standalone is still live** on separate gekko hardware, with intact local
+>   backups. So mentolder is a reversible DNS flip with a warm fallback; korczewski is a
+>   fresh deploy (its data is NOT being restored — see §3).
 
-## 0. Prerequisite gate (STOP if any fails)
+## 0. Prerequisite gate — deploy the fleet platform (STOP if any fails)
 
-- [ ] Stage 1 complete: `kubectl --context fleet get pods -n workspace` and
-      `-n workspace-korczewski` all Ready.
-- [ ] `environments/fleet-mentolder.yaml` TURN/LIVEKIT pin = `204.168.244.104` (pk-4).
+The fleet cluster has no brand workloads yet. These must all be true before any DNS work.
+
+**Operator assets required (currently MISSING — must be supplied):**
+- [ ] `environments/.secrets/fleet-mentolder.yaml` and `environments/.secrets/fleet-korczewski.yaml`
+      (plaintext secret inputs; gitignored).
+- [ ] ipv64 ACME DNS-01 API key (for `task cert:secret`).
+- [ ] Confirm capacity on pk-4/6/8 for both brands' workloads.
+
+**Bring-up order on the `fleet` context** (mirrors CLAUDE.md fresh-cluster order):
+- [ ] `task sealed-secrets:install ENV=fleet-mentolder` — controller before any SealedSecret.
+- [ ] `task cert:install ENV=fleet-mentolder` — cert-manager CRDs (already running; idempotent).
+- [ ] Install Longhorn on fleet (StorageClass for backup-pvc + data PVCs).
+- [ ] `task env:fetch-cert ENV=fleet-mentolder` — fetch fleet sealing cert → `environments/certs/fleet.pem`.
+- [ ] `task env:seal ENV=fleet-mentolder` and `task env:seal ENV=fleet-korczewski` →
+      writes `environments/sealed-secrets/fleet-*.yaml`.
+- [ ] `task cert:secret -- <ipv64-key> ENV=fleet-mentolder` (creates the ACME key in
+      `cert-manager` AND the workspace ns).
+- [ ] `task fleet:deploy` — runs `fleet:platform` once, then `fleet:deploy:brand` for
+      `fleet-mentolder` (ns `workspace`) and `fleet-korczewski` (ns `workspace-korczewski`).
+- [ ] Verify: `kubectl --context fleet get pods -n workspace` and `-n workspace-korczewski`
+      all Ready.
+
+**DNS + cert prerequisites:**
+- [ ] `environments/fleet-mentolder.yaml` TURN/LIVEKIT pin = `204.168.244.104` (pk-4) — DONE.
 - [ ] `IPV64_API_KEY` on fleet controls BOTH domains — verify:
       `curl -fsS "https://ipv64.net/api?get_domains" -H "Authorization: Bearer $IPV64_API_KEY" | jq '.subdomains // .record_info'`
-      Confirm both `mentolder.de` and `korczewski.de` appear. **Confirm the JSON path
-      used by `capture_rollback_state()` in `scripts/fleet-dns-cutover.sh` matches this
-      real response**; adjust the jq filter if the live shape differs, then re-run
+      Confirm both `mentolder.de` and `korczewski.de` appear. **Confirm the JSON path used by
+      `capture_rollback_state()` in `scripts/fleet-dns-cutover.sh` matches this real
+      response**; adjust the jq filter if the live shape differs, then re-run
       `bats tests/unit/fleet-dns-cutover.bats`.
-- [ ] Certs pre-warmed on fleet: apply `Certificate` for `*.mentolder.de` +
-      `mentolder.de` and `*.korczewski.de`; wait `READY=True`
-      (`kubectl --context fleet get certificate -A`). DNS-01 works before the flip.
+- [ ] Certs pre-warmed on fleet: `Certificate` for `*.mentolder.de` + `mentolder.de` and
+      `*.korczewski.de`; wait `READY=True` (`kubectl --context fleet get certificate -A`).
 - [ ] Record current live A-records for both domains by hand (authoritative rollback
-      fallback): run `task fleet:dns:cutover ENV=fleet-mentolder` (dry-run) and save
-      the dashboard values.
+      fallback): run `task fleet:dns:cutover ENV=fleet-mentolder` (dry-run) and save the values.
 
-## 1. mentolder cutover (canary)
+## 1. mentolder cutover (data copy + reversible DNS flip)
 
 1. Post maintenance banner; quiesce writes on mentolder-standalone (scale app to 0 /
    set DB read-only).
-2. Final delta sync standalone → fleet: `pg_dump` of live DBs + PVC `rsync`; verify
-   row counts / file checksums.
+2. **Final delta data sync standalone → fleet via direct backup-pvc copy** (Filen is NOT
+   used — see Appendix A):
+   - Trigger fresh backups on the standalone: `bash scripts/backup-restore.sh trigger
+     --context mentolder` and `... pvc-trigger --context mentolder`.
+   - Copy the newest DB + PVC timestamp dirs from the standalone `backup-pvc` into the
+     fleet `backup-pvc` (helper pod + `kubectl cp`, both ends ns `workspace`) — see
+     Appendix A for the exact procedure.
+   - Restore into fleet: `bash scripts/backup-restore.sh restore all <ts> --context fleet -y`
+     and `... pvc-restore all <pvc-ts> --context fleet -y`. (Fleet's `workspace-secrets`
+     must carry the SAME `BACKUP_PASSPHRASE` as the standalone, or the openssl decrypt
+     fails — it does, because both seal from the same plaintext inputs.)
+   - Verify row counts / file checksums against the standalone before flipping.
 3. Dry-run and review: `task fleet:dns:cutover ENV=fleet-mentolder` (prints `CHANGE:` lines).
 4. Apply: `task fleet:dns:cutover ENV=fleet-mentolder ACTION=cutover`.
 5. Verify: `dig +short mentolder.de` returns the pk IPs; TLS serves; smoke checks.
@@ -47,28 +87,48 @@ Order: **mentolder** (reversible canary) → same-day soak → **korczewski** (i
 - [ ] Mail spot-check (tutanota MX untouched)
 - FAIL → `task fleet:dns:rollback ENV=fleet-mentolder`, fix, retry.
 
-## 3. korczewski handover (irreversible — brief outage accepted)
+## 3. korczewski — fresh deploy + DNS cleanup (NO data restore)
 
-1. Post maintenance banner; final delta sync standalone → fleet (as §1.2).
-2. Release `:80/:443` on pk-hetzner-4/6/8: disable korczewski-standalone ingress
-   (servicelb/Traefik), then enable fleet's ingress hostPort bind on the three hosts.
-   Brief hard outage during the swap.
-   > Requires working `korczewski` kubeconfig access — see ticket T000341 (x509 from
-   > the WSL workstation); refresh before this step.
-3. DNS cleanup: `task fleet:dns:cutover ENV=fleet-korczewski ACTION=cutover`
-   (drops stray `14.249.175.67`, adds pk-8 `62.238.23.79`, ensures `*` wildcard).
-   livekit/stream/turn already pk-6; mailbox.org records frozen. See ticket T000340.
-4. Verify + smoke.
+> korczewski-standalone is already gone and its data is NOT being restored (operator
+> decision 2026-05-30: fresh start). The ingress "handover" of §3 in the old plan has
+> already happened de-facto — fleet owns :80/:443 on the pk hosts. What remains:
+
+1. Confirm `fleet-korczewski` deployed clean (§0) with empty/fresh databases; run any
+   first-run seed/setup (Keycloak realm, website content, OIDC clients) as for a new env.
+2. DNS cleanup: `task fleet:dns:cutover ENV=fleet-korczewski ACTION=cutover`
+   (drops stray `14.249.175.67`, ensures pk-4/6/8 on `@`/`*`, livekit/stream/turn pinned).
+   mailbox.org / mail records frozen by construction. See ticket T000339 (DNS drift).
+3. Verify `web.korczewski.de` serves a real Let's Encrypt cert (not TRAEFIK DEFAULT CERT)
+   and returns 200; smoke the brand.
 
 ## 4. Rollback reference
 
-- **mentolder:** `task fleet:dns:rollback ENV=fleet-mentolder` (restores recorded
-  state; gekko was never torn down — clean).
-- **korczewski:** re-enable standalone ingress on the hosts +
-  `task fleet:dns:rollback ENV=fleet-korczewski`. Recovery, not a flip-back; data
-  written to fleet during/after handover does not roll back.
+- **mentolder:** `task fleet:dns:rollback ENV=fleet-mentolder` (restores recorded state;
+  gekko standalone was never torn down — clean warm fallback).
+- **korczewski:** NO rollback to standalone is possible — it is gone. Recovery means
+  re-deploying `fleet-korczewski` and re-running DNS cleanup. There is no warm fallback.
+
+## Appendix A — direct backup-pvc copy (Filen replacement)
+
+Filen-based restore (`scripts/backup-restore.sh filen-pull`) is **out of service**: the
+02:00 db-backup `filen-upload` sidecar fails with `Invalid credentials!`
+(`k3d/backup-cronjob.yaml` warns 2FA breaks @filen/cli login permanently). Fix is tracked
+separately and is NOT on the migration critical path — mentolder data moves by direct copy,
+korczewski starts fresh.
+
+Direct copy (standalone `backup-pvc` → fleet `backup-pvc`, both ns `workspace`):
+1. Spawn a reader pod on the standalone mounting `backup-pvc` read-only; `kubectl cp` the
+   chosen `<ts>/` (DB) and `pvc-<ts>/` (PVC) dirs to the workstation `/tmp`.
+2. Spawn a writer pod on fleet mounting `backup-pvc`; `kubectl cp` the dirs up into
+   `/backups/` on the fleet PVC.
+3. Both PVCs are Longhorn RWO — schedule the helper pods off the home worker nodes
+   (the `restore`/`list` commands already encode the `NotIn[k3s-*,k3w-*]` affinity).
+4. Then run the standard `restore` / `pvc-restore` against `--context fleet`.
+
+> Ongoing cloud backups remain broken until Filen creds are rotated/re-sealed
+> (FILEN_EMAIL/FILEN_PASSWORD in `workspace-secrets`, default path `/Backup`). Track separately.
 
 ## Out of scope (Stage 3)
 
-Decommission standalone clusters, reclaim gekko hardware, remove old envs /
-sealed-secrets, final DNS TTL hardening.
+Decommission mentolder gekko standalone, reclaim hardware, remove old envs /
+sealed-secrets, restore Filen cloud backups, final DNS TTL hardening.


### PR DESCRIPTION
## Summary
Rewrites the Fleet Stage 2 cutover runbook to match **verified live topology** discovered this session, and pivots the data-restore path off the (broken) Filen pipeline. Docs-only — the merged cutover mechanism (#1189) is unchanged.

## Why
While verifying the Stage 2 cutover gate, live inspection found the runbook's assumptions were stale:
- **korczewski-standalone is already torn down.** Fleet k3s now owns pk-hetzner-4/6/8; the old `korczewski` kubeconfig context (`204.168.244.104:6443`) is dead (x509 = fleet's CA, minted today). The brand must be operated via the `fleet` context (ns `workspace-korczewski`). `korczewski.de` currently 404s behind the Traefik default cert — down-but-expected until `fleet:deploy` runs.
- **Filen backups are broken** — the 02:00 `db-backup` `filen-upload` sidecar fails with `Invalid credentials!` (the cronjob warns 2FA breaks `@filen/cli` login permanently). So `filen-pull` restore is out of service.
- **The fleet platform was never deployed** — `workspace` / `workspace-korczewski` namespaces are empty.

## Changes (docs/fleet-stage2-cutover-runbook.md)
- **§0** is now a full fleet **platform-deploy gate** with the missing operator assets enumerated (`.secrets/fleet-*.yaml`, sealing cert, Longhorn, ipv64 key) — DNS work cannot start until `task fleet:deploy` succeeds and pods are Ready.
- **§1** mentolder data sync pivoted from `filen-pull` → **direct `backup-pvc` copy** (standalone is alive, backups intact). New **Appendix A** documents the copy procedure + the `BACKUP_PASSPHRASE` coupling.
- **§3** korczewski reframed as a **fresh deploy, no data restore** (operator decision) + DNS cleanup only; the ingress handover already happened de-facto.
- **§4** rollback: korczewski has no warm fallback (standalone gone); mentolder still does (gekko intact).
- Fixed ticket refs: kubeconfig = **T000340**, DNS drift = **T000339**.

## Migration status (not done by this PR)
The **live cutover remains blocked** on operator-supplied assets (fleet sealed secrets, Longhorn, ipv64 key) before `task fleet:deploy`. This PR only corrects the runbook so the next operator session follows reality. Filen repair is now **off** the migration critical path.

## Test
- `tests/unit/fleet-dns-cutover.bats` → 10/10 pass (script untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)