### PR TITLE
fix(infra): Collabora dual-brand Ingress + CI release-please trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,12 +34,16 @@ jobs:
           node-version: '22'
           cache: 'npm'
 
+      - uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611  # v2.0.0
+        with:
+          version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Install dependencies
         run: |
           sudo apt-get update && sudo apt-get install -y jq curl python3-pip
-          curl -sSL "https://dl.k8s.io/release/v1.31.0/bin/linux/amd64/kubectl" \
+          curl --fail -sSL "https://dl.k8s.io/release/v1.31.0/bin/linux/amd64/kubectl" \
             -o /usr/local/bin/kubectl && chmod +x /usr/local/bin/kubectl
-          sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b /usr/local/bin
 
       - name: Install node dependencies (docs-gen generator + tests)
         run: npm ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,13 @@ on:
   pull_request:
     branches: [main]
   push:
-    branches: [main]
+    branches:
+      - main
+      # release-please PRs are opened by github-actions[bot] with GITHUB_TOKEN,
+      # which GitHub does not re-trigger pull_request workflows for (loop-prevention).
+      # Triggering on push to the release-please branch gives branch-protection the
+      # required check run so the PR can auto-merge.
+      - 'release-please--branches--main'
 
 concurrency:
   # Cancel superseded runs on the same PR (rapid iteration / stacked Factory pushes);

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1247,13 +1247,10 @@ tasks:
             export COLLABORA_INGRESS_MIDDLEWARES="${WORKSPACE_NAMESPACE:-workspace}-redirect-https@kubernetescrd,${WORKSPACE_NAMESPACE:-workspace}-hsts-headers@kubernetescrd"
             ;;
         esac
-        # Single-brand deploy: second-brand vars are empty (only fleet-deploy populates them).
-        export COLLABORA_HOST_2=""
-        export COLLABORA_ALIASGROUP2=""
         context_flag=""
         [ "{{.ENV}}" != "dev" ] && context_flag="--context ${ENV_CONTEXT}"
         kustomize build k3d/office-stack \
-          | envsubst '$PROD_DOMAIN $COLLABORA_HOST $COLLABORA_HOST_2 $COLLABORA_ALIASGROUP1 $COLLABORA_ALIASGROUP2 $COLLABORA_SERVER_NAME $COLLABORA_SSL_TERMINATION $COLLABORA_TLS_SECRET $COLLABORA_INGRESS_MIDDLEWARES' \
+          | envsubst '$PROD_DOMAIN $COLLABORA_HOST $COLLABORA_ALIASGROUP1 $COLLABORA_ALIASGROUP2 $COLLABORA_SERVER_NAME $COLLABORA_SSL_TERMINATION $COLLABORA_TLS_SECRET $COLLABORA_INGRESS_MIDDLEWARES' \
           | kubectl $context_flag apply -f -
       - |
         source scripts/env-resolve.sh "{{.ENV}}"
@@ -1857,15 +1854,14 @@ tasks:
             | jq --arg ns "$NS" 'del(.metadata.resourceVersion,.metadata.uid,.metadata.creationTimestamp,.metadata.managedFields,.metadata.annotations) | .metadata.namespace = $ns' \
             | kubectl --context fleet apply -f - || echo "warn: failed to sync korczewski-tls to $NS"
         done
-        # --- Collabora (shared, dual-host) ---
-        # Primary host vars from fleet-mentolder; second host from fleet-korczewski.
+        # --- Collabora (shared, dual-brand) ---
+        # Primary (mentolder) vars; second brand applied as a separate Ingress resource
+        # (ingress-korczewski.yaml) so each brand gets its own TLS secret and its own
+        # namespace-prefixed middleware chain (T000478).
         source scripts/env-resolve.sh fleet-mentolder
         export COLLABORA_HOST="office.${PROD_DOMAIN}"
