### PR TITLE
fix(env): mark BRAINSTORM_OIDC_SECRET dev-only so prod env:validate passes

### DIFF
--- a/environments/schema.yaml
+++ b/environments/schema.yaml
@@ -527,8 +527,10 @@ secrets:
     generate: true
     length: 40
 
+  # BRAINSTORM_OIDC_SECRET is dev-only (brainstorm.dev.mentolder.de; no prod broker).
+  # required:false so prod env:validate doesn't demand it; generate:true keeps dev auto-gen.
   - name: BRAINSTORM_OIDC_SECRET
-    required: true
+    required: false
     generate: true
     length: 40
 


### PR DESCRIPTION
brainstorm-collab (PR #1272) added BRAINSTORM_OIDC_SECRET as required:true, but brainstorm is dev-only (no prod broker). The sealed-secret validator has no dev-gating, so prod env:validate failed demanding it. required:false keeps dev auto-gen + unblocks prod. RECOVERY_OIDC_SECRET stays required (legit prod seal, pending).