### PR TITLE
chore(security): harden keycloak MCP auth — CLIENT_CREDENTIALS + NetworkPolicy [T000973]

### DIFF
--- a/environments/sealed-secrets/mentolder-mcp-keycloak-secret.yaml
+++ b/environments/sealed-secrets/mentolder-mcp-keycloak-secret.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: claude-code-mcp-secret
+  namespace: workspace
+spec:
+  encryptedData:
+    MCP_KEYCLOAK_CLIENT_SECRET: AgCrdLDwgvVTCKsRl5TdINKmwZgvZ41WZ+fSx+KkBYL4hbAE4GBHGL4HylY19a797AZLnITBZoSAQHxMQleoZmq0uFJ5NXWH6tUvAklEObvmysIeibEfONICmDmqkki9Tyz3OvFiZBJDTkrbFfQin1kVcAV8/eqtLxgZfJQMCaHcqQFcWGn1TM1uO00TLAi6+ddAEB0oLvDtiKadCX93RZoRxgA739uL/HNGN9Bnh9Hds6o143or8rVL3Er7cLmcvGLJWvp85Of2dJJu6nSWWtwhGsyvMCnui69ldU7a1MPS66DJxwjechuCimM4Yn4Dn6/ChamtF803I8kDXjTQFWJV5mrN9ovakroWg4hiB5tFjHdQTlAjGvqfDpia/LEQaQbsnsXE0d+Ue5cblcsfSe2EqK6ASqQQqe4cbVlTWPoGy0t70HSseaaniD2v7ZUXsE7D/smCZcVH1BEBqvUGBMWqLlTM3ZMN+ygTUACte3AaS/kQzqX87yGfFLP8ti+2aRbf9aRCopci4ZUIv7QOyrTq1jFMxeJJRusmChsIIHTy9oqAGezK3uGrd3gC/XqonJijY/5JW/eRHsLN+IT6K/uwCJQaRGzPU7j87audpl1uuzNEyvCaiSVhvpofp8DFVKa4crIzgf6sI/LeawkH9vPPUidANuCS2pGKuNJ9x+zgs9zr3U5QmeGxjJ6Ayei32ws9PWoen8Q5Wx5Z4a4zq/AByqvvGsd5+txvN6i/RkbuUA==
+  template:
+    metadata:
+      name: claude-code-mcp-secret
+      namespace: workspace

--- a/k3d/claude-code-mcp-auth.yaml
+++ b/k3d/claude-code-mcp-auth.yaml
@@ -1,6 +1,8 @@
 # ═══════════════════════════════════════════════════════════════════
-# Claude Code MCP Auth — Keycloak SSO management (SSE transport)
+# Claude Code MCP Auth — Keycloak SSO management (Streamable-HTTP)
 # Auth enforced externally (portforward / Traefik ForwardAuth in prod).
+# Uses dedicated service-account client with CLIENT_CREDENTIALS grant;
+# no admin password, only: view-users, manage-users, query-users, view-realm.
 # ═══════════════════════════════════════════════════════════════════
 apiVersion: apps/v1
 kind: Deployment
@@ -31,20 +33,23 @@ spec:
             - name: KC_REALM
               value: "master"
             - name: OIDC_CLIENT_ID
-              value: "admin-cli"
+              value: "claude-code-mcp"
             # Auth is enforced externally (portforward / Traefik ForwardAuth in prod).
-            # Container-level OIDC check bypassed so MCP clients don't need a KC token.
+            # Container-level OIDC check bypassed; access controlled at network layer.
             - name: QUARKUS_HTTP_AUTH_PERMISSION_MCP_POLICY
               value: "permit"
-            - name: QUARKUS_KEYCLOAK_ADMIN_CLIENT_USERNAME
-              value: admin
-            - name: QUARKUS_KEYCLOAK_ADMIN_CLIENT_PASSWORD
+            # Dedicated service account with minimal realm roles (no admin password).
+            # Quarkus property: quarkus.keycloak.admin-client.client-id
+            - name: QUARKUS_KEYCLOAK_ADMIN_CLIENT_CLIENT_ID
+              value: "claude-code-mcp"
+            # Quarkus property: quarkus.keycloak.admin-client.client-secret
+            - name: QUARKUS_KEYCLOAK_ADMIN_CLIENT_CLIENT_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: workspace-secrets
-                  key: KEYCLOAK_ADMIN_PASSWORD
+                  name: claude-code-mcp-secret
+                  key: MCP_KEYCLOAK_CLIENT_SECRET
             - name: QUARKUS_KEYCLOAK_ADMIN_CLIENT_GRANT_TYPE
-              value: password
+              value: "CLIENT_CREDENTIALS"
           securityContext:
             allowPrivilegeEscalation: false
             runAsNonRoot: true
@@ -77,3 +82,28 @@ spec:
   ports:
     - port: 8080
       targetPort: 8080
+---
+# NetworkPolicy: restrict ingress to claude-code-mcp-auth.
+# Allows only: pods with app=claude-code label (in-cluster consumers)
+# + kube-system (kube-apiserver proxies kubectl port-forward traffic).
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: claude-code-mcp-auth
+  labels:
+    app: claude-code
+spec:
+  podSelector:
+    matchLabels:
+      app: claude-code-mcp-auth
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: claude-code
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system


### PR DESCRIPTION
## Summary

- Replaces insecure `PASSWORD` grant (realm-admin creds) with `CLIENT_CREDENTIALS` using a dedicated `claude-code-mcp` service account with minimal permissions (view-users, manage-users, query-users, view-realm on master realm)
- Adds `NetworkPolicy` for `claude-code-mcp-auth`: ingress restricted to `app=claude-code` pods + `kube-system` (for `kubectl port-forward`)
- Adds `SealedSecret claude-code-mcp-secret` with the client secret (fleet, `workspace` namespace)
- Fixes Quarkus env var naming: `QUARKUS_KEYCLOAK_ADMIN_CLIENT_CLIENT_ID` / `QUARKUS_KEYCLOAK_ADMIN_CLIENT_CLIENT_SECRET` (double `CLIENT` prefix)

## Motivation

Security review [T000973] flagged that any pod in `workspace` namespace could reach `claude-code-mcp-auth:8080` without authentication and gain full Keycloak admin access via the realm-admin PASSWORD grant. This PR limits blast radius by:
1. Removing admin credentials entirely (service account with 4 specific roles only)
2. Restricting network access via NetworkPolicy

## Test plan

- [x] `kubectl apply` and rollout completed successfully on fleet `workspace`
- [x] Keycloak MCP `/mcp` endpoint responds HTTP 200 after rollout
- [x] `task workspace:validate` passes
- [x] `task freshness:check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016gRzviPkBQn3vNPkGQUmbT