### PR TITLE
chore(feature-intake): HTML-Formular als Standard-Intake für Patrick

### DIFF
--- a/.claude/skills/feature-intake/SKILL.md
+++ b/.claude/skills/feature-intake/SKILL.md
@@ -11,19 +11,23 @@ Dieser Skill ist dem `dev-flow-plan` **vorgelagert**: er sammelt Feature-Ideen u
 
 | Modus | Wann | Ergebnis |
 |-------|------|---------|
-| **Brainstorm** | User ist anwesend, möchte gemeinsam ideieren | Strukturierte Feature-Liste → direkt zu `dev-flow-plan` |
-| **PM-Formular** | PM (gekko) soll Anforderungen offline einsammeln | HTML-Datei in `/tmp/` → ausgefülltes Markdown → `dev-flow-plan` |
+| **Brainstorm** | User will jetzt live mitreden / frei ideieren | Strukturierte Feature-Liste → direkt zu `dev-flow-plan` |
+| **HTML-Formular** | Auswahl + Priorisierung soll bequem per Klick statt Tippen erfolgen — **für Patrick selbst ODER für gekko** | Leicht ausfüllbares HTML-Formular → ausgefülltes Markdown → `dev-flow-plan` |
+
+**Standard-Annahme:** Patrick füllt Auswahl/Priorisierung lieber in einem **HTML-Formular** aus als in einer Inline-Text-Frage-Antwort-Runde (siehe Memory „Grilling via HTML form"). Im Zweifel **generiere das Formular** und liefere es per `SendUserFile` — nicht für gekko, sondern für ihn selbst.
 
 ---
 
 ## Modus-Wahl
 
 ```
-User ist verfügbar und will jetzt planen?
-  → Brainstorm-Modus
+User will JETZT frei mitdenken / Cluster live durchgehen?
+  → Brainstorm-Modus (Modus A)
 
-User sagt "schick gekko einen Fragebogen" / "PM soll entscheiden"?
-  → PM-Formular-Modus
+User will Features nur auswählen + priorisieren (wenig tippen),
+ODER sagt "schick gekko einen Fragebogen" / "PM soll entscheiden",
+ODER "mach mir ein Formular"?
+  → HTML-Formular-Modus (Modus B) — Empfänger = Patrick oder gekko
 ```
 
 ---
@@ -89,18 +93,33 @@ Danach: direkt zu **`dev-flow-plan`** für den gewählten Kandidaten.
 
 ---
 
-## Modus B: PM-Fragebogen (HTML-Formular)
+## Modus B: HTML-Formular (für Patrick oder gekko)
 
-**Sage:** "Ich generiere ein HTML-Formular für gekko."
+**Sage:** "Ich generiere ein HTML-Formular zum Ausfüllen." (Bei Empfänger gekko: "… für gekko.")
 
-Erstelle eine selbst-enthaltene HTML-Datei unter `/tmp/feature-intake-<YYYY-MM-DD>.html`.
+### Schritt 1 — Template nutzen, NICHT neu bauen
+
+Es gibt ein fertiges, getestetes Template: **`.claude/skills/feature-intake/pm-form-template.html`** (selbst-enthalten, dark theme, Bereich-Chips → Feature-Listen → Prio/Aufwand-Dropdowns → robuster "Markdown kopieren"-Button mit Fallback-Textfeld).
+
+```bash
+cp .claude/skills/feature-intake/pm-form-template.html /tmp/feature-intake-$(date +%F).html
+```
+
+Dann **nur den `FEATURES`-Block anpassen** (JS-Objekt im `<script>`): die Kandidaten-Listen aktualisieren, falls neue Projektbereiche/Tickets relevant sind (siehe „Vorausgefüllte Feature-Kandidaten" unten). Layout/Copy-Logik nicht neu erfinden.
+
+> Nur falls das Template fehlt oder grundlegend anders sein soll, baue von Grund auf neu — dann gelten die „Formular-Anforderungen" und „Formular-Struktur" unten als Spezifikation.
+
+### Schritt 2 — An den Empfänger liefern
+
+- **Empfänger Patrick (Standard):** Liefere die Datei direkt per `SendUserFile` (`/tmp/feature-intake-<datum>.html`), damit er sie mit einem Klick im Browser öffnen kann. Sag ihm: ausfüllen → „Markdown kopieren" → hier einfügen.
+- **Empfänger gekko:** Nenne den `/tmp/`-Pfad und beschreibe den Versandweg (z.B. anhängen/teilen). Gleiche Ausfüll-Anleitung.
 
 ### Formular-Anforderungen
 
 Das Formular muss:
-- **Kein Backend** benötigen (läuft lokal im Browser)
+- **Kein Backend** benötigen (läuft lokal im Browser via `file://`)
 - Überwiegend **Checkboxen / Radio-Buttons / Dropdowns** verwenden (minimales Tippen)
-- Einen **"Markdown kopieren"**-Button haben, der strukturierten Output in die Zwischenablage legt
+- Einen **"Markdown kopieren"**-Button haben, der strukturierten Output in die Zwischenablage legt — **mit Fallback-Textfeld**, falls `navigator.clipboard` auf `file://` scheitert (Template hat das bereits)
 - Das kopierte Markdown muss **direkt von Claude** lesbar/verarbeitbar sein
 
 ### Formular-Struktur
@@ -181,7 +200,7 @@ Nutze diese als Checkbox-Vorschläge im Formular:
 
 ### Übergabe nach Rücklauf
 
-Wenn gekko das Markdown zurückschickt:
+Wenn das ausgefüllte Markdown zurückkommt (egal ob von Patrick oder gekko):
 1. Parse die Feature-Liste (Abschnitte Hohe/Mittlere Priorität + Freie Ideen)
 2. Schlage vor, welches Feature als erstes zu `dev-flow-plan` gehen soll
 3. Erstelle auf Anfrage Tickets für alle Features der Liste

--- a/.claude/skills/feature-intake/pm-form-template.html
+++ b/.claude/skills/feature-intake/pm-form-template.html
@@ -77,6 +77,12 @@
   <button class="btn btn-primary" onclick="copyMarkdown()">📋 Markdown kopieren</button>
 </div>
 
+<div class="section" id="fallbackSection" style="display:none">
+  <h2>Markdown — manuell kopieren</h2>
+  <p style="color:var(--muted);font-size:.82rem;margin-bottom:.5rem">Automatisches Kopieren hat nicht geklappt (passiert manchmal bei lokalen Dateien). Markiere den Text unten und kopiere ihn von Hand (Strg/Cmd + C).</p>
+  <textarea id="fallbackOut" readonly style="width:100%;min-height:180px;background:var(--bg);color:var(--text);border:1px solid var(--accent);border-radius:6px;padding:.6rem .75rem;font-family:ui-monospace,monospace;font-size:.82rem;resize:vertical"></textarea>
+</div>
+
 <div class="toast" id="toast">✓ In Zwischenablage kopiert!</div>
 
 <script>
@@ -242,11 +248,38 @@ function copyMarkdown() {
     return;
   }
 
-  navigator.clipboard.writeText(lines.join('\n')).then(() => {
+  const md = lines.join('\n');
+
+  // Fallback-Textfeld immer befüllen, damit der Output nie verloren geht
+  const out = document.getElementById('fallbackOut');
+  out.value = md;
+
+  const showToast = () => {
     const t = document.getElementById('toast');
     t.classList.add('show');
     setTimeout(() => t.classList.remove('show'), 2500);
-  });
+  };
+  const showFallback = () => {
+    document.getElementById('fallbackSection').style.display = 'block';
+    out.focus();
+    out.select();
+    out.scrollIntoView({ behavior: 'smooth', block: 'center' });
+  };
+
+  // 1. moderner Clipboard-API-Weg
+  if (navigator.clipboard && navigator.clipboard.writeText) {
+    navigator.clipboard.writeText(md).then(showToast).catch(() => {
+      // 2. Fallback: execCommand('copy') über das Textfeld
+      out.style.display = 'block';
+      document.getElementById('fallbackSection').style.display = 'block';
+      out.focus(); out.select();
+      let ok = false;
+      try { ok = document.execCommand('copy'); } catch (e) { ok = false; }
+      ok ? showToast() : showFallback();
+    });
+  } else {
+    showFallback();
+  }
 }
 </script>
 </body>


### PR DESCRIPTION
## Was

Verbessert den `feature-intake`-Skill so, dass leicht ausfüllbare **HTML-Formulare auch für Patrick selbst** generiert werden — nicht mehr nur als Offline-Fragebogen für gekko.

## Änderungen

- **`SKILL.md`**
  - Modus B umgerahmt: HTML-Formular ist Standard-Intake für Patrick *oder* gekko; Lieferung an Patrick direkt per `SendUserFile`.
  - Verweist jetzt auf das vorhandene Template `pm-form-template.html` (`cp` → nur `FEATURES`-Block anpassen) statt das Formular jedes Mal neu zu bauen — schließt die Drift-Lücke (Asset lag da, wurde nie referenziert).
- **`pm-form-template.html`**
  - Robuster Kopier-Button: `navigator.clipboard` → `execCommand`-Fallback → sichtbares Fallback-Textfeld. Verhindert stillen Output-Verlust auf lokal geöffneten Dateien (`file://`).

## Verifikation

- `node --check` über das eingebettete JS: grün
- Dokumentierter `cp`-Ablauf erzeugt valides `/tmp/feature-intake-<datum>.html`

🤖 Generated with [Claude Code](https://claude.com/claude-code)