### PR TITLE
feat(ops): interaktive Plan-Review-UI mit render/annotate/submit [T000886]

### DIFF
--- a/.claude/skills/dev-flow-plan/SKILL.md
+++ b/.claude/skills/dev-flow-plan/SKILL.md
@@ -200,7 +200,31 @@ git commit -m "chore(plans): stage <slug> for execution [$TICKET_EXT_ID]"
 git push -u origin $(git branch --show-current)
 ```
 
-### Schritt 6: Batch-Status prüfen und Ausführungsoptionen anzeigen
+### Schritt 6: Optionaler Plan-Review (interaktiv)
+
+Bevor du den Plan committest und Ausführungsoptionen anzeigst, kannst du den Plan
+annotierbar rendern und im Browser reviewen (additiv/optional; der bestehende
+STOP-Text in Schritt 5 bleibt der Default):
+
+```bash
+bash scripts/plan-review/plan-review.sh render docs/superpowers/plans/<date>-<slug>.md
+```
+
+Im Browser: Text markieren → annotieren (Durchstreichen/Ersetzen/Einfügen/Kommentar) →
+✓ Approve oder ↺ Änderungen anfordern. Danach das Ergebnis einlesen:
+
+```bash
+bash scripts/plan-review/plan-review.sh result
+```
+
+- **approve**: `{verdict:"approve"}` → fahre mit Schritt 6 fort (Ausführungsoptionen).
+- **request-changes**: `{verdict:"request-changes", annotations:[…]}` → die
+  Annotationen als Änderungsauftrag an einen Plan-Schreib-Agenten übergeben,
+  1 Revisions-Runde, dann erneut rendern und reviewen. Wiederhole bis approve.
+
+Details siehe [plan-review-ui.md](file:///home/patrick/Bachelorprojekt/.claude/skills/references/plan-review-ui.md).
+
+### Schritt 6.5: Batch-Status prüfen und Ausführungsoptionen anzeigen
 
 Prüfe ob weitere Pläne in der Kommissionierung warten und zeige dem User die Batch-Ausführungsoptionen:
 

--- a/.claude/skills/references/plan-review-ui.md
+++ b/.claude/skills/references/plan-review-ui.md
@@ -1,0 +1,67 @@
+# Plan-Review-UI — Render → Review → Verdict → (Revise | Execute)
+
+## Overview
+
+The Plan Review UI lets you visually review a plan file line-by-line in a local
+browser, annotate changes (strike/replace/insert lines, comment), and submit a
+verdict (`approve` or `request-changes`) over the existing loopback `/submit`
+channel. No external service, no DB, no network.
+
+## Flow
+
+1. **Render**
+   ```bash
+   bash scripts/plan-review/plan-review.sh render docs/superpowers/plans/<plan.md>
+   ```
+   → Opens the plan in the Companion board with line-numbered HTML.
+
+2. **Review & annotate** in the browser:
+   - Select text → sidebar op buttons (Durchstreichen, Ersetzen, Einfügen, Kommentar)
+   - Annotations appear in the sidebar (removable)
+   - Submit ✓ Approve or ↺ Änderungen anfordern
+
+3. **Read verdict**
+   ```bash
+   bash scripts/plan-review/plan-review.sh result
+   ```
+   → `jq`-formatted `{kind, verdict, annotations, plan}`
+   - `approve` → proceed with execution
+   - `request-changes` → apply annotations, 1 revision round, re-render
+
+## Files
+
+| File | Role |
+|------|------|
+| `scripts/plan-review/render-plan.mjs` | Pure Node Markdown→HTML renderer |
+| `scripts/plan-review/annotate-client.js` | Vanilla-JS annotation client (embedded in HTML) |
+| `scripts/plan-review/plan-review.sh` | CLI wrapper: `render` / `result` |
+| `scripts/tests/plan-review-smoke.sh` | Server smoke test |
+
+## Security
+
+- **Loopback-only gate**: the annotation client activates only on
+  `http://localhost|127.0.0.1` with `__BRAINSTORM_SUBMIT_PORT` set (injected by
+  server). Public pages (https via funnel) never see the annotation UI.
+- **Server-side**: the plan-review fields (`annotations`, `verdict`) are added
+  only when `ev.kind === 'plan-review'`. Regular brainstorm submit payloads are
+  unaffected.
+- **No hardcoded hostnames**: the board host comes from `brainstorm.sh`; the
+  submit port from the server-injected `__BRAINSTORM_SUBMIT_PORT`.
+
+## Payload Contract
+
+POST `http://localhost:<submitPort>/submit`:
+```json
+{
+  "kind": "plan-review",
+  "plan": "Plan title",
+  "verdict": "approve|request-changes",
+  "annotations": [
+    {"op": "strike|replace|insert|comment", "fromLine": 3, "toLine": 5,
+     "text": "…", "reason": "…", "position": "before|after"}
+  ],
+  "nonce": "<unique>",
+  "screen": "<path>",
+  "markdown": "«PLAN-REVIEW»\\nVerdict: approve\\n..."
+}
+```

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -290,6 +290,8 @@ tasks:
       - task: test:unit:readiness-webhook
       - task: test:unit:staging
       - task: test:unit:api-auth-gate
+      - task: test:unit:brainstorm-submit-smoke
+      - task: test:unit:plan-review-smoke
 
   test:unit:build-graph:
     internal: true
@@ -330,6 +332,16 @@ tasks:
     internal: true
     cmds:
       - ./tests/unit/lib/bats-core/bin/bats tests/unit/api-auth-gate.bats
+
+  test:unit:brainstorm-submit-smoke:
+    internal: true
+    cmds:
+      - bash scripts/tests/brainstorm-submit-smoke.sh
+
+  test:unit:plan-review-smoke:
+    internal: true
+    cmds:
+      - bash scripts/tests/plan-review-smoke.sh
 
   test:unit:ticket-triage:
     internal: true

--- a/docs/superpowers/plans/2026-06-16-t000886.md
+++ b/docs/superpowers/plans/2026-06-16-t000886.md
@@ -4,11 +4,11 @@ ticket_id: T000886
 domains: [ops]
 status: active
 pr_number: null
-file_locks: []
+file_locks: [Taskfile.yml, website/src/data/test-inventory.json]
 shared_changes: false
-batch_id: null
+batch_id: batch-2026-06-16-planning
 parent_feature: null
-depends_on_plans: []
+depends_on_plans: [2026-06-16-t000885]
 ---
 
 # Plan — T000886: Interaktive Plan-Review-UI vor dev-flow-execute
@@ -179,3 +179,17 @@ wir halten die Regel trotzdem ein.
 - [ ] `task freshness:regenerate` (generierte Artefakte: test-inventory, repo-index, …).
 - [ ] `task freshness:check` (CI-Äquivalent: Freshness + `quality:check` S1–S4-Ratchet +
       Baseline-Key-Count-Assertion). Muss grün sein, bevor PR.
+
+## Parallelorchestration (Batch `batch-2026-06-16-planning`)
+
+Teil des 3er-Batches **T000884 ∥ T000885 ∥ T000886**. Code-Dateien sind disjunkt; parallele
+Ausführung ist sicher. Dieser Plan teilt sich `Taskfile.yml` mit T000885 → als **letztes** mergen:
+
+- **`Taskfile.yml`:** dieser Plan ergänzt `test:unit:*`-Subtasks; T000885 ergänzt `factory:usage` —
+  **disjunkte Sektionen**. `depends_on_plans: [2026-06-16-t000885]` dokumentiert die Reihenfolge:
+  **nach** T000885 mergen, vorher auf `main` rebasen (trivialer 3-way-Merge der Taskfile-Sektionen).
+- **FA-SF-Nummern:** dieser Plan nutzt **keine** FA-SF-Nummer (Tests unter `scripts/tests/`) →
+  keine Kollision mit T000884 (56) / T000885 (54/55).
+- **`website/src/data/test-inventory.json`:** generiert, von allen drei berührt. Nach jedem Rebase
+  **`task test:inventory`** neu, niemals hand-mergen.
+- Empfohlene Merge-Reihenfolge: **T000884 → T000885 → T000886**.

