### PR TITLE
feat(website): add image upload to HTML editor

### DIFF
--- a/website/src/components/admin/DokumentEditor.svelte
+++ b/website/src/components/admin/DokumentEditor.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import HtmlEditor from './HtmlEditor.svelte';
   import NewsletterAdmin from './NewsletterAdmin.svelte';
   import QuestionnaireTemplateEditor from './QuestionnaireTemplateEditor.svelte';
 
@@ -240,16 +241,9 @@
 
         <!-- HTML editor — DIN-A4 width (794 px) -->
         <div class="overflow-x-auto">
-          <div>
-            <label class="block text-sm text-muted mb-1">HTML-Inhalt *</label>
-            <textarea
-              bind:value={composeHtml}
-              placeholder="<h1>Vertrag</h1><p>Inhalt hier…</p>"
-              rows="18"
-              style="width: 794px"
-              class="bg-dark border border-dark-lighter rounded-lg px-3 py-2 text-light text-sm font-mono focus:border-gold focus:ring-1 focus:ring-gold/20 outline-none resize-y"
-            ></textarea>
-            <p class="text-xs text-muted mt-1" style="width: 794px">
+          <div style="width: 794px">
+            <HtmlEditor bind:value={composeHtml} rows={18} label="HTML-Inhalt *" />
+            <p class="text-xs text-muted mt-1">
               Feste Platzhalter (direkt ins PDF eingebettet):
               <span class="font-mono text-gold/80">&#123;&#123;KUNDENNUMMER&#125;&#125;</span>
               <span class="font-mono text-gold/80">&#123;&#123;DATUM&#125;&#125;</span>

--- a/website/src/components/admin/HtmlEditor.svelte
+++ b/website/src/components/admin/HtmlEditor.svelte
@@ -9,6 +9,7 @@
     placeholder = '<p>HTML hier eingeben…</p>',
     rows = 20,
     label = 'HTML-Inhalt',
+    enableImageUpload = true,
   }: {
     value?: string;
     previewMode?: 'direct' | 'server';
@@ -17,11 +18,16 @@
     placeholder?: string;
     rows?: number;
     label?: string;
+    enableImageUpload?: boolean;
   } = $props();
 
   let viewMode = $state<ViewMode>('split');
   let serverPreviewHtml = $state('');
   let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+  let uploading = $state(false);
