### PR TITLE
fix(website): repair kontakt page hydration — decouple PortalSidekick from server-only factory-floor dependency

### DIFF
--- a/website/src/components/assistant/PipelineSidekickView.svelte
+++ b/website/src/components/assistant/PipelineSidekickView.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { PIPELINE_LANES, STATUS_BUCKETS } from '../../lib/factory-floor';
+  import { PIPELINE_LANES, STATUS_BUCKETS } from '../../lib/tickets/pipeline-order';
   import type { FloorPayload, HallItem, StagedItem, LoadingDockItem, ShippedItem } from '../../lib/factory-floor';
   import PhaseStepper from '../factory/PhaseStepper.svelte';
 


### PR DESCRIPTION
## Fix

The  page's E2E smoke tests (FA-10 T5/T6) have been consistently timing out because  never completes — one of the 4 astro-island components on the page fails to hydrate.

### Root Cause

`PipelineSidekickView.svelte` imported `PIPELINE_LANES` and `STATUS_BUCKETS` from `factory-floor.ts`, which transitively pulls in:
- `pool` from `website-db.ts`
- `pg` (PostgreSQL client)
- Node.js `Buffer` API

When bundled for the browser, this causes:
```
[astro-island] Error hydrating /_astro/PortalSidekick.Bozy61ef.js
ReferenceError: Buffer is not defined
    at PhaseStepper.UAwsu92B.js
```

The PortalSidekick never finishes hydration → its `ssr` attribute is never removed → `waitForHydration` times out.

### Fix

Import `PIPELINE_LANES` and `STATUS_BUCKETS` directly from `tickets/pipeline-order.ts`, a pure module with zero server-side dependencies. The `type` imports from `factory-floor` are fine — they're erased at compile time.

### Verification

- All existing vitest tests pass (187/189 — 2 pre-existing timeouts in `shareFile.test.ts`)
- The same approach was used previously in commit `80a67498` to fix a similar hydration issue