### PR TITLE
chore(ci): wire opencode GitHub Action (DeepSeek + public-repo gate)

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -1,0 +1,42 @@
+name: opencode
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+jobs:
+  opencode:
+    # Public repo: nur Repo-Mitglieder duerfen opencode triggern (kein anonymer Trigger).
+    if: |
+      (
+        github.event.comment.author_association == 'OWNER' ||
+        github.event.comment.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'COLLABORATOR'
+      ) && (
+        startsWith(github.event.comment.body, '/oc') ||
+        contains(github.event.comment.body, ' /oc') ||
+        startsWith(github.event.comment.body, '/opencode') ||
+        contains(github.event.comment.body, ' /opencode')
+      )
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write        # OIDC -> Installation-Token der opencode GitHub App
+      contents: read
+      pull-requests: read
+      issues: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Run opencode
+        uses: anomalyco/opencode/github@latest
+        env:
+          # Wiederverwendung des vorhandenen DeepSeek-Secrets (gleiches Modell wie ai-review.yml).
+          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+        with:
+          model: deepseek/deepseek-chat

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -34,7 +34,9 @@ jobs:
           persist-credentials: false
 
       - name: Run opencode
-        uses: anomalyco/opencode/github@latest
+        # SHA-gepinnt (Supply-Chain: Action erhaelt DEEPSEEK_API_KEY). v1.17.7 (2026-06-14).
+        # Bump via Review/Dependabot; nie @latest fuer secret-tragende Third-Party-Actions.
+        uses: anomalyco/opencode/github@4ed4f749e644ffb5b279fb30b7b915e743d80142
         env:
           # Wiederverwendung des vorhandenen DeepSeek-Secrets (gleiches Modell wie ai-review.yml).
           DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}


### PR DESCRIPTION
## Was

Härtet `.github/workflows/opencode.yml` für den produktiven `/oc`-Einsatz:

- **Backend = DeepSeek** (`model: deepseek/deepseek-chat`) über das **vorhandene** `DEEPSEEK_API_KEY`-Secret — gleiches Modell wie `ai-review.yml`. Kein neuer Account/Secret.
- **GitHub-App-Auth** via OIDC (`id-token: write`) → Commits/PRs/Kommentare laufen über die opencode-App, minimale Workflow-Permissions (read-only).
- **Author-Gate für public Repo**: nur `OWNER`/`MEMBER`/`COLLABORATOR` dürfen `/oc` triggern (verhindert anonyme Agent-Runs/Credit-Burn).
- Trigger-Guard mit `startsWith`/` /oc` (kein Substring-Fehlmatch), `fetch-depth: 1`.

## Manueller Schritt (nicht im Repo)

GitHub-App `opencode-agent` auf dieses Repo installieren: https://github.com/apps/opencode-agent

## Verifikation nach Merge

Auf einem Issue `/oc explain this issue` kommentieren → opencode antwortet als App-Bot. Falls der DeepSeek-Provider sich nicht authentifiziert, Fallback wie in `ai-review.yml` (Anthropic-kompatibler Endpoint via `ANTHROPIC_BASE_URL=DEEPSEEK_BASE_URL` + `model: anthropic/deepseek-chat`).

Closes T000875

🤖 Generated with [Claude Code](https://claude.com/claude-code)