### PR TITLE
fix(brett): ship public/assets into served dist/client — figure-pack 404 regression [T000527]

### DIFF
--- a/brett/Dockerfile
+++ b/brett/Dockerfile
@@ -15,6 +15,11 @@ COPY package.json package-lock.json ./
 RUN npm ci --omit=dev
 COPY src ./src
 COPY --from=builder /app/dist/client ./dist/client
+# Vite (root: 'public') bundles only index.html + imported JS into dist/client; the
+# static figure-pack/props/terrain assets fetched at runtime (/assets/...) are NOT
+# emitted by the build, so ship public/assets into the served dir explicitly.
+# Without this, express.static(dist/client) 404s every figure-pack asset (T000527).
+COPY --from=builder /app/public/assets ./dist/client/assets
 USER node
 EXPOSE 3000
 CMD ["npm", "start"]

--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 370,
+      "file_count": 371,
       "files": [
         "tests/.gitignore",
         "tests/e2e/brett-globals.d.ts",
@@ -87,6 +87,7 @@
         "tests/e2e/specs/fa-44-platform-health-integrity.spec.ts",
         "tests/e2e/specs/fa-45-authenticated-flows.spec.ts",
         "tests/e2e/specs/fa-46-lernpfad-cta.spec.ts",
+        "tests/e2e/specs/fa-47-brett-figure-pack-assets.spec.ts",
         "tests/e2e/specs/fa-admin-backup-ops.spec.ts",
         "tests/e2e/specs/fa-admin-backup-settings.spec.ts",
         "tests/e2e/specs/fa-admin-billing-system.spec.ts",

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -244,6 +244,7 @@ export default defineConfig({
       testMatch: [
         '**/korczewski-home.spec.ts',  // Kore brand homepage
         '**/brett-art.spec.ts',        // Brett art-library (canvas sprites)
+        '**/fa-47-brett-figure-pack-assets.spec.ts', // figure-pack assets served (T000527/T000522)
         '**/dashboard-art.spec.ts',    // Dashboard art-library tab (web.korczewski.de/admin)
         '**/fa-content-hub-legal-ssot.spec.ts',
       ],

--- a/tests/e2e/specs/fa-47-brett-figure-pack-assets.spec.ts
+++ b/tests/e2e/specs/fa-47-brett-figure-pack-assets.spec.ts
@@ -1,0 +1,89 @@
+// tests/e2e/specs/fa-47-brett-figure-pack-assets.spec.ts
+// Regression test for T000527: Brett figure-pack assets must be served in prod.
+//
+// Since the #1375 TS migration (vite root:'public' + multi-stage Dockerfile) the
+// public/assets/ tree was no longer shipped into the served dist/client, so every
+// figure-pack asset 404'd. This test asserts the served brett app exposes the
+// placement_spec.json registry AND the individual asset PNGs (covering both the
+// pre-existing assets and the T000522 additions: relieved/defiant/fearful +
+// scarf/spectacles).
+//
+// Brett is SSO-gated (oauth2-proxy → Keycloak). Auth mirrors brett-art.spec.ts:
+// korczewski-setup writes .auth/korczewski-brett.json via a real OIDC login. When
+// no valid auth state exists the authenticated checks skip gracefully and only the
+// redirect behaviour is asserted.
+import { test, expect } from '@playwright/test';
+import * as path from 'path';
+import * as fs from 'fs';
+
+const BRETT_URL        = (process.env.BRETT_URL ?? 'https://brett.korczewski.de').replace(/\/$/, '');
+const BRETT_STATE_FILE = path.join(__dirname, '..', '.auth', 'korczewski-brett.json');
+
+// Pre-existing baseline asset + the T000522 additions — all must serve.
+const EXPECT_FACES       = ['neutral', 'relieved', 'defiant', 'fearful'];
+const EXPECT_ACCESSORIES = ['shawl', 'scarf', 'spectacles'];
+const ASSET_PNGS = [
+  'assets/figure-pack/faces/neutral.png',
+  'assets/figure-pack/faces/relieved.png',
+  'assets/figure-pack/faces/defiant.png',
+  'assets/figure-pack/faces/fearful.png',
+  'assets/figure-pack/accessories/scarf.png',
+  'assets/figure-pack/accessories/spectacles.png',
+];
+
+function hasAuthState(): boolean {
+  if (!fs.existsSync(BRETT_STATE_FILE)) return false;
+  try {
+    const raw = JSON.parse(fs.readFileSync(BRETT_STATE_FILE, 'utf-8'));
+    return Array.isArray(raw?.cookies) && raw.cookies.length > 0;
+  } catch {
+    return false;
+  }
+}
+
+test.describe('FA-47: Brett figure-pack assets are served (T000527 / T000522)', () => {
+  test('T1: Brett redirects unauthenticated users to Keycloak', async ({ browser }) => {
+    const ctx = await browser.newContext({ ignoreHTTPSErrors: true });
+    const page = await ctx.newPage();
+    await page.goto(BRETT_URL, { waitUntil: 'domcontentloaded' });
+    if (hasAuthState()) {
+      await ctx.close();
+      test.skip();
+      return;
+    }
+    await expect(page).toHaveURL(/auth\.|realms\/workspace/, { timeout: 15_000 });
+    await ctx.close();
+  });
+
+  test('T2: placement_spec.json is served and registers the new faces/accessories', async ({ browser }) => {
+    if (!hasAuthState()) { test.skip(); return; }
+    const ctx = await browser.newContext({ ignoreHTTPSErrors: true, storageState: BRETT_STATE_FILE });
+    try {
+      const res = await ctx.request.get(`${BRETT_URL}/assets/figure-pack/placement_spec.json`);
+      expect(res.status(), 'placement_spec.json must be served (not 404)').toBe(200);
+      const spec = await res.json();
+      for (const f of EXPECT_FACES) {
+        expect(spec.faces?.[f]?.file, `face ${f} registered`).toBe(`faces/${f}.png`);
+      }
+      for (const a of EXPECT_ACCESSORIES) {
+        expect(spec.accessories?.[a]?.file, `accessory ${a} registered`).toBe(`accessories/${a}.png`);
+      }
+    } finally {
+      await ctx.close();
+    }
+  });
+
+  test('T3: figure-pack PNGs are served (HTTP 200, image/png)', async ({ browser }) => {
+    if (!hasAuthState()) { test.skip(); return; }
+    const ctx = await browser.newContext({ ignoreHTTPSErrors: true, storageState: BRETT_STATE_FILE });
+    try {
+      for (const p of ASSET_PNGS) {
+        const res = await ctx.request.get(`${BRETT_URL}/${p}`);
+        expect(res.status(), `${p} should be served`).toBe(200);
+        expect(res.headers()['content-type'] ?? '', `${p} content-type`).toContain('image/png');
+      }
+    } finally {
+      await ctx.close();
+    }
+  });
+});

--- a/website/src/data/test-inventory.json
+++ b/website/src/data/test-inventory.json
@@ -936,6 +936,12 @@
     "kind": "playwright"
   },
   {
+    "id": "FA-47",
+    "file": "tests/e2e/specs/fa-47-brett-figure-pack-assets.spec.ts",
+    "category": "FA",
+    "kind": "playwright"
+  },
+  {
     "id": "FA-SF-01",
     "file": "tests/local/FA-SF-01-conflict-check.bats",
     "category": "FA",


### PR DESCRIPTION
## Problem
Since the #1375 TS migration (2026-06-06: `vite.config` `root:'public'` + multi-stage Dockerfile), **all** Brett figure-pack assets (faces/accessories/props/terrain) have 404'd in production on both brands.

- Vite (`root:'public'`) bundles only `index.html` + imported JS into `dist/client`; the figure-pack PNGs are fetched dynamically (`/assets/figure-pack/...`) and are **not** emitted by the build.
- The Dockerfile runtime stage ships only `dist/client` (no `public/`).
- The server does a single `express.static(dist/client)` → every asset 404s.
- **Pod evidence:** `/app` had no `public/`, 0 PNGs anywhere.

This also rendered the T000522 additions (relieved/defiant/fearful + scarf/spectacles) invisible. Caught by the new fa-47 E2E.

## Fix
Runtime Docker stage now `COPY --from=builder /app/public/assets ./dist/client/assets`, merging the static asset tree into the served directory (no collision with Vite's hashed JS bundles).

## Verification
- **In-pod (both brands, post-deploy):** `dist/client/assets/figure-pack/` present with all assets (neutral + relieved/defiant/fearful + scarf/spectacles). Was `STILL MISSING` before the fix → present after.
- `task test:all` green.
- `fa-47-brett-figure-pack-assets.spec.ts` added (korczewski project): asserts `placement_spec.json` + asset PNGs serve (200, image/png). Runs fully in nightly e2e (authenticated).

## Note (out of scope)
Runtime-uploaded **skins** (`skins-upload.ts` → `public/assets/skins`) are likely affected by the same dir mismatch — separate follow-up.

Closes T000527.

🤖 Generated with [Claude Code](https://claude.com/claude-code)