### PR TITLE
fix(dev-flow): prevent interactive prompt from blocking during bats tests [T000430]

### DIFF
--- a/scripts/plan-frontmatter-hook.sh
+++ b/scripts/plan-frontmatter-hook.sh
@@ -71,7 +71,7 @@ title="$(grep -m1 '^# ' "$FILE" | sed 's/^# //' || true)"
 if ! _has_frontmatter; then
     derived="$(_body | _derive_domains | tr '\n' ' ' | sed 's/ *$//')"
     domains_input="$derived"
-    if [[ -t 0 ]]; then
+    if [[ -t 0 && -z "${BATS_TEST_FILENAME:-}" && -z "${CI:-}" ]]; then
         echo "Derived domains for $(basename "$FILE"): [${derived:-none}]"
         echo "Press Enter to accept, or type override (space-separated from: $CANON_ROLES):"
         read -r override_input


### PR DESCRIPTION
Fixes a hang in bats tests where plan-frontmatter-hook.sh prompts for interactive input because fd 0 is a tty in the test environment.