### PR TITLE
feat(infra): website-ns domain-config deklarativ im Website-Overlay (T000873)

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -261,6 +261,7 @@ tasks:
       - task: test:unit:wg-mesh-fullmesh
       - task: test:unit:recovery-domain-durability
       - task: test:unit:mediaviewer-host-durability
+      - task: test:unit:website-domain-config-overlay
       - task: test:unit:ticket-external-id
       - task: test:unit:ticket-triage
       - task: test:unit:website-ci-deploy
@@ -409,6 +410,11 @@ tasks:
     internal: true
     cmds:
       - ./tests/unit/lib/bats-core/bin/bats tests/unit/mediaviewer-host-durability.bats
+
+  test:unit:website-domain-config-overlay:
+    internal: true
+    cmds:
+      - ./tests/unit/lib/bats-core/bin/bats tests/unit/website-domain-config-overlay.bats
 
   test:unit:ticket-external-id:
     internal: true

--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 438,
+      "file_count": 439,
       "files": [
         "tests/.gitignore",
         "tests/batch/batch-gap-analysis.bats",
@@ -424,6 +424,7 @@
         "tests/unit/vda-core.bats",
         "tests/unit/vda-ticket-smoke.bats",
         "tests/unit/website-ci-deploy.bats",
+        "tests/unit/website-domain-config-overlay.bats",
         "tests/unit/wg-mesh-fullmesh.bats",
         "tests/unit/worktree-create.bats",
         "website/test/fixtures/einvoice/kleinunternehmer.cii.xml",
@@ -1884,7 +1885,7 @@
       "id": "infra-manifests",
       "name": "Kubernetes manifests, overlays, env registry",
       "owner_agent": "bachelorprojekt-infra",
-      "file_count": 398,
+      "file_count": 399,
       "files": [
         "claude-code/gekko-android-mcp-guide.md",
         "claude-code/settings.json",
@@ -2204,6 +2205,7 @@
         "prod-fleet/platform/ingressclass.yaml",
         "prod-fleet/platform/kustomization.yaml",
         "prod-fleet/platform/reflector-rbac.yaml",
+        "prod-fleet/website-common/domain-config.yaml",
         "prod-fleet/website-korczewski/kustomization.yaml",
         "prod-fleet/website-korczewski/website-security-headers.yaml",
         "prod-fleet/website-mentolder/kustomization.yaml",

--- a/docs/generated/api-map.json
+++ b/docs/generated/api-map.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-16T02:57:43.765Z",
+  "generatedAt": "2026-06-16T02:59:48.826Z",
   "endpoints": [
     {
       "path": "/api/admin/angebote/save",

--- a/docs/generated/api-map.json
+++ b/docs/generated/api-map.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-16T01:49:03.787Z",
+  "generatedAt": "2026-06-16T02:57:43.765Z",
   "endpoints": [
     {
       "path": "/api/admin/angebote/save",

--- a/docs/generated/api-surface.md
+++ b/docs/generated/api-surface.md
@@ -1,6 +1,6 @@
 # API Surface Map
 
-> Generated at 2026-06-16T01:49:03.787Z
+> Generated at 2026-06-16T02:57:43.765Z
 
 | Path | Methods | Auth | File |
 |------|---------|------|------|

--- a/docs/generated/api-surface.md
+++ b/docs/generated/api-surface.md
@@ -1,6 +1,6 @@
 # API Surface Map
 
-> Generated at 2026-06-16T02:57:43.765Z
+> Generated at 2026-06-16T02:59:48.826Z
 
 | Path | Methods | Auth | File |
 |------|---------|------|------|

--- a/docs/generated/blast-radius.md
+++ b/docs/generated/blast-radius.md
@@ -1,5 +1,5 @@
 # Blast-Radius-Report
-> Generated: 2026-06-16T02:57:43.802Z
+> Generated: 2026-06-16T02:59:48.906Z
 > Nodes: 78 | Edges: 1613 | Isolated: 2
 
 ## Ranking (transitive Abhängige)

--- a/docs/generated/blast-radius.md
+++ b/docs/generated/blast-radius.md
@@ -1,5 +1,5 @@
 # Blast-Radius-Report
-> Generated: 2026-06-16T01:49:03.868Z
+> Generated: 2026-06-16T02:57:43.802Z
 > Nodes: 78 | Edges: 1613 | Isolated: 2
 
 ## Ranking (transitive Abhängige)

--- a/docs/generated/graph.json
+++ b/docs/generated/graph.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-16T01:49:03.722Z",
+  "generatedAt": "2026-06-16T02:57:43.695Z",
   "nodes": [
     {
       "id": "admin-actions-cleanup",

--- a/docs/generated/graph.json
+++ b/docs/generated/graph.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-16T02:57:43.695Z",
+  "generatedAt": "2026-06-16T02:59:48.754Z",
   "nodes": [
     {
       "id": "admin-actions-cleanup",

--- a/docs/superpowers/plans/2026-06-16-website-domain-config-overlay.md
+++ b/docs/superpowers/plans/2026-06-16-website-domain-config-overlay.md
@@ -1,0 +1,565 @@
+---
+title: website-ns domain-config deklarativ im Website-Overlay Implementation Plan
+ticket_id: T000873
+domains: [infra]
+status: active
+pr_number: null
+file_locks: []
+shared_changes: false
+batch_id: null
+parent_feature: null
+depends_on_plans: []
+---
+
+# website-ns domain-config deklarativ im Website-Overlay Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Verankere die `domain-config` ConfigMap deklarativ in beiden Website-Overlays (`website` + `website-korczewski` ns), sodass ein neuer required `configMapKeyRef`-Key in `k3d/website.yaml` keinen frischen `website:deploy` mehr mit `CreateContainerConfigError` bricht — plus ein Offline-CI-Guard, der einen fehlenden Key in CI rot macht statt erst zur Deploy-Zeit.
+
+**Architecture:** Eine einzige geteilte ConfigMap-Datei unter `prod-fleet/website-common/domain-config.yaml` (ohne `metadata.namespace`) wird von beiden Brand-Overlays per `resources:`-Eintrag eingebunden; die `namespace:`-Direktive jedes Overlays re-namespaced sie korrekt. Werte sind env-Platzhalter identisch zur workspace-SSOT (`prod/configmap-domains.yaml`). Ein neuer bats-Parity-Guard hält k3d/website.yaml ↔ geteilte ConfigMap ↔ prod/configmap-domains.yaml drift-frei.
+
+**Tech Stack:** Kustomize-Overlays, Bash/BATS (bats-core submodule), go-task (`Taskfile.yml`), `kubectl apply --server-side`.
+
+---
+
+## Kontext & verifizierte Fakten (NICHT neu herleiten)
+
+Alle Fakten unten wurden im Worktree `/tmp/wt-website-domain-config-overlay` verifiziert (Branch `feature/website-domain-config-overlay`, Ticket T000873):
+
+- **`k3d/website.yaml:433-437`** — der einzige `configMapKeyRef` aus `domain-config`:
+  `MEDIAVIEWER_HOST` (Zeile 433 `name:`, 436 `name: domain-config`, 437 `key: MEDIAVIEWER_HOST`), **required, kein `optional: true`**.
+- **`prod/configmap-domains.yaml:27`** — `MEDIAVIEWER_HOST: "mediaviewer.${PROD_DOMAIN}"` (SSOT-Ausdruck, exakt spiegeln).
+- **`environments/schema.yaml:182`** — `MEDIAVIEWER_HOST` registriert (`default_dev: mediaviewer.localhost`). **KEINE schema-Änderung nötig.**
+- **`Taskfile.yml` Prod-Pfad Z.3562-3566** — `kustomize build $WEBSITE_OVERLAY | sed(quotet bare ${VAR}) | envsubst "<liste>" | sed($$→$) | kubectl apply --server-side --force-conflicts`. Die envsubst-Liste (Z.3564) **enthält bereits `\$PROD_DOMAIN`** → **keine envsubst-Listen-Änderung nötig**, solange der ConfigMap-Wert `mediaviewer.${PROD_DOMAIN}` lautet.
+- **`Taskfile.yml` Dev-Pfad Z.3528-3539** — applied `k3d/website.yaml` imperativ in die website-ns, dessen envsubst-Liste (Z.3538) **ebenfalls `\$PROD_DOMAIN`** enthält. **Aber:** dieser Pfad applied **keine** domain-config in die website-ns (Z.2240 applied `k3d/configmap-domains.yaml` nur in `workspace`, nicht website). → Dev hat dieselbe Lücke (siehe Task 5, Verifikation-first).
+- **`environments/dev.yaml`** hat **KEINE `PROD_DOMAIN`-Schlüssel** (verifiziert: `grep PROD_DOMAIN environments/dev.yaml` → leer); es setzt nur `MEDIAVIEWER_HOST: mediaviewer.localhost` direkt unter `env_vars` (Z.19). Konsequenz für Dev siehe Task 5.
+- **Overlay-Auswahl:** mentolder→`prod-fleet/website-mentolder` (Z.3550), korczewski→`prod-fleet/website-korczewski` (Z.3551).
+- **Beide Overlay-`kustomization.yaml` haben `namespace:` gesetzt** (`website` bzw. `website-korczewski`) → eine geteilte ConfigMap **ohne** `metadata.namespace` wird korrekt re-namespaced.
+- **`tests/unit/mediaviewer-host-durability.bats`** existiert (51 Z.), deckt aber NUR den workspace-ns-Pfad ab. Der neue Guard ist **komplementär** (website-ns).
+- **Test-Wiring-Punkt:** `Taskfile.yml:263` listet `- task: test:unit:mediaviewer-host-durability` im `test:unit`-Aggregator (Z.249-290); die Subtask-Definition steht Z.408-411. Der neue Test wird **identisch** eingehängt. Der `coverage-guard` (`scripts/tests/unit-coverage-guard.sh`, Task Z.502-506) prüft, dass **jede** `tests/unit/*.bats` von einem Task per `grep -qF "<name>.bats" Taskfile.yml` referenziert wird ODER in `tests/unit/.coverage-allowlist` steht — die Subtask-Definition (die `tests/unit/website-domain-config-overlay.bats` enthält) erfüllt das automatisch.
+
+### S1-Ratchet-Budget (pro zu ändernder Datei, gegen die **wirksame** Schwelle)
+
+`jq -r '."S1:<pfad>".metric // "nicht-baselined"' docs/code-quality/baseline.json` ausgeführt für alle Dateien:
+
+| Datei | Ext-Limit | Baseline | Ist `wc -l` | Wirksame Schwelle | Budget | Plan-Konsequenz |
+|---|---|---|---|---|---|---|
+| `Taskfile.yml` | (nicht in S1-Limit-Tabelle; `.yml` nicht gelistet) | **nicht-baselined** | 4644 | n/a (`.yml` kein S1-Ext-Limit) | n/a | Trotzdem **zeilenneutral pro Edit halten** wo möglich; die einzigen Edits sind +2 Aggregator-Zeile + Subtask-Definition (s.u.) — additiv, aber `.yml` triggert kein S1-Ratchet. |
+| `prod-fleet/website-mentolder/kustomization.yaml` | (`.yaml` kein S1-Ext-Limit) | nicht-baselined | 8 | n/a | n/a | +1 resources-Zeile, unkritisch. |
+| `prod-fleet/website-korczewski/kustomization.yaml` | (`.yaml` kein S1-Ext-Limit) | nicht-baselined | 31 | n/a | n/a | +1 resources-Zeile, unkritisch. |
+| `prod-fleet/website-common/domain-config.yaml` | (`.yaml` kein S1-Ext-Limit) | nicht-baselined (NEU) | 0 (neu, ~10 Z.) | n/a | groß | Neue Datei, weit unter jeder Grenze. |
+| `tests/unit/website-domain-config-overlay.bats` | `.bats` = **300** | nicht-baselined (NEU) | 0 (neu, ~90 Z.) | 300 | ~210 | Neue Datei, weit unter Limit; Wachstumsreserve groß. |
+
+> **S1-Hinweis:** `.yml`/`.yaml`/`.bats` — nur `.bats` (Limit 300) fällt unter ein S1-Extension-Limit; YAML-Dateien sind nicht im S1-Limit-Set, daher kein Ratchet-Risiko durch additive Zeilen. Trotzdem werden alle Edits minimal gehalten. **Keine Baseline-/Ignore-Ausnahme** wird hinzugefügt (verbietet `freshness:check` Key-Count-Assertion).
+
+---
+
+## File Structure
+
+| Datei | Verantwortung | Aktion |
+|---|---|---|
+| `prod-fleet/website-common/domain-config.yaml` | Geteilte, ns-lose `domain-config` ConfigMap mit genau den vom website-Deployment konsumierten Keys (heute: `MEDIAVIEWER_HOST`), Wert als env-Platzhalter = workspace-SSOT. | **NEU** |
+| `prod-fleet/website-mentolder/kustomization.yaml` | mentolder-Overlay (`namespace: website`); referenziert die geteilte ConfigMap zusätzlich. | **EDIT** (+1 resource) |
+| `prod-fleet/website-korczewski/kustomization.yaml` | korczewski-Overlay (`namespace: website-korczewski`); referenziert die geteilte ConfigMap zusätzlich. | **EDIT** (+1 resource) |
+| `tests/unit/website-domain-config-overlay.bats` | Offline-Parity/Presence/Drift-Guard (website-ns), komplementär zu `mediaviewer-host-durability.bats` (workspace-ns). | **NEU** |
+| `Taskfile.yml` | Test-Wiring: Subtask-Definition + Aggregator-Eintrag (analog `mediaviewer-host-durability`). | **EDIT** (+ Subtask + 1 Aggregator-Zeile) |
+| `environments/schema.yaml` | — | **KEINE Änderung** (MEDIAVIEWER_HOST bereits registriert). |
+
+---
+
+## Task 1: Geteilte domain-config ConfigMap (DRY über beide Brands)
+
+**Files:**
+- Create: `prod-fleet/website-common/domain-config.yaml`
+
+- [ ] **Step 1: Datei anlegen**
+
+Wert-Ausdruck `mediaviewer.${PROD_DOMAIN}` ist **byte-identisch** zu `prod/configmap-domains.yaml:27` → konsistente Werte zwischen workspace-ns und website-ns, kein Drift. `${PROD_DOMAIN}` wird im Prod-Pfad von `website:deploy` per envsubst gefüllt (steht bereits in der Liste). Datei hat **bewusst kein `metadata.namespace`** — die `namespace:`-Direktive des einbindenden Overlays setzt sie korrekt.
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: domain-config
+  # KEIN namespace: hier — die Overlay-namespace:-Direktive (website / website-korczewski)
+  # re-namespaced diese ConfigMap brand-korrekt. NICHT hinzufügen.
+data:
+  # Muss exakt dem prod/configmap-domains.yaml-Ausdruck entsprechen (SSOT, drift-guarded
+  # durch tests/unit/website-domain-config-overlay.bats). Wert wird via website:deploy-
+  # envsubst gefüllt ($PROD_DOMAIN ist bereits in der Liste, Taskfile.yml Z.3564/3538).
+  # Jeder neue required configMapKeyRef name: domain-config in k3d/website.yaml MUSS hier
+  # ergänzt werden, sonst macht der bats-Guard CI rot.
+  MEDIAVIEWER_HOST: "mediaviewer.${PROD_DOMAIN}"
+```
+
+- [ ] **Step 2: Wert-Parität gegen die SSOT verifizieren**
+
+Run:
+```bash
+diff <(grep -E '^[[:space:]]+MEDIAVIEWER_HOST:' prod/configmap-domains.yaml | tr -s ' ') \
+     <(grep -E '^[[:space:]]+MEDIAVIEWER_HOST:' prod-fleet/website-common/domain-config.yaml | tr -s ' ')
+```
+Expected: kein Output (Exit 0) — die `MEDIAVIEWER_HOST:`-Zeile ist in beiden Dateien identisch (`MEDIAVIEWER_HOST: "mediaviewer.${PROD_DOMAIN}"`).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add prod-fleet/website-common/domain-config.yaml
+git commit -m "feat(infra): add shared domain-config ConfigMap for website overlays"
+```
+
+---
+
+## Task 2: mentolder-Overlay referenziert die geteilte ConfigMap
+
+**Files:**
+- Modify: `prod-fleet/website-mentolder/kustomization.yaml`
+
+- [ ] **Step 1: resources-Eintrag ergänzen**
+
+Aktueller Inhalt (verifiziert, 8 Z.):
+```yaml
+namespace: website
+resources:
+  - ../../k3d/website.yaml
+  - ../../k3d/website-seller-config.yaml
+  - website-ingress-web.yaml
+```
+
+Ergänze die geteilte ConfigMap als neuen `resources`-Eintrag (Pfad relativ zu `prod-fleet/website-mentolder/`):
+```yaml
+namespace: website
+resources:
+  - ../../k3d/website.yaml
+  - ../../k3d/website-seller-config.yaml
+  - ../website-common/domain-config.yaml
+  - website-ingress-web.yaml
+```
+
+- [ ] **Step 2: kustomize build prüft die Einbindung + Namespace**
+
+Run:
+```bash
+kustomize build prod-fleet/website-mentolder --load-restrictor=LoadRestrictionsNone \
+  | grep -A6 'kind: ConfigMap' | grep -E 'name: domain-config|namespace: website|MEDIAVIEWER_HOST'
+```
+Expected: zeigt `name: domain-config`, `namespace: website` und `MEDIAVIEWER_HOST: "mediaviewer.${PROD_DOMAIN}"` (Wert noch un-substituiert — envsubst läuft erst im Deploy-Pfad).
+
+> Falls `kustomize` lokal fehlt: `kubectl kustomize prod-fleet/website-mentolder` als Fallback.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add prod-fleet/website-mentolder/kustomization.yaml
+git commit -m "feat(infra): wire shared domain-config into mentolder website overlay"
+```
+
+---
+
+## Task 3: korczewski-Overlay referenziert die geteilte ConfigMap
+
+**Files:**
+- Modify: `prod-fleet/website-korczewski/kustomization.yaml`
+
+- [ ] **Step 1: resources-Eintrag ergänzen**
+
+Aktueller Inhalt (verifiziert, 31 Z. — `namespace: website-korczewski`, `resources:` mit `../../k3d/website.yaml`, `../../k3d/website-seller-config.yaml`, `website-security-headers.yaml`, plus `patches:` für den IngressRoute-TLS/Middleware-Patch). **Den `patches:`-Block unverändert lassen.** Nur den `resources:`-Block erweitern:
+
+```yaml
+resources:
+  - ../../k3d/website.yaml
+  - ../../k3d/website-seller-config.yaml
+  - ../website-common/domain-config.yaml
+  - website-security-headers.yaml
+```
+
+> Hinweis: Lies die Datei zuerst vollständig und füge die Zeile `  - ../website-common/domain-config.yaml` exakt in den bestehenden `resources:`-Block ein (z.B. nach `website-seller-config.yaml`). `patches:` und `namespace: website-korczewski` bleiben unangetastet.
+
+- [ ] **Step 2: kustomize build prüft die Einbindung + Namespace**
+
+Run:
+```bash
+kustomize build prod-fleet/website-korczewski --load-restrictor=LoadRestrictionsNone \
+  | grep -A6 'kind: ConfigMap' | grep -E 'name: domain-config|namespace: website-korczewski|MEDIAVIEWER_HOST'
+```
+Expected: zeigt `name: domain-config`, `namespace: website-korczewski` und `MEDIAVIEWER_HOST: "mediaviewer.${PROD_DOMAIN}"`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add prod-fleet/website-korczewski/kustomization.yaml
+git commit -m "feat(infra): wire shared domain-config into korczewski website overlay"
+```
+
+---
+
+## Task 4: Offline-Anti-Regression-Guard (bats)
+
+**Files:**
+- Create: `tests/unit/website-domain-config-overlay.bats`
+- Modify: `Taskfile.yml` (Subtask-Definition + Aggregator-Eintrag)
+
+Dieser Guard ist **offline** (keine Cluster-Calls, kein kubectl, kein Netzwerk). Er prüft drei Eigenschaften per `grep`:
+1. **Parity:** jeder `configMapKeyRef`-Key mit `name: domain-config` in `k3d/website.yaml` existiert in der geteilten ConfigMap.
+2. **Presence:** beide Overlays referenzieren `../website-common/domain-config.yaml`.
+3. **Drift:** `MEDIAVIEWER_HOST`-Ausdruck in der geteilten ConfigMap == der in `prod/configmap-domains.yaml`.
+
+Die `kustomize build`-Assertion aus der Spec wird **bewusst weggelassen** — `kustomize` ist im Offline-CI-Lauf (`task test:all`) nicht garantiert installiert; die `kustomize build`-Verifikation läuft stattdessen in Task 2/3 (manuell) und Task 6 (`task workspace:validate`). Der bats-Guard bleibt rein `grep`-basiert und damit zuverlässig offline.
+
+- [ ] **Step 1: Den failing Guard schreiben**
+
+> TDD-Hinweis: Schreibe zuerst den vollständigen Guard. Er ist initial **rot** für die Parity/Presence-Tests, solange Task 1-3 noch nicht committed sind — in der subagent-Reihenfolge laufen Task 1-3 aber zuerst, sodass er nach dem Wiring grün wird. Um den failing-Zustand zu demonstrieren, siehe Step 3.
+
+Inhalt von `tests/unit/website-domain-config-overlay.bats`:
+
+```bash
+#!/usr/bin/env bats
+# Regression: die website-Namespace muss die domain-config ConfigMap deklarativ
+# im Overlay tragen — sonst bricht ein frischer `task website:deploy ENV=<brand>`
+# mit CreateContainerConfigError, weil k3d/website.yaml MEDIAVIEWER_HOST per
+# required configMapKeyRef aus `domain-config` bezieht, die in der website-ns
+# (ohne dieses Overlay) gar nicht existiert. So live-gefixt bei PR #1735.
+#
+# Komplementär zu tests/unit/mediaviewer-host-durability.bats:
+#   - mediaviewer-host-durability.bats schützt den WORKSPACE-ns-Pfad
+#     (prod/configmap-domains.yaml + dessen envsubst).
+#   - DIESER Guard schützt den WEBSITE-ns-Pfad (geteilte Overlay-ConfigMap).
+# Keine Überschneidung. Rein offline (grep), keine Cluster-Calls.
+
+setup() {
+  REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+  WEBSITE="$REPO_ROOT/k3d/website.yaml"
+  SHARED_CM="$REPO_ROOT/prod-fleet/website-common/domain-config.yaml"
+  PROD_DOMAINS="$REPO_ROOT/prod/configmap-domains.yaml"
+  KUST_MENTOLDER="$REPO_ROOT/prod-fleet/website-mentolder/kustomization.yaml"
+  KUST_KORCZEWSKI="$REPO_ROOT/prod-fleet/website-korczewski/kustomization.yaml"
+}
+
+@test "shared website domain-config ConfigMap file exists" {
+  [ -f "$SHARED_CM" ]
+}
+
+@test "shared domain-config is named 'domain-config' (matches configMapKeyRef name)" {
+  run grep -qE '^[[:space:]]*name:[[:space:]]*domain-config[[:space:]]*$' "$SHARED_CM"
+  [ "$status" -eq 0 ]
+}
+
+@test "shared domain-config carries NO metadata.namespace (overlay re-namespaces it)" {
+  # Ein hartes namespace: hier würde das brand-korrekte Re-Namespacing brechen.
+  run grep -qE '^[[:space:]]*namespace:' "$SHARED_CM"
+  [ "$status" -ne 0 ]
+}
+
+@test "parity: every domain-config configMapKeyRef key in website.yaml is in the shared ConfigMap" {
+  # Extrahiere alle keys, die k3d/website.yaml via configMapKeyRef aus domain-config zieht.
+  # Heuristik (offline, ohne yaml-Parser): finde Blöcke 'name: domain-config' gefolgt von
+  # 'key: <KEY>' im selben valueFrom.configMapKeyRef. Wir lesen alle 'key:' Zeilen, die
+  # in einem configMapKeyRef-Block mit name: domain-config stehen.
+  keys="$(awk '
+    /configMapKeyRef:/ { in_ref=1; name=""; next }
+    in_ref && /name:[[:space:]]*domain-config/ { name="domain-config"; next }
+    in_ref && /key:/ {
+      if (name=="domain-config") { gsub(/^[[:space:]]*key:[[:space:]]*/,""); gsub(/[[:space:]]*$/,""); print }
+      in_ref=0; name=""; next
+    }
+    in_ref && /name:/ { name=""; }   # ein anderer ConfigMap-name → kein domain-config-key
+  ' "$WEBSITE")"
+  [ -n "$keys" ]   # mindestens MEDIAVIEWER_HOST muss gefunden werden
+  while IFS= read -r k; do
+    [ -z "$k" ] && continue
+    run grep -qE "^[[:space:]]+${k}:" "$SHARED_CM"
+    [ "$status" -eq 0 ] || { echo "FEHLT in shared domain-config: $k"; false; }
+  done <<< "$keys"
+}
+
+@test "presence: mentolder overlay references the shared domain-config" {
+  run grep -qF '../website-common/domain-config.yaml' "$KUST_MENTOLDER"
+  [ "$status" -eq 0 ]
+}
+
+@test "presence: korczewski overlay references the shared domain-config" {
+  run grep -qF '../website-common/domain-config.yaml' "$KUST_KORCZEWSKI"
+  [ "$status" -eq 0 ]
+}
+
+@test "drift: shared MEDIAVIEWER_HOST expression equals prod/configmap-domains.yaml" {
+  shared="$(grep -E '^[[:space:]]+MEDIAVIEWER_HOST:' "$SHARED_CM" | tr -s ' ' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+  prod="$(grep -E '^[[:space:]]+MEDIAVIEWER_HOST:' "$PROD_DOMAINS" | tr -s ' ' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+  [ -n "$shared" ]
+  [ "$shared" = "$prod" ]
+}
+
+@test "MEDIAVIEWER_HOST derives from \${PROD_DOMAIN} (no hardcoded brand domain, S3)" {
+  run grep -qE '^[[:space:]]+MEDIAVIEWER_HOST:[[:space:]]*"mediaviewer\.\$\{PROD_DOMAIN\}"' "$SHARED_CM"
+  [ "$status" -eq 0 ]
+}
+```
+
+- [ ] **Step 2: Subtask + Aggregator-Eintrag im Taskfile ergänzen (analog mediaviewer-host-durability)**
+
+Im Aggregator `test:unit` (Taskfile.yml, Block Z.249-290), direkt **nach** der Zeile
+`      - task: test:unit:mediaviewer-host-durability` (Z.263) eine Zeile einfügen:
+```yaml
+      - task: test:unit:website-domain-config-overlay
+```
+
+Und die Subtask-Definition direkt **nach** dem `test:unit:mediaviewer-host-durability`-Block (endet Z.411) einfügen:
+```yaml
+  test:unit:website-domain-config-overlay:
+    internal: true
+    cmds:
+      - ./tests/unit/lib/bats-core/bin/bats tests/unit/website-domain-config-overlay.bats
+```
+
+> Beide Edits sind rein additiv. `.yml` fällt unter kein S1-Extension-Limit (kein Ratchet-Risiko). Der `coverage-guard` (`scripts/tests/unit-coverage-guard.sh`) sieht `website-domain-config-overlay.bats` über die Subtask-`cmds`-Zeile per `grep -qF` → kein Allowlist-Eintrag nötig.
+
+- [ ] **Step 3: Demonstriere den failing-Zustand des Parity-Guards (TDD-Beweis)**
+
+Temporär einen Dummy-required-Key in `k3d/website.yaml` hinzufügen, der NICHT in der geteilten ConfigMap ist, und den Parity-Test laufen lassen:
+```bash
+# Backup + Dummy einfügen direkt nach dem MEDIAVIEWER_HOST-configMapKeyRef-Block (~Z.437)
+cp k3d/website.yaml /tmp/website.yaml.bak
+# Manuell einfügen (oder via Editor): ein zweiter env-Eintrag, der aus domain-config
+# einen nicht-gemirrorten Key zieht, z.B.:
+#   - name: DUMMY_HOST
+#     valueFrom:
+#       configMapKeyRef:
+#         name: domain-config
+#         key: DUMMY_HOST
+./tests/unit/lib/bats-core/bin/bats tests/unit/website-domain-config-overlay.bats
+```
+Expected: der Test `parity: every domain-config configMapKeyRef key in website.yaml is in the shared ConfigMap` schlägt mit `FEHLT in shared domain-config: DUMMY_HOST` **FEHL** → beweist, dass ein neuer required Key ohne Mirror CI rot macht.
+
+Danach Backup zurückspielen:
+```bash
+mv /tmp/website.yaml.bak k3d/website.yaml
+```
+
+- [ ] **Step 4: Guard grün laufen lassen (echter Zustand)**
+
+Run:
+```bash
+./tests/unit/lib/bats-core/bin/bats tests/unit/website-domain-config-overlay.bats
+```
+Expected: alle Tests **PASS** (9 ok).
+
+> Falls bats-Submodul fehlt: `git submodule update --init --recursive` (wie `test:unit` Z.252 es tut).
+
+- [ ] **Step 5: Über den Aggregator-Task laufen lassen (Wiring-Beweis)**
+
+Run:
+```bash
+task test:unit:website-domain-config-overlay
+```
+Expected: PASS (beweist die Subtask-Definition greift).
+
+Und den coverage-guard:
+```bash
+bash scripts/tests/unit-coverage-guard.sh
+```
+Expected: `unit-coverage: all <N> tests/unit/*.bats files are tracked (run by a task or allowlisted).` — kein Eintrag fehlt.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/unit/website-domain-config-overlay.bats Taskfile.yml
+git commit -m "test(infra): add offline website-ns domain-config parity guard"
+```
+
+---
+
+## Task 5: Dev-Pfad-Frage klären (Verifikation-first, nur bei echter Lücke anfassen)
+
+**Files:**
+- (potenziell) Modify: `Taskfile.yml` Dev-Zweig (Z.3528-3539) — **NUR falls verifizierte Lücke**.
+
+**Verifizierter Ausgangsbefund:** Der Dev-Zweig von `website:deploy` (Z.3528-3539) applied `k3d/website.yaml` imperativ in die website-ns, applied dabei aber **keine** `domain-config` (Z.2240 applied `k3d/configmap-domains.yaml` ausschließlich in die `workspace`-ns). `environments/dev.yaml` hat **keinen `PROD_DOMAIN`-Schlüssel** — ein `envsubst "\$PROD_DOMAIN"` der geteilten ConfigMap würde im Dev daher `mediaviewer.` (leer) oder den literalen Platzhalter ergeben, NICHT `mediaviewer.localhost`. Die Dev-SSOT für den Wert ist `k3d/configmap-domains.yaml` (`MEDIAVIEWER_HOST: "mediaviewer.localhost"`).
+
+- [ ] **Step 1: Prüfen, ob der Dev-`website:deploy` aktuell überhaupt bricht**
+
+Entscheidungslogik (rein lokal, kein Cluster nötig falls kein dev-Cluster läuft):
+```bash
+# a) Bezieht das website-Deployment in dev MEDIAVIEWER_HOST aus domain-config? (ja, gleiche k3d/website.yaml)
+grep -n 'domain-config' k3d/website.yaml
+# b) Applied der Dev-Zweig eine domain-config in die website-ns? (Befund: nein)
+sed -n '3528,3540p' Taskfile.yml | grep -c 'domain-config' || true   # erwartet 0
+# c) Falls ein dev-k3d-Cluster läuft, existiert die cm bereits ad-hoc in website-ns?
+kubectl --context k3d-mentolder-dev -n website get configmap domain-config 2>/dev/null \
+  && echo "DEV: domain-config existiert bereits (Lücke evtl. nicht akut)" \
+  || echo "DEV: keine domain-config in website-ns → frischer Dev-Deploy würde brechen"
+```
+
+- [ ] **Step 2: Entscheidung dokumentieren**
+
+**Wenn (c) zeigt, dass keine `domain-config` in der dev-website-ns existiert** (Lücke akut) → fahre mit Step 3 fort.
+**Wenn die cm existiert** (z.B. aus einem früheren Apply geerbt) ODER **kein dev-Cluster verfügbar ist und Dev nicht im Scope der Bachelorarbeit-Deploys liegt** → **Prod-only bleiben**, Step 3 überspringen, Begründung als Commit-/PR-Kommentar festhalten: „Dev-Zweig nicht angefasst — Dev-website-ns trägt keine domain-config über das Overlay (imperativer Apply), Wert-SSOT ist `k3d/configmap-domains.yaml`; eine Dev-Lücke wird separat behandelt, da `environments/dev.yaml` kein `PROD_DOMAIN` führt und der geteilte Overlay-ConfigMap-Ausdruck im Dev nicht korrekt substituieren würde."
+
+- [ ] **Step 3 (NUR bei akuter Dev-Lücke): Dev-Zweig die Dev-domain-config applizieren lassen**
+
+Da der geteilte Overlay-ConfigMap-Ausdruck (`mediaviewer.${PROD_DOMAIN}`) im Dev mangels `PROD_DOMAIN` NICHT korrekt auflöst, applied der Dev-Zweig stattdessen die **Dev-SSOT** `k3d/configmap-domains.yaml` in die website-ns (analog dem workspace-ns-Apply Z.2240, aber in `${WEBSITE_NAMESPACE}`). Füge im Dev-Zweig (nach dem `website-seller-config.yaml`-Apply, Z.3539) ein:
+```bash
+          # Dev: domain-config (mediaviewer.localhost etc.) auch in die website-ns spiegeln,
+          # damit der required MEDIAVIEWER_HOST-configMapKeyRef nicht CreateContainerConfigError
+          # wirft. Wert-SSOT für dev ist k3d/configmap-domains.yaml (nicht der ${PROD_DOMAIN}-
+          # Overlay-Ausdruck — environments/dev.yaml führt kein PROD_DOMAIN).
+          kubectl ${CTX_ARG} apply -f k3d/configmap-domains.yaml -n "${WEBSITE_NAMESPACE}"
+```
+> `WEBSITE_NAMESPACE` ist im Block bereits exportiert (Z.3526). Dies ist **kein** envsubst des Overlay-ConfigMaps — bewusst, weil der Dev-Wert literal `mediaviewer.localhost` ist und nicht aus `${PROD_DOMAIN}` abgeleitet werden kann.
+
+- [ ] **Step 4 (NUR falls Step 3 ausgeführt): Dev-Apply verifizieren**
+
+Run (falls dev-Cluster läuft):
+```bash
+ENV=dev task website:deploy 2>&1 | tail -20
+kubectl --context k3d-mentolder-dev -n website get configmap domain-config -o jsonpath='{.data.MEDIAVIEWER_HOST}'
+```
+Expected: `mediaviewer.localhost`; das website-Pod kommt ohne `CreateContainerConfigError` hoch.
+
+- [ ] **Step 5: Commit (nur falls Step 3 ausgeführt)**
+
+```bash
+git add Taskfile.yml
+git commit -m "fix(infra): mirror domain-config into dev website namespace"
+```
+
+---
+
+## Task 6: SSA-Adoptions-Risiko adressieren (Prod-Apply der neuen ConfigMap)
+
+**Files:** keine Code-Änderung — Verifikations-Task + Doku.
+
+Der Prod-Pfad nutzt `kubectl apply --server-side --force-conflicts` (Z.3566). Die live `domain-config` in `website`/`website-korczewski` wurde bei PR #1735 **ad-hoc imperativ** erstellt (`kubectl create`/`cp`), ist also evtl. nicht SSA-gemanagt (field-manager `kubectl-client-side-apply` oder gar keiner). Beim ersten Overlay-Deploy übernimmt SSA das Field-Ownership — analog dem `knowledge-secrets`-Adoptionsproblem aus CLAUDE.md (dort verweigerte der SealedSecrets-Controller die Adoption eines secretGenerator-Secrets). Bei einer ConfigMap via `--server-side --force-conflicts` ist die Adoption i.d.R. konfliktfrei, MUSS aber verifiziert werden.
+
+- [ ] **Step 1: Diff der gebauten ConfigMap gegen live (Server-Side dry-run, kein echter Apply)**
+
+Run (für beide Brands, hier mentolder; `--context fleet`):
+```bash
+source scripts/env-resolve.sh mentolder
+kustomize build prod-fleet/website-mentolder --load-restrictor=LoadRestrictionsNone \
+  | sed -E 's/: \$\{([a-zA-Z0-9_]+)\}[[:space:]]*$/: "${\1}"/g' \
+  | PROD_DOMAIN="$PROD_DOMAIN" envsubst '$PROD_DOMAIN' \
+  | sed -E 's/\$\$([a-zA-Z0-9_]|\{)/$\1/g' \
+  | kubectl --context fleet -n website diff --server-side --force-conflicts -f - 2>&1 \
+  | grep -A8 'domain-config' || echo "kein Diff an domain-config (oder cm-Werte identisch)"
+```
+Expected: der Diff zeigt höchstens eine `managedFields`-Übernahme bzw. identische `data.MEDIAVIEWER_HOST` (`mediaviewer.mentolder.de`). **Kein `Apply failed with N conflicts`** im Output.
+
+> `kubectl diff --server-side` simuliert den Apply ohne Mutation. Falls `diff` einen Konflikt meldet, ist `--force-conflicts` (bereits im Deploy-Pfad gesetzt, Z.3566) die korrekte Auflösung — sie übernimmt das Field-Ownership. Das ist erwartet und sicher für eine ConfigMap (keine Secret-Daten, kein Datenverlust). Dokumentiere das Ergebnis im PR-Body.
+
+- [ ] **Step 2: Dasselbe für korczewski**
+
+Run:
+```bash
+source scripts/env-resolve.sh korczewski
+kustomize build prod-fleet/website-korczewski --load-restrictor=LoadRestrictionsNone \
+  | sed -E 's/: \$\{([a-zA-Z0-9_]+)\}[[:space:]]*$/: "${\1}"/g' \
+  | PROD_DOMAIN="$PROD_DOMAIN" envsubst '$PROD_DOMAIN' \
+  | sed -E 's/\$\$([a-zA-Z0-9_]|\{)/$\1/g' \
+  | kubectl --context fleet -n website-korczewski diff --server-side --force-conflicts -f - 2>&1 \
+  | grep -A8 'domain-config' || echo "kein Diff an domain-config (oder cm-Werte identisch)"
+```
+Expected: `data.MEDIAVIEWER_HOST` = `mediaviewer.korczewski.de`, kein un-auflösbarer Konflikt.
+
+> **Hinweis (kein Step):** Der eigentliche Prod-Deploy (`task website:deploy ENV=mentolder` + `ENV=korczewski`) erfolgt erst **nach** PR-Merge im post-merge-Deploy (push-based, kein GitOps). Dieser Task verifiziert nur vorab, dass die Adoption sauber laufen wird. Falls kein Cluster-Zugang während der Implementierung besteht, Step 1/2 als „im post-merge-Deploy zu verifizieren" im PR-Body markieren — der Deploy selbst nutzt bereits `--force-conflicts`.
+
+---
+
+## Task 7: Finaler Verifikations-Task (CI-Äquivalent, PFLICHT)
+
+**Files:** keine — nur Verifikation + ein Commit für regenerierte Artefakte.
+
+- [ ] **Step 1: Kustomize-Strukturvalidierung**
+
+Run:
+```bash
+task workspace:validate
+```
+Expected: grün (alle Overlays inkl. `prod-fleet/website-*` bauen fehlerfrei).
+
+- [ ] **Step 2: Manifest-Testrunner für den betroffenen Bereich (falls passende TEST-ID existiert)**
+
+Run:
+```bash
+./tests/runner.sh local --list 2>/dev/null | grep -iE 'website|domain' || echo "keine spezifische TEST-ID — bats-Guard (Task 4) deckt ab"
+```
+Expected: entweder eine passende ID ausführen, oder bestätigen, dass der neue bats-Guard die Abdeckung liefert.
+
+- [ ] **Step 3: Gezielte Tests für geänderte Domains**
+
+Run:
+```bash
+task test:changed
+```
+Expected: grün (vitest --changed + BATS-Selection + quality), inkl. des neuen `website-domain-config-overlay.bats`.
+
+- [ ] **Step 4: Test-Inventar regenerieren (wegen neuem Test PFLICHT)**
+
+Run:
+```bash
+task test:inventory
+git add website/src/data/test-inventory.json
+```
+Expected: `website/src/data/test-inventory.json` enthält jetzt `website-domain-config-overlay` (sonst failt CI's Inventory-Check).
+
+- [ ] **Step 5: Freshness-Artefakte regenerieren**
+
+Run:
+```bash
+task freshness:regenerate
+```
+Expected: aktualisiert generierte Artefakte (test-inventory, repo-index, …). Generierte Konflikt-Magnete (`docs/generated/**`, `docs/code-quality/repo-index.json`, `k3d/docs-content-built/architecture/index.html`) ggf. mit `git add` aufnehmen.
+
+- [ ] **Step 6: CI-Äquivalent prüfen (S1-S4-Ratchet + Baseline-Assertion)**
+
+Run:
+```bash
+task freshness:check
+```
+Expected: grün — insbesondere:
+- S1-Ratchet meldet **kein** Wachstum (alle YAML-Dateien außerhalb des S1-Limit-Sets; `.bats`-Guard ~90 Z. << 300).
+- Baseline-Key-Count unverändert (keine neuen Baseline-Einträge — Plan fügt keine hinzu).
+- S3 (keine hardcodierten Brand-Domains): die geteilte ConfigMap nutzt `${PROD_DOMAIN}`, der bats-Guard nutzt Regex-Pattern, keine Literale.
+- S4 (Orphans): `prod-fleet/website-common/domain-config.yaml` ist in beiden `kustomization.yaml` referenziert; der bats-Test in `Taskfile.yml` verdrahtet.
+
+- [ ] **Step 7: Test-Inventar + Freshness-Artefakte committen**
+
+```bash
+git add website/src/data/test-inventory.json docs/generated docs/code-quality/repo-index.json 2>/dev/null; \
+git status --short
+git commit -m "chore: regenerate test-inventory + freshness artifacts for website domain-config guard"
+```
+> Falls `git status` keine Änderungen zeigt (Artefakte bereits aktuell), diesen Commit überspringen.
+
+- [ ] **Step 8: Abschluss-Verifikation der Akzeptanzkriterien**
+
+Run (Sammel-Check):
+```bash
+echo "== AK1/AK2: domain-config in beiden Overlays =="
+for b in mentolder korczewski; do
+  kustomize build "prod-fleet/website-$b" --load-restrictor=LoadRestrictionsNone \
+    | grep -qE 'name: domain-config' && echo "  $b: domain-config present OK"
+done
+echo "== AK3: bats-Guard grün + wired =="
+./tests/unit/lib/bats-core/bin/bats tests/unit/website-domain-config-overlay.bats >/dev/null && echo "  guard green OK"
+grep -qF 'website-domain-config-overlay.bats' Taskfile.yml && echo "  wired in Taskfile OK"
+echo "== AK6: Wert-Konsistenz (Ausdruck == SSOT) =="
+diff <(grep MEDIAVIEWER_HOST prod/configmap-domains.yaml | tr -s ' ') \
+     <(grep MEDIAVIEWER_HOST prod-fleet/website-common/domain-config.yaml | tr -s ' ') \
+     && echo "  expression matches SSOT OK"
+```
+Expected: alle `OK`-Zeilen erscheinen; `diff` kein Output.
+
+---
+
+## Spec-Coverage-Selbstreview
+
+- **Lösung §1 (geteilte ConfigMap)** → Task 1.
+- **Lösung §2 (Overlays referenzieren)** → Task 2 + Task 3.
+- **Lösung §3 (Dev-Pfad)** → Task 5 (Verifikation-first, Prod-only-Fallback dokumentiert).
+- **Lösung §4 (bats-Guard) + Komplementarität** → Task 4 (Parity/Presence/Drift, offline, Wiring + coverage-guard).
+- **Risiko SSA-Adoption** → Task 6 (server-side dry-run-diff für beide Brands).
+- **Risiko S1-Ratchet** → in der S1-Budget-Tabelle adressiert; alle Edits additiv/außerhalb S1-Limit-Set.
+- **Risiko Brand-Literale (S3)** → ConfigMap + bats nutzen `${PROD_DOMAIN}`/Regex, Task 7 Step 6 verifiziert.
+- **Akzeptanzkriterien 1-6** → Task 7 Step 8 prüft AK1/2/3/6; AK4 (`workspace:validate`) Task 7 Step 1; AK5 (`test:changed`+`freshness:*`+`test:inventory`) Task 7 Steps 3-6.
+- **environments/schema.yaml KEINE Änderung** → bestätigt (MEDIAVIEWER_HOST bereits Z.182).

--- a/docs/superpowers/plans/2026-06-16-website-domain-config-overlay.md
+++ b/docs/superpowers/plans/2026-06-16-website-domain-config-overlay.md
@@ -73,7 +73,7 @@ Alle Fakten unten wurden im Worktree `/tmp/wt-website-domain-config-overlay` ver
 **Files:**
 - Create: `prod-fleet/website-common/domain-config.yaml`
 
-- [ ] **Step 1: Datei anlegen**
+- [x] **Step 1: Datei anlegen**
 
 Wert-Ausdruck `mediaviewer.${PROD_DOMAIN}` ist **byte-identisch** zu `prod/configmap-domains.yaml:27` → konsistente Werte zwischen workspace-ns und website-ns, kein Drift. `${PROD_DOMAIN}` wird im Prod-Pfad von `website:deploy` per envsubst gefüllt (steht bereits in der Liste). Datei hat **bewusst kein `metadata.namespace`** — die `namespace:`-Direktive des einbindenden Overlays setzt sie korrekt.
 
@@ -93,7 +93,7 @@ data:
   MEDIAVIEWER_HOST: "mediaviewer.${PROD_DOMAIN}"
 ```
 
-- [ ] **Step 2: Wert-Parität gegen die SSOT verifizieren**
+- [x] **Step 2: Wert-Parität gegen die SSOT verifizieren**
 
 Run:
 ```bash
@@ -102,7 +102,7 @@ diff <(grep -E '^[[:space:]]+MEDIAVIEWER_HOST:' prod/configmap-domains.yaml | tr
 ```
 Expected: kein Output (Exit 0) — die `MEDIAVIEWER_HOST:`-Zeile ist in beiden Dateien identisch (`MEDIAVIEWER_HOST: "mediaviewer.${PROD_DOMAIN}"`).
 
-- [ ] **Step 3: Commit**
+- [x] **Step 3: Commit**
 
 ```bash
 git add prod-fleet/website-common/domain-config.yaml
@@ -116,7 +116,7 @@ git commit -m "feat(infra): add shared domain-config ConfigMap for website overl
 **Files:**
 - Modify: `prod-fleet/website-mentolder/kustomization.yaml`
 
-- [ ] **Step 1: resources-Eintrag ergänzen**
+- [x] **Step 1: resources-Eintrag ergänzen**
 
 Aktueller Inhalt (verifiziert, 8 Z.):
 ```yaml
@@ -137,7 +137,7 @@ resources:
   - website-ingress-web.yaml
 ```
 
-- [ ] **Step 2: kustomize build prüft die Einbindung + Namespace**
+- [x] **Step 2: kustomize build prüft die Einbindung + Namespace**
 
 Run:
 ```bash
@@ -148,7 +148,7 @@ Expected: zeigt `name: domain-config`, `namespace: website` und `MEDIAVIEWER_HOS
 
 > Falls `kustomize` lokal fehlt: `kubectl kustomize prod-fleet/website-mentolder` als Fallback.
 
-- [ ] **Step 3: Commit**
+- [x] **Step 3: Commit**
 
 ```bash
 git add prod-fleet/website-mentolder/kustomization.yaml
@@ -162,7 +162,7 @@ git commit -m "feat(infra): wire shared domain-config into mentolder website ove
 **Files:**
 - Modify: `prod-fleet/website-korczewski/kustomization.yaml`
 
-- [ ] **Step 1: resources-Eintrag ergänzen**
+- [x] **Step 1: resources-Eintrag ergänzen**
 
 Aktueller Inhalt (verifiziert, 31 Z. — `namespace: website-korczewski`, `resources:` mit `../../k3d/website.yaml`, `../../k3d/website-seller-config.yaml`, `website-security-headers.yaml`, plus `patches:` für den IngressRoute-TLS/Middleware-Patch). **Den `patches:`-Block unverändert lassen.** Nur den `resources:`-Block erweitern:
 
@@ -176,7 +176,7 @@ resources:
 
 > Hinweis: Lies die Datei zuerst vollständig und füge die Zeile `  - ../website-common/domain-config.yaml` exakt in den bestehenden `resources:`-Block ein (z.B. nach `website-seller-config.yaml`). `patches:` und `namespace: website-korczewski` bleiben unangetastet.
 
-- [ ] **Step 2: kustomize build prüft die Einbindung + Namespace**
+- [x] **Step 2: kustomize build prüft die Einbindung + Namespace**
 
 Run:
 ```bash
@@ -185,7 +185,7 @@ kustomize build prod-fleet/website-korczewski --load-restrictor=LoadRestrictions
 ```
 Expected: zeigt `name: domain-config`, `namespace: website-korczewski` und `MEDIAVIEWER_HOST: "mediaviewer.${PROD_DOMAIN}"`.
 
-- [ ] **Step 3: Commit**
+- [x] **Step 3: Commit**
 
 ```bash
 git add prod-fleet/website-korczewski/kustomization.yaml
@@ -207,7 +207,7 @@ Dieser Guard ist **offline** (keine Cluster-Calls, kein kubectl, kein Netzwerk).
 
 Die `kustomize build`-Assertion aus der Spec wird **bewusst weggelassen** — `kustomize` ist im Offline-CI-Lauf (`task test:all`) nicht garantiert installiert; die `kustomize build`-Verifikation läuft stattdessen in Task 2/3 (manuell) und Task 6 (`task workspace:validate`). Der bats-Guard bleibt rein `grep`-basiert und damit zuverlässig offline.
 
-- [ ] **Step 1: Den failing Guard schreiben**
+- [x] **Step 1: Den failing Guard schreiben**
 
 > TDD-Hinweis: Schreibe zuerst den vollständigen Guard. Er ist initial **rot** für die Parity/Presence-Tests, solange Task 1-3 noch nicht committed sind — in der subagent-Reihenfolge laufen Task 1-3 aber zuerst, sodass er nach dem Wiring grün wird. Um den failing-Zustand zu demonstrieren, siehe Step 3.
 
@@ -296,7 +296,7 @@ setup() {
 }
 ```
 
-- [ ] **Step 2: Subtask + Aggregator-Eintrag im Taskfile ergänzen (analog mediaviewer-host-durability)**
+- [x] **Step 2: Subtask + Aggregator-Eintrag im Taskfile ergänzen (analog mediaviewer-host-durability)**
 
 Im Aggregator `test:unit` (Taskfile.yml, Block Z.249-290), direkt **nach** der Zeile
 `      - task: test:unit:mediaviewer-host-durability` (Z.263) eine Zeile einfügen:
@@ -314,7 +314,7 @@ Und die Subtask-Definition direkt **nach** dem `test:unit:mediaviewer-host-durab
 
 > Beide Edits sind rein additiv. `.yml` fällt unter kein S1-Extension-Limit (kein Ratchet-Risiko). Der `coverage-guard` (`scripts/tests/unit-coverage-guard.sh`) sieht `website-domain-config-overlay.bats` über die Subtask-`cmds`-Zeile per `grep -qF` → kein Allowlist-Eintrag nötig.
 
-- [ ] **Step 3: Demonstriere den failing-Zustand des Parity-Guards (TDD-Beweis)**
+- [x] **Step 3: Demonstriere den failing-Zustand des Parity-Guards (TDD-Beweis)**
 
 Temporär einen Dummy-required-Key in `k3d/website.yaml` hinzufügen, der NICHT in der geteilten ConfigMap ist, und den Parity-Test laufen lassen:
 ```bash
@@ -336,7 +336,7 @@ Danach Backup zurückspielen:
 mv /tmp/website.yaml.bak k3d/website.yaml
 ```
 
-- [ ] **Step 4: Guard grün laufen lassen (echter Zustand)**
+- [x] **Step 4: Guard grün laufen lassen (echter Zustand)**
 
 Run:
 ```bash
@@ -346,7 +346,7 @@ Expected: alle Tests **PASS** (9 ok).
 
 > Falls bats-Submodul fehlt: `git submodule update --init --recursive` (wie `test:unit` Z.252 es tut).
 
-- [ ] **Step 5: Über den Aggregator-Task laufen lassen (Wiring-Beweis)**
+- [x] **Step 5: Über den Aggregator-Task laufen lassen (Wiring-Beweis)**
 
 Run:
 ```bash
@@ -360,7 +360,7 @@ bash scripts/tests/unit-coverage-guard.sh
 ```
 Expected: `unit-coverage: all <N> tests/unit/*.bats files are tracked (run by a task or allowlisted).` — kein Eintrag fehlt.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add tests/unit/website-domain-config-overlay.bats Taskfile.yml
@@ -376,7 +376,7 @@ git commit -m "test(infra): add offline website-ns domain-config parity guard"
 
 **Verifizierter Ausgangsbefund:** Der Dev-Zweig von `website:deploy` (Z.3528-3539) applied `k3d/website.yaml` imperativ in die website-ns, applied dabei aber **keine** `domain-config` (Z.2240 applied `k3d/configmap-domains.yaml` ausschließlich in die `workspace`-ns). `environments/dev.yaml` hat **keinen `PROD_DOMAIN`-Schlüssel** — ein `envsubst "\$PROD_DOMAIN"` der geteilten ConfigMap würde im Dev daher `mediaviewer.` (leer) oder den literalen Platzhalter ergeben, NICHT `mediaviewer.localhost`. Die Dev-SSOT für den Wert ist `k3d/configmap-domains.yaml` (`MEDIAVIEWER_HOST: "mediaviewer.localhost"`).
 
-- [ ] **Step 1: Prüfen, ob der Dev-`website:deploy` aktuell überhaupt bricht**
+- [x] **Step 1: Prüfen, ob der Dev-`website:deploy` aktuell überhaupt bricht**
 
 Entscheidungslogik (rein lokal, kein Cluster nötig falls kein dev-Cluster läuft):
 ```bash
@@ -390,7 +390,7 @@ kubectl --context k3d-mentolder-dev -n website get configmap domain-config 2>/de
   || echo "DEV: keine domain-config in website-ns → frischer Dev-Deploy würde brechen"
 ```
 
-- [ ] **Step 2: Entscheidung dokumentieren**
+- [x] **Step 2: Entscheidung dokumentieren**
 
 **Wenn (c) zeigt, dass keine `domain-config` in der dev-website-ns existiert** (Lücke akut) → fahre mit Step 3 fort.
 **Wenn die cm existiert** (z.B. aus einem früheren Apply geerbt) ODER **kein dev-Cluster verfügbar ist und Dev nicht im Scope der Bachelorarbeit-Deploys liegt** → **Prod-only bleiben**, Step 3 überspringen, Begründung als Commit-/PR-Kommentar festhalten: „Dev-Zweig nicht angefasst — Dev-website-ns trägt keine domain-config über das Overlay (imperativer Apply), Wert-SSOT ist `k3d/configmap-domains.yaml`; eine Dev-Lücke wird separat behandelt, da `environments/dev.yaml` kein `PROD_DOMAIN` führt und der geteilte Overlay-ConfigMap-Ausdruck im Dev nicht korrekt substituieren würde."
@@ -431,7 +431,7 @@ git commit -m "fix(infra): mirror domain-config into dev website namespace"
 
 Der Prod-Pfad nutzt `kubectl apply --server-side --force-conflicts` (Z.3566). Die live `domain-config` in `website`/`website-korczewski` wurde bei PR #1735 **ad-hoc imperativ** erstellt (`kubectl create`/`cp`), ist also evtl. nicht SSA-gemanagt (field-manager `kubectl-client-side-apply` oder gar keiner). Beim ersten Overlay-Deploy übernimmt SSA das Field-Ownership — analog dem `knowledge-secrets`-Adoptionsproblem aus CLAUDE.md (dort verweigerte der SealedSecrets-Controller die Adoption eines secretGenerator-Secrets). Bei einer ConfigMap via `--server-side --force-conflicts` ist die Adoption i.d.R. konfliktfrei, MUSS aber verifiziert werden.
 
-- [ ] **Step 1: Diff der gebauten ConfigMap gegen live (Server-Side dry-run, kein echter Apply)**
+- [x] **Step 1: Diff der gebauten ConfigMap gegen live (Server-Side dry-run, kein echter Apply)**
 
 Run (für beide Brands, hier mentolder; `--context fleet`):
 ```bash
@@ -447,7 +447,7 @@ Expected: der Diff zeigt höchstens eine `managedFields`-Übernahme bzw. identis
 
 > `kubectl diff --server-side` simuliert den Apply ohne Mutation. Falls `diff` einen Konflikt meldet, ist `--force-conflicts` (bereits im Deploy-Pfad gesetzt, Z.3566) die korrekte Auflösung — sie übernimmt das Field-Ownership. Das ist erwartet und sicher für eine ConfigMap (keine Secret-Daten, kein Datenverlust). Dokumentiere das Ergebnis im PR-Body.
 
-- [ ] **Step 2: Dasselbe für korczewski**
+- [x] **Step 2: Dasselbe für korczewski**
 
 Run:
 ```bash
@@ -469,7 +469,7 @@ Expected: `data.MEDIAVIEWER_HOST` = `mediaviewer.korczewski.de`, kein un-auflös
 
 **Files:** keine — nur Verifikation + ein Commit für regenerierte Artefakte.
 
-- [ ] **Step 1: Kustomize-Strukturvalidierung**
+- [x] **Step 1: Kustomize-Strukturvalidierung**
 
 Run:
 ```bash
@@ -477,7 +477,7 @@ task workspace:validate
 ```
 Expected: grün (alle Overlays inkl. `prod-fleet/website-*` bauen fehlerfrei).
 
-- [ ] **Step 2: Manifest-Testrunner für den betroffenen Bereich (falls passende TEST-ID existiert)**
+- [x] **Step 2: Manifest-Testrunner für den betroffenen Bereich (falls passende TEST-ID existiert)**
 
 Run:
 ```bash

--- a/docs/superpowers/plans/2026-06-16-website-domain-config-overlay.md
+++ b/docs/superpowers/plans/2026-06-16-website-domain-config-overlay.md
@@ -395,7 +395,7 @@ kubectl --context k3d-mentolder-dev -n website get configmap domain-config 2>/de
 **Wenn (c) zeigt, dass keine `domain-config` in der dev-website-ns existiert** (Lücke akut) → fahre mit Step 3 fort.
 **Wenn die cm existiert** (z.B. aus einem früheren Apply geerbt) ODER **kein dev-Cluster verfügbar ist und Dev nicht im Scope der Bachelorarbeit-Deploys liegt** → **Prod-only bleiben**, Step 3 überspringen, Begründung als Commit-/PR-Kommentar festhalten: „Dev-Zweig nicht angefasst — Dev-website-ns trägt keine domain-config über das Overlay (imperativer Apply), Wert-SSOT ist `k3d/configmap-domains.yaml`; eine Dev-Lücke wird separat behandelt, da `environments/dev.yaml` kein `PROD_DOMAIN` führt und der geteilte Overlay-ConfigMap-Ausdruck im Dev nicht korrekt substituieren würde."
 
-- [ ] **Step 3 (NUR bei akuter Dev-Lücke): Dev-Zweig die Dev-domain-config applizieren lassen**
+- [x] **Step 3 (NUR bei akuter Dev-Lücke): Dev-Zweig die Dev-domain-config applizieren lassen** _(übersprungen — kein dev-Cluster, prod-only per Plan-Entscheidung)_
 
 Da der geteilte Overlay-ConfigMap-Ausdruck (`mediaviewer.${PROD_DOMAIN}`) im Dev mangels `PROD_DOMAIN` NICHT korrekt auflöst, applied der Dev-Zweig stattdessen die **Dev-SSOT** `k3d/configmap-domains.yaml` in die website-ns (analog dem workspace-ns-Apply Z.2240, aber in `${WEBSITE_NAMESPACE}`). Füge im Dev-Zweig (nach dem `website-seller-config.yaml`-Apply, Z.3539) ein:
 ```bash
@@ -407,7 +407,7 @@ Da der geteilte Overlay-ConfigMap-Ausdruck (`mediaviewer.${PROD_DOMAIN}`) im Dev
 ```
 > `WEBSITE_NAMESPACE` ist im Block bereits exportiert (Z.3526). Dies ist **kein** envsubst des Overlay-ConfigMaps — bewusst, weil der Dev-Wert literal `mediaviewer.localhost` ist und nicht aus `${PROD_DOMAIN}` abgeleitet werden kann.
 
-- [ ] **Step 4 (NUR falls Step 3 ausgeführt): Dev-Apply verifizieren**
+- [x] **Step 4 (NUR falls Step 3 ausgeführt): Dev-Apply verifizieren** _(übersprungen — kein dev-Cluster, prod-only per Plan-Entscheidung)_
 
 Run (falls dev-Cluster läuft):
 ```bash
@@ -416,7 +416,7 @@ kubectl --context k3d-mentolder-dev -n website get configmap domain-config -o js
 ```
 Expected: `mediaviewer.localhost`; das website-Pod kommt ohne `CreateContainerConfigError` hoch.
 
-- [ ] **Step 5: Commit (nur falls Step 3 ausgeführt)**
+- [x] **Step 5: Commit (nur falls Step 3 ausgeführt)** _(übersprungen — kein dev-Cluster, prod-only per Plan-Entscheidung)_
 
 ```bash
 git add Taskfile.yml
@@ -485,7 +485,7 @@ Run:
 ```
 Expected: entweder eine passende ID ausführen, oder bestätigen, dass der neue bats-Guard die Abdeckung liefert.
 
-- [ ] **Step 3: Gezielte Tests für geänderte Domains**
+- [x] **Step 3: Gezielte Tests für geänderte Domains**
 
 Run:
 ```bash
@@ -493,7 +493,7 @@ task test:changed
 ```
 Expected: grün (vitest --changed + BATS-Selection + quality), inkl. des neuen `website-domain-config-overlay.bats`.
 
-- [ ] **Step 4: Test-Inventar regenerieren (wegen neuem Test PFLICHT)**
+- [x] **Step 4: Test-Inventar regenerieren (wegen neuem Test PFLICHT)**
 
 Run:
 ```bash
@@ -502,7 +502,7 @@ git add website/src/data/test-inventory.json
 ```
 Expected: `website/src/data/test-inventory.json` enthält jetzt `website-domain-config-overlay` (sonst failt CI's Inventory-Check).
 
-- [ ] **Step 5: Freshness-Artefakte regenerieren**
+- [x] **Step 5: Freshness-Artefakte regenerieren**
 
 Run:
 ```bash
@@ -510,7 +510,7 @@ task freshness:regenerate
 ```
 Expected: aktualisiert generierte Artefakte (test-inventory, repo-index, …). Generierte Konflikt-Magnete (`docs/generated/**`, `docs/code-quality/repo-index.json`, `k3d/docs-content-built/architecture/index.html`) ggf. mit `git add` aufnehmen.
 
-- [ ] **Step 6: CI-Äquivalent prüfen (S1-S4-Ratchet + Baseline-Assertion)**
+- [x] **Step 6: CI-Äquivalent prüfen (S1-S4-Ratchet + Baseline-Assertion)**
 
 Run:
 ```bash
@@ -522,7 +522,7 @@ Expected: grün — insbesondere:
 - S3 (keine hardcodierten Brand-Domains): die geteilte ConfigMap nutzt `${PROD_DOMAIN}`, der bats-Guard nutzt Regex-Pattern, keine Literale.
 - S4 (Orphans): `prod-fleet/website-common/domain-config.yaml` ist in beiden `kustomization.yaml` referenziert; der bats-Test in `Taskfile.yml` verdrahtet.
 
-- [ ] **Step 7: Test-Inventar + Freshness-Artefakte committen**
+- [x] **Step 7: Test-Inventar + Freshness-Artefakte committen**
 
 ```bash
 git add website/src/data/test-inventory.json docs/generated docs/code-quality/repo-index.json 2>/dev/null; \
@@ -531,7 +531,7 @@ git commit -m "chore: regenerate test-inventory + freshness artifacts for websit
 ```
 > Falls `git status` keine Änderungen zeigt (Artefakte bereits aktuell), diesen Commit überspringen.
 
-- [ ] **Step 8: Abschluss-Verifikation der Akzeptanzkriterien**
+- [x] **Step 8: Abschluss-Verifikation der Akzeptanzkriterien**
 
 Run (Sammel-Check):
 ```bash

--- a/docs/superpowers/specs/2026-06-16-website-domain-config-overlay-design.md
+++ b/docs/superpowers/specs/2026-06-16-website-domain-config-overlay-design.md
@@ -1,0 +1,167 @@
+---
+title: "website-ns domain-config deklarativ in den Website-Overlay aufnehmen"
+date: 2026-06-16
+slug: website-domain-config-overlay
+ticket_id: T000873
+plan_ref: null
+status: spec
+domains: [infra]
+---
+
+# Spec: website-ns domain-config deklarativ in den Website-Overlay
+
+## Problem
+
+Das `website` Deployment (`k3d/website.yaml:433`) bezieht `MEDIAVIEWER_HOST` per
+`configMapKeyRef` aus der ConfigMap **`domain-config`** (required, kein `optional: true`).
+Diese ConfigMap ist in den Website-Overlays **nicht deklariert** —
+`prod-fleet/website-mentolder/` und `prod-fleet/website-korczewski/` importieren nur
+`k3d/website.yaml` + `k3d/website-seller-config.yaml` (+ Ingress/Middleware). Die
+`domain-config` existiert deklarativ nur in der **workspace**-Overlay
+(`prod/kustomization.yaml` patcht `prod/configmap-domains.yaml` in die `workspace`-ns),
+**nicht** in `website` / `website-korczewski`.
+
+**Folge:** Sobald ein neuer required `configMapKeyRef`-Key zu `k3d/website.yaml`
+hinzukommt (so geschehen mit `MEDIAVIEWER_HOST`, PR #1735), bricht ein frischer
+`task website:deploy ENV=korczewski` mit **CreateContainerConfigError**, weil
+`website-korczewski` gar keine `domain-config` hat. Der Rollout hängt auf
+„1 old replicas pending termination". Bei PR #1735 musste das für mentolder UND
+korczewski **live** gefixt werden (cm aus `workspace[-korczewski]` kopieren) — das ist
+die latente Fragilität, die PR #1735 selbst geflaggt hat.
+
+## Ziel
+
+`domain-config` für die website-Namespace **deklarativ** im Website-Overlay verankern —
+analog zur workspace-Overlay — sodass ein neuer `domain-config`-Key keinen frischen
+`website:deploy` mehr bricht. Plus ein **Offline-CI-Guard**, der einen fehlenden Key
+in CI rot macht statt erst zur Deploy-Zeit als CreateContainerConfigError.
+
+## Nicht-Ziel
+
+- Keine Änderung am Laufzeitverhalten der Website (Werte bleiben identisch).
+- Keine Migration der workspace-ns `domain-config` (die ist bereits deklarativ und korrekt).
+- Kein Voll-Mirror aller ~30 Domain-Keys in die website-ns (siehe Design-Entscheidung).
+
+## Design-Entscheidung (autonom gewählt, mit Begründung)
+
+Drei Optionen abgewogen:
+
+| Option | Inhalt | Bewertung |
+|---|---|---|
+| **A: Minimaler Subset + Guard** ✅ | Eine `domain-config` ConfigMap mit genau den vom website-Deployment via `configMapKeyRef` konsumierten Keys (heute: `MEDIAVIEWER_HOST`), Werte als env-Platzhalter identisch zu `prod/configmap-domains.yaml`. Plus bats-Parity-Guard. | **Gewählt.** Kleinste Blast-Radius, SSOT-konsistente Werte, Footgun via CI eliminiert. |
+| B: Voll-Mirror | Komplette `prod/configmap-domains.yaml` (alle Keys, inkl. KC_USER-Credentials, TURN-IPs) in die website-ns spiegeln. | Verworfen: leakt irrelevante Keys (Credentials/IPs) in die website-ns, koppelt website-Overlay an prod/-Interna. |
+| C: Cross-NS-Referenz | website-Overlay re-namespaced den workspace base+patch. | Verworfen: hacky (`patches:` ist nicht als Cross-Overlay-Resource gedacht), zieht trotzdem alle Keys. |
+
+**Warum kein visueller Brainstorm-Tunnel:** reine Config/Overlay-Refaktorierung ohne
+UI-/Design-Ambiguität; Problem + Lösung sind durch das Auto-Memory
+`reference-website-korczewski-domain-config-gap` und die Codebase-Exploration
+vollständig bestimmt.
+
+## Lösung (Option A)
+
+### 1. Geteilte ConfigMap-Datei (DRY über beide Brands)
+
+Neue Datei `prod-fleet/website-common/domain-config.yaml` — **ohne** `metadata.namespace`
+(die Overlay-`namespace:`-Direktive setzt sie korrekt auf `website` bzw.
+`website-korczewski`):
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: domain-config
+data:
+  # Muss exakt dem prod/configmap-domains.yaml-Ausdruck entsprechen (SSOT, drift-guarded).
+  # Wert wird via website:deploy-envsubst gefüllt ($PROD_DOMAIN ist bereits in der Liste).
+  MEDIAVIEWER_HOST: "mediaviewer.${PROD_DOMAIN}"
+```
+
+> Wert-Ausdruck `mediaviewer.${PROD_DOMAIN}` ist **identisch** zu
+> `prod/configmap-domains.yaml:27` → konsistente Werte zwischen workspace-ns und
+> website-ns, kein Drift. `$PROD_DOMAIN` ist in der website:deploy-envsubst-Liste
+> (Taskfile.yml Prod-Pfad Z.3564 und Dev-Pfad Z.3538) bereits enthalten → **keine
+> Taskfile-envsubst-Änderung nötig**.
+
+### 2. Overlays referenzieren die geteilte Datei
+
+`prod-fleet/website-mentolder/kustomization.yaml` und
+`prod-fleet/website-korczewski/kustomization.yaml` bekommen je einen `resources`-Eintrag:
+
+```yaml
+resources:
+  - ../../k3d/website.yaml
+  - ../../k3d/website-seller-config.yaml
+  - ../website-common/domain-config.yaml   # ← NEU
+  # ... (bestehende Ingress/Middleware bleiben)
+```
+
+### 3. Dev-Pfad
+
+Der Dev-Zweig von `website:deploy` (Taskfile.yml ~Z.3528–3539) applied `k3d/website.yaml`
+imperativ in die `website`-ns ohne domain-config → gleiche Fehlerklasse in dev.
+**Verifizieren** ob dev aktuell überhaupt funktioniert (evtl. erbt die dev-website-ns die
+cm aus einem früheren Apply). Falls Lücke: im Dev-Zweig
+`envsubst "\$PROD_DOMAIN ..." < prod-fleet/website-common/domain-config.yaml | kubectl apply -f -`
+mit `WEBSITE_NAMESPACE` ergänzen. Dev-`PROD_DOMAIN` (aus `environments/dev.yaml`) muss zu
+`mediaviewer.localhost` auflösen (= `default_dev` in schema.yaml) — prüfen.
+
+### 4. Anti-Regression-Guard (bats, offline)
+
+Neue Datei `tests/unit/website-domain-config-overlay.bats`:
+
+- **Parity:** Jeder `configMapKeyRef`-Key mit `name: domain-config` in `k3d/website.yaml`
+  MUSS in `prod-fleet/website-common/domain-config.yaml` vorhanden sein. → ein neuer Key
+  ohne Mirror macht **CI rot** statt CreateContainerConfigError zur Deploy-Zeit.
+- **Presence:** Beide Overlays (`website-mentolder`, `website-korczewski`) referenzieren
+  `../website-common/domain-config.yaml`.
+- **Drift:** `MEDIAVIEWER_HOST`-Ausdruck in der geteilten ConfigMap == der in
+  `prod/configmap-domains.yaml` (gemeinsame Keys dürfen nicht auseinanderlaufen).
+- **Kustomize-Build:** `kustomize build prod-fleet/website-mentolder` bzw.
+  `…website-korczewski` emittiert eine `domain-config` ConfigMap in der korrekten
+  Namespace mit dem Key (falls offline-fähig; sonst als nicht-CI-Step markieren).
+
+Test in `task test:all` einhängen (coverage-guard-Konvention — wie bei
+`mediaviewer-host-durability.bats` in PR #1735; den Wiring-Punkt im Taskfile finden).
+
+### Komplementarität zur bestehenden `mediaviewer-host-durability.bats`
+
+Die existierende `tests/unit/mediaviewer-host-durability.bats` schützt nur den
+**workspace-ns**-Pfad (`prod/configmap-domains.yaml` + dessen envsubst). Der neue Guard
+deckt die **website-ns** ab — keine Überschneidung, sondern die fehlende Hälfte.
+
+## Betroffene Dateien
+
+| Datei | Aktion |
+|---|---|
+| `prod-fleet/website-common/domain-config.yaml` | NEU (geteilte ConfigMap, ~8 Z.) |
+| `prod-fleet/website-mentolder/kustomization.yaml` | EDIT (+1 resource) |
+| `prod-fleet/website-korczewski/kustomization.yaml` | EDIT (+1 resource) |
+| `tests/unit/website-domain-config-overlay.bats` | NEU (Guard) |
+| `Taskfile.yml` | EDIT nur falls Dev-Pfad-cm-Apply nötig (verifizieren) + Test-Wiring in test:all |
+| `environments/schema.yaml` | KEINE Änderung (MEDIAVIEWER_HOST bereits registriert, Z.182) |
+
+## Akzeptanzkriterien
+
+1. `kustomize build prod-fleet/website-mentolder` enthält eine `domain-config` ConfigMap
+   (namespace `website`) mit `MEDIAVIEWER_HOST`.
+2. `kustomize build prod-fleet/website-korczewski` enthält eine `domain-config` ConfigMap
+   (namespace `website-korczewski`) mit `MEDIAVIEWER_HOST`.
+3. Der neue bats-Guard ist grün und in `task test:all` eingehängt; ein hinzugefügter
+   Dummy-`configMapKeyRef`-Key ohne Mirror würde ihn rot machen.
+4. `task workspace:validate` (kustomize-Strukturvalidierung) bleibt grün.
+5. CI-Äquivalent grün: `task test:changed` + `task freshness:regenerate` +
+   `task freshness:check` + (wegen Test-Änderung) `task test:inventory`.
+6. Werte-Konsistenz: website-ns `MEDIAVIEWER_HOST` löst zu `mediaviewer.<PROD_DOMAIN>` auf
+   (mentolder/korczewski), nicht zum dev-Default.
+
+## Risiken / Gotchas
+
+- **`$patch: delete` / SSA:** Prod-Apply nutzt `kubectl apply --server-side
+  --force-conflicts`. Eine via SSA gemanagte `domain-config` übernimmt das Feld-Ownership
+  — sicherstellen, dass das die live (ad-hoc erstellte) cm sauber adoptiert, nicht
+  konfligiert (analog `knowledge-secrets`-Adoptionsproblem in CLAUDE.md).
+- **S1-Ratchet:** `Taskfile.yml` ist groß und evtl. baselined — pro Datei `wc -l` +
+  `baseline.json` prüfen; Edits zeilenneutral halten (nur bestehende Zeilen ändern, keine
+  Netto-Zeilen), sonst echten Verkleinerungs-Schritt einplanen.
+- **Keine Brand-Domain-Literale** in Code/Snippets (S3) — Werte über `${PROD_DOMAIN}`.
+- **Dev-Regression:** Dev-Pfad-Änderung nur falls verifizierte Lücke; sonst nicht anfassen.

--- a/k3d/docs-content-built/architecture/index.html
+++ b/k3d/docs-content-built/architecture/index.html
@@ -178,7 +178,7 @@
 <body>
   <div class="header">
     <h1>⬡ Architektur — Living Docs</h1>
-    <span class="meta">Generiert: 2026-06-16T01:49:03.824Z</span>
+    <span class="meta">Generiert: 2026-06-16T02:57:42.031Z</span>
   </div>
 
   <div class="stats">

--- a/k3d/docs-content-built/architecture/index.html
+++ b/k3d/docs-content-built/architecture/index.html
@@ -178,7 +178,7 @@
 <body>
   <div class="header">
     <h1>⬡ Architektur — Living Docs</h1>
-    <span class="meta">Generiert: 2026-06-16T02:57:42.031Z</span>
+    <span class="meta">Generiert: 2026-06-16T02:59:48.867Z</span>
   </div>
 
   <div class="stats">

--- a/prod-fleet/website-common/domain-config.yaml
+++ b/prod-fleet/website-common/domain-config.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: domain-config
+  # KEIN namespace: hier — die Overlay-namespace:-Direktive (website / website-korczewski)
+  # re-namespaced diese ConfigMap brand-korrekt. NICHT hinzufügen.
+data:
+  # Muss exakt dem prod/configmap-domains.yaml-Ausdruck entsprechen (SSOT, drift-guarded
+  # durch tests/unit/website-domain-config-overlay.bats). Wert wird via website:deploy-
+  # envsubst gefüllt ($PROD_DOMAIN ist bereits in der Liste, Taskfile.yml Z.3564/3538).
+  # Jeder neue required configMapKeyRef name: domain-config in k3d/website.yaml MUSS hier
+  # ergänzt werden, sonst macht der bats-Guard CI rot.
+  MEDIAVIEWER_HOST: "mediaviewer.${PROD_DOMAIN}"

--- a/prod-fleet/website-korczewski/kustomization.yaml
+++ b/prod-fleet/website-korczewski/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - ../../k3d/website.yaml
   - ../../k3d/website-seller-config.yaml
   # Security-headers middleware in this namespace (allowCrossNamespace disabled on korczewski)
+  - ../website-common/domain-config.yaml
   - website-security-headers.yaml
 patches:
   # Fix HTTPS: add websecure entryPoint + wildcard TLS cert (T000144)

--- a/prod-fleet/website-mentolder/kustomization.yaml
+++ b/prod-fleet/website-mentolder/kustomization.yaml
@@ -5,4 +5,5 @@ resources:
   - ../../k3d/website.yaml
   - ../../k3d/website-seller-config.yaml
   # mentolder HTTPS Ingress (tracked here to survive cluster rebuilds — T000146)
+  - ../website-common/domain-config.yaml
   - website-ingress-web.yaml

--- a/tests/unit/website-domain-config-overlay.bats
+++ b/tests/unit/website-domain-config-overlay.bats
@@ -1,0 +1,80 @@
+#!/usr/bin/env bats
+# Regression: die website-Namespace muss die domain-config ConfigMap deklarativ
+# im Overlay tragen — sonst bricht ein frischer `task website:deploy ENV=<brand>`
+# mit CreateContainerConfigError, weil k3d/website.yaml MEDIAVIEWER_HOST per
+# required configMapKeyRef aus `domain-config` bezieht, die in der website-ns
+# (ohne dieses Overlay) gar nicht existiert. So live-gefixt bei PR #1735.
+#
+# Komplementär zu tests/unit/mediaviewer-host-durability.bats:
+#   - mediaviewer-host-durability.bats schützt den WORKSPACE-ns-Pfad
+#     (prod/configmap-domains.yaml + dessen envsubst).
+#   - DIESER Guard schützt den WEBSITE-ns-Pfad (geteilte Overlay-ConfigMap).
+# Keine Überschneidung. Rein offline (grep), keine Cluster-Calls.
+
+setup() {
+  REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+  WEBSITE="$REPO_ROOT/k3d/website.yaml"
+  SHARED_CM="$REPO_ROOT/prod-fleet/website-common/domain-config.yaml"
+  PROD_DOMAINS="$REPO_ROOT/prod/configmap-domains.yaml"
+  KUST_MENTOLDER="$REPO_ROOT/prod-fleet/website-mentolder/kustomization.yaml"
+  KUST_KORCZEWSKI="$REPO_ROOT/prod-fleet/website-korczewski/kustomization.yaml"
+}
+
+@test "shared website domain-config ConfigMap file exists" {
+  [ -f "$SHARED_CM" ]
+}
+
+@test "shared domain-config is named 'domain-config' (matches configMapKeyRef name)" {
+  run grep -qE '^[[:space:]]*name:[[:space:]]*domain-config[[:space:]]*$' "$SHARED_CM"
+  [ "$status" -eq 0 ]
+}
+
+@test "shared domain-config carries NO metadata.namespace (overlay re-namespaces it)" {
+  # Ein hartes namespace: hier würde das brand-korrekte Re-Namespacing brechen.
+  run grep -qE '^[[:space:]]*namespace:' "$SHARED_CM"
+  [ "$status" -ne 0 ]
+}
+
+@test "parity: every domain-config configMapKeyRef key in website.yaml is in the shared ConfigMap" {
+  # Extrahiere alle keys, die k3d/website.yaml via configMapKeyRef aus domain-config zieht.
+  # Heuristik (offline, ohne yaml-Parser): finde Blöcke 'name: domain-config' gefolgt von
+  # 'key: <KEY>' im selben valueFrom.configMapKeyRef. Wir lesen alle 'key:' Zeilen, die
+  # in einem configMapKeyRef-Block mit name: domain-config stehen.
+  keys="$(awk '
+    /configMapKeyRef:/ { in_ref=1; name=""; next }
+    in_ref && /name:[[:space:]]*domain-config/ { name="domain-config"; next }
+    in_ref && /key:/ {
+      if (name=="domain-config") { gsub(/^[[:space:]]*key:[[:space:]]*/,""); gsub(/[[:space:]]*$/,""); print }
+      in_ref=0; name=""; next
+    }
+    in_ref && /name:/ { name=""; }   # ein anderer ConfigMap-name → kein domain-config-key
+  ' "$WEBSITE")"
+  [ -n "$keys" ]   # mindestens MEDIAVIEWER_HOST muss gefunden werden
+  while IFS= read -r k; do
+    [ -z "$k" ] && continue
+    run grep -qE "^[[:space:]]+${k}:" "$SHARED_CM"
+    [ "$status" -eq 0 ] || { echo "FEHLT in shared domain-config: $k"; false; }
+  done <<< "$keys"
+}
+
+@test "presence: mentolder overlay references the shared domain-config" {
+  run grep -qF '../website-common/domain-config.yaml' "$KUST_MENTOLDER"
+  [ "$status" -eq 0 ]
+}
+
+@test "presence: korczewski overlay references the shared domain-config" {
+  run grep -qF '../website-common/domain-config.yaml' "$KUST_KORCZEWSKI"
+  [ "$status" -eq 0 ]
+}
+
+@test "drift: shared MEDIAVIEWER_HOST expression equals prod/configmap-domains.yaml" {
+  shared="$(grep -E '^[[:space:]]+MEDIAVIEWER_HOST:' "$SHARED_CM" | tr -s ' ' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+  prod="$(grep -E '^[[:space:]]+MEDIAVIEWER_HOST:' "$PROD_DOMAINS" | tr -s ' ' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+  [ -n "$shared" ]
+  [ "$shared" = "$prod" ]
+}
+
+@test "MEDIAVIEWER_HOST derives from \${PROD_DOMAIN} (no hardcoded brand domain, S3)" {
+  run grep -qE '^[[:space:]]+MEDIAVIEWER_HOST:[[:space:]]*"mediaviewer\.\$\{PROD_DOMAIN\}"' "$SHARED_CM"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
Closes T000873

## Summary
Adds a shared  ConfigMap to both website overlays (, ), fixing the latent  that would occur on a fresh `task website:deploy ENV=<brand>` because `k3d/website.yaml` references `domain-config` via required `configMapKeyRef`, but the ConfigMap was never declared in the overlay (it was applied ad-hoc at PR #1735).

## Changes
- **NEW** `prod-fleet/website-common/domain-config.yaml`: shared ConfigMap (no `namespace:` — overlay re-namespaces it brand-correctly)
- **EDIT** `prod-fleet/website-mentolder/kustomization.yaml`: +1 resource entry
- **EDIT** `prod-fleet/website-korczewski/kustomization.yaml`: +1 resource entry
- **NEW** `tests/unit/website-domain-config-overlay.bats`: offline Parity/Presence/Drift guard (8 tests, all green)
- **EDIT** `Taskfile.yml`: +subtask definition + aggregator entry (analogous to `mediaviewer-host-durability`)

## Verification
- `kustomize build` for both overlays: ConfigMap present with correct namespace ✓
- bats guard: 8/8 tests PASS ✓
- `task workspace:validate`: green ✓
- `task test:changed`: 50/50 pass ✓
- `task freshness:check`: green (no S1/S3/S4 violations, baseline stable 93→93) ✓
- SSA dry-run (both brands, fleet context): no conflicts — `domain-config` already live from PR #1735, field ownership transfer clean ✓

## Dev-path decision
Dev-Zweig nicht angefasst — kein dev-Cluster läuft und `environments/dev.yaml` führt kein `PROD_DOMAIN`, sodass der geteilte Overlay-Ausdruck im Dev nicht korrekt substituieren würde. Dev-SSOT bleibt `k3d/configmap-domains.yaml`.