### PR TITLE
feat(tickets): Pflichtenheft→Lastenheft requirements list with AI-readiness lock [T000928]

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -273,6 +273,7 @@ tasks:
       - task: test:unit:ticket-add-pr-link
       - task: test:unit:ticket-create
       - task: test:unit:ticket-grill
+      - task: test:unit:ticket-lastenheft
       - task: test:unit:worktree-create
       - task: test:unit:test-tasks-node-deps
       - task: test:unit:quality-loop
@@ -494,6 +495,11 @@ tasks:
     internal: true
     cmds:
       - ./tests/unit/lib/bats-core/bin/bats tests/unit/ticket-grill.bats
+
+  test:unit:ticket-lastenheft:
+    internal: true
+    cmds:
+      - ./tests/unit/lib/bats-core/bin/bats tests/unit/ticket-lastenheft.bats
 
   test:unit:worktree-create:
     internal: true

--- a/docs/superpowers/plans/2026-06-17-ticket-pflichtenheft-lastenheft.md
+++ b/docs/superpowers/plans/2026-06-17-ticket-pflichtenheft-lastenheft.md
@@ -1,0 +1,48 @@
+---
+ticket_id: T000928
+status: done
+domains: [website, factory, db]
+spec_ref: docs/superpowers/specs/2026-06-17-ticket-pflichtenheft-lastenheft-design.md
+file_locks: []
+shared_changes: false
+batch_id: null
+parent_feature: null
+depends_on_plans: []
+---
+
+# Plan: Pflichtenheft → Lastenheft (Ticket-Anforderungsliste mit KI-Reife-Lock)
+
+Spec: `docs/superpowers/specs/2026-06-17-ticket-pflichtenheft-lastenheft-design.md`
+
+Umgesetzt in einem Durchgang (Ziel-getriebener autonomer Lauf). Alle Schritte verifiziert.
+
+## Tasks
+
+- [x] **T1 — DB-Spalte.** `requirements_list TEXT[]` idempotent in `initTicketsSchema()`
+  (`website/src/lib/tickets-db.ts`), zeilenneutral auf die bestehende `readiness`-Zeile gesetzt
+  (S1-Ratchet: die Datei ist baselined, Budget 0). Lock-Flag lebt im `readiness` JSONB unter
+  `lastenheft_locked`.
+- [x] **T2 — Pure Helper.** `website/src/lib/tickets/lastenheft.ts` — `canLock` (≥1 Anforderung),
+  `nextStatusOnLock` (forward-only → `backlog`), `requirementsLabel`, `isLastenheftLocked`,
+  `normalizeRequirements`. Vollständig unit-getestet (`lastenheft.test.ts`, 5 Tests).
+- [x] **T3 — Planungsbüro-Logik.** `website/src/lib/planning-office.ts`: `OfficeItem` +
+  `requirementsList`/`lastenheftLocked`; `listOffice` selektiert die Spalte; `patchItem` nimmt
+  `requirements` + `lastenheftLocked` (Vorbedingung via `canLock`, readiness als **JSONB-Merge**
+  statt Replace — verhindert das Löschen von `lastenheft_locked` beim DOR-Toggle — und
+  forward-only Status-Transition).
+- [x] **T4 — API.** `api/admin/planungsbuero/[extId].ts` reicht `requirements`/`lastenheftLocked`
+  durch; `lastenheft_empty` → HTTP 422.
+- [x] **T5 — Harter Factory-Gate.** `scripts/factory/queue.sh`: WHERE +
+  `COALESCE((readiness->>'lastenheft_locked')::boolean,false)=true` — Autopilot zieht nur
+  verriegelte Tickets (fail-closed).
+- [x] **T6 — CLI.** `scripts/ticket.sh`: `plan-meta --requirements "a|b|c"` (pipe-getrennt,
+  Kommas bleiben erhalten) + neuer `lastenheft lock|unlock --id` Subcommand (Vorbedingung +
+  Status-Transition).
+- [x] **T7 — UI.** `PlanningOfficeDetail.svelte`: Anforderungs-Editor + Lock-Toggle, Label-Flip
+  Pflichtenheft↔Lastenheft, read-only wenn verriegelt. `PlanningOffice.svelte`: `saveRequirements`
+  + `toggleLock` (422-Handling, Item verlässt das Büro nach Lock).
+- [x] **T8 — Tests.** `tests/unit/ticket-lastenheft.bats` (8 Tests, in `test:all` verdrahtet);
+  `lastenheft.test.ts` (5). Coverage-Guard grün.
+- [x] **T9 — Verifikation.** `task test:all` (EXIT 0), `pnpm vitest run` (1167 pass), `astro check`
+  (keine neuen Fehler in berührten Dateien), `task freshness:check` + `quality:check`
+  (0 blocking), `task test:inventory`.

