### PR TITLE
fix(admin): preserve catalog linkage in service-page save + reactivity triggers [T000788]

### DIFF
--- a/website/src/components/admin/InhalteEditor.svelte
+++ b/website/src/components/admin/InhalteEditor.svelte
@@ -197,11 +197,17 @@
         {:else if activeSection === 'coaching'}<SchemaEditor schema={schemaFor('service:coaching')!} initialValue={initialData.coaching?.value ?? null} initialVersion={initialData.coaching?.version ?? 0} />
         {:else if activeSection === 'fuehrung-persoenlichkeit'}<SchemaEditor schema={schemaFor('service:fuehrung-persoenlichkeit')!} initialValue={initialData.fuehrung?.value ?? null} initialVersion={initialData.fuehrung?.version ?? 0} />
         {:else if activeSection === '50plus-digital'}
-          <ServicePageSection initialData={initialData['50plus-digital']} slug="50plus-digital" pageLabel="50+ digital" />
+          <ServicePageSection initialData={initialData['50plus-digital']} slug="50plus-digital" pageLabel="50+ digital"
+            isCatalogLinked={initialData['50plus-digital']?.isCatalogLinked}
+            catalogTiers={initialData['50plus-digital']?.catalogTiers ?? []} />
         {:else if activeSection === 'ki-transition'}
-          <ServicePageSection initialData={initialData['ki-transition']} slug="ki-transition" pageLabel="KI-Transition Coaching" />
+          <ServicePageSection initialData={initialData['ki-transition']} slug="ki-transition" pageLabel="KI-Transition Coaching"
+            isCatalogLinked={initialData['ki-transition']?.isCatalogLinked}
+            catalogTiers={initialData['ki-transition']?.catalogTiers ?? []} />
         {:else if activeSection === 'beratung'}
-          <ServicePageSection initialData={initialData.beratung} slug="beratung" pageLabel="Unternehmensberatung" />
+          <ServicePageSection initialData={initialData.beratung} slug="beratung" pageLabel="Unternehmensberatung"
+            isCatalogLinked={initialData.beratung?.isCatalogLinked}
+            catalogTiers={initialData.beratung?.catalogTiers ?? []} />
         {:else if activeSection === 'angebote'}
           <AngeboteSection initialServices={initialData.services} initialLeistungen={initialData.leistungen} initialPriceListUrl={initialData.priceListUrl} staticSlugs={staticServiceSlugs} />
         {:else if activeSection === 'faq'}<FaqSection initialData={initialData.faq} />

