### PR TITLE
fix(e2e): stamp test-data rows to prevent inbox accumulation

### DIFF
--- a/tests/e2e/specs/fa-10-website.spec.ts
+++ b/tests/e2e/specs/fa-10-website.spec.ts
@@ -65,11 +65,27 @@ test.describe('FA-10: Unternehmenswebsite (Astro) & Kontaktformular', () => {
   });
 
   test('T6: Valid form submission succeeds', async ({ page }) => {
+    // Intercept the API call to inject the E2E marker headers so the row is
+    // stamped is_test_data=true and cleaned up by the purge bracket. Without
+    // this the browser-submitted POST carries no X-E2E-Test / X-Cron-Secret
+    // and real inbox items accumulate on every E2E run.
+    const cronSecret = process.env.CRON_SECRET;
+    if (cronSecret) {
+      await page.route('**/api/contact', async (route) => {
+        await route.continue({
+          headers: {
+            ...route.request().headers(),
+            'X-E2E-Test': '1',
+            'X-Cron-Secret': cronSecret,
+          },
+        });
+      });
+    }
     await page.goto(`${BASE}/kontakt`);
     await waitForHydration(page);
     await page.getByRole('tab', { name: /Nachricht/i }).click();
-    await page.getByRole('textbox', { name: /name/i }).first().fill('Test E2E User');
-    await page.getByRole('textbox', { name: /e-mail/i }).fill('test-e2e@example.de');
+    await page.getByRole('textbox', { name: /name/i }).first().fill('[TEST] E2E User');
+    await page.getByRole('textbox', { name: /e-mail/i }).fill('test-e2e@example.invalid');
     await page.getByRole('textbox', { name: /ihre nachricht/i }).fill('Dies ist eine automatisierte Testnachricht.');
     await page.getByRole('button', { name: /nachricht senden/i }).click();
     await expect(page.locator('text=Vielen Dank')).toBeVisible({ timeout: 10_000 });

--- a/tests/e2e/specs/fa-26-bug-report-form.spec.ts
+++ b/tests/e2e/specs/fa-26-bug-report-form.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '@playwright/test';
 
-const BASE = process.env.WEBSITE_URL || 'http://localhost:4321';
+const BASE        = process.env.WEBSITE_URL || 'http://localhost:4321';
+const CRON_SECRET = process.env.CRON_SECRET;
 
 // The bug report widget is rendered inside AdminLayout (admin-only UI).
 // These tests exercise the public /api/bug-report endpoint directly.
@@ -35,10 +36,19 @@ test.describe('FA-26: Bug report API', () => {
   });
 
   test('POST /api/bug-report with valid data returns 200 with ticketId', async ({ request }) => {
+    // X-E2E-Test + X-Cron-Secret stamps is_test_data=true so the purge bracket
+    // cleans up the created ticket and inbox item. Without these headers the row
+    // accumulates in the admin inbox on every E2E run.
+    const headers: Record<string, string> = {};
+    if (CRON_SECRET) {
+      headers['X-E2E-Test'] = '1';
+      headers['X-Cron-Secret'] = CRON_SECRET;
+    }
     const res = await request.post(`${BASE}/api/bug-report`, {
+      headers,
       multipart: {
         description: 'Automatischer E2E-Test: Seite lädt nicht korrekt.',
-        email: 'e2e-test@example.de',
+        email: 'e2e-test@example.invalid',
         category: 'fehler',
         url: `${BASE}/`,
       },

--- a/tests/e2e/specs/fa-bugs-notifications.spec.ts
+++ b/tests/e2e/specs/fa-bugs-notifications.spec.ts
@@ -20,10 +20,11 @@
 import { test, expect } from '@playwright/test';
 import { assertAuthenticatedReachable } from '../lib/health-assertions';
 
-const BASE       = process.env.WEBSITE_URL ?? 'http://localhost:4321';
-const MAILPIT    = process.env.MAILPIT_URL  ?? 'http://localhost:8025';
-const ADMIN_USER = process.env.E2E_ADMIN_USER ?? 'paddione';
-const ADMIN_PASS = process.env.E2E_ADMIN_PASS;
+const BASE        = process.env.WEBSITE_URL ?? 'http://localhost:4321';
+const MAILPIT     = process.env.MAILPIT_URL  ?? 'http://localhost:8025';
+const ADMIN_USER  = process.env.E2E_ADMIN_USER ?? 'paddione';
+const ADMIN_PASS  = process.env.E2E_ADMIN_PASS;
+const CRON_SECRET = process.env.CRON_SECRET;
 
 test.describe('FA-bug-notify', () => {
   test('reporter receives close-mail when admin resolves ticket', async ({ page, request }, testInfo) => {
@@ -37,7 +38,13 @@ test.describe('FA-bug-notify', () => {
     // ── Step 1: Submit public bug report via API (no auth required) ──
     const reporter = `e2e-${Date.now()}@example.com`;
 
+    const e2eHeaders: Record<string, string> = {};
+    if (CRON_SECRET) {
+      e2eHeaders['X-E2E-Test'] = '1';
+      e2eHeaders['X-Cron-Secret'] = CRON_SECRET;
+    }
     const create = await request.post(`${BASE}/api/bug-report`, {
+      headers: e2eHeaders,
       multipart: {
         description: 'E2E notification test — Playwright FA-bug-notify',
         email:       reporter,


### PR DESCRIPTION
## Summary

- Three E2E tests were submitting real form data without the `X-E2E-Test` + `X-Cron-Secret` marker headers, so `fn_purge_test_data()` never cleaned them up
- **fa-10 T6** (contact form via browser UI): added `page.route('**/api/contact')` to inject E2E headers before the browser POST is forwarded
- **fa-26 T4** (bug-report via `request.post()`): added E2E headers when `CRON_SECRET` is available
- **fa-bugs-notifications** (bug-report submission): same fix
- Switched test emails to `@example.invalid` (reserved TLD) and names to `[TEST]` prefix

**Manual cleanup already applied to prod:** 6 test contacts + 10 test bug tickets purged directly from the DB.

## Test plan

- [ ] CI green (`task test:all`)
- [ ] Next nightly E2E run leaves zero new test rows in admin inbox
- [ ] `fa-10` T6 still asserts "Vielen Dank" success message
- [ ] `fa-26` T4 still asserts `ticketId` in response body

🤖 Generated with [Claude Code](https://claude.com/claude-code)