### PR TITLE
fix(infra): skip non-env files versions.yaml and fleet.yaml in env:validate:all [T000396]

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1488,9 +1488,15 @@ tasks:
     cmds:
       - |
         errors=0
+        # Non-env files that live in environments/ but are NOT full env configs:
+        #   schema.yaml   — the validation schema itself
+        #   versions.yaml — version-pin file (scripts/discover-versions.sh)
+        #   fleet.yaml    — partial bootstrap/shared config, not a deployable ENV
         for f in environments/*.yaml; do
           name="$(basename "$f" .yaml)"
-          [ "$name" = "schema" ] && continue
+          case "$name" in
+            schema|versions|fleet) continue ;;
+          esac
           echo "--- Validating: $name ---"
           bash scripts/env-validate.sh --env "$name" --env-dir environments --schema-only || errors=$((errors + 1))
         done


### PR DESCRIPTION
## Summary

`task env:validate:all` looped over every `environments/*.yaml` and skipped only `schema.yaml`. Two non-env files in that directory were therefore validated as if they were full env configs:

- `versions.yaml` — a version-pin file (`scripts/discover-versions.sh`), no `environment:`/`env_vars` config
- `fleet.yaml` — a partial bootstrap/shared config (`environment: fleet`, `env_vars: {}`), never resolved as a deployable ENV by `env-resolve.sh`

Each emitted ~35 spurious "missing required env_var/setup_var" errors, inflating the aggregate count by ~70.

## Fix

Replace the single-file `schema` skip with an explicit skip-list (`schema|versions|fleet`) in the `env:validate:all` loop in `Taskfile.yml`. Only real deployable env configs are now validated. An `environment:`-presence gate alone would not work, because `fleet.yaml` carries `environment: fleet` and would slip past it — hence the explicit skip-list.

Single-file change; no schema or domain-registry edits.

## Test evidence

`task env:validate:all` now lists only the 5 real envs (no `versions`/`fleet` blocks):

```
--- Validating: dev ---
--- Validating: fleet-korczewski ---
--- Validating: fleet-mentolder ---
--- Validating: korczewski ---
--- Validating: mentolder ---
```

Offline loop-logic check prints exactly `dev, fleet-korczewski, fleet-mentolder, korczewski, mentolder`.

`scripts/env-validate.sh` behavior is unchanged — all 10 bats tests pass:

```
1..10
ok 1 valid dev environment passes validation
...
ok 10 drift detection runs without error on consistent envs
```

## Out-of-scope note

After this fix, `task env:validate:all` still legitimately FAILS with 2 errors each on `fleet-mentolder` and `fleet-korczewski` (`RECOVER_DOMAIN` env_var + `RECOVERY_OIDC_SECRET` sealed key missing). Those are **real pre-existing config gaps on actual env files**, unrelated to T000396, and are intentionally not masked — they should be filed/handled separately.

Closes T000396.

🤖 Generated with [Claude Code](https://claude.com/claude-code)