### PR TITLE
feat(ops): token/cost control — precompact-prune + usage-report [T000885]

### DIFF
--- a/Taskfile.factory.yml
+++ b/Taskfile.factory.yml
@@ -113,6 +113,11 @@ tasks:
     cmds:
       - bash scripts/factory/budget-guard.sh "{{.ENV}}"
 
+  usage:
+    desc: "Cross-Tool-CLI Token/Kosten-Überblick (tokscale-Delta, read-only). Usage: task factory:usage -- [--json] [--otel]"
+    cmds:
+      - bash scripts/factory/usage-report.sh {{.CLI_ARGS}}
+
   disp:korczewski:
     desc: "Run Software Factory schedule for korczewski brand (convenience wrapper for disp-korczewski.sh)"
     cmds:

--- a/docs/superpowers/plans/2026-06-16-t000885.md
+++ b/docs/superpowers/plans/2026-06-16-t000885.md
@@ -4,9 +4,9 @@ ticket_id: T000885
 domains: [infra, ops]
 status: active
 pr_number: null
-file_locks: []
+file_locks: [Taskfile.yml, website/src/data/test-inventory.json]
 shared_changes: false
-batch_id: null
+batch_id: batch-2026-06-16-planning
 parent_feature: null
 depends_on_plans: []
 ---
@@ -45,8 +45,8 @@ bestehende Factory-Budget-/OTel-Infra zu duplizieren:
 |-------|--------|-----|-------------------|--------|
 | `scripts/hooks/precompact-prune.sh` (NEU) | neu | 0 | 500 (`.sh`) | Ziel < 200 (Reserve) |
 | `scripts/factory/usage-report.sh` (NEU) | neu | 0 | 500 (`.sh`) | Ziel < 200 (Reserve) |
-| `tests/local/FA-SF-50-precompact-prune.bats` (NEU) | neu | 0 | — (Tests gebaselined-ignoriert) | — |
-| `tests/local/FA-SF-51-usage-report.bats` (NEU) | neu | 0 | — | — |
+| `tests/local/FA-SF-54-precompact-prune.bats` (NEU) | neu | 0 | — (Tests gebaselined-ignoriert) | — |
+| `tests/local/FA-SF-55-usage-report.bats` (NEU) | neu | 0 | — | — |
 | `Taskfile.yml` | geändert | groß (gebaselined) | — | nur +wenige Zeilen (neuer Task) — netto minimal; falls Baseline-Wachstum droht: zeilenneutral halten |
 | `scripts/factory/README.md` | Doku | — | n/a (.md) | — |
 
@@ -78,7 +78,7 @@ erreichbar; `precompact-prune.sh` wird in `scripts/factory/README.md` + neuer Do
   Payload auf stdin). Annahmen aus Spec §8 bestätigen oder anpassen. Erkenntnisse als Kommentar im
   Skript-Kopf festhalten. (Keine Code-Änderung.)
 
-- [ ] **A2. TDD: BATS `tests/local/FA-SF-50-precompact-prune.bats` zuerst.** Fixtures als Inline-
+- [ ] **A2. TDD: BATS `tests/local/FA-SF-54-precompact-prune.bats` zuerst.** Fixtures als Inline-
   Heredoc-JSONL im `setup()` (außerhalb des Repos via `$BATS_TMPDIR`/`mktemp -d`, teardown-Cleanup
   — Memory-Regel). Cases:
   - fehlendes/leeres Transcript → no-op, Exit 0, kein Schreibzugriff
@@ -116,7 +116,7 @@ erreichbar; `precompact-prune.sh` wird in `scripts/factory/README.md` + neuer Do
   Logs am Host verifizieren (Token-Zähler, Modell-ID, Timestamp, Tool-Kennung). Defensive Feld-
   Annahmen festhalten. (Keine Code-Änderung.)
 
-- [ ] **B2. TDD: BATS `tests/local/FA-SF-51-usage-report.bats` zuerst.** Fixture-JSONL in
+- [ ] **B2. TDD: BATS `tests/local/FA-SF-55-usage-report.bats` zuerst.** Fixture-JSONL in
   `$BATS_TMPDIR`, Log-Dirs via Env (`CLAUDE_USAGE_DIR`/`OPENCLAW_USAGE_DIR`) überschreibbar. Cases:
   - fehlende Log-Dirs → 0-Aggregate, Exit 0
   - Fixtures → korrekte Summen pro Tag / Modell / Tool
@@ -147,7 +147,7 @@ erreichbar; `precompact-prune.sh` wird in `scripts/factory/README.md` + neuer Do
   scripts/factory/usage-report.sh`; `shellcheck` beide (lokal, da CI keinen shellcheck fährt).
 
 - [ ] **C2. Gezielte Tests:** `./tests/unit/lib/bats-core/bin/bats
-  tests/local/FA-SF-50-precompact-prune.bats tests/local/FA-SF-51-usage-report.bats` → grün.
+  tests/local/FA-SF-54-precompact-prune.bats tests/local/FA-SF-55-usage-report.bats` → grün.
 
 - [ ] **C3. Test-Inventar regenerieren** (neue BATS hinzugefügt):
   `task test:inventory` und `website/src/data/test-inventory.json` mitcommitten.
@@ -171,3 +171,19 @@ erreichbar; `precompact-prune.sh` wird in `scripts/factory/README.md` + neuer Do
   usage-report über README referenziert → kein Orphan). Bevorzugt Taskfile (bessere Erreichbarkeit).
 - **Skript wächst >~400 Zeilen.** Heuristik in `*-lib.sh` auslagern (Modul-Split) — aktuell nicht
   erwartet.
+
+## Parallelorchestration (Batch `batch-2026-06-16-planning`)
+
+Teil des 3er-Batches **T000884 ∥ T000885 ∥ T000886**. Code-Dateien sind disjunkt; parallele
+Ausführung ist sicher. Geteilte Berührungspunkte (in dieser Datei: `Taskfile.yml`,
+`website/src/data/test-inventory.json`) werden über die **Merge-Disziplin** gelöst, nicht durch
+Hand-Merge:
+
+- **FA-SF-Nummern:** dieser Plan nutzt **FA-SF-54 / FA-SF-55** (50–53 sind belegt). T000884 nutzt
+  FA-SF-56 → keine Kollision.
+- **`Taskfile.yml`:** dieser Plan ergänzt einen `factory:usage`-Task; T000886 ergänzt
+  `test:unit:*`-Subtasks — **disjunkte Sektionen**. Beim sequentiellen Merge rebaset der jeweils
+  spätere Branch auf `main` (trivialer 3-way-Merge). Empfohlene Merge-Reihenfolge: **T000884 →
+  T000885 → T000886** (T000884 berührt `Taskfile.yml` nicht).
+- **`website/src/data/test-inventory.json`:** generiert. Nach jedem Rebase **regenerieren**
+  (`task test:inventory`), niemals hand-mergen (Konflikt-Magnet wie die freshness-Artefakte).

