### PR TITLE
chore(docs-gen): render skills OVERVIEW.md as a doc page

### DIFF
--- a/scripts/docs-gen/discover.mjs
+++ b/scripts/docs-gen/discover.mjs
@@ -73,6 +73,8 @@ async function listMdFiles(dir) {
 }
 
 // Repo skills: .claude/skills/<name>/SKILL.md, plus superpowers/<sub>/SKILL.md (one deeper).
+// Also: top-level *.md files directly under .claude/skills/ (e.g. OVERVIEW.md) render as 'doc'
+// pages — they are index/overview content, not invokable per-skill SKILL.md files.
 async function discoverRepoSkills(repoRoot, pluginsRoot) {
   const skillsRoot = join(repoRoot, '.claude', 'skills');
   const docs = [];
@@ -87,6 +89,9 @@ async function discoverRepoSkills(repoRoot, pluginsRoot) {
     }
     const md = join(dir, 'SKILL.md');
     if (existsSync(md)) docs.push(await makeSourceDoc('skill', name, md, pluginsRoot));
+  }
+  for (const md of await listMdFiles(skillsRoot)) {
+    docs.push(await makeSourceDoc('doc', basename(md, '.md'), md, pluginsRoot));
   }
   return docs;
 }

--- a/scripts/docs-gen/discover.test.mjs
+++ b/scripts/docs-gen/discover.test.mjs
@@ -38,6 +38,8 @@ test('discoverSources: finds repo skill, repo agent, doc; excludes specs; missin
     // repo skill
     await mkdir(join(root, '.claude/skills/fleet-ops'), { recursive: true });
     await writeFile(join(root, '.claude/skills/fleet-ops/SKILL.md'), '---\nname: fleet-ops\n---\n# Fleet Ops\n');
+    // top-level skills index/overview markdown (not a per-skill SKILL.md) → renders as a doc page
+    await writeFile(join(root, '.claude/skills/OVERVIEW.md'), '# Skills Overview\n');
     // one-level-deeper superpowers sub-skill
     await mkdir(join(root, '.claude/skills/superpowers/brainstorming'), { recursive: true });
     await writeFile(join(root, '.claude/skills/superpowers/brainstorming/SKILL.md'), '---\nname: brainstorming\n---\n# Brainstorm\n');
@@ -89,6 +91,13 @@ test('discoverSources: finds repo skill, repo agent, doc; excludes specs; missin
     const doc = sources.find(s => s.sourcePath.endsWith('docs/website/overview.md'));
     assert.equal(doc.type, 'doc');
     assert.equal(doc.provenance, 'repo');
+
+    // top-level skills OVERVIEW.md renders as a doc page (not a skill)
+    const overview = sources.find(s => s.sourcePath.endsWith('.claude/skills/OVERVIEW.md'));
+    assert.ok(overview, 'skills OVERVIEW.md discovered');
+    assert.equal(overview.type, 'doc');
+    assert.equal(overview.name, 'OVERVIEW');
+    assert.equal(overview.provenance, 'repo');
 
     // deterministic sort: by type then sourcePath
     const sortedCopy = [...sources].sort((a, b) =>


### PR DESCRIPTION
## Was & Warum

`scripts/docs-gen/discover.mjs` rendert bislang nur `.claude/skills/<name>/SKILL.md`. Die Top-Level-`OVERVIEW.md` — die jetzt den **Schicht-Kontrakt** (dev-flow↔superpowers) trägt — wurde dadurch **nie** ins Docs-Site veröffentlicht (festgestellt im Follow-up zu #1492).

## Änderung
- `discoverRepoSkills` zieht zusätzlich direkte Top-Level-`*.md` unter `.claude/skills/` als `type: 'doc'` ein → `OVERVIEW.md` wird eine Doc-Seite.
- `references/*.md` bleiben bewusst unveröffentlicht (nur aus SKILL.md verlinkt — kein Verzeichnis-Walk).
- Test in `discover.test.mjs` ergänzt (OVERVIEW.md → type doc, name OVERVIEW, provenance repo).

## Verifikation
- `node --test scripts/docs-gen/*.test.mjs`: **113/113 grün** (inkl. neuem Assert + `build-smoke` voller Docs-Build → keine Slug-Kollision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)