### PR TITLE
feat(website): F3 workflow-status-minimap — portal orientation widget

### DIFF
--- a/website/src/components/portal/WorkflowStatusMinimap.svelte
+++ b/website/src/components/portal/WorkflowStatusMinimap.svelte
@@ -1,0 +1,99 @@
+<script lang="ts">
+  import type { WorkflowTrack } from '../../lib/workflow-status';
+
+  let { tracks = [] as WorkflowTrack[] } = $props<{ tracks?: WorkflowTrack[] }>();
+
+  const STORAGE_KEY = 'wf-minimap-collapsed';
+
+  // Collapse state — persisted so the user's choice survives navigation.
+  let collapsed = $state(false);
+  $effect(() => {
+    try {
+      collapsed = localStorage.getItem(STORAGE_KEY) === '1';
+    } catch {
+      /* SSR / privacy mode — default open */
+    }
+  });
+
+  function toggle() {
+    collapsed = !collapsed;
+    try {
+      localStorage.setItem(STORAGE_KEY, collapsed ? '1' : '0');
+    } catch {
+      /* ignore */
+    }
+  }
+
+  // Count of tracks that still need attention (anything not done/empty).
+  const openCount = $derived(
+    tracks.filter((t: WorkflowTrack) => t.status === 'offen' || t.status === 'geplant').length,
+  );
+
+  const statusText: Record<WorkflowTrack['status'], string> = {
+    offen: 'offen',
+    geplant: 'geplant',
+    erledigt: 'erledigt',
+    leer: 'nichts offen',
+  };
+
+  /** Per-step class: completed steps before the current, the current ("du bist
+   *  hier"), and not-yet-reached steps. */
+  function stepClass(track: WorkflowTrack, index: number): string {
+    const step = index + 1; // 1-based
+    if (track.status === 'erledigt') return 'wf-step done';
+    if (step < track.stage.current) return 'wf-step done';
+    if (step === track.stage.current) return 'wf-step here';
+    return 'wf-step';
+  }
+
+  function trackAria(track: WorkflowTrack): string {
+    return `${track.label}: ${statusText[track.status]}, Schritt ${track.stage.current} von ${track.stage.total}`;
+  }
+</script>
+
+{#if tracks.length > 0}
+  <aside
+    class="wf-minimap"
+    role="complementary"
+    aria-label="Workflow-Status-Minimap"
+    data-testid="workflow-minimap"
+  >
+    <button
+      type="button"
+      class="wf-minimap-header"
+      aria-expanded={!collapsed}
+      aria-controls="wf-minimap-body"
+      onclick={toggle}
+    >
+      <span class="wf-minimap-eyebrow">Mein Workflow</span>
+      {#if openCount > 0}
+        <span class="wf-minimap-count" aria-label={`${openCount} offene Schritte`}>{openCount}</span>
+      {/if}
+      <span class="wf-minimap-chevron" class:collapsed aria-hidden="true">▾</span>
+    </button>
+
+    {#if !collapsed}
+      <div class="wf-minimap-body" id="wf-minimap-body">
+        {#each tracks as track (track.key)}
+          <a
+            class="wf-track"
+            href={track.href}
+            aria-label={trackAria(track)}
+            aria-current={track.status === 'offen' || track.status === 'geplant' ? 'step' : undefined}
+          >
+            <span class="wf-track-emoji" aria-hidden="true">{track.emoji}</span>
+            <span class="wf-track-main">
+              <span class="wf-track-label">{track.label}</span>
+              <span class="wf-progress" aria-hidden="true">
+                {#each Array(track.stage.total) as _, i (i)}
+                  <span class={stepClass(track, i)}></span>
+                {/each}
+              </span>
+            </span>
+            <span class={`wf-badge ${track.status}`}>{statusText[track.status]}</span>
+          </a>
+        {/each}
+      </div>
+    {/if}
+  </aside>
+{/if}

--- a/website/src/layouts/PortalLayout.astro
+++ b/website/src/layouts/PortalLayout.astro
@@ -1,10 +1,13 @@
 ---
 import '../styles/global.css';
 import '../styles/sidekick-panels.css';
+import '../styles/workflow-minimap.css';
 import { config } from '../config/index';
 import { isAdmin } from '../lib/auth';
 import type { UserSession } from '../lib/auth';
 import PortalSidekick from '../components/PortalSidekick.svelte';
+import WorkflowStatusMinimap from '../components/portal/WorkflowStatusMinimap.svelte';
+import { getWorkflowStatus, type WorkflowTrack } from '../lib/workflow-status';
 import TicketWidgetBar from '../components/TicketWidgetBar.astro';
 import AssistantWidget from '../components/assistant/AssistantWidget.svelte';
 const ASSISTANT_ENABLED = (process.env.ENABLE_ASSISTANT_PORTAL ?? 'false') === 'true';
@@ -66,6 +69,16 @@ const brandWord     = config.meta.siteTitle.replace(/\.de$/i, '').toLowerCase();
 const userIsAdmin   = isAdmin(session);
 const brandId       = (process.env.BRAND_ID ?? process.env.BRAND ?? 'mentolder').toLowerCase();
 const isKore        = brandId === 'korczewski';
+
+// Workflow-Status-Minimap (F3): aggregate the user's standing across the real
+// portal sources (questionnaires / signatures / bookings). Best-effort — never
+// block the portal render if a source is unavailable.
+let workflowTracks: WorkflowTrack[] = [];
+try {
+  workflowTracks = await getWorkflowStatus(session);
+} catch {
+  workflowTracks = [];
+}
 ---
 
 <!doctype html>
@@ -282,6 +295,9 @@ const isKore        = brandId === 'korczewski';
     ) : null}
     <TicketWidgetBar context="portal" showEdit={!ASSISTANT_ENABLED} />
     <PortalSidekick client:load helpSection={section} helpContext="portal" />
+    {workflowTracks.length > 0 && (
+      <WorkflowStatusMinimap client:load tracks={workflowTracks} />
+    )}
     <SessionExpiryWarning client:load />
 
     <script is:inline>

--- a/website/src/lib/workflow-status.test.ts
+++ b/website/src/lib/workflow-status.test.ts
@@ -1,0 +1,232 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildWorkflowTracks,
+  getWorkflowStatus,
+  questionnaireStage,
+  bookingStage,
+  signatureStage,
+  type WorkflowDeps,
+  type WorkflowSources,
+  type WorkflowTrack,
+} from './workflow-status';
+import type { UserSession } from './auth';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Fixtures — shaped like the real sources (questionnaire assignments, pending
+// signature count, upcoming bookings). Only the fields the aggregator reads.
+// ─────────────────────────────────────────────────────────────────────────────
+
+function qa(status: string): { status: string } {
+  return { status };
+}
+
+const NOW = new Date('2026-06-01T12:00:00Z');
+
+function booking(offsetDays: number, status = 'CONFIRMED'): { start: Date; status: string } {
+  const start = new Date(NOW);
+  start.setDate(start.getDate() + offsetDays);
+  return { start, status };
+}
+
+function trackByKey(tracks: WorkflowTrack[], key: string): WorkflowTrack | undefined {
+  return tracks.find((t) => t.key === key);
+}
+
+describe('questionnaireStage', () => {
+  it('maps the lifecycle status to a 1-based stage out of 4', () => {
+    expect(questionnaireStage('pending')).toBe(1);
+    expect(questionnaireStage('in_progress')).toBe(2);
+    expect(questionnaireStage('submitted')).toBe(3);
+    expect(questionnaireStage('reviewed')).toBe(4);
+    expect(questionnaireStage('archived')).toBe(4);
+  });
+
+  it('treats unknown / dismissed status as the first stage (defensive)', () => {
+    expect(questionnaireStage('dismissed')).toBe(1);
+    expect(questionnaireStage('whatever')).toBe(1);
+  });
+});
+
+describe('bookingStage', () => {
+  it('is "done"/total when no upcoming bookings exist', () => {
+    expect(bookingStage(0)).toEqual({ current: 2, total: 2 });
+  });
+  it('is the first stage when at least one upcoming booking is pending', () => {
+    expect(bookingStage(1)).toEqual({ current: 1, total: 2 });
+    expect(bookingStage(5)).toEqual({ current: 1, total: 2 });
+  });
+});
+
+describe('signatureStage', () => {
+  it('is open (stage 1/2) while signatures are pending', () => {
+    expect(signatureStage(3)).toEqual({ current: 1, total: 2 });
+  });
+  it('is complete (stage 2/2) when nothing is pending', () => {
+    expect(signatureStage(0)).toEqual({ current: 2, total: 2 });
+  });
+});
+
+describe('buildWorkflowTracks', () => {
+  const baseSources: WorkflowSources = {
+    questionnaires: [qa('in_progress'), qa('submitted'), qa('archived')],
+    pendingSignatures: 2,
+    bookings: [booking(-3), booking(4)], // one past, one upcoming
+    now: NOW,
+  };
+
+  it('returns exactly three tracks in a stable order: fragebogen, vertraege, buchung', () => {
+    const tracks = buildWorkflowTracks(baseSources);
+    expect(tracks.map((t) => t.key)).toEqual(['fragebogen', 'vertraege', 'buchung']);
+  });
+
+  it('every track carries label, emoji, status, stage{current,total} and an href', () => {
+    for (const t of buildWorkflowTracks(baseSources)) {
+      expect(typeof t.label).toBe('string');
+      expect(t.label.length).toBeGreaterThan(0);
+      expect(typeof t.emoji).toBe('string');
+      expect(t.emoji.length).toBeGreaterThan(0);
+      expect(typeof t.status).toBe('string');
+      expect(t.stage.total).toBeGreaterThan(0);
+      expect(t.stage.current).toBeGreaterThanOrEqual(1);
+      expect(t.stage.current).toBeLessThanOrEqual(t.stage.total);
+      expect(t.href).toMatch(/^\/portal\?section=/);
+    }
+  });
+
+  it('questionnaire track reflects the FURTHEST-along open assignment as "du bist hier"', () => {
+    // open assignments: in_progress (stage 2) + submitted (stage 3); archived is done.
+    // The least-advanced open one is the actionable "you are here" → stage 2.
+    const t = trackByKey(buildWorkflowTracks(baseSources), 'fragebogen')!;
+    expect(t.stage.total).toBe(4);
+    expect(t.stage.current).toBe(2);
+    expect(t.status).toBe('offen');
+    expect(t.href).toBe('/portal?section=frageb%C3%B6gen');
+  });
+
+  it('questionnaire track is "erledigt" when every assignment is in a terminal state', () => {
+    const t = trackByKey(
+      buildWorkflowTracks({ ...baseSources, questionnaires: [qa('reviewed'), qa('archived')] }),
+      'fragebogen',
+    )!;
+    expect(t.status).toBe('erledigt');
+    expect(t.stage.current).toBe(t.stage.total);
+  });
+
+  it('questionnaire track is "leer" (no work) when there are no assignments at all', () => {
+    const t = trackByKey(
+      buildWorkflowTracks({ ...baseSources, questionnaires: [] }),
+      'fragebogen',
+    )!;
+    expect(t.status).toBe('leer');
+  });
+
+  it('signature track is open while pending > 0 and links to the contracts section', () => {
+    const t = trackByKey(buildWorkflowTracks(baseSources), 'vertraege')!;
+    expect(t.status).toBe('offen');
+    expect(t.stage).toEqual({ current: 1, total: 2 });
+    expect(t.href).toBe('/portal?section=vertraege');
+  });
+
+  it('signature track is "erledigt" with zero pending signatures', () => {
+    const t = trackByKey(
+      buildWorkflowTracks({ ...baseSources, pendingSignatures: 0 }),
+      'vertraege',
+    )!;
+    expect(t.status).toBe('erledigt');
+    expect(t.stage).toEqual({ current: 2, total: 2 });
+  });
+
+  it('booking track counts ONLY future bookings relative to `now`', () => {
+    // baseSources has one past (-3) and one future (+4) booking → 1 upcoming.
+    const t = trackByKey(buildWorkflowTracks(baseSources), 'buchung')!;
+    expect(t.status).toBe('geplant');
+    expect(t.stage).toEqual({ current: 1, total: 2 });
+    expect(t.href).toBe('/portal?section=termine');
+  });
+
+  it('booking track prompts a booking ("leer") when nothing upcoming', () => {
+    const t = trackByKey(
+      buildWorkflowTracks({ ...baseSources, bookings: [booking(-10)] }),
+      'buchung',
+    )!;
+    expect(t.status).toBe('leer');
+    expect(t.href).toBe('/portal?section=buchung');
+  });
+
+  it('ignores CANCELLED future bookings when deciding upcoming count', () => {
+    const t = trackByKey(
+      buildWorkflowTracks({ ...baseSources, bookings: [booking(5, 'CANCELLED')] }),
+      'buchung',
+    )!;
+    expect(t.status).toBe('leer');
+  });
+
+  it('is resilient to malformed input (missing arrays) — never throws, yields 3 tracks', () => {
+    const tracks = buildWorkflowTracks({
+      // deliberately under-specified
+      questionnaires: undefined as unknown as WorkflowSources['questionnaires'],
+      pendingSignatures: undefined as unknown as number,
+      bookings: undefined as unknown as WorkflowSources['bookings'],
+      now: NOW,
+    });
+    expect(tracks).toHaveLength(3);
+    expect(tracks.map((t) => t.key)).toEqual(['fragebogen', 'vertraege', 'buchung']);
+  });
+});
+
+describe('getWorkflowStatus (I/O wrapper, injected deps)', () => {
+  const session = {
+    sub: 'u-1',
+    email: 'klient@example.com',
+    name: 'Klient',
+    preferred_username: 'klient',
+    realmRoles: [],
+    brand: 'mentolder',
+    access_token: '',
+    refresh_token: '',
+    expires_at: 0,
+  } satisfies UserSession;
+
+  function deps(over: Partial<WorkflowDeps> = {}): WorkflowDeps {
+    return {
+      getCustomerByEmail: async () => ({ id: 'cust-1' }),
+      listQAssignmentsForCustomer: async () => [{ status: 'in_progress' }],
+      countPendingDocAssignments: async () => 2,
+      getClientBookings: async () => [{ start: new Date('2026-07-01T00:00:00Z'), status: 'CONFIRMED' }],
+      now: () => NOW,
+      ...over,
+    };
+  }
+
+  it('wires every source through to three populated tracks', async () => {
+    const tracks = await getWorkflowStatus(session, deps());
+    expect(tracks.map((t) => t.key)).toEqual(['fragebogen', 'vertraege', 'buchung']);
+    expect(trackByKey(tracks, 'fragebogen')!.status).toBe('offen');
+    expect(trackByKey(tracks, 'vertraege')!.status).toBe('offen');
+    expect(trackByKey(tracks, 'buchung')!.status).toBe('geplant');
+  });
+
+  it('degrades a single failing source to a neutral track without throwing', async () => {
+    const tracks = await getWorkflowStatus(
+      session,
+      deps({
+        listQAssignmentsForCustomer: async () => {
+          throw new Error('db down');
+        },
+      }),
+    );
+    expect(tracks).toHaveLength(3);
+    // failed questionnaire fetch → empty list → "leer", not a thrown error.
+    expect(trackByKey(tracks, 'fragebogen')!.status).toBe('leer');
+  });
+
+  it('still resolves bookings when there is no customer record', async () => {
+    const tracks = await getWorkflowStatus(
+      session,
+      deps({ getCustomerByEmail: async () => null }),
+    );
+    expect(trackByKey(tracks, 'fragebogen')!.status).toBe('leer');
+    expect(trackByKey(tracks, 'vertraege')!.status).toBe('erledigt');
+    expect(trackByKey(tracks, 'buchung')!.status).toBe('geplant');
+  });
+});

--- a/website/src/lib/workflow-status.ts
+++ b/website/src/lib/workflow-status.ts
@@ -1,0 +1,247 @@
+/**
+ * Workflow-Status aggregation for the portal "Minimap".
+ *
+ * Surfaces where a logged-in portal user stands across the few workflow tracks
+ * that the portal can actually answer for, server-side, from EXISTING sources:
+ *
+ *   - Fragebögen   → questionnaire_assignments (questionnaire-db)
+ *   - Verträge     → pending signatures (DocuSeal assignments + Nextcloud queue),
+ *                    already counted by portal.astro as `pendingSignatures`
+ *   - Buchung      → upcoming CalDAV bookings (caldav.getClientBookings)
+ *
+ * No data is invented: every track is derived from a real, query-able source.
+ * If a source is unavailable the track degrades to a neutral "leer" state
+ * rather than throwing — the minimap is a read-only orientation aid and must
+ * never break the portal render.
+ *
+ * The pure builder (`buildWorkflowTracks`) is split from the I/O wrapper
+ * (`getWorkflowStatus`) so the stage/"du bist hier" logic is unit-testable
+ * without a database — mirroring the lib-layer convention in this repo.
+ */
+
+import type { UserSession } from './auth';
+
+// ── Public shape ────────────────────────────────────────────────────────────
+
+export type WorkflowTrackKey = 'fragebogen' | 'vertraege' | 'buchung';
+
+/** One row in the minimap: a single workflow the user can be "located" in. */
+export interface WorkflowTrack {
+  key: WorkflowTrackKey;
+  label: string;
+  emoji: string;
+  /** Human, lowercase German status word used for the badge text. */
+  status: 'offen' | 'erledigt' | 'geplant' | 'leer';
+  /** 1-based current step ("du bist hier") out of `total` steps. */
+  stage: { current: number; total: number };
+  href: string;
+}
+
+/** Raw inputs the builder aggregates. Shaped to match the real sources but
+ *  intentionally minimal so callers can pass already-fetched rows. */
+export interface WorkflowSources {
+  questionnaires: Array<{ status: string }>;
+  pendingSignatures: number;
+  bookings: Array<{ start: Date | string; status?: string }>;
+  now: Date;
+}
+
+// ── Stage helpers (pure, unit-tested) ───────────────────────────────────────
+
+const QUESTIONNAIRE_TOTAL_STAGES = 4;
+
+/** Map a questionnaire assignment lifecycle status to a 1-based stage (1..4). */
+export function questionnaireStage(status: string): number {
+  switch (status) {
+    case 'pending':
+      return 1;
+    case 'in_progress':
+      return 2;
+    case 'submitted':
+      return 3;
+    case 'reviewed':
+    case 'archived':
+      return QUESTIONNAIRE_TOTAL_STAGES;
+    default:
+      // dismissed / unknown — treat as not-yet-started (defensive).
+      return 1;
+  }
+}
+
+const QUESTIONNAIRE_TERMINAL = new Set(['reviewed', 'archived', 'dismissed']);
+
+/** A questionnaire is "open" (actionable) while not in a terminal state. */
+function isQuestionnaireOpen(status: string): boolean {
+  return !QUESTIONNAIRE_TERMINAL.has(status);
+}
+
+/** Two-step signature track: pending → signed. */
+export function signatureStage(pending: number): { current: number; total: number } {
+  return pending > 0 ? { current: 1, total: 2 } : { current: 2, total: 2 };
+}
+
+/** Two-step booking track: nothing upcoming → at least one upcoming. */
+export function bookingStage(upcoming: number): { current: number; total: number } {
+  return upcoming > 0 ? { current: 1, total: 2 } : { current: 2, total: 2 };
+}
+
+// ── Track builders (pure) ───────────────────────────────────────────────────
+
+function buildQuestionnaireTrack(
+  questionnaires: WorkflowSources['questionnaires'],
+): WorkflowTrack {
+  const href = `/portal?section=${encodeURIComponent('fragebögen')}`;
+  const list = Array.isArray(questionnaires) ? questionnaires : [];
+
+  if (list.length === 0) {
+    return {
+      key: 'fragebogen',
+      label: 'Fragebögen',
+      emoji: '📋',
+      status: 'leer',
+      stage: { current: 1, total: QUESTIONNAIRE_TOTAL_STAGES },
+      href,
+    };
+  }
+
+  const openStages = list
+    .filter((q) => isQuestionnaireOpen(q.status))
+    .map((q) => questionnaireStage(q.status));
+
+  if (openStages.length === 0) {
+    // Everything is terminal → done.
+    return {
+      key: 'fragebogen',
+      label: 'Fragebögen',
+      emoji: '📋',
+      status: 'erledigt',
+      stage: { current: QUESTIONNAIRE_TOTAL_STAGES, total: QUESTIONNAIRE_TOTAL_STAGES },
+      href,
+    };
+  }
+
+  // "Du bist hier" = the least-advanced open assignment: that's the next thing
+  // the user actually needs to act on.
+  const current = Math.min(...openStages);
+  return {
+    key: 'fragebogen',
+    label: 'Fragebögen',
+    emoji: '📋',
+    status: 'offen',
+    stage: { current, total: QUESTIONNAIRE_TOTAL_STAGES },
+    href,
+  };
+}
+
+function buildSignatureTrack(pendingSignatures: number): WorkflowTrack {
+  const pending = Number.isFinite(pendingSignatures) ? Math.max(0, pendingSignatures) : 0;
+  return {
+    key: 'vertraege',
+    label: 'Verträge',
+    emoji: '✍️',
+    status: pending > 0 ? 'offen' : 'erledigt',
+    stage: signatureStage(pending),
+    href: '/portal?section=vertraege',
+  };
+}
+
+function buildBookingTrack(
+  bookings: WorkflowSources['bookings'],
+  now: Date,
+): WorkflowTrack {
+  const list = Array.isArray(bookings) ? bookings : [];
+  const reference = now instanceof Date && !isNaN(now.getTime()) ? now : new Date();
+
+  const upcoming = list.filter((b) => {
+    if ((b.status ?? 'CONFIRMED').toUpperCase() === 'CANCELLED') return false;
+    const start = b.start instanceof Date ? b.start : new Date(b.start);
+    return !isNaN(start.getTime()) && start.getTime() >= reference.getTime();
+  }).length;
+
+  return {
+    key: 'buchung',
+    label: 'Buchung',
+    emoji: '📅',
+    status: upcoming > 0 ? 'geplant' : 'leer',
+    stage: bookingStage(upcoming),
+    // Upcoming bookings are reviewed under Termine; an empty track invites a
+    // new booking.
+    href: upcoming > 0 ? '/portal?section=termine' : '/portal?section=buchung',
+  };
+}
+
+/**
+ * Pure aggregation: raw sources → ordered `WorkflowTrack[]`.
+ * Stable order (fragebogen, vertraege, buchung). Never throws.
+ */
+export function buildWorkflowTracks(sources: WorkflowSources): WorkflowTrack[] {
+  return [
+    buildQuestionnaireTrack(sources.questionnaires),
+    buildSignatureTrack(sources.pendingSignatures),
+    buildBookingTrack(sources.bookings, sources.now),
+  ];
+}
+
+// ── I/O wrapper ──────────────────────────────────────────────────────────────
+
+/** Injectable data dependencies — defaults wire to the real lib modules.
+ *  Lets the wrapper be tested without a live DB / CalDAV. */
+export interface WorkflowDeps {
+  getCustomerByEmail: (email: string) => Promise<{ id: string } | null>;
+  listQAssignmentsForCustomer: (customerId: string) => Promise<Array<{ status: string }>>;
+  countPendingDocAssignments: (customerId: string) => Promise<number>;
+  getClientBookings: (email: string) => Promise<Array<{ start: Date | string; status?: string }>>;
+  now?: () => Date;
+}
+
+let cachedDeps: WorkflowDeps | null = null;
+
+/** Lazily import the real lib modules so this file stays importable in a
+ *  DB-less unit test (e.g. the pure builder above) without side effects. */
+async function defaultDeps(): Promise<WorkflowDeps> {
+  if (cachedDeps) return cachedDeps;
+  const [{ getCustomerByEmail }, questionnaire, documents, caldav] = await Promise.all([
+    import('./messaging-db'),
+    import('./questionnaire-db'),
+    import('./documents-db'),
+    import('./caldav'),
+  ]);
+  cachedDeps = {
+    getCustomerByEmail,
+    listQAssignmentsForCustomer: questionnaire.listQAssignmentsForCustomer,
+    countPendingDocAssignments: documents.countPendingAssignmentsForCustomer,
+    getClientBookings: caldav.getClientBookings,
+    now: () => new Date(),
+  };
+  return cachedDeps;
+}
+
+/**
+ * Fetch every workflow source for `session` and aggregate into tracks.
+ *
+ * Best-effort: each source is guarded so a single failing dependency yields a
+ * neutral track rather than failing the whole portal render. Returns an empty
+ * array only when there is no resolvable customer (anonymous-ish session).
+ */
+export async function getWorkflowStatus(
+  session: UserSession,
+  deps?: Partial<WorkflowDeps>,
+): Promise<WorkflowTrack[]> {
+  const d: WorkflowDeps = { ...(await defaultDeps()), ...deps };
+  const now = (d.now ?? (() => new Date()))();
+
+  const customer = await d.getCustomerByEmail(session.email).catch(() => null);
+
+  const [questionnaires, pendingSignatures, bookings] = await Promise.all([
+    customer ? d.listQAssignmentsForCustomer(customer.id).catch(() => []) : Promise.resolve([]),
+    customer ? d.countPendingDocAssignments(customer.id).catch(() => 0) : Promise.resolve(0),
+    d.getClientBookings(session.email).catch(() => []),
+  ]);
+
+  return buildWorkflowTracks({
+    questionnaires,
+    pendingSignatures,
+    bookings,
+    now,
+  });
+}

--- a/website/src/styles/workflow-minimap.css
+++ b/website/src/styles/workflow-minimap.css
@@ -1,0 +1,173 @@
+/* =========================================================================
+   Workflow-Status-Minimap (F3)
+   Sticky bottom-LEFT orientation widget for the portal. Bottom-RIGHT is owned
+   by PortalSidekick's FAB, so this stays on the left and below the same
+   z-index band to avoid overlap. Tokens (--brass, --ink-*, --line, --mono,
+   --sage, --fg-soft, --mute) come from global.css :root and are overridden by
+   body.kore for the korczewski brand — no hard-coded brand colours here.
+   ========================================================================= */
+
+.wf-minimap {
+  position: fixed;
+  bottom: 24px;
+  left: 24px;
+  z-index: 9030; /* below PortalSidekick FAB (9040) and drawer (9050) */
+  width: 268px;
+  max-width: calc(100vw - 48px);
+  background: var(--ink-850);
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  box-shadow: 0 12px 36px rgba(0, 0, 0, 0.42);
+  font-family: var(--font-sans, var(--sans));
+  overflow: hidden;
+}
+
+/* Header / toggle */
+.wf-minimap-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 12px 14px;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  color: var(--fg);
+  text-align: left;
+  transition: background 180ms ease;
+}
+.wf-minimap-header:hover { background: rgba(255, 255, 255, 0.03); }
+.wf-minimap-header:focus-visible {
+  outline: 2px solid var(--brass);
+  outline-offset: -2px;
+}
+.wf-minimap-eyebrow {
+  flex: 1;
+  font-family: var(--font-mono, var(--mono));
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--brass);
+}
+.wf-minimap-count {
+  font-family: var(--font-mono, var(--mono));
+  font-size: 10px;
+  font-weight: 700;
+  padding: 1px 7px;
+  border-radius: 999px;
+  background: var(--brass-d);
+  color: var(--brass);
+}
+.wf-minimap-chevron {
+  font-size: 14px;
+  line-height: 1;
+  color: var(--brass);
+  transition: transform 220ms ease;
+  width: 14px;
+  text-align: center;
+}
+.wf-minimap-chevron.collapsed { transform: rotate(-90deg); }
+
+/* Body */
+.wf-minimap-body {
+  border-top: 1px solid var(--line);
+  padding: 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+/* Track row (link) */
+.wf-track {
+  display: grid;
+  grid-template-columns: 22px 1fr auto;
+  align-items: center;
+  gap: 9px;
+  padding: 9px 8px;
+  border-radius: 9px;
+  text-decoration: none;
+  color: var(--fg-soft);
+  transition: background 160ms ease, color 160ms ease;
+}
+.wf-track:hover { background: var(--ink-800); color: var(--fg); }
+.wf-track:focus-visible {
+  outline: 2px solid var(--brass);
+  outline-offset: -2px;
+}
+.wf-track-emoji {
+  font-size: 15px;
+  line-height: 1;
+  text-align: center;
+}
+.wf-track-main { min-width: 0; }
+.wf-track-label {
+  font-size: 12.5px;
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Progress bar with segmented "du bist hier" steps */
+.wf-progress {
+  display: flex;
+  gap: 3px;
+  margin-top: 5px;
+}
+.wf-step {
+  flex: 1;
+  height: 3px;
+  border-radius: 99px;
+  background: var(--line-2);
+}
+.wf-step.done { background: var(--brass); }
+.wf-step.here {
+  background: var(--brass);
+  box-shadow: 0 0 0 1px var(--brass), 0 0 6px var(--brass-d);
+}
+
+/* Status badge */
+.wf-badge {
+  font-family: var(--font-mono, var(--mono));
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 3px 8px;
+  border-radius: 999px;
+  border: 1px solid;
+  white-space: nowrap;
+}
+.wf-badge.offen,
+.wf-badge.geplant {
+  background: var(--brass-d);
+  color: var(--brass);
+  border-color: oklch(0.80 0.09 75 / 0.35);
+}
+.wf-badge.erledigt {
+  background: oklch(0.80 0.06 160 / 0.12);
+  color: var(--sage);
+  border-color: oklch(0.80 0.06 160 / 0.4);
+}
+.wf-badge.leer {
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--mute);
+  border-color: var(--line-2);
+}
+
+.wf-minimap-empty {
+  padding: 14px 12px;
+  font-size: 12px;
+  font-style: italic;
+  color: var(--mute);
+}
+
+/* Mobile: shrink + dodge the mobile topbar; still bottom-left. */
+@media (max-width: 767px) {
+  .wf-minimap {
+    width: calc(100vw - 32px);
+    left: 16px;
+    bottom: 16px;
+  }
+}


### PR DESCRIPTION
## Was es macht
Eine **sticky, collapsible "Mein Workflow"-Minimap** (unten **LINKS**, klar vom `PortalSidekick`-FAB unten rechts getrennt) im Portal, die den eingeloggten User über seine Workflow-Tracks verortet. Pro Track: Emoji + Label + segmentierter Fortschrittsbalken mit hervorgehobenem **"du bist hier"**-Schritt + Status-Badge; Klick navigiert in den passenden Portal-Bereich.

Aggregiert wird **ausschließlich aus realen, server-seitig abfragbaren Quellen** — nichts erfunden:
- **Fragebögen** → `questionnaire_assignments` (`questionnaire-db`)
- **Verträge** → ausstehende Signaturen (DocuSeal-Assignments + Nextcloud-Queue), wie schon von `portal.astro` als `pendingSignatures` gezählt
- **Buchung** → anstehende CalDAV-Buchungen (`caldav.getClientBookings`, nur zukünftige, `CANCELLED` ausgenommen)

## Spec
Abschnitt **F3 — Workflow-Status-Minimap** aus `/tmp/ux-features-spec.md`.

## Geänderte Dateien (scoped)
- `website/src/lib/workflow-status.ts` — pure `buildWorkflowTracks()` + Stage-Helper (`questionnaireStage`/`signatureStage`/`bookingStage`), getrennt vom I/O-Wrapper `getWorkflowStatus(session)` (injizierbare Deps, best-effort, wirft nie).
- `website/src/components/portal/WorkflowStatusMinimap.svelte` — Svelte-5-Runes-Komponente; `role="complementary"`, aria-labels, tastaturbedienbar, `localStorage`-Collapse-State.
- `website/src/styles/workflow-minimap.css` — nur Brand-Tokens (brass/sage/ink/`--mono`), kore-aware via `body.kore`.
- `website/src/layouts/PortalLayout.astro` — Tracks server-seitig via `getWorkflowStatus(session)` berechnet + Widget für eingeloggte Portal-User gemountet.
- `website/src/lib/workflow-status.test.ts` — neue Tests.

## Test- & Build-Evidence
- **TDD**: Test zuerst geschrieben, schlug korrekt mit "Cannot find module './workflow-status'" fehl, dann implementiert.
- `pnpm vitest run src/lib/workflow-status.test.ts` → **20 passed** (Stage-Mapping, Aggregation/Reihenfolge, "du bist hier", `erledigt`/`leer`-States, nur-zukünftige + `CANCELLED`-ausschließende Buchungen, Resilienz gegen malformed input, I/O-Wrapper-Wiring + Degradation einer fehlerhaften Quelle).
- `astro build` **grün für BEIDE Brands** (`BRAND_ID=mentolder` und `BRAND_ID=korczewski`, jeweils Exit 0, "Complete!").
- `astro check`: **null Diagnostics auf den berührten Dateien** (die 11 verbleibenden Repo-Fehler liegen alle in unangetasteten Dateien wie `agentGuide.ts`/`index.astro` und sind vorbestehend).

## Follow-ups (optional)
- Optionaler Client-Refresh über vorhandene `/api/portal/*`-Routen (aktuell rein server-seitig initialisiert, was für eine Orientierungshilfe ausreicht).
- Weitere Tracks (z. B. Rechnungen/Projekte) ließen sich additiv ergänzen, sobald eine eindeutige Stage-Semantik definiert ist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)