### PR TITLE
test(factory): update FA-SF-30 guard — no model pins required post-T000543

### DIFF
--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -1909,7 +1909,7 @@
       "id": "scripts-infra",
       "name": "Operational + build scripts",
       "owner_agent": "bachelorprojekt-infra",
-      "file_count": 263,
+      "file_count": 264,
       "files": [
         "scripts/add-whiteboard-library.py",
         "scripts/admin-menu-gate.sh",
@@ -2067,6 +2067,7 @@
         "scripts/factory/review-pattern-enforcer.prompt.md",
         "scripts/factory/review-perf-reviewer.prompt.md",
         "scripts/factory/review-security-auditor.prompt.md",
+        "scripts/factory/run-dispatcher.sh",
         "scripts/factory/schedule.sh",
         "scripts/factory/shared-state-allowlist.txt",
         "scripts/factory/slots.sh",

--- a/tests/local/FA-SF-30-dispatcher-contract.bats
+++ b/tests/local/FA-SF-30-dispatcher-contract.bats
@@ -56,13 +56,14 @@ setup() { load 'test_helper.bash'; }
   run grep -Eq "\.error|status === 'blocked'|status: *'blocked'|blocked" "$SCRIPT"; [ "$status" -eq 0 ]
 }
 
-@test "FA-SF-30: every agent() opts pins an explicit model (DeepSeek reasoning_effort 400 guard — T000528)" {
-  # The dispatcher runs under DeepSeek-backed autopilot; an agent() call that inherits the
-  # ambient model config trips the 'thinking cannot be disabled when reasoning_effort is set'
-  # 400 and fails PREP. Each agent() opts (prep/escalate/metrics) must pin model: explicitly.
-  # Sibling guard to the pipeline.js fix (T000519/#1430).
+@test "FA-SF-30: agent() opts do NOT pin a model (T000543/#1466 — inherit session model via run-dispatcher.sh)" {
+  # T000519/#1430 fixed the DeepSeek 400 by unsetting CLAUDE_CODE_EFFORT_LEVEL in wakeup.sh
+  # and run-dispatcher.sh, so the ambient config no longer carries reasoning_effort.
+  # T000543/#1466 then intentionally removed the model: pins so the dispatcher inherits the
+  # session model from the invoker (DeepSeek or Anthropic), keeping dispatch flexible.
+  # Guard: verify all 3 agent labels are present but none carry a hard model: pin.
   labels=$(grep -cE "label: '(prep|escalate|metrics)'" "$SCRIPT")
   [ "$labels" -eq 3 ]
-  pinned=$(grep -E "label: '(prep|escalate|metrics)'" "$SCRIPT" | grep -c "model:")
-  [ "$pinned" -eq 3 ]
+  pinned=$(grep -E "label: '(prep|escalate|metrics)'" "$SCRIPT" | grep "model:" | wc -l)
+  [ "$pinned" -eq 0 ]
 }


### PR DESCRIPTION
## Summary

- FA-SF-30 was added as a guard against the DeepSeek 400 error (reasoning_effort/thinking conflict) by requiring explicit `model:` pins on `prep`/`escalate`/`metrics` agent() calls
- T000519/#1430 fixed the root cause by unsetting `CLAUDE_CODE_EFFORT_LEVEL` in `wakeup.sh` and `run-dispatcher.sh`
- T000543/#1466 then intentionally removed the model pins so the dispatcher inherits the invoker's session model
- The FA-SF-30 test was never updated → CI failures on all subsequent PRs (including #1469, #1470)

**Fix:** Invert the assertion (0 model pins expected instead of 3) and switch `grep -c` to `wc -l` to avoid exit-1 on zero matches under bats `set -e`.

## Test plan

- [x] `task test:factory` passes locally (all 222 tests green)
- [x] FA-SF-30 bats file runs clean in isolation
- [x] Same fix applied to PR #1469 and #1470 branches to unblock their CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)