### PR TITLE
fix(brett): runtime skin uploads 404 — write to dist/client/assets/skins [T000529]

### DIFF
--- a/brett/src/server/skins-upload.ts
+++ b/brett/src/server/skins-upload.ts
@@ -6,8 +6,16 @@ import multer from 'multer';
 
 export const MAX_SKIN_BYTES = 20 * 1024 * 1024; // 20 MB
 
-// Storage root: brett/public/assets/skins/<uuid>/
-const SKINS_ROOT = path.join(__dirname, '..', '..', 'public', 'assets', 'skins');
+// Resolve where skins are stored, mirroring the express.static root in index.ts.
+// In production the container ships no public/ dir; express.static serves from
+// dist/client, so uploads must land there too (T000529).
+export function computeSkinsRoot(distClientPath: string): string {
+  return fs.existsSync(path.join(distClientPath, 'index.html'))
+    ? path.join(distClientPath, 'assets', 'skins')
+    : path.join(path.dirname(path.dirname(distClientPath)), 'public', 'assets', 'skins');
+}
+
+const SKINS_ROOT = computeSkinsRoot(path.join(__dirname, '..', '..', 'dist', 'client'));
 
 export function checkSkinAuth(
   headerValue: string | undefined,

--- a/brett/test/skins-upload.test.ts
+++ b/brett/test/skins-upload.test.ts
@@ -1,5 +1,8 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import express from 'express';
 import { once } from 'node:events';
 import {
@@ -7,6 +10,7 @@ import {
   validateGlbSize,
   glbHasMixamoBones,
   attachSkinsUpload,
+  computeSkinsRoot,
   MAX_SKIN_BYTES,
 } from '../src/server/skins-upload';
 
@@ -140,5 +144,31 @@ test('POST /api/skins/upload: 413 for GLB over 20 MB', async () => {
     assert.equal(status, 413);
   } finally {
     close();
+  }
+});
+
+// ── T000529: SKINS_ROOT must resolve to the served static directory ─────────
+
+test('computeSkinsRoot: returns dist/client/assets/skins when index.html exists (regression T000529)', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'brett-skins-'));
+  try {
+    fs.writeFileSync(path.join(tmpDir, 'index.html'), '<html/>');
+    const result = computeSkinsRoot(tmpDir);
+    assert.equal(result, path.join(tmpDir, 'assets', 'skins'),
+      'production: skins must land inside dist/client so express.static serves them');
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true });
+  }
+});
+
+test('computeSkinsRoot: returns public/assets/skins when no built index.html (dev mode)', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'brett-skins-'));
+  try {
+    // No index.html → dev mode
+    const result = computeSkinsRoot(tmpDir);
+    const expected = path.join(path.dirname(path.dirname(tmpDir)), 'public', 'assets', 'skins');
+    assert.equal(result, expected, 'dev: fall back to public/assets/skins');
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true });
   }
 });


### PR DESCRIPTION
## Summary
- **Root cause:** `SKINS_ROOT` in `skins-upload.ts` was hardcoded to `public/assets/skins`, but the production container ships no `public/` directory — the Dockerfile only copies `public/assets` into `dist/client/assets` (the T000527 fix) for build-time static assets
- **Effect:** Any skin uploaded at runtime lands at `/app/public/assets/skins/<uuid>/` (unserved path), so subsequent `GET /assets/skins/<uuid>/skin.glb` returns 404
- **Fix:** `computeSkinsRoot(distClientPath)` mirrors the `staticDir` logic from `index.ts`: when `dist/client/index.html` exists (production), writes into `dist/client/assets/skins`; otherwise falls back to `public/assets/skins` (local dev / vite dev server)
- **Tests:** 2 new regression tests cover both branches of `computeSkinsRoot`; all 444 Brett tests pass

## Test plan
- [ ] `cd brett && npx tsx --test test/*.test.ts` — 444 pass, 0 fail
- [ ] Upload a skin via the Brett UI on fleet → verify `GET /assets/skins/<uuid>/skin.glb` returns 200

Closes T000529

🤖 Generated with [Claude Code](https://claude.com/claude-code)