### PR TITLE
chore(agent-guide): wire platform-descriptions into emit + freshness gate

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -546,6 +546,7 @@ tasks:
           docs/agent-guide/maps/tools-map.md
           docs/agent-guide/maps/danger-map.md
           website/src/lib/agent-guide.generated.json
+          website/src/lib/platform-descriptions.generated.json
         "
         for f in $FILES; do
           if ! git diff --exit-code "$f"; then
@@ -2428,16 +2429,22 @@ tasks:
       - node scripts/agent-guide/emit-webapp.mjs
 
   agent-guide:emit:
-    desc: "Umbrella: regenerate all agent-guide surfaces (docs + webapp + maps)"
+    desc: "Umbrella: regenerate all agent-guide surfaces (docs + webapp + maps + platform-descriptions)"
     cmds:
       - task: agent-guide:docs
       - task: agent-guide:webapp
       - task: agent-guide:maps
+      - task: agent-guide:platform-descriptions
 
   agent-guide:maps:
     desc: "Regenerate docs/agent-guide/maps/{goals,tools,danger}-map.md from the registry"
     cmds:
       - node scripts/agent-guide/emit-maps.mjs
+
+  agent-guide:platform-descriptions:
+    desc: "Regenerate website/src/lib/platform-descriptions.generated.json from the components registry"
+    cmds:
+      - node scripts/gen-platform-descriptions.mjs
 
   quality:index:
     desc: "Validate the code-quality registry and regenerate docs/code-quality/repo-index.json"


### PR DESCRIPTION
## Was

`task freshness:regenerate` hat `website/src/lib/platform-descriptions.generated.json` bisher **nicht** mitregeneriert — nur `test:agent-guide` hat die Datei regeneriert und gegen die committete Version gedifft. Diese Lücke (aus dem Config-Integrity-Audit, PR #1501) wird hier geschlossen.

## Wie

- Neuer Sub-Task `agent-guide:platform-descriptions` (`node scripts/gen-platform-descriptions.mjs`).
- Eingehängt unter den `agent-guide:emit`-Umbrella — die Wurzel: `emit` behauptete „regenerate **all** agent-guide surfaces", regenerierte platform-descriptions aber nicht. Jetzt erbt **jeder** emit-Aufrufer (inkl. `freshness:regenerate`) den Schritt.
- `platform-descriptions.generated.json` zusätzlich in die `freshness:check`-Diff-Liste aufgenommen, damit eine stale committete Kopie den Gate **failt** statt still regeneriert-aber-ungeprüft zu bleiben.

## Verifikation

- `task freshness:regenerate` → führt `agent-guide:platform-descriptions` aus, Tree bleibt sauber.
- `task workspace:validate` ✓ · `task test:all` ✓ (inkl. `test:agent-guide`-Gate).
- Adversarial: Registry-Quelle sabotiert → `task freshness:check` failt (EXIT 201) und nennt nun explizit `platform-descriptions.generated.json is stale`; vorher ungeprüft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)