### PR TITLE
fix(tickets): allocate external_id from a global sequence + reconcile duplicates [T000402]

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -255,6 +255,7 @@ tasks:
       - task: test:unit:shared-db-initdb-selfheal
       - task: test:unit:wg-mesh-fullmesh
       - task: test:unit:recovery-domain-durability
+      - task: test:unit:ticket-external-id
 
   test:unit:assert:
     internal: true
@@ -305,6 +306,11 @@ tasks:
     internal: true
     cmds:
       - ./tests/unit/lib/bats-core/bin/bats tests/unit/recovery-domain-durability.bats
+
+  test:unit:ticket-external-id:
+    internal: true
+    cmds:
+      - ./tests/unit/lib/bats-core/bin/bats tests/unit/ticket-external-id-sequence.bats
 
   test:art-library:
     desc: "Validate every art-library/sets/* manifest"

--- a/website/src/lib/tickets-db.ts
+++ b/website/src/lib/tickets-db.ts
@@ -410,7 +410,13 @@ export async function initTicketsSchema(): Promise<void> {
   await pool.query(`CREATE INDEX IF NOT EXISTS pr_events_brand_idx     ON tickets.pr_events (brand) WHERE brand IS NOT NULL`);
   await pool.query(`CREATE INDEX IF NOT EXISTS pr_events_category_idx  ON tickets.pr_events (category)`);
 
-  // Per-brand monotonic counter — feeds the BEFORE-INSERT trigger that mints T-numbers.
+  // DEPRECATED (T000402): tickets.ticket_counters was a PER-BRAND monotonic
+  // counter that fed the external_id trigger. external_id is GLOBALLY unique
+  // (see the UNIQUE constraint on tickets.tickets.external_id), so per-brand
+  // counters drifted and re-minted the same T-number across brands, violating
+  // the constraint and blocking ticket creation. The single source of truth is
+  // now the global sequence tickets.external_id_seq (below). The table is kept
+  // as inert legacy history; nothing reads or writes it anymore.
   await pool.query(`
     CREATE TABLE IF NOT EXISTS tickets.ticket_counters (
       brand       TEXT REFERENCES public.brands(id) ON UPDATE CASCADE ON DELETE RESTRICT PRIMARY KEY,
@@ -424,16 +430,20 @@ export async function initTicketsSchema(): Promise<void> {
       END $$;
   `);
 
+  // GLOBAL external_id sequence — the single source of truth for T-numbers.
+  // `IF NOT EXISTS` adopts the vestigial live sequence if one was created
+  // out-of-band, and creates it otherwise. Owned by `website` so later
+  // schema-init queries (run as website) can setval it.
+  await pool.query(`CREATE SEQUENCE IF NOT EXISTS tickets.external_id_seq AS BIGINT START 1`);
+  await pool.query(`ALTER SEQUENCE tickets.external_id_seq OWNER TO website`);
+
   await pool.query(`
     CREATE OR REPLACE FUNCTION tickets.fn_assign_external_id() RETURNS trigger AS $$
     DECLARE
       next_v BIGINT;
     BEGIN
       IF NEW.external_id IS NULL THEN
-        INSERT INTO tickets.ticket_counters (brand, last_value)
-        VALUES (NEW.brand, 1)
-        ON CONFLICT (brand) DO UPDATE SET last_value = tickets.ticket_counters.last_value + 1
-        RETURNING last_value INTO next_v;
+        next_v := nextval('tickets.external_id_seq');
         NEW.external_id := 'T' || LPAD(next_v::text, 6, '0');
       END IF;
       RETURN NEW;
@@ -447,22 +457,17 @@ export async function initTicketsSchema(): Promise<void> {
   `);
 
   // Idempotent backfill: any ticket whose external_id is NULL or not in T-format
-  // gets a T-number, ordered by created_at within its brand.
-  await pool.query(`
-    INSERT INTO tickets.ticket_counters (brand, last_value)
-    SELECT t.brand,
-           COALESCE(MAX(CASE WHEN t.external_id ~ '^T[0-9]+$'
-                             THEN CAST(SUBSTRING(t.external_id FROM 2) AS BIGINT)
-                             ELSE 0 END), 0)
-      FROM tickets.tickets t
-     GROUP BY t.brand
-    ON CONFLICT (brand) DO NOTHING
-  `);
+  // gets a fresh T-number, allocated GLOBALLY above the current global max so it
+  // can never collide with an existing id. Ordered by created_at for stable
+  // numbering. This only touches NULL / non-T-format rows — it never renumbers a
+  // row that already holds a valid T-number.
   await pool.query(`
     WITH to_fill AS (
-      SELECT t.id, t.brand,
-             (SELECT last_value FROM tickets.ticket_counters tc WHERE tc.brand = t.brand) +
-             ROW_NUMBER() OVER (PARTITION BY t.brand ORDER BY t.created_at ASC, t.id ASC) AS new_seq
+      SELECT t.id,
+             (SELECT COALESCE(MAX(CAST(SUBSTRING(external_id FROM 2) AS BIGINT)), 0)
+                FROM tickets.tickets
+               WHERE external_id ~ '^T[0-9]+$')
+             + ROW_NUMBER() OVER (ORDER BY t.created_at ASC, t.id ASC) AS new_seq
         FROM tickets.tickets t
        WHERE t.external_id IS NULL OR t.external_id !~ '^T[0-9]+$'
     )
@@ -471,16 +476,20 @@ export async function initTicketsSchema(): Promise<void> {
       FROM to_fill f
      WHERE t.id = f.id
   `);
+
+  // Seal the sequence above the current global max so future inserts never
+  // re-collide with a backfilled or pre-existing id. Idempotent: setval to the
+  // observed max on every boot is a no-op once the sequence is already ahead.
+  // NOTE (T000402): historical cross-brand DUPLICATE external_ids that already
+  // hold valid T-numbers (e.g. T000342/T000399/T000402) are NOT reconciled here
+  // — that renumber touches live, externally-referenced ids and is a separate
+  // one-shot manual migration. See the PR's HELD-FOR-REVIEW section.
   await pool.query(`
-    UPDATE tickets.ticket_counters tc
-       SET last_value = sub.max_v
-      FROM (
-        SELECT brand, MAX(CAST(SUBSTRING(external_id FROM 2) AS BIGINT)) AS max_v
-          FROM tickets.tickets
-         WHERE external_id ~ '^T[0-9]+$'
-         GROUP BY brand
-      ) sub
-     WHERE tc.brand = sub.brand AND tc.last_value < sub.max_v
+    SELECT setval('tickets.external_id_seq',
+                  (SELECT COALESCE(MAX(CAST(SUBSTRING(external_id FROM 2) AS BIGINT)), 0)
+                     FROM tickets.tickets
+                    WHERE external_id ~ '^T[0-9]+$'),
+                  true)
   `);
       } finally {
         await client.query(`SELECT pg_advisory_unlock(hashtext('init:tickets'))`);


### PR DESCRIPTION
## Summary

`tickets.fn_assign_external_id()` minted T-numbers from a **per-brand** counter (`tickets.ticket_counters`, keyed by `brand`), but `tickets.tickets.external_id` carries a **global** `UNIQUE` constraint. Each brand counter started at 1 independently, so brands drifted and re-minted the same T-number — korczewski recomputed ~`T000342` while mentolder was near `T000397` — producing cross-brand collisions that violate the unique constraint and intermittently block ticket creation.

PR #1187 (`fix(tickets): allocate external_id from a global sequence`) was supposed to fix this but only added the regression test `tests/unit/ticket-external-id-sequence.bats` and never touched `tickets-db.ts`. That orphaned test was also never wired into `task test:unit` / CI, so the missing implementation went unnoticed (all 3 assertions fail on `main`).

## Changes (code + test wiring only)

- **`website/src/lib/tickets-db.ts`**
  - Create a **global** sequence `tickets.external_id_seq` idempotently (`CREATE SEQUENCE IF NOT EXISTS` — adopts the vestigial live seq if present), owned by `website`.
  - Rewrite the BEFORE-INSERT trigger `fn_assign_external_id` to allocate via `nextval('tickets.external_id_seq')` — single source of truth. It no longer reads/writes `ticket_counters`.
  - Make the NULL / non-T-format backfill **global** (allocated above the global max) instead of brand-partitioned.
  - **Seal** the sequence with `setval('tickets.external_id_seq', MAX, true)` on every boot so future inserts can't re-collide (idempotent no-op once ahead).
  - Keep `tickets.ticket_counters` as **inert legacy history** (table preserved, no longer fed).
- **`Taskfile.yml`** — add internal task `test:unit:ticket-external-id` and append it to the `test:unit` chain so CI (`task test:all`) exercises the regression test permanently.

This all runs as plain TS schema-init under the existing `pg_advisory_lock(hashtext('init:tickets'))` on every website boot.

## Test evidence (offline)

`tests/unit/ticket-external-id-sequence.bats`: **3 failing → 3 passing**.

```
1..3
ok 1 tickets-db.ts assigns external_id from a global sequence (nextval)
ok 2 fn_assign_external_id does NOT allocate external_id from per-brand ticket_counters
ok 3 external_id sequence is seeded to the current global max on init
```

Full `task test:unit` chain passes with the newly wired sub-task running last. No live DB was touched.

## ⚠️ HELD FOR REVIEW

This PR is a **DRAFT** — do not merge without the steps below. It is a **live DB migration**: the schema-init runs on every website boot under the advisory lock, so deploying the new website image to **both** brands applies it.

**Reviewer must verify before marking ready / merging:**

1. **Backup first.** Run `task workspace:backup` and confirm a snapshot exists for both `workspace` and `workspace-korczewski` shared-db before any rollout.
2. **Read-only duplicate audit on BOTH brands' shared-db** (decides which row keeps each number — the one already cited by a PR title / plan filename / memory note keeps it):
   ```sql
   SELECT external_id, count(*), array_agg(brand)
     FROM tickets.tickets
    WHERE external_id ~ '^T[0-9]+$'
    GROUP BY external_id HAVING count(*) > 1
    ORDER BY external_id;
   ```
   Suspected duplicates per the ticket: `T000342 / T000399 / T000402`.
3. **Cross-brand apply.** Deploy the website image to **both** `workspace` (mentolder) and `workspace-korczewski` namespaces on fleet — both run independent `initTicketsSchema()`.
4. Confirm the vestigial live `tickets.external_id_seq` (created out-of-band) is correctly adopted by `CREATE SEQUENCE IF NOT EXISTS` and not double-created.

**DEFERRED — separate manual follow-up (NOT in this PR):**

The **historical cross-brand DUPLICATE reconciliation** (renumbering rows that already hold valid duplicated T-numbers, e.g. `T000342/T000399/T000402`) is intentionally **omitted**. `external_id` is a globally-unique TEXT key soft-referenced by PR titles, plan filenames (`docs/superpowers/plans/*.md` embed `[Txxxxxx]`), and memory notes — renumbering it is live data surgery that must be hand-verified per row (keep the **oldest** / externally-cited row's number, reassign the newer duplicate above MAX). This must be a **one-shot, guarded** reconciliation (gate on `EXISTS(duplicate)` so it doesn't churn rows every boot), not part of the idempotent schema-init.

Note: `tickets.ticket_links.pr_number` and `bugs.bug_tickets.fixed_in_pr` join via UUID/`pr_number`, **not** `external_id`, so those FK-style links survive a future renumber. The interim live workaround (brand counters synced to the global max) already keeps ticket creation working, so the duplicate cleanup is **not urgent**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)