### PR TITLE
fix(factory): remove hardcoded model:'sonnet' from dispatcher.js [T000533]

### DIFF
--- a/scripts/factory/dispatcher.js
+++ b/scripts/factory/dispatcher.js
@@ -109,7 +109,7 @@ async function main() {
      If a guard read errors (non-zero with no documented meaning), fail-closed: skip that brand.
      If a ticket has no plan reference, set branch and plan_path to null.
      If nothing was claimed across both brands, return { "launch": [], "skipped": [...] }.`,
-    { label: 'prep', phase: 'Prep', schema: PLAN_SCHEMA, model: 'sonnet' },
+    { label: 'prep', phase: 'Prep', schema: PLAN_SCHEMA },
   )
 
   log(
@@ -169,7 +169,7 @@ async function main() {
          bash ${REPO}/scripts/ticket.sh add-comment --id T000413 \\
            --body ${JSON.stringify('Factory dispatcher: ' + escalations.length + ' run(s) escalated this tick.')}
        Report what was notified and the ticket-comment output.`,
-      { label: 'escalate', phase: 'Launch', model: 'sonnet' },
+      { label: 'escalate', phase: 'Launch' },
     )
   } else {
     log(`Dispatcher: all ${results?.length ?? 0} pipeline run(s) completed without error/block.`)
@@ -182,7 +182,7 @@ async function main() {
        BRAND=mentolder bash ${REPO}/scripts/factory/metrics.sh
        BRAND=korczewski bash ${REPO}/scripts/factory/metrics.sh
      (metrics.sh is best-effort: a missing Vorhaben ticket on a brand is a silent no-op.)`,
-    { label: 'metrics', phase: 'Metrics', model: 'sonnet' },
+    { label: 'metrics', phase: 'Metrics' },
   )
 }
 await main();


### PR DESCRIPTION
## Summary
- Removes 3 explicit `model:'sonnet'` overrides from `prep`, `escalate`, and `metrics` agent() calls in `scripts/factory/dispatcher.js`
- These caused `reasoning_effort` API conflicts when the session model is DeepSeek or another backend that rejects the combination (same bug as T000519/PR #1430 fixed in pipeline.js)
- Dispatcher agent calls now inherit the session model, consistent with the rest of the pipeline

## Test plan
- [ ] CI passes (no changed logic, only option removal)
- [ ] Manual: run dispatcher dry-run — `node scripts/factory/dispatcher.js` — confirm no 400 reasoning_effort errors on prep/escalate/metrics

🤖 Generated with [Claude Code](https://claude.com/claude-code)