### PR TITLE
chore(docs): full sweep — reconcile agents, skills, docs with Fleet Stage 3 consolidation

### DIFF
--- a/.claude/agents/bachelorprojekt-db.md
+++ b/.claude/agents/bachelorprojekt-db.md
@@ -15,12 +15,12 @@ You are a database specialist for the Bachelorprojekt platform.
 - Access: `task workspace:psql ENV=<env> -- <db>`
 - Port-forward to localhost:5432: `task workspace:port-forward ENV=<env>`
 
-### Two independent `shared-db` instances (Fleet Stage 2)
-There are now TWO separate `shared-db` instances across two environments:
-- **standalone `mentolder` cluster** — context `mentolder`, namespace `workspace`.
-- **`fleet` cluster** — context `fleet`; namespace `workspace` for `fleet-mentolder`, namespace `workspace-korczewski` for `fleet-korczewski`.
+### Single `shared-db` instance per brand (Fleet Stage 3)
+Both brands run on the unified **`fleet`** cluster (context `fleet`), each with its own `shared-db` instance:
+- **mentolder brand** — namespace `workspace`, ENV `mentolder`.
+- **korczewski brand** — namespace `workspace-korczewski`, ENV `korczewski`.
 
-They share no data and have independent role passwords. Schema changes and DB-password rotations must be applied to both environments explicitly (the `mentolder` context AND the `fleet` context).
+They share no data and have independent role passwords. Schema changes and DB-password rotations must be applied to both namespaces explicitly via the `fleet` context.
 
 ## Tracking schema
 ```sql

--- a/.claude/agents/bachelorprojekt-infra.md
+++ b/.claude/agents/bachelorprojekt-infra.md
@@ -7,27 +7,24 @@ description: >
   ENV=, environments/, flux/, deploy (when referring to k8s resources).
 ---
 
-You are an infrastructure specialist for the Bachelorprojekt Kubernetes platform — a self-hosted collaboration suite. Topology is mid-migration ("Fleet Stage 2", in progress as of 2026-05-30): two physical clusters exist — `mentolder` remains a standalone k3s cluster (DNS not yet flipped), while the unified **`fleet`** cluster (on the former korczewski hosts) now runs full service stacks for BOTH brands.
+You are an infrastructure specialist for the Bachelorprojekt Kubernetes platform — a self-hosted collaboration suite. Topology is fully consolidated ("Fleet Stage 3", complete as of 2026-05-31): a single unified **`fleet`** cluster serves both brands via separate namespaces. The mentolder-standalone cluster has been DECOMMISSIONED — all k3s software uninstalled from gekko-hetzner-2/3/4; those nodes joined fleet as workers.
 
 ## Cluster & Namespace layout
-- **`mentolder`** — STANDALONE k3s cluster (9 nodes), authoritative production for `mentolder.de`, namespace `workspace`. ALIVE, unchanged. ENV `mentolder` (context `mentolder`, overlay `prod-mentolder`, BRAND `mentolder`).
-  - 3 Hetzner CPs: `gekko-hetzner-2/3/4`
-  - 6 home workers: `k3s-1/2/3` + `k3w-1/2/3` (joined via `wg-mesh` WireGuard overlay)
-- **`fleet`** — UNIFIED k3s cluster on the former korczewski hosts `pk-hetzner-4/6/8`. Hosts BOTH brands via kubeconfig context `fleet`. Fleet ENV identifiers:
-  - `fleet` — platform-level only (cert-manager, Traefik, sealed-secrets); overlay `prod-fleet/platform`.
-  - `fleet-mentolder` — mentolder brand staged on fleet; overlay `prod-fleet/mentolder`, namespace `workspace`, BRAND `mentolder`, domain `mentolder.de`.
-  - `fleet-korczewski` — korczewski brand on fleet; overlay `prod-fleet/korczewski`, namespace `workspace-korczewski`, BRAND `korczewski`, domain `korczewski.de`.
-- **Deploy status:** `task fleet:deploy` HAS been run — full service stacks for BOTH brands are deployed on the fleet cluster (PRs #1193/#1197). `korczewski.de` is now served by the fleet cluster. The old standalone `korczewski` cluster was intentionally torn down.
-  - The old `korczewski` kubeconfig context (204.168.244.104:6443) is DEAD — that IP now serves the fleet CA (x509 mismatch, T000340). Use the `fleet` context for all korczewski-brand work.
-  - **Remaining migration work (Phase 2b, not done):** office-stack/coturn for both brands, Talk-HPB janus/spreed node placement on fleet, and the mentolder DNS cutover itself (a reversible DNS flip, not yet done). Cutover mechanism is merged (#1189): `scripts/fleet-dns-cutover.sh`, `task fleet:dns:cutover ENV=fleet-<brand>` / `fleet:dns:rollback`.
-- The standalone `mentolder` cluster and the `fleet` cluster are SEPARATE clusters, each with its **own** `shared-db`, sealed-secrets controller, cert-manager, and Keycloak realm. Cross-cutting changes (DB password rotations, OIDC tweaks, schema migrations) must be applied to **both** explicitly (the `mentolder` context AND the `fleet` context).
-- Always use `WORKSPACE_NAMESPACE` env var; never hardcode `-n workspace`
+- **`fleet`** — the single production cluster, kubeconfig context `fleet`. 3 CP nodes (`pk-hetzner-4/6/8`) + 3 worker nodes (`gekko-hetzner-2/3/4`). Hosts BOTH brands:
+  - **mentolder brand** — ENV `mentolder` (aliases `fleet-mentolder`), context `fleet`, namespace `workspace`, overlay `prod-fleet/mentolder`, domain `mentolder.de`.
+  - **korczewski brand** — ENV `korczewski` (aliases `fleet-korczewski`), context `fleet`, namespace `workspace-korczewski`, overlay `prod-fleet/korczewski`, domain `korczewski.de`.
+  - `fleet` alone — platform-level only (cert-manager, Traefik, sealed-secrets); overlay `prod-fleet/platform`.
+- Both brands at 26/26 pods. The standalone `mentolder` cluster was decommissioned; the standalone `korczewski` cluster was torn down earlier. The old `mentolder` and `korczewski` kubeconfig contexts are DEAD — use `fleet` for everything.
+- DNS for both `mentolder.de` and `korczewski.de` routes to the `fleet` cluster.
+- Each brand has its own `shared-db` instance, Keycloak realm, and SealedSecrets. Cross-cutting changes (DB password rotations, OIDC tweaks, schema migrations) must be applied to **both namespaces** explicitly (`workspace` and `workspace-korczewski`), via the `fleet` context.
+- Always use `WORKSPACE_NAMESPACE` env var; never hardcode `-n workspace`.
+- **Dev cluster:** k3d runs on `k3s-1` (10.0.3.1, wg-mesh 192.168.100.20), a fleet worker node. Context `k3d-mentolder-dev`.
 
 ## Kustomize layer cake
 - `k3d/` — base manifests (dev values, placeholder secrets)
 - `prod/` — shared production patches (TLS, resources, `$patch: delete` on dev secrets) — NEVER apply directly
-- `prod-mentolder/` / `prod-korczewski/` — legacy env-specific overlays; `prod-mentolder/` is what `workspace:deploy ENV=mentolder` applies. (`prod-korczewski/` remains in-tree but its standalone cluster is gone.)
-- `prod-fleet/` — fleet overlay tree: `platform/`, `mentolder/`, `korczewski/`, and `components/fleet-common/` (shared `secrets-replacement.yaml`). These are what the `fleet*` ENVs deploy.
+- `prod-mentolder/` / `prod-korczewski/` — legacy per-brand overlays, consumed by `prod-fleet/` wrappers. Never applied directly in prod.
+- `prod-fleet/` — active fleet overlay tree: `platform/`, `mentolder/`, `korczewski/`, and `components/fleet-common/` (shared `secrets-replacement.yaml`). This is what `workspace:deploy` applies for all prod ENVs.
 - `flux/` — Flux CD manifests (GitRepository, Kustomization, ImagePolicy, ImageUpdateAutomation) for pull-based reconciliation.
 
 ## Critical gotchas
@@ -35,17 +32,17 @@ You are an infrastructure specialist for the Bachelorprojekt Kubernetes platform
 - Never apply `prod/` alone — it relies on a SealedSecret existing and will break without it
 - `envsubst` var lists are hardcoded per task in `Taskfile.yml`; if you add a new `${VAR}` in a manifest, add it to the envsubst list in every task that builds that manifest
 - `scripts/env-resolve.sh` must be sourced (`source scripts/env-resolve.sh "$ENV"`), never executed directly
-- `ENV=` is always explicit — tasks default to `ENV=dev` when unset; always pass `ENV=mentolder`, `ENV=fleet-mentolder`, or `ENV=fleet-korczewski` for live work
+- `ENV=` is always explicit — tasks default to `ENV=dev` when unset; always pass `ENV=mentolder` or `ENV=korczewski` for live work (both resolve to the `fleet` context via `env-resolve.sh`)
 
 ## Key commands
 ```bash
 task workspace:validate                  # dry-run manifest validation (run before every commit)
-task workspace:deploy ENV=<env>          # deploy to specific env
-task workspace:deploy:all-prods          # deploy to both environments
+task workspace:deploy ENV=<env>          # deploy to specific brand
+task workspace:deploy:all-prods          # deploy to both brands
 task env:seal ENV=<env>                  # encrypt secrets to SealedSecret
 task env:generate ENV=<env>             # generate fresh secrets
