### PR TITLE
fix(ci): kustomize bereits auf Runner vorhanden — vor Install entfernen

### DIFF
--- a/.github/workflows/build-website.yml
+++ b/.github/workflows/build-website.yml
@@ -111,6 +111,7 @@ jobs:
         run: |
           curl -sSL "https://dl.k8s.io/release/v1.31.0/bin/linux/amd64/kubectl" \
             -o /usr/local/bin/kubectl && chmod +x /usr/local/bin/kubectl
+          rm -f /usr/local/bin/kustomize
           curl -sSL "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" \
             | bash -s -- 5.4.3 /usr/local/bin
           mkdir -p ~/.kube


### PR DESCRIPTION
## Summary

- `build-website.yml` Deploy-Step scheiterte seit mehreren Builds mit `/usr/local/bin/kustomize exists. Remove it first.`
- Der GitHub Actions Runner hat kustomize bereits vorinstalliert; das offizielle Install-Script verweigert in diesem Fall die Installation
- Fix: `rm -f /usr/local/bin/kustomize` vor dem Install-Script

## Test plan

- [ ] `Build & Deploy Website (mentolder)` läuft durch
- [ ] Website-Image wird gebaut und gepusht
- [ ] Rollout auf den Fleet-Cluster erfolgt erfolgreich

🤖 Generated with [Claude Code](https://claude.com/claude-code)