### PR TITLE
feat(website): dynamic SEO metadata editor with OG image upload and sitemap

### DIFF
--- a/website/src/components/admin/SeoEditor.svelte
+++ b/website/src/components/admin/SeoEditor.svelte
@@ -1,68 +1,8 @@
 <script lang="ts">
-  type PageDef = { key: string; label: string; fallbackDesc: string; fallbackTitle?: string };
+  type PageDef = { key: string; label: string; path: string };
 
-  const PAGES: PageDef[] = [
-    {
-      key: 'home',
-      label: 'Startseite',
-      fallbackTitle: 'Gerald Korczewski – Coach & Mentor',
-      fallbackDesc: 'Coaching & digitale Begleitung in Lüneburg und Hamburg – persönlich, erfahren, auf Augenhöhe. Für Führungsperslichkeiten und Menschen in Veränderung.',
-    },
-    {
-      key: 'kontakt',
-      label: 'Kontakt',
-      fallbackDesc: 'Nehmen Sie Kontakt auf – kostenloses Erstgespräch, kein Verkaufsdruck.',
-    },
-    {
-      key: 'ueber-mich',
-      label: 'Über mich',
-      fallbackTitle: 'Gerald Korczewski – Coach, Mentor & KI-Pionier',
-      fallbackDesc: 'Gerald Korczewski: 30+ Jahre Führungserfahrung bei der Polizei Hamburg, systemischer Coach, KI-Pionier. Begleitung für Frauen und Männer in Führung und Veränderung.',
-    },
-    {
-      key: 'leistungen',
-      label: 'Angebote',
-      fallbackDesc: 'Coaching, digitale Begleitung 50+ und Unternehmensberatung – Angebote von Gerald Korczewski.',
-    },
-    {
-      key: 'coaching',
-      label: '/coaching',
-      fallbackTitle: 'Coaching für Führungskräfte & Menschen in Verantwortung | mentolder.de',
-      // KORRIGIERT: 40+ → 30+ Jahre Führungserfahrung
-      fallbackDesc: 'Karriere-Coaching für Führungskräfte in Lüneburg und Hamburg. Profil schärfen, Strategie entwickeln, Gespräche vorbereiten – auf Augenhöhe mit 30+ Jahren Führungserfahrung.',
-    },
-    {
-      key: '50plus-digital',
-      label: '/50plus-digital',
-      fallbackTitle: '50+ digital – Digitale Begleitung in Lüneburg & Hamburg | mentolder.de',
-      fallbackDesc: 'Digitale Begleitung für Menschen 50+ in Lüneburg und Hamburg. Smartphone, WhatsApp, Online-Banking – Schritt für Schritt, ohne Fachchinesisch, in Ihrem Tempo.',
-    },
-    {
-      key: 'beratung',
-      label: '/beratung',
-      fallbackTitle: 'Digitale Transformation & KI-Beratung für Mittelstand | mentolder.de',
-      fallbackDesc: 'Digitale Transformation & KI-Strategie für Mittelstand, Verwaltung und kritische Infrastrukturen – mit 40 Jahren Praxis. Lüneburg & Hamburg.',
-    },
-    {
-      key: 'ki-transition',
-      label: '/ki-transition',
-      fallbackTitle: 'KI-Transition Coaching – Orientierung im digitalen Wandel | mentolder.de',
-      fallbackDesc: 'KI verändert Berufsbilder – ich begleite Sie dabei. Für IT-Fachkräfte, Führungspersonlichkeiten und Unternehmen in Lüneburg, Hamburg und online.',
-    },
-    {
-      key: 'fuehrung-persoenlichkeit',
-      label: '/fuehrung-persoenlichkeit',
-      fallbackTitle: 'Führung & Persönlichkeit – Coaching für Führungskräfte | mentolder.de',
-      fallbackDesc: 'Führen aus der Mitte: Coaching für Frauen und Männer in Führung. Standortbestimmung, Authentizität, Entscheidungen in Unsicherheit – in Lüneburg, Hamburg und online.',
-    },
-    {
-      key: 'referenzen',
-      label: '/referenzen',
-      fallbackDesc: 'Referenzen und Kooperationspartner von Gerald Korczewski – Unternehmen, Behörden und Organisationen, mit denen ich zusammengearbeitet habe.',
-    },
-  ];
-
-  let values = $state<Record<string, { desc: string; title: string }>>({});
+  let pages = $state<PageDef[]>([]);
+  let values = $state<Record<string, { desc: string; title: string; ogImage: string }>>({});
   let savingKey = $state<string | null>(null);
   let messages = $state<Record<string, { text: string; ok: boolean }>>({});
   let loading = $state(true);
