### PR TITLE
fix(factory): resolve conflict-gate deadlock — backlog serializes, not blocks [T000473]

### DIFF
--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 357,
+      "file_count": 358,
       "files": [
         "tests/.gitignore",
         "tests/e2e/brett-globals.d.ts",
@@ -244,6 +244,7 @@
         "tests/local/FA-SF-42-dashboard-route.bats",
         "tests/local/FA-SF-43-worktree-gitcrypt.bats",
         "tests/local/FA-SF-44-verify-diff-killswitch.bats",
+        "tests/local/FA-SF-45-conflict-gate-deadlock.bats",
         "tests/local/NFA-01.sh",
         "tests/local/NFA-02.sh",
         "tests/local/NFA-03.sh",

--- a/scripts/factory/conflict-check.sh
+++ b/scripts/factory/conflict-check.sh
@@ -119,7 +119,7 @@ SELECT json_agg(DISTINCT t.external_id)
 FROM tickets.tickets t, new_files nf
 WHERE t.external_id != :'ext_id'
   AND t.type IN ('feature','task')
-  AND t.status IN ('backlog','in_progress','in_review')
+  AND t.status IN ('in_progress','in_review')
   AND t.touched_files IS NOT NULL
   AND (
     -- base: exact element containment (unchanged)

--- a/scripts/factory/pipeline.js
+++ b/scripts/factory/pipeline.js
@@ -59,7 +59,6 @@ const COMPLEXITY_EFFORT_INDEX = {
 function clampEffortIdx(i) {
   return Math.max(0, Math.min(EFFORT_LADDER.length - 1, i))
 }
-
 function chooseEffort(complexity, risk, budgetRemaining) {
   let idx = COMPLEXITY_EFFORT_INDEX[complexity]
   if (idx === undefined) idx = 1
@@ -95,11 +94,9 @@ function provision(task) {
 // Top-level globals injected by the harness: agent, parallel, pipeline, phase, log, args.
 // args.timestamp (never Date.now()), args.slug, args.title, args.description, args.ticket_id, args.brand.
 
-// Pipeline body runs as a top-level async IIFE so that:
-//   • `return` is syntactically valid (node --check passes)
-//   • `await` is valid at the call sites
-//   • harness-injected globals (agent, parallel, pipeline, phase, log, args)
-//     are in scope without any destructuring from a harness param
+// Pipeline body runs as a top-level async function so that:
+//   • `return` is valid (node --check passes)
+//   • harness-injected globals are in scope without a harness-param destructure
 async function main() {
 
 // ─── Config ──────────────────────────────────────────────────────────────
@@ -245,15 +242,18 @@ if (!isSimple) {
   )
   if (/\"T0/.test(conflict)) {
     log(`Conflict detected: ${conflict}`)
+    // Release slot + reset to backlog so the next tick can retry; without `backlog`
+    // in conflict-check's active set, ≤1 overlapping ticket per tick serializes.
     await agent(
-      `A file-overlap conflict blocks this feature. Notify the operator: PushNotification is DEFERRED —
-       run \`ToolSearch select:PushNotification\` first, then call it once:
-         title:   "Factory conflict: ${A.ticket_id} (${brand})"
-         message: "Pipeline blocked on file overlap. Detail: ${String(conflict).slice(0, 280)}"
-       Report what was notified.`,
+      `Release slot + return to queue (the next tick can retry — without backlog in the conflict-check active set, ≤1 overlapping ticket/tick):
+       bash ${REPO}/scripts/ticket.sh release-slot --id ${A.ticket_id}
+       bash ${REPO}/scripts/ticket.sh update-status --id ${A.ticket_id} --status backlog
+       Notify: PushNotification is DEFERRED — \`ToolSearch select:PushNotification\`,
+       then call it once: title "Factory conflict: ${A.ticket_id} (${brand})",
+       message "Pipeline blocked on overlap. ${String(conflict).slice(0, 200)}"`,
       { label: 'conflict:escalate', phase: 'Plan' },
     )
-    return { status: 'blocked', reason: 'file-overlap', conflict }
+    return { status: 'blocked', reason: 'file-overlap', conflict, released: true }
   }
 
   const planProv = provision({ complexity: scout.complexity, role: 'plan', risk: (scout.risk_areas?.length ? 'high' : 'low'), budgetRemaining: 1, ticketId: A.ticket_id, touchedFiles: scout.touched_files, gpuEmbeddings: false })

--- a/tests/local/FA-SF-45-conflict-gate-deadlock.bats
+++ b/tests/local/FA-SF-45-conflict-gate-deadlock.bats
@@ -1,0 +1,35 @@
+#!/usr/bin/env bats
+# FA-SF-45: the conflict gate must not deadlock the backlog when multiple queued
+# features share files (e.g. all 8 Brett tickets share messages.ts/state.ts).
+# Fix: (a) conflict-check.sh drops 'backlog' from active statuses — only
+# in_progress/in_review block; (b) pipeline.js releases slot + resets to backlog
+# on conflict (prevents wedged in_progress tickets).
+
+@test "FA-SF-45: conflict-check.sh does NOT count backlog as active" {
+  run grep -Eq "t\.status IN \('in_progress','in_review'\)" scripts/factory/conflict-check.sh
+  [ "$status" -eq 0 ]
+  run grep -Eq "'backlog'" scripts/factory/conflict-check.sh
+  [ "$status" -ne 0 ]
+}
+
+@test "FA-SF-45: pipeline.js releases slot + resets to backlog on conflict" {
+  # the conflict-block path must include release-slot (template: ${A.ticket_id})
+  run bash -c "grep -Eq 'release-slot.*--id.*ticket_id' scripts/factory/pipeline.js && grep -Eq 'update-status.*--id.*ticket_id.*backlog' scripts/factory/pipeline.js"
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-45: pipeline.js conflict-block return includes released:true" {
+  run grep -Eq "released: true" scripts/factory/pipeline.js
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-45: scheme.sh claim sets status=in_progress (the gate sees it)" {
+  run grep -Eq "status='in_progress'" scripts/factory/slots.sh
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-45: offline parsing passes" {
+  run node --check scripts/factory/pipeline.js;   [ "$status" -eq 0 ]
+  run bash -n scripts/factory/conflict-check.sh;  [ "$status" -eq 0 ]
+  run bash -n scripts/factory/slots.sh;           [ "$status" -eq 0 ]
+}

--- a/website/src/data/test-inventory.json
+++ b/website/src/data/test-inventory.json
@@ -1074,6 +1074,12 @@
     "kind": "shell"
   },
   {
+    "id": "FA-SF-45",
+    "file": "tests/local/FA-SF-45-conflict-gate-deadlock.bats",
+    "category": "FA",
+    "kind": "shell"
+  },
+  {
     "id": "NFA-01",
     "file": "tests/local/NFA-01.sh",
     "category": "NFA",


### PR DESCRIPTION
## Problem

The conflict-check counted **`backlog`** as an "active" status that blocks other tickets from touching the same files. After Scout populated `touched_files` on all 8 Brett tickets (which all share files like `messages.ts`, `state.ts`, `ws-handler.ts`), **every backlog ticket blocked every other** → **total deadlock**: no Brett ticket could ever pass the Plan conflict gate. Observed in the 09:17 tick: 3 tickets claimed, all 3 conflict-blocked, **0 built**.

Compounding: the pipeline.js Plan conflict-block returned `{status:'blocked'}` **without** releasing the slot or resetting to backlog → conflict-blocked tickets **wedged in `in_progress`** holding slots that `schedule.sh` can never reclaim.

## Fix (3-point)

1. **`conflict-check.sh:122`**: `status IN ('backlog','in_progress','in_review')` → `status IN ('in_progress','in_review')`. A backlog ticket is NOT being worked on; its `touched_files` prediction should not pre-emptively block a peer. The `schedule.sh`→`slots.sh claim` sets `in_progress` atomically, so the loop **serializes** naturally: ticket 1 claims → ticket 2 sees the conflict → skips → retries next tick. Each tick builds ≤1 Brett ticket (instead of 0).

2. **`pipeline.js` Plan conflict-block**: `release-slot` + `update-status backlog` BEFORE returning `{status:'blocked', released:true}`. Feedback loop with #1: the serialized tickets retry cleanly next tick.

3. **Verified**: `slots.sh claim` already sets `status='in_progress'` in the same atomic UPDATE (line 27, unchanged) — this is the lynchpin serialisation mechanism.

## Testing

- **FA-SF-45** (5/5): conflict-check drops backlog, pipeline releases on conflict, claim sets in_progress.
- `task test:factory` = **173/173** (FA-SF-20/31/43/44 regression included).
- `quality:check` 0 blocking; `freshness:check` clean; `pipeline.js` 599 lines.

## Expected behavior after merge

Kill-switch off → T000465 claimed → builds through one complete dry-run → T000466 deferred to next tick (conflict-gate sees T000465 in_progress but T000465 is actually WORKING now, not just backlog-falsely-active) → serialises 1/tick → 8 Brett tickets drain over ~8 ticks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)