### PR TITLE
chore: commit pending dispatcher fixes and AGENTS.md/docuseal improvements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,1 +1,152 @@
-CLAUDE.md
+# AGENTS.md — High-Signal Reference for AI Agents
+
+## Agent Routing
+
+Check these signals before acting; delegate to the named sub-agent when they match:
+
+| Signals | Agent |
+|---------|-------|
+| `website/`, Astro, Svelte, component, homepage, kore, brand, CSS, UI, frontend, design | `bachelorprojekt-website` |
+| pod, logs, status, restart, crash, health, kubectl, "what's wrong", "why is X failing", "is X running" | `bachelorprojekt-ops` |
+| `k3d/`, `prod*/`, manifest, kustomize, overlay, Taskfile, `ENV=`, `environments/`, deploy | `bachelorprojekt-infra` |
+| test, `FA-*`, `SA-*`, `NFA-*`, `AK-*`, BATS, Playwright, `runner.sh` | `bachelorprojekt-test` |
+| database, PostgreSQL, psql, schema, query, backup, restore, `v_timeline` | `bachelorprojekt-db` |
+| SealedSecret, Keycloak realm, OIDC, DSGVO, credentials, rotate, certificate, secret | `bachelorprojekt-security` |
+
+Before dispatching any agent: `bash scripts/plan-context.sh <role>` → prepend output as `<active-plans>`. Tie-break: prefer domain of files being changed. Cross-cutting requests stay with orchestrator.
+
+## Core Commands
+
+```bash
+# Task oracle — primary CLI. Never hardcode task paths.
+bash scripts/task-oracle.sh '<goal in plain English>'
+
+# Dev cluster (k3d, default ENV=dev)
+task cluster:create && task workspace:deploy && task workspace:office:deploy && task workspace:post-setup
+
+# Tests
+./tests/runner.sh local            # full suite against k3d
+./tests/runner.sh local FA-01      # single test (IDs: FA-*, SA-*, NFA-*, AK-*)
+task test:all                      # offline suite (BATS + manifests + dry-run)
+
+# Prod — ENV= is always explicit
+task workspace:deploy ENV=mentolder
+task feature:deploy                # fan-out to both brands
+```
+
+## Workflow
+
+- Branch naming: `feature/*`, `fix/*`, `chore/*`
+- All changes via PRs → squash-and-merge. No direct pushes to `main`.
+- For structured work: invoke `dev-flow-plan` skill (plan → push) then `dev-flow-execute` (implement → PR → deploy).
+- CI must be green: `task test:all` before commit.
+- Validate manifests: `task workspace:validate`.
+
+## Architecture
+
+- **Fleet cluster** (single k3s): mentolder → ns `workspace`, korczewski → ns `workspace-korczewski`. Both run on `fleet` context.
+- **k3d/ is base** for all Kustomize manifests. Prod overlays: `prod-fleet/mentolder/` and `prod-fleet/korczewski/`.
+- **No GitOps** — deploy is push-based (`task workspace:deploy ENV=<brand>`). Only website auto-deploys via GH Actions.
+- **Centralized domains**: `k3d/configmap-domains.yaml` — never hardcode hostnames.
+- **Secrets flow**: plaintext `environments/.secrets/<env>.yaml` → `task env:seal ENV=<env>` → SealedSecret in `environments/sealed-secrets/`.
+- Cross-cutting DB/OIDC changes apply to **both** `workspace` and `workspace-korczewski` namespaces explicitly.
+
+## Critical Footguns
+
+- **`scripts/env-resolve.sh` must be sourced, not executed.** `bash scripts/env-resolve.sh` exits the parent shell.
+- **Adding `${VAR}` to a manifest?** Register in `environments/schema.yaml` AND the `envsubst` list in every Taskfile task that builds that manifest.
+- **Never SELECT * from `tickets.ticket_plans`** — `content` column is multi-MB markdown. Query metadata columns or filter by id/slug.
+- **`docs:sync` does NOT work** — container rootfs is read-only. Deploy via `task docs:deploy`.
+- **Website, Brett, Docs images use `:latest` intentionally** — don't "fix" to digests.
+- **`env:generate ENV=<target>` must run before `env:seal`** — talk-hpb-setup.sh aborts on placeholder values.
+- **Cluster reset order**: sealed-secrets:install → env:fetch-cert → env:seal → cert:install → cert:secret → workspace:deploy.
+
+## Agent Coordination
+
+Multiple agent sessions share one checkout. Use:
+
+```bash
+bash scripts/agent-lock.sh reap    # start of every session
+bash scripts/agent-lock.sh claim ticket <id> --branch <b> --worktree <wt> --label <skill>
+bash scripts/agent-lock.sh release ticket <id>
+bash scripts/agent-lock.sh list    # see who is doing what
+```
+
+Use worktrees (`scripts/worktree-create.sh`) for isolation — main-checkout commits are gated by agent-lock.
+
+## Task Reference
+
+Use `bash scripts/task-oracle.sh '<goal>'` when unsure — it routes to the right task. The groups below are for quick orientation.
+
+**Daily workflow**
+```
+task test:all                          # before every push (offline CI)
+task freshness:regenerate              # after modifying generated artifacts
+task workspace:validate                # validate manifests without deploying
+task feature:website                   # rebuild + deploy website on both brands
+task feature:brett                     # rebuild + deploy brett on both brands
+task feature:deploy                    # all workspace changes on both brands
+task workspace:deploy ENV=mentolder    # single brand deploy
+```
+
+**Dev cluster**
+```
+task up / task down / task clean
+task cluster:create|delete|start|stop|status
+task dev:deploy                        # build images + apply manifests to k3d
+task dev:redeploy:website|brett        # fast redeploy single service
+task dev:db:refresh                    # restore prod snapshot into dev DB
+task website:dev                       # Astro hot-reload dev server
+```
+
+**Tests**
+```
+task test:all          # BATS unit + factory + agent-lock + manifests + dry-run
+task test:unit         # BATS only
+task test:manifests    # kustomize structure check
+task test:factory      # FA-SF bats (Software Factory)
+task test:e2e ENV=mentolder            # Playwright E2E
+task test:e2e:all-prods               # E2E against both brands
+```
+
+**Secrets & environments**
+```
+task secrets:unlock KEY=<path>
+task env:seal ENV=<brand>
+task env:fetch-cert ENV=<brand>
+task env:generate ENV=<brand>
+task secrets:sync                      # apply SealedSecrets to both clusters
+```
+
+**Ops / health**
+```
+task health                            # cross-cluster health check
+task workspace:status:all-prods        # pod/svc/ingress/PVC on both brands
+task workspace:verify ENV=<brand>      # post-deploy sanity check
+task workspace:backup ENV=<brand>      # trigger immediate DB backup
+task workspace:db:restore -- <db> <ts> # restore DB from backup
+task recovery:browse ENV=<brand>       # SSO-gated file recovery UI
+```
+
+**Software Factory (autopilot)**
+```
+task factory:autopilot:install|status|uninstall
+task factory:enqueue -- <T-ID> <branch> <plan-file>
+```
+
+**Service-specific**
+```
+task brett:deploy|sync|logs|bot-setup ENV=...
+task website:deploy|sync|logs|restart ENV=...
+task arena:deploy|logs|status ENV=...
+task keycloak:sync ENV=...
+task llm:deploy|status|test ENV=...
+task openclaw:start|status|logs
+task docs:deploy
+```
+
+## Important Links
+
+- `website/CLAUDE.md` — Astro/Svelte dev quick-start, content model, adding service pages, footguns
+- `docs/agent-guide/README.md` — agent operating guide registry (taxonomy, guardrails, tools, goals)
+- `CONTRIBUTING.md` — human-readable dev workflow, PR expectations

