### PR TITLE
fix(factory): resolve Workflow reasoning_effort conflict + model downgrades

### DIFF
--- a/scripts/factory/dispatcher.js
+++ b/scripts/factory/dispatcher.js
@@ -101,7 +101,7 @@ async function main() {
      If a guard read errors (non-zero with no documented meaning), fail-closed: skip that brand.
      If a ticket has no plan reference, set branch and plan_path to null.
      If nothing was claimed across both brands, return { "launch": [], "skipped": [...] }.`,
-    { label: 'prep', phase: 'Prep', schema: PLAN_SCHEMA, model: 'opus' },
+    { label: 'prep', phase: 'Prep', schema: PLAN_SCHEMA, model: 'haiku' },
   )
 
   log(
@@ -161,7 +161,7 @@ async function main() {
          bash ${REPO}/scripts/ticket.sh add-comment --id T000413 \\
            --body ${JSON.stringify('Factory dispatcher: ' + escalations.length + ' run(s) escalated this tick.')}
        Report what was notified and the ticket-comment output.`,
-      { label: 'escalate', phase: 'Launch', model: 'opus' },
+      { label: 'escalate', phase: 'Launch', model: 'haiku' },
     )
   } else {
     log(`Dispatcher: all ${results?.length ?? 0} pipeline run(s) completed without error/block.`)

--- a/scripts/factory/wakeup.sh
+++ b/scripts/factory/wakeup.sh
@@ -58,9 +58,10 @@ fi
 # harness then sets thinking.type:disabled for agent() spawns → 400 API error.
 CLAUDE_CODE_EFFORT_LEVEL=low
 # Strip [1m] from model env vars if present (belt-and-suspenders).
-ANTHROPIC_MODEL="${ANTHROPIC_MODEL/\[1m\]/}"
-ANTHROPIC_DEFAULT_OPUS_MODEL="${ANTHROPIC_DEFAULT_OPUS_MODEL/\[1m\]/}"
-ANTHROPIC_DEFAULT_SONNET_MODEL="${ANTHROPIC_DEFAULT_SONNET_MODEL/\[1m\]/}"
+# Use :- default to avoid nounset errors in CI where autopilot.env is absent.
+ANTHROPIC_MODEL="${ANTHROPIC_MODEL:-}"; ANTHROPIC_MODEL="${ANTHROPIC_MODEL/\[1m\]/}"
+ANTHROPIC_DEFAULT_OPUS_MODEL="${ANTHROPIC_DEFAULT_OPUS_MODEL:-}"; ANTHROPIC_DEFAULT_OPUS_MODEL="${ANTHROPIC_DEFAULT_OPUS_MODEL/\[1m\]/}"
+ANTHROPIC_DEFAULT_SONNET_MODEL="${ANTHROPIC_DEFAULT_SONNET_MODEL:-}"; ANTHROPIC_DEFAULT_SONNET_MODEL="${ANTHROPIC_DEFAULT_SONNET_MODEL/\[1m\]/}"
 
 # ── headless dispatcher tick: nest dispatcher.js via the Workflow tool ────────
 # The permission allowlist is tight: only the Workflow tool + the deterministic

--- a/scripts/factory/wakeup.sh
+++ b/scripts/factory/wakeup.sh
@@ -53,6 +53,15 @@ if [[ -f "${CRYPT_PROBE}" ]] && head -c 16 "${CRYPT_PROBE}" 2>/dev/null | grep -
   fi
 fi
 
+# ── ensure Extended Thinking is OFF so Workflow harness can spawn subagents ───
+# [1m] suffix or CLAUDE_CODE_EFFORT_LEVEL=max activates reasoning_effort; the
+# harness then sets thinking.type:disabled for agent() spawns → 400 API error.
+CLAUDE_CODE_EFFORT_LEVEL=low
+# Strip [1m] from model env vars if present (belt-and-suspenders).
+ANTHROPIC_MODEL="${ANTHROPIC_MODEL/\[1m\]/}"
+ANTHROPIC_DEFAULT_OPUS_MODEL="${ANTHROPIC_DEFAULT_OPUS_MODEL/\[1m\]/}"
+ANTHROPIC_DEFAULT_SONNET_MODEL="${ANTHROPIC_DEFAULT_SONNET_MODEL/\[1m\]/}"
+
 # ── headless dispatcher tick: nest dispatcher.js via the Workflow tool ────────
 # The permission allowlist is tight: only the Workflow tool + the deterministic
 # factory primitives the dispatcher shells out to. dry_run is the ONLY policy.


### PR DESCRIPTION
## Summary

- **`wakeup.sh`**: Fügt einen Guard hinzu, der vor dem headless `claude -p` Call `[1m]` aus allen Modell-Env-Vars strippt und `CLAUDE_CODE_EFFORT_LEVEL=low` erzwingt. Root cause: `ANTHROPIC_MODEL=deepseek-v4-pro[1m]` + `CLAUDE_CODE_EFFORT_LEVEL=max` in `autopilot.env` aktiviert Extended Thinking (`reasoning_effort`); der Workflow-Harness setzt dann `thinking.type: "disabled"` für `agent()`-Spawns → `400 API error: thinking options type cannot be disabled when reasoning_effort is set`.
- **`dispatcher.js`**: Downgrades `prep`/`escalate` Agents von `opus` zu `haiku` — beide laufen nur deterministische Bash-Kommandos und benötigen kein Tier-3-Modell.

## Root Cause

`autopilot.env` konfiguriert `deepseek-v4-pro[1m]` als Session-Modell. Das `[1m]`-Suffix aktiviert Extended Thinking unabhängig vom Effort-Level. Der Workflow-Harness setzt `thinking.type: "disabled"` für alle `agent()`-Calls, was mit `reasoning_effort` in Konflikt steht. `autopilot.env` ist gitignored und wurde manuell ohne `[1m]` / mit `CLAUDE_CODE_EFFORT_LEVEL=low` gepatcht; `wakeup.sh` enthält jetzt denselben Fix als Belt-and-Suspenders.

## Test plan

- [ ] `node --check scripts/factory/wakeup.sh` (kein Syntaxfehler)
- [ ] `./tests/runner.sh local FA-SF-30` grün (Dispatcher-Contract)
- [ ] `./tests/runner.sh local FA-SF-31` grün (Schedule-Contract)
- [ ] Manueller Factory-Tick nach Merge: `systemctl --user start factory.service` → Journal zeigt keine `400 thinking` Fehler mehr

🤖 Generated with [Claude Code](https://claude.com/claude-code)