### PR TITLE
feat(videovault): Phase 2c — server-side split backend [T-2c-1..T-2c-4]

### DIFF
--- a/.claude/skills/dev-flow-execute/SKILL.md
+++ b/.claude/skills/dev-flow-execute/SKILL.md
@@ -133,15 +133,17 @@ Starte danach **für jedes Element aus `$BATCH_JSON`** einen Subagenten via `Age
 - `subagent_type: general-purpose`
 - **Prompt** (Kontext-Injektion, da der Subagent KEINEN Kontext hat):
   ```
+  /goal Finish dev-flow-execute and merge the PR cleanly.
+
   Du implementierst Ticket <TICKET_ID> im Worktree <WT_PATH> (Branch: <BRANCH>).
   Plan-Datei: <WT_PATH>/<PLAN_FILE>.
-  
+
   Führe aus: Schritt 1.4 bis Schritt 7.5 aus dev-flow-execute (Single-Modus) —
   d.h. Doppelarbeit-Guard, Ticket in_progress, Implementierung via superpowers:executing-plans,
   lokale Verifikation (task test:changed + freshness:check), Code-Review-Gate,
   PR öffnen, CI-Fix-Schleife, Auto-Merge, Ticket abschließen, Plan archivieren,
   Worktree bereinigen.
