### PR TITLE
docs(agent-guide): explain Software Factory workflows in sidekick

### DIFF
--- a/docs/agent-guide/10-ziele.md
+++ b/docs/agent-guide/10-ziele.md
@@ -233,3 +233,44 @@ Ist der letzte Deploy für mentolder live? Prüfe Status, Logs und mach einen E2
 **Schutzregeln (Guardrails):** ENV immer explizit setzen (G-ENV-EXPLICIT)
 
 **Verwandte Ziele:** Ich will eine Änderung in der Produktion ausrollen, Ich will prüfen, ob alle Dienste laufen
+
+## Ich will ein Feature von der Software Factory bauen lassen
+
+🟠 **Nur mit Hilfe**
+
+**Wann?** Ein Feature ist klar genug, dass es ein Multi-Agent-Lauf weitgehend selbst bauen kann — erst geplant, dann übergeben.
+
+**So gehst du vor:**
+
+1. [[dev-flow-plan]] — Plane das Feature wie gewohnt; am Stopp-Punkt bietet der Skill 'an Factory übergeben' an (legt das Ticket per ticket.sh enqueue auf die Warteschlange).
+2. Software Factory (Auto-Bau) — Die Factory übernimmt den fertigen Plan (Plan-Reuse, kein Neu-Planen) und baut Implement → Verify → Deploy. Erst Dry-Run, dann scharf schalten.
+
+**Diesen Prompt kannst du der KI geben:**
+
+```text
+Plane die neue Tickets-Übersichtsseite und übergib den Plan dann an die Software Factory (zuerst als Dry-Run).
+```
+
+**Schutzregeln (Guardrails):** Erst ziehen, dann arbeiten (G-PULL-FIRST), Factory erst im Dry-Run beweisen (G-FACTORY-DRYRUN), Nie direkt auf main (G-PR-NOT-MAIN)
+
+**Verwandte Ziele:** Ich will eine neue Funktion bauen, Ich will, dass die Factory wartende Aufgaben selbst abarbeitet
+
+## Ich will, dass die Factory wartende Aufgaben selbst abarbeitet
+
+🟠 **Nur mit Hilfe**
+
+**Wann?** Mehrere übergebene Tickets liegen in der Warteschlange und sollen automatisch der Reihe nach gebaut werden.
+
+**So gehst du vor:**
+
+1. Factory-Dispatcher (Warteschlange) — Der Dispatcher pollt die Warteschlange, prüft Datei-Konflikte, vergibt Slots pro Marke und startet die Pipeline — wiederkehrend via /loop.
+
+**Diesen Prompt kannst du der KI geben:**
+
+```text
+Starte den Factory-Dispatcher und arbeite die wartenden Tickets ab — als Dry-Run.
+```
+
+**Schutzregeln (Guardrails):** Factory erst im Dry-Run beweisen (G-FACTORY-DRYRUN), Nie direkt auf main (G-PR-NOT-MAIN)
+
+**Verwandte Ziele:** Ich will ein Feature von der Software Factory bauen lassen, Ich will prüfen, ob alle Dienste laufen

