### PR TITLE
fix(ops): unblock nightly E2E, fix shared-db bootstrap order, eager tickets schema init [T000408 T000409 T000410]

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -105,6 +105,9 @@ jobs:
           # Auth
           MM_TEST_USER: ${{ secrets.MM_TEST_USER }}
           MM_TEST_PASS: ${{ secrets.MM_TEST_PASS }}
+          # Skip prod DB purge until CRON_SECRET is provisioned as a repo secret (T000408).
+          # Without this the global setup throws before any spec runs.
+          SKIP_DB_PURGE: "1"
         run: npx playwright test
 
       # Ingest Playwright JSON into the website's test_runs/test_results +

--- a/k3d/shared-db.yaml
+++ b/k3d/shared-db.yaml
@@ -218,9 +218,9 @@ spec:
                       -c "ALTER USER vaultwarden WITH PASSWORD '$${VAULTWARDEN_DB_PASSWORD}';" \
                       -c "ALTER USER website WITH PASSWORD '$${WEBSITE_DB_PASSWORD}';"
                     psql -U postgres -c "DO \$\$ BEGIN IF EXISTS (SELECT FROM pg_roles WHERE rolname = 'docuseal') THEN EXECUTE 'ALTER USER docuseal WITH PASSWORD ''$${DOCUSEAL_DB_PASSWORD}'''; END IF; END \$\$;"
+                    bash /scripts/ensure-knowledge-schema.sh || true
                     bash /scripts/ensure-meetings-schema.sh || true
                     bash /scripts/ensure-bachelorprojekt-schema.sh || true
-                    bash /scripts/ensure-knowledge-schema.sh || true
           ports:
             - containerPort: 5432
           volumeMounts:

--- a/website/src/lib/website-db.ts
+++ b/website/src/lib/website-db.ts
@@ -56,6 +56,11 @@ export function __resetSchemaInitCacheForTests(): void {
   _schemaInitOnce.clear();
 }
 
+// Eager boot-time init so tracker schema migrations apply on rollout rather
+// than on the first lazy code path that happens to call initTicketsSchema (T000410).
+// Non-blocking fire-and-forget: ensureSchemaOnce caches the promise and retries
+// on the next access if the DB is not yet ready at startup.
+initTicketsSchema().catch(() => { /* retried on first access via ensureSchemaOnce */ });
 
 // ── Timeline (PR5: reads from tickets.pr_events on the same DB) ─────────────
 // Historical note: an earlier implementation used a separate tracking pool


### PR DESCRIPTION
## Summary

- **T000408**: `e2e.yml` — `SKIP_DB_PURGE=1` gesetzt, damit die nightly Playwright-Suite ohne provisioniertes `CRON_SECRET` läuft. Das globale Setup warf bisher vor jedem Spec-Run einen Fehler. Die `SKIP_DB_PURGE`-Pfad ist bereits in `global-db-cleanup.ts` implementiert (sicherer Bypass, kein Purge-Stub). Option (a) (CRON_SECRET im Repo-Secret) bleibt offen für später.
- **T000409**: `k3d/shared-db.yaml` — `ensure-knowledge-schema.sh` wird jetzt als **erstes** postStart-Skript ausgeführt (vorher letztes). `coaching.books` hat einen FK auf `knowledge.collections`; wenn `ensure-meetings-schema.sh` vor `ensure-knowledge-schema.sh` lief, brach das gesamte Skript bei einem frischen korczewski-Cluster mit `ON_ERROR_STOP=1` ab — alles danach (test-Tabellen, fn_purge_test_data, GRANTs) wurde nie angelegt.
- **T000410**: `website/src/lib/website-db.ts` — `initTicketsSchema()` wird jetzt **beim Modulstart** (fire-and-forget) aufgerufen. Bisher war die Funktion lazy — Schema-Migrationen griffen erst beim ersten Code-Pfad, der sie triggerte. `ensureSchemaOnce` sorgt dafür, dass sie genau einmal ausgeführt wird und bei einem Startfehler beim nächsten Zugriff wiederholt wird.

## Test plan

- [ ] Nightly E2E (`e2e.yml`) manuell dispatchen — sollte jetzt durchlaufen (kein Abbruch im globalSetup)
- [ ] Nach Deploy auf fleet: shared-db neu starten auf korczewski, prüfen ob `coaching.books` + `fn_purge_test_data()` korrekt angelegt werden
- [ ] Website rollout: erste Anfrage an `/api/admin/tickets` — `initTicketsSchema` sollte bereits gelaufen sein, kein Kaltstart-Delay

🤖 Generated with [Claude Code](https://claude.com/claude-code)