### PR TITLE
fix(dev-status): slotCap persistent + KpiGrid responsive breakpoint

### DIFF
--- a/website/src/components/factory/FactoryKpiGrid.svelte
+++ b/website/src/components/factory/FactoryKpiGrid.svelte
@@ -126,6 +126,11 @@
     0%, 100% { opacity: 1; }
     50% { opacity: 0.5; }
   }
+  @media (max-width: 900px) {
+    .kpi-grid {
+      grid-template-columns: repeat(3, 1fr);
+    }
+  }
   @media (max-width: 640px) {
     .kpi-grid {
       grid-template-columns: repeat(2, 1fr);

--- a/website/src/pages/api/admin/factory-control.ts
+++ b/website/src/pages/api/admin/factory-control.ts
@@ -25,15 +25,15 @@ async function readControl(key: string, fallback: string): Promise<{ value: stri
 }
 
 async function getControlState(): Promise<ControlState> {
-  const [kill, dry, slotCapEnv, daily, dailyCapRow] = await Promise.all([
+  const envSlotCap = process.env.FACTORY_GLOBAL_CAP ?? '4';
+  const [kill, dry, daily, slotCapDb] = await Promise.all([
     readControl('killswitch', 'off'),
     readControl('dry-run', 'off'),
-    Promise.resolve(process.env.FACTORY_GLOBAL_CAP ?? '4'),
     readControl('daily-cap', '20'),
-    readControl('killswitch', 'off'),
+    readControl('slot-cap', envSlotCap),
   ]);
 
-  const latestUpdate = [kill.updated_at, dry.updated_at, daily.updated_at]
+  const latestUpdate = [kill.updated_at, dry.updated_at, daily.updated_at, slotCapDb.updated_at]
     .filter(Boolean)
     .sort()
     .pop() ?? null;
@@ -41,7 +41,7 @@ async function getControlState(): Promise<ControlState> {
   return {
     killSwitch: kill.value === 'on',
     dryRun: dry.value === 'on',
-    slotCap: parseInt(slotCapEnv, 10) || 4,
+    slotCap: parseInt(slotCapDb.value, 10) || parseInt(envSlotCap, 10) || 4,
     dailyCap: parseInt(daily.value, 10) || 20,
     updatedAt: latestUpdate,
   };


### PR DESCRIPTION
## Summary

- **Control Panel Tab (slotCap bug)**: `factory-control GET` hat `slotCap` immer aus der Env-Variable `FACTORY_GLOBAL_CAP` gelesen, obwohl `PATCH` die Änderung in die DB schreibt. Nach dem Speichern im UI revertierte der Wert sofort zum Env-Wert. Fix: GET liest jetzt `slot-cap` aus der DB, mit Env als Fallback.
- **Control Panel Tab (dead code)**: `dailyCapRow` hat fälschlicherweise nochmal `killswitch` gelesen (Copy-Paste-Fehler). Variable wurde nicht verwendet. Entfernt.
- **Analytics Tab (KpiGrid)**: `FactoryKpiGrid` hatte keine Breakpoint-Stufe zwischen 5-col (≥641px) und 2-col (≤640px). Auf Tablets/mittleren Screens waren 5 KPI-Karten zu eng. Neuer Breakpoint: 3-col bei ≤900px.

## Test plan

- [ ] Control Panel > SlotCap stepper ändert Wert → nach Reload bleibt der neue Wert erhalten
- [ ] Analytics Tab > KPI Grid auf 768px viewport: 3 Spalten sichtbar (nicht 5, nicht 2)
- [ ] Alle 5 Tabs im dev-status laden ohne Fehler

🤖 Generated with [Claude Code](https://claude.com/claude-code)