@@ -70,14 +10,20 @@
 
   async function load() {
     try {
-      const res = await fetch('/api/admin/seo');
-      if (!res.ok) { loadError = 'Fehler beim Laden.'; return; }
-      const data: { descriptions: Record<string, string>; titles: Record<string, string> } = await res.json();
-      const initial: Record<string, { desc: string; title: string }> = {};
-      for (const p of PAGES) {
+      const [pagesRes, seoRes] = await Promise.all([
+        fetch('/api/admin/seo/pages'),
+        fetch('/api/admin/seo'),
+      ]);
+      if (!pagesRes.ok || !seoRes.ok) { loadError = 'Fehler beim Laden.'; return; }
+      const pagesData: { pages: PageDef[] } = await pagesRes.json();
+      const seoData: { descriptions: Record<string, string>; titles: Record<string, string>; ogImages: Record<string, string> } = await seoRes.json();
+      pages = pagesData.pages;
+      const initial: Record<string, { desc: string; title: string; ogImage: string }> = {};
+      for (const p of pagesData.pages) {
         initial[p.key] = {
-          desc: data.descriptions?.[p.key] ?? p.fallbackDesc,
-          title: data.titles?.[p.key] ?? (p.fallbackTitle ?? ''),
+          desc: seoData.descriptions?.[p.key] ?? '',
+          title: seoData.titles?.[p.key] ?? '',
+          ogImage: seoData.ogImages?.[p.key] ?? '',
         };
       }
       values = initial;
@@ -99,6 +45,7 @@
           pageKey,
           description: values[pageKey]?.desc ?? '',
           title: values[pageKey]?.title ?? '',
+          ogImage: values[pageKey]?.ogImage ?? '',
         }),
       });
       messages = {
@@ -114,7 +61,29 @@
     }
   }
 
