### PR TITLE
chore(skills): clarify dev-flow↔superpowers boundaries & dedup

### DIFF
--- a/.claude/skills/OVERVIEW.md
+++ b/.claude/skills/OVERVIEW.md
@@ -10,10 +10,47 @@
 
 | Skill | When to use |
 |---|---|
-| `dev-flow-plan` | **Entry point** for all repo changes — determines feature/fix/chore path, runs brainstorming, creates spec + plan, commits to branch. Chores finish inline. |
+| `dev-flow-plan` | **Entry point** for feature/fix changes — runs brainstorming, creates spec + plan, commits to branch, then **stops**. Routes chores to `dev-flow-chore`. |
+| `dev-flow-chore` | Maintenance with no behavior change (docs, dep bumps, config, CI) — executes and merges **inline**, no plan/execute handoff. |
 | `dev-flow-execute` | After `dev-flow-plan` has pushed a staged plan — implements, verifies, opens PR, merges, deploys. |
-| `dev-flow-iterate` | Deploys a surface, browses with Playwright MCP, tails logs, applies fixes, and loops until dev cluster is clean (used standalone or within `dev-flow-execute`). |
+| `dev-flow-iterate` | **Sub-routine of `dev-flow-execute`** (Schritt 4) + standalone dev-cluster loop — deploys a surface, browses with Playwright MCP, tails logs, applies small fixes. **Not** an alternative to execute. |
 | `dev-flow-e2e` | After `dev-flow-execute` has merged and deployed — writes + runs Playwright E2E tests against live environment. |
+
+---
+
+## Schicht-Kontrakt: dev-flow orchestriert, superpowers liefert Disziplin
+
+Die `dev-flow-*`-Skills sind **projektspezifische Orchestratoren**. Sie rufen die generischen
+`superpowers:*`-Skills für die Disziplin-Schritte auf und ergänzen Projekt-Tooling
+(`worktree-create.sh`, `ticket.sh`, `agent-lock.sh`, Deploy-Tasks).
+
+**Regel:** Für Repo-Arbeit **immer über `dev-flow-*` einsteigen** — nie direkt in
+`superpowers:brainstorming` / `writing-plans` / `executing-plans` / `finishing-a-development-branch`.
+Der dev-flow-Skill ruft diese zur richtigen Zeit selbst auf.
+
+| dev-flow-Schritt | ruft superpowers-Skill |
+|---|---|
+| `dev-flow-plan` Schritt 3 | `brainstorming` |
+| `dev-flow-plan` Schritt 3.7 (Subagent) | `writing-plans` |
+| `dev-flow-execute` Schritt 2 (Implementer) | `executing-plans` (in-context) + `test-driven-development` |
+| `dev-flow-execute` bei Fehlern | `systematic-debugging` |
+| `dev-flow-execute` Schritt 3 | `verification-before-completion` |
+| `dev-flow-execute` Schritt 3.8 | `requesting-code-review` |
+
+> **Worktrees:** `using-git-worktrees` (superpowers) ist im dev-flow-Pfad durch
+> `scripts/worktree-create.sh` ersetzt (git-crypt-safe). Nicht beide mischen.
+
+### Verifikations-Leiter (wer prüft was — kein doppeltes Gate)
+
+Verifikation passiert bewusst auf zwei Ebenen mit **unterschiedlichem Zweck** — das ist kein Stacking:
+
+1. **Implementer-Subagent:** `test-driven-development` (Rot-Grün) → stoppt erst bei grünen Tests. *Selbst-Check.*
+2. **Eltern (execute):** `verification-before-completion` → **unabhängige** Re-Verifikation der Subagent-Behauptung (Evidence vor Assertion).
+3. **Eltern (execute):** `requesting-code-review` → fremde Augen auf Korrektheit/Stil **vor** Merge.
+4. **Eltern (execute):** CI-Fix-Loop → die Wahrheit der CI nach dem Push.
+
+Stufe 2 wiederholt Stufe 1 *nicht* aus Misstrauen, sondern weil delegierte Selbstauskunft kein
+unabhängiger Beweis ist. Stufen 3+4 prüfen andere Dimensionen (Review-Qualität, CI-Realität).
 
 ---
 
