### PR TITLE
ci: expand docs-only paths-ignore to include **/CLAUDE.md

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
     paths-ignore:
       - 'docs/**'
       - '*.md'
+      - '**/CLAUDE.md'
   push:
     branches:
       - main
@@ -17,6 +18,7 @@ on:
     paths-ignore:
       - 'docs/**'
       - '*.md'
+      - '**/CLAUDE.md'
 
 concurrency:
   # Cancel superseded runs on the same PR (rapid iteration / stacked Factory pushes);


### PR DESCRIPTION
## Ticket
eea90c15 — CI Auto-Skip bei Docs-only-Changes

## Changes
- `.github/workflows/ci.yml` — `**/CLAUDE.md` zu `paths-ignore` hinzugefügt

## Verification
- YAML-Syntax valid ✅

## Effect
PRs die ausschließlich `*.md`, `docs/**`, oder `**/CLAUDE.md` ändern, triggern die CI-Pipeline nicht mehr.