### PR TITLE
fix(factory): git-crypt-safe Implement worktree (unblocks autopilot) [T000473]

### DIFF
--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 355,
+      "file_count": 356,
       "files": [
         "tests/.gitignore",
         "tests/e2e/brett-globals.d.ts",
@@ -242,6 +242,7 @@
         "tests/local/FA-SF-40-provision.bats",
         "tests/local/FA-SF-41-wakeup.bats",
         "tests/local/FA-SF-42-dashboard-route.bats",
+        "tests/local/FA-SF-43-worktree-gitcrypt.bats",
         "tests/local/NFA-01.sh",
         "tests/local/NFA-02.sh",
         "tests/local/NFA-03.sh",

--- a/scripts/factory/pipeline.js
+++ b/scripts/factory/pipeline.js
@@ -134,9 +134,8 @@ let featureComplexity = null
 // Same hoist rationale: the Deploy phase's two-gated retry loop (outside the !REUSE block)
 // feeds the touched-file list to paths_are_escalate_class. Stays [] in the REUSE path.
 let featureTouchedFiles = []
-// The plan file path is captured from the Plan agent's return (the agent stamps the date
-// itself via `date +%F` — the harness does not reliably pass A.timestamp). Used by the
-// Deploy phase's archive-plan step. REUSE path sets it to the handed-off plan.
+// Plan file path: captured from the Plan agent's return (it stamps `date +%F` itself, as
+// A.timestamp is unreliable). Used by Deploy's archive-plan. REUSE → the handed-off plan.
 let planFilePath = REUSE ? REUSE_PLAN : null
 
 // JSON schemas for structured agent outputs
@@ -318,21 +317,15 @@ if (REUSE) {
 }
 
 // ── ④ Implement (ONE shared git-crypt-safe worktree, tasks run sequentially) ──
-// NOTE: we do NOT use the harness `isolation: 'worktree'` option here — it runs a
-// raw `git worktree add` whose checkout invokes the git-crypt smudge filter, which
-// fails fatally because the new per-worktree gitdir has no git-crypt key (T000473 /
-// T000426). Instead one shared worktree is created up front via the git-crypt-safe
-// scripts/worktree-create.sh, and the per-task prompts (and the Deploy phase) already
-// assume that single ${WORK_WT}. Tasks run SEQUENTIALLY: they share one worktree, so
-// concurrent `task test:all` / git-commit would race on the working tree + index.lock.
-// (Plan guarantees disjoint files, so sequential is purely a safety choice — parallel
-// per-task worktrees + a merge step is a possible future optimization.)
+// NOT the harness `isolation: 'worktree'` option: its raw `git worktree add` checkout
+// runs the git-crypt smudge filter and dies (new gitdir has no key) — T000473/T000426.
+// One shared worktree is made up front via scripts/worktree-create.sh; tasks run
+// SEQUENTIALLY (shared tree → concurrent test/commit would race the index.lock; Plan
+// guarantees disjoint files, so per-task worktrees+merge is a future optimization).
 let implemented = []
 if (tasks.length) {
   phase('Implement')
 
-  // Create the ONE shared worktree (git-crypt-safe). worktree-create.sh handles both
-  // a NEW branch (self-plan path, from origin/main) and an EXISTING branch (reuse path).
   const wtSetup = await agent(
     `Record pipeline liveness: run \`bash ${REPO}/scripts/ticket.sh touch --id ${A.ticket_id}\`. Then:
      From ${REPO}, create the isolated worktree for this feature using the git-crypt-safe wrapper
@@ -342,8 +335,7 @@ if (tasks.length) {
     { label: 'impl:worktree-setup', phase: 'Implement' },
   )
   if (!/ready on/.test(String(wtSetup ?? ''))) {
-    // Fail loudly so the dispatcher's escalation routing surfaces it (a swallowed
-    // worktree failure is exactly how the 2026-06-07 first real run looked "green").
+    // Fail loudly so the dispatcher's escalation routing surfaces it (not a swallowed "green").
     await agent(
       `The git-crypt-safe worktree could not be created for ${A.ticket_id}; the pipeline cannot implement.
        Record it and notify: bash ${REPO}/scripts/ticket.sh update-status --id ${A.ticket_id} --status blocked

--- a/scripts/factory/pipeline.js
+++ b/scripts/factory/pipeline.js
@@ -134,6 +134,10 @@ let featureComplexity = null
 // Same hoist rationale: the Deploy phase's two-gated retry loop (outside the !REUSE block)
 // feeds the touched-file list to paths_are_escalate_class. Stays [] in the REUSE path.
 let featureTouchedFiles = []
+// The plan file path is captured from the Plan agent's return (the agent stamps the date
+// itself via `date +%F` — the harness does not reliably pass A.timestamp). Used by the
+// Deploy phase's archive-plan step. REUSE path sets it to the handed-off plan.
+let planFilePath = REUSE ? REUSE_PLAN : null
 
 // JSON schemas for structured agent outputs
 const SCOUT_SCHEMA = {
@@ -212,12 +216,14 @@ if (!isSimple) {
      ARCH/GOALS/RISKS/DECISIONS structure. For medium/complex, include an adversarial
      "try to refute this design" section.
 
-     Save the spec to: ${REPO}/docs/superpowers/specs/${A.timestamp}-${slug}-design.md
+     Save the spec to: ${REPO}/docs/superpowers/specs/$(date +%F)-${slug}-design.md
+     (compute the YYYY-MM-DD prefix yourself with \`date +%F\` — do NOT use a literal
+     "undefined"; the harness does not always pass a timestamp arg.)
 
      Then attach it to the ticket:
      bash ${REPO}/scripts/ticket-attach.sh <uuid> <specfile>
 
-     Return the spec file path (just the path, nothing else).`,
+     Return the spec file path (just the absolute path you wrote, nothing else).`,
     { label: 'design', phase: 'Design' },
   )
   specPath = design.trim()
@@ -257,21 +263,24 @@ if (!isSimple) {
      touch the same file. For each task provide: id, target_files (array),
      acceptance_criteria (array of strings).
 
-     Write the full plan to:
-     ${REPO}/docs/superpowers/plans/${A.timestamp}-${slug}.md
+     Write the full plan to ${REPO}/docs/superpowers/plans/$(date +%F)-${slug}.md
+     (compute the YYYY-MM-DD prefix yourself with \`date +%F\` — do NOT use a literal
+     "undefined"; the harness does not always pass a timestamp arg.)
 
-     Then run the frontmatter hook:
-     bash ${REPO}/scripts/plan-frontmatter-hook.sh ${REPO}/docs/superpowers/plans/${A.timestamp}-${slug}.md
+     Then run the frontmatter hook on the SAME file you just wrote:
+     bash ${REPO}/scripts/plan-frontmatter-hook.sh <the-plan-file-you-wrote>
 
-     Return a JSON object { tasks: [...] } matching the task schema.`,
+     Return a JSON object { tasks: [...], plan_path: "<absolute path of the plan file you wrote>" }
+     matching the schema.`,
     {
       ...(planProv.model ? { model: planProv.model } : {}),
       label: 'plan:decompose',
       phase: 'Plan',
       schema: {
         type: 'object',
-        required: ['tasks'],
+        required: ['tasks', 'plan_path'],
         properties: {
+          plan_path: { type: 'string' },
           tasks: {
             type: 'array',
             items: {
@@ -289,54 +298,94 @@ if (!isSimple) {
     },
   )
   tasks = plan.tasks
+  planFilePath = plan.plan_path
 }
 }
 
 if (REUSE) {
   phase('Plan')
   const reuse = await agent(
-    `A human already planned this feature via dev-flow. Check out the existing branch
-     ${WORK_BRANCH} into an isolated worktree at ${WORK_WT} (from ${REPO}), then read the
-     plan file ${REUSE_PLAN} on that branch. Decompose it into independent tasks where no
-     two tasks touch the same file: each { id, target_files:[...], acceptance_criteria:[...] }.
+    `A human already planned this feature via dev-flow on the existing branch ${WORK_BRANCH}.
+     Read the plan file WITHOUT creating a worktree (the Implement phase creates the shared
+     worktree later) — from ${REPO} run: git show "origin/${WORK_BRANCH}:${REUSE_PLAN}"
+     (fall back to \`git show "${WORK_BRANCH}:${REUSE_PLAN}"\` if the remote ref is absent).
+     Decompose it into independent tasks where no two tasks touch the same file:
+     each { id, target_files:[...], acceptance_criteria:[...] }.
      Do NOT write a new plan or spec — reuse the human one. Return { tasks: [...] }.`,
     { label: 'plan:reuse', phase: 'Plan', schema: { type:'object', required:['tasks'], properties:{ tasks:{ type:'array', items:{ type:'object', required:['id','target_files','acceptance_criteria'], properties:{ id:{type:'string'}, target_files:{type:'array',items:{type:'string'}}, acceptance_criteria:{type:'array',items:{type:'string'}} } } } } } },
   )
   tasks = reuse.tasks
 }
 
-// ── ④ Implement (N parallel tasks, isolated worktrees) ─────────────────────
+// ── ④ Implement (ONE shared git-crypt-safe worktree, tasks run sequentially) ──
+// NOTE: we do NOT use the harness `isolation: 'worktree'` option here — it runs a
+// raw `git worktree add` whose checkout invokes the git-crypt smudge filter, which
+// fails fatally because the new per-worktree gitdir has no git-crypt key (T000473 /
+// T000426). Instead one shared worktree is created up front via the git-crypt-safe
+// scripts/worktree-create.sh, and the per-task prompts (and the Deploy phase) already
+// assume that single ${WORK_WT}. Tasks run SEQUENTIALLY: they share one worktree, so
+// concurrent `task test:all` / git-commit would race on the working tree + index.lock.
+// (Plan guarantees disjoint files, so sequential is purely a safety choice — parallel
+// per-task worktrees + a merge step is a possible future optimization.)
 let implemented = []
 if (tasks.length) {
   phase('Implement')
-  implemented = (await pipeline(
-    tasks,
-    (t) => {
-      const prov = provision({ complexity: featureComplexity, role: 'implement', risk: (t.target_files?.some((f) => /\.sql$|^k3d\/|^environments\/|realm.*\.json/.test(f)) ? 'high' : 'low'), budgetRemaining: 1, ticketId: A.ticket_id, touchedFiles: t.target_files, gpuEmbeddings: false })
-      return agent(
-        `Record pipeline liveness first so the dispatcher watchdog does not flag this run as stale: run \`bash ${REPO}/scripts/ticket.sh touch --id ${A.ticket_id}\`. Then:
-         Implement task ${t.id} on branch ${WORK_BRANCH} in an isolated worktree at ${WORK_WT}.
-         Target files: ${t.target_files.join(', ')}.
-         Follow TDD (red-green). Acceptance criteria: ${t.acceptance_criteria.join('; ')}.
-         DARK-LAUNCH: gate every new user-visible behavior behind isFeatureEnabled('${brand}', '${slug}')
-         (import from website/src/lib/tickets-db.ts). The flag defaults OFF, so the merge ships dark;
-         do NOT enable it in code. The default-OFF feature_flags row is seeded in the Deploy phase.
-         Provisioned context hints (assemble compactly, never raw-dump): ${prov.contextHints.join(' | ')}.
-         After implementing, run locally:
-           cd ${WORK_WT} && task workspace:validate && task test:all && task freshness:regenerate
-         (freshness:regenerate keeps generated artifacts like test-inventory.json and route-manifest.json
-         up to date so CI passes. Commit the regenerated files alongside your implementation.)
-         Return a summary of the diff and the local test result (pass/fail).`,
-        { label: `impl:${t.id}`, phase: 'Implement', isolation: 'worktree', ...(prov.model ? { model: prov.model } : {}) },
-      )
-    },
-    (_res, t) => agent(
-      `Self-verify task ${t.id}: re-read the implementation diff and confirm that each
-       acceptance criterion is met: ${t.acceptance_criteria.join('; ')}.
-       Report pass/fail for each criterion.`,
+
+  // Create the ONE shared worktree (git-crypt-safe). worktree-create.sh handles both
+  // a NEW branch (self-plan path, from origin/main) and an EXISTING branch (reuse path).
+  const wtSetup = await agent(
+    `Record pipeline liveness: run \`bash ${REPO}/scripts/ticket.sh touch --id ${A.ticket_id}\`. Then:
+     From ${REPO}, create the isolated worktree for this feature using the git-crypt-safe wrapper
+     (do NOT run a raw \`git worktree add\` — it fails on git-crypt'd paths):
+       bash ${REPO}/scripts/worktree-create.sh ${WORK_BRANCH} ${WORK_WT} origin/main
+     Report the FULL stdout and the exit code. A success line contains "ready on".`,
+    { label: 'impl:worktree-setup', phase: 'Implement' },
+  )
+  if (!/ready on/.test(String(wtSetup ?? ''))) {
+    // Fail loudly so the dispatcher's escalation routing surfaces it (a swallowed
+    // worktree failure is exactly how the 2026-06-07 first real run looked "green").
+    await agent(
+      `The git-crypt-safe worktree could not be created for ${A.ticket_id}; the pipeline cannot implement.
+       Record it and notify: bash ${REPO}/scripts/ticket.sh update-status --id ${A.ticket_id} --status blocked
+       Then PushNotification is DEFERRED — run \`ToolSearch select:PushNotification\`, then call it once:
+         title:   "Factory worktree setup failed: ${A.ticket_id} (${brand})"
+         message: "scripts/worktree-create.sh did not report success. Detail: ${String(wtSetup ?? '').slice(0, 240)}"
+       Report what was notified.`,
+      { label: 'impl:worktree-escalate', phase: 'Implement' },
+    )
+    return { status: 'blocked', reason: 'worktree-setup', detail: String(wtSetup ?? '').slice(0, 400) }
+  }
+
+  for (const t of tasks) {
+    const prov = provision({ complexity: featureComplexity, role: 'implement', risk: (t.target_files?.some((f) => /\.sql$|^k3d\/|^environments\/|realm.*\.json/.test(f)) ? 'high' : 'low'), budgetRemaining: 1, ticketId: A.ticket_id, touchedFiles: t.target_files, gpuEmbeddings: false })
+    const impl = await agent(
+      `Record pipeline liveness first so the dispatcher watchdog does not flag this run as stale: run \`bash ${REPO}/scripts/ticket.sh touch --id ${A.ticket_id}\`. Then:
+       Implement task ${t.id} on branch ${WORK_BRANCH} in the SHARED worktree at ${WORK_WT}
+       (it already exists and ${WORK_BRANCH} is checked out there — do NOT run \`git worktree add\`).
+       Target files: ${t.target_files.join(', ')}.
+       Follow TDD (red-green). Acceptance criteria: ${t.acceptance_criteria.join('; ')}.
+       DARK-LAUNCH: gate every new user-visible behavior behind isFeatureEnabled('${brand}', '${slug}')
+       (import from website/src/lib/tickets-db.ts). The flag defaults OFF, so the merge ships dark;
+       do NOT enable it in code. The default-OFF feature_flags row is seeded in the Deploy phase.
+       Provisioned context hints (assemble compactly, never raw-dump): ${prov.contextHints.join(' | ')}.
+       After implementing, run locally:
+         cd ${WORK_WT} && task workspace:validate && task test:all && task freshness:regenerate
+       (freshness:regenerate keeps generated artifacts like test-inventory.json and route-manifest.json
+       up to date so CI passes.)
+       Finally COMMIT your work on ${WORK_BRANCH} (so the Verify/Deploy phases can diff it):
+         cd ${WORK_WT} && git add -A && git commit -m ${JSON.stringify(`feat(${slug}): ${t.id} [factory]`)}
+       Return a summary of the diff and the local test result (pass/fail).`,
+      { label: `impl:${t.id}`, phase: 'Implement', ...(prov.model ? { model: prov.model } : {}) },
+    )
+    if (impl == null) continue   // agent died (terminal API error) — skip its self-verify
+    const verify = await agent(
+      `Self-verify task ${t.id}: re-read the implementation diff in ${WORK_WT}
+       (git -C ${WORK_WT} diff origin/main...HEAD) and confirm each acceptance criterion is met:
+       ${t.acceptance_criteria.join('; ')}. Report pass/fail for each criterion.`,
       { label: `impl-verify:${t.id}`, phase: 'Implement' },
-    ),
-  )).filter(Boolean)
+    )
+    if (verify != null) implemented.push(verify)
+  }
 }
 
 // ── ⑤ Verify (adversarial review panel — three parallel lenses) ────────────
@@ -484,7 +533,7 @@ const deploy = await agent(
    5. Close the ticket and archive the plan:
       bash ${REPO}/scripts/ticket.sh update-status --id ${A.ticket_id} --status done --resolution shipped
       bash ${REPO}/scripts/ticket.sh archive-plan --id ${A.ticket_id} --slug ${slug} \
-        --branch ${WORK_BRANCH} --plan-file ${REPO}/docs/superpowers/plans/${A.timestamp}-${slug}.md
+        --branch ${WORK_BRANCH} --plan-file ${planFilePath ?? `${REPO}/docs/superpowers/plans/${slug}.md`}
    5b. Seed the dark-launch flag default-OFF for BOTH brands (mirrors the
        isFeatureEnabled('${slug}') gate added during Implement):
       bash ${REPO}/scripts/ticket.sh feature-flag set --brand mentolder --key ${slug} --enabled false --set-by factory

--- a/scripts/worktree-create.sh
+++ b/scripts/worktree-create.sh
@@ -12,9 +12,13 @@
 # (locked repo). Finally it inits submodules (the BATS runner lives in one).
 #
 # Usage: scripts/worktree-create.sh <branch> <path> [<base>]
-#   <branch>  new branch name, e.g. fix/foo
+#   <branch>  branch name, e.g. fix/foo. If it already exists (locally or on
+#             origin) the worktree CHECKS IT OUT; otherwise a new branch is
+#             created from <base>. The existing-branch mode is what the Software
+#             Factory plan-reuse / dev-flow handoff path needs (T000473).
 #   <path>    worktree path, e.g. /tmp/wt-foo
-#   <base>    base ref (default: origin/main)
+#   <base>    base ref for a NEW branch (default: origin/main); ignored when the
+#             branch already exists.
 set -euo pipefail
 
 BRANCH="${1:?Usage: worktree-create.sh <branch> <path> [<base>]}"
@@ -25,19 +29,38 @@ BASE="${3:-origin/main}"
 COMMON_DIR="$(cd "$(git rev-parse --git-common-dir)" && pwd)"
 KEY_SRC="$COMMON_DIR/git-crypt/keys/default"
 
+# Does the branch already exist locally or on origin? Decides create-vs-checkout
+# and whether rollback may delete the branch (never delete a pre-existing one).
+BRANCH_EXISTS=0
+if git show-ref --verify --quiet "refs/heads/$BRANCH" \
+   || git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+    BRANCH_EXISTS=1
+fi
+
+# Idempotency: drop a stale worktree at this path left by a prior aborted run
+# (removing a worktree never deletes its branch). Lets the factory retry cleanly.
+git worktree remove --force "$WT_PATH" 2>/dev/null || true
+git worktree prune 2>/dev/null || true
+
 # 1) Skeleton without checkout — never runs the smudge filter, so it cannot fail
 #    on git-crypt paths.
-git worktree add --no-checkout -b "$BRANCH" "$WT_PATH" "$BASE"
+if [ "$BRANCH_EXISTS" -eq 1 ]; then
+    # Existing branch: fetch it so the local ref is current, then check it out.
+    git fetch --quiet origin "$BRANCH" 2>/dev/null || true
+    git worktree add --no-checkout "$WT_PATH" "$BRANCH"
+else
+    git worktree add --no-checkout -b "$BRANCH" "$WT_PATH" "$BASE"
+fi
 
-# Roll back the half-created worktree + branch if any later step fails (cp,
-# checkout, submodule). Otherwise a retry hits a misleading "branch already
-# exists" / "<path> already exists" that hides the original error.
+# Roll back the half-created worktree (+ the branch ONLY if we created it) if any
+# later step fails (cp, checkout, submodule). Otherwise a retry hits a misleading
+# "branch already exists" / "<path> already exists" that hides the original error.
 _ok=0
 _rollback() {
     [ "$_ok" -eq 1 ] && return
-    echo "worktree-create: setup failed — rolling back $WT_PATH and branch $BRANCH" >&2
+    echo "worktree-create: setup failed — rolling back $WT_PATH${BRANCH_EXISTS:+ (keeping existing branch $BRANCH)}" >&2
     git worktree remove --force "$WT_PATH" 2>/dev/null || true
-    git branch -D "$BRANCH" 2>/dev/null || true
+    [ "$BRANCH_EXISTS" -eq 0 ] && git branch -D "$BRANCH" 2>/dev/null || true
 }
 trap _rollback EXIT
 
@@ -64,4 +87,8 @@ fi
 git -C "$WT_PATH" submodule update --init --recursive --quiet
 
 _ok=1   # reached a clean finish — disarm the rollback trap
-echo "worktree-create: $WT_PATH ready on branch $BRANCH (base $BASE)"
+if [ "$BRANCH_EXISTS" -eq 1 ]; then
+    echo "worktree-create: $WT_PATH ready on existing branch $BRANCH"
+else
+    echo "worktree-create: $WT_PATH ready on branch $BRANCH (base $BASE)"
+fi

--- a/tests/local/FA-SF-43-worktree-gitcrypt.bats
+++ b/tests/local/FA-SF-43-worktree-gitcrypt.bats
@@ -1,0 +1,45 @@
+#!/usr/bin/env bats
+# FA-SF-43: the factory pipeline's Implement phase must create its worktree via the
+# git-crypt-safe scripts/worktree-create.sh, NOT the harness `isolation: 'worktree'`
+# option. The harness option runs a raw `git worktree add` whose checkout invokes the
+# git-crypt smudge filter and fails fatally (the new per-worktree gitdir has no key) —
+# T000473 / T000426. Verified live 2026-06-07: the first real autopilot run failed at
+# exactly this step. These are structural guards (grep + node --check), in the spirit
+# of FA-SF-20/31, because the Workflow script cannot be unit-executed offline.
+
+@test "FA-SF-43: pipeline.js does NOT pass the harness isolation:'worktree' option (code, not comments)" {
+  run bash -c "CODE_ONLY() { grep -v '^[[:space:]]*//' scripts/factory/pipeline.js | grep -v '^[[:space:]]*\*'; }; CODE_ONLY | grep -Eq \"isolation:[[:space:]]*'worktree'\""
+  [ "$status" -ne 0 ]
+}
+
+@test "FA-SF-43: pipeline.js creates the worktree via scripts/worktree-create.sh" {
+  run grep -Eq 'scripts/worktree-create\.sh[[:space:]]+\$\{WORK_BRANCH\}[[:space:]]+\$\{WORK_WT\}' scripts/factory/pipeline.js
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-43: pipeline.js fails loudly (returns blocked) when worktree setup fails" {
+  run grep -Eq "reason: 'worktree-setup'" scripts/factory/pipeline.js
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-43: spec/plan filenames are date-stamped by the agent, not from A.timestamp" {
+  # the undefined- filename bug: A.timestamp is not reliably passed → must use date +%F
+  run grep -Eq '\$\{A\.timestamp\}-\$\{slug\}' scripts/factory/pipeline.js
+  [ "$status" -ne 0 ]
+  run grep -Eq 'docs/superpowers/specs/\$\(date \+%F\)-\$\{slug\}-design\.md' scripts/factory/pipeline.js
+  [ "$status" -eq 0 ]
+  run grep -Eq 'docs/superpowers/plans/\$\(date \+%F\)-\$\{slug\}\.md' scripts/factory/pipeline.js
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-43: worktree-create.sh supports an existing branch (reuse/dev-flow path)" {
+  run grep -q 'BRANCH_EXISTS' scripts/worktree-create.sh
+  [ "$status" -eq 0 ]
+  run bash -n scripts/worktree-create.sh
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-43: pipeline.js still parses" {
+  run node --check scripts/factory/pipeline.js
+  [ "$status" -eq 0 ]
+}

--- a/website/src/data/test-inventory.json
+++ b/website/src/data/test-inventory.json
@@ -1062,6 +1062,12 @@
     "kind": "shell"
   },
   {
+    "id": "FA-SF-43",
+    "file": "tests/local/FA-SF-43-worktree-gitcrypt.bats",
+    "category": "FA",
+    "kind": "shell"
+  },
+  {
     "id": "NFA-01",
     "file": "tests/local/NFA-01.sh",
     "category": "NFA",


### PR DESCRIPTION
## Problem

The Software Factory autopilot's **first real run** (2026-06-07 07:38) nested `pipeline.js` and ran Scout/Design/Plan for real (`agentCount: 35`, real complexity analyses) — proving the T000460 fix (#1389) works at runtime — but **built nothing**. The Implement phase used the Workflow harness `isolation: 'worktree'` option, whose raw `git worktree add` checkout invokes the **git-crypt smudge filter** and fails fatally because the new per-worktree gitdir has no git-crypt key:

```
git-crypt: Unable to open key file ... fatal: deploy/mcp/claude-code-secrets.yaml: smudge filter git-crypt failed
```

Same footgun as T000426. **Blocks every feature build**, not just the 8 Brett tickets queued.

A repo-wide git-crypt pass-through was investigated and rejected: `git worktree add`'s checkout runs in the **invoking (main) checkout's** filter context, so it either keeps failing (main pinned to git-crypt) or risks committing the public repo's secrets as **plaintext** (main on `cat` while unlocked). The two-step `--no-checkout` wrapper (`scripts/worktree-create.sh`) is the correct fix.

## Fix

- **`pipeline.js` Implement**: create ONE shared, git-crypt-safe worktree up front via `scripts/worktree-create.sh` (the per-task prompts + Deploy phase already assume a single `${WORK_WT}`); **drop `isolation:'worktree'`**; run tasks **sequentially** in that worktree (concurrent `task test:all`/commits in one tree would race on the working tree + `index.lock`; Plan guarantees disjoint files so this is purely a safety choice). Return `{status:'blocked', reason:'worktree-setup'}` when the helper fails → the dispatcher's escalation routing surfaces it instead of the swallowed "all green" the first run showed.
- **`worktree-create.sh`**: support an **existing branch** (checkout vs `-b`) for the plan-reuse / dev-flow handoff path; idempotently prune a stale worktree path so factory retries are clean; never delete a pre-existing branch on rollback.
- **timestamp robustness**: spec/plan filenames are now date-stamped by the agent (`date +%F`) and the plan path is captured from the agent return, instead of the unreliable `A.timestamp` arg (which produced the `undefined-*.md` artifacts in the first run; root cause = LLM doesn't reliably transcribe the timestamp through the wakeup→dispatcher→pipeline prompt hops).
- **plan-reuse** reads the handed-off plan via `git show` (no premature worktree).
- **FA-SF-43**: structural guards (no isolation option in code, uses `worktree-create.sh`, blocks on setup failure, date-stamped filenames, existing-branch support).

## Testing

- `task test:factory` → **161/161 pass** (FA-SF-20/31 regression + new FA-SF-43).
- `node --check scripts/factory/pipeline.js` ✓, `bash -n scripts/worktree-create.sh` ✓.
- Simulated raw `git worktree add` reproduced the failure; the helper-based path is the fix.

## Follow-ups (out of scope)

- Canary image tag still uses `${A.timestamp}` (line ~551) — separate Deploy concern; images aren't timestamp-tagged.
- Parallel per-task worktrees + merge step is a possible throughput optimization over the current sequential model.

After merge: turn the kill-switch off (`ticket.sh factory-control set --key killswitch --value off`) and the 8 queued Brett tickets (T000465–T000472) drain (dry-run-first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)