### PR TITLE
fix(infra): allow CronJob egress to the Kubernetes apiserver + drop stale affinity

### DIFF
--- a/docs/superpowers/plans/2026-05-31-cronjob-apiserver-egress.md
+++ b/docs/superpowers/plans/2026-05-31-cronjob-apiserver-egress.md
@@ -1,0 +1,87 @@
+---
+title: CronJob API-server egress + drift fixes Implementation Plan
+ticket_id: T000368
+domains: [infra, ops, test]
+status: active
+pr_number: null
+---
+
+# CronJob API-server egress + drift fixes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop the nightly (03:00 UTC) failures of the `pvc-backup` (T000368) and `tests-results-retention` (T000369) CronJobs on both fleet brands by closing a NetworkPolicy egress gap and removing two pieces of post-consolidation manifest drift.
+
+**Root cause (already diagnosed — do NOT re-investigate the cluster):** `wg-fleet` is healthy. The failures come from the `default-deny-egress` NetworkPolicy in `workspace`/`workspace-korczewski`: no policy permits egress to the Kubernetes API server, so in-cluster `kubectl` calls fail with `dial tcp 10.43.0.1:443: connection refused`. **Proven empirically:** kube-router evaluates egress against the *post-DNAT* endpoint — the apiserver is hostNetwork, so its endpoints are the CP **node IPs `10.20.0.0/24:6443`**, not the ClusterIP. Allowing only `10.43.0.0/16:443` does NOT work (kubectl still fails); adding `10.20.0.0/24:6443` → 12/12 reachable + `kubectl get --raw /version` OK.
+
+Two compounding bugs in the same blast radius:
+- `pvc-backup` orchestrator hardcodes `NS=workspace` in its container args. kustomize namespace-remapping does not rewrite string literals, so on korczewski (ns `workspace-korczewski`) the SA operates in `workspace` and hits RBAC `Forbidden`.
+- `pvc-backup` mounter `nodeAffinity` excludes decommissioned node names (`k3s-1/2/3`, `k3w-1/2/3`) that no longer exist on fleet (dead no-op drift).
+- `tests-results-retention` requires `nodeAffinity` `node-location=hetzner`; no fleet node carries that label → unschedulable on all 6 nodes.
+
+**Architecture:** All fixes are in the shared `k3d/` base (consumed by both prod overlays via the namespace directive), so a single change fixes both brands. The new `allow-apiserver-egress` NetworkPolicy mirrors the existing namespace-wide allow policies (`allow-dns-egress`, `allow-internet-egress`) — podSelector `{}`, tightly scoped to the apiserver ports/CIDRs. API access is RBAC-gated, so a namespace-wide egress allow is low-risk and is consistent with `allow-cronjobs-to-website-egress` (which also uses `podSelector: {}` because short-lived CronJob pods have no stable label).
+
+**Tech Stack:** Kustomize, kubectl, BATS (`tests/unit/manifests.bats`).
+
+**Spec/diagnosis source:** memory `reference_workspace_apiserver_egress_gap`. **Tickets:** T000368 (major), T000369 (trivial).
+
+---
+
+## Failing tests (already written & RED — `tests/unit/manifests.bats`)
+
+- [ ] `network-policies grant egress to the Kubernetes apiserver (T000368)` — asserts a NetworkPolicy egresses to `10.20.0.0/24:6443` **and** `10.43.0.0/16:443`.
+- [ ] `pvc-backup derives namespace at runtime, not hardcoded NS=workspace (T000368)`
+- [ ] `pvc-backup mounter nodeAffinity has no decommissioned node names (T000368)`
+- [ ] `tests-results-retention has no stale node-location affinity (T000369)`
+
+These 4 tests are committed alongside this plan and currently fail (proven red). Each task below turns one or more green.
+
+## Task 1 — Add `allow-apiserver-egress` NetworkPolicy (T000368)
+
+- [ ] In `k3d/network-policies.yaml`, append a new `NetworkPolicy` named `allow-apiserver-egress`:
+  - `podSelector: {}`, `policyTypes: [Egress]`
+  - egress rule 1: `to: [{ipBlock: {cidr: 10.20.0.0/24}}]`, `ports: [{port: 6443, protocol: TCP}]` — fleet CP node IPs (post-DNAT apiserver endpoints). Comment why the node CIDR (not ClusterIP) is the operative allow.
+  - egress rule 2: `to: [{ipBlock: {cidr: 10.43.0.0/16}}]`, `ports: [{port: 443, protocol: TCP}]` — ClusterIP (defense-in-depth / clusters matching pre-DNAT).
+- [ ] Verify: `kubectl kustomize k3d/ | grep -A12 allow-apiserver-egress` shows both CIDRs/ports.
+- [ ] Test `network-policies grant egress to the Kubernetes apiserver` goes green.
+
+## Task 2 — Derive pvc-backup namespace at runtime (T000368)
+
+- [ ] In `k3d/pvc-backup-cronjob.yaml` orchestrator script, replace `NS=workspace` with:
+  `NS=$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)`
+- [ ] Confirm no other hardcoded `workspace` namespace literal remains in the orchestrator/mounter args (the mounter `apply` uses `-n "$NS"` via the orchestrator; clones/jobs are created with `-n "$NS"`). The metadata `namespace: workspace` on the CronJob object itself stays (kustomize remaps it per overlay).
+- [ ] Test `pvc-backup derives namespace at runtime` goes green.
+
+## Task 3 — Remove stale mounter nodeAffinity (T000368)
+
+- [ ] In `k3d/pvc-backup-cronjob.yaml`, the mounter Job's `nodeAffinity` `NotIn [k3s-1,k3s-2,k3s-3,k3w-1,k3w-2,k3w-3]` references dead nodes. The mounter is already co-located with the nextcloud pod via `podAffinity` (required, topology hostname), which is what makes nextcloud's local-path volume shareable. Remove the dead `nodeAffinity` block (keep `podAffinity`) — the podAffinity is sufficient and the NotIn list was a no-op on fleet.
+- [ ] Verify the mounter still renders with the nextcloud `podAffinity` intact: `kubectl kustomize k3d/ | grep -B2 -A6 'app: nextcloud'`.
+- [ ] Test `pvc-backup mounter nodeAffinity has no decommissioned node names` goes green.
+
+## Task 4 — Remove stale tests-results-retention nodeAffinity (T000369)
+
+- [ ] In `k3d/tests-retention-cronjob.yaml`, remove the `affinity.nodeAffinity` block requiring `node-location In [hetzner]`. The prune job only `kubectl exec`s into the website pod and is placement-independent. It will rely on the new `allow-apiserver-egress` policy (Task 1) to reach the API for the exec.
+- [ ] Test `tests-results-retention has no stale node-location affinity` goes green.
+
+## Task 5 — Verify & validate
+
+- [ ] `./tests/runner.sh local manifests` — all green (incl. the 4 new tests).
+- [ ] `task test:all` — green (offline CI parity).
+- [ ] `task workspace:validate` — manifests valid.
+- [ ] `task test:inventory && git diff --exit-code website/src/data/test-inventory.json` — regenerate + commit if changed (4 new test IDs).
+
+## Deploy (post-merge, via dev-flow-execute)
+
+- [ ] `task feature:deploy` (fans out `k3d/`+overlay changes to both fleet brands) — files touched are `k3d/**`.
+- [ ] Post-deploy verification (live):
+  - Confirm `allow-apiserver-egress` exists in both namespaces: `kubectl --context fleet -n workspace get netpol allow-apiserver-egress` (and `-n workspace-korczewski`).
+  - Manually trigger a backup run and confirm the orchestrator reaches the API on a gekko-hosted pod:
+    `kubectl --context fleet -n workspace create job --from=cronjob/pvc-backup pvc-backup-manual-verify` → check it gets past "Creating clone PVCs" (no `connection refused`).
+  - For korczewski, confirm no `Forbidden ... namespace "workspace"` in the orchestrator log (namespace now runtime-derived).
+  - Unsuspend/confirm `tests-results-retention` schedules (no longer `Unschedulable`).
+  - Clean up the manual verify job afterward.
+
+## Notes / out of scope
+
+- **No host/wireguard changes.** `wg-fleet` is healthy; the original T000368 "ClusterIP unreachable" framing pointed at networking but the cause is the netpol egress gap. Update T000368 with the corrected root cause on close.
+- Dev k3d (single-node) is unaffected by the node-CIDR allow (harmless unused rule there).

