### PR TITLE
feat(factory): cleanup stale branches + worktrees after pipeline completion

### DIFF
--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 360,
+      "file_count": 361,
       "files": [
         "tests/.gitignore",
         "tests/e2e/brett-globals.d.ts",
@@ -247,6 +247,7 @@
         "tests/local/FA-SF-43-worktree-gitcrypt.bats",
         "tests/local/FA-SF-44-verify-diff-killswitch.bats",
         "tests/local/FA-SF-45-conflict-gate-deadlock.bats",
+        "tests/local/FA-SF-46-cleanup.bats",
         "tests/local/NFA-01.sh",
         "tests/local/NFA-02.sh",
         "tests/local/NFA-03.sh",
@@ -1877,7 +1878,7 @@
       "id": "scripts-infra",
       "name": "Operational + build scripts",
       "owner_agent": "bachelorprojekt-infra",
-      "file_count": 248,
+      "file_count": 249,
       "files": [
         "scripts/add-whiteboard-library.py",
         "scripts/admin-menu-gate.sh",
@@ -2009,6 +2010,7 @@
         "scripts/factory/README.md",
         "scripts/factory/classify-failure.sh",
         "scripts/factory/classify-paths.sh",
+        "scripts/factory/cleanup.sh",
         "scripts/factory/conflict-check.sh",
         "scripts/factory/dispatcher.js",
         "scripts/factory/factory.service",

--- a/scripts/factory/cleanup.sh
+++ b/scripts/factory/cleanup.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# scripts/factory/cleanup.sh — remove factory branch + worktree after pipeline end.
+#
+# Best-effort: all steps are non-fatal; the script ALWAYS exits 0 so a missing
+# worktree or already-deleted branch never blocks or masks the real pipeline result.
+#
+# Usage: cleanup.sh --branch <name> --worktree <path>
+#   --branch    local branch to delete (e.g. feature/sf-t000469)
+#   --worktree  worktree path to remove (e.g. /tmp/wt-sf-t000469)
+set -euo pipefail
+
+BRANCH=""
+WT_PATH=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --branch)   BRANCH="$2"; shift 2 ;;
+    --worktree) WT_PATH="$2"; shift 2 ;;
+    *)          echo "cleanup.sh: unknown option: $1" >&2; shift ;;
+  esac
+done
+
+cleaned=()
+
+# 1) Remove the worktree (force — even if dirty). Idempotent: a missing worktree
+#    is not an error (exit 0 from `git worktree remove --force`).
+if [[ -n "$WT_PATH" ]] && [[ -d "$WT_PATH" ]]; then
+  if git worktree remove --force "$WT_PATH" 2>/dev/null; then
+    cleaned+=("worktree $WT_PATH")
+  else
+    # If git refuses (catastrophic corruption), fall back to rm -rf.
+    rm -rf "$WT_PATH" 2>/dev/null || true
+    echo "cleanup.sh: force-removed worktree directory $WT_PATH (git remove failed)" >&2
+  fi
+elif [[ -n "$WT_PATH" ]]; then
+  echo "cleanup.sh: worktree $WT_PATH does not exist — nothing to remove" >&2
+fi
+
+# 2) Prune stale worktree metadata (safe post-remove housekeeping).
+git worktree prune 2>/dev/null || true
+
+# 3) Delete the local branch if it exists.
+if [[ -n "$BRANCH" ]]; then
+  if git show-ref --verify --quiet "refs/heads/$BRANCH" 2>/dev/null; then
+    if git branch -D "$BRANCH" 2>/dev/null; then
+      cleaned+=("branch $BRANCH")
+    else
+      echo "cleanup.sh: could not delete branch $BRANCH (may be checked out elsewhere)" >&2
+    fi
+  else
+    echo "cleanup.sh: branch $BRANCH does not exist locally — nothing to delete" >&2
+  fi
+fi
+
+# 4) Report.
+if [[ ${#cleaned[@]} -gt 0 ]]; then
+  echo "cleanup.sh: removed ${cleaned[*]}"
+else
+  echo "cleanup.sh: nothing to clean up"
+fi

--- a/scripts/factory/pipeline.js
+++ b/scripts/factory/pipeline.js
@@ -168,7 +168,7 @@ const REVIEW_SCHEMA = {
     summary: { type: 'string' },
   },
 }
-if (!REUSE) {
+try { if (!REUSE) {
 // ── ① Scout ────────────────────────────────────────────────────────────────
 phase('Scout')
 const scout = await agent(
@@ -594,7 +594,7 @@ if (canaryRed.length) {
 if (deploy.includes('deploy-guard') || deploy.includes('"status": "blocked"') || deploy.includes("status: 'blocked'")) {
   return { status: 'blocked', reason: 'deploy-guard' }
 }
-
 return { status: 'done', pr: deploy, reviews: reviews.length, tasks: tasks.length, implemented: implemented.length }
+} finally { if (WORK_BRANCH || WORK_WT) { try { await agent(`bash ${REPO}/scripts/factory/cleanup.sh --branch '${WORK_BRANCH}' --worktree '${WORK_WT}'`, { label: 'cleanup' }) } catch (_) {} } }
 }
 await main();

--- a/tests/local/FA-SF-46-cleanup.bats
+++ b/tests/local/FA-SF-46-cleanup.bats
@@ -1,0 +1,79 @@
+#!/usr/bin/env bats
+# FA-SF-46: cleanup.sh removes factory branch + worktree after pipeline completion.
+# All operations are best-effort (always exit 0). The script is idempotent — calling
+# it with a non-existent branch/worktree is a clean no-op.
+
+@test "FA-SF-46: cleanup.sh parses without syntax errors" {
+  run bash -n scripts/factory/cleanup.sh
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-46: cleanup.sh is executable" {
+  [ -x scripts/factory/cleanup.sh ]
+}
+
+@test "FA-SF-46: cleanup.sh exits 0 with missing args (idempotent)" {
+  run bash scripts/factory/cleanup.sh
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-46: cleanup.sh exits 0 for non-existent branch" {
+  run bash scripts/factory/cleanup.sh --branch "nonexistent-fa-sf-46-deadbeef"
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "nothing to clean up" ]]
+}
+
+@test "FA-SF-46: cleanup.sh exits 0 for non-existent worktree" {
+  run bash scripts/factory/cleanup.sh --worktree "/tmp/wt-nonexistent-fa-sf-46"
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "nothing to clean up" ]]
+}
+
+@test "FA-SF-46: cleanup.sh removes a real branch + worktree" {
+  # Create a disposable branch and worktree, then clean them up.
+  git branch -D fa-sf-46-test-cleanup 2>/dev/null || true
+  git branch fa-sf-46-test-cleanup
+  git worktree add --no-checkout /tmp/wt-fa-sf-46-test fa-sf-46-test-cleanup 2>/dev/null || true
+
+  run bash scripts/factory/cleanup.sh --branch "fa-sf-46-test-cleanup" --worktree "/tmp/wt-fa-sf-46-test"
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "removed" ]]
+
+  # Verify both are gone.
+  run git show-ref --verify --quiet "refs/heads/fa-sf-46-test-cleanup" 2>/dev/null
+  [ "$status" -ne 0 ]
+  [ ! -d /tmp/wt-fa-sf-46-test ]
+}
+
+@test "FA-SF-46: cleanup.sh is idempotent (call twice in a row)" {
+  # First call cleans up (nothing exists from previous test — already cleaned).
+  run bash scripts/factory/cleanup.sh --branch "fa-sf-46-test-cleanup" --worktree "/tmp/wt-fa-sf-46-test"
+  [ "$status" -eq 0 ]
+
+  # Second call on already-cleaned targets is also a no-op.
+  run bash scripts/factory/cleanup.sh --branch "fa-sf-46-test-cleanup" --worktree "/tmp/wt-fa-sf-46-test"
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "nothing to clean up" ]]
+}
+
+@test "FA-SF-46: pipeline.js wraps main body in try/finally" {
+  # finally block must contain the cleanup agent call.
+  run grep -Eq '} finally \{' scripts/factory/pipeline.js
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-46: pipeline.js finally block calls cleanup.sh" {
+  run grep -Eq 'scripts/factory/cleanup\.sh' scripts/factory/pipeline.js
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-46: pipeline.js cleanup is wrapped in try/catch (never masks real result)" {
+  run grep -Eq 'catch[[:space:]]*\(_\)' scripts/factory/pipeline.js
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-46: pipeline.js cleanup passes both WORK_BRANCH and WORK_WT" {
+  # The invocation is inside a JS template literal: --branch ${WORK_BRANCH} --worktree ${WORK_WT}
+  run grep -Eq 'cleanup\.sh.*--branch.*WORK_BRANCH.*--worktree.*WORK_WT' scripts/factory/pipeline.js
+  [ "$status" -eq 0 ]
+}