--- a/docs/superpowers/plans/2026-06-16-t000885.md
+++ b/docs/superpowers/plans/2026-06-16-t000885.md
@@ -1,0 +1,173 @@
+---
+title: Plan: T000885 — Token-/Kosten-Kontrolle (Context-Pruning + Usage-Tracking)
+ticket_id: T000885
+domains: [infra, ops]
+status: active
+pr_number: null
+file_locks: []
+shared_changes: false
+batch_id: null
+parent_feature: null
+depends_on_plans: []
+---
+
+# Plan: T000885 — Token-/Kosten-Kontrolle (Context-Pruning + Usage-Tracking)
+
+**Ticket:** T000885
+**Branch:** feature/t000885
+**Spec:** docs/superpowers/specs/2026-06-16-t000885-design.md
+**Domains:** infra, ops
+
+## Ziel
+
+Zwei getrennte, abhängigkeitsarme Hebel gegen Token-Kosten/Context-Bloat liefern, **ohne**
+bestehende Factory-Budget-/OTel-Infra zu duplizieren:
+
+- **A:** versionierter PreCompact-Pruning-Hook `scripts/hooks/precompact-prune.sh` (Opt-in, kein
+  Auto-Wiring) kürzt obsolete Tool-Outputs vor `/compact`.
+- **B:** read-only `scripts/factory/usage-report.sh` (tokscale-Delta) für Cross-Tool-CLI-Token-/
+  Kosten-Aggregate, optional via bestehendem `otel-emit.sh` an den Collector.
+
+## Architektur & Tech-Stack
+
+- **Bash** (kein Vendoring, keine npm-Deps). `jq` für JSONL-Parsing (im Repo-Toolset vorhanden).
+- Wiederverwendet: `scripts/factory/otel-emit.sh` (fire-and-forget OTLP). KEIN neuer Emitter,
+  KEINE neue DB-Tabelle (`tickets.factory_run_budget` bleibt SSOT für Per-Ticket-Kosten).
+- Opt-in-Lieferweg analog `scripts/factory/autopilot.env.example` (`.claude/settings.json`
+  gitignored → Skript versioniert + Doku, manuelles Wiring).
+- Tests: BATS unter `tests/local/FA-SF-*` (laufen via `task test:factory`).
+
+## Plan-Quality-Gates (geprüft gegen .claude/skills/references/plan-quality-gates.md)
+
+**S1 — Zeilenbudget (Limit `.sh`=500, `.bash`=300; Baseline-Werte geprüft):**
+
+| Datei | Status | Ist | Wirksame Schwelle | Budget |
+|-------|--------|-----|-------------------|--------|
+| `scripts/hooks/precompact-prune.sh` (NEU) | neu | 0 | 500 (`.sh`) | Ziel < 200 (Reserve) |
+| `scripts/factory/usage-report.sh` (NEU) | neu | 0 | 500 (`.sh`) | Ziel < 200 (Reserve) |
+| `tests/local/FA-SF-50-precompact-prune.bats` (NEU) | neu | 0 | — (Tests gebaselined-ignoriert) | — |
+| `tests/local/FA-SF-51-usage-report.bats` (NEU) | neu | 0 | — | — |
+| `Taskfile.yml` | geändert | groß (gebaselined) | — | nur +wenige Zeilen (neuer Task) — netto minimal; falls Baseline-Wachstum droht: zeilenneutral halten |
+| `scripts/factory/README.md` | Doku | — | n/a (.md) | — |
+
+`Taskfile.yml` ist gebaselined; der neue `factory:usage`-Task fügt ~6 Zeilen hinzu. Vor Commit
+`jq -r '."S1:Taskfile.yml".metric' docs/code-quality/baseline.json` prüfen — liegt der Ist-Wert
+unter Baseline (Headroom), ist +6 ok; sonst Task minimal halten. **S1-Schwelle der neuen Skripte
+ist großzügig**; sollte ein Skript >~400 Zeilen wachsen → reine Heuristik-Funktion in
+`scripts/factory/usage-lib.sh` bzw. `scripts/hooks/prune-lib.sh` auslagern (Modul-Split
+einplanen). Aktuelle Schätzung: beide < 200, kein Split nötig.
+
+**S2 — Import-Zyklen:** Bash-Skripte; nur `source scripts/factory/otel-emit.sh` (pure,
+fire-and-forget, ohne DB/API). Keine Rück-Abhängigkeit.
+
+**S3 — Hostnamen:** keine Brand-Domain-Literale; OTLP-Endpoint ausschließlich aus
+`OTEL_EXPORTER_OTLP_ENDPOINT`-Env. Doku-Beispiele nutzen `otel.example.invalid` (wie
+autopilot.env.example).
+
+**S4 — Orphan-Vermeidung:** `usage-report.sh` wird über neuen Taskfile-Task `factory:usage`
+erreichbar; `precompact-prune.sh` wird in `scripts/factory/README.md` + neuer Doku referenziert
+(Opt-in-Hook, kein Taskfile-Einstieg nötig, aber dokumentiert → kein Orphan). Beide BATS in
+`tests/local/FA-SF-*` werden bereits vom bestehenden Glob in `task test:factory` erfasst.
+
+---
+
+## Phase A — PreCompact-Pruning-Hook (ops)
+
+- [ ] **A1. Spike: Transcript-Format verifizieren.** Eine echte Claude-Code-Transcript-JSONL am
+  WSL-Host inspizieren (Struktur eines `tool_use`/`tool_result`-Eintrags, Pfad in PreCompact-Hook-
+  Payload auf stdin). Annahmen aus Spec §8 bestätigen oder anpassen. Erkenntnisse als Kommentar im
+  Skript-Kopf festhalten. (Keine Code-Änderung.)
+
+- [ ] **A2. TDD: BATS `tests/local/FA-SF-50-precompact-prune.bats` zuerst.** Fixtures als Inline-
+  Heredoc-JSONL im `setup()` (außerhalb des Repos via `$BATS_TMPDIR`/`mktemp -d`, teardown-Cleanup
+  — Memory-Regel). Cases:
+  - fehlendes/leeres Transcript → no-op, Exit 0, kein Schreibzugriff
+  - obsoletes read-only `tool_result` mit späterem Re-Read desselben Pfads → ersetzt durch
+    `[pruned: ...]`-Marker
+  - jüngstes / im letzten Reasoning referenziertes Output → unangetastet
+  - Idempotenz: zweiter Lauf = byte-identisch
+  - Invariante: jede Output-Zeile valides JSON (`jq -e . `), `tool_use`-/`tool_result`-Count erhalten
+  Tests laufen lassen → müssen **rot** sein (Skript existiert noch nicht).
+
+- [ ] **A3. `scripts/hooks/precompact-prune.sh` implementieren** (`set -uo pipefail`, fail-open):
+  - stdin lesen → Transcript-Pfad extrahieren (`jq -r '.transcript_path // empty'`); leer/fehlend →
+    Exit 0.
+  - Pro Zeile: read-only-Tool + späteres `tool_result` für denselben Ziel-Pfad ODER
+    Alter > `${PRUNE_MIN_AGE_TURNS:-3}` und nicht im jüngsten Reasoning referenziert → content-Feld
+    durch kompakten Marker ersetzen (Originallänge/Turn im Marker). Marker werden NICHT erneut
+    geprunet (Idempotenz).
+  - Atomar zurückschreiben (`tmp` + `mv`), nur wenn Validierung passt (alle Zeilen JSON, Counts
+    gleich); sonst Original lassen.
+  - Opt-Telemetrie: bei gesetztem `OTEL_EXPORTER_OTLP_ENDPOINT`
+    `bash "$(dirname …)/../factory/otel-emit.sh" metric factory.context.pruned_chars "$total"` —
+    fire-and-forget, nie failend.
+  - `chmod +x`. `node --check` n/a (Bash) → `bash -n` lokal.
+  - BATS aus A2 grün.
+
+- [ ] **A4. Opt-in-Doku.** Abschnitt „PreCompact Context-Pruning (Opt-in)" in
+  `scripts/factory/README.md` (oder `docs/superpowers/references/`): zeigt den manuellen
+  `.claude/settings.json`-Hook-Eintrag (`hooks.PreCompact[].hooks[].command =
+  "bash scripts/hooks/precompact-prune.sh"`), Hinweis dass settings.json gitignored + maschinen-
+  gebunden ist, `PRUNE_MIN_AGE_TURNS`-Env. Klarstellen: NICHT auto-aktiviert.
+
+## Phase B — tokscale-Delta: usage-report (infra/ops)
+
+- [ ] **B1. Spike: Usage-Log-Format.** Pfade + JSONL-Schema der Claude-Code- und OpenClaw-Usage-
+  Logs am Host verifizieren (Token-Zähler, Modell-ID, Timestamp, Tool-Kennung). Defensive Feld-
+  Annahmen festhalten. (Keine Code-Änderung.)
+
+- [ ] **B2. TDD: BATS `tests/local/FA-SF-51-usage-report.bats` zuerst.** Fixture-JSONL in
+  `$BATS_TMPDIR`, Log-Dirs via Env (`CLAUDE_USAGE_DIR`/`OPENCLAW_USAGE_DIR`) überschreibbar. Cases:
+  - fehlende Log-Dirs → 0-Aggregate, Exit 0
+  - Fixtures → korrekte Summen pro Tag / Modell / Tool
+  - `--json` → valides JSON (`jq -e`)
+  - `--otel` ohne `OTEL_EXPORTER_OTLP_ENDPOINT` → no-op (kein Netz, Exit 0)
+  Rot laufen lassen.
+
+- [ ] **B3. `scripts/factory/usage-report.sh` implementieren** (read-only, `set -uo pipefail`):
+  - Log-Dirs aus Env mit Defaults (`${CLAUDE_USAGE_DIR:-$HOME/.claude/...}`,
+    `${OPENCLAW_USAGE_DIR:-$HOME/.openclaw/...}`) — exakte Defaults aus B1.
+  - JSONL einlesen, mit `jq`/`awk` nach Tag×Modell×Tool aggregieren (tokens_in/out, cost_usd falls
+    vorhanden, sonst aus Pricing-Map wie budget-estimate.sh).
+  - Default: lesbarer Text. `--json`: maschinenlesbar.
+  - `--otel`: pro Tages-Aggregat `otel-emit.sh metric tokscale.tokens.daily …` /
+    `tokscale.cost.daily.usd …` mit `tool=`/`model=`-Attributen (nur bei gesetztem Endpoint).
+  - **NIE** Prompt-/Completion-Inhalte oder Auth-Material ausgeben (Spec §6).
+  - `chmod +x`, `bash -n`. BATS aus B2 grün.
+
+- [ ] **B4. Taskfile-Einstieg `factory:usage`.** Unter `factory:`-Gruppe in `Taskfile.yml` einen
+  read-only Task ergänzen (`desc` + `cmds: bash scripts/factory/usage-report.sh {{.CLI_ARGS}}`).
+  Vor Commit Baseline-Headroom für `Taskfile.yml` prüfen (S1); Task minimal halten. In
+  `scripts/factory/README.md` kurz dokumentieren (usage-report = Cross-Tool-CLI-Delta, baut NICHT
+  auf factory_run_budget auf).
+
+## Phase C — Verifikation & Abschluss
+
+- [ ] **C1. Lokale Skript-Lints:** `bash -n scripts/hooks/precompact-prune.sh
+  scripts/factory/usage-report.sh`; `shellcheck` beide (lokal, da CI keinen shellcheck fährt).
+
+- [ ] **C2. Gezielte Tests:** `./tests/unit/lib/bats-core/bin/bats
+  tests/local/FA-SF-50-precompact-prune.bats tests/local/FA-SF-51-usage-report.bats` → grün.
+
+- [ ] **C3. Test-Inventar regenerieren** (neue BATS hinzugefügt):
+  `task test:inventory` und `website/src/data/test-inventory.json` mitcommitten.
+
+- [ ] **C4. Finaler Verifikations-Gate (Pflicht):**
+  ```bash
+  task test:all            # = test:changed: factory-BATS (FA-SF-*) + quality gate
+  task freshness:regenerate
+  task freshness:check     # S1–S4-Ratchet + Baseline-Key-Count-Assertion
+  ```
+  Alle grün. Insbesondere: keine Baseline-Neueinträge, `Taskfile.yml` nicht über Baseline gewachsen,
+  keine S3-Domain-Literale, keine Orphan-Skripte (usage-report via `factory:usage`,
+  precompact-prune via README referenziert).
+
+## Risiken / Fallbacks
+
+- **Transcript/Usage-Schema weicht ab (A1/B1).** Parser sind defensiv (unbekannte Felder ignorieren,
+  fehlende = 0); im Zweifel Pruning = no-op (fail-open) bzw. Aggregat = 0. Kein Crash.
+- **Taskfile-Baseline-Wachstum.** Falls `Taskfile.yml` bereits auf Baseline-Grenze: neuen Task
+  zeilenneutral einfügen (kompakte `cmds`-Zeile) oder als Hinweis in README statt Taskfile (dann
+  usage-report über README referenziert → kein Orphan). Bevorzugt Taskfile (bessere Erreichbarkeit).
+- **Skript wächst >~400 Zeilen.** Heuristik in `*-lib.sh` auslagern (Modul-Split) — aktuell nicht
+  erwartet.

