### PR TITLE
chore(skills): haiku spec-reviewer false negatives → sonnet + grep [T000551]

### DIFF
--- a/.claude/skills/references/subagent-provisioning.md
+++ b/.claude/skills/references/subagent-provisioning.md
@@ -20,6 +20,12 @@ Klassifiziere die Aufgabe nach **Komplexität × Risiko × Rolle**:
 Im Zweifel **eine Stufe höher**. Wenn unsicher, ob ein Spezial-Modell überhaupt passt: **`model` weglassen**
 → der Subagent erbt das Main-Loop-Modell (fast immer korrekt).
 
+> **⚠ Haiku-Fußangel bei Spec-Reviews [T000551]:** Haiku liest ohne expliziten `limit`-Parameter nur
+> die ersten ~80 Zeilen einer Datei und liefert daher false negatives bei Spec-Compliance-Prüfungen
+> über mehrere Dateien. **Spec-Reviewer-Subagenten müssen `sonnet` oder besser verwenden.**
+> Zusätzlich: Im Prompt explizit `grep`-basierte Verifikation verlangen statt blindem `Read()` — das
+> umgeht sowohl das Zeilenlimit als auch potenzielle Read-Caching-Artefakte.
+
 ## 2. Effort (per Prompt-Direktive)
 
 Das `Agent`/`Task`-Tool kennt **nur `model`, keinen Effort-Regler** — Effort wird über die Prompt-Einleitung vermittelt:


### PR DESCRIPTION
## Summary
- Adds a ⚠ warning block in `subagent-provisioning.md` about Haiku's ~80-line read limit causing false negatives in spec compliance reviews
- Directs spec-reviewer subagents to use `sonnet` or better
- Recommends grep-based verification in reviewer prompts to avoid Read() caching artifacts

## Motivation
T000551: During T000544 (Tasks 4+5), the Haiku spec-reviewer read stale/incomplete file versions and falsely reported missing implementations. Root cause: Haiku's default Read() without `limit` stops at ~80 lines.

## Test plan
- [ ] `subagent-provisioning.md` contains the new warning block
- [ ] Next time `superpowers:subagent-driven-development` is invoked, orchestrator sees the note and provisions spec reviewer with sonnet

Closes T000551

🤖 Generated with [Claude Code](https://claude.com/claude-code)