### PR TITLE
chore(hooks): pre-push freshness warning for .bats changes [T000553]

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Warn if .bats files changed but repo-index.json is not part of this push. [T000553]
+# Fail-open: only prints a warning, never blocks the push.
+set -uo pipefail
+
+warn() { printf '⚠  pre-push: %s\n' "$*" >&2; }
+
+# Determine range of commits being pushed
+REMOTE="$1"
+URL="$2"
+while IFS=' ' read -r LOCAL_REF LOCAL_SHA REMOTE_REF REMOTE_SHA; do
+  [[ "$LOCAL_SHA" == "0000000000000000000000000000000000000000" ]] && continue
+  BASE="${REMOTE_SHA:-}"
+  if [[ -z "$BASE" || "$BASE" == "0000000000000000000000000000000000000000" ]]; then
+    BASE=$(git rev-parse --verify "origin/main" 2>/dev/null || git rev-parse --verify "HEAD~1" 2>/dev/null || true)
+  fi
+  [[ -z "$BASE" ]] && continue
+
+  CHANGED_BATS=$(git diff --name-only "$BASE..$LOCAL_SHA" 2>/dev/null | grep '\.bats$' || true)
+  [[ -z "$CHANGED_BATS" ]] && continue
+
+  CHANGED_INDEX=$(git diff --name-only "$BASE..$LOCAL_SHA" 2>/dev/null | grep 'repo-index\.json\|test-inventory\.json' || true)
+  if [[ -z "$CHANGED_INDEX" ]]; then
+    warn "BATS-Dateien geändert, aber repo-index.json/test-inventory.json fehlen im Push."
+    warn "CI schlägt möglicherweise fehl. Fix:"
+    warn "  task freshness:regenerate"
+    warn "  git add docs/code-quality/repo-index.json website/src/data/test-inventory.json"
+    warn "  git commit --amend --no-edit && git push --force-with-lease"
+  fi
+done
+
+exit 0

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1032,6 +1032,7 @@ tasks:
     cmds:
       - git config core.hooksPath .githooks
       - chmod +x .githooks/pre-commit
+      - chmod +x .githooks/pre-push
       - echo "hooksPath set to .githooks"
 
   secrets:unlock:


### PR DESCRIPTION
## Summary
- Adds `.githooks/pre-push` that warns when `.bats` files change but `repo-index.json` / `test-inventory.json` are absent from the push
- Fail-open (exit 0 always) — prints a recovery hint but never blocks the push
- Adds `chmod +x .githooks/pre-push` to `secrets:install-hooks`

## Motivation
T000553: After adding FA-SF-30 update, repo-index.json was not regenerated in PR worktrees and CI failed at the freshness:check step. This hook catches the pattern early.

## Test plan
- [ ] `task secrets:install-hooks` runs without error
- [ ] Push a branch with a `.bats` change but without updated `repo-index.json` → warning appears, push succeeds
- [ ] Push with both `.bats` + `repo-index.json` updated → no warning

Closes T000553

🤖 Generated with [Claude Code](https://claude.com/claude-code)