### PR TITLE
fix(brett): allow HTTP OIDC discovery after openid-client v4→v6 upgrade

### DIFF
--- a/brett/src/server/auth.ts
+++ b/brett/src/server/auth.ts
@@ -11,13 +11,18 @@ export async function getOidcClient(): Promise<Configuration> {
   const clientId   = process.env.BRETT_KC_CLIENT_ID || 'brett-app';
   const clientSecret = process.env.BRETT_OIDC_SECRET || '';
   const issuerUrl  = `${kcUrl}/realms/${kcRealm}`;
-  const isHttp = issuerUrl.startsWith('http:');
+  const url = new URL(issuerUrl);
+  const isClusterHttp = url.protocol === 'http:' &&
+    (url.hostname === 'localhost' || url.hostname === '127.0.0.1' || url.hostname.endsWith('.svc.cluster.local'));
+  if (url.protocol === 'http:' && !isClusterHttp) {
+    throw new Error(`OIDC issuer URL must use HTTPS or a cluster-internal hostname, got: ${url.hostname}`);
+  }
   oidcConfig = await discovery(
-    new URL(issuerUrl),
+    url,
     clientId,
     { client_secret: clientSecret },
     ClientSecretPost(),
-    isHttp ? { execute: [allowInsecureRequests] } : undefined,
+    isClusterHttp ? { execute: [allowInsecureRequests] } : undefined,
   );
   return oidcConfig;
 }

--- a/brett/src/server/auth.ts
+++ b/brett/src/server/auth.ts
@@ -1,4 +1,4 @@
-import { discovery, ClientSecretPost } from 'openid-client';
+import { discovery, ClientSecretPost, allowInsecureRequests } from 'openid-client';
 import type { Configuration } from 'openid-client';
 import type { Request, Response, NextFunction } from 'express';
 
@@ -11,7 +11,14 @@ export async function getOidcClient(): Promise<Configuration> {
   const clientId   = process.env.BRETT_KC_CLIENT_ID || 'brett-app';
   const clientSecret = process.env.BRETT_OIDC_SECRET || '';
   const issuerUrl  = `${kcUrl}/realms/${kcRealm}`;
-  oidcConfig = await discovery(new URL(issuerUrl), clientId, { client_secret: clientSecret }, ClientSecretPost());
+  const isHttp = issuerUrl.startsWith('http:');
+  oidcConfig = await discovery(
+    new URL(issuerUrl),
+    clientId,
+    { client_secret: clientSecret },
+    ClientSecretPost(),
+    isHttp ? { execute: [allowInsecureRequests] } : undefined,
+  );
   return oidcConfig;
 }
 


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- `openid-client` v6 (via `oauth4webapi`) forbids HTTP OIDC discovery requests by default — breaking Brett's connection to the internal Keycloak URL `http://keycloak.workspace.svc.cluster.local:8080`
- Error: `OAUTH_HTTP_REQUEST_FORBIDDEN: only requests to HTTPS are allowed`
- Fix: import `allowInsecureRequests` from `openid-client` v6 and pass it via `{ execute: [allowInsecureRequests] }` when the issuer URL is HTTP

## Test plan

- [ ] CI green (brett typecheck + unit tests)
- [ ] `task feature:brett` deploys new image to fleet
- [ ] `brett.mentolder.de` loads without internal server error
- [ ] Login via Keycloak SSO succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)