@@ -67,10 +104,27 @@
 ```mermaid
 graph TD
     subgraph "Dev-Flow Pipeline (sequentiell)"
-        DP[dev-flow-plan] --> DE[dev-flow-execute]
-        DE --> DI[dev-flow-iterate]
+        DP[dev-flow-plan] -->|feature/fix| DE[dev-flow-execute]
+        DP -->|chore| DC[dev-flow-chore]
+        DE -->|Schritt 4 Sub-Routine| DI[dev-flow-iterate]
         DE --> DEE[dev-flow-e2e]
     end
+
+    subgraph "superpowers (Disziplin-Schicht)"
+        BS[brainstorming]
+        WP[writing-plans]
+        EP[executing-plans]
+        TDD[test-driven-development]
+        VBC[verification-before-completion]
+        RCR[requesting-code-review]
+    end
+
+    DP --> BS
+    DP --> WP
+    DE --> EP
+    DE --> TDD
+    DE --> VBC
+    DE --> RCR
 
     subgraph "Runbooks (eigenständig)"
         CD[cluster-deployment]
@@ -120,6 +174,7 @@ graph TD
 | Start | Verlauf | Ergebnis |
 |-------|---------|----------|
 | Feature entwickeln | `dev-flow-plan` → `dev-flow-execute` → `dev-flow-e2e` | Gemergetes + getestetes Feature |
+| Wartung (Chore) | `dev-flow-chore` (inline) | Gemergte Wartung ohne Plan-Handoff |
 | Cluster aufsetzen | `cluster-deployment` → `fleet-ops` → `secret-rotation` | Produktions-Cluster |
 | DB-Migration | `database-ops` → `dev-flow-execute` (Schema-Change) | Gemergte Migration |
 | Secret rotieren | `secret-rotation` → `fleet-ops` (Deploy) | Rotierte Secrets |

--- a/.claude/skills/dev-flow-chore/SKILL.md
+++ b/.claude/skills/dev-flow-chore/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: dev-flow-chore
+description: Use for maintenance work with no behavior change — docs, dependency bumps, config/rename, CI tweaks, cleanup. Executes and merges inline; no separate plan or dev-flow-execute handoff.
+---
+
+# dev-flow-chore — Wartung direkt ausführen & mergen
+
+## Wann diese Skill greift
+
+Eine **Chore**: Wartung ohne Verhaltensänderung — Doku, Dependency-Bumps, Config/Rename, CI-Tweaks,
+Aufräumen. Chores brauchen **keinen** Plan und **keinen** `dev-flow-execute`-Handoff: sie werden in
+einem Rutsch erledigt und gemergt. Für Features/Fixes stattdessen `dev-flow-plan` nutzen.
+
+**Sage zu Beginn:** "Ich nutze dev-flow-chore und führe die Wartung direkt aus."
+
+---
+
+## Schritt 0: Reaper & Pull-First
+
+```bash
+bash scripts/agent-lock.sh reap   # Session-Koordination [T000510]: Zombies/stale Worktrees/tote Locks räumen
+git fetch origin main
+if git diff --quiet HEAD; then git pull --rebase origin main; else git stash && git pull --rebase origin main && git stash pop; fi
+```
+
+## Schritt 0.5: Wiederkehrend oder einmalig?
+
+Frage den User, ob die Chore regelmäßig laufen soll. Falls ja, rufe `/schedule` auf und richte
+einen Cron-Job ein. **STOPP hier.**
+
+## Schritt 1: Worktree anlegen & claimen
+
+```bash
+# git-crypt-safe: creates the worktree, handles git-crypt, inits submodules
+bash scripts/worktree-create.sh chore/<slug> /tmp/wt-<slug>
+cd /tmp/wt-<slug>
+bash scripts/agent-lock.sh claim branch "chore/<slug>" --worktree "$PWD" --label dev-flow-chore
+```
+
+Falls ausnahmsweise inline im main-Checkout gearbeitet wird: zusätzlich `claim main-checkout` —
+der `.githooks/pre-commit` sperrt sonst konkurrierende Commits anderer Sessions.
+
+## Schritt 2: Änderungen vornehmen
+
+Setze die Wartung um. Bei mechanischer Arbeit über mehrere Dateien kannst du an einen passend
+provisionierten Subagenten delegieren (siehe [subagent-provisioning.md](file:///home/patrick/Bachelorprojekt/.claude/skills/references/subagent-provisioning.md) — Chores sind i.d.R. `haiku`/`sonnet`, Effort low).
+
+## Schritt 3: Verifizieren
+
+```bash
+task workspace:validate
+task test:all
+task freshness:regenerate   # generierte Artefakte aktuell halten, sonst CI rot
+```
+
+Siehe [dev-flow-gotchas.md](file:///home/patrick/Bachelorprojekt/.claude/skills/references/dev-flow-gotchas.md) für TypeScript/pnpm-Gotchas in Worktrees.
+
+## Schritt 4: Commit, Push & PR
+
+```bash
+git add -A
+git commit -m "chore(<scope>): <subject>"   # commitlint: Body-Zeilen <100 Zeichen
+```
+Rufe `commit-commands:commit-push-pr` auf (oder `gh pr create` manuell).
+
+## Schritt 5: Merge wenn CI grün
+
+```bash
+MAIN_REPO=$(git worktree list --porcelain | awk '/^worktree/{print $2; exit}')
+(cd "$MAIN_REPO" && gh pr merge --auto --squash --delete-branch)
+```
+
+## Schritt 6: Worktree & Branch bereinigen
+
+```bash
+bash scripts/agent-lock.sh release branch "chore/<slug>" 2>/dev/null || true
+cd /home/patrick/Bachelorprojekt
+git worktree remove "/tmp/wt-<slug>" --force
+git branch -D "chore/<slug>"
+```
+
+## Schritt 7: Deploy (falls nötig)
+
+Nur wenn die Chore deploybare Pfade berührt — Mapping in
+[deploy-routing.md](file:///home/patrick/Bachelorprojekt/.claude/skills/references/deploy-routing.md) (Single Source of Truth).
+
+---
+
+## Verwandte Skills
+
+| Skill | Beziehung |
+|-------|-----------|
+| `dev-flow-plan` | Geschwister — Features/Fixes (mit Plan + Handoff) statt Chores |
+| `using-git-worktrees` | Hintergrund — wird hier durch `scripts/worktree-create.sh` (git-crypt-safe) ersetzt |
+| `mishap-tracker` | Abschluss — protokolliert Frictions |
+
+## Nachbereitung & Mishap Report
+
+Melde alle aufgetretenen Fehler oder Prozess-Frictionen am Ende über `mishap-tracker`
+(`bash scripts/hooks/mishap-tracker.sh`).

--- a/.claude/skills/dev-flow-execute/SKILL.md
+++ b/.claude/skills/dev-flow-execute/SKILL.md
@@ -117,6 +117,8 @@ ATTACHMENT_DIR="/tmp/ticket-attachments-$TICKET_ID"
 
 Statt deinen eigenen Kontext/Modell zurückzusetzen (das ließe dich den Faden verlieren), delegiere die **gesamte Implementierung an EINEN frischen Subagenten** — sauberer Kontext per Konstruktion, **Modell + Effort passend zum Charakter der Plan-Tasks**. Du behältst den vollen Plan-Kontext und verifizierst das Ergebnis anschließend unabhängig.
 
+> **Warum EIN Implementer statt `superpowers:subagent-driven-development`-Fan-out?** Dieser Skill läuft bereits *selbst* als delegierte Ebene (oft aus einem dev-flow-Orchestrator). Ein zusätzlicher Per-Task-Fan-out wäre **verschachtelte Delegation** → Kontext-Explosion und Synthese-Last (siehe [subagent-provisioning.md](file:///home/patrick/Bachelorprojekt/.claude/skills/references/subagent-provisioning.md), 162k-Prompt-Lehre). Der Implementer ruft `superpowers:executing-plans` daher **in-context** auf (kein weiterer Agenten-Fan-out). Nur wenn der Plan ausdrücklich viele **voneinander unabhängige** Tasks hat und der Einzel-Implementer am Kontext-Limit scheitert, lohnt der Wechsel auf `subagent-driven-development` bzw. einen `Workflow`-Fan-out — bewusste Eskalation, nicht Default.
+
 Spawne über das `Agent`/`Task`-Tool einen Subagenten, **provisioniert gemäß** [subagent-provisioning.md](file:///home/patrick/Bachelorprojekt/.claude/skills/references/subagent-provisioning.md) (Modell · Effort · Kontext):
 - **Modell — nach Plan-Charakter wählen, nicht pauschal:** mechanisch (Config/Doku/Single-File) → `haiku`; Standard-Feature/Fix (mehrere Dateien, klarer Plan) → `sonnet`; komplex/riskant (systemübergreifend, Architektur, Security, DB-/Schema-Migration, Auto-Deploy) → `opus`. Im Zweifel eine Stufe höher.
 - **Effort per Prompt-Direktive** (das `Agent`-Tool kennt keinen Effort-Regler): mechanisch „Arbeite zügig und fokussiert."; komplex/riskant „Ultrathink. Denke sehr gründlich nach."
@@ -381,21 +383,9 @@ fi
 ./scripts/ticket.sh phase "$TICKET_ID" deploy done --driver devflow || true
 ```
 
