### PR TITLE
feat(website): agent-guide mental-model start [T000385]

### DIFF
--- a/docs/agent-guide/10-ziele.md
+++ b/docs/agent-guide/10-ziele.md
@@ -171,3 +171,65 @@ Bitte NICHT allein ausführen – zuerst Patrick fragen.
 **Schutzregeln (Guardrails):** Geheimnis-Reihenfolge einhalten (G-SECRET-ORDER), ENV immer explizit setzen (G-ENV-EXPLICIT), Bei Rot: stoppen und fragen (G-ASK-EXPERT)
 
 **Verwandte Ziele:** Ich will eine Änderung in der Produktion ausrollen
+
+## Ich habe eine Idee — wie fange ich an?
+
+🟢 **Sicher**
+
+**Wann?** Du willst etwas verändern, weißt aber noch nicht, wie der Weg aussieht.
+
+**So gehst du vor:**
+
+1. Brainstorming (/brainstorming) — Beschreibe die Idee; der Brainstorming-Skill schärft sie zu einem Design.
+2. [[dev-flow-plan]] — Danach schreibt der Planungs-Skill einen Schritt-für-Schritt-Plan.
+
+**Diesen Prompt kannst du der KI geben:**
+
+```text
+Ich habe eine Idee für die Plattform und möchte sie erst gemeinsam durchdenken.
+```
+
+**Schutzregeln (Guardrails):** Erst ziehen, dann arbeiten (G-PULL-FIRST)
+
+**Verwandte Ziele:** Ich will eine neue Funktion bauen, Ich will einen Fehler beheben
+
+## Ich will einen Pull Request öffnen und CI grün bekommen
+
+🟠 **Nur mit Hilfe**
+
+**Wann?** Der Code ist fertig und soll als Pull Request geprüft und gemergt werden.
+
+**So gehst du vor:**
+
+1. [[dev-flow-execute]] — Pusht den Branch, öffnet den PR und wartet, bis die CI-Checks grün sind.
+
+**Diesen Prompt kannst du der KI geben:**
+
+```text
+Bitte öffne einen Pull Request für diesen Branch und sag mir, ob die CI grün ist.
+```
+
+**Schutzregeln (Guardrails):** Nie direkt auf main (G-PR-NOT-MAIN)
+
+**Verwandte Ziele:** Ich will eine neue Funktion bauen, Ich will eine Änderung in der Produktion ausrollen
+
+## Ich will prüfen, ob mein Deploy wirklich live ist
+
+🟢 **Sicher**
+
+**Wann?** Nach einem Deploy willst du sehen, ob die Änderung in der echten Umgebung angekommen ist.
+
+**So gehst du vor:**
+
+1. [[bachelorprojekt-ops]] — Lässt Pod-Status und Logs prüfen, ob der neue Stand läuft.
+2. [[dev-flow-e2e]] — Verifiziert per E2E-Test gegen die Live-URL, dass das Feature funktioniert.
+
+**Diesen Prompt kannst du der KI geben:**
+
+```text
+Ist der letzte Deploy für mentolder live? Prüfe Status, Logs und mach einen E2E-Check.
+```
+
+**Schutzregeln (Guardrails):** ENV immer explizit setzen (G-ENV-EXPLICIT)
+
+**Verwandte Ziele:** Ich will eine Änderung in der Produktion ausrollen, Ich will prüfen, ob alle Dienste laufen

--- a/docs/agent-guide/maps/danger-map.md
+++ b/docs/agent-guide/maps/danger-map.md
@@ -11,7 +11,9 @@ Ziele/Werkzeuge sie referenzieren (transitiv) — also ggf. unter mehreren Stufe
 **enforcement_default:** `none`
 
 **Ziele:**
+- `deploy-pruefen` — Ich will prüfen, ob mein Deploy wirklich live ist
 - `dienst-status-pruefen` — Ich will prüfen, ob alle Dienste laufen
+- `idee-starten` — Ich habe eine Idee — wie fange ich an?
 - `website-text-aendern` — Ich will einen Text auf der Website ändern
 
 **Werkzeuge:**
@@ -22,6 +24,7 @@ Ziele/Werkzeuge sie referenzieren (transitiv) — also ggf. unter mehreren Stufe
 
 **Guardrails (transitiv):**
 - `G-CONTEXT-CHECK` — Kubectl-Kontext prüfen
+- `G-ENV-EXPLICIT` — ENV immer explizit setzen
 - `G-PR-NOT-MAIN` — Nie direkt auf main
 - `G-PULL-FIRST` — Erst ziehen, dann arbeiten
 
@@ -54,6 +57,7 @@ Ziele/Werkzeuge sie referenzieren (transitiv) — also ggf. unter mehreren Stufe
 **Ziele:**
 - `aenderung-ausrollen` — Ich will eine Änderung in der Produktion ausrollen
 - `datenbank-aendern` — Ich will das Datenbankschema ändern
+- `pr-oeffnen` — Ich will einen Pull Request öffnen und CI grün bekommen
 
 **Werkzeuge:**
 - `agent-db` — Datenbank-Agent (db)
@@ -63,6 +67,7 @@ Ziele/Werkzeuge sie referenzieren (transitiv) — also ggf. unter mehreren Stufe
 **Guardrails (transitiv):**
 - `G-ASK-EXPERT` — Bei Rot: stoppen und fragen
 - `G-ENV-EXPLICIT` — ENV immer explizit setzen
+- `G-PR-NOT-MAIN` — Nie direkt auf main
 - `G-SECRET-ORDER` — Geheimnis-Reihenfolge einhalten
 - `G-VALIDATE-FIRST` — Erst prüfen, dann anwenden
 

--- a/docs/agent-guide/maps/goals-map.md
+++ b/docs/agent-guide/maps/goals-map.md
@@ -11,7 +11,10 @@ Die Tier-Emojis (🟢🟡🟠🔴) sind in `danger-map.md` erklärt, die Werkzeu
 | Ich will einen Fehler beheben | dev-flow-plan → dev-flow-execute | 🟡 Vorsicht | G-PR-NOT-MAIN, G-PULL-FIRST | Auf web.mentolder.de tut der Login-Knopf nichts. Bitte finde die Ursache und behebe sie. |
 | Ich will den Cluster neu aufsetzen | agent-infra → agent-security | 🔴 Niemals allein | G-ASK-EXPERT, G-ENV-EXPLICIT, G-SECRET-ORDER | Bitte NICHT allein ausführen – zuerst Patrick fragen. |
 | Ich will das Datenbankschema ändern | dev-flow-plan → agent-db → dev-flow-execute | 🟠 Nur mit Hilfe | G-ASK-EXPERT, G-ENV-EXPLICIT | Bitte füge eine Spalte 'invoice_number' zur Tabelle 'orders' hinzu. |
+| Ich will prüfen, ob mein Deploy wirklich live ist | agent-ops → dev-flow-e2e | 🟢 Sicher | G-ENV-EXPLICIT | Ist der letzte Deploy für mentolder live? Prüfe Status, Logs und mach einen E2E-Check. |
 | Ich will prüfen, ob alle Dienste laufen | agent-ops | 🟢 Sicher | — | Bitte prüfe, ob alle Pods laufen und zeig mir den Plattform-Status. |
 | Ich will eine neue Funktion bauen | dev-flow-plan → dev-flow-execute | 🟡 Vorsicht | G-PR-NOT-MAIN, G-PULL-FIRST | Ich hätte gerne eine Seite, die alle aktiven Tickets anzeigt. |
+| Ich habe eine Idee — wie fange ich an? | brainstorming → dev-flow-plan | 🟢 Sicher | G-PULL-FIRST | Ich habe eine Idee für die Plattform und möchte sie erst gemeinsam durchdenken. |
+| Ich will einen Pull Request öffnen und CI grün bekommen | dev-flow-execute | 🟠 Nur mit Hilfe | G-PR-NOT-MAIN | Bitte öffne einen Pull Request für diesen Branch und sag mir, ob die CI grün ist. |
 | Ich will ein Passwort oder Geheimnis ändern | agent-security | 🔴 Niemals allein | G-ASK-EXPERT, G-SECRET-ORDER | Bitte NICHT allein ausführen – zuerst Patrick fragen. (Rotation des shared-db-Passworts.) |
 | Ich will einen Text auf der Website ändern | agent-website | 🟢 Sicher | G-PR-NOT-MAIN, G-PULL-FIRST | Bitte ändere den Begrüßungstext auf der Startseite auf: 'Herzlich willkommen bei ...'. |

--- a/docs/agent-guide/registry/components.yaml
+++ b/docs/agent-guide/registry/components.yaml
@@ -9,6 +9,9 @@
   what_for_de: "Das mit Astro + Svelte gebaute Frontend (die Web-Oberfläche). Öffentliche Seite plus eingeloggtes Kundenportal."
   url: null
   links: []
+  area: dienste
+  theme: website
+  relates_to: [website-text-aendern]
 - slug: keycloak
   kind: software
   name: "Keycloak"
@@ -19,6 +22,9 @@
   what_for_de: "Keycloak prüft, wer du bist (über OIDC) und meldet dich bei Nextcloud, Vaultwarden u. a. an. Herzstück der Sicherheit."
   url: null
   links: []
+  area: plattform
+  theme: sicherheit
+  relates_to: [secret-aendern]
 - slug: nextcloud
   kind: software
   name: "Nextcloud"
@@ -29,6 +35,8 @@
   what_for_de: "Wie eine eigene Dropbox + Office + Kalender, komplett auf eigenen Servern (DSGVO-konform)."
   url: null
   links: []
+  area: dienste
+  theme: betrieb
 - slug: collabora
   kind: software
   name: "Collabora"
@@ -39,6 +47,8 @@
   what_for_de: "Die Online-Office-Suite, die Nextcloud-Dateien bearbeitbar macht (vergleichbar mit Office im Web)."
   url: null
   links: []
+  area: dienste
+  theme: betrieb
 - slug: vaultwarden
   kind: software
   name: "Vaultwarden"
@@ -49,6 +59,8 @@
   what_for_de: "Verwaltet Zugangsdaten zentral und verschlüsselt; per Bitwarden-Apps nutzbar."
   url: null
   links: []
+  area: dienste
+  theme: sicherheit
 - slug: nextcloud-talk-hpb
   kind: software
   name: "Talk HPB"
@@ -89,6 +101,8 @@
   what_for_de: "Versendet Dokumente zur rechtssicheren elektronischen Unterschrift."
   url: null
   links: []
+  area: dienste
+  theme: betrieb
 - slug: whiteboard
   kind: software
   name: "Whiteboard"
@@ -129,6 +143,9 @@
   what_for_de: "Gemeinsamer Datenbank-Server für Website, Keycloak, Nextcloud u. v. m. Pro Marke eigene Instanz."
   url: null
   links: []
+  area: daten
+  theme: datenbank
+  relates_to: [datenbank-aendern]
 - slug: traefik
   kind: software
   name: "Traefik"
@@ -139,6 +156,8 @@
   what_for_de: "Ingress-Controller: verteilt eingehenden Verkehr (Routing) und terminiert TLS."
   url: null
   links: []
+  area: plattform
+  theme: ausrollen
 - slug: sealed-secrets
   kind: software
   name: "Sealed Secrets"
@@ -149,6 +168,9 @@
   what_for_de: "Wandelt Secrets in verschlüsselte 'SealedSecrets', die gefahrlos eingecheckt werden können."
   url: null
   links: []
+  area: daten
+  theme: sicherheit
+  relates_to: [secret-aendern]
 - slug: cert-manager
   kind: software
   name: "cert-manager"
@@ -159,6 +181,8 @@
   what_for_de: "Automatisiert TLS-Zertifikate, damit alle Domains gültiges HTTPS haben."
   url: null
   links: []
+  area: plattform
+  theme: sicherheit
 - slug: k3s
   kind: software
   name: "k3s / k3d"
@@ -169,6 +193,9 @@
   what_for_de: "Leichtgewichtige Kubernetes-Variante (k3s in Prod, k3d lokal). Trägt alle Workloads."
   url: null
   links: []
+  area: plattform
+  theme: ausrollen
+  relates_to: [cluster-neu-aufsetzen]
 - slug: wireguard
   kind: software
   name: "WireGuard (wg-mesh)"
@@ -209,6 +236,8 @@
   what_for_de: "Echtzeit-Video-Server; läuft im Host-Netz und ist an einen festen Knoten gebunden."
   url: null
   links: []
+  area: dienste
+  theme: betrieb
 - slug: livekit-ingress
   kind: software
   name: "LiveKit Ingress"

--- a/docs/agent-guide/registry/flow.yaml
+++ b/docs/agent-guide/registry/flow.yaml
@@ -1,0 +1,10 @@
+# docs/agent-guide/registry/flow.yaml
+# Stations of the "Dein Weg: Idee → live" ribbon. `order` drives left→right.
+# `danger` must be a taxonomy id. Goals/tools opt onto a station via `stages: [<id>]`.
+- { id: idee,       label_de: "Idee",       emoji: "💡", danger: safe,     order: 1, blurb_de: "Was soll sich ändern? Noch nichts angefasst." }
+- { id: brainstorm, label_de: "Brainstorm", emoji: "🧠", danger: safe,     order: 2, blurb_de: "Die Idee zu einem klaren Design schärfen." }
+- { id: plan,       label_de: "Plan",       emoji: "📋", danger: caution,  order: 3, blurb_de: "Einen Schritt-für-Schritt-Plan schreiben." }
+- { id: code,       label_de: "Code+TDD",   emoji: "💻", danger: caution,  order: 4, blurb_de: "Erst den Test, dann die Umsetzung." }
+- { id: pr-ci,      label_de: "PR+CI",      emoji: "🔀", danger: assisted, order: 5, blurb_de: "Pull Request öffnen — CI muss grün sein." }
+- { id: deploy,     label_de: "Deploy",     emoji: "🚀", danger: assisted, order: 6, blurb_de: "Die Änderung live bringen (Flux / Task)." }
+- { id: live,       label_de: "Live",       emoji: "🌍", danger: safe,     order: 7, blurb_de: "Läuft es? Status und Logs prüfen." }

--- a/docs/agent-guide/registry/goals.yaml
+++ b/docs/agent-guide/registry/goals.yaml
@@ -10,6 +10,8 @@
   one_liner_de: "Inhalt oder Preis auf der Website korrigieren."
   common: true
   order: 1
+  stages: [code]
+  concept_de: "Konzept: Inhalte ändert man über einen Branch + PR, nicht direkt auf main."
   aliases_de: [text, inhalt, preis, startseite, webseite, aendern]
   guardrails: [G-PULL-FIRST, G-PR-NOT-MAIN]
   related: [feature-bauen]
@@ -25,6 +27,8 @@
   one_liner_de: "Nachsehen, ob alle Dienste laufen."
   common: true
   order: 2
+  stages: [live]
+  concept_de: "Konzept: Status/Logs lesen ist 🟢 — es verändert nichts."
   aliases_de: [status, laeuft, gesund, pods, health, uebersicht]
   guardrails: []
   related: [bug-beheben]
@@ -42,6 +46,8 @@
   one_liner_de: "Etwas funktioniert nicht — finden und reparieren."
   common: true
   order: 3
+  stages: [plan, code, pr-ci, deploy]
+  concept_de: "Konzept: erst ein Test, der den Fehler zeigt (TDD), dann der Fix."
   aliases_de: [fehler, bug, kaputt, "geht nicht", reparieren, fix]
   guardrails: [G-PULL-FIRST, G-PR-NOT-MAIN]
   related: [feature-bauen]
@@ -57,6 +63,8 @@
   danger: caution
   theme: entwickeln
   one_liner_de: "Eine neue Funktion oder Seite hinzufügen."
+  stages: [plan, code, pr-ci, deploy]
+  concept_de: "Konzept: jede neue Funktion durchläuft Plan → Code → PR → Deploy."
   aliases_de: [funktion, feature, neu, seite, bauen]
   guardrails: [G-PULL-FIRST, G-PR-NOT-MAIN]
   related: [bug-beheben, aenderung-ausrollen]
@@ -72,6 +80,8 @@
   danger: assisted
   theme: ausrollen
   one_liner_de: "Einen gemergten Stand live schalten."
+  stages: [deploy, live]
+  concept_de: "Konzept: Deploy heißt einen gemergten Stand in einer Umgebung (ENV) aktivieren."
   aliases_de: [deploy, ausrollen, live, produktion, release]
   guardrails: [G-ENV-EXPLICIT, G-VALIDATE-FIRST]
   related: [feature-bauen]
@@ -89,6 +99,8 @@
   danger: assisted
   theme: datenbank
   one_liner_de: "Tabelle, Spalte oder Index ergänzen."
+  stages: [plan, code, deploy]
+  concept_de: "Konzept: Schema-Änderungen treffen beide Marken — immer als Migration."
   aliases_de: [datenbank, schema, migration, tabelle, spalte, sql]
   guardrails: [G-ENV-EXPLICIT, G-ASK-EXPERT]
   related: [feature-bauen]
@@ -120,3 +132,56 @@
   aliases_de: [cluster, reset, neuaufbau, sealedsecrets, ausfall]
   guardrails: [G-SECRET-ORDER, G-ENV-EXPLICIT, G-ASK-EXPERT]
   related: [aenderung-ausrollen]
+- id: idee-starten
+  title_de: "Ich habe eine Idee — wie fange ich an?"
+  when_de: "Du willst etwas verändern, weißt aber noch nicht, wie der Weg aussieht."
+  flow:
+    - tool: brainstorming
+      note_de: "Beschreibe die Idee; der Brainstorming-Skill schärft sie zu einem Design."
+    - tool: dev-flow-plan
+      note_de: "Danach schreibt der Planungs-Skill einen Schritt-für-Schritt-Plan."
+  example_prompt_de: "Ich habe eine Idee für die Plattform und möchte sie erst gemeinsam durchdenken."
+  danger: safe
+  theme: entwickeln
+  one_liner_de: "Von der Idee zum Plan — der erste Schritt."
+  common: true
+  order: 6
+  stages: [idee, brainstorm]
+  concept_de: "Konzept: jede Änderung beginnt mit Brainstorm → Plan, bevor Code entsteht."
+  aliases_de: [idee, anfangen, start, neu, wie]
+  guardrails: [G-PULL-FIRST]
+  related: [feature-bauen, bug-beheben]
+- id: pr-oeffnen
+  title_de: "Ich will einen Pull Request öffnen und CI grün bekommen"
+  when_de: "Der Code ist fertig und soll als Pull Request geprüft und gemergt werden."
+  flow:
+    - tool: dev-flow-execute
+      note_de: "Pusht den Branch, öffnet den PR und wartet, bis die CI-Checks grün sind."
+  example_prompt_de: "Bitte öffne einen Pull Request für diesen Branch und sag mir, ob die CI grün ist."
+  danger: assisted
+  theme: entwickeln
+  one_liner_de: "Branch als PR einreichen und CI abwarten."
+  stages: [pr-ci]
+  concept_de: "Konzept: nichts kommt nach main ohne PR + grüne CI (Squash-Merge)."
+  aliases_de: [pr, "pull request", ci, merge, review]
+  guardrails: [G-PR-NOT-MAIN]
+  related: [feature-bauen, aenderung-ausrollen]
+- id: deploy-pruefen
+  title_de: "Ich will prüfen, ob mein Deploy wirklich live ist"
+  when_de: "Nach einem Deploy willst du sehen, ob die Änderung in der echten Umgebung angekommen ist."
+  flow:
+    - tool: agent-ops
+      note_de: "Lässt Pod-Status und Logs prüfen, ob der neue Stand läuft."
+    - tool: dev-flow-e2e
+      note_de: "Verifiziert per E2E-Test gegen die Live-URL, dass das Feature funktioniert."
+  example_prompt_de: "Ist der letzte Deploy für mentolder live? Prüfe Status, Logs und mach einen E2E-Check."
+  danger: safe
+  theme: betrieb
+  one_liner_de: "Nach dem Deploy prüfen, ob alles läuft."
+  common: true
+  order: 7
+  stages: [live]
+  concept_de: "Konzept: Deploy ≠ live — erst Status, Logs und ein E2E-Check bestätigen es."
+  aliases_de: [deploy, live, pruefen, status, "ist es da"]
+  guardrails: [G-ENV-EXPLICIT]
+  related: [aenderung-ausrollen, dienst-status-pruefen]

--- a/docs/agent-guide/registry/tools.yaml
+++ b/docs/agent-guide/registry/tools.yaml
@@ -7,6 +7,7 @@
   what_could_go_wrong_de: "Kaum etwas: er lädt nur Wissen, ändert nichts am Code."
   danger: safe
   theme: entwickeln
+  stages: [brainstorm]
   aliases_de: [superpowers, skills, fertigkeiten]
   guardrails: []
   related: [dev-flow-plan]
@@ -21,6 +22,7 @@
   what_could_go_wrong_de: "Wenig: er stoppt bewusst vor der Umsetzung. Du bestätigst das Design."
   danger: safe
   theme: entwickeln
+  stages: [idee, brainstorm]
   aliases_de: [brainstorm, brainstorming, idee, design, konzept]
   guardrails: []
   related: [dev-flow-plan, superpowers]
@@ -35,6 +37,7 @@
   what_could_go_wrong_de: "Wenig: er stoppt bewusst, bevor Code geschrieben wird. Du bestätigst Design und Plan."
   danger: caution
   theme: entwickeln
+  stages: [plan]
   aliases_de: [plan, planen, brainstorm, spec]
   guardrails: [G-PULL-FIRST]
   related: [dev-flow-execute]
@@ -49,6 +52,7 @@
   what_could_go_wrong_de: "Der falsche Branch könnte aktiv sein (🟡); CI könnte fehlschlagen und den Merge blockieren."
   danger: caution
   theme: entwickeln
+  stages: [code, pr-ci]
   aliases_de: [umsetzen, implementieren, ausfuehren, pr]
   guardrails: [G-PULL-FIRST, G-PR-NOT-MAIN]
   related: [dev-flow-plan, dev-flow-iterate]
@@ -63,6 +67,7 @@
   what_could_go_wrong_de: "Deployment schlägt fehl; Logs zeigen den Fehler. ENV= muss auf dev zeigen."
   danger: caution
   theme: entwickeln
+  stages: [code, deploy]
   aliases_de: [dev, iterieren, ausprobieren, "dev-cluster"]
   guardrails: [G-ENV-EXPLICIT, G-CONTEXT-CHECK]
   related: [dev-flow-execute, dev-flow-e2e]
@@ -77,6 +82,7 @@
   what_could_go_wrong_de: "Test schlägt fehl, wenn die Umgebung noch startet oder fehlerhaft deployt wurde."
   danger: caution
   theme: testen