--- a/website/src/data/test-inventory.json
+++ b/website/src/data/test-inventory.json
@@ -1080,6 +1080,12 @@
     "kind": "shell"
   },
   {
+    "id": "FA-SF-46",
+    "file": "tests/local/FA-SF-46-cleanup.bats",
+    "category": "FA",
+    "kind": "shell"
+  },
+  {
     "id": "NFA-01",
     "file": "tests/local/NFA-01.sh",
     "category": "NFA",


### PR DESCRIPTION
## Was

Die Software Factory hat nach erfolgreichem Merge (und auch bei Blocked/Error) den lokalen Branch und das Worktree nicht aufgeräumt. Das sammelt sich über Zeit an.

## Änderungen

- **`scripts/factory/cleanup.sh`** — Best-effort Cleanup-Script (immer exit 0). Entfernt Worktree + lokalen Branch.
- **`scripts/factory/pipeline.js`** — `try/finally` um die Hauptlogik. Der `finally`-Block ruft `cleanup.sh` bei **jedem** Exit-Pfad auf (Done, Blocked, Error). Inneres `try/catch` stellt sicher, dass ein Cleanup-Fehler niemals das echte Pipeline-Ergebnis maskiert.
- **`tests/local/FA-SF-46-cleanup.bats`** — 11 Tests: Syntax, Idempotenz, echte Branch+Worktree-Entfernung, strukturelle Guards.

## Tests

- 184/184 Factory-Tests grün (173 bestehend + 11 neu)
- `task test:all` komplett grün

🤖 Generated with [Claude Code](https://claude.com/claude-code)