### PR TITLE
fix(factory): stateless MCP transport + reliable start/stop

### DIFF
--- a/Taskfile.openclaw.yml
+++ b/Taskfile.openclaw.yml
@@ -144,29 +144,38 @@ tasks:
   factory-mcp:start:
     desc: "Start the Factory MCP server in the background (PID file)"
     cmds:
+      # Run under real bash: go-task's mvdan/sh interpreter returns a job handle
+      # (e.g. "g1") instead of a real OS PID from `$!`, which breaks the PID file
+      # and factory-mcp:stop. bash gives the actual node PID.
       - |
-        PIDFILE=/tmp/factory-mcp.pid
-        if [[ -f "$PIDFILE" ]] && kill -0 "$(cat "$PIDFILE")" 2>/dev/null; then
-          echo "factory-mcp already running (PID $(cat $PIDFILE))"
-        else
-          nohup node scripts/factory/mcp-server.mjs > /tmp/factory-mcp.log 2>&1 &
-          echo $! > "$PIDFILE"
-          echo "factory-mcp started (PID $!)"
-        fi
+        bash -c '
+          PIDFILE=/tmp/factory-mcp.pid
+          if [[ -f "$PIDFILE" ]] && kill -0 "$(cat "$PIDFILE")" 2>/dev/null; then
+            echo "factory-mcp already running (PID $(cat "$PIDFILE"))"
+          else
+            nohup node scripts/factory/mcp-server.mjs > /tmp/factory-mcp.log 2>&1 &
+            echo $! > "$PIDFILE"
+            echo "factory-mcp started (PID $(cat "$PIDFILE"))"
+          fi
+        '
 
   factory-mcp:stop:
     desc: "Stop the Factory MCP server"
     cmds:
+      # Run under real bash: go-task's mvdan/sh `kill` builtin mishandles `kill -0`,
+      # so the liveness check always fails and the server is never actually stopped.
       - |
-        PIDFILE=/tmp/factory-mcp.pid
-        if [[ -f "$PIDFILE" ]] && kill -0 "$(cat "$PIDFILE")" 2>/dev/null; then
-          kill "$(cat "$PIDFILE")"
-          rm -f "$PIDFILE"
-          echo "factory-mcp stopped"
-        else
-          echo "factory-mcp not running"
-          rm -f "$PIDFILE"
-        fi
+        bash -c '
+          PIDFILE=/tmp/factory-mcp.pid
+          if [[ -f "$PIDFILE" ]] && kill -0 "$(cat "$PIDFILE")" 2>/dev/null; then
+            kill "$(cat "$PIDFILE")"
+            rm -f "$PIDFILE"
+            echo "factory-mcp stopped"
+          else
+            echo "factory-mcp not running"
+            rm -f "$PIDFILE"
+          fi
+        '
 
   factory-mcp:status:
     desc: "Health-check the Factory MCP server"

--- a/scripts/factory/mcp-server.mjs
+++ b/scripts/factory/mcp-server.mjs
@@ -3,7 +3,6 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js'
 import { createServer } from 'node:http'
 import { execFileSync, execFile } from 'child_process'
-import { randomUUID } from 'crypto'
 import { z } from 'zod'
 
 const REPO = process.env.FACTORY_REPO || '/home/patrick/Bachelorprojekt'
@@ -17,6 +16,11 @@ function psqlJSON(sql) {
   } catch (e) { return JSON.stringify({ error: e.message }) }
 }
 
+// Build a fresh server instance per request (stateless MCP — see transport below).
+// Tools are pure (shell/psql calls, no shared in-process state), so re-registering
+// per request is cheap and avoids the "already connected" / single-session pitfalls
+// of sharing one McpServer across multiple clients.
+function buildServer() {
 const server = new McpServer({ name: 'factory', version: '1.0.0' })
 
 server.tool('factory_status', 'Show factory queue depth and whether a tick is running', async () => {
@@ -50,6 +54,9 @@ server.tool('factory_recent', 'Show last N factory run comments from ticket_comm
   return { content: [{ type: 'text', text: psqlJSON(sql) }] }
 })
 
+  return server
+}
+
 const app = createServer(async (req, res) => {
   if (req.method === 'GET' && req.url === '/health') {
     res.writeHead(200, { 'Content-Type': 'application/json' })
@@ -59,10 +66,22 @@ const app = createServer(async (req, res) => {
   if (req.method === 'POST' && req.url === '/mcp') {
     let body = ''
     for await (const chunk of req) body += chunk
-    const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: () => randomUUID() })
-    await server.connect(transport)
-    req.body = JSON.parse(body)
-    await transport.handleRequest(req, res, req.body)
+    // Stateless transport: a fresh server+transport per request, no session id.
+    // Every initialize is accepted, so multiple/reconnecting clients (Claude Code,
+    // the OpenCode bridge) never collide on a single shared session.
+    const server = buildServer()
+    const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined })
+    res.on('close', () => { transport.close(); server.close() })
+    try {
+      req.body = JSON.parse(body)
+      await server.connect(transport)
+      await transport.handleRequest(req, res, req.body)
+    } catch (e) {
+      if (!res.headersSent) {
+        res.writeHead(500, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({ jsonrpc: '2.0', error: { code: -32603, message: String(e?.message || e) }, id: null }))
+      }
+    }
     return
   }
   res.writeHead(404).end()


### PR DESCRIPTION
## Problem
The factory MCP server (`scripts/factory/mcp-server.mjs`) called `server.connect()` per request on a single shared `McpServer`, throwing `Already connected to a transport`. This killed every request after the first; a second/reconnecting client (Claude Code + the OpenCode bridge) got HTTP 400.

## Fix
- **`mcp-server.mjs`**: fresh `server`+`transport` per request in **stateless mode** (`sessionIdGenerator: undefined`) via a `buildServer()` factory. Full handshake (`initialize` → `tools/list`) works; multiple/reconnecting clients no longer collide on one session. Adds POST error handling; drops the now-unused `randomUUID` import.
- **`Taskfile.openclaw.yml`**: run `factory-mcp:start`/`:stop` under `bash -c`. go-task's `mvdan/sh` returns a job handle (`g1`) instead of a real PID from `$!` and its `kill` builtin mishandles `kill -0`, so `stop` never actually killed the server and the PID file was bogus.

## Verification
- BATS `tests/unit/factory/mcp-server.bats`: 2/2 ✓
- Full `start → status → stop` cycle via `task -t Taskfile.openclaw.yml factory-mcp:*` (pidfile == listener PID, port freed on stop) ✓
- Live multi-client handshake against `127.0.0.1:13003`: clients A/B/C all HTTP 200 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)