### PR TITLE
docs: add migrate-foreign-code migration skill (SP3)

### DIFF
--- a/.claude/skills/OVERVIEW.md
+++ b/.claude/skills/OVERVIEW.md
@@ -26,6 +26,14 @@
 
 ---
 
+## Migration (Fremdcode → Plattform)
+
+| Skill | When to use |
+|---|---|
+| `migrate-foreign-code` | Eine bestehende, externe App ins Bachelorprojekt übernehmen — 6-Phasen-Reise (entkoppeln → vendoren → containerisieren → server-side → integrieren) über `dev-flow`, mit Pattern-Katalog. Operator-getrieben; sequenziert dev-flow, ersetzt es nicht. |
+
+---
+
 ## Schicht-Kontrakt: dev-flow orchestriert, superpowers liefert Disziplin
 
 Die `dev-flow-*`-Skills sind **projektspezifische Orchestratoren**. Sie rufen die generischen

--- a/.claude/skills/migrate-foreign-code/SKILL.md
+++ b/.claude/skills/migrate-foreign-code/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: migrate-foreign-code
+description: Use when bringing an externally-developed app into the Bachelorprojekt platform — decouple it in its origin repo, vendor it, containerize it, move client-only capabilities server-side, and integrate it (Kustomize/Ingress/Keycloak/embed) across both brands. A 6-phase meta-runbook over dev-flow.
+---
+
+# migrate-foreign-code — Fremdcode in die Plattform übernehmen
+
+## Wann diese Skill greift
+
+Wenn eine **bestehende, extern entwickelte App** ins Bachelorprojekt übernommen werden soll
+(erste Anwendung: VideoVault). Die Reise ist generisch; der [Pattern-Katalog](#pattern-katalog)
+liefert die wiederkehrenden technischen Muster + Stolpersteine.
+
+## Schicht-Hinweis: ein Meta-Runbook über dev-flow
+
+Dieser Skill ist **operator-getrieben** und **ersetzt dev-flow nicht** — er **sequenziert** es.
+**Jede Phase ist ein eigener `dev-flow-plan` → `dev-flow-execute`-Zyklus.** Für die Deploy-/Auth-/
+Secret-Mechanik wird auf die bestehenden Skills verwiesen (siehe [Verwandte Skills](#verwandte-skills)),
+nicht dupliziert.
+
+## Die 6 Phasen
+
+| Phase | Was passiert (generisch) | VideoVault-Instanz |
+|---|---|---|
+| **0 · Assess & Decide** | Stack/Build/Daten/Auth inventarisieren; **Migrations-Fitness-Gate** | Zwei Apps, client-first, FSAA-basiert |
+| **1 · Decouple in-place** | God-Module zerlegen, Shared-Packages extrahieren, Verhalten per Characterization-Tests einfrieren — **im Ursprungs-Repo gegen dessen Test-Suite** | `useVideoManager` (1762 Z.) → 3 Hooks; `videovault-player`-Package |
+| **2 · Vendor** | Code in-repo holen (Dockerfile + CI, Idiom wie `website/`/`brett/`); source-only-Package via Alias | Player-Package + Service vendored |
+| **3 · Containerize** | Multi-Stage-Build (Client + Server → 1 Port); native Deps; neue DB in `shared-db`; PVC für Zwischendaten | Slim-Image + ffmpeg via APT |
+| **4 · Server-Capabilities** | Client-only-Backend hinter dem **bestehenden Interface** auf server-resident tauschen (Hybrid via Capability-Signal) | Server-seitiger Schnitt |
+| **5 · Platform-Integration** | Kustomize/Ingress; host-owned Auth (Keycloak/oauth2-proxy); Embed-Bridge; `configmap-domains`; **beide Brands** | Companion-Panel im Portal |
+
+## Decision-Gates
+
+Zwischen jeder Phase ein explizites Gate: **Voraussetzungen erfüllt? · reversibel? · weiter/stopp?**
+Leitprinzip: **erst in-place stabilisieren, dann migrieren**.
+
+- **Gate 0→1:** Migrations-Fitness bejaht **und** Ursprungs-Test-Suite grün, bevor entkoppelt wird.
+- **Gate 1→2:** Grenzen per Characterization-Tests eingefroren; Interfaces extrahiert (ermöglicht Phase 4).
+- **Gate 3→4:** Server-resident nur wo es Mehrwert bringt — Annahmen (z.B. GPU) per Code-Erkundung
+  verifizieren, nicht raten.
+- **Gate 4→5:** Integration zuletzt, wenn die App als Container eigenständig läuft.
+
+## Pattern-Katalog
+
+Wiederkehrende technische Muster — je generisches Muster, VideoVault-Beispiel und Stolpersteine:
+
+| Pattern | Phase(n) | Inhalt |
+|---|---|---|
+| [pattern-vendoring](references/pattern-vendoring.md) | 2 | In-Repo-Vendoring-Idiom (Dockerfile + CI, kein committed `node_modules`) |
+| [pattern-multistage-build](references/pattern-multistage-build.md) | 3 | Client+Server → ein Runtime-Port; Slim-Image + native Deps |
+| [pattern-source-only-package](references/pattern-source-only-package.md) | 1, 2 | source-only Package via Alias; Dual-Build; React-Dedup; WASM-Assets |
+| [pattern-hybrid-backend](references/pattern-hybrid-backend.md) | 4 | Backend-Tausch hinter stabilem Interface via Capability-Signal |
+| [pattern-embed-bridge](references/pattern-embed-bridge.md) | 5 | postMessage Host↔Widget mit Origin-Validierung; Props+Handle |
+| [pattern-data-and-auth](references/pattern-data-and-auth.md) | 3, 5 | DB in `shared-db` + PVC; host-owned Auth; beide Brands |
+
+## Verwandte Skills
+
+| Skill | Beziehung |
+|---|---|
+| `dev-flow-plan` / `dev-flow-execute` | Pro Phase ein Plan/Execute-Zyklus — der eigentliche Arbeitsmotor |
+| `workspace-deploy` / `cluster-deployment` | Phase 3 — Manifeste, DB, PVC, Deploy |
+| `keycloak-realm-sync` | Phase 5 — OIDC/Realm/Auth |
+| `secret-rotation` | Phase 5 — Credentials der neuen App |
+| `fleet-ops` | Phase 3/5 — Cross-Brand-Fan-out (beide Namespaces) |
+
+## Quelle der Learnings
+
+Destilliert aus dem VideoVault-Vorhaben (SP1 Split + SP2 Migration) in `~/projects/`:
+`docs/superpowers/specs/2026-06-15-videovault-migration-learnings.md`,
+`docs/superpowers/specs/2026-06-15-videovault-split-design.md`,
+`docs/superpowers/plans/2026-06-15-videovault-split.md`,
+`docs/superpowers/plans/2026-06-15-videovault-migration-2{b,c,d}-*.md`.
+Dieser Skill ist die **destillierte, eigenständige Kopie** — kein Live-Link.

--- a/.claude/skills/migrate-foreign-code/references/pattern-data-and-auth.md
+++ b/.claude/skills/migrate-foreign-code/references/pattern-data-and-auth.md
@@ -1,0 +1,28 @@
+# Pattern: Daten & Auth in der Plattform (beide Brands)
+
+Wie Persistenz, Zwischendaten und Authentifizierung der migrierten App in die Plattform eingebettet werden.
+
+## Muster (generisch)
+
+- **Persistenz:** eine neue, isolierte DB in der **zentralen `shared-db`** statt einer eigenen
+  Datenbank-Instanz.
+- **Zwischendaten** (Uploads, Schnitt-Artefakte): ein **RWO-PVC** mit single-replica
+  `Recreate`-Strategie.
+- **Auth: host-owned.** Die App vertraut dem Host; SSO läuft über Keycloak/oauth2-proxy. Die App
+  bringt **keine** eigene Auth mit.
+- **Domain-Auflösung** zentral über `configmap-domains`.
+- **Multi-Brand:** Die Brands sind **separate per-Brand-Deployments im selben Fleet-Cluster**
+  (Namespaces `workspace` + `workspace-korczewski`). Cross-cutting-Änderungen — DB-Anlage,
+  OIDC-Clients, Schema-Migrationen — müssen **explizit in beide Namespaces** ausgerollt werden.
+
+## VideoVault-Beispiel
+
+Neue DB `videovault` in der zentralen `shared-db`; Upload-PVC (RWO, `Recreate`) für
+Schnitt-Zwischendaten; Auth durch den Workspace-Host (Keycloak); Auslieferung in beide Brands.
+
+## Stolpersteine
+
+- **Beide Namespaces nicht vergessen:** ein Roll-out nur in `workspace` lässt den korczewski-Brand
+  ohne DB/OIDC zurück. Das gilt für jede cross-cutting Änderung.
+- **Mechanik nicht duplizieren — routen:** für OIDC-/Realm-Arbeit auf `keycloak-realm-sync`, für
+  Credentials auf `secret-rotation`, für den Cross-Brand-Fan-out auf `fleet-ops` verweisen.

--- a/.claude/skills/migrate-foreign-code/references/pattern-embed-bridge.md
+++ b/.claude/skills/migrate-foreign-code/references/pattern-embed-bridge.md
@@ -1,0 +1,31 @@
+# Pattern: postMessage-Embed-Bridge (Host ↔ Widget)
+
+Wie die migrierte App als eingebettetes Widget in das Plattform-Portal integriert wird.
+
+## Muster (generisch)
+
+Der Host bettet die App als `<iframe>`-Widget ein. Kommunikation läuft über eine
+**postMessage-Bridge** mit **Origin-Validierung auf beiden Seiten**. Der **Host besitzt die Daten**
+und steuert das Widget per **Props + imperativem Handle**; das Widget bleibt zustandslos und greift
+nicht selbst auf Persistenz zu. Die Bridge wird als **pure, testbare Hilfe** auf beiden Seiten
+gespiegelt (gleiches Protokoll, getrennt getestet).
+
+Die Widget-Domain wird **nie hardcodiert**, sondern über zentrale Domain-Config aufgelöst (siehe
+`configmap-domains` und [pattern-data-and-auth](pattern-data-and-auth.md)) und per Env-Variable ins
+Frontend injiziert.
+
+## VideoVault-Beispiel
+
+Die Widget-Seite der Bridge (`mediaviewer-widget/src/embed/bridge.ts`) entstand in Phase 2a; die
+Host-Seite (`website/src/lib/mediaviewer-bridge.ts`) spiegelt das Protokoll in Phase 2d. Ein
+**versioniertes Hilfsvideo-Manifest** (`help-videos.json`) wird über einen **Zod-validierten
+Loader** geladen. Das Companion-Panel rendert den `<iframe>`, postet beim Laden `setVideos` und
+empfängt `select`/`progress`/`ended`/`error` **origin-validiert**. Die Widget-Domain kommt über
+`MEDIAVIEWER_HOST` (aus `configmap-domains.yaml`), injiziert ins Portal-Layout.
+
+## Stolpersteine
+
+- **Widget-Allowlist** muss den Host-Origin enthalten — eine fehlende Einträge-Korrektur war Teil
+  von Phase 2d, sonst verwirft das Widget die Host-Messages.
+- **Domain nie als Literal** im Code — immer über `configmap-domains` + Env-Injektion auflösen
+  (sonst bricht Multi-Brand und das CI-Domain-Literal-Gate S3 greift in echten Service-Pfaden).

--- a/.claude/skills/migrate-foreign-code/references/pattern-hybrid-backend.md
+++ b/.claude/skills/migrate-foreign-code/references/pattern-hybrid-backend.md
@@ -1,0 +1,30 @@
+# Pattern: Hybrid-Backend hinter stabilem Interface
+
+Wie eine client-only Fähigkeit server-seitig nachgezogen wird, ohne die UI anzufassen.
+
+## Muster (generisch)
+
+Das in der Entkopplungs-Phase (Phase 1) extrahierte **Interface** zahlt sich hier aus: eine
+client-only Implementierung wird durch eine server-resident Implementierung **hinter demselben
+Interface** ergänzt — die UI ändert sich nicht. Ein **Selektor** wählt zur Laufzeit die passende
+Implementierung anhand eines **Capability-Signals**, das ohnehin im Zustand vorhanden ist — **ohne**
+ein neues Typ-Feld am Domänen-Objekt einzuführen.
+
+Das Signal soll aus etwas Bestehendem abgeleitet werden (z.B. „liegt ein File-Handle vor?"), nicht
+künstlich an die Datenstruktur angeheftet werden.
+
+## VideoVault-Beispiel
+
+Schnitt-Backend-Wahl per `FileHandleRegistry`: FSAA-Handle vorhanden → WASM-Backend (Browser),
+sonst → Server-Backend. Es gab nur **eine** neue `serverSplitterBackend`-Implementierung + einen
+`selectSplitterBackend`-Selektor; **kein** neues k8s-Manifest (die gesamte 2b-Infra — Image, PVC,
+ffmpeg via APT — wurde wiederverwendet).
+
+## Stolpersteine
+
+- **GPU-Annahme verifizieren, bevor man Infrastruktur plant.** `ffmpeg -c copy` (Stream-Copy) ist
+  **I/O-gebunden** — nvenc/GPU bringt messbar null. Die Spec hatte fälschlich einen GPU-Worker
+  angenommen; der Befund kam aus **Code-Erkundung beim Planen**, nicht erst beim Bauen. In-Container-
+  CPU war leistungsgleich und ersparte ein ganzes GPU-Infra-Teilprojekt.
+- Ein optionales echtes Transcode-/GPU-Backend bleibt eine **spätere dritte** Implementierung hinter
+  demselben Interface — nicht vorauseilend bauen (YAGNI).

--- a/.claude/skills/migrate-foreign-code/references/pattern-multistage-build.md
+++ b/.claude/skills/migrate-foreign-code/references/pattern-multistage-build.md
@@ -1,0 +1,30 @@
+# Pattern: Multi-Stage-Build (Client + Server → ein Runtime-Port)
+
+Wie eine Client+Server-App zu einem einzigen, schlanken Container-Image gebaut wird.
+
+## Muster (generisch)
+
+Ein **Multi-Stage-Build** trennt Bau und Laufzeit:
+
+- **Client-Stage:** `vite build` → statische Assets nach `dist/public`.
+- **Server-Stage:** `esbuild` bündelt den Server → `dist/index.js`.
+- **Runtime-Stage:** ein schlankes Base-Image (`node:bookworm-slim`) startet den Express-Server,
+  der die **SPA und die `/api`-Routen auf einem einzigen Port** serviert.
+
+Ein Port für SPA + API erspart Ingress-Sonderfälle (kein getrenntes Routing für Frontend/Backend).
+Native bzw. System-Abhängigkeiten werden in der Runtime-Stage per APT nachinstalliert, weil das
+Slim-Image sie nicht mitbringt.
+
+## VideoVault-Beispiel
+
+Das Runtime-Image installiert `ffmpeg`/`ffprobe` via APT (für den serverseitigen Schnitt, siehe
+[pattern-hybrid-backend](pattern-hybrid-backend.md)). Die Client-first-Architektur bleibt
+unangetastet — FSAA und der WASM-Splitter laufen weiter im Browser; das server-resident ffmpeg ist
+eine separate Fähigkeit.
+
+## Stolpersteine
+
+- **Native/System-Deps** (`ffmpeg`, `ffprobe`, …) fehlen im `*-slim`-Image und müssen explizit per
+  APT in die Runtime-Stage — sonst schlägt die Funktion erst zur Laufzeit fehl.
+- **Ein Port für SPA + API** bewusst wählen: vermeidet doppeltes Ingress-Routing und
+  CORS-Sonderfälle gegenüber zwei getrennten Deployments.

--- a/.claude/skills/migrate-foreign-code/references/pattern-source-only-package.md
+++ b/.claude/skills/migrate-foreign-code/references/pattern-source-only-package.md
@@ -1,0 +1,35 @@
+# Pattern: Source-only Package (geteilter Code via Alias)
+
+Wie Code zwischen Apps geteilt wird, ohne einen eigenen Build-/Publish-Schritt.
+
+## Muster (generisch)
+
+Geteilter Code (z.B. eine extrahierte UI-Komponente) wird als **source-only Package** abgelegt —
+**kein** Build-Schritt, reiner Alias-Mechanismus:
+
+- `package.json`: `"main"` und `"types"` zeigen direkt auf `src/index.ts`.
+- Konsumenten binden es per `resolve.alias` (Vite/Vitest) + `paths` (tsconfig) ein.
+- Tests laufen direkt im Package (eigenes Vitest), keine Vorab-Kompilierung nötig.
+
+So bleibt das Package eine reine Quell-Einheit; Konsumenten kompilieren es als Teil ihres eigenen
+Builds. Das ist der Hebel, der in der Entkopplungs-Phase (Phase 1) das spätere Backend-Tauschen
+ermöglicht (siehe [pattern-hybrid-backend](pattern-hybrid-backend.md)).
+
+## VideoVault-Beispiel
+
+`@videovault-player` ist als source-only Package eingebunden. Die Widget-App nutzt zusätzlich ein
+**Dual-Build-Pattern**: `vite.config.ts` prüft `mode === 'lib'` → `build.lib`-Eintrag mit
+`external: ['react','react-dom', …]`; sonst Standard-App-Dev-Server. Der Alias ist in **beiden**
+Modi gesetzt.
+
+FFmpeg-Assets: `toBlobURL('/ffmpeg/ffmpeg-core.js', 'text/javascript')` aus `@ffmpeg/util` statt
+`new URL('@ffmpeg/core/dist/umd/…', import.meta.url)` — ab `@ffmpeg/core` v0.12 wird der
+`dist/umd`-Specifier nicht mehr exportiert (`Missing "./dist/umd/…"`). Core-Dateien per Copy-Script
+nach `public/ffmpeg/` kopieren; `@ffmpeg/ffmpeg` + `@ffmpeg/core` in `optimizeDeps.exclude`.
+
+## Stolpersteine
+
+- **Duplicate React instances** beim Import über node_modules-Grenzen hinweg → `resolve.alias` für
+  `react` **und** `react-dom` in der Vitest/Vite-Config des Konsumenten.
+- **Hook-Reihenfolge:** alle Hooks **vor** einem frühen `return null` platzieren — ein
+  `useCallback` nach dem Guard löst „Rendered more hooks than during the previous render" aus.

--- a/.claude/skills/migrate-foreign-code/references/pattern-vendoring.md
+++ b/.claude/skills/migrate-foreign-code/references/pattern-vendoring.md
@@ -1,0 +1,30 @@
+# Pattern: In-Repo-Vendoring
+
+Wie eine externe App in den Monorepo geholt wird, ohne sie als Fremd-Dependency zu konsumieren.
+
+## Muster (generisch)
+
+Statt die migrierte App als externes Paket/Submodul einzubinden, wird ihr Quellcode **in-repo
+vendored** und nach dem etablierten Repo-Idiom gebaut: ein **in-repo `Dockerfile`** + ein
+**CI-Workflow**, genau wie die bestehenden vendored Dienste (`website/`, `brett/`). Die vendored
+Quelle ist Teil des Monorepos und wird bei jedem Build neu gebaut — keine Abhängigkeit von einer
+externen Registry oder einem Upstream-Tag.
+
+Vorteil: ein einziger Build-/Deploy-Pfad für alles, keine Versions-Drift zwischen „unserem" Stand
+und dem Upstream, und die Migration kann den Code schrittweise an die Plattform-Konventionen
+angleichen (siehe [pattern-multistage-build](pattern-multistage-build.md),
+[pattern-source-only-package](pattern-source-only-package.md)).
+
+## VideoVault-Beispiel
+
+`packages/videovault-player` (geteiltes Player-Package) und der VideoVault-Service wurden als
+in-repo Quelle vendored. Der CI-Build baut dasselbe Image neu; bei Phase 2c wurden lediglich die
+Quellen re-vendored, und CI baute das Image ohne neue Infrastruktur neu.
+
+## Stolpersteine
+
+- **`git add -f`** für Dateien, die in einem `.gitignore`-geschützten Verzeichnis liegen — sonst
+  landen vendored Build-Assets stillschweigend nicht im Commit.
+- **Niemals `node_modules` committen.** Das ist während der VideoVault-Migration **zweimal**
+  passiert. Korrektur: `git rm -r --cached <dir>` + `git commit --amend`.
+- **`npm install`-Peer-Dep-Konflikte** (z.B. Canvas/jsdom): `--legacy-peer-deps` nötig.

--- a/docs/superpowers/plans/2026-06-15-migrate-foreign-code.md
+++ b/docs/superpowers/plans/2026-06-15-migrate-foreign-code.md
@@ -1,5 +1,5 @@
 ---
-ticket_id: null
+ticket_id: T000840
 plan_ref: null
 status: active
 date: 2026-06-15

--- a/docs/superpowers/plans/2026-06-15-migrate-foreign-code.md
+++ b/docs/superpowers/plans/2026-06-15-migrate-foreign-code.md
@@ -1,0 +1,307 @@
+---
+ticket_id: null
+plan_ref: null
+status: active
+date: 2026-06-15
+domains: [website, infra, db, ops, test, security]
+file_locks: []
+shared_changes: false
+batch_id: null
+parent_feature: null
+depends_on_plans: []
+---
+
+# `migrate-foreign-code` Skill — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ein wiederverwendbares Bachelorprojekt-Skill `migrate-foreign-code` schreiben, das die SP1+SP2-VideoVault-Migrationserfahrung als 6-Phasen-Runbook (`SKILL.md`) + Pattern-Katalog (`references/`) kodifiziert.
+
+**Architecture:** Reine Dokumentation — ein `SKILL.md` (generische Phasen + Decision-Gates, verlinkt die Patterns) und sechs `references/pattern-*.md` (je generisches Muster + VideoVault-Instanz + Stolpersteine). Pattern-Dateien zuerst (unabhängig), `SKILL.md` danach (verlinkt sie), dann `OVERVIEW.md`-Eintrag, dann Freshness-Verifikation. Quelle: SP1/SP2-Artefakte in `~/projects/docs/superpowers/`.
+
+**Tech Stack:** Markdown, YAML-Frontmatter, `task freshness:*` / `scripts/build-docs.mjs` (Skill-Discovery).
+
+**Quell-Material** (read-only, in `~/projects/`):
+- `docs/superpowers/specs/2026-06-15-videovault-migration-learnings.md` (L)
+- `docs/superpowers/plans/2026-06-15-videovault-split.md` (SP1)
+- `docs/superpowers/plans/2026-06-15-videovault-migration-2b-service-deploy.md` (2b)
+- `docs/superpowers/plans/2026-06-15-videovault-migration-2c-server-split.md` (2c)
+- `docs/superpowers/plans/2026-06-15-videovault-migration-2d-embed.md` (2d)
+
+**Gate-Hinweise (aus `plan-quality-gates.md` geprüft):** S1-Zeilenlimits gelten **nicht** für `.md`. S3 (Domain-Literale) und S4 (Orphans) scopen `k3d/`/`prod*/`/`website/src/`/`scripts/` — `.claude/skills/` ist außerhalb; trotzdem domänen-literalfrei schreiben (Verweis auf `configmap-domains`) und Skill in `OVERVIEW.md` referenzieren. Finaler Task führt `task test:changed` + `task freshness:regenerate` + `task freshness:check`.
+
+---
+
+## File Structure
+
+| Datei | Verantwortung |
+|---|---|
+| `.claude/skills/migrate-foreign-code/SKILL.md` | Entry: Wann greift der Skill, die 6 Phasen, Decision-Gates, Verweise auf Patterns + bestehende Skills |
+| `.claude/skills/migrate-foreign-code/references/pattern-vendoring.md` | In-Repo-Vendoring-Idiom |
+| `.claude/skills/migrate-foreign-code/references/pattern-multistage-build.md` | Multi-Stage-Build Client+Server |
+| `.claude/skills/migrate-foreign-code/references/pattern-source-only-package.md` | Source-only-Package via Alias |
+| `.claude/skills/migrate-foreign-code/references/pattern-hybrid-backend.md` | Backend-Tausch hinter Interface |
+| `.claude/skills/migrate-foreign-code/references/pattern-embed-bridge.md` | postMessage-Embed-Bridge |
+| `.claude/skills/migrate-foreign-code/references/pattern-data-and-auth.md` | DB/PVC + host-owned Auth, beide Brands |
+| `.claude/skills/OVERVIEW.md` | Modify: neuer Skill-Eintrag |
+
+Konvention pro Pattern-Datei: `# Titel` → `## Muster (generisch)` → `## VideoVault-Beispiel` → `## Stolpersteine`.
+
+---
+
+### Task 1: `pattern-vendoring.md`
+
+**Files:**
+- Create: `.claude/skills/migrate-foreign-code/references/pattern-vendoring.md`
+
+- [ ] **Step 1: Verzeichnis + Datei anlegen, Inhalt schreiben**
+
+Inhalt (Quelle: 2b „vendored wie website/brett", L §„git add -f", §„node_modules committed"):
+- **Muster:** Fremdcode in-repo holen statt als externe Dependency; in-repo `Dockerfile` + CI-Workflow nach dem etablierten `website/`/`brett/`-Idiom; vendored Quelle wird per Build neu gebaut.
+- **VideoVault-Beispiel:** `packages/videovault-player` + VideoVault-Service als in-repo Quelle; CI baut dasselbe Image neu.
+- **Stolpersteine:** `git add -f` für Dateien in `.gitignore`-geschützten Verzeichnissen; **niemals** `node_modules` committen (zweimal passiert → `git rm -r --cached` + `git commit --amend`); `npm install` Peer-Dep-Konflikt → `--legacy-peer-deps`.
+
+- [ ] **Step 2: Struktur-Check**
+
+Run: `grep -c '^## ' .claude/skills/migrate-foreign-code/references/pattern-vendoring.md`
+Expected: `3` (die drei Pflicht-Abschnitte)
+
+- [ ] **Step 3: Keine Domain-Literale**
+
+Run: `grep -nE '(mentolder|korczewski)\.de' .claude/skills/migrate-foreign-code/references/pattern-vendoring.md || echo OK`
+Expected: `OK`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .claude/skills/migrate-foreign-code/references/pattern-vendoring.md
+git commit -m "docs(skill): add migrate-foreign-code pattern-vendoring"
+```
+
+---
+
+### Task 2: `pattern-multistage-build.md`
+
+**Files:**
+- Create: `.claude/skills/migrate-foreign-code/references/pattern-multistage-build.md`
+
+- [ ] **Step 1: Inhalt schreiben**
+
+Inhalt (Quelle: 2b Architecture):
+- **Muster:** Multi-Stage-Build — Client (`vite build` → `dist/public`) + Server (`esbuild` → `dist/index.js`); Runtime startet einen Express-Server, der SPA **und** `/api` auf **einem** Port serviert. Base-Image `node:bookworm-slim`; native/System-Deps via APT.
+- **VideoVault-Beispiel:** `ffmpeg`/`ffprobe` via APT im Runtime-Image; Client-first bleibt (FSAA, WASM), server-ffmpeg ist separat (siehe `pattern-hybrid-backend`).
+- **Stolpersteine:** native Deps müssen im Slim-Image nachinstalliert werden; ein Port für SPA+API vermeidet Ingress-Sonderfälle.
+
+- [ ] **Step 2: Struktur-Check** — `grep -c '^## ' …pattern-multistage-build.md` → Expected `3`
+- [ ] **Step 3: Keine Domain-Literale** — `grep -nE '(mentolder|korczewski)\.de' …pattern-multistage-build.md || echo OK` → Expected `OK`
+- [ ] **Step 4: Commit**
+
+```bash
+git add .claude/skills/migrate-foreign-code/references/pattern-multistage-build.md
+git commit -m "docs(skill): add migrate-foreign-code pattern-multistage-build"
+```
+
+---
+
+### Task 3: `pattern-source-only-package.md`
+
+**Files:**
+- Create: `.claude/skills/migrate-foreign-code/references/pattern-source-only-package.md`
+
+- [ ] **Step 1: Inhalt schreiben**
+
+Inhalt (Quelle: L §„Source-only Package", §„Dual-Build-Pattern", §„FFmpeg: toBlobURL", §„Duplicate React"):
+- **Muster:** Geteilter Code als source-only Package — kein Build-Schritt, reiner Alias-Mechanismus. `package.json`: `main`/`types` = `src/index.ts`; Einbindung via `resolve.alias` (vite/vitest) + `paths` (tsconfig); Tests laufen direkt im Package.
+- **VideoVault-Beispiel:** `@videovault-player`-Alias; Dual-Build (`mode === 'lib'` → `build.lib` + externals; sonst App-Dev-Server); `toBlobURL('/ffmpeg/…')` aus `@ffmpeg/util` statt `new URL(...)` (ab `@ffmpeg/core` v0.12 kein `dist/umd`-Specifier mehr), Core-Dateien via Copy-Script nach `public/ffmpeg/`, `optimizeDeps.exclude`.
+- **Stolpersteine:** **Duplicate React instances** über node_modules-Grenzen → `resolve.alias` für `react`+`react-dom`; Hooks **vor** frühem `return null` platzieren (sonst „Rendered more hooks").
+
+- [ ] **Step 2: Struktur-Check** — `grep -c '^## ' …` → Expected `3`
+- [ ] **Step 3: Keine Domain-Literale** — `… || echo OK` → Expected `OK`
+- [ ] **Step 4: Commit**
+
+```bash
+git add .claude/skills/migrate-foreign-code/references/pattern-source-only-package.md
+git commit -m "docs(skill): add migrate-foreign-code pattern-source-only-package"
+```
+
+---
+
+### Task 4: `pattern-hybrid-backend.md`
+
+**Files:**
+- Create: `.claude/skills/migrate-foreign-code/references/pattern-hybrid-backend.md`
+
+- [ ] **Step 1: Inhalt schreiben**
+
+Inhalt (Quelle: L §„Phase 2c", 2c Architecture/Korrektur):
+- **Muster:** Das in der Entkopplung (Phase 1) extrahierte Interface zahlt sich aus — Backend-Tausch **ohne** UI-Änderung; Selektor wählt Implementierung per **Capability-Signal**, ohne neues Typ-Feld am Domänen-Objekt.
+- **VideoVault-Beispiel:** `FileHandleRegistry` vorhanden → WASM-Backend, sonst → Server-Backend; nur eine `serverSplitterBackend`-Impl + `selectSplitterBackend`-Selektor; kein neues k8s-Manifest (2b-Infra wiederverwendet).
+- **Stolpersteine:** GPU-Annahme prüfen — `ffmpeg -c copy` (Stream-Copy) ist **I/O-gebunden**, nvenc/GPU bringt null; Befund via Code-Erkundung **beim Planen**, nicht erst beim Bauen.
+
+- [ ] **Step 2: Struktur-Check** — `grep -c '^## ' …` → Expected `3`
+- [ ] **Step 3: Keine Domain-Literale** — `… || echo OK` → Expected `OK`
+- [ ] **Step 4: Commit**
+
+```bash
+git add .claude/skills/migrate-foreign-code/references/pattern-hybrid-backend.md
+git commit -m "docs(skill): add migrate-foreign-code pattern-hybrid-backend"
+```
+
+---
+
+### Task 5: `pattern-embed-bridge.md`
+
+**Files:**
+- Create: `.claude/skills/migrate-foreign-code/references/pattern-embed-bridge.md`
+
+- [ ] **Step 1: Inhalt schreiben**
+
+Inhalt (Quelle: 2d Architecture, SP1 §Widget-Kontrakt):
+- **Muster:** Host bindet die migrierte App als `<iframe>`-Widget ein; Kommunikation per **postMessage-Bridge** mit **Origin-Validierung** auf beiden Seiten; Host besitzt die Daten und steuert per Props + imperativem Handle; Widget bleibt zustandslos.
+- **VideoVault-Beispiel:** Widget-Seite (`bridge.ts`) aus 2a; Host-Seite (`mediaviewer-bridge.ts`) spiegelt das Protokoll; versioniertes Hilfsvideo-Manifest mit **Zod-validiertem Loader**; Companion-Panel postet `setVideos`, empfängt `select`/`progress`/`ended`/`error` origin-validiert; Widget-Domain via `MEDIAVIEWER_HOST` aus `configmap-domains`.
+- **Stolpersteine:** Widget-**Allowlist** muss den Host-Origin enthalten (Korrektur in 2d); Domain nie hardcoden → über `configmap-domains` + Env-Injektion.
+
+- [ ] **Step 2: Struktur-Check** — `grep -c '^## ' …` → Expected `3`
+- [ ] **Step 3: Keine Domain-Literale** — `… || echo OK` → Expected `OK`
+- [ ] **Step 4: Commit**
+
+```bash
+git add .claude/skills/migrate-foreign-code/references/pattern-embed-bridge.md
+git commit -m "docs(skill): add migrate-foreign-code pattern-embed-bridge"
+```
+
+---
+
+### Task 6: `pattern-data-and-auth.md`
+
+**Files:**
+- Create: `.claude/skills/migrate-foreign-code/references/pattern-data-and-auth.md`
+
+- [ ] **Step 1: Inhalt schreiben**
+
+Inhalt (Quelle: 2b §DB/PVC, 2d §Auth, CLAUDE.md §beide Namespaces):
+- **Muster:** Persistenz über neue DB in der zentralen `shared-db`; Zwischendaten über RWO-PVC (single-replica `Recreate`); host-owned Auth (Keycloak/oauth2-proxy) — die App vertraut dem Host; Domain via `configmap-domains`; cross-cutting Änderungen (DB/OIDC/Schema) explizit über **beide** Namespaces (`workspace` + `workspace-korczewski`).
+- **VideoVault-Beispiel:** neue DB `videovault` in `shared-db`; Upload-PVC (RWO, `Recreate`); Auth durch den Workspace-Host; beide Brands.
+- **Stolpersteine:** Namespaces sind separate per-Brand-Deployments im selben Fleet-Cluster → Migration muss in beide ausgerollt werden; verweise für Mechanik auf `keycloak-realm-sync` / `secret-rotation` / `fleet-ops` statt sie zu duplizieren.
+
+- [ ] **Step 2: Struktur-Check** — `grep -c '^## ' …` → Expected `3`
+- [ ] **Step 3: Keine Domain-Literale** — `… || echo OK` → Expected `OK`
+- [ ] **Step 4: Commit**
+
+```bash
+git add .claude/skills/migrate-foreign-code/references/pattern-data-and-auth.md
+git commit -m "docs(skill): add migrate-foreign-code pattern-data-and-auth"
+```
+
+---
+
+### Task 7: `SKILL.md` (Spine)
+
+**Files:**
+- Create: `.claude/skills/migrate-foreign-code/SKILL.md`
+
+- [ ] **Step 1: Frontmatter + Inhalt schreiben**
+
+```markdown
+---
+name: migrate-foreign-code
+description: Use when bringing an externally-developed app into the Bachelorprojekt platform — decouple it in its origin repo, vendor it, containerize it, move client-only capabilities server-side, and integrate it (Kustomize/Ingress/Keycloak/embed) across both brands. A 6-phase meta-runbook over dev-flow.
+---
+```
+
+Body (schlank, progressive disclosure):
+- **Wann diese Skill greift:** Übernahme einer bestehenden Fremd-App ins Bachelorprojekt.
+- **Schicht-Hinweis:** Operator-getrieben; **jede Phase ist ein eigener `dev-flow-plan`/`dev-flow-execute`-Zyklus** — der Skill ersetzt dev-flow nicht, er sequenziert es.
+- **Die 6 Phasen** (Tabelle generisch + VideoVault-Instanz, identisch zur Spec): 0 Assess & Decide · 1 Decouple in-place · 2 Vendor · 3 Containerize · 4 Server-Capabilities · 5 Platform-Integration.
+- **Decision-Gates:** zwischen jeder Phase Voraussetzungen/Reversibilität/weiter-stopp; Gate 0→1 = Fitness bejaht + Ursprungs-Suite grün.
+- **Pattern-Katalog:** Liste mit relativen Links auf alle 6 `references/pattern-*.md` (Phase-Zuordnung dazuschreiben).
+- **Verwandte Skills:** Tabelle — `dev-flow-plan`/`-execute` (pro Phase), `workspace-deploy`/`cluster-deployment` (Phase 3), `keycloak-realm-sync`/`secret-rotation`/`fleet-ops` (Phase 5).
+- **Quelle der Learnings:** Pfade in `~/projects/docs/superpowers/` nennen (destillierte Kopie, kein Live-Link).
+
+- [ ] **Step 2: Frontmatter-Felder vorhanden**
+
+Run: `head -4 .claude/skills/migrate-foreign-code/SKILL.md | grep -E '^(name|description):'`
+Expected: beide Zeilen `name:` und `description:`
+
+- [ ] **Step 3: Alle Pattern-Links existieren**
+
+```bash
+cd .claude/skills/migrate-foreign-code
+for f in $(grep -oE 'references/pattern-[a-z-]+\.md' SKILL.md | sort -u); do
+  test -f "$f" && echo "OK $f" || echo "MISSING $f"
+done
+```
+Expected: 6× `OK`, kein `MISSING`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .claude/skills/migrate-foreign-code/SKILL.md
+git commit -m "docs(skill): add migrate-foreign-code SKILL.md (6-phase runbook)"
+```
+
+---
+
+### Task 8: `OVERVIEW.md`-Eintrag
+
+**Files:**
+- Modify: `.claude/skills/OVERVIEW.md`
+
+- [ ] **Step 1: Eintrag ergänzen**
+
+Neue Rubrik „## Migration" (nach „Feature Discovery") mit Tabellenzeile:
+`| `migrate-foreign-code` | Eine bestehende externe App ins Bachelorprojekt übernehmen — 6-Phasen-Reise (entkoppeln → vendoren → containerisieren → server-side → integrieren) über dev-flow, mit Pattern-Katalog. |`
+
+- [ ] **Step 2: Verifizieren**
+
+Run: `grep -c 'migrate-foreign-code' .claude/skills/OVERVIEW.md`
+Expected: `>= 1`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .claude/skills/OVERVIEW.md
+git commit -m "docs(skill): list migrate-foreign-code in skills OVERVIEW"
+```
+
+---
+
+### Task 9: Verifikation (CI-Äquivalent)
+
+**Files:** keine (nur Checks)
+
+- [ ] **Step 1: Geänderte Tests**
+
+Run: `task test:changed`
+Expected: PASS (oder „keine relevanten Tests" — Doku-only).
+
+- [ ] **Step 2: Freshness regenerieren**
+
+Run: `task freshness:regenerate`
+Erwartung: regeneriert Skill-Index/Docs-Artefakte (build-docs entdeckt das neue Skill).
+
+- [ ] **Step 3: Regenerierte Artefakte committen (falls Diff)**
+
+```bash
+git add -A
+git diff --cached --quiet || git commit -m "chore(freshness): regenerate after migrate-foreign-code skill"
+```
+
+- [ ] **Step 4: Freshness-Check**
+
+Run: `task freshness:check`
+Expected: PASS (inkl. S1–S4-Ratchet + Baseline-Key-Count-Assertion).
+
+- [ ] **Step 5: Push**
+
+```bash
+git push
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:** Alle 6 Phasen → Task 7 (SKILL.md); alle 6 Patterns → Tasks 1–6; OVERVIEW → Task 8; Verifikation (freshness/links/frontmatter) → Tasks 2/3-Steps + Task 9. Decision-Gates → Task 7 Body. Relationship-to-existing-skills → Task 7 „Verwandte Skills". ✓
+**Placeholder scan:** Jeder Pattern-Task nennt konkrete Quell-Sektionen + Stichpunkte (kein „TBD"). Code-Step (SKILL.md-Frontmatter) zeigt den realen Block. ✓
+**Konsistenz:** Dateinamen identisch über File-Structure-Tabelle, Tasks 1–6, SKILL.md-Links (Task 7 Step 3 prüft das maschinell). ✓

--- a/docs/superpowers/specs/2026-06-15-migrate-foreign-code-design.md
+++ b/docs/superpowers/specs/2026-06-15-migrate-foreign-code-design.md
@@ -1,0 +1,181 @@
+---
+ticket_id: null
+plan_ref: docs/superpowers/plans/2026-06-15-migrate-foreign-code.md
+status: active
+date: 2026-06-15
+---
+
+# `migrate-foreign-code` Skill — Design Spec (Sub-Projekt 3)
+
+## Context
+
+Dies ist **Sub-Projekt 3** des VideoVault-Vorhabens. Die Dekomposition (aus
+`~/projects/docs/superpowers/specs/2026-06-15-videovault-split-design.md`, § Gesamtvorhaben):
+
+| # | Sub-Projekt | Repo | Status |
+|---|---|---|---|
+| 1 | VideoVault-Split (Mediaviewer-Widget + Bibliothek) | `~/projects/` | ✅ fertig |
+| 2 | Beide Apps ins Bachelorprojekt übernehmen (Container, Kustomize, Ingress, Keycloak-Auth) | `~/projects/` → `~/Bachelorprojekt/` | ✅ fertig (Phasen 2a–2d) |
+| **3** | **Fremdcode-Migrations-Skill aus den Learnings** | `~/Bachelorprojekt/.claude/skills/` | **dieser Spec** |
+
+Abhängigkeit **1 → 2 → 3**: SP1 und SP2 wurden bewusst zuerst durchgeführt, damit SP3 aus
+*gelebter* Erfahrung destilliert wird, nicht aus Theorie.
+
+**Rohmaterial** (liegt in `~/projects/`, wird in den Skill destilliert — kein Live-Link):
+- `docs/superpowers/specs/2026-06-15-videovault-migration-learnings.md` — die zentrale Learnings-Sammlung
+- `docs/superpowers/specs/2026-06-15-videovault-split-design.md` — SP1-Design (Entkopplung)
+- `docs/superpowers/plans/2026-06-15-videovault-split.md` — SP1-Plan
+- `docs/superpowers/plans/2026-06-15-videovault-migration-2b-service-deploy.md` — SP2b (Vendoring/Build/DB/PVC)
+- `docs/superpowers/plans/2026-06-15-videovault-migration-2c-server-split.md` — SP2c (Hybrid-Backend)
+- `docs/superpowers/plans/2026-06-15-videovault-migration-2d-embed.md` — SP2d (Embed-Bridge, Auth, Brands)
+
+## Problem
+
+Das Bachelorprojekt wird in Zukunft weitere bestehende, extern entwickelte Apps aufnehmen
+(VideoVault war die erste). Jede solche Migration durchläuft dieselbe Reise — Entkoppeln,
+Vendoren, Containerisieren, server-seitige Fähigkeiten nachziehen, in die Plattform integrieren —
+mit denselben wiederkehrenden Stolpersteinen. Dieses Wissen liegt aktuell verstreut in den
+SP1/SP2-Artefakten in einem **anderen Repo** und verfällt, wenn es nicht kodifiziert wird.
+
+## Bestätigte Entscheidungen (aus dem Brainstorming)
+
+1. **Scope: volles Playbook (SP1 + SP2).** Der Skill deckt die ganze Reise ab —
+   Entkopplungs-Vorbereitung im Ursprungs-Repo **und** Migration ins Bachelorprojekt.
+2. **Form: Referenz-Runbook.** `SKILL.md` (schlank, progressive disclosure) + `references/`
+   (Pattern-Katalog). Operator-getrieben; respektiert die „Repo-Arbeit immer über
+   `dev-flow-*` einsteigen"-Regel — der Skill *sequenziert* dev-flow-Zyklen, ersetzt sie nicht.
+3. **Ziel-Repo: Bachelorprojekt.** Skill lebt unter `.claude/skills/migrate-foreign-code/`.
+4. **Generalisierung: Pattern-Katalog.** Generische Migrations-Phasen im `SKILL.md` + ein
+   Katalog benannter, wiederverwendbarer Patterns in `references/`, jeweils mit der konkreten
+   VideoVault-Instanz als Beispiel.
+5. **Umsetzung: seriell, ein Plan.** `SKILL.md` + die 6 Pattern-Dateien werden nacheinander
+   geschrieben (keine Multi-Agent-Orchestrierung). Planung über getrimmtes `dev-flow-plan`:
+   **kein DB-Ticket, kein `stage-plan`, kein Factory-Enqueue.**
+
+## Goals
+
+- Die SP1/SP2-Erfahrung als **eigenständiges, wiederverwendbares Skill** im Bachelorprojekt
+  festhalten, das die nächste Fremdcode-Migration messbar beschleunigt.
+- Eine generische **6-Phasen-Reise** mit expliziten Decision-Gates bereitstellen.
+- Einen **Pattern-Katalog** der wiederkehrenden technischen Muster + ihrer Stolpersteine liefern.
+- Sauber an die **bestehenden Skills** andocken (`dev-flow-*`, `workspace-deploy`,
+  `cluster-deployment`, `keycloak-realm-sync`, `secret-rotation`) — routen, nicht duplizieren.
+
+## Non-Goals (YAGNI)
+
+- **Keine** Automatik/Meta-Orchestrierung (kein factory-autopilot-Stil) — operator-getrieben.
+- **Keine** Duplizierung von Deploy-/Auth-/Secret-Mechanik, die bereits Skills haben.
+- **Keine** retroaktive Umschreibung der SP1/SP2-Artefakte in `~/projects/`.
+- **Kein** generischer „migriere beliebige Sprache/Framework"-Anspruch über das hinaus, was die
+  Patterns mit der VideoVault-Instanz tatsächlich belegen — der Katalog wächst mit künftigen Migrationen.
+
+## Architektur — `SKILL.md` + Pattern-Katalog
+
+```
+.claude/skills/migrate-foreign-code/
+├── SKILL.md                          # 6 generische Phasen + Decision-Gates, schlank
+└── references/
+    ├── pattern-vendoring.md
+    ├── pattern-multistage-build.md
+    ├── pattern-source-only-package.md
+    ├── pattern-hybrid-backend.md
+    ├── pattern-embed-bridge.md
+    └── pattern-data-and-auth.md
+```
+
+> **Konventions-Hinweis:** Alle bestehenden Bachelorprojekt-Skills sind heute Single-File-`SKILL.md`;
+> ein gemeinsames `.claude/skills/references/` hält nur dev-flow-übergreifende Docs. Dieser Skill
+> führt bewusst ein **per-Skill `references/`-Unterverzeichnis** ein (Standard-Skill-Konvention,
+> progressive disclosure) — der Pattern-Katalog ist zu umfangreich für einen Fließtext und profitiert
+> von Disclosure-on-demand. `SKILL.md` verlinkt die Pattern-Dateien per relativem Pfad.
+
+### Die 6 Phasen (im `SKILL.md`)
+
+Jede Phase = ein eigener `dev-flow-plan`/`dev-flow-execute`-Zyklus mit Eingangs-/Ausgangs-Gate.
+
+| Phase | Generisch | VideoVault-Instanz (Beispiel) |
+|---|---|---|
+| **0 Assess & Decide** | Stack/Build/Daten/Auth inventarisieren; Migrations-Fitness-Gate (lohnt sich die Übernahme?) | Zwei Apps, client-first, FSAA-basiert |
+| **1 Decouple in-place** | God-Module zerlegen, Shared-Packages extrahieren, Verhalten per Characterization-Tests einfrieren — **im Ursprungs-Repo gegen dessen Test-Suite** | SP1: `useVideoManager` (1762 Z.) → 3 Hooks; `videovault-player`-Package |
+| **2 Vendor** | Code in-repo holen (Dockerfile + CI, Idiom wie `website/`/`brett/`); source-only-Package via Alias | SP2a |
+| **3 Containerize** | Multi-Stage-Build (Client + Server → 1 Runtime-Port); Base-Image, native Deps; neue DB in `shared-db`; PVC für Zwischendaten | SP2b |
+| **4 Server-Capabilities** | Client-only-Backend hinter dem **bestehenden Interface** auf server-resident tauschen (Hybrid via Capability-Signal) | SP2c (server-side Split) |
+| **5 Platform-Integration** | Kustomize/Ingress; host-owned Auth (Keycloak/oauth2-proxy); Embed-Bridge; `configmap-domains`; **beide Brands** | SP2d (Companion-Panel) |
+
+### Der Pattern-Katalog (`references/`)
+
+Jede Datei: **(a)** das generische Muster, **(b)** die konkrete VideoVault-Instanz als Beispiel,
+**(c)** die zugehörigen Stolpersteine/Workarounds aus den Learnings.
+
+1. **`pattern-vendoring.md`** — In-Repo-Vendoring-Idiom (Dockerfile + CI wie `website/`/`brett/`),
+   `git add -f` für gitignore-geschützte Verzeichnisse, **kein** committed `node_modules`
+   (Stolperstein: zweimal versehentlich committet → `git rm -r --cached`).
+2. **`pattern-multistage-build.md`** — Client (`vite build` → `dist/public`) + Server
+   (`esbuild` → `dist/index.js`) → ein Runtime-Port; Base-Image `bookworm-slim`; native/System-Deps
+   (`ffmpeg`/`ffprobe` via APT).
+3. **`pattern-source-only-package.md`** — `file:packages/*`-Alias, `main`/`types` = `src/index.ts`,
+   `resolve.alias` für `react`/`react-dom` (Duplicate-React-Instances-Falle), `paths` in tsconfig,
+   Dual-Build (`mode === 'lib'` vs. App), `toBlobURL` für WASM-Assets (`@ffmpeg/core`-Specifier-Falle).
+4. **`pattern-hybrid-backend.md`** — Das in Phase 1 extrahierte Interface zahlt sich aus: Backend-Tausch
+   ohne UI-Änderung; Selektor per **Capability-Signal** (z.B. `FileHandleRegistry` → WASM, sonst Server),
+   ohne neues Typ-Feld; Falle: „Stream-Copy (`-c copy`) ist I/O-gebunden → GPU bringt null".
+5. **`pattern-embed-bridge.md`** — postMessage-Bridge Host↔iframe mit **Origin-Validierung**;
+   versioniertes Manifest (Zod-validierter Loader); Props + imperatives Handle als Kontrakt;
+   Widget-Allowlist-Korrektur.
+6. **`pattern-data-and-auth.md`** — Neue DB in zentraler `shared-db` über **beide** Namespaces
+   (`workspace` + `workspace-korczewski`); host-owned Auth (Keycloak/oauth2-proxy); Domain via
+   `configmap-domains` + Env-Injektion; beide Brands.
+
+### Decision-Gates
+
+Zwischen jeder Phase ein explizites Gate: **Voraussetzungen erfüllt?** · **reversibel?** ·
+**weiter/stopp?**. Spiegelt das SP-Prinzip „erst in-place stabilisieren, dann migrieren". Beispiel
+Gate 0→1: Migrations-Fitness bejaht und Ursprungs-Test-Suite grün, bevor entkoppelt wird.
+
+## Relationship to existing skills
+
+Der Skill ist ein **Meta-Runbook**, das bestehende Skills sequenziert statt sie zu duplizieren:
+
+| Phase | Ruft / verweist auf |
+|---|---|
+| Alle | `dev-flow-plan` / `dev-flow-execute` (pro Phase ein Zyklus) |
+| 3 | `workspace-deploy`, `cluster-deployment` (Manifeste/DB/PVC) |
+| 5 | `keycloak-realm-sync` (OIDC/Auth), `secret-rotation` (Credentials), `fleet-ops` (beide Brands) |
+
+`OVERVIEW.md` erhält einen Eintrag unter einer passenden Rubrik (z.B. „Development Flow" oder eine
+neue „Migration"-Zeile).
+
+## Verification (leicht)
+
+Kein klassischer Unit-Test (reine Doku). Validierung:
+- `SKILL.md` hat gültiges Frontmatter (`name`, `description`).
+- Alle `references/`-Links lösen relativ auf.
+- Skill ist invokebar (per `description` auto-discoverbar) und in `OVERVIEW.md` gelistet.
+- Falls Skill-HTML in den Docs-Build (`scripts/build-docs.mjs` → `k3d/docs-content-built/`) einfließt:
+  `task freshness:regenerate` + `task freshness:check` grün (beim Schreiben des Plans verifizieren).
+
+## Execution Path (gemäß Entscheidung 5)
+
+Getrimmtes `dev-flow-plan`:
+1. Worktree `feature/migrate-foreign-code` (✅ angelegt) + Branch-Claim (✅).
+2. Diese Spec nach `docs/superpowers/specs/2026-06-15-migrate-foreign-code-design.md` → commit/push.
+3. Plan-Schreiben (`superpowers:writing-plans`) → `docs/superpowers/plans/2026-06-15-migrate-foreign-code.md`,
+   gegen `.claude/skills/references/plan-quality-gates.md`; serielles Authoring von `SKILL.md` + 6 Pattern-Dateien.
+4. Plan committen/pushen. **STOPP** — kein Ticket, kein `stage-plan`, kein Factory-Enqueue.
+
+Implementierung später via `dev-flow-execute` (oder manuell), wenn freigegeben.
+
+## Risks & Mitigations
+
+| Risiko | Mitigation |
+|---|---|
+| **Über-Generalisierung** — Patterns zu abstrakt, unbrauchbar | Jedes Pattern trägt die konkrete VideoVault-Instanz als Beispiel |
+| **Learnings-Drift** — Quelle in `~/projects/`, Skill in `~/Bachelorprojekt/` | Spec nennt die Quell-Pfade; Skill ist destillierte, eigenständige Kopie (kein Live-Link) |
+| **Per-Skill `references/` ist neu** im BA-Repo | Bewusste, im Spec dokumentierte Konvention; relative Links |
+| **Single-File-Erwartung** anderer Tooling | Beim Plan prüfen, ob Docs-Build/Freshness das `references/`-Subdir korrekt aufnimmt |
+
+## Out of Scope
+
+- Implementierung der nächsten konkreten Fremdcode-Migration (der Skill *ermöglicht* sie, führt sie nicht durch).
+- Erweiterung des Pattern-Katalogs über die durch VideoVault belegten Muster hinaus (wächst künftig organisch).
+- Jegliche Änderung an den SP1/SP2-Artefakten in `~/projects/`.


### PR DESCRIPTION
## Sub-Projekt 3 — Fremdcode-Migrations-Skill

Kodifiziert die VideoVault-Migrationserfahrung (SP1 Split + SP2 Migration) als wiederverwendbares Bachelorprojekt-Skill.

### Was
- **`.claude/skills/migrate-foreign-code/SKILL.md`** — 6-Phasen-Meta-Runbook über dev-flow: Assess → Decouple → Vendor → Containerize → Server-Capabilities → Platform-Integration, mit Decision-Gates.
- **`references/pattern-*.md`** (6) — Pattern-Katalog: vendoring · multistage-build · source-only-package · hybrid-backend · embed-bridge · data-and-auth. Je generisches Muster + VideoVault-Beispiel + Stolpersteine.
- **`OVERVIEW.md`** — neue „Migration"-Rubrik.
- **Spec + Plan** unter `docs/superpowers/{specs,plans}/2026-06-15-migrate-foreign-code*`.

### Scope
Reine Dokumentation. Operator-getrieben — sequenziert bestehende Skills (`dev-flow-*`, `workspace-deploy`, `keycloak-realm-sync`, `secret-rotation`, `fleet-ops`), dupliziert sie nicht.

### Verifikation
- `task test:changed` → 50/50 pass
- `task freshness:check` → EXIT=0, ERRORS=0
- Struktur-/Domain-Literal-/Frontmatter-/Link-Checks grün

🤖 Generated with [Claude Code](https://claude.com/claude-code)