### PR TITLE
fix(ci): revert CONTACT_CITY to Hamburg for mentolder impressum

### DIFF
--- a/.github/workflows/build-website.yml
+++ b/.github/workflows/build-website.yml
@@ -49,7 +49,7 @@ jobs:
           BRAND_NAME: Mentolder
           CONTACT_EMAIL: info@mentolder.de
           CONTACT_PHONE: "+49 151 508 32 601"
-          CONTACT_CITY: "Lüneburg, Hamburg und Umgebung"
+          CONTACT_CITY: "Hamburg"
           CONTACT_NAME: Gerald Korczewski
           LEGAL_STREET: "Ludwig-Erhard-Str. 18"
           LEGAL_ZIP: "20459"
@@ -88,7 +88,7 @@ jobs:
           BRAND_NAME: Mentolder
           CONTACT_EMAIL: info@mentolder.de
           CONTACT_PHONE: "+49 151 508 32 601"
-          CONTACT_CITY: "Lüneburg, Hamburg und Umgebung"
+          CONTACT_CITY: "Hamburg"
           CONTACT_NAME: Gerald Korczewski
           LEGAL_STREET: "Ludwig-Erhard-Str. 18"
           LEGAL_ZIP: "20459"


### PR DESCRIPTION
## Summary

- Korrigiert `CONTACT_CITY` zurück auf `"Hamburg"` (vorheriger Commit hatte fälschlicherweise `"Lüneburg, Hamburg und Umgebung"` gesetzt)
- Der einzige echte Fix war `LEGAL_ZIP: 20457 → 20459`

Folge-Fix zu #1852 (bereits gemergt).

## Test plan

- [ ] Impressum zeigt `Ludwig-Erhard-Str. 18, 20459 Hamburg`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M2z8YZqUD1VoFaJ3yHAKYG