### PR TITLE
feat(factory): deterministic CI-wait + freshness fast-path + auto-merge

### DIFF
--- a/scripts/factory/classify-failure.sh
+++ b/scripts/factory/classify-failure.sh
@@ -3,15 +3,23 @@
 # SOURCE, do not execute. Defines classify_failure.
 #
 # classify_failure <ci-log-file> echoes exactly ONE of:
-#   ci | test | lint | sql | manifest | secret | realm | other
-# Specific classes (sql/manifest/secret/realm) are checked first so they win over
-# the generic ci/test/lint signal a failed step also emits.
+#   freshness | ci | test | lint | sql | manifest | secret | realm | other
+# Specific classes (freshness/sql/manifest/secret/realm) are checked first so they
+# win over the generic ci/test/lint signal a failed step also emits. freshness is
+# checked before manifest because the stale-file list includes route-manifest.json.
 
 classify_failure() {
   local log="${1:-}"
   if [[ -z "$log" || ! -f "$log" ]]; then
     echo "other"
     return 0
+  fi
+
+  # Stale generated artifacts (freshness:check). Checked FIRST: the stale-file list
+  # includes route-manifest.json, so the word 'manifest' would otherwise mis-route it
+  # to the `manifest` class. A deterministic `task freshness:regenerate` fixes it.
+  if grep -qiE "is stale — run 'task freshness:regenerate'|generated artifact\(s\) are stale|freshness:regenerate locally and commit" "$log"; then
+    echo "freshness"; return 0
   fi
 
   # Specific, high-signal classes first.

--- a/scripts/factory/pipeline.js
+++ b/scripts/factory/pipeline.js
@@ -378,14 +378,30 @@ const deploy = await agent(
     3. STRUCTURED SELF-HEALING RETRY LOOP (≤2 fix attempts; NO raw SQL — use ticket.sh).
        Run CI to green using this exact loop. Per attempt:
 
-       a) Read the current retry count (fail-closed → treat unreadable as 2):
+       a) Wait for CI to finish and read its verdict DETERMINISTICALLY — never eyeball
+          the PR page or guess. From ${REPO}:
+            gh pr checks "$PR" --watch --interval 20 --fail-fast > /tmp/factory-ci-${A.ticket_id}.status 2>&1; CI_RC=$?
+          CI_RC == 0  ⇒ every required check is GREEN → go to step 4 (merge).
+          CI_RC != 0  ⇒ a required check failed or was cancelled → self-heal below.
+          Read the current retry count (fail-closed → treat unreadable as 2):
             RC=$(bash ${REPO}/scripts/ticket.sh retry-count get --id ${A.ticket_id})
-          If CI is GREEN → go to step 4 (merge).
           If RC -ge 2 → STOP: this is the 3rd failure. Set blocked, notify, return.
 
        b) Capture the failing CI log to a file:
             gh run view --log-failed > /tmp/factory-ci-${A.ticket_id}.log 2>&1 || \
               gh run view --log > /tmp/factory-ci-${A.ticket_id}.log 2>&1
+
+       b2) DETERMINISTIC freshness fast-path (no LLM guess, spends NO retry). Classify first:
+            source ${REPO}/scripts/factory/classify-failure.sh
+            CLASS=$(classify_failure /tmp/factory-ci-${A.ticket_id}.log)
+          If CLASS == freshness AND you have not already regenerated once this run:
+            the only failure is stale generated artifacts — regenerate deterministically in
+            the worktree (${WORK_WT}, where ${WORK_BRANCH} is checked out):
+              cd ${WORK_WT} && task freshness:regenerate \
+                && git commit -am 'chore: refresh generated artifacts (factory)' && git push
+            then re-run CI from (a) WITHOUT incrementing the retry count (deterministic
+            regeneration, not a code fix). Do this AT MOST ONCE per run; if CLASS == freshness
+            again afterwards, regeneration did not converge → treat as class "other" and BLOCK.
 
        c) TWO-GATED auto-fix decision. Auto-fix ONLY when BOTH gates pass:
           Gate 1 (failure class): source ${REPO}/scripts/factory/classify-failure.sh;
