### PR TITLE
fix(factory): make FA-SF-41 hermetic — isolate wakeup.sh lock + env file [T000523]

### DIFF
--- a/docs/superpowers/plans/2026-06-08-factory-tick-lock-hermetic.md
+++ b/docs/superpowers/plans/2026-06-08-factory-tick-lock-hermetic.md
@@ -1,0 +1,53 @@
+---
+ticket_id: T000523
+status: in-progress
+domains: [test, infra]
+---
+
+# Fix: FA-SF-41 non-hermetic — isolate wakeup.sh single-flight lock + env file
+
+**Ticket:** T000523 · **Branch:** `fix/factory-tick-lock-hermetic`
+
+## Problem
+
+`tests/local/FA-SF-41-wakeup.bats` (behavioral "forwards -p/--allowedTools/…")
+false-reds **locally** while green in **CI**. Two non-hermetic couplings to host
+state, both surfaced while writing the regression test:
+
+1. **Shared single-flight lock.** `scripts/factory/wakeup.sh` flock's the
+   hardcoded `/tmp/factory-tick.lock`. When the live autopilot tick holds it,
+   wakeup.sh skips early → the stub `claude` is never exec'd → argv assertions fail.
+2. **Prod env-file clobber.** wakeup.sh sources `~/.config/factory/autopilot.env`
+   with `set -a`, which **overrides** test-provided env (notably
+   `FACTORY_CLAUDE_BIN`) → the real claude is exec'd instead of the stub.
+
+CI has neither a held lock nor the env file, so it stays green — masking the bug.
+
+## Fix (TDD, red→green)
+
+- **Test first (RED):** make the behavioral test hermetic and add a dedicated
+  guard that holds an *isolated* override lock and asserts wakeup.sh skips on IT
+  (not the shared `/tmp` lock). Update the structural test to assert the
+  overridable default. Confirmed red before the script change.
+- **Script (GREEN):** two new optional knobs in `wakeup.sh`, defaults unchanged
+  so production behavior is identical:
+  - `FACTORY_TICK_LOCK` → `LOCKFILE` (default `/tmp/factory-tick.lock`)
+  - `FACTORY_ENV_FILE`  → sourced prod config (default `~/.config/factory/autopilot.env`)
+  - skip message now interpolates `${LOCKFILE}`.
+- Tests pass `FACTORY_TICK_LOCK`/`FACTORY_ENV_FILE` at isolated tmp paths.
+
+## Verification
+
+- `FA-SF-41` deterministically green: 10/10 runs, 0 not-ok, with the live
+  autopilot still ticking.
+- `task test:factory`: 194 green, exit 0.
+- `bash -n scripts/factory/wakeup.sh` clean.
+- No other repo references to the hardcoded lock/env paths.
+
+(JS suites `test:docs-gen`/`test:agent-guide` fail in the *worktree* only —
+missing node_modules — unrelated to this bash-scoped change; green in CI.)
+
+## Files
+
+- `scripts/factory/wakeup.sh`
+- `tests/local/FA-SF-41-wakeup.bats`

--- a/scripts/factory/wakeup.sh
+++ b/scripts/factory/wakeup.sh
@@ -18,25 +18,31 @@
 #     FACTORY_DRY_RUN         true|false           (default: true — fail-safe: never auto-merge unless opted in)
 #     FACTORY_GITCRYPT_KEY    path to bp-secrets.key for `task secrets:unlock`
 #     FACTORY_CLAUDE_BIN      claude binary        (default: claude on PATH)
+#     FACTORY_TICK_LOCK       single-flight lock   (default: /tmp/factory-tick.lock)
+#     FACTORY_ENV_FILE        prod config to source(default: ~/.config/factory/autopilot.env)
 set -euo pipefail
 
-if [[ -f "${HOME}/.config/factory/autopilot.env" ]]; then
+# Production config (real claude bin, DeepSeek creds, dry_run policy). Sourced
+# with set -a so it exports everything — which means it CLOBBERS pre-set env.
+# Tests point FACTORY_ENV_FILE at a non-existent path for full env isolation. [T000523]
+FACTORY_ENV_FILE="${FACTORY_ENV_FILE:-${HOME}/.config/factory/autopilot.env}"
+if [[ -f "${FACTORY_ENV_FILE}" ]]; then
   set -a
-  source "${HOME}/.config/factory/autopilot.env"
+  source "${FACTORY_ENV_FILE}"
   set +a
 fi
 
 REPO="${FACTORY_REPO:-/home/patrick/Bachelorprojekt}"
 DRY_RUN="${FACTORY_DRY_RUN:-true}"
 CLAUDE_BIN="${FACTORY_CLAUDE_BIN:-claude}"
-LOCKFILE="/tmp/factory-tick.lock"
+LOCKFILE="${FACTORY_TICK_LOCK:-/tmp/factory-tick.lock}"
 
 cd "${REPO}"
 
 # ── single-flight: acquire the tick lock non-blocking; bail if a tick is live ──
 exec 9>"${LOCKFILE}"
 if ! flock -n 9; then
-  echo "wakeup.sh: a factory tick is already running (flock /tmp/factory-tick.lock held) — skipping" >&2
+  echo "wakeup.sh: a factory tick is already running (flock ${LOCKFILE} held) — skipping" >&2
   exit 0
 fi
 

--- a/tests/local/FA-SF-41-wakeup.bats
+++ b/tests/local/FA-SF-41-wakeup.bats
@@ -20,8 +20,12 @@ setup() { load 'test_helper.bash'; }
   [ "$status" -eq 0 ]
 }
 