+  stages: [live]
   aliases_de: [e2e, playwright, "end-to-end", walkthrough]
   guardrails: [G-ENV-EXPLICIT]
   related: [dev-flow-iterate]
@@ -121,6 +127,7 @@
   what_could_go_wrong_de: "Beim reinen Nachschauen kaum etwas. Vorsicht erst, wenn er etwas neu startet (das ist 🟡)."
   danger: safe
   theme: betrieb
+  stages: [live]
   common: true
   order: 4
   aliases_de: ["warum rot", crash, logs, "laeuft nicht", status, betrieb]
@@ -137,6 +144,7 @@
   what_could_go_wrong_de: "Falsches ENV= deployt in die falsche Umgebung (🟠). Manifestfehler können Dienste lahmlegen."
   danger: assisted
   theme: ausrollen
+  stages: [deploy]
   aliases_de: [infra, kubernetes, kustomize, manifest, deploy]
   guardrails: [G-ENV-EXPLICIT, G-VALIDATE-FIRST, G-ASK-EXPERT]
   related: [agent-ops, agent-security]

--- a/docs/superpowers/plans/2026-05-31-agent-guide-mental-model.md
+++ b/docs/superpowers/plans/2026-05-31-agent-guide-mental-model.md
@@ -1,0 +1,1360 @@
+---
+title: Agent-Anleitung „Mental-Model" Start — Implementation Plan
+ticket_id: T000385
+domains: [website, test]
+status: active
+pr_number: null
+---
+
+# Agent-Anleitung „Mental-Model" Start — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a collapsible "🧭 So funktioniert die Plattform" card (flow ribbon + infra territory map) above the existing Agent-Anleitung catalog; clicking a flow station or a territory node filters the catalog, and a teaching layer (concept line + glossary tooltips) onboards collaborators.
+
+**Architecture:** Additive changes to a tested SSOT→emitter→UI pipeline. The registry (`docs/agent-guide/registry/*.yaml`) gains a new `flow.yaml`, optional `stages`/`concept_de` on goals/tools, and optional `area`/`theme`/`relates_to` on components. `emit-webapp.mjs` projects these into a new `map` block in `agent-guide.generated.json`. A new `GuideMap.svelte` renders the map and emits a `mapFilter` consumed by the existing search pipeline as an extra filter axis. A pure `splitGlossaryTerms` helper + `GlossaryTerm.svelte` add inline term popovers.
+
+**Tech Stack:** Node ESM emitters (`node:test`), Svelte 5 runes (`$state`/`$derived`/`$effect`/`$props`), TypeScript, vitest (`website/src/lib/*.test.ts`), Playwright E2E, YAML registry. Tasks run via `task agent-guide:webapp`, `task test:agent-guide`, and `cd website && pnpm test:unit`.
+
+---
+
+## Conventions & invariants (read before starting)
+
+- **Components are DB-bound.** `validate.mjs:95-100` cross-checks every `components.yaml` slug against `website/src/db/migrations/*platform_assets*`. **Never add or remove a component slug** — only add fields (`area`/`theme`/`relates_to`) to existing entries.
+- **`links` ≠ drill targets.** `links: [{label_de,url}]` are external URLs. In-app drill targets use the new `relates_to: [<goal/tool id>]`.
+- **Brittle test:** `website/src/lib/agentGuideSearch.test.ts:71` asserts the `website` theme has exactly **2** entries. New content goals/tools must **not** use `theme: website`.
+- **Strict test:** `scripts/agent-guide/emit-webapp.test.mjs:97` asserts the emitted component object has exactly 7 keys. Task 2 updates this test before changing the emitter.
+- **Stale-check:** `task test:agent-guide` regenerates `agent-guide.generated.json` and runs `git diff --exit-code` on it. After any registry change you MUST run `task agent-guide:emit` and commit the regenerated artifacts (webapp JSON + docs/*.md + maps/*.md).
+- **CSS lives in one file**, not component-scoped: `website/src/styles/sidekick-panels.css`, all rules under `.drawer .ag-*` (Svelte-5/Vite prunes unrendered component CSS). Use the existing tokens: `var(--tier)`, `var(--accent)`, `var(--brass)`, `var(--fg)`, `var(--mute)`, `var(--line)`, `var(--serif)`, `var(--mono)`, `--ink-900: #0f1623`, and `color-mix(in srgb, …)`.
+- Work happens in the worktree `/tmp/wt-agent-guide-mental-model` on branch `feature/agent-guide-mental-model`. Run commands from the repo root of that worktree.
+
+## File structure
+
+| Action | Path | Responsibility |
+|--------|------|----------------|
+| Create | `docs/agent-guide/registry/flow.yaml` | Ordered flow-ribbon stations (SSOT). |
+| Create | `scripts/agent-guide/map-areas.mjs` | Shared constant: ordered territory areas (imported by emit + validate). |
+| Modify | `scripts/agent-guide/validate.mjs` | Load+validate flow.yaml; check `stages`/`area`/`theme`/`relates_to` refs; warn on empty station. |
+| Modify | `scripts/agent-guide/validate.test.mjs` | Fixtures + assertions for the new validation. |
+| Modify | `scripts/agent-guide/emit-webapp.mjs` | Emit `map` block + `stages`/`concept_de` passthrough. |
+| Modify | `scripts/agent-guide/emit-webapp.test.mjs` | Update component-keys test; add map-block tests. |
+| Modify | `docs/agent-guide/registry/{goals,tools,components}.yaml` | Author `stages`/`concept_de`/`area`/`theme`/`relates_to` + 3 new goals. |
+| Modify | `website/src/lib/agentGuide.ts` | Types + exports for `stages`, `concept_de`, `map`. |
+| Modify | `tests/e2e/lib/agent-guide.ts` | Mirror new types + expose `map` in `loadGuideData`. |
+| Modify | `website/src/lib/agentGuideSearch.ts` | `stages` on `GuideEntry`; pure `mapFilterIds` + `splitGlossaryTerms`. |
+| Modify | `website/src/lib/agentGuideSearch.test.ts` | vitest for the two new pure helpers. |
+| Create | `website/src/components/assistant/agent-guide/GuideMap.svelte` | Render flow ribbon + territory lanes; emit `onSelect`. |
+| Create | `website/src/components/assistant/agent-guide/GlossaryTerm.svelte` | Inline term chip + popover. |
+| Modify | `website/src/components/assistant/AgentGuideView.svelte` | Mount map; `mapFilter`/`mapOpen` state; first-run; active-filter chip. |
+| Modify | `website/src/components/assistant/agent-guide/GuideCard.svelte` | Render `concept_de` line with glossary annotation. |
+| Modify | `website/src/styles/sidekick-panels.css` | `.ag-map*`, `.ag-concept`, `.ag-gloss*`, `.ag-mapfilter*` styles. |
+| Modify | `tests/e2e/specs/agent-guide-walkthrough.spec.ts` | Map render/click/collapse/glossary E2E + film step. |
+
+---
+
+## Task 1: flow.yaml + territory-areas module + validation
+
+**Files:**
+- Create: `docs/agent-guide/registry/flow.yaml`
+- Create: `scripts/agent-guide/map-areas.mjs`
+- Create: `scripts/agent-guide/fixtures/bad-stage-ref/` (+ copy of a good registry with one bad `stages` ref)
+- Modify: `scripts/agent-guide/validate.mjs`
+- Test: `scripts/agent-guide/validate.test.mjs`
+
+- [ ] **Step 1: Create the territory-areas module**
+
+Create `scripts/agent-guide/map-areas.mjs`:
+
+```js
+// scripts/agent-guide/map-areas.mjs
+// Emitter-owned presentation metadata for the territory map lanes.
+// Components opt onto the map by setting `area: <one of these ids>`.
+export const TERRITORY_AREAS = [
+  { id: 'dienste',   label_de: 'Dienste',             order: 1 },
+  { id: 'plattform', label_de: 'Plattform & Cluster', order: 2 },
+  { id: 'daten',     label_de: 'Daten & Geheimnisse', order: 3 },
+];
+export const TERRITORY_AREA_IDS = new Set(TERRITORY_AREAS.map((a) => a.id));
+```
+
+- [ ] **Step 2: Create flow.yaml**
+
+Create `docs/agent-guide/registry/flow.yaml`:
+
+```yaml
+# docs/agent-guide/registry/flow.yaml
+# Stations of the "Dein Weg: Idee → live" ribbon. `order` drives left→right.
+# `danger` must be a taxonomy id. Goals/tools opt onto a station via `stages: [<id>]`.
+- { id: idee,       label_de: "Idee",       emoji: "💡", danger: safe,     order: 1, blurb_de: "Was soll sich ändern? Noch nichts angefasst." }
+- { id: brainstorm, label_de: "Brainstorm", emoji: "🧠", danger: safe,     order: 2, blurb_de: "Die Idee zu einem klaren Design schärfen." }
+- { id: plan,       label_de: "Plan",       emoji: "📋", danger: caution,  order: 3, blurb_de: "Einen Schritt-für-Schritt-Plan schreiben." }
+- { id: code,       label_de: "Code+TDD",   emoji: "💻", danger: caution,  order: 4, blurb_de: "Erst den Test, dann die Umsetzung." }
+- { id: pr-ci,      label_de: "PR+CI",      emoji: "🔀", danger: assisted, order: 5, blurb_de: "Pull Request öffnen — CI muss grün sein." }
+- { id: deploy,     label_de: "Deploy",     emoji: "🚀", danger: assisted, order: 6, blurb_de: "Die Änderung live bringen (Flux / Task)." }
+- { id: live,       label_de: "Live",       emoji: "🌍", danger: safe,     order: 7, blurb_de: "Läuft es? Status und Logs prüfen." }
+```
+
+- [ ] **Step 3: Write the failing validation fixture + test**
+
+Create the bad fixture by copying the good one and injecting a dangling stage ref. Run:
+
+```bash
+cd /tmp/wt-agent-guide-mental-model
+cp -r scripts/agent-guide/fixtures/good scripts/agent-guide/fixtures/bad-stage-ref
+cat > scripts/agent-guide/fixtures/bad-stage-ref/flow.yaml <<'EOF'
+- { id: plan, label_de: "Plan", emoji: "📋", danger: caution, order: 1, blurb_de: "x" }
+EOF
+```
+
+Then append a `stages: [does-not-exist]` to the first goal in `scripts/agent-guide/fixtures/bad-stage-ref/goals.yaml` (add the two lines under that goal):
+
+```yaml
+  stages: [does-not-exist]
+```
+
+Add to `scripts/agent-guide/validate.test.mjs`:
+
+```js
+test('dangling stages reference is rejected', () => {
+  const res = validateRegistry(join(here, 'fixtures', 'bad-stage-ref'));
+  assert.equal(res.ok, false);
+  assert.ok(
+    res.errors.some((e) => e.includes('stages') && e.includes('does-not-exist')),
+    `expected a stages-ref error, got: ${JSON.stringify(res.errors)}`,
+  );
+});
+
+test('good fixture still validates with a flow.yaml present', () => {
+  // good fixture has no flow.yaml → flow checks are skipped, not errors
+  const res = validateRegistry(join(here, 'fixtures', 'good'));
+  assert.equal(res.ok, true, JSON.stringify(res.errors, null, 2));
+});
+```
+
+- [ ] **Step 4: Run the test to verify it fails**
+
+Run: `node --test scripts/agent-guide/validate.test.mjs`
+Expected: FAIL on `dangling stages reference is rejected` (validate doesn't know `stages` yet, so no error is produced → `res.ok` is `true`).
+
+- [ ] **Step 5: Implement validation in validate.mjs**
+
+In `scripts/agent-guide/validate.mjs`, add the import at the top (after the existing imports):
+
+```js
+import { TERRITORY_AREA_IDS } from './map-areas.mjs';
+```
+
+Inside `validateRegistry`, after the `themes`/`themeIds` block (around line 37), load flow and build id sets:
+
+```js
+  let flow = [];
+  try { flow = load(dir, 'flow.yaml'); } catch { flow = []; }
+  const flowIds = new Set((flow ?? []).map((f) => f && f.id));
+
+  const goalIdSet = new Set(goals.map((g) => g.id));
+  const cardIdSet = new Set([...goalIdSet, ...toolIds]); // valid relates_to / drill targets
+```
+
+Add flow-shape validation (only when a flow.yaml exists) right after:
+
+```js
+  for (const f of flow ?? []) {
+    for (const k of ['id', 'label_de', 'emoji', 'danger', 'order', 'blurb_de'])
+      req(f?.[k] !== undefined && f?.[k] !== null, `flow[${f?.id}]: missing '${k}'`);
+    if (f?.danger) req(taxIds.has(f.danger), `flow[${f?.id}]: danger '${f.danger}' not in taxonomy`);
+  }
+```
+
+Extend `checkCardExtras` (the opt-in block) to validate `stages`. Add inside that arrow function, before its closing brace:
+
+```js
+    for (const s of card?.stages ?? [])
+      req(flowIds.size === 0 || flowIds.has(s), `${label}: stage '${s}' not in flow.yaml`);
+```
+
+Add component field validation. Inside the existing `for (const c of components)` loop, after the `sensitivity` check (line ~92), add:
+
+```js
+    if (c?.area !== undefined && c?.area !== null)
+      req(TERRITORY_AREA_IDS.has(c.area), `components[${c?.slug}]: area '${c.area}' not a known territory area`);
+    if (c?.theme !== undefined && c?.theme !== null && themeIds.size > 0)
+      req(themeIds.has(c.theme), `components[${c?.slug}]: theme '${c.theme}' not in themes.yaml`);
+    for (const rid of c?.relates_to ?? [])
+      req(cardIdSet.has(rid), `components[${c?.slug}]: relates_to '${rid}' not a known goal/tool id`);
+```
+
+Add a non-fatal warnings array. Near the top of `validateRegistry` (after `const errors = [];`):
+
+```js
+  const warnings = [];
+```
+
+After all checks, before `return`, warn on empty stations:
+
+```js
+  if (flowIds.size > 0) {
+    const usedStages = new Set();
+    for (const card of [...goals, ...tools])
+      for (const s of card?.stages ?? []) usedStages.add(s);
+    for (const f of flow) if (!usedStages.has(f.id)) warnings.push(`flow station '${f.id}' has no goal/tool (stages)`);
+  }
+```
+
+Change the return to include warnings:
+
+```js
+  return { ok: errors.length === 0, errors, warnings };
+```
+
+Update the CLI block at the bottom to print warnings without failing:
+
+```js
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const repoRoot = process.cwd();
+  const res = validateRegistry(join(repoRoot, 'docs', 'agent-guide', 'registry'), repoRoot);
+  for (const w of res.warnings ?? []) console.warn('⚠', w);
+  if (!res.ok) { for (const e of res.errors) console.error('✗', e); process.exit(1); }
+  console.log('✓ agent-guide registry valid');
+}
+```
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+Run: `node --test scripts/agent-guide/validate.test.mjs`
+Expected: PASS (all tests, including the new two).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add scripts/agent-guide/flow.yaml docs/agent-guide/registry/flow.yaml \
+  scripts/agent-guide/map-areas.mjs scripts/agent-guide/validate.mjs \
+  scripts/agent-guide/validate.test.mjs scripts/agent-guide/fixtures/bad-stage-ref
+git commit -m "feat(agent-guide): flow.yaml + validation for stages/area/theme/relates_to"
+```
+
+> Note: `flow.yaml` belongs under `docs/agent-guide/registry/`, not `scripts/`. The `git add` above lists the registry path; remove the stray `scripts/agent-guide/flow.yaml` token if your shell created nothing there.
+
+---
+
+## Task 2: Emitter emits the `map` block + `stages`/`concept_de`
+
+**Files:**
+- Modify: `scripts/agent-guide/emit-webapp.mjs`
+- Test: `scripts/agent-guide/emit-webapp.test.mjs`
+
+- [ ] **Step 1: Update the strict component-keys test (it will break otherwise)**
+
+In `scripts/agent-guide/emit-webapp.test.mjs`, the test `buildWebappData: keys components by slug with only the §6.1 fields` (lines ~93-104) asserts an exact 7-key set. Replace its body so the base keys remain required but the new optional keys are allowed only when present. Replace lines 93-104 with:
+
+```js
+test('buildWebappData: keys components by slug with the base fields (+ optional map fields)', () => {
+  const data = buildWebappData(fixtureRegistry());
+  assert.ok(data.components.keycloak, 'components is an object keyed by slug');
+  const kc = data.components.keycloak;
+  const BASE = ['emoji', 'kind', 'name', 'sensitivity', 'slug', 'summary_de', 'url'];
+  for (const k of BASE) assert.ok(k in kc, `component keeps base field '${k}'`);
+  assert.equal(kc.sensitivity, 'assisted');
+  // The fixture component has no area/theme/relates_to → those keys must be ABSENT.
+  assert.ok(!('area' in kc) && !('theme' in kc) && !('relates_to' in kc));
+  // what_for_de / placeholder_en / links are NOT needed by S2 → dropped
+  assert.ok(!('what_for_de' in kc));
+  assert.ok(!('placeholder_en' in kc));
+  assert.ok(!('links' in kc));
+});
+```
+
+- [ ] **Step 2: Write the failing map-block tests**
+
+Append to `scripts/agent-guide/emit-webapp.test.mjs`:
+
+```js
+// ── Map block (flow ribbon + territory) ──────────────────────────────────────
+function fixtureRegistryMapped() {
+  const dir = fixtureRegistryThemed();
+  writeFileSync(join(dir, 'flow.yaml'), [
+    '- { id: idee, label_de: "Idee", emoji: "💡", danger: safe, order: 1, blurb_de: "PR Idee." }',
+    '- { id: plan, label_de: "Plan", emoji: "📋", danger: caution, order: 2, blurb_de: "Plan ENV." }',
+    '',
+  ].join('\n'));
+  // give the themed goal a stage + concept, the plan tool a stage
+  writeFileSync(join(dir, 'goals.yaml'), [
+    '- id: change-website-text',
+    '  title_de: "Ich will den Text auf der Website ändern"',
+    '  when_de: "Wenn etwas Falsches dasteht."', '  danger: safe',
+    '  theme: website', '  one_liner_de: "Text korrigieren."',
+    '  concept_de: "Konzept: ein PR ist ein Änderungsvorschlag."',
+    '  stages: [plan]',
+    '  flow:', '    - { tool: agent-website, note_de: "Sag ihm, welche Seite." }',
+    '  example_prompt_de: "Ändere die Überschrift."',
+    '  guardrails: [G-ENV-EXPLICIT]', '  related: []', '',
+  ].join('\n'));
+  // tag keycloak onto the map; mailpit stays off-map
+  writeFileSync(join(dir, 'components.yaml'), [
+    '- { slug: keycloak, kind: software, name: "Keycloak", emoji: "🔐", summary_de: "SSO.", what_for_de: "x", placeholder_en: "x", sensitivity: assisted, url: "https://auth", links: [], area: plattform, theme: website, relates_to: [change-website-text] }',
+    '- { slug: mailpit,  kind: software, name: "Mailpit",  emoji: "📭", summary_de: "Test.", what_for_de: "x", placeholder_en: "x", sensitivity: safe, url: "https://mail", links: [] }',
+    '',
+  ].join('\n'));
+  return dir;
+}
+
+test('buildWebappData: emits a map.flow ordered by station order with resolved goal/tool ids', () => {
+  const data = buildWebappData(fixtureRegistryMapped());
+  assert.ok(data.map && Array.isArray(data.map.flow));
+  assert.deepEqual(data.map.flow.map((s) => s.id), ['idee', 'plan']);
+  const plan = data.map.flow.find((s) => s.id === 'plan');
+  assert.equal(plan.label_de, 'Plan');
+  assert.equal(plan.danger, 'caution');
+  assert.deepEqual(plan.goalIds, ['change-website-text']);
+  assert.deepEqual(data.map.flow.find((s) => s.id === 'idee').goalIds, []);
+});
+
+test('buildWebappData: emits map.territory areas with only opted-in components, carrying accent', () => {
+  const data = buildWebappData(fixtureRegistryMapped());
+  const plattform = data.map.territory.find((a) => a.id === 'plattform');
+  assert.ok(plattform, 'plattform area present');
+  assert.deepEqual(plattform.nodes.map((n) => n.slug), ['keycloak']);
+  const kc = plattform.nodes[0];
+  assert.equal(kc.sensitivity, 'assisted');
+  assert.equal(kc.theme, 'website');
+  assert.equal(kc.accent, '#4a9eff');                 // resolved from themes.yaml
+  assert.deepEqual(kc.relatesTo, ['change-website-text']);
+  // mailpit has no area → must not appear anywhere in territory
+  const allSlugs = data.map.territory.flatMap((a) => a.nodes.map((n) => n.slug));
+  assert.ok(!allSlugs.includes('mailpit'));
+});
+
+test('buildWebappData: passes stages + concept_de onto goals', () => {
+  const data = buildWebappData(fixtureRegistryMapped());
+  const g = data.goals.find((x) => x.id === 'change-website-text');
+  assert.deepEqual(g.stages, ['plan']);
+  assert.equal(g.concept_de, 'Konzept: ein PR ist ein Änderungsvorschlag.');
+});
+
+test('buildWebappData: tolerates a registry with no flow.yaml (empty map.flow)', () => {
+  const data = buildWebappData(globalThis.__agFixtureRegistry());
+  assert.deepEqual(data.map.flow, []);
+  assert.ok(Array.isArray(data.map.territory));
+});
+```
+
+- [ ] **Step 3: Run the tests to verify they fail**
+
+Run: `node --test scripts/agent-guide/emit-webapp.test.mjs`
+Expected: FAIL — the map tests fail (`data.map` is undefined) and the determinism `$schema` regex test still passes.
+
+- [ ] **Step 4: Implement the emitter changes**
+
+In `scripts/agent-guide/emit-webapp.mjs`, add the import (after line 8):
+
+```js
+import { TERRITORY_AREAS } from './map-areas.mjs';
+```
+
+Inside `buildWebappData`, change the `goals` projection to pass `stages` + `concept_de` (modify the returned object literal, lines ~91-111). Add these two properties before the `escalate_to_de` spread:
+
+```js
+    stages: g.stages ?? [],
+    concept_de: g.concept_de ?? (g.flow?.[0] ? (toolById(g.flow[0].tool)?.summary_de ?? '') : ''),
+```
+
+Add `stages` to the `tools` projection (object literal lines ~70-89), before the `init_prompt_de` spread:
+
+```js
+    stages: t.stages ?? [],
+```
+
+Change the `components` projection to include the optional map fields. Replace the `components` loop (lines ~113-124) with:
+
+```js
+  const themeAccent = (id) => themes.find((t) => t.id === id)?.accent ?? '#888888';
+  const components = {};
+  for (const c of reg.components) {
+    components[c.slug] = {
+      slug: c.slug,
+      kind: c.kind,
+      name: c.name,
+      emoji: c.emoji,
+      summary_de: c.summary_de,
+      sensitivity: c.sensitivity,
+      url: c.url,
+      ...(c.area ? { area: c.area } : {}),
+      ...(c.theme ? { theme: c.theme } : {}),
+      ...(c.relates_to ? { relates_to: c.relates_to } : {}),
+    };
+  }
+```
+
+Build the `map` object. Add this just before the final `return {…}` (after the `components` loop):
+
+```js
+  const flowRaw = loadOptionalList(registryDir, 'flow');
+  const flowStations = flowRaw
+    .map((s) => ({
+      id: s.id, label_de: s.label_de, emoji: s.emoji, danger: s.danger,
+      order: s.order ?? 999, blurb_de: s.blurb_de ?? '',
+      goalIds: reg.goals.filter((g) => (g.stages ?? []).includes(s.id)).map((g) => g.id),
+      toolIds: reg.tools.filter((t) => (t.stages ?? []).includes(s.id)).map((t) => t.id),
+    }))
+    .sort((a, b) => a.order - b.order);
+
+  const territory = TERRITORY_AREAS
+    .map((a) => ({
+      id: a.id, label_de: a.label_de, order: a.order,
+      nodes: reg.components
+        .filter((c) => c.area === a.id)
+        .map((c) => ({
+          slug: c.slug, name: c.name, emoji: c.emoji, sensitivity: c.sensitivity,
+          theme: c.theme ?? null, accent: c.theme ? themeAccent(c.theme) : '#888888',
+          relatesTo: c.relates_to ?? [],
+        })),
+    }));
+
+  const map = { flow: flowStations, territory };
+```
+
+Add `map` to the returned object (the `return {…}` literal, after `components,`):
+
+```js
+    components,
+    map,
+  };
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `node --test scripts/agent-guide/emit-webapp.test.mjs`
+Expected: PASS (all tests, including the 4 new map tests and the updated component-keys test).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/agent-guide/emit-webapp.mjs scripts/agent-guide/emit-webapp.test.mjs
+git commit -m "feat(agent-guide): emit map block + stages/concept_de passthrough"
+```
+
+---
+
+## Task 3: Author registry content (stages, concept_de, territory tags, new goals)
+
+**Files:**
+- Modify: `docs/agent-guide/registry/goals.yaml`
+- Modify: `docs/agent-guide/registry/tools.yaml`
+- Modify: `docs/agent-guide/registry/components.yaml`
+- Regenerate + commit: `website/src/lib/agent-guide.generated.json`, `docs/agent-guide/{10-ziele,20-werkzeuge,30-bausteine}.md`, `docs/agent-guide/maps/*.md`
+
+- [ ] **Step 1: Add `stages` to existing tools**
+
+In `docs/agent-guide/registry/tools.yaml`, add a `stages:` line to each tool below (insert after its `theme:` line):
+
+- `superpowers`: `stages: [brainstorm]`
+- `brainstorming`: `stages: [idee, brainstorm]`
+- `dev-flow-plan`: `stages: [plan]`
+- `dev-flow-execute`: `stages: [code, pr-ci]`
+- `dev-flow-iterate`: `stages: [code, deploy]`
+- `dev-flow-e2e`: `stages: [live]`
+- `agent-infra`: `stages: [deploy]`
+- `agent-ops`: `stages: [live]`
+
+(Leave `task-oracle`, `agent-website`, `agent-test`, `agent-db`, `agent-security` without `stages`.)
+
+- [ ] **Step 2: Add `stages` + `concept_de` to existing goals**
+
+In `docs/agent-guide/registry/goals.yaml`, add to each goal:
+
+- `website-text-aendern`: `stages: [code]` and `concept_de: "Konzept: Inhalte ändert man über einen Branch + PR, nicht direkt auf main."`
+- `dienst-status-pruefen`: `stages: [live]` and `concept_de: "Konzept: Status/Logs lesen ist 🟢 — es verändert nichts."`
+- `bug-beheben`: `stages: [plan, code, pr-ci, deploy]` and `concept_de: "Konzept: erst ein Test, der den Fehler zeigt (TDD), dann der Fix."`
+- `feature-bauen`: `stages: [plan, code, pr-ci, deploy]` and `concept_de: "Konzept: jede neue Funktion durchläuft Plan → Code → PR → Deploy."`
+- `aenderung-ausrollen`: `stages: [deploy, live]` and `concept_de: "Konzept: Deploy heißt einen gemergten Stand in einer Umgebung (ENV) aktivieren."`
+- `datenbank-aendern`: `stages: [plan, code, deploy]` and `concept_de: "Konzept: Schema-Änderungen treffen beide Marken — immer als Migration."`
+- `secret-aendern`, `cluster-neu-aufsetzen`: leave without `stages` (forbidden, off the normal flow).
+
+- [ ] **Step 3: Add three onboarding goals (fills idee / pr-ci / live)**
+
+Append to `docs/agent-guide/registry/goals.yaml`:
+
+```yaml
+- id: idee-starten
+  title_de: "Ich habe eine Idee — wie fange ich an?"
+  when_de: "Du willst etwas verändern, weißt aber noch nicht, wie der Weg aussieht."
+  flow:
+    - tool: brainstorming
+      note_de: "Beschreibe die Idee; der Brainstorming-Skill schärft sie zu einem Design."
+    - tool: dev-flow-plan
+      note_de: "Danach schreibt der Planungs-Skill einen Schritt-für-Schritt-Plan."
+  example_prompt_de: "Ich habe eine Idee für die Plattform und möchte sie erst gemeinsam durchdenken."
+  danger: safe
+  theme: entwickeln
+  one_liner_de: "Von der Idee zum Plan — der erste Schritt."
+  common: true
+  order: 6
+  stages: [idee, brainstorm]
+  concept_de: "Konzept: jede Änderung beginnt mit Brainstorm → Plan, bevor Code entsteht."
+  aliases_de: [idee, anfangen, start, neu, wie]
+  guardrails: [G-PULL-FIRST]
+  related: [feature-bauen, bug-beheben]
+- id: pr-oeffnen
+  title_de: "Ich will einen Pull Request öffnen und CI grün bekommen"
+  when_de: "Der Code ist fertig und soll als Pull Request geprüft und gemergt werden."
+  flow:
+    - tool: dev-flow-execute
+      note_de: "Pusht den Branch, öffnet den PR und wartet, bis die CI-Checks grün sind."
+  example_prompt_de: "Bitte öffne einen Pull Request für diesen Branch und sag mir, ob die CI grün ist."
+  danger: assisted
+  theme: entwickeln
+  one_liner_de: "Branch als PR einreichen und CI abwarten."
+  stages: [pr-ci]
+  concept_de: "Konzept: nichts kommt nach main ohne PR + grüne CI (Squash-Merge)."
+  aliases_de: [pr, "pull request", ci, merge, review]
+  guardrails: [G-PR-NOT-MAIN]
+  related: [feature-bauen, aenderung-ausrollen]
+- id: deploy-pruefen
+  title_de: "Ich will prüfen, ob mein Deploy wirklich live ist"
+  when_de: "Nach einem Deploy willst du sehen, ob die Änderung in der echten Umgebung angekommen ist."
+  flow:
+    - tool: agent-ops
+      note_de: "Lässt Pod-Status und Logs prüfen, ob der neue Stand läuft."
+    - tool: dev-flow-e2e
+      note_de: "Verifiziert per E2E-Test gegen die Live-URL, dass das Feature funktioniert."
+  example_prompt_de: "Ist der letzte Deploy für mentolder live? Prüfe Status, Logs und mach einen E2E-Check."
+  danger: safe
+  theme: betrieb
+  one_liner_de: "Nach dem Deploy prüfen, ob alles läuft."
+  common: true
+  order: 7
+  stages: [live]
+  concept_de: "Konzept: Deploy ≠ live — erst Status, Logs und ein E2E-Check bestätigen es."
+  aliases_de: [deploy, live, pruefen, status, "ist es da"]
+  guardrails: [G-ENV-EXPLICIT]
+  related: [aenderung-ausrollen, dienst-status-pruefen]
+```
+
+(These use themes `entwickeln`/`betrieb` — **never `website`** — so `agentGuideSearch.test.ts:71` stays valid.)
+
+- [ ] **Step 4: Tag territory components**
+
+In `docs/agent-guide/registry/components.yaml`, add `area`, `theme`, and (where natural) `relates_to` to the curated set below. Add the three lines under each listed component's existing fields. **Only these slugs get tagged; all others stay off the map.**
+
+```yaml
+# website:         area: dienste    theme: website     relates_to: [website-text-aendern]
+# nextcloud:       area: dienste    theme: betrieb
+# collabora:       area: dienste    theme: betrieb
+# vaultwarden:     area: dienste    theme: sicherheit
+# docuseal:        area: dienste    theme: betrieb
+# livekit:         area: dienste    theme: betrieb
+# keycloak:        area: plattform  theme: sicherheit  relates_to: [secret-aendern]
+# traefik:         area: plattform  theme: ausrollen
+# k3s:             area: plattform  theme: ausrollen    relates_to: [cluster-neu-aufsetzen]
+# cert-manager:    area: plattform  theme: sicherheit
+# postgresql:      area: daten      theme: datenbank    relates_to: [datenbank-aendern]
+# sealed-secrets:  area: daten      theme: sicherheit   relates_to: [secret-aendern]
+```
+
+For example, the `website` entry becomes:
+
+```yaml
+- slug: website
+  kind: software
+  name: "Website"
+  emoji: "🌐"
+  sensitivity: caution
+  placeholder_en: "Astro + Svelte frontend"
+  summary_de: "Die öffentliche Webseite und das Kundenportal. Hier ändert man Texte, Preise und sieht eigene Daten."
+  what_for_de: "Das mit Astro + Svelte gebaute Frontend (die Web-Oberfläche). Öffentliche Seite plus eingeloggtes Kundenportal."
+  url: null
+  links: []
+  area: dienste
+  theme: website
+  relates_to: [website-text-aendern]
+```
+
+Apply the analogous three (or two) lines to `nextcloud`, `collabora`, `vaultwarden`, `docuseal`, `livekit`, `keycloak`, `traefik`, `k3s`, `cert-manager`, `postgresql`, `sealed-secrets` per the table above.
+
+- [ ] **Step 5: Validate, regenerate all surfaces, and review the diff**
+
+Run:
+```bash
+cd /tmp/wt-agent-guide-mental-model
+node scripts/agent-guide/validate.mjs        # expect: ✓ agent-guide registry valid (no ✗; ⚠ only if a station is empty)
+task agent-guide:emit                         # regenerates webapp JSON + docs/*.md + maps/*.md
+git --no-pager diff --stat
+```
+Expected: `validate.mjs` prints `✓` (and no warnings, since every station now has a card). `agent-guide.generated.json` now contains a `map` key; `goals[]` carry `stages`/`concept_de`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docs/agent-guide/registry/goals.yaml docs/agent-guide/registry/tools.yaml \
+  docs/agent-guide/registry/components.yaml \
+  website/src/lib/agent-guide.generated.json \
+  docs/agent-guide/10-ziele.md docs/agent-guide/20-werkzeuge.md docs/agent-guide/30-bausteine.md \
+  docs/agent-guide/maps/goals-map.md docs/agent-guide/maps/tools-map.md docs/agent-guide/maps/danger-map.md
+git commit -m "content(agent-guide): stages/concept_de, territory tags, 3 onboarding goals"
+```
+
+---
+
+## Task 4: TypeScript types (`agentGuide.ts` + E2E lib)
+
+**Files:**
+- Modify: `website/src/lib/agentGuide.ts`
+- Modify: `tests/e2e/lib/agent-guide.ts`
+
+- [ ] **Step 1: Extend types and exports in agentGuide.ts**
+
+In `website/src/lib/agentGuide.ts`, add `stages` + `concept_de?` to `Goal` (after `order: number;`) and `stages` to `Tool` (after `order: number;`):
+
+```ts
+  stages: string[];
+  concept_de?: string;   // Goal only
+```
+```ts
+  stages: string[];      // Tool
+```
+
+Add the map interfaces (after the `Component` interface, before the `export const` block):
+
+```ts
+export interface FlowStation {
+  id: string;
+  label_de: string;
+  emoji: string;
+  danger: string;
+  order: number;
+  blurb_de: string;
+  goalIds: string[];
+  toolIds: string[];
+}
+
+export interface TerritoryNode {
+  slug: string;
+  name: string;
+  emoji: string;
+  sensitivity: string;
+  theme: string | null;
+  accent: string;
+  relatesTo: string[];
+}
+
+export interface TerritoryArea {
+  id: string;
+  label_de: string;
+  order: number;
+  nodes: TerritoryNode[];
+}
+
+export interface MapData {
+  flow: FlowStation[];
+  territory: TerritoryArea[];
+}
+```
+
+Add the export (after `export const components …`):
+
+```ts
+export const guideMap: MapData = (data.map ?? { flow: [], territory: [] }) as MapData;
+```
+
+- [ ] **Step 2: Mirror types + expose map in the E2E lib**
+
+In `tests/e2e/lib/agent-guide.ts`: add `stages: string[];` + `concept_de?: string;` to `Goal`, `stages: string[];` to `Tool`, and the `FlowStation`/`TerritoryNode`/`TerritoryArea`/`MapData` interfaces (copy from Step 1). Add `map: MapData;` to `GuideData`, and in `loadGuideData` add:
+
+```ts
+    map: (raw.map ?? { flow: [], territory: [] }) as MapData,
+```
+
+- [ ] **Step 3: Typecheck**
+
+Run: `cd /tmp/wt-agent-guide-mental-model/website && pnpm exec tsc --noEmit -p tsconfig.json`
+Expected: no errors from `agentGuide.ts` (pre-existing unrelated errors, if any, are out of scope — confirm none reference our files).
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /tmp/wt-agent-guide-mental-model
+git add website/src/lib/agentGuide.ts tests/e2e/lib/agent-guide.ts
+git commit -m "feat(agent-guide): types for stages/concept_de + map data"
+```
+
+---
+
+## Task 5: Pure search helpers — `mapFilterIds` + `splitGlossaryTerms`
+
+**Files:**
+- Modify: `website/src/lib/agentGuideSearch.ts`
+- Test: `website/src/lib/agentGuideSearch.test.ts`
+
+- [ ] **Step 1: Write the failing vitest cases**
+
+Append to `website/src/lib/agentGuideSearch.test.ts`. First extend the imports at the top:
+
+```ts
+import { goals, tools, taxonomy, themes, guideMap, glossary } from './agentGuide';
+import {
+  MIN_QUERY, normalize, buildEntries, matches, filterEntries,
+  groupBy, sortCommonFirst, highlight, mapFilterIds, splitGlossaryTerms,
+} from './agentGuideSearch';
+```
+
+Then append:
+
+```ts
+describe('buildEntries: stages', () => {
+  it('carries the stages array onto each entry', () => {
+    const e = ALL.find(x => x.id === 'bug-beheben')!;
+    expect(Array.isArray(e.stages)).toBe(true);
+    expect(e.stages).toContain('plan');
+  });
+});
+
+describe('mapFilterIds', () => {
+  it('returns null for a null filter (no restriction)', () => {
+    expect(mapFilterIds(null, guideMap)).toBeNull();
+  });
+  it('flow filter → the station goalIds+toolIds set', () => {
+    const ids = mapFilterIds({ kind: 'flow', id: 'plan' }, guideMap)!;
+    const plan = guideMap.flow.find(s => s.id === 'plan')!;
+    expect(ids.has(plan.goalIds[0] ?? plan.toolIds[0])).toBe(true);
+    expect(ids.has('dienst-status-pruefen')).toBe(false); // live station, not plan
+  });
+  it('node filter → the territory node relatesTo set', () => {
+    const node = guideMap.territory.flatMap(a => a.nodes).find(n => n.relatesTo.length > 0)!;
+    const ids = mapFilterIds({ kind: 'node', id: node.slug }, guideMap)!;
+    expect(ids.has(node.relatesTo[0])).toBe(true);
+  });
+  it('unknown id → empty set (filters everything out, never throws)', () => {
+    expect(mapFilterIds({ kind: 'flow', id: 'nope' }, guideMap)!.size).toBe(0);
+  });
+});
+
+describe('splitGlossaryTerms', () => {
+  const terms = glossary.map(g => g.term); // includes 'PR', 'CI', 'Deploy', …
+  it('splits a known whole-word term into a marked segment', () => {
+    const segs = splitGlossaryTerms('Öffne einen PR und warte auf CI.', terms);
+    expect(segs.some(s => s.term === 'PR')).toBe(true);
+    expect(segs.some(s => s.term === 'CI')).toBe(true);
+    expect(segs.map(s => s.text).join('')).toBe('Öffne einen PR und warte auf CI.');
+  });
+  it('does not match inside a larger word', () => {
+    const segs = splitGlossaryTerms('Preisliste', ['PR']);
+    expect(segs.every(s => !s.term)).toBe(true);
+    expect(segs.map(s => s.text).join('')).toBe('Preisliste');
+  });
+  it('returns one plain segment when there are no terms', () => {
+    expect(splitGlossaryTerms('nichts hier', [])).toEqual([{ text: 'nichts hier' }]);
+  });
+});
+```
+
+- [ ] **Step 2: Run vitest to verify failure**
+
+Run: `cd /tmp/wt-agent-guide-mental-model/website && pnpm test:unit -- agentGuideSearch`
+Expected: FAIL — `mapFilterIds`/`splitGlossaryTerms` are not exported; `e.stages` undefined.
+
+- [ ] **Step 3: Implement in agentGuideSearch.ts**
+
+Add `stages` to the `GuideEntry` interface (after `aliases_de: string[];`):
+
+```ts
+  stages: string[];
+```
+
+In `buildEntries`, add `stages` to both the goal and tool entry objects:
+
+```ts
+    // goal entry — add:
+    stages: g.stages ?? [],
+```
+```ts
+    // tool entry — add:
+    stages: t.stages ?? [],
+```
+
+Add the import of map types at the top (extend the existing type import):
+
+```ts
+import type { Goal, Tool, Theme, TierEntry, MapData } from './agentGuide';
+```
+
+Append the two pure helpers at the end of the file:
+
+```ts
+export type MapFilter = { kind: 'flow' | 'node'; id: string } | null;
+
+/** Resolve a map selection to the set of entry ids it permits, or null = no restriction. */
+export function mapFilterIds(filter: MapFilter, map: MapData): Set<string> | null {
+  if (!filter) return null;
+  if (filter.kind === 'flow') {
+    const s = map.flow.find(f => f.id === filter.id);
+    return new Set([...(s?.goalIds ?? []), ...(s?.toolIds ?? [])]);
+  }
+  const node = map.territory.flatMap(a => a.nodes).find(n => n.slug === filter.id);
+  return new Set(node?.relatesTo ?? []);
+}
+
+export interface GlossSegment { text: string; term?: string; }
+
+/** Split `text` into segments, marking the first whole-word occurrence of each glossary
+ *  term (longest term first). Whole-word = bounded by non-word chars; case-insensitive. */
+export function splitGlossaryTerms(text: string, terms: string[]): GlossSegment[] {
+  const wanted = [...terms].filter(Boolean).sort((a, b) => b.length - a.length);
+  const used = new Set<string>();
+  let segs: GlossSegment[] = [{ text }];
+  for (const term of wanted) {
+    const next: GlossSegment[] = [];
+    for (const seg of segs) {
+      if (seg.term || used.has(term)) { next.push(seg); continue; }
+      const re = new RegExp(`(^|[^\\p{L}\\p{N}])(${term.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')})(?=[^\\p{L}\\p{N}]|$)`, 'iu');
+      const m = re.exec(seg.text);
+      if (!m) { next.push(seg); continue; }
+      const start = m.index + m[1].length;
+      const end = start + m[2].length;
+      if (seg.text.slice(0, start)) next.push({ text: seg.text.slice(0, start) });
+      next.push({ text: seg.text.slice(start, end), term });
+      if (seg.text.slice(end)) next.push({ text: seg.text.slice(end) });
+      used.add(term);
+    }
+    segs = next;
+  }
+  return segs.length ? segs : [{ text }];
+}
+```
+
+- [ ] **Step 4: Run vitest to verify pass**
+
+Run: `cd /tmp/wt-agent-guide-mental-model/website && pnpm test:unit -- agentGuideSearch`
+Expected: PASS (all describe blocks, including the 3 new ones).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /tmp/wt-agent-guide-mental-model
+git add website/src/lib/agentGuideSearch.ts website/src/lib/agentGuideSearch.test.ts
+git commit -m "feat(agent-guide): stages on entries + pure mapFilterIds/splitGlossaryTerms"
+```
+
+---
+
+## Task 6: `GuideMap.svelte` — flow ribbon + territory lanes
+
+**Files:**
+- Create: `website/src/components/assistant/agent-guide/GuideMap.svelte`
+
+- [ ] **Step 1: Create the component**
+
+Create `website/src/components/assistant/agent-guide/GuideMap.svelte`:
+
+```svelte
+<script lang="ts">
+  import type { MapData } from '../../../lib/agentGuide';
+  import { tierColor, tierEmoji, tierLabel } from '../../../lib/agentGuide';
+  import { splitGlossaryTerms } from '../../../lib/agentGuideSearch';
+  import GlossaryTerm from './GlossaryTerm.svelte';
+
+  let {
+    map,
+    active = null,
+    glossaryTerms = [],
+    onSelect,
+  }: {
+    map: MapData;
+    active?: { kind: 'flow' | 'node'; id: string } | null;
+    glossaryTerms?: string[];
+    onSelect: (sel: { kind: 'flow' | 'node'; id: string; label: string } | null) => void;
+  } = $props();
+
+  const isActive = (kind: 'flow' | 'node', id: string) =>
+    active?.kind === kind && active?.id === id;
+
+  function pick(kind: 'flow' | 'node', id: string, label: string) {
+    if (isActive(kind, id)) onSelect(null);          // toggle off
+    else onSelect({ kind, id, label });
+  }
+</script>
+
+<div class="ag-map" aria-label="So funktioniert die Plattform">
+  <!-- Flow ribbon -->
+  <p class="ag-section-label">Dein Weg: Idee → live</p>
+  <ol class="ag-flowband">
+    {#each map.flow as s, i (s.id)}
+      <li>
+        <button
+          type="button"
+          class="ag-flow-station"
+          class:on={isActive('flow', s.id)}
+          style="--tier: {tierColor(s.danger)}"
+          aria-pressed={isActive('flow', s.id)}
+          title={s.blurb_de}
+          onclick={() => pick('flow', s.id, s.label_de)}
+        >
+          <span aria-hidden="true">{s.emoji}</span>
+          <span class="ag-flow-name">{s.label_de}</span>
+          <span class="ag-sr">– {tierLabel(s.danger)}, {s.goalIds.length + s.toolIds.length} Einträge</span>
+        </button>
+      </li>
+      {#if i < map.flow.length - 1}<li class="ag-flow-arrow" aria-hidden="true">→</li>{/if}
+    {/each}
+  </ol>
+
+  <!-- Territory map -->
+  <p class="ag-section-label">Die Plattform: was läuft wo</p>
+  <div class="ag-territory">
+    {#each map.territory.filter(a => a.nodes.length) as area (area.id)}
+      <div class="ag-terr-area">
+        <span class="ag-terr-label">{area.label_de}</span>
+        <div class="ag-terr-nodes">
+          {#each area.nodes as n (n.slug)}
+            <button
+              type="button"
+              class="ag-terr-node"
+              class:on={isActive('node', n.slug)}
+              style="--accent: {n.accent}; --tier: {tierColor(n.sensitivity)}"
+              aria-pressed={isActive('node', n.slug)}
+              onclick={() => pick('node', n.slug, n.name)}
+            >
+              <span aria-hidden="true">{n.emoji}</span> {n.name}
+              <span aria-hidden="true" class="ag-terr-dot">{tierEmoji(n.sensitivity)}</span>
+              <span class="ag-sr">Gefahrenstufe {tierLabel(n.sensitivity)}</span>
+            </button>
+          {/each}
+        </div>
+      </div>
+    {/each}
+  </div>
+</div>
+```
+
+> The component renders the active station's blurb via the parent's filter chip (Task 8); the `splitGlossaryTerms`/`GlossaryTerm` import is used in Task 7's pairing — keep the imports, they are referenced once the concept line lands. If `pnpm check` flags an unused import before Task 7, leave it; Task 7 wires it. (Alternatively move the import line into Task 7's edit.)
+
+- [ ] **Step 2: Commit (compiles; rendered/tested in Task 8 + Task 10)**
+
+```bash
+git add website/src/components/assistant/agent-guide/GuideMap.svelte
+git commit -m "feat(agent-guide): GuideMap component (flow ribbon + territory)"
+```
+
+---
+
+## Task 7: `GlossaryTerm.svelte` + concept line in GuideCard
+
+**Files:**
+- Create: `website/src/components/assistant/agent-guide/GlossaryTerm.svelte`
+- Modify: `website/src/components/assistant/agent-guide/GuideCard.svelte`
+
+- [ ] **Step 1: Create GlossaryTerm.svelte**
+
+Create `website/src/components/assistant/agent-guide/GlossaryTerm.svelte`:
+
+```svelte
+<script lang="ts">
+  let { term, def }: { term: string; def: string } = $props();
+  let open = $state(false);
+</script>
+
+<span class="ag-gloss-wrap">
+  <button
+    type="button"
+    class="ag-gloss"
+    aria-expanded={open}
+    onclick={() => (open = !open)}
+    onmouseenter={() => (open = true)}
+    onmouseleave={() => (open = false)}
+  >{term}</button>
+  {#if open}
+    <span class="ag-gloss-pop" role="note">{def}</span>
+  {/if}
+</span>
+```
+
+- [ ] **Step 2: Render the concept line in GuideCard (goal branch)**
+
+In `website/src/components/assistant/agent-guide/GuideCard.svelte`, extend the imports:
+
+```ts
+  import { glossary } from '../../../lib/agentGuide';
+  import { highlight, splitGlossaryTerms, type GuideEntry } from '../../../lib/agentGuideSearch';
+  import GlossaryTerm from './GlossaryTerm.svelte';
+```
+
+Add a derived term list + def lookup in the `<script>`:
+
+```ts
+  const glossTerms = glossary.map(g => g.term);
+  const glossDef = (t: string) => glossary.find(g => g.term === t)?.def_de ?? '';
+  const conceptSegs = $derived(
+    entry.kind === 'goal' && goal?.concept_de
+      ? splitGlossaryTerms(goal.concept_de, glossTerms)
+      : [],
+  );
+```
+
+In the goal branch, immediately after the `{#if !isForbidden}<p class="ag-when">…</p>{/if}` line (line ~70), insert the concept line:
+
+```svelte
+        {#if conceptSegs.length}
+          <p class="ag-concept">
+            {#each conceptSegs as seg}{#if seg.term}<GlossaryTerm term={seg.term} def={glossDef(seg.term)} />{:else}{seg.text}{/if}{/each}
+          </p>
+        {/if}
+```
+
+- [ ] **Step 3: Build the website to confirm it compiles**
+
+Run: `cd /tmp/wt-agent-guide-mental-model/website && pnpm build`
+Expected: build succeeds (Astro/Svelte compile clean). If `pnpm build` is slow/unavailable, run `pnpm exec svelte-check --threshold error` and confirm no errors in the three touched components.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /tmp/wt-agent-guide-mental-model
+git add website/src/components/assistant/agent-guide/GlossaryTerm.svelte \
+  website/src/components/assistant/agent-guide/GuideCard.svelte
+git commit -m "feat(agent-guide): glossary tooltips + concept line on goal cards"
+```
+
+---
+
+## Task 8: Wire the map into AgentGuideView
+
+**Files:**
+- Modify: `website/src/components/assistant/AgentGuideView.svelte`
+
+- [ ] **Step 1: Import + state**
+
+In `website/src/components/assistant/AgentGuideView.svelte`, extend imports:
+
+```ts
+  import { goals, tools, taxonomy, themes, glossary, guideMap, tierColor, tierEmoji } from '../../lib/agentGuide';
+  import {
+    buildEntries, filterEntries, groupBy, sortCommonFirst, normalize, mapFilterIds, MIN_QUERY,
+    type Axis, type GuideEntry, type MapFilter,
+  } from '../../lib/agentGuideSearch';
+  import GuideMap from './agent-guide/GuideMap.svelte';
+```
+
+Add state (after `let glossaryOpen = $state(false);`):
+
+```ts
+  let mapFilter = $state<MapFilter>(null);
+  let mapOpen = $state(true);
+  const MAP_KEY = 'ag-map-v1';
+  const glossTerms = glossary.map(g => g.term);
+```
+
+- [ ] **Step 2: First-run + persistence for the map**
+
+In the `onMount` block, after the axis rehydrate, add:
+
+```ts
+      const rawMap = localStorage.getItem(MAP_KEY);
+      if (rawMap === 'open' || rawMap === 'closed') mapOpen = rawMap === 'open';
+      else mapOpen = true; // first run: map open to onboard newcomers
+```
+
+Add a persist effect (next to the axis effect):
+
+```ts
+  $effect(() => { if (hydrated) { try { localStorage.setItem(MAP_KEY, mapOpen ? 'open' : 'closed'); } catch { /* ignore */ } } });
+```
+
+- [ ] **Step 3: Compose the map filter into the pipeline**
+
+Change the `preFiltered` derivation to also honor `mapFilter`:
+
+```ts
+  const allowedByMap = $derived(mapFilterIds(mapFilter, guideMap)); // Set<string> | null
+  const preFiltered = $derived(
+    ALL.filter(e =>
+      (allowedByMap === null || allowedByMap.has(e.id)) &&
+      (domainFilter === null || e.theme === domainFilter) &&
+      (tierFilter.size === 0 || tierFilter.has(e.danger)),
+    ),
+  );
+```
+
+- [ ] **Step 4: Render the map + active-filter chip**
+
+In the markup, replace the `<div class="ag-intro">…</div>` block's closing and the `<GuideFindBar … />` with a map section inserted between them. Immediately after the `</div>` that closes `.ag-intro` (line ~164), insert:
+
+```svelte
+  {#if guideMap.flow.length}
+    <section class="ag-map-section">
+      <button type="button" class="ag-map-toggle" aria-expanded={mapOpen} onclick={() => (mapOpen = !mapOpen)}>
+        <span class="ag-map-toggle-icon" aria-hidden="true">🧭</span>
+        <span class="ag-map-toggle-label">So funktioniert die Plattform</span>
+        <span class="ag-chevron" aria-hidden="true">{mapOpen ? '▾' : '▸'}</span>
+      </button>
+      {#if mapOpen}
+        <p class="ag-map-hint">Neu hier? Folge dem Band von links — klick eine Station oder einen Baustein, um die passenden Karten zu sehen.</p>
+        <GuideMap map={guideMap} active={mapFilter} glossaryTerms={glossTerms} onSelect={(sel) => (mapFilter = sel)} />
+      {/if}
+      {#if mapFilter}
+        <button type="button" class="ag-mapfilter-chip" onclick={() => (mapFilter = null)}>
+          Gefiltert: {mapFilter.kind === 'flow' ? 'Station' : 'Baustein'} ✕
+        </button>
+      {/if}
+    </section>
+  {/if}
+```
+
+- [ ] **Step 5: Auto-scroll catalog into view when a map filter is applied**
+
+Add a handler and call it on select. Replace the `onSelect={(sel) => (mapFilter = sel)}` above with `onSelect={selectMap}` and add the function near `jumpTo`:
+
+```ts
+  function selectMap(sel: MapFilter) {
+    mapFilter = sel;
+    if (!sel) return;
+    requestAnimationFrame(() => {
+      document.querySelector('.ag-findbar')?.scrollIntoView({
+        behavior: prefersReducedMotion() ? 'auto' : 'smooth', block: 'start',
+      });
+    });
+  }
+```
+
+- [ ] **Step 6: Build to confirm it compiles**
+
+Run: `cd /tmp/wt-agent-guide-mental-model/website && pnpm build`
+Expected: build succeeds.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /tmp/wt-agent-guide-mental-model
+git add website/src/components/assistant/AgentGuideView.svelte
+git commit -m "feat(agent-guide): mount map, mapFilter pipeline, first-run + persistence"
+```
+
+---
+
+## Task 9: Styles (`.ag-map*`, `.ag-concept`, `.ag-gloss*`, `.ag-mapfilter*`)
+
+**Files:**
+- Modify: `website/src/styles/sidekick-panels.css`
+
+- [ ] **Step 1: Append the styles**
+
+Append to the `.ag-*` region of `website/src/styles/sidekick-panels.css` (after the existing `.drawer .ag-group-cards` rule, ~line 1805):
+
+```css
+/* ── Mental-model map ──────────────────────────────────────────────────────── */
+.drawer .ag-map-section { margin: 12px 22px 0; }
+.drawer .ag-map-toggle {
+  display: flex; align-items: center; gap: 8px; width: 100%;
+  padding: 8px 10px; border: 0; border-left: 4px solid var(--brass, #e8c870);
+  background: color-mix(in srgb, var(--brass, #e8c870) 12%, transparent);
+  border-radius: 8px; color: var(--fg); cursor: pointer; text-align: left;
+}
+.drawer .ag-map-toggle:focus-visible { outline: 2px solid var(--brass); outline-offset: -2px; }
+.drawer .ag-map-toggle-label { flex: 1 1 auto; font-family: var(--serif); font-size: 15px; }
+.drawer .ag-map-hint { margin: 8px 2px; font-size: 12px; color: var(--mute); }
+.drawer .ag-map { display: flex; flex-direction: column; gap: 6px; }
+.drawer .ag-flowband { list-style: none; display: flex; flex-wrap: wrap; align-items: center;
+  gap: 4px; padding: 0; margin: 2px 0 10px; }
+.drawer .ag-flow-arrow { color: var(--mute); font-size: 12px; }
+.drawer .ag-flow-station {
+  display: inline-flex; align-items: center; gap: 5px; padding: 5px 9px;
+  font-size: 12px; color: var(--fg); cursor: pointer;
+  background: transparent; border: 1px solid color-mix(in srgb, var(--tier) 45%, transparent);
+  border-left: 3px solid var(--tier); border-radius: 7px;
+}
+.drawer .ag-flow-station.on { background: color-mix(in srgb, var(--tier) 18%, transparent); }
+.drawer .ag-flow-station:focus-visible { outline: 2px solid var(--brass); outline-offset: 1px; }
+.drawer .ag-flow-name { font-weight: 600; }
+.drawer .ag-territory { display: flex; flex-direction: column; gap: 8px; }
+.drawer .ag-terr-area { border: 1px dashed color-mix(in srgb, var(--line) 70%, transparent);
+  border-radius: 8px; padding: 7px 9px; }
+.drawer .ag-terr-label { display: block; font-family: var(--mono); font-size: 10px;
+  text-transform: uppercase; letter-spacing: 0.4px; color: var(--mute); margin-bottom: 6px; }
+.drawer .ag-terr-nodes { display: flex; flex-wrap: wrap; gap: 6px; }
+.drawer .ag-terr-node {
+  display: inline-flex; align-items: center; gap: 5px; padding: 4px 8px;
+  font-size: 11.5px; color: var(--fg); cursor: pointer; background: transparent;
+  border: 1px solid color-mix(in srgb, var(--accent, var(--line)) 40%, transparent);
+  border-left: 3px solid var(--accent, var(--line)); border-radius: 7px;
+}
+.drawer .ag-terr-node.on { background: color-mix(in srgb, var(--accent) 16%, transparent); }
+.drawer .ag-terr-node:focus-visible { outline: 2px solid var(--brass); outline-offset: 1px; }
+.drawer .ag-terr-dot { font-size: 10px; }
+.drawer .ag-mapfilter-chip {
+  margin-top: 8px; padding: 4px 10px; font-size: 11px; cursor: pointer;
+  color: var(--ink-900, #0f1623); background: var(--brass, #e8c870);
+  border: 0; border-radius: 999px; font-weight: 600;
+}
+
+/* ── Concept line + glossary tooltip ───────────────────────────────────────── */
+.drawer .ag-concept { margin: 2px 0 8px; font-size: 12.5px; color: var(--mute); font-style: italic; }
+.drawer .ag-gloss-wrap { position: relative; display: inline-block; }
+.drawer .ag-gloss {
+  border: 0; background: transparent; padding: 0; cursor: help; color: inherit;
+  font: inherit; border-bottom: 1px dotted var(--brass, #e8c870);
+}
+.drawer .ag-gloss:focus-visible { outline: 2px solid var(--brass); outline-offset: 2px; }
+.drawer .ag-gloss-pop {
+  position: absolute; left: 0; top: 130%; z-index: 5; width: max-content; max-width: 240px;
+  padding: 6px 9px; font-size: 11.5px; font-style: normal; color: var(--fg);
+  background: var(--ink-900, #0f1623); border: 1px solid var(--line);
+  border-radius: 6px; box-shadow: 0 4px 14px rgba(0,0,0,.4);
+}
+@media (prefers-reduced-motion: reduce) { .drawer .ag-flow-station, .drawer .ag-terr-node { transition: none; } }
+```
+
+- [ ] **Step 2: Build + eyeball**
+
+Run: `cd /tmp/wt-agent-guide-mental-model/website && pnpm build`
+Expected: build succeeds. (Visual check happens in the E2E film step / `task dev-flow-iterate`.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /tmp/wt-agent-guide-mental-model
+git add website/src/styles/sidekick-panels.css
+git commit -m "style(agent-guide): map, concept line, glossary tooltip styles"
+```
+
+---
+
+## Task 10: E2E coverage
+
+**Files:**
+- Modify: `tests/e2e/specs/agent-guide-walkthrough.spec.ts`
+- Modify: `tests/e2e/lib/agent-guide.ts` (helper)
+
+- [ ] **Step 1: Add a helper to open the map (it is open by default, but ensure)**
+
+In `tests/e2e/lib/agent-guide.ts`, add:
+
+```ts
+/** Ensures the mental-model map is expanded; returns the .ag-map locator. */
+export async function ensureMapOpen(page: Page) {
+  const toggle = page.locator('.ag-map-toggle');
+  if (await toggle.count()) {
+    const open = await toggle.getAttribute('aria-expanded');
+    if (open !== 'true') await toggle.click();
+  }
+  const map = page.locator('.ag-map');
+  await expect(map).toBeVisible({ timeout: 5_000 });
+  return map;
+}
+```
+
+- [ ] **Step 2: Write the failing E2E assertions**
+
+Add to `tests/e2e/specs/agent-guide-walkthrough.spec.ts` (import `ensureMapOpen` and `map` from the lib):
+
+```ts
+import { openAgentGuide, expandCardByTitle, loadGuideData, ensureMapOpen, showFilmBanner, removeFilmBanner } from '../lib/agent-guide';
+const { goals, tools, taxonomy, themes, glossary, map } = loadGuideData();
+
+test('Mental-Model-Karte zeigt Fluss-Band und Gebietskarte', async ({ page }) => {
+  await openAgentGuide(page);
+  await ensureMapOpen(page);
+  await expect(page.locator('.ag-flow-station')).toHaveCount(map.flow.length);
+  await expect(page.locator('.ag-terr-node').first()).toBeVisible();
+});
+
+test('Klick auf eine Fluss-Station filtert den Katalog', async ({ page }) => {
+  await openAgentGuide(page);
+  await ensureMapOpen(page);
+  const plan = map.flow.find(s => s.id === 'plan')!;
+  await page.locator('.ag-flow-station', { hasText: plan.label_de }).click();
+  await expect(page.locator('.ag-mapfilter-chip')).toBeVisible();
+  // a known plan goal card is present, an unrelated live goal is not
+  await expect(page.locator('.ag-name', { hasText: 'Fehler beheben' })).toBeVisible();
+  await expect(page.locator('.ag-name', { hasText: 'Dienste laufen' })).toHaveCount(0);
+});
+
+test('Klick auf einen Baustein filtert auf seine verknüpften Karten', async ({ page }) => {
+  await openAgentGuide(page);
+  await ensureMapOpen(page);
+  const node = map.territory.flatMap(a => a.nodes).find(n => n.relatesTo.length > 0)!;
+  await page.locator('.ag-terr-node', { hasText: node.name }).first().click();
+  await expect(page.locator('.ag-mapfilter-chip')).toBeVisible();
+  await expect(page.locator('.ag-card-head')).toHaveCount(node.relatesTo.length);
+});
+
+test('Konzept-Zeile + Glossar-Tooltip auf einer Ziel-Karte', async ({ page }) => {
+  await openAgentGuide(page);
+  const conceptGoal = goals.find(g => g.concept_de)!;
+  const card = await expandCardByTitle(page, conceptGoal.title_de);
+  await expect(card.locator('.ag-concept')).toBeVisible();
+  const gloss = card.locator('.ag-gloss').first();
+  if (await gloss.count()) {
+    await gloss.click();
+    await expect(card.locator('.ag-gloss-pop').first()).toBeVisible();
+  }
+});
+
+test('Karte einklappen bleibt nach Reload erhalten', async ({ page }) => {
+  await openAgentGuide(page);
+  await ensureMapOpen(page);
+  await page.locator('.ag-map-toggle').click();                    // collapse
+  await expect(page.locator('.ag-map')).toHaveCount(0);
+  await page.reload();
+  await page.waitForLoadState('networkidle');
+  // re-open drawer + guide after reload, then assert the map stayed collapsed
+  await openAgentGuide(page);
+  await expect(page.locator('.ag-map-toggle')).toHaveAttribute('aria-expanded', 'false');
+});
+```
+
+> Title substrings (`'Fehler beheben'`, `'Dienste laufen'`) match existing goal titles. If a title changes, update the substring.
+
+- [ ] **Step 3: Run the E2E spec against a local preview**
+
+The E2E suite runs against a base URL. Use the dev iterate flow or a local preview:
+
+Run: `cd /tmp/wt-agent-guide-mental-model && task test:e2e:agent-guide` (or the project's standard E2E invocation; see `Taskfile.yml:376` for the film variant).
+Expected: the 5 new tests pass alongside the existing ones. If the runner needs a base URL, start `cd website && pnpm build && pnpm preview` and point the Playwright `baseURL` at it per the existing E2E config.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /tmp/wt-agent-guide-mental-model
+git add tests/e2e/specs/agent-guide-walkthrough.spec.ts tests/e2e/lib/agent-guide.ts
+git commit -m "test(agent-guide): E2E for map render/filter/glossary/collapse"
+```
+
+---
+
+## Task 11: Full verification + regenerate-and-commit gate
+
+**Files:** none new — verification only.
+
+- [ ] **Step 1: Registry + emitter gate (CI parity)**
+
+Run: `cd /tmp/wt-agent-guide-mental-model && task test:agent-guide`
+Expected: `node --test` green; `validate.mjs` prints `✓`; the `git diff --exit-code` on `agent-guide.generated.json` passes (i.e. the committed JSON already matches the emitter — it does, because Task 3 regenerated+committed it). If it reports "stale", run `task agent-guide:emit` and `git commit` the result, then re-run.
+
+- [ ] **Step 2: Unit (vitest) gate**
+
+Run: `cd /tmp/wt-agent-guide-mental-model/website && pnpm test:unit`
+Expected: all `agentGuide*.test.ts` pass, including the pre-existing brittle `website` theme count (still 2) and the new `mapFilterIds`/`splitGlossaryTerms`/`stages` tests.
+
+- [ ] **Step 3: Offline test suite (CI parity)**
+
+Run: `cd /tmp/wt-agent-guide-mental-model && task test:all`
+Expected: green. In particular the test-inventory check passes (no test-id changes here, but confirm `website/src/data/test-inventory.json` is unchanged or regenerated per CI: `task test:inventory` then commit if it differs).
+
+- [ ] **Step 4: Build gate**
+
+Run: `cd /tmp/wt-agent-guide-mental-model/website && pnpm build`
+Expected: Astro build succeeds.
+
+- [ ] **Step 5: Final review against the spec**
+
+Confirm each spec section maps to a task: A→Tasks 6/8, B→Tasks 1/2/3, C→Tasks 5/6/8, D→Tasks 5/7, E→Task 8, F→Task 3, G→Tasks 1/2/5/10. Confirm no `agent-guide/maps/` emitter code changed (only regenerated output). Confirm no new component slug was introduced.
+
+- [ ] **Step 6: Hand off to dev-flow-execute's PR step**
+
+This plan is implemented on `feature/agent-guide-mental-model`. Open the PR per the project flow (squash-merge, CI green). After merge, deploy the website (`task feature:website` / per the deploy table) so both brands pick up the new bundle.
+
+---
+
+## Self-review (author)
+
+- **Spec coverage:** A (experience) → GuideMap + AgentGuideView (T6/T8). B (data model) → flow.yaml/areas/validate (T1), emitter (T2), content (T3). C (render/interaction) → mapFilter pipeline + pure helper (T5/T8), GuideMap (T6). D (teaching) → splitGlossaryTerms + GlossaryTerm + concept line (T5/T7). E (onboarding/polish) → first-run + persistence + styles (T8/T9). F (content coverage) → 3 new goals + station fill + validate warning (T1/T3). G (testing) → node:test (T1/T2), vitest (T5), Playwright (T10). All covered.
+- **Placeholder scan:** every code step shows real code; no TBD/TODO.
+- **Type consistency:** `MapFilter` is `{kind:'flow'|'node'; id:string} | null` everywhere (search export, GuideMap prop is the non-null variant, AgentGuideView state is `MapFilter`); `guideMap`/`map` naming — exported as `guideMap` from `agentGuide.ts` (avoids clash with JS `Map`), aliased to `map` only in the E2E `loadGuideData` return; `mapFilterIds(filter, map)` takes `MapData`. `stages` is `string[]` on Goal/Tool/GuideEntry/registry consistently. Component emit adds `area`/`theme`/`relates_to` (snake_case in registry+emit) → territory node exposes `relatesTo` (camelCase) — the rename is intentional and only crosses the emitter boundary once (tested in T2).
+- **Known coupling handled:** T2 Step 1 fixes the strict component-keys test before the emitter change; T3 keeps the `website` theme at 2 entries.

--- a/docs/superpowers/specs/2026-05-31-agent-guide-mental-model-design.md
+++ b/docs/superpowers/specs/2026-05-31-agent-guide-mental-model-design.md
@@ -1,0 +1,116 @@
+# Agent-Anleitung — „Mental-Model" Einstieg (Design Spec)
+
+- **Datum:** 2026-05-31
+- **Branch:** `feature/agent-guide-mental-model`
+- **Status:** approved (brainstorming)
+- **Vorgänger:** `2026-05-31-agent-guide-sidekick-ux-design.md` (UX-Basis), `2026-05-31-docs-sidekick-refresh-design.md` (Init-Prompts/Reskin), `2026-05-31-agent-guide-inapp-help-design.md` (In-App-Surface)
+
+## Problem & Ziel
+
+Die Agent-Anleitung im Sidekick ist heute ein **Katalog für Profis**: ein:e Kenner:in tippt einen Suchbegriff und landet auf der richtigen Karte. Für die eigentliche Zielgruppe — **Mitstreiter:innen und Future-Patrick, die die Plattform *nicht* kennen** — fehlt das Davor: ein mentales Modell davon, *wie* die Plattform funktioniert und *wie* eine Änderung sicher von der Idee bis live reist.
+
+Ziel: Die Anleitung beginnt mit einer **lehrenden Landkarte** und lässt von dort in den vorhandenen Katalog drillen. Sie soll **onboarden, nicht nur routen** — und dabei die heutige schnelle Referenz für Profis erhalten (Karte ist wegklappbar).
+
+Dieser Spec adressiert die vier vom User benannten Lücken in einem kohärenten Umbau:
+- **Content coverage** — jede Flow-Station und jeder Plattform-Baustein bekommt erklärenden Inhalt; fehlende Szenarien werden ergänzt.
+- **Findability & navigation** — die Karte ist ein neuer, visueller Einstiegs-Filter neben Suche/Thema/Gefahr/Art.
+- **Actionability** — Stationen/Bausteine führen direkt zu den passenden Karten mit Schritten und Copy-Prompts.
+- **Onboarding & polish** — die Karte ist der First-Run-Einstieg mit Lese-Hinweis; passt in den Dark-Reskin; farbblind-sicher.
+
+## Gewählter Ansatz (aus Brainstorming)
+
+- **Variante C** — „Concept-first / Mental-Model"-Einstieg (statt Katalog-zuerst).
+- **Geschichtete Karte (Variante 3):** Fluss-Band oben **+** Gebietskarte darunter.
+- **Gebietskarte = „Both, infra as backdrop":** die echte Plattform-Topologie (Brands → `fleet`-Cluster mit Dienst-Bausteinen → Secrets/Backups), jeder Knoten **eingefärbt nach zuständiger Domäne/Agent** und mit Gefahrenstufe badged.
+
+## Die Erfahrung (UX)
+
+Beim Öffnen der Agent-Anleitung erscheint **oberhalb** des heutigen Find-Bars eine ein-/ausklappbare Karte **„🧭 So funktioniert die Plattform"** mit zwei Ebenen:
+
+1. **Fluss-Band** (lehrt „wie reist ein Change sicher"):
+   `💡 Idee → 🧠 Brainstorm → 📋 Plan → 💻 Code+TDD → 🔀 PR+CI → 🚀 Deploy → 🌍 Live`
+   Jede Station ist nach ihrer **Gefahrenstufe** eingefärbt (Rand/Emoji-Punkt) und anklickbar.
+
+2. **Gebietskarte** (lehrt „was läuft wo"):
+   `🏷️ mentolder.de · korczewski.de` → Box **`☸️ fleet`** mit Dienst-Chips (Keycloak, Nextcloud, Website, shared-db, Vaultwarden, LiveKit, …) → darunter `🔒 Secrets`, `💾 Backups`.
+   Jeder Knoten trägt einen **linken Farbrand in der Akzentfarbe seiner Domäne** (aus `themes.yaml`) und ein **Gefahrenstufen-Badge** (aus `components.yaml › sensitivity`). Anklickbar.
+
+**Drill-down:** Klick auf eine Station **oder** einen Knoten setzt einen `mapFilter`, der den Katalog darunter auf die zugehörigen Karten filtert und dorthin scrollt. Suche, Gefahr- und Thema-Filter **komponieren** weiterhin mit diesem neuen Filter (die Karte ist nur eine weitere Filter-Achse). Ein sichtbares „Filter: Station Plan ✕"-Chip erlaubt das Zurücksetzen.
+
+**Profi-Modus:** Die Karte ist einklappbar; der eingeklappte Zustand wird in `localStorage` gemerkt (Muster wie `ag-axis-v1`, neuer Key `ag-map-v1`). Eingeklappt sieht man exakt die heutige Referenzansicht.
+
+## Datenmodell (additiv, keine Breaking Changes)
+
+Single source of truth bleibt `docs/agent-guide/registry/*.yaml`. Änderungen:
+
+1. **Neu: `registry/flow.yaml`** — geordnete Stationen des Fluss-Bands:
+   ```yaml
+   - { id: idee,      label_de: "Idee",       emoji: "💡", danger: safe,    order: 1, blurb_de: "Was soll sich ändern? Noch nichts angefasst." }
+   - { id: brainstorm,label_de: "Brainstorm", emoji: "🧠", danger: safe,    order: 2, blurb_de: "Idee zu einem Design schärfen." }
+   - { id: plan,      label_de: "Plan",       emoji: "📋", danger: caution, order: 3, blurb_de: "Schritt-für-Schritt-Plan schreiben." }
+   - { id: code,      label_de: "Code+TDD",   emoji: "💻", danger: caution, order: 4, blurb_de: "Test zuerst, dann umsetzen." }
+   - { id: pr-ci,     label_de: "PR+CI",      emoji: "🔀", danger: assisted,order: 5, blurb_de: "Pull Request öffnen, CI muss grün sein." }
+   - { id: deploy,    label_de: "Deploy",     emoji: "🚀", danger: assisted,order: 6, blurb_de: "Änderung live bringen (Flux/Task)." }
+   - { id: live,      label_de: "Live",       emoji: "🌍", danger: safe,    order: 7, blurb_de: "Läuft es? Status & Logs prüfen." }
+   ```
+
+2. **`goals.yaml` + `tools.yaml`:** optionales Feld `stages: [<flow-id>…]`. Ein mehrstufiges Ziel (z. B. `bug-beheben`) trägt `stages: [plan, code, pr-ci, deploy]`. Fehlt das Feld, taucht der Eintrag nicht im Fluss-Band auf (nur im Katalog) — abwärtskompatibel.
+
+3. **`components.yaml`:** pro Baustein zwei neue Felder:
+   - `theme: <domain-id>` — die zuständige Domäne (= Akzentfarbe & impliziter Agent). Referenz auf `themes.yaml`.
+   - `area: brand | cluster | cross-cutting` — Platzierung auf der Gebietskarte.
+   - bestehendes `links: []` wird genutzt, um auf relevante `goals`/`tools`-IDs zu zeigen (Drill-Ziel beim Klick auf einen Knoten).
+   `sensitivity` (existiert bereits) liefert das Gefahren-Badge.
+
+4. **`scripts/agent-guide/emit-webapp.mjs`:** emittiert einen neuen `map`-Block in `website/src/lib/agent-guide.generated.json`:
+   ```jsonc
+   "map": {
+     "flow":      [ { "id":"plan","label_de":"Plan","emoji":"📋","danger":"caution","blurb_de":"…","goalIds":[…],"toolIds":[…] }, … ],
+     "territory": { "brands":[…components…], "cluster":[…], "crossCutting":[…] }   // je Knoten: slug, name, emoji, theme(+accent), sensitivity, linkIds
+   }
+   ```
+   Die `goalIds`/`toolIds` je Station werden aus `stages` rückwärts aufgelöst (Emitter-seitig), damit die UI keinen Join machen muss.
+
+5. **`scripts/agent-guide/validate.mjs`:** prüft, dass jede `stages`-ID in `flow.yaml`, jedes `components.theme` in `themes.yaml` und jede `links`/`goalIds`/`toolIds`-ID existiert; warnt, wenn eine Flow-Station **keine** Karte hat (Content-Lücke).
+
+## Rendern & Interaktion
+
+- **Neu: `website/src/components/assistant/agent-guide/GuideMap.svelte`** — rendert Fluss-Band + Gebietskarte aus `map`. Emittiert ein `select`-Event `{kind:'flow'|'node', id}`.
+- **`AgentGuideView.svelte`:** mountet `<GuideMap>` oberhalb von `<GuideFindBar>`; hält `mapFilter`-State; reicht ihn an die bestehende Filter-Pipeline weiter.
+- **`agentGuideSearch.ts`:** `filterEntries` bekommt ein zusätzliches Prädikat `matchesMapFilter(entry, mapFilter)` — Komposition mit Text/Tier/Theme bleibt multiplikativ. Keine Änderung an der Such-Normalisierung.
+- **CSS:** alle Stile in `website/src/styles/sidekick-panels.css` unter `.drawer .ag-map*` (etabliertes nicht-scoped Muster wegen Svelte-5/Vite-CSS-Pruning).
+- **Klapp-Zustand:** `ag-map-v1` in `localStorage`, gleiches debounced-write-Muster wie `ag-open-v1`.
+
+## Lehren (Teaching-Glue)
+
+- **Glossar-Tooltips:** Begriffe, die einer `glossary.yaml`-ID entsprechen, werden in Karten- und Karten-Texten als Chip mit gepunktetem Unterstrich gerendert; Hover/Tap öffnet ein kleines Popover mit der deutschen Definition. Tastatur- und Screenreader-zugänglich (`aria-describedby`, fokussierbar). Umsetzung als kleiner, testbarer Svelte-Wrapper `GlossaryTerm.svelte`.
+- **Konzept-Zeile:** Jede Ziel-Karte bekommt eine optionale einzeilige `concept_de`-Erklärung („Konzept: ein *Skill* ist …"). Fehlt sie, fällt die UI auf die `summary_de` des ersten verlinkten Tools zurück.
+
+## Onboarding & Polish
+
+- **First-Run:** Sind keine `ag-*`-Keys in `localStorage`, startet die Karte **aufgeklappt** mit Hinweis *„Neu hier? Folge dem Band von links."* Danach respektiert sie den gemerkten Zustand.
+- **Dark-Reskin:** nutzt die vorhandenen Tokens; Domänen-Akzente sind kühle Hues (aus `themes.yaml`), die nie mit der warmen Gefahren-Rampe kollidieren.
+- **Farbblind-Sicherheit:** Gefahrenstufe immer redundant (Emoji-Punkt **+** Rand **+** Badge-Text), Domäne über Akzent **plus** Label — nie Farbe allein.
+
+## Content coverage
+
+Eine Inhalts-Audit stellt sicher, dass **jede Flow-Station ≥1 Ziel/Tool** und **jeder Gebiets-Knoten einen Erklärtext** hat. Erwartete Ergänzungen (per `validate.mjs`-Warnung getrieben): Stationen `pr-ci` und `live` brauchen voraussichtlich neue Ziele (z. B. „PR öffnen & CI grün bekommen", „Prüfen ob mein Deploy live ist / Logs lesen"). Bausteine in `components.yaml` werden mit `theme`/`area`/`links` vervollständigt.
+
+## Testing
+
+- **Registry/Emitter:** `validate.test.mjs` (neue Felder, Referenz-Integrität, „leere Station"-Warnung), `emit-webapp.test.mjs` (der `map`-Block wird korrekt geformt).
+- **Such-Logik:** `agentGuideSearch.test.ts` — `mapFilter` komponiert korrekt mit Text/Tier/Theme; Zurücksetzen funktioniert.
+- **E2E (`tests/e2e/specs/agent-guide-walkthrough.spec.ts`):** Karte rendert (Fluss-Band + Gebietskarte sichtbar); Klick auf Station filtert Katalog + scrollt; Klick auf Knoten filtert; Glossar-Tooltip öffnet per Klick & Tastatur; Karte einklappen → Zustand bleibt nach Reload. Film-Modus-Schritt ergänzt.
+- **CI-Gate:** committetes `agent-guide.generated.json` muss weiterhin dem Emitter-Output entsprechen (`task test:agent-guide` + Inventory-Check).
+
+## Out of Scope / Non-Goals
+
+- **Kein** Mode-Split „Lernen/Nachschlagen" (Variante B verworfen) — die Karte ist wegklappbar, das genügt.
+- **Kein** Feature-Flag — der Umbau ist Inhalt + UI und additiv; die Referenzansicht bleibt jederzeit funktionsfähig.
+- **Keine** Änderung an den agent-readable Maps unter `docs/agent-guide/maps/` (`task agent-guide:maps`) — die sind für Agenten, nicht für diese visuelle Karte. Bleibt unangetastet.
+- **Kein** Umbau der Such-Normalisierung oder der bestehenden Achsen (Thema/Gefahr/Art bleiben).
+- Der **kollaborative Brainstorm-Tunnel** (gekko schaut/macht mit) ist eine **separate** Arbeit (eigener Spec, später).
+
+## Risiko
+
+Niedrig: jede Änderung ist additiv auf einer gut getesteten SSOT→Emitter→UI-Pipeline. Der Katalog funktioniert auch bei eingeklappter / fehlerhafter Karte weiter. Ein PR, kein Flag.

--- a/scripts/agent-guide/emit-webapp.mjs
+++ b/scripts/agent-guide/emit-webapp.mjs
@@ -6,6 +6,7 @@ import { fileURLToPath } from 'node:url';
 import { dirname, resolve, join } from 'node:path';
 import { validateRegistry } from './validate.mjs';
 import { parse as parseYaml } from 'yaml';
+import { TERRITORY_AREAS } from './map-areas.mjs';
 
 /** Fixed per-tier palette (emitter-owned, §6.4). AA-contrast against the #0f1623 drawer. */
 const TIER_COLORS = {
@@ -84,6 +85,7 @@ export function buildWebappData(registryDir) {
     aliases_de: t.aliases_de ?? [],
     common: t.common === true,
     order: t.order ?? 999,
+    stages: t.stages ?? [],
     ...(t.init_prompt_de ? { init_prompt_de: t.init_prompt_de } : {}),
     ...(t.danger === 'forbidden' ? { escalate_to_de: t.escalate_to_de ?? 'Patrick' } : {}),
   }));
@@ -107,9 +109,13 @@ export function buildWebappData(registryDir) {
     aliases_de: g.aliases_de ?? [],
     common: g.common === true,
     order: g.order ?? 999,
+    stages: g.stages ?? [],
+    // Only apply the tool-summary fallback for non-forbidden goals (forbidden goals have no teaching concept).
+    concept_de: g.concept_de ?? (g.danger !== 'forbidden' && g.flow?.[0] ? (toolById(g.flow[0].tool)?.summary_de ?? '') : ''),
     ...(g.danger === 'forbidden' ? { escalate_to_de: g.escalate_to_de ?? 'Patrick' } : {}),
   }));
 
+  const themeAccent = (id) => themes.find((t) => t.id === id)?.accent ?? '#888888';
   const components = {};
   for (const c of reg.components) {
     components[c.slug] = {
@@ -120,8 +126,35 @@ export function buildWebappData(registryDir) {
       summary_de: c.summary_de,
       sensitivity: c.sensitivity,
       url: c.url,
+      ...(c.area ? { area: c.area } : {}),
+      ...(c.theme ? { theme: c.theme } : {}),
+      ...(c.relates_to ? { relates_to: c.relates_to } : {}),
     };
   }
+
+  const flowRaw = loadOptionalList(registryDir, 'flow');
+  const flowStations = flowRaw
+    .map((s) => ({
+      id: s.id, label_de: s.label_de, emoji: s.emoji, danger: s.danger,
+      order: s.order ?? 999, blurb_de: s.blurb_de ?? '',
+      goalIds: reg.goals.filter((g) => (g.stages ?? []).includes(s.id)).map((g) => g.id),
+      toolIds: reg.tools.filter((t) => (t.stages ?? []).includes(s.id)).map((t) => t.id),
+    }))
+    .sort((a, b) => a.order - b.order);
+
+  const territory = TERRITORY_AREAS
+    .map((a) => ({
+      id: a.id, label_de: a.label_de, order: a.order,
+      nodes: reg.components
+        .filter((c) => c.area === a.id)
+        .map((c) => ({
+          slug: c.slug, name: c.name, emoji: c.emoji, sensitivity: c.sensitivity,
+          theme: c.theme ?? null, accent: c.theme ? themeAccent(c.theme) : '#888888',
+          relatesTo: c.relates_to ?? [],
+        })),
+    }));
+
+  const map = { flow: flowStations, territory };
 
   return {
     $schema: 'agent-guide.generated/v1',
@@ -132,6 +165,7 @@ export function buildWebappData(registryDir) {
     goals,
     tools,
     components,
+    map,
   };
 }
 

--- a/scripts/agent-guide/emit-webapp.test.mjs
+++ b/scripts/agent-guide/emit-webapp.test.mjs
@@ -90,13 +90,15 @@ test('buildWebappData: emits all four taxonomy tiers each with a non-empty color
   assert.ok(!('enforcement_default' in data.taxonomy[0]));
 });
 
-test('buildWebappData: keys components by slug with only the §6.1 fields', () => {
+test('buildWebappData: keys components by slug with the base fields (+ optional map fields)', () => {
   const data = buildWebappData(fixtureRegistry());
   assert.ok(data.components.keycloak, 'components is an object keyed by slug');
   const kc = data.components.keycloak;
-  assert.deepEqual(Object.keys(kc).sort(),
-    ['emoji', 'kind', 'name', 'sensitivity', 'slug', 'summary_de', 'url']);
+  const BASE = ['emoji', 'kind', 'name', 'sensitivity', 'slug', 'summary_de', 'url'];
+  for (const k of BASE) assert.ok(k in kc, `component keeps base field '${k}'`);
   assert.equal(kc.sensitivity, 'assisted');
+  // The fixture component has no area/theme/relates_to → those keys must be ABSENT.
+  assert.ok(!('area' in kc) && !('theme' in kc) && !('relates_to' in kc));
   // what_for_de / placeholder_en / links are NOT needed by S2 → dropped
   assert.ok(!('what_for_de' in kc));
   assert.ok(!('placeholder_en' in kc));
@@ -262,4 +264,71 @@ test('buildWebappData includes init_prompt_de when present and omits it when abs
   assert.ok(!('init_prompt_de' in website), 'absent field must not be emitted as a key');
 });
 
+// ── Map block (flow ribbon + territory) ──────────────────────────────────────
+function fixtureRegistryMapped() {
+  const dir = fixtureRegistryThemed();
+  writeFileSync(join(dir, 'flow.yaml'), [
+    '- { id: idee, label_de: "Idee", emoji: "💡", danger: safe, order: 1, blurb_de: "PR Idee." }',
+    '- { id: plan, label_de: "Plan", emoji: "📋", danger: caution, order: 2, blurb_de: "Plan ENV." }',
+    '',
+  ].join('\n'));
+  // give the themed goal a stage + concept, the plan tool a stage
+  writeFileSync(join(dir, 'goals.yaml'), [
+    '- id: change-website-text',
+    '  title_de: "Ich will den Text auf der Website ändern"',
+    '  when_de: "Wenn etwas Falsches dasteht."', '  danger: safe',
+    '  theme: website', '  one_liner_de: "Text korrigieren."',
+    '  concept_de: "Konzept: ein PR ist ein Änderungsvorschlag."',
+    '  stages: [plan]',
+    '  flow:', '    - { tool: agent-website, note_de: "Sag ihm, welche Seite." }',
+    '  example_prompt_de: "Ändere die Überschrift."',
+    '  guardrails: [G-ENV-EXPLICIT]', '  related: []', '',
+  ].join('\n'));
+  // tag keycloak onto the map; mailpit stays off-map
+  writeFileSync(join(dir, 'components.yaml'), [
+    '- { slug: keycloak, kind: software, name: "Keycloak", emoji: "🔐", summary_de: "SSO.", what_for_de: "x", placeholder_en: "x", sensitivity: assisted, url: "https://auth", links: [], area: plattform, theme: website, relates_to: [change-website-text] }',
+    '- { slug: mailpit,  kind: software, name: "Mailpit",  emoji: "📭", summary_de: "Test.", what_for_de: "x", placeholder_en: "x", sensitivity: safe, url: "https://mail", links: [] }',
+    '',
+  ].join('\n'));
+  return dir;
+}
+
+test('buildWebappData: emits a map.flow ordered by station order with resolved goal/tool ids', () => {
+  const data = buildWebappData(fixtureRegistryMapped());
+  assert.ok(data.map && Array.isArray(data.map.flow));
+  assert.deepEqual(data.map.flow.map((s) => s.id), ['idee', 'plan']);
+  const plan = data.map.flow.find((s) => s.id === 'plan');
+  assert.equal(plan.label_de, 'Plan');
+  assert.equal(plan.danger, 'caution');
+  assert.deepEqual(plan.goalIds, ['change-website-text']);
+  assert.deepEqual(data.map.flow.find((s) => s.id === 'idee').goalIds, []);
+});
+
+test('buildWebappData: emits map.territory areas with only opted-in components, carrying accent', () => {
+  const data = buildWebappData(fixtureRegistryMapped());
+  const plattform = data.map.territory.find((a) => a.id === 'plattform');
+  assert.ok(plattform, 'plattform area present');
+  assert.deepEqual(plattform.nodes.map((n) => n.slug), ['keycloak']);
+  const kc = plattform.nodes[0];
+  assert.equal(kc.sensitivity, 'assisted');
+  assert.equal(kc.theme, 'website');
+  assert.equal(kc.accent, '#4a9eff');                 // resolved from themes.yaml
+  assert.deepEqual(kc.relatesTo, ['change-website-text']);
+  // mailpit has no area → must not appear anywhere in territory
+  const allSlugs = data.map.territory.flatMap((a) => a.nodes.map((n) => n.slug));
+  assert.ok(!allSlugs.includes('mailpit'));
+});
+
+test('buildWebappData: passes stages + concept_de onto goals', () => {
+  const data = buildWebappData(fixtureRegistryMapped());
+  const g = data.goals.find((x) => x.id === 'change-website-text');
+  assert.deepEqual(g.stages, ['plan']);
+  assert.equal(g.concept_de, 'Konzept: ein PR ist ein Änderungsvorschlag.');
+});
+
+test('buildWebappData: tolerates a registry with no flow.yaml (empty map.flow)', () => {
+  const data = buildWebappData(globalThis.__agFixtureRegistry());
+  assert.deepEqual(data.map.flow, []);
+  assert.ok(Array.isArray(data.map.territory));
+});
 

--- a/scripts/agent-guide/fixtures/bad-stage-ref/components.yaml
+++ b/scripts/agent-guide/fixtures/bad-stage-ref/components.yaml
@@ -1,0 +1,10 @@
+- slug: keycloak
+  kind: software
+  name: "Keycloak"
+  emoji: "🔑"
+  summary_de: "Die zentrale Anmeldung für alle Dienste."
+  what_for_de: "Ein Login (Single Sign-On) für die ganze Plattform."
+  placeholder_en: "SSO / OIDC identity provider"
+  sensitivity: forbidden
+  url: null
+  links: []

--- a/scripts/agent-guide/fixtures/bad-stage-ref/flow.yaml
+++ b/scripts/agent-guide/fixtures/bad-stage-ref/flow.yaml
@@ -1,0 +1,1 @@
+- { id: plan, label_de: "Plan", emoji: "📋", danger: caution, order: 1, blurb_de: "x" }

--- a/scripts/agent-guide/fixtures/bad-stage-ref/goals.yaml
+++ b/scripts/agent-guide/fixtures/bad-stage-ref/goals.yaml
@@ -1,0 +1,11 @@
+- id: bug-beheben
+  title_de: "Ich will einen Fehler beheben"
+  when_de: "Etwas funktioniert nicht wie erwartet."
+  flow:
+    - tool: dev-flow-plan
+      note_de: "Beschreibe den Fehler."
+  example_prompt_de: "Der Login-Button tut nichts. Bitte finde und behebe den Fehler."
+  danger: caution
+  guardrails: [G-ENV-EXPLICIT]
+  related: []
+  stages: [does-not-exist]

--- a/scripts/agent-guide/fixtures/bad-stage-ref/guardrails.yaml
+++ b/scripts/agent-guide/fixtures/bad-stage-ref/guardrails.yaml
@@ -1,0 +1,5 @@
+- id: G-ENV-EXPLICIT
+  name_de: "ENV immer setzen"
+  rule_de: "Setze bei jedem Deploy ENV= explizit."
+  why_de: "Sonst trifft der Befehl die falsche Umgebung."
+  enforced_by: docs-only

--- a/scripts/agent-guide/fixtures/bad-stage-ref/taxonomy.yaml
+++ b/scripts/agent-guide/fixtures/bad-stage-ref/taxonomy.yaml
@@ -1,0 +1,24 @@
+- id: safe
+  label_de: "🟢 Sicher"
+  emoji: "🟢"
+  meaning_de: "Selbst machen, keine Gefahr."
+  doc_treatment: "green-badge"
+  enforcement_default: "none"
+- id: caution
+  label_de: "🟡 Vorsicht"
+  emoji: "🟡"
+  meaning_de: "Checkliste abarbeiten, Agent bestätigt."
+  doc_treatment: "yellow-badge"
+  enforcement_default: "pre-flight-confirm"
+- id: assisted
+  label_de: "🟠 Nur mit Hilfe"
+  emoji: "🟠"
+  meaning_de: "Mit erfahrener Person."
+  doc_treatment: "orange-warning"
+  enforcement_default: "double-confirm"
+- id: forbidden
+  label_de: "🔴 Niemals allein"
+  emoji: "🔴"
+  meaning_de: "Von Enforcement blockiert."
+  doc_treatment: "red-stop"
+  enforcement_default: "hard-block"

--- a/scripts/agent-guide/fixtures/bad-stage-ref/tools.yaml
+++ b/scripts/agent-guide/fixtures/bad-stage-ref/tools.yaml
@@ -1,0 +1,11 @@
+- id: dev-flow-plan
+  name_de: "Planungs-Skill"
+  kind: skill
+  summary_de: "Wählt den Pfad und schreibt den Plan."
+  what_for_de: "Startpunkt für jede Änderung."
+  how_to_start_de: "Beschreibe einfach, was du ändern willst."
+  what_could_go_wrong_de: "Nichts — er stoppt vor der Umsetzung."
+  danger: caution
+  guardrails: [G-ENV-EXPLICIT]
+  related: []
+  links: []

--- a/scripts/agent-guide/map-areas.mjs
+++ b/scripts/agent-guide/map-areas.mjs
@@ -1,0 +1,9 @@
+// scripts/agent-guide/map-areas.mjs
+// Emitter-owned presentation metadata for the territory map lanes.
+// Components opt onto the map by setting `area: <one of these ids>`.
+export const TERRITORY_AREAS = [
+  { id: 'dienste',   label_de: 'Dienste',             order: 1 },
+  { id: 'plattform', label_de: 'Plattform & Cluster', order: 2 },
+  { id: 'daten',     label_de: 'Daten & Geheimnisse', order: 3 },
+];
+export const TERRITORY_AREA_IDS = new Set(TERRITORY_AREAS.map((a) => a.id));

--- a/scripts/agent-guide/validate.mjs
+++ b/scripts/agent-guide/validate.mjs
@@ -1,6 +1,7 @@
 import { readFileSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { parse } from 'yaml';
+import { TERRITORY_AREA_IDS } from './map-areas.mjs';
 
 const TAXONOMY_REQUIRED = ['safe', 'caution', 'assisted', 'forbidden'];
 const TOOL_KINDS = ['skill', 'agent', 'task'];
@@ -24,6 +25,7 @@ function migrationSlugs(repoRoot) {
 
 export function validateRegistry(dir, repoRoot = null) {
   const errors = [];
+  const warnings = [];
   const req = (cond, msg) => { if (!cond) errors.push(msg); };
 
   const taxonomy = load(dir, 'taxonomy.yaml');
@@ -39,6 +41,19 @@ export function validateRegistry(dir, repoRoot = null) {
   const taxIds = new Set(taxonomy.map((t) => t.id));
   const grIds = new Set(guardrails.map((g) => g.id));
   const toolIds = new Set(tools.map((t) => t.id));
+
+  let flow = [];
+  try { flow = load(dir, 'flow.yaml'); } catch { flow = []; }
+  const flowIds = new Set((flow ?? []).map((f) => f && f.id));
+
+  const goalIdSet = new Set(goals.map((g) => g.id));
+  const cardIdSet = new Set([...goalIdSet, ...toolIds]); // valid relates_to / drill targets
+
+  for (const f of flow ?? []) {
+    for (const k of ['id', 'label_de', 'emoji', 'danger', 'order', 'blurb_de'])
+      req(f?.[k] !== undefined && f?.[k] !== null, `flow[${f?.id}]: missing '${k}'`);
+    if (f?.danger) req(taxIds.has(f.danger), `flow[${f?.id}]: danger '${f.danger}' not in taxonomy`);
+  }
 
   for (const id of TAXONOMY_REQUIRED) req(taxIds.has(id), `taxonomy: missing required tier '${id}'`);
   for (const t of taxonomy)
@@ -80,6 +95,8 @@ export function validateRegistry(dir, repoRoot = null) {
       if (l && typeof l === 'object')
         req(typeof l.url === 'string' && l.url.length > 0, `${label}: link has empty 'url'`);
     }
+    for (const s of card?.stages ?? [])
+      req(flowIds.size === 0 || flowIds.has(s), `${label}: stages ref '${s}' not in flow.yaml`);
   };
   for (const t of tools) checkCardExtras(t, `tools[${t?.id}]`);
   for (const g of goals) checkCardExtras(g, `goals[${g?.id}]`);
@@ -90,6 +107,12 @@ export function validateRegistry(dir, repoRoot = null) {
     req(['software', 'hardware'].includes(c?.kind), `components[${c?.slug}]: bad kind '${c?.kind}'`);
     req((c?.summary_de ?? '').length <= 140, `components[${c?.slug}]: summary_de > 140 chars`);
     req(taxIds.has(c?.sensitivity), `components[${c?.slug}]: sensitivity '${c?.sensitivity}' not in taxonomy`);
+    if (c?.area !== undefined && c?.area !== null)
+      req(TERRITORY_AREA_IDS.has(c.area), `components[${c?.slug}]: area '${c.area}' not a known territory area`);
+    if (c?.theme !== undefined && c?.theme !== null && themeIds.size > 0)
+      req(themeIds.has(c.theme), `components[${c?.slug}]: theme '${c.theme}' not in themes.yaml`);
+    for (const rid of c?.relates_to ?? [])
+      req(cardIdSet.has(rid), `components[${c?.slug}]: relates_to '${rid}' not a known goal/tool id`);
   }
 
   if (repoRoot) {
@@ -99,13 +122,21 @@ export function validateRegistry(dir, repoRoot = null) {
     for (const s of compSlugs) req(dbSlugs.has(s), `components: registry slug '${s}' not in any migration`);
   }
 
-  return { ok: errors.length === 0, errors };
+  if (flowIds.size > 0) {
+    const usedStages = new Set();
+    for (const card of [...goals, ...tools])
+      for (const s of card?.stages ?? []) usedStages.add(s);
+    for (const f of flow) if (!usedStages.has(f.id)) warnings.push(`flow station '${f.id}' has no goal/tool (stages)`);
+  }
+
+  return { ok: errors.length === 0, errors, warnings };
 }
 
 // CLI: validate the real registry (with DB slug cross-check) and exit non-zero on failure.
 if (import.meta.url === `file://${process.argv[1]}`) {
   const repoRoot = process.cwd();
   const res = validateRegistry(join(repoRoot, 'docs', 'agent-guide', 'registry'), repoRoot);
+  for (const w of res.warnings ?? []) console.warn('⚠', w);
   if (!res.ok) { for (const e of res.errors) console.error('✗', e); process.exit(1); }
   console.log('✓ agent-guide registry valid');
 }

--- a/scripts/agent-guide/validate.test.mjs
+++ b/scripts/agent-guide/validate.test.mjs
@@ -50,3 +50,18 @@ test('a short init_prompt_de in the good fixture would validate', () => {
   assert.equal(res.ok, true, JSON.stringify(res.errors, null, 2));
 });
 
+test('dangling stages reference is rejected', () => {
+  const res = validateRegistry(join(here, 'fixtures', 'bad-stage-ref'));
+  assert.equal(res.ok, false);
+  assert.ok(
+    res.errors.some((e) => e.includes('stages') && e.includes('does-not-exist')),
+    `expected a stages-ref error, got: ${JSON.stringify(res.errors)}`,
+  );
+});
+
+test('good fixture still validates with a flow.yaml present', () => {
+  // good fixture has no flow.yaml → flow checks are skipped, not errors
+  const res = validateRegistry(join(here, 'fixtures', 'good'));
+  assert.equal(res.ok, true, JSON.stringify(res.errors, null, 2));
+});
+

--- a/tests/e2e/lib/agent-guide.ts
+++ b/tests/e2e/lib/agent-guide.ts
@@ -57,6 +57,8 @@ export interface Goal {
   aliases_de: string[];
   common: boolean;
   order: number;
+  stages: string[];
+  concept_de?: string;
   escalate_to_de?: string;
 }
 
@@ -77,7 +79,41 @@ export interface Tool {
   aliases_de: string[];
   common: boolean;
   order: number;
+  stages: string[];
   escalate_to_de?: string;
+}
+
+export interface FlowStation {
+  id: string;
+  label_de: string;
+  emoji: string;
+  danger: string;
+  order: number;
+  blurb_de: string;
+  goalIds: string[];
+  toolIds: string[];
+}
+
+export interface TerritoryNode {
+  slug: string;
+  name: string;
+  emoji: string;
+  sensitivity: string;
+  theme: string | null;
+  accent: string;
+  relatesTo: string[];
+}
+
+export interface TerritoryArea {
+  id: string;
+  label_de: string;
+  order: number;
+  nodes: TerritoryNode[];
+}
+
+export interface MapData {
+  flow: FlowStation[];
+  territory: TerritoryArea[];
 }
 
 export interface GuideData {
@@ -86,6 +122,7 @@ export interface GuideData {
   taxonomy: TierEntry[];
   themes: Theme[];
   glossary: GlossaryEntry[];
+  map: MapData;
 }
 
 export function loadGuideData(): GuideData {
@@ -97,6 +134,7 @@ export function loadGuideData(): GuideData {
     taxonomy: raw.taxonomy as TierEntry[],
     themes: raw.themes as Theme[],
     glossary: raw.glossary as GlossaryEntry[],
+    map: (raw.map ?? { flow: [], territory: [] }) as MapData,
   };
 }
 
@@ -140,6 +178,18 @@ export async function openAgentGuide(page: Page) {
   const body = page.locator('.ag-body');
   await expect(body).toBeVisible({ timeout: 5_000 });
   return body;
+}
+
+/** Ensures the mental-model map is expanded; returns the .ag-map locator. */
+export async function ensureMapOpen(page: Page) {
+  const toggle = page.locator('.ag-map-toggle');
+  if (await toggle.count()) {
+    const open = await toggle.getAttribute('aria-expanded');
+    if (open !== 'true') await toggle.click();
+  }
+  const map = page.locator('.ag-map');
+  await expect(map).toBeVisible({ timeout: 5_000 });
+  return map;
 }
 
 /** Injects a fixed-position film banner into the page (removed after next step). */

--- a/tests/e2e/specs/agent-guide-walkthrough.spec.ts
+++ b/tests/e2e/specs/agent-guide-walkthrough.spec.ts
@@ -4,11 +4,11 @@
  * No login required — PortalSidekick is on the public Layout.astro.
  */
 import { test, expect } from '@playwright/test';
-import { openAgentGuide, expandCardByTitle, loadGuideData, showFilmBanner, removeFilmBanner } from '../lib/agent-guide';
+import { openAgentGuide, expandCardByTitle, loadGuideData, ensureMapOpen, showFilmBanner, removeFilmBanner } from '../lib/agent-guide';
 
 const FILM = !!process.env.AG_FILM;
 const FILM_PAUSE = 1500;
-const { goals, tools, taxonomy, themes, glossary } = loadGuideData();
+const { goals, tools, taxonomy, themes, glossary, map } = loadGuideData();
 
 test('öffnet die Agent-Anleitung und zeigt den Titel', async ({ page }) => {
   await openAgentGuide(page);
@@ -140,3 +140,54 @@ if (FILM) {
     await removeFilmBanner(page);
   });
 }
+
+test('Mental-Model-Karte zeigt Fluss-Band und Gebietskarte', async ({ page }) => {
+  await openAgentGuide(page);
+  await ensureMapOpen(page);
+  await expect(page.locator('.ag-flow-station')).toHaveCount(map.flow.length);
+  await expect(page.locator('.ag-terr-node').first()).toBeVisible();
+});
+
+test('Klick auf eine Fluss-Station filtert den Katalog', async ({ page }) => {
+  await openAgentGuide(page);
+  await ensureMapOpen(page);
+  const plan = map.flow.find(s => s.id === 'plan')!;
+  await page.locator('.ag-flow-station', { hasText: plan.label_de }).click();
+  await expect(page.locator('.ag-mapfilter-chip')).toBeVisible();
+  // a known plan goal card is present, an unrelated live goal is not
+  await expect(page.locator('.ag-name', { hasText: 'Fehler beheben' })).toBeVisible();
+  await expect(page.locator('.ag-name', { hasText: 'Dienste laufen' })).toHaveCount(0);
+});
+
+test('Klick auf einen Baustein filtert auf seine verknüpften Karten', async ({ page }) => {
+  await openAgentGuide(page);
+  await ensureMapOpen(page);
+  const node = map.territory.flatMap(a => a.nodes).find(n => n.relatesTo.length > 0)!;
+  await page.locator('.ag-terr-node', { hasText: node.name }).first().click();
+  await expect(page.locator('.ag-mapfilter-chip')).toBeVisible();
+  await expect(page.locator('.ag-card-head')).toHaveCount(node.relatesTo.length);
+});
+
+test('Konzept-Zeile + Glossar-Tooltip auf einer Ziel-Karte', async ({ page }) => {
+  await openAgentGuide(page);
+  const conceptGoal = goals.find(g => g.concept_de)!;
+  const card = await expandCardByTitle(page, conceptGoal.title_de);
+  await expect(card.locator('.ag-concept')).toBeVisible();
+  const gloss = card.locator('.ag-gloss').first();
+  if (await gloss.count()) {
+    await gloss.click();
+    await expect(card.locator('.ag-gloss-pop').first()).toBeVisible();
+  }
+});
+
+test('Karte einklappen bleibt nach Reload erhalten', async ({ page }) => {
+  await openAgentGuide(page);
+  await ensureMapOpen(page);
+  await page.locator('.ag-map-toggle').click();                    // collapse
+  await expect(page.locator('.ag-map')).toHaveCount(0);
+  await page.reload();
+  await page.waitForLoadState('networkidle');
+  // re-open drawer + guide after reload, then assert the map stayed collapsed
+  await openAgentGuide(page);
+  await expect(page.locator('.ag-map-toggle')).toHaveAttribute('aria-expanded', 'false');
+});

--- a/website/src/components/assistant/AgentGuideView.svelte
+++ b/website/src/components/assistant/AgentGuideView.svelte
@@ -1,13 +1,14 @@
 <script lang="ts">
   import { onMount, untrack } from 'svelte';
-  import { goals, tools, taxonomy, themes, glossary, tierColor, tierEmoji } from '../../lib/agentGuide';
+  import { goals, tools, taxonomy, themes, glossary, guideMap, tierColor, tierEmoji } from '../../lib/agentGuide';
   import {
-    buildEntries, filterEntries, groupBy, sortCommonFirst, normalize, MIN_QUERY,
-    type Axis, type GuideEntry,
+    buildEntries, filterEntries, groupBy, sortCommonFirst, normalize, mapFilterIds, MIN_QUERY,
+    type Axis, type GuideEntry, type MapFilter,
   } from '../../lib/agentGuideSearch';
   import GuideFindBar from './agent-guide/GuideFindBar.svelte';
   import GuideGroup from './agent-guide/GuideGroup.svelte';
   import GuideCard from './agent-guide/GuideCard.svelte';
+  import GuideMap from './agent-guide/GuideMap.svelte';
 
   // ── Cross-link lookup: id → human label/kind/danger/domId ──────────────────
   const lookup: Record<string, { label: string; kind: string; danger: string; domId: string }> = {};
@@ -37,6 +38,10 @@
   let domainFilter = $state<string | null>(null);       // null = all (theme-based)
   let copiedId = $state<string | null>(null);
   let glossaryOpen = $state(false);
+  let mapFilter = $state<MapFilter>(null);
+  let mapOpen = $state(true);
+  const MAP_KEY = 'ag-map-v1';
+  const glossTerms = glossary.map(g => g.term);
 
   const OPEN_KEY = 'ag-open-v1';
   const AXIS_KEY = 'ag-axis-v1';
@@ -50,6 +55,9 @@
       if (rawOpen) expanded = new Set(JSON.parse(rawOpen) as string[]);
       const rawAxis = localStorage.getItem(AXIS_KEY);
       if (rawAxis === 'thema' || rawAxis === 'gefahr' || rawAxis === 'art') axis = rawAxis as Axis;
+      const rawMap = localStorage.getItem(MAP_KEY);
+      if (rawMap === 'open' || rawMap === 'closed') mapOpen = rawMap === 'open';
+      else mapOpen = true; // first run: map open to onboard newcomers
     } catch { /* ignore */ }
     hydrated = true;   // gate the persist effects so they never clobber saved state
   });
@@ -65,13 +73,16 @@
     }, 250);
   });
   $effect(() => { if (hydrated) { try { localStorage.setItem(AXIS_KEY, axis); } catch { /* ignore */ } } });
+  $effect(() => { if (hydrated) { try { localStorage.setItem(MAP_KEY, mapOpen ? 'open' : 'closed'); } catch { /* ignore */ } } });
 
   // ── Derivations ──────────────────────────────────────────────────────────────
   const searching = $derived(query.trim().length >= MIN_QUERY);
 
-  // domain + tier pre-filter (applied before text search for tier counts)
+  // domain + tier + map pre-filter (applied before text search for tier counts)
+  const allowedByMap = $derived(mapFilterIds(mapFilter, guideMap)); // Set<string> | null
   const preFiltered = $derived(
     ALL.filter(e =>
+      (allowedByMap === null || allowedByMap.has(e.id)) &&
       (domainFilter === null || e.theme === domainFilter) &&
       (tierFilter.size === 0 || tierFilter.has(e.danger)),
     ),
@@ -154,6 +165,16 @@
       setTimeout(() => el.classList.remove('ag-flash'), 900);
     });
   }
+
+  function selectMap(sel: MapFilter) {
+    mapFilter = sel;
+    if (!sel) return;
+    requestAnimationFrame(() => {
+      document.querySelector('.ag-findbar')?.scrollIntoView({
+        behavior: prefersReducedMotion() ? 'auto' : 'smooth', block: 'start',
+      });
+    });
+  }
 </script>
 
 <div class="ag-body">
@@ -162,6 +183,25 @@
     <h3 class="ag-title">Ich will … — welches Werkzeug nehme ich?</h3>
     <p class="ag-desc">Gruppiert nach Thema. Tippe ≥ 3 Zeichen zum Suchen. Die Farbe zeigt, wie vorsichtig Du sein musst.</p>
   </div>
+
+  {#if guideMap.flow.length}
+    <section class="ag-map-section">
+      <button type="button" class="ag-map-toggle" aria-expanded={mapOpen} onclick={() => (mapOpen = !mapOpen)}>
+        <span class="ag-map-toggle-icon" aria-hidden="true">🧭</span>
+        <span class="ag-map-toggle-label">So funktioniert die Plattform</span>
+        <span class="ag-chevron" aria-hidden="true">{mapOpen ? '▾' : '▸'}</span>
+      </button>
+      {#if mapOpen}
+        <p class="ag-map-hint">Neu hier? Folge dem Band von links — klick eine Station oder einen Baustein, um die passenden Karten zu sehen.</p>
+        <GuideMap map={guideMap} active={mapFilter} glossaryTerms={glossTerms} onSelect={selectMap} />
+      {/if}
+      {#if mapFilter}
+        <button type="button" class="ag-mapfilter-chip" onclick={() => (mapFilter = null)}>
+          Gefiltert: {mapFilter.kind === 'flow' ? 'Station' : 'Baustein'} ✕
+        </button>
+      {/if}
+    </section>
+  {/if}
 
   <GuideFindBar
     {taxonomy} {themes} {tierCounts} {query} {axis} {tierFilter} {domainFilter}

--- a/website/src/components/assistant/agent-guide/GlossaryTerm.svelte
+++ b/website/src/components/assistant/agent-guide/GlossaryTerm.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+  let { term, def }: { term: string; def: string } = $props();
+  let open = $state(false);
+</script>
+
+<span class="ag-gloss-wrap">
+  <button
+    type="button"
+    class="ag-gloss"
+    aria-expanded={open}
+    onclick={() => (open = !open)}
+    onmouseenter={() => (open = true)}
+    onmouseleave={() => (open = false)}
+  >{term}</button>
+  {#if open}
+    <span class="ag-gloss-pop" role="note">{def}</span>
+  {/if}
+</span>

--- a/website/src/components/assistant/agent-guide/GuideCard.svelte
+++ b/website/src/components/assistant/agent-guide/GuideCard.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
-  import { tierColor, tierEmoji, tierLabel, tierFor } from '../../../lib/agentGuide';
-  import { highlight, type GuideEntry } from '../../../lib/agentGuideSearch';
+  import { tierColor, tierEmoji, tierLabel, tierFor, glossary } from '../../../lib/agentGuide';
+  import { highlight, splitGlossaryTerms, type GuideEntry } from '../../../lib/agentGuideSearch';
+  import GlossaryTerm from './GlossaryTerm.svelte';
 
   let {
     entry,
@@ -27,6 +28,13 @@
     entry.kind === 'goal'
       ? `${goal!.flow.length} Schritt${goal!.flow.length === 1 ? '' : 'e'}`
       : entry.artLabel,
+  );
+  const glossTerms = glossary.map(g => g.term);
+  const glossDef = (t: string) => glossary.find(g => g.term === t)?.def_de ?? '';
+  const conceptSegs = $derived(
+    entry.kind === 'goal' && goal?.concept_de
+      ? splitGlossaryTerms(goal.concept_de, glossTerms)
+      : [],
   );
 </script>
 
@@ -68,6 +76,11 @@
 
       {#if entry.kind === 'goal'}
         {#if !isForbidden}<p class="ag-when">{goal!.when_de}</p>{/if}
+        {#if conceptSegs.length}
+          <p class="ag-concept">
+            {#each conceptSegs as seg}{#if seg.term}<GlossaryTerm term={seg.term} def={glossDef(seg.term)} />{:else}{seg.text}{/if}{/each}
+          </p>
+        {/if}
         {#if goal!.flow.length}
           <ol class="ag-flow">
             {#each goal!.flow as step, i (i)}

--- a/website/src/components/assistant/agent-guide/GuideMap.svelte
+++ b/website/src/components/assistant/agent-guide/GuideMap.svelte
@@ -1,0 +1,75 @@
+<script lang="ts">
+  import type { MapData } from '../../../lib/agentGuide';
+  import { tierColor, tierEmoji, tierLabel } from '../../../lib/agentGuide';
+
+  let {
+    map,
+    active = null,
+    glossaryTerms = [],
+    onSelect,
+  }: {
+    map: MapData;
+    active?: { kind: 'flow' | 'node'; id: string } | null;
+    glossaryTerms?: string[];
+    onSelect: (sel: { kind: 'flow' | 'node'; id: string; label: string } | null) => void;
+  } = $props();
+
+  const isActive = (kind: 'flow' | 'node', id: string) =>
+    active?.kind === kind && active?.id === id;
+
+  function pick(kind: 'flow' | 'node', id: string, label: string) {
+    if (isActive(kind, id)) onSelect(null);          // toggle off
+    else onSelect({ kind, id, label });
+  }
+</script>
+
+<div class="ag-map" aria-label="So funktioniert die Plattform">
+  <!-- Flow ribbon -->
+  <p class="ag-section-label">Dein Weg: Idee → live</p>
+  <ol class="ag-flowband">
+    {#each map.flow as s, i (s.id)}
+      <li>
+        <button
+          type="button"
+          class="ag-flow-station"
+          class:on={isActive('flow', s.id)}
+          style="--tier: {tierColor(s.danger)}"
+          aria-pressed={isActive('flow', s.id)}
+          title={s.blurb_de}
+          onclick={() => pick('flow', s.id, s.label_de)}
+        >
+          <span aria-hidden="true">{s.emoji}</span>
+          <span class="ag-flow-name">{s.label_de}</span>
+          <span class="ag-sr">– {tierLabel(s.danger)}, {s.goalIds.length + s.toolIds.length} Einträge</span>
+        </button>
+      </li>
+      {#if i < map.flow.length - 1}<li class="ag-flow-arrow" aria-hidden="true">→</li>{/if}
+    {/each}
+  </ol>
+
+  <!-- Territory map -->
+  <p class="ag-section-label">Die Plattform: was läuft wo</p>
+  <div class="ag-territory">
+    {#each map.territory.filter(a => a.nodes.length) as area (area.id)}
+      <div class="ag-terr-area">
+        <span class="ag-terr-label">{area.label_de}</span>
+        <div class="ag-terr-nodes">
+          {#each area.nodes as n (n.slug)}
+            <button
+              type="button"
+              class="ag-terr-node"
+              class:on={isActive('node', n.slug)}
+              style="--accent: {n.accent}; --tier: {tierColor(n.sensitivity)}"
+              aria-pressed={isActive('node', n.slug)}
+              onclick={() => pick('node', n.slug, n.name)}
+            >
+              <span aria-hidden="true">{n.emoji}</span> {n.name}
+              <span aria-hidden="true" class="ag-terr-dot">{tierEmoji(n.sensitivity)}</span>
+              <span class="ag-sr">Gefahrenstufe {tierLabel(n.sensitivity)}</span>
+            </button>
+          {/each}
+        </div>
+      </div>
+    {/each}
+  </div>
+</div>

--- a/website/src/lib/agent-guide.generated.json
+++ b/website/src/lib/agent-guide.generated.json
@@ -182,7 +182,11 @@
         "aendern"
       ],
       "common": true,
-      "order": 1
+      "order": 1,
+      "stages": [
+        "code"
+      ],
+      "concept_de": "Konzept: Inhalte ändert man über einen Branch + PR, nicht direkt auf main."
     },
     {
       "id": "dienst-status-pruefen",
@@ -213,7 +217,11 @@
         "uebersicht"
       ],
       "common": true,
-      "order": 2
+      "order": 2,
+      "stages": [
+        "live"
+      ],
+      "concept_de": "Konzept: Status/Logs lesen ist 🟢 — es verändert nichts."
     },
     {
       "id": "bug-beheben",
@@ -262,7 +270,14 @@
         "fix"
       ],
       "common": true,
-      "order": 3
+      "order": 3,
+      "stages": [
+        "plan",
+        "code",
+        "pr-ci",
+        "deploy"
+      ],
+      "concept_de": "Konzept: erst ein Test, der den Fehler zeigt (TDD), dann der Fix."
     },
     {
       "id": "feature-bauen",
@@ -311,7 +326,14 @@
         "bauen"
       ],
       "common": false,
-      "order": 999
+      "order": 999,
+      "stages": [
+        "plan",
+        "code",
+        "pr-ci",
+        "deploy"
+      ],
+      "concept_de": "Konzept: jede neue Funktion durchläuft Plan → Code → PR → Deploy."
     },
     {
       "id": "aenderung-ausrollen",
@@ -359,7 +381,12 @@
         "release"
       ],
       "common": false,
-      "order": 999
+      "order": 999,
+      "stages": [
+        "deploy",
+        "live"
+      ],
+      "concept_de": "Konzept: Deploy heißt einen gemergten Stand in einer Umgebung (ENV) aktivieren."
     },
     {
       "id": "datenbank-aendern",
@@ -413,7 +440,13 @@
         "sql"
       ],
       "common": false,
-      "order": 999
+      "order": 999,
+      "stages": [
+        "plan",
+        "code",
+        "deploy"
+      ],
+      "concept_de": "Konzept: Schema-Änderungen treffen beide Marken — immer als Migration."
     },
     {
       "id": "secret-aendern",
@@ -457,6 +490,8 @@
       ],
       "common": false,
       "order": 999,
+      "stages": [],
+      "concept_de": "",
       "escalate_to_de": "Patrick"
     },
     {
@@ -512,7 +547,146 @@
       ],
       "common": false,
       "order": 999,
+      "stages": [],
+      "concept_de": "",
       "escalate_to_de": "Patrick"
+    },
+    {
+      "id": "idee-starten",
+      "title_de": "Ich habe eine Idee — wie fange ich an?",
+      "when_de": "Du willst etwas verändern, weißt aber noch nicht, wie der Weg aussieht.",
+      "danger": "safe",
+      "flow": [
+        {
+          "tool": "brainstorming",
+          "tool_name_de": "Brainstorming (/brainstorming)",
+          "note_de": "Beschreibe die Idee; der Brainstorming-Skill schärft sie zu einem Design."
+        },
+        {
+          "tool": "dev-flow-plan",
+          "tool_name_de": "Planungs-Skill (dev-flow-plan)",
+          "note_de": "Danach schreibt der Planungs-Skill einen Schritt-für-Schritt-Plan."
+        }
+      ],
+      "example_prompt_de": "Ich habe eine Idee für die Plattform und möchte sie erst gemeinsam durchdenken.",
+      "guardrails": [
+        {
+          "id": "G-PULL-FIRST",
+          "name_de": "Erst ziehen, dann arbeiten",
+          "rule_de": "Immer 'git pull --rebase origin main' bevor du etwas änderst.",
+          "why_de": "Sonst arbeitest du auf einem veralteten Stand und bekommst Konflikte."
+        }
+      ],
+      "related": [
+        "feature-bauen",
+        "bug-beheben"
+      ],
+      "links": [],
+      "theme": "entwickeln",
+      "one_liner_de": "Von der Idee zum Plan — der erste Schritt.",
+      "aliases_de": [
+        "idee",
+        "anfangen",
+        "start",
+        "neu",
+        "wie"
+      ],
+      "common": true,
+      "order": 6,
+      "stages": [
+        "idee",
+        "brainstorm"
+      ],
+      "concept_de": "Konzept: jede Änderung beginnt mit Brainstorm → Plan, bevor Code entsteht."
+    },
+    {
+      "id": "pr-oeffnen",
+      "title_de": "Ich will einen Pull Request öffnen und CI grün bekommen",
+      "when_de": "Der Code ist fertig und soll als Pull Request geprüft und gemergt werden.",
+      "danger": "assisted",
+      "flow": [
+        {
+          "tool": "dev-flow-execute",
+          "tool_name_de": "Umsetzungs-Skill (dev-flow-execute)",
+          "note_de": "Pusht den Branch, öffnet den PR und wartet, bis die CI-Checks grün sind."
+        }
+      ],
+      "example_prompt_de": "Bitte öffne einen Pull Request für diesen Branch und sag mir, ob die CI grün ist.",
+      "guardrails": [
+        {
+          "id": "G-PR-NOT-MAIN",
+          "name_de": "Nie direkt auf main",
+          "rule_de": "Änderungen immer über einen Branch + Pull Request, niemals direkt nach main pushen.",
+          "why_de": "main ist geschützt; direktes Pushen umgeht Review und CI."
+        }
+      ],
+      "related": [
+        "feature-bauen",
+        "aenderung-ausrollen"
+      ],
+      "links": [],
+      "theme": "entwickeln",
+      "one_liner_de": "Branch als PR einreichen und CI abwarten.",
+      "aliases_de": [
+        "pr",
+        "pull request",
+        "ci",
+        "merge",
+        "review"
+      ],
+      "common": false,
+      "order": 999,
+      "stages": [
+        "pr-ci"
+      ],
+      "concept_de": "Konzept: nichts kommt nach main ohne PR + grüne CI (Squash-Merge)."
+    },
+    {
+      "id": "deploy-pruefen",
+      "title_de": "Ich will prüfen, ob mein Deploy wirklich live ist",
+      "when_de": "Nach einem Deploy willst du sehen, ob die Änderung in der echten Umgebung angekommen ist.",
+      "danger": "safe",
+      "flow": [
+        {
+          "tool": "agent-ops",
+          "tool_name_de": "Betriebs-Agent (ops)",
+          "note_de": "Lässt Pod-Status und Logs prüfen, ob der neue Stand läuft."
+        },
+        {
+          "tool": "dev-flow-e2e",
+          "tool_name_de": "E2E-Test-Skill (dev-flow-e2e)",
+          "note_de": "Verifiziert per E2E-Test gegen die Live-URL, dass das Feature funktioniert."
+        }
+      ],
+      "example_prompt_de": "Ist der letzte Deploy für mentolder live? Prüfe Status, Logs und mach einen E2E-Check.",
+      "guardrails": [
+        {
+          "id": "G-ENV-EXPLICIT",
+          "name_de": "ENV immer explizit setzen",
+          "rule_de": "Bei jedem Deploy/Cluster-Befehl ENV= ausdrücklich angeben (z. B. ENV=mentolder).",
+          "why_de": "Ohne ENV= wird 'dev' angenommen und der Befehl trifft heimlich die falsche Umgebung."
+        }
+      ],
+      "related": [
+        "aenderung-ausrollen",
+        "dienst-status-pruefen"
+      ],
+      "links": [],
+      "theme": "betrieb",
+      "one_liner_de": "Nach dem Deploy prüfen, ob alles läuft.",
+      "aliases_de": [
+        "deploy",
+        "live",
+        "pruefen",
+        "status",
+        "ist es da"
+      ],
+      "common": true,
+      "order": 7,
+      "stages": [
+        "live"
+      ],
+      "concept_de": "Konzept: Deploy ≠ live — erst Status, Logs und ein E2E-Check bestätigen es."
     }
   ],
   "tools": [
@@ -539,6 +713,9 @@
       ],
       "common": false,
       "order": 999,
+      "stages": [
+        "brainstorm"
+      ],
       "init_prompt_de": "/superpowers"
     },
     {
@@ -567,6 +744,10 @@
       ],
       "common": false,
       "order": 999,
+      "stages": [
+        "idee",
+        "brainstorm"
+      ],
       "init_prompt_de": "/brainstorming – ich möchte etwas Neues bauen und will es erst durchdenken."
     },
     {
@@ -600,6 +781,9 @@
       ],
       "common": false,
       "order": 999,
+      "stages": [
+        "plan"
+      ],
       "init_prompt_de": "Ich will etwas ändern – starte die Planung (dev-flow-plan)."
     },
     {
@@ -640,6 +824,10 @@
       ],
       "common": false,
       "order": 999,
+      "stages": [
+        "code",
+        "pr-ci"
+      ],
       "init_prompt_de": "/dev-flow-execute – setze den fertigen Plan um und öffne einen PR."
     },
     {
@@ -680,6 +868,10 @@
       ],
       "common": false,
       "order": 999,
+      "stages": [
+        "code",
+        "deploy"
+      ],
       "init_prompt_de": "/dev-flow-iterate – deploye ins Dev-Cluster und zeig mir die Logs."
     },
     {
@@ -713,6 +905,9 @@
       ],
       "common": false,
       "order": 999,
+      "stages": [
+        "live"
+      ],
       "init_prompt_de": "/dev-flow-e2e – schreibe und führe E2E-Tests gegen die Live-Umgebung aus."
     },
     {
@@ -737,7 +932,8 @@
         "kommando"
       ],
       "common": true,
-      "order": 5
+      "order": 5,
+      "stages": []
     },
     {
       "id": "agent-website",
@@ -782,6 +978,7 @@
       ],
       "common": false,
       "order": 999,
