### PR TITLE
fix(brett): guard getScene() in onWsMessage against pre-scene WebSocket messages

### DIFF
--- a/brett/src/client/ws-client.ts
+++ b/brett/src/client/ws-client.ts
@@ -217,15 +217,19 @@ export function onWsMessage(evt: MessageEvent): void {
     return;
   }
 
-  const { scene } = getScene();
   const presets = PRESETS;
   const stiffSlider = document.getElementById('stiffness') as HTMLInputElement | null;
 
   switch (msg.type) {
-    case 'snapshot':
+    case 'snapshot': {
+      // scene may not be initialized yet when main.ts connects the WS early
+      // (before bootBoard()/initScene()). Process lobby/phase parts regardless;
+      // skip scene-graph mutations until the scene is ready.
+      let sceneForSnapshot: ReturnType<typeof getScene> | null = null;
+      try { sceneForSnapshot = getScene(); } catch { /* pre-scene lobby snapshot */ }
       // Reset world from server state
       for (const f of STATE.figures) {
-        scene.remove(f.root);
+        sceneForSnapshot?.scene.remove(f.root);
       }
       STATE.figures.length = 0;
       STATE.selectedId = null;
@@ -330,6 +334,7 @@ export function onWsMessage(evt: MessageEvent): void {
         optik: (msg as any).optik ?? null,
       });
       break;
+    }
 
     case 'stiffness':
       STATE.stiffness = msg.value;
@@ -420,7 +425,7 @@ export function onWsMessage(evt: MessageEvent): void {
     case 'delete': {
       const idx = STATE.figures.findIndex(f => f.id === msg.id);
       if (idx >= 0) {
-        scene.remove(STATE.figures[idx].root);
+        try { getScene().scene.remove(STATE.figures[idx].root); } catch { /* pre-scene */ }
         // Billboard-Cleanup (Feature-Flag sf-t000469)
         import('./ui/hud').then(m => {
           if (typeof (m as any).clearFigureNoteBillboard === 'function') {


### PR DESCRIPTION
## Summary

- `main.ts` opens the WebSocket before `bootBoard()`/`initScene()` runs so the lobby bootstrap can route phase/snapshot messages to the view-machine.
- If the server sends any message (e.g. `snapshot`) before the Three.js scene is initialized, the unconditional `getScene()` call at the top of `onWsMessage` throws `Error: scene not initialized`.
- This manifested as `Uncaught Error: scene not initialized at Te (index-...js) at WebSocket.Rr (ws-client-...js)` in the browser console on fresh board load.

## Fix

Move `getScene()` out of the top-level and into the two `case` branches that actually need it (`snapshot` and `delete`). Both now wrap the call in `try/catch` — if the scene isn't ready the `scene.remove()` is skipped, but all lobby/phase/state parts still process normally.

## Test plan

- [ ] Open Brett in a new browser tab — no `scene not initialized` error in console
- [ ] Figures appear correctly on join (snapshot processed)
- [ ] Delete a figure — scene updates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)