### PR TITLE
fix(website): update LiveKit DNS pin IP from decommissioned node to fleet IP [T000944]

### DIFF
--- a/docs/superpowers/plans/2026-06-19-t000944-livekit-dns-pin.md
+++ b/docs/superpowers/plans/2026-06-19-t000944-livekit-dns-pin.md
@@ -1,0 +1,22 @@
+---
+ticket: T000944
+status: active
+effort: small
+model: opus
+areas: [infra, website]
+---
+# Plan: LiveKit DNS-Pin auf korrekte Fleet-IP umstellen
+
+## Goal
+LiveKit DNS-Pin für mentolder von stillgelegter standalone-Node-IP (46.225.125.59) auf aktuelle Fleet-IP (204.168.244.104) ändern.
+
+## Files
+- `k3d/website.yaml:385` — `LIVEKIT_PIN_IP_MENTOLDER:"46.225.125.59"` → `"204.168.244.104"`
+- `website/src/pages/api/admin/ops/dns/pin.ts:6` — Default-Fallback ändern
+- `website/src/components/admin/ops/DnsZertTab.svelte:91` — Hardcoded-Label durch konfigurierte IP ersetzen
+
+## Steps
+- [ ] M1: LIVEKIT_PIN_IP_MENTOLDER in k3d/website.yaml auf 204.168.244.104 setzen
+- [ ] M2: Default in pin.ts anpassen
+- [ ] M3: DnsZertTab.svelte Label dynamisieren (IP aus Config/API statt hardcoded)
+- [ ] M4: Optional: LIVEKIT_PIN_IP_MENTOLDER aus environments/mentolder.yaml treiben (wie LIVEKIT_PIN_IP)

--- a/k3d/website.yaml
+++ b/k3d/website.yaml
@@ -382,7 +382,7 @@ spec:
                   key: IPV64_API_KEY
                   optional: true
             - name: LIVEKIT_PIN_IP_MENTOLDER
-              value: "46.225.125.59"
+              value: "204.168.244.104"
             - name: LIVEKIT_PIN_IP_KORCZEWSKI
               value: "37.27.251.38"
             - name: ANTHROPIC_API_KEY

--- a/website/src/components/admin/ops/DnsZertTab.svelte
+++ b/website/src/components/admin/ops/DnsZertTab.svelte
@@ -12,6 +12,7 @@
   let pinLoading = false;
   let pinResults: string[] = [];
   let pinError: string | null = null;
+  let lastPinIp: string | null = null;
 
   const CLUSTER_LABELS: Record<string, string> = { mentolder: 'mentolder.de', korczewski: 'korczewski.de' };
 
@@ -26,7 +27,7 @@
   }
 
   async function pinDns() {
-    pinLoading = true; pinError = null; pinResults = [];
+    pinLoading = true; pinError = null; pinResults = []; lastPinIp = null;
     try {
       const res = await fetch('/api/admin/ops/dns/pin', {
         method: 'POST', headers: { 'Content-Type': 'application/json' },
@@ -35,6 +36,7 @@
       const j = await res.json();
       if (!res.ok) { pinError = j.error ?? 'Fehler'; return; }
       pinResults = j.results;
+      lastPinIp = j.pinIp ?? null;
     } catch { pinError = 'Netzwerkfehler'; }
     finally { pinLoading = false; }
   }
@@ -88,7 +90,8 @@
   <div>
     <h3 class="text-sm font-semibold text-gray-200 mb-3">📌 LiveKit DNS-Pinning</h3>
     <p class="text-xs text-gray-400 mb-4">
-      Setzt <code>livekit.*</code> und <code>stream.*</code> DNS-Einträge auf die Pin-Node-IP (mentolder: 46.225.125.59, korczewski: 37.27.251.38).
+      Setzt <code>livekit.*</code> und <code>stream.*</code> DNS-Einträge auf die Pin-Node-IP
+      (siehe Konfiguration <code>LIVEKIT_PIN_IP_MENTOLDER</code> / <code>LIVEKIT_PIN_IP_KORCZEWSKI</code>).
       Nötig nach Node-Wechsel oder IP-Änderung.
     </p>
     <div class="flex flex-wrap gap-3 items-end">
@@ -109,6 +112,7 @@
     {#if pinResults.length > 0}
       <div class="mt-3 bg-gray-900 border border-gray-700 rounded p-3 font-mono text-xs space-y-1">
         {#each pinResults as line}<div class="text-green-300">{line}</div>{/each}
+        {#if lastPinIp}<div class="text-gray-400 mt-1">Pin-IP: {lastPinIp}</div>{/if}
       </div>
     {/if}
   </div>

--- a/website/src/pages/api/admin/ops/dns/pin.ts
+++ b/website/src/pages/api/admin/ops/dns/pin.ts
@@ -3,7 +3,7 @@ import https from 'node:https';
 import { getSession, isAdmin } from '../../../../../lib/auth';
 
 const CONFIG: Record<string, { domain: string; pinIp: string }> = {
-  mentolder:  { domain: 'mentolder.de',  pinIp: process.env.LIVEKIT_PIN_IP_MENTOLDER  ?? '46.225.125.59' },
+  mentolder:  { domain: 'mentolder.de',  pinIp: process.env.LIVEKIT_PIN_IP_MENTOLDER  ?? '204.168.244.104' },
   korczewski: { domain: 'korczewski.de', pinIp: process.env.LIVEKIT_PIN_IP_KORCZEWSKI ?? '37.27.251.38' },
 };
 


### PR DESCRIPTION
## Fix

Der DNS-Pin für mentolder LiveKit zeigte auf die stillgelegte standalone-Node-IP 46.225.125.59. Ein Admin-Klick auf 'DNS jetzt pinnen' hätte livekit.mentolder.de und stream.mentolder.de auf einen toten Host umgeleitet → Streaming ausgefallen.

### Änderungen
- **k3d/website.yaml**: LIVEKIT_PIN_IP_MENTOLDER von 46.225.125.59 → 204.168.244.104 (pk-hetzner-4)
- **pin.ts**: Default-Fallback aktualisiert
- **DnsZertTab.svelte**: Hardcoded IPs aus dem Label entfernt, pinIp aus API-Response angezeigt

Closes T000944