### PR TITLE
fix(website): use service_page_config table for per-slug page content

### DIFF
--- a/website/src/lib/website-db.ts
+++ b/website/src/lib/website-db.ts
@@ -4284,6 +4284,23 @@ export async function initEurTables(): Promise<void> {
   eurTablesReady = true;
 }
 
+// ─── Service-page content store (per-slug) ────────────────────────────────────
+
+async function initServicePageConfigTable(): Promise<void> {
+  return ensureSchemaOnce('service_page_config', async () => {
+    await pool.query(`
+      CREATE TABLE IF NOT EXISTS service_page_config (
+        brand        TEXT NOT NULL REFERENCES public.brands(id) ON UPDATE CASCADE ON DELETE RESTRICT,
+        slug         TEXT NOT NULL,
+        page_content JSONB,
+        version      INTEGER NOT NULL DEFAULT 0,
+        updated_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+        PRIMARY KEY (brand, slug)
+      )
+    `);
+  });
+}
+
 // ─── Content-Store accessors (T000306) ────────────────────────────────────────
 
 export interface ContentRead { value: any | null; version: number }
@@ -4330,8 +4347,9 @@ async function liveRead(
         : { value: null, version: 0 };
     }
     case 'service': {
+      await initServicePageConfigTable();
       const r = await client.query(
-        'SELECT page_content, version FROM service_config WHERE brand=$1 AND slug=$2',
+        'SELECT page_content, version FROM service_page_config WHERE brand=$1 AND slug=$2',
         [brand, ref.storeKey],
       );
       return r.rows.length
@@ -4375,9 +4393,10 @@ async function liveWrite(
       );
       return;
     case 'service':
+      await initServicePageConfigTable();
       await client.query(
-        `INSERT INTO service_config (brand, slug, page_content, version) VALUES ($1,$2,$3,$4)
-         ON CONFLICT (brand, slug) DO UPDATE SET page_content=$3, version=$4`,
+        `INSERT INTO service_page_config (brand, slug, page_content, version, updated_at) VALUES ($1,$2,$3,$4,now())
+         ON CONFLICT (brand, slug) DO UPDATE SET page_content=$3, version=$4, updated_at=now()`,
         [brand, ref.storeKey, JSON.stringify(value), version],
       );
       return;


### PR DESCRIPTION
## Summary

- `liveRead`/`liveWrite` for `contentType: 'service'` war auf `service_config` mit Spalten `slug`, `page_content`, `version` gerichtet — die dort nicht existieren (Tabelle hat nur `brand PK + services_json`)
- Neue Tabelle `service_page_config(brand, slug, page_content JSONB, version, updated_at)` eingeführt, die per-Slug Page-Content speichert
- `initServicePageConfigTable()` via `ensureSchemaOnce` idempotent erstellt
- DB-Migration manuell angewendet: Tabelle in Prod erstellt + `coaching` und `fuehrung-persoenlichkeit` aus `services_json[].pageContent` geseedet

## Root Cause

Der Content-Hub (Admin → Inhalte) liest Coaching- und Führung-Tabs via `readContent('service:coaching')`, das intern `SELECT page_content ... FROM service_config WHERE slug=...` ausführt. Da `service_config` keine `slug`-Spalte hat, schlägt die Query fehl — das `.catch(() => null)` schluckt den Fehler, die Tabs bleiben leer.

## Test plan

- [ ] Admin → Inhalte → Tab "Coaching" zeigt Inhalte (nicht leer)
- [ ] Admin → Inhalte → Tab "Führung & Pers." zeigt Inhalte (nicht leer)
- [ ] Speichern in einem der Tabs → kein Fehler, Inhalt bleibt erhalten
- [ ] CI grün

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NikkAppXc96nocDR7Gyzwy