### PR TITLE
chore(coaching): DeepSeek als Standard-Provider aktivieren + UI-Fix

### DIFF
--- a/scripts/migrations/2026-06-14-coaching-deepseek-seed.sql
+++ b/scripts/migrations/2026-06-14-coaching-deepseek-seed.sql
@@ -1,4 +1,4 @@
--- Seed DeepSeek als Coaching-Provider für beide Brands (idempotent)
+-- Seed DeepSeek als Standard-Coaching-Provider für beide Brands (idempotent)
 -- Führe aus: kubectl exec -n workspace <shared-db-pod> -- psql -U website website -f /tmp/migration.sql
 -- UND: kubectl exec -n workspace-korczewski <shared-db-pod> -- psql -U website website -f /tmp/migration.sql
 
@@ -6,6 +6,7 @@ DO $$
 DECLARE
   next_priority INTEGER;
 BEGIN
+  -- mentolder: DeepSeek einfügen falls nicht vorhanden
   IF NOT EXISTS (SELECT 1 FROM tickets.provider_config WHERE source = 'coaching' AND brand = 'mentolder' AND provider = 'deepseek') THEN
     SELECT COALESCE(MAX(priority), 0) + 1 INTO next_priority
       FROM tickets.provider_config WHERE source = 'coaching' AND tier = 'coaching';
@@ -17,6 +18,16 @@ BEGIN
     RAISE NOTICE 'deepseek coaching provider existiert bereits für mentolder';
   END IF;
 
+  -- mentolder: DeepSeek als einzigen aktiven Provider setzen
+  UPDATE tickets.provider_config
+    SET is_active = false
+    WHERE source = 'coaching' AND brand = 'mentolder' AND provider <> 'deepseek';
+  UPDATE tickets.provider_config
+    SET is_active = true
+    WHERE source = 'coaching' AND brand = 'mentolder' AND provider = 'deepseek';
+  RAISE NOTICE 'deepseek als aktiver Coaching-Provider für mentolder gesetzt';
+
+  -- korczewski: DeepSeek einfügen falls nicht vorhanden
   IF NOT EXISTS (SELECT 1 FROM tickets.provider_config WHERE source = 'coaching' AND brand = 'korczewski' AND provider = 'deepseek') THEN
     SELECT COALESCE(MAX(priority), 0) + 1 INTO next_priority
       FROM tickets.provider_config WHERE source = 'coaching' AND tier = 'coaching';
@@ -27,4 +38,13 @@ BEGIN
   ELSE
     RAISE NOTICE 'deepseek coaching provider existiert bereits für korczewski';
   END IF;
+
+  -- korczewski: DeepSeek als einzigen aktiven Provider setzen
+  UPDATE tickets.provider_config
+    SET is_active = false
+    WHERE source = 'coaching' AND brand = 'korczewski' AND provider <> 'deepseek';
+  UPDATE tickets.provider_config
+    SET is_active = true
+    WHERE source = 'coaching' AND brand = 'korczewski' AND provider = 'deepseek';
+  RAISE NOTICE 'deepseek als aktiver Coaching-Provider für korczewski gesetzt';
 END $$;

--- a/website/src/components/admin/coaching/CoachingSettings.svelte
+++ b/website/src/components/admin/coaching/CoachingSettings.svelte
@@ -450,6 +450,8 @@
             <div class="provider-model">{p.modelName ?? 'kein Modell'}</div>
             {#if p.apiKey}
               <div class="provider-key">API-Key gesetzt ✓</div>
+            {:else if p.provider === 'deepseek' || p.provider === 'anthropic'}
+              <div class="provider-key">ENV-Key konfiguriert ✓</div>
             {:else if p.provider !== 'lumo'}
               <div class="provider-key warn">kein API-Key</div>
             {/if}
@@ -550,10 +552,12 @@
   .btn-activate { padding: 0.4rem 0.8rem; background: var(--gold,#c9a55c); color: #111; border: none; border-radius: 4px; cursor: pointer; font-weight: 600; font-size: 0.82rem; }
   .btn-activate:disabled { opacity: 0.5; cursor: not-allowed; }
   .provider-badge { font-size: 0.7rem; font-weight: 700; padding: 0.15rem 0.5rem; border-radius: 99px; letter-spacing: 0.03em; }
-  .provider-badge.openai  { background: #16a34a22; color: #4ade80; border: 1px solid #16a34a44; }
-  .provider-badge.mistral { background: #ea580c22; color: #fb923c; border: 1px solid #ea580c44; }
-  .provider-badge.lumo    { background: #0891b222; color: #38bdf8; border: 1px solid #0891b244; }
-  .provider-badge.custom  { background: #52525b22; color: #a1a1aa; border: 1px solid #52525b44; }
+  .provider-badge.openai    { background: #16a34a22; color: #4ade80; border: 1px solid #16a34a44; }
+  .provider-badge.mistral   { background: #ea580c22; color: #fb923c; border: 1px solid #ea580c44; }
+  .provider-badge.lumo      { background: #0891b222; color: #38bdf8; border: 1px solid #0891b244; }
+  .provider-badge.deepseek  { background: #1d4ed822; color: #60a5fa; border: 1px solid #1d4ed844; }
+  .provider-badge.anthropic { background: #7c3aed22; color: #c084fc; border: 1px solid #7c3aed44; }
+  .provider-badge.custom    { background: #52525b22; color: #a1a1aa; border: 1px solid #52525b44; }
   .edit-panel { border: 1px solid var(--gold,#c9a55c); border-radius: 10px; background: var(--bg-2,#1a1a1a); padding: 1.5rem; display: flex; flex-direction: column; gap: 1.25rem; }
   .edit-panel-header { display: flex; align-items: center; justify-content: space-between; gap: 1rem; }
   .edit-title { display: flex; align-items: center; gap: 0.75rem; font-weight: 700; color: var(--text-light,#f0f0f0); }


### PR DESCRIPTION
## Summary

- **Seed-SQL**: DeepSeek wird als `is_active=true` gesetzt; alle anderen Coaching-Provider werden deaktiviert — DeepSeek ist jetzt Standard
- **CoachingSettings**: CSS-Badge für `deepseek` (blau) und `anthropic` (lila) ergänzt
- **CoachingSettings**: Zeigt „ENV-Key konfiguriert ✓" für deepseek/anthropic statt falscher Warnung „kein API-Key" (der `DEEPSEEK_API_KEY` wird bereits im Backend via ENV aufgelöst)

## Test plan

- [ ] Seed-SQL auf Dev-DB anwenden und prüfen, dass DeepSeek `is_active=true` ist
- [ ] `/admin/coaching/settings` öffnen → DeepSeek-Karte mit blauem Badge + `● Aktiv` + „ENV-Key konfiguriert ✓"
- [ ] Coaching-Session starten → DeepSeek antwortet korrekt

🤖 Generated with [Claude Code](https://claude.com/claude-code)