--- a/docs/superpowers/specs/2026-06-16-t000885-design.md
+++ b/docs/superpowers/specs/2026-06-16-t000885-design.md
@@ -1,0 +1,142 @@
+# T000885 — Token-/Kosten-Kontrolle: Context-Pruning + Usage-Tracking (tokscale-Muster)
+
+**Status:** Spec · 2026-06-16
+**Domains:** infra, ops
+**Shared-Changes:** nein
+**Quelle:** Ticket T000885 + Gap-Kontext (dev-flow-batch, geklärt 2026-06-16); inspiriert von
+`dynamic-context-pruning` (Tarquinen/opencode-dynamic-context-pruning) und `tokscale` (junhoyeo/tokscale).
+
+## 1. Problem & Motivation
+
+Teil des GPU-/Kosten-Minimierungs-Push (PR #1744). Zwei unabhängige Hebel gegen Token-Kosten und
+Context-Bloat:
+
+1. **Context-Bloat im Orchestrator.** Lange Claude-Code-Sessions (insb. der dev-flow-Orchestrator)
+   sammeln obsolete Tool-Outputs an. Beim `/compact`-Event wird der gesamte Verlauf — inkl.
+   abgeschlossener, längst irrelevanter Tool-Resultate — neu zusammengefasst. Das macht
+   Sessions teurer (mehr Input-Tokens) und langsamer. Es gibt **keinen** PreCompact-Hook und
+   **keine** Pruning-Logik im Repo (verifiziert).
+
+2. **Kostenintransparenz außerhalb der Factory.** Die Factory misst Per-Ticket-Token/Kosten bereits
+   (siehe §2). Was fehlt, ist ein **Cross-Tool-CLI-Überblick** über die tatsächliche Token-Nutzung
+   von Claude Code / OpenClaw insgesamt — auch außerhalb von Factory-Runs (interaktive dev-flow-
+   Sessions, manuelle Arbeit). Genau diesen Gap füllt das `tokscale`-Muster.
+
+## 2. Bestehende Infrastruktur — WIEDERVERWENDEN, NICHT DUPLIZIEREN
+
+Harte Auflage aus der Klärung: Hebel 2 baut auf vorhandener Infra auf.
+
+| Asset | Zweck | Verhältnis zu T000885 |
+|-------|-------|------------------------|
+| `tickets.factory_run_budget` (Tabelle) | tokens_in/out est+act, cost_usd est+act **pro Phase pro Ticket** | **Bleibt SSOT für Per-Ticket-Kosten.** Keine neue Tabelle. |
+| `scripts/factory/budget-estimate.sh` | Pre-Run-Schätzung → schreibt `factory_run_budget` | unverändert |
+| `scripts/factory/budget-guard.sh` | Tageslimit-Gate (`factory_control` key `budget-limit-daily-usd`) | unverändert |
+| `scripts/factory/metrics.sh` | Factory-Durchsatz-Summary als Ticket-Kommentar | unverändert |
+| `scripts/factory/otel-emit.{cjs,sh}` (T000883) | native `claude_code.token.usage`/`.cost.usage` → OTLP | unverändert |
+| `website/src/pages/admin/factory-observability.astro` + `lib/factory-observability.ts` (T000883) | Per-Ticket-Observability-Dashboard | wird referenziert, nicht ersetzt |
+
+**Abgrenzung tokscale-Delta:** tokscale liefert **nur** den Cross-Tool-CLI-Aggregat-Blick
+(Claude-Code + OpenClaw, JSONL-Usage-Logs des CLI), den die Factory-Budget-Pipeline strukturell
+nicht abdeckt (die kennt nur Factory-Runs, keine interaktiven Sessions). tokscale baut **keine**
+Per-Ticket-Kosten nach und legt **keine** DB-Tabelle an.
+
+## 3. Scope
+
+Voller Original-Scope, zwei klar getrennte Teile:
+
+### Teil A — PreCompact-Pruning-Hook (ops, lokal/Orchestrator)
+
+- Versioniertes Shell-Skript `scripts/hooks/precompact-prune.sh`, das als Claude-Code
+  **PreCompact-Hook** läuft. Es liest das Transcript-JSONL (Pfad via Hook-Payload auf stdin),
+  identifiziert **obsolete Tool-Outputs** und schreibt eine geprunete Variante, sodass der
+  anschließende `/compact`-Schritt weniger Input verarbeitet.
+- **Obsolet-Heuristik (konservativ, fail-safe):** ein `tool_result`-Block wird gekürzt, wenn
+  - es ein read-only/idempotenter Tool-Aufruf war (`Bash` read-only-Muster, `Read`, `Grep`, `Glob`,
+    `ls`/`cat`-artige Outputs) **und**
+  - derselbe Inhalt/dieselbe Datei seither erneut gelesen/überschrieben wurde (späteres
+    `tool_result` für denselben Ziel-Pfad existiert) **oder** der Output älter als N Turns ist
+    **und** nicht im jüngsten Assistant-Reasoning referenziert wird.
+  - Gekürzt = ersetzt durch einen kompakten Marker (`[pruned: <tool> output, N chars, see turn X]`),
+    **nie** gelöscht (Reihenfolge/IDs bleiben valide).
+- **Fail-open / idempotent:** kein Transcript-Pfad, unparsebares JSONL, fehlende Tools → no-op,
+  Exit 0, Original unangetastet. Mehrfachlauf auf bereits geprunetem Transcript ändert nichts
+  (Marker werden nicht erneut geprunet).
+- **Opt-in-Lieferweg:** `.claude/settings.json` ist gitignored → das Skript wird versioniert und
+  bereitgestellt, das Wiring ist **dokumentiertes Opt-in** (analog `autopilot.env`-Muster), NICHT
+  global erzwungen / auto-aktiviert. Doku zeigt den `settings.json`-Hook-Eintrag, den der User
+  manuell einträgt.
+- **Optional-Telemetrie:** wenn `OTEL_EXPORTER_OTLP_ENDPOINT` gesetzt, emittiert das Skript per
+  bestehendem `otel-emit.sh metric factory.context.pruned_chars <n>` (fire-and-forget, kein neuer
+  Emitter). Sonst still.
+
+### Teil B — tokscale-Delta für Cross-Tool-Usage-Transparenz (infra/ops)
+
+- Read-only Aggregator-Skript `scripts/factory/usage-report.sh`, das die lokalen Claude-Code- und
+  OpenClaw-Usage-Logs (JSONL unter den jeweiligen CLI-Datenverzeichnissen) einliest und einen
+  Token-/Kosten-Überblick **pro Tag / pro Modell / pro Tool** ausgibt (Text + `--json`).
+- **Keine neue DB-Tabelle.** Per-Ticket-Kosten bleiben in `factory_run_budget`. usage-report ist
+  der CLI-Aggregat-Blick über das, was die Factory NICHT sieht.
+- Optionaler Sync-Modus `--otel`: emittiert die Tages-Aggregate über das bestehende `otel-emit.sh`
+  als Gauges (`tokscale.tokens.daily` / `tokscale.cost.daily.usd` mit `tool=`/`model=`-Attributen),
+  damit sie im selben Collector/Dashboard wie die Factory-Telemetrie landen — wieder ohne neuen
+  Emitter.
+- Taskfile-Einstieg `factory:usage` (read-only), damit das Skript erreichbar ist (S4).
+
+## 4. Nicht-Ziele
+
+- Keine neue DB-Tabelle, kein neues Dashboard, kein neuer OTLP-Emitter.
+- Kein Auto-Wiring/Erzwingen des PreCompact-Hooks (Opt-in bleibt manuell).
+- Keine Änderung an `factory_run_budget`-Schema oder an den bestehenden budget-*-Skripten.
+- Kein Cross-Brand-Deploy nötig (beide Teile sind WSL-host-/CLI-lokal; keine Cluster-Manifeste).
+- Kein Vendoring von tokscale/dynamic-context-pruning — nur Portierung des **Musters** als
+  eigenständige, abhängigkeitsarme Shell-Skripte.
+
+## 5. Architektur & Datenfluss
+
+```
+Teil A (lokal, pro Session)
+  Claude Code /compact ──PreCompact-Event──▶ scripts/hooks/precompact-prune.sh (stdin: payload)
+        │                                          │ liest transcript JSONL
+        │                                          │ markiert obsolete tool_result → [pruned ...]
+        │                                          ▼ schreibt geprunetes JSONL zurück
+        ◀──────────────────────────────── /compact sieht kleineren Input
+                                                   └─(opt) otel-emit.sh metric pruned_chars
+
+Teil B (read-only, on-demand)
+  ~/.claude/**/usage*.jsonl  ┐
+  ~/.openclaw/**/usage*.jsonl ┘──▶ scripts/factory/usage-report.sh ──▶ text | --json
+                                          └─(opt --otel) otel-emit.sh gauge → Collector
+```
+
+- Teil A und B teilen **nur** den bestehenden `otel-emit.sh` (fire-and-forget) — keine sonstige
+  gemeinsame State.
+- Beide Skripte sind **pure** Shell ohne Repo-interne Import-Zyklen (S2 n/a für Bash, aber keine
+  Quelle aus DB/API-Schichten).
+
+## 6. Sicherheit & Robustheit
+
+- **Pruning fail-open:** das Pruning darf eine laufende Session NIE korrumpieren. Bei jedem Zweifel
+  Original durchreichen. Validierung: jede Zeile bleibt valides JSON, Anzahl `tool_use`/`tool_result`
+  bleibt gleich (nur Inhalt gekürzt), Reihenfolge unverändert.
+- **Keine Secrets im Output:** usage-report liest nur Token-Zähler/Modell-IDs/Timestamps aus den
+  CLI-Logs, nie Prompt-/Completion-Inhalte. Kein Echo von `~/.claude`-Auth-Material.
+- **Hostnamen:** keine Brand-Domain-Literale in Skripten (S3) — OTLP-Endpoint kommt aus Env.
+
+## 7. Tests
+
+- BATS für `precompact-prune.sh`: (a) leeres/fehlendes Transcript → no-op Exit 0; (b) obsoletes
+  read-only `tool_result` mit späterem Re-Read → geprunet auf Marker; (c) referenziertes/jüngstes
+  Output → unangetastet; (d) Idempotenz (zweiter Lauf = Identität); (e) jede Output-Zeile valides
+  JSON, `tool_use`/`tool_result`-Count erhalten.
+- BATS für `usage-report.sh`: (a) fehlende Log-Dirs → leere/0-Aggregate Exit 0; (b) Fixture-JSONL →
+  korrekte Tages-/Modell-Summen; (c) `--json` valides JSON; (d) `--otel` ruft otel-emit.sh nur bei
+  gesetztem Endpoint (kein Netz im Test → no-op).
+- Beide BATS unter `tests/local/FA-SF-*` (laufen via `task test:factory`, das `task test:changed`
+  bei `scripts/factory/`-Änderungen triggert).
+
+## 8. Offene Punkte / Annahmen
+
+- Format der Claude-Code/OpenClaw-Usage-JSONL wird im Implement-Schritt am realen Host verifiziert;
+  der Parser ist defensiv (unbekannte Felder ignorieren, fehlende = 0).
+- N-Turns-Schwelle der Pruning-Heuristik startet konservativ (z.B. >3 Turns alt) und ist per Env
+  (`PRUNE_MIN_AGE_TURNS`) überschreibbar.

--- a/scripts/factory/README.md
+++ b/scripts/factory/README.md
@@ -152,6 +152,33 @@ cp scripts/factory/autopilot.env.example ~/.config/factory/autopilot.env
   liegt als SealedSecret `otel-collector-auth` im monitoring-ns.
 - Dashboard: `/admin/factory-observability` (isAdmin-gated).
 
+## PreCompact Context-Pruning (Opt-in)
+
+`scripts/hooks/precompact-prune.sh` ist ein Claude Code PreCompact-Hook, der obsolete
+`tool_result`-Blöcke vor `/compact` kürzt, um Context-Bloat zu reduzieren.
+
+**Aktivierung (Opt-in, per Maschine):** In `.claude/settings.json` (gitignored) ergänzen:
+```json
+{ "hooks": { "PreCompact": [{ "command": "bash scripts/hooks/precompact-prune.sh" }] } }
+```
+- `PRUNE_MIN_AGE_TURNS` (Env, Default 3): Mindestalter in Turns vor dem Prunen.
+- `OTEL_EXPORTER_OTLP_ENDPOINT`: Optional — emittiert `factory.context.pruned_chars`-Metrik.
+- Fail-open: bei jedem Zweifel bleibt das Original unangetastet.
+
+## Cross-Tool Usage-Report (tokscale-Delta)
+
+`scripts/factory/usage-report.sh` ist ein read-only Aggregator der lokalen Claude-Code- und
+OpenClaw-Usage-Logs für einen Cross-Tool-CLI-Token/Kosten-Überblick.
+
+```
+task factory:usage                     # Text-Ansicht
+task factory:usage -- --json           # Maschinenlesbar
+task factory:usage -- --otel           # Optional: Gauges an OTLP-Collector
+```
+- Baut NICHT auf `factory_run_budget` auf (separater CLI-Blick).
+- `CLAUDE_USAGE_DIR` / `OPENCLAWN_USAGE_DIR` (Env) überschreiben die Log-Pfade.
+- `OTEL_EXPORTER_OTLP_ENDPOINT` muss gesetzt sein für `--otel`.
+
 ## Verwandte Dokumente
 
 - Spec: `docs/superpowers/specs/2026-06-01-software-factory-design.md`

--- a/scripts/factory/usage-report.sh
+++ b/scripts/factory/usage-report.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# scripts/factory/usage-report.sh — Cross-Tool-CLI Token/Kosten-Überblick.
+# Liest Claude-Code + OpenClaw Usage-JSONL, aggregiert pro Tag/Modell/Tool.
+# Read-only. --json für maschinenlesbar, --otel für OTLP-Gauges.
+# Defaults: ~/.claude/usage*.jsonl, ~/.openclaw/usage*.jsonl (überschreibbar via Env).
+set -uo pipefail
+
+CLAUDE_USAGE_DIR="${CLAUDE_USAGE_DIR:-$HOME/.claude}"
+OPENCLAW_USAGE_DIR="${OPENCLAW_USAGE_DIR:-$HOME/.openclaw}"
+
+MODE="text"
+OTEL=false
+for arg in "$@"; do
+  case "$arg" in
+    --json) MODE="json" ;;
+    --otel) OTEL=true ;;
+  esac
+done
+
+declare -A tokens_in tokens_out cost_usd
+declare -A model_set tool_set
+
+aggregate_dir() {
+  local dir="$1" tool_name="$2"
+  [[ ! -d "$dir" ]] && return 0
+  while IFS= read -r line; do
+    [[ -z "$line" ]] && continue
+    local ts model tin tout cost
+    ts=$(echo "$line" | jq -r '(.timestamp // .created_at // .ts // "")[:10]' 2>/dev/null)
+    [[ -z "$ts" || "$ts" == "null" ]] && continue
+    model=$(echo "$line" | jq -r '(.model // .model_id // "")' 2>/dev/null)
+    [[ -z "$model" || "$model" == "null" ]] && model="unknown"
+    tin=$(echo "$line" | jq -r '(.tokens_in // .input_tokens // .prompt_tokens // 0)' 2>/dev/null)
+    tout=$(echo "$line" | jq -r '(.tokens_out // .output_tokens // .completion_tokens // 0)' 2>/dev/null)
+    cost=$(echo "$line" | jq -r '(.cost_usd // .cost // 0)' 2>/dev/null)
+    [[ "$tin" == "null" ]] && tin=0
+    [[ "$tout" == "null" ]] && tout=0
+    [[ "$cost" == "null" ]] && cost=0
+    local key="${ts}|${model}|${tool_name}"
+    tokens_in["$key"]=$(( ${tokens_in["$key"]:-0} + tin ))
+    tokens_out["$key"]=$(( ${tokens_out["$key"]:-0} + tout ))
+    cost_usd["$key"]=$(awk "BEGIN { printf \"%.6f\", ${cost_usd["$key"]:-0} + $cost }")
+    model_set["$model"]=1
+    tool_set["$tool_name"]=1
+  done < <(find "$dir" -name 'usage*.jsonl' -type f -exec cat {} + 2>/dev/null)
+}
+
+aggregate_dir "$CLAUDE_USAGE_DIR" "claude-code"
+aggregate_dir "$OPENCLAW_USAGE_DIR" "openclaw"
+
+if [[ "$MODE" == "json" ]]; then
+  echo "["
+  first=true
+  for key in "${!tokens_in[@]}"; do
+    $first || echo ","
+    first=false
+    IFS='|' read -r ts model tool <<< "$key"
+    printf '  {"date":"%s","model":"%s","tool":"%s","tokens_in":%s,"tokens_out":%s,"cost_usd":%s}' \
+      "$ts" "$model" "$tool" "${tokens_in[$key]}" "${tokens_out[$key]}" "${cost_usd[$key]}"
+  done
+  echo ""
+  echo "]"
+else
+  printf "%-14s %-14s %-12s %10s %10s %12s\n" "DATE" "MODEL" "TOOL" "TOKENS_IN" "TOKENS_OUT" "COST_USD"
+  printf "%s\n" "----------------------------------------------------------------------------"
+  for key in "${!tokens_in[@]}"; do
+    IFS='|' read -r ts model tool <<< "$key"
+    printf "%-14s %-14s %-12s %10d %10d %12.6f\n" \
+      "$ts" "$model" "$tool" "${tokens_in[$key]}" "${tokens_out[$key]}" "${cost_usd[$key]}"
+  done
+fi
+
+if $OTEL && [[ -n "${OTEL_EXPORTER_OTLP_ENDPOINT:-}" ]]; then
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  for key in "${!tokens_in[@]}"; do
+    IFS='|' read -r ts model tool <<< "$key"
+    bash "${script_dir}/otel-emit.sh" gauge tokscale.tokens.daily "${tokens_in[$key]}" \
+      "date=$ts,model=$model,tool=$tool,direction=in" 2>/dev/null || true
+    bash "${script_dir}/otel-emit.sh" gauge tokscale.tokens.daily "${tokens_out[$key]}" \
+      "date=$ts,model=$model,tool=$tool,direction=out" 2>/dev/null || true
+    bash "${script_dir}/otel-emit.sh" gauge tokscale.cost.daily.usd "${cost_usd[$key]}" \
+      "date=$ts,model=$model,tool=$tool" 2>/dev/null || true
+  done
+fi