--- a/docs/superpowers/specs/2026-06-17-ticket-pflichtenheft-lastenheft-design.md
+++ b/docs/superpowers/specs/2026-06-17-ticket-pflichtenheft-lastenheft-design.md
@@ -1,0 +1,89 @@
+---
+ticket_id: T000928
+plan_ref: null
+domains: [website, factory, db]
+status: draft
+---
+
+# Pflichtenheft → Lastenheft: Ticket-Anforderungsliste mit KI-Reife-Lock
+
+## Problem / Warum
+
+Tickets haben kein strukturiertes Feld für die fachlichen Anforderungen, die die Software
+erfüllen soll. Es gibt keinen expliziten, maschinenlesbaren „ab jetzt darf die KI ran"-Schalter:
+Die Reife eines Tickets zur autonomen Bearbeitung ist heute implizit über mehrere
+`readiness`-Flags + Status verstreut.
+
+Wir führen eine **Anforderungsliste** ein, die im Entwurf **„Pflichtenheft"** heißt und beim
+Verriegeln zu **„Lastenheft"** wird. Dieser Übergang ist das **Reife-Signal**: ein verriegeltes
+Lastenheft (mit ≥1 Anforderung) gibt das Ticket an die Software-Factory frei.
+
+> **Begriffs-Hinweis (bewusste Domänen-Konvention):** Diese Richtung (Pflichtenheft = Entwurf →
+> Lastenheft = verriegelt/KI-reif) kehrt die DIN-69901-Lehrbuch-Bedeutung um. Das ist die
+> gewünschte Projektsprache und wird überall konsistent so verwendet.
+
+## Verhalten (Entscheidungen)
+
+1. **Harter Factory-Gate:** Der Autopilot-Dispatcher bearbeitet ein Feature nur, wenn das
+   Lastenheft verriegelt ist (`readiness.lastenheft_locked = true`). Fail-closed.
+2. **Lock-Semantik:** Verriegelt = read-only. Bearbeiten erfordert explizites Entriegeln →
+   Liste heißt wieder „Pflichtenheft", KI-Reife erlischt.
+3. **Lock-Vorbedingung:** Verriegeln nur möglich mit **≥1 nicht-leerer Anforderung**.
+4. **Status-Kopplung:** Verriegeln transitioniert den Status automatisch **vorwärts → `backlog`**
+   (die Autopilot-Lane), forward-only — Tickets ab `in_progress` werden nicht zurückgeworfen.
+   Entriegeln setzt den Status **nicht** destruktiv zurück; der Gate allein verhindert das
+   KI-Pickup.
+
+## Architektur / Datenmodell
+
+Minimal-invasiv, folgt der bestehenden `value_prop`/`areas`-Präzedenz-Kette
+(DB → CLI → API → Types → UI).
+
+- **DB:** neue Spalte `requirements_list TEXT[]` in `tickets.tickets` (idempotenter `ALTER` in
+  `website/src/lib/tickets-db.ts`, neben `areas`/`depends_on`). Lock-Zustand lebt im bestehenden
+  `readiness JSONB` unter dem Key `lastenheft_locked` (bool) — **kein neuer Status-Enum-Wert,
+  kein zweites Feld**.
+- **Label rein abgeleitet:** `lastenheft_locked=true` → „Lastenheft", sonst „Pflichtenheft".
+  Nie persistiert.
+
+### Komponenten / Schnittstellen
+
+| Unit | Aufgabe | Abhängigkeiten |
+|------|---------|----------------|
+| `tickets-db.ts` (Schema) | Spalte `requirements_list` idempotent anlegen | pg pool |
+| `ticket-readiness.ts` → `lastenheftLocked(id,pool)` | reine Lese-Prüfung des Lock-Flags | pg pool |
+| `lib/tickets/lastenheft.ts` (neu) | reine Helfer: `canLock(list)` (≥1 req), `nextStatusOnLock(cur)` (forward-only → `backlog`) | keine (pures Modul, keine Import-Zyklen) |
+| `patchItem` (planning-office.ts) | `requirements_list` schreiben, `readiness` **mergen** (DOR+Lock), bei Lock serverseitig Vorbedingung+forward-Transition | lastenheft.ts |
+| API `PATCH /api/admin/planungsbuero/[extId]` | reicht `requirements`,`lastenheftLocked` durch; `lastenheft_empty`→422 | patchItem |
+| `ticket.sh` | `plan-meta --requirements "a|b|c"`, `lastenheft lock|unlock --id` | psql |
+| `factory/queue.sh` | Gate: WHERE … `AND COALESCE((readiness->>'lastenheft_locked')::boolean,false)=true` | — |
+| `PlanningOfficeDetail.svelte` | Anforderungs-Editor + Lock-Toggle + Label-Flip | API |
+| `PlanningOffice.svelte` | Badge `✓ Lastenheft` / `⚠ Pflichtenheft offen` | cockpit-types |
+
+### Datenfluss (Lock)
+
+UI Lock-Klick → `PATCH /api/admin/planungsbuero/[extId] {lastenheftLocked:true}` → `patchItem`:
+`canLock` prüfen (≥1 req, sonst 422) → readiness als ein JSONB-Merge (DOR+Lock) →
+`status = CASE … THEN 'backlog' …` (forward-only) → UPDATE.
+Danach pollt `queue.sh` das Ticket; ohne Lock bleibt es unsichtbar für den Dispatcher.
+
+## Fehlerbehandlung
+
+- Lock ohne Anforderung → **422** `{error:"lastenheft_empty"}`, kein State-Change.
+- readiness-Merge erhält **immer** andere Flags (`||`-Merge, nie überschreiben).
+- Status-Transition forward-only: `nextStatusOnLock` lässt `in_progress`/`in_review`/`done`/… unangetastet.
+- Gate fail-closed: fehlendes/ungültiges `readiness` → `false` (COALESCE).
+
+## Tests
+
+- **vitest** (`admin.ts`/`lastenheft.ts`): requirements round-trip; `canLock([])===false`;
+  readiness-Merge erhält Fremd-Flags; `nextStatusOnLock('triage')==='backlog'`,
+  `nextStatusOnLock('in_progress')==='in_progress'`.
+- **bats** (`tests/unit/`): `queue.sh`-Gate (verriegeltes Feature erscheint, unverriegeltes nicht);
+  `ticket.sh lastenheft lock` lehnt leere Liste ab und setzt Flag+Status bei gefüllter Liste.
+
+## Out of Scope (YAGNI)
+
+- Keine Versionierung/History der Anforderungsliste.
+- Kein eigener neuer Status-Enum-Wert.
+- Keine Migration bestehender Tickets (Default `'{}'` + Flag absent = „Pflichtenheft offen").

--- a/scripts/factory/queue.sh
+++ b/scripts/factory/queue.sh
@@ -15,6 +15,9 @@ FROM (
   SELECT external_id, title, priority, touched_files, created_at
   FROM tickets.tickets
   WHERE type='feature' AND status='backlog'
+    -- Pflichtenheft → Lastenheft gate: the autopilot only picks up tickets whose
+    -- Lastenheft is locked (requirements firm = AI-ready). Fail-closed on absent flag.
+    AND COALESCE((readiness->>'lastenheft_locked')::boolean, false) = true
   ORDER BY CASE priority WHEN 'hoch' THEN 1 WHEN 'mittel' THEN 2 WHEN 'niedrig' THEN 3 END, created_at
 ) q;
 SQL

--- a/scripts/ticket.sh
+++ b/scripts/ticket.sh
@@ -533,7 +533,7 @@ cmd_plan_meta() {
   if [[ "$action" != "set" && "$action" != "get" ]]; then
     echo "ERROR: plan-meta requires a subaction: set|get" >&2; exit 2
   fi
-  local id="" value_prop="" effort="" areas="" depends="" rank="" readiness=""
+  local id="" value_prop="" effort="" areas="" depends="" rank="" readiness="" requirements=""
   while [[ $# -gt 0 ]]; do case "$1" in
       --id)          id="$2"; shift 2 ;;
       --value-prop)  value_prop="$2"; shift 2 ;;
@@ -542,6 +542,7 @@ cmd_plan_meta() {
       --depends-on)  depends="$2"; shift 2 ;;
       --rank)        rank="$2"; shift 2 ;;
       --readiness)   readiness="$2"; shift 2 ;;