-@test "FA-SF-41: wakeup.sh single-flights via flock on /tmp/factory-tick.lock" {
-  run grep -E 'flock[^#]*/tmp/factory-tick\.lock' "$WAKEUP"
+@test "FA-SF-41: wakeup.sh single-flights via flock, default lock /tmp/factory-tick.lock, overridable" {
+  # Default preserved, but the path is sourced from FACTORY_TICK_LOCK so tests
+  # (and parallel hosts) can isolate the single-flight lock. [T000523]
+  run grep -E 'FACTORY_TICK_LOCK:-/tmp/factory-tick\.lock' "$WAKEUP"
+  [ "$status" -eq 0 ]
+  run grep -F 'flock -n 9' "$WAKEUP"
   [ "$status" -eq 0 ]
 }
 
@@ -54,14 +58,42 @@ setup() { load 'test_helper.bash'; }
 printf '%s\n' "\$@" > "${argfile}"
 STUB
   chmod +x "${tmp}/claude-stub"
+  # Isolate the single-flight lock (so a real autopilot tick holding the shared
+  # /tmp/factory-tick.lock can't false-red this) AND the env file (so a present
+  # ~/.config/factory/autopilot.env can't clobber FACTORY_CLAUDE_BIN). [T000523]
   FACTORY_REPO="${tmp}" FACTORY_CLAUDE_BIN="${tmp}/claude-stub" FACTORY_DRY_RUN=true \
-    run bash "$WAKEUP"
+    FACTORY_TICK_LOCK="${tmp}/tick.lock" FACTORY_ENV_FILE="${tmp}/no-env" run bash "$WAKEUP"
   [ "$status" -eq 0 ]
   run grep -q -- '-p' "${argfile}";              [ "$status" -eq 0 ]
   run grep -q -- '--allowedTools' "${argfile}";  [ "$status" -eq 0 ]
   run grep -qF 'Workflow' "${argfile}";          [ "$status" -eq 0 ]
   run grep -q -- '--permission-mode' "${argfile}"; [ "$status" -eq 0 ]
   run grep -qF 'acceptEdits' "${argfile}";       [ "$status" -eq 0 ]
+  rm -rf "${tmp}"
+}
+
+@test "FA-SF-41: wakeup.sh single-flight honors FACTORY_TICK_LOCK (hermetic, not the shared /tmp lock)" {
+  # Regression guard for the non-hermetic flock path [T000523]: hold an ISOLATED
+  # override lock and prove the wrapper skips on IT (not the shared /tmp lock).
+  # Pre-fix the wrapper ignored the override and flock'd /tmp/factory-tick.lock,
+  # so on a free host it would RUN and exec the stub → this test fails. Post-fix
+  # it skips cleanly without ever touching the stub.
+  tmp="$(mktemp -d)"
+  argfile="${tmp}/argv"
+  cat > "${tmp}/claude-stub" <<STUB
+#!/usr/bin/env bash
+printf '%s\n' "\$@" > "${argfile}"
+STUB
+  chmod +x "${tmp}/claude-stub"
+  lock="${tmp}/tick.lock"
+  exec 8>"${lock}"
+  flock -n 8   # hold the override lock for the duration of the run
+  FACTORY_REPO="${tmp}" FACTORY_CLAUDE_BIN="${tmp}/claude-stub" FACTORY_DRY_RUN=true \
+    FACTORY_TICK_LOCK="${lock}" FACTORY_ENV_FILE="${tmp}/no-env" run bash "$WAKEUP"
+  exec 8>&-
+  [ "$status" -eq 0 ]              # skip is a clean exit 0
+  [ ! -f "${argfile}" ]           # stub was NOT exec'd → single-flight honored the override
+  echo "$output" | grep -qF "${lock}"   # skip message names the override lock
   rm -rf "${tmp}"
 }
 


### PR DESCRIPTION
Behebt **T000523**.

## Problem
`tests/local/FA-SF-41-wakeup.bats` (behavioral "forwards -p/--allowedTools/--permission-mode") **false-red lokal, grün in CI** — zwei nicht-hermetische Kopplungen an Host-State:

1. **Geteilter Single-Flight-Lock.** `wakeup.sh` flockt den hartkodierten `/tmp/factory-tick.lock`. Hält ein laufender Autopilot-Tick ihn, überspringt der Wrapper früh → Stub-`claude` nie exec't → argv-Assertions rot.
2. **Prod-env-File-Clobber.** `wakeup.sh` sourct `~/.config/factory/autopilot.env` mit `set -a` → überschreibt vom Test gesetztes `FACTORY_CLAUDE_BIN` mit dem echten claude.

CI hat weder gehaltenen Lock noch die env-Datei → grün, Bug maskiert.

## Fix (TDD rot→grün)
Zwei optionale Knobs in `wakeup.sh`, **Defaults unverändert → Prod-Verhalten identisch**:
- `FACTORY_TICK_LOCK` → Lock-Pfad (Default `/tmp/factory-tick.lock`)
- `FACTORY_ENV_FILE` → gesourcte Prod-Config (Default `~/.config/factory/autopilot.env`)

Tests zeigen beide auf isolierte tmp-Pfade; neuer Wächter hält einen isolierten Lock und beweist, dass der Wrapper den Override respektiert (skippt auf IHM, nicht dem geteilten Lock). Strukturtest auf überschreibbaren Default angepasst.

## Verifikation
- `FA-SF-41` deterministisch grün: **10/10 Läufe, 0 not-ok** (während Live-Autopilot weiter tickt)
- `task test:factory`: **194 grün**, exit 0
- `bash -n` clean; keine weiteren Referenzen auf die Altpfade

(JS-Suites `test:docs-gen`/`test:agent-guide` scheitern nur im Worktree an fehlenden node_modules — unabhängig von dieser bash-Änderung, in CI grün.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)