### PR TITLE
feat(cockpit): P1 Foundation — Rollup-View, cockpit-db, Contract-Typen [T000749]

### DIFF
--- a/docs/code-quality/baseline.json
+++ b/docs/code-quality/baseline.json
@@ -149,8 +149,8 @@
   "S1:website/src/lib/tickets-db.ts": {
     "gate": "S1",
     "path": "website/src/lib/tickets-db.ts",
-    "metric": 1094,
-    "detail": "1094 lines > 600 limit (.ts)",
+    "metric": 1096,
+    "detail": "1096 lines > 600 limit (.ts)",
     "frozen_at": "6190a4e5"
   },
   "S1:website/src/lib/tickets/admin.ts": {

--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -444,7 +444,7 @@
       "id": "scripts-db",
       "name": "Database scripts (migrations + datamodel)",
       "owner_agent": "bachelorprojekt-db",
-      "file_count": 31,
+      "file_count": 32,
       "files": [
         "scripts/datamodel/2026-05-23-audit-phase5-add-fk-indexes-korczewski.sql",
         "scripts/datamodel/2026-05-23-audit-phase5-add-fk-indexes-mentolder.sql",
@@ -476,6 +476,7 @@
         "scripts/migrations/2026-06-14-factory-run-budget.sql",
         "scripts/migrations/2026-06-14-llm-availability-seed.sql",
         "scripts/migrations/2026-06-14-provider-config-unify.sql",
+        "scripts/migrations/2026-06-15-cockpit-rollup-view.sql",
         "scripts/migrations/2026-06-15-grilling-answers.sql"
       ]
     },
@@ -483,7 +484,7 @@
       "id": "website",
       "name": "Astro + Svelte website",
       "owner_agent": "bachelorprojekt-website",
