### PR TITLE
feat(factory): Software Factory Phase 2 — Dispatcher (Tier 1) [T000424]

### DIFF
--- a/Taskfile.factory.yml
+++ b/Taskfile.factory.yml
@@ -17,3 +17,18 @@ tasks:
         echo "Offline lint:     node --check scripts/factory/pipeline.js"
         echo "Contract tests:   ./tests/runner.sh local FA-SF-20"
         echo "Full offline gate: task test:all"
+
+  dispatch:
+    desc: |
+      Print how to run the Phase-2 Software Factory dispatcher.
+      Invoke scripts/factory/dispatcher.js via the Claude Code Workflow tool,
+      driven on an interval by the /loop skill (self-paced ScheduleWakeup).
+    silent: true
+    cmds:
+      - |
+        echo "Software Factory — Phase 2 dispatcher"
+        echo "Invoke via the Workflow tool: { scriptPath: 'scripts/factory/dispatcher.js' }, args: { timestamp }"
+        echo "Recurring: /loop \"run the software-factory-dispatcher workflow\""
+        echo "Offline lint:   node --check scripts/factory/dispatcher.js"
+        echo "Contract tests: ./tests/runner.sh local FA-SF-30"
+        echo "Primitives:     slots.sh queue.sh schedule.sh watchdog.sh metrics.sh (BRAND=<brand>)"