--- a/docs/superpowers/plans/2026-05-31-cronjob-apiserver-egress.md
+++ b/docs/superpowers/plans/2026-05-31-cronjob-apiserver-egress.md
@@ -29,50 +29,50 @@ Two compounding bugs in the same blast radius:
 
 ## Failing tests (already written & RED — `tests/unit/manifests.bats`)
 
-- [ ] `network-policies grant egress to the Kubernetes apiserver (T000368)` — asserts a NetworkPolicy egresses to `10.20.0.0/24:6443` **and** `10.43.0.0/16:443`.
-- [ ] `pvc-backup derives namespace at runtime, not hardcoded NS=workspace (T000368)`
-- [ ] `pvc-backup mounter nodeAffinity has no decommissioned node names (T000368)`
-- [ ] `tests-results-retention has no stale node-location affinity (T000369)`
+- [x] `network-policies grant egress to the Kubernetes apiserver (T000368)` — asserts a NetworkPolicy egresses to `10.20.0.0/24:6443` **and** `10.43.0.0/16:443`.
+- [x] `pvc-backup derives namespace at runtime, not hardcoded NS=workspace (T000368)`
+- [x] `pvc-backup mounter nodeAffinity has no decommissioned node names (T000368)`
+- [x] `tests-results-retention has no stale node-location affinity (T000369)`
 
 These 4 tests are committed alongside this plan and currently fail (proven red). Each task below turns one or more green.
 
 ## Task 1 — Add `allow-apiserver-egress` NetworkPolicy (T000368)
 
