### PR TITLE
chore(mcp): add Task Master + OpenSpec MCP servers (local Ollama)

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,15 @@
+{
+  "mcpServers": {
+    "task-master-ai": {
+      "command": "npx",
+      "args": ["-y", "task-master-ai"],
+      "env": {
+        "OLLAMA_BASE_URL": "http://localhost:11434/api"
+      }
+    },
+    "openspec": {
+      "command": "npx",
+      "args": ["-y", "openspec-mcp"]
+    }
+  }
+}

--- a/.taskmaster/config.json
+++ b/.taskmaster/config.json
@@ -1,0 +1,31 @@
+{
+  "models": {
+    "main": {
+      "provider": "ollama",
+      "modelId": "qwen2.5-coder:32b-instruct-q3_K_M",
+      "maxTokens": 32000,
+      "temperature": 0.2
+    },
+    "research": {
+      "provider": "ollama",
+      "modelId": "qwen2.5-coder:32b-instruct-q3_K_M",
+      "maxTokens": 32000,
+      "temperature": 0.1
+    },
+    "fallback": {
+      "provider": "ollama",
+      "modelId": "qwen2.5-coder:32b-instruct-q3_K_M",
+      "maxTokens": 32000,
+      "temperature": 0.2
+    }
+  },
+  "global": {
+    "logLevel": "info",
+    "debug": false,
+    "defaultSubtasks": 5,
+    "defaultPriority": "medium",
+    "defaultTag": "master",
+    "projectName": "Bachelorprojekt",
+    "ollamaBaseURL": "http://localhost:11434/api"
+  }
+}

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,0 +1,20 @@
+schema: spec-driven
+
+# Project context (optional)
+# This is shown to AI when creating artifacts.
+# Add your tech stack, conventions, style guides, domain knowledge, etc.
+# Example:
+#   context: |
+#     Tech stack: TypeScript, React, Node.js
+#     We use conventional commits
+#     Domain: e-commerce platform
+
+# Per-artifact rules (optional)
+# Add custom rules for specific artifacts.
+# Example:
+#   rules:
+#     proposal:
+#       - Keep proposals under 500 words
+#       - Always include a "Non-goals" section
+#     tasks:
+#       - Break tasks into chunks of max 2 hours


### PR DESCRIPTION
## Was

Registriert zwei project-scoped MCP-Server und legt das Scaffolding an.

| Server | Command | Provider / Daten |
|--------|---------|------------------|
| `task-master-ai` | `npx -y task-master-ai` | lokales Ollama (`qwen2.5-coder:32b-instruct-q3_K_M`), keine Cloud-Keys |
| `openspec` | `npx -y openspec-mcp` | wrappt `@fission-ai/openspec`, liest `openspec/` |

## Dateien

- `.mcp.json` — beide Server. **Force-added** trotz `.gitignore:15`, damit die Config im Repo geteilt wird (so vom Maintainer gewünscht).
- `.taskmaster/config.json` — Ollama-Modellkonfiguration (main/research/fallback alle auf das lokal verfügbare Modell).
- `openspec/config.yaml` — minimales Scaffold via `openspec init --tools none` (keine Slash-Command-Dateien → kein Konflikt mit dem bestehenden dev-flow-Workflow).

## Hinweise / Risiken

- **Supply-Chain:** `openspec-mcp` ist ein Single-Maintainer-Drittanbieter-Paket (v0.4.2). `npx -y openspec-mcp` führt bei jedem Start fremden Code aus und ist nun in der committeten Config eines öffentlichen Repos.
- Beide Server sind project-scoped → erfordern beim Klonen eine einmalige Approval-Bestätigung in Claude Code, bevor `npx` läuft.
- Keine Secrets in der Config (Ollama keyless; OpenSpec keyless).

🤖 Generated with [Claude Code](https://claude.com/claude-code)