### PR TITLE
fix(factory): repair batch workflow-gen IIFE + frontmatter ticket_id derivation

### DIFF
--- a/scripts/batch-workflow-gen.sh
+++ b/scripts/batch-workflow-gen.sh
@@ -147,8 +147,6 @@ Bestätige mit der Ausgabe des Befehls.`,
 ))
 
 return { succeeded: succeeded.length, total: tickets.length, skipped: tickets.length - succeeded.length }
-
-})()
 WORKFLOW_EOF
 
 echo "$OUTPUT"

--- a/scripts/vda/frontmatter.sh
+++ b/scripts/vda/frontmatter.sh
@@ -79,6 +79,20 @@ _body() {
     fi
 }
 
+# Derive the ticket id (TNNNN…) from the plan body (**Ticket:** TNNNN) or, as a
+# fallback, from the filename slug (…-tNNNN.md). Empty when nothing derivable —
+# callers MUST only fill ticket_id when this is non-empty (preserves idempotency
+# for slug-less plans whose ticket_id is a deliberate null).
+_derive_ticket_id() {
+    local tid
+    tid="$(grep -m1 -ioE 'ticket:[*[:space:]]*T[0-9]{4,}' "$FILE" 2>/dev/null \
+        | grep -oiE 'T[0-9]{4,}' | head -1 | tr '[:lower:]' '[:upper:]')"
+    if [[ -z "$tid" ]]; then
+        tid="$(basename "$FILE" .md | grep -oiE 't[0-9]{4,}' | head -1 | tr '[:lower:]' '[:upper:]')"
+    fi
+    printf '%s' "$tid"
+}
+
 # value of KEY inside the frontmatter block (first pair of ---); empty if absent
 _fm_field() {
     awk -v key="$1" '
@@ -109,7 +123,8 @@ if ! _has_frontmatter; then
     {
         printf '%s\n' "---"
         printf 'title: %s\n' "$title"
-        printf 'ticket_id: null\n'
+        tid_new="$(_derive_ticket_id)"
+        if [[ -n "$tid_new" ]]; then printf 'ticket_id: %s\n' "$tid_new"; else printf 'ticket_id: null\n'; fi
         printf 'domains: %s\n' "$domains_yaml"
         printf 'status: active\n'
         printf 'pr_number: null\n'
@@ -130,6 +145,7 @@ fi
 dom_raw="$(_fm_field domains | tr -d ' \t\r')"
 st_raw="$(_fm_field status | tr -d ' \t\r')"
 fl_raw="$(_fm_field file_locks | tr -d ' \t\r')"
+tid_raw="$(_fm_field ticket_id | tr -d ' \t\r')"
 
 needs_domains=0
 case "$dom_raw" in ""|"[]"|"null") needs_domains=1 ;; esac
@@ -138,8 +154,13 @@ case "$st_raw" in ""|"null") needs_status=1 ;; esac
 [[ "$FORCE_ACTIVE" -eq 1 ]] && needs_status=1
 needs_batch=0
 [[ -z "$fl_raw" ]] && needs_batch=1
+# Fill a null/missing ticket_id ONLY when one is derivable — a slug-less plan
+# with a deliberate `ticket_id: null` must stay a clean no-op (idempotency).
+tid_derived="$(_derive_ticket_id)"
+needs_ticket=0
+case "$tid_raw" in ""|"null") [[ -n "$tid_derived" ]] && needs_ticket=1 ;; esac
 
-if [[ "$needs_domains" -eq 0 && "$needs_status" -eq 0 && "$needs_batch" -eq 0 ]]; then
+if [[ "$needs_domains" -eq 0 && "$needs_status" -eq 0 && "$needs_batch" -eq 0 && "$needs_ticket" -eq 0 ]]; then
     echo "Frontmatter already complete in $FILE — nothing to do."
     exit 0
 fi
@@ -151,13 +172,15 @@ derived_yaml="$(_domains_to_yaml "$derived")"
 
 tmpfile="$(mktemp)"
 awk -v derived="$derived_yaml" -v needs_dom="$needs_domains" \
-    -v needs_st="$needs_status" -v needs_batch="$needs_batch" '
-    BEGIN { infm=0; dom_seen=0; st_seen=0; batch_seen=0 }
+    -v needs_st="$needs_status" -v needs_batch="$needs_batch" \
+    -v tid="$tid_derived" -v needs_ticket="$needs_ticket" '
+    BEGIN { infm=0; dom_seen=0; st_seen=0; batch_seen=0; tid_seen=0 }
     { sub(/\r$/,"") }
     NR==1 && $0=="---" { print; infm=1; next }
     infm==1 && $0=="---" {
-        if (needs_dom==1   && dom_seen==0)   print "domains: " derived
-        if (needs_st==1    && st_seen==0)    print "status: active"
+        if (needs_dom==1    && dom_seen==0)    print "domains: " derived
+        if (needs_st==1     && st_seen==0)     print "status: active"
+        if (needs_ticket==1 && tid_seen==0)    print "ticket_id: " tid
         if (needs_batch==1 && batch_seen==0) {
             print "file_locks: []"
             print "shared_changes: false"
@@ -166,6 +189,11 @@ awk -v derived="$derived_yaml" -v needs_dom="$needs_domains" \
             print "depends_on_plans: []"
         }
         print; infm=0; next
+    }
+    infm==1 && $0 ~ /^ticket_id:/ {
+        tid_seen=1
+        if (needs_ticket==1) { print "ticket_id: " tid } else { print }
+        next
     }
     infm==1 && $0 ~ /^domains:/ {
         dom_seen=1

--- a/tests/unit/plan-frontmatter-hook.bats
+++ b/tests/unit/plan-frontmatter-hook.bats
@@ -229,3 +229,78 @@ EOF
   [ "$status" -eq 0 ]
   [ "$before" == "$(cat "$TMP/g-spec.md")" ]
 }
+
+# ── ticket_id derivation (the T000886 batch bug) ─────────────────────
+
+@test "no frontmatter: ticket_id derived from body **Ticket:** line, not null" {
+  cat > "$TMP/h-body-ticket.md" <<'EOF'
+# Plan — Some Feature
+
+**Ticket:** T000886
+**Branch:** feature/t000886
+
+Touches scripts/ and skills.
+EOF
+  run bash "$HOOK" "$TMP/h-body-ticket.md"
+  [ "$status" -eq 0 ]
+  grep -q '^ticket_id: T000886$' "$TMP/h-body-ticket.md"
+  ! grep -Eq '^ticket_id: *null' "$TMP/h-body-ticket.md"
+}
+
+@test "no frontmatter: ticket_id derived from filename slug when body lacks it" {
+  cat > "$TMP/2026-06-16-t000884.md" <<'EOF'
+# Plan — Loops
+
+Touches scripts/factory and tests/.
+EOF
+  run bash "$HOOK" "$TMP/2026-06-16-t000884.md"
+  [ "$status" -eq 0 ]
+  grep -q '^ticket_id: T000884$' "$TMP/2026-06-16-t000884.md"
+}
+
+@test "incomplete frontmatter: null ticket_id is repaired when derivable from body" {
+  cat > "$TMP/i-null-ticket.md" <<'EOF'
+---
+title: Repair me
+ticket_id: null
+domains: []
+status: active
+---
+
+# Plan
+
+**Ticket:** T000999
+
+Touches k3d/ manifests.
+EOF
+  run bash "$HOOK" "$TMP/i-null-ticket.md"
+  [ "$status" -eq 0 ]
+  grep -q '^ticket_id: T000999$' "$TMP/i-null-ticket.md"
+  # domains were also re-derived (infra), proving combined repair
+  grep -Eq '^domains:.*infra' "$TMP/i-null-ticket.md"
+}
+
+@test "ticket_id null stays null (idempotent) when NOT derivable from body or slug" {
+  cat > "$TMP/j-undeterminable.md" <<'EOF'
+---
+title: Generic
+ticket_id: null
+domains: [infra]
+status: active
+pr_number: null
+file_locks: []
+shared_changes: false
+batch_id: null
+parent_feature: null
+depends_on_plans: []
+---
+
+# Plan
+
+Touches k3d/ manifests.
+EOF
+  before="$(cat "$TMP/j-undeterminable.md")"
+  run bash "$HOOK" "$TMP/j-undeterminable.md"
+  [ "$status" -eq 0 ]
+  [ "$before" = "$(cat "$TMP/j-undeterminable.md")" ]
+}


### PR DESCRIPTION
## Was

Zwei `dev-flow-batch`-Tooling-Bugs, aufgedeckt durch den T000884–886-Batch-Run.

### 1. `scripts/batch-workflow-gen.sh` — verwaistes `})()`
Der Generator hängte ein `})()` ohne öffnendes IIFE an → **jeder** generierte Batch-Workflow scheiterte am Harness-Parse (`Unexpected token`). Die Workflow-Harness wrappt den Body in eine async-Funktion (top-level `return`/`await` sind by-design erlaubt), das `})()` war reine Breakage. Entfernt.

> Hinweis: `node --check` ist **kein** gültiges Gate für diese Scripts — es lehnt das by-design top-level `return` ab. Beweis ist die erfolgreiche Harness-Ausführung.

### 2. `scripts/vda/frontmatter.sh` — `ticket_id` immer `null`
Der Hook setzte `ticket_id` hart auf `null` und leitete es nie ab. Pläne, deren Spec-Agent kein Frontmatter schrieb (Case A), bekamen `ticket_id: null` → bricht `plan-context.sh`/GH-Action-Routing (traf T000886). Neu: `_derive_ticket_id` (Body `**Ticket:**`-Zeile, Slug-Fallback `…-tNNNN.md`); füllt in Case A **und** im Repair-Pfad — aber **nur** wenn ableitbar, damit ein bewusstes slug-loses `null` idempotent bleibt.

## Tests
- 4 neue bats-Fälle in `tests/unit/plan-frontmatter-hook.bats`
- **16/16** unit + **4/4** batch frontmatter-Tests grün
- `bash -n` beide Scripts; Generator erzeugt parsebaren Workflow (Harness-verifiziert)

🤖 Generated with [Claude Code](https://claude.com/claude-code)