### PR TITLE
fix(factory): Verify/Deploy diff the worktree + RuntimeMaxSec + kill-switch fail-open [T000473][T000474]

### DIFF
--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 356,
+      "file_count": 357,
       "files": [
         "tests/.gitignore",
         "tests/e2e/brett-globals.d.ts",
@@ -243,6 +243,7 @@
         "tests/local/FA-SF-41-wakeup.bats",
         "tests/local/FA-SF-42-dashboard-route.bats",
         "tests/local/FA-SF-43-worktree-gitcrypt.bats",
+        "tests/local/FA-SF-44-verify-diff-killswitch.bats",
         "tests/local/NFA-01.sh",
         "tests/local/NFA-02.sh",
         "tests/local/NFA-03.sh",

--- a/scripts/factory/factory.service
+++ b/scripts/factory/factory.service
@@ -13,8 +13,12 @@ Type=oneshot
 WorkingDirectory=/home/patrick/Bachelorprojekt
 ExecStart=/home/patrick/Bachelorprojekt/scripts/factory/wakeup.sh
 # Hard-kill a hung `claude -p` tick so OnUnitInactiveSec can re-arm cleanly.
-RuntimeMaxSec=900
+# A REAL build (worktree + per-task `task test:all` + a 3-lens review panel, ×N
+# parallel pipelines) far exceeds the old 900s — that SIGTERM-killed the first real
+# run mid-Implement (T000473 follow-up). 3600s gives a real dry-run room; the timer
+# only re-arms after exit, so a long tick just delays the next one.
+RuntimeMaxSec=3600
 # wakeup.sh needs the user's git-crypt key + claude creds; pass via env file if present.
 EnvironmentFile=-%h/.config/factory/autopilot.env
 # Keep failures visible in the journal but never wedge the timer.
-TimeoutStartSec=960
+TimeoutStartSec=3660

--- a/scripts/factory/guards.sh
+++ b/scripts/factory/guards.sh
@@ -24,14 +24,17 @@ source "${GUARDS_DIR}/lib.sh"
 
 # guard_killswitch_on <brand> — exit 0 (ON) when the global (brand NULL) OR the
 # per-brand kill-switch value is "on"/"true"/"1". Fail-closed: any read error → ON.
+# FAIL-CLOSED on duplicates too (T000474): a `get` may return MULTIPLE lines if
+# factory_control accumulated duplicate NULL-brand rows (ON CONFLICT does not fire
+# on NULL). Match per-LINE with grep so ANY 'on' line → paused; an exact-string
+# `case` over a multi-line "off\non" value would mis-read as OFF (silent fail-open).
 guard_killswitch_on() {
   local brand="${1:?brand required}" g b
   g=$(bash "${GUARDS_REPO}/scripts/ticket.sh" factory-control get --key killswitch 2>/dev/null) \
     || { echo "guard_killswitch_on: global read FAILED → fail-closed ON" >&2; return 0; }
   b=$(bash "${GUARDS_REPO}/scripts/ticket.sh" factory-control get --key killswitch --brand "$brand" 2>/dev/null) \
     || { echo "guard_killswitch_on: brand read FAILED → fail-closed ON" >&2; return 0; }
-  case "${g,,}" in on|true|1) return 0 ;; esac
-  case "${b,,}" in on|true|1) return 0 ;; esac
+  printf '%s\n%s\n' "$g" "$b" | grep -qiE '^[[:space:]]*(on|true|1)[[:space:]]*$' && return 0
   return 1
 }
 
