### PR TITLE
fix(recovery): wire RECOVER_DOMAIN into prod overlay + envsubst browse [T000398]

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -254,6 +254,7 @@ tasks:
       - task: test:unit:fleet-phase2b
       - task: test:unit:shared-db-initdb-selfheal
       - task: test:unit:wg-mesh-fullmesh
+      - task: test:unit:recovery-domain-durability
 
   test:unit:assert:
     internal: true
@@ -299,6 +300,11 @@ tasks:
     internal: true
     cmds:
       - ./tests/unit/lib/bats-core/bin/bats tests/unit/wg-mesh-fullmesh.bats
+
+  test:unit:recovery-domain-durability:
+    internal: true
+    cmds:
+      - ./tests/unit/lib/bats-core/bin/bats tests/unit/recovery-domain-durability.bats
 
   test:art-library:
     desc: "Validate every art-library/sets/* manifest"
@@ -1757,7 +1763,7 @@ tasks:
           ENVSUBST_VARS="$ENVSUBST_VARS \$WEBSITE_IMAGE \$TURN_PUBLIC_IP \$TURN_NODE \$BRAND_ID"
           ENVSUBST_VARS="$ENVSUBST_VARS \$KC_USER1_USERNAME \$KC_USER1_EMAIL \$KC_USER2_USERNAME \$KC_USER2_EMAIL"
           ENVSUBST_VARS="$ENVSUBST_VARS \$BRETT_DOMAIN"
-          ENVSUBST_VARS="$ENVSUBST_VARS \$LIVEKIT_DOMAIN \$STREAM_DOMAIN"
+          ENVSUBST_VARS="$ENVSUBST_VARS \$LIVEKIT_DOMAIN \$STREAM_DOMAIN \$RECOVER_DOMAIN"
           ENVSUBST_VARS="$ENVSUBST_VARS \$WORKSPACE_NAMESPACE \$WEBSITE_NAMESPACE"
           ENVSUBST_VARS="$ENVSUBST_VARS \$SYSTEMTEST_LOOP_ENABLED"
           ENVSUBST_VARS="$ENVSUBST_VARS \$LLM_HOST_IP \$LLM_ENABLED \$LLM_RERANK_ENABLED \$LLM_ROUTER_URL \$LLM_EMBED_URL"

--- a/prod/configmap-domains.yaml
+++ b/prod/configmap-domains.yaml
@@ -18,6 +18,12 @@ data:
   BRETT_DOMAIN: "brett.${PROD_DOMAIN}"
   LIVEKIT_DOMAIN: "livekit.${PROD_DOMAIN}"
   STREAM_DOMAIN: "stream.${PROD_DOMAIN}"
+  # Recovery filebrowser host — registry-sourced (recover.<domain>). MUST be set
+  # here: this file is a strategic-merge patch over base k3d/configmap-domains.yaml,
+  # so without it the live domain-config keeps the dev value `recover.localhost`,
+  # silently breaking the recovery oauth2-proxy redirect + realm client + browse
+  # ingress on every deploy. domain-config is the runtime SSOT for those. [T000398]
+  RECOVER_DOMAIN: "${RECOVER_DOMAIN}"
   # Env-registry values (substituted from environments/<env>.yaml at deploy time)
   PROD_DOMAIN: "${PROD_DOMAIN}"
   WEBSITE_IMAGE: "${WEBSITE_IMAGE}"

--- a/scripts/backup-restore.sh
+++ b/scripts/backup-restore.sh
@@ -85,6 +85,22 @@ KC="kubectl ${CTX_FLAG}"
 # ── Helpers ───────────────────────────────────────────────────────────────────
 _die() { echo "ERROR: $*" >&2; exit 1; }
 