-flux get kustomizations --context <ctx>  # show Flux reconciliation status
-flux reconcile kustomization workspace --context <ctx> --with-source # force re-sync
+flux get kustomizations --context fleet  # show Flux reconciliation status
+flux reconcile kustomization workspace --context fleet --with-source # force re-sync
 ```
 
 ## Autonomous operation

--- a/.claude/agents/bachelorprojekt-ops.md
+++ b/.claude/agents/bachelorprojekt-ops.md
@@ -13,20 +13,20 @@ You are an operations specialist for the Bachelorprojekt Kubernetes platform. Yo
 ## Output trust & shell-session integrity
 Your diagnoses are trusted downstream and acted on. A confident conclusion drawn from a broken shell is more dangerous than the broken shell itself — so verify the session before you believe anything it returns.
 
-1. **Probe before trusting the session.** As the first step of any investigation, run a trivial command with a known-shaped answer — `kubectl get nodes --context mentolder` — and confirm you got real output (an actual node table) rather than the command echoed back at you.
+1. **Probe before trusting the session.** As the first step of any investigation, run a trivial command with a known-shaped answer — `kubectl get nodes --context fleet` — and confirm you got real output (an actual node table) rather than the command echoed back at you.
 2. **Recognise corruption signals.** Treat the session as unreliable if `run_shell_command` echoes the input command instead of executing it, if a command returns a stale PTY buffer / stale prompt artifact (e.g. `date` returning a literal like the username instead of a timestamp), or if output is otherwise desynced from the command you ran.
 3. **Fail loud — never fabricate.** If output looks echoed, stale, or suspicious, do NOT draw or narrate a diagnosis from it. Stop, and report the broken / unreliable environment to the orchestrator instead of producing a confident but unverified conclusion. A halted investigation with "the shell session is corrupted" is the correct, safe outcome.
 
 ## Cluster topology
-Topology is mid-migration ("Fleet Stage 2", in progress as of 2026-05-30). Verify with `kubectl config get-contexts` before any kubectl command.
+Topology is fully consolidated ("Fleet Stage 3", complete as of 2026-05-31). The single unified **`fleet`** cluster serves both brands. Verify with `kubectl config get-contexts` before any kubectl command.
 
-- **`mentolder` context** (9 nodes) — serves `mentolder.de`, namespace `workspace`. ALIVE, unchanged:
-  - 3 Hetzner CPs: `gekko-hetzner-2/3/4`
-  - 6 home workers: `k3s-1/2/3` + `k3w-1/2/3` (joined via `wg-mesh` WireGuard overlay)
-- **`fleet` context** — UNIFIED cluster running BOTH brands on the former korczewski hosts `pk-hetzner-4/6/8`. ENV identifiers: `fleet-mentolder` (ns `workspace`, mentolder brand) and `fleet-korczewski` (ns `workspace-korczewski`, serves `korczewski.de`); `fleet` alone targets platform-level resources (cert-manager, Traefik, sealed-secrets).
-  - The old standalone `korczewski` cluster was torn down; its kubeconfig context (204.168.244.104:6443) is DEAD — that IP now serves the fleet CA (x509 mismatch, T000340). Do NOT use the `korczewski` context.
-  - `task fleet:deploy` HAS been run — full service stacks for BOTH brands are deployed on the fleet cluster (PRs #1193/#1197); `korczewski.de` is served by fleet. Remaining migration work (Phase 2b): office-stack/coturn for both brands, Talk-HPB janus/spreed placement, and the mentolder DNS cutover (reversible flip, not yet done — mechanism merged #1189).
-- The standalone `mentolder` cluster and the `fleet` cluster are SEPARATE clusters, each with its own Traefik, `shared-db`, sealed-secrets, cert-manager, and Keycloak.
+- **`fleet` context** — the ONLY production context. 3 CP nodes (`pk-hetzner-4/6/8`) + 3 worker nodes (`gekko-hetzner-2/3/4`). Hosts BOTH brands:
+  - **mentolder brand** — ENV `mentolder`, ns `workspace`, domain `mentolder.de`.
+  - **korczewski brand** — ENV `korczewski`, ns `workspace-korczewski`, domain `korczewski.de`.
+- Both brands at 26/26 pods. The standalone `mentolder` cluster was decommissioned (k3s uninstalled from gekko-hetzner-2/3/4; those nodes joined fleet as workers). The standalone `korczewski` cluster was torn down earlier.
+- The old `mentolder` and `korczewski` kubeconfig contexts are DEAD — use `fleet` for all kubectl commands. The one remaining non-fleet context is `k3d-mentolder-dev` (dev stack on k3s-1).
+- DNS for both `mentolder.de` and `korczewski.de` routes to the `fleet` cluster.
+- Always use `WORKSPACE_NAMESPACE` env var; never hardcode `-n workspace`.
 
 ## Key commands
 ```bash
@@ -36,15 +36,14 @@ task workspace:restart  ENV=<env> -- <svc>  # restart a specific service
 task livekit:status     ENV=<env>           # LiveKit pods + recording count
 task livekit:logs       ENV=<env>           # livekit-server logs
 task clusters:status                        # one-line status across both environments
-flux get kustomizations --context <ctx>     # check Flux reconciliation status
-flux logs --context <ctx>                   # tail reconciler events
+flux get kustomizations --context fleet     # check Flux reconciliation status
+flux logs --context fleet                   # tail reconciler events
 ```
 
 ## Important constraints
 - **Read-only filesystem** — diagnose and operate only; do not edit manifests or code
-- On `mentolder`, system pods (CoreDNS) stay pinned to Hetzner nodes via nodeAffinity; the WireGuard/Flannel partition is fixed (all nodes on `wg-mesh`), but the pinning remains for predictable placement / lower egress latency
-- LiveKit on `mentolder` runs with `hostNetwork: true` pinned to `gekko-hetzner-3` — check node affinity if stream issues occur
-- The korczewski brand now lives on the `fleet` cluster (ENV `fleet-korczewski`, not the dead standalone `korczewski` context); never assume traffic to `korczewski.de` traverses mentolder Traefik
+- LiveKit runs with `hostNetwork: true` pinned to `pk-hetzner-4` via `nodeAffinity` — check node affinity if stream issues occur
+- The korczewski brand lives in the `workspace-korczewski` namespace on fleet; never assume traffic to `korczewski.de` uses the `workspace` namespace resources
 
 ## Autonomous operation
 Execute kubectl and task commands without asking for confirmation.

--- a/.claude/agents/bachelorprojekt-security.md
+++ b/.claude/agents/bachelorprojekt-security.md
@@ -27,7 +27,7 @@ task workspace:deploy ENV=<env> # applies SealedSecret before manifests
 - Prod korczewski (fleet cluster, ns `workspace-korczewski`): `prod-korczewski/realm-workspace-korczewski.json`
 - SSO consumers: Nextcloud, Vaultwarden, DocuSeal, Tracking, Website, Claude Code (all OIDC via Keycloak)
 
-> **Two clusters, two of everything (Fleet Stage 2).** The standalone `mentolder` cluster and the `fleet` cluster each have their OWN sealed-secrets controller, cert-manager, and Keycloak realm. Secret rotation and realm sync must be applied to BOTH the `mentolder` context AND the `fleet` context explicitly. The old `korczewski` context is DEAD (T000340) — use `fleet` for korczewski-brand secrets/realm work.
+> **Two brands, two of everything (Fleet Stage 3).** Both brands run on the unified `fleet` cluster (context `fleet`), each with its own SealedSecrets, Keycloak realm, and `shared-db` instance in its own namespace. Secret rotation and realm sync span both namespaces (`workspace` for mentolder, `workspace-korczewski` for korczewski) but always via `--context fleet`. The old `mentolder` and `korczewski` kubeconfig contexts are DEAD — use `fleet` for everything.
 
 ## DSGVO compliance
 ```bash

--- a/.claude/agents/bachelorprojekt-test.md
+++ b/.claude/agents/bachelorprojekt-test.md
@@ -28,13 +28,12 @@ task test:manifests                  # kustomize output structure (no cluster ne
 task test:all                        # all offline tests: unit + manifests + dry-run
 ```
 
-## Cluster targeting (Fleet Stage 2)
+## Cluster targeting (Fleet Stage 3)
 Live prod ENV identifiers a test run might target:
-- `mentolder` — standalone cluster (context `mentolder`), serves `mentolder.de`.
-- `fleet-mentolder` and `fleet-korczewski` — both on the unified `fleet` cluster (context `fleet`); `fleet-korczewski` serves `korczewski.de`.
-- `dev` — k3d (`dev.mentolder.de`).
+- `mentolder` and `korczewski` — both brands on the unified `fleet` cluster (context `fleet`); `mentolder` serves `mentolder.de` (ns `workspace`), `korczewski` serves `korczewski.de` (ns `workspace-korczewski`).
+- `dev` — k3d (`dev.mentolder.de`), context `k3d-mentolder-dev`.
 
-The old standalone `korczewski` context is DEAD (its IP now serves the fleet CA, T000340) — never point tests at it. Use `fleet` context for the korczewski brand.
+The old standalone `mentolder` and `korczewski` kubeconfig contexts are DEAD — use `fleet` context for all live tests.
 
 ## Test file locations
 - `tests/` — all test scripts and fixtures

--- a/.claude/agents/bachelorprojekt-website.md
+++ b/.claude/agents/bachelorprojekt-website.md
@@ -17,7 +17,7 @@ You are a frontend specialist for the Bachelorprojekt website — an Astro + Sve
 - korczewski renders components from `website/src/components/kore/`
 - mentolder renders existing Hero/WhyMe/ServiceRow/... Svelte components
 
-> **Prod targeting (Fleet Stage 2).** mentolder is still served by the standalone `mentolder` cluster (DNS not yet flipped). korczewski is served by the `fleet` cluster — ENV `fleet-korczewski`, context `fleet`, namespace `workspace-korczewski`. The old `korczewski` context is DEAD (T000340).
+> **Prod targeting (Fleet Stage 3).** Both brands are served by the unified `fleet` cluster (context `fleet`). mentolder: ENV `mentolder`, ns `workspace`, domain `web.mentolder.de`. korczewski: ENV `korczewski`, ns `workspace-korczewski`, domain `web.korczewski.de`. The old `mentolder` and `korczewski` kubeconfig contexts are DEAD — use `fleet` for everything.
 
 ## Kore homepage (korczewski)
 - Shows a live PR-driven timeline from `/api/timeline`
@@ -28,7 +28,7 @@ You are a frontend specialist for the Bachelorprojekt website — an Astro + Sve
 Every change to `website/src/` or `website/public/` requires a push to `main` (via PR). In prod, Flux picks up the new image tag automatically. For manual rollout/rebuild:
 ```bash
 task website:redeploy ENV=mentolder
