### PR TITLE
fix(fleet): fresh-cluster deploy blockers — shared-db ns, keycloak realm vars, brainstorm-sish pin [T000338]

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1592,8 +1592,12 @@ tasks:
             --overwrite
           # Apply website-schema ConfigMap first as shared-db expects it for schema init
           kubectl --context "$ENV_CONTEXT" -n "${_ws_ns}" apply -f k3d/website-schema.yaml
+          # -n "${_ws_ns}" places the namespace-less shared-db Deployment in the
+          # target ns. The base manifest intentionally omits namespace on the
+          # Deployment so the prod/ strategic-merge patch matches it as [noNs];
+          # PVC/ConfigMap/Services keep their explicit (sed-rewritten) namespace.
           sed "s/namespace: workspace$/namespace: ${_ws_ns}/g" k3d/shared-db.yaml \
-            | kubectl --context "$ENV_CONTEXT" apply -f -
+            | kubectl --context "$ENV_CONTEXT" -n "${_ws_ns}" apply -f -
           echo "Waiting for shared-db to be ready before deploying dependent services..."
           kubectl --context "$ENV_CONTEXT" rollout status deployment/shared-db -n "${_ws_ns}" --timeout=120s
 

--- a/k3d/keycloak.yaml
+++ b/k3d/keycloak.yaml
@@ -148,6 +148,11 @@ spec:
                 secretKeyRef:
                   name: workspace-secrets
                   key: BRETT_OIDC_SECRET
+            - name: COMFY_OIDC_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: workspace-secrets
+                  key: COMFY_OIDC_SECRET
             - name: TZ
               value: Europe/Berlin
           ports:

--- a/k3d/realm-import-entrypoint.sh
+++ b/k3d/realm-import-entrypoint.sh
@@ -25,7 +25,7 @@ for var in NEXTCLOUD_OIDC_SECRET \
            NC_DOMAIN WEB_DOMAIN VAULT_DOMAIN DOCS_DOMAIN TRAEFIK_DOMAIN MAIL_DOMAIN \
            PROD_DOMAIN KC_USER1_EMAIL KC_USER2_EMAIL \
            SMTP_HOST SMTP_PORT SMTP_FROM SMTP_USER SMTP_PASSWORD \
-           BRETT_OIDC_SECRET; do
+           BRETT_OIDC_SECRET COMFY_OIDC_SECRET; do
   eval val="\${${var}:-}"
   if [ -z "$val" ]; then
     echo "[import-entrypoint] WARNUNG: ${var} ist nicht gesetzt!"

--- a/prod-fleet/mentolder/kustomization.yaml
+++ b/prod-fleet/mentolder/kustomization.yaml
@@ -110,6 +110,15 @@ patches:
                         - key: kubernetes.io/hostname
                           operator: In
                           values: [pk-hetzner-4, pk-hetzner-6, pk-hetzner-8]
+  # The prod-mentolder base hard-pins brainstorm-sish via nodeSelector to
+  # gekko-hetzner-2 (a node that does not exist on fleet). nodeSelector is ANDed
+  # with the nodeAffinity above, so it must be removed or the pod stays Pending.
+  - target:
+      kind: Deployment
+      name: brainstorm-sish
+    patch: |-
+      - op: remove
+        path: /spec/template/spec/nodeSelector
   # whisper needs a GPU node on mentolder (k3s home workers); fleet pk nodes have
   # no GPU, so transcription is best-effort here — repoint so the pod at least
   # schedules instead of staying Pending (flag for Phase 2b capacity review).

--- a/prod/import-entrypoint.sh
+++ b/prod/import-entrypoint.sh
@@ -40,6 +40,7 @@ for var in \
     SMTP_USER \
     SMTP_PASSWORD \
     BRETT_OIDC_SECRET \
+    COMFY_OIDC_SECRET \
     DEV_DOMAIN \
     DEV_WORKSPACE_OIDC_SECRET; do
   eval val="\$${$${var}:-}"


### PR DESCRIPTION
## Summary
Three latent bugs surfaced by the **first `task fleet:deploy` on a genuinely fresh cluster** (the fleet platform). Each is masked on long-lived clusters where the resource already exists from a prior kustomize apply. All fixes verified live on the fleet cluster.

### 1. shared-db lands in `default` on fresh deploy
`workspace:deploy` pre-applies `k3d/shared-db.yaml` via `sed | kubectl apply` with **no `-n`**. The Deployment has no explicit `namespace:` (the PVC/ConfigMap/Services do), so it went to `default` while the rest went to the target ns — and the readiness wait (`-n <ws>`) failed `NotFound`, aborting the deploy.
**Fix:** add `-n "${_ws_ns}"` to the apply. (Not fixed in the manifest, because the base intentionally omits the namespace so the `prod/` strategic-merge patch matches it as `[noNs]` — adding it there breaks the patch.)

### 2. keycloak realm import fails on `${COMFY_OIDC_SECRET}`
The realm template references a comfy OIDC client, but the placeholder was never substitutable: keycloak's pod env didn't map `COMFY_OIDC_SECRET`, and the import-entrypoint substitution lists (both `k3d/realm-import-entrypoint.sh` and `prod/import-entrypoint.sh`) omitted it. Only bites a fresh cluster, where the realm import actually runs.
**Fix:** wire the env var in `k3d/keycloak.yaml` + add `COMFY_OIDC_SECRET` to both substitution lists.

### 3. brainstorm-sish Pending on fleet
`prod-fleet/mentolder` repointed brainstorm-sish nodeAffinity to the pk pool but left the prod-mentolder base `nodeSelector: gekko-hetzner-2` (a node that doesn't exist on fleet). nodeSelector ∧ nodeAffinity → unschedulable.
**Fix:** JSON-patch to remove the stale nodeSelector in the fleet overlay.

## Verification (live, fleet context)
- shared-db rolls out Ready in `workspace`; all 6 service DBs present.
- keycloak imports the realm and is Running (was CrashLoop on `${COMFY_OIDC_SECRET}`).
- brainstorm-sish schedules onto a pk node (was Pending).
- fleet-mentolder: ~25/26 pods Running.

## Out of scope (tracked for Phase 2b)
- Talk HPB `janus`/`spreed-signaling` still gekko-affined → spreed Pending.
- `office-stack` (Collabora) + `coturn-stack` deploy separately (`workspace:office:deploy`); the deploy's coturn/talk post-setup steps abort on a fresh cluster without them.
- shared-db service-DB creation depends on `initdb.d` running once — brittle on fresh clusters (worked around manually this run).
- fleet-korczewski brand not yet deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)