-- [ ] In `k3d/network-policies.yaml`, append a new `NetworkPolicy` named `allow-apiserver-egress`:
+- [x] In `k3d/network-policies.yaml`, append a new `NetworkPolicy` named `allow-apiserver-egress`:
   - `podSelector: {}`, `policyTypes: [Egress]`
   - egress rule 1: `to: [{ipBlock: {cidr: 10.20.0.0/24}}]`, `ports: [{port: 6443, protocol: TCP}]` — fleet CP node IPs (post-DNAT apiserver endpoints). Comment why the node CIDR (not ClusterIP) is the operative allow.
   - egress rule 2: `to: [{ipBlock: {cidr: 10.43.0.0/16}}]`, `ports: [{port: 443, protocol: TCP}]` — ClusterIP (defense-in-depth / clusters matching pre-DNAT).
-- [ ] Verify: `kubectl kustomize k3d/ | grep -A12 allow-apiserver-egress` shows both CIDRs/ports.
-- [ ] Test `network-policies grant egress to the Kubernetes apiserver` goes green.
+- [x] Verify: `kubectl kustomize k3d/ | grep -A12 allow-apiserver-egress` shows both CIDRs/ports.
+- [x] Test `network-policies grant egress to the Kubernetes apiserver` goes green.
 
 ## Task 2 — Derive pvc-backup namespace at runtime (T000368)
 
-- [ ] In `k3d/pvc-backup-cronjob.yaml` orchestrator script, replace `NS=workspace` with:
+- [x] In `k3d/pvc-backup-cronjob.yaml` orchestrator script, replace `NS=workspace` with:
   `NS=$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)`
-- [ ] Confirm no other hardcoded `workspace` namespace literal remains in the orchestrator/mounter args (the mounter `apply` uses `-n "$NS"` via the orchestrator; clones/jobs are created with `-n "$NS"`). The metadata `namespace: workspace` on the CronJob object itself stays (kustomize remaps it per overlay).
-- [ ] Test `pvc-backup derives namespace at runtime` goes green.
+- [x] Confirm no other hardcoded `workspace` namespace literal remains in the orchestrator/mounter args (the mounter `apply` uses `-n "$NS"` via the orchestrator; clones/jobs are created with `-n "$NS"`). The metadata `namespace: workspace` on the CronJob object itself stays (kustomize remaps it per overlay).
+- [x] Test `pvc-backup derives namespace at runtime` goes green.
 
 ## Task 3 — Remove stale mounter nodeAffinity (T000368)
 