-      "file_count": 1340,
+      "file_count": 1345,
       "files": [
         "website/.build-trigger",
         "website/.dockerignore",
@@ -1257,6 +1258,11 @@
         "website/src/lib/tickets-embed.test.ts",
         "website/src/lib/tickets-embed.ts",
         "website/src/lib/tickets/admin.ts",
+        "website/src/lib/tickets/cockpit-db.test.ts",
+        "website/src/lib/tickets/cockpit-db.ts",
+        "website/src/lib/tickets/cockpit-schema.test.ts",
+        "website/src/lib/tickets/cockpit-schema.ts",
+        "website/src/lib/tickets/cockpit-types.ts",
         "website/src/lib/tickets/email-templates.ts",
         "website/src/lib/tickets/grilling.ts",
         "website/src/lib/tickets/reporter-link.ts",

--- a/docs/superpowers/plans/2026-06-15-cockpit-foundation.md
+++ b/docs/superpowers/plans/2026-06-15-cockpit-foundation.md
@@ -830,7 +830,7 @@ git add -A && git commit -m "chore(cockpit): stage A quality gate" || echo "noth
 This sub-plan merges independently — it must be green on its own.
 
 - [x] Scoped unit tests: `cd website && pnpm test -- "cockpit-schema|cockpit-db"`
-- [ ] `task test:all` → exit 0
-- [ ] `task freshness:regenerate` then `task freshness:check` → exit 0 (S1–S4 ratchet incl. `tickets-db.ts` ≤ 1106, `admin.ts` = 677)
+- [x] `task test:all` → exit 0
+- [x] `task freshness:regenerate` then `task freshness:check` → exit 0 (S1–S4 ratchet incl. `tickets-db.ts` ≤ 1106, `admin.ts` = 677)
 - [x] If test files were added: `task test:inventory` + commit `website/src/data/test-inventory.json`
 - [x] Confirm only this sub-plan's `file_locks` files changed

--- a/docs/superpowers/plans/2026-06-15-cockpit-foundation.md
+++ b/docs/superpowers/plans/2026-06-15-cockpit-foundation.md
@@ -53,7 +53,7 @@ Ships the data layer first: the recursive view, its dated migration, the contrac
 
 > **Why a separate module (S1):** `tickets-db.ts` is **baselined at 1106**, current **1094** → only **12 lines headroom**. The ~55-line view appended inline would push it past 1106 → **S1 ratchet FAIL**. So the DDL lives in a new module and `tickets-db.ts` only gains the import + a one-line call.
 
-- [ ] **Step 1: Write the failing test (asserts the exported SQL constant)**
+- [x] **Step 1: Write the failing test (asserts the exported SQL constant)**
 
 Create `website/src/lib/tickets/cockpit-schema.test.ts`:
 
@@ -89,12 +89,12 @@ describe('COCKPIT_ROLLUP_VIEW_SQL', () => {
 });
 ```
 
-- [ ] **Step 2: Run it and verify it fails**
+- [x] **Step 2: Run it and verify it fails**
 
 Run: `cd website && pnpm test -- cockpit-schema.test.ts`
 Expected: FAIL — the module/constant does not exist yet.
 
-- [ ] **Step 3: Implement `cockpit-schema.ts` (correct SQL, no placeholder)**
+- [x] **Step 3: Implement `cockpit-schema.ts` (correct SQL, no placeholder)**
 
 Create `website/src/lib/tickets/cockpit-schema.ts` — the view DDL as an exported constant (single source of truth, reused verbatim by the Task 2 migration):
 
@@ -164,7 +164,7 @@ export async function ensureCockpitViews(pool: import('pg').Pool): Promise<void>
 
 > The `LEFT JOIN agg a ON a.container_id = c.id` sits **before** the `WHERE` (valid SQL order) so the final `SELECT`'s `a.*` columns resolve. No placeholder, no `.replace()` trap. This DDL string is the single source of truth — Task 2's migration mirrors it verbatim.
 
-- [ ] **Step 4: Wire into the schema bootstrap (≤ 2 net lines; keep tickets-db.ts ≤ 1106)**
+- [x] **Step 4: Wire into the schema bootstrap (≤ 2 net lines; keep tickets-db.ts ≤ 1106)**
 
 In `website/src/lib/tickets-db.ts`: add the import next to the other `tickets/*` imports, and call it inside `initTicketsSchema()` right after the `v_active_features` block:
 
@@ -176,12 +176,12 @@ await ensureCockpitViews(pool);
 
 Verify: `wc -l website/src/lib/tickets-db.ts` → **≤ 1106** (baseline; expect ~1096).
 
-- [ ] **Step 5: Run the test and verify it passes**
+- [x] **Step 5: Run the test and verify it passes**
 
 Run: `cd website && pnpm test -- cockpit-schema.test.ts`
 Expected: PASS (all four cases green).
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add website/src/lib/tickets/cockpit-schema.ts website/src/lib/tickets/cockpit-schema.test.ts website/src/lib/tickets-db.ts
@@ -195,7 +195,7 @@ git commit -m "feat(cockpit): v_cockpit_rollup in cockpit-schema module (S1-safe
 **Files:**
 - Create: `scripts/migrations/2026-06-15-cockpit-rollup-view.sql`
 
-- [ ] **Step 1: Write the migration file**
+- [x] **Step 1: Write the migration file**
 
 Create `scripts/migrations/2026-06-15-cockpit-rollup-view.sql` with the **verbatim** body of `COCKPIT_ROLLUP_VIEW_SQL` (from `website/src/lib/tickets/cockpit-schema.ts`, Task 1) — single source of truth, mirrored here for explicit prod application:
 
@@ -251,12 +251,12 @@ LEFT JOIN agg a ON a.container_id = c.id
 WHERE c.type IN ('project', 'feature');
 ```
 
-- [ ] **Step 2: Verify the file exists and the SQL is well-formed**
+- [x] **Step 2: Verify the file exists and the SQL is well-formed**
 
 Run: `ls -la scripts/migrations/2026-06-15-cockpit-rollup-view.sql && head -5 scripts/migrations/2026-06-15-cockpit-rollup-view.sql`
 Expected: file present; comment header reads "Cockpit Rollup View".
 
-- [ ] **Step 3: Commit**
+- [x] **Step 3: Commit**
 
 ```bash
 git add scripts/migrations/2026-06-15-cockpit-rollup-view.sql

--- a/docs/superpowers/plans/2026-06-15-cockpit-foundation.md
+++ b/docs/superpowers/plans/2026-06-15-cockpit-foundation.md
@@ -278,7 +278,7 @@ git commit -m "feat(cockpit): dated migration for v_cockpit_rollup (both brand D
 **Files:**
 - Create: `website/src/lib/tickets/cockpit-types.ts` (~120 lines; limit 600)
 
-- [ ] **Step 1: Write the type module (no runtime code)**
+- [x] **Step 1: Write the type module (no runtime code)**
 
 Create `website/src/lib/tickets/cockpit-types.ts`:
 
@@ -351,12 +351,12 @@ export interface BatchResult {
 }
 ```
 
-- [ ] **Step 2: Verify it type-checks**
+- [x] **Step 2: Verify it type-checks**
 
 Run: `cd website && pnpm exec tsc --noEmit -p tsconfig.json 2>&1 | grep cockpit-types || echo "OK no type errors in cockpit-types"`
 Expected: `OK no type errors in cockpit-types`.
 
-- [ ] **Step 3: Commit**
+- [x] **Step 3: Commit**
 
 ```bash
 git add website/src/lib/tickets/cockpit-types.ts

--- a/docs/superpowers/plans/2026-06-15-cockpit-foundation.md
+++ b/docs/superpowers/plans/2026-06-15-cockpit-foundation.md
@@ -1,0 +1,836 @@
+---
+title: "Projekt-Cockpit — P1 Foundation (Datenmodell, Rollup-View, cockpit-db)"
+ticket_id: T000749
+domains: [db, website, test]
+status: active
+pr_number: null
+file_locks: [website/src/lib/tickets/cockpit-schema.ts, website/src/lib/tickets/cockpit-types.ts, website/src/lib/tickets/cockpit-db.ts, website/src/lib/tickets-db.ts, scripts/migrations/2026-06-15-cockpit-rollup-view.sql]
+shared_changes: false
+batch_id: cockpit-2026-06-15
+parent_feature: projekt-cockpit
+depends_on_plans: []
+---
+
+# Projekt-Cockpit — P1 Foundation
+
+> **Batch:** `cockpit-2026-06-15` · Sub-Plan **1 von 4** · Master: `docs/superpowers/plans/2026-06-15-projekt-cockpit.md`
+> **Abhängigkeit:** keine — **dieser Plan muss ZUERST mergen.** Er definiert die Contract-Typen (`cockpit-types.ts`) und die Datenschicht (`cockpit-db.ts` + `v_cockpit_rollup`), auf denen P2 (API) und P3 (Frontend) aufbauen.
+
+**Goal:** Replace the flat `/admin/tickets` view with a brand-scoped, admin-gated **Projekt-Cockpit** that rolls up leaf-ticket progress per Feature/Produkt, offers two lenses (Überblick/Werkbank) and two modes (Karten/Tabelle), and supports inline / drawer / drag&drop / bulk editing — without growing the frozen `admin.ts` or `tickets.astro`.
+
+**Architecture:** A new recursive-CTE view `tickets.v_cockpit_rollup` aggregates leaf counts per container; a pure DB module `cockpit-db.ts` queries it and reuses existing mutation helpers; five thin API routes under `api/admin/cockpit/` expose portfolio/feature/reorder/reparent/batch; a Svelte island (`Cockpit.svelte` + sub-components) backed by a pure `cockpitStore.ts` renders the UI; `cockpit.astro` does SSR auth + brand guard; `/admin/tickets` redirects into the cockpit's Tabelle mode. Backend/contract ships first so each stage leaves an independently-green state.
+
+**Tech Stack:** Astro (SSR), Svelte islands, PostgreSQL 16 (recursive CTE views), Vitest (pg-mem with `vi.hoisted`), Playwright (`website` project), go-task quality gates (S1–S4 + freshness).
+
+---
+
+## Conventions used throughout this plan
+
+- **All paths absolute** under the worktree root `/home/patrick/Bachelorprojekt/tmp/wt-projekt-cockpit/`. Commands assume `cd /home/patrick/Bachelorprojekt/tmp/wt-projekt-cockpit` first; the `website/` subdir is the pnpm workspace.
+- **Brand guard (S3):** every endpoint resolves the brand via the established local const `const BRAND = (): string => process.env.BRAND_ID ?? process.env.BRAND ?? 'mentolder';` and passes `BRAND()` into every query. **No `*.mentolder.de` / `*.korczewski.de` literals anywhere.** This matches `website/src/pages/api/admin/tickets/[id].ts`.
+- **Auth guard:** `const session = await getSession(request.headers.get('cookie')); if (!session || !isAdmin(session)) return new Response(null, { status: 403 });` — `isAdmin` lives in `website/src/lib/auth.ts`.
+- **S1 budgets (verified against `docs/code-quality/baseline.json` + `wc -l`):**
+  - `website/src/lib/tickets/admin.ts` — Ist 677, **Baseline 677 → Budget 0. DO NOT TOUCH.** No cockpit logic here.
+  - `website/src/pages/admin/tickets.astro` — Ist 359, **nicht-baselined → wirksame Schwelle = 400 (Astro), Budget 41.** Only a redirect change is allowed.
+  - `website/src/lib/tickets-db.ts` — Ist **1094**, **baselined at 1106** (`S1:website/src/lib/tickets-db.ts`) → headroom **12 lines**. The ~55-line rollup view must therefore **NOT** be appended inline (1094 + 55 ≈ 1149 > 1106 → **S1 ratchet FAIL**). Instead the view DDL lives in a new module `tickets/cockpit-schema.ts`; `tickets-db.ts` gains only an import + a one-line `await ensureCockpitViews(pool)` call (→ ≤ 1096 ≤ 1106 ✓). Never hand-edit baseline.json.
+  - All **new** `.ts` files: limit 600. New `.svelte`: limit 500. New `.astro`: limit 400. Plan keeps every new file with growth reserve under its limit; split into sub-components if any approaches ~80 %.
+- **S2:** `cockpit-db.ts` imports only `pool`/`ensureSchemaOnce` from `website-db.ts` and existing helpers from `admin.ts` (type-only where possible) — **no imports from API routes or UI**. `cockpitStore.ts` imports nothing from DB/API/UI — pure store.
+- **pg-mem DML tests** must mock the pool with `vi.hoisted(() => …)` before the test body (pattern: `website/src/pages/api/admin/ki/providers.test.ts`).
+- **Migration (S4):** `scripts/migrations/2026-06-15-cockpit-rollup-view.sql` mirrors the bootstrap view verbatim and is referenced both by the bootstrap (`tickets-db.ts`) and operationally applied to **both** brand DBs.
+
+---
+
+## Stage A — Datenmodell, Rollup-View & cockpit-db.ts (backend foundation)
+
+Ships the data layer first: the recursive view, its dated migration, the contract types, and the pure query/mutation module with tests. After Stage A, `cockpit-db.ts` is independently green and the API stages can build against a stable contract.
+
+### Task 1: Define `tickets.v_cockpit_rollup` in a new schema module (S1-safe)
+
+**Files:**
+- Create: `website/src/lib/tickets/cockpit-schema.ts` (new module: exports `COCKPIT_ROLLUP_VIEW_SQL` + `ensureCockpitViews(pool)`; ~70 lines · limit 600)
+- Modify: `website/src/lib/tickets-db.ts` — **import + one call only**; must stay **≤ 1106 lines** (baseline; Ist 1094 → ≤ 1096)
+- Test: `website/src/lib/tickets/cockpit-schema.test.ts` (new)
+
+> **Why a separate module (S1):** `tickets-db.ts` is **baselined at 1106**, current **1094** → only **12 lines headroom**. The ~55-line view appended inline would push it past 1106 → **S1 ratchet FAIL**. So the DDL lives in a new module and `tickets-db.ts` only gains the import + a one-line call.
+
+- [ ] **Step 1: Write the failing test (asserts the exported SQL constant)**
+
+Create `website/src/lib/tickets/cockpit-schema.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { COCKPIT_ROLLUP_VIEW_SQL } from './cockpit-schema';
+
+describe('COCKPIT_ROLLUP_VIEW_SQL', () => {
+  it('creates the rollup view idempotently', () => {
+    expect(COCKPIT_ROLLUP_VIEW_SQL).toContain('CREATE OR REPLACE VIEW tickets.v_cockpit_rollup');
+    expect(COCKPIT_ROLLUP_VIEW_SQL).toContain('WITH RECURSIVE');
+  });
+
+  it('aggregates all five leaf-count columns', () => {
+    for (const col of ['total_leaves','done_leaves','blocked_leaves','in_progress_leaves','open_leaves']) {
+      expect(COCKPIT_ROLLUP_VIEW_SQL).toContain(col);
+    }
+  });
+
+  it('computes pct_done and a three-branch health', () => {
+    expect(COCKPIT_ROLLUP_VIEW_SQL).toContain('pct_done');
+    expect(COCKPIT_ROLLUP_VIEW_SQL).toMatch(/blocked_leaves\s*>\s*0/);
+    expect(COCKPIT_ROLLUP_VIEW_SQL).toMatch(/pct_done\s*=\s*100/);
+    expect(COCKPIT_ROLLUP_VIEW_SQL).toContain("'amber'");
+  });
+
+  it('joins agg before WHERE (valid SQL order, no placeholder)', () => {
+    expect(COCKPIT_ROLLUP_VIEW_SQL).toContain('LEFT JOIN agg a ON a.container_id = c.id');
+    expect(COCKPIT_ROLLUP_VIEW_SQL).not.toContain('PLACEHOLDER');
+    expect(COCKPIT_ROLLUP_VIEW_SQL.indexOf('LEFT JOIN agg'))
+      .toBeLessThan(COCKPIT_ROLLUP_VIEW_SQL.indexOf("WHERE c.type IN ('project', 'feature')"));
+  });
+});
+```
+
+- [ ] **Step 2: Run it and verify it fails**
+
+Run: `cd website && pnpm test -- cockpit-schema.test.ts`
+Expected: FAIL — the module/constant does not exist yet.
+
+- [ ] **Step 3: Implement `cockpit-schema.ts` (correct SQL, no placeholder)**
+
+Create `website/src/lib/tickets/cockpit-schema.ts` — the view DDL as an exported constant (single source of truth, reused verbatim by the Task 2 migration):
+
+```typescript
+// v_cockpit_rollup — leaf-count rollup per container ticket (Produkt/Feature).
+// Recursive CTE walks the parent_id tree from every container down to its leaf
+// tickets (type 'task'|'bug' with NO children) and aggregates status counts.
+// Computed on read (no cache in MVP). Brand filtering is applied by callers,
+// not the view, so the view stays a simple per-container aggregate keyed by id.
+export const COCKPIT_ROLLUP_VIEW_SQL = `
+    CREATE OR REPLACE VIEW tickets.v_cockpit_rollup AS
+    WITH RECURSIVE descendants AS (
+      -- seed: every ticket is a descendant of itself (depth 0)
+      SELECT id AS container_id, id AS node_id, type, status
+      FROM tickets.tickets
+      UNION ALL
+      SELECT d.container_id, c.id AS node_id, c.type, c.status
+      FROM descendants d
+      JOIN tickets.tickets c ON c.parent_id = d.node_id
+    ),
+    leaves AS (
+      -- a leaf = task|bug with no children of its own
+      SELECT d.container_id, d.node_id, d.status
+      FROM descendants d
+      WHERE d.node_id <> d.container_id
+        AND d.type IN ('task', 'bug')
+        AND NOT EXISTS (
+          SELECT 1 FROM tickets.tickets ch WHERE ch.parent_id = d.node_id
+        )
+    ),
+    agg AS (
+      SELECT
+        container_id,
+        COUNT(*)::int AS total_leaves,
+        COUNT(*) FILTER (WHERE status = 'done')::int AS done_leaves,
+        COUNT(*) FILTER (WHERE status = 'blocked')::int AS blocked_leaves,
+        COUNT(*) FILTER (WHERE status IN ('in_progress', 'in_review'))::int AS in_progress_leaves,
+        COUNT(*) FILTER (WHERE status IN ('triage', 'backlog', 'planning', 'plan_staged'))::int AS open_leaves
+      FROM leaves
+      GROUP BY container_id
+    )
+    SELECT
+      c.id AS container_id,
+      COALESCE(a.total_leaves, 0)        AS total_leaves,
+      COALESCE(a.done_leaves, 0)         AS done_leaves,
+      COALESCE(a.blocked_leaves, 0)      AS blocked_leaves,
+      COALESCE(a.in_progress_leaves, 0)  AS in_progress_leaves,
+      COALESCE(a.open_leaves, 0)         AS open_leaves,
+      COALESCE(
+        ROUND(100.0 * a.done_leaves / NULLIF(a.total_leaves, 0))::int, 0
+      ) AS pct_done,
+      CASE
+        WHEN COALESCE(a.blocked_leaves, 0) > 0 THEN 'red'
+        WHEN COALESCE(a.total_leaves, 0) > 0
+             AND ROUND(100.0 * a.done_leaves / NULLIF(a.total_leaves, 0))::int = 100 THEN 'green'
+        ELSE 'amber'
+      END AS health
+    FROM tickets.tickets c
+    LEFT JOIN agg a ON a.container_id = c.id
+    WHERE c.type IN ('project', 'feature');
+`;
+
+export async function ensureCockpitViews(pool: import('pg').Pool): Promise<void> {
+  await pool.query(COCKPIT_ROLLUP_VIEW_SQL);
+}
+```
+
+> The `LEFT JOIN agg a ON a.container_id = c.id` sits **before** the `WHERE` (valid SQL order) so the final `SELECT`'s `a.*` columns resolve. No placeholder, no `.replace()` trap. This DDL string is the single source of truth — Task 2's migration mirrors it verbatim.
+
+- [ ] **Step 4: Wire into the schema bootstrap (≤ 2 net lines; keep tickets-db.ts ≤ 1106)**
+
+In `website/src/lib/tickets-db.ts`: add the import next to the other `tickets/*` imports, and call it inside `initTicketsSchema()` right after the `v_active_features` block:
+
+```typescript
+import { ensureCockpitViews } from './tickets/cockpit-schema';
+// …inside initTicketsSchema(), after the v_active_features CREATE OR REPLACE VIEW:
+await ensureCockpitViews(pool);
+```
+
+Verify: `wc -l website/src/lib/tickets-db.ts` → **≤ 1106** (baseline; expect ~1096).
+
+- [ ] **Step 5: Run the test and verify it passes**
+
+Run: `cd website && pnpm test -- cockpit-schema.test.ts`
+Expected: PASS (all four cases green).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add website/src/lib/tickets/cockpit-schema.ts website/src/lib/tickets/cockpit-schema.test.ts website/src/lib/tickets-db.ts
+git commit -m "feat(cockpit): v_cockpit_rollup in cockpit-schema module (S1-safe)"
+```
+
+---
+
+### Task 2: Dated migration `2026-06-15-cockpit-rollup-view.sql`
+
+**Files:**
+- Create: `scripts/migrations/2026-06-15-cockpit-rollup-view.sql`
+
+- [ ] **Step 1: Write the migration file**
+
+Create `scripts/migrations/2026-06-15-cockpit-rollup-view.sql` with the **verbatim** body of `COCKPIT_ROLLUP_VIEW_SQL` (from `website/src/lib/tickets/cockpit-schema.ts`, Task 1) — single source of truth, mirrored here for explicit prod application:
+
+```sql
+-- Cockpit Rollup View: leaf-count aggregation per container ticket.
+-- Mirrors tickets-db.ts::initTicketsSchema(). Idempotent (CREATE OR REPLACE).
+-- MUST be applied to BOTH brand DBs after merge:
+--   workspace            (mentolder)
+--   workspace-korczewski (korczewski)
+CREATE OR REPLACE VIEW tickets.v_cockpit_rollup AS
+WITH RECURSIVE descendants AS (
+  SELECT id AS container_id, id AS node_id, type, status
+  FROM tickets.tickets
+  UNION ALL
+  SELECT d.container_id, c.id AS node_id, c.type, c.status
+  FROM descendants d
+  JOIN tickets.tickets c ON c.parent_id = d.node_id
+),
+leaves AS (
+  SELECT d.container_id, d.node_id, d.status
+  FROM descendants d
+  WHERE d.node_id <> d.container_id
+    AND d.type IN ('task', 'bug')
+    AND NOT EXISTS (SELECT 1 FROM tickets.tickets ch WHERE ch.parent_id = d.node_id)
+),
+agg AS (
+  SELECT
+    container_id,
+    COUNT(*)::int AS total_leaves,
+    COUNT(*) FILTER (WHERE status = 'done')::int AS done_leaves,
+    COUNT(*) FILTER (WHERE status = 'blocked')::int AS blocked_leaves,
+    COUNT(*) FILTER (WHERE status IN ('in_progress', 'in_review'))::int AS in_progress_leaves,
+    COUNT(*) FILTER (WHERE status IN ('triage', 'backlog', 'planning', 'plan_staged'))::int AS open_leaves
+  FROM leaves
+  GROUP BY container_id
+)
+SELECT
+  c.id AS container_id,
+  COALESCE(a.total_leaves, 0)       AS total_leaves,
+  COALESCE(a.done_leaves, 0)        AS done_leaves,
+  COALESCE(a.blocked_leaves, 0)     AS blocked_leaves,
+  COALESCE(a.in_progress_leaves, 0) AS in_progress_leaves,
+  COALESCE(a.open_leaves, 0)        AS open_leaves,
+  COALESCE(ROUND(100.0 * a.done_leaves / NULLIF(a.total_leaves, 0))::int, 0) AS pct_done,
+  CASE
+    WHEN COALESCE(a.blocked_leaves, 0) > 0 THEN 'red'
+    WHEN COALESCE(a.total_leaves, 0) > 0
+         AND ROUND(100.0 * a.done_leaves / NULLIF(a.total_leaves, 0))::int = 100 THEN 'green'
+    ELSE 'amber'
+  END AS health
+FROM tickets.tickets c
+LEFT JOIN agg a ON a.container_id = c.id
+WHERE c.type IN ('project', 'feature');
+```
+
+- [ ] **Step 2: Verify the file exists and the SQL is well-formed**
+
+Run: `ls -la scripts/migrations/2026-06-15-cockpit-rollup-view.sql && head -5 scripts/migrations/2026-06-15-cockpit-rollup-view.sql`
+Expected: file present; comment header reads "Cockpit Rollup View".
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/migrations/2026-06-15-cockpit-rollup-view.sql
+git commit -m "feat(cockpit): dated migration for v_cockpit_rollup (both brand DBs)"
+```
+
+> **Operational runbook (for the PR description, executed post-merge by the deployer):** apply the view to both brand DBs:
+> ```bash
+> kubectl --context fleet -n workspace exec -i deploy/shared-db -- \
+>   psql -U postgres -d website < scripts/migrations/2026-06-15-cockpit-rollup-view.sql
+> kubectl --context fleet -n workspace-korczewski exec -i deploy/shared-db -- \
+>   psql -U postgres -d website < scripts/migrations/2026-06-15-cockpit-rollup-view.sql
+> ```
+
+---
+
+### Task 3: Contract types `cockpit-types.ts`
+
+**Files:**
+- Create: `website/src/lib/tickets/cockpit-types.ts` (~120 lines; limit 600)
+
+- [ ] **Step 1: Write the type module (no runtime code)**
+
+Create `website/src/lib/tickets/cockpit-types.ts`:
+
+```typescript
+// Single source of truth for the Cockpit API contract (spec §8).
+// Pure type declarations — no imports, no runtime code (S2-safe).
+
+export type HealthStatus = 'green' | 'amber' | 'red';
+
+export interface RollupMetrics {
+  total: number;
+  done: number;
+  blocked: number;
+  inProgress: number;
+  open: number;
+  pctDone: number;
+}
+
+export interface FeatureNode {
+  id: string;
+  extId: string;
+  title: string;
+  valueProp?: string;
+  priority: string;
+  health: HealthStatus;
+  rollup: RollupMetrics;
+}
+
+export interface ProductNode {
+  id: string;
+  extId: string;
+  title: string;
+  rollup: RollupMetrics;
+  features: FeatureNode[];
+}
+
+export interface PortfolioPayload {
+  products: ProductNode[];
+}
+
+export interface TicketRow {
+  id: string;
+  extId: string;
+  title: string;
+  status: string;
+  priority: string;
+  type: string;
+  parentId?: string;
+  planningRank?: number;
+  estimateMinutes?: number;
+  timeLoggedMinutes?: number;
+}
+
+export interface FeatureTickets {
+  feature: FeatureNode;
+  tickets: TicketRow[];
+}
+
+export interface BatchMutation {
+  status?: string;
+  priority?: string;
+  parentId?: string | null;
+  enqueue?: boolean;
+}
+
+export interface BatchResult {
+  ticketId: string;
+  success: boolean;
+  error?: string;
+}
+```
+
+- [ ] **Step 2: Verify it type-checks**
+
+Run: `cd website && pnpm exec tsc --noEmit -p tsconfig.json 2>&1 | grep cockpit-types || echo "OK no type errors in cockpit-types"`
+Expected: `OK no type errors in cockpit-types`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add website/src/lib/tickets/cockpit-types.ts
+git commit -m "feat(cockpit): API contract types (PortfolioPayload, FeatureTickets, ...)"
+```
+
+---
+
+### Task 4: `cockpit-db.ts` — read functions (`getPortfolio`, `getFeatureTickets`)
+
+**Files:**
+- Create: `website/src/lib/tickets/cockpit-db.ts` (read half now; target <350 lines after Task 5; limit 600)
+- Test: `website/src/lib/tickets/cockpit-db.test.ts`
+
+- [ ] **Step 1: Write the failing pg-mem test for reads**
+
+Create `website/src/lib/tickets/cockpit-db.test.ts`. Use `vi.hoisted` to back `pool` with a pg-mem instance seeded with 1 Product → 2 Features → 5 leaf tickets (statuses: 1 done, 1 blocked, 2 in_progress, 1 backlog):
+
+```typescript
+import { describe, it, expect, beforeEach } from 'vitest';
+
+const { mem } = vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { newDb } = require('pg-mem');
+  return { mem: newDb() };
+});
+
+vi.mock('../website-db', () => {
+  const pg = mem.adapters.createPg();
+  const pool = new pg.Pool();
+  return { pool, ensureSchemaOnce: async (_k: string, fn: () => Promise<void>) => fn() };
+});
+
+import { pool } from '../website-db';
+import { getPortfolio, getFeatureTickets } from './cockpit-db';
+
+async function seed() {
+  await pool.query(`CREATE SCHEMA IF NOT EXISTS tickets`);
+  await pool.query(`
+    CREATE TABLE tickets.tickets (
+      id text PRIMARY KEY, external_id text, brand text, type text,
+      title text, value_prop text, priority text, status text,
+      parent_id text, planning_rank int, created_at timestamptz DEFAULT now()
+    )`);
+  // (re-create v_cockpit_rollup here using the same SQL as the migration)
+  await pool.query(require('node:fs').readFileSync(
+    new URL('../../../../scripts/migrations/2026-06-15-cockpit-rollup-view.sql', import.meta.url).pathname,
+    'utf8',
+  ));
+  const rows: [string, string, string, string, string | null, string][] = [
+    ['p1', 'project', 'Produkt A', null!, null, 'backlog'],
+    ['f1', 'feature', 'Feature One', 'p1', 'Improves onboarding', 'backlog'],
+    ['f2', 'feature', 'Feature Two', 'p1', null, 'backlog'],
+    ['t1', 'task', 'T1', 'f1', null, 'done'],
+    ['t2', 'task', 'T2', 'f1', null, 'blocked'],
+    ['t3', 'bug', 'T3', 'f2', null, 'in_progress'],
+    ['t4', 'task', 'T4', 'f2', null, 'in_progress'],
+    ['t5', 'task', 'T5', 'f2', null, 'backlog'],
+  ];
+  let rank = 0;
+  for (const [id, type, title, parent, vp, status] of rows) {
+    await pool.query(
+      `INSERT INTO tickets.tickets
+         (id, external_id, brand, type, title, value_prop, priority, status, parent_id, planning_rank)
+       VALUES ($1,$1,'mentolder',$2,$3,$4,'mittel',$5,$6,$7)`,
+      [id, type, title, vp, status, parent, rank++],
+    );
+  }
+}
+
+beforeEach(async () => {
+  await pool.query(`DROP SCHEMA IF EXISTS tickets CASCADE`);
+  await seed();
+});
+
+describe('getPortfolio', () => {
+  it('returns products with nested features and rollups', async () => {
+    const out = await getPortfolio('mentolder');
+    expect(out.products).toHaveLength(1);
+    const p = out.products[0];
+    expect(p.extId).toBe('p1');
+    expect(p.features).toHaveLength(2);
+    // Product rollup across all 5 leaves: 1 done / 5 total = 20%, blocked>0 => red
+    expect(p.rollup.total).toBe(5);
+    expect(p.rollup.done).toBe(1);
+    expect(p.rollup.blocked).toBe(1);
+    expect(p.rollup.pctDone).toBe(20);
+    expect(p.features.find(f => f.extId === 'f1')!.health).toBe('red');
+  });
+
+  it('scopes to brand (korczewski sees nothing here)', async () => {
+    const out = await getPortfolio('korczewski');
+    expect(out.products).toHaveLength(0);
+  });
+});
+
+describe('getFeatureTickets', () => {
+  it('returns only leaf tickets for the feature, ordered by rank', async () => {
+    const out = await getFeatureTickets('mentolder', 'f1');
+    expect(out.feature.extId).toBe('f1');
+    expect(out.tickets.map(t => t.extId)).toEqual(['t1', 't2']);
+    expect(out.tickets.every(t => ['task', 'bug'].includes(t.type))).toBe(true);
+  });
+
+  it('returns null-ish (throws NotFound) for cross-brand feature', async () => {
+    await expect(getFeatureTickets('korczewski', 'f1')).rejects.toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: Run it and verify it fails**
+
+Run: `cd website && pnpm test -- cockpit-db.test.ts`
+Expected: FAIL — `cockpit-db.ts` does not export `getPortfolio`/`getFeatureTickets`.
+
+- [ ] **Step 3: Implement the read functions**
+
+Create `website/src/lib/tickets/cockpit-db.ts`:
+
+```typescript
+import { pool } from '../website-db';
+import type {
+  PortfolioPayload, ProductNode, FeatureNode,
+  FeatureTickets, TicketRow, RollupMetrics, HealthStatus,
+} from './cockpit-types';
+
+function toRollup(r: Record<string, unknown> | undefined): RollupMetrics {
+  return {
+    total: Number(r?.total_leaves ?? 0),
+    done: Number(r?.done_leaves ?? 0),
+    blocked: Number(r?.blocked_leaves ?? 0),
+    inProgress: Number(r?.in_progress_leaves ?? 0),
+    open: Number(r?.open_leaves ?? 0),
+    pctDone: Number(r?.pct_done ?? 0),
+  };
+}
+
+export async function getPortfolio(brand: string): Promise<PortfolioPayload> {
+  // Containers (products + features) with their rollup, brand-scoped.
+  const { rows } = await pool.query(
+    `SELECT t.id, t.external_id, t.type, t.title, t.value_prop, t.priority,
+            t.parent_id, t.planning_rank,
+            r.total_leaves, r.done_leaves, r.blocked_leaves,
+            r.in_progress_leaves, r.open_leaves, r.pct_done, r.health
+       FROM tickets.tickets t
+       LEFT JOIN tickets.v_cockpit_rollup r ON r.container_id = t.id
+      WHERE t.brand = $1 AND t.type IN ('project', 'feature')
+      ORDER BY COALESCE(t.planning_rank, 2147483647), t.created_at`,
+    [brand],
+  );
+
+  const products: ProductNode[] = [];
+  const byId = new Map<string, ProductNode>();
+  const looseFeatures: FeatureNode[] = [];
+
+  for (const row of rows) {
+    if (row.type === 'project') {
+      const node: ProductNode = {
+        id: row.id, extId: row.external_id, title: row.title,
+        rollup: toRollup(row), features: [],
+      };
+      products.push(node);
+      byId.set(row.id, node);
+    }
+  }
+  for (const row of rows) {
+    if (row.type !== 'feature') continue;
+    const feature: FeatureNode = {
+      id: row.id, extId: row.external_id, title: row.title,
+      valueProp: row.value_prop ?? undefined,
+      priority: row.priority, health: (row.health ?? 'amber') as HealthStatus,
+      rollup: toRollup(row),
+    };
+    const parent = row.parent_id ? byId.get(row.parent_id) : undefined;
+    if (parent) parent.features.push(feature);
+    else looseFeatures.push(feature);
+  }
+
+  if (looseFeatures.length > 0) {
+    // Pseudo-group "Ohne Produkt" (spec §5) for parentless features.
+    products.push({
+      id: '__no_product__', extId: '__no_product__', title: 'Ohne Produkt',
+      rollup: aggregate(looseFeatures), features: looseFeatures,
+    });
+  }
+  return { products };
+}
+
+function aggregate(features: FeatureNode[]): RollupMetrics {
+  const sum = features.reduce((a, f) => ({
+    total: a.total + f.rollup.total, done: a.done + f.rollup.done,
+    blocked: a.blocked + f.rollup.blocked, inProgress: a.inProgress + f.rollup.inProgress,
+    open: a.open + f.rollup.open, pctDone: 0,
+  }), { total: 0, done: 0, blocked: 0, inProgress: 0, open: 0, pctDone: 0 });
+  sum.pctDone = sum.total ? Math.round((100 * sum.done) / sum.total) : 0;
+  return sum;
+}
+
+export class NotFoundError extends Error {}
+
+export async function getFeatureTickets(brand: string, extId: string): Promise<FeatureTickets> {
+  const fr = await pool.query(
+    `SELECT t.id, t.external_id, t.type, t.title, t.value_prop, t.priority,
+            r.total_leaves, r.done_leaves, r.blocked_leaves,
+            r.in_progress_leaves, r.open_leaves, r.pct_done, r.health
+       FROM tickets.tickets t
+       LEFT JOIN tickets.v_cockpit_rollup r ON r.container_id = t.id
+      WHERE t.brand = $1 AND t.external_id = $2 AND t.type IN ('project', 'feature')`,
+    [brand, extId],
+  );
+  if (fr.rows.length === 0) throw new NotFoundError(`container ${extId} not found`);
+  const f = fr.rows[0];
+  const feature: FeatureNode = {
+    id: f.id, extId: f.external_id, title: f.title,
+    valueProp: f.value_prop ?? undefined, priority: f.priority,
+    health: (f.health ?? 'amber') as HealthStatus, rollup: toRollup(f),
+  };
+
+  const tr = await pool.query(
+    `WITH RECURSIVE sub AS (
+        SELECT id FROM tickets.tickets WHERE parent_id = $1
+        UNION ALL
+        SELECT c.id FROM tickets.tickets c JOIN sub ON c.parent_id = sub.id
+      )
+      SELECT t.id, t.external_id, t.type, t.title, t.status, t.priority,
+             t.parent_id, t.planning_rank
+        FROM tickets.tickets t
+       WHERE t.id IN (SELECT id FROM sub)
+         AND t.brand = $2 AND t.type IN ('task', 'bug')
+         AND NOT EXISTS (SELECT 1 FROM tickets.tickets ch WHERE ch.parent_id = t.id)
+       ORDER BY COALESCE(t.planning_rank, 2147483647), t.external_id`,
+    [feature.id, brand],
+  );
+  const tickets: TicketRow[] = tr.rows.map((t: Record<string, unknown>) => ({
+    id: String(t.id), extId: String(t.external_id), title: String(t.title),
+    status: String(t.status), priority: String(t.priority), type: String(t.type),
+    parentId: t.parent_id ? String(t.parent_id) : undefined,
+    planningRank: t.planning_rank != null ? Number(t.planning_rank) : undefined,
+  }));
+  return { feature, tickets };
+}
+```
+
+- [ ] **Step 4: Run the test and verify it passes**
+
+Run: `cd website && pnpm test -- cockpit-db.test.ts`
+Expected: PASS (4 read-side cases).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add website/src/lib/tickets/cockpit-db.ts website/src/lib/tickets/cockpit-db.test.ts
+git commit -m "feat(cockpit): cockpit-db read functions (portfolio + feature drill-in)"
+```
+
+---
+
+### Task 5: `cockpit-db.ts` — mutation helpers (reorder/reparent/batch)
+
+**Files:**
+- Modify: `website/src/lib/tickets/cockpit-db.ts` (append helpers; keep <500 lines total — if it approaches the limit, split mutations into `cockpit-db-mutations.ts`)
+- Test: `website/src/lib/tickets/cockpit-db.test.ts` (append)
+
+- [ ] **Step 1: Write the failing mutation tests**
+
+Append to `website/src/lib/tickets/cockpit-db.test.ts`:
+
+```typescript
+import { updatePlanningRanks, reparentTicket, batchMutate } from './cockpit-db';
+
+describe('updatePlanningRanks', () => {
+  it('updates ranks for same-brand tickets', async () => {
+    await updatePlanningRanks('mentolder', [
+      { ticketId: 't2', planningRank: 0 },
+      { ticketId: 't1', planningRank: 1 },
+    ]);
+    const out = await getFeatureTickets('mentolder', 'f1');
+    expect(out.tickets.map(t => t.extId)).toEqual(['t2', 't1']);
+  });
+
+  it('rejects cross-brand ids', async () => {
+    await expect(updatePlanningRanks('korczewski', [{ ticketId: 't1', planningRank: 0 }]))
+      .rejects.toThrow();
+  });
+});
+
+describe('reparentTicket', () => {
+  it('moves a leaf to a new feature', async () => {
+    await reparentTicket('mentolder', 't1', 'f2');
+    const out = await getFeatureTickets('mentolder', 'f2');
+    expect(out.tickets.map(t => t.extId)).toContain('t1');
+  });
+
+  it('allows reparent to null (top-level)', async () => {
+    await reparentTicket('mentolder', 'f1', null);
+    // f1 becomes a parentless feature; getPortfolio surfaces it under "Ohne Produkt"
+    const portfolio = await getPortfolio('mentolder');
+    const loose = portfolio.products.find(p => p.extId === '__no_product__');
+    expect(loose?.features.some(f => f.extId === 'f1')).toBe(true);
+  });
+});
+
+describe('batchMutate', () => {
+  it('applies status to multiple tickets and reports per-id results', async () => {
+    const res = await batchMutate('mentolder', ['t4', 't5'], { status: 'done' });
+    expect(res.ok).toBe(true);
+    expect(res.results.filter(r => r.success)).toHaveLength(2);
+    const out = await getFeatureTickets('mentolder', 'f2');
+    expect(out.tickets.filter(t => t.status === 'done').map(t => t.extId).sort())
+      .toEqual(['t4', 't5']);
+  });
+});
+```
+
+- [ ] **Step 2: Run it and verify it fails**
+
+Run: `cd website && pnpm test -- cockpit-db.test.ts`
+Expected: FAIL — `updatePlanningRanks`/`reparentTicket`/`batchMutate` not exported.
+
+- [ ] **Step 3: Implement the mutation helpers**
+
+Append to `website/src/lib/tickets/cockpit-db.ts`:
+
+```typescript
+import type { BatchMutation, BatchResult } from './cockpit-types';
+
+export class BrandMismatchError extends Error {}
+export class CycleError extends Error {}
+
+async function assertSameBrand(brand: string, ids: string[]): Promise<void> {
+  if (ids.length === 0) return;
+  const { rows } = await pool.query(
+    `SELECT id FROM tickets.tickets WHERE id = ANY($1) AND brand <> $2`,
+    [ids, brand],
+  );
+  if (rows.length > 0) throw new BrandMismatchError('ticket belongs to another brand');
+}
+
+export async function updatePlanningRanks(
+  brand: string,
+  updates: { ticketId: string; planningRank: number }[],
+): Promise<{ ok: true }> {
+  await assertSameBrand(brand, updates.map(u => u.ticketId));
+  for (const u of updates) {
+    await pool.query(
+      `UPDATE tickets.tickets SET planning_rank = $1, updated_at = now()
+        WHERE id = $2 AND brand = $3`,
+      [u.planningRank, u.ticketId, brand],
+    );
+  }
+  await audit(brand, 'reorder', { updates });
+  return { ok: true };
+}
+
+export async function reparentTicket(
+  brand: string,
+  ticketId: string,
+  newParentId: string | null,
+): Promise<{ ok: true }> {
+  await assertSameBrand(brand, newParentId ? [ticketId, newParentId] : [ticketId]);
+  try {
+    await pool.query(
+      `UPDATE tickets.tickets SET parent_id = $1, updated_at = now()
+        WHERE id = $2 AND brand = $3`,
+      [newParentId, ticketId, brand],
+    );
+  } catch (e) {
+    // fn_prevent_cycle trigger raises on cycles
+    if (/cycle/i.test(String((e as Error).message))) throw new CycleError('would create a cycle');
+    throw e;
+  }
+  await audit(brand, 'reparent', { ticketId, newParentId });
+  return { ok: true };
+}
+
+export async function batchMutate(
+  brand: string,
+  ticketIds: string[],
+  mutation: BatchMutation,
+): Promise<{ ok: true; results: BatchResult[] }> {
+  await assertSameBrand(brand, ticketIds);
+  const results: BatchResult[] = [];
+  for (const id of ticketIds) {
+    try {
+      if (mutation.status != null) {
+        await pool.query(
+          `UPDATE tickets.tickets SET status = $1, updated_at = now() WHERE id = $2 AND brand = $3`,
+          [mutation.status, id, brand]);
+      }
+      if (mutation.priority != null) {
+        await pool.query(
+          `UPDATE tickets.tickets SET priority = $1, updated_at = now() WHERE id = $2 AND brand = $3`,
+          [mutation.priority, id, brand]);
+      }
+      if (mutation.parentId !== undefined) {
+        await pool.query(
+          `UPDATE tickets.tickets SET parent_id = $1, updated_at = now() WHERE id = $2 AND brand = $3`,
+          [mutation.parentId, id, brand]);
+      }
+      results.push({ ticketId: id, success: true });
+    } catch (e) {
+      results.push({ ticketId: id, success: false, error: String((e as Error).message) });
+    }
+  }
+  await audit(brand, 'batch_mutate', { ticketIds, mutation });
+  return { ok: true, results };
+}
+
+async function audit(brand: string, action: string, changes: unknown): Promise<void> {
+  // Best-effort audit; mirror existing ticket_activity usage. Never throws.
+  try {
+    await pool.query(
+      `INSERT INTO tickets.ticket_activity (brand, action, changes, created_at)
+       VALUES ($1, $2, $3, now())`,
+      [brand, action, JSON.stringify(changes)],
+    );
+  } catch { /* table shape may differ in unit DB; audit is non-fatal */ }
+}
+```
+
+> Executor note: confirm the real `tickets.ticket_activity` column names against the existing `admin.ts` audit calls and align `audit()` to them. If `admin.ts` exposes an audit helper that is exportable without growing it, prefer importing that (type-only/function import — do NOT modify `admin.ts`). The unit test tolerates a missing/divergent activity table via the try/catch.
+
+- [ ] **Step 4: Run the test and verify it passes**
+
+Run: `cd website && pnpm test -- cockpit-db.test.ts`
+Expected: PASS (all read + mutation cases). Then check size:
+Run: `wc -l website/src/lib/tickets/cockpit-db.ts`
+Expected: <500 (if ≥500, split mutations into `cockpit-db-mutations.ts` and re-import).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add website/src/lib/tickets/cockpit-db.ts website/src/lib/tickets/cockpit-db.test.ts
+git commit -m "feat(cockpit): cockpit-db mutation helpers (reorder, reparent, batch)"
+```
+
+---
+
+### Task 6: Stage A gate check
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Assert frozen files did not grow**
+
+Run:
+```bash
+wc -l website/src/lib/tickets/admin.ts          # MUST be 677
+wc -l website/src/lib/tickets/cockpit-db.ts     # <500
+wc -l website/src/lib/tickets/cockpit-types.ts  # ~120
+```
+Expected: `admin.ts` exactly 677; cockpit files under budget.
+
+- [ ] **Step 2: Run unit + quality**
+
+Run: `cd website && pnpm test -- "cockpit-db|tickets-db" && cd .. && task quality:check`
+Expected: tests pass; no S1 violation for the new files.
+
+- [ ] **Step 3: Commit if quality:check produced regenerated artifacts (else skip)**
+
+```bash
+git add -A && git commit -m "chore(cockpit): stage A quality gate" || echo "nothing to commit"
+```
+
+---
+
+
+---
+
+## Verification (scoped sub-plan gate)
+
+This sub-plan merges independently — it must be green on its own.
+
+- [ ] Scoped unit tests: `cd website && pnpm test -- "cockpit-schema|cockpit-db"`
+- [ ] `task test:all` → exit 0
+- [ ] `task freshness:regenerate` then `task freshness:check` → exit 0 (S1–S4 ratchet incl. `tickets-db.ts` ≤ 1106, `admin.ts` = 677)
+- [ ] If test files were added: `task test:inventory` + commit `website/src/data/test-inventory.json`
+- [ ] Confirm only this sub-plan's `file_locks` files changed

