### PR TITLE
feat(infra): provision dev VM successor to dead k3s-1

### DIFF
--- a/prod/cloud-init-dev-vm.yaml
+++ b/prod/cloud-init-dev-vm.yaml
@@ -1,0 +1,132 @@
+#cloud-config
+# =============================================================================
+# cloud-init-dev-vm.yaml — the NEW dev VM (dev.mentolder.de k3d stack host).
+# =============================================================================
+# Successor to the dead k3s-1 VM. This is NOT a k3s cluster node: it runs a
+# Docker daemon and a lightweight k3d cluster (see Taskfile.dev-stack.yml).
+#
+# Consumed by scripts/provision-dev-vm.sh, which:
+#   * substitutes the WireGuard private-key + peer-block placeholders below,
+#   * uploads the rendered file to the `dev` Proxmox host as a cicustom snippet,
+#   * creates + boots the VM via `qm`.
+#
+# Toolchain (Docker CE, k3d, kubectl, go-task, Node 22, pnpm, gh) is installed
+# by scripts/install-dev-tools.sh, which is hostname-guarded and matches the
+# `mentolder-dev` hostname set below.
+# =============================================================================
+
+hostname: mentolder-dev
+fqdn: dev.mentolder.de
+manage_etc_hosts: true
+
+users:
+  - default
+  - name: patrick
+    groups: [sudo, docker]
+    shell: /bin/bash
+    sudo: "ALL=(ALL) NOPASSWD:ALL"
+    lock_passwd: true
+    ssh_authorized_keys:
+      - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFN75CnuOz7YXaJipTFxWMVDgm35heu64JKN1QL+Z84+ patrick@korczewski.de
+  - name: gekko
+    groups: [sudo, docker]
+    shell: /bin/bash
+    sudo: "ALL=(ALL) NOPASSWD:ALL"
+    lock_passwd: true
+    ssh_authorized_keys:
+      - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIH43aUqN4w9u7DIt3gUREOJY4pmVIWvIbqFsG/fPSlV0 gekko@mentolder-20260513
+
+ssh_pwauth: false
+
+package_update: true
+package_upgrade: true
+
+packages:
+  - curl
+  - wget
+  - git
+  - htop
+  - jq
+  - ca-certificates
+  - gnupg
+  - unattended-upgrades
+  - fail2ban
+  - ufw
+  - wireguard-tools
+  - open-iscsi
+  - nfs-common
+
+write_files:
+  # WireGuard mesh — node `dev-vm`, mentolder mesh (192.168.100.0/24, port 51821).
+  # wg_ip 192.168.100.23 (see wireguard/wg-mesh-nodes.yaml). provision-dev-vm.sh
+  # injects the private key and the peer list before this file is uploaded.
+  - path: /etc/wireguard/wg-mesh.conf
+    permissions: '0600'
+    owner: root:root
+    content: |
+      [Interface]
+      PrivateKey = REPLACEME_WG_PRIVATE_KEY
+      Address = 192.168.100.23/24
+      ListenPort = 51821
+
+      REPLACEME_WG_PEERS_BLOCK
+
+  # k3d needs generous inotify limits; the dev cluster otherwise fails to start
+  # watchers under load. Mirrors prod/cloud-init.yaml's 99-k3s.conf.
+  - path: /etc/sysctl.d/99-dev-k3d.conf
+    content: |
+      net.ipv4.ip_forward=1
+      net.bridge.bridge-nf-call-iptables=1
+      fs.inotify.max_user_watches=524288
+      fs.inotify.max_user_instances=512
+      vm.max_map_count=262144
+
+  - path: /etc/fail2ban/jail.local
+    content: |
+      [sshd]
+      enabled = true
+      port = 22
+      maxretry = 5
+      bantime = 3600
+      findtime = 600
+
+  - path: /etc/ssh/sshd_config.d/hardened.conf
+    content: |
+      PasswordAuthentication no
+      KbdInteractiveAuthentication no
+      PermitRootLogin no
+      AllowUsers patrick gekko
+
+runcmd:
+  - sysctl --system
+
+  # ── Firewall (dev k3d stack port map: see Taskfile.dev-stack.yml) ──────────
+  - ufw default deny incoming
+  - ufw default allow outgoing
+  - ufw allow 22/tcp
+  - ufw allow 51821/udp                 # WireGuard mesh (mentolder subnet)
+  - ufw allow 18080/tcp comment "k3d Traefik web"
+  - ufw allow 18443/tcp comment "k3d Traefik websecure"
+  - ufw allow from 10.0.0.0/24 to any port 15432 proto tcp comment "dev Postgres (LAN only)"
+  - ufw deny 2222/tcp comment "sish - default deny (open per-CIDR via dev:firewall:open)"
+  - ufw --force enable
+
+  # ── Services ──────────────────────────────────────────────────────────────
+  - systemctl enable fail2ban && systemctl start fail2ban
+  - systemctl restart ssh
+  - systemctl enable unattended-upgrades && systemctl start unattended-upgrades
+  - systemctl enable --now iscsid
+
+  # ── WireGuard mesh up (before the dev toolchain so k3d sees the iface) ──────
+  - systemctl enable wg-quick@wg-mesh
+  - systemctl start wg-quick@wg-mesh || true
+
+  # ── Dev toolchain: Docker CE, k3d, kubectl, go-task, Node 22, pnpm ──────────
+  # Same installer prod/cloud-init.yaml uses. It is hostname-guarded to
+  # gekko-hetzner-2, so we override the guard (FORCE=1) and tell it which user
+  # gets the docker group + pnpm (DEV_USER=gekko, the primary dev login).
+  - curl -fsSL https://raw.githubusercontent.com/Paddione/Bachelorprojekt/main/scripts/install-dev-tools.sh -o /usr/local/sbin/install-dev-tools.sh
+  - chmod +x /usr/local/sbin/install-dev-tools.sh
+  - FORCE=1 DEV_USER=gekko /usr/local/sbin/install-dev-tools.sh
+
+final_message: "dev VM (mentolder-dev) ready - $(hostname) - $(date). Next: task dev:cluster:create SSH_TARGET=gekko@dev-vm"

