### PR TITLE
fix(livekit): pin livekit-ingress-rtmp to specific nodes to prevent collision [T000475]

### DIFF
--- a/prod-fleet/mentolder/kustomization.yaml
+++ b/prod-fleet/mentolder/kustomization.yaml
@@ -88,3 +88,10 @@ patches:
                         - key: kubernetes.io/hostname
                           operator: In
                           values: [pk-hetzner-4, pk-hetzner-6, pk-hetzner-8]
+  - patch: |-
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: livekit-ingress-rtmp
+        annotations:
+          svccontroller.k3s.cattle.io/nodeselector: "kubernetes.io/hostname=pk-hetzner-4"

--- a/prod-korczewski/patch-livekit.yaml
+++ b/prod-korczewski/patch-livekit.yaml
@@ -77,3 +77,11 @@ spec:
                     operator: In
                     values:
                       - pk-hetzner-6
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: livekit-ingress-rtmp
+  namespace: workspace
+  annotations:
+    svccontroller.k3s.cattle.io/nodeselector: "kubernetes.io/hostname=pk-hetzner-6"

--- a/prod-mentolder/patch-livekit.yaml
+++ b/prod-mentolder/patch-livekit.yaml
@@ -29,3 +29,11 @@ spec:
                     operator: In
                     values:
                       - gekko-hetzner-3
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: livekit-ingress-rtmp
+  namespace: workspace
+  annotations:
+    svccontroller.k3s.cattle.io/nodeselector: "kubernetes.io/hostname=gekko-hetzner-3"


### PR DESCRIPTION
This PR pins the `livekit-ingress-rtmp` service to specific nodes (pk-hetzner-4 for mentolder, pk-hetzner-6 for korczewski) to avoid hostPort 1935 conflict in the fleet cluster where both namespaces co-exist. Under the default configuration, Klipper LoadBalancer DaemonSets for both brands schedule pods on all nodes, colliding and leaving half of the pods in Pending state.