+# Render k3d/recovery-browser.yaml ($MANIFEST) with its envsubst placeholders
+# resolved from the live domain-config ConfigMap (the deploy-time SSOT). The
+# manifest header documents these as substituted-at-browse-time; a raw apply
+# would push the literal ${...} (broken Ingress host + oauth2 redirect-url).
+# Reads globals: MANIFEST, KC, NS. Restricted envsubst list leaves the k8s
+# $(RECOVERY_OIDC_SECRET) env-expansion untouched.
+_render_recovery_browser() {
+  local cm; cm=$($KC get configmap domain-config -n "$NS" -o json 2>/dev/null || echo '{}')
+  export RECOVER_DOMAIN TLS_SECRET_NAME KC_DOMAIN WORKSPACE_NAMESPACE
+  RECOVER_DOMAIN=$(printf '%s' "$cm"  | jq -r '.data.RECOVER_DOMAIN // "recover.localhost"')
+  TLS_SECRET_NAME=$(printf '%s' "$cm" | jq -r '.data.TLS_SECRET_NAME // "workspace-wildcard-tls"')
+  KC_DOMAIN=$(printf '%s' "$cm"       | jq -r '.data.KC_DOMAIN // "auth.localhost"')
+  WORKSPACE_NAMESPACE="$NS"
+  envsubst '$RECOVER_DOMAIN $TLS_SECRET_NAME $KC_DOMAIN $WORKSPACE_NAMESPACE' < "$MANIFEST"
+}
+
 _db_pass_key() {
   case "$1" in
     keycloak)    echo KEYCLOAK_DB_PASSWORD ;;
@@ -939,7 +955,7 @@ YAML
     MANIFEST="${REPO_ROOT}/k3d/recovery-browser.yaml"
     [[ -f "$MANIFEST" ]] || _die "recovery-browser.yaml missing — Plan 2 (feature/recovery-browse) provides it"
     echo "Bringing up the recovery filebrowser (read-only over recovery-pvc:/recovery)..."
-    $KC apply -n "$NS" -f "$MANIFEST"
+    _render_recovery_browser | $KC apply -n "$NS" -f -
     DOM=$($KC get configmap domain-config -n "$NS" -o jsonpath='{.data.RECOVER_DOMAIN}' 2>/dev/null || echo "recover.localhost")
     echo "✓ Browse at: https://${DOM}  (Keycloak login, group /recovery-access). Tear down with: $SCRIPT unbrowse"
     ;;
@@ -947,7 +963,7 @@ YAML
   unbrowse)
     MANIFEST="${REPO_ROOT}/k3d/recovery-browser.yaml"
     echo "Removing the recovery filebrowser..."
-    $KC delete -n "$NS" -f "$MANIFEST" --ignore-not-found 2>/dev/null || true
+    _render_recovery_browser | $KC delete -n "$NS" -f - --ignore-not-found 2>/dev/null || true
     echo "✓ recovery filebrowser removed"
     ;;
 

