### PR TITLE
chore(deps): regenerate npm lockfile after removing yaml overrides [T000829]

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -11696,6 +11696,18 @@
       "integrity": "sha512-3Zjgh+8b5fhRJBQZoy+zbVKpAQGLyka0MPgW3zruTF4dFFJ8Fqcfu9YsAvi/rvdcaTeWG3MkbZv4WKxAn/84Lg==",
       "license": "MIT"
     },
+    "node_modules/yaml-language-server/node_modules/yaml": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.1.tgz",
+      "integrity": "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/yargs": {
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",


### PR DESCRIPTION
## Summary

PR #1719 removed the `yaml` override from `package.json` (moved to `pnpm-workspace.yaml`) but did not regenerate the `package-lock.json`.

Without the override, `yaml-language-server@1.20.0` requires its own nested `yaml@2.7.1`, which was missing from the lockfile. This caused `npm ci` to fail on CI with:

> ```
> npm error Missing: yaml@2.7.1 from lock file
> ```

## Change

`website/package-lock.json` — added nested `yaml-language-server/node_modules/yaml@2.7.1` entry (12 lines).

## Verification

- [x] `npm ci --prefix website` passes locally
- [x] Lockfile diff shows only the expected addition

Closes T000829