### PR TITLE
feat(dev-mcp): token-authed public route for the dev MCP monolith

### DIFF
--- a/Taskfile.dev-stack.yml
+++ b/Taskfile.dev-stack.yml
@@ -127,6 +127,7 @@ tasks:
         SHARED=$(yq -r '.DEV_SHARED_DB_PASSWORD // ""' "$SECRETS_FILE")
         SITE=$(yq -r '.DEV_WEBSITE_DB_PASSWORD // ""' "$SECRETS_FILE")
         AUTHKEYS=$(yq -r '.DEV_SISH_AUTHORIZED_KEYS // ""' "$SECRETS_FILE")
+        MCP_TOKEN=$(yq -r '.DEV_MCP_TOKEN // ""' "$SECRETS_FILE")
         if [[ -z "$SHARED" || -z "$SITE" ]]; then
           echo "DEV_SHARED_DB_PASSWORD or DEV_WEBSITE_DB_PASSWORD missing from $SECRETS_FILE." >&2
           echo "Run task env:generate ENV={{.ENV}} (or add the keys manually) and try again." >&2
@@ -140,6 +141,15 @@ tasks:
         kubectl --context {{.CTX_DEV}} -n {{.NS_DEV}} create configmap sish-authorized-keys \
           --from-literal=authorized_keys="$AUTHKEYS" \
           --dry-run=client -o yaml | kubectl --context {{.CTX_DEV}} apply -f -
+        # mcp-tokens — single CLUSTER_TOKEN tier for the dev MCP public route
+        # (mcp-auth-proxy-dev ForwardAuth). Skipped if DEV_MCP_TOKEN is unset.
+        if [[ -n "$MCP_TOKEN" ]]; then
+          kubectl --context {{.CTX_DEV}} -n {{.NS_DEV}} create secret generic mcp-tokens \
+            --from-literal=CLUSTER_TOKEN="$MCP_TOKEN" \
+            --dry-run=client -o yaml | kubectl --context {{.CTX_DEV}} apply -f -
+        else
+          echo "DEV_MCP_TOKEN missing from $SECRETS_FILE — skipping mcp-tokens (mcp.dev route will fail closed)." >&2
+        fi
 
   build:website:
     desc: "[dev] Build the website image and import it into the dev k3d cluster"

