### PR TITLE
fix(plans): add --priority mittel to ticket.sh create commands [T000373]

### DIFF
--- a/.claude/skills/dev-flow-plan/SKILL.md
+++ b/.claude/skills/dev-flow-plan/SKILL.md
@@ -23,6 +23,7 @@ TICKET_RESULT=$(./scripts/ticket.sh create \
   --type task \
   --brand mentolder \
   --title "Grilling: <kurzer-titel>" \
+  --priority mittel \
   --description "FUNKTIONALE ANFORDERUNGEN:"$'\n'"$GRILLING_REQUIREMENTS"$'\n\n'"ASSETS ZU BESCHAFFEN:"$'\n'"$GRILLING_ASSETS_TODO")
 
 export GRILLING_TICKET_EXT_ID=$(echo "$TICKET_RESULT" | cut -d'|' -f1)
@@ -123,6 +124,7 @@ TICKET_RESULT=$(./scripts/ticket.sh create \
   --type task \
   --brand mentolder \
   --title "Plan: <slug>" \
+  --priority mittel \
   --description "Branch: feature/<slug>"$'\n'"Plan: docs/superpowers/plans/<date>-<slug>.md"$'\n'"Spec: docs/superpowers/specs/<date>-<slug>-design.md"$GRILLING_REF)
 
 TICKET_EXT_ID=$(echo "$TICKET_RESULT" | cut -d'|' -f1)

--- a/scripts/ticket.sh
+++ b/scripts/ticket.sh
@@ -33,7 +33,7 @@ _exec_sql() {
 }
 
 cmd_create() {
-  local type="" title="" desc="" brand="mentolder" severity="" priority="" status="triage"
+  local type="" title="" desc="" brand="mentolder" severity="" priority="mittel" status="triage"
   while [[ $# -gt 0 ]]; do
     case "$1" in
       --type)        type="$2"; shift 2 ;;


### PR DESCRIPTION
Fixes the issue where ticket.sh create commands fail due to the priority column's NOT NULL constraint being violated when --priority is omitted. Defaults priority to 'mittel' in scripts/ticket.sh and updates dev-flow-plan SKILL.md commands.