### PR TITLE
fix(website): Kontaktformular-Hydration reparieren (i18n-Imports + locale) [T000712]

### DIFF
--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -472,7 +472,7 @@
       "id": "website",
       "name": "Astro + Svelte website",
       "owner_agent": "bachelorprojekt-website",
-      "file_count": 1289,
+      "file_count": 1290,
       "files": [
         "website/.build-trigger",
         "website/.dockerignore",
@@ -590,6 +590,7 @@
         "website/src/components/BookingForm.svelte",
         "website/src/components/CallToAction.svelte",
         "website/src/components/ChatRoomPanel.svelte",
+        "website/src/components/ContactForm.i18n.test.ts",
         "website/src/components/ContactForm.svelte",
         "website/src/components/ContactHub.svelte",
         "website/src/components/CookieConsent.svelte",

--- a/docs/generated/api-map.json
+++ b/docs/generated/api-map.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-14T16:24:42.745Z",
+  "generatedAt": "2026-06-14T17:07:55.331Z",
   "endpoints": [
     {
       "path": "/api/admin/angebote/save",

--- a/docs/generated/api-map.json
+++ b/docs/generated/api-map.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-14T17:07:55.331Z",
+  "generatedAt": "2026-06-14T17:12:41.609Z",
   "endpoints": [
     {
       "path": "/api/admin/angebote/save",

--- a/docs/generated/api-surface.md
+++ b/docs/generated/api-surface.md
@@ -1,6 +1,6 @@
 # API Surface Map
 
-> Generated at 2026-06-14T17:07:55.331Z
+> Generated at 2026-06-14T17:12:41.609Z
 
 | Path | Methods | Auth | File |
 |------|---------|------|------|

--- a/docs/generated/api-surface.md
+++ b/docs/generated/api-surface.md
@@ -1,6 +1,6 @@
 # API Surface Map
 
-> Generated at 2026-06-14T16:24:42.745Z
+> Generated at 2026-06-14T17:07:55.331Z
 
 | Path | Methods | Auth | File |
 |------|---------|------|------|

--- a/docs/generated/blast-radius.md
+++ b/docs/generated/blast-radius.md
@@ -1,5 +1,5 @@
 # Blast-Radius-Report
-> Generated: 2026-06-14T17:07:55.366Z
+> Generated: 2026-06-14T17:12:41.680Z
 > Nodes: 74 | Edges: 1385 | Isolated: 2
 
 ## Ranking (transitive Abhängige)

--- a/docs/generated/blast-radius.md
+++ b/docs/generated/blast-radius.md
@@ -1,5 +1,5 @@
 # Blast-Radius-Report
-> Generated: 2026-06-14T16:24:42.846Z
+> Generated: 2026-06-14T17:07:55.366Z
 > Nodes: 74 | Edges: 1385 | Isolated: 2
 
 ## Ranking (transitive Abhängige)

--- a/docs/generated/graph.json
+++ b/docs/generated/graph.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-14T16:24:42.661Z",
+  "generatedAt": "2026-06-14T17:07:55.263Z",
   "nodes": [
     {
       "id": "admin-actions-cleanup",

--- a/docs/generated/graph.json
+++ b/docs/generated/graph.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-14T17:07:55.263Z",
+  "generatedAt": "2026-06-14T17:12:41.544Z",
   "nodes": [
     {
       "id": "admin-actions-cleanup",

--- a/k3d/docs-content-built/architecture/index.html
+++ b/k3d/docs-content-built/architecture/index.html
@@ -178,7 +178,7 @@
 <body>
   <div class="header">
     <h1>⬡ Architektur — Living Docs</h1>
-    <span class="meta">Generiert: 2026-06-14T16:24:42.792Z</span>
+    <span class="meta">Generiert: 2026-06-14T17:07:53.474Z</span>
   </div>
 
   <div class="stats">

--- a/k3d/docs-content-built/architecture/index.html
+++ b/k3d/docs-content-built/architecture/index.html
@@ -178,7 +178,7 @@
 <body>
   <div class="header">
     <h1>⬡ Architektur — Living Docs</h1>
-    <span class="meta">Generiert: 2026-06-14T17:07:53.474Z</span>
+    <span class="meta">Generiert: 2026-06-14T17:12:41.644Z</span>
   </div>
 
   <div class="stats">

--- a/website/src/components/ContactForm.i18n.test.ts
+++ b/website/src/components/ContactForm.i18n.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { compile } from 'svelte/compiler';
+import { render } from 'svelte/server';
+import { readFileSync, writeFileSync, rmSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Regression für den Live-Bug (PR #1624): ContactForm.svelte nutzte t(locale,…)/getTypes(locale)
+// ohne Imports/locale-Prop → ReferenceError bei der Hydration → Kontaktformular-Felder erschienen
+// nie (FA-10 T5/T6 Timeout). Hier wird die Komponente server-gerendert: vor dem Fix wirft der
+// freie Identifier, nach dem Fix erscheinen die lokalisierten Labels.
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const COMPILED = join(__dirname, '.ContactForm.compiled.svelte.mjs');
+
+async function renderContactForm(props: Record<string, unknown>): Promise<string> {
+  const source = readFileSync(join(__dirname, 'ContactForm.svelte'), 'utf8');
+  const { js } = compile(source, { generate: 'server', runes: true, name: 'ContactForm' });
+  writeFileSync(COMPILED, js.code);
+  const mod = await import(/* @vite-ignore */ COMPILED);
+  return render(mod.default, { props }).body;
+}
+
+afterEach(() => {
+  try { rmSync(COMPILED, { force: true }); } catch { /* ignore */ }
+});
+
+describe('ContactForm i18n', () => {
+  it('rendert ohne ReferenceError und zeigt die lokalisierten Felder (de)', async () => {
+    const html = await renderContactForm({ locale: 'de' });
+    expect(html).toContain('Name');
+    expect(html).toContain('Ihre Nachricht');      // contact.message-label
+    expect(html).toContain('Nachricht senden');     // contact.submit
+    expect(html).toContain('Allgemeine Anfrage');   // typeOptions via i18n
+  });
+
+  it('lokalisiert die Labels auf en', async () => {
+    const html = await renderContactForm({ locale: 'en' });
+    expect(html).toContain('Your message');         // contact.message-label (en)
+    expect(html).toContain('Send message');         // contact.submit (en)
+    expect(html).toContain('General inquiry');      // contact.type-allgemein (en)
+  });
+
+  it('hat einen Default-Locale (de) wenn keine Prop gesetzt ist', async () => {
+    const html = await renderContactForm({});
+    expect(html).toContain('Nachricht senden');
+  });
+});

--- a/website/src/components/ContactForm.svelte
+++ b/website/src/components/ContactForm.svelte
@@ -1,4 +1,8 @@
 <script lang="ts">
+  import { t, type Locale } from '../i18n/index';
+
+  let { locale = 'de' }: { locale?: Locale } = $props();
+
   let name = $state('');
   let email = $state('');
   let phone = $state('');
@@ -7,14 +11,15 @@
   let submitting = $state(false);
   let result = $state<{ success: boolean; message: string } | null>(null);
 
-  const types = [
-    { value: 'allgemein', label: 'Allgemeine Anfrage' },
-    { value: 'erstgespraech', label: 'Kostenloses Erstgespräch' },
-    { value: '50plus-digital', label: '50+ digital' },
-    { value: 'coaching', label: 'Führungskräfte-Coaching' },
-    { value: 'beratung', label: 'Unternehmensberatung' },
-    { value: 'support', label: 'Support' },
-    { value: 'feedback', label: 'Feedback' },
+  // Submission-Values bleiben stabil (API-Kontrakt); Labels kommen aus i18n.
+  const typeOptions = [
+    { value: 'allgemein', key: 'contact.type-allgemein' },
+    { value: 'erstgespraech', key: 'contact.type-erstgespraech' },
+    { value: '50plus-digital', key: 'contact.type-50plus' },
+    { value: 'coaching', key: 'contact.type-coaching' },
+    { value: 'beratung', key: 'contact.type-beratung' },
+    { value: 'support', key: 'contact.type-support' },
+    { value: 'feedback', key: 'contact.type-feedback' },
   ];
 
   async function handleSubmit(e: Event) {
@@ -54,8 +59,8 @@
   <div class="cf-field">
     <label for="cf-type" class="cf-label">{t(locale, 'contact.type-label')}</label>
     <select id="cf-type" bind:value={type} class="cf-input">
-      {#each getTypes(locale) as item}
-        <option value={item.value}>{item.label}</option>
+      {#each typeOptions as item}
+        <option value={item.value}>{t(locale, item.key)}</option>
       {/each}
     </select>
   </div>

--- a/website/src/components/ContactHub.svelte
+++ b/website/src/components/ContactHub.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
   import ContactForm from './ContactForm.svelte';
   import BookingForm from './BookingForm.svelte';
+  import { type Locale } from '../i18n/index';
 
   interface Props {
+    locale?: Locale;
     initialMode?: 'message' | 'termin' | 'callback' | null;
     initialServiceKey?: string;
     initialDate?: string;
@@ -19,6 +21,7 @@
   }
 
   let {
+    locale = 'de',
     initialMode = null,
     initialServiceKey,
     initialDate = '',
@@ -95,7 +98,7 @@
             <BookingForm initialType="erstgespraech" serviceKey={initialServiceKey}
               {initialDate} {initialStart} {initialEnd} />
           {:else if activeMode === 'message'}
-            <ContactForm />
+            <ContactForm {locale} />
           {:else}
             <BookingForm initialType="callback" serviceKey={initialServiceKey} />
           {/if}

--- a/website/src/pages/kontakt.astro
+++ b/website/src/pages/kontakt.astro
@@ -5,7 +5,9 @@ import BookingForm from '../components/BookingForm.svelte';
 import { config } from '../config/index';
 import { getEffectiveKontakt, getEffectiveStammdaten } from '../lib/content';
 import { getSiteSetting, getSeoOgImage } from '../lib/website-db';
+import { getLocaleFromUrl, type Locale } from '../i18n/index';
 
+const locale: Locale = (Astro.locals.locale as Locale) ?? getLocaleFromUrl(Astro.url);
 const BRAND_ID = process.env.BRAND_ID ?? process.env.BRAND ?? 'mentolder';
 const isKore = BRAND_ID === 'korczewski';
 const layoutBrand = isKore ? 'korczewski-kore' : undefined;
@@ -68,6 +70,7 @@ const seoOgImage = await getSeoOgImage(BRAND_ID, 'kontakt').catch(() => null);
   <!-- ContactHub now owns the mode switcher + booking grid + sidebar -->
   <ContactHub
     client:load
+    {locale}
     initialMode={initialMode}
     initialServiceKey={initialServiceKey}
     {initialDate} {initialStart} {initialEnd}


### PR DESCRIPTION
## Production-Bug (blockiert das Required-E2E-Gate für ALLE PRs)
Auf **web.mentolder.de** wirft das Kontaktformular beim Klick auf den „Nachricht"-Tab `ReferenceError: t is not defined` → die Felder erscheinen nie. Damit schlagen `fa-10-website.spec.ts` T5 + T6 fehl, und „E2E PR" (Required Check) ist rot — auf **jedem** PR (auch auf #1651).

**Ursache:** PR #1624 (i18n DE/EN, commit `205d96ac`, 2026-06-13) ersetzte in `ContactForm.svelte` die Strings durch `t(locale,…)` / `getTypes(locale)` — **ohne** `import { t }`, **ohne** `locale`-Prop, und `getTypes` existiert nirgends. `astro build` macht keinen `astro check`, daher überlebte der Dangling-Identifier bis in den Client-Bundle und wirft erst zur Hydration. (Root-Cause via 4-Agenten-Untersuchung, live reproduziert.)

## Fix
- `ContactForm.svelte`: `import { t, type Locale }`, `locale`-Prop (default `'de'`), `getTypes(locale)` → `typeOptions` (Submission-Values stabil, Labels via i18n).
- `ContactHub.svelte`: `locale`-Prop, an `<ContactForm {locale} />` durchgereicht.
- `kontakt.astro`: `locale = (Astro.locals.locale ?? getLocaleFromUrl(Astro.url))` → ContactHub (deckt auch `/en/kontakt`, das `kontakt.astro` re-rendert).
- **Regressionstest** `ContactForm.i18n.test.ts`: server-rendert die Komponente (de+en) — vor dem Fix ReferenceError, jetzt grün.

## Verifikation (lokal)
- `pnpm vitest run` ✅ 871 passed · `astro build` ✅ · `task freshness:check` ✅
- ContactForm 165 Z., ContactHub 319 Z., kontakt.astro 149 Z. (alle unter S1-Limits)

## ⚠️ Henne-Ei beim Mergen
„E2E PR" testet die **Live-Produktion**, nicht den PR-Build. Live wird erst nach dem **Deploy** (= Merge → `build-website*.yml`) repariert. Daher kann dieser Fix-PR sein eigenes E2E-Gate **nicht** vor dem Merge grün bekommen → Merge braucht **Admin-Override** (oder E2E temporär entrequiren). Nach Merge: prüfen, dass das neue `:latest`-Image wirklich landet (Digest-Pin-Stale-Footgun), dann E2E auf #1651 erneut laufen lassen → grün.

Empfohlene Reihenfolge: **diesen Fix admin-mergen → deployen → Live T5/T6 grün → dann mergt #1651 normal.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)