--- a/docs/superpowers/plans/2026-06-05-sf-dispatcher.md
+++ b/docs/superpowers/plans/2026-06-05-sf-dispatcher.md
@@ -1,0 +1,1285 @@
+---
+title: Software Factory — Phase 2 (Dispatcher / Tier 1) Implementation Plan
+ticket_id: T000424
+domains: [db, test, infra]
+status: active
+pr_number: null
+---
+
+# Software Factory — Phase 2 (Dispatcher / Tier 1) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Turn the manually-invoked P1 single-feature pipeline into an autonomous, `/loop`-driven multi-feature Dispatcher (Tier 1) that polls the feature queue, conflict-gates + slot-schedules, launches pipelines in parallel (Model A: a Workflow that nests pipeline workflows), sweeps for stale runs, and writes throughput metrics — across both brands.
+
+**Architecture:** Five deterministic bash primitives (`slots.sh`, `queue.sh`, `schedule.sh`, `watchdog.sh`, `metrics.sh`) sharing `scripts/factory/lib.sh`, plus `ticket.sh` extensions, are orchestrated by a Model-A Workflow script `scripts/factory/dispatcher.js`. Per tick the dispatcher runs ONE deterministic PREP agent (watchdog→queue→conflict-gate→slot-claim, returns a schema-validated launch plan), LAUNCHES one nested `pipeline.js` workflow per scheduled feature via `workflow({scriptPath})`, then runs a METRICS agent. Single-flight comes from `/loop`'s natural cadence (next wake scheduled only after the run ends) plus an atomic slot-claim and a global concurrency cap — **not** a pg advisory lock (which would not survive separate `kubectl exec` psql sessions). Liveness is `updated_at` (auto-bumped by the `fn_lifecycle_ts` trigger) plus a per-phase `ticket.sh touch` written by `pipeline.js`; the watchdog escalates `in_progress` features stale > 30 min.
+
+**Tech Stack:** Bash (`set -euo pipefail`, `jq`), `kubectl --context fleet exec … psql` against each brand's `shared-db`, the Claude Code **Workflow tool** (harness globals `agent`/`parallel`/`phase`/`log`/`workflow`, `args.timestamp`), `/loop` (`ScheduleWakeup`), BATS (`tests/local/FA-SF-*.bats` via `./tests/runner.sh local`), `task` (go-task). PostgreSQL schema is app-managed in `website/src/lib/tickets-db.ts` (read-only here; no DDL changes in P2).
+
+**Decisions locked in (from brainstorming, see `docs/superpowers/specs/2026-06-05-sf-dispatcher-design.md`):**
+- Launch model **A** (dispatcher Workflow nests pipeline workflows). `/loop` self-paced trigger.
+- Per-brand slot pools (3/brand) + global concurrency cap (start 3).
+- Watchdog = `updated_at` sweep + per-phase progress touch.
+- Layer-4 canary, directory-level conflict heuristic, semantic dedup, `embedTicket` wiring/backfill → **all P3 / out of scope.**
+- Test seeding via `is_test_data=true` + `SF-TEST-` title prefix + disjoint synthetic file paths; cleanup via existing `tickets.fn_purge_test_data()`.
+
+**Out of scope (P3):** the directory-level conflict heuristic (`conflict-check.sh` stays file-level), Layer-4 canary smoke + auto-rollback, a semantic dedup gate, `embedTicket` wiring into `ticket.sh create` + the embedding backfill (GPU host down; Scout stays fail-soft `[]`), event/webhook triggers, a dedicated dispatcher Deployment, a live dashboard, and any DDL change to `tickets-db.ts`.
+
+---
+
+## File Structure
+
+| File | Responsibility | Tasks |
+|---|---|---|
+| `scripts/ticket.sh` (modify) | new subcommands `get`, `set-touched-files`, `set-pipeline-slot`, `release-slot`, `touch`; `--is-test-data` flag on `create`; `BRAND`→namespace map | T1 |
+| `scripts/factory/lib.sh` (**new**) | shared `factory_resolve` / `factory_pgpod` / `factory_psql` for the primitives | T2 |
+| `tests/lib/factory-test-fixtures.sh` (**new**) | `seed_test_feature` / `purge_factory_test_data` for FA-SF seed tests (refuses prod) | T2 |
+| `scripts/factory/slots.sh` (**new**) | per-brand slot accounting: `next` / `count` / `claim` (atomic) / `release` | T3 |
+| `scripts/factory/queue.sh` (**new**) | raw `backlog` feature list per brand (priority→FIFO), JSON | T4 |
+| `scripts/factory/schedule.sh` (**new**) | conflict-gate + slot-claim up to per-brand pool & global cap → launch plan | T5 |
+| `scripts/factory/watchdog.sh` (**new**) | escalate `in_progress` features stale > 30 min (triage + release slot + comment) | T6 |
+| `scripts/factory/metrics.sh` (**new**) | summarize `v_factory_metrics` → comment on the Vorhaben ticket | T7 |
+| `scripts/factory/pipeline.js` (modify) | per-phase `ticket.sh touch` progress write (watchdog liveness) | T8 |
+| `scripts/factory/dispatcher.js` (**new**) | Model-A Workflow: PREP → LAUNCH (nest pipelines) → METRICS | T9 |
+| `Taskfile.factory.yml` (modify) | `factory:dispatch` doc target | T10 |
+| `tests/local/FA-SF-21..27,30-*.bats` (**new**) | per-component BATS (offline + live-seed) | T1–T9 |
+| `scripts/build-test-inventory.sh` → `website/src/data/test-inventory.json` | regenerated inventory (CI diff-gated) | T10 |
+| `scripts/factory/README.md`, `docs/superpowers/references/factory-usage.md` (modify) | Phase-2 status flip | T10 |
+
+**Dependency order:** T0 (spike, execution-time) → T1 → T2 → {T3, T4} → T5 (needs T3+T4) → T6 → T7 → T8 → T9 (needs T3–T7) → T10. Commit after every green step group with `[T000413]`.
+
+---
+
+## Conventions for every task
+
+- **Worktree:** all work happens in the current feature worktree (`/tmp/wt-sf-dispatcher`, branch `feature/sf-dispatcher`). Never use `.claude/worktrees/`.
+- **Run one BATS test:** `./tests/runner.sh local FA-SF-NN` (the runner finds `.bats` by ID; live tests need a reachable cluster).
+- **Offline lint a Workflow script:** `node --check scripts/factory/<name>.js`.
+- **Test cluster context:** seed/live BATS default to a **dev** context, never prod `fleet`. Set `FACTORY_CTX`/`FACTORY_NS` (e.g. `FACTORY_CTX=k3d-korczewski-dev FACTORY_NS=workspace-korczewski-dev`) — the fixtures **refuse** to seed into `fleet` unless `FACTORY_ALLOW_PROD_SEED=1`.
+- **Read-only DB discipline:** never `SELECT *`/`content` on `tickets.ticket_plans`. Primitives select metadata columns only.
+
+---
+
+### Task 0: De-risk spike — confirm the Workflow execution + nesting model (execution-time, no commit)
+
+**Why:** P1's `pipeline.js` was only ever `node --check`+grep-tested (FA-SF-20); **it has never actually run**. The dispatcher is the first thing that will execute a pipeline, and Model A depends on three unverified harness facts: (a) the harness calls `export async function run(args, harness)` and injects `{agent, parallel, phase, log, workflow}` (does it inject `workflow`?); (b) `workflow({scriptPath: '…/pipeline.js'}, childArgs)` runs the child as a one-level nested workflow; (c) nested children share the parent's concurrency cap/budget (documented, but confirm no hard error). Resolve this **before** building everything on it.
+
+- [ ] **Step 1: Write a throwaway spike workflow (do NOT add to the repo)**
+
+In the Claude Code session, invoke the **Workflow tool** with this inline script (it does not touch the DB):
+```js
+export const meta = { name: 'sf-spike-nesting', description: 'confirm workflow() nesting + child execution', phases: [{ title: 'Spike' }] }
+export async function run(args, harness) {
+  const { workflow, log } = harness
+  if (typeof workflow !== 'function') return { ok: false, reason: 'workflow global not injected into harness param' }
+  // A trivial inline child via scriptPath is not possible (needs a file); instead nest a named-by-scriptPath child
+  // pointing at a tiny no-op script written to /tmp first by an agent. Simpler: confirm the API shape only.
+  log('workflow() is a function on the harness param')
+  return { ok: true, hasWorkflow: true, timestamp: args?.timestamp ?? null }
+}
+export default run
+```
+Pass `args: { timestamp: "<the current ISO timestamp>" }`.
+
+- [ ] **Step 2: Confirm the execution contract**
+
+Observe the spike result. Expected: `{ ok: true, hasWorkflow: true }`. This confirms (a) the `run(args, harness)` contract and that `workflow` is injected. **If `workflow` is NOT on the harness param**, check whether it is a top-level global instead — and adjust `dispatcher.js` in Task 9 accordingly (top-level globals vs harness-param destructure), and likewise re-confirm `pipeline.js`'s contract. Record the finding in a comment on T000413:
+```bash
+bash scripts/ticket.sh get --id T000413 >/dev/null  # sanity: ticket.sh reachable (after T1)
+```
+
+- [ ] **Step 3: Confirm scriptPath nesting with a no-op child (after T9 skeleton exists, revisit if needed)**
+
+Defer the full `workflow({scriptPath})` nesting check to Task 9 Step 6 (it needs `dispatcher.js`). No commit for Task 0 — it is a recorded verification only.
+
+---
+
+### Task 1: Extend `ticket.sh` (get / set-touched-files / set-pipeline-slot / release-slot / touch / --is-test-data / BRAND map)
+
+**Why:** The dispatcher and fixtures need to read a ticket, write `touched_files` (**fixes a latent P1 bug**: `pipeline.js:113` already calls `set-touched-files`, which does not exist), set/clear `pipeline_slot`, bump `updated_at` for liveness (`add-comment` does **not** touch `tickets`), and create purge-able test tickets. `ticket.sh` is also not brand-aware today (defaults `TICKET_NS=workspace` = prod mentolder).
+
+**Files:**
+- Modify: `scripts/ticket.sh` (header comment, `BRAND` map after L16, `cmd_create` flag + INSERT, five new `cmd_*`, dispatch `case`, usage line)
+- Test: `tests/local/FA-SF-21-ticket-cli.bats` (**new**, offline arg-validation)
+
+- [ ] **Step 1: Write the failing offline test**
+
+Create `tests/local/FA-SF-21-ticket-cli.bats`:
+```bash
+#!/usr/bin/env bats
+# FA-SF-21: offline arg-validation contract for the new ticket.sh subcommands.
+setup() { load 'test_helper.bash'; }
+
+@test "FA-SF-21: get requires --id" {
+  run bash scripts/ticket.sh get
+  [ "$status" -eq 2 ]
+  [[ "$output" =~ "--id" ]]
+}
+
+@test "FA-SF-21: set-touched-files requires --id and --files" {
+  run bash scripts/ticket.sh set-touched-files --id T000001
+  [ "$status" -eq 2 ]
+  [[ "$output" =~ "--files" ]]
+}
+
+@test "FA-SF-21: set-pipeline-slot requires --id and --slot" {
+  run bash scripts/ticket.sh set-pipeline-slot --id T000001
+  [ "$status" -eq 2 ]
+}
+
+@test "FA-SF-21: unknown BRAND is rejected with exit 2" {
+  run env BRAND=bogus bash scripts/ticket.sh get --id T000001
+  [ "$status" -eq 2 ]
+  [[ "$output" =~ "unknown BRAND" ]]
+}
+
+@test "FA-SF-21: dispatch lists the new commands in usage" {
+  run bash scripts/ticket.sh
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "set-touched-files" ]]
+}
+```
+
+- [ ] **Step 2: Run it — verify it fails**
+
+Run: `./tests/runner.sh local FA-SF-21`
+Expected: FAIL — `get`/`set-touched-files`/etc. are unknown commands; the BRAND map and usage text are absent.
+
+- [ ] **Step 3: Add the BRAND→namespace map + fix the dev-pod label selector**
+
+In `scripts/ticket.sh`, immediately after the `USER="website"` line (L16), insert:
+```bash
+
+# Brand → namespace map (mirrors conflict-check.sh). BRAND wins over TICKET_NS so
+# a caller cannot silently hit the wrong brand's prod DB.
+case "${BRAND:-}" in
+  mentolder)   NS="workspace" ;;
+  korczewski)  NS="workspace-korczewski" ;;
+  "")          : ;;  # no BRAND given — keep TICKET_NS default
+  *)           echo "ERROR: unknown BRAND (use mentolder|korczewski)" >&2; exit 2 ;;
+esac
+```
+
+**Also fix `_pgpod` (L20) to find the dev DB pod.** Today it uses `-l app=shared-db`, but the dev shared-db is labeled `app: shared-db-dev` (`k3d/dev-stack/shared-db-dev.yaml`), so every `TICKET_CTX=k3d-*-dev` write (watchdog escalation, the live seed tests) would fail with "no shared-db pod found". Change the selector to match `conflict-check.sh:47` / `lib.sh`:
+```bash
+  pod=$(kubectl get pod -n "$NS" --context "$CTX" -l 'app in (shared-db, shared-db-dev)' -o name 2>/dev/null | head -1)
+```
+
+- [ ] **Step 4: Add the `--is-test-data` flag to `cmd_create`**
+
+In `cmd_create`, add to the local declaration (L36) `is_test="false"`, add a case arm in the arg loop:
+```bash
+      --is-test-data) is_test="true"; shift ;;
+```
+and change the INSERT (L70-72) to:
+```bash
+INSERT INTO tickets.tickets (type, brand, title, description, status, severity, priority, is_test_data)
+VALUES (:'type', :'brand', :'title', :'desc', :'status', NULLIF(:'sev', ''), :'prio', :'is_test'::boolean)
+RETURNING external_id || '|' || id;
+```
+and add `-v is_test="$is_test"` to the `_exec_sql` call (alongside the existing `-v` flags, before the heredoc).
+
+- [ ] **Step 5: Add the five new command functions**
+
+Insert before the final `if [[ $# -lt 1 ]]` block (after `cmd_get_attachments`):
+```bash
+cmd_get() {
+  local id=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --id) id="$2"; shift 2 ;;
+      *)    echo "Unknown get option: $1" >&2; exit 2 ;;
+    esac
+  done
+  if [[ -z "$id" ]]; then echo "ERROR: --id is required." >&2; exit 2; fi
+  local pod; pod=$(_pgpod)
+  # Metadata only — NEVER select ticket_plans.content.
+  _exec_sql "$pod" -v ext_id="$id" <<'EOF'
+SELECT json_build_object(
+  'external_id', external_id, 'id', id, 'type', type, 'brand', brand,
+  'title', title, 'status', status, 'priority', priority,
+  'touched_files', touched_files, 'pipeline_slot', pipeline_slot,
+  'created_at', created_at, 'updated_at', updated_at
+) FROM tickets.tickets WHERE external_id = :'ext_id';
+EOF
+}
+
+cmd_set_touched_files() {
+  local id="" files=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --id)    id="$2"; shift 2 ;;
+      --files) files="$2"; shift 2 ;;
+      *)       echo "Unknown set-touched-files option: $1" >&2; exit 2 ;;
+    esac
+  done
+  if [[ -z "$id" || -z "$files" ]]; then echo "ERROR: --id and --files are required." >&2; exit 2; fi
+  local pod; pod=$(_pgpod)
+  _exec_sql "$pod" -v ext_id="$id" -v files="$files" <<'EOF' >/dev/null
+UPDATE tickets.tickets SET touched_files = string_to_array(:'files', ',') WHERE external_id = :'ext_id';
+EOF
+  echo "touched_files set for ticket $id"
+}
+
+cmd_set_pipeline_slot() {
+  local id="" slot=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --id)   id="$2"; shift 2 ;;
+      --slot) slot="$2"; shift 2 ;;
+      *)      echo "Unknown set-pipeline-slot option: $1" >&2; exit 2 ;;
+    esac
+  done
+  if [[ -z "$id" || -z "$slot" ]]; then echo "ERROR: --id and --slot are required (use --slot null to clear)." >&2; exit 2; fi
+  local pod; pod=$(_pgpod)
+  _exec_sql "$pod" -v ext_id="$id" -v slot="$slot" <<'EOF' >/dev/null
+UPDATE tickets.tickets SET pipeline_slot = NULLIF(:'slot','null')::integer WHERE external_id = :'ext_id';
+EOF
+  echo "pipeline_slot set to $slot for ticket $id"
+}
+
+cmd_release_slot() {
+  local id=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --id) id="$2"; shift 2 ;;
+      *)    echo "Unknown release-slot option: $1" >&2; exit 2 ;;
+    esac
+  done
+  if [[ -z "$id" ]]; then echo "ERROR: --id is required." >&2; exit 2; fi
+  local pod; pod=$(_pgpod)
+  _exec_sql "$pod" -v ext_id="$id" <<'EOF' >/dev/null
+UPDATE tickets.tickets SET pipeline_slot = NULL WHERE external_id = :'ext_id';
+EOF
+  echo "pipeline_slot released for ticket $id"
+}
+
+cmd_touch() {
+  local id=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --id) id="$2"; shift 2 ;;
+      *)    echo "Unknown touch option: $1" >&2; exit 2 ;;
+    esac
+  done
+  if [[ -z "$id" ]]; then echo "ERROR: --id is required." >&2; exit 2; fi
+  local pod; pod=$(_pgpod)
+  # Bump updated_at (the fn_lifecycle_ts BEFORE-UPDATE trigger sets it on any UPDATE).
+  _exec_sql "$pod" -v ext_id="$id" <<'EOF' >/dev/null
+UPDATE tickets.tickets SET updated_at = now() WHERE external_id = :'ext_id';
+EOF
+  echo "touched ticket $id"
+}
+```
+
+- [ ] **Step 6: Wire the dispatch `case` + usage**
+
+Update the usage block (L290-292) `Commands:` line to include the new commands, and add to the `case "$cmd"` block (after `get-attachments)`):
+```bash
+  get)               cmd_get "$@" ;;
+  set-touched-files) cmd_set_touched_files "$@" ;;
+  set-pipeline-slot) cmd_set_pipeline_slot "$@" ;;
+  release-slot)      cmd_release_slot "$@" ;;
+  touch)             cmd_touch "$@" ;;
+```
+Also extend the file header comment block (L4-9) with one usage line per new command.
+
+- [ ] **Step 7: Run the test — verify it passes**
+
+Run: `./tests/runner.sh local FA-SF-21`
+Expected: PASS (all 5 assertions). These are offline (no cluster needed — arg-validation exits before `_pgpod`).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add scripts/ticket.sh tests/local/FA-SF-21-ticket-cli.bats
+git commit -m "feat(factory): extend ticket.sh with get/set-touched-files/set-pipeline-slot/release-slot/touch + brand map [T000413]"
+```
+
+---
+
+### Task 2: `scripts/factory/lib.sh` + `tests/lib/factory-test-fixtures.sh`
+
+**Why:** The five primitives share brand-resolution + a psql helper (DRY). The seed-layer FA-SF tests need a fixture that creates purge-able test features with disjoint synthetic paths and **refuses to seed into prod**.
+
+**Files:**
+- Create: `scripts/factory/lib.sh`
+- Create: `tests/lib/factory-test-fixtures.sh`
+- Test: `tests/local/FA-SF-22-fixtures.bats` (**new**, offline guard + dry-resolve)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/local/FA-SF-22-fixtures.bats`:
+```bash
+#!/usr/bin/env bats
+# FA-SF-22: factory shared lib + test fixtures contract (offline assertions only).
+setup() { load 'test_helper.bash'; }
+
+@test "FA-SF-22: lib.sh dry-resolve maps korczewski to workspace-korczewski" {
+  run env BRAND=korczewski FACTORY_DRY_RESOLVE=1 bash -c 'source scripts/factory/lib.sh; factory_resolve; echo "ns=$FACTORY_NS ctx=$FACTORY_CTX"'
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"ns=workspace-korczewski"* ]]
+}
+
+@test "FA-SF-22: lib.sh rejects unknown BRAND" {
+  run env BRAND=bogus bash -c 'source scripts/factory/lib.sh; factory_resolve'
+  [ "$status" -eq 2 ]
+}
+
+@test "FA-SF-22: fixtures refuse to seed into prod fleet without override" {
+  run env FACTORY_CTX=fleet bash -c 'source tests/lib/factory-test-fixtures.sh; seed_test_feature mentolder "tests/fixtures/x.txt"'
+  [ "$status" -ne 0 ]
+  [[ "$output" =~ "refusing" ]]
+}
+```
+
+- [ ] **Step 2: Run it — verify it fails**
+
+Run: `./tests/runner.sh local FA-SF-22`
+Expected: FAIL — `scripts/factory/lib.sh` and `tests/lib/factory-test-fixtures.sh` do not exist.
+
+- [ ] **Step 3: Create `scripts/factory/lib.sh`**
+
+```bash
+#!/usr/bin/env bash
+# scripts/factory/lib.sh — shared helpers for the Software Factory Dispatcher
+# primitives (slots/queue/schedule/watchdog/metrics). SOURCE, do not execute.
+#
+#   BRAND               mentolder|korczewski → resolves FACTORY_NS
+#   FACTORY_NS          explicit namespace (used when BRAND unset; default workspace)
+#   FACTORY_CTX         kubectl context (default: fleet)
+#   FACTORY_DRY_RESOLVE if set, callers print resolved ctx+ns and exit 0
+
+factory_resolve() {
+  case "${BRAND:-}" in
+    mentolder)   FACTORY_NS="workspace" ;;
+    korczewski)  FACTORY_NS="workspace-korczewski" ;;
+    "")          : ;;
+    *)           echo '{"error":"unknown BRAND (use mentolder|korczewski)"}' >&2; exit 2 ;;
+  esac
+  FACTORY_NS="${FACTORY_NS:-workspace}"
+  FACTORY_CTX="${FACTORY_CTX:-fleet}"
+}
+
+factory_pgpod() {
+  local pod
+  pod=$(kubectl get pod -n "$FACTORY_NS" --context "$FACTORY_CTX" -l 'app in (shared-db, shared-db-dev)' -o name 2>/dev/null | head -1)
+  if [[ -z "$pod" ]]; then echo '{"error":"no shared-db pod found"}' >&2; exit 2; fi
+  echo "$pod"
+}
+
+# factory_psql — reads SQL from stdin, returns tab-less single-column rows.
+# Forwards any extra args to psql (e.g. -v ext_id=… for bound params), mirroring
+# ticket.sh's _exec_sql:32 so callers can avoid interpolating into SQL.
+factory_psql() {
+  local pod; pod=$(factory_pgpod)
+  kubectl exec -i "$pod" -n "$FACTORY_NS" --context "$FACTORY_CTX" -c postgres -- \
+    psql -U website -d website -qtA -v ON_ERROR_STOP=1 "$@"
+}
+```
+
+- [ ] **Step 4: Create `tests/lib/factory-test-fixtures.sh`**
+
+```bash
+#!/usr/bin/env bash
+# tests/lib/factory-test-fixtures.sh — seed + reap throwaway feature tickets for
+# Software Factory FA-SF BATS tests. SOURCE, do not execute.
+#
+#   source tests/lib/factory-test-fixtures.sh
+#   ext_id=$(seed_test_feature korczewski "tests/fixtures/sf-test-foo-a.txt")
+#   ... assertions ...
+#   purge_factory_test_data korczewski   # in teardown()
+#
+# Every seeded ticket carries is_test_data=true and a unique 'SF-TEST-' title and
+# is reaped by tickets.fn_purge_test_data(). Pass DISJOINT touched_file paths per
+# test so the conflict gate does not legitimately fire between fixtures. Do NOT
+# run concurrently with the Playwright e2e suite (shared global purge).
+
+# Resolve the repo root from this file's location so the fixture works
+# regardless of the BATS working directory.
+_FIXTURE_REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+# seed_test_feature <brand> [touched_file ...] → echoes the new external_id
+seed_test_feature() {
+  local brand="$1"; shift
+  local ctx="${FACTORY_CTX:-fleet}"
+  if [[ "$ctx" == "fleet" && -z "${FACTORY_ALLOW_PROD_SEED:-}" ]]; then
+    echo "refusing to seed test data into prod context 'fleet' (set FACTORY_ALLOW_PROD_SEED=1 to override)" >&2
+    return 3
+  fi
+  local files; files="$(IFS=,; echo "$*")"
+  local title="SF-TEST-${brand}-${BATS_TEST_NAME:-manual}-$$-${RANDOM}"
+  local result ext_id
+  result=$(BRAND="$brand" TICKET_CTX="$ctx" bash "$_FIXTURE_REPO_ROOT/scripts/ticket.sh" create \
+    --type feature --brand "$brand" --title "$title" \
+    --description "factory fixture" --priority mittel --status backlog --is-test-data)
+  ext_id="${result%%|*}"
+  if [[ -n "$files" ]]; then
+    BRAND="$brand" TICKET_CTX="$ctx" bash "$_FIXTURE_REPO_ROOT/scripts/ticket.sh" set-touched-files --id "$ext_id" --files "$files" >/dev/null
+  fi
+  echo "$ext_id"
+}
+
+# purge_factory_test_data <brand> — reap all is_test_data=true rows on that brand
+purge_factory_test_data() {
+  local brand="$1"
+  local ctx="${FACTORY_CTX:-fleet}" ns
+  case "$brand" in
+    mentolder)  ns="workspace" ;;
+    korczewski) ns="workspace-korczewski" ;;
+    *) echo "purge_factory_test_data: unknown brand $brand" >&2; return 2 ;;
+  esac
+  local pod
+  pod=$(kubectl get pod -n "$ns" --context "$ctx" -l 'app in (shared-db, shared-db-dev)' -o name 2>/dev/null | head -1)
+  [[ -z "$pod" ]] && { echo "no shared-db pod in $ns" >&2; return 1; }
+  kubectl exec -i "$pod" -n "$ns" --context "$ctx" -c postgres -- \
+    psql -U website -d website -qtAc "SELECT tickets.fn_purge_test_data();" >/dev/null
+}
+```
+
+- [ ] **Step 5: Run the test — verify it passes**
+
+Run: `./tests/runner.sh local FA-SF-22`
+Expected: PASS (all 3 offline assertions — they never reach a live cluster).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/factory/lib.sh tests/lib/factory-test-fixtures.sh tests/local/FA-SF-22-fixtures.bats
+git commit -m "feat(factory): add factory lib.sh + seed/purge test fixtures (prod-seed guard) [T000413]"
+```
+
+---
+
+### Task 3: `scripts/factory/slots.sh` — per-brand slot accounting
+
+**Why:** The scheduler needs an atomic, race-free way to claim/free the 3 per-brand slots (`pipeline_slot` column) and find the next free slot number.
+
+**Files:**
+- Create: `scripts/factory/slots.sh`
+- Test: `tests/local/FA-SF-23-slots.bats` (**new**: offline dry-resolve + live seed claim/release)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/local/FA-SF-23-slots.bats`:
+```bash
+#!/usr/bin/env bats
+# FA-SF-23: slots.sh contract. Offline assertions always run; live claim/release
+# runs only when a dev cluster is reachable (FACTORY_CTX/FACTORY_NS set to dev).
+setup() { load 'test_helper.bash'; source 'tests/lib/factory-test-fixtures.sh'; }
+
+@test "FA-SF-23: dry-resolve prints brand namespace" {
+  run env BRAND=mentolder FACTORY_DRY_RESOLVE=1 bash scripts/factory/slots.sh count
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"ns=workspace"* ]]
+}
+
+@test "FA-SF-23: unknown subcommand exits 2" {
+  run env BRAND=mentolder FACTORY_DRY_RESOLVE= bash scripts/factory/slots.sh bogus
+  [ "$status" -eq 2 ]
+}
+
+@test "FA-SF-23: claim is atomic — second claim on the same ticket fails" {
+  [ -n "${FACTORY_CTX:-}" ] || skip "no dev cluster context set"
+  local brand="${TEST_BRAND:-korczewski}"
+  ext=$(seed_test_feature "$brand" "tests/fixtures/sf-test-slots-$$-a.txt")
+  run env BRAND="$brand" bash scripts/factory/slots.sh claim "$ext" 1
+  [ "$status" -eq 0 ]
+  [ "$output" = "1" ]
+  run env BRAND="$brand" bash scripts/factory/slots.sh claim "$ext" 2
+  [ "$status" -eq 1 ]                       # already slotted → claim fails
+  run env BRAND="$brand" bash scripts/factory/slots.sh release "$ext"
+  [ "$status" -eq 0 ]
+}
+
+teardown() { [ -n "${FACTORY_CTX:-}" ] && purge_factory_test_data "${TEST_BRAND:-korczewski}" || true; }
+```
+
+- [ ] **Step 2: Run it — verify it fails**
+
+Run: `./tests/runner.sh local FA-SF-23`
+Expected: FAIL — `scripts/factory/slots.sh` does not exist.
+
+- [ ] **Step 3: Implement `scripts/factory/slots.sh`**
+
+```bash
+#!/usr/bin/env bash
+# scripts/factory/slots.sh — per-brand slot accounting for the Dispatcher.
+#   BRAND=<brand> bash scripts/factory/slots.sh count                # occupied slots (this brand)
+#   BRAND=<brand> bash scripts/factory/slots.sh next                 # lowest free slot 1..N, or empty if full
+#   BRAND=<brand> bash scripts/factory/slots.sh claim <ext_id> <n>   # atomic; echoes n on success
+#   BRAND=<brand> bash scripts/factory/slots.sh release <ext_id>
+# Slots are 1..FACTORY_SLOTS_PER_BRAND (default 3). claim only succeeds if the
+# feature has no slot yet (UPDATE ... WHERE pipeline_slot IS NULL) — race-free.
+# Exit 0 ok, 1 claim-failed, 2 error.
+set -euo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+factory_resolve
+[[ -n "${FACTORY_DRY_RESOLVE:-}" ]] && { echo "resolved: ctx=${FACTORY_CTX} ns=${FACTORY_NS}"; exit 0; }
+
+SLOTS_PER_BRAND="${FACTORY_SLOTS_PER_BRAND:-3}"
+cmd="${1:-}"; shift || true
+
+case "$cmd" in
+  count)
+    printf "SELECT count(*) FROM tickets.tickets WHERE pipeline_slot IS NOT NULL AND status='in_progress';" | factory_psql
+    ;;
+  next)
+    printf "WITH used AS (SELECT pipeline_slot FROM tickets.tickets WHERE pipeline_slot IS NOT NULL AND status='in_progress'), s AS (SELECT generate_series(1,%s) AS n) SELECT min(n) FROM s WHERE n NOT IN (SELECT pipeline_slot FROM used);" "$SLOTS_PER_BRAND" | factory_psql
+    ;;
+  claim)
+    ext_id="${1:?usage: claim <ext_id> <slot>}"; slot="${2:?usage: claim <ext_id> <slot>}"
+    out=$(printf '%s' "UPDATE tickets.tickets SET pipeline_slot = :'slot'::integer, status='in_progress' WHERE external_id = :'ext_id' AND pipeline_slot IS NULL AND status IN ('backlog','triage') RETURNING pipeline_slot;" | factory_psql -v ext_id="$ext_id" -v slot="$slot")
+    if [[ -z "$out" ]]; then echo "claim failed (already slotted or wrong status): $ext_id" >&2; exit 1; fi
+    echo "$out"
+    ;;
+  release)
+    ext_id="${1:?usage: release <ext_id>}"
+    printf '%s' "UPDATE tickets.tickets SET pipeline_slot=NULL WHERE external_id = :'ext_id';" | factory_psql -v ext_id="$ext_id" >/dev/null
+    echo "released $ext_id"
+    ;;
+  *) echo '{"error":"usage: slots.sh count|next|claim|release [...]"}' >&2; exit 2 ;;
+esac
+```
+
+- [ ] **Step 4: Run the test — verify it passes**
+
+Run: `./tests/runner.sh local FA-SF-23`
+Expected: PASS — offline assertions pass; the live claim/release passes if a dev cluster context is set (otherwise that test is `skip`ped).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/factory/slots.sh tests/local/FA-SF-23-slots.bats
+git commit -m "feat(factory): add slots.sh atomic per-brand slot accounting [T000413]"
+```
+
+---
+
+### Task 4: `scripts/factory/queue.sh` — backlog feature queue
+
+**Why:** First consumer of the queue. Must read **raw** `backlog` features (NOT `v_active_features`, which filters `touched_files IS NOT NULL` and would hide fresh features whose touched_files are only set later inside the pipeline's Scout phase).
+
+**Files:**
+- Create: `scripts/factory/queue.sh`
+- Test: `tests/local/FA-SF-24-queue.bats` (**new**)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/local/FA-SF-24-queue.bats`:
+```bash
+#!/usr/bin/env bats
+# FA-SF-24: queue.sh lists backlog features as ordered JSON.
+setup() { load 'test_helper.bash'; source 'tests/lib/factory-test-fixtures.sh'; }
+
+@test "FA-SF-24: dry-resolve works" {
+  run env BRAND=mentolder FACTORY_DRY_RESOLVE=1 bash scripts/factory/queue.sh
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"ns=workspace"* ]]
+}
+
+@test "FA-SF-24: a seeded backlog feature appears in the queue JSON" {
+  [ -n "${FACTORY_CTX:-}" ] || skip "no dev cluster context set"
+  local brand="${TEST_BRAND:-korczewski}"
+  ext=$(seed_test_feature "$brand" "tests/fixtures/sf-test-queue-$$-a.txt")
+  run env BRAND="$brand" bash scripts/factory/queue.sh
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e --arg e "$ext" 'any(.[]; .external_id == $e)'
+}
+
+teardown() { [ -n "${FACTORY_CTX:-}" ] && purge_factory_test_data "${TEST_BRAND:-korczewski}" || true; }
+```
+
+- [ ] **Step 2: Run it — verify it fails**
+
+Run: `./tests/runner.sh local FA-SF-24`
+Expected: FAIL — `scripts/factory/queue.sh` does not exist.
+
+- [ ] **Step 3: Implement `scripts/factory/queue.sh`**
+
+```bash
+#!/usr/bin/env bash
+# scripts/factory/queue.sh — schedulable backlog feature tickets for a brand.
+#   BRAND=<brand> bash scripts/factory/queue.sh
+# Reads RAW backlog features (touched_files may be NULL — a fresh feature gets
+# its touched_files inside the pipeline's Scout phase, so v_active_features
+# (which filters NULL touched_files) is NOT used here). JSON array, ordered
+# priority (hoch→mittel→niedrig) then created_at. Read-only metadata only.
+set -euo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+factory_resolve
+[[ -n "${FACTORY_DRY_RESOLVE:-}" ]] && { echo "resolved: ctx=${FACTORY_CTX} ns=${FACTORY_NS}"; exit 0; }
+cat <<'SQL' | factory_psql
+SELECT COALESCE(json_agg(row_to_json(q)), '[]')
+FROM (
+  SELECT external_id, title, priority, touched_files, created_at
+  FROM tickets.tickets
+  WHERE type='feature' AND status='backlog'
+  ORDER BY CASE priority WHEN 'hoch' THEN 1 WHEN 'mittel' THEN 2 WHEN 'niedrig' THEN 3 END, created_at
+) q;
+SQL
+```
+
+- [ ] **Step 4: Run the test — verify it passes**
+
+Run: `./tests/runner.sh local FA-SF-24`
+Expected: PASS (offline dry-resolve always; live ordering when a dev cluster is set).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/factory/queue.sh tests/local/FA-SF-24-queue.bats
+git commit -m "feat(factory): add queue.sh backlog feature poller [T000413]"
+```
+
+---
+
+### Task 5: `scripts/factory/schedule.sh` — conflict-gate + slot-claim → launch plan
+
+**Why:** Combines `queue.sh` + `conflict-check.sh` (file-level, best-effort on known `touched_files`) + `slots.sh` into the per-brand launch plan, enforcing the per-brand pool AND a global concurrency cap across both brands.
+
+**Files:**
+- Create: `scripts/factory/schedule.sh`
+- Test: `tests/local/FA-SF-25-schedule.bats` (**new**)
+- Reuse: `scripts/factory/conflict-check.sh` (unchanged), `queue.sh`, `slots.sh`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/local/FA-SF-25-schedule.bats`:
+```bash
+#!/usr/bin/env bats
+# FA-SF-25: schedule.sh emits a launch plan and claims slots.
+setup() { load 'test_helper.bash'; source 'tests/lib/factory-test-fixtures.sh'; }
+
+@test "FA-SF-25: dry-resolve works" {
+  run env BRAND=mentolder FACTORY_DRY_RESOLVE=1 bash scripts/factory/schedule.sh
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-25: two disjoint backlog features both get scheduled with slots" {
+  [ -n "${FACTORY_CTX:-}" ] || skip "no dev cluster context set"
+  local brand="${TEST_BRAND:-korczewski}"
+  e1=$(seed_test_feature "$brand" "tests/fixtures/sf-test-sched-$$-a.txt")
+  e2=$(seed_test_feature "$brand" "tests/fixtures/sf-test-sched-$$-b.txt")
+  run env BRAND="$brand" FACTORY_GLOBAL_CAP=3 bash scripts/factory/schedule.sh
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e --arg e "$e1" 'any(.[]; .external_id == $e and (.slot|type=="number"))'
+  echo "$output" | jq -e --arg e "$e2" 'any(.[]; .external_id == $e)'
+}
+
+@test "FA-SF-25: global cap of 1 schedules at most one feature" {
+  [ -n "${FACTORY_CTX:-}" ] || skip "no dev cluster context set"
+  local brand="${TEST_BRAND:-korczewski}"
+  seed_test_feature "$brand" "tests/fixtures/sf-test-cap-$$-a.txt" >/dev/null
+  seed_test_feature "$brand" "tests/fixtures/sf-test-cap-$$-b.txt" >/dev/null
+  run env BRAND="$brand" FACTORY_GLOBAL_CAP=1 bash scripts/factory/schedule.sh
+  [ "$status" -eq 0 ]
+  count=$(echo "$output" | jq 'length')
+  [ "$count" -le 1 ]
+}
+
+teardown() { [ -n "${FACTORY_CTX:-}" ] && purge_factory_test_data "${TEST_BRAND:-korczewski}" || true; }
+```
+
+- [ ] **Step 2: Run it — verify it fails**
+
+Run: `./tests/runner.sh local FA-SF-25`
+Expected: FAIL — `scripts/factory/schedule.sh` does not exist.
+
+- [ ] **Step 3: Implement `scripts/factory/schedule.sh`**
+
+```bash
+#!/usr/bin/env bash
+# scripts/factory/schedule.sh — poll the queue for a brand, run the best-effort
+# brand-aware conflict gate on KNOWN touched_files, claim a slot per
+# non-conflicting feature up to the per-brand pool AND a global concurrency cap
+# (summed across both brands), and emit the launch plan as JSON:
+#   [{ "brand": "...", "external_id": "...", "slot": N }]
+#
+#   BRAND=<brand> FACTORY_GLOBAL_CAP=3 bash scripts/factory/schedule.sh
+#
+# The AUTHORITATIVE conflict gate is pipeline.js' Plan phase (③). This is a
+# pre-filter on already-known touched_files; a fresh feature (NULL touched_files,
+# conflict-check exits 2 = "no known conflict") schedules and self-corrects if
+# the pipeline's own gate later blocks it.
+set -euo pipefail
+HERE="$(dirname "${BASH_SOURCE[0]}")"
+source "$HERE/lib.sh"
+factory_resolve
+[[ -n "${FACTORY_DRY_RESOLVE:-}" ]] && { echo "resolved: ctx=${FACTORY_CTX} ns=${FACTORY_NS}"; exit 0; }
+
+GLOBAL_CAP="${FACTORY_GLOBAL_CAP:-3}"
+
+# Global concurrency = occupied slots across BOTH brands (separate DBs).
+global_used=0
+for b in mentolder korczewski; do
+  n=$(BRAND="$b" FACTORY_CTX="$FACTORY_CTX" bash "$HERE/slots.sh" count 2>/dev/null || echo 0)
+  global_used=$((global_used + ${n:-0}))
+done
+
+plan='[]'
+mapfile -t candidates < <(BRAND="$BRAND" FACTORY_CTX="$FACTORY_CTX" bash "$HERE/queue.sh" | jq -c '.[]')
+for c in "${candidates[@]}"; do
+  [[ -z "$c" ]] && continue
+  [[ "$global_used" -ge "$GLOBAL_CAP" ]] && break
+  ext_id=$(echo "$c" | jq -r '.external_id')
+
+  # Best-effort conflict gate on known touched_files. rc 0 = no conflict,
+  # rc 1 = conflict (skip), rc 2 = error/null touched_files (treat as schedulable).
+  set +e
+  BRAND="$BRAND" FACTORY_CTX="$FACTORY_CTX" bash "$HERE/conflict-check.sh" "$ext_id" >/dev/null 2>&1
+  rc=$?
+  set -e
+  [[ "$rc" -eq 1 ]] && continue
+
+  slot=$(BRAND="$BRAND" FACTORY_CTX="$FACTORY_CTX" bash "$HERE/slots.sh" next)
+  [[ -z "$slot" ]] && continue   # brand pool full
+
+  if BRAND="$BRAND" FACTORY_CTX="$FACTORY_CTX" bash "$HERE/slots.sh" claim "$ext_id" "$slot" >/dev/null 2>&1; then
+    plan=$(echo "$plan" | jq -c --arg b "$BRAND" --arg e "$ext_id" --argjson s "$slot" '. + [{brand:$b, external_id:$e, slot:$s}]')
+    global_used=$((global_used + 1))
+  fi
+done
+echo "$plan"
+```
+
+- [ ] **Step 4: Run the test — verify it passes**
+
+Run: `./tests/runner.sh local FA-SF-25`
+Expected: PASS (dry-resolve always; live scheduling + cap when a dev cluster is set).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/factory/schedule.sh tests/local/FA-SF-25-schedule.bats
+git commit -m "feat(factory): add schedule.sh conflict-gated slot scheduler with global cap [T000413]"
+```
+
+---
+
+### Task 6: `scripts/factory/watchdog.sh` — stale-run escalation
+
+**Why:** A pipeline that hangs (no progress write) must be returned to the queue and its slot freed, so the slot pool does not leak. Liveness = `updated_at` (auto-bumped by `fn_lifecycle_ts`), refreshed at each pipeline phase boundary by `ticket.sh touch` (Task 8).
+
+**Files:**
+- Create: `scripts/factory/watchdog.sh`
+- Test: `tests/local/FA-SF-26-watchdog.bats` (**new**)
+- Reuse: `scripts/ticket.sh` (`update-status`, `release-slot`, `add-comment`)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/local/FA-SF-26-watchdog.bats`:
+```bash
+#!/usr/bin/env bats
+# FA-SF-26: watchdog escalates stale in_progress features.
+setup() { load 'test_helper.bash'; source 'tests/lib/factory-test-fixtures.sh'; }
+
+@test "FA-SF-26: dry-resolve works" {
+  run env BRAND=mentolder FACTORY_DRY_RESOLVE=1 bash scripts/factory/watchdog.sh
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-26: a stale in_progress feature is returned to triage and its slot freed" {
+  [ -n "${FACTORY_CTX:-}" ] || skip "no dev cluster context set"
+  local brand="${TEST_BRAND:-korczewski}"
+  ext=$(seed_test_feature "$brand" "tests/fixtures/sf-test-wd-$$-a.txt")
+  env BRAND="$brand" bash scripts/factory/slots.sh claim "$ext" 1 >/dev/null
+  # Derive the namespace from the brand (do not rely on a FACTORY_NS default).
+  local ns; case "$brand" in mentolder) ns=workspace ;; korczewski) ns=workspace-korczewski ;; esac
+  # Backdate updated_at by 40 minutes to simulate a hung pipeline.
+  pod=$(kubectl get pod -n "$ns" --context "$FACTORY_CTX" -l 'app in (shared-db, shared-db-dev)' -o name | head -1)
+  kubectl exec -i "$pod" -n "$ns" --context "$FACTORY_CTX" -c postgres -- \
+    psql -U website -d website -qtAc "UPDATE tickets.tickets SET updated_at = now() - interval '40 minutes' WHERE external_id='$ext';"
+  run env BRAND="$brand" FACTORY_STALE_MIN=30 bash scripts/factory/watchdog.sh
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e --arg e "$ext" 'any(.[]; . == $e)'
+  # Confirm status=triage and pipeline_slot cleared.
+  st=$(BRAND="$brand" TICKET_CTX="$FACTORY_CTX" bash scripts/ticket.sh get --id "$ext" | jq -r '.status')
+  [ "$st" = "triage" ]
+}
+
+teardown() { [ -n "${FACTORY_CTX:-}" ] && purge_factory_test_data "${TEST_BRAND:-korczewski}" || true; }
+```
+
+- [ ] **Step 2: Run it — verify it fails**
+
+Run: `./tests/runner.sh local FA-SF-26`
+Expected: FAIL — `scripts/factory/watchdog.sh` does not exist.
+
+- [ ] **Step 3: Implement `scripts/factory/watchdog.sh`**
+
+```bash
+#!/usr/bin/env bash
+# scripts/factory/watchdog.sh — escalate stale in-flight features for a brand.
+#   BRAND=<brand> FACTORY_STALE_MIN=30 bash scripts/factory/watchdog.sh
+# A feature in_progress whose updated_at is older than the threshold is treated
+# as a hung/crashed pipeline: status → triage (back to queue), slot released, and
+# a comment recorded. updated_at is auto-bumped by fn_lifecycle_ts on every row
+# write; pipeline.js writes a `ticket.sh touch` at each phase boundary, so a
+# healthy long phase is not mistaken for stale. JSON array of escalated ext_ids.
+set -euo pipefail
+HERE="$(dirname "${BASH_SOURCE[0]}")"
+source "$HERE/lib.sh"
+factory_resolve
+[[ -n "${FACTORY_DRY_RESOLVE:-}" ]] && { echo "resolved: ctx=${FACTORY_CTX} ns=${FACTORY_NS}"; exit 0; }
+STALE_MIN="${FACTORY_STALE_MIN:-30}"
+
+mapfile -t stale < <(printf "SELECT external_id FROM tickets.tickets WHERE type='feature' AND status='in_progress' AND updated_at < now() - make_interval(mins => %s);" "$STALE_MIN" | factory_psql)
+
+escalated='[]'
+for ext_id in "${stale[@]}"; do
+  [[ -z "$ext_id" ]] && continue
+  BRAND="$BRAND" TICKET_CTX="$FACTORY_CTX" bash "$HERE/../ticket.sh" update-status --id "$ext_id" --status triage >/dev/null
+  BRAND="$BRAND" TICKET_CTX="$FACTORY_CTX" bash "$HERE/../ticket.sh" release-slot --id "$ext_id" >/dev/null
+  BRAND="$BRAND" TICKET_CTX="$FACTORY_CTX" bash "$HERE/../ticket.sh" add-comment --id "$ext_id" \
+    --body "Watchdog: pipeline stale > ${STALE_MIN}min (no phase progress write). Returned to queue (triage); slot released." >/dev/null
+  escalated=$(echo "$escalated" | jq -c --arg e "$ext_id" '. + [$e]')
+done
+echo "$escalated"
+```
+
+- [ ] **Step 4: Run the test — verify it passes**
+
+Run: `./tests/runner.sh local FA-SF-26`
+Expected: PASS (dry-resolve always; live escalation when a dev cluster is set).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/factory/watchdog.sh tests/local/FA-SF-26-watchdog.bats
+git commit -m "feat(factory): add watchdog.sh stale-run escalation (triage + slot release) [T000413]"
+```
+
+---
+
+### Task 7: `scripts/factory/metrics.sh` — throughput summary comment
+
+**Why:** First consumer of `v_factory_metrics`. Posts a short markdown summary to the Vorhaben ticket. `add-comment`'s `INSERT…SELECT … WHERE external_id` is a silent no-op if the ticket is absent in a brand's DB (korczewski has its own external_id space) — so it is naturally best-effort per brand.
+
+**Files:**
+- Create: `scripts/factory/metrics.sh`
+- Test: `tests/local/FA-SF-27-metrics.bats` (**new**)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/local/FA-SF-27-metrics.bats`:
+```bash
+#!/usr/bin/env bats
+# FA-SF-27: metrics.sh summarizes v_factory_metrics and posts a comment.
+setup() { load 'test_helper.bash'; source 'tests/lib/factory-test-fixtures.sh'; }
+
+@test "FA-SF-27: dry-resolve works" {
+  run env BRAND=mentolder FACTORY_DRY_RESOLVE=1 bash scripts/factory/metrics.sh
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-27: posts a comment to a seeded metrics ticket" {
+  [ -n "${FACTORY_CTX:-}" ] || skip "no dev cluster context set"
+  local brand="${TEST_BRAND:-korczewski}"
+  # Use a throwaway test ticket as the metrics sink so we don't touch T000413.
+  sink=$(seed_test_feature "$brand" "tests/fixtures/sf-test-metrics-$$-a.txt")
+  run env BRAND="$brand" FACTORY_METRICS_TICKET="$sink" bash scripts/factory/metrics.sh
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "Comment added" ]] || [[ "$output" =~ "Factory metrics" ]]
+}
+
+teardown() { [ -n "${FACTORY_CTX:-}" ] && purge_factory_test_data "${TEST_BRAND:-korczewski}" || true; }
+```
+
+- [ ] **Step 2: Run it — verify it fails**
+
+Run: `./tests/runner.sh local FA-SF-27`
+Expected: FAIL — `scripts/factory/metrics.sh` does not exist.
+
+- [ ] **Step 3: Implement `scripts/factory/metrics.sh`**
+
+```bash
+#!/usr/bin/env bash
+# scripts/factory/metrics.sh — summarize factory throughput for a brand and post
+# it as a comment on the Vorhaben ticket (default T000413).
+#   BRAND=<brand> FACTORY_METRICS_TICKET=T000413 bash scripts/factory/metrics.sh
+# Reads the latest v_factory_metrics row + a live slot/queue snapshot, formats a
+# short markdown summary, and appends it via ticket.sh add-comment (best-effort:
+# a missing ticket in a brand's DB is a silent no-op).
+set -euo pipefail
+HERE="$(dirname "${BASH_SOURCE[0]}")"
+source "$HERE/lib.sh"
+factory_resolve
+[[ -n "${FACTORY_DRY_RESOLVE:-}" ]] && { echo "resolved: ctx=${FACTORY_CTX} ns=${FACTORY_NS}"; exit 0; }
+TICKET="${FACTORY_METRICS_TICKET:-T000413}"
+
+today=$(cat <<'SQL' | factory_psql
+SELECT COALESCE(
+  (SELECT format('shipped=%s avg_cycle_h=%s escalations=%s total_features=%s',
+     features_shipped, COALESCE(avg_cycle_time_h::text,'n/a'), escalations, total_features)
+   FROM tickets.v_factory_metrics ORDER BY day DESC LIMIT 1),
+  'no metrics yet');
+SQL
+)
+active=$(printf "SELECT count(*) FROM tickets.tickets WHERE type='feature' AND status='in_progress';" | factory_psql)
+backlog=$(printf "SELECT count(*) FROM tickets.tickets WHERE type='feature' AND status='backlog';" | factory_psql)
+
+body=$(printf '**Factory metrics — %s**\n- %s\n- active(in_progress)=%s backlog=%s' "$BRAND" "$today" "$active" "$backlog")
+BRAND="$BRAND" TICKET_CTX="$FACTORY_CTX" bash "$HERE/../ticket.sh" add-comment --id "$TICKET" --body "$body"
+echo "$body"
+```
+
+- [ ] **Step 4: Run the test — verify it passes**
+
+Run: `./tests/runner.sh local FA-SF-27`
+Expected: PASS (dry-resolve always; live comment when a dev cluster is set).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/factory/metrics.sh tests/local/FA-SF-27-metrics.bats
+git commit -m "feat(factory): add metrics.sh v_factory_metrics summary comment [T000413]"
+```
+
+---
+
+### Task 8: `pipeline.js` per-phase progress touch (watchdog liveness)
+
+**Why:** The watchdog flags `in_progress` features whose `updated_at` is stale. A healthy pipeline can spend > 30 min in the Implement phase without otherwise writing the ticket row, so it must emit a lightweight `ticket.sh touch` at each phase boundary (which the `fn_lifecycle_ts` trigger turns into an `updated_at` bump).
+
+**Files:**
+- Modify: `scripts/factory/pipeline.js` (add a `TOUCH` instruction, reference it in every phase's lead agent prompt)
+- Test: `tests/local/FA-SF-20-pipeline-contract.bats` (extend — it is the existing P1 contract test)
+
+- [ ] **Step 1: Add the failing contract assertion**
+
+Append to `tests/local/FA-SF-20-pipeline-contract.bats`:
+```bash
+@test "FA-SF-20: pipeline writes a per-phase liveness touch (>=6 references)" {
+  run grep -c "ticket.sh touch" "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$output" -ge 6 ]
+}
+```
+
+- [ ] **Step 2: Run it — verify it fails**
+
+Run: `./tests/runner.sh local FA-SF-20`
+Expected: FAIL — the new assertion finds 0 references to `ticket.sh touch`.
+
+- [ ] **Step 3: Inline a per-phase liveness touch at the start of each phase's lead agent prompt**
+
+Do **not** add a shared variable — to keep each prompt self-contained AND make the literal `ticket.sh touch` appear exactly six times (the contract test counts it), inline the same sentence verbatim at the **start** of the lead `agent(\`...\`)` template in each of the six phases. The sentence to prepend (verbatim, including the backticked command) is:
+```
+Record pipeline liveness first so the dispatcher watchdog does not flag this run as stale: run `bash /home/patrick/Bachelorprojekt/scripts/ticket.sh touch --id ${A.ticket_id}`. Then:
+```
+> Use `${A.ticket_id}` and `${REPO}` interpolation consistent with each existing prompt (the lead prompts already interpolate `${REPO}`; write the command as `bash ${REPO}/scripts/ticket.sh touch --id ${A.ticket_id}`).
+
+Prepend it to the lead agent in each phase:
+- Scout agent (currently starts `` `Scout the feature ...` `` at L94)
+- Design agent (`` `Write a design spec ...` `` at L127)
+- Plan conflict agent (`` `Run the brand-aware conflict gate ...` `` at L149)
+- Implement stage-1 agent (`` `Implement task ${t.id} ...` `` at L207)
+- Verify panel agent (`` `Read the review prompt ...` `` at L233, inside `lenses.map`)
+- Deploy agent (`` `Deploy the feature to both brands. ...` `` at L257)
+
+After this edit, `grep -c "ticket.sh touch" scripts/factory/pipeline.js` returns exactly `6`.
+
+- [ ] **Step 4: Run `node --check` + the contract test — verify they pass**
+
+Run:
+```bash
+node --check scripts/factory/pipeline.js && echo SYNTAX_OK
+./tests/runner.sh local FA-SF-20
+```
+Expected: `SYNTAX_OK` and all FA-SF-20 assertions PASS (including the new `>= 6` touch references).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/factory/pipeline.js tests/local/FA-SF-20-pipeline-contract.bats
+git commit -m "feat(factory): pipeline.js emits per-phase liveness touch for the watchdog [T000413]"
+```
+
+---
+
+### Task 9: `scripts/factory/dispatcher.js` — Model-A Dispatcher Workflow
+
+**Why:** The one missing P2 deliverable — the Tier-1 orchestration spine. PREP runs the deterministic primitives and returns a schema-validated launch plan; LAUNCH nests one `pipeline.js` workflow per scheduled feature; METRICS posts the throughput summary. Mirrors `pipeline.js`'s `run(args, harness)` + `export default run` contract (confirmed in Task 0).
+
+**Files:**
+- Create: `scripts/factory/dispatcher.js`
+- Test: `tests/local/FA-SF-30-dispatcher-contract.bats` (**new**, offline structural contract)
+- Reference (mirror style): `scripts/factory/pipeline.js`
+
+- [ ] **Step 1: Write the failing structural contract test**
+
+Create `tests/local/FA-SF-30-dispatcher-contract.bats`:
+```bash
+#!/usr/bin/env bats
+# FA-SF-30: structural contract for the dispatcher Workflow script (offline).
+SCRIPT="scripts/factory/dispatcher.js"
+setup() { load 'test_helper.bash'; }
+
+@test "FA-SF-30: dispatcher.js exists and is syntactically valid JS" {
+  [ -f "$SCRIPT" ]
+  run node --check "$SCRIPT"
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-30: exports meta with the three expected phases" {
+  run grep -Eq "export const meta" "$SCRIPT"; [ "$status" -eq 0 ]
+  for p in Prep Launch Metrics; do
+    run grep -q "phase('$p')" "$SCRIPT"; [ "$status" -eq 0 ]
+  done
+}
+
+@test "FA-SF-30: wires the primitives (watchdog, schedule, metrics, ticket.sh get)" {
+  for needle in "watchdog.sh" "schedule.sh" "metrics.sh" "ticket.sh get"; do
+    run grep -q "$needle" "$SCRIPT"; [ "$status" -eq 0 ]
+  done
+}
+
+@test "FA-SF-30: launches pipeline.js via workflow scriptPath" {
+  run grep -q "scripts/factory/pipeline.js" "$SCRIPT"; [ "$status" -eq 0 ]
+  run grep -Eq "workflow\(" "$SCRIPT"; [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-30: resume-safe (uses args.timestamp, no Date.now()/Math.random())" {
+  run grep -q "args.timestamp\|A.timestamp" "$SCRIPT"; [ "$status" -eq 0 ]
+  run grep -Eq "Date\.now\(\)|Math\.random\(\)" "$SCRIPT"; [ "$status" -ne 0 ]
+}
+
+@test "FA-SF-30: schedules across BOTH brands" {
+  run grep -q "mentolder" "$SCRIPT"; [ "$status" -eq 0 ]
+  run grep -q "korczewski" "$SCRIPT"; [ "$status" -eq 0 ]
+}
+```
+
+- [ ] **Step 2: Run it — verify it fails**
+
+Run: `./tests/runner.sh local FA-SF-30`
+Expected: FAIL — `scripts/factory/dispatcher.js` does not exist.
+
+- [ ] **Step 3: Implement `scripts/factory/dispatcher.js`**
+
+```js
+/**
+ * scripts/factory/dispatcher.js
+ *
+ * Software Factory Phase-2 Dispatcher (Tier 1) — Claude Code Workflow script.
+ *
+ * Model A: ONE bounded Workflow run per /loop tick that nests pipeline.js runs.
+ * The globals are HARNESS-INJECTED via the `harness` param (mirrors pipeline.js).
+ * Run by the Workflow tool, NOT `node scripts/factory/dispatcher.js`.
+ *
+ * Offline lint:   node --check scripts/factory/dispatcher.js
+ * Contract tests: ./tests/runner.sh local FA-SF-30
+ *
+ * Trigger: /loop self-paced (ScheduleWakeup) — the next wake is scheduled only
+ * after this run ends, giving natural single-flight. Over-scheduling is
+ * additionally bounded by schedule.sh's global cap + the atomic slot-claim
+ * (a pg advisory lock would NOT survive separate kubectl-exec psql sessions).
+ *
+ * Usage (Workflow tool): args = { timestamp }  // ISO8601 from the harness
+ */
+
+export const meta = {
+  name: 'software-factory-dispatcher',
+  description: 'Phase-2 dispatcher: watchdog sweep → poll → conflict-gate + slot-claim → launch pipelines → metrics',
+  phases: [{ title: 'Prep' }, { title: 'Launch' }, { title: 'Metrics' }],
+}
+
+export async function run(args, harness) {
+  const { agent, parallel, phase, log, workflow } = harness
+  const A = args ?? {}
+  const REPO = '/home/patrick/Bachelorprojekt'
+
+  const PLAN_SCHEMA = {
+    type: 'object',
+    required: ['launch'],
+    properties: {
+      launch: {
+        type: 'array',
+        items: {
+          type: 'object',
+          required: ['brand', 'external_id', 'slot'],
+          properties: {
+            brand: { enum: ['mentolder', 'korczewski'] },
+            external_id: { type: 'string' },
+            slot: { type: 'integer' },
+            title: { type: 'string' },
+          },
+        },
+      },
+    },
+  }
+
+  // ── ① Prep: watchdog sweep + queue poll + conflict-gate + slot-claim (deterministic) ──
+  phase('Prep')
+  const prep = await agent(
+    `You are the Software Factory dispatcher PREP step. Run the deterministic scripts below from
+     ${REPO} and report ONLY what the scripts decide — do not schedule by your own judgment.
+
+     For EACH brand in [mentolder, korczewski]:
+       1. Watchdog sweep (escalate stale runs, free their slots):
+          BRAND=<brand> bash ${REPO}/scripts/factory/watchdog.sh
+       2. Schedule (poll backlog + best-effort conflict gate + claim slots up to the global cap):
+          BRAND=<brand> FACTORY_GLOBAL_CAP=3 bash ${REPO}/scripts/factory/schedule.sh
+          (schedule.sh enforces the global cap across BOTH brands by summing occupied slots.)
+
+     Collect every {brand, external_id, slot} object that schedule.sh claimed across both brands.
+     For each claimed external_id, fetch its title:
+       BRAND=<brand> bash ${REPO}/scripts/ticket.sh get --id <external_id>   (read .title from the JSON)
+
+     Return JSON: { "launch": [ {brand, external_id, slot, title} ... ] }. If nothing was claimed, return { "launch": [] }.`,
+    { label: 'prep', phase: 'Prep', schema: PLAN_SCHEMA },
+  )
+
+  log(`Dispatcher: ${prep.launch.length} feature(s) scheduled this tick`)
+  if (prep.launch.length === 0) {
+    return { status: 'idle', launched: 0, timestamp: A.timestamp }
+  }
+
+  // ── ② Launch: nest one pipeline workflow per scheduled feature (Model A) ──
+  phase('Launch')
+  const results = await parallel(
+    prep.launch.map((f) => () =>
+      workflow(
+        { scriptPath: 'scripts/factory/pipeline.js' },
+        {
+          title: f.title ?? f.external_id,
+          description: `Dispatched by the Software Factory dispatcher (slot ${f.slot}).`,
+          slug: `sf-${String(f.external_id).toLowerCase()}`,
+          ticket_id: f.external_id,
+          brand: f.brand,
+          timestamp: A.timestamp,
+        },
+      )
+        .then((r) => ({ external_id: f.external_id, brand: f.brand, result: r }))
+        .catch((e) => ({ external_id: f.external_id, brand: f.brand, error: String(e) })),
+    ),
+  )
+
+  // ── ③ Metrics: per-brand throughput summary on the Vorhaben ticket ──
+  phase('Metrics')
+  await agent(
+    `Run the factory metrics summary for BOTH brands from ${REPO} and report stdout:
+       BRAND=mentolder bash ${REPO}/scripts/factory/metrics.sh
+       BRAND=korczewski bash ${REPO}/scripts/factory/metrics.sh
+     (metrics.sh is best-effort: a missing Vorhaben ticket on a brand is a silent no-op.)`,
+    { label: 'metrics', phase: 'Metrics' },
+  )
+
+  return { status: 'done', launched: results.length, results, timestamp: A.timestamp }
+}
+
+// The harness calls run(args, { agent, parallel, phase, log, workflow }).
+export default run
+```
+
+- [ ] **Step 4: Run `node --check` + the contract test — verify they pass**
+
+Run:
+```bash
+node --check scripts/factory/dispatcher.js && echo SYNTAX_OK
+./tests/runner.sh local FA-SF-30
+```
+Expected: `SYNTAX_OK` and all FA-SF-30 assertions PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/factory/dispatcher.js tests/local/FA-SF-30-dispatcher-contract.bats
+git commit -m "feat(factory): add Model-A dispatcher.js Workflow (prep→launch→metrics) [T000413]"
+```
+
+- [ ] **Step 6: Execution-time nesting spike (no commit)**
+
+Invoke the **Workflow tool** with `{scriptPath: "scripts/factory/dispatcher.js"}` and `args: { timestamp: "<ISO now>" }` against a **dev** cluster (set `FACTORY_CTX` for the primitives via the agent environment, or seed one `SF-TEST-` backlog feature first). Confirm: PREP returns a `launch` array, LAUNCH nests a `pipeline.js` workflow (appears as a `▸ software-factory-pipeline` group in `/workflows`), and the run returns `{status:'done'|'idle'}`. **If `workflow({scriptPath})` errors** ("nesting" / "unknown ref"), fall back to registering `pipeline.js` under `.claude/workflows/` and referencing it by name — record which worked in a T000413 comment. This is the first real end-to-end pipeline execution; expect to fix a pipeline.js runtime issue here (it was previously only `node --check`ed).
+
+---
+
+### Task 10: `task factory:dispatch` + inventory registration + doc status flip
+
+**Why:** A documented invocation surface, CI-tracked test IDs, and honest factory docs.
+
+**Files:**
+- Modify: `Taskfile.factory.yml`
+- Regenerate: `website/src/data/test-inventory.json` (via `scripts/build-test-inventory.sh` — already accepts `FA-SF-NN`)
+- Modify: `scripts/factory/README.md`, `docs/superpowers/references/factory-usage.md`
+
+- [ ] **Step 1: Add the `factory:dispatch` doc target**
+
+In `Taskfile.factory.yml`, add a second task after `run:`:
+```yaml
+  dispatch:
+    desc: |
+      Print how to run the Phase-2 Software Factory dispatcher.
+      Invoke scripts/factory/dispatcher.js via the Claude Code Workflow tool,
+      driven on an interval by the /loop skill (self-paced ScheduleWakeup).
+    silent: true
+    cmds:
+      - |
+        echo "Software Factory — Phase 2 dispatcher"
+        echo "Invoke via the Workflow tool: { scriptPath: 'scripts/factory/dispatcher.js' }, args: { timestamp }"
+        echo "Recurring: /loop \"run the software-factory-dispatcher workflow\""
+        echo "Offline lint:   node --check scripts/factory/dispatcher.js"
+        echo "Contract tests: ./tests/runner.sh local FA-SF-30"
+        echo "Primitives:     slots.sh queue.sh schedule.sh watchdog.sh metrics.sh (BRAND=<brand>)"
+```
+
+- [ ] **Step 2: Regenerate + verify the inventory registers every new FA-SF id**
+
+Run:
+```bash
+task test:inventory
+grep -o '"FA-SF-[0-9]*"' website/src/data/test-inventory.json | sort -u
+```
+Expected: includes `FA-SF-01`, `FA-SF-04`, `FA-SF-20`, **`FA-SF-21`, `FA-SF-22`, `FA-SF-23`, `FA-SF-24`, `FA-SF-25`, `FA-SF-26`, `FA-SF-27`, `FA-SF-30`**. No duplicate-ID error.
+
+- [ ] **Step 3: Flip the factory doc status to Phase-2-live**
+
+In `docs/superpowers/references/factory-usage.md`: under "🔜 Phase 2: Dispatcher", change the heading to "✅ Phase 2: Dispatcher (live)" and replace the "Noch nicht verfügbar" bullets with the now-shipped capabilities (queue polling via `queue.sh`, conflict-gated slot scheduling via `schedule.sh`, `watchdog.sh` 30-min stale escalation, `metrics.sh` summary comments, `dispatcher.js` Workflow + `/loop` trigger). Keep Layer-4 canary / directory heuristic / semantic dedup under 📋 Phase 3.
+
+In `scripts/factory/README.md`: change the Dispatcher/Watchdog/Slot-manager rows from 🔜 to ✅ pointing at the new scripts; keep canary/dir-heuristic as 📋 Phase 3.
+
+- [ ] **Step 4: Verify the Taskfile parses and offline gate is green**
+
+Run:
+```bash
+task --list 2>/dev/null | grep -E "factory:(run|dispatch)" && echo TASK_OK
+git diff --quiet website/src/data/test-inventory.json && echo "INVENTORY UNCHANGED (bug)" || echo "INVENTORY UPDATED"
+task test:all
+```
+Expected: `TASK_OK`, `INVENTORY UPDATED`, and `task test:all` green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Taskfile.factory.yml website/src/data/test-inventory.json scripts/factory/README.md docs/superpowers/references/factory-usage.md
+git commit -m "docs(factory): add task factory:dispatch + register FA-SF tests + flip Phase-2 status [T000413]"
+```
+
+---
+
+## Final verification (run before opening the PR)
+
+- [ ] Offline gate green: `task test:all`
+- [ ] Inventory in sync: `task test:inventory && git diff --quiet website/src/data/test-inventory.json && echo INVENTORY_CLEAN`
+- [ ] Both Workflow scripts lint: `node --check scripts/factory/pipeline.js && node --check scripts/factory/dispatcher.js && echo WF_OK`
+- [ ] All new FA-SF offline assertions pass without a cluster: `for t in FA-SF-20 FA-SF-21 FA-SF-22 FA-SF-23 FA-SF-24 FA-SF-25 FA-SF-26 FA-SF-27 FA-SF-30; do ./tests/runner.sh local $t; done` (live-only assertions `skip` when no dev cluster context is set)
+- [ ] Live seed-layer pass on a **dev** cluster (set `FACTORY_CTX`/`FACTORY_NS` to a dev context, NEVER `fleet`): FA-SF-23/24/25/26/27 exercise claim/queue/schedule/watchdog/metrics against real rows and purge them.
+- [ ] Task 0 + Task 9 Step 6 spikes recorded on T000413 (Workflow execution + `workflow({scriptPath})` nesting confirmed; any pipeline.js runtime fix committed).
+- [ ] Manual dispatcher dry-run documented: one `SF-TEST-` backlog feature → dispatcher PREP schedules it → LAUNCH nests a pipeline → no merge in the dry-run (kill the pipeline before Deploy).
+
+---
+
+## Self-Review notes (spec coverage)
+
+- Spec §2 (Model A: PREP-agent bundling, no in-process MONITOR, shared-cap global deckel) → T9 (`dispatcher.js` PREP/LAUNCH/METRICS) + T5 (`FACTORY_GLOBAL_CAP`).
+- Spec §3.1 (`ticket.sh` get/set-touched-files/set-pipeline-slot/release-slot, --is-test-data; **+`touch`** added during planning for liveness) → T1.
+- Spec §3.2–3.6 (slots/queue/schedule/watchdog/metrics primitives) → T3/T4/T5/T6/T7, all sharing `lib.sh` (T2).
+- Spec §3.7 (`dispatcher.js`, resume-safe, `<pipeline-ref>` = `workflow({scriptPath})`) → T9 + Task 0/Step 6 spikes.
+- Spec §3.8 (`pipeline.js` phase progress writes) → T8.
+- Spec §3.9 (`factory:dispatch`) → T10.
+- Spec §4 (per-brand slots + global cap; atomic claim; **single-flight realized via /loop natural cadence + slot accounting, not advisory lock** — corrects spec shorthand) → T3/T5/T9.
+- Spec §5 (escalation table) → T6 (watchdog), T8/T9 (pipeline Verify-block + crash→triage handled by P1 pipeline + watchdog).
+- Spec §6 (3-layer test split + fixtures + disjoint paths + purge) → T1–T9 BATS + T2 fixtures; serial-collision avoided via disjoint synthetic paths per test.
+- Spec §7 (P3 out-of-scope) → not built (no DDL, no canary, no dir-heuristic, no embedTicket wiring).
+- Spec §8 risks → addressed: latent ticket.sh bug (T1), atomic slot-claim (T3), dual-brand handled per-brand (T5/T9), workflow-ref (Task 0/T9 spikes), GPU-independent core (queue/conflict on touched_files only).

--- a/docs/superpowers/references/factory-usage.md
+++ b/docs/superpowers/references/factory-usage.md
@@ -1,7 +1,7 @@
 # Software Factory — Usage Guide
 
-> **Status (2026-06-05):** Phase 1 Foundation is live.
-> ✅ = available now · 🔜 = Phase 2 (cron Dispatcher) · 📋 = Phase 3 (Full Auto-Pilot)
+> **Status (2026-06-05):** Phase 2 Dispatcher is live.
+> ✅ = available now · 📋 = Phase 3 (Full Auto-Pilot)
 > Plane neue Features mit dem runnable `scripts/factory/pipeline.js` Workflow Script.
 
 ## ✅ Phase 1: Pipeline — runnable via Claude Code Workflow Tool
@@ -56,9 +56,6 @@ SELECT * FROM tickets.v_factory_metrics;
 SELECT * FROM tickets.v_active_features;
 ```
 
-## 🔜 Phase 2: Dispatcher (in Entwicklung)
-
-Der Cron-basierte Dispatcher automatisiert Queue-Polling, Konflikt-Analyse,
 ### Pipeline Workflow Script ✅
 
 Invokiere `scripts/factory/pipeline.js` via das Claude Code Workflow Tool:
@@ -75,16 +72,30 @@ BRAND=mentolder bash scripts/factory/conflict-check.sh T000413 "k3d/website.yaml
 # Returns: [] (no conflicts) or ["T000412"] (conflicts with ticket T000412)
 ```
 
-## 🔜 Phase 2: Dispatcher (geplant)
+## ✅ Phase 2: Dispatcher (live)
 
-Der Cron-basierte Dispatcher automatisiert Queue-Polling, Konflikt-Analyse,
-und Pipeline-Launch. Siehe `scripts/factory/README.md` für die Architektur.
+Der Dispatcher automatisiert Queue-Polling, Konflikt-Analyse, Slot-Scheduling
+und Pipeline-Launch. Alle Primitives sind unter `scripts/factory/` verfügbar.
 
-**Noch nicht verfügbar:**
-- Automatisches Queue-Polling
-- Automatische Konflikt-Analyse vor Pipeline-Start (brand-aware conflict-check ist in Phase 1 manuell/per-pipeline)
-- Watchdog (30min Timeout-Erkennung)
-- Automatische Metriken-Kommentare
+**Invokierung via Claude Code Workflow Tool:**
+```
+scriptPath: 'scripts/factory/dispatcher.js'
+args: { timestamp }
+```
+
+**Recurring (selbst-getaktet) via /loop:**
+```
+/loop "run the software-factory-dispatcher workflow"
+```
+
+**Offline-Dokumentation:** `task factory:dispatch`
+
+**Shipped Capabilities:**
+- **Queue-Polling** via `queue.sh` — raw Backlog, Priority+FIFO-Sortierung
+- **Konflikt-gegatetes Slot-Scheduling** via `schedule.sh` — pro-Brand Pool + globales Cap
+- **Watchdog** via `watchdog.sh` — 30-min Stale-Eskalation, Triage-Kommentar + Slot-Release
+- **Metriken** via `metrics.sh` — Durchsatz-Zusammenfassung auf T000413
+- **dispatcher.js** — Workflow Script das alle Primitives orchestriert
 
 ## 📋 Phase 3: Full Auto-Pilot (geplant)
 

--- a/docs/superpowers/specs/2026-06-05-sf-dispatcher-design.md
+++ b/docs/superpowers/specs/2026-06-05-sf-dispatcher-design.md
@@ -1,0 +1,180 @@
+# Spec: Software Factory — Phase 2 (Dispatcher / Tier 1)
+
+**Vorhaben-Ticket:** T000413 (Metrik-Sink) · **Vorgänger:** Phase 1 (T000420, PR #1326)
+**Datum:** 2026-06-05
+**Status:** design-approved
+**Branch:** `feature/sf-dispatcher`
+
+---
+
+## 1. Vision & Kontext
+
+Phase 1 ("Augmented Single-Feature", T000420/#1326) lieferte das Fundament: das lauffähige 6-Phasen-`pipeline.js`-Workflow-Script (Scout → Design → Plan → Implement → Verify → Deploy), die brand-aware `conflict-check.sh` (file-level Overlap), die `findSimilarTickets`-Suche, sowie das DB-Schema (`touched_files`, `pipeline_slot`, `ticket_embeddings` + HNSW, `fn_find_similar`, `v_factory_metrics`, `v_active_features`).
+
+**Phase 2 baut Tier 1 — den Dispatcher.** Er macht aus dem manuell-invokierten Single-Feature-Lauf eine **autonome, wiederkehrende Multi-Feature-Orchestrierung**: er pollt die Feature-Queue, analysiert Konflikte, weist Slots zu, startet Pipelines parallel, überwacht ihre Liveness und schreibt Metriken — ohne menschliche Intervention im Happy Path.
+
+P2 **erfindet nichts neu**; es **verdrahtet** die P1-Primitiven zu einem Loop. Die Spec dieses Loops war in `2026-06-01-software-factory-design.md` §4 bereits skizziert; dieses Dokument legt die konkreten, in der Planung getroffenen Entscheidungen fest.
+
+### Grundsatz-Entscheidungen (in der Planung gelockt)
+
+| Achse | Entscheidung | Begründung |
+|---|---|---|
+| **Launch-Topologie** | **Modell A** — ein Dispatcher-Workflow nestet die Pipelines via `workflow('pipeline', …)` | Wörtliche „Dispatcher-as-Workflow"-Lesart; eine Metrik-Sicht, in-process Koordination |
+| **Trigger** | **`/loop` self-paced** (`ScheduleWakeup`), lokal, + `pg_advisory_lock` Single-Flight | Re-armt sich jeden Zyklus (kein CronCreate-3-Tage-Ablauf); natürliche Überlappungsfreiheit (Wake erst nach Run-Ende); Pipelines brauchen lokale Worktrees + Fleet-Kubeconfig (Remote-Routine scheidet aus) |
+| **Slots** | **Per-Brand-Pools (je 3) + globaler Gesamt-Deckel (start 3)** | `pipeline_slot` lebt physisch je Brand-DB; `conflict-check` ist strukturell per-brand; Deckel schützt den geteilten Modell-A-Agent-Cap |
+| **Watchdog-Signal** | **`updated_at`-Sweep + Phasengrenzen-Progress-Writes** | `fn_lifecycle_ts`-Trigger bumpt `updated_at` bei jedem Row-Write gratis → Heartbeat-Semantik ohne Schema-Änderung auf beiden Brands |
+| **Layer-4 Canary** | **Auf P3 verschoben** | Spec §7 + `pipeline.js:25-27` markieren es als P2-out-of-scope; `feature:promote` hat Smoke+Rollback bereits auf Deploy-Ebene |
+| **Test-Seeding** | **`factory-test-fixtures.sh` + `is_test_data=true` + `SF-TEST-`-Prefix + `fn_purge_test_data()`** | Folgt dem bestehenden Purge-Muster; keine neue Test-Infra |
+| **Semantische Suche** | **Fail-soft beibehalten; `embedTicket`-Wiring + Backfill = eigenes Follow-up** | GPU-Host down → Embeddings leer; Dispatcher-Kern (touched_files-Overlap) ist GPU-unabhängig |
+
+---
+
+## 2. Architektur
+
+Der Dispatcher ist **ein Workflow-Run pro Tick** (Modell A), getrieben durch `/loop` self-paced. Wegen des **1000-Agent-Lifetime-Caps pro Run** ist er **kein ewiger Einzel-Run**, sondern ein frischer, gebundener Run je Tick.
+
+```
+/loop wake ──▶ [pg_advisory_lock frei?] ──nein──▶ no-op exit (anderer Run aktiv)
+                     │ ja
+                     ▼
+        dispatcher.js  (Modell-A Workflow, 1 Run/Tick)
+          ① PREP-Agent  (1 Agent, deterministisch, schema-validierter Output):
+                watchdog.sh → stale-sweep (updated_at>30min) + eskaliere + Slot freigeben
+                queue.sh    → v_active_features je Brand (Prio→FIFO)
+                schedule.sh → conflict-check (file-level) + atomarer Slot-Claim
+                └─▶ LAUNCH-PLAN: [{brand, external_id, slug, slot}], ≤ Gesamt-Deckel
+          ② LAUNCH       parallel( plan.map(f => () => workflow('pipeline', f)) )
+          ③ METRICS-Agent  metrics.sh → Markdown-Kommentar an T000413
+                     │
+                     ▼  (Run kehrt zurück; der äußere /loop-Turn ruft)
+        ScheduleWakeup(1200s)  ← erst NACH Run-Ende → natürliche Single-Flight
+```
+
+### Warum PREP gebündelt ist (kein literal-phasenweiser POLL/CONFLICT/SCHEDULE)
+
+Workflow-Scripts haben **kein direktes Bash** — nur `agent()`/`parallel()`/`pipeline()`/`workflow()`. Deterministische bash-Primitiven müssen von einem Agenten ausgeführt werden. Statt pro SQL-Query einen Agenten zu verbrennen (Agent-Cap-Druck + Latenz), bündelt **ein PREP-Agent** `watchdog.sh`+`queue.sh`+`schedule.sh` und gibt den fertigen, schema-validierten Launch-Plan zurück. Agent-Ökonomie pro Run: **1 PREP + N Pipeline-Sub-Workflows + 1 METRICS**.
+
+### Warum MONITOR nicht in-process ist
+
+Das Workflow-Harness bietet **kein Timeout-Primitiv** für `await`. Eine hängende Pipeline würde ein in-process `MONITOR` (und damit den ganzen Dispatcher-Run) blockieren. Stattdessen ist der Watchdog ein **DB-Poll-Sweep zu Beginn des *nächsten* Runs** (im PREP-Agenten): er findet in-flight Features aus früheren Runs, die `updated_at > 30min` stale sind, und eskaliert sie. Das ist robust gegen hängende Pipelines und passt zur `/loop`-Kadenz.
+
+### Modell-A-Konsequenz: geteilte Ressourcen
+
+Per `workflow()` genestete Kinder **teilen sich** den Concurrency-Cap (`min(16, cores-2)`), das Token-Budget und das 1000-Agent-Lifetime-Limit des Parents (Workflow-Tool-Semantik). Deshalb: **globaler Gesamt-Deckel** auf gleichzeitige Pipelines (start: 3), unabhängig davon, dass jeder Brand nominell 3 Slots hat. „3 Slots/Brand" ist die *Buchhaltungs*-Obergrenze je Brand; der *globale Deckel* ist die physische Concurrency-Grenze.
+
+---
+
+## 3. Komponenten & Verträge
+
+Jede Einheit hat einen klaren Zweck, kommuniziert über JSON/Exit-Codes und ist isoliert testbar.
+
+### 3.1 `scripts/ticket.sh` (erweitern) — **zuerst**
+
+Neue Subcommands (das CLI hat heute nur `create`, `update-status`, `add-comment`, `archive-plan`, `get-attachments`):
+
+- **`get --id <external_id>`** → JSON eines Tickets (für Dispatcher-State-Reads). Niemals `ticket_plans.content` selektieren.
+- **`set-touched-files --id <external_id> --files <csv>`** → schreibt `tickets.touched_files`. **Fixt einen latenten P1-Bug:** `pipeline.js:113` ruft `set-touched-files` bereits auf, aber das Subcommand existiert nicht (Scout→touched_files-Pfad heute stumm gebrochen).
+- **`set-pipeline-slot --id <external_id> --slot <int|null>`** und **`release-slot --id <external_id>`** → Slot-Verwaltung.
+- **`--is-test-data` Flag** auf `create` → setzt `is_test_data=true` für purge-fähige Test-Tickets.
+
+Alle neuen Pfade nutzen das bestehende advisory-lock-Muster des CLI und respektieren `WORKSPACE_NAMESPACE`/`BRAND`.
+
+### 3.2 `scripts/factory/slots.sh` (neu)
+
+Slot-Buchhaltung gegen `tickets.tickets.pipeline_slot`. Subcommands: `claim <brand>` (atomares `UPDATE … SET pipeline_slot=<n>, status='in_progress' WHERE external_id=… AND pipeline_slot IS NULL RETURNING` — race-frei ohne expliziten Lock), `release <external_id>`, `count <brand>` (belegte Slots je Brand), `count-global` (Summe über beide Brands gegen den Gesamt-Deckel). Env: `BRAND`→ns (wie `conflict-check.sh`), `FACTORY_CTX`, `FACTORY_DRY_RESOLVE`.
+
+### 3.3 `scripts/factory/queue.sh` (neu)
+
+Pollt `v_active_features` **je Brand** und gibt schedulebare `backlog`-Features als JSON aus (geordnet Prio `hoch→mittel→niedrig`, dann `created_at` — die View liefert das bereits). **Erster Konsument** von `v_active_features`. Read-only (nur Metadaten-Spalten, nie `content`).
+
+### 3.4 `scripts/factory/schedule.sh` (neu)
+
+Je Kandidat aus `queue.sh`: ruft `BRAND=<brand> conflict-check.sh <external_id> <touched_files…>` (file-level, brand-aware, **unverändert** aus P1). Bei Exit 0 (kein Konflikt) **und** freiem Slot (per-Brand-Pool **und** globaler Deckel nicht erreicht) → `slots.sh claim`. Gibt den **Launch-Plan** aus: `[{brand, external_id, slug, slot}]`. Konfliktierende/slot-lose Kandidaten bleiben `backlog`.
+
+### 3.5 `scripts/factory/watchdog.sh` (neu)
+
+Sweep über `v_active_features` WHERE `status='in_progress' AND updated_at < now() - interval '30 min'` (Schwelle aus Spec §4, konfigurierbar). Pro Treffer: Eskalation gemäß §4 (Status setzen, Kommentar mit Kontext, Slot via `release-slot` freigeben). Läuft **je Brand**.
+
+### 3.6 `scripts/factory/metrics.sh` (neu)
+
+Liest `v_factory_metrics` (+ optional `v_active_features`), formatiert eine Markdown-Zusammenfassung (features_shipped/Tag, avg_cycle_time_h, Eskalationen, aktive Slots) und schreibt sie via `ticket.sh add-comment --id T000413`. **Erster Konsument** von `v_factory_metrics`. Läuft je Brand, eine konsolidierte Sicht.
+
+### 3.7 `scripts/factory/dispatcher.js` (neu)
+
+Der Modell-A-Workflow. `export const meta` mit Phasen `Prep`/`Launch`/`Metrics`. PREP-Agent führt watchdog→queue→schedule aus und gibt den schema-validierten Launch-Plan zurück; LAUNCH = `parallel(plan.map(f => () => workflow(<pipeline-ref>, f)))`; METRICS-Agent führt `metrics.sh` aus. **Resume-safe:** nutzt `args.timestamp`, **kein** `Date.now()`/`Math.random()`. Wird vom Workflow-Tool ausgeführt, **nicht** `node`.
+
+> **`<pipeline-ref>` muss in der Plan-Phase geklärt werden:** `workflow(name)` löst nur **registrierte** Workflows auf (Registry = `.claude/workflows/`), aber dieses Verzeichnis **existiert heute nicht** (Recon-Befund). Zwei Wege: (a) `pipeline.js` als benannten Workflow in `.claude/workflows/` registrieren und per Name referenzieren, **oder** (b) direkt `workflow({scriptPath: 'scripts/factory/pipeline.js'}, f)` aufrufen. **(b) ist der defaultlose, robustere Weg** (keine neue Registry-Konvention) und wird empfohlen, sofern der Plan nichts dagegen findet.
+
+### 3.8 `scripts/factory/pipeline.js` (modifizieren)
+
+An jeder Phasengrenze (Scout→Design→…→Deploy) ein leichter Progress-Write via `ticket.sh` (Status-Touch / kurzer Kommentar) → `fn_lifecycle_ts` bumpt `updated_at` gratis → echte Pipeline-Liveness für den Watchdog ohne Schema-Änderung. Keine sonstige Verhaltensänderung an P1.
+
+### 3.9 `Taskfile.factory.yml` (erweitern)
+
+Neuer Task `factory:dispatch`: dokumentiert die Invocation von `dispatcher.js` via `/loop` + Workflow-Tool (analog zum bestehenden `factory:run`). Reiner Doku-/Lint-Task — der Dispatcher läuft über das Harness, nicht über `node`.
+
+---
+
+## 4. Daten- & State-Modell
+
+- **Status-Übergänge:** `backlog` →(Slot-Claim, atomar)→ `in_progress` →(Verify-Phase)→ `in_review` →(Deploy)→ `done` · Eskalation → `blocked` · Crash/Timeout → `triage` (zurück in Queue, Slot frei).
+- **`pipeline_slot`:** gesetzt beim Claim, geleert bei Completion/Eskalation. **Per-Brand-Pool** (1..3 je Brand-DB). **Globaler Deckel** (start 3) gegen Modell-A-Cap-Übersubscription; tunebar über eine ENV/Konstante.
+- **Locks:** `pg_advisory_lock(<dispatcher_key>)` für Dispatcher-Single-Flight (belt-and-suspenders über der natürlichen `/loop`-Single-Flight). Slot-Claim braucht **keinen** expliziten Lock — das atomare conditional `UPDATE … WHERE pipeline_slot IS NULL` serialisiert konkurrierende Claims race-frei.
+- **Brand-Isolation:** Jeder Brand hat eine **eigene** `shared-db` (ns `workspace` / `workspace-korczewski`). Es gibt **keine** Cross-DB-Koordination; der Dispatcher iteriert beide Brands sequenziell innerhalb eines Runs, hält aber eine konsolidierte Metrik-Sicht.
+
+---
+
+## 5. Fehlerbehandlung & Eskalation (Spec §4)
+
+| Fall | Aktion |
+|---|---|
+| Test-Fail nach 2 Retries (in `pipeline.js`) | Ticket → `blocked` + Kommentar mit Fehlerlog |
+| Merge-Konflikt nicht auflösbar | Ticket → `blocked` + Diff |
+| Pipeline-Crash / Session-Timeout | Ticket → `triage` (zurück in Queue), Slot via `release-slot` frei |
+| Watchdog: stale > 30min | Eskalation wie Crash (triage + Slot frei + Kommentar) |
+| HIGH/CRITICAL Review-Finding (Verify, P1) | Ticket → `blocked` + Eskalation an Mensch |
+| `conflict-check` Overlap | Kandidat bleibt `backlog`, kein Slot-Claim (sequenziert sich von selbst) |
+
+---
+
+## 6. Testing
+
+Drei-Schichten-Split (wie P1) bleibt erhalten:
+
+1. **Offline-Logik** (`slots.sh`/`queue.sh`/`schedule.sh`/`dispatcher.js`-Kontrakt): gegen Mocks + `FACTORY_DRY_RESOLVE`, kein Cluster. `dispatcher.js` per `node --check` + grep-Kontrakt (analog FA-SF-20: Phasen vorhanden, `args.timestamp`, kein `Date.now`/`Math.random`, `workflow('software-factory-pipeline'`).
+2. **Live-Read** (`watchdog.sh`-Sweep, Schema-Parität beider Brands): `kubectl exec`+psql gegen Fleet, `FACTORY_NS` überschreibbar.
+3. **Seed** (slot-claim, queue-order, watchdog-eskalation, die echte Rows brauchen): neue **`tests/lib/factory-test-fixtures.sh`** mit `seed_test_feature()` → `ticket.sh create --is-test-data --title 'SF-TEST-…'`; Teardown via bestehende `fn_purge_test_data()` (löscht `is_test_data=true`).
+
+**Parallel-Seed-Kollision:** Factory-BATS **seriell gepinnt** (`JOBS=1`) **oder** disjunkte synthetische Pfade je Test, damit `conflict-check` nicht legitim zwischen Test-Features Konflikt meldet. Neue IDs (`FA-SF-NN`) in `test-inventory.json` registriert (CI-diff-gated via `task test:inventory`).
+
+---
+
+## 7. Scope
+
+**In Scope (P2):** Dispatcher-Loop (`dispatcher.js`), bash-Primitiven (slots/queue/schedule/watchdog/metrics), `ticket.sh`-Erweiterung (get/set-touched-files/set-pipeline-slot/release-slot/--is-test-data), `pipeline.js`-Progress-Writes, per-Brand-Slots + globaler Deckel, `updated_at`-Watchdog, `/loop`-Trigger + advisory-lock Single-Flight, Metriken an T000413, FA-SF-Tests + Fixtures, Doku.
+
+**Out of Scope (P3):** Layer-4 Canary-Smoke + Auto-Rollback · Verzeichnis-Level-Konflikt-Heuristik (`conflict-check` bleibt file-level) · semantisches Dedup-Gate · `embedTicket`-Verdrahtung in `ticket.sh create` + Backfill (GPU down → eigenes Follow-up; Scout bleibt fail-soft `[]`) · Event/Webhook-Trigger · dediziertes Dispatcher-Deployment · Live-Dashboard.
+
+---
+
+## 8. Bekannte Risiken & Gaps (aus Recon)
+
+1. **Geteilter Modell-A-Cap** — N Pipelines + Agenten teilen `min(16,cores-2)`. Mitigiert durch globalen Gesamt-Deckel (start 3, tunebar).
+2. **Latenter P1-Bug** — `pipeline.js:113` ruft `ticket.sh set-touched-files`, das nicht existiert. **Erste P2-Task fixt das.**
+3. **`ticket_embeddings` leer + GPU down** — Scout-Semantik bleibt fail-soft (`[]`); Dispatcher-Kern GPU-unabhängig. Wiring/Backfill = Follow-up.
+4. **Dual-Brand-Schema-Parität** — vor Launch verifizieren, dass die Factory-Objekte auf **beiden** `shared-db` (workspace + workspace-korczewski) live sind (idempotenter Website-Boot-Init).
+5. **Slot-Doppelzuweisung** — durch atomares conditional `UPDATE` (nicht durch Lese-dann-Schreib) ausgeschlossen.
+6. **`/loop` session-gebunden** — endet die Session, schläft der Loop bis zum manuellen Neustart. Akzeptiert für P2; daemon-hafter Trigger ist P3.
+7. **Stale `feature/sf-dispatcher`-Annahmen** — P2 startet frisch von `origin/main` (verifiziert: Worktree von `origin/main` angelegt).
+8. **`workflow()`-Referenz auf `pipeline.js`** — kein `.claude/workflows/`-Registry vorhanden; Plan klärt Name-Registrierung vs. `{scriptPath}` (Empfehlung: `{scriptPath}`, s. §3.7). Verifizieren, dass ein per `{scriptPath}` genesteter Workflow korrekt als ein-Level-Kind läuft.
+
+---
+
+## 9. Verwandte Specs & Infrastruktur
+
+- `docs/superpowers/specs/2026-06-01-software-factory-design.md` — Gesamt-Spec (§4 Dispatcher-Loop, §5 Views, §6/§7 Layer-4/Phasen)
+- `docs/superpowers/plans/2026-06-05-software-factory-phase1.md` — P1-Plan (T000420), out-of-scope-Liste = dieser P2-Scope
+- `scripts/factory/pipeline.js`, `scripts/factory/conflict-check.sh`, `scripts/ticket.sh` — P1-Primitiven
+- `website/src/lib/tickets-db.ts` — Schema (`pipeline_slot`, `v_active_features`, `v_factory_metrics`, `fn_lifecycle_ts`-Trigger)
+- `tests/local/FA-SF-*.bats` + `scripts/build-test-inventory.sh` — Test-Inventar-Muster
+- `/loop` Skill (`ScheduleWakeup`) + Workflow-Tool (`workflow()`-Nesting: ein Level, geteilter Cap/Budget)

--- a/scripts/factory/README.md
+++ b/scripts/factory/README.md
@@ -1,14 +1,14 @@
 # Software Factory — Komponenten & Architektur
 
-> **Status:** Phase 1 (Foundation) — manuelle Pipeline-Invocation.
-> Phase 2 (Dispatcher) und Phase 3 (Full Auto-Pilot) sind geplant.
+> **Status:** Phase 2 (Dispatcher) — live.
+> Phase 3 (Full Auto-Pilot) ist geplant.
 > Vorhaben-Ticket: T000413
 
 ## Architektur-Übersicht
 
 ```
 ┌─────────────────────────────────────────────────────────┐
-│ TIER 1: DISPATCHER (Phase 2 — geplant)                  │
+│ TIER 1: DISPATCHER (Phase 2 — live)                     │
 │ Queue-Manager · Konflikt-Detektor · Scheduler           │
 └──────────────────────┬──────────────────────────────────┘
                        │
@@ -39,8 +39,14 @@
 | `review-security-auditor.prompt.md` | Adversarial Review: Security-Audit | ✅ |
 | `review-pattern-enforcer.prompt.md` | Adversarial Review: Konventions-Prüfung | ✅ |
 | `conflict-check.sh` | Konflikt-Detektor (Datei-Overlap), brand-aware | ✅ |
-| Dispatcher-Script | Queue-Manager + Scheduler | 🔜 Phase 2 |
-| Workflow-Runner-cron | Automatisierte periodische Pipeline-Ausführung | 🔜 Phase 2 |
+| `dispatcher.js` | Workflow-Dispatcher: Queue-Poll → Konflikt → Schedule → Launch | ✅ Phase 2 |
+| `slots.sh` | Slot-Manager: pro-Brand Pool + globales Cap | ✅ Phase 2 |
+| `queue.sh` | Queue-Manager: Backlog lesen, Priority+FIFO | ✅ Phase 2 |
+| `schedule.sh` | Scheduler: Konflikt-gegatetes Slot-Scheduling | ✅ Phase 2 |
+| `watchdog.sh` | Watchdog: 30-min Stale-Eskalation + Slot-Release | ✅ Phase 2 |
+| `metrics.sh` | Durchsatz-Zusammenfassung für T000413 | ✅ Phase 2 |
+| Canary-Deployment | Layer-4: automatisches Canary-Rollout | 📋 Phase 3 |
+| Directory-Heuristic | Layer-4: verzeichnisbasierte Konflikt-Erkennung | 📋 Phase 3 |
 
 ## Quickstart (Phase 1 — Manuell)
 

--- a/scripts/factory/dispatcher.js
+++ b/scripts/factory/dispatcher.js
@@ -1,0 +1,110 @@
+/**
+ * scripts/factory/dispatcher.js
+ *
+ * Software Factory Phase-2 Dispatcher (Tier 1) — Claude Code Workflow script.
+ *
+ * Model A: ONE bounded Workflow run per /loop tick that nests pipeline.js runs.
+ * The harness injects agent/parallel/phase/log/workflow/args as TOP-LEVEL globals.
+ * Run by the Workflow tool, NOT `node scripts/factory/dispatcher.js`.
+ *
+ * Offline lint:   node --check scripts/factory/dispatcher.js
+ * Contract tests: ./tests/runner.sh local FA-SF-30
+ *
+ * Trigger: /loop self-paced (ScheduleWakeup) — the next wake is scheduled only
+ * after this run ends, giving natural single-flight. Over-scheduling is
+ * additionally bounded by schedule.sh's global cap + the atomic slot-claim
+ * (a pg advisory lock would NOT survive separate kubectl-exec psql sessions).
+ *
+ * Usage (Workflow tool): args = { timestamp }  // ISO8601 passed in
+ */
+
+export const meta = {
+  name: 'software-factory-dispatcher',
+  description:
+    'Phase-2 dispatcher: watchdog sweep → poll → conflict-gate + slot-claim → launch pipelines → metrics',
+  phases: [{ title: 'Prep' }, { title: 'Launch' }, { title: 'Metrics' }],
+}
+
+;(async () => {
+  const A = args ?? {}
+  const REPO = '/home/patrick/Bachelorprojekt'
+
+  const PLAN_SCHEMA = {
+    type: 'object',
+    required: ['launch'],
+    properties: {
+      launch: {
+        type: 'array',
+        items: {
+          type: 'object',
+          required: ['brand', 'external_id', 'slot'],
+          properties: {
+            brand: { enum: ['mentolder', 'korczewski'] },
+            external_id: { type: 'string' },
+            slot: { type: 'integer' },
+            title: { type: 'string' },
+          },
+        },
+      },
+    },
+  }
+
+  // ── ① Prep: watchdog sweep + queue poll + conflict-gate + slot-claim ──────────
+  phase('Prep')
+  const prep = await agent(
+    `You are the Software Factory dispatcher PREP step. Run the deterministic scripts below from
+     ${REPO} and report ONLY what the scripts decide — do not schedule by your own judgment.
+
+     For EACH brand in [mentolder, korczewski]:
+       1. Watchdog sweep (escalate stale runs, free their slots):
+          BRAND=<brand> bash ${REPO}/scripts/factory/watchdog.sh
+       2. Schedule (poll backlog + best-effort conflict gate + claim slots up to the global cap):
+          BRAND=<brand> FACTORY_GLOBAL_CAP=3 bash ${REPO}/scripts/factory/schedule.sh
+          (schedule.sh enforces the global cap across BOTH brands by summing occupied slots.)
+
+     Collect every {brand, external_id, slot} object that schedule.sh claimed across both brands.
+     For each claimed external_id, fetch its title:
+       BRAND=<brand> bash ${REPO}/scripts/ticket.sh get --id <external_id>   (read .title from the JSON)
+
+     Return JSON: { "launch": [ {brand, external_id, slot, title} ... ] }. If nothing was claimed, return { "launch": [] }.`,
+    { label: 'prep', phase: 'Prep', schema: PLAN_SCHEMA },
+  )
+
+  log(
+    `Dispatcher: ${prep.launch.length} feature(s) scheduled this tick (${A.timestamp ?? 'no timestamp'})`,
+  )
+  if (prep.launch.length === 0) {
+    return
+  }
+
+  // ── ② Launch: nest one pipeline workflow per scheduled feature (Model A) ──────
+  phase('Launch')
+  await parallel(
+    prep.launch.map(
+      (f) => () =>
+        workflow(
+          { scriptPath: 'scripts/factory/pipeline.js' },
+          {
+            title: f.title ?? f.external_id,
+            description: `Dispatched by the Software Factory dispatcher (slot ${f.slot}).`,
+            slug: `sf-${String(f.external_id).toLowerCase()}`,
+            ticket_id: f.external_id,
+            brand: f.brand,
+            timestamp: A.timestamp,
+          },
+        )
+          .then((r) => ({ external_id: f.external_id, brand: f.brand, result: r }))
+          .catch((e) => ({ external_id: f.external_id, brand: f.brand, error: String(e) })),
+    ),
+  )
+
+  // ── ③ Metrics: per-brand throughput summary on the Vorhaben ticket ────────────
+  phase('Metrics')
+  await agent(
+    `Run the factory metrics summary for BOTH brands from ${REPO} and report stdout:
+       BRAND=mentolder bash ${REPO}/scripts/factory/metrics.sh
+       BRAND=korczewski bash ${REPO}/scripts/factory/metrics.sh
+     (metrics.sh is best-effort: a missing Vorhaben ticket on a brand is a silent no-op.)`,
+    { label: 'metrics', phase: 'Metrics' },
+  )
+})()

--- a/scripts/factory/lib.sh
+++ b/scripts/factory/lib.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# scripts/factory/lib.sh — shared helpers for the Software Factory Dispatcher
+# primitives (slots/queue/schedule/watchdog/metrics). SOURCE, do not execute.
+#
+#   BRAND               mentolder|korczewski → resolves FACTORY_NS
+#   FACTORY_NS          explicit namespace (used when BRAND unset; default workspace)
+#   FACTORY_CTX         kubectl context (default: fleet)
+#   FACTORY_DRY_RESOLVE if set, callers print resolved ctx+ns and exit 0
+
+factory_resolve() {
+  case "${BRAND:-}" in
+    mentolder)   FACTORY_NS="workspace" ;;
+    korczewski)  FACTORY_NS="workspace-korczewski" ;;
+    "")          : ;;
+    *)           echo '{"error":"unknown BRAND (use mentolder|korczewski)"}' >&2; exit 2 ;;
+  esac
+  FACTORY_NS="${FACTORY_NS:-workspace}"
+  FACTORY_CTX="${FACTORY_CTX:-fleet}"
+}
+
+factory_pgpod() {
+  local pod
+  pod=$(kubectl get pod -n "$FACTORY_NS" --context "$FACTORY_CTX" -l 'app in (shared-db, shared-db-dev)' -o name 2>/dev/null | head -1)
+  if [[ -z "$pod" ]]; then echo '{"error":"no shared-db pod found"}' >&2; exit 2; fi
+  echo "$pod"
+}
+
+# factory_psql — reads SQL from stdin, returns tab-less single-column rows.
+# Forwards any extra args to psql (e.g. -v ext_id=… for bound params), mirroring
+# ticket.sh's _exec_sql so callers can avoid interpolating into SQL.
+factory_psql() {
+  local pod; pod=$(factory_pgpod)
+  kubectl exec -i "$pod" -n "$FACTORY_NS" --context "$FACTORY_CTX" -c postgres -- \
+    psql -U website -d website -qtA -v ON_ERROR_STOP=1 "$@"
+}