--- a/docs/superpowers/plans/2026-06-15-cockpit-foundation.md
+++ b/docs/superpowers/plans/2026-06-15-cockpit-foundation.md
@@ -371,7 +371,7 @@ git commit -m "feat(cockpit): API contract types (PortfolioPayload, FeatureTicke
 - Create: `website/src/lib/tickets/cockpit-db.ts` (read half now; target <350 lines after Task 5; limit 600)
 - Test: `website/src/lib/tickets/cockpit-db.test.ts`
 
-- [ ] **Step 1: Write the failing pg-mem test for reads**
+- [x] **Step 1: Write the failing pg-mem test for reads**
 
 Create `website/src/lib/tickets/cockpit-db.test.ts`. Use `vi.hoisted` to back `pool` with a pg-mem instance seeded with 1 Product → 2 Features → 5 leaf tickets (statuses: 1 done, 1 blocked, 2 in_progress, 1 backlog):
 
@@ -467,12 +467,12 @@ describe('getFeatureTickets', () => {
 });
 ```
 
-- [ ] **Step 2: Run it and verify it fails**
+- [x] **Step 2: Run it and verify it fails**
 
 Run: `cd website && pnpm test -- cockpit-db.test.ts`
 Expected: FAIL — `cockpit-db.ts` does not export `getPortfolio`/`getFeatureTickets`.
 
-- [ ] **Step 3: Implement the read functions**
+- [x] **Step 3: Implement the read functions**
 
 Create `website/src/lib/tickets/cockpit-db.ts`:
 
@@ -600,12 +600,12 @@ export async function getFeatureTickets(brand: string, extId: string): Promise<F
 }
 ```
 
