### PR TITLE
fix(worktree): symlink node_modules into new worktrees so task test:all works [T000526]

### DIFF
--- a/docs/superpowers/plans/2026-06-08-worktree-node-modules.md
+++ b/docs/superpowers/plans/2026-06-08-worktree-node-modules.md
@@ -1,0 +1,47 @@
+---
+ticket_id: T000526
+status: in-progress
+domains: [infra, test]
+---
+
+# Fix: worktree-create.sh provisions node_modules (offline gate works in worktrees)
+
+**Ticket:** T000526 · **Branch:** `fix/worktree-node-modules`
+
+## Problem
+
+`scripts/worktree-create.sh` inits submodules but never provisions the
+gitignored root `node_modules` (~536M, only in the base checkout). git worktrees
+don't share it, so `task test:all`'s node-importing subtasks (`test:docs-gen`,
+`test:agent-guide`) die with `ERR_MODULE_NOT_FOUND` (cheerio/gray-matter) in a
+fresh worktree — exactly the dev-flow default. CI is green (it runs `npm ci`).
+
+T000427 already added `[ -d node_modules ] || npm ci` guards to those tasks, but
+under the **concurrent** `task test:all` they race: `npm ci` creates the
+`node_modules/` dir early, so a parallel task sees `-d node_modules` true, skips
+its own install, and imports before deps are written → the same error.
+
+## Fix (TDD, red→green)
+
+- **Test first (RED):** two cases in `tests/unit/worktree-create.bats` — a base
+  with `node_modules` must leave it resolvable from the worktree root; a base
+  without one must still succeed (no dangling link). Confirmed red before the fix.
+- **Script (GREEN):** after submodule init, symlink the base checkout's
+  `node_modules` (`dirname` of the shared git-common-dir) into the worktree when
+  present and absent in the worktree. Instant, no reinstall; the existing
+  `[ -d node_modules ] || npm ci` guards then short-circuit, so the concurrency
+  race never triggers in worktrees. Skipped cleanly when the base has none.
+
+## Verification
+
+- `tests/unit/worktree-create.bats`: 8/8 green (2 new). `test-tasks-node-deps`
+  (T000427) still green. `bash -n` clean.
+- End-to-end in a real worktree (symlinked node_modules): `task test:docs-gen`,
+  `task test:agent-guide`, full `task test:all`, and `task freshness:check` all
+  exit 0 — previously red on ERR_MODULE_NOT_FOUND.
+- `node_modules` is gitignored → the symlink never appears in `git status`.
+
+## Files
+
+- `scripts/worktree-create.sh`
+- `tests/unit/worktree-create.bats`

--- a/scripts/worktree-create.sh
+++ b/scripts/worktree-create.sh
@@ -86,6 +86,18 @@ fi
 # 2) Init submodules (git worktree add does NOT; the BATS runner lives in one).
 git -C "$WT_PATH" submodule update --init --recursive --quiet
 
+# 3) node_modules: git worktrees don't share the gitignored root node_modules,
+#    and several `task test:all` subtasks (test:docs-gen, test:agent-guide) import
+#    third-party packages from it. Symlink the base checkout's node_modules so the
+#    worktree resolves deps instantly — no 536M reinstall, and the Taskfile's
+#    `[ -d node_modules ] || npm ci` guards short-circuit (avoiding their race
+#    under concurrent test:all). Skipped cleanly if the base has none. [T000526]
+MAIN_ROOT="$(dirname "$COMMON_DIR")"
+if [ -d "$MAIN_ROOT/node_modules" ] && [ ! -e "$WT_PATH/node_modules" ]; then
+    ln -s "$MAIN_ROOT/node_modules" "$WT_PATH/node_modules"
+    echo "worktree-create: linked node_modules → $MAIN_ROOT/node_modules" >&2
+fi
+
 _ok=1   # reached a clean finish — disarm the rollback trap
 if [ "$BRANCH_EXISTS" -eq 1 ]; then
     echo "worktree-create: $WT_PATH ready on existing branch $BRANCH"

