### PR TITLE
fix(e2e): E2E-Specs verschmutzen nicht mehr den Produktions-Tracker [T000862]

### DIFF
--- a/.github/workflows/e2e-pr.yml
+++ b/.github/workflows/e2e-pr.yml
@@ -50,6 +50,7 @@ jobs:
       SKIP_DB_PURGE: "1"
       E2E_ADMIN_USER: paddione
       E2E_ADMIN_PASS: ${{ secrets.E2E_ADMIN_PASS }}
+      CRON_SECRET: ${{ secrets.CRON_SECRET }}
       MM_TEST_USER: ${{ secrets.MM_TEST_USER }}
       MM_TEST_PASS: ${{ secrets.MM_TEST_PASS }}
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -111,8 +111,7 @@ jobs:
           # Admin auth for E2E suite (T000480 — was missing, caused 35+ specs to silently skip)
           E2E_ADMIN_USER: paddione
           E2E_ADMIN_PASS: ${{ secrets.E2E_ADMIN_PASS }}
-          # Skip prod DB purge until CRON_SECRET is provisioned as a repo secret (T000408).
-          # Without this the global setup throws before any spec runs.
+          CRON_SECRET: ${{ secrets.CRON_SECRET }}
           SKIP_DB_PURGE: "1"
         run: npx playwright test
 

--- a/.github/workflows/factory-post-merge-e2e.yml
+++ b/.github/workflows/factory-post-merge-e2e.yml
@@ -38,6 +38,7 @@ jobs:
         if: steps.factory-check.outputs.is_factory == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CRON_SECRET: ${{ secrets.CRON_SECRET }}
           TICKET_ID: ${{ steps.factory-check.outputs.ticket_id }}
         run: |
           echo "Triggering e2e.yml for ticket $TICKET_ID (cluster=both)"

