### PR TITLE
fix(backup): make pvc-backup local-path-aware so korczewski backups succeed [T000403]

### DIFF
--- a/k3d/pvc-backup-cronjob.yaml
+++ b/k3d/pvc-backup-cronjob.yaml
@@ -61,7 +61,44 @@ spec:
                   NS=$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)
                   STAMP=$(date +%Y%m%d-%H%M%S)
                   MOUNTER="pvc-backup-mounter-$${STAMP}"
-                  CLONES="vaultwarden-data-backup-clone docuseal-data-backup-clone"
+
+                  # Longhorn supports CSI clone (placement-independent copy);
+                  # local-path does NOT. Detect each data PVC's storageclass so
+                  # we ONLY clone the longhorn-backed sources. local-path sources
+                  # are mounted LIVE (readOnly) by the mounter, which is then
+                  # co-located on the owning pod's node via podAffinity so the
+                  # RWO local-path volume is shareable — the same model already
+                  # used for nextcloud-data. mentolder keeps both data PVCs on
+                  # longhorn (cloned); korczewski has no Longhorn install, so its
+                  # vaultwarden/docuseal PVCs stay on local-path and are tarred
+                  # live. [T000403]
+                  VW_SC=$(kubectl -n "$NS" get pvc vaultwarden-data-pvc -o jsonpath='{.spec.storageClassName}')
+                  DS_SC=$(kubectl -n "$NS" get pvc docuseal-data-pvc   -o jsonpath='{.spec.storageClassName}')
+                  echo "Storage classes: vaultwarden=$VW_SC docuseal=$DS_SC"
+
+                  CLONES=""
+                  [ "$VW_SC" = "longhorn" ] && CLONES="$CLONES vaultwarden-data-backup-clone"
+                  [ "$DS_SC" = "longhorn" ] && CLONES="$CLONES docuseal-data-backup-clone"
+
+                  # Each data volume points at its clone (longhorn) or its live
+                  # PVC (local-path). The mounter co-locates with every live
+                  # local-path source's owning pod via these podAffinity terms.
+                  if [ "$VW_SC" = "longhorn" ]; then
+                    VW_CLAIM="vaultwarden-data-backup-clone"; VW_AFFINITY=""
+                  else
+                    VW_CLAIM="vaultwarden-data-pvc"
+                    VW_AFFINITY="
+                              - labelSelector: { matchLabels: { app: vaultwarden } }
+                                topologyKey: kubernetes.io/hostname"
+                  fi
+                  if [ "$DS_SC" = "longhorn" ]; then
+                    DS_CLAIM="docuseal-data-backup-clone"; DS_AFFINITY=""
+                  else
+                    DS_CLAIM="docuseal-data-pvc"
+                    DS_AFFINITY="
+                              - labelSelector: { matchLabels: { app: docuseal } }
+                                topologyKey: kubernetes.io/hostname"
+                  fi
 
                   cleanup() {
                     echo "Cleanup: deleting mounter Job and clone PVCs..."
@@ -77,43 +114,42 @@ spec:
                     kubectl -n "$NS" delete pvc "$c" --ignore-not-found || true
                   done
 
-                  echo "Creating clone PVCs from live Longhorn volumes..."
-                  VW_SIZE=$(kubectl -n "$NS" get pvc vaultwarden-data-pvc -o jsonpath='{.spec.resources.requests.storage}')
-                  DS_SIZE=$(kubectl -n "$NS" get pvc docuseal-data-pvc   -o jsonpath='{.spec.resources.requests.storage}')
-                  kubectl -n "$NS" apply -f - <<CLONE
+                  if [ -n "$CLONES" ]; then
+                    echo "Creating clone PVCs from live Longhorn volumes..."
+                    VW_SIZE=$(kubectl -n "$NS" get pvc vaultwarden-data-pvc -o jsonpath='{.spec.resources.requests.storage}')
+                    DS_SIZE=$(kubectl -n "$NS" get pvc docuseal-data-pvc   -o jsonpath='{.spec.resources.requests.storage}')
+                    for c in $CLONES; do
+                      case "$c" in
+                        vaultwarden-data-backup-clone) SRC=vaultwarden-data-pvc; SIZE=$VW_SIZE ;;
+                        docuseal-data-backup-clone)    SRC=docuseal-data-pvc;    SIZE=$DS_SIZE ;;
+                      esac
+                      kubectl -n "$NS" apply -f - <<CLONE
                   apiVersion: v1
                   kind: PersistentVolumeClaim
                   metadata:
-                    name: vaultwarden-data-backup-clone
+                    name: $${c}
                     labels: { app: pvc-backup }
                   spec:
                     storageClassName: longhorn
                     accessModes: ["ReadWriteOnce"]
-                    resources: { requests: { storage: $${VW_SIZE} } }
-                    dataSource: { kind: PersistentVolumeClaim, name: vaultwarden-data-pvc }
-                  ---
-                  apiVersion: v1
-                  kind: PersistentVolumeClaim
-                  metadata:
-                    name: docuseal-data-backup-clone
-                    labels: { app: pvc-backup }
-                  spec:
-                    storageClassName: longhorn
-                    accessModes: ["ReadWriteOnce"]
-                    resources: { requests: { storage: $${DS_SIZE} } }
-                    dataSource: { kind: PersistentVolumeClaim, name: docuseal-data-pvc }
+                    resources: { requests: { storage: $${SIZE} } }
+                    dataSource: { kind: PersistentVolumeClaim, name: $${SRC} }
                   CLONE
-
-                  echo "Waiting for clone PVCs to bind..."
-                  for c in $CLONES; do
-                    for i in $(seq 1 60); do
-                      PHASE=$(kubectl -n "$NS" get pvc "$c" -o jsonpath='{.status.phase}' 2>/dev/null || echo "")
-                      [ "$PHASE" = "Bound" ] && break
-                      sleep 5
                     done
-                    [ "$PHASE" = "Bound" ] || { echo "Clone $c did not bind (phase=$PHASE)"; exit 1; }
-                    echo "  ✓ $c Bound"
-                  done
+
+                    echo "Waiting for clone PVCs to bind..."
+                    for c in $CLONES; do
+                      for i in $(seq 1 60); do
+                        PHASE=$(kubectl -n "$NS" get pvc "$c" -o jsonpath='{.status.phase}' 2>/dev/null || echo "")
+                        [ "$PHASE" = "Bound" ] && break
+                        sleep 5
+                      done
+                      [ "$PHASE" = "Bound" ] || { echo "Clone $c did not bind (phase=$PHASE)"; exit 1; }
+                      echo "  ✓ $c Bound"
+                    done
+                  else
+                    echo "No longhorn-backed data PVCs — all sources mounted live (local-path)."
+                  fi
 
                   echo "Launching mounter Job $MOUNTER..."
                   kubectl -n "$NS" apply -f - <<MJOB
@@ -137,10 +173,15 @@ spec:
                           # list referenced decommissioned nodes (k3s-1/2/3,
                           # k3w-1/2/3) that no longer exist on fleet — dead drift,
                           # removed. [T000368]
+                          # When a data PVC is local-path (korczewski), the per-source
+                          # affinity snippets below add a podAffinity term for that
+                          # source's owning pod so the LIVE RWO volume is shareable on
+                          # the same node; they are empty for longhorn-cloned sources
+                          # (mentolder), leaving only the nextcloud term. [T000403]
                           podAffinity:
                             requiredDuringSchedulingIgnoredDuringExecution:
                               - labelSelector: { matchLabels: { app: nextcloud } }
-                                topologyKey: kubernetes.io/hostname
+                                topologyKey: kubernetes.io/hostname$${VW_AFFINITY}$${DS_AFFINITY}
                         securityContext:
                           runAsNonRoot: true
                           runAsUser: 65534
