### PR TITLE
feat(brett): Touch-Drag Android — contextmenu block + multi-touch guard (T000703)

### DIFF
--- a/brett/package-lock.json
+++ b/brett/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "express": "^5.2.1",
         "express-session": "^1.19.0",
+        "jspdf": "^4.2.1",
         "multer": "^1.4.5-lts.1",
         "openid-client": "^6.8.4",
         "pg": "^8.21.0",
@@ -26,7 +27,6 @@
         "@types/three": "^0.184.1",
         "@types/ws": "^8.18.1",
         "concurrently": "^9.2.1",
-        "jspdf": "^4.2.1",
         "three": "^0.184.0",
         "typescript": "^5.9.3",
         "vite": "^5.4.21"
@@ -36,7 +36,6 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
       "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -923,7 +922,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.4.tgz",
       "integrity": "sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/pg": {
@@ -949,7 +947,6 @@
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
       "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
-      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -1007,7 +1004,6 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -1077,7 +1073,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
       "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -1167,7 +1162,6 @@
       "version": "3.0.11",
       "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz",
       "integrity": "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1333,7 +1327,6 @@
       "version": "3.49.0",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
       "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -1352,7 +1345,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
       "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1389,7 +1381,6 @@
       "version": "3.4.8",
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.8.tgz",
       "integrity": "sha512-yb1cEmaOum7wFvOCSQxyfgVlv5D47Rc30iZWoMpbDIWTnJ6grDDQyu2KFJzB2k7u0pMuJcQ1zphH//fFnw2tjQ==",
-      "dev": true,
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optional": true,
       "optionalDependencies": {
@@ -1619,7 +1610,6 @@
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/fast-png/-/fast-png-6.4.0.tgz",
       "integrity": "sha512-kAqZq1TlgBjZcLr5mcN6NP5Rv4V2f22z00c3g8vRrwkcqjerx7BEhPbOnWCPqaHUl2XWQBJQvOT/FQhdMT7X/Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/pako": "^2.0.3",
@@ -1631,7 +1621,6 @@
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
       "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/finalhandler": {
@@ -1793,7 +1782,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
       "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1850,7 +1838,6 @@
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/iobuffer/-/iobuffer-5.4.0.tgz",
       "integrity": "sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/ipaddr.js": {
@@ -1897,7 +1884,6 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-4.2.1.tgz",
       "integrity": "sha512-YyAXyvnmjTbR4bHQRLzex3CuINCDlQnBqoSYyjJwTP2x9jDLuKDzy7aKUl0hgx3uhcl7xzg32agn5vlie6HIlQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.6",
@@ -2167,7 +2153,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
       "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
-      "dev": true,
       "license": "(MIT AND Zlib)"
     },
     "node_modules/parseurl": {
@@ -2193,7 +2178,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
-      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -2399,7 +2383,6 @@
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
       "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2464,7 +2447,6 @@
       "version": "0.13.11",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
       "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
-      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -2482,7 +2464,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
       "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
-      "dev": true,
       "license": "MIT OR SEE LICENSE IN FEEL-FREE.md",
       "optional": true,
       "engines": {
@@ -2745,7 +2726,6 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
       "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -2832,7 +2812,6 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
       "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -2843,7 +2822,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
       "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2990,7 +2968,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
       "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {

--- a/brett/src/client/touch-handler.ts
+++ b/brett/src/client/touch-handler.ts
@@ -207,4 +207,14 @@ export function initTouchHandler({ canvas, deps }: TouchHandlerWireDeps): void {
   };
   canvas.addEventListener('pointerup', up);
   canvas.addEventListener('pointercancel', up);
+
+  canvas.addEventListener('contextmenu', (e: Event) => {
+    e.preventDefault();
+  }, { passive: false });
+
+  canvas.addEventListener('touchstart', (e: TouchEvent) => {
+    if (e.touches.length > 1) {
+      e.preventDefault();
+    }
+  }, { passive: false });
 }

--- a/brett/test/touch-handler.test.ts
+++ b/brett/test/touch-handler.test.ts
@@ -12,6 +12,7 @@ import {
   _onPointerDown,
   _onPointerMove,
   _onPointerUp,
+  initTouchHandler,
   type TouchDeps,
 } from '../src/client/touch-handler';
 
@@ -146,4 +147,69 @@ test('orbit move calls applyOrbitDelta with sensitivity-scaled deltas', () => {
   assert.ok(captured);
   assert.strictEqual(captured!.dTheta, -10 * TOUCH_ORBIT_SENSITIVITY);
   assert.strictEqual(captured!.dPhi, -10 * TOUCH_ORBIT_SENSITIVITY);
+});
+
+// ── DOM wiring tests (contextmenu + multi-touch guard) ─────────────────────
+
+function makeMinimalCanvas() {
+  const listeners = new Map<string, ((...args: any[]) => void)[]>();
+  return {
+    addEventListener(type: string, fn: (...args: any[]) => void, _opts?: any) {
+      if (!listeners.has(type)) listeners.set(type, []);
+      listeners.get(type)!.push(fn);
+    },
+    removeEventListener() {},
+    triggerEvent(type: string, event: any) {
+      const fns = listeners.get(type) ?? [];
+      for (const fn of fns) fn(event);
+    },
+  };
+}
+
+function makeMinimalTouchDeps() {
+  return {
+    pickContactAt: () => null,
+    canDragFigure: () => false,
+    startFigureDrag: () => {},
+    moveFigureDrag: () => {},
+    endFigureDrag: () => {},
+    getOrbitDist: () => 10,
+    setOrbitDist: () => {},
+    applyOrbitDelta: () => {},
+    capturePointer: () => {},
+    releasePointer: () => {},
+  };
+}
+
+test('contextmenu listener calls preventDefault', () => {
+  const canvas = makeMinimalCanvas();
+  initTouchHandler({ canvas: canvas as any, deps: makeMinimalTouchDeps() });
+  let prevented = false;
+  const fakeEvent = { preventDefault: () => { prevented = true; } };
+  canvas.triggerEvent('contextmenu', fakeEvent);
+  assert.ok(prevented, 'contextmenu should call preventDefault');
+});
+
+test('touchstart with 2 fingers calls preventDefault', () => {
+  const canvas = makeMinimalCanvas();
+  initTouchHandler({ canvas: canvas as any, deps: makeMinimalTouchDeps() });
+  let prevented = false;
+  const fakeEvent = {
+    touches: { length: 2 },
+    preventDefault: () => { prevented = true; },
+  };
+  canvas.triggerEvent('touchstart', fakeEvent);
+  assert.ok(prevented, 'two-finger touchstart should call preventDefault');
+});
+
+test('touchstart with 1 finger does not call preventDefault', () => {
+  const canvas = makeMinimalCanvas();
+  initTouchHandler({ canvas: canvas as any, deps: makeMinimalTouchDeps() });
+  let prevented = false;
+  const fakeEvent = {
+    touches: { length: 1 },
+    preventDefault: () => { prevented = true; },
+  };
+  canvas.triggerEvent('touchstart', fakeEvent);
+  assert.ok(!prevented, 'single-finger touchstart should not call preventDefault');
 });

--- a/docs/superpowers/plans/2026-06-14-t000703.md
+++ b/docs/superpowers/plans/2026-06-14-t000703.md
@@ -1,0 +1,171 @@
+---
+title: Plan: Brett – Touch-Drag Android (T000703)
+ticket_id: null
+domains: [website, infra, db, ops]
+status: active
+pr_number: null
+file_locks: []
+shared_changes: false
+batch_id: null
+parent_feature: null
+depends_on_plans: []
+---
+
+# Plan: Brett – Touch-Drag Android (T000703)
+
+**Datum:** 2026-06-14  
+**Ticket:** T000703  
+**Branch:** `feature/t000703`  
+**Spec:** `docs/superpowers/specs/2026-06-14-t000703-design.md`  
+
+---
+
+## Ziel
+
+Natives, verzögerungsfreies Touch-Drag von Figuren auf Android durch:
+1. Unterdrückung des `contextmenu`-Events auf dem Canvas (verhindert Long-Press-Popup).
+2. Ergänzenden `touchstart`-Guard für Multi-Touch (verhindert Browser-Zoom beim zweiten
+   Finger).
+
+Keine Architektur-Änderungen — der Pointer-Events-Pfad aus T000606 bleibt primär.
+
+---
+
+## Tech-Stack / Einschränkungen
+
+- TypeScript (brett/src/client/) — Limit `.ts`: 600 Zeilen
+- `touch-handler.ts`: aktuell **210/600** — +~15 Zeilen geplant → unkritisch
+- `touch-handler.test.ts`: aktuell **150** Zeilen (node:test) — +~50 Zeilen geplant → unkritisch
+- Keine neuen Dateien, keine Manifest-/Schema-Änderungen (S4 n/a, S3 n/a)
+- S2 Import-Zyklen: kein neuer Import → unkritisch
+
+---
+
+## Aufgaben
+
+### Task A — contextmenu-Block in `initTouchHandler()`
+
+**Datei:** `brett/src/client/touch-handler.ts`  
+**Zeilen-Budget:** 210 → ~225 (unkritisch, Limit 600)
+
+- [ ] A1: In `initTouchHandler()` einen `contextmenu`-Listener auf `canvas` registrieren,
+  der `e.preventDefault()` aufruft.
+  ```typescript
+  canvas.addEventListener('contextmenu', (e: Event) => {
+    e.preventDefault();
+  }, { passive: false });
+  ```
+  Platzierung: direkt nach der letzten `pointercancel`-Registrierung, vor dem schließenden
+  `}` von `initTouchHandler`.
+
+### Task B — Multi-Touch-Guard in `initTouchHandler()`
+
+**Datei:** `brett/src/client/touch-handler.ts`
+
+- [ ] B1: Unmittelbar nach dem `contextmenu`-Listener einen `touchstart`-Listener
+  registrieren, der bei mehr als einem gleichzeitigen Touch `preventDefault()` aufruft:
+  ```typescript
+  canvas.addEventListener('touchstart', (e: TouchEvent) => {
+    if (e.touches.length > 1) {
+      e.preventDefault();
+    }
+  }, { passive: false });
+  ```
+  Dieser Listener enthält keine Drag-Logik — er ist ausschließlich ein Browser-Guard.
+
+### Task C — Tests für contextmenu-Block und Multi-Touch-Guard
+
+**Datei:** `brett/test/touch-handler.test.ts` (vorhandene Datei erweitern)  
+**Zeilen-Budget:** ~150 → ~200 (unkritisch, Limit 600 für .ts)
+
+Strategie: minimaler Fake-`EventTarget` (kein JSDOM), der registrierte Listener
+speichert und beim Aufrufen weitergibt. `initTouchHandler()` wird mit dem Fake-Canvas
+und einem minimalen `TouchHandlerWireDeps`-Stub aufgerufen.
+
+- [ ] C1: Hilfsfunktion `makeMinimalCanvas()` am Ende des Test-Files hinzufügen —
+  gibt ein Objekt zurück, das `addEventListener` implementiert und Listener in einer Map
+  speichert (`listeners: Map<string, EventListenerOrEventListenerObject[]>`).
+
+- [ ] C2: Hilfsfunktion `makeMinimalDeps()` — erzeugt ein minimales `TouchHandlerWireDeps`
+  mit dem Fake-Canvas und einem leeren `TouchDeps`-Stub (alle Felder No-ops).
+
+- [ ] C3: Test `contextmenu listener calls preventDefault`:
+  ```typescript
+  test('contextmenu listener calls preventDefault', () => {
+    const canvas = makeMinimalCanvas();
+    initTouchHandler({ canvas, deps: makeMinimalDeps() });
+    let prevented = false;
+    const fakeEvent = { preventDefault: () => { prevented = true; } };
+    canvas.triggerEvent('contextmenu', fakeEvent);
+    assert.ok(prevented, 'contextmenu should call preventDefault');
+  });
+  ```
+
+- [ ] C4: Test `touchstart with 2 fingers calls preventDefault`:
+  ```typescript
+  test('touchstart with 2 fingers calls preventDefault', () => {
+    const canvas = makeMinimalCanvas();
+    initTouchHandler({ canvas, deps: makeMinimalDeps() });
+    let prevented = false;
+    const fakeEvent = {
+      touches: { length: 2 },
+      preventDefault: () => { prevented = true; },
+    };
+    canvas.triggerEvent('touchstart', fakeEvent);
+    assert.ok(prevented, 'two-finger touchstart should call preventDefault');
+  });
+  ```
+
+- [ ] C5: Test `touchstart with 1 finger does NOT call preventDefault`:
+  ```typescript
+  test('touchstart with 1 finger does not call preventDefault', () => {
+    const canvas = makeMinimalCanvas();
+    initTouchHandler({ canvas, deps: makeMinimalDeps() });
+    let prevented = false;
+    const fakeEvent = {
+      touches: { length: 1 },
+      preventDefault: () => { prevented = true; },
+    };
+    canvas.triggerEvent('touchstart', fakeEvent);
+    assert.ok(!prevented, 'single-finger touchstart should not call preventDefault');
+  });
+  ```
+
+### Task D — Test-Inventar aktualisieren
+
+- [ ] D1: `task test:inventory` ausführen und
+  `website/src/data/test-inventory.json` committen (CI-Pflicht bei Test-Änderungen).
+
+### Task E — Verifikation
+
+- [ ] E1: `task test:all` — alle Offline-Tests grün (inkl. neuer Touch-Tests)
+- [ ] E2: `task freshness:regenerate` — generierte Artefakte aktualisieren
+- [ ] E3: `task freshness:check` — Freshness + S1-S4-Ratchet grün
+- [ ] E4: Manuell in Chrome DevTools (Device Mode → Android Generic) verifizieren:
+  - Figur sofort verschiebbar ohne Long-Press-Wartezeit
+  - Kein Kontextmenü erscheint
+  - Zwei-Finger-Pinch löst keinen Browser-Zoom aus
+
+---
+
+## Nicht ändern
+
+- `brett/src/client/board-boot.ts` — Desktop-Maus-Logik unberührt
+- `brett/src/client/touch-controls.ts` — TouchDeps-Verdrahtung unberührt
+- `brett/public/index.html` — `touch-action: none` ist bereits korrekt gesetzt
+- `k3d/`, `prod*/`, `environments/` — keine Deployment-Änderungen
+
+---
+
+## Abhängigkeiten
+
+Keine externen Abhängigkeiten. T000606 (Pointer-Events-Basis) ist bereits gemergt.
+
+---
+
+## Risiken
+
+| Risiko | Maßnahme |
+|--------|---------|
+| contextmenu-Block stört Desktop-Rechtsklick | Canvas-Listener ist scope-begrenzt auf den Board-Canvas; Desktop-Rechtsklick auf UI-Elementen außerhalb ist unberührt |
+| passive:false Performance-Warnung | Akzeptabel für interaktives Canvas (bekannte Trade-off) |

--- a/docs/superpowers/specs/2026-06-14-t000703-design.md
+++ b/docs/superpowers/specs/2026-06-14-t000703-design.md
@@ -1,0 +1,140 @@
+# Spec: Brett – Touch-Drag Android (T000703)
+
+**Datum:** 2026-06-14  
+**Ticket:** T000703  
+**Status:** draft  
+
+---
+
+## Problem
+
+Auf Android-Smartphones können Figuren im Brett-Board derzeit nicht direkt per Finger
+gezogen werden. Das aktuelle System basiert auf Pointer Events
+(`pointerdown`/`pointermove`/`pointerup` mit `pointerType !== 'mouse'`-Filter). Auf
+Android Chrome löst der Browser vor dem ersten `pointermove` einen langen Drückvorgang
+aus (Long-Press-Geste), um das Kontextmenü oder Textauswahl anzubieten. Solange dieses
+Verhalten nicht unterdrückt wird, wird der Drag-Vorgang erst nach einer spürbaren
+Verzögerung aktiv — oder er startet gar nicht, wenn `contextmenu` die Pointer-Capture
+abbricht.
+
+### Symptome
+- Figur verschieben erfordert langes Drücken (~500 ms statt sofortigem Start).
+- Beim Loslassen erscheint gelegentlich ein nativer Kontextmenü-Dialog.
+- Multi-Touch (zwei Finger) führt zu unerwünschtem Browser-Zoom statt Pinch-Zoom der
+  Szene, weil Android den zweiten Touch als Scroll/Zoom-Geste abfängt.
+
+### Ursache
+1. **`contextmenu`-Event fehlt** – Das Canvas hat keinen `contextmenu`-Listener. Android
+   Chrome löst `contextmenu` bei Long-Press aus und unterbricht dadurch die aktive
+   Pointer-Capture-Sequenz.
+2. **`pointermove` passive nicht explizit false auf dem zweiten Finger** – `touch-action:
+   none` im CSS reicht auf manchen Android-Versionen nicht aus, wenn der zweite Touch auf
+   ein anderes Element fällt.
+3. **Kein `touchstart`/`touchmove`-Fallback** – Ältere Android-WebViews (z. B.
+   eingebettete Browser in Apps) unterstützen Pointer Events schlechter als Touch Events.
+
+---
+
+## Ziel
+
+Natives, unmittelbares Touch-Drag von Figuren auf Android ohne Maus-Emulation oder
+Long-Press-Wartephase. Konkret:
+
+1. **Sofortiger Drag** – `pointerdown` auf einer Figur startet den Drag ohne spürbare
+   Verzögerung.
+2. **Kein Kontextmenü** – `contextmenu` auf dem Canvas wird immer unterdrückt
+   (`preventDefault`).
+3. **Multi-Touch-Schutz** – Ein zweiter Finger schaltet zuverlässig in Pinch-Zoom-Modus,
+   ohne dass der Browser den nativen Pinch-Zoom auslöst. `touch-action: none` ist bereits
+   gesetzt; zusätzlich wird `touchstart` mit `{ passive: false }` und `preventDefault()`
+   registriert.
+4. **Scroll-Schutz** – `pointermove` wird mit `{ passive: false }` registriert, damit
+   `preventDefault()` den Scroll unterbindet (bereits in T000606 umgesetzt — validieren).
+
+---
+
+## Nicht-Ziele
+
+- Keine Änderung der Desktop-Maus-Logik in `board-boot.ts`.
+- Kein Refactoring der Pointer-Events-Architektur aus T000606.
+- Keine Unterstützung für iOS-Safari-spezifische Quirks (separates Ticket bei Bedarf).
+- Kein Umbau auf `touchstart`/`touchmove`/`touchend` als primären Pfad — Pointer Events
+  bleiben der primäre Pfad; Touch Events dienen als Ergänzung für den
+  Context-Menu-Block und den Multi-Touch-Guard.
+
+---
+
+## Architektur
+
+### Dateien betroffen
+
+| Datei | Änderung |
+|-------|---------|
+| `brett/src/client/touch-handler.ts` | `contextmenu`-Listener + `touchstart`-Multi-Touch-Guard in `initTouchHandler()` |
+| `brett/test/touch-handler.test.ts` | Neue Tests für contextmenu-Block und multi-touch-Guard |
+
+Keine Manifest-, Schema- oder ConfigMap-Änderungen notwendig.
+
+### `initTouchHandler()` Erweiterung
+
+```typescript
+// (1) Sofortiger contextmenu-Block — verhindert Long-Press-Popup
+canvas.addEventListener('contextmenu', (e) => {
+  e.preventDefault();
+}, { passive: false });
+
+// (2) Multi-Touch-Guard via Touch Events (ergänzend zu Pointer Events)
+// Verhindert Browser-nativen Pinch-Zoom wenn ein zweiter Finger landet.
+canvas.addEventListener('touchstart', (e) => {
+  if (e.touches.length > 1) {
+    e.preventDefault();
+  }
+}, { passive: false });
+```
+
+Der bestehende `pointerdown`-Handler ruft bereits `e.preventDefault()` — das reicht für
+den Einzel-Touch-Fall. Der neue `touchstart`-Listener schließt die Lücke für den zweiten
+Finger, der parallel zu einem noch laufenden `pointerdown` landet (Android feuert
+`touchstart` vor `pointerdown` für zusätzliche Berührungen).
+
+### Kein doppeltes Handling
+
+`touchstart`-Handler ruft keinerlei Board-Logik (kein Drag-Start, kein Mode-Switch) — er
+dient ausschließlich als Guard. Die gesamte Drag-Logik verbleibt im Pointer-Events-Pfad.
+Dadurch: kein doppeltes State-Update, keine Reentranz-Probleme.
+
+---
+
+## Test-Strategie
+
+Die Tests in `brett/test/touch-handler.test.ts` werden erweitert (keine neue Datei):
+
+- **contextmenu-Block**: Fake-Event mit `preventDefault`-Spy → verifizieren, dass
+  `initTouchHandler()` einen Listener registriert der `preventDefault` aufruft.
+- **Multi-Touch-Guard**: `TouchEvent` mit `touches.length === 2` → `preventDefault`
+  aufgerufen; `touches.length === 1` → nicht aufgerufen.
+
+Da `initTouchHandler()` DOM-abhängig ist (registriert Listener direkt), werden die neuen
+Tests mit einem minimal-Fake-`EventTarget` geschrieben (kein JSDOM erforderlich).
+
+---
+
+## Akzeptanzkriterien
+
+| # | Kriterium |
+|---|-----------|
+| AC1 | Figur lässt sich auf Android Chrome (simuliert via DevTools Device Mode) ohne Verzögerung verschieben |
+| AC2 | Kein Kontextmenü-Dialog erscheint beim Drücken auf eine Figur |
+| AC3 | Zwei-Finger-Pinch-Zoom löst Browser-nativen Zoom nicht aus |
+| AC4 | Bestehende Desktop-Maus-Tests bleiben grün |
+| AC5 | `task test:all` + `task freshness:check` grün |
+
+---
+
+## Risiken
+
+| Risiko | Wahrscheinlichkeit | Gegenmaßnahme |
+|--------|--------------------|--------------|
+| `contextmenu`-Block stört Desktop-Rechtsklick | Niedrig | Listener prüft `e.pointerType` oder wird nur für `canvas`-Scope gesetzt |
+| `touchstart { passive: false }` Performance-Warnung in DevTools | Niedrig | Bekannt und akzeptabel für interaktives Canvas |
+| Android-WebView-Quirks beim Pointer-Capture | Mittel | Fallback: `releasePointerCapture` in `pointercancel` (bereits implementiert) |


### PR DESCRIPTION
## T000703 — Touch-Drag Android

Natives, verzögerungsfreies Touch-Drag von Figuren auf Android:

- **contextmenu-Block**: Unterdrückt das Long-Press-Popup auf dem Canvas
- **Multi-Touch-Guard**: Verhindert Browser-Zoom beim zweiten Finger

Keine Architektur-Änderungen — der Pointer-Events-Pfad aus T000606 bleibt primär.

### Changes
- `brett/src/client/touch-handler.ts`: +contextmenu listener + touchstart guard
- `brett/test/touch-handler.test.ts`: +3 tests (contextmenu, 2-finger, 1-finger)