### PR TITLE
feat: Spec-Generator — KI destilliert Grilling-Antworten in Specs (T000723)

### DIFF
--- a/.claude/skills/feature-intake/SKILL.md
+++ b/.claude/skills/feature-intake/SKILL.md
@@ -142,17 +142,103 @@ bash scripts/ticket.sh add-comment \
 - <frage>: <antwort>"
 ```
 
-#### 5b — Readiness-Flags aktualisieren
+#### 5b — Vollständigkeits-Check (Vorbedingung für Spec-Generierung)
+
+Prüfe den Rücklauf auf Vollständigkeit bevor die Spec generiert wird:
+
+| Block | Prüfung | BLOCK wenn |
+|-------|---------|------------|
+| Block 1 — Ablauf | Textarea-Länge | < 20 Zeichen |
+| Block 1 — Nutzergruppe | Feld vorhanden + nicht leer | Fehlt |
+| Block 2 — Nicht-Scope | ≥1 Checkbox ODER Freitext | Beides leer |
+| Block 3 — Edge Cases | ≥1 Checkbox ODER Freitext | Beides leer |
+| Block 5 — Fehlerfall | Radio ausgewählt | Nicht gesetzt |
+| Block 6 — Erfolgsmetrik | Radio ODER Freitext | Beides leer |
+
+**Bei unvollständigem Rücklauf:**
+
+Gib aus:
+```
+⛔ Spec-Generierung blockiert — folgende Blöcke fehlen oder sind leer:
+  • [Liste der fehlenden Blöcke]
+
+→ Bitte das Grilling-Formular erneut öffnen und die markierten Felder ausfüllen:
+  /tmp/grilling-<TICKET_EXT_ID>-<DATUM>.html
+```
+
+Stoppe hier — führe Schritt 5c NICHT aus.
+
+**Bei vollständigem Rücklauf:** Fahre direkt mit Schritt 5c fort.
+
+#### 5c — Spec-Datei generieren und schreiben
+
+Destilliere die Grilling-Antworten in eine vollständige Spec. Dateiname:
+
+```bash
+SPEC_SLUG=$(echo "<Ticket-Titel>" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | sed 's/^-\|-$//g')
+SPEC_FILE="docs/superpowers/specs/$(date +%F)-${SPEC_SLUG}.md"
+# Bei Kollision: SPEC_FILE mit -v2 Suffix
+```
+
+Schreibe die Datei mit dem `Write`-Tool nach folgendem Schema (auf Deutsch):
+
+```markdown
+---
+ticket_id: <TICKET_EXT_ID>
+plan_ref: docs/superpowers/plans/<DATUM>-<SPEC_SLUG>.md
+status: active
+date: <DATUM>
+---
+
+# Spec: <Ticket-Titel>
+
+## Kern-Nutzerflow
+[Prosa aus Block 1 — Schritt-für-Schritt destilliert]
+
+## Akzeptanzkriterien
+[Testbar formuliert aus Blocks 1/3/5/6 — z.B. "Wenn User X tut, erscheint Y"]
+
+## Edge Cases
+[Liste aus Block 3]
+
+## Fehlerfall-Behandlung
+[Aus Block 5]
+
+## Erfolgsmetrik
+[Aus Block 6 — messbar oder beobachtbar]
+
+## Technische Constraints
+[Aus Ticket-Areas + domain-spezifischen Blöcken + depends_on]
+
+## Betroffene Dateien
+[Aus areas abgeleitet — grobe Hinweise]
+```
+
+Danach den Spec-Inhalt auch als Ticket-Kommentar schreiben:
+
+```bash
+bash scripts/ticket.sh add-comment \
+  --id <TICKET_EXT_ID> \
+  --author "feature-intake/spec-generator" \
+  --body "## Auto-generierte Spec $(date +%F)
+
+[vollständiger Spec-Inhalt]
+
+---
+*Generiert aus Grilling-Rücklauf via feature-intake/spec-generator*"
+```
+
+#### 5d — Readiness-Flags aktualisieren
 
 Setze einen Flag auf `true` nur wenn die zugehörige Frage tatsächlich beantwortet wurde:
 
 ```bash
 bash scripts/ticket.sh plan-meta set \
   --id <external_id> \