-  function charClass(len: number): string {
+  async function uploadOgImage(pageKey: string, file: File) {
+    const form = new FormData();
+    form.append('file', file);
+    try {
+      const res = await fetch('/api/admin/seo/upload-og-image', { method: 'POST', body: form });
+      if (!res.ok) return;
+      const data: { src: string } = await res.json();
+      values = { ...values, [pageKey]: { ...values[pageKey], ogImage: data.src } };
+    } catch { /* ignore */ }
+  }
+
+  function removeOgImage(pageKey: string) {
+    values = { ...values, [pageKey]: { ...values[pageKey], ogImage: '' } };
+  }
+
+  function titleCharClass(len: number): string {
+    if (len >= 50 && len <= 70) return 'text-green-400';
+    if (len >= 30 && len < 50) return 'text-yellow-400';
+    if (len > 70) return 'text-red-400';
+    return 'text-yellow-400';
+  }
+
+  function descCharClass(len: number): string {
     if (len >= 120 && len <= 160) return 'text-green-400';
     if (len >= 100 && len < 120) return 'text-yellow-400';
     if (len > 160) return 'text-red-400';
@@ -140,23 +109,35 @@
   {:else if loadError}
     <p class="text-red-400 text-sm">{loadError}</p>
   {:else}
-    {#each PAGES as page}
+    {#each pages as page}
       {@const desc = values[page.key]?.desc ?? ''}
       {@const descLen = desc.length}
+      {@const titleVal = values[page.key]?.title ?? ''}
+      {@const titleLen = titleVal.length}
+      {@const ogImg = values[page.key]?.ogImage ?? ''}
       <div class="border border-dark-lighter rounded-xl p-4 space-y-3">
-        <p class="text-xs font-mono uppercase tracking-widest text-gold">{page.label}</p>
+        <div class="flex items-center justify-between">
+          <p class="text-xs font-mono uppercase tracking-widest text-gold">{page.label}</p>
+          <span class="text-xs text-muted font-mono">{page.path}</span>
+        </div>
 
-        {#if page.fallbackTitle !== undefined}
-          <div>
-            <label class={labelCls}>Seitentitel (title-Tag)</label>
-            <input
-              type="text"
-              class={inputLineCls}
-              bind:value={values[page.key].title}
-              placeholder={page.fallbackTitle}
-            />
+        <div>
+          <label class={labelCls}>Seitentitel (title-Tag)</label>
+          <input
+            type="text"
+            class={inputLineCls}
+            bind:value={values[page.key].title}
+            placeholder="Standard-Titel verwenden"
+          />
+          <div class="flex items-center gap-2 mt-1">
+            <span class="text-xs {titleCharClass(titleLen)} font-mono">
+              {titleLen} Zeichen
+              {#if titleLen >= 50 && titleLen <= 70}(gut)
+              {:else if titleLen > 70}(zu lang — Ziel: 50–70)
+              {:else}(Ziel: 50–70){/if}
+            </span>
           </div>
-        {/if}
+        </div>
 
         <div>
           <label class={labelCls}>Meta-Beschreibung</label>
@@ -164,14 +145,44 @@
             rows={3}
             class={inputCls}
             bind:value={values[page.key].desc}
-            placeholder={page.fallbackDesc}
+            placeholder="Standard-Beschreibung verwenden"
           ></textarea>
           <div class="flex items-center gap-2 mt-1">
-            <span class="text-xs {charClass(descLen)} font-mono">
+            <span class="text-xs {descCharClass(descLen)} font-mono">
               {descLen} Zeichen
               {#if descLen < 120}(zu kurz — Ziel: 120–160){:else if descLen > 160}(zu lang — Ziel: 120–160){:else}(gut){/if}
             </span>
           </div>
+        </div>
+
+        <div>
+          <label class={labelCls}>OG-Bild</label>
+          {#if ogImg}
+            <div class="flex items-center gap-3">
+              <img src={ogImg} alt="OG-Bild Vorschau" class="h-16 w-auto rounded border border-dark-lighter" />
+              <button
+                onclick={() => removeOgImage(page.key)}
+                class="px-3 py-1.5 text-xs bg-red-500/20 text-red-400 rounded-lg hover:bg-red-500/30"
+              >
+                Entfernen
+              </button>
+            </div>
+          {:else}
+            <p class="text-xs text-muted mb-2">Brand-Default wird verwendet.</p>
+          {/if}
+          <label class="inline-flex items-center gap-2 mt-2 px-3 py-1.5 bg-dark-lighter text-light text-xs rounded-lg cursor-pointer hover:bg-dark-lighter/80">
+            <span>{ogImg ? 'Anderes Bild hochladen' : 'Bild hochladen'}</span>
+            <input
+              type="file"
+              accept="image/jpeg,image/png,image/webp"
+              class="hidden"
+              onchange={(e) => {
+                const f = (e.target as HTMLInputElement).files?.[0];
+                if (f) uploadOgImage(page.key, f);
+                (e.target as HTMLInputElement).value = '';
+              }}
+            />
+          </label>
         </div>
 
         <div class="flex items-center justify-end gap-3">

--- a/website/src/layouts/Layout.astro
+++ b/website/src/layouts/Layout.astro
@@ -14,11 +14,13 @@ interface Props {
   rawTitle?: boolean;
   description?: string;
   brand?: string;
+  ogImage?: string;
 }
 
-const { title, rawTitle = false, description = config.meta.siteDescription, brand } = Astro.props;
+const { title, rawTitle = false, description = config.meta.siteDescription, brand, ogImage } = Astro.props;
 const isKore = brand === 'korczewski-kore';
 const pageTitle = rawTitle ? title : `${title} | ${config.meta.siteTitle}`;
+const effectiveOgImage = ogImage || (isKore ? '/brand/korczewski/og-image.png' : '/brand/mentolder/og-image.png');
 const effectiveNav = await getEffectiveNavigation().catch(() => null);
 // Map NavItem[] (with order) to NavigationLink[] shape expected by Navigation component
 const navLinks = effectiveNav
@@ -44,11 +46,11 @@ const navLinks = effectiveNav
         <meta property="og:title" content={title} />
         <meta property="og:description" content={description} />
         <meta property="og:url" content={`https://web.korczewski.de${Astro.url.pathname}`} />
-        <meta property="og:image" content="/brand/korczewski/og-image.png" />
+        <meta property="og:image" content={effectiveOgImage} />
         <meta property="og:image:width" content="1200" />
         <meta property="og:image:height" content="630" />
         <meta name="twitter:card" content="summary_large_image" />
-        <meta name="twitter:image" content="/brand/korczewski/og-image.png" />
+        <meta name="twitter:image" content={effectiveOgImage} />
       </>
     ) : (
       <>
@@ -57,11 +59,11 @@ const navLinks = effectiveNav
         <meta property="og:title" content={title} />
         <meta property="og:description" content={description} />
         <meta property="og:url" content={`https://web.mentolder.de${Astro.url.pathname}`} />
-        <meta property="og:image" content="/brand/mentolder/og-image.png" />
+        <meta property="og:image" content={effectiveOgImage} />
         <meta property="og:image:width" content="1200" />
         <meta property="og:image:height" content="630" />
         <meta name="twitter:card" content="summary_large_image" />
-        <meta name="twitter:image" content="/brand/mentolder/og-image.png" />
+        <meta name="twitter:image" content={effectiveOgImage} />
       </>
     )}
     <link rel="preconnect" href="https://fonts.googleapis.com" />

--- a/website/src/lib/website-db.ts
+++ b/website/src/lib/website-db.ts
@@ -1072,6 +1072,26 @@ export async function getSeoTitle(brand: string, pageKey: string): Promise<strin
   return getSiteSetting(brand, `seo_title_${pageKey}`).catch(() => null);
 }
 
+export async function getSeoOgImage(brand: string, pageKey: string): Promise<string | null> {
+  return getSiteSetting(brand, `seo_og_image_${pageKey}`).catch(() => null);
+}
+
+export async function getSeoMeta(brand: string, pageKey: string): Promise<{ title: string | null; description: string | null; ogImage: string | null }> {
+  const result = await pool.query(
+    `SELECT key, value FROM site_settings WHERE brand = $1 AND key IN ($2, $3, $4)`,
+    [brand, `seo_title_${pageKey}`, `seo_meta_desc_${pageKey}`, `seo_og_image_${pageKey}`],
+  );
+  const map: Record<string, string> = {};
+  for (const row of result.rows) {
+    map[row.key as string] = row.value as string;
+  }
+  return {
+    title: map[`seo_title_${pageKey}`] ?? null,
+    description: map[`seo_meta_desc_${pageKey}`] ?? null,
+    ogImage: map[`seo_og_image_${pageKey}`] ?? null,
+  };
+}
+
 // ── Vacation / Blackout Periods ───────────────────────────────────────────────
 
 export interface VacationPeriod {

--- a/website/src/pages/[service].astro
+++ b/website/src/pages/[service].astro
@@ -4,7 +4,7 @@ import CallToAction from '../components/CallToAction.svelte';
 import FAQ from '../components/FAQ.svelte';
 import { getEffectiveServices } from '../lib/content';
 import { config } from '../config/index';
-import { getSiteSetting, getSeoTitle } from '../lib/website-db';
+import { getSiteSetting, getSeoTitle, getSeoOgImage } from '../lib/website-db';
 
 const BRAND_ID = process.env.BRAND_ID ?? process.env.BRAND ?? 'mentolder';
 const layoutBrand = BRAND_ID === 'korczewski' ? 'korczewski-kore' : undefined;
@@ -33,13 +33,15 @@ const useRawTitle = seoTitle !== svc.title;
 const dbSeoDesc = await getSiteSetting(BRAND_ID, `seo_meta_desc_${svc.slug}`).catch(() => null);
 const seoDesc = dbSeoDesc ?? (pc as any).seoDescription ?? svc.description;
 
+const seoOgImage = await getSeoOgImage(BRAND_ID, svc.slug).catch(() => null);
+
 // introNote: special section rendered between intro and forWhom
 const introNoteSection = pc.sections?.find((s) => s.title === '__introNote__');
 const introNoteParagraphs = introNoteSection?.items ?? [];
 const visibleSections = (pc.sections ?? []).filter((s) => s.title !== '__introNote__');
 ---
 
-<Layout title={seoTitle} rawTitle={useRawTitle} description={seoDesc} brand={layoutBrand}>
+<Layout title={seoTitle} rawTitle={useRawTitle} description={seoDesc} brand={layoutBrand} ogImage={seoOgImage ?? undefined}>
   <section class="pt-28 pb-16 bg-dark">
     <div class="max-w-4xl mx-auto px-6">
       <nav class="mb-6" aria-label="Breadcrumb">

--- a/website/src/pages/api/admin/seo/index.ts
+++ b/website/src/pages/api/admin/seo/index.ts
@@ -9,22 +9,25 @@ export const GET: APIRoute = async ({ request }) => {
   if (!session || !isAdmin(session)) return new Response('Unauthorized', { status: 401 });
 
   const result = await pool.query(
-    `SELECT key, value FROM site_settings WHERE brand = $1 AND (key LIKE 'seo_meta_desc_%' OR key LIKE 'seo_title_%')`,
+    `SELECT key, value FROM site_settings WHERE brand = $1 AND (key LIKE 'seo_meta_desc_%' OR key LIKE 'seo_title_%' OR key LIKE 'seo_og_image_%')`,
     [BRAND],
   );
 
   const descriptions: Record<string, string> = {};
   const titles: Record<string, string> = {};
+  const ogImages: Record<string, string> = {};
   for (const row of result.rows) {
     const key = row.key as string;
     if (key.startsWith('seo_meta_desc_')) {
       descriptions[key.replace('seo_meta_desc_', '')] = row.value as string;
+    } else if (key.startsWith('seo_og_image_')) {
+      ogImages[key.replace('seo_og_image_', '')] = row.value as string;
     } else if (key.startsWith('seo_title_')) {
       titles[key.replace('seo_title_', '')] = row.value as string;
     }
   }
 
-  return new Response(JSON.stringify({ descriptions, titles }), {
+  return new Response(JSON.stringify({ descriptions, titles, ogImages }), {
     headers: { 'Content-Type': 'application/json' },
   });
 };

--- a/website/src/pages/api/admin/seo/pages.ts
+++ b/website/src/pages/api/admin/seo/pages.ts
@@ -1,0 +1,36 @@
+import type { APIRoute } from 'astro';
+import { getSession, isAdmin } from '../../../../lib/auth';
+import { getEffectiveServices } from '../../../../lib/content';
+import { listCustomSections } from '../../../../lib/website-db';
+
+const STATIC_PAGES: Array<{ key: string; label: string; path: string }> = [
+  { key: 'home', label: 'Startseite', path: '/' },
+  { key: 'kontakt', label: 'Kontakt', path: '/kontakt' },
+  { key: 'ueber-mich', label: 'Über mich', path: '/ueber-mich' },
+  { key: 'leistungen', label: 'Angebote', path: '/leistungen' },
+  { key: 'referenzen', label: 'Referenzen', path: '/referenzen' },
+];
+
+export const GET: APIRoute = async ({ request }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) return new Response('Unauthorized', { status: 401 });
+
+  const services = await getEffectiveServices().catch(() => []);
+  const customSections = await listCustomSections().catch(() => []);
+
+  const servicePages = services
+    .filter((s) => !s.hidden)
+    .map((s) => ({ key: s.slug, label: `/${s.slug}`, path: `/${s.slug}` }));
+
+  const sectionPages = customSections.map((cs) => ({
+    key: cs.slug,
+    label: cs.title,
+    path: `/${cs.slug}`,
+  }));
+
+  const pages = [...STATIC_PAGES, ...servicePages, ...sectionPages];
+
+  return new Response(JSON.stringify({ pages }), {
+    headers: { 'Content-Type': 'application/json' },
+  });
+};

--- a/website/src/pages/api/admin/seo/save.ts
+++ b/website/src/pages/api/admin/seo/save.ts
@@ -4,17 +4,11 @@ import { setSiteSetting } from '../../../../lib/website-db';
 
 const BRAND = process.env.BRAND || 'mentolder';
 
-const ALLOWED_PAGE_KEYS = [
-  'home', 'kontakt', 'ueber-mich', 'leistungen',
-  'coaching', '50plus-digital', 'beratung', 'ki-transition',
-  'fuehrung-persoenlichkeit',
-];
-
 export const POST: APIRoute = async ({ request }) => {
   const session = await getSession(request.headers.get('cookie'));
   if (!session || !isAdmin(session)) return new Response('Unauthorized', { status: 401 });
 
-  let body: { pageKey: string; description: string; title?: string };
+  let body: { pageKey: string; description: string; title?: string; ogImage?: string };
   try {
     body = await request.json();
   } catch {
@@ -24,10 +18,10 @@ export const POST: APIRoute = async ({ request }) => {
     });
   }
 
-  const { pageKey, description, title } = body;
+  const { pageKey, description, title, ogImage } = body;
 
-  if (!ALLOWED_PAGE_KEYS.includes(pageKey)) {
-    return new Response(JSON.stringify({ error: 'Invalid pageKey' }), {
+  if (typeof pageKey !== 'string' || !pageKey) {
+    return new Response(JSON.stringify({ error: 'pageKey is required' }), {
       status: 400,
       headers: { 'Content-Type': 'application/json' },
     });
@@ -43,9 +37,22 @@ export const POST: APIRoute = async ({ request }) => {
   try {
     if (description.trim()) {
       await setSiteSetting(BRAND, `seo_meta_desc_${pageKey}`, description);
+    } else {
+      await setSiteSetting(BRAND, `seo_meta_desc_${pageKey}`, '');
     }
-    if (title !== undefined && typeof title === 'string' && title.trim()) {
-      await setSiteSetting(BRAND, `seo_title_${pageKey}`, title);
+    if (title !== undefined && typeof title === 'string') {
+      if (title.trim()) {
+        await setSiteSetting(BRAND, `seo_title_${pageKey}`, title);
+      } else {
+        await setSiteSetting(BRAND, `seo_title_${pageKey}`, '');
+      }
+    }
+    if (ogImage !== undefined) {
+      if (typeof ogImage === 'string' && ogImage.trim()) {
+        await setSiteSetting(BRAND, `seo_og_image_${pageKey}`, ogImage);
+      } else {
+        await setSiteSetting(BRAND, `seo_og_image_${pageKey}`, '');
+      }
     }
   } catch (err) {
     console.error('[seo/save] DB error:', err);

--- a/website/src/pages/api/admin/seo/upload-og-image.ts
+++ b/website/src/pages/api/admin/seo/upload-og-image.ts
@@ -1,0 +1,48 @@
+import type { APIRoute } from 'astro';
+import { getSession, isAdmin } from '../../../../lib/auth';
+
+const MAX_SIZE = 2 * 1024 * 1024;
+const ALLOWED  = ['image/jpeg', 'image/png', 'image/webp'];
+
+export const POST: APIRoute = async ({ request }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session || !isAdmin(session)) {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401, headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  let form: FormData;
+  try {
+    form = await request.formData();
+  } catch {
+    return new Response(JSON.stringify({ error: 'Ungültiges Formular' }), {
+      status: 400, headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const file = form.get('file') as File | null;
+  if (!file || typeof file === 'string') {
+    return new Response(JSON.stringify({ error: 'Keine Datei übermittelt' }), {
+      status: 400, headers: { 'Content-Type': 'application/json' },
+    });
+  }
+  if (!ALLOWED.includes(file.type)) {
+    return new Response(JSON.stringify({ error: 'Nur JPEG, PNG oder WebP erlaubt' }), {
+      status: 400, headers: { 'Content-Type': 'application/json' },
+    });
+  }
+  if (file.size > MAX_SIZE) {
+    return new Response(JSON.stringify({ error: 'Datei zu groß (max. 2 MB)' }), {
+      status: 400, headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const buffer = await file.arrayBuffer();
+  const base64 = Buffer.from(buffer).toString('base64');
+  const dataUrl = `data:${file.type};base64,${base64}`;
+
+  return new Response(JSON.stringify({ src: dataUrl }), {
+    headers: { 'Content-Type': 'application/json' },
+  });
+};

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -12,7 +12,7 @@ import { config } from '../config/index';
 import type { DaySlots } from '../lib/caldav';
 import { getAvailableSlots } from '../lib/caldav';
 import { getEffectiveServices, getEffectiveHomepage, getEffectiveFaq, getEffectiveStammdaten, getEffectiveNavigation, getEffectiveFooter, getEffectiveKoreFlags } from '../lib/content';
-import { listTimeline, getSiteSetting, getSeoTitle } from '../lib/website-db';
+import { listTimeline, getSiteSetting, getSeoTitle, getSeoOgImage } from '../lib/website-db';
 
 const BRAND_ID = process.env.BRAND_ID ?? process.env.BRAND ?? 'mentolder';
 const isKore = BRAND_ID === 'korczewski';
@@ -27,6 +27,10 @@ const homeTitle = !isKore
   ? await getSeoTitle(BRAND_ID, 'home').catch(() => null)
   : null;
 const pageTitle = homeTitle ?? config.meta.siteTitle;
+
+const homeOgImage = !isKore
+  ? await getSeoOgImage(BRAND_ID, 'home').catch(() => null)
+  : null;
 
 const [homepage, faq, allServices, stammdaten, effectiveNav, effectiveFooter, effectiveKoreFlags] = await Promise.all([
   getEffectiveHomepage(),
@@ -56,7 +60,7 @@ try {
 const processSteps = homepage.processSteps ?? [];
 ---
 
-<Layout title={pageTitle} rawTitle={!isKore} description={metaDescription} brand={layoutBrand}>
+<Layout title={pageTitle} rawTitle={!isKore} description={metaDescription} brand={layoutBrand} ogImage={homeOgImage ?? undefined}>
   {isKore ? (
     <KoreHomepage
       client:load

--- a/website/src/pages/kontakt.astro
+++ b/website/src/pages/kontakt.astro
@@ -4,7 +4,7 @@ import ContactHub from '../components/ContactHub.svelte';
 import BookingForm from '../components/BookingForm.svelte';
 import { config } from '../config/index';
 import { getEffectiveKontakt, getEffectiveStammdaten } from '../lib/content';
-import { getSiteSetting } from '../lib/website-db';
+import { getSiteSetting, getSeoOgImage } from '../lib/website-db';
 
 const BRAND_ID = process.env.BRAND_ID ?? process.env.BRAND ?? 'mentolder';
 const isKore = BRAND_ID === 'korczewski';
@@ -31,9 +31,10 @@ const slotPreview  = rawMode === 'termin' && initialDate && initialStart;
 const seoTitle = await getSiteSetting(BRAND_ID, 'seo_title_kontakt').catch(() => null) ?? 'Kontakt | mentolder.de';
 const seoDesc  = await getSiteSetting(BRAND_ID, 'seo_meta_desc_kontakt').catch(() => null)
   ?? 'Nehmen Sie Kontakt auf. Kostenloses Erstgespräch vereinbaren – kein Verkaufsdruck.';
+const seoOgImage = await getSeoOgImage(BRAND_ID, 'kontakt').catch(() => null);
 ---
 
-<Layout title={seoTitle} description={seoDesc} brand={layoutBrand}>
+<Layout title={seoTitle} description={seoDesc} brand={layoutBrand} ogImage={seoOgImage ?? undefined}>
   {slotPreview && (
     <section class="slot-preview">
       <div class="slot-preview-inner">

--- a/website/src/pages/referenzen.astro
+++ b/website/src/pages/referenzen.astro
@@ -1,6 +1,7 @@
 ---
 import Layout from '../layouts/Layout.astro';
 import { getEffectiveReferenzen } from '../lib/content';
+import { getSeoOgImage } from '../lib/website-db';
 import type { ReferenzItem } from '../lib/website-db';
 
 const BRAND_ID = process.env.BRAND_ID ?? process.env.BRAND ?? 'mentolder';
@@ -9,6 +10,7 @@ const layoutBrand = BRAND_ID === 'korczewski' ? 'korczewski-kore' : undefined;
 const config = await getEffectiveReferenzen();
 const heading = config.heading?.trim() || 'Referenzen';
 const subheading = config.subheading?.trim() || 'Unternehmen und Personen, die mir ihr Vertrauen geschenkt haben.';
+const seoOgImage = await getSeoOgImage(BRAND_ID, 'referenzen').catch(() => null);
 
 // Group items by type, in the order defined by config.types.
 // Items with no type (or with a type that no longer exists) are appended in a final "Weitere" group.
@@ -33,7 +35,7 @@ const populatedGroups = groups.filter((g) => g.items.length > 0);
 const hasGrouping = populatedGroups.length > 1 || (populatedGroups.length === 1 && populatedGroups[0].id !== '__untyped__');
 ---
 
-<Layout title={heading} brand={layoutBrand}>
+<Layout title={heading} brand={layoutBrand} ogImage={seoOgImage ?? undefined}>
   <section class="pt-28 pb-20">
     <div class="max-w-4xl mx-auto px-6">
 

--- a/website/src/pages/sitemap.xml.ts
+++ b/website/src/pages/sitemap.xml.ts
@@ -1,0 +1,40 @@
+import type { APIRoute } from 'astro';
+import { getEffectiveServices } from '../lib/content';
+import { listCustomSections } from '../lib/website-db';
+
+const BRAND = process.env.BRAND || 'mentolder';
+const DOMAIN = BRAND === 'korczewski' ? 'web.korczewski.de' : 'web.mentolder.de';
+
+const STATIC_PATHS = ['/', '/kontakt', '/ueber-mich', '/leistungen', '/referenzen'];
+
+export const GET: APIRoute = async () => {
+  const services = await getEffectiveServices().catch(() => []);
+  const customSections = await listCustomSections().catch(() => []);
+
+  const servicePaths = services
+    .filter((s) => !s.hidden)
+    .map((s) => `/${s.slug}`);
+
+  const sectionPaths = customSections.map((cs) => `/${cs.slug}`);
+
+  const allPaths = [...STATIC_PATHS, ...servicePaths, ...sectionPaths];
+  const baseUrl = `https://${DOMAIN}`;
+
+  const urls = allPaths.map((path) => {
+    const loc = path === '/' ? baseUrl : `${baseUrl}${path}`;
+    return `  <url>\n    <loc>${escapeXml(loc)}</loc>\n    <changefreq>weekly</changefreq>\n    <priority>${path === '/' ? '1.0' : '0.8'}</priority>\n  </url>`;
+  });
+
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${urls.join('\n')}
+</urlset>`;
+
+  return new Response(xml, {
+    headers: { 'Content-Type': 'application/xml; charset=utf-8' },
+  });
+};
+
+function escapeXml(str: string): string {
+  return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&apos;');
+}

--- a/website/src/pages/ueber-mich.astro
+++ b/website/src/pages/ueber-mich.astro
@@ -3,7 +3,7 @@ import Layout from '../layouts/Layout.astro';
 import CallToAction from '../components/CallToAction.svelte';
 import { config } from '../config/index';
 import { getEffectiveUebermich, getEffectiveStammdaten } from '../lib/content';
-import { getSiteSetting, getSeoTitle } from '../lib/website-db';
+import { getSiteSetting, getSeoTitle, getSeoOgImage } from '../lib/website-db';
 
 const BRAND_ID = process.env.BRAND_ID ?? process.env.BRAND ?? 'mentolder';
 const layoutBrand = BRAND_ID === 'korczewski' ? 'korczewski-kore' : undefined;
@@ -16,9 +16,10 @@ const seoTitle = await getSeoTitle(BRAND_ID, 'ueber-mich').catch(() => null)
   ?? `Gerald Korczewski – Coach, Mentor & KI-Pionier`;
 const seoDesc = await getSiteSetting(BRAND_ID, 'seo_meta_desc_ueber-mich').catch(() => null)
   ?? `Über ${sName} – ${config.legal.tagline}`;
+const seoOgImage = await getSeoOgImage(BRAND_ID, 'ueber-mich').catch(() => null);
 ---
 
-<Layout title={seoTitle} rawTitle={true} description={seoDesc} brand={layoutBrand}>
+<Layout title={seoTitle} rawTitle={true} description={seoDesc} brand={layoutBrand} ogImage={seoOgImage ?? undefined}>
   <section class="pt-28 pb-16 bg-dark">
     <div class="max-w-4xl mx-auto px-6">
       <p class="text-gold font-semibold text-lg mb-4 tracking-widest uppercase">{uebermich.subheadline}</p>


### PR DESCRIPTION
## Ticket
3e6d6927 — Website: SEO-Metadaten-Editor

## Changes
- `website-db.ts` — `getSeoOgImage()`, `getSeoMeta()` Helper
- `/api/admin/seo/pages.ts` — dynamische Seitenliste
- `/api/admin/seo/upload-og-image.ts` — OG-Bild-Upload
- `/api/admin/seo/index.ts` + `save.ts` — OG-Image-Feld erweitert
- `Layout.astro` — `ogImage` Prop mit Brand-Default-Fallback
- `SeoEditor.svelte` — dynamisch, OG-Bild-Upload, Zeichenzähler
- Alle statischen Seiten + `[service].astro` — OG-Bild laden
- `/sitemap.xml.ts` — dynamische Sitemap (SSR)

## Verification
- `npm --prefix website run build` ✅ (17s)

## Features
- Alle Seiten unterstützt (nicht nur die alten 9)
- OG-Title = Meta-Title (gleiches Feld)
- OG-Bild Upload mit Default-Fallback
- Sitemap-Generierung für beide Brands