### PR TITLE
fix(batch): batch-gap-analysis.sh Schema-Drift (uuid→id) + Gap-Kontext T000666–668

### DIFF
--- a/docs/superpowers/specs/.gaps/T000666.md
+++ b/docs/superpowers/specs/.gaps/T000666.md
@@ -1,0 +1,11 @@
+# Gap-Antworten T000666 — API-Auth-Coverage-Gate
+
+Entschieden vom Orchestrator (Standard-Defaults, sauber statt ad-hoc):
+
+1. **Auth-Kategorien**: Der Generator klassifiziert in `admin` | `session` | `internal` (Bearer/internes Secret, z.B. /api/internal/*) | `cron` (cron-secret-gesichert) | `public`. Endpoints ohne erkennbares Muster sind `unclassified` — NICHT stillschweigend `public`. `unclassified` bricht das Gate immer; `public` bricht das Gate ohne Allowlist-Eintrag.
+2. **Allowlist-Format**: JSON, analog zur code-quality `baseline.json`. Pro Eintrag verpflichtend: `path`, `methods`, `reason` (Freitext-Begründung, reviewbar). Datei z.B. `website/api-public-allowlist.json`.
+3. **Gate-Modi**: Beides. (a) Coverage-Gate: neuer public/unclassified Endpoint ohne Allowlist-Eintrag → fail. (b) Regressions-Gate: Klassifikations-Änderung eines bestehenden Endpoints in Richtung schwächer (admin/session → public/unclassified) → fail, außer die Allowlist wurde im selben Commit angepasst.
+4. **Implementierung**: Node-Script (`scripts/code-quality/`-Muster, z.B. `api-auth-check.mjs`) als primärer Check, eingebunden in `task test:all` über einen eigenen Task. Zusätzlich dünner BATS-Wrapper, damit die coverage-guard-Konvention (jede tests/unit-BATS run-or-allowlist) erfüllt ist.
+5. **Baseline-Bootstrap**: Alle heutigen `public`-Endpoints kommen in die initiale Allowlist mit `reason: "baseline — nicht einzeln auditiert"`. ABER: die Spec muss `/api/billing/create-invoice`, `/api/stripe/checkout` und `/api/internal/tickets/notify-close` konkret prüfen — wenn sie real geschützt sind (z.B. internes Secret), korrekt als `internal`/`cron` klassifizieren statt allowlisten. Falls wirklich ungeschützt: als Findings im Plan dokumentieren (Follow-up-Ticket), nicht still durchwinken.
+
+Brand: beide (Generator/Gate sind brand-agnostisch, läuft in CI). Keine Shared-Changes (keine neue Domain, kein Schema-Var).

--- a/docs/superpowers/specs/.gaps/T000667.md
+++ b/docs/superpowers/specs/.gaps/T000667.md
@@ -1,0 +1,12 @@
+# Gap-Antworten T000667 — Knowledge-Graph v2 + Blast-Radius
+
+Entschieden vom Orchestrator (Standard-Defaults):
+
+1. **secretRef-Modellierung**: Secrets werden KEINE eigenen Knoten. Eine Kante `Deployment ↔ Deployment` mit `via: "secret:<name>"` wird nur erzeugt, wenn ≥2 Workloads dasselbe Secret referenzieren (shared-secret-Kopplung). Single-Consumer-Secrets werden ignoriert (Rauschen).
+2. **Ingress-Parsing**: Beides — vanilla `Ingress` UND Traefik `IngressRoute` CRD. Die IngressRoute-Variante ist der Grund für die meisten der 14 isolierten Knoten. Kantenkette: ingress → service → workload (via Service-Selector aufgelöst).
+3. **Blast-Radius-Richtung**: Primär downstream — „was bricht, wenn X ausfällt" (transitive Abhängige). Der Report (`docs/generated/blast-radius.md`) listet pro Service die transitiven Abhängigen, sortiert nach Anzahl; In-Degree/Upstream als zusätzliche Tabellenspalte.
+4. **ConfigMap-Modellierung**: Nur als Kanten-Annotation (`via: "configmap:<name>"`), keine eigenen Knoten. Knotentypen bleiben Workloads + Services.
+5. **Kanten-Schema**: Jede Kante bekommt zusätzlich ein `kind`-Feld (`env` | `command` | `ingress` | `secret` | `configmap` | `selector`). Additiv/abwärtskompatibel — bestehende Konsumenten von `{from,to,via}` dürfen nicht brechen (Konsumenten vorher greppen!).
+6. **Freshness**: `blast-radius.md` in `freshness:regenerate` + CI-Drift-Check aufnehmen, exakt wie `api-surface.md`. Achtung bekanntes Muster: Staleness-Gates stolpern über uncommitted Regen (PR #1501) — Regenerate + Commit im selben Schritt.
+
+Brand: brand-agnostisch (statische Manifest-Analyse). Keine Shared-Changes.

--- a/docs/superpowers/specs/.gaps/T000668.md
+++ b/docs/superpowers/specs/.gaps/T000668.md
@@ -1,0 +1,13 @@
+# Gap-Antworten T000668 — Live-Architektur-Graph im Admin
+
+Entschieden vom Orchestrator (Standard-Defaults):
+
+1. **Pod→Graph-Node-Matching**: Primär über Label `app=<node.name>`; Fallback Präfix-Match auf Pod-Namen. Nicht matchbare Pods erscheinen in einem „unzugeordnet"-Hinweis statt still zu verschwinden.
+2. **Namespace-Templates** (`${WEBSITE_NAMESPACE}` etc. in graph.json): serverseitig zur Request-Zeit anhand `BRAND` auflösen (mentolder → workspace/website, korczewski → workspace-korczewski/website-korczewski).
+3. **Auslieferung graph.json**: über einen neuen Admin-API-Endpoint (z.B. `/api/admin/cluster/graph`), der die Datei serverseitig liest — kein Build-Time-Bundling (vermeidet Staleness, ist Factory-observable/skriptbar; vgl. Agentic-first-Präferenz). Endpoint ist admin-geschützt → automatisch vom T000666-Gate als `admin` erfasst.
+4. **Render-Library**: leichtgewichtig — `d3-force` mit SVG-Rendering in einer Svelte-Komponente, Namespace-Gruppierung als Cluster. Keine schwere Graph-Lib (kein cytoscape/sigma) ohne Not. Layout deterministisch seeden, damit die Ansicht stabil bleibt.
+5. **Logs-Link**: verlinkt auf die bestehende Admin-Cluster-Ansicht mit Query-Param (Pod vorausgewählt), kein neuer Log-Viewer.
+6. **Status-Overlay**: grün = alle Pods ready, gelb = degraded (restarts>0 in letzter Zeit oder ready<desired), rot = kein Pod ready / CrashLoop. Polling 10s, pausiert bei verborgenem Tab.
+7. **Abhängigkeit**: baut auf dem heutigen graph.json auf; wenn T000667 (Graph v2) vorher merged, `kind`-Kantenlabels in der Legende mit anzeigen — Plan soll dafür einen optionalen, kleinen Folgeschritt vorsehen statt harter Kopplung. depends_on T000667 ist gesetzt (Factory-Reihenfolge).
+
+Brand: beide (BRAND-aware Namespace-Filter). Keine Shared-Changes (keine neue Domain — läuft unter web.<domain>/admin).

--- a/scripts/batch-gap-analysis.sh
+++ b/scripts/batch-gap-analysis.sh
@@ -19,11 +19,11 @@ fi
 kubectl exec -i "$pod" -n "$NS" --context "$CTX" -c postgres -- \
   psql -U website -d website -qtA -v ON_ERROR_STOP=1 <<'EOF'
 SELECT COALESCE(
-  json_agg(row_to_json(t) ORDER BY t.created_at),
+  json_agg(row_to_json(t) ORDER BY t.external_id),
   '[]'::json
 )
 FROM (
-  SELECT external_id, uuid, title, description, brand, priority, severity
+  SELECT external_id, id AS uuid, title, description, brand, priority, severity
   FROM tickets.tickets
   WHERE status = 'planning'
 ) t;


### PR DESCRIPTION
## Zusammenfassung
- `scripts/batch-gap-analysis.sh` war gegen das aktuelle `tickets.tickets`-Schema gebrochen: Spalte `uuid` existiert nicht (heißt `id`), und `ORDER BY t.created_at` referenzierte eine nicht selektierte Spalte. Fix: `id AS uuid` (Output-Shape bleibt stabil) + `ORDER BY external_id`.
- Gap-Kontext-Dateien für die drei aus der Knowledgegraph-Analyse abgeleiteten Planning-Tickets T000666 (API-Auth-Coverage-Gate), T000667 (Knowledge-Graph v2 + Blast-Radius), T000668 (Live-Architektur-Graph im Admin).

## Test
- `bash scripts/batch-gap-analysis.sh` liefert jetzt das JSON-Array der planning-Tickets (manuell verifiziert gegen fleet shared-db).

🤖 Generated with [Claude Code](https://claude.com/claude-code)