### PR TITLE
fix(office): add failing guard test for single-brand Collabora deploy…

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1225,6 +1225,20 @@ tasks:
       - sh: kubectl cluster-info > /dev/null 2>&1
         msg: "No cluster running."
     cmds:
+      - |
+        if [ "{{.ENV}}" != "dev" ]; then
+          echo "❌ workspace:office:deploy is for DEV (k3d) only."
+          echo ""
+          echo "   The shared fleet office-stack serves BOTH brands from a single"
+          echo "   Collabora instance. A single-brand deploy overwrites the Ingress"
+          echo "   and drops the other brand's host (T000478)."
+          echo ""
+          echo "   For production fleet deploys, use:"
+          echo "     task fleet:shared-services"
+          echo ""
+          echo "   This deploys Collabora + CoTURN/Janus for both brands in one shot."
+          exit 1
+        fi
       - task: workspace:office:pull-secret
         vars: { ENV: "{{.ENV}}" }
       - |

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -263,12 +263,18 @@ tasks:
       - task: test:unit:quality-loop
       - task: test:unit:offline-batch
       - task: test:unit:collabora-wopi-discovery
+      - task: test:unit:collabora-wopi-single-brand-guard
       - task: test:unit:coverage-guard
 
   test:unit:collabora-wopi-discovery:
     internal: true
     cmds:
       - ./tests/unit/lib/bats-core/bin/bats tests/unit/collabora-wopi-discovery.bats
+
+  test:unit:collabora-wopi-single-brand-guard:
+    internal: true
+    cmds:
+      - ./tests/unit/lib/bats-core/bin/bats tests/unit/collabora-wopi-single-brand-guard.bats
 
   test:unit:website-ci-deploy:
     internal: true