+      "stages": [],
       "init_prompt_de": "Übergib das an den Website-Agenten: <was auf der Website geändert werden soll>."
     },
     {
@@ -817,6 +1014,9 @@
       ],
       "common": true,
       "order": 4,
+      "stages": [
+        "live"
+      ],
       "init_prompt_de": "Frag den Betriebs-Agenten: warum läuft <Dienst> nicht / ist alles grün?"
     },
     {
@@ -864,6 +1064,9 @@
       ],
       "common": false,
       "order": 999,
+      "stages": [
+        "deploy"
+      ],
       "init_prompt_de": "Übergib das an den Infrastruktur-Agenten: <Manifest-/Overlay-/Deploy-Aufgabe>."
     },
     {
@@ -897,6 +1100,7 @@
       ],
       "common": false,
       "order": 999,
+      "stages": [],
       "init_prompt_de": "Übergib das an den Test-Agenten: <Test schreiben/reparieren/ausführen>."
     },
     {
@@ -937,6 +1141,7 @@
       ],
       "common": false,
       "order": 999,
+      "stages": [],
       "init_prompt_de": "Frag den Datenbank-Agenten: <Schema, Query, Backup/Restore>."
     },
     {
@@ -989,6 +1194,7 @@
       ],
       "common": false,
       "order": 999,
