### PR TITLE
fix(website): create member-scoped onboarding endpoints to fix silent 403 [T000945]

### DIFF
--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -534,7 +534,7 @@
       "id": "website",
       "name": "Astro + Svelte website",
       "owner_agent": "bachelorprojekt-website",
-      "file_count": 1482,
+      "file_count": 1484,
       "files": [
         "website/.build-trigger",
         "website/.design-sync/NOTES.md",
@@ -1926,6 +1926,8 @@
         "website/src/pages/api/portal/messages/[threadId].ts",
         "website/src/pages/api/portal/nachrichten.ts",
         "website/src/pages/api/portal/onboarding/mark-step.ts",
+        "website/src/pages/api/portal/onboarding/reset.ts",
+        "website/src/pages/api/portal/onboarding/update.ts",
         "website/src/pages/api/portal/profile/export.ts",
         "website/src/pages/api/portal/profile/update.ts",
         "website/src/pages/api/portal/projekte.ts",

--- a/docs/generated/api-map.json
+++ b/docs/generated/api-map.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-17T18:34:05.423Z",
+  "generatedAt": "2026-06-19T18:22:02.959Z",
   "endpoints": [
     {
       "path": "/api/admin/angebote/save",
@@ -3038,6 +3038,22 @@
       ],
       "auth": "session",
       "file": "website/src/pages/api/portal/onboarding/mark-step.ts"
+    },
+    {
+      "path": "/api/portal/onboarding/reset",
+      "methods": [
+        "POST"
+      ],
+      "auth": "session",
+      "file": "website/src/pages/api/portal/onboarding/reset.ts"
+    },
+    {
+      "path": "/api/portal/onboarding/update",
+      "methods": [
+        "POST"
+      ],
+      "auth": "session",
+      "file": "website/src/pages/api/portal/onboarding/update.ts"
     },
     {
       "path": "/api/portal/profile/export",

--- a/docs/generated/api-surface.md
+++ b/docs/generated/api-surface.md
@@ -1,6 +1,6 @@
 # API Surface Map
 
-> Generated at 2026-06-17T18:34:05.423Z
+> Generated at 2026-06-19T18:22:02.959Z
 
 | Path | Methods | Auth | File |
 |------|---------|------|------|
@@ -376,6 +376,8 @@
 | `/api/portal/messages/{threadId}` | GET, POST | 🔑 session | `website/src/pages/api/portal/messages/[threadId].ts` |
 | `/api/portal/nachrichten` | GET | 🔑 session | `website/src/pages/api/portal/nachrichten.ts` |
 | `/api/portal/onboarding/mark-step` | POST | 🔑 session | `website/src/pages/api/portal/onboarding/mark-step.ts` |
+| `/api/portal/onboarding/reset` | POST | 🔑 session | `website/src/pages/api/portal/onboarding/reset.ts` |
+| `/api/portal/onboarding/update` | POST | 🔑 session | `website/src/pages/api/portal/onboarding/update.ts` |
 | `/api/portal/profile/export` | GET | 🔑 session | `website/src/pages/api/portal/profile/export.ts` |
 | `/api/portal/profile/update` | POST | 🔑 session | `website/src/pages/api/portal/profile/update.ts` |
 | `/api/portal/projekte` | GET | 🔑 session | `website/src/pages/api/portal/projekte.ts` |

--- a/docs/superpowers/plans/2026-06-19-t000945-onboarding-403.md
+++ b/docs/superpowers/plans/2026-06-19-t000945-onboarding-403.md
@@ -1,0 +1,23 @@
+---
+ticket: T000945
+status: active
+effort: medium
+model: opus
+areas: [website, security]
+---
+# Plan: Member-Onboarding-Checkliste von Admin-Endpunkten entkoppeln
+
+## Goal
+Die Onboarding-Checkliste für Mitglieder posted derzeit an Admin-Only-Endpunkte (/api/admin/onboarding/*) und bekommt 403. Member-eigene Endpunkte erstellen.
+
+## Files
+- `website/src/pages/api/admin/onboarding/update.ts` — Referenz für neue Member-Endpoints
+- `website/src/pages/api/admin/onboarding/reset.ts` — Referenz
+- `website/src/components/portal/OnboardingTab.astro` — form actions ändern
+- `website/src/pages/portal.astro` — Aufrufer
+
+## Steps
+- [ ] M1: `/api/portal/onboarding/update.ts` erstellen — authorisiert per keycloakUserId, nicht isAdmin
+- [ ] M2: `/api/portal/onboarding/reset.ts` erstellen
+- [ ] M3: OnboardingTab.astro form actions auf /api/portal/onboarding/* umstellen
+- [ ] M4: IDOR-Guard: Server-seitig prüfen dass das Item dem anfragenden User gehört

--- a/k3d/docs-content-built/architecture/index.html
+++ b/k3d/docs-content-built/architecture/index.html
@@ -178,7 +178,7 @@
 <body>
   <div class="header">
     <h1>⬡ Architektur — Living Docs</h1>
-    <span class="meta">Generiert: 2026-06-17T18:34:05.468Z</span>
+    <span class="meta">Generiert: 2026-06-19T18:22:03.008Z</span>
   </div>
 
   <div class="stats">
@@ -191,7 +191,7 @@
       <span class="stat-label">Abhängigkeiten</span>
     </div>
     <div class="stat">
-      <span class="stat-value">400</span>
+      <span class="stat-value">402</span>
       <span class="stat-label">API Endpoints</span>
     </div>
   </div>
@@ -1959,7 +1959,7 @@ flowchart TB
     <div class="filter-bar">
       <span class="filter-label">Filter:</span>
       <input class="filter-input" type="text" id="api-filter" placeholder="/api/..." oninput="filterApi(this.value)">
-      <span class="filter-label" id="api-count">400 endpoints</span>
+      <span class="filter-label" id="api-count">402 endpoints</span>
     </div>
     <div style="max-height:70vh;overflow-y:auto;border:1px solid var(--ff-border);border-radius:4px;">
       <table>
@@ -3828,6 +3828,16 @@ flowchart TB
     </tr>
       <tr>
       <td><code>/api/portal/onboarding/mark-step</code></td>
+      <td><code style="background:#1a1a1a;color:#f59e0b;padding:1px 5px;border-radius:3px;font-size:11px">POST</code></td>
+      <td style="color:#6b7280">? session</td>
+    </tr>
+      <tr>
+      <td><code>/api/portal/onboarding/reset</code></td>
+      <td><code style="background:#1a1a1a;color:#f59e0b;padding:1px 5px;border-radius:3px;font-size:11px">POST</code></td>
+      <td style="color:#6b7280">? session</td>
+    </tr>
+      <tr>
+      <td><code>/api/portal/onboarding/update</code></td>
       <td><code style="background:#1a1a1a;color:#f59e0b;padding:1px 5px;border-radius:3px;font-size:11px">POST</code></td>
       <td style="color:#6b7280">? session</td>
     </tr>

--- a/website/src/components/portal/OnboardingTab.astro
+++ b/website/src/components/portal/OnboardingTab.astro
@@ -24,8 +24,7 @@ const pct       = items.length ? Math.round((doneCount / items.length) * 100) : 
       <h3 class="text-lg font-semibold text-light">Onboarding-Checkliste</h3>
       <p class="text-sm text-muted mt-0.5">{doneCount}/{items.length} Schritte abgeschlossen</p>
     </div>
-    <form method="post" action="/api/admin/onboarding/reset">
-      <input type="hidden" name="keycloakUserId" value={keycloakUserId} />
+    <form method="post" action="/api/portal/onboarding/reset">
       <input type="hidden" name="_back" value={back} />
       <button type="submit"
         class="px-3 py-1.5 text-xs bg-dark border border-dark-lighter text-muted rounded-lg hover:text-light hover:border-gold/40 transition-colors"
@@ -45,7 +44,7 @@ const pct       = items.length ? Math.round((doneCount / items.length) * 100) : 
     {items.map(item => (
       <li class="flex items-center gap-3 p-3 bg-dark rounded-xl border border-dark-lighter"
         data-testid="onboarding-item">
-        <form method="post" action="/api/admin/onboarding/update" class="contents">
+        <form method="post" action="/api/portal/onboarding/update" class="contents">
           <input type="hidden" name="id" value={item.id} />
           <input type="hidden" name="done" value={item.done ? 'false' : 'true'} />
           <input type="hidden" name="_back" value={back} />

--- a/website/src/pages/api/portal/onboarding/reset.ts
+++ b/website/src/pages/api/portal/onboarding/reset.ts
@@ -1,0 +1,16 @@
+import type { APIRoute } from 'astro';
+import { getSession } from '../../../../lib/auth';
+import { resetOnboardingChecklist } from '../../../../lib/website-db';
+
+export const POST: APIRoute = async ({ request }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session) return new Response(null, { status: 401 });
+
+  const form = await request.formData();
+  const back = form.get('_back') as string | null;
+
+  // Reset the checklist for the current user (not an arbitrary userId from the form)
+  await resetOnboardingChecklist(session.sub);
+
+  return new Response(null, { status: 302, headers: { Location: back || '/portal' } });
+};

--- a/website/src/pages/api/portal/onboarding/update.ts
+++ b/website/src/pages/api/portal/onboarding/update.ts
@@ -1,0 +1,25 @@
+import type { APIRoute } from 'astro';
+import { getSession } from '../../../../lib/auth';
+import { pool } from '../../../../lib/website-db';
+
+export const POST: APIRoute = async ({ request }) => {
+  const session = await getSession(request.headers.get('cookie'));
+  if (!session) return new Response(null, { status: 401 });
+
+  const form = await request.formData();
+  const id   = form.get('id') as string;
+  const done = form.get('done') === 'true';
+  const back = form.get('_back') as string | null;
+
+  if (!id) return new Response(null, { status: 400 });
+
+  // Verify ownership: only update if the item belongs to this user
+  const result = await pool.query(
+    'UPDATE onboarding_items SET done = $2 WHERE id = $1 AND keycloak_user_id = $3',
+    [id, done, session.sub]
+  );
+
+  if (result.rowCount === 0) return new Response(null, { status: 404 });
+
+  return new Response(null, { status: 302, headers: { Location: back || '/portal' } });
+};


### PR DESCRIPTION
## Fix

Die Onboarding-Checkliste für Mitglieder (OnboardingTab.astro) postete ihre Checkbox-Toggles an /api/admin/onboarding/update und /api/admin/onboarding/reset — beide Endpunkte erfordern isAdmin(). Jedes Mitglied bekam stilles 403, die Checkliste war für ihre Zielgruppe nicht funktional.

### Änderungen
- **Neu: /api/portal/onboarding/update** — Toggle mit Ownership-Check (UPDATE WHERE id = $1 AND keycloak_user_id = session.sub)
- **Neu: /api/portal/onboarding/reset** — Reset der eigenen Checkliste via session.sub
- **OnboardingTab.astro** — Form actions auf /api/portal/onboarding/* umgestellt, keycloakUserId-Feld entfernt
- Admin-Endpunkte bleiben für Admin-Client-View erhalten

Closes T000945