### PR TITLE
fix(admin): drop v_cockpit_rollup before recreating to handle column reorders

### DIFF
--- a/website/src/lib/tickets/cockpit-schema.ts
+++ b/website/src/lib/tickets/cockpit-schema.ts
@@ -4,7 +4,7 @@
 // Computed on read (no cache in MVP). Brand filtering is applied by callers,
 // not the view, so the view stays a simple per-container aggregate keyed by id.
 export const COCKPIT_ROLLUP_VIEW_SQL = `
-    CREATE OR REPLACE VIEW tickets.v_cockpit_rollup AS
+    CREATE VIEW tickets.v_cockpit_rollup AS
     WITH RECURSIVE descendants AS (
       -- seed: every ticket is a descendant of itself (depth 0)
       SELECT id AS container_id, id AS node_id, type, status
@@ -61,5 +61,7 @@ export const COCKPIT_ROLLUP_VIEW_SQL = `
 `;
 
 export async function ensureCockpitViews(pool: import('pg').Pool): Promise<void> {
+  // DROP first so column additions/reorderings don't fail with CREATE OR REPLACE.
+  await pool.query(`DROP VIEW IF EXISTS tickets.v_cockpit_rollup`);
   await pool.query(COCKPIT_ROLLUP_VIEW_SQL);
 }


### PR DESCRIPTION
## Summary

- `CREATE OR REPLACE VIEW` fails silently when columns are added in non-trailing positions — PostgreSQL rejects the rename of an existing column name
- `awaiting_deploy_leaves` was inserted *before* `open_leaves` in the new rollup view, causing every `initTicketsSchema()` call to throw `cannot change name of view column "open_leaves" to "awaiting_deploy_leaves"`
- This broke `/admin/tickets/[id]` (Vollansicht) returning 404 on every request

## Fix

Changed `ensureCockpitViews` to `DROP VIEW IF EXISTS` before `CREATE VIEW`. Since `initTicketsSchema` is memoized via `schemaReady`, this only runs once per process start — no concurrency risk.

## Production hotfix (already applied)

```sql
DROP VIEW IF EXISTS tickets.v_cockpit_rollup;
CREATE VIEW tickets.v_cockpit_rollup AS ...; -- new column order
ALTER VIEW tickets.v_cockpit_rollup OWNER TO website;
```

The view was created as `postgres` (superuser) during the hotfix, requiring an `OWNER TO website` to restore app permissions.

## Test plan

- [ ] `/admin/tickets/<uuid>` loads the Vollansicht without 404 (verified in production)
- [ ] CI `task test:all` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)