-        # Empty server_name → coolwsd derives the WOPI discovery urlsrc host
-        # from the request Host header. The shared dual-host office-stack
-        # serves both brands; a hardcoded office.${PROD_DOMAIN} would make
-        # office.korczewski.de/hosting/discovery advertise the mentolder
-        # host (T000478).
+        # Empty server_name → coolwsd auto-derives the WOPI discovery urlsrc hostname
+        # from the request Host header, making a single Collabora instance serve both brands.
         export COLLABORA_SERVER_NAME=""
         export COLLABORA_ALIASGROUP1="https://files\\.${PROD_DOMAIN}:443"
         export COLLABORA_SSL_TERMINATION="true"
@@ -1877,14 +1873,16 @@ tasks:
         ( source scripts/env-resolve.sh fleet-korczewski; echo "office.${PROD_DOMAIN}|https://files\\.${PROD_DOMAIN}:443" ) > /tmp/_kore_collabora.txt
         export COLLABORA_HOST_2="$(cut -d'|' -f1 /tmp/_kore_collabora.txt)"
         export COLLABORA_ALIASGROUP2="$(cut -d'|' -f2 /tmp/_kore_collabora.txt)"
+        export COLLABORA_TLS_SECRET_2="korczewski-tls"
+        export COLLABORA_INGRESS_MIDDLEWARES_2="workspace-korczewski-redirect-https@kubernetescrd,workspace-korczewski-hsts-headers@kubernetescrd"
+        # Apply kustomize (primary brand Deployment + Service + primary Ingress).
         kustomize build k3d/office-stack \
-          | envsubst '$PROD_DOMAIN $COLLABORA_HOST $COLLABORA_HOST_2 $COLLABORA_ALIASGROUP1 $COLLABORA_ALIASGROUP2 $COLLABORA_SERVER_NAME $COLLABORA_SSL_TERMINATION $COLLABORA_TLS_SECRET $COLLABORA_INGRESS_MIDDLEWARES' \
+          | envsubst '$PROD_DOMAIN $COLLABORA_HOST $COLLABORA_ALIASGROUP1 $COLLABORA_ALIASGROUP2 $COLLABORA_SERVER_NAME $COLLABORA_SSL_TERMINATION $COLLABORA_TLS_SECRET $COLLABORA_INGRESS_MIDDLEWARES' \
           | kubectl --context fleet apply -f -
-        # Patch ingress to give korczewski its own TLS entry (its cert is in korczewski-tls).
-        kubectl --context fleet patch ingress office-ingress -n workspace-office --type=json -p='[
-          {"op":"replace","path":"/spec/tls/0/hosts/1","value":"office.korczewski.de"},
-          {"op":"add","path":"/spec/tls/-","value":{"hosts":["office.korczewski.de"],"secretName":"korczewski-tls"}}
-        ]' 2>/dev/null || true
+        # Apply second-brand Ingress separately (own TLS + own middleware namespace).
+        envsubst '$COLLABORA_HOST_2 $COLLABORA_TLS_SECRET_2 $COLLABORA_INGRESS_MIDDLEWARES_2' \
+          < k3d/office-stack/ingress-korczewski.yaml \
+          | kubectl --context fleet apply -f -
         kubectl --context fleet rollout status deploy/collabora -n workspace-office --timeout=300s
         # --- CoTURN/Janus (shared) ---
         export TURN_NODE="$MENTOLDER_TURN_NODE"; export TURN_PUBLIC_IP="$MENTOLDER_TURN_PUBLIC_IP"

--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -1506,7 +1506,7 @@
       "id": "infra-manifests",
       "name": "Kubernetes manifests, overlays, env registry",
       "owner_agent": "bachelorprojekt-infra",
