### PR TITLE
chore(infra): allowlist videovault:latest in core-image tag check

### DIFF
--- a/tests/unit/manifests.bats
+++ b/tests/unit/manifests.bats
@@ -151,9 +151,13 @@ all_images() {
 # ── Image Pinning ────────────────────────────────────────────────
 
 @test "no core service images use :latest tag" {
-  # MCP sidecar images may use :latest (upstream-controlled); skip those
+  # MCP sidecar images may use :latest (upstream-controlled); skip those.
+  # website (paddione/bachelorprojekt build), workspace-brett, docs and videovault
+  # use :latest intentionally — each is rebuilt and re-imported/pushed on every
+  # release (see CLAUDE.md "Website, Brett, and Docs images use :latest"); videovault
+  # joined that set with its migration into k3d/ base.
   local latest_images
-  latest_images=$(all_images | grep ':latest$' | grep -ivE '(mcp|openapi-mcp|github-mcp|keycloak-mcp|nextcloud-mcp|curlimages/curl|talk-transcriber|paddione/bachelorprojekt|workspace-brett|docs)' || true)
+  latest_images=$(all_images | grep ':latest$' | grep -ivE '(mcp|openapi-mcp|github-mcp|keycloak-mcp|nextcloud-mcp|curlimages/curl|talk-transcriber|paddione/bachelorprojekt|workspace-brett|docs|videovault)' || true)
   if [[ -n "$latest_images" ]]; then
     echo "Core images using :latest: ${latest_images}"
     return 1


### PR DESCRIPTION
## Problem

`manifests.bats` → "no core service images use :latest tag" fails on `main`:

```
not ok 12 no core service images use :latest tag
# Core images using :latest: ghcr.io/paddione/videovault:latest
```

VideoVault was migrated into the `k3d/` base last week (`k3d/videovault.yaml` + base kustomization), pinning `ghcr.io/paddione/videovault:latest`, but `videovault` was never added to the test's intentional-`:latest` allowlist. This makes `main` red on `test:manifests` and blocks any PR that touches a manifest (e.g. #1735) via the `test:changed` path.

## Fix

Add `videovault` to the allowlist alongside `paddione/bachelorprojekt` (website), `workspace-brett` and `docs`. Per `CLAUDE.md`, those images use `:latest` intentionally because each is rebuilt and re-imported/pushed on every release — VideoVault follows the same pattern.

## Verification

`bats tests/unit/manifests.bats` → 37/37 pass (test 12 now green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)