### PR TITLE
feat(factory): self-correcting build-loop (ralph-wiggum) + task-verify-loop [T000884]

### DIFF
--- a/.claude/skills/dev-flow-execute/SKILL.md
+++ b/.claude/skills/dev-flow-execute/SKILL.md
@@ -346,6 +346,54 @@ Der Subagent führt den gesamten dev-flow-execute-Pipeline selbstständig bis zu
 
 ---
 
+## Schritt 2.5 — Lokaler Self-Correcting-Loop (optional)
+
+Nach dem Implementer-Subagenten (Schritt 2) **vor** der finalen Verifikation (Schritt 3):
+
+```bash
+source scripts/factory/build-loop.sh
+source scripts/factory/classify-failure.sh
+source scripts/factory/classify-paths.sh
+
+MAX_LOOP=${FACTORY_BUILD_LOOP_MAX:-3}
+ITER=0
+PREV_HASH=""
+RESULT_FILE=$(mktemp)
+
+# implementer output captured into RESULT_FILE
+while [[ $ITER -lt $MAX_LOOP ]]; do
+  task test:changed > "$RESULT_FILE" 2>&1 || true
+  CLASS=$(classify_failure "$RESULT_FILE")
+  HASH=$(build_loop_sig_hash "$RESULT_FILE")
+  TOUCHED=$(git diff --name-only origin/main...HEAD | tr '\n' ',')
+
+  DECIDE=$(build_loop_decide "$ITER" "$MAX_LOOP" "$PREV_HASH" "$CLASS" "$TOUCHED" "$HASH")
+  DECIDE_ACTION=$(echo "$DECIDE" | sed -n '1p')
+  DECIDE_HASH=$(echo "$DECIDE" | sed -n '2p')
+
+  case "$DECIDE_ACTION" in
+    continue)
+      FEEDBACK=$(build_loop_feedback "$CLASS" "$RESULT_FILE" "")
+      ./scripts/ticket.sh phase "$TICKET_ID" implement loop --driver devflow --detail "iter $((ITER+1))/$MAX_LOOP class=$CLASS" || true
+      # Spawne Korrektur-Subagent mit dem Feedback-Block
+      ITER=$((ITER + 1))
+      PREV_HASH="$DECIDE_HASH"
+      ;;
+    abort:no-progress|abort:max-iterations|abort:escalate-gate)
+      ./scripts/ticket.sh add-comment --id "$TICKET_ID" --body "Build-Loop aborted: $DECIDE_ACTION (class=$CLASS)" || true
+      break
+      ;;
+  esac
+done
+rm -f "$RESULT_FILE"
+```
+
+- Default `MAX_LOOP=3`, env `FACTORY_BUILD_LOOP_MAX` überschreibbar.
+- Bei `abort:escalate-gate|no-progress|max-iterations`: Eskalation (Ticket-Kommentar), **kein** blindes Weiter-Pushen.
+- **Abgrenzung zu Schritt 5.5:** Dieser Loop ist **vorgelagert** (lokal, vor `git push`) und reduziert die Last auf die CI-Retry-Schleife — ersetzt sie aber nicht. Schritt 3 (finale Verifikation) bleibt unverändert.
+
+---
+
 ## Schritt 3: Lokale Verifikation
 
 Rufe das Skill **`verification-before-completion`** auf, um die Verifikation strukturiert zu steuern.

--- a/docs/superpowers/plans/2026-06-16-t000884.md
+++ b/docs/superpowers/plans/2026-06-16-t000884.md
@@ -4,9 +4,9 @@ ticket_id: T000884
 domains: [test, ops]
 status: active
 pr_number: null
-file_locks: []
+file_locks: [website/src/data/test-inventory.json]
 shared_changes: false
-batch_id: null
+batch_id: batch-2026-06-16-planning
 parent_feature: null
 depends_on_plans: []
 ---
@@ -138,7 +138,8 @@ BATS, Taskfile. Keine neuen Runtime-Dependencies.
 - [ ] Erst nach passender bestehender Datei suchen:
       `grep -rl "classify_failure\|classify-paths\|retry" tests/local/FA-SF-*.bats`.
       Bevorzugt eine bestehende failure-classification/retry-nahe FA-SF-Bats erweitern; nur wenn
-      keine thematisch passt, neue `tests/local/FA-SF-<n>-build-loop.bats` anlegen.
+      keine thematisch passt, neue `tests/local/FA-SF-56-build-loop.bats` anlegen
+      (FA-SF-56 ist frei; 50–53 sind durch T000885 + Bestand belegt).
 - [ ] Test-Fälle (offline, sourcen `build-loop.sh`):
   - Hash-Stabilität: identischer Log (mit unterschiedlichem Pfad-/Timestamp-Rauschen) → gleicher Hash.
   - no-progress: `prev_hash == hash` → `abort:no-progress`.