-  
+
   Erstelle KEINEN weiteren Batch-Modus. TICKET_ID=$<TICKET_ID>.
   Hauptrepo: <MAIN_REPO>.
   ```
@@ -332,13 +334,14 @@ Spawne über das `Agent`/`Task`-Tool einen Subagenten, **provisioniert gemäß**
   **Neue `.bats`-Datei nur wenn:** das zu testende Modul hat bisher NULL Testabdeckung UND kein thematisch verwandter Dateiname existiert. In allen anderen Fällen: `@test`-Block in die passende bestehende Datei einfügen. Ziel: die Gesamtzahl der `.bats`-Dateien in `tests/unit/` sinkt oder bleibt konstant.
 
 - **Auftrag:**
+  - **/goal: Finish dev-flow-execute and merge the PR cleanly.**
   - *Feature:* Rufe `superpowers:executing-plans` (in-context, KEIN weiterer Agenten-Fan-out) + `test-driven-development` auf und arbeite den Plan vollständig ab. Aktualisiere nach jedem Meilenstein die Checkbox im Plan (`- [ ] M1` → `- [x] M1`), committe und pushe.
   - *Fix:* Verifiziere zuerst, dass ein failing Test existiert, dann nach Rot-Grün-Prinzip bis grün.
    - Bei Kompilier-/Testfehlern: diagnostiziere und fixe systematisch (Logs lesen, Fehler eingrenzen, Hypothese testen, fixen, Re-Test).
-  - Falls Delegations-Tools `finishing-a-development-branch` aufrufen: Menü mit `--no-menu` / `MENU=skip` unterdrücken.
-  - Erstelle KEINEN PR und merge nicht — stoppe nach grünen Tests und gib eine Zusammenfassung zurück (geänderte Dateien, Test-Status, offene Punkte).
+  - Erstelle einen PR, durchlaufe die CI-Fix-Schleife bis grün, und merge via Auto-Merge.
+  - Schließe das Ticket ab und archiviere den Plan.
 
-Nimm das Ergebnis entgegen und mach bei Schritt 3 (unabhängige Verifikation) weiter.
+Der Subagent führt den gesamten dev-flow-execute-Pipeline selbstständig bis zum Merge durch. Du wirst per `<task-notification>` benachrichtigt, wenn er fertig ist. Fahre dann mit Schritt 8 (Post-Merge Deploy & Verify) fort.
 
 ---
 

--- a/.claude/skills/references/subagent-provisioning.md
+++ b/.claude/skills/references/subagent-provisioning.md
@@ -28,7 +28,7 @@ Im Zweifel **eine Stufe höher**. Wenn unsicher, ob ein Spezial-Modell überhaup
 
 ## 2. Effort (per Prompt-Direktive)
 
-Das `Agent`/`Task`-Tool kennt **nur `model`, keinen Effort-Regler** — Effort wird über die Prompt-Einleitung vermittelt:
+Das `task`-Tool kennt **`subagent_type` und `description`**, keinen separaten Effort-Regler — Effort wird über die Prompt-Einleitung vermittelt. Für reine Read-only-Arbeiten (Recherche, Analyse) verwende `delegate(prompt, agent)` mit agent `"researcher"` oder `"explore"` — Effort wird über die Prompt-Einleitung vermittelt:
 
 | Stufe | Prompt-Einleitung | Wann |
 |---|---|---|

--- a/VideoVault/client/src/hooks/use-video-manager.ts
+++ b/VideoVault/client/src/hooks/use-video-manager.ts
@@ -30,7 +30,7 @@ import {
   type SplitVideoOptions,
   type SplitVideoResult,
 } from '@/services/video-splitter';
-import { activeSplitterBackend } from '@/services/video-splitter-backend';
+import { selectSplitterBackend } from '@/services/video-splitter-backend';
 import { LibraryMetadataService } from '@/services/library-metadata';
 import { WatchStateService, type WatchStatesByRoot } from '@/services/watch-state-service';
 import { AppSettingsService } from '@/services/app-settings';
@@ -1484,7 +1484,7 @@ export function useVideoManager(): UseVideoManagerReturn {
       if (!source) {
         return { success: false, message: 'Video not found' };
       }
-      const result = await activeSplitterBackend.split(source, options);
+      const result = await selectSplitterBackend(source).split(source, options);
       if (result.success) {
         setState((prev) => {
           const updated = VideoDatabase.addVideos(prev.videos, result.segments);

--- a/VideoVault/client/src/services/video-splitter-backend.test.ts
+++ b/VideoVault/client/src/services/video-splitter-backend.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('./api-client', () => ({
+  ApiClient: { post: vi.fn() },
+  HttpError: class HttpError extends Error { constructor(public status: number) { super('http'); } },
+}));
+vi.mock('./file-handle-registry', () => ({
+  FileHandleRegistry: { get: vi.fn() },
+}));
+vi.mock('./video-splitter', () => ({
+  VideoSplitter: { splitVideo: vi.fn() },
+}));
+
+import { ApiClient, HttpError } from './api-client';
+import { FileHandleRegistry } from './file-handle-registry';
+import { serverSplitterBackend, selectSplitterBackend, wasmSplitterBackend } from './video-splitter-backend';
+import type { Video } from '@/types/video';
+import type { SplitVideoOptions } from './video-splitter';
+
+const video = { id: 'v1', path: 'movies/clip.mp4', rootKey: 'root-a' } as Video;
+const options = { splitTimeSeconds: 10, first: {} as any, second: {} as any } as SplitVideoOptions;
+
+beforeEach(() => {
+  vi.mocked(ApiClient.post).mockReset();
+  vi.mocked(FileHandleRegistry.get).mockReset();
+});
+
+describe('selectSplitterBackend', () => {
+  it('uses the WASM backend when a local FSAA handle exists', () => {
+    vi.mocked(FileHandleRegistry.get).mockReturnValue({} as any);
+    expect(selectSplitterBackend(video)).toBe(wasmSplitterBackend);
+  });
+
+  it('uses the server backend when no local handle exists', () => {
+    vi.mocked(FileHandleRegistry.get).mockReturnValue(undefined);
+    expect(selectSplitterBackend(video)).toBe(serverSplitterBackend);
+  });
+});
+
+describe('serverSplitterBackend', () => {
+  it('POSTs to /api/videos/:id/split and returns the result verbatim', async () => {
+    vi.mocked(ApiClient.post).mockResolvedValue({ success: true, segments: [{}, {}] } as any);
+    const res = await serverSplitterBackend.split(video, options);
+    expect(ApiClient.post).toHaveBeenCalledWith('/api/videos/v1/split', expect.objectContaining({
+      sourcePath: 'movies/clip.mp4', rootKey: 'root-a', splitTimeSeconds: 10,
+    }));
+    expect(res.success).toBe(true);
+  });
+
+  it('maps an HttpError to a failure result instead of throwing', async () => {
+    vi.mocked(ApiClient.post).mockRejectedValue(new (HttpError as any)(500));
+    const res = await serverSplitterBackend.split(video, options);
+    expect(res).toEqual({ success: false, message: expect.stringContaining('500'), code: 'ffmpeg_failed' });
+  });
+});

--- a/VideoVault/client/src/services/video-splitter-backend.ts
+++ b/VideoVault/client/src/services/video-splitter-backend.ts
@@ -1,5 +1,7 @@
 import { Video } from '@/types/video';
 import { VideoSplitter, type SplitVideoOptions, type SplitVideoResult } from './video-splitter';
+import { ApiClient, HttpError } from './api-client';
+import { FileHandleRegistry } from './file-handle-registry';
 
 export interface VideoSplitterBackend {
   kind: 'wasm' | 'server';
@@ -11,7 +13,34 @@ export const wasmSplitterBackend: VideoSplitterBackend = {
   split: (video, options) => VideoSplitter.splitVideo(video, options),
 };
 
-// Future: server-side split backend
-// export const serverSplitterBackend: VideoSplitterBackend = { ... };
+export const serverSplitterBackend: VideoSplitterBackend = {
+  kind: 'server',
+  async split(video, options) {
+    try {
+      return await ApiClient.post<SplitVideoResult>(`/api/videos/${video.id}/split`, {
+        sourcePath: video.path,
+        rootKey: video.rootKey,
+        splitTimeSeconds: options.splitTimeSeconds,
+        first: options.first,
+        second: options.second,
+      });
+    } catch (err) {
+      if (err instanceof HttpError) {
+        return { success: false, message: `Server split failed (${err.status})`, code: 'ffmpeg_failed' };
+      }
+      return { success: false, message: err instanceof Error ? err.message : 'Server split failed' };
+    }
+  },
+};
 
+/**
+ * Wählt das Schneide-Backend pro Video:
+ * - Lokaler FSAA-FileHandle vorhanden → lokal via WASM schneiden (kein Server nötig).
+ * - Kein Handle (server-resident / Movie-Mode) → serverseitiges ffmpeg.
+ */
+export function selectSplitterBackend(video: Video): VideoSplitterBackend {
+  return FileHandleRegistry.get(video.id) ? wasmSplitterBackend : serverSplitterBackend;
+}
+
+// Rückwärtskompatibler Default (WASM). Aufrufer sollen selectSplitterBackend(video) nutzen.
 export const activeSplitterBackend: VideoSplitterBackend = wasmSplitterBackend;

--- a/VideoVault/server/handlers/split-handler.test.ts
+++ b/VideoVault/server/handlers/split-handler.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../lib/path-resolver', () => ({
+  resolveInputPath: vi.fn(),
+}));
+vi.mock('./movie-handler', () => ({
+  extractMovieMetadata: vi.fn(),
+}));
+vi.mock('child_process', () => ({
+  spawn: vi.fn(),
+}));
+vi.mock('fs/promises', () => ({
+  default: {
+    mkdir: vi.fn().mockResolvedValue(undefined),
+    access: vi.fn().mockRejectedValue(new Error('ENOENT')),
+    stat: vi.fn().mockResolvedValue({ size: 123, mtime: new Date('2026-01-01T00:00:00Z') }),
+    rm: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+import { resolveInputPath } from '../lib/path-resolver';
+import { extractMovieMetadata } from './movie-handler';
+import { spawn } from 'child_process';
+import { splitVideoOnServer, type ServerSplitParams } from './split-handler';
+
+function fakeFfmpegOk() {
+  return {
+    stderr: { on: vi.fn() },
+    on: (event: string, cb: (code?: number) => void) => {
+      if (event === 'close') cb(0);
+    },
+  } as any;
+}
+
+const META = { duration: 100, width: 1920, height: 1080, bitrate: 5000, codec: 'h264', fps: 30, aspectRatio: '16:9', fileSize: 123 };
+
+const baseParams: ServerSplitParams = {
+  sourceId: 'src1',
+  sourcePath: 'movies/clip.mp4',
+  rootKey: 'root-a',
+  splitTimeSeconds: 42,
+  first: { displayName: 'Part 1', filename: 'part1.mp4', categories: {} as any, customCategories: {} },
+  second: { displayName: 'Part 2', filename: 'part2.mp4', categories: {} as any, customCategories: {} },
+};
+
+beforeEach(() => {
+  vi.mocked(resolveInputPath).mockReset();
+  vi.mocked(extractMovieMetadata).mockReset();
+  vi.mocked(spawn).mockReset();
+});
+
+describe('splitVideoOnServer', () => {
+  it('returns not_server_resident when the source path cannot be resolved', async () => {
+    vi.mocked(resolveInputPath).mockResolvedValue(null);
+    const res = await splitVideoOnServer(baseParams, undefined);
+    expect(res).toEqual({ success: false, message: expect.any(String), code: 'not_server_resident' });
+  });
+
+  it('rejects a split time outside the valid window', async () => {
+    vi.mocked(resolveInputPath).mockResolvedValue('/media/movies/clip.mp4');
+    vi.mocked(extractMovieMetadata).mockResolvedValue({ ...META, duration: 10 });
+    const res = await splitVideoOnServer({ ...baseParams, splitTimeSeconds: 9.99 }, undefined);
+    expect(res).toEqual({ success: false, message: expect.any(String), code: 'invalid_split' });
+  });
+
+  it('produces two segment records on success with -c copy', async () => {
+    vi.mocked(resolveInputPath).mockResolvedValue('/media/movies/clip.mp4');
+    vi.mocked(extractMovieMetadata).mockResolvedValue(META);
+    vi.mocked(spawn).mockImplementation(() => fakeFfmpegOk());
+
+    const res = await splitVideoOnServer(baseParams, undefined);
+
+    expect(res.success).toBe(true);
+    if (!res.success) return;
+    expect(res.segments).toHaveLength(2);
+    expect(res.segments[0].displayName).toBe('Part 1');
+    expect(res.segments[1].filename).toBe('part2.mp4');
+    const firstArgs = vi.mocked(spawn).mock.calls[0][1] as string[];
+    expect(firstArgs).toContain('-c');
+    expect(firstArgs).toContain('copy');
+    expect(firstArgs).toContain('-t');
+    const secondArgs = vi.mocked(spawn).mock.calls[1][1] as string[];
+    expect(secondArgs).toContain('-ss');
+  });
+});

--- a/VideoVault/server/handlers/split-handler.ts
+++ b/VideoVault/server/handlers/split-handler.ts
@@ -1,0 +1,126 @@
+import path from 'path';
+import fs from 'fs/promises';
+import crypto from 'crypto';
+import { spawn } from 'child_process';
+import { resolveInputPath } from '../lib/path-resolver';
+import { extractMovieMetadata } from './movie-handler';
+import { generateVideoIdSync } from '@shared/video-id';
+import { logger } from '../lib/logger';
+
+const PROCESSED_MEDIA_PATH =
+  process.env.PROCESSED_MEDIA_PATH || path.join(process.cwd(), 'processed');
+
+export type SplitErrorCode =
+  | 'missing_handle' | 'missing_directory' | 'invalid_split'
+  | 'ffmpeg_failed' | 'permission_denied' | 'conflict' | 'not_server_resident';
+
+export interface SplitSegmentInput {
+  displayName: string;
+  filename: string;
+  categories: Record<string, string[]>;
+  customCategories: Record<string, string[]>;
+}
+
+export interface ServerSplitParams {
+  sourceId: string;
+  sourcePath: string;
+  rootKey?: string;
+  splitTimeSeconds: number;
+  first: SplitSegmentInput;
+  second: SplitSegmentInput;
+}
+
+interface SegmentRecord {
+  type: 'video';
+  id: string;
+  filename: string;
+  displayName: string;
+  path: string;
+  size: number;
+  lastModified: string;
+  categories: Record<string, string[]>;
+  customCategories: Record<string, string[]>;
+  metadata: { duration: number; width: number; height: number; bitrate: number; codec: string; fps: number; aspectRatio: string };
+  rootKey?: string;
+}
+
+export type ServerSplitResult =
+  | { success: true; segments: [SegmentRecord, SegmentRecord] }
+  | { success: false; message: string; code?: SplitErrorCode };
+
+const STANDARD_KEYS = ['age', 'physical', 'ethnicity', 'relationship', 'acts', 'setting', 'quality', 'performer'];
+
+function withStandardKeys(input: Record<string, string[]> | undefined): Record<string, string[]> {
+  const out: Record<string, string[]> = { ...(input ?? {}) };
+  for (const k of STANDARD_KEYS) if (!Array.isArray(out[k])) out[k] = [];
+  return out;
+}
+
+function runFfmpeg(args: string[]): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const proc = spawn('ffmpeg', args);
+    let stderr = '';
+    proc.stderr.on('data', (d: Buffer) => { stderr += d.toString(); });
+    proc.on('error', reject);
+    proc.on('close', (code: number) =>
+      code === 0 ? resolve() : reject(new Error(`ffmpeg exited ${code}: ${stderr.slice(0, 500)}`)));
+  });
+}
+
+async function buildSegment(outAbsPath: string, input: SplitSegmentInput, rootKey: string | undefined): Promise<SegmentRecord> {
+  const meta = await extractMovieMetadata(outAbsPath);
+  const stats = await fs.stat(outAbsPath);
+  return {
+    type: 'video',
+    id: generateVideoIdSync(crypto, rootKey || 'splits', outAbsPath),
+    filename: input.filename,
+    displayName: input.displayName,
+    path: outAbsPath,
+    size: stats.size,
+    lastModified: stats.mtime.toISOString(),
+    categories: withStandardKeys(input.categories),
+    customCategories: input.customCategories ?? {},
+    metadata: {
+      duration: meta.duration, width: meta.width, height: meta.height,
+      bitrate: meta.bitrate, codec: meta.codec, fps: meta.fps, aspectRatio: meta.aspectRatio,
+    },
+    rootKey,
+  };
+}
+
+export async function splitVideoOnServer(p: ServerSplitParams, db: unknown): Promise<ServerSplitResult> {
+  const resolved = await resolveInputPath(p.sourcePath, p.rootKey, db);
+  if (!resolved) {
+    return { success: false, message: `Source not available on server: ${p.sourcePath}`, code: 'not_server_resident' };
+  }
+
+  const srcMeta = await extractMovieMetadata(resolved);
+  if (!(p.splitTimeSeconds > 0.1 && p.splitTimeSeconds < srcMeta.duration - 0.1)) {
+    return { success: false, message: `Split time ${p.splitTimeSeconds}s outside 0.1..${srcMeta.duration - 0.1}s`, code: 'invalid_split' };
+  }
+
+  const outDir = path.join(PROCESSED_MEDIA_PATH, 'splits', p.sourceId.slice(0, 2));
+  await fs.mkdir(outDir, { recursive: true });
+  const out1 = path.join(outDir, p.first.filename);
+  const out2 = path.join(outDir, p.second.filename);
+
+  for (const out of [out1, out2]) {
+    try { await fs.access(out); return { success: false, message: `File already exists: ${out}`, code: 'conflict' }; }
+    catch { /* not present → ok */ }
+  }
+
+  const t = p.splitTimeSeconds.toFixed(2);
+  try {
+    await runFfmpeg(['-hide_banner', '-loglevel', 'error', '-y', '-i', resolved, '-t', t, '-c', 'copy', '-avoid_negative_ts', 'make_zero', out1]);
+    await runFfmpeg(['-hide_banner', '-loglevel', 'error', '-y', '-ss', t, '-i', resolved, '-c', 'copy', '-avoid_negative_ts', 'make_zero', out2]);
+  } catch (err) {
+    await fs.rm(out1, { force: true }).catch(() => {});
+    await fs.rm(out2, { force: true }).catch(() => {});
+    logger.error('[Split] ffmpeg failed', { error: err instanceof Error ? err.message : String(err) });
+    return { success: false, message: err instanceof Error ? err.message : 'ffmpeg failed', code: 'ffmpeg_failed' };
+  }
+
+  const seg1 = await buildSegment(out1, p.first, p.rootKey);
+  const seg2 = await buildSegment(out2, p.second, p.rootKey);
+  return { success: true, segments: [seg1, seg2] };
+}

--- a/VideoVault/server/routes.ts
+++ b/VideoVault/server/routes.ts
@@ -51,6 +51,7 @@ import scanStateRoutes from './routes/scan-state';
 import jobsRoutes from './routes/jobs';
 import processingRoutes from './routes/processing';
 import browseRoutes from './routes/browse';
+import splitRoutes from './routes/split';
 import { users } from '@shared/schema';
 import { eq } from 'drizzle-orm';
 import { db } from './db';
@@ -259,6 +260,8 @@ export function registerRoutes(app: Express): Server {
   app.post('/api/videos/compute-hashes', asyncHandler(computeHashes));
   app.get('/api/videos/duplicates', asyncHandler(getDuplicates));
   app.post('/api/videos/duplicates/ignore', asyncHandler(ignoreDuplicateRoute));
+
+  app.use('/api/videos', splitRoutes);
 
   app.post('/api/tags/:id/rename', asyncHandler(renameTagRoute));
   app.post('/api/tags/merge', asyncHandler(mergeTagsRoute));

--- a/VideoVault/server/routes/split.test.ts
+++ b/VideoVault/server/routes/split.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../handlers/split-handler', () => ({
+  splitVideoOnServer: vi.fn(),
+}));
+vi.mock('../db', () => ({ db: undefined }));
+
+import { splitVideoOnServer } from '../handlers/split-handler';
+import { splitRouteHandler } from './split';
+
+function mockRes() {
+  const res: any = {};
+  res.status = vi.fn().mockReturnValue(res);
+  res.json = vi.fn().mockReturnValue(res);
+  return res;
+}
+
+const validBody = {
+  sourcePath: 'movies/clip.mp4',
+  rootKey: 'root-a',
+  splitTimeSeconds: 42,
+  first: { displayName: 'A', filename: 'a.mp4', categories: {}, customCategories: {} },
+  second: { displayName: 'B', filename: 'b.mp4', categories: {}, customCategories: {} },
+};
+
+beforeEach(() => vi.mocked(splitVideoOnServer).mockReset());
+
+describe('splitRouteHandler', () => {
+  it('400s on missing fields', async () => {
+    const res = mockRes();
+    await splitRouteHandler({ params: { id: 'x' }, body: { splitTimeSeconds: 1 } } as any, res);
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(splitVideoOnServer).not.toHaveBeenCalled();
+  });
+
+  it('200s and returns the result on success', async () => {
+    vi.mocked(splitVideoOnServer).mockResolvedValue({ success: true, segments: [{} as any, {} as any] });
+    const res = mockRes();
+    await splitRouteHandler({ params: { id: 'src1' }, body: validBody } as any, res);
+    expect(splitVideoOnServer).toHaveBeenCalledWith(expect.objectContaining({ sourceId: 'src1', splitTimeSeconds: 42 }), undefined);
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it('422s when the handler reports failure', async () => {
+    vi.mocked(splitVideoOnServer).mockResolvedValue({ success: false, message: 'nope', code: 'invalid_split' });
+    const res = mockRes();
+    await splitRouteHandler({ params: { id: 'src1' }, body: validBody } as any, res);
+    expect(res.status).toHaveBeenCalledWith(422);
+  });
+});

--- a/VideoVault/server/routes/split.ts
+++ b/VideoVault/server/routes/split.ts
@@ -1,0 +1,24 @@
+import { Router, type Request, type Response } from 'express';
+import { asyncHandler } from '../middleware/async-error-handler';
+import { splitVideoOnServer, type ServerSplitParams } from '../handlers/split-handler';
+import { db } from '../db';
+
+const router = Router();
+
+export async function splitRouteHandler(req: Request, res: Response): Promise<void> {
+  const { id } = req.params;
+  const { sourcePath, rootKey, splitTimeSeconds, first, second } = req.body ?? {};
+
+  if (!sourcePath || typeof splitTimeSeconds !== 'number' || !first || !second) {
+    res.status(400).json({ success: false, message: 'Missing required fields', code: 'invalid_split' });
+    return;
+  }
+
+  const params: ServerSplitParams = { sourceId: id, sourcePath, rootKey, splitTimeSeconds, first, second };
+  const result = await splitVideoOnServer(params, db);
+  res.status(result.success ? 200 : 422).json(result);
+}
+
+router.post('/:id/split', asyncHandler(splitRouteHandler));
+
+export default router;


### PR DESCRIPTION
Re-vendor der 2c-Server-Split-Implementierung aus projects/VideoVault:

- `server/handlers/split-handler.ts`: Serverseitiges ffmpeg -c copy (In-Container, kein GPU)
- `POST /api/videos/:id/split`: Synchroner Split-Endpunkt
- `serverSplitterBackend` + `selectSplitterBackend`: Hybrid FSAA→WASM, server-resident→Server
- `use-video-manager.splitVideo`: Nutzt per-Video-Selektor

Kein neues k8s-Manifest — in-container ffmpeg nutzt die gesamte 2b-Infra weiter.

Plan: docs/superpowers/plans/2026-06-15-videovault-migration-2c-server-split.md