### PR TITLE
fix(scripts): resolve ENV from positional brand arg in keycloak-ensure-mappers.sh [T000400]

### DIFF
--- a/scripts/keycloak-ensure-mappers.sh
+++ b/scripts/keycloak-ensure-mappers.sh
@@ -10,12 +10,13 @@
 #
 # Usage:
 #   ENV=mentolder bash scripts/keycloak-ensure-mappers.sh
+#   bash scripts/keycloak-ensure-mappers.sh korczewski
 # ═══════════════════════════════════════════════════════════════════════
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-ENV="${ENV:-dev}"
+ENV="${ENV:-${1:-dev}}"
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/env-resolve.sh" "$ENV" "$SCRIPT_DIR/../environments"
 


### PR DESCRIPTION
## Summary

`scripts/keycloak-ensure-mappers.sh` resolved the target environment **only** from the `ENV` environment variable (`ENV="${ENV:-dev}"`) and never read the positional `$1` brand argument. The documented invocation in `.claude/skills/keycloak-realm-sync/SKILL.md` (`bash scripts/keycloak-ensure-mappers.sh korczewski`) therefore silently discarded `korczewski`, fell back to `dev`, and pointed `KC_URL` at `http://auth.localhost` instead of `https://auth.korczewski.de` — so the mapper upsert tried to grab an admin token from the wrong (non-existent) endpoint.

## Fix

Single-line change at line 18:

```diff
-ENV="${ENV:-dev}"
+ENV="${ENV:-${1:-dev}}"
```

The `ENV=` env-var form keeps precedence, so the only repo call site (`Taskfile.yml`, `ENV={{.ENV}} bash scripts/keycloak-ensure-mappers.sh`) is unaffected; the change purely adds the positional fallback so the SKILL.md-documented form works. This matches the convention already used by `scripts/check-connectivity.sh` and `scripts/pre-deploy-check.sh` (`ENV="${1:-dev}"`). The usage comment block was also updated to show the positional form.

Resolves ticket **T000400**.

## Test evidence

Offline (no cluster required) — spec `testCommand`:

```
$ bash -n scripts/keycloak-ensure-mappers.sh && bash -c 'ENV="${ENV:-${1:-dev}}"; source scripts/env-resolve.sh "$ENV" environments >/dev/null 2>&1; if [[ "$ENV" == "dev" ]]; then KC_URL="http://auth.localhost"; else KC_URL="https://auth.${PROD_DOMAIN}"; fi; echo "ENV=$ENV KC_URL=$KC_URL"' -- korczewski
ENV=korczewski KC_URL=https://auth.korczewski.de
```

Precedence cross-checks:

```
# env-var beats positional (Taskfile path safe)
ENV=mentolder ... -- korczewski   => ENV=mentolder KC_URL=https://auth.mentolder.de
# neither set -> dev
                                  => ENV=dev KC_URL=http://auth.localhost
```

## Notes

A separate latent issue (out of scope) exists in `scripts/keycloak-sync.sh` (identical `ENV="${ENV:-dev}"` pattern) — left untouched to keep this fix scoped to T000400; worth a follow-up ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)