### PR TITLE
fix(factory): harden plan-lint shell-out against command injection [T000910]

### DIFF
--- a/scripts/factory/pipeline.js
+++ b/scripts/factory/pipeline.js
@@ -301,9 +301,14 @@ if (!isSimple) {
   phaseEvent('plan', 'done', `${(plan.tasks || []).length} Tasks`)
 
   // Deterministic plan-lint gate (T000910) — fail-closed, no LLM. One fix iteration.
+  // Security (T000910 follow-up): every interpolated value below is either a sanitized
+  // ticket id ([A-Za-z0-9_-] only) or base64-encoded before it reaches the shell, so
+  // untrusted linter output / plan paths can never break out of the command string.
+  const shSafeTicketId = String(A.ticket_id).replace(/[^A-Za-z0-9_-]/g, '')
+  const shQuotedPlanPath = `'${String(planFilePath).replace(/'/g, "'\\''")}'`
   const lintOnce = async (note) => agent(
     `Run the deterministic plan linter and return ONLY its stdout:
-     bash ${REPO}/scripts/plan-lint.sh --json ${planFilePath}` + (note || ''),
+     bash ${REPO}/scripts/plan-lint.sh --json ${shQuotedPlanPath}` + (note || ''),
     { label: 'plan:lint', phase: 'Plan' },
   )
   let lintOut = await lintOnce('')
@@ -316,11 +321,15 @@ if (!isSimple) {
     lintOut = await lintOnce(' (after fix iteration)')
   }
   if (/"verdict"\s*:\s*"FAIL"/.test(lintOut)) {
+    // base64-encode the untrusted linter output; the shell decodes it back into a single
+    // --body argument. base64's alphabet ([A-Za-z0-9+/=]) is safe inside single quotes,
+    // so no token in lintOut (backtick, $(), ;, quote) can ever break out of the command.
+    const reasonB64 = Buffer.from(`plan-lint FAIL: ${String(lintOut).slice(0, 300)}`, 'utf8').toString('base64')
     await agent(
       `Plan still fails plan-lint after one fix. Block enqueue + comment the ticket:
-       bash ${REPO}/scripts/ticket.sh release-slot --id ${A.ticket_id}
-       bash ${REPO}/scripts/ticket.sh update-status --id ${A.ticket_id} --status backlog
-       bash ${REPO}/scripts/ticket.sh add-comment --id ${A.ticket_id} --body "plan-lint FAIL: ${String(lintOut).replace(/"/g,"'").slice(0, 300)}"`,
+       bash ${REPO}/scripts/ticket.sh release-slot --id '${shSafeTicketId}'
+       bash ${REPO}/scripts/ticket.sh update-status --id '${shSafeTicketId}' --status backlog
+       bash ${REPO}/scripts/ticket.sh add-comment --id '${shSafeTicketId}' --body "$(printf %s '${reasonB64}' | base64 -d)"`,
       { label: 'plan:lint-block', phase: 'Plan' },
     )
     phaseEvent('plan', 'blocked', 'plan-lint-fail')


### PR DESCRIPTION
## Was

Härtet das in #1778 (T000910) hinzugefügte plan-lint-Gate in `scripts/factory/pipeline.js` gegen Command-Injection (Befund des automatischen Commit-Security-Reviews, MEDIUM).

## Problem

Der Block-Pfad baute den Ticket-Kommentar per String-Interpolation:
```js
--body "plan-lint FAIL: ${String(lintOut).replace(/"/g,"'").slice(0, 300)}"
```
`lintOut` (Linter-Output, enthält Inhalte aus dem Plan-Markdown) ist nicht vertrauenswürdig; `.replace(/"/g,"'")` lässt Backticks und `$()` durch → Injection, sobald der Subagent das Bash ausführt. Zusätzlich war `${A.ticket_id}` ungequotet.

## Fix

- `lintOut`-Body wird in JS **base64-kodiert** und im Shell mit `base64 -d` dekodiert. Das base64-Alphabet (`[A-Za-z0-9+/=]`) ist innerhalb von Single-Quotes shell-sicher — kein Token kann ausbrechen.
- `ticket_id` wird auf `[A-Za-z0-9_-]` gesäubert und single-quoted; `planFilePath` wird shell-quoted.

## Verifikation

- `node --check scripts/factory/pipeline.js` ✓
- `task test:factory` ✓ (307 Tests)
- `task freshness:check` ✓ (exit 0)

Closes T000910 (security follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)