### PR TITLE
fix(website): guard systemtest test_runs/test_results FK on table presence [T000406]

### DIFF
--- a/website/src/lib/systemtest/db.ts
+++ b/website/src/lib/systemtest/db.ts
@@ -210,12 +210,21 @@ export async function ensureSystemtestSchema(pool: Pool): Promise<void> {
       -- test_runs / test_results FKs: nullable, NO CASCADE — keep the ticket
       -- around if the run/result row gets pruned by a future retention sweep.
       -- ON DELETE SET NULL keeps the ticket discoverable but breaks the link.
-      IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'tickets_source_test_run_fk') THEN
+      -- Guarded on the referenced table existing: test_runs/test_results are
+      -- created by the DB-boot schema hook (ensure-meetings-schema.sh), which on
+      -- a freshly-cut brand (e.g. korczewski) may not have run them yet. Without
+      -- the guard the FK ALTER throws "relation test_runs does not exist" and
+      -- aborts the whole ensure (T000406) even though the systemtest tables were
+      -- already created; the constraint is re-attempted on the next call once the
+      -- table exists. Mirrors the auth.users/bookings guards above.
+      IF to_regclass('public.test_runs') IS NOT NULL
+         AND NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'tickets_source_test_run_fk') THEN
         ALTER TABLE tickets.tickets
           ADD CONSTRAINT tickets_source_test_run_fk
           FOREIGN KEY (source_test_run_id) REFERENCES test_runs(id) ON DELETE SET NULL;
       END IF;
-      IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'tickets_source_test_result_fk') THEN
+      IF to_regclass('public.test_results') IS NOT NULL
+         AND NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'tickets_source_test_result_fk') THEN
         ALTER TABLE tickets.tickets
           ADD CONSTRAINT tickets_source_test_result_fk
           FOREIGN KEY (source_test_result_id) REFERENCES test_results(id) ON DELETE SET NULL;


### PR DESCRIPTION
Follow-up to #1299 (merged).

## Problem

`ensureSystemtestSchema()` adds `tickets_source_test_run_fk` / `tickets_source_test_result_fk` **unconditionally**. On a freshly-cut brand (korczewski) the referenced `public.test_runs` / `public.test_results` tables — created by the DB-boot schema hook `ensure-meetings-schema.sh` — do **not** exist (that hook aborts upstream on korczewski at `relation "knowledge.collections" does not exist`, a separate bug). So the FK `ALTER` throws `relation "test_runs" does not exist` and aborts the whole ensure, **even though the 6 questionnaire/systemtest tables were already created** earlier in the same function.

After #1299's image rolls out, the cron endpoints call `ensureQuestionnaireSchemaOnce()` → `ensureSystemtestSchema()`; without this guard that ensure-once would still reject on korczewski.

## Fix

Guard both FK adds on `to_regclass('public.test_runs'/'test_results') IS NOT NULL`, mirroring the `auth.users` / `bookings.bookings` existence guards already in this same DO block. The constraint is re-attempted on the next ensure call once the table exists. Pure additive hardening; idempotent.

## Tests

`systemtest/db.test.ts` (DB-gated) still skips offline; touched file type-checks clean. No behavioural change on mentolder (where `test_runs`/`test_results` exist).

> Note: this does NOT fix the separate korczewski DB-bootstrap gap (`ensure-meetings-schema.sh` aborting on `knowledge.collections`, leaving `test_runs`/`test_results`/`tickets.fn_purge_test_data` uncreated) — that needs its own infra/db ticket. This change only makes the systemtest ensure resilient to those tables being absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)