### PR TITLE
chore(infra): decommission devc and k3s-1, update to new Proxmox hosts [T000448]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,17 +189,10 @@ The env var is `BRAND` in the Kubernetes ConfigMap (`k3d/website.yaml`) and `BRA
 
 ### dev.mentolder.de stack
 
-**Architecture (as of 2026-05):** 3-node k3s HA cluster (`devc`) on Proxmox dev1/dev2/dev3, replacing the old single-VM k3d setup on k3s-1.
+**Architecture & Status (2026-06):** The previous 3-node `devc` k3s HA cluster and the legacy `k3s-1` VM have been permanently **DECOMMISSIONED**. A new Proxmox cluster is active at IPs `10.0.0.9`, `10.0.0.11`, and `10.0.0.25`. Local development is performed via local k3d.
 
-- **`devc` cluster:** 3 k3s server nodes (`devc-1/2/3`, IPs `10.0.0.21/22/23`) with embedded etcd + kube-vip ARP VIP `10.0.0.20`. context: `devc`. Deployed via `task devcluster:deploy`. **`task dev:cluster:create` is deprecated** (prints a deprecation notice and exits non-zero).
-- **Ingress:** Traefik LoadBalancer at VIP `10.0.0.20:80/443`. `oauth2-proxy-dev` in the fleet cluster forwards to `http://10.0.0.20:80`.
-- **Storage:** Longhorn (3 replicas, default StorageClass) on `/var/lib/longhorn` (200 GB LV per node). Install via `k3d/dev-cluster/longhorn-install.sh`. The k3s HelmChart CRD cannot reach `charts.longhorn.io` from within the cluster (TLS intercepted by Traefik); use the direct manifest script.
-- **Dev sees prod data.** The 03:30 UTC `dev-db-refresh` CronJob drops + recreates the prod databases in `shared-db-dev`. `PGHOST=10.0.0.20`, `PGPORT=15432` (LoadBalancer service `shared-db-dev-lb`). The local `task dev:db:refresh` path restores from snapshot files. Don't write production rituals against the dev DB — they will be erased nightly.
-- **SSH 2222 is publicly exposed** but ufw-deny-default'd. Per-CIDR allow rules apply via `task dev:firewall:open` (reads `DEV_SSH_ALLOWLIST` from `environments/mentolder.yaml`). Even allowlisted clients still need a key in `DEV_SISH_AUTHORIZED_KEYS` to publish tunnels.
-- **Dev secrets** are materialised as plain Secrets by `task dev:_materialise-secrets`. Don't `kubectl apply environments/sealed-secrets/mentolder.yaml` to the `devc` context — there's no sealed-secrets controller there.
-- **`workspace-dev` Keycloak client enforces `/dev-access` group membership at the oauth2-proxy layer** (`--allowed-groups=/dev-access`). Add yourself in the KC admin UI before the first visit, else you'll loop on 403.
-
-### WSL Bootstrapping & Workstation Setup
+- **Storage & Services:** Historical reference: longhorn, shared-db-dev, and sish tunnels are offline. Local dev utilizes standard k3d namespaces.
+- **WSL Bootstrapping & Workstation Setup**
 
 - **`task` command collision:** On Ubuntu 24.04 (and newer), `apt install task` installs `taskwarrior` instead of `go-task`. Use `snap install task --classic` or install via the official go-task script.
 - **Docker Desktop integration:** WSL integration is not auto-enabled for new distros, which blocks all build/k3d/docker work. Enable it manually under Docker Desktop Settings > Resources > WSL Integration.

--- a/environments/mentolder.yaml
+++ b/environments/mentolder.yaml
@@ -104,7 +104,8 @@ setup_vars:
   PATRICK_SSH_PUBLIC_KEY: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFN75CnuOz7YXaJipTFxWMVDgm35heu64JKN1QL+Z84+ patrick@korczewski.de"
   GEKKO_SSH_PRIVATE_KEY: SEALED
   GEKKO_SSH_PUBLIC_KEY: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIH43aUqN4w9u7DIt3gUREOJY4pmVIWvIbqFsG/fPSlV0 gekko@mentolder-20260513"
-  # HA dev cluster (devc) — 3-node k3s on Proxmox dev1/dev2/dev3
-  # context: devc, kubeconfig: ~/.kube/config or ~/.kube/devc.yaml
-  DEVC_VIP: "10.0.0.20"
-  DEVC_NODE_IPS: "10.0.0.21,10.0.0.22,10.0.0.23"
+  # HA dev cluster (devc) — 3-node k3s on Proxmox dev1/dev2/dev3 (DECOMMISSIONED)
+  # New Proxmox cluster hosts are at: 10.0.0.9, 10.0.0.11, 10.0.0.25
+  DEVC_VIP: ""
+  DEVC_NODE_IPS: ""
+  PVE_HOSTS: "10.0.0.9,10.0.0.11,10.0.0.25"

--- a/environments/schema.yaml
+++ b/environments/schema.yaml
@@ -952,3 +952,6 @@ setup_vars:
   - name: DEVC_NODE_IPS
     required: false
     description: "Comma-separated IPs of the devc k3s nodes (devc-1/2/3)"
+  - name: PVE_HOSTS
+    required: false
+    description: "Comma-separated IPs of the Proxmox cluster hosts"


### PR DESCRIPTION
This PR updates the dev stack documentation and config to reflect that devc and k3s-1 are decommissioned, and documents the new Proxmox hosts at 10.0.0.9, 10.0.0.11, 10.0.0.25. It also references [T000448] which was marked obsolete in the database.