### PR TITLE
chore(dev-flow): adaptive subagent provisioning (model/effort/context)

### DIFF
--- a/.claude/skills/dev-flow-execute/SKILL.md
+++ b/.claude/skills/dev-flow-execute/SKILL.md
@@ -91,11 +91,12 @@ ATTACHMENT_DIR="/tmp/ticket-attachments-$TICKET_ID"
 
 ## Schritt 2: Implementierung an frischen Implementer-Subagenten delegieren
 
-Statt deinen eigenen Kontext/Modell zurückzusetzen (das ließe dich den Faden verlieren), delegiere die **gesamte Implementierung an EINEN frischen Subagenten** — sauberer Kontext per Konstruktion, günstiges/schnelles Modell für die mechanische Arbeit. Du behältst den vollen Plan-Kontext und verifizierst das Ergebnis anschließend unabhängig.
+Statt deinen eigenen Kontext/Modell zurückzusetzen (das ließe dich den Faden verlieren), delegiere die **gesamte Implementierung an EINEN frischen Subagenten** — sauberer Kontext per Konstruktion, **Modell + Effort passend zum Charakter der Plan-Tasks**. Du behältst den vollen Plan-Kontext und verifizierst das Ergebnis anschließend unabhängig.
 
-Spawne über das `Agent`/`Task`-Tool einen Subagenten mit:
-- `subagent_type: general-purpose`, `model: sonnet`
-- **Effort per Prompt-Direktive:** „Arbeite zügig und fokussiert (medium effort)." (das `Agent`-Tool kennt nur `model`, keinen Effort-Regler).
+Spawne über das `Agent`/`Task`-Tool einen Subagenten, **provisioniert gemäß** [subagent-provisioning.md](file:///home/patrick/Bachelorprojekt/.claude/skills/references/subagent-provisioning.md) (Modell · Effort · Kontext):
+- **Modell — nach Plan-Charakter wählen, nicht pauschal:** mechanisch (Config/Doku/Single-File) → `haiku`; Standard-Feature/Fix (mehrere Dateien, klarer Plan) → `sonnet`; komplex/riskant (systemübergreifend, Architektur, Security, DB-/Schema-Migration, Auto-Deploy) → `opus`. Im Zweifel eine Stufe höher.
+- **Effort per Prompt-Direktive** (das `Agent`-Tool kennt keinen Effort-Regler): mechanisch „Arbeite zügig und fokussiert."; komplex/riskant „Ultrathink. Denke sehr gründlich nach."
+- `subagent_type: general-purpose`.
 - **Kontext-Injektion** (er hat sonst KEINEN Kontext — gib ihm alles explizit):
   - Absoluter Worktree-Pfad + Branch-Name; er arbeitet NUR relativ dazu.
   - Plan-Datei `docs/superpowers/plans/<slug>.md` + Ticket-ID.

--- a/.claude/skills/dev-flow-plan/SKILL.md
+++ b/.claude/skills/dev-flow-plan/SKILL.md
@@ -100,13 +100,14 @@ Ergebnis: Spec-Datei in `docs/superpowers/specs/<date>-<slug>-design.md`.
 ### Schritt 3.5: Playwright-Projekt-Gate
 Falls neue E2E-Tests geplant sind, weise das passende Playwright-Projekt zu (siehe [dev-flow-gotchas.md](file:///home/patrick/Bachelorprojekt/.claude/skills/references/dev-flow-gotchas.md) für Zuordnungstabelle).
 
-### Schritt 3.7: Plan-Erstellung an frischen Opus-Subagenten delegieren
-Statt deinen eigenen Kontext zurückzusetzen (das ließe dich den Faden verlieren), committe die Spec und delegiere das Plan-Schreiben an einen **frischen Subagenten** — der hat per Konstruktion einen sauberen Kontext und bekommt das stärkste Modell + hohen Effort. Du selbst behältst den vollen Brainstorming-Kontext.
+### Schritt 3.7: Plan-Erstellung an einen passend provisionierten Subagenten delegieren
+Statt deinen eigenen Kontext zurückzusetzen (das ließe dich den Faden verlieren), committe die Spec und delegiere das Plan-Schreiben an einen **frischen Subagenten** — der hat per Konstruktion einen sauberen Kontext und bekommt ein **zur Plan-Komplexität passendes Modell + Effort**. Du selbst behältst den vollen Brainstorming-Kontext.
 
 1. Committe und pushe die Spec-Datei auf den Feature-Branch.
-2. Spawne über das `Agent`/`Task`-Tool einen Subagenten mit:
-   - `subagent_type: general-purpose`, `model: opus`
-   - **Effort per Prompt-Direktive:** beginne den Prompt mit „Ultrathink. Denke sehr gründlich nach." (das `Agent`-Tool kennt nur `model`, keinen Effort-Regler — Effort wird also im Prompt vermittelt).
+2. Spawne über das `Agent`/`Task`-Tool einen Subagenten, **provisioniert gemäß** [subagent-provisioning.md](file:///home/patrick/Bachelorprojekt/.claude/skills/references/subagent-provisioning.md) (Modell · Effort · Kontext):
+   - **Modell:** Plan-Schreiben ist reasoning-lastige Meta-Arbeit → Default `model: opus`. Bei trivialem (chore-artigem) Plan genügt `sonnet`.
+   - **Effort:** Default high — beginne den Prompt mit „Ultrathink. Denke sehr gründlich nach." (das `Agent`-Tool kennt nur `model`, keinen Effort-Regler — Effort wird im Prompt vermittelt). **Bei großen multi-subsystem-Specs → ultra:** statt eines Einzel-Agenten das `Workflow`-Tool nutzen (parallele Plan-Segment-Autoren gegen einen geteilten Interface-Contract + abschließende Self-Review), siehe Rubrik.
+   - `subagent_type: general-purpose`.
    - **Kontext-Injektion** (er hat sonst KEINEN Kontext — gib ihm alles explizit):
      - Absoluter Worktree-Pfad (`pwd`) + Branch-Name; er arbeitet NUR relativ dazu.
      - Spec-Pfad: `docs/superpowers/specs/<date>-<slug>-design.md`

--- a/.claude/skills/references/subagent-provisioning.md
+++ b/.claude/skills/references/subagent-provisioning.md
@@ -1,0 +1,41 @@
+# Subagent-Provisioning-Rubrik (Modell · Effort · Kontext)
+
+Wenn ein dev-flow-Skill Arbeit an einen frischen Subagenten delegiert, wähle **nicht** pauschal ein
+Modell — provisioniere den **passenden** Subagenten entlang dreier Achsen. (Gleiche Logik wie die
+Software-Factory-`provision()` aus `docs/superpowers/specs/2026-06-05-software-factory-phase3-design.md`.)
+
+Leitsatz: **Korrektheit vor Kosten.** Im Zweifel eine Stufe höher (Modell) bzw. mehr Effort.
+
+## 1. Modell (ideal)
+
+Klassifiziere die Aufgabe nach **Komplexität × Risiko × Rolle**:
+
+| Aufgaben-Charakter | Modell |
+|---|---|
+| Mechanisch: Config, Doku, Rename, Single-File-Edit, Lockfile-/Dependency-Bump | `haiku` |
+| Standard: normale Feature-/Fix-Implementierung, mehrere Dateien, klarer Plan | `sonnet` |
+| Komplex/riskant: systemübergreifend, Architektur, Security, DB-/Schema-Migration, Nebenläufigkeit, Auto-Deploy | `opus` |
+| Reasoning-lastige Meta-Arbeit: Plan-Schreiben, Design/Architektur, adversariale Review | `opus` (immer) |
+
+Im Zweifel **eine Stufe höher**. Wenn unsicher, ob ein Spezial-Modell überhaupt passt: **`model` weglassen**
+→ der Subagent erbt das Main-Loop-Modell (fast immer korrekt).
+
+## 2. Effort (per Prompt-Direktive)
+
+Das `Agent`/`Task`-Tool kennt **nur `model`, keinen Effort-Regler** — Effort wird über die Prompt-Einleitung vermittelt:
+
+| Stufe | Prompt-Einleitung | Wann |
+|---|---|---|
+| low | „Arbeite zügig und fokussiert." | mechanisch, geringes Risiko |
+| medium | (neutral, kein Zusatz) | Standard |
+| high | „Ultrathink. Denke sehr gründlich nach." | komplex/riskant/Meta |
+| **ultra** | high **+ `Workflow`-Fan-out statt Einzel-Agent** | sehr groß/parallelisierbar (multi-subsystem Plan/Review): nutze das `Workflow`-Tool (mehrere Agenten + adversariale Verifikation gegen einen **geteilten Interface-Contract**), nicht einen einzelnen Agenten |
+
+## 3. Kontext (passend & KOMPAKT)
+
+Der Subagent hat per Konstruktion **keinen** Kontext — gib alles explizit, aber **verdichtet**:
+
+- Absoluter Worktree-Pfad (`pwd`) + Branch-Name; er arbeitet NUR relativ dazu.
+- Die relevanten **Artefakt-Pfade** (Spec/Plan/Ticket), nicht deren Volltext, wenn er sie selbst lesen kann.
+- Bei mehreren Vorstufen-Ergebnissen: **zusammenfassen, nie Roh-JSON dumpen**. (Ein 162k-Zeichen-Prompt ließ
+  einen Synthese-Agenten ohne brauchbare Antwort scheitern — die Provisioning-Lehre schlechthin.)


### PR DESCRIPTION
## Was

Follow-up zu #1345. Die Plan-/Execute-Delegationen in den dev-flow-Skills haben das Modell **hartcodiert** (`opus` für Plan, `sonnet` für Execute) + festen Effort. Diese PR macht die Delegation **adaptiv** — „den passenden Subagenten provisionieren" statt pauschal.

## Änderungen

- **NEU** `.claude/skills/references/subagent-provisioning.md` — geteilte Rubrik (Modell · Effort · Kontext), DRY, gleiche Achsen wie die Software-Factory-`provision()` aus der P3-Spec:
  - **Modell:** mechanisch→`haiku`, Standard→`sonnet`, komplex/riskant→`opus`, reasoning-lastige Meta-Arbeit→`opus` (immer); im Zweifel eine Stufe höher.
  - **Effort** per Prompt-Direktive (low/medium/high/**ultra→`Workflow`-Fan-out**).
  - **Kontext** kompakt: Pfade statt Volltext, Vorstufen zusammenfassen, nie Roh-JSON (Lehre aus einem 162k-Zeichen-Synth-Fail).
- `dev-flow-plan` Schritt 3.7: statt fix `opus` → Rubrik; Default `opus`+Ultrathink, große multi-subsystem-Specs → ultra (Workflow-Fan-out).
- `dev-flow-execute` Schritt 2: statt fix `sonnet` → Modell nach Plan-Task-Charakter.

## Test

Reine Skill-/Doku-Änderung (Markdown). CI: `task test:all`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)