### PR TITLE
fix(netpol): add fleet wg-mesh ipBlock to signaling-coturn-egress

### DIFF
--- a/k3d/network-policies.yaml
+++ b/k3d/network-policies.yaml
@@ -265,6 +265,12 @@ spec:
     ports:
     - port: 8188
       protocol: TCP
+  - to:
+    - ipBlock:
+        cidr: 10.20.0.0/24    # fleet wg-mesh node IPs (Janus hostNetwork on pk-hetzner-4)
+    ports:
+    - port: 8188
+      protocol: TCP
 ---
 # Nextcloud → Collabora (workspace-office Namespace, WOPI Port 9980)
 apiVersion: networking.k8s.io/v1


### PR DESCRIPTION
## Summary
- `allow-signaling-coturn-egress` NetworkPolicy was missing `10.20.0.0/24` (fleet WireGuard mesh) from its ipBlock allowlist
- kube-router enforces egress policy in the INPUT chain **after** kube-proxy DNAT — so the destination it sees is the Janus hostNetwork IP (`10.20.0.1`) not the ClusterIP (`10.43.71.32`)
- Without this range, kube-router REJECTs every Janus WebSocket connection, causing `spreed-signaling` to loop with "connection refused" despite Janus listening
- The existing `10.13.14.0/24` covers the old korczewski standalone wg-mesh; this adds the equivalent for the unified `fleet` cluster
- Applied live imperatively (`kubectl patch`) to both `workspace` and `workspace-korczewski` before this commit — both `spreed-signaling` pods are now `1/1 Ready`

## Root cause trace
1. Janus uses `hostNetwork: true`, pinned to pk-hetzner-4 (wg-fleet IP `10.20.0.1`)
2. kube-proxy DNAT: ClusterIP `10.43.71.32:8188` → `10.20.0.1:8188`
3. Filter INPUT chain sees src=pod, dst=`10.20.0.1:8188`
4. kube-router `KUBE-POD-FW` chain runs `allow-signaling-coturn-egress` policy
5. `10.20.0.1` ∉ any allowed destination → REJECT

## Test plan
- `task test:all` ✓ green
- `task workspace:validate` ✓ green
- Live: both `spreed-signaling` pods in `workspace` and `workspace-korczewski` now `1/1 Running` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)