+      --requirements) requirements="$2"; shift 2 ;;  # Pflichtenheft list; '|'-separated (reqs may contain commas)
       *) echo "Unknown plan-meta option: $1" >&2; exit 2 ;;
     esac; done
   if [[ -z "$id" ]]; then echo "ERROR: --id is required." >&2; exit 2; fi
@@ -555,27 +556,30 @@ cmd_plan_meta() {
 SELECT json_build_object(
   'external_id', external_id, 'status', status, 'value_prop', value_prop,
   'effort', effort, 'areas', areas, 'depends_on', depends_on,
-  'planning_rank', planning_rank, 'readiness', readiness
+  'planning_rank', planning_rank, 'readiness', readiness,
+  'requirements_list', requirements_list
 ) FROM tickets.tickets WHERE external_id = :'ext_id';
 EOF
     return
   fi
 
-  local areas_sql="NULL" depends_sql="NULL" rank_sql="NULL" readiness_sql="NULL"
+  local areas_sql="NULL" depends_sql="NULL" rank_sql="NULL" readiness_sql="NULL" requirements_sql="NULL"
   [[ -n "$areas" ]]   && areas_sql="ARRAY[$(_csv_to_quoted "$areas")]"
   [[ -n "$depends" ]] && depends_sql="ARRAY[$(_csv_to_quoted "$depends")]"
   [[ -n "$rank" ]]    && rank_sql="$rank"
   [[ -n "$readiness" ]] && readiness_sql="'$(_readiness_to_json "$readiness")'::jsonb"
+  [[ -n "$requirements" ]] && requirements_sql="ARRAY[$(_pipe_to_quoted "$requirements")]"
   _exec_sql "$pod" \
     -v ext_id="$id" -v vp="$value_prop" -v eff="$effort" <<EOF >/dev/null
 UPDATE tickets.tickets SET
-  value_prop    = COALESCE(NULLIF(:'vp',''), value_prop),
-  effort        = COALESCE(NULLIF(:'eff',''), effort),
-  areas         = COALESCE($areas_sql, areas),
-  depends_on    = COALESCE($depends_sql, depends_on),
-  planning_rank = COALESCE($rank_sql, planning_rank),
-  readiness     = COALESCE($readiness_sql, readiness),
-  updated_at    = now()
+  value_prop        = COALESCE(NULLIF(:'vp',''), value_prop),
+  effort            = COALESCE(NULLIF(:'eff',''), effort),
+  areas             = COALESCE($areas_sql, areas),
+  depends_on        = COALESCE($depends_sql, depends_on),
+  planning_rank     = COALESCE($rank_sql, planning_rank),
+  readiness         = COALESCE($readiness_sql, readiness),
+  requirements_list = COALESCE($requirements_sql, requirements_list),
+  updated_at        = now()
 WHERE external_id = :'ext_id';
 EOF
   echo "plan-meta updated for $id"
@@ -591,6 +595,63 @@ _csv_to_quoted() {
   echo "$out"
 }
 
+# "a|b,c|d" -> "'a','b,c','d'" — pipe-separated so requirement lines may contain commas.
+_pipe_to_quoted() {
+  local IFS='|'; local out=""; local item
+  for item in $1; do
+    item="${item//\'/\'\'}"
+    out+="${out:+,}'$item'"
+  done
+  echo "$out"
+}
+
+# lastenheft lock|unlock --id <external_id>
+#   lock:   requires >=1 requirement; sets readiness.lastenheft_locked=true and
+#           forward-transitions status (triage/planning/plan_staged -> backlog).
+#   unlock: clears the flag (back to "Pflichtenheft"); status untouched.
+cmd_lastenheft() {
+  local action="${1:-}"; shift || true
+  if [[ "$action" != "lock" && "$action" != "unlock" ]]; then
+    echo "ERROR: lastenheft requires a subaction: lock|unlock" >&2; exit 2
+  fi
+  local id=""
+  while [[ $# -gt 0 ]]; do case "$1" in
+      --id) id="$2"; shift 2 ;;
+      *) echo "Unknown lastenheft option: $1" >&2; exit 2 ;;
+    esac; done
+  # Validate before _pgpod so bad-arg errors are deterministic without a cluster.
+  if [[ -z "$id" ]]; then echo "ERROR: --id is required." >&2; exit 2; fi
+  local pod; pod=$(_pgpod)
+  if [[ "$action" == "lock" ]]; then
+    local n
+    n=$(_exec_sql "$pod" -v ext_id="$id" <<'EOF'
+SELECT COALESCE(array_length(array_remove(array_remove(requirements_list, NULL), ''), 1), 0)
+FROM tickets.tickets WHERE external_id = :'ext_id';
+EOF
+)
+    n="${n//[[:space:]]/}"
+    if [[ -z "$n" || "$n" == "0" ]]; then
+      echo "ERROR: cannot lock — Lastenheft is empty (need >=1 requirement)." >&2; exit 3
+    fi
+    _exec_sql "$pod" -v ext_id="$id" <<'EOF' >/dev/null
+UPDATE tickets.tickets SET
+  readiness = COALESCE(readiness,'{}'::jsonb) || '{"lastenheft_locked":true}'::jsonb,
+  status    = CASE WHEN status IN ('triage','planning','plan_staged') THEN 'backlog' ELSE status END,
+  updated_at = now()
+WHERE external_id = :'ext_id';
+EOF
+    echo "lastenheft locked for $id (Lastenheft — AI-ready, status forwarded to backlog)"
+  else
+    _exec_sql "$pod" -v ext_id="$id" <<'EOF' >/dev/null
+UPDATE tickets.tickets SET
+  readiness = COALESCE(readiness,'{}'::jsonb) || '{"lastenheft_locked":false}'::jsonb,
+  updated_at = now()
+WHERE external_id = :'ext_id';
+EOF
+    echo "lastenheft unlocked for $id (Pflichtenheft — editable)"
+  fi
+}
+
 # "spec_skizziert=true,aufwand_geschaetzt=false" -> {"spec_skizziert":true,...}
 _readiness_to_json() {
   local IFS=','; local out=""; local kv k v
@@ -604,7 +665,7 @@ _readiness_to_json() {
 
 if [[ $# -lt 1 ]]; then
   echo "Usage: $0 <command> [options]" >&2
-  echo "Commands: create, update-status, add-comment, add-pr-link, grill, archive-plan, get-attachments, get, set-touched-files, set-pipeline-slot, release-slot, touch, enqueue, stage-plan, retry-count, factory-control, dryrun-mark, dryrun-check, feature-flag, phase, inject, get-injections, plan-meta" >&2
+  echo "Commands: create, update-status, add-comment, add-pr-link, grill, archive-plan, get-attachments, get, set-touched-files, set-pipeline-slot, release-slot, touch, enqueue, stage-plan, retry-count, factory-control, dryrun-mark, dryrun-check, feature-flag, phase, inject, get-injections, plan-meta, lastenheft" >&2
   exit 1
 fi
 cmd="$1"; shift
@@ -632,6 +693,7 @@ case "$cmd" in
   inject)            cmd_inject "$@" ;;
   get-injections)    cmd_get_injections "$@" ;;
   plan-meta)         cmd_plan_meta "$@" ;;
+  lastenheft)        cmd_lastenheft "$@" ;;
   *)                 echo "Unknown command: $cmd" >&2; exit 1 ;;
 esac
 

