### PR TITLE
fix(fleet): skip workspace:deploy embedded talk-setup during brand-core phase

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1474,8 +1474,10 @@ tasks:
       # mcp:deploy + post-setup are the core post-deploy steps that are safe
       # WITHOUT coturn. The Talk wiring phase is deferred to its own brand task
       # because it requires the shared coturn/Janus (fleet:shared-services) to exist.
+      # SKIP_TALK_SETUP=true stops workspace:deploy from running its embedded
+      # coturn sync + Talk wiring (which hard-fails before coturn exists).
       - task: workspace:deploy
-        vars: { ENV: "{{.BRAND}}" }
+        vars: { ENV: "{{.BRAND}}", SKIP_TALK_SETUP: "true" }
       - task: mcp:deploy
         vars: { ENV: "{{.BRAND}}" }
       - task: workspace:post-setup
@@ -1734,8 +1736,19 @@ tasks:
       # right cluster.
       - |
         if [ "{{.ENV}}" != "dev" ]; then
-          task workspace:coturn:sync-secret ENV="{{.ENV}}" || true
-          task workspace:talk-setup ENV="{{.ENV}}"
+          # SKIP_TALK_SETUP lets a multi-brand orchestrator (fleet:deploy:brand)
+          # defer the embedded coturn:sync-secret + talk-setup chain. On a fresh
+          # SHARED-stack cluster, coturn/Janus do not exist yet during the brand
+          # core deploy — they come up once in fleet:shared-services AFTER both
+          # brands' SealedSecrets (collabora-secrets/workspace-secrets) are applied.
+          # talk-setup then runs per-brand via fleet:talk-setup:brand. Default
+          # "false" preserves the standalone single-cluster deploy behavior.
+          if [ "{{.SKIP_TALK_SETUP | default "false"}}" != "true" ]; then
+            task workspace:coturn:sync-secret ENV="{{.ENV}}" || true
+            task workspace:talk-setup ENV="{{.ENV}}"
+          else
+            echo "⏭  SKIP_TALK_SETUP=true — deferring coturn:sync-secret + talk-setup (fleet:shared-services + fleet:talk-setup:brand handle it)"
+          fi
           # Re-pin LiveKit DNS after every prod deploy so the livekit/stream
           # subdomains always resolve to the livekit node (nodeAffinity pin).
           # Without pinning, round-robin DNS routes ~66 % of signalling WS

--- a/tests/unit/fleet-phase2b.bats
+++ b/tests/unit/fleet-phase2b.bats
@@ -39,3 +39,20 @@ setup() {
   [ "$brand_line" -lt "$shared_line" ]
   [ "$shared_line" -lt "$talk_line" ]
 }
+
+# Regression: workspace:deploy embeds coturn:sync-secret + talk-setup, which hard-fail
+# on a fresh fleet cluster because coturn/Janus only come up later in fleet:shared-services.
+# fleet:deploy:brand must be able to skip that embedded talk chain.
+
+@test "workspace:deploy gates its embedded talk-setup behind SKIP_TALK_SETUP" {
+  block="$(awk '/^  workspace:deploy:$/{f=1} f&&/^  [a-z].*:$/&&!/workspace:deploy:$/{if(seen)exit} f{print; seen=1}' "$TASKFILE")"
+  # the block still invokes talk-setup ...
+  echo "$block" | grep -q 'workspace:talk-setup'
+  # ... but only when SKIP_TALK_SETUP is not "true"
+  echo "$block" | grep -q 'SKIP_TALK_SETUP'
+}
+
+@test "fleet:deploy:brand passes SKIP_TALK_SETUP=true so brand core skips talk-setup" {
+  block="$(awk '/^  fleet:deploy:brand:/{f=1} f&&/^  [a-z].*:$/&&!/fleet:deploy:brand:/{if(seen)exit} f{print; seen=1}' "$TASKFILE")"
+  echo "$block" | grep -q 'SKIP_TALK_SETUP'
+}


### PR DESCRIPTION
## Summary
- Discovered at live deploy (Task 8 of T000345): `task fleet:deploy` fails on the first brand because `workspace:deploy` embeds `coturn:sync-secret` + `talk-setup` at its tail, and `talk-setup` hard-fails on a fresh shared-stack fleet cluster — coturn/Janus only come up later in `fleet:shared-services` (which itself must run AFTER both brands' SealedSecrets land collabora-secrets/workspace-secrets, since shared Collabora needs collabora-secrets).
- Fix: gate the embedded coturn-sync + Talk chain behind `SKIP_TALK_SETUP` (default `false` → standalone single-cluster deploys unchanged). `fleet:deploy:brand` sets `SKIP_TALK_SETUP=true`; the Talk wiring runs per-brand in `fleet:talk-setup:brand` after `fleet:shared-services`.

## Root cause
The merged Phase 2b ordering was correct in intent, but missed that `workspace:deploy` invokes talk-setup internally — so the brand-core phase never finished and shared-services/korczewski/talk-setup never ran.

## Test plan
- [x] new BATS regression (red→green): `workspace:deploy` gates embedded talk-setup behind SKIP_TALK_SETUP; `fleet:deploy:brand` passes it
- [x] `task test:all` (7/7 fleet-phase2b green, suite exit 0)
- [x] `task workspace:validate`
- [x] `task --dry fleet:deploy:brand BRAND=fleet-mentolder` shows the skip branch

Closes T000345

Co-Authored-By: Claude Opus 4.8