### PR TITLE
fix(security): eliminate command injection via execSync [T000935]

### DIFF
--- a/scripts/app-install.sh
+++ b/scripts/app-install.sh
@@ -25,6 +25,11 @@ if [[ -z "$APP_NAME" ]]; then
   exit 1
 fi
 
+if [[ ! "$APP_NAME" =~ ^[a-z0-9-]+$ ]]; then
+  echo "❌ Error: APP_NAME must match pattern ^[a-z0-9-]+$ (got \"$APP_NAME\")"
+  exit 1
+fi
+
 APP_DIR="$ROOT_DIR/apps/$APP_NAME"
 MANIFEST_PATH="$APP_DIR/app.yaml"
 
@@ -43,8 +48,8 @@ echo "🔍 Validating manifest schema for $APP_NAME..."
 node "$SCRIPT_DIR/validate-manifest.mjs" "$MANIFEST_PATH"
 
 # 3. Read manifest properties
-TITLE=$(node -e "import YAML from 'yaml'; import fs from 'fs'; console.log(YAML.parse(fs.readFileSync('$MANIFEST_PATH', 'utf8')).title || '$APP_NAME')")
-KUSTOMIZE_PATH_RAW=$(node -e "import YAML from 'yaml'; import fs from 'fs'; console.log(YAML.parse(fs.readFileSync('$MANIFEST_PATH', 'utf8')).kustomize)")
+TITLE=$(node "$SCRIPT_DIR/read-manifest-field.mjs" "$MANIFEST_PATH" "title" "$APP_NAME")
+KUSTOMIZE_PATH_RAW=$(node "$SCRIPT_DIR/read-manifest-field.mjs" "$MANIFEST_PATH" "kustomize")
 KUSTOMIZE_PATH="$ROOT_DIR/$KUSTOMIZE_PATH_RAW"
 
 if [[ ! -d "$KUSTOMIZE_PATH" ]]; then

