### PR TITLE
fix(ci): hardcode impressum values in build-website workflow

### DIFF
--- a/.github/workflows/build-website.yml
+++ b/.github/workflows/build-website.yml
@@ -48,13 +48,13 @@ jobs:
           PROD_DOMAIN: mentolder.de
           BRAND_NAME: Mentolder
           CONTACT_EMAIL: info@mentolder.de
-          CONTACT_PHONE: ${{ secrets.CONTACT_PHONE }}
+          CONTACT_PHONE: "+49 151 508 32 601"
           CONTACT_CITY: "L\u00fcneburg, Hamburg und Umgebung"
           CONTACT_NAME: Gerald Korczewski
-          LEGAL_STREET: ${{ secrets.LEGAL_STREET }}
-          LEGAL_ZIP: ${{ secrets.LEGAL_ZIP }}
+          LEGAL_STREET: "Ludwig-Erhard-Str. 18"
+          LEGAL_ZIP: "20459"
           LEGAL_JOBTITLE: Coach und digitaler Begleiter
-          LEGAL_UST_ID: ${{ secrets.LEGAL_UST_ID }}
+          LEGAL_UST_ID: "33/023/05100"
           LEGAL_WEBSITE: mentolder.de
         run: |
           IMAGE="ghcr.io/paddione/mentolder-website"
@@ -87,13 +87,13 @@ jobs:
           PROD_DOMAIN: mentolder.de
           BRAND_NAME: Mentolder
           CONTACT_EMAIL: info@mentolder.de
-          CONTACT_PHONE: ${{ secrets.CONTACT_PHONE }}
+          CONTACT_PHONE: "+49 151 508 32 601"
           CONTACT_CITY: "Lüneburg, Hamburg und Umgebung"
           CONTACT_NAME: Gerald Korczewski
-          LEGAL_STREET: ${{ secrets.LEGAL_STREET }}
-          LEGAL_ZIP: ${{ secrets.LEGAL_ZIP }}
+          LEGAL_STREET: "Ludwig-Erhard-Str. 18"
+          LEGAL_ZIP: "20459"
           LEGAL_JOBTITLE: Coach und digitaler Begleiter
-          LEGAL_UST_ID: ${{ secrets.LEGAL_UST_ID }}
+          LEGAL_UST_ID: "33/023/05100"
           LEGAL_WEBSITE: mentolder.de
           SMTP_USER: mentolder@mailbox.org
           SMTP_HOST: smtp.mailbox.org


### PR DESCRIPTION
The impressum page on web.mentolder.de was showing empty values for Telefon, Adresse (street/ZIP), and USt-IdNr. after redeployment.

**Root cause:** build-website.yml read these from GitHub Secrets (CONTACT_PHONE, LEGAL_STREET, LEGAL_ZIP, LEGAL_UST_ID) which were never set.

**Fix:** Hardcode the values in the workflow - they are legally required public data (Impressumspflicht), not secrets. Values match environments/fleet-mentolder.yaml.

**Immediate fix already applied:** Patched the website-config ConfigMap on fleet + restarted pod. Live site now correct.