### PR TITLE
chore(ci): replace commitlint with semantic-pull-request action [T000435]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,17 +198,24 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
-      - uses: actions/checkout@v5
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          fetch-depth: 0
-      - uses: actions/setup-node@v5
-        with:
-          node-version: '22'
-      - name: Install commitlint
-        run: npm install -g @commitlint/cli @commitlint/config-conventional
-      - name: Lint commit messages
-        run: |
-          npx commitlint \
-            --from ${{ github.event.pull_request.base.sha }} \
-            --to ${{ github.event.pull_request.head.sha }} \
-            --verbose
+          # Mirror repo conventions — these are the types used in practice
+          types: |
+            feat
+            fix
+            chore
+            docs
+            refactor
+            test
+            build
+            ci
+            perf
+            revert
+          # Ticket references like [T000436] can extend subject length
+          subjectPattern: ^.{1,200}$
+          subjectPatternError: |
+            The subject must be between 1 and 200 characters.
+            If your PR title includes ticket references like [T000436], that counts toward the limit.


### PR DESCRIPTION
## Zusammenfassung

Ersetzt den `commit-lint` CI-Job: Statt **commitlint** (lintet jeden Branch-Commit) verwendet der Job jetzt **action-semantic-pull-request** (lintet nur den PR-Title).

### Warum?

Das Repo nutzt **Squash-Merge** — alle intermediate Branch-Commits werden verworfen, nur der PR-Title landet als Commit-Message auf `main`. Das Linten jedes Branch-Commits ist daher reine Friktion ohne Qualitätsgewinn.

### Was ändert sich?

| Vorher | Nachher |
|--------|---------|
| 4 Steps (checkout, setup-node, commitlint install, commitlint run) | 1 Step (semantic-pull-request action) |
| Lintet ALLE Branch-Commits | Lintet nur den PR-Title |
| Braucht Node.js + npm install | Kein Node.js — direkt als Action |
| `header-max-length: 150` in commitlint.config.cjs | `subjectPattern: ^.{1,200}$` im Action-Config |

### Konfiguration

- **Types:** feat, fix, chore, docs, refactor, test, build, ci, perf, revert
- **Subject-Limit:** 200 Zeichen (Platz für `[T000XXX]` Ticket-Referenzen)
- **Scope:** Optional (wie bisher)

Closes T000435.

🤖 Generated with [Claude Code](https://claude.com/claude-code)