--- a/scripts/process-oidc.mjs
+++ b/scripts/process-oidc.mjs
@@ -2,7 +2,7 @@
 import fs from 'fs';
 import path from 'path';
 import YAML from 'yaml';
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 
 const [appName, envName, dryRunFlag] = process.argv.slice(2);
 if (!appName || !envName) {
@@ -39,12 +39,12 @@ try {
   } else {
     // 1. Register secret
     console.log(`[OIDC] Registering secret ${secretVarName}...`);
-    execSync(`node scripts/register-secret.mjs "${secretVarName}" "${envName}"`, { stdio: 'inherit' });
+    execFileSync('node', ['scripts/register-secret.mjs', secretVarName, envName], { stdio: 'inherit' });
 
     // 2. Register OIDC client in Keycloak JSON files
     console.log(`[OIDC] Registering OIDC client ${clientId}...`);
     const redirectUrisJson = JSON.stringify(redirectUris);
-    execSync(`node scripts/register-oidc-client.mjs "${clientId}" "${title}" '${redirectUrisJson}' "${secretVarName}"`, { stdio: 'inherit' });
+    execFileSync('node', ['scripts/register-oidc-client.mjs', clientId, title, redirectUrisJson, secretVarName], { stdio: 'inherit' });
   }
 
   process.exit(0);

--- a/scripts/process-secrets.mjs
+++ b/scripts/process-secrets.mjs
@@ -2,7 +2,7 @@
 import fs from 'fs';
 import path from 'path';
 import YAML from 'yaml';
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 
 const [appName, envName, dryRunFlag] = process.argv.slice(2);
 if (!appName || !envName) {
@@ -32,7 +32,7 @@ try {
       console.log(`[SECRETS] Would register secret "${secret}" in schema and environments/.secrets/${envName}.yaml`);
     } else {
       console.log(`[SECRETS] Registering secret ${secret}...`);
-      execSync(`node scripts/register-secret.mjs "${secret}" "${envName}"`, { stdio: 'inherit' });
+      execFileSync('node', ['scripts/register-secret.mjs', secret, envName], { stdio: 'inherit' });
     }
   }
 

--- a/scripts/read-manifest-field.mjs
+++ b/scripts/read-manifest-field.mjs
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+import fs from 'fs';
+import path from 'path';
+import YAML from 'yaml';
+
+const [manifestPath, field, fallback] = process.argv.slice(2);
+if (!manifestPath || !field) {
+  console.error('Usage: node read-manifest-field.mjs <path-to-app.yaml> <field> [fallback]');
+  process.exit(1);
+}
+
+try {
+  const resolvedPath = path.resolve(manifestPath);
+  const manifest = YAML.parse(fs.readFileSync(resolvedPath, 'utf8'));
+  const value = manifest[field];
+  if (value !== undefined && value !== null) {
+    console.log(String(value));
+  } else if (fallback !== undefined) {
+    console.log(fallback);
+  }
+  process.exit(0);
+} catch (err) {
+  console.error(`Error reading manifest field: ${err.message}`);
+  process.exit(1);
+}

--- a/scripts/validate-manifest.mjs
+++ b/scripts/validate-manifest.mjs
@@ -33,6 +33,11 @@ try {
     throw new Error(`Field "name" must match pattern ^[a-z0-9-]+$ (got "${doc.name}")`);
   }
 
+  // Title must not contain shell metacharacters
+  if (doc.title && /[$`"'|&;()<>{}[\]\\!#~*? \t\n]/.test(doc.title)) {
+    throw new Error(`Field "title" contains forbidden shell metacharacters (got "${doc.title}")`);
+  }
+
   // Optional domains validation
   if (doc.domains !== undefined) {
     if (!Array.isArray(doc.domains)) {
@@ -59,12 +64,21 @@ try {
     if (!doc.oidc.client_id || typeof doc.oidc.client_id !== 'string') {
       throw new Error('oidc.client_id must be a string');
     }
+    if (/[$`"'|&;()<>{}[\]\\!#~*?\t\n]/.test(doc.oidc.client_id)) {
+      throw new Error(`oidc.client_id contains forbidden shell metacharacters (got "${doc.oidc.client_id}")`);
+    }
     if (!Array.isArray(doc.oidc.redirect_uris)) {
       throw new Error('oidc.redirect_uris must be an array');
     }
     for (const [idx, uri] of doc.oidc.redirect_uris.entries()) {
       if (typeof uri !== 'string') {
         throw new Error(`oidc.redirect_uris[${idx}] must be a string`);
+      }
+      const sanitized = uri.replace(/\$\{[^}]+\}/g, 'placeholder.example.com');
+      try {
+        new URL(sanitized);
+      } catch {
+        throw new Error(`oidc.redirect_uris[${idx}] is not a valid URL (got "${uri}")`);
       }
     }
   }
@@ -77,6 +91,9 @@ try {
     for (const [idx, secret] of doc.secrets.entries()) {
       if (typeof secret !== 'string') {
         throw new Error(`secrets[${idx}] must be a string`);
+      }
+      if (!/^[A-Z][A-Z0-9_]*$/.test(secret)) {
+        throw new Error(`secrets[${idx}] must match pattern ^[A-Z][A-Z0-9_]*$ (got "${secret}")`);
       }
     }
   }


### PR DESCRIPTION
## Summary

Eliminates 3 command injection vulnerabilities in the app catalog installer pipeline where manifest-controlled data was interpolated into shell strings via `execSync` / `node -e`.

## Changes

- **`scripts/process-oidc.mjs`**: `execSync(string)` → `execFileSync('node', [...argv])` for register-secret and register-oidc-client calls
- **`scripts/process-secrets.mjs`**: Same pattern for secret registration
- **`scripts/app-install.sh`**: Replaced `node -e` with new `scripts/read-manifest-field.mjs` helper; added `APP_NAME` validation against `^[a-z0-9-]+$`
- **`scripts/validate-manifest.mjs`**: Added shell metacharacter checks for `title` and `oidc.client_id`, URL format validation for `redirect_uris`, and secret name allowlist (`^[A-Z][A-Z0-9_]*$`)
- **`scripts/read-manifest-field.mjs`** (new): Helper to safely read YAML manifest fields via argv

Fixes: T000935
Source: security-guidance post-commit review on 8faaa1c9