@@ -169,3 +170,16 @@ task test:all
 task freshness:regenerate
 task freshness:check
 ```
+
+## Parallelorchestration (Batch `batch-2026-06-16-planning`)
+
+Teil des 3er-Batches **T000884 ∥ T000885 ∥ T000886**. Code-Dateien sind disjunkt; parallele
+Ausführung ist sicher. Dieser Plan ist der **am wenigsten gekoppelte**:
+
+- **`Taskfile.yml`:** wird **nicht** berührt → kein Konflikt mit T000885/T000886 → kann zuerst oder
+  voll parallel gemergt werden.
+- **FA-SF-Nummern:** dieser Plan bevorzugt eine bestehende FA-SF-Bats zu erweitern; falls neu, dann
+  **FA-SF-56** (T000885 belegt 54/55, Bestand 50–53) → keine Kollision.
+- **`website/src/data/test-inventory.json`:** einziger geteilter Berührungspunkt (mit allen drei).
+  Generiert → nach jedem Rebase **`task test:inventory`** neu, niemals hand-mergen.
+- Empfohlene Merge-Reihenfolge: **T000884 → T000885 → T000886**.

--- a/docs/superpowers/plans/2026-06-16-t000884.md
+++ b/docs/superpowers/plans/2026-06-16-t000884.md
@@ -1,0 +1,171 @@
+---
+title: Plan — T000884: Selbstkorrigierende Execute-Loops (ralph-wiggum-Muster)
+ticket_id: T000884
+domains: [test, ops]
+status: active
+pr_number: null
+file_locks: []
+shared_changes: false
+batch_id: null
+parent_feature: null
+depends_on_plans: []
+---
+
+# Plan — T000884: Selbstkorrigierende Execute-Loops (ralph-wiggum-Muster)
+
+**Ticket:** T000884
+**Spec:** docs/superpowers/specs/2026-06-16-t000884-design.md
+**Branch:** feature/t000884
+**Domains:** test, ops
+
+## Ziel
+
+Ein bounded, lokaler `build → test → Fehler lesen → fix`-Loop **vor** dem PR, der schwache erste
+Build-Outputs autonom korrigiert. Adressiert Factory (`pipeline.js` Implement-Phase) und
+`dev-flow-execute` (SKILL Schritt 2/3). Deckelung über Iterationszahl + Fehler-Hash-Stagnation.
+Synergie mit T000883 (OTel): Loop-Iterationen als Events sichtbar.
+
+## Architektur
+
+- **Geteilter Loop-Kontrakt** (Spec §5.1): reine Entscheidungsfunktion `continue|abort:<grund>`
+  + Failure-Class + Fehler-Signatur-Hash. Hält keinen Agenten-State.
+- **Zwei Implementierungen desselben Kontrakts:**
+  - `scripts/factory/build-loop.sh` — SOURCE-only Bash-Helper für die SKILL/bash-Pfade.
+  - `scripts/factory/build-loop.cjs` — require-barer Node-Helper für `pipeline.js`.
+- **Wiederverwendung:** `classify-failure.sh`, `classify-paths.sh`, `ticket.sh retry-count`,
+  `otel-emit.cjs`, `phaseEvent`/`ticket.sh phase`.
+- **Pure Module (S2):** beide Helper ohne DB/API-Imports, ohne Import-Zyklen.
+
+## Tech-Stack
+
+Bash (POSIX-nah, `sha256sum`), Node `.cjs` (CommonJS, `require`, `node --check`-offline-safe),
+BATS, Taskfile. Keine neuen Runtime-Dependencies.
+
+## S1-Zeilenbudget (verbindlich vor Implementierung ermittelt)
+
+| Datei | Ist | Baseline | wirksame Schwelle | Budget | Konsequenz |
+|---|---|---|---|---|---|
+| `scripts/factory/pipeline.js` | 604 | nicht-baselined | 600 (`.js`-Limit) | **−4 (negativ!)** | Änderung MUSS **netto schrumpfen**: Self-Verify-Inline-Block durch `require('./build-loop.cjs')`-Aufruf ersetzen, kein Zuwachs. Ziel ≤ 600. |
+| `scripts/factory/build-loop.sh` | neu | — | 500 (`.sh`) | Ziel < 200 | Wachstumsreserve, reiner Helper. |
+| `scripts/factory/build-loop.cjs` | neu | — | 200 (`.cjs`) | Ziel < 160 | `.cjs`-Limit ist 200 → eng schneiden, reine Funktionen. |
+| `.claude/skills/dev-flow-execute/SKILL.md` | 637 | — | (`.md`, kein S1-Limit) | n/a | Doku-Ergänzung Schritt 2/3. |
+| `tests/local/FA-SF-*.bats` (bestehend) | — | — | (Tests) | n/a | bestehende Datei erweitern; neues File nur wenn kein passendes existiert. |
+
+> **Kritisch:** `pipeline.js` ist bereits 4 Zeilen über dem `.js`-Limit und **nicht baselined** →
+> jede Netto-Zeile macht `quality:check` rot. Der Plan ersetzt den 6-zeiligen Inline-Self-Verify-
+> Block (Z.371–377) durch einen ~4-zeiligen `require`-Aufruf → **netto −2, Ziel 602 → unter
+> Re-Messung weiter Richtung ≤600 trimmen** (siehe Task 4, Pflicht-Gate).
+
+## S3 / S4 Hinweise
+
+- **S3:** Keine Brand-Domain-Literale in den Helpern oder Snippets (Loop-Logik ist domain-frei).
+- **S4:** `build-loop.sh` + `build-loop.cjs` müssen erreichbar sein:
+  - `build-loop.cjs` → `require` aus `pipeline.js` (Quelle).
+  - `build-loop.sh` → in `dev-flow-execute/SKILL.md` referenziert + von BATS gesourct.
+  - Beide werden von der erweiterten FA-SF-Bats getestet (kein Orphan).
+
+## Tasks
+
+### Task 1 — Pure Loop-Helper (cjs) + Offline-Test
+
+- [ ] `scripts/factory/build-loop.cjs` anlegen. Exportiert:
+  - `normalize(logText)` — entfernt absolute Pfade, Timestamps, Zeilennummern-Rauschen, Worktree-
+    Pfade → deterministischer String.
+  - `sigHash(logText)` — `sha256` über `normalize(logText)` (via `require('crypto')`).
+  - `decide({ iteration, max, prevHash, classify, escalatePaths })` → `{ action, reason, hash? }`
+    mit `action ∈ {continue, abort}` und `reason ∈ {success, no-progress, max-iterations,
+    escalate-gate}` gemäß Spec §5.1. (`classify`/`escalatePaths` werden vom Aufrufer aus
+    `classify-failure.sh`/`classify-paths.sh` eingespeist — Helper bleibt DB/IO-frei → S2.)
+  - `feedbackBlock({ classify, logTail, attempts })` — kompakter Prompt-String fürs nächste Iter.
+- [ ] Header-Kommentar: „pure, require-able. node --check offline. No DB/API imports (S2)."
+- [ ] `scripts/factory/build-loop.test.cjs` anlegen (analog `pipeline-decompose.test.cjs`):
+  testet Hash-Stabilität (gleicher Input → gleicher Hash; Rauschen ändert Hash nicht),
+  no-progress (`prevHash==hash` → abort), max-iter, escalate-gate.
+- **Acceptance:** `node --check scripts/factory/build-loop.cjs`; `node scripts/factory/build-loop.test.cjs` exit 0; `wc -l` < 200.
+
+### Task 2 — Pure Loop-Helper (bash, SOURCE-only)
+
+- [ ] `scripts/factory/build-loop.sh` anlegen (SOURCE-only, kein Shebang-Exec-Pfad). Definiert:
+  - `build_loop_sig_hash <log-file>` — normalisiert + `sha256sum` → echo hash.
+  - `build_loop_decide <iteration> <max> <prev_hash> <classify> <touched_csv>` — sourct
+    `classify-paths.sh`, ruft `paths_are_escalate_class`, prüft class-Gate, prev_hash-Stagnation,
+    max-iter → echo `continue|abort:<reason>` + (zweite Zeile) hash.
+  - `build_loop_feedback <classify> <log-file> <attempts-file>` — echo kompakten Feedback-Block.
+- [ ] Kontrakt-Parität zu `build-loop.cjs` (gleiche Klassen-Gates, gleiche reasons).
+- **Acceptance:** `bash -n scripts/factory/build-loop.sh`; in der BATS-Suite (Task 5) abgedeckt; `wc -l` < 200.
+
+### Task 3 — pipeline.js Implement-Phase auf Loop umstellen (zeilenneutral/-schrumpfend)
+
+- [ ] `const BL = require('./build-loop.cjs')` neben `const D = require('./pipeline-decompose.cjs')`.
+- [ ] Den Inline-Self-Verify-Block (heute Z.371–377, `agent('Self-verify …')` + `implemented.push`)
+      durch eine **bounded Schleife** ersetzen, die:
+  1. nach dem Implementer den lokalen Build/Test-Output sammelt (Implementer meldet bereits
+     `task workspace:validate && task test:all`-Ergebnis — bei Rot Output an den Loop geben),
+  2. `BL.decide(...)` mit `classify` (aus `classify-failure.sh` über `execFileSync`) und
+     `escalatePaths` (aus `classify-paths.sh`) konsultiert,
+  3. bei `continue`: einen **Korrektur-Agenten** mit `BL.feedbackBlock(...)` spawnt
+     (`label: fix:<t.id>:iterK`, `phaseEvent('implement','loop', 'iter K/N class=…')`,
+     `ticket.sh retry-count incr` wird NICHT benutzt — eigener Iter-Zähler, um die Post-PR-
+     Schleife nicht zu verbrauchen),
+  4. bei `abort:<reason>`: Loop verlassen; `abort:escalate-gate|no-progress` ⇒ kein weiterer
+     Fix, Eskalations-Breadcrumb; `success` ⇒ weiter.
+- [ ] `FACTORY_BUILD_LOOP_MAX` (Default 3) aus `process.env` lesen.
+- [ ] **Netto-Zeilen prüfen:** Datei muss nach der Änderung ≤ 600 Zeilen sein (Ziel). Falls die
+      Schleife mehr Zeilen kostet als der entfernte Block: weitere Logik in `build-loop.cjs`
+      auslagern (z.B. einen `BL.runDecision(...)`-Wrapper), bis `pipeline.js` ≤ 600.
+- **Acceptance:** `node --check scripts/factory/pipeline.js`; `wc -l scripts/factory/pipeline.js` ≤ 600; FA-SF-20 (pipeline-contract) bleibt grün.
+
+### Task 4 — dev-flow-execute SKILL: Loop in Schritt 2/3 dokumentieren
+
+- [ ] In `.claude/skills/dev-flow-execute/SKILL.md` nach Schritt 2 (Implementer) einen
+      **„Schritt 2.5 — Lokaler Self-Correcting-Loop"** ergänzen:
+  - nach dem Implementer `task test:changed` (bzw. `task test:all`) laufen lassen,
+  - bei Rot: `source scripts/factory/build-loop.sh` + `source scripts/factory/classify-failure.sh`,
+    `CLASS=$(classify_failure <log>)`, `build_loop_decide …`,
+  - bei `continue`: **Korrektur-Subagent** mit dem Feedback-Block + `systematic-debugging`-Auftrag
+    (provisioniert via `subagent-provisioning.md`); Floor-Event
+    `./scripts/ticket.sh phase "$TICKET_ID" implement loop --driver devflow --detail "iter K/N"`,
+  - bei `abort:escalate-gate|no-progress|max-iterations`: Eskalation (Ticket-Kommentar, ggf.
+    `blocked`), kein blindes Weiter-Pushen.
+- [ ] Schritt 3 (finale Verifikation) **unverändert** lassen — Loop sitzt davor; der finale
+      Verifikations-Block (`freshness:regenerate` + `freshness:check`) bleibt das Gate vor dem PR.
+- [ ] Default `MAX=3`, env `FACTORY_BUILD_LOOP_MAX` erwähnen; Abgrenzung zur Post-PR-Schleife
+      (Schritt 5.5) explizit notieren („vorgelagert, ersetzt 5.5 nicht").
+- **Acceptance:** SKILL referenziert `build-loop.sh` (S4-Erreichbarkeit); kein Brand-Literal (S3); bestehender Schritt-3-Block intakt.
+
+### Task 5 — BATS-Abdeckung (bestehende FA-SF-Datei erweitern)
+
+- [ ] Erst nach passender bestehender Datei suchen:
+      `grep -rl "classify_failure\|classify-paths\|retry" tests/local/FA-SF-*.bats`.
+      Bevorzugt eine bestehende failure-classification/retry-nahe FA-SF-Bats erweitern; nur wenn
+      keine thematisch passt, neue `tests/local/FA-SF-<n>-build-loop.bats` anlegen.
+- [ ] Test-Fälle (offline, sourcen `build-loop.sh`):
+  - Hash-Stabilität: identischer Log (mit unterschiedlichem Pfad-/Timestamp-Rauschen) → gleicher Hash.
+  - no-progress: `prev_hash == hash` → `abort:no-progress`.
+  - max-iter: `iteration >= max` → `abort:max-iterations`.
+  - escalate-gate: touched_files mit `*.sql`/`*secret*` → `abort:escalate-gate`.
+  - class-gate: `classify=other` → `abort:escalate-gate` (kein Auto-Fix).
+- [ ] `task test:inventory` regenerieren + `website/src/data/test-inventory.json` mitcommitten.
+- **Acceptance:** `task test:factory` grün; neue/erweiterte Bats laufen offline ohne Cluster.
+
+### Task 6 — Finale Verifikation (Pflicht-Gate)
+
+- [ ] `wc -l scripts/factory/pipeline.js` ≤ 600 **und** `build-loop.sh`/`build-loop.cjs` unter Limit
+      bestätigen (S1).
+- [ ] `node --check scripts/factory/pipeline.js scripts/factory/build-loop.cjs`
+- [ ] `task test:all`
+- [ ] `task freshness:regenerate`
+- [ ] `task freshness:check`
+- **Acceptance:** alle Kommandos exit 0; `git diff --name-only` zeigt keine ungewollten generierten Artefakt-Drifts.
+
+## Verifikation (zusammengefasst)
+
+```bash
+wc -l scripts/factory/pipeline.js          # ≤ 600
+node --check scripts/factory/pipeline.js scripts/factory/build-loop.cjs
+node scripts/factory/build-loop.test.cjs
+task test:factory
+task test:all
+task freshness:regenerate
+task freshness:check
+```

--- a/docs/superpowers/specs/2026-06-16-t000884-design.md
+++ b/docs/superpowers/specs/2026-06-16-t000884-design.md
@@ -1,0 +1,149 @@
+# Spec — T000884: Selbstkorrigierende Execute-Loops (ralph-wiggum-Muster)
+
+**Ticket:** T000884
+**Domains:** test, ops
+**Status:** design
+**Shared-Changes:** nein
+
+## 1. Problem
+
+Die Software Factory kann Tickets autonom orchestrieren (Scout → Design → Plan → Implement
+→ Verify → Deploy), aber die **Build-Qualität der ersten Iteration** ist — besonders auf
+schwächeren Providern (DeepSeek: „Scout 0 touched_files auf trivialer Aufgabe") — unzuverlässig.
+
+Heute gibt es **keinen automatischen Korrektur-Loop vor dem PR**:
+
+- `scripts/factory/pipeline.js` (Implement-Phase, ~Z.346–378): Implementer-Agent läuft EINMAL
+  → `task test:all` → ein **nicht-iterativer** Self-Verify-Agent, der den Diff nur re-liest und
+  pass/fail meldet. Schlägt der Build fehl, **loopt nichts zurück** — das Ticket landet später
+  reaktiv in der Post-PR-CI-Retry-Schleife (~Z.529–544, cap 2) oder wird `blocked`.
+- `.claude/skills/dev-flow-execute/SKILL.md`: Schritt 2 ist ein einmaliger Implementer-Subagent,
+  Schritt 3 eine one-shot lokale Verifikation. Erst Schritt 5.5 (`MAX_CI_ATTEMPTS=5`) korrigiert
+  reaktiv **nach** CI-Rot.
+
+**Folge:** Ein schwacher erster Output erfordert entweder manuellen Eingriff oder verbrennt eine
+teure PR/CI-Runde, bevor überhaupt korrigiert wird.
+
+## 2. Ziel
+
+Ein **bounded, lokaler `build → test → Fehler lesen → fix`-Loop** um den Implement/Verify-Schritt,
+**VOR** dem PR — inspiriert vom ralph-wiggum-Muster
+(https://github.com/Th0rgal/opencode-ralph-wiggum):
+
+> iteratives „Build → Test → Fehler lesen → korrigieren" bis grün, mit strukturiertem
+> Fehler-Feedback in die nächste Iteration, gedeckelt durch Iterationszahl und ein
+> „kein-Fortschritt"-Abbruchkriterium.
+
+Adressiert **beide** Execute-Pfade: Factory (`pipeline.js`) und `dev-flow-execute` (SKILL).
+
+## 3. Nicht-Ziele
+
+- **Kein** Ersatz der bestehenden Post-PR-CI-Retry-Schleife (~Z.529–544 / Schritt 5.5). Der neue
+  Loop ist **vorgelagert** (lokal, vor `git push`) und reduziert die Last auf die CI-Schleife —
+  ersetzt sie aber nicht.
+- **Kein** neues Provider-Routing, kein neues Slot-/Budget-System — die bestehenden
+  (`route-provider.sh`, Slots) bleiben unverändert.
+- **Kein** Auto-Fix für escalate-class-Änderungen (secret/realm/*.sql/shared-state) — diese
+  müssen weiter `blocked` werden (Wiederverwendung `classify-paths.sh`).
+- **Kein** unbeschränkter Loop. Hartes Iterationslimit + Fortschritts-Abbruch sind Pflicht.
+
+## 4. Anforderungen
+
+### 4.1 Bounded Retry-Loop (funktional)
+
+- **Iterationslimit `N`:** Default `3`, konfigurierbar über env (`FACTORY_BUILD_LOOP_MAX`).
+  Loop terminiert spätestens nach `N` Iterationen.
+- **Erfolgs-Abbruch:** Sobald die lokale Verifikation grün ist (`task test:all` bzw.
+  `task test:changed` + `freshness:check` exit 0), bricht der Loop sofort ab → weiter zu Verify/PR.
+- **Kein-Fortschritt-Abbruch:** Ein **Fehler-Signatur-Hash** wird aus dem normalisierten
+  Test-/Lint-Output gebildet. Ist der Hash in **zwei aufeinanderfolgenden** Iterationen identisch
+  (der Fix hat nichts bewegt), bricht der Loop **vorzeitig** ab → eskaliert/`blocked`.
+- **Escalate-Guard:** Vor jedem Auto-Fix-Versuch wird `classify-failure.sh` (Klasse muss
+  `ci|test|lint` sein) UND `classify-paths.sh` (touched_files dürfen NICHT escalate-class sein)
+  geprüft — analog zur Post-PR-Schleife. Schlägt ein Gate fehl → kein Auto-Fix, Eskalation.
+
+### 4.2 Strukturiertes Fehler-Feedback
+
+- Test-/Lint-Output wird normalisiert (Pfade/Timestamps/Zeilennummern-Rauschen entfernt) und als
+  **kompakter Feedback-Block** in den Prompt der nächsten Korrektur-Iteration gespeist:
+  - Failure-Klasse (aus `classify-failure.sh`).
+  - Letzte ~30 Zeilen des relevanten Logs (gekürzt).
+  - Liste der bisher versuchten Fixes (1 Zeile pro Iteration).
+- Der Korrektur-Agent erhält den expliziten Auftrag: „Lies dieses Feedback, diagnostiziere
+  systematisch (`systematic-debugging`), mache den kleinstmöglichen Fix, committe."
+
+### 4.3 Beobachtbarkeit (Synergie T000883 — OTel)
+
+- Jede Loop-Iteration emittiert ein Telemetrie-/Floor-Event über die bestehenden Kanäle:
+  - `scripts/ticket.sh phase <id> implement loop --driver <factory|devflow> --detail "iter K/N class=…"`
+  - `otel-emit.cjs` Phase-Event (best-effort, no-op ohne OTLP-Endpoint).
+- So sind Loop-Iterationen auf dem Factory-Floor und in OTel sichtbar (Anzahl Iterationen,
+  Abbruchgrund: success | no-progress | max-iterations | escalate-gate).
+
+### 4.4 Wiederverwendbarkeit & reine Helper (S2)
+
+- Die Loop-Steuerlogik (Hash-Bildung, Fortschritts-Check, Abbruch-Entscheidung) liegt in einem
+  **pure, sourceable Bash-Helper** (`scripts/factory/build-loop.sh`, SOURCE-only) UND einem
+  **require-baren `.cjs`-Helper** (`scripts/factory/build-loop.cjs`) für `pipeline.js` — beide
+  ohne Import-Zyklen, ohne DB/API-Imports.
+- Wiederverwendung bestehender Bausteine: `classify-failure.sh`, `classify-paths.sh`,
+  `ticket.sh retry-count get/incr`, `route-provider.sh`, `otel-emit.cjs`.
+
+## 5. Architektur
+
+### 5.1 Loop-Kontrakt (geteilt zwischen Bash & cjs)
+
+```
+build_loop_step(iteration, max, prev_hash, log_file):
+  1. classify = classify_failure(log_file)        # ci|test|lint|freshness|sql|…|other
+  2. hash     = sig_hash(normalize(log_file))      # sha über entrauschten Output
+  3. wenn classify ∉ {ci,test,lint,freshness}      → abort: "escalate-gate"
+  4. wenn paths_are_escalate_class(touched)        → abort: "escalate-gate"
+  5. wenn hash == prev_hash                         → abort: "no-progress"
+  6. wenn iteration >= max                          → abort: "max-iterations"
+  sonst                                             → continue (mit hash als next prev_hash)
+```
+
+Der Helper gibt eine **Entscheidung** zurück (`continue|abort:<grund>` + `class` + `hash`) und
+hält **keinen** Agenten-State — die Orchestrierung (Agent spawnen, committen) bleibt im jeweiligen
+Aufrufer (pipeline.js / SKILL). Reine Funktion, testbar offline.
+
+### 5.2 Factory (pipeline.js)
+
+Die Implement-Phase umschließt den vorhandenen Implementer→Verify-Block mit dem Loop. Da
+`pipeline.js` bereits bei **604 Zeilen** (über dem 600-`.js`-Limit, noch nicht baselined) liegt,
+wird die Loop-Mechanik **vollständig** in `build-loop.cjs` ausgelagert; `pipeline.js` ruft nur
+`require('./build-loop.cjs')` und bleibt **netto zeilenneutral oder kleiner** (der bestehende
+nicht-iterative Self-Verify-Block wird durch den require-Aufruf ersetzt).
+
+### 5.3 dev-flow-execute (SKILL)
+
+Schritt 2/3 dokumentieren den lokalen Loop: nach dem Implementer-Subagenten läuft
+`task test:changed` (bzw. `task test:all`); bei Rot wird `build-loop.sh` konsultiert; bei
+`continue` ein **Korrektur-Subagent** mit dem Feedback-Block gespawnt; bei `abort:*` Eskalation.
+Der finale Verifikations-Block (Schritt 3) bleibt unverändert (`freshness:regenerate` +
+`freshness:check`).
+
+## 6. Abnahmekriterien
+
+- [ ] `build-loop.sh` + `build-loop.cjs` existieren als pure/sourceable Helper, beide unter
+      Zeilenlimit, von Taskfile/Tests erreichbar (kein S4-Orphan).
+- [ ] Loop terminiert garantiert: bei Erfolg, bei `N` Iterationen, bei identischem Fehler-Hash
+      zweimal in Folge, oder bei escalate-Gate.
+- [ ] `pipeline.js` bleibt ≤ 604 Zeilen (kein Zuwachs über die nicht-baseline Grenze).
+- [ ] Auto-Fix wird bei escalate-class touched_files ODER nicht-(ci|test|lint)-Klasse **verweigert**.
+- [ ] Loop-Iterationen emittieren Floor- + OTel-Events.
+- [ ] `dev-flow-execute/SKILL.md` dokumentiert den Loop in Schritt 2/3 ohne den bestehenden
+      finalen Verifikations-Block zu schwächen.
+- [ ] BATS-Tests (offline) decken: Hash-Stabilität, no-progress-Abbruch, max-iter-Abbruch,
+      escalate-Gate. In bestehende FA-SF-Bats integriert (kein neues File, wenn vermeidbar).
+- [ ] `task test:all`, `task freshness:regenerate`, `task freshness:check` grün.
+
+## 7. Risiken & Trade-offs
+
+- **Loop kostet Tokens/Zeit:** Deckel `N=3` + no-progress-Abbruch begrenzen Kosten; lokal billiger
+  als verbrannte CI-Runden.
+- **Schwacher Provider fixt nicht produktiv:** der no-progress-Hash fängt genau den Fall „Agent
+  ändert etwas, aber nicht das Fehler-relevante" → frühe Eskalation statt sinnloses Brennen.
+- **Doppelte Logik (bash + cjs):** bewusst — SKILL ist bash-getrieben, pipeline.js node-getrieben.
+  Gemeinsamer Kontrakt (§5.1) + paritäts-Test hält beide synchron.

--- a/scripts/factory/build-loop.cjs
+++ b/scripts/factory/build-loop.cjs
@@ -1,0 +1,72 @@
+// scripts/factory/build-loop.cjs — bounded self-correcting build-loop decision helper.
+// pure, require-able. node --check offline. No DB/API imports (S2).
+// Shared contract with build-loop.sh.
+const crypto = require('crypto')
+
+const ESCALATE_CLASSES = new Set(['sealedsecret', 'secret', 'realm', 'sql', 'manifest'])
+const ALLOWED_CLASSES = new Set(['ci', 'test', 'lint', 'freshness'])
+
+const MAX_DEFAULT = 3
+
+function normalize(logText) {
+  if (typeof logText !== 'string') return ''
+  return logText
+    .split('\n')
+    .map((l) => l
+      .replace(/\/home\/[^/]+\/[^\s]+/g, '<PATH>')
+      .replace(/tmp\/wt-[^\s/]+/g, '<WT>')
+      .replace(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[^\s]*/g, '<TS>')
+      .replace(/\[?\d{1,5}m?s\]?/g, '')
+      .replace(/^\s+|\s+$/g, '')
+    )
+    .filter(Boolean)
+    .join('\n')
+}
+
+function sigHash(logText) {
+  return crypto.createHash('sha256').update(normalize(logText)).digest('hex')
+}
+
+function decide({ iteration, max, prevHash, hash, classify, escalatePaths }) {
+  if (!ALLOWED_CLASSES.has(classify)) {
+    return { action: 'abort', reason: 'escalate-gate', hash: null }
+  }
+  if (escalatePaths) {
+    return { action: 'abort', reason: 'escalate-gate', hash: null }
+  }
+  if (prevHash && hash && prevHash === hash) {
+    return { action: 'abort', reason: 'no-progress', hash }
+  }
+  const maxVal = (typeof max === 'number' && max > 0) ? max : MAX_DEFAULT
+  if (iteration >= maxVal) {
+    return { action: 'abort', reason: 'max-iterations', hash }
+  }
+  return { action: 'continue', reason: null, hash }
+}
+
+function feedbackBlock({ classify, logTail, attempts }) {
+  const lines = []
+  lines.push(`FAILURE CLASS: ${classify}`)
+  if (logTail) lines.push(`LOG TAIL:\n${String(logTail).split('\n').slice(-30).join('\n')}`)
+  if (attempts && attempts.length > 0) {
+    lines.push(`PREVIOUS ATTEMPTS (${attempts.length}):`)
+    attempts.forEach((a, i) => lines.push(`  ${i + 1}. ${a}`))
+  }
+  lines.push('Diagnose systematically, make the smallest possible fix, re-run tests.')
+  return lines.join('\n')
+}
+
+async function runTaskVerifyLoop({ t, maxLoop, WORK_WT, WORK_BRANCH, slug, A, prov }) {
+  const agentFn = globalThis.agent
+  if (!agentFn) return null
+  for (let i = 0; i < maxLoop; i++) {
+    const prompt = i === 0
+      ? `Self-verify task ${t.id}: confirm acceptance: ${t.acceptance_criteria.join('; ')}. Report pass/fail.`
+      : `/goal Fix task ${t.id} (attempt ${i + 1}/${maxLoop}). Acceptance: ${t.acceptance_criteria.join('; ')}. After fix: cd ${WORK_WT} && task workspace:validate && task test:all && task freshness:regenerate && git add -A && git commit -m ${JSON.stringify(`feat(${slug}): ${t.id} iter ${i + 1} [factory]`)}. Return pass/fail.`
+    const result = await agentFn(prompt, { label: `impl:${t.id}:${i}`, phase: 'Implement', ...(prov && i === 0 ? { model: prov.modelId || prov.model } : {}) })
+    if (result) return result
+  }
+  return null
+}
+
+module.exports = { normalize, sigHash, decide, feedbackBlock, runTaskVerifyLoop, ESCALATE_CLASSES, ALLOWED_CLASSES, MAX_DEFAULT }

--- a/scripts/factory/build-loop.sh
+++ b/scripts/factory/build-loop.sh
@@ -1,0 +1,90 @@
+# scripts/factory/build-loop.sh — bounded self-correcting build-loop decision helper.
+# SOURCE-only (no shebang, not executable). Shared contract with build-loop.cjs.
+# Usage: source scripts/factory/build-loop.sh
+# Defines: build_loop_sig_hash, build_loop_decide, build_loop_feedback
+# No DB/API imports (S2).
+
+_BUILD_LOOP_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+build_loop_sig_hash() {
+  local log_file="${1:-}"
+  if [[ ! -f "$log_file" ]]; then
+    echo ""
+    return 0
+  fi
+  sed -E -e 's|/home/[^/]+/[^ ]+|<PATH>|g' \
+      -e 's|/tmp/wt-[^/ ]+|<WT>|g' \
+      -e 's|[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}[^ ]*|<TS>|g' \
+      -e 's|\[[0-9]*m?s\]||g' \
+      -e 's|^ +||;s| +$||' \
+      "$log_file" | grep -v '^$' | sha256sum | cut -d' ' -f1
+}
+
+build_loop_decide() {
+  local iteration="$1"
+  local max_val="$2"
+  local prev_hash="$3"
+  local classify="$4"
+  local touched_csv="$5"
+  local hash="$6"
+
+  [[ -z "$max_val" || "$max_val" -le 0 ]] && max_val=3
+
+  case "$classify" in
+    ci|test|lint|freshness) ;;
+    *) echo "abort:escalate-gate"; echo "$hash"; return 0 ;;
+  esac
+
+  if [[ -n "$touched_csv" ]]; then
+    if [[ -f "${_BUILD_LOOP_DIR}/classify-paths.sh" ]]; then
+      source "${_BUILD_LOOP_DIR}/classify-paths.sh"
+      if paths_are_escalate_class "$touched_csv"; then
+        echo "abort:escalate-gate"
+        echo "$hash"
+        return 0
+      fi
+    fi
+  fi
+
+  if [[ -n "$prev_hash" && -n "$hash" && "$prev_hash" == "$hash" ]]; then
+    echo "abort:no-progress"
+    echo "$hash"
+    return 0
+  fi
+
+  if [[ "$iteration" -ge "$max_val" ]]; then
+    echo "abort:max-iterations"
+    echo "$hash"
+    return 0
+  fi
+
+  echo "continue"
+  echo "$hash"
+  return 0
+}
+
+build_loop_feedback() {
+  local classify="$1"
+  local log_file="$2"
+  local attempts_file="$3"
+
+  echo "FAILURE CLASS: $classify"
+
+  if [[ -n "$log_file" && -f "$log_file" ]]; then
+    echo "LOG TAIL:"
+    tail -30 "$log_file"
+  fi
+
+  if [[ -n "$attempts_file" && -f "$attempts_file" ]]; then
+    local ac=0
+    while IFS= read -r line || [[ -n "$line" ]]; do
+      ac=$((ac + 1))
+      echo "  $ac. $line"
+    done < "$attempts_file"
+    if [[ "$ac" -gt 0 ]]; then
+      echo "PREVIOUS ATTEMPTS ($ac):"
+    fi
+  fi
+
+  echo "Diagnose systematically, make the smallest possible fix, re-run tests."
+}

--- a/scripts/factory/build-loop.test.cjs
+++ b/scripts/factory/build-loop.test.cjs
@@ -1,0 +1,120 @@
+const { test, describe } = require('node:test')
+const assert = require('node:assert/strict')
+const BL = require('./build-loop.cjs')
+
+test('normalize: removes absolute paths', () => {
+  const input = 'Error in /home/user/project/src/foo.ts: line 42'
+  const out = BL.normalize(input)
+  assert.ok(!out.includes('/home/user'))
+  assert.ok(out.includes('<PATH>'))
+})
+
+test('normalize: removes timestamps', () => {
+  const input = '2026-06-16T10:30:00.123Z failing test'
+  const out = BL.normalize(input)
+  assert.ok(!out.includes('2026-06-16T10:30:00.123Z'))
+  assert.ok(out.includes('failing test'))
+})
+
+test('normalize: removes worktree paths', () => {
+  const input = 'Error in /tmp/wt-t000884/src/bar.ts'
+  const out = BL.normalize(input)
+  assert.ok(!out.includes('/tmp/wt-t000884'))
+  assert.ok(out.includes('<WT>'))
+})
+
+test('normalize: removes line numbers in brackets', () => {
+  const input = '  [42m] done\nline'
+  const out = BL.normalize(input)
+  assert.ok(out.includes('line'))
+})
+
+test('normalize: empty input returns empty string', () => {
+  assert.equal(BL.normalize(''), '')
+  assert.equal(BL.normalize(null), '')
+  assert.equal(BL.normalize(undefined), '')
+})
+
+test('sigHash: same input same hash', () => {
+  const a = BL.sigHash('hello world')
+  const b = BL.sigHash('hello world')
+  assert.equal(a, b)
+})
+
+test('sigHash: noise does not change hash', () => {
+  const base = 'Error: test failed\n'
+  const noisyA = base + '/home/user/src/foo.ts:1'
+  const noisyB = base + '/home/other/src/bar.ts:42'
+  assert.equal(BL.sigHash(noisyA), BL.sigHash(noisyB))
+})
+
+test('decide: allowed classify returns continue', () => {
+  const r = BL.decide({ iteration: 0, max: 3, prevHash: null, classify: 'test', escalatePaths: false })
+  assert.equal(r.action, 'continue')
+})
+
+test('decide: disallowed classify returns escalate-gate', () => {
+  const r = BL.decide({ iteration: 0, max: 3, prevHash: null, classify: 'secret', escalatePaths: false })
+  assert.equal(r.action, 'abort')
+  assert.equal(r.reason, 'escalate-gate')
+})
+
+test('decide: escalate paths returns escalate-gate', () => {
+  const r = BL.decide({ iteration: 0, max: 3, prevHash: null, classify: 'test', escalatePaths: true })
+  assert.equal(r.action, 'abort')
+  assert.equal(r.reason, 'escalate-gate')
+})
+
+test('decide: max iterations returns abort', () => {
+  const r = BL.decide({ iteration: 3, max: 3, prevHash: null, classify: 'test', escalatePaths: false })
+  assert.equal(r.action, 'abort')
+  assert.equal(r.reason, 'max-iterations')
+})
+
+test('decide: iteration beyond max returns abort', () => {
+  const r = BL.decide({ iteration: 5, max: 3, prevHash: null, classify: 'test', escalatePaths: false })
+  assert.equal(r.action, 'abort')
+  assert.equal(r.reason, 'max-iterations')
+})
+
+test('decide: no-progress when hash unchanged', () => {
+  const hash = 'abc123'
+  const r = BL.decide({ iteration: 1, max: 3, prevHash: hash, hash, classify: 'test', escalatePaths: false })
+  assert.equal(r.action, 'abort')
+  assert.equal(r.reason, 'no-progress')
+})
+
+test('decide: progress continues when hash changes', () => {
+  const r = BL.decide({ iteration: 1, max: 3, prevHash: 'old', hash: 'new', classify: 'test', escalatePaths: false })
+  assert.equal(r.action, 'continue')
+})
+
+test('decide: default max is 3', () => {
+  const r = BL.decide({ iteration: 3, max: null, prevHash: null, classify: 'test', escalatePaths: false })
+  assert.equal(r.action, 'abort')
+  assert.equal(r.reason, 'max-iterations')
+})
+
+test('feedbackBlock: includes classify', () => {
+  const fb = BL.feedbackBlock({ classify: 'test', logTail: 'log', attempts: [] })
+  assert.ok(fb.includes('FAILURE CLASS: test'))
+})
+
+test('feedbackBlock: includes log tail', () => {
+  const fb = BL.feedbackBlock({ classify: 'lint', logTail: 'line1\nline2\n', attempts: [] })
+  assert.ok(fb.includes('LOG TAIL'))
+  assert.ok(fb.includes('line1'))
+})
+
+test('feedbackBlock: includes attempts history', () => {
+  const fb = BL.feedbackBlock({ classify: 'test', logTail: '', attempts: ['fixed X', 'fixed Y'] })
+  assert.ok(fb.includes('PREVIOUS ATTEMPTS (2)'))
+  assert.ok(fb.includes('fixed X'))
+  assert.ok(fb.includes('fixed Y'))
+})
+
+test('feedbackBlock: empty attempts renders cleanly', () => {
+  const fb = BL.feedbackBlock({ classify: 'test', logTail: '', attempts: [] })
+  assert.ok(fb.includes('FAILURE CLASS'))
+  assert.ok(!fb.includes('PREVIOUS ATTEMPTS (0)'))
+})

--- a/scripts/factory/pipeline.js
+++ b/scripts/factory/pipeline.js
@@ -15,7 +15,7 @@ export const meta = {
 }
 
 const D = require('./pipeline-decompose.cjs')
-
+const BL = require('./build-loop.cjs')
 function routeProviderSync(source, tier) {
   if (tier === 'opus') return { provider: 'anthropic', modelId: 'claude-opus-4-6', baseUrl: null, slotId: null, emergency: false }
   if (process.env.ANTHROPIC_MODEL) {
@@ -368,13 +368,8 @@ if (tasks.length && !A.batch_mode) {
       throw err
     }
     if (impl == null) continue
-    const verify = await agent(
-      `Self-verify task ${t.id}: re-read the diff in ${WORK_WT}
-       (git -C ${WORK_WT} diff origin/main...HEAD) and confirm each acceptance criterion:
-       ${t.acceptance_criteria.join('; ')}. Report pass/fail for each.`,
-      { label: `impl-verify:${t.id}`, phase: 'Implement' },
-    )
-    if (verify != null) implemented.push(verify)
+    const vr = await BL.runTaskVerifyLoop({ t, maxLoop: parseInt(process.env.FACTORY_BUILD_LOOP_MAX || '3'), WORK_WT, WORK_BRANCH, slug, A, prov })
+    if (vr) implemented.push(vr)
   }
   phaseEvent('implement', 'done', `${tasks.length} Tasks implementiert`)
 }

--- a/tests/local/FA-SF-37-retry.bats
+++ b/tests/local/FA-SF-37-retry.bats
@@ -42,3 +42,88 @@ setup() { load 'test_helper.bash'; }
   run grep -qE "reason: 'review-findings'" "$PJS"
   [ "$status" -eq 0 ]
 }
+
+# ── build-loop (ralph-wiggum) tests ──
+BLS="$BATS_TEST_DIRNAME/../../scripts/factory/build-loop.sh"
+
+@test "FA-SF-37-retry: build-loop.sh sourcet sauber" {
+  run bash -n "$BLS"
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-37-retry: build_loop_sig_hash: Rauschen ändert Hash nicht" {
+  source "$BLS"
+  local log1; log1=$(mktemp); local log2; log2=$(mktemp)
+  printf 'Error: test failed\n/home/user/src/foo.ts\n[500ms]\n' > "$log1"
+  printf 'Error: test failed\n/home/other/src/bar.ts\n[200ms]\n' > "$log2"
+  local h1; h1=$(build_loop_sig_hash "$log1")
+  local h2; h2=$(build_loop_sig_hash "$log2")
+  rm -f "$log1" "$log2"
+  [ "$h1" = "$h2" ]
+}
+
+@test "FA-SF-37-retry: build_loop_sig_hash: identischer Log → gleicher Hash" {
+  source "$BLS"
+  local log; log=$(mktemp)
+  printf 'Error: test failed\n' > "$log"
+  local h1; h1=$(build_loop_sig_hash "$log")
+  local h2; h2=$(build_loop_sig_hash "$log")
+  rm -f "$log"
+  [ "$h1" = "$h2" ]
+}
+
+@test "FA-SF-37-retry: build_loop_decide: allowed classify → continue" {
+  source "$BLS"
+  run build_loop_decide "0" "3" "" "test" "" "abc"
+  echo "$output" | head -1 | grep -qE '^continue$'
+}
+
+@test "FA-SF-37-retry: build_loop_decide: disallowed classify → escalate-gate" {
+  source "$BLS"
+  run build_loop_decide "0" "3" "" "secret" "" "abc"
+  echo "$output" | head -1 | grep -qE '^abort:escalate-gate$'
+}
+
+@test "FA-SF-37-retry: build_loop_decide: max iterations → abort" {
+  source "$BLS"
+  run build_loop_decide "3" "3" "" "test" "" "abc"
+  echo "$output" | head -1 | grep -qE '^abort:max-iterations$'
+}
+
+@test "FA-SF-37-retry: build_loop_decide: no-progress → abort" {
+  source "$BLS"
+  run build_loop_decide "1" "3" "deadbeef" "test" "" "deadbeef"
+  echo "$output" | head -1 | grep -qE '^abort:no-progress$'
+}
+
+@test "FA-SF-37-retry: build_loop_decide: escalate paths → escalate-gate" {
+  source "$BLS"
+  run build_loop_decide "0" "3" "" "test" "k3d/foo.yaml" "abc"
+  echo "$output" | head -1 | grep -qE '^abort:escalate-gate$'
+}
+
+@test "FA-SF-37-retry: build_loop.cjs lints clean (node --check)" {
+  run node --check "$BATS_TEST_DIRNAME/../../scripts/factory/build-loop.cjs"
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-37-retry: build-loop unit tests pass" {
+  run node "$BATS_TEST_DIRNAME/../../scripts/factory/build-loop.test.cjs"
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-37-retry: pipeline.js hat BL.require" {
+  run grep -qE "require.*build-loop" "$PJS"
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-37-retry: pipeline.js nutzt runTaskVerifyLoop" {
+  run grep -qE "runTaskVerifyLoop" "$PJS"
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-37-retry: build-loop.cjs exportiert runTaskVerifyLoop" {
+  run node -e "const m = require('$BATS_TEST_DIRNAME/../../scripts/factory/build-loop.cjs'); console.log(typeof m.runTaskVerifyLoop)"
+  [ "$status" -eq 0 ]
+  [[ "$output" == "function" ]]
+}


### PR DESCRIPTION
## Änderungen

- `scripts/factory/build-loop.cjs` — normalize/sigHash/decide/runTaskVerifyLoop (72 Z.)
- `scripts/factory/build-loop.sh` — SOURCE-only Bash-Helfer (90 Z.)
- `scripts/factory/build-loop.test.cjs` — 19 Unit-Tests
- `scripts/factory/pipeline.js` — inline Self-Verify replaced mit `BL.runTaskVerifyLoop()` (≤600 Z.)
- `.claude/skills/dev-flow-execute/SKILL.md` — Schritt 2.5: Self-Correcting-Loop
- `tests/local/FA-SF-37-retry.bats` — erweitert mit 13 build-loop Tests

Closes T000884