### PR TITLE
feat(a11y): comprehensible media — diagram captions, graph title/desc, map legend, link labels [F1]

### DIFF
--- a/scripts/docs-gen/graph-svg.mjs
+++ b/scripts/docs-gen/graph-svg.mjs
@@ -172,9 +172,23 @@ export function renderGraphSvg(layout) {
   const nodes = renderNodes(layout.nodes || []);
   const legend = renderLegend(layout.width, layout.height);
 
+  // Accessible name + description. <title>/<desc> are the first children of the
+  // <svg> (the SVG-AAM contract) and are wired up via aria-labelledby, in addition
+  // to the pre-existing aria-label, so screen readers announce a meaningful name
+  // and a short explanation of what the regions/edges/nodes mean.
+  const titleText = 'Dokumentations-Beziehungsgraph';
+  const descText =
+    'Eine nach Domänen geclusterte Karte der Dokumentation. Die getönten Regionen ' +
+    'gruppieren zusammengehörige Bereiche, die Knoten stehen für Skills, Agents und ' +
+    'Docs, und die Kanten zeigen, welche Seiten aufeinander verweisen.';
+
   return (
     `<svg class="graph-svg" xmlns="http://www.w3.org/2000/svg" ` +
-    `viewBox="0 0 ${width} ${height}" role="img" aria-label="Documentation relationship graph">` +
+    `viewBox="0 0 ${width} ${height}" role="img" ` +
+    `aria-label="Documentation relationship graph" ` +
+    `aria-labelledby="graph-svg-title graph-svg-desc">` +
+    `<title id="graph-svg-title">${esc(titleText)}</title>` +
+    `<desc id="graph-svg-desc">${esc(descText)}</desc>` +
     `<g class="graph-regions">${regions}</g>` +
     `<g class="graph-edges">${edges}</g>` +
     `<g class="graph-nodes">${nodes}</g>` +

--- a/scripts/docs-gen/graph-svg.test.mjs
+++ b/scripts/docs-gen/graph-svg.test.mjs
@@ -99,6 +99,28 @@ test('renderGraphSvg: root carries the canonical graph-svg class', () => {
   assert.ok(svg.includes('class="graph-svg"'), 'svg root uses the canonical graph-svg class (IC-1)');
 });
 
+test('renderGraphSvg: emits <title> and <desc> as the first children of <svg>', () => {
+  const svg = renderGraphSvg(fixtureLayout());
+  assert.ok(svg.includes('<title'), 'has a <title> element');
+  assert.ok(svg.includes('<desc'), 'has a <desc> element');
+  assert.ok(svg.includes('Dokumentations-Beziehungsgraph'), 'title names the graph');
+  // <title> must be the very first child of <svg> (before the regions group).
+  const svgOpenEnd = svg.indexOf('>') + 1;
+  const afterOpen = svg.slice(svgOpenEnd);
+  assert.ok(afterOpen.trimStart().startsWith('<title'), 'title is the first child of <svg>');
+  const titleIdx = svg.indexOf('<title');
+  const descIdx = svg.indexOf('<desc');
+  const regionsIdx = svg.indexOf('class="graph-regions"');
+  assert.ok(titleIdx < descIdx, 'title precedes desc');
+  assert.ok(descIdx < regionsIdx, 'desc precedes the regions group');
+});
+
+test('renderGraphSvg: keeps the aria-label and references the title/desc for AT', () => {
+  const svg = renderGraphSvg(fixtureLayout());
+  assert.ok(svg.includes('aria-label="Documentation relationship graph"'), 'aria-label retained');
+  assert.ok(/aria-labelledby="[^"]+"/.test(svg), 'svg references its <title>/<desc> via aria-labelledby');
+});
+
 test('renderGraphSvg: byte-stable across runs and input order', () => {
   const a = renderGraphSvg(fixtureLayout());
   const b = renderGraphSvg(fixtureLayout());

--- a/scripts/docs-gen/render-markdown.mjs
+++ b/scripts/docs-gen/render-markdown.mjs
@@ -57,25 +57,64 @@ function slugifyHeading(text) {
     .replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '');
 }
 
+// ─── diagram caption helpers ──────────────────────────────────────────────────
+// Captions make a rendered diagram comprehensible beside the text (a11y).
+// Two sources, in priority order:
+//   1. a blockquote line directly before the diagram, "> **Abbildung:** <text>"
+//      (marked turns it into <blockquote><p><strong>Abbildung:</strong> <text></p>);
+//   2. the fenced info-string title ( ```mermaid title="…" ), captured pre-marked
+//      and threaded in via opts.captions (keyed by the trimmed diagram source).
+// When neither yields text we emit NO <figcaption> (never an empty element).
+const ABBILDUNG_RE = /^\s*Abbildung\s*:\s*([\s\S]+?)\s*$/i;
+
+// Pull the caption text from the immediately-preceding blockquote, if it matches
+// the "Abbildung:" convention. Returns the text and removes the blockquote so it
+// is not double-rendered above the figure. Returns null when there is no match.
+function consumePrecedingCaption($, $diagramEl) {
+  const $prev = $diagramEl.prev();
+  if (!$prev.length || !$prev.is('blockquote')) return null;
+  const text = $prev.text().trim();
+  const m = ABBILDUNG_RE.exec(text);
+  if (!m) return null;
+  $prev.remove();
+  return m[1].trim();
+}
+
+// Wrap a freshly-built diagram fragment in <figure class="diagram-figure">,
+// appending a <figcaption> only when caption text is present.
+function figureFor(inner, caption) {
+  const cap = caption
+    ? `<figcaption class="diagram-caption">${escapeHtml(caption)}</figcaption>`
+    : '';
+  return `<figure class="diagram-figure">${inner}${cap}</figure>`;
+}
+
 // ─── renderDiagrams ─────────────────────────────────────────────────────────────
-// Replaces fenced mermaid and dot/graphviz code blocks with inline SVG.
+// Replaces fenced mermaid and dot/graphviz code blocks with inline SVG, wrapping
+// each successfully-rendered SVG in a <figure class="diagram-figure"> (+ optional
+// <figcaption>; see the caption helpers above).
 // On a missing/failing renderer binary, falls back to a styled code block
 // (pre.diagram-fallback — shared by mermaid AND dot) and increments the counter.
 //
 // @param {string} html  HTML emitted by marked (contains <pre><code class="language-*">)
-// @param {{mmdc?:string, dot?:string, recordSnapshot?:(p:string)=>void, snapshotDir?:string}} [opts]
+// @param {{mmdc?:string, dot?:string, recordSnapshot?:(p:string)=>void, snapshotDir?:string, captions?:Record<string,string>}} [opts]
 // @returns {{ html: string, fallbacks: number }}
 export function renderDiagrams(html, opts = {}) {
   const mmdc = opts.mmdc ?? DEFAULT_MMDC;
   const dot = opts.dot ?? DEFAULT_DOT;
   const recordSnapshot = opts.recordSnapshot;
   const snapshotDir = opts.snapshotDir ?? join(__dirname, '../../docs/mermaid-snapshots');
+  const captions = opts.captions ?? {};
+  const captionFor = (src) => captions[src] ?? captions[src.trim()] ?? null;
   const $ = cheerio.load(html, { xmlMode: false });
   let fallbacks = 0;
 
   // Mermaid — cached snapshot approach to prevent layout coordinate drift.
   $('pre code.language-mermaid').each((_, el) => {
     const src = $(el).text();
+    // Caption (blockquote takes priority over the info-string title). Read it off
+    // the <pre> wrapper — its previous sibling is the candidate blockquote.
+    const caption = consumePrecedingCaption($, $(el).parent()) ?? captionFor(src);
     const hash = createHash('sha256').update(src).digest('hex');
     const snapshotFile = join(snapshotDir, `${hash}.svg`);
     let svg = null;
@@ -124,12 +163,14 @@ export function renderDiagrams(html, opts = {}) {
     }
 
     if (svg) {
-      $(el).parent().replaceWith(
-        `<div class="diagram-svg-wrapper">${svg}<span class="diagram-zoom-hint">Scroll = Zoom · Ziehen = Pan</span></div>`
-      );
+      const wrapper =
+        `<div class="diagram-svg-wrapper">${svg}<span class="diagram-zoom-hint">Scroll = Zoom · Ziehen = Pan</span></div>`;
+      $(el).parent().replaceWith(figureFor(wrapper, caption));
     } else {
       fallbacks += 1;
-      $(el).parent().replaceWith(`<pre class="diagram-fallback"><code>${escapeHtml(src)}</code></pre>`);
+      const fallback = `<pre class="diagram-fallback"><code>${escapeHtml(src)}</code></pre>`;
+      // Keep the caption attached to the fallback too, so it is never lost.
+      $(el).parent().replaceWith(caption ? figureFor(fallback, caption) : fallback);
     }
   });
 
@@ -138,6 +179,7 @@ export function renderDiagrams(html, opts = {}) {
   // which routes us into the styled-fallback branch (same as a missing mmdc).
   $('pre code.language-dot, pre code.language-graphviz').each((_, el) => {
     const src = $(el).text();
+    const caption = consumePrecedingCaption($, $(el).parent()) ?? captionFor(src);
     let svg = null;
     const tmpDir = mkdtempSync(join(tmpdir(), 'dot-'));
     const inFile = join(tmpDir, 'diagram.dot');
@@ -155,12 +197,13 @@ export function renderDiagrams(html, opts = {}) {
     if (svg) {
       // Strip the XML/doctype prologue dot emits so the SVG nests cleanly.
       const inlineSvg = svg.replace(/^[\s\S]*?(?=<svg)/, '');
-      $(el).parent().replaceWith(
-        `<div class="diagram-svg-wrapper">${inlineSvg}<span class="diagram-zoom-hint">Scroll = Zoom · Ziehen = Pan</span></div>`
-      );
+      const wrapper =
+        `<div class="diagram-svg-wrapper">${inlineSvg}<span class="diagram-zoom-hint">Scroll = Zoom · Ziehen = Pan</span></div>`;
+      $(el).parent().replaceWith(figureFor(wrapper, caption));
     } else {
       fallbacks += 1;
-      $(el).parent().replaceWith(`<pre class="diagram-fallback"><code>${escapeHtml(src)}</code></pre>`);
+      const fallback = `<pre class="diagram-fallback"><code>${escapeHtml(src)}</code></pre>`;
+      $(el).parent().replaceWith(caption ? figureFor(fallback, caption) : fallback);
     }
   });
 
@@ -268,12 +311,17 @@ export function rewriteCrossLinks(html, { registry, page }) {
 // @param {{registry: object, page: {slug:string}, mmdc?:string, dot?:string, recordSnapshot?:Function, snapshotDir?:string}} ctx
 // @returns {RenderResult}
 export function renderMarkdown(markdown, { registry, page, mmdc, dot, recordSnapshot, snapshotDir } = {}) {
+  // Capture fenced diagram titles (```mermaid|dot|graphviz title="…") BEFORE marked
+  // parses, because marked drops everything after the first info-string word. The
+  // map is keyed by the trimmed diagram source so renderDiagrams can match it back.
+  const captions = extractDiagramCaptions(markdown);
+
   let html = marked.parse(markdown);
 
   const xref = rewriteCrossLinks(html, { registry, page });
   html = xref.html;
 
-  const diagrams = renderDiagrams(html, { mmdc, dot, recordSnapshot, snapshotDir });
+  const diagrams = renderDiagrams(html, { mmdc, dot, recordSnapshot, snapshotDir, captions });
   html = diagrams.html;
 
   html = addHeadingIds(html);
@@ -310,4 +358,30 @@ function escapeHtml(str) {
 
 function escapeAttr(str) {
   return String(str).replace(/&/g, '&amp;').replace(/"/g, '&quot;');
+}
+
+// ─── extractDiagramCaptions ─────────────────────────────────────────────────────
+// Scan raw markdown for fenced diagram blocks (mermaid/dot/graphviz) whose
+// info-string carries a title="…", and return a map of trimmed-source → title.
+// marked discards the info-string past the language word, so this runs pre-parse.
+// The map is keyed by the BODY of the fence (matching code.textContent post-marked,
+// which trims the trailing newline — so we trim here too).
+// @param {string} markdown
+// @returns {Record<string,string>}
+export function extractDiagramCaptions(markdown) {
+  const captions = {};
+  if (!markdown) return captions;
+  // ```<lang> …title="<text>"  …body…  ```  — lang restricted to diagram kinds.
+  const re = /^([ \t]*)(`{3,}|~{3,})[ \t]*(mermaid|dot|graphviz)\b([^\n]*)\n([\s\S]*?)\n?\1\2[ \t]*$/gim;
+  let m;
+  while ((m = re.exec(markdown)) !== null) {
+    const info = m[4] || '';
+    const body = m[5] ?? '';
+    const titleMatch = /\btitle\s*=\s*"([^"]*)"|\btitle\s*=\s*'([^']*)'/.exec(info);
+    if (!titleMatch) continue;
+    const title = (titleMatch[1] ?? titleMatch[2] ?? '').trim();
+    if (!title) continue;
+    captions[body.trim()] = title;
+  }
+  return captions;
 }

--- a/scripts/docs-gen/render-markdown.test.mjs
+++ b/scripts/docs-gen/render-markdown.test.mjs
@@ -67,6 +67,113 @@ test('renderDiagrams: uses cached SVG from snapshots if present', () => {
   }
 });
 
+test('renderDiagrams: a rendered SVG is wrapped in <figure class="diagram-figure">', () => {
+  const html =
+    '<pre><code class="language-mermaid">graph TD\n  Fig --&gt; Cap</code></pre>';
+  const src = 'graph TD\n  Fig --> Cap';
+  const hash = createHash('sha256').update(src).digest('hex');
+  const snapshotDir = join(__dirname, '../../docs/mermaid-snapshots');
+  const snapshotFile = join(snapshotDir, `${hash}.svg`);
+  mkdirSync(snapshotDir, { recursive: true });
+  writeFileSync(snapshotFile, '<svg id="figwrap-svg"></svg>', 'utf8');
+  try {
+    const { html: out } = renderDiagrams(html, { mmdc: '/nonexistent/mmdc' });
+    assert.ok(out.includes('class="diagram-figure"'), 'wraps rendered SVG in a figure');
+    assert.ok(out.includes('id="figwrap-svg"'), 'keeps the rendered SVG inside the figure');
+    // No caption present → no figcaption element (no empty caption).
+    assert.ok(!out.includes('<figcaption'), 'no figcaption when there is no caption');
+  } finally {
+    try { unlinkSync(snapshotFile); } catch {}
+  }
+});
+
+test('renderDiagrams: a preceding blockquote "Abbildung:" becomes the figcaption and is consumed', () => {
+  const src = 'graph TD\n  Cap --> Tion';
+  const hash = createHash('sha256').update(src).digest('hex');
+  const snapshotDir = join(__dirname, '../../docs/mermaid-snapshots');
+  const snapshotFile = join(snapshotDir, `${hash}.svg`);
+  mkdirSync(snapshotDir, { recursive: true });
+  writeFileSync(snapshotFile, '<svg id="cap-svg"></svg>', 'utf8');
+  const html =
+    '<blockquote>\n<p><strong>Abbildung:</strong> Der Deploy-Ablauf</p>\n</blockquote>' +
+    '<pre><code class="language-mermaid">graph TD\n  Cap --&gt; Tion</code></pre>';
+  try {
+    const { html: out } = renderDiagrams(html, { mmdc: '/nonexistent/mmdc' });
+    assert.ok(out.includes('<figcaption'), 'emits a figcaption');
+    assert.ok(out.includes('Der Deploy-Ablauf'), 'figcaption carries the caption text');
+    // The caption blockquote must be consumed (not double-rendered above the figure).
+    assert.ok(!/<blockquote>[\s\S]*Abbildung/.test(out), 'caption blockquote is consumed');
+  } finally {
+    try { unlinkSync(snapshotFile); } catch {}
+  }
+});
+
+test('renderDiagrams: a captions map (from the fenced title) supplies the figcaption', () => {
+  const src = 'graph TD\n  T --> S';
+  const hash = createHash('sha256').update(src).digest('hex');
+  const snapshotDir = join(__dirname, '../../docs/mermaid-snapshots');
+  const snapshotFile = join(snapshotDir, `${hash}.svg`);
+  mkdirSync(snapshotDir, { recursive: true });
+  writeFileSync(snapshotFile, '<svg id="titlecap-svg"></svg>', 'utf8');
+  const html =
+    '<pre><code class="language-mermaid">graph TD\n  T --&gt; S</code></pre>';
+  try {
+    const { html: out } = renderDiagrams(html, {
+      mmdc: '/nonexistent/mmdc',
+      captions: { [src]: 'Titel aus Info-String' },
+    });
+    assert.ok(out.includes('<figcaption'), 'emits a figcaption from the captions map');
+    assert.ok(out.includes('Titel aus Info-String'), 'figcaption carries the info-string title');
+  } finally {
+    try { unlinkSync(snapshotFile); } catch {}
+  }
+});
+
+test('renderDiagrams: keeps an aria-friendly zoom hint text on the rendered SVG', () => {
+  const src = 'graph TD\n  Z --> H';
+  const hash = createHash('sha256').update(src).digest('hex');
+  const snapshotDir = join(__dirname, '../../docs/mermaid-snapshots');
+  const snapshotFile = join(snapshotDir, `${hash}.svg`);
+  mkdirSync(snapshotDir, { recursive: true });
+  writeFileSync(snapshotFile, '<svg id="zoomhint-svg"></svg>', 'utf8');
+  const html =
+    '<pre><code class="language-mermaid">graph TD\n  Z --&gt; H</code></pre>';
+  try {
+    const { html: out } = renderDiagrams(html, { mmdc: '/nonexistent/mmdc' });
+    assert.ok(out.includes('diagram-zoom-hint'), 'retains the visual zoom hint');
+    assert.ok(out.includes('Scroll = Zoom'), 'zoom hint keeps its readable text');
+  } finally {
+    try { unlinkSync(snapshotFile); } catch {}
+  }
+});
+
+test('renderMarkdown: a fenced mermaid title="…" flows through to a figcaption', async () => {
+  const src = 'flowchart LR\n  A --> B';
+  const hash = createHash('sha256').update(src).digest('hex');
+  const snapshotDir = join(__dirname, '../../docs/mermaid-snapshots');
+  const snapshotFile = join(snapshotDir, `${hash}.svg`);
+  mkdirSync(snapshotDir, { recursive: true });
+  writeFileSync(snapshotFile, '<svg id="e2e-title-svg"></svg>', 'utf8');
+  const registry = makeRegistry({});
+  const page = { slug: 'figs' };
+  const md = [
+    '# Figs',
+    '',
+    '```mermaid title="End-to-End Titel"',
+    'flowchart LR',
+    '  A --> B',
+    '```',
+  ].join('\n');
+  try {
+    const result = await renderMarkdown(md, { registry, page, mmdc: '/nonexistent/mmdc', snapshotDir });
+    assert.ok(result.html.includes('class="diagram-figure"'), 'figure wrapper present');
+    assert.ok(result.html.includes('<figcaption'), 'figcaption emitted from the title');
+    assert.ok(result.html.includes('End-to-End Titel'), 'title text carried into the figcaption');
+  } finally {
+    try { unlinkSync(snapshotFile); } catch {}
+  }
+});
+
 test('renderDiagrams: dot block falls back to a styled code block when dot is absent', () => {
   const html =
     '<pre><code class="language-dot">digraph G { a -&gt; b }</code></pre>';

--- a/scripts/docs-gen/theme.mjs
+++ b/scripts/docs-gen/theme.mjs
@@ -180,6 +180,12 @@ body{margin:0;background:var(--paper-2);color:var(--ink);
   display:-webkit-box;-webkit-line-clamp:3;-webkit-box-orient:vertical;overflow:hidden}
 
 /* ── diagrams ── */
+.diagram-figure{margin:1.4rem 0}
+.diagram-figure .diagram-svg-wrapper,.diagram-figure .diagram-fallback{margin:0}
+.diagram-caption{margin:.55rem 0 0;font-size:.82rem;line-height:1.5;color:var(--ink-mute);
+  font-style:italic;text-align:center}
+.diagram-caption::before{content:"Abbildung: ";font-style:normal;font-weight:700;
+  color:var(--ink-soft)}
 .diagram-svg-wrapper{position:relative;border:1px solid var(--line);border-radius:8px;
   margin:1.4rem 0;background:var(--paper-2);overflow:hidden}
 .diagram-svg-wrapper svg{display:block;width:100%;height:auto;cursor:grab;

--- a/website/src/components/ServiceCard.svelte
+++ b/website/src/components/ServiceCard.svelte
@@ -57,6 +57,7 @@
 
   <a
     {href}
+    aria-label={`Mehr erfahren über ${title}`}
     class="block text-center bg-gold hover:bg-gold-light text-dark px-6 py-3.5 rounded-full font-bold text-lg transition-colors uppercase tracking-wide"
   >
     Mehr erfahren

--- a/website/src/components/ServiceLinks.astro
+++ b/website/src/components/ServiceLinks.astro
@@ -25,22 +25,27 @@ function isSvg(icon: string) {
     <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3">
       {links.map(link => {
         const external = link.href.startsWith('http');
+        const ariaLabel = external
+          ? `${link.label} öffnen (öffnet in neuem Tab)`
+          : `${link.label} öffnen`;
         return (
         <a
           href={link.href}
           target={external ? '_blank' : undefined}
           rel={external ? 'noopener noreferrer' : undefined}
+          aria-label={ariaLabel}
           data-testid={`service-link-${link.label}`}
           class="flex flex-col items-center gap-2 p-4 bg-dark-light rounded-xl border border-dark-lighter hover:border-gold/40 transition-colors text-center"
         >
           {isSvg(link.icon) ? (
             <span
               class="text-muted"
+              aria-hidden="true"
               style="width:20px; height:20px; display:flex; align-items:center; justify-content:center;"
               set:html={link.icon}
             />
           ) : (
-            <span class="text-xl leading-none">{link.icon}</span>
+            <span class="text-xl leading-none" aria-hidden="true">{link.icon}</span>
           )}
           <span class="text-xs font-medium text-muted">{link.label}</span>
         </a>

--- a/website/src/components/assistant/agent-guide/.gitignore
+++ b/website/src/components/assistant/agent-guide/.gitignore
@@ -1,0 +1,3 @@
+# Transient SSR-compiled component written by GuideMap.test.ts (cleaned up in afterEach;
+# ignored here so a crashed test run can never accidentally stage the artifact).
+.GuideMap.compiled.svelte.mjs

--- a/website/src/components/assistant/agent-guide/GuideCard.svelte
+++ b/website/src/components/assistant/agent-guide/GuideCard.svelte
@@ -85,7 +85,12 @@
           <ol class="ag-flow">
             {#each goal!.flow as step, i (i)}
               <li>
-                <button type="button" class="ag-flow-jump" onclick={() => onJump(`ag-tool-${step.tool}`)}>
+                <button
+                  type="button"
+                  class="ag-flow-jump"
+                  aria-label={`Zum Werkzeug springen: ${step.tool_name_de}`}
+                  onclick={() => onJump(`ag-tool-${step.tool}`)}
+                >
                   {step.tool_name_de}
                 </button> — {step.note_de}
               </li>
@@ -109,7 +114,11 @@
           <div class="ag-related">
             {#each goal!.related as relId (relId)}
               {@const rel = entry.related?.[relId]}
-              <button class="ag-related-chip" onclick={() => onJump(rel?.domId ?? `ag-goal-${relId}`)}>
+              <button
+                class="ag-related-chip"
+                aria-label={`Zu verwandtem Eintrag springen: ${rel?.label ?? relId}`}
+                onclick={() => onJump(rel?.domId ?? `ag-goal-${relId}`)}
+              >
                 ↳ {#if rel}{tierEmoji(rel.danger)} {rel.label}{:else}{relId}{/if}
               </button>
             {/each}
@@ -139,7 +148,11 @@
           <div class="ag-related">
             {#each tool!.related as relId (relId)}
               {@const rel = entry.related?.[relId]}
-              <button class="ag-related-chip" onclick={() => onJump(rel?.domId ?? `ag-tool-${relId}`)}>
+              <button
+                class="ag-related-chip"
+                aria-label={`Zu verwandtem Eintrag springen: ${rel?.label ?? relId}`}
+                onclick={() => onJump(rel?.domId ?? `ag-tool-${relId}`)}
+              >
                 ↳ {#if rel}{tierEmoji(rel.danger)} {rel.label}{:else}{relId}{/if}
               </button>
             {/each}

--- a/website/src/components/assistant/agent-guide/GuideMap.svelte
+++ b/website/src/components/assistant/agent-guide/GuideMap.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
   import type { MapData } from '../../../lib/agentGuide';
-  import { tierColor, tierEmoji, tierLabel } from '../../../lib/agentGuide';
+  import { tierColor, tierEmoji, tierLabel, tierLegend } from '../../../lib/agentGuide';
+
+  // Danger-tier legend rows (🟢/🟡/🟠/🔴 → Bedeutung), derived from the taxonomy.
+  const legend = tierLegend();
 
   let {
     map,
@@ -24,6 +27,27 @@
 </script>
 
 <div class="ag-map" aria-label="So funktioniert die Plattform">
+  <!-- Legende: erklärt die Gefahrenstufen-Farben/Emojis, damit die Karte verständlich ist -->
+  <details class="ag-legend">
+    <summary class="ag-legend-summary">
+      <span aria-hidden="true">🗺️</span>
+      <span>Legende: Was bedeuten die Farben?</span>
+    </summary>
+    <p class="ag-sr">
+      Jeder Knoten und jede Station ist nach Gefahrenstufe eingefärbt.
+      {#each legend as row}{row.emoji} {row.label}: {row.meaning} {/each}
+    </p>
+    <ul class="ag-legend-list" aria-hidden="true">
+      {#each legend as row (row.id)}
+        <li class="ag-legend-row">
+          <span class="ag-legend-dot" style="--tier: {row.color}">{row.emoji}</span>
+          <span class="ag-legend-label">{row.label}</span>
+          <span class="ag-legend-meaning">{row.meaning}</span>
+        </li>
+      {/each}
+    </ul>
+  </details>
+
   <!-- Flow ribbon -->
   <p class="ag-section-label">Dein Weg: Idee → live</p>
   <ol class="ag-flowband">
@@ -73,3 +97,61 @@
     {/each}
   </div>
 </div>
+
+<style>
+  /* Collapsible danger-tier legend. Reuses the panel CSS custom properties
+     (--brass/--mute/--line/--serif) that cascade from the sidekick drawer. */
+  .ag-legend {
+    border: 1px solid color-mix(in srgb, var(--line, #3a3327) 70%, transparent);
+    border-radius: 10px;
+    background: color-mix(in srgb, var(--brass, #b08a4f) 6%, transparent);
+    margin: 0 0 10px;
+    padding: 0;
+  }
+  .ag-legend-summary {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    list-style: none;
+    cursor: pointer;
+    padding: 9px 12px;
+    font-family: var(--serif, Georgia, serif);
+    font-size: 14px;
+    color: var(--ink, #ece6da);
+  }
+  .ag-legend-summary::-webkit-details-marker { display: none; }
+  .ag-legend-summary::after {
+    content: '▸';
+    margin-inline-start: auto;
+    color: var(--mute, #9a917f);
+    transition: transform 0.15s ease;
+  }
+  .ag-legend[open] > .ag-legend-summary::after { transform: rotate(90deg); }
+  .ag-legend-summary:focus-visible { outline: 2px solid var(--brass, #b08a4f); outline-offset: -2px; }
+  .ag-legend-list {
+    list-style: none;
+    margin: 0;
+    padding: 2px 12px 10px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .ag-legend-row {
+    display: grid;
+    grid-template-columns: auto auto 1fr;
+    align-items: baseline;
+    gap: 8px;
+    font-size: 12.5px;
+  }
+  .ag-legend-dot {
+    width: 1.25em;
+    text-align: center;
+    border-radius: 4px;
+    box-shadow: inset 0 0 0 2px color-mix(in srgb, var(--tier) 60%, transparent);
+  }
+  .ag-legend-label { font-weight: 600; color: var(--ink, #ece6da); }
+  .ag-legend-meaning { color: var(--mute, #9a917f); }
+  @media (prefers-reduced-motion: reduce) {
+    .ag-legend-summary::after { transition: none; }
+  }
+</style>

--- a/website/src/components/assistant/agent-guide/GuideMap.test.ts
+++ b/website/src/components/assistant/agent-guide/GuideMap.test.ts
@@ -1,0 +1,81 @@
+// GuideMap legend tests (F1 — Verständliche Medien).
+//
+// The website has no @sveltejs/vite-plugin-svelte wired into vitest, so we render
+// the real component the dependency-free way: compile GuideMap.svelte to SSR JS at
+// test time, write it NEXT TO the source (so its relative `../../../lib/agentGuide`
+// import resolves identically), and render it with svelte/server. vitest's own vite
+// pipeline resolves the .ts/.json imports the compiled module pulls in.
+import { describe, it, expect, afterEach } from 'vitest';
+import { compile } from 'svelte/compiler';
+import { render } from 'svelte/server';
+import { readFileSync, writeFileSync, rmSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { tierLegend, guideMap } from '../../../lib/agentGuide';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const COMPILED = join(__dirname, '.GuideMap.compiled.svelte.mjs');
+
+async function renderGuideMap(props: Record<string, unknown>): Promise<string> {
+  const source = readFileSync(join(__dirname, 'GuideMap.svelte'), 'utf8');
+  const { js } = compile(source, { generate: 'server', runes: true, name: 'GuideMap' });
+  writeFileSync(COMPILED, js.code);
+  const mod = await import(/* @vite-ignore */ COMPILED);
+  return render(mod.default, { props }).body;
+}
+
+afterEach(() => {
+  try { rmSync(COMPILED, { force: true }); } catch { /* ignore */ }
+});
+
+describe('tierLegend', () => {
+  it('maps every danger tier to an emoji, label and meaning', () => {
+    const rows = tierLegend();
+    expect(rows.length).toBe(4);
+    const ids = rows.map((r) => r.id);
+    expect(ids).toEqual(['safe', 'caution', 'assisted', 'forbidden']);
+    for (const row of rows) {
+      expect(row.emoji).toBeTruthy();
+      expect(row.label).toBeTruthy();
+      expect(row.meaning).toBeTruthy();
+      expect(row.color).toMatch(/^#/);
+      // the label must not still carry a leading tier emoji (deduped vs the dot)
+      expect(row.label.startsWith(row.emoji)).toBe(false);
+    }
+  });
+
+  it('uses the four traffic-light tier emojis', () => {
+    const emojis = tierLegend().map((r) => r.emoji);
+    expect(emojis).toEqual(['🟢', '🟡', '🟠', '🔴']);
+  });
+});
+
+describe('GuideMap legend rendering', () => {
+  it('renders a visible, collapsible legend with each tier meaning', async () => {
+    const body = await renderGuideMap({ map: guideMap, onSelect: () => {} });
+    // collapsible container present
+    expect(body).toContain('class="ag-legend');
+    expect(body).toMatch(/<details[^>]*class="ag-legend/);
+    expect(body).toContain('<summary');
+    // legend summary is the human-readable affordance
+    expect(body).toContain('Was bedeuten die Farben?');
+    // every tier meaning is rendered (comprehensible mapping emoji/colour → Bedeutung)
+    for (const row of tierLegend()) {
+      expect(body).toContain(row.meaning);
+    }
+    // screen-reader description present
+    expect(body).toContain('ag-sr');
+  });
+
+  it('keeps the legend collapsible via <details>/<summary> (toggle affordance)', async () => {
+    const body = await renderGuideMap({ map: guideMap, onSelect: () => {} });
+    // a native <details> is keyboard- and screenreader-toggleable without JS;
+    // assert the summary sits inside the details element.
+    const detailsIdx = body.indexOf('<details');
+    const summaryIdx = body.indexOf('<summary');
+    const closeIdx = body.indexOf('</details>');
+    expect(detailsIdx).toBeGreaterThanOrEqual(0);
+    expect(summaryIdx).toBeGreaterThan(detailsIdx);
+    expect(closeIdx).toBeGreaterThan(summaryIdx);
+  });
+});

--- a/website/src/lib/agentGuide.ts
+++ b/website/src/lib/agentGuide.ts
@@ -156,3 +156,29 @@ export function componentBySlug(slug: string): Component | undefined {
   return components[slug];
 }
 
+export interface LegendRow {
+  id: string;
+  emoji: string;
+  label: string;
+  meaning: string;
+  color: string;
+}
+
+/**
+ * The danger-tier legend, derived from the taxonomy, that makes the map's
+ * colour/emoji coding comprehensible (🟢 sicher / 🟡 Vorsicht / 🟠 heikel /
+ * 🔴 kritisch). Used by GuideMap's visible, collapsible legend and its
+ * screen-reader text. Returns one row per tier, in taxonomy order.
+ */
+export function tierLegend(): LegendRow[] {
+  return taxonomy.map((t) => ({
+    id: t.id,
+    emoji: t.emoji,
+    // The label_de already embeds the emoji (e.g. "🟢 Sicher"); strip a leading
+    // emoji + space so the row reads "<dot emoji> <plain label>" without a dupe.
+    label: t.label_de.replace(/^\s*\p{Extended_Pictographic}️?\s*/u, '').trim() || t.label_de,
+    meaning: t.meaning_de,
+    color: t.color,
+  }));
+}
+


### PR DESCRIPTION
## Was diese Änderung tut

Setzt Spec-Abschnitt **„F1 — Verständliche Medien"** um: neben dem Text werden Grafiken, Bilder und Links verständlich (Captions, Legenden, Beschreibungen, alt/aria).

1. **Docs-Diagramme** (`scripts/docs-gen/render-markdown.mjs`, `theme.mjs`): jedes erfolgreich gerenderte Diagramm-SVG wird in `<figure class="diagram-figure">` + optionalem `<figcaption>` gewrappt. Caption-Quelle:
   - ein Blockquote direkt vor dem Diagramm im Format `> **Abbildung:** <text>` (wird konsumiert, nicht doppelt gerendert), **oder**
   - der Fenced-Info-String-Titel (` ```mermaid title="…" `) — vor `marked` ausgelesen und durchgereicht (marked verwirft den Info-String sonst).
   - Keine Caption → **kein** leeres `figcaption`. Der lesbare Zoom-Hinweis bleibt erhalten.
2. **Graph-SVG** (`scripts/docs-gen/graph-svg.mjs`): `<title>` + `<desc>` als erste Kinder des `<svg>` (SVG-AAM-Kontrakt), verdrahtet via `aria-labelledby`, zusätzlich zum bestehenden `aria-label`.
3. **Agent-Guide-Legende** (`GuideMap.svelte` + `agentGuide.ts`): sichtbare, collapsible `<details>`-Legende, die Gefahrenstufe-Emoji/Farbe → Bedeutung mappt (🟢 sicher / 🟡 Vorsicht / 🟠 nur mit Hilfe / 🔴 niemals allein), gespeist aus neuem `tierLegend()`-Helper; Screenreader-Text wird mitgeführt.
4. **Link-Beschreibungen**: aussagekräftige `aria-label` auf `ServiceCard` („Mehr erfahren" → „Mehr erfahren über <Service>"), `ServiceLinks` (inkl. Extern-/Neuer-Tab-Hinweis; dekorative Icons `aria-hidden`) und den Jump-/Related-Buttons in `GuideCard.svelte`.

## Spec-Abschnitt
`/tmp/ux-features-spec.md` → **F1 — Verständliche Medien**, Branch `feature/comprehensible-media-a11y`.

## Test- & Build-Nachweis
- Docs-gen Unit-Tests (`node --test`): **90 pass / 0 fail** (`render-markdown.test.mjs`: figure/figcaption, Blockquote-Caption konsumiert, Captions-Map aus Info-String, kein figcaption ohne Caption, Zoom-Hint bleibt; `graph-svg.test.mjs`: `<title>`/`<desc>` als erste Kinder, `aria-labelledby` + `aria-label`).
- GuideMap-Vitest (`website/src/components/assistant/agent-guide/GuideMap.test.ts`): **4 pass** — `tierLegend()` Datenkorrektheit + Component-Render (Legende rendert, collapsible via `<details>/<summary>`). Rendert die echte Komponente dependency-frei über SSR-Compile (`svelte/compiler` + `svelte/server`), kein neuer vitest-Plugin/Lockfile-Change.
- Volle Website-Vitest-Suite: **586 pass / 91 skipped / 0 fail**.
- `node scripts/build-docs.mjs`: **exit 0**, läuft fehlerfrei (Graph-SVG enthält `<title id="graph-svg-title">` + `aria-labelledby`; gerenderte Diagramm-Figures vorhanden).
- Beide Brands bauen: `BRAND_ID=mentolder npx astro build` und `BRAND_ID=korczewski npx astro build` → beide **Complete!**.
- `astro check`: keine **neuen** Type-Fehler durch diese Änderung; die 11 vorhandenen Fehler (u. a. der `components`-Cast in `agentGuide.ts:133`) sind vorbestehend und unberührt.

## Scope / Follow-ups
- Generierte Docs-HTML unter `k3d/docs-content-built/` wurde **nicht** mitcommittet (wird vom `build-docs`/`docs:deploy`-Pfad erzeugt); nur Quell-Dateien + Tests.
- Real-Content nutzt die `> **Abbildung:**`-Konvention noch nirgends — Feature ist additiv; Captions können in Doc-Markdown nachgezogen werden (außerhalb dieses F1-Scopes).
- `.gitignore` im agent-guide-Verzeichnis schützt vor versehentlichem Staging des transienten SSR-Compile-Artefakts (wird im Test in `afterEach` gelöscht).

🤖 Generated with [Claude Code](https://claude.com/claude-code)