+  let dragOver = $state(false);
+  let fileInput: HTMLInputElement;
+  let textareaEl: HTMLTextAreaElement;
 
   const iframeSrcdoc = $derived(
     previewMode === 'direct'
@@ -54,6 +60,79 @@
 
   const btnCls = (active: boolean) =>
     `px-2.5 py-1 text-xs rounded transition-colors ${active ? 'bg-gold text-dark font-semibold' : 'bg-dark-lighter text-muted hover:text-light'}`;
+
+  async function uploadImage(file: File): Promise<string | null> {
+    const formData = new FormData();
+    formData.append('file', file);
+    try {
+      const res = await fetch('/api/admin/assets/upload', {
+        method: 'POST',
+        body: formData,
+      });
+      if (!res.ok) return null;
+      const data = await res.json();
+      return data.url;
+    } catch {
+      return null;
+    }
+  }
+
+  function insertAtCursor(text: string) {
+    if (!textareaEl) {
+      value += text;
+      return;
+    }
+    const start = textareaEl.selectionStart;
+    const end = textareaEl.selectionEnd;
+    value = value.slice(0, start) + text + value.slice(end);
+    requestAnimationFrame(() => {
+      textareaEl.selectionStart = textareaEl.selectionEnd = start + text.length;
+      textareaEl.focus();
+    });
+  }
+
+  async function handleFiles(files: FileList | File[]) {
+    const imageFiles = Array.from(files).filter(f =>
+      f.type === 'image/jpeg' || f.type === 'image/png' || f.type === 'image/webp'
+    );
+    if (imageFiles.length === 0) return;
+    uploading = true;
+    try {
+      for (const file of imageFiles) {
+        const url = await uploadImage(file);
+        if (url) {
+          insertAtCursor(`<img src="${url}" alt="">`);
+        }
+      }
+    } finally {
+      uploading = false;
+    }
+  }
+
+  function onFileSelect(e: Event) {
+    const input = e.target as HTMLInputElement;
+    if (input.files) {
+      handleFiles(input.files);
+      input.value = '';
+    }
+  }
+
+  function onDragOver(e: DragEvent) {
+    e.preventDefault();
+    dragOver = true;
+  }
+
+  function onDragLeave() {
+    dragOver = false;
+  }
+
+  function onDrop(e: DragEvent) {
+    e.preventDefault();
+    dragOver = false;
+    if (e.dataTransfer?.files) {
+      handleFiles(e.dataTransfer.files);
+    }
+  }
 </script>
 
 <div class="flex flex-col gap-2">
@@ -66,14 +145,45 @@
     </div>
   </div>
 
+  {#if enableImageUpload && viewMode !== 'preview'}
+    <div class="flex items-center gap-2">
+      <input
+        type="file"
+        accept="image/jpeg,image/png,image/webp"
+        multiple
+        bind:this={fileInput}
+        onchange={onFileSelect}
+        class="hidden"
+      />
+      <button
+        type="button"
+        onclick={() => fileInput.click()}
+        disabled={uploading}
+        class="px-2.5 py-1 text-xs rounded bg-dark-lighter text-muted hover:text-light transition-colors disabled:opacity-50"
+      >{uploading ? 'Lädt…' : 'Bild'}</button>
+    </div>
+  {/if}
+
   <div class={`flex gap-3 ${viewMode === 'split' ? 'flex-row' : 'flex-col'}`} style="min-height: {rows * 24}px">
     {#if viewMode !== 'preview'}
-      <textarea
-        bind:value
-        {placeholder}
-        {rows}
-        class={`bg-dark border border-dark-lighter rounded-lg px-3 py-2 text-light text-sm font-mono focus:border-gold focus:ring-1 focus:ring-gold/20 outline-none resize-y ${viewMode === 'split' ? 'w-1/2' : 'w-full'}`}
-      ></textarea>
+      <div class={`relative ${viewMode === 'split' ? 'w-1/2' : 'w-full'}`}>
+        <textarea
+          bind:this={textareaEl}
+          bind:value
+          {placeholder}
+          {rows}
+          ondragover={enableImageUpload ? onDragOver : undefined}
+          ondragenter={enableImageUpload ? onDragOver : undefined}
+          ondragleave={enableImageUpload ? onDragLeave : undefined}
+          ondrop={enableImageUpload ? onDrop : undefined}
+          class={`bg-dark border border-dark-lighter rounded-lg px-3 py-2 text-light text-sm font-mono focus:border-gold focus:ring-1 focus:ring-gold/20 outline-none resize-y w-full`}
+        ></textarea>
+        {#if dragOver}
+          <div class="absolute inset-0 flex items-center justify-center bg-gold/20 border-2 border-dashed border-gold rounded-lg pointer-events-none">
+            <span class="text-gold font-semibold text-sm">Bild hier ablegen</span>
+          </div>
+        {/if}
+      </div>
     {/if}
 
     {#if viewMode !== 'editor'}

--- a/website/src/pages/api/admin/assets/upload.ts
+++ b/website/src/pages/api/admin/assets/upload.ts
@@ -1,0 +1,97 @@
+import type { APIRoute } from 'astro';
+import { randomUUID } from 'node:crypto';
+import { getSession, isAdmin } from '../../../../lib/auth';
+import { pool } from '../../../../lib/website-db';
+import { ensureFolder, uploadFile } from '../../../../lib/nextcloud-files';
+
+const MAX_SIZE = 10 * 1024 * 1024;
+const ALLOWED = ['image/jpeg', 'image/png', 'image/webp'];
+
+function sanitizeFilename(name: string): string {
+  const normalized = name
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-zA-Z0-9._-]/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '')
+    .slice(0, 120);
+  return normalized || 'file';
+}
+
+function getExt(mime: string): string {
+  if (mime === 'image/jpeg') return 'jpg';
+  if (mime === 'image/png') return 'png';
+  if (mime === 'image/webp') return 'webp';
+  return 'bin';
+}
+
+export const POST: APIRoute = async ({ request }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401, headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  let form: FormData;
+  try {
+    form = await request.formData();
+  } catch {
+    return new Response(JSON.stringify({ error: 'Ungültiges Formular' }), {
+      status: 400, headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const file = form.get('file') as File | null;
+  if (!file || typeof file === 'string') {
+    return new Response(JSON.stringify({ error: 'Keine Datei übermittelt' }), {
+      status: 400, headers: { 'Content-Type': 'application/json' },
+    });
+  }
+  if (!ALLOWED.includes(file.type)) {
+    return new Response(JSON.stringify({ error: 'Nur JPEG, PNG oder WebP erlaubt' }), {
+      status: 400, headers: { 'Content-Type': 'application/json' },
+    });
+  }
+  if (file.size > MAX_SIZE) {
+    return new Response(JSON.stringify({ error: 'Datei zu groß (max. 10 MB)' }), {
+      status: 400, headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const now = new Date();
+  const monthFolder = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
+  const uuid = randomUUID();
+  const ext = getExt(file.type);
+  const originalName = sanitizeFilename(file.name);
+  const ncFolder = `EditorImages/${monthFolder}`;
+  const ncPath = `${ncFolder}/${uuid}.${ext}`;
+  const filePath = `editor-images/${monthFolder}/${uuid}.${ext}`;
+
+  try {
+    await ensureFolder(ncFolder);
+    const buffer = Buffer.from(await file.arrayBuffer());
+    await uploadFile(ncPath, buffer, file.type);
+
+    await pool.query(
+      `INSERT INTO assets.registry (name, type, file_path, metadata)
+       VALUES ($1, 'image', $2, $3)`,
+      [originalName, filePath, JSON.stringify({
+        original_name: file.name,
+        size_bytes: file.size,
+        mime_type: file.type,
+      })],
+    );
+
+    return new Response(JSON.stringify({
+      url: `/api/assets/${filePath}`,
+      asset_id: uuid,
+    }), {
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (err) {
+    return new Response(JSON.stringify({ error: 'Upload fehlgeschlagen' }), {
+      status: 500, headers: { 'Content-Type': 'application/json' },
+    });
+  }
+};

--- a/website/src/pages/api/assets/[...path].ts
+++ b/website/src/pages/api/assets/[...path].ts
@@ -1,0 +1,38 @@
+import type { APIRoute } from 'astro';
+import { pool } from '../../../lib/website-db';
+import { downloadFile } from '../../../lib/nextcloud-files';
+
+export const GET: APIRoute = async ({ params }) => {
+  const pathParts = params.path;
+  if (!pathParts) {
+    return new Response('Not Found', { status: 404 });
+  }
+
+  const filePath = Array.isArray(pathParts) ? pathParts.join('/') : pathParts;
+
+  try {
+    const result = await pool.query(
+      `SELECT file_path, metadata FROM assets.registry WHERE file_path = $1`,
+      [filePath],
+    );
+
+    if (result.rows.length === 0) {
+      return new Response('Not Found', { status: 404 });
+    }
+
+    const row = result.rows[0];
+    const ncPath = `EditorImages/${row.file_path.replace('editor-images/', '')}`;
+    const buffer = await downloadFile(ncPath);
+
+    const mime = row.metadata?.mime_type || 'application/octet-stream';
+
+    return new Response(buffer, {
+      headers: {
+        'Content-Type': mime,
+        'Cache-Control': 'public, max-age=86400',
+      },
+    });
+  } catch {
+    return new Response('Not Found', { status: 404 });
+  }
+};


### PR DESCRIPTION
## Ticket
10283f10 — Website: Bild-Upload direkt im HTML-Editor

## Changes
- Upload-API (`/api/admin/assets/upload.ts`) — multipart, 10 MB max, JPG/PNG/WebP
- Asset-Proxy (`/api/assets/[...path].ts`) — öffentliche Auslieferung aus Nextcloud
- HtmlEditor.svelte — Upload-Button + Drag & Drop Zone
- DokumentEditor.svelte — auf HtmlEditor umgestellt

## Verification
- `npm --prefix website run build` ✅
- `task test:all` ✅ (262/262 tests pass)

## Storage
Bilder in `assets.registry` (Schema `assets`), relative Pfade im HTML