--- a/scripts/factory/metrics.sh
+++ b/scripts/factory/metrics.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# scripts/factory/metrics.sh — summarize factory throughput for a brand and post
+# it as a comment on the Vorhaben ticket (default T000413).
+#   BRAND=<brand> FACTORY_METRICS_TICKET=T000413 bash scripts/factory/metrics.sh
+# Reads the latest v_factory_metrics row + a live slot/queue snapshot, formats a
+# short markdown summary, and appends it via ticket.sh add-comment (best-effort:
+# a missing ticket in a brand's DB is a silent no-op).
+set -euo pipefail
+HERE="$(dirname "${BASH_SOURCE[0]}")"
+source "$HERE/lib.sh"
+factory_resolve
+[[ -n "${FACTORY_DRY_RESOLVE:-}" ]] && { echo "resolved: ctx=${FACTORY_CTX} ns=${FACTORY_NS}"; exit 0; }
+TICKET="${FACTORY_METRICS_TICKET:-T000413}"
+
+today=$(cat <<'SQL' | factory_psql
+SELECT COALESCE(
+  (SELECT format('shipped=%s avg_cycle_h=%s escalations=%s total_features=%s',
+     features_shipped, COALESCE(avg_cycle_time_h::text,'n/a'), escalations, total_features)
+   FROM tickets.v_factory_metrics ORDER BY day DESC LIMIT 1),
+  'no metrics yet');
+SQL
+)
+active=$(printf "SELECT count(*) FROM tickets.tickets WHERE type='feature' AND status='in_progress';" | factory_psql)
+backlog=$(printf "SELECT count(*) FROM tickets.tickets WHERE type='feature' AND status='backlog';" | factory_psql)
+
+body=$(printf '**Factory metrics — %s**\n- %s\n- active(in_progress)=%s backlog=%s' "$BRAND" "$today" "$active" "$backlog")
+BRAND="$BRAND" TICKET_CTX="$FACTORY_CTX" bash "$HERE/../ticket.sh" add-comment --id "$TICKET" --body "$body"
+echo "$body"

