### PR TITLE
chore(skills): fix kubectl stderr, unit tier, dev-deploy bootstrap [T000355 T000356 T000359 T000361 T000350]

### DIFF
--- a/.claude/skills/dev-flow-execute/SKILL.md
+++ b/.claude/skills/dev-flow-execute/SKILL.md
@@ -218,7 +218,7 @@ Falls `$TICKET_ID` gesetzt:
 PGPOD=$(kubectl get pod -n workspace --context mentolder \
   -l app=shared-db -o name | head -1)
 
-kubectl exec "$PGPOD" -n workspace --context mentolder -- \
+kubectl exec "$PGPOD" -n workspace --context mentolder -c postgres -- \
   psql -U website -d website -At -c \
   "UPDATE tickets.tickets SET status = 'in_progress'
    WHERE external_id = '$TICKET_ID';"
@@ -308,6 +308,8 @@ task workspace:validate
 ./tests/runner.sh local <FA-XX oder SA-XX oder NFA-XX>   # falls relevant
 task test:all
 ```
+
+> **Strukturelle/Offline-Tests ohne k3d:** `./tests/runner.sh unit <test-id>` überspringt `k3d_wait` und Port-Forwards — ideal für reine BATS-Unit-Tests die keinen Live-Cluster brauchen. Direktaufruf als letzter Ausweg: `tests/unit/lib/bats-core/bin/bats tests/unit/<file>.bats`.
 
 > **`task test:all` exit 128 im Worktree (erster Lauf):** Kann beim ersten Aufruf transient mit exit 128 auf `test:art-library` fehlschlagen — Ursache ist eine Race-Condition zwischen `npm install` und dem BATS-Submodul-Check. Einfach nochmal ausführen; zweiter Lauf läuft durch. [T000218]
 
@@ -501,7 +503,7 @@ PR_NUM=$(gh pr view --json number -q '.number')
 PGPOD=$(kubectl get pod -n workspace --context mentolder \
   -l app=shared-db -o name | head -1)
 
-kubectl exec "$PGPOD" -n workspace --context mentolder -- \
+kubectl exec "$PGPOD" -n workspace --context mentolder -c postgres -- \
   psql -U website -d website -c \
   "UPDATE tickets.tickets
      SET status = 'done', resolution = '$RESOLUTION'
@@ -575,7 +577,7 @@ fi
 PGPOD=$(kubectl get pod -n workspace --context mentolder \
   -l app=shared-db -o name | head -1)
 
-TICKET_UUID=$(kubectl exec "$PGPOD" -n workspace --context mentolder -- \
+TICKET_UUID=$(kubectl exec "$PGPOD" -n workspace --context mentolder -c postgres -- \
   psql -U website -d website -At -c \
   "SELECT id FROM tickets.tickets WHERE external_id = '$TICKET_ID';")
 
@@ -599,7 +601,7 @@ if (( ARCHIVE_BYTES < 200 )); then
   exit 1
 fi
 
-kubectl exec -i "$PGPOD" -n workspace --context mentolder -- \
+kubectl exec -i "$PGPOD" -n workspace --context mentolder -c postgres -- \
   psql -U website -d website -v ON_ERROR_STOP=1 < "$TMPFILE"
 
 rm "$TMPFILE"
@@ -607,7 +609,7 @@ rm "$TMPFILE"
 # Verify the row actually persisted BEFORE removing the plan file (T000344).
 # A parallel-tool-call cancellation can drop the INSERT silently; if we rm the
 # file anyway the plan is lost until recovered from git history.
-ARCHIVED_ROWS=$(kubectl exec "$PGPOD" -n workspace --context mentolder -- \
+ARCHIVED_ROWS=$(kubectl exec "$PGPOD" -n workspace --context mentolder -c postgres -- \
   psql -U website -d website -At -c \
   "SELECT count(*) FROM tickets.ticket_plans WHERE ticket_id='$TICKET_UUID' AND slug='$SLUG';")
 if [[ "$ARCHIVED_ROWS" -lt 1 ]]; then
@@ -709,6 +711,17 @@ Schau dir die geänderten Dateien an (`gh pr view <pr> --json files`) und führe
 
 Wenn mehrere Kategorien matchen: workspace → website → brett → livekit → docs.
 
+> **`prod-mentolder/dev-*` geändert aber dev-auto-deploy bricht fehl (~/Bachelorprojekt fehlt):** Falls `dev-auto-deploy.yml` mit `cd: /home/.../Bachelorprojekt: No such file or directory` fehlschlägt, ist das Repo auf dem Deploy-Host nicht geclont. Manueller Fallback:
+> ```bash
+> # Kustomize lokal rendern und per SSH an k3s-1 übergeben
+> source scripts/env-resolve.sh dev
+> kubectl kustomize prod-mentolder | envsubst "..." | \
+>   ssh -i ~/.ssh/gekko_id_ed25519 gekko@k3s-1 \
+>   "kubectl --context k3d-mentolder-dev apply -f -"
+> # Secrets ggf. separat via SSH-Pipe materialisieren (kein Echo im Log)
+> ```
+> Alternativ direkt auf k3s-1 einloggen (`ssh gekko@k3s-1`) und `task dev:deploy` nach manuellem `git clone`.
+
 **Verify:**
 - Copy/Visual-Änderungen: Screenshot via Playwright.
 - Funktionale Änderungen: `./tests/runner.sh local <FA-XX>` gegen Live-URL.
@@ -722,14 +735,14 @@ Wenn mehrere Kategorien matchen: workspace → website → brett → livekit →
 - **Beweismaterial ans Ticket hängen (bei jedem Failure-Pfad):** Wenn du einen Failure-Screenshot, Log-Auszug oder Trace-Output hast, frage Patrick nach Pfaden (`.png`/`.log`/`.txt`/`.mp4`) und hänge sie ans Ticket — der Fix-Branch erbt dann sofort den Kontext:
   ```bash
   # TICKET_UUID aus dem aktuellen Ticket holen:
