### PR TITLE
chore(skills): add false-positive guard to mishap-tracker [T000649]

### DIFF
--- a/.claude/skills/mishap-tracker/SKILL.md
+++ b/.claude/skills/mishap-tracker/SKILL.md
@@ -21,6 +21,25 @@ If the log is empty or no mishaps were found, report that and stop — nothing t
 
 ---
 
+## Step 0: Verify Before Creating (False-Positive Guard)
+
+Before inserting any ticket, verify the claim with a concrete check. Each mishap type has a minimum verification:
+
+| Mishap type | Required verification |
+|---|---|
+| `broken` (import cycle) | `grep -r 'import.*<file>' <target>` to confirm the cycle actually exists |
+| `broken` (file missing/stale) | `ls` or `git show HEAD:<file>` to confirm the file is actually absent or stale |
+| `drift` (version mismatch) | Check current value via kubectl/grep before asserting drift |
+| `suspicious` (unexpected state) | Run the command that would reveal the state and confirm it |
+| `process` | These are observations, not assertions — no verification needed |
+| `security` | These are always created without suppression |
+
+**If verification contradicts the observation:** drop the mishap entry and log `[mishap-tracker] SKIP <title> — verified false positive: <reason>` instead of creating a ticket.
+
+**If verification is not feasible in context** (e.g. no cluster access): create the ticket but add `[UNVERIFIED — <reason>]` to the description so the assignee knows to verify first.
+
+---
+
 ## Step 1: Severity Mapping
 
 | Mishap type | Ticket type | Ticket severity |


### PR DESCRIPTION
## Summary
- Adds Step 0 (Verify Before Creating) to mishap-tracker SKILL.md
- Requires concrete verification (grep/ls/kubectl check) before inserting tickets for broken/suspicious/drift mishap types
- If verification contradicts the observation → drop with SKIP log (prevents creating tickets for things that don't exist)
- If verification infeasible → create ticket with [UNVERIFIED] tag
- security and process mishaps are exempt (always created)

## Root cause (T000649)
T000642 (import cycle) and T000643 (stale repo-index) were both logged as mishaps but were false positives — no cycle existed, repo-index was correct. The mishap-tracker had no verification gate.

## Test plan
- [ ] CI passes (skill file change only, no runtime code)
- [ ] Future mishap-tracker invocations include verification step

🤖 Generated with [Claude Code](https://claude.com/claude-code)