### PR TITLE
chore(ci): upgrade actions/setup-node from v4 to v5, node 20→22 [T000441]

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -22,7 +22,7 @@ jobs:
           VERSION="${TAG#docs-v}"        # 1.2.3
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: '22'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
           fetch-depth: 0
           submodules: recursive
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: '22'
 
@@ -186,7 +186,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with: { node-version: '22' }
       - run: npm ci --prefix brett
       - run: node --test brett/test/*.test.js brett/test/*.test.mjs
@@ -201,9 +201,9 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
-          node-version: '20'
+          node-version: '22'
       - name: Install commitlint
         run: npm install -g @commitlint/cli @commitlint/config-conventional
       - name: Lint commit messages

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -61,10 +61,10 @@ jobs:
       - uses: actions/checkout@v5
         if: steps.gate.outputs.skip != 'true'
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         if: steps.gate.outputs.skip != 'true'
         with:
-          node-version: "20"
+          node-version: "22"
           cache: npm
           cache-dependency-path: tests/e2e/package-lock.json
 

--- a/.github/workflows/quality-loop.yml
+++ b/.github/workflows/quality-loop.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version-file: ".nvmrc"
 


### PR DESCRIPTION
## Zusammenfassung

Upgrade aller `actions/setup-node@v4` → `@v5` und `node-version: '20'` → `'22'` in allen GitHub Actions Workflows.

**Betroffene Dateien (4):**
- `.github/workflows/ci.yml` — 3 Jobs (offline-tests, brett-server-test, commit-lint)
- `.github/workflows/quality-loop.yml`
- `.github/workflows/build-docs.yml`
- `.github/workflows/e2e.yml`

**Hintergrund:** Node.js 20 ist auf GitHub Actions deprecated und wird ab 16. Juni 2026 auf Node.js 24 zwangsmigriert. Dieser PR verhindert unerwartete Breakage.

Closes T000441.

🤖 Generated with [Claude Code](https://claude.com/claude-code)