--- a/scripts/hooks/precompact-prune.sh
+++ b/scripts/hooks/precompact-prune.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# scripts/hooks/precompact-prune.sh — Claude Code PreCompact hook: prune obsolete
+# tool_result blocks before /compact to reduce context-bloat.
+#
+# Opt-in: add to .claude/settings.json (gitignored, per-machine):
+#   { "hooks": { "PreCompact": [{ "command": "bash scripts/hooks/precompact-prune.sh" }] } }
+# Env: PRUNE_MIN_AGE_TURNS (default 3), OTEL_EXPORTER_OTLP_ENDPOINT (opt telemetry)
+#
+# Fail-open: no transcript path, unparseable JSONL, missing tools → exit 0, original untouched.
+# Idempotent: [pruned: …] markers are never re-pruned.
+set -uo pipefail
+
+PRUNE_MIN_AGE="${PRUNE_MIN_AGE_TURNS:-3}"
+
+transcript_path="$(jq -r '.transcript_path // empty' 2>/dev/null)" || exit 0
+[[ -z "$transcript_path" || ! -f "$transcript_path" ]] && exit 0
+
+tmp_out="$(mktemp)"
+trap 'rm -f "$tmp_out"' EXIT
+
+total_pruned=0
+line_num=0
+declare -a turns=()
+declare -A refs=()
+
+while IFS= read -r line || [[ -n "$line" ]]; do
+  turns+=("$line")
+done < "$transcript_path"
+
+n_turns="${#turns[@]}"
+
+for (( i = 0; i < n_turns; i++ )); do
+  if echo "${turns[$i]}" | jq -e '.type == "assistant" and .content != null' >/dev/null 2>&1; then
+    while IFS= read -r block; do
+      [[ -z "$block" ]] && continue
+      refs["$(echo "$block" | jq -r '.tool_use_id // empty')"]=1
+    done < <(echo "${turns[$i]}" | jq -c '.content[]? | select(.type == "tool_use" or .type == "reasoning")' 2>/dev/null)
+  fi
+done
+
+has_refs=false
+if [[ "${#refs[@]}" -gt 0 ]]; then
+  has_refs=true
+fi
+
+for (( i = 0; i < n_turns; i++ )); do
+  line="${turns[$i]}"
+  if echo "$line" | jq -e '.type == "tool_result" and (.content | type == "string")' >/dev/null 2>&1; then
+    tool_use_id=$(echo "$line" | jq -r '.tool_use_id // empty' 2>/dev/null)
+    origin_tool=$(echo "$line" | jq -r '.metadata.original_tool // empty' 2>/dev/null)
+    [[ -z "$origin_tool" ]] && origin_tool="$tool_use_id"
+    is_readonly=false
+    if echo "$origin_tool" | grep -qiE '^(Bash|Read|Grep|Glob|ls)$' 2>/dev/null; then
+      is_readonly=true
+    fi
+
+    already_pruned=false
+    if echo "$line" | jq -e '.content | startswith("[pruned:")' >/dev/null 2>&1; then
+      already_pruned=true
+    fi
+
+    is_recent=false
+    turn_distance=$((n_turns - i))
+    [[ "$turn_distance" -le "$PRUNE_MIN_AGE" ]] && is_recent=true
+
+    is_referenced=false
+    if $has_refs; then
+      [[ -n "$tool_use_id" && -n "${refs[$tool_use_id]:-}" ]] && is_referenced=true
+      [[ -n "${refs[$origin_tool]:-}" ]] && is_referenced=true
+    fi
+
+    if ! $already_pruned && $is_readonly && ! $is_recent && ! $is_referenced; then
+      orig_len=$(echo "$line" | jq '.content | length' 2>/dev/null || echo 0)
+      marker="[pruned: ${origin_tool} output, ${orig_len} chars, see turn ${i}]"
+      turns[$i]=$(echo "$line" | jq --arg m "$marker" '.content = $m' 2>/dev/null || echo "$line")
+      total_pruned=$((total_pruned + orig_len))
+    fi
+  fi
+done
+
+printf '%s\n' "${turns[@]}" | jq -c . > "$tmp_out" 2>/dev/null
+if [[ $? -eq 0 ]] && [[ -s "$tmp_out" ]]; then
+  output_count=$(jq -c . < "$tmp_out" | wc -l)
+  input_count=$(jq -c . < "$transcript_path" | wc -l)
+  if [[ "$output_count" -eq "$input_count" ]]; then
+    cp "$tmp_out" "$transcript_path"
+  fi
+fi
+
+if [[ -n "${OTEL_EXPORTER_OTLP_ENDPOINT:-}" && "$total_pruned" -gt 0 ]]; then
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  bash "${script_dir}/../factory/otel-emit.sh" metric factory.context.pruned_chars "$total_pruned" 2>/dev/null || true
+fi
+
+exit 0

