### PR TITLE
fix(test): sync test expectations with VideoVault additions from #1724

### DIFF
--- a/tests/unit/manifests.bats
+++ b/tests/unit/manifests.bats
@@ -153,7 +153,7 @@ all_images() {
 @test "no core service images use :latest tag" {
   # MCP sidecar images may use :latest (upstream-controlled); skip those
   local latest_images
-  latest_images=$(all_images | grep ':latest$' | grep -ivE '(mcp|openapi-mcp|github-mcp|keycloak-mcp|nextcloud-mcp|curlimages/curl|talk-transcriber|paddione/bachelorprojekt|workspace-brett|docs)' || true)
+  latest_images=$(all_images | grep ':latest$' | grep -ivE '(mcp|openapi-mcp|github-mcp|keycloak-mcp|nextcloud-mcp|curlimages/curl|talk-transcriber|paddione/bachelorprojekt|workspace-brett|docs|videovault|mediaviewer-widget)' || true)
   if [[ -n "$latest_images" ]]; then
     echo "Core images using :latest: ${latest_images}"
     return 1

--- a/tests/unit/shared-db-initdb-selfheal.bats
+++ b/tests/unit/shared-db-initdb-selfheal.bats
@@ -14,7 +14,7 @@ setup() {
 }
 
 @test "postStart self-heals databases (CREATE DATABASE loop over all services)" {
-  run grep -qE 'for db in keycloak nextcloud vaultwarden website pentest; do' "$MANIFEST"
+  run grep -qE 'for db in keycloak nextcloud vaultwarden website pentest videovault; do' "$MANIFEST"
   [ "$status" -eq 0 ]
   grep -qE 'CREATE DATABASE' "$MANIFEST"
 }


### PR DESCRIPTION
## Summary

PR #1724 (VideoVault + MediaViewer-Widget integration) updated `k3d/shared-db.yaml` and added new images, but left two unit tests out of sync with the manifest — breaking `main` CI and blocking all subsequent PRs (notably #1735).

**Two fixes in one commit:**

1. **`tests/unit/manifests.bats` — test 12 "no core service images use :latest tag"**
   `videovault:latest` and `mediaviewer-widget:latest` were not in the intentional-`:latest` allowlist. Both follow the same rebuilt-on-release pattern as `workspace-brett` and `workspace-docs` (see CLAUDE.md gotchas). This caused CI to fail on `main` and on every PR that touched a manifest (e.g. #1735 via `test:changed`).

2. **`tests/unit/shared-db-initdb-selfheal.bats` — test 2 "postStart self-heals databases"**
   The test grepped for the old loop `for db in keycloak nextcloud vaultwarden website pentest; do`, but #1724 extended it to `… pentest videovault; do`. PR #1738 attempted to fix only issue #1 but still failed CI on issue #2.

## Supersedes

Closes / supersedes PR #1738 (addressed only the manifests.bats allowlist, missed the shared-db test, and had a conventional-commit scope typo `tests` → `test`).

## Verification

- `bats tests/unit/shared-db-initdb-selfheal.bats` → 4/4 pass (was 3/4)
- Simulated `all_images` grep against rendered k3d output → no unexpected `:latest` images remain

## Note on `mediaviewer-widget:latest`

The image appears in `k3d/mediaviewer-widget.yaml` as `- image:` (YAML list-item syntax). The current `all_images()` grep pattern (`^\s+image:`) misses list-item style entries, so the test never caught it. It is added to the allowlist proactively so that if the grep is ever widened, it won't create a false failure.

🤖 Automated maintenance — 2026-06-16

---
_Generated by [Claude Code](https://claude.ai/code/session_01HHhTX8T6hrk2F8veZ27XAW)_