### PR TITLE
feat(website): off-script design-sync pipeline for claude.ai/design

### DIFF
--- a/website/.design-sync/NOTES.md
+++ b/website/.design-sync/NOTES.md
@@ -1,0 +1,40 @@
+# design-sync NOTES — mentolder Website Components
+
+Off-script sync: the website is **Astro + Svelte 5**, not a React package. The stock
+converter (`package-build.mjs`) does not apply. The build pipeline is bespoke under
+`.ds-sync/` and produces the standard `ds-bundle/` upload layout.
+
+## How it works
+- `.ds-sync/gen.mjs` — generator. Run from website root: `node .ds-sync/gen.mjs`.
+  1. Wraps each curated Svelte component in a React mount-wrapper (`mount()`/`unmount()` in `useEffect`).
+  2. esbuild → IIFE `window.MentolderDS` (Svelte runtime inlined; `react`→`window.React` via reactShim).
+  3. Tailwind v4 (`@tailwindcss/node`) compiles `.ds-sync/theme-input.css` + scanned classes → `_ds_bundle.css`.
+  4. Emits per-component `.jsx`/`.d.ts`/`.prompt.md`/`.html` cards + `_preview/<Name>.js`, `_ds_sync.json`, README, `.review.html`.
+- `.ds-sync/svelte-plugin.mjs` — esbuild Svelte 5 plugin (TS-strip + compile, `css:'injected'`).
+- `.ds-sync/contract.mjs` — faithful replication of the design-sync card/header/vendor contract.
+- `.ds-sync/render-check.mjs` — headless render gate + per-component screenshots (`ds-bundle/_screenshots/`).
+- `.design-sync/previews/<Name>.tsx` — authored preview compositions (read `window.MentolderDS` lazily at render).
+
+## Gotchas learned
+- **Isolated TS-strip elides markup-only imports.** Preprocessing the `<script>` block alone makes
+  esbuild drop imports used only in the template (`t`, child components) → "X is not defined" at runtime.
+  Fix: `verbatimModuleSyntax: true` in the TS transform (never elide value imports). All curated
+  components annotate type-only imports with `type`, so this is safe.
+- **Dark-brand DS.** mentolder renders on `--color-ink-900`; light component text (`--color-fg`)
+  is invisible on a white card. The preview card body is set to the brand ink (contract.mjs).
+- **Svelte compiler `state_referenced_locally` warnings** on the wrapper imports are benign.
+- **Chromium version mismatch**: cached `chromium-1223` vs playwright 1.61 wanting 1228 →
+  render-check launches system Chrome via `channel: 'chrome'`.
+- `.ds-pilot/` (early proof) vanished mid-run — likely a parallel session's cleanup. The `.ds-sync/`
+  scripts are self-contained; recreate any missing file from this repo if it happens again.
+
+## Re-sync risks
+- Curated scope is hand-listed in `.ds-sync/components.mjs` (Brand + UI ~20). `.astro` is excluded
+  (server-only, not client-mountable). New components must be added there.
+- Fonts load via the Google Fonts CDN `@import` in `styles.css` (`[FONT_REMOTE]`, informational —
+  no local font files shipped).
+- `_ds_sync.json` is a best-effort anchor; if its schema drifts from the official converter, a
+  re-sync simply re-verifies everything.
+- The `.d.ts` props bodies are lifted verbatim from each component's `interface Props` + a small set
+  of referenced types (WhyMePoint/FAQItem/NavigationLink) + `type Locale`. New referenced types need
+  adding to `extraTypes()` in gen.mjs.

--- a/website/.design-sync/config.json
+++ b/website/.design-sync/config.json
@@ -1,0 +1,10 @@
+{
+  "pkg": "mentolder-website",
+  "globalName": "MentolderDS",
+  "projectId": "5afb3eef-e9a4-43db-a111-03e308d5f0b8",
+  "shape": "package",
+  "readmeHeader": ".design-sync/conventions.md",
+  "offScript": true,
+  "note": "Off-script Svelte→React-wrapper sync. The stock converter (package-build.mjs) does NOT apply — components are Svelte 5, not React. Build pipeline lives in .ds-sync/ (gen.mjs). See NOTES.md.",
+  "globalNamespace": "MentolderDS"
+}

--- a/website/.design-sync/conventions.md
+++ b/website/.design-sync/conventions.md
@@ -1,0 +1,60 @@
+# Building with the mentolder design system
+
+mentolder is a **dark-brand** German digital-coaching / leadership-mentoring site.
+Every screen sits on a deep navy ink ground with a warm brass accent and an editorial
+serif display face. Import components from `window.MentolderDS` (e.g. `MentolderDS.Hero`,
+`MentolderDS.ServiceCard`) and compose them as React elements.
+
+## Wrapping & setup (read first)
+
+- **Put everything on the brand ground.** The page/root MUST set
+  `background: var(--color-ink-900)` (`#0b111c`) and `color: var(--color-fg)` (`#eef1f3`).
+  Component text is light by design — on a white background it disappears. There is no
+  ThemeProvider; the tokens live in `:root` (shipped via `styles.css` → `_ds_bundle.css`),
+  so just load `styles.css` and set the dark ground.
+- Components are self-styling: each carries its own scoped CSS (injected on mount) plus the
+  brand tokens. You only supply props and your own layout glue.
+
+## The styling idiom — two coexisting layers, real names
+
+1. **CSS custom properties** (the source of truth). Colors: `--color-ink-900/-850/-800/-750`
+   (surfaces), `--color-fg` / `--color-fg-soft` / `--color-mute` (text), `--color-brass` /
+   `--color-brass-2` (primary accent, hover), `--color-sage` (healthy/ready), `--color-line` /
+   `--color-line-2` (hairlines). Type: `--font-serif` (Newsreader — display/headlines),
+   `--font-sans` (Geist — body/UI), `--font-mono` (Geist Mono — eyebrows, meta, labels).
+   Use them in your own layout CSS: `style={{ background: 'var(--color-ink-850)' }}`.
+2. **Tailwind v4 utilities** derived from those tokens (already compiled into the bundle).
+   Use them for your glue markup: surfaces `bg-dark-light` / `bg-dark-lighter`; text
+   `text-light` / `text-muted` / `text-gold`; accent fills `bg-gold` / `hover:bg-gold-light`;
+   plus standard Tailwind (`rounded-2xl`, `p-8`, `flex`, `gap-3`, `font-serif`). Headlines use
+   `font-serif`; eyebrows/labels use `font-mono` + uppercase + letter-spacing.
+
+Brass is for ONE primary action per view — CTAs, active states, eyebrow ticks. Body copy is
+`--color-fg-soft`; never pure white. Generous vertical rhythm (sections breathe at 80–130px).
+
+## Where the truth lives
+
+- `styles.css` and its `@import "./_ds_bundle.css"` closure — all tokens + utilities.
+- Per component: `<Name>.d.ts` (the prop contract you code against) and `<Name>.prompt.md`
+  (usage). Read these before composing a component.
+
+## Idiomatic snippet
+
+```jsx
+const { Hero, ServiceCard } = window.MentolderDS;
+<main style={{ background: 'var(--color-ink-900)', color: 'var(--color-fg)' }}>
+  <Hero
+    tagline="Digital Coach & Führungskräfte-Mentor"
+    title="Menschen, Prozesse und Technik —"
+    titleEmphasis="wieder in Einklang gebracht."
+  />
+  <section className="flex gap-6 p-8">
+    <ServiceCard icon="🧭" title="Digital Coaching"
+      description="Persönliche Begleitung für Führungskräfte."
+      features={['1:1 Sessions', 'Praxisnah', 'Erreichbar']}
+      href="/leistungen/coaching" price="ab 180 € / Session" />
+  </section>
+</main>
+```
+
+Brand: "mentolder" is always lowercase. Location: Lüneburg, Hamburg und Umgebung.

