### PR TITLE
feat(brett): Figur-Notizen & Statement-Billboards [T000469]

### DIFF
--- a/brett/public/index.html
+++ b/brett/public/index.html
@@ -87,6 +87,27 @@
     #fig-label-input:focus { outline: none; border-color: var(--brett-brass, oklch(0.80 0.09 75)); }
     #fig-label-input::placeholder { color: rgba(231,234,208,0.3); }
 
+    #fig-note-textarea {
+      background: var(--brett-ink-850, #101826);
+      border: 1px solid var(--brett-line-2, rgba(255,255,255,0.12));
+      border-radius: 5px;
+      color: var(--brett-fg, #eef1f3);
+      font: inherit;
+      font-size: 12px;
+      padding: 5px 8px;
+      width: 100%;
+      resize: vertical;
+      min-height: 72px;
+      line-height: 1.4;
+    }
+    #fig-note-textarea:focus {
+      outline: none;
+      border-color: var(--brett-brass, oklch(0.80 0.09 75));
+    }
+    #fig-note-textarea::placeholder {
+      color: rgba(231,234,208,0.3);
+    }
+
     #fig-panel-add {
       background: var(--brett-brass, oklch(0.80 0.09 75)); color: var(--brett-ink-900, #0b111c);
       border: none; border-radius: 6px;
@@ -319,6 +340,11 @@
           <div id="fig-panel-persons" style="display:grid;grid-template-columns:1fr 1fr;gap:4px;"></div>
           <span class="fig-panel-label">Name</span>
           <input id="fig-label-input" type="text" placeholder="Figur benennen …" maxlength="40" />
+          <span class="fig-panel-label">Notiz / Statement</span>
+          <textarea id="fig-note-textarea"
+            placeholder="Was spricht diese Figur? Was sieht sie?"
+            maxlength="1000"
+            rows="4"></textarea>
           <button id="fig-panel-add">＋ Klick auf Brett zum Platzieren</button>
         </div>
       </div>

--- a/brett/src/client/state.ts
+++ b/brett/src/client/state.ts
@@ -49,6 +49,9 @@ export const PLACEMENT_SPEC: { faces: Record<string, any>; bodies: Record<string
 export const lockSprites = new Map<string, THREE.Sprite>();
 export const activeLocks = new Map<string, { userId: string; name: string; color: string }>();
 
+// ── Note billboard sprites (Slice 5, T000469) ─────────────────────
+export const noteSprites = new Map<string, THREE.Sprite>();
+
 // ── Drag/placement cross-cutting flags ────────────────────────────
 export const ui = {
   dragging: null as null | { figId: string; boneName: string; plane: any },

--- a/brett/src/client/ui/fig-panel.ts
+++ b/brett/src/client/ui/fig-panel.ts
@@ -1,6 +1,6 @@
 import { STATE, ui } from '../state';
 import { makeMannequin, recolorFigure } from '../mannequin';
-import { sendAddFigure, sendUpdate } from '../ws-client';
+import { sendAddFigure, sendUpdate, sendClient } from '../ws-client';
 
 export function addFigure(position: { x: number; z: number }): any {
   const id = (typeof crypto !== 'undefined' && crypto.randomUUID) ? crypto.randomUUID() : ('f-' + Math.random().toString(36).slice(2,10));
@@ -20,16 +20,19 @@ export function syncPanelToSelection(id: string | null): void {
   const title  = document.getElementById('fig-panel-title');
   const addBtn = document.getElementById('fig-panel-add');
   const input  = document.getElementById('fig-label-input') as HTMLInputElement | null;
+  const noteArea = document.getElementById('fig-note-textarea') as HTMLTextAreaElement | null;
   if (!title) return;
   const fig = STATE.figures.find(f => f.id === id);
   if (fig) {
     title.textContent = 'FIGUR BEARBEITEN';
     if (addBtn) addBtn.hidden = true;
     if (input) input.value = fig.label || '';
+    if (noteArea) noteArea.value = (fig as any).note || '';
   } else {
     title.textContent = 'NEUE FIGUR';
     if (addBtn) addBtn.hidden = false;
     if (input) input.value = '';
+    if (noteArea) noteArea.value = '';
   }
 }
 
@@ -102,6 +105,26 @@ export function initFigPanel(): void {
     if (fig) {
       fig.label = (e.target as HTMLInputElement).value;
       sendUpdate(fig, { label: fig.label });
+    }
+  });
+
+  // Note textarea — sendet figure_note_set bei Eingabe (debounced via native input event)
+  document.getElementById('fig-note-textarea')!.addEventListener('input', e => {
+    const fig = STATE.figures.find(f => f.id === STATE.selectedId);
+    if (fig) {
+      const note = (e.target as HTMLTextAreaElement).value;
+      (fig as any).note = note;
+      sendClient({ type: 'figure_note_set', figureId: fig.id, note });
+      // Billboard update (Feature-Flag sf-t000469) — lazy import to avoid hard dep
+      const feats: Record<string, boolean> =
+        (typeof window !== 'undefined' && (window as any).__brettFeatures) || {};
+      if (feats['sf-t000469']) {
+        import('./hud').then(m => {
+          if (typeof (m as any).setFigureNoteBillboard === 'function') {
+            (m as any).setFigureNoteBillboard(fig.id, note);
+          }
+        }).catch(() => {});
+      }
     }
   });
 

--- a/brett/src/client/ui/hud.ts
+++ b/brett/src/client/ui/hud.ts
@@ -1,5 +1,5 @@
 import * as THREE from 'three';
-import { STATE, ui, lockSprites, activeLocks, currentUser, getWs, isWsReady } from '../state';
+import { STATE, ui, lockSprites, noteSprites, activeLocks, currentUser, getWs, isWsReady } from '../state';
 import { lockBadgeStyle, type VarGetter } from './skin';
 import { isFreeFly } from '../free-fly-camera';
 
@@ -161,5 +161,74 @@ export function releaseAllPossessions(): void {
   const ws = getWs();
   if (isWsReady() && ws) {
     ws.send(JSON.stringify({ type: 'figure_release' })); // no figureId → release all
+  }
+}
+
+/**
+ * Setzt oder aktualisiert den Notiz-Billboard-Sprite über einer Figur.
+ * Feature-Flag: sf-t000469. Zeigt max. 40 Zeichen der Notiz an.
+ */
+export function setFigureNoteBillboard(figureId: string, note: string): void {
+  clearFigureNoteBillboard(figureId);
+  const feats: Record<string, boolean> =
+    (typeof window !== 'undefined' && (window as any).__brettFeatures) || {};
+  if (!feats['sf-t000469']) return;
+  if (!note || !note.trim()) return; // Leere Notizen: kein Sprite
+
+  const fig = STATE.figures.find(f => f.id === figureId);
+  if (!fig) return;
+
+  const preview = note.length > 40 ? note.slice(0, 40) + '…' : note;
+
+  const canvas = document.createElement('canvas');
+  canvas.width = 320;
+  canvas.height = 80;
+  const ctx = canvas.getContext('2d')!;
+
+  // Hintergrund: leicht transparentes Dunkel mit goldenem Rand
+  ctx.fillStyle = 'rgba(11,17,28,0.82)';
+  if ((ctx as any).roundRect) {
+    (ctx as any).roundRect(4, 4, 312, 72, 12);
+  } else {
+    ctx.rect(4, 4, 312, 72);
+  }
+  ctx.fill();
+  ctx.strokeStyle = 'rgba(200,169,110,0.7)';
+  ctx.lineWidth = 2;
+  if ((ctx as any).roundRect) {
+    ctx.beginPath();
+    (ctx as any).roundRect(4, 4, 312, 72, 12);
+    ctx.stroke();
+  }
+
+  // Notiztext
+  ctx.font = '500 13px ui-sans-serif, system-ui, sans-serif';
+  ctx.fillStyle = '#e7ead0';
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  ctx.fillText(preview, 160, 40);
+
+  const texture = new THREE.CanvasTexture(canvas);
+  const mat = new THREE.SpriteMaterial({ map: texture, transparent: true });
+  const sprite = new THREE.Sprite(mat);
+  // Breiter als Lock-Badge, höher positioniert (über dem Kopf der Figur)
+  sprite.scale.set(2.0, 0.5, 1);
+  sprite.position.set(0, 1.9, 0);
+
+  fig.root.add(sprite);
+  noteSprites.set(figureId, sprite);
+}
+
+/**
+ * Entfernt den Notiz-Billboard-Sprite einer Figur und gibt GPU-Ressourcen frei.
+ */
+export function clearFigureNoteBillboard(figureId: string): void {
+  const sprite = noteSprites.get(figureId);
+  if (sprite) {
+    const fig = STATE.figures.find(f => f.id === figureId);
+    if (fig) fig.root.remove(sprite);
+    if (sprite.material.map) sprite.material.map.dispose();
+    sprite.material.dispose();
+    noteSprites.delete(figureId);
   }
 }

--- a/brett/src/client/ws-client.ts
+++ b/brett/src/client/ws-client.ts
@@ -238,6 +238,23 @@ export function onWsMessage(evt: MessageEvent): void {
         onModerationChange(moderationState);
       }
 
+      // Billboard-Wiederherstellung für alle Figuren mit Notizen (Feature-Flag sf-t000469)
+      {
+        const feats: Record<string, boolean> =
+          (typeof window !== 'undefined' && (window as any).__brettFeatures) || {};
+        if (feats['sf-t000469']) {
+          import('./ui/hud').then(m => {
+            if (typeof (m as any).setFigureNoteBillboard === 'function') {
+              for (const f of STATE.figures) {
+                if ((f as any).note) {
+                  (m as any).setFigureNoteBillboard(f.id, (f as any).note);
+                }
+              }
+            }
+          }).catch(() => {});
+        }
+      }
+
       // FE-2: the join snapshot is the FIRST (often ONLY) state a client gets on
       // connect, and it carries the authoritative phase/sessionCode/roster. Route
       // it through the lobby reducer and drive the view-machine on a phase change
@@ -335,6 +352,12 @@ export function onWsMessage(evt: MessageEvent): void {
       const idx = STATE.figures.findIndex(f => f.id === msg.id);
       if (idx >= 0) {
         scene.remove(STATE.figures[idx].root);
+        // Billboard-Cleanup (Feature-Flag sf-t000469)
+        import('./ui/hud').then(m => {
+          if (typeof (m as any).clearFigureNoteBillboard === 'function') {
+            (m as any).clearFigureNoteBillboard(msg.id);
+          }
+        }).catch(() => {});
         STATE.figures.splice(idx, 1);
       }
       break;

--- a/brett/src/client/ws-client.ts
+++ b/brett/src/client/ws-client.ts
@@ -195,6 +195,10 @@ export function onWsMessage(evt: MessageEvent): void {
           fig.boneOverrides = { ...f.boneOverrides };
         }
         (fig as any)._serverPossessor = (f as any).possessor ?? null;
+        // Notizen aus Snapshot wiederherstellen (Slice 5, T000469)
+        if ((f as any).note !== undefined) {
+          (fig as any).note = (f as any).note;
+        }
         STATE.figures.push(fig);
         if (f.appearance) {
           applyAppearanceToFig(fig, f.appearance);
@@ -420,6 +424,29 @@ export function onWsMessage(evt: MessageEvent): void {
     case 'moderation_state': {
       moderationState = { spotlight: msg.spotlight, dim: msg.dim, freeze: msg.freeze };
       onModerationChange(moderationState);
+      break;
+    }
+
+    case 'figure_note_changed': {
+      const fig = STATE.figures.find(f => f.id === msg.figureId);
+      if (fig) {
+        (fig as any).note = msg.note;
+        // Panel aktualisieren wenn diese Figur gerade selektiert ist
+        if (STATE.selectedId === msg.figureId) {
+          const noteArea = document.getElementById('fig-note-textarea') as HTMLTextAreaElement | null;
+          if (noteArea) noteArea.value = msg.note;
+        }
+        // Billboard update (Feature-Flag sf-t000469)
+        const feats: Record<string, boolean> =
+          (typeof window !== 'undefined' && (window as any).__brettFeatures) || {};
+        if (feats['sf-t000469']) {
+          import('./ui/hud').then(m => {
+            if (typeof (m as any).setFigureNoteBillboard === 'function') {
+              (m as any).setFigureNoteBillboard(msg.figureId, msg.note);
+            }
+          }).catch(() => {});
+        }
+      }
       break;
     }
 

--- a/brett/src/server/figures.ts
+++ b/brett/src/server/figures.ts
@@ -104,6 +104,15 @@ export function applyMutation(room: string, msg: any): void {
       }
       break;
     }
+    case 'figure_note_set': {
+      // Notiz-Mutation: Server-autoritativ, max. 1000 Zeichen.
+      // figureId muss existieren — kein Phantom-Figure-Erzeugen.
+      if (typeof msg.figureId === 'string' && figs.has(msg.figureId)) {
+        const note = typeof msg.note === 'string' ? msg.note.slice(0, 1000) : '';
+        figs.set(msg.figureId, { ...figs.get(msg.figureId), note });
+      }
+      break;
+    }
     case 'clear':
       figs.clear();
       break;

--- a/brett/src/server/permissions.ts
+++ b/brett/src/server/permissions.ts
@@ -11,7 +11,8 @@ export type MutationType =
   | 'add' | 'move' | 'update' | 'jump' | 'delete'
   | 'clear' | 'stiffness' | 'snapshot' | 'request_state_snapshot'
   | 'figure_lock'
-  | 'figure_possess' | 'figure_release';
+  | 'figure_possess' | 'figure_release'
+  | 'figure_note_set';  // Slice 5: Notizen pro Figur
 
 export interface MutateContext {
   msgType: MutationType;
@@ -57,6 +58,7 @@ export function canMutate(ctx: MutateContext): boolean {
     case 'figure_lock':
     case 'figure_possess':
     case 'figure_release':
+    case 'figure_note_set':
       break;
     default:
       return false; // Default-Deny for any non-matrix msgType.
@@ -71,6 +73,7 @@ export function canMutate(ctx: MutateContext): boolean {
       case 'jump':
       case 'delete':
       case 'figure_lock':
+      case 'figure_note_set':
         return ctx.figureOwnerId != null && ctx.figureOwnerId === ctx.playerId;
       case 'add':
         return ctx.allowRepresentativeAdd === true;

--- a/brett/src/server/ws-handler.ts
+++ b/brett/src/server/ws-handler.ts
@@ -407,6 +407,27 @@ export function attachWsServer(wss: WebSocketServer, deps: WsDeps): void {
           return;
         }
 
+        // ── Notiz-Mutation (Slice 5, T000469) ──────────────────────────────────
+        if (msg.type === 'figure_note_set') {
+          if (typeof msg.figureId !== 'string' || typeof msg.note !== 'string') return;
+          if (!gateMutation(ws, room, 'figure_note_set', msg.figureId, deps)) {
+            try { ws.send(JSON.stringify({ type: 'error', reason: 'forbidden' })); } catch {}
+            return;
+          }
+          deps.applyMutation(room, {
+            type: 'figure_note_set',
+            figureId: msg.figureId,
+            note: msg.note,
+          });
+          deps.broadcast(room, {
+            type: 'figure_note_changed',
+            figureId: msg.figureId,
+            note: msg.note.slice(0, 1000),
+          });
+          deps.schedulePersist(room);
+          return;
+        }
+
         // Non-privileged, ephemeral live-lobby readiness self-report.
         if (msg.type === 'lobby_set_ready') {
           handleLobbySetReady(ws, msg, deps);

--- a/brett/src/types/messages.ts
+++ b/brett/src/types/messages.ts
@@ -33,7 +33,8 @@ export type ClientMessage =
   | { type: 'figure_type_set'; figureId: string; figureType: FigureType }
   | { type: 'admin_spotlight_set'; figureId: string | null }
   | { type: 'admin_dim_set'; figureId: string | null }
-  | { type: 'admin_freeze_set'; frozen: boolean };
+  | { type: 'admin_freeze_set'; frozen: boolean }
+  | { type: 'figure_note_set'; figureId: string; note: string };
 
 // ── Server → Client ──────────────────────────────────────────────
 export type ServerMessage =
@@ -64,6 +65,7 @@ export type ServerMessage =
   | { type: 'figure_released'; figureId: string; playerId: string }
   | { type: 'figure_type_changed'; figureId: string; figureType: FigureType }
   | { type: 'moderation_state'; spotlight: string | null; dim: string | null; freeze: boolean }
+  | { type: 'figure_note_changed'; figureId: string; note: string }
   | { type: 'error'; reason: string };
 
 export interface ServerLock {

--- a/brett/src/types/state.ts
+++ b/brett/src/types/state.ts
@@ -50,6 +50,11 @@ export interface Figure {
   possessor?: string | null;
   /** Semantic figure type from the design system. Leader-only via figure_type_set. */
   figureType?: FigureType;
+  /**
+   * Freitext-Notiz zur Figur (Aussagen, Perspektiven, Statements).
+   * Gesetzt via figure_note_set (server-authoritative, via applyMutation).
+   */
+  note?: string;
 }
 
 export interface Participant {

--- a/brett/test/figure-note.test.ts
+++ b/brett/test/figure-note.test.ts
@@ -1,0 +1,136 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { applyMutation, ensureFigureMap, seedFigureMapFromState, figureMaps } from '../src/server/figures';
+import { canMutate } from '../src/server/permissions';
+import { buildStateFromMutations, initPhases } from '../src/server/phases';
+
+// Wire up phases (needed by buildStateFromMutations)
+initPhases({ figureMaps, applyMutation });
+
+// ── Test-Setup Hilfsfunktionen ────────────────────────────────────────────────
+
+function makeRoom(roomId: string): string {
+  const figs = ensureFigureMap(roomId);
+  figs.clear();
+  // Basis-Figuren anlegen
+  applyMutation(roomId, { type: 'add', figure: { id: 'fig-1', x: 0, z: 0, facingY: 0, appearance: {} } });
+  applyMutation(roomId, { type: 'add', figure: { id: 'fig-2', x: 1, z: 1, facingY: 0, appearance: {} } });
+  // ownerId direkt setzen (server-autoritativ)
+  applyMutation(roomId, { type: 'figure_owner_set', figureId: 'fig-2', ownerId: 'player-a' });
+  return roomId;
+}
+
+// ── applyMutation: figure_note_set ───────────────────────────────────────────
+
+test('applyMutation figure_note_set: setzt note auf existierende Figur', () => {
+  const room = makeRoom('note-test-1');
+  applyMutation(room, { type: 'figure_note_set', figureId: 'fig-1', note: 'Ich sehe Weite.' });
+  const fig = figureMaps.get(room)!.get('fig-1');
+  assert.strictEqual(fig.note, 'Ich sehe Weite.');
+});
+
+test('applyMutation figure_note_set: kürzt auf 1000 Zeichen', () => {
+  const room = makeRoom('note-test-2');
+  const long = 'x'.repeat(2000);
+  applyMutation(room, { type: 'figure_note_set', figureId: 'fig-1', note: long });
+  const fig = figureMaps.get(room)!.get('fig-1');
+  assert.strictEqual(fig.note!.length, 1000);
+});
+
+test('applyMutation figure_note_set: no-op bei unbekannter figureId', () => {
+  const room = makeRoom('note-test-3');
+  applyMutation(room, { type: 'figure_note_set', figureId: 'nonexistent', note: 'test' });
+  // kein Fehler, figureMaps unverändert
+  assert.ok(!figureMaps.get(room)!.has('nonexistent'));
+});
+
+test('applyMutation figure_note_set: leerer String löscht Notiz', () => {
+  const room = makeRoom('note-test-4');
+  applyMutation(room, { type: 'figure_note_set', figureId: 'fig-1', note: 'erste Notiz' });
+  applyMutation(room, { type: 'figure_note_set', figureId: 'fig-1', note: '' });
+  const fig = figureMaps.get(room)!.get('fig-1');
+  assert.strictEqual(fig.note, '');
+});
+
+// ── canMutate: figure_note_set ────────────────────────────────────────────────
+
+type CtxInput = Parameters<typeof canMutate>[0];
+
+function ctx(overrides: Partial<CtxInput>): CtxInput {
+  return {
+    msgType: 'figure_note_set',
+    role: 'beobachter',
+    playerId: 'me',
+    figureOwnerId: null,
+    allowRepresentativeAdd: false,
+    ...overrides,
+  };
+}
+
+test('canMutate figure_note_set: leiter → true (beliebige Figur)', () => {
+  assert.strictEqual(canMutate(ctx({ role: 'leiter', figureOwnerId: null })), true);
+  assert.strictEqual(canMutate(ctx({ role: 'leiter', figureOwnerId: 'other' })), true);
+});
+
+test('canMutate figure_note_set: stellvertreter eigene Figur → true', () => {
+  assert.strictEqual(
+    canMutate(ctx({ role: 'stellvertreter', playerId: 'me', figureOwnerId: 'me' })),
+    true,
+  );
+});
+
+test('canMutate figure_note_set: stellvertreter fremde Figur → false', () => {
+  assert.strictEqual(
+    canMutate(ctx({ role: 'stellvertreter', playerId: 'me', figureOwnerId: 'other' })),
+    false,
+  );
+});
+
+test('canMutate figure_note_set: stellvertreter null Owner → false', () => {
+  assert.strictEqual(
+    canMutate(ctx({ role: 'stellvertreter', playerId: 'me', figureOwnerId: null })),
+    false,
+  );
+});
+
+test('canMutate figure_note_set: beobachter → false', () => {
+  assert.strictEqual(canMutate(ctx({ role: 'beobachter' })), false);
+});
+
+// ── buildStateFromMutations: note in figures ──────────────────────────────────
+
+test('buildStateFromMutations: note erscheint in figures-Array', () => {
+  const room = makeRoom('note-build-1');
+  applyMutation(room, { type: 'figure_note_set', figureId: 'fig-1', note: 'Perspektive: Norden.' });
+  const state = buildStateFromMutations(room);
+  const fig1 = state.figures.find((f: any) => f.id === 'fig-1');
+  assert.ok(fig1, 'fig-1 muss in figures[] sein');
+  assert.strictEqual(fig1.note, 'Perspektive: Norden.');
+});
+
+// ── seedFigureMapFromState: note wird re-hydriert ─────────────────────────────
+
+test('seedFigureMapFromState: note wird korrekt re-hydriert', () => {
+  const map = new Map<string, any>();
+  const persistedState = {
+    figures: [
+      { id: 'f-1', x: 0, z: 0, facingY: 0, appearance: {}, note: 'Gespeicherte Notiz' },
+      { id: 'f-2', x: 1, z: 1, facingY: 0, appearance: {} }, // keine Notiz
+    ],
+  };
+  seedFigureMapFromState(map, persistedState);
+  assert.strictEqual(map.get('f-1').note, 'Gespeicherte Notiz');
+  assert.ok(map.has('f-2'));
+  assert.strictEqual(map.get('f-2').note, undefined);
+});
+
+test('seedFigureMapFromState: note überlebt DB-Round-Trip ohne Verlust', () => {
+  const room = makeRoom('note-seed-1');
+  applyMutation(room, { type: 'figure_note_set', figureId: 'fig-1', note: 'Round-Trip Test' });
+  const state = buildStateFromMutations(room);
+  // Simuliere DB-Round-Trip: neues Map aus gespeichertem State
+  const freshMap = new Map<string, any>();
+  seedFigureMapFromState(freshMap, state);
+  const rehydrated = freshMap.get('fig-1');
+  assert.strictEqual(rehydrated.note, 'Round-Trip Test');
+});

--- a/brett/test/messages.test.ts
+++ b/brett/test/messages.test.ts
@@ -12,7 +12,7 @@ const HANDLED_SERVER_TYPES = new Set<ServerMessageType>([
   'session_ended', 'admin_token_changed', 'coaching_steps_change', 'error',
   'role_changed', 'figure_owner_changed', 'lobby_ready_changed', 'lobby_settings_change',
   'figure_possessed', 'figure_released', 'figure_type_changed',
-  'moderation_state',
+  'moderation_state', 'figure_note_changed',
 ]);
 
 // Compile-time exhaustiveness: this function must handle every ServerMessage
@@ -47,6 +47,7 @@ function routeServer(msg: ServerMessage): string {
     case 'figure_released': return 'figure_released';
     case 'figure_type_changed': return 'figure_type_changed';
     case 'moderation_state': return 'moderation_state';
+    case 'figure_note_changed': return 'figure_note_changed';
     default: return assertNever(msg); // ← compile error if a variant is unhandled
   }
 }
@@ -85,6 +86,7 @@ function routeClient(msg: ClientMessage): string {
     case 'admin_spotlight_set': return 'admin_spotlight_set';
     case 'admin_dim_set': return 'admin_dim_set';
     case 'admin_freeze_set': return 'admin_freeze_set';
+    case 'figure_note_set': return 'figure_note_set';
     default: return assertNever(msg); // ← compile error if a variant is unhandled
   }
 }

--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -2137,7 +2137,7 @@
       "id": "brett",
       "name": "Brett 3D board (CommonJS)",
       "owner_agent": "bachelorprojekt-website",
-      "file_count": 250,
+      "file_count": 251,
       "files": [
         "brett/.dockerignore",
         "brett/.gitignore",

--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -2337,6 +2337,7 @@
         "brett/test/facelift-tokens.test.ts",
         "brett/test/figure-label.test.ts",
         "brett/test/figure-locks.test.ts",
+        "brett/test/figure-note.test.ts",
         "brett/test/figure-owner.test.ts",
         "brett/test/free-fly-camera.test.ts",
         "brett/test/hud-model.test.ts",

--- a/docs/superpowers/plans/2026-06-07-brett-figure-notes.md
+++ b/docs/superpowers/plans/2026-06-07-brett-figure-notes.md
@@ -1,0 +1,856 @@
+---
+title: "Brett: Notizen & Statements pro Figur (Slice 5)"
+ticket_id: T000469
+spec: docs/superpowers/specs/2026-06-07-brett-figure-notes-design.md
+branch: feature/brett-figure-notes
+domains: [website]
+status: active
+pr_number: null
+---
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Füge pro Figur ein persistiertes, WS-synchronisiertes Notizfeld hinzu — mit Side-Panel-UI, `figure_note_set`-Mutation und optionalem Billboard-Sprite über der Figur.
+
+**Architecture:** `note?: string` direkt im `Figure`-Interface (kein neuer Sentinel), server-autoritativ via neuer `figure_note_set`-Mutation und `figure_note_changed`-Broadcast; Billboard hinter Feature-Flag `sf-t000469`; `MutationType` und `canMutate` um den neuen Typ erweitert.
+
+**Tech Stack:** TypeScript, Three.js, ws, node:test, tsx/jsdom
+
+**Ticket-ID:** T000469
+
+---
+
+## Meilenstein 1: Shared Types & Permissions
+
+### Task 1.1: `note` Feld zu `Figure` Interface hinzufügen
+
+**Files:**
+- Modify: `brett/src/types/state.ts`
+
+- [ ] **Step 1: `note?: string` zum `Figure`-Interface hinzufügen**
+
+```typescript
+// In brett/src/types/state.ts, innerhalb des Figure-Interface nach `figureType?`:
+  /**
+   * Freitext-Notiz zur Figur (Aussagen, Perspektiven, Statements).
+   * Gesetzt via figure_note_set (server-authoritative, via applyMutation).
+   */
+  note?: string;
+```
+
+- [ ] **Step 2: TypeScript verifizieren**
+
+Run: `cd brett && npx tsc --noEmit`
+Expected: PASS (kein Fehler durch das optionale Feld)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add brett/src/types/state.ts
+git commit -m "feat(brett): add note field to Figure interface [T000469]"
+```
+
+---
+
+### Task 1.2: Message-Typen für `figure_note_set` und `figure_note_changed`
+
+**Files:**
+- Modify: `brett/src/types/messages.ts`
+
+- [ ] **Step 1: `figure_note_set` zu `ClientMessage` hinzufügen**
+
+Ergänze am Ende der `ClientMessage`-Union (nach `figure_type_set`):
+```typescript
+  | { type: 'figure_note_set'; figureId: string; note: string }
+```
+
+- [ ] **Step 2: `figure_note_changed` zu `ServerMessage` hinzufügen**
+
+Ergänze am Ende der `ServerMessage`-Union (nach `figure_type_changed`):
+```typescript
+  | { type: 'figure_note_changed'; figureId: string; note: string }
+```
+
+- [ ] **Step 3: TypeScript verifizieren**
+
+Run: `cd brett && npx tsc --noEmit`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add brett/src/types/messages.ts
+git commit -m "feat(brett): add figure_note_set / figure_note_changed message types [T000469]"
+```
+
+---
+
+### Task 1.3: `MutationType` und `canMutate` für `figure_note_set`
+
+**Files:**
+- Modify: `brett/src/server/permissions.ts`
+
+- [ ] **Step 1: `figure_note_set` zu `MutationType` hinzufügen**
+
+```typescript
+// In brett/src/server/permissions.ts:
+export type MutationType =
+  | 'add' | 'move' | 'update' | 'jump' | 'delete'
+  | 'clear' | 'stiffness' | 'snapshot' | 'request_state_snapshot'
+  | 'figure_lock' | 'figure_possess' | 'figure_release'
+  | 'figure_note_set';  // Slice 5: Notizen pro Figur
+```
+
+- [ ] **Step 2: `canMutate` um `figure_note_set` erweitern**
+
+Im `canMutate`-Switch den `beobachter`-Zweig und den `stellvertreter`-Zweig anpassen. Suche die `beobachter`-Section und füge `figure_note_set` zur deny-Liste hinzu (beobachter darf nicht schreiben). Im `stellvertreter`-Zweig ownership-gated analog zu `move`/`update`:
+
+```typescript
+// Innerhalb canMutate, Stellvertreter-Zweig:
+// OWNER_GATED: erlaubt wenn figureOwnerId === playerId
+const OWNER_GATED_NOTE = new Set<MutationType>(['move', 'update', 'jump', 'delete', 'figure_lock', 'figure_note_set']);
+if (OWNER_GATED_NOTE.has(ctx.msgType)) {
+  return ctx.figureOwnerId === ctx.playerId;
+}
+```
+
+Für leiter bleibt `return true` unverändert.
+
+Für beobachter: `figure_note_set` ist **nicht** in der allow-Liste (`figure_possess`, `figure_release`), daher automatisch `false` durch den Default-Deny.
+
+- [ ] **Step 3: TypeScript verifizieren**
+
+Run: `cd brett && npx tsc --noEmit`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add brett/src/server/permissions.ts
+git commit -m "feat(brett): add figure_note_set to MutationType + canMutate [T000469]"
+```
+
+---
+
+## Meilenstein 2: Server-Side Mutation & WS-Handler
+
+### Task 2.1: `applyMutation`-Case für `figure_note_set`
+
+**Files:**
+- Modify: `brett/src/server/figures.ts`
+
+- [ ] **Step 1: Case `figure_note_set` in `applyMutation`-Switch hinzufügen**
+
+Einfügen nach dem `figure_type_set`-Case (vor dem abschließenden `case 'clear':`):
+
+```typescript
+    case 'figure_note_set': {
+      // Notiz-Mutation: Server-autoritativ, max. 1000 Zeichen.
+      // figureId muss existieren — kein Phantom-Figure-Erzeugen.
+      if (typeof msg.figureId === 'string' && figs.has(msg.figureId)) {
+        const note = typeof msg.note === 'string' ? msg.note.slice(0, 1000) : '';
+        figs.set(msg.figureId, { ...figs.get(msg.figureId), note });
+      }
+      break;
+    }
+```
+
+- [ ] **Step 2: TypeScript verifizieren**
+
+Run: `cd brett && npx tsc --noEmit`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add brett/src/server/figures.ts
+git commit -m "feat(brett): applyMutation case for figure_note_set [T000469]"
+```
+
+---
+
+### Task 2.2: WS-Handler-Block für `figure_note_set`
+
+**Files:**
+- Modify: `brett/src/server/ws-handler.ts`
+
+- [ ] **Step 1: Handler-Block für `figure_note_set` einfügen**
+
+Einfügen NACH dem `figure_release`-Block und VOR dem `lobby_set_ready`-Check (analog zum Possession-Pattern):
+
+```typescript
+        // ── Notiz-Mutation (Slice 5, T000469) ──────────────────────────────────
+        if (msg.type === 'figure_note_set') {
+          if (typeof msg.figureId !== 'string' || typeof msg.note !== 'string') return;
+          if (!gateMutation(ws, room, 'figure_note_set', msg.figureId, deps)) {
+            try { ws.send(JSON.stringify({ type: 'error', reason: 'forbidden' })); } catch {}
+            return;
+          }
+          deps.applyMutation(room, {
+            type: 'figure_note_set',
+            figureId: msg.figureId,
+            note: msg.note,
+          });
+          deps.broadcast(room, {
+            type: 'figure_note_changed',
+            figureId: msg.figureId,
+            note: msg.note.slice(0, 1000),
+          });
+          deps.schedulePersist(room);
+          return;
+        }
+```
+
+- [ ] **Step 2: Sicherstellen dass `figure_note_set` NICHT in `RELAY_TYPES` oder `ADMIN_TYPES` landet**
+
+Prüfe:
+```typescript
+// RELAY_TYPES enthält 'figure_note_set' NICHT (eigener Handler oben)
+// ADMIN_TYPES enthält 'figure_note_set' NICHT (non-admin Mutation)
+```
+
+Run: `cd brett && grep -n "figure_note_set" src/server/ws-handler.ts`
+Expected: nur der neue Handler-Block
+
+- [ ] **Step 3: TypeScript verifizieren**
+
+Run: `cd brett && npx tsc --noEmit`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add brett/src/server/ws-handler.ts
+git commit -m "feat(brett): ws-handler block for figure_note_set mutation [T000469]"
+```
+
+---
+
+## Meilenstein 3: Client-Side Panel & WS-Client
+
+### Task 3.1: DOM-Elemente für Notizfeld in `index.html`
+
+**Files:**
+- Modify: `brett/public/index.html`
+
+- [ ] **Step 1: `<textarea>` und Label in `#fig-panel` einfügen**
+
+Im `#fig-panel`-Dialog, nach dem `#fig-label-input`-Block und VOR dem `#fig-panel-add`-Button einfügen:
+
+```html
+          <span class="fig-panel-label">Notiz / Statement</span>
+          <textarea id="fig-note-textarea"
+            placeholder="Was spricht diese Figur? Was sieht sie?"
+            maxlength="1000"
+            rows="4"></textarea>
+```
+
+- [ ] **Step 2: CSS für `#fig-note-textarea` hinzufügen**
+
+Im `<style>`-Block nach den `#fig-label-input`-Regeln:
+
+```css
+    #fig-note-textarea {
+      background: var(--brett-ink-850, #101826);
+      border: 1px solid var(--brett-line-2, rgba(255,255,255,0.12));
+      border-radius: 5px;
+      color: var(--brett-fg, #eef1f3);
+      font: inherit;
+      font-size: 12px;
+      padding: 5px 8px;
+      width: 100%;
+      resize: vertical;
+      min-height: 72px;
+      line-height: 1.4;
+    }
+    #fig-note-textarea:focus {
+      outline: none;
+      border-color: var(--brett-brass, oklch(0.80 0.09 75));
+    }
+    #fig-note-textarea::placeholder {
+      color: rgba(231,234,208,0.3);
+    }
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add brett/public/index.html
+git commit -m "feat(brett): add note textarea to fig-panel HTML+CSS [T000469]"
+```
+
+---
+
+### Task 3.2: `fig-panel.ts` — Notizfeld synchronisieren und senden
+
+**Files:**
+- Modify: `brett/src/client/ui/fig-panel.ts`
+
+- [ ] **Step 1: Import `sendClient` aus `ws-client.ts` sicherstellen**
+
+Am Anfang der Datei ist bereits `import { sendAddFigure, sendUpdate } from '../ws-client';`. Ergänze:
+
+```typescript
+import { sendAddFigure, sendUpdate, sendClient } from '../ws-client';
+```
+
+- [ ] **Step 2: `syncPanelToSelection` für Notizfeld erweitern**
+
+Ergänze in `syncPanelToSelection(id)` das Befüllen des Notizfelds:
+
+```typescript
+export function syncPanelToSelection(id: string | null): void {
+  const title  = document.getElementById('fig-panel-title');
+  const addBtn = document.getElementById('fig-panel-add');
+  const input  = document.getElementById('fig-label-input') as HTMLInputElement | null;
+  const noteArea = document.getElementById('fig-note-textarea') as HTMLTextAreaElement | null;  // NEU
+  if (!title) return;
+  const fig = STATE.figures.find(f => f.id === id);
+  if (fig) {
+    title.textContent = 'FIGUR BEARBEITEN';
+    if (addBtn) addBtn.hidden = true;
+    if (input) input.value = fig.label || '';
+    if (noteArea) noteArea.value = (fig as any).note || '';  // NEU
+  } else {
+    title.textContent = 'NEUE FIGUR';
+    if (addBtn) addBtn.hidden = false;
+    if (input) input.value = '';
+    if (noteArea) noteArea.value = '';  // NEU
+  }
+}
+```
+
+- [ ] **Step 3: `input`-Handler für `fig-note-textarea` in `initFigPanel` registrieren**
+
+Nach dem `fig-label-input`-Handler in `initFigPanel`:
+
+```typescript
+  // Note textarea — sendet figure_note_set bei Eingabe (debounced via native input event)
+  document.getElementById('fig-note-textarea')!.addEventListener('input', e => {
+    const fig = STATE.figures.find(f => f.id === STATE.selectedId);
+    if (fig) {
+      const note = (e.target as HTMLTextAreaElement).value;
+      (fig as any).note = note;
+      sendClient({ type: 'figure_note_set', figureId: fig.id, note });
+      // Billboard update (Feature-Flag sf-t000469) — lazy import to avoid hard dep
+      const feats: Record<string, boolean> =
+        (typeof window !== 'undefined' && (window as any).__brettFeatures) || {};
+      if (feats['sf-t000469']) {
+        import('./hud').then(m => {
+          if (typeof (m as any).setFigureNoteBillboard === 'function') {
+            (m as any).setFigureNoteBillboard(fig.id, note);
+          }
+        }).catch(() => {});
+      }
+    }
+  });
+```
+
+- [ ] **Step 4: TypeScript verifizieren**
+
+Run: `cd brett && npx tsc --noEmit`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add brett/src/client/ui/fig-panel.ts
+git commit -m "feat(brett): sync note textarea in fig-panel, send figure_note_set [T000469]"
+```
+
+---
+
+### Task 3.3: `ws-client.ts` — `figure_note_changed` empfangen
+
+**Files:**
+- Modify: `brett/src/client/ws-client.ts`
+
+- [ ] **Step 1: `figure_note_changed`-Case in `onWsMessage`-Switch hinzufügen**
+
+Einfügen nach dem `figure_type_changed`-Case (vor `case 'error':`):
+
+```typescript
+    case 'figure_note_changed': {
+      const fig = STATE.figures.find(f => f.id === msg.figureId);
+      if (fig) {
+        (fig as any).note = msg.note;
+        // Panel aktualisieren wenn diese Figur gerade selektiert ist
+        if (STATE.selectedId === msg.figureId) {
+          const noteArea = document.getElementById('fig-note-textarea') as HTMLTextAreaElement | null;
+          if (noteArea) noteArea.value = msg.note;
+        }
+        // Billboard update (Feature-Flag sf-t000469)
+        const feats: Record<string, boolean> =
+          (typeof window !== 'undefined' && (window as any).__brettFeatures) || {};
+        if (feats['sf-t000469']) {
+          import('./ui/hud').then(m => {
+            if (typeof (m as any).setFigureNoteBillboard === 'function') {
+              (m as any).setFigureNoteBillboard(msg.figureId, msg.note);
+            }
+          }).catch(() => {});
+        }
+      }
+      break;
+    }
+```
+
+- [ ] **Step 2: `snapshot`-Case um `note`-Wiederherstellung erweitern**
+
+Im `case 'snapshot':` nach der Figur-Erstellung aus `msg.figures` (wo `appearance` schon applied wird), ergänze Notiz-Wiederherstellung:
+
+```typescript
+        // Notizen aus Snapshot wiederherstellen (Slice 5, T000469)
+        if (f.note !== undefined) {
+          (fig as any).note = f.note;
+        }
+```
+
+Das Billboard wird nach dem `snapshot`-Case per Feature-Flag initial gesetzt; hier reicht es, `note` zu setzen — das Panel synct via `selectFigure`.
+
+- [ ] **Step 3: TypeScript verifizieren**
+
+Run: `cd brett && npx tsc --noEmit`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add brett/src/client/ws-client.ts
+git commit -m "feat(brett): handle figure_note_changed in ws-client + snapshot rehydration [T000469]"
+```
+
+---
+
+## Meilenstein 4: 3D Billboard (Feature-Flag `sf-t000469`)
+
+### Task 4.1: Billboard-Funktionen in `hud.ts`
+
+**Files:**
+- Modify: `brett/src/client/ui/hud.ts`
+- Modify: `brett/src/client/state.ts`
+
+- [ ] **Step 1: `noteSprites`-Map in `state.ts` exportieren**
+
+In `brett/src/client/state.ts`, nach `export const lockSprites`:
+
+```typescript
+export const noteSprites = new Map<string, THREE.Sprite>();
+```
+
+- [ ] **Step 2: `noteSprites` in `hud.ts` importieren**
+
+Passe den Import am Anfang von `hud.ts` an:
+
+```typescript
+import { STATE, ui, lockSprites, noteSprites, activeLocks, currentUser, getWs, isWsReady } from '../state';
+```
+
+- [ ] **Step 3: `setFigureNoteBillboard` und `clearFigureNoteBillboard` in `hud.ts` hinzufügen**
+
+Am Ende von `hud.ts` (nach `clearLockBadgesForUser`):
+
+```typescript
+/**
+ * Setzt oder aktualisiert den Notiz-Billboard-Sprite über einer Figur.
+ * Feature-Flag: sf-t000469. Zeigt max. 40 Zeichen der Notiz an.
+ */
+export function setFigureNoteBillboard(figureId: string, note: string): void {
+  clearFigureNoteBillboard(figureId);
+  const feats: Record<string, boolean> =
+    (typeof window !== 'undefined' && (window as any).__brettFeatures) || {};
+  if (!feats['sf-t000469']) return;
+  if (!note || !note.trim()) return; // Leere Notizen: kein Sprite
+
+  const fig = STATE.figures.find(f => f.id === figureId);
+  if (!fig) return;
+
+  const preview = note.length > 40 ? note.slice(0, 40) + '…' : note;
+
+  const canvas = document.createElement('canvas');
+  canvas.width = 320;
+  canvas.height = 80;
+  const ctx = canvas.getContext('2d')!;
+
+  // Hintergrund: leicht transparentes Dunkel mit goldenem Rand
+  ctx.fillStyle = 'rgba(11,17,28,0.82)';
+  if ((ctx as any).roundRect) {
+    (ctx as any).roundRect(4, 4, 312, 72, 12);
+  } else {
+    ctx.rect(4, 4, 312, 72);
+  }
+  ctx.fill();
+  ctx.strokeStyle = 'rgba(200,169,110,0.7)';
+  ctx.lineWidth = 2;
+  if ((ctx as any).roundRect) {
+    ctx.beginPath();
+    (ctx as any).roundRect(4, 4, 312, 72, 12);
+    ctx.stroke();
+  }
+
+  // Notiztext
+  ctx.font = '500 13px ui-sans-serif, system-ui, sans-serif';
+  ctx.fillStyle = '#e7ead0';
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  ctx.fillText(preview, 160, 40);
+
+  const texture = new THREE.CanvasTexture(canvas);
+  const mat = new THREE.SpriteMaterial({ map: texture, transparent: true });
+  const sprite = new THREE.Sprite(mat);
+  // Breiter als Lock-Badge, höher positioniert (über dem Kopf der Figur)
+  sprite.scale.set(2.0, 0.5, 1);
+  sprite.position.set(0, 1.9, 0);
+
+  fig.root.add(sprite);
+  noteSprites.set(figureId, sprite);
+}
+
+/**
+ * Entfernt den Notiz-Billboard-Sprite einer Figur und gibt GPU-Ressourcen frei.
+ */
+export function clearFigureNoteBillboard(figureId: string): void {
+  const sprite = noteSprites.get(figureId);
+  if (sprite) {
+    const fig = STATE.figures.find(f => f.id === figureId);
+    if (fig) fig.root.remove(sprite);
+    if (sprite.material.map) sprite.material.map.dispose();
+    sprite.material.dispose();
+    noteSprites.delete(figureId);
+  }
+}
+```
+
+- [ ] **Step 4: TypeScript verifizieren**
+
+Run: `cd brett && npx tsc --noEmit`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add brett/src/client/state.ts brett/src/client/ui/hud.ts
+git commit -m "feat(brett): note billboard sprite functions in hud.ts (sf-t000469) [T000469]"
+```
+
+---
+
+### Task 4.2: Billboard-Cleanup bei Figur-Löschung
+
+**Files:**
+- Modify: `brett/src/client/ws-client.ts`
+
+- [ ] **Step 1: Billboard-Cleanup im `delete`-Case sicherstellen**
+
+Im `case 'delete':`-Block in `onWsMessage`, nach `scene.remove(STATE.figures[idx].root)`:
+
+```typescript
+    case 'delete': {
+      const idx = STATE.figures.findIndex(f => f.id === msg.id);
+      if (idx >= 0) {
+        scene.remove(STATE.figures[idx].root);
+        // Billboard-Cleanup (Feature-Flag sf-t000469)
+        import('./ui/hud').then(m => {
+          if (typeof (m as any).clearFigureNoteBillboard === 'function') {
+            (m as any).clearFigureNoteBillboard(msg.id);
+          }
+        }).catch(() => {});
+        STATE.figures.splice(idx, 1);
+      }
+      break;
+    }
+```
+
+- [ ] **Step 2: Billboard-Initialisierung im `snapshot`-Case**
+
+Am Ende des `case 'snapshot':`-Blocks (nach dem kompletten Figures-Rebuild), füge hinzu:
+
+```typescript
+      // Billboard-Wiederherstellung für alle Figuren mit Notizen (Feature-Flag sf-t000469)
+      const feats: Record<string, boolean> =
+        (typeof window !== 'undefined' && (window as any).__brettFeatures) || {};
+      if (feats['sf-t000469']) {
+        import('./ui/hud').then(m => {
+          if (typeof (m as any).setFigureNoteBillboard === 'function') {
+            for (const f of STATE.figures) {
+              if ((f as any).note) {
+                (m as any).setFigureNoteBillboard(f.id, (f as any).note);
+              }
+            }
+          }
+        }).catch(() => {});
+      }
+```
+
+- [ ] **Step 3: TypeScript verifizieren**
+
+Run: `cd brett && npx tsc --noEmit`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add brett/src/client/ws-client.ts
+git commit -m "feat(brett): billboard cleanup on delete + restore on snapshot [T000469]"
+```
+
+---
+
+## Meilenstein 5: Tests
+
+### Task 5.1: Server-Unit-Tests `figure-note.test.ts`
+
+**Files:**
+- Create: `brett/test/figure-note.test.ts`
+
+- [ ] **Step 1: Test-Datei erstellen**
+
+```typescript
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { applyMutation, ensureFigureMap, seedFigureMapFromState } from '../src/server/figures';
+import { canMutate } from '../src/server/permissions';
+import { buildStateFromMutations } from '../src/server/phases';
+import { initPhases } from '../src/server/phases';
+import { figureMaps } from '../src/server/figures';
+
+// ── Test-Setup Hilfsfunktionen ────────────────────────────────────────────────
+
+function makeRoom(roomId: string): string {
+  const figs = ensureFigureMap(roomId);
+  figs.clear();
+  // Basis-Figur anlegen
+  applyMutation(roomId, { type: 'add', figure: { id: 'fig-1', x: 0, z: 0, facingY: 0, appearance: {} } });
+  applyMutation(roomId, { type: 'add', figure: { id: 'fig-2', x: 1, z: 1, facingY: 0, appearance: {}, ownerId: 'player-a' } });
+  // ownerId direkt setzen (server-autoritativ)
+  applyMutation(roomId, { type: 'figure_owner_set', figureId: 'fig-2', ownerId: 'player-a' });
+  return roomId;
+}
+
+// ── applyMutation: figure_note_set ───────────────────────────────────────────
+
+test('applyMutation figure_note_set: setzt note auf existierende Figur', () => {
+  const room = makeRoom('note-test-1');
+  applyMutation(room, { type: 'figure_note_set', figureId: 'fig-1', note: 'Ich sehe Weite.' });
+  const fig = figureMaps.get(room)!.get('fig-1');
+  assert.strictEqual(fig.note, 'Ich sehe Weite.');
+});
+
+test('applyMutation figure_note_set: kürzt auf 1000 Zeichen', () => {
+  const room = makeRoom('note-test-2');
+  const long = 'x'.repeat(2000);
+  applyMutation(room, { type: 'figure_note_set', figureId: 'fig-1', note: long });
+  const fig = figureMaps.get(room)!.get('fig-1');
+  assert.strictEqual(fig.note!.length, 1000);
+});
+
+test('applyMutation figure_note_set: no-op bei unbekannter figureId', () => {
+  const room = makeRoom('note-test-3');
+  applyMutation(room, { type: 'figure_note_set', figureId: 'nonexistent', note: 'test' });
+  // kein Fehler, figureMaps unverändert
+  assert.ok(!figureMaps.get(room)!.has('nonexistent'));
+});
+
+test('applyMutation figure_note_set: leerer String löscht Notiz', () => {
+  const room = makeRoom('note-test-4');
+  applyMutation(room, { type: 'figure_note_set', figureId: 'fig-1', note: 'erste Notiz' });
+  applyMutation(room, { type: 'figure_note_set', figureId: 'fig-1', note: '' });
+  const fig = figureMaps.get(room)!.get('fig-1');
+  assert.strictEqual(fig.note, '');
+});
+
+// ── canMutate: figure_note_set ────────────────────────────────────────────────
+
+function ctx(overrides: Partial<Parameters<typeof canMutate>[0]>): Parameters<typeof canMutate>[0] {
+  return {
+    msgType: 'figure_note_set' as any,
+    role: 'beobachter',
+    playerId: 'me',
+    figureOwnerId: null,
+    allowRepresentativeAdd: false,
+    ...overrides,
+  };
+}
+
+test('canMutate figure_note_set: leiter → true (beliebige Figur)', () => {
+  assert.strictEqual(canMutate(ctx({ role: 'leiter', figureOwnerId: null })), true);
+  assert.strictEqual(canMutate(ctx({ role: 'leiter', figureOwnerId: 'other' })), true);
+});
+
+test('canMutate figure_note_set: stellvertreter eigene Figur → true', () => {
+  assert.strictEqual(
+    canMutate(ctx({ role: 'stellvertreter', playerId: 'me', figureOwnerId: 'me' })),
+    true,
+  );
+});
+
+test('canMutate figure_note_set: stellvertreter fremde Figur → false', () => {
+  assert.strictEqual(
+    canMutate(ctx({ role: 'stellvertreter', playerId: 'me', figureOwnerId: 'other' })),
+    false,
+  );
+});
+
+test('canMutate figure_note_set: stellvertreter null Owner → false', () => {
+  assert.strictEqual(
+    canMutate(ctx({ role: 'stellvertreter', playerId: 'me', figureOwnerId: null })),
+    false,
+  );
+});
+
+test('canMutate figure_note_set: beobachter → false', () => {
+  assert.strictEqual(canMutate(ctx({ role: 'beobachter' })), false);
+});
+
+// ── buildStateFromMutations: note in figures ──────────────────────────────────
+
+test('buildStateFromMutations: note erscheint in figures-Array', () => {
+  // initPhases braucht figureMaps + applyMutation
+  initPhases({ figureMaps, applyMutation });
+  const room = makeRoom('note-build-1');
+  applyMutation(room, { type: 'figure_note_set', figureId: 'fig-1', note: 'Perspektive: Norden.' });
+  const state = buildStateFromMutations(room);
+  const fig1 = state.figures.find((f: any) => f.id === 'fig-1');
+  assert.ok(fig1, 'fig-1 muss in figures[] sein');
+  assert.strictEqual(fig1.note, 'Perspektive: Norden.');
+});
+
+// ── seedFigureMapFromState: note wird re-hydriert ─────────────────────────────
+
+test('seedFigureMapFromState: note wird korrekt re-hydriert', () => {
+  const map = new Map<string, any>();
+  const persistedState = {
+    figures: [
+      { id: 'f-1', x: 0, z: 0, facingY: 0, appearance: {}, note: 'Gespeicherte Notiz' },
+      { id: 'f-2', x: 1, z: 1, facingY: 0, appearance: {} }, // keine Notiz
+    ],
+  };
+  seedFigureMapFromState(map, persistedState);
+  assert.strictEqual(map.get('f-1').note, 'Gespeicherte Notiz');
+  assert.ok(map.has('f-2'));
+  assert.strictEqual(map.get('f-2').note, undefined);
+});
+
+test('seedFigureMapFromState: note überlebt DB-Round-Trip ohne Verlust', () => {
+  initPhases({ figureMaps, applyMutation });
+  const room = makeRoom('note-seed-1');
+  applyMutation(room, { type: 'figure_note_set', figureId: 'fig-1', note: 'Round-Trip Test' });
+  const state = buildStateFromMutations(room);
+  // Simuliere DB-Round-Trip: neues Map aus gespeichertem State
+  const freshMap = new Map<string, any>();
+  seedFigureMapFromState(freshMap, state);
+  const rehydrated = freshMap.get('fig-1');
+  assert.strictEqual(rehydrated.note, 'Round-Trip Test');
+});
+```
+
+- [ ] **Step 2: Tests ausführen**
+
+Run: `cd brett && node --test test/figure-note.test.ts`
+Expected: Alle Tests PASS (grün)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add brett/test/figure-note.test.ts
+git commit -m "test(brett): figure-note unit tests — applyMutation/perms/buildState/seed [T000469]"
+```
+
+---
+
+### Task 5.2: Message-Typ-Exhaustiveness-Test
+
+**Files:**
+- Modify: `brett/test/messages.test.ts`
+
+- [ ] **Step 1: Sicherstellen dass `figure_note_set` und `figure_note_changed` in den Type-Unions sind**
+
+In `brett/test/messages.test.ts` (oder entsprechende Datei), füge Assert hinzu:
+
+```typescript
+import type { ClientMessageType, ServerMessageType } from '../src/types/messages';
+
+// Compile-time check: diese Typen müssen in den Unions enthalten sein
+// (wird zur Build-Zeit durch TypeScript erzwungen)
+type AssertNoteSetInClient = ClientMessageType extends infer T
+  ? 'figure_note_set' extends T ? true : false
+  : false;
+type AssertNoteChangedInServer = ServerMessageType extends infer T
+  ? 'figure_note_changed' extends T ? true : false
+  : false;
+
+// Runtime-Check
+import { test } from 'node:test';
+import assert from 'node:assert';
+
+test('ClientMessageType enthält figure_note_set', () => {
+  const types: ClientMessageType[] = ['figure_note_set'];
+  assert.ok(types.length === 1);
+});
+
+test('ServerMessageType enthält figure_note_changed', () => {
+  const types: ServerMessageType[] = ['figure_note_changed'];
+  assert.ok(types.length === 1);
+});
+```
+
+- [ ] **Step 2: TypeScript verifizieren**
+
+Run: `cd brett && npx tsc --noEmit`
+Expected: PASS — TypeScript erzwingt zur Compilezeit dass die Types existieren
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add brett/test/messages.test.ts
+git commit -m "test(brett): verify figure_note_set/changed in message type unions [T000469]"
+```
+
+---
+
+### Task 5.3: Abschluss-Verifikation
+
+**Files:**
+- Keine Änderungen
+
+- [ ] **Step 1: Alle Brett-Tests laufen**
+
+Run: `cd brett && node --test test/figure-note.test.ts test/permissions.test.ts test/messages.test.ts`
+Expected: Alle Tests PASS
+
+- [ ] **Step 2: Gesamt-TypeScript-Check**
+
+Run: `cd brett && npx tsc --noEmit`
+Expected: PASS (keine neuen Fehler)
+
+- [ ] **Step 3: Lint / bekannte CI-Checks**
+
+Run: `cd /home/patrick/Bachelorprojekt && bash scripts/task-oracle.sh 'run all offline tests'`
+Expected: CI-relevante Offline-Tests grün
+
+- [ ] **Step 4: Abschluss-Commit und PR**
+
+```bash
+git add .
+git commit -m "chore(brett): pre-PR verification pass [T000469]"
+```
+
+Dann PR erstellen per `gh pr create`.
+
+---
+
+## Zusammenfassung der Dateien
+
+| Datei | Änderung |
+|-------|----------|
+| `brett/src/types/state.ts` | `note?: string` zu `Figure` |
+| `brett/src/types/messages.ts` | `figure_note_set` + `figure_note_changed` |
+| `brett/src/server/permissions.ts` | `MutationType` + `canMutate` |
+| `brett/src/server/figures.ts` | `applyMutation` Case |
+| `brett/src/server/ws-handler.ts` | Handler-Block |
+| `brett/public/index.html` | DOM + CSS für `#fig-note-textarea` |
+| `brett/src/client/ui/fig-panel.ts` | Panel-Sync + Input-Handler |
+| `brett/src/client/ws-client.ts` | `figure_note_changed` + snapshot + delete-cleanup |
+| `brett/src/client/state.ts` | `noteSprites` Map exportieren |
+| `brett/src/client/ui/hud.ts` | `setFigureNoteBillboard` + `clearFigureNoteBillboard` |
+| `brett/test/figure-note.test.ts` | Neue Test-Datei (erstellen) |
+| `brett/test/messages.test.ts` | Type-Union-Assert ergänzen |

--- a/docs/superpowers/specs/2026-06-07-brett-figure-notes-design.md
+++ b/docs/superpowers/specs/2026-06-07-brett-figure-notes-design.md
@@ -1,0 +1,177 @@
+---
+title: "Brett: Notizen & Statements pro Figur (Slice 5)"
+ticket_id: T000469
+domains: [website]
+status: active
+pr_number: null
+---
+
+# Design: Brett: Notizen & Statements pro Figur (Slice 5)
+
+**Ticket:** T000469
+**Branch (vorgesehen):** feature/brett-figure-notes
+
+---
+
+## Überblick
+
+### Feature-Beschreibung
+
+Das Systembrett dient als Werkzeug in Einzel- und Gruppencoachings, bei dem Figuren systemische Rollen repräsentieren. Bisher können Figuren lediglich durch Label, Farbe und Aussehen unterschieden werden — eine direkte Möglichkeit, Aussagen, Statements oder Notizen direkt an einer Figur zu verankern, fehlt.
+
+Slice 5 führt ein **figurbezogenes Notizfeld** ein: Klick auf eine Figur öffnet ein Side-Panel (`fig-panel.ts`), das den Namen der Figur anzeigt und ein editierbares Textfeld für Notizen/Statements bereitstellt ("Was spricht diese Figur? Was sieht sie?"). Die Notiz wird im Serverzustand persistiert (neues Feld `note?: string` im `Figure`-Interface), über die WS-Mutation `figure_note_set` synchronisiert und ist für alle Teilnehmer live sichtbar.
+
+Optional: Billboard-Anzeige einer gekürzten Notiz als 3D-Sprite über der Figur (analog zum Lock-Badge in `hud.ts`), gesteuert über einen Feature-Flag `sf-t000469`.
+
+### Coaching-Nutzen
+
+- **Systemische Arbeit:** Der Coach (oder repräsentierende Teilnehmer) kann die innere Perspektive einer Figur ("Von hier sehe ich...") direkt notieren.
+- **Nachverfolgbarkeit:** Notizen bleiben im Server-Zustand erhalten und überstehen Re-Joins, Reconnects und Browser-Refreshes.
+- **Co-Präsenz:** Alle Teilnehmer sehen Notizen in Echtzeit — keine Medienbrüche für Protokollierung.
+- **Billboard-Visualisierung:** Ein kurzer Auszug der Notiz erscheint als 3D-Text-Sprite über der Figur und macht den Zustand im Systemblick unmittelbar sichtbar.
+
+---
+
+## Architectural Decision
+
+### Option A: Notiz als Teil von `Figure.note` (gewählt)
+
+Notizen werden direkt in das bestehende `Figure`-Interface als optionales `note?: string`-Feld aufgenommen. Die Mutation `figure_note_set { figureId, note }` schreibt dieses Feld server-autoritativ via `applyMutation`. Die `buildStateFromMutations`-Pipeline exportiert `note` als Teil jedes Figure-Objekts — kein neuer Sentinel nötig.
+
+**Vorteile:**
+- Nutzt die vorhandene Persistence-Pipeline ohne neue DB-Felder oder Sentinels.
+- Notiz reist automatisch in jedem `snapshot` mit (als Teil des Figure-Arrays).
+- Passt in das bestehende `seedFigureMapFromState`-Muster (Figuren werden als Objekte re-hydriert, `note` ist ein einfaches String-Feld).
+- `update`-Mutation könnte prinzipiell Notizen mitführen — wir verwenden aber eine eigene Mutation für Granularität und Perms-Gating.
+
+**Nachteile:**
+- Notizen landen in jedem Snapshot-Frame (geringe Mehrbelastung bei großen Boards — vertretbar für max. 200 Figuren).
+
+### Option B: Separater `__notes__`-Sentinel (verworfen)
+
+Ein neuer Sentinel `Map<figureId, note>` analog zu `__roles__` würde Notizen vom Figure-Array trennen. Dieser Ansatz erzeugt unnötige Komplexität: zwei neue Felder in `buildStateFromMutations`, ein neues Seed-Case in `seedFigureMapFromState`, potentielle Inkonsistenz wenn Figuren gelöscht werden (orphane Notizen im Sentinel).
+
+### Permissions-Entscheidung
+
+`figure_note_set` wird als **nicht-RELAY, nicht-ADMIN**-Nachricht behandelt — analog zu `figure_possess`/`figure_release`. Es gibt eine eigene Handler-Logik im ws-handler:
+
+- **leiter:** immer erlaubt (jede Figur).
+- **stellvertreter:** nur wenn `figureOwnerId === playerId` (besitzt die Figur) — analog zur ownership-gated Move/Update-Logik.
+- **beobachter:** verweigert (read-only).
+- **Free-Board (kein Session-Code, keine Rollen):** REG-1-Bypass — erlaubt, genau wie alle anderen Mutationen.
+
+Hierfür wird `MutationType` um `'figure_note_set'` erweitert und `canMutate` entsprechend ergänzt.
+
+### Billboard-Feature-Flag
+
+Die 3D-Billboard-Anzeige der Notiz wird hinter `window.__brettFeatures['sf-t000469']` gated, genau wie `setCameraToOrbit` hinter `sf-t000465`. Der Flag defaultet OFF (dark-launch). Das Panel-UI ist IMMER aktiv (kein Flag), nur die 3D-Visualisierung ist hinter dem Flag.
+
+---
+
+## Data Model / Interface Changes
+
+### `brett/src/types/state.ts` — Figure Interface
+
+```typescript
+export interface Figure {
+  // ... existing fields ...
+  /**
+   * Freitext-Notiz zur Figur (Aussagen, Perspektiven, Statements).
+   * Gesetzt via figure_note_set (server-authoritative, via applyMutation).
+   * Persistiert als Teil des Figure-Objekts im figureMaps.
+   */
+  note?: string;
+}
+```
+
+### `brett/src/types/messages.ts` — Message Types
+
+**ClientMessage:**
+```typescript
+| { type: 'figure_note_set'; figureId: string; note: string }
+```
+
+**ServerMessage:**
+```typescript
+| { type: 'figure_note_changed'; figureId: string; note: string }
+```
+
+**MutationType** (permissions.ts):
+```typescript
+export type MutationType =
+  | 'add' | 'move' | 'update' | 'jump' | 'delete'
+  | 'clear' | 'stiffness' | 'snapshot' | 'request_state_snapshot'
+  | 'figure_lock' | 'figure_possess' | 'figure_release'
+  | 'figure_note_set';  // NEU
+```
+
+### Server `applyMutation` — neuer Case
+
+```typescript
+case 'figure_note_set': {
+  if (typeof msg.figureId === 'string' && figs.has(msg.figureId)) {
+    const note = typeof msg.note === 'string' ? msg.note.slice(0, 1000) : '';
+    figs.set(msg.figureId, { ...figs.get(msg.figureId), note });
+  }
+  break;
+}
+```
+
+Notiz wird auf 1000 Zeichen beschränkt (serverseitige Validierung), um Missbrauch und Bloat zu verhindern.
+
+### Kein neuer DB-Sentinel erforderlich
+
+`note` reist als Teil des Figure-Objekts in `buildStateFromMutations → figures[]`, wird mit `persistState` in `brett_rooms.state` (JSONB) gespeichert und durch `seedFigureMapFromState` beim nächsten Join wiederhergestellt — **null Änderungen an der DB-Schicht nötig**.
+
+---
+
+## Implementation Strategy
+
+### Server-Side (Meilenstein 1)
+
+1. **types/state.ts:** `note?: string` zu `Figure` hinzufügen.
+2. **types/messages.ts:** `figure_note_set` zu `ClientMessage` und `figure_note_changed` zu `ServerMessage` hinzufügen.
+3. **server/permissions.ts:** `'figure_note_set'` zu `MutationType` hinzufügen; `canMutate` um den neuen Typ erweitern (leiter: immer; stellvertreter: ownerId-gated; beobachter: false).
+4. **server/figures.ts:** `applyMutation`-Case für `figure_note_set` hinzufügen (note slicen auf 1000 chars).
+5. **server/ws-handler.ts:** Eigenen Handler-Block für `figure_note_set` (analog zum `figure_possess`-Block), inkl. `gateMutation`-Check, `applyMutation`, `broadcast(figure_note_changed)`, `schedulePersist`.
+
+### Client-Side Panel (Meilenstein 2)
+
+1. **client/ui/fig-panel.ts:** `syncPanelToSelection` erweitern — neues DOM-Element `#fig-note-textarea` befüllen. Neuen Input-Handler für `fig-note-textarea` → `sendClient({ type: 'figure_note_set', figureId, note })`.
+2. **public/index.html:** DOM-Elemente für das Notizfeld in `#fig-panel` einfügen (Label + `<textarea id="fig-note-textarea">`), CSS-Styles.
+3. **client/ws-client.ts:** `onWsMessage`-Switch um `figure_note_changed` erweitern — lokal `fig.note` aktualisieren, Panel-Textarea aktualisieren falls Figur gerade selektiert.
+
+### 3D Billboard (Meilenstein 3, Feature-Flag `sf-t000469`)
+
+1. **client/ui/hud.ts:** `noteSprites: Map<string, THREE.Sprite>` analog zu `lockSprites`. Funktion `setFigureNoteBillboard(figureId, note)`: Canvas 256×80, Notentext auf 40 Zeichen kürzen, Sprite über Figur. `clearFigureNoteBillboard(figureId)` für Cleanup.
+2. **client/state.ts:** `noteSprites` Map exportieren.
+3. **client/ws-client.ts:** Bei `figure_note_changed` und in der `snapshot`-Verarbeitung die Billboard-Funktionen aufrufen (Feature-Flag geprüft).
+4. **fig-panel.ts:** Bei Panel-Änderungen lokale Billboard-Aktualisierung anstoßen (optimistic update).
+
+### Tests (Meilenstein 4)
+
+1. **test/figure-note.test.ts:** Server-seitige Tests mit Node.js `node:test`:
+   - `applyMutation figure_note_set`: Notiz wird gesetzt, auf 1000 Zeichen gekürzt, fehlendes figureId no-op.
+   - `permissions figure_note_set`: leiter true; stellvertreter owned true / foreign false; beobachter false.
+   - `buildStateFromMutations`: note überlebt den figures-Array-Export.
+   - `seedFigureMapFromState`: note wird korrekt re-hydriert.
+   - WS-Handler-Integration (Mock-Setup): `figure_note_set` → `figure_note_changed`-Broadcast.
+2. **test/messages.test.ts:** Prüfen dass `figure_note_set` und `figure_note_changed` in den ClientMessageType/ServerMessageType-Unions enthalten sind.
+
+### Rollout-Reihenfolge
+
+1. Merge server-side (Typen + Perms + applyMutation + WS-Handler) — rückwärtskompatibel, da `note` optional ist.
+2. Merge client-side Panel-UI — Clients ohne Reload ignorieren `figure_note_changed` (Switch default).
+3. Billboard hinter Feature-Flag — Deploy separat, Flag in DB setzen wenn bereit.
+
+---
+
+## Edge Cases & Guards
+
+- **Länge:** Server kürzt auf 1000 Zeichen. Client-`maxlength="1000"` im `<textarea>`.
+- **Löschen einer Notiz:** `note: ''` (leerer String) ist gültig — setzt die Notiz zurück. Server speichert `''` als leeren String, Client-Panel zeigt leeres Textfeld.
+- **Figur gelöscht:** `applyMutation('delete')` entfernt die Figur aus `figureMaps` — die Notiz verschwindet automatisch. Das Billboard wird durch `clearFigureNoteBillboard` in der `delete`-Verarbeitung des Clients bereinigt.
+- **REG-1 Free-Board:** Ohne Session-Code und ohne Rollen gilt der Legacy-Bypass — jeder kann Notizen setzen. Dieses Verhalten ist konsistent mit allen anderen Mutationen.
+- **Rollback-Sicherheit:** `note?: string` ist optional im `Figure`-Interface — alte persistierte Zustände ohne `note`-Feld funktionieren unverändert (`note` ist dann `undefined`).
+- **Billboard-Text:** Kurze Vorschau: erste 40 Zeichen + `…` falls länger. Zeilenumbrüche im Billboard ignorieren (Canvas füllt erste Zeile).
+- **Encoding:** `msg.note.slice(0, 1000)` ist sicher für Unicode (JavaScript-String-Indices).


### PR DESCRIPTION
## Summary
- Adds per-figure notes (max 1000 chars) stored as `note` field on `Figure`
- Owner-gated: stellvertreter can only set notes on their own figures; leiter unrestricted
- Note panel in fig-panel UI with textarea; sends `figure_note_set` mutation
- Billboard sprite above figures when note is non-empty (feature-flag `sf-t000469`)
- Note persisted via server mutation log; snapshot-rehydrated on late join
- 12 new unit tests; 330/330 total passing

## Test plan
- [ ] CI green
- [ ] Billboard activates with `window.__brettFeatures['sf-t000469'] = true`

Closes T000469

🤖 Generated with [Claude Code](https://claude.com/claude-code)