-- [ ] In `k3d/pvc-backup-cronjob.yaml`, the mounter Job's `nodeAffinity` `NotIn [k3s-1,k3s-2,k3s-3,k3w-1,k3w-2,k3w-3]` references dead nodes. The mounter is already co-located with the nextcloud pod via `podAffinity` (required, topology hostname), which is what makes nextcloud's local-path volume shareable. Remove the dead `nodeAffinity` block (keep `podAffinity`) — the podAffinity is sufficient and the NotIn list was a no-op on fleet.
-- [ ] Verify the mounter still renders with the nextcloud `podAffinity` intact: `kubectl kustomize k3d/ | grep -B2 -A6 'app: nextcloud'`.
-- [ ] Test `pvc-backup mounter nodeAffinity has no decommissioned node names` goes green.
+- [x] In `k3d/pvc-backup-cronjob.yaml`, the mounter Job's `nodeAffinity` `NotIn [k3s-1,k3s-2,k3s-3,k3w-1,k3w-2,k3w-3]` references dead nodes. The mounter is already co-located with the nextcloud pod via `podAffinity` (required, topology hostname), which is what makes nextcloud's local-path volume shareable. Remove the dead `nodeAffinity` block (keep `podAffinity`) — the podAffinity is sufficient and the NotIn list was a no-op on fleet.
+- [x] Verify the mounter still renders with the nextcloud `podAffinity` intact: `kubectl kustomize k3d/ | grep -B2 -A6 'app: nextcloud'`.
+- [x] Test `pvc-backup mounter nodeAffinity has no decommissioned node names` goes green.
 
 ## Task 4 — Remove stale tests-results-retention nodeAffinity (T000369)
 
-- [ ] In `k3d/tests-retention-cronjob.yaml`, remove the `affinity.nodeAffinity` block requiring `node-location In [hetzner]`. The prune job only `kubectl exec`s into the website pod and is placement-independent. It will rely on the new `allow-apiserver-egress` policy (Task 1) to reach the API for the exec.
-- [ ] Test `tests-results-retention has no stale node-location affinity` goes green.
+- [x] In `k3d/tests-retention-cronjob.yaml`, remove the `affinity.nodeAffinity` block requiring `node-location In [hetzner]`. The prune job only `kubectl exec`s into the website pod and is placement-independent. It will rely on the new `allow-apiserver-egress` policy (Task 1) to reach the API for the exec.
+- [x] Test `tests-results-retention has no stale node-location affinity` goes green.
 
 ## Task 5 — Verify & validate
 
-- [ ] `./tests/runner.sh local manifests` — all green (incl. the 4 new tests).
-- [ ] `task test:all` — green (offline CI parity).
-- [ ] `task workspace:validate` — manifests valid.
-- [ ] `task test:inventory && git diff --exit-code website/src/data/test-inventory.json` — regenerate + commit if changed (4 new test IDs).
+- [x] `./tests/runner.sh local manifests` — all green (incl. the 4 new tests).
+- [x] `task test:all` — green (offline CI parity).
+- [x] `task workspace:validate` — manifests valid.
+- [x] `task test:inventory && git diff --exit-code website/src/data/test-inventory.json` — regenerate + commit if changed (4 new test IDs).
 
 ## Deploy (post-merge, via dev-flow-execute)
 
-- [ ] `task feature:deploy` (fans out `k3d/`+overlay changes to both fleet brands) — files touched are `k3d/**`.
+- [x] `task feature:deploy` (fans out `k3d/`+overlay changes to both fleet brands) — files touched are `k3d/**`.
 - [ ] Post-deploy verification (live):
   - Confirm `allow-apiserver-egress` exists in both namespaces: `kubectl --context fleet -n workspace get netpol allow-apiserver-egress` (and `-n workspace-korczewski`).
   - Manually trigger a backup run and confirm the orchestrator reaches the API on a gekko-hosted pod:

--- a/k3d/network-policies.yaml
+++ b/k3d/network-policies.yaml
@@ -74,6 +74,38 @@ spec:
         - 172.16.0.0/12
         - 192.168.0.0/16
 ---
+# Kubernetes-API-Server erreichen (T000368).
+# In-cluster CronJobs (pvc-backup, tests-results-retention) rufen die API via
+# kubectl auf. allow-internet-egress schließt 10.0.0.0/8 aus, deshalb braucht
+# es eine gezielte Freigabe. WICHTIG: kube-router wertet Egress gegen den
+# POST-DNAT-Endpoint aus — der apiserver läuft hostNetwork, seine Endpoints
+# sind die CP-Node-IPs (10.20.0.0/24:6443), NICHT die ClusterIP. Eine reine
+# ClusterIP-Freigabe (10.43.0.0/16:443) reicht daher NICHT; die Node-CIDR auf
+# 6443 ist die operative Regel (empirisch verifiziert: 12/12 + kubectl OK).
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-apiserver-egress
+spec:
+  podSelector: {}
+  policyTypes:
+  - Egress
+  egress:
+  # CP-Node-IPs = apiserver-Endpoints nach DNAT (fleet wg-fleet-Subnet)
+  - to:
+    - ipBlock:
+        cidr: 10.20.0.0/24
+    ports:
+    - protocol: TCP
+      port: 6443
+  # ClusterIP der kubernetes.default Service (defense-in-depth / pre-DNAT-Match)
+  - to:
+    - ipBlock:
+        cidr: 10.43.0.0/16
+    ports:
+    - protocol: TCP
+      port: 443
+---
 # LLM-Gateway-Hosts auf dem wg-mesh erreichen (192.168.100.x mentolder, 10.13.14.x korczewski)
 # allow-internet-egress blockiert RFC1918 — diese Policy öffnet gezielt die wg-mesh-Subnets.
 apiVersion: networking.k8s.io/v1

--- a/k3d/pvc-backup-cronjob.yaml
+++ b/k3d/pvc-backup-cronjob.yaml
@@ -53,7 +53,12 @@ spec:
               args:
                 - |
                   set -eu
-                  NS=workspace
+                  # Derive the namespace at runtime from the pod's serviceaccount.
+                  # kustomize namespace-remapping does NOT rewrite string literals
+                  # in container args, so a hardcoded NS=workspace operated in the
+                  # wrong namespace on the korczewski brand (workspace-korczewski)
+                  # and hit RBAC Forbidden. [T000368]
+                  NS=$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)
                   STAMP=$(date +%Y%m%d-%H%M%S)
                   MOUNTER="pvc-backup-mounter-$${STAMP}"
                   CLONES="vaultwarden-data-backup-clone docuseal-data-backup-clone"
@@ -126,17 +131,16 @@ spec:
                       spec:
                         restartPolicy: Never
                         affinity:
+                          # Co-locate with the nextcloud pod so its local-path
+                          # volume is shareable (same node). This podAffinity is
+                          # sufficient for placement; the former nodeAffinity NotIn
+                          # list referenced decommissioned nodes (k3s-1/2/3,
+                          # k3w-1/2/3) that no longer exist on fleet — dead drift,
+                          # removed. [T000368]
                           podAffinity:
                             requiredDuringSchedulingIgnoredDuringExecution:
                               - labelSelector: { matchLabels: { app: nextcloud } }
                                 topologyKey: kubernetes.io/hostname
-                          nodeAffinity:
-                            requiredDuringSchedulingIgnoredDuringExecution:
-                              nodeSelectorTerms:
-                                - matchExpressions:
-                                    - key: kubernetes.io/hostname
-                                      operator: NotIn
-                                      values: [k3s-1, k3s-2, k3s-3, k3w-1, k3w-2, k3w-3]
                         securityContext:
                           runAsNonRoot: true
                           runAsUser: 65534

--- a/k3d/tests-retention-cronjob.yaml
+++ b/k3d/tests-retention-cronjob.yaml
@@ -13,14 +13,10 @@ spec:
         spec:
           restartPolicy: Never
           serviceAccountName: tests-retention-sa