--- a/docs/agent-guide/20-werkzeuge.md
+++ b/docs/agent-guide/20-werkzeuge.md
@@ -285,3 +285,47 @@ Rotiert Secrets, verwaltet Keycloak-Realms und SealedSecrets.
 **Verwandt:** [[bachelorprojekt-infra]]
 
 **Mehr dazu:** [https://docs.mentolder.de/glossary.html](https://docs.mentolder.de/glossary.html)
+
+## Software Factory (Auto-Bau)
+
+**Task** · 🟠 **Nur mit Hilfe**
+
+Baut ein Feature (halb-)autonom: Scout → Design → Plan → Implement → Verify → Deploy.
+
+**Wofür?** Wenn ein gut umrissenes Feature von einem Multi-Agent-Lauf gebaut werden soll — entweder selbst geplant oder aus einem übergebenen Menschen-Plan (Plan-Reuse).
+
+**So startest du:** Über das Claude-Code-Workflow-Tool mit scripts/factory/pipeline.js starten ('task factory:run' zeigt die genaue Invocation). Für einen gefahrlosen Probelauf args { dry_run: true } übergeben — kein Merge, kein Deploy.
+
+**Was schiefgehen kann:** Sie implementiert und deployt selbstständig (🟠). Ohne Dry-Run kann ein fehlerhafter Stand live gehen — darum erst den Probelauf, dann bewusst scharf schalten.
+
+**Du kannst diesen Prompt kopieren und in Claude Code einfügen:**
+
+```text
+Übergib das an die Software Factory: <gut umrissenes Feature> — und mach zuerst einen Dry-Run.
+```
+
+**Schutzregeln (Guardrails):** Factory erst im Dry-Run beweisen (G-FACTORY-DRYRUN), Nie direkt auf main (G-PR-NOT-MAIN), Erst prüfen, dann anwenden (G-VALIDATE-FIRST)
+
+**Verwandt:** [[dev-flow-plan]], Factory-Dispatcher (Warteschlange)
+
+## Factory-Dispatcher (Warteschlange)
+
+**Task** · 🟠 **Nur mit Hilfe**
+
+Holt wartende Tickets aus der Warteschlange, prüft Konflikte und startet die Factory-Pipeline.
+
+**Wofür?** Damit übergebene Tickets (type=feature/status=backlog) automatisch abgearbeitet werden — mit Slots pro Marke, Konflikt-Gate und Watchdog.
+
+**So startest du:** Über das Workflow-Tool mit scripts/factory/dispatcher.js starten ('task factory:dispatch' zeigt die Invocation), wiederkehrend selbst-getaktet via /loop. Probelauf mit args { dry_run: true }.
+
+**Was schiefgehen kann:** Er startet Bauläufe selbstständig (🟠). Bei überlappenden Dateien greift das Konflikt-Gate; ein hängender Lauf wird nach 30 min vom Watchdog eskaliert.
+
+**Du kannst diesen Prompt kopieren und in Claude Code einfügen:**
+
+```text
+Starte den Factory-Dispatcher: arbeite wartende Tickets aus der Warteschlange ab (zuerst Dry-Run).
+```
+
+**Schutzregeln (Guardrails):** Factory erst im Dry-Run beweisen (G-FACTORY-DRYRUN), Nie direkt auf main (G-PR-NOT-MAIN)
+
+**Verwandt:** Software Factory (Auto-Bau)

--- a/docs/agent-guide/maps/danger-map.md
+++ b/docs/agent-guide/maps/danger-map.md
@@ -57,17 +57,23 @@ Ziele/Werkzeuge sie referenzieren (transitiv) — also ggf. unter mehreren Stufe
 **Ziele:**
 - `aenderung-ausrollen` — Ich will eine Änderung in der Produktion ausrollen
 - `datenbank-aendern` — Ich will das Datenbankschema ändern
+- `factory-autopilot` — Ich will, dass die Factory wartende Aufgaben selbst abarbeitet
+- `factory-feature-bauen` — Ich will ein Feature von der Software Factory bauen lassen
 - `pr-oeffnen` — Ich will einen Pull Request öffnen und CI grün bekommen
 
 **Werkzeuge:**
 - `agent-db` — Datenbank-Agent (db)
 - `agent-infra` — Infrastruktur-Agent (infra)
 - `agent-security` — Sicherheits-Agent (security)
+- `factory` — Software Factory (Auto-Bau)
+- `factory-dispatch` — Factory-Dispatcher (Warteschlange)
 
 **Guardrails (transitiv):**
 - `G-ASK-EXPERT` — Bei Rot: stoppen und fragen
 - `G-ENV-EXPLICIT` — ENV immer explizit setzen
+- `G-FACTORY-DRYRUN` — Factory erst im Dry-Run beweisen
 - `G-PR-NOT-MAIN` — Nie direkt auf main
+- `G-PULL-FIRST` — Erst ziehen, dann arbeiten
 - `G-SECRET-ORDER` — Geheimnis-Reihenfolge einhalten
 - `G-VALIDATE-FIRST` — Erst prüfen, dann anwenden
 

--- a/docs/agent-guide/maps/goals-map.md
+++ b/docs/agent-guide/maps/goals-map.md
@@ -13,6 +13,8 @@ Die Tier-Emojis (🟢🟡🟠🔴) sind in `danger-map.md` erklärt, die Werkzeu
 | Ich will das Datenbankschema ändern | dev-flow-plan → agent-db → dev-flow-execute | 🟠 Nur mit Hilfe | G-ASK-EXPERT, G-ENV-EXPLICIT | Bitte füge eine Spalte 'invoice_number' zur Tabelle 'orders' hinzu. |
 | Ich will prüfen, ob mein Deploy wirklich live ist | agent-ops → dev-flow-e2e | 🟢 Sicher | G-ENV-EXPLICIT | Ist der letzte Deploy für mentolder live? Prüfe Status, Logs und mach einen E2E-Check. |
 | Ich will prüfen, ob alle Dienste laufen | agent-ops | 🟢 Sicher | — | Bitte prüfe, ob alle Pods laufen und zeig mir den Plattform-Status. |
+| Ich will, dass die Factory wartende Aufgaben selbst abarbeitet | factory-dispatch | 🟠 Nur mit Hilfe | G-FACTORY-DRYRUN, G-PR-NOT-MAIN | Starte den Factory-Dispatcher und arbeite die wartenden Tickets ab — als Dry-Run. |
+| Ich will ein Feature von der Software Factory bauen lassen | dev-flow-plan → factory | 🟠 Nur mit Hilfe | G-FACTORY-DRYRUN, G-PR-NOT-MAIN, G-PULL-FIRST | Plane die neue Tickets-Übersichtsseite und übergib den Plan dann an die Software Factory (zuerst als Dry-Run). |
 | Ich will eine neue Funktion bauen | dev-flow-plan → dev-flow-execute | 🟡 Vorsicht | G-PR-NOT-MAIN, G-PULL-FIRST | Ich hätte gerne eine Seite, die alle aktiven Tickets anzeigt. |
 | Ich habe eine Idee — wie fange ich an? | brainstorming → dev-flow-plan | 🟢 Sicher | G-PULL-FIRST | Ich habe eine Idee für die Plattform und möchte sie erst gemeinsam durchdenken. |
 | Ich will einen Pull Request öffnen und CI grün bekommen | dev-flow-execute | 🟠 Nur mit Hilfe | G-PR-NOT-MAIN | Bitte öffne einen Pull Request für diesen Branch und sag mir, ob die CI grün ist. |

--- a/docs/agent-guide/maps/tools-map.md
+++ b/docs/agent-guide/maps/tools-map.md
@@ -20,6 +20,8 @@ Die Tier-Emojis (🟢🟡🟠🔴) sind in `danger-map.md` erklärt.
 
 | Id | Name | Art | Tier | Wofür | Guardrails | Init |
 | --- | --- | --- | --- | --- | --- | --- |
+| factory | Software Factory (Auto-Bau) | task | 🟠 Nur mit Hilfe | Baut ein Feature (halb-)autonom: Scout → Design → Plan → Implement → Verify → Deploy. | G-FACTORY-DRYRUN, G-PR-NOT-MAIN, G-VALIDATE-FIRST | Übergib das an die Software Factory: <gut umrissenes Feature> — und mach zuerst einen Dry-Run. |
+| factory-dispatch | Factory-Dispatcher (Warteschlange) | task | 🟠 Nur mit Hilfe | Holt wartende Tickets aus der Warteschlange, prüft Konflikte und startet die Factory-Pipeline. | G-FACTORY-DRYRUN, G-PR-NOT-MAIN | Starte den Factory-Dispatcher: arbeite wartende Tickets aus der Warteschlange ab (zuerst Dry-Run). |
 | task-oracle | Task-Orakel (task-oracle) | task | 🟢 Sicher | Findet den richtigen Task-Befehl für ein Ziel in einfachem Deutsch. | — | — |
 
 ## Agenten

--- a/docs/agent-guide/registry/glossary.yaml
+++ b/docs/agent-guide/registry/glossary.yaml
@@ -12,3 +12,8 @@
 - { term: "ENV",       def_de: "Die Ziel-Umgebung eines Befehls, z. B. ENV=mentolder oder ENV=dev." }
 - { term: "Guardrail", def_de: "Eine Schutzregel, die gefährliche Aktionen bremst oder blockiert." }
 - { term: "CI",        def_de: "Continuous Integration — automatische Tests bei jedem Pull Request." }
+- { term: "Software Factory", def_de: "Eine (halb-)autonome Pipeline, die ein Feature mit mehreren Agenten von der Planung bis zum Deploy selbst baut." }
+- { term: "Pipeline",  def_de: "Die feste Phasenfolge der Factory: Scout → Design → Plan → Implement → Verify → Deploy." }
+- { term: "Dispatcher", def_de: "Der Verteiler, der wartende Tickets aus der Warteschlange holt, auf Konflikte prüft und die Pipeline startet." }
+- { term: "Dry-Run",   def_de: "Ein Probelauf der Factory bis kurz vor Deploy (args dry_run: true) — ohne Merge und ohne Live-Schaltung, um Fehler vorab zu finden." }
+- { term: "Scout",     def_de: "Die erste Factory-Phase: erkundet die Codebase, schätzt die Komplexität und findet die betroffenen Dateien." }

--- a/docs/agent-guide/registry/goals.yaml
+++ b/docs/agent-guide/registry/goals.yaml
@@ -185,3 +185,35 @@
   aliases_de: [deploy, live, pruefen, status, "ist es da"]
   guardrails: [G-ENV-EXPLICIT]
   related: [aenderung-ausrollen, dienst-status-pruefen]
+- id: factory-feature-bauen
+  title_de: "Ich will ein Feature von der Software Factory bauen lassen"
+  when_de: "Ein Feature ist klar genug, dass es ein Multi-Agent-Lauf weitgehend selbst bauen kann — erst geplant, dann übergeben."
+  flow:
+    - tool: dev-flow-plan
+      note_de: "Plane das Feature wie gewohnt; am Stopp-Punkt bietet der Skill 'an Factory übergeben' an (legt das Ticket per ticket.sh enqueue auf die Warteschlange)."
+    - tool: factory
+      note_de: "Die Factory übernimmt den fertigen Plan (Plan-Reuse, kein Neu-Planen) und baut Implement → Verify → Deploy. Erst Dry-Run, dann scharf schalten."
+  example_prompt_de: "Plane die neue Tickets-Übersichtsseite und übergib den Plan dann an die Software Factory (zuerst als Dry-Run)."
+  danger: assisted
+  theme: fabrik
+  one_liner_de: "Planen, übergeben — die Factory baut es."
+  stages: [plan, code, pr-ci, deploy]
+  concept_de: "Konzept: Mensch plant, Factory baut. Der vorhandene Plan wird wiederverwendet, nicht neu erfunden."
+  aliases_de: [factory, übergeben, autonom, "bauen lassen", pipeline, "auto-bau"]
+  guardrails: [G-PULL-FIRST, G-FACTORY-DRYRUN, G-PR-NOT-MAIN]
+  related: [feature-bauen, factory-autopilot]
+- id: factory-autopilot
+  title_de: "Ich will, dass die Factory wartende Aufgaben selbst abarbeitet"
+  when_de: "Mehrere übergebene Tickets liegen in der Warteschlange und sollen automatisch der Reihe nach gebaut werden."
+  flow:
+    - tool: factory-dispatch
+      note_de: "Der Dispatcher pollt die Warteschlange, prüft Datei-Konflikte, vergibt Slots pro Marke und startet die Pipeline — wiederkehrend via /loop."
+  example_prompt_de: "Starte den Factory-Dispatcher und arbeite die wartenden Tickets ab — als Dry-Run."
+  danger: assisted
+  theme: fabrik
+  one_liner_de: "Wartende Tickets automatisch abarbeiten lassen."
+  stages: [code, pr-ci, deploy]
+  concept_de: "Konzept: Warteschlange + Konflikt-Gate + Slots verhindern, dass zwei Läufe dieselben Dateien anfassen."
+  aliases_de: [dispatcher, warteschlange, autopilot, queue, automatisch]
+  guardrails: [G-FACTORY-DRYRUN, G-PR-NOT-MAIN]
+  related: [factory-feature-bauen, dienst-status-pruefen]

--- a/docs/agent-guide/registry/guardrails.yaml
+++ b/docs/agent-guide/registry/guardrails.yaml
@@ -33,3 +33,8 @@
   rule_de: "Bei 🔴-Aktionen nicht selbst handeln — Patrick fragen."
   why_de: "Diese Aktionen können die Plattform für alle lahmlegen."
   enforced_by: hook-forbidden-stop
+- id: G-FACTORY-DRYRUN
+  name_de: "Factory erst im Dry-Run beweisen"
+  rule_de: "Die Software Factory zuerst im Dry-Run (Workflow-args dry_run: true) laufen lassen; den echten Deploy erst nach grünem Probelauf bewusst freischalten."
+  why_de: "Die Factory implementiert und deployt selbstständig — ein Probelauf ohne Merge und Deploy fängt Fehler ab, bevor sie live gehen."
+  enforced_by: docs-only

--- a/docs/agent-guide/registry/themes.yaml
+++ b/docs/agent-guide/registry/themes.yaml
@@ -9,3 +9,4 @@
 - { id: ausrollen,  label_de: "Ausrollen & Infrastruktur", emoji: "🚀", order: 5, accent: "#5ad1c4", blurb_de: "Änderungen live bringen, Cluster verwalten." }
 - { id: datenbank,  label_de: "Datenbank",                 emoji: "🗄", order: 6, accent: "#6c8cff", blurb_de: "Schema, Migrationen und Daten." }
 - { id: sicherheit, label_de: "Sicherheit & Geheimnisse",  emoji: "🔒", order: 7, accent: "#c77dff", blurb_de: "Secrets, Keycloak, Zertifikate." }
+- { id: fabrik,     label_de: "Software Factory",           emoji: "🏭", order: 8, accent: "#7d6cf0", blurb_de: "Features (halb-)autonom bauen lassen — von der Übergabe bis zum Deploy." }

--- a/docs/agent-guide/registry/tools.yaml
+++ b/docs/agent-guide/registry/tools.yaml
@@ -193,3 +193,33 @@
   links:
     - { label_de: "Begriffe & Glossar", url: "https://docs.mentolder.de/glossary.html" }
   init_prompt_de: "Übergib das an den Security-Agenten: <Secret rotieren, Keycloak/OIDC, DSGVO>."
+- id: factory
+  name_de: "Software Factory (Auto-Bau)"
+  kind: task
+  summary_de: "Baut ein Feature (halb-)autonom: Scout → Design → Plan → Implement → Verify → Deploy."
+  what_for_de: "Wenn ein gut umrissenes Feature von einem Multi-Agent-Lauf gebaut werden soll — entweder selbst geplant oder aus einem übergebenen Menschen-Plan (Plan-Reuse)."
+  how_to_start_de: "Über das Claude-Code-Workflow-Tool mit scripts/factory/pipeline.js starten ('task factory:run' zeigt die genaue Invocation). Für einen gefahrlosen Probelauf args { dry_run: true } übergeben — kein Merge, kein Deploy."
+  what_could_go_wrong_de: "Sie implementiert und deployt selbstständig (🟠). Ohne Dry-Run kann ein fehlerhafter Stand live gehen — darum erst den Probelauf, dann bewusst scharf schalten."
+  danger: assisted
+  theme: fabrik
+  stages: [code, pr-ci, deploy]
+  aliases_de: [factory, "software factory", pipeline, "auto-bau", autonom, scout]
+  guardrails: [G-FACTORY-DRYRUN, G-PR-NOT-MAIN, G-VALIDATE-FIRST]
+  related: [dev-flow-plan, factory-dispatch]
+  links: []
+  init_prompt_de: "Übergib das an die Software Factory: <gut umrissenes Feature> — und mach zuerst einen Dry-Run."
+- id: factory-dispatch
+  name_de: "Factory-Dispatcher (Warteschlange)"
+  kind: task
+  summary_de: "Holt wartende Tickets aus der Warteschlange, prüft Konflikte und startet die Factory-Pipeline."
+  what_for_de: "Damit übergebene Tickets (type=feature/status=backlog) automatisch abgearbeitet werden — mit Slots pro Marke, Konflikt-Gate und Watchdog."
+  how_to_start_de: "Über das Workflow-Tool mit scripts/factory/dispatcher.js starten ('task factory:dispatch' zeigt die Invocation), wiederkehrend selbst-getaktet via /loop. Probelauf mit args { dry_run: true }."
+  what_could_go_wrong_de: "Er startet Bauläufe selbstständig (🟠). Bei überlappenden Dateien greift das Konflikt-Gate; ein hängender Lauf wird nach 30 min vom Watchdog eskaliert."
+  danger: assisted
+  theme: fabrik
+  stages: [code, pr-ci, deploy]
+  aliases_de: [dispatcher, warteschlange, queue, slots, watchdog, scheduler]
+  guardrails: [G-FACTORY-DRYRUN, G-PR-NOT-MAIN]
+  related: [factory]
+  links: []
+  init_prompt_de: "Starte den Factory-Dispatcher: arbeite wartende Tickets aus der Warteschlange ab (zuerst Dry-Run)."

--- a/website/src/lib/agent-guide.generated.json
+++ b/website/src/lib/agent-guide.generated.json
@@ -87,6 +87,14 @@
       "order": 7,
       "accent": "#c77dff",
       "blurb_de": "Secrets, Keycloak, Zertifikate."
+    },
+    {
+      "id": "fabrik",
+      "label_de": "Software Factory",
+      "emoji": "🏭",
+      "order": 8,
+      "accent": "#7d6cf0",
+      "blurb_de": "Features (halb-)autonom bauen lassen — von der Übergabe bis zum Deploy."
     }
   ],
   "glossary": [
@@ -137,6 +145,26 @@
     {
       "term": "CI",
       "def_de": "Continuous Integration — automatische Tests bei jedem Pull Request."
+    },
+    {
+      "term": "Software Factory",
+      "def_de": "Eine (halb-)autonome Pipeline, die ein Feature mit mehreren Agenten von der Planung bis zum Deploy selbst baut."
+    },
+    {
+      "term": "Pipeline",
+      "def_de": "Die feste Phasenfolge der Factory: Scout → Design → Plan → Implement → Verify → Deploy."
+    },
+    {
+      "term": "Dispatcher",
+      "def_de": "Der Verteiler, der wartende Tickets aus der Warteschlange holt, auf Konflikte prüft und die Pipeline startet."
+    },
+    {
+      "term": "Dry-Run",
+      "def_de": "Ein Probelauf der Factory bis kurz vor Deploy (args dry_run: true) — ohne Merge und ohne Live-Schaltung, um Fehler vorab zu finden."
+    },
+    {
+      "term": "Scout",
+      "def_de": "Die erste Factory-Phase: erkundet die Codebase, schätzt die Komplexität und findet die betroffenen Dateien."
     }
   ],
   "goals": [
@@ -687,6 +715,119 @@
         "live"
       ],
       "concept_de": "Konzept: Deploy ≠ live — erst Status, Logs und ein E2E-Check bestätigen es."
