### PR TITLE
feat(admin): reichere KI-Feature-Vorschläge im Cockpit (value/health/rollup) [T000924]

### DIFF
--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -507,7 +507,7 @@
       "id": "website",
       "name": "Astro + Svelte website",
       "owner_agent": "bachelorprojekt-website",
-      "file_count": 1435,
+      "file_count": 1437,
       "files": [
         "website/.build-trigger",
         "website/.design-sync/NOTES.md",
@@ -1367,6 +1367,8 @@
         "website/src/lib/tickets/grilling.ts",
         "website/src/lib/tickets/pipeline-order.ts",
         "website/src/lib/tickets/reporter-link.ts",
+        "website/src/lib/tickets/suggest-prompt.test.ts",
+        "website/src/lib/tickets/suggest-prompt.ts",
         "website/src/lib/tickets/transition.status.test.ts",
         "website/src/lib/tickets/transition.ts",
         "website/src/lib/vat-id-validation.test.ts",

--- a/docs/generated/api-map.json
+++ b/docs/generated/api-map.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-16T19:44:46.968Z",
+  "generatedAt": "2026-06-16T19:53:24.805Z",
   "endpoints": [
     {
       "path": "/api/admin/angebote/save",

--- a/docs/generated/api-surface.md
+++ b/docs/generated/api-surface.md
@@ -1,6 +1,6 @@
 # API Surface Map
 
-> Generated at 2026-06-16T19:44:46.968Z
+> Generated at 2026-06-16T19:53:24.805Z
 
 | Path | Methods | Auth | File |
 |------|---------|------|------|

--- a/docs/generated/blast-radius.md
+++ b/docs/generated/blast-radius.md
@@ -1,5 +1,5 @@
 # Blast-Radius-Report
-> Generated: 2026-06-16T19:44:47.064Z
+> Generated: 2026-06-16T19:53:24.892Z
 > Nodes: 79 | Edges: 1614 | Isolated: 2
 
 ## Ranking (transitive Abhängige)

--- a/docs/generated/graph.json
+++ b/docs/generated/graph.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-16T19:44:46.884Z",
+  "generatedAt": "2026-06-16T19:53:24.683Z",
   "nodes": [
     {
       "id": "admin-actions-cleanup",

--- a/docs/superpowers/plans/2026-06-16-cockpit-suggest-richer.md
+++ b/docs/superpowers/plans/2026-06-16-cockpit-suggest-richer.md
@@ -1,0 +1,124 @@
+---
+title: Reichere Cockpit-Feature-Vorschläge
+date: 2026-06-16
+slug: cockpit-suggest-richer
+ticket_id: T000924
+spec_ref: docs/superpowers/specs/2026-06-16-cockpit-suggest-richer-design.md
+domains: [website, ai/factory]
+status: draft
+file_locks: []
+shared_changes: false
+batch_id: null
+parent_feature: null
+depends_on_plans: []
+---
+
+# Reichere Cockpit-Feature-Vorschläge — Implementation Plan
+
+Anreicherung der KI-Vorschläge unter `POST /api/admin/cockpit/suggest`: die reichen
+Signale, die bereits auf `FeatureNode` liegen (`valueProp`, `health`, `rollup`
+mit `pctDone`/`blocked`/`open`), in Prompt-Input, Prompt-Regeln und Output-Schema
+einspeisen — rein prompt-/output-seitig, ohne DB- oder Typänderung. Prompt-Bau und
+Antwort-Parsing wandern in ein reines, testbares Helper-Modul, damit die Route
+schlank bleibt (S1) und die Logik per Vitest ohne LLM/HTTP geprüft werden kann (S2).
+
+## File Structure
+
+Neu:
+- `website/src/lib/tickets/suggest-prompt.ts` — reines Helper-Modul:
+  `buildFeatureList`, `SUGGEST_SYSTEM_PROMPT`, `parseSuggestions`, Typ `Suggestion`.
+- `website/src/lib/tickets/suggest-prompt.test.ts` — Vitest für die Helper.
+
+Geändert:
+- `website/src/pages/api/admin/cockpit/suggest.ts` — nutzt die Helper statt
+  inline-Prompt/Parser; Route schrumpft dadurch (.ts, Zeilen-Limit 600, aktuell
+  ~68 Zeilen → reichlich Kapazität, Netto-Zeilen sinken).
+- `website/src/components/admin/SuggestionBar.svelte` — optionales `impact`-Badge
+  neben der `reason` (.svelte, Zeilen-Limit 500 → unkritisch, nur additive Zeilen).
+
+E2E:
+- `tests/e2e/specs/` — bestehende Cockpit-Suggest-Spec verifizieren/erweitern
+  (genauer Dateiname wird in Task 1 ermittelt).
+
+## Task 1: Helper-Modul + failing Vitest (rot)
+
+Ziel: pure Funktionen anlegen und mit einem Test absichern, der zuerst fehlschlägt.
+
+Schritte:
+1. Cockpit-Suggest-E2E-Spec lokalisieren:
+   `grep -rl "cockpit" tests/e2e/specs/ | xargs grep -l "suggest\|Rollen" || true`
+   und Dateinamen notieren (für Task 4).
+2. `website/src/lib/tickets/suggest-prompt.test.ts` schreiben — deckt ab:
+   - `buildFeatureList` nimmt `valueProp`, `health`, `pctDone`, `blocked`, `open`
+     in die Zeile auf und lässt `synthetic`-Buckets weg.
+   - `parseSuggestions` extrahiert valides JSON-Array, verwirft Einträge ohne
+     `featureId`, toleriert fehlendes `impact`, gibt bei Müll-Input `[]` zurück.
+3. Den Test laufen lassen — expected: FAIL (Modul existiert noch nicht):
+   `cd website && pnpm vitest run src/lib/tickets/suggest-prompt.test.ts`
+   Es ist zu verify it fails (rot), bevor Implementierung beginnt.
+
+Akzeptanz: Vitest läuft und schlägt erwartungsgemäß fehl (kein Modul / Funktionen leer).
+
+## Task 2: Helper implementieren (grün)
+
+Ziel: `suggest-prompt.ts` so implementieren, dass Task-1-Test grün wird.
+
+Schritte:
+1. `Suggestion`-Typ: `{ featureId: string; nextStep: boolean; reason: string; impact?: 'hoch'|'mittel'|'niedrig' }`.
+2. `buildFeatureList(portfolio)`: über `products.flatMap(p => p.features)` iterieren,
+   `synthetic`-Features ausfiltern, je Zeile `extId, title, Produkt, priority,
+   valueProp, health, pctDone%, blocked, open, major/discarded/nextStep, Kommentar`.
+3. `SUGGEST_SYSTEM_PROMPT`: bestehende Gleichverteilungsregel plus: hohen
+   `valueProp` und fast-fertige (`pctDone` hoch, <100) bevorzugen; entblockende
+   Features höher gewichten; `health=red`/`blocked>0` meiden; `reason` konkret auf
+   die Signale stützen; Output `[{featureId,nextStep,reason,impact?}]`.
+4. `parseSuggestions(text)`: Array via Regex extrahieren, `JSON.parse`, je Eintrag
+   `featureId` (string) + `nextStep` (bool) erzwingen, sonst Eintrag verwerfen;
+   `impact` nur übernehmen, wenn aus dem Enum; bei Fehler `[]`.
+5. Test grün: `cd website && pnpm vitest run src/lib/tickets/suggest-prompt.test.ts`.
+
+Akzeptanz: Task-1-Vitest grün; keine Import-Zyklen (S2); kein Brand-Domain-Literal (S3).
+
+## Task 3: Route auf Helper umstellen
+
+Ziel: `suggest.ts` nutzt die Helper, Route bleibt schlank.
+
+Schritte:
+1. In `website/src/pages/api/admin/cockpit/suggest.ts` den inline-`featureList`-Bau,
+   den inline-`systemPrompt` und das inline-Parsing durch
+   `buildFeatureList`, `SUGGEST_SYSTEM_PROMPT`, `parseSuggestions` ersetzen.
+2. Auth-Gate, Provider/Model-Defaults, DeepSeek-Call und Fehlerbehandlung
+   unverändert lassen; Antwortform `{ suggestions }` bleibt rückwärtskompatibel.
+3. Typcheck: `cd website && pnpm tsc --noEmit` (oder `pnpm check`).
+
+Akzeptanz: `tsc` grün; Route nutzt ausschließlich die Helper für Prompt/Parsing.
+
+## Task 4: UI-Badge + E2E
+
+Ziel: `impact` in der UI zeigen und E2E-Abdeckung sicherstellen.
+
+Schritte:
+1. In `website/src/components/admin/SuggestionBar.svelte` neben `reason` ein
+   dezentes `impact`-Badge rendern, wenn `s.impact` gesetzt ist; bestehende
+   Anzeige/Übernehmen unverändert.
+2. Die in Task 1 gefundene Cockpit-Suggest-E2E-Spec prüfen: läuft sie noch gegen
+   die Selektoren? Falls die reichere Anzeige eine Assertion erlaubt, additive
+   Erwartung ergänzen; sonst unverändert lassen.
+3. Falls Tests hinzukamen: `task test:inventory` und das aktualisierte
+   `website/src/data/test-inventory.json` mit committen.
+
+Akzeptanz: SuggestionBar zeigt `impact`-Badge bei vorhandenem Feld; E2E-Spec konsistent.
+
+## Task 5: Finale Verifikation (CI-Äquivalent)
+
+Ziel: lokale Reproduktion des CI-Gates vor dem Push.
+
+Schritte:
+1. `cd website && pnpm vitest run src/lib/tickets/suggest-prompt.test.ts` — grün.
+2. `task test:changed` — Offline-/Unit-/Manifest-Gate für die geänderten Pfade.
+3. `task freshness:regenerate` — generierte Artefakte neu erzeugen.
+4. `task freshness:check` — S1–S4-Ratchet + Freshness grün; bei roten S1-Budgets
+   die Route weiter verschlanken statt Schwelle anheben.
+5. Bei Test-Änderungen `task test:inventory` erneut und Inventar committen.
+
+Akzeptanz: alle drei Gate-Kommandos grün; keine offenen Diffs an generierten Artefakten.

--- a/docs/superpowers/specs/2026-06-16-cockpit-suggest-richer-design.md
+++ b/docs/superpowers/specs/2026-06-16-cockpit-suggest-richer-design.md
@@ -1,0 +1,112 @@
+---
+title: Reichere Cockpit-Feature-Vorschläge
+date: 2026-06-16
+slug: cockpit-suggest-richer
+ticket_id: T000924
+plan_ref: docs/superpowers/plans/2026-06-16-cockpit-suggest-richer.md
+domains: [website, ai/factory]
+status: draft
+---
+
+# Reichere Cockpit-Feature-Vorschläge
+
+## Warum (Problem)
+
+Der KI-gestützte Portfolio-Manager unter `POST /api/admin/cockpit/suggest`
+(eingeführt mit T000784 / PR #1706) erzeugt **arme** Vorschläge. Er füttert dem
+LLM pro Feature nur einen dünnen Slice — `extId, title, Produkt, priority,
+majorFeature, discarded, nextStep, suggestionComment` — und gibt ihm nur 5 grobe
+Regeln (Gleichverteilung über Produkte, discarded meiden, major bevorzugen,
+Kommentar beachten, JSON-Format).
+
+Dabei trägt das Portfolio-Datenmodell (`FeatureNode` in
+`website/src/lib/tickets/cockpit-types.ts`, befüllt von `getPortfolio` in
+`cockpit-db.ts`) bereits **reiche Signale, die `suggest.ts` wegwirft**:
+
+- `valueProp` — der Ein-Satz-Nutzen (wird von `getPortfolio` selektiert, aber nicht in den Prompt gegeben)
+- `health` (`red`/`amber`/`green`) — Ampel aus dem Rollup
+- `rollup` — `total / done / blocked / inProgress / open / pctDone` der Leaf-Tickets
+
+Das LLM entscheidet also **blind** zu Wert, Fortschritt und Blockern. Vorschläge
+sind dadurch generisch und nicht handlungsleitend.
+
+## Was (Lösung)
+
+Die Vorschlags-Erzeugung **reichhaltiger** machen — rein prompt- und
+output-seitig, **ohne Schema- oder DAL-Änderung** (alle Felder liegen schon auf
+`FeatureNode`):
+
+1. **Reicherer LLM-Input.** Die Feature-Zeile um die vorhandenen Signale
+   erweitern: `valueProp`, `health`, `pctDone%`, `blocked`-Anzahl, `open`-Anzahl.
+   Synthetische Buckets (`Alle Tickets` / `Ohne Feature`, `synthetic: true`)
+   werden ausgefiltert — sie sind keine echten Features.
+
+2. **Reichere Prompt-Regeln.** Zusätzlich zur Gleichverteilung soll das Modell:
+   - Features mit hohem `valueProp` und **fast fertige** (hohes `pctDone`, aber
+     nicht 100 %) bevorzugen — „nahe am Abschluss zuerst",
+   - Features, die andere entblocken (Hinweis über `blocked`/Abhängigkeiten), höher gewichten,
+   - **blockierte** (`health=red` / `blocked>0`) eher meiden,
+   - die `reason` **konkret auf die gelieferten Signale** stützen (kein generisches Geschwafel).
+
+3. **Reicheres Output-Schema (rückwärtskompatibel).** Pro Vorschlag zusätzlich
+   ein optionales `impact`-Feld (`hoch`/`mittel`/`niedrig`). Bestehende Consumer,
+   die nur `featureId`/`nextStep`/`reason` lesen, bleiben unberührt.
+   Schema: `[{ "featureId", "nextStep", "reason", "impact"? }]`.
+
+4. **Robusteres Parsing.** Das aktuelle `text.match(/\[[\s\S]*\]/)` ist fragil
+   (greift ggf. zu gierig). Parsing in einen reinen Helper auslagern, der das
+   Array extrahiert, JSON-parsed und pro Eintrag die Pflichtfelder validiert
+   (Einträge ohne `featureId` verwerfen statt die ganze Antwort).
+
+5. **UI-Anreicherung (minimal).** In `SuggestionBar.svelte` neben der `reason`
+   ein dezentes `impact`-Badge anzeigen, wenn vorhanden. Keine Layout-Umbauten.
+
+### Architektur-Entscheidung: Pure Helper-Modul
+
+Prompt-Bau und Antwort-Parsing wandern in ein **reines, importzyklenfreies**
+Modul `website/src/lib/tickets/suggest-prompt.ts`:
+
+- `buildFeatureList(portfolio): string` — reiche Feature-Zeilen, synthetische gefiltert
+- `SUGGEST_SYSTEM_PROMPT: string` — die reicheren Regeln
+- `parseSuggestions(text): Suggestion[]` — tolerantes Extrahieren + Validieren
+
+**Trade-off / Begründung:**
+- Hält `suggest.ts` schlank → respektiert das **S1-Zeilen-Ratchet** (die Route
+  würde sonst durch Prompt-Text deutlich wachsen).
+- Reine Funktionen sind **unit-testbar ohne HTTP/LLM** → TDD möglich, schnelle
+  Vitest-Abdeckung statt nur teurer E2E.
+- Erfüllt **S2** (pures Modul, keine Import-Zyklen, kein Seiteneffekt).
+
+## Nicht-Ziele
+
+- Kein Repo-/PR-Kontext oder Dedup-Erkennung an das LLM (separater, größerer
+  Schritt — gehört in den Retro-Verbesserungsplan, nicht hierher).
+- Keine Änderung an `getPortfolio`, am DB-Schema oder an `cockpit-types.ts`.
+- Keine Änderung am Planungsbüro-Klärungs-Flow (`clarification-questions.ts`) oder
+  an GekkoMode.
+- Kein neuer Provider/Model-Pfad — DeepSeek-Default bleibt.
+
+## Akzeptanzkriterien
+
+- [ ] `buildFeatureList` nimmt `valueProp`, `health`, `pctDone`, `blocked`, `open`
+      in die Zeile auf und filtert `synthetic`-Buckets heraus (Vitest).
+- [ ] `parseSuggestions` extrahiert valides Array, verwirft Einträge ohne
+      `featureId`, toleriert fehlendes `impact` (Vitest, inkl. Müll-Input).
+- [ ] Der System-Prompt enthält die reicheren Regeln (Wert/Fortschritt/Blocker).
+- [ ] `suggest.ts` nutzt die Helper; Route bleibt zeilen-budget-konform (S1).
+- [ ] `SuggestionBar.svelte` zeigt `impact`-Badge wenn vorhanden; bestehende
+      Anzeige (`reason`/Übernehmen) unverändert funktionsfähig.
+- [ ] E2E des Cockpit-Suggest-Flows bleibt grün (bzw. wird um die reichere
+      Anzeige erweitert).
+- [ ] `task test:changed` + `task freshness:regenerate` + `task freshness:check`
+      grün; `task test:inventory` aktualisiert falls Tests hinzukamen.
+
+## Betroffene Dateien (Erst-Einschätzung)
+
+| Datei | Änderung |
+|---|---|
+| `website/src/lib/tickets/suggest-prompt.ts` | **neu** — pure Helper (buildFeatureList / SYSTEM_PROMPT / parseSuggestions) |
+| `website/src/lib/tickets/suggest-prompt.test.ts` | **neu** — Vitest |
+| `website/src/pages/api/admin/cockpit/suggest.ts` | Helper nutzen, Route schlank halten |
+| `website/src/components/admin/SuggestionBar.svelte` | impact-Badge (minimal) |
+| `tests/e2e/specs/…cockpit…suggest….spec.ts` | reichere Anzeige verifizieren |

--- a/k3d/docs-content-built/architecture/index.html
+++ b/k3d/docs-content-built/architecture/index.html
@@ -178,7 +178,7 @@
 <body>
   <div class="header">
     <h1>⬡ Architektur — Living Docs</h1>
-    <span class="meta">Generiert: 2026-06-16T19:44:47.012Z</span>
+    <span class="meta">Generiert: 2026-06-16T19:53:24.847Z</span>
   </div>
 
   <div class="stats">

--- a/website/src/components/admin/CockpitSidebar.svelte
+++ b/website/src/components/admin/CockpitSidebar.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { onMount } from 'svelte';
   import type { PortfolioPayload, FeatureNode } from '../../lib/tickets/cockpit-types';
+  import type { Suggestion } from '../../lib/tickets/suggest-prompt';
   import SuggestionBar from './SuggestionBar.svelte';
 
   export let portfolio: PortfolioPayload;
@@ -11,6 +12,9 @@
 
   let drawerOpen = false;
   let isRolling = false;
+  // Last AI roll result — surfaced in the SuggestionBar so the model's
+  // value/blocker reasoning + impact is visible instead of silently discarded.
+  let suggestions: Suggestion[] = [];
 
   // Scaling controls for the 130+ feature list: search, active-only, per-product collapse.
   let filter = '';
@@ -70,8 +74,10 @@
         body: JSON.stringify({ provider: detail.provider, model: detail.model }),
       });
       if (!res.ok) throw new Error(`suggest ${res.status}`);
+      const data = await res.json().catch(() => ({}));
+      suggestions = Array.isArray(data.suggestions) ? data.suggestions : [];
       onMutated?.();
-    } catch { /* errors surfaced via parent toast */ }
+    } catch { suggestions = []; /* errors surfaced via parent toast */ }
     finally { isRolling = false; }
   }
 
@@ -191,6 +197,7 @@
   <div class="sidebar-footer">
     <SuggestionBar
       features={allFeatures.filter((f) => !f.synthetic)}
+      {suggestions}
       {isRolling}
       onroll={handleRoll}
       onapply={handleApply}

--- a/website/src/components/admin/SuggestionBar.svelte
+++ b/website/src/components/admin/SuggestionBar.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
   import { createEventDispatcher } from 'svelte';
   import type { FeatureNode } from '../../lib/tickets/cockpit-types';
+  import type { Suggestion } from '../../lib/tickets/suggest-prompt';
 
   export let features: FeatureNode[] = [];
+  export let suggestions: Suggestion[] = [];
   export let isRolling: boolean = false;
   export let onroll: ((detail: { provider: string; model: string }) => void) | undefined = undefined;
   export let onapply: (() => void) | undefined = undefined;
@@ -16,6 +18,10 @@
   $: nextCount = features.filter(f => f.nextStep).length;
   $: discardedCount = features.filter(f => f.discarded).length;
   $: majorCount = features.filter(f => f.majorFeature).length;
+
+  function titleFor(featureId: string): string {
+    return features.find(f => f.extId === featureId)?.title ?? featureId;
+  }
 
   function onRoll() {
     const detail = { provider, model };
@@ -68,6 +74,23 @@
   </div>
 </div>
 
+{#if suggestions.length > 0}
+  <ul class="suggestion-list" data-testid="suggestion-list">
+    {#each suggestions as s (s.featureId)}
+      <li class="suggestion" class:next={s.nextStep}>
+        <span class="s-flag" title={s.nextStep ? 'Als nächster Schritt empfohlen' : 'Nicht für nächsten Schritt'}>
+          {s.nextStep ? '▶' : '·'}
+        </span>
+        <span class="s-title">{titleFor(s.featureId)}</span>
+        {#if s.impact}
+          <span class="impact impact-{s.impact}" title="Geschätzter Nutzen">{s.impact}</span>
+        {/if}
+        <span class="s-reason">{s.reason}</span>
+      </li>
+    {/each}
+  </ul>
+{/if}
+
 <style>
   .suggestion-bar { display: flex; align-items: center; justify-content: space-between;
     gap: 0.75rem; padding: 0.5rem 0.75rem; background: rgba(28,31,38,.5); border-radius: 8px;
@@ -92,4 +115,19 @@
   .counter.discarded { background: rgba(239,68,68,.12); color: #f87171; }
   .counter.major { background: rgba(245,158,11,.12); color: #fbbf24; }
   .counter.total { background: #2a2e37; color: #9ca3af; }
+
+  .suggestion-list { list-style: none; margin: 0.5rem 0 0; padding: 0;
+    display: flex; flex-direction: column; gap: 0.25rem; }
+  .suggestion { display: flex; align-items: baseline; gap: 0.4rem;
+    font-size: 0.78rem; padding: 0.2rem 0.4rem; border-radius: 6px;
+    background: rgba(28,31,38,.4); }
+  .suggestion.next { background: rgba(16,185,129,.08); }
+  .s-flag { color: #34d399; width: 1ch; flex-shrink: 0; }
+  .s-title { font-weight: 600; color: #e5e7eb; flex-shrink: 0; }
+  .s-reason { color: #9ca3af; }
+  .impact { padding: 0.05rem 0.4rem; border-radius: 999px; font-size: 0.7rem;
+    font-weight: 600; flex-shrink: 0; }
+  .impact-hoch { background: rgba(16,185,129,.15); color: #34d399; }
+  .impact-mittel { background: rgba(245,158,11,.15); color: #fbbf24; }
+  .impact-niedrig { background: #2a2e37; color: #9ca3af; }
 </style>

--- a/website/src/components/admin/SuggestionBar.test.ts
+++ b/website/src/components/admin/SuggestionBar.test.ts
@@ -63,4 +63,21 @@ describe('SuggestionBar', () => {
     expect((getByText('Übernehmen') as HTMLButtonElement).disabled).toBe(true);
     expect((getByText('Zurücksetzen') as HTMLButtonElement).disabled).toBe(true);
   });
+
+  it('renders the rich AI suggestions with reason, title and impact badge', () => {
+    const suggestions = [
+      { featureId: 'f1', nextStep: true, reason: 'fast fertig, hoher Wert', impact: 'hoch' as const },
+      { featureId: 'f3', nextStep: false, reason: 'blockiert' },
+    ];
+    const { getByTestId, getByText } = render(SuggestionBar, { features, suggestions, isRolling: false });
+    expect(getByTestId('suggestion-list')).toBeTruthy();
+    expect(getByText('fast fertig, hoher Wert')).toBeTruthy();
+    expect(getByText('hoch')).toBeTruthy();       // impact badge
+    expect(getByText('F1')).toBeTruthy();          // resolved feature title
+  });
+
+  it('does not render the suggestion list when there are no suggestions', () => {
+    const { queryByTestId } = render(SuggestionBar, { features, isRolling: false });
+    expect(queryByTestId('suggestion-list')).toBeNull();
+  });
 });

--- a/website/src/lib/tickets/suggest-prompt.test.ts
+++ b/website/src/lib/tickets/suggest-prompt.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest';
+import { buildFeatureList, parseSuggestions, SUGGEST_SYSTEM_PROMPT } from './suggest-prompt';
+import type { PortfolioPayload } from './cockpit-types';
+
+function portfolio(): PortfolioPayload {
+  return {
+    products: [
+      {
+        id: 'p1', extId: 'P1', title: 'Brett',
+        rollup: { total: 10, done: 5, blocked: 1, inProgress: 2, open: 2, pctDone: 50 },
+        features: [
+          {
+            id: 'f1', extId: 'T000111', title: 'Lobby-Refresh',
+            valueProp: 'Schnellerer Lobby-Beitritt', priority: 'hoch', health: 'amber',
+            rollup: { total: 4, done: 3, blocked: 0, inProgress: 1, open: 0, pctDone: 75 },
+            nextStep: false, discarded: false, majorFeature: false,
+            suggestionComment: 'fast fertig',
+          },
+          {
+            id: 'f2', extId: 'T000222', title: 'Blocker-Feature',
+            valueProp: undefined, priority: 'mittel', health: 'red',
+            rollup: { total: 6, done: 0, blocked: 2, inProgress: 0, open: 4, pctDone: 0 },
+            nextStep: false, discarded: false, majorFeature: true,
+          },
+        ],
+      },
+      {
+        // synthetic aggregate bucket — must be filtered out
+        id: 'ALL', extId: 'ALL', title: 'Alle Tickets',
+        rollup: { total: 99, done: 0, blocked: 0, inProgress: 0, open: 99, pctDone: 0 },
+        features: [
+          {
+            id: 'ALL', extId: 'ALL', title: 'Alle Tickets', priority: 'mittel', health: 'amber',
+            rollup: { total: 99, done: 0, blocked: 0, inProgress: 0, open: 99, pctDone: 0 },
+            nextStep: false, discarded: false, majorFeature: false, synthetic: true,
+          },
+        ],
+      },
+    ],
+  };
+}
+
+describe('buildFeatureList', () => {
+  const list = buildFeatureList(portfolio());
+
+  it('includes the rich signals valueProp, health, pctDone, blocked, open', () => {
+    expect(list).toContain('Schnellerer Lobby-Beitritt');
+    expect(list).toContain('amber');
+    expect(list).toContain('75'); // pctDone of f1
+    expect(list).toContain('Blockiert: 2'); // blocked of f2
+    expect(list).toMatch(/Offen: 4/); // open of f2
+  });
+
+  it('lists real features and excludes synthetic aggregate buckets', () => {
+    expect(list).toContain('T000111');
+    expect(list).toContain('T000222');
+    expect(list).not.toContain('Alle Tickets');
+  });
+});
+
+describe('SUGGEST_SYSTEM_PROMPT', () => {
+  it('asks the model for the richer output schema and value/blocker reasoning', () => {
+    expect(SUGGEST_SYSTEM_PROMPT).toMatch(/impact/);
+    expect(SUGGEST_SYSTEM_PROMPT).toMatch(/value|Wert/i);
+    expect(SUGGEST_SYSTEM_PROMPT).toMatch(/block/i);
+  });
+});
+
+describe('parseSuggestions', () => {
+  it('parses a valid JSON array with the rich fields', () => {
+    const out = parseSuggestions(
+      '[{"featureId":"T000111","nextStep":true,"reason":"fast fertig","impact":"hoch"}]',
+    );
+    expect(out).toHaveLength(1);
+    expect(out[0]).toEqual({
+      featureId: 'T000111', nextStep: true, reason: 'fast fertig', impact: 'hoch',
+    });
+  });
+
+  it('extracts the array even when surrounded by prose', () => {
+    const out = parseSuggestions('Hier mein Vorschlag:\n[{"featureId":"X","nextStep":false,"reason":"r"}]\nEnde.');
+    expect(out).toHaveLength(1);
+    expect(out[0].featureId).toBe('X');
+  });
+
+  it('tolerates a missing impact field', () => {
+    const out = parseSuggestions('[{"featureId":"X","nextStep":true,"reason":"r"}]');
+    expect(out[0].impact).toBeUndefined();
+  });
+
+  it('drops entries without a featureId', () => {
+    const out = parseSuggestions('[{"nextStep":true,"reason":"r"},{"featureId":"Y","nextStep":false,"reason":"ok"}]');
+    expect(out).toHaveLength(1);
+    expect(out[0].featureId).toBe('Y');
+  });
+
+  it('ignores an impact value outside the enum', () => {
+    const out = parseSuggestions('[{"featureId":"Z","nextStep":true,"reason":"r","impact":"BOOM"}]');
+    expect(out[0].impact).toBeUndefined();
+  });
+
+  it('returns [] for non-array or garbage input', () => {
+    expect(parseSuggestions('no json here')).toEqual([]);
+    expect(parseSuggestions('{"featureId":"X"}')).toEqual([]);
+    expect(parseSuggestions('')).toEqual([]);
+  });
+});

--- a/website/src/lib/tickets/suggest-prompt.ts
+++ b/website/src/lib/tickets/suggest-prompt.ts
@@ -1,0 +1,97 @@
+// Pure, side-effect-free helpers for the cockpit feature-suggestion route
+// (`POST /api/admin/cockpit/suggest`). Kept out of the route so the prompt
+// building and (brittle) LLM-output parsing are unit-testable without HTTP or
+// a live model, and so the route stays line-budget-lean (S1). No imports other
+// than the portfolio types — no import cycles (S2).
+import type { PortfolioPayload, FeatureNode } from './cockpit-types';
+
+export const IMPACT_VALUES = ['hoch', 'mittel', 'niedrig'] as const;
+export type Impact = (typeof IMPACT_VALUES)[number];
+
+export interface Suggestion {
+  featureId: string;
+  nextStep: boolean;
+  reason: string;
+  impact?: Impact;
+}
+
+/**
+ * Render one richly-annotated line per real feature for the LLM. Unlike the
+ * previous thin list (id/title/priority/flags only) this surfaces the value and
+ * progress signals that already live on the FeatureNode — `valueProp`, the
+ * health traffic-light, and the rollup (`pctDone`, `blocked`, `open`) — so the
+ * model can reason about value, near-completion and blockers. Synthetic
+ * aggregate buckets ("Alle Tickets" / "Ohne Feature") are excluded — they are
+ * not real features and must never be marked as a next step.
+ */
+export function buildFeatureList(portfolio: PortfolioPayload): string {
+  const rows: string[] = [];
+  for (const product of portfolio.products) {
+    for (const f of product.features) {
+      if (f.synthetic) continue;
+      rows.push(featureLine(rows.length + 1, f, product.title));
+    }
+  }
+  return rows.join('\n');
+}
+
+function featureLine(n: number, f: FeatureNode, productTitle: string): string {
+  const r = f.rollup;
+  const parts = [
+    `Produkt: ${productTitle}`,
+    `Priorität: ${f.priority}`,
+    `Wert: ${f.valueProp?.trim() || '—'}`,
+    `Ampel: ${f.health}`,
+    `Fortschritt: ${r.pctDone}%`,
+    `Blockiert: ${r.blocked}`,
+    `Offen: ${r.open}`,
+    `Major: ${f.majorFeature}`,
+    `Verworfen: ${f.discarded}`,
+    `Nächster Schritt: ${f.nextStep}`,
+  ];
+  if (f.suggestionComment) parts.push(`Kommentar: ${f.suggestionComment}`);
+  return `${n}. [${f.extId}] ${f.title} (${parts.join(', ')})`;
+}
+
+export const SUGGEST_SYSTEM_PROMPT = `Du bist ein Feature-Portfolio-Manager. Entscheide, welche Features als "nächster Schritt" (nextStep) angegangen werden sollen, und begründe es konkret aus den gelieferten Signalen.
+Regeln:
+1. Gleichverteilung über Produkte: ungefähr gleiche Anzahl Features pro Produkt für nextStep=true.
+2. Bevorzuge Features mit hohem geschäftlichem Wert (siehe "Wert") und solche, die fast fertig sind (hoher Fortschritt %, aber <100).
+3. Bevorzuge Features, die andere Arbeit entblocken; meide Features, die selbst blockiert sind (Ampel rot bzw. Blockiert > 0).
+4. Features mit Verworfen=true nicht für nextStep vorschlagen; Major-Features tendenziell bevorzugen.
+5. Falls ein Kommentar vorhanden ist, diesen als Kontext berücksichtigen.
+6. Die "reason" MUSS sich konkret auf die gelieferten Signale stützen (Wert, Fortschritt, Blocker) — kein generischer Text.
+7. "impact" schätzt den Nutzen der Empfehlung als "hoch", "mittel" oder "niedrig".
+8. Antworte NUR mit einem JSON-Array, kein weiterer Text:
+[{"featureId":"<extId>","nextStep":true|false,"reason":"<kurze, signalgestützte Begründung>","impact":"hoch|mittel|niedrig"}]`;
+
+/**
+ * Tolerant parser for the model's reply. The model is asked for a bare JSON
+ * array but often wraps it in prose; we extract the first `[ … ]` span, parse
+ * it, and validate each entry — dropping malformed entries (missing featureId)
+ * rather than failing the whole response. Returns `[]` on any structural error.
+ */
+export function parseSuggestions(text: string): Suggestion[] {
+  const match = text.match(/\[[\s\S]*\]/);
+  if (!match) return [];
+  let raw: unknown;
+  try { raw = JSON.parse(match[0]); } catch { return []; }
+  if (!Array.isArray(raw)) return [];
+
+  const out: Suggestion[] = [];
+  for (const item of raw) {
+    if (!item || typeof item !== 'object') continue;
+    const rec = item as Record<string, unknown>;
+    if (typeof rec.featureId !== 'string' || rec.featureId === '') continue;
+    const suggestion: Suggestion = {
+      featureId: rec.featureId,
+      nextStep: rec.nextStep === true,
+      reason: typeof rec.reason === 'string' ? rec.reason : '',
+    };
+    if (typeof rec.impact === 'string' && (IMPACT_VALUES as readonly string[]).includes(rec.impact)) {
+      suggestion.impact = rec.impact as Impact;
+    }
+    out.push(suggestion);
+  }
+  return out;
+}

--- a/website/src/pages/api/admin/cockpit/suggest.ts
+++ b/website/src/pages/api/admin/cockpit/suggest.ts
@@ -1,6 +1,7 @@
 import type { APIRoute } from 'astro';
 import { getSession, isAdmin } from '../../../../lib/auth';
 import { getPortfolio } from '../../../../lib/tickets/cockpit-db';
+import { buildFeatureList, parseSuggestions, SUGGEST_SYSTEM_PROMPT } from '../../../../lib/tickets/suggest-prompt';
 
 const BRAND = (): string => process.env.BRAND_ID ?? process.env.BRAND ?? 'mentolder';
 const json = (d: unknown, s = 200) =>
@@ -17,25 +18,9 @@ export const POST: APIRoute = async ({ request }) => {
   const model = body.model || 'deepseek-chat';
 
   const portfolio = await getPortfolio(BRAND());
-  const features = portfolio.products.flatMap(p => p.features);
+  const featureList = buildFeatureList(portfolio);
 
-  if (features.length === 0) return json({ suggestions: [] });
-
-  const featureList = features.map((f, i) =>
-    `${i + 1}. [${f.extId}] ${f.title} (Produkt: ${portfolio.products.find(p =>
-      p.features.some(pf => pf.id === f.id))?.title ?? '?'}, ` +
-    `Priorität: ${f.priority}, Major: ${f.majorFeature}, Verworfen: ${f.discarded}, ` +
-    `Nächster Schritt: ${f.nextStep}` +
-    `${f.suggestionComment ? `, Kommentar: ${f.suggestionComment}` : ''})`,
-  ).join('\n');
-
-  const systemPrompt = `Du bist ein Feature-Portfolio-Manager. Verteile die folgenden Features auf "nächster Schritt" (nextStep).
-Regeln:
-1. Gleichverteilung über Produkte: ungefähr gleiche Anzahl Features pro Produkt für nextStep=true.
-2. Features mit discarded=true nicht für nextStep vorschlagen.
-3. Features mit majorFeature=true bevorzugen.
-4. Falls ein Kommentar vorhanden ist, diesen als Kontext berücksichtigen.
-5. Antworte NUR mit einem JSON-Array, kein weiterer Text: [{"featureId":"<extId>","nextStep":true|false,"reason":"<kurze Begründung>"}]`;
+  if (featureList === '') return json({ suggestions: [] });
 
   try {
     const { default: OpenAI } = await import('openai');
@@ -48,16 +33,15 @@ Regeln:
       max_tokens: 2000,
       temperature: 0.3,
       messages: [
-        { role: 'system', content: systemPrompt },
+        { role: 'system', content: SUGGEST_SYSTEM_PROMPT },
         { role: 'user', content: `Hier sind die Features:\n\n${featureList}` },
       ],
     });
 
     const text = resp.choices[0]?.message.content ?? '';
-    const match = text.match(/\[[\s\S]*\]/);
-    if (!match) return json({ error: 'AI response could not be parsed', raw: text }, 500);
+    const suggestions = parseSuggestions(text);
+    if (suggestions.length === 0) return json({ error: 'AI response could not be parsed', raw: text }, 500);
 
-    const suggestions = JSON.parse(match[0]);
     return json({ suggestions });
   } catch (e) {
     const msg = String((e as Error).message);


### PR DESCRIPTION
## Was
`POST /api/admin/cockpit/suggest` fütterte dem LLM nur `id/title/priority/flags` und **verwarf** die reichen Signale, die bereits auf `FeatureNode` liegen (`valueProp`, `health`, `rollup` mit `pctDone/blocked/open`). Zudem verwarf `CockpitSidebar.handleRoll` die Vorschläge komplett (nur Refetch).

## Änderung
- **Neu** `website/src/lib/tickets/suggest-prompt.ts` — reines, unit-getestetes Helper-Modul:
  - `buildFeatureList`: reiche Feature-Zeilen (Wert/Ampel/Fortschritt/Blockiert/Offen), synthetische Buckets gefiltert
  - `SUGGEST_SYSTEM_PROMPT`: reichere Regeln (hoher Wert + fast-fertig bevorzugen, Blocker meiden, signalgestützte `reason`)
  - `parseSuggestions`: tolerantes Parsen + Validieren, optionales `impact`-Feld, verwirft kaputte Einträge
- `suggest.ts` nutzt die Helper (Route schlanker → S1)
- `CockpitSidebar` konsumiert das Roll-Ergebnis; `SuggestionBar` zeigt je Vorschlag `reason` + `impact`-Badge

## Tests
- Vitest: `suggest-prompt.test.ts` (9) + `SuggestionBar.test.ts` (+2) — 18/18 grün
- `task test:changed` 50/50, `task freshness:check` grün, astro-check clean in geänderten Dateien

Spec: `docs/superpowers/specs/2026-06-16-cockpit-suggest-richer-design.md`
Plan: `docs/superpowers/plans/2026-06-16-cockpit-suggest-richer.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)