-          affinity:
-            nodeAffinity:
-              requiredDuringSchedulingIgnoredDuringExecution:
-                nodeSelectorTerms:
-                  - matchExpressions:
-                      - key: node-location
-                        operator: In
-                        values: [hetzner]
+          # No nodeAffinity: this prune job only kubectl-execs into the website
+          # pod (placement-independent). The former node-location=hetzner affinity
+          # matched no fleet node after Phase 3 consolidation → unschedulable on
+          # all 6 nodes. Reaches the API via the allow-apiserver-egress policy. [T000369]
           containers:
             - name: prune
               # alpine/k8s ships kubectl + /bin/sh on Alpine; matches the k3s

--- a/tests/unit/manifests.bats
+++ b/tests/unit/manifests.bats
@@ -523,7 +523,8 @@ PY
 # The mounter nodeAffinity excluded node names from decommissioned clusters
 # (k3s-1/2/3, k3w-1/2/3) which no longer exist on fleet — dead drift.
 @test "pvc-backup mounter nodeAffinity has no decommissioned node names (T000368)" {
-  run grep -E 'k3s-1|k3s-2|k3s-3|k3w-1|k3w-2|k3w-3' k3d/pvc-backup-cronjob.yaml
+  # Ignore comment lines — a comment referencing the old names is not the bug.
+  run bash -c "grep -vE '^[[:space:]]*#' k3d/pvc-backup-cronjob.yaml | grep -E 'k3s-1|k3s-2|k3s-3|k3w-1|k3w-2|k3w-3'"
   assert_failure
 }
 
@@ -533,7 +534,8 @@ PY
 # nodes. The prune job is placement-independent (kubectl exec into the website
 # pod), so the affinity must be dropped.
 @test "tests-results-retention has no stale node-location affinity (T000369)" {
-  run grep -E 'node-location' k3d/tests-retention-cronjob.yaml
+  # Ignore comment lines — a comment explaining the removal is not the bug.
+  run bash -c "grep -vE '^[[:space:]]*#' k3d/tests-retention-cronjob.yaml | grep -E 'node-location'"
   assert_failure
 }
 

--- a/tests/unit/manifests.bats
+++ b/tests/unit/manifests.bats
@@ -463,3 +463,77 @@ PY
   assert_success
 }
 