-      "file_count": 365,
+      "file_count": 366,
       "files": [
         "claude-code/gekko-android-mcp-guide.md",
         "claude-code/settings.json",
@@ -1748,6 +1748,7 @@
         "k3d/oauth2-proxy-mailpit.yaml",
         "k3d/oauth2-proxy-traefik.yaml",
         "k3d/office-stack/collabora.yaml",
+        "k3d/office-stack/ingress-korczewski.yaml",
         "k3d/office-stack/ingress.yaml",
         "k3d/office-stack/kustomization.yaml",
         "k3d/office-stack/namespace.yaml",

--- a/k3d/office-stack/ingress-korczewski.yaml
+++ b/k3d/office-stack/ingress-korczewski.yaml
@@ -1,0 +1,35 @@
+# ═══════════════════════════════════════════════════════════════════
+# office Ingress (Korczewski brand) — second brand pointing at the
+# shared Collabora Deployment in workspace-office namespace.
+# ═══════════════════════════════════════════════════════════════════
+# Applied only by the fleet:office:all-prods task, NOT included in
+# k3d/office-stack/kustomization.yaml (kustomize can't conditionally
+# skip resources with empty envsubst vars).
+#
+# envsubst vars set by the Taskfile fleet deploy:
+#   ${COLLABORA_HOST_2}              — e.g. office.korczewski.de
+#   ${COLLABORA_TLS_SECRET_2}        — e.g. korczewski-tls
+#   ${COLLABORA_INGRESS_MIDDLEWARES_2} — workspace-korczewski-redirect-https@kubernetescrd,...
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: office-ingress-korczewski
+  namespace: workspace-office
+  annotations:
+    traefik.ingress.kubernetes.io/router.middlewares: "${COLLABORA_INGRESS_MIDDLEWARES_2}"
+spec:
+  tls:
+    - hosts:
+        - "${COLLABORA_HOST_2}"
+      secretName: "${COLLABORA_TLS_SECRET_2}"
+  rules:
+    - host: "${COLLABORA_HOST_2}"
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: collabora
+                port:
+                  number: 9980

--- a/k3d/office-stack/ingress.yaml
+++ b/k3d/office-stack/ingress.yaml
@@ -4,40 +4,27 @@
 # Lives in this namespace because Ingress backends must point to a
 # Service in the same namespace. Host and TLS secret are envsubst'd
 # at deploy time:
-#   ${COLLABORA_HOST}       — fully-qualified hostname (e.g. office.mentolder.de)
-#   ${COLLABORA_TLS_SECRET} — name of the wildcard TLS secret
+#   ${COLLABORA_HOST}              — primary brand hostname (e.g. office.mentolder.de)
+#   ${COLLABORA_TLS_SECRET}        — TLS secret name for primary brand
+#   ${COLLABORA_INGRESS_MIDDLEWARES} — Traefik middleware chain for primary brand
 #
-# The Traefik middleware chain is hardcoded to
-# `workspace-redirect-https@kubernetescrd,workspace-hsts-headers@kubernetescrd`
-# because both production clusters host their middlewares in the
-# `workspace` namespace (same as prod/ingress.yaml). Cross-namespace
-# middleware references are fine: Traefik resolves by the annotation
-# prefix, not the Ingress's own namespace.
+# For dual-brand fleet deploys the second brand gets its own Ingress in
+# ingress-korczewski.yaml (separate resource so each brand can reference
+# its own TLS secret and its own namespace-prefixed middleware chain).
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: office-ingress
   namespace: workspace-office
   annotations:
-    traefik.ingress.kubernetes.io/router.middlewares: "workspace-redirect-https@kubernetescrd,workspace-hsts-headers@kubernetescrd"
+    traefik.ingress.kubernetes.io/router.middlewares: "${COLLABORA_INGRESS_MIDDLEWARES}"
 spec:
   tls:
     - hosts:
         - "${COLLABORA_HOST}"
-        - "${COLLABORA_HOST_2}"
       secretName: "${COLLABORA_TLS_SECRET}"
   rules:
     - host: "${COLLABORA_HOST}"
-      http:
-        paths:
-          - path: /
-            pathType: Prefix
-            backend:
-              service:
-                name: collabora
-                port:
-                  number: 9980
-    - host: "${COLLABORA_HOST_2}"
       http:
         paths:
           - path: /

--- a/scripts/factory/dispatcher.js
+++ b/scripts/factory/dispatcher.js
@@ -101,7 +101,7 @@ async function main() {
      If a guard read errors (non-zero with no documented meaning), fail-closed: skip that brand.
      If a ticket has no plan reference, set branch and plan_path to null.
      If nothing was claimed across both brands, return { "launch": [], "skipped": [...] }.`,
-    { label: 'prep', phase: 'Prep', schema: PLAN_SCHEMA },
+    { label: 'prep', phase: 'Prep', schema: PLAN_SCHEMA, model: 'sonnet' },
   )
 
   log(
@@ -161,7 +161,7 @@ async function main() {
          bash ${REPO}/scripts/ticket.sh add-comment --id T000413 \\
            --body ${JSON.stringify('Factory dispatcher: ' + escalations.length + ' run(s) escalated this tick.')}
        Report what was notified and the ticket-comment output.`,
-      { label: 'escalate', phase: 'Launch' },
+      { label: 'escalate', phase: 'Launch', model: 'sonnet' },
     )
   } else {
     log(`Dispatcher: all ${results?.length ?? 0} pipeline run(s) completed without error/block.`)
@@ -174,7 +174,7 @@ async function main() {
        BRAND=mentolder bash ${REPO}/scripts/factory/metrics.sh
        BRAND=korczewski bash ${REPO}/scripts/factory/metrics.sh
      (metrics.sh is best-effort: a missing Vorhaben ticket on a brand is a silent no-op.)`,
-    { label: 'metrics', phase: 'Metrics' },
+    { label: 'metrics', phase: 'Metrics', model: 'sonnet' },
   )
 }
 await main();


### PR DESCRIPTION
## Summary

- **T000478 (Collabora WOPI):** Ersetzt die einzelne Ingress-Ressource mit fragiler `kubectl patch`-Nachkorrektur durch zwei deklarative Ingress-Objekte. `office-ingress` (mentolder) und `office-ingress-korczewski` (korczewski) haben jeweils ihren eigenen TLS-Secret-Verweis und namespace-präfixierte Middleware-Chain. `server_name` bleibt leer — coolwsd leitet den WOPI-Discovery-Host automatisch aus dem Request-Host-Header ab, damit eine Collabora-Instanz beide Brands bedient.
- **T000483 (CI release-please):** Fügt `release-please--branches--main` zum `push`-Trigger in `ci.yml` hinzu. GitHub feuert `pull_request`-Workflows nicht erneut, wenn `github-actions[bot]` einen PR mit `GITHUB_TOKEN` öffnet; der `push`-Trigger auf dem release-please-Branch gibt dem Branch-Protection den benötigten Check-Run.
- **Factory dispatcher:** Setzt `model: 'sonnet'` auf drei Agent-Calls zur Kostenreduktion.

## Änderungen

| Datei | Was |
|---|---|
| `.github/workflows/ci.yml` | Push-Trigger für `release-please--branches--main` |
| `k3d/office-stack/ingress.yaml` | Single-brand, nur primärer Host + eigenes TLS/Middleware |
| `k3d/office-stack/ingress-korczewski.yaml` | Neue zweite Ingress für Korczewski (nicht in kustomization.yaml — fleet-Task wendet sie per `envsubst \| kubectl apply` an) |
| `Taskfile.yml` | `fleet:office:all-prods` setzt `COLLABORA_TLS_SECRET_2` + `COLLABORA_INGRESS_MIDDLEWARES_2`, entfernt fragilen `kubectl patch`; `workspace:office:deploy` bereinigt leere HOST_2/ALIASGROUP2-Vars |
| `scripts/factory/dispatcher.js` | `model: 'sonnet'` auf 3 Agent-Calls |

## Test plan

- [ ] `kustomize build k3d/office-stack` produziert valides Manifest ohne leere TLS-Hosts
- [ ] `task workspace:office:deploy ENV=mentolder` deployt Collabora mit korrekter mentolder-Ingress
- [ ] `task fleet:office:all-prods` deployt beide Ingresses (`office-ingress` + `office-ingress-korczewski`) mit jeweils eigenen Certs
- [ ] `https://office.mentolder.de/hosting/discovery` liefert WOPI-URLs mit `office.mentolder.de`-Host
- [ ] `https://office.korczewski.de/hosting/discovery` liefert WOPI-URLs mit `office.korczewski.de`-Host
- [ ] release-please PR triggert CI-Checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)