### PR TITLE
chore(ci): auto-enable squash auto-merge on new PRs

### DIFF
--- a/.github/workflows/auto-enable-automerge.yml
+++ b/.github/workflows/auto-enable-automerge.yml
@@ -1,0 +1,34 @@
+name: Auto-enable Auto-Merge
+
+# Aktiviert Squash-Auto-Merge auf jeder neuen Nicht-Draft-PR gegen main.
+# Der Merge selbst passiert erst, wenn alle Required-Checks grün sind und
+# Branch-Protection erfüllt ist — diese Action setzt nur das --auto-Flag,
+# das bislang manuell via `gh pr merge --auto` gesetzt werden musste.
+# Repo-Voraussetzung: allow_auto_merge ist aktiviert.
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, ready_for_review, reopened]
+
+concurrency:
+  group: auto-enable-automerge-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  enable-automerge:
+    name: Enable Auto-Merge
+    # Drafts ausnehmen — "fertig, aber nicht mergen" bleibt über Draft-Status möglich.
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      pull-requests: write
+      contents: read
+    steps:
+      - name: Enable squash auto-merge
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: gh pr merge --auto --squash --delete-branch --repo "$REPO" "$PR_NUMBER"

--- a/.github/workflows/auto-enable-automerge.yml
+++ b/.github/workflows/auto-enable-automerge.yml
@@ -27,8 +27,10 @@ jobs:
       contents: read
     steps:
       - name: Enable squash auto-merge
+        # GITHUB_TOKEN darf enablePullRequestAutoMerge nicht ausführen
+        # ("Resource not accessible by integration") — daher PAT.
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_PAT }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
         run: gh pr merge --auto --squash --delete-branch --repo "$REPO" "$PR_NUMBER"


### PR DESCRIPTION
## Was

Neuer Workflow `.github/workflows/auto-enable-automerge.yml`: aktiviert bei jeder **Nicht-Draft-PR** gegen `main` (`opened`/`ready_for_review`/`reopened`) automatisch Squash-Auto-Merge via `gh pr merge --auto --squash --delete-branch`.

## Warum

Auto-Merge ist kein GitHub-Default — es muss pro PR gesetzt werden. Bei #1497 wurde der Schritt vergessen, die grüne PR blieb offen liegen. Diese Action schließt die Lücke server-seitig — greift auch bei PRs, die nicht aus einer Claude-Session geöffnet werden (Gemini/Web-UI).

## Sicherheit

- Merge passiert weiterhin **erst wenn alle Required-Checks grün** sind + Branch-Protection erfüllt ist; die Action setzt nur das `--auto`-Flag.
- Drafts ausgenommen → "fertig, aber noch nicht mergen" bleibt über Draft-Status möglich.
- Repo-Voraussetzung `allow_auto_merge: true` ist bereits gesetzt.
- Kein Freitext-Input in `run:` — `PR_NUMBER`/`REPO` via `env:` + gequotet (keine Injection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)