### PR TITLE
chore(hooks): auto-regenerate freshness artifacts in pre-commit

### DIFF
--- a/.claude/skills/dev-flow-chore/SKILL.md
+++ b/.claude/skills/dev-flow-chore/SKILL.md
@@ -55,6 +55,8 @@ task freshness:regenerate   # generierte Artefakte aktuell halten, sonst CI rot
 
 Siehe [dev-flow-gotchas.md](file:///home/patrick/Bachelorprojekt/.claude/skills/references/dev-flow-gotchas.md) für TypeScript/pnpm-Gotchas in Worktrees.
 
+> **⚠ Freshness-Guard (vor jedem Commit):** Neue Test-Specs, Routen oder Assets ändern generierte Indexdateien (`repo-index.json`, `test-inventory.json`, …). Ohne Regenerierung schlägt CI fehl. Der Pre-commit-Hook erledigt das automatisch nach `task secrets:install-hooks` — ohne Hook: `task freshness:regenerate` manuell ausführen und staged Änderungen mitcommittten.
+
 ## Schritt 4: Commit, Push & PR
 
 ```bash

--- a/.claude/skills/dev-flow-execute/SKILL.md
+++ b/.claude/skills/dev-flow-execute/SKILL.md
@@ -189,6 +189,8 @@ Rufe `dev-flow-iterate` auf, um Änderungen im dev-Cluster zu testen.
 
 ---
 
+> **⚠ Freshness-Guard (vor dem Commit):** Wenn Schritt 3 (`task freshness:regenerate`) übersprungen oder der Subagent es vergessen hat, schlägt CI mit "stale artifact" fehl. Prüfe: `git diff --name-only` sollte keine generierten Indexdateien zeigen. Falls doch: `task freshness:regenerate && git add` nachholen. Der Pre-commit-Hook automatisiert das nach `task secrets:install-hooks`.
+
 ## Schritt 5: PR erstellen
 
 ```bash

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -20,3 +20,37 @@ if ! bash "$repo_root/scripts/git-crypt-guard.sh" check-staged; then
   echo "Did you run 'git-crypt unlock'? See docs/WSL-BOOTSTRAP.md." >&2
   exit 1
 fi
+
+# --- freshness: auto-regenerate generated artifacts before commit [T000581] ---
+# Prevents CI failures when new test/route/asset files are added without regenerating.
+# Best-effort: never blocks the commit if task or node is unavailable.
+_FRESHNESS_FILES=(
+  website/src/data/test-inventory.json
+  website/src/data/route-manifest.json
+  website/src/lib/learning-assets.generated.json
+  website/public/learning-assets/THIRD-PARTY-ASSETS.md
+  docs/code-quality/repo-index.json
+  docs/agent-guide/10-ziele.md
+  docs/agent-guide/20-werkzeuge.md
+  docs/agent-guide/30-bausteine.md
+  docs/agent-guide/maps/goals-map.md
+  docs/agent-guide/maps/tools-map.md
+  docs/agent-guide/maps/danger-map.md
+  website/src/lib/agent-guide.generated.json
+  website/src/lib/platform-descriptions.generated.json
+)
+if command -v task >/dev/null 2>&1 && task --version 2>&1 | grep -q "Task version"; then
+  if (cd "$repo_root" && task freshness:regenerate > /dev/null 2>&1); then
+    _staged=0
+    for _f in "${_FRESHNESS_FILES[@]}"; do
+      if ! git -C "$repo_root" diff --quiet -- "$_f" 2>/dev/null; then
+        git -C "$repo_root" add -- "$_f"
+        echo "  ↻ freshness: auto-staged $_f"
+        _staged=$((_staged + 1))
+      fi
+    done
+    [ "$_staged" -gt 0 ] && echo "  ↻ freshness: $_staged artifact(s) updated — included in this commit."
+  else
+    echo "  ⚠ freshness:regenerate failed — verify generated artifacts are current." >&2
+  fi
+fi


### PR DESCRIPTION
## Summary

- `.githooks/pre-commit`: runs `task freshness:regenerate` automatically before every commit, auto-stages any changed generated artifacts (repo-index.json, test-inventory.json, route-manifest.json, agent-guide maps, etc.)
- `dev-flow-chore` skill: adds a ⚠️ Freshness-Guard callout before Schritt 4 (commit)
- `dev-flow-execute` skill: adds a ⚠️ Freshness-Guard callout before Schritt 5 (PR/commit)

**Motivation:** PR #1516 CI failed because `docs/code-quality/repo-index.json` wasn't regenerated after adding `fa-48-factory-devflow.spec.ts`. This is a recurring pattern — the hook makes it impossible to accidentally commit stale artifacts.

The hook is best-effort (`|| true` on failure) so it never blocks a commit if `task` or `node` is unavailable.

## Test plan
- [ ] Commit a new file in a repo with hooks installed → verify generated artifacts are auto-staged
- [ ] CI passes on this PR (freshness:check green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)