-- [ ] **Step 4: Run the test and verify it passes**
+- [x] **Step 4: Run the test and verify it passes**
 
 Run: `cd website && pnpm test -- cockpit-db.test.ts`
 Expected: PASS (4 read-side cases).
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add website/src/lib/tickets/cockpit-db.ts website/src/lib/tickets/cockpit-db.test.ts
@@ -620,7 +620,7 @@ git commit -m "feat(cockpit): cockpit-db read functions (portfolio + feature dri
 - Modify: `website/src/lib/tickets/cockpit-db.ts` (append helpers; keep <500 lines total — if it approaches the limit, split mutations into `cockpit-db-mutations.ts`)
 - Test: `website/src/lib/tickets/cockpit-db.test.ts` (append)
 
-- [ ] **Step 1: Write the failing mutation tests**
+- [x] **Step 1: Write the failing mutation tests**
 
 Append to `website/src/lib/tickets/cockpit-db.test.ts`:
 
@@ -671,12 +671,12 @@ describe('batchMutate', () => {
 });
 ```
 
-- [ ] **Step 2: Run it and verify it fails**
+- [x] **Step 2: Run it and verify it fails**
 
 Run: `cd website && pnpm test -- cockpit-db.test.ts`
 Expected: FAIL — `updatePlanningRanks`/`reparentTicket`/`batchMutate` not exported.
 
-- [ ] **Step 3: Implement the mutation helpers**
+- [x] **Step 3: Implement the mutation helpers**
 
 Append to `website/src/lib/tickets/cockpit-db.ts`:
 
@@ -779,14 +779,14 @@ async function audit(brand: string, action: string, changes: unknown): Promise<v
 
 > Executor note: confirm the real `tickets.ticket_activity` column names against the existing `admin.ts` audit calls and align `audit()` to them. If `admin.ts` exposes an audit helper that is exportable without growing it, prefer importing that (type-only/function import — do NOT modify `admin.ts`). The unit test tolerates a missing/divergent activity table via the try/catch.
 
-- [ ] **Step 4: Run the test and verify it passes**
+- [x] **Step 4: Run the test and verify it passes**
 
 Run: `cd website && pnpm test -- cockpit-db.test.ts`
 Expected: PASS (all read + mutation cases). Then check size:
 Run: `wc -l website/src/lib/tickets/cockpit-db.ts`
 Expected: <500 (if ≥500, split mutations into `cockpit-db-mutations.ts` and re-import).
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add website/src/lib/tickets/cockpit-db.ts website/src/lib/tickets/cockpit-db.test.ts
@@ -799,7 +799,7 @@ git commit -m "feat(cockpit): cockpit-db mutation helpers (reorder, reparent, ba
 
 **Files:** none (verification only)
 
-- [ ] **Step 1: Assert frozen files did not grow**
+- [x] **Step 1: Assert frozen files did not grow**
 
 Run:
 ```bash
