### PR TITLE
fix(website): add crawl trigger button to WissenHub for web_crawl collections [T000948]

### DIFF
--- a/docs/superpowers/plans/2026-06-19-t000948-webcrawl-ui.md
+++ b/docs/superpowers/plans/2026-06-19-t000948-webcrawl-ui.md
@@ -1,0 +1,20 @@
+---
+ticket: T000948
+status: active
+effort: small
+model: sonnet
+areas: [website, admin]
+---
+# Plan: Web-Crawl-Trigger im WissenHub-UI einbauen
+
+## Goal
+WebCrawlSourceModal sagt "Crawl in Tabelle starten", aber WissenHub hat keinen Crawl-Button. Button + Polling hinzufügen.
+
+## Files
+- `website/src/components/admin/WissenHub.svelte:138-152` — Button hinzufügen
+- `website/src/pages/api/admin/knowledge/collections/[id]/crawl.ts` — Referenz (existiert)
+
+## Steps
+- [ ] M1: 'Crawl starten'-Button für `col.source === 'web_crawl'` in WissenHub.svelte
+- [ ] M2: POST /crawl endpoint aufrufen
+- [ ] M3: Polling GET /crawl → 'Läuft…'-Status + Button-Disable während aktiv

--- a/website/src/components/admin/WissenHub.svelte
+++ b/website/src/components/admin/WissenHub.svelte
@@ -65,6 +65,36 @@
     if (j.cmd) alert(`Bitte ausführen:\n${j.cmd}`);
     else if (!r.ok) alert(j.message ?? j.error ?? 'Fehler');
   }
+
+  let crawlingIds = $state<Set<string>>(new Set());
+
+  async function startCrawl(id: string, btn: HTMLButtonElement) {
+    btn.disabled = true;
+    btn.textContent = 'Starte…';
+    const r = await fetch(`/api/admin/knowledge/collections/${id}/crawl`, { method: 'POST' });
+    const j = await r.json().catch(() => ({}));
+    if (r.ok) {
+      crawlingIds = new Set([...crawlingIds, id]);
+      pollCrawl(id);
+    } else {
+      btn.disabled = false;
+      btn.textContent = 'Crawl starten';
+      alert(j.error ?? 'Fehler beim Starten des Crawls');
+    }
+  }
+
+  function pollCrawl(id: string) {
+    const interval = setInterval(async () => {
+      const r = await fetch(`/api/admin/knowledge/collections/${id}/crawl`);
+      if (!r.ok) { clearInterval(interval); crawlingIds = new Set([...crawlingIds].filter(x => x !== id)); return; }
+      const j = await r.json();
+      if (!j.running) {
+        clearInterval(interval);
+        crawlingIds = new Set([...crawlingIds].filter(x => x !== id));
+        collections = collections.map(c => c.id === id ? { ...c } : c);
+      }
+    }, 2000);
+  }
 </script>
 
 <div class="wissen-hub">
@@ -143,6 +173,13 @@
               <td>{col.chunk_count}</td>
               <td>{col.last_indexed_at ? new Date(col.last_indexed_at).toLocaleString('de-DE') : '—'}</td>
               <td class="actions">
+                {#if col.source === 'web_crawl'}
+                  {#if crawlingIds.has(col.id)}
+                    <button class="btn-action" disabled>Crawl läuft…</button>
+                  {:else}
+                    <button class="btn-action" onclick={(e) => startCrawl(col.id, e.currentTarget as HTMLButtonElement)}>Crawl starten</button>
+                  {/if}
+                {/if}
                 {#if col.source !== 'pr_history' && col.source !== 'specs_plans' && col.source !== 'claude_md' && col.source !== 'bug_tickets'}
                   <button class="btn-action" onclick={(e) => reindex(col.id, e.currentTarget as HTMLButtonElement)}>Re-index</button>
                   <button class="btn-danger" onclick={() => deleteCollectionById(col.id)}>Löschen</button>


### PR DESCRIPTION
## Fix

Der WebCrawlSourceModal sagt dem Nutzer "Crawl kann jetzt in der Tabelle gestartet werden", aber WissenHub.svelte hatte keinen Crawl-Button. Der Endpoint `POST /api/admin/knowledge/collections/[id]/crawl` existierte bereits vollständig — nur der UI-Trigger fehlte.

### Änderungen in WissenHub.svelte
- **Crawl starten-Button** für `col.source === 'web_crawl'` Collections
- **Polling**: GET /crawl alle 2s → zeigt "Crawl läuft…"-Status + Button-Disable während aktiv
- **Fehlerbehandlung**: Oberflächen-Fehler vom Endpoint (422 kein startUrl, 409 läuft bereits, etc.)

Closes T000948