### PR TITLE
fix(platform): keep platformPool per-brand (drop broken centralization)

### DIFF
--- a/website/src/lib/website-db.ts
+++ b/website/src/lib/website-db.ts
@@ -31,18 +31,12 @@ function nodeLookup(
 const poolConfig = { connectionString: MEETINGS_DB_URL, lookup: nodeLookup } as unknown as import('pg').PoolConfig;
 export const pool = new Pool(poolConfig);
 
-// Construct a platform database pool.
-// On korczewski brand, this redirects to the mentolder (workspace) database.
-const PLATFORM_DB_URL = (() => {
-  const url = process.env.SESSIONS_DATABASE_URL;
-  if (url && url.includes('shared-db.workspace-korczewski')) {
-    return url.replace('shared-db.workspace-korczewski', 'shared-db.workspace');
-  }
-  return url || 'postgresql://website:devwebsitedb@shared-db.workspace.svc.cluster.local:5432/website';
-})();
-
-const platformPoolConfig = { connectionString: PLATFORM_DB_URL, lookup: nodeLookup } as unknown as import('pg').PoolConfig;
-export const platformPool = new Pool(platformPoolConfig);
+// Platform/ops-audit pool. This deliberately stays PER-BRAND (== pool).
+// An earlier attempt redirected korczewski -> the mentolder (workspace) DB to
+// centralize, but a korczewski website pod cannot reach shared-db.workspace
+// across namespaces in the fleet cluster (ClusterIP egress -> ECONNREFUSED),
+// which broke korczewski admin-ops. Each brand uses its own shared-db.
+export const platformPool = pool;
 
 // Schema initialisation must run ONCE per process, not on every request.
 // Running idempotent DDL (CREATE TABLE IF NOT EXISTS / ALTER ... ADD CONSTRAINT)


### PR DESCRIPTION
## Problem (Regression aus #1339)

#1339 lenkte korczewskis `platformPool` auf die mentolder-DB (`shared-db.workspace`) um, um Plattform-/Ops-Audit-Daten zu zentralisieren. **Laufzeit-Test ergab:** ein korczewski-Website-Pod erreicht `shared-db.workspace` **nicht** (cross-namespace ClusterIP → `ECONNREFUSED` im Fleet-Cluster). Damit wären korczewskis **Admin-Ops** (Audit-Log, Asset-CRUD, redeploy/user-create/reindex) zur Laufzeit gebrochen. mentolder unberührt (lokal).

Funktional verifiziert:
- korczewski → mentolder-DB: `ECONNREFUSED` ❌
- korczewski → eigene DB: `PERBRAND_OK {"db":"website"}` ✅
- mentolder → eigene DB: `MENTOLDER_OK` ✅

## Fix

`platformPool = pool` (per-Marke). Stellt das funktionierende Vor-#1339-Verhalten wieder her und behält die nützlichen #1339-Teile (`fn_purge_test_data` v4, purge-init-Reihenfolge, Test-Fixes, Theme 7→8). 33/33 Tests grün.

Echte Cross-Brand-Zentralisierung (falls gewünscht) braucht eine **Infra-Änderung** (NetworkPolicy/Konnektivität korczewski→workspace-shared-db), nicht nur ein Host-Rewrite — bewusst hier nicht enthalten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)