@@ -62,8 +65,11 @@ guard_dryrun_ok() {
 # Reads `git diff --shortstat origin/main...HEAD`, sums insertions+deletions.
 # exit 0 if within budget; exit 1 if over (caller HARD-blocks). Read error → over (1).
 guard_check_diff_size() {
-  local max="${1:?max required}" line ins del total
-  line=$(git diff --shortstat origin/main...HEAD 2>/dev/null) \
+  # $1 = max line budget; $2 = ref to diff (default HEAD). The factory passes the
+  # feature branch (WORK_BRANCH): it runs from the MAIN repo whose HEAD is main, so
+  # diffing bare HEAD would always be empty and silently pass (T000473 follow-up).
+  local max="${1:?max required}" ref="${2:-HEAD}" line ins del total
+  line=$(git diff --shortstat "origin/main...${ref}" 2>/dev/null) \
     || { echo "guard_check_diff_size: git diff FAILED → fail-closed OVER" >&2; return 1; }
   ins=$(sed -nE 's/.*[, ]([0-9]+) insertion.*/\1/p' <<<"$line"); ins="${ins:-0}"
   del=$(sed -nE 's/.*[, ]([0-9]+) deletion.*/\1/p'  <<<"$line"); del="${del:-0}"

--- a/scripts/factory/pipeline.js
+++ b/scripts/factory/pipeline.js
@@ -390,9 +390,9 @@ const lenses = [
 const reviews = (await parallel(
   lenses.map((l) => () => agent(
     `Record pipeline liveness first so the dispatcher watchdog does not flag this run as stale: run \`bash ${REPO}/scripts/ticket.sh touch --id ${A.ticket_id}\`. Then:
-     Read the review prompt at ${REPO}/${l.file} and apply it to the diff of
-     branch ${WORK_BRANCH} (run: git diff origin/main...HEAD in ${REPO}).
-     Return your findings as JSON matching the review schema.`,
+     Read the review prompt at ${REPO}/${l.file} and apply it to the diff of branch
+     ${WORK_BRANCH}: git -C ${WORK_WT} diff origin/main...HEAD  (in the WORKTREE — NOT
+     in ${REPO} whose HEAD is main → empty diff). Return findings as JSON per schema.`,
     { label: `review:${l.key}`, phase: 'Verify', schema: REVIEW_SCHEMA, model: provision({ role: l.key === 'security' ? 'security' : 'review' }).model },
   )),
 )).filter(Boolean)
@@ -425,8 +425,8 @@ if (blocking.length) {
 phase('Deploy')
 if (DRY_RUN) {
   const report = await agent(
-    `DRY RUN — do NOT push, merge, or deploy anything. From ${REPO}:
-     1. Show the planned diff: git diff origin/main...HEAD (branch ${WORK_BRANCH}).
+    `DRY RUN — do NOT push, merge, or deploy anything. Work from the WORKTREE (HEAD=${WORK_BRANCH}):
+     1. Show the planned diff: git -C ${WORK_WT} diff origin/main...HEAD --stat
      2. Summarise the review findings already gathered (${reviews.length} review lens result(s)).
      3. Release the pipeline slot and return the ticket to the queue (nothing shipped):
         bash ${REPO}/scripts/ticket.sh release-slot --id ${A.ticket_id}
@@ -447,7 +447,7 @@ const deploy = await agent(
       printf '%s' "${WORK_BRANCH}" | grep -Eq '^(feature|fix)/' || { echo "BLOCK: WORK_BRANCH ${WORK_BRANCH} not feature/*|fix/*"; exit 1; }
    b. Diff-size cap (HARD): from ${REPO},
       source ${REPO}/scripts/factory/guards.sh
-      GUARDS_REPO=${REPO} guard_check_diff_size ${process.env.FACTORY_MAX_DIFF ?? '800'}
+      GUARDS_REPO=${REPO} guard_check_diff_size ${process.env.FACTORY_MAX_DIFF ?? '800'} ${WORK_BRANCH}
       If guard_check_diff_size returns non-zero, the diff exceeds FACTORY_MAX_DIFF — DO NOT push/merge/deploy.
    c. CWD assertion: every git/gh/task command below MUST run with cwd = ${REPO} (the MAIN repo),
       never the worktree ${WORK_WT} (gotcha T000342).

--- a/scripts/ticket.sh
+++ b/scripts/ticket.sh
@@ -486,11 +486,11 @@ SELECT value FROM tickets.factory_control
 WHERE key = :'key' AND brand IS NOT DISTINCT FROM NULLIF(:'brand','');
 EOF
   else
+    # Delete-then-insert, NOT ON CONFLICT: the unique index treats NULL brands as DISTINCT, so ON CONFLICT never fires for the global row → duplicates → kill-switch fail-open (T000474).
     _exec_sql "$pod" -v key="$key" -v brand="$brand" -v value="$value" -v set_by="$set_by" <<'EOF' >/dev/null
+DELETE FROM tickets.factory_control WHERE key = :'key' AND brand IS NOT DISTINCT FROM NULLIF(:'brand','');
 INSERT INTO tickets.factory_control (key, brand, value, set_by, updated_at)
-VALUES (:'key', NULLIF(:'brand',''), :'value', NULLIF(:'set_by',''), now())
-ON CONFLICT (key, brand) DO UPDATE
-  SET value = EXCLUDED.value, set_by = EXCLUDED.set_by, updated_at = now();
+VALUES (:'key', NULLIF(:'brand',''), :'value', NULLIF(:'set_by',''), now());
 EOF
     echo "factory-control set: $key=${value}${brand:+ (brand=$brand)}"
   fi

--- a/tests/local/FA-SF-44-verify-diff-killswitch.bats
+++ b/tests/local/FA-SF-44-verify-diff-killswitch.bats
@@ -1,0 +1,65 @@
+#!/usr/bin/env bats
+# FA-SF-44: follow-ups to the first real autopilot build (T000473):
+#   - Verify/Deploy must diff the WORKTREE, not ${REPO} (whose HEAD is main → empty diff
+#     → false "no code" review blockers).
+#   - guard_check_diff_size must diff the feature branch ref, not bare HEAD.
+#   - factory.service RuntimeMaxSec must allow a real build (old 900s SIGTERM-killed it).
+#   - T000474: the kill-switch must be FAIL-CLOSED on duplicate factory_control rows,
+#     and `factory-control set` must not create NULL-brand duplicates.
+
+@test "FA-SF-44: Verify panel diffs the worktree, not bare HEAD in REPO" {
+  run grep -Eq 'git -C \$\{WORK_WT\} diff origin/main\.\.\.HEAD' scripts/factory/pipeline.js
+  [ "$status" -eq 0 ]
+  # the old empty-diff form must be gone
+  run grep -Eq 'git diff origin/main\.\.\.HEAD in \$\{REPO\}' scripts/factory/pipeline.js
+  [ "$status" -ne 0 ]
+}
+
+@test "FA-SF-44: diff-size guard is passed the feature branch ref" {
+  run grep -Eq 'guard_check_diff_size \$\{process\.env\.FACTORY_MAX_DIFF \?\? .800.\} \$\{WORK_BRANCH\}' scripts/factory/pipeline.js
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-44: guard_check_diff_size accepts a ref arg (defaults HEAD)" {
+  run grep -Eq 'ref="\$\{2:-HEAD\}"' scripts/factory/guards.sh
+  [ "$status" -eq 0 ]
+  run grep -Eq 'origin/main\.\.\.\$\{ref\}' scripts/factory/guards.sh
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-44: factory.service RuntimeMaxSec allows a real build (>=3600)" {
+  run bash -c "v=\$(grep -oE 'RuntimeMaxSec=[0-9]+' scripts/factory/factory.service | cut -d= -f2); [ \"\${v:-0}\" -ge 3600 ]"
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-44: factory-control set dedups via DELETE+INSERT (no ON CONFLICT)" {
+  run grep -Eq 'DELETE FROM tickets\.factory_control WHERE key' scripts/ticket.sh
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-44: guard_killswitch_on is FAIL-CLOSED on a duplicated off/on read (T000474)" {
+  tmp="$(mktemp -d)"
+  mkdir -p "$tmp/scripts"
+  cat > "$tmp/scripts/ticket.sh" <<'STUB'
+#!/usr/bin/env bash
+case "$*" in
+  *--brand*) printf '' ;;      # no per-brand row
+  *)         printf 'off\non\n' ;;  # duplicated global rows: one off, one on
+esac
+STUB
+  chmod +x "$tmp/scripts/ticket.sh"
+  # subshell isolates guards.sh's `set -uo pipefail`; expect exit 0 = ON (paused)
+  run bash -c "source scripts/factory/guards.sh; GUARDS_REPO='$tmp' guard_killswitch_on mentolder"
+  rm -rf "$tmp"
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-44: guard_killswitch_on returns NOT-paused when the only row is off" {
+  tmp="$(mktemp -d)"
+  mkdir -p "$tmp/scripts"
+  printf '#!/usr/bin/env bash\nprintf '"'"'off\\n'"'"'\n' > "$tmp/scripts/ticket.sh"
+  chmod +x "$tmp/scripts/ticket.sh"
+  run bash -c "source scripts/factory/guards.sh; GUARDS_REPO='$tmp' guard_killswitch_on mentolder"
+  rm -rf "$tmp"
+  [ "$status" -ne 0 ]
+}

--- a/website/src/data/test-inventory.json
+++ b/website/src/data/test-inventory.json
@@ -1068,6 +1068,12 @@
     "kind": "shell"
   },
   {
+    "id": "FA-SF-44",
+    "file": "tests/local/FA-SF-44-verify-diff-killswitch.bats",
+    "category": "FA",
+    "kind": "shell"
+  },
+  {
     "id": "NFA-01",
     "file": "tests/local/NFA-01.sh",
     "category": "NFA",


### PR DESCRIPTION
Follow-ups surfaced by the **first real autopilot build** (after #1394 merged). That run was a breakthrough — the autopilot built real code on `feature/sf-t000469` (`brett/src/types/state.ts +17`) via the git-crypt-safe worktree — but it never **completed**. Three concrete causes, all fixed here.

## 1. Verify/Deploy diffed the wrong place (false "no code" blockers)
The review panel and Deploy dry-run ran `git diff origin/main...HEAD in ${REPO}`, but `${REPO}`'s HEAD is `main` (the work is on `WORK_BRANCH` in `WORK_WT`). → **empty diff** → review agents returned false HIGH/CRITICAL "no code to review" → pipeline returned `blocked` (this falsely blocked T000467).
- Verify panel + Deploy dry-run now diff `git -C ${WORK_WT} diff origin/main...HEAD`.
- `guard_check_diff_size` had the same bare-HEAD bug → now takes a `ref` arg; Deploy passes `${WORK_BRANCH}` (diffable from REPO via the shared gitdir).

## 2. RuntimeMaxSec too short (SIGTERM-killed the run)
`factory.service` was killed (status=143, result='timeout') at ~17min — per-task `task test:all` ×N parallel pipelines blow the old `RuntimeMaxSec=900`. Raised to **3600** (+`TimeoutStartSec`). The timer only re-arms after exit, so a long tick just delays the next one.

## 3. T000474 — kill-switch FAIL-OPEN (observed live)
`tickets.factory_control` NULL-brand rows **duplicate** (`ON CONFLICT (key, brand)` never fires on NULL), and `guard_killswitch_on` exact-matched `case … in on|true|1`, so a duplicated `"off\non"` read as **OFF** → setting the kill-switch ON did **not** pause the autopilot.
- `factory-control set` now **DELETE+INSERT** → exactly one row per (key, brand incl. NULL).
- `guard_killswitch_on` greps per-line and is **fail-closed**: any `on` row → paused.

## Testing
- **FA-SF-44** covers all four (structural + a **behavioral** fail-closed kill-switch test with a stubbed `ticket.sh`).
- `task test:factory` = **168/168**; `quality:check` 0 blocking; `freshness:check` clean.

## Deploy note
`factory.service` is symlinked into `~/.config/systemd/user` → run `systemctl --user daemon-reload` after merge so the new `RuntimeMaxSec` takes effect.

After merge: kill-switch off → the 8 Brett tickets (T000465–T000472) should now run a **complete dry-run** (the next untested surface is the Deploy dry-run path itself).

🤖 Generated with [Claude Code](https://claude.com/claude-code)