--- a/docs/superpowers/plans/2026-05-30-dev-mcp-public-route.md
+++ b/docs/superpowers/plans/2026-05-30-dev-mcp-public-route.md
@@ -1,0 +1,111 @@
+---
+title: Public token-authenticated route for the dev MCP monolith — Implementation Plan
+ticket_id: T000352
+domains: [website, infra, ops, test, security]
+status: active
+pr_number: null
+---
+
+# Public token-authenticated route for the dev MCP monolith — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give the dev MCP monolith (`claude-code-mcp-monolith`, ns `workspace-dev`, k3d-mentolder-dev on k3s-1) a durable, token-authenticated public route at `https://mcp.dev.mentolder.de/{kubernetes,postgres,github,browser}/mcp` usable from any Claude Code client.
+
+**Architecture:** Approach B — minimal prod surface. Add `--skip-auth-route` to the existing `oauth2-proxy-dev` reverse proxy (the only hostNetwork bridge from prod Traefik to the k3d Traefik LB at `127.0.0.1:18080`) so MCP path prefixes bypass the OIDC `/dev-access` gate but are still proxied into k3d. Host the **token gate + path routing entirely inside the dev k3d cluster**, porting the prod MCP pattern (`deploy/mcp/`): an nginx ForwardAuth (`mcp-auth-proxy-dev`) + a Traefik `IngressRoute` for `Host(mcp.dev.mentolder.de)` with a strip-prefix/forward-auth middleware chain. `mcp.dev.mentolder.de` already resolves via the `*.dev` wildcard and is covered by `workspace-dev-wildcard-tls` — no new DNS/cert.
+
+**Tech Stack:** Kustomize, kubectl (`k3d-mentolder-dev` + `mentolder` contexts), Traefik IngressRoute/Middleware CRDs, nginx ForwardAuth, oauth2-proxy v7.9.0, envsubst, BATS, Bash.
+
+**Spec:** `docs/superpowers/specs/2026-05-30-dev-mcp-public-route-design.md`
+**Ticket:** T000352 · **Branch:** `feature/dev-mcp-public-route`
+
+---
+
+## Pre-flight (verify before editing — do not assume)
+
+- [ ] Confirm object names/ports still match the spec:
+  - `kubectl --context mentolder -n workspace get deploy oauth2-proxy-dev -o jsonpath='{.spec.template.spec.containers[0].args}'` — confirm no existing `--skip-auth-route`.
+  - `kubectl --context k3d-mentolder-dev -n workspace-dev get svc claude-code-mcp-monolith -o jsonpath='{.spec.ports[*].name}'` — expect `kubernetes postgres browser github`.
+- [ ] Confirm `kubectl kustomize prod-mentolder/ | grep -c oauth2-proxy-dev` and `kubectl kustomize k3d/dev-stack/` both build clean today (baseline before changes).
+- [ ] Re-read `deploy/mcp/mcp-auth-proxy.yaml`, `deploy/mcp/ingress.yaml`, `deploy/mcp/mcp-tokens.yaml` — these are the templates being ported.
+
+---
+
+## Task 1 — Generate + register the dev MCP token (secret plumbing)
+
+- [ ] Add a `DEV_MCP_TOKEN` key to `environments/.secrets/mentolder.yaml` (gitignored). Generate with `openssl rand -hex 32`. (Operator action — file is off-limits to read/echo; ask the operator to add it, or add via an explicit instruction.)
+- [ ] In `Taskfile.dev-stack.yml`, extend the imperative secret materialisation (the step that creates `claude-code-secrets` for the monolith) to also create/patch a `mcp-tokens` Secret in `{{.NS_DEV}}` with key `CLUSTER_TOKEN` = `$DEV_MCP_TOKEN`, read from `environments/.secrets/mentolder.yaml` via the same parsing used for `DEV_SHARED_DB_PASSWORD`. Use `kubectl create secret generic mcp-tokens --from-literal=... --dry-run=client -o yaml | kubectl apply` for idempotency.
+- [ ] Verify: after a dev deploy, `kubectl --context k3d-mentolder-dev -n workspace-dev get secret mcp-tokens -o jsonpath='{.data.CLUSTER_TOKEN}' | base64 -d` is non-empty.
+
+**Note:** dev has no sealed-secrets controller — do NOT seal. This mirrors how `claude-code-secrets` is already made (`k3d/dev-stack/mcp-monolith-dev.yaml:11-13`).
+
+## Task 2 — Dev-side token ForwardAuth (`k3d/dev-stack/mcp-auth-proxy-dev.yaml`)
+
+- [ ] Port `deploy/mcp/mcp-auth-proxy.yaml` to a new `k3d/dev-stack/mcp-auth-proxy-dev.yaml`. Changes from the prod original:
+  - Single token tier: keep `CLUSTER_TOKEN` logic, **drop** `BUSINESS_TOKEN` (env, perl_set, and the business `if`-block).
+  - **Drop** the `node-location=hetzner` nodeAffinity (dev k3d is a single node).
+  - Keep the nginx ForwardAuth `/auth` (200 + `X-MCP-Role: cluster` / 401) and the `/healthz` endpoint, the `Authorization: Bearer` + `?token=` (`X-Forwarded-Uri`) fallback logic, the `mcp-tokens` Secret ref, ConfigMap mount, probes, resources.
+  - Resource names: ConfigMap `mcp-auth-proxy-dev-config`, Deployment/Service `mcp-auth-proxy-dev`.
+- [ ] Add `mcp-auth-proxy-dev.yaml` to `k3d/dev-stack/kustomization.yaml` `resources:`.
+
+## Task 3 — Dev-side routing + middleware (`k3d/dev-stack/mcp-ingress-dev.yaml`)
+
+- [ ] Create `k3d/dev-stack/mcp-ingress-dev.yaml` porting `deploy/mcp/ingress.yaml`, scoped to ns `workspace-dev`. Contents:
+  - `Middleware mcp-dev-forwardauth` → `forwardAuth.address: http://mcp-auth-proxy-dev:80/auth`, `authResponseHeaders: ["X-MCP-Role"]`.
+  - `Middleware mcp-dev-strip-auth-header` → strips `Authorization`, sets `Accept` (mirror prod `mcp-strip-auth-header`).
+  - One `Middleware` per service to strip the path prefix (`mcp-dev-strip-kubernetes` → stripPrefix `/kubernetes`, etc.) OR a single stripPrefix middleware per route — match whatever prod `mcp-strip-service-prefix` does. **Read prod first** to copy the exact stripPrefix style.
+  - `IngressRoute` `mcp-dev` on `entryPoints: [web]`, `Host(\`mcp.dev.mentolder.de\`)` with **four routes** (one per path prefix) — but note `${DEV_DOMAIN}` is `dev.mentolder.de`, so use `mcp.${DEV_DOMAIN}` via envsubst (see Task 5). Each route: `Host(\`mcp.${DEV_DOMAIN}\`) && PathPrefix(\`/postgres\`)` → service `claude-code-mcp-monolith:3001`, middlewares `[forwardauth, strip-auth, strip-postgres]`. Set route `priority` high enough to beat `sish-catchall` (priority 1) — e.g. 10.
+  - Map: `/kubernetes`→8080, `/postgres`→3001, `/github`→3002, `/browser`→3000.
+- [ ] Add `mcp-ingress-dev.yaml` to `k3d/dev-stack/kustomization.yaml` `resources:` (after the wildcard ingress so it is unambiguous).
+
+## Task 4 — Prod bridge: skip-auth on `oauth2-proxy-dev`
+
+- [ ] Edit `prod-mentolder/oauth2-proxy-dev.yaml` args list (after line 90, `--keycloak-group=/dev-access`): add
+  `--skip-auth-route=^/(kubernetes|postgres|github|browser)(/|$)`.
+  (oauth2-proxy v7.9.0 accepts repeatable `--skip-auth-route=<path_regex>`; a single regex covering all four prefixes is sufficient.)
+- [ ] Confirm this does NOT widen real-app auth: the skipped paths only reach an MCP backend on the `mcp.dev` host inside k3d; `web.dev`/`brett.dev` define no such paths and 404 at k3d. Document this in a manifest comment.
+
+## Task 5 — envsubst wiring
+
+- [ ] `mcp-ingress-dev.yaml` references `mcp.${DEV_DOMAIN}` → confirm `$DEV_DOMAIN` is already in the `dev:apply` envsubst list (`Taskfile.dev-stack.yml`); it is. No new var needed unless a literal host is used (prefer `${DEV_DOMAIN}`).
+- [ ] `prod-mentolder/oauth2-proxy-dev.yaml` change introduces no new `${VAR}` — no prod envsubst list change.
+
+## Task 6 — Structural test (TDD-ish, offline)
+
+- [ ] Add a BATS test (`tests/...` per existing kustomize-structure test conventions) that runs `kubectl kustomize k3d/dev-stack/` (with the dev envsubst vars set to placeholders) and asserts:
+  - an `IngressRoute` named `mcp-dev` exists with a `Host(...mcp...)` match and references `mcp-auth-proxy-dev`,
+  - a Deployment `mcp-auth-proxy-dev` exists,
+  - the four path prefixes (`/kubernetes /postgres /github /browser`) are present.
+- [ ] Add an assertion that `kubectl kustomize prod-mentolder/` output for `oauth2-proxy-dev` contains the `--skip-auth-route` arg.
+- [ ] Run `task test:inventory && git diff --exit-code website/src/data/test-inventory.json` — regenerate + stage if it changed.
+- [ ] `./tests/runner.sh local <new-test-id>` → expect PASS after Tasks 2–4; capture output.
+
+## Task 7 — Deploy + live verification (post-merge, both layers)
+
+- [ ] Prod layer: `task workspace:deploy ENV=mentolder` (applies the oauth2-proxy-dev arg change). Verify the pod rolled (`Recreate` strategy) and is Ready: `kubectl --context mentolder -n workspace rollout status deploy/oauth2-proxy-dev`.
+- [ ] Dev layer: `task dev:apply` (or the appropriate `dev:redeploy`/`dev:deploy` task per the oracle) against `k3d-mentolder-dev`. Verify `mcp-auth-proxy-dev` pod Ready and the `mcp-dev` IngressRoute present.
+- [ ] Acceptance checks (from the spec):
+  - `curl -s -o /dev/null -w '%{http_code}' https://mcp.dev.mentolder.de/postgres/mcp` → **401** (token gate, not 302 OIDC, not 404).
+  - `POST .../postgres/mcp?token=$DEV_MCP_TOKEN` with an MCP `initialize` body → valid `initialize` result.
+  - repeat for `/kubernetes/mcp` and `/github/mcp`.
+  - `curl -sI https://web.dev.mentolder.de/` still 302→Keycloak (SSO intact).
+- [ ] Note: mentolder DNS round-robins three IPs incl. the dead fleet `204.168.244.104` — if a check flakes, retry / `--resolve` to a live IP. (Pre-existing; logged as mishap.)
+
+## Task 8 — Client registration + docs
+
+- [ ] Print the `claude mcp add --transport http -s user` commands for each of the four endpoints with `?token=$DEV_MCP_TOKEN`, for the operator to run. (A newly added MCP server connects on the **next** Claude Code session, not mid-session.)
+- [ ] Add a short "dev MCP monolith — public access" subsection to `docs/dev-stack/README.md` documenting the URL pattern, the token location, and the skip-auth carve-out.
+- [ ] Update `CLAUDE.md` §Gotchas (dev.mentolder.de stack) with a one-liner: `mcp.dev.mentolder.de` is token-gated (dev-side ForwardAuth) and skip-auth'd at oauth2-proxy-dev — not OIDC-gated.
+
+---
+
+## Rollback
+
+- Prod: remove the `--skip-auth-route` arg, redeploy `oauth2-proxy-dev` → MCP paths fall back under the OIDC gate (route becomes unreachable to token clients, fail-closed).
+- Dev: drop `mcp-ingress-dev.yaml` + `mcp-auth-proxy-dev.yaml` from `k3d/dev-stack/kustomization.yaml`, re-apply. Monolith returns to ClusterIP-only. No data touched.
+
+## Risks / watch-items
+
+- **Shared oauth2-proxy-dev change** affects all `*.dev` hosts (path-scoped). Verify SSO still gates real app paths (acceptance check). Reversible.
+- **Fleet Phase-2a interaction:** `prod-fleet/mentolder` already excludes the 8 dev.mentolder.de resources (incl. `oauth2-proxy-dev`) from the fleet overlay, so the arg change does not propagate to fleet. No new prod resource is added, so nothing new for the fleet overlay to exclude. Confirm no merge collision with `feature/fleet-phase2-cutover`.
+- **Token in URL:** acceptable for `claude.ai`-style header-less clients; prefer the `Authorization: Bearer` form when the client supports it.

