### PR TITLE
chore: regenerate freshness artifacts before build in release workflows [T000751]

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -29,10 +29,21 @@ jobs:
         with:
           node-version: '22'
 
-      - name: Install root deps and build docs
+      - uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611  # v2.0.0
+        with:
+          version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install root deps
+        run: npm install
+
+      - name: Regenerate freshness artifacts before build
         run: |
-          npm install
-          node scripts/build-docs.mjs
+          bash scripts/ci-dummy-secrets.sh
+          task freshness:regenerate
+
+      - name: Build docs
+        run: node scripts/build-docs.mjs
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3

--- a/.github/workflows/build-website.yml
+++ b/.github/workflows/build-website.yml
@@ -21,6 +21,21 @@ jobs:
         with:
           submodules: recursive
 
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444  # v5
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611  # v2.0.0
+        with:
+          version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Regenerate freshness artifacts before build
+        run: |
+          bash scripts/ci-dummy-secrets.sh
+          task freshness:regenerate
+
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
         with:

--- a/docs/generated/api-map.json
+++ b/docs/generated/api-map.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-15T14:53:19.049Z",
+  "generatedAt": "2026-06-15T15:04:05.862Z",
   "endpoints": [
     {
       "path": "/api/admin/angebote/save",

--- a/docs/generated/api-map.json
+++ b/docs/generated/api-map.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-15T15:04:05.862Z",
+  "generatedAt": "2026-06-15T15:11:26.555Z",
   "endpoints": [
     {
       "path": "/api/admin/angebote/save",

--- a/docs/generated/api-surface.md
+++ b/docs/generated/api-surface.md
@@ -1,6 +1,6 @@
 # API Surface Map
 
-> Generated at 2026-06-15T15:04:05.862Z
+> Generated at 2026-06-15T15:11:26.555Z
 
 | Path | Methods | Auth | File |
 |------|---------|------|------|

--- a/docs/generated/api-surface.md
+++ b/docs/generated/api-surface.md
@@ -1,6 +1,6 @@
 # API Surface Map
 
-> Generated at 2026-06-15T14:53:19.049Z
+> Generated at 2026-06-15T15:04:05.862Z
 
 | Path | Methods | Auth | File |
 |------|---------|------|------|

--- a/docs/generated/blast-radius.md
+++ b/docs/generated/blast-radius.md
@@ -1,5 +1,5 @@
 # Blast-Radius-Report
-> Generated: 2026-06-15T15:04:05.960Z
+> Generated: 2026-06-15T15:11:26.656Z
 > Nodes: 74 | Edges: 1385 | Isolated: 2
 
 ## Ranking (transitive Abhängige)

--- a/docs/generated/blast-radius.md
+++ b/docs/generated/blast-radius.md
@@ -1,5 +1,5 @@
 # Blast-Radius-Report
-> Generated: 2026-06-15T14:53:19.153Z
+> Generated: 2026-06-15T15:04:05.960Z
 > Nodes: 74 | Edges: 1385 | Isolated: 2
 
 ## Ranking (transitive Abhängige)

--- a/docs/generated/graph.json
+++ b/docs/generated/graph.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-15T15:04:05.772Z",
+  "generatedAt": "2026-06-15T15:11:26.471Z",
   "nodes": [
     {
       "id": "admin-actions-cleanup",

--- a/docs/generated/graph.json
+++ b/docs/generated/graph.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-15T14:53:18.959Z",
+  "generatedAt": "2026-06-15T15:04:05.772Z",
   "nodes": [
     {
       "id": "admin-actions-cleanup",

--- a/k3d/docs-content-built/architecture/index.html
+++ b/k3d/docs-content-built/architecture/index.html
@@ -178,7 +178,7 @@
 <body>
   <div class="header">
     <h1>⬡ Architektur — Living Docs</h1>
-    <span class="meta">Generiert: 2026-06-15T14:53:19.097Z</span>
+    <span class="meta">Generiert: 2026-06-15T15:04:05.909Z</span>
   </div>
 
   <div class="stats">

--- a/k3d/docs-content-built/architecture/index.html
+++ b/k3d/docs-content-built/architecture/index.html
@@ -178,7 +178,7 @@
 <body>
   <div class="header">
     <h1>⬡ Architektur — Living Docs</h1>
-    <span class="meta">Generiert: 2026-06-15T15:04:05.909Z</span>
+    <span class="meta">Generiert: 2026-06-15T15:11:26.602Z</span>
   </div>
 
   <div class="stats">


### PR DESCRIPTION
**Problem:** `freshness-regen.yml` und Build-Workflows (`build-website.yml`, `build-docs.yml`) laufen parallel bei Push auf `main`. Der Build bekommt stale Freshness-Artefakte, weil `freshness-regen.yml` erst danach committed.

**Lösung:** Beide Build-Workflows führen jetzt `task freshness:regenerate` vor dem eigentlichen Build aus:

- `build-website.yml`: `freshness:regenerate` vor Docker-Build (setup-node + setup-task hinzugefügt)
- `build-docs.yml`: `freshness:regenerate` vor docs-Build (setup-task + Schritt hinzugefügt)

Nach Merge wird Release Please #1711 automatisch neu evaluiert und der Release baut mit frischen Freshness-Artefakten.