--- a/docs/superpowers/plans/2026-06-16-t000886.md
+++ b/docs/superpowers/plans/2026-06-16-t000886.md
@@ -1,7 +1,7 @@
 ---
 title: Plan — T000886: Interaktive Plan-Review-UI vor dev-flow-execute
-ticket_id: null
-domains: [website, infra, db, test]
+ticket_id: T000886
+domains: [ops]
 status: active
 pr_number: null
 file_locks: []

--- a/docs/superpowers/plans/2026-06-16-t000886.md
+++ b/docs/superpowers/plans/2026-06-16-t000886.md
@@ -1,0 +1,181 @@
+---
+title: Plan — T000886: Interaktive Plan-Review-UI vor dev-flow-execute
+ticket_id: null
+domains: [website, infra, db, test]
+status: active
+pr_number: null
+file_locks: []
+shared_changes: false
+batch_id: null
+parent_feature: null
+depends_on_plans: []
+---
+
+# Plan — T000886: Interaktive Plan-Review-UI vor dev-flow-execute
+
+**Ticket:** T000886
+**Branch:** feature/t000886
+**Spec:** docs/superpowers/specs/2026-06-16-t000886-design.md
+**Domain:** ops · **Shared-Changes:** nein
+
+## Ziel
+
+Die bestehende Brainstorm-Companion-Infra (WSL-Bridge) zu einer **annotierbaren Plan-Review-UI**
+ausbauen, die das Zeile-für-Zeile-Abnicken vor `dev-flow-execute` ablöst: Ein Plan wird als
+zeilennummeriertes HTML im Browser geöffnet, Text lässt sich markieren →
+durchstreichen/ersetzen/einfügen/kommentieren → `approve` oder `request-changes`. Die Annotationen
+fließen als strukturiertes Operations-JSON über den **bestehenden** loopback-`/submit`-Pfad zurück
+in den Orchestrator. Voll lokal/offline.
+
+## Architektur
+
+```
+plan.md
+  │  scripts/plan-review/render-plan.mjs   (pure, kein Netz/NPM)
+  ▼
+plan-<ts>.html  (jede Quellzeile = <…data-line=N>)  +  annotate-client.js
+  │  scripts/plan-review/plan-review.sh render → scripts/vda/brainstorm.sh show
+  ▼
+Companion-Board (0.0.0.0, loopback-http)  ── Reviewer markiert + annotiert
+  │  POST /submit  { kind:"plan-review", verdict, annotations[] }   (Origin-Allowlist)
+  ▼
+server.cjs (gepatcht via superpowers-submit-patch.sh)
+  ├─ state/submission.json  (annotations+verdict additiv)
+  └─ clip.exe ← «PLAN-REVIEW»-Markdown
+        │  scripts/plan-review/plan-review.sh result
+        ▼
+dev-flow-plan Schritt 6:  approve → execute-Optionen | request-changes → 1 Revisions-Runde
+```
+
+**Prinzip:** rein additiv. Kein zweiter Port, keine neue Server-Komponente — der bestehende
+`/submit`-Listener und der Companion-`show`-Pfad werden wiederverwendet. Der öffentliche
+Funnel/WS-Pfad und `HARDEN_PUBLIC` bleiben unangetastet (Annotation rendert nur auf loopback-`http`).
+
+## Tech-Stack
+
+- **Renderer:** Node `.mjs`, eingebauter Minimal-Markdown→HTML (Headings, Listen, Checkboxen,
+  Code-Fences, Absätze) — bewusst **kein** NPM-Markdown-Dep (offline, keine Supply-Chain, keine
+  Import-Zyklen). Pure Funktionen, kein Import auf DB-/API-Schichten (S2).
+- **Client:** Vanilla-JS (wie `helper-submit.js`), Selection-API + Sidebar, postet auf `/submit`.
+- **Server-Patch:** additive Anchor-Passage in `superpowers-submit-patch.sh` (Marker
+  `plan-review-server v1`), failt sicher bei Plugin-Drift wie der bestehende Patch.
+- **CLI:** Bash-Wrapper über `scripts/vda/brainstorm.sh` (keine Tunnel-/Service-Duplikation).
+- **Tests:** BATS/Bash-Smoke (`mktemp -d`, außerhalb des Trees), im Taskfile verdrahtet.
+
+## S1-Zeilenbudget (wirksame Schwelle pro zu ändernder Datei)
+
+| Datei | Ist | wirksame Schwelle | Budget | Plan |
+|-------|-----|-------------------|--------|------|
+| `scripts/superpowers-submit-patch.sh` (ändern) | 179 | 500 (`.sh`, nicht-baselined) | ~321 | additive Passage ~40 Z → unkritisch |
+| `scripts/plan-review/render-plan.mjs` (neu) | 0 | 500 (`.mjs`) | <500 | Renderer + Minimal-MD, Ziel <~280 Z (Reserve) |
+| `scripts/plan-review/annotate-client.js` (neu) | 0 | 600 (`.js`) | <600 | Selection+Sidebar+Submit, Ziel <~330 Z |
+| `scripts/plan-review/plan-review.sh` (neu) | 0 | 500 (`.sh`) | <500 | dünner Wrapper, Ziel <~120 Z |
+| `scripts/tests/plan-review-smoke.sh` (neu) | 0 | 500 (`.sh`) | <500 | Ziel <~90 Z |
+| `Taskfile.yml` (ändern) | — | kein S1-Gate | — | 2 neue Task-Einträge |
+| `.claude/skills/dev-flow-plan/SKILL.md` (ändern) | 390 | kein S1-Gate (.md) | — | ~10 Z Verweis |
+| `.claude/skills/references/plan-review-ui.md` (neu) | 0 | kein S1-Gate (.md) | — | Referenzdoc |
+
+> Liegt eine neue Datei beim Schreiben über ~80 % ihrer Schwelle, **echt aufteilen** (z. B. Renderer
+> vs. Minimal-MD-Helper in zwei Module) statt Zeilen zusammenzuziehen. Beim Schreiben jeweils
+> `wc -l` gegenchecken.
+
+## S3 / Hardcodierte Hostnamen
+
+Renderer/Client/CLI dürfen **keine** `*.mentolder.de`/`*.korczewski.de`-Literale enthalten. Der
+Board-Host kommt ausschließlich aus `brainstorm.sh` (das den MagicDNS/Port selbst auflöst); der
+Client postet relativ auf `http://localhost:<__BRAINSTORM_SUBMIT_PORT>` (vom Server injiziert) —
+keine Domain im Code. `scripts/plan-review/` liegt nicht unter `k3d/`/`prod*/`/`website/src/`, aber
+wir halten die Regel trotzdem ein.
+
+## S4 / Orphan-Vermeidung
+
+- `render-plan.mjs`, `plan-review.sh`, `annotate-client.js` werden von `plan-review.sh` bzw.
+  voneinander referenziert und von der Referenzdoc + `dev-flow-plan/SKILL.md` aus erreichbar.
+- `plan-review-smoke.sh` **und** der bisher verwaiste `brainstorm-submit-smoke.sh` werden in
+  `Taskfile.yml` als `test:unit:*`-Subtasks verdrahtet (beide in der `test:unit`-Liste).
+
+---
+
+## Tasks
+
+### Task 1 — Plan→HTML-Renderer (pure, offline)
+
+- [ ] `scripts/plan-review/render-plan.mjs` anlegen: liest Plan-`.md` (arg), gibt eigenständiges
+      HTML auf stdout (oder `--out <file>`).
+- [ ] Minimal-Markdown→HTML inline (Headings `#..####`, `- [ ]/[x]` Checkboxen, ungeordnete/geordnete
+      Listen, ``` Code-Fences, Absätze, Inline-`code`). Bewusst **kein** NPM-Markdown-Dep.
+- [ ] Jede **Quellzeile** als ankerbares Element rendern: `<div class="ln" data-line="N">…</div>`
+      mit sichtbarer Zeilennummer, damit Annotationen einen stabilen Zeilen-Span haben.
+- [ ] `<script>`-Tag mit Inhalt von `annotate-client.js` einbetten (Datei einlesen + inline) — der
+      Companion liefert das HTML statisch aus, daher muss der Client im Dokument selbst stecken.
+- [ ] Pure Funktionen, keine Imports auf DB/API/Netz (S2). `wc -l` prüfen; >~80 % von 500 → Minimal-MD
+      in `render-md.mjs` auslagern und importieren.
+
+### Task 2 — Annotations-Client (Vanilla-JS)
+
+- [ ] `scripts/plan-review/annotate-client.js` anlegen (Muster: `helper-submit.js`).
+- [ ] Loopback-Gate: nur auf `http://localhost|127.0.0.1` aktiv **und** wenn
+      `window.__BRAINSTORM_SUBMIT_PORT` gesetzt (exakt wie `helper-submit.js`).
+- [ ] Selektion über `data-line`-Elemente erfassen → `fromLine`/`toLine`. Vier Op-Buttons:
+      `strike`, `replace` (Prompt/Feld für Ersatztext), `insert` (Text + `position` vor/nach),
+      `comment` (Freitext). Jede Annotation mit optionaler `reason`.
+- [ ] Sidebar-Panel listet Annotationen (entfernbar). Footer-Buttons `✓ Approve` und
+      `↺ Änderungen anfordern`.
+- [ ] POST auf `http://localhost:<submitPort>/submit` mit
+      `{kind:"plan-review", plan, verdict, annotations, nonce, screen}` + Markdown-Feld
+      (`«PLAN-REVIEW»`-Format clientseitig vorgebaut, Server nutzt es für `clip.exe`).
+- [ ] Feedback-Note wie beim Submit-Button (kopiert → Strg+V).
+
+### Task 3 — Server-Patch erweitern (additives Schema)
+
+- [ ] `scripts/superpowers-submit-patch.sh`: neue Marker-guarded Anchor-Passage
+      (`/* plan-review-server v1 */`), die im `handleSubmit`-Block `annotations` (Array) und
+      `verdict` (String) ins persistierte `submission.json`-Objekt aufnimmt — **additiv** zu
+      `selected`/`fields`, ohne den bestehenden Anchor zu verändern.
+- [ ] Anchor muss exakt 1× matchen (die `missing.length`-Prüfung im Skript greift sonst) → einen
+      stabilen, eindeutigen Substring im erzeugten `handleSubmit`-Body wählen.
+- [ ] `node --check` auf den gepatchten `server.cjs` muss grün bleiben (der Smoke-Test prüft das).
+
+### Task 4 — CLI-Wrapper
+
+- [ ] `scripts/plan-review/plan-review.sh` anlegen: `render <plan.md>` →
+      `node render-plan.mjs <plan> --out <tmp.html>` → `scripts/vda/brainstorm.sh show <tmp.html>`;
+      `result` → `scripts/vda/brainstorm.sh submission` lesen und Annotationen+Verdict ausgeben
+      (jq, fail-soft wenn noch nichts da). Keine Tunnel-/Service-Logik duplizieren.
+- [ ] `set -euo pipefail`, absolute Pfade relativ zu `$(dirname "$0")`.
+
+### Task 5 — Smoke-Test + Taskfile-Verdrahtung
+
+- [ ] `scripts/tests/plan-review-smoke.sh` anlegen (Muster: `brainstorm-submit-smoke.sh`): gepatchten
+      Server in `mktemp -d` booten (Fixtures außerhalb des Repo-Trees, teardown-Cleanup), einen
+      `plan-review`-Payload (Annotationen + verdict) auf `/submit` posten, prüfen:
+      `submission.json` enthält `annotations`+`verdict` (mode 600), `events`-Zeile, Bad-Origin→403,
+      Nonce-Dedupe, `node --check` grün.
+- [ ] `Taskfile.yml`: zwei neue `test:unit:*`-Subtasks (`test:unit:plan-review-smoke`,
+      `test:unit:brainstorm-submit-smoke`) anlegen und **beide** in die `test:unit`-Deps-Liste
+      aufnehmen (behebt auch den bestehenden Orphan von `brainstorm-submit-smoke.sh`).
+
+### Task 6 — dev-flow-Integration + Referenzdoc
+
+- [ ] `.claude/skills/references/plan-review-ui.md` anlegen: render→review→verdict→(revise|execute),
+      Befehle (`plan-review.sh render/result`), Payload-/Markdown-Vertrag, loopback-only-Sicherheit.
+- [ ] `.claude/skills/dev-flow-plan/SKILL.md` Schritt 6: optionale Plan-Review-Stufe ergänzen
+      (Plan rendern → Board zeigen → `verdict` lesen; `approve` → bestehende Ausführungsoptionen;
+      `request-changes` → Annotationen als Änderungsauftrag an den Plan-Schreib-Agenten,
+      1 Revisions-Runde, dann erneut rendern). Auf `plan-review-ui.md` verlinken. Bestehender
+      STOP-Text bleibt als Default (Review ist additiv/optional).
+
+### Task 7 — Verifikation (CI-Äquivalent — Pflicht)
+
+- [ ] `bash scripts/superpowers-submit-patch.sh --check` (Patch-Idempotenz/Drift) und
+      `bash scripts/tests/plan-review-smoke.sh` + `bash scripts/tests/brainstorm-submit-smoke.sh`
+      lokal grün.
+- [ ] `task test:unit:plan-review-smoke` und `task test:unit:brainstorm-submit-smoke` laufen über
+      die neue Taskfile-Verdrahtung.
+- [ ] Nach Test-Änderungen: `task test:inventory` regenerieren und
+      `website/src/data/test-inventory.json` mitcommitten.
+- [ ] `task test:changed` (gezielte Tests für geänderte Domains — hier `scripts/` → `test:unit`,
+      plus `task test:code-quality` für S1–S4).
+- [ ] `task freshness:regenerate` (generierte Artefakte: test-inventory, repo-index, …).
+- [ ] `task freshness:check` (CI-Äquivalent: Freshness + `quality:check` S1–S4-Ratchet +
+      Baseline-Key-Count-Assertion). Muss grün sein, bevor PR.

--- a/docs/superpowers/specs/2026-06-16-t000886-design.md
+++ b/docs/superpowers/specs/2026-06-16-t000886-design.md
@@ -1,0 +1,138 @@
+# Spec — T000886: Interaktive Plan-Review-UI vor dev-flow-execute (plannotator-Muster)
+
+**Ticket:** T000886
+**Domain:** ops
+**Shared-Changes:** nein (voll lokal/offline — keine `configmap-domains.yaml`/`schema.yaml`/`kustomization.yaml`)
+**Quelle:** Ticket-Beschreibung + Grounding im bestehenden Companion-Code (kein Brainstorm-Bedarf,
+`offene_fragen_geklaert`). Inspiration: plannotator (`backnotprop/plannotator`),
+open-plan-annotator (`ndom91/open-plan-annotator`).
+
+## 1. Problem
+
+Heute wird ein Implementierungsplan vor `dev-flow-execute` im Terminal "abgenickt": Der Plan wird als
+`docs/superpowers/plans/<date>-<slug>.md` committet/gepusht und der Skill stoppt mit einer
+Text-Optionsliste (`dev-flow-plan` Schritt 5/6). Es gibt keinen Weg, **gezielt über den Plantext zu
+annotieren** — eine Zeile durchstreichen, eine Formulierung ersetzen, eine Einfügung oder einen
+Kommentar an genau eine Stelle hängen. Der Reviewer kann nur global "passt" oder "ändere X" sagen
+und muss die Stelle in Prosa beschreiben. Das ist das Zeile-für-Zeile-Abnicken, das dieser Task
+ablösen soll.
+
+Die bestehende Brainstorm-Companion-Infrastruktur (WSL-Bridge) ist der natürliche Unterbau, kann
+aber heute **nur Selektionen und Formularfelder** zurückmelden (`gatherSelection` in
+`scripts/superpowers-submit/helper-submit.js`), **keine Prosa-Annotationen über ein Dokument**.
+
+## 2. Grounding (verifiziert im Code)
+
+- **Companion-Server** ist reif: `scripts/vda/brainstorm.sh` (Fork des superpowers-Companion) bindet
+  `0.0.0.0`, pusht HTML-Screens via `show <file>` (Auto-Reload aus `content/`), läuft
+  zug-wechsel-fest (`BRAINSTORM_OWNER_PID=1`) und hat einen **loopback-only** `/submit`-Listener
+  (`127.0.0.1`, Origin-Allowlist, 32 KiB Body-Cap, Nonce-Dedupe) der nach
+  `state/submission.json` schreibt + `clip.exe` füttert + eine `events`-Zeile anhängt.
+- **Patch-Pipeline:** `scripts/superpowers-submit-patch.sh` injiziert idempotent (Marker-guarded)
+  den Submit-Channel in den Plugin-Cache: `helper-submit.js` ans `helper.js` anhängen +
+  `handleSubmit`/`startSubmitListener`/Port-Injection in `server.cjs`. Der Anchor-Mechanismus
+  failt sicher (`anchors not unique/found`), wenn sich das Plugin ändert.
+- **Submit-Vertrag heute:** Browser-Button `✓ Auswahl ans Terminal` → `gatherSelection()` baut
+  `{question, selected, fields}` + Markdown → POST `/submit` → `submission.json`. Der Server
+  validiert nur `markdown`/`nonce`/`selected`/`fields` — das Schema ist erweiterbar.
+- **STOP-Gate:** `.claude/skills/dev-flow-plan/SKILL.md` Schritt 5 committet/pusht den Plan, Schritt 6
+  zeigt Ausführungsoptionen und stoppt. Hier wird das Plan-Review eingehängt.
+- **Smoke-Test-Muster:** `scripts/tests/brainstorm-submit-smoke.sh` bootet einen gepatchten Server in
+  `mktemp -d` und übt den `/submit`-Pfad (403/200/dedupe). Noch **nicht** im Taskfile verdrahtet
+  (Orphan — wird in diesem Task mit-behoben).
+
+## 3. Lösung (Scope)
+
+Die bestehende Companion-Infra zur **annotierbaren Plan-Review-UI** ausbauen — additiv, nicht
+ersetzend:
+
+1. **Plan→HTML-Renderer** (`scripts/plan-review/render-plan.mjs`): liest eine Plan-`.md`, rendert sie
+   als zeilennummeriertes, markierbares HTML-Dokument (jede Quellzeile = eigenes ankerbares Element
+   mit `data-line`). Schreibt eine eigenständige HTML-Datei nach `state/`/`content/`, die der
+   Companion via `show` ausliefert. Reines lokales Rendering, kein Netz, kein Markdown-NPM-Dep
+   (minimaler eingebauter Renderer für Headings/Listen/Code-Fences/Checkboxen — genug für unsere
+   Pläne).
+2. **Annotations-Client** (`scripts/plan-review/annotate-client.js`): client-seitiges JS, das im
+   gerenderten Plan Textselektion erlaubt und vier Operationen erfasst —
+   `strike` (durchstreichen), `replace` (ersetzen, mit Ersatztext), `insert` (einfügen, mit Text,
+   vor/nach einer Zeile), `comment` (Freitext-Kommentar). Jede Annotation hat einen **Zeilen-Span**
+   (`fromLine`,`toLine`) bzw. einen Anker und eine Freitext-Begründung. Ein Sidebar-Panel listet
+   alle Annotationen; Buttons `✓ Approve` und `↺ Änderungen anfordern` (= Annotationen zurück).
+3. **Submit-Schema-Erweiterung:** Der Annotations-Client postet auf denselben **bestehenden**
+   `/submit`-Pfad ein neues JSON-Feld `annotations: [{op, fromLine, toLine, anchor?, text?,
+   reason?}]` plus `verdict: "approve" | "request-changes"`. Der Server-Patch
+   (`superpowers-submit-patch.sh`) wird um eine additive Schema-Passage erweitert
+   (`annotations`/`verdict` in das persistierte `submission.json` aufnehmen). Bestehende
+   Selektions-/Feld-Pfade bleiben unverändert.
+4. **Operations-Markdown:** Der Server rendert für `clip.exe`/Terminal ein strukturiertes
+   `«PLAN-REVIEW»`-Markdown-Block-Format (analog `«BRAINSTORM-AUSWAHL»`), das die Annotationen als
+   gezielte Diff-/Patch-Anweisungen pro Zeile zusammenfasst — der Orchestrator liest das als
+   Änderungsauftrag.
+5. **CLI-Front-End** (`scripts/plan-review/plan-review.sh`): `render <plan.md>` (rendert + pusht via
+   `brainstorm.sh show`), `result` (gibt `submission.json` → Annotationen+Verdict aus). Dünner
+   Wrapper über `brainstorm.sh` — keine Duplizierung der Tunnel-/Service-Logik.
+6. **dev-flow-plan-Integration:** Schritt 6 (STOP-Gate) erhält eine optionale Plan-Review-Stufe:
+   Plan rendern → Board zeigen → auf `verdict` warten. `approve` → Ausführungsoptionen wie bisher.
+   `request-changes` → Annotationen als Änderungsauftrag an den Plan-Schreib-Agenten zurück
+   (eine Revisions-Runde), dann erneut rendern. Beschrieben als Referenz
+   (`.claude/skills/references/plan-review-ui.md`), im SKILL.md verlinkt.
+
+## 4. Nicht-Ziele
+
+- Keine Änderung am öffentlichen Funnel/WS-Pfad oder an `HARDEN_PUBLIC` (Annotation rendert nur auf
+  dem loopback-`http`-Board, exakt wie der Submit-Button heute — Origin-Allowlist bleibt).
+- Kein automatisches Anwenden der Annotationen auf die Plan-`.md` (der Orchestrator/Schreib-Agent
+  setzt sie um — Mensch-im-Loop bleibt).
+- Keine neue Server-Komponente, kein zweiter Port: ausschließlich Wiederverwendung des bestehenden
+  `/submit`-Listeners + Companion-`show`-Pfads.
+- Keine `configmap-domains.yaml`/`schema.yaml`/`kustomization.yaml`-Änderung; keine Brand-Domain im
+  Code.
+
+## 5. Vertrag / Datenmodell
+
+Submit-Payload (additiv zum bestehenden Schema):
+
+```json
+{
+  "kind": "plan-review",
+  "plan": "docs/superpowers/plans/2026-06-16-t000886.md",
+  "verdict": "approve | request-changes",
+  "annotations": [
+    { "op": "strike",   "fromLine": 42, "toLine": 42, "reason": "redundant" },
+    { "op": "replace",  "fromLine": 51, "toLine": 53, "text": "…neuer Text…", "reason": "…" },
+    { "op": "insert",   "anchor": 60, "position": "after", "text": "…", "reason": "…" },
+    { "op": "comment",  "fromLine": 12, "toLine": 12, "reason": "Frage: …" }
+  ],
+  "nonce": "…", "ts": 0
+}
+```
+
+Terminal-Markdown (`clip.exe`):
+
+```
+«PLAN-REVIEW» <plan-pfad>  Verdict: request-changes
+- [strike L42] redundant
+- [replace L51-53] → "…neuer Text…"  (Grund: …)
+- [insert nach L60] "…"  (Grund: …)
+- [comment L12] Frage: …
+«ENDE»
+```
+
+## 6. Akzeptanzkriterien
+
+- **AK1** `render-plan.mjs <plan.md>` erzeugt eigenständiges HTML, jede Quellzeile als `data-line`
+  ankerbares Element; kein externes NPM-/Netz-Dep.
+- **AK2** Annotations-Client erfasst alle vier Ops mit Zeilen-Span + Begründung und einen Verdict;
+  rendert/sendet **nur** auf loopback-`http` (Origin-Allowlist greift wie beim Submit-Button).
+- **AK3** Der gepatchte Server persistiert `annotations`+`verdict` in `submission.json` und schreibt
+  das `«PLAN-REVIEW»`-Markdown in die Zwischenablage; bestehende Selektions-/Feld-Pfade bleiben grün
+  (`brainstorm-submit-smoke.sh` weiter ok).
+- **AK4** `plan-review.sh render <plan>` pusht über `brainstorm.sh show`; `plan-review.sh result`
+  gibt Annotationen+Verdict strukturiert aus.
+- **AK5** Ein neuer Smoke-Test (`plan-review-smoke.sh`) bootet den gepatchten Server, postet einen
+  Annotations-Payload und prüft Persistenz + Markdown; **im Taskfile verdrahtet** (kein Orphan).
+  Der bestehende `brainstorm-submit-smoke.sh` wird in derselben PR mit-verdrahtet.
+- **AK6** `dev-flow-plan` Schritt 6 referenziert die optionale Review-Stufe; Referenzdoc beschreibt
+  render→review→verdict→(revise|execute).
+- **AK7** S1–S4 grün: keine Datei über wirksamer Schwelle, keine Brand-Domain-Literale, neue
+  Skripte/Tests von Taskfile referenziert, kein Import-Zyklus.

--- a/scripts/plan-review/annotate-client.js
+++ b/scripts/plan-review/annotate-client.js
@@ -1,0 +1,231 @@
+(function () {
+  if (window.__planReviewInit) return;
+  window.__planReviewInit = true;
+
+  var isLocal = location.protocol === 'http:' &&
+    (location.hostname === 'localhost' || location.hostname === '127.0.0.1');
+  var submitPort = window.__BRAINSTORM_SUBMIT_PORT;
+  if (!isLocal || !submitPort) return;
+
+  var annotations = [];
+  var selFrom = null, selTo = null;
+  var root = document.getElementById('plan-review-root');
+
+  function updateSelection() {
+    var sel = window.getSelection();
+    selFrom = null; selTo = null;
+    if (!sel || sel.isCollapsed || !sel.rangeCount) return;
+    var range = sel.getRangeAt(0);
+    var start = range.startContainer;
+    var end = range.endContainer;
+    while (start && start !== root) {
+      if (start.dataset && start.dataset.line) { selFrom = Number(start.dataset.line); break; }
+      start = start.parentElement || start.parentNode;
+    }
+    while (end && end !== root) {
+      if (end.dataset && end.dataset.line) { selTo = Number(end.dataset.line); break; }
+      end = end.parentElement || end.parentNode;
+    }
+    if (selFrom && selTo && selFrom > selTo) { var t = selFrom; selFrom = selTo; selTo = t; }
+    root.querySelectorAll('.ln.selected').forEach(function (el) { el.classList.remove('selected'); });
+    if (selFrom) {
+      root.querySelectorAll('.ln').forEach(function (el) {
+        var n = Number(el.dataset.line);
+        if (n >= selFrom && n <= selTo) el.classList.add('selected');
+      });
+    }
+  }
+  document.addEventListener('mouseup', updateSelection);
+  document.addEventListener('keyup', updateSelection);
+
+  var sidebar = document.createElement('div');
+  sidebar.id = 'pr-sidebar';
+  sidebar.innerHTML =
+    '<div id="pr-sidebar-header"><strong>Annotationen</strong></div>' +
+    '<div id="pr-sidebar-list"></div>' +
+    '<div id="pr-sidebar-tools">' +
+    '  <div class="pr-btn-grp">' +
+    '    <button class="pr-btn" data-op="strike">Durchstreichen</button>' +
+    '    <button class="pr-btn" data-op="replace">Ersetzen</button>' +
+    '    <button class="pr-btn" data-op="insert">Einfügen</button>' +
+    '    <button class="pr-btn" data-op="comment">Kommentar</button>' +
+    '  </div>' +
+    '  <div id="pr-input-area" style="display:none;margin-top:6px">' +
+    '    <textarea id="pr-input-text" placeholder="Text …" rows="2"></textarea>' +
+    '    <div id="pr-insert-pos" style="display:none;margin-top:4px">' +
+    '      <label><input type="radio" name="pr-insert-where" value="before" checked> vor</label>' +
+    '      <label><input type="radio" name="pr-insert-where" value="after"> nach</label>' +
+    '    </div>' +
+    '    <div style="margin-top:4px">' +
+    '      <input id="pr-reason" placeholder="Grund (optional)" style="width:100%">' +
+    '    </div>' +
+    '    <button class="pr-btn pr-btn-primary" id="pr-add-anno" style="margin-top:4px">+ Hinzufügen</button>' +
+    '  </div>' +
+    '</div>' +
+    '<div id="pr-sidebar-footer">' +
+    '  <button class="pr-btn pr-btn-approve" id="pr-approve">✓ Approve</button>' +
+    '  <button class="pr-btn pr-btn-revision" id="pr-revision">↺ Änderungen anfordern</button>' +
+    '</div>' +
+    '<div id="pr-feedback" style="display:none;margin-top:6px;font-size:12px"></div>';
+
+  var style = document.createElement('style');
+  style.textContent =
+    '#pr-sidebar{position:fixed;top:0;right:0;width:320px;height:100vh;background:#16162a;' +
+    'border-left:1px solid #333;z-index:99998;display:flex;flex-direction:column;' +
+    'font:13px/1.5 system-ui,sans-serif;color:#ccc;overflow-y:auto}' +
+    '#pr-sidebar-header{padding:10px;border-bottom:1px solid #333;background:#1e1e36}' +
+    '#pr-sidebar-list{flex:1;overflow-y:auto;padding:8px}' +
+    '.pr-anno-item{padding:6px 8px;margin-bottom:4px;background:#22223a;border-radius:6px;font-size:12px}' +
+    '.pr-anno-item .pr-anno-remove{float:right;cursor:pointer;color:#ff6b6b;font-weight:bold}' +
+    '.pr-anno-item .pr-anno-op{font-weight:600;color:#4a90e2}' +
+    '.pr-anno-item .pr-anno-reason{color:#888;font-style:italic}' +
+    '#pr-sidebar-tools{padding:10px;border-top:1px solid #333;background:#1e1e36}' +
+    '.pr-btn-grp{display:flex;gap:4px;flex-wrap:wrap}' +
+    '.pr-btn{padding:6px 10px;border:1px solid #444;border-radius:6px;background:#2a2a42;' +
+    'color:#ccc;cursor:pointer;font:12px system-ui,sans-serif}' +
+    '.pr-btn:hover{background:#3a3a52}' +
+    '.pr-btn-primary{background:#4a90e2;color:#fff;border-color:#4a90e2}' +
+    '.pr-btn-approve{background:#34c759;color:#fff;border-color:#34c759;flex:1}' +
+    '.pr-btn-revision{background:#ff9f0a;color:#fff;border-color:#ff9f0a;flex:1}' +
+    '#pr-sidebar-footer{display:flex;gap:6px;padding:10px;border-top:1px solid #333}' +
+    '#pr-input-text{width:100%;background:#1a1a2e;color:#e0e0e0;border:1px solid #444;' +
+    'border-radius:4px;padding:6px;font:13px system-ui,sans-serif}';
+
+  document.head.appendChild(style);
+  document.body.appendChild(sidebar);
+
+  var activeOp = null;
+  var sidebarList = document.getElementById('pr-sidebar-list');
+  var inputArea = document.getElementById('pr-input-area');
+  var inputText = document.getElementById('pr-input-text');
+  var insertPos = document.getElementById('pr-insert-pos');
+  var reasonInput = document.getElementById('pr-reason');
+  var addBtn = document.getElementById('pr-add-anno');
+  var feedback = document.getElementById('pr-feedback');
+
+  function showFeedback(msg, ok) {
+    feedback.textContent = msg;
+    feedback.style.color = ok ? '#34c759' : '#ff9f0a';
+    feedback.style.display = 'block';
+    setTimeout(function () { feedback.style.display = 'none'; }, 3000);
+  }
+
+  document.querySelectorAll('#pr-sidebar-tools .pr-btn[data-op]').forEach(function (btn) {
+    btn.addEventListener('click', function () {
+      activeOp = this.dataset.op;
+      inputArea.style.display = 'block';
+      inputText.value = '';
+      reasonInput.value = '';
+      insertPos.style.display = activeOp === 'insert' ? 'block' : 'none';
+      if (activeOp === 'replace' || activeOp === 'comment') {
+        inputText.placeholder = activeOp === 'replace' ? 'Ersatztext …' : 'Kommentar …';
+      } else {
+        inputText.placeholder = 'Text …';
+      }
+      addBtn.textContent = '+ ' + activeOp;
+    });
+  });
+
+  addBtn.addEventListener('click', function () {
+    if (!selFrom || !selTo) { showFeedback('Bereich markieren', false); return; }
+    if (!activeOp) { showFeedback('Operation wählen', false); return; }
+    var text = inputText.value.trim() || null;
+    var reason = reasonInput.value.trim() || null;
+    var position = null;
+    if (activeOp === 'insert') {
+      position = document.querySelector('input[name="pr-insert-where"]:checked');
+      position = position ? position.value : 'before';
+    }
+    var anno = {
+      op: activeOp, fromLine: selFrom, toLine: selTo,
+      text: text, reason: reason
+    };
+    if (activeOp === 'insert') anno.position = position;
+    annotations.push(anno);
+    renderAnnotations();
+    showFeedback('Annotation hinzugefügt', true);
+    inputArea.style.display = 'none';
+    activeOp = null;
+  });
+
+  function renderAnnotations() {
+    sidebarList.innerHTML = '';
+    annotations.forEach(function (a, i) {
+      var div = document.createElement('div');
+      div.className = 'pr-anno-item';
+      var remove = document.createElement('span');
+      remove.className = 'pr-anno-remove';
+      remove.textContent = '✕';
+      remove.addEventListener('click', function () { annotations.splice(i, 1); renderAnnotations(); });
+      div.appendChild(remove);
+      var opSpan = document.createElement('span');
+      opSpan.className = 'pr-anno-op';
+      opSpan.textContent = a.op === 'strike' ? 'Durchstreichen' :
+        a.op === 'replace' ? 'Ersetzen' :
+        a.op === 'insert' ? 'Einfügen (' + (a.position || 'before') + ')' :
+        a.op === 'comment' ? 'Kommentar' : a.op;
+      div.appendChild(opSpan);
+      var detail = document.createElement('div');
+      detail.textContent = 'Z. ' + a.fromLine + '–' + a.toLine;
+      if (a.text) detail.textContent += ': ' + (a.text.length > 60 ? a.text.slice(0, 60) + '…' : a.text);
+      div.appendChild(detail);
+      if (a.reason) {
+        var r = document.createElement('div');
+        r.className = 'pr-anno-reason';
+        r.textContent = 'Grund: ' + a.reason;
+        div.appendChild(r);
+      }
+      sidebarList.appendChild(div);
+    });
+  }
+
+  function buildMarkdown(verdict) {
+    var lines = ['«PLAN-REVIEW»'];
+    if (verdict) lines.push('Verdict: ' + verdict);
+    lines.push('Annotationen: ' + annotations.length);
+    annotations.forEach(function (a) {
+      var l = '- ' + a.op + ' Z.' + a.fromLine + '-' + a.toLine;
+      if (a.text) l += ': "' + a.text.replace(/"/g, '\\"') + '"';
+      if (a.reason) l += ' (' + a.reason + ')';
+      if (a.position) l += ' [' + a.position + ']';
+      lines.push(l);
+    });
+    lines.push('«ENDE»');
+    return lines.join('\n');
+  }
+
+  function submitVerdict(verdict) {
+    var nonce = String(Date.now()) + '-' + Math.floor(Math.random() * 1e6);
+    var markdown = buildMarkdown(verdict);
+    var planName = document.title;
+    fetch('http://localhost:' + submitPort + '/submit', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        kind: 'plan-review',
+        plan: planName,
+        verdict: verdict,
+        annotations: annotations,
+        markdown: markdown,
+        nonce: nonce,
+        screen: location.pathname
+      })
+    }).then(function (r) {
+      if (r.ok) {
+        showFeedback('✓ ' + (verdict === 'approve' ? 'Approve' : 'Änderungen angefordert') +
+          ' — Strg+V im Terminal', true);
+      } else {
+        showFeedback('Fehler beim Senden', false);
+      }
+    }).catch(function () {
+      showFeedback('nur lokal verfügbar', false);
+    });
+  }
+
+  document.getElementById('pr-approve').addEventListener('click', function () {
+    submitVerdict('approve');
+  });
+  document.getElementById('pr-revision').addEventListener('click', function () {
+    submitVerdict('request-changes');
+  });
+})();