-  --readiness offene_fragen_geklaert=true,abhaengigkeiten_klar=true
+  --readiness offene_fragen_geklaert=true,abhaengigkeiten_klar=true,spec_skizziert=true
 ```
 
-#### 5c — Abhängigkeiten eintragen (wenn konkrete IDs genannt)
+#### 5e — Abhängigkeiten eintragen (wenn konkrete IDs genannt)
 
 ```bash
 bash scripts/ticket.sh plan-meta set \
@@ -160,9 +246,39 @@ bash scripts/ticket.sh plan-meta set \
   --depends-on T000571,T000573
 ```
 
-#### 5d — Status-Report ausgeben
+#### 5f — Automatischer Handoff zu dev-flow-plan
 
-Kurze Zusammenfassung: welche Tickets sind jetzt vollständig readiness-ready (alle 4 Flags true), welche bleiben offen. Tickets mit allen Flags auf `true` → proaktiv vorschlagen: „T000xxx ist plan-ready → `dev-flow-plan` starten?"
+Nach vollständiger Spec-Generierung übergib direkt an dev-flow-plan — kein STOP, kein manueller Eingriff:
+
+```bash
+export TICKET_EXT_ID="<TICKET_EXT_ID>"
+# dev-flow-plan erkennt TICKET_EXT_ID und überspringt Ticket-Erstellung
+```
+
+Sage: "Spec generiert ✓ — übergebe direkt an dev-flow-plan für die Implementierungsplanung."
+
+Rufe dann `dev-flow-plan` auf.
+
+#### 5g — Abschluss-Report
+
+Gib folgende Zusammenfassung aus:
+
+```
+Grilling + Spec-Generierung abgeschlossen für <TICKET_EXT_ID>:
+
+✓ Spec-Material als Kommentar hinterlegt (author: feature-intake/grilling)
+✓ Auto-Spec generiert: docs/superpowers/specs/<dateiname>
+✓ Spec als Ticket-Kommentar hinterlegt (author: feature-intake/spec-generator)
+✓ Readiness-Flags aktualisiert: spec_skizziert=true, offene_fragen_geklaert=true, abhaengigkeiten_klar=true
+✓ Handoff zu dev-flow-plan eingeleitet
+
+[nur wenn noch Flags fehlen:]
+Verbleibende offene Flags:
+  🔴 abhaengigkeiten_klar — noch ausstehend
+  🔴 aufwand_geschaetzt — noch ausstehend
+```
+
+Zeige welche Tickets jetzt vollständig readiness-ready sind (alle 4 Flags true).
 
 ---
 

--- a/docs/superpowers/plans/2026-06-14-spec-generator.md
+++ b/docs/superpowers/plans/2026-06-14-spec-generator.md
@@ -1,0 +1,267 @@
+---
+ticket_id: T000723
+spec_ref: docs/superpowers/specs/2026-06-14-spec-generator.md
+status: active
+date: 2026-06-14
+domains: [skills, scripts]
+file_locks: []
+shared_changes: false
+batch_id: null
+parent_feature: null
+depends_on_plans: []
+---
+
+# Plan: Spec-Generator — KI destilliert Grilling-Antworten in vollständige Feature-Spec
+
+## Ziel
+
+Nach vollständig ausgefülltem Grilling-Rücklauf (Modus E, Schritt 5) generiert der Skill automatisch eine vollständige Spec-Datei, schreibt einen Ticket-Kommentar, setzt das Readiness-Flag `spec_skizziert=true` und übergibt an `dev-flow-plan` — ohne manuellen Stop.
+
+## Architektur
+
+Einzige Änderung: Erweiterung von `.claude/skills/feature-intake/SKILL.md`. Der bisherige Schritt 5 (Rücklauf verarbeiten) wird um einen neuen **Schritt 5b** (Spec-Generator) ergänzt, der direkt nach Schritt 5a (Spec-Kommentar ins Ticket schreiben) eingehängt wird.
+
+```
+Modus E — Schritt 5 (Rücklauf verarbeiten)
+  ├── 5a: Spec-Material als Kommentar ins Ticket  [BESTEHT BEREITS]
+  ├── 5b: Vollständigkeits-Check                  [NEU]
+  ├── 5c: Spec-Datei generieren + schreiben       [NEU]  ← war bisher Schritt 5b (Abschluss-Report)
+  ├── 5d: Readiness-Flag spec_skizziert=true      [NEU]
+  ├── 5e: Handoff zu dev-flow-plan (kein STOP)    [NEU]
+  └── 5f: Abschluss-Report (angepasst)            [ANGEPASST]
+```
+
+Bestehende Schritte 5b (Readiness-Flags) und 5c (Abschluss-Report) werden umbenannt/angepasst um Nummernkollision zu vermeiden.
+
+## S1-Budget-Analyse
+
+| Datei | Typ | S1-Limit | Baseline | Status |
+|-------|-----|----------|----------|--------|
+| `.claude/skills/feature-intake/SKILL.md` | Markdown | **kein Limit** | nicht baselined | ✅ Unbegrenzt |
+
+Markdown-Dateien (`.md`) sind von den S1-Gates ausgenommen — nur `.ts`, `.js`, `.svelte` etc. unterliegen Zeilenlimits aus `docs/code-quality/gates.yaml`. Die Erweiterung von feature-intake/SKILL.md hat kein Budget-Risiko.
+
+## Dateistruktur
+
+| Datei | Aktion | Begründung |
+|-------|--------|-----------|
+| `.claude/skills/feature-intake/SKILL.md` | Erweitern | Neue Schritte 5b–5e nach bestehendem 5a |
+| `docs/superpowers/specs/2026-06-14-spec-generator.md` | Erstellt | Diese Spec (bereits vorhanden) |
+| `docs/superpowers/plans/2026-06-14-spec-generator.md` | Erstellt | Dieser Plan (bereits vorhanden) |
+
+Keine weiteren Dateien werden erstellt oder modifiziert.
+
+## Tasks
+
+### Task 1: Vollständigkeits-Check-Logik definieren (SKILL.md-Erweiterung vorbereiten)
+
+**Ziel:** Klare, parsbare Vollständigkeits-Regeln als Inline-Logik in SKILL.md formulieren.
+
+**Prüfregeln (in Prosa für den Skill-Agenten):**
+
+```
+Vollständig wenn ALLE folgenden Bedingungen erfüllt:
+  • Block 1 Ablauf-Textarea: length > 20 Zeichen
+  • Block 1 Primäre Nutzergruppe: nicht leer, nicht "(nicht angegeben)"
+  • Block 2 Nicht-Scope: ≥1 Checkbox gesetzt ODER Freitext > 5 Zeichen
+  • Block 3 Edge Cases: ≥1 Checkbox gesetzt ODER Freitext > 5 Zeichen
+  • Block 5 Fehlerfall-Radio: nicht leer
+  • Block 6 Erfolgsmetrik: Radio gesetzt ODER Freitext > 5 Zeichen
+
+Optional (kein BLOCK wenn fehlend):
+  • Block 4 Mobile
+  • Domain-spezifische Blöcke
+```
+
+**Bei unvollständig:** Fehlende Blöcke auflisten + Formular-Verweis + kein Weiterfahren.
+
+### Task 2: Neuen Schritt 5b (Vollständigkeits-Check) in SKILL.md einfügen
+
+**Position:** In Modus E, nach dem bestehenden Abschnitt `#### 5a — Spec-Kommentar ins Ticket schreiben`.
+
+**Inhalt des neuen Abschnitts:**
+
+```markdown
+#### 5b — Vollständigkeits-Check (Vorbedingung für Spec-Generierung)
+
+Prüfe den Rücklauf auf Vollständigkeit bevor die Spec generiert wird:
+
+| Block | Prüfung | BLOCK wenn |
+|-------|---------|------------|
+| Block 1 — Ablauf | Textarea-Länge | < 20 Zeichen |
+| Block 1 — Nutzergruppe | Feld vorhanden + nicht leer | Fehlt |
+| Block 2 — Nicht-Scope | ≥1 Checkbox ODER Freitext | Beides leer |
+| Block 3 — Edge Cases | ≥1 Checkbox ODER Freitext | Beides leer |
+| Block 5 — Fehlerfall | Radio ausgewählt | Nicht gesetzt |
+| Block 6 — Erfolgsmetrik | Radio ODER Freitext | Beides leer |
+
+**Bei unvollständigem Rücklauf:**
+
+Gib aus:
+```
+⛔ Spec-Generierung blockiert — folgende Blöcke fehlen oder sind leer:
+  • [Liste der fehlenden Blöcke]
+
+→ Bitte das Grilling-Formular erneut öffnen und die markierten Felder ausfüllen:
+  /tmp/grilling-<TICKET_EXT_ID>-<DATUM>.html
+```
+
+Stoppe hier — führe Schritt 5c NICHT aus.
+
+**Bei vollständigem Rücklauf:** Fahre direkt mit Schritt 5c fort.
+```
+
+### Task 3: Neuen Schritt 5c (Spec-Datei generieren + schreiben) in SKILL.md einfügen
+
+**Position:** Nach dem neuen Schritt 5b.
+
+**Inhalt des neuen Abschnitts:**
+
+```markdown
+#### 5c — Spec-Datei generieren und schreiben
+
+Destilliere die Grilling-Antworten in eine vollständige Spec. Dateiname:
+
+```bash
+SPEC_SLUG=$(echo "<Ticket-Titel>" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | sed 's/^-\|-$//g')
+SPEC_FILE="docs/superpowers/specs/$(date +%F)-${SPEC_SLUG}.md"
+# Bei Kollision: SPEC_FILE mit -v2 Suffix
+```
+
+Schreibe die Datei mit dem `Write`-Tool nach folgendem Schema (auf Deutsch):
+
+```markdown
+---
+ticket_id: <TICKET_EXT_ID>
+plan_ref: docs/superpowers/plans/<DATUM>-<SPEC_SLUG>.md
+status: active
+date: <DATUM>
+---
+
+# Spec: <Ticket-Titel>
+
+## Kern-Nutzerflow
+[Prosa aus Block 1 — Schritt-für-Schritt destilliert]
+
+## Akzeptanzkriterien
+[Testbar formuliert aus Blocks 1/3/5/6 — z.B. "Wenn User X tut, erscheint Y"]
+
+## Edge Cases
+[Liste aus Block 3]
+
+## Fehlerfall-Behandlung
+[Aus Block 5]
+
+## Erfolgsmetrik
+[Aus Block 6 — messbar oder beobachtbar]
+
+## Technische Constraints
+[Aus Ticket-Areas + domain-spezifischen Blöcken + depends_on]
+
+## Betroffene Dateien
+[Aus areas abgeleitet — grobe Hinweise]
+```
+
+Danach den Spec-Inhalt auch als Ticket-Kommentar schreiben:
+
+```bash
+bash scripts/ticket.sh add-comment \
+  --id <TICKET_EXT_ID> \
+  --author "feature-intake/spec-generator" \
+  --body "## Auto-generierte Spec $(date +%F)
+
+[vollständiger Spec-Inhalt]
+
+---
+*Generiert aus Grilling-Rücklauf via feature-intake/spec-generator*"
+```
+```
+
+### Task 4: Bestehenden Schritt 5b (Readiness-Flags) zu 5d umbenennen + spec_skizziert=true ergänzen
+
+**Änderung:** Bisheriger `#### 5b — Readiness-Flags aktualisieren` wird zu `#### 5d — Readiness-Flags aktualisieren`. Zusätzlich `spec_skizziert=true` nach erfolgreicher Spec-Generierung setzen:
+
+```bash
+bash scripts/ticket.sh plan-meta set \
+  --id <TICKET_EXT_ID> \
+  --readiness spec_skizziert=true
+```
+
+Der bestehende Code für `offene_fragen_geklaert=true` und `aufwand_geschaetzt=true` bleibt erhalten.
+
+### Task 5: Neuen Schritt 5e (Automatischer Handoff zu dev-flow-plan) einfügen
+
+**Position:** Nach 5d (Readiness-Flags), vor dem Abschluss-Report.
+
+**Inhalt:**
+
+```markdown
+#### 5e — Automatischer Handoff zu dev-flow-plan
+
+Nach vollständiger Spec-Generierung übergib direkt an dev-flow-plan — kein STOP, kein manueller Eingriff:
+
+```bash
+export TICKET_EXT_ID="<TICKET_EXT_ID>"
+# dev-flow-plan erkennt TICKET_EXT_ID und überspringt Ticket-Erstellung
+```
+
+Sage: "Spec generiert ✓ — übergebe direkt an dev-flow-plan für die Implementierungsplanung."
+
+Rufe dann `dev-flow-plan` auf.
+```
+
+### Task 6: Abschluss-Report (bisheriger Schritt 5c) zu 5f umbenennen und anpassen
+
+**Änderung:** Der Abschluss-Report zeigt jetzt auch die generierte Spec-Datei:
+
+```
+Grilling + Spec-Generierung abgeschlossen für <TICKET_EXT_ID>:
+
+✓ Spec-Material als Kommentar hinterlegt (author: feature-intake/grilling)
+✓ Auto-Spec generiert: docs/superpowers/specs/<dateiname>
+✓ Spec als Ticket-Kommentar hinterlegt (author: feature-intake/spec-generator)
+✓ Readiness-Flags aktualisiert: spec_skizziert=true, offene_fragen_geklaert=true
+✓ Handoff zu dev-flow-plan eingeleitet
+
+[nur wenn noch Flags fehlen:]
+Verbleibende offene Flags:
+  🔴 abhaengigkeiten_klar — noch ausstehend
+  🔴 aufwand_geschaetzt — noch ausstehend
+```
+
+### Task 7: Verifikation
+
+```bash
+# Offline-Tests + Freshness-Check
+task test:all
+task freshness:regenerate
+task freshness:check
+```
+
+Manuelle Verifikation:
+- feature-intake/SKILL.md manuell lesen: Schritte 5a–5f sind korrekt nummeriert und vollständig
+- Spec-Format-Check: Alle 6 Abschnitte im Spec-Template vorhanden
+- Vollständigkeits-Tabelle: Alle 6 Pflicht-Blöcke aufgeführt
+- Handoff-Sektion: Export von TICKET_EXT_ID und dev-flow-plan Aufruf vorhanden
+
+## Implementierungs-Reihenfolge
+
+```
+Task 2 (5b Vollständigkeits-Check einfügen)
+  → Task 3 (5c Spec-Datei generieren einfügen)
+  → Task 4 (5b→5d Readiness umbenennen + spec_skizziert)
+  → Task 5 (5e Handoff einfügen)
+  → Task 6 (5c→5f Abschluss-Report anpassen)
+  → Task 7 (Verifikation: task test:all + freshness)
+```
+
+Alle Tasks sind reine SKILL.md-Edits — sequenziell, eine Datei, keine Parallelisierung nötig.
+
+## Risiken & Guardrails
+
+| Risiko | Mitigation |
+|--------|-----------|
+| Bestehende Schrittsnummern kollisionieren | Umbenennung von 5b→5d und 5c→5f explizit dokumentiert |
+| Grilling-Rücklauf-Format ändert sich | Vollständigkeits-Check ist format-tolerant (sucht `### Block N —` Header) |
+| dev-flow-plan ignoriert TICKET_EXT_ID | Bestehende Übergabe-Logik in feature-intake schon vorhanden (siehe Ende von Modus A/B) |
+| spec_skizziert=true überschreibt vorhandenes Flag | Idempotent — flag kann beliebig oft auf true gesetzt werden |

