### PR TITLE
fix(fleet): correct Collabora hosts/TLS in fleet:shared-services [T000366]

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1531,24 +1531,39 @@ tasks:
       - |
         set -euo pipefail
         kubectl config use-context fleet
+        # --- TLS cert sync: copy wildcard certs to workspace-office and coturn ---
+        # tls-sync-manual runs before certs are issued; sync here as a fallback.
+        for NS in workspace-office coturn; do
+          kubectl --context fleet get secret workspace-wildcard-tls -n workspace -o json \
+            | jq --arg ns "$NS" 'del(.metadata.resourceVersion,.metadata.uid,.metadata.creationTimestamp,.metadata.managedFields,.metadata.annotations) | .metadata.namespace = $ns' \
+            | kubectl --context fleet apply -f - || echo "warn: failed to sync workspace-wildcard-tls to $NS"
+          kubectl --context fleet get secret korczewski-tls -n workspace-korczewski -o json \
+            | jq --arg ns "$NS" 'del(.metadata.resourceVersion,.metadata.uid,.metadata.creationTimestamp,.metadata.managedFields,.metadata.annotations) | .metadata.namespace = $ns' \
+            | kubectl --context fleet apply -f - || echo "warn: failed to sync korczewski-tls to $NS"
+        done
         # --- Collabora (shared, dual-host) ---
         # Primary host vars from fleet-mentolder; second host from fleet-korczewski.
         source scripts/env-resolve.sh fleet-mentolder
-        export COLLABORA_HOST="collabora.${PROD_DOMAIN}"
-        export COLLABORA_SERVER_NAME="collabora.${PROD_DOMAIN}"
-        export COLLABORA_ALIASGROUP1="https://cloud\\.${PROD_DOMAIN}:443"
+        export COLLABORA_HOST="office.${PROD_DOMAIN}"
+        export COLLABORA_SERVER_NAME="office.${PROD_DOMAIN}"
+        export COLLABORA_ALIASGROUP1="https://files\\.${PROD_DOMAIN}:443"
         export COLLABORA_SSL_TERMINATION="true"
-        export COLLABORA_TLS_SECRET="collabora-tls"
+        export COLLABORA_TLS_SECRET="workspace-wildcard-tls"
         export COLLABORA_INGRESS_MIDDLEWARES="workspace-redirect-https@kubernetescrd,workspace-hsts-headers@kubernetescrd"
         # Capture mentolder TURN vars BEFORE re-sourcing korczewski.
         MENTOLDER_TURN_NODE="$TURN_NODE"; MENTOLDER_TURN_PUBLIC_IP="${TURN_PUBLIC_IP:-$LIVEKIT_PIN_IP}"
         MENTOLDER_TLS_SECRET_NAME="${TLS_SECRET_NAME:-workspace-tls}"; MENTOLDER_PROD_DOMAIN="$PROD_DOMAIN"
-        ( source scripts/env-resolve.sh fleet-korczewski; echo "collabora.${PROD_DOMAIN}|https://cloud\\.${PROD_DOMAIN}:443" ) > /tmp/_kore_collabora.txt
+        ( source scripts/env-resolve.sh fleet-korczewski; echo "office.${PROD_DOMAIN}|https://files\\.${PROD_DOMAIN}:443" ) > /tmp/_kore_collabora.txt
         export COLLABORA_HOST_2="$(cut -d'|' -f1 /tmp/_kore_collabora.txt)"
         export COLLABORA_ALIASGROUP2="$(cut -d'|' -f2 /tmp/_kore_collabora.txt)"
         kustomize build k3d/office-stack \
           | envsubst '$PROD_DOMAIN $COLLABORA_HOST $COLLABORA_HOST_2 $COLLABORA_ALIASGROUP1 $COLLABORA_ALIASGROUP2 $COLLABORA_SERVER_NAME $COLLABORA_SSL_TERMINATION $COLLABORA_TLS_SECRET $COLLABORA_INGRESS_MIDDLEWARES' \
           | kubectl --context fleet apply -f -
+        # Patch ingress to give korczewski its own TLS entry (its cert is in korczewski-tls).
+        kubectl --context fleet patch ingress office-ingress -n workspace-office --type=json -p='[
+          {"op":"replace","path":"/spec/tls/0/hosts/1","value":"office.korczewski.de"},
+          {"op":"add","path":"/spec/tls/-","value":{"hosts":["office.korczewski.de"],"secretName":"korczewski-tls"}}
+        ]' 2>/dev/null || true
         kubectl --context fleet rollout status deploy/collabora -n workspace-office --timeout=300s
         # --- CoTURN/Janus (shared) ---
         export TURN_NODE="$MENTOLDER_TURN_NODE"; export TURN_PUBLIC_IP="$MENTOLDER_TURN_PUBLIC_IP"

--- a/tests/unit/fleet-dns-cutover.bats
+++ b/tests/unit/fleet-dns-cutover.bats
@@ -131,3 +131,19 @@ STATE
   assert_output --partial 'fleet:dns:cutover:'
   assert_output --partial 'fleet:dns:rollback:'
 }
+
+@test "fleet:shared-services uses office.* hosts not collabora.* for Collabora" {
+  # Collabora ingress host must be office.<domain> so Nextcloud public_wopi_url resolves.
+  run grep -A 20 'fleet:shared-services:' "$REPO_ROOT/Taskfile.yml"
+  assert_success
+  assert_output --partial 'COLLABORA_HOST="office.'
+  refute_output --partial 'COLLABORA_HOST="collabora.'
+}
+
+@test "fleet:shared-services aliasgroup references files.* not cloud.*" {
+  # WOPI aliasgroup must match the Nextcloud host (files.<domain>), not cloud.*.
+  run grep -A 20 'fleet:shared-services:' "$REPO_ROOT/Taskfile.yml"
+  assert_success
+  assert_output --partial 'ALIASGROUP1="https://files\.'
+  refute_output --partial 'ALIASGROUP1="https://cloud\.'
+}


### PR DESCRIPTION
## Summary
- Fixes `office.mentolder.de` returning 404 — Collabora ingress used `collabora.*` prefix instead of `office.*`
- Fixes Collabora aliasgroup using `cloud.*` instead of `files.*` (Nextcloud host for WOPI)
- Adds TLS cert sync (workspace-wildcard-tls, korczewski-tls) to workspace-office before Collabora deploy
- Adds post-apply ingress patch to split TLS entries per domain (each gets its own TLS secret)

## Root cause
`fleet:shared-services` was deployed before `PROD_DOMAIN` was updated to real domains (PR #1207). The env vars retained old fleet-specific hostnames (`collabora.fleet-m.korczewski.de`).

## Test plan
- [x] `task test:all` green
- [x] New BATS assertions: `office.*` present, `collabora.*` absent; `files.*` present, `cloud.*` absent
- [ ] Post-merge: re-run `task fleet:shared-services` to apply corrected ingress + Collabora pod
- [ ] Verify: `curl -sk https://office.mentolder.de/ -o /dev/null -w "%{http_code}"` returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)