### PR TITLE
chore(scripts): drop LM Studio path, pin local routing to small qwen3

### DIFF
--- a/scripts/llm-pull-models.sh
+++ b/scripts/llm-pull-models.sh
@@ -14,6 +14,7 @@ SSH_OPTS=(-i "$SSH_KEY" -o StrictHostKeyChecking=accept-new)
 echo "[1/3] Pulling Ollama models (~32 GB)..."
 ssh "${SSH_OPTS[@]}" "${HOST}" "bash -s" <<'REMOTE'
 set -euo pipefail
+ollama pull qwen3:4b   # lightweight routing/classification (Factory ticket-triage, oracle) — keeps GPU footprint minimal
 ollama pull qwen2.5:14b-instruct-q4_K_M
 ollama pull qwen2.5-coder:14b-instruct-q4_K_M
 ollama pull qwen2.5vl:7b-instruct-q4_K_M

--- a/scripts/vda/oracle.sh
+++ b/scripts/vda/oracle.sh
@@ -193,7 +193,6 @@ fi
 # ─────────────────────────────────────────────────────────────────────────────
 
 REPO="/home/patrick/Bachelorprojekt"
-MODEL="qwen/qwen3-4b-2507"
 HERMES="${HERMES:-$HOME/.local/bin/hermes}"
 
 # ── Infer target environment from goal keywords ───────────────────────────
@@ -209,7 +208,7 @@ infer_env() {
   fi
 }
 
-# ── Check if local LLM (Ollama or LM Studio) is available ──────────────────
+# ── Check if local LLM (Ollama) is available ───────────────────────────────
 local_llm_available() {
   if [[ "${HERMES:-}" == "/dev/null" ]]; then
     return 1
@@ -220,11 +219,7 @@ try:
     urllib.request.urlopen("http://localhost:11434/api/tags", timeout=0.8)
     sys.exit(0)
 except Exception:
-    try:
-        urllib.request.urlopen("http://localhost:1234/v1/models", timeout=0.8)
-        sys.exit(0)
-    except Exception:
-        sys.exit(1)
+    sys.exit(1)
 ' 2>/dev/null
 }
 
@@ -240,12 +235,23 @@ def get_ollama_model(base_url):
         with urllib.request.urlopen(req, timeout=1.5) as response:
             data = json.loads(response.read().decode("utf-8"))
             models = [m["name"] for m in data.get("models", [])]
-            if models:
-                qwen_models = [m for m in models if "qwen" in m.lower()]
-                return qwen_models[0] if qwen_models else models[0]
     except Exception:
-        pass
-    return None
+        return None
+    if not models:
+        return None
+    # Routing is a lightweight classification task -- deterministically prefer a
+    # small qwen3 model and avoid large coder models, so the local GPU footprint
+    # stays minimal regardless of which other models happen to be pulled.
+    big = ("14b", "30b", "32b", "35b", "70b", "72b")
+    def is_small(m): return not any(b in m.lower() for b in big)
+    for pref in (lambda m: m == "qwen3:4b",
+                 lambda m: "qwen3" in m.lower() and is_small(m),
+                 lambda m: "qwen" in m.lower() and is_small(m),
+                 lambda m: "qwen" in m.lower()):
+        hit = [m for m in models if pref(m)]
+        if hit:
+            return hit[0]
+    return models[0]
 
 def query_ollama(base_url, prompt):
     model = get_ollama_model(base_url)
@@ -265,30 +271,8 @@ def query_ollama(base_url, prompt):
     except Exception:
         return None
 
-def query_lmstudio(base_url, prompt):
-    url = f"{base_url}/v1/chat/completions"
-    payload = {
-        "messages": [{"role": "user", "content": prompt}],
-        "temperature": 0.1
-    }
-    try:
-        req = urllib.request.Request(
-            url,
-            data=json.dumps(payload).encode("utf-8"),
-            headers={"Content-Type": "application/json"}
-        )
-        with urllib.request.urlopen(req, timeout=15) as response:
-            res_data = json.loads(response.read().decode("utf-8"))
-            choices = res_data.get("choices", [])
-            if choices:
-                return choices[0].get("message", {}).get("content", "")
-    except Exception:
-        return None
-
 prompt = sys.argv[1]
 res = query_ollama("http://localhost:11434", prompt)
-if not res:
-    res = query_lmstudio("http://localhost:1234", prompt)
 if res:
     print(res)
     sys.exit(0)
@@ -466,6 +450,6 @@ if curl -sf http://localhost:18789/healthz >/dev/null 2>&1; then
   fi
 fi
 
-echo "No local LLM service (Ollama/LM Studio) or Opencode/OpenClaw daemon is running (Neither Hermes nor OpenClaw is available)." >&2
+echo "No local LLM service (Ollama) or Opencode/OpenClaw daemon is running (Neither Hermes nor OpenClaw is available)." >&2
 echo "Discover tasks manually: cd ${REPO} && task --list" >&2
 exit 1


### PR DESCRIPTION
## Was
Lokales Routing (vda/oracle + Factory ticket-triage) auf das kleine **qwen3:4b** festgenagelt und den **LM-Studio-Pfad entfernt** — Teil der Minimal-GPU-Konsolidierung (Software-Engineering-Builds laufen Cloud-DeepSeek, lokal nur noch winziges Routing + bge-m3-Embeddings).

## Änderungen
- `scripts/vda/oracle.sh`: LM-Studio-Probe, `query_lmstudio`-Fallback, tote `MODEL`-ID und LM-Studio-Erwähnungen entfernt.
- `scripts/vda/oracle.sh`: `get_ollama_model()` deterministisch — bevorzugt kleines `qwen3`, meidet 14b/30b/32b/35b/70b/72b, damit ein vorhandenes `qwen2.5-coder:32b` das Routing nicht kapert.
- `scripts/llm-pull-models.sh`: `qwen3:4b` zum GPU-Host-Modellset hinzugefügt.

## Verifikation
- `bash -n scripts/vda/oracle.sh` grün; eingebettete Python-Blöcke parsen.
- Live-Oracle-Lauf gegen mentolder klassifiziert + führt aus, wählt `qwen3:4b`.
- Keine `lmstudio`/`1234`-Reste mehr im Script.

## Kontext
Provider-Routing in der DB (beide Brands) wurde separat live umgestellt: ticket-triage→qwen3:4b, assistant-chat 35B→DeepSeek. Nicht Teil dieses PRs (kein Repo-Artefakt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)