### PR TITLE
fix(website): ensure questionnaire+systemtest schema in cron endpoints [T000406]

### DIFF
--- a/website/src/lib/questionnaire-db.ensure.test.ts
+++ b/website/src/lib/questionnaire-db.ensure.test.ts
@@ -1,0 +1,92 @@
+// website/src/lib/questionnaire-db.ensure.test.ts
+//
+// Offline (no real DB) regression test for T000406.
+//
+// Root cause: the questionnaire_* / systemtest_* schema was only ever created
+// by questionnaire-db.ts's fire-and-forget initDb() at module-load time, which
+// only runs when questionnaire-db is imported. The background system-test
+// CronJob endpoints (drain-outbox / cleanup-fixtures / purge-all) import only
+// website-db, so on a fresh korczewski pod that never served a questionnaire/
+// admin page the tables never existed and the cron endpoints 500'd.
+//
+// Fix: ensureQuestionnaireSchemaOnce(pool) — a memoised wrapper the cron
+// endpoints call before querying. This test pins the two guarantees the fix
+// relies on:
+//   1. It actually emits the questionnaire CREATE DDL (so the tables get made).
+//   2. It runs that DDL AT MOST ONCE per process, even across many calls and
+//      even when called concurrently (the ensureSchemaOnce run-once gate).
+//
+// We mock `pg` with a CountingPool that swallows every statement and returns an
+// empty result, so we don't need a live Postgres or pg-mem DDL compatibility —
+// we only care how many times the schema CREATE DDL is issued. Mirrors the
+// pattern in platform-db.ensure.test.ts.
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('pg', () => {
+  class CountingPool {
+    static questionnaireCreateDdlCount = 0;
+    async query(textOrConfig: unknown, _values?: unknown): Promise<unknown> {
+      const sql =
+        typeof textOrConfig === 'string'
+          ? textOrConfig
+          : (textOrConfig as { text?: string })?.text ?? '';
+      // Count only the leading CREATE of the questionnaire_templates table —
+      // the first statement ensureQuestionnaireSchema() issues. (Other CREATE
+      // TABLE statements merely REFERENCE questionnaire_templates in a FK, so a
+      // looser regex would over-count a single schema run.)
+      if (/^\s*create\s+table\s+if\s+not\s+exists\s+questionnaire_templates\b/i.test(sql)) {
+        CountingPool.questionnaireCreateDdlCount += 1;
+      }
+      return { rows: [], rowCount: 0 };
+    }
+    async connect(): Promise<{ query: () => Promise<unknown>; release: () => void }> {
+      return { query: async () => ({ rows: [], rowCount: 0 }), release: () => {} };
+    }
+    async end(): Promise<void> {}
+  }
+  return { default: { Pool: CountingPool }, Pool: CountingPool };
+});
+
+// website-db pulls in tickets-db / transition at import; stub them so the module
+// graph loads without a DB. ensureSchemaOnce + __resetSchemaInitCacheForTests
+// are pure and come through the real website-db module.
+vi.mock('./tickets-db', () => ({ initTicketsSchema: vi.fn().mockResolvedValue(undefined) }));
+vi.mock('./tickets/transition', () => ({ transitionTicket: vi.fn().mockResolvedValue(undefined) }));
+
+import { pool, __resetSchemaInitCacheForTests } from './website-db';
+import { ensureQuestionnaireSchemaOnce } from './questionnaire-db';
+
+const CountingPool = (pool as unknown as {
+  constructor: { questionnaireCreateDdlCount: number };
+}).constructor;
+
+describe('ensureQuestionnaireSchemaOnce (T000406)', () => {
+  beforeEach(() => {
+    __resetSchemaInitCacheForTests();
+    CountingPool.questionnaireCreateDdlCount = 0;
+  });
+
+  it('issues the questionnaire schema CREATE DDL on first call', async () => {
+    await ensureQuestionnaireSchemaOnce(pool as never);
+    expect(CountingPool.questionnaireCreateDdlCount).toBe(1);
+  });
+
+  it('runs the schema DDL at most once across repeated sequential calls', async () => {
+    await ensureQuestionnaireSchemaOnce(pool as never);
+    await ensureQuestionnaireSchemaOnce(pool as never);
+    await ensureQuestionnaireSchemaOnce(pool as never);
+    // ensureSchemaOnce memoises the init promise → DDL emitted exactly once.
+    expect(CountingPool.questionnaireCreateDdlCount).toBe(1);
+  });
+
+  it('runs the schema DDL at most once under concurrent callers', async () => {
+    await Promise.all([
+      ensureQuestionnaireSchemaOnce(pool as never),
+      ensureQuestionnaireSchemaOnce(pool as never),
+      ensureQuestionnaireSchemaOnce(pool as never),
+      ensureQuestionnaireSchemaOnce(pool as never),
+    ]);
+    expect(CountingPool.questionnaireCreateDdlCount).toBe(1);
+  });
+});

