### PR TITLE
fix(website): cache-bust embedSrc to bypass stale X-Frame-Options browser cache

### DIFF
--- a/website/src/components/MediaviewerPanel.svelte
+++ b/website/src/components/MediaviewerPanel.svelte
@@ -30,7 +30,9 @@
   } = $props();
 
   const widgetOrigin = $derived(`https://${mediaviewerHost}`);
-  const embedSrc = $derived(`${widgetOrigin}/embed.html`);
+  // Cache-buster forces a fresh server response, bypassing any browser-cached response
+  // that still has the old X-Frame-Options: SAMEORIGIN security header.
+  const embedSrc = $derived(`${widgetOrigin}/embed.html?v=${mediaviewerHost}`);
 
   let iframeEl = $state<HTMLIFrameElement | null>(null);
 

--- a/website/src/components/MediaviewerPanel.test.ts
+++ b/website/src/components/MediaviewerPanel.test.ts
@@ -21,7 +21,7 @@ describe('MediaviewerPanel', () => {
     const { getByTitle } = render(MediaviewerPanel, { mediaviewerHost: 'mediaviewer.localhost', videos });
     const iframe = getByTitle('Mediaviewer') as HTMLIFrameElement;
     expect(iframe.tagName).toBe('IFRAME');
-    expect(iframe.getAttribute('src')).toBe('https://mediaviewer.localhost/embed.html');
+    expect(iframe.getAttribute('src')).toBe('https://mediaviewer.localhost/embed.html?v=mediaviewer.localhost');
   });
 
   it('posts setVideos to the iframe once it has loaded', async () => {

--- a/website/src/components/PortalSidekick.test.ts
+++ b/website/src/components/PortalSidekick.test.ts
@@ -15,6 +15,6 @@ describe('PortalSidekick — mediaviewer view', () => {
     await fireEvent.click(getByLabelText('Sidekick öffnen'));
     await fireEvent.click(getByText('Mediaviewer'));
     const iframe = getByTitle('Mediaviewer') as HTMLIFrameElement;
-    expect(iframe.getAttribute('src')).toBe('https://mediaviewer.localhost/embed.html');
+    expect(iframe.getAttribute('src')).toBe('https://mediaviewer.localhost/embed.html?v=mediaviewer.localhost');
   });
 });


### PR DESCRIPTION
## Summary

- Adds a stable query parameter (`?v=<mediaviewerHost>`) to the `embedSrc` in `MediaviewerPanel.svelte`
- This forces Chrome to fetch a fresh response for `embed.html`, bypassing any cached response that still contains the old `X-Frame-Options: SAMEORIGIN` header (from before PR #1901)
- Without this, users who visited `mediaviewer.mentolder.de` before the fix would see the iframe as a broken page, because Chrome served the cached response with the old blocking header

## Root cause

Chrome caches HTTP responses including security headers. The static file server sets `cache-control: max-age=86400` for `embed.html`. Users whose browser cached the response before PR #1901 (which removed `X-Frame-Options` via the new Traefik middleware) would continue to see the iframe blocked — even though the server now returns correct headers — until the cache TTL expired (24h).

## Fix

A stable query parameter `?v=${mediaviewerHost}` (e.g. `?v=mediaviewer.mentolder.de`) makes `embed.html?v=...` a distinct URL from `embed.html`, so the browser treats it as uncached and fetches the current server response — which no longer includes `X-Frame-Options`.

## Test plan

- [ ] Open Admin Cockpit → Grilling ticket → Sidekick → confirm MediaviewerPanel loads (not broken-page icon)
- [ ] Check browser Network tab: `embed.html?v=mediaviewer.mentolder.de` → 200, no `X-Frame-Options` header

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016gRzviPkBQn3vNPkGQUmbT