-**Deploy-Mapping (Referenz):**
-
-| Geänderte Dateipfade | Task |
-|---|---|
-| `website/**` | `task feature:website` |
-| `brett/**` | `task feature:brett` |
-| `docs/**` | `task docs:deploy` |
-| `k3d/**`, `prod*/**`, `environments/**` | `task feature:deploy` |
-| Mehrere Bereiche | Alle zutreffenden Tasks nacheinander |
-
-**Nach dem Deploy:** Überprüfe kurz, dass die Pods `Running` sind:
-```bash
-kubectl --context fleet get pods -n workspace | grep -v Running
-kubectl --context fleet get pods -n workspace-korczewski | grep -v Running
-```
+**Deploy-Mapping (Single Source of Truth):** Die obige Auto-Detection und die vollständige
+Pfad→Task-Tabelle leben in [deploy-routing.md](file:///home/patrick/Bachelorprojekt/.claude/skills/references/deploy-routing.md) — dort steht auch die Pod-Verify-Schleife und die
+Stale-Tree-/Digest-Pin-Footguns. Bei Änderungen am Deploy-Mapping **nur** diese Referenz pflegen.
 
 Führe danach `dev-flow-e2e` aus, um E2E-Tests gegen die Live-Umgebung zu schreiben.
 

--- a/.claude/skills/dev-flow-iterate/SKILL.md
+++ b/.claude/skills/dev-flow-iterate/SKILL.md
@@ -64,6 +64,8 @@ echo "Surface erkannt: $SURFACE"
 | `brett` | `task dev:redeploy:brett ENV=$ENV` | `app=brett` |
 | `full` | `task dev:deploy ENV=$ENV` | `app=website`, `app=brett` |
 
+> Diese Dev-Cluster-Tabelle ist die Loop-nahe Kopie aus der SSOT [deploy-routing.md](file:///home/patrick/Bachelorprojekt/.claude/skills/references/deploy-routing.md) (Abschnitt „Dev-Cluster-Redeploy"). Änderungen am Mapping dort pflegen.
+
 ---
 
 ## Schritt 2: Ziel-URL ableiten
@@ -184,10 +186,18 @@ Loop beenden, zu Schritt 4.
 - Aufgerufen von `dev-flow-execute` → Kontrolle zurück an **Schritt 5 (PR)**.
 - Standalone → Ende. Berichte Zusammenfassung: Cycles gelaufen, Issues gefixt.
 
+## Identität (eine Rolle, nicht drei)
+
+Dieser Skill ist eine **Sub-Routine von `dev-flow-execute`** (Schritt 4, optional) plus ein
+**Standalone-Werkzeug** für ad-hoc Dev-Cluster-Loops. Er ist **keine Alternative** zu
+`dev-flow-execute` — die eigentliche Implementierung (Plan-Ausführung, Tests, PR, Merge) gehört
+immer zu `dev-flow-execute`. `dev-flow-iterate` deployt nur ins Dev-Cluster, liest Logs/Browser
+und wendet kleine Fixes an.
+
 ## Verwandte Skills
 
 | Skill | Beziehung |
 |-------|-----------|
-| `dev-flow-execute` | Alternative — batch-weise Implementierung |
+| `dev-flow-execute` | Eltern — ruft diesen Skill in Schritt 4 auf (und nimmt Kontrolle zurück) |
 | `cluster-deployment` | Querschnitt — bei Cluster-Problemen |
 | `mishap-tracker` | Abschluss — protokolliert Frictions |

--- a/.claude/skills/dev-flow-plan/SKILL.md
+++ b/.claude/skills/dev-flow-plan/SKILL.md
@@ -65,9 +65,12 @@ git worktree list
 
 Wähle einen der Pfade (Feature/Fix/Chore) basierend auf der Anfrage und kläre dies mit dem User ab.
 
-- **feature**: Neue Funktionen oder UI-Elemente.
-- **fix**: Fehlerbehebung (erfordert Ticket-ID).
-- **chore**: Wartung, Doku, Dependency-Bumps (keine Verhaltensänderung).
+- **feature**: Neue Funktionen oder UI-Elemente. → diese Skill (Feature-Pfad unten).
+- **fix**: Fehlerbehebung (erfordert Ticket-ID). → diese Skill (Fix-Pfad unten).
+- **chore**: Wartung, Doku, Dependency-Bumps (keine Verhaltensänderung). → **rufe `dev-flow-chore` auf und STOPP** — Chores werden dort direkt ausgeführt und gemergt, nicht hier geplant.
+
+> Diese Skill plant nur (Feature/Fix) und stoppt vor der Umsetzung. Die Umsetzung übernimmt
+> `dev-flow-execute`. Chores laufen vollständig in `dev-flow-chore`.
 
 ---
 
@@ -200,19 +203,8 @@ Füge den failing Test und den Plan hinzu, committe und pushe auf den fix Branch
 
 ## Chore-Pfad
 
-Chores brauchen keinen Plan, sie werden direkt ausgeführt und gemergt.
-
-### Schritt 0.5: Wiederkehrend oder einmalig?
-Frage den User, ob die Chore regelmäßig laufen soll. Falls ja, rufe `/schedule` auf und richte einen Cron-Job ein. **STOPP hier.**
-
-### Schritt 1-7: Direkt bearbeiten und mergen
-1. Kurze Beschreibung formulieren.
-2. Worktree anlegen: `/tmp/wt-<slug>`; dann `bash scripts/agent-lock.sh claim branch "chore/<slug>" --worktree "$PWD" --label dev-flow-chore`. (Falls ausnahmsweise inline im main-Checkout gearbeitet wird: zusätzlich `claim main-checkout` — der `.githooks/pre-commit` sperrt sonst konkurrierende Commits anderer Sessions.)
-3. Änderungen vornehmen.
-4. Verifizieren (`task test:all`, `task workspace:validate` etc.).
-5. Committen, pushen und PR erstellen (`commit-commands:commit-push-pr`).
-6. PR mergen (`gh pr merge --auto --squash --delete-branch`).
-7. Passenden Deploy-Task aufrufen (siehe Deploy-Tabelle in [dev-flow-gotchas.md](file:///home/patrick/Bachelorprojekt/.claude/skills/references/dev-flow-gotchas.md)).
+Ausgelagert nach `dev-flow-chore` — Chores brauchen keinen Plan und werden dort direkt ausgeführt
+und gemergt. In Schritt 0 für Chores sofort `dev-flow-chore` aufrufen und hier stoppen.
 
 ---
 
@@ -221,8 +213,11 @@ Frage den User, ob die Chore regelmäßig laufen soll. Falls ja, rufe `/schedule
 
 | Skill | Beziehung |
 |-------|-----------|
-| `using-git-worktrees` | Voraussetzung — Worktree-Isolation |
+| `using-git-worktrees` | Hintergrund — ersetzt durch `scripts/worktree-create.sh` (git-crypt-safe) |
+| `superpowers:brainstorming` | Aufgerufen in Schritt 3 — Intent/Design klären |
+| `superpowers:writing-plans` | Aufgerufen vom Plan-Subagenten (Schritt 3.7) |
 | `dev-flow-execute` | Folge — implementiert den erstellten Plan |
+| `dev-flow-chore` | Geschwister — Chores statt Features/Fixes |
 | `mishap-tracker` | Abschluss — protokolliert Frictions |
 
 ## Nachbereitung & Mishap Report

--- a/.claude/skills/references/deploy-routing.md
+++ b/.claude/skills/references/deploy-routing.md
@@ -1,0 +1,53 @@
+# Deploy-Routing (Single Source of Truth)
+
+Diese Tabelle ist die **einzige** verbindliche Quelle dafür, welcher Deploy-Task zu welchen
+geänderten Pfaden gehört. `dev-flow-execute` (Post-Merge-Deploy), `dev-flow-chore` (Schritt 7)
+und `dev-flow-iterate` (Dev-Cluster-Redeploy) verweisen alle hierher — **nicht** die Tabelle
+kopieren, sondern verlinken.
+
+> Push-basiertes Deploy-Modell: Es gibt **keinen** GitOps-Reconciler auf dem fleet-Cluster.
+> Ein Merge nach `main` deployt nichts automatisch (außer `website/**` via `build-website*.yml`).
+> Nach dem Merge muss explizit deployt werden.
+
+## Prod-Deploy (nach Merge — beide Brands auf fleet)
+
+| Geänderte Dateipfade | Task |
+|---|---|
+| `website/**` | `task feature:website` (rollt auto via CI; manueller Re-Deploy bei Bedarf) |
+| `brett/**` | `task feature:brett` |
+| `docs/**` | `task docs:deploy` |
+| `k3d/**`, `prod*/**`, `prod-fleet/**`, `environments/**` | `task feature:deploy` |
+| Mehrere Bereiche | Alle zutreffenden Tasks nacheinander |
+
+**Auto-Detection (für `dev-flow-execute` Schritt 8):**
+```bash
+MERGE_COMMIT=$(git log origin/main -1 --format="%H")
+CHANGED=$(git diff-tree --no-commit-id -r --name-only "$MERGE_COMMIT")
+echo "$CHANGED" | grep -qE '^website/'                                            && task feature:website
+echo "$CHANGED" | grep -qE '^brett/'                                              && task feature:brett
+echo "$CHANGED" | grep -qE '^docs/'                                               && task docs:deploy
+echo "$CHANGED" | grep -qE '^(k3d/|prod|prod-fleet|prod-mentolder|prod-korczewski|environments/)' && task feature:deploy
+```
+
+**Verify nach dem Deploy:**
+```bash
+kubectl --context fleet get pods -n workspace            | grep -v Running
+kubectl --context fleet get pods -n workspace-korczewski | grep -v Running
+```
+
+## Dev-Cluster-Redeploy (für `dev-flow-iterate`, k3d)
+
+| SURFACE | Redeploy-Task | Watched pods |
+|---------|--------------|--------------|
+| `website` | `task dev:redeploy:website ENV=$ENV` | `app=website` |
+| `brett` | `task dev:redeploy:brett ENV=$ENV` | `app=brett` |
+| `full` | `task dev:deploy ENV=$ENV` | `app=website`, `app=brett` |
+
+## Footguns
+
+- `task feature:*` baut aus dem **Working Tree des aktuellen cwd** — aus einem frischen, mit
+  `origin/main` synchronisierten Tree deployen, sonst landet alter Code (Memory:
+  *Deploy from a fresh tree, not a stale main checkout*).
+- Website-Deploys werden über `build-website*.yml` digest-gepinnt → ein bloßer `rollout restart`
+  landet das neue Image evtl. nicht (Memory: *Website deploy goes silently stale*).
+- `ENV=` ist immer explizit; ohne `ENV=` greift `dev` und der Context-Mismatch-Check entfällt.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Default Workflow
 
-For any work request in this repo (add/change/fix/build), invoke **`dev-flow-plan`** (`.claude/skills/dev-flow-plan/SKILL.md`). It handles path declaration (feature/fix/chore), worktree setup, brainstorming, spec, and plan creation — then commits and pushes the plan to the branch and stops. Chores execute fully inline. When ready to implement a staged plan, invoke **`dev-flow-execute`** (`.claude/skills/dev-flow-execute/SKILL.md`) — it picks up the plan, runs implementation, verification, PR, and post-merge deploy. Both skills auto-invoke via their `description` frontmatter; no special wiring needed.
+For any work request in this repo (add/change/fix/build), invoke **`dev-flow-plan`** (`.claude/skills/dev-flow-plan/SKILL.md`). It declares the path, and for **feature/fix** does worktree setup, brainstorming, spec, and plan creation — then commits and pushes the plan to the branch and stops. **Chores** (maintenance, no behavior change) route to **`dev-flow-chore`** (`.claude/skills/dev-flow-chore/SKILL.md`), which executes and merges inline (no plan/execute handoff). When ready to implement a staged plan, invoke **`dev-flow-execute`** (`.claude/skills/dev-flow-execute/SKILL.md`) — it picks up the plan, runs implementation, verification, PR, and post-merge deploy. All auto-invoke via their `description` frontmatter; no special wiring needed. The `dev-flow-*` skills are project orchestrators that call the generic `superpowers:*` skills for discipline — see `.claude/skills/OVERVIEW.md` (Schicht-Kontrakt) for the layering and which step calls which.
 
 ## Project Overview
 

--- a/docs/agent-guide/20-werkzeuge.md
+++ b/docs/agent-guide/20-werkzeuge.md
@@ -70,7 +70,29 @@ Ich will etwas ändern – starte die Planung (dev-flow-plan).
 
 **Schutzregeln (Guardrails):** Erst ziehen, dann arbeiten (G-PULL-FIRST)
 
-**Verwandt:** [[dev-flow-execute]]
+**Verwandt:** [[dev-flow-execute]], Wartungs-Skill (dev-flow-chore)
+
+## Wartungs-Skill (dev-flow-chore)
+
+**Skill** · 🟡 **Vorsicht**
+
+Erledigt Wartung ohne Verhaltensänderung in einem Rutsch und mergt sie.
+
+**Wofür?** Für Doku, Dependency-Bumps, Config/Umbenennungen, CI-Tweaks und Aufräumen — direkt ausgeführt und gemergt, ohne Plan und ohne dev-flow-execute. Für Features/Fixes stattdessen dev-flow-plan.
+
+**So startest du:** Sage z.B. 'bump die Abhängigkeiten' oder 'räum die Doku auf' – der Skill startet von selbst, oder dev-flow-plan leitet Chores hierher.
+
+**Was schiefgehen kann:** Wenig: keine Verhaltensänderung. CI könnte den Merge blockieren; der falsche Branch könnte aktiv sein (🟡).
+
+**Du kannst diesen Prompt kopieren und in Claude Code einfügen:**
+
+```text
+/dev-flow-chore – erledige diese Wartung und merge sie.
+```
+
+**Schutzregeln (Guardrails):** Erst ziehen, dann arbeiten (G-PULL-FIRST), Nie direkt auf main (G-PR-NOT-MAIN)
+
+**Verwandt:** [[dev-flow-plan]]
 
 ## Umsetzungs-Skill (dev-flow-execute)
 

--- a/docs/agent-guide/maps/danger-map.md
+++ b/docs/agent-guide/maps/danger-map.md
@@ -39,6 +39,7 @@ Ziele/Werkzeuge sie referenzieren (transitiv) — also ggf. unter mehreren Stufe
 **Werkzeuge:**
 - `agent-test` — Test-Agent
 - `agent-website` — Website-Agent
+- `dev-flow-chore` — Wartungs-Skill (dev-flow-chore)
 - `dev-flow-e2e` — E2E-Test-Skill (dev-flow-e2e)
 - `dev-flow-execute` — Umsetzungs-Skill (dev-flow-execute)
 - `dev-flow-iterate` — Dev-Iterations-Skill (dev-flow-iterate)

--- a/docs/agent-guide/maps/tools-map.md
+++ b/docs/agent-guide/maps/tools-map.md
@@ -10,6 +10,7 @@ Die Tier-Emojis (🟢🟡🟠🔴) sind in `danger-map.md` erklärt.
 | Id | Name | Art | Tier | Wofür | Guardrails | Init |
 | --- | --- | --- | --- | --- | --- | --- |
 | brainstorming | Brainstorming (/brainstorming) | skill | 🟢 Sicher | Denkt ein Vorhaben mit dir durch, bevor Code entsteht – Intention, Anforderungen, Design. | — | /brainstorming – ich möchte etwas Neues bauen und will es erst durchdenken. |
+| dev-flow-chore | Wartungs-Skill (dev-flow-chore) | skill | 🟡 Vorsicht | Erledigt Wartung ohne Verhaltensänderung in einem Rutsch und mergt sie. | G-PR-NOT-MAIN, G-PULL-FIRST | /dev-flow-chore – erledige diese Wartung und merge sie. |
 | dev-flow-e2e | E2E-Test-Skill (dev-flow-e2e) | skill | 🟡 Vorsicht | Schreibt und führt End-to-End-Tests gegen die Live-Umgebung nach einem Merge aus. | G-ENV-EXPLICIT | /dev-flow-e2e – schreibe und führe E2E-Tests gegen die Live-Umgebung aus. |
 | dev-flow-execute | Umsetzungs-Skill (dev-flow-execute) | skill | 🟡 Vorsicht | Setzt einen fertigen Plan um und öffnet einen Pull Request. | G-PR-NOT-MAIN, G-PULL-FIRST | /dev-flow-execute – setze den fertigen Plan um und öffne einen PR. |
 | dev-flow-iterate | Dev-Iterations-Skill (dev-flow-iterate) | skill | 🟡 Vorsicht | Deployt Änderungen ins Dev-Cluster und zeigt Logs – zum schnellen Ausprobieren. | G-CONTEXT-CHECK, G-ENV-EXPLICIT | /dev-flow-iterate – deploye ins Dev-Cluster und zeig mir die Logs. |

--- a/docs/agent-guide/registry/tools.yaml
+++ b/docs/agent-guide/registry/tools.yaml
@@ -40,9 +40,24 @@
   stages: [plan]
   aliases_de: [plan, planen, brainstorm, spec]
   guardrails: [G-PULL-FIRST]
-  related: [dev-flow-execute]
+  related: [dev-flow-execute, dev-flow-chore]
   links: []
   init_prompt_de: "Ich will etwas ändern – starte die Planung (dev-flow-plan)."
+- id: dev-flow-chore
+  name_de: "Wartungs-Skill (dev-flow-chore)"
+  kind: skill
+  summary_de: "Erledigt Wartung ohne Verhaltensänderung in einem Rutsch und mergt sie."
+  what_for_de: "Für Doku, Dependency-Bumps, Config/Umbenennungen, CI-Tweaks und Aufräumen — direkt ausgeführt und gemergt, ohne Plan und ohne dev-flow-execute. Für Features/Fixes stattdessen dev-flow-plan."
+  how_to_start_de: "Sage z.B. 'bump die Abhängigkeiten' oder 'räum die Doku auf' – der Skill startet von selbst, oder dev-flow-plan leitet Chores hierher."
+  what_could_go_wrong_de: "Wenig: keine Verhaltensänderung. CI könnte den Merge blockieren; der falsche Branch könnte aktiv sein (🟡)."
+  danger: caution
+  theme: entwickeln
+  stages: [code, pr-ci]
+  aliases_de: [chore, wartung, aufraeumen, "dependency-bump", doku]
+  guardrails: [G-PULL-FIRST, G-PR-NOT-MAIN]
+  related: [dev-flow-plan]
+  links: []
+  init_prompt_de: "/dev-flow-chore – erledige diese Wartung und merge sie."
 - id: dev-flow-execute
   name_de: "Umsetzungs-Skill (dev-flow-execute)"
   kind: skill

--- a/website/src/lib/agent-guide.generated.json
+++ b/website/src/lib/agent-guide.generated.json
@@ -910,7 +910,8 @@
         }
       ],
       "related": [
-        "dev-flow-execute"
+        "dev-flow-execute",
+        "dev-flow-chore"
       ],
       "links": [],
       "theme": "entwickeln",
@@ -926,6 +927,50 @@
         "plan"
       ],
       "init_prompt_de": "Ich will etwas ändern – starte die Planung (dev-flow-plan)."
+    },
+    {
+      "id": "dev-flow-chore",
+      "name_de": "Wartungs-Skill (dev-flow-chore)",
+      "kind": "skill",
+      "kind_de": "Fertigkeit",
+      "summary_de": "Erledigt Wartung ohne Verhaltensänderung in einem Rutsch und mergt sie.",
+      "what_for_de": "Für Doku, Dependency-Bumps, Config/Umbenennungen, CI-Tweaks und Aufräumen — direkt ausgeführt und gemergt, ohne Plan und ohne dev-flow-execute. Für Features/Fixes stattdessen dev-flow-plan.",
+      "how_to_start_de": "Sage z.B. 'bump die Abhängigkeiten' oder 'räum die Doku auf' – der Skill startet von selbst, oder dev-flow-plan leitet Chores hierher.",
+      "what_could_go_wrong_de": "Wenig: keine Verhaltensänderung. CI könnte den Merge blockieren; der falsche Branch könnte aktiv sein (🟡).",
+      "danger": "caution",
+      "guardrails": [
+        {
+          "id": "G-PULL-FIRST",
+          "name_de": "Erst ziehen, dann arbeiten",
+          "rule_de": "Immer 'git pull --rebase origin main' bevor du etwas änderst.",
+          "why_de": "Sonst arbeitest du auf einem veralteten Stand und bekommst Konflikte."
+        },
+        {
+          "id": "G-PR-NOT-MAIN",
+          "name_de": "Nie direkt auf main",
+          "rule_de": "Änderungen immer über einen Branch + Pull Request, niemals direkt nach main pushen.",
+          "why_de": "main ist geschützt; direktes Pushen umgeht Review und CI."
+        }
+      ],
+      "related": [
+        "dev-flow-plan"
+      ],
+      "links": [],
+      "theme": "entwickeln",
+      "aliases_de": [
+        "chore",
+        "wartung",
+        "aufraeumen",
+        "dependency-bump",
+        "doku"
+      ],
+      "common": false,
+      "order": 999,
+      "stages": [
+        "code",
+        "pr-ci"
+      ],
+      "init_prompt_de": "/dev-flow-chore – erledige diese Wartung und merge sie."
     },
     {
       "id": "dev-flow-execute",
@@ -1876,6 +1921,7 @@
           "factory-autopilot"
         ],
         "toolIds": [
+          "dev-flow-chore",
           "dev-flow-execute",
           "dev-flow-iterate",
           "factory",
@@ -1897,6 +1943,7 @@
           "factory-autopilot"
         ],
         "toolIds": [
+          "dev-flow-chore",
           "dev-flow-execute",
           "factory",
           "factory-dispatch"


### PR DESCRIPTION
## Was & Warum

Optimiert die Skill-Suite auf **klare Grenzen** statt „Stacking ohne Boundaries" (User-Feedback). Reine Doku/Skill/Registry-Änderungen, keine Verhaltensänderung.

### Änderungen
- **OVERVIEW.md** — neuer **Schicht-Kontrakt**: `dev-flow-*` orchestrieren, `superpowers:*` liefern Disziplin. Regel „immer über dev-flow einsteigen" + Schritt→Skill-Mapping + **Verifikations-Leiter** (warum Subagent-TDD ≠ Eltern-Re-Verify ≠ Review ≠ CI). Graph zeigt beide Schichten.
- **dev-flow-iterate** — dreifache Identität behoben → Sub-Routine von execute + Standalone, **keine** Alternative.
- **deploy-routing.md** (neu) — Single Source of Truth fürs Deploy-Mapping; execute/iterate/chore verlinken. Behebt toten gotchas-Verweis.
- **dev-flow-execute** — dokumentiert, warum ein In-Context-Implementer statt `subagent-driven-development`-Fan-out.
- **dev-flow-chore** (neu) — Chore-Ausführung aus `dev-flow-plan` ausgelagert (plan plant jetzt nur Feature/Fix). In agent-guide-Registry registriert.
- **CLAUDE.md** — Default-Workflow für Chore-Split + Layering aktualisiert.

### Verifikation
- `task freshness:check`: generierte agent-guide-Artefakte deterministisch regeneriert (dev-flow-chore in Maps/Docs/JSON), nach Commit kein Drift.
- Alle Cross-Referenzen lösen auf; `dev-flow-chore` in Skill-Liste + Maps auffindbar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)