### PR TITLE
feat(platform): route ops-audit + platform schema to a dedicated platformPool

### DIFF
--- a/website/src/lib/agentGuide.test.ts
+++ b/website/src/lib/agentGuide.test.ts
@@ -47,7 +47,7 @@ describe('agentGuide typed re-export', () => {
 
   it('exposes themes[] (ordered) and glossary[] from the generated JSON', () => {
     expect(Array.isArray(themes)).toBe(true);
-    expect(themes.length).toBe(7);
+    expect(themes.length).toBe(8);
     expect(themes.map(t => t.id)).toEqual(
       [...themes].sort((a, b) => a.order - b.order).map(t => t.id),
     );

--- a/website/src/lib/platform-db.ts
+++ b/website/src/lib/platform-db.ts
@@ -1,4 +1,4 @@
-import { platformPool } from './website-db';
+import { pool, platformPool } from './website-db';
 import { ensureSchemaOnce } from './website-db';
 import platformDescriptions from './platform-descriptions.generated.json';
 
@@ -120,7 +120,9 @@ export async function deleteSoftwareAsset(id: string): Promise<void> {
 }
 
 export async function getTicketsByAsset(slug: string) {
-  const result = await platformPool.query(`
+  // Tickets are per-brand (pool), unlike the centralized platform assets
+  // (platformPool). Querying the viewing brand's tickets tagged for this asset.
+  const result = await pool.query(`
     SELECT t.id, t.external_id, t.title, t.status, t.created_at
     FROM tickets.tickets t
     JOIN tickets.ticket_tags tt ON tt.ticket_id = t.id

--- a/website/src/lib/platform-db.ts
+++ b/website/src/lib/platform-db.ts
@@ -1,4 +1,4 @@
-import { pool } from './website-db';
+import { platformPool } from './website-db';
 import { ensureSchemaOnce } from './website-db';
 import platformDescriptions from './platform-descriptions.generated.json';
 
@@ -37,7 +37,7 @@ export interface HardwareAsset {
 // tables are reproducible on a fresh DB. Descriptions are set ONLY where still NULL
 // or the known English placeholder — never overwriting an admin edit. Wrapped in
 // ensureSchemaOnce so it runs at most once per process (see website-db.ts T000304).
-export async function runPlatformSchema(db: { query: typeof pool.query } = pool): Promise<void> {
+export async function runPlatformSchema(db: { query: typeof platformPool.query } = platformPool): Promise<void> {
   await db.query(`CREATE SCHEMA IF NOT EXISTS platform`);
   await db.query(`CREATE TABLE IF NOT EXISTS platform.software_assets (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(), slug TEXT NOT NULL UNIQUE, name TEXT NOT NULL,
@@ -68,12 +68,12 @@ export async function runPlatformSchema(db: { query: typeof pool.query } = pool)
 }
 
 export function ensurePlatformSchema(): Promise<void> {
-  return ensureSchemaOnce('platform-schema', () => runPlatformSchema(pool));
+  return ensureSchemaOnce('platform-schema', () => runPlatformSchema(platformPool));
 }
 
 export async function listSoftwareAssets(): Promise<SoftwareAsset[]> {
   await ensurePlatformSchema();
-  const result = await pool.query(
+  const result = await platformPool.query(
     'SELECT * FROM platform.software_assets ORDER BY sort_order ASC, name ASC'
   );
   return result.rows;
@@ -81,14 +81,14 @@ export async function listSoftwareAssets(): Promise<SoftwareAsset[]> {
 
 export async function listHardwareAssets(): Promise<HardwareAsset[]> {
   await ensurePlatformSchema();
-  const result = await pool.query(
+  const result = await platformPool.query(
     'SELECT * FROM platform.hardware_assets ORDER BY sort_order ASC, name ASC'
   );
   return result.rows;
 }
 
 export async function upsertSoftwareAsset(asset: Partial<SoftwareAsset>): Promise<SoftwareAsset> {
-  const result = await pool.query(
+  const result = await platformPool.query(
     `INSERT INTO platform.software_assets
       (slug, name, description, category, emoji, clusters, namespace, deployment_name, image_tag, url, base_status, sort_order)
      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
@@ -116,11 +116,11 @@ export async function upsertSoftwareAsset(asset: Partial<SoftwareAsset>): Promis
 }
 
 export async function deleteSoftwareAsset(id: string): Promise<void> {
-  await pool.query('DELETE FROM platform.software_assets WHERE id = $1', [id]);
+  await platformPool.query('DELETE FROM platform.software_assets WHERE id = $1', [id]);
 }
 
 export async function getTicketsByAsset(slug: string) {
-  const result = await pool.query(`
+  const result = await platformPool.query(`
     SELECT t.id, t.external_id, t.title, t.status, t.created_at
     FROM tickets.tickets t
     JOIN tickets.ticket_tags tt ON tt.ticket_id = t.id

--- a/website/src/lib/tickets-db.ts
+++ b/website/src/lib/tickets-db.ts
@@ -612,6 +612,315 @@ export async function initTicketsSchema(): Promise<void> {
                     WHERE external_id ~ '^T[0-9]+$'),
                   true)
   `);
+
+  await pool.query(`
+    CREATE OR REPLACE FUNCTION tickets.fn_purge_test_data()
+      RETURNS JSONB
+      LANGUAGE plpgsql
+      SECURITY DEFINER
+      SET search_path = public, tickets
+    AS $$
+    DECLARE
+      result            JSONB := '{}'::jsonb;
+      cnt               INT;
+      has_scores        BOOLEAN;
+      has_answers       BOOLEAN;
+      has_test_results  BOOLEAN;
+      has_test_runs     BOOLEAN;
+      has_pw_reports    BOOLEAN;
+      has_billing_inv   BOOLEAN;
+      has_src_assn_col  BOOLEAN;
+      has_meetings      BOOLEAN;
+      has_qts_evidence  BOOLEAN;
+      has_inbox_flag    BOOLEAN;
+      has_thread_flag   BOOLEAN;
+      has_messages_flag BOOLEAN;
+      keep_emails       TEXT[] := ARRAY[
+                           'patrick@korczewski.de',
+                           'p.korczewski@gmail.com',
+                           'quamain@web.de'
+                         ];
+    BEGIN
+      -- Probe optional tables / columns.
+      SELECT EXISTS(SELECT 1 FROM information_schema.tables
+                     WHERE table_schema='public' AND table_name='questionnaire_assignment_scores')
+        INTO has_scores;
+      SELECT EXISTS(SELECT 1 FROM information_schema.tables
+                     WHERE table_schema='public' AND table_name='questionnaire_answers')
+        INTO has_answers;
+      SELECT EXISTS(SELECT 1 FROM information_schema.tables
+                     WHERE table_schema='public' AND table_name='test_results')
+        INTO has_test_results;
+      SELECT EXISTS(SELECT 1 FROM information_schema.tables
+                     WHERE table_schema='public' AND table_name='test_runs')
+        INTO has_test_runs;
+      SELECT EXISTS(SELECT 1 FROM information_schema.tables
+                     WHERE table_schema='public' AND table_name='playwright_reports')
+        INTO has_pw_reports;
+      SELECT EXISTS(SELECT 1 FROM information_schema.tables
+                     WHERE table_schema='public' AND table_name='billing_invoices')
+        INTO has_billing_inv;
+      SELECT EXISTS(SELECT 1 FROM information_schema.tables
+                     WHERE table_schema='public' AND table_name='meetings')
+        INTO has_meetings;
+      SELECT EXISTS(SELECT 1 FROM information_schema.columns
+                     WHERE table_schema='tickets'
+                       AND table_name='tickets'
+                       AND column_name='source_test_assignment_id')
+        INTO has_src_assn_col;
+      SELECT EXISTS(SELECT 1 FROM information_schema.columns
+                     WHERE table_schema='public'
+                       AND table_name='questionnaire_test_status'
+                       AND column_name='evidence_id')
+        INTO has_qts_evidence;
+      SELECT EXISTS(SELECT 1 FROM information_schema.columns
+                     WHERE table_schema='public'
+                       AND table_name='inbox_items'
+                       AND column_name='is_test_data')
+        INTO has_inbox_flag;
+      SELECT EXISTS(SELECT 1 FROM information_schema.columns
+                     WHERE table_schema='public'
+                       AND table_name='message_threads'
+                       AND column_name='is_test_data')
+        INTO has_thread_flag;
+      SELECT EXISTS(SELECT 1 FROM information_schema.columns
+                     WHERE table_schema='public'
+                       AND table_name='messages'
+                       AND column_name='is_test_data')
+        INTO has_messages_flag;
+
+      ----------------------------------------------------------------------------
+      -- 1) Clear FK from questionnaire_test_status to test-data tickets.
+      ----------------------------------------------------------------------------
+      UPDATE questionnaire_test_status
+         SET last_failure_ticket_id = NULL
+       WHERE last_failure_ticket_id IN (
+               SELECT id FROM tickets.tickets WHERE is_test_data = true
+             );
+      GET DIAGNOSTICS cnt = ROW_COUNT;
+      result := result || jsonb_build_object('questionnaire_test_status_cleared', cnt);
+
+      ----------------------------------------------------------------------------
+      -- 2) Null out tickets.source_test_assignment_id refs to test assignments.
+      ----------------------------------------------------------------------------
+      IF has_src_assn_col THEN
+        UPDATE tickets.tickets
+           SET source_test_assignment_id = NULL
+         WHERE source_test_assignment_id IN (
+                 SELECT id FROM questionnaire_assignments WHERE is_test_data = true
+               );
+        GET DIAGNOSTICS cnt = ROW_COUNT;
+        result := result || jsonb_build_object('tickets_assignment_ref_cleared', cnt);
+      END IF;
+
+      ----------------------------------------------------------------------------
+      -- 3a) NULL out questionnaire_test_status.evidence_id refs we're about to
+      --     delete.
+      ----------------------------------------------------------------------------
+      IF has_qts_evidence THEN
+        UPDATE questionnaire_test_status
+           SET evidence_id = NULL
+         WHERE evidence_id IN (
+                 SELECT id FROM questionnaire_test_evidence
+                  WHERE assignment_id IN (
+                          SELECT id FROM questionnaire_assignments WHERE is_test_data = true
+                        )
+               );
+        GET DIAGNOSTICS cnt = ROW_COUNT;
+        result := result || jsonb_build_object('questionnaire_test_status_evidence_cleared', cnt);
+      END IF;
+
+      ----------------------------------------------------------------------------
+      -- 3b) Delete questionnaire_test_evidence for test-data assignments.
+      ----------------------------------------------------------------------------
+      DELETE FROM questionnaire_test_evidence
+       WHERE assignment_id IN (
+               SELECT id FROM questionnaire_assignments WHERE is_test_data = true
+             );
+      GET DIAGNOSTICS cnt = ROW_COUNT;
+      result := result || jsonb_build_object('questionnaire_test_evidence', cnt);
+
+      ----------------------------------------------------------------------------
+      -- 4) Delete questionnaire_test_fixtures for test-data assignments.
+      ----------------------------------------------------------------------------
+      DELETE FROM questionnaire_test_fixtures
+       WHERE assignment_id IN (
+               SELECT id FROM questionnaire_assignments WHERE is_test_data = true
+             );
+      GET DIAGNOSTICS cnt = ROW_COUNT;
+      result := result || jsonb_build_object('questionnaire_test_fixtures', cnt);
+
+      ----------------------------------------------------------------------------
+      -- 5) Delete questionnaire_assignment_scores (if table present).
+      ----------------------------------------------------------------------------
+      IF has_scores THEN
+        DELETE FROM questionnaire_assignment_scores
+         WHERE assignment_id IN (
+                 SELECT id FROM questionnaire_assignments WHERE is_test_data = true
+               );
+        GET DIAGNOSTICS cnt = ROW_COUNT;
+        result := result || jsonb_build_object('questionnaire_assignment_scores', cnt);
+      END IF;
+
+      ----------------------------------------------------------------------------
+      -- 6) Delete questionnaire_answers (if table present).
+      ----------------------------------------------------------------------------
+      IF has_answers THEN
+        DELETE FROM questionnaire_answers
+         WHERE assignment_id IN (
+                 SELECT id FROM questionnaire_assignments WHERE is_test_data = true
+               );
+        GET DIAGNOSTICS cnt = ROW_COUNT;
+        result := result || jsonb_build_object('questionnaire_answers', cnt);
+      END IF;
+
+      ----------------------------------------------------------------------------
+      -- 6b) ── questionnaire_templates sweep (NEW in v4 / Gap 2). ───────────────
+      --     fa-fragebogen.spec.ts INSERTs templates with title 'e2e-*' and
+      --     deletes them in afterAll — but a crash leaves them permanently.
+      --     Sweep here, before assignments (7), so any FK from assignment →
+      --     template is already resolved.
+      ----------------------------------------------------------------------------
+      DELETE FROM questionnaire_templates WHERE title LIKE 'e2e-%';
+      GET DIAGNOSTICS cnt = ROW_COUNT;
+      result := result || jsonb_build_object('questionnaire_templates', cnt);
+
+      ----------------------------------------------------------------------------
+      -- 7) Delete the test-data assignments themselves.
+      ----------------------------------------------------------------------------
+      DELETE FROM questionnaire_assignments WHERE is_test_data = true;
+      GET DIAGNOSTICS cnt = ROW_COUNT;
+      result := result || jsonb_build_object('questionnaire_assignments', cnt);
+
+      ----------------------------------------------------------------------------
+      -- 8) Drain transient systemtest plumbing.
+      ----------------------------------------------------------------------------
+      DELETE FROM systemtest_failure_outbox;
+      GET DIAGNOSTICS cnt = ROW_COUNT;
+      result := result || jsonb_build_object('systemtest_failure_outbox', cnt);
+
+      DELETE FROM systemtest_magic_tokens;
+      GET DIAGNOSTICS cnt = ROW_COUNT;
+      result := result || jsonb_build_object('systemtest_magic_tokens', cnt);
+
+      ----------------------------------------------------------------------------
+      -- 9) Optional reporting / run-history tables.
+      ----------------------------------------------------------------------------
+      IF has_pw_reports THEN
+        DELETE FROM playwright_reports;
+        GET DIAGNOSTICS cnt = ROW_COUNT;
+        result := result || jsonb_build_object('playwright_reports', cnt);
+      END IF;
+
+      IF has_test_results THEN
+        DELETE FROM test_results;
+        GET DIAGNOSTICS cnt = ROW_COUNT;
+        result := result || jsonb_build_object('test_results', cnt);
+      END IF;
+      IF has_test_runs THEN
+        DELETE FROM test_runs;
+        GET DIAGNOSTICS cnt = ROW_COUNT;
+        result := result || jsonb_build_object('test_runs', cnt);
+      END IF;
+
+      ----------------------------------------------------------------------------
+      -- 10) Delete child test-data tickets (non-project).
+      ----------------------------------------------------------------------------
+      DELETE FROM tickets.tickets
+       WHERE is_test_data = true
+         AND type <> 'project';
+      GET DIAGNOSTICS cnt = ROW_COUNT;
+      result := result || jsonb_build_object('tickets_children', cnt);
+
+      ----------------------------------------------------------------------------
+      -- 11) Delete project (epic) test-data tickets last.
+      ----------------------------------------------------------------------------
+      DELETE FROM tickets.tickets
+       WHERE is_test_data = true
+         AND type = 'project';
+      GET DIAGNOSTICS cnt = ROW_COUNT;
+      result := result || jsonb_build_object('tickets_projects', cnt);
+
+      ----------------------------------------------------------------------------
+      -- 11b) Messaging sweeps.
+      --     Order: messages → message_threads → inbox_items.
+      ----------------------------------------------------------------------------
+      IF has_messages_flag THEN
+        DELETE FROM messages WHERE is_test_data = true;
+        GET DIAGNOSTICS cnt = ROW_COUNT;
+        result := result || jsonb_build_object('messages', cnt);
+      END IF;
+
+      IF has_thread_flag THEN
+        DELETE FROM message_threads WHERE is_test_data = true;
+        GET DIAGNOSTICS cnt = ROW_COUNT;
+        result := result || jsonb_build_object('message_threads', cnt);
+      END IF;
+
+      IF has_inbox_flag THEN
+        DELETE FROM inbox_items WHERE is_test_data = true;
+        GET DIAGNOSTICS cnt = ROW_COUNT;
+        result := result || jsonb_build_object('inbox_items', cnt);
+      END IF;
+
+      ----------------------------------------------------------------------------
+      -- 11c) Knowledge Collections test data sweep.
+      ----------------------------------------------------------------------------
+      DELETE FROM knowledge.collections WHERE name LIKE 'e2e-crawl-%' OR name LIKE 'e2e-webcrawl-%' OR name LIKE 'e2e-%';
+      GET DIAGNOSTICS cnt = ROW_COUNT;
+      result := result || jsonb_build_object('knowledge_collections', cnt);
+
+      ----------------------------------------------------------------------------
+      -- 11d) ── Meetings sweep (NEW in v4 / Gap 1). ─────────────────────────────
+      --     booking-flow.ts seeds meetings with meeting_type '[TEST] systemtest-
+      --     booking'. These are tracked as fixtures but NOT deleted by the bracket
+      --     because fn_purge_test_data had no meetings step — only the hourly
+      --     CronJob could reach them. Meanwhile the customer allowlist sweep
+      --     (step 12) guards with NOT EXISTS (meetings WHERE customer_id = c.id),
+      --     so test customers also leaked.
+      --     Fix: sweep meetings by meeting_type LIKE '[TEST]%' before customers.
+      ----------------------------------------------------------------------------
+      IF has_meetings THEN
+        DELETE FROM meetings WHERE meeting_type LIKE '[TEST]%';
+        GET DIAGNOSTICS cnt = ROW_COUNT;
+        result := result || jsonb_build_object('meetings', cnt);
+      END IF;
+
+      ----------------------------------------------------------------------------
+      -- 12) Customer allowlist sweep.
+      ----------------------------------------------------------------------------
+      DELETE FROM customers c
+       WHERE c.email <> ALL (keep_emails)
+         AND NOT EXISTS (
+               SELECT 1 FROM meetings m WHERE m.customer_id = c.id
+             )
+         AND (
+               NOT has_billing_inv
+               OR NOT EXISTS (
+                    SELECT 1 FROM billing_invoices bi
+                     WHERE bi.customer_id = c.id::text
+                  )
+             )
+         AND NOT EXISTS (SELECT 1 FROM chat_room_members      WHERE customer_id        = c.id)
+         AND NOT EXISTS (SELECT 1 FROM chat_messages          WHERE sender_customer_id = c.id)
+         AND NOT EXISTS (SELECT 1 FROM chat_message_reads     WHERE customer_id        = c.id)
+         AND NOT EXISTS (SELECT 1 FROM chat_rooms             WHERE direct_customer_id = c.id)
+         AND NOT EXISTS (SELECT 1 FROM document_assignments   WHERE customer_id        = c.id)
+         AND NOT EXISTS (SELECT 1 FROM message_threads        WHERE customer_id        = c.id)
+         AND NOT EXISTS (SELECT 1 FROM messages               WHERE sender_customer_id = c.id)
+         AND NOT EXISTS (SELECT 1 FROM brett_snapshots        WHERE customer_id        = c.id)
+         AND NOT EXISTS (SELECT 1 FROM questionnaire_assignments WHERE customer_id     = c.id)
+         AND NOT EXISTS (SELECT 1 FROM tickets.tickets        WHERE customer_id        = c.id);
+      GET DIAGNOSTICS cnt = ROW_COUNT;
+      result := result || jsonb_build_object('customers', cnt);
+
+      RETURN result;
+    END;
+    $$;
+  `);
+
+  await pool.query(`COMMENT ON FUNCTION tickets.fn_purge_test_data() IS 'Idempotent test-data purge. v4 (2026-05-24)'`);
+  await pool.query(`GRANT EXECUTE ON FUNCTION tickets.fn_purge_test_data() TO website`);
       } finally {
         await client.query(`SELECT pg_advisory_unlock(hashtext('init:tickets'))`);
       }

--- a/website/src/lib/tickets-embed.test.ts
+++ b/website/src/lib/tickets-embed.test.ts
@@ -13,11 +13,14 @@ vi.mock('pg', () => {
 });
 
 // ─── embeddings mock ────────────────────────────────────────────────────────
-const embedBatch = vi.fn();
-const embedQuery = vi.fn();
+let embedBatch: ReturnType<typeof vi.fn>;
+let embedQuery: ReturnType<typeof vi.fn>;
 vi.mock('./embeddings', async (orig) => {
   const actual = await orig<typeof import('./embeddings')>();
-  return { ...actual, embedBatch, embedQuery };
+  const _embedBatch = vi.fn();
+  const _embedQuery = vi.fn();
+  (globalThis as any).__embeddingsMock = { embedBatch: _embedBatch, embedQuery: _embedQuery };
+  return { ...actual, embedBatch: _embedBatch, embedQuery: _embedQuery };
 });
 
 // ─── imports that depend on the mocks ──────────────────────────────────────
@@ -27,6 +30,8 @@ import { MixedEmbeddingModelError } from './tickets-db';
 
 beforeEach(() => {
   poolQuery = (globalThis as any).__pgMock.poolQuery;
+  embedBatch = (globalThis as any).__embeddingsMock.embedBatch;
+  embedQuery = (globalThis as any).__embeddingsMock.embedQuery;
   poolQuery.mockReset();
   embedBatch.mockReset();
   embedQuery.mockReset();

--- a/website/src/lib/website-db.ts
+++ b/website/src/lib/website-db.ts
@@ -31,6 +31,19 @@ function nodeLookup(
 const poolConfig = { connectionString: MEETINGS_DB_URL, lookup: nodeLookup } as unknown as import('pg').PoolConfig;
 export const pool = new Pool(poolConfig);
 
+// Construct a platform database pool.
+// On korczewski brand, this redirects to the mentolder (workspace) database.
+const PLATFORM_DB_URL = (() => {
+  const url = process.env.SESSIONS_DATABASE_URL;
+  if (url && url.includes('shared-db.workspace-korczewski')) {
+    return url.replace('shared-db.workspace-korczewski', 'shared-db.workspace');
+  }
+  return url || 'postgresql://website:devwebsitedb@shared-db.workspace.svc.cluster.local:5432/website';
+})();
+
+const platformPoolConfig = { connectionString: PLATFORM_DB_URL, lookup: nodeLookup } as unknown as import('pg').PoolConfig;
+export const platformPool = new Pool(platformPoolConfig);
+
 // Schema initialisation must run ONCE per process, not on every request.
 // Running idempotent DDL (CREATE TABLE IF NOT EXISTS / ALTER ... ADD CONSTRAINT)
 // on the hot path races concurrent requests on the Postgres system catalog,

--- a/website/src/pages/api/admin/ops/ai/reindex.ts
+++ b/website/src/pages/api/admin/ops/ai/reindex.ts
@@ -1,7 +1,7 @@
 import type { APIRoute } from 'astro';
 import { createK8sClient } from '../../../../../lib/k8s';
 import { getSession, isAdmin } from '../../../../../lib/auth';
-import { pool } from '../../../../../lib/website-db';
+import { platformPool } from '../../../../../lib/website-db';
 import { startAction, finishAction, ConcurrentActionError } from '../../../../../lib/admin-actions';
 import { sanitizeForLog } from '../../../../../lib/sanitize';
 
@@ -21,7 +21,7 @@ export const POST: APIRoute = async ({ request }) => {
 
   let actionId: number | null = null;
   try {
-    actionId = await startAction(pool, {
+    actionId = await startAction(platformPool, {
       actor: session.preferred_username, action: 'ai_reindex', target: collection, payload: { collection },
     });
 
@@ -50,14 +50,14 @@ export const POST: APIRoute = async ({ request }) => {
     };
     await k8s.post(`/apis/batch/v1/namespaces/${WORKSPACE_NS}/jobs`, job);
 
-    await finishAction(pool, actionId, { status: 'success', payload: { job_name: jobName } });
+    await finishAction(platformPool, actionId, { status: 'success', payload: { job_name: jobName } });
     return new Response(JSON.stringify({ action_id: actionId, job_name: jobName }), { status: 200 });
   } catch (err) {
     if (err instanceof ConcurrentActionError) {
       return new Response(JSON.stringify({ error: 'Reindex läuft bereits, bitte warten' }), { status: 409 });
     }
     const msg = sanitizeForLog((err as Error).message);
-    if (actionId !== null) await finishAction(pool, actionId, { status: 'failed', error: msg }).catch(() => {});
+    if (actionId !== null) await finishAction(platformPool, actionId, { status: 'failed', error: msg }).catch(() => {});
     console.error('[ops/ai/reindex]', err);
     return new Response(JSON.stringify({ error: 'Reindex fehlgeschlagen: ' + msg.slice(0, 200) }), { status: 500 });
   }

--- a/website/src/pages/api/admin/ops/audit/log.ts
+++ b/website/src/pages/api/admin/ops/audit/log.ts
@@ -1,6 +1,6 @@
 import type { APIRoute } from 'astro';
 import { getSession, isAdmin } from '../../../../../lib/auth';
-import { pool } from '../../../../../lib/website-db';
+import { platformPool } from '../../../../../lib/website-db';
 import { listActions } from '../../../../../lib/admin-actions';
 
 export const GET: APIRoute = async ({ url, request }) => {
@@ -10,6 +10,6 @@ export const GET: APIRoute = async ({ url, request }) => {
 
   const actionFilter = url.searchParams.get('action_filter') || undefined;
   const limit = Number(url.searchParams.get('limit') ?? 50);
-  const actions = await listActions(pool, { actionFilter, limit });
+  const actions = await listActions(platformPool, { actionFilter, limit });
   return new Response(JSON.stringify({ actions }), { status: 200 });
 };

--- a/website/src/pages/api/admin/ops/redeploy/brett.ts
+++ b/website/src/pages/api/admin/ops/redeploy/brett.ts
@@ -1,7 +1,7 @@
 import type { APIRoute } from 'astro';
 import { createK8sClient } from '../../../../../lib/k8s';
 import { getSession, isAdmin } from '../../../../../lib/auth';
-import { pool } from '../../../../../lib/website-db';
+import { platformPool } from '../../../../../lib/website-db';
 import { startAction, finishAction, ConcurrentActionError } from '../../../../../lib/admin-actions';
 import { sanitizeForLog } from '../../../../../lib/sanitize';
 
@@ -22,7 +22,7 @@ export const POST: APIRoute = async ({ request }) => {
 
   let actionId: number | null = null;
   try {
-    actionId = await startAction(pool, {
+    actionId = await startAction(platformPool, {
       actor: session.preferred_username,
       action: 'redeploy_brett',
       target: cluster,
@@ -37,7 +37,7 @@ export const POST: APIRoute = async ({ request }) => {
       { spec: { template: { metadata: { annotations: { 'kubectl.kubernetes.io/restartedAt': restartedAt } } } } }
     );
 
-    await finishAction(pool, actionId, { status: 'success', payload: { restartedAt } });
+    await finishAction(platformPool, actionId, { status: 'success', payload: { restartedAt } });
     return new Response(JSON.stringify({ action_id: actionId, message: 'Deployment gestartet', restartedAt }), { status: 200 });
   } catch (err) {
     if (err instanceof ConcurrentActionError) {
@@ -46,7 +46,7 @@ export const POST: APIRoute = async ({ request }) => {
     }
     const msg = sanitizeForLog((err as Error).message);
     if (actionId !== null) {
-      await finishAction(pool, actionId, { status: 'failed', error: msg }).catch(() => {});
+      await finishAction(platformPool, actionId, { status: 'failed', error: msg }).catch(() => {});
     }
     console.error('[ops/redeploy/brett]', err);
     return new Response(JSON.stringify({ error: `Aktion fehlgeschlagen: ${msg.slice(0, 200)}` }), { status: 500 });

--- a/website/src/pages/api/admin/ops/redeploy/docs.ts
+++ b/website/src/pages/api/admin/ops/redeploy/docs.ts
@@ -1,7 +1,7 @@
 import type { APIRoute } from 'astro';
 import { createK8sClient } from '../../../../../lib/k8s';
 import { getSession, isAdmin } from '../../../../../lib/auth';
-import { pool } from '../../../../../lib/website-db';
+import { platformPool } from '../../../../../lib/website-db';
 import { startAction, finishAction, ConcurrentActionError } from '../../../../../lib/admin-actions';
 import { sanitizeForLog } from '../../../../../lib/sanitize';
 
@@ -22,7 +22,7 @@ export const POST: APIRoute = async ({ request }) => {
 
   let actionId: number | null = null;
   try {
-    actionId = await startAction(pool, {
+    actionId = await startAction(platformPool, {
       actor: session.preferred_username,
       action: 'redeploy_docs',
       target: cluster,
@@ -37,7 +37,7 @@ export const POST: APIRoute = async ({ request }) => {
       { spec: { template: { metadata: { annotations: { 'kubectl.kubernetes.io/restartedAt': restartedAt } } } } }
     );
 
-    await finishAction(pool, actionId, { status: 'success', payload: { restartedAt } });
+    await finishAction(platformPool, actionId, { status: 'success', payload: { restartedAt } });
     return new Response(JSON.stringify({ action_id: actionId, message: 'Deployment gestartet', restartedAt }), { status: 200 });
   } catch (err) {
     if (err instanceof ConcurrentActionError) {
@@ -46,7 +46,7 @@ export const POST: APIRoute = async ({ request }) => {
     }
     const msg = sanitizeForLog((err as Error).message);
     if (actionId !== null) {
-      await finishAction(pool, actionId, { status: 'failed', error: msg }).catch(() => {});
+      await finishAction(platformPool, actionId, { status: 'failed', error: msg }).catch(() => {});
     }
     console.error('[ops/redeploy/docs]', err);
     return new Response(JSON.stringify({ error: `Aktion fehlgeschlagen: ${msg.slice(0, 200)}` }), { status: 500 });

--- a/website/src/pages/api/admin/ops/redeploy/website.ts
+++ b/website/src/pages/api/admin/ops/redeploy/website.ts
@@ -1,7 +1,7 @@
 import type { APIRoute } from 'astro';
 import { createK8sClient } from '../../../../../lib/k8s';
 import { getSession, isAdmin } from '../../../../../lib/auth';
-import { pool } from '../../../../../lib/website-db';
+import { platformPool } from '../../../../../lib/website-db';
 import { startAction, finishAction, ConcurrentActionError } from '../../../../../lib/admin-actions';
 import { sanitizeForLog } from '../../../../../lib/sanitize';
 
@@ -22,7 +22,7 @@ export const POST: APIRoute = async ({ request }) => {
 
   let actionId: number | null = null;
   try {
-    actionId = await startAction(pool, {
+    actionId = await startAction(platformPool, {
       actor: session.preferred_username,
       action: 'redeploy_website',
       target: cluster,
@@ -37,7 +37,7 @@ export const POST: APIRoute = async ({ request }) => {
       { spec: { template: { metadata: { annotations: { 'kubectl.kubernetes.io/restartedAt': restartedAt } } } } }
     );
 
-    await finishAction(pool, actionId, { status: 'success', payload: { restartedAt } });
+    await finishAction(platformPool, actionId, { status: 'success', payload: { restartedAt } });
     return new Response(JSON.stringify({ action_id: actionId, message: 'Deployment gestartet', restartedAt }), { status: 200 });
   } catch (err) {
     if (err instanceof ConcurrentActionError) {
@@ -46,7 +46,7 @@ export const POST: APIRoute = async ({ request }) => {
     }
     const msg = sanitizeForLog((err as Error).message);
     if (actionId !== null) {
-      await finishAction(pool, actionId, { status: 'failed', error: msg }).catch(() => {});
+      await finishAction(platformPool, actionId, { status: 'failed', error: msg }).catch(() => {});
     }
     console.error('[ops/redeploy/website]', err);
     return new Response(JSON.stringify({ error: `Aktion fehlgeschlagen: ${msg.slice(0, 200)}` }), { status: 500 });

--- a/website/src/pages/api/admin/ops/users/create.ts
+++ b/website/src/pages/api/admin/ops/users/create.ts
@@ -1,7 +1,7 @@
 import type { APIRoute } from 'astro';
 import { getSession, isAdmin } from '../../../../../lib/auth';
 import { createUser as kcCreateUser, assignUserToGroups, sendPasswordResetEmail } from '../../../../../lib/keycloak';
-import { pool } from '../../../../../lib/website-db';
+import { platformPool } from '../../../../../lib/website-db';
 import { startAction, finishAction, ConcurrentActionError } from '../../../../../lib/admin-actions';
 import { sanitizeForLog } from '../../../../../lib/sanitize';
 
@@ -22,7 +22,7 @@ export const POST: APIRoute = async ({ request }) => {
   const username = email.split('@')[0];
   let actionId: number | null = null;
   try {
-    actionId = await startAction(pool, {
+    actionId = await startAction(platformPool, {
       actor: session.preferred_username,
       action: 'user_create',
       target: username,
@@ -45,7 +45,7 @@ export const POST: APIRoute = async ({ request }) => {
       }
     }
 
-    await finishAction(pool, actionId, {
+    await finishAction(platformPool, actionId, {
       status: partial ? 'partial_success' : 'success',
       payload: { user_id: create.userId, partial, inviteError },
       error: partial ? `User angelegt, Einladung fehlgeschlagen: ${inviteError}` : undefined,
@@ -57,7 +57,7 @@ export const POST: APIRoute = async ({ request }) => {
       return new Response(JSON.stringify({ error: 'Anlage läuft bereits, bitte warten' }), { status: 409 });
     }
     const msg = sanitizeForLog((err as Error).message);
-    if (actionId !== null) await finishAction(pool, actionId, { status: 'failed', error: msg }).catch(() => {});
+    if (actionId !== null) await finishAction(platformPool, actionId, { status: 'failed', error: msg }).catch(() => {});
     console.error('[ops/users/create]', err);
     return new Response(JSON.stringify({ error: 'Anlage fehlgeschlagen: ' + msg.slice(0, 200) }), { status: 500 });
   }

--- a/website/src/pages/api/admin/systemtest/purge-all-test-data.ts
+++ b/website/src/pages/api/admin/systemtest/purge-all-test-data.ts
@@ -16,6 +16,7 @@ import { pool } from '../../../../lib/website-db';
 import { getSession, isAdmin } from '../../../../lib/auth';
 import { purgeAllTestData } from '../../../../lib/systemtest/purge-all';
 import { ensureQuestionnaireSchemaOnce } from '../../../../lib/questionnaire-db';
+import { initTicketsSchema } from '../../../../lib/tickets-db';
 
 export const POST: APIRoute = async ({ request }) => {
   const cronSecret = request.headers.get('X-Cron-Secret');
@@ -31,6 +32,7 @@ export const POST: APIRoute = async ({ request }) => {
     // questionnaire/admin page the questionnaire_* / systemtest_* tables may not
     // exist yet. tickets.fn_purge_test_data() DELETEs from them unconditionally,
     // so it would 500 without the tables (T000406). Memoised — runs at most once.
+    await initTicketsSchema();
     await ensureQuestionnaireSchemaOnce(pool);
     const counts = await purgeAllTestData(pool);
     return new Response(

--- a/website/tests/api/ops/ai-reindex.test.ts
+++ b/website/tests/api/ops/ai-reindex.test.ts
@@ -8,12 +8,15 @@ vi.mock('../../../src/lib/auth', () => ({
   getSession: vi.fn(async () => ({ preferred_username: 'gekko', realmRoles: ['admin'] })),
   isAdmin: vi.fn(() => true),
 }));
-vi.mock('../../../src/lib/website-db', () => ({
-  pool: { query: vi.fn()
+vi.mock('../../../src/lib/website-db', () => {
+  const mockQuery = vi.fn()
     .mockResolvedValueOnce({ rows: [] })    // checkConcurrent
-    .mockResolvedValue({ rows: [{ id: 1 }] })  // INSERT + UPDATE
-  },
-}));
+    .mockResolvedValue({ rows: [{ id: 1 }] });  // INSERT + UPDATE
+  return {
+    pool: { query: mockQuery },
+    platformPool: { query: mockQuery },
+  };
+});
 
 import { POST } from '../../../src/pages/api/admin/ops/ai/reindex';
 

--- a/website/tests/api/ops/audit-log.test.ts
+++ b/website/tests/api/ops/audit-log.test.ts
@@ -4,11 +4,15 @@ vi.mock('../../../src/lib/auth', () => ({
   getSession: vi.fn(async () => ({ preferred_username: 'paddione', realmRoles: ['admin'] })),
   isAdmin: vi.fn(() => true),
 }));
-vi.mock('../../../src/lib/website-db', () => ({
-  pool: { query: vi.fn(async () => ({ rows: [
+vi.mock('../../../src/lib/website-db', () => {
+  const q = vi.fn(async () => ({ rows: [
     { id: 5, actor: 'gekko', action: 'redeploy_website', target: 'mentolder', status: 'success', created_at: new Date() },
-  ] })) },
-}));
+  ] }));
+  return {
+    pool: { query: q },
+    platformPool: { query: q },
+  };
+});
 
 import { GET } from '../../../src/pages/api/admin/ops/audit/log';
 

--- a/website/tests/api/ops/redeploy.test.ts
+++ b/website/tests/api/ops/redeploy.test.ts
@@ -9,13 +9,15 @@ vi.mock('../../../src/lib/auth', () => ({
   getSession: vi.fn(async () => ({ preferred_username: 'gekko', realmRoles: ['admin'] })),
   isAdmin: vi.fn(() => true),
 }));
-vi.mock('../../../src/lib/website-db', () => ({
-  pool: {
-    query: vi.fn()
-      .mockResolvedValueOnce({ rows: [] })        // checkConcurrent → no existing action
-      .mockResolvedValue({ rows: [{ id: 1 }] }),  // INSERT + finishAction fallback
-  },
-}));
+vi.mock('../../../src/lib/website-db', () => {
+  const mockQuery = vi.fn()
+    .mockResolvedValueOnce({ rows: [] })        // checkConcurrent → no existing action
+    .mockResolvedValue({ rows: [{ id: 1 }] });  // INSERT + finishAction fallback
+  return {
+    pool: { query: mockQuery },
+    platformPool: { query: mockQuery },
+  };
+});
 
 import { POST as redeployWebsite } from '../../../src/pages/api/admin/ops/redeploy/website';
 

--- a/website/tests/api/ops/users.test.ts
+++ b/website/tests/api/ops/users.test.ts
@@ -11,15 +11,18 @@ vi.mock('../../../src/lib/keycloak', () => ({
   assignUserToGroups: vi.fn(async () => true),
   sendPasswordResetEmail: vi.fn(async () => true),
 }));
-vi.mock('../../../src/lib/website-db', () => ({
-  pool: { query: vi.fn()
+vi.mock('../../../src/lib/website-db', () => {
+  const mockQuery = vi.fn()
     .mockResolvedValueOnce({ rows: [] })       // T2: checkConcurrent SELECT → no conflict
     .mockResolvedValueOnce({ rows: [{ id: 1 }] })  // T2: startAction INSERT → id=1
     .mockResolvedValueOnce({ rows: [{ id: 1 }] })  // T2: finishAction UPDATE
     .mockResolvedValueOnce({ rows: [] })       // T5: checkConcurrent SELECT → no conflict
-    .mockResolvedValue({ rows: [{ id: 1 }] })  // T5: INSERT + finishAction + any subsequent
-  },
-}));
+    .mockResolvedValue({ rows: [{ id: 1 }] }); // T5: INSERT + finishAction + any subsequent
+  return {
+    pool: { query: mockQuery },
+    platformPool: { query: mockQuery },
+  };
+});
 
 import { GET as listUsersHandler } from '../../../src/pages/api/admin/ops/users/list';
 import { POST as createUserHandler } from '../../../src/pages/api/admin/ops/users/create';


### PR DESCRIPTION
## Herkunft

Setzt eine **gestoppte Gemini-Session** fort, deren Ziel die **Verifikation der Software Factory** war. Ich habe deren uncommittete Arbeit (16 Dateien) gesichert, auf post-#1338-`main` rebased, getestet und hier als reviewbaren PR gebündelt.

> **Factory-Verifikation (separat, abgeschlossen):** Die Factory läuft. FA-SF-31 (5/5) + FA-SF-20 (6/6) grün; ein Live-Workflow-Nesting-Smoke (`workflow({scriptPath})` wie `dispatcher.js:91`) lieferte `verdict: FACTORY-EXECUTION-MODEL-WORKS` (genesteter `agent()` lief, ~29k Tokens, Return propagiert). Der IIFE-No-op ist real behoben.

## Inhalt dieses PRs

- **`website-db.ts`**: neuer `platformPool` (aus `SESSIONS_DATABASE_URL`; auf korczewski Umlenkung `shared-db.workspace-korczewski` → `shared-db.workspace`, d.h. Plattform-Layer zentral in der mentolder-DB).
- **`platform-db.ts` + Admin-Ops** (`audit/log`, `ai/reindex`, `redeploy/{brett,docs,website}`, `users/create`): nutzen `platformPool` für Schema + Admin-Action-Audit.
- **`tickets-db.ts`**: `tickets.fn_purge_test_data()` (v4) in `initTicketsSchema()` — die Factory-Testdaten-Aufräumung (bleibt **per-Marke** auf `pool`, by design).
- **`purge-all-test-data.ts`**: `initTicketsSchema()` vor dem Purge (T000406).
- **`tickets-embed.test.ts`**: vi.mock-Hoisting-Fix via `globalThis`-Handle.
- **`agentGuide.test.ts`**: Themes 7 → 8 (Nachzug zum `fabrik`-Theme aus #1338 — schließt eine Test-Lücke, die #1338 hinterlassen hat).

## Verifikation
- **33/33** vitest grün über die 6 berührten Testdateien.
- Mentolder unverändert (`pool` und `platformPool` zeigen dort auf dieselbe DB).

## ⚠️ Review nötig (vor Merge)
1. **Zentralisierung bestätigen:** `platformPool` legt Admin-Audit + Plattform-Assets für **beide Marken** in die mentolder-DB. Gewollt?
2. **`getTicketsByAsset`** nutzt jetzt `platformPool`. Tickets sind aber **per-Marke** — auf korczewski würde diese Funktion damit mentolder-Tickets lesen. Bitte gegen die Produktabsicht prüfen.

Bewusst **nicht auto-gemergt** — wartet auf diese Entscheidung.

🤖 Generated with [Claude Code](https://claude.com/claude-code)