### PR TITLE
chore(ci): auto-deploy Brett und Docs on push to main

### DIFF
--- a/.github/workflows/build-brett.yml
+++ b/.github/workflows/build-brett.yml
@@ -2,7 +2,8 @@ name: Build Brett
 
 on:
   push:
-    tags: ['brett-v*']
+    branches: [main]
+    paths: ['brett/**']
 
 jobs:
   build:
@@ -15,9 +16,6 @@ jobs:
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
 
-      # Quality gate: a tag cut from a branch that skipped PR CI cannot ship a
-      # type-broken or test-failing image. Typecheck is a no-op until brett's TS
-      # refactor lands (npm run --if-present), then enforces automatically.
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444  # v5
         with:
           node-version: '22'
@@ -32,12 +30,9 @@ jobs:
         env:
           MOCK_DB: 'true'
 
-      - name: Extract version from tag
+      - name: Get short SHA
         id: version
-        run: |
-          TAG="${GITHUB_REF_NAME}"           # brett-v1.2.3
-          VERSION="${TAG#brett-v}"           # 1.2.3
-          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+        run: echo "sha=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
@@ -49,13 +44,13 @@ jobs:
       - name: Build & push Docker image
         run: |
           IMAGE="ghcr.io/paddione/workspace-brett"
-          VERSION="${{ steps.version.outputs.version }}"
+          SHA="${{ steps.version.outputs.sha }}"
           docker build \
-            -t "${IMAGE}:v${VERSION}" \
+            -t "${IMAGE}:sha-${SHA}" \
             -t "${IMAGE}:latest" \
             -f brett/Dockerfile \
             brett
-          docker push "${IMAGE}:v${VERSION}"
+          docker push "${IMAGE}:sha-${SHA}"
           docker push "${IMAGE}:latest"
 
       - name: Deploy to mentolder

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -2,7 +2,11 @@ name: Build Docs
 
 on:
   push:
-    tags: ['docs-v*']
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - 'scripts/build-docs.mjs'
+      - 'scripts/docs.Dockerfile'
 
 jobs:
   build:
@@ -15,12 +19,9 @@ jobs:
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
 
-      - name: Extract version from tag
+      - name: Get short SHA
         id: version
-        run: |
-          TAG="${GITHUB_REF_NAME}"       # docs-v1.2.3
-          VERSION="${TAG#docs-v}"        # 1.2.3
-          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+        run: echo "sha=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
 
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444  # v5
         with:
@@ -41,11 +42,35 @@ jobs:
       - name: Build & push Docker image
         run: |
           IMAGE="ghcr.io/paddione/workspace-docs"
-          VERSION="${{ steps.version.outputs.version }}"
+          SHA="${{ steps.version.outputs.sha }}"
           docker build \
-            -t "${IMAGE}:v${VERSION}" \
+            -t "${IMAGE}:sha-${SHA}" \
             -t "${IMAGE}:latest" \
             -f scripts/docs.Dockerfile \
             .
-          docker push "${IMAGE}:v${VERSION}"
+          docker push "${IMAGE}:sha-${SHA}"
           docker push "${IMAGE}:latest"
+
+      - name: Deploy to mentolder
+        env:
+          KUBECONFIG_DATA: ${{ secrets.FLEET_KUBECONFIG }}
+        run: |
+          curl -sSL "https://dl.k8s.io/release/v1.31.0/bin/linux/amd64/kubectl" \
+            -o /usr/local/bin/kubectl && chmod +x /usr/local/bin/kubectl
+          mkdir -p ~/.kube
+          echo "$KUBECONFIG_DATA" | base64 -d > ~/.kube/config
+          chmod 600 ~/.kube/config
+          kubectl rollout restart deployment/docs -n workspace
+          kubectl rollout status deployment/docs -n workspace --timeout=120s
+
+      - name: Deploy to korczewski
+        env:
+          KUBECONFIG_DATA: ${{ secrets.FLEET_KUBECONFIG }}
+        run: |
+          curl -sSL "https://dl.k8s.io/release/v1.31.0/bin/linux/amd64/kubectl" \
+            -o /usr/local/bin/kubectl && chmod +x /usr/local/bin/kubectl
+          mkdir -p ~/.kube
+          echo "$KUBECONFIG_DATA" | base64 -d > ~/.kube/config
+          chmod 600 ~/.kube/config
+          kubectl rollout restart deployment/docs -n workspace-korczewski
+          kubectl rollout status deployment/docs -n workspace-korczewski --timeout=120s


### PR DESCRIPTION
## Was

Brett und Docs deployen jetzt automatisch wenn ihre Quell-Dateien auf `main` landen — kein manueller Git-Tag mehr nötig.

## Änderungen

| Workflow | Vorher | Nachher |
|----------|--------|---------|
| `build-brett.yml` | Trigger: `brett-v*` Tag | Trigger: `push` auf `brett/**` |
| `build-docs.yml` | Trigger: `docs-v*` Tag | Trigger: `push` auf `docs/**`, `scripts/build-docs.mjs`, `scripts/docs.Dockerfile` |
| `build-docs.yml` | Kein Deploy-Step | Deploy zu mentolder + korczewski |
| Beide | Image-Tag `:vX.Y.Z` | Image-Tag `:sha-<short>` + `:latest` |

## Verhalten

- Brett-Änderungen → Merge → CI baut Image → rollout restart auf beiden Brands
- Docs-Änderungen → Merge → CI baut Image → rollout restart auf beiden Brands
- Tags (`brett-v*`, `docs-v*`) werden nicht mehr ausgewertet

🤖 Generated with [Claude Code](https://claude.com/claude-code)