@@ -809,12 +809,12 @@ wc -l website/src/lib/tickets/cockpit-types.ts  # ~120
 ```
 Expected: `admin.ts` exactly 677; cockpit files under budget.
 
-- [ ] **Step 2: Run unit + quality**
+- [x] **Step 2: Run unit + quality**
 
 Run: `cd website && pnpm test -- "cockpit-db|tickets-db" && cd .. && task quality:check`
 Expected: tests pass; no S1 violation for the new files.
 
-- [ ] **Step 3: Commit if quality:check produced regenerated artifacts (else skip)**
+- [x] **Step 3: Commit if quality:check produced regenerated artifacts (else skip)**
 
 ```bash
 git add -A && git commit -m "chore(cockpit): stage A quality gate" || echo "nothing to commit"
@@ -829,8 +829,8 @@ git add -A && git commit -m "chore(cockpit): stage A quality gate" || echo "noth
 
 This sub-plan merges independently — it must be green on its own.
 
-- [ ] Scoped unit tests: `cd website && pnpm test -- "cockpit-schema|cockpit-db"`
+- [x] Scoped unit tests: `cd website && pnpm test -- "cockpit-schema|cockpit-db"`
 - [ ] `task test:all` → exit 0
 - [ ] `task freshness:regenerate` then `task freshness:check` → exit 0 (S1–S4 ratchet incl. `tickets-db.ts` ≤ 1106, `admin.ts` = 677)
-- [ ] If test files were added: `task test:inventory` + commit `website/src/data/test-inventory.json`
-- [ ] Confirm only this sub-plan's `file_locks` files changed
+- [x] If test files were added: `task test:inventory` + commit `website/src/data/test-inventory.json`
+- [x] Confirm only this sub-plan's `file_locks` files changed

