### PR TITLE
chore(ci): consolidate MENTOLDER/KORCZEWSKI_KUBECONFIG → FLEET_KUBECONFIG

### DIFF
--- a/.github/workflows/build-brett.yml
+++ b/.github/workflows/build-brett.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Deploy to mentolder
         env:
-          KUBECONFIG_DATA: ${{ secrets.MENTOLDER_KUBECONFIG }}
+          KUBECONFIG_DATA: ${{ secrets.FLEET_KUBECONFIG }}
         run: |
           curl -sSL "https://dl.k8s.io/release/v1.31.0/bin/linux/amd64/kubectl" \
             -o /usr/local/bin/kubectl && chmod +x /usr/local/bin/kubectl
@@ -55,7 +55,7 @@ jobs:
 
       - name: Deploy to korczewski
         env:
-          KUBECONFIG_DATA: ${{ secrets.KORCZEWSKI_KUBECONFIG }}
+          KUBECONFIG_DATA: ${{ secrets.FLEET_KUBECONFIG }}
         run: |
           curl -sSL "https://dl.k8s.io/release/v1.31.0/bin/linux/amd64/kubectl" \
             -o /usr/local/bin/kubectl && chmod +x /usr/local/bin/kubectl

--- a/.github/workflows/build-website-korczewski.yml
+++ b/.github/workflows/build-website-korczewski.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Deploy to korczewski
         env:
-          KUBECONFIG_DATA: ${{ secrets.KORCZEWSKI_KUBECONFIG }}
+          KUBECONFIG_DATA: ${{ secrets.FLEET_KUBECONFIG }}
         run: |
           curl -sSL "https://dl.k8s.io/release/v1.31.0/bin/linux/amd64/kubectl" \
             -o /usr/local/bin/kubectl && chmod +x /usr/local/bin/kubectl

--- a/.github/workflows/build-website.yml
+++ b/.github/workflows/build-website.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Deploy to mentolder
         env:
-          KUBECONFIG_DATA: ${{ secrets.MENTOLDER_KUBECONFIG }}
+          KUBECONFIG_DATA: ${{ secrets.FLEET_KUBECONFIG }}
         run: |
           curl -sSL "https://dl.k8s.io/release/v1.31.0/bin/linux/amd64/kubectl" \
             -o /usr/local/bin/kubectl && chmod +x /usr/local/bin/kubectl


### PR DESCRIPTION
Both brands now run on the unified fleet cluster (204.168.244.104:6443). The old standalone mentolder-standalone cluster is decommissioned.

- Replace `MENTOLDER_KUBECONFIG` + `KORCZEWSKI_KUBECONFIG` with single `FLEET_KUBECONFIG` in build-website.yml, build-website-korczewski.yml, build-brett.yml
- GitHub secret `FLEET_KUBECONFIG` set to fleet kubeconfig pointing at 204.168.244.104:6443
- Old brand-specific secrets deleted

🤖 Generated with [Claude Code](https://claude.com/claude-code)