### PR TITLE
feat(website): add static referenzen fallback for mentolder

### DIFF
--- a/website/src/config/brands/korczewski.ts
+++ b/website/src/config/brands/korczewski.ts
@@ -359,6 +359,10 @@ export const korczewskiConfig: BrandConfig = {
     href: '/kontakt',
     text: 'Anfragen',
   },
+  referenzen: {
+    types: [],
+    items: [],
+  },
   features: {
     hasBooking: true,
     hasRegistration: true,

--- a/website/src/config/brands/mentolder.ts
+++ b/website/src/config/brands/mentolder.ts
@@ -372,6 +372,36 @@ export const mentolderConfig: BrandConfig = {
     href: '/termin',
     text: 'Termin buchen',
   },
+  referenzen: {
+    heading: 'Referenzen',
+    subheading: 'Unternehmen und Personen, die mir ihr Vertrauen geschenkt haben.',
+    types: [
+      { id: 'ausbildung', label: 'Ausbildung & Qualifikation' },
+      { id: 'projekte', label: 'Projekte' },
+      { id: 'laufbahn', label: 'Berufliche Stationen' },
+    ],
+    items: [
+      {
+        id: 'brueckenschlag',
+        name: 'Brückenschlag e.V., Lüneburg',
+        url: 'https://www.bs-lg.de',
+        description: 'Systemische Coach-Ausbildung',
+        type: 'ausbildung',
+      },
+      {
+        id: 'digital-cafe',
+        name: 'Digital Café',
+        description: '6-monatiges Projekt in einem Lüneburger Seniorenheim (2023) mit über 50 Teilnehmer/innen – verantwortlich mitgestaltet',
+        type: 'projekte',
+      },
+      {
+        id: 'polizei-hamburg',
+        name: 'Polizei Hamburg',
+        description: 'KI-gestützte Gesichtserkennung + BOS-Digitalfunk – Referenz aus der beruflichen Laufbahn mit ~30 Jahren Führungserfahrung',
+        type: 'laufbahn',
+      },
+    ],
+  },
   features: {
     hasBooking: true,
     hasRegistration: true,

--- a/website/src/config/types.ts
+++ b/website/src/config/types.ts
@@ -1,3 +1,24 @@
+export interface ReferenzItem {
+  id: string;
+  name: string;
+  url?: string;
+  logoUrl?: string;
+  description?: string;
+  type?: string;
+}
+
+export interface ReferenzenType {
+  id: string;
+  label: string;
+}
+
+export interface ReferenzenConfig {
+  heading?: string;
+  subheading?: string;
+  types: ReferenzenType[];
+  items: ReferenzItem[];
+}
+
 export interface ServicePageSection {
   title: string;
   items: string[];
@@ -158,6 +179,7 @@ export interface BrandConfig {
     hasOIDC: boolean;
     hasBilling: boolean;
   };
+  referenzen?: ReferenzenConfig;
   i18n?: {
     tagline?: { de: string; en: string };
     siteDescription?: { de: string; en: string };

--- a/website/src/lib/content.ts
+++ b/website/src/lib/content.ts
@@ -33,7 +33,9 @@ export async function getPriceListUrl(): Promise<string | null> {
 }
 
 export async function getEffectiveReferenzen(): Promise<ReferenzenConfig> {
-  return (await getReferenzen(BRAND).catch(() => null)) ?? { types: [], items: [] };
+  const db = await getReferenzen(BRAND).catch(() => null);
+  if (db) return db;
+  return config.referenzen ?? { types: [], items: [] };
 }
 
 /**

--- a/website/src/lib/website-db.ts
+++ b/website/src/lib/website-db.ts
@@ -1,3 +1,5 @@
+import type { ReferenzItem, ReferenzenType, ReferenzenConfig } from '../config/types';
+
 // Meeting Knowledge Pipeline — PostgreSQL client.
 // Writes meeting data, transcripts, and artifacts to the meetings DB.
 // Uses the 'pg' npm package for direct database access.
@@ -1155,29 +1157,9 @@ export async function saveLegalPage(brand: string, pageKey: string, contentHtml:
 }
 
 // ── Referenzen Config ─────────────────────────────────────────────────────────
+// Types re-exported from config/types.ts for backward compatibility.
 
-export interface ReferenzItem {
-  id: string;
-  name: string;
-  url?: string;
-  logoUrl?: string;
-  description?: string;
-  /** Optional type/group ID — must match one of `ReferenzenConfig.types[].id` */
-  type?: string;
-}
-
-export interface ReferenzenType {
-  id: string;
-  label: string;
-}
-
-export interface ReferenzenConfig {
-  heading?: string;
-  subheading?: string;
-  /** Ordered list — display order of groups follows this array. */
-  types: ReferenzenType[];
-  items: ReferenzItem[];
-}
+export type { ReferenzItem, ReferenzenType, ReferenzenConfig } from '../config/types';
 
 export async function initReferenzenTable(): Promise<void> {
   return ensureSchemaOnce('referenzen_config', async () => {


### PR DESCRIPTION
## Summary
- Adds 3 referenzen to the mentolder  page as static fallback
- Data: Brückenschlag e.V., Digital Café, Polizei Hamburg
- Previously the page showed "Referenzen werden demnächst ergänzt" because:
  1. No static fallback existed (unlike homepage, uebermich, etc.)
  2. DB connection from website pod has auth issues
- Now falls back to static config when DB is unavailable

## Changes
- `website/src/config/types.ts`: Add ReferenzItem, ReferenzenType, ReferenzenConfig types + referenzen field to BrandConfig
- `website/src/config/brands/mentolder.ts`: Add 3 referenzen with type grouping
- `website/src/config/brands/korczewski.ts`: Add empty referenzen config
- `website/src/lib/content.ts`: Update getEffectiveReferenzen() to use static config as fallback
- `website/src/lib/website-db.ts`: Re-export types from types.ts (DRY)