### PR TITLE
chore(brett): multi-stage Vite build in Dockerfile + runtime fallback [T000498]

### DIFF
--- a/brett/Dockerfile
+++ b/brett/Dockerfile
@@ -1,9 +1,20 @@
+# Stage 1: build Vite client bundle
+FROM node:22-alpine AS builder
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+COPY src ./src
+COPY public ./public
+COPY vite.config.ts tsconfig.json tsconfig.client.json tsconfig.server.json ./
+RUN npm run build
+
+# Stage 2: runtime (tsx server + built client)
 FROM node:22-alpine
 WORKDIR /app
 COPY package.json package-lock.json ./
 RUN npm ci --omit=dev
 COPY src ./src
-COPY public ./public
+COPY --from=builder /app/dist/client ./dist/client
 USER node
 EXPOSE 3000
 CMD ["npm", "start"]

--- a/brett/src/server/index.ts
+++ b/brett/src/server/index.ts
@@ -48,7 +48,12 @@ app.use((req, res, next) => {
   next();
 });
 
-app.use(express.static(path.join(__dirname, '..', '..', 'public'), {
+// In production (after `vite build`), serve from dist/client; in dev, fall back to public/.
+const distClient = path.join(__dirname, '..', '..', 'dist', 'client');
+const staticDir = fs.existsSync(path.join(distClient, 'index.html'))
+  ? distClient
+  : path.join(__dirname, '..', '..', 'public');
+app.use(express.static(staticDir, {
   setHeaders: (res, filePath) => {
     if (filePath.endsWith('.html')) {
       res.setHeader('Cache-Control', 'no-cache');

--- a/brett/src/server/presets.ts
+++ b/brett/src/server/presets.ts
@@ -2,7 +2,9 @@ import fs from 'fs';
 import path from 'path';
 
 export const PRESETS_FILE = process.env.BRETT_PRESETS_PATH || path.join(__dirname, '..', '..', 'presets.json');
-export const SPEC_PATH = path.join(__dirname, '..', '..', 'public', 'assets', 'figure-pack', 'placement_spec.json');
+const SPEC_PATH_PUBLIC = path.join(__dirname, '..', '..', 'public', 'assets', 'figure-pack', 'placement_spec.json');
+const SPEC_PATH_DIST   = path.join(__dirname, '..', '..', 'dist', 'client', 'assets', 'figure-pack', 'placement_spec.json');
+export const SPEC_PATH = fs.existsSync(SPEC_PATH_PUBLIC) ? SPEC_PATH_PUBLIC : SPEC_PATH_DIST;
 
 export let SPEC: { faces: Record<string, any>; accessories: Record<string, any>; bodies: Record<string, any> } =
   { faces: {}, accessories: {}, bodies: {} };


### PR DESCRIPTION
## Summary

- **Dockerfile**: 2-stage build — Stage 1 runs `npm run build` (Vite), Stage 2 copies `dist/client` to runtime container (removing unbundled `public/` from the image)
- **index.ts**: static serving auto-detects `dist/client/index.html`; falls back to `public/` when not present (dev mode)
- **presets.ts**: `SPEC_PATH` resolves `placement_spec.json` from either `dist/client` or `public/` at startup

## Test plan

- [ ] Brett baut lokal mit `docker build .` (im brett/ Verzeichnis)
- [ ] Dev-Modus (ohne `npm run build`) fällt auf public/ zurück
- [ ] CI grün

Schließt T000498 (uncommitted Vite-Build-Changes in main Worktree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)