--- a/tests/local/FA-SF-54-precompact-prune.bats
+++ b/tests/local/FA-SF-54-precompact-prune.bats
@@ -1,0 +1,90 @@
+#!/usr/bin/env bats
+# FA-SF-54 — precompact-prune.sh: prune obsolete tool_result before /compact
+setup() {
+  load 'test_helper.bash'
+  export TMPDIR; TMPDIR=$(mktemp -d)
+}
+teardown() { rm -rf "$TMPDIR"; }
+
+make_transcript() {
+  local f="$TMPDIR/transcript.jsonl"
+  while IFS= read -r line; do echo "$line" >> "$f"; done
+  echo "$f"
+}
+
+@test "FA-SF-54: fehlendes Transcript → exit 0, kein Schreibzugriff" {
+  run bash scripts/hooks/precompact-prune.sh <<< '{}'
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-54: leeres Transcript → exit 0, unverändert" {
+  local f; f=$(make_transcript <<< '')
+  run bash -c "echo '{\"transcript_path\": \"$f\"}' | bash scripts/hooks/precompact-prune.sh"
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-54: obsoletes read-only tool_result → pruned" {
+  local f; f=$(make_transcript <<'JSON'
+{"type":"tool_use","tool_use_id":"call-init"}
+{"type":"tool_result","tool_use_id":"call-1","content":"very long output here that is obsolete","metadata":{"original_tool":"Read"}}
+{"type":"tool_use","tool_use_id":"call-2"}
+{"type":"tool_result","tool_use_id":"call-2","content":"newer read","metadata":{"original_tool":"Read"}}
+{"type":"tool_use","tool_use_id":"call-3"}
+{"type":"tool_result","tool_use_id":"call-3","content":"even newer","metadata":{"original_tool":"Bash"}}
+JSON
+)
+  run bash -c "echo '{\"transcript_path\": \"$f\"}' | bash scripts/hooks/precompact-prune.sh"
+  [ "$status" -eq 0 ]
+  run jq -r 'select(.type == "tool_result") | select(.content | startswith("[pruned:")) | .content' "$f"
+  [ -n "$output" ]
+}
+
+@test "FA-SF-54: jüngstes Output → unangetastet" {
+  local f; f=$(make_transcript <<'JSON'
+{"type":"tool_use","tool_use_id":"call-init"}
+{"type":"tool_result","tool_use_id":"call-1","content":"recent output","metadata":{"original_tool":"Read"}}
+{"type":"assistant","content":[{"type":"tool_use","tool_use_id":"call-1"}]}
+{"type":"tool_use","tool_use_id":"call-2"}
+{"type":"tool_result","tool_use_id":"call-2","content":"other","metadata":{"original_tool":"Bash"}}
+JSON
+)
+  run bash -c "echo '{\"transcript_path\": \"$f\"}' | bash scripts/hooks/precompact-prune.sh"
+  [ "$status" -eq 0 ]
+  run jq -r 'select(.type == "tool_result") | select(.tool_use_id == "call-1") | .content' "$f"
+  [[ "$output" == "recent output" ]]
+}
+
+@test "FA-SF-54: Idempotenz — zweiter Lauf = byte-identisch" {
+  local f; f=$(make_transcript <<'JSON'
+{"type":"tool_use","tool_use_id":"call-init"}
+{"type":"tool_result","tool_use_id":"call-1","content":"long obsolete read","metadata":{"original_tool":"Grep"}}
+{"type":"tool_use","tool_use_id":"call-2"}
+{"type":"tool_result","tool_use_id":"call-2","content":"newer","metadata":{"original_tool":"Read"}}
+{"type":"tool_use","tool_use_id":"call-3"}
+{"type":"tool_result","tool_use_id":"call-3","content":"latest","metadata":{"original_tool":"Bash"}}
+JSON
+)
+  run bash -c "echo '{\"transcript_path\": \"$f\"}' | bash scripts/hooks/precompact-prune.sh"
+  [ "$status" -eq 0 ]
+  local h1; h1=$(sha256sum "$f" | cut -d' ' -f1)
+  run bash -c "echo '{\"transcript_path\": \"$f\"}' | bash scripts/hooks/precompact-prune.sh"
+  [ "$status" -eq 0 ]
+  local h2; h2=$(sha256sum "$f" | cut -d' ' -f1)
+  [ "$h2" = "$h1" ]
+}
+
+@test "FA-SF-54: alle Zeilen valides JSON nach Prune" {
+  local f; f=$(make_transcript <<'JSON'
+{"type":"tool_use","tool_use_id":"call-init"}
+{"type":"tool_result","tool_use_id":"call-1","content":"long content here","metadata":{"original_tool":"Bash"}}
+{"type":"tool_use","tool_use_id":"call-2"}
+{"type":"tool_result","tool_use_id":"call-2","content":"more content","metadata":{"original_tool":"Read"}}
+{"type":"tool_use","tool_use_id":"call-3"}
+{"type":"tool_result","tool_use_id":"call-3","content":"latest","metadata":{"original_tool":"Bash"}}
+JSON
+)
+  run bash -c "echo '{\"transcript_path\": \"$f\"}' | bash scripts/hooks/precompact-prune.sh"
+  [ "$status" -eq 0 ]
+  run bash -c "jq -e . < '$f' >/dev/null 2>&1"
+  [ "$status" -eq 0 ]
+}