--- a/tests/unit/ticket-lastenheft.bats
+++ b/tests/unit/ticket-lastenheft.bats
@@ -1,0 +1,81 @@
+#!/usr/bin/env bats
+# bats file_tags=offline
+# Offline test: `ticket.sh lastenheft` lock/unlock + `plan-meta --requirements`, and the
+# queue.sh autopilot gate. Arg-validation runs before any cluster access; SQL shape is
+# asserted against captured psql input. kubectl is mocked; no live cluster.
+
+setup() {
+  TICKET="$BATS_TEST_DIRNAME/../../scripts/ticket.sh"
+  QUEUE="$BATS_TEST_DIRNAME/../../scripts/factory/queue.sh"
+  MOCKDIR="$(mktemp -d)"
+  CAP="$MOCKDIR/captured.sql"
+  # Default mock: any exec (count SELECT + UPDATE) returns "1" so lock precondition passes.
+  cat > "$MOCKDIR/kubectl" <<EOF
+#!/usr/bin/env bash
+if [[ "\$*" == *"get pod"* ]]; then echo "pod/shared-db-0"; exit 0; fi
+if [[ "\$*" == *"exec"* ]]; then echo "# kubectl \$*" >> "$CAP"; cat >> "$CAP"; echo "1"; exit 0; fi
+exit 0
+EOF
+  chmod +x "$MOCKDIR/kubectl"
+  PATH="$MOCKDIR:$PATH"
+  export PATH CAP
+}
+
+teardown() { rm -rf "$MOCKDIR"; }
+
+@test "lastenheft requires a subaction (deterministic exit 2 without a cluster)" {
+  run bash "$TICKET" lastenheft
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"lock|unlock"* ]]
+}
+
+@test "lastenheft rejects an unknown subaction" {
+  run bash "$TICKET" lastenheft frobnicate --id T000123
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"lock|unlock"* ]]
+}
+
+@test "lastenheft lock requires --id" {
+  run bash "$TICKET" lastenheft lock
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"--id is required"* ]]
+}
+
+@test "lastenheft lock sets the flag (true) and forward-transitions status to backlog" {
+  run bash "$TICKET" lastenheft lock --id T000123
+  [ "$status" -eq 0 ]
+  grep -q '"lastenheft_locked":true' "$CAP"
+  grep -q "COALESCE(readiness,'{}'::jsonb) ||" "$CAP"
+  grep -q "status    = CASE WHEN status IN ('triage','planning','plan_staged') THEN 'backlog' ELSE status END" "$CAP"
+}
+
+@test "lastenheft lock refuses an empty Lastenheft (exit 3)" {
+  # Override the mock so the requirements-count SELECT returns 0.
+  cat > "$MOCKDIR/kubectl" <<EOF
+#!/usr/bin/env bash
+if [[ "\$*" == *"get pod"* ]]; then echo "pod/shared-db-0"; exit 0; fi
+if [[ "\$*" == *"exec"* ]]; then echo "0"; exit 0; fi
+exit 0
+EOF
+  chmod +x "$MOCKDIR/kubectl"
+  run bash "$TICKET" lastenheft lock --id T000123
+  [ "$status" -eq 3 ]
+  [[ "$output" == *"Lastenheft is empty"* ]]
+}
+
+@test "lastenheft unlock clears the flag (false) and does NOT transition status" {
+  run bash "$TICKET" lastenheft unlock --id T000123
+  [ "$status" -eq 0 ]
+  grep -q '"lastenheft_locked":false' "$CAP"
+  ! grep -q "THEN 'backlog'" "$CAP"
+}
+
+@test "plan-meta --requirements writes requirements_list, preserving commas (pipe-separated)" {
+  run bash "$TICKET" plan-meta set --id T000123 --requirements 'Login via SSO|Export, als PDF'
+  [ "$status" -eq 0 ]
+  grep -q "requirements_list = COALESCE(ARRAY\['Login via SSO','Export, als PDF'\], requirements_list)" "$CAP"
+}
+
+@test "queue.sh gates the autopilot on a locked Lastenheft (fail-closed)" {
+  grep -q "COALESCE((readiness->>'lastenheft_locked')::boolean, false) = true" "$QUEUE"
+}

