### PR TITLE
fix(bug-report): stamp is_test_data on E2E-created tickets [T000760]

### DIFF
--- a/website/src/lib/website-db.ts
+++ b/website/src/lib/website-db.ts
@@ -673,16 +673,18 @@ export async function insertBugTicket(params: {
   url?: string;
   brand: string;
   screenshots?: string[];
+  isTestData?: boolean;
 }): Promise<{ id: string; ticketId: string } | null> {
   await initTicketsSchema();
   const { rows } = await pool.query<{ id: string; external_id: string }>(
     `INSERT INTO tickets.tickets
-       (type, brand, title, description, url, reporter_email, status)
-     VALUES ('bug', $1, $2, $3, $4, $5, 'triage')
+       (type, brand, title, description, url, reporter_email, status, is_test_data)
+     VALUES ('bug', $1, $2, $3, $4, $5, 'triage', $6)
      RETURNING id, external_id`,
     [params.brand,
      params.description.slice(0, 200),
-     params.description, params.url ?? null, params.reporterEmail]
+     params.description, params.url ?? null, params.reporterEmail,
+     params.isTestData ?? false]
   );
   if (rows.length === 0) return null;
   const newId = rows[0].id;

--- a/website/src/pages/api/bug-report.ts
+++ b/website/src/pages/api/bug-report.ts
@@ -74,6 +74,7 @@ export const POST: APIRoute = async ({ request }) => {
       screenshotDataUrls.push(`data:${file.type};base64,${base64}`);
     }
 
+    const isTestData = isE2ETestRequest(request);
     const inserted = await insertBugTicket({
       category,
       reporterEmail: email,
@@ -81,6 +82,7 @@ export const POST: APIRoute = async ({ request }) => {
       url,
       brand: BRAND,
       screenshots: screenshotDataUrls.length > 0 ? screenshotDataUrls : undefined,
+      isTestData,
     });
     if (!inserted) {
       return jsonError('Ticket konnte nicht erstellt werden.', 500);
@@ -104,7 +106,7 @@ export const POST: APIRoute = async ({ request }) => {
         url,
         brand: BRAND,
       },
-      isTestData: isE2ETestRequest(request),
+      isTestData,
     });
 
     return new Response(


### PR DESCRIPTION
## Description

The `insertBugTicket` API endpoint was not stamping `is_test_data=true` on tickets created by E2E tests (FA-26), even though `createInboxItem` already supports it. This caused test run tickets to accumulate in the admin inbox as stale entries.

## Changes

- `website/src/lib/website-db.ts`: Added `isTestData` parameter to `insertBugTicket()`, writes it to the `is_test_data` column
- `website/src/pages/api/bug-report.ts`: Passes `isE2ETestRequest(request)` to `insertBugTicket()`

## Related

Fixes T000760 — E2E test runner creates duplicate generic tickets without page/test context