### PR TITLE
fix(infra): pvc-backup heredoc escaping + PVC watch RBAC [T000670, T000674]

### DIFF
--- a/docs/generated/api-map.json
+++ b/docs/generated/api-map.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-13T07:29:00.304Z",
+  "generatedAt": "2026-06-13T07:56:12.766Z",
   "endpoints": [
     {
       "path": "/api/admin/angebote/save",

--- a/docs/generated/api-surface.md
+++ b/docs/generated/api-surface.md
@@ -1,6 +1,6 @@
 # API Surface Map
 
-> Generated at 2026-06-13T07:29:00.304Z
+> Generated at 2026-06-13T07:56:12.766Z
 
 | Path | Methods | Auth | File |
 |------|---------|------|------|

--- a/docs/generated/blast-radius.md
+++ b/docs/generated/blast-radius.md
@@ -1,5 +1,5 @@
 # Blast-Radius-Report
-> Generated: 2026-06-13T07:29:00.401Z
+> Generated: 2026-06-13T07:56:12.849Z
 > Nodes: 74 | Edges: 1385 | Isolated: 2
 
 ## Ranking (transitive Abhängige)

--- a/docs/generated/graph.json
+++ b/docs/generated/graph.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-13T07:29:00.227Z",
+  "generatedAt": "2026-06-13T07:56:12.704Z",
   "nodes": [
     {
       "id": "admin-actions-cleanup",

--- a/k3d/docs-content-built/architecture/index.html
+++ b/k3d/docs-content-built/architecture/index.html
@@ -178,7 +178,7 @@
 <body>
   <div class="header">
     <h1>⬡ Architektur — Living Docs</h1>
-    <span class="meta">Generiert: 2026-06-13T07:29:00.349Z</span>
+    <span class="meta">Generiert: 2026-06-13T07:56:12.799Z</span>
   </div>
 
   <div class="stats">

--- a/k3d/pvc-backup-cronjob.yaml
+++ b/k3d/pvc-backup-cronjob.yaml
@@ -202,31 +202,31 @@ spec:
                                 set -euo pipefail
                                 sleep 5
                                 STAMP=\$(date +%Y%m%d-%H%M%S)
-                                BACKUP_DIR=/backups/pvc-\$${STAMP}
-                                mkdir -p "\$${BACKUP_DIR}"
+                                BACKUP_DIR=/backups/pvc-\${STAMP}
+                                mkdir -p "\${BACKUP_DIR}"
                                 FAILED=0
                                 backup_dir() {
                                   SRC="\$1"; OUT="\$2"; LABEL="\$3"
-                                  echo "Backing up \$${LABEL} (\$${SRC})..."
-                                  if [ "\$(ls -A "\$${SRC}" 2>/dev/null)" ]; then
-                                    tar czf - -C "\$${SRC}" . \
+                                  echo "Backing up \${LABEL} (\${SRC})..."
+                                  if [ "\$(ls -A "\${SRC}" 2>/dev/null)" ]; then
+                                    tar czf - -C "\${SRC}" . \
                                       | openssl enc -aes-256-cbc -salt -pbkdf2 \
-                                          -out "\$${BACKUP_DIR}/\$${OUT}" -pass env:BACKUP_PASSPHRASE \
-                                      && echo "  ✓ \$${LABEL} OK (\$(ls -lh "\$${BACKUP_DIR}/\$${OUT}" | awk '{print \$5}'))" \
-                                      || { echo "  ✗ \$${LABEL} FAILED"; FAILED=\$((FAILED+1)); }
+                                          -out "\${BACKUP_DIR}/\${OUT}" -pass env:BACKUP_PASSPHRASE \
+                                      && echo "  ✓ \${LABEL} OK (\$(ls -lh "\${BACKUP_DIR}/\${OUT}" | awk '{print \$5}'))" \
+                                      || { echo "  ✗ \${LABEL} FAILED"; FAILED=\$((FAILED+1)); }
                                   else
-                                    echo "  ⚠ \$${SRC} empty — skipping"
+                                    echo "  ⚠ \${SRC} empty — skipping"
                                   fi
                                 }
                                 backup_dir /nextcloud-data   nextcloud-files.tar.gz.enc  nextcloud-data
                                 backup_dir /vaultwarden-data vaultwarden-data.tar.gz.enc vaultwarden-data
 
                                 find /backups -maxdepth 1 -type d -name 'pvc-*' -mtime +30 -exec rm -rf {} +
-                                printf '%s' "\$${FILEN_DEFAULT_UPLOAD_PATH}" > /staging/.filen_path
-                                printf '%s' "pvc-\$${STAMP}" > /staging/.done
-                                echo "PVC backup complete: \$${BACKUP_DIR}"
-                                ls -lh "\$${BACKUP_DIR}/"
-                                [ "\$${FAILED}" -eq 0 ] || { echo "WARN: \$${FAILED} backup(s) failed"; exit 1; }
+                                printf '%s' "\${FILEN_DEFAULT_UPLOAD_PATH}" > /staging/.filen_path
+                                printf '%s' "pvc-\${STAMP}" > /staging/.done
+                                echo "PVC backup complete: \${BACKUP_DIR}"
+                                ls -lh "\${BACKUP_DIR}/"
+                                [ "\${FAILED}" -eq 0 ] || { echo "WARN: \${FAILED} backup(s) failed"; exit 1; }
                             volumeMounts:
                               - { name: backup-storage,   mountPath: /backups }
                               - { name: nextcloud-data,   mountPath: /nextcloud-data,   readOnly: true }
@@ -245,7 +245,7 @@ spec:
                             command: ["/bin/sh", "-c"]
                             args:
                               - |
-                                if [ -z "\$${FILEN_EMAIL}" ] || [ -z "\$${FILEN_PASSWORD}" ]; then
+                                if [ -z "\${FILEN_EMAIL}" ] || [ -z "\${FILEN_PASSWORD}" ]; then
                                   echo "Filen not configured — skipping remote backup"
                                   until [ -f /staging/.done ]; do sleep 2; done
                                   exit 0
@@ -259,10 +259,10 @@ spec:
                                 npm install -g @filen/cli --prefix /tmp/npm-global 2>&1 \
                                   || { echo "ERROR: filen-cli install failed"; exit 1; }
                                 export PATH="/tmp/npm-global/bin:\$PATH"
-                                echo "Uploading \$${STAMP} to Filen: \$${UPLOAD_PATH}/\$${STAMP}/"
-                                if ! filen --email "\$${FILEN_EMAIL}" --password "\$${FILEN_PASSWORD}" \
-                                     upload "/backups/\$${STAMP}/" "\$${UPLOAD_PATH}/\$${STAMP}/"; then
-                                  echo "ERROR: Filen remote upload failed for \$${STAMP} — local backup on backup-pvc is intact."
+                                echo "Uploading \${STAMP} to Filen: \${UPLOAD_PATH}/\${STAMP}/"
+                                if ! filen --email "\${FILEN_EMAIL}" --password "\${FILEN_PASSWORD}" \
+                                     upload "/backups/\${STAMP}/" "\${UPLOAD_PATH}/\${STAMP}/"; then
+                                  echo "ERROR: Filen remote upload failed for \${STAMP} — local backup on backup-pvc is intact."
                                   echo "       Likely cause: invalid credentials, or 2FA enabled (this job requires 2FA OFF)."
                                   exit 1
                                 fi

--- a/k3d/pvc-backup-rbac.yaml
+++ b/k3d/pvc-backup-rbac.yaml
@@ -18,7 +18,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
-    verbs: ["get", "list", "create", "delete"]
+    verbs: ["get", "list", "create", "delete", "watch"]
   - apiGroups: ["batch"]
     resources: ["jobs"]
     verbs: ["get", "list", "create", "delete", "watch"]


### PR DESCRIPTION
## Summary
- **T000670**: Fix `\$${VAR}` → `\${VAR}` for all inner-container variables in the pvc-backup mounter Job heredoc. alpine/k8s 1.34.0 ash now strictly expands `\$${VAR}` as `\$` + `${VAR}` in heredoc context, causing `set -u` to abort on unset `BACKUP_DIR` in the outer orchestrator scope. Affects mentolder + korczewski (3 consecutive nightly failures since 2026-06-11).
- **T000674**: Add `watch` verb to pvc-backup ServiceAccount Role for `persistentvolumeclaims` to fix reflector RBAC errors during clone PVC status polling.

## Test plan
- [ ] CI passes (kustomize validate + BATS)
- [ ] Next nightly run at 03:00 UTC produces mounter Job with `Complete` status

🤖 Generated with [Claude Code](https://claude.com/claude-code)