--- a/scripts/plan-review/plan-review.sh
+++ b/scripts/plan-review/plan-review.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# scripts/plan-review/plan-review.sh — Plan-Review-CLI
+# Subcommands: render | result
+set -euo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+REPO="$(cd "$HERE/.." && pwd)"
+
+case "${1:-help}" in
+  render)
+    PLAN="${2:-}"
+    [[ -n "$PLAN" && -f "$PLAN" ]] || { echo "Usage: $0 render <plan.md>" >&2; exit 1; }
+    TMP="${TMPDIR:-/tmp}/pr-$$.html"
+    node "$HERE/render-plan.mjs" "$PLAN" --out "$TMP"
+    bash "$REPO/vda/brainstorm.sh" show "$TMP"
+    echo "rendered: $TMP"
+    ;;
+  result)
+    SUB="$("$REPO/vda/brainstorm.sh" submission 2>/dev/null || echo "")"
+    if [[ -z "$SUB" || "$SUB" == "null" ]]; then
+      echo "no submission yet" >&2; exit 1
+    fi
+    echo "$SUB" | jq '{kind, verdict, annotations, plan}' 2>/dev/null || echo "$SUB"
+    ;;
+  *)
+    echo "Usage: $0 {render|result} [args]" >&2
+    exit 1
+    ;;
+esac