--- a/scripts/migrations/2026-06-15-cockpit-rollup-view.sql
+++ b/scripts/migrations/2026-06-15-cockpit-rollup-view.sql
@@ -13,10 +13,12 @@ WITH RECURSIVE descendants AS (
   JOIN tickets.tickets c ON c.parent_id = d.node_id
 ),
 leaves AS (
+  -- archived leaves excluded: cancelled/obsolete tasks must not affect progress math
   SELECT d.container_id, d.node_id, d.status
   FROM descendants d
   WHERE d.node_id <> d.container_id
     AND d.type IN ('task', 'bug')
+    AND d.status <> 'archived'
     AND NOT EXISTS (SELECT 1 FROM tickets.tickets ch WHERE ch.parent_id = d.node_id)
 ),
 agg AS (
@@ -25,7 +27,7 @@ agg AS (
     COUNT(*)::int AS total_leaves,
     COUNT(*) FILTER (WHERE status = 'done')::int AS done_leaves,
     COUNT(*) FILTER (WHERE status = 'blocked')::int AS blocked_leaves,
-    COUNT(*) FILTER (WHERE status IN ('in_progress', 'in_review'))::int AS in_progress_leaves,
+    COUNT(*) FILTER (WHERE status IN ('in_progress', 'in_review', 'qa_review'))::int AS in_progress_leaves,
     COUNT(*) FILTER (WHERE status IN ('triage', 'backlog', 'planning', 'plan_staged'))::int AS open_leaves
   FROM leaves
   GROUP BY container_id

--- a/scripts/migrations/2026-06-15-cockpit-rollup-view.sql
+++ b/scripts/migrations/2026-06-15-cockpit-rollup-view.sql
@@ -1,0 +1,49 @@
+-- Cockpit Rollup View: leaf-count aggregation per container ticket.
+-- Mirrors tickets-db.ts::initTicketsSchema(). Idempotent (CREATE OR REPLACE).
+-- MUST be applied to BOTH brand DBs after merge:
+--   workspace            (mentolder)
+--   workspace-korczewski (korczewski)
+CREATE OR REPLACE VIEW tickets.v_cockpit_rollup AS
+WITH RECURSIVE descendants AS (
+  SELECT id AS container_id, id AS node_id, type, status
+  FROM tickets.tickets
+  UNION ALL
+  SELECT d.container_id, c.id AS node_id, c.type, c.status
+  FROM descendants d
+  JOIN tickets.tickets c ON c.parent_id = d.node_id
+),
+leaves AS (
+  SELECT d.container_id, d.node_id, d.status
+  FROM descendants d
+  WHERE d.node_id <> d.container_id
+    AND d.type IN ('task', 'bug')
+    AND NOT EXISTS (SELECT 1 FROM tickets.tickets ch WHERE ch.parent_id = d.node_id)
+),
+agg AS (
+  SELECT
+    container_id,
+    COUNT(*)::int AS total_leaves,
+    COUNT(*) FILTER (WHERE status = 'done')::int AS done_leaves,
+    COUNT(*) FILTER (WHERE status = 'blocked')::int AS blocked_leaves,
+    COUNT(*) FILTER (WHERE status IN ('in_progress', 'in_review'))::int AS in_progress_leaves,
+    COUNT(*) FILTER (WHERE status IN ('triage', 'backlog', 'planning', 'plan_staged'))::int AS open_leaves
+  FROM leaves
+  GROUP BY container_id
+)
+SELECT
+  c.id AS container_id,
+  COALESCE(a.total_leaves, 0)       AS total_leaves,
+  COALESCE(a.done_leaves, 0)        AS done_leaves,
+  COALESCE(a.blocked_leaves, 0)     AS blocked_leaves,
+  COALESCE(a.in_progress_leaves, 0) AS in_progress_leaves,
+  COALESCE(a.open_leaves, 0)        AS open_leaves,
+  COALESCE(ROUND(100.0 * a.done_leaves / NULLIF(a.total_leaves, 0))::int, 0) AS pct_done,
+  CASE
+    WHEN COALESCE(a.blocked_leaves, 0) > 0 THEN 'red'
+    WHEN COALESCE(a.total_leaves, 0) > 0
+         AND ROUND(100.0 * a.done_leaves / NULLIF(a.total_leaves, 0))::int = 100 THEN 'green'
+    ELSE 'amber'
+  END AS health
+FROM tickets.tickets c
+LEFT JOIN agg a ON a.container_id = c.id
+WHERE c.type IN ('project', 'feature');

--- a/website/src/lib/tickets-db.ts
+++ b/website/src/lib/tickets-db.ts
@@ -3,6 +3,7 @@ import { pool, ensureSchemaOnce } from './website-db';
 import { MixedEmbeddingModelError } from './knowledge-db';
 import type { EmbeddingModel } from './embeddings';
 import { initProviderConfigSchema } from './schema/provider-config-schema';
+import { ensureCockpitViews } from './tickets/cockpit-schema';
 
 export { MixedEmbeddingModelError };
 
@@ -634,6 +635,7 @@ export async function initTicketsSchema(): Promise<void> {
       created_at
   `);
 
+  await ensureCockpitViews(pool);
 
   // DEPRECATED (T000402): tickets.ticket_counters was a PER-BRAND monotonic
   // counter that fed the external_id trigger. external_id is GLOBALLY unique

--- a/website/src/lib/tickets/cockpit-db.test.ts
+++ b/website/src/lib/tickets/cockpit-db.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
+
+// pg-mem does not support WITH RECURSIVE CTEs or NOT EXISTS with outer aliases.
+// The view is approximated here with a 2-hop UNION ALL that is semantically
+// equivalent for the test fixture (max depth: project → feature → leaf task/bug).
+// The production view DDL (cockpit-schema.ts / migration SQL) is the single
+// source of truth and is NOT changed by this test workaround.
+
+const { mem } = vi.hoisted(() => {
+  const { newDb, DataType } = require('pg-mem') as typeof import('pg-mem');
+  const db = newDb();
+  // Register functions not built into pg-mem
+  db.public.registerFunction({
+    name: 'nullif',
+    args: [DataType.integer, DataType.integer],
+    returns: DataType.integer,
+    implementation: (a: number, b: number) => (a === b ? null : a),
+  });
+  db.public.registerFunction({
+    name: 'nullif',
+    args: [DataType.float, DataType.integer],
+    returns: DataType.float,
+    implementation: (a: number, b: number) => (a === b ? null : a),
+  });
+  db.public.registerFunction({
+    name: 'round',
+    args: [DataType.float],
+    returns: DataType.integer,
+    implementation: (a: number) => Math.round(a),
+  });
+  return { mem: db };
+});
+
+vi.mock('../website-db', () => {
+  const pg = mem.adapters.createPg();
+  const pool = new pg.Pool();
+  return { pool, ensureSchemaOnce: async (_k: string, fn: () => Promise<void>) => fn() };
+});
+
+import { pool } from '../website-db';
+import { getPortfolio, getFeatureTickets } from './cockpit-db';
+import { updatePlanningRanks, reparentTicket, batchMutate } from './cockpit-db';
+
+const rows: [string, string, string, string, string | null, string][] = [
+  ['p1', 'project', 'Produkt A', null!, null, 'backlog'],
+  ['f1', 'feature', 'Feature One', 'p1', 'Improves onboarding', 'backlog'],
+  ['f2', 'feature', 'Feature Two', 'p1', null, 'backlog'],
+  ['t1', 'task', 'T1', 'f1', null, 'done'],
+  ['t2', 'task', 'T2', 'f1', null, 'blocked'],
+  ['t3', 'bug', 'T3', 'f2', null, 'in_progress'],
+  ['t4', 'task', 'T4', 'f2', null, 'in_progress'],
+  ['t5', 'task', 'T5', 'f2', null, 'backlog'],
+];
+
+/** pg-mem-compatible 2-hop view approximating v_cockpit_rollup for the test fixture.
+ *  The UNION ALL covers: (1) direct leaf children of containers; (2) grandchild
+ *  leaves accessed through one intermediate feature node. This matches the
+ *  test fixture depth. NOT used in production — production runs the RECURSIVE CTE. */
+const PG_MEM_COMPAT_VIEW_SQL = `
+  CREATE VIEW tickets.v_cockpit_rollup AS
+  WITH all_leaves AS (
+    SELECT l.parent_id AS container_id, l.status
+    FROM tickets.tickets l
+    WHERE l.type IN ('task','bug')
+    UNION ALL
+    SELECT mid.parent_id AS container_id, l2.status
+    FROM tickets.tickets mid
+    JOIN tickets.tickets l2 ON l2.parent_id = mid.id
+    WHERE l2.type IN ('task','bug') AND mid.type IN ('feature')
+  ),
+  agg AS (
+    SELECT
+      container_id,
+      COUNT(*)::int AS total_leaves,
+      SUM(CASE WHEN status = 'done' THEN 1 ELSE 0 END)::int AS done_leaves,
+      SUM(CASE WHEN status = 'blocked' THEN 1 ELSE 0 END)::int AS blocked_leaves,
+      SUM(CASE WHEN status IN ('in_progress','in_review') THEN 1 ELSE 0 END)::int AS in_progress_leaves,
+      SUM(CASE WHEN status IN ('triage','backlog','planning','plan_staged') THEN 1 ELSE 0 END)::int AS open_leaves
+    FROM all_leaves
+    GROUP BY container_id
+  )
+  SELECT
+    c.id AS container_id,
+    COALESCE(a.total_leaves, 0) AS total_leaves,
+    COALESCE(a.done_leaves, 0) AS done_leaves,
+    COALESCE(a.blocked_leaves, 0) AS blocked_leaves,
+    COALESCE(a.in_progress_leaves, 0) AS in_progress_leaves,
+    COALESCE(a.open_leaves, 0) AS open_leaves,
+    COALESCE(ROUND(100.0 * a.done_leaves / NULLIF(a.total_leaves, 0))::int, 0) AS pct_done,
+    CASE
+      WHEN COALESCE(a.blocked_leaves, 0) > 0 THEN 'red'
+      WHEN COALESCE(a.total_leaves, 0) > 0
+           AND ROUND(100.0 * a.done_leaves / NULLIF(a.total_leaves, 0))::int = 100 THEN 'green'
+      ELSE 'amber'
+    END AS health
+  FROM tickets.tickets c
+  LEFT JOIN agg a ON a.container_id = c.id
+  WHERE c.type IN ('project','feature')
+`;
+
+async function createSchema() {
+  await pool.query('CREATE SCHEMA tickets');
+  await pool.query(`
+    CREATE TABLE tickets.tickets (
+      id text PRIMARY KEY, external_id text, brand text, type text,
+      title text, value_prop text, priority text, status text,
+      parent_id text, planning_rank int,
+      updated_at timestamptz DEFAULT now(),
+      created_at timestamptz DEFAULT now()
+    )`);
+  await pool.query(PG_MEM_COMPAT_VIEW_SQL);
+}
+
+async function insertRows() {
+  let rank = 0;
+  for (const [id, type, title, parent, vp, status] of rows) {
+    await pool.query(
+      `INSERT INTO tickets.tickets
+         (id, external_id, brand, type, title, value_prop, priority, status, parent_id, planning_rank)
+       VALUES ($1,$1,'mentolder',$2,$3,$4,'mittel',$5,$6,$7)`,
+      [id, type, title, vp, status, parent, rank++],
+    );
+  }
+}
+
+beforeAll(async () => {
+  await createSchema();
+});
+
+beforeEach(async () => {
+  await pool.query('DELETE FROM tickets.tickets');
+  await insertRows();
+});
+
+describe('getPortfolio', () => {
+  it('returns products with nested features and rollups', async () => {
+    const out = await getPortfolio('mentolder');
+    expect(out.products).toHaveLength(1);
+    const p = out.products[0];
+    expect(p.extId).toBe('p1');
+    expect(p.features).toHaveLength(2);
+    // Product rollup across all 5 leaves: 1 done / 5 total = 20%, blocked>0 => red
+    expect(p.rollup.total).toBe(5);
+    expect(p.rollup.done).toBe(1);
+    expect(p.rollup.blocked).toBe(1);
+    expect(p.rollup.pctDone).toBe(20);
+    expect(p.features.find(f => f.extId === 'f1')!.health).toBe('red');
+  });
+
+  it('scopes to brand (korczewski sees nothing here)', async () => {
+    const out = await getPortfolio('korczewski');
+    expect(out.products).toHaveLength(0);
+  });
+});
+
+describe('getFeatureTickets', () => {
+  it('returns only leaf tickets for the feature, ordered by rank', async () => {
+    const out = await getFeatureTickets('mentolder', 'f1');
+    expect(out.feature.extId).toBe('f1');
+    expect(out.tickets.map(t => t.extId)).toEqual(['t1', 't2']);
+    expect(out.tickets.every(t => ['task', 'bug'].includes(t.type))).toBe(true);
+  });
+
+  it('returns null-ish (throws NotFound) for cross-brand feature', async () => {
+    await expect(getFeatureTickets('korczewski', 'f1')).rejects.toThrow();
+  });
+});
+
+describe('updatePlanningRanks', () => {
+  it('updates ranks for same-brand tickets', async () => {
+    await updatePlanningRanks('mentolder', [
+      { ticketId: 't2', planningRank: 0 },
+      { ticketId: 't1', planningRank: 1 },
+    ]);
+    const out = await getFeatureTickets('mentolder', 'f1');
+    expect(out.tickets.map(t => t.extId)).toEqual(['t2', 't1']);
+  });
+
+  it('rejects cross-brand ids', async () => {
+    await expect(updatePlanningRanks('korczewski', [{ ticketId: 't1', planningRank: 0 }]))
+      .rejects.toThrow();
+  });
+});
+
+describe('reparentTicket', () => {
+  it('moves a leaf to a new feature', async () => {
+    await reparentTicket('mentolder', 't1', 'f2');
+    const out = await getFeatureTickets('mentolder', 'f2');
+    expect(out.tickets.map(t => t.extId)).toContain('t1');
+  });
+
+  it('allows reparent to null (top-level)', async () => {
+    await reparentTicket('mentolder', 'f1', null);
+    // f1 becomes a parentless feature; getPortfolio surfaces it under "Ohne Produkt"
+    const portfolio = await getPortfolio('mentolder');
+    const loose = portfolio.products.find(p => p.extId === '__no_product__');
+    expect(loose?.features.some(f => f.extId === 'f1')).toBe(true);
+  });
+});
+
+describe('batchMutate', () => {
+  it('applies status to multiple tickets and reports per-id results', async () => {
+    const res = await batchMutate('mentolder', ['t4', 't5'], { status: 'done' });
+    expect(res.ok).toBe(true);
+    expect(res.results.filter(r => r.success)).toHaveLength(2);
+    const out = await getFeatureTickets('mentolder', 'f2');
+    expect(out.tickets.filter(t => t.status === 'done').map(t => t.extId).sort())
+      .toEqual(['t4', 't5']);
+  });
+});

--- a/website/src/lib/tickets/cockpit-db.test.ts
+++ b/website/src/lib/tickets/cockpit-db.test.ts
@@ -55,18 +55,22 @@ const rows: [string, string, string, string, string | null, string][] = [
 /** pg-mem-compatible 2-hop view approximating v_cockpit_rollup for the test fixture.
  *  The UNION ALL covers: (1) direct leaf children of containers; (2) grandchild
  *  leaves accessed through one intermediate feature node. This matches the
- *  test fixture depth. NOT used in production — production runs the RECURSIVE CTE. */
+ *  test fixture depth. NOT used in production — production runs the RECURSIVE CTE.
+ *
+ *  Mirrors the production view logic exactly:
+ *  - archived leaves excluded from total_leaves (cancelled/obsolete)
+ *  - qa_review counted in in_progress_leaves so every non-archived leaf falls in exactly one bucket */
 const PG_MEM_COMPAT_VIEW_SQL = `
   CREATE VIEW tickets.v_cockpit_rollup AS
   WITH all_leaves AS (
     SELECT l.parent_id AS container_id, l.status
     FROM tickets.tickets l
-    WHERE l.type IN ('task','bug')
+    WHERE l.type IN ('task','bug') AND l.status <> 'archived'
     UNION ALL
     SELECT mid.parent_id AS container_id, l2.status
     FROM tickets.tickets mid
     JOIN tickets.tickets l2 ON l2.parent_id = mid.id
-    WHERE l2.type IN ('task','bug') AND mid.type IN ('feature')
+    WHERE l2.type IN ('task','bug') AND l2.status <> 'archived' AND mid.type IN ('feature')
   ),
   agg AS (
     SELECT
@@ -74,7 +78,7 @@ const PG_MEM_COMPAT_VIEW_SQL = `
       COUNT(*)::int AS total_leaves,
       SUM(CASE WHEN status = 'done' THEN 1 ELSE 0 END)::int AS done_leaves,
       SUM(CASE WHEN status = 'blocked' THEN 1 ELSE 0 END)::int AS blocked_leaves,
-      SUM(CASE WHEN status IN ('in_progress','in_review') THEN 1 ELSE 0 END)::int AS in_progress_leaves,
+      SUM(CASE WHEN status IN ('in_progress','in_review','qa_review') THEN 1 ELSE 0 END)::int AS in_progress_leaves,
       SUM(CASE WHEN status IN ('triage','backlog','planning','plan_staged') THEN 1 ELSE 0 END)::int AS open_leaves
     FROM all_leaves
     GROUP BY container_id
@@ -206,5 +210,47 @@ describe('batchMutate', () => {
     const out = await getFeatureTickets('mentolder', 'f2');
     expect(out.tickets.filter(t => t.status === 'done').map(t => t.extId).sort())
       .toEqual(['t4', 't5']);
+  });
+});
+
+describe('rollup bucket invariant: done+blocked+inProgress+open === total', () => {
+  it('qa_review leaf counts in inProgress, archived leaf excluded from total', async () => {
+    // Add a qa_review leaf under f1 and an archived leaf under f1
+    await pool.query(
+      `INSERT INTO tickets.tickets
+         (id, external_id, brand, type, title, value_prop, priority, status, parent_id, planning_rank)
+       VALUES ($1,$1,'mentolder','task','QA task',null,'mittel','qa_review','f1',99)`,
+      ['tqa'],
+    );
+    await pool.query(
+      `INSERT INTO tickets.tickets
+         (id, external_id, brand, type, title, value_prop, priority, status, parent_id, planning_rank)
+       VALUES ($1,$1,'mentolder','task','Archived task',null,'mittel','archived','f1',100)`,
+      ['tarch'],
+    );
+
+    // Query the view directly for feature f1
+    const { rows } = await pool.query(
+      `SELECT total_leaves, done_leaves, blocked_leaves, in_progress_leaves, open_leaves
+         FROM tickets.v_cockpit_rollup WHERE container_id = 'f1'`,
+    );
+    expect(rows).toHaveLength(1);
+    const r = rows[0];
+    const total = Number(r.total_leaves);
+    const done = Number(r.done_leaves);
+    const blocked = Number(r.blocked_leaves);
+    const inProgress = Number(r.in_progress_leaves);
+    const open = Number(r.open_leaves);
+
+    // Invariant: buckets sum to total (archived tarch must NOT be in total)
+    expect(done + blocked + inProgress + open).toBe(total);
+
+    // Original f1 leaves: t1=done, t2=blocked → plus tqa=qa_review (inProgress)
+    // tarch=archived → excluded from total
+    expect(total).toBe(3);       // t1 + t2 + tqa (tarch excluded)
+    expect(done).toBe(1);        // t1
+    expect(blocked).toBe(1);     // t2
+    expect(inProgress).toBe(1);  // tqa (qa_review → inProgress bucket)
+    expect(open).toBe(0);
   });
 });

--- a/website/src/lib/tickets/cockpit-db.ts
+++ b/website/src/lib/tickets/cockpit-db.ts
@@ -150,8 +150,8 @@ export async function updatePlanningRanks(
         WHERE id = $2 AND brand = $3`,
       [u.planningRank, u.ticketId, brand],
     );
+    await audit(u.ticketId, 'planning_rank', u.planningRank);
   }
-  await audit('reorder', brand, { updates });
   return { ok: true };
 }
 
@@ -171,7 +171,7 @@ export async function reparentTicket(
     if (/cycle/i.test(String((e as Error).message))) throw new CycleError('would create a cycle');
     throw e;
   }
-  await audit('reparent', brand, { ticketId, newParentId });
+  await audit(ticketId, 'parent_id', newParentId);
   return { ok: true };
 }
 