--- a/docs/superpowers/specs/2026-05-30-dev-mcp-public-route-design.md
+++ b/docs/superpowers/specs/2026-05-30-dev-mcp-public-route-design.md
@@ -1,0 +1,157 @@
+# Public token-authenticated route for the dev MCP monolith — Design Spec
+
+**Date:** 2026-05-30
+**Branch:** `feature/dev-mcp-public-route`
+**Author:** dev-flow-plan (straight-to-spec, approach pre-chosen by operator)
+
+## Problem
+
+The dev MCP monolith (`claude-code-mcp-monolith` in namespace `workspace-dev` on
+the `k3d-mentolder-dev` cluster, hosted as a k3d-in-k3s sibling on `k3s-1`) is
+healthy and speaks MCP correctly, but it is **ClusterIP-only**. There is no
+public route, so a Claude Code client on a workstation cannot reach it. The
+operator wants a **durable, token-authenticated** public endpoint
+(`mcp.dev.mentolder.de`) so the dev monolith's `kubernetes` / `postgres` /
+`github` / `browser` MCP servers are usable from any Claude Code client,
+surviving cluster/pod restarts — not a per-session SSH tunnel.
+
+### Verified current state (2026-05-30)
+
+- Monolith pod `claude-code-mcp-monolith` is **4/4 Running** in `workspace-dev`.
+- Health: postgres (`:3001/health`), browser (`:3000/health`), github
+  (`:3002/health`) all return `ok`; kubernetes (`:8080`) listens (TCP probe, no
+  `/health`).
+- postgres MCP completes a proper MCP `initialize` handshake over a port-forward
+  (`serverInfo: example-servers/postgres`, advertises tools + resources).
+- `mcp.dev.mentolder.de` resolves to the three mentolder Traefik IPs via the
+  `*.dev.mentolder.de` wildcard and is covered by the existing
+  `workspace-dev-wildcard-tls` cert. **No new DNS record or cert is required.**
+
+## Constraints discovered (the two-layer routing reality)
+
+External `*.dev.mentolder.de` traffic does **not** reach the k3d cluster
+directly. The path is:
+
+```
+client ──HTTPS──▶ prod Traefik (mentolder k3s, :443, valid wildcard cert)
+                   └─ Ingress workspace-ingress-dev  (host *.dev.mentolder.de + dev.mentolder.de)
+                       backend ──▶ Service oauth2-proxy-dev:4181
+                                    └─ oauth2-proxy-dev  (v7.9.0, reverse-proxy,
+                                       hostNetwork on k3s-1, OIDC /dev-access gate)
+                                        └─ --upstream http://127.0.0.1:18080  (k3d Traefik LB, localhost-only)
+                                            ├─ web.dev.mentolder.de   → website
+                                            ├─ brett.dev.mentolder.de → brett
+                                            └─ *.dev.mentolder.de     → sish catch-all (priority 1)
+```
+
+Key facts (file:line):
+
+- `prod-mentolder/dev-ingress.yaml:15-34` — native `Ingress` `workspace-ingress-dev`
+  matches `*.${DEV_DOMAIN}` **and** `${DEV_DOMAIN}`, both backing
+  `oauth2-proxy-dev:4181`. TLS = `workspace-dev-wildcard-tls`.
+- `prod-mentolder/oauth2-proxy-dev.yaml:65-96` — `oauth2-proxy-dev` is a **full
+  reverse proxy** (`--reverse-proxy=true --upstream=http://127.0.0.1:18080`),
+  `hostNetwork: true`, pinned `nodeSelector kubernetes.io/hostname=${DEV_NODE}`
+  (k3s-1), `hostPort 4181`, OIDC gate `--keycloak-group=/dev-access`. It is the
+  **only** bridge into k3d, and `127.0.0.1:18080` is localhost-only (a normal
+  pod cannot reach it — hostNetwork is mandatory).
+- `deploy/mcp/mcp-auth-proxy.yaml` — the prod MCP token gate is an **nginx
+  ForwardAuth** target: `/auth` returns 200 (with `X-MCP-Role`) or 401, reading
+  `Authorization: Bearer <tok>` or, as fallback for header-less clients,
+  `?token=` extracted from `X-Forwarded-Uri`. Tokens live in Secret `mcp-tokens`
+  (keys `CLUSTER_TOKEN`, `BUSINESS_TOKEN`).
+- `deploy/mcp/ingress.yaml:44-110` — prod `mcp.mentolder.de` IngressRoute applies
+  middleware chain `mcp-forwardauth → mcp-strip-auth-header → mcp-strip-service-prefix`,
+  path-routing `/kubernetes→8080 /postgres→3001 /browser→3000 /github→3002`,
+  entrypoints `web` + `websecure`.
+- `k3d/dev-stack/traefik-wildcard-ingress.yaml` — inside k3d, explicit hosts use
+  native `Ingress`; the catch-all is a Traefik `IngressRoute` `sish-catchall`
+  (`priority: 1`, entrypoint `web` only). **TLS is terminated at prod Traefik;
+  dev k3d runs plain HTTP on entrypoint `web`.**
+- `Taskfile.dev-stack.yml` — `dev:apply` runs `kubectl --context
+  k3d-mentolder-dev` over `k3d/dev-stack/`, envsubst vars `$DEV_DOMAIN
+  $DEV_WEBSITE_HOST $DEV_BRETT_HOST $PROD_DOMAIN $CONTACT_EMAIL`. Dev secrets are
+  **materialised imperatively** (`dev:_materialise-secrets`) from
+  `environments/.secrets/mentolder.yaml`; there is **no sealed-secrets
+  controller** in the dev k3d cluster.
+
+## Chosen approach — "B: skip-auth bridge + dev-side token gate"
+
+Keep the prod surface minimal and mirror the existing prod MCP pattern, but
+host the token gate + routing entirely **inside** the dev k3d cluster.
+
+1. **Bridge (prod, 2-line change):** Add `--skip-auth-route` entries to
+   `oauth2-proxy-dev` for the MCP path prefixes
+   (`^/(kubernetes|postgres|github|browser)(/|$)`). Skipped routes bypass the
+   OIDC gate but are **still reverse-proxied to `127.0.0.1:18080`** with the
+   original `Host` header intact. This is the only prod change and it is fully
+   reversible.
+
+2. **Token gate (dev k3d):** Port `deploy/mcp/mcp-auth-proxy.yaml` into
+   `k3d/dev-stack/` as `mcp-auth-proxy-dev` (nginx ForwardAuth, `/auth` →
+   200/401, Bearer or `?token=`). Single token tier (`CLUSTER_TOKEN`) is enough
+   for dev; drop the business tier.
+
+3. **Routing (dev k3d):** Add a Traefik `IngressRoute`
+   `Host(mcp.dev.mentolder.de)` on entrypoint `web` with middleware chain
+   `mcp-dev-forwardauth → mcp-dev-strip-auth-header → mcp-dev-strip-service-prefix`,
+   path-routing `/kubernetes→8080 /postgres→3001 /github→3002 /browser→3000`
+   (mirror prod). Priority above the `sish-catchall` (which is `priority: 1`).
+
+4. **Token secret (dev):** `mcp-tokens` Secret in `workspace-dev`, key
+   `CLUSTER_TOKEN`, materialised imperatively in the dev deploy step from a new
+   `DEV_MCP_TOKEN` key in `environments/.secrets/mentolder.yaml` (same mechanism
+   as `claude-code-secrets`). No sealing (dev has no controller).
+
+5. **Client registration:** Document `claude mcp add --transport http` commands
+   for `https://mcp.dev.mentolder.de/{kubernetes,postgres,github,browser}/mcp?token=<TOKEN>`.
+
+### Why not the alternatives
+
+- **A: dedicated hostNetwork token-bridge pod in prod** (parallel to
+  oauth2-proxy-dev, exact-host Ingress beats the wildcard). More isolated from
+  the shared SSO proxy, but adds a **new prod hostNetwork Deployment + Service +
+  Ingress + sealed secret + a second host port on k3s-1** — more prod surface to
+  maintain and for the in-flight fleet Phase-2a overlay to exclude. Rejected as
+  heavier for no real security gain (the token gate is the actual control in
+  both designs).
+- **Local SSH tunnel** — operator explicitly rejected (not durable).
+
+### Security notes
+
+- `--skip-auth-route` is **path-based and applies to every `*.dev` host**, not
+  just `mcp.dev`. This is acceptable: only the `mcp.dev.mentolder.de`
+  IngressRoute serves those paths inside k3d; the same paths on
+  `web.dev`/`brett.dev` have no backend and 404 at the k3d layer. The MCP itself
+  is gated by the dev-side token ForwardAuth.
+- The token is a bearer secret in the URL/header; it lives only in
+  `environments/.secrets/mentolder.yaml` (gitignored) and the materialised dev
+  Secret. Never committed.
+- postgres MCP reaches `shared-db-dev` (`/website` DB) which holds **prod-derived
+  data** (nightly refresh). Treat the token as production-sensitive.
+
+## Acceptance criteria
+
+- [ ] `curl https://mcp.dev.mentolder.de/postgres/mcp` **without** a token → 401
+      from the dev token gate (not an OIDC redirect, not a 404).
+- [ ] `POST https://mcp.dev.mentolder.de/postgres/mcp?token=<TOKEN>` with an MCP
+      `initialize` body → valid MCP `initialize` result (`example-servers/postgres`).
+- [ ] Same handshake succeeds for `/kubernetes/mcp` and `/github/mcp` with a
+      valid token.
+- [ ] An OIDC browser visit to `web.dev.mentolder.de` still requires
+      `/dev-access` login (skip-auth did not widen the SSO bypass for real app
+      paths).
+- [ ] `task test:all` green; `task workspace:validate` green (kustomize builds
+      for `prod-mentolder/` and `k3d/dev-stack/`).
+- [ ] A BATS/structural test asserts the `mcp.dev` IngressRoute + ForwardAuth
+      chain exist in the rendered `k3d/dev-stack` kustomize output.
+
+## Out of scope
+
+- Korczewski / fleet dev MCP (mentolder dev only).
+- Repairing the **prod** `mcp.mentolder.de` 404 (separate issue — logged as a
+  mishap).
+- The stale fleet IP `204.168.244.104` in mentolder DNS (pre-existing DNS
+  hygiene — logged as a mishap; ~1/3 of requests to any mentolder hostname hit a
+  dead IP).
+- Multi-tier (business) tokens in dev.

