### PR TITLE
fix(factory): classify new k3d files and fix bats paths

### DIFF
--- a/scripts/factory/service-registry.sh
+++ b/scripts/factory/service-registry.sh
@@ -61,6 +61,11 @@ declare -A SERVICE_REGISTRY=(
   [k3d/website-allow-egress-monitoring.yaml]="website"
   [k3d/cicd-deploy-sa.yaml]="cicd"
   [k3d/llm-gpu.yaml]="llm-gateway"
+  [k3d/mediaviewer-widget.yaml]="mediaviewer-widget"
+  [k3d/oauth2-proxy-mediaviewer.yaml]="mediaviewer-widget"
+  [k3d/oauth2-proxy-videovault.yaml]="videovault"
+  [k3d/videovault-uploads-pvc.yaml]="videovault"
+  [k3d/videovault.yaml]="videovault"
 )
 
 # Infra: namespace/network/secrets/controller — ALWAYS full-deploy, never partial.

--- a/tests/local/FA-SF-38-canary.bats
+++ b/tests/local/FA-SF-38-canary.bats
@@ -1,6 +1,7 @@
 #!/usr/bin/env bats
 # FA-SF-38 — Layer-4 canary/rollback contract (observe_prod in feature-promote.sh)
 SCRIPT="$BATS_TEST_DIRNAME/../../scripts/feature-promote.sh"
+PHASES_SCRIPT="$BATS_TEST_DIRNAME/../../scripts/lib/promote-phases.sh"
 
 setup() { load 'test_helper.bash'; }
 
@@ -10,21 +11,21 @@ setup() { load 'test_helper.bash'; }
 }
 
 @test "FA-SF-38: observe_prod() exists" {
-  run grep -qE '^observe_prod\(\)' "$SCRIPT"
+  run grep -qE '^observe_prod\(\)' "$PHASES_SCRIPT"
   [ "$status" -eq 0 ]
 }
 
 @test "FA-SF-38: observe_prod targets the LIVE site, not dev" {
-  run grep -E 'web\.\$\{?brand|web\.\$\{cluster|web\.mentolder\.de|web\.korczewski\.de' "$SCRIPT"
+  run grep -E 'web\.\$\{?brand|web\.\$\{cluster|web\.mentolder\.de|web\.korczewski\.de' "$PHASES_SCRIPT"
   [ "$status" -eq 0 ]
 }
 
 @test "FA-SF-38: observe_prod captures pre-deploy revision before rollback" {
-  run grep -qE 'rollout history|--to-revision' "$SCRIPT"
+  run grep -qE 'rollout history|--to-revision' "$PHASES_SCRIPT"
   [ "$status" -eq 0 ]
 }
 
 @test "FA-SF-38: observe_prod context comes from env-resolve, never dead prod_ctx" {
-  run grep -qE 'env-resolve\.sh|ENV_CONTEXT' "$SCRIPT"
+  run grep -qE 'env-resolve\.sh|ENV_CONTEXT' "$PHASES_SCRIPT"
   [ "$status" -eq 0 ]
 }


### PR DESCRIPTION
Resolves the test-suite breakages where mediaviewer/videovault k3d config files were unclassified, and points observe_prod bats tests to promote-phases.sh.