+      "stages": [],
       "init_prompt_de": "Übergib das an den Security-Agenten: <Secret rotieren, Keycloak/OIDC, DSGVO>."
     }
   ],
@@ -1000,7 +1206,12 @@
       "emoji": "🌐",
       "summary_de": "Die öffentliche Webseite und das Kundenportal. Hier ändert man Texte, Preise und sieht eigene Daten.",
       "sensitivity": "caution",
-      "url": null
+      "url": null,
+      "area": "dienste",
+      "theme": "website",
+      "relates_to": [
+        "website-text-aendern"
+      ]
     },
     "keycloak": {
       "slug": "keycloak",
@@ -1009,7 +1220,12 @@
       "emoji": "🔑",
       "summary_de": "Die zentrale Anmeldung (Single Sign-On): ein Login für alle Dienste.",
       "sensitivity": "forbidden",
-      "url": null
+      "url": null,
+      "area": "plattform",
+      "theme": "sicherheit",
+      "relates_to": [
+        "secret-aendern"
+      ]
     },
     "nextcloud": {
       "slug": "nextcloud",
@@ -1018,7 +1234,9 @@
       "emoji": "☁️",
       "summary_de": "Deine private Cloud: Dateien, Kalender, Kontakte und Video-Telefonie (Talk).",
       "sensitivity": "assisted",
-      "url": null
+      "url": null,
+      "area": "dienste",
+      "theme": "betrieb"
     },
     "collabora": {
       "slug": "collabora",
@@ -1027,7 +1245,9 @@
       "emoji": "📄",
       "summary_de": "Office im Browser: Dokumente, Tabellen und Präsentationen direkt in Nextcloud bearbeiten.",
       "sensitivity": "caution",
-      "url": null
+      "url": null,
+      "area": "dienste",
+      "theme": "betrieb"
     },
     "vaultwarden": {
       "slug": "vaultwarden",
@@ -1036,7 +1256,9 @@
       "emoji": "🔒",
       "summary_de": "Der Passwort-Tresor (kompatibel mit Bitwarden). Speichert Passwörter sicher und verschlüsselt.",
       "sensitivity": "forbidden",
-      "url": null
+      "url": null,
+      "area": "dienste",
+      "theme": "sicherheit"
     },
     "nextcloud-talk-hpb": {
       "slug": "nextcloud-talk-hpb",
@@ -1072,7 +1294,9 @@
       "emoji": "📝",
       "summary_de": "Dokumente digital unterschreiben lassen (elektronische Signatur).",
       "sensitivity": "caution",
-      "url": null
+      "url": null,
+      "area": "dienste",
+      "theme": "betrieb"
     },
     "whiteboard": {
       "slug": "whiteboard",
@@ -1108,7 +1332,12 @@
       "emoji": "🐘",
       "summary_de": "Die zentrale Datenbank (PostgreSQL 16). Hier liegen fast alle Daten der Plattform.",
       "sensitivity": "forbidden",
-      "url": null
+      "url": null,
+      "area": "daten",
+      "theme": "datenbank",
+      "relates_to": [
+        "datenbank-aendern"
+      ]
     },
     "traefik": {
       "slug": "traefik",
@@ -1117,7 +1346,9 @@
       "emoji": "🔀",
       "summary_de": "Der Türsteher des Clusters: leitet jede Web-Anfrage an den richtigen Dienst und macht HTTPS.",
       "sensitivity": "assisted",
-      "url": null
+      "url": null,
+      "area": "plattform",
+      "theme": "ausrollen"
     },
     "sealed-secrets": {
       "slug": "sealed-secrets",
@@ -1126,7 +1357,12 @@
       "emoji": "🔐",
       "summary_de": "Verschlüsselt geheime Zugangsdaten, damit sie sicher in Git liegen können.",
       "sensitivity": "forbidden",
-      "url": null
+      "url": null,
+      "area": "daten",
+      "theme": "sicherheit",
+      "relates_to": [
+        "secret-aendern"
+      ]
     },
     "cert-manager": {
       "slug": "cert-manager",
@@ -1135,7 +1371,9 @@
       "emoji": "📜",
       "summary_de": "Holt und erneuert automatisch die HTTPS-Zertifikate (über Let's Encrypt / DNS-01).",
       "sensitivity": "assisted",
-      "url": null
+      "url": null,
+      "area": "plattform",
+      "theme": "sicherheit"
     },
     "k3s": {
       "slug": "k3s",
@@ -1144,7 +1382,12 @@
       "emoji": "☸️",
       "summary_de": "Das schlanke Kubernetes, auf dem alle Dienste laufen. Das Fundament der Plattform.",
       "sensitivity": "forbidden",
-      "url": null
+      "url": null,
+      "area": "plattform",
+      "theme": "ausrollen",
+      "relates_to": [
+        "cluster-neu-aufsetzen"
+      ]
     },
     "wireguard": {
       "slug": "wireguard",
@@ -1180,7 +1423,9 @@
       "emoji": "📡",
       "summary_de": "Der WebRTC-Server für Live-Video und Streaming (z. B. Bühnen-Übertragungen).",
       "sensitivity": "assisted",
-      "url": null
+      "url": null,
+      "area": "dienste",
+      "theme": "betrieb"
     },
     "livekit-ingress": {
       "slug": "livekit-ingress",
@@ -1326,5 +1571,264 @@
       "sensitivity": "assisted",
       "url": null
     }