--- a/scripts/install-dev-tools.sh
+++ b/scripts/install-dev-tools.sh
@@ -50,12 +50,19 @@ apt-get install -y -qq build-essential ca-certificates curl gnupg lsb-release
 log "step 2/6 — docker"
 if ! command -v docker >/dev/null; then
   install -m 0755 -d /etc/apt/keyrings
-  curl -fsSL https://download.docker.com/linux/ubuntu/gpg \
+  # Use the matching Docker repo for the actual distro (debian vs ubuntu).
+  # The gekko nodes are Ubuntu; the dev VM is Debian — both must resolve.
+  DISTRO_ID=$(. /etc/os-release && echo "$ID")
+  case "$DISTRO_ID" in
+    debian) DOCKER_REPO="debian" ;;
+    *)      DOCKER_REPO="ubuntu" ;;
+  esac
+  curl -fsSL "https://download.docker.com/linux/${DOCKER_REPO}/gpg" \
     | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
   chmod a+r /etc/apt/keyrings/docker.gpg
   ARCH=$(dpkg --print-architecture)
-  CODENAME=$(. /etc/os-release && echo "$VERSION_CODENAME")
-  echo "deb [arch=${ARCH} signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu ${CODENAME} stable" \
+  CODENAME=$(. /etc/os-release && echo "${VERSION_CODENAME:-}")
+  echo "deb [arch=${ARCH} signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/${DOCKER_REPO} ${CODENAME} stable" \
     > /etc/apt/sources.list.d/docker.list
   apt-get update -qq
   apt-get install -y -qq docker-ce docker-ce-cli containerd.io \