--- a/website/src/components/PlanningOffice.svelte
+++ b/website/src/components/PlanningOffice.svelte
@@ -18,6 +18,8 @@
     dorScore: number;
     isNextCandidate: boolean;
     pinned: boolean;
+    requirementsList: string[];
+    lastenheftLocked: boolean;
   }
 
   interface Stats {
@@ -75,6 +77,31 @@
 
   async function toggleDor(it: PlanItem, key: string) {
     await patch(it.extId, { readiness: { ...it.readiness, [key]: !(it.readiness?.[key]) } });
+  }
+
+  // Save the requirements list (Pflichtenheft) without locking.
+  async function saveRequirements(it: PlanItem, requirements: string[]) {
+    await patch(it.extId, { requirements });
+  }
+
+  // Toggle the Lastenheft lock. Locking needs >=1 requirement (server-enforced) and
+  // forwards the ticket into the autopilot lane → it leaves the Planungsbüro.
+  async function toggleLock(it: PlanItem) {
+    const r = await fetch(`/api/admin/planungsbuero/${it.extId}`, {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ lastenheftLocked: !it.lastenheftLocked }),
+    });
+    if (r.status === 422) {
+      alert('Lastenheft kann nicht verriegelt werden — mindestens eine Anforderung nötig.');
+      return;
+    }
+    if (!it.lastenheftLocked && r.ok) {
+      // Just locked → status forwarded to backlog; clear selection (item left the office).
+      selected = null;
+      sheetOpen = false;
+    }
+    await load();
   }
 
   async function promote(it: PlanItem) {
@@ -252,6 +279,8 @@
             promoteFn={promote}
             removeDepFn={removeDep}
             addDepFn={addDep}
+            saveRequirementsFn={saveRequirements}
+            lockFn={toggleLock}
           />
         </div>
       {/if}

--- a/website/src/components/PlanningOfficeDetail.svelte
+++ b/website/src/components/PlanningOfficeDetail.svelte
@@ -20,6 +20,8 @@
     dorScore: number;
     isNextCandidate: boolean;
     pinned: boolean;
+    requirementsList: string[];
+    lastenheftLocked: boolean;
   }
 
   let {
@@ -31,6 +33,8 @@
     promoteFn,
     removeDepFn,
     addDepFn,
+    saveRequirementsFn,
+    lockFn,
   }: {
     item: PlanItem;
     override: boolean;
@@ -40,7 +44,18 @@
     promoteFn: (item: PlanItem) => void;
     removeDepFn: (dep: string) => void;
     addDepFn: () => void;
+    saveRequirementsFn: (item: PlanItem, requirements: string[]) => void;
+    lockFn: (item: PlanItem) => void;
   } = $props();
+
+  // The requirements editor binds to a newline-joined draft; one line = one requirement.
+  // While locked the textarea is read-only ("Lastenheft"); unlock to edit ("Pflichtenheft").
+  function linesToList(text: string): string[] {
+    return text.split('\n').map((s) => s.trim()).filter((s) => s.length > 0);
+  }
+  function saveReqs(e: Event) {
+    saveRequirementsFn(item, linesToList((e.target as HTMLTextAreaElement).value));
+  }
 </script>
 
 <h2 class="pb-detail-title">{item.title}</h2>
@@ -51,6 +66,31 @@
     onblur={(e) => patchFn(item.extId, { valueProp: (e.target as HTMLTextAreaElement).value })}
   ></textarea>
 </label>
