### PR TITLE
fix(brett): resolve OIDC issuer mismatch after openid-client v6 upgrade [T000538]

### DIFF
--- a/brett/src/server/auth.ts
+++ b/brett/src/server/auth.ts
@@ -1,4 +1,4 @@
-import { discovery, ClientSecretPost, allowInsecureRequests } from 'openid-client';
+import { discovery, ClientSecretPost, allowInsecureRequests, customFetch } from 'openid-client';
 import type { Configuration } from 'openid-client';
 import type { Request, Response, NextFunction } from 'express';
 
@@ -6,23 +6,45 @@ let oidcConfig: Configuration | null = null;
 
 export async function getOidcClient(): Promise<Configuration> {
   if (oidcConfig) return oidcConfig;
-  const kcUrl      = process.env.KEYCLOAK_URL || 'http://keycloak.workspace.svc.cluster.local:8080';
-  const kcRealm    = process.env.KEYCLOAK_REALM || 'workspace';
-  const clientId   = process.env.BRETT_KC_CLIENT_ID || 'brett-app';
+  const kcUrl       = process.env.KEYCLOAK_URL || 'http://keycloak.workspace.svc.cluster.local:8080';
+  const kcPublicUrl = process.env.KEYCLOAK_PUBLIC_URL || '';
+  const kcRealm     = process.env.KEYCLOAK_REALM || 'workspace';
+  const clientId    = process.env.BRETT_KC_CLIENT_ID || 'brett-app';
   const clientSecret = process.env.BRETT_OIDC_SECRET || '';
-  const issuerUrl  = `${kcUrl}/realms/${kcRealm}`;
-  const url = new URL(issuerUrl);
-  const isClusterHttp = url.protocol === 'http:' &&
-    (url.hostname === 'localhost' || url.hostname === '127.0.0.1' || url.hostname.endsWith('.svc.cluster.local'));
-  if (url.protocol === 'http:' && !isClusterHttp) {
-    throw new Error(`OIDC issuer URL must use HTTPS or a cluster-internal hostname, got: ${url.hostname}`);
+
+  const internalUrl = new URL(`${kcUrl}/realms/${kcRealm}`);
+  // When KEYCLOAK_PUBLIC_URL is set, openid-client validates the discovered issuer
+  // against the public URL while customFetch routes the actual request to the
+  // cluster-internal endpoint (avoids issuer mismatch with RFC-compliant v6).
+  const issuerUrl = kcPublicUrl ? new URL(`${kcPublicUrl}/realms/${kcRealm}`) : internalUrl;
+
+  const isClusterHttp = internalUrl.protocol === 'http:' &&
+    (internalUrl.hostname === 'localhost' || internalUrl.hostname === '127.0.0.1' || internalUrl.hostname.endsWith('.svc.cluster.local'));
+  if (internalUrl.protocol === 'http:' && !isClusterHttp) {
+    throw new Error(`OIDC issuer URL must use HTTPS or a cluster-internal hostname, got: ${internalUrl.hostname}`);
   }
+
+  const opts: Record<string | symbol, unknown> = {};
+  if (isClusterHttp) opts.execute = [allowInsecureRequests];
+  if (kcPublicUrl && kcPublicUrl !== kcUrl) {
+    opts[customFetch] = (input: Parameters<typeof fetch>[0], init?: RequestInit) => {
+      const href = typeof input === 'string' ? input : input instanceof URL ? input.href : (input as { url: string }).url;
+      const u = new URL(href);
+      if (u.hostname === issuerUrl.hostname) {
+        u.protocol = internalUrl.protocol;
+        u.host = internalUrl.host;
+        return fetch(u.toString(), init);
+      }
+      return fetch(input, init);
+    };
+  }
+
   oidcConfig = await discovery(
-    url,
+    issuerUrl,
     clientId,
     { client_secret: clientSecret },
     ClientSecretPost(),
-    isClusterHttp ? { execute: [allowInsecureRequests] } : undefined,
+    Object.keys(opts).length || Object.getOwnPropertySymbols(opts).length ? (opts as any) : undefined,
   );
   return oidcConfig;
 }

--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -1531,7 +1531,7 @@
       "id": "infra-manifests",
       "name": "Kubernetes manifests, overlays, env registry",
       "owner_agent": "bachelorprojekt-infra",
-      "file_count": 367,
+      "file_count": 368,
       "files": [
         "claude-code/gekko-android-mcp-guide.md",
         "claude-code/settings.json",
@@ -1877,6 +1877,7 @@
         "prod/mail-ingressroute.yaml",
         "prod/nextcloud-oidc-prod.php",
         "prod/old-webspace.yaml",
+        "prod/patch-brett.yaml",
         "prod/patch-claude-code-config.yaml",
         "prod/patch-docuseal.yaml",
         "prod/patch-keycloak.yaml",

--- a/prod/kustomization.yaml
+++ b/prod/kustomization.yaml
@@ -210,6 +210,7 @@ patches:
   - path: patch-oauth2-proxy-traefik.yaml
   - path: patch-oauth2-proxy-mailpit.yaml
   - path: patch-oauth2-proxy-brett.yaml
+  - path: patch-brett.yaml
   - path: patch-oauth2-proxy-comfy.yaml
   # Collabora lives in the workspace-office namespace, deployed via
   # task workspace:office:deploy — no patch target on this overlay.

--- a/prod/patch-brett.yaml
+++ b/prod/patch-brett.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: brett
+spec:
+  template:
+    spec:
+      containers:
+        - name: brett
+          env:
+            - name: KEYCLOAK_PUBLIC_URL
+              value: "https://auth.${PROD_DOMAIN}"


### PR DESCRIPTION
## Summary

- **Root cause**: openid-client v6 (oauth4webapi) is RFC-strict — it validates that the `issuer` field in the discovered OIDC metadata exactly matches the URL passed to `discovery()`. Brett uses the cluster-internal URL (`http://keycloak.workspace.svc.cluster.local:8080`) for discovery, but Keycloak advertises `https://auth.mentolder.de/realms/workspace` as its issuer → `OAUTH_JSON_ATTRIBUTE_COMPARISON_FAILED` → 500 on every auth request.
- **Fix in `auth.ts`**: when `KEYCLOAK_PUBLIC_URL` is set, `discovery()` receives the public URL (issuer check passes), and openid-client's `customFetch` symbol is used to transparently redirect the actual HTTP request to the internal cluster endpoint. Both URLs are used together — public for validation, internal for transport.
- **New prod patch** (`prod/patch-brett.yaml`): injects `KEYCLOAK_PUBLIC_URL=https://auth.${PROD_DOMAIN}` into the brett Deployment via strategic-merge patch for both brands (mentolder + korczewski).

## Test plan

- [ ] CI green (TypeScript typecheck + kustomize build)
- [ ] Build + deploy brett image: `task feature:brett`
- [ ] Verify `https://brett.mentolder.de` loads without 500 / `internal_error`
- [ ] Check logs: no more `OAUTH_JSON_ATTRIBUTE_COMPARISON_FAILED`
- [ ] Verify korczewski brand also works after deploy with `ENV=korczewski`

🤖 Generated with [Claude Code](https://claude.com/claude-code)