### PR TITLE
fix(factory): unset reasoning_effort so DeepSeek-backed autopilot works [T000519]

### DIFF
--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 367,
+      "file_count": 368,
       "files": [
         "tests/.gitignore",
         "tests/e2e/brett-globals.d.ts",
@@ -252,6 +252,7 @@
         "tests/local/FA-SF-44-verify-diff-killswitch.bats",
         "tests/local/FA-SF-45-conflict-gate-deadlock.bats",
         "tests/local/FA-SF-46-cleanup.bats",
+        "tests/local/FA-SF-47-wakeup-reasoning-effort.bats",
         "tests/local/NFA-01.sh",
         "tests/local/NFA-02.sh",
         "tests/local/NFA-03.sh",

--- a/scripts/factory/wakeup.sh
+++ b/scripts/factory/wakeup.sh
@@ -53,10 +53,14 @@ if [[ -f "${CRYPT_PROBE}" ]] && head -c 16 "${CRYPT_PROBE}" 2>/dev/null | grep -
   fi
 fi
 
-# ── ensure Extended Thinking is OFF so Workflow harness can spawn subagents ───
-# [1m] suffix or CLAUDE_CODE_EFFORT_LEVEL=max activates reasoning_effort; the
-# harness then sets thinking.type:disabled for agent() spawns → 400 API error.
-CLAUDE_CODE_EFFORT_LEVEL=low
+# ── reasoning_effort MUST stay UNSET so the Workflow harness can spawn subagents ─
+# The harness forces thinking.type=disabled for nested agent() spawns. If
+# reasoning_effort is ALSO set (any level), the Anthropic-compatible endpoint
+# (e.g. DeepSeek) rejects the request with:
+#   400 thinking options type cannot be disabled when reasoning_effort is set
+# → the dispatcher PREP step crashes. Setting it to "low" does NOT help — it must
+# be UNSET entirely. autopilot.env may export it, so neutralize it here. [T000519]
+unset CLAUDE_CODE_EFFORT_LEVEL
 # Strip [1m] from model env vars if present (belt-and-suspenders).
 # Use :- default to avoid nounset errors in CI where autopilot.env is absent.
 ANTHROPIC_MODEL="${ANTHROPIC_MODEL:-}"; ANTHROPIC_MODEL="${ANTHROPIC_MODEL/\[1m\]/}"
@@ -72,6 +76,5 @@ The dispatcher reads all guards (kill-switch, daily-cap, dry-run-first) fresh pe
 Report only the dispatcher's final JSON result. Do not improvise scheduling."
 
 exec "${CLAUDE_BIN:-claude}" -p "${PROMPT}" \
-  --effort low \
   --allowedTools "Workflow,Bash(bash scripts/factory/*),Bash(bash scripts/ticket.sh*),ToolSearch,PushNotification" \
   --permission-mode acceptEdits

--- a/tests/local/FA-SF-47-wakeup-reasoning-effort.bats
+++ b/tests/local/FA-SF-47-wakeup-reasoning-effort.bats
@@ -1,0 +1,33 @@
+#!/usr/bin/env bats
+# FA-SF-47: wakeup.sh must NOT set reasoning_effort. [T000519]
+# The Workflow harness forces thinking.type=disabled for nested agent() spawns.
+# If reasoning_effort is ALSO set (via --effort or CLAUDE_CODE_EFFORT_LEVEL=<level>),
+# the Anthropic-compatible endpoint (e.g. DeepSeek) returns:
+#   400 thinking options type cannot be disabled when reasoning_effort is set
+# which crashes the dispatcher PREP step. The fix is to leave reasoning_effort UNSET
+# (not "low"). These cases are pure static greps — offline/CI-safe.
+SCRIPT="scripts/factory/wakeup.sh"
+
+@test "FA-SF-47: wakeup.sh exists and is valid bash" {
+  [ -f "$SCRIPT" ]
+  run bash -n "$SCRIPT"
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-47: claude is NOT invoked with --effort" {
+  run grep -Eq -- '--effort' "$SCRIPT"
+  [ "$status" -ne 0 ]
+}
+
+@test "FA-SF-47: CLAUDE_CODE_EFFORT_LEVEL is never assigned a non-empty level" {
+  # Allowed: `unset CLAUDE_CODE_EFFORT_LEVEL` or `CLAUDE_CODE_EFFORT_LEVEL=` (empty).
+  # Forbidden: `CLAUDE_CODE_EFFORT_LEVEL=low|medium|high|max|...`.
+  run grep -Eq 'CLAUDE_CODE_EFFORT_LEVEL=[A-Za-z]' "$SCRIPT"
+  [ "$status" -ne 0 ]
+}
+
+@test "FA-SF-47: wakeup.sh actively neutralizes any inherited effort level" {
+  # autopilot.env may set CLAUDE_CODE_EFFORT_LEVEL; wakeup.sh must unset it.
+  run grep -Eq 'unset[[:space:]]+CLAUDE_CODE_EFFORT_LEVEL' "$SCRIPT"
+  [ "$status" -eq 0 ]
+}

--- a/website/src/data/test-inventory.json
+++ b/website/src/data/test-inventory.json
@@ -1092,6 +1092,12 @@
     "kind": "shell"
   },
   {
+    "id": "FA-SF-47",
+    "file": "tests/local/FA-SF-47-wakeup-reasoning-effort.bats",
+    "category": "FA",
+    "kind": "shell"
+  },
+  {
     "id": "NFA-01",
     "file": "tests/local/NFA-01.sh",
     "category": "NFA",


### PR DESCRIPTION
## Problem
The Software Factory autopilot (`wakeup.sh` → headless `claude -p` → Workflow → `dispatcher.js`) crashed every tick on the DeepSeek-backed config:

```
API Error: 400 thinking options type cannot be disabled when reasoning_effort is set
```

The PREP agent returned `null`, so `prep.launch` threw a `TypeError` and **no brands were processed**.

## Root cause
The Workflow harness forces `thinking.type=disabled` for nested `agent()` spawns. PR #1406 tried to fix the original conflict by setting `--effort low` — but that **still sets `reasoning_effort`**. The Anthropic-compatible endpoint (DeepSeek's `/anthropic`) rejects the combination. Effort must be **UNSET**, not "low".

## Fix
- `wakeup.sh`: `unset CLAUDE_CODE_EFFORT_LEVEL` (autopilot.env may export it) and drop `--effort low` from the `claude -p` exec.
- Corrected the misleading comment block.
- New regression guard **FA-SF-47** asserts wakeup.sh never sets `reasoning_effort`.

## Verification
- `FA-SF-47` green (4/4).
- **Live**: a real `dispatcher.js` dry-run with effort unset completes clean on DeepSeek (`{"launch":[],"skipped":[]}`, no 400) — vs. the 04:18 tick which 400'd.

## Notes
- Pre-existing flake: `FA-SF-41-wakeup.bats` behavioral test #7 shares the global `/tmp/factory-tick.lock` with the live systemd timer and flakes locally under contention (passes in clean CI). Not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)