+  },
+  "map": {
+    "flow": [
+      {
+        "id": "idee",
+        "label_de": "Idee",
+        "emoji": "💡",
+        "danger": "safe",
+        "order": 1,
+        "blurb_de": "Was soll sich ändern? Noch nichts angefasst.",
+        "goalIds": [
+          "idee-starten"
+        ],
+        "toolIds": [
+          "brainstorming"
+        ]
+      },
+      {
+        "id": "brainstorm",
+        "label_de": "Brainstorm",
+        "emoji": "🧠",
+        "danger": "safe",
+        "order": 2,
+        "blurb_de": "Die Idee zu einem klaren Design schärfen.",
+        "goalIds": [
+          "idee-starten"
+        ],
+        "toolIds": [
+          "superpowers",
+          "brainstorming"
+        ]
+      },
+      {
+        "id": "plan",
+        "label_de": "Plan",
+        "emoji": "📋",
+        "danger": "caution",
+        "order": 3,
+        "blurb_de": "Einen Schritt-für-Schritt-Plan schreiben.",
+        "goalIds": [
+          "bug-beheben",
+          "feature-bauen",
+          "datenbank-aendern"
+        ],
+        "toolIds": [
+          "dev-flow-plan"
+        ]
+      },
+      {
+        "id": "code",
+        "label_de": "Code+TDD",
+        "emoji": "💻",
+        "danger": "caution",
+        "order": 4,
+        "blurb_de": "Erst den Test, dann die Umsetzung.",
+        "goalIds": [
+          "website-text-aendern",
+          "bug-beheben",
+          "feature-bauen",
+          "datenbank-aendern"
+        ],
+        "toolIds": [
+          "dev-flow-execute",
+          "dev-flow-iterate"
+        ]
+      },
+      {
+        "id": "pr-ci",
+        "label_de": "PR+CI",
+        "emoji": "🔀",
+        "danger": "assisted",
+        "order": 5,
+        "blurb_de": "Pull Request öffnen — CI muss grün sein.",
+        "goalIds": [
+          "bug-beheben",
+          "feature-bauen",
+          "pr-oeffnen"
+        ],
+        "toolIds": [
+          "dev-flow-execute"
+        ]
+      },
+      {
+        "id": "deploy",
+        "label_de": "Deploy",
+        "emoji": "🚀",
+        "danger": "assisted",
+        "order": 6,
+        "blurb_de": "Die Änderung live bringen (Flux / Task).",
+        "goalIds": [
+          "bug-beheben",
+          "feature-bauen",
+          "aenderung-ausrollen",
+          "datenbank-aendern"
+        ],
+        "toolIds": [
+          "dev-flow-iterate",
+          "agent-infra"
+        ]
+      },
+      {
+        "id": "live",
+        "label_de": "Live",
+        "emoji": "🌍",
+        "danger": "safe",
+        "order": 7,
+        "blurb_de": "Läuft es? Status und Logs prüfen.",
+        "goalIds": [
+          "dienst-status-pruefen",
+          "aenderung-ausrollen",
+          "deploy-pruefen"
+        ],
+        "toolIds": [
+          "dev-flow-e2e",
+          "agent-ops"
+        ]
+      }
+    ],
+    "territory": [
+      {
+        "id": "dienste",
+        "label_de": "Dienste",
+        "order": 1,
+        "nodes": [
+          {
+            "slug": "website",
+            "name": "Website",
+            "emoji": "🌐",
+            "sensitivity": "caution",
+            "theme": "website",
+            "accent": "#4a9eff",
+            "relatesTo": [
+              "website-text-aendern"
+            ]
+          },
+          {
+            "slug": "nextcloud",
+            "name": "Nextcloud",
+            "emoji": "☁️",
+            "sensitivity": "assisted",
+            "theme": "betrieb",
+            "accent": "#7e9aa6",
+            "relatesTo": []
+          },
+          {
+            "slug": "collabora",
+            "name": "Collabora",
+            "emoji": "📄",
+            "sensitivity": "caution",
+            "theme": "betrieb",
+            "accent": "#7e9aa6",
+            "relatesTo": []
+          },
+          {
+            "slug": "vaultwarden",
+            "name": "Vaultwarden",
+            "emoji": "🔒",
+            "sensitivity": "forbidden",
+            "theme": "sicherheit",
+            "accent": "#c77dff",
+            "relatesTo": []
+          },
+          {
+            "slug": "docuseal",
+            "name": "DocuSeal",
+            "emoji": "📝",
+            "sensitivity": "caution",
+            "theme": "betrieb",
+            "accent": "#7e9aa6",
+            "relatesTo": []
+          },
+          {
+            "slug": "livekit",
+            "name": "LiveKit Server",
+            "emoji": "📡",
+            "sensitivity": "assisted",
+            "theme": "betrieb",
+            "accent": "#7e9aa6",
+            "relatesTo": []
+          }
+        ]
+      },
+      {
+        "id": "plattform",
+        "label_de": "Plattform & Cluster",
+        "order": 2,
+        "nodes": [
+          {
+            "slug": "keycloak",
+            "name": "Keycloak",
+            "emoji": "🔑",
+            "sensitivity": "forbidden",
+            "theme": "sicherheit",
+            "accent": "#c77dff",
+            "relatesTo": [
+              "secret-aendern"
+            ]
+          },
+          {
+            "slug": "traefik",
+            "name": "Traefik",
+            "emoji": "🔀",
+            "sensitivity": "assisted",
+            "theme": "ausrollen",
+            "accent": "#5ad1c4",
+            "relatesTo": []
+          },
+          {
+            "slug": "cert-manager",
+            "name": "cert-manager",
+            "emoji": "📜",
+            "sensitivity": "assisted",
+            "theme": "sicherheit",
+            "accent": "#c77dff",
+            "relatesTo": []
+          },
+          {
+            "slug": "k3s",
+            "name": "k3s / k3d",
+            "emoji": "☸️",
+            "sensitivity": "forbidden",
+            "theme": "ausrollen",
+            "accent": "#5ad1c4",
+            "relatesTo": [
+              "cluster-neu-aufsetzen"
+            ]
+          }
+        ]
+      },
+      {
+        "id": "daten",
+        "label_de": "Daten & Geheimnisse",
+        "order": 3,
+        "nodes": [
+          {
+            "slug": "postgresql",
+            "name": "PostgreSQL 16",
+            "emoji": "🐘",
+            "sensitivity": "forbidden",
+            "theme": "datenbank",
+            "accent": "#6c8cff",
+            "relatesTo": [
+              "datenbank-aendern"
+            ]
+          },
+          {
+            "slug": "sealed-secrets",
+            "name": "Sealed Secrets",
+            "emoji": "🔐",
+            "sensitivity": "forbidden",
+            "theme": "sicherheit",
+            "accent": "#c77dff",
+            "relatesTo": [
+              "secret-aendern"
+            ]
+          }
+        ]
+      }
+    ]
   }
 }

