### PR TITLE
fix(website): DependencyGraph legacy $: statements break runes-mode build

### DIFF
--- a/website/src/components/DependencyGraph.svelte
+++ b/website/src/components/DependencyGraph.svelte
@@ -193,15 +193,15 @@
     if (pollInterval) clearInterval(pollInterval);
   });
 
-  $: layout = graphData ? layoutNodes(graphData) : [];
-  $: nodePos = new Map(layout.map(n => [n.id, n]));
-  $: maxLayer = layout.reduce((m, n) => Math.max(m, n.layer), 0);
-  $: maxPerLayer = layout.reduce((acc, n) => {
+  const layout = $derived(graphData ? layoutNodes(graphData) : []);
+  const nodePos = $derived(new Map(layout.map(n => [n.id, n])));
+  const maxLayer = $derived(layout.reduce((m, n) => Math.max(m, n.layer), 0));
+  const maxPerLayer = $derived(layout.reduce((acc, n) => {
     acc[n.layer] = (acc[n.layer] ?? 0) + 1;
     return acc;
-  }, {} as Record<number, number>);
-  $: svgW = PAD * 2 + (maxLayer + 1) * LAYER_GAP_X;
-  $: svgH = PAD * 2 + Math.max(...Object.values(maxPerLayer), 1) * NODE_GAP_Y;
+  }, {} as Record<number, number>));
+  const svgW = $derived(PAD * 2 + (maxLayer + 1) * LAYER_GAP_X);
+  const svgH = $derived(PAD * 2 + Math.max(...Object.values(maxPerLayer), 1) * NODE_GAP_Y);
 </script>
 
 <div class="dag-container">


### PR DESCRIPTION
## Problem
Seit 2026-06-11 schlägt **jeder** `build-website*.yml`-Lauf auf main fehl (beide Brands): `DependencyGraph.svelte` nutzt `$state`-Runes **und** sechs legacy `$:`-Statements — in Svelte 5 ein harter Compile-Fehler (`legacy_reactive_statement_invalid`). Die Live-Sites laufen dadurch auf einem stale Image von 2026-06-11 00:35; u. a. fehlt #1579 (Factory mobile parity) live, was die 5 DevStatusTabs-E2E-Failures auf PR #1573 erklärt.

PR-CI blieb grün, weil der Vitest-Job kein `astro build` ausführt — der Svelte-Compiler läuft erst im Docker-Build nach dem Merge.

## Fix
Die sechs `$:`-Statements zu `$derived` konvertiert. Lokal verifiziert: `pnpm build` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)