### PR TITLE
fix(e2e): repair FA-10 website tests — SSR crash + hydration race

### DIFF
--- a/tests/e2e/specs/fa-10-website.spec.ts
+++ b/tests/e2e/specs/fa-10-website.spec.ts
@@ -1,6 +1,19 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
 
 const BASE = process.env.WEBSITE_URL || 'http://localhost:4321';
+
+/**
+ * Wait for all Astro islands to finish hydration by polling for the removal
+ * of the `ssr` attribute. Astro removes this attribute from <astro-island>
+ * elements after the component JavaScript finishes loading and the framework
+ * (Svelte, Vue, etc.) completes hydration.
+ */
+async function waitForHydration(page: Page) {
+  await page.waitForFunction(
+    () => document.querySelectorAll('astro-island[ssr]').length === 0,
+    { timeout: 8000 }
+  );
+}
 
 test.describe('FA-10: Unternehmenswebsite (Astro) & Kontaktformular', () => {
 
@@ -42,6 +55,7 @@ test.describe('FA-10: Unternehmenswebsite (Astro) & Kontaktformular', () => {
 
   test('T5: Contact form has all required fields', async ({ page }) => {
     await page.goto(`${BASE}/kontakt`);
+    await waitForHydration(page);
     // The new UI uses tabs. "Nachricht" is tab 02.
     await page.getByRole('tab', { name: /Nachricht/i }).click();
     await expect(page.getByRole('combobox', { name: /wie kann ich helfen/i })).toBeVisible();
@@ -52,6 +66,7 @@ test.describe('FA-10: Unternehmenswebsite (Astro) & Kontaktformular', () => {
 
   test('T6: Valid form submission succeeds', async ({ page }) => {
     await page.goto(`${BASE}/kontakt`);
+    await waitForHydration(page);
     await page.getByRole('tab', { name: /Nachricht/i }).click();
     await page.getByRole('textbox', { name: /name/i }).first().fill('Test E2E User');
     await page.getByRole('textbox', { name: /e-mail/i }).fill('test-e2e@example.de');

--- a/website/src/components/assistant/agent-guide/GlossaryTerm.svelte
+++ b/website/src/components/assistant/agent-guide/GlossaryTerm.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   let { term, def }: { term: string; def: string } = $props();
-  let open = $state(false);
+  let pinned = $state(false);
+  let hovered = $state(false);
+  let open = $derived(pinned || hovered);
 </script>
 
 <span class="ag-gloss-wrap">
@@ -8,9 +10,9 @@
     type="button"
     class="ag-gloss"
     aria-expanded={open}
-    onclick={() => (open = !open)}
-    onmouseenter={() => (open = true)}
-    onmouseleave={() => (open = false)}
+    onclick={() => (pinned = !pinned)}
+    onmouseenter={() => (hovered = true)}
+    onmouseleave={() => (hovered = false)}
   >{term}</button>
   {#if open}
     <span class="ag-gloss-pop" role="note">{def}</span>

--- a/website/src/lib/content.ts
+++ b/website/src/lib/content.ts
@@ -203,10 +203,12 @@ export async function getEffectiveHomepage(): Promise<HomepageContent> {
     avatarType: db.avatarType ?? c.avatarType,
     avatarSrc: db.avatarSrc ?? c.avatarSrc,
     avatarInitials: db.avatarInitials ?? c.avatarInitials,
-    whyMePoints: db.whyMePoints.map((pt, i) => ({
-      ...pt,
-      iconPath: c.whyMePoints[i]?.iconPath,
-    })),
+    whyMePoints: Array.isArray(db.whyMePoints)
+      ? db.whyMePoints.map((pt, i) => ({
+          ...pt,
+          iconPath: c.whyMePoints[i]?.iconPath,
+        }))
+      : c.whyMePoints.map(p => ({ title: p.title, text: p.text, iconPath: p.iconPath })),
     processSteps: db.processSteps ?? DEFAULT_PROCESS_STEPS,
     processEyebrow: db.processEyebrow ?? 'So arbeiten wir',
     processHeadline: db.processHeadline ?? 'Vier ruhige Schritte.',
@@ -215,11 +217,17 @@ export async function getEffectiveHomepage(): Promise<HomepageContent> {
 
 export async function getEffectiveUebermich(): Promise<UebermichContent> {
   const db = await getUebermichContent(BRAND).catch(() => null);
-  const fallback = config.uebermich;
-  if (!db) return fallback;
+  const f = config.uebermich;
+  if (!db) return f;
   return {
-    ...db,
-    warumdieserName: db.warumdieserName ?? fallback.warumdieserName,
+    pageHeadline: typeof db.pageHeadline === 'string' ? db.pageHeadline : f.pageHeadline,
+    subheadline: typeof db.subheadline === 'string' ? db.subheadline : f.subheadline,
+    introParagraphs: Array.isArray(db.introParagraphs) ? db.introParagraphs : f.introParagraphs,
+    sections: Array.isArray(db.sections) ? db.sections : f.sections,
+    milestones: Array.isArray(db.milestones) ? db.milestones : f.milestones,
+    notDoing: Array.isArray(db.notDoing) ? db.notDoing : f.notDoing,
+    privateText: typeof db.privateText === 'string' ? db.privateText : f.privateText,
+    warumdieserName: db.warumdieserName ?? f.warumdieserName,
   };
 }
 


### PR DESCRIPTION
## Fixes

### T2: /ueber-mich SSR crash (needs deploy)

`getEffectiveUebermich()` used shallow spread (`...db`) which replaced required array fields with `undefined` from partial DB records. Fixed with per-field type-checked fallbacks. Also hardened `getEffectiveHomepage()` same pattern.

### T5/T6: Contact tab hydration race

Svelte 5 event delegation isn't ready when `page.goto()` fires `load`. Added `waitForHydration()` helper that polls `astro-island[ssr]` removal — Astro's own hydration-complete signal.

### GlossaryTerm.svelte

Tooltip race between `onclick`/`onmouseenter` — split into pinned/hovered states.

## Verification

6/7 FA-10 tests pass (T2 requires this deploy).