### PR TITLE
fix(website): auto-select a default feature in the cockpit

### DIFF
--- a/website/src/components/admin/Cockpit.svelte
+++ b/website/src/components/admin/Cockpit.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount } from 'svelte';
-  import type { PortfolioPayload, FeatureTickets, TicketRow } from '../../lib/tickets/cockpit-types';
+  import type { PortfolioPayload, FeatureTickets, TicketRow, FeatureNode } from '../../lib/tickets/cockpit-types';
   import { cockpitStore, selectFeature, setActiveTicket, initStoreFromUrl, setLoading, setError }
     from '../../lib/stores/cockpitStore';
   import CockpitSidebar from './CockpitSidebar.svelte';
@@ -21,9 +21,22 @@
   $: allFeatures = portfolio?.products?.flatMap((p) => p.features) ?? [];
   $: currentFeatureNode = allFeatures.find((f) => f.extId === $cockpitStore.selectedFeature) ?? null;
 
+  // Pick a sensible default feature so the cockpit lands on a populated
+  // ticket list instead of an empty table. Prefer the first non-discarded
+  // feature that actually has tickets; fall back to the first feature.
+  function pickDefaultFeature(): FeatureNode | null {
+    const feats = allFeatures.filter((f) => !f.discarded);
+    return feats.find((f) => (f.rollup?.total ?? 0) > 0) ?? feats[0] ?? allFeatures[0] ?? null;
+  }
+
   onMount(async () => {
     if (typeof window !== 'undefined') initStoreFromUrl(new URL(window.location.href).searchParams);
     if (!portfolio) await loadPortfolio();
+    // No feature from URL/localStorage → auto-select one so tickets show on open.
+    if (!$cockpitStore.selectedFeature) {
+      const def = pickDefaultFeature();
+      if (def) selectFeature(def.extId);
+    }
     if ($cockpitStore.selectedFeature) await loadFeature($cockpitStore.selectedFeature);
   });
 

--- a/website/src/components/admin/CockpitShell.integration.test.ts
+++ b/website/src/components/admin/CockpitShell.integration.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { render, fireEvent } from '@testing-library/svelte';
 import Cockpit from './Cockpit.svelte';
+import { selectFeature } from '../../lib/stores/cockpitStore';
 
 const portfolio = { products: [{
   id: 'p1', extId: 'p1', title: 'P',
@@ -9,12 +10,38 @@ const portfolio = { products: [{
     rollup: { total: 1, done: 0, blocked: 0, inProgress: 0, open: 1, pctDone: 0 } }],
 }]};
 
-beforeEach(() => localStorage.clear());
+beforeEach(() => {
+  // The cockpit store is a module singleton — reset it so state doesn't leak between tests.
+  selectFeature(null);
+  localStorage.clear();
+});
+afterEach(() => vi.unstubAllGlobals());
 
 describe('Cockpit shell integration', () => {
   it('persists the selected feature to localStorage', async () => {
     const { getByText } = render(Cockpit, { portfolioInitial: portfolio, brand: 'mentolder' });
     await fireEvent.click(getByText('F1'));
+    expect(localStorage.getItem('cockpit:feature')).toBe('F1');
+  });
+
+  it('auto-selects the first feature with tickets and shows them on open', async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/api/admin/cockpit/feature')) {
+        return new Response(JSON.stringify({
+          feature: portfolio.products[0].features[0],
+          tickets: [{ id: 't1', extId: 'T1', title: 'Erstes Ticket',
+            status: 'open', priority: 'mittel', type: 'task' }],
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      return new Response(JSON.stringify(portfolio), { status: 200 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { findByText } = render(Cockpit, { portfolioInitial: portfolio, brand: 'mentolder' });
+
+    // Without any manual click, the cockpit must already render a ticket list.
+    expect(await findByText('Erstes Ticket')).toBeTruthy();
     expect(localStorage.getItem('cockpit:feature')).toBe('F1');
   });
 });


### PR DESCRIPTION
## Problem

Opening the admin **Cockpit** lands on an empty ticket table. The data is there (mentolder has 13 projects / 126 features / 390 tasks / 279 bugs) but nothing shows until you manually click a feature in the sidebar.

## Root cause

`onMount` only called `loadFeature` when a feature was *already* selected (from URL or localStorage). On a fresh open with neither, no feature is selected → `loadFeature` never runs → `featureData` stays null → the table renders `[]`.

This bites hardest on prod because **all 669 task/bug leaves are parentless** (`parent_id IS NULL`) — none are nested under a feature, so every real feature has `rollup.total = 0` and the tickets only live under the synthetic **"Ohne Feature"** bucket ([T000848]). The user had to know to scroll to and click that bucket.

## Fix

- `pickDefaultFeature()`: prefer the first non-discarded feature with tickets (`rollup.total > 0`), else the first feature. Since the "Ohne Feature" bucket surfaces as a feature with `total = 669`, the cockpit now auto-lands there when only parentless leaves exist.
- `onMount` selects it when nothing is selected yet → cockpit opens on a populated list.
- Reset the module-singleton cockpit store between integration tests (state was leaking across cases).

## Verification

- `vitest run src/components/admin/ src/lib/stores/cockpitStore` → **62/62 pass** (incl. new "auto-selects the first feature with tickets and shows them on open")
- `task test:inventory` unchanged

## Notes

- This is the website code half of the empty-cockpit investigation. Deploys automatically via `build-website.yml` on merge to `main`.
- The parentless-tickets data shape was confirmed *expected* (tickets simply aren't organized into features yet) — "Ohne Feature" is the correct catch-all, so no reparenting is in scope here.
- Separate, related fix in flight: #1735 (MEDIAVIEWER_HOST prod config — the Sidekick `postMessage` console error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)