--- a/scripts/factory/pipeline.js
+++ b/scripts/factory/pipeline.js
@@ -50,7 +50,6 @@ export const meta = {
 const A = args ?? {}
 const slug = A.slug
 const brand = A.brand ?? 'mentolder'
-const ENV = brand === 'korczewski' ? 'korczewski' : 'mentolder'  // used in Deploy phase
 const REPO = '/home/patrick/Bachelorprojekt'
 const WT = `/tmp/wt-${slug}`
 
@@ -216,7 +215,7 @@ if (!isSimple && tasks.length) {
        Return a summary of the diff and the local test result (pass/fail).`,
       { label: `impl:${t.id}`, phase: 'Implement', isolation: 'worktree' },
     ),
-    (res, t) => agent(
+    (_res, t) => agent(
       `Self-verify task ${t.id}: re-read the implementation diff and confirm that each
        acceptance criterion is met: ${t.acceptance_criteria.join('; ')}.
        Report pass/fail for each criterion.`,

--- a/scripts/factory/pipeline.js
+++ b/scripts/factory/pipeline.js
@@ -5,7 +5,7 @@
  *
  * CRITICAL: This is a Workflow script run by the Claude Code harness Workflow tool.
  * The globals `agent`, `parallel`, `pipeline`, `phase`, `log`, `args` are
- * HARNESS-INJECTED — do NOT run this with `node scripts/factory/pipeline.js`.
+ * HARNESS-INJECTED top-level globals — do NOT run this with `node scripts/factory/pipeline.js`.
  *
  * Offline lint only: `node --check scripts/factory/pipeline.js`
  * Contract tests:    `./tests/runner.sh local FA-SF-20`
@@ -35,258 +35,258 @@ export const meta = {
   ],
 }
 
-/**
- * Main pipeline function — called by the harness with injected globals.
- * Wrapped in an async function so `return` and `await` are syntactically valid
- * for `node --check` while still supporting harness-driven execution.
- *
- * @param {object} args        - args.timestamp (never Date.now()), args.slug, etc.
- * @param {object} harness     - { agent, parallel, pipeline, phase, log } from harness
- */
-export async function run(args, harness) {
-  const { agent, parallel, pipeline, phase, log } = harness
+// Top-level globals injected by the harness: agent, parallel, pipeline, phase, log, args.
+// args.timestamp (never Date.now()), args.slug, args.title, args.description, args.ticket_id, args.brand.
 
-  // ─── Config ──────────────────────────────────────────────────────────────
+// Pipeline body runs as a top-level async IIFE so that:
+//   • `return` is syntactically valid (node --check passes)
+//   • `await` is valid at the call sites
+//   • harness-injected globals (agent, parallel, pipeline, phase, log, args)
+//     are in scope without any destructuring from a harness param
+;(async () => {
 
-  const A = args ?? {}
-  const slug = A.slug
-  const brand = A.brand ?? 'mentolder'
-  const ENV = brand === 'korczewski' ? 'korczewski' : 'mentolder'  // used in Deploy phase
-  const REPO = '/home/patrick/Bachelorprojekt'
-  const WT = `/tmp/wt-${slug}`
+// ─── Config ──────────────────────────────────────────────────────────────
 
-  // JSON schemas for structured agent outputs
-  const SCOUT_SCHEMA = {
-    type: 'object',
-    required: ['complexity', 'touched_files', 'risk_areas', 'similar_tickets', 'estimated_slots'],
-    properties: {
-      complexity: { enum: ['simple', 'medium', 'complex'] },
-      touched_files: { type: 'array', items: { type: 'string' } },
-      risk_areas: { type: 'array', items: { type: 'string' } },
-      similar_tickets: { type: 'array', items: { type: 'string' } },
-      estimated_slots: { type: 'integer' },
-    },
-  }
-  const REVIEW_SCHEMA = {
-    type: 'object',
-    required: ['findings'],
-    properties: {
-      findings: {
-        type: 'array',
-        items: {
-          type: 'object',
-          required: ['severity', 'file', 'description'],
-          properties: {
-            severity: { enum: ['low', 'medium', 'high', 'critical'] },
-            file: { type: 'string' },
-            line: { type: 'integer' },
-            description: { type: 'string' },
-            suggested_fix: { type: 'string' },
-          },
+const A = args ?? {}
+const slug = A.slug
+const brand = A.brand ?? 'mentolder'
+const ENV = brand === 'korczewski' ? 'korczewski' : 'mentolder'  // used in Deploy phase
+const REPO = '/home/patrick/Bachelorprojekt'
+const WT = `/tmp/wt-${slug}`
+
+// JSON schemas for structured agent outputs
+const SCOUT_SCHEMA = {
+  type: 'object',
+  required: ['complexity', 'touched_files', 'risk_areas', 'similar_tickets', 'estimated_slots'],
+  properties: {
+    complexity: { enum: ['simple', 'medium', 'complex'] },
+    touched_files: { type: 'array', items: { type: 'string' } },
+    risk_areas: { type: 'array', items: { type: 'string' } },
+    similar_tickets: { type: 'array', items: { type: 'string' } },
+    estimated_slots: { type: 'integer' },
+  },
+}
+const REVIEW_SCHEMA = {
+  type: 'object',
+  required: ['findings'],
+  properties: {
+    findings: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['severity', 'file', 'description'],
+        properties: {
+          severity: { enum: ['low', 'medium', 'high', 'critical'] },
+          file: { type: 'string' },
+          line: { type: 'integer' },
+          description: { type: 'string' },
+          suggested_fix: { type: 'string' },
         },
       },
-      summary: { type: 'string' },
     },
+    summary: { type: 'string' },
+  },
+}
+
+// ── ① Scout ────────────────────────────────────────────────────────────────
+phase('Scout')
+const scout = await agent(
+  `Record pipeline liveness first so the dispatcher watchdog does not flag this run as stale: run \`bash ${REPO}/scripts/ticket.sh touch --id ${A.ticket_id}\`. Then:
+   Scout the feature "${A.title}" against the codebase at ${REPO}.
+   Description: ${A.description}.
+
+   1. Read the scout template at ${REPO}/scripts/factory/templates/scout-template.md.
+   2. Find similar past tickets by running:
+      \`cd ${REPO}/website && npx tsx scripts/find-similar-tickets.mjs "${A.title} ${A.description}" 5\`
+      (fail-soft: [] is fine if the DB is empty or the GPU host is down).
+   3. Identify which files this feature will edit (touched_files), the complexity
+      (simple/medium/complex), risk_areas, and estimated_slots.
+
+   Return a JSON object matching the scout schema.`,
+  { label: 'scout', phase: 'Scout', schema: SCOUT_SCHEMA },
+)
+
+// Persist touched_files back onto the ticket via ticket.sh (NO raw SQL).
+log(`Scout: complexity=${scout.complexity}, ${scout.touched_files.length} touched files`)
+await agent(
+  `Run the following command to record which files this feature touches on the ticket:
+   bash ${REPO}/scripts/ticket.sh set-touched-files --id ${A.ticket_id} --files ${JSON.stringify(scout.touched_files.join(','))}
+   If the set-touched-files subcommand does not exist, fall back to:
+   bash ${REPO}/scripts/ticket.sh update --id ${A.ticket_id} --touched-files ${JSON.stringify(scout.touched_files.join(','))}
+   Report the command output.`,
+  { label: 'scout:persist', phase: 'Scout' },
+)
+
+// SIMPLE features skip Design/Plan/Implement and go straight to Verify→Deploy.
+const isSimple = scout.complexity === 'simple'
+
+// ── ② Design ───────────────────────────────────────────────────────────────
+let specPath = null
+if (!isSimple) {
+  phase('Design')
+  const design = await agent(
+    `Record pipeline liveness first so the dispatcher watchdog does not flag this run as stale: run \`bash ${REPO}/scripts/ticket.sh touch --id ${A.ticket_id}\`. Then:
+     Write a design spec for "${A.title}" following the structure in
+     ${REPO}/scripts/factory/templates/design-template.md (if it exists) or using standard
+     ARCH/GOALS/RISKS/DECISIONS structure. For medium/complex, include an adversarial
+     "try to refute this design" section.
+
+     Save the spec to: ${REPO}/docs/superpowers/specs/${A.timestamp}-${slug}-design.md
+
+     Then attach it to the ticket:
+     bash ${REPO}/scripts/ticket-attach.sh <uuid> <specfile>
+
+     Return the spec file path (just the path, nothing else).`,
+    { label: 'design', phase: 'Design' },
+  )
+  specPath = design.trim()
+}
+
+// ── ③ Plan (with conflict gate) ────────────────────────────────────────────
+let tasks = []
+if (!isSimple) {
+  phase('Plan')
+  // Brand-aware disjoint-files gate BEFORE fanning tasks.
+  const conflict = await agent(
+    `Record pipeline liveness first so the dispatcher watchdog does not flag this run as stale: run \`bash ${REPO}/scripts/ticket.sh touch --id ${A.ticket_id}\`. Then:
+     Run the brand-aware conflict gate to ensure no active feature is already touching
+     the files this feature needs to edit:
+     BRAND=${brand} bash ${REPO}/scripts/factory/conflict-check.sh ${A.ticket_id} ${scout.touched_files.join(' ')}
+
+     Report the exact stdout JSON and the exit code.
+     Exit 0 = no conflicts (proceed). Exit 1 = conflicts found (STOP). Exit 2 = error.`,
+    { label: 'plan:conflict', phase: 'Plan' },
+  )
+  if (/\"T0/.test(conflict)) {
+    log(`Conflict detected: ${conflict}`)
+    return { status: 'blocked', reason: 'file-overlap', conflict }
   }
 
-  // ── ① Scout ────────────────────────────────────────────────────────────────
-  phase('Scout')
-  const scout = await agent(
-    `Scout the feature "${A.title}" against the codebase at ${REPO}.
-     Description: ${A.description}.
+  const plan = await agent(
+    `Decompose the spec at ${specPath} into independent tasks where no two tasks
+     touch the same file. For each task provide: id, target_files (array),
+     acceptance_criteria (array of strings).
 
-     1. Read the scout template at ${REPO}/scripts/factory/templates/scout-template.md.
-     2. Find similar past tickets by running:
-        \`cd ${REPO}/website && npx tsx scripts/find-similar-tickets.mjs "${A.title} ${A.description}" 5\`
-        (fail-soft: [] is fine if the DB is empty or the GPU host is down).
-     3. Identify which files this feature will edit (touched_files), the complexity
-        (simple/medium/complex), risk_areas, and estimated_slots.
+     Write the full plan to:
+     ${REPO}/docs/superpowers/plans/${A.timestamp}-${slug}.md
 
-     Return a JSON object matching the scout schema.`,
-    { label: 'scout', phase: 'Scout', schema: SCOUT_SCHEMA },
-  )
+     Then run the frontmatter hook:
+     bash ${REPO}/scripts/plan-frontmatter-hook.sh ${REPO}/docs/superpowers/plans/${A.timestamp}-${slug}.md
 
-  // Persist touched_files back onto the ticket via ticket.sh (NO raw SQL).
-  log(`Scout: complexity=${scout.complexity}, ${scout.touched_files.length} touched files`)
-  await agent(
-    `Run the following command to record which files this feature touches on the ticket:
-     bash ${REPO}/scripts/ticket.sh set-touched-files --id ${A.ticket_id} --files ${JSON.stringify(scout.touched_files.join(','))}
-     If the set-touched-files subcommand does not exist, fall back to:
-     bash ${REPO}/scripts/ticket.sh update --id ${A.ticket_id} --touched-files ${JSON.stringify(scout.touched_files.join(','))}
-     Report the command output.`,
-    { label: 'scout:persist', phase: 'Scout' },
-  )
-
-  // SIMPLE features skip Design/Plan/Implement and go straight to Verify→Deploy.
-  const isSimple = scout.complexity === 'simple'
-
-  // ── ② Design ───────────────────────────────────────────────────────────────
-  let specPath = null
-  if (!isSimple) {
-    phase('Design')
-    const design = await agent(
-      `Write a design spec for "${A.title}" following the structure in
-       ${REPO}/scripts/factory/templates/design-template.md (if it exists) or using standard
-       ARCH/GOALS/RISKS/DECISIONS structure. For medium/complex, include an adversarial
-       "try to refute this design" section.
-
-       Save the spec to: ${REPO}/docs/superpowers/specs/${A.timestamp}-${slug}-design.md
-
-       Then attach it to the ticket:
-       bash ${REPO}/scripts/ticket-attach.sh <uuid> <specfile>
-
-       Return the spec file path (just the path, nothing else).`,
-      { label: 'design', phase: 'Design' },
-    )
-    specPath = design.trim()
-  }
-
-  // ── ③ Plan (with conflict gate) ────────────────────────────────────────────
-  let tasks = []
-  if (!isSimple) {
-    phase('Plan')
-    // Brand-aware disjoint-files gate BEFORE fanning tasks.
-    const conflict = await agent(
-      `Run the brand-aware conflict gate to ensure no active feature is already touching
-       the files this feature needs to edit:
-       BRAND=${brand} bash ${REPO}/scripts/factory/conflict-check.sh ${A.ticket_id} ${scout.touched_files.join(' ')}
-
-       Report the exact stdout JSON and the exit code.
-       Exit 0 = no conflicts (proceed). Exit 1 = conflicts found (STOP). Exit 2 = error.`,
-      { label: 'plan:conflict', phase: 'Plan' },
-    )
-    if (/\"T0/.test(conflict)) {
-      log(`Conflict detected: ${conflict}`)
-      return { status: 'blocked', reason: 'file-overlap', conflict }
-    }
-
-    const plan = await agent(
-      `Decompose the spec at ${specPath} into independent tasks where no two tasks
-       touch the same file. For each task provide: id, target_files (array),
-       acceptance_criteria (array of strings).
-
-       Write the full plan to:
-       ${REPO}/docs/superpowers/plans/${A.timestamp}-${slug}.md
-
-       Then run the frontmatter hook:
-       bash ${REPO}/scripts/plan-frontmatter-hook.sh ${REPO}/docs/superpowers/plans/${A.timestamp}-${slug}.md
-
-       Return a JSON object { tasks: [...] } matching the task schema.`,
-      {
-        label: 'plan:decompose',
-        phase: 'Plan',
-        schema: {
-          type: 'object',
-          required: ['tasks'],
-          properties: {
-            tasks: {
-              type: 'array',
-              items: {
-                type: 'object',
-                required: ['id', 'target_files', 'acceptance_criteria'],
-                properties: {
-                  id: { type: 'string' },
-                  target_files: { type: 'array', items: { type: 'string' } },
-                  acceptance_criteria: { type: 'array', items: { type: 'string' } },
-                },
+     Return a JSON object { tasks: [...] } matching the task schema.`,
+    {
+      label: 'plan:decompose',
+      phase: 'Plan',
+      schema: {
+        type: 'object',
+        required: ['tasks'],
+        properties: {
+          tasks: {
+            type: 'array',
+            items: {
+              type: 'object',
+              required: ['id', 'target_files', 'acceptance_criteria'],
+              properties: {
+                id: { type: 'string' },
+                target_files: { type: 'array', items: { type: 'string' } },
+                acceptance_criteria: { type: 'array', items: { type: 'string' } },
               },
             },
           },
         },
       },
-    )
-    tasks = plan.tasks
-  }
-
-  // ── ④ Implement (N parallel tasks, isolated worktrees) ─────────────────────
-  let implemented = []
-  if (!isSimple && tasks.length) {
-    phase('Implement')
-    implemented = (await pipeline(
-      tasks,
-      (t) => agent(
-        `Implement task ${t.id} on branch feature/${slug} in an isolated worktree at ${WT}.
-         Target files: ${t.target_files.join(', ')}.
-         Follow TDD (red-green). Acceptance criteria: ${t.acceptance_criteria.join('; ')}.
-         After implementing, run locally:
-           cd ${WT} && task workspace:validate && task test:all
-         Return a summary of the diff and the local test result (pass/fail).`,
-        { label: `impl:${t.id}`, phase: 'Implement', isolation: 'worktree' },
-      ),
-      (res, t) => agent(
-        `Self-verify task ${t.id}: re-read the implementation diff and confirm that each
-         acceptance criterion is met: ${t.acceptance_criteria.join('; ')}.
-         Report pass/fail for each criterion.`,
-        { label: `impl-verify:${t.id}`, phase: 'Implement' },
-      ),
-    )).filter(Boolean)
-  }
-
-  // ── ⑤ Verify (adversarial review panel — three parallel lenses) ────────────
-  phase('Verify')
-  const lenses = [
-    { key: 'bug',      file: 'scripts/factory/review-bug-hunter.prompt.md' },
-    { key: 'security', file: 'scripts/factory/review-security-auditor.prompt.md' },
-    { key: 'pattern',  file: 'scripts/factory/review-pattern-enforcer.prompt.md' },
-  ]
-  const reviews = (await parallel(
-    lenses.map((l) => () => agent(
-      `Read the review prompt at ${REPO}/${l.file} and apply it to the diff of
-       branch feature/${slug} (run: git diff origin/main...HEAD in ${REPO}).
-       Return your findings as JSON matching the review schema.`,
-      { label: `review:${l.key}`, phase: 'Verify', schema: REVIEW_SCHEMA },
-    )),
-  )).filter(Boolean)
-
-  const blocking = reviews.flatMap((r) => r.findings).filter((f) => f.severity === 'high' || f.severity === 'critical')
-  if (blocking.length) {
-    await agent(
-      `The adversarial review panel found HIGH/CRITICAL findings that block merge.
-       Run these commands to record the block:
-       bash ${REPO}/scripts/ticket.sh update-status --id ${A.ticket_id} --status blocked
-       bash ${REPO}/scripts/ticket.sh add-comment --id ${A.ticket_id} \
-         --body ${JSON.stringify('Factory Verify blocked: ' + JSON.stringify(blocking))}
-       Report the command outputs.`,
-      { label: 'verify:escalate', phase: 'Verify' },
-    )
-    return { status: 'blocked', reason: 'review-findings', blocking }
-  }
-
-  // ── ⑥ Deploy (auto-merge on green CI + both-brand explicit deploy) ──────────
-  phase('Deploy')
-  const deploy = await agent(
-    `Deploy the feature to both brands. Operate from the MAIN repo at ${REPO}
-     (NOT the worktree ${WT}) to avoid gotcha T000342 (merge conflicts from wrong CWD).
-
-     Steps:
-     1. Push branch feature/${slug} to origin:
-        cd ${REPO} && git push -u origin feature/${slug}
-     2. Open a PR (if not open):
-        gh pr create --title "feat(${slug}): ${A.title}" --base main
-     3. Wait for CI to go green. If CI is red after 2 fix attempts, set the ticket
-        to blocked and STOP.
-     4. Squash-merge (from ${REPO}, NOT the worktree):
-        cd ${REPO} && gh pr merge --squash --delete-branch
-     5. Close the ticket and archive the plan:
-        bash ${REPO}/scripts/ticket.sh update-status --id ${A.ticket_id} --status done --resolution shipped
-        bash ${REPO}/scripts/ticket.sh archive-plan --id ${A.ticket_id} --slug ${slug} \
-          --branch feature/${slug} --plan-file ${REPO}/docs/superpowers/plans/${A.timestamp}-${slug}.md
-     6. Deploy BOTH brands explicitly (fleet cluster, push-based — no GitOps reconciler):
-        Website changes: task feature:website (auto-rolls out via CI for both brands)
-        K8s/manifest changes: task workspace:deploy ENV=mentolder && task workspace:deploy ENV=korczewski
-        (Or use the umbrella if available: task feature:deploy)
-     7. Verify rollout on both brands:
-        kubectl --context fleet rollout status deployment/website -n website --timeout=300s
-        kubectl --context fleet rollout status deployment/website -n website-korczewski --timeout=300s
-
-     Report the merged PR number and the deploy command outputs.`,
-    { label: 'deploy', phase: 'Deploy' },
+    },
   )
-
-  return { status: 'done', pr: deploy, reviews: reviews.length, tasks: tasks.length, implemented: implemented.length }
+  tasks = plan.tasks
 }
 
-// The harness calls run(args, { agent, parallel, pipeline, phase, log }).
-// For backward-compat with harness versions that call the script body directly,
-// we also expose the run function as the default export.
-export default run
+// ── ④ Implement (N parallel tasks, isolated worktrees) ─────────────────────
+let implemented = []
+if (!isSimple && tasks.length) {
+  phase('Implement')
+  implemented = (await pipeline(
+    tasks,
+    (t) => agent(
+      `Record pipeline liveness first so the dispatcher watchdog does not flag this run as stale: run \`bash ${REPO}/scripts/ticket.sh touch --id ${A.ticket_id}\`. Then:
+       Implement task ${t.id} on branch feature/${slug} in an isolated worktree at ${WT}.
+       Target files: ${t.target_files.join(', ')}.
+       Follow TDD (red-green). Acceptance criteria: ${t.acceptance_criteria.join('; ')}.
+       After implementing, run locally:
+         cd ${WT} && task workspace:validate && task test:all
+       Return a summary of the diff and the local test result (pass/fail).`,
+      { label: `impl:${t.id}`, phase: 'Implement', isolation: 'worktree' },
+    ),
+    (res, t) => agent(
+      `Self-verify task ${t.id}: re-read the implementation diff and confirm that each
+       acceptance criterion is met: ${t.acceptance_criteria.join('; ')}.
+       Report pass/fail for each criterion.`,
+      { label: `impl-verify:${t.id}`, phase: 'Implement' },
+    ),
+  )).filter(Boolean)
+}
+
+// ── ⑤ Verify (adversarial review panel — three parallel lenses) ────────────
+phase('Verify')
+const lenses = [
+  { key: 'bug',      file: 'scripts/factory/review-bug-hunter.prompt.md' },
+  { key: 'security', file: 'scripts/factory/review-security-auditor.prompt.md' },
+  { key: 'pattern',  file: 'scripts/factory/review-pattern-enforcer.prompt.md' },
+]
+const reviews = (await parallel(
+  lenses.map((l) => () => agent(
+    `Record pipeline liveness first so the dispatcher watchdog does not flag this run as stale: run \`bash ${REPO}/scripts/ticket.sh touch --id ${A.ticket_id}\`. Then:
+     Read the review prompt at ${REPO}/${l.file} and apply it to the diff of
+     branch feature/${slug} (run: git diff origin/main...HEAD in ${REPO}).
+     Return your findings as JSON matching the review schema.`,
+    { label: `review:${l.key}`, phase: 'Verify', schema: REVIEW_SCHEMA },
+  )),
+)).filter(Boolean)
+
+const blocking = reviews.flatMap((r) => r.findings).filter((f) => f.severity === 'high' || f.severity === 'critical')
+if (blocking.length) {
+  await agent(
+    `The adversarial review panel found HIGH/CRITICAL findings that block merge.
+     Run these commands to record the block:
+     bash ${REPO}/scripts/ticket.sh update-status --id ${A.ticket_id} --status blocked
+     bash ${REPO}/scripts/ticket.sh add-comment --id ${A.ticket_id} \
+       --body ${JSON.stringify('Factory Verify blocked: ' + JSON.stringify(blocking))}
+     Report the command outputs.`,
+    { label: 'verify:escalate', phase: 'Verify' },
+  )
+  return { status: 'blocked', reason: 'review-findings', blocking }
+}
+
+// ── ⑥ Deploy (auto-merge on green CI + both-brand explicit deploy) ──────────
+phase('Deploy')
+const deploy = await agent(
+  `Record pipeline liveness first so the dispatcher watchdog does not flag this run as stale: run \`bash ${REPO}/scripts/ticket.sh touch --id ${A.ticket_id}\`. Then:
+   Deploy the feature to both brands. Operate from the MAIN repo at ${REPO}
+   (NOT the worktree ${WT}) to avoid gotcha T000342 (merge conflicts from wrong CWD).
+
+   Steps:
+   1. Push branch feature/${slug} to origin:
+      cd ${REPO} && git push -u origin feature/${slug}
+   2. Open a PR (if not open):
+      gh pr create --title "feat(${slug}): ${A.title}" --base main
+   3. Wait for CI to go green. If CI is red after 2 fix attempts, set the ticket
+      to blocked and STOP.
+   4. Squash-merge (from ${REPO}, NOT the worktree):
+      cd ${REPO} && gh pr merge --squash --delete-branch
+   5. Close the ticket and archive the plan:
+      bash ${REPO}/scripts/ticket.sh update-status --id ${A.ticket_id} --status done --resolution shipped
+      bash ${REPO}/scripts/ticket.sh archive-plan --id ${A.ticket_id} --slug ${slug} \
+        --branch feature/${slug} --plan-file ${REPO}/docs/superpowers/plans/${A.timestamp}-${slug}.md
+   6. Deploy BOTH brands explicitly (fleet cluster, push-based — no GitOps reconciler):
+      Website changes: task feature:website (auto-rolls out via CI for both brands)
+      K8s/manifest changes: task workspace:deploy ENV=mentolder && task workspace:deploy ENV=korczewski
+      (Or use the umbrella if available: task feature:deploy)
+   7. Verify rollout on both brands:
+      kubectl --context fleet rollout status deployment/website -n website --timeout=300s
+      kubectl --context fleet rollout status deployment/website -n website-korczewski --timeout=300s
+
+   Report the merged PR number and the deploy command outputs.`,
+  { label: 'deploy', phase: 'Deploy' },
+)
+
+return { status: 'done', pr: deploy, reviews: reviews.length, tasks: tasks.length, implemented: implemented.length }
+})()

--- a/scripts/factory/queue.sh
+++ b/scripts/factory/queue.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# scripts/factory/queue.sh — schedulable backlog feature tickets for a brand.
+#   BRAND=<brand> bash scripts/factory/queue.sh
+# Reads RAW backlog features (touched_files may be NULL — a fresh feature gets
+# its touched_files inside the pipeline's Scout phase, so v_active_features
+# (which filters NULL touched_files) is NOT used here). JSON array, ordered
+# priority (hoch→mittel→niedrig) then created_at. Read-only metadata only.
+set -euo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+factory_resolve
+[[ -n "${FACTORY_DRY_RESOLVE:-}" ]] && { echo "resolved: ctx=${FACTORY_CTX} ns=${FACTORY_NS}"; exit 0; }
+cat <<'SQL' | factory_psql
+SELECT COALESCE(json_agg(row_to_json(q)), '[]')
+FROM (
+  SELECT external_id, title, priority, touched_files, created_at
+  FROM tickets.tickets
+  WHERE type='feature' AND status='backlog'
+  ORDER BY CASE priority WHEN 'hoch' THEN 1 WHEN 'mittel' THEN 2 WHEN 'niedrig' THEN 3 END, created_at
+) q;
+SQL

--- a/scripts/factory/schedule.sh
+++ b/scripts/factory/schedule.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# scripts/factory/schedule.sh — poll the queue for a brand, run the best-effort
+# brand-aware conflict gate on KNOWN touched_files, claim a slot per
+# non-conflicting feature up to the per-brand pool AND a global concurrency cap
+# (summed across both brands), and emit the launch plan as JSON:
+#   [{ "brand": "...", "external_id": "...", "slot": N }]
+#
+#   BRAND=<brand> FACTORY_GLOBAL_CAP=3 bash scripts/factory/schedule.sh
+#
+# The AUTHORITATIVE conflict gate is pipeline.js' Plan phase (③). This is a
+# pre-filter on already-known touched_files; a fresh feature (NULL touched_files,
+# conflict-check exits 2 = "no known conflict") schedules and self-corrects if
+# the pipeline's own gate later blocks it.
+set -euo pipefail
+HERE="$(dirname "${BASH_SOURCE[0]}")"
+source "$HERE/lib.sh"
+factory_resolve
+[[ -n "${FACTORY_DRY_RESOLVE:-}" ]] && { echo "resolved: ctx=${FACTORY_CTX} ns=${FACTORY_NS}"; exit 0; }
+
+GLOBAL_CAP="${FACTORY_GLOBAL_CAP:-3}"
+
+# Global concurrency = occupied slots across BOTH brands (separate DBs).
+global_used=0
+for b in mentolder korczewski; do
+  n=$(BRAND="$b" FACTORY_CTX="$FACTORY_CTX" bash "$HERE/slots.sh" count 2>/dev/null || echo 0)
+  global_used=$((global_used + ${n:-0}))
+done
+
+plan='[]'
+mapfile -t candidates < <(BRAND="$BRAND" FACTORY_CTX="$FACTORY_CTX" bash "$HERE/queue.sh" | jq -c '.[]')
+for c in "${candidates[@]}"; do
+  [[ -z "$c" ]] && continue
+  [[ "$global_used" -ge "$GLOBAL_CAP" ]] && break
+  ext_id=$(echo "$c" | jq -r '.external_id')
+
+  # Best-effort conflict gate on known touched_files. rc 0 = no conflict,
+  # rc 1 = conflict (skip), rc 2 = error/null touched_files (treat as schedulable).
+  set +e
+  BRAND="$BRAND" FACTORY_CTX="$FACTORY_CTX" bash "$HERE/conflict-check.sh" "$ext_id" >/dev/null 2>&1
+  rc=$?
+  set -e
+  [[ "$rc" -eq 1 ]] && continue
+
+  slot=$(BRAND="$BRAND" FACTORY_CTX="$FACTORY_CTX" bash "$HERE/slots.sh" next)
+  [[ -z "$slot" ]] && continue   # brand pool full
+
+  if BRAND="$BRAND" FACTORY_CTX="$FACTORY_CTX" bash "$HERE/slots.sh" claim "$ext_id" "$slot" >/dev/null 2>&1; then
+    plan=$(echo "$plan" | jq -c --arg b "$BRAND" --arg e "$ext_id" --argjson s "$slot" '. + [{brand:$b, external_id:$e, slot:$s}]')
+    global_used=$((global_used + 1))
+  fi
+done
+echo "$plan"

--- a/scripts/factory/slots.sh
+++ b/scripts/factory/slots.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# scripts/factory/slots.sh — per-brand slot accounting for the Dispatcher.
+#   BRAND=<brand> bash scripts/factory/slots.sh count                # occupied slots (this brand)
+#   BRAND=<brand> bash scripts/factory/slots.sh next                 # lowest free slot 1..N, or empty if full
+#   BRAND=<brand> bash scripts/factory/slots.sh claim <ext_id> <n>   # atomic; echoes n on success
+#   BRAND=<brand> bash scripts/factory/slots.sh release <ext_id>
+# Slots are 1..FACTORY_SLOTS_PER_BRAND (default 3). claim only succeeds if the
+# feature has no slot yet (UPDATE ... WHERE pipeline_slot IS NULL) — race-free.
+# Exit 0 ok, 1 claim-failed, 2 error.
+set -euo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+factory_resolve
+[[ -n "${FACTORY_DRY_RESOLVE:-}" ]] && { echo "resolved: ctx=${FACTORY_CTX} ns=${FACTORY_NS}"; exit 0; }
+
+SLOTS_PER_BRAND="${FACTORY_SLOTS_PER_BRAND:-3}"
+cmd="${1:-}"; shift || true
+
+case "$cmd" in
+  count)
+    printf "SELECT count(*) FROM tickets.tickets WHERE pipeline_slot IS NOT NULL AND status='in_progress';" | factory_psql
+    ;;
+  next)
+    printf "WITH used AS (SELECT pipeline_slot FROM tickets.tickets WHERE pipeline_slot IS NOT NULL AND status='in_progress'), s AS (SELECT generate_series(1,%s) AS n) SELECT min(n) FROM s WHERE n NOT IN (SELECT pipeline_slot FROM used);" "$SLOTS_PER_BRAND" | factory_psql
+    ;;
+  claim)
+    ext_id="${1:?usage: claim <ext_id> <slot>}"; slot="${2:?usage: claim <ext_id> <slot>}"
+    out=$(printf '%s' "UPDATE tickets.tickets SET pipeline_slot = :'slot'::integer, status='in_progress' WHERE external_id = :'ext_id' AND pipeline_slot IS NULL AND status IN ('backlog','triage') RETURNING pipeline_slot;" | factory_psql -v ext_id="$ext_id" -v slot="$slot")
+    if [[ -z "$out" ]]; then echo "claim failed (already slotted or wrong status): $ext_id" >&2; exit 1; fi
+    echo "$out"
+    ;;
+  release)
+    ext_id="${1:?usage: release <ext_id>}"
+    printf '%s' "UPDATE tickets.tickets SET pipeline_slot=NULL WHERE external_id = :'ext_id';" | factory_psql -v ext_id="$ext_id" >/dev/null
+    echo "released $ext_id"
+    ;;
+  *) echo '{"error":"usage: slots.sh count|next|claim|release [...]"}' >&2; exit 2 ;;
+esac

