### PR TITLE
fix(tdr): auto-trigger successor readiness on ticket → done

### DIFF
--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -458,7 +458,7 @@
       "id": "website",
       "name": "Astro + Svelte website",
       "owner_agent": "bachelorprojekt-website",
-      "file_count": 1197,
+      "file_count": 1198,
       "files": [
         "website/.build-trigger",
         "website/.dockerignore",
@@ -1133,6 +1133,7 @@
         "website/src/lib/tax-monitor.ts",
         "website/src/lib/test-runner.ts",
         "website/src/lib/ticket-graph.ts",
+        "website/src/lib/ticket-readiness.ts",
         "website/src/lib/ticket-triage.ts",
         "website/src/lib/tickets-db.featureflag.test.ts",
         "website/src/lib/tickets-db.providerrouting.test.ts",

--- a/scripts/code-quality/gates/s2-cycles.test.mjs
+++ b/scripts/code-quality/gates/s2-cycles.test.mjs
@@ -64,18 +64,17 @@ test('runS2 THROWS (fail closed) when a graph dir is missing instead of reportin
   );
 });
 
-test('real-tree S2 counts are unchanged: website=6, arena-server=0, e2e=0', () => {
+test('real-tree S2 counts are unchanged: website=5, arena-server=0, e2e=0', () => {
   // Frozen-baseline guard: the hardening must not perturb the live counts.
-  // Baseline bumped 5→6: transition.ts now imports ticket-graph.ts which imports
-  // website-db.ts, extending the pre-existing transition↔website-db cycle by one node.
+  // ticket-readiness.ts uses Pool DI (no import of website-db.ts), so no new cycle.
   const res = runS2(repoRoot, loadGates(cfgDir));
   const byGraph = {};
   for (const v of res.violations) {
     const id = v.key.split(':')[1];
     byGraph[id] = (byGraph[id] || 0) + 1;
   }
-  assert.equal(byGraph.website ?? 0, 6);
+  assert.equal(byGraph.website ?? 0, 5);
   assert.equal(byGraph['arena-server'] ?? 0, 0);
   assert.equal(byGraph.e2e ?? 0, 0);
-  assert.equal(res.violations.length, 6);
+  assert.equal(res.violations.length, 5);
 });

--- a/scripts/code-quality/gates/s2-cycles.test.mjs
+++ b/scripts/code-quality/gates/s2-cycles.test.mjs
@@ -64,16 +64,18 @@ test('runS2 THROWS (fail closed) when a graph dir is missing instead of reportin
   );
 });
 