--- a/website/.design-sync/previews/Avatar.tsx
+++ b/website/.design-sync/previews/Avatar.tsx
@@ -1,0 +1,26 @@
+// @ts-nocheck
+// Authored preview — mentolder initials avatar in its variant set.
+export const Brass = () => {
+  const { Avatar } = window.MentolderDS;
+  return <Avatar givenName="Patrick" familyName="Korczewski" variant="brass" size={56} />;
+};
+
+export const Hairline = () => {
+  const { Avatar } = window.MentolderDS;
+  return <Avatar name="Patrick Korczewski" variant="hairline" size={44} />;
+};
+
+export const Ring = () => {
+  const { Avatar } = window.MentolderDS;
+  return <Avatar givenName="Gerald" familyName="Köhler" variant="ring" size={44} />;
+};
+
+export const Plate = () => {
+  const { Avatar } = window.MentolderDS;
+  return <Avatar name="mentolder System" variant="plate" size={48} />;
+};
+
+export const SerifGerald = () => {
+  const { Avatar } = window.MentolderDS;
+  return <Avatar givenName="Gerald" familyName="Köhler" variant="serif" size={56} />;
+};

--- a/website/.design-sync/previews/BookingForm.tsx
+++ b/website/.design-sync/previews/BookingForm.tsx
@@ -1,0 +1,17 @@
+// @ts-nocheck
+// Authored preview — mentolder Terminbuchung. Renders the type/leistung step
+// chain in its idle state (slot fetch is async; the static scaffold shows).
+export const Default = () => {
+  const { BookingForm } = window.MentolderDS;
+  return <BookingForm />;
+};
+
+export const ErstgespraechPrefilled = () => {
+  const { BookingForm } = window.MentolderDS;
+  return (
+    <BookingForm
+      initialType="erstgespraech"
+      serviceKey="digital-coaching"
+    />
+  );
+};

--- a/website/.design-sync/previews/CallToAction.tsx
+++ b/website/.design-sync/previews/CallToAction.tsx
@@ -1,0 +1,22 @@
+// @ts-nocheck
+// Authored preview — closing call-to-action band.
+export const Default = () => {
+  const { CallToAction } = window.MentolderDS;
+  return <CallToAction locale="de" />;
+};
+
+export const CustomWithSecondary = () => {
+  const { CallToAction } = window.MentolderDS;
+  return (
+    <CallToAction
+      locale="de"
+      eyebrow="Kostenloses Erstgespräch"
+      title="Bereit für den"
+      titleEmphasis="nächsten Schritt?"
+      subtitle="Lass uns in 30 Minuten herausfinden, wo du stehst und was als Nächstes sinnvoll ist — ohne Verkaufsdruck."
+      primaryText="Termin vereinbaren"
+      secondaryText="Mehr erfahren"
+      secondaryHref="/leistungen"
+    />
+  );
+};

--- a/website/.design-sync/previews/ContactForm.tsx
+++ b/website/.design-sync/previews/ContactForm.tsx
@@ -1,0 +1,11 @@
+// @ts-nocheck
+// Authored preview — mentolder Kontaktformular in its idle (empty) state.
+export const German = () => {
+  const { ContactForm } = window.MentolderDS;
+  return <ContactForm locale="de" />;
+};
+
+export const English = () => {
+  const { ContactForm } = window.MentolderDS;
+  return <ContactForm locale="en" />;
+};

--- a/website/.design-sync/previews/CookieConsent.tsx
+++ b/website/.design-sync/previews/CookieConsent.tsx
@@ -1,0 +1,11 @@
+// @ts-nocheck
+// Authored preview — mentolder cookie-consent banner (necessary-cookies only).
+// NOTE: this component takes NO props. Its onMount reads localStorage[cookie_consent_v1]
+// and only sets visible=true when NO consent has been stored yet. In a fresh preview frame
+// localStorage is usually empty, so the banner SHOULD render. If the preview frame has a
+// stored consent value, it will render EMPTY (no force-show prop exists) — orchestrator may
+// need a floor card / localStorage clear.
+export const Default = () => {
+  const { CookieConsent } = window.MentolderDS;
+  return <CookieConsent />;
+};

--- a/website/.design-sync/previews/FAQ.tsx
+++ b/website/.design-sync/previews/FAQ.tsx
@@ -1,0 +1,61 @@
+// @ts-nocheck
+// Authored preview — mentolder FAQ accordion with realistic coaching questions.
+export const Default = () => {
+  const { FAQ } = window.MentolderDS;
+  return (
+    <FAQ
+      items={[
+        {
+          question: 'Für wen ist ein Coaching bei mentolder geeignet?',
+          answer: 'Für Führungskräfte und Selbstständige, die digitale Veränderung gestalten wollen — ob beim ersten Schritt in die Transformation oder bei konkreten Entscheidungen im Tagesgeschäft.',
+        },
+        {
+          question: 'Finden die Termine online oder vor Ort statt?',
+          answer: 'Beides ist möglich. Persönliche Termine biete ich in Lüneburg, Hamburg und Umgebung an, digitale Sessions per Videocall deutschlandweit.',
+        },
+        {
+          question: 'Wie läuft das erste Gespräch ab?',
+          answer: 'Das Erstgespräch ist unverbindlich. Wir klären Ihr Anliegen, schauen, ob die Chemie stimmt, und legen erst danach gemeinsam die nächsten Schritte fest.',
+        },
+        {
+          question: 'Wie vertraulich sind die Gespräche?',
+          answer: 'Vollständig. Alles, was im Coaching besprochen wird, bleibt zwischen uns — Diskretion ist die Grundlage meiner Arbeit.',
+        },
+      ]}
+    />
+  );
+};
+
+export const CustomTitle = () => {
+  const { FAQ } = window.MentolderDS;
+  return (
+    <FAQ
+      title="Häufige Fragen zur IT-Sicherheit"
+      items={[
+        {
+          question: 'Brauche ich ein Security-Audit, wenn bei uns nie etwas passiert ist?',
+          answer: 'Gerade dann. Ein Audit deckt Risiken auf, bevor sie zum Vorfall werden — und gibt Ihnen eine belastbare Grundlage für Entscheidungen.',
+        },
+        {
+          question: 'Wie lange dauert ein Audit?',
+          answer: 'Je nach Umfang zwischen einem und mehreren Tagen. Den genauen Rahmen klären wir vorab im Gespräch.',
+        },
+      ]}
+    />
+  );
+};
+
+export const Single = () => {
+  const { FAQ } = window.MentolderDS;
+  return (
+    <FAQ
+      title="Kurz gefragt"
+      items={[
+        {
+          question: 'Was kostet eine Coaching-Session?',
+          answer: 'Eine 1:1 Session beginnt bei 180 €. Für längere Begleitungen vereinbaren wir gerne ein passendes Paket.',
+        },
+      ]}
+    />
+  );
+};

--- a/website/.design-sync/previews/Hero.tsx
+++ b/website/.design-sync/previews/Hero.tsx
@@ -1,0 +1,22 @@
+// @ts-nocheck
+// Authored preview — realistic mentolder hero compositions.
+export const Default = () => {
+  const { Hero } = window.MentolderDS;
+  return <Hero />;
+};
+
+export const WithInitials = () => {
+  const { Hero } = window.MentolderDS;
+  return (
+    <Hero
+      tagline="Digital Coach & Führungskräfte-Mentor"
+      title="Menschen, Prozesse und Technik —"
+      titleEmphasis="wieder in Einklang gebracht."
+      subtitle="Mit 30+ Jahren Führungserfahrung begleite ich Menschen und Organisationen bei der digitalen Transformation — praxisnah, empathisch und auf Augenhöhe."
+      avatarType="initials"
+      avatarInitials="PK"
+      personName="Patrick Korczewski"
+      personRole="Gründer · mentolder"
+    />
+  );
+};

--- a/website/.design-sync/previews/LanguageSwitcher.tsx
+++ b/website/.design-sync/previews/LanguageSwitcher.tsx
@@ -1,0 +1,11 @@
+// @ts-nocheck
+// Authored preview — DE/EN locale toggle. Active locale derives from pathname.
+export const German = () => {
+  const { LanguageSwitcher } = window.MentolderDS;
+  return <LanguageSwitcher pathname="/ueber-mich" />;
+};
+
+export const English = () => {
+  const { LanguageSwitcher } = window.MentolderDS;
+  return <LanguageSwitcher pathname="/en/ueber-mich" />;
+};

