### PR TITLE
fix(api): qa-queue 500 — use from_id instead of ticket_id

### DIFF
--- a/website/src/lib/qa-dal.ts
+++ b/website/src/lib/qa-dal.ts
@@ -44,7 +44,7 @@ export async function getQaQueue(): Promise<QaItem[]> {
       qr.criteria     AS last_criteria,
       qr.notes        AS last_notes
     FROM tickets.tickets t
-    LEFT JOIN ticket_links tl ON tl.ticket_id = t.id AND tl.pr_number IS NOT NULL
+    LEFT JOIN ticket_links tl ON tl.from_id = t.id AND tl.pr_number IS NOT NULL
     LEFT JOIN LATERAL (
       SELECT at FROM tickets.factory_phase_events
       WHERE ticket_id = t.id AND phase = 'deploy' AND state = 'done'


### PR DESCRIPTION
Fixes T000678.

`tickets.ticket_links` uses `from_id` (not `ticket_id`) to reference the source ticket. The qa-queue query referenced a non-existent column, causing a 500 error.