-test('real-tree S2 counts are unchanged: website=5, arena-server=0, e2e=0', () => {
+test('real-tree S2 counts are unchanged: website=6, arena-server=0, e2e=0', () => {
   // Frozen-baseline guard: the hardening must not perturb the live counts.
+  // Baseline bumped 5→6: transition.ts now imports ticket-graph.ts which imports
+  // website-db.ts, extending the pre-existing transition↔website-db cycle by one node.
   const res = runS2(repoRoot, loadGates(cfgDir));
   const byGraph = {};
   for (const v of res.violations) {
     const id = v.key.split(':')[1];
     byGraph[id] = (byGraph[id] || 0) + 1;
   }
-  assert.equal(byGraph.website ?? 0, 5);
+  assert.equal(byGraph.website ?? 0, 6);
   assert.equal(byGraph['arena-server'] ?? 0, 0);
   assert.equal(byGraph.e2e ?? 0, 0);
-  assert.equal(res.violations.length, 5);
+  assert.equal(res.violations.length, 6);
 });

--- a/tests/unit/readiness-webhook.bats
+++ b/tests/unit/readiness-webhook.bats
@@ -9,7 +9,7 @@ PROJECT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
 setup() {
   export PROJECT_DIR
   READINESS_API="${PROJECT_DIR}/website/src/pages/api/tickets/[id]/readiness.ts"
-  GRAPH_LIB="${PROJECT_DIR}/website/src/lib/ticket-graph.ts"
+  READINESS_LIB="${PROJECT_DIR}/website/src/lib/ticket-readiness.ts"
 }
 
 @test "static: readiness API endpoint exists" {
@@ -48,16 +48,16 @@ setup() {
   grep -q "updateSuccessorReadiness" "$READINESS_API"
 }
 
-@test "static: graph lib exports updateSuccessorReadiness" {
-  grep -q "export async function updateSuccessorReadiness" "$GRAPH_LIB"
+@test "static: readiness lib exports updateSuccessorReadiness" {
+  grep -q "export async function updateSuccessorReadiness" "$READINESS_LIB"
 }
 
-@test "static: graph lib exports allPredecessorsDone" {
-  grep -q "export async function allPredecessorsDone" "$GRAPH_LIB"
+@test "static: readiness lib exports allPredecessorsDone" {
+  grep -q "export async function allPredecessorsDone" "$READINESS_LIB"
 }
 
 @test "static: updateSuccessorReadiness sets abhaengigkeiten_klar in readiness JSONB" {
-  grep -q "abhaengigkeiten_klar" "$GRAPH_LIB"
+  grep -q "abhaengigkeiten_klar" "$READINESS_LIB"
 }
 
 @test "static: TypeScript syntax valid" {

--- a/tests/unit/ticket-graph.bats
+++ b/tests/unit/ticket-graph.bats
@@ -9,6 +9,7 @@ PROJECT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
 setup() {
   export PROJECT_DIR
   GRAPH_LIB="${PROJECT_DIR}/website/src/lib/ticket-graph.ts"
+  READINESS_LIB="${PROJECT_DIR}/website/src/lib/ticket-readiness.ts"
   GRAPH_API="${PROJECT_DIR}/website/src/pages/api/tickets/graph.ts"
 }
 
@@ -25,11 +26,11 @@ setup() {
 }
 
 @test "static: exports allPredecessorsDone function" {
-  grep -q "export async function allPredecessorsDone" "$GRAPH_LIB"
+  grep -q "export async function allPredecessorsDone" "$READINESS_LIB"
 }
 
 @test "static: exports updateSuccessorReadiness function" {
-  grep -q "export async function updateSuccessorReadiness" "$GRAPH_LIB"
+  grep -q "export async function updateSuccessorReadiness" "$READINESS_LIB"
 }
 
 @test "static: exports TicketGraph interface" {
@@ -85,15 +86,15 @@ setup() {
 }
 
 @test "static: allPredecessorsDone checks status=done" {
-  grep -q "status === 'done'" "$GRAPH_LIB"
+  grep -q "status === 'done'" "$READINESS_LIB"
 }
 
 @test "static: updateSuccessorReadiness sets abhaengigkeiten_klar" {
-  grep -q "abhaengigkeiten_klar" "$GRAPH_LIB"
+  grep -q "abhaengigkeiten_klar" "$READINESS_LIB"
 }
 
 @test "static: updateSuccessorReadiness finds successors via depends_on" {
-  grep -q '\$1 = ANY(depends_on)' "$GRAPH_LIB"
+  grep -q '\$1 = ANY(depends_on)' "$READINESS_LIB"
 }
 
 @test "static: TypeScript syntax valid" {

--- a/website/src/lib/ticket-graph.ts
+++ b/website/src/lib/ticket-graph.ts
@@ -127,31 +127,3 @@ function computeCriticalPath(nodes: GraphNode[], edges: GraphEdge[]): string[] {
   return path;
 }
 
-export async function allPredecessorsDone(dependsOn: string[]): Promise<boolean> {
-  if (!dependsOn.length) return true;
-  const { rows } = await pool.query(
-    `SELECT external_id, status FROM tickets.tickets WHERE external_id = ANY($1)`,
-    [dependsOn],
-  );
-  return rows.length === dependsOn.length && rows.every((r: any) => r.status === 'done');
-}
-
-export async function updateSuccessorReadiness(ticketId: string): Promise<number> {
-  const { rows: successors } = await pool.query(
-    `SELECT id, external_id, depends_on FROM tickets.tickets WHERE $1 = ANY(depends_on)`,
-    [ticketId],
-  );
-
-  let updated = 0;
-  for (const s of successors) {
-    const done = await allPredecessorsDone(s.depends_on);
-    if (done) {
-      const r = await pool.query(
-        `UPDATE tickets.tickets SET readiness = COALESCE(readiness, '{}'::jsonb) || '{"abhaengigkeiten_klar":true}'::jsonb, updated_at = now() WHERE id = $1`,
-        [s.id],
-      );
-      if ((r.rowCount ?? 0) > 0) updated++;
-    }
-  }
-  return updated;
-}

--- a/website/src/lib/ticket-readiness.ts
+++ b/website/src/lib/ticket-readiness.ts
@@ -1,0 +1,30 @@
+import type { Pool } from 'pg';
+
+export async function allPredecessorsDone(dependsOn: string[], pool: Pool): Promise<boolean> {
+  if (!dependsOn.length) return true;
+  const { rows } = await pool.query(
+    `SELECT external_id, status FROM tickets.tickets WHERE external_id = ANY($1)`,
+    [dependsOn],
+  );
+  return rows.length === dependsOn.length && rows.every((r: any) => r.status === 'done');
+}
+
+export async function updateSuccessorReadiness(ticketId: string, pool: Pool): Promise<number> {
+  const { rows: successors } = await pool.query(
+    `SELECT id, external_id, depends_on FROM tickets.tickets WHERE $1 = ANY(depends_on)`,
+    [ticketId],
+  );
+
+  let updated = 0;
+  for (const s of successors) {
+    const done = await allPredecessorsDone(s.depends_on, pool);
+    if (done) {
+      const r = await pool.query(
+        `UPDATE tickets.tickets SET readiness = COALESCE(readiness, '{}'::jsonb) || '{"abhaengigkeiten_klar":true}'::jsonb, updated_at = now() WHERE id = $1`,
+        [s.id],
+      );
+      if ((r.rowCount ?? 0) > 0) updated++;
+    }
+  }
+  return updated;
+}

--- a/website/src/lib/tickets/transition.ts
+++ b/website/src/lib/tickets/transition.ts
@@ -2,6 +2,7 @@
 import { pool } from '../website-db';
 import { sendBugCloseEmail } from './email-templates';
 import { linkReporterByEmail } from './reporter-link';
+import { updateSuccessorReadiness } from '../ticket-graph';
 
 export type TicketStatus =
   'triage' | 'planning' | 'plan_staged' | 'backlog' | 'in_progress' | 'in_review' | 'blocked' | 'done' | 'archived';
@@ -121,6 +122,12 @@ export async function transitionTicket(
         resolution: after.resolution,
         note: p.noteVisibility === 'public' ? p.note : undefined,
       });
+    }
+
+    if (becomingDone) {
+      updateSuccessorReadiness(after.id).catch((err: unknown) =>
+        console.error('[transition] updateSuccessorReadiness failed:', err)
+      );
     }
 
     return {

--- a/website/src/lib/tickets/transition.ts
+++ b/website/src/lib/tickets/transition.ts
@@ -2,7 +2,7 @@
 import { pool } from '../website-db';
 import { sendBugCloseEmail } from './email-templates';
 import { linkReporterByEmail } from './reporter-link';
-import { updateSuccessorReadiness } from '../ticket-graph';
+import { updateSuccessorReadiness } from '../ticket-readiness';
 
 export type TicketStatus =
   'triage' | 'planning' | 'plan_staged' | 'backlog' | 'in_progress' | 'in_review' | 'blocked' | 'done' | 'archived';
@@ -125,7 +125,7 @@ export async function transitionTicket(
     }
 
     if (becomingDone) {
-      updateSuccessorReadiness(after.id).catch((err: unknown) =>
+      updateSuccessorReadiness(after.id, pool).catch((err: unknown) =>
         console.error('[transition] updateSuccessorReadiness failed:', err)
       );
     }

--- a/website/src/pages/api/tickets/[id]/readiness.ts
+++ b/website/src/pages/api/tickets/[id]/readiness.ts
@@ -1,7 +1,7 @@
 import type { APIRoute } from 'astro';
 import { getSession, isAdmin } from '../../../../lib/auth';
 import { pool } from '../../../../lib/website-db';
-import { updateSuccessorReadiness } from '../../../../lib/ticket-graph';
+import { updateSuccessorReadiness } from '../../../../lib/ticket-readiness';
 
 export const prerender = false;
 
@@ -40,7 +40,7 @@ export const POST: APIRoute = async ({ request, params }) => {
       });
     }
 
-    const updated = await updateSuccessorReadiness(rows[0].id);
+    const updated = await updateSuccessorReadiness(rows[0].id, pool);
     return new Response(JSON.stringify({ ok: true, successors_updated: updated }), {
       status: 200,
       headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Summary
- Imports `updateSuccessorReadiness` in `transition.ts`
- Fires it (fire-and-forget) whenever a ticket transitions to `done` for the first time
- Errors sind fire-and-forget (geloggt, nicht geworfen) — ein fehlgeschlagener Successor-Update rollt die Transition nie zurück

## Warum
TDR-4 hat den Readiness-Webhook als standalone `POST /api/tickets/:id/readiness` implementiert, aber nie in den Transition-Flow eingehängt. `abhaengigkeiten_klar` bei Nachfolgern wurde nur gesetzt wenn jemand den Endpoint manuell aufrief. Jetzt feuert er automatisch bei jedem `→ done`-Übergang.

## Test plan
- [ ] Ticket mit Nachfolgern auf `done` setzen → `abhaengigkeiten_klar=true` erscheint bei Nachfolgern deren alle Vorgänger erledigt sind
- [ ] `task test:all` grün

🤖 Generated with [Claude Code](https://claude.com/claude-code)