--- a/website/.design-sync/previews/Navigation.tsx
+++ b/website/.design-sync/previews/Navigation.tsx
@@ -1,0 +1,32 @@
+// @ts-nocheck
+// Authored preview — mentolder sticky top navigation (idle, logged-out state).
+const navLinks = [
+  { label: 'Angebote', href: '/#angebote' },
+  { label: 'Über mich', href: '/ueber-mich' },
+  { label: 'Referenzen', href: '/referenzen' },
+  { label: 'Kontakt', href: '/kontakt' },
+];
+
+export const Default = () => {
+  const { Navigation } = window.MentolderDS;
+  return (
+    <Navigation
+      siteTitle="mentolder"
+      links={navLinks}
+      pathname="/"
+      locale="de"
+    />
+  );
+};
+
+export const OnReferenzen = () => {
+  const { Navigation } = window.MentolderDS;
+  return (
+    <Navigation
+      siteTitle="mentolder"
+      links={navLinks}
+      pathname="/referenzen"
+      locale="de"
+    />
+  );
+};

--- a/website/.design-sync/previews/NewsletterSignup.tsx
+++ b/website/.design-sync/previews/NewsletterSignup.tsx
@@ -1,0 +1,11 @@
+// @ts-nocheck
+// Authored preview — mentolder footer newsletter signup, idle state (German + English locale).
+export const Default = () => {
+  const { NewsletterSignup } = window.MentolderDS;
+  return <NewsletterSignup locale="de" />;
+};
+
+export const English = () => {
+  const { NewsletterSignup } = window.MentolderDS;
+  return <NewsletterSignup locale="en" />;
+};

--- a/website/.design-sync/previews/Portrait.tsx
+++ b/website/.design-sync/previews/Portrait.tsx
@@ -1,0 +1,41 @@
+// @ts-nocheck
+// Authored preview — mentolder framed founder portrait (initials placeholder).
+export const Default = () => {
+  const { Portrait } = window.MentolderDS;
+  return (
+    <Portrait
+      avatarType="initials"
+      avatarInitials="PK"
+      name="Patrick Korczewski"
+      role="Gründer · Digital Coach"
+      location="Lüneburg · DE"
+      tagText="Anno 2026 · Lüneburg"
+    />
+  );
+};
+
+export const MentorRole = () => {
+  const { Portrait } = window.MentolderDS;
+  return (
+    <Portrait
+      avatarType="initials"
+      avatarInitials="PK"
+      name="Patrick Korczewski"
+      role="Führungskräfte-Mentor"
+      location="Hamburg · DE"
+      tagText="40 Jahre IT · Sicherheit"
+    />
+  );
+};
+
+export const Defaults = () => {
+  const { Portrait } = window.MentolderDS;
+  return (
+    <Portrait
+      avatarType="initials"
+      avatarInitials="PK"
+      name="Patrick Korczewski"
+      role="Coach & Sparringspartner"
+    />
+  );
+};

--- a/website/.design-sync/previews/QuoteCard.tsx
+++ b/website/.design-sync/previews/QuoteCard.tsx
@@ -1,0 +1,24 @@
+// @ts-nocheck
+// Authored preview — testimonial / pull-quote cards (text-heavy: checks serif + italics).
+export const Testimonial = () => {
+  const { QuoteCard } = window.MentolderDS;
+  return (
+    <QuoteCard
+      quote="Patrick hat es geschafft, dass unser Team Technologie nicht mehr als Bedrohung, sondern als Werkzeug begreift. Das hat unsere Zusammenarbeit grundlegend verändert."
+      name="Sabine Mertens"
+      role="Bereichsleiterin, mittelständischer Maschinenbau"
+    />
+  );
+};
+
+export const Short = () => {
+  const { QuoteCard } = window.MentolderDS;
+  return (
+    <QuoteCard
+      quote="Endlich jemand, der Klartext spricht und trotzdem zuhört."
+      name="Andreas Vogt"
+      role="Geschäftsführer"
+      initials="AV"
+    />
+  );
+};

--- a/website/.design-sync/previews/RegistrationForm.tsx
+++ b/website/.design-sync/previews/RegistrationForm.tsx
@@ -1,0 +1,11 @@
+// @ts-nocheck
+// Authored preview — mentolder Erstgespräch registration form, idle state (German + English locale).
+export const Default = () => {
+  const { RegistrationForm } = window.MentolderDS;
+  return <RegistrationForm locale="de" />;
+};
+
+export const English = () => {
+  const { RegistrationForm } = window.MentolderDS;
+  return <RegistrationForm locale="en" />;
+};

--- a/website/.design-sync/previews/SegmentDots.tsx
+++ b/website/.design-sync/previews/SegmentDots.tsx
@@ -1,0 +1,16 @@
+// @ts-nocheck
+// Authored preview — SegmentDots progress primitive (factory UI), partial + full fill.
+export const MidProgress = () => {
+  const { SegmentDots } = window.MentolderDS;
+  return <SegmentDots total={8} filled={5} />;
+};
+
+export const Complete = () => {
+  const { SegmentDots } = window.MentolderDS;
+  return <SegmentDots total={6} filled={6} />;
+};
+
+export const Empty = () => {
+  const { SegmentDots } = window.MentolderDS;
+  return <SegmentDots total={8} filled={1} />;
+};

--- a/website/.design-sync/previews/ServiceCard.tsx
+++ b/website/.design-sync/previews/ServiceCard.tsx
@@ -1,0 +1,28 @@
+// @ts-nocheck
+// Authored preview — mentolder service offering cards (Tailwind-styled).
+export const Default = () => {
+  const { ServiceCard } = window.MentolderDS;
+  return (
+    <ServiceCard
+      icon="🧭"
+      title="Digital Coaching"
+      description="Persönliche Begleitung für Führungskräfte, die digitale Veränderung souverän gestalten wollen."
+      features={['1:1 Sessions', 'Praxisnahe Methoden', 'Zwischen den Terminen erreichbar']}
+      href="/leistungen/coaching"
+      price="ab 180 € / Session"
+    />
+  );
+};
+
+export const WithoutPrice = () => {
+  const { ServiceCard } = window.MentolderDS;
+  return (
+    <ServiceCard
+      icon="🛡️"
+      title="IT-Sicherheit & Strategie"
+      description="40 Jahre IT-Erfahrung für tragfähige Entscheidungen — von der Architektur bis zur Absicherung."
+      features={['Security-Audit', 'Risiko-Bewertung', 'Umsetzungs-Roadmap']}
+      href="/leistungen/it-sicherheit"
+    />
+  );
+};

--- a/website/.design-sync/previews/ServiceRow.tsx
+++ b/website/.design-sync/previews/ServiceRow.tsx
@@ -1,0 +1,63 @@
+// @ts-nocheck
+// Authored preview — mentolder editorial service rows (numbered offer list).
+export const Default = () => {
+  const { ServiceRow } = window.MentolderDS;
+  return (
+    <ServiceRow
+      num="01"
+      title="Digital Coaching"
+      meta="1:1 Begleitung"
+      description="Persönliche Begleitung für Führungskräfte, die digitale Veränderung souverän und auf Augenhöhe gestalten wollen — vom ersten Impuls bis zur nachhaltigen Umsetzung."
+      features={['Vertrauliche 1:1 Sessions', 'Praxisnahe Methoden', 'Zwischen den Terminen erreichbar']}
+      price="180 € / Session"
+      href="/leistungen/coaching"
+      icon="🧭"
+    />
+  );
+};
+
+export const ITSecurity = () => {
+  const { ServiceRow } = window.MentolderDS;
+  return (
+    <ServiceRow
+      num="02"
+      title="IT-Sicherheit & Strategie"
+      meta="40 Jahre Erfahrung"
+      description="Tragfähige Entscheidungen statt Bauchgefühl — von der Architektur über die Risiko-Bewertung bis zur konkreten Absicherung Ihrer Systeme."
+      features={['Security-Audit', 'Risiko-Bewertung', 'Umsetzungs-Roadmap']}
+      price="ab 1.200 € / Audit"
+      href="/leistungen/it-sicherheit"
+      icon="🛡️"
+    />
+  );
+};
+
+export const Workshop = () => {
+  const { ServiceRow } = window.MentolderDS;
+  return (
+    <ServiceRow
+      num="03"
+      title="Führungs-Workshops"
+      description="Kompakte Impulse für Teams im Wandel — wir bringen Menschen, Prozesse und Technik wieder in Einklang."
+      features={['Halbtags oder ganztags', 'Inhouse in Lüneburg & Hamburg', 'Maßgeschneiderte Agenda']}
+      price="auf Anfrage"
+      priceUnit="pro Tag"
+      href="/leistungen/workshops"
+      icon="🤝"
+    />
+  );
+};
+
+export const Minimal = () => {
+  const { ServiceRow } = window.MentolderDS;
+  return (
+    <ServiceRow
+      num="04"
+      title="Sparring-Gespräch"
+      description="Ein klärendes Gespräch, wenn eine Entscheidung ansteht — direkt, vertraulich, ohne langfristige Bindung."
+      features={[]}
+      price="90 € / 60 Min"
+      href="/leistungen/sparring"
+    />
+  );
+};

