### PR TITLE
chore(ci): fix stale freshness gate — remove hardcoded route count + clearer failure message [T000936]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,12 +84,13 @@ jobs:
         run: |
           if ! task freshness:check; then
             echo ""
-            echo "❌ Freshness artifacts are stale."
-            echo "   Run locally:  task freshness:regenerate"
-            echo "   Then commit and push the regenerated files."
+            echo "❌ Freshness / quality gate failed — see above for the specific cause."
+            echo ""
+            echo "   Stale generated artifacts  →  task freshness:regenerate  (then commit + push)"
+            echo "   New code-quality violation →  task quality:check  (then fix or 'task quality:baseline:freeze')"
             exit 1
           fi
-          echo "✅ Freshness artifacts are up to date"
+          echo "✅ Freshness and quality gates passed"
 
       - name: Verify learning-assets build script (unit test)
         run: node --test scripts/build-learning-assets.test.mjs

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -939,9 +939,6 @@ tasks:
           if (!Array.isArray(m.routes)) {
             errs.push("routes must be an array");
           }
-          if (m.count !== 134) {
-            errs.push(`expected count===133, got ${m.count}`);
-          }
           for (const r of (m.routes || [])) {
             const isAdmin = r.route.startsWith("/admin");
             const isPortal = r.route.startsWith("/portal");


### PR DESCRIPTION
## Summary

- **Remove `m.count !== 134` assertion** from Phase 4 of `freshness:check` (Taskfile.yml): the Phase-1 `git diff --exit-code` already proves every generated manifest is fresh. Re-checking the route count against a hardcoded magic number is redundant — and breaks CI on every PR that adds a website route, even when `freshness:regenerate` was run correctly.
- **Clearer CI failure message**: previously any `freshness:check` failure (including `quality:check` violations like S3 hardcoded-hostname) printed `❌ Freshness artifacts are stale` and told devs to run `freshness:regenerate` — wrong advice when the actual cause is a new quality gate violation. The new message distinguishes both paths.

## Root cause (analysis)

PR #1811 (T000895) failed the freshness gate for two reasons:
1. `quality:check` caught a new S3 violation (`staging.korczewski.de` in the staging Keycloak realm — same pattern as baselined prod realms) → reported misleadingly as "stale artifacts"
2. The upstream quick-fix bumped the count from `133` to `134`, but this is still fragile

## Test plan
- [x] `task freshness:check` passes in worktree (`route-manifest OK: 134 page files, 141 sweep routes`)
- [x] `task workspace:validate` passes
- [x] No regression: auth-tier invariants and `generatedFrom` checks remain intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)