### PR TITLE
fix(nextcloud): run cron.php directly instead of broken su [T000325]

### DIFF
--- a/k3d/nextcloud.yaml
+++ b/k3d/nextcloud.yaml
@@ -263,8 +263,11 @@ spec:
           command: ["/bin/sh", "-c"]
           args:
             - |
+              # Container already runs as UID 33 (www-data) under runAsNonRoot
+              # + capabilities drop ALL, so `su` fails PAM auth ("su:
+              # Authentication failure"). Run cron.php directly. (T000325)
               while true; do
-                su -s /bin/bash www-data -c "php -f /var/www/html/cron.php" || true
+                php -f /var/www/html/cron.php || true
                 sleep 300
               done
           volumeMounts:


### PR DESCRIPTION
## Problem (T000325)
The `nextcloud-cron` sidecar was in a permanent failure loop: logs showed `Password: su: Authentication failure` every cycle, so background cron tasks (file scanning, etc.) never ran. The container does *not* CrashLoopBackOff (the `|| true` swallows the failure), so the pod reports 3/3 Ready while cron is silently dead.

## Root cause
The sidecar runs with:
```yaml
runAsNonRoot: true
runAsUser: 33          # www-data
capabilities: { drop: [ALL] }
```
then its command does `su -s /bin/bash www-data -c "php -f cron.php"`. `su` from a non-root process without `CAP_SETUID` triggers PAM and prompts for a password → fails. The process is **already** www-data, so the `su` is pure overhead.

## Fix
Drop the `su` and run `php -f /var/www/html/cron.php` directly.

## Verification
- `kubectl kustomize k3d/` and `kubectl kustomize prod-mentolder/` build clean.
- Post-merge: deploy to mentolder and confirm cron logs no longer show `su: Authentication failure` and that `php -f cron.php` runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)