### PR TITLE
fix(ci): remove [ci skip] from auto-regenerate freshness commit [T000872]

### DIFF
--- a/.github/workflows/freshness-regen.yml
+++ b/.github/workflows/freshness-regen.yml
@@ -58,5 +58,5 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add -A
-          git commit -m "chore: auto-regenerate freshness artifacts [ci skip]"
+          git commit -m "chore: auto-regenerate freshness artifacts"
           git push


### PR DESCRIPTION
## Summary

Removes `[ci skip]` from the auto-regenerate freshness commit message. Developers copying this pattern on PR branches inadvertently block CI from re-running after fixing stale artifacts.

Fixes: T000872