### PR TITLE
fix(test): factory-mcp test needs npm install [T000914]

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -336,6 +336,7 @@ tasks:
   test:unit:factory-mcp:
     internal: true
     cmds:
+      - '[ -d scripts/factory/node_modules ] || npm install --prefix scripts/factory --silent'
       - ./tests/unit/lib/bats-core/bin/bats tests/unit/factory/mcp-server.bats
 
   test:unit:readiness-webhook:

--- a/tests/unit/factory/mcp-server.bats
+++ b/tests/unit/factory/mcp-server.bats
@@ -3,9 +3,12 @@
 # Tool endpoint tests require full MCP protocol handshake — tested via manual integration.
 
 setup() {
+  ORIG_REPO="$(cd "${BATS_TEST_DIRNAME}/../../.." && pwd)"
+  if [[ ! -d "${ORIG_REPO}/scripts/factory/node_modules/@modelcontextprotocol" ]]; then
+    skip "scripts/factory/node_modules not installed (run npm install in scripts/factory/)"
+  fi
   export FACTORY_REPO="${BATS_TMPDIR}/mock-repo"
   mkdir -p "$FACTORY_REPO/scripts/factory"
-  ORIG_REPO="$(cd "${BATS_TEST_DIRNAME}/../../.." && pwd)"
   export FACTORY_MCP_PORT=13099
   export REPO="$FACTORY_REPO"
   MCP_SERVER="${ORIG_REPO}/scripts/factory/mcp-server.mjs"


### PR DESCRIPTION
Fixes pre-existing CI failure on main: test:unit:factory-mcp failed because @modelcontextprotocol/sdk was not installed.\n\n- Add npm install pre-step to test:unit:factory-mcp task\n- Add skip guard in BATS test when node_modules missing\n\nThis unblocks T000909 auto-merge (PR #1784).