--- a/k3d/dev-stack/kustomization.yaml
+++ b/k3d/dev-stack/kustomization.yaml
@@ -9,4 +9,6 @@ resources:
   - sish.yaml
   - traefik-wildcard-ingress.yaml
   - mcp-monolith-dev.yaml
+  - mcp-auth-proxy-dev.yaml
+  - mcp-ingress-dev.yaml
 # images: populated by `task dev:deploy` with concrete tags at apply time.

--- a/k3d/dev-stack/mcp-auth-proxy-dev.yaml
+++ b/k3d/dev-stack/mcp-auth-proxy-dev.yaml
@@ -1,0 +1,141 @@
+# ════════════════════════════════════════════════════════════════════════════
+# mcp-auth-proxy-dev — token ForwardAuth gate for the dev MCP monolith.
+#
+# Ported from deploy/mcp/mcp-auth-proxy.yaml, adapted for the dev k3d stack:
+#   - single token tier (CLUSTER_TOKEN); the prod BUSINESS_TOKEN tier is dropped
+#   - no node-location=hetzner nodeAffinity (dev k3d is a single node)
+#
+# Traefik calls GET /auth (via the mcp-dev-chain middleware). 200 → request is
+# forwarded to the monolith; 401 → rejected. The token is read from
+# `Authorization: Bearer <tok>` or, for header-less clients, the ?token= query
+# param forwarded by Traefik as X-Forwarded-Uri.
+#
+# The mcp-tokens Secret (key CLUSTER_TOKEN) is materialised imperatively by
+# `_materialise-secrets` in Taskfile.dev-stack.yml from DEV_MCP_TOKEN — never
+# committed.
+# ════════════════════════════════════════════════════════════════════════════
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mcp-auth-proxy-dev-config
+data:
+  nginx.conf: |
+    load_module modules/ngx_http_perl_module.so;
+
+    env CLUSTER_TOKEN;
+
+    events {
+      worker_connections 128;
+    }
+
+    http {
+      perl_set $cluster_token 'sub { return $ENV{"CLUSTER_TOKEN"} // "" }';
+      # Fallback: extract ?token= from original request URI forwarded by Traefik ForwardAuth
+      perl_set $bearer_from_uri 'sub {
+        my $r = shift;
+        my $uri = $r->header_in("X-Forwarded-Uri") // "";
+        if ($uri =~ /[?&]token=([^&]+)/) { return $1; }
+        return "";
+      }';
+
+      server {
+        listen 80;
+
+        location = /healthz {
+          access_log off;
+          return 200 "OK\n";
+        }
+
+        location = /auth {
+          set $bearer "";
+          if ($http_authorization ~* "^Bearer\s+(.+)$") {
+            set $bearer $1;
+          }
+
+          # Fallback: token query param (for clients like claude.ai web that cannot set headers)
+          if ($bearer = "") {
+            set $bearer $bearer_from_uri;
+          }
+
+          # No token provided
+          if ($bearer = "") {
+            return 401 '{"error":"missing or invalid Authorization header"}\n';
+          }
+
+          # Unknown token
+          if ($bearer != $cluster_token) {
+            return 401 '{"error":"invalid token"}\n';
+          }
+
+          # Valid cluster token: allow everything
+          add_header X-MCP-Role "cluster" always;
+          return 200 '{"status":"ok","role":"cluster"}\n';
+        }
+      }
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mcp-auth-proxy-dev
+  labels:
+    app: mcp-auth-proxy-dev
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mcp-auth-proxy-dev
+  template:
+    metadata:
+      labels:
+        app: mcp-auth-proxy-dev
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.27-alpine-perl
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 80
+          env:
+            - name: CLUSTER_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: mcp-tokens
+                  key: CLUSTER_TOKEN
+          volumeMounts:
+            - name: config
+              mountPath: /etc/nginx/nginx.conf
+              subPath: nginx.conf
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 80
+            initialDelaySeconds: 2
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 80
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            requests:
+              memory: "16Mi"
+              cpu: "10m"
+            limits:
+              memory: "64Mi"
+      volumes:
+        - name: config
+          configMap:
+            name: mcp-auth-proxy-dev-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mcp-auth-proxy-dev
+spec:
+  selector:
+    app: mcp-auth-proxy-dev
+  ports:
+    - port: 80
+      targetPort: 80

