### PR TITLE
fix(api): qa-queue 500 — missing schema prefix on ticket_links [T000678]

### DIFF
--- a/docs/generated/api-map.json
+++ b/docs/generated/api-map.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-13T13:53:30.800Z",
+  "generatedAt": "2026-06-13T13:53:42.175Z",
   "endpoints": [
     {
       "path": "/api/admin/angebote/save",

--- a/docs/generated/api-surface.md
+++ b/docs/generated/api-surface.md
@@ -1,6 +1,6 @@
 # API Surface Map
 
-> Generated at 2026-06-13T13:53:30.800Z
+> Generated at 2026-06-13T13:53:42.175Z
 
 | Path | Methods | Auth | File |
 |------|---------|------|------|

--- a/docs/generated/blast-radius.md
+++ b/docs/generated/blast-radius.md
@@ -1,5 +1,5 @@
 # Blast-Radius-Report
-> Generated: 2026-06-13T13:53:30.894Z
+> Generated: 2026-06-13T13:53:42.255Z
 > Nodes: 74 | Edges: 1385 | Isolated: 2
 
 ## Ranking (transitive Abhängige)

--- a/docs/generated/graph.json
+++ b/docs/generated/graph.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-13T13:53:30.722Z",
+  "generatedAt": "2026-06-13T13:53:42.105Z",
   "nodes": [
     {
       "id": "admin-actions-cleanup",

--- a/k3d/docs-content-built/architecture/index.html
+++ b/k3d/docs-content-built/architecture/index.html
@@ -178,7 +178,7 @@
 <body>
   <div class="header">
     <h1>⬡ Architektur — Living Docs</h1>
-    <span class="meta">Generiert: 2026-06-13T13:53:30.843Z</span>
+    <span class="meta">Generiert: 2026-06-13T13:53:42.213Z</span>
   </div>
 
   <div class="stats">

--- a/website/src/lib/qa-dal.ts
+++ b/website/src/lib/qa-dal.ts
@@ -44,7 +44,7 @@ export async function getQaQueue(): Promise<QaItem[]> {
       qr.criteria     AS last_criteria,
       qr.notes        AS last_notes
     FROM tickets.tickets t
-    LEFT JOIN ticket_links tl ON tl.from_id = t.id AND tl.pr_number IS NOT NULL
+    LEFT JOIN tickets.ticket_links tl ON tl.from_id = t.id AND tl.pr_number IS NOT NULL
     LEFT JOIN LATERAL (
       SELECT at FROM tickets.factory_phase_events
       WHERE ticket_id = t.id AND phase = 'deploy' AND state = 'done'


### PR DESCRIPTION
## Problem\n\n`GET /api/admin/qa-queue` returned 500 on live because the SQL query referenced `ticket_links` without the `tickets.` schema prefix.\n\n## Fix\n\nChanged `LEFT JOIN ticket_links` → `LEFT JOIN tickets.ticket_links` in `website/src/lib/qa-dal.ts`.\n\nCloses T000678.