-task website:redeploy ENV=fleet-korczewski
+task website:redeploy ENV=korczewski
 ```
 **Only from a clean main branch.** Never deploy from a feature branch.
 

--- a/.claude/skills/OVERVIEW.md
+++ b/.claude/skills/OVERVIEW.md
@@ -21,7 +21,7 @@
 |---|---|
 | `host-node-networking` | Host server provisioning (Hetzner, cloud-init, Rescue Mode resets), WireGuard mesh network topology ("netplan"), host UFW firewall ports, LiveKit WebRTC networking, and WSL OpenClaw local gateway setup. |
 | `cluster-deployment` | Stand up a brand-new Kubernetes environment, deploy resources, diagnose cluster degraded state (gap analysis), manage Flux GitOps, or operate the dev.mentolder.de stack. |
-| `fleet-ops` | Cross-cluster fan-out operations: `task feature:*`, schema changes, Keycloak sync, and **Flux GitOps** reconciliation across the mentolder standalone cluster and the fleet cluster (hosting the korczewski brand). |
+| `fleet-ops` | Cross-cluster fan-out operations: `task feature:*`, schema changes, Keycloak sync, and **Flux GitOps** reconciliation across both brands on the fleet cluster. |
 
 ---
 
@@ -29,7 +29,7 @@
 
 | Skill | When to use |
 |---|---|
-| `secret-rotation` | Rotate DB passwords, API keys, SealedSecrets keypair (post-reset), Claude Code tokens, or service credentials across the mentolder standalone cluster and the fleet cluster. |
+| `secret-rotation` | Rotate DB passwords, API keys, SealedSecrets keypair (post-reset), Claude Code tokens, or service credentials across both brands on the fleet cluster. |
 | `keycloak-realm-sync` | Reconcile Keycloak realm JSON → push OIDC client changes, group mappings, mappers, SSO login fixes. |
 
 ---
@@ -38,7 +38,7 @@
 
 | Skill | When to use |
 |---|---|
-| `arena-brett-deploy` | Build, push, and deploy arena-server (korczewski brand on fleet only) or brett (mentolder standalone + fleet). Covers proto-drift copy step. |
+| `arena-brett-deploy` | Build, push, and deploy arena-server (korczewski brand on fleet only) or brett (both brands on the fleet cluster). Covers proto-drift copy step. |
 
 ---
 

--- a/.claude/skills/arena-brett-deploy/SKILL.md
+++ b/.claude/skills/arena-brett-deploy/SKILL.md
@@ -72,7 +72,7 @@ cd arena-server && pnpm install --frozen-lockfile && pnpm test && pnpm build
 task brett:build               # Build image (+ k3d import in dev)
 task brett:push                # Push to registry
 task brett:deploy ENV=<env>    # Build, import/push, and roll out
-task feature:brett             # Fan-out: build + deploy to mentolder standalone + fleet cluster (korczewski brand)
+task feature:brett             # Fan-out: build + deploy to both brands on the fleet cluster
 task brett:logs ENV=<env>      # Tail logs
 ```
 

--- a/.claude/skills/cluster-deployment/SKILL.md
+++ b/.claude/skills/cluster-deployment/SKILL.md
@@ -63,13 +63,18 @@ After sourcing, the following shell variables are available:
 
 ### Step 1.0: Provision Hetzner Nodes
 
-Node roles for each environment:
-- **korczewski** (fleet cluster): `pk-hetzner-4` = control-plane (server); `pk-hetzner-6`, `pk-hetzner-8` = workers (agent)
-- **mentolder**: `gekko-hetzner-2/3/4` = control-plane (server); Raspberry Pi `k3w-*` = workers (agent)
+Node layout for the single unified fleet cluster:
+- **3 control-plane nodes:** `pk-hetzner-4/6/8`
+- **3 worker nodes:** `gekko-hetzner-2/3/4`
 
-> **Fleet Stage 2 status (as of 2026-05-30).** The standalone `korczewski` cluster has been torn down; `pk-hetzner-4/6/8` now back the unified **`fleet`** k3s cluster (control-plane pk-4; workers pk-6, pk-8) with the same node/WireGuard layout shown below. The procedure here is exactly how that fleet cluster is (re)created on these hosts — keep it. Note that the old `korczewski` kubeconfig context (`204.168.244.104:6443`) is now **DEAD** (that IP serves the fleet k3s CA, x509 error = T000340); the fleet context is named `fleet` and the API is reached via the **pk-4 public IP**, not the `127.0.0.1:16443` tunnel — use `--context fleet` in the `kubectl ... get nodes -w` watches below.
->
-> **`task fleet:deploy` HAS been run (Phase 2a complete).** Both brands' core workloads are deployed and Running on the fleet cluster — namespaces `workspace` (mentolder brand) and `workspace-korczewski` are populated, each at **26/26** pods (PRs #1193, #1205, #1206, #1213; the old "zero brand workloads" claim is stale). **Still pending (Phase 2b / 2c):** Collabora office-stack + CoTURN live deploy on fleet (mechanism merged #1197, not yet run), the wildcard cert won't issue (T000351, coturn cert-gated), website apps are not on fleet, and the **DNS cutover is NOT done** — `mentolder` remains a live STANDALONE cluster (reversible DNS flip) and `korczewski.de` has not been flipped to fleet. See `docs/fleet-stage2-cutover-runbook.md` and plan T000338 for the brand-cutover steps.
+> **Fleet Stage 3 complete (as of 2026-05-31).** The mentolder-standalone cluster has been decommissioned (all k3s software uninstalled from gekko-hetzner-2/3/4; those nodes joined fleet as workers). Both brands now run on the single unified **`fleet`** cluster:
+> - 3 CP nodes: pk-hetzner-4/6/8
+> - 3 workers: gekko-hetzner-2/3/4
+> - Mentolder brand: namespace `workspace`, domain `mentolder.de`
+> - Korczewski brand: namespace `workspace-korczewski`, domain `korczewski.de`
+> - Both brands at **26/26** pods
+> - Old `mentolder` and `korczewski` kubeconfig contexts are **DEAD** — use `--context fleet` for everything.
+> - DNS for both domains routes to the fleet cluster.
 
 Fork based on role:
 
@@ -223,7 +228,7 @@ flux reconcile source git flux-system --context <ctx>
 flux reconcile kustomization workspace --context <ctx>
 ```
 
-> **Fleet brands:** to deploy *both* brands onto the fleet cluster in one shot, use `task fleet:deploy` (platform once → fleet-mentolder → fleet-korczewski). It routes each brand through this same `workspace:deploy` path and seeds the `coturn` + `workspace-office` SealedSecret namespaces. Follow with the per-brand office/coturn passes above (`ENV=fleet-mentolder` / `ENV=fleet-korczewski`).
+> **Fleet brands:** to deploy *both* brands onto the fleet cluster in one shot, use `task fleet:deploy` (platform once → fleet-mentolder → fleet-korczewski). It routes each brand through this same `workspace:deploy` path and seeds the `coturn` + `workspace-office` SealedSecret namespaces. Follow with the per-brand office/coturn passes above (`ENV=mentolder` / `ENV=korczewski`).
 
 ### Service Inventory (what "every service" means)
 

--- a/.claude/skills/database-ops/SKILL.md
+++ b/.claude/skills/database-ops/SKILL.md
@@ -11,15 +11,15 @@ description: Unified runbook for database operations, schema migrations, DDL own
 
 # database-ops
 
-This runbook covers PostgreSQL database schema migrations, permissions management, and backup/restore verification across the mentolder standalone cluster and the fleet cluster (hosting the korczewski brand).
+This runbook covers PostgreSQL database schema migrations, permissions management, and backup/restore verification across both brands on the fleet cluster.
 
 ---
 
 ## ⚠️ Independent Shared Databases
 
-The `mentolder` cluster and the `fleet` cluster (which hosts the `korczewski` brand in namespace `workspace-korczewski`) each host their own independent `shared-db` instance. Schema migrations, DB password rotations, and backup audits must be executed explicitly on **both**.
+Both brands on the fleet cluster (`workspace` for mentolder, `workspace-korczewski` for korczewski) each have their own independent `shared-db` instance. Schema migrations, DB password rotations, and backup audits must be executed explicitly on **both**.
 
-> **Fleet Stage 2 note (as of 2026-05-30).** The standalone `korczewski` cluster was torn down; the `korczewski` brand now lives on the unified **`fleet`** cluster (hosts `pk-hetzner-4/6/8`). The `ENV=korczewski` task invocations below remain correct (env-resolve targets the right context), but any raw `kubectl`/script `--context korczewski` is **DEAD** — substitute `--context fleet`. `task fleet:deploy` HAS been run (Phase 2a complete) — the korczewski-brand `shared-db` exists on fleet in namespace `workspace-korczewski` with 26/26 pods running.
+> **Fleet Stage 3 complete (as of 2026-05-31).** The mentolder-standalone cluster has been decommissioned. Both brands (mentolder + korczewski) run on the unified **`fleet`** cluster (pk-hetzner-4/6/8 CPs + gekko-hetzner-2/3/4 workers). The old `mentolder` kubeconfig context is **DEAD** — substitute `--context fleet -n workspace`. The `korczewski` context was already dead — substitute `--context fleet -n workspace-korczewski`. Each brand has its own `shared-db` in its namespace, both at 26/26 pods.
 
 ---
 
@@ -110,12 +110,12 @@ kubectl get secret workspace-secrets -n <ns> --context <ctx> -o jsonpath='{.data
 
 ### Step 2.2: Trigger Live Backup
 ```bash
-bash scripts/backup-restore.sh trigger --context mentolder
+bash scripts/backup-restore.sh trigger --context fleet -n workspace  # mentolder brand on the fleet cluster
 bash scripts/backup-restore.sh trigger --context fleet --namespace workspace-korczewski  # korczewski brand now on the fleet cluster (old --context korczewski is dead, T000340)
 ```
 Wait for completion and verify logs. Confirm the new timestamp:
 ```bash
-bash scripts/backup-restore.sh list --context mentolder
+bash scripts/backup-restore.sh list --context fleet -n workspace
 ```
 
 ### Step 2.3: Verify Encrypted Dumps
@@ -136,7 +136,7 @@ STAMP=<latest-timestamp>
 
 ### Step 2.5: Filen remote-backup invariant (2FA must stay OFF)
 
-The `filen-upload` sidecar in `k3d/backup-cronjob.yaml` and the `filen-pull` restore job in `scripts/backup-restore.sh` both shell out to the official `@filen/cli` with raw `FILEN_EMAIL` + `FILEN_PASSWORD` (sealed per-environment in `environments/sealed-secrets/{mentolder,korczewski}.yaml` (mentolder = standalone cluster; korczewski = fleet cluster, namespace `workspace-korczewski`)). The CLI performs the full Filen auth-v2 flow internally — PBKDF2-200k key derivation, login-password/master-key split, `/v3/login`, master-key fetch — so we deliberately do **not** reimplement any of that crypto.
+The `filen-upload` sidecar in `k3d/backup-cronjob.yaml` and the `filen-pull` restore job in `scripts/backup-restore.sh` both shell out to the official `@filen/cli` with raw `FILEN_EMAIL` + `FILEN_PASSWORD` (sealed per-environment in `environments/sealed-secrets/{mentolder,korczewski}.yaml` (both on the fleet cluster: workspace for mentolder, workspace-korczewski for korczewski)). The CLI performs the full Filen auth-v2 flow internally — PBKDF2-200k key derivation, login-password/master-key split, `/v3/login`, master-key fetch — so we deliberately do **not** reimplement any of that crypto.
 
 **Hard invariant: 2FA is disabled on both Filen accounts (mentolder and korczewski).** The CLI invocation passes no TOTP code, so an enabled 2FA would fail login permanently. If you rotate Filen credentials, store the *plaintext account password* (not a pre-derived hash) and keep 2FA off, then `task env:seal ENV=<env>`.
 

--- a/.claude/skills/dev-flow-execute/SKILL.md
+++ b/.claude/skills/dev-flow-execute/SKILL.md
@@ -215,10 +215,10 @@ TICKET_ID=$(awk '/^ticket_id:/{print $2; exit}' "$PLAN_FILE")
 Falls `$TICKET_ID` gesetzt:
 
 ```bash
