### PR TITLE
fix(brett): resolve OIDC issuer mismatch after openid-client v6 upgrade [T000538]

### DIFF
--- a/brett/src/server/auth.ts
+++ b/brett/src/server/auth.ts
@@ -1,4 +1,4 @@
-import { discovery, ClientSecretPost, allowInsecureRequests } from 'openid-client';
+import { discovery, ClientSecretPost, allowInsecureRequests, customFetch } from 'openid-client';
 import type { Configuration } from 'openid-client';
 import type { Request, Response, NextFunction } from 'express';
 
@@ -6,23 +6,45 @@ let oidcConfig: Configuration | null = null;
 
 export async function getOidcClient(): Promise<Configuration> {
   if (oidcConfig) return oidcConfig;
-  const kcUrl      = process.env.KEYCLOAK_URL || 'http://keycloak.workspace.svc.cluster.local:8080';
-  const kcRealm    = process.env.KEYCLOAK_REALM || 'workspace';
-  const clientId   = process.env.BRETT_KC_CLIENT_ID || 'brett-app';
+  const kcUrl       = process.env.KEYCLOAK_URL || 'http://keycloak.workspace.svc.cluster.local:8080';
+  const kcPublicUrl = process.env.KEYCLOAK_PUBLIC_URL || '';
+  const kcRealm     = process.env.KEYCLOAK_REALM || 'workspace';
+  const clientId    = process.env.BRETT_KC_CLIENT_ID || 'brett-app';
   const clientSecret = process.env.BRETT_OIDC_SECRET || '';
-  const issuerUrl  = `${kcUrl}/realms/${kcRealm}`;
-  const url = new URL(issuerUrl);
-  const isClusterHttp = url.protocol === 'http:' &&
-    (url.hostname === 'localhost' || url.hostname === '127.0.0.1' || url.hostname.endsWith('.svc.cluster.local'));
-  if (url.protocol === 'http:' && !isClusterHttp) {
-    throw new Error(`OIDC issuer URL must use HTTPS or a cluster-internal hostname, got: ${url.hostname}`);
+
+  const internalUrl = new URL(`${kcUrl}/realms/${kcRealm}`);
+  // When KEYCLOAK_PUBLIC_URL is set, openid-client validates the discovered issuer
+  // against the public URL while customFetch routes the actual request to the
+  // cluster-internal endpoint (avoids issuer mismatch with RFC-compliant v6).
+  const issuerUrl = kcPublicUrl ? new URL(`${kcPublicUrl}/realms/${kcRealm}`) : internalUrl;
+
+  const isClusterHttp = internalUrl.protocol === 'http:' &&
+    (internalUrl.hostname === 'localhost' || internalUrl.hostname === '127.0.0.1' || internalUrl.hostname.endsWith('.svc.cluster.local'));
+  if (internalUrl.protocol === 'http:' && !isClusterHttp) {
+    throw new Error(`OIDC issuer URL must use HTTPS or a cluster-internal hostname, got: ${internalUrl.hostname}`);
   }
+
+  const opts: Record<string | symbol, unknown> = {};
+  if (isClusterHttp) opts.execute = [allowInsecureRequests];
+  if (kcPublicUrl && kcPublicUrl !== kcUrl) {
+    opts[customFetch] = (input: Parameters<typeof fetch>[0], init?: RequestInit) => {
+      const href = typeof input === 'string' ? input : input instanceof URL ? input.href : (input as { url: string }).url;
+      const u = new URL(href);
+      if (u.hostname === issuerUrl.hostname) {
+        u.protocol = internalUrl.protocol;
+        u.host = internalUrl.host;
+        return fetch(u.toString(), init);
+      }
+      return fetch(input, init);
+    };
+  }
+
   oidcConfig = await discovery(
-    url,
+    issuerUrl,
     clientId,
     { client_secret: clientSecret },
     ClientSecretPost(),
-    isClusterHttp ? { execute: [allowInsecureRequests] } : undefined,
+    Object.keys(opts).length || Object.getOwnPropertySymbols(opts).length ? (opts as any) : undefined,
   );
   return oidcConfig;
 }

--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -1531,7 +1531,7 @@
       "id": "infra-manifests",
       "name": "Kubernetes manifests, overlays, env registry",
       "owner_agent": "bachelorprojekt-infra",
-      "file_count": 367,
+      "file_count": 368,
       "files": [
         "claude-code/gekko-android-mcp-guide.md",
         "claude-code/settings.json",
@@ -1877,6 +1877,7 @@
         "prod/mail-ingressroute.yaml",
         "prod/nextcloud-oidc-prod.php",
         "prod/old-webspace.yaml",
+        "prod/patch-brett.yaml",
         "prod/patch-claude-code-config.yaml",
         "prod/patch-docuseal.yaml",
         "prod/patch-keycloak.yaml",

--- a/prod/kustomization.yaml
+++ b/prod/kustomization.yaml
@@ -210,6 +210,7 @@ patches:
   - path: patch-oauth2-proxy-traefik.yaml
   - path: patch-oauth2-proxy-mailpit.yaml
   - path: patch-oauth2-proxy-brett.yaml
+  - path: patch-brett.yaml
   - path: patch-oauth2-proxy-comfy.yaml
   # Collabora lives in the workspace-office namespace, deployed via
   # task workspace:office:deploy — no patch target on this overlay.

--- a/prod/patch-brett.yaml
+++ b/prod/patch-brett.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: brett
+spec:
+  template:
+    spec:
+      containers:
+        - name: brett
+          env:
+            - name: KEYCLOAK_PUBLIC_URL
+              value: "https://auth.${PROD_DOMAIN}"


### PR DESCRIPTION
## Summary

- `openid-client` v6 validates that the discovered `issuer` exactly matches the URL passed to `discovery()`. The internal cluster URL (`http://keycloak.workspace.svc.cluster.local:8080`) returns metadata with `issuer=https://auth.<domain>/realms/workspace` — causing `OAUTH_JSON_ATTRIBUTE_COMPARISON_FAILED`.
- Fix: pass the public URL to `discovery()` when `KEYCLOAK_PUBLIC_URL` is set; use openid-client's `customFetch` symbol to transparently route the actual HTTP request to the internal cluster endpoint.
- Prod patch adds `KEYCLOAK_PUBLIC_URL=https://auth.${PROD_DOMAIN}` via `prod/patch-brett.yaml` for both brands.

## Files changed

- `brett/src/server/auth.ts` — discovery URL / customFetch routing logic
- `prod/patch-brett.yaml` — new env var for prod deployments  
- `prod/kustomization.yaml` — wires in the new patch

## Test plan

- [ ] Brett login redirects to Keycloak and back without `OAUTH_JSON_ATTRIBUTE_COMPARISON_FAILED`
- [ ] `brett.mentolder.de` accessible after deploy
- [ ] `brett.korczewski.de` accessible after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)