### PR TITLE
chore(dev-flow): delegate plan/impl to fresh subagents instead of context reset

### DIFF
--- a/.claude/skills/dev-flow-execute/SKILL.md
+++ b/.claude/skills/dev-flow-execute/SKILL.md
@@ -13,12 +13,6 @@ Du bist auf einem `feature/*` oder `fix/*` Branch. `dev-flow-plan` hat Spec und 
 
 ---
 
-## Schritt −2: Kontext-Reset + Sonnet (medium) — Execute-Gate
-
-Bitte den User, die Slash-Befehle `/model claude-sonnet-4-6` und danach `/clear` auszuführen. Dies sind User-Befehle, die du nicht selbst ausführen kannst.
-
----
-
 ## Schritt −1: Main-Branch im Haupt-Repo synchronisieren (Pull-First)
 
 Synchronisiere `main` im Haupt-Repo:
@@ -95,19 +89,25 @@ ATTACHMENT_DIR="/tmp/ticket-attachments-$TICKET_ID"
 
 ---
 
-## Schritt 2: Implementierung
+## Schritt 2: Implementierung an frischen Implementer-Subagenten delegieren
 
-### Feature
-Verwende bevorzugt `superpowers:subagent-driven-development` oder `superpowers:executing-plans`.
-- **Milestone-Updates**: Aktualisiere nach jedem abgeschlossenen Meilenstein die Checkbox im Plan (`- [ ] M1` → `- [x] M1`), committe und pushe.
-- **Kollisionen vermeiden**: Falls Delegations-Tools das Skill `finishing-a-development-branch` aufrufen, unterdrücke das interaktive Menü mit dem Argument `--no-menu` oder der Variable `MENU=skip`.
-- **Workspace-Pfad**: Übergib Sub-Agenten immer den absoluten Worktree-Pfad und weise sie an, nur relativ dazu zu arbeiten.
+Statt deinen eigenen Kontext/Modell zurückzusetzen (das ließe dich den Faden verlieren), delegiere die **gesamte Implementierung an EINEN frischen Subagenten** — sauberer Kontext per Konstruktion, günstiges/schnelles Modell für die mechanische Arbeit. Du behältst den vollen Plan-Kontext und verifizierst das Ergebnis anschließend unabhängig.
 
-### Fix
-Verifiziere, dass ein failing Test existiert, bevor du Code änderst. Implementiere nach dem Rot-Grün-Prinzip, bis der Test grün wird.
+Spawne über das `Agent`/`Task`-Tool einen Subagenten mit:
+- `subagent_type: general-purpose`, `model: sonnet`
+- **Effort per Prompt-Direktive:** „Arbeite zügig und fokussiert (medium effort)." (das `Agent`-Tool kennt nur `model`, keinen Effort-Regler).
+- **Kontext-Injektion** (er hat sonst KEINEN Kontext — gib ihm alles explizit):
+  - Absoluter Worktree-Pfad + Branch-Name; er arbeitet NUR relativ dazu.
+  - Plan-Datei `docs/superpowers/plans/<slug>.md` + Ticket-ID.
+  - Attachment-Verzeichnis `$ATTACHMENT_DIR` — bei UI-Arbeit ALLE Bilder/Texte mit dem `Read`-Tool einlesen.
+- **Auftrag:**
+  - *Feature:* Rufe `superpowers:executing-plans` (in-context, KEIN weiterer Agenten-Fan-out) + `test-driven-development` auf und arbeite den Plan vollständig ab. Aktualisiere nach jedem Meilenstein die Checkbox im Plan (`- [ ] M1` → `- [x] M1`), committe und pushe.
+  - *Fix:* Verifiziere zuerst, dass ein failing Test existiert, dann nach Rot-Grün-Prinzip bis grün.
+  - Bei Kompilier-/Testfehlern: starte sofort `systematic-debugging`.
+  - Falls Delegations-Tools `finishing-a-development-branch` aufrufen: Menü mit `--no-menu` / `MENU=skip` unterdrücken.
+  - Erstelle KEINEN PR und merge nicht — stoppe nach grünen Tests und gib eine Zusammenfassung zurück (geänderte Dateien, Test-Status, offene Punkte).
 
-### Fehlerbehandlung & Debugging
-Falls Kompilierungsfehler oder Test-Fehlschläge auftreten, starte sofort das Skill **`systematic-debugging`**, um die Ursache systematisch zu isolieren.
+Nimm das Ergebnis entgegen und mach bei Schritt 3 (unabhängige Verifikation) weiter.
 
 ---
 