+    },
+    {
+      "id": "factory-feature-bauen",
+      "title_de": "Ich will ein Feature von der Software Factory bauen lassen",
+      "when_de": "Ein Feature ist klar genug, dass es ein Multi-Agent-Lauf weitgehend selbst bauen kann — erst geplant, dann übergeben.",
+      "danger": "assisted",
+      "flow": [
+        {
+          "tool": "dev-flow-plan",
+          "tool_name_de": "Planungs-Skill (dev-flow-plan)",
+          "note_de": "Plane das Feature wie gewohnt; am Stopp-Punkt bietet der Skill 'an Factory übergeben' an (legt das Ticket per ticket.sh enqueue auf die Warteschlange)."
+        },
+        {
+          "tool": "factory",
+          "tool_name_de": "Software Factory (Auto-Bau)",
+          "note_de": "Die Factory übernimmt den fertigen Plan (Plan-Reuse, kein Neu-Planen) und baut Implement → Verify → Deploy. Erst Dry-Run, dann scharf schalten."
+        }
+      ],
+      "example_prompt_de": "Plane die neue Tickets-Übersichtsseite und übergib den Plan dann an die Software Factory (zuerst als Dry-Run).",
+      "guardrails": [
+        {
+          "id": "G-PULL-FIRST",
+          "name_de": "Erst ziehen, dann arbeiten",
+          "rule_de": "Immer 'git pull --rebase origin main' bevor du etwas änderst.",
+          "why_de": "Sonst arbeitest du auf einem veralteten Stand und bekommst Konflikte."
+        },
+        {
+          "id": "G-FACTORY-DRYRUN",
+          "name_de": "Factory erst im Dry-Run beweisen",
+          "rule_de": "Die Software Factory zuerst im Dry-Run (Workflow-args dry_run: true) laufen lassen; den echten Deploy erst nach grünem Probelauf bewusst freischalten.",
+          "why_de": "Die Factory implementiert und deployt selbstständig — ein Probelauf ohne Merge und Deploy fängt Fehler ab, bevor sie live gehen."
+        },
+        {
+          "id": "G-PR-NOT-MAIN",
+          "name_de": "Nie direkt auf main",
+          "rule_de": "Änderungen immer über einen Branch + Pull Request, niemals direkt nach main pushen.",
+          "why_de": "main ist geschützt; direktes Pushen umgeht Review und CI."
+        }
+      ],
+      "related": [
+        "feature-bauen",
+        "factory-autopilot"
+      ],
+      "links": [],
+      "theme": "fabrik",
+      "one_liner_de": "Planen, übergeben — die Factory baut es.",
+      "aliases_de": [
+        "factory",
+        "übergeben",
+        "autonom",
+        "bauen lassen",
+        "pipeline",
+        "auto-bau"
+      ],
+      "common": false,
+      "order": 999,
+      "stages": [
+        "plan",
+        "code",
+        "pr-ci",
+        "deploy"
+      ],
+      "concept_de": "Konzept: Mensch plant, Factory baut. Der vorhandene Plan wird wiederverwendet, nicht neu erfunden."
+    },
+    {
+      "id": "factory-autopilot",
+      "title_de": "Ich will, dass die Factory wartende Aufgaben selbst abarbeitet",
+      "when_de": "Mehrere übergebene Tickets liegen in der Warteschlange und sollen automatisch der Reihe nach gebaut werden.",
+      "danger": "assisted",
+      "flow": [
+        {
+          "tool": "factory-dispatch",
+          "tool_name_de": "Factory-Dispatcher (Warteschlange)",
+          "note_de": "Der Dispatcher pollt die Warteschlange, prüft Datei-Konflikte, vergibt Slots pro Marke und startet die Pipeline — wiederkehrend via /loop."
+        }
+      ],
+      "example_prompt_de": "Starte den Factory-Dispatcher und arbeite die wartenden Tickets ab — als Dry-Run.",
+      "guardrails": [
+        {
+          "id": "G-FACTORY-DRYRUN",
+          "name_de": "Factory erst im Dry-Run beweisen",
+          "rule_de": "Die Software Factory zuerst im Dry-Run (Workflow-args dry_run: true) laufen lassen; den echten Deploy erst nach grünem Probelauf bewusst freischalten.",
+          "why_de": "Die Factory implementiert und deployt selbstständig — ein Probelauf ohne Merge und Deploy fängt Fehler ab, bevor sie live gehen."
+        },
+        {
+          "id": "G-PR-NOT-MAIN",
+          "name_de": "Nie direkt auf main",
+          "rule_de": "Änderungen immer über einen Branch + Pull Request, niemals direkt nach main pushen.",
+          "why_de": "main ist geschützt; direktes Pushen umgeht Review und CI."
+        }
+      ],
+      "related": [
+        "factory-feature-bauen",
+        "dienst-status-pruefen"
+      ],
+      "links": [],
+      "theme": "fabrik",
+      "one_liner_de": "Wartende Tickets automatisch abarbeiten lassen.",
+      "aliases_de": [
+        "dispatcher",
+        "warteschlange",
+        "autopilot",
+        "queue",
+        "automatisch"
+      ],
+      "common": false,
+      "order": 999,
+      "stages": [
+        "code",
+        "pr-ci",
+        "deploy"
+      ],
+      "concept_de": "Konzept: Warteschlange + Konflikt-Gate + Slots verhindern, dass zwei Läufe dieselben Dateien anfassen."
     }
   ],
   "tools": [
@@ -1196,6 +1337,105 @@
       "order": 999,
       "stages": [],
       "init_prompt_de": "Übergib das an den Security-Agenten: <Secret rotieren, Keycloak/OIDC, DSGVO>."
+    },
+    {
+      "id": "factory",
+      "name_de": "Software Factory (Auto-Bau)",
+      "kind": "task",
+      "kind_de": "Aufgabe",
+      "summary_de": "Baut ein Feature (halb-)autonom: Scout → Design → Plan → Implement → Verify → Deploy.",
+      "what_for_de": "Wenn ein gut umrissenes Feature von einem Multi-Agent-Lauf gebaut werden soll — entweder selbst geplant oder aus einem übergebenen Menschen-Plan (Plan-Reuse).",
+      "how_to_start_de": "Über das Claude-Code-Workflow-Tool mit scripts/factory/pipeline.js starten ('task factory:run' zeigt die genaue Invocation). Für einen gefahrlosen Probelauf args { dry_run: true } übergeben — kein Merge, kein Deploy.",
+      "what_could_go_wrong_de": "Sie implementiert und deployt selbstständig (🟠). Ohne Dry-Run kann ein fehlerhafter Stand live gehen — darum erst den Probelauf, dann bewusst scharf schalten.",
+      "danger": "assisted",
+      "guardrails": [
+        {
+          "id": "G-FACTORY-DRYRUN",
+          "name_de": "Factory erst im Dry-Run beweisen",
+          "rule_de": "Die Software Factory zuerst im Dry-Run (Workflow-args dry_run: true) laufen lassen; den echten Deploy erst nach grünem Probelauf bewusst freischalten.",
+          "why_de": "Die Factory implementiert und deployt selbstständig — ein Probelauf ohne Merge und Deploy fängt Fehler ab, bevor sie live gehen."
+        },
+        {
+          "id": "G-PR-NOT-MAIN",
+          "name_de": "Nie direkt auf main",
+          "rule_de": "Änderungen immer über einen Branch + Pull Request, niemals direkt nach main pushen.",
+          "why_de": "main ist geschützt; direktes Pushen umgeht Review und CI."
+        },
+        {
+          "id": "G-VALIDATE-FIRST",
+          "name_de": "Erst prüfen, dann anwenden",
+          "rule_de": "Manifeste vor dem Anwenden validieren (task workspace:validate) / dry-run nutzen.",
+          "why_de": "Fängt kaputte Konfiguration ab, bevor sie den Cluster erreicht."
+        }
+      ],
+      "related": [
+        "dev-flow-plan",
+        "factory-dispatch"
+      ],
+      "links": [],
+      "theme": "fabrik",
+      "aliases_de": [
+        "factory",
+        "software factory",
+        "pipeline",
+        "auto-bau",
+        "autonom",
+        "scout"
+      ],
+      "common": false,
+      "order": 999,
+      "stages": [
+        "code",
+        "pr-ci",
+        "deploy"
+      ],
+      "init_prompt_de": "Übergib das an die Software Factory: <gut umrissenes Feature> — und mach zuerst einen Dry-Run."
+    },
+    {
+      "id": "factory-dispatch",
+      "name_de": "Factory-Dispatcher (Warteschlange)",
+      "kind": "task",
+      "kind_de": "Aufgabe",
+      "summary_de": "Holt wartende Tickets aus der Warteschlange, prüft Konflikte und startet die Factory-Pipeline.",
+      "what_for_de": "Damit übergebene Tickets (type=feature/status=backlog) automatisch abgearbeitet werden — mit Slots pro Marke, Konflikt-Gate und Watchdog.",
+      "how_to_start_de": "Über das Workflow-Tool mit scripts/factory/dispatcher.js starten ('task factory:dispatch' zeigt die Invocation), wiederkehrend selbst-getaktet via /loop. Probelauf mit args { dry_run: true }.",
+      "what_could_go_wrong_de": "Er startet Bauläufe selbstständig (🟠). Bei überlappenden Dateien greift das Konflikt-Gate; ein hängender Lauf wird nach 30 min vom Watchdog eskaliert.",
+      "danger": "assisted",
+      "guardrails": [
+        {
+          "id": "G-FACTORY-DRYRUN",
+          "name_de": "Factory erst im Dry-Run beweisen",
+          "rule_de": "Die Software Factory zuerst im Dry-Run (Workflow-args dry_run: true) laufen lassen; den echten Deploy erst nach grünem Probelauf bewusst freischalten.",
+          "why_de": "Die Factory implementiert und deployt selbstständig — ein Probelauf ohne Merge und Deploy fängt Fehler ab, bevor sie live gehen."
+        },
+        {
+          "id": "G-PR-NOT-MAIN",
+          "name_de": "Nie direkt auf main",
+          "rule_de": "Änderungen immer über einen Branch + Pull Request, niemals direkt nach main pushen.",
+          "why_de": "main ist geschützt; direktes Pushen umgeht Review und CI."
+        }
+      ],
+      "related": [
+        "factory"
+      ],
+      "links": [],
+      "theme": "fabrik",
+      "aliases_de": [
+        "dispatcher",
+        "warteschlange",
+        "queue",
+        "slots",
+        "watchdog",
+        "scheduler"
+      ],
+      "common": false,
+      "order": 999,
+      "stages": [
+        "code",
+        "pr-ci",
+        "deploy"
+      ],
+      "init_prompt_de": "Starte den Factory-Dispatcher: arbeite wartende Tickets aus der Warteschlange ab (zuerst Dry-Run)."
     }
   ],
   "components": {
@@ -1613,7 +1853,8 @@
         "goalIds": [
           "bug-beheben",
           "feature-bauen",
-          "datenbank-aendern"
+          "datenbank-aendern",
+          "factory-feature-bauen"
         ],
         "toolIds": [
           "dev-flow-plan"
@@ -1630,11 +1871,15 @@
           "website-text-aendern",
           "bug-beheben",
           "feature-bauen",
-          "datenbank-aendern"
+          "datenbank-aendern",
+          "factory-feature-bauen",
+          "factory-autopilot"
         ],
         "toolIds": [
           "dev-flow-execute",
-          "dev-flow-iterate"
+          "dev-flow-iterate",
+          "factory",
+          "factory-dispatch"
         ]
       },
       {
@@ -1647,10 +1892,14 @@
         "goalIds": [
           "bug-beheben",
           "feature-bauen",
-          "pr-oeffnen"
+          "pr-oeffnen",
+          "factory-feature-bauen",
+          "factory-autopilot"
         ],
         "toolIds": [
-          "dev-flow-execute"
+          "dev-flow-execute",
+          "factory",
+          "factory-dispatch"
         ]
       },
       {
@@ -1664,11 +1913,15 @@
           "bug-beheben",
           "feature-bauen",
           "aenderung-ausrollen",
-          "datenbank-aendern"
+          "datenbank-aendern",
+          "factory-feature-bauen",
+          "factory-autopilot"
         ],
         "toolIds": [
           "dev-flow-iterate",
-          "agent-infra"
+          "agent-infra",
+          "factory",
+          "factory-dispatch"
         ]
       },
       {


### PR DESCRIPTION
## Was

Erweitert den **Agent-Help-Sidekick** („Agent-Anleitung", `website/src/components/assistant/AgentGuideView.svelte`) um Erklärungen zu den **neuen Software-Factory-Workflows** — Umfang: **Übergabe + Factory** (vom User gewählt).

Der Sidekick ist datengetrieben (`docs/agent-guide/registry/*.yaml` → `task agent-guide:emit` → `website/src/lib/agent-guide.generated.json`). Es wurden **keine UI-Komponenten** geändert, nur Registry-Inhalte + regenerierte Flächen.

## Neue Registry-Einträge

- **Theme** `fabrik` (🏭 Software Factory)
- **Guardrail** `G-FACTORY-DRYRUN` — erst im Dry-Run beweisen, dann scharf schalten
- **Tools** `factory` (Auto-Bau-Pipeline, `kind: task`) und `factory-dispatch` (Warteschlangen-Dispatcher)
- **Goals** `factory-feature-bauen` (planen mit dev-flow-plan → an Factory übergeben, Plan-Reuse) und `factory-autopilot` (Dispatcher arbeitet wartende Tickets ab)
- **Glossar** Software Factory, Pipeline, Dispatcher, Dry-Run, Scout

Inhalte sind an den gemergten Stand (#1335, dev-flow↔Factory-Integration) geerdet: `dry_run: true`-Flag, `ticket.sh enqueue`, `task factory:run`/`dispatch`. Der `assisted` (🟠)-Tier + Dry-Run-Guardrail spiegeln wider, dass die Factory selbstständig implementiert und deployt.

## Verifikation

- `node scripts/agent-guide/validate.mjs` → Registry valid (inkl. DB-Slug-Cross-Check)
- `npm run test:agent-guide` → 59/59 Emitter-Tests grün
- Website-Vitest (agentGuide/Search/GuideMap) → 38/38 grün
- `task test:inventory` → `test-inventory.json` unverändert
- Generierte Flächen (webapp JSON, docs, maps) frisch via `task agent-guide:emit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)