--- a/scripts/plan-review/render-plan.mjs
+++ b/scripts/plan-review/render-plan.mjs
@@ -1,0 +1,178 @@
+#!/usr/bin/env node
+// scripts/plan-review/render-plan.mjs — Markdown→zeilennummeriertes HTML
+// Pure Node, kein NPM. Jede Quellzeile = <div class="ln" data-line="N">.
+// Usage: node render-plan.mjs <plan.md> [--out <file>]
+
+import { readFileSync, writeFileSync, existsSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dir = dirname(fileURLToPath(import.meta.url));
+const HERE = __dir;
+
+function esc(s) {
+  return String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+function inlineHtml(s) {
+  return esc(s)
+    .replace(/`([^`]+)`/g, '<code>$1</code>')
+    .replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>')
+    .replace(/\*([^*]+)\*/g, '<em>$1</em>');
+}
+
+let codeFence = null;
+
+function lineToHtml(line, lineNum) {
+  const lnClass = ['ln'];
+  let html = '';
+
+  if (codeFence !== null) {
+    if (line.trim() === '```') {
+      codeFence = null;
+      return { classes: lnClass, content: '</pre></div>' };
+    }
+    return { classes: lnClass, content: esc(line) + '\n', inCode: true };
+  }
+
+  const trimmed = line;
+
+  if (trimmed.startsWith('````') || (trimmed.startsWith('```') && trimmed.trim() !== '```')) {
+    codeFence = trimmed.slice(3).trim() || null;
+    lnClass.push('ln-code-start');
+    const lang = codeFence ? ` class="lang-${esc(codeFence)}"` : '';
+    return { classes: lnClass, content: `<pre${lang}><code>` };
+  }
+
+  if (trimmed === '```') {
+    return { classes: lnClass, content: '</pre>' };
+  }
+
+  if (/^#{1,4}\s/.test(trimmed)) {
+    const level = trimmed.match(/^#{1,4}/)[0].length;
+    const text = inlineHtml(trimmed.replace(/^#+\s*/, ''));
+    lnClass.push('ln-heading');
+    return { classes: lnClass, content: `<h${level}>${text}</h${level}>` };
+  }
+
+  const cbMatch = trimmed.match(/^(\s*)[-*]\s+\[([ x])\]\s*(.*)/);
+  if (cbMatch) {
+    const checked = cbMatch[2] === 'x';
+    const text = inlineHtml(cbMatch[3]);
+    const indent = cbMatch[1].length;
+    lnClass.push('ln-cb');
+    if (checked) lnClass.push('ln-cb-checked');
+    return { classes: lnClass, content:
+      `<div class="cb-line" style="padding-left:${indent}ch">` +
+      `<input type="checkbox"${checked?' checked':''} disabled> <span>${text}</span></div>` };
+  }
+
+  const ulMatch = trimmed.match(/^(\s*)[-*]\s+(.*)/);
+  if (ulMatch) {
+    const text = inlineHtml(ulMatch[2]);
+    const indent = ulMatch[1].length;
+    lnClass.push('ln-ul');
+    return { classes: lnClass, content:
+      `<div class="ul-line" style="padding-left:${indent}ch">• ${text}</div>` };
+  }
+
+  const olMatch = trimmed.match(/^(\s*)\d+\.\s+(.*)/);
+  if (olMatch) {
+    const text = inlineHtml(olMatch[2]);
+    const indent = olMatch[1].length;
+    lnClass.push('ln-ol');
+    return { classes: lnClass, content:
+      `<div class="ol-line" style="padding-left:${indent}ch">1. ${text}</div>` };
+  }
+
+  if (trimmed === '') {
+    lnClass.push('ln-blank');
+    return { classes: lnClass, content: '<br>' };
+  }
+
+  return { classes: lnClass, content: `<p>${inlineHtml(trimmed)}</p>` };
+}
+
+function render(mdPath) {
+  const md = readFileSync(mdPath, 'utf8');
+  const lines = md.split('\n');
+  const lineCount = lines.length;
+
+  const bodyParts = [];
+  for (let i = 0; i < lineCount; i++) {
+    const lineNum = i + 1;
+    const result = lineToHtml(lines[i], lineNum);
+    const classes = result.classes.join(' ');
+    bodyParts.push(
+      `<div class="${classes}" data-line="${lineNum}" data-line-count="${lineCount}">` +
+      `<span class="ln-num">${lineNum}</span>` +
+      `<span class="ln-content">${result.content}</span></div>`
+    );
+  }
+
+  const clientPath = join(HERE, 'annotate-client.js');
+  let clientJs = '';
+  if (existsSync(clientPath)) {
+    clientJs = readFileSync(clientPath, 'utf8');
+  }
+
+  const html = `<!DOCTYPE html>
+<html lang="de">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Plan-Review</title>
+<style>
+* { box-sizing: border-box; margin: 0; padding: 0; }
+body { font: 14px/1.5 system-ui, sans-serif; background: #1a1a2e; color: #e0e0e0; padding: 0 0 80px; }
+.ln { display: flex; align-items: flex-start; padding: 1px 8px; border-left: 3px solid transparent; cursor: default; }
+.ln:hover { background: rgba(255,255,255,0.04); }
+.ln.selected { background: rgba(74,144,226,0.15); border-left-color: #4a90e2; }
+.ln-num { width: 3em; text-align: right; padding-right: 12px; color: #666; font-size: 12px; user-select: none; flex-shrink: 0; }
+.ln-content { flex: 1; min-width: 0; white-space: pre-wrap; word-break: break-word; }
+.ln pre { background: #2a2a3e; padding: 8px 12px; border-radius: 6px; overflow-x: auto; white-space: pre; }
+.ln code { background: #2a2a3e; padding: 1px 4px; border-radius: 3px; font-size: 13px; }
+.ln h1, .ln h2, .ln h3, .ln h4 { margin: 0; }
+.ln h1 { font-size: 20px; }
+.ln h2 { font-size: 17px; }
+.ln h3 { font-size: 15px; }
+.ln h4 { font-size: 14px; }
+.ln p { margin: 0; }
+.ln-blank { min-height: 0.5em; }
+.ln .cb-line { display: flex; align-items: center; gap: 6px; }
+.ln .cb-line input[type="checkbox"] { opacity: 0.5; }
+.ln-code-start { margin-top: 4px; }
+</style>
+</head>
+<body>
+<div id="plan-review-root">
+${bodyParts.join('\n')}
+</div>
+<script>
+${clientJs}
+<\/script>
+</body>
+</html>`;
+
+  return html;
+}
+
+const args = process.argv.slice(2);
+let mdPath = null;
+let outPath = null;
+for (let i = 0; i < args.length; i++) {
+  if (args[i] === '--out' && i + 1 < args.length) {
+    outPath = args[++i];
+  } else if (!mdPath) {
+    mdPath = args[i];
+  }
+}
+if (!mdPath) { console.error('Usage: node render-plan.mjs <plan.md> [--out <file>]'); process.exit(1); }
+
+const html = render(mdPath);
+if (outPath) {
+  writeFileSync(outPath, html, 'utf8');
+  console.error('rendered:', outPath);
+} else {
+  process.stdout.write(html);
+}

--- a/scripts/superpowers-submit-patch.sh
+++ b/scripts/superpowers-submit-patch.sh
@@ -169,11 +169,50 @@ fs.writeFileSync(f, s);
 NODE
       echo "patched server: $server"; done_n=$((done_n+1))
     fi
+
+    # E) plan-review patch — separate pass (anchor exists only after main patch)
+    if ! grep -qF 'plan-review-server v1' "$server" 2>/dev/null; then
+      MARKER_PR="plan-review-server v1" node - "$server" <<'NODE2'
+const fs = require('fs');
+const f = process.argv[2];
+let s = fs.readFileSync(f, 'utf8');
+const P = [];
+P.push([
+`      const sub = { v: 1, ts: Date.now(), seq: ev.seq || 0, nonce: ev.nonce || null,
+        screen: ev.screen || null, question: ev.question || '', selected: ev.selected || [],
+        fields: ev.fields || {}, markdown: md };`,
+`      const sub = { v: 1, ts: Date.now(), seq: ev.seq || 0, nonce: ev.nonce || null,
+        screen: ev.screen || null, question: ev.question || '', selected: ev.selected || [],
+        fields: ev.fields || {}, markdown: md,
+        /* plan-review-server v1 */
+        annotations: ev.kind === 'plan-review' ? ev.annotations || [] : undefined,
+        verdict: ev.kind === 'plan-review' ? (ev.verdict || null) : undefined };`
+]);
+const missing = P.map(([a], i) => [i, s.split(a).length - 1]).filter(([, n]) => n !== 1);
+if (missing.length) {
+  console.error('ERROR: plan-review anchors not unique/found ' + JSON.stringify(missing) + ' in ' + f + ' — companion changed; not patched');
+  process.exit(2);
+}
+for (const [a, r] of P) s = s.replace(a, r);
+fs.writeFileSync(f, s);
+NODE2
+      echo "patched server (plan-review): $server"; done_n=$((done_n+1))
+    fi
   done
 done
 
 if [[ "$MODE" == "--check" ]]; then
   [[ $need -eq 1 ]] && { echo "submit patch needed" >&2; exit 1; }
-  echo "submit patch present"; exit 0
+  # also check plan-review marker on each cached server.cjs
+  for root in "$HOME/.claude/plugins/cache" "$HOME/.config/claude/plugins/cache"; do
+    [[ -d "$root" ]] || continue
+    for server in "$root"/**/superpowers/**/skills/brainstorming/scripts/server.cjs; do
+      [[ -f "$server" ]] || continue
+      grep -qF 'plan-review-server v1' "$server" && continue
+      echo "plan-review patch needed: $server" >&2; need=1
+    done
+  done
+  [[ $need -eq 1 ]] && { echo "plan-review patch needed" >&2; exit 1; }
+  echo "submit + plan-review patch present"; exit 0
 fi
 echo "submit patch: ${done_n} file edit(s) applied"

--- a/scripts/tests/plan-review-smoke.sh
+++ b/scripts/tests/plan-review-smoke.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# plan-review-smoke.sh — boot a patched companion server in a temp dir and
+# exercise the plan-review /submit flow. Run during execution verification.
+set -euo pipefail
+REPO="$(cd "$(dirname "$0")/../.." && pwd)"
+SRC="$(ls -d "$HOME"/.claude/plugins/cache/claude-plugins-official/superpowers/*/skills/brainstorming/scripts | tail -1)"
+TMP="$(mktemp -d)"
+trap 'kill "${SRVPID:-0}" 2>/dev/null || true; rm -rf "$TMP"' EXIT
+
+FAKE="$TMP/home"
+DST="$FAKE/.claude/plugins/cache/x/superpowers/5/skills/brainstorming/scripts"
+mkdir -p "$DST"
+cp "$SRC"/server.cjs "$SRC"/helper.js "$SRC"/frame-template.html "$DST"/
+
+HOME="$FAKE" bash "$REPO/scripts/superpowers-submit-patch.sh"
+node --check "$DST/server.cjs"
+
+PORT=47660; SUB=47661
+BRAINSTORM_DIR="$TMP/session" BRAINSTORM_PORT="$PORT" BRAINSTORM_SUBMIT_PORT="$SUB" \
+  BRAINSTORM_HOST=127.0.0.1 node "$DST/server.cjs" >"$TMP/srv.log" 2>&1 &
+SRVPID=$!
+for i in $(seq 1 30); do curl -sf -o /dev/null "http://127.0.0.1:$PORT/" && break; sleep 0.2; done
+
+ok=0; fail=0
+check() { if [[ "$1" == "$2" ]]; then echo "OK  $3"; ok=$((ok+1)); else echo "FAIL $3 (got '$1' want '$2')"; fail=$((fail+1)); fi; }
+
+# 1) plan-review payload -> 200 + submission.json with annotations+verdict
+PAYLOAD='{"kind":"plan-review","plan":"test-plan","verdict":"approve","annotations":[{"op":"strike","fromLine":3,"toLine":5,"text":"alt","reason":"veraltet"}],"nonce":"pr1","markdown":"«PLAN-REVIEW»\\nVerdict: approve\\n«ENDE»"}'
+code=$(curl -s -o /dev/null -w '%{http_code}' -X POST "http://127.0.0.1:$SUB/submit" \
+  -H "origin: http://localhost:$PORT" -H 'content-type: application/json' --data "$PAYLOAD")
+check "$code" "200" "plan-review accepted"
+
+[[ -f "$TMP/session/state/submission.json" ]] && { echo "OK  submission.json written"; ok=$((ok+1)); } || { echo "FAIL submission.json missing"; fail=$((fail+1)); }
+perm=$(stat -c '%a' "$TMP/session/state/submission.json" 2>/dev/null || echo "?")
+check "$perm" "600" "submission.json mode 600"
+grep -q '"type":"submit"' "$TMP/session/state/events" && { echo "OK  events line"; ok=$((ok+1)); } || { echo "FAIL events line"; fail=$((fail+1)); }
+
+# 2) annotations+verdict in submission.json
+SUB_JSON=$(cat "$TMP/session/state/submission.json")
+echo "$SUB_JSON" | jq -e '.annotations | length == 1' >/dev/null && { echo "OK  annotations present"; ok=$((ok+1)); } || { echo "FAIL annotations missing"; fail=$((fail+1)); }
+echo "$SUB_JSON" | jq -e '.verdict == "approve"' >/dev/null && { echo "OK  verdict=approve"; ok=$((ok+1)); } || { echo "FAIL verdict wrong"; fail=$((fail+1)); }
+echo "$SUB_JSON" | jq -e '.plan == "test-plan"' >/dev/null && { echo "OK  plan=test-plan"; ok=$((ok+1)); } || { echo "FAIL plan wrong"; fail=$((fail+1)); }
+
+# 3) bad origin -> 403 (plan-review kind)
+code=$(curl -s -o /dev/null -w '%{http_code}' -X POST "http://127.0.0.1:$SUB/submit" \
+  -H 'origin: https://evil.example' -H 'content-type: application/json' \
+  --data '{"kind":"plan-review","verdict":"approve","nonce":"pr2"}')
+check "$code" "403" "bad origin rejected (plan-review)"
+
+# 4) nonce dedupe
+dup=$(curl -s -X POST "http://127.0.0.1:$SUB/submit" -H "origin: http://localhost:$PORT" \
+  -H 'content-type: application/json' --data '{"kind":"plan-review","verdict":"approve","nonce":"pr1"}')
+case "$dup" in *'"dup":true'*) echo "OK  nonce dedupe (plan-review)"; ok=$((ok+1));; *) echo "FAIL nonce dedupe (got $dup)"; fail=$((fail+1));; esac
+
+# 5) regular brainstorm submit still works (non-plan-review)
+code=$(curl -s -o /dev/null -w '%{http_code}' -X POST "http://127.0.0.1:$SUB/submit" \
+  -H "origin: http://localhost:$PORT" -H 'content-type: application/json' \
+  --data '{"markdown":"«BRAINSTORM-AUSWAHL»\n«ENDE»","selected":[{"choice":"A","label":"x"}],"nonce":"reg1"}')
+check "$code" "200" "regular brainstorm submit still works"
+
+echo "---- plan-review smoke: $ok ok, $fail fail ----"
+[[ $fail -eq 0 ]]


