### PR TITLE
fix(infra): persist G1/G2 hotfixes in repo - networkpolicy ingress and drop empty cost/token panels [T000889]

### DIFF
--- a/k3d/monitoring/grafana-dashboards/factory-otel.json
+++ b/k3d/monitoring/grafana-dashboards/factory-otel.json
@@ -4,32 +4,6 @@
   "schemaVersion": 39,
   "panels": [
     {
-      "id": 1,
-      "title": "Token Usage / Day",
-      "type": "timeseries",
-      "targets": [
-        {
-          "expr": "sum by (model) (rate(claude_code_token_usage{brand=~\"$brand\"}[1d]))",
-          "legendFormat": "{{model}}"
-        }
-      ],
-      "gridPos": { "x": 0, "y": 0, "w": 12, "h": 8 },
-      "fieldConfig": { "defaults": { "unit": "short" } }
-    },
-    {
-      "id": 2,
-      "title": "Cost / Day (USD)",
-      "type": "timeseries",
-      "targets": [
-        {
-          "expr": "sum by (model) (rate(claude_code_cost_usage{brand=~\"$brand\"}[1d]))",
-          "legendFormat": "{{model}}"
-        }
-      ],
-      "gridPos": { "x": 12, "y": 0, "w": 12, "h": 8 },
-      "fieldConfig": { "defaults": { "unit": "currencyUSD" } }
-    },
-    {
       "id": 3,
       "title": "Tickets / Day",
       "type": "stat",
@@ -39,7 +13,7 @@
           "legendFormat": "Ticks"
         }
       ],
-      "gridPos": { "x": 0, "y": 8, "w": 6, "h": 4 }
+      "gridPos": { "x": 0, "y": 0, "w": 6, "h": 4 }
     },
     {
       "id": 4,
@@ -51,7 +25,7 @@
           "legendFormat": "ms"
         }
       ],
-      "gridPos": { "x": 6, "y": 8, "w": 6, "h": 4 },
+      "gridPos": { "x": 6, "y": 0, "w": 6, "h": 4 },
       "fieldConfig": { "defaults": { "unit": "ms" } }
     },
     {
@@ -64,7 +38,7 @@
           "legendFormat": "Escalations"
         }
       ],
-      "gridPos": { "x": 12, "y": 8, "w": 6, "h": 4 }
+      "gridPos": { "x": 12, "y": 0, "w": 6, "h": 4 }
     },
     {
       "id": 6,
@@ -76,7 +50,7 @@
           "legendFormat": "Queue"
         }
       ],
-      "gridPos": { "x": 18, "y": 8, "w": 6, "h": 4 }
+      "gridPos": { "x": 18, "y": 0, "w": 6, "h": 4 }
     },
     {
       "id": 7,
@@ -88,7 +62,7 @@
           "legendFormat": "{{phase}}"
         }
       ],
-      "gridPos": { "x": 0, "y": 12, "w": 12, "h": 8 },
+      "gridPos": { "x": 0, "y": 4, "w": 12, "h": 8 },
       "fieldConfig": { "defaults": { "unit": "ms" } },
       "options": { "orientation": "horizontal", "displayMode": "gradient" }
     },
@@ -102,33 +76,7 @@
           "legendFormat": "{{phase}}/{{state}}"
         }
       ],
-      "gridPos": { "x": 12, "y": 12, "w": 12, "h": 8 }
-    },
-    {
-      "id": 9,
-      "title": "Token Usage by Provider & Model",
-      "type": "timeseries",
-      "targets": [
-        {
-          "expr": "sum by (model) (rate(claude_code_token_usage{brand=~\"$brand\"}[1d]))",
-          "legendFormat": "{{model}}"
-        }
-      ],
-      "gridPos": { "x": 0, "y": 20, "w": 12, "h": 8 }
-    },
-    {
-      "id": 10,
-      "title": "Cost per Ticket (Top 10)",
-      "type": "table",
-      "targets": [
-        {
-          "expr": "topk(10, sum by (ticket_id) (claude_code_cost_usage{brand=~\"$brand\"}))",
-          "legendFormat": "{{ticket_id}}",
-          "format": "table"
-        }
-      ],
-      "gridPos": { "x": 12, "y": 20, "w": 12, "h": 8 },
-      "fieldConfig": { "defaults": { "unit": "currencyUSD" } }
+      "gridPos": { "x": 12, "y": 4, "w": 12, "h": 8 }
     },
     {
       "id": 11,
@@ -140,7 +88,7 @@
           "legendFormat": "{{brand}} ticks"
         }
       ],
-      "gridPos": { "x": 0, "y": 28, "w": 24, "h": 6 }
+      "gridPos": { "x": 0, "y": 12, "w": 24, "h": 6 }
     }
   ],
   "templating": {

--- a/k3d/monitoring/networkpolicy.yaml
+++ b/k3d/monitoring/networkpolicy.yaml
@@ -29,4 +29,10 @@ spec:
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: monitoring
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: website
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: website-korczewski
         - podSelector: {}


### PR DESCRIPTION
## T000889 — Monitoring-Repo-Änderungen

Vier Schritte, die die Live-Hotfixes (G1-G3) dauerhaft im Repo verankern:

### (A) G2: NetworkPolicy Ingress — Website-Namespaces hinzugefügt
`k3d/monitoring/networkpolicy.yaml`
- `website` und `website-korczewski` in `monitoring-allow-ingress-traefik-and-intra` aufgenommen
- Ermöglicht In-App-Prometheus-Queries (`/admin/factory-observability`) aus beiden Brands
- Live-Cluster hatte dies bereits via Hotfix — nächster Re-Deploy hätte es überschrieben

### (B) Cost/Token-Panels entfernt (4 leere Panels)
`k3d/monitoring/grafana-dashboards/factory-otel.json`
- Panels 1 (Token Usage / Day), 2 (Cost / Day), 9 (Token Usage by Provider), 10 (Cost per Ticket) gelöscht
- Diese `claude_code_token_usage` / `claude_code_cost_usage`-Metriken fließen noch nicht (kein OTel-Datensource-Mapping)
- Verbleiben: 7 Panels mit Tick-/Phasen-Metriken (Tickets/Day, Phase Duration, Escalations, Queue Depth, etc.) — alle live getestet

### (C) G3: autopilot.env (host-level, live provisioned)
- `~/.config/factory/autopilot.env` auf WSL-Host konfiguriert (OTLP-Endpoint, Token, Intervalle)
- Repo-Vorlage `scripts/factory/autopilot.env.example` bereits korrekt — kein Code-Change nötig

**Live-Status:** Grafana-Dashboard ✅, In-App erreicht Prometheus (beide Brands) ✅, Tick-/Phasen-Metriken fließen ✅