### PR TITLE
fix(brainstorm): fast cluster-reachability check before tunnel/status [T000541]

### DIFF
--- a/Taskfile.brainstorm.yml
+++ b/Taskfile.brainstorm.yml
@@ -37,10 +37,18 @@ tasks:
         if [[ -z "$PORT" ]]; then
           echo "Usage: task brainstorm:publish -- <localport>" >&2; exit 2
         fi
+        # Proactively check dev-cluster reachability before attempting the tunnel [T000541]
+        if ! kubectl --context {{.CTX_DEV}} cluster-info --request-timeout=3s >/dev/null 2>&1; then
+          echo "⚠  Dev-Cluster ({{.CTX_DEV}}) nicht erreichbar — Tunnel nicht möglich." >&2
+          echo "   Fallback: Companion läuft lokal auf http://localhost:$PORT" >&2
+          echo "   Starte den Companion mit: node scripts/companion.js $PORT" >&2
+          exit 1
+        fi
         echo "Publishing localhost:$PORT as https://brainstorm.$DEV_DOMAIN — leave this terminal open."
         echo "  ssh -p {{.SSH_PORT}} -R brainstorm:80:localhost:$PORT tunnel@$DEV_DOMAIN"
         exec ssh -p {{.SSH_PORT}} -N \
           -o StrictHostKeyChecking=accept-new \
+          -o ConnectTimeout=5 \
           -o ServerAliveInterval=30 \
           -o ServerAliveCountMax=3 \
           -o ExitOnForwardFailure=yes \
@@ -88,6 +96,13 @@ tasks:
       - |
         set -euo pipefail
         source scripts/env-resolve.sh "{{.ENV}}"
+        # Quick reachability check first to avoid a long kubectl timeout [T000541]
+        if ! kubectl --context {{.CTX_DEV}} cluster-info --request-timeout=3s >/dev/null 2>&1; then
+          echo "⚠  Dev-Cluster ({{.CTX_DEV}}) nicht erreichbar."
+          echo "   Brainstorm-Tunnel ist nicht verfügbar. Fallback: lokaler Companion auf localhost:<port>"
+          echo "   Sobald der Dev-Cluster wieder läuft: task brainstorm:publish -- <port>"
+          exit 0
+        fi
         kubectl --context {{.CTX_DEV}} -n {{.NS_DEV}} get pod -l app=sish -o wide
         echo "── HTTPS probe ────────────────────────────────────────────"
         curl -sSI --max-time 5 "https://brainstorm.${DEV_DOMAIN}/" || true


### PR DESCRIPTION
## Summary
- `brainstorm:status` and `brainstorm:publish` now probe `kubectl cluster-info --request-timeout=3s` before any kubectl/SSH operation
- When dev-cluster is unreachable: immediately prints localhost fallback hint (no 15s timeout)
- `publish` exits with code 1 (informational) when cluster is down; `status` exits 0 (non-blocking diagnostic)
- Adds `ConnectTimeout=5` to SSH options as a belt-and-suspenders cap

## Motivation
T000541: `brainstorm.dev.mentolder.de` was unreachable on 2026-06-08 because the dev-cluster returned "no route to host". `brainstorm:status` and `brainstorm:publish` timed out after 15s instead of immediately suggesting the localhost fallback.

## Test plan
- [ ] With `k3d-mentolder-dev` unreachable: `task brainstorm:status` exits quickly with fallback hint
- [ ] With cluster up: `task brainstorm:status` shows pod list + HTTPS probe as before

Closes T000541

🤖 Generated with [Claude Code](https://claude.com/claude-code)