--- a/docs/superpowers/specs/2026-06-14-spec-generator.md
+++ b/docs/superpowers/specs/2026-06-14-spec-generator.md
@@ -1,0 +1,165 @@
+---
+ticket_id: T000723
+plan_ref: docs/superpowers/plans/2026-06-14-spec-generator.md
+status: active
+date: 2026-06-14
+---
+
+# Spec: Spec-Generator — KI destilliert Grilling-Antworten in vollständige Feature-Spec
+
+## Kontext: Ist-Zustand
+
+Nach einem abgeschlossenen Feature-Grilling (Modus E in `feature-intake/SKILL.md`) liegen die Antworten als strukturiertes Markdown in einem Ticket-Kommentar vor. Danach muss Patrick manuell eine Spec-Datei erstellen und `dev-flow-plan` starten. Dieser manuelle Eingriff unterbricht den Fluss und erzeugt Reibung.
+
+**Betroffener Flow:**
+1. Modus E (Grilling) → HTML-Formular → Rücklauf → Kommentar ins Ticket (Schritt 5a)
+2. **[Manuelle Lücke]** Patrick schreibt Spec, öffnet dev-flow-plan
+3. dev-flow-plan liest Ticket + Spec → Brainstorming → Implementierungsplan
+
+## Was dieses Feature ändert
+
+Nach vollständig ausgefülltem Grilling-Rücklauf (Schritt 5a, alle Pflicht-Blöcke befüllt) führt der Skill automatisch folgende Schritte aus:
+
+1. Vollständigkeits-Check: alle 6 Pflicht-Blöcke müssen nicht-leer sein
+2. Spec-Generierung aus den Grilling-Antworten (kein weiterer User-Input nötig)
+3. Spec als Datei in `docs/superpowers/specs/` schreiben
+4. Spec-Inhalt als Ticket-Kommentar hinterlegen (author: `feature-intake/spec-generator`)
+5. Readiness-Flag `spec_skizziert=true` setzen
+6. Automatischer Handoff zu `dev-flow-plan` ohne STOP
+
+## Kern-Nutzerflow
+
+```
+Grilling-Rücklauf kommt zurück (Markdown mit Blöcken 1–6)
+  │
+  ▼
+Vollständigkeits-Check
+  ├── Alle 6 Blöcke befüllt? → JA → weiter
+  └── Nein → BLOCK: Fehlende Blöcke auflisteen, Formular erneut zeigen
+  │
+  ▼
+Spec-Text generieren (KI-destillation aus Grilling-Antworten)
+  │
+  ▼
+Datei schreiben: docs/superpowers/specs/<DATUM>-<ticket-slug>.md
+  │
+  ▼
+Ticket-Kommentar: scripts/ticket.sh add-comment --author "feature-intake/spec-generator"
+  │
+  ▼
+Readiness-Flag: spec_skizziert=true (via ticket.sh plan-meta set)
+  │
+  ▼
+Handoff: dev-flow-plan aufrufen mit TICKET_EXT_ID (kein STOP)
+```
+
+## Vollständigkeits-Check-Logik
+
+Ein Grilling gilt als **vollständig**, wenn alle folgenden Bedingungen erfüllt sind:
+
+| Block | Pflicht-Feld | Gilt als befüllt wenn |
+|-------|-------------|----------------------|
+| Block 1 | Kern-Nutzerflow (Ablauf-Textarea) | Länge > 20 Zeichen |
+| Block 1 | Primäre Nutzergruppe | Nicht leer / nicht „(nicht angegeben)" |
+| Block 2 | Nicht-Scope | Mindestens eine Checkbox ODER Freitext > 5 Zeichen |
+| Block 3 | Edge Cases | Mindestens eine Checkbox ODER Freitext > 5 Zeichen |
+| Block 5 | Fehlerfall-Radio | Nicht leer |
+| Block 6 | Erfolgsmetrik | Radio oder Freitext > 5 Zeichen |
+
+**Block 4 (Mobile)** und domain-spezifische Blöcke sind optional — fehlen sie, wird kein BLOCK ausgelöst.
+
+Bei unvollständigem Grilling:
+
+```
+⛔ Spec-Generierung blockiert — folgende Blöcke fehlen oder sind leer:
+  • Block 1 — Kern-Nutzerflow: Ablauf-Feld ist leer
+  • Block 6 — Erfolgsmetrik: weder Radio noch Freitext ausgefüllt
+
+→ Bitte das Grilling-Formular erneut aufrufen und die markierten Felder ausfüllen.
+  (Grilling-Formular: /tmp/grilling-<TICKET_EXT_ID>-<DATUM>.html)
+```
+
+## Spec-Inhalt (Ausgabeformat)
+
+Die generierte Spec enthält folgende Abschnitte auf Deutsch:
+
+```markdown
+---
+ticket_id: <TICKET_EXT_ID>
+plan_ref: docs/superpowers/plans/<DATUM>-<slug>.md
+status: active
+date: <DATUM>
+---
+
+# Spec: <Ticket-Titel>
+
+## Kern-Nutzerflow
+[Destilliert aus Block 1 — Schritt-für-Schritt, in Prosaform]
+
+## Akzeptanzkriterien
+[Testbar formuliert, abgeleitet aus Blocks 1/3/5/6 — Beispiel:
+- Wenn User X tut, erscheint Y innerhalb Z Sekunden
+- Bei Fehlerfall zeigt System Fehlermeldung mit Retry-Option
+- Feature ist auf Android-Chrome vollständig nutzbar (falls Mobile=Ja)]
+
+## Edge Cases
+[Liste aus Block 3 — je ein Satz was passiert]
+
+## Fehlerfall-Behandlung
+[Aus Block 5 — konkretes Verhalten bei Fehlern]
+
+## Erfolgsmetrik
+[Aus Block 6 — messbar oder beobachtbar]
+
+## Technische Constraints
+[Aus Ticket-Feldern + domain-spezifischen Blöcken:
+- Betroffene Areas: <areas>
+- Mobile: <Block 4 Ergebnis>
+- Brand-Scope: <falls website/infra block vorhanden>
+- Abhängigkeiten: <depends_on aus Ticket>]
+
+## Betroffene Dateien
+[Aus areas abgeleitet — grobe Hinweise für dev-flow-plan]
+```
+
+**Kein Nicht-Scope-Block** (explizit ausgenommen per Grilling-Entscheidung). Kein Wireframes-/Mockups-Block. Keine Migrations-SQL. Kein adversarialer KI-Review.
+
+## Akzeptanzkriterien
+
+- **AK-1:** Nach vollständigem Grilling-Rücklauf (alle 6 Pflicht-Blöcke befüllt) wird automatisch eine Spec-Datei unter `docs/superpowers/specs/<DATUM>-<slug>.md` erzeugt — ohne weiteren User-Input.
+- **AK-2:** Die Spec enthält alle 6 Abschnitte (Kern-Nutzerflow, Akzeptanzkriterien, Edge Cases, Fehlerfall-Behandlung, Erfolgsmetrik, Technische Constraints) und ist auf Deutsch verfasst.
+- **AK-3:** Alle Akzeptanzkriterien in der Spec sind testbar formuliert (kein „sollte besser sein", sondern „wenn X passiert, zeigt System Y").
+- **AK-4:** Der Ticket-Kommentar wird via `scripts/ticket.sh add-comment --author "feature-intake/spec-generator"` geschrieben und ist im Ticket sichtbar.
+- **AK-5:** Das Readiness-Flag `spec_skizziert=true` wird nach erfolgreicher Spec-Generierung gesetzt.
+- **AK-6:** Der Handoff zu `dev-flow-plan` erfolgt automatisch mit der Ticket-ID — kein STOP, kein manueller Eingriff von Patrick.
+- **AK-7:** Bei unvollständigem Grilling (mindestens ein Pflicht-Block leer) wird die Spec-Generierung GEBLOCKT und die fehlenden Blöcke werden mit Formular-Verweis aufgelistet.
+- **AK-8:** Der gesamte Durchgang Grilling → Spec → Plan-Start läuft in einem einzigen Skill-Aufruf ohne Unterbrechung.
+
+## Edge Cases
+
+- **Leere Textarea im Pflicht-Block:** → BLOCK mit klarem Hinweis, welcher Block fehlt
+- **Nur Checkboxen, keine Freitexte:** → gilt als befüllt (Checkboxen reichen)
+- **Grilling-Rücklauf fehlt Block-Header:** → Parser erkennt Blöcke an `### Block N —` Prefix; fehlt ein Header → Block als fehlend werten
+- **Domain-spezifischer Block fehlt:** → Kein Fehler; Technische Constraints werden ohne diesen Block generiert
+- **Ticket hat keine `areas`:** → Betroffene Dateien-Abschnitt wird weggelassen
+- **Spec-Datei existiert bereits (Datum+Slug Kollision):** → Suffix `-v2` anhängen
+
+## Technische Constraints
+
+- Implementierung ausschließlich als neue Sektion in `.claude/skills/feature-intake/SKILL.md` (nach Schritt 5a in Modus E)
+- Kein neues Backend, kein neues Skript — nur SKILL.md-Erweiterung
+- `scripts/ticket.sh add-comment` für Ticket-Kommentar (bestehender Befehl)
+- `scripts/ticket.sh plan-meta set --readiness spec_skizziert=true` für Flag-Update
+- Spec-Datei wird mit dem `Write`-Tool in `docs/superpowers/specs/` geschrieben
+- Dateiname-Konvention: `<DATUM>-<ticket-slug>.md` wobei slug = Ticket-Titel lowercased, Leerzeichen → Bindestriche, Sonderzeichen entfernt
+- Handoff zu dev-flow-plan via `export TICKET_EXT_ID` + Skill-Aufruf (wie in bestehender Übergabe-Sektion in feature-intake/SKILL.md)
+- Spec auf Deutsch (Abschnittsnamen auf Deutsch, Inhalt auf Deutsch)
+- Markdown-Dateien unterliegen keinem S1-Zeilenlimit (nur .ts/.js/.svelte etc.)
+
+## Betroffene Dateien
+
+| Datei | Änderung |
+|-------|---------|
+| `.claude/skills/feature-intake/SKILL.md` | Neuer Schritt 5b (Spec-Generator) nach bisherigem Schritt 5a — Vollständigkeits-Check + Spec-Generierung + Datei schreiben + Kommentar + Flag + Handoff |
+
+Alle anderen Dateien bleiben unverändert.


### PR DESCRIPTION
## Summary

Erweitert Modus C (Planungsbüro-Klärung) in feature-intake/SKILL.md um einen automatischen Spec-Generator. Nach vollständig ausgefülltem Grilling-Rücklauf destilliert die KI die Antworten automatisch in eine vollständige Spec-Datei und übergibt an dev-flow-plan — ohne manuellen Stop.

## Changes

- **5b (NEU):** Vollständigkeits-Check — prüft alle 6 Pflicht-Blöcke vor Spec-Generierung
- **5c (NEU):** Spec-Datei generieren aus Grilling-Antworten + Ticket-Kommentar
- **5d (ANGEPASST):** Readiness-Flags inkl. `spec_skizziert=true`
- **5e (UMBENANNT):** Abhängigkeiten eintragen (ehemals 5c)
- **5f (NEU):** Automatischer Handoff zu dev-flow-plan
- **5g (ANGEPASST):** Abschluss-Report mit Spec-Status

Closes T000723