--- a/website/src/components/admin/inhalte/AngeboteSection.svelte
+++ b/website/src/components/admin/inhalte/AngeboteSection.svelte
@@ -233,8 +233,8 @@
     {#each leistungen as cat}
       <div class="p-4 bg-dark rounded-lg border border-dark-lighter space-y-3">
         <div class="grid grid-cols-2 gap-4">
-          <div><label class={labelCls}>Kategorie-Titel</label><input type="text" bind:value={cat.title} class={inputCls} /></div>
-          <div><label class={labelCls}>Icon</label><input type="text" bind:value={cat.icon} class={inputCls} /></div>
+          <div><label class={labelCls}>Kategorie-Titel</label><input type="text" bind:value={cat.title} class={inputCls} onchange={() => { leistungen = [...leistungen]; }} /></div>
+          <div><label class={labelCls}>Icon</label><input type="text" bind:value={cat.icon} class={inputCls} onchange={() => { leistungen = [...leistungen]; }} /></div>
         </div>
         {#each (cat.services??[]) as svc, sIdx}
           <div class="p-3 bg-dark-lighter/30 rounded-lg space-y-2">
@@ -242,14 +242,14 @@
               <button type="button" onclick={() => moveLeistungService(cat,sIdx,-1)} disabled={sIdx===0} class={moveBtnCls}>↑</button>
               <button type="button" onclick={() => moveLeistungService(cat,sIdx,1)} disabled={sIdx===(cat.services?.length??0)-1} class={moveBtnCls}>↓</button>
               <p class="text-xs font-mono text-muted">{svc.key}</p>
-              <label class="ml-auto flex items-center gap-2 cursor-pointer text-xs text-muted"><input type="checkbox" bind:checked={svc.highlight} class="accent-gold" /><span>Hervorheben</span></label>
+              <label class="ml-auto flex items-center gap-2 cursor-pointer text-xs text-muted"><input type="checkbox" bind:checked={svc.highlight} class="accent-gold" onchange={() => { leistungen = [...leistungen]; }} /><span>Hervorheben</span></label>
             </div>
             <div class="grid grid-cols-3 gap-3">
-              <div><label class={labelCls}>Name</label><input type="text" bind:value={svc.name} class={inputCls} /></div>
-              <div><label class={labelCls}>Preis</label><input type="text" bind:value={svc.price} class={inputCls} /></div>
-              <div><label class={labelCls}>Einheit</label><input type="text" bind:value={svc.unit} class={inputCls} /></div>
+              <div><label class={labelCls}>Name</label><input type="text" bind:value={svc.name} class={inputCls} onchange={() => { leistungen = [...leistungen]; }} /></div>
+              <div><label class={labelCls}>Preis</label><input type="text" bind:value={svc.price} class={inputCls} onchange={() => { leistungen = [...leistungen]; }} /></div>
+              <div><label class={labelCls}>Einheit</label><input type="text" bind:value={svc.unit} class={inputCls} onchange={() => { leistungen = [...leistungen]; }} /></div>
             </div>
-            <div><label class={labelCls}>Beschreibung</label><textarea bind:value={svc.desc} rows={2} class="{inputCls} resize-none"></textarea></div>
+            <div><label class={labelCls}>Beschreibung</label><textarea bind:value={svc.desc} rows={2} class="{inputCls} resize-none" onchange={() => { leistungen = [...leistungen]; }}></textarea></div>
           </div>
         {/each}
       </div>

--- a/website/src/components/admin/inhalte/ServicePageSection.svelte
+++ b/website/src/components/admin/inhalte/ServicePageSection.svelte
@@ -42,10 +42,12 @@
     seoDescription?: string;
   }
 
-  let { initialData, slug, pageLabel }: {
+  let { initialData, slug, pageLabel, isCatalogLinked = false, catalogTiers = [] }: {
     initialData: ServicePageData;
     slug: string;
     pageLabel: string;
+    isCatalogLinked?: boolean;
+    catalogTiers?: Array<{ label: string; price: string; unit: string; highlight: boolean }>;
   } = $props();
 
   let data = $state(JSON.parse(JSON.stringify(initialData)));
@@ -138,7 +140,12 @@
     </div>
     <div>
       <label class={labelCls}>Preis (auf der Karte)</label>
-      <input type="text" bind:value={data.cardPrice} class={inputCls} placeholder="z.B. Ab 60 € / Stunde" />
+      {#if isCatalogLinked}
+        <div class="px-3 py-2 bg-dark-lighter/50 border border-gold/20 rounded-lg text-gold text-sm font-semibold">{data.cardPrice || '—'}</div>
+        <p class="text-xs text-muted mt-1">Abgeleiteter Preis aus dem Katalog. Zum Ändern → <a href="/admin/inhalte?tab=website&section=angebote" class="text-gold hover:underline">Angebote-Tab</a>.</p>
+      {:else}
+        <input type="text" bind:value={data.cardPrice} class={inputCls} placeholder="z.B. Ab 60 € / Stunde" />
+      {/if}
     </div>
     <div>
       <div class="flex justify-between items-center mb-2">
@@ -218,24 +225,37 @@
   <div class={sectionCls}>
     <div class="flex justify-between items-center">
       <h3 class="text-xl font-bold text-light font-serif">Investition</h3>
-      <button onclick={addPricing} class={addBtnCls}>+ Preis</button>
+      {#if !isCatalogLinked}
+        <button onclick={addPricing} class={addBtnCls}>+ Preis</button>
+      {/if}
     </div>
-    {#each data.pricing as p, i}
-      <div class="p-4 bg-dark rounded-lg border border-dark-lighter space-y-2">
-        <div class="grid grid-cols-3 gap-3">
-          <div><label class={labelCls}>Bezeichnung</label><input type="text" bind:value={p.label} class={inputCls} /></div>
-          <div><label class={labelCls}>Preis</label><input type="text" bind:value={p.price} class={inputCls} /></div>
-          <div><label class={labelCls}>Einheit / Hinweis</label><input type="text" bind:value={p.unit} class={inputCls} /></div>
+    {#if isCatalogLinked}
+      <p class="text-xs text-muted mb-3">Preis-Tiers werden aus dem Katalog abgeleitet. Zum Ändern → <a href="/admin/inhalte?tab=website&section=angebote" class="text-gold hover:underline">Angebote-Tab → Leistungskatalog</a>.</p>
+      {#each catalogTiers as tier}
+        <div class="flex items-center gap-3 px-3 py-1.5 bg-dark-lighter/20 rounded text-xs text-muted mb-1">
+          <span class={tier.highlight ? 'text-gold font-semibold' : ''}>{tier.label}</span>
+          <span class="ml-auto font-mono">{tier.price}{tier.unit ? ' ' + tier.unit : ''}</span>
+          {#if tier.highlight}<span class="text-gold text-[10px] border border-gold/30 rounded px-1">Headline</span>{/if}
         </div>
-        <div class="flex items-center justify-between">
-          <label class="flex items-center gap-2 text-xs text-muted cursor-pointer">
-            <input type="checkbox" bind:checked={p.highlight} class="accent-gold" />
-            Hervorheben (Goldrand)
-          </label>
-          <button onclick={() => removePricing(i)} class={removeBtnCls}>Entfernen</button>
+      {/each}
+    {:else}
+      {#each data.pricing as p, i}
+        <div class="p-4 bg-dark rounded-lg border border-dark-lighter space-y-2">
+          <div class="grid grid-cols-3 gap-3">
+            <div><label class={labelCls}>Bezeichnung</label><input type="text" bind:value={p.label} class={inputCls} /></div>
+            <div><label class={labelCls}>Preis</label><input type="text" bind:value={p.price} class={inputCls} /></div>
+            <div><label class={labelCls}>Einheit / Hinweis</label><input type="text" bind:value={p.unit} class={inputCls} /></div>
+          </div>
+          <div class="flex items-center justify-between">
+            <label class="flex items-center gap-2 text-xs text-muted cursor-pointer">
+              <input type="checkbox" bind:checked={p.highlight} class="accent-gold" />
+              Hervorheben (Goldrand)
+            </label>
+            <button onclick={() => removePricing(i)} class={removeBtnCls}>Entfernen</button>
+          </div>
         </div>
-      </div>
-    {/each}
+      {/each}
+    {/if}
   </div>
 
   <!-- CTA -->

--- a/website/src/config/brands/mentolder.ts
+++ b/website/src/config/brands/mentolder.ts
@@ -363,7 +363,7 @@ export const mentolderConfig: BrandConfig = {
   faq: [
     { question: 'Für wen ist 50+ digital geeignet?', answer: 'Für alle Menschen 50+, die digital selbständiger werden möchten. Keine Vorkenntnisse nötig – wir fangen genau da an, wo Sie stehen.' },
     { question: 'Wie läuft ein Coaching ab?', answer: 'Wir starten mit einem kostenlosen Erstgespräch (30-45 Min.), um Ihre Situation zu verstehen. Danach arbeiten wir in individuellen Sessions an Ihren Zielen – online oder vor Ort.' },
-    { question: 'Arbeiten Sie auch online?', answer: 'Ja! Coaching und Beratung funktionieren hervorragend online per Video. 50+ digital biete ich bevorzugt vor Ort in {city} und Umgebung an.' },
+    { question: 'Arbeiten Sie auch online?', answer: 'Ja! Coaching und Beratung funktionieren hervorragend online per Video. 50+ digital biete ich bevorzugt vor Ort in {city} an.' },
     { question: 'Was kostet ein Erstgespräch?', answer: 'Nichts. Das Erstgespräch ist kostenlos und unverbindlich. Wir lernen uns kennen und klären, ob eine Zusammenarbeit passt.' },
     { question: 'Was unterscheidet Sie von anderen Coaches?', answer: 'Ich komme aus 30+ Jahren Führungspraxis bei der Polizei Hamburg. Ich kenne beide Seiten des Tisches, bin direkt und ehrlich – und verstehe die Herausforderungen der Generation 50+ aus eigener Erfahrung.' },
   ],

--- a/website/src/pages/admin/inhalte.astro
+++ b/website/src/pages/admin/inhalte.astro
@@ -36,6 +36,12 @@ function serviceToEditorData(svc: any) {
     ctaHref: '/termin',
     seoTitle: (pc as any).seoTitle ?? '',
     seoDescription: (pc as any).seoDescription ?? svc?.description ?? '',
+    isCatalogLinked: !!svc?.leistungCategoryId,
+    catalogTiers: (svc?.leistungCategoryId
+      ? leistungen.find((c: any) => c.id === svc.leistungCategoryId)?.services?.map((r: any) => ({
+          label: r.name ?? '', price: r.price ?? '', unit: r.unit ?? '', highlight: r.highlight ?? false,
+        })) ?? []
+      : []),
   };
 }
 

--- a/website/src/pages/api/admin/service-page/save.ts
+++ b/website/src/pages/api/admin/service-page/save.ts
@@ -35,22 +35,32 @@ export const POST: APIRoute = async ({ request, url }) => {
       ...(body.sections ?? []),
     ];
 
+    const prev = idx >= 0 ? existing[idx] : null;
+    const isCatalogLinked = !!(prev?.leistungCategoryId);
+
     const override: ServiceOverride = {
       slug,
       title: body.cardTitle ?? staticSvc?.title ?? slug,
       description: body.cardDescription ?? staticSvc?.description ?? '',
       icon: body.cardIcon ?? staticSvc?.icon ?? '✨',
-      price: body.cardPrice ?? staticSvc?.price ?? '',
       features: body.cardFeatures ?? staticSvc?.features ?? [],
-      hidden: existing[idx]?.hidden ?? false,
+      hidden: prev?.hidden ?? false,
+      // Preserve catalog linkage — strip legacy price/pricing when linked
+      ...(prev?.leistungCategoryId ? { leistungCategoryId: prev.leistungCategoryId } : {}),
+      ...(prev?.headlineKey ? { headlineKey: prev.headlineKey } : {}),
+      ...(prev?.headlinePrefix != null ? { headlinePrefix: prev.headlinePrefix } : {}),
+      ...(isCatalogLinked
+        ? {}
+        : { price: body.cardPrice ?? staticSvc?.price ?? '' }),
       pageContent: {
         headline: body.headline,
         intro: body.intro,
         forWhom: body.forWhom ?? [],
         sections,
-        pricing: body.pricing ?? [],
+        ...(isCatalogLinked
+          ? {}
+          : { pricing: body.pricing ?? [] }),
         faq: body.faq ?? [],
-        // SEO als Felder im pageContent gespeichert
         seoTitle: body.seoTitle || undefined,
         seoDescription: body.seoDescription || undefined,
       },


### PR DESCRIPTION
## Root causes & fixes

### 1. Prices changed from "nach Vereinbarung" to concrete values

**Cause**: `service-page/save.ts` did not preserve `leistungCategoryId`, `headlineKey`, and `headlinePrefix` from the existing DB record. Every save through `ServicePageSection` deleted the catalog linkage, causing the card to fall back to its own stored `price` field instead of the catalog-derived "nach Vereinbarung".

**Fix**: `service-page/save.ts` now preserves catalog linkage fields and strips `price`/`pricing` for catalog-linked cards (matching `angebote/save.ts`).

### 2. Edit fields not working

**Two sub-issues**:

a) Price and pricing fields in `ServicePageSection` were always editable even when catalog-linked — changes were saved but overridden on display. They are now **read-only** with a link to the Angebote tab when `isCatalogLinked=true`.

b) Leistungskatalog inputs in `AngeboteSection` were missing `onchange` reactivity triggers (`leistungen = [...leistungen]`) present elsewhere in the component. Added to all 7 fields.

### 3. Duplicate "Umgebung" in FAQ
- `mentolder.ts`: FAQ answer had `{city} und Umgebung` but `{city}` already resolves to "Lüneburg, Hamburg und Umgebung" — removed redundant suffix.