### PR TITLE
test(e2e): unified-fleet topology + korczewski deploy gate [T000338]

### DIFF
--- a/.claude/skills/dev-flow-e2e/SKILL.md
+++ b/.claude/skills/dev-flow-e2e/SKILL.md
@@ -215,6 +215,13 @@ Für `systemtest` läuft der vollständige Zyklus gegen beide Cluster (via `task
 > gestartet werden. `npx playwright` vom Repo-Root aus findet zwei Versionen von
 > `@playwright/test` (Repo-Root + `tests/e2e/node_modules`) und bricht ab.
 
+> **Wichtig — Dependencies & Binary:** Auf einem frischen Checkout fehlen die
+> `tests/e2e/`-Dependencies. Dann zieht `npx playwright` eine fremde Version nach
+> `~/.npm/_npx` und bricht mit `Cannot find module '@playwright/test'` ab. Vorher
+> **immer** `cd tests/e2e/ && npm ci` ausführen und danach das lokale Binary
+> `./node_modules/.bin/playwright` (statt `npx playwright`) verwenden — so wird
+> garantiert die projekt-lokale Version benutzt.
+
 > **Wichtig — korczewski-setup auth overwrite:** Das Ausführen von Tests im `korczewski`-Projekt (selbst mit `--grep`) triggert automatisch das dependency-Projekt `korczewski-setup`. Wenn `TEST_ADMIN_PASSWORD` nicht gesetzt ist, überschreibt dies bestehende gültige Auth-Cookies in `.auth/korczewski-*.json` mit leeren Werten! Wenn du bestehende gültige Cookies behalten willst, überspringe `korczewski-setup` (indem du den Test direkt ohne das Projekt oder mit einem Mock ausführst) oder setze `TEST_ADMIN_PASSWORD` vor dem Ausführen.
 
 ```bash
@@ -234,7 +241,9 @@ else
   # SKIP_DB_PURGE=1 überspringt global-db-cleanup.ts (nötig ohne CRON_SECRET lokal)
   # Spec path must come BEFORE --project; Playwright treats positional args after
   # --project as project names and throws "project not found".
-  cd tests/e2e/ && SKIP_DB_PURGE=1 WEBSITE_URL="$BASE_URL" npx playwright test \
+  # npm ci einmalig auf frischem Checkout; danach lokales Binary statt npx.
+  cd tests/e2e/ && [[ -x ./node_modules/.bin/playwright ]] || npm ci
+  SKIP_DB_PURGE=1 WEBSITE_URL="$BASE_URL" ./node_modules/.bin/playwright test \
     specs/<neu>.spec.ts \
     --project "$PLAYWRIGHT_PROJECT"
 fi
@@ -288,7 +297,7 @@ Falls die Änderung kritisch ist oder neue Service-Endpunkte betrifft:
 
 ```bash
 # Alle website-Tests gegen Mentolder-Live — aus tests/e2e/ ausführen!
-cd tests/e2e/ && SKIP_DB_PURGE=1 WEBSITE_URL=https://web.mentolder.de npx playwright test \
+cd tests/e2e/ && SKIP_DB_PURGE=1 WEBSITE_URL=https://web.mentolder.de ./node_modules/.bin/playwright test \
   --project website
 ```
 

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -173,6 +173,7 @@ export default defineConfig({
         '**/nfa-10-*.spec.ts',   // Arena Health-Endpoint Performance
         '**/nfa-11-*.spec.ts',   // GPU-VRAM nach Modell-Rotation
         '**/nfa-12-*.spec.ts',   // Brainstorm-Tunnel ConfigMap-Persistenz
+        '**/nfa-13-*.spec.ts',   // Unified-fleet korczewski deploy GATE (red until Phase 2b)
         '**/nfa-infra-health-sweep.spec.ts', // Service health sweep (all 17 services)
         '**/sa-15-*.spec.ts',    // Cross-cluster health verification
         '**/ak-03-*.spec.ts',    // Technische Machbarkeit

--- a/tests/e2e/specs/fa-44-platform-health-integrity.spec.ts
+++ b/tests/e2e/specs/fa-44-platform-health-integrity.spec.ts
@@ -2,6 +2,11 @@ import { test, expect } from '@playwright/test';
 
 const BASE = process.env.WEBSITE_URL ?? 'https://web.mentolder.de';
 
+// Topology note (unified-fleet, Fleet Stage 2): each website instance probes
+// ONLY its own cluster's services — mentolder (standalone) reports cluster key
+// 'mentolder'; the korczewski brand (namespace workspace-korczewski on the
+// unified `fleet` cluster) reports 'korczewski'. The single-cluster assertion
+// in T3 holds for both — there is deliberately no cross-cluster fan-out.
 test.describe('FA-44: Platform Hub — Software Assets & System-Integrität', () => {
   test('T1: /api/admin/platform/software requires authentication', async ({ request }) => {
     const res = await request.get(`${BASE}/api/admin/platform/software`);

--- a/tests/e2e/specs/nfa-13-fleet-unified-cluster.spec.ts
+++ b/tests/e2e/specs/nfa-13-fleet-unified-cluster.spec.ts
@@ -1,0 +1,69 @@
+// tests/e2e/specs/nfa-13-fleet-unified-cluster.spec.ts
+//
+// NFA-13: Unified Fleet Cluster — korczewski deploy GATE
+//
+// ⚠ INTENTIONAL RED GATE ⚠
+// These checks are EXPECTED TO FAIL until Phase 2b of the Fleet Stage 2
+// migration completes (`task fleet:deploy ENV=korczewski` against the unified
+// `fleet` cluster, namespace workspace-korczewski). They go green the moment
+// the fleet Traefik + cert-manager serve the korczewski brand. Do NOT
+// "stabilise" them with skips — a failure here is the signal that korczewski
+// is not yet live on the unified cluster.
+//
+// Topology: the standalone korczewski cluster was torn down; its hosts
+// (pk-hetzner-4/6/8) now run the unified `fleet` k3s cluster which will serve
+// the korczewski brand from namespace workspace-korczewski. mentolder remains
+// a separate standalone cluster until its (later) DNS flip.
+//
+// Verification is external HTTP/TLS only — no kubectl/cluster-internal access.
+//
+// Env vars:
+//   KORCZEWSKI_URL   (default: https://web.korczewski.de)
+
+import { test, expect } from '@playwright/test';
+
+const KORCZEWSKI_BASE = (process.env.KORCZEWSKI_URL ?? 'https://web.korczewski.de').replace(/\/$/, '');
+const KORCZEWSKI_AUTH = 'https://auth.korczewski.de';
+const ARENA_BASE      = 'https://arena-ws.korczewski.de';
+
+const OPTIONS = { ignoreHTTPSErrors: false, maxRedirects: 3 } as const;
+const IS_PROD = KORCZEWSKI_BASE.startsWith('https://');
+
+test.describe('NFA-13: Unified Fleet — korczewski deploy GATE', () => {
+
+  // GATE T1: the fleet Traefik serves the korczewski website root.
+  test('GATE: korczewski website root returns 200 (served by fleet)', async ({ request }) => {
+    test.skip(!IS_PROD, 'requires prod URLs');
+    const res = await request.get(KORCZEWSKI_BASE + '/', OPTIONS);
+    expect(res.status()).toBe(200);
+  });
+
+  // GATE T2: cert-manager on the fleet issued a valid cert for the korczewski
+  // SNI — while undeployed the handshake fails with `unrecognized name`.
+  test('GATE: korczewski TLS handshake succeeds (cert-manager cert present)', async ({ request }) => {
+    test.skip(!IS_PROD, 'requires prod URLs');
+    // ignoreHTTPSErrors:false → an invalid/absent cert makes this request throw.
+    const res = await request.get(KORCZEWSKI_BASE + '/', OPTIONS);
+    expect(res.status()).toBeLessThan(500);
+  });
+
+  // GATE T3: Keycloak in workspace-korczewski answers OIDC discovery with the
+  // korczewski realm issuer.
+  test('GATE: korczewski OIDC discovery returns korczewski issuer', async ({ request }) => {
+    test.skip(!IS_PROD, 'requires prod URLs');
+    const res = await request.get(
+      `${KORCZEWSKI_AUTH}/realms/workspace/.well-known/openid-configuration`,
+      OPTIONS,
+    );
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    expect(body.issuer).toContain('korczewski');
+  });
+
+  // GATE T4: Arena (korczewski-only) is healthy on the fleet cluster.
+  test('GATE: arena /healthz returns 200 on fleet', async ({ request }) => {
+    test.skip(!IS_PROD, 'requires prod URLs');
+    const res = await request.get(`${ARENA_BASE}/healthz`, OPTIONS);
+    expect(res.status()).toBe(200);
+  });
+});

--- a/tests/e2e/specs/sa-15-cross-cluster-health.spec.ts
+++ b/tests/e2e/specs/sa-15-cross-cluster-health.spec.ts
@@ -1,8 +1,21 @@
 // tests/e2e/specs/sa-15-cross-cluster-health.spec.ts
 //
-// SA-15: Cross-Cluster Health Verification
-// Verifies both mentolder + korczewski clusters independently:
-// OIDC discovery, website root, TLS validity, and cluster independence.
+// SA-15: Multi-Brand Health Verification (unified-fleet topology)
+//
+// Topology (Fleet Stage 2, 2026-05-30):
+//   • mentolder  — STILL a standalone k3s cluster (DNS flip pending). Always
+//     expected live in prod.
+//   • korczewski — now a BRAND NAMESPACE (workspace-korczewski) on the unified
+//     `fleet` k3s cluster (pk-hetzner-4/6/8). It is NOT a separate physical
+//     cluster any more. Until Phase 2b (`task fleet:deploy` for korczewski)
+//     lands, the fleet Traefik has no router/cert for the korczewski SNI and
+//     these checks SKIP rather than fail. See nfa-13 for the deploy GATE that
+//     intentionally goes red until korczewski is live on fleet.
+//
+// This spec asserts each brand independently (website root, OIDC discovery,
+// TLS validity) and that the two brands expose independent Keycloak realms —
+// brand/realm isolation that holds whether or not they share a physical
+// cluster.
 //
 // Env vars:
 //   WEBSITE_URL      (default: https://web.mentolder.de)
@@ -21,9 +34,27 @@ const OPTIONS = { ignoreHTTPSErrors: false, maxRedirects: 3 } as const;
 
 const IS_PROD = MENTOLDER_BASE.startsWith('https://');
 
-test.describe('SA-15: Cross-Cluster Health', () => {
+// Probe whether the korczewski brand is already serving on the fleet cluster.
+// While it is mid-migration the TLS handshake fails with `unrecognized name`
+// (no router/cert) — fetch throws and we treat the brand as not-yet-deployed,
+// so the brand-scoped checks SKIP instead of producing false regressions.
+let korczewskiUp = false;
+test.beforeAll(async () => {
+  if (!IS_PROD) return;
+  try {
+    const res = await fetch(
+      `${KORCZEWSKI_AUTH}/realms/workspace/.well-known/openid-configuration`,
+      { redirect: 'follow' },
+    );
+    korczewskiUp = res.status === 200;
+  } catch {
+    korczewskiUp = false; // TLS unrecognized_name / connection refused — pending fleet:deploy
+  }
+});
 
-  // ── mentolder cluster ──────────────────────────────────────────────────
+test.describe('SA-15: Multi-Brand Health', () => {
+
+  // ── mentolder (standalone cluster) ─────────────────────────────────────
   test('mentolder: website root returns 200', async ({ request }) => {
     test.skip(!IS_PROD, 'requires prod URLs');
     const res = await request.get(MENTOLDER_BASE + '/', OPTIONS);
@@ -62,15 +93,18 @@ test.describe('SA-15: Cross-Cluster Health', () => {
     expect(tlsError, `TLS error on mentolder: ${tlsError}`).toBeUndefined();
   });
 
-  // ── korczewski cluster ─────────────────────────────────────────────────
+  // ── korczewski brand (on the unified fleet cluster) ────────────────────
+  // SKIP while the brand is not yet deployed on fleet — nfa-13 is the GATE.
   test('korczewski: website root returns 200', async ({ request }) => {
     test.skip(!IS_PROD, 'requires prod URLs');
+    test.skip(!korczewskiUp, 'korczewski brand not yet serving on fleet — pending Phase 2b fleet:deploy');
     const res = await request.get(KORCZEWSKI_BASE + '/', OPTIONS);
     expect(res.status()).toBe(200);
   });
 
   test('korczewski: keycloak OIDC discovery returns 200', async ({ request }) => {
     test.skip(!IS_PROD, 'requires prod URLs');
+    test.skip(!korczewskiUp, 'korczewski brand not yet serving on fleet — pending Phase 2b fleet:deploy');
     const res = await request.get(
       `${KORCZEWSKI_AUTH}/realms/workspace/.well-known/openid-configuration`,
       OPTIONS,
@@ -82,12 +116,14 @@ test.describe('SA-15: Cross-Cluster Health', () => {
 
   test('korczewski: brett root reachable', async ({ request }) => {
     test.skip(!IS_PROD, 'requires prod URLs');
+    test.skip(!korczewskiUp, 'korczewski brand not yet serving on fleet — pending Phase 2b fleet:deploy');
     const res = await request.get('https://brett.korczewski.de', OPTIONS);
     expect(res.status()).toBeLessThan(500);
   });
 
   test('korczewski: TLS cert valid (no cert error)', async ({ page }) => {
     test.skip(!IS_PROD, 'requires prod URLs');
+    test.skip(!korczewskiUp, 'korczewski brand not yet serving on fleet — pending Phase 2b fleet:deploy');
     let tlsError: string | undefined;
     page.on('requestfailed', req => {
       if (req.failure()?.errorText?.includes('CERT')) {
@@ -98,16 +134,21 @@ test.describe('SA-15: Cross-Cluster Health', () => {
     expect(tlsError, `TLS error on korczewski: ${tlsError}`).toBeUndefined();
   });
 
-  // ── korczewski-only: Arena ─────────────────────────────────────────────
+  // ── korczewski-only: Arena (on fleet) ──────────────────────────────────
   test('arena: /healthz returns 200 (korczewski-only)', async ({ request }) => {
     test.skip(!IS_PROD, 'requires prod URLs');
+    test.skip(!korczewskiUp, 'korczewski brand not yet serving on fleet — pending Phase 2b fleet:deploy');
     const res = await request.get(`${ARENA_BASE}/healthz`, OPTIONS);
     expect(res.status()).toBe(200);
   });
 
-  // ── Cluster independence ───────────────────────────────────────────────
-  test('clusters: auth domains serve independent realms', async ({ request }) => {
+  // ── Brand-realm independence ───────────────────────────────────────────
+  // Each brand exposes its own Keycloak realm with a distinct issuer + JWKS.
+  // This isolation must hold whether the brands share a physical cluster
+  // (unified fleet) or not (mentolder still standalone today).
+  test('brands: auth domains serve independent realms', async ({ request }) => {
     test.skip(!IS_PROD, 'requires prod URLs');
+    test.skip(!korczewskiUp, 'korczewski brand not yet serving on fleet — pending Phase 2b fleet:deploy');
 
     const [mentolderDiscovery, korczewskiDiscovery] = await Promise.all([
       request.get(
@@ -120,12 +161,12 @@ test.describe('SA-15: Cross-Cluster Health', () => {
       ).then(r => r.json()) as Promise<{ issuer: string; jwks_uri: string }>,
     ]);
 
-    // Issuers must differ — they're independent realms on separate clusters
+    // Issuers must differ — independent realms, one per brand
     expect(mentolderDiscovery.issuer).not.toBe(korczewskiDiscovery.issuer);
     expect(mentolderDiscovery.issuer).toContain('mentolder');
     expect(korczewskiDiscovery.issuer).toContain('korczewski');
 
-    // JWKS URIs must come from different hosts
+    // JWKS URIs must come from different hosts (per-brand auth domain)
     expect(mentolderDiscovery.jwks_uri).not.toBe(korczewskiDiscovery.jwks_uri);
   });
 });

--- a/website/src/data/test-inventory.json
+++ b/website/src/data/test-inventory.json
@@ -1128,6 +1128,12 @@
     "kind": "shell"
   },
   {
+    "id": "NFA-13",
+    "file": "tests/e2e/specs/nfa-13-fleet-unified-cluster.spec.ts",
+    "category": "NFA",
+    "kind": "playwright"
+  },
+  {
     "id": "SA-01",
     "file": "tests/local/SA-01.bats",
     "category": "SA",


### PR DESCRIPTION
## What

Updates the E2E suite to reflect the **unified \`fleet\` cluster** topology (Fleet Stage 2). korczewski is no longer a separate physical cluster — it is a brand namespace (\`workspace-korczewski\`) on the unified fleet cluster. mentolder remains standalone (DNS flip pending).

## Changes

- **\`sa-15\`** (reframed, stays green now): renamed *Cross-Cluster* → *Multi-Brand Health*. Models korczewski as a fleet brand namespace; korczewski checks **gracefully skip** while the brand is undeployed on fleet (TLS \`unrecognized name\`). The independence assertion is reframed from "separate physical clusters" to **brand-realm independence** (distinct issuers + JWKS), which holds regardless of shared cluster.
- **\`nfa-13\`** (new — intentional **RED GATE**): external HTTP/TLS checks that the fleet Traefik + cert-manager serve the korczewski brand (website root, valid TLS cert, OIDC issuer, Arena health). **Expected to fail until Phase 2b** (\`task fleet:deploy\` for korczewski) lands; flips green on deploy. Do not stabilise with skips.
- **\`fa-44\`**: clarifying comment — each website probes only its own cluster under the unified topology (logic unchanged, still correct).
- Registered \`nfa-13\` in the \`services\` project; regenerated \`test-inventory.json\`.

## Verification (against live prod)

| Spec | Result |
|------|--------|
| \`sa-15\` | mentolder checks **pass**; 6 korczewski checks **skip** (pending fleet deploy) ✅ |
| \`nfa-13\` | all 4 GATE checks **fail** as designed (korczewski not yet on fleet) 🔴 |

Verification is **external HTTP/TLS only** — portable, no kubectl/cluster-internal access.

## ⚠ Note: unrelated live degradation found
\`sa-15\` surfaced a real issue: \`files.mentolder.de/status.php\` returns a persistent **503** (Nextcloud degraded on mentolder). Not caused by this PR (assertion unchanged) — flagged for ops follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)