--- a/tests/unit/recovery-domain-durability.bats
+++ b/tests/unit/recovery-domain-durability.bats
@@ -1,0 +1,53 @@
+#!/usr/bin/env bats
+# Regression: recovery (recover.<domain>) must survive a prod deploy.
+#
+# Two coupled bugs this guards against:
+#   T000398 — prod/configmap-domains.yaml carried no RECOVER_DOMAIN, so the
+#     strategic-merge over base k3d/configmap-domains.yaml left the live
+#     domain-config with the dev value `recover.localhost`. domain-config is the
+#     runtime SSOT for keycloak-sync's recovery-client redirect URIs, the
+#     browse-time ingress/oauth2 envsubst, and the printed URL — so every
+#     `workspace:deploy` silently broke recovery until hand-patched.
+#   browse raw-apply — scripts/backup-restore.sh `browse` applied
+#     k3d/recovery-browser.yaml with a bare `kubectl apply -f`, never running the
+#     envsubst the manifest header (recovery-browser.yaml) documents, so
+#     ${RECOVER_DOMAIN}/${TLS_SECRET_NAME}/${KC_DOMAIN}/${WORKSPACE_NAMESPACE}
+#     reached the cluster literally (broken Ingress host + oauth2 redirect-url).
+
+setup() {
+  REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+  PROD_DOMAINS="$REPO_ROOT/prod/configmap-domains.yaml"
+  TASKFILE="$REPO_ROOT/Taskfile.yml"
+  BR="$REPO_ROOT/scripts/backup-restore.sh"
+  BROWSER="$REPO_ROOT/k3d/recovery-browser.yaml"
+}
+
+@test "prod domain-config defines RECOVER_DOMAIN (else merge leaves dev recover.localhost)" {
+  run grep -qE '^[[:space:]]+RECOVER_DOMAIN:' "$PROD_DOMAINS"
+  [ "$status" -eq 0 ]
+}
+
+@test "prod deploy envsubst list includes RECOVER_DOMAIN" {
+  # The prod-overlay deploy pipes kustomize output through envsubst "$ENVSUBST_VARS";
+  # RECOVER_DOMAIN must be in that list so both domain-config and the realm-template
+  # ConfigMap (which carries \${RECOVER_DOMAIN} redirect URIs) get substituted.
+  run grep -qE 'ENVSUBST_VARS=.*RECOVER_DOMAIN' "$TASKFILE"
+  [ "$status" -eq 0 ]
+}
+
+@test "backup-restore.sh renders recovery-browser.yaml through envsubst" {
+  run grep -q 'envsubst' "$BR"
+  [ "$status" -eq 0 ]
+}
+
+@test "backup-restore.sh browse no longer applies recovery-browser.yaml raw" {
+  # The broken raw apply was: $KC apply -n "$NS" -f "$MANIFEST"
+  run grep -qF '$KC apply -n "$NS" -f "$MANIFEST"' "$BR"
+  [ "$status" -ne 0 ]
+}
+
+@test "recovery-browser.yaml still parameterizes the host with \${RECOVER_DOMAIN}" {
+  # Non-regression: the manifest must keep the placeholder the deploy/browse path fills.
+  run grep -qF 'host: ${RECOVER_DOMAIN}' "$BROWSER"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Problem

Two coupled bugs left **production recovery broken after any deploy**:

1. **T000398 — `RECOVER_DOMAIN` not set by any prod overlay.** `prod/configmap-domains.yaml` is a *strategic-merge patch* over base `k3d/configmap-domains.yaml` (`prod/kustomization.yaml:198`). It carried no `RECOVER_DOMAIN`, so the merge left the live `domain-config` with the dev value `recover.localhost` on every `workspace:deploy`. That ConfigMap is the **runtime SSOT** for:
   - the recovery `oauth2-proxy` `--redirect-url`,
   - the Keycloak realm recovery-client redirect URIs (`keycloak-sync.sh` builds its substitution map from `cm/domain-config`; `kc_assert_no_placeholders` would otherwise skip the client),
   - the browse-time ingress host + printed URL (`backup-restore.sh`).
   This is the live drift tracked as **T000392** (stale domain-config) / **T000391** (stale realm-template).

2. **Browse never substituted its placeholders.** `scripts/backup-restore.sh browse` applied `k3d/recovery-browser.yaml` with a bare `kubectl apply -f` — the script had **no `envsubst` at all** — even though the manifest header documents `${RECOVER_DOMAIN}/${TLS_SECRET_NAME}/${KC_DOMAIN}/${WORKSPACE_NAMESPACE}` as substituted-at-browse-time. So the Ingress host and oauth2 redirect-url were applied as the literal string `${RECOVER_DOMAIN}`.

## Fix

- `prod/configmap-domains.yaml`: add `RECOVER_DOMAIN: "${RECOVER_DOMAIN}"` (registry-sourced, consistent with the other `environments/<env>.yaml`-sourced values in the file).
- `Taskfile.yml`: add `$RECOVER_DOMAIN` to the prod-deploy `ENVSUBST_VARS` so **both** the domain-config and the realm-template ConfigMap (which carries `${RECOVER_DOMAIN}` redirect URIs) render at deploy time. `env-resolve.sh` already exports it for both brands.
- `scripts/backup-restore.sh`: `browse`/`unbrowse` now render the manifest via a new `_render_recovery_browser` helper that resolves values from the live `domain-config`. The **restricted** `envsubst` var list intentionally leaves the k8s `$(RECOVERY_OIDC_SECRET)` env-expansion untouched.
- `tests/unit/recovery-domain-durability.bats`: failing-test-first regression guard, wired into `test:unit`.

## Verification

- `prod-mentolder` and `prod-korczewski` rendered via `env-resolve → kustomize → envsubst`:
  - domain-config → `recover.mentolder.de` / `recover.korczewski.de`
  - realm redirect URIs → `https://recover.<brand>.de(/oauth2/callback)`
  - **0 literal `${RECOVER_DOMAIN}` leftovers** in either brand.
- Browse render: ingress host / redirect-url / issuer / TLS / middlewares all resolve; `$(RECOVERY_OIDC_SECRET)` preserved; passes `kubectl apply --dry-run=client` (5 resources).
- `task test:unit` (incl. new test) and `task test:manifests` green.

## Scope notes
- Resolves **T000398**; clears the live symptoms **T000392 / T000391** once deployed.
- **Out of scope (flagged):** **T000399** (`keycloak:sync` does not create the `/recovery-access` realm group) is a separate recovery gap — recommend a follow-up PR.

## Post-merge
`task workspace:deploy ENV=mentolder` + `ENV=korczewski`, then `task keycloak:sync` for each, to land the durable domain-config and realm clients.

🤖 Generated with [Claude Code](https://claude.com/claude-code)