### PR TITLE
fix(infra): allow mediaviewer iframe embedding (X-Frame-Options + SameSite cookie)

### DIFF
--- a/prod/ingress.yaml
+++ b/prod/ingress.yaml
@@ -249,7 +249,7 @@ kind: Ingress
 metadata:
   name: workspace-ingress-mediaviewer
   annotations:
-    traefik.ingress.kubernetes.io/router.middlewares: "${WORKSPACE_NAMESPACE}-redirect-https@kubernetescrd,${WORKSPACE_NAMESPACE}-hsts-headers@kubernetescrd,${WORKSPACE_NAMESPACE}-security-headers@kubernetescrd"
+    traefik.ingress.kubernetes.io/router.middlewares: "${WORKSPACE_NAMESPACE}-redirect-https@kubernetescrd,${WORKSPACE_NAMESPACE}-hsts-headers@kubernetescrd,${WORKSPACE_NAMESPACE}-mediaviewer-embed-headers@kubernetescrd"
 spec:
   tls:
     - hosts:

--- a/prod/patch-oauth2-proxy-mediaviewer.yaml
+++ b/prod/patch-oauth2-proxy-mediaviewer.yaml
@@ -24,6 +24,7 @@ spec:
             - "--upstream=http://mediaviewer-widget:80"
             - "--http-address=0.0.0.0:4180"
             - "--cookie-secure=true"
+            - "--cookie-samesite=none"
             - "--cookie-name=_oauth2_proxy_mediaviewer"
             - "--email-domain=*"
             - "--pass-access-token=true"

--- a/prod/traefik-middlewares.yaml
+++ b/prod/traefik-middlewares.yaml
@@ -35,6 +35,26 @@ spec:
       Permissions-Policy: "camera=(self), microphone=(self), geolocation=(), payment=()"
       X-Robots-Tag: "noindex"
 ---
+# ── Security-Header-Variante für eingebettete Widgets (iframe-kompatibel) ──
+# Verwendet für: mediaviewer.${PROD_DOMAIN} (im Admin-Sidekick als iframe)
+# Entfernt X-Frame-Options und setzt CSP frame-ancestors stattdessen,
+# damit der Widget-iframe in web.${PROD_DOMAIN} geladen werden kann.
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: mediaviewer-embed-headers
+  namespace: workspace
+spec:
+  headers:
+    customResponseHeaders:
+      X-Frame-Options: ""
+      X-Content-Type-Options: "nosniff"
+      X-XSS-Protection: "1; mode=block"
+      Referrer-Policy: "strict-origin-when-cross-origin"
+      Permissions-Policy: "camera=(self), microphone=(self), geolocation=(), payment=()"
+      X-Robots-Tag: "noindex"
+      Content-Security-Policy: "frame-ancestors 'self' https://web.${PROD_DOMAIN}"
+---
 # ── Rate-Limiting: Keycloak (Brute-Force-Schutz) ──────────────────
 apiVersion: traefik.io/v1alpha1
 kind: Middleware


### PR DESCRIPTION
## Summary

- New `mediaviewer-embed-headers` Traefik middleware: removes `X-Frame-Options` (which blocked iframe load even on 302 redirects) and replaces it with `Content-Security-Policy: frame-ancestors` for the specific production domain
- Switch `workspace-ingress-mediaviewer` from `security-headers` → `mediaviewer-embed-headers`
- Add `--cookie-samesite=none` to `oauth2-proxy-mediaviewer` so the auth cookie is forwarded in cross-origin iframes (default `SameSite=Lax` blocks cookie in iframes, causing every load to re-trigger the auth redirect, which itself hits X-Frame-Options)

## Root cause

The mediaviewer widget is embedded as an `<iframe src="https://mediaviewer.mentolder.de/embed.html">` inside the Admin Sidekick panel on `web.mentolder.de`. Two independent blockers:

1. `X-Frame-Options: SAMEORIGIN` — set by the global `security-headers` Traefik middleware on **all** responses including oauth2-proxy's 302 redirects. Chrome enforces XFO on redirect frames.
2. `SameSite=Lax` cookie — not forwarded in cross-origin iframes since Chrome 80+, so the oauth2-proxy always saw no cookie → issued a new auth redirect → hit blocker #1 again.

## Test plan

- [ ] Deploy to mentolder: `task workspace:deploy ENV=mentolder`
- [ ] Navigate to `https://web.mentolder.de/admin/cockpit`
- [ ] Dispatch `sidekick:navigate` with `{ ticketId: '<uuid>', view: 'grilling' }` 
- [ ] Confirm iframe loads `https://mediaviewer.mentolder.de/embed.html` without X-Frame-Options error
- [ ] Confirm suggestion chips appear in the grilling form

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016gRzviPkBQn3vNPkGQUmbT