### PR TITLE
fix(factory): don't count terminal tickets' leaked pipeline_slot (Leitstand 8/3) [T000525]

### DIFF
--- a/scripts/ticket.sh
+++ b/scripts/ticket.sh
@@ -121,6 +121,8 @@ UPDATE tickets.tickets SET
   status = :'status',
   resolution = NULLIF(:'res', ''),
   done_at = CASE WHEN :'status' = 'done' THEN now() ELSE done_at END,
+  -- Release the pipeline slot on a terminal transition so the ledger never leaks (T000525).
+  pipeline_slot = CASE WHEN :'status' IN ('done','archived') THEN NULL ELSE pipeline_slot END,
   notes = CASE WHEN :'notes' <> '' THEN COALESCE(notes || E'\n\n', '') || :'notes' ELSE notes END
 WHERE external_id = :'ext_id';
 EOF

--- a/website/src/lib/factory-floor.test.ts
+++ b/website/src/lib/factory-floor.test.ts
@@ -26,7 +26,9 @@ vi.mock('pg', () => {
       -- one backlog feature waiting (no slot)
       ('d1','T000480','feature','Dock feature','niedrig','backlog',NULL,0,NULL, now(), now()),
       -- one shipped ticket
-      ('s1','T000467','feature','Shipped feature','mittel','done',NULL,0, now(), now(), now());
+      ('s1','T000467','feature','Shipped feature','mittel','done',NULL,0, now(), now(), now()),
+      -- LEAKED: a terminal (archived) ticket that still holds a stale pipeline_slot
+      ('x1','T000466','feature','Leaked terminal slot','mittel','archived',4,0,NULL, now(), now() - INTERVAL '30 min');
     INSERT INTO tickets.factory_phase_events (ticket_id, phase, state, detail, driver, at) VALUES
       ('h1','scout','done',NULL,'factory', now() - INTERVAL '10 min'),
       ('h1','implement','entered',NULL,'factory', now() - INTERVAL '2 min'),
@@ -89,6 +91,15 @@ describe('factory-floor DAL', () => {
     expect(c.slotsCap).toBe(3);
     expect(c.slotsUsed).toBe(2); // h1 + b1 in slots
     expect(c.dailyCap).toBe(5);
+  });
+
+  it('ignores terminal tickets that still hold a stale pipeline_slot (slot-leak guard)', async () => {
+    // x1 is archived but still has pipeline_slot=4 (a leaked slot) and is 30 min stale.
+    const c = await getControl(3);
+    expect(c.slotsUsed).toBe(2); // x1 (archived) is NOT counted as occupied
+    expect(c.watchdogStale).toBe(0); // a terminal ticket's stale slot is NOT a running-stale
+    const hall = await getHall();
+    expect(hall.map((h) => h.extId)).not.toContain('T000466'); // archived ticket not in the Halle
   });
 
   it('getTicketDetail returns the full phase timeline + breadcrumbs + PR for a ticket', async () => {

--- a/website/src/lib/factory-floor.ts
+++ b/website/src/lib/factory-floor.ts
@@ -50,10 +50,17 @@ export async function getControl(slotsCap: number): Promise<ControlSnapshot> {
     readControl('daily-cap', '5'),
     readControl(`daily-deploys:${new Date().toISOString().slice(0, 10)}`, '0'),
     readControl('dry-run', 'off'),
-    pool.query(`SELECT COUNT(*)::int AS n FROM tickets.tickets WHERE pipeline_slot IS NOT NULL`),
+    // A slot only counts as occupied while the ticket is actively running. Terminal
+    // tickets (done/archived) can retain a stale pipeline_slot — exclude them so the
+    // Leitstand never shows e.g. "8/3" from leaked slots. Mirrors slots.sh's status gate.
     pool.query(
       `SELECT COUNT(*)::int AS n FROM tickets.tickets
-        WHERE pipeline_slot IS NOT NULL AND updated_at < now() - INTERVAL '20 minutes'`,
+        WHERE pipeline_slot IS NOT NULL AND status IN ('in_progress','in_review')`,
+    ),
+    pool.query(
+      `SELECT COUNT(*)::int AS n FROM tickets.tickets
+        WHERE pipeline_slot IS NOT NULL AND status IN ('in_progress','in_review')
+          AND updated_at < now() - INTERVAL '20 minutes'`,
     ),
   ]);
   return {
@@ -112,7 +119,7 @@ export async function getHall(): Promise<HallItem[]> {
            FROM tickets.factory_phase_events
           ORDER BY ticket_id, at DESC
        ) e ON e.ticket_id = t.id
-      WHERE t.pipeline_slot IS NOT NULL
+      WHERE t.pipeline_slot IS NOT NULL AND t.status IN ('in_progress','in_review')
       ORDER BY t.pipeline_slot`,
   );
   return r.rows.map((row: any) => ({


### PR DESCRIPTION
## Problem
`/dev-status` Leitstand zeigte **8/3 Slots** und nur 1 Ticket in der Laderampe. Ursache: Tickets mit Status `done`/`archived` behielten ihren `pipeline_slot` (Ledger-Leak). `getControl.slotsUsed`, `watchdogStale` und `getHall` zählten/zeigten diese stale Slots (`pipeline_slot IS NOT NULL` ohne Status-Filter). `slots.sh` (Dispatcher-Cap) war bereits status-aware, daher war der Cap nicht blockiert — aber die Anzeige war falsch und terminale Tickets erschienen in der Halle.

## Fix
- **`factory-floor.ts`**: `slotsUsed`, `watchdogStale`, `getHall` verlangen jetzt `status IN ('in_progress','in_review')` (spiegelt `slots.sh`).
- **`ticket.sh update-status`**: gibt `pipeline_slot` bei `done`/`archived` frei → Leak an der Quelle behoben.
- Neuer pg-mem-Test: archiviertes Ticket mit stale Slot wird ignoriert (slotsUsed/watchdogStale/Halle).

## Verifikation
- `vitest factory-floor.test.ts` 9/9 (2 vorher rot → grün).
- `quality:check` 0 blocking.
- Stale Slots in der Live-DB bereits manuell freigegeben (8 → 0).

Closes T000525.

🤖 Generated with [Claude Code](https://claude.com/claude-code)