### PR TITLE
fix(website): FactoryFloor desktop lane order front→back [T000922]

### DIFF
--- a/website/src/components/FactoryFloor.svelte
+++ b/website/src/components/FactoryFloor.svelte
@@ -275,6 +275,41 @@
       ontouchstart={onTouchStart}
       ontouchend={onTouchEnd}
     >
+      <StagedColumn
+        staged={data.staged}
+        stagedWaiting={data.stagedWaiting ?? 0}
+        {releasing}
+        {releaseErr}
+        {manualHintFor}
+        {mobileColIndex}
+        onOpenDetail={openDetail}
+        onReleaseToFactory={releaseToFactory}
+        onToggleManualHint={toggleManualHint}
+        {relTime}
+        {prioDot}
+        {planUrl}
+        {ticketUrl}
+      />
+      <div data-col="backlog" class:mobile-visible={mobileColIndex === 1} class="lg:w-1/5" data-testid="floor-loadingdock">
+        <h3 class="font-semibold mb-2">Laderampe</h3>
+        {#if data.loadingDock.length === 0}
+          <p class="text-muted text-sm">Leer.</p>
+        {:else}
+          <ul class="space-y-1">
+            {#each data.loadingDock as d (d.extId)}
+              <li class="rounded bg-white/5 px-2 py-1 text-sm">
+                <div class="flex items-center gap-1.5">
+                  <span class="h-2 w-2 shrink-0 rounded-full {prioDot(d.priority)}" title={`Priorität: ${d.priority}`}></span>
+                  <a href={ticketUrl(d.extId)} class="font-mono text-xs text-gold hover:underline">{d.extId}</a>
+                  <span class="truncate">{d.title}</span>
+                </div>
+                <span class="block text-muted text-xs">⏳ {d.waitReason}</span>
+              </li>
+            {/each}
+          </ul>
+        {/if}
+      </div>
+
       {#if floorView === 'conveyor'}
         <div class="conveyor-wrapper w-full" data-testid="floor-hall">
           <ConveyorBelt
@@ -337,50 +372,6 @@
         </div>
       {/if}
 
-      <StagedColumn
-        staged={data.staged}
-        stagedWaiting={data.stagedWaiting ?? 0}
-        {releasing}
-        {releaseErr}
-        {manualHintFor}
-        {mobileColIndex}
-        onOpenDetail={openDetail}
-        onReleaseToFactory={releaseToFactory}
-        onToggleManualHint={toggleManualHint}
-        {relTime}
-        {prioDot}
-        {planUrl}
-        {ticketUrl}
-      />
-      <div data-col="backlog" class:mobile-visible={mobileColIndex === 1} class="lg:w-1/5" data-testid="floor-loadingdock">
-        <h3 class="font-semibold mb-2">Laderampe</h3>
-        {#if data.loadingDock.length === 0}
-          <p class="text-muted text-sm">Leer.</p>
-        {:else}
-          <ul class="space-y-1">
-            {#each data.loadingDock as d (d.extId)}
-              <li class="rounded bg-white/5 px-2 py-1 text-sm">
-                <div class="flex items-center gap-1.5">
-                  <span class="h-2 w-2 shrink-0 rounded-full {prioDot(d.priority)}" title={`Priorität: ${d.priority}`}></span>
-                  <a href={ticketUrl(d.extId)} class="font-mono text-xs text-gold hover:underline">{d.extId}</a>
-                  <span class="truncate">{d.title}</span>
-                </div>
-                <span class="block text-muted text-xs">⏳ {d.waitReason}</span>
-              </li>
-            {/each}
-          </ul>
-        {/if}
-      </div>
-
-      <ShippedColumn
-        shipped={data.shipped}
-        {mobileColIndex}
-        onOpenDetail={openDetail}
-        {relTime}
-        {prUrl}
-        {ticketUrl}
-      />
-
       <div class="lg:w-1/5" data-testid="floor-qa">
         <h3 class="font-semibold mb-2">QS-Abnahme</h3>
         {#if qaItems.length === 0}
@@ -398,6 +389,15 @@
           </div>
         {/if}
       </div>
+
+      <ShippedColumn
+        shipped={data.shipped}
+        {mobileColIndex}
+        onOpenDetail={openDetail}
+        {relTime}
+        {prUrl}
+        {ticketUrl}
+      />
     </div>
 
     <DetailPanel

--- a/website/src/components/FactoryFloor.svelte
+++ b/website/src/components/FactoryFloor.svelte
@@ -1,6 +1,15 @@
+<script module lang="ts">
+  import { PHASE_ORDER } from '../lib/factory-floor';
+  import type { Phase } from '../lib/factory-floor';
+  export const STATIONS: { key: Phase; label: string }[] =
+    PHASE_ORDER.map((key) => ({ key, label: key.charAt(0).toUpperCase() + key.slice(1) }));
+  export const MOBILE_COL_INDEX: Record<string, number> =
+    { staged: 0, backlog: 1, scout: 2, design: 3, plan: 4, implement: 5, verify: 6, deploy: 7, qs: 8, done: 9 };
+</script>
+
 <script lang="ts">
   import { onMount, onDestroy } from 'svelte';
-  import type { FloorPayload, TicketDetail, HallItem, Phase, InjectionKind } from '../lib/factory-floor';
+  import type { FloorPayload, TicketDetail, HallItem, InjectionKind } from '../lib/factory-floor';
 
   import QaChip from './QaChip.svelte';
   import QaModal from './QaModal.svelte';
@@ -19,13 +28,7 @@
 
   let { initial }: { initial: FloorPayload | null } = $props();
 
-  const STATIONS: { key: Phase; label: string }[] = [
-    { key: 'scout', label: 'Scout' }, { key: 'design', label: 'Design' }, { key: 'plan', label: 'Plan' },
-    { key: 'implement', label: 'Implement' }, { key: 'verify', label: 'Verify' }, { key: 'deploy', label: 'Deploy' },
-  ];
-
   const MOBILE_COL_COUNT = 10;
-  const MOBILE_COL_INDEX: Record<string, number> = { staged: 0, backlog: 1, scout: 2, design: 3, plan: 4, implement: 5, verify: 6, deploy: 7, qs: 8, done: 9 };
   let mobileColIndex = $state(0);
   let touchStartX = $state(0);
   let isMobile = $state(false);

--- a/website/src/components/factory/MobileTabBar.svelte
+++ b/website/src/components/factory/MobileTabBar.svelte
@@ -1,5 +1,5 @@
-<script lang="ts">
-  const TABS = [
+<script module lang="ts">
+  export const TABS = [
     { key: 'staged', label: 'STAGED' },
     { key: 'backlog', label: 'BACKLOG' },
     { key: 'scout', label: 'SCOUT' },
@@ -11,7 +11,9 @@
     { key: 'qs', label: 'QS' },
     { key: 'done', label: 'DONE' },
   ] as const;
+</script>
 
+<script lang="ts">
   let {
     activeIndex,
     onSelect,

--- a/website/src/lib/factory-floor.order.test.ts
+++ b/website/src/lib/factory-floor.order.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
 import {
   PIPELINE_LANES,
   PIPELINE_STATUSES,
@@ -14,6 +14,12 @@ import {
   ALL_TICKET_STATUSES as FF_ALL_TICKET_STATUSES,
 } from './factory-floor';
 
+import { TABS } from '../components/factory/MobileTabBar.svelte';
+import { MOBILE_COL_INDEX, STATIONS } from '../components/FactoryFloor.svelte';
+import { PHASE_ORDER } from './factory-floor';
+import { render } from '@testing-library/svelte';
+import FactoryFloor from '../components/FactoryFloor.svelte';
+
 // The declared expectation, independent of the implementation. Front→back, linear lanes only.
 const EXPECTED_LINEAR_STATUSES = [
   'triage', 'planning', 'plan_staged', 'backlog', 'in_progress', 'in_review', 'qa_review', 'done',
@@ -26,10 +32,49 @@ const EXPECTED_BUCKETS: Record<string, LaneKey> = {
   done: 'shipped', archived: 'archive',
 };
 
+const EXPECTED_MOBILE_SEQUENCE = ['staged', 'backlog', ...PHASE_ORDER, 'qs', 'done'];
+
+const MOCK_FLOOR = {
+  control: { killSwitch: false, slotsUsed: 0, slotsCap: 3, dailyCap: 5, dailyUsed: 0, dryRun: false, watchdogStale: 0 },
+  metrics: { shippedToday: 0, avgCycleH: null },
+  loadingDock: [],
+  hall: [],
+  shipped: [],
+  staged: [],
+  providerHealth: [],
+  officeWaiting: 0,
+  stagedWaiting: 0,
+  planningCount: { total: 0, ready: 0 },
+  attention: { blocked: [], stuck: [], cooldowns: [], isEmpty: true },
+  fetchedAt: new Date().toISOString(),
+};
+
+beforeAll(() => {
+  vi.stubGlobal('EventSource', class {
+    addEventListener = vi.fn();
+    close = vi.fn();
+  });
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('{}', { status: 200 })));
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+});
+
+afterAll(() => {
+  vi.unstubAllGlobals();
+});
+
 describe('pipeline-order SSOT', () => {
   it('PIPELINE_STATUSES is the linear front→back sequence (qa_review before done)', () => {
     expect([...PIPELINE_STATUSES]).toEqual([...EXPECTED_LINEAR_STATUSES]);
-    // explicit lifecycle-direction guard against the "verkehrt herum" regression
     expect(PIPELINE_STATUSES.indexOf('qa_review')).toBeLessThan(PIPELINE_STATUSES.indexOf('done'));
   });
 
@@ -62,12 +107,24 @@ describe('pipeline-order SSOT', () => {
     expect(FF_ALL_TICKET_STATUSES).toBe(ALL_TICKET_STATUSES);
   });
 
-  // ---- Component-order checks wired by Sub-Plan 4 (T000922). Left as todos here ----
-  // SP4 owns MobileTabBar.svelte / FactoryFloor.svelte; when it derives TABS,
-  // MOBILE_COL_INDEX and the macro-lane DOM order from PIPELINE_LANES/PHASE_ORDER,
-  // it converts each of these into a real assertion against the SSOT. SP1 does NOT
-  // touch those components, so they stay as it.todo placeholders here.
-  it.todo('SP4: MobileTabBar.TABS order matches the SSOT-derived lane/phase order');
-  it.todo('SP4: MOBILE_COL_INDEX order matches the SSOT-derived lane/phase order');
-  it.todo('SP4: FactoryFloor macro-lane DOM order matches PIPELINE_LANES (qa before done)');
+  it('MobileTabBar.TABS matches the SSOT-derived front→back sequence', () => {
+    expect(TABS.map((t) => t.key)).toEqual(EXPECTED_MOBILE_SEQUENCE);
+  });
+
+  it('MOBILE_COL_INDEX matches the SSOT-derived front→back sequence', () => {
+    expect(Object.entries(MOBILE_COL_INDEX).sort((a, b) => a[1] - b[1]).map(([k]) => k)).toEqual(EXPECTED_MOBILE_SEQUENCE);
+  });
+
+  it('STATIONS (Hall phase columns) equal PHASE_ORDER left→right', () => {
+    expect(STATIONS.map((s) => s.key)).toEqual([...PHASE_ORDER]);
+  });
+
+  it('FactoryFloor desktop macro-lanes render front→back (qa before done, backlog before hall)', () => {
+    const { container } = render(FactoryFloor, { props: { initial: MOCK_FLOOR as any } });
+    const order = [...container.querySelectorAll('[data-testid^="floor-"]')].map(
+      (e) => (e as HTMLElement).dataset.testid ?? '',
+    );
+    expect(order.indexOf('floor-loadingdock')).toBeLessThan(order.indexOf('floor-hall'));
+    expect(order.indexOf('floor-qa')).toBeLessThan(order.indexOf('floor-shipped'));
+  });
 });

--- a/website/src/lib/factory-floor.ts
+++ b/website/src/lib/factory-floor.ts
@@ -6,7 +6,7 @@ import { pool } from './website-db';
 import { officeCount } from './planning-office';
 
 
-const PHASE_ORDER = ['scout', 'design', 'plan', 'implement', 'verify', 'deploy'] as const;
+export const PHASE_ORDER = ['scout', 'design', 'plan', 'implement', 'verify', 'deploy'] as const;
 export type Phase = (typeof PHASE_ORDER)[number];
 export type PhaseState = 'entered' | 'done' | 'blocked';
 

--- a/website/vitest.config.ts
+++ b/website/vitest.config.ts
@@ -11,6 +11,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const COMPONENT_TESTS = [
   'src/components/**/*.{test,spec}.ts',
   'src/lib/stores/cockpitStore.test.ts',
+  'src/lib/factory-floor.order.test.ts',
 ];
 
 export default defineConfig({


### PR DESCRIPTION
SP4 (T000922) — reorder FactoryFloor desktop macro-lanes front→back:

- **Task 1:** Export order-bearing constants (TABS, STATIONS, MOBILE_COL_INDEX) from components, derive STATIONS from PHASE_ORDER SSOT
- **Task 2:** Write failing DOM-order test proving the 'wrong way' bug (shipped before qa)
- **Task 3:** Reorder kanban-container children: Staged → Laderampe → Hall → QS → Shipped
- **Task 4:** Verify gates (test:changed, freshness:regenerate, workspace:validate)

Closes T000922.