--- a/k3d/docuseal.yaml
+++ b/k3d/docuseal.yaml
@@ -105,6 +105,13 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /data
+          startupProbe:
+            httpGet:
+              path: /
+              port: 3000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 30
           readinessProbe:
             httpGet:
               path: /

--- a/scripts/factory/dispatcher.js
+++ b/scripts/factory/dispatcher.js
@@ -109,8 +109,18 @@ async function main() {
      If a guard read errors (non-zero with no documented meaning), fail-closed: skip that brand.
      If a ticket has no plan reference, set branch and plan_path to null.
      If nothing was claimed across both brands, return { "launch": [], "skipped": [...] }.`,
-    { label: 'prep', phase: 'Prep', schema: PLAN_SCHEMA, model: 'sonnet' },
+    { label: 'prep', phase: 'Prep', schema: PLAN_SCHEMA },
   )
+
+  // Guard: PREP agent returned null (API error, model config mismatch, or subagent failure).
+  // Fail-closed — record the outage and exit cleanly so the /loop can retry next tick.
+  if (!prep || !prep.launch) {
+    log(
+      `Dispatcher: PREP step returned null (agent error). No brands processed this tick. ` +
+        `Raw prep value: ${JSON.stringify(prep)}. Retrying next tick.`,
+    )
+    return
+  }
 
   log(
     `Dispatcher: ${prep.launch.length} feature(s) scheduled this tick (${A.timestamp ?? 'no timestamp'})`,
@@ -169,7 +179,7 @@ async function main() {
          bash ${REPO}/scripts/ticket.sh add-comment --id T000413 \\
            --body ${JSON.stringify('Factory dispatcher: ' + escalations.length + ' run(s) escalated this tick.')}
        Report what was notified and the ticket-comment output.`,
-      { label: 'escalate', phase: 'Launch', model: 'sonnet' },
+      { label: 'escalate', phase: 'Launch' },
     )
   } else {
     log(`Dispatcher: all ${results?.length ?? 0} pipeline run(s) completed without error/block.`)
@@ -182,7 +192,7 @@ async function main() {
        BRAND=mentolder bash ${REPO}/scripts/factory/metrics.sh
        BRAND=korczewski bash ${REPO}/scripts/factory/metrics.sh
      (metrics.sh is best-effort: a missing Vorhaben ticket on a brand is a silent no-op.)`,
-    { label: 'metrics', phase: 'Metrics', model: 'sonnet' },
+    { label: 'metrics', phase: 'Metrics' },
   )
 }
 await main();

--- a/scripts/factory/run-dispatcher.sh
+++ b/scripts/factory/run-dispatcher.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# scripts/factory/run-dispatcher.sh — wrapper that unsets CLAUDE_CODE_EFFORT_LEVEL
+# before invoking the dispatcher via a fresh `claude -p` session.
+# This is the same pattern as wakeup.sh:69 — the env var MUST be unset for
+# Workflow subagents to work with DeepSeek. [T000519]
+set -euo pipefail
+unset CLAUDE_CODE_EFFORT_LEVEL
+REPO="${FACTORY_REPO:-/home/patrick/Bachelorprojekt}"
+cd "${REPO}"
+TIMESTAMP="${1:-$(date -u +%FT%TZ)}"
+DRY_RUN="${2:-false}"
+PROMPT="Run the Software Factory dispatcher now. Invoke the Workflow tool with \
+scriptPath 'scripts/factory/dispatcher.js' and args { timestamp: '${TIMESTAMP}', dry_run: ${DRY_RUN} }. \
+The dispatcher reads all guards (kill-switch, daily-cap, dry-run-first) fresh per brand inside its PREP step. \
+Report only the dispatcher's final JSON result. Do not improvise scheduling."
+exec claude -p "${PROMPT}" \
+  --allowedTools "Workflow,Bash(bash scripts/factory/*),Bash(bash scripts/ticket.sh*),ToolSearch,PushNotification" \
+  --permission-mode acceptEdits


### PR DESCRIPTION
## Summary

- **dispatcher.js**: `model:'sonnet'`-Pin bei prep/escalate/metrics entfernt (erben jetzt Session-Modell); PREP-Null-Guard für sauberes fail-closed-Verhalten bei API-Fehler (T000519-Nachlauf)
- **run-dispatcher.sh**: Neuer `CLAUDE_CODE_EFFORT_LEVEL`-Unset-Wrapper für `claude -p`-Aufruf (analoges Muster zu `wakeup.sh`)
- **AGENTS.md**: Symlink → Standalone-Datei (Gemini/Codex-Agent-Kompatibilität)
- **docuseal.yaml**: `startupProbe` ergänzt (failureThreshold 30) gegen verfrühte Readiness-Failures beim langsamen DocuSeal-Boot

Closes T000543

## Test plan

- [ ] CI grün (`task test:all` offline-Tests)
- [ ] `scripts/factory/run-dispatcher.sh` ist ausführbar und enthält korrektes `unset CLAUDE_CODE_EFFORT_LEVEL`

🤖 Generated with [Claude Code](https://claude.com/claude-code)