### PR TITLE
fix(brett): replay-mode guards — updateLinePositions, seq seed race, sinceSeq NaN [T000472]

### DIFF
--- a/brett/src/client/board-boot.ts
+++ b/brett/src/client/board-boot.ts
@@ -385,6 +385,11 @@ export async function bootBoard(): Promise<void> {
     }
   });
 
+  // T000471: Wire moderation change handler — update visuals on server push
+  // Declared before the async gap (maybeStartReplayMode) to prevent TDZ errors
+  // if a mousedown fires during the async fetch in replay mode.
+  let currentModerationState: ClientModerationState = { spotlight: null, dim: null, freeze: false };
+
   // ── WS connect + seed figure ───────────────────────────────────────
   // Replay mode (Slice 5, T000472) takes precedence over a live WS connection:
   // it reconstructs board state locally from recorded events and never connects.
@@ -392,9 +397,6 @@ export async function bootBoard(): Promise<void> {
   if (!isReplayMode) {
     wsClient.connectWS();
   }
-
-  // T000471: Wire moderation change handler — update visuals on server push
-  let currentModerationState: ClientModerationState = { spotlight: null, dim: null, freeze: false };
   wsClient.setModerationChangeHandler((state) => {
     currentModerationState = state;
     freezeBanner.style.display = state.freeze ? 'block' : 'none';
@@ -413,7 +415,7 @@ export async function bootBoard(): Promise<void> {
     const dt = Math.min(0.05, (now - lastTickMs) / 1000);
     lastTickMs = now;
     mannequin.tickSpring(dt);
-    updateLinePositions();
+    if (!isReplayMode) updateLinePositions();
     mannequin.updatePossessionVisuals(STATE.figures, currentUser.userId);
     // T000471: Moderation visuals (Spotlight/Dim/Freeze)
     mannequin.updateModerationVisuals(STATE.figures, currentModerationState);

--- a/brett/src/server/event-log.ts
+++ b/brett/src/server/event-log.ts
@@ -29,6 +29,17 @@ const seqCounters = new Map<string, number>();
 /** Rooms for which seq has been seeded from DB (prevents re-seeding). */
 const seqSeeded = new Set<string>();
 
+/**
+ * Events buffered while the DB seq seed is in flight.
+ * Held without a seq number until the seed resolves; then re-numbered
+ * starting from dbMax+1 and moved to eventBuffers. Prevents ON CONFLICT
+ * DO NOTHING silent data loss when the server restarts mid-session.
+ */
+const seedPendingBuffers = new Map<string, Array<Omit<RecordedEvent, 'id' | 'seq'>>>();
+
+/** Pending seed Promises per room — awaited by flushEventBuffer. */
+const seedPromises = new Map<string, Promise<void>>();
+
 /** Per-room flush timer handles. */
 const flushTimers = new Map<string, NodeJS.Timeout>();
 
@@ -50,19 +61,46 @@ export function appendEvent(
 ): void {
   if (!pool) return;
 
-  // Seed seq counter from DB on first use after restart (async, fire-and-forget).
-  // Events during seeding use an optimistic counter; seeding completes before
-  // the first flush (FLUSH_INTERVAL_MS = 2s >> typical seeding latency < 20ms).
+  // Seed seq counter from DB on first use after restart.
+  // Events arriving during seeding are held in seedPendingBuffers without a seq
+  // and re-numbered once the DB max is known — prevents ON CONFLICT DO NOTHING
+  // silent data loss when the server restarts mid-session.
   if (!seqSeeded.has(room)) {
-    seqSeeded.add(room);
-    pool.query('SELECT COALESCE(MAX(seq), 0) AS max_seq FROM session_events WHERE room_token = $1', [room])
-      .then(({ rows }) => {
-        const dbMax = Number(rows[0]?.max_seq ?? 0);
-        const current = seqCounters.get(room) ?? 0;
-        // Advance the counter if DB is ahead of our in-memory start position.
-        if (dbMax >= current) seqCounters.set(room, dbMax);
-      })
-      .catch(err => console.error('[brett/event-log] seq seed error:', err));
+    if (!seedPendingBuffers.has(room)) {
+      seedPendingBuffers.set(room, []);
+      const seedPromise = pool
+        .query('SELECT COALESCE(MAX(seq), 0) AS max_seq FROM session_events WHERE room_token = $1', [room])
+        .then(({ rows }) => {
+          const dbMax = Number(rows[0]?.max_seq ?? 0);
+          seqCounters.set(room, dbMax);
+          seqSeeded.add(room);
+          seedPromises.delete(room);
+          const pending = seedPendingBuffers.get(room) ?? [];
+          seedPendingBuffers.delete(room);
+          if (pending.length === 0) return;
+          let seq = dbMax;
+          let buf = eventBuffers.get(room);
+          if (!buf) { buf = []; eventBuffers.set(room, buf); }
+          for (const ev of pending) {
+            seq += 1;
+            buf.push({ ...ev, seq });
+          }
+          seqCounters.set(room, seq);
+          scheduleFlush(room);
+        })
+        .catch(err => {
+          seqSeeded.add(room);
+          seedPendingBuffers.delete(room);
+          seedPromises.delete(room);
+          console.error('[brett/event-log] seq seed error:', err);
+        });
+      seedPromises.set(room, seedPromise);
+    }
+    const pending = seedPendingBuffers.get(room);
+    if (pending) {
+      pending.push({ roomToken: room, sessionCode, eventType, payload, recordedAt: new Date().toISOString() });
+      return;
+    }
   }
 
   const seq = (seqCounters.get(room) ?? 0) + 1;
@@ -80,13 +118,15 @@ export function appendEvent(
     recordedAt: new Date().toISOString(),
   });
 
-  // Auto-flush when buffer exceeds max batch size
   if (buf.length >= MAX_BATCH_SIZE) {
     flushEventBuffer(room).catch(err => console.error('[brett/event-log] flush error:', err));
     return;
   }
 
-  // Schedule debounced flush
+  scheduleFlush(room);
+}
+
+function scheduleFlush(room: string): void {
   if (!flushTimers.has(room)) {
     flushTimers.set(room, setTimeout(() => {
       flushTimers.delete(room);
@@ -101,6 +141,11 @@ export function appendEvent(
  */
 export async function flushEventBuffer(room: string): Promise<void> {
   if (!pool) return;
+
+  // If the DB seq seed is still in flight, wait for it so pending events are
+  // moved to eventBuffers and re-numbered before we attempt the INSERT.
+  const seed = seedPromises.get(room);
+  if (seed) await seed;
 
   const timer = flushTimers.get(room);
   if (timer) { clearTimeout(timer); flushTimers.delete(room); }
@@ -185,9 +230,10 @@ export async function loadSessionMetas(room: string): Promise<Array<{
 
 /** Returns current buffer stats (used in tests). */
 export function getBufferStats(room: string): { buffered: number; nextSeq: number } {
+  const pendingCount = seedPendingBuffers.get(room)?.length ?? 0;
   return {
-    buffered: eventBuffers.get(room)?.length ?? 0,
-    nextSeq: (seqCounters.get(room) ?? 0) + 1,
+    buffered: (eventBuffers.get(room)?.length ?? 0) + pendingCount,
+    nextSeq: (seqCounters.get(room) ?? 0) + pendingCount + 1,
   };
 }
 
@@ -198,6 +244,8 @@ export function resetEventLog(): void {
   seqCounters.clear();
   seqSeeded.clear();
   flushTimers.clear();
+  seedPendingBuffers.clear();
+  seedPromises.clear();
 }
 
 /** Flush all rooms with buffered events (call during graceful shutdown). */

--- a/brett/src/server/index.ts
+++ b/brett/src/server/index.ts
@@ -244,8 +244,10 @@ app.get('/api/snapshots/:id', asyncHandler(async (req: any, res: any) => {
 /** GET /api/sessions/:room/events — liefert alle Events einer Session (admin only). */
 app.get('/api/sessions/:room/events', auth.requireAdmin, asyncHandler(async (req: any, res: any) => {
   const { room } = req.params;
-  const sinceSeq = req.query.sinceSeq ? parseInt(req.query.sinceSeq as string, 10) : undefined;
-  const limit = req.query.limit ? Math.min(parseInt(req.query.limit as string, 10), 10_000) : undefined;
+  const sinceSeqRaw = parseInt(req.query.sinceSeq as string, 10);
+  const sinceSeq = req.query.sinceSeq && !isNaN(sinceSeqRaw) ? sinceSeqRaw : undefined;
+  const limitRaw = parseInt(req.query.limit as string, 10);
+  const limit = req.query.limit && !isNaN(limitRaw) ? Math.min(limitRaw, 10_000) : undefined;
   const events = await eventLog.loadEvents(room, { sinceSeq, limit });
   res.json({ events });
 }));


### PR DESCRIPTION
## Summary

Post-merge bugfixes für Brett Timeline/Replay (T000472, PR #1425):

- **`updateLinePositions()` crash im Replay-Mode** — Tick-Loop rief es ohne Guard auf; STATE.figures enthält in Replay plain JSON ohne `.root` → TypeError. Fix: `if (!isReplayMode) updateLinePositions()`
- **`currentModerationState` TDZ-Risiko** — Deklaration nach `await maybeStartReplayMode()`, aber Referenz in vor dem await registriertem mousedown-Handler → potenzielle ReferenceError. Fix: Deklaration vor den async-Gap verschoben.
- **Seq-Counter-Race beim Neustart** — fire-and-forget DB-Seed; Events mit seq 1,2,3 im Buffer bevor seed abgeschlossen → ON CONFLICT DO NOTHING verschluckt sie. Fix: Pending-Buffer hält Events bis Seed fertig, danach re-numbering ab dbMax+1.
- **`sinceSeq` NaN** — parseInt(\'abc\') → NaN → SQL-Parameter → 0 Zeilen, kein Fehler. Fix: isNaN-Guard.

## Test plan

- [ ] `cd brett && npm test` → 442/442 grün
- [ ] `cd brett && npx tsc --noEmit` → PASS
- [ ] `task test:all` → nur pre-existenter FA-SF-41-Fehler

🤖 Generated with [Claude Code](https://claude.com/claude-code)