### PR TITLE
fix(ci): install videovault-player deps before tsc check [T-2c-fix]

### DIFF
--- a/.github/workflows/build-videovault.yml
+++ b/.github/workflows/build-videovault.yml
@@ -25,7 +25,13 @@ jobs:
         with:
           node-version: '20'
           cache: 'npm'
-          cache-dependency-path: VideoVault/package-lock.json
+          cache-dependency-path: |
+            VideoVault/package-lock.json
+            packages/videovault-player/package-lock.json
+
+      - name: Install videovault-player deps
+        working-directory: packages/videovault-player
+        run: npm install
 
       - name: Test gate (types + client unit)
         working-directory: VideoVault


### PR DESCRIPTION
Der build-videovault CI scheitert an tsc: `packages/videovault-player` findet `react` nicht, weil `npm install` nur in `VideoVault/` läuft.

Fix:
- `npm install` in `packages/videovault-player/` vor dem tsc-Check
- Cache-Dependency-Path um player package-lock.json erweitert