### PR TITLE
fix(sidekick): Drawer schließen beim Klick auf Lernpfad [T000558]

### DIFF
--- a/website/src/components/PortalSidekick.svelte
+++ b/website/src/components/PortalSidekick.svelte
@@ -233,6 +233,7 @@
     {#if view === 'home'}
       <SidekickHome
         onNavigate={navigate}
+        onClose={closeDrawer}
         {pendingQuestionnaires}
         {helpSection}
         {helpContext}

--- a/website/src/components/assistant/SidekickHome.svelte
+++ b/website/src/components/assistant/SidekickHome.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
   import { decideBanner, type BannerDecision } from '../../lib/assistant/sidekick-nudge';
 
-  type View = 'home' | 'support' | 'questionnaire' | 'help' | 'tickets' | 'inbox' | 'agent-guide' | 'loslernen';
+  type View = 'home' | 'support' | 'questionnaire' | 'help' | 'tickets' | 'inbox' | 'agent-guide';
 
   let {
     onNavigate,
+    onClose,
     pendingQuestionnaires = 0,
     helpSection = '',
     helpContext = 'portal',
@@ -13,6 +14,7 @@
     summary = null,
   }: {
     onNavigate: (view: View) => void;
+    onClose?: () => void;
     pendingQuestionnaires?: number;
     helpSection?: string;
     helpContext?: string;
@@ -79,6 +81,7 @@
           class:sk-row--hover={hover === item.id}
           onmouseenter={() => hover = item.id}
           onmouseleave={() => hover = null}
+          onclick={() => onClose?.()}
           role="listitem"
           aria-label="{item.title} — {item.sub}"
         >


### PR DESCRIPTION
## Problem

Der **Lernpfad**-Eintrag im Sidekick-Menü (`SidekickHome.svelte`) war ein `<a href="/portal/loslernen">` Link. Beim Klick navigierte er zur Seite, aber der Sidekick-Drawer (`z-index: 9050`) blieb geöffnet und überlagerte den gesamten Lernpfad-Inhalt.

Zusätzlich hatte `SidekickHome` den Typ `'loslernen'` im lokalen `View`-Typ, obwohl dieser Wert nie an `onNavigate` übergeben wird (er ist ein Link, kein View-Wechsel).

## Lösung

- `onClose?: () => void` Prop zu `SidekickHome` hinzugefügt
- `onclick={() => onClose?.()}` auf alle `href`-basierten Link-Elemente gesetzt — Drawer schließt vor der Navigation
- `onClose={closeDrawer}` von `PortalSidekick` an `SidekickHome` übergeben
- `'loslernen'` aus dem lokalen `View`-Typ entfernt (Type-Konsistenz)

## Test plan

- [ ] Sidekick öffnen → auf "Lernpfad" klicken → Drawer schließt, `/portal/loslernen` wird angezeigt ohne Überlagerung
- [ ] Alle anderen Menü-Einträge (Buttons) funktionieren unverändert
- [ ] Vitest: 704/704 ✅
- [ ] TypeScript: keine neuen Errors ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)