### PR TITLE
feat(website): DeepSeek als primärer AI-Provider für Website-Endpunkte

### DIFF
--- a/docs/generated/api-map.json
+++ b/docs/generated/api-map.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-14T13:23:35.568Z",
+  "generatedAt": "2026-06-14T13:26:28.460Z",
   "endpoints": [
     {
       "path": "/api/admin/angebote/save",

--- a/docs/generated/api-surface.md
+++ b/docs/generated/api-surface.md
@@ -1,6 +1,6 @@
 # API Surface Map
 
-> Generated at 2026-06-14T13:23:35.568Z
+> Generated at 2026-06-14T13:26:28.460Z
 
 | Path | Methods | Auth | File |
 |------|---------|------|------|

--- a/docs/generated/blast-radius.md
+++ b/docs/generated/blast-radius.md
@@ -1,5 +1,5 @@
 # Blast-Radius-Report
-> Generated: 2026-06-14T13:23:35.659Z
+> Generated: 2026-06-14T13:26:28.537Z
 > Nodes: 74 | Edges: 1385 | Isolated: 2
 
 ## Ranking (transitive Abhängige)

--- a/docs/generated/graph.json
+++ b/docs/generated/graph.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-14T13:23:35.491Z",
+  "generatedAt": "2026-06-14T13:26:28.386Z",
   "nodes": [
     {
       "id": "admin-actions-cleanup",

--- a/environments/schema.yaml
+++ b/environments/schema.yaml
@@ -748,6 +748,14 @@ secrets:
       - namespace: website
         secret: website-secrets
 
+  - name: DEEPSEEK_API_KEY
+    required: false
+    generate: false
+    description: "DeepSeek API key for website AI features (meeting insights, ticket triage, assistant chat). When set, DeepSeek is preferred over Anthropic as the sonnet/haiku provider via the provider_config routing table."
+    extra_namespaces:
+      - namespace: website
+        secret: website-secrets
+
   - name: LLM_ROUTER_API_KEY
     required: false
     generate: false

--- a/k3d/docs-content-built/architecture/index.html
+++ b/k3d/docs-content-built/architecture/index.html
@@ -178,7 +178,7 @@
 <body>
   <div class="header">
     <h1>⬡ Architektur — Living Docs</h1>
-    <span class="meta">Generiert: 2026-06-14T13:23:35.610Z</span>
+    <span class="meta">Generiert: 2026-06-14T13:26:28.496Z</span>
   </div>
 
   <div class="stats">

--- a/k3d/secrets.yaml
+++ b/k3d/secrets.yaml
@@ -87,6 +87,8 @@ stringData:
   LLM_ROUTER_API_KEY: ""
   # Anthropic API key for LLM fallback (optional, user-provided)
   ANTHROPIC_API_KEY: ""
+  # DeepSeek API key for website AI endpoints (meeting insights, triage, assistant)
+  DEEPSEEK_API_KEY: ""
   # Hetzner API key for DNS/provisioning (optional, user-provided)
   HETZNER_API_KEY: ""
   # HuggingFace token for authenticated model downloads (ComfyUI, TEI, Hunyuan3D)

--- a/website/src/lib/assistant/llm.ts
+++ b/website/src/lib/assistant/llm.ts
@@ -4,6 +4,7 @@ import { searchHelp, formatHit, noMatchReply } from './search';
 import { queryNearest } from '../knowledge-db';
 import { resolveCoachingCollectionIds } from './coaching-collections';
 import { pool } from '../website-db';
+import { getProviderConfig } from '../provider-config';
 
 export interface AssistantChatInput {
   profile: AssistantProfile;
@@ -34,8 +35,8 @@ export async function assistantChat(input: AssistantChatInput): Promise<Assistan
     return { reply: 'Frag mich etwas — ich bin für dich da.' };
   }
 
-  const apiKey = process.env.ANTHROPIC_API_KEY;
-  if (!apiKey) {
+  const cfg = await getProviderConfig('assistant-chat', 'sonnet');
+  if (!cfg.apiKey) {
     // Fallback: keyword search (dev without API key)
     const hit = searchHelp(lastUser.content, input.profile);
     if (!hit) return { reply: noMatchReply(input.profile) };
@@ -79,9 +80,12 @@ export async function assistantChat(input: AssistantChatInput): Promise<Assistan
     }
   }
 
-  const client = new Anthropic({ apiKey });
+  const client = new Anthropic({
+    apiKey: cfg.apiKey,
+    ...(cfg.baseUrl ? { baseURL: cfg.baseUrl } : {}),
+  });
   const response = await client.messages.create({
-    model: 'claude-sonnet-4-6',
+    model: cfg.modelId,
     max_tokens: 1024,
     system: systemPrompt,
     messages: input.messages.map((m) => ({

--- a/website/src/lib/provider-config.ts
+++ b/website/src/lib/provider-config.ts
@@ -12,9 +12,15 @@ const FALLBACK: Omit<ProviderChoice, 'apiKey'> = {
   provider: 'anthropic', modelId: 'claude-sonnet-4-6', baseUrl: null,
 };
 
+function apiKeyForProvider(provider: string): string {
+  if (provider === 'deepseek') return process.env.DEEPSEEK_API_KEY || '';
+  return process.env.ANTHROPIC_API_KEY || '';
+}
+
 export async function getProviderConfig(source: string, tier: 'sonnet' | 'haiku' | 'opus'): Promise<ProviderChoice> {
-  const apiKey = process.env.ANTHROPIC_API_KEY || '';
-  if (tier === 'opus') return { provider: 'anthropic', modelId: OPUS_MODEL, baseUrl: null, apiKey };
+  if (tier === 'opus') {
+    return { provider: 'anthropic', modelId: OPUS_MODEL, baseUrl: null, apiKey: process.env.ANTHROPIC_API_KEY || '' };
+  }
   try {
     const { rows } = await pool.query(
       `SELECT pc.provider, pc.model_id, pc.base_url
@@ -27,10 +33,11 @@ export async function getProviderConfig(source: string, tier: 'sonnet' | 'haiku'
       [source, tier],
     );
     if (rows.length) {
-      return { provider: rows[0].provider, modelId: rows[0].model_id, baseUrl: rows[0].base_url ?? null, apiKey };
+      const { provider, model_id, base_url } = rows[0];
+      return { provider, modelId: model_id, baseUrl: base_url ?? null, apiKey: apiKeyForProvider(provider) };
     }
   } catch (err) {
     console.error('[provider-config] DB lookup failed, falling back to anthropic:', err);
   }
-  return { ...FALLBACK, apiKey };
+  return { ...FALLBACK, apiKey: process.env.ANTHROPIC_API_KEY || '' };
 }

--- a/website/src/lib/tickets-db.ts
+++ b/website/src/lib/tickets-db.ts
@@ -23,10 +23,7 @@ async function initProviderRouting(c: import('pg').PoolClient): Promise<void> {
     provider TEXT PRIMARY KEY, failure_count INTEGER NOT NULL DEFAULT 0, last_failure TIMESTAMPTZ,
     cooldown_until TIMESTAMPTZ, active_agents INTEGER NOT NULL DEFAULT 0, updated_at TIMESTAMPTZ NOT NULL DEFAULT now())`);
   await c.query(`INSERT INTO tickets.provider_config (source,tier,priority,provider,model_id,base_url)
-    VALUES ('*','sonnet',99,'anthropic','claude-sonnet-4-6',NULL),
-           ('*','haiku',99,'anthropic','claude-haiku-4-5',NULL),
-           ('*','sonnet',1,'deepseek','deepseek-v4-pro','https://api.deepseek.com/anthropic'),
-           ('*','haiku',1,'deepseek','deepseek-v4-flash','https://api.deepseek.com/anthropic')
+    VALUES ('*','sonnet',99,'anthropic','claude-sonnet-4-6',NULL),('*','haiku',99,'anthropic','claude-haiku-4-5',NULL),('*','sonnet',1,'deepseek','deepseek-v4-pro','https://api.deepseek.com/anthropic'),('*','haiku',1,'deepseek','deepseek-v4-flash','https://api.deepseek.com/anthropic')
     ON CONFLICT (source,tier,priority) DO NOTHING`);
 }
 

--- a/website/src/lib/tickets-db.ts
+++ b/website/src/lib/tickets-db.ts
@@ -23,7 +23,10 @@ async function initProviderRouting(c: import('pg').PoolClient): Promise<void> {
     provider TEXT PRIMARY KEY, failure_count INTEGER NOT NULL DEFAULT 0, last_failure TIMESTAMPTZ,
     cooldown_until TIMESTAMPTZ, active_agents INTEGER NOT NULL DEFAULT 0, updated_at TIMESTAMPTZ NOT NULL DEFAULT now())`);
   await c.query(`INSERT INTO tickets.provider_config (source,tier,priority,provider,model_id,base_url)
-    VALUES ('*','sonnet',99,'anthropic','claude-sonnet-4-6',NULL),('*','haiku',99,'anthropic','claude-haiku-4-5',NULL)
+    VALUES ('*','sonnet',99,'anthropic','claude-sonnet-4-6',NULL),
+           ('*','haiku',99,'anthropic','claude-haiku-4-5',NULL),
+           ('*','sonnet',1,'deepseek','deepseek-v4-pro','https://api.deepseek.com/anthropic'),
+           ('*','haiku',1,'deepseek','deepseek-v4-flash','https://api.deepseek.com/anthropic')
     ON CONFLICT (source,tier,priority) DO NOTHING`);
 }
 


### PR DESCRIPTION
## Summary

- **`provider-config.ts`**: Neue `apiKeyForProvider()`-Funktion wählt `DEEPSEEK_API_KEY` für DeepSeek, `ANTHROPIC_API_KEY` für Anthropic — bisher wurde immer der Anthropic-Key zurückgegeben, auch für andere Provider
- **`tickets-db.ts`**: DeepSeek mit Priority 1 in die `provider_config`-Seed-Tabelle eingetragen (deepseek-v4-pro für sonnet, deepseek-v4-flash für haiku) via Anthropic-kompatibler Endpoint — Anthropic bleibt als Fallback auf Priority 99
- **`assistant/llm.ts`**: Hardcoded `ANTHROPIC_API_KEY` → `getProviderConfig('assistant-chat', 'sonnet')` — nutzt jetzt denselben Routing-Mechanismus wie `claude.ts` und `ticket-triage.ts`
- **`k3d/secrets.yaml`** + **`environments/schema.yaml`**: `DEEPSEEK_API_KEY` als neues Env-Var mit Injection in `website-secrets`

## Betroffene AI-Endpunkte

| Endpoint | Vorher | Nachher |
|----------|--------|---------|
| Meeting Insights (`claude.ts`) | Anthropic via provider_config (aber immer ANTHROPIC_API_KEY) | DeepSeek Priority 1, Anthropic Fallback |
| Ticket Triage (`ticket-triage.ts`) | Anthropic via provider_config | DeepSeek Priority 1, Anthropic Fallback |
| Assistant Chat (`assistant/llm.ts`) | Hardcoded Anthropic | DeepSeek Priority 1, Anthropic Fallback |

## Secrets-Aktion erforderlich (manuell)

Da git-crypt auf diesem Rechner kein GPG-Key hat, muss der Schlüssel manuell eingetragen werden:

```bash
task secrets:unlock KEY=<pfad-zum-bp-secrets.key>
# environments/.secrets/mentolder.yaml → DEEPSEEK_API_KEY: sk-ac8a425f68b341b0a62900124d11bb30 hinzufügen
# environments/.secrets/fleet-mentolder.yaml → gleich
task env:seal ENV=mentolder
task env:seal ENV=fleet-mentolder
git add environments/sealed-secrets/
git commit -m "chore(secrets): seal DEEPSEEK_API_KEY for mentolder"
```

## Test plan

- [ ] CI grün
- [ ] Nach Merge + Deploy: Website-Meeting-Insights-Endpunkt prüfen → muss ohne Fehler antworten
- [ ] `tickets.provider_config` im DB prüfen: `SELECT * FROM tickets.provider_config;` → DeepSeek-Zeilen sichtbar
- [ ] Secrets korrekt gesetzt: `kubectl get secret website-secrets -n website -o jsonpath='{.data.DEEPSEEK_API_KEY}' | base64 -d`

🤖 Generated with [Claude Code](https://claude.com/claude-code)