--- a/website/.design-sync/previews/Stepper.tsx
+++ b/website/.design-sync/previews/Stepper.tsx
@@ -1,0 +1,16 @@
+// @ts-nocheck
+// Authored preview — Stepper numeric control (factory UI), mid-progress and bounds.
+export const MidValue = () => {
+  const { Stepper } = window.MentolderDS;
+  return <Stepper value={4} min={1} max={10} />;
+};
+
+export const AtMin = () => {
+  const { Stepper } = window.MentolderDS;
+  return <Stepper value={1} min={1} max={10} />;
+};
+
+export const AtMax = () => {
+  const { Stepper } = window.MentolderDS;
+  return <Stepper value={10} min={1} max={10} />;
+};

--- a/website/.design-sync/previews/Timeline.tsx
+++ b/website/.design-sync/previews/Timeline.tsx
@@ -1,0 +1,68 @@
+// @ts-nocheck
+// Authored preview — mentolder/kore PR-feed timeline, SSR-seeded with realistic rows
+// so it renders without the /api/timeline fetch.
+export const Default = () => {
+  const { Timeline } = window.MentolderDS;
+  return (
+    <Timeline
+      initialRows={[
+        {
+          id: 787,
+          day: '2026-05-14',
+          pr_number: 787,
+          title: 'Fleet-Konsolidierung: beide Brands auf einem Cluster',
+          description: 'mentolder und korczewski teilen sich jetzt den unified fleet-Cluster mit getrennten Namespaces.',
+          category: 'infra',
+          scope: 'cluster',
+          brand: 'mentolder',
+          requirement_id: 'NFA-12',
+          bugs_fixed: 0,
+          ticket_external_id: 'T000338',
+          ticket_id: '338',
+        },
+        {
+          id: 752,
+          day: '2026-05-08',
+          pr_number: 752,
+          title: 'Newsletter-Anmeldung im Footer',
+          description: 'Double-Opt-In Newsletter-Signup für die mentolder-Startseite.',
+          category: 'feat',
+          scope: 'website',
+          brand: 'mentolder',
+          requirement_id: 'FA-07',
+          bugs_fixed: 0,
+          ticket_external_id: 'T000291',
+          ticket_id: '291',
+        },
+        {
+          id: 740,
+          day: '2026-05-02',
+          pr_number: 740,
+          title: 'Cookie-Banner: nur notwendige Cookies',
+          description: 'DSGVO-konformer Consent-Banner ohne Tracking.',
+          category: 'fix',
+          scope: 'website',
+          brand: 'mentolder',
+          requirement_id: null,
+          bugs_fixed: 2,
+          ticket_external_id: null,
+          ticket_id: null,
+        },
+        {
+          id: 718,
+          day: '2026-04-24',
+          pr_number: 718,
+          title: 'Leistungsseiten-Dokumentation überarbeitet',
+          description: 'Inhaltsmodell und Admin-Workflow für Service-Seiten dokumentiert.',
+          category: 'docs',
+          scope: 'website',
+          brand: 'mentolder',
+          requirement_id: null,
+          bugs_fixed: 0,
+          ticket_external_id: 'T000260',
+          ticket_id: '260',
+        },
+      ]}
+    />
+  );
+};

--- a/website/.design-sync/previews/ToggleSwitch.tsx
+++ b/website/.design-sync/previews/ToggleSwitch.tsx
@@ -1,0 +1,16 @@
+// @ts-nocheck
+// Authored preview — ToggleSwitch primitive (factory UI), on and off states.
+export const On = () => {
+  const { ToggleSwitch } = window.MentolderDS;
+  return <ToggleSwitch value={true} size="md" glow={true} />;
+};
+
+export const Off = () => {
+  const { ToggleSwitch } = window.MentolderDS;
+  return <ToggleSwitch value={false} size="md" glow={true} />;
+};
+
+export const Large = () => {
+  const { ToggleSwitch } = window.MentolderDS;
+  return <ToggleSwitch value={true} size="lg" glow={true} />;
+};

--- a/website/.design-sync/previews/WhyMe.tsx
+++ b/website/.design-sync/previews/WhyMe.tsx
@@ -1,0 +1,77 @@
+// @ts-nocheck
+// Authored preview — mentolder "Warum ich" section with reasons + founder quote.
+export const Default = () => {
+  const { WhyMe } = window.MentolderDS;
+  return (
+    <WhyMe
+      headline="Warum mentolder"
+      intro="Erfahrung, die *Orientierung* gibt — wenn Technik und Menschen aufeinandertreffen."
+      points={[
+        {
+          title: '30+ Jahre Führungserfahrung',
+          text: 'Ich weiß, wie sich Verantwortung anfühlt — und begleite Sie aus eigener Erfahrung, nicht aus dem Lehrbuch.',
+        },
+        {
+          title: '40 Jahre in IT & Sicherheit',
+          text: 'Von den Grundlagen bis zur Absicherung komplexer Systeme: ich übersetze Technik in tragfähige Entscheidungen.',
+        },
+        {
+          title: 'Empathisch & auf Augenhöhe',
+          text: 'Kein Frontalunterricht, sondern echtes Sparring — vertraulich, klar und ohne Fachjargon.',
+        },
+      ]}
+      quote="Digitale Transformation gelingt nicht über Tools, sondern über Menschen, die sie tragen."
+      quoteName="Patrick Korczewski"
+      quoteRole="Gründer · mentolder"
+    />
+  );
+};
+
+export const TwoPoints = () => {
+  const { WhyMe } = window.MentolderDS;
+  return (
+    <WhyMe
+      headline="Mein Ansatz"
+      intro="Weniger *Buzzwords*, mehr Wirkung."
+      points={[
+        {
+          title: 'Praxis vor Theorie',
+          text: 'Jede Empfehlung lässt sich am Montag umsetzen — nicht erst nach dem nächsten Großprojekt.',
+        },
+        {
+          title: 'Diskretion als Standard',
+          text: 'Was im Coaching besprochen wird, bleibt im Coaching. Immer.',
+        },
+      ]}
+      quote="Die beste Strategie ist die, die Ihr Team auch wirklich lebt."
+      quoteName="Patrick Korczewski"
+      quoteRole="Digital Coach & Mentor"
+    />
+  );
+};
+
+export const NoQuoteRole = () => {
+  const { WhyMe } = window.MentolderDS;
+  return (
+    <WhyMe
+      headline="Über mich"
+      intro="Ein Mentor für Führungskräfte in *Lüneburg, Hamburg und Umgebung*."
+      points={[
+        {
+          title: 'Lokal verwurzelt',
+          text: 'Vor Ort in der Region — für persönliche Termine ebenso wie für digitale Sessions.',
+        },
+        {
+          title: 'Branchenübergreifend',
+          text: 'Vom Handwerksbetrieb bis zum Mittelstand: ich höre zu, bevor ich berate.',
+        },
+        {
+          title: 'Verbindlich erreichbar',
+          text: 'Auch zwischen den Terminen bin ich für meine Klientinnen und Klienten da.',
+        },
+      ]}
+      quote="Veränderung beginnt mit einem ehrlichen Gespräch."
+      quoteName="Patrick Korczewski"
+    />
+  );
+};

