### PR TITLE
ci: cancel-in-progress + npm cache + Brett typecheck gate

### DIFF
--- a/.github/workflows/build-brett.yml
+++ b/.github/workflows/build-brett.yml
@@ -15,6 +15,23 @@ jobs:
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
 
+      # Quality gate: a tag cut from a branch that skipped PR CI cannot ship a
+      # type-broken or test-failing image. Typecheck is a no-op until brett's TS
+      # refactor lands (npm run --if-present), then enforces automatically.
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444  # v5
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: brett/package-lock.json
+
+      - name: Typecheck & test before build
+        run: |
+          npm ci --prefix brett
+          npm --prefix brett run typecheck --if-present
+          npm --prefix brett test
+        env:
+          MOCK_DB: 'true'
+
       - name: Extract version from tag
         id: version
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,10 +6,17 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  # Cancel superseded runs on the same PR (rapid iteration / stacked Factory pushes);
+  # never cancel push-to-main runs, which gate the deployable history.
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   offline-tests:
     name: Offline Tests (Manifests, Configs, Unit)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
         with:
@@ -19,6 +26,7 @@ jobs:
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444  # v5
         with:
           node-version: '22'
+          cache: 'npm'
 
       - name: Install dependencies
         run: |
@@ -48,6 +56,7 @@ jobs:
   security-scan:
     name: Security Scan
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
 
@@ -83,20 +92,33 @@ jobs:
           echo "All managed secret files are git-crypt-encrypted"
 
   brett-server-test:
-    name: Brett Server Tests
+    name: Brett Typecheck & Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444  # v5
-        with: { node-version: '22' }
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: brett/package-lock.json
       - run: npm ci --prefix brett
-      - run: node --test brett/test/*.test.js brett/test/*.test.mjs
+      # No-op until brett's TS refactor lands on the checked-out ref
+      # (`npm run --if-present` exits 0 when the script is absent), then auto-activates
+      # the moment brett/package.json defines a "typecheck" script — no further CI edits.
+      - name: Typecheck
+        run: npm --prefix brett run typecheck --if-present
+      # Call the package's own test script (single source of truth): it is `node --test`
+      # on main today and upgrades to `tsx --test` incl. *.test.ts once the refactor merges.
+      - name: Unit tests
+        run: npm --prefix brett test
         env:
           MOCK_DB: 'true'
 
   commit-lint:
     name: Conventional Commits
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     if: github.event_name == 'pull_request'
     steps:
       - uses: amannn/action-semantic-pull-request@e32d7e603df1aa1ba07e981f2a23455dee596825  # v5.5.3


### PR DESCRIPTION
## Was & Warum

**PR1** der CI/Test/Factory-Härtung (aus einem 4-Agenten-Audit der Testumgebung). Enthält **Tranche A (Brett-Typ-Sicherheit)** + **Tranche B (CI-Speed)**. **Kein Produktverhalten geändert** — reine CI-Config.

Kontext: Der Per-PR-Gate ist mit Ø 83 s bereits schnell; das eigentliche Risiko war **Korrektheit/Coverage** bei schneller Factory-/Brett-TS-Iteration.

### `ci.yml`
- **`concurrency: cancel-in-progress`** nur für `pull_request` (niemals push-to-main): überholte PR-/Factory-Pushes verschwenden keinen Runner mehr.
- **`cache: 'npm'`** auf `offline-tests` + Brett-Job (kaltes `npm ci` ~16 s → warm).
- **`timeout-minutes`** auf jedem Job (15/10/10/5) — ein hängender Step kann nicht mehr den 6-h-Default ausbrennen und den Runner-Pool blockieren.
- **Brett-Job** läuft jetzt zusätzlich `npm --prefix brett run typecheck --if-present` und ruft das paket-eigene `npm test` (Single Source of Truth).

### `build-brett.yml`
- **Typecheck + Unit-Tests vor dem Image-Build** → ein Tag aus einem Branch, der PR-CI übersprungen hat, kann kein typ-kaputtes/test-failing Image ausliefern.

## Der `--if-present`-Trick (Ordering-sicher)

main's `brett/` ist noch der alte Monolith (kein `typecheck`-Script). Mit `npm run typecheck --if-present` ist der Job auf main ein **No-Op** und **schärft sich automatisch**, sobald die TS-Refaktorierung (`feature/brett-typescript-refactor`) nach main mergt — dann gaten `tsc` + `*.test.ts` jeden PR, ohne weitere CI-Edits. Ebenso `npm --prefix brett test`: auf main identisch (`node --test`), auf dem Refactor-Branch automatisch `tsx --test` inkl. `*.test.ts`.

## Verifikation (lokal, gegen main's brett)
- `npm --prefix brett run typecheck --if-present` → **exit 0 (No-Op)**
- `npm --prefix brett test` → **91 pass, 0 fail**
- Beide Workflow-Dateien parsen sauber; Jobs intakt.

## Follow-up
Um den **laufenden** Refactor-Branch *vor* dem Merge zu schützen, muss `feature/brett-typescript-refactor` auf das neue main rebased werden (erbt dieses `ci.yml`). Angeboten.

## Bewusst NICHT enthalten (Begründung)
- **Job-Path-Filter** für den Brett-Job: spart kein Wall-Clock (Long-Pole ist `offline-tests` ~80 s, parallel).
- **kubectl/task Composite-Action** (B4): reine Wartbarkeit, größerer Blast-Radius → separat.
- **Tranche C** (website/arena vitest, bats-Glob) → **PR2** (braucht eigene Offline-Verifikation).
- **Tranche D** (Factory-Loop) + Branch-Protection → **PR3** + Policy-Schritt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