--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 363,
+      "file_count": 364,
       "files": [
         "tests/.gitignore",
         "tests/e2e/brett-globals.d.ts",
@@ -304,6 +304,7 @@
         "tests/unit/brainstorm-extract-choice.bats",
         "tests/unit/coaching-json-ingest.bats",
         "tests/unit/collabora-wopi-discovery.bats",
+        "tests/unit/collabora-wopi-single-brand-guard.bats",
         "tests/unit/dev-build-safety.bats",
         "tests/unit/dev-cluster-autostart.bats",
         "tests/unit/dev-mcp-route.bats",

--- a/docs/superpowers/plans/2026-06-07-collabora-wopi-dual-brand.md
+++ b/docs/superpowers/plans/2026-06-07-collabora-wopi-dual-brand.md
@@ -1,0 +1,155 @@
+---
+title: Collabora WOPI Dual-Brand Guard (T000478) Implementation Plan
+ticket_id: T000478
+domains: [website, infra, ops, test, security]
+status: active
+pr_number: null
+---
+
+# Collabora WOPI Dual-Brand Guard (T000478) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Verhindern, dass Single-Brand-`workspace:office:deploy`-Aufrufe in Prod-Kontexten die andere Brand aus dem Ingress löschen. Der `server_name=""`-Fix ist bereits aktiv — das fehlende Stück ist der operative Guard.
+
+**Architecture:** Die geteilte Collabora-Instanz im `workspace-office` Namespace bedient beide Brands. Nur `fleet:shared-services` (Taskfile ~1844) deployed korrekt mit beiden Hosts (`COLLABORA_HOST` + `COLLABORA_HOST_2`). Ein Single-Brand-Deploy via `workspace:office:deploy` setzt `COLLABORA_HOST_2=""` und überschreibt den Ingress → die andere Brand verschwindet. Fix: `workspace:office:deploy` blockt nicht-dev ENVs mit klarer Fehlermeldung, die auf `fleet:shared-services` verweist.
+
+**Tech Stack:** BATS-Tests, Bash, Taskfile (go-task)
+
+**Ticket:** T000478
+
+---
+
+## Diagnose
+
+### Was bereits funktioniert
+
+1. **`COLLABORA_SERVER_NAME=""`** ist in allen Deploy-Pfaden gesetzt → coolwsd leitet WOPI-Discovery-Host vom Request-Header ab ✓
+2. **`fleet:shared-services`** setzt beide `COLLABORA_HOST` + `COLLABORA_HOST_2` → Ingress hat beide Hosts ✓
+3. **`fleet:shared-services`** patcht das Ingress für korczewski-TLS-Zertifikat ✓
+4. BATS-Tests (`collabora-wopi-discovery.bats`) validieren den leeren server_name ✓
+
+### Was noch fehlt
+
+**Single-Brand-Deploy ist destruktiv.** `workspace:office:deploy ENV=mentolder` deployed den Ingress NUR mit `office.mentolder.de` — `office.korczewski.de` wird aus der Konfiguration entfernt.
+
+Der Task wird aufgerufen von:
+- `workspace:office:deploy` (direkt, Zeile 1214)
+- `fleet:deploy:brand` (Zeile 1798) — ruft office:deploy NICHT auf, verweist auf shared-services
+
+### Betroffene Dateien
+
+| Datei | Änderung |
+|-------|----------|
+| `Taskfile.yml` | Guard in `workspace:office:deploy` einbauen |
+| `tests/unit/collabora-wopi-single-brand-guard.bats` | Test existiert bereits (ROT) |
+| `Taskfile.yml` | Test in `test:unit` verdrahten |
+
+---
+
+## Tasks
+
+### Task 1: Prod-Guard in `workspace:office:deploy` einbauen
+
+**Files:**
+- Modify: `Taskfile.yml` (workspace:office:deploy task, ~Zeile 1214)
+
+- [ ] **Step 1: Guard-Logik hinzufügen**
+
+Vor der Deploy-Logik (vor Schritt `workspace:office:pull-secret`) eine ENV-Prüfung einfügen:
+
+```yaml
+  workspace:office:deploy:
+    desc: "Deploy Collabora office-stack (DEV ONLY — use fleet:shared-services for prod)"
+    vars:
+      ENV: '{{.ENV | default "dev"}}'
+    cmds:
+      - |
+        source scripts/env-resolve.sh "{{.ENV}}"
+        if [ "{{.ENV}}" != "dev" ]; then
+          echo "❌ workspace:office:deploy is for DEV (k3d) only."
+          echo ""
+          echo "   The shared fleet office-stack serves BOTH brands. A single-brand"
+          echo "   deploy overwrites the Ingress and drops the other brand's host."
+          echo ""
+          echo "   For production fleet deploys, use:"
+          echo "     task fleet:shared-services"
+          echo ""
+          echo "   This deploys Collabora + CoTURN/Janus for both brands in one shot."
+          exit 1
+        fi
+      - task: workspace:office:pull-secret
+        vars: { ENV: "{{.ENV}}" }
+      # ... rest of existing deploy steps
+```
+
+- [ ] **Step 2: Test ausführen (jetzt GRÜN)**
+
+```bash
+./tests/unit/lib/bats-core/bin/bats tests/unit/collabora-wopi-single-brand-guard.bats
+```
+
+Erwartet: Alle 3 Tests PASS (Guard wird gefunden).
+
+### Task 2: BATS-Test in `test:unit` verdrahten
+
+**Files:**
+- Modify: `Taskfile.yml`
+
+- [ ] **Step 1: Task-Definition hinzufügen**
+
+```yaml
+  test:unit:collabora-wopi-single-brand-guard:
+    internal: true
+    cmds:
+      - ./tests/unit/lib/bats-core/bin/bats tests/unit/collabora-wopi-single-brand-guard.bats
+```
+
+- [ ] **Step 2: In `test:unit` aufrufen**
+
+Nach `test:unit:collabora-wopi-discovery` einfügen:
+```yaml
+      - task: test:unit:collabora-wopi-discovery
+      - task: test:unit:collabora-wopi-single-brand-guard
+```
+
+### Task 3: Finale Verifikation & Commit
+
+- [ ] **Step 1: Vollständige Test-Suite ausführen**
+
+```bash
+task test:all
+```
+
+Erwartet: Alle Tests PASS.
+
+- [ ] **Step 2: Committen**
+
+```bash
+git add Taskfile.yml tests/unit/collabora-wopi-single-brand-guard.bats docs/superpowers/plans/2026-06-07-collabora-wopi-dual-brand.md
+git commit -m "fix(office): guard single-brand office:deploy against prod use [T000478]
+
+workspace:office:deploy now refuses non-dev ENVs with a clear pointer to
+fleet:shared-services. Single-brand deploys overwrite the shared Ingress
+and drop the other brand's host — only fleet:shared-services sets both
+COLLABORA_HOST + COLLABORA_HOST_2.
+
+The server_name='' fix (dynamic WOPI discovery from Host header) is already
+in place; this guard closes the remaining operational gap."
+```
+
+---
+
+## Architektur-Entscheidung: Warum kein Split?
+
+**Option A (Split in zwei Instanzen)** wurde evaluiert, aber für jetzt zurückgestellt:
+
+| Kriterium | Split (A) | Guard (gewählt) |
+|-----------|-----------|-----------------|
+| Aufwand | Hoch: neues Namespace, zweites Deployment, zweiter Ingress, Secrets, NetworkPolicy | Gering: eine if-Abfrage |
+| Ressourcen | 2× RAM/CPU (512Mi-2Gi pro Instanz) | 1× (Status Quo) |
+| Wartung | Zwei Instanzen patchen/updaten | Eine Instanz |
+| Risiko | CAP_SYS_ADMIN × 2 Pods | Unverändert |
+| Dringlichkeit | Niedrig — Status Quo funktioniert mit fleet:shared-services | Hoch — Fußangel existiert |
+
+**Empfehlung:** Jetzt den Guard einbauen. Split in einem separaten Feature-Plan angehen, falls Ressourcen-Isolation oder unabhängiges Rollout pro Brand benötigt wird.

--- a/tests/unit/.coverage-allowlist
+++ b/tests/unit/.coverage-allowlist
@@ -43,3 +43,8 @@ fleet-dns-cutover
 # --- `task` binary (only curl is stubbed), so the structured-input cases exit non-zero
 # --- without a configured env. Needs a `task` stub before it can join the offline gate.
 task-oracle-fastpath
+#
+# --- Intentionally RED TDD guard (T000478): tests assert prod-safety guards and
+# --- dual-brand Ingress wiring that are not yet implemented. Excluded until
+# --- fleet:deploy:shared-services and workspace:office:deploy guards are in place.
+collabora-wopi-single-brand-guard

--- a/tests/unit/collabora-wopi-single-brand-guard.bats
+++ b/tests/unit/collabora-wopi-single-brand-guard.bats
@@ -39,7 +39,9 @@ setup() {
   # The workspace:office:deploy task MUST either:
   #   a) refuse to run on prod contexts, OR
   #   b) warn that fleet:deploy:shared-services should be used instead
-  run grep -A100 'workspace:office:deploy:' "$TASKFILE" | grep -iE 'fleet|prod|shared|ENV.*dev|only.*dev|block'
+  # Note: run cmd | pipe doesn't work in bats (run captures stdout internally);
+  # use run bash -c "pipeline" to capture the whole pipeline's exit code.
+  run bash -c "grep -A100 'workspace:office:deploy:' '$TASKFILE' | grep -iE 'fleet|prod|shared|ENV.*dev|only.*dev|block'"
   [ "$status" -eq 0 ] || {
     echo "FAIL: workspace:office:deploy has no prod guard." >&2
     echo "      On fleet, use fleet:deploy:shared-services instead." >&2

--- a/tests/unit/collabora-wopi-single-brand-guard.bats
+++ b/tests/unit/collabora-wopi-single-brand-guard.bats
@@ -1,0 +1,48 @@
+#!/usr/bin/env bats
+# Regression test for T000478.
+#
+# Collabora WOPI: One office-stack instance serves both brands on fleet.
+# The empty COLLABORA_SERVER_NAME fix (coolwsd derives server_name from
+# Host header) is already in place, BUT single-brand deploys
+# (workspace:office:deploy) overwrite the Ingress and DROP the other
+# brand's host — only fleet:deploy:shared-services sets both hosts.
+#
+# This test guards against regressions:
+#   A) single-brand deploy accidentally run on a prod env → must warn/block
+#   B) COLLABORA_SERVER_NAME stays empty in ALL deploy paths
+#   C) fleet:deploy:shared-services sets BOTH COLLABORA_HOST + COLLABORA_HOST_2
+#
+# RED until guards are in place; GREEN after.
+
+setup() {
+  REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+  TASKFILE="$REPO_ROOT/Taskfile.yml"
+}
+
+@test "T000478: fleet:shared-services sets COLLABORA_HOST_2 to a non-empty value" {
+  # The fleet deploy must set a second host so the Ingress serves both brands.
+  run bash -c "grep -A100 '^  fleet:shared-services:' $TASKFILE | grep 'COLLABORA_HOST_2='"
+  [ "$status" -eq 0 ]
+  # Must NOT be empty
+  [[ "$output" != *'COLLABORA_HOST_2=""'* ]] || false
+}
+
+@test "T000478: COLLABORA_SERVER_NAME stays empty in ALL deploy paths" {
+  total=$(grep -cE 'export[[:space:]]+COLLABORA_SERVER_NAME=' "$TASKFILE" || true)
+  empty=$(grep -cE 'export[[:space:]]+COLLABORA_SERVER_NAME=""' "$TASKFILE" || true)
+  [ "$total" -ge 1 ]
+  [ "$total" -eq "$empty" ]
+}
+
+@test "T000478: workspace:office:deploy has a prod-safety guard (blocks single-brand deploy on fleet)" {
+  # Single-brand deploys overwrite the Ingress and drop the other brand's host.
+  # The workspace:office:deploy task MUST either:
+  #   a) refuse to run on prod contexts, OR
+  #   b) warn that fleet:deploy:shared-services should be used instead
+  run grep -A100 'workspace:office:deploy:' "$TASKFILE" | grep -iE 'fleet|prod|shared|ENV.*dev|only.*dev|block'
+  [ "$status" -eq 0 ] || {
+    echo "FAIL: workspace:office:deploy has no prod guard." >&2
+    echo "      On fleet, use fleet:deploy:shared-services instead." >&2
+    false
+  }
+}


### PR DESCRIPTION
… [T000478]

Single-brand workspace:office:deploy overwrites the shared Ingress and drops the other brand's host. The server_name='' fix is already in place; this guard prevents accidental prod use and points to fleet:shared-services.

RED: tests/unit/collabora-wopi-single-brand-guard.bats test 3
FIX: add ENV guard to workspace:office:deploy blocking non-dev contexts

## Zusammenfassung

> **Hinweis:** Dieser PR ist nach dem Review sofort zu mergen (Squash-Merge) und nicht offen zu lassen.
> PRs dienen ausschliesslich der sauberen Git-History -- kein langwieriger Review-Prozess vorgesehen.

<!-- Beschreibe WAS sich geaendert hat und WARUM (nicht wie -- das zeigt der Diff). -->

## Art der Aenderung

- [ ] Feature (`feature/*` Branch)
- [ ] Bugfix (`fix/*` Branch)
- [ ] Refactoring / Wartung (`chore/*` Branch)
- [ ] Dokumentation
- [ ] Infrastruktur / K8s-Manifeste

## Checkliste

### Pflicht fuer alle PRs
- [ ] Branch folgt der Namenskonvention (`feature/`, `fix/`, `chore/`)
- [ ] Aenderungen betreffen nur ein Thema
- [ ] Keine Secrets oder Zugangsdaten committet (Dev-Secrets in `k3d/secrets.yaml` sind OK)

### Bei Aenderungen an Kubernetes-Manifesten (`k3d/`)
- [ ] `kubectl kustomize k3d/` funktioniert lokal
- [ ] Im lokalen k3d-Cluster deployt und verifiziert (`task workspace:deploy`)
- [ ] Resource Requests/Limits fuer neue Container gesetzt
- [ ] Health Probes fuer neue Services konfiguriert
- [ ] Keine hartkodierten Hostnamen -- `configMapKeyRef` aus `domain-config` verwenden

### Bei Aenderungen an Skripten (`scripts/`, `tests/`)
- [ ] `shellcheck` bestanden (Warnungen akzeptabel, Fehler nicht)
- [ ] In sauberer Umgebung getestet

### Bei Aenderungen an Authentifizierung (Keycloak / OIDC)
- [ ] `k3d/realm-workspace-dev.json` aktualisiert falls Clients geaendert
- [ ] SSO-Login fuer alle betroffenen Services getestet


**Anforderungs-ID:** <!-- z.B. FA-09, SA-08, NFA-08 -->

## Testplan



**Anforderungs-JSON Testfall:**
<!-- Testfall-Feld aus dem JSON-Eintrag einfuegen, damit Reviewer die Abdeckung pruefen koennen -->

**Implementierte Tests:**
- [ ] Test-Skript in `tests/local/` (Bash) oder `tests/e2e/specs/` (Playwright) hinzugefuegt/aktualisiert
- [ ] Jeder Testfall (T1, T2, ...) aus dem JSON `Testfall` wird durch eine Assertion abgedeckt
- [ ] Assertions verwenden die korrekte Anforderungs-ID und Test-ID: `assert_* ... "REQ-ID" "T1" "Beschreibung"`
- [ ] `./tests/runner.sh local <REQ-ID>` besteht

## Screenshots / Logs

<!-- Falls zutreffend, Ausgabe oder Screenshots einfuegen -->
