### PR TITLE
feat(website): flat 'Alle Tickets' cockpit view so the PM sees every ticket [T000877]

### DIFF
--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -493,7 +493,7 @@
       "id": "website",
       "name": "Astro + Svelte website",
       "owner_agent": "bachelorprojekt-website",
-      "file_count": 1386,
+      "file_count": 1387,
       "files": [
         "website/.build-trigger",
         "website/.dockerignore",
@@ -1298,6 +1298,7 @@
         "website/src/lib/tickets/admin.ts",
         "website/src/lib/tickets/cockpit-db.test.ts",
         "website/src/lib/tickets/cockpit-db.ts",
+        "website/src/lib/tickets/cockpit-ids.ts",
         "website/src/lib/tickets/cockpit-labels.test.ts",
         "website/src/lib/tickets/cockpit-labels.ts",
         "website/src/lib/tickets/cockpit-schema.test.ts",

--- a/docs/generated/api-map.json
+++ b/docs/generated/api-map.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-16T03:49:12.486Z",
+  "generatedAt": "2026-06-16T04:45:40.778Z",
   "endpoints": [
     {
       "path": "/api/admin/angebote/save",

--- a/docs/generated/api-surface.md
+++ b/docs/generated/api-surface.md
@@ -1,6 +1,6 @@
 # API Surface Map
 
-> Generated at 2026-06-16T03:49:12.486Z
+> Generated at 2026-06-16T04:45:40.778Z
 
 | Path | Methods | Auth | File |
 |------|---------|------|------|

--- a/docs/generated/blast-radius.md
+++ b/docs/generated/blast-radius.md
@@ -1,5 +1,5 @@
 # Blast-Radius-Report
-> Generated: 2026-06-16T03:49:12.562Z
+> Generated: 2026-06-16T04:45:40.869Z
 > Nodes: 78 | Edges: 1613 | Isolated: 2
 
 ## Ranking (transitive Abhängige)

--- a/docs/generated/graph.json
+++ b/docs/generated/graph.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-16T03:49:12.419Z",
+  "generatedAt": "2026-06-16T04:45:40.702Z",
   "nodes": [
     {
       "id": "admin-actions-cleanup",

--- a/k3d/docs-content-built/architecture/index.html
+++ b/k3d/docs-content-built/architecture/index.html
@@ -178,7 +178,7 @@
 <body>
   <div class="header">
     <h1>⬡ Architektur — Living Docs</h1>
-    <span class="meta">Generiert: 2026-06-16T03:49:12.522Z</span>
+    <span class="meta">Generiert: 2026-06-16T04:45:40.823Z</span>
   </div>
 
   <div class="stats">

--- a/website/src/components/admin/Cockpit.svelte
+++ b/website/src/components/admin/Cockpit.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { onMount } from 'svelte';
   import type { PortfolioPayload, FeatureTickets, TicketRow, FeatureNode } from '../../lib/tickets/cockpit-types';
+  import { ALL_TICKETS_ID } from '../../lib/tickets/cockpit-ids';
   import { cockpitStore, selectFeature, setActiveTicket, initStoreFromUrl, setLoading, setError }
     from '../../lib/stores/cockpitStore';
   import CockpitSidebar from './CockpitSidebar.svelte';
@@ -21,20 +22,30 @@
   $: allFeatures = portfolio?.products?.flatMap((p) => p.features) ?? [];
   $: currentFeatureNode = allFeatures.find((f) => f.extId === $cockpitStore.selectedFeature) ?? null;
 
-  // Pick a sensible default feature so the cockpit lands on a populated
-  // ticket list instead of an empty table. Prefer the first non-discarded
-  // feature that actually has tickets; fall back to the first feature.
-  function pickDefaultFeature(): FeatureNode | null {
-    const feats = allFeatures.filter((f) => !f.discarded);
-    return feats.find((f) => (f.rollup?.total ?? 0) > 0) ?? feats[0] ?? allFeatures[0] ?? null;
+  // Pick a sensible default feature so the cockpit lands on a populated ticket
+  // list instead of an empty table. Prefer the flat "Alle Tickets" bucket (the
+  // PM's see-everything view); otherwise the first non-discarded feature that
+  // actually has tickets, then any feature.
+  function pickDefaultFeature(feats: FeatureNode[]): FeatureNode | null {
+    const all = feats.find((f) => f.extId === ALL_TICKETS_ID);
+    if (all) return all;
+    const live = feats.filter((f) => !f.discarded);
+    return live.find((f) => (f.rollup?.total ?? 0) > 0) ?? live[0] ?? feats[0] ?? null;
   }
 
   onMount(async () => {
     if (typeof window !== 'undefined') initStoreFromUrl(new URL(window.location.href).searchParams);
     if (!portfolio) await loadPortfolio();
-    // No feature from URL/localStorage → auto-select one so tickets show on open.
-    if (!$cockpitStore.selectedFeature) {
-      const def = pickDefaultFeature();
+    // Auto-select a feature when there is none, OR when the persisted/URL
+    // selection no longer exists in the portfolio (e.g. a stale localStorage
+    // feature, or the old "Ohne Feature" bucket now folded into "Alle Tickets").
+    // Without this the table renders empty and never recovers — the user's
+    // "I still can't see any tickets" report.
+    const feats = portfolio?.products?.flatMap((p) => p.features) ?? [];
+    const sel = $cockpitStore.selectedFeature;
+    const known = !!sel && feats.some((f) => f.extId === sel);
+    if (!known) {
+      const def = pickDefaultFeature(feats);
       if (def) selectFeature(def.extId);
     }
     if ($cockpitStore.selectedFeature) await loadFeature($cockpitStore.selectedFeature);

--- a/website/src/components/admin/CockpitSidebar.svelte
+++ b/website/src/components/admin/CockpitSidebar.svelte
@@ -48,8 +48,9 @@
       features: p.features.filter((f: FeatureNode) => {
         const matchText = !q || f.title.toLowerCase().includes(q) || f.extId.toLowerCase().includes(q);
         const openWork = (f.rollup.open ?? 0) + (f.rollup.inProgress ?? 0) + (f.rollup.blocked ?? 0);
-        // Always keep the selected feature visible even if it has no open work.
-        const matchActive = !activeOnly || openWork > 0 || f.extId === selectedFeature;
+        // Always keep synthetic aggregate buckets (Alle Tickets / Ohne Feature)
+        // and the selected feature visible even if there is no open work.
+        const matchActive = !activeOnly || f.synthetic || openWork > 0 || f.extId === selectedFeature;
         return matchText && matchActive;
       }),
     }))
@@ -151,7 +152,7 @@
                   <span class="feature-name">{f.title}</span>
                   <span class="feature-count">{f.rollup.total} Tickets</span>
                 </button>
-                {#if onFeatureAction}
+                {#if onFeatureAction && !f.synthetic}
                   <div class="action-overlay" role="group" aria-label="Feature-Aktionen">
                     <button
                       class="action-btn next-btn"
@@ -189,7 +190,7 @@
 
   <div class="sidebar-footer">
     <SuggestionBar
-      features={allFeatures}
+      features={allFeatures.filter((f) => !f.synthetic)}
       {isRolling}
       onroll={handleRoll}
       onapply={handleApply}

--- a/website/src/lib/tickets/cockpit-db.test.ts
+++ b/website/src/lib/tickets/cockpit-db.test.ts
@@ -143,9 +143,10 @@ beforeEach(async () => {
 describe('getPortfolio', () => {
   it('returns products with nested features and rollups', async () => {
     const out = await getPortfolio('mentolder');
-    expect(out.products).toHaveLength(1);
-    const p = out.products[0];
-    expect(p.extId).toBe('p1');
+    // Besides the real product p1, getPortfolio now prepends a synthetic
+    // "Alle Tickets" bucket (see the dedicated describe block below).
+    const p = out.products.find((x) => x.extId === 'p1')!;
+    expect(p).toBeTruthy();
     expect(p.features).toHaveLength(2);
     // Product rollup across all 5 leaves: 1 done / 5 total = 20%, blocked>0 => red
     expect(p.rollup.total).toBe(5);
@@ -307,5 +308,77 @@ describe('orphan tickets bucket (Ohne Feature)', () => {
     const out = await getPortfolio('korczewski');
     const noFeat = out.products.flatMap(p => p.features).find(f => f.extId === '__no_feature__');
     expect(noFeat).toBeUndefined();
+  });
+});
+
+describe('Alle Tickets bucket (flat all-tickets view)', () => {
+  // T000877 follow-up: on mentolder every work ticket is parentless and every
+  // feature is empty, so the feature-centric cockpit surfaces nothing but the
+  // "Ohne Feature" catch-all. The PM asked for a flat "Alle Tickets" view that
+  // lists EVERY task/bug leaf across all features, regardless of parent linkage.
+  async function insertOrphans() {
+    await pool.query(
+      `INSERT INTO tickets.tickets
+         (id, external_id, brand, type, title, value_prop, priority, status, parent_id, planning_rank)
+       VALUES ('o1','o1','mentolder','task','Orphan A',null,'mittel','backlog',null,10)`);
+    await pool.query(
+      `INSERT INTO tickets.tickets
+         (id, external_id, brand, type, title, value_prop, priority, status, parent_id, planning_rank)
+       VALUES ('o2','o2','mentolder','bug','Orphan B',null,'mittel','done',null,11)`);
+    await pool.query(
+      `INSERT INTO tickets.tickets
+         (id, external_id, brand, type, title, value_prop, priority, status, parent_id, planning_rank)
+       VALUES ('o3','o3','mentolder','task','Orphan archived',null,'mittel','archived',null,12)`);
+  }
+
+  it('surfaces a synthetic __all_tickets__ bucket covering ALL non-archived leaves', async () => {
+    // base fixture: t1..t5 all parented under f1/f2 (no orphans)
+    const out = await getPortfolio('mentolder');
+    const all = out.products.flatMap(p => p.features).find(f => f.extId === '__all_tickets__');
+    expect(all).toBeTruthy();
+    expect(all!.synthetic).toBe(true);
+    expect(all!.rollup.total).toBe(5);   // t1..t5
+    expect(all!.rollup.done).toBe(1);     // t1
+    expect(all!.rollup.blocked).toBe(1);  // t2
+  });
+
+  it('appears as the FIRST product so the cockpit can default to it', async () => {
+    const out = await getPortfolio('mentolder');
+    expect(out.products[0].extId).toBe('__all_tickets__');
+  });
+
+  it('loads every task/bug leaf (parented + orphan) via getFeatureTickets(__all_tickets__)', async () => {
+    await insertOrphans();
+    const out = await getFeatureTickets('mentolder', '__all_tickets__');
+    expect(out.feature.extId).toBe('__all_tickets__');
+    expect(out.feature.synthetic).toBe(true);
+    // t1..t5 (parented) + o1,o2 (orphan); archived o3 excluded
+    expect(out.tickets.map(t => t.extId).sort()).toEqual(['o1', 'o2', 't1', 't2', 't3', 't4', 't5']);
+    expect(out.tickets.every(t => ['task', 'bug'].includes(t.type))).toBe(true);
+  });
+
+  it('omits the redundant Ohne Feature bucket when EVERY leaf is orphan', async () => {
+    await pool.query('DELETE FROM tickets.tickets'); // drop the parented base fixture
+    await insertOrphans();                            // only orphan leaves remain
+    const out = await getPortfolio('mentolder');
+    const all = out.products.flatMap(p => p.features).find(f => f.extId === '__all_tickets__');
+    const noFeat = out.products.flatMap(p => p.features).find(f => f.extId === '__no_feature__');
+    expect(all!.rollup.total).toBe(2);   // o1 + o2 (archived o3 excluded)
+    expect(noFeat).toBeUndefined();       // identical to Alle Tickets → not shown twice
+  });
+
+  it('still shows Ohne Feature when orphans are a genuine subset of all tickets', async () => {
+    await insertOrphans(); // base parented fixture + 2 orphans → orphan(2) < all(7)
+    const out = await getPortfolio('mentolder');
+    const all = out.products.flatMap(p => p.features).find(f => f.extId === '__all_tickets__');
+    const noFeat = out.products.flatMap(p => p.features).find(f => f.extId === '__no_feature__');
+    expect(all!.rollup.total).toBe(7);
+    expect(noFeat).toBeTruthy();
+    expect(noFeat!.rollup.total).toBe(2);
+  });
+
+  it('omits Alle Tickets entirely for a brand with no tickets', async () => {
+    const out = await getPortfolio('korczewski');
+    expect(out.products).toHaveLength(0);
   });
 });

--- a/website/src/lib/tickets/cockpit-db.ts
+++ b/website/src/lib/tickets/cockpit-db.ts
@@ -4,6 +4,7 @@ import type {
   FeatureTickets, TicketRow, RollupMetrics, HealthStatus,
   BatchMutation, BatchResult,
 } from './cockpit-types';
+import { ALL_TICKETS_ID, NO_FEATURE_ID, NO_PRODUCT_ID } from './cockpit-ids';
 
 function toRollup(r: Record<string, unknown> | undefined): RollupMetrics {
   return {
@@ -16,11 +17,14 @@ function toRollup(r: Record<string, unknown> | undefined): RollupMetrics {
   };
 }
 
-// Synthetic feature that collects parentless task/bug leaves. The cockpit only
-// renders tickets nested under a feature, so without this bucket every leaf with
-// parent_id IS NULL is invisible (root cause of T000848 on live). Mirrors the
-// existing "__no_product__" pattern for parentless features.
-export const NO_FEATURE_ID = '__no_feature__';
+// Synthetic aggregate buckets surface task/bug *leaves* that the feature-centric
+// cockpit would otherwise hide:
+//   - ALL_TICKETS_ID ("Alle Tickets"): every leaf of the brand, regardless of
+//     feature linkage — the flat "see all my tickets" view (T000877 follow-up).
+//   - NO_FEATURE_ID  ("Ohne Feature"): parentless leaves only (T000848); a
+//     subset of Alle Tickets, surfaced only when it is a genuine subset.
+// Re-exported so existing importers keep resolving these ids from cockpit-db.
+export { ALL_TICKETS_ID, NO_FEATURE_ID };
 
 function rollupHealth(r: RollupMetrics): HealthStatus {
   if (r.blocked > 0) return 'red';
@@ -28,10 +32,11 @@ function rollupHealth(r: RollupMetrics): HealthStatus {
   return 'amber';
 }
 
-// Rollup over brand-scoped task/bug leaves that have no parent. Bucket logic
-// mirrors tickets.v_cockpit_rollup (archived excluded; qa_review counts as
-// in-progress) so the synthetic bucket reads consistently with real features.
-async function fetchOrphanRollup(brand: string): Promise<RollupMetrics> {
+// Rollup over brand-scoped task/bug leaves. Bucket logic mirrors
+// tickets.v_cockpit_rollup (archived excluded; qa_review counts as in-progress)
+// so the synthetic bucket reads consistently with real features. When
+// `orphanOnly` is set the rollup is restricted to parentless leaves.
+async function fetchLeafRollup(brand: string, orphanOnly: boolean): Promise<RollupMetrics> {
   const { rows } = await pool.query(
     `SELECT
        SUM(CASE WHEN status <> 'archived' THEN 1 ELSE 0 END) AS total_leaves,
@@ -40,7 +45,7 @@ async function fetchOrphanRollup(brand: string): Promise<RollupMetrics> {
        SUM(CASE WHEN status IN ('in_progress','in_review','qa_review') THEN 1 ELSE 0 END) AS in_progress_leaves,
        SUM(CASE WHEN status IN ('triage','backlog','planning','plan_staged') THEN 1 ELSE 0 END) AS open_leaves
      FROM tickets.tickets
-     WHERE brand = $1 AND type IN ('task', 'bug') AND parent_id IS NULL`,
+     WHERE brand = $1 AND type IN ('task', 'bug')${orphanOnly ? ' AND parent_id IS NULL' : ''}`,
     [brand],
   );
   const r = rows[0] ?? {};
@@ -55,22 +60,26 @@ async function fetchOrphanRollup(brand: string): Promise<RollupMetrics> {
   };
 }
 
-function syntheticNoFeature(rollup: RollupMetrics): FeatureNode {
+function syntheticBucket(id: string, title: string, rollup: RollupMetrics): FeatureNode {
   return {
-    id: NO_FEATURE_ID, extId: NO_FEATURE_ID, title: 'Ohne Feature',
+    id, extId: id, title,
     priority: 'mittel', health: rollupHealth(rollup), rollup,
-    nextStep: false, discarded: false, majorFeature: false,
+    nextStep: false, discarded: false, majorFeature: false, synthetic: true,
   };
 }
 
-async function getOrphanTickets(brand: string): Promise<FeatureTickets> {
-  const feature = syntheticNoFeature(await fetchOrphanRollup(brand));
+// Load the leaves for a synthetic bucket. `orphanOnly` selects the "Ohne Feature"
+// semantics; otherwise it is the full "Alle Tickets" list across every feature.
+async function getLeafTickets(
+  brand: string, id: string, title: string, orphanOnly: boolean,
+): Promise<FeatureTickets> {
+  const feature = syntheticBucket(id, title, await fetchLeafRollup(brand, orphanOnly));
   const tr = await pool.query(
     `SELECT t.id, t.external_id, t.type, t.title, t.status, t.priority,
             t.parent_id, t.planning_rank
        FROM tickets.tickets t
       WHERE t.brand = $1 AND t.type IN ('task', 'bug')
-        AND t.parent_id IS NULL AND t.status <> 'archived'
+        AND t.status <> 'archived'${orphanOnly ? ' AND t.parent_id IS NULL' : ''}
       ORDER BY COALESCE(t.planning_rank, 2147483647), t.external_id`,
     [brand],
   );
@@ -130,19 +139,32 @@ export async function getPortfolio(brand: string): Promise<PortfolioPayload> {
 
   if (looseFeatures.length > 0) {
     products.push({
-      id: '__no_product__', extId: '__no_product__', title: 'Ohne Produkt',
+      id: NO_PRODUCT_ID, extId: NO_PRODUCT_ID, title: 'Ohne Produkt',
       rollup: aggregate(looseFeatures), features: looseFeatures,
     });
   }
 
   // Surface parentless task/bug leaves under a synthetic "Ohne Feature" bucket
-  // so they are visible in the cockpit (T000848). Omitted when there are none.
-  const orphanRollup = await fetchOrphanRollup(brand);
-  if (orphanRollup.total > 0) {
-    const orphanFeature = syntheticNoFeature(orphanRollup);
+  // (T000848). Only shown when it is a genuine SUBSET of "Alle Tickets" — when
+  // every leaf is parentless the two buckets are identical, so it is dropped to
+  // avoid a confusing duplicate.
+  const orphanRollup = await fetchLeafRollup(brand, true);
+  const allRollup = await fetchLeafRollup(brand, false);
+  if (orphanRollup.total > 0 && orphanRollup.total < allRollup.total) {
     products.push({
       id: NO_FEATURE_ID, extId: NO_FEATURE_ID, title: 'Ohne Feature',
-      rollup: orphanRollup, features: [orphanFeature],
+      rollup: orphanRollup, features: [syntheticBucket(NO_FEATURE_ID, 'Ohne Feature', orphanRollup)],
+    });
+  }
+
+  // Prepend the flat "Alle Tickets" bucket: every task/bug leaf of the brand,
+  // regardless of feature linkage. This is the PM's primary entry point and the
+  // cockpit's default landing — when no ticket is nested under a feature
+  // (mentolder), it is the only place work is visible at all. (T000877)
+  if (allRollup.total > 0) {
+    products.unshift({
+      id: ALL_TICKETS_ID, extId: ALL_TICKETS_ID, title: 'Alle Tickets',
+      rollup: allRollup, features: [syntheticBucket(ALL_TICKETS_ID, 'Alle Tickets', allRollup)],
     });
   }
   return { products };
@@ -161,7 +183,8 @@ function aggregate(features: FeatureNode[]): RollupMetrics {
 export class NotFoundError extends Error {}
 
 export async function getFeatureTickets(brand: string, extId: string): Promise<FeatureTickets> {
-  if (extId === NO_FEATURE_ID) return getOrphanTickets(brand);
+  if (extId === ALL_TICKETS_ID) return getLeafTickets(brand, ALL_TICKETS_ID, 'Alle Tickets', false);
+  if (extId === NO_FEATURE_ID) return getLeafTickets(brand, NO_FEATURE_ID, 'Ohne Feature', true);
   const fr = await pool.query(
     `SELECT t.id, t.external_id, t.type, t.title, t.value_prop, t.priority,
             t.next_step, t.discarded, t.major_feature, t.suggestion_comment,

--- a/website/src/lib/tickets/cockpit-ids.ts
+++ b/website/src/lib/tickets/cockpit-ids.ts
@@ -1,0 +1,13 @@
+// Synthetic cockpit bucket ids — shared by the server (cockpit-db) and the
+// client Svelte components. Kept in their own module so the components can
+// reference them WITHOUT importing cockpit-db (which pulls in `pg` and would
+// break the browser bundle).
+//
+// - ALL_TICKETS: flat view over every task/bug leaf of a brand, regardless of
+//   feature linkage. The PM's "see all my tickets" entry point.
+// - NO_FEATURE:  parentless task/bug leaves only (T000848). A subset of
+//   ALL_TICKETS — only surfaced when it is a genuine subset.
+// - NO_PRODUCT:  parentless features (containers without a project).
+export const ALL_TICKETS_ID = '__all_tickets__';
+export const NO_FEATURE_ID = '__no_feature__';
+export const NO_PRODUCT_ID = '__no_product__';

--- a/website/src/lib/tickets/cockpit-types.ts
+++ b/website/src/lib/tickets/cockpit-types.ts
@@ -24,6 +24,10 @@ export interface FeatureNode {
   discarded: boolean;
   majorFeature: boolean;
   suggestionComment?: string;
+  /** True for synthetic aggregate buckets (Alle Tickets / Ohne Feature) that do
+   *  not map to a real ticket row — the UI hides feature-actions for these and
+   *  keeps them visible regardless of the "only open work" filter. */
+  synthetic?: boolean;
 }
 
 export interface ProductNode {


### PR DESCRIPTION
## Problem

On **mentolder** the Projekt-Cockpit only ever showed the *Ohne Feature* catch-all bucket plus the feature/idea-assignment controls — the PM reported *"ich kann keine anderen Tickets sehen, nur Ideen zuweisen"*.

**Root cause (verified live):** every work ticket on mentolder is parentless (`parent_id IS NULL`) — **677 task/bug tickets, 0 parented** — and **all 133 features are empty** (`0 Tickets`). The feature-centric cockpit (T000786/T000877) nests tickets under features, so with this flat data every feature renders empty and all real tickets collapse into the single synthetic *Ohne Feature* bucket. With the default *"nur mit offener Arbeit"* sidebar filter that bucket was the only thing visible.

## Fix (frontend/data-read only — no production data mutation)

- **New synthetic `__all_tickets__` bucket** (`getPortfolio` prepends it; `getFeatureTickets` loads it): a flat list of **every** non-archived task/bug leaf of the brand, regardless of feature linkage — the PM's "see all my tickets" entry point. Searchable/filterable via the existing table toolbar + pagination.
- **`Ohne Feature` is now only shown when it is a genuine subset** (`orphan < all`) so mentolder (all-orphan) doesn't get two identical buckets.
- **Cockpit defaults to `Alle Tickets`** and **recovers from a stale/unknown selection** (e.g. a persisted `localStorage` feature that no longer exists) — the table can no longer silently render empty.
- **Sidebar:** synthetic aggregate buckets stay visible regardless of the *only-open-work* filter; the meaningless next-step/discard/major actions are hidden on them; the AI suggestion bar ignores synthetic buckets.

## Tests

- 6 new + 1 updated unit tests in `cockpit-db.test.ts` (Alle-Tickets bucket coverage, subset/omit rules, brand scoping).
- Full website suite green: **1086 passed**, cockpit component tests **34 passed**.

Follow-up to T000877.

🤖 Generated with [Claude Code](https://claude.com/claude-code)