### PR TITLE
feat(recovery): browsable backup staging engine [T000386]

### DIFF
--- a/.claude/skills/database-ops/SKILL.md
+++ b/.claude/skills/database-ops/SKILL.md
@@ -147,6 +147,66 @@ kubectl get jobs -n <ns> --context <ctx> -l app=db-backup   # any Failed → ins
 
 ---
 
+## Phase 3 — Browsable Recovery Workflow (stage → browse → selective restore)
+
+The new `stage`/`verify`/`restore-file`/`restore-table`/`browse`/`unstage` subcommands in `scripts/backup-restore.sh` let you inspect and selectively recover from backups **without touching live data** until you explicitly confirm.
+
+### Runbook
+
+**Step 3.1: Apply the recovery PVC (once per cluster)**
+```bash
+task recovery:prepare ENV=mentolder    # creates recovery-pvc in workspace namespace
+task recovery:prepare ENV=korczewski   # creates recovery-pvc in workspace-korczewski
+```
+
+**Step 3.2: Prove a dump is restorable (non-destructive)**
+```bash
+task recovery:verify ENV=mentolder -- 20260530-020001 website
+# Restores the dump into website_verify_<pid>, prints table counts, then drops it.
+```
+
+**Step 3.3: Stage a DB or service for inspection**
+```bash
+# DB: decrypts and pg_restore into <db>_recovery (live DB untouched)
+task recovery:stage ENV=mentolder -- 20260530-020001 website
+
+# Service PVC: decrypts + extracts to recovery-pvc:/recovery/<ts>/<service>/
+task recovery:stage ENV=mentolder -- pvc-20260530-030001 nextcloud-files
+```
+
+**Step 3.4: Browse staged data**
+```bash
+# Files (filebrowser over SSO):
+task recovery:browse ENV=mentolder   # prints https://recover.<domain>
+
+# DB tables (psql into *_recovery):
+kubectl exec -n workspace --context fleet deploy/shared-db -- \
+  psql -U postgres -d website_recovery
+```
+
+**Step 3.5: Selective restore (requires explicit confirmation)**
+```bash
+# Restore one file from staging into the live PVC:
+task recovery:restore-file ENV=mentolder -- pvc-20260530-030001 nextcloud-files admin/files/Doc.pdf -y
+
+# Restore one table from dump into the live DB:
+task recovery:restore-table ENV=mentolder -- 20260530-020001 website site_settings -y
+```
+
+**Step 3.6: Clean up staging**
+```bash
+task recovery:unbrowse ENV=mentolder          # tear down the filebrowser
+task recovery:unstage ENV=mentolder -- pvc-20260530-030001 -y  # drop *_recovery DBs + clear staging dir
+```
+
+### Invariants
+- `stage` and `verify` never touch live data; only `restore-file` / `restore-table` write to live volumes (and only after explicit `-y` confirmation).
+- Per-service staging: always stage the service you need, not "all" — keeps `recovery-pvc` small.
+- `recovery-browser.yaml` is applied on demand (not in kustomization.yaml). It requires Plan 2 (`feature/recovery-browse`) to be merged before `browse` works.
+- The `browse` command fails cleanly with a clear message if `recovery-browser.yaml` is missing.
+
+---
+
 ## Troubleshooting & Common Blockers
 
 | Symptom | Cause | Fix |

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1137,6 +1137,78 @@ tasks:
         echo ""
         bash scripts/backup-restore.sh pvc-restore {{.CLI_ARGS}} $ctx_arg
 
+  recovery:prepare:
+    desc: "Apply recovery-pvc (run once per cluster before staging). ENV=<env>"
+    vars:
+      ENV: '{{.ENV | default "dev"}}'
+    cmds:
+      - |
+        source scripts/env-resolve.sh "{{.ENV}}"
+        kubectl apply --context "$ENV_CONTEXT" -n "${WORKSPACE_NAMESPACE:-workspace}" -f k3d/recovery-pvc.yaml
+
+  recovery:stage:
+    desc: "Stage one backup entry browsable. ENV=<env> -- <timestamp> <db|service>"
+    vars:
+      ENV: '{{.ENV | default "dev"}}'
+    cmds:
+      - |
+        source scripts/env-resolve.sh "{{.ENV}}"
+        bash scripts/backup-restore.sh stage {{.CLI_ARGS}} --context "$ENV_CONTEXT" --namespace "${WORKSPACE_NAMESPACE:-workspace}"
+
+  recovery:verify:
+    desc: "Prove a DB dump restores + show table counts. ENV=<env> -- <timestamp> <db>"
+    vars:
+      ENV: '{{.ENV | default "dev"}}'
+    cmds:
+      - |
+        source scripts/env-resolve.sh "{{.ENV}}"
+        bash scripts/backup-restore.sh verify {{.CLI_ARGS}} --context "$ENV_CONTEXT" --namespace "${WORKSPACE_NAMESPACE:-workspace}"
+
+  recovery:browse:
+    desc: "Bring up the on-demand recovery filebrowser (SSO). ENV=<env>"
+    vars:
+      ENV: '{{.ENV | default "dev"}}'
+    cmds:
+      - |
+        source scripts/env-resolve.sh "{{.ENV}}"
+        bash scripts/backup-restore.sh browse --context "$ENV_CONTEXT" --namespace "${WORKSPACE_NAMESPACE:-workspace}"
+
+  recovery:unbrowse:
+    desc: "Tear the recovery filebrowser down. ENV=<env>"
+    vars:
+      ENV: '{{.ENV | default "dev"}}'
+    cmds:
+      - |
+        source scripts/env-resolve.sh "{{.ENV}}"
+        bash scripts/backup-restore.sh unbrowse --context "$ENV_CONTEXT" --namespace "${WORKSPACE_NAMESPACE:-workspace}"
+
+  recovery:restore-file:
+    desc: "Restore ONE staged file/dir into the live PVC. ENV=<env> -- <timestamp> <service> <path>"
+    vars:
+      ENV: '{{.ENV | default "dev"}}'
+    cmds:
+      - |
+        source scripts/env-resolve.sh "{{.ENV}}"
+        bash scripts/backup-restore.sh restore-file {{.CLI_ARGS}} --context "$ENV_CONTEXT" --namespace "${WORKSPACE_NAMESPACE:-workspace}"
+
+  recovery:restore-table:
+    desc: "Restore ONE table into the live DB. ENV=<env> -- <timestamp> <db> <table>"
+    vars:
+      ENV: '{{.ENV | default "dev"}}'
+    cmds:
+      - |
+        source scripts/env-resolve.sh "{{.ENV}}"
+        bash scripts/backup-restore.sh restore-table {{.CLI_ARGS}} --context "$ENV_CONTEXT" --namespace "${WORKSPACE_NAMESPACE:-workspace}"
+
+  recovery:unstage:
+    desc: "Drop *_recovery DBs + clear staging. ENV=<env> -- <timestamp>"
+    vars:
+      ENV: '{{.ENV | default "dev"}}'
+    cmds:
+      - |
+        source scripts/env-resolve.sh "{{.ENV}}"
+        bash scripts/backup-restore.sh unstage {{.CLI_ARGS}} --context "$ENV_CONTEXT" --namespace "${WORKSPACE_NAMESPACE:-workspace}"
+
   workspace:db:start:
     desc: "Ensure shared-db is running; scale up if at 0 replicas, otherwise restart (ENV=dev|mentolder|korczewski)"
     vars:

--- a/docs/superpowers/plans/2026-05-31-recovery-engine.md
+++ b/docs/superpowers/plans/2026-05-31-recovery-engine.md
@@ -1,0 +1,973 @@
+---
+title: Recovery Engine — Implementation Plan (Plan 1 of 2)
+ticket_id: T000386
+domains: [infra, test]
+status: active
+pr_number: null
+---
+
+# Recovery Engine — Implementation Plan (Plan 1 of 2)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+>
+> **Parallel-safe:** This plan touches `scripts/backup-restore.sh`, `k3d/recovery-pvc.yaml`, `Taskfile.yml`, `tests/unit/backup-restore-recovery.bats` — **disjoint** from Plan 2 (`feature/recovery-browse`). The only cross-reference is `browse` running `kubectl apply -f k3d/recovery-browser.yaml` (a path Plan 2 creates) and the shared contract `recovery-pvc:/recovery/<ts>/<service>/`.
+
+**Goal:** Turn opaque, all-or-nothing recovery into a browsable, selective, self-verifying staging workflow: new `stage`/`verify`/`restore-file`/`restore-table`/`browse`/`unstage` subcommands in `backup-restore.sh`, backed by a `recovery-pvc` and throwaway `<db>_recovery` inspection databases.
+
+**Architecture:** Additive subcommands in `scripts/backup-restore.sh`, each rendering a Kubernetes Job via heredoc — exactly like the existing `restore`/`pvc-restore`/`filen-pull` (PodSecurity 65534/65532, `nodeAffinity` excluding home nodes for backup-pvc, `podAffinity` to `shared-db`, secrets `BACKUP_PASSPHRASE`/`SHARED_DB_PASSWORD` from `workspace-secrets`, all `$KC` calls carry `-n "$NS"`). Per-service/per-db staging keeps `recovery-pvc` small.
+
+**Tech Stack:** Bash (`set -euo pipefail`), kubectl Jobs, `openssl enc -d -aes-256-cbc -pbkdf2`, `pg_restore`/`createdb`/`dropdb` (pgvector/pgvector:0.8.0-pg16), `tar`/`cp` (alpine:3), BATS (`tests/unit/`, kubectl stub).
+
+---
+
+## Invariants (read first)
+
+- **`-n "$NS"` everywhere.** `tests/unit/backup-restore-namespace.bats` greps for literal `-n workspace` and for `$KC … secret … workspace-secrets` without `-n "$NS"`. Every new `$KC` call must pass `-n "$NS"`. The only allowed `workspace` literal is the existing `NS=workspace` default.
+- **No live data touched by `stage`/`verify`.** They create `<db>_recovery` DBs and write under `recovery-pvc:/recovery/`. Only `restore-file`/`restore-table` write to live data, and only after a `yes` confirmation (skippable with `-y`).
+- **Mirror existing Job hygiene:** `ttlSecondsAfterFinished: 600`, `backoffLimit: 0`, `restartPolicy: Never`, `runAsNonRoot`, `seccompProfile: RuntimeDefault`, `capabilities: drop:[ALL]`, resource requests/limits — copy from the `restore`/`pvc-restore` Jobs.
+- **Repo root in the script:** add near the top (after `SCRIPT=`): `REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)`.
+
+## File structure
+
+| Action | Path | Responsibility |
+|--------|------|----------------|
+| Create | `k3d/recovery-pvc.yaml` | The staging volume (`recovery-pvc`). |
+| Modify | `scripts/backup-restore.sh` | New `stage`/`verify`/`restore-file`/`restore-table`/`browse`/`unbrowse`/`unstage` subcommands + helpers + usage. |
+| Modify | `Taskfile.yml` | `recovery:*` tasks wrapping the script (env-resolved, namespaced). |
+| Create | `tests/unit/backup-restore-recovery.bats` | Unit tests (kubectl stub, rendered-YAML assertions). |
+
+---
+
+## Task 1: `recovery-pvc` manifest
+
+**Files:** Create `k3d/recovery-pvc.yaml`
+
+- [ ] **Step 1: Create the PVC manifest**
+
+Create `k3d/recovery-pvc.yaml` (mirror `k3d/backup-pvc.yaml`'s shape; larger size for decompressed staging):
+
+```yaml
+# recovery-pvc — scratch space for browsable backup staging (recovery workflow).
+# Holds decrypted+extracted PVC file trees under /recovery/<ts>/<service>/.
+# Per-service staging keeps real usage well under the quota. NOT mounted by any
+# always-on workload; written by `backup-restore.sh stage`, read-only by the
+# on-demand recovery filebrowser (Plan 2).
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: recovery-pvc
+  labels:
+    app: recovery
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi
+```
+
+- [ ] **Step 2: Validate the manifest**
+
+Run: `cd /tmp/wt-recovery-engine && kubectl apply --dry-run=client -f k3d/recovery-pvc.yaml`
+Expected: `persistentvolumeclaim/recovery-pvc created (dry run)`.
+
+> Note: do NOT add `recovery-pvc.yaml` to `k3d/kustomization.yaml` — it is applied on demand by the recovery tasks (like office-stack/coturn). It is applied via the Taskfile in Task 7.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add k3d/recovery-pvc.yaml
+git commit -m "feat(recovery): recovery-pvc staging volume"
+```
+
+---
+
+## Task 2: helpers + `stage` subcommand
+
+**Files:** Modify `scripts/backup-restore.sh`; Test `tests/unit/backup-restore-recovery.bats`
+
+- [ ] **Step 1: Write the failing BATS test**
+
+Create `tests/unit/backup-restore-recovery.bats` (mirror `backup-restore-filen-pull.bats`'s kubectl stub):
+
+```bash
+#!/usr/bin/env bats
+# backup-restore-recovery.bats — unit tests for the recovery-staging subcommands.
+# Stubs kubectl; captures the applied Job/exec YAML; no live cluster required.
+
+load test_helper
+
+SCRIPT="${PROJECT_DIR}/scripts/backup-restore.sh"
+
+setup() {
+  FAKE_BIN=$(mktemp -d)
+  export CAPTURE="${BATS_TEST_TMPDIR}/applied.yaml"
+  cat > "${FAKE_BIN}/kubectl" <<EOF
+#!/usr/bin/env bash
+args="\$*"
+case "\$args" in
+  *"apply"*) cat > "${CAPTURE}" ; exit 0 ;;
+  *"wait"*)  exit 0 ;;
+  *"logs"*)  exit 0 ;;
+  *"get configmap domain-config"*) echo "recover.localhost" ; exit 0 ;;
+  *) exit 0 ;;
+esac
+EOF
+  chmod +x "${FAKE_BIN}/kubectl"
+  export PATH="${FAKE_BIN}:${PATH}"
+}
+
+teardown() { rm -rf "$FAKE_BIN"; }
+
+@test "stage without args fails with usage" {
+  run bash "$SCRIPT" stage
+  assert_failure
+  assert_output --partial "Usage"
+}
+
+@test "stage of a DB renders a pg_restore Job into <db>_recovery (live DB untouched)" {
+  run bash "$SCRIPT" stage 20260530-020001 website -y
+  assert_success
+  run cat "$CAPTURE"
+  assert_output --partial "kind: Job"
+  assert_output --partial "website.dump.enc"
+  assert_output --partial "createdb -h shared-db -U postgres -O website website_recovery"
+  assert_output --partial "pg_restore -h shared-db -U postgres -d website_recovery"
+  # never drops the live db during staging
+  refute_output --partial "dropdb -h shared-db -U postgres --if-exists website "
+}
+
+@test "stage of a service extracts into recovery-pvc under /recovery/<ts>/<service>" {
+  run bash "$SCRIPT" stage pvc-20260530-030001 nextcloud-files -y
+  assert_success
+  run cat "$CAPTURE"
+  assert_output --partial "nextcloud-files.tar.gz.enc"
+  assert_output --partial "claimName: recovery-pvc"
+  assert_output --partial "/recovery/pvc-20260530-030001/nextcloud-files"
+  # backup source mounted read-only
+  assert_output --partial "claimName: backup-pvc"
+}
+```
+
+Add `tests/unit/backup-restore-recovery.bats` to the test inventory only if CI requires (the BATS files are globbed by `runner.sh`; no manual registration needed — verify in Task 8).
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd /tmp/wt-recovery-engine && bats tests/unit/backup-restore-recovery.bats`
+Expected: FAIL — `stage` is unknown, so the script prints usage and exits 1 for all cases.
+
+- [ ] **Step 3: Add helpers + repo root**
+
+In `scripts/backup-restore.sh`, after `SCRIPT=$(basename "$0")` (line ~7) add:
+
+```bash
+REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
+```
+
+After `_pvc_service_mount()` (line ~94) add a target classifier and a recovery-pvc list of DBs/services:
+
+```bash
+_target_kind() {
+  case "$1" in
+    keycloak|nextcloud|vaultwarden|website|docuseal) echo db ;;
+    nextcloud-files|vaultwarden-data|docuseal-data)  echo service ;;
+    *) _die "unknown stage target '$1' (db: keycloak nextcloud vaultwarden website docuseal | service: nextcloud-files vaultwarden-data docuseal-data)" ;;
+  esac
+}
+```
+
+- [ ] **Step 4: Implement the `stage` subcommand**
+
+Add a new `case` branch before the final `*)` in the dispatch (after the `filen-pull` branch, line ~567):
+
+```bash
+  stage)
+    TS="${1:-}"; TARGET="${2:-}"
+    [[ -n "$TS" && -n "$TARGET" ]] || _die "Usage: $SCRIPT stage <timestamp> <db|service>"
+    KIND=$(_target_kind "$TARGET")
+
+    if [[ "$KIND" == "db" ]]; then
+      echo "--> Staging DB '${TARGET}' from ${TS} into ${TARGET}_recovery (live DB untouched)..."
+      JOB="recovery-stage-db-${TARGET}-$$"
+      $KC apply -n "$NS" -f - <<YAML
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ${JOB}
+  namespace: ${NS}
+  labels: { app: recovery-stage }
+spec:
+  ttlSecondsAfterFinished: 600
+  backoffLimit: 0
+  template:
+    spec:
+      restartPolicy: Never
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector: { matchLabels: { app: shared-db } }
+              topologyKey: kubernetes.io/hostname
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        fsGroup: 65534
+        seccompProfile: { type: RuntimeDefault }
+      containers:
+        - name: stage
+          image: pgvector/pgvector:0.8.0-pg16
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -e
+              sleep 10
+              ENC="/backups/${TS}/${TARGET}.dump.enc"
+              [ -f "\$ENC" ] || { echo "ERROR: \$ENC not found"; exit 1; }
+              openssl enc -d -aes-256-cbc -pbkdf2 -in "\$ENC" -out /tmp/${TARGET}.dump -pass env:BACKUP_PASSPHRASE
+              PGPASSWORD="\$SHARED_DB_PASSWORD" dropdb -h shared-db -U postgres --if-exists ${TARGET}_recovery
+              PGPASSWORD="\$SHARED_DB_PASSWORD" createdb -h shared-db -U postgres -O ${TARGET} ${TARGET}_recovery
+              PGPASSWORD="\$SHARED_DB_PASSWORD" pg_restore -h shared-db -U postgres -d ${TARGET}_recovery --no-owner --exit-on-error /tmp/${TARGET}.dump
+              rm /tmp/${TARGET}.dump
+              echo "✓ staged ${TARGET}_recovery — inspect with: psql -h shared-db -U postgres -d ${TARGET}_recovery"
+          env:
+            - { name: BACKUP_PASSPHRASE,  valueFrom: { secretKeyRef: { name: workspace-secrets, key: BACKUP_PASSPHRASE } } }
+            - { name: SHARED_DB_PASSWORD, valueFrom: { secretKeyRef: { name: workspace-secrets, key: SHARED_DB_PASSWORD } } }
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            runAsUser: 65534
+            capabilities: { drop: ["ALL"] }
+          volumeMounts:
+            - { name: backup-storage, mountPath: /backups, readOnly: true }
+          resources:
+            requests: { memory: 256Mi, cpu: "200m" }
+            limits:   { memory: 512Mi, cpu: "1" }
+      volumes:
+        - name: backup-storage
+          persistentVolumeClaim: { claimName: backup-pvc }
+YAML
+    else
+      ARCHIVE_FILE=$(_pvc_service_mount "$TARGET")
+      echo "--> Staging service '${TARGET}' from ${TS} into recovery-pvc:/recovery/${TS}/${TARGET}/ ..."
+      JOB="recovery-stage-svc-${TARGET}-$$"
+      $KC apply -n "$NS" -f - <<YAML
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ${JOB}
+  namespace: ${NS}
+  labels: { app: recovery-stage }
+spec:
+  ttlSecondsAfterFinished: 600
+  backoffLimit: 0
+  template:
+    spec:
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        fsGroup: 65534
+        seccompProfile: { type: RuntimeDefault }
+      containers:
+        - name: stage
+          image: alpine:3
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -e
+              ENC="/backups/${TS}/${ARCHIVE_FILE}"
+              [ -f "\$ENC" ] || { echo "ERROR: \$ENC not found"; exit 1; }
+              DEST="/recovery/${TS}/${TARGET}"
+              mkdir -p "\$DEST"
+              find "\$DEST" -mindepth 1 -delete
+              openssl enc -d -aes-256-cbc -pbkdf2 -in "\$ENC" -out /tmp/stage.tar.gz -pass env:BACKUP_PASSPHRASE
+              tar xzf /tmp/stage.tar.gz -C "\$DEST"
+              rm /tmp/stage.tar.gz
+              echo "✓ staged \$DEST — browse it via: $SCRIPT browse"
+          env:
+            - { name: BACKUP_PASSPHRASE, valueFrom: { secretKeyRef: { name: workspace-secrets, key: BACKUP_PASSPHRASE } } }
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            runAsUser: 65534
+            capabilities: { drop: ["ALL"] }
+          volumeMounts:
+            - { name: backup-storage, mountPath: /backups, readOnly: true }
+            - { name: recovery,       mountPath: /recovery }
+          resources:
+            requests: { memory: 256Mi, cpu: "200m" }
+            limits:   { memory: 1Gi,   cpu: "1" }
+      volumes:
+        - { name: backup-storage, persistentVolumeClaim: { claimName: backup-pvc } }
+        - { name: recovery,       persistentVolumeClaim: { claimName: recovery-pvc } }
+YAML
+    fi
+    echo "    Waiting for stage job to complete (up to 10 min)..."
+    if ! $KC wait -n "$NS" job/"$JOB" --for=condition=Complete --timeout=600s 2>/dev/null; then
+      echo "    ERROR: stage job did not complete"; $KC logs -n "$NS" -l "job-name=${JOB}" --tail=50 2>/dev/null || true; exit 1
+    fi
+    $KC logs -n "$NS" -l "job-name=${JOB}" --tail=10 2>/dev/null || true
+    ;;
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `cd /tmp/wt-recovery-engine && bats tests/unit/backup-restore-recovery.bats`
+Expected: PASS for the 3 `stage` tests. (The `-y` flag is parsed by the existing flag loop; `stage` itself doesn't prompt, so `-y` is a harmless no-op kept for symmetry — the stub makes `wait` succeed.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/backup-restore.sh tests/unit/backup-restore-recovery.bats
+git commit -m "feat(recovery): stage subcommand (DB → *_recovery, service → recovery-pvc)"
+```
+
+---
+
+## Task 3: `verify` subcommand
+
+**Files:** Modify `scripts/backup-restore.sh`; Test `tests/unit/backup-restore-recovery.bats`
+
+- [ ] **Step 1: Add the failing test**
+
+Append to `tests/unit/backup-restore-recovery.bats`:
+
+```bash
+@test "verify renders a Job that restores into a temp DB, counts, and drops it" {
+  run bash "$SCRIPT" verify 20260530-020001 website
+  assert_success
+  run cat "$CAPTURE"
+  assert_output --partial "website.dump.enc"
+  assert_output --partial "createdb -h shared-db -U postgres"
+  assert_output --partial "information_schema.tables"
+  assert_output --partial "dropdb -h shared-db -U postgres --if-exists"
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd /tmp/wt-recovery-engine && bats tests/unit/backup-restore-recovery.bats -f verify`
+Expected: FAIL (`verify` unknown).
+
+- [ ] **Step 3: Implement `verify`**
+
+Add after the `stage)` branch:
+
+```bash
+  verify)
+    TS="${1:-}"; DB="${2:-}"
+    [[ -n "$TS" && -n "$DB" ]] || _die "Usage: $SCRIPT verify <timestamp> <db>"
+    [[ "$(_target_kind "$DB")" == "db" ]] || _die "verify expects a database name"
+    echo "--> Verifying ${DB} dump from ${TS} (restore into temp DB, count, drop)..."
+    JOB="recovery-verify-${DB}-$$"
+    $KC apply -n "$NS" -f - <<YAML
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ${JOB}
+  namespace: ${NS}
+  labels: { app: recovery-verify }
+spec:
+  ttlSecondsAfterFinished: 600
+  backoffLimit: 0
+  template:
+    spec:
+      restartPolicy: Never
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector: { matchLabels: { app: shared-db } }
+              topologyKey: kubernetes.io/hostname
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        fsGroup: 65534
+        seccompProfile: { type: RuntimeDefault }
+      containers:
+        - name: verify
+          image: pgvector/pgvector:0.8.0-pg16
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -e
+              sleep 10
+              ENC="/backups/${TS}/${DB}.dump.enc"
+              [ -f "\$ENC" ] || { echo "ERROR: \$ENC not found"; exit 1; }
+              TMP=${DB}_verify_$$
+              openssl enc -d -aes-256-cbc -pbkdf2 -in "\$ENC" -out /tmp/${DB}.dump -pass env:BACKUP_PASSPHRASE
+              PGPASSWORD="\$SHARED_DB_PASSWORD" createdb -h shared-db -U postgres "\$TMP"
+              PGPASSWORD="\$SHARED_DB_PASSWORD" pg_restore -h shared-db -U postgres -d "\$TMP" --no-owner --exit-on-error /tmp/${DB}.dump
+              echo "── Tabellen-Zähler für ${DB} (${TS}) ──"
+              PGPASSWORD="\$SHARED_DB_PASSWORD" psql -h shared-db -U postgres -d "\$TMP" -c \
+                "SELECT table_name, (xpath('/row/c/text()', query_to_xml(format('SELECT count(*) AS c FROM %I.%I', table_schema, table_name), false, true, '')))[1]::text::int AS rows FROM information_schema.tables WHERE table_schema='public' ORDER BY rows DESC;"
+              PGPASSWORD="\$SHARED_DB_PASSWORD" dropdb -h shared-db -U postgres --if-exists "\$TMP"
+              rm /tmp/${DB}.dump
+              echo "✓ ${DB} dump from ${TS} is restorable."
+          env:
+            - { name: BACKUP_PASSPHRASE,  valueFrom: { secretKeyRef: { name: workspace-secrets, key: BACKUP_PASSPHRASE } } }
+            - { name: SHARED_DB_PASSWORD, valueFrom: { secretKeyRef: { name: workspace-secrets, key: SHARED_DB_PASSWORD } } }
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            runAsUser: 65534
+            capabilities: { drop: ["ALL"] }
+          volumeMounts:
+            - { name: backup-storage, mountPath: /backups, readOnly: true }
+          resources:
+            requests: { memory: 256Mi, cpu: "200m" }
+            limits:   { memory: 512Mi, cpu: "1" }
+      volumes:
+        - { name: backup-storage, persistentVolumeClaim: { claimName: backup-pvc } }
+YAML
+    echo "    Waiting for verify job (up to 10 min)..."
+    if ! $KC wait -n "$NS" job/"$JOB" --for=condition=Complete --timeout=600s 2>/dev/null; then
+      echo "    ✗ ${DB} dump FAILED to restore — backup is NOT trustworthy"; $KC logs -n "$NS" -l "job-name=${JOB}" --tail=50 2>/dev/null || true; exit 1
+    fi
+    $KC logs -n "$NS" -l "job-name=${JOB}" 2>/dev/null || true
+    ;;
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cd /tmp/wt-recovery-engine && bats tests/unit/backup-restore-recovery.bats -f verify`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/backup-restore.sh tests/unit/backup-restore-recovery.bats
+git commit -m "feat(recovery): verify subcommand (restorability + table counts)"
+```
+
+---
+
+## Task 4: `restore-file` (selective file recovery)
+
+**Files:** Modify `scripts/backup-restore.sh`; Test `tests/unit/backup-restore-recovery.bats`
+
+- [ ] **Step 1: Add the failing test**
+
+Append:
+
+```bash
+@test "restore-file copies one path from staging into the live PVC (with -y)" {
+  run bash "$SCRIPT" restore-file pvc-20260530-030001 nextcloud-files admin/files/Doc.pdf -y
+  assert_success
+  run cat "$CAPTURE"
+  assert_output --partial "claimName: recovery-pvc"
+  assert_output --partial "claimName: nextcloud-data-pvc"
+  assert_output --partial "/recovery/pvc-20260530-030001/nextcloud-files/admin/files/Doc.pdf"
+}
+
+@test "restore-file requires confirmation without -y" {
+  run bash -c "echo no | bash '$SCRIPT' restore-file pvc-20260530-030001 nextcloud-files admin/files/Doc.pdf"
+  assert_failure
+  assert_output --partial "Aborted"
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd /tmp/wt-recovery-engine && bats tests/unit/backup-restore-recovery.bats -f restore-file`
+Expected: FAIL (`restore-file` unknown).
+
+- [ ] **Step 3: Implement `restore-file`**
+
+Add after the `verify)` branch. Reuse the live-PVC name mapping from `pvc-restore`:
+
+```bash
+  restore-file)
+    SVC="${1:-}"; SUBPATH=""; TS="${1:-}"
+    # arg order: <timestamp> <service> <path>
+    TS="${1:-}"; SVC="${2:-}"; SUBPATH="${3:-}"
+    [[ -n "$TS" && -n "$SVC" && -n "$SUBPATH" ]] || _die "Usage: $SCRIPT restore-file <timestamp> <service> <path>"
+    _pvc_service_mount "$SVC" >/dev/null   # validate service name
+    case "$SVC" in
+      nextcloud-files)  PVC_NAME="nextcloud-data-pvc";  MOUNT_PATH="/data" ;;
+      vaultwarden-data) PVC_NAME="vaultwarden-data-pvc"; MOUNT_PATH="/data" ;;
+      docuseal-data)    PVC_NAME="docuseal-data-pvc";    MOUNT_PATH="/data" ;;
+    esac
+    echo ""
+    echo " SELECTIVE FILE RESTORE"
+    printf "  From staging : recovery-pvc:/recovery/%s/%s/%s\n" "$TS" "$SVC" "$SUBPATH"
+    printf "  Into live    : %s:%s/%s  (ns=%s)\n" "$PVC_NAME" "$MOUNT_PATH" "$SUBPATH" "$NS"
+    echo "  This overwrites that path in the LIVE volume."
+    if [[ "$YES" != true ]]; then
+      read -rp "Type 'yes' to continue: " CONFIRM
+      [[ "$CONFIRM" == "yes" ]] || { echo "Aborted."; exit 1; }
+    fi
+    JOB="recovery-restore-file-${SVC}-$$"
+    $KC apply -n "$NS" -f - <<YAML
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ${JOB}
+  namespace: ${NS}
+  labels: { app: recovery-restore-file }
+spec:
+  ttlSecondsAfterFinished: 600
+  backoffLimit: 0
+  template:
+    spec:
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        fsGroup: 65534
+        seccompProfile: { type: RuntimeDefault }
+      containers:
+        - name: restore-file
+          image: alpine:3
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -e
+              SRC="/recovery/${TS}/${SVC}/${SUBPATH}"
+              DST="${MOUNT_PATH}/${SUBPATH}"
+              [ -e "\$SRC" ] || { echo "ERROR: \$SRC not staged — run: $SCRIPT stage ${TS} ${SVC}"; exit 1; }
+              mkdir -p "\$(dirname "\$DST")"
+              cp -a "\$SRC" "\$DST"
+              echo "✓ restored \$DST from staging"
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            runAsUser: 65534
+            capabilities: { drop: ["ALL"] }
+          volumeMounts:
+            - { name: recovery, mountPath: /recovery, readOnly: true }
+            - { name: target,   mountPath: ${MOUNT_PATH} }
+          resources:
+            requests: { memory: 128Mi, cpu: "100m" }
+            limits:   { memory: 512Mi, cpu: "1" }
+      volumes:
+        - { name: recovery, persistentVolumeClaim: { claimName: recovery-pvc } }
+        - { name: target,   persistentVolumeClaim: { claimName: ${PVC_NAME} } }
+YAML
+    echo "    Waiting for restore-file job (up to 5 min)..."
+    if ! $KC wait -n "$NS" job/"$JOB" --for=condition=Complete --timeout=300s 2>/dev/null; then
+      echo "    ERROR: restore-file did not complete"; $KC logs -n "$NS" -l "job-name=${JOB}" --tail=50 2>/dev/null || true; exit 1
+    fi
+    $KC logs -n "$NS" -l "job-name=${JOB}" --tail=10 2>/dev/null || true
+    ;;
+```
+
+> Note: the first two `SVC=`/`TS=` lines are intentionally re-assigned on the next two lines — keep only the canonical `TS="${1:-}"; SVC="${2:-}"; SUBPATH="${3:-}"` line and delete the stray first assignment when implementing (it's shown to flag the arg order explicitly).
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cd /tmp/wt-recovery-engine && bats tests/unit/backup-restore-recovery.bats -f restore-file`
+Expected: PASS (both cases).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/backup-restore.sh tests/unit/backup-restore-recovery.bats
+git commit -m "feat(recovery): restore-file (selective file recovery from staging)"
+```
+
+---
+
+## Task 5: `restore-table` (selective DB-table recovery)
+
+**Files:** Modify `scripts/backup-restore.sh`; Test `tests/unit/backup-restore-recovery.bats`
+
+- [ ] **Step 1: Add the failing test**
+
+```bash
+@test "restore-table renders pg_restore -t <table> into the live DB (with -y)" {
+  run bash "$SCRIPT" restore-table 20260530-020001 website site_settings -y
+  assert_success
+  run cat "$CAPTURE"
+  assert_output --partial "website.dump.enc"
+  assert_output --partial "pg_restore -h shared-db -U postgres -d website"
+  assert_output --partial "-t site_settings"
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd /tmp/wt-recovery-engine && bats tests/unit/backup-restore-recovery.bats -f restore-table`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement `restore-table`**
+
+Add after the `restore-file)` branch:
+
+```bash
+  restore-table)
+    TS="${1:-}"; DB="${2:-}"; TABLE="${3:-}"
+    [[ -n "$TS" && -n "$DB" && -n "$TABLE" ]] || _die "Usage: $SCRIPT restore-table <timestamp> <db> <table>"
+    [[ "$(_target_kind "$DB")" == "db" ]] || _die "restore-table expects a database name"
+    echo ""
+    echo " SELECTIVE TABLE RESTORE"
+    printf "  Dump  : %s/%s.dump.enc\n" "$TS" "$DB"
+    printf "  Into  : LIVE %s.%s (ns=%s) — table is DROPPED + recreated from the dump\n" "$DB" "$TABLE" "$NS"
+    if [[ "$YES" != true ]]; then
+      read -rp "Type 'yes' to continue: " CONFIRM
+      [[ "$CONFIRM" == "yes" ]] || { echo "Aborted."; exit 1; }
+    fi
+    JOB="recovery-restore-table-${DB}-$$"
+    $KC apply -n "$NS" -f - <<YAML
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ${JOB}
+  namespace: ${NS}
+  labels: { app: recovery-restore-table }
+spec:
+  ttlSecondsAfterFinished: 600
+  backoffLimit: 0
+  template:
+    spec:
+      restartPolicy: Never
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector: { matchLabels: { app: shared-db } }
+              topologyKey: kubernetes.io/hostname
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        fsGroup: 65534
+        seccompProfile: { type: RuntimeDefault }
+      containers:
+        - name: restore-table
+          image: pgvector/pgvector:0.8.0-pg16
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -e
+              sleep 10
+              ENC="/backups/${TS}/${DB}.dump.enc"
+              [ -f "\$ENC" ] || { echo "ERROR: \$ENC not found"; exit 1; }
+              openssl enc -d -aes-256-cbc -pbkdf2 -in "\$ENC" -out /tmp/${DB}.dump -pass env:BACKUP_PASSPHRASE
+              PGPASSWORD="\$SHARED_DB_PASSWORD" pg_restore -h shared-db -U postgres -d ${DB} --no-owner --clean --if-exists -t ${TABLE} /tmp/${DB}.dump
+              rm /tmp/${DB}.dump
+              echo "✓ restored table ${DB}.${TABLE} from ${TS}"
+          env:
+            - { name: BACKUP_PASSPHRASE,  valueFrom: { secretKeyRef: { name: workspace-secrets, key: BACKUP_PASSPHRASE } } }
+            - { name: SHARED_DB_PASSWORD, valueFrom: { secretKeyRef: { name: workspace-secrets, key: SHARED_DB_PASSWORD } } }
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            runAsUser: 65534
+            capabilities: { drop: ["ALL"] }
+          volumeMounts:
+            - { name: backup-storage, mountPath: /backups, readOnly: true }
+          resources:
+            requests: { memory: 256Mi, cpu: "200m" }
+            limits:   { memory: 512Mi, cpu: "1" }
+      volumes:
+        - { name: backup-storage, persistentVolumeClaim: { claimName: backup-pvc } }
+YAML
+    echo "    Waiting for restore-table job (up to 5 min)..."
+    if ! $KC wait -n "$NS" job/"$JOB" --for=condition=Complete --timeout=300s 2>/dev/null; then
+      echo "    ERROR: restore-table did not complete"; $KC logs -n "$NS" -l "job-name=${JOB}" --tail=50 2>/dev/null || true; exit 1
+    fi
+    $KC logs -n "$NS" -l "job-name=${JOB}" --tail=10 2>/dev/null || true
+    ;;
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cd /tmp/wt-recovery-engine && bats tests/unit/backup-restore-recovery.bats -f restore-table`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/backup-restore.sh tests/unit/backup-restore-recovery.bats
+git commit -m "feat(recovery): restore-table (selective pg_restore -t into live DB)"
+```
+
+---
+
+## Task 6: `browse` / `unbrowse` / `unstage` + usage
+
+**Files:** Modify `scripts/backup-restore.sh`; Test `tests/unit/backup-restore-recovery.bats`
+
+- [ ] **Step 1: Add the failing tests**
+
+```bash
+@test "browse applies the recovery-browser manifest and prints the URL" {
+  run bash "$SCRIPT" browse
+  assert_success
+  assert_output --partial "recover."
+}
+
+@test "unstage drops *_recovery DBs and clears the staging dir for a timestamp" {
+  run bash "$SCRIPT" unstage pvc-20260530-030001 -y
+  assert_success
+  run cat "$CAPTURE"
+  assert_output --partial "/recovery/pvc-20260530-030001"
+}
+
+@test "usage lists the recovery commands" {
+  run bash "$SCRIPT" --help
+  assert_success
+  assert_output --partial "stage"
+  assert_output --partial "verify"
+  assert_output --partial "restore-file"
+  assert_output --partial "restore-table"
+  assert_output --partial "browse"
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd /tmp/wt-recovery-engine && bats tests/unit/backup-restore-recovery.bats -f "browse|unstage|usage"`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement `browse`/`unbrowse`/`unstage`**
+
+Add after the `restore-table)` branch:
+
+```bash
+  browse)
+    MANIFEST="${REPO_ROOT}/k3d/recovery-browser.yaml"
+    [[ -f "$MANIFEST" ]] || _die "recovery-browser.yaml missing — Plan 2 (feature/recovery-browse) provides it"
+    echo "Bringing up the recovery filebrowser (read-only over recovery-pvc:/recovery)..."
+    $KC apply -n "$NS" -f "$MANIFEST"
+    DOM=$($KC get configmap domain-config -n "$NS" -o jsonpath='{.data.RECOVER_DOMAIN}' 2>/dev/null || echo "recover.localhost")
+    echo "✓ Browse at: https://${DOM}  (Keycloak login, group /recovery-access). Tear down with: $SCRIPT unbrowse"
+    ;;
+
+  unbrowse)
+    MANIFEST="${REPO_ROOT}/k3d/recovery-browser.yaml"
+    echo "Removing the recovery filebrowser..."
+    $KC delete -n "$NS" -f "$MANIFEST" --ignore-not-found 2>/dev/null || true
+    echo "✓ recovery filebrowser removed"
+    ;;
+
+  unstage)
+    TS="${1:-}"
+    [[ -n "$TS" ]] || _die "Usage: $SCRIPT unstage <timestamp>"
+    if [[ "$YES" != true ]]; then
+      read -rp "Drop all *_recovery DBs and clear recovery-pvc:/recovery/${TS}? Type 'yes': " CONFIRM
+      [[ "$CONFIRM" == "yes" ]] || { echo "Aborted."; exit 1; }
+    fi
+    JOB="recovery-unstage-$$"
+    $KC apply -n "$NS" -f - <<YAML
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ${JOB}
+  namespace: ${NS}
+  labels: { app: recovery-unstage }
+spec:
+  ttlSecondsAfterFinished: 300
+  backoffLimit: 0
+  template:
+    spec:
+      restartPolicy: Never
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector: { matchLabels: { app: shared-db } }
+              topologyKey: kubernetes.io/hostname
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        fsGroup: 65534
+        seccompProfile: { type: RuntimeDefault }
+      containers:
+        - name: unstage
+          image: pgvector/pgvector:0.8.0-pg16
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -e
+              for db in keycloak nextcloud vaultwarden website docuseal; do
+                PGPASSWORD="\$SHARED_DB_PASSWORD" dropdb -h shared-db -U postgres --if-exists \${db}_recovery
+              done
+              rm -rf "/recovery/${TS}" 2>/dev/null || true
+              echo "✓ unstaged ${TS}"
+          env:
+            - { name: SHARED_DB_PASSWORD, valueFrom: { secretKeyRef: { name: workspace-secrets, key: SHARED_DB_PASSWORD } } }
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            runAsUser: 65534
+            capabilities: { drop: ["ALL"] }
+          volumeMounts:
+            - { name: recovery, mountPath: /recovery }
+          resources:
+            requests: { memory: 128Mi, cpu: "100m" }
+            limits:   { memory: 256Mi, cpu: "500m" }
+      volumes:
+        - { name: recovery, persistentVolumeClaim: { claimName: recovery-pvc } }
+YAML
+    $KC wait -n "$NS" job/"$JOB" --for=condition=Complete --timeout=180s 2>/dev/null || true
+    $KC logs -n "$NS" -l "job-name=${JOB}" --tail=10 2>/dev/null || true
+    ;;
+```
+
+- [ ] **Step 4: Extend `usage()`**
+
+In `usage()`, add a recovery block before `Options:` (after the disaster-recovery block, line ~38):
+
+```bash
+  cat <<'EOF'
+
+Commands (browsable recovery — stage, browse, selectively restore):
+  stage <timestamp> <db|service>      Decrypt one entry into a browsable staging area
+                                        db → <db>_recovery inspection DB; service →
+                                        recovery-pvc:/recovery/<ts>/<service>/
+  verify <timestamp> <db>             Prove a DB dump restores; print table counts; drop temp
+  browse                              Bring up the on-demand recovery filebrowser (SSO)
+  unbrowse                            Tear the filebrowser down
+  restore-file <timestamp> <service> <path>   Copy ONE staged path back into the live PVC
+  restore-table <timestamp> <db> <table>      Restore ONE table back into the live DB
+  unstage <timestamp>                 Drop *_recovery DBs + clear the staging dir
+EOF
+```
+
+(Place this `cat` immediately after the existing heredoc's closing `EOF` and before the function's closing brace, or fold the lines into the single existing heredoc — keep it inside `usage()`.)
+
+- [ ] **Step 5: Run to verify pass**
+
+Run: `cd /tmp/wt-recovery-engine && bats tests/unit/backup-restore-recovery.bats`
+Expected: PASS (entire file).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/backup-restore.sh tests/unit/backup-restore-recovery.bats
+git commit -m "feat(recovery): browse/unbrowse/unstage + usage"
+```
+
+---
+
+## Task 7: Taskfile `recovery:*` tasks
+
+**Files:** Modify `Taskfile.yml`
+
+- [ ] **Step 1: Read the neighbouring backup tasks to match style**
+
+Run: `cd /tmp/wt-recovery-engine && sed -n '1082,1200p' Taskfile.yml`
+Expected: see `workspace:backup`, `workspace:db:restore`, `workspace:pvc:restore` — note how they `source scripts/env-resolve.sh "$ENV"`, export `WORKSPACE_NAMESPACE`, and call `bash scripts/backup-restore.sh … --context "$ENV_CONTEXT" --namespace "${WORKSPACE_NAMESPACE:-workspace}"`.
+
+- [ ] **Step 2: Add the recovery tasks**
+
+Insert after `workspace:pvc:restore` (match the exact env-resolve + `--context`/`--namespace` wrapper of the neighbours). Template:
+
+```yaml
+  recovery:prepare:
+    desc: "Apply recovery-pvc (run once per cluster before staging). ENV=<env>"
+    cmds:
+      - |
+        source scripts/env-resolve.sh "{{.ENV | default \"dev\"}}"
+        kubectl apply --context "$ENV_CONTEXT" -n "${WORKSPACE_NAMESPACE:-workspace}" -f k3d/recovery-pvc.yaml
+
+  recovery:stage:
+    desc: "Stage one backup entry browsable. ENV=<env> -- <timestamp> <db|service>"
+    cmds:
+      - |
+        source scripts/env-resolve.sh "{{.ENV | default \"dev\"}}"
+        bash scripts/backup-restore.sh stage {{.CLI_ARGS}} --context "$ENV_CONTEXT" --namespace "${WORKSPACE_NAMESPACE:-workspace}"
+
+  recovery:verify:
+    desc: "Prove a DB dump restores + show table counts. ENV=<env> -- <timestamp> <db>"
+    cmds:
+      - |
+        source scripts/env-resolve.sh "{{.ENV | default \"dev\"}}"
+        bash scripts/backup-restore.sh verify {{.CLI_ARGS}} --context "$ENV_CONTEXT" --namespace "${WORKSPACE_NAMESPACE:-workspace}"
+
+  recovery:browse:
+    desc: "Bring up the on-demand recovery filebrowser (SSO). ENV=<env>"
+    cmds:
+      - |
+        source scripts/env-resolve.sh "{{.ENV | default \"dev\"}}"
+        bash scripts/backup-restore.sh browse --context "$ENV_CONTEXT" --namespace "${WORKSPACE_NAMESPACE:-workspace}"
+
+  recovery:unbrowse:
+    desc: "Tear the recovery filebrowser down. ENV=<env>"
+    cmds:
+      - |
+        source scripts/env-resolve.sh "{{.ENV | default \"dev\"}}"
+        bash scripts/backup-restore.sh unbrowse --context "$ENV_CONTEXT" --namespace "${WORKSPACE_NAMESPACE:-workspace}"
+
+  recovery:restore-file:
+    desc: "Restore ONE staged file/dir into the live PVC. ENV=<env> -- <timestamp> <service> <path>"
+    cmds:
+      - |
+        source scripts/env-resolve.sh "{{.ENV | default \"dev\"}}"
+        bash scripts/backup-restore.sh restore-file {{.CLI_ARGS}} --context "$ENV_CONTEXT" --namespace "${WORKSPACE_NAMESPACE:-workspace}"
+
+  recovery:restore-table:
+    desc: "Restore ONE table into the live DB. ENV=<env> -- <timestamp> <db> <table>"
+    cmds:
+      - |
+        source scripts/env-resolve.sh "{{.ENV | default \"dev\"}}"
+        bash scripts/backup-restore.sh restore-table {{.CLI_ARGS}} --context "$ENV_CONTEXT" --namespace "${WORKSPACE_NAMESPACE:-workspace}"
+
+  recovery:unstage:
+    desc: "Drop *_recovery DBs + clear staging. ENV=<env> -- <timestamp>"
+    cmds:
+      - |
+        source scripts/env-resolve.sh "{{.ENV | default \"dev\"}}"
+        bash scripts/backup-restore.sh unstage {{.CLI_ARGS}} --context "$ENV_CONTEXT" --namespace "${WORKSPACE_NAMESPACE:-workspace}"
+```
+
+> Match the exact quoting/escaping used by the surrounding tasks (`{{.ENV | default "dev"}}` may need the unescaped form depending on the file's convention — copy a neighbour verbatim and swap the subcommand).
+
+- [ ] **Step 3: Validate the Taskfile parses**
+
+Run: `cd /tmp/wt-recovery-engine && task --list 2>&1 | grep recovery:`
+Expected: the eight `recovery:*` tasks listed, no YAML parse error.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Taskfile.yml
+git commit -m "feat(recovery): Taskfile recovery:* wrappers (env-resolved, namespaced)"
+```
+
+---
+
+## Task 8: Verification + docs
+
+**Files:** none new (verification) + a doc note.
+
+- [ ] **Step 1: Full BATS + offline suite**
+
+Run: `cd /tmp/wt-recovery-engine && bats tests/unit/backup-restore-recovery.bats tests/unit/backup-restore-namespace.bats`
+Expected: all pass — crucially `backup-restore-namespace.bats` still passes (no hardcoded `-n workspace`; every new `$KC … workspace-secrets` lookup carries `-n "$NS"` — note our new code only references `workspace-secrets` inside YAML heredocs, which the test explicitly allows).
+
+- [ ] **Step 2: Offline CI parity**
+
+Run: `cd /tmp/wt-recovery-engine && task test:all`
+Expected: green. If the test-inventory check flags a new test file, run `task test:inventory` and commit the regenerated `website/src/data/test-inventory.json`.
+
+- [ ] **Step 3: shellcheck (advisory)**
+
+Run: `cd /tmp/wt-recovery-engine && shellcheck scripts/backup-restore.sh || true`
+Expected: no new errors introduced by the recovery branches (pre-existing advisories may remain).
+
+- [ ] **Step 4: Note for the database-ops skill (cross-plan, do in whichever merges last)**
+
+The `database-ops` skill doc (`.claude/skills/database-ops/SKILL.md`) backup/restore section should gain the stage→browse→selective-restore runbook. Leave a `TODO(recovery-docs)` only if Plan 2 owns the doc; otherwise append the runbook here and commit:
+
+```bash
+# append the runbook to the skill, then:
+git add .claude/skills/database-ops/SKILL.md
+git commit -m "docs(database-ops): browsable recovery runbook"
+```
+
+- [ ] **Step 5: PR**
+
+Open the PR for `feature/recovery-engine` (squash-merge, CI green). Mergeable independently of Plan 2; `browse` will print a clear error until Plan 2's `recovery-browser.yaml` is also merged.
+
+---
+
+## Self-review (author)
+
+- **Spec coverage:** browse-files → staging + Plan-2 surface (T2/T6), trustworthy restore → `verify` + clearer Job output (T3), selective recovery → `restore-file`/`restore-table` (T4/T5), browse-DB → `stage` into `<db>_recovery` + `psql` (T2). Lifecycle → `unstage`/`unbrowse` (T6). Per-service staging → `stage <ts> <service>` (T2). recovery-pvc → T1. Tasks → T7.
+- **Placeholder scan:** real code throughout; the two deliberately-flagged spots (the stray `SVC=`/`TS=` line in T4, the usage-heredoc placement in T6) carry explicit instructions to resolve them.
+- **Invariant consistency:** every `$KC` call carries `-n "$NS"`; `workspace-secrets` only inside heredocs (allowed by the namespace test); Job hygiene copied from existing restore Jobs; `<db>_recovery` naming consistent across stage/unstage.
+- **Parallel safety:** files disjoint from Plan 2; `browse` references `k3d/recovery-browser.yaml` by path and fails gracefully if absent.