--- a/website/src/lib/agentGuide.ts
+++ b/website/src/lib/agentGuide.ts
@@ -55,6 +55,8 @@ export interface Goal {
   aliases_de: string[];
   common: boolean;
   order: number;
+  stages: string[];
+  concept_de?: string;
   escalate_to_de?: string;
 }
 
@@ -75,6 +77,7 @@ export interface Tool {
   aliases_de: string[];
   common: boolean;
   order: number;
+  stages: string[];
   escalate_to_de?: string;
   init_prompt_de?: string;
 }
@@ -89,12 +92,46 @@ export interface Component {
   url: string;
 }
 
+export interface FlowStation {
+  id: string;
+  label_de: string;
+  emoji: string;
+  danger: string;
+  order: number;
+  blurb_de: string;
+  goalIds: string[];
+  toolIds: string[];
+}
+
+export interface TerritoryNode {
+  slug: string;
+  name: string;
+  emoji: string;
+  sensitivity: string;
+  theme: string | null;
+  accent: string;
+  relatesTo: string[];
+}
+
+export interface TerritoryArea {
+  id: string;
+  label_de: string;
+  order: number;
+  nodes: TerritoryNode[];
+}
+
+export interface MapData {
+  flow: FlowStation[];
+  territory: TerritoryArea[];
+}
+
 export const taxonomy: TierEntry[] = data.taxonomy as TierEntry[];
 export const themes: Theme[] = (data.themes ?? []) as Theme[];
 export const glossary: GlossaryEntry[] = (data.glossary ?? []) as GlossaryEntry[];
 export const goals: Goal[] = data.goals as Goal[];
 export const tools: Tool[] = data.tools as Tool[];
 export const components: Record<string, Component> = data.components as Record<string, Component>;
