### PR TITLE
fix(env): make env-seal empty-value scan schema-aware [T000395]

### DIFF
--- a/scripts/env-seal.sh
+++ b/scripts/env-seal.sh
@@ -44,6 +44,7 @@ usage() {
 
 scan_for_dev_values() {
   local secrets_file="$1"
+  local schema_file="${2:-}"
   local bad_keys=()
 
   while IFS= read -r line; do
@@ -71,8 +72,18 @@ scan_for_dev_values() {
       [[ "$value" == "not-configured" ]] && is_bad=true
       [[ "$value" == "MANAGED_EXTERNALLY" ]] && is_bad=true
 
-      # Empty values are never valid secrets
-      [[ -z "$value" ]] && is_bad=true
+      # Empty values are rejected — UNLESS the schema explicitly marks this key
+      # required: false (e.g. BRAINSTORM_OIDC_SECRET is dev-only, intentionally
+      # blank in prod). Without a schema we can't tell, so fail closed.
+      if [[ -z "$value" ]]; then
+        local required="true"
+        if [[ -n "$schema_file" && -f "$schema_file" ]]; then
+          local schema_required
+          schema_required=$(schema_field "$schema_file" "secrets" "$key" "required")
+          [[ "$schema_required" == "false" ]] && required="false"
+        fi
+        [[ "$required" == "true" ]] && is_bad=true
+      fi
 
       $is_bad && bad_keys+=("$key")
     fi
@@ -249,7 +260,7 @@ done
 # ── Test-mode: only run the dev-value scan ───────────────────────
 
 if [[ -n "$_TEST_SCAN_FILE" ]]; then
-  if scan_for_dev_values "$_TEST_SCAN_FILE"; then
+  if scan_for_dev_values "$_TEST_SCAN_FILE" "$_TEST_SCHEMA_FILE"; then
     echo "OK: no dev placeholder values found"
     exit 0
   else
@@ -325,7 +336,7 @@ fi
 # ── Scan for dev placeholder values ─────────────────────────────
 
 info "Scanning secrets for dev placeholder values..."
-if ! scan_for_dev_values "$SECRETS_FILE"; then
+if ! scan_for_dev_values "$SECRETS_FILE" "$SCHEMA"; then
   exit 1
 fi
 info "No dev placeholder values detected."

--- a/tests/unit/scripts.bats
+++ b/tests/unit/scripts.bats
@@ -323,6 +323,51 @@ YAML
   rm -rf "$tmpdir"
 }
 
+@test "env-seal.sh allows empty value for a schema required:false secret" {
+  local tmpdir
+  tmpdir="$(mktemp -d)"
+  cat > "${tmpdir}/schema.yaml" <<'YAML'
+version: 1
+secrets:
+  - name: BRAINSTORM_OIDC_SECRET
+    required: false
+    generate: true
+setup_vars: []
+YAML
+  cat > "${tmpdir}/mysecrets.yaml" <<'YAML'
+BRAINSTORM_OIDC_SECRET: ""
+YAML
+
+  run bash "${PROJECT_DIR}/scripts/env-seal.sh" \
+    --_test-dev-scan "${tmpdir}/mysecrets.yaml" \
+    --_test-schema "${tmpdir}/schema.yaml"
+  assert_success
+  assert_output --partial "OK"
+  rm -rf "$tmpdir"
+}
+
+@test "env-seal.sh still rejects empty value for a schema required:true secret" {
+  local tmpdir
+  tmpdir="$(mktemp -d)"
+  cat > "${tmpdir}/schema.yaml" <<'YAML'
+version: 1
+secrets:
+  - name: SMTP_PASSWORD
+    required: true
+setup_vars: []
+YAML
+  cat > "${tmpdir}/mysecrets.yaml" <<'YAML'
+SMTP_PASSWORD: ""
+YAML
+
+  run bash "${PROJECT_DIR}/scripts/env-seal.sh" \
+    --_test-dev-scan "${tmpdir}/mysecrets.yaml" \
+    --_test-schema "${tmpdir}/schema.yaml"
+  assert_failure
+  assert_output --partial "SMTP_PASSWORD"
+  rm -rf "$tmpdir"
+}
+
 @test "env-seal.sh rejects secrets file with duplicate keys" {
   local tmpdir
   tmpdir="$(mktemp -d)"


### PR DESCRIPTION
## Summary
The `env-seal.sh` dev-value scanner rejected **every** empty secret value unconditionally (line 75, `[[ -z "$value" ]] && is_bad=true`). This broke sealing for keys intentionally marked `required: false` in `environments/schema.yaml` — e.g. `BRAINSTORM_OIDC_SECRET`, which is dev-only and left blank in prod (introduced in #1276 / ef6f8d96).

This makes the empty-value check schema-conditional:
- If the schema marks the key `required: false`, an empty value is allowed.
- If the key is required (or no schema is available), the check still fails closed — preserving the original behaviour.

It reuses the existing `schema_field` helper and threads the schema file through both the test-mode (`--_test-schema`) and the main scan call sites.

## Test plan
- **TDD**: added two bats tests (red → green):
  - `allows empty value for a schema required:false secret`
  - `still rejects empty value for a schema required:true secret`
- The existing `rejects empty values` test (no schema → fail closed) still passes.
- Full `tests/unit/scripts.bats`: 35/35 pass.
- `task test:all`: the only failure is the pre-existing `test:agent-guide` `ERR_MODULE_NOT_FOUND` (missing `node_modules` in the worktree — fails identically on clean `main`, unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)