### PR TITLE
chore(gotchas): warn developers about ticket_plans query timeout [T000388]

### DIFF
--- a/.claude/skills/operations-management/SKILL.md
+++ b/.claude/skills/operations-management/SKILL.md
@@ -35,6 +35,8 @@ PGPOD=$(kubectl get pod -n workspace --context fleet -l app=shared-db -o name | 
 psql() { kubectl exec "$PGPOD" -n workspace --context fleet -c postgres -- psql -U website -d website "$@"; }
 ```
 
+> ⚠️ **Warning on tickets.ticket_plans**: When querying this table, never run `SELECT *` or retrieve the `content` column without filtering by a specific ticket/slug. The `content` column stores large plan markdown files, and querying the entire table will transfer megabytes over `kubectl exec`, causing connection timeouts. Always query metadata columns (e.g. `id`, `ticket_id`, `slug`, `branch`, `pr_number`, `archived_at`) or filter explicitly.
+
 ---
 
 ## Phase 1 — Production Incident Response

--- a/.claude/skills/references/dev-flow-gotchas.md
+++ b/.claude/skills/references/dev-flow-gotchas.md
@@ -73,3 +73,10 @@ This document aggregates known operational issues, gotchas, and workarounds for 
 ### [T000344] Database row check before file deletion
 **Context**: Deleting plan markdown file before verifying database storage.
 **Rule**: Always verify that the plan exists in `tickets.ticket_plans` by checking that the row count is greater than 0 before running `rm` on the plan file.
+
+---
+
+### [T000388] tickets.ticket_plans Query Timeout
+**Context**: Querying the `tickets.ticket_plans` table over `kubectl exec`.
+**Rule**: Never run `SELECT *` or query the `content` column on the entire `tickets.ticket_plans` table. The `content` column contains large markdown plan files which will cause connection timeouts over the `kubectl exec` tunnel. Always query metadata columns (such as `id`, `ticket_id`, `slug`, `branch`, `pr_number`, `archived_at`) or filter explicitly by a specific `ticket_id` or `slug`.
+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,6 +145,9 @@ Non-obvious repo behaviors. Violating these silently breaks things or hits the w
 - **`envsubst` variable lists are hardcoded per task in `Taskfile.yml` (not `Taskfile.yaml`).** If you add a new `${VAR}` reference to a manifest, also add it to the `envsubst "\$VAR1 \$VAR2 ..."` list in every task that builds that manifest, or the placeholder stays literal and kubectl apply fails with an invalid manifest. Key locations: dev deploy (line ~1117, vars: `PROD_DOMAIN BRAND_NAME CONTACT_EMAIL BRAND_ID`), prod deploy (line ~1145, dynamic `ENVSUBST_VARS` build — append there), `mcp:deploy` (line ~1350), `workspace:office:deploy` (line ~510).
 - **`env:generate ENV=<target>` must run before `env:seal` and before deploying prod.** `talk-hpb-setup.sh` aborts on placeholder `MANAGED_EXTERNALLY` values if signaling/turn secrets were never generated.
 
+### Database queries
+- **Never run `SELECT *` or query the `content` column on the entire `tickets.ticket_plans` table.** The `content` column stores large plan markdown files, and selecting it over a `kubectl exec` connection will transfer megabytes of data, causing connection timeouts. Always query metadata columns (such as `id`, `ticket_id`, `slug`, `branch`, `pr_number`, `archived_at`) or filter explicitly by a specific `ticket_id` or `slug`.
+
 ### Cluster reset / fresh cluster bring-up order
 After any cluster reset (including replacing a Sealed Secrets controller keypair), the mandatory order is:
 


### PR DESCRIPTION
Warns developers in CLAUDE.md, dev-flow-gotchas.md, and operations-management runbook to query metadata columns or filter when querying tickets.ticket_plans to avoid kubectl exec timeouts.