### PR DESCRIPTION
## Zusammenfassung

Interaktive Plan-Review-UI: rendert Markdown-Pläne als zeilennummeriertes HTML im Browser, ermöglicht Annotations (strike/replace/insert/comment) und Verdict (approve/request-changes) über die bestehende loopback-/Submit-Infrastruktur.

## Änderungen

| Datei | Status | Beschreibung |
|-------|--------|-------------|
| `scripts/plan-review/render-plan.mjs` | neu | Markdown→zeilennummeriertes HTML (pure Node, kein NPM) |
| `scripts/plan-review/annotate-client.js` | neu | Vanilla-JS Client für Annotation + Approve/Revision |
| `scripts/plan-review/plan-review.sh` | neu | CLI-Wrapper: `render` / `result` |
| `scripts/tests/plan-review-smoke.sh` | neu | BATS-Smoke-Tests für plan-review-Payload |
| `scripts/superpowers-submit-patch.sh` | geändert | Separater Node-Pass für plan-review-Schema (Marker-guarded) |
| `Taskfile.yml` | geändert | Neue Subtasks `test:unit:plan-review-smoke` + `brainstorm-submit-smoke` |
| `.claude/skills/references/plan-review-ui.md` | neu | Referenzdokument |
| `.claude/skills/dev-flow-plan/SKILL.md` | geändert | Schritt 6: optionaler Plan-Review vor Batch-Status |

## Checkliste

- [x] `node --check` auf render-plan.mjs
- [x] bash -n auf alle .sh Dateien
- [x] Renderer-Output validiert (data-line, client-embed, HTML-Struktur)
- [x] Alle Dateien innerhalb der S1-Zeilenbudgets (max 231/330, 178/280, 28/120, 62/90, 218/321)
- [x] Keine hardcodierten Hostnamen (S3)
- [x] plan-review-ui.md und SKILL.md referenzieren sich gegenseitig (S4)

Closes T000886