@@ -409,8 +425,9 @@ const deploy = await agent(
             bash ${REPO}/scripts/ticket.sh add-comment --id ${A.ticket_id} \
               --body "Factory blocked: CI red after ${A.ticket_id} retries (class gate or cap)."
           and report that the ticket is blocked. Take NO merge action.
-   4. Squash-merge (from ${REPO}, NOT the worktree):
-      cd ${REPO} && gh pr merge --squash --delete-branch
+   4. Squash-merge (from ${REPO}, NOT the worktree). With required status checks on
+      main, --auto merges the instant the gate is green and refuses a red merge:
+      cd ${REPO} && gh pr merge "$PR" --squash --delete-branch --auto
    5. Close the ticket and archive the plan:
       bash ${REPO}/scripts/ticket.sh update-status --id ${A.ticket_id} --status done --resolution shipped
       bash ${REPO}/scripts/ticket.sh archive-plan --id ${A.ticket_id} --slug ${slug} \

--- a/tests/local/FA-SF-33-classify-failure.bats
+++ b/tests/local/FA-SF-33-classify-failure.bats
@@ -61,3 +61,12 @@ _cf() { source scripts/factory/classify-failure.sh; classify_failure "$TMPLOG"; 
   run bash -c 'source scripts/factory/classify-failure.sh; classify_failure /nonexistent/path.log'
   [ "$output" = "other" ]
 }
+
+@test "FA-SF-33: stale-artifact freshness failure classifies as freshness" {
+  # The fixture names route-manifest.json on purpose: freshness must win over the
+  # `manifest` class (the word 'manifest' appears in the stale file path).
+  printf "  ✗ website/src/data/route-manifest.json is stale — run 'task freshness:regenerate' locally and commit\nERROR: 1 generated artifact(s) are stale (see above).\n" > "$TMPLOG"
+  run _cf
+  [ "$status" -eq 0 ]
+  [ "$output" = "freshness" ]
+}


### PR DESCRIPTION
## Was & Warum

**PR3** der CI/Test/Factory-Härtung — **Tranche D (Factory-Verify-Loop)**. Strafft die Deploy-Phase der autonomen Software Factory. Verhaltensänderung beschränkt sich auf die Pipeline.

### `scripts/factory/pipeline.js` (Deploy-Phase)
- **D1 — Deterministisches CI-Wait-Primitiv:** Ersetzt das vage „If CI is GREEN" durch `gh pr checks "$PR" --watch --interval 20 --fail-fast`. Der Agent muss das Grün/Rot nicht mehr durch Improvisieren/Pollen der PR-Seite erraten.
- **D3 — freshness-Fast-Path:** Vor der Zwei-Gate-Auto-Fix-Entscheidung. Ein Stale-Artifact-CI-Fehler wird **deterministisch** behoben (`task freshness:regenerate` + commit + push, **höchstens einmal**) — **ohne** einen der 2 Retry-Slots an einen LLM-Rateversuch zu verschwenden.
- **D2 — Auto-Merge:** `gh pr merge "$PR" --squash --delete-branch --auto`. Mit Required Status Checks auf main merged das genau dann, wenn der Gate grün ist, und verweigert einen roten Merge.

### `scripts/factory/classify-failure.sh`
- Neue **`freshness`-Klasse**, geprüft **vor `manifest`** (die Stale-Datei-Liste enthält `route-manifest.json`, dessen `manifest`-Substring es sonst fehlklassifizieren würde).

### `tests/local/FA-SF-33-classify-failure.bats`
- TDD-Fall, der die Reihenfolge `freshness > manifest` festnagelt (Fixture nennt `route-manifest.json`).

## Verifikation (lokal)
- `node --check pipeline.js` sauber; **`task test:factory` 155/0**; `freshness:check` grün; FA-SF-37-Retry-Greps unverletzt.

## Bewusst aufgeschoben
- **D4** (Inner-Loop-`test:all` auf touched_files scopen): tauscht Zuverlässigkeit gegen Tempo und verdient ein eigenes Design + Freigabe. Der volle `test:all` im Inner-Loop ist beabsichtigte Defense-in-Depth.

## Companion-Infra (nächster Schritt, nicht in diesem PR)
- **Required Status Checks** auf main aktivieren **+ Repo-Auto-Merge** einschalten (macht D2 wirksam). Wird nach dem Merge dieses PRs angewandt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
