### PR TITLE
chore(nextcloud): persist htaccess.RewriteBase=/ for pretty URLs

### DIFF
--- a/k3d/nextcloud-extra-config.php
+++ b/k3d/nextcloud-extra-config.php
@@ -9,6 +9,12 @@ $CONFIG = [
     ],
     'forwarded_for_headers' => ['HTTP_X_FORWARDED_FOR'],
 
+    // Pretty URLs — route bare app paths (e.g. /apps/spreed/ for Talk) through
+    // index.php so they don't 403 against the physical app directory. The image
+    // entrypoint regenerates .htaccess via `occ maintenance:update:htaccess` on
+    // init, picking up this value, so the rewrite survives a pod rebuild.
+    'htaccess.RewriteBase' => '/',
+
     // Memcache
     'memcache.local'       => '\\OC\\Memcache\\APCu',
     'memcache.distributed' => '\\OC\\Memcache\\Redis',

--- a/prod-korczewski/nextcloud-extra-config-korczewski.php
+++ b/prod-korczewski/nextcloud-extra-config-korczewski.php
@@ -9,6 +9,12 @@ $CONFIG = [
     ],
     'forwarded_for_headers' => ['HTTP_X_FORWARDED_FOR'],
 
+    // Pretty URLs — route bare app paths (e.g. /apps/spreed/ for Talk) through
+    // index.php so they don't 403 against the physical app directory. The image
+    // entrypoint regenerates .htaccess via `occ maintenance:update:htaccess` on
+    // init, picking up this value, so the rewrite survives a pod rebuild.
+    'htaccess.RewriteBase' => '/',
+
     // Memcache
     'memcache.local'       => '\\OC\\Memcache\\APCu',
     'memcache.distributed' => '\\OC\\Memcache\\Redis',


### PR DESCRIPTION
## Was & Warum

`https://files.mentolder.de/apps/spreed/` (Talk) lieferte **403 Forbidden** von Apache. Ursache: Nextclouds `.htaccess`-Rewrite überspringt existierende Verzeichnisse (`RewriteCond %{REQUEST_FILENAME} !-d`), und `apps/spreed` ist ein echtes Verzeichnis im Docroot → Apache serviert es direkt → 403 (`Options -Indexes`). Kein Defekt, aber unschöne UX.

Setzen von `htaccess.RewriteBase => '/'` aktiviert „pretty URLs": Der Image-Entrypoint regeneriert beim Init die `.htaccess` via `occ maintenance:update:htaccess` und nimmt diesen Wert auf → die kurze URL routet durch `index.php` (302 → Login/Talk) statt 403.

## Scope

- `k3d/nextcloud-extra-config.php` — Basis (mentolder, ns `workspace`)
- `prod-korczewski/nextcloud-extra-config-korczewski.php` — korczewski-Override (ns `workspace-korczewski`)

Beide ConfigMaps betten den Wert nach `kubectl kustomize` ein (verifiziert). Persistiert über Pod-Rebuilds, da read-only gemountet und vom Entrypoint vor `update:htaccess` gelesen.

## Verifikation (live, mentolder)

| URL (im Pod) | vorher | nachher |
|---|---|---|
| `/apps/spreed/` | 403 | 303 |
| extern `https://files.mentolder.de/apps/spreed/` | 403 | 302 → `/login?redirect_url=/apps/spreed/` |

Live auf mentolder bereits gesetzt + `update:htaccess` gelaufen. korczewski wird nach Merge live nachgezogen.

## Hinweis
Lokaler Volllauf von `task test:all` zeigt einen **vorbestehenden, unabhängigen** Fehlschlag `FA-SF-41` (wakeup.sh, Software Factory) — reproduziert identisch auf pristinem `main`, von dieser Änderung nicht berührt. Wahrscheinlich WSL-lokal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)