### PR TITLE
fix(grilling): prevent skip-on-keypress in GrillingStepper

### DIFF
--- a/website/src/components/admin/GrillingStepper.svelte
+++ b/website/src/components/admin/GrillingStepper.svelte
@@ -27,8 +27,23 @@
   const progress = $derived(grillingProgress(questionnaireId, QUESTIONNAIRES, answers, meta));
 
   let mode = $state<'step' | 'all'>('step');
-  let idx = $state(0);
-  const current = $derived(ordered[Math.min(idx, Math.max(0, ordered.length - 1))]);
+
+  // Track current question by stable ID (not position) so mid-typing reordering of `ordered`
+  // never changes which question is shown. Only navigation (prev/next/dismiss) updates this.
+  let currentId = $state<string>('');
+
+  $effect(() => {
+    // (Re-)initialize when currentId is missing or no longer in the question set.
+    // `all` depends only on questionnaire structure (not answers), so this only triggers
+    // on questionnaire switch or first render — not on every keystroke.
+    const ids = new Set(all.map((q) => q.id));
+    if (!currentId || !ids.has(currentId)) {
+      currentId = ordered[0]?.id ?? '';
+    }
+  });
+
+  const current = $derived(all.find((q) => q.id === currentId) ?? null);
+  const currentIdx = $derived(ordered.findIndex((q) => q.id === currentId));
   const answerText = $derived(current ? (answers[questionnaireId]?.[current.id] ?? '') : '');
 
   let saveTimer: ReturnType<typeof setTimeout> | null = null;
@@ -52,23 +67,33 @@
 
   function dismiss() {
     if (!current) return;
+    const i = ordered.findIndex((q) => q.id === currentId);
+    // Capture next BEFORE meta update — Svelte 5 derived re-evaluates on read,
+    // so reading `ordered` after `meta = …` would yield the post-dismiss sort.
+    const next = ordered[i + 1] ?? ordered[Math.max(0, i - 1)];
     const entry = meta[questionnaireId] ?? { questions: [], dismissed: [] };
     if (!entry.dismissed.includes(current.id)) {
       meta = { ...meta, [questionnaireId]: { ...entry, dismissed: [...entry.dismissed, current.id] } };
     }
-    if (idx >= ordered.length - 1 && idx > 0) idx -= 1;
+    if (next && next.id !== current.id) currentId = next.id;
     void patch({ grillingMeta: meta });
   }
 
-  function prev() { if (idx > 0) idx -= 1; }
-  function next() { if (idx < ordered.length - 1) idx += 1; }
+  function prev() {
+    const i = ordered.findIndex((q) => q.id === currentId);
+    if (i > 0) currentId = ordered[i - 1].id;
+  }
+  function next() {
+    const i = ordered.findIndex((q) => q.id === currentId);
+    if (i < ordered.length - 1) currentId = ordered[i + 1].id;
+  }
 </script>
 
 <section class="bg-dark-light rounded-2xl border border-dark-lighter p-6 space-y-4">
   <header class="flex items-center justify-between">
     <h3 class="font-semibold">Grilling — Schritt für Schritt</h3>
     <span data-testid="grilling-progress" class="text-sm text-muted">
-      Frage {Math.min(idx + 1, ordered.length)}/{ordered.length} ·
+      Frage {Math.min(currentIdx + 1, ordered.length)}/{ordered.length} ·
       {progress.answered} beantwortet · {progress.dismissed} verworfen
     </span>
     <button type="button" data-testid="grilling-mode" onclick={() => (mode = mode === 'step' ? 'all' : 'step')}>
@@ -81,9 +106,9 @@
     <p class="font-medium">{current.prompt}</p>
     <textarea class="w-full rounded-lg bg-dark border border-dark-lighter p-3" rows="4" aria-label="Antwort" oninput={onInput}>{answerText}</textarea>
     <div class="flex gap-2">
-      <button type="button" onclick={prev} disabled={idx === 0}>Zurück</button>
+      <button type="button" onclick={prev} disabled={currentIdx <= 0}>Zurück</button>
       <button type="button" onclick={dismiss}>Verwerfen</button>
-      <button type="button" onclick={next} disabled={idx >= ordered.length - 1}>Weiter</button>
+      <button type="button" onclick={next} disabled={currentIdx >= ordered.length - 1}>Weiter</button>
     </div>
   {:else}
     <p class="text-muted">Keine Fragen.</p>

--- a/website/src/components/admin/GrillingStepper.test.ts
+++ b/website/src/components/admin/GrillingStepper.test.ts
@@ -59,6 +59,20 @@ describe('GrillingStepper', () => {
     expect(screen.getByText(QUESTIONNAIRES[QN].sections[0].questions[1].label)).toBeTruthy();
   });
 
+  it('typing an answer does NOT advance to the next question (regression: skip-on-keypress)', async () => {
+    setup(null, null);
+    const first = QUESTIONNAIRES[QN].sections[0].questions[0].label;
+    expect(screen.getByText(first)).toBeTruthy();
+    const ta = screen.getByLabelText('Antwort') as HTMLTextAreaElement;
+    // Simulate typing character by character — each input must keep the same question visible
+    for (const char of ['H', 'He', 'Hel', 'Hell', 'Hello']) {
+      await fireEvent.input(ta, { target: { value: char } });
+      expect(screen.getByText(first)).toBeTruthy();
+    }
+    // After typing, textarea still holds the typed value
+    expect(ta.value).toBe('Hello');
+  });
+
   it('mode toggle switches between step and all mode', async () => {
     setup(null, null);
     const btn = screen.getByTestId('grilling-mode');


### PR DESCRIPTION
## Problem

Beim Eintippen einer Antwort im GrillingStepper wurde bei **jedem Tastendruck** zur nächsten Frage gesprungen — die Textarea zeigte plötzlich eine andere (leere) Frage.

## Root Cause

`ordered` war ein `$derived`, das über `questionStatus()` von `answers` abhing. Beim ersten Tastenanschlag wechselte die aktuelle Frage von `'open'` → `'answered'` und rutschte ans Ende der Liste. `ordered[idx]` zeigte danach auf die **nächste** offene Frage.

Außerdem: `dismiss()` las `ordered[i + 1]` **nach** dem `meta = …`-Update, was in Svelte 5 (lazy derived re-evaluation) die bereits neu sortierte Liste lieferte → Off-by-one beim Navigation.

## Fix

- `idx` (Position) → `currentId` (stabiler String-State)
- `current = all.find(q => q.id === currentId)` — hängt **nicht** von `answers` ab
- `$effect` initialisiert `currentId` nur, wenn er fehlt oder die Frage nicht mehr existiert
- In `dismiss()`: `next` wird **vor** dem Meta-Update gecaptured

## Tests

- 6/6 bestehende Tests bleiben grün
- **Neuer Regressionstest** `typing an answer does NOT advance to the next question`: 5 sequentielle Input-Events müssen dieselbe Frage anzeigen

## Test plan

- [ ] Grilling-Stepper in einem Ticket öffnen
- [ ] Text tippen → Frage bleibt dieselbe
- [ ] Weiter/Zurück funktioniert
- [ ] Verwerfen navigiert zur richtigen Folgefrage

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M2z8YZqUD1VoFaJ3yHAKYG