--- a/website/src/lib/questionnaire-db.ts
+++ b/website/src/lib/questionnaire-db.ts
@@ -3,6 +3,7 @@ import { resolve4 } from 'dns';
 import { SYSTEM_TEST_TEMPLATES, type SystemTestTemplate } from './system-test-seed-data';
 import { ensureSystemtestSchema } from './systemtest/db';
 import { openFailureTicket, enqueueOutboxRetry } from './systemtest/failure-bridge';
+import { ensureSchemaOnce } from './website-db';
 
 const DB_URL = process.env.SESSIONS_DATABASE_URL
   || 'postgresql://website:devwebsitedb@shared-db.workspace.svc.cluster.local:5432/website';
@@ -234,8 +235,24 @@ async function updateSystemTestTemplate(
   }
 }
 
-async function initDb() {
-  await pool.query(`
+/**
+ * Idempotent DDL for the questionnaire + system-test schema.
+ *
+ * Creates every questionnaire_* table, the back-ref columns, the
+ * v_questionnaire_kpi view, and (via ensureSystemtestSchema) the systemtest_*
+ * tables + failure-board view + retest trigger. ALL statements use
+ * IF NOT EXISTS / OR REPLACE / DO-block guards, so repeated calls are safe.
+ *
+ * Split out of initDb() so callers can ensure the tables exist WITHOUT running
+ * the system-test template seeding (syncSystemTestTemplates). See T000406: the
+ * background CronJob endpoints (drain-outbox / cleanup-fixtures / purge-all)
+ * import only website-db, never questionnaire-db, so on a fresh korczewski pod
+ * that never served a questionnaire/admin page initDb() never ran and the cron
+ * endpoints 500'd with "relation systemtest_failure_outbox does not exist".
+ * Those endpoints now call ensureQuestionnaireSchemaOnce() before querying.
+ */
+export async function ensureQuestionnaireSchema(targetPool: pg.Pool = pool): Promise<void> {
+  await targetPool.query(`
     CREATE TABLE IF NOT EXISTS questionnaire_templates (
       id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
       title TEXT NOT NULL,
@@ -246,7 +263,7 @@ async function initDb() {
       updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
     )
   `);
-  await pool.query(`
+  await targetPool.query(`
     CREATE TABLE IF NOT EXISTS questionnaire_dimensions (
       id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
       template_id UUID NOT NULL REFERENCES questionnaire_templates(id) ON DELETE CASCADE,
@@ -258,7 +275,7 @@ async function initDb() {
       created_at TIMESTAMPTZ NOT NULL DEFAULT now()
     )
   `);
-  await pool.query(`
+  await targetPool.query(`
     CREATE TABLE IF NOT EXISTS questionnaire_questions (
       id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
       template_id UUID NOT NULL REFERENCES questionnaire_templates(id) ON DELETE CASCADE,
@@ -268,7 +285,7 @@ async function initDb() {
       created_at TIMESTAMPTZ NOT NULL DEFAULT now()
     )
   `);
-  await pool.query(`
+  await targetPool.query(`
     CREATE TABLE IF NOT EXISTS questionnaire_answer_options (
       id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
       question_id UUID NOT NULL REFERENCES questionnaire_questions(id) ON DELETE CASCADE,
@@ -278,7 +295,7 @@ async function initDb() {
       weight INTEGER NOT NULL DEFAULT 1
     )
   `);
-  await pool.query(`
+  await targetPool.query(`
     CREATE TABLE IF NOT EXISTS questionnaire_assignments (
       id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
       customer_id UUID NOT NULL,
@@ -290,7 +307,7 @@ async function initDb() {
       reviewed_at TIMESTAMPTZ
     )
   `);
-  await pool.query(`
+  await targetPool.query(`
     CREATE TABLE IF NOT EXISTS questionnaire_answers (
       id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
       assignment_id UUID NOT NULL REFERENCES questionnaire_assignments(id) ON DELETE CASCADE,
@@ -301,20 +318,20 @@ async function initDb() {
     )
   `);
   // Migrations for test_step question type
-  await pool.query(`ALTER TABLE questionnaire_questions
+  await targetPool.query(`ALTER TABLE questionnaire_questions
     ADD COLUMN IF NOT EXISTS test_expected_result TEXT,
     ADD COLUMN IF NOT EXISTS test_function_url TEXT,
     ADD COLUMN IF NOT EXISTS test_menu_path TEXT,
     ADD COLUMN IF NOT EXISTS test_role TEXT`);
-  await pool.query(`ALTER TABLE questionnaire_answers
+  await targetPool.query(`ALTER TABLE questionnaire_answers
     ADD COLUMN IF NOT EXISTS details_text TEXT`);
-  await pool.query(`ALTER TABLE questionnaire_templates
+  await targetPool.query(`ALTER TABLE questionnaire_templates
     ADD COLUMN IF NOT EXISTS is_system_test BOOLEAN NOT NULL DEFAULT false`);
-  await pool.query(`ALTER TABLE questionnaire_assignments ADD COLUMN IF NOT EXISTS dismissed_at TIMESTAMPTZ`);
-  await pool.query(`ALTER TABLE questionnaire_assignments ADD COLUMN IF NOT EXISTS dismiss_reason TEXT`);
-  await pool.query(`ALTER TABLE questionnaire_assignments ADD COLUMN IF NOT EXISTS project_id UUID REFERENCES tickets.tickets(id) ON DELETE SET NULL`);
-  await pool.query(`ALTER TABLE questionnaire_assignments ADD COLUMN IF NOT EXISTS archived_at TIMESTAMPTZ`);
-  await pool.query(`
+  await targetPool.query(`ALTER TABLE questionnaire_assignments ADD COLUMN IF NOT EXISTS dismissed_at TIMESTAMPTZ`);
+  await targetPool.query(`ALTER TABLE questionnaire_assignments ADD COLUMN IF NOT EXISTS dismiss_reason TEXT`);
+  await targetPool.query(`ALTER TABLE questionnaire_assignments ADD COLUMN IF NOT EXISTS project_id UUID REFERENCES tickets.tickets(id) ON DELETE SET NULL`);
+  await targetPool.query(`ALTER TABLE questionnaire_assignments ADD COLUMN IF NOT EXISTS archived_at TIMESTAMPTZ`);
+  await targetPool.query(`
     CREATE TABLE IF NOT EXISTS questionnaire_test_status (
       question_id UUID PRIMARY KEY REFERENCES questionnaire_questions(id) ON DELETE CASCADE,
       last_result TEXT NOT NULL CHECK (last_result IN ('erfüllt', 'teilweise', 'nicht_erfüllt')),
@@ -323,7 +340,7 @@ async function initDb() {
       last_assignment_id UUID
     )
   `);
-  await pool.query(`
+  await targetPool.query(`
     DO $$
     BEGIN
       IF NOT EXISTS (
@@ -337,7 +354,7 @@ async function initDb() {
       END IF;
     END$$
   `);
-  await pool.query(`
+  await targetPool.query(`
     CREATE TABLE IF NOT EXISTS questionnaire_assignment_scores (
       id             UUID PRIMARY KEY DEFAULT gen_random_uuid(),
       assignment_id  UUID NOT NULL REFERENCES questionnaire_assignments(id) ON DELETE CASCADE,
@@ -350,17 +367,17 @@ async function initDb() {
       CONSTRAINT uq_qas_assignment_dimension UNIQUE (assignment_id, dimension_id)
     )
   `);
-  await pool.query(
+  await targetPool.query(
     `ALTER TABLE IF EXISTS questionnaire_assignment_scores DROP COLUMN IF EXISTS dimension_name;`
   );
-  await pool.query(
+  await targetPool.query(
     `CREATE INDEX IF NOT EXISTS idx_qas_assignment ON questionnaire_assignment_scores(assignment_id)`,
   );
-  await pool.query(`CREATE SCHEMA IF NOT EXISTS bachelorprojekt`);
+  await targetPool.query(`CREATE SCHEMA IF NOT EXISTS bachelorprojekt`);
   // ensureSystemtestSchema must run before the v_questionnaire_kpi view
   // because the view references questionnaire_test_evidence (created there).
-  await ensureSystemtestSchema(pool);
-  await pool.query(`
+  await ensureSystemtestSchema(targetPool);
+  await targetPool.query(`
     CREATE OR REPLACE VIEW bachelorprojekt.v_questionnaire_kpi AS
     SELECT
       a.id              AS assignment_id,
@@ -392,6 +409,27 @@ async function initDb() {
     ) ev ON true
     WHERE a.status = 'archived'
   `);
+}
+
+/**
+ * Run-once wrapper around ensureQuestionnaireSchema(), memoised per process via
+ * the shared ensureSchemaOnce gate (see website-db.ts / T000304). Safe to call
+ * on the hot path of any number of concurrent requests — the idempotent DDL is
+ * executed at most once and a rejected init is evicted so a later call retries.
+ *
+ * This is the entry point the background system-test CronJob endpoints
+ * (drain-outbox / cleanup-fixtures / purge-all-test-data) call before touching
+ * the questionnaire_* / systemtest_* tables, so the schema reliably exists even
+ * on a pod that has never imported questionnaire-db (T000406). It takes the
+ * caller's pool so the endpoints can ensure against the very pool they query
+ * (website-db's pool), not just this module's private pool.
+ */
+export function ensureQuestionnaireSchemaOnce(targetPool: pg.Pool = pool): Promise<void> {
+  return ensureSchemaOnce('questionnaire-schema', () => ensureQuestionnaireSchema(targetPool));
+}
+
+async function initDb() {
+  await ensureQuestionnaireSchemaOnce(pool);
   await syncSystemTestTemplates();
 }
 

--- a/website/src/pages/api/admin/systemtest/cleanup-fixtures.ts
+++ b/website/src/pages/api/admin/systemtest/cleanup-fixtures.ts
@@ -11,6 +11,7 @@ import type { APIRoute } from 'astro';
 import { pool } from '../../../../lib/website-db';
 import { getSession, isAdmin } from '../../../../lib/auth';
 import { purgeFixturesFor, purgeExpiredMagicTokens } from '../../../../lib/systemtest/cleanup';
+import { ensureQuestionnaireSchemaOnce } from '../../../../lib/questionnaire-db';
 
 export const POST: APIRoute = async ({ request }) => {
   const cronSecret = request.headers.get('X-Cron-Secret');
@@ -21,6 +22,12 @@ export const POST: APIRoute = async ({ request }) => {
   }
 
   try {
+    // Defensive, idempotent schema-ensure: this CronJob endpoint imports only
+    // website-db (never questionnaire-db), so on a fresh pod that never served a
+    // questionnaire/admin page the questionnaire_* / systemtest_* tables may not
+    // exist yet and the sweeps below would 500 (T000406). Memoised — runs the
+    // DDL at most once per process.
+    await ensureQuestionnaireSchemaOnce(pool);
     const fixtures = await purgeFixturesFor(pool, { graceHours: 24 });
     const tokens = await purgeExpiredMagicTokens(pool);
     return new Response(

--- a/website/src/pages/api/admin/systemtest/drain-outbox.ts
+++ b/website/src/pages/api/admin/systemtest/drain-outbox.ts
@@ -12,6 +12,7 @@ import { pool } from '../../../../lib/website-db';
 import { getSession, isAdmin } from '../../../../lib/auth';
 import { drainOutbox } from '../../../../lib/systemtest/cleanup';
 import { runReconciler } from '../../../../lib/systemtest/reconciler';
+import { ensureQuestionnaireSchemaOnce } from '../../../../lib/questionnaire-db';
 
 export const POST: APIRoute = async ({ request }) => {
   const cronSecret = request.headers.get('X-Cron-Secret');
@@ -22,6 +23,12 @@ export const POST: APIRoute = async ({ request }) => {
   }
 
   try {
+    // Defensive, idempotent schema-ensure: these CronJob endpoints import only
+    // website-db (never questionnaire-db), so on a fresh pod that never served a
+    // questionnaire/admin page the questionnaire_* / systemtest_* tables may not
+    // exist yet and the queries below would 500 (T000406). Memoised — runs the
+    // DDL at most once per process.
+    await ensureQuestionnaireSchemaOnce(pool);
     const outbox = await drainOutbox(pool);
     const reconciler = await runReconciler(pool);
     return new Response(

--- a/website/src/pages/api/admin/systemtest/purge-all-test-data.ts
+++ b/website/src/pages/api/admin/systemtest/purge-all-test-data.ts
@@ -15,6 +15,7 @@ import type { APIRoute } from 'astro';
 import { pool } from '../../../../lib/website-db';
 import { getSession, isAdmin } from '../../../../lib/auth';
 import { purgeAllTestData } from '../../../../lib/systemtest/purge-all';
+import { ensureQuestionnaireSchemaOnce } from '../../../../lib/questionnaire-db';
 
 export const POST: APIRoute = async ({ request }) => {
   const cronSecret = request.headers.get('X-Cron-Secret');
@@ -25,6 +26,12 @@ export const POST: APIRoute = async ({ request }) => {
   }
 
   try {
+    // Defensive, idempotent schema-ensure: this CronJob endpoint imports only
+    // website-db (never questionnaire-db), so on a fresh pod that never served a
+    // questionnaire/admin page the questionnaire_* / systemtest_* tables may not
+    // exist yet. tickets.fn_purge_test_data() DELETEs from them unconditionally,
+    // so it would 500 without the tables (T000406). Memoised — runs at most once.
+    await ensureQuestionnaireSchemaOnce(pool);
     const counts = await purgeAllTestData(pool);
     return new Response(
       JSON.stringify({ ok: true, counts }),


### PR DESCRIPTION
## Problem

The nightly **E2E (Live Production)** Action failed on **both brands**. Root cause is on **korczewski**: its `website` DB (ns `workspace-korczewski`, context `fleet`) is missing the entire `questionnaire_*` + `systemtest_*` schema, while mentolder's has all of it.

The schema is created **only** by `questionnaire-db.ts`'s fire-and-forget `initDb()` at **module-load time** — which runs only when `questionnaire-db` is actually imported into the process. The three system-test CronJob endpoints (`drain-outbox`, `cleanup-fixtures`, `purge-all-test-data`) import only `website-db`, **never** `questionnaire-db`, so on a fresh korczewski pod that never served a questionnaire/admin page the schema was never created. Every cron run then 500'd:

```
[systemtest/drain-outbox] failed: relation "systemtest_failure_outbox" does not exist
[systemtest/cleanup-fixtures] failed: relation "questionnaire_test_fixtures" does not exist
```

→ curl `-sf` exits 22 → CronJobs `Error` every run (~43h). mentolder's pod had served questionnaire pages, so its `initDb()` had run and the tables existed — hence the asymmetry. `SYSTEMTEST_LOOP_ENABLED=true` for both brands, so korczewski is intended to run system-test; the schema was genuinely missing, not intentionally absent.

## Fix

- Extract the questionnaire + system-test DDL out of `initDb()` into an exported, idempotent **`ensureQuestionnaireSchema(pool)`**, and add a process-memoised **`ensureQuestionnaireSchemaOnce(pool)`** built on the shared `ensureSchemaOnce` run-once gate (the T000304 hot-path-safe pattern).
- The three cron endpoints now call `ensureQuestionnaireSchemaOnce(pool)` **before** querying — defensive, idempotent (`CREATE TABLE IF NOT EXISTS` throughout), and the DDL runs at most once per process.
- `initDb()` still seeds the system-test templates (`syncSystemTestTemplates`); only the schema half is now shared with the cron path. No behavioural change for the already-working user-facing/admin paths.

## Tests

- New offline unit test `questionnaire-db.ensure.test.ts`: asserts the schema CREATE DDL is emitted on first call and runs **at most once** across repeated sequential and concurrent callers (validates the run-once gate the fix relies on).
- Full website vitest suite: **582 passed / 91 skipped / 0 failed**. Touched files type-check clean. Test-inventory regen produces no diff.

## Safety / deploy

`website/**` changes auto-deploy to **both brands** on merge (`build-website*.yml`). The change is additive and idempotent — safe for both the already-healthy mentolder pods and the broken korczewski pods.

🤖 Generated with [Claude Code](https://claude.com/claude-code)