--- a/scripts/provision-dev-vm.sh
+++ b/scripts/provision-dev-vm.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+# =============================================================================
+# provision-dev-vm.sh — create the new dev VM on the `dev` Proxmox node.
+# =============================================================================
+# Successor to the dead k3s-1 VM. Creates a Debian 12 cloud-init VM on the
+# standalone Proxmox host `dev` (10.0.0.25), pre-installs the dev toolchain
+# (Docker CE, k3d, kubectl, go-task, Node 22, pnpm, gh — via install-dev-tools.sh),
+# installs WireGuard, and enrolls users patrick + gekko with their pubkeys.
+#
+# After it finishes, bring up the dev k3d cluster with:
+#   task dev:cluster:create \
+#     SSH_TARGET=gekko@dev-vm \
+#     SSH_KEY=~/Bachelorprojekt/environments/.secrets/.ssh/gekko_ed25519
+#
+# Idempotent: re-running skips the image download and refuses to clobber an
+# existing VMID (pass FORCE=1 to destroy + recreate).
+#
+# All tunables are env-overridable; defaults match the SSH config + wg registry.
+# =============================================================================
+set -euo pipefail
+
+# ---- repo paths -------------------------------------------------------------
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SSH_CONFIG="${SSH_CONFIG:-$REPO_ROOT/environments/.secrets/.ssh/config}"
+CLOUD_INIT_SRC="${CLOUD_INIT_SRC:-$REPO_ROOT/prod/cloud-init-dev-vm.yaml}"
+WG_SECRETS_DIR="${WG_SECRETS_DIR:-$REPO_ROOT/environments/.secrets/wireguard}"
+
+# ---- Proxmox / VM parameters ------------------------------------------------
+PVE_HOST="${PVE_HOST:-dev}"                 # ssh alias of the Proxmox node (root@10.0.0.25)
+VMID="${VMID:-9002}"                        # old k3s-1 was 9001
+VM_NAME="${VM_NAME:-mentolder-dev}"         # must match install-dev-tools.sh guard list
+VM_IP="${VM_IP:-10.0.0.26}"                 # static LAN IP (matches `dev-vm` SSH alias)
+VM_CIDR="${VM_CIDR:-24}"
+VM_GW="${VM_GW:-10.0.0.1}"
+VM_DNS="${VM_DNS:-1.1.1.1 9.9.9.9}"
+WG_IP="${WG_IP:-192.168.100.23}"            # matches wireguard/wg-mesh-nodes.yaml (dev-vm)
+
+CORES="${CORES:-4}"
+MEM_MB="${MEM_MB:-8192}"
+DISK_SIZE="${DISK_SIZE:-60G}"
+BRIDGE="${BRIDGE:-vmbr0}"
+STORAGE="${STORAGE:-local-lvm}"             # where the VM disk lives
+SNIPPET_STORAGE="${SNIPPET_STORAGE:-local}" # storage with the 'snippets' content type
+SNIPPET_NAME="${SNIPPET_NAME:-dev-vm-user.yaml}"
+
+IMAGE_URL="${IMAGE_URL:-https://cloud.debian.org/images/cloud/bookworm/latest/debian-12-genericcloud-amd64.qcow2}"
+IMAGE_FILE="${IMAGE_FILE:-debian-12-genericcloud-amd64.qcow2}"
+IMAGE_CACHE="${IMAGE_CACHE:-/var/lib/vz/template/iso}"
+
+# wg hub: the dev VM is a home-LAN node on the mentolder mesh (192.168.100.0/24,
+# port 51821). Like k3s-1/devc-*, it initiates outbound to a Hetzner CP node and
+# routes the whole mesh through it. gekko-hetzner-2's pubkey is published in the
+# registry, so this connects out-of-the-box (override to pin a different node).
+WG_HUB_ENDPOINT="${WG_HUB_ENDPOINT:-178.104.169.206:51821}"   # gekko-hetzner-2
+WG_HUB_PUBKEY="${WG_HUB_PUBKEY:-iXnGP9bIwrofD6a96D5Fz5rM7smbIAc3gXJcUx5m6j0=}"
+WG_ALLOWED_IPS="${WG_ALLOWED_IPS:-192.168.100.0/24}"
+
+FORCE="${FORCE:-0}"
+
+# Remote exec on the Proxmox node. Force a login shell so /usr/sbin (qm, pvesm,
+# lvextend, ...) is on PATH — non-login ssh sessions on Proxmox omit it.
+ssh_pve() { ssh -F "$SSH_CONFIG" "$PVE_HOST" "bash -lc \"\$(cat)\"" <<<"$*"; }
+
+log() { printf '\033[1;36m==>\033[0m %s\n' "$*"; }
+die() { printf '\033[1;31mERROR:\033[0m %s\n' "$*" >&2; exit 1; }
+
+# ---- 0. sanity --------------------------------------------------------------
+command -v wg >/dev/null || die "wireguard-tools (wg) not installed locally — needed to generate the VM keypair."
+[[ -f "$CLOUD_INIT_SRC" ]] || die "cloud-init template not found: $CLOUD_INIT_SRC"
+log "Target Proxmox node: $PVE_HOST  |  VMID=$VMID  name=$VM_NAME  ip=$VM_IP/$VM_CIDR  wg=$WG_IP"
+ssh_pve 'command -v qm >/dev/null' || die "cannot reach $PVE_HOST or 'qm' missing — check $SSH_CONFIG and that the node is up."
+
+# ---- 1. WireGuard keypair for the VM ----------------------------------------
+mkdir -p "$WG_SECRETS_DIR"; chmod 700 "$WG_SECRETS_DIR"
+WG_KEY="$WG_SECRETS_DIR/dev-vm.key"
+WG_PUB="$WG_SECRETS_DIR/dev-vm.pub"
+if [[ ! -s "$WG_KEY" ]]; then
+  log "Generating WireGuard keypair for dev-vm → $WG_KEY"
+  (umask 077; wg genkey > "$WG_KEY")
+  wg pubkey < "$WG_KEY" > "$WG_PUB"
+fi
+chmod 600 "$WG_KEY"
+WG_PRIVKEY="$(cat "$WG_KEY")"
+log "dev-vm WireGuard pubkey: $(cat "$WG_PUB")"
+log "  → paste this into wireguard/wg-mesh-nodes.yaml (dev-vm wg_pubkey) and add"
+log "    it as a peer on pk-hetzner-4 (AllowedIPs $WG_IP/32), then 'wg syncconf'."
+
+# ---- 2. render cloud-init (inject wg private key + peer block) ---------------
+PEERS_BLOCK="[Peer]
+# mentolder mesh hub (routes the whole 192.168.100.0/24 mesh for this LAN node)
+PublicKey = $WG_HUB_PUBKEY
+Endpoint = $WG_HUB_ENDPOINT
+AllowedIPs = $WG_ALLOWED_IPS
+PersistentKeepalive = 25"
+
+RENDERED="$(mktemp)"; trap 'rm -f "$RENDERED"' EXIT
+# Use python for safe multi-line substitution (no sed delimiter / escaping pain).
+python3 - "$CLOUD_INIT_SRC" "$WG_PRIVKEY" "$PEERS_BLOCK" > "$RENDERED" <<'PY'
+import sys
+src, privkey, peers = sys.argv[1], sys.argv[2], sys.argv[3]
+text = open(src).read()
+text = text.replace("REPLACEME_WG_PRIVATE_KEY", privkey)
+# keep the YAML block indentation (6 spaces) for the multi-line peer block
+peers_indented = "\n".join(("      " + l if l else l) for l in peers.splitlines())
+text = text.replace("      REPLACEME_WG_PEERS_BLOCK", peers_indented)
+sys.stdout.write(text)
+PY
+[[ "$WG_HUB_PUBKEY" == REPLACEME_* ]] && \
+  log "NOTE: WG_HUB_PUBKEY is a placeholder — set it (pk-hetzner-4 pubkey) so the mesh actually connects."
+
+# ---- 3. upload cloud-init snippet -------------------------------------------
+log "Uploading cloud-init snippet → $PVE_HOST:/var/lib/vz/snippets/$SNIPPET_NAME"
+ssh_pve 'mkdir -p /var/lib/vz/snippets'
+scp -F "$SSH_CONFIG" "$RENDERED" "$PVE_HOST:/var/lib/vz/snippets/$SNIPPET_NAME" >/dev/null
+ssh_pve "chmod 600 /var/lib/vz/snippets/$SNIPPET_NAME"
+
+# ---- 4. create the VM on the Proxmox node -----------------------------------
+log "Creating VM $VMID on $PVE_HOST"
+ssh_pve "$(cat <<REMOTE
+set -euo pipefail
+
+if qm status $VMID &>/dev/null; then
+  if [[ "$FORCE" == "1" ]]; then
+    echo ">> VM $VMID exists; FORCE=1 → stopping + destroying"
+    qm stop $VMID || true
+    qm destroy $VMID --purge
+  else
+    echo "ERROR: VM $VMID already exists. Re-run with FORCE=1 to recreate." >&2
+    exit 1
+  fi
+fi
+
+# Download the Debian cloud image once (cached).
+mkdir -p "$IMAGE_CACHE"
+if [[ ! -s "$IMAGE_CACHE/$IMAGE_FILE" ]]; then
+  echo ">> downloading $IMAGE_URL"
+  curl -fSL "$IMAGE_URL" -o "$IMAGE_CACHE/$IMAGE_FILE"
+fi
+
+echo ">> qm create"
+qm create $VMID \
+  --name $VM_NAME \
+  --memory $MEM_MB \
+  --cores $CORES \
+  --cpu host \
+  --net0 virtio,bridge=$BRIDGE \
+  --scsihw virtio-scsi-single \
+  --ostype l26 \
+  --agent enabled=1
+
+echo ">> import disk"
+qm importdisk $VMID "$IMAGE_CACHE/$IMAGE_FILE" $STORAGE
+qm set $VMID --scsi0 $STORAGE:vm-$VMID-disk-0
+qm set $VMID --ide2 $STORAGE:cloudinit
+qm set $VMID --boot order=scsi0
+qm set $VMID --serial0 socket --vga serial0
+
+echo ">> cloud-init network + custom user-data"
+qm set $VMID --ipconfig0 ip=$VM_IP/$VM_CIDR,gw=$VM_GW
+qm set $VMID --nameserver "$VM_DNS"
+qm set $VMID --cicustom "user=$SNIPPET_STORAGE:snippets/$SNIPPET_NAME"
+
+echo ">> resize disk to $DISK_SIZE"
+qm disk resize $VMID scsi0 $DISK_SIZE
+
+echo ">> start"
+qm start $VMID
+echo ">> VM $VMID started. cloud-init runs on first boot (toolchain install takes a few minutes)."
+REMOTE
+)"
+# ---- 5. next steps ----------------------------------------------------------
+cat <<EOF
+
+$(log "Done. The dev VM is booting at $VM_IP (alias: dev-vm / dev-vm/gekko).")
+
+Next:
+  1. Wait for cloud-init to finish (watch: ssh -F $SSH_CONFIG dev "qm terminal $VMID").
+  2. Verify access:    ssh -F $SSH_CONFIG dev-vm "docker version && k3d version"
+  3. Finish WireGuard: add dev-vm's pubkey ($(cat "$WG_PUB" 2>/dev/null)) as a peer
+     on pk-hetzner-4 and set WG_HUB_PUBKEY in wg-mesh.conf if it was a placeholder.
+  4. Bring up the dev cluster:
+       task dev:cluster:create SSH_TARGET=gekko@dev-vm \\
+         SSH_KEY=~/Bachelorprojekt/environments/.secrets/.ssh/gekko_ed25519
+EOF

