### PR TITLE
fix(website): Coaching-Migration FK-Name korrigieren (sessions_ki_config_id_fkey) [T000711]

### DIFF
--- a/docs/generated/api-map.json
+++ b/docs/generated/api-map.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-14T17:31:45.458Z",
+  "generatedAt": "2026-06-14T17:41:08.898Z",
   "endpoints": [
     {
       "path": "/api/admin/angebote/save",

--- a/docs/generated/api-surface.md
+++ b/docs/generated/api-surface.md
@@ -1,6 +1,6 @@
 # API Surface Map
 
-> Generated at 2026-06-14T17:31:45.458Z
+> Generated at 2026-06-14T17:41:08.898Z
 
 | Path | Methods | Auth | File |
 |------|---------|------|------|

--- a/docs/generated/blast-radius.md
+++ b/docs/generated/blast-radius.md
@@ -1,5 +1,5 @@
 # Blast-Radius-Report
-> Generated: 2026-06-14T17:31:45.559Z
+> Generated: 2026-06-14T17:41:08.935Z
 > Nodes: 74 | Edges: 1385 | Isolated: 2
 
 ## Ranking (transitive Abhängige)

--- a/docs/generated/graph.json
+++ b/docs/generated/graph.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-14T17:31:45.371Z",
+  "generatedAt": "2026-06-14T17:41:08.833Z",
   "nodes": [
     {
       "id": "admin-actions-cleanup",

--- a/k3d/docs-content-built/architecture/index.html
+++ b/k3d/docs-content-built/architecture/index.html
@@ -178,7 +178,7 @@
 <body>
   <div class="header">
     <h1>⬡ Architektur — Living Docs</h1>
-    <span class="meta">Generiert: 2026-06-14T17:31:45.506Z</span>
+    <span class="meta">Generiert: 2026-06-14T17:41:07.130Z</span>
   </div>
 
   <div class="stats">

--- a/scripts/migrations/2026-06-14-coaching-data-migrate.sql
+++ b/scripts/migrations/2026-06-14-coaching-data-migrate.sql
@@ -37,13 +37,19 @@ JOIN tickets.provider_config p
   ON p.source = 'coaching' AND p.brand = k.brand AND p.provider = k.provider
 ON CONFLICT (old_id) DO NOTHING;
 
--- 3) FK lösen (falls vorhanden) und Sessions remappen (overlap-sicher idempotent:
+-- 3) Alte FK (-> coaching.ki_config) lösen. Postgres-Default-Name = <table>_<col>_fkey =
+--    sessions_ki_config_id_fkey. Dann Sessions remappen (overlap-sicher idempotent:
 --    bereits auf eine new_id zeigende Sessions werden übersprungen).
-ALTER TABLE coaching.sessions DROP CONSTRAINT IF EXISTS coaching_sessions_ki_config_id_fkey;
+ALTER TABLE coaching.sessions DROP CONSTRAINT IF EXISTS sessions_ki_config_id_fkey;
 UPDATE coaching.sessions s
 SET ki_config_id = m.new_id
 FROM coaching.ki_config_id_map m
 WHERE s.ki_config_id = m.old_id
   AND NOT EXISTS (SELECT 1 FROM coaching.ki_config_id_map m2 WHERE m2.new_id = s.ki_config_id);
+
+-- 4) FK neu auf den vereinheitlichten Store setzen (gleicher Name, gleiches ON DELETE SET NULL).
+ALTER TABLE coaching.sessions
+  ADD CONSTRAINT sessions_ki_config_id_fkey
+  FOREIGN KEY (ki_config_id) REFERENCES tickets.provider_config(id) ON DELETE SET NULL;
 
 COMMIT;

--- a/website/src/lib/schema/coaching-migrate.test.ts
+++ b/website/src/lib/schema/coaching-migrate.test.ts
@@ -17,7 +17,12 @@ async function setup(): Promise<Pool> {
       frequency_penalty NUMERIC, safe_prompt BOOLEAN, random_seed INT,
       organization_id TEXT, eu_endpoint BOOLEAN, enabled_fields JSONB
     );
-    CREATE TABLE coaching.sessions (id SERIAL PRIMARY KEY, ki_config_id INT);
+    CREATE TABLE coaching.sessions (
+      id SERIAL PRIMARY KEY,
+      ki_config_id INT,
+      CONSTRAINT sessions_ki_config_id_fkey FOREIGN KEY (ki_config_id)
+        REFERENCES coaching.ki_config(id) ON DELETE SET NULL
+    );
     INSERT INTO coaching.ki_config (brand,provider,is_active,model_name,display_name,api_key,temperature)
       VALUES ('mentolder','claude',true,'claude-haiku','Claude','sk-1',0.4),
              ('mentolder','openai',false,NULL,'GPT',NULL,NULL);

--- a/website/src/lib/schema/coaching-migrate.ts
+++ b/website/src/lib/schema/coaching-migrate.ts
@@ -49,8 +49,9 @@ export async function migrateCoachingKiConfig(c: PoolClient): Promise<{ migrated
     );
   }
 
-  // FK auf das alte coaching.ki_config lösen (falls vorhanden), dann Sessions remappen.
-  await c.query(`ALTER TABLE coaching.sessions DROP CONSTRAINT IF EXISTS coaching_sessions_ki_config_id_fkey`);
+  // Alte FK (-> coaching.ki_config) lösen. Postgres-Default-Name ist <table>_<col>_fkey
+  // = sessions_ki_config_id_fkey (NICHT coaching_sessions_…). Dann Sessions remappen.
+  await c.query(`ALTER TABLE coaching.sessions DROP CONSTRAINT IF EXISTS sessions_ki_config_id_fkey`);
 
   const { rows: maps } = await c.query(`SELECT old_id, new_id FROM coaching.ki_config_id_map`);
   const oldToNew = new Map<number, number>(maps.map((m: Record<string, unknown>) => [Number(m.old_id), Number(m.new_id)]));
@@ -67,6 +68,13 @@ export async function migrateCoachingKiConfig(c: PoolClient): Promise<{ migrated
       remapped++;
     }
   }