--- a/scripts/factory/watchdog.sh
+++ b/scripts/factory/watchdog.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# scripts/factory/watchdog.sh — escalate stale in-flight features for a brand.
+#   BRAND=<brand> FACTORY_STALE_MIN=30 bash scripts/factory/watchdog.sh
+# A feature in_progress whose updated_at is older than the threshold is treated
+# as a hung/crashed pipeline: status → triage (back to queue), slot released, and
+# a comment recorded. updated_at is auto-bumped by fn_lifecycle_ts on every row
+# write; pipeline.js writes a `ticket.sh touch` at each phase boundary, so a
+# healthy long phase is not mistaken for stale. JSON array of escalated ext_ids.
+set -euo pipefail
+HERE="$(dirname "${BASH_SOURCE[0]}")"
+source "$HERE/lib.sh"
+factory_resolve
+[[ -n "${FACTORY_DRY_RESOLVE:-}" ]] && { echo "resolved: ctx=${FACTORY_CTX} ns=${FACTORY_NS}"; exit 0; }
+STALE_MIN="${FACTORY_STALE_MIN:-30}"
+
+mapfile -t stale < <(printf "SELECT external_id FROM tickets.tickets WHERE type='feature' AND status='in_progress' AND updated_at < now() - make_interval(mins => %s);" "$STALE_MIN" | factory_psql)
+
+escalated='[]'
+for ext_id in "${stale[@]}"; do
+  [[ -z "$ext_id" ]] && continue
+  BRAND="$BRAND" TICKET_CTX="$FACTORY_CTX" bash "$HERE/../ticket.sh" update-status --id "$ext_id" --status triage >/dev/null
+  BRAND="$BRAND" TICKET_CTX="$FACTORY_CTX" bash "$HERE/../ticket.sh" release-slot --id "$ext_id" >/dev/null
+  BRAND="$BRAND" TICKET_CTX="$FACTORY_CTX" bash "$HERE/../ticket.sh" add-comment --id "$ext_id" \
+    --body "Watchdog: pipeline stale > ${STALE_MIN}min (no phase progress write). Returned to queue (triage); slot released." >/dev/null
+  escalated=$(echo "$escalated" | jq -c --arg e "$ext_id" '. + [$e]')
+done
+echo "$escalated"