--- a/.claude/skills/dev-flow-plan/SKILL.md
+++ b/.claude/skills/dev-flow-plan/SKILL.md
@@ -100,18 +100,21 @@ Ergebnis: Spec-Datei in `docs/superpowers/specs/<date>-<slug>-design.md`.
 ### Schritt 3.5: Playwright-Projekt-Gate
 Falls neue E2E-Tests geplant sind, weise das passende Playwright-Projekt zu (siehe [dev-flow-gotchas.md](file:///home/patrick/Bachelorprojekt/.claude/skills/references/dev-flow-gotchas.md) für Zuordnungstabelle).
 
-### Schritt 3.7: Kontext-Reset + Opus (xhigh)
-Bevor der Plan geschrieben wird, verringere den Kontext-Ballast:
-1. Committe und pushe die Spec-Datei auf den Feature-Branch.
-2. Bitte den User, die Slash-Befehle `/model claude-opus-4-8` und danach `/compact` auszuführen (weise darauf hin, dass dies User-Befehle sind und du sie nicht selbst ausführen kannst).
-3. Lese nach dem Reset die Spec-Datei neu ein.
+### Schritt 3.7: Plan-Erstellung an frischen Opus-Subagenten delegieren
+Statt deinen eigenen Kontext zurückzusetzen (das ließe dich den Faden verlieren), committe die Spec und delegiere das Plan-Schreiben an einen **frischen Subagenten** — der hat per Konstruktion einen sauberen Kontext und bekommt das stärkste Modell + hohen Effort. Du selbst behältst den vollen Brainstorming-Kontext.
 
-### Schritt 4: Plan schreiben
-Rufe `superpowers:writing-plans` auf. **Wichtig:** Weise die Skill ausdrücklich an, die Ausführung/Implementierung noch nicht zu starten (nur Plan schreiben und STOPPEN).
-Wende danach das Frontmatter-Skript an:
-```bash
-bash scripts/plan-frontmatter-hook.sh docs/superpowers/plans/<date>-<slug>.md
-```
+1. Committe und pushe die Spec-Datei auf den Feature-Branch.
+2. Spawne über das `Agent`/`Task`-Tool einen Subagenten mit:
+   - `subagent_type: general-purpose`, `model: opus`
+   - **Effort per Prompt-Direktive:** beginne den Prompt mit „Ultrathink. Denke sehr gründlich nach." (das `Agent`-Tool kennt nur `model`, keinen Effort-Regler — Effort wird also im Prompt vermittelt).
+   - **Kontext-Injektion** (er hat sonst KEINEN Kontext — gib ihm alles explizit):
+     - Absoluter Worktree-Pfad (`pwd`) + Branch-Name; er arbeitet NUR relativ dazu.
+     - Spec-Pfad: `docs/superpowers/specs/<date>-<slug>-design.md`
+     - Ticket-/Grilling-Kontext (`$GRILLING_TICKET_EXT_ID` etc.), falls vorhanden.
+   - **Auftrag:** „Lies die Spec. Rufe `superpowers:writing-plans` auf und schreibe den Implementierungsplan nach `docs/superpowers/plans/<date>-<slug>.md`. Starte KEINE Implementierung (nur Plan schreiben, dann STOPP). Führe danach `bash scripts/plan-frontmatter-hook.sh docs/superpowers/plans/<date>-<slug>.md` aus. Gib den Plan-Pfad und eine 3-Zeilen-Zusammenfassung zurück."
+
+### Schritt 4: Plan prüfen & übernehmen
+Du behältst deinen vollen Brainstorming-Kontext: lies den vom Subagenten zurückgegebenen Plan und prüfe ihn gegen die im Brainstorming getroffenen Entscheidungen. Bei Lücken oder Abweichungen delegiere erneut (Schritt 3.7) mit konkreten Korrektur-Hinweisen. Erst wenn der Plan passt, weiter zu Schritt 4.5.
 
 ### Schritt 4.5: Ticket anlegen
 Erstelle ein Plan-Ticket in der Datenbank:


### PR DESCRIPTION
## Was

Ersetzt die „bitte `/clear` / `/compact` / `/model` ausführen"-Gates in den dev-flow-Skills durch **Delegation an frische Subagenten**.

**Problem:** Nach einem User-getriebenen Kontext-Reset (`/clear`/`/compact`) lief *derselbe* Orchestrator-Agent ohne Gedächtnis weiter und verlor den Faden.

**Lösung:** Ein Subagent hat per Konstruktion einen sauberen Kontext. Der Orchestrator behält seinen vollen Faden und delegiert nur die schwere Aktivität — mit Modell-Override + Effort-Direktive + Kontext-Injektion.

## Änderungen

- **`dev-flow-plan` Schritt 3.7** → spawnt einen Opus `general-purpose`-Subagenten (hoher Effort per Prompt-Direktive) mit injiziertem Spec-Pfad; dieser ruft `writing-plans` + Frontmatter-Hook auf und gibt den Plan zurück. Schritt 4 wird zum Orchestrator-Review.
- **`dev-flow-execute`** → Reset-Gate (Schritt −2) ersatzlos entfernt; Schritt 2 delegiert die gesamte Implementierung an **einen** frischen Sonnet-Subagenten (medium Effort) mit Worktree-Pfad, Plan-Datei und Ticket-ID. Orchestrator macht bei der Verifikation weiter.

## Hinweise

- Effort wird per Prompt-Direktive vermittelt, weil das `Agent`-Tool nur `model` (opus/sonnet/haiku) kennt, keinen Effort-Regler.
- Die vorgebauten Docs-HTMLs unter `k3d/docs-content-built/` sind ein Build-Artefakt und werden beim nächsten `task docs:deploy` neu generiert (kein CI-Sync-Gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)