### PR TITLE
fix(cronjob): add pg_isready wait to admin-actions CronJobs [T000419]

### DIFF
--- a/k3d/admin-actions-cronjobs.yaml
+++ b/k3d/admin-actions-cronjobs.yaml
@@ -39,6 +39,7 @@ spec:
                 - sh
                 - -c
                 - |
+                  until pg_isready -h "$PGHOST" -U "$PGUSER" -d "$PGDATABASE" -q; do sleep 1; done
                   psql -v ON_ERROR_STOP=1 -c "
                     UPDATE public.admin_actions
                     SET status = 'failed',
@@ -89,6 +90,7 @@ spec:
                 - sh
                 - -c
                 - |
+                  until pg_isready -h "$PGHOST" -U "$PGUSER" -d "$PGDATABASE" -q; do sleep 1; done
                   psql -v ON_ERROR_STOP=1 -c "
                     DELETE FROM public.admin_actions
                     WHERE created_at < now() - interval '90 days';


### PR DESCRIPTION
## Summary

- `admin-actions-cleanup` und `admin-actions-prune` CronJobs feuern beide simultan (beide `*/30` bzw. `0 4`) auf demselben Node
- Beide Pods konkurrieren beim Start sofort um Verbindungen zu `shared-db`, ohne auf DB-Bereitschaft zu warten
- Erste `psql`-Ausführung schlägt fehl (Verbindungsfehler), Kubernetes startet Container neu → RESTARTS=1 bei jedem abgeschlossenen Pod
- Fix: `until pg_isready ...; do sleep 1; done` vor jedem `psql`-Aufruf — wartet bis DB Verbindungen annimmt

## Test plan

- [ ] Nach Deploy: nächster `*/30` CronJob-Run zeigt `RESTARTS=0` in beiden Namespaces
- [ ] `kubectl get pods -n workspace --context fleet | grep admin-actions` → Completed mit 0 Restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)