### PR TITLE
fix(factory): correct prometheus URL fallback and improve error message [T000889]

### DIFF
--- a/docs/generated/api-map.json
+++ b/docs/generated/api-map.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-16T08:01:32.862Z",
+  "generatedAt": "2026-06-16T08:42:23.797Z",
   "endpoints": [
     {
       "path": "/api/admin/angebote/save",

--- a/docs/generated/api-surface.md
+++ b/docs/generated/api-surface.md
@@ -1,6 +1,6 @@
 # API Surface Map
 
-> Generated at 2026-06-16T08:01:32.862Z
+> Generated at 2026-06-16T08:42:23.797Z
 
 | Path | Methods | Auth | File |
 |------|---------|------|------|

--- a/docs/generated/blast-radius.md
+++ b/docs/generated/blast-radius.md
@@ -1,5 +1,5 @@
 # Blast-Radius-Report
-> Generated: 2026-06-16T08:01:33.002Z
+> Generated: 2026-06-16T08:42:23.859Z
 > Nodes: 79 | Edges: 1614 | Isolated: 2
 
 ## Ranking (transitive Abhängige)

--- a/docs/generated/graph.json
+++ b/docs/generated/graph.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-16T08:01:32.752Z",
+  "generatedAt": "2026-06-16T08:42:23.696Z",
   "nodes": [
     {
       "id": "admin-actions-cleanup",

--- a/k3d/docs-content-built/architecture/index.html
+++ b/k3d/docs-content-built/architecture/index.html
@@ -178,7 +178,7 @@
 <body>
   <div class="header">
     <h1>⬡ Architektur — Living Docs</h1>
-    <span class="meta">Generiert: 2026-06-16T08:01:32.951Z</span>
+    <span class="meta">Generiert: 2026-06-16T08:42:21.462Z</span>
   </div>
 
   <div class="stats">

--- a/website/src/components/factory/FactoryObservability.svelte
+++ b/website/src/components/factory/FactoryObservability.svelte
@@ -132,7 +132,7 @@
           {/each}
         </div>
       {:else}
-        <p class="muted">Keine Phasen-Metriken verfügbar (OTel Collector noch nicht deployed).</p>
+        <p class="muted">Keine Phasen-Metriken verfügbar (Prometheus/OTel Verbindung prüfen oder noch keine Factory Ticks gelaufen).</p>
       {/if}
     </div>
 

--- a/website/src/lib/factory-observability.ts
+++ b/website/src/lib/factory-observability.ts
@@ -7,7 +7,7 @@ import { pool } from './website-db';
 
 const PROM_BASE =
   process.env.PROMETHEUS_URL ||
-  'http://kube-prometheus-stack-prometheus.monitoring.svc.cluster.local:9090';
+  'http://monitoring-prometheus.monitoring.svc.cluster.local:9090';
 
 export interface PromMatrix {
   status: string;


### PR DESCRIPTION
Closes T000889. Corrects the DNS fallback address of Prometheus for website serverside querying to match the real cluster service, and improves the empty-state message in the Svelte observability dashboard component to guide verification.