### PR TITLE
fix(dev-flow): lazily install node deps in test:all so fresh worktrees pass [T000427]

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -264,6 +264,7 @@ tasks:
       - task: test:unit:website-ci-deploy
       - task: test:unit:plan-frontmatter-hook
       - task: test:unit:worktree-create
+      - task: test:unit:test-tasks-node-deps
 
   test:unit:website-ci-deploy:
     internal: true
@@ -335,6 +336,11 @@ tasks:
     cmds:
       - ./tests/unit/lib/bats-core/bin/bats tests/unit/worktree-create.bats
 
+  test:unit:test-tasks-node-deps:
+    internal: true
+    cmds:
+      - ./tests/unit/lib/bats-core/bin/bats tests/unit/test-tasks-node-deps.bats
+
   test:art-library:
     desc: "Validate every art-library/sets/* manifest"
     cmds:
@@ -380,11 +386,17 @@ tasks:
   test:docs-gen:
     desc: "Run the docs-site generator unit tests + full-build smoke test (node:test)"
     cmds:
+      # Fresh worktrees (scripts/worktree-create.sh) ship no root node_modules;
+      # install lazily before any node script. No-op in CI / installed trees. [T000427]
+      - '[ -d node_modules ] || npm ci'
       - node --test scripts/docs-gen/*.test.mjs
 
   test:agent-guide:
     desc: "Validate the AI-agent guide registry (unit tests + real registry + generated JSON freshness)"
     cmds:
+      # The scripts below `import ... from 'yaml'` (root node_modules). A fresh
+      # worktree has none, so install lazily first. No-op in CI / installed. [T000427]
+      - '[ -d node_modules ] || npm ci'
       - node --test scripts/agent-guide/*.test.mjs
       - node scripts/agent-guide/validate.mjs
       - node scripts/gen-platform-descriptions.mjs

--- a/tests/unit/test-tasks-node-deps.bats
+++ b/tests/unit/test-tasks-node-deps.bats
@@ -1,0 +1,83 @@
+#!/usr/bin/env bats
+# Regression test for T000427.
+#
+# A fresh git worktree created by scripts/worktree-create.sh has NO root
+# node_modules (the wrapper inits submodules but never installs JS deps). When
+# `task test:all` then runs its dep `test:agent-guide`, that task executes node
+# scripts which `import ... from 'yaml'` — a third-party package that lives in
+# the root node_modules. So the offline suite dies on a fresh checkout with
+#   Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'yaml'
+#
+# Fix: every test task that runs a third-party-importing node script must lazily
+# install deps first, using the pattern already established by the Playwright
+# tasks in this Taskfile:
+#   [ -d node_modules ] || npm ci
+# The guard is a no-op in CI (ci.yml runs `npm ci` before `task test:all`) and
+# on any tree that is already installed, so it only ever fires on a fresh local
+# worktree — exactly the broken case.
+#
+# RED until Taskfile.yml guards test:agent-guide (+ defensively test:docs-gen);
+# GREEN after.
+
+setup() {
+  REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+  TASKFILE="$REPO_ROOT/Taskfile.yml"
+  GUARD_RE='\[ -d node_modules \] \|\| npm ci'
+  # A real `node` invocation in a cmd: "      - node ..." (NOT "node_modules").
+  NODE_RE='-[[:space:]]+node[[:space:]]'
+}
+
+# Print the YAML block of a top-level task ("  <name>:") up to (but excluding)
+# the next top-level task — a line that begins with exactly two spaces then a
+# letter. Continuation/cmd lines are indented 4+ spaces, so they stay inside.
+task_block() {
+  awk -v t="  $1:" '
+    index($0, t) == 1 { f = 1; print; next }
+    f && /^  [a-zA-Z]/ { exit }
+    f { print }
+  ' "$TASKFILE"
+}
+
+# 1-based line number of the first regex match in stdin, or empty if none.
+# `--` stops option parsing: NODE_RE begins with '-' and would otherwise be
+# mistaken for a grep flag.
+first_match_line() {
+  grep -nE -- "$1" | head -1 | cut -d: -f1
+}
+
+@test "T000427: Taskfile.yml exists" {
+  [ -f "$TASKFILE" ]
+}
+
+@test "T000427: test:agent-guide block is extractable and runs node" {
+  block="$(task_block test:agent-guide)"
+  [ -n "$block" ]
+  echo "$block" | grep -qE -- "$NODE_RE"
+}
+
+@test "T000427: test:agent-guide lazily installs node deps before any node call" {
+  block="$(task_block test:agent-guide)"
+  echo "$block" | grep -qE -- "$GUARD_RE"
+  guard_ln="$(echo "$block" | first_match_line "$GUARD_RE")"
+  node_ln="$(echo "$block" | first_match_line "$NODE_RE")"
+  [ -n "$guard_ln" ]
+  [ -n "$node_ln" ]
+  [ "$guard_ln" -lt "$node_ln" ]
+}
+
+@test "T000427: test:docs-gen lazily installs node deps before any node call (defensive)" {
+  block="$(task_block test:docs-gen)"
+  echo "$block" | grep -qE -- "$GUARD_RE"
+  guard_ln="$(echo "$block" | first_match_line "$GUARD_RE")"
+  node_ln="$(echo "$block" | first_match_line "$NODE_RE")"
+  [ -n "$guard_ln" ]
+  [ -n "$node_ln" ]
+  [ "$guard_ln" -lt "$node_ln" ]
+}
+
+@test "T000427: the lazy-install guard reuses the existing Taskfile convention" {
+  # 3 pre-existing Playwright guards + the 2 we add here = at least 5.
+  run grep -cE "$GUARD_RE" "$TASKFILE"
+  [ "$status" -eq 0 ]
+  [ "$output" -ge 5 ]
+}


### PR DESCRIPTION
## Was

Behebt **T000427** — `task test:all` scheitert in einem frischen Worktree (von `scripts/worktree-create.sh`) an fehlendem `node_modules`.

## Warum

Ein frischer Worktree initialisiert Submodule, installiert aber **nie** JS-Dependencies. `task test:all` → dep `test:agent-guide` ruft dann Node-Skripte auf, die `import … from 'yaml'` machen (Drittpaket im Root-`node_modules`):

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'yaml'
    imported from .../scripts/agent-guide/load.mjs
```

→ Die ganze Offline-Suite kippt auf einem frischen Checkout.

## Fix

`test:agent-guide` (betroffen) und defensiv `test:docs-gen` bekommen den **bereits etablierten** Lazy-Guard, den die Playwright-Tasks im selben Taskfile schon 3× nutzen:

```yaml
- '[ -d node_modules ] || npm ci'
```

- **No-op in CI** — `ci.yml` macht `npm ci` *vor* `task test:all`, also greift der Guard dort nie (kein Slowdown).
- **No-op in installierten Trees** — feuert nur im frischen lokalen Worktree, genau dem kaputten Fall.

## Test (TDD)

Neu: `tests/unit/test-tasks-node-deps.bats` (in `test:unit` verdrahtet) — struktureller Regressionstest, der prüft, dass beide Tasks Deps **vor** jedem `node`-Aufruf installieren. RED ohne Fix, GREEN mit.

## Verifikation

- ✅ Repro bestätigt: `task test:agent-guide` im frischen Worktree → `ERR_MODULE_NOT_FOUND: yaml`
- ✅ Regressionstest: RED → GREEN
- ✅ Behaviorale Heilung: **derselbe** frische Worktree läuft nach dem Fix komplett durch (Guard zieht `npm ci`, dann 59/59 agent-guide-Tests grün, exit 0)
- ✅ `task test:all` → exit 0 (volle Offline-CI-Gate, keine Regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)