### PR TITLE
fix(website): extract graph-utils lib to fix SSR/browser bundle leak

### DIFF
--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -472,7 +472,7 @@
       "id": "website",
       "name": "Astro + Svelte website",
       "owner_agent": "bachelorprojekt-website",
-      "file_count": 1288,
+      "file_count": 1289,
       "files": [
         "website/.build-trigger",
         "website/.dockerignore",
@@ -1063,6 +1063,7 @@
         "website/src/lib/generate-3d-pipeline.test.ts",
         "website/src/lib/generation-jobs.ts",
         "website/src/lib/github-ci.ts",
+        "website/src/lib/graph-utils.ts",
         "website/src/lib/helpContent.platform.test.ts",
         "website/src/lib/helpContent.ts",
         "website/src/lib/ingest-json-core.ts",

--- a/docs/generated/api-map.json
+++ b/docs/generated/api-map.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-14T15:39:36.715Z",
+  "generatedAt": "2026-06-14T15:49:06.817Z",
   "endpoints": [
     {
       "path": "/api/admin/angebote/save",

--- a/docs/generated/api-surface.md
+++ b/docs/generated/api-surface.md
@@ -1,6 +1,6 @@
 # API Surface Map
 
-> Generated at 2026-06-14T15:39:36.715Z
+> Generated at 2026-06-14T15:49:06.817Z
 
 | Path | Methods | Auth | File |
 |------|---------|------|------|

--- a/docs/generated/blast-radius.md
+++ b/docs/generated/blast-radius.md
@@ -1,5 +1,5 @@
 # Blast-Radius-Report
-> Generated: 2026-06-14T15:39:36.813Z
+> Generated: 2026-06-14T15:49:06.899Z
 > Nodes: 74 | Edges: 1385 | Isolated: 2
 
 ## Ranking (transitive Abhängige)

--- a/docs/generated/graph.json
+++ b/docs/generated/graph.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-14T15:39:36.636Z",
+  "generatedAt": "2026-06-14T15:49:06.746Z",
   "nodes": [
     {
       "id": "admin-actions-cleanup",

--- a/k3d/docs-content-built/architecture/index.html
+++ b/k3d/docs-content-built/architecture/index.html
@@ -178,7 +178,7 @@
 <body>
   <div class="header">
     <h1>⬡ Architektur — Living Docs</h1>
-    <span class="meta">Generiert: 2026-06-14T15:39:36.759Z</span>
+    <span class="meta">Generiert: 2026-06-14T15:49:06.855Z</span>
   </div>
 
   <div class="stats">

--- a/website/src/components/admin/ArchitekturGraph.svelte
+++ b/website/src/components/admin/ArchitekturGraph.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { onMount, onDestroy } from 'svelte';
-  import type { GraphNode, GraphEdge, PodEntry, NodeStatus } from '../../pages/api/admin/cluster/graph';
-  import { buildStatusMap } from '../../pages/api/admin/cluster/graph';
+  import type { GraphNode, GraphEdge, PodEntry, NodeStatus } from '../../lib/graph-utils';
+  import { buildStatusMap } from '../../lib/graph-utils';
   import GraphCanvas from './graph/GraphCanvas.svelte';
   import NodeDetailPanel from './graph/NodeDetailPanel.svelte';
 

--- a/website/src/components/admin/graph/GraphCanvas.svelte
+++ b/website/src/components/admin/graph/GraphCanvas.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { onMount, onDestroy } from 'svelte';
   import * as d3 from 'd3';
-  import type { GraphNode, GraphEdge, NodeStatus } from '../../../pages/api/admin/cluster/graph';
+  import type { GraphNode, GraphEdge, NodeStatus } from '../../../lib/graph-utils';
   import GraphNodeComponent from './GraphNode.svelte';
   import GraphLegend from './GraphLegend.svelte';
 

--- a/website/src/components/admin/graph/GraphNode.svelte
+++ b/website/src/components/admin/graph/GraphNode.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
-  import type { GraphNode as GNode } from '../../../pages/api/admin/cluster/graph';
-  import type { NodeStatus } from '../../../pages/api/admin/cluster/graph';
+  import type { GraphNode as GNode, NodeStatus } from '../../../lib/graph-utils';
 
   interface Props {
     node: GNode & { x?: number; y?: number };

--- a/website/src/components/admin/graph/NodeDetailPanel.svelte
+++ b/website/src/components/admin/graph/NodeDetailPanel.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { GraphNode, PodEntry } from '../../../pages/api/admin/cluster/graph';
+  import type { GraphNode, PodEntry } from '../../../lib/graph-utils';
 
   interface Warning {
     namespace: string;

--- a/website/src/lib/codesearch-db.ts
+++ b/website/src/lib/codesearch-db.ts
@@ -1,12 +1,12 @@
 import { Pool } from 'pg';
-import { resolve4 } from 'node:dns';
+import dns from 'node:dns';
 
 function nodeLookup(
   hostname: string,
   _opts: unknown,
   cb: (err: Error | null, addr: string, family: number) => void,
 ) {
-  resolve4(hostname, (err, addrs) => cb(err ?? null, addrs?.[0] ?? '', 4));
+  dns.resolve4(hostname, (err, addrs) => cb(err ?? null, addrs?.[0] ?? '', 4));
 }
 
 let _pool: Pool | null = null;

--- a/website/src/lib/graph-utils.ts
+++ b/website/src/lib/graph-utils.ts
@@ -1,0 +1,108 @@
+// Browser-safe graph types and utilities — no Node.js built-ins.
+// Keep this file free of server-only imports so Svelte client bundles can import from here.
+
+export interface GraphNode {
+  id: string;
+  namespace: string;
+  type: string;
+  name: string;
+}
+
+export interface GraphEdge {
+  from: string;
+  to: string;
+  via?: string;
+  kind?: string;
+}
+
+export interface GraphData {
+  generatedAt: string;
+  nodes: GraphNode[];
+  edges: GraphEdge[];
+}
+
+export interface PodEntry {
+  name: string;
+  phase: string;
+  ready: boolean;
+  restarts: number;
+  containers: string[];
+  labels?: Record<string, string>;
+}
+
+export interface NodeStatus {
+  color: string;
+  detail: string;
+  pods: PodEntry[];
+  matched: boolean;
+}
+
+const NS_MAP: Record<string, Record<string, string>> = {
+  '${WEBSITE_NAMESPACE}': { mentolder: 'website', korczewski: 'website-korczewski' },
+  '${WORKSPACE_NAMESPACE}': { mentolder: 'workspace', korczewski: 'workspace-korczewski' },
+  '$STAGING_NS': { mentolder: 'workspace-dev', korczewski: 'workspace-dev' },
+};
+
+export function resolveNamespace(placeholder: string, brand: string): string {
+  const mapping = NS_MAP[placeholder];
+  if (mapping) return mapping[brand] ?? mapping.mentolder;
+  return placeholder;
+}
+
+export function resolveGraph(graph: GraphData, brand: string): GraphData {
+  const resolvedNodes = graph.nodes.map(n => ({
+    ...n,
+    namespace: resolveNamespace(n.namespace, brand),
+  }));
+  return { ...graph, nodes: resolvedNodes };
+}
+
+export function matchPodsToNode(node: GraphNode, pods: PodEntry[]): PodEntry[] {
+  const labelMatch = pods.filter(p => {
+    const app = p.labels?.app;
+    return app === node.id || app === node.name;
+  });
+  if (labelMatch.length > 0) return labelMatch;
+
+  const prefixMatch = pods.filter(p => p.name.startsWith(node.name + '-'));
+  if (prefixMatch.length > 0) return prefixMatch;
+
+  return [];
+}
+
+export function buildStatusMap(
+  nodes: GraphNode[],
+  podsByNamespace: Map<string, PodEntry[]>,
+): Map<string, NodeStatus> {
+  const map = new Map<string, NodeStatus>();
+
+  for (const node of nodes) {
+    const pods = podsByNamespace.get(node.namespace) ?? [];
+    const matched = matchPodsToNode(node, pods);
+
+    if (node.type === 'CronJob') {
+      map.set(node.id, { color: '#6b7280', detail: 'CronJob — kein laufender Pod erwartet', pods: matched, matched: true });
+      continue;
+    }
+
+    if (matched.length === 0) {
+      map.set(node.id, { color: '#374151', detail: 'Kein Pod zugeordnet', pods: [], matched: false });
+      continue;
+    }
+
+    const allReady = matched.every(p => p.ready);
+    const anyReady = matched.some(p => p.ready);
+    const totalRestarts = matched.reduce((a, p) => a + p.restarts, 0);
+    const hasCrashLoop = matched.some(p => p.phase === 'CrashLoopBackOff' || p.phase === 'Error');
+
+    if (hasCrashLoop || !anyReady) {
+      map.set(node.id, { color: '#ef4444', detail: `Kritisch: ${matched.length} Pods, keiner ready`, pods: matched, matched: true });
+    } else if (!allReady || totalRestarts > 0) {
+      map.set(node.id, { color: '#eab308', detail: `Degraded: ${matched.filter(p => p.ready).length}/${matched.length} ready, ${totalRestarts} Restarts`, pods: matched, matched: true });
+    } else {
+      map.set(node.id, { color: '#22c55e', detail: `Healthy: ${matched.length} Pods ready`, pods: matched, matched: true });
+    }
+  }
+
+  return map;
+}

--- a/website/src/lib/knowledge-db.ts
+++ b/website/src/lib/knowledge-db.ts
@@ -1,5 +1,5 @@
 import { Pool } from 'pg';
-import { resolve4 } from 'dns';
+import dns from 'dns';
 import { embedQuery, type EmbeddingModel } from './embeddings';
 
 export class MixedEmbeddingModelError extends Error {
@@ -17,7 +17,7 @@ function nodeLookup(
   _opts: unknown,
   cb: (err: Error | null, addr: string, family: number) => void,
 ) {
-  resolve4(hostname, (err, addrs) => cb(err ?? null, addrs?.[0] ?? '', 4));
+  dns.resolve4(hostname, (err, addrs) => cb(err ?? null, addrs?.[0] ?? '', 4));
 }
 
 let _pool: Pool | null = null;

--- a/website/src/lib/website-db.ts
+++ b/website/src/lib/website-db.ts
@@ -3,7 +3,7 @@
 // Uses the 'pg' npm package for direct database access.
 
 import pg from 'pg';
-import { resolve4 } from 'dns';
+import dns from 'dns';
 import { initTicketsSchema } from './tickets-db';
 import { transitionTicket } from './tickets/transition';
 import { refFor } from './content-registry';
@@ -23,7 +23,7 @@ function nodeLookup(
   _opts: unknown,
   cb: (err: Error | null, addr: string, family: number) => void,
 ) {
-  resolve4(hostname, (err, addrs) => cb(err ?? null, addrs?.[0] ?? '', 4));
+  dns.resolve4(hostname, (err, addrs) => cb(err ?? null, addrs?.[0] ?? '', 4));
 }
 
 // pg's PoolConfig type doesn't declare `lookup`, but pg-pool passes it through

--- a/website/src/pages/api/admin/cluster/graph.ts
+++ b/website/src/pages/api/admin/cluster/graph.ts
@@ -2,112 +2,13 @@ import type { APIRoute } from 'astro';
 import { getSession, isAdmin } from '../../../../lib/auth';
 import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
+import {
+  resolveGraph,
+  type GraphData,
+} from '../../../../lib/graph-utils';
 
-export interface GraphNode {
-  id: string;
-  namespace: string;
-  type: string;
-  name: string;
-}
-
-export interface GraphEdge {
-  from: string;
-  to: string;
-  via?: string;
-  kind?: string;
-}
-
-export interface GraphData {
-  generatedAt: string;
-  nodes: GraphNode[];
-  edges: GraphEdge[];
-}
-
-export interface PodEntry {
-  name: string;
-  phase: string;
-  ready: boolean;
-  restarts: number;
-  containers: string[];
-  labels?: Record<string, string>;
-}
-
-export interface NodeStatus {
-  color: string;
-  detail: string;
-  pods: PodEntry[];
-  matched: boolean;
-}
-
-const NS_MAP: Record<string, Record<string, string>> = {
-  '${WEBSITE_NAMESPACE}': { mentolder: 'website', korczewski: 'website-korczewski' },
-  '${WORKSPACE_NAMESPACE}': { mentolder: 'workspace', korczewski: 'workspace-korczewski' },
-  '$STAGING_NS': { mentolder: 'workspace-dev', korczewski: 'workspace-dev' },
-};
-
-export function resolveNamespace(placeholder: string, brand: string): string {
-  const mapping = NS_MAP[placeholder];
-  if (mapping) return mapping[brand] ?? mapping.mentolder;
-  return placeholder;
-}
-
-export function resolveGraph(graph: GraphData, brand: string): GraphData {
-  const resolvedNodes = graph.nodes.map(n => ({
-    ...n,
-    namespace: resolveNamespace(n.namespace, brand),
-  }));
-  return { ...graph, nodes: resolvedNodes };
-}
-
-export function matchPodsToNode(node: GraphNode, pods: PodEntry[]): PodEntry[] {
-  const labelMatch = pods.filter(p => {
-    const app = p.labels?.app;
-    return app === node.id || app === node.name;
-  });
-  if (labelMatch.length > 0) return labelMatch;
-
-  const prefixMatch = pods.filter(p => p.name.startsWith(node.name + '-'));
-  if (prefixMatch.length > 0) return prefixMatch;
-
-  return [];
-}
-
-export function buildStatusMap(
-  nodes: GraphNode[],
-  podsByNamespace: Map<string, PodEntry[]>,
-): Map<string, NodeStatus> {
-  const map = new Map<string, NodeStatus>();
-
-  for (const node of nodes) {
-    const pods = podsByNamespace.get(node.namespace) ?? [];
-    const matched = matchPodsToNode(node, pods);
-
-    if (node.type === 'CronJob') {
-      map.set(node.id, { color: '#6b7280', detail: 'CronJob — kein laufender Pod erwartet', pods: matched, matched: true });
-      continue;
-    }
-
-    if (matched.length === 0) {
-      map.set(node.id, { color: '#374151', detail: 'Kein Pod zugeordnet', pods: [], matched: false });
-      continue;
-    }
-
-    const allReady = matched.every(p => p.ready);
-    const anyReady = matched.some(p => p.ready);
-    const totalRestarts = matched.reduce((a, p) => a + p.restarts, 0);
-    const hasCrashLoop = matched.some(p => p.phase === 'CrashLoopBackOff' || p.phase === 'Error');
-
-    if (hasCrashLoop || !anyReady) {
-      map.set(node.id, { color: '#ef4444', detail: `Kritisch: ${matched.length} Pods, keiner ready`, pods: matched, matched: true });
-    } else if (!allReady || totalRestarts > 0) {
-      map.set(node.id, { color: '#eab308', detail: `Degraded: ${matched.filter(p => p.ready).length}/${matched.length} ready, ${totalRestarts} Restarts`, pods: matched, matched: true });
-    } else {
-      map.set(node.id, { color: '#22c55e', detail: `Healthy: ${matched.length} Pods ready`, pods: matched, matched: true });
-    }
-  }
-
-  return map;
-}
+export type { GraphNode, GraphEdge, GraphData, PodEntry, NodeStatus } from '../../../../lib/graph-utils';
+export { resolveNamespace, resolveGraph, matchPodsToNode, buildStatusMap } from '../../../../lib/graph-utils';
 
 export const GET: APIRoute = async ({ request }) => {
   const session = await getSession(request.headers.get('cookie'));


### PR DESCRIPTION
## Summary
- Fixes the broken `build-website.yml` workflow that has been failing since PR #1617 (2026-06-13)
- Creates `src/lib/graph-utils.ts` with all browser-safe types and functions moved out of the SSR-only API route `graph.ts`
- Updates 4 Svelte components (`ArchitekturGraph`, `GraphCanvas`, `NodeDetailPanel`, `GraphNode`) to import from `graph-utils` instead of the API route
- Changes `import { resolve4 } from 'dns'` → `import dns from 'dns'` in `knowledge-db.ts`, `codesearch-db.ts`, and `website-db.ts` to prevent fatal Rollup error from Vite's browser stub

## Root Causes
1. **graph.ts runtime import**: `ArchitekturGraph.svelte` (rendered with `client:load`) imported `buildStatusMap` at runtime from `pages/api/admin/cluster/graph.ts`. That API route imports `node:fs/promises` and `node:path`, pulling Node.js built-ins into the browser bundle → fatal Rollup error: `"join" is not exported by "__vite-browser-external"`
2. **dns named import**: `import { resolve4 } from 'dns'` — Vite's browser stub for `dns` is `{}` with no named exports, so Rollup throws: `"resolve4" is not exported by "__vite-browser-external"`

## Test plan
- [ ] Local `pnpm build` passes (verified: built in 20.55s, no errors)
- [ ] CI `build-website.yml` green after merge
- [ ] KI-Konfiguration page accessible at `/admin/ki-konfiguration` after deploy
- [ ] Architektur-Graph admin page still functional

🤖 Generated with [Claude Code](https://claude.com/claude-code)