-  TICKET_UUID=$(kubectl exec "$PGPOD" -n workspace --context mentolder -- \
+  TICKET_UUID=$(kubectl exec "$PGPOD" -n workspace --context mentolder -c postgres -- \
     psql -U website -d website -At -c \
     "SELECT id FROM tickets.tickets WHERE external_id='$TICKET_ID';")
   bash scripts/ticket-attach.sh "$TICKET_UUID" /pfad/zu/failure.png /pfad/zu/ci.log
   ```
 - **CI rot vor Merge:** Diagnose, Fix auf demselben Branch, neu pushen. Keinen zweiten PR aufmachen. Falls nach 2 Versuchen noch rot: Ticket-Kommentar hinterlassen:
   ```bash
-  kubectl exec "$PGPOD" -n workspace --context mentolder -- \
+  kubectl exec "$PGPOD" -n workspace --context mentolder -c postgres -- \
     psql -U website -d website -c \
     "INSERT INTO tickets.ticket_comments (ticket_id, author_label, body, visibility)
      SELECT id,

--- a/.claude/skills/dev-flow-plan/SKILL.md
+++ b/.claude/skills/dev-flow-plan/SKILL.md
@@ -130,7 +130,7 @@ export GRILLING_ASSETS_TODO="<ZU-BESCHAFFEN-Liste>"
 PGPOD=$(kubectl get pod -n workspace --context mentolder \
   -l app=shared-db -o name | head -1)
 
-TICKET_RESULT=$(kubectl exec "$PGPOD" -n workspace --context mentolder -- \
+TICKET_RESULT=$(kubectl exec "$PGPOD" -n workspace --context mentolder -c postgres -- \
   psql -U website -d website -At -c \
   "INSERT INTO tickets.tickets (type, brand, title, description, status)
    VALUES (
@@ -519,7 +519,7 @@ Als allererstes nach dem Compact — vor `superpowers:writing-plans` — ausfüh
 # Ticket-Content aus DB holen (für jede ID in REINJECT_TICKETS)
 PGPOD=$(kubectl get pod -n workspace --context mentolder -l app=shared-db -o name | head -1)
 for TID in "${REINJECT_TICKETS[@]}"; do
-  kubectl exec "$PGPOD" -n workspace --context mentolder -- \
+  kubectl exec "$PGPOD" -n workspace --context mentolder -c postgres -- \
     psql -U website -d website -At -c \
     "SELECT '=== ' || external_id || ' ===' || E'\nTitle: ' || title
             || E'\n\n' || COALESCE(description,'(kein Inhalt)')
@@ -559,7 +559,7 @@ if [[ -n "${GRILLING_TICKET_EXT_ID:-}" ]]; then
   GRILLING_REF=$'\n'"Grilling-Ticket: ${GRILLING_TICKET_EXT_ID}"
 fi
 
-TICKET_RESULT=$(kubectl exec "$PGPOD" -n workspace --context mentolder -- \
+TICKET_RESULT=$(kubectl exec "$PGPOD" -n workspace --context mentolder -c postgres -- \
   psql -U website -d website -At -c \
   "INSERT INTO tickets.tickets (type, brand, title, description, status)
    VALUES (
@@ -657,7 +657,7 @@ Frage den User nach der Ticket-ID (Format: `T######`, z.B. `T000288`).
 
 ```bash
 PGPOD=$(kubectl get pod -n workspace --context mentolder -l app=shared-db -o name | head -1)
-TICKET_UUID=$(kubectl exec "$PGPOD" -n workspace --context mentolder -- \
+TICKET_UUID=$(kubectl exec "$PGPOD" -n workspace --context mentolder -c postgres -- \
   psql -U website -d website -At -c \
   "SELECT id FROM tickets.tickets WHERE external_id='$TICKET_EXT_ID';")
 ```
@@ -684,7 +684,7 @@ Falls `.txt`/`.log`/`.md`/`.png`/`.jpg`: zusätzlich vor der Ticket-Anlage `Read
 PGPOD=$(kubectl get pod -n workspace --context mentolder \
   -l app=shared-db -o name | head -1)
 
-TICKET_RESULT=$(kubectl exec "$PGPOD" -n workspace --context mentolder -- \
+TICKET_RESULT=$(kubectl exec "$PGPOD" -n workspace --context mentolder -c postgres -- \
   psql -U website -d website -At -c \
   "INSERT INTO tickets.tickets (type, brand, title, description, status, severity, priority)
    VALUES (

--- a/.claude/skills/operations-management/SKILL.md
+++ b/.claude/skills/operations-management/SKILL.md
@@ -32,7 +32,7 @@ Never use `tickets.ticket_links` for PR references — it is ticket→ticket onl
 All SQL below assumes:
 ```bash
 PGPOD=$(kubectl get pod -n workspace --context mentolder -l app=shared-db -o name | head -1)
-psql() { kubectl exec "$PGPOD" -n workspace --context mentolder -- psql -U website -d website "$@"; }
+psql() { kubectl exec "$PGPOD" -n workspace --context mentolder -c postgres -- psql -U website -d website "$@"; }
 ```
 
 ---
@@ -52,7 +52,7 @@ Determine:
 Create a ticket in the database:
 ```bash
 PGPOD=$(kubectl get pod -n workspace --context mentolder -l app=shared-db -o name | head -1)
-kubectl exec "$PGPOD" -n workspace --context mentolder -- psql -U website -d website -At -c \
+kubectl exec "$PGPOD" -n workspace --context mentolder -c postgres -- psql -U website -d website -At -c \
   "INSERT INTO tickets.tickets (type, brand, title, description, status, severity, priority)
    VALUES ('bug', 'mentolder', 'Incident: <desc>', 'Affected: <svc>\nCluster: <env>\nSymptoms: <symptoms>', 'in_progress', '<critical|major|minor>', 'hoch')
    RETURNING external_id;"
@@ -183,7 +183,7 @@ Convert local execution `MISHAP_LOG` entries into tickets.
 For each entry in the log:
 ```bash
 PGPOD=$(kubectl get pod -n workspace --context mentolder -l app=shared-db -o name | head -1)
-kubectl exec "$PGPOD" -n workspace --context mentolder -- psql -U website -d website -At -c \
+kubectl exec "$PGPOD" -n workspace --context mentolder -c postgres -- psql -U website -d website -At -c \
   "INSERT INTO tickets.tickets (type, brand, title, description, severity, status, component)
    VALUES ('<type>', 'mentolder', '<title>', '<description>', '<severity>', 'triage', '<component>')
    RETURNING external_id;"

--- a/.claude/skills/superpowers/using-git-worktrees/SKILL.md
+++ b/.claude/skills/superpowers/using-git-worktrees/SKILL.md
@@ -110,3 +110,16 @@ in new worktree…" the hook fired (Claude Code only).
 (see Post-Create Checklist above). The `dev-flow-plan` SKILL.md (manual worktree
 path, lines ~128–130) already includes `git submodule update --init --recursive`
 in the worktree-add block — follow that pattern exactly (T000107).
+
+## Concurrent-Session Safety (T000350)
+
+**Never run `git checkout`, `git reset`, `git stash`, or `git rebase` in the
+shared primary worktree (`/home/patrick/Bachelorprojekt`) when another session
+may be active on a different branch.** These commands silently retarget HEAD and
+cause PR/branch operations that omit `--head` to resolve against the wrong branch.
+
+Rules:
+- Any subagent that mutates git state (checkout, rebase, stash) **must** operate
+  in an isolated `/tmp/wt-*` worktree, never the primary repo.
+- Always pass `--head <branch>` explicitly on `gh pr create` and `gh pr merge`
+  — never rely on the ambient current branch.

--- a/.github/workflows/dev-auto-deploy.yml
+++ b/.github/workflows/dev-auto-deploy.yml
@@ -56,6 +56,9 @@ jobs:
           command_timeout: 20m
           script: |
             set -e
+            if [ ! -d ~/Bachelorprojekt ]; then
+              git clone --depth 1 https://github.com/Paddione/Bachelorprojekt.git ~/Bachelorprojekt
+            fi
             cd ~/Bachelorprojekt
             git fetch --depth 1 origin main
             git reset --hard origin/main

--- a/tests/runner.sh
+++ b/tests/runner.sh
@@ -37,12 +37,12 @@ export FAIL_FAST="${FAIL_FAST:-false}"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    local|prod|report) TIER="$1"; shift ;;
+    local|prod|report|unit) TIER="$1"; shift ;;
     --verbose) export VERBOSE="true"; shift ;;
     --fail-fast) export FAIL_FAST="true"; shift ;;
     -j|--jobs) export JOBS="$2"; shift 2 ;;
     -h|--help)
-      echo "Usage: $0 <local|prod|report> [TEST_IDS...] [--verbose] [-j|--jobs N]"
+      echo "Usage: $0 <local|prod|unit|report> [TEST_IDS...] [--verbose] [-j|--jobs N]"
       echo "  -j N, --jobs N        Parallel jobs (default: nproc/2, max 4)"
       echo "  --fail-fast           Abort on first failure"
       exit 0 ;;
@@ -52,7 +52,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [[ -z "$TIER" ]]; then
-  echo "Error: Tier required. Usage: $0 <local|prod|report>"
+  echo "Error: Tier required. Usage: $0 <local|prod|unit|report>"
   exit 1
 fi
 
@@ -163,6 +163,24 @@ if [[ "$TIER" == "report" ]]; then
     md_file="${json_file%.json}.md"
     generate_markdown "$json_file" "$md_file"
   done
+  exit 0
+fi
+
+# ── Unit-only mode (no cluster required) ─────────────────────────
+# Runs tests/unit/ BATS files directly without k3d_wait or port-forwards.
+# Use for structural/offline tests that don't need a live cluster.
+if [[ "$TIER" == "unit" ]]; then
+  check_prereqs
+  mkdir -p "$RESULTS_DIR"
+  DATE_TAG=$(date +%Y-%m-%d)
+  export RESULTS_FILE="${RESULTS_DIR}/.tmp-unit-${DATE_TAG}.jsonl"
+  > "$RESULTS_FILE"
+  echo "═══════════════════════════════════════════════════════════════"
+  echo "  Workspace MVP — Test Runner (unit / offline)"
+  echo "  $(date -u '+%Y-%m-%d %H:%M:%S UTC')"
+  echo "═══════════════════════════════════════════════════════════════"
+  run_test_files "${SCRIPT_DIR}/unit"
+  generate_summary "$RESULTS_FILE"
   exit 0
 fi
 


### PR DESCRIPTION
## Summary

- **T000355**: Add `-c postgres` to all `kubectl exec` shared-db calls in dev-flow-plan, dev-flow-execute, and operations-management skills — silences the "Defaulted container" stderr that was corrupting `external_id` parsing
- **T000356**: Add `git clone` bootstrap step in `dev-auto-deploy.yml` so the deploy succeeds on first run when `~/Bachelorprojekt` is missing on the deploy host
- **T000359**: Document manual dev-stack deploy fallback in dev-flow-execute Schritt 8 for when `dev-auto-deploy` is broken
- **T000361**: Add `unit` tier to `tests/runner.sh` that skips `k3d_wait` and port-forwards — structural BATS tests no longer hang waiting for Keycloak; add tip to dev-flow-execute skill
- **T000350**: Document concurrent-session git-safety rules in using-git-worktrees skill — git-mutating subagents must use isolated worktrees; `gh pr` ops must always pass `--head` explicitly

## Test plan

- [ ] CI passes (offline tests, kustomize validate — no manifest changes)
- [ ] `./tests/runner.sh unit` exits without waiting for k3d
- [ ] Next `dev-auto-deploy` push succeeds when repo was missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)