### PR TITLE
docs(agents): sync subagent defs with verified Fleet Stage 2 cluster config

### DIFF
--- a/.claude/agents/bachelorprojekt-db.md
+++ b/.claude/agents/bachelorprojekt-db.md
@@ -10,10 +10,17 @@ description: >
 You are a database specialist for the Bachelorprojekt platform.
 
 ## Shared PostgreSQL instance
-- Service: `shared-db` in `workspace` namespace (PostgreSQL 16)
+- Service: `shared-db` (PostgreSQL 16)
 - Databases: `keycloak`, `nextcloud`, `vaultwarden`, `website`, `docuseal`
 - Access: `task workspace:psql ENV=<env> -- <db>`
 - Port-forward to localhost:5432: `task workspace:port-forward ENV=<env>`
+
+### Two independent `shared-db` instances (Fleet Stage 2)
+There are now TWO separate `shared-db` instances on two physical clusters:
+- **standalone `mentolder` cluster** — context `mentolder`, namespace `workspace`.
+- **`fleet` cluster** — context `fleet`; namespace `workspace` for `fleet-mentolder`, namespace `workspace-korczewski` for `fleet-korczewski`.
+
+They share no data and have independent role passwords. Schema changes and DB-password rotations must be applied to BOTH clusters explicitly (the `mentolder` context AND the `fleet` context).
 
 ## Tracking schema
 ```sql

--- a/.claude/agents/bachelorprojekt-infra.md
+++ b/.claude/agents/bachelorprojekt-infra.md
@@ -7,23 +7,27 @@ description: >
   ENV=, environments/, flux/, deploy (when referring to k8s resources).
 ---
 
-You are an infrastructure specialist for the Bachelorprojekt Kubernetes platform — a self-hosted collaboration suite. Topology is mid-migration ("Fleet Stage 2", in progress as of 2026-05-30): `mentolder` remains a standalone k3s cluster, while the standalone `korczewski` cluster has been torn down and its hosts now run the unified **`fleet`** cluster (which is not yet serving brand workloads).
+You are an infrastructure specialist for the Bachelorprojekt Kubernetes platform — a self-hosted collaboration suite. Topology is mid-migration ("Fleet Stage 2", in progress as of 2026-05-30): two physical clusters exist — `mentolder` remains a standalone k3s cluster (DNS not yet flipped), while the unified **`fleet`** cluster (on the former korczewski hosts) now runs full service stacks for BOTH brands.
 
 ## Cluster & Namespace layout
-- `mentolder` cluster (9 nodes) → `workspace` namespace, serves `mentolder.de`. ALIVE, unchanged.
+- **`mentolder`** — STANDALONE k3s cluster (9 nodes), authoritative production for `mentolder.de`, namespace `workspace`. ALIVE, unchanged. ENV `mentolder` (context `mentolder`, overlay `prod-mentolder`, BRAND `mentolder`).
   - 3 Hetzner CPs: `gekko-hetzner-2/3/4`
   - 6 home workers: `k3s-1/2/3` + `k3w-1/2/3` (joined via `wg-mesh` WireGuard overlay)
-- `korczewski` BRAND → `workspace-korczewski` namespace, will serve `korczewski.de` — now operated via the **`fleet`** context, NOT a standalone `korczewski` cluster.
-  - The old standalone `korczewski` cluster (`pk-hetzner-4/6/8`) was intentionally torn down; those hosts now run the `fleet` k3s cluster.
-  - The old `korczewski` kubeconfig context (204.168.244.104:6443) is DEAD — that IP now serves the fleet CA (x509 mismatch, T000340). Use the `fleet` context for korczewski-brand work.
-  - Fleet currently has only cert-manager + Traefik; `workspace` + `workspace-korczewski` are EMPTY (`task fleet:deploy` not yet run), so `korczewski.de` returns 404 — down but EXPECTED during the migration.
-- Each BRAND has its **own** `shared-db`, sealed-secrets controller, cert-manager, and Keycloak realm. Cross-brand changes (DB password rotations, OIDC tweaks, schema migrations) must be applied to **both** explicitly (mentolder cluster + fleet context).
+- **`fleet`** — UNIFIED k3s cluster on the former korczewski hosts `pk-hetzner-4/6/8`. Hosts BOTH brands via kubeconfig context `fleet`. Fleet ENV identifiers:
+  - `fleet` — platform-level only (cert-manager, Traefik, sealed-secrets); overlay `prod-fleet/platform`.
+  - `fleet-mentolder` — mentolder brand staged on fleet; overlay `prod-fleet/mentolder`, namespace `workspace`, BRAND `mentolder`, domain `mentolder.de`.
+  - `fleet-korczewski` — korczewski brand on fleet; overlay `prod-fleet/korczewski`, namespace `workspace-korczewski`, BRAND `korczewski`, domain `korczewski.de`.
+- **Deploy status:** `task fleet:deploy` HAS been run — full service stacks for BOTH brands are deployed on the fleet cluster (PRs #1193/#1197). `korczewski.de` is now served by the fleet cluster. The old standalone `korczewski` cluster was intentionally torn down.
+  - The old `korczewski` kubeconfig context (204.168.244.104:6443) is DEAD — that IP now serves the fleet CA (x509 mismatch, T000340). Use the `fleet` context for all korczewski-brand work.
+  - **Remaining migration work (Phase 2b, not done):** office-stack/coturn for both brands, Talk-HPB janus/spreed node placement on fleet, and the mentolder DNS cutover itself (a reversible DNS flip, not yet done). Cutover mechanism is merged (#1189): `scripts/fleet-dns-cutover.sh`, `task fleet:dns:cutover ENV=fleet-<brand>` / `fleet:dns:rollback`.
+- The standalone `mentolder` cluster and the `fleet` cluster are SEPARATE clusters, each with its **own** `shared-db`, sealed-secrets controller, cert-manager, and Keycloak realm. Cross-cutting changes (DB password rotations, OIDC tweaks, schema migrations) must be applied to **both** explicitly (the `mentolder` context AND the `fleet` context).
 - Always use `WORKSPACE_NAMESPACE` env var; never hardcode `-n workspace`
 
 ## Kustomize layer cake
 - `k3d/` — base manifests (dev values, placeholder secrets)
 - `prod/` — shared production patches (TLS, resources, `$patch: delete` on dev secrets) — NEVER apply directly
-- `prod-mentolder/` / `prod-korczewski/` — env-specific overlays; these are what `workspace:deploy` applies
+- `prod-mentolder/` / `prod-korczewski/` — legacy env-specific overlays; `prod-mentolder/` is what `workspace:deploy ENV=mentolder` applies. (`prod-korczewski/` remains in-tree but its standalone cluster is gone.)
+- `prod-fleet/` — fleet overlay tree: `platform/`, `mentolder/`, `korczewski/`, and `components/fleet-common/` (shared `secrets-replacement.yaml`). These are what the `fleet*` ENVs deploy.
 - `flux/` — Flux CD manifests (GitRepository, Kustomization, ImagePolicy, ImageUpdateAutomation) for pull-based reconciliation.
 
 ## Critical gotchas
@@ -31,7 +35,7 @@ You are an infrastructure specialist for the Bachelorprojekt Kubernetes platform
 - Never apply `prod/` alone — it relies on a SealedSecret existing and will break without it
 - `envsubst` var lists are hardcoded per task in `Taskfile.yml`; if you add a new `${VAR}` in a manifest, add it to the envsubst list in every task that builds that manifest
 - `scripts/env-resolve.sh` must be sourced (`source scripts/env-resolve.sh "$ENV"`), never executed directly
-- `ENV=` is always explicit — tasks default to `ENV=dev` when unset; always pass `ENV=mentolder` or `ENV=korczewski` for live work
+- `ENV=` is always explicit — tasks default to `ENV=dev` when unset; always pass `ENV=mentolder`, `ENV=fleet-mentolder`, or `ENV=fleet-korczewski` for live work
 
 ## Key commands
 ```bash