--- a/scripts/ticket.sh
+++ b/scripts/ticket.sh
@@ -2,11 +2,16 @@
 # scripts/ticket.sh — unified CLI helper for ticket database operations.
 #
 # Commands:
-#   create --type <type> --title <title> --description <description> [--brand <brand>] [--severity <severity>] [--priority <priority>]
+#   create --type <type> --title <title> --description <description> [--brand <brand>] [--severity <severity>] [--priority <priority>] [--is-test-data]
 #   update-status --id <external_id> --status <status> [--resolution <resolution>] [--notes <notes>]
 #   add-comment --id <external_id> --body <body> [--author <author_label>] [--visibility <visibility>]
 #   archive-plan --id <external_id> --slug <slug> --branch <branch> --plan-file <plan_file> [--pr <pr_number>]
 #   get-attachments --id <external_id> --out-dir <out_dir>
+#   get --id <external_id>
+#   set-touched-files --id <external_id> --files <comma-separated-paths>
+#   set-pipeline-slot --id <external_id> --slot <integer|null>
+#   release-slot --id <external_id>
+#   touch --id <external_id>
 
 set -euo pipefail
 
@@ -15,9 +20,18 @@ NS="${TICKET_NS:-workspace}"
 DB="website"
 USER="website"
 
+# Brand → namespace map (mirrors conflict-check.sh). BRAND wins over TICKET_NS so
+# a caller cannot silently hit the wrong brand's prod DB.
+case "${BRAND:-}" in
+  mentolder)   NS="workspace" ;;
+  korczewski)  NS="workspace-korczewski" ;;
+  "")          : ;;  # no BRAND given — keep TICKET_NS default
+  *)           echo "ERROR: unknown BRAND (use mentolder|korczewski)" >&2; exit 2 ;;
+esac
+
 _pgpod() {
   local pod
-  pod=$(kubectl get pod -n "$NS" --context "$CTX" -l app=shared-db -o name 2>/dev/null | head -1)
+  pod=$(kubectl get pod -n "$NS" --context "$CTX" -l 'app in (shared-db, shared-db-dev)' -o name 2>/dev/null | head -1)
   if [[ -z "$pod" ]]; then
     echo "ERROR: no shared-db pod found in namespace $NS (context $CTX)" >&2
     exit 1
@@ -33,7 +47,7 @@ _exec_sql() {
 }
 
 cmd_create() {
-  local type="" title="" desc="" brand="mentolder" severity="" priority="mittel" status="triage"
+  local type="" title="" desc="" brand="mentolder" severity="" priority="mittel" status="triage" is_test="false"
   while [[ $# -gt 0 ]]; do
     case "$1" in
       --type)        type="$2"; shift 2 ;;
@@ -43,6 +57,7 @@ cmd_create() {
       --severity)    severity="$2"; shift 2 ;;
       --priority)    priority="$2"; shift 2 ;;
       --status)      status="$2"; shift 2 ;;
+      --is-test-data) is_test="true"; shift ;;
       *)             echo "Unknown create option: $1" >&2; exit 2 ;;
     esac
   done
