### PR TITLE
fix(keycloak-sync): reconcile realm groups (recovery-access) idempotently [T000399]

### DIFF
--- a/scripts/keycloak-sync.sh
+++ b/scripts/keycloak-sync.sh
@@ -205,9 +205,45 @@ else
   warn "TEMPLATE_AVAILABLE=0 — skipping template-driven upsert (no ConfigMap)."
 fi
 
+# ── Upsert realm groups from the template ─────────────────────────────
+# Top-level groups only (none of the realms use subGroups). oauth2-proxy
+# gates /recovery-access (and dev /brainstorm-access); the group must exist
+# in Keycloak or members can't be assigned → 403-loop.
+GROUPS_CREATED=0
+GROUPS_SKIPPED=0
+if [ "$TEMPLATE_AVAILABLE" -eq 1 ]; then
+  while IFS= read -r RAW_GROUP; do
+    [ -z "$RAW_GROUP" ] && continue
+    GROUP_NAME=$(printf '%s' "$RAW_GROUP" | jq -r '.name')
+    [ -z "$GROUP_NAME" ] || [ "$GROUP_NAME" = "null" ] && continue
+    # Already present? (top-level lookup by exact name)
+    EXISTING_GID=$(curl -sk \
+      "${KC_URL}/admin/realms/${KC_REALM}/groups?search=${GROUP_NAME}&exact=true" \
+      -H "Authorization: Bearer ${ADMIN_TOKEN}" \
+      | jq -r --arg n "$GROUP_NAME" '.[] | select(.name==$n) | .id' | head -1 || true)
+    if [ -n "$EXISTING_GID" ]; then
+      log "  ✓ group ${GROUP_NAME} (exists)"
+      GROUPS_SKIPPED=$((GROUPS_SKIPPED + 1))
+      continue
+    fi
+    HTTP_STATUS=$(curl -sk -o /dev/null -w "%{http_code}" \
+      -X POST "${KC_URL}/admin/realms/${KC_REALM}/groups" \
+      -H "Authorization: Bearer ${ADMIN_TOKEN}" \
+      -H "Content-Type: application/json" \
+      -d "{\"name\":\"${GROUP_NAME}\"}" || echo "000")
+    if [[ "$HTTP_STATUS" =~ ^2 ]]; then
+      log "  + group ${GROUP_NAME} (created)"
+      GROUPS_CREATED=$((GROUPS_CREATED + 1))
+    else
+      err "  ✗ group ${GROUP_NAME}: POST failed HTTP ${HTTP_STATUS}"
+      FAILED=$((FAILED + 1))
+    fi
+  done < <(kc_extract_groups_from_template "$REALM_TMP")
+fi
+
 # ── Zusammenfassung ───────────────────────────────────────────────────
 echo ""
-log "Sync abgeschlossen: ${CREATED} erstellt, ${SECRET_UPDATED} secret-aktualisiert, ${SKIPPED} übersprungen, ${FAILED} fehlgeschlagen."
+log "Sync abgeschlossen: ${CREATED} erstellt, ${SECRET_UPDATED} secret-aktualisiert, ${SKIPPED} übersprungen, ${GROUPS_CREATED} Gruppen erstellt, ${GROUPS_SKIPPED} Gruppen vorhanden, ${FAILED} fehlgeschlagen."
 
 if [[ $FAILED -gt 0 ]]; then
   warn "Einige Clients konnten nicht synchronisiert werden."

--- a/scripts/lib/keycloak-helpers.sh
+++ b/scripts/lib/keycloak-helpers.sh
@@ -49,3 +49,12 @@ kc_extract_clients_from_template() {
   local file="$1"
   jq -c '.clients[]' "$file"
 }
+
+# kc_extract_groups_from_template FILE
+#   Reads the realm template JSON at FILE and prints each element of the
+#   .groups[] array on its own line as compact JSON (NDJSON). Emits nothing
+#   when .groups is absent or empty. Requires jq.
+kc_extract_groups_from_template() {
+  local file="$1"
+  jq -c '.groups // [] | .[]' "$file"
+}

--- a/tests/unit/keycloak-sync.bats
+++ b/tests/unit/keycloak-sync.bats
@@ -98,3 +98,25 @@ JSON
   [ "$status" -eq 0 ]
   [ -z "$output" ]
 }
+
+# ── kc_extract_groups_from_template ─────────────────────────────
+
+@test "kc_extract_groups_from_template emits one group JSON per line (NDJSON)" {
+  local fixture="${BATS_TEST_TMPDIR}/realm.json"
+  cat > "$fixture" <<'JSON'
+{"realm":"workspace","groups":[{"name":"recovery-access","path":"/recovery-access","subGroups":[]}]}
+JSON
+  run kc_extract_groups_from_template "$fixture"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"name":"recovery-access"'* ]]
+}
+
+@test "kc_extract_groups_from_template emits nothing when .groups absent" {
+  local fixture="${BATS_TEST_TMPDIR}/nogroups.json"
+  cat > "$fixture" <<'JSON'
+{"realm":"workspace","clients":[]}
+JSON
+  run kc_extract_groups_from_template "$fixture"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}


### PR DESCRIPTION
## Summary

`scripts/keycloak-sync.sh` reconciled only OIDC clients (`.clients[]`). The `.groups[]` section of the realm template — already present in the `realm-template` ConfigMap that the sync reads into `$REALM_TMP` — was **never read**. Every realm defines exactly one top-level group with no subGroups:

- prod-mentolder / prod-korczewski → `/recovery-access`
- k3d (dev) → `/brainstorm-access`

Because `keycloak:sync` never created these groups, the recovery-browser oauth2-proxy (`k3d/recovery-browser.yaml`, `--allowed-groups=/recovery-access`) could have no members and produced a 403 redirect-loop.

## Fix (ticket T000399)

Mirrors the existing client pattern with three minimal, additive changes:

1. **`scripts/lib/keycloak-helpers.sh`** — new pure helper `kc_extract_groups_from_template` (NDJSON; emits nothing when `.groups` is absent/empty).
2. **`scripts/keycloak-sync.sh`** — idempotent GET-then-POST group-upsert loop inside the existing `TEMPLATE_AVAILABLE` guard. Groups carry no `${VAR}` placeholders, so the substitution/assert pipeline is deliberately skipped. POST body sends only `{"name":...}` (path/subGroups are derived by Keycloak). Summary line extended to report created/existing groups.
3. **`tests/unit/keycloak-sync.bats`** — two new pure-helper tests mirroring the `kc_extract_clients` tests.

No Taskfile / schema / domain-registry changes. Low risk: additive, idempotent, offline-testable.

## Test evidence

Offline bats (no cluster/curl/kubectl), `tests/unit/keycloak-sync.bats`:

```
1..12
ok 1 kc_substitute_placeholders replaces single ${VAR} with value
...
ok 10 kc_extract_clients_from_template emits nothing for empty clients array
ok 11 kc_extract_groups_from_template emits one group JSON per line (NDJSON)
ok 12 kc_extract_groups_from_template emits nothing when .groups absent
```

All 12 tests pass (10 existing + 2 new). Direct `bats` invocation exits 0.

## Post-merge

Deploy is push-based — after merge run `task keycloak:sync ENV=mentolder` **and** `ENV=korczewski` (context `fleet`, namespaces `workspace` + `workspace-korczewski`) to create `/recovery-access` in both realms; dev gets `/brainstorm-access`.

Closes T000399.

🤖 Generated with [Claude Code](https://claude.com/claude-code)