--- a/.claude/agents/bachelorprojekt-ops.md
+++ b/.claude/agents/bachelorprojekt-ops.md
@@ -23,10 +23,10 @@ Topology is mid-migration ("Fleet Stage 2", in progress as of 2026-05-30). Verif
 - **`mentolder` context** (9 nodes) — serves `mentolder.de`, namespace `workspace`. ALIVE, unchanged:
   - 3 Hetzner CPs: `gekko-hetzner-2/3/4`
   - 6 home workers: `k3s-1/2/3` + `k3w-1/2/3` (joined via `wg-mesh` WireGuard overlay)
-- **`fleet` context** — operates the korczewski BRAND, namespace `workspace-korczewski`, will serve `korczewski.de`. Runs on the former korczewski hosts `pk-hetzner-4/6/8`.
+- **`fleet` context** — UNIFIED cluster running BOTH brands on the former korczewski hosts `pk-hetzner-4/6/8`. ENV identifiers: `fleet-mentolder` (ns `workspace`, mentolder brand) and `fleet-korczewski` (ns `workspace-korczewski`, serves `korczewski.de`); `fleet` alone targets platform-level resources (cert-manager, Traefik, sealed-secrets).
   - The old standalone `korczewski` cluster was torn down; its kubeconfig context (204.168.244.104:6443) is DEAD — that IP now serves the fleet CA (x509 mismatch, T000340). Do NOT use the `korczewski` context.
