### PR TITLE
fix(website): set MEDIAVIEWER_HOST in prod domain-config

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -260,6 +260,7 @@ tasks:
       - task: test:unit:shared-db-initdb-selfheal
       - task: test:unit:wg-mesh-fullmesh
       - task: test:unit:recovery-domain-durability
+      - task: test:unit:mediaviewer-host-durability
       - task: test:unit:ticket-external-id
       - task: test:unit:ticket-triage
       - task: test:unit:website-ci-deploy
@@ -403,6 +404,11 @@ tasks:
     internal: true
     cmds:
       - ./tests/unit/lib/bats-core/bin/bats tests/unit/recovery-domain-durability.bats
+
+  test:unit:mediaviewer-host-durability:
+    internal: true
+    cmds:
+      - ./tests/unit/lib/bats-core/bin/bats tests/unit/mediaviewer-host-durability.bats
 
   test:unit:ticket-external-id:
     internal: true

--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 437,
+      "file_count": 438,
       "files": [
         "tests/.gitignore",
         "tests/batch/batch-gap-analysis.bats",
@@ -377,6 +377,7 @@
         "tests/unit/lib/bats-support",
         "tests/unit/manifests.bats",
         "tests/unit/mcp-supergateway-stateful.bats",
+        "tests/unit/mediaviewer-host-durability.bats",
         "tests/unit/mishap-tracker.bats",
         "tests/unit/newsletter-scheduled-publish.bats",
         "tests/unit/openclaw-taskfile.bats",

--- a/docs/generated/api-map.json
+++ b/docs/generated/api-map.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-16T01:40:45.314Z",
+  "generatedAt": "2026-06-16T01:43:04.022Z",
   "endpoints": [
     {
       "path": "/api/admin/angebote/save",

--- a/docs/generated/api-surface.md
+++ b/docs/generated/api-surface.md
@@ -1,6 +1,6 @@
 # API Surface Map
 
-> Generated at 2026-06-16T01:40:45.314Z
+> Generated at 2026-06-16T01:43:04.022Z
 
 | Path | Methods | Auth | File |
 |------|---------|------|------|

--- a/docs/generated/blast-radius.md
+++ b/docs/generated/blast-radius.md
@@ -1,5 +1,5 @@
 # Blast-Radius-Report
-> Generated: 2026-06-16T01:40:45.426Z
+> Generated: 2026-06-16T01:43:04.099Z
 > Nodes: 78 | Edges: 1613 | Isolated: 2
 
 ## Ranking (transitive Abhängige)

--- a/docs/generated/graph.json
+++ b/docs/generated/graph.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-16T01:40:45.228Z",
+  "generatedAt": "2026-06-16T01:43:03.957Z",
   "nodes": [
     {
       "id": "admin-actions-cleanup",

--- a/k3d/docs-content-built/architecture/index.html
+++ b/k3d/docs-content-built/architecture/index.html
@@ -178,7 +178,7 @@
 <body>
   <div class="header">
     <h1>⬡ Architektur — Living Docs</h1>
-    <span class="meta">Generiert: 2026-06-16T01:40:45.362Z</span>
+    <span class="meta">Generiert: 2026-06-16T01:43:04.057Z</span>
   </div>
 
   <div class="stats">

--- a/prod/configmap-domains.yaml
+++ b/prod/configmap-domains.yaml
@@ -17,6 +17,14 @@ data:
   BRETT_DOMAIN: "brett.${PROD_DOMAIN}"
   LIVEKIT_DOMAIN: "livekit.${PROD_DOMAIN}"
   STREAM_DOMAIN: "stream.${PROD_DOMAIN}"
+  # Mediaviewer host (mediaviewer.<domain>). MUST be set here for the same reason
+  # as RECOVER_DOMAIN below: this file is a strategic-merge patch over base
+  # k3d/configmap-domains.yaml, so without it the live domain-config keeps the dev
+  # value `mediaviewer.localhost`. domain-config is the runtime SSOT the website
+  # reads (configMapKeyRef → PortalLayout SSR → PortalSidekick/MediaviewerPanel),
+  # so the dev value makes the Sidekick mediaviewer iframe load mediaviewer.localhost
+  # and its postMessage target origin mismatch the live origin on every deploy.
+  MEDIAVIEWER_HOST: "mediaviewer.${PROD_DOMAIN}"
   # Recovery filebrowser host — registry-sourced (recover.<domain>). MUST be set
   # here: this file is a strategic-merge patch over base k3d/configmap-domains.yaml,
   # so without it the live domain-config keeps the dev value `recover.localhost`,

--- a/tests/unit/mediaviewer-host-durability.bats
+++ b/tests/unit/mediaviewer-host-durability.bats
@@ -1,0 +1,51 @@
+#!/usr/bin/env bats
+# Regression: the Sidekick mediaviewer (mediaviewer.<domain>) must survive a prod deploy.
+#
+# Bug this guards against:
+#   prod/configmap-domains.yaml carried no MEDIAVIEWER_HOST, so the strategic-merge
+#   over base k3d/configmap-domains.yaml left the live domain-config (both the
+#   workspace and website namespaces) with the dev value `mediaviewer.localhost`.
+#   The website reads MEDIAVIEWER_HOST from domain-config (configMapKeyRef) and
+#   passes it through PortalLayout (SSR) → PortalSidekick → MediaviewerPanel, which
+#   builds `widgetOrigin = https://<MEDIAVIEWER_HOST>`. With the dev value the embed
+#   iframe loaded https://mediaviewer.localhost/embed.html (dead in prod) and every
+#   postMessage targeted the dev origin → console error on web.<domain> and a broken
+#   mediaviewer panel. Mirrors the RECOVER_DOMAIN durability bug [T000398].
+
+setup() {
+  REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+  PROD_DOMAINS="$REPO_ROOT/prod/configmap-domains.yaml"
+  BASE_DOMAINS="$REPO_ROOT/k3d/configmap-domains.yaml"
+  TASKFILE="$REPO_ROOT/Taskfile.yml"
+  WEBSITE="$REPO_ROOT/k3d/website.yaml"
+}
+
+@test "prod domain-config defines MEDIAVIEWER_HOST (else merge leaves dev mediaviewer.localhost)" {
+  run grep -qE '^[[:space:]]+MEDIAVIEWER_HOST:' "$PROD_DOMAINS"
+  [ "$status" -eq 0 ]
+}
+
+@test "prod MEDIAVIEWER_HOST derives from \${PROD_DOMAIN} (not a hardcoded host)" {
+  run grep -qE '^[[:space:]]+MEDIAVIEWER_HOST:[[:space:]]*"mediaviewer\.\$\{PROD_DOMAIN\}"' "$PROD_DOMAINS"
+  [ "$status" -eq 0 ]
+}
+
+@test "prod deploy envsubst list includes PROD_DOMAIN (fills MEDIAVIEWER_HOST placeholder)" {
+  # The prod-overlay deploy pipes kustomize output through envsubst "$ENVSUBST_VARS";
+  # PROD_DOMAIN must be in that list so MEDIAVIEWER_HOST: "mediaviewer.${PROD_DOMAIN}"
+  # is substituted rather than reaching the cluster literally.
+  run grep -qE 'ENVSUBST_VARS=.*PROD_DOMAIN' "$TASKFILE"
+  [ "$status" -eq 0 ]
+}
+
+@test "website Deployment still sources MEDIAVIEWER_HOST from domain-config" {
+  # Non-regression: the consumer wiring the fix depends on must stay intact.
+  run grep -qF 'key: MEDIAVIEWER_HOST' "$WEBSITE"
+  [ "$status" -eq 0 ]
+}
+
+@test "base domain-config keeps the dev mediaviewer.localhost value (patch-only override)" {
+  # The base is the dev SSOT; prod must override via the patch, not by editing base.
+  run grep -qE '^[[:space:]]+MEDIAVIEWER_HOST:[[:space:]]*"mediaviewer\.localhost"' "$BASE_DOMAINS"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Problem

On prod (`web.mentolder.de` / `web.korczewski.de`) the Sidekick mediaviewer panel is broken and the console logs:

> Failed to execute 'postMessage' on 'DOMWindow': The target origin provided ('https://mediaviewer.localhost') does not match the recipient window's origin ('https://web.mentolder.de').

## Root cause

`prod/configmap-domains.yaml` is a **strategic-merge patch** over the base `k3d/configmap-domains.yaml`, but it **omitted `MEDIAVIEWER_HOST`**. So the live `domain-config` ConfigMap — in **both** the `workspace` and `website` namespaces — keeps the base dev value `mediaviewer.localhost`.

Data flow that turns that into the error:
1. `domain-config.MEDIAVIEWER_HOST = mediaviewer.localhost` (live, both brands — verified on fleet)
2. `k3d/website.yaml` → `MEDIAVIEWER_HOST` via `configMapKeyRef: domain-config`
3. `PortalLayout.astro` reads `process.env.MEDIAVIEWER_HOST` (SSR) → prop to `PortalSidekick` → `MediaviewerPanel`
4. `MediaviewerPanel` builds `widgetOrigin = https://mediaviewer.localhost` → iframe `src` is dead in prod **and** every `postMessage` targets the dev origin → the console error above

This is the same class of bug as the `RECOVER_DOMAIN` omission ([T000398]) — the comment block in the file documents that pattern.

## Fix

- Add `MEDIAVIEWER_HOST: "mediaviewer.${PROD_DOMAIN}"` to the prod patch (renders `mediaviewer.mentolder.de` / `mediaviewer.korczewski.de`; `PROD_DOMAIN` is already in the deploy envsubst list).
- New bats regression test `tests/unit/mediaviewer-host-durability.bats` mirroring `recovery-domain-durability.bats`.

## Verification

- `bats tests/unit/mediaviewer-host-durability.bats` → 5/5 pass
- `kustomize build prod-fleet/mentolder` renders `MEDIAVIEWER_HOST: mediaviewer.mentolder.de`
- `task test:inventory` unchanged

## Post-merge deploy (manual — not auto-applied)

`domain-config` is push-based; merging does **not** reach the cluster. After merge, update both brands and restart the website pods (env-from-configMapKeyRef does not hot-reload):

```
task workspace:deploy ENV=mentolder    # updates workspace-ns domain-config
task workspace:deploy ENV=korczewski
# website-ns domain-config is applied ad-hoc (client-side) — patch + restart:
kubectl -n website            patch configmap domain-config --type merge -p '{"data":{"MEDIAVIEWER_HOST":"mediaviewer.mentolder.de"}}'
kubectl -n website-korczewski patch configmap domain-config --type merge -p '{"data":{"MEDIAVIEWER_HOST":"mediaviewer.korczewski.de"}}'
kubectl -n website            rollout restart deployment/website
kubectl -n website-korczewski rollout restart deployment/website
```

> Note: the `website`-namespace `domain-config` is currently applied by an ad-hoc client-side `kubectl apply` with no committed deploy task — a separate latent fragility worth a follow-up (make it declarative like the workspace overlay).

🤖 Generated with [Claude Code](https://claude.com/claude-code)