### PR TITLE
chore(ci): add workflow_dispatch trigger to widget build

### DIFF
--- a/.github/workflows/build-mediaviewer-widget.yml
+++ b/.github/workflows/build-mediaviewer-widget.yml
@@ -7,6 +7,7 @@ on:
       - 'mediaviewer-widget/**'
       - 'packages/videovault-player/**'
       - '.github/workflows/build-mediaviewer-widget.yml'
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
Adds workflow_dispatch to build-mediaviewer-widget.yml so the widget can be rebuilt manually after allowlist changes.