--- a/wireguard/wg-mesh-nodes.yaml
+++ b/wireguard/wg-mesh-nodes.yaml
@@ -55,10 +55,27 @@ mentolder:
   # Workers initiate outbound to Hetzner; PersistentKeepalive = 25 keeps NAT mapping alive.
   home_workers:
     - name: k3s-1
-      endpoint: ""        # behind NAT (Proxmox vmid=100 on pvemain, LAN IP 10.0.3.1)
+      endpoint: ""        # behind NAT (Proxmox vmid=100 on pvemain, LAN IP 10.0.3.1) — DEAD 2026-05-31
       wg_ip: "192.168.100.20"
       schema_key: WG_MESH_K3S1
       public_key: "bfEvZgmkMwGANBYapNdA0zNoLMgWfWyp5DmcEI3Awww="
+      keepalive: 25
+
+    # New dev VM — Proxmox guest on the `dev` node (10.0.0.25). Successor to the
+    # dead k3s-1; hosts the dev k3d cluster (dev.mentolder.de). Provisioned
+    # 2026-05-31 by scripts/provision-dev-vm.sh (VMID 9002, LAN 10.0.0.26).
+    # NOTE: wg-mesh is installed + up on the VM (iface 192.168.100.23, port
+    # 51821) but the mentolder mesh has NO live hub anymore — gekko-hetzner-2/3/4
+    # moved to wg-fleet (10.20.0.0/24) in the consolidation, so their wg-mesh
+    # interfaces are down. dev-vm therefore sends keepalives with no handshake.
+    # This is harmless: the dev stack is reached over LAN / dev.mentolder.de,
+    # not the mesh. Reviving cross-node mentolder-mesh connectivity for dev is a
+    # separate decision (would need a live hub on a node still running wg-mesh).
+    - name: dev-vm
+      endpoint: ""        # behind NAT (FritzBox), LAN IP 10.0.0.26 — initiates outbound
+      wg_ip: "192.168.100.23"
+      schema_key: WG_MESH_DEVVM
+      public_key: "TQu+0XGGDRuuQyMUQUQWZMp7tyIQ0c4RTe9+FcMaWg4="
       keepalive: 25
 
   # HA dev cluster servers — ON wg-mesh (provisioned 2026-05-30).


