### PR TITLE
fix(ticket.sh): create/add-pr-link NOT NULL constraint violations [T000783]

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -266,6 +266,7 @@ tasks:
       - task: test:unit:plan-frontmatter-hook
       - task: test:unit:mishap-tracker
       - task: test:unit:ticket-add-pr-link
+      - task: test:unit:ticket-create
       - task: test:unit:ticket-grill
       - task: test:unit:worktree-create
       - task: test:unit:test-tasks-node-deps
@@ -430,6 +431,11 @@ tasks:
     internal: true
     cmds:
       - ./tests/unit/lib/bats-core/bin/bats tests/unit/ticket-add-pr-link.bats
+
+  test:unit:ticket-create:
+    internal: true
+    cmds:
+      - ./tests/unit/lib/bats-core/bin/bats tests/unit/ticket-create.bats
 
   test:unit:ticket-grill:
     internal: true

--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 431,
+      "file_count": 432,
       "files": [
         "tests/.gitignore",
         "tests/batch/batch-gap-analysis.bats",
@@ -405,6 +405,7 @@
         "tests/unit/test_art_library_manifest.bats",
         "tests/unit/test_helper.bash",
         "tests/unit/ticket-add-pr-link.bats",
+        "tests/unit/ticket-create.bats",
         "tests/unit/ticket-external-id-sequence.bats",
         "tests/unit/ticket-graph.bats",
         "tests/unit/ticket-grill.bats",

--- a/docs/generated/api-map.json
+++ b/docs/generated/api-map.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-15T08:03:25.591Z",
+  "generatedAt": "2026-06-15T08:13:48.357Z",
   "endpoints": [
     {
       "path": "/api/admin/angebote/save",

--- a/docs/generated/api-map.json
+++ b/docs/generated/api-map.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-15T08:13:48.357Z",
+  "generatedAt": "2026-06-15T08:17:06.224Z",
   "endpoints": [
     {
       "path": "/api/admin/angebote/save",

--- a/docs/generated/api-surface.md
+++ b/docs/generated/api-surface.md
@@ -1,6 +1,6 @@
 # API Surface Map
 
-> Generated at 2026-06-15T08:13:48.357Z
+> Generated at 2026-06-15T08:17:06.224Z
 
 | Path | Methods | Auth | File |
 |------|---------|------|------|

--- a/docs/generated/api-surface.md
+++ b/docs/generated/api-surface.md
@@ -1,6 +1,6 @@
 # API Surface Map
 
-> Generated at 2026-06-15T08:03:25.591Z
+> Generated at 2026-06-15T08:13:48.357Z
 
 | Path | Methods | Auth | File |
 |------|---------|------|------|

--- a/docs/generated/blast-radius.md
+++ b/docs/generated/blast-radius.md
@@ -1,5 +1,5 @@
 # Blast-Radius-Report
-> Generated: 2026-06-15T08:13:48.395Z
+> Generated: 2026-06-15T08:17:06.322Z
 > Nodes: 74 | Edges: 1385 | Isolated: 2
 
 ## Ranking (transitive Abhängige)

--- a/docs/generated/blast-radius.md
+++ b/docs/generated/blast-radius.md
@@ -1,5 +1,5 @@
 # Blast-Radius-Report
-> Generated: 2026-06-15T08:03:25.693Z
+> Generated: 2026-06-15T08:13:48.395Z
 > Nodes: 74 | Edges: 1385 | Isolated: 2
 
 ## Ranking (transitive Abhängige)

--- a/docs/generated/graph.json
+++ b/docs/generated/graph.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-15T08:13:48.292Z",
+  "generatedAt": "2026-06-15T08:17:06.142Z",
   "nodes": [
     {
       "id": "admin-actions-cleanup",

--- a/docs/generated/graph.json
+++ b/docs/generated/graph.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-15T08:03:25.506Z",
+  "generatedAt": "2026-06-15T08:13:48.292Z",
   "nodes": [
     {
       "id": "admin-actions-cleanup",

--- a/k3d/docs-content-built/architecture/index.html
+++ b/k3d/docs-content-built/architecture/index.html
@@ -178,7 +178,7 @@
 <body>
   <div class="header">
     <h1>⬡ Architektur — Living Docs</h1>
-    <span class="meta">Generiert: 2026-06-15T08:03:25.637Z</span>
+    <span class="meta">Generiert: 2026-06-15T08:13:46.553Z</span>
   </div>
 
   <div class="stats">

--- a/k3d/docs-content-built/architecture/index.html
+++ b/k3d/docs-content-built/architecture/index.html
@@ -178,7 +178,7 @@
 <body>
   <div class="header">
     <h1>⬡ Architektur — Living Docs</h1>
-    <span class="meta">Generiert: 2026-06-15T08:13:46.553Z</span>
+    <span class="meta">Generiert: 2026-06-15T08:17:06.272Z</span>
   </div>
 
   <div class="stats">

--- a/scripts/lib/ticket-links.sh
+++ b/scripts/lib/ticket-links.sh
@@ -2,9 +2,11 @@
 # scripts/lib/ticket-links.sh
 # Pure helper sourced by ticket.sh — declares cmd_add_pr_link only.
 # No top-level side effects, no back-imports.
-# Schema: tickets.ticket_links (from_id text, kind text, pr_number int, ...)
-# getShipped() in factory-floor.ts reads: WHERE kind = 'pr' AND pr_number IS NOT NULL
-#   and joins l.from_id = t.id
+# Schema: tickets.ticket_links (from_id uuid NOT NULL, to_id uuid NOT NULL,
+#   kind text, pr_number int, UNIQUE(from_id, to_id, kind)). A PR has no target
+#   ticket, so we self-link (to_id = from_id) to satisfy the NOT NULL FK.
+# Readers (delivery-metrics, getShipped) filter WHERE kind = 'pr'
+#   AND pr_number IS NOT NULL and join l.from_id = t.id (to_id is ignored).
 
 cmd_add_pr_link() {
   local id="" pr=""
@@ -37,16 +39,16 @@ EOF
     exit 1
   fi
 
-  # Idempotent: skip if a pr-link for this ticket+pr already exists.
+  # Idempotent: to_id is NOT NULL (FK to tickets), and a PR has no target
+  # ticket, so we self-link (to_id = from_id) — same pattern as transition.ts.
+  # ON CONFLICT (from_id, to_id, kind) keeps one 'pr' link per ticket, updated
+  # to the latest PR number.
   _exec_sql "$pod" \
     -v uuid="$uuid" \
     -v pr="$pr" <<'EOF' >/dev/null
-INSERT INTO tickets.ticket_links (from_id, kind, pr_number)
-SELECT :'uuid', 'pr', :'pr'::integer
-WHERE NOT EXISTS (
-  SELECT 1 FROM tickets.ticket_links
-   WHERE from_id = :'uuid' AND kind = 'pr' AND pr_number = :'pr'::integer
-);
+INSERT INTO tickets.ticket_links (from_id, to_id, kind, pr_number)
+VALUES (:'uuid', :'uuid', 'pr', :'pr'::integer)
+ON CONFLICT (from_id, to_id, kind) DO UPDATE SET pr_number = EXCLUDED.pr_number;
 EOF
 
   echo "PR link #$pr recorded for ticket $id"

--- a/scripts/ticket.sh
+++ b/scripts/ticket.sh
@@ -86,7 +86,7 @@ cmd_create() {
     -v attn="$attention_mode" \
     -v is_test="$is_test" <<'EOF'
 INSERT INTO tickets.tickets (type, brand, title, description, status, severity, priority, attention_mode, is_test_data)
-VALUES (:'type', :'brand', :'title', :'desc', :'status', NULLIF(:'sev', ''), :'prio', NULLIF(:'attn', ''), :'is_test'::boolean)
+VALUES (:'type', :'brand', :'title', :'desc', :'status', NULLIF(:'sev', ''), :'prio', COALESCE(NULLIF(:'attn', ''), 'auto'), :'is_test'::boolean)
 RETURNING external_id || '|' || id;
 EOF
 )

--- a/tests/unit/ticket-add-pr-link.bats
+++ b/tests/unit/ticket-add-pr-link.bats
@@ -41,6 +41,9 @@ teardown() { rm -rf "$MOCKDIR"; }
   grep -q "INSERT INTO tickets.ticket_links" "$CAP"
   grep -q "kind" "$CAP"
   grep -qi "pr_number" "$CAP"
+  # to_id is NOT NULL (FK) — the INSERT MUST set it (self-link to_id = from_id),
+  # otherwise it violates the not-null constraint at runtime.
+  grep -q "to_id" "$CAP"
   # MUST NOT reference the non-existent columns from the spec snippet
   ! grep -qE "\bref\b|\burl\b" "$CAP"
 }

--- a/tests/unit/ticket-create.bats
+++ b/tests/unit/ticket-create.bats
@@ -1,0 +1,45 @@
+#!/usr/bin/env bats
+# Offline test: `ticket.sh create` builds an INSERT into tickets.tickets that
+# never sets attention_mode = NULL (the column is NOT NULL; its 'auto' default
+# is bypassed by an explicit NULL). Verifies arg-parsing + SQL shape WITHOUT a
+# live cluster (kubectl is mocked).
+
+setup() {
+  TICKET="$BATS_TEST_DIRNAME/../../scripts/ticket.sh"
+  MOCKDIR="$(mktemp -d)"
+  CAP="$MOCKDIR/captured.sql"
+  cat > "$MOCKDIR/kubectl" <<EOF
+#!/usr/bin/env bash
+if [[ "\$*" == *"get pod"* ]]; then echo "pod/shared-db-0"; exit 0; fi
+if [[ "\$*" == *"exec"* ]]; then cat >> "$CAP"; echo "T000999|fake-uuid-1234"; exit 0; fi
+exit 0
+EOF
+  chmod +x "$MOCKDIR/kubectl"
+  PATH="$MOCKDIR:$PATH"
+  export PATH CAP
+}
+
+teardown() { rm -rf "$MOCKDIR"; }
+
+@test "create requires --type, --title and --description" {
+  run bash "$TICKET" create --type bug --title "x"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"required"* ]]
+}
+
+@test "create never inserts a NULL attention_mode (defaults to 'auto')" {
+  run bash "$TICKET" create --type bug --title "T" --description "D"
+  [ "$status" -eq 0 ]
+  grep -q "INSERT INTO tickets.tickets" "$CAP"
+  grep -q "attention_mode" "$CAP"
+  # The attention_mode value must coalesce an empty/missing value to 'auto'
+  # so the NOT NULL constraint is satisfied without an explicit --attention-mode.
+  grep -qiE "COALESCE\(NULLIF\(:'attn', ''\), 'auto'\)" "$CAP"
+}
+
+@test "create passes an explicit --attention-mode through" {
+  run bash "$TICKET" create --type bug --title "T" --description "D" --attention-mode ai_ready
+  [ "$status" -eq 0 ]
+  # The COALESCE still wraps the bind param; the value is supplied via -v attn=.
+  grep -qiE "COALESCE\(NULLIF\(:'attn', ''\), 'auto'\)" "$CAP"
+}


### PR DESCRIPTION
## Two ticket.sh DB-layer bugs (commands failed at runtime)

Both surfaced during cockpit wave-2 (the Shipped-tab PR link + a tracking ticket couldn't be written).

1. **`cmd_create` → `attention_mode` NOT NULL violation** (`scripts/ticket.sh`): the INSERT passed `NULLIF(:'attn','')`, so without `--attention-mode` it inserted `NULL`. The column is NOT NULL; its `'auto'` default is bypassed by an explicit NULL. → `COALESCE(NULLIF(:'attn',''), 'auto')`.
2. **`cmd_add_pr_link` → `to_id` NOT NULL violation** (`scripts/lib/ticket-links.sh`): the INSERT omitted `to_id` (NOT NULL FK). A PR has no target ticket → self-link `to_id = from_id` with `ON CONFLICT (from_id,to_id,kind) DO UPDATE`, matching `transition.ts`. Header comment corrected (it wrongly claimed `from_id text`).

**Verified live** against the fleet DB: `create` filed T000782/T000783; `add-pr-link` backfilled PR links #1695/#1697 onto T000750/T000751 (self-link, kind='pr').

**Tests:** new offline bats coverage — `ticket-create.bats` (asserts COALESCE→'auto', never NULL) + `to_id` assertion in `ticket-add-pr-link.bats`; both wired into `task test:unit` (coverage-guard green, 78 bats).

Closes T000783.