### PR TITLE
fix(factory): pin model on dispatcher agent() calls — DeepSeek PREP 400 guard [T000528]

### DIFF
--- a/scripts/factory/dispatcher.js
+++ b/scripts/factory/dispatcher.js
@@ -109,7 +109,7 @@ async function main() {
      If a guard read errors (non-zero with no documented meaning), fail-closed: skip that brand.
      If a ticket has no plan reference, set branch and plan_path to null.
      If nothing was claimed across both brands, return { "launch": [], "skipped": [...] }.`,
-    { label: 'prep', phase: 'Prep', schema: PLAN_SCHEMA },
+    { label: 'prep', phase: 'Prep', schema: PLAN_SCHEMA, model: 'sonnet' },
   )
 
   log(
@@ -169,7 +169,7 @@ async function main() {
          bash ${REPO}/scripts/ticket.sh add-comment --id T000413 \\
            --body ${JSON.stringify('Factory dispatcher: ' + escalations.length + ' run(s) escalated this tick.')}
        Report what was notified and the ticket-comment output.`,
-      { label: 'escalate', phase: 'Launch' },
+      { label: 'escalate', phase: 'Launch', model: 'sonnet' },
     )
   } else {
     log(`Dispatcher: all ${results?.length ?? 0} pipeline run(s) completed without error/block.`)
@@ -182,7 +182,7 @@ async function main() {
        BRAND=mentolder bash ${REPO}/scripts/factory/metrics.sh
        BRAND=korczewski bash ${REPO}/scripts/factory/metrics.sh
      (metrics.sh is best-effort: a missing Vorhaben ticket on a brand is a silent no-op.)`,
-    { label: 'metrics', phase: 'Metrics' },
+    { label: 'metrics', phase: 'Metrics', model: 'sonnet' },
   )
 }
 await main();

--- a/tests/local/FA-SF-30-dispatcher-contract.bats
+++ b/tests/local/FA-SF-30-dispatcher-contract.bats
@@ -55,3 +55,14 @@ setup() { load 'test_helper.bash'; }
   run grep -q "ToolSearch select:PushNotification" "$SCRIPT"; [ "$status" -eq 0 ]
   run grep -Eq "\.error|status === 'blocked'|status: *'blocked'|blocked" "$SCRIPT"; [ "$status" -eq 0 ]
 }
+
+@test "FA-SF-30: every agent() opts pins an explicit model (DeepSeek reasoning_effort 400 guard — T000528)" {
+  # The dispatcher runs under DeepSeek-backed autopilot; an agent() call that inherits the
+  # ambient model config trips the 'thinking cannot be disabled when reasoning_effort is set'
+  # 400 and fails PREP. Each agent() opts (prep/escalate/metrics) must pin model: explicitly.
+  # Sibling guard to the pipeline.js fix (T000519/#1430).
+  labels=$(grep -cE "label: '(prep|escalate|metrics)'" "$SCRIPT")
+  [ "$labels" -eq 3 ]
+  pinned=$(grep -E "label: '(prep|escalate|metrics)'" "$SCRIPT" | grep -c "model:")
+  [ "$pinned" -eq 3 ]
+}


### PR DESCRIPTION
## Problem
The Software Factory dispatcher (`scripts/factory/dispatcher.js`) calls `agent()` three times (`prep`/`escalate`/`metrics`) **without an explicit model**. Under DeepSeek-backed autopilot these inherit the ambient model config and trip the `thinking … cannot be disabled when reasoning_effort is set` **400**, failing PREP with **no brands processed** — observed ~4× on 2026-06-08.

## Fix
Pin `model: 'sonnet'` on all three `agent()` opts. Sibling of **T000519/#1430**, which fixed the same failure class in `pipeline.js`.

## Test (TDD)
Adds a `FA-SF-30` regression assertion: every `agent()` opts (prep/escalate/metrics) must pin `model:` explicitly. Verified red→green; full FA-SF suite **195/195 green, 0 failures**, `node --check` clean.

Closes T000528.

🤖 Generated with [Claude Code](https://claude.com/claude-code)