--- a/tests/unit/worktree-create.bats
+++ b/tests/unit/worktree-create.bats
@@ -102,6 +102,30 @@ teardown() { rm -rf "$TMP"; }
   [ "$status" -eq 0 ]
 }
 
+# ── node_modules provisioning: worktrees share deps with the base checkout ──
+
+@test "T000526: a fresh worktree resolves node_modules from the base checkout" {
+  # The base has installed JS deps (gitignored, ~536M). git worktrees do NOT
+  # share node_modules, so without provisioning `task test:all`'s node-importing
+  # subtasks (test:docs-gen, test:agent-guide) die on ERR_MODULE_NOT_FOUND. The
+  # helper must make the base's node_modules resolvable from the worktree root.
+  mkdir -p "$MAIN/node_modules/cheerio"
+  printf '{"name":"cheerio"}\n' > "$MAIN/node_modules/cheerio/package.json"
+  run bash -c "cd '$MAIN' && bash '$HELPER' feature/nm '$TMP/wt-nm' HEAD"
+  [ "$status" -eq 0 ]
+  [ -e "$TMP/wt-nm/node_modules/cheerio/package.json" ]
+  grep -q 'cheerio' "$TMP/wt-nm/node_modules/cheerio/package.json"
+}
+
+@test "T000526: node_modules provisioning is skipped cleanly when the base has none" {
+  # No node_modules in the base → the helper must still succeed (no error, no
+  # dangling link), so a not-yet-installed repo can still spawn worktrees.
+  [ ! -e "$MAIN/node_modules" ]
+  run bash -c "cd '$MAIN' && bash '$HELPER' feature/nonm '$TMP/wt-nonm' HEAD"
+  [ "$status" -eq 0 ]
+  [ ! -e "$TMP/wt-nonm/node_modules" ]
+}
+
 # ── Rollback: a failure AFTER the --no-checkout skeleton must not leave junk ──
 
 @test "a post-skeleton failure rolls back the worktree and branch (no leftover)" {


### PR DESCRIPTION
Behebt **T000526**.

## Problem
`scripts/worktree-create.sh` initialisiert Submodules, stellt aber das gitignorete Root-`node_modules` (~536M, nur im Basis-Checkout) **nicht** bereit. Git-Worktrees teilen es nicht → in einem frischen Worktree sterben die node-importierenden `task test:all`-Subtasks (`test:docs-gen`, `test:agent-guide`) an `ERR_MODULE_NOT_FOUND` (cheerio/gray-matter). Genau der dev-flow-Normalfall. CI grün (dort läuft `npm ci`).

T000427 hatte zwar `[ -d node_modules ] || npm ci`-Guards ergänzt, aber unter dem **nebenläufigen** `test:all` racen die: `npm ci` legt `node_modules/` früh an → ein paralleler Task sieht `-d node_modules` = true, überspringt seine Installation, importiert bevor die Deps geschrieben sind → derselbe Fehler.

## Fix (TDD rot→grün)
Nach der Submodule-Init das `node_modules` des Basis-Checkouts (`dirname` des shared git-common-dir) in den Worktree **symlinken** (wenn vorhanden und im Worktree fehlend). Instant, kein Reinstall; die vorhandenen Guards greifen dann kurz → der Race triggert in Worktrees nie. Sauberer Skip, wenn die Basis keins hat.

## Verifikation
- `tests/unit/worktree-create.bats`: **8/8 grün** (2 neu); `test-tasks-node-deps` (T000427) weiter grün; `bash -n` clean.
- End-to-End in echtem Worktree (symlinktes node_modules): `task test:docs-gen`, `task test:agent-guide`, voller `task test:all` **und** `task freshness:check` → exit 0 (zuvor rot auf ERR_MODULE_NOT_FOUND).
- `node_modules` gitignoret → der Symlink taucht nie in `git status` auf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)