@@ -255,9 +296,9 @@ spec:
                           - name: nextcloud-data
                             persistentVolumeClaim: { claimName: nextcloud-data-pvc }
                           - name: vaultwarden-data
-                            persistentVolumeClaim: { claimName: vaultwarden-data-backup-clone }
+                            persistentVolumeClaim: { claimName: $${VW_CLAIM} }
                           - name: docuseal-data
-                            persistentVolumeClaim: { claimName: docuseal-data-backup-clone }
+                            persistentVolumeClaim: { claimName: $${DS_CLAIM} }
                           - name: staging
                             emptyDir: {}
                   MJOB

--- a/k3d/website-schema.yaml
+++ b/k3d/website-schema.yaml
@@ -47,6 +47,28 @@ data:
         END IF;
       END $$;
 
+      -- db-backup runs `pg_dump -U website -d website`. Schemas whose tables
+      -- are owned by another role (arena_app, postgres) fail "permission
+      -- denied for table ..." mid-dump, marking the whole CronJob Failed.
+      -- Grant website read access on every backup-relevant schema so the dump
+      -- covers the full DB. Mirrors the arena_app grant above (guarded per
+      -- schema so it is a no-op when a schema is absent — e.g. arena on
+      -- mentolder/dev). Idempotent; re-applies on every cluster reset. [T000403]
+      DO $$
+      DECLARE
+        s TEXT;
+      BEGIN
+        FOREACH s IN ARRAY ARRAY['public','arena','bugs','bachelorprojekt','platform','meetings'] LOOP
+          IF EXISTS (SELECT FROM pg_namespace WHERE nspname = s) THEN
+            EXECUTE format('GRANT USAGE ON SCHEMA %I TO website', s);
+            EXECUTE format('GRANT SELECT ON ALL TABLES IN SCHEMA %I TO website', s);
+            EXECUTE format('GRANT SELECT ON ALL SEQUENCES IN SCHEMA %I TO website', s);
+            EXECUTE format('ALTER DEFAULT PRIVILEGES IN SCHEMA %I GRANT SELECT ON TABLES TO website', s);
+            EXECUTE format('ALTER DEFAULT PRIVILEGES IN SCHEMA %I GRANT SELECT ON SEQUENCES TO website', s);
+          END IF;
+        END LOOP;
+      END $$;
+
       CREATE TABLE IF NOT EXISTS customers (
           id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
           name TEXT NOT NULL,
@@ -717,6 +739,28 @@ data:
         IF EXISTS (SELECT FROM pg_roles WHERE rolname = 'arena_app') THEN
           GRANT SELECT, REFERENCES ON public.brands TO arena_app;
         END IF;
+      END $$;
+
+      -- db-backup runs `pg_dump -U website -d website`. Schemas whose tables
+      -- are owned by another role (arena_app, postgres) fail "permission
+      -- denied for table ..." mid-dump, marking the whole CronJob Failed.
+      -- Grant website read access on every backup-relevant schema so the dump
+      -- covers the full DB. Mirrors the arena_app grant above (guarded per
+      -- schema so it is a no-op when a schema is absent — e.g. arena on
+      -- mentolder/dev). Idempotent; re-applies on every cluster reset. [T000403]
+      DO $$
+      DECLARE
+        s TEXT;
+      BEGIN
+        FOREACH s IN ARRAY ARRAY['public','arena','bugs','bachelorprojekt','platform','meetings'] LOOP
+          IF EXISTS (SELECT FROM pg_namespace WHERE nspname = s) THEN
+            EXECUTE format('GRANT USAGE ON SCHEMA %I TO website', s);
+            EXECUTE format('GRANT SELECT ON ALL TABLES IN SCHEMA %I TO website', s);
+            EXECUTE format('GRANT SELECT ON ALL SEQUENCES IN SCHEMA %I TO website', s);
+            EXECUTE format('ALTER DEFAULT PRIVILEGES IN SCHEMA %I GRANT SELECT ON TABLES TO website', s);
+            EXECUTE format('ALTER DEFAULT PRIVILEGES IN SCHEMA %I GRANT SELECT ON SEQUENCES TO website', s);
+          END IF;
+        END LOOP;
       END $$;
 
       CREATE TABLE IF NOT EXISTS customers (

--- a/tests/unit/manifests.bats
+++ b/tests/unit/manifests.bats
@@ -567,6 +567,32 @@ PY
   assert_failure
 }
 
+# ── pvc-backup gates Longhorn cloning on storageClassName (T000403) ──
+# The orchestrator UNCONDITIONALLY cloned the vaultwarden+docuseal data PVCs
+# via Longhorn CSI, then waited for the clones to bind. korczewski has no
+# Longhorn install → those PVCs stay on local-path (no CSI clone support) →
+# the clones never bind → the bind loop times out → the whole CronJob Failed.
+# The fix detects each data PVC's storageClassName and only clones the
+# longhorn-backed sources; local-path sources are tarred LIVE by the mounter
+# co-located on the owning pod's node. Pin the storageclass gate so a
+# regression to unconditional cloning fails CI.
+@test "pvc-backup gates clone creation on storageClassName == longhorn (T000403)" {
+  # Orchestrator must read each data PVC's storageClassName.
+  grep -q 'get pvc vaultwarden-data-pvc -o jsonpath=.*storageClassName' k3d/pvc-backup-cronjob.yaml
+  grep -q 'get pvc docuseal-data-pvc'   k3d/pvc-backup-cronjob.yaml
+  # And the clone list must be built conditionally on the longhorn class —
+  # not the old static "both clones always" assignment.
+  grep -qE '\[ "\$VW_SC" = "longhorn" \]' k3d/pvc-backup-cronjob.yaml
+  grep -qE '\[ "\$DS_SC" = "longhorn" \]' k3d/pvc-backup-cronjob.yaml
+}
+
+@test "pvc-backup no longer unconditionally clones both data PVCs (T000403)" {
+  # The regression shape: a static CLONES assignment naming both clones
+  # (ignoring comment lines). Must be absent — cloning is now gated.
+  run bash -c "grep -vE '^[[:space:]]*#' k3d/pvc-backup-cronjob.yaml | grep -E 'CLONES=\"vaultwarden-data-backup-clone docuseal-data-backup-clone\"'"
+  assert_failure
+}
+
 # ── tests-results-retention has no stale node-location affinity (T000369) ──
 # The CronJob required nodeAffinity node-location=hetzner, but no fleet node
 # carries that label after Phase 3 consolidation → unschedulable on all 6


### PR DESCRIPTION
## Summary

The shared `pvc-backup` CronJob Failed on **korczewski** because the orchestrator unconditionally cloned the vaultwarden + docuseal data PVCs via Longhorn CSI. korczewski has no Longhorn install, so those PVCs stay on the base `local-path` storageclass (no CSI clone support) — the clone PVCs never provision, the orchestrator's bind loop times out, and the whole Job Failed. mentolder works only because `prod-mentolder/patch-data-pvc-storage.yaml` repoints both PVCs to `longhorn`.

### PART A — pvc-backup storageclass-aware cloning (`k3d/pvc-backup-cronjob.yaml`)
- Orchestrator now reads each data PVC's `storageClassName` and **only clones the longhorn-backed sources**. The clone-create + bind-wait block is skipped entirely when no source is longhorn-backed.
- For `local-path` sources the mounter mounts the **LIVE** PVC (readOnly) and co-locates on the owning pod's node via an added `podAffinity` term (the same model already used for `nextcloud-data`). The vaultwarden/docuseal volume `claimName`s and the affinity terms are assembled conditionally per source.
- **mentolder path is byte-identical**: both clone PVCs created, mounter has the single nextcloud affinity term, volumes point at the clones. Verified by rendering + a stubbed orchestrator run for both `longhorn` and `local-path` storageclasses.
- The tar / encrypt / staging / filen-upload command bodies are unchanged — only source-volume plumbing + node placement.
- Two new `tests/unit/manifests.bats` assertions pin the storageclass gate (`[ "$VW_SC" = "longhorn" ]`) and assert the old unconditional `CLONES="...both..."` line is gone, so a regression to unconditional cloning fails CI.

### PART B — codify the db-backup grant (`k3d/website-schema.yaml`)
The live db-backup fix granted role `website` `SELECT` (+ `USAGE` + default privileges) on the backup-relevant schemas of the website DB so `pg_dump -U website -d website` no longer fails "permission denied for table ..." mid-dump (e.g. on `arena.*`, owned by `arena_app`). This PR adds an idempotent, per-schema-guarded `GRANT` block to **both** the init and ensure schema-seeding scripts, right after the existing `arena_app → public.brands` grant it mirrors, so a fresh cluster / reset re-applies it. The block no-ops on absent schemas (e.g. `arena` on mentolder/dev).

> Note: the db-backup half was already fixed live (grants) — this PR only **codifies** it. No `k3d/backup-cronjob.yaml` change.

## Offline verification (all green)
- `kubectl kustomize prod-fleet/korczewski` + `prod-fleet/mentolder` render and `kubectl apply --dry-run=client` cleanly.
- `task workspace:validate` passes (`configmap/website-schema` + `cronjob.batch/pvc-backup` both `configured (dry run)`).
- `tests/unit/manifests.bats` — **36/36 pass**, including the two new T000403 assertions.
- Full deploy transform simulated (`kustomize | envsubst | sed 's/\$\$.../$.../'`): final orchestrator script passes `sh -n`; generated mounter Job is valid YAML for both brands — korczewski mounts 3 live PVCs with nextcloud+vaultwarden+docuseal affinity; mentolder mounts 2 clones with nextcloud-only affinity.
- `test-inventory.json` regenerated — no diff (new bats names don't feed the requirement inventory).

## ⚠️ HELD FOR REVIEW — verify before merge
- **PART A node placement needs LIVE verification.** Offline rendering cannot prove the mounter actually schedules. After merge + deploy, trigger a korczewski run and confirm it succeeds:
  `kubectl --context fleet -n workspace-korczewski create job pvc-backup-verify-$(date +%s) --from=cronjob/pvc-backup` then check the mounter Job reaches Complete and the three `*.tar.gz.enc` archives land on `backup-pvc`.
  - The mounter now requires nextcloud **+** vaultwarden **+** docuseal pods to be **co-located on one node** (single-Job tri-co-location). If they are scattered across nodes the mounter stays **Pending** (a different failure with the same Failed-Job symptom). The more robust alternative — **per-PVC local-path mounter Jobs** (one per source, each co-located with only its owning pod) — was deliberately deferred to keep this change small and the longhorn path byte-identical; revisit if korczewski's pods don't co-locate reliably.
  - Confirm mentolder's next scheduled `pvc-backup` still clones + completes (longhorn path unchanged, but worth a live spot-check).
- **PART B** is a fresh-cluster/reset safety net; it does not re-grant on already-running clusters until shared-db restarts (postStart re-runs the ensure script). The live grant is already in place, so no immediate action — but confirm a future korczewski reset re-applies it (or run the existing `task workspace:fix-tickets-grants` / the arena migration as the remediation path).
- Reviewer should sanity-check the `$$`-escaping of the new orchestrator vars (`$${VW_CLAIM}`, `$${VW_AFFINITY}`, `$${c}`, `$${SIZE}`, `$${SRC}`) — they must collapse to single-`$` only at deploy time, which the simulation confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)