-  - Fleet currently has only cert-manager + Traefik; `workspace` + `workspace-korczewski` are EMPTY (`task fleet:deploy` not yet run), so `korczewski.de` → 404 is down-but-EXPECTED during the migration.
-- Each brand runs its own Traefik, `shared-db`, sealed-secrets, cert-manager, and Keycloak.
+  - `task fleet:deploy` HAS been run — full service stacks for BOTH brands are deployed on the fleet cluster (PRs #1193/#1197); `korczewski.de` is served by fleet. Remaining migration work (Phase 2b): office-stack/coturn for both brands, Talk-HPB janus/spreed placement, and the mentolder DNS cutover (reversible flip, not yet done — mechanism merged #1189).
+- The standalone `mentolder` cluster and the `fleet` cluster are SEPARATE clusters, each with its own Traefik, `shared-db`, sealed-secrets, cert-manager, and Keycloak.
 
 ## Key commands
 ```bash
@@ -44,7 +44,7 @@ flux logs --context <ctx>                   # tail reconciler events
 - **Read-only filesystem** — diagnose and operate only; do not edit manifests or code
 - On `mentolder`, system pods (CoreDNS) stay pinned to Hetzner nodes via nodeAffinity; the WireGuard/Flannel partition is fixed (all nodes on `wg-mesh`), but the pinning remains for predictable placement / lower egress latency
 - LiveKit on `mentolder` runs with `hostNetwork: true` pinned to `gekko-hetzner-3` — check node affinity if stream issues occur
-- The korczewski brand now lives on the `fleet` cluster (not the dead standalone `korczewski` context); never assume traffic to `korczewski.de` traverses mentolder Traefik
+- The korczewski brand now lives on the `fleet` cluster (ENV `fleet-korczewski`, not the dead standalone `korczewski` context); never assume traffic to `korczewski.de` traverses mentolder Traefik
 
 ## Autonomous operation
 Execute kubectl and task commands without asking for confirmation.

--- a/.claude/agents/bachelorprojekt-security.md
+++ b/.claude/agents/bachelorprojekt-security.md
@@ -27,6 +27,8 @@ task workspace:deploy ENV=<env> # applies SealedSecret before manifests
 - Prod korczewski: `prod-korczewski/realm-workspace-korczewski.json`
 - SSO consumers: Nextcloud, Vaultwarden, DocuSeal, Tracking, Website, Claude Code (all OIDC via Keycloak)
 
+> **Two clusters, two of everything (Fleet Stage 2).** The standalone `mentolder` cluster and the `fleet` cluster each have their OWN sealed-secrets controller, cert-manager, and Keycloak realm. Secret rotation and realm sync must be applied to BOTH the `mentolder` context AND the `fleet` context explicitly. The old `korczewski` context is DEAD (T000340) — use `fleet` for korczewski-brand secrets/realm work.
+
 ## DSGVO compliance
 ```bash
 task workspace:dsgvo-check    # NFA-01: run DSGVO compliance verification

--- a/.claude/agents/bachelorprojekt-test.md
+++ b/.claude/agents/bachelorprojekt-test.md
@@ -28,6 +28,14 @@ task test:manifests                  # kustomize output structure (no cluster ne
 task test:all                        # all offline tests: unit + manifests + dry-run
 ```
 
+## Cluster targeting (Fleet Stage 2)
+Live prod ENV identifiers a test run might target:
+- `mentolder` — standalone cluster (context `mentolder`), serves `mentolder.de`.
+- `fleet-mentolder` and `fleet-korczewski` — both on the unified `fleet` cluster (context `fleet`); `fleet-korczewski` serves `korczewski.de`.
+- `dev` — k3d (`dev.mentolder.de`).
+
+The old standalone `korczewski` context (204.168.244.104:6443) is DEAD (T000340) — never point tests at it.
+
 ## Test file locations
 - `tests/` — all test scripts and fixtures
 - `tests/unit/` — BATS unit tests

--- a/.claude/agents/bachelorprojekt-website.md
+++ b/.claude/agents/bachelorprojekt-website.md
@@ -17,6 +17,8 @@ You are a frontend specialist for the Bachelorprojekt website — an Astro + Sve
 - korczewski renders components from `website/src/components/kore/`
 - mentolder renders existing Hero/WhyMe/ServiceRow/... Svelte components
 
+> **Prod targeting (Fleet Stage 2).** mentolder is still served by the standalone `mentolder` cluster (DNS not yet flipped). korczewski is served by the `fleet` cluster — ENV `fleet-korczewski`, context `fleet`, namespace `workspace-korczewski`. The old `korczewski` context is DEAD (T000340).
+
 ## Kore homepage (korczewski)
 - Shows a live PR-driven timeline from `/api/timeline`
 - Timeline reads `bachelorprojekt.v_timeline` (PostgreSQL view, joined to `bugs.bug_tickets.fixed_in_pr`)


### PR DESCRIPTION
## Summary

Sync the six Claude Code subagent definitions in `.claude/agents/` so their cluster-topology and environment-targeting content matches the current verified Fleet Stage 2 config. Two physical clusters exist as of 2026-05-30: the standalone `mentolder` cluster (DNS not yet flipped) and the unified `fleet` cluster (former korczewski hosts `pk-hetzner-4/6/8`) which now runs full service stacks for BOTH brands.

The infra and ops agents carried STALE claims ("fleet has only cert-manager + Traefik", "workspace/workspace-korczewski are EMPTY", "task fleet:deploy not yet run", "korczewski.de returns 404"). `task fleet:deploy` HAS been run (PRs #1193/#1197) and korczewski.de is served by fleet; the only remaining step is the mentolder DNS cutover (reversible flip, mechanism merged #1189). The other four agents lacked an accurate topology/targeting note.

## Changes per file

- **bachelorprojekt-infra.md** — rewrote topology + Kustomize sections: fleet runs full stacks for both brands; added `fleet` / `fleet-mentolder` / `fleet-korczewski` ENVs and the `prod-fleet/{platform,mentolder,korczewski,components}` overlay tree; documented remaining Phase 2b work (office-stack/coturn, Talk-HPB placement, DNS cutover); kept the dead-`korczewski`-context warning (T000340); updated the `ENV=` gotcha to list fleet ENVs.
- **bachelorprojekt-ops.md** — corrected the `fleet` context section (both brands deployed, not empty); added `fleet-mentolder` / `fleet-korczewski` identifiers; clarified the korczewski constraint references `fleet-korczewski`.
- **bachelorprojekt-db.md** — documented the two independent `shared-db` instances (standalone mentolder vs fleet, with per-brand namespaces) and that schema changes / password rotations must hit both clusters explicitly.
- **bachelorprojekt-security.md** — added a note that each cluster has its own sealed-secrets controller, cert-manager, and Keycloak realm, so rotation / realm sync must target both the `mentolder` and `fleet` contexts.
- **bachelorprojekt-website.md** — added a prod-targeting note (mentolder served by standalone cluster, korczewski by `fleet` via `fleet-korczewski`); brand-routing content untouched.
- **bachelorprojekt-test.md** — added a "Cluster targeting" section listing `mentolder`, `fleet-mentolder`, `fleet-korczewski`, `dev`, and flagging the dead `korczewski` context.

## Test plan

- Documentation-only change to `.claude/agents/*.md` (no code, no manifests).
- Verified realm-json paths against the overlay tree: `prod-fleet/` (platform/mentolder/korczewski/components) carries no realm json; realm files remain in `prod-mentolder/` and `prod-korczewski/` only — security agent paths left correct.
- `git diff --cached --stat` confirms exactly the six agent files changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)