--- a/website/.ds-sync/components.mjs
+++ b/website/.ds-sync/components.mjs
@@ -1,0 +1,29 @@
+// Curated mentolder design-system surface (Brand + UI). .astro excluded (server-only).
+// group = DS pane grouping; file = svelte source relative to website root.
+export const COMPONENTS = [
+  // Marketing / brand surface
+  { name: 'Hero', group: 'Marketing', file: 'src/components/Hero.svelte' },
+  { name: 'CallToAction', group: 'Marketing', file: 'src/components/CallToAction.svelte' },
+  { name: 'ServiceCard', group: 'Marketing', file: 'src/components/ServiceCard.svelte' },
+  { name: 'ServiceRow', group: 'Marketing', file: 'src/components/ServiceRow.svelte', card: { cardMode: 'column' } },
+  { name: 'QuoteCard', group: 'Marketing', file: 'src/components/QuoteCard.svelte' },
+  { name: 'WhyMe', group: 'Marketing', file: 'src/components/WhyMe.svelte', card: { cardMode: 'column' } },
+  { name: 'FAQ', group: 'Marketing', file: 'src/components/FAQ.svelte' },
+  { name: 'Portrait', group: 'Marketing', file: 'src/components/Portrait.svelte' },
+  { name: 'Avatar', group: 'Marketing', file: 'src/components/Avatar.svelte' },
+  // Navigation
+  { name: 'Navigation', group: 'Navigation', file: 'src/components/Navigation.svelte', card: { cardMode: 'column' } },
+  { name: 'LanguageSwitcher', group: 'Navigation', file: 'src/components/LanguageSwitcher.svelte' },
+  // Forms
+  { name: 'ContactForm', group: 'Forms', file: 'src/components/ContactForm.svelte' },
+  { name: 'BookingForm', group: 'Forms', file: 'src/components/BookingForm.svelte' },
+  { name: 'RegistrationForm', group: 'Forms', file: 'src/components/RegistrationForm.svelte' },
+  { name: 'NewsletterSignup', group: 'Forms', file: 'src/components/NewsletterSignup.svelte' },
+  // Feedback / data
+  { name: 'CookieConsent', group: 'Feedback', file: 'src/components/CookieConsent.svelte' },
+  { name: 'Timeline', group: 'Feedback', file: 'src/components/Timeline.svelte' },
+  // UI primitives
+  { name: 'SegmentDots', group: 'UI', file: 'src/components/ui/SegmentDots.svelte' },
+  { name: 'Stepper', group: 'UI', file: 'src/components/ui/Stepper.svelte' },
+  { name: 'ToggleSwitch', group: 'UI', file: 'src/components/ui/ToggleSwitch.svelte' },
+];