--- a/k3d/dev-stack/mcp-ingress-dev.yaml
+++ b/k3d/dev-stack/mcp-ingress-dev.yaml
@@ -1,0 +1,100 @@
+# ════════════════════════════════════════════════════════════════════════════
+# mcp-ingress-dev — public token-authed route for the dev MCP monolith.
+# Access: https://mcp.${DEV_DOMAIN}/{kubernetes,postgres,github,browser}/mcp
+#
+# Ported from deploy/mcp/ingress.yaml, scoped to the dev k3d stack:
+#   - host is mcp.${DEV_DOMAIN} (envsubst), entryPoint `web` only (TLS is
+#     terminated at the prod Traefik layer; dev k3d runs plain HTTP)
+#   - keycloak route dropped (the dev monolith has no keycloak container)
+#   - ForwardAuth points at mcp-auth-proxy-dev (single CLUSTER_TOKEN tier)
+#
+# Reachability: prod Traefik → oauth2-proxy-dev (which --skip-auth-route's the
+# MCP path prefixes, see prod-mentolder/oauth2-proxy-dev.yaml) → 127.0.0.1:18080
+# (this k3d Traefik) → these routes. The token gate below is the real control.
+#
+# `mcp-auth-proxy-dev` MUST be addressed by FQDN: Traefik runs in kube-system,
+# so a short name would resolve there, not in workspace-dev.
+# ════════════════════════════════════════════════════════════════════════════
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: mcp-dev-forwardauth
+spec:
+  forwardAuth:
+    address: http://mcp-auth-proxy-dev.workspace-dev.svc.cluster.local:80/auth
+    authResponseHeaders:
+      - X-MCP-Role
+---
+# Strip first path segment: /postgres/mcp → /mcp
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: mcp-dev-strip-service-prefix
+spec:
+  stripPrefixRegex:
+    regex:
+      - "^/[^/]+"
+---
+# Strip Authorization (GitHub MCP rejects it as OAuth); force Accept.
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: mcp-dev-strip-auth-header
+spec:
+  headers:
+    customRequestHeaders:
+      Authorization: ""
+      Accept: "application/json, text/event-stream"
+---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: mcp-dev-chain
+spec:
+  chain:
+    middlewares:
+      - name: mcp-dev-forwardauth
+      - name: mcp-dev-strip-auth-header
+      - name: mcp-dev-strip-service-prefix
+---
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: mcp-dev
+spec:
+  entryPoints:
+    - web
+  routes:
+    # priority above the sish-catchall (priority 1) so the MCP host always wins.
+    - kind: Rule
+      match: Host(`mcp.${DEV_DOMAIN}`) && PathPrefix(`/kubernetes`)
+      priority: 100
+      middlewares:
+        - name: mcp-dev-chain
+      services:
+        - name: claude-code-mcp-monolith
+          port: 8080
+    - kind: Rule
+      match: Host(`mcp.${DEV_DOMAIN}`) && PathPrefix(`/postgres`)
+      priority: 100
+      middlewares:
+        - name: mcp-dev-chain
+      services:
+        - name: claude-code-mcp-monolith
+          port: 3001
+    - kind: Rule
+      match: Host(`mcp.${DEV_DOMAIN}`) && PathPrefix(`/github`)
+      priority: 100
+      middlewares:
+        - name: mcp-dev-chain
+      services:
+        - name: claude-code-mcp-monolith
+          port: 3002
+    - kind: Rule
+      match: Host(`mcp.${DEV_DOMAIN}`) && PathPrefix(`/browser`)
+      priority: 100
+      middlewares:
+        - name: mcp-dev-chain
+      services:
+        - name: claude-code-mcp-monolith
+          port: 3000

