### PR TITLE
fix(scripts): resolve ENV from positional brand arg in keycloak-sync.sh [T000405]

### DIFF
--- a/scripts/keycloak-sync.sh
+++ b/scripts/keycloak-sync.sh
@@ -10,6 +10,7 @@
 # Usage:
 #   bash scripts/keycloak-sync.sh
 #   ENV=mentolder bash scripts/keycloak-sync.sh
+#   bash scripts/keycloak-sync.sh korczewski   # positional brand arg
 #   task keycloak:sync ENV=mentolder
 # ═══════════════════════════════════════════════════════════════════════
 set -euo pipefail
@@ -17,7 +18,10 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # ── Environment ───────────────────────────────────────────────────────
-ENV="${ENV:-dev}"
+# ENV= env-var wins (Taskfile call site); fall back to a positional brand arg
+# so `bash scripts/keycloak-sync.sh korczewski` resolves correctly (matches
+# keycloak-ensure-mappers.sh / check-connectivity.sh). [T000405]
+ENV="${ENV:-${1:-dev}}"
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/env-resolve.sh" "$ENV" "$SCRIPT_DIR/../environments"
 # shellcheck disable=SC1091


### PR DESCRIPTION
Closes T000405. Mirrors the merged T000400 fix.

`scripts/keycloak-sync.sh` resolved `ENV` only from the env-var (`ENV="${ENV:-dev}"`), so the documented positional invocation `bash scripts/keycloak-sync.sh korczewski` silently fell back to `dev` → `auth.localhost`. Now `ENV="${ENV:-${1:-dev}}"`: the `ENV=` form keeps precedence (the only call site, Taskfile.yml:1993 `ENV={{.ENV}} bash ...`, is unaffected) and a positional brand arg works.

**Offline test:** positional `korczewski`→korczewski; `ENV=mentolder` + positional `korczewski`→mentolder; neither→dev. `bash -n` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)