+export const guideMap: MapData = (data.map ?? { flow: [], territory: [] }) as MapData;
 
 /** Single resolver over taxonomy[]; the conveniences below are derived from it. */
 export function tierFor(id: string): { emoji: string; label: string; color: string; meaning: string } | undefined {

--- a/website/src/lib/agentGuideSearch.test.ts
+++ b/website/src/lib/agentGuideSearch.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { goals, tools, taxonomy, themes } from './agentGuide';
+import { goals, tools, taxonomy, themes, guideMap, glossary } from './agentGuide';
 import {
   MIN_QUERY, normalize, buildEntries, matches, filterEntries,
-  groupBy, sortCommonFirst, highlight,
+  groupBy, sortCommonFirst, highlight, mapFilterIds, splitGlossaryTerms,
 } from './agentGuideSearch';
 
 const ALL = buildEntries(goals, tools);
@@ -115,5 +115,51 @@ describe('highlight', () => {
   it('returns a single unmarked segment below MIN_QUERY or on no match', () => {
     expect(highlight('Hallo', 'ha')).toEqual([{ text: 'Hallo', mark: false }]);
     expect(highlight('Hallo', 'xyz')).toEqual([{ text: 'Hallo', mark: false }]);
+  });
+});
+
+describe('buildEntries: stages', () => {
+  it('carries the stages array onto each entry', () => {
+    const e = ALL.find(x => x.id === 'bug-beheben')!;
+    expect(Array.isArray(e.stages)).toBe(true);
+    expect(e.stages).toContain('plan');
+  });
+});
+
+describe('mapFilterIds', () => {
+  it('returns null for a null filter (no restriction)', () => {
+    expect(mapFilterIds(null, guideMap)).toBeNull();
+  });
+  it('flow filter → the station goalIds+toolIds set', () => {
+    const ids = mapFilterIds({ kind: 'flow', id: 'plan' }, guideMap)!;
+    const plan = guideMap.flow.find(s => s.id === 'plan')!;
+    expect(ids.has(plan.goalIds[0] ?? plan.toolIds[0])).toBe(true);
+    expect(ids.has('dienst-status-pruefen')).toBe(false); // live station, not plan
+  });
+  it('node filter → the territory node relatesTo set', () => {
+    const node = guideMap.territory.flatMap(a => a.nodes).find(n => n.relatesTo.length > 0)!;
+    const ids = mapFilterIds({ kind: 'node', id: node.slug }, guideMap)!;
+    expect(ids.has(node.relatesTo[0])).toBe(true);
+  });
+  it('unknown id → empty set (filters everything out, never throws)', () => {
+    expect(mapFilterIds({ kind: 'flow', id: 'nope' }, guideMap)!.size).toBe(0);
+  });
+});
+
+describe('splitGlossaryTerms', () => {
+  const terms = glossary.map(g => g.term); // includes 'PR', 'CI', 'Deploy', …
+  it('splits a known whole-word term into a marked segment', () => {
+    const segs = splitGlossaryTerms('Öffne einen PR und warte auf CI.', terms);
+    expect(segs.some(s => s.term === 'PR')).toBe(true);
+    expect(segs.some(s => s.term === 'CI')).toBe(true);
+    expect(segs.map(s => s.text).join('')).toBe('Öffne einen PR und warte auf CI.');
+  });
+  it('does not match inside a larger word', () => {
+    const segs = splitGlossaryTerms('Preisliste', ['PR']);
+    expect(segs.every(s => !s.term)).toBe(true);
+    expect(segs.map(s => s.text).join('')).toBe('Preisliste');
+  });
+  it('returns one plain segment when there are no terms', () => {
+    expect(splitGlossaryTerms('nichts hier', [])).toEqual([{ text: 'nichts hier' }]);
   });
 });

--- a/website/src/lib/agentGuideSearch.ts
+++ b/website/src/lib/agentGuideSearch.ts
@@ -1,4 +1,4 @@
-import type { Goal, Tool, Theme, TierEntry } from './agentGuide';
+import type { Goal, Tool, Theme, TierEntry, MapData } from './agentGuide';
 
 export type Axis = 'thema' | 'gefahr' | 'art';
 export const MIN_QUERY = 3;
@@ -16,6 +16,7 @@ export interface GuideEntry {
   common: boolean;
   order: number;
   aliases_de: string[];
+  stages: string[];
   haystack: string;         // normalized
   goal?: Goal;
   tool?: Tool;
@@ -72,6 +73,7 @@ export function buildEntries(goals: Goal[], tools: Tool[]): GuideEntry[] {
     danger: g.danger, theme: g.theme,
     art: 'ziel', artLabel: ART_LABEL.ziel,
     common: g.common, order: g.order, aliases_de: g.aliases_de ?? [],
+    stages: g.stages ?? [],
     haystack: goalHaystack(g), goal: g,
   }));
   const toolEntries: GuideEntry[] = tools.map(t => {
@@ -82,6 +84,7 @@ export function buildEntries(goals: Goal[], tools: Tool[]): GuideEntry[] {
       danger: t.danger, theme: t.theme,
       art, artLabel: ART_LABEL[art] ?? t.kind_de,
       common: t.common, order: t.order, aliases_de: t.aliases_de ?? [],
+      stages: t.stages ?? [],
       haystack: toolHaystack(t), tool: t,
     };
   });
