### PR TITLE
fix(backup): pvc-backup filen-upload exits 1 on failure, npm install visible [T000330]

### DIFF
--- a/k3d/pvc-backup-cronjob.yaml
+++ b/k3d/pvc-backup-cronjob.yaml
@@ -213,7 +213,7 @@ spec:
                             args:
                               - |
                                 if [ -z "\$${FILEN_EMAIL}" ] || [ -z "\$${FILEN_PASSWORD}" ]; then
-                                  echo "Filen not configured — skipping upload"
+                                  echo "Filen not configured — skipping remote backup"
                                   until [ -f /staging/.done ]; do sleep 2; done
                                   exit 0
                                 fi
@@ -221,13 +221,18 @@ spec:
                                 until [ -f /staging/.done ]; do sleep 2; done
                                 STAMP=\$(cat /staging/.done)
                                 UPLOAD_PATH=\$(cat /staging/.filen_path)
+                                echo "Installing Filen CLI..."
                                 export HOME=/tmp
-                                npm install -g @filen/cli --prefix /tmp/npm-global --silent 2>&1 | tail -3
+                                npm install -g @filen/cli --prefix /tmp/npm-global 2>&1 \
+                                  || { echo "ERROR: filen-cli install failed"; exit 1; }
                                 export PATH="/tmp/npm-global/bin:\$PATH"
                                 echo "Uploading \$${STAMP} to Filen: \$${UPLOAD_PATH}/\$${STAMP}/"
-                                filen --email "\$${FILEN_EMAIL}" --password "\$${FILEN_PASSWORD}" \
-                                  upload "/backups/\$${STAMP}/" "\$${UPLOAD_PATH}/\$${STAMP}/" \
-                                  || echo "WARNING: Filen upload failed — local backup intact"
+                                if ! filen --email "\$${FILEN_EMAIL}" --password "\$${FILEN_PASSWORD}" \
+                                     upload "/backups/\$${STAMP}/" "\$${UPLOAD_PATH}/\$${STAMP}/"; then
+                                  echo "ERROR: Filen remote upload failed for \$${STAMP} — local backup on backup-pvc is intact."
+                                  echo "       Likely cause: invalid credentials, or 2FA enabled (this job requires 2FA OFF)."
+                                  exit 1
+                                fi
                                 echo "Filen upload done"
                             env:
                               - name: FILEN_EMAIL

--- a/tests/unit/manifests.bats
+++ b/tests/unit/manifests.bats
@@ -240,6 +240,15 @@ all_images() {
   grep -q 'docuseal-data-pvc' "$RENDERED"
 }
 
+@test "pvc-backup filen-upload fails loudly on upload error (exit 1, not silent warning)" {
+  # Ensure the pvc-backup CronJob filen-upload script exits 1 on upload failure
+  # rather than swallowing errors with a WARNING echo (T000330).
+  run grep -c 'WARNING: Filen upload failed' k3d/pvc-backup-cronjob.yaml
+  assert_output "0"
+  # And that it uses exit 1 for failure visibility
+  grep -q 'exit 1' k3d/pvc-backup-cronjob.yaml
+}
+
 # ── PVCs ─────────────────────────────────────────────────────────
 
 @test "PersistentVolumeClaims exist for stateful services" {


### PR DESCRIPTION
## Summary
- Silent `|| echo "WARNING"` on Filen upload failure replaced with `exit 1` so CronJob history shows Failed (not Succeeded) when upload breaks
- npm install no longer uses `--silent` — install errors are now visible in pod logs
- Adds BATS test asserting no silent-warning pattern exists in pvc-backup

## Root cause
`filen-cli` was failing to install in the pod (silently, because of `--silent` + pipe eating the exit code), then the `filen` command failed with "command not found", swallowed by `|| echo "WARNING"`. Result: CronJob showed Succeeded with no remote backup ever created.

## Test plan
- [x] `task test:manifests` — test 23 `pvc-backup filen-upload fails loudly on upload error` passes
- [x] `task workspace:validate` — manifests valid
- [ ] Trigger `kubectl create job --from=cronjob/pvc-backup` on fleet after merge to verify Filen upload works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)