+
+  // FK neu auf den vereinheitlichten Store setzen (gleicher Name, gleiches ON DELETE SET NULL).
+  // Idempotent: der DROP oben entfernt sie vor dem erneuten Anlegen.
+  await c.query(
+    `ALTER TABLE coaching.sessions ADD CONSTRAINT sessions_ki_config_id_fkey
+       FOREIGN KEY (ki_config_id) REFERENCES tickets.provider_config(id) ON DELETE SET NULL`,
+  );
 
   return { migrated, remapped };
 }


### PR DESCRIPTION
## Latenter Bug in der Coaching-Daten-Migration (T000711-Nachzügler)
Die echte FK auf `coaching.sessions.ki_config_id` heißt **`sessions_ki_config_id_fkey`** (Postgres-Default `<table>_<col>_fkey`), nicht `coaching_sessions_ki_config_id_fkey`. Der `DROP CONSTRAINT IF EXISTS coaching_sessions_…` griff daher **nicht** → auf einer frischen Brand wäre die alte FK (→ `coaching.ki_config`) bestehen geblieben und der Remap (`ki_config_id` → `provider_config.id`) hätte sie **verletzt** → Migration failt. Der pg-mem-Test hatte keine FK, daher unentdeckt.

## Fix
- `schema/coaching-migrate.ts` + `2026-06-14-coaching-data-migrate.sql`: korrekter `DROP CONSTRAINT IF EXISTS sessions_ki_config_id_fkey`; nach dem Remap **FK neu** auf `tickets.provider_config(id) ON DELETE SET NULL` (gleicher Name, idempotent).
- `coaching-migrate.test.ts`: `coaching.sessions` mit der echten benannten FK angelegt → reproduziert das Prod-Schema (pg-mem erzwingt FK), hätte den Bug gefangen. 3/3 grün.

## Prod-Status (bereits erledigt)
Die Migration lief **mit der korrigierten Variante** bereits live auf beiden Brands:
- **mentolder**: 9 Coaching-Provider → `provider_config`, 36 Sessions remappt (0 verwaist), FK → `provider_config`.
- **korczewski**: 8 Provider, 0 Sessions, FK → `provider_config`.
Diese PR bringt nur die **Repo-Dateien** in Einklang (für frische Brands / Re-Runs).

## Verifikation
`pnpm vitest run` (coaching-migrate 3/3) · `task freshness:check` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)