--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 435,
+      "file_count": 436,
       "files": [
         "tests/.gitignore",
         "tests/batch/batch-gap-analysis.bats",
@@ -439,6 +439,7 @@
         "website/tests/api/portal-sign.test.ts",
         "website/tests/api/signing-template-renderer.test.ts",
         "website/tests/compute-scores.test.mjs",
+        "website/tests/e2e-marker-hygiene.test.ts",
         "website/tests/fixtures/mustang.sh",
         "website/tests/live-state.test.mjs",
         "website/tests/zugferd.test.mjs"

--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 436,
+      "file_count": 437,
       "files": [
         "tests/.gitignore",
         "tests/batch/batch-gap-analysis.bats",
@@ -20,6 +20,7 @@
         "tests/e2e/lib/auth.ts",
         "tests/e2e/lib/build-gallery.mjs",
         "tests/e2e/lib/dynamic-resolver.ts",
+        "tests/e2e/lib/e2e-marker.ts",
         "tests/e2e/lib/health-assertions.test.ts",
         "tests/e2e/lib/health-assertions.ts",
         "tests/e2e/lib/nav-graph.ts",

--- a/docs/generated/api-map.json
+++ b/docs/generated/api-map.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-16T00:20:52.893Z",
+  "generatedAt": "2026-06-16T00:38:36.744Z",
   "endpoints": [
     {
       "path": "/api/admin/angebote/save",

--- a/docs/generated/api-surface.md
+++ b/docs/generated/api-surface.md
@@ -1,6 +1,6 @@
 # API Surface Map
 
-> Generated at 2026-06-16T00:20:52.893Z
+> Generated at 2026-06-16T00:38:36.744Z
 
 | Path | Methods | Auth | File |
 |------|---------|------|------|

--- a/docs/generated/blast-radius.md
+++ b/docs/generated/blast-radius.md
@@ -1,5 +1,5 @@
 # Blast-Radius-Report
-> Generated: 2026-06-16T00:20:52.996Z
+> Generated: 2026-06-16T00:38:36.829Z
 > Nodes: 78 | Edges: 1613 | Isolated: 2
 
 ## Ranking (transitive Abhängige)

--- a/docs/generated/graph.json
+++ b/docs/generated/graph.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-16T00:20:52.812Z",
+  "generatedAt": "2026-06-16T00:38:36.671Z",
   "nodes": [
     {
       "id": "admin-actions-cleanup",

--- a/docs/superpowers/plans/2026-06-16-e2e-tracker-pollution.md
+++ b/docs/superpowers/plans/2026-06-16-e2e-tracker-pollution.md
@@ -64,7 +64,7 @@ verifizieren/redeployen. Sensibler Wert → kann/darf hier nicht gesetzt werden.
 
 ## Implementierungsschritte
 
-### 1. Shared Helper `tests/e2e/lib/e2e-marker.ts` (neu, Leaf-Modul, kein Import-Zyklus)
+### [x] 1. Shared Helper `tests/e2e/lib/e2e-marker.ts` (neu, Leaf-Modul, kein Import-Zyklus)
 
 ```ts
 const BASE = process.env.WEBSITE_URL ?? 'http://localhost:4321';
@@ -96,19 +96,19 @@ export async function createTestBugReport(
 }
 ```
 
-### 2. `tests/e2e/specs/fa-admin-tickets.spec.ts` (T000863)
+### [x] 2. `tests/e2e/specs/fa-admin-tickets.spec.ts` (T000863)
 
 - Import `createTestBugReport`, `markerAvailable`.
 - Am Anfang des Full-Flow-Tests: `test.skip(!markerAvailable(), 'CRON_SECRET fehlt — Seed würde Prod-Tracker verschmutzen');`
 - Seed-Block (Z. 55–67) durch `const { ticketId: externalId } = await createTestBugReport(request, { description: 'PR4 admin-tickets E2E seed', email: reporter, category: 'fehler', url: '/admin/tickets-e2e' });` ersetzen.
 
-### 3. `tests/e2e/specs/fa-26-bug-report-form.spec.ts` (T000862)
+### [x] 3. `tests/e2e/specs/fa-26-bug-report-form.spec.ts` (T000862)
 
 - Import `markerHeaders`, `markerAvailable`.
 - Den Inline-`if (CRON_SECRET)`-Block durch `markerHeaders()` ersetzen.
 - Test *"valid data returns 200"*: `test.skip(!markerAvailable(), 'CRON_SECRET fehlt — würde echtes Ticket erzeugen');` voranstellen. (Die 400-Validierungs-Tests erzeugen keine Zeilen → laufen weiter.)
 
-### 4. Workflow-Verdrahtung — `CRON_SECRET: ${{ secrets.CRON_SECRET }}`
+### [x] 4. Workflow-Verdrahtung — `CRON_SECRET: ${{ secrets.CRON_SECRET }}`
 
 In den Runner-/Step-`env`-Block aufnehmen (forward-kompatibel: fehlt das Repo-Secret,
 ist der Wert leer → Tests skippen statt zu lecken):
@@ -117,7 +117,7 @@ ist der Wert leer → Tests skippen statt zu lecken):
 - `.github/workflows/e2e.yml` (Playwright-Step-`env`; den reinen Kommentar Z. 114 durch die echte Zuweisung ersetzen).
 - `.github/workflows/factory-post-merge-e2e.yml` (Step-`env`, falls er Playwright fährt).
 
-### 5. Guard-Test (bereits geschrieben, rot→grün)
+### [x] 5. Guard-Test (bereits geschrieben, rot→grün) — inkl. markerTokens-Erweiterung
 
 `website/tests/e2e-marker-hygiene.test.ts` — scannt alle Specs; jede, die zu
 `/api/bug-report` POSTet, muss den Marker führen. Heute rot (fa-admin-tickets),

--- a/docs/superpowers/plans/2026-06-16-e2e-tracker-pollution.md
+++ b/docs/superpowers/plans/2026-06-16-e2e-tracker-pollution.md
@@ -1,0 +1,157 @@
+---
+ticket_id: T000862
+status: active
+domains: [website, test, infra]
+file_locks: []
+shared_changes: false
+batch_id: null
+parent_feature: null
+depends_on_plans: []
+---
+
+# Fix: E2E-Specs verschmutzen den Produktions-Tracker [T000862, T000863]
+
+## Problem (verifizierte Root-Cause-Analyse)
+
+Zwei Playwright-Specs erzeugen echte Zeilen in `tickets.tickets` auf der Live-Prod-DB
+(mentolder), die nie aufgeräumt werden:
+
+- **T000862** — `tests/e2e/specs/fa-26-bug-report-form.spec.ts` Test *"valid data returns 200"*
+  POSTet ein echtes Bug-Report-Formular. Der Cleanup ist an `CRON_SECRET` gekoppelt
+  (`if (CRON_SECRET) { headers… }`). Fehlt das Secret auf dem Runner, werden die
+  Marker-Header **still weggelassen** → echte Zeile → Akkumulation
+  (Titel: *"Automatischer E2E-Test: Seite lädt nicht korrekt."*, 17× gesamt).
+- **T000863** — `tests/e2e/specs/fa-admin-tickets.spec.ts` erzeugt den Seed via
+  `/api/bug-report` **ganz ohne** Marker-Header → echte Zeile; der Test setzt am Ende
+  nur `done`, löscht aber nichts (Titel: *"PR4 admin-tickets E2E seed"*, 26× gesamt).
+
+### Mechanismus (bereits vorhanden, nur nicht scharf)
+
+- `website/src/pages/api/bug-report.ts:77` stempelt `isTestData = isE2ETestRequest(request)`.
+- `website/src/lib/e2e-marker.ts`: verlangt `X-E2E-Test: 1` **und**
+  `X-Cron-Secret === process.env.CRON_SECRET`; **fail-closed** wenn `CRON_SECRET`
+  serverseitig fehlt (Z. 30 `if (!expected) return false`).
+- Purge: `POST /api/admin/systemtest/purge-all-test-data` (gerufen von Playwright
+  globalSetup/globalTeardown + CronJob `admin-actions-cleanup` alle 30 min) löscht
+  `is_test_data=true`-Zeilen.
+
+### Warum end-to-end kaputt (verifiziert)
+
+1. Die 3 E2E-Workflows reichen `CRON_SECRET` **nicht** an den Runner:
+   `e2e.yml` hat es nur als Kommentar (Z. 114, "until CRON_SECRET is provisioned … T000408"),
+   `e2e-pr.yml` (läuft gegen Live-Prod `web.mentolder.de`) und
+   `factory-post-merge-e2e.yml` haben es gar nicht. → Marker-Header fehlen / sind wertlos,
+   und der globalTeardown-Purge kann sich nicht authentifizieren.
+2. `fa-admin-tickets` sendet die Header gar nicht erst.
+3. Der Live-Website-Pod hatte beim Triage **kein** `CRON_SECRET` in der Env, obwohl
+   `k3d/website.yaml:241` es aus `website-secrets` verdrahtet — d. h. Deploy-Lag
+   (push-based, kein GitOps). **T000408 wurde `done/fixed` geschlossen, ohne dass die
+   Verdrahtung wirklich greift** (Regression-Notiz, siehe unten).
+
+Die existierenden geleakten Zeilen sind bereits triagiert (2 frische diese Runde geschlossen;
+Rest historisch `done`). Dieser Fix verhindert **künftige** Leaks; ein nachträgliches Purgen
+der Altzeilen ist nicht nötig (sie sind `is_test_data=false` und bereits `done`).
+
+## Lösung — Scope-Trennung
+
+**Autonom (dieser Fix):** Test-Helper + fail-loud Skip-Guard + Workflow-YAML-Verdrahtung.
+Der Skip-Guard stoppt die Pollution **sofort** (skippen statt lecken), auch bevor das
+Repo-Secret existiert; sobald es existiert, stempeln die Marker + globalTeardown purged.
+
+**Mensch (Prerequisite, nicht in diesem PR — Bezug T000408):** GitHub-Repo-Secret
+`CRON_SECRET` (= Wert aus `website-secrets` SealedSecret) anlegen, und Live-Pod-Env
+verifizieren/redeployen. Sensibler Wert → kann/darf hier nicht gesetzt werden.
+
+## Implementierungsschritte
+
+### 1. Shared Helper `tests/e2e/lib/e2e-marker.ts` (neu, Leaf-Modul, kein Import-Zyklus)
+
+```ts
+const BASE = process.env.WEBSITE_URL ?? 'http://localhost:4321';
+
+/** Marker-Header-Paar, falls CRON_SECRET verfügbar — sonst undefined (fail-closed). */
+export function markerHeaders(): Record<string, string> | undefined {
+  const s = process.env.CRON_SECRET;
+  return s ? { 'X-E2E-Test': '1', 'X-Cron-Secret': s } : undefined;
+}
+
+export function markerAvailable(): boolean {
+  return !!process.env.CRON_SECRET;
+}
+
+/** POST /api/bug-report mit Marker → is_test_data=true. Wirft, wenn Marker fehlt. */
+export async function createTestBugReport(
+  request: import('@playwright/test').APIRequestContext,
+  fields: { description: string; email: string; category: string; url?: string },
+): Promise<{ ticketId: string }> {
+  const headers = markerHeaders();
+  if (!headers) throw new Error('createTestBugReport ohne CRON_SECRET — Aufrufer muss vorher markerAvailable() skippen');
+  const res = await request.post(`${BASE}/api/bug-report`, {
+    headers,
+    multipart: { url: '/', ...fields },
+  });
+  if (!res.ok()) throw new Error(`bug-report create failed: ${res.status()}`);
+  const body = await res.json() as { success: boolean; ticketId: string };
+  return { ticketId: body.ticketId };
+}
+```
+
+### 2. `tests/e2e/specs/fa-admin-tickets.spec.ts` (T000863)
+
+- Import `createTestBugReport`, `markerAvailable`.
+- Am Anfang des Full-Flow-Tests: `test.skip(!markerAvailable(), 'CRON_SECRET fehlt — Seed würde Prod-Tracker verschmutzen');`
+- Seed-Block (Z. 55–67) durch `const { ticketId: externalId } = await createTestBugReport(request, { description: 'PR4 admin-tickets E2E seed', email: reporter, category: 'fehler', url: '/admin/tickets-e2e' });` ersetzen.
+
+### 3. `tests/e2e/specs/fa-26-bug-report-form.spec.ts` (T000862)
+
+- Import `markerHeaders`, `markerAvailable`.
+- Den Inline-`if (CRON_SECRET)`-Block durch `markerHeaders()` ersetzen.
+- Test *"valid data returns 200"*: `test.skip(!markerAvailable(), 'CRON_SECRET fehlt — würde echtes Ticket erzeugen');` voranstellen. (Die 400-Validierungs-Tests erzeugen keine Zeilen → laufen weiter.)
+
+### 4. Workflow-Verdrahtung — `CRON_SECRET: ${{ secrets.CRON_SECRET }}`
+
+In den Runner-/Step-`env`-Block aufnehmen (forward-kompatibel: fehlt das Repo-Secret,
+ist der Wert leer → Tests skippen statt zu lecken):
+
+- `.github/workflows/e2e-pr.yml` (job-`env`, beim `E2E_ADMIN_*`/`MM_TEST_*`-Block).
+- `.github/workflows/e2e.yml` (Playwright-Step-`env`; den reinen Kommentar Z. 114 durch die echte Zuweisung ersetzen).
+- `.github/workflows/factory-post-merge-e2e.yml` (Step-`env`, falls er Playwright fährt).
+
+### 5. Guard-Test (bereits geschrieben, rot→grün)
+
+`website/tests/e2e-marker-hygiene.test.ts` — scannt alle Specs; jede, die zu
+`/api/bug-report` POSTet, muss den Marker führen. Heute rot (fa-admin-tickets),
+nach Schritt 2 grün. Läuft offline im `node`-vitest-Projekt → in `task test:all`.
+
+### 6. (Optional, nur falls zeilenneutral machbar) fa-10 / fa-admin-inbox-delete
+
+`fa-10-website.spec.ts` (T6) und `fa-admin-inbox-delete.spec.ts` posten zu `/api/contact`
+mit dupliziertem Marker-Block — können `markerHeaders()` adoptieren. **Optional**, da
+anderer Endpoint (vom Guard-Test nicht erfasst); nur anfassen, wenn risikolos.
+
+## Verifikation (finaler Task)
+
+```bash
+cd website && pnpm vitest run tests/e2e-marker-hygiene.test.ts   # muss GRÜN sein
+cd .. && task test:changed                                       # vitest + domain-BATS
+task test:inventory                                              # Tests hinzugefügt → Inventar regenerieren
+git add website/src/data/test-inventory.json
+task freshness:regenerate && task freshness:check                # S1–S4-Ratchet (CI-Äquivalent)
+```
+
+S1–S4: `e2e-marker.ts` ist neu (kein Baseline-Budget), Spec-Edits netto-klein, Workflow-YAML
+nur additive `env`-Zeilen, keine Brand-Domain-Literale in Snippets, Helper ist Leaf (kein Zyklus),
+keine verwaisten Manifeste. Erwartet konfliktfrei.
+
+## Menschlicher Folge-Schritt (separat, Bezug T000408)
+
+1. GitHub-Repo-Secret `CRON_SECRET` = Wert aus `website-secrets` SealedSecret anlegen.
+2. Live-Website-Pod-Env prüfen (`kubectl get deploy website -o jsonpath …`); falls
+   `CRON_SECRET` fehlt → `task workspace:deploy ENV=mentolder` **und** `ENV=korczewski`.
+3. T000408 als regrediert kommentieren/wieder-eröffnen (geschlossen, aber Verdrahtung greift nicht).
+
+## Betroffene Tickets
+
+- **T000862** (fa-26 silent-create) — fixed durch Schritt 1+3+4.
+- **T000863** (fa-admin-tickets seed leak) — fixed durch Schritt 1+2+4.
+- **T000408** (CRON_SECRET-Provisionierung) — Regression-Notiz; menschlicher Folge-Schritt.

--- a/k3d/docs-content-built/architecture/index.html
+++ b/k3d/docs-content-built/architecture/index.html
@@ -178,7 +178,7 @@
 <body>
   <div class="header">
     <h1>⬡ Architektur — Living Docs</h1>
-    <span class="meta">Generiert: 2026-06-16T00:20:52.940Z</span>
+    <span class="meta">Generiert: 2026-06-16T00:38:36.787Z</span>
   </div>
 
   <div class="stats">

--- a/tests/e2e/lib/e2e-marker.ts
+++ b/tests/e2e/lib/e2e-marker.ts
@@ -1,0 +1,25 @@
+const BASE = process.env.WEBSITE_URL ?? 'http://localhost:4321';
+
+export function markerHeaders(): Record<string, string> | undefined {
+  const s = process.env.CRON_SECRET;
+  return s ? { 'X-E2E-Test': '1', 'X-Cron-Secret': s } : undefined;
+}
+
+export function markerAvailable(): boolean {
+  return !!process.env.CRON_SECRET;
+}
+
+export async function createTestBugReport(
+  request: import('@playwright/test').APIRequestContext,
+  fields: { description: string; email: string; category: string; url?: string },
+): Promise<{ ticketId: string }> {
+  const headers = markerHeaders();
+  if (!headers) throw new Error('createTestBugReport ohne CRON_SECRET — Aufrufer muss vorher markerAvailable() skippen');
+  const res = await request.post(`${BASE}/api/bug-report`, {
+    headers,
+    multipart: { url: '/', ...fields },
+  });
+  if (!res.ok()) throw new Error(`bug-report create failed: ${res.status()}`);
+  const body = await res.json() as { success: boolean; ticketId: string };
+  return { ticketId: body.ticketId };
+}

--- a/tests/e2e/specs/fa-26-bug-report-form.spec.ts
+++ b/tests/e2e/specs/fa-26-bug-report-form.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
+import { markerHeaders, markerAvailable } from '../lib/e2e-marker';
 
 const BASE        = process.env.WEBSITE_URL || 'http://localhost:4321';
-const CRON_SECRET = process.env.CRON_SECRET;
 
 // The bug report widget is rendered inside AdminLayout (admin-only UI).
 // These tests exercise the public /api/bug-report endpoint directly.
@@ -36,14 +36,9 @@ test.describe('FA-26: Bug report API', () => {
   });
 
   test('POST /api/bug-report with valid data returns 200 with ticketId', async ({ request }) => {
-    // X-E2E-Test + X-Cron-Secret stamps is_test_data=true so the purge bracket
-    // cleans up the created ticket and inbox item. Without these headers the row
-    // accumulates in the admin inbox on every E2E run.
-    const headers: Record<string, string> = {};
-    if (CRON_SECRET) {
-      headers['X-E2E-Test'] = '1';
-      headers['X-Cron-Secret'] = CRON_SECRET;
-    }
+    test.skip(!markerAvailable(), 'CRON_SECRET fehlt — würde echtes Ticket erzeugen');
+
+    const headers = markerHeaders();
     const res = await request.post(`${BASE}/api/bug-report`, {
       headers,
       multipart: {

--- a/tests/e2e/specs/fa-admin-tickets.spec.ts
+++ b/tests/e2e/specs/fa-admin-tickets.spec.ts
@@ -13,6 +13,7 @@
 
 import { test, expect } from '@playwright/test';
 import { assertAuthenticatedReachable } from '../lib/health-assertions';
+import { createTestBugReport, markerAvailable } from '../lib/e2e-marker';
 
 const BASE       = process.env.WEBSITE_URL ?? 'http://localhost:4321';
 const MAILPIT    = process.env.MAILPIT_URL ?? 'http://localhost:8025';
@@ -44,6 +45,8 @@ async function loginAsAdmin(page: import('@playwright/test').Page) {
 
 test.describe('FA-admin-tickets', { tag: ['@admin'] }, () => {
   test('full flow: filter + comment + transition + timeline', async ({ page, request }, testInfo) => {
+    test.skip(!markerAvailable(), 'CRON_SECRET fehlt — Seed würde Prod-Tracker verschmutzen');
+
     await assertAuthenticatedReachable(
       request,
       `${BASE}/admin/tickets`,
@@ -53,18 +56,12 @@ test.describe('FA-admin-tickets', { tag: ['@admin'] }, () => {
 
     // ── 1. Mint a public bug as the seed ticket ──
     const reporter = `e2e-tickets-${Date.now()}@example.com`;
-    const create = await request.post(`${BASE}/api/bug-report`, {
-      multipart: {
-        description: 'PR4 admin-tickets E2E seed',
-        email:       reporter,
-        category:    'fehler',
-        url:         '/admin/tickets-e2e',
-      },
+    const { ticketId: externalId } = await createTestBugReport(request, {
+      description: 'PR4 admin-tickets E2E seed',
+      email:       reporter,
+      category:    'fehler',
+      url:         '/admin/tickets-e2e',
     });
-    expect(create.ok()).toBeTruthy();
-    const cb = await create.json() as { success: boolean; ticketId: string };
-    expect(cb.ticketId).toMatch(/^T\d{6,}$/);
-    const externalId = cb.ticketId;
 
     // ── 2. Admin login + index filter ──
     await loginAsAdmin(page);

--- a/website/tests/e2e-marker-hygiene.test.ts
+++ b/website/tests/e2e-marker-hygiene.test.ts
@@ -1,0 +1,76 @@
+// website/tests/e2e-marker-hygiene.test.ts
+//
+// Regression guard for T000862 / T000863 — "E2E specs pollute the production
+// tracker".
+//
+// Root cause class: a Playwright spec POSTs to a write endpoint that creates a
+// real DB row (e.g. /api/bug-report) WITHOUT the E2E marker header pair
+// (`X-E2E-Test` + `X-Cron-Secret`). Without the marker the server's
+// `isE2ETestRequest()` returns false → the row is stored as real data
+// (`is_test_data=false`) → the purge bracket never reaps it → it accumulates in
+// the live tickets table on every E2E run.
+//
+// This static test scans every Playwright spec under tests/e2e/ and fails if a
+// spec creates a bug report without going through the E2E marker. It runs
+// offline in the website `node` vitest project (no server / DB needed), so the
+// guard is part of `task test:all` / CI rather than only catching the leak in
+// production after the fact.
+//
+// RED today: tests/e2e/specs/fa-admin-tickets.spec.ts POSTs to /api/bug-report
+// with no marker. GREEN once that seed goes through the shared marker helper.
+
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = resolve(fileURLToPath(import.meta.url), '..');
+// website/tests/ -> repo-root tests/e2e/
+const E2E_ROOT = resolve(__dirname, '../../tests/e2e');
+
+/** Recursively collect every *.spec.ts file under a directory. */
+function collectSpecFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      out.push(...collectSpecFiles(full));
+    } else if (entry.endsWith('.spec.ts')) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+/**
+ * A spec that creates a bug report must carry the E2E marker — either inline
+ * (`X-E2E-Test`) or via the shared helper (`createTestBugReport`). Detection is
+ * intentionally conservative: it only flags files that POST to /api/bug-report.
+ */
+const MARKER_TOKENS = ['X-E2E-Test', 'createTestBugReport', 'bugReportMarkerHeaders'];
+
+describe('E2E marker hygiene (T000862/T000863)', () => {
+  const specs = collectSpecFiles(E2E_ROOT);
+
+  it('finds the e2e spec tree', () => {
+    expect(specs.length).toBeGreaterThan(0);
+  });
+
+  it('every spec that POSTs to /api/bug-report carries the E2E marker', () => {
+    const violators: string[] = [];
+    for (const file of specs) {
+      const src = readFileSync(file, 'utf8');
+      const createsBugReport = src.includes('/api/bug-report') && src.includes('.post(');
+      if (!createsBugReport) continue;
+      const hasMarker = MARKER_TOKENS.some((t) => src.includes(t));
+      if (!hasMarker) {
+        violators.push(file.slice(file.indexOf('tests/e2e')));
+      }
+    }
+    expect(
+      violators,
+      `These specs create bug-report rows without the E2E marker (X-E2E-Test + X-Cron-Secret) ` +
+        `and therefore leak real rows into the production tracker:\n  ${violators.join('\n  ')}`,
+    ).toEqual([]);
+  });
+});

--- a/website/tests/e2e-marker-hygiene.test.ts
+++ b/website/tests/e2e-marker-hygiene.test.ts
@@ -47,7 +47,7 @@ function collectSpecFiles(dir: string): string[] {
  * (`X-E2E-Test`) or via the shared helper (`createTestBugReport`). Detection is
  * intentionally conservative: it only flags files that POST to /api/bug-report.
  */
-const MARKER_TOKENS = ['X-E2E-Test', 'createTestBugReport', 'bugReportMarkerHeaders'];
+const MARKER_TOKENS = ['X-E2E-Test', 'createTestBugReport', 'bugReportMarkerHeaders', 'markerHeaders', 'markerAvailable'];
 
 describe('E2E marker hygiene (T000862/T000863)', () => {
   const specs = collectSpecFiles(E2E_ROOT);


### PR DESCRIPTION
## Summary

Schließt **T000862** (gebündelt mit T000863) — verhindert, dass E2E-Playwright-Specs echte Zeilen im Produktions-Tracker anlegen.

### Changes

1. **Shared Helper** `tests/e2e/lib/e2e-marker.ts` — `markerHeaders()`, `markerAvailable()`, `createTestBugReport()`
2. **fa-admin-tickets.spec.ts** (T000863) — Seed via `createTestBugReport` mit Skip-Guard
3. **fa-26-bug-report-form.spec.ts** (T000862) — `markerHeaders()` statt Inline-`if(CRON_SECRET)`, Skip-Guard
4. **Workflows** — `CRON_SECRET: ${{ secrets.CRON_SECRET }}` in e2e-pr.yml, e2e.yml, factory-post-merge-e2e.yml
5. **Guard-Test** — `MARKER_TOKENS` um `markerHeaders`/`markerAvailable` erweitert

### Verification

- `pnpm vitest run tests/e2e-marker-hygiene.test.ts` ✅
- `task test:changed` ✅
- `task workspace:validate` ✅
- `task freshness:regenerate && task freshness:check` ✅
- `task test:code-quality` (0 new violations) ✅

Closes #T000862
Closes #T000863