### PR TITLE
fix(env): add RECOVER_DOMAIN + seal RECOVERY_OIDC_SECRET into fleet alias env files [T000394]

### DIFF
--- a/environments/fleet-korczewski.yaml
+++ b/environments/fleet-korczewski.yaml
@@ -44,6 +44,7 @@ env_vars:
   TRAEFIK_EXTERNAL_URL: "https://traefik.korczewski.de"
   MAIL_EXTERNAL_URL: "https://mail.korczewski.de"
   BRETT_DOMAIN: brett.korczewski.de
+  RECOVER_DOMAIN: recover.korczewski.de
   LIVEKIT_DOMAIN: livekit.korczewski.de
   LIVEKIT_PIN_IP: "37.27.251.38"
   STREAM_DOMAIN: stream.korczewski.de

--- a/environments/fleet-mentolder.yaml
+++ b/environments/fleet-mentolder.yaml
@@ -45,6 +45,7 @@ env_vars:
   TRAEFIK_EXTERNAL_URL: "https://traefik.mentolder.de"
   MAIL_EXTERNAL_URL: "https://mail.mentolder.de"
   BRETT_DOMAIN: brett.mentolder.de
+  RECOVER_DOMAIN: recover.mentolder.de
   LIVEKIT_DOMAIN: livekit.mentolder.de
   # Pinned to pk-hetzner-4 (fleet node) — livekit/stream/turn all resolve here.
   LIVEKIT_PIN_IP: "204.168.244.104"


### PR DESCRIPTION
## Summary

PR #1271 (`feat(recovery)`, [T000387]) added the required env var `RECOVER_DOMAIN` and sealed the required secret `RECOVERY_OIDC_SECRET` only into the **canonical** `environments/mentolder.yaml` / `korczewski.yaml` (+ their sealed-secrets). The **actively-used** `fleet-*` alias env files were never brought to parity.

There is **no aliasing** in `scripts/env-resolve.sh` — `environments/fleet-mentolder.yaml` and `environments/fleet-korczewski.yaml` are standalone parallel copies loaded directly by env-resolve. They are referenced live by `Taskfile.yml`: `fleet:shared-services` (dual-host Collabora), `fleet:talk-setup:brand`, and `fleet:dns:cutover` / `fleet:dns:rollback`. So deletion is the wrong fix — parity is.

Because `RECOVER_DOMAIN` is `required:true` and `RECOVERY_OIDC_SECRET` is `required:true generate:true` in `schema.yaml`, the schema-only validator reported **2 errors per alias file**.

## What this PR does (PART A — plain, CI-verifiable offline)

Adds `RECOVER_DOMAIN` to both fleet alias files, mirroring the canonical placement (between `BRETT_DOMAIN` and `LIVEKIT_DOMAIN`):

- `environments/fleet-mentolder.yaml` → `RECOVER_DOMAIN: recover.mentolder.de`
- `environments/fleet-korczewski.yaml` → `RECOVER_DOMAIN: recover.korczewski.de`

(The alias serves the same real `mentolder.de` / `korczewski.de` domain, so the values are identical to the canonical files.)

### Test evidence (offline schema-only)

Before: each alias file → `2 error(s)` (`Missing required env_var: RECOVER_DOMAIN` + `Sealed secret missing required key: RECOVERY_OIDC_SECRET`).
After this patch:

```
$ bash scripts/env-validate.sh --env fleet-mentolder --env-dir environments --schema-only
INFO: Validating environment: fleet-mentolder (dev=false)
ERROR: Sealed secret missing required key: RECOVERY_OIDC_SECRET
FAIL: Environment 'fleet-mentolder' has 1 error(s)

$ bash scripts/env-validate.sh --env fleet-korczewski --env-dir environments --schema-only
INFO: Validating environment: fleet-korczewski (dev=false)
ERROR: Sealed secret missing required key: RECOVERY_OIDC_SECRET
FAIL: Environment 'fleet-korczewski' has 1 error(s)
```

The `RECOVER_DOMAIN` error is **GONE** on both files. Only the deferred `RECOVERY_OIDC_SECRET` error remains (PART B, below).

## ⚠️ HELD FOR REVIEW

This PR is a **DRAFT** and intentionally implements **only the non-sensitive plain part (PART A)**. The sealing step (PART B) was **DEFERRED** because it requires restricted secret/cert access (`environments/.secrets/*.yaml` + the fleet cluster sealing cert), which this automated run is not permitted to read or run.

**The maintainer must run PART B before merge** to clear the remaining validation error:

1. Ensure `RECOVERY_OIDC_SECRET` is present in each plaintext alias secret file. If missing:
   `task env:generate ENV=fleet-mentolder` and `task env:generate ENV=fleet-korczewski` (fills any missing `generate:true` keys without clobbering existing ones; skip if already present).
2. `task env:fetch-cert ENV=fleet-mentolder` — ensure the fleet controller's sealing cert is present (both aliases target context `fleet`; same cert is reused).
3. `task env:seal ENV=fleet-mentolder` **and** `task env:seal ENV=fleet-korczewski` — re-encrypts into `environments/sealed-secrets/fleet-mentolder.yaml` / `fleet-korczewski.yaml`, adding the `RECOVERY_OIDC_SECRET` `encryptedData` entry. Commit the regenerated sealed files onto this branch.

**Reviewer must verify:**
- `task env:validate:all` moves both `fleet-mentolder` and `fleet-korczewski` from `1 error(s)` to `OK` after the seal in step 3.
- **OIDC-drift caveat:** both the fleet alias and the canonical env name deploy to the **same** fleet namespaces (`workspace` / `workspace-korczewski`). The sealed `RECOVERY_OIDC_SECRET` should **reuse the brand's existing recovery-client secret value** (from the canonical plaintext) rather than minting a fresh one — otherwise the recovery oauth2-proxy login will 401 until the Keycloak recovery client secret is rotated to match.
- Do **not** hand-edit the sealed blobs — they are cluster-key-bound and must be produced by `task env:seal`.

Per the security policy, `environments/.secrets/*.yaml` and `environments/certs/*` were **not** read or modified in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)