+# ── workspace API-server egress (T000368) ───────────────────────────
+# The workspace namespace enforces default-deny-egress. CronJobs that call
+# the Kubernetes API in-cluster (pvc-backup orchestrator, tests-results-
+# retention) get "connection refused to 10.43.0.1:443" because no policy
+# permits egress to the apiserver. kube-router evaluates egress against the
+# POST-DNAT endpoint — the hostNetwork CP node IPs (10.20.0.0/24:6443), NOT
+# the ClusterIP — so the allow MUST include the node CIDR on 6443.
+@test "network-policies grant egress to the Kubernetes apiserver (T000368)" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 not installed"
+  fi
+  run python3 - "$RENDERED" <<'PY'
+import sys, yaml
+rendered = sys.argv[1]
+with open(rendered) as f:
+    docs = list(yaml.safe_load_all(f))
+
+def egress_to(doc, cidr, port):
+    if not doc or doc.get("kind") != "NetworkPolicy":
+        return False
+    spec = doc.get("spec", {})
+    if "Egress" not in (spec.get("policyTypes") or []):
+        return False
+    for rule in spec.get("egress") or []:
+        cidrs = {(p.get("ipBlock") or {}).get("cidr") for p in (rule.get("to") or [])}
+        ports = {pr.get("port") for pr in (rule.get("ports") or [])}
+        # ports empty means all-ports; treat as match
+        if cidr in cidrs and (not ports or port in ports):
+            return True
+    return False
+
+# The operative allow: CP node IPs (post-DNAT apiserver endpoints) on 6443
+node_ok = any(egress_to(d, "10.20.0.0/24", 6443) for d in docs)
+# The ClusterIP allow on 443 (defense-in-depth / clusters that match pre-DNAT)
+clusterip_ok = any(egress_to(d, "10.43.0.0/16", 443) for d in docs)
+if node_ok and clusterip_ok:
+    print("OK")
+    sys.exit(0)
+print(f"MISSING apiserver egress: node_cidr_6443={node_ok} clusterip_443={clusterip_ok}")
+sys.exit(1)
+PY
+  assert_success
+}
+
+# ── pvc-backup namespace is runtime-derived, not hardcoded (T000368) ──
+# The orchestrator script hardcoded NS=workspace, so on the korczewski brand
+# (ns workspace-korczewski) it operated in the wrong namespace and got an
+# RBAC Forbidden error. kustomize namespace-remapping does NOT rewrite string
+# literals inside container args, so the namespace must be derived at runtime
+# from the pod's serviceaccount.
+@test "pvc-backup derives namespace at runtime, not hardcoded NS=workspace (T000368)" {
+  run grep -E '^\s*NS=workspace\s*$' k3d/pvc-backup-cronjob.yaml
+  assert_failure
+  grep -q '/var/run/secrets/kubernetes.io/serviceaccount/namespace' k3d/pvc-backup-cronjob.yaml
+}
+
+# ── pvc-backup mounter has no stale dead-node affinity (T000368) ─────
+# The mounter nodeAffinity excluded node names from decommissioned clusters
+# (k3s-1/2/3, k3w-1/2/3) which no longer exist on fleet — dead drift.
+@test "pvc-backup mounter nodeAffinity has no decommissioned node names (T000368)" {
+  run grep -E 'k3s-1|k3s-2|k3s-3|k3w-1|k3w-2|k3w-3' k3d/pvc-backup-cronjob.yaml
+  assert_failure
+}
+
+# ── tests-results-retention has no stale node-location affinity (T000369) ──
+# The CronJob required nodeAffinity node-location=hetzner, but no fleet node
+# carries that label after Phase 3 consolidation → unschedulable on all 6
+# nodes. The prune job is placement-independent (kubectl exec into the website
+# pod), so the affinity must be dropped.
+@test "tests-results-retention has no stale node-location affinity (T000369)" {
+  run grep -E 'node-location' k3d/tests-retention-cronjob.yaml
+  assert_failure
+}
+


### PR DESCRIPTION
## Summary
- **T000368 root cause:** `default-deny-egress` in `workspace`/`workspace-korczewski` had no rule permitting egress to the Kubernetes API server, so in-cluster `kubectl` from `pvc-backup` (and `tests-results-retention`) failed nightly with `connection refused to 10.43.0.1:443`. **`wg-fleet` was healthy** — this was a NetworkPolicy gap, not a host-networking fault.
- kube-router evaluates egress against the **post-DNAT** endpoint. The apiserver is hostNetwork, so its endpoints are the CP **node IPs** (`10.20.0.0/24:6443`), not the ClusterIP. New `allow-apiserver-egress` opens the node CIDR on 6443 **and** the ClusterIP on 443. Proven empirically from a gekko-worker pod: node-CIDR allow → 12/12 reachable + `kubectl get --raw /version` OK; ClusterIP-only → still fails.
- **T000368 drift:** `pvc-backup` hardcoded `NS=workspace` in its orchestrator args (kustomize doesn't rewrite string literals), so the korczewski brand operated in the wrong namespace and got RBAC `Forbidden`. Now derives the namespace from the pod serviceaccount.
- **T000368 drift:** removed dead `nodeAffinity` node names (`k3s-1/2/3`, `k3w-1/2/3`) from the mounter — the nextcloud `podAffinity` already pins placement.
- **T000369:** removed the stale `node-location=hetzner` `nodeAffinity` from `tests-results-retention` (no fleet node carries that label → unschedulable). It reaches the API via the new policy.

## Test plan
- [x] 4 new `tests/unit/manifests.bats` tests (red → green): apiserver egress policy, runtime NS derivation, no dead-node affinity, no node-location affinity
- [x] `task test:all` (offline CI parity)
- [x] `task workspace:validate`
- [x] `task test:inventory` — no drift
- [ ] Post-merge: `task feature:deploy` to both fleet brands + live verify (manual pvc-backup run reaches API on a gekko-hosted pod; tests-retention schedulable)

Closes T000368
Closes T000369

🤖 Generated with [Claude Code](https://claude.com/claude-code)