--- a/docs/superpowers/specs/2026-05-31-recovery-staging-design.md
+++ b/docs/superpowers/specs/2026-05-31-recovery-staging-design.md
@@ -1,0 +1,72 @@
+# Backup Recovery — Browsable Staging + Selective Restore (Design Spec)
+
+- **Datum:** 2026-05-31
+- **Branches (parallel):** `feature/recovery-engine` (Plan 1), `feature/recovery-browse` (Plan 2)
+- **Status:** approved (brainstorming)
+- **Betrifft:** `scripts/backup-restore.sh`, neue `recovery-*`-Manifeste, `database-ops`-Skill
+- **Vorgänger:** `2026-05-30-backup-filen-pull-design.md` (one-way → two-way Filen), `2026-05-29-pvc-backup.md`
+
+## Problem & Ziel
+
+Heute sind Backups **undurchsichtig** und Recovery ist **nur-Automatik & destruktiv**:
+- DB-Dumps: `pg_dump -Fc` (Binär) → `*.dump.enc` (AES-256). PVCs: `tar.gz` → `*.tar.gz.enc` (AES-256).
+- `restore` / `pvc-restore` entschlüsseln direkt in ein `dropdb`+`pg_restore` bzw. `tar x` über den Live-Daten. Man kann **nichts vorher ansehen**, **nichts browsen**, **nichts gezielt** zurückholen, und der volle Pfad ist **nie end-to-end bewiesen** worden.
+
+Ziel (alle vier vom User bestätigt):
+1. **Backup browsen** — Dateien in einem Dateibaum sehen, *bevor*/*ohne* destruktiven Restore.
+2. **Vertrauenswürdiger Restore** — der Weg `filen-pull → entschlüsseln → wiederherstellen → verifizieren` ist nachweislich lauffähig, mit klarer Erfolgs-/Fehlerausgabe.
+3. **Selektives Recovery** — einzelne Dateien bzw. DB-Tabellen zurückholen, nicht alles-oder-nichts.
+4. **DB-Inhalte ansehen** — Tabellen/Zeilen eines Backups inspizieren, bevor man zurückspielt.
+
+## Gewählter Ansatz (aus Brainstorming)
+
+**„Recovery-Staging":** Ein Backup wird **einmal** in einen *browsebaren* Bereich entpackt, statt direkt destruktiv wiederhergestellt:
+- PVC-Tarballs → **per Dienst on-demand** entpackt nach `recovery-pvc:/recovery/<ts>/<service>/…`
+- jede DB → restauriert in eine **Wegwerf-Inspektions-DB** `<db>_recovery` in derselben Marken-`shared-db`
+
+Davon ausgehend: browsen (Dateien per Web, DB per `psql`), gezielt zurückholen, und das erfolgreiche Staging **beweist** die Wiederherstellbarkeit. Browse-Oberfläche: **Hybrid** — Web-Filebrowser für Dateien, `psql` für DB. Web-UI ist **on-demand** (durch den Recovery-Befehl hoch-/runtergefahren), Daten bleiben **im Cluster** (DSGVO).
+
+**Wichtig — per-service:** Staging entpackt **bewusst pro Dienst** (nicht alles auf einmal), damit `recovery-pvc` klein bleibt; man staged genau, was man braucht.
+
+## Aufteilung in zwei parallel ausführbare Pläne
+
+Disjunkte Dateien → zwei `dev-flow-execute`-Läufe kollidieren nie.
+
+### Plan 1 — Recovery-Engine (`feature/recovery-engine`)
+Datei-Eigentum: `scripts/backup-restore.sh`, `k3d/recovery-pvc.yaml`, `Taskfile.yml` (neue `recovery:*`-Tasks), `tests/unit/backup-restore-recovery.bats`.
+
+Neue Subkommandos in `backup-restore.sh` (gleiche Job-via-heredoc-Muster wie heute — PodSecurity, nodeAffinity ohne Home-Nodes, shared-db-podAffinity, `BACKUP_PASSPHRASE`/`SHARED_DB_PASSWORD` aus `workspace-secrets`, durchgängig `-n "$NS"`):
+- `stage <ts> <db|service>` — entschlüsselt **einen** Eintrag und stagt ihn: DB → `createdb <db>_recovery` + `pg_restore` hinein (Live-DB unangetastet); Service → `tar x` nach `recovery-pvc:/recovery/<ts>/<service>/`.
+- `verify <ts> <db>` — stagt in eine Inspektions-DB, druckt Tabellen-/Zeilen-Zähler, dann `unstage` (beweist Wiederherstellbarkeit).
+- `restore-file <ts> <service> <path>` — kopiert genau diesen Pfad aus dem Staging in die **Live**-PVC (Bestätigung; Job mountet recovery-pvc + Ziel-PVC).
+- `restore-table <ts> <db> <table>` — `pg_restore -t <table>` (optional `--data-only`) aus dem entschlüsselten Dump in die Live-DB (Bestätigung).
+- `browse [<ts>]` — `kubectl apply -f k3d/recovery-browser.yaml` (Manifest aus Plan 2) und druckt die `recover.<domain>`-URL.
+- `unbrowse` / `unstage <ts>` — `unbrowse` löscht die Browser-Stack-Ressourcen; `unstage <ts>` zusätzlich: `dropdb` aller `*_recovery`, leert `recovery-pvc:/recovery/<ts>`.
+- `recovery-pvc`: neues PVC (Longhorn in Prod / local-path Dev), Default-Größe konfigurierbar (z. B. 20Gi); per-service-Staging hält den realen Bedarf klein.
+
+### Plan 2 — Recovery-Browse-Surface (`feature/recovery-browse`)
+Datei-Eigentum: `k3d/recovery-browser.yaml`, `k3d/configmap-domains.yaml` (+`RECOVER_DOMAIN`), `prod-mentolder/realm-workspace-mentolder.json` + `prod-korczewski/realm-workspace-korczewski.json` (+ OIDC-Client `recovery`), `tests/unit/recovery-browser-manifest.bats`.
+
+- `k3d/recovery-browser.yaml` (NICHT in `k3d/kustomization.yaml` — on-demand wie office/coturn): `filebrowser/filebrowser`-Deployment + Service (mountet `recovery-pvc:/recovery` **read-only** unter `/srv`), `oauth2-proxy-recovery`-Deployment + Service (Klon von `oauth2-proxy-docs.yaml`, `--client-id=recovery`, `--upstream=http://recovery-browser:80`, `--allowed-groups=/recovery-access`, Cookie `_oauth2_proxy_recovery`), Traefik-IngressRoute `recover.<domain>` → `oauth2-proxy-recovery:4180`.
+- Keycloak-Client `recovery` (gespiegelt vom `docs`-Client) mit Redirect `…/oauth2/callback` und Gruppen-Mapper für `/recovery-access`.
+- `RECOVER_DOMAIN: "recover.localhost"` (Dev) in der Domains-ConfigMap; Prod-Overlay überschreibt auf `recover.<PROD_DOMAIN>`.
+- Secret-Key `RECOVERY_OIDC_SECRET` (+ Schema/Seal-Eintrag) analog `DOCS_OIDC_SECRET`.
+
+**Integrationsvertrag (beide Pläne):** PVC-Name `recovery-pvc`, Pfad-Layout `/recovery/<ts>/<service>/`, Manifest-Dateiname `k3d/recovery-browser.yaml`, Filebrowser mountet read-only.
+
+## Lebenszyklus & Sicherheit
+
+- `unstage`/`unbrowse` räumen vollständig auf (Inspektions-DBs gedroppt, Staging gelöscht, Browser entfernt). Stale-Staging älter als N Tage → Warnung.
+- Web-UI nur on-demand, gruppen-gated (`/recovery-access`), read-only Mount, Cookie-Secret-Pattern wie docs. Entschlüsselte Daten verlassen nie den Cluster.
+- Pro Marke über `--namespace` (`workspace` / `workspace-korczewski`); `<db>_recovery` liegt in der jeweiligen `shared-db`.
+
+## Out of Scope / Non-Goals
+
+- **Kein** Download/Entschlüsseln auf einen lokalen Rechner (DSGVO — echte Vaultwarden/Nextcloud-Daten blieben sonst auf dem Laptop).
+- **Kein** Web-DB-Browser (pgweb/adminer) — DB-Inspektion bleibt `psql` (mächtiger, kein Extra-Image).
+- **Keine** Änderung am Backup-Mechanismus (CronJobs, Format, Verschlüsselung, Filen-Upload) — nur die Recovery-Seite.
+- **Keine** Änderung am bestehenden destruktiven `restore`/`pvc-restore` außer „verify-first"-Hinweisen + klarerer Ausgabe.
+
+## Risiko
+
+Mittel. Plan 1 ist additiv zu einem bewährten Skript (gleiche Job-Muster); neue Inspektions-DBs/Recovery-PVC berühren keine Live-Daten außer beim expliziten, bestätigten `restore-file`/`restore-table`. Plan 2 fügt eine on-demand, gruppen-gated, read-only Web-Oberfläche hinzu (Sicherheitsfläche bewusst minimiert: nicht im kustomization, kein Dauerbetrieb).

--- a/k3d/recovery-pvc.yaml
+++ b/k3d/recovery-pvc.yaml
@@ -1,0 +1,17 @@
+# recovery-pvc — scratch space for browsable backup staging (recovery workflow).
+# Holds decrypted+extracted PVC file trees under /recovery/<ts>/<service>/.
+# Per-service staging keeps real usage well under the quota. NOT mounted by any
+# always-on workload; written by `backup-restore.sh stage`, read-only by the
+# on-demand recovery filebrowser (Plan 2).
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: recovery-pvc
+  labels:
+    app: recovery
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi

--- a/scripts/backup-restore.sh
+++ b/scripts/backup-restore.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 
 NS=workspace
 SCRIPT=$(basename "$0")
+REPO_ROOT="${REPO_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
 
 usage() {
   cat <<EOF
@@ -36,6 +37,17 @@ Commands (disaster recovery — fresh cluster):
                              FILEN_DEFAULT_UPLOAD_PATH. Timestamps are discovered
                              out-of-band (Filen web/desktop app or 'filen ls').
 
+Commands (browsable recovery — stage, browse, selectively restore):
+  stage <timestamp> <db|service>      Decrypt one entry into a browsable staging area
+                                        db → <db>_recovery inspection DB; service →
+                                        recovery-pvc:/recovery/<ts>/<service>/
+  verify <timestamp> <db>             Prove a DB dump restores; print table counts; drop temp
+  browse                              Bring up the on-demand recovery filebrowser (SSO)
+  unbrowse                            Tear the filebrowser down
+  restore-file <timestamp> <service> <path>   Copy ONE staged path back into the live PVC
+  restore-table <timestamp> <db> <table>      Restore ONE table back into the live DB
+  unstage <timestamp>                 Drop *_recovery DBs + clear the staging dir
+
 Options:
   --context <ctx>   kubectl context (default: active context)
   --namespace <ns>  Kubernetes namespace (default: workspace)
@@ -44,10 +56,10 @@ Options:
 
 Examples:
   $SCRIPT list
-  $SCRIPT pvc-list --context fleet -n workspace
+  $SCRIPT pvc-list --context fleet --namespace workspace
   $SCRIPT pvc-trigger
-  $SCRIPT pvc-restore nextcloud-files pvc-20260427-030001 --context fleet -n workspace -y
-  $SCRIPT restore all 20260427-020001 --context fleet -n workspace-korczewski -y
+  $SCRIPT pvc-restore nextcloud-files pvc-20260427-030001 --context fleet --namespace workspace -y
+  $SCRIPT restore all 20260427-020001 --context fleet --namespace workspace-korczewski -y
 EOF
 }
 
@@ -90,6 +102,14 @@ _pvc_service_mount() {
     vaultwarden-data)  echo "vaultwarden-data.tar.gz.enc" ;;
     docuseal-data)     echo "docuseal-data.tar.gz.enc" ;;
     *) _die "unknown PVC service '$1' (valid: nextcloud-files vaultwarden-data docuseal-data all)" ;;
+  esac
+}
+
+_target_kind() {
+  case "$1" in
+    keycloak|nextcloud|vaultwarden|website|docuseal) echo db ;;
+    nextcloud-files|vaultwarden-data|docuseal-data)  echo service ;;
+    *) _die "unknown stage target '$1' (db: keycloak nextcloud vaultwarden website docuseal | service: nextcloud-files vaultwarden-data docuseal-data)" ;;
   esac
 }
 
@@ -564,6 +584,434 @@ YAML
     echo "    $SCRIPT pvc-list ${CTX_FLAG}    # PVC backups now in backup-pvc"
     echo "    $SCRIPT restore <db> ${TS} ${CTX_FLAG}"
     echo "    $SCRIPT pvc-restore <svc> ${TS} ${CTX_FLAG}"
+    ;;
+
+  stage)
+    TS="${1:-}"; TARGET="${2:-}"
+    [[ -n "$TS" && -n "$TARGET" ]] || _die "Usage: $SCRIPT stage <timestamp> <db|service>"
+    KIND=$(_target_kind "$TARGET")
+
+    if [[ "$KIND" == "db" ]]; then
+      echo "--> Staging DB '${TARGET}' from ${TS} into ${TARGET}_recovery (live DB untouched)..."
+      JOB="recovery-stage-db-${TARGET}-$$"
+      $KC apply -n "$NS" -f - <<YAML
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ${JOB}
+  namespace: ${NS}
+  labels: { app: recovery-stage }
+spec:
+  ttlSecondsAfterFinished: 600
+  backoffLimit: 0
+  template:
+    spec:
+      restartPolicy: Never
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector: { matchLabels: { app: shared-db } }
+              topologyKey: kubernetes.io/hostname
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        fsGroup: 65534
+        seccompProfile: { type: RuntimeDefault }
+      containers:
+        - name: stage
+          image: pgvector/pgvector:0.8.0-pg16
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -e
+              sleep 10
+              ENC="/backups/${TS}/${TARGET}.dump.enc"
+              [ -f "\$ENC" ] || { echo "ERROR: \$ENC not found"; exit 1; }
+              openssl enc -d -aes-256-cbc -pbkdf2 -in "\$ENC" -out /tmp/${TARGET}.dump -pass env:BACKUP_PASSPHRASE
+              PGPASSWORD="\$SHARED_DB_PASSWORD" dropdb -h shared-db -U postgres --if-exists ${TARGET}_recovery
+              PGPASSWORD="\$SHARED_DB_PASSWORD" createdb -h shared-db -U postgres -O ${TARGET} ${TARGET}_recovery
+              PGPASSWORD="\$SHARED_DB_PASSWORD" pg_restore -h shared-db -U postgres -d ${TARGET}_recovery --no-owner --exit-on-error /tmp/${TARGET}.dump
+              rm /tmp/${TARGET}.dump
+              echo "✓ staged ${TARGET}_recovery — inspect with: psql -h shared-db -U postgres -d ${TARGET}_recovery"
+          env:
+            - { name: BACKUP_PASSPHRASE,  valueFrom: { secretKeyRef: { name: workspace-secrets, key: BACKUP_PASSPHRASE } } }
+            - { name: SHARED_DB_PASSWORD, valueFrom: { secretKeyRef: { name: workspace-secrets, key: SHARED_DB_PASSWORD } } }
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            runAsUser: 65534
+            capabilities: { drop: ["ALL"] }
+          volumeMounts:
+            - { name: backup-storage, mountPath: /backups, readOnly: true }
+          resources:
+            requests: { memory: 256Mi, cpu: "200m" }
+            limits:   { memory: 512Mi, cpu: "1" }
+      volumes:
+        - name: backup-storage
+          persistentVolumeClaim: { claimName: backup-pvc }
+YAML
+    else
+      ARCHIVE_FILE=$(_pvc_service_mount "$TARGET")
+      echo "--> Staging service '${TARGET}' from ${TS} into recovery-pvc:/recovery/${TS}/${TARGET}/ ..."
+      JOB="recovery-stage-svc-${TARGET}-$$"
+      $KC apply -n "$NS" -f - <<YAML
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ${JOB}
+  namespace: ${NS}
+  labels: { app: recovery-stage }
+spec:
+  ttlSecondsAfterFinished: 600
+  backoffLimit: 0
+  template:
+    spec:
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        fsGroup: 65534
+        seccompProfile: { type: RuntimeDefault }
+      containers:
+        - name: stage
+          image: alpine:3
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -e
+              ENC="/backups/${TS}/${ARCHIVE_FILE}"
+              [ -f "\$ENC" ] || { echo "ERROR: \$ENC not found"; exit 1; }
+              DEST="/recovery/${TS}/${TARGET}"
+              mkdir -p "\$DEST"
+              find "\$DEST" -mindepth 1 -delete
+              openssl enc -d -aes-256-cbc -pbkdf2 -in "\$ENC" -out /tmp/stage.tar.gz -pass env:BACKUP_PASSPHRASE
+              tar xzf /tmp/stage.tar.gz -C "\$DEST"
+              rm /tmp/stage.tar.gz
+              echo "✓ staged \$DEST — browse it via: $SCRIPT browse"
+          env:
+            - { name: BACKUP_PASSPHRASE, valueFrom: { secretKeyRef: { name: workspace-secrets, key: BACKUP_PASSPHRASE } } }
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            runAsUser: 65534
+            capabilities: { drop: ["ALL"] }
+          volumeMounts:
+            - { name: backup-storage, mountPath: /backups, readOnly: true }
+            - { name: recovery,       mountPath: /recovery }
+          resources:
+            requests: { memory: 256Mi, cpu: "200m" }
+            limits:   { memory: 1Gi,   cpu: "1" }
+      volumes:
+        - { name: backup-storage, persistentVolumeClaim: { claimName: backup-pvc } }
+        - { name: recovery,       persistentVolumeClaim: { claimName: recovery-pvc } }
+YAML
+    fi
+    echo "    Waiting for stage job to complete (up to 10 min)..."
+    if ! $KC wait -n "$NS" job/"$JOB" --for=condition=Complete --timeout=600s 2>/dev/null; then
+      echo "    ERROR: stage job did not complete"; $KC logs -n "$NS" -l "job-name=${JOB}" --tail=50 2>/dev/null || true; exit 1
+    fi
+    $KC logs -n "$NS" -l "job-name=${JOB}" --tail=10 2>/dev/null || true
+    ;;
+
+  verify)
+    TS="${1:-}"; DB="${2:-}"
+    [[ -n "$TS" && -n "$DB" ]] || _die "Usage: $SCRIPT verify <timestamp> <db>"
+    [[ "$(_target_kind "$DB")" == "db" ]] || _die "verify expects a database name"
+    echo "--> Verifying ${DB} dump from ${TS} (restore into temp DB, count, drop)..."
+    JOB="recovery-verify-${DB}-$$"
+    $KC apply -n "$NS" -f - <<YAML
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ${JOB}
+  namespace: ${NS}
+  labels: { app: recovery-verify }
+spec:
+  ttlSecondsAfterFinished: 600
+  backoffLimit: 0
+  template:
+    spec:
+      restartPolicy: Never
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector: { matchLabels: { app: shared-db } }
+              topologyKey: kubernetes.io/hostname
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        fsGroup: 65534
+        seccompProfile: { type: RuntimeDefault }
+      containers:
+        - name: verify
+          image: pgvector/pgvector:0.8.0-pg16
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -e
+              sleep 10
+              ENC="/backups/${TS}/${DB}.dump.enc"
+              [ -f "\$ENC" ] || { echo "ERROR: \$ENC not found"; exit 1; }
+              TMP=${DB}_verify_$$
+              openssl enc -d -aes-256-cbc -pbkdf2 -in "\$ENC" -out /tmp/${DB}.dump -pass env:BACKUP_PASSPHRASE
+              PGPASSWORD="\$SHARED_DB_PASSWORD" createdb -h shared-db -U postgres "\$TMP"
+              PGPASSWORD="\$SHARED_DB_PASSWORD" pg_restore -h shared-db -U postgres -d "\$TMP" --no-owner --exit-on-error /tmp/${DB}.dump
+              echo "── Tabellen-Zähler für ${DB} (${TS}) ──"
+              PGPASSWORD="\$SHARED_DB_PASSWORD" psql -h shared-db -U postgres -d "\$TMP" -c \
+                "SELECT table_name, (xpath('/row/c/text()', query_to_xml(format('SELECT count(*) AS c FROM %I.%I', table_schema, table_name), false, true, '')))[1]::text::int AS rows FROM information_schema.tables WHERE table_schema='public' ORDER BY rows DESC;"
+              PGPASSWORD="\$SHARED_DB_PASSWORD" dropdb -h shared-db -U postgres --if-exists "\$TMP"
+              rm /tmp/${DB}.dump
+              echo "✓ ${DB} dump from ${TS} is restorable."
+          env:
+            - { name: BACKUP_PASSPHRASE,  valueFrom: { secretKeyRef: { name: workspace-secrets, key: BACKUP_PASSPHRASE } } }
+            - { name: SHARED_DB_PASSWORD, valueFrom: { secretKeyRef: { name: workspace-secrets, key: SHARED_DB_PASSWORD } } }
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            runAsUser: 65534
+            capabilities: { drop: ["ALL"] }
+          volumeMounts:
+            - { name: backup-storage, mountPath: /backups, readOnly: true }
+          resources:
+            requests: { memory: 256Mi, cpu: "200m" }
+            limits:   { memory: 512Mi, cpu: "1" }
+      volumes:
+        - { name: backup-storage, persistentVolumeClaim: { claimName: backup-pvc } }
+YAML
+    echo "    Waiting for verify job (up to 10 min)..."
+    if ! $KC wait -n "$NS" job/"$JOB" --for=condition=Complete --timeout=600s 2>/dev/null; then
+      echo "    ✗ ${DB} dump FAILED to restore — backup is NOT trustworthy"; $KC logs -n "$NS" -l "job-name=${JOB}" --tail=50 2>/dev/null || true; exit 1
+    fi
+    $KC logs -n "$NS" -l "job-name=${JOB}" 2>/dev/null || true
+    ;;
+
+  restore-file)
+    TS="${1:-}"; SVC="${2:-}"; SUBPATH="${3:-}"
+    [[ -n "$TS" && -n "$SVC" && -n "$SUBPATH" ]] || _die "Usage: $SCRIPT restore-file <timestamp> <service> <path>"
+    _pvc_service_mount "$SVC" >/dev/null   # validate service name
+    case "$SVC" in
+      nextcloud-files)  PVC_NAME="nextcloud-data-pvc";  MOUNT_PATH="/data" ;;
+      vaultwarden-data) PVC_NAME="vaultwarden-data-pvc"; MOUNT_PATH="/data" ;;
+      docuseal-data)    PVC_NAME="docuseal-data-pvc";    MOUNT_PATH="/data" ;;
+    esac
+    echo ""
+    echo " SELECTIVE FILE RESTORE"
+    printf "  From staging : recovery-pvc:/recovery/%s/%s/%s\n" "$TS" "$SVC" "$SUBPATH"
+    printf "  Into live    : %s:%s/%s  (ns=%s)\n" "$PVC_NAME" "$MOUNT_PATH" "$SUBPATH" "$NS"
+    echo "  This overwrites that path in the LIVE volume."
+    if [[ "$YES" != true ]]; then
+      read -rp "Type 'yes' to continue: " CONFIRM
+      [[ "$CONFIRM" == "yes" ]] || { echo "Aborted."; exit 1; }
+    fi
+    JOB="recovery-restore-file-${SVC}-$$"
+    $KC apply -n "$NS" -f - <<YAML
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ${JOB}
+  namespace: ${NS}
+  labels: { app: recovery-restore-file }
+spec:
+  ttlSecondsAfterFinished: 600
+  backoffLimit: 0
+  template:
+    spec:
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        fsGroup: 65534
+        seccompProfile: { type: RuntimeDefault }
+      containers:
+        - name: restore-file
+          image: alpine:3
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -e
+              SRC="/recovery/${TS}/${SVC}/${SUBPATH}"
+              DST="${MOUNT_PATH}/${SUBPATH}"
+              [ -e "\$SRC" ] || { echo "ERROR: \$SRC not staged — run: $SCRIPT stage ${TS} ${SVC}"; exit 1; }
+              mkdir -p "\$(dirname "\$DST")"
+              cp -a "\$SRC" "\$DST"
+              echo "✓ restored \$DST from staging"
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            runAsUser: 65534
+            capabilities: { drop: ["ALL"] }
+          volumeMounts:
+            - { name: recovery, mountPath: /recovery, readOnly: true }
+            - { name: target,   mountPath: ${MOUNT_PATH} }
+          resources:
+            requests: { memory: 128Mi, cpu: "100m" }
+            limits:   { memory: 512Mi, cpu: "1" }
+      volumes:
+        - { name: recovery, persistentVolumeClaim: { claimName: recovery-pvc } }
+        - { name: target,   persistentVolumeClaim: { claimName: ${PVC_NAME} } }
+YAML
+    echo "    Waiting for restore-file job (up to 5 min)..."
+    if ! $KC wait -n "$NS" job/"$JOB" --for=condition=Complete --timeout=300s 2>/dev/null; then
+      echo "    ERROR: restore-file did not complete"; $KC logs -n "$NS" -l "job-name=${JOB}" --tail=50 2>/dev/null || true; exit 1
+    fi
+    $KC logs -n "$NS" -l "job-name=${JOB}" --tail=10 2>/dev/null || true
+    ;;
+
+  restore-table)
+    TS="${1:-}"; DB="${2:-}"; TABLE="${3:-}"
+    [[ -n "$TS" && -n "$DB" && -n "$TABLE" ]] || _die "Usage: $SCRIPT restore-table <timestamp> <db> <table>"
+    [[ "$(_target_kind "$DB")" == "db" ]] || _die "restore-table expects a database name"
+    echo ""
+    echo " SELECTIVE TABLE RESTORE"
+    printf "  Dump  : %s/%s.dump.enc\n" "$TS" "$DB"
+    printf "  Into  : LIVE %s.%s (ns=%s) — table is DROPPED + recreated from the dump\n" "$DB" "$TABLE" "$NS"
+    if [[ "$YES" != true ]]; then
+      read -rp "Type 'yes' to continue: " CONFIRM
+      [[ "$CONFIRM" == "yes" ]] || { echo "Aborted."; exit 1; }
+    fi
+    JOB="recovery-restore-table-${DB}-$$"
+    $KC apply -n "$NS" -f - <<YAML
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ${JOB}
+  namespace: ${NS}
+  labels: { app: recovery-restore-table }
+spec:
+  ttlSecondsAfterFinished: 600
+  backoffLimit: 0
+  template:
+    spec:
+      restartPolicy: Never
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector: { matchLabels: { app: shared-db } }
+              topologyKey: kubernetes.io/hostname
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        fsGroup: 65534
+        seccompProfile: { type: RuntimeDefault }
+      containers:
+        - name: restore-table
+          image: pgvector/pgvector:0.8.0-pg16
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -e
+              sleep 10
+              ENC="/backups/${TS}/${DB}.dump.enc"
+              [ -f "\$ENC" ] || { echo "ERROR: \$ENC not found"; exit 1; }
+              openssl enc -d -aes-256-cbc -pbkdf2 -in "\$ENC" -out /tmp/${DB}.dump -pass env:BACKUP_PASSPHRASE
+              PGPASSWORD="\$SHARED_DB_PASSWORD" pg_restore -h shared-db -U postgres -d ${DB} --no-owner --clean --if-exists -t ${TABLE} /tmp/${DB}.dump
+              rm /tmp/${DB}.dump
+              echo "✓ restored table ${DB}.${TABLE} from ${TS}"
+          env:
+            - { name: BACKUP_PASSPHRASE,  valueFrom: { secretKeyRef: { name: workspace-secrets, key: BACKUP_PASSPHRASE } } }
+            - { name: SHARED_DB_PASSWORD, valueFrom: { secretKeyRef: { name: workspace-secrets, key: SHARED_DB_PASSWORD } } }
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            runAsUser: 65534
+            capabilities: { drop: ["ALL"] }
+          volumeMounts:
+            - { name: backup-storage, mountPath: /backups, readOnly: true }
+          resources:
+            requests: { memory: 256Mi, cpu: "200m" }
+            limits:   { memory: 512Mi, cpu: "1" }
+      volumes:
+        - { name: backup-storage, persistentVolumeClaim: { claimName: backup-pvc } }
+YAML
+    echo "    Waiting for restore-table job (up to 5 min)..."
+    if ! $KC wait -n "$NS" job/"$JOB" --for=condition=Complete --timeout=300s 2>/dev/null; then
+      echo "    ERROR: restore-table did not complete"; $KC logs -n "$NS" -l "job-name=${JOB}" --tail=50 2>/dev/null || true; exit 1
+    fi
+    $KC logs -n "$NS" -l "job-name=${JOB}" --tail=10 2>/dev/null || true
+    ;;
+
+  browse)
+    MANIFEST="${REPO_ROOT}/k3d/recovery-browser.yaml"
+    [[ -f "$MANIFEST" ]] || _die "recovery-browser.yaml missing — Plan 2 (feature/recovery-browse) provides it"
+    echo "Bringing up the recovery filebrowser (read-only over recovery-pvc:/recovery)..."
+    $KC apply -n "$NS" -f "$MANIFEST"
+    DOM=$($KC get configmap domain-config -n "$NS" -o jsonpath='{.data.RECOVER_DOMAIN}' 2>/dev/null || echo "recover.localhost")
+    echo "✓ Browse at: https://${DOM}  (Keycloak login, group /recovery-access). Tear down with: $SCRIPT unbrowse"
+    ;;
+
+  unbrowse)
+    MANIFEST="${REPO_ROOT}/k3d/recovery-browser.yaml"
+    echo "Removing the recovery filebrowser..."
+    $KC delete -n "$NS" -f "$MANIFEST" --ignore-not-found 2>/dev/null || true
+    echo "✓ recovery filebrowser removed"
+    ;;
+
+  unstage)
+    TS="${1:-}"
+    [[ -n "$TS" ]] || _die "Usage: $SCRIPT unstage <timestamp>"
+    if [[ "$YES" != true ]]; then
+      read -rp "Drop all *_recovery DBs and clear recovery-pvc:/recovery/${TS}? Type 'yes': " CONFIRM
+      [[ "$CONFIRM" == "yes" ]] || { echo "Aborted."; exit 1; }
+    fi
+    JOB="recovery-unstage-$$"
+    $KC apply -n "$NS" -f - <<YAML
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ${JOB}
+  namespace: ${NS}
+  labels: { app: recovery-unstage }
+spec:
+  ttlSecondsAfterFinished: 300
+  backoffLimit: 0
+  template:
+    spec:
+      restartPolicy: Never
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector: { matchLabels: { app: shared-db } }
+              topologyKey: kubernetes.io/hostname
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        fsGroup: 65534
+        seccompProfile: { type: RuntimeDefault }
+      containers:
+        - name: unstage
+          image: pgvector/pgvector:0.8.0-pg16
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -e
+              for db in keycloak nextcloud vaultwarden website docuseal; do
+                PGPASSWORD="\$SHARED_DB_PASSWORD" dropdb -h shared-db -U postgres --if-exists \${db}_recovery
+              done
+              rm -rf "/recovery/${TS}" 2>/dev/null || true
+              echo "✓ unstaged ${TS}"
+          env:
+            - { name: SHARED_DB_PASSWORD, valueFrom: { secretKeyRef: { name: workspace-secrets, key: SHARED_DB_PASSWORD } } }
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            runAsUser: 65534
+            capabilities: { drop: ["ALL"] }
+          volumeMounts:
+            - { name: recovery, mountPath: /recovery }
+          resources:
+            requests: { memory: 128Mi, cpu: "100m" }
+            limits:   { memory: 256Mi, cpu: "500m" }
+      volumes:
+        - { name: recovery, persistentVolumeClaim: { claimName: recovery-pvc } }
+YAML
+    $KC wait -n "$NS" job/"$JOB" --for=condition=Complete --timeout=180s 2>/dev/null || true
+    $KC logs -n "$NS" -l "job-name=${JOB}" --tail=10 2>/dev/null || true
     ;;
 
   *)

--- a/tests/unit/backup-restore-recovery.bats
+++ b/tests/unit/backup-restore-recovery.bats
@@ -1,0 +1,119 @@
+#!/usr/bin/env bats
+# backup-restore-recovery.bats — unit tests for the recovery-staging subcommands.
+# Stubs kubectl; captures the applied Job/exec YAML; no live cluster required.
+
+load test_helper
+
+SCRIPT="${PROJECT_DIR}/scripts/backup-restore.sh"
+
+setup() {
+  FAKE_BIN=$(mktemp -d)
+  export CAPTURE="${BATS_TEST_TMPDIR}/applied.yaml"
+  # Create a stub recovery-browser.yaml so browse/unbrowse can find it without Plan 2.
+  mkdir -p "${BATS_TEST_TMPDIR}/k3d"
+  echo "# stub recovery-browser.yaml (Plan 2)" > "${BATS_TEST_TMPDIR}/k3d/recovery-browser.yaml"
+  cat > "${FAKE_BIN}/kubectl" <<EOF
+#!/usr/bin/env bash
+args="\$*"
+case "\$args" in
+  *"apply"*)  cat > "${CAPTURE}" ; exit 0 ;;
+  *"delete"*) exit 0 ;;
+  *"wait"*)   exit 0 ;;
+  *"logs"*)   exit 0 ;;
+  *"get configmap domain-config"*) echo "recover.localhost" ; exit 0 ;;
+  *) exit 0 ;;
+esac
+EOF
+  chmod +x "${FAKE_BIN}/kubectl"
+  export PATH="${FAKE_BIN}:${PATH}"
+  # Override REPO_ROOT so the script finds our stub manifest.
+  export REPO_ROOT="${BATS_TEST_TMPDIR}"
+}
+
+teardown() { rm -rf "$FAKE_BIN"; }
+
+@test "stage without args fails with usage" {
+  run bash "$SCRIPT" stage
+  assert_failure
+  assert_output --partial "Usage"
+}
+
+@test "stage of a DB renders a pg_restore Job into <db>_recovery (live DB untouched)" {
+  run bash "$SCRIPT" stage 20260530-020001 website -y
+  assert_success
+  run cat "$CAPTURE"
+  assert_output --partial "kind: Job"
+  assert_output --partial "website.dump.enc"
+  assert_output --partial "createdb -h shared-db -U postgres -O website website_recovery"
+  assert_output --partial "pg_restore -h shared-db -U postgres -d website_recovery"
+  # never drops the live db during staging
+  refute_output --partial "dropdb -h shared-db -U postgres --if-exists website "
+}
+
+@test "stage of a service extracts into recovery-pvc under /recovery/<ts>/<service>" {
+  run bash "$SCRIPT" stage pvc-20260530-030001 nextcloud-files -y
+  assert_success
+  run cat "$CAPTURE"
+  assert_output --partial "nextcloud-files.tar.gz.enc"
+  assert_output --partial "claimName: recovery-pvc"
+  assert_output --partial "/recovery/pvc-20260530-030001/nextcloud-files"
+  # backup source mounted read-only
+  assert_output --partial "claimName: backup-pvc"
+}
+
+@test "verify renders a Job that restores into a temp DB, counts, and drops it" {
+  run bash "$SCRIPT" verify 20260530-020001 website
+  assert_success
+  run cat "$CAPTURE"
+  assert_output --partial "website.dump.enc"
+  assert_output --partial "createdb -h shared-db -U postgres"
+  assert_output --partial "information_schema.tables"
+  assert_output --partial "dropdb -h shared-db -U postgres --if-exists"
+}
+
+@test "restore-file copies one path from staging into the live PVC (with -y)" {
+  run bash "$SCRIPT" restore-file pvc-20260530-030001 nextcloud-files admin/files/Doc.pdf -y
+  assert_success
+  run cat "$CAPTURE"
+  assert_output --partial "claimName: recovery-pvc"
+  assert_output --partial "claimName: nextcloud-data-pvc"
+  assert_output --partial "/recovery/pvc-20260530-030001/nextcloud-files/admin/files/Doc.pdf"
+}
+
+@test "restore-file requires confirmation without -y" {
+  run bash -c "echo no | bash '$SCRIPT' restore-file pvc-20260530-030001 nextcloud-files admin/files/Doc.pdf"
+  assert_failure
+  assert_output --partial "Aborted"
+}
+
+@test "restore-table renders pg_restore -t <table> into the live DB (with -y)" {
+  run bash "$SCRIPT" restore-table 20260530-020001 website site_settings -y
+  assert_success
+  run cat "$CAPTURE"
+  assert_output --partial "website.dump.enc"
+  assert_output --partial "pg_restore -h shared-db -U postgres -d website"
+  assert_output --partial "-t site_settings"
+}
+
+@test "browse applies the recovery-browser manifest and prints the URL" {
+  run bash "$SCRIPT" browse
+  assert_success
+  assert_output --partial "recover."
+}
+
+@test "unstage drops *_recovery DBs and clears the staging dir for a timestamp" {
+  run bash "$SCRIPT" unstage pvc-20260530-030001 -y
+  assert_success
+  run cat "$CAPTURE"
+  assert_output --partial "/recovery/pvc-20260530-030001"
+}
+
+@test "usage lists the recovery commands" {
+  run bash "$SCRIPT" --help
+  assert_success
+  assert_output --partial "stage"
+  assert_output --partial "verify"
+  assert_output --partial "restore-file"
+  assert_output --partial "restore-table"
+  assert_output --partial "browse"
+}


### PR DESCRIPTION
## Summary

- Adds `recovery-pvc` (20Gi PVC) as scratch space for browsable backup staging
- New subcommands in `scripts/backup-restore.sh`: `stage`, `verify`, `restore-file`, `restore-table`, `browse`, `unbrowse`, `unstage`
- 8 new `recovery:*` Taskfile wrappers (env-resolved, namespaced, mirroring neighbours)
- 10 new BATS tests in `tests/unit/backup-restore-recovery.bats`; namespace invariant test also fixed (was pre-existing failure due to `-n workspace` in usage examples)
- Browsable recovery runbook added to `database-ops` skill

## Plan alignment

This is **Plan 1 of 2** — implements the Recovery Engine (bash + k8s + Taskfile + BATS).  
Sibling: `feature/recovery-browse` (Plan 2) owns `k3d/recovery-browser.yaml`, Keycloak client, domains.  
The `browse` subcommand references `k3d/recovery-browser.yaml` by path and fails with a clear error message until Plan 2 is merged — this is intentional per the plan.

## Architecture

All new subcommands follow existing Job-via-heredoc patterns:
- `ttlSecondsAfterFinished: 600`, `backoffLimit: 0`, `restartPolicy: Never`
- `runAsNonRoot: true`, `runAsUser: 65534`, `seccompProfile: RuntimeDefault`, `capabilities: drop: [ALL]`
- `podAffinity` to `shared-db` for DB jobs
- All `$KC` calls carry `-n "$NS"` (enforced by `backup-restore-namespace.bats`)
- DB staging creates `<db>_recovery` inspection DB — live DB untouched
- Service staging extracts to `recovery-pvc:/recovery/<ts>/<service>/`

## Test results

```
bats tests/unit/backup-restore-recovery.bats tests/unit/backup-restore-namespace.bats
1..12
ok 1 stage without args fails with usage
ok 2 stage of a DB renders a pg_restore Job into <db>_recovery (live DB untouched)
ok 3 stage of a service extracts into recovery-pvc under /recovery/<ts>/<service>
ok 4 verify renders a Job that restores into a temp DB, counts, and drops it
ok 5 restore-file copies one path from staging into the live PVC (with -y)
ok 6 restore-file requires confirmation without -y
ok 7 restore-table renders pg_restore -t <table> into the live DB (with -y)
ok 8 browse applies the recovery-browser manifest and prints the URL
ok 9 unstage drops *_recovery DBs and clears the staging dir for a timestamp
ok 10 usage lists the recovery commands
ok 11 no hardcoded '-n workspace' remains outside the NS default assignment
ok 12 kubectl secret lookups for workspace-secrets pass -n $NS

kubectl apply --dry-run=client -f k3d/recovery-pvc.yaml
→ persistentvolumeclaim/recovery-pvc created (dry run)

task --list | grep recovery: → 8 tasks listed
task test:all → 267 tests, 0 failures
```

## Test plan

- [ ] Merge `feature/recovery-browse` (Plan 2) so `browse` has its manifest
- [ ] `task recovery:prepare ENV=mentolder` — creates recovery-pvc on fleet
- [ ] `task recovery:verify ENV=mentolder -- <recent-ts> website` — proves a dump restores
- [ ] `task recovery:stage ENV=mentolder -- <recent-ts> nextcloud-files` — stages service
- [ ] `task recovery:browse ENV=mentolder` — confirms filebrowser comes up
- [ ] `task recovery:unstage ENV=mentolder -- <ts> -y` — confirms cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)