### PR TITLE
feat(infra): add post-deploy monitoring with auto-rollback

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -2143,6 +2143,7 @@ tasks:
           if [ "{{.ENV}}" = "mentolder" ]; then
             task livekit:dns-pin ENV="{{.ENV}}" APPLY=true || true
           fi
+          bash scripts/post-deploy-watch.sh "{{.ENV}}" || true
         fi
       - 'echo "✓ Workspace deployed to {{.ENV}}"'
       - 'echo ""'

--- a/environments/fleet-korczewski.yaml
+++ b/environments/fleet-korczewski.yaml
@@ -65,6 +65,8 @@ env_vars:
   ARENA_WS_URL: https://arena-ws.korczewski.de
   # Dev stack intentionally omitted — dev migration is Phase 2c.
   DEV_SSH_ALLOWLIST: ""
+  PUSHOVER_TOKEN: ""
+  PUSHOVER_USER: ""
 
 # overlay points at the fleet wrapper (reuses prod-korczewski + deletes the
 # platform-owned cluster singletons via the fleet-common component). workspace:deploy

--- a/environments/fleet-mentolder.yaml
+++ b/environments/fleet-mentolder.yaml
@@ -65,6 +65,8 @@ env_vars:
   ARENA_WS_URL: https://arena-ws.mentolder.de
   # Dev stack intentionally omitted — dev migration is Phase 2c.
   DEV_SSH_ALLOWLIST: ""
+  PUSHOVER_TOKEN: ""
+  PUSHOVER_USER: ""
 
 # overlay points at the fleet wrapper (reuses prod-mentolder + deletes the
 # platform-owned cluster singletons via the fleet-common component). workspace:deploy

--- a/environments/korczewski.yaml
+++ b/environments/korczewski.yaml
@@ -67,6 +67,8 @@ env_vars:
   DEV_WEBSITE_HOST: web.dev.korczewski.de
   DEV_BRETT_HOST: brett.dev.korczewski.de
   DEV_SSH_ALLOWLIST: ""
+  PUSHOVER_TOKEN: ""
+  PUSHOVER_USER: ""
 
 overlay: prod-fleet/korczewski
 workspace_namespace: workspace-korczewski

--- a/environments/mentolder.yaml
+++ b/environments/mentolder.yaml
@@ -69,6 +69,8 @@ env_vars:
   # dev node's public IP), so the brainstorm reverse-SSH tunnel can publish to
   # the dev sish (brainstorm.dev.mentolder.de) [T000364].
   DEV_SSH_ALLOWLIST: "217.195.151.153/32"
+  PUSHOVER_TOKEN: ""
+  PUSHOVER_USER: ""
 
 overlay: prod-fleet/mentolder
 workspace_namespace: workspace

--- a/environments/schema.yaml
+++ b/environments/schema.yaml
@@ -761,6 +761,16 @@ secrets:
     generate: false
     description: "Hetzner Cloud API token for the cluster's project. Used for node provisioning and automation via the Hetzner Cloud API."
 
+  - name: PUSHOVER_TOKEN
+    required: false
+    generate: false
+    description: "Pushover API token for deploy notifications. Optional — notifications are skipped when unset."
+
+  - name: PUSHOVER_USER
+    required: false
+    generate: false
+    description: "Pushover user key for deploy notifications. Optional — notifications are skipped when unset."
+
   # ─────────────────────────────────────────────────────────────────
   # Dev stack — sealed against mentolder cluster cert.
   # The shared-db-dev passwords are DISTINCT from prod's shared-db

--- a/scripts/feature-promote.sh
+++ b/scripts/feature-promote.sh
@@ -54,6 +54,11 @@ set -euo pipefail
 REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO"
 
+# shellcheck disable=SC1091
+source "$REPO/scripts/lib/notify.sh"
+# shellcheck disable=SC1091
+source "$REPO/scripts/lib/post-deploy-watch.sh"
+
 SERVICE="${SERVICE:-}"
 TARGET="${TARGET:-}"
 PROMOTE_TAG="${PROMOTE_TAG:-promote-$(git rev-parse --short HEAD 2>/dev/null || echo nogit)-$(date +%s)}"
