### PR TITLE
feat(prompt-library): reusable prompt DB + insert dropdown [F2]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,8 +63,8 @@ jobs:
             if (!Array.isArray(m.routes)) {
               errs.push("routes must be an array");
             }
-            if (m.count !== 98) {
-              errs.push(`expected count===98, got ${m.count}`);
+            if (m.count !== 99) {
+              errs.push(`expected count===99, got ${m.count}`);
             }
             for (const r of (m.routes || [])) {
               const isAdmin = r.route.startsWith("/admin");

--- a/k3d/website-schema.yaml
+++ b/k3d/website-schema.yaml
@@ -677,6 +677,30 @@ data:
         END IF;
       END$$;
 
+      -- ── Prompt Library (F2 — reusable canned replies) ─────────────────
+      -- Brand-scoped reusable prompts inserted into the messaging compose box.
+      -- Additive, idempotent. NO FK to public.brands on purpose: avoids the
+      -- known korczewski bootstrap gap where a fresh deploy has not yet seeded
+      -- the brands table. The DB layer (prompt-library-db.ts) also self-heals
+      -- this schema on the query path (T000406 lesson).
+      CREATE TABLE IF NOT EXISTS prompt_library (
+          id           SERIAL PRIMARY KEY,
+          brand        TEXT NOT NULL,
+          category     TEXT NOT NULL DEFAULT 'canned_reply',
+          title        TEXT NOT NULL,
+          body         TEXT NOT NULL,
+          description  TEXT,
+          is_active    BOOLEAN DEFAULT true,
+          usage_count  INTEGER DEFAULT 0,
+          created_by   TEXT,
+          created_at   TIMESTAMPTZ DEFAULT now(),
+          updated_at   TIMESTAMPTZ DEFAULT now(),
+          is_test_data BOOLEAN DEFAULT false,
+          UNIQUE (brand, title)
+      );
+      CREATE INDEX IF NOT EXISTS idx_prompt_library_brand_active
+          ON prompt_library (brand) WHERE is_active;
+
       -- Grant full access to the website user
       GRANT ALL ON ALL TABLES IN SCHEMA public TO website;
       GRANT ALL ON ALL SEQUENCES IN SCHEMA public TO website;
@@ -1427,6 +1451,28 @@ data:
             WHERE source_test_run_id IS NOT NULL;
         END IF;
       END$$;
+
+      -- ── Prompt Library (F2 — reusable canned replies) ─────────────────
+      -- Mirrors the additive table from the init script so existing DBs gain it
+      -- on every boot. Idempotent, no FK to public.brands (korczewski bootstrap
+      -- gap). See prompt-library-db.ts (also self-heals on the query path).
+      CREATE TABLE IF NOT EXISTS prompt_library (
+          id           SERIAL PRIMARY KEY,
+          brand        TEXT NOT NULL,
+          category     TEXT NOT NULL DEFAULT 'canned_reply',
+          title        TEXT NOT NULL,
+          body         TEXT NOT NULL,
+          description  TEXT,
+          is_active    BOOLEAN DEFAULT true,
+          usage_count  INTEGER DEFAULT 0,
+          created_by   TEXT,
+          created_at   TIMESTAMPTZ DEFAULT now(),
+          updated_at   TIMESTAMPTZ DEFAULT now(),
+          is_test_data BOOLEAN DEFAULT false,
+          UNIQUE (brand, title)
+      );
+      CREATE INDEX IF NOT EXISTS idx_prompt_library_brand_active
+          ON prompt_library (brand) WHERE is_active;
 
       GRANT ALL ON ALL TABLES IN SCHEMA public TO website;
       GRANT ALL ON ALL SEQUENCES IN SCHEMA public TO website;

--- a/scripts/lib/route-manifest.test.mjs
+++ b/scripts/lib/route-manifest.test.mjs
@@ -96,7 +96,7 @@ const PAGES = join(REPO, 'website/src/pages');
 test('buildManifest: shape + authoritative counts', () => {
   const manifest = buildManifest(PAGES, FIXTURE_BRANDS);
   assert.equal(manifest.generatedFrom, 'website/src/pages');
-  assert.equal(manifest.count, 98); // page-file count (enumerated, pre-service-expansion)
+  assert.equal(manifest.count, 99); // page-file count (enumerated, pre-service-expansion)
   assert.ok(Array.isArray(manifest.routes));
   // /[service] literal is NOT emitted
   assert.ok(!manifest.routes.some((r) => r.route === '/[service]'),
@@ -106,7 +106,7 @@ test('buildManifest: shape + authoritative counts', () => {
   assert.ok(manifest.routes.some((r) => r.route === '/ki-beratung' && r.brand === 'korczewski'));
 });
 
-test('buildManifest: tier split admin=67 portal=9 public=22 over page files', () => {
+test('buildManifest: tier split admin=68 portal=9 public=22 over page files', () => {
   const manifest = buildManifest(PAGES, FIXTURE_BRANDS);
   // Tier split is asserted over the ENUMERATED page files (count basis), so collapse
   // expanded service routes back to the single /[service] page file for the tally.
@@ -120,7 +120,7 @@ test('buildManifest: tier split admin=67 portal=9 public=22 over page files', ()
   const admin = nonService.filter((r) => r.authTier === 'admin').length;
   const portal = nonService.filter((r) => r.authTier === 'portal').length;
   const publicLiterals = nonService.filter((r) => r.authTier === 'public').length;
-  assert.equal(admin, 67, 'admin tier page files');
+  assert.equal(admin, 68, 'admin tier page files');
   assert.equal(portal, 9, 'portal tier page files');
   assert.equal(publicLiterals + serviceContributes, 22, 'public tier page files incl /[service]');
 });

--- a/website/src/components/ChatRoomPanel.svelte
+++ b/website/src/components/ChatRoomPanel.svelte
@@ -1,5 +1,8 @@
 <script lang="ts">
   import type { ChatRoom, ChatMessage } from '../lib/messaging-db';
+  import {
+    loadActivePrompts, insertPromptBody, recordPromptUse, type PromptOption,
+  } from '../lib/prompt-insert';
 
   type Member = { customer_id: string; name: string; email: string };
   type Customer = { id: string; name: string; email: string };
@@ -30,6 +33,25 @@
   let allCustomers = $state<Customer[]>([]);
   let memberSearch = $state('');
   let memberLoading = $state(false);
+
+  // ── Prompt-library "Vorlage einfügen" dropdown (admin only) ──────────────
+  let prompts = $state<PromptOption[]>([]);
+  let promptsLoaded = $state(false);
+  let showPromptMenu = $state(false);
+
+  async function togglePromptMenu() {
+    showPromptMenu = !showPromptMenu;
+    if (showPromptMenu && !promptsLoaded) {
+      prompts = await loadActivePrompts();
+      promptsLoaded = true;
+    }
+  }
+
+  function insertPrompt(p: PromptOption) {
+    newBody = insertPromptBody(newBody, p.body);
+    showPromptMenu = false;
+    void recordPromptUse(p.id);
+  }
 
   // Admin uses /api/admin/rooms/[id] (no /messages suffix)
   // Portal uses /api/portal/rooms/[id]/messages
@@ -231,6 +253,29 @@
       <div class="reply-bar">
         <textarea bind:value={newBody} placeholder="Nachricht…" rows="2"
           onkeydown={(e) => { if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); sendMessage(); } }}></textarea>
+        {#if role === 'admin'}
+          <div class="prompt-insert">
+            <button type="button" class="btn-prompt" onclick={togglePromptMenu}
+              aria-haspopup="listbox" aria-expanded={showPromptMenu} title="Vorlage einfügen">
+              ✎ Vorlage
+            </button>
+            {#if showPromptMenu}
+              <ul class="prompt-menu" role="listbox" aria-label="Vorlage einfügen">
+                {#if prompts.length === 0}
+                  <li class="prompt-empty">Keine aktiven Vorlagen.</li>
+                {:else}
+                  {#each prompts as p (p.id)}
+                    <li role="option" aria-selected="false">
+                      <button type="button" class="prompt-item" onclick={() => insertPrompt(p)}>
+                        {p.title}
+                      </button>
+                    </li>
+                  {/each}
+                {/if}
+              </ul>
+            {/if}
+          </div>
+        {/if}
         <button class="btn-send" disabled={!newBody.trim() || sending} onclick={sendMessage}>
           {sending ? '…' : '↑'}
         </button>
@@ -276,4 +321,11 @@
   .new-form input { background: #1e1e2e; color: #e8e8f0; border: 1px solid #374151; border-radius: 4px; padding: 6px; font-size: 12px; }
   .form-actions { display: flex; justify-content: flex-end; gap: 6px; }
   .form-actions button { background: #374151; color: #ccc; border: none; border-radius: 4px; padding: 4px 10px; font-size: 12px; cursor: pointer; }
+  .prompt-insert { position: relative; align-self: flex-end; }
+  .btn-prompt { background: #2a2a3e; color: #ccc; border: 1px solid #374151; border-radius: 6px; padding: 8px 10px; font-size: 12px; cursor: pointer; white-space: nowrap; }
+  .btn-prompt:hover { background: #374151; }
+  .prompt-menu { position: absolute; bottom: calc(100% + 6px); right: 0; min-width: 200px; max-width: 280px; max-height: 240px; overflow-y: auto; list-style: none; margin: 0; padding: 4px; background: #1e1e2e; border: 1px solid #374151; border-radius: 8px; box-shadow: 0 8px 24px rgba(0,0,0,.4); z-index: 20; }
+  .prompt-item { width: 100%; text-align: left; background: transparent; border: none; color: #e8e8f0; padding: 8px 10px; font-size: 13px; cursor: pointer; border-radius: 4px; }
+  .prompt-item:hover { background: #2a2a3e; }
+  .prompt-empty { color: #666; font-size: 12px; padding: 8px 10px; }
 </style>

--- a/website/src/components/MessagePanel.svelte
+++ b/website/src/components/MessagePanel.svelte
@@ -1,5 +1,8 @@
 <script lang="ts">
   import type { MessageThread, Message } from '../lib/messaging-db';
+  import {
+    loadActivePrompts, insertPromptBody, recordPromptUse, type PromptOption,
+  } from '../lib/prompt-insert';
 
   const {
     threads: initialThreads,
@@ -22,6 +25,25 @@
   let showNewForm = $state(false);
   let newCustomerId = $state('');
   let newBody2 = $state('');
+
+  // ── Prompt-library "Vorlage einfügen" dropdown (admin only) ──────────────
+  let prompts = $state<PromptOption[]>([]);
+  let promptsLoaded = $state(false);
+  let showPromptMenu = $state(false);
+
+  async function togglePromptMenu() {
+    showPromptMenu = !showPromptMenu;
+    if (showPromptMenu && !promptsLoaded) {
+      prompts = await loadActivePrompts();
+      promptsLoaded = true;
+    }
+  }
+
+  function insertPrompt(p: PromptOption) {
+    newBody = insertPromptBody(newBody, p.body);
+    showPromptMenu = false;
+    void recordPromptUse(p.id);
+  }
 
   async function openThread(thread: MessageThread) {
     activeThread = thread;
@@ -170,6 +192,29 @@
       <div class="reply-bar">
         <textarea bind:value={newBody} placeholder="Antwort schreiben…" rows="2"
           onkeydown={(e) => { if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); sendReply(); } }}></textarea>
+        {#if role === 'admin'}
+          <div class="prompt-insert">
+            <button type="button" class="btn-prompt" onclick={togglePromptMenu}
+              aria-haspopup="listbox" aria-expanded={showPromptMenu} title="Vorlage einfügen">
+              ✎ Vorlage
+            </button>
+            {#if showPromptMenu}
+              <ul class="prompt-menu" role="listbox" aria-label="Vorlage einfügen">
+                {#if prompts.length === 0}
+                  <li class="prompt-empty">Keine aktiven Vorlagen.</li>
+                {:else}
+                  {#each prompts as p (p.id)}
+                    <li role="option" aria-selected="false">
+                      <button type="button" class="prompt-item" onclick={() => insertPrompt(p)}>
+                        {p.title}
+                      </button>
+                    </li>
+                  {/each}
+                {/if}
+              </ul>
+            {/if}
+          </div>
+        {/if}
         <button class="btn-send" disabled={!newBody.trim() || sending} onclick={sendReply}>
           {sending ? '…' : '↑'}
         </button>
@@ -205,4 +250,11 @@
   .new-form select, .new-form textarea { background: #1e1e2e; color: #e8e8f0; border: 1px solid #374151; border-radius: 4px; padding: 6px; font-size: 12px; width: 100%; box-sizing: border-box; }
   .form-actions { display: flex; justify-content: flex-end; gap: 8px; }
   .form-actions button { background: #374151; color: #ccc; border: none; border-radius: 4px; padding: 4px 10px; font-size: 12px; cursor: pointer; }
+  .prompt-insert { position: relative; align-self: flex-end; }
+  .btn-prompt { background: #2a2a3e; color: #ccc; border: 1px solid #374151; border-radius: 6px; padding: 8px 10px; font-size: 12px; cursor: pointer; white-space: nowrap; }
+  .btn-prompt:hover { background: #374151; }
+  .prompt-menu { position: absolute; bottom: calc(100% + 6px); right: 0; min-width: 200px; max-width: 280px; max-height: 240px; overflow-y: auto; list-style: none; margin: 0; padding: 4px; background: #1e1e2e; border: 1px solid #374151; border-radius: 8px; box-shadow: 0 8px 24px rgba(0,0,0,.4); z-index: 20; }
+  .prompt-item { width: 100%; text-align: left; background: transparent; border: none; color: #e8e8f0; padding: 8px 10px; font-size: 13px; cursor: pointer; border-radius: 4px; }
+  .prompt-item:hover { background: #2a2a3e; }
+  .prompt-empty { color: #666; font-size: 12px; padding: 8px 10px; }
 </style>

--- a/website/src/components/admin/PromptLibraryManager.svelte
+++ b/website/src/components/admin/PromptLibraryManager.svelte
@@ -1,0 +1,227 @@
+<script lang="ts">
+  import type { Prompt } from '../../lib/prompt-library-db';
+
+  const { prompts: initialPrompts }: { prompts: Prompt[] } = $props();
+
+  let prompts = $state<Prompt[]>(initialPrompts);
+  let saving = $state(false);
+  let error = $state('');
+
+  // Editor state — editingId null = "new prompt" form.
+  let editingId = $state<number | null>(null);
+  let fTitle = $state('');
+  let fCategory = $state('canned_reply');
+  let fBody = $state('');
+  let fDescription = $state('');
+  let fActive = $state(true);
+
+  function resetForm() {
+    editingId = null;
+    fTitle = '';
+    fCategory = 'canned_reply';
+    fBody = '';
+    fDescription = '';
+    fActive = true;
+    error = '';
+  }
+
+  function editPrompt(p: Prompt) {
+    editingId = p.id;
+    fTitle = p.title;
+    fCategory = p.category;
+    fBody = p.body;
+    fDescription = p.description ?? '';
+    fActive = p.isActive;
+    error = '';
+  }
+
+  async function save() {
+    if (!fTitle.trim() || !fBody.trim() || saving) {
+      error = 'Titel und Inhalt sind erforderlich.';
+      return;
+    }
+    saving = true;
+    error = '';
+    const payload = {
+      title: fTitle.trim(),
+      body: fBody,
+      category: fCategory.trim() || 'canned_reply',
+      description: fDescription.trim() || null,
+      isActive: fActive,
+    };
+    const url = editingId === null
+      ? '/api/admin/prompt-library'
+      : `/api/admin/prompt-library/${editingId}`;
+    const method = editingId === null ? 'POST' : 'PUT';
+    try {
+      const res = await fetch(url, {
+        method,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      if (!res.ok) {
+        error = 'Speichern fehlgeschlagen.';
+        return;
+      }
+      const data = (await res.json()) as { prompt: Prompt };
+      if (editingId === null) {
+        prompts = [data.prompt, ...prompts.filter(p => p.id !== data.prompt.id)];
+      } else {
+        prompts = prompts.map(p => (p.id === data.prompt.id ? data.prompt : p));
+      }
+      resetForm();
+    } catch {
+      error = 'Netzwerkfehler beim Speichern.';
+    } finally {
+      saving = false;
+    }
+  }
+
+  async function toggleActive(p: Prompt) {
+    try {
+      const res = await fetch(`/api/admin/prompt-library/${p.id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          title: p.title,
+          body: p.body,
+          category: p.category,
+          description: p.description,
+          isActive: !p.isActive,
+        }),
+      });
+      if (res.ok) {
+        const data = (await res.json()) as { prompt: Prompt };
+        prompts = prompts.map(x => (x.id === data.prompt.id ? data.prompt : x));
+      }
+    } catch { /* ignore */ }
+  }
+
+  async function remove(p: Prompt) {
+    if (!confirm(`Vorlage „${p.title}“ löschen?`)) return;
+    try {
+      const res = await fetch(`/api/admin/prompt-library/${p.id}`, { method: 'DELETE' });
+      if (res.ok) {
+        prompts = prompts.filter(x => x.id !== p.id);
+        if (editingId === p.id) resetForm();
+      }
+    } catch { /* ignore */ }
+  }
+</script>
+
+<div class="prompt-mgr">
+  <header class="mgr-head">
+    <h1>Prompt-Bibliothek</h1>
+    <p class="sub">Wiederverwendbare Vorlagen für schnelle, konsistente Antworten. Aktive Vorlagen erscheinen im „Vorlage einfügen“-Menü der Nachrichten- und Raum-Ansicht.</p>
+  </header>
+
+  <div class="mgr-grid">
+    <section class="editor" aria-label="Vorlage bearbeiten">
+      <h2>{editingId === null ? 'Neue Vorlage' : 'Vorlage bearbeiten'}</h2>
+      <label>
+        <span>Titel</span>
+        <input bind:value={fTitle} placeholder="z. B. Begrüßung Erstgespräch" maxlength="200" />
+      </label>
+      <label>
+        <span>Kategorie</span>
+        <input bind:value={fCategory} placeholder="canned_reply" maxlength="100" />
+      </label>
+      <label>
+        <span>Inhalt</span>
+        <textarea bind:value={fBody} placeholder="Der einzufügende Text…" rows="6"></textarea>
+      </label>
+      <label>
+        <span>Beschreibung (optional)</span>
+        <input bind:value={fDescription} placeholder="Wann wird diese Vorlage verwendet?" maxlength="500" />
+      </label>
+      <label class="chk">
+        <input type="checkbox" bind:checked={fActive} />
+        <span>Aktiv (im Einfüge-Menü sichtbar)</span>
+      </label>
+      {#if error}<p class="err" role="alert">{error}</p>{/if}
+      <div class="actions">
+        {#if editingId !== null}
+          <button class="ghost" onclick={resetForm}>Abbrechen</button>
+        {/if}
+        <button class="primary" disabled={saving || !fTitle.trim() || !fBody.trim()} onclick={save}>
+          {saving ? 'Speichert…' : (editingId === null ? 'Anlegen' : 'Speichern')}
+        </button>
+      </div>
+    </section>
+
+    <section class="list" aria-label="Vorlagen">
+      <h2>Vorlagen ({prompts.length})</h2>
+      {#if prompts.length === 0}
+        <p class="empty">Noch keine Vorlagen. Lege links die erste an.</p>
+      {:else}
+        <ul>
+          {#each prompts as p (p.id)}
+            <li class="row {p.isActive ? '' : 'inactive'} {editingId === p.id ? 'editing' : ''}">
+              <div class="row-main">
+                <div class="row-title">
+                  <span class="title">{p.title}</span>
+                  <span class="cat">{p.category}</span>
+                  {#if !p.isActive}<span class="badge-off">inaktiv</span>{/if}
+                </div>
+                <p class="row-body">{p.body}</p>
+                {#if p.description}<p class="row-desc">{p.description}</p>{/if}
+                <p class="row-meta">{p.usageCount}× verwendet</p>
+              </div>
+              <div class="row-actions">
+                <button class="mini" onclick={() => editPrompt(p)} aria-label={`Vorlage ${p.title} bearbeiten`}>Bearbeiten</button>
+                <button class="mini" onclick={() => toggleActive(p)} aria-label={`Vorlage ${p.title} ${p.isActive ? 'deaktivieren' : 'aktivieren'}`}>
+                  {p.isActive ? 'Deaktivieren' : 'Aktivieren'}
+                </button>
+                <button class="mini danger" onclick={() => remove(p)} aria-label={`Vorlage ${p.title} löschen`}>Löschen</button>
+              </div>
+            </li>
+          {/each}
+        </ul>
+      {/if}
+    </section>
+  </div>
+</div>
+
+<style>
+  .prompt-mgr { max-width: 1100px; }
+  .mgr-head h1 { margin: 0 0 4px; font-size: 22px; }
+  .mgr-head .sub { color: #888; font-size: 13px; margin: 0 0 18px; max-width: 720px; }
+  .mgr-grid { display: grid; grid-template-columns: 360px 1fr; gap: 20px; align-items: start; }
+  @media (max-width: 820px) { .mgr-grid { grid-template-columns: 1fr; } }
+
+  .editor, .list { background: #16162a; border: 1px solid #2a2a3e; border-radius: 8px; padding: 16px; }
+  .editor h2, .list h2 { margin: 0 0 12px; font-size: 15px; }
+  .editor label { display: block; margin-bottom: 10px; }
+  .editor label > span { display: block; font-size: 12px; color: #aaa; margin-bottom: 4px; }
+  .editor input[type="text"], .editor input:not([type]), .editor textarea {
+    width: 100%; box-sizing: border-box; background: #1e1e2e; color: #e8e8f0;
+    border: 1px solid #374151; border-radius: 6px; padding: 8px; font-size: 13px;
+  }
+  .editor textarea { resize: vertical; font-family: inherit; }
+  .editor label.chk { display: flex; align-items: center; gap: 8px; font-size: 13px; color: #ccc; }
+  .editor label.chk > span { margin: 0; }
+  .err { color: #fca5a5; font-size: 12px; margin: 4px 0 0; }
+  .actions { display: flex; justify-content: flex-end; gap: 8px; margin-top: 12px; }
+  button { cursor: pointer; border: none; border-radius: 6px; font-size: 13px; }
+  button:disabled { opacity: .5; cursor: not-allowed; }
+  .primary { background: #7c6ff7; color: #fff; padding: 8px 16px; font-weight: 600; }
+  .ghost { background: #374151; color: #ccc; padding: 8px 14px; }
+
+  .list ul { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 10px; }
+  .empty { color: #555; font-size: 13px; }
+  .row { display: flex; justify-content: space-between; gap: 12px; background: #1e1e2e; border: 1px solid #2a2a3e; border-radius: 6px; padding: 12px; }
+  .row.inactive { opacity: .6; }
+  .row.editing { border-color: #7c6ff7; }
+  .row-main { min-width: 0; }
+  .row-title { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+  .title { font-weight: 600; font-size: 14px; }
+  .cat { font-size: 10px; color: #888; background: #2a2a3e; padding: 1px 6px; border-radius: 4px; }
+  .badge-off { font-size: 10px; color: #fca5a5; background: #3a1f1f; padding: 1px 6px; border-radius: 4px; }
+  .row-body { margin: 6px 0 0; font-size: 12px; color: #ccc; white-space: pre-wrap; max-height: 5em; overflow: hidden; }
+  .row-desc { margin: 4px 0 0; font-size: 11px; color: #888; font-style: italic; }
+  .row-meta { margin: 4px 0 0; font-size: 10px; color: #666; }
+  .row-actions { display: flex; flex-direction: column; gap: 6px; flex-shrink: 0; }
+  .mini { background: #2a2a3e; color: #ccc; padding: 4px 10px; font-size: 11px; }
+  .mini:hover { background: #374151; }
+  .mini.danger { background: #3a1f1f; color: #fca5a5; }
+</style>

--- a/website/src/data/route-manifest.json
+++ b/website/src/data/route-manifest.json
@@ -1,6 +1,6 @@
 {
   "generatedFrom": "website/src/pages",
-  "count": 98,
+  "count": 99,
   "routes": [
     {
       "route": "/",
@@ -432,6 +432,14 @@
       "authTier": "admin",
       "brand": "both",
       "dynamic": true,
+      "excludeFromSweep": false,
+      "media": false
+    },
+    {
+      "route": "/admin/prompts",
+      "authTier": "admin",
+      "brand": "both",
+      "dynamic": false,
       "excludeFromSweep": false,
       "media": false
     },

--- a/website/src/layouts/AdminLayout.astro
+++ b/website/src/layouts/AdminLayout.astro
@@ -119,6 +119,7 @@ const navGroups: { label: string; iconClass: string; items: NavItem[] }[] = [
     iconClass: 'nav-icon-coaching',
     items: [
       { href: '/admin/coaching/sessions',  label: 'Sitzungen',   icon: 'clipboard', matches: ['/admin/coaching/sessions', '/admin/fragebogen'] },
+      { href: '/admin/prompts',            label: 'Prompt-Bibliothek', icon: 'book' },
       { href: BRETT_URL,                    label: 'Systembrett', icon: 'brett', external: true },
       ...(isKore ? [{ href: '/admin/arena', label: 'Arena',       icon: 'arena' }] : []),
     ],

--- a/website/src/lib/prompt-insert.test.ts
+++ b/website/src/lib/prompt-insert.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  insertPromptBody,
+  loadActivePrompts,
+  recordPromptUse,
+  type PromptOption,
+} from './prompt-insert';
+
+describe('insertPromptBody', () => {
+  it('inserts into an empty draft', () => {
+    expect(insertPromptBody('', 'Hallo')).toBe('Hallo');
+  });
+
+  it('appends to a non-empty draft with a separating newline', () => {
+    expect(insertPromptBody('Guten Tag.', 'Hallo')).toBe('Guten Tag.\nHallo');
+  });
+
+  it('does not double the newline when the draft already ends with one', () => {
+    expect(insertPromptBody('Guten Tag.\n', 'Hallo')).toBe('Guten Tag.\nHallo');
+  });
+
+  it('trims trailing whitespace-only drafts to a clean insert', () => {
+    expect(insertPromptBody('   ', 'Hallo')).toBe('Hallo');
+  });
+});
+
+describe('loadActivePrompts', () => {
+  const fetchMock = vi.fn();
+  beforeEach(() => {
+    vi.stubGlobal('fetch', fetchMock);
+    fetchMock.mockReset();
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('requests the admin prompt-library endpoint and returns the prompts array', async () => {
+    const prompts: PromptOption[] = [
+      { id: 1, title: 'A', body: 'a' },
+      { id: 2, title: 'B', body: 'b' },
+    ];
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ prompts }),
+    });
+    const result = await loadActivePrompts();
+    expect(fetchMock).toHaveBeenCalledWith('/api/admin/prompt-library');
+    expect(result).toEqual(prompts);
+  });
+
+  it('returns an empty array when the request fails', async () => {
+    fetchMock.mockResolvedValue({ ok: false, json: async () => ({}) });
+    expect(await loadActivePrompts()).toEqual([]);
+  });
+
+  it('returns an empty array when fetch throws', async () => {
+    fetchMock.mockRejectedValue(new Error('network'));
+    expect(await loadActivePrompts()).toEqual([]);
+  });
+});
+
+describe('recordPromptUse', () => {
+  const fetchMock = vi.fn();
+  beforeEach(() => {
+    vi.stubGlobal('fetch', fetchMock);
+    fetchMock.mockReset();
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('POSTs to the per-id use endpoint', async () => {
+    fetchMock.mockResolvedValue({ ok: true });
+    await recordPromptUse(7);
+    expect(fetchMock).toHaveBeenCalledWith('/api/admin/prompt-library/7/use', { method: 'POST' });
+  });
+
+  it('swallows network errors (usage tracking is best-effort)', async () => {
+    fetchMock.mockRejectedValue(new Error('network'));
+    await expect(recordPromptUse(7)).resolves.toBeUndefined();
+  });
+});

--- a/website/src/lib/prompt-insert.ts
+++ b/website/src/lib/prompt-insert.ts
@@ -1,0 +1,51 @@
+// website/src/lib/prompt-insert.ts
+// Shared, browser-side helpers for the "Vorlage einfügen" (insert prompt
+// template) dropdown rendered in MessagePanel.svelte and ChatRoomPanel.svelte.
+//
+// Kept framework-free so the load/insert/usage logic is unit-testable without a
+// Svelte component test harness (the repo has no @testing-library/svelte / svelte
+// vitest plugin; DB layers and pure helpers are the established test surface).
+
+export interface PromptOption {
+  id: number;
+  title: string;
+  body: string;
+}
+
+/**
+ * Compute the new compose-box value after inserting a template body. Appends
+ * to any existing draft on its own line so the admin can prepend a greeting and
+ * then drop in a canned block. A whitespace-only draft is treated as empty.
+ */
+export function insertPromptBody(draft: string, body: string): string {
+  const base = draft.replace(/\s+$/, '');
+  return base ? `${base}\n${body}` : body;
+}
+
+/**
+ * Fetch the active prompts for the current brand. The API scopes by brand
+ * server-side via process.env.BRAND, so the client just calls the list
+ * endpoint. Fails soft to an empty list — the dropdown simply shows nothing.
+ */
+export async function loadActivePrompts(): Promise<PromptOption[]> {
+  try {
+    const res = await fetch('/api/admin/prompt-library');
+    if (!res.ok) return [];
+    const data = (await res.json()) as { prompts?: PromptOption[] };
+    return data.prompts ?? [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Best-effort usage tracking — bumps usage_count so popular templates can
+ * surface first. Never throws: a failed POST must not block sending a message.
+ */
+export async function recordPromptUse(id: number): Promise<void> {
+  try {
+    await fetch(`/api/admin/prompt-library/${id}/use`, { method: 'POST' });
+  } catch {
+    /* best-effort: ignore */
+  }
+}

--- a/website/src/lib/prompt-library-db.test.ts
+++ b/website/src/lib/prompt-library-db.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { newDb } from 'pg-mem';
+import type { Pool } from 'pg';
+import {
+  ensurePromptLibrarySchema,
+  listPrompts,
+  getPrompt,
+  upsertPrompt,
+  deletePrompt,
+  incrementUsage,
+} from './prompt-library-db';
+
+/**
+ * Each test starts from a COMPLETELY EMPTY pg-mem database — the
+ * prompt_library table is never pre-created. This proves that
+ * ensurePromptLibrarySchema() is solely responsible for creating the
+ * schema (the T000406 lesson: every query must self-heal the schema),
+ * and that running it twice is idempotent.
+ */
+function freshPool(): Pool {
+  // noAstCoverageCheck: pg-mem otherwise throws on a *replayed*
+  // `CREATE TABLE IF NOT EXISTS` (it re-parses inline PRIMARY KEY / NOT NULL
+  // constraints on the skipped statement). Real Postgres has no such issue;
+  // the option only relaxes pg-mem's strict planner so the idempotency the
+  // T000406 lesson requires can actually be exercised here.
+  const db = newDb({ noAstCoverageCheck: true });
+  // pg-mem has a partial-index bug: a `CREATE INDEX ... WHERE is_active`
+  // makes it route *unfiltered* `WHERE brand = $1` lookups through that index,
+  // silently hiding inactive rows. Real Postgres only ever uses a partial
+  // index as an optional access path and never hides rows. Strip the partial
+  // index DDL in the in-memory harness so the production index (kept for perf)
+  // doesn't corrupt query results under test.
+  db.public.interceptQueries((sql) =>
+    /CREATE\s+INDEX[\s\S]*WHERE/i.test(sql) ? [] : null,
+  );
+  const { Pool: PgMemPool } = db.adapters.createPg();
+  return new PgMemPool() as unknown as Pool;
+}
+
+let pool: Pool;
+beforeEach(() => {
+  pool = freshPool();
+});
+
+describe('ensurePromptLibrarySchema', () => {
+  it('creates the prompt_library table on a fresh DB', async () => {
+    await ensurePromptLibrarySchema(pool);
+    // listPrompts would throw "relation does not exist" if the table was missing.
+    const rows = await listPrompts(pool, 'mentolder');
+    expect(rows).toEqual([]);
+  });
+
+  it('is idempotent — running twice does not error', async () => {
+    await ensurePromptLibrarySchema(pool);
+    await ensurePromptLibrarySchema(pool);
+    const rows = await listPrompts(pool, 'mentolder');
+    expect(rows).toEqual([]);
+  });
+});
+
+describe('upsertPrompt', () => {
+  it('inserts a new prompt and returns it with defaults', async () => {
+    const p = await upsertPrompt(pool, {
+      brand: 'mentolder',
+      title: 'Begrüßung',
+      body: 'Hallo und herzlich willkommen!',
+      createdBy: 'admin@example.com',
+    });
+    expect(p.id).toBeGreaterThan(0);
+    expect(p.brand).toBe('mentolder');
+    expect(p.title).toBe('Begrüßung');
+    expect(p.body).toBe('Hallo und herzlich willkommen!');
+    expect(p.category).toBe('canned_reply');
+    expect(p.isActive).toBe(true);
+    expect(p.usageCount).toBe(0);
+  });
+
+  it('updates an existing prompt on (brand, title) conflict', async () => {
+    await upsertPrompt(pool, { brand: 'mentolder', title: 'FAQ', body: 'alt' });
+    const updated = await upsertPrompt(pool, {
+      brand: 'mentolder',
+      title: 'FAQ',
+      body: 'neu',
+      description: 'Beschreibung',
+      category: 'faq',
+      isActive: false,
+    });
+    expect(updated.body).toBe('neu');
+    expect(updated.description).toBe('Beschreibung');
+    expect(updated.category).toBe('faq');
+    expect(updated.isActive).toBe(false);
+    // Still only one row for this (brand, title).
+    const all = await listPrompts(pool, 'mentolder', { activeOnly: false });
+    expect(all.filter(r => r.title === 'FAQ')).toHaveLength(1);
+  });
+
+  it('updates an existing prompt by id (rename allowed)', async () => {
+    const created = await upsertPrompt(pool, { brand: 'mentolder', title: 'Alt', body: 'x' });
+    const renamed = await upsertPrompt(pool, {
+      id: created.id,
+      brand: 'mentolder',
+      title: 'Neu',
+      body: 'y',
+    });
+    expect(renamed.id).toBe(created.id);
+    expect(renamed.title).toBe('Neu');
+    expect(renamed.body).toBe('y');
+    const got = await getPrompt(pool, created.id);
+    expect(got?.title).toBe('Neu');
+  });
+});
+
+describe('listPrompts', () => {
+  beforeEach(async () => {
+    await upsertPrompt(pool, { brand: 'mentolder', title: 'A', body: 'a' });
+    await upsertPrompt(pool, { brand: 'mentolder', title: 'B', body: 'b', isActive: false });
+    await upsertPrompt(pool, { brand: 'korczewski', title: 'C', body: 'c' });
+  });
+
+  it('returns only the requested brand', async () => {
+    const rows = await listPrompts(pool, 'mentolder', { activeOnly: false });
+    expect(rows.map(r => r.title).sort()).toEqual(['A', 'B']);
+  });
+
+  it('activeOnly=true filters out inactive prompts', async () => {
+    const rows = await listPrompts(pool, 'mentolder', { activeOnly: true });
+    expect(rows.map(r => r.title)).toEqual(['A']);
+  });
+
+  it('activeOnly defaults to false (returns all)', async () => {
+    const rows = await listPrompts(pool, 'mentolder');
+    expect(rows).toHaveLength(2);
+  });
+});
+
+describe('getPrompt', () => {
+  it('returns null for an unknown id', async () => {
+    await ensurePromptLibrarySchema(pool);
+    expect(await getPrompt(pool, 99999)).toBeNull();
+  });
+
+  it('returns the matching prompt', async () => {
+    const created = await upsertPrompt(pool, { brand: 'mentolder', title: 'X', body: 'x' });
+    const got = await getPrompt(pool, created.id);
+    expect(got?.id).toBe(created.id);
+    expect(got?.title).toBe('X');
+  });
+});
+
+describe('incrementUsage', () => {
+  it('increments usage_count by one and returns the new count', async () => {
+    const created = await upsertPrompt(pool, { brand: 'mentolder', title: 'Y', body: 'y' });
+    expect(created.usageCount).toBe(0);
+    const after1 = await incrementUsage(pool, created.id);
+    expect(after1).toBe(1);
+    const after2 = await incrementUsage(pool, created.id);
+    expect(after2).toBe(2);
+    const reread = await getPrompt(pool, created.id);
+    expect(reread?.usageCount).toBe(2);
+  });
+
+  it('returns null for an unknown id', async () => {
+    await ensurePromptLibrarySchema(pool);
+    expect(await incrementUsage(pool, 99999)).toBeNull();
+  });
+});
+
+describe('deletePrompt', () => {
+  it('removes the prompt', async () => {
+    const created = await upsertPrompt(pool, { brand: 'mentolder', title: 'Z', body: 'z' });
+    const affected = await deletePrompt(pool, created.id);
+    expect(affected).toBe(1);
+    expect(await getPrompt(pool, created.id)).toBeNull();
+  });
+
+  it('returns 0 when the id does not exist', async () => {
+    await ensurePromptLibrarySchema(pool);
+    expect(await deletePrompt(pool, 99999)).toBe(0);
+  });
+});

--- a/website/src/lib/prompt-library-db.ts
+++ b/website/src/lib/prompt-library-db.ts
@@ -1,0 +1,194 @@
+// website/src/lib/prompt-library-db.ts
+// DB layer for the reusable Prompt Library (F2 — Prompt-DB).
+//
+// Brand-scoped, reusable canned replies / prompts that admins can insert into
+// the messaging compose box for fast, consistent answers. Pattern mirrors
+// messaging-db.ts (shared-db pool, dns.resolve4 lookup) and
+// coaching-ki-config-db.ts (pool injected as first arg → unit-testable with
+// pg-mem).
+//
+// EVERY exported query calls ensurePromptLibrarySchema() first. This is the
+// T000406 lesson: a defensive `CREATE TABLE IF NOT EXISTS` on the query path
+// means a fresh DB (or a pod whose schema-init script hasn't run yet) never
+// 500s with "relation prompt_library does not exist". The DDL is idempotent.
+
+import pg from 'pg';
+import { resolve4 } from 'dns';
+
+const DB_URL = process.env.SESSIONS_DATABASE_URL
+  || 'postgresql://website:devwebsitedb@shared-db.workspace.svc.cluster.local:5432/website';
+
+function nodeLookup(
+  hostname: string,
+  _opts: unknown,
+  cb: (err: Error | null, addr: string, family: number) => void,
+) {
+  resolve4(hostname, (err, addrs) => cb(err ?? null, addrs?.[0] ?? '', 4));
+}
+
+const pool = new pg.Pool(
+  { connectionString: DB_URL, lookup: nodeLookup } as unknown as import('pg').PoolConfig,
+);
+
+// ── Types ───────────────────────────────────────────────────────────────────
+
+export interface Prompt {
+  id: number;
+  brand: string;
+  category: string;
+  title: string;
+  body: string;
+  description: string | null;
+  isActive: boolean;
+  usageCount: number;
+  createdBy: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface UpsertPromptArgs {
+  /** When provided, updates that row by id (allows renaming title). */
+  id?: number;
+  brand: string;
+  title: string;
+  body: string;
+  category?: string;
+  description?: string | null;
+  isActive?: boolean;
+  createdBy?: string | null;
+}
+
+function rowToPrompt(row: Record<string, unknown>): Prompt {
+  return {
+    id: row.id as number,
+    brand: row.brand as string,
+    category: row.category as string,
+    title: row.title as string,
+    body: row.body as string,
+    description: (row.description as string | null) ?? null,
+    isActive: row.is_active as boolean,
+    usageCount: Number(row.usage_count ?? 0),
+    createdBy: (row.created_by as string | null) ?? null,
+    createdAt: row.created_at as Date,
+    updatedAt: row.updated_at as Date,
+  };
+}
+
+// ── Schema ──────────────────────────────────────────────────────────────────
+
+/**
+ * Defensive, idempotent schema creation. Mirrors the additive table defined in
+ * k3d/website-schema.yaml (init + ensure scripts). Called at the top of every
+ * query in this module so the table always exists before it is read/written.
+ * NO foreign key to public.brands — avoids the known korczewski bootstrap gap
+ * where a fresh deploy has not yet seeded the brands table.
+ */
+export async function ensurePromptLibrarySchema(targetPool: pg.Pool = pool): Promise<void> {
+  await targetPool.query(`
+    CREATE TABLE IF NOT EXISTS prompt_library (
+      id          SERIAL PRIMARY KEY,
+      brand       TEXT NOT NULL,
+      category    TEXT NOT NULL DEFAULT 'canned_reply',
+      title       TEXT NOT NULL,
+      body        TEXT NOT NULL,
+      description TEXT,
+      is_active   BOOLEAN DEFAULT true,
+      usage_count INTEGER DEFAULT 0,
+      created_by  TEXT,
+      created_at  TIMESTAMPTZ DEFAULT now(),
+      updated_at  TIMESTAMPTZ DEFAULT now(),
+      is_test_data BOOLEAN DEFAULT false,
+      UNIQUE (brand, title)
+    )
+  `);
+  await targetPool.query(`
+    CREATE INDEX IF NOT EXISTS idx_prompt_library_brand_active
+      ON prompt_library (brand) WHERE is_active
+  `);
+}
+
+// ── Queries ─────────────────────────────────────────────────────────────────
+
+export async function listPrompts(
+  targetPool: pg.Pool,
+  brand: string,
+  opts: { activeOnly?: boolean } = {},
+): Promise<Prompt[]> {
+  await ensurePromptLibrarySchema(targetPool);
+  const where = opts.activeOnly
+    ? 'WHERE brand = $1 AND is_active = true'
+    : 'WHERE brand = $1';
+  const { rows } = await targetPool.query(
+    `SELECT * FROM prompt_library ${where}
+     ORDER BY usage_count DESC, title ASC`,
+    [brand],
+  );
+  return rows.map(rowToPrompt);
+}
+
+export async function getPrompt(targetPool: pg.Pool, id: number): Promise<Prompt | null> {
+  await ensurePromptLibrarySchema(targetPool);
+  const { rows } = await targetPool.query(
+    'SELECT * FROM prompt_library WHERE id = $1',
+    [id],
+  );
+  return rows[0] ? rowToPrompt(rows[0]) : null;
+}
+
+export async function upsertPrompt(targetPool: pg.Pool, args: UpsertPromptArgs): Promise<Prompt> {
+  await ensurePromptLibrarySchema(targetPool);
+  const category = args.category ?? 'canned_reply';
+  const description = args.description ?? null;
+  const isActive = args.isActive ?? true;
+
+  if (args.id !== undefined) {
+    // Update an existing row by id (supports renaming the title).
+    const { rows } = await targetPool.query(
+      `UPDATE prompt_library
+         SET brand = $2, title = $3, body = $4, category = $5,
+             description = $6, is_active = $7, updated_at = now()
+       WHERE id = $1
+       RETURNING *`,
+      [args.id, args.brand, args.title, args.body, category, description, isActive],
+    );
+    if (!rows[0]) throw new Error(`Prompt ${args.id} not found`);
+    return rowToPrompt(rows[0]);
+  }
+
+  // Insert, or update in place on (brand, title) conflict.
+  const { rows } = await targetPool.query(
+    `INSERT INTO prompt_library (brand, category, title, body, description, is_active, created_by)
+     VALUES ($1, $2, $3, $4, $5, $6, $7)
+     ON CONFLICT (brand, title) DO UPDATE
+       SET body = EXCLUDED.body,
+           category = EXCLUDED.category,
+           description = EXCLUDED.description,
+           is_active = EXCLUDED.is_active,
+           updated_at = now()
+     RETURNING *`,
+    [args.brand, category, args.title, args.body, description, isActive, args.createdBy ?? null],
+  );
+  return rowToPrompt(rows[0]);
+}
+
+export async function deletePrompt(targetPool: pg.Pool, id: number): Promise<number> {
+  await ensurePromptLibrarySchema(targetPool);
+  const r = await targetPool.query('DELETE FROM prompt_library WHERE id = $1', [id]);
+  return r.rowCount ?? 0;
+}
+
+/**
+ * Atomically bump usage_count for a prompt. Returns the new count, or null if
+ * the id was unknown. Called when an admin inserts a prompt into a message.
+ */
+export async function incrementUsage(targetPool: pg.Pool, id: number): Promise<number | null> {
+  await ensurePromptLibrarySchema(targetPool);
+  const { rows } = await targetPool.query(
+    `UPDATE prompt_library
+       SET usage_count = usage_count + 1
+     WHERE id = $1
+     RETURNING usage_count`,
+    [id],
+  );
+  return rows[0] ? Number(rows[0].usage_count) : null;
+}

--- a/website/src/pages/admin/prompts.astro
+++ b/website/src/pages/admin/prompts.astro
@@ -1,0 +1,24 @@
+---
+import AdminLayout from '../../layouts/AdminLayout.astro';
+import PromptLibraryManager from '../../components/admin/PromptLibraryManager.svelte';
+import { getSession, isAdmin, getLoginUrl } from '../../lib/auth';
+import { pool } from '../../lib/website-db';
+import { listPrompts } from '../../lib/prompt-library-db';
+
+const BRAND = process.env.BRAND_ID ?? process.env.BRAND ?? 'mentolder';
+
+const session = await getSession(Astro.request.headers.get('cookie'));
+if (!session) return Astro.redirect(getLoginUrl(Astro.url.pathname));
+if (!isAdmin(session)) return Astro.redirect('/admin');
+
+let prompts: Awaited<ReturnType<typeof listPrompts>> = [];
+try {
+  prompts = await listPrompts(pool, BRAND, { activeOnly: false });
+} catch (err) {
+  console.error('[admin/prompts] DB error:', err);
+}
+---
+
+<AdminLayout title="Prompt-Bibliothek">
+  <PromptLibraryManager prompts={prompts} client:load />
+</AdminLayout>

--- a/website/src/pages/api/admin/prompt-library/[id].ts
+++ b/website/src/pages/api/admin/prompt-library/[id].ts
@@ -1,0 +1,66 @@
+// website/src/pages/api/admin/prompt-library/[id].ts
+// Prompt Library admin API — update (PUT) and delete (DELETE) a single prompt.
+import type { APIRoute } from 'astro';
+import { getSession, isAdmin } from '../../../../lib/auth';
+import { pool } from '../../../../lib/website-db';
+import { upsertPrompt, deletePrompt, getPrompt } from '../../../../lib/prompt-library-db';
+
+const BRAND = process.env.BRAND_ID ?? process.env.BRAND ?? 'mentolder';
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+export const PUT: APIRoute = async ({ request, params }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) return json({ error: 'Unauthorized' }, 401);
+
+  const id = Number(params.id);
+  if (!Number.isInteger(id)) return json({ error: 'invalid id' }, 400);
+
+  const existing = await getPrompt(pool, id);
+  if (!existing) return json({ error: 'not found' }, 404);
+
+  const body = (await request.json().catch(() => null)) as {
+    title?: string;
+    body?: string;
+    category?: string;
+    description?: string | null;
+    isActive?: boolean;
+  } | null;
+
+  if (!body?.title?.trim() || !body?.body?.trim()) {
+    return json({ error: 'title and body required' }, 400);
+  }
+
+  try {
+    const prompt = await upsertPrompt(pool, {
+      id,
+      brand: BRAND,
+      title: body.title.trim(),
+      body: body.body,
+      category: body.category?.trim() || existing.category,
+      description: body.description ?? null,
+      isActive: body.isActive ?? existing.isActive,
+    });
+    return json({ prompt });
+  } catch (err) {
+    console.error('[api/admin/prompt-library/[id]] update error:', err);
+    return json({ error: 'update failed' }, 500);
+  }
+};
+
+export const DELETE: APIRoute = async ({ request, params }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) return json({ error: 'Unauthorized' }, 401);
+
+  const id = Number(params.id);
+  if (!Number.isInteger(id)) return json({ error: 'invalid id' }, 400);
+
+  const affected = await deletePrompt(pool, id);
+  if (affected === 0) return json({ error: 'not found' }, 404);
+  return json({ ok: true });
+};

--- a/website/src/pages/api/admin/prompt-library/[id]/use.ts
+++ b/website/src/pages/api/admin/prompt-library/[id]/use.ts
@@ -1,0 +1,25 @@
+// website/src/pages/api/admin/prompt-library/[id]/use.ts
+// Prompt Library admin API — record a use (POST), bumping usage_count.
+import type { APIRoute } from 'astro';
+import { getSession, isAdmin } from '../../../../../lib/auth';
+import { pool } from '../../../../../lib/website-db';
+import { incrementUsage } from '../../../../../lib/prompt-library-db';
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+export const POST: APIRoute = async ({ request, params }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) return json({ error: 'Unauthorized' }, 401);
+
+  const id = Number(params.id);
+  if (!Number.isInteger(id)) return json({ error: 'invalid id' }, 400);
+
+  const usageCount = await incrementUsage(pool, id);
+  if (usageCount === null) return json({ error: 'not found' }, 404);
+  return json({ usageCount });
+};

--- a/website/src/pages/api/admin/prompt-library/index.ts
+++ b/website/src/pages/api/admin/prompt-library/index.ts
@@ -1,0 +1,58 @@
+// website/src/pages/api/admin/prompt-library/index.ts
+// Prompt Library admin API — list (GET) and create (POST).
+import type { APIRoute } from 'astro';
+import { getSession, isAdmin } from '../../../../lib/auth';
+import { pool } from '../../../../lib/website-db';
+import { listPrompts, upsertPrompt } from '../../../../lib/prompt-library-db';
+
+const BRAND = process.env.BRAND_ID ?? process.env.BRAND ?? 'mentolder';
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+export const GET: APIRoute = async ({ request, url }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) return json({ error: 'Unauthorized' }, 401);
+  // The compose-box dropdown only wants active templates; the admin manager
+  // wants everything. Default to active-only so the dropdown is the simple path.
+  const activeOnly = url.searchParams.get('all') !== '1';
+  const prompts = await listPrompts(pool, BRAND, { activeOnly });
+  return json({ prompts });
+};
+
+export const POST: APIRoute = async ({ request }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) return json({ error: 'Unauthorized' }, 401);
+
+  const body = (await request.json().catch(() => null)) as {
+    title?: string;
+    body?: string;
+    category?: string;
+    description?: string | null;
+    isActive?: boolean;
+  } | null;
+
+  if (!body?.title?.trim() || !body?.body?.trim()) {
+    return json({ error: 'title and body required' }, 400);
+  }
+
+  try {
+    const prompt = await upsertPrompt(pool, {
+      brand: BRAND,
+      title: body.title.trim(),
+      body: body.body,
+      category: body.category?.trim() || undefined,
+      description: body.description ?? null,
+      isActive: body.isActive ?? true,
+      createdBy: session.email ?? session.sub,
+    });
+    return json({ prompt }, 201);
+  } catch (err) {
+    console.error('[api/admin/prompt-library] create error:', err);
+    return json({ error: 'create failed' }, 500);
+  }
+};


### PR DESCRIPTION
## What

Implements **spec section F2 — Prompt-DB**: a brand-scoped Prompt Library so admins can store reusable canned replies and insert them into the messaging compose box for fast, consistent answers.

## Changes

- **Schema** (`k3d/website-schema.yaml`): additive `prompt_library` table added to **both** the `init-meetings-schema.sh` and `ensure-meetings-schema.sh` scripts. Idempotent (`CREATE TABLE IF NOT EXISTS` + `CREATE INDEX IF NOT EXISTS ... (brand) WHERE is_active`). **No FK to `public.brands`** — deliberately avoids the known korczewski bootstrap gap where a fresh deploy hasn't seeded the brands table.
- **DB layer** (`website/src/lib/prompt-library-db.ts`): `ensurePromptLibrarySchema(pool)` (defensive, self-heals on the query path — the **T000406 lesson**), `listPrompts(brand, {activeOnly})`, `getPrompt`, `upsertPrompt`, `deletePrompt`, `incrementUsage`. Pool injected as the first arg (mirrors `coaching-ki-config-db.ts`) so it's unit-testable with `pg-mem`. Every query calls `ensurePromptLibrarySchema` first.
- **API** (admin-auth via `getSession()` + `isAdmin()`): `prompt-library/index.ts` (GET list, POST create), `[id].ts` (PUT, DELETE), `[id]/use.ts` (POST increment usage).
- **Admin UI**: `/admin/prompts` page + `PromptLibraryManager.svelte` (list / create / edit / delete / active-toggle; fields title, category, body, description). Linked into the **Coaching** nav group in `AdminLayout.astro`.
- **Insert integration**: a "✎ Vorlage" (insert template) dropdown on the compose box in **both** `MessagePanel.svelte` and `ChatRoomPanel.svelte` (admin role). Loads active prompts of the brand via `/api/admin/prompt-library`, inserts `body` into the textarea, and POSTs to `[id]/use`. Shared, framework-free helpers live in `prompt-insert.ts`.
- **route-manifest**: regenerated for the new `/admin/prompts` page; updated the count assertions in `scripts/lib/route-manifest.test.mjs` (98→99 page files, 67→68 admin) accordingly.

## Spec section

F2 — Prompt-DB (`/tmp/ux-features-spec.md`).

## Test + build evidence

- **TDD** (failing test first): `prompt-library-db.test.ts` (14) — fresh empty pg-mem DB proves `ensurePromptLibrarySchema` creates the table, idempotency, CRUD, `incrementUsage`; `prompt-insert.test.ts` (9) — insert/append logic, load (fail-soft), best-effort use tracking. **23/23 pass.**
- `scripts/lib/route-manifest.test.mjs`: **7/7 pass**; committed `route-manifest.json` matches a fresh regen (CI staleness check clean).
- `astro build` succeeds for **both** brands (mentolder + korczewski) — no type errors in touched files.
- `kubectl kustomize k3d/` builds; `prompt_library` table confirmed present in both schema scripts.

### Testing note
The Svelte-component side is verified via the extracted pure helpers (`prompt-insert.ts`) rather than a rendered component test — the repo has no `@testing-library/svelte` / svelte-vitest plugin, and DB layers + pure helpers are the established test surface here.

## Follow-ups
- None required. If desired later, the dropdown could be extended to portal (non-admin) surfaces; currently admin-only by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)