--- a/prod-mentolder/oauth2-proxy-dev.yaml
+++ b/prod-mentolder/oauth2-proxy-dev.yaml
@@ -88,6 +88,13 @@ spec:
             - --insecure-oidc-allow-unverified-email=true
             - --scope=openid email profile
             - --keycloak-group=/dev-access
+            # Bypass the OIDC gate for the dev MCP path prefixes so token-auth
+            # MCP clients (which cannot do the browser OIDC dance) reach the k3d
+            # cluster. Skipped requests are still reverse-proxied to 18080; the
+            # real control is the dev-side ForwardAuth (mcp-auth-proxy-dev).
+            # Path-scoped, so it only matters on the mcp.dev host — web.dev /
+            # brett.dev define no such backends and 404 at the k3d layer.
+            - --skip-auth-route=^/(kubernetes|postgres|github|browser)(/|$)
           env:
             - name: DEV_WORKSPACE_OIDC_SECRET
               valueFrom:

--- a/tests/unit/dev-mcp-route.bats
+++ b/tests/unit/dev-mcp-route.bats
@@ -1,0 +1,71 @@
+#!/usr/bin/env bats
+# ═══════════════════════════════════════════════════════════════════
+# dev-mcp-route.bats — Structural guard for the dev MCP public route
+# ═══════════════════════════════════════════════════════════════════
+# The dev MCP monolith (claude-code-mcp-monolith, ns workspace-dev) is
+# exposed at https://mcp.<DEV_DOMAIN>/{service}/mcp via:
+#   - a dev-side token ForwardAuth (mcp-auth-proxy-dev) + IngressRoute
+#     (mcp-dev) inside the k3d-mentolder-dev cluster, and
+#   - a --skip-auth-route carve-out on the prod oauth2-proxy-dev that
+#     bridges those MCP paths past the OIDC gate into the k3d cluster.
+# These assertions ensure both halves stay wired (T000352).
+# ═══════════════════════════════════════════════════════════════════
+
+load test_helper
+
+setup() {
+  export DEV_DIR="${PROJECT_DIR}/k3d/dev-stack"
+  export PROD_DIR="${PROJECT_DIR}/prod-mentolder"
+  export DEV_RENDERED="${BATS_TEST_TMPDIR}/dev-stack.yaml"
+  export PROD_RENDERED="${BATS_TEST_TMPDIR}/prod-mentolder.yaml"
+
+  if [[ ! -f "$DEV_RENDERED" ]]; then
+    kubectl kustomize "${DEV_DIR}" --load-restrictor=LoadRestrictionsNone > "$DEV_RENDERED" 2>&1 \
+      || { echo "dev-stack kustomize failed:" >&2; cat "$DEV_RENDERED" >&2; return 1; }
+  fi
+  if [[ ! -f "$PROD_RENDERED" ]]; then
+    kubectl kustomize "${PROD_DIR}" --load-restrictor=LoadRestrictionsNone > "$PROD_RENDERED" 2>&1 \
+      || { echo "prod-mentolder kustomize failed:" >&2; cat "$PROD_RENDERED" >&2; return 1; }
+  fi
+}
+
+@test "dev-stack renders the mcp-auth-proxy-dev Deployment" {
+  run grep -E "name: mcp-auth-proxy-dev$" "$DEV_RENDERED"
+  assert_success
+}
+
+@test "dev-stack mcp-auth-proxy-dev reads CLUSTER_TOKEN from the mcp-tokens secret" {
+  run grep -E "name: mcp-tokens" "$DEV_RENDERED"
+  assert_success
+  run grep -E "key: CLUSTER_TOKEN" "$DEV_RENDERED"
+  assert_success
+}
+
+@test "dev-stack renders the mcp-dev IngressRoute on the mcp host" {
+  run grep -E "name: mcp-dev$" "$DEV_RENDERED"
+  assert_success
+  # host is mcp.<DEV_DOMAIN> — the ${DEV_DOMAIN} placeholder is envsubst'd at apply time
+  run grep -E "Host\(.mcp\." "$DEV_RENDERED"
+  assert_success
+}
+
+@test "dev-stack mcp-dev routes all four MCP path prefixes to the monolith" {
+  for prefix in kubernetes postgres github browser; do
+    run grep -F "PathPrefix(\`/${prefix}\`)" "$DEV_RENDERED"
+    assert_success
+  done
+  run grep -E "name: claude-code-mcp-monolith" "$DEV_RENDERED"
+  assert_success
+}
+
+@test "dev-stack mcp-dev wires the ForwardAuth chain to mcp-auth-proxy-dev" {
+  run grep -E "mcp-auth-proxy-dev.workspace-dev.svc.cluster.local" "$DEV_RENDERED"
+  assert_success
+  run grep -E "name: mcp-dev-chain" "$DEV_RENDERED"
+  assert_success
+}
+
+@test "prod oauth2-proxy-dev carves out the MCP paths via --skip-auth-route" {
+  run grep -F -- "--skip-auth-route=^/(kubernetes|postgres|github|browser)" "$PROD_RENDERED"
+  assert_success
+}


