### PR TITLE
chore(schema): document Collabora Taskfile-derived envsubst vars [T000531]

### DIFF
--- a/environments/schema.yaml
+++ b/environments/schema.yaml
@@ -432,6 +432,15 @@ secrets:
   #    task body, passed directly to envsubst — not stored in environments/):
   #      ARENA_IMAGE         (prod-korczewski/arena.yaml — set to either
   #                           :latest or a pinned digest in arena:deploy)
+  #      COLLABORA_INGRESS_MIDDLEWARES
+  #                          (k3d/office-stack/ingress.yaml — computed from
+  #                           WORKSPACE_NAMESPACE in workspace:office:deploy)
+  #      COLLABORA_INGRESS_MIDDLEWARES_2
+  #                          (k3d/office-stack/ingress-korczewski.yaml — computed
+  #                           for the korczewski brand in workspace:office:deploy)
+  #      COLLABORA_TLS_SECRET_2
+  #                          (k3d/office-stack/ingress-korczewski.yaml — hardcoded
+  #                           to "korczewski-tls" in workspace:office:deploy)
   #
   # 6. Comment text matched by the audit regex (not real envsubst targets):
   #      VAR                 (k3d/coturn-stack/coturn.yaml line ~43 — used


### PR DESCRIPTION
## Summary
- `COLLABORA_INGRESS_MIDDLEWARES`, `COLLABORA_INGRESS_MIDDLEWARES_2`, `COLLABORA_TLS_SECRET_2` erschienen im Weekly-Audit (Issue #1444) als undokumentierte `${VAR}`-Platzhalter in Manifesten
- Diese Vars werden in `workspace:office:deploy` per Taskfile berechnet und direkt an `envsubst` übergeben — sie sind nie in `environments/*.yaml` gespeichert
- Korrekte Einordnung: Kategorie 5 (Taskfile-derived), analog zu `ARENA_IMAGE`
- Keine funktionalen Änderungen

## Test plan
- [ ] `task test:all` grün (nur YAML/Docs-Änderung, keine Manifest-Änderung)

Closes T000531

🤖 Generated with [Claude Code](https://claude.com/claude-code)