### PR TITLE
chore: improve git workflows — freshness auto-fix, ticket tag enforcement, branch cleanup, docs prefix [T000751]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,9 @@ jobs:
     name: Offline Tests (Manifests, Configs, Unit)
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: write
+      pull-requests: read
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
         with:
@@ -71,6 +74,35 @@ jobs:
           git show origin/main:docs/generated/api-map.json > /tmp/api-map-main.json 2>/dev/null || echo '{"generatedAt":"","endpoints":[]}' > /tmp/api-map-main.json
           node scripts/api-auth-check.mjs --regression --main-map /tmp/api-map-main.json
 
+      - name: Ensure freshness artifacts are up to date
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          task freshness:regenerate
+          if git diff --quiet; then
+            echo "✅ Freshness artifacts are up to date"
+            exit 0
+          fi
+          echo "⚠️ Freshness artifacts were stale — auto-regenerating and pushing to PR branch"
+          # Use GH_PAT for git push so the push triggers a new CI run
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git stash
+          git fetch origin "${{ github.head_ref }}"
+          git checkout "${{ github.head_ref }}"
+          if git stash pop; then
+            git add -A
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git commit -m "chore: regenerate freshness artifacts"
+            git push origin "HEAD:${{ github.head_ref }}" 2>/dev/null || true
+            echo "✅ Freshness fix pushed — new CI run will validate"
+          else
+            echo "⚠️ Could not auto-fix (fork PR or no permission). Fix manually: task freshness:regenerate"
+          fi
+        # Fall through so freshness:check below still validates.
+        # On successful push above, this CI run gets cancelled by concurrency;
+        # the new run on the updated PR head will pass freshness:check.
       - name: Verify generated artifacts are fresh
         run: task freshness:check
 
@@ -189,3 +221,13 @@ jobs:
           subjectPatternError: |
             The subject must be between 1 and 200 characters.
             If your PR title includes ticket references like [T000436], that counts toward the limit.
+      - name: Validate ticket tag [T000XXX] in PR title
+        run: |
+          echo "PR title: ${{ github.event.pull_request.title }}"
+          if echo "${{ github.event.pull_request.title }}" | grep -qP '\[T\d+\]'; then
+            echo "✅ Ticket tag found"
+          else
+            echo "❌ PR title must contain a ticket tag like [T000123]"
+            echo "   Example: feat(scope): add feature X [T000123]"
+            exit 1
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,7 @@ website/.astro/
 
 # ── Worktrees ───────────────────────────────────
 .worktrees/
+tmp/
 
 # ── Claude Code local state (settings + hookify rules) ──
 .claude/*.local.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@ task feature:deploy                # fan-out to both brands
 
 ## Workflow
 
-- Branch naming: `feature/*`, `fix/*`, `chore/*`
+- Branch naming: `feature/*`, `fix/*`, `chore/*`, `docs/*`
 - All changes via PRs → squash-and-merge. No direct pushes to `main`.
 - For structured work: invoke `dev-flow-plan` skill (plan → push) then `dev-flow-execute` (implement → PR → deploy).
 - CI must be green: `task test:all` before commit.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,8 @@ Alle Änderungen gehen durch Pull Requests. Direkte Pushes auf `main` sind nicht
 |--------------|----------------------------------|
 | `feature/*`  | Neue Funktionalität              |
 | `fix/*`      | Fehlerbehebungen                 |
-| `chore/*`    | Refactoring, Doku, Dependencies, CI/CD |
+| `chore/*`    | Refactoring, Dependencies, CI/CD |
+| `docs/*`     | Reine Dokumentations-Änderungen  |
 
 ### Standard-Workflow (`dev-flow`)
 
@@ -36,6 +37,11 @@ task workspace:validate    # Dry-Run der Manifeste falls relevant
 task test:all              # Offline-Suite
 git push -u origin feature/mein-feature
 gh pr create --fill
+```
+
+**Pre-Push-Gate umgehen** (nur im Notfall):
+```bash
+SKIP_CI_CHECK=1 git push   # überspringt task quality:check
 ```
 
 ### Lokale Entwicklung

--- a/scripts/agent-lock.sh
+++ b/scripts/agent-lock.sh
@@ -180,6 +180,14 @@ cmd_reap() {
   git worktree prune 2>/dev/null || true
   # 2b) prune stale remote-tracking refs (branches deleted on GitHub after merge)
   git fetch --prune origin 2>/dev/null || true
+  # 2c) delete local branches that were squash-merged into main (upstream gone)
+  for br in $(git branch --merged main 2>/dev/null | sed 's/^[* ]*//' | grep -v '^main$'); do
+    # only delete if the upstream tracking branch is gone
+    upstream="$(git rev-parse --abbrev-ref "$br@{upstream}" 2>/dev/null)" || true
+    if [ -z "$upstream" ] || ! git show-ref --verify --quiet "refs/remotes/$upstream" 2>/dev/null; then
+      git branch -d "$br" 2>/dev/null || true
+    fi
+  done
   # 3) drop reapable (clearly dead) locks
   if [ -d "$d" ]; then
     local f


### PR DESCRIPTION
## Changes

### 1. Freshness commit noise elimination
CI now auto-regenerates freshness artifacts and pushes them to the PR branch when stale. This ensures the squash-merge commit always contains correct freshness, eliminating the `chore: auto-regenerate freshness artifacts` commits on `main` (~115 and counting).

- `ci.yml`: New `Ensure freshness artifacts are up to date` step auto-fixes and pushes to PR branch
- Uses GH_PAT so the push triggers a fresh CI run; concurrency cancels the stale one
- Falls back gracefully for fork PRs (cannot push)

### 2. Ticket tag `[T000XXX]` enforcement in CI
- `ci.yml` `commit-lint` job: new step validates PR titles contain `[T\d+]`
- Fails CI if missing, preventing untagged PRs from auto-merging

### 3. Stale local branch cleanup
- `agent-lock.sh reap`: now deletes local branches that were squash-merged into `main` whose upstream tracking ref is gone (auto-merged PRs use `--delete-branch`)

### 4. `SKIP_CI_CHECK=1` documented
- `CONTRIBUTING.md`: Added bypass documentation for rapid iteration

### 5. `docs/*` branch prefix
- `AGENTS.md` + `CONTRIBUTING.md`: Added `docs/*` as a valid branch prefix for documentation-only changes