@@ -66,9 +81,10 @@ cmd_create() {
     -v desc="$desc" \
     -v status="$status" \
     -v sev="$severity" \
-    -v prio="$priority" <<'EOF'
-INSERT INTO tickets.tickets (type, brand, title, description, status, severity, priority)
-VALUES (:'type', :'brand', :'title', :'desc', :'status', NULLIF(:'sev', ''), :'prio')
+    -v prio="$priority" \
+    -v is_test="$is_test" <<'EOF'
+INSERT INTO tickets.tickets (type, brand, title, description, status, severity, priority, is_test_data)
+VALUES (:'type', :'brand', :'title', :'desc', :'status', NULLIF(:'sev', ''), :'prio', :'is_test'::boolean)
 RETURNING external_id || '|' || id;
 EOF
 }
@@ -286,18 +302,111 @@ EOF
   echo "Successfully downloaded $count attachments for ticket $id."
 }
 
+cmd_get() {
+  local id=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --id) id="$2"; shift 2 ;;
+      *)    echo "Unknown get option: $1" >&2; exit 2 ;;
+    esac
+  done
+  if [[ -z "$id" ]]; then echo "ERROR: --id is required." >&2; exit 2; fi
+  local pod; pod=$(_pgpod)
+  # Metadata only — NEVER select ticket_plans.content.
+  _exec_sql "$pod" -v ext_id="$id" <<'EOF'
+SELECT json_build_object(
+  'external_id', external_id, 'id', id, 'type', type, 'brand', brand,
+  'title', title, 'status', status, 'priority', priority,
+  'touched_files', touched_files, 'pipeline_slot', pipeline_slot,
+  'created_at', created_at, 'updated_at', updated_at
+) FROM tickets.tickets WHERE external_id = :'ext_id';
+EOF
+}
+
+cmd_set_touched_files() {
+  local id="" files=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --id)    id="$2"; shift 2 ;;
+      --files) files="$2"; shift 2 ;;
+      *)       echo "Unknown set-touched-files option: $1" >&2; exit 2 ;;
+    esac
+  done
+  if [[ -z "$id" || -z "$files" ]]; then echo "ERROR: --id and --files are required." >&2; exit 2; fi
+  local pod; pod=$(_pgpod)
+  _exec_sql "$pod" -v ext_id="$id" -v files="$files" <<'EOF' >/dev/null
+UPDATE tickets.tickets SET touched_files = string_to_array(:'files', ',') WHERE external_id = :'ext_id';
+EOF
+  echo "touched_files set for ticket $id"
+}
+
+cmd_set_pipeline_slot() {
+  local id="" slot=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --id)   id="$2"; shift 2 ;;
+      --slot) slot="$2"; shift 2 ;;
+      *)      echo "Unknown set-pipeline-slot option: $1" >&2; exit 2 ;;
+    esac
+  done
+  if [[ -z "$id" || -z "$slot" ]]; then echo "ERROR: --id and --slot are required (use --slot null to clear)." >&2; exit 2; fi
+  local pod; pod=$(_pgpod)
+  _exec_sql "$pod" -v ext_id="$id" -v slot="$slot" <<'EOF' >/dev/null
+UPDATE tickets.tickets SET pipeline_slot = NULLIF(:'slot','null')::integer WHERE external_id = :'ext_id';
+EOF
+  echo "pipeline_slot set to $slot for ticket $id"
+}
+
+cmd_release_slot() {
+  local id=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --id) id="$2"; shift 2 ;;
+      *)    echo "Unknown release-slot option: $1" >&2; exit 2 ;;
+    esac
+  done
+  if [[ -z "$id" ]]; then echo "ERROR: --id is required." >&2; exit 2; fi
+  local pod; pod=$(_pgpod)
+  _exec_sql "$pod" -v ext_id="$id" <<'EOF' >/dev/null
+UPDATE tickets.tickets SET pipeline_slot = NULL WHERE external_id = :'ext_id';
+EOF
+  echo "pipeline_slot released for ticket $id"
+}
+
+cmd_touch() {
+  local id=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --id) id="$2"; shift 2 ;;
+      *)    echo "Unknown touch option: $1" >&2; exit 2 ;;
+    esac
+  done
+  if [[ -z "$id" ]]; then echo "ERROR: --id is required." >&2; exit 2; fi
+  local pod; pod=$(_pgpod)
+  # Bump updated_at (the fn_lifecycle_ts BEFORE-UPDATE trigger sets it on any UPDATE).
+  _exec_sql "$pod" -v ext_id="$id" <<'EOF' >/dev/null
+UPDATE tickets.tickets SET updated_at = now() WHERE external_id = :'ext_id';
+EOF
+  echo "touched ticket $id"
+}
+
 if [[ $# -lt 1 ]]; then
   echo "Usage: $0 <command> [options]" >&2
-  echo "Commands: create, update-status, add-comment, archive-plan, get-attachments" >&2
+  echo "Commands: create, update-status, add-comment, archive-plan, get-attachments, get, set-touched-files, set-pipeline-slot, release-slot, touch" >&2
   exit 1
 fi
 
 cmd="$1"; shift
 case "$cmd" in
-  create)          cmd_create "$@" ;;
-  update-status)   cmd_update_status "$@" ;;
-  add-comment)     cmd_add_comment "$@" ;;
-  archive-plan)    cmd_archive_plan "$@" ;;
-  get-attachments) cmd_get_attachments "$@" ;;
-  *)               echo "Unknown command: $cmd" >&2; exit 1 ;;
+  create)            cmd_create "$@" ;;
+  update-status)     cmd_update_status "$@" ;;
+  add-comment)       cmd_add_comment "$@" ;;
+  archive-plan)      cmd_archive_plan "$@" ;;
+  get-attachments)   cmd_get_attachments "$@" ;;
+  get)               cmd_get "$@" ;;
+  set-touched-files) cmd_set_touched_files "$@" ;;
+  set-pipeline-slot) cmd_set_pipeline_slot "$@" ;;
+  release-slot)      cmd_release_slot "$@" ;;
+  touch)             cmd_touch "$@" ;;
+  *)                 echo "Unknown command: $cmd" >&2; exit 1 ;;
 esac

