### PR TITLE
chore(ki-routing): configurable api keys + model routing updates

### DIFF
--- a/docs/generated/api-map.json
+++ b/docs/generated/api-map.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-14T22:09:06.471Z",
+  "generatedAt": "2026-06-14T22:21:51.931Z",
   "endpoints": [
     {
       "path": "/api/admin/angebote/save",

--- a/docs/generated/api-surface.md
+++ b/docs/generated/api-surface.md
@@ -1,6 +1,6 @@
 # API Surface Map
 
-> Generated at 2026-06-14T22:09:06.471Z
+> Generated at 2026-06-14T22:21:51.931Z
 
 | Path | Methods | Auth | File |
 |------|---------|------|------|

--- a/docs/generated/blast-radius.md
+++ b/docs/generated/blast-radius.md
@@ -1,5 +1,5 @@
 # Blast-Radius-Report
-> Generated: 2026-06-14T22:09:06.571Z
+> Generated: 2026-06-14T22:21:51.903Z
 > Nodes: 74 | Edges: 1385 | Isolated: 2
 
 ## Ranking (transitive Abhängige)

--- a/docs/generated/graph.json
+++ b/docs/generated/graph.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-14T22:09:06.386Z",
+  "generatedAt": "2026-06-14T22:21:51.859Z",
   "nodes": [
     {
       "id": "admin-actions-cleanup",

--- a/k3d/docs-content-built/architecture/index.html
+++ b/k3d/docs-content-built/architecture/index.html
@@ -178,7 +178,7 @@
 <body>
   <div class="header">
     <h1>⬡ Architektur — Living Docs</h1>
-    <span class="meta">Generiert: 2026-06-14T22:09:06.518Z</span>
+    <span class="meta">Generiert: 2026-06-14T22:21:49.932Z</span>
   </div>
 
   <div class="stats">

--- a/website/src/components/admin/KiKonfiguration.svelte
+++ b/website/src/components/admin/KiKonfiguration.svelte
@@ -6,6 +6,7 @@
     id: number; source: string; tier: 'sonnet' | 'haiku'; priority: number;
     provider: string; model_id: string; base_url: string | null;
     max_concurrent: number; enabled: boolean;
+    api_key_hint: string | null;
   }
   interface Health {
     provider: string; cooldown_until: string | null; active_agents: number;
@@ -46,7 +47,7 @@
   let form = $state(blankForm());
 
   function blankForm(source = '', tier: 'sonnet' | 'haiku' = 'sonnet') {
-    return { source, tier, priority: 1, provider: '', model_id: '', base_url: '', max_concurrent: 3, enabled: true };
+    return { source, tier, priority: 1, provider: '', model_id: '', base_url: '', max_concurrent: 3, enabled: true, api_key: '' };
   }
 
   // When a GPU-worker / cluster provider is chosen and base_url is still empty,
@@ -120,7 +121,7 @@
 
   function startEdit(e: ProviderEntry) {
     editId = e.id;
-    form = { source: e.source, tier: e.tier, priority: e.priority, provider: e.provider, model_id: e.model_id, base_url: e.base_url ?? '', max_concurrent: e.max_concurrent, enabled: e.enabled };
+    form = { source: e.source, tier: e.tier, priority: e.priority, provider: e.provider, model_id: e.model_id, base_url: e.base_url ?? '', max_concurrent: e.max_concurrent, enabled: e.enabled, api_key: '' };
   }
   function startNew() {
     editId = -1;
@@ -129,7 +130,13 @@
   }
 
   async function saveForm() {
-    const payload = { ...form, base_url: form.base_url.trim() || null };
+    const payload: Record<string, unknown> = { ...form, base_url: form.base_url.trim() || null };
+    // On edit: empty api_key = keep existing (omit from payload). On create: empty = no key (null).
+    if (editId !== -1 && !form.api_key.trim()) {
+      delete payload.api_key;
+    } else {
+      payload.api_key = form.api_key.trim() || null;
+    }
     const isNew = editId === -1;
     const res = await fetch(isNew ? '/api/admin/ki/providers' : `/api/admin/ki/providers/${editId}`, {
       method: isNew ? 'POST' : 'PUT',
@@ -275,7 +282,7 @@
                   {e.priority}
                   <button onclick={() => changePriority(e, 1)} aria-label="niedriger">↓</button>
                 </span>
-                <span class="who">{e.provider} · {e.model_id} · {e.tier}</span>
+                <span class="who">{e.provider} · {e.model_id} · {e.tier}{e.api_key_hint ? ' 🔑' : ''}</span>
                 <span class="badge {inCooldown(e.provider) ? 'cooldown' : e.enabled ? 'live' : 'off'}">
                   &#9679; {inCooldown(e.provider) ? 'cooldown' : e.enabled ? 'live' : 'off'}
                 </span>
@@ -321,6 +328,14 @@
       <input placeholder="model_id" bind:value={form.model_id} />
     {/if}
     <input placeholder="base_url (optional)" bind:value={form.base_url} />
+    {#if editId !== -1}
+      {@const hint = entries.find((e) => e.id === editId)?.api_key_hint}
+      <input type="password" autocomplete="new-password"
+        placeholder={hint ? `Key gesetzt (${hint}) — leer lassen = unverändert` : 'API-Key setzen (optional)'}
+        bind:value={form.api_key} />
+    {:else}
+      <input type="password" autocomplete="new-password" placeholder="API-Key (optional)" bind:value={form.api_key} />
+    {/if}
     <select bind:value={form.tier}><option value="sonnet">sonnet</option><option value="haiku">haiku</option></select>
     <input placeholder="source" bind:value={form.source} />
     <input type="number" min="1" placeholder="max_concurrent" bind:value={form.max_concurrent} />

--- a/website/src/lib/ki-config-db.ts
+++ b/website/src/lib/ki-config-db.ts
@@ -19,6 +19,8 @@ export interface ProviderConfigEntry {
   max_concurrent: number;
   enabled: boolean;
   updated_at: string | null;
+  /** Masked key shown in admin UI (e.g. "sk-...abcd"). Null when no key stored. */
+  api_key_hint: string | null;
 }
 
 export interface ProviderHealth {
@@ -38,10 +40,11 @@ export interface NewProvider {
   base_url: string | null;
   max_concurrent: number;
   enabled: boolean;
+  api_key?: string | null;
 }
 
 const COLS =
-  'id, source, tier, priority, provider, model_id, base_url, max_concurrent, enabled, updated_at';
+  'id, source, tier, priority, provider, model_id, base_url, max_concurrent, enabled, updated_at, api_key';
 
 export async function listProviders(): Promise<ProviderConfigEntry[]> {
   // Coaching-Rows (source='coaching') leben im selben Store, werden aber über die
@@ -87,16 +90,16 @@ export async function countEnabledForSource(
 export async function createProvider(p: NewProvider): Promise<number> {
   const { rows } = await pool.query(
     `INSERT INTO tickets.provider_config
-       (source, tier, priority, provider, model_id, base_url, max_concurrent, enabled, updated_at)
-     VALUES ($1,$2,$3,$4,$5,$6,$7,$8, now())
+       (source, tier, priority, provider, model_id, base_url, max_concurrent, enabled, api_key, updated_at)
+     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9, now())
      RETURNING id`,
-    [p.source, p.tier, p.priority, p.provider, p.model_id, p.base_url, p.max_concurrent, p.enabled],
+    [p.source, p.tier, p.priority, p.provider, p.model_id, p.base_url, p.max_concurrent, p.enabled, p.api_key ?? null],
   );
   return Number(rows[0].id);
 }
 
 const UPDATABLE = [
-  'source', 'tier', 'priority', 'provider', 'model_id', 'base_url', 'max_concurrent', 'enabled',
+  'source', 'tier', 'priority', 'provider', 'model_id', 'base_url', 'max_concurrent', 'enabled', 'api_key',
 ] as const;
 type Updatable = (typeof UPDATABLE)[number];
 
@@ -136,6 +139,11 @@ export async function getProvider(id: number): Promise<ProviderConfigEntry | nul
   return rows.length ? mapRow(rows[0]) : null;
 }
 
+function maskKey(key: unknown): string | null {
+  if (typeof key !== 'string' || !key) return null;
+  return key.length <= 8 ? '••••••••' : `••••••••${key.slice(-4)}`;
+}
+
 function mapRow(r: Record<string, unknown>): ProviderConfigEntry {
   return {
     id: Number(r.id),
@@ -148,5 +156,6 @@ function mapRow(r: Record<string, unknown>): ProviderConfigEntry {
     max_concurrent: Number(r.max_concurrent),
     enabled: Boolean(r.enabled),
     updated_at: r.updated_at ? new Date(r.updated_at as string).toISOString() : null,
+    api_key_hint: maskKey(r.api_key),
   };
 }

--- a/website/src/lib/provider-config.ts
+++ b/website/src/lib/provider-config.ts
@@ -26,7 +26,7 @@ export async function getProviderConfig(source: string, tier: 'sonnet' | 'haiku'
   }
   try {
     const { rows } = await pool.query(
-      `SELECT pc.provider, pc.model_id, pc.base_url
+      `SELECT pc.provider, pc.model_id, pc.base_url, pc.api_key
          FROM tickets.provider_config pc
          LEFT JOIN tickets.provider_health ph ON ph.provider = pc.provider
         WHERE (pc.source = $1 OR pc.source = '*') AND pc.tier = $2 AND pc.enabled = true
@@ -36,8 +36,9 @@ export async function getProviderConfig(source: string, tier: 'sonnet' | 'haiku'
       [source, tier],
     );
     if (rows.length) {
-      const { provider, model_id, base_url } = rows[0];
-      return { provider, modelId: model_id, baseUrl: base_url ?? null, apiKey: apiKeyForProvider(provider) };
+      const { provider, model_id, base_url, api_key } = rows[0];
+      const apiKey = (typeof api_key === 'string' && api_key) ? api_key : apiKeyForProvider(provider);
+      return { provider, modelId: model_id, baseUrl: base_url ?? null, apiKey };
     }
   } catch (err) {
     console.error('[provider-config] DB lookup failed, falling back to anthropic:', err);

--- a/website/src/lib/tickets-db.providerrouting.test.ts
+++ b/website/src/lib/tickets-db.providerrouting.test.ts
@@ -16,6 +16,7 @@ vi.mock('pg', () => {
       provider       TEXT NOT NULL,
       model_id       TEXT NOT NULL,
       base_url       TEXT,
+      api_key        TEXT,
       max_concurrent INTEGER NOT NULL DEFAULT 3,
       enabled        BOOLEAN NOT NULL DEFAULT true,
       updated_at     TIMESTAMPTZ NOT NULL DEFAULT now(),

--- a/website/src/pages/api/admin/ki/providers.ts
+++ b/website/src/pages/api/admin/ki/providers.ts
@@ -31,12 +31,14 @@ function parseNew(body: Record<string, unknown>): { error: string } | { value: N
   const baseUrlRaw = typeof body.base_url === 'string' ? body.base_url.trim() : '';
   const max_concurrent = body.max_concurrent == null ? 3 : Number(body.max_concurrent);
   if (!Number.isInteger(max_concurrent) || max_concurrent < 1) return { error: 'max_concurrent muss >= 1 sein' };
+  const apiKeyRaw = typeof body.api_key === 'string' ? body.api_key.trim() : '';
   return {
     value: {
       source, tier: body.tier as Tier, priority, provider, model_id,
       base_url: baseUrlRaw || null,
       max_concurrent,
       enabled: body.enabled === undefined ? true : Boolean(body.enabled),
+      api_key: apiKeyRaw || null,
     },
   };
 }

--- a/website/src/pages/api/admin/ki/providers/[id].ts
+++ b/website/src/pages/api/admin/ki/providers/[id].ts
@@ -17,7 +17,7 @@ async function guard(request: Request): Promise<Response | null> {
 }
 
 const TIERS: Tier[] = ['sonnet', 'haiku'];
-const PATCHABLE = ['source', 'tier', 'priority', 'provider', 'model_id', 'base_url', 'max_concurrent', 'enabled'];
+const PATCHABLE = ['source', 'tier', 'priority', 'provider', 'model_id', 'base_url', 'max_concurrent', 'enabled', 'api_key'];
 
 /** Whitelist + coerce an inbound PATCH body. Returns error string or a clean patch object. */
 function parsePatch(body: Record<string, unknown>): { error: string } | { patch: Record<string, unknown> } {
@@ -38,7 +38,8 @@ function parsePatch(body: Record<string, unknown>): { error: string } | { patch:
       patch[k] = n;
     } else if (k === 'enabled') {
       patch[k] = Boolean(v);
-    } else if (k === 'base_url') {
+    } else if (k === 'base_url' || k === 'api_key') {
+      // nullable string fields: empty string → clear to null
       const s = typeof v === 'string' ? v.trim() : '';
       patch[k] = s || null;
     } else {


### PR DESCRIPTION
## Summary

- **API-Key pro Row konfigurierbar**: `api_key`-Spalte wird jetzt von `getProviderConfig` gelesen — DB-Key schlägt ENV-Fallback
- **Admin-UI**: Passwort-Input im Drawer (leer = unverändert bei Edit), 🔑-Badge wenn Key gesetzt
- **Routing-Updates**: `ticket-triage` → `deepseek-v4-flash` (p10 Fallback) + `local-cluster/qwen3.6:35b` (p1); `assistant-chat` → `deepseek-v4-pro` (p10) + `local-cluster/qwen3.6:35b` (p1)
- **PK DeepSeek Key** in DB-Wildcard-Rows geschrieben (live, nicht in Git)

## Test plan

- [ ] Admin UI `/admin/ki-konfiguration` — Drawer zeigt 🔑 bei Rows mit gesetztem Key
- [ ] Neuer Key via UI setzen → Routing verwendet ihn statt ENV
- [ ] Leeres Key-Feld beim Bearbeiten → bestehender Key bleibt erhalten
- [ ] `ticket-triage` Requests → gehen an `local-cluster` (qwen3.6:35b), Fallback DeepSeek
- [ ] `assistant-chat` Requests → gehen an `local-cluster` (qwen3.6:35b), Fallback DeepSeek

🤖 Generated with [Claude Code](https://claude.com/claude-code)