### PR TITLE
chore(factory): remove hardcoded haiku model overrides in dispatcher

### DIFF
--- a/scripts/factory/dispatcher.js
+++ b/scripts/factory/dispatcher.js
@@ -101,7 +101,7 @@ async function main() {
      If a guard read errors (non-zero with no documented meaning), fail-closed: skip that brand.
      If a ticket has no plan reference, set branch and plan_path to null.
      If nothing was claimed across both brands, return { "launch": [], "skipped": [...] }.`,
-    { label: 'prep', phase: 'Prep', schema: PLAN_SCHEMA, model: 'haiku' },
+    { label: 'prep', phase: 'Prep', schema: PLAN_SCHEMA },
   )
 
   log(
@@ -161,7 +161,7 @@ async function main() {
          bash ${REPO}/scripts/ticket.sh add-comment --id T000413 \\
            --body ${JSON.stringify('Factory dispatcher: ' + escalations.length + ' run(s) escalated this tick.')}
        Report what was notified and the ticket-comment output.`,
-      { label: 'escalate', phase: 'Launch', model: 'haiku' },
+      { label: 'escalate', phase: 'Launch' },
     )
   } else {
     log(`Dispatcher: all ${results?.length ?? 0} pipeline run(s) completed without error/block.`)


### PR DESCRIPTION
## Summary

- Removed explicit `model: 'haiku'` overrides from the `prep` and `escalate` agent calls in `dispatcher.js`
- Both agents now inherit the session model, consistent with subagent-provisioning guidelines

## Test plan

- [ ] CI offline gate passes (no factory logic changed, only model selection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)