+
+<fieldset class="pb-fieldset">
+  <legend>
+    {item.lastenheftLocked ? 'Lastenheft' : 'Pflichtenheft'} — Anforderungen
+    {#if item.lastenheftLocked}<span class="pb-lock-badge" data-testid="pb-lastenheft-badge">🔒 verriegelt · KI-bereit</span>{/if}
+  </legend>
+  <textarea
+    class="pb-textarea pb-requirements"
+    data-testid="pb-requirements"
+    placeholder={'Eine Anforderung pro Zeile…\n- Login via SSO\n- Export als PDF'}
+    value={(item.requirementsList ?? []).join('\n')}
+    readonly={item.lastenheftLocked}
+    onblur={saveReqs}
+  ></textarea>
+  <button
+    class="pb-lock-btn"
+    class:locked={item.lastenheftLocked}
+    data-testid="pb-lastenheft-toggle"
+    onclick={() => lockFn(item)}
+  >
+    {item.lastenheftLocked
+      ? '🔓 Entriegeln (zurück zu Pflichtenheft)'
+      : '🔒 Verriegeln → Lastenheft (an Factory übergeben)'}
+  </button>
+</fieldset>
 <fieldset class="pb-fieldset">
   <legend>Definition of Ready</legend>
   {#each DOR_KEYS as k}
@@ -127,6 +167,40 @@
     border-radius: 4px;
     padding: 8px 12px;
     margin: 12px 0;
+  }
+
+  .pb-requirements {
+    min-height: 90px;
+    margin-top: 4px;
+  }
+
+  .pb-requirements[readonly] {
+    opacity: 0.7;
+    cursor: not-allowed;
+  }
+
+  .pb-lock-badge {
+    font-size: 0.65rem;
+    color: var(--pb-amber);
+    margin-left: 6px;
+  }
+
+  .pb-lock-btn {
+    width: 100%;
+    margin-top: 8px;
+    padding: 6px 8px;
+    background: var(--pb-bg);
+    border: 1px solid var(--pb-amber);
+    color: var(--pb-amber);
+    border-radius: 4px;
+    cursor: pointer;
+    font-family: var(--pb-mono);
+    font-size: 0.75rem;
+  }
+
+  .pb-lock-btn.locked {
+    border-color: var(--pb-border);
+    color: var(--pb-text-muted);
   }
 
   .pb-fieldset legend {

--- a/website/src/lib/clarification-questions.test.ts
+++ b/website/src/lib/clarification-questions.test.ts
@@ -7,6 +7,7 @@ function item(partial: Partial<OfficeItem>): OfficeItem {
     extId: 'T000571', title: 'X', valueProp: null, priority: 'mittel',
     effort: null, areas: [], dependsOn: [], rank: null,
     readiness: {}, dorScore: 0, isNextCandidate: false, pinned: false,
+    requirementsList: [], lastenheftLocked: false,
     createdAt: '', updatedAt: '', ...partial,
   };
 }

--- a/website/src/lib/planning-office.ts
+++ b/website/src/lib/planning-office.ts
@@ -1,4 +1,5 @@
 import { pool } from './website-db';
+import { canLock, normalizeRequirements, isLastenheftLocked, LASTENHEFT_LOCK_KEY } from './tickets/lastenheft';
 
 export const DOR_KEYS = [
   'spec_skizziert', 'offene_fragen_geklaert', 'abhaengigkeiten_klar', 'aufwand_geschaetzt',
@@ -11,6 +12,8 @@ export interface OfficeItem {
   effort: string | null; areas: string[]; dependsOn: string[];
   rank: number | null; readiness: Readiness; dorScore: number;
   isNextCandidate: boolean; pinned: boolean; createdAt: string; updatedAt: string;
+  // Pflichtenheft → Lastenheft: the requirements list + derived lock state.
+  requirementsList: string[]; lastenheftLocked: boolean;
 }
 
 export function dorScore(r: Readiness | null): number {
@@ -27,13 +30,15 @@ function mapRow(row: any): OfficeItem {
     rank: row.planning_rank, readiness, dorScore: dorScore(readiness),
     isNextCandidate: (row.planning_rank ?? 99) === 0 && dorScore(readiness) === 4,
     pinned: row.pinned ?? false, createdAt: row.created_at, updatedAt: row.updated_at,
+    requirementsList: row.requirements_list ?? [],
+    lastenheftLocked: isLastenheftLocked(readiness),
   };
 }
 
 export async function listOffice(): Promise<OfficeItem[]> {
   const r = await pool.query(
     `SELECT external_id, title, value_prop, priority, effort, areas, depends_on,
-            planning_rank, readiness, pinned, created_at, updated_at
+            planning_rank, readiness, pinned, created_at, updated_at, requirements_list
        FROM tickets.tickets
       WHERE type = 'feature' AND status = 'planning'
       ORDER BY pinned DESC, COALESCE(planning_rank, 2147483647), created_at`,
@@ -62,8 +67,24 @@ export async function createIdea(inp: CreateInput): Promise<string> {
 export interface PatchInput {
   valueProp?: string; priority?: string; effort?: string;
   areas?: string[]; dependsOn?: string[]; rank?: number; readiness?: Readiness; pinned?: boolean;
+  // Pflichtenheft → Lastenheft. `requirements` overwrites the list; `lastenheftLocked`
+  // toggles the lock (locking needs >=1 requirement, else throws 'lastenheft_empty',
+  // and forward-transitions the status into the autopilot lane).
+  requirements?: string[]; lastenheftLocked?: boolean;
 }
 export async function patchItem(extId: string, p: PatchInput): Promise<boolean> {
+  // Lock precondition: a Lastenheft may only be locked with >=1 requirement.
+  if (p.lastenheftLocked === true) {
+    let effective = p.requirements;
+    if (effective === undefined) {
+      const cur = await pool.query(
+        `SELECT requirements_list FROM tickets.tickets WHERE external_id = $1 AND status = 'planning'`,
+        [extId]);
+      effective = cur.rows[0]?.requirements_list ?? [];
+    }
+    if (!canLock(effective)) throw new Error('lastenheft_empty');
+  }
+
   const sets: string[] = []; const vals: any[] = []; let i = 1;
   const add = (col: string, v: any) => { sets.push(`${col} = $${i++}`); vals.push(v); };
   if (p.valueProp !== undefined) add('value_prop', p.valueProp);
@@ -73,11 +94,21 @@ export async function patchItem(extId: string, p: PatchInput): Promise<boolean> 
   if (p.dependsOn !== undefined) add('depends_on', p.dependsOn);
   if (p.rank !== undefined) add('planning_rank', p.rank);
   if (p.pinned !== undefined) add('pinned', p.pinned);
-  if (p.readiness !== undefined) {
-    const clean: Readiness = {};
-    for (const k of DOR_KEYS) if (p.readiness[k] !== undefined) clean[k] = !!p.readiness[k];
-    add('readiness', JSON.stringify(clean));
+  if (p.requirements !== undefined) add('requirements_list', normalizeRequirements(p.requirements));
+  // Accumulate all readiness changes (DOR flags + lock flag) into ONE JSONB merge,
+  // so toggling a DOR checkbox never clobbers lastenheft_locked and vice-versa.
+  const readinessMerge: Record<string, boolean> = {};
+  if (p.readiness !== undefined)
+    for (const k of DOR_KEYS) if (p.readiness[k] !== undefined) readinessMerge[k] = !!p.readiness[k];
+  if (p.lastenheftLocked !== undefined) readinessMerge[LASTENHEFT_LOCK_KEY] = p.lastenheftLocked;
+  if (Object.keys(readinessMerge).length) {
+    sets.push(`readiness = COALESCE(readiness, '{}'::jsonb) || $${i++}::jsonb`);
+    vals.push(JSON.stringify(readinessMerge));
   }
+  // Locking releases the ticket into the autopilot lane; forward-only, never regresses.
+  if (p.lastenheftLocked === true)
+    sets.push(`status = CASE WHEN status IN ('triage','planning','plan_staged') THEN 'backlog' ELSE status END`);
+
   if (!sets.length) return false;
   vals.push(extId);
   const r = await pool.query(

--- a/website/src/lib/tickets-db.ts
+++ b/website/src/lib/tickets-db.ts
@@ -176,7 +176,7 @@ export async function initTicketsSchema(): Promise<void> {
       ADD COLUMN IF NOT EXISTS areas         TEXT[],
       ADD COLUMN IF NOT EXISTS depends_on    TEXT[],
       ADD COLUMN IF NOT EXISTS planning_rank INTEGER,
-      ADD COLUMN IF NOT EXISTS readiness         JSONB,
+      ADD COLUMN IF NOT EXISTS readiness         JSONB, ADD COLUMN IF NOT EXISTS requirements_list TEXT[],
       ADD COLUMN IF NOT EXISTS pinned            BOOLEAN NOT NULL DEFAULT false
   `);
   await pool.query(`ALTER TABLE tickets.tickets DROP CONSTRAINT IF EXISTS tickets_effort_check`);

--- a/website/src/lib/tickets/lastenheft.test.ts
+++ b/website/src/lib/tickets/lastenheft.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import {
+  canLock,
+  normalizeRequirements,
+  nextStatusOnLock,
+  requirementsLabel,
+  isLastenheftLocked,
+  LASTENHEFT_LOCK_KEY,
+} from './lastenheft';
+
+describe('lastenheft helpers', () => {
+  it('normalizeRequirements trims and drops empties', () => {
+    expect(normalizeRequirements([' a ', '', '  ', 'b', null, undefined])).toEqual(['a', 'b']);
+    expect(normalizeRequirements(null)).toEqual([]);
+    expect(normalizeRequirements(undefined)).toEqual([]);
+  });
+
+  it('canLock requires >=1 non-empty requirement', () => {
+    expect(canLock([])).toBe(false);
+    expect(canLock(['  ', ''])).toBe(false);
+    expect(canLock(null)).toBe(false);
+    expect(canLock(['needs auth'])).toBe(true);
+    expect(canLock([' ', 'real req'])).toBe(true);
+  });
+
+  it('nextStatusOnLock forward-only into backlog, never regresses', () => {
+    expect(nextStatusOnLock('triage')).toBe('backlog');
+    expect(nextStatusOnLock('planning')).toBe('backlog');
+    expect(nextStatusOnLock('plan_staged')).toBe('backlog');
+    // in-flight / terminal statuses are left untouched
+    expect(nextStatusOnLock('backlog')).toBe('backlog');
+    expect(nextStatusOnLock('in_progress')).toBe('in_progress');
+    expect(nextStatusOnLock('in_review')).toBe('in_review');
+    expect(nextStatusOnLock('done')).toBe('done');
+    expect(nextStatusOnLock('archived')).toBe('archived');
+  });
+
+  it('requirementsLabel flips on lock', () => {
+    expect(requirementsLabel(false)).toBe('Pflichtenheft');
+    expect(requirementsLabel(true)).toBe('Lastenheft');
+  });
+
+  it('isLastenheftLocked reads the readiness flag fail-closed', () => {
+    expect(isLastenheftLocked({ [LASTENHEFT_LOCK_KEY]: true })).toBe(true);
+    expect(isLastenheftLocked({ [LASTENHEFT_LOCK_KEY]: false })).toBe(false);
+    expect(isLastenheftLocked({ spec_skizziert: true })).toBe(false);
+    expect(isLastenheftLocked(null)).toBe(false);
+    expect(isLastenheftLocked(undefined)).toBe(false);
+  });
+});

--- a/website/src/lib/tickets/lastenheft.ts
+++ b/website/src/lib/tickets/lastenheft.ts
@@ -1,0 +1,44 @@
+// website/src/lib/tickets/lastenheft.ts
+//
+// Pure helpers for the Pflichtenheft → Lastenheft requirements-lock feature.
+// No imports → no import cycles (S2). The requirements live in the
+// tickets.requirements_list TEXT[] column; the lock state lives in the existing
+// `readiness` JSONB under `lastenheft_locked`. The "Pflichtenheft" (draft) vs
+// "Lastenheft" (locked, AI-ready) distinction is derived purely from that flag.
+
+export const LASTENHEFT_LOCK_KEY = 'lastenheft_locked';
+
+/** Statuses from which locking forward-transitions a ticket into the autopilot lane. */
+export const LOCK_FORWARD_FROM = ['triage', 'planning', 'plan_staged'] as const;
+
+/** Trim each line and drop empties — the canonical requirement list. */
+export function normalizeRequirements(
+  list: readonly (string | null | undefined)[] | null | undefined,
+): string[] {
+  if (!list) return [];
+  return list.map((s) => (s ?? '').trim()).filter((s) => s.length > 0);
+}
+
+/** A Lastenheft may only be locked with at least one non-empty requirement. */
+export function canLock(
+  list: readonly (string | null | undefined)[] | null | undefined,
+): boolean {
+  return normalizeRequirements(list).length >= 1;
+}
+
+/** Forward-only status transition on lock; never regresses an in-flight ticket. */
+export function nextStatusOnLock(current: string): string {
+  return (LOCK_FORWARD_FROM as readonly string[]).includes(current) ? 'backlog' : current;
+}
+
+/** Derived UI label for the requirements list. */
+export function requirementsLabel(locked: boolean): 'Lastenheft' | 'Pflichtenheft' {
+  return locked ? 'Lastenheft' : 'Pflichtenheft';
+}
+
+/** Read the lock flag out of a readiness JSONB object (fail-closed). */
+export function isLastenheftLocked(
+  readiness: Record<string, unknown> | null | undefined,
+): boolean {
+  return readiness?.[LASTENHEFT_LOCK_KEY] === true;
+}

--- a/website/src/pages/api/admin/planungsbuero/[extId].ts
+++ b/website/src/pages/api/admin/planungsbuero/[extId].ts
@@ -35,9 +35,13 @@ export const PATCH: APIRoute = async ({ request, params }) => {
       dependsOn: Array.isArray(b.dependsOn) ? b.dependsOn : undefined,
       rank: typeof b.rank === 'number' ? b.rank : undefined,
       readiness,
+      requirements: Array.isArray(b.requirements) ? b.requirements : undefined,
+      lastenheftLocked: typeof b.lastenheftLocked === 'boolean' ? b.lastenheftLocked : undefined,
     });
     return ok ? json({ ok: true }) : json({ error: 'not_found_or_noop' }, 404);
   } catch (e) {
+    if (e instanceof Error && e.message === 'lastenheft_empty')
+      return json({ error: 'lastenheft_empty' }, 422);
     console.error('[api/admin/planungsbuero PATCH]', e);
     return json({ error: 'patch_failed' }, 500);
   }


### PR DESCRIPTION
## Was & Warum

Tickets bekommen ein **Anforderungs-Listenfeld** (`requirements_list TEXT[]`), das im Entwurf **„Pflichtenheft"** heißt. Beim **Verriegeln** (≥1 Anforderung) wird es zum **„Lastenheft"** — dieser Wechsel ist das **KI-Reife-Signal**: ein verriegeltes Ticket wird an die Software-Factory freigegeben.

> Begriffs-Konvention (bewusst): Pflichtenheft = Entwurf → Lastenheft = verriegelt/KI-reif (kehrt die DIN-69901-Lehrbuchrichtung um, gewünschte Projektsprache).

## Verhalten (abgestimmt)
- **Harter Factory-Gate** (`queue.sh`): Autopilot zieht nur Tickets mit `readiness.lastenheft_locked=true` — fail-closed.
- **Lock = read-only**; Bearbeiten erfordert explizites Entriegeln (→ wieder „Pflichtenheft", Reife erlischt).
- **Vorbedingung**: Verriegeln nur mit ≥1 Anforderung (sonst HTTP 422).
- **Status-Kopplung**: Verriegeln transitioniert vorwärts → `backlog` (forward-only, nie zurück).

## Umsetzung
- DB: `requirements_list` idempotent in `initTicketsSchema()` (zeilenneutral, S1-baseline). Lock-Flag im bestehenden `readiness` JSONB.
- Pure Helper `lib/tickets/lastenheft.ts` (Entscheidungslogik, unit-getestet).
- Planungsbüro: `planning-office.ts` (`patchItem` + readiness **Merge** statt Replace → DOR-Toggle löscht das Lock-Flag nicht mehr), API durchgereicht, UI-Editor + Lock-Toggle.
- CLI: `ticket.sh lastenheft lock|unlock` + `plan-meta --requirements`.

## Tests / Verifikation
- `lastenheft.test.ts` (5) · `ticket-lastenheft.bats` (8, in `test:all` verdrahtet) · Coverage-Guard grün
- `task test:all` EXIT 0 · `pnpm vitest run` 1167 pass · `task freshness:check`/`quality:check` 0 blocking · `astro check` keine neuen Fehler in berührten Dateien

🤖 Generated with [Claude Code](https://claude.com/claude-code)