### PR TITLE
chore(ci): add synchronize trigger to auto-enable-automerge workflow [T000785]

### DIFF
--- a/.github/workflows/auto-enable-automerge.yml
+++ b/.github/workflows/auto-enable-automerge.yml
@@ -13,7 +13,7 @@ name: Auto-enable Auto-Merge
 on:
   pull_request:
     branches: [main]
-    types: [opened, ready_for_review, reopened]
+    types: [opened, synchronize, ready_for_review, reopened]
 
 concurrency:
   group: auto-enable-automerge-${{ github.event.pull_request.number }}


### PR DESCRIPTION
Adds `synchronize` to the trigger events in `auto-enable-automerge.yml` so auto-merge is re-enabled on every push to a PR. This closes a reliability gap: if the initial enablement fails (transient error, expired PAT, etc.), subsequent pushes will re-enable auto-merge automatically.