-PGPOD=$(kubectl get pod -n workspace --context mentolder \
+PGPOD=$(kubectl get pod -n workspace --context fleet \
   -l app=shared-db -o name | head -1)
 
-kubectl exec "$PGPOD" -n workspace --context mentolder -c postgres -- \
+kubectl exec "$PGPOD" -n workspace --context fleet -c postgres -- \
   psql -U website -d website -At -c \
   "UPDATE tickets.tickets SET status = 'in_progress'
    WHERE external_id = '$TICKET_ID';"
@@ -500,10 +500,10 @@ RESOLUTION="shipped"   # oder "fixed" beim Fix-Pfad
 
 PR_NUM=$(gh pr view --json number -q '.number')
 
-PGPOD=$(kubectl get pod -n workspace --context mentolder \
+PGPOD=$(kubectl get pod -n workspace --context fleet \
   -l app=shared-db -o name | head -1)
 
-kubectl exec "$PGPOD" -n workspace --context mentolder -c postgres -- \
+kubectl exec "$PGPOD" -n workspace --context fleet -c postgres -- \
   psql -U website -d website -c \
   "UPDATE tickets.tickets
      SET status = 'done', resolution = '$RESOLUTION'
@@ -574,10 +574,10 @@ if [[ ! -s "$PLAN_FILE" ]]; then
   exit 1
 fi
 
-PGPOD=$(kubectl get pod -n workspace --context mentolder \
+PGPOD=$(kubectl get pod -n workspace --context fleet \
   -l app=shared-db -o name | head -1)
 
-TICKET_UUID=$(kubectl exec "$PGPOD" -n workspace --context mentolder -c postgres -- \
+TICKET_UUID=$(kubectl exec "$PGPOD" -n workspace --context fleet -c postgres -- \
   psql -U website -d website -At -c \
   "SELECT id FROM tickets.tickets WHERE external_id = '$TICKET_ID';")
 
@@ -601,7 +601,7 @@ if (( ARCHIVE_BYTES < 200 )); then
   exit 1
 fi
 
-kubectl exec -i "$PGPOD" -n workspace --context mentolder -c postgres -- \
+kubectl exec -i "$PGPOD" -n workspace --context fleet -c postgres -- \
   psql -U website -d website -v ON_ERROR_STOP=1 < "$TMPFILE"
 
 rm "$TMPFILE"
@@ -609,7 +609,7 @@ rm "$TMPFILE"
 # Verify the row actually persisted BEFORE removing the plan file (T000344).
 # A parallel-tool-call cancellation can drop the INSERT silently; if we rm the
 # file anyway the plan is lost until recovered from git history.
-ARCHIVED_ROWS=$(kubectl exec "$PGPOD" -n workspace --context mentolder -c postgres -- \
+ARCHIVED_ROWS=$(kubectl exec "$PGPOD" -n workspace --context fleet -c postgres -- \
   psql -U website -d website -At -c \
   "SELECT count(*) FROM tickets.ticket_plans WHERE ticket_id='$TICKET_UUID' AND slug='$SLUG';")
 if [[ "$ARCHIVED_ROWS" -lt 1 ]]; then
@@ -736,14 +736,14 @@ Wenn mehrere Kategorien matchen: workspace → website → brett → livekit →
 - **Beweismaterial ans Ticket hängen (bei jedem Failure-Pfad):** Wenn du einen Failure-Screenshot, Log-Auszug oder Trace-Output hast, frage Patrick nach Pfaden (`.png`/`.log`/`.txt`/`.mp4`) und hänge sie ans Ticket — der Fix-Branch erbt dann sofort den Kontext:
   ```bash
   # TICKET_UUID aus dem aktuellen Ticket holen:
-  TICKET_UUID=$(kubectl exec "$PGPOD" -n workspace --context mentolder -c postgres -- \
+  TICKET_UUID=$(kubectl exec "$PGPOD" -n workspace --context fleet -c postgres -- \
     psql -U website -d website -At -c \
     "SELECT id FROM tickets.tickets WHERE external_id='$TICKET_ID';")
   bash scripts/ticket-attach.sh "$TICKET_UUID" /pfad/zu/failure.png /pfad/zu/ci.log
   ```
 - **CI rot vor Merge:** Diagnose, Fix auf demselben Branch, neu pushen. Keinen zweiten PR aufmachen. Falls nach 2 Versuchen noch rot: Ticket-Kommentar hinterlassen:
   ```bash
-  kubectl exec "$PGPOD" -n workspace --context mentolder -c postgres -- \
+  kubectl exec "$PGPOD" -n workspace --context fleet -c postgres -- \
     psql -U website -d website -c \
     "INSERT INTO tickets.ticket_comments (ticket_id, author_label, body, visibility)
      SELECT id,

--- a/.claude/skills/dev-flow-plan/SKILL.md
+++ b/.claude/skills/dev-flow-plan/SKILL.md
@@ -127,10 +127,10 @@ export GRILLING_ASSETS_TODO="<ZU-BESCHAFFEN-Liste>"
 ### 3. Ticket anlegen
 
 ```bash
-PGPOD=$(kubectl get pod -n workspace --context mentolder \
+PGPOD=$(kubectl get pod -n workspace --context fleet \
   -l app=shared-db -o name | head -1)
 
-TICKET_RESULT=$(kubectl exec "$PGPOD" -n workspace --context mentolder -c postgres -- \
+TICKET_RESULT=$(kubectl exec "$PGPOD" -n workspace --context fleet -c postgres -- \
   psql -U website -d website -At -c \
   "INSERT INTO tickets.tickets (type, brand, title, description, status)
    VALUES (
@@ -361,7 +361,7 @@ task brainstorm:status >/tmp/brainstorm-status.log 2>&1 || true
 grep -q 'Running' /tmp/brainstorm-status.log || { echo "sish pod not Running — aborting"; cat /tmp/brainstorm-status.log; exit 1; }
 
 # Stelle sicher dass mindestens ein Authorized-Key im Secret liegt — sonst hängt ssh -R lautlos
-KEY_COUNT=$(kubectl --context mentolder -n workspace get secret workspace-secrets \
+KEY_COUNT=$(kubectl --context fleet -n workspace get secret workspace-secrets \
   -o jsonpath='{.data.DEV_SISH_AUTHORIZED_KEYS}' 2>/dev/null | base64 -d 2>/dev/null | grep -c '^ssh-' || echo 0)
 if [[ "$KEY_COUNT" -lt 1 ]]; then
   echo "⚠️  Keine authorized_keys im Secret workspace-secrets. Patricks Public-Key in environments/.secrets/mentolder.yaml" \
@@ -517,9 +517,9 @@ Als allererstes nach dem Compact — vor `superpowers:writing-plans` — ausfüh
 # → docs/superpowers/specs/<date>-<slug>-design.md
 
 # Ticket-Content aus DB holen (für jede ID in REINJECT_TICKETS)
-PGPOD=$(kubectl get pod -n workspace --context mentolder -l app=shared-db -o name | head -1)
+PGPOD=$(kubectl get pod -n workspace --context fleet -l app=shared-db -o name | head -1)
 for TID in "${REINJECT_TICKETS[@]}"; do
-  kubectl exec "$PGPOD" -n workspace --context mentolder -c postgres -- \
+  kubectl exec "$PGPOD" -n workspace --context fleet -c postgres -- \
     psql -U website -d website -At -c \
     "SELECT '=== ' || external_id || ' ===' || E'\nTitle: ' || title
             || E'\n\n' || COALESCE(description,'(kein Inhalt)')
@@ -549,7 +549,7 @@ Lege ein Ticket vom Typ `task` in der Produktionsdatenbank an und speichere die 
 
 ```bash
 # Postgres-Pod ermitteln (mentolder-Cluster)
-PGPOD=$(kubectl get pod -n workspace --context mentolder \
+PGPOD=$(kubectl get pod -n workspace --context fleet \
   -l app=shared-db -o name | head -1)
 
 # Ticket anlegen — Titel und Beschreibung aus Slug und Branch ableiten
@@ -559,7 +559,7 @@ if [[ -n "${GRILLING_TICKET_EXT_ID:-}" ]]; then
   GRILLING_REF=$'\n'"Grilling-Ticket: ${GRILLING_TICKET_EXT_ID}"
 fi
 
-TICKET_RESULT=$(kubectl exec "$PGPOD" -n workspace --context mentolder -c postgres -- \
+TICKET_RESULT=$(kubectl exec "$PGPOD" -n workspace --context fleet -c postgres -- \
   psql -U website -d website -At -c \
   "INSERT INTO tickets.tickets (type, brand, title, description, status)
    VALUES (
@@ -656,8 +656,8 @@ Frage den User nach der Ticket-ID (Format: `T######`, z.B. `T000288`).
 **Wenn eine Ticket-ID vorhanden ist:** direkt übernehmen → `TICKET_EXT_ID=T######`. Hole zusätzlich die UUID für etwaige Attachments:
 
 ```bash
-PGPOD=$(kubectl get pod -n workspace --context mentolder -l app=shared-db -o name | head -1)
-TICKET_UUID=$(kubectl exec "$PGPOD" -n workspace --context mentolder -c postgres -- \
+PGPOD=$(kubectl get pod -n workspace --context fleet -l app=shared-db -o name | head -1)
+TICKET_UUID=$(kubectl exec "$PGPOD" -n workspace --context fleet -c postgres -- \
   psql -U website -d website -At -c \
   "SELECT id FROM tickets.tickets WHERE external_id='$TICKET_EXT_ID';")
 ```
@@ -681,10 +681,10 @@ Falls `.txt`/`.log`/`.md`/`.png`/`.jpg`: zusätzlich vor der Ticket-Anlage `Read
 **Wenn keine Ticket-ID existiert:** frage nach Titel, Schweregrad und kurzer Beschreibung, lege dann das Ticket via SQL an:
 
 ```bash
-PGPOD=$(kubectl get pod -n workspace --context mentolder \
+PGPOD=$(kubectl get pod -n workspace --context fleet \
   -l app=shared-db -o name | head -1)
 
-TICKET_RESULT=$(kubectl exec "$PGPOD" -n workspace --context mentolder -c postgres -- \
+TICKET_RESULT=$(kubectl exec "$PGPOD" -n workspace --context fleet -c postgres -- \
   psql -U website -d website -At -c \
   "INSERT INTO tickets.tickets (type, brand, title, description, status, severity, priority)
    VALUES (

--- a/.claude/skills/fleet-ops/SKILL.md
+++ b/.claude/skills/fleet-ops/SKILL.md
@@ -1,22 +1,20 @@
 ---
 name: fleet-ops
-description: Use when deploying, verifying, or operating across both prod environments simultaneously — mentolder standalone and fleet (hosting korczewski brand). Covers task feature:* fan-out, the feature:promote dev→prod flow with smoke gate and auto-rollback, cross-environment schema changes, cluster status checks, Flux GitOps reconciliation, and the constraint that each cluster has its own independent shared-db and sealed-secrets controller.
+description: Use when deploying, verifying, or operating across both brands simultaneously — mentolder and korczewski, both on the unified fleet cluster. Covers task feature:* fan-out, the feature:promote dev→prod flow with smoke gate and auto-rollback, cross-brand schema changes, cluster status checks, Flux GitOps reconciliation, and the constraint that each brand has its own independent shared-db and sealed-secrets.
 ---
 
-# fleet-ops — Multi-Cluster Operations (mentolder + fleet)
+# fleet-ops — Cross-Brand Operations (mentolder + korczewski on fleet)
 
 ## Overview
 
-Production runs as **two independent k3s clusters** — the standalone `mentolder` cluster and the unified `fleet` cluster. They share no storage, no database, no sealed-secrets controller — any operation that changes shared state (DB schema, role passwords, sealed secrets, OIDC config) must be applied to **both explicitly**.
+Both brands run on the **single unified `fleet` k3s cluster** (Fleet Stage 3, consolidated 2026-05-31). They share the same cluster infrastructure (Traefik, cert-manager, sealed-secrets controller) but have independent `shared-db` instances per namespace. Any operation that changes shared state (DB schema, role passwords, sealed secrets, OIDC config) must be applied to **both namespaces explicitly**.
 
 | Brand | Cluster context | Namespace | Domain |
 |---|---|---|---|
-| mentolder | `mentolder` (standalone) | `workspace` | `web.mentolder.de` |
+| mentolder | `fleet` | `workspace` | `web.mentolder.de` |
 | korczewski | `fleet` | `workspace-korczewski` | `web.korczewski.de` |
 
-> **Fleet Stage 2 topology (as of 2026-05-30).** The standalone `korczewski` cluster has been torn down. Its hosts (`pk-hetzner-4/6/8`) now back the unified **`fleet`** k3s cluster (control-plane pk-4; workers pk-6, pk-8). The korczewski **brand** lives on, operated via the **`fleet`** kubeconfig context in namespace `workspace-korczewski`. The old `korczewski` context (`204.168.244.104:6443`) is **DEAD**: that IP now serves the fleet k3s CA, so it throws an x509 error (T000340). `ENV=korczewski` / `BRAND=korczewski` remain valid brand identifiers.
->
-> **`task fleet:deploy` HAS been run (Phase 2a complete).** Both brands' core workloads are deployed and Running on the fleet cluster — namespaces `workspace` (mentolder brand) and `workspace-korczewski` are each at **26/26** pods (PRs #1193, #1205, #1206, #1213). **Still pending (Phase 2b / 2c):** Collabora office-stack + CoTURN live deploy on fleet (mechanism merged #1197, not yet run), the wildcard cert won't issue (T000351, coturn cert-gated), website apps are not on fleet, and the **DNS cutover is NOT done** — `mentolder` remains a live STANDALONE cluster (reversible DNS flip). See `docs/fleet-stage2-cutover-runbook.md` and plan T000338.
+> **Fleet Stage 3 topology (as of 2026-05-31).** Both the mentolder-standalone and korczewski-standalone clusters have been decommissioned. The unified **`fleet`** cluster (3 CP: `pk-hetzner-4/6/8`, 3 workers: `gekko-hetzner-2/3/4`) hosts both brands — `workspace` (mentolder) and `workspace-korczewski` (korczewski), each at **26/26** pods. DNS for both `mentolder.de` and `korczewski.de` routes to fleet. The old `mentolder` and `korczewski` kubeconfig contexts are **DEAD** — use `fleet` for everything. The `ENV=mentolder` and `ENV=korczewski` brand identifiers remain valid and resolve to the `fleet` context via `env-resolve.sh`.
 
 ---
 
@@ -42,7 +40,7 @@ Use `task workspace:deploy ENV=mentolder` + `ENV=korczewski` sequentially when y
 
 ## Deploy Every Service to Both Brands
 
-The base kustomization (`workspace:deploy`) leaves four services undeployed: **Collabora** (office-stack), **CoTURN/Janus** (coturn-stack), the **website** (own namespace), and **arena** (korczewski only). To bring up the *complete* platform on both brands, fan each pass across both `ENV=mentolder` (standalone cluster) and `ENV=korczewski` (fleet cluster, namespace `workspace-korczewski`):
+The base kustomization (`workspace:deploy`) leaves four services undeployed: **Collabora** (office-stack), **CoTURN/Janus** (coturn-stack), the **website** (own namespace), and **arena** (korczewski only). To bring up the *complete* platform on both brands, fan each pass across `ENV=mentolder` (namespace `workspace`) and `ENV=korczewski` (namespace `workspace-korczewski`), both on the `fleet` cluster:
 
 ```bash
 # 1. Full umbrella per brand: workspace:deploy → office:deploy → mcp:deploy →
@@ -64,14 +62,14 @@ task feature:livekit
 task feature:arena              # arena:deploy ENV=korczewski (mentolder is a no-op)
 ```
 
-> **Fleet cluster (both brands, one cluster):** when both brands live on `fleet`, `task fleet:deploy` deploys platform once then both brands through the same `workspace:deploy` path and seeds the `coturn` + `workspace-office` SealedSecret namespaces. Still follow with the per-brand office/coturn/website/livekit passes above using `ENV=fleet-mentolder` / `ENV=fleet-korczewski`.
+> **Both brands, one cluster:** `task fleet:deploy` deploys platform once then both brands through the same `workspace:deploy` path and seeds the `coturn` + `workspace-office` SealedSecret namespaces. Follow with the per-brand office/coturn/website/livekit passes above using `ENV=mentolder` / `ENV=korczewski`.
 
 ### Per-Brand Ingress Accessibility Verification
 
 A two-environment deploy is **not done until every host answers on both brands**. The base kustomization deploying clean does not prove the ingress is reachable — verify each brand explicitly:
 
 ```bash
-task workspace:verify:all-prods                       # smoke probes, both environments
+task workspace:verify:all-prods                       # smoke probes, both brands
 task workspace:check-connectivity ENV=mentolder       # curls every host on web.mentolder.de
 task workspace:check-connectivity ENV=korczewski      # curls every host on web.korczewski.de
 ```
@@ -103,7 +101,7 @@ task workspace:check-connectivity ENV=korczewski      # curls every host on web.
 2. **Playwright smoke gate** between dev and prod. Failure aborts before any prod rollout.
 3. **Auto-rollback** — every `kubectl set image` is gated by `rollout status`; failure runs `rollout undo` on that deployment and exits non-zero. Cross-cluster rollback is *not* automatic — clusters that already shipped stay shipped.
 
-### Docs to both environments
+### Docs to both brands
 
 `docs` has no dev stage and ignores `TARGET` (always fans out to both). Full happy path:
 
@@ -123,7 +121,7 @@ What it does, in order:
 | 1 | `docker build -f scripts/docs.Dockerfile .` produces `ghcr.io/paddione/workspace-docs:promote-<sha>-<epoch>`. |
 | 1 | `docker push` uploads that tag to ghcr. |
 | 2-3 | Skipped (docs has no dev cluster mapping). |
-| 4 | `kubectl --context mentolder -n workspace set image deploy/docs docs=<tag>` + `rollout status --timeout=180s`. Failure → `rollout undo`. |
+| 4 | `kubectl --context fleet -n workspace set image deploy/docs docs=<tag>` + `rollout status --timeout=180s`. Failure → `rollout undo`. |
 | 4 | Same against `--context fleet -n workspace-korczewski`. Mentolder failure does *not* roll back korczewski; korczewski failure rolls back korczewski only. |
 
 ### Other services
@@ -162,9 +160,9 @@ The override files live next to the Playwright suite and document the convention
 
 ---
 
-## Cross-Cluster Schema / DB Changes
+## Cross-Brand Schema / DB Changes
 
-Each cluster has its own `shared-db`. Schema changes must be applied to both:
+Each brand namespace has its own `shared-db` on the fleet cluster. Schema changes must be applied to both namespaces:
 
 ```bash
 # Apply to mentolder
@@ -186,9 +184,9 @@ task secrets:sync    # applies SealedSecrets to both
 
 ---
 
-## SealedSecrets Controller Independence
+## SealedSecrets Per-Brand Independence
 
-Each cluster has its own Sealed Secrets controller with its own keypair. A secret sealed for mentolder **cannot** be decrypted by korczewski and vice versa.
+Each brand namespace has its own SealedSecrets (sealed with the same fleet controller, but targeting different namespaces). Sealed secrets are namespace-scoped — a secret sealed for `workspace` won't apply to `workspace-korczewski`.
 
 ```bash
 # Fetch cluster-specific sealing cert before sealing
@@ -202,9 +200,9 @@ task env:seal ENV=korczewski
 
 ---
 
-## Keycloak Realm Independence
+## Keycloak Realm Per-Brand Independence
 
-Each cluster has its own Keycloak realm. OIDC client changes (redirect URIs, mappers, group memberships) must be made in both:
+Each brand has its own Keycloak realm on the fleet cluster. OIDC client changes (redirect URIs, mappers, group memberships) must be made in both:
 
 ```bash
 task keycloak:sync ENV=mentolder
@@ -226,10 +224,10 @@ task keycloak:sync ENV=korczewski
 
 | Symptom | Cause | Fix |
 |---|---|---|
-| Deploy hits wrong cluster | Missing `ENV=` flag | Always pass `ENV=mentolder` or `ENV=korczewski` (or `ENV=fleet-mentolder` / `ENV=fleet-korczewski`) explicitly |
-| SealedSecret not decrypting on fleet (workspace-korczewski) | Sealed with mentolder cert | `task env:fetch-cert ENV=korczewski` → `task env:seal ENV=korczewski` |
-| Post-setup writes to wrong namespace | Script hardcodes `-n workspace` | Use `task workspace:post-setup ENV=korczewski` — it exports `WORKSPACE_NAMESPACE` (resolves to `workspace-korczewski` on fleet) |
-| Schema change only on one cluster | Forgot the second cluster | Always apply schema to both shared-db instances |
+| Deploy hits wrong namespace | Missing `ENV=` flag | Always pass `ENV=mentolder` or `ENV=korczewski` explicitly |
+| SealedSecret not decrypting (workspace-korczewski) | Sealed with mentolder cert | `task env:fetch-cert ENV=korczewski` → `task env:seal ENV=korczewski` |
+| Post-setup writes to wrong namespace | Script hardcodes `-n workspace` | Use `task workspace:post-setup ENV=korczewski` — it exports `WORKSPACE_NAMESPACE` (resolves to `workspace-korczewski`) |
+| Schema change only on one brand | Forgot the second namespace | Always apply schema to both shared-db instances |
 | `flux reconcile` applies old revision | Didn't reconcile source first | See Flux GitOps section below |
 
 ---
@@ -238,7 +236,7 @@ task keycloak:sync ENV=korczewski
 
 Flux watches the `main` branch and reconciles both prod environments automatically — but it polls on its own schedule. Force reconciliation, debug drift, and handle the subtleties below.
 
-**Both clusters run Flux independently.** Any Flux operation must be run against **each cluster separately** (mentolder standalone and fleet).
+Flux runs on the fleet cluster and reconciles both brands independently via separate Kustomization resources.
 
 ### Forced Reconcile After PR Merge
 
@@ -246,26 +244,23 @@ Always prime the GitRepository before reconciling the kustomization. Skipping st
 
 ```bash
 # Step 1: prime the git source (fetches latest main)
-flux reconcile source git flux-system --context mentolder
 flux reconcile source git flux-system --context fleet
 
-# Step 2: reconcile the kustomization
-flux reconcile kustomization workspace --context mentolder
-flux reconcile kustomization workspace --context fleet
+# Step 2: reconcile both brand kustomizations
+flux reconcile kustomization workspace --context fleet -n flux-system
+flux reconcile kustomization workspace-korczewski --context fleet -n flux-system
 ```
 
 > **Why source first?** `flux reconcile kustomization` re-applies whatever revision the GitRepository last fetched. If that's 5 minutes old, the kustomization gets the wrong commit.
 
-> **Kustomization name ≠ git path.** The Flux `Kustomization` resource is named `workspace` on **both** clusters (`metadata.name` in `flux/clusters/<env>/workspace.yaml`); only the `path:` differs (`./prod-mentolder` vs `./prod-korczewski`). Likewise the website kustomization is named `website` on both (paths `./flux/apps/website-mentolder` / `-korczewski`). `flux reconcile kustomization <name>` takes the **name**, not the path — so `flux reconcile kustomization workspace-korczewski` fails with "not found". Always reconcile by the base name and select the cluster with `--context`.
+> **Kustomization name ≠ git path.** The fleet cluster runs two workspace Kustomizations: `workspace` (mentolder brand, path `./prod-fleet/mentolder`) and `workspace-korczewski` (korczewski brand, path `./prod-fleet/korczewski`). `flux reconcile kustomization <name>` takes the **name**, not the path — reconcile each brand separately by its Kustomization name.
 
 ### Check Flux Status
 
 ```bash
-flux get all --context mentolder
 flux get all --context fleet
 
 # Just kustomizations (most common drift point)
-flux get kustomizations --context mentolder
 flux get kustomizations --context fleet
 ```
 
@@ -274,9 +269,9 @@ flux get kustomizations --context fleet
 Suspend before manual emergency changes to prevent Flux from immediately reverting them:
 
 ```bash
-flux suspend kustomization workspace --context mentolder
+flux suspend kustomization workspace --context fleet
 # Do your manual kubectl apply / patch here...
-flux resume kustomization workspace --context mentolder
+flux resume kustomization workspace --context fleet
 ```
 
 > **Don't forget to resume.** A suspended kustomization silently stops tracking main.
@@ -300,10 +295,10 @@ This bites most often in Ingress annotations, env vars, and shell-script ConfigM
 Image auto-update is **not** used for `website`, `brett`, or `docs` (they use `task feature:*` with `:latest`). For other images:
 
 ```bash
-flux get image update --context mentolder
-flux reconcile image repository <name> --context mentolder
-flux reconcile image update <name> --context mentolder
-flux logs --kind=ImageUpdateAutomation --context mentolder
+flux get image update --context fleet
+flux reconcile image repository <name> --context fleet
+flux reconcile image update <name> --context fleet
+flux logs --kind=ImageUpdateAutomation --context fleet
 ```
 
 ### Flux Failure Modes

--- a/.claude/skills/host-node-networking/SKILL.md
+++ b/.claude/skills/host-node-networking/SKILL.md
@@ -20,12 +20,12 @@ This runbook covers host-level networking, node provisioning, firewall rules, an
 The platform operates across stands of physical servers and local workstations connected via a WireGuard-mesh VPN overlay (`wg-mesh` on subnet `10.13.13.0/24` or `192.168.100.0/24` depending on cluster).
 
 ```
-          [ Hetzner Cloud CP Nodes ]
-             gekko-hetzner-1 (INIT)
-             gekko-hetzner-2 (JOIN)
-             gekko-hetzner-3 (JOIN / LiveKit)
+          [ Fleet Cluster (unified k3s — 6 nodes) ]
+     CP: pk-hetzner-4 (LiveKit) / pk-hetzner-6 / pk-hetzner-8
+     Workers: gekko-hetzner-2 / gekko-hetzner-3 / gekko-hetzner-4
+     (LiveKit pinned to pk-hetzner-4 via nodeAffinity; hostNetwork: true)
                       ▲
-                      │  (WireGuard mesh overlay)
+                      │  (WireGuard mesh overlay — wg-fleet)
                       ▼
         [ Local Workstation / WSL Host ] ◄──► [ GPU Worker (Ollama) ]
            (OpenClaw Gateway)                 (RTX 5070 Ti - 10.10.0.3)
@@ -184,15 +184,15 @@ LiveKit handles multi-user audio/video streams on `mentolder`.
 
 ### Step 3.1: Node Pinning & DNS Pinning
 
-Since LiveKit binds candidate IPs directly to its host via `hostNetwork: true`, it is pinned via `nodeAffinity` to `gekko-hetzner-3`.
+Since LiveKit binds candidate IPs directly to its host via `hostNetwork: true`, it is pinned via `nodeAffinity` to `pk-hetzner-4` (fleet cluster).
 If the pod is not scheduled, verify node labels:
 ```bash
-kubectl get nodes --context mentolder --show-labels | grep gekko-hetzner-3
+kubectl get nodes --context fleet --show-labels | grep pk-hetzner-4
 # Apply pin label if missing:
-kubectl label node gekko-hetzner-3 livekit-pin-node=true --context mentolder
+kubectl label node pk-hetzner-4 livekit-pin-node=true --context fleet
 ```
 
-DNS records for `livekit.mentolder.de` and `stream.mentolder.de` **must** point directly to `gekko-hetzner-3`'s public IP (`46.225.125.59`).
+DNS records for `livekit.mentolder.de` and `stream.mentolder.de` **must** point directly to `pk-hetzner-4`'s public IP (`204.168.244.104`).
 Verify with:
 ```bash
 dig livekit.mentolder.de +short

--- a/.claude/skills/keycloak-realm-sync/SKILL.md
+++ b/.claude/skills/keycloak-realm-sync/SKILL.md
@@ -11,7 +11,7 @@ description: Use when Keycloak realm configuration needs to be reconciled — OI
 
 # keycloak-realm-sync
 
-Reconcile Keycloak realm configuration from the checked-in realm JSON files. Covers the mentolder standalone cluster and the fleet cluster (hosting the korczewski brand).
+Reconcile Keycloak realm configuration from the checked-in realm JSON files. Covers both brands on the fleet cluster.
 
 ---
 

--- a/.claude/skills/knowledge-management/SKILL.md
+++ b/.claude/skills/knowledge-management/SKILL.md
@@ -78,11 +78,11 @@ Index repository documentation, GitHub PRs, and platform bug reports.
 Ensure the embedding backend for the target collection is reachable:
 * **TEI (bge-m3):** Check GPU host health and logs:
   ```bash
-  kubectl exec -n workspace --context mentolder -c llm-gateway -- curl -s http://localhost:8081/health
+  kubectl exec -n workspace --context fleet -c llm-gateway -- curl -s http://localhost:8081/health
   ```
 * **Voyage AI:** Verify api key length is valid:
   ```bash
-  kubectl get secret workspace-secrets -n workspace --context mentolder -o jsonpath='{.data.VOYAGE_API_KEY}' | base64 -d | wc -c
+  kubectl get secret workspace-secrets -n workspace --context fleet -o jsonpath='{.data.VOYAGE_API_KEY}' | base64 -d | wc -c
   ```
 
 ### Step 2.2: Execute Reindex

--- a/.claude/skills/mishap-tracker/SKILL.md
+++ b/.claude/skills/mishap-tracker/SKILL.md
@@ -41,8 +41,8 @@ For `process` mishaps, set `component = 'skills/<skill-name>'` and `attention_mo
 For each entry, attempt to insert into the Postgres tracker on mentolder:
 
 ```bash
-PGPOD=$(kubectl get pod -n workspace --context mentolder -l app=shared-db -o name | head -1)
-kubectl exec "$PGPOD" -n workspace --context mentolder -c postgres -- psql -U website -d website -At -c \
+PGPOD=$(kubectl get pod -n workspace --context fleet -l app=shared-db -o name | head -1)
+kubectl exec "$PGPOD" -n workspace --context fleet -c postgres -- psql -U website -d website -At -c \
   "INSERT INTO tickets.tickets (type, brand, title, description, severity, status, component${ATTN:+, attention_mode})
    VALUES ('<ticket_type>', 'mentolder', '<title>', '<description>', '<severity>', 'triage', '<component>'${ATTN:+, '$ATTN'})
    RETURNING external_id;"

--- a/.claude/skills/operations-management/SKILL.md
+++ b/.claude/skills/operations-management/SKILL.md
@@ -31,8 +31,8 @@ Never use `tickets.ticket_links` for PR references — it is ticket→ticket onl
 
 All SQL below assumes:
 ```bash
-PGPOD=$(kubectl get pod -n workspace --context mentolder -l app=shared-db -o name | head -1)
-psql() { kubectl exec "$PGPOD" -n workspace --context mentolder -c postgres -- psql -U website -d website "$@"; }
+PGPOD=$(kubectl get pod -n workspace --context fleet -l app=shared-db -o name | head -1)
+psql() { kubectl exec "$PGPOD" -n workspace --context fleet -c postgres -- psql -U website -d website "$@"; }
 ```
 
 ---
@@ -44,15 +44,15 @@ Use this process when a core platform service is down or degraded.
 ### Step 1.1: Scope the Incident (< 2 min)
 Determine:
 1. **Affected Service:** Keycloak, Nextcloud, Website, Brett, Arena, Vaultwarden, Docs, LiveKit, or Shared-DB.
-2. **Target Cluster:** `mentolder` (standalone), `fleet` (for korczewski brand, namespace `workspace-korczewski`), or both.
+2. **Target Cluster:** `mentolder` brand (fleet cluster), `korczewski` brand (fleet cluster), or both.
 3. **Onset Time:** Since when has it been failing? Check git log or deployment status.
 4. **Blast Radius:** All users or a subset of features?
 
 ### Step 1.2: Open an Incident Ticket
 Create a ticket in the database:
 ```bash
-PGPOD=$(kubectl get pod -n workspace --context mentolder -l app=shared-db -o name | head -1)
-kubectl exec "$PGPOD" -n workspace --context mentolder -c postgres -- psql -U website -d website -At -c \
+PGPOD=$(kubectl get pod -n workspace --context fleet -l app=shared-db -o name | head -1)
+kubectl exec "$PGPOD" -n workspace --context fleet -c postgres -- psql -U website -d website -At -c \
   "INSERT INTO tickets.tickets (type, brand, title, description, status, severity, priority)
    VALUES ('bug', 'mentolder', 'Incident: <desc>', 'Affected: <svc>\nCluster: <env>\nSymptoms: <symptoms>', 'in_progress', '<critical|major|minor>', 'hoch')
    RETURNING external_id;"
@@ -182,8 +182,8 @@ Convert local execution `MISHAP_LOG` entries into tickets.
 ### Step 4.2: Insert Tickets
 For each entry in the log:
 ```bash
-PGPOD=$(kubectl get pod -n workspace --context mentolder -l app=shared-db -o name | head -1)
-kubectl exec "$PGPOD" -n workspace --context mentolder -c postgres -- psql -U website -d website -At -c \
+PGPOD=$(kubectl get pod -n workspace --context fleet -l app=shared-db -o name | head -1)
+kubectl exec "$PGPOD" -n workspace --context fleet -c postgres -- psql -U website -d website -At -c \
   "INSERT INTO tickets.tickets (type, brand, title, description, severity, status, component)
    VALUES ('<type>', 'mentolder', '<title>', '<description>', '<severity>', 'triage', '<component>')
    RETURNING external_id;"

--- a/.claude/skills/secret-rotation/SKILL.md
+++ b/.claude/skills/secret-rotation/SKILL.md
@@ -11,7 +11,7 @@ description: Use when rotating secrets across clusters — DB passwords, API key
 
 # secret-rotation
 
-Safe, ordered secret rotation across the mentolder standalone cluster and the fleet cluster (hosting the korczewski brand).
+Safe, ordered secret rotation across both brands on the fleet cluster.
 
 ---
 
@@ -162,16 +162,16 @@ task mcp:logs -- keycloak
 
 ---
 
-## Cross-cluster checklist
+## Cross-brand checklist (both on fleet)
 
-Each cluster has its own sealed-secrets controller, sealing cert, and shared-db. Any secret rotation that touches both environments must be applied independently:
+Each brand namespace has its own SealedSecrets (on the same fleet cluster), sealing cert, and shared-db. Any secret rotation that touches both environments must be applied independently:
 
 ```bash
 task env:fetch-cert ENV=mentolder
 task env:seal ENV=mentolder
 task workspace:deploy ENV=mentolder
 
-# korczewski brand → fleet cluster, namespace workspace-korczewski
+# korczewski brand — on the same fleet cluster, namespace workspace-korczewski
 task env:fetch-cert ENV=korczewski
 task env:seal ENV=korczewski
 task workspace:deploy ENV=korczewski

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,7 +75,7 @@ Vollständige Task-Referenz siehe [CLAUDE.md](CLAUDE.md#common-commands).
 
 Nicht in CI (lokal bei Bedarf): `yamllint`, `shellcheck`, `kubeconform`. Frühere Doku behauptete das fälschlich.
 
-Weitere Workflows: `e2e.yml` (nightly Playwright gegen beide Prod-Cluster), `track-pr.yml` (PR → Tracking-JSON), `build-website.yml` / `build-website-korczewski.yml`, `dev-auto-deploy.yml`, `dev-smoke.yml`.
+Weitere Workflows: `e2e.yml` (nightly Playwright gegen beide Brands), `build-website.yml` / `build-website-korczewski.yml`, `dev-auto-deploy.yml`, `dev-smoke.yml`.
 
 ### Tests ausführen
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -4,10 +4,10 @@
 
 ## Project Overview
 
-Kubernetes-based self-hosted collaboration platform (bachelor thesis). Two prod clusters (`mentolder` + `korczewski`) plus k3d for dev. All services in `workspace` (mentolder) / `workspace-korczewski` (korczewski) namespaces, fronted by Traefik.
+Kubernetes-based self-hosted collaboration platform (bachelor thesis). Beide Marken laufen auf dem unified `fleet` Cluster (3 CP pk-hetzner-4/6/8, 3 Worker gekko-hetzner-2/3/4) plus k3d for dev. All services in `workspace` (mentolder) / `workspace-korczewski` (korczewski) namespaces, fronted by Traefik.
 
 **Core Services:**
-*   **Keycloak:** Identity Provider (SSO/OIDC, eigene Realm pro Cluster)
+*   **Keycloak:** Identity Provider (SSO/OIDC, eigene Realm pro Brand)
 *   **Nextcloud + Talk:** Dateien, Kalender, Kontakte, Video
 *   **Collabora Online:** WOPI-Backend für Nextcloud (separater `task workspace:office:deploy` Overlay)
 *   **Talk HPB:** WebRTC Signaling (Janus + NATS + coturn)
@@ -19,11 +19,11 @@ Kubernetes-based self-hosted collaboration platform (bachelor thesis). Two prod 
 *   **Website:** Astro + Svelte (Brand-aware: mentolder + korczewski via `BRAND_ID`)
 *   **Claude Code MCP Monolith:** AI-Tooling
 *   **Traefik:** Ingress Controller
-*   **PostgreSQL `shared-db`:** Eigene Instanz pro Cluster, separate DBs pro Service
+*   **PostgreSQL `shared-db`:** Eigene Instanz pro Brand/Namespace (workspace / workspace-korczewski), separate DBs pro Service
 
 **Infrastructure:**
 *   k3d (Dev) + k3s (Prod). Kustomize-basierte Manifeste, reconciliiert via Flux GitOps (Pull-basiert).
-*   SealedSecrets (bitnami) pro Cluster; Secrets-Pipeline via `task env:seal ENV=<env>`.
+*   SealedSecrets (bitnami) pro Brand; Secrets-Pipeline via `task env:seal ENV=<env>`.
 
 ## Building and Running
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ task workspace:post-setup      # Nextcloud-Apps + OIDC
 
 ## Produktion
 
-Zwei Brands (`ENV=mentolder` / `ENV=korczewski`). **Fleet-Stage-2-Migration läuft (Stand 2026-05-30):** `mentolder` ist weiterhin ein eigenständiger k3s-Cluster; der standalone `korczewski`-Cluster wurde abgebaut, die korczewski-Brand läuft jetzt über den `fleet`-Cluster (`pk-hetzner-4/6/8`, ns `workspace-korczewski`). Details in CLAUDE.md. Jede ENV-aware Task akzeptiert `ENV=mentolder` oder `ENV=korczewski`:
+Zwei Brands (`ENV=mentolder` / `ENV=korczewski`). **Fleet-Stage-3 abgeschlossen (Stand 2026-05-31):** Beide Marken laufen auf dem vereinheitlichten `fleet`-Cluster (`pk-hetzner-4/6/8`, + 3 Worker gekko-hetzner-2/3/4). Mentolder läuft im Namespace `workspace` (mentolder.de), Korczewski in `workspace-korczewski` (korczewski.de). Der alte `mentolder`-Standalone-Cluster wurde **decommissioned**. Details in CLAUDE.md. Jede ENV-aware Task akzeptiert `ENV=mentolder` oder `ENV=korczewski`:
 
 ```bash
 task workspace:deploy ENV=mentolder

--- a/USER.md
+++ b/USER.md
@@ -9,10 +9,10 @@
 
 ## Context
 
-Patrick is writing his bachelor thesis — this repo IS the thesis project: a self-hosted Kubernetes collaboration platform for small teams. He runs two live production clusters:
+Patrick is writing his bachelor thesis — this repo IS the thesis project: a self-hosted Kubernetes collaboration platform for small teams. He runs a single unified fleet cluster hosting both brands:
 
-- **mentolder** — Hetzner VPS, hosts mentolder.de (his dad's coaching platform, Astro+Svelte)
-- **korczewski** — separate k3s cluster, hosts korczewski.de
+- **mentolder** — fleet namespace `workspace`, hosts mentolder.de (his dad's coaching platform, Astro+Svelte)
+- **korczewski** — fleet namespace `workspace-korczewski`, hosts korczewski.de
 
 He prefers direct, concise communication. No filler, no step-by-step narration. Merge PRs immediately after creating (PRs are for history, not review). Always work against live environments (mentolder/korczewski), never k3d-dev for production changes.
 

--- a/arena-server/README.md
+++ b/arena-server/README.md
@@ -20,4 +20,4 @@ pnpm test
 
 ## Deployment
 
-See `task arena:deploy ENV=korczewski` in the repo root Taskfile. Arena runs on the korczewski cluster only (`arena-ws.korczewski.de`).
+See `task arena:deploy ENV=korczewski` in the repo root Taskfile. Arena runs on the korczewski brand (namespace `workspace-korczewski` on the fleet cluster, `arena-ws.korczewski.de`).

--- a/claude-code/gekko-android-mcp-guide.md
+++ b/claude-code/gekko-android-mcp-guide.md
@@ -4,7 +4,7 @@
 > ohne Fachbegriffe geschrieben — einfach Schritt für Schritt durchgehen.
 >
 > **Geltungsbereich:** Diese Anleitung bezieht sich auf den MCP-Server unter `mcp.mentolder.de`
-> (mentolder-Cluster). Für korczewski.de gibt es einen separaten MCP-Endpunkt unter `mcp.korczewski.de`.
+> (fleet cluster, mentolder brand). Für korczewski.de gibt es einen separaten MCP-Endpunkt unter `mcp.korczewski.de`.
 >
 > **Vor dem Verschicken:** Patrick muss an einer Stelle (Schritt 2) den
 > Bearer-Token einsetzen. Anweisung dafür ganz unten.
@@ -124,7 +124,7 @@ Bei Fragen: einfach Patrick anrufen 😄
 So bekommst du den Bearer-Token, den du oben in Schritt 2 einsetzen musst:
 
 ```bash
-kubectl --context mentolder -n default get secret mcp-tokens \
+kubectl --context fleet -n default get secret mcp-tokens \
   -o jsonpath='{.data.BUSINESS_TOKEN}' | base64 -d; echo
 ```
 

--- a/docs/dev-stack/README.md
+++ b/docs/dev-stack/README.md
@@ -1,19 +1,19 @@
 # dev.mentolder.de — Operator Runbook
 
 Persistent staging stack hosted as a k3d-in-k3s sibling on
-`gekko-hetzner-2`. Mirrors the website + Brett against last night's prod
-data; ad-hoc reverse-SSH tunnels publish localhost ports as
-`<name>.dev.mentolder.de`. All traffic passes through the same
-Keycloak realm as prod via a dedicated `workspace-dev` OIDC client —
-membership in `/dev-access` is required.
+`k3s-1` (10.0.3.1, wg-mesh 192.168.100.20). Mirrors the website + Brett
+against last night's prod data; ad-hoc reverse-SSH tunnels publish
+localhost ports as `<name>.dev.mentolder.de`. All traffic passes through
+the same Keycloak realm as prod via a dedicated `workspace-dev` OIDC
+client — membership in `/dev-access` is required.
 
 ## Architecture (one paragraph)
 
 A k3d cluster (`mentolder-dev`) runs as a Docker workload on
-`gekko-hetzner-2`. Its HTTP loadbalancer binds `127.0.0.1:18080`. Prod
+`k3s-1` (10.0.3.1). Its HTTP loadbalancer binds `127.0.0.1:18080`. Prod
 Traefik fronts it as an SSO-gated reverse proxy: `oauth2-proxy-dev`
 (in the prod `workspace` namespace, `hostNetwork: true`, pinned to
-`gekko-hetzner-2`) dials `127.0.0.1:18080` after auth via
+`k3s-1`) dials `127.0.0.1:18080` after auth via
 `workspace-dev` Keycloak client. A nightly CronJob `pg_restore`s the
 latest prod snapshot into `shared-db-dev`. `sish` exposes
 `0.0.0.0:2222` for `ssh -R` tunnels, gated by pubkey-auth plus a ufw
@@ -21,7 +21,7 @@ allowlist (`DEV_SSH_ALLOWLIST` → `task dev:firewall:open`).
 
 ```
 client
-  └─ HTTPS ─► prod Traefik (gekko-hetzner-2)
+  └─ HTTPS ─► prod Traefik (k3s-1)
               └─ workspace-ingress-dev (host *.dev.mentolder.de)
                   └─ ForwardAuth middleware ─► oauth2-proxy-dev:4181/oauth2/auth
                   └─ backend ─► oauth2-proxy-dev:4181
@@ -66,16 +66,16 @@ client
 
 | Symptom | Probable cause | Fix |
 |---|---|---|
-| `web.dev.mentolder.de` returns 502 | k3d cluster not running or oauth2-proxy-dev down | `task dev:cluster:status`; check `kubectl --context mentolder -n workspace get pods -l app=oauth2-proxy-dev`. |
+| `web.dev.mentolder.de` returns 502 | k3d cluster not running or oauth2-proxy-dev down | `task dev:cluster:status`; check `kubectl --context fleet -n workspace get pods -l app=oauth2-proxy-dev`. |
 | Looping at the SSO callback | KC user not in `/dev-access`, or `workspace-dev` client redirect URIs out of sync with `${DEV_DOMAIN}` | Re-check group membership; `task keycloak:sync ENV=mentolder`. |
-| `dev-tls.bats` cert check fails | LetsEncrypt rate-limit, or DNS record for `*.dev.mentolder.de` drifted | `kubectl --context mentolder -n workspace get certificate workspace-dev-wildcard-tls`; re-pin DNS via the ipv64 API. |
+| `dev-tls.bats` cert check fails | LetsEncrypt rate-limit, or DNS record for `*.dev.mentolder.de` drifted | `kubectl --context fleet -n workspace get certificate workspace-dev-wildcard-tls`; re-pin DNS via the ipv64 API. |
 | `dev:db:refresh` errors with "No backups found" | backup-pvc empty on the prod side | Inspect the prod `backup` CronJob — `task workspace:backup:list ENV=mentolder`. |
 | `ssh -R` from new laptop hangs | `DEV_SSH_ALLOWLIST` missing the CIDR | Add and `task dev:firewall:open`. |
 
 ## Gotchas (reproduce in CLAUDE.md§Gotchas before merge)
 
 - **`dev:cluster:create` MUST run while logged in to the laptop that
-  can SSH `root@gekko-hetzner-2`.** It doesn't bootstrap the node
+  can SSH `root@k3s-1`.** It doesn't bootstrap the node
   itself — Docker + k3d binary must already be there (Task 10 of the
   plan covers this).
 - **The dev cluster sees prod data.** Don't write production rituals

--- a/docs/fleet-stage2-cutover-runbook.md
+++ b/docs/fleet-stage2-cutover-runbook.md
@@ -1,5 +1,10 @@
 # Fleet Stage 2 — Cutover Runbook
 
+> **ARCHIVAL NOTICE:** This runbook documents a completed migration (executed 2026-05-30/31).
+> The mentolder-standalone cluster has been **decommissioned**. Both brands now run on the
+> unified `fleet` cluster (3 CP pk-hetzner-4/6/8, 3 workers gekko-hetzner-2/3/4).
+> This document is retained as a historical reference only.
+
 Spec: `docs/superpowers/specs/2026-05-30-fleet-stage2-dns-cutover-design.md`
 Order: **fleet platform deploy** → **mentolder** (data copy + reversible DNS flip) →
 same-day soak → **korczewski** (fresh deploy + DNS cleanup).
@@ -15,9 +20,8 @@ same-day soak → **korczewski** (fresh deploy + DNS cleanup).
 >   brand via the `fleet` context, namespace `workspace-korczewski`** — do NOT try to "fix"
 >   the `korczewski` context (ticket T000340). The fleet deploy has run; korczewski.de
 >   availability now depends on DNS/cert readiness (Phase 2b/2c + cutover still pending).
-> - **mentolder-standalone is still live** on separate gekko hardware, with intact local
->   backups. So mentolder is a reversible DNS flip with a warm fallback; korczewski is a
->   fresh deploy (its data is NOT being restored — see §3).
+> - **mentolder-standalone has been decommissioned** (was still live when this runbook was
+>   written; Phase 3 completed 2026-05-31). No fallback exists — both brands are fleet-only.
 
 ## 0. Prerequisite gate — fleet platform deploy (Phase 2a COMPLETE, 2b/2c pending)
 

--- a/environments/korczewski.yaml
+++ b/environments/korczewski.yaml
@@ -1,6 +1,6 @@
 # environments/korczewski.yaml
 environment: korczewski
-context: korczewski
+context: fleet
 domain: korczewski.de
 
 env_vars:

--- a/tests/unit/agent-ops-output-trust.bats
+++ b/tests/unit/agent-ops-output-trust.bats
@@ -36,7 +36,7 @@ AGENT_FILE="${PROJECT_DIR}/.claude/agents/bachelorprojekt-ops.md"
 }
 
 @test "ops agent prescribes the trivial verifiable probe" {
-  run grep -qF 'kubectl get nodes --context mentolder' "$AGENT_FILE"
+  run grep -qF 'kubectl get nodes --context fleet' "$AGENT_FILE"
   [ "$status" -eq 0 ]
 }
 


### PR DESCRIPTION
## Summary

Full documentation sweep reconciling all 28 files with the **Fleet Stage 3** consolidated topology.

### Root cause
CLAUDE.md was updated to reflect the fleet consolidation (mentolder-standalone decommissioned, single `fleet` cluster), but agents, skills, and docs still described Fleet Stage 2 (two clusters, mentolder standalone alive).

### What changed

**6 Subagents** — Topology rewrites: Fleet Stage 2 → 3, context `mentolder` → `fleet`, node roles updated, LiveKit pin corrected.

**13 Skills** — All "standalone cluster" / "dual cluster" references replaced with unified fleet language. Network diagram and LiveKit pin updated in `host-node-networking`. Full rewrite of `fleet-ops` from dual-cluster to cross-brand model.

**8 Root/Sub-docs** — README, GEMINI, USER, CONTRIBUTING, dev-stack, fleet-runbook (archival notice), arena-server, gekko-mcp-guide.

**1 Env Config** — `environments/korczewski.yaml`: context `korczewski` → `fleet` (dead context removed).

### Files (28)
```
M  .claude/agents/bachelorprojekt-db.md
M  .claude/agents/bachelorprojekt-infra.md
M  .claude/agents/bachelorprojekt-ops.md
M  .claude/agents/bachelorprojekt-security.md
M  .claude/agents/bachelorprojekt-test.md
M  .claude/agents/bachelorprojekt-website.md
M  .claude/skills/OVERVIEW.md
M  .claude/skills/arena-brett-deploy/SKILL.md
M  .claude/skills/cluster-deployment/SKILL.md
M  .claude/skills/database-ops/SKILL.md
M  .claude/skills/dev-flow-execute/SKILL.md
M  .claude/skills/dev-flow-plan/SKILL.md
M  .claude/skills/fleet-ops/SKILL.md
M  .claude/skills/host-node-networking/SKILL.md
M  .claude/skills/keycloak-realm-sync/SKILL.md
M  .claude/skills/knowledge-management/SKILL.md
M  .claude/skills/mishap-tracker/SKILL.md
M  .claude/skills/operations-management/SKILL.md
M  .claude/skills/secret-rotation/SKILL.md
M  CONTRIBUTING.md
M  GEMINI.md
M  README.md
M  USER.md
M  arena-server/README.md
M  claude-code/gekko-android-mcp-guide.md
M  docs/dev-stack/README.md
M  docs/fleet-stage2-cutover-runbook.md
M  environments/korczewski.yaml
```

### Verification
- Zero `--context mentolder` references remain in agents/skills
- Zero "Fleet Stage 2" references remain in agents/skills
- Zero "standalone cluster" (non-historical) references remain
- All ENV contexts now point to `fleet`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