--- a/tests/local/FA-SF-55-usage-report.bats
+++ b/tests/local/FA-SF-55-usage-report.bats
@@ -1,0 +1,70 @@
+#!/usr/bin/env bats
+# FA-SF-55 — usage-report.sh: Cross-Tool-CLI Token/Kosten-Überblick
+setup() {
+  load 'test_helper.bash'
+  export TMPDIR; TMPDIR=$(mktemp -d)
+  export CLAUDE_USAGE_DIR="$TMPDIR/claude"
+  export OPENCLAW_USAGE_DIR="$TMPDIR/openclaw"
+  mkdir -p "$CLAUDE_USAGE_DIR" "$OPENCLAW_USAGE_DIR"
+}
+teardown() { rm -rf "$TMPDIR"; }
+
+@test "FA-SF-55: fehlende Log-Dirs → 0-Aggregate, Exit 0" {
+  export CLAUDE_USAGE_DIR="$TMPDIR/nonexistent-claude"
+  export OPENCLAW_USAGE_DIR="$TMPDIR/nonexistent-openclaw"
+  run bash scripts/factory/usage-report.sh
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-55: Fixtures → korrekte Summen pro Tag" {
+  cat > "$CLAUDE_USAGE_DIR/usage-1.jsonl" <<'JSON'
+{"timestamp":"2026-06-15T10:00:00Z","model":"claude-sonnet-4","tokens_in":100,"tokens_out":50,"cost_usd":0.002}
+{"timestamp":"2026-06-15T11:00:00Z","model":"claude-sonnet-4","tokens_in":200,"tokens_out":100,"cost_usd":0.004}
+JSON
+  run bash scripts/factory/usage-report.sh
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"2026-06-15"* ]]
+  [[ "$output" == *"claude-sonnet-4"* ]]
+}
+
+@test "FA-SF-55: --json → valides JSON" {
+  cat > "$CLAUDE_USAGE_DIR/usage-1.jsonl" <<'JSON'
+{"timestamp":"2026-06-14T10:00:00Z","model":"claude-haiku-4","tokens_in":50,"tokens_out":25,"cost_usd":0.001}
+JSON
+  run bash scripts/factory/usage-report.sh --json
+  [ "$status" -eq 0 ]
+  run jq -e . <<< "$output"
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-55: --otel ohne Endpoint → no-op (Exit 0)" {
+  cat > "$CLAUDE_USAGE_DIR/usage-1.jsonl" <<'JSON'
+{"timestamp":"2026-06-13T10:00:00Z","model":"claude-opus-4","tokens_in":300,"tokens_out":150,"cost_usd":0.015}
+JSON
+  unset OTEL_EXPORTER_OTLP_ENDPOINT
+  run bash scripts/factory/usage-report.sh --otel
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-55: unbekannte Felder → kein Crash" {
+  cat > "$CLAUDE_USAGE_DIR/usage-1.jsonl" <<'JSON'
+{"weird_field":true,"unknown":"data"}
+{"timestamp":"2026-06-12T10:00:00Z","model":"claude-sonnet-4","tokens_in":100,"tokens_out":50,"cost_usd":0.002}
+JSON
+  run bash scripts/factory/usage-report.sh
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"2026-06-12"* ]]
+}
+
+@test "FA-SF-55: beide Tools gemischt" {
+  cat > "$CLAUDE_USAGE_DIR/usage-1.jsonl" <<'JSON'
+{"timestamp":"2026-06-10T10:00:00Z","model":"claude-sonnet-4","tokens_in":100,"tokens_out":50,"cost_usd":0.002}
+JSON
+  cat > "$OPENCLAW_USAGE_DIR/usage-1.jsonl" <<'JSON'
+{"timestamp":"2026-06-10T11:00:00Z","model":"claude-sonnet-4","tokens_in":50,"tokens_out":25,"cost_usd":0.001}
+JSON
+  run bash scripts/factory/usage-report.sh
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"claude-code"* ]]
+  [[ "$output" == *"openclaw"* ]]
+}


### PR DESCRIPTION
## Änderungen

- `scripts/hooks/precompact-prune.sh` — Claude Code PreCompact-Hook (95 Z., opt-in, fail-open)
- `scripts/factory/usage-report.sh` — tokscale-Delta CLI aggregator (84 Z., --json/--otel)
- `tests/local/FA-SF-54-precompact-prune.bats` — 6 Tests
- `tests/local/FA-SF-55-usage-report.bats` — 6 Tests
- `Taskfile.factory.yml` — neuer Task `factory:usage`
- `scripts/factory/README.md` — Opt-in-Doku

Closes T000885