@@ -225,16 +230,14 @@ roll() {
 # ── Layer-4 live-prod canary + capture-revision rollback (Phase 1D) ───────────
 # observe_prod <cluster> <full_image>
 # Precondition: the prod set-image for <cluster> already ran (via roll prod …).
-# Captures the pre-deploy revision FIRST, re-probes the LIVE web.<brand>.de site
-# (unauth grep from tests/e2e/smoke/website.txt) for ~5 min, and on red rolls the
-# deployment back to the captured revision. Context is resolved STRICTLY via
-# env-resolve.sh (ENV_CONTEXT=fleet); prod_ctx() also resolves via env-resolve.sh now.
+# Runs post_deploy_watch() for CrashLoopBackOff + healthcheck monitoring,
+# then runs Playwright smoke only if the watch passes. On failure, rolls back
+# to the captured pre-deploy revision.
 observe_prod() {
   local cluster="$1" full="$2"
   local deploy ns ctx prev_rev live grep_pat
   deploy=$(svc_deployment "$SERVICE")
 
-  # Context strictly via env-resolve.sh → ENV_CONTEXT=fleet (same as prod_ctx() does).
   # shellcheck disable=SC1091
   source "$REPO/scripts/env-resolve.sh" "$cluster" >/dev/null
   ctx="$ENV_CONTEXT"
@@ -245,42 +248,37 @@ observe_prod() {
     korczewski) live="https://web.korczewski.de" ;;
   esac
 
-  # Pre-deploy revision = current minus one (the set-image already bumped it).
   prev_rev=$(run kubectl --context "$ctx" -n "$ns" rollout history "deploy/${deploy}" \
               2>/dev/null | awk 'NF && $1 ~ /^[0-9]+$/ {r=$1} END{print r-1}')
   [[ -z "$prev_rev" || "$prev_rev" -lt 1 ]] && prev_rev=""
 
-  echo "▸ Canary observe prod/${cluster}: re-probe ${live} for ~5 min (rev to keep=${full}, fallback rev=${prev_rev:-<none>})"
+  echo "▸ Canary observe prod/${cluster}: post-deploy-watch + smoke (${live}, rev=${prev_rev:-<none>})"
+
+  if ! post_deploy_watch "$cluster" "$deploy" "$ns" "$ctx" "${live}/api/health"; then
+    echo "✗ post-deploy-watch FAILED on prod/${cluster} — rollback already triggered" >&2
+    return 1
+  fi
 
   grep_pat=$(resolve_smoke_grep "$SERVICE")
-  local ok=1 i
-  for i in 1 2 3 4 5; do
-    # readiness gate first: /api/health must answer 200 on the live site.
+  if [[ -n "$grep_pat" ]]; then
     if [[ "$DRY_RUN" == "1" ]]; then
-      echo "  [dry-run] canary probe $i/5: curl -fsS ${live}/api/health && playwright --grep '${grep_pat}'"
-    else
-      if curl -fsS -o /dev/null --max-time 20 "${live}/api/health"; then
-        if [[ -z "$grep_pat" ]] || smoke_one "$cluster" "$grep_pat"; then ok=0; break; fi
+      echo "  [dry-run] playwright --grep '${grep_pat}' against ${live}"
+    elif ! smoke_one "$cluster" "$grep_pat"; then
+      echo "✗ Canary RED on prod/${cluster} — rolling back ${deploy} to revision ${prev_rev:-previous}…" >&2
+      if [[ -n "$prev_rev" ]]; then
+        run kubectl --context "$ctx" -n "$ns" rollout undo "deploy/${deploy}" --to-revision="$prev_rev" || true
+      else
+        run kubectl --context "$ctx" -n "$ns" rollout undo "deploy/${deploy}" || true
       fi
-      [[ "$i" -lt 5 ]] && sleep 60
+      run kubectl --context "$ctx" -n "$ns" rollout status "deploy/${deploy}" --timeout=120s || true
+      notify_pushover "Deploy FAIL ${cluster}" "Playwright smoke failed on ${deploy} — rolled back to rev ${prev_rev:-previous}" "1"
+      echo "↩ Canary rolled prod/${cluster} back (rev=${prev_rev:-previous})." >&2
+      return 1
     fi
-  done
-  [[ "$DRY_RUN" == "1" ]] && return 0
-
-  if (( ok == 0 )); then
-    echo "✓ Canary GREEN on prod/${cluster}."
-    return 0
   fi
 
-  echo "✗ Canary RED on prod/${cluster} — rolling back ${deploy} to revision ${prev_rev:-previous}…" >&2
-  if [[ -n "$prev_rev" ]]; then
-    run kubectl --context "$ctx" -n "$ns" rollout undo "deploy/${deploy}" --to-revision="$prev_rev" || true
-  else
-    run kubectl --context "$ctx" -n "$ns" rollout undo "deploy/${deploy}" || true
-  fi
-  run kubectl --context "$ctx" -n "$ns" rollout status "deploy/${deploy}" --timeout=120s || true
-  echo "↩ Canary rolled prod/${cluster} back (rev=${prev_rev:-previous})." >&2
-  return 1
+  echo "✓ Canary GREEN on prod/${cluster}."
+  return 0
 }
 
 # ── Playwright smoke ─────────────────────────────────────────────────────────

--- a/scripts/lib/notify.sh
+++ b/scripts/lib/notify.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+notify_pushover() {
+  local title="$1" message="$2" priority="${3:-0}"
+  if [[ -z "${PUSHOVER_TOKEN:-}" || -z "${PUSHOVER_USER:-}" ]]; then
+    echo "⚠ Pushover not configured (PUSHOVER_TOKEN/PUSHOVER_USER missing) — skipping notification" >&2
+    return 0
+  fi
+  if ! curl -fsS --max-time 10 -d "token=${PUSHOVER_TOKEN}&user=${PUSHOVER_USER}&title=${title}&message=${message}&priority=${priority}" https://api.pushover.net/1/messages.json 2>/dev/null; then
+    echo "⚠ Pushover notification failed (curl error) — continuing" >&2
+  fi
+}

--- a/scripts/lib/post-deploy-watch.sh
+++ b/scripts/lib/post-deploy-watch.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+post_deploy_watch() {
+  local cluster="$1" deployment="$2" namespace="$3" context="$4" health_url="$5"
+  local errors=0 i
+  for i in 1 2 3 4 5; do
+    echo "▸ post-deploy-watch ${cluster}: probe ${i}/5 (${deployment} in ${namespace})"
+    if [[ "${DRY_RUN:-0}" == "1" ]]; then
+      echo "  [dry-run] kubectl --context ${context} -n ${namespace} get pods -l app=${deployment}"
+      echo "  [dry-run] curl -fsS ${health_url}"
+      return 0
+    fi
+    local crash_pods
+    crash_pods=$(kubectl --context "$context" -n "$namespace" get pods -l "app=${deployment}" \
+      -o jsonpath='{range .items[*]}{.status.containerStatuses[0].state.waiting.reason}{"\n"}{end}' 2>/dev/null || true)
+    if echo "$crash_pods" | grep -qE 'CrashLoopBackOff|Error|OOMKilled'; then
+      echo "✗ CrashLoopBackOff/Error/OOMKilled detected on ${cluster}/${deployment}" >&2
+      notify_pushover "Deploy FAIL ${cluster}" "CrashLoopBackOff detected on ${deployment} in ${namespace} — rolling back" "1"
+      kubectl --context "$context" -n "$namespace" rollout undo "deploy/${deployment}" || true
+      kubectl --context "$context" -n "$namespace" rollout status "deploy/${deployment}" --timeout=120s || true
+      return 1
+    fi
+    if curl -fsS -o /dev/null --max-time 20 "$health_url" 2>/dev/null; then
+      errors=0
+    else
+      errors=$((errors + 1))
+      echo "  healthcheck failed (${errors}/3)" >&2
+    fi
+    if [[ "$errors" -ge 3 ]]; then
+      echo "✗ 3 consecutive healthcheck failures on ${cluster}/${deployment}" >&2
+      notify_pushover "Deploy FAIL ${cluster}" "3 consecutive healthcheck failures on ${deployment} in ${namespace} — rolling back" "1"
+      kubectl --context "$context" -n "$namespace" rollout undo "deploy/${deployment}" || true
+      kubectl --context "$context" -n "$namespace" rollout status "deploy/${deployment}" --timeout=120s || true
+      return 1
+    fi
+    [[ "$i" -lt 5 ]] && sleep 60
+  done
+  echo "✓ post-deploy-watch ${cluster}: ${deployment} healthy"
+  return 0
+}

--- a/scripts/post-deploy-watch.sh
+++ b/scripts/post-deploy-watch.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO"
+
+# shellcheck disable=SC1091
+source "$REPO/scripts/lib/notify.sh"
+# shellcheck disable=SC1091
+source "$REPO/scripts/lib/post-deploy-watch.sh"
+
+ENV="${1:-}"
+if [[ -z "$ENV" ]]; then
+  echo "Usage: $0 <env>" >&2
+  echo "  e.g. $0 mentolder" >&2
+  exit 1
+fi
+
+# shellcheck disable=SC1091
+source "$REPO/scripts/env-resolve.sh" "$ENV"
+
+DRY_RUN="${DRY_RUN:-0}"
+CTX="${ENV_CONTEXT}"
+WS_NS="${WORKSPACE_NAMESPACE:-workspace}"
+
+if [[ "$WS_NS" == "workspace" ]]; then
+  WEB_NS="website"
+else
+  WEB_NS="website-${WS_NS#workspace-}"
+fi
+
+case "$ENV" in
+  mentolder|fleet-mentolder)
+    HEALTH_URL="https://web.mentolder.de/api/health"
+    BRAND="mentolder"
+    ;;
+  korczewski|fleet-korczewski)
+    HEALTH_URL="https://web.korczewski.de/api/health"
+    BRAND="korczewski"
+    ;;
+  *)
+    echo "✗ Unsupported ENV='${ENV}'" >&2
+    exit 1
+    ;;
+esac
+
+FAIL=0
+
+echo "═══ Post-deploy watch for ${ENV} ═══"
+
+DEPLOYMENTS=(
+  "keycloak:${WS_NS}"
+  "nextcloud:${WS_NS}"
+  "shared-db:${WS_NS}"
+  "website:${WEB_NS}"
+)
+
+if [[ "$BRAND" == "korczewski" ]]; then
+  DEPLOYMENTS+=("arena-server:${WS_NS}")
+fi
+
+for entry in "${DEPLOYMENTS[@]}"; do
+  deploy="${entry%%:*}"
+  ns="${entry##*:}"
+  if ! post_deploy_watch "$BRAND" "$deploy" "$ns" "$CTX" "$HEALTH_URL"; then
+    FAIL=1
+  fi
+done
+
+if [[ "$FAIL" -eq 1 ]]; then
+  echo ""
+  echo "✗ At least one post-deploy watch failed for ${ENV}" >&2
+  exit 1
+fi
+
+echo ""
+echo "✓ All post-deploy watches passed for ${ENV}"


### PR DESCRIPTION
## Ticket
1e1c2151 — Infra: Automatisches Rollback bei Failed Deploy

## Changes
- `scripts/lib/notify.sh` — Pushover-Notification-Library
- `scripts/lib/post-deploy-watch.sh` — Post-Deploy-Monitoring-Funktion
- `scripts/post-deploy-watch.sh` — Standalone-Entry-Point
- `feature-promote.sh` — `observe_prod()` refactored, nutzt `post_deploy_watch()`
- `Taskfile.yml` — `workspace:deploy` ruft Post-Deploy-Watch auf
- Schema + Env-Dateien — `PUSHOVER_TOKEN` + `PUSHOVER_USER` (optional)

## Verification
- `bash -n` syntax OK ✅
- `task test:unit` ✅

## Behavior
5 Checks in 60s-Abstand, CrashLoopBackOff oder 3x Healthcheck-Fehler → Auto-Rollback + Pushover