### PR TITLE
fix: resolve 3 latent test failures (T000454, T000455, T000456)

### DIFF
--- a/k3d/secrets.yaml
+++ b/k3d/secrets.yaml
@@ -71,10 +71,27 @@ stringData:
   # Internal API token — used by tracking-import CronJob to call /api/internal/tickets/notify-close
   # TODO: set a strong random value in environments/.secrets/<env>.yaml then `task env:seal ENV=<env>`
   INTERNAL_API_TOKEN: "dev-placeholder-not-for-prod"
+  # Recovery OIDC secrets
+  RECOVERY_OIDC_SECRET: "devrecoveryoidcsecret12345678901234"
+  # Arena server (korczewski-only, optional)
+  arena_db_password: ""
+  arena_db_url: ""
+  # Tracking DB URL (legacy, tracking pipeline fully removed)
+  TRACKING_DB_URL: ""
   # Voyage AI API key (also projected into knowledge-secrets for CronJob)
   VOYAGE_API_KEY: "dev_voyage_api_key_placeholder"
+  # Dev-environment overrides (shared-db aliases for korczewski dev)
+  DEV_SHARED_DB_PASSWORD: ""
+  DEV_WEBSITE_DB_PASSWORD: ""
+  DEV_OAUTH2_PROXY_COOKIE_SECRET: ""
+  DEV_WORKSPACE_OIDC_SECRET: ""
+  DEV_SISH_AUTHORIZED_KEYS: ""
   # Windows LM router API key — set in .secrets/<env>.yaml for prod
   LLM_ROUTER_API_KEY: ""
+  # Anthropic API key for LLM fallback (optional, user-provided)
+  ANTHROPIC_API_KEY: ""
+  # Hetzner API key for DNS/provisioning (optional, user-provided)
+  HETZNER_API_KEY: ""
 ---
 # knowledge-secrets — Voyage AI API key for knowledge ingestion CronJobs.
 # Prod value must be sealed: task env:seal ENV=<env>

--- a/scripts/task-oracle.sh
+++ b/scripts/task-oracle.sh
@@ -5,7 +5,8 @@ set -euo pipefail
 
 # ── Interactive mode ──────────────────────────────────────────────────────────
 interactive_mode() {
-  local REPO="/home/patrick/Bachelorprojekt"
+  local REPO
+  REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
   set +o pipefail
   local ALL_TASKS
@@ -146,7 +147,7 @@ if [[ "$GOAL" =~ $FASTPATH_REGEX ]]; then
   FP_TASK="${BASH_REMATCH[1]}"
   FP_ENV="${BASH_REMATCH[3]}"   # "dev"|"mentolder"|"korczewski"|"both"|""
 
-  REPO_FP="/home/patrick/Bachelorprojekt"
+  REPO_FP="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
   # Validate task exists in the Taskfile
   set +o pipefail

--- a/tests/unit/fleet-dns-cutover.bats
+++ b/tests/unit/fleet-dns-cutover.bats
@@ -134,7 +134,7 @@ STATE
 
 @test "fleet:shared-services uses office.* hosts not collabora.* for Collabora" {
   # Collabora ingress host must be office.<domain> so Nextcloud public_wopi_url resolves.
-  run grep -A 20 'fleet:shared-services:' "$REPO_ROOT/Taskfile.yml"
+  run grep -A 25 'fleet:shared-services:' "$REPO_ROOT/Taskfile.yml"
   assert_success
   assert_output --partial 'COLLABORA_HOST="office.'
   refute_output --partial 'COLLABORA_HOST="collabora.'
@@ -142,8 +142,9 @@ STATE
 
 @test "fleet:shared-services aliasgroup references files.* not cloud.*" {
   # WOPI aliasgroup must match the Nextcloud host (files.<domain>), not cloud.*.
-  run grep -A 20 'fleet:shared-services:' "$REPO_ROOT/Taskfile.yml"
+  run grep -A 25 'fleet:shared-services:' "$REPO_ROOT/Taskfile.yml"
   assert_success
-  assert_output --partial 'ALIASGROUP1="https://files\.'
-  refute_output --partial 'ALIASGROUP1="https://cloud\.'
+  # Taskfile uses double-backslash (YAML literal block → envsubst escaping)
+  assert_output --partial 'ALIASGROUP1="https://files\\'
+  refute_output --partial 'ALIASGROUP1="https://cloud\\'
 }


### PR DESCRIPTION
Resolves 3 ai_ready tickets:

- **T000454**: Add 11 missing schema keys to `k3d/secrets.yaml` workspace-secrets with dev placeholder values
- **T000455**: Fix `grep -A` context window (20→25) and assertion escaping in fleet-dns-cutover aliasgroup test
- **T000456**: Replace hardcoded `/home/patrick/Bachelorprojekt` path with dynamic detection in task-oracle.sh

All 24 affected tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)