### PR DESCRIPTION
## Summary
- Exposes the dev MCP monolith (`claude-code-mcp-monolith`, ns `workspace-dev`, k3d-mentolder-dev) at `https://mcp.<DEV_DOMAIN>/{kubernetes,postgres,github,browser}/mcp` so Claude Code clients can use it durably (no per-session SSH tunnel).
- **dev k3d:** `mcp-auth-proxy-dev` (nginx ForwardAuth, single `CLUSTER_TOKEN` tier) + `mcp-dev` IngressRoute path-routing to the monolith via a strip-prefix/forward-auth chain — ported from the prod `deploy/mcp/` pattern.
- **prod bridge:** one `--skip-auth-route` arg on `oauth2-proxy-dev` carves the MCP path prefixes past the OIDC `/dev-access` gate into the k3d cluster (the only hostNetwork bridge to `127.0.0.1:18080`). The dev-side token gate is the real control; `web.dev`/`brett.dev` define no such paths and 404 at k3d.
- `mcp-tokens` secret materialised from `DEV_MCP_TOKEN` in `_materialise-secrets`. `mcp.dev.mentolder.de` already resolves via the `*.dev` wildcard + cert — no new DNS/cert.

Plan: `docs/superpowers/plans/2026-05-30-dev-mcp-public-route.md` · Ticket: T000352

## Test plan
- [x] `task test:all` (incl. new `tests/unit/dev-mcp-route.bats`, 6/6)
- [x] `task workspace:validate`
- [x] `kubectl kustomize` builds clean for `k3d/dev-stack/` and `prod-mentolder/`
- [ ] Post-merge live: 401 without token, valid MCP `initialize` with token on /postgres /kubernetes /github; SSO still gates `web.dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)