--- a/website/.ds-sync/contract.mjs
+++ b/website/.ds-sync/contract.mjs
@@ -1,0 +1,144 @@
+// Faithful replication of the design-sync upload contract (header / @dsCard html
+// card / vendor React / review page) — see skill lib/{bundle,emit}.mjs. Off-script
+// generation per the package-shape SKILL ("produce the layout by whatever means
+// the repo allows"); package-validate.mjs remains the oracle for the format.
+import { readFileSync, writeFileSync, existsSync, statSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { createHash } from 'node:crypto';
+
+export const escapeHtml = (s) =>
+  String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+
+// react→window.React shim so _ds_bundle.js and the preview cards share ONE React.
+export const reactShim = {
+  name: 'react-global',
+  setup(b) {
+    b.onResolve({ filter: /^react(\/(jsx-(dev-)?runtime|compiler-runtime))?$/ }, () => ({ path: 'react-shim', namespace: 'shim' }));
+    b.onResolve({ filter: /^react-dom(\/client)?$/ }, () => ({ path: 'react-dom-shim', namespace: 'shim' }));
+    b.onLoad({ filter: /^react-shim$/, namespace: 'shim' }, () => ({
+      contents: `var R=window.React;
+function jsx(t,p,k){return R.createElement(t,k===void 0?p:Object.assign({key:k},p));}
+module.exports=R;module.exports.jsx=jsx;module.exports.jsxs=jsx;module.exports.jsxDEV=jsx;module.exports.Fragment=R.Fragment;`,
+      loader: 'js',
+    }));
+    b.onLoad({ filter: /^react-dom-shim$/, namespace: 'shim' }, () => ({
+      contents: 'var D=window.ReactDOM,n=function(){};module.exports=Object.assign({preload:n,preinit:n,preconnect:n,prefetchDNS:n,preloadModule:n,preinitModule:n},D);',
+      loader: 'js',
+    }));
+  },
+};
+
+// Prepend `/* @ds-bundle: {…} */` first-line header read by the app self-check.
+export function stampHeader(bundleJs, { namespace, components, inlinedExternals }) {
+  const body = readFileSync(bundleJs, 'utf8');
+  const out = dirname(bundleJs);
+  const sourceHashes = Object.fromEntries(
+    components.flatMap((c) => {
+      const base = `components/${c.group}/${c.name}/${c.name}`;
+      return ['.jsx', '.d.ts', '.prompt.md']
+        .map((ext) => base + ext)
+        .filter((rel) => existsSync(join(out, rel)))
+        .map((rel) => [rel, createHash('sha256').update(readFileSync(join(out, rel))).digest('hex').slice(0, 12)]);
+    }),
+  );
+  const meta = {
+    namespace,
+    components: components.map((c) => ({ name: c.name, sourcePath: `components/${c.group}/${c.name}/${c.name}.jsx` })),
+    sourceHashes,
+    inlinedExternals,
+    builtBy: 'cc-design-sync',
+  };
+  const headerJson = JSON.stringify(meta).replace(/\*\//g, '*\\/');
+  writeFileSync(bundleJs, `/* @ds-bundle: ${headerJson} */\n` + body);
+}
+
+// React 19 has no UMD — bundle our own IIFE that sets window.React/ReactDOM.
+export async function vendorReact(esbuild, { nodeModules, out }) {
+  const noClobber =
+    ';window.React=window.React||window.__dsReact;window.ReactDOM=window.ReactDOM||window.__dsReactDOM;' +
+    'try{delete window.__dsReact;delete window.__dsReactDOM;}catch(e){}';
+  await esbuild.build({
+    stdin: {
+      contents:
+        'window.__dsReact=require("react");window.__dsReactDOM=require("react-dom");' +
+        'try{Object.assign(window.__dsReactDOM,require("react-dom/client"))}catch(e){}',
+      resolveDir: nodeModules,
+    },
+    bundle: true, format: 'iife', outfile: join(out, '_vendor', 'react.js'),
+    platform: 'browser', define: { 'process.env.NODE_ENV': '"development"' },
+    logLevel: 'error', footer: { js: noClobber }, nodePaths: [nodeModules],
+  });
+  writeFileSync(join(out, '_vendor', 'react-dom.js'), '/* merged into react.js */');
+}
+
+// <Name>.html — renders preview exports from window.__dsPreview (loaded from
+// _preview/<Name>.js). Faithful to lib/emit.mjs previewHtmlModule, no provider.
+export function previewHtmlModule(group, name, GLOBAL, card = {}) {
+  const viewportAttr = card.viewport ? ` viewport="${escapeHtml(card.viewport)}"` : '';
+  const mode = card.cardMode === 'single' ? 'single' : card.cardMode === 'column' ? 'column' : 'grid';
+  return `<!-- @dsCard group="${escapeHtml(group)}"${viewportAttr} -->
+<!doctype html>
+<html><head><meta charset="utf-8">
+  <link rel="stylesheet" href="../../../styles.css">
+  <link rel="stylesheet" href="../../../_ds_bundle.css">
+  <style>
+    /* mentolder is a dark-brand DS — render cards on the brand ink so light
+       component text (--color-fg) is visible. Self-dark components are unaffected. */
+    body{margin:0;padding:24px;background:var(--color-ink-900,#0b111c);color:var(--color-fg,#eef1f3)}
+    .ds-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(320px,1fr));gap:20px;align-items:start}
+    .ds-grid.ds-col{grid-template-columns:1fr}
+    .ds-cell{border:1px solid rgba(255,255,255,.12);border-radius:8px;padding:12px;min-width:0;overflow:hidden;transform:translateZ(0)}
+    .ds-cell>h4{margin:0 0 8px;font:600 12px system-ui;color:#8c96a3;text-transform:uppercase;letter-spacing:.04em}
+    .ds-single{transform:translateZ(0)}
+  </style>
+</head><body>
+  <div class="ds-grid" id="g"></div>
+  <script src="../../../_vendor/react.js"></script>
+  <script src="../../../_vendor/react-dom.js"></script>
+  <script src="../../../_ds_bundle.js"></script>
+  <script src="../../../_preview/${name}.js"></script>
+  <script>
+    var h=React.createElement, g=document.getElementById('g');
+    var E=[]; for (var k in (window.__dsPreview||{})) { if (typeof window.__dsPreview[k]==='function' && /^[A-Z]/.test(k)) E.push(k); }
+    window.__dsCells=E.slice();
+    var q=null; try{q=new URLSearchParams(location.search).get('story')}catch(e){}
+    var MODE=${JSON.stringify(mode)}; window.__dsMode=MODE;
+    var PRIMARY=${JSON.stringify(card.primaryStory ?? '')};
+    if(MODE==='column'){g.className+=' ds-col';var cpi=PRIMARY?E.indexOf(PRIMARY):-1;if(cpi>0){E.splice(cpi,1);E.unshift(PRIMARY)}}
+    function mount(id,key){try{ReactDOM.createRoot(document.getElementById(id)).render(h(window.__dsPreview[key]))}catch(e){document.getElementById(id).textContent='⚠ '+(e&&e.message||e)}}
+    var pick=null;
+    if(q){for(var j=0;j<E.length;j++){if(E[j]===q||E[j].toLowerCase()===q.toLowerCase()){pick=E[j];break}}}
+    else if(MODE==='single'&&E.length){pick=E.indexOf(PRIMARY)>=0?PRIMARY:E[0]}
+    if(q&&!pick){g.textContent='⚠ no export named '+q}
+    else if(pick){var s=document.createElement('div');s.className='ds-single';s.id='r0';if(!q)document.body.style.padding='0';g.parentNode.replaceChild(s,g);mount('r0',pick);}
+    else {for(var i=0;i<E.length;i++){var cell=document.createElement('section');cell.className='ds-cell';cell.innerHTML='<h4>'+E[i]+'</h4><div id="r'+i+'"></div>';g.appendChild(cell);mount('r'+i,E[i]);}if(E.length===0){g.textContent='⚠ no PascalCase exports in _preview/${name}.js'}}
+  </script>
+</body></html>
+`;
+}
+
+// Floor card — honest typographic block for an unauthored component (still fully importable).
+export function floorCard(group, name) {
+  return `<!-- @dsCard group="${escapeHtml(group)}" -->
+<!doctype html>
+<html><head><meta charset="utf-8">
+  <link rel="stylesheet" href="../../../styles.css">
+  <link rel="stylesheet" href="../../../_ds_bundle.css">
+  <style>body{margin:0;padding:40px;background:var(--color-ink-900,#0b111c);color:var(--color-fg,#eef1f3);font-family:system-ui}</style>
+</head><body data-ds-fallback="1">
+  <div style="border:1px dashed rgba(255,255,255,.18);border-radius:10px;padding:28px">
+    <div style="font:600 18px system-ui;color:var(--color-fg,#eef1f3)">${escapeHtml(name)}</div>
+    <div style="font-size:12px;color:#8c96a3;margin-top:14px;line-height:1.5">Preview not yet authored. The component is fully importable — its API is in <code>${escapeHtml(name)}.d.ts</code> and usage in <code>${escapeHtml(name)}.prompt.md</code>.</div>
+  </div>
+</body></html>
+`;
+}
+
+export function emitReviewPage(OUT, components) {
+  const rows = components.map((c) =>
+    `<h3 style="font:600 13px system-ui;margin:24px 0 6px">${escapeHtml(c.group)} / ${escapeHtml(c.name)}</h3>` +
+    `<iframe src="components/${encodeURIComponent(c.group)}/${encodeURIComponent(c.name)}/${encodeURIComponent(c.name)}.html" loading="lazy" style="width:100%;height:360px;border:1px solid #eee;border-radius:8px" title="${escapeHtml(c.name)}"></iframe>`,
+  ).join('\n');
+  writeFileSync(join(OUT, '.review.html'),
+    `<!doctype html><meta charset="utf-8"><title>mentolder DS review</title><body style="margin:0;padding:24px;background:#fafafa;max-width:1200px;margin:auto">${rows}</body>`);
+}

--- a/website/.ds-sync/gen.mjs
+++ b/website/.ds-sync/gen.mjs
@@ -1,0 +1,184 @@
+// Off-script generator for the mentolder Svelte design system → claude.ai/design layout.
+// Run from website root:  node .ds-sync/gen.mjs
+import esbuild from 'esbuild';
+import { compile as twCompile } from '@tailwindcss/node';
+import {
+  readFileSync, writeFileSync, mkdirSync, rmSync, existsSync, readdirSync,
+} from 'node:fs';
+import { join, dirname } from 'node:path';
+import { createHash } from 'node:crypto';
+import { fileURLToPath } from 'node:url';
+import { sveltePlugin } from './svelte-plugin.mjs';
+import { COMPONENTS } from './components.mjs';
+import { reactShim, stampHeader, vendorReact, previewHtmlModule, floorCard, emitReviewPage } from './contract.mjs';
+
+const ROOT = process.cwd();
+const NM = join(ROOT, 'node_modules');
+const OUT = join(ROOT, 'ds-bundle');
+const PREVIEWS = join(ROOT, '.design-sync', 'previews');
+const GLOBAL = 'MentolderDS';
+const VERSION = JSON.parse(readFileSync(join(ROOT, 'package.json'), 'utf8')).version;
+const sha12 = (s) => createHash('sha256').update(s).digest('hex').slice(0, 12);
+
+// ── reset output ──
+rmSync(OUT, { recursive: true, force: true });
+mkdirSync(join(OUT, '_vendor'), { recursive: true });
+mkdirSync(join(OUT, '_preview'), { recursive: true });
+mkdirSync(join(OUT, 'tokens'), { recursive: true });
+
+// ── 1. React-wrapped entry over all Svelte components ──
+const importLines = COMPONENTS.map((c, i) => `import C${i} from '../${c.file}';`).join('\n');
+const exportLines = COMPONENTS.map((c, i) => `export const ${c.name} = wrap(C${i}, ${JSON.stringify(c.name)});`).join('\n');
+const entrySrc = `import React, { useRef, useEffect } from 'react';
+import { mount, unmount } from 'svelte';
+${importLines}
+function wrap(SvelteComp, name) {
+  function W(props) {
+    const ref = useRef(null);
+    useEffect(() => {
+      if (!ref.current) return;
+      let inst;
+      try { inst = mount(SvelteComp, { target: ref.current, props: props || {} }); }
+      catch (e) { ref.current.textContent = '⚠ ' + (e && e.message || e); }
+      return () => { try { if (inst) unmount(inst); } catch (e) {} };
+    }, []);
+    return React.createElement('div', { ref, 'data-ds-host': name });
+  }
+  W.displayName = name;
+  return W;
+}
+${exportLines}
+`;
+const ENTRY = join(ROOT, '.ds-sync', '.entry.jsx');
+writeFileSync(ENTRY, entrySrc);
+
+// ── 2. bundle → IIFE window.MentolderDS (svelte inlined, react shimmed) ──
+const bundleJs = join(OUT, '_ds_bundle.js');
+const res = await esbuild.build({
+  entryPoints: [ENTRY],
+  bundle: true, format: 'iife', globalName: GLOBAL, outfile: bundleJs,
+  platform: 'browser', target: 'es2020', jsx: 'automatic', metafile: true,
+  nodePaths: [NM], plugins: [sveltePlugin(), reactShim],
+  loader: { '.svg': 'dataurl', '.png': 'dataurl', '.woff': 'dataurl', '.woff2': 'dataurl' },
+  define: { 'process.env.NODE_ENV': '"development"' },
+  logLevel: 'warning',
+});
+const inlinedExternals = [...new Set(Object.keys(res.metafile?.inputs ?? {})
+  .map((p) => p.match(/(?:^|\/)node_modules\/((?:@[^/]+\/)?[^/]+)\//)?.[1])
+  .filter((pkg) => pkg && !['react', 'react-dom', 'react-is'].includes(pkg)))].sort();
+console.error(`bundle: ${(readFileSync(bundleJs).length / 1024).toFixed(0)} KB; inlined: ${inlinedExternals.join(', ') || '(none)'}`);
+
+// ── 3. Tailwind v4 CSS (theme :root vars + utilities used by in-scope components) → _ds_bundle.css ──
+const themeBlock = readFileSync(join(ROOT, '.ds-sync', 'theme-input.css'), 'utf8');
+const candidates = new Set();
+for (const c of COMPONENTS) {
+  const src = readFileSync(join(ROOT, c.file), 'utf8');
+  for (const m of src.matchAll(/class(?:Name)?=["'`]([^"'`]+)["'`]/g))
+    for (const tok of m[1].split(/\s+/)) if (tok) candidates.add(tok);
+  for (const m of src.matchAll(/class:([\w-]+)/g)) candidates.add(m[1]);
+}
+const tw = await twCompile(themeBlock, { base: ROOT, onDependency() {} });
+// Factory tokens (--factory-*) used by the UI primitives (SegmentDots/Stepper/ToggleSwitch),
+// minus the duplicate font @import (styles.css already loads it).
+const factoryTokens = readFileSync(join(ROOT, 'src', 'styles', 'factory-tokens.css'), 'utf8')
+  .replace(/@import url\([^)]*\);?/g, '');
+const twCss = tw.build([...candidates]) + '\n\n/* factory-* tokens for UI primitives */\n' + factoryTokens;
+writeFileSync(join(OUT, '_ds_bundle.css'), twCss);
+
+// ── 4. styles.css (the import closure designs receive) + tokens ──
+writeFileSync(join(OUT, 'tokens', 'theme.css'), twCss);
+writeFileSync(join(OUT, 'styles.css'),
+  `/* mentolder design tokens + component utilities. */
+@import url("https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,300;0,6..72,400;0,6..72,500;0,6..72,600;1,6..72,400&family=Geist:wght@300;400;500;600;700&family=Geist+Mono:wght@400;500&display=swap");
+@import "./_ds_bundle.css";
+html,body{margin:0;background:var(--color-ink-900,#0b111c);color:var(--color-fg,#eef1f3);font-family:var(--font-sans,system-ui)}
+`);
+
+// ── 5. _vendor/react.js ──
+await vendorReact(esbuild, { nodeModules: NM, out: OUT });
+
+// ── 6. per-component: .d.ts / .jsx / .prompt.md / .html + preview compile ──
+const COMMON_TYPES = `type Locale = "de" | "en";\n`;
+function propsBody(c) {
+  const src = readFileSync(join(ROOT, c.file), 'utf8');
+  const m = src.match(/interface Props\s*\{([\s\S]*?)\n\s*\}/);
+  if (!m) return '  [key: string]: unknown;';
+  // strip JSDoc-only lines? keep them — valid TS. Trim trailing.
+  return m[1].replace(/\n+$/, '');
+}
+function extraTypes(c) {
+  const src = readFileSync(join(ROOT, c.file), 'utf8');
+  let out = '';
+  for (const t of ['WhyMePoint', 'FAQItem', 'NavigationLink']) {
+    const tm = src.match(new RegExp(`interface ${t}\\s*\\{[\\s\\S]*?\\n\\s*\\}`));
+    if (tm) out += tm[0] + '\n';
+  }
+  return out;
+}
+
+const built = [];
+for (const c of COMPONENTS) {
+  const dir = join(OUT, 'components', c.group, c.name);
+  mkdirSync(dir, { recursive: true });
+  // .jsx stub
+  writeFileSync(join(dir, `${c.name}.jsx`),
+    `// Re-export of mentolder-website@${VERSION} ${c.name}. Implementation is in root _ds_bundle.js (window.${GLOBAL}).\n` +
+    `import { ${c.name} } from '../../../_ds_bundle.js';\nexport { ${c.name} };\nexport default ${c.name};\n`);
+  // .d.ts
+  writeFileSync(join(dir, `${c.name}.d.ts`),
+    `import * as React from 'react';\n${COMMON_TYPES}${extraTypes(c)}export interface ${c.name}Props {\n${propsBody(c)}\n}\n\nexport declare const ${c.name}: React.ComponentType<${c.name}Props>;\n`);
+
+  // preview?
+  const previewTsx = join(PREVIEWS, `${c.name}.tsx`);
+  let hasPreview = false, storyNames = [];
+  if (existsSync(previewTsx)) {
+    try {
+      await esbuild.build({
+        entryPoints: [previewTsx], bundle: true, format: 'iife', globalName: '__dsPreview',
+        outfile: join(OUT, '_preview', `${c.name}.js`), platform: 'browser', target: 'es2020',
+        jsx: 'automatic', nodePaths: [NM], plugins: [reactShim],
+        footer: { js: ';window.__dsPreview=__dsPreview;' },
+        define: { 'process.env.NODE_ENV': '"development"' }, logLevel: 'warning',
+      });
+      hasPreview = true;
+      storyNames = [...readFileSync(previewTsx, 'utf8').matchAll(/export const ([A-Z]\w*)/g)].map((m) => m[1]);
+    } catch (e) {
+      console.error(`! preview build failed: ${c.name}: ${e.message?.split('\n')[0]}`);
+    }
+  }
+  // .prompt.md (first line = element-index summary, never empty)
+  const summary = `${c.name} — mentolder ${c.group.toLowerCase()} component (Svelte, brand-styled).`;
+  let prompt = `${summary}\n\n## ${c.name}\n\nImport from \`window.${GLOBAL}.${c.name}\`. Props contract in \`${c.name}.d.ts\`.\n`;
+  if (storyNames.length) prompt += `\nVariants (see \`${c.name}.html\`): ${storyNames.join(', ')}.\n`;
+  writeFileSync(join(dir, `${c.name}.prompt.md`), prompt);
+  // .html
+  writeFileSync(join(dir, `${c.name}.html`),
+    hasPreview ? previewHtmlModule(c.group, c.name, GLOBAL, c.card || {}) : floorCard(c.group, c.name));
+  built.push({ ...c, hasPreview, storyNames });
+}
+
+// ── 7. header + sidecar + readme + review page ──
+stampHeader(bundleJs, { namespace: GLOBAL, components: COMPONENTS, inlinedExternals });
+
+const bundleSha12 = sha12(readFileSync(bundleJs));
+const styleSha = sha12(readFileSync(join(OUT, 'styles.css')) + readFileSync(join(OUT, '_ds_bundle.css')));
+const renderHashes = {}, sourceKeys = {};
+for (const c of built) {
+  renderHashes[c.name] = sha12(readFileSync(join(OUT, 'components', c.group, c.name, `${c.name}.html`)));
+  sourceKeys[c.name] = sha12(readFileSync(join(ROOT, c.file)) + (c.hasPreview ? readFileSync(join(PREVIEWS, `${c.name}.tsx`)) : ''));
+}
+writeFileSync(join(OUT, '_ds_sync.json'), JSON.stringify({
+  shape: 'package', styleSha, bundleSha12, renderHashes, sourceKeys,
+  keyRecipe: 'sha256(svelteSrc+previewTsx).slice(12)', builtBy: 'cc-design-sync', version: VERSION,
+}, null, 2));
+
+const header = existsSync(join(ROOT, '.design-sync', 'conventions.md'))
+  ? readFileSync(join(ROOT, '.design-sync', 'conventions.md'), 'utf8') + '\n\n' : '';
+const index = built.map((c) => `- **${c.name}** (${c.group}) — ${c.hasPreview ? c.storyNames.length + ' preview(s)' : 'floor card'}`).join('\n');
+writeFileSync(join(OUT, 'README.md'),
+  `${header}# mentolder design system\n\nReact-wrapped Svelte components. Import from \`window.${GLOBAL}\`.\n\n## Components\n\n${index}\n`);
+
+emitReviewPage(OUT, built);
+
+const authored = built.filter((c) => c.hasPreview).length;
+console.error(`\nOK: ${built.length} components (${authored} authored previews, ${built.length - authored} floor cards) → ${OUT}`);

--- a/website/.ds-sync/render-check.mjs
+++ b/website/.ds-sync/render-check.mjs
@@ -1,0 +1,47 @@
+// Render-check gate: open each <Name>.html headless, assert non-empty root, screenshot.
+import { chromium } from 'playwright';
+import { pathToFileURL } from 'node:url';
+import { mkdirSync } from 'node:fs';
+import path from 'node:path';
+import { COMPONENTS } from './components.mjs';
+
+const OUT = path.resolve('ds-bundle');
+const SHOTS = path.join(OUT, '_screenshots');
+mkdirSync(SHOTS, { recursive: true });
+const only = process.argv.slice(2); // optional component name filter
+
+const browser = await chromium.launch({ channel: 'chrome' });
+const results = [];
+for (const c of COMPONENTS) {
+  if (only.length && !only.includes(c.name)) continue;
+  const file = path.join(OUT, 'components', c.group, c.name, `${c.name}.html`);
+  const page = await browser.newPage({ viewport: { width: 1100, height: 1000 }, deviceScaleFactor: 2 });
+  const errs = [];
+  page.on('pageerror', (e) => errs.push('pageerror: ' + e.message));
+  page.on('console', (m) => { if (m.type() === 'error') errs.push('console: ' + m.text()); });
+  await page.goto(pathToFileURL(file).href, { waitUntil: 'networkidle' }).catch((e) => errs.push('goto: ' + e.message));
+  await page.waitForTimeout(1000);
+  const info = await page.evaluate(() => {
+    const body = document.body;
+    const fallback = body.getAttribute('data-ds-fallback') === '1';
+    const text = (body.innerText || '').trim();
+    const warn = text.startsWith('⚠');
+    return { fallback, len: text.length, warn, sample: text.slice(0, 80) };
+  }).catch(() => ({ fallback: false, len: 0, warn: false, sample: '(eval failed)' }));
+  await page.screenshot({ path: path.join(SHOTS, `${c.group}__${c.name}.png`), fullPage: true }).catch(() => {});
+  // Network/CORS fetch failures under file:// are expected for data-bound components
+  // (they render their idle state) — non-blocking, like the skill's [RENDER_ERRORS] tag.
+  const blockingErrs = errs.filter((e) =>
+    !/CORS|ERR_FAILED|Failed to load resource|Access to fetch|net::/i.test(e));
+  const bad = !info.fallback && (info.len < 3 || info.warn || blockingErrs.length > 0);
+  results.push({ name: c.name, group: c.group, ...info, errs, bad });
+  await page.close();
+}
+await browser.close();
+for (const r of results) {
+  const tag = r.fallback ? 'FLOOR' : r.bad ? 'BAD  ' : 'OK   ';
+  console.log(`${tag} ${r.group}/${r.name}  len=${r.len}${r.warn ? ' WARN' : ''}${r.errs.length ? ' ERR:' + JSON.stringify(r.errs.slice(0, 2)) : ''}  "${r.sample.replace(/\n/g, ' ')}"`);
+}
+const bad = results.filter((r) => r.bad);
+console.log(`\n${results.length} checked · ${results.filter((r) => r.fallback).length} floor · ${bad.length} bad`);
+process.exit(bad.length ? 1 : 0);

--- a/website/.ds-sync/svelte-plugin.mjs
+++ b/website/.ds-sync/svelte-plugin.mjs
@@ -1,0 +1,50 @@
+// esbuild plugin: TS-strip preprocess + Svelte 5 compile (client, injected CSS).
+import { readFile } from 'node:fs/promises';
+import { preprocess, compile } from 'svelte/compiler';
+import esbuild from 'esbuild';
+
+export function sveltePlugin() {
+  return {
+    name: 'svelte-mini',
+    setup(build) {
+      build.onLoad({ filter: /\.svelte$/ }, async (args) => {
+        const source = await readFile(args.path, 'utf8');
+        const processed = await preprocess(
+          source,
+          {
+            script: async ({ content, attributes }) => {
+              if (attributes.lang === 'ts' || attributes.lang === 'typescript') {
+                // verbatimModuleSyntax:true → never elide value imports. The
+                // script is preprocessed in ISOLATION (no markup), so esbuild
+                // would otherwise drop imports used only in the template
+                // (e.g. `t`, child components) → "X is not defined" at runtime.
+                const r = await esbuild.transform(content, {
+                  loader: 'ts',
+                  tsconfigRaw: { compilerOptions: { verbatimModuleSyntax: true } },
+                });
+                return { code: r.code };
+              }
+              return undefined;
+            },
+          },
+          { filename: args.path },
+        );
+        const { js, warnings } = compile(processed.code, {
+          filename: args.path,
+          generate: 'client',
+          css: 'injected',
+          dev: false,
+        });
+        const warn = (warnings || [])
+          .filter((w) => !/a11y|unused/i.test(w.code || ''))
+          .map((w) => `${w.code}: ${w.message}`);
+        return {
+          contents: js.code,
+          loader: 'js',
+          resolveDir: args.path.replace(/[^/]+$/, ''),
+          warnings: warn.map((text) => ({ text })),
+        };
+      });
+    },
+  };
+}

--- a/website/.ds-sync/theme-input.css
+++ b/website/.ds-sync/theme-input.css
@@ -1,0 +1,46 @@
+@import "tailwindcss";
+
+@theme {
+  --color-dark: #0b111c;
+  --color-dark-light: #101826;
+  --color-dark-lighter: #17202e;
+  --color-gold: oklch(0.80 0.09 75);
+  --color-gold-light: oklch(0.86 0.09 75);
+  --color-gold-dim: oklch(0.80 0.09 75 / 0.14);
+  --color-light: #eef1f3;
+  --color-muted: #8c96a3;
+  --color-muted-dark: #6a727e;
+  --color-ink-900: #0b111c;
+  --color-ink-850: #101826;
+  --color-ink-800: #17202e;
+  --color-ink-750: #1d2736;
+  --color-fg: #eef1f3;
+  --color-fg-soft: #cdd3d9;
+  --color-mute: #8c96a3;
+  --color-mute-2: #6a727e;
+  --color-brass: oklch(0.80 0.09 75);
+  --color-brass-2: oklch(0.86 0.09 75);
+  --color-brass-d: oklch(0.80 0.09 75 / 0.14);
+  --color-sage: oklch(0.80 0.06 160);
+  --color-surface: #101826;
+  --color-surface-hover: #17202e;
+  --color-border: rgba(255, 255, 255, 0.10);
+  --color-line: rgba(255, 255, 255, 0.07);
+  --color-line-2: rgba(255, 255, 255, 0.12);
+  --font-serif: "Newsreader", "Iowan Old Style", Georgia, serif;
+  --font-sans: "Geist", ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
+  --font-mono: "Geist Mono", ui-monospace, "SFMono-Regular", Menlo, monospace;
+  --radius: 22px;
+  --maxw: 1240px;
+}
+
+/* Shorthand CSS vars the scoped component <style> blocks reference. */
+:root {
+  --ink-900: var(--color-ink-900); --ink-850: var(--color-ink-850);
+  --ink-800: var(--color-ink-800); --ink-750: var(--color-ink-750);
+  --fg: var(--color-fg); --fg-soft: var(--color-fg-soft);
+  --mute: var(--color-mute); --mute-2: var(--color-mute-2);
+  --brass: var(--color-brass); --brass-2: var(--color-brass-2); --brass-d: var(--color-brass-d);
+  --sage: var(--color-sage); --line: var(--color-line); --line-2: var(--color-line-2);
+  --serif: var(--font-serif); --sans: var(--font-sans); --mono: var(--font-mono);
+}

--- a/website/.gitignore
+++ b/website/.gitignore
@@ -1,0 +1,5 @@
+
+# design-sync (claude.ai/design) — regenerated output + machine state
+/ds-bundle/
+/.design-sync/.cache/
+/.ds-sync/.entry.jsx


### PR DESCRIPTION
## Was

Synct die echten Svelte-Komponenten der mentolder-Website in ein **Claude-Design-Projekt** (`mentolder Website Components`), damit der Design-Agent on-brand mit den realen Komponenten baut.

## Warum off-script

Der Standard-`/design-sync`-Converter zielt auf **React-Pakete**. mentolder ist **Astro + Svelte 5** ohne Storybook → der React-Bundle-Pfad passt nicht. Diese PR fügt eine bespoke Off-Script-Pipeline hinzu (vom Skill ausdrücklich sanktioniert: „produce the layout by whatever means the repo allows").

## Wie

- **`.ds-sync/`** — Build-Pipeline: jede kuratierte Svelte-Komponente wird in einen React-Mount-Wrapper (`mount()`/`unmount()`) gekapselt, zu `window.MentolderDS` gebundelt (Svelte-Runtime inline, `react`→`window.React`), Tailwind v4 kompiliert Tokens + Utilities, Karten/`.d.ts`/`.prompt.md`/Previews werden im Standard-Upload-Layout emittiert. Headless Render-Check als Gate.
- **`.design-sync/`** — durable inputs: `config.json` (projectId-Pin), `NOTES.md` (Gotchas + Re-Sync-Risiken), `conventions.md` (Header für den Design-Agenten), 20 authored Preview-Kompositionen.

## Scope

**20 Komponenten** (Marketing, Navigation, Forms, Feedback, UI) — alle headless gerendert und auf dem absoluten Rubric (styled/complete/plausible) als `good` benotet. `.astro` ausgeschlossen (server-only, nicht client-mountbar).

Re-Sync: `node .ds-sync/gen.mjs && node .ds-sync/render-check.mjs` → upload. Details in `website/.design-sync/NOTES.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)