@@ -163,4 +166,44 @@ export function highlight(text: string, query: string): Segment[] {
     { text: text.slice(startOrig, endOrig), mark: true },
     { text: text.slice(endOrig), mark: false },
   ].filter(s => s.text.length > 0);
+}
+
+export type MapFilter = { kind: 'flow' | 'node'; id: string } | null;
+
+/** Resolve a map selection to the set of entry ids it permits, or null = no restriction. */
+export function mapFilterIds(filter: MapFilter, map: MapData): Set<string> | null {
+  if (!filter) return null;
+  if (filter.kind === 'flow') {
+    const s = map.flow.find(f => f.id === filter.id);
+    return new Set([...(s?.goalIds ?? []), ...(s?.toolIds ?? [])]);
+  }
+  const node = map.territory.flatMap(a => a.nodes).find(n => n.slug === filter.id);
+  return new Set(node?.relatesTo ?? []);
+}
+
+export interface GlossSegment { text: string; term?: string; }
+
+/** Split `text` into segments, marking the first whole-word occurrence of each glossary
+ *  term (longest term first). Whole-word = bounded by non-word chars; case-insensitive. */
+export function splitGlossaryTerms(text: string, terms: string[]): GlossSegment[] {
+  const wanted = [...terms].filter(Boolean).sort((a, b) => b.length - a.length);
+  const used = new Set<string>();
+  let segs: GlossSegment[] = [{ text }];
+  for (const term of wanted) {
+    const next: GlossSegment[] = [];
+    for (const seg of segs) {
+      if (seg.term || used.has(term)) { next.push(seg); continue; }
+      const re = new RegExp(`(^|[^\\p{L}\\p{N}])(${term.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')})(?=[^\\p{L}\\p{N}]|$)`, 'iu');
+      const m = re.exec(seg.text);
+      if (!m) { next.push(seg); continue; }
+      const start = m.index + m[1].length;
+      const end = start + m[2].length;
+      if (seg.text.slice(0, start)) next.push({ text: seg.text.slice(0, start) });
+      next.push({ text: seg.text.slice(start, end), term });
+      if (seg.text.slice(end)) next.push({ text: seg.text.slice(end) });
+      used.add(term);
+    }
+    segs = next;
+  }
+  return segs.length ? segs : [{ text }];
 }

--- a/website/src/styles/sidekick-panels.css
+++ b/website/src/styles/sidekick-panels.css
@@ -1831,3 +1831,64 @@
   .drawer .ag-empty,
   .drawer .ag-section-label { margin-inline: 18px; }
 }
+
+/* ── Mental-model map ──────────────────────────────────────────────────────── */
+.drawer .ag-map-section { margin: 12px 22px 0; }
+.drawer .ag-map-toggle {
+  display: flex; align-items: center; gap: 8px; width: 100%;
+  padding: 8px 10px; border: 0; border-left: 4px solid var(--brass, #e8c870);
+  background: color-mix(in srgb, var(--brass, #e8c870) 12%, transparent);
+  border-radius: 8px; color: var(--fg); cursor: pointer; text-align: left;
+}
+.drawer .ag-map-toggle:focus-visible { outline: 2px solid var(--brass); outline-offset: -2px; }
+.drawer .ag-map-toggle-label { flex: 1 1 auto; font-family: var(--serif); font-size: 15px; }
+.drawer .ag-map-hint { margin: 8px 2px; font-size: 12px; color: var(--mute); }
+.drawer .ag-map { display: flex; flex-direction: column; gap: 6px; }
+.drawer .ag-flowband { list-style: none; display: flex; flex-wrap: wrap; align-items: center;
+  gap: 4px; padding: 0; margin: 2px 0 10px; }
+.drawer .ag-flow-arrow { color: var(--mute); font-size: 12px; }
+.drawer .ag-flow-station {
+  display: inline-flex; align-items: center; gap: 5px; padding: 5px 9px;
+  font-size: 12px; color: var(--fg); cursor: pointer;
+  background: transparent; border: 1px solid color-mix(in srgb, var(--tier) 45%, transparent);
+  border-left: 3px solid var(--tier); border-radius: 7px;
+}
+.drawer .ag-flow-station.on { background: color-mix(in srgb, var(--tier) 18%, transparent); }
+.drawer .ag-flow-station:focus-visible { outline: 2px solid var(--brass); outline-offset: 1px; }
+.drawer .ag-flow-name { font-weight: 600; }
+.drawer .ag-territory { display: flex; flex-direction: column; gap: 8px; }
+.drawer .ag-terr-area { border: 1px dashed color-mix(in srgb, var(--line) 70%, transparent);
+  border-radius: 8px; padding: 7px 9px; }
+.drawer .ag-terr-label { display: block; font-family: var(--mono); font-size: 10px;
+  text-transform: uppercase; letter-spacing: 0.4px; color: var(--mute); margin-bottom: 6px; }
+.drawer .ag-terr-nodes { display: flex; flex-wrap: wrap; gap: 6px; }
+.drawer .ag-terr-node {
+  display: inline-flex; align-items: center; gap: 5px; padding: 4px 8px;
+  font-size: 11.5px; color: var(--fg); cursor: pointer; background: transparent;
+  border: 1px solid color-mix(in srgb, var(--accent, var(--line)) 40%, transparent);
+  border-left: 3px solid var(--accent, var(--line)); border-radius: 7px;
+}
+.drawer .ag-terr-node.on { background: color-mix(in srgb, var(--accent) 16%, transparent); }
+.drawer .ag-terr-node:focus-visible { outline: 2px solid var(--brass); outline-offset: 1px; }
+.drawer .ag-terr-dot { font-size: 10px; }
+.drawer .ag-mapfilter-chip {
+  margin-top: 8px; padding: 4px 10px; font-size: 11px; cursor: pointer;
+  color: var(--ink-900, #0f1623); background: var(--brass, #e8c870);
+  border: 0; border-radius: 999px; font-weight: 600;
+}
+
+/* ── Concept line + glossary tooltip ───────────────────────────────────────── */
+.drawer .ag-concept { margin: 2px 0 8px; font-size: 12.5px; color: var(--mute); font-style: italic; }
+.drawer .ag-gloss-wrap { position: relative; display: inline-block; }
+.drawer .ag-gloss {
+  border: 0; background: transparent; padding: 0; cursor: help; color: inherit;
+  font: inherit; border-bottom: 1px dotted var(--brass, #e8c870);
+}
+.drawer .ag-gloss:focus-visible { outline: 2px solid var(--brass); outline-offset: 2px; }
+.drawer .ag-gloss-pop {
+  position: absolute; left: 0; top: 130%; z-index: 5; width: max-content; max-width: 240px;
+  padding: 6px 9px; font-size: 11.5px; font-style: normal; color: var(--fg);
+  background: var(--ink-900, #0f1623); border: 1px solid var(--line);
+  border-radius: 6px; box-shadow: 0 4px 14px rgba(0,0,0,.4);
+}
+@media (prefers-reduced-motion: reduce) { .drawer .ag-flow-station, .drawer .ag-terr-node { transition: none; } }


### PR DESCRIPTION
## Summary

- Adds a collapsible **🧭 So funktioniert die Plattform** map card above the Agent-Anleitung catalog, consisting of a flow ribbon (Idee → Brainstorm → Plan → Code+TDD → PR+CI → Deploy → Live) and a territory lane view (Dienste / Plattform & Cluster / Daten & Geheimnisse)
- Clicking a flow station or territory node filters the catalog via a new `mapFilter` axis; an active-filter chip with dismiss button makes the filter visible
- A `splitGlossaryTerms` helper + `GlossaryTerm.svelte` add inline dotted-underline tooltips on concept lines rendered below each goal card
- Registry gains `flow.yaml`, optional `stages`/`concept_de` on goals/tools, and `area`/`theme`/`relates_to` on 12 components; validation and emitter updated accordingly; 3 onboarding goals added (`idee-starten`, `pr-oeffnen`, `deploy-pruefen`)
- First-run: map is open by default; state persisted in `localStorage` under `ag-map-v1`

Closes T000385

## Test results

```
task test:agent-guide   → 59/59 node:test pass, validate ✓, stale-check ✓  (exit 0)
pnpm test:unit          → Test Files: 95 passed | 14 skipped (109 total); Tests: 579 passed | 91 skipped (670)
task test:all           → exit 0 (all BATS + kustomize + dry-run suites green)
pnpm build              → Complete! (no compile errors)
```

## Code review findings addressed

- **Forbidden goal concept_de**: suppressed the tool-summary fallback for `danger: forbidden` goals so the red stop card doesn't show a misleading teaching concept (e.g. "Deployt Kubernetes-Manifeste…" on `cluster-neu-aufsetzen`)
- **Unused GuideMap imports**: removed `splitGlossaryTerms` and `GlossaryTerm` imports that were stranded in `GuideMap.svelte` after the concept line landed in `GuideCard.svelte` instead

🤖 Generated with [Claude Code](https://claude.com/claude-code)