### PR TITLE
feat(brett): open-host — any authenticated user may start a session [T000532]

### DIFF
--- a/brett/src/client/ui/menu.ts
+++ b/brett/src/client/ui/menu.ts
@@ -38,10 +38,10 @@ export function isValidJoinCode(code: string): boolean {
   return JOIN_CODE_RE.test(code.trim());
 }
 
-/** Pure: admin-gated item list + identity line. */
+/** Item list + identity line. Any authenticated user may start a session. */
 export function menuModel(user: MenuUser): MenuModel {
   const items: MenuItem[] = [];
-  if (user.isAdmin) {
+  if (user.userId && user.userId !== 'anon') {
     items.push({ id: 'new-session', label: 'Neue Session starten', hint: 'Eine Aufstellung leiten' });
   }
   items.push({ id: 'join', label: 'Session beitreten', hint: 'Mit Code teilnehmen' });

--- a/brett/src/server/ws-handler.ts
+++ b/brett/src/server/ws-handler.ts
@@ -264,9 +264,6 @@ export function attachWsServer(wss: WebSocketServer, deps: WsDeps): void {
             }
           }
 
-          // Maintain admin presence for grace reassignment (B14). Accumulate any
-          // OIDC-admin into roomAdminPresence; if the (re)joining admin is the
-          // current token holder, cancel a pending grace timer.
           if (ws._session?.isAdmin) {
             const pid = resolvePlayerId(ws);
             const existing = [...(deps.roomAdminPresence.get(room) ?? [])];
@@ -279,10 +276,7 @@ export function attachWsServer(wss: WebSocketServer, deps: WsDeps): void {
 
           const freshState = deps.buildStateFromMutations(room);
           if (freshState) {
-            // REG-6: merge the persisted __roles__ into each participant so the
-            // late-joiner's roster (seeded from this snapshot) shows assigned roles
-            // — not just {userId,name,color}. `ready` is ephemeral (never persisted)
-            // and defaults to false until the peer re-emits lobby_ready_changed.
+            // REG-6: merge persisted __roles__ into participants for late-joiner roster.
             const persistedRoles = freshState.roles || {};
             freshState.participants = deps.listParticipants(room).map((p: any) => ({
               ...p,
@@ -493,9 +487,6 @@ export function attachWsServer(wss: WebSocketServer, deps: WsDeps): void {
               deps.broadcast(room, { type: 'figure_owner_changed', figureId: newId, ownerId: playerId });
             }
           }
-          // Late-join tracking is done in the `join` handler (SEC-1/REG-3), not via
-          // a relay `player_join` (which was never in RELAY_TYPES nor sent by any
-          // client — dead code, removed).
           if (msg.type === 'clear') {
             deps.flushImmediate(room).catch((err: any) => console.error('[brett] flush:', err));
           }

--- a/brett/src/server/ws-handler.ts
+++ b/brett/src/server/ws-handler.ts
@@ -505,9 +505,21 @@ export function attachWsServer(wss: WebSocketServer, deps: WsDeps): void {
         }
 
         if (ADMIN_TYPES.has(msg.type)) {
-          if (!ws._session?.isAdmin) return;
           const adminRoom = ws._room;
           if (!adminRoom) return;
+          const isKcAdmin = !!ws._session?.isAdmin;
+          if (msg.type === 'admin_session_create') {
+            // Any authenticated user may start a session and become its host.
+            if (!ws._session?.userId) return;
+          } else if (msg.type === 'admin_broadcast') {
+            // Internal website notification — Keycloak-admin only.
+            if (!isKcAdmin) return;
+          } else {
+            // All other host actions: Keycloak-admin OR current room leiter.
+            const roomRoles = deps.buildStateFromMutations(adminRoom)?.roles ?? {};
+            const isLeiter = deps.resolveRole(ws, roomRoles) === 'leiter';
+            if (!isKcAdmin && !isLeiter) return;
+          }
           await handleAdminMessage(ws, msg, adminRoom, deps);
           return;
         }

--- a/brett/test/menu-model.test.ts
+++ b/brett/test/menu-model.test.ts
@@ -3,8 +3,8 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { menuModel, isValidJoinCode } from '../src/client/ui/menu';
 
-test('admin/Leiter sees "Neue Session"; identity line reflects the name', () => {
-  const m = menuModel({ userId: 'u1', name: 'Anna', isAdmin: true });
+test('authenticated user sees "Neue Session"; identity line reflects the name', () => {
+  const m = menuModel({ userId: 'u1', name: 'Anna', isAdmin: false });
   const ids = m.items.map((i) => i.id);
   assert.ok(ids.includes('new-session'));
   assert.ok(ids.includes('join'));
@@ -13,10 +13,10 @@ test('admin/Leiter sees "Neue Session"; identity line reflects the name', () => 
   assert.equal(m.identityLine, 'angemeldet als: Anna');
 });
 
-test('non-admin omits "Neue Session" but keeps join/saved/settings', () => {
+test('anon user omits "Neue Session" but keeps join/saved/settings', () => {
   const m = menuModel({ userId: 'anon', name: 'Teilnehmer', isAdmin: false });
   const ids = m.items.map((i) => i.id);
-  assert.ok(!ids.includes('new-session'), '"Neue Session" is Leiter/Admin only');
+  assert.ok(!ids.includes('new-session'), '"Neue Session" requires authentication');
   assert.ok(ids.includes('join'));
   assert.ok(ids.includes('saved'));
   assert.ok(ids.includes('settings'));
@@ -31,7 +31,7 @@ test('isValidJoinCode accepts the 6-char session-code shape only', () => {
 });
 
 test('FE-4: saved + settings are disabled placeholders; join + new-session are active', () => {
-  const m = menuModel({ userId: 'u1', name: 'Anna', isAdmin: true });
+  const m = menuModel({ userId: 'u1', name: 'Anna', isAdmin: false });
   const byId = Object.fromEntries(m.items.map((i) => [i.id, i]));
   assert.equal(byId['saved'].disabled, true, 'Gespeicherte Aufstellungen is disabled');
   assert.equal(byId['settings'].disabled, true, 'Einstellungen is disabled');


### PR DESCRIPTION
## Summary
- Entfernt den Keycloak-Admin-Gate für `admin_session_create`: jeder eingeloggte User kann eine Session starten und wird automatisch Leiter (`leiter`-Rolle)
- Alle anderen Host-Aktionen (round_start/stop, assign_role, spotlight, etc.) bleiben für den Leiter verfügbar — nicht mehr nur für Keycloak-Admins
- `admin_broadcast` (interne Website-Benachrichtigung) bleibt Keycloak-Admin-only
- Client: "Neue Session starten"-Button erscheint für alle authentifizierten User (vorher: nur Admins)

## Änderungen
- `brett/src/server/ws-handler.ts`: ADMIN_TYPES-Gate ersetzt durch differenzierten Check (session_create → userId-Check, broadcast → isAdmin, Rest → isAdmin OR leiter)
- `brett/src/client/ui/menu.ts`: `if (user.isAdmin)` → `if (user.userId !== 'anon')`
- `brett/test/menu-model.test.ts`: Tests auf neue Semantik angepasst

## Test plan
- [ ] 442/442 Brett-Tests grün (`MOCK_DB=true npx tsx --test test/*.test.ts` in `brett/`)
- [ ] `task test:all` grün (FAIL=0)
- [ ] Manuell: Nicht-Admin-User sieht "Neue Session starten"-Button und kann Session starten

🤖 Generated with [Claude Code](https://claude.com/claude-code)