### PR TITLE
fix(brett): ghost participant + missing start button on new session

### DIFF
--- a/brett/src/server/ws-admin-commands.ts
+++ b/brett/src/server/ws-admin-commands.ts
@@ -58,7 +58,7 @@ export async function handleAdminMessage(ws: any, msg: any, adminRoom: string, d
       break;
     }
     case 'admin_session_create': {
-      const playerId = ws._playerId || ws._session?.name;
+      const playerId = resolvePlayerId(ws);
       if (!playerId) return;
       // CP-2: do NOT silently reset a LIVE session back to lobby. A raw
       // session_phase_set bypasses the per-edge transition allowlist
@@ -103,8 +103,8 @@ export async function handleAdminMessage(ws: any, msg: any, adminRoom: string, d
     }
     case 'admin_handoff_token': {
       if (typeof msg.targetPlayerId !== 'string') return;
-      const fromPlayerId = ws._playerId || ws._session?.name;
-      if (!fromPlayerId) return;
+      const fromPlayerId = resolvePlayerId(ws);
+      if (!fromPlayerId || fromPlayerId === 'anon') return;
       deps.handleAdminHandoffMessage(adminRoom, fromPlayerId, msg.targetPlayerId, (out: any) => deps.broadcast(adminRoom, out));
       deps.schedulePersist(adminRoom);
       break;

--- a/brett/test/lobby-admin-session-create.test.ts
+++ b/brett/test/lobby-admin-session-create.test.ts
@@ -42,6 +42,27 @@ test('admin_session_create registers the creator as a leiter participant', async
   assert.strictEqual(join.participant.ready, false);
 });
 
+// REG: when _playerId is unset (no active session at join time), resolvePlayerId falls
+// back to _session.userId so the creator uses their OIDC UUID, not their display name.
+test('admin_session_create uses _session.userId when _playerId is unset', async () => {
+  const room = 'admin-create-oidc-fallback';
+  const collected: any[] = [];
+  const ws = { _playerId: undefined, _session: { name: 'Coach OIDC', userId: 'oidc-uuid-42' }, send: () => {} };
+
+  await handleAdminMessage(ws, { type: 'admin_session_create' }, room, makeDeps(collected));
+
+  const parts = listParticipants(room);
+  assert.strictEqual(parts.some((p: any) => p.userId === 'oidc-uuid-42'), true,
+    'creator must be keyed by OIDC userId, not by display name');
+  assert.strictEqual(parts.some((p: any) => p.userId === 'Coach OIDC'), false,
+    'display name must not be used as userId');
+
+  const join = collected.find((m: any) => m.type === 'presence_join');
+  assert.ok(join, 'expected a presence_join broadcast');
+  assert.strictEqual(join.participant.userId, 'oidc-uuid-42');
+  assert.strictEqual(join.participant.role, 'leiter');
+});
+
 test('admin_session_create clears stale participants before adding the creator', async () => {
   const room = 'admin-create-stale';
   const collected: any[] = [];


### PR DESCRIPTION
## Summary

- **Ghost-Teilnehmer entfernt**: Beim Erstellen einer neuen Session ohne vorherige aktive Session wurde `ws._playerId` im Join-Handler nicht gesetzt (der Teilnehmer-Block ist hinter `if (activeState && activeState.sessionCode)` geblockt). `admin_session_create` fiel dadurch auf `ws._session?.name` (Anzeigename) als playerId zurück — statt auf die OIDC-UUID. Beim nächsten Reconnect verwendete der Join-Handler die korrekte UUID, was zu zwei Roster-Einträgen mit gleichem Anzeigenamen führte.
- **Start-Button wiederhergestellt**: `isLeader` prüfte die UUID des Nutzers, aber die leiter-Rolle war auf dem Anzeigenamen-Key gespeichert → `false` → kein Start-Button.
- **Fix**: `resolvePlayerId(ws)` in `admin_session_create` und `admin_handoff_token` verwenden (gibt `ws._session?.userId ?? ws._playerId ?? 'anon'` zurück — liest OIDC-UUID auch ohne vorher gesetztes `_playerId`).
- **Regressionstest** hinzugefügt, der den Fall `_playerId=undefined` + `_session.userId` abdeckt.

## Test plan

- [ ] 483 bestehende Tests grün (`npm test` im `brett/`-Verzeichnis)
- [ ] Neuer Test `admin_session_create uses _session.userId when _playerId is unset` grün
- [ ] Manuell: Neue Session erstellen → nur ein Patrick in der Teilnehmerliste
- [ ] Manuell: Start-Button für den Session-Ersteller sichtbar
- [ ] Manuell: Solo-Session startbar (kein anderer Teilnehmer nötig)

🤖 Generated with [Claude Code](https://claude.com/claude-code)