--- a/tests/lib/factory-test-fixtures.sh
+++ b/tests/lib/factory-test-fixtures.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# tests/lib/factory-test-fixtures.sh — seed + reap throwaway feature tickets for
+# Software Factory FA-SF BATS tests. SOURCE, do not execute.
+#
+#   source tests/lib/factory-test-fixtures.sh
+#   ext_id=$(seed_test_feature korczewski "tests/fixtures/sf-test-foo-a.txt")
+#   ... assertions ...
+#   purge_factory_test_data korczewski   # in teardown()
+#
+# Every seeded ticket carries is_test_data=true and a unique 'SF-TEST-' title and
+# is reaped by tickets.fn_purge_test_data(). Pass DISJOINT touched_file paths per
+# test so the conflict gate does not legitimately fire between fixtures. Do NOT
+# run concurrently with the Playwright e2e suite (shared global purge).
+
+# Resolve the repo root from this file's location so the fixture works
+# regardless of the BATS working directory.
+_FIXTURE_REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+# seed_test_feature <brand> [touched_file ...] → echoes the new external_id
+seed_test_feature() {
+  local brand="$1"; shift
+  local ctx="${FACTORY_CTX:-fleet}"
+  if [[ "$ctx" == "fleet" && -z "${FACTORY_ALLOW_PROD_SEED:-}" ]]; then
+    echo "refusing to seed test data into prod context 'fleet' (set FACTORY_ALLOW_PROD_SEED=1 to override)" >&2
+    return 3
+  fi
+  local files; files="$(IFS=,; echo "$*")"
+  local title="SF-TEST-${brand}-${BATS_TEST_NAME:-manual}-$$-${RANDOM}"
+  local result ext_id
+  result=$(BRAND="$brand" TICKET_CTX="$ctx" bash "$_FIXTURE_REPO_ROOT/scripts/ticket.sh" create \
+    --type feature --brand "$brand" --title "$title" \
+    --description "factory fixture" --priority mittel --status backlog --is-test-data)
+  ext_id="${result%%|*}"
+  if [[ -n "$files" ]]; then
+    BRAND="$brand" TICKET_CTX="$ctx" bash "$_FIXTURE_REPO_ROOT/scripts/ticket.sh" set-touched-files --id "$ext_id" --files "$files" >/dev/null
+  fi
+  echo "$ext_id"
+}
+
+# purge_factory_test_data <brand> — reap all is_test_data=true rows on that brand
+purge_factory_test_data() {
+  local brand="$1"
+  local ctx="${FACTORY_CTX:-fleet}" ns
+  case "$brand" in
+    mentolder)  ns="workspace" ;;
+    korczewski) ns="workspace-korczewski" ;;
+    *) echo "purge_factory_test_data: unknown brand $brand" >&2; return 2 ;;
+  esac
+  local pod
+  pod=$(kubectl get pod -n "$ns" --context "$ctx" -l 'app in (shared-db, shared-db-dev)' -o name 2>/dev/null | head -1)
+  [[ -z "$pod" ]] && { echo "no shared-db pod in $ns" >&2; return 1; }
+  kubectl exec -i "$pod" -n "$ns" --context "$ctx" -c postgres -- \
+    psql -U website -d website -qtAc "SELECT tickets.fn_purge_test_data();" >/dev/null
+}

--- a/tests/local/FA-SF-20-pipeline-contract.bats
+++ b/tests/local/FA-SF-20-pipeline-contract.bats
@@ -36,3 +36,9 @@ SCRIPT="scripts/factory/pipeline.js"
   run grep -q "feature:" "$SCRIPT"; [ "$status" -eq 0 ]
   run grep -Eq "ENV=mentolder|ENV=korczewski|ENV=fleet-" "$SCRIPT"; [ "$status" -eq 0 ]
 }
+
+@test "FA-SF-20: pipeline writes a per-phase liveness touch (>=6 references)" {
+  run grep -c "ticket.sh touch" "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$output" -ge 6 ]
+}

--- a/tests/local/FA-SF-21-ticket-cli.bats
+++ b/tests/local/FA-SF-21-ticket-cli.bats
@@ -1,0 +1,32 @@
+#!/usr/bin/env bats
+# FA-SF-21: offline arg-validation contract for the new ticket.sh subcommands.
+setup() { load 'test_helper.bash'; }
+
+@test "FA-SF-21: get requires --id" {
+  run bash scripts/ticket.sh get
+  [ "$status" -eq 2 ]
+  [[ "$output" =~ "--id" ]]
+}
+
+@test "FA-SF-21: set-touched-files requires --id and --files" {
+  run bash scripts/ticket.sh set-touched-files --id T000001
+  [ "$status" -eq 2 ]
+  [[ "$output" =~ "--files" ]]
+}
+
+@test "FA-SF-21: set-pipeline-slot requires --id and --slot" {
+  run bash scripts/ticket.sh set-pipeline-slot --id T000001
+  [ "$status" -eq 2 ]
+}
+
+@test "FA-SF-21: unknown BRAND is rejected with exit 2" {
+  run env BRAND=bogus bash scripts/ticket.sh get --id T000001
+  [ "$status" -eq 2 ]
+  [[ "$output" =~ "unknown BRAND" ]]
+}
+
+@test "FA-SF-21: dispatch lists the new commands in usage" {
+  run bash scripts/ticket.sh
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "set-touched-files" ]]
+}

--- a/tests/local/FA-SF-22-fixtures.bats
+++ b/tests/local/FA-SF-22-fixtures.bats
@@ -1,0 +1,20 @@
+#!/usr/bin/env bats
+# FA-SF-22: factory shared lib + test fixtures contract (offline assertions only).
+setup() { load 'test_helper.bash'; }
+
+@test "FA-SF-22: lib.sh dry-resolve maps korczewski to workspace-korczewski" {
+  run env BRAND=korczewski FACTORY_DRY_RESOLVE=1 bash -c 'source scripts/factory/lib.sh; factory_resolve; echo "ns=$FACTORY_NS ctx=$FACTORY_CTX"'
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"ns=workspace-korczewski"* ]]
+}
+
+@test "FA-SF-22: lib.sh rejects unknown BRAND" {
+  run env BRAND=bogus bash -c 'source scripts/factory/lib.sh; factory_resolve'
+  [ "$status" -eq 2 ]
+}
+
+@test "FA-SF-22: fixtures refuse to seed into prod fleet without override" {
+  run env FACTORY_CTX=fleet bash -c 'source tests/lib/factory-test-fixtures.sh; seed_test_feature mentolder "tests/fixtures/x.txt"'
+  [ "$status" -ne 0 ]
+  [[ "$output" =~ "refusing" ]]
+}

--- a/tests/local/FA-SF-23-slots.bats
+++ b/tests/local/FA-SF-23-slots.bats
@@ -1,0 +1,30 @@
+#!/usr/bin/env bats
+# FA-SF-23: slots.sh contract. Offline assertions always run; live claim/release
+# runs only when a dev cluster is reachable (FACTORY_CTX/FACTORY_NS set to dev).
+setup() { load 'test_helper.bash'; source 'tests/lib/factory-test-fixtures.sh'; }
+
+@test "FA-SF-23: dry-resolve prints brand namespace" {
+  run env BRAND=mentolder FACTORY_DRY_RESOLVE=1 bash scripts/factory/slots.sh count
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"ns=workspace"* ]]
+}
+
+@test "FA-SF-23: unknown subcommand exits 2" {
+  run env BRAND=mentolder FACTORY_DRY_RESOLVE= bash scripts/factory/slots.sh bogus
+  [ "$status" -eq 2 ]
+}
+
+@test "FA-SF-23: claim is atomic — second claim on the same ticket fails" {
+  [ -n "${FACTORY_CTX:-}" ] || skip "no dev cluster context set"
+  local brand="${TEST_BRAND:-korczewski}"
+  ext=$(seed_test_feature "$brand" "tests/fixtures/sf-test-slots-$$-a.txt")
+  run env BRAND="$brand" bash scripts/factory/slots.sh claim "$ext" 1
+  [ "$status" -eq 0 ]
+  [ "$output" = "1" ]
+  run env BRAND="$brand" bash scripts/factory/slots.sh claim "$ext" 2
+  [ "$status" -eq 1 ]                       # already slotted → claim fails
+  run env BRAND="$brand" bash scripts/factory/slots.sh release "$ext"
+  [ "$status" -eq 0 ]
+}
+
+teardown() { [ -n "${FACTORY_CTX:-}" ] && purge_factory_test_data "${TEST_BRAND:-korczewski}" || true; }

--- a/tests/local/FA-SF-24-queue.bats
+++ b/tests/local/FA-SF-24-queue.bats
@@ -1,0 +1,20 @@
+#!/usr/bin/env bats
+# FA-SF-24: queue.sh lists backlog features as ordered JSON.
+setup() { load 'test_helper.bash'; source 'tests/lib/factory-test-fixtures.sh'; }
+
+@test "FA-SF-24: dry-resolve works" {
+  run env BRAND=mentolder FACTORY_DRY_RESOLVE=1 bash scripts/factory/queue.sh
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"ns=workspace"* ]]
+}
+
+@test "FA-SF-24: a seeded backlog feature appears in the queue JSON" {
+  [ -n "${FACTORY_CTX:-}" ] || skip "no dev cluster context set"
+  local brand="${TEST_BRAND:-korczewski}"
+  ext=$(seed_test_feature "$brand" "tests/fixtures/sf-test-queue-$$-a.txt")
+  run env BRAND="$brand" bash scripts/factory/queue.sh
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e --arg e "$ext" 'any(.[]; .external_id == $e)'
+}
+
+teardown() { [ -n "${FACTORY_CTX:-}" ] && purge_factory_test_data "${TEST_BRAND:-korczewski}" || true; }

--- a/tests/local/FA-SF-25-schedule.bats
+++ b/tests/local/FA-SF-25-schedule.bats
@@ -1,0 +1,32 @@
+#!/usr/bin/env bats
+# FA-SF-25: schedule.sh emits a launch plan and claims slots.
+setup() { load 'test_helper.bash'; source 'tests/lib/factory-test-fixtures.sh'; }
+
+@test "FA-SF-25: dry-resolve works" {
+  run env BRAND=mentolder FACTORY_DRY_RESOLVE=1 bash scripts/factory/schedule.sh
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-25: two disjoint backlog features both get scheduled with slots" {
+  [ -n "${FACTORY_CTX:-}" ] || skip "no dev cluster context set"
+  local brand="${TEST_BRAND:-korczewski}"
+  e1=$(seed_test_feature "$brand" "tests/fixtures/sf-test-sched-$$-a.txt")
+  e2=$(seed_test_feature "$brand" "tests/fixtures/sf-test-sched-$$-b.txt")
+  run env BRAND="$brand" FACTORY_GLOBAL_CAP=3 bash scripts/factory/schedule.sh
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e --arg e "$e1" 'any(.[]; .external_id == $e and (.slot|type=="number"))'
+  echo "$output" | jq -e --arg e "$e2" 'any(.[]; .external_id == $e)'
+}
+
+@test "FA-SF-25: global cap of 1 schedules at most one feature" {
+  [ -n "${FACTORY_CTX:-}" ] || skip "no dev cluster context set"
+  local brand="${TEST_BRAND:-korczewski}"
+  seed_test_feature "$brand" "tests/fixtures/sf-test-cap-$$-a.txt" >/dev/null
+  seed_test_feature "$brand" "tests/fixtures/sf-test-cap-$$-b.txt" >/dev/null
+  run env BRAND="$brand" FACTORY_GLOBAL_CAP=1 bash scripts/factory/schedule.sh
+  [ "$status" -eq 0 ]
+  count=$(echo "$output" | jq 'length')
+  [ "$count" -le 1 ]
+}
+
+teardown() { [ -n "${FACTORY_CTX:-}" ] && purge_factory_test_data "${TEST_BRAND:-korczewski}" || true; }

--- a/tests/local/FA-SF-26-watchdog.bats
+++ b/tests/local/FA-SF-26-watchdog.bats
@@ -1,0 +1,29 @@
+#!/usr/bin/env bats
+# FA-SF-26: watchdog escalates stale in_progress features.
+setup() { load 'test_helper.bash'; source 'tests/lib/factory-test-fixtures.sh'; }
+
+@test "FA-SF-26: dry-resolve works" {
+  run env BRAND=mentolder FACTORY_DRY_RESOLVE=1 bash scripts/factory/watchdog.sh
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-26: a stale in_progress feature is returned to triage and its slot freed" {
+  [ -n "${FACTORY_CTX:-}" ] || skip "no dev cluster context set"
+  local brand="${TEST_BRAND:-korczewski}"
+  ext=$(seed_test_feature "$brand" "tests/fixtures/sf-test-wd-$$-a.txt")
+  env BRAND="$brand" bash scripts/factory/slots.sh claim "$ext" 1 >/dev/null
+  # Derive the namespace from the brand (do not rely on a FACTORY_NS default).
+  local ns; case "$brand" in mentolder) ns=workspace ;; korczewski) ns=workspace-korczewski ;; esac
+  # Backdate updated_at by 40 minutes to simulate a hung pipeline.
+  pod=$(kubectl get pod -n "$ns" --context "$FACTORY_CTX" -l 'app in (shared-db, shared-db-dev)' -o name | head -1)
+  kubectl exec -i "$pod" -n "$ns" --context "$FACTORY_CTX" -c postgres -- \
+    psql -U website -d website -qtAc "UPDATE tickets.tickets SET updated_at = now() - interval '40 minutes' WHERE external_id='$ext';"
+  run env BRAND="$brand" FACTORY_STALE_MIN=30 bash scripts/factory/watchdog.sh
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e --arg e "$ext" 'any(.[]; . == $e)'
+  # Confirm status=triage and pipeline_slot cleared.
+  st=$(BRAND="$brand" TICKET_CTX="$FACTORY_CTX" bash scripts/ticket.sh get --id "$ext" | jq -r '.status')
+  [ "$st" = "triage" ]
+}
+
+teardown() { [ -n "${FACTORY_CTX:-}" ] && purge_factory_test_data "${TEST_BRAND:-korczewski}" || true; }

--- a/tests/local/FA-SF-27-metrics.bats
+++ b/tests/local/FA-SF-27-metrics.bats
@@ -1,0 +1,20 @@
+#!/usr/bin/env bats
+# FA-SF-27: metrics.sh summarizes v_factory_metrics and posts a comment.
+setup() { load 'test_helper.bash'; source 'tests/lib/factory-test-fixtures.sh'; }
+
+@test "FA-SF-27: dry-resolve works" {
+  run env BRAND=mentolder FACTORY_DRY_RESOLVE=1 bash scripts/factory/metrics.sh
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-27: posts a comment to a seeded metrics ticket" {
+  [ -n "${FACTORY_CTX:-}" ] || skip "no dev cluster context set"
+  local brand="${TEST_BRAND:-korczewski}"
+  # Use a throwaway test ticket as the metrics sink so we don't touch T000413.
+  sink=$(seed_test_feature "$brand" "tests/fixtures/sf-test-metrics-$$-a.txt")
+  run env BRAND="$brand" FACTORY_METRICS_TICKET="$sink" bash scripts/factory/metrics.sh
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "Comment added" ]] || [[ "$output" =~ "Factory metrics" ]]
+}
+
+teardown() { [ -n "${FACTORY_CTX:-}" ] && purge_factory_test_data "${TEST_BRAND:-korczewski}" || true; }

--- a/tests/local/FA-SF-30-dispatcher-contract.bats
+++ b/tests/local/FA-SF-30-dispatcher-contract.bats
@@ -1,0 +1,38 @@
+#!/usr/bin/env bats
+# FA-SF-30: structural contract for the dispatcher Workflow script (offline).
+SCRIPT="scripts/factory/dispatcher.js"
+setup() { load 'test_helper.bash'; }
+
+@test "FA-SF-30: dispatcher.js exists and is syntactically valid JS" {
+  [ -f "$SCRIPT" ]
+  run node --check "$SCRIPT"
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-30: exports meta with the three expected phases" {
+  run grep -Eq "export const meta" "$SCRIPT"; [ "$status" -eq 0 ]
+  for p in Prep Launch Metrics; do
+    run grep -q "phase('$p')" "$SCRIPT"; [ "$status" -eq 0 ]
+  done
+}
+
+@test "FA-SF-30: wires the primitives (watchdog, schedule, metrics, ticket.sh get)" {
+  for needle in "watchdog.sh" "schedule.sh" "metrics.sh" "ticket.sh get"; do
+    run grep -q "$needle" "$SCRIPT"; [ "$status" -eq 0 ]
+  done
+}
+
+@test "FA-SF-30: launches pipeline.js via workflow scriptPath" {
+  run grep -q "scripts/factory/pipeline.js" "$SCRIPT"; [ "$status" -eq 0 ]
+  run grep -Eq "workflow\(" "$SCRIPT"; [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-30: resume-safe (uses args.timestamp, no Date.now()/Math.random())" {
+  run grep -q "args.timestamp\|A.timestamp" "$SCRIPT"; [ "$status" -eq 0 ]
+  run grep -Eq "Date\.now\(\)|Math\.random\(\)" "$SCRIPT"; [ "$status" -ne 0 ]
+}
+
+@test "FA-SF-30: schedules across BOTH brands" {
+  run grep -q "mentolder" "$SCRIPT"; [ "$status" -eq 0 ]
+  run grep -q "korczewski" "$SCRIPT"; [ "$status" -eq 0 ]
+}

--- a/website/src/data/test-inventory.json
+++ b/website/src/data/test-inventory.json
@@ -996,6 +996,54 @@
     "kind": "shell"
   },
   {
+    "id": "FA-SF-21",
+    "file": "tests/local/FA-SF-21-ticket-cli.bats",
+    "category": "FA",
+    "kind": "shell"
+  },
+  {
+    "id": "FA-SF-22",
+    "file": "tests/local/FA-SF-22-fixtures.bats",
+    "category": "FA",
+    "kind": "shell"
+  },
+  {
+    "id": "FA-SF-23",
+    "file": "tests/local/FA-SF-23-slots.bats",
+    "category": "FA",
+    "kind": "shell"
+  },
+  {
+    "id": "FA-SF-24",
+    "file": "tests/local/FA-SF-24-queue.bats",
+    "category": "FA",
+    "kind": "shell"
+  },
+  {
+    "id": "FA-SF-25",
+    "file": "tests/local/FA-SF-25-schedule.bats",
+    "category": "FA",
+    "kind": "shell"
+  },
+  {
+    "id": "FA-SF-26",
+    "file": "tests/local/FA-SF-26-watchdog.bats",
+    "category": "FA",
+    "kind": "shell"
+  },
+  {
+    "id": "FA-SF-27",
+    "file": "tests/local/FA-SF-27-metrics.bats",
+    "category": "FA",
+    "kind": "shell"
+  },
+  {
+    "id": "FA-SF-30",
+    "file": "tests/local/FA-SF-30-dispatcher-contract.bats",
+    "category": "FA",
+    "kind": "shell"
+  },
+  {
     "id": "NFA-01",
     "file": "tests/local/NFA-01.sh",
     "category": "NFA",


### PR DESCRIPTION
## Summary

- **Harness-Bug behoben:** `pipeline.js` verwendete `export async function run(args, harness)` — ein Muster das der Workflow-Harness nicht unterstützt (`SyntaxError`). Umgestellt auf Top-Level-Globals (`agent`, `parallel`, `phase`, `log`, `args`, `workflow`), die der Harness direkt injiziert.
- **Dispatcher (Tier 1) implementiert:** `scripts/factory/dispatcher.js` — Model-A Workflow, der pro `/loop`-Tick eine PREP-Phase (Watchdog-Sweep + Schedule für beide Brands) ausführt und dann je ein `pipeline.js`-Workflow via `workflow({scriptPath})` parallel nestelt.
- **5 Primitives neu:** `slots.sh` (atomarer Slot-Claim), `queue.sh` (Raw-Backlog), `schedule.sh` (Conflict-Gate + Global-Cap), `watchdog.sh` (Stale-Escalation 30 min), `metrics.sh` (Throughput-Kommentar auf T000413).
- **`ticket.sh` erweitert:** `get`, `set-touched-files`, `set-pipeline-slot`, `release-slot`, `touch` + Brand-Namespace-Map + `--is-test-data`-Flag.
- **Shared Library:** `scripts/factory/lib.sh` + Test-Fixtures `tests/lib/factory-test-fixtures.sh` (Prod-Seed-Guard).
- **9 neue BATS-Suiten** (FA-SF-21–27, FA-SF-30) + FA-SF-20 erweitert; Inventar regeneriert (234 Einträge).

## Architektur-Entscheidungen (aus Brainstorming + T0-Spike)

| Achse | Entscheidung |
|---|---|
| Harness-Vertrag | Top-Level-Globals (kein `run(args,harness)`) — via Spike bestätigt |
| Launch-Modell | Model A: dispatcher.js nestelt pipeline.js via `workflow({scriptPath})` |
| Single-Flight | `/loop`-Kadenz + atomarer Slot-Claim (kein pg_advisory_lock — überlebt keine separaten kubectl-exec-Sessions) |
| Slots | Per-Brand-Pools (3) + globaler Deckel (3) |
| Watchdog | `updated_at`-Sweep (fn_lifecycle_ts-Trigger) + per-Phase `ticket.sh touch` |
| P3-deferred | Canary, Verzeichnis-Heuristik, semantisches Dedup, embedTicket-Wiring |

## Test plan

- [x] `node --check scripts/factory/pipeline.js && node --check scripts/factory/dispatcher.js`
- [x] FA-SF-20 (6/6) — pipeline contract inkl. ≥6 touch-Referenzen
- [x] FA-SF-21 (5/5) — ticket.sh Arg-Validierung (offline)
- [x] FA-SF-22 (3/3) — factory lib + fixtures Prod-Guard (offline)
- [x] FA-SF-23 (2/2+1 skip) — slots.sh dry-resolve + Atomarität
- [x] FA-SF-24 (1/1+1 skip) — queue.sh dry-resolve
- [x] FA-SF-25 (1/1+2 skip) — schedule.sh dry-resolve
- [x] FA-SF-26 (1/1+1 skip) — watchdog.sh dry-resolve
- [x] FA-SF-27 (1/1+1 skip) — metrics.sh dry-resolve
- [x] FA-SF-30 (6/6) — dispatcher contract (offline strukturell)
- [x] `task test:all` — 300/300 grün
- [x] Inventar in Sync (234 Einträge, `git diff --quiet`)

## Verwandte Tickets

Closes T000424 · Advances T000413 (P2 live)

🤖 Generated with [Claude Code](https://claude.com/claude-code)