### PR DESCRIPTION
## Summary
k3s-1 died from host-level memory corruption, taking down the `dev.mentolder.de` k3d stack. This stands up a replacement dev VM on the new standalone Proxmox node `dev` (10.0.0.25).

The VM is **already provisioned and verified live** (2026-05-31) — these files codify what was done so it's reproducible.

## Changes
- **`prod/cloud-init-dev-vm.yaml`** (new) — cloud-init for VM `mentolder-dev`: Debian 12, users `patrick`+`gekko` with their keys, hardened sshd, UFW for the k3d port map (18080/18443, LAN-only 15432, sish default-deny), WireGuard mesh, dev toolchain via `install-dev-tools.sh`.
- **`scripts/provision-dev-vm.sh`** (new) — reproducible provisioner: generates the VM wg keypair, renders + uploads the cloud-init snippet, creates the VM via `qm` (VMID 9002, IP 10.0.0.26, 60G disk). All tunables env-overridable.
- **`scripts/install-dev-tools.sh`** — pick the Docker apt repo by distro (`debian` vs `ubuntu`) from `/etc/os-release` instead of hardcoding ubuntu. The gekko nodes are Ubuntu; the dev VM is Debian — both now resolve.
- **`wireguard/wg-mesh-nodes.yaml`** — register `dev-vm` (192.168.100.23) under `mentolder.home_workers`, with a note that the mentolder mesh has no live hub post-consolidation (dev is reached over LAN, not the mesh).

## Verification (live)
- k3d cluster `mentolder-dev`: `1/1` server, `/healthz` → `ok`, kube-system pods Running/Completed
- Autostart `k3d-mentolder-dev.service` enabled (survives reboot)
- Both SSH users login; `gekko` has no-sudo docker (Docker 29.5.2, k3d v5.7.4)
- Load-bearing port maps bound: `0.0.0.0:2222`, `127.0.0.1:18080`, `127.0.0.1:15432`

## Notes
- Secrets (`dev_rsa`, VM wg key) live under gitignored `environments/.secrets/` — not in this PR.
- WireGuard return path is down by design: the mentolder mesh lost its hub when gekko-hetzner-2/3/4 moved to wg-fleet. Harmless for dev; reviving it is a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)