@@ -183,43 +183,49 @@ export async function batchMutate(
   await assertSameBrand(brand, ticketIds);
   const results: BatchResult[] = [];
   for (const id of ticketIds) {
+    const client = await pool.connect();
     try {
+      await client.query('BEGIN');
       if (mutation.status != null) {
-        await pool.query(
+        await client.query(
           `UPDATE tickets.tickets SET status = $1, updated_at = now() WHERE id = $2 AND brand = $3`,
           [mutation.status, id, brand],
         );
       }
       if (mutation.priority != null) {
-        await pool.query(
+        await client.query(
           `UPDATE tickets.tickets SET priority = $1, updated_at = now() WHERE id = $2 AND brand = $3`,
           [mutation.priority, id, brand],
         );
       }
       if (mutation.parentId !== undefined) {
-        await pool.query(
+        await client.query(
           `UPDATE tickets.tickets SET parent_id = $1, updated_at = now() WHERE id = $2 AND brand = $3`,
           [mutation.parentId, id, brand],
         );
       }
+      await client.query('COMMIT');
       results.push({ ticketId: id, success: true });
     } catch (e) {
+      await client.query('ROLLBACK');
       results.push({ ticketId: id, success: false, error: String((e as Error).message) });
+    } finally {
+      client.release();
     }
+    // best-effort audit outside the ticket transaction so it never rolls back business logic
+    await audit(id, 'batch_mutate', mutation);
   }
-  await audit('batch_mutate', brand, { ticketIds, mutation });
   return { ok: true, results };
 }
 
-/** Best-effort audit using the real ticket_activity schema.
- *  Bulk cockpit mutations don't carry a single ticket_id, so we log to _updated field.
+/** Best-effort audit — one row per affected ticket.
  *  Never throws — audit failure must not roll back business logic. */
-async function audit(action: string, brand: string, changes: unknown): Promise<void> {
+async function audit(ticketId: string, field: string, newValue: unknown): Promise<void> {
   try {
     await pool.query(
       `INSERT INTO tickets.ticket_activity (ticket_id, actor_label, field, new_value)
-       VALUES (NULL, $1, $2, $3)`,
-      [brand, action, JSON.stringify(changes)],
+       VALUES ($1, 'cockpit', $2, $3::jsonb)`,
+      [ticketId, field, JSON.stringify(newValue)],
     );
-  } catch { /* table may differ in unit DB or ticket_id may be NOT NULL; audit is non-fatal */ }
+  } catch { /* best-effort; activity table may differ in unit DB */ }
 }

--- a/website/src/lib/tickets/cockpit-db.ts
+++ b/website/src/lib/tickets/cockpit-db.ts
@@ -1,0 +1,225 @@
+import { pool } from '../website-db';
+import type {
+  PortfolioPayload, ProductNode, FeatureNode,
+  FeatureTickets, TicketRow, RollupMetrics, HealthStatus,
+  BatchMutation, BatchResult,
+} from './cockpit-types';
+
+function toRollup(r: Record<string, unknown> | undefined): RollupMetrics {
+  return {
+    total: Number(r?.total_leaves ?? 0),
+    done: Number(r?.done_leaves ?? 0),
+    blocked: Number(r?.blocked_leaves ?? 0),
+    inProgress: Number(r?.in_progress_leaves ?? 0),
+    open: Number(r?.open_leaves ?? 0),
+    pctDone: Number(r?.pct_done ?? 0),
+  };
+}
+
+export async function getPortfolio(brand: string): Promise<PortfolioPayload> {
+  const { rows } = await pool.query(
+    `SELECT t.id, t.external_id, t.type, t.title, t.value_prop, t.priority,
+            t.parent_id, t.planning_rank,
+            r.total_leaves, r.done_leaves, r.blocked_leaves,
+            r.in_progress_leaves, r.open_leaves, r.pct_done, r.health
+       FROM tickets.tickets t
+       LEFT JOIN tickets.v_cockpit_rollup r ON r.container_id = t.id
+      WHERE t.brand = $1 AND t.type IN ('project', 'feature')
+      ORDER BY COALESCE(t.planning_rank, 2147483647), t.created_at`,
+    [brand],
+  );
+
+  const products: ProductNode[] = [];
+  const byId = new Map<string, ProductNode>();
+  const looseFeatures: FeatureNode[] = [];
+
+  for (const row of rows) {
+    if (row.type === 'project') {
+      const node: ProductNode = {
+        id: row.id, extId: row.external_id, title: row.title,
+        rollup: toRollup(row), features: [],
+      };
+      products.push(node);
+      byId.set(row.id, node);
+    }
+  }
+  for (const row of rows) {
+    if (row.type !== 'feature') continue;
+    const feature: FeatureNode = {
+      id: row.id, extId: row.external_id, title: row.title,
+      valueProp: row.value_prop ?? undefined,
+      priority: row.priority, health: (row.health ?? 'amber') as HealthStatus,
+      rollup: toRollup(row),
+    };
+    const parent = row.parent_id ? byId.get(row.parent_id) : undefined;
+    if (parent) parent.features.push(feature);
+    else looseFeatures.push(feature);
+  }
+
+  if (looseFeatures.length > 0) {
+    products.push({
+      id: '__no_product__', extId: '__no_product__', title: 'Ohne Produkt',
+      rollup: aggregate(looseFeatures), features: looseFeatures,
+    });
+  }
+  return { products };
+}
+
+function aggregate(features: FeatureNode[]): RollupMetrics {
+  const sum = features.reduce((a, f) => ({
+    total: a.total + f.rollup.total, done: a.done + f.rollup.done,
+    blocked: a.blocked + f.rollup.blocked, inProgress: a.inProgress + f.rollup.inProgress,
+    open: a.open + f.rollup.open, pctDone: 0,
+  }), { total: 0, done: 0, blocked: 0, inProgress: 0, open: 0, pctDone: 0 });
+  sum.pctDone = sum.total ? Math.round((100 * sum.done) / sum.total) : 0;
+  return sum;
+}
+
+export class NotFoundError extends Error {}
+
+export async function getFeatureTickets(brand: string, extId: string): Promise<FeatureTickets> {
+  const fr = await pool.query(
+    `SELECT t.id, t.external_id, t.type, t.title, t.value_prop, t.priority,
+            r.total_leaves, r.done_leaves, r.blocked_leaves,
+            r.in_progress_leaves, r.open_leaves, r.pct_done, r.health
+       FROM tickets.tickets t
+       LEFT JOIN tickets.v_cockpit_rollup r ON r.container_id = t.id
+      WHERE t.brand = $1 AND t.external_id = $2 AND t.type IN ('project', 'feature')`,
+    [brand, extId],
+  );
+  if (fr.rows.length === 0) throw new NotFoundError(`container ${extId} not found`);
+  const f = fr.rows[0];
+  const feature: FeatureNode = {
+    id: f.id, extId: f.external_id, title: f.title,
+    valueProp: f.value_prop ?? undefined, priority: f.priority,
+    health: (f.health ?? 'amber') as HealthStatus, rollup: toRollup(f),
+  };
+
+  // Two-hop flat union covers the expected hierarchy depth (feature → task/bug).
+  // Direct children of the feature + children-of-children (sub-features / sub-tasks).
+  // This avoids WITH RECURSIVE which is unsupported in the pg-mem unit-test adapter
+  // while remaining semantically correct for the expected ticket depth.
+  const tr = await pool.query(
+    `SELECT t.id, t.external_id, t.type, t.title, t.status, t.priority,
+            t.parent_id, t.planning_rank
+       FROM tickets.tickets t
+      WHERE t.brand = $2 AND t.type IN ('task', 'bug')
+        AND (
+          t.parent_id = $1
+          OR t.parent_id IN (SELECT id FROM tickets.tickets WHERE parent_id = $1)
+        )
+      ORDER BY COALESCE(t.planning_rank, 2147483647), t.external_id`,
+    [feature.id, brand],
+  );
+  const tickets: TicketRow[] = tr.rows.map((t: Record<string, unknown>) => ({
+    id: String(t.id), extId: String(t.external_id), title: String(t.title),
+    status: String(t.status), priority: String(t.priority), type: String(t.type),
+    parentId: t.parent_id ? String(t.parent_id) : undefined,
+    planningRank: t.planning_rank != null ? Number(t.planning_rank) : undefined,
+  }));
+  return { feature, tickets };
+}
+
+// ---------------------------------------------------------------------------
+// Mutation helpers
+// ---------------------------------------------------------------------------
+
+export class BrandMismatchError extends Error {}
+export class CycleError extends Error {}
+
+async function assertSameBrand(brand: string, ids: string[]): Promise<void> {
+  if (ids.length === 0) return;
+  // Build individual $N placeholders instead of ANY($1::text[]) to work around
+  // pg-mem's inconsistent array parameter binding in vitest environments.
+  const placeholders = ids.map((_, i) => `$${i + 1}`).join(', ');
+  const { rows } = await pool.query(
+    `SELECT id FROM tickets.tickets WHERE id IN (${placeholders}) AND brand <> $${ids.length + 1}`,
+    [...ids, brand],
+  );
+  if (rows.length > 0) throw new BrandMismatchError('ticket belongs to another brand');
+}
+
+export async function updatePlanningRanks(
+  brand: string,
+  updates: { ticketId: string; planningRank: number }[],
+): Promise<{ ok: true }> {
+  await assertSameBrand(brand, updates.map(u => u.ticketId));
+  for (const u of updates) {
+    await pool.query(
+      `UPDATE tickets.tickets SET planning_rank = $1, updated_at = now()
+        WHERE id = $2 AND brand = $3`,
+      [u.planningRank, u.ticketId, brand],
+    );
+  }
+  await audit('reorder', brand, { updates });
+  return { ok: true };
+}
+
+export async function reparentTicket(
+  brand: string,
+  ticketId: string,
+  newParentId: string | null,
+): Promise<{ ok: true }> {
+  await assertSameBrand(brand, newParentId ? [ticketId, newParentId] : [ticketId]);
+  try {
+    await pool.query(
+      `UPDATE tickets.tickets SET parent_id = $1, updated_at = now()
+        WHERE id = $2 AND brand = $3`,
+      [newParentId, ticketId, brand],
+    );
+  } catch (e) {
+    if (/cycle/i.test(String((e as Error).message))) throw new CycleError('would create a cycle');
+    throw e;
+  }
+  await audit('reparent', brand, { ticketId, newParentId });
+  return { ok: true };
+}
+
+export async function batchMutate(
+  brand: string,
+  ticketIds: string[],
+  mutation: BatchMutation,
+): Promise<{ ok: true; results: BatchResult[] }> {
+  await assertSameBrand(brand, ticketIds);
+  const results: BatchResult[] = [];
+  for (const id of ticketIds) {
+    try {
+      if (mutation.status != null) {
+        await pool.query(
+          `UPDATE tickets.tickets SET status = $1, updated_at = now() WHERE id = $2 AND brand = $3`,
+          [mutation.status, id, brand],
+        );
+      }
+      if (mutation.priority != null) {
+        await pool.query(
+          `UPDATE tickets.tickets SET priority = $1, updated_at = now() WHERE id = $2 AND brand = $3`,
+          [mutation.priority, id, brand],
+        );
+      }
+      if (mutation.parentId !== undefined) {
+        await pool.query(
+          `UPDATE tickets.tickets SET parent_id = $1, updated_at = now() WHERE id = $2 AND brand = $3`,
+          [mutation.parentId, id, brand],
+        );
+      }
+      results.push({ ticketId: id, success: true });
+    } catch (e) {
+      results.push({ ticketId: id, success: false, error: String((e as Error).message) });
+    }
+  }
+  await audit('batch_mutate', brand, { ticketIds, mutation });
+  return { ok: true, results };
+}
+
+/** Best-effort audit using the real ticket_activity schema.
+ *  Bulk cockpit mutations don't carry a single ticket_id, so we log to _updated field.
+ *  Never throws — audit failure must not roll back business logic. */
+async function audit(action: string, brand: string, changes: unknown): Promise<void> {
+  try {
+    await pool.query(
+      `INSERT INTO tickets.ticket_activity (ticket_id, actor_label, field, new_value)
+       VALUES (NULL, $1, $2, $3)`,
+      [brand, action, JSON.stringify(changes)],
+    );
+  } catch { /* table may differ in unit DB or ticket_id may be NOT NULL; audit is non-fatal */ }
+}

--- a/website/src/lib/tickets/cockpit-schema.test.ts
+++ b/website/src/lib/tickets/cockpit-schema.test.ts
@@ -27,4 +27,23 @@ describe('COCKPIT_ROLLUP_VIEW_SQL', () => {
     expect(COCKPIT_ROLLUP_VIEW_SQL.indexOf('LEFT JOIN agg'))
       .toBeLessThan(COCKPIT_ROLLUP_VIEW_SQL.indexOf("WHERE c.type IN ('project', 'feature')"));
   });
+
+  it('excludes archived leaves from total_leaves count (leaves CTE filters archived)', () => {
+    // archived tickets are cancelled/obsolete and must not contribute to progress math
+    expect(COCKPIT_ROLLUP_VIEW_SQL).toContain("d.status <> 'archived'");
+  });
+
+  it('includes qa_review in in_progress_leaves bucket', () => {
+    // qa_review must fall into exactly one bucket so done+blocked+inProgress+open == total
+    // Verify qa_review is in the FILTER for in_progress_leaves (same FILTER expression as in_review)
+    expect(COCKPIT_ROLLUP_VIEW_SQL).toMatch(
+      /FILTER\s*\(WHERE status IN\s*\([^)]*'in_review'[^)]*'qa_review'[^)]*\)\)/,
+    );
+    // qa_review must NOT appear in the open_leaves bucket
+    const openLeavesLine = COCKPIT_ROLLUP_VIEW_SQL
+      .split('\n')
+      .find(l => l.includes('open_leaves') && l.includes('FILTER'));
+    expect(openLeavesLine).toBeDefined();
+    expect(openLeavesLine).not.toContain('qa_review');
+  });
 });

--- a/website/src/lib/tickets/cockpit-schema.test.ts
+++ b/website/src/lib/tickets/cockpit-schema.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { COCKPIT_ROLLUP_VIEW_SQL } from './cockpit-schema';
+
+describe('COCKPIT_ROLLUP_VIEW_SQL', () => {
+  it('creates the rollup view idempotently', () => {
+    expect(COCKPIT_ROLLUP_VIEW_SQL).toContain('CREATE OR REPLACE VIEW tickets.v_cockpit_rollup');
+    expect(COCKPIT_ROLLUP_VIEW_SQL).toContain('WITH RECURSIVE');
+  });
+
+  it('aggregates all five leaf-count columns', () => {
+    for (const col of ['total_leaves','done_leaves','blocked_leaves','in_progress_leaves','open_leaves']) {
+      expect(COCKPIT_ROLLUP_VIEW_SQL).toContain(col);
+    }
+  });
+
+  it('computes pct_done and a three-branch health', () => {
+    expect(COCKPIT_ROLLUP_VIEW_SQL).toContain('pct_done');
+    expect(COCKPIT_ROLLUP_VIEW_SQL).toContain('blocked_leaves');
+    expect(COCKPIT_ROLLUP_VIEW_SQL).toContain("'red'");
+    expect(COCKPIT_ROLLUP_VIEW_SQL).toContain("'green'");
+    expect(COCKPIT_ROLLUP_VIEW_SQL).toContain("'amber'");
+  });
+
+  it('joins agg before WHERE (valid SQL order, no placeholder)', () => {
+    expect(COCKPIT_ROLLUP_VIEW_SQL).toContain('LEFT JOIN agg a ON a.container_id = c.id');
+    expect(COCKPIT_ROLLUP_VIEW_SQL).not.toContain('PLACEHOLDER');
+    expect(COCKPIT_ROLLUP_VIEW_SQL.indexOf('LEFT JOIN agg'))
+      .toBeLessThan(COCKPIT_ROLLUP_VIEW_SQL.indexOf("WHERE c.type IN ('project', 'feature')"));
+  });
+});

--- a/website/src/lib/tickets/cockpit-schema.ts
+++ b/website/src/lib/tickets/cockpit-schema.ts
@@ -1,0 +1,61 @@
+// v_cockpit_rollup — leaf-count rollup per container ticket (Produkt/Feature).
+// Recursive CTE walks the parent_id tree from every container down to its leaf
+// tickets (type 'task'|'bug' with NO children) and aggregates status counts.
+// Computed on read (no cache in MVP). Brand filtering is applied by callers,
+// not the view, so the view stays a simple per-container aggregate keyed by id.
+export const COCKPIT_ROLLUP_VIEW_SQL = `
+    CREATE OR REPLACE VIEW tickets.v_cockpit_rollup AS
+    WITH RECURSIVE descendants AS (
+      -- seed: every ticket is a descendant of itself (depth 0)
+      SELECT id AS container_id, id AS node_id, type, status
+      FROM tickets.tickets
+      UNION ALL
+      SELECT d.container_id, c.id AS node_id, c.type, c.status
+      FROM descendants d
+      JOIN tickets.tickets c ON c.parent_id = d.node_id
+    ),
+    leaves AS (
+      -- a leaf = task|bug with no children of its own
+      SELECT d.container_id, d.node_id, d.status
+      FROM descendants d
+      WHERE d.node_id <> d.container_id
+        AND d.type IN ('task', 'bug')
+        AND NOT EXISTS (
+          SELECT 1 FROM tickets.tickets ch WHERE ch.parent_id = d.node_id
+        )
+    ),
+    agg AS (
+      SELECT
+        container_id,
+        COUNT(*)::int AS total_leaves,
+        COUNT(*) FILTER (WHERE status = 'done')::int AS done_leaves,
+        COUNT(*) FILTER (WHERE status = 'blocked')::int AS blocked_leaves,
+        COUNT(*) FILTER (WHERE status IN ('in_progress', 'in_review'))::int AS in_progress_leaves,
+        COUNT(*) FILTER (WHERE status IN ('triage', 'backlog', 'planning', 'plan_staged'))::int AS open_leaves
+      FROM leaves
+      GROUP BY container_id
+    )
+    SELECT
+      c.id AS container_id,
+      COALESCE(a.total_leaves, 0)        AS total_leaves,
+      COALESCE(a.done_leaves, 0)         AS done_leaves,
+      COALESCE(a.blocked_leaves, 0)      AS blocked_leaves,
+      COALESCE(a.in_progress_leaves, 0)  AS in_progress_leaves,
+      COALESCE(a.open_leaves, 0)         AS open_leaves,
+      COALESCE(
+        ROUND(100.0 * a.done_leaves / NULLIF(a.total_leaves, 0))::int, 0
+      ) AS pct_done,
+      CASE
+        WHEN COALESCE(a.blocked_leaves, 0) > 0 THEN 'red'
+        WHEN COALESCE(a.total_leaves, 0) > 0
+             AND ROUND(100.0 * a.done_leaves / NULLIF(a.total_leaves, 0))::int = 100 THEN 'green'
+        ELSE 'amber'
+      END AS health
+    FROM tickets.tickets c
+    LEFT JOIN agg a ON a.container_id = c.id
+    WHERE c.type IN ('project', 'feature');
+`;
+
+export async function ensureCockpitViews(pool: import('pg').Pool): Promise<void> {
+  await pool.query(COCKPIT_ROLLUP_VIEW_SQL);
+}

--- a/website/src/lib/tickets/cockpit-schema.ts
+++ b/website/src/lib/tickets/cockpit-schema.ts
@@ -15,11 +15,13 @@ export const COCKPIT_ROLLUP_VIEW_SQL = `
       JOIN tickets.tickets c ON c.parent_id = d.node_id
     ),
     leaves AS (
-      -- a leaf = task|bug with no children of its own
+      -- a leaf = task|bug with no children of its own; archived leaves are excluded
+      -- (archived = cancelled/obsolete; must not count toward feature progress math)
       SELECT d.container_id, d.node_id, d.status
       FROM descendants d
       WHERE d.node_id <> d.container_id
         AND d.type IN ('task', 'bug')
+        AND d.status <> 'archived'
         AND NOT EXISTS (
           SELECT 1 FROM tickets.tickets ch WHERE ch.parent_id = d.node_id
         )
@@ -30,7 +32,7 @@ export const COCKPIT_ROLLUP_VIEW_SQL = `
         COUNT(*)::int AS total_leaves,
         COUNT(*) FILTER (WHERE status = 'done')::int AS done_leaves,
         COUNT(*) FILTER (WHERE status = 'blocked')::int AS blocked_leaves,
-        COUNT(*) FILTER (WHERE status IN ('in_progress', 'in_review'))::int AS in_progress_leaves,
+        COUNT(*) FILTER (WHERE status IN ('in_progress', 'in_review', 'qa_review'))::int AS in_progress_leaves,
         COUNT(*) FILTER (WHERE status IN ('triage', 'backlog', 'planning', 'plan_staged'))::int AS open_leaves
       FROM leaves
       GROUP BY container_id

--- a/website/src/lib/tickets/cockpit-types.ts
+++ b/website/src/lib/tickets/cockpit-types.ts
@@ -1,0 +1,66 @@
+// Single source of truth for the Cockpit API contract (spec §8).
+// Pure type declarations — no imports, no runtime code (S2-safe).
+
+export type HealthStatus = 'green' | 'amber' | 'red';
+
+export interface RollupMetrics {
+  total: number;
+  done: number;
+  blocked: number;
+  inProgress: number;
+  open: number;
+  pctDone: number;
+}
+
+export interface FeatureNode {
+  id: string;
+  extId: string;
+  title: string;
+  valueProp?: string;
+  priority: string;
+  health: HealthStatus;
+  rollup: RollupMetrics;
+}
+
+export interface ProductNode {
+  id: string;
+  extId: string;
+  title: string;
+  rollup: RollupMetrics;
+  features: FeatureNode[];
+}
+
+export interface PortfolioPayload {
+  products: ProductNode[];
+}
+
+export interface TicketRow {
+  id: string;
+  extId: string;
+  title: string;
+  status: string;
+  priority: string;
+  type: string;
+  parentId?: string;
+  planningRank?: number;
+  estimateMinutes?: number;
+  timeLoggedMinutes?: number;
+}
+
+export interface FeatureTickets {
+  feature: FeatureNode;
+  tickets: TicketRow[];
+}
+
+export interface BatchMutation {
+  status?: string;
+  priority?: string;
+  parentId?: string | null;
+  enqueue?: boolean;
+}
+
+export interface BatchResult {
+  ticketId: string;
+  success: boolean;
+  error?: string;
+}


### PR DESCRIPTION
## Projekt-Cockpit — P1 Foundation (Datenmodell, Rollup-View, cockpit-db)

Sub-Plan **1 von 4** des Batch `cockpit-2026-06-15` (Master: `projekt-cockpit`). **Muss zuerst mergen** — definiert Contract-Typen + Datenschicht, auf denen P2 (API) und P3 (Frontend) aufbauen.

Closes T000749.

### Was drin ist (Stage A — Backend Foundation)
- **`tickets.v_cockpit_rollup`** — rekursive-CTE-View, die Leaf-Counts pro Container (Produkt/Feature) aggregiert (`cockpit-schema.ts`, S1-sicher als eigenes Modul statt Inline in `tickets-db.ts`).
- **Datierte Migration** `scripts/migrations/2026-06-15-cockpit-rollup-view.sql` (verbatim-Spiegel der View-DDL).
- **Contract-Typen** `cockpit-types.ts` (PortfolioPayload, FeatureTickets, BatchMutation, …).
- **`cockpit-db.ts`** — reine Datenschicht: `getPortfolio`, `getFeatureTickets` (Reads) + `updatePlanningRanks`, `reparentTicket`, `batchMutate` (Mutationen), alle brand-scoped.
- Verdrahtung: `tickets-db.ts` +2 Zeilen (`ensureCockpitViews(pool)` im Schema-Bootstrap).

### Code-Review-Fixes (vor Merge eingearbeitet)
1. **Rollup-Buckets vollständig:** `qa_review` → `in_progress_leaves`, `archived` aus dem Rollup ausgeschlossen → `done+blocked+inProgress+open === total_leaves` (vorher fielen 2 Status in keinen Bucket → Progress-Mathematik stimmte nicht).
2. **Audit funktioniert:** `audit()` schrieb `ticket_id=NULL` gegen eine `NOT NULL`-Spalte → schlug immer still fehl. Jetzt eine Zeile pro Ticket mit echtem `ticket_id`.
3. **`batchMutate` atomar:** Multi-Feld-Updates pro Ticket in `BEGIN/COMMIT/ROLLBACK` — kein partieller Mutationszustand mehr.

### Bekannte Limitierung (relevant für P2/P3)
`getFeatureTickets` nutzt eine 2-Hop-Subtree-Query (statt `WITH RECURSIVE`) als pg-mem-Test-Kompromiss. Empirisch geprüft: aktuelle reale Baumtiefe unter Features = 0–1 Hop → deckt feature→task→subtask (2 Ebenen) ab. Der Headline-Rollup (View) nutzt echte Rekursion und ist bei beliebiger Tiefe korrekt. Bei Tiefe ≥3 könnte die gelistete Ticket-Menge < Rollup-Count sein (nicht erreichbar mit aktuellen Daten/normaler Cockpit-Nutzung).

### Verifikation (lokal, grün)
- `pnpm exec vitest run cockpit-db|cockpit-schema` → **16/16**
- `task test:all` → exit 0 · `task freshness:check` → exit 0 · `task quality:check` → 0 blocking
- `admin.ts` unberührt (677), `tickets-db.ts` ≤ 1106, neue `.ts` < Budget

### Post-Merge-Runbook (Deployer — View auf BEIDE Brand-DBs anwenden)
```bash
kubectl --context fleet -n workspace exec -i deploy/shared-db -- \
  psql -U postgres -d website < scripts/migrations/2026-06-15-cockpit-rollup-view.sql
kubectl --context fleet -n workspace-korczewski exec -i deploy/shared-db -- \
  psql -U postgres -d website < scripts/migrations/2026-06-15-cockpit-rollup-view.sql
```
(Idempotent — `CREATE OR REPLACE VIEW`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
