### PR TITLE
chore(infra): fix dev-deploy namespace targeting and add BRAINSTORM_OIDC_SECRET

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1896,10 +1896,10 @@ tasks:
         if [ "{{.ENV}}" = "dev" ]; then
           # Deploy shared-db prerequisites + shared-db first so dependent services don't crash-loop
           kubectl apply -f k3d/namespace.yaml
-          kubectl apply -f k3d/secrets.yaml
-          kubectl apply -f k3d/configmap-domains.yaml
-          kubectl apply -f k3d/website-schema.yaml
-          kubectl apply -f k3d/shared-db.yaml
+          kubectl apply -f k3d/secrets.yaml -n workspace
+          kubectl apply -f k3d/configmap-domains.yaml -n workspace
+          kubectl apply -f k3d/website-schema.yaml -n workspace
+          kubectl apply -f k3d/shared-db.yaml -n workspace
           echo "Waiting for shared-db to be ready before deploying dependent services..."
           kubectl rollout status deployment/shared-db -n workspace --timeout=120s
           # Full apply (idempotent — updates configs, adds remaining services)

--- a/environments/dev.yaml
+++ b/environments/dev.yaml
@@ -11,6 +11,7 @@ env_vars:
   BRAND_NAME: "KORE"
   WEBSITE_IMAGE: korczewski-website
   DOCS_IMAGE: korczewski-docs
+  WEBSITE_NAMESPACE: workspace-korczewski-dev
   LLM_ENABLED: "false"
   LLM_RERANK_ENABLED: "false"
   LLM_HOST_IP: ""

--- a/k3d/keycloak.yaml
+++ b/k3d/keycloak.yaml
@@ -153,6 +153,11 @@ spec:
                 secretKeyRef:
                   name: workspace-secrets
                   key: COMFY_OIDC_SECRET
+            - name: BRAINSTORM_OIDC_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: workspace-secrets
+                  key: BRAINSTORM_OIDC_SECRET
             - name: TZ
               value: Europe/Berlin
           ports:

--- a/k3d/realm-import-entrypoint.sh
+++ b/k3d/realm-import-entrypoint.sh
@@ -25,7 +25,7 @@ for var in NEXTCLOUD_OIDC_SECRET \
            NC_DOMAIN WEB_DOMAIN VAULT_DOMAIN DOCS_DOMAIN TRAEFIK_DOMAIN MAIL_DOMAIN \
            PROD_DOMAIN KC_USER1_EMAIL KC_USER2_EMAIL \
            SMTP_HOST SMTP_PORT SMTP_FROM SMTP_USER SMTP_PASSWORD \
-           BRETT_OIDC_SECRET COMFY_OIDC_SECRET; do
+           BRETT_OIDC_SECRET COMFY_OIDC_SECRET BRAINSTORM_OIDC_SECRET; do
   eval val="\${${var}:-}"
   if [ -z "$val" ]; then
     echo "[import-entrypoint] WARNUNG: ${var} ist nicht gesetzt!"

--- a/k3d/secrets.yaml
+++ b/k3d/secrets.yaml
@@ -58,6 +58,7 @@ stringData:
   BRETT_BOT_SECRET: "devbrettbotsecret_change_me_a1b2c3d4e5f6"
   BRETT_OIDC_SECRET: "devbrettoidcsecret12345678901234"
   COMFY_OIDC_SECRET: "devcomfyoidcsecret12345678901234"
+  BRAINSTORM_OIDC_SECRET: "devbrainstormoidcsecret12345678"
   # Filen.io backup storage (optional, user-provided)
   FILEN_EMAIL: "dev_filen_email@placeholder.local"
   FILEN_PASSWORD: "dev_filen_password_placeholder"


### PR DESCRIPTION
## Summary

- Fix `kubectl apply` calls in dev `workspace:deploy` to use `-n workspace` (prevents resources landing in `default` ns)
- Add `BRAINSTORM_OIDC_SECRET` to Keycloak import-entrypoint for-loop and Deployment env-vars (was causing Keycloak CrashLoopBackOff on fresh deploys)
- Add `BRAINSTORM_OIDC_SECRET` dev placeholder to `k3d/secrets.yaml`
- Add `WEBSITE_NAMESPACE` to `environments/dev.yaml`

## Test plan

- [ ] `task workspace:deploy ENV=dev` on fresh cluster — all resources land in `workspace` ns
- [ ] Keycloak starts without `${BRAINSTORM_OIDC_SECRET}` unresolved error

🤖 Generated with [Claude Code](https://claude.com/claude-code)