### PR TITLE
fix(nextcloud): give cron sidecar DB env so cron.php can authenticate [T000325]

### DIFF
--- a/k3d/nextcloud.yaml
+++ b/k3d/nextcloud.yaml
@@ -270,6 +270,21 @@ spec:
                 php -f /var/www/html/cron.php || true
                 sleep 300
               done
+          # zz-db.config.php resolves dbpassword via getenv('POSTGRES_PASSWORD'),
+          # so the cron sidecar needs the same DB env as the main container —
+          # otherwise cron.php hits "fe_sendauth: no password supplied". (T000325)
+          env:
+            - name: POSTGRES_HOST
+              value: nextcloud-db
+            - name: POSTGRES_DB
+              value: nextcloud
+            - name: POSTGRES_USER
+              value: nextcloud
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: workspace-secrets
+                  key: NEXTCLOUD_DB_PASSWORD
           volumeMounts:
             - name: app
               mountPath: /var/www/html


### PR DESCRIPTION
## Follow-up to #1201 (T000325)
#1201 removed the broken `su` from the `nextcloud-cron` sidecar, so `cron.php` now actually executes. That surfaced a second, previously-masked failure:

```
Failed to connect to the database: ... fe_sendauth: no password supplied
```

## Root cause
`zz-db.config.php` resolves the DB password at runtime:
```php
$CONFIG = ['dbpassword' => getenv('POSTGRES_PASSWORD')];
```
The main and `notify-push` containers carry a `POSTGRES_PASSWORD` env (and `POSTGRES_HOST/DB/USER`). The **cron sidecar had no `env:` block at all**, so `getenv('POSTGRES_PASSWORD')` returned empty. While `su` was failing, cron never reached the DB, so this was hidden.

## Fix
Add the same `POSTGRES_*` env block (password from `workspace-secrets/NEXTCLOUD_DB_PASSWORD`) to the cron sidecar.

## Verification
- `kubectl kustomize k3d/` and `prod-mentolder/` build clean.
- Post-merge: roll out and confirm cron logs are free of both `su: Authentication failure` and `fe_sendauth: no password supplied`.

Closes T000325

🤖 Generated with [Claude Code](https://claude.com/claude-code)