### PR TITLE
chore(test): add tests/spec/software-factory.bats — one-file-per-spec PoC [T000984]

### DIFF
--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 480,
+      "file_count": 482,
       "files": [
         "tests/.gitignore",
         "tests/batch/batch-gap-analysis.bats",
@@ -348,6 +348,8 @@
         "tests/runner.sh",
         "tests/scripts/admin-menu-gate.bats",
         "tests/scripts/helper-collab-mock-runner.mjs",
+        "tests/spec/software-factory.bats",
+        "tests/spec/test_helper.bash",
         "tests/sql/software-history.sql",
         "tests/unit/.coverage-allowlist",
         "tests/unit/T000617-alert-rules.bats",

--- a/tests/spec/software-factory.bats
+++ b/tests/spec/software-factory.bats
@@ -1,0 +1,2870 @@
+#!/usr/bin/env bats
+# tests/spec/software-factory.bats
+# SSOT: openspec/specs/software-factory.md
+#
+# Consolidated BATS suite for the Software Factory component.
+# Aggregated from tests/local/FA-SF-*.bats (41 source files).
+# Convention: one .bats file per OpenSpec SSOT spec.
+
+# ── File-level variables ──────────────────────────────────────────────────────
+PIPELINE_SCRIPT="scripts/factory/pipeline.js"
+DISPATCHER_SCRIPT="scripts/factory/dispatcher.js"
+GUARDS_SCRIPT="scripts/factory/guards.sh"
+CANARY_SCRIPT="$BATS_TEST_DIRNAME/../../scripts/feature-promote.sh"
+PHASES_SCRIPT="$BATS_TEST_DIRNAME/../../scripts/lib/promote-phases.sh"
+WAKEUP_SCRIPT="scripts/factory/wakeup.sh"
+PROVISION_MOD="scripts/factory/provision.js"
+PROVISION_SUITE="scripts/factory/provision.test.mjs"
+DECOMPOSE_MOD="scripts/factory/pipeline-decompose.cjs"
+DECOMPOSE_SUITE="scripts/factory/pipeline-decompose.test.cjs"
+PJS="$BATS_TEST_DIRNAME/../../scripts/factory/pipeline.js"
+BLS="$BATS_TEST_DIRNAME/../../scripts/factory/build-loop.sh"
+WAKEUP="${BATS_TEST_DIRNAME}/../../scripts/factory/wakeup.sh"
+SERVICE="${BATS_TEST_DIRNAME}/../../scripts/factory/factory.service"
+TIMER="${BATS_TEST_DIRNAME}/../../scripts/factory/factory.timer"
+TASKFILE="${BATS_TEST_DIRNAME}/../../Taskfile.factory.yml"
+ROUTE="${BATS_TEST_DIRNAME}/../../website/src/pages/api/factory-metrics.ts"
+REG="scripts/factory/service-registry.sh"
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+# Skip if no shared-db pod is reachable (offline / CI without cluster).
+# Used by FA-SF-04 db-schema tests which require a live DB.
+_skip_if_no_db() {
+  local _pod
+  _pod=$(kubectl get pod -n "${FACTORY_NS:-workspace}" --context "${FACTORY_CTX:-fleet}" \
+    -l 'app in (shared-db,shared-db-dev)' -o name 2>/dev/null | head -1) || true
+  if [[ -z "$_pod" ]]; then
+    skip "no shared-db pod reachable (offline/CI)"
+  fi
+}
+
+# ── Setup / Teardown ──────────────────────────────────────────────────────────
+setup() {
+  load 'test_helper.bash'
+
+  # Runtime paths (BATS_TEST_DIRNAME not available at file-level)
+  REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+  REPO="$REPO_ROOT"
+
+  # FA-SF-05: auto-triage.sh path + inline validator (mirrors auto-triage.sh)
+  SCRIPT="${REPO}/scripts/factory/auto-triage.sh"
+  ENUMS_FILE="${REPO}/scripts/factory/triage-enums.json"
+  validate_triage() {
+    local json="$1"
+    if ! echo "$json" | jq empty 2>/dev/null; then return 1; fi
+    local t; t=$(echo "$json" | jq -r '.type // ""')
+    if [[ ! "$t" =~ ^(bug|feature|task|project)$ ]]; then return 1; fi
+    local s; s=$(echo "$json" | jq -r '.severity // ""')
+    if [[ ! "$s" =~ ^(critical|major|minor|trivial)$ ]]; then return 1; fi
+    local p; p=$(echo "$json" | jq -r '.priority // ""')
+    if [[ ! "$p" =~ ^(hoch|mittel|niedrig)$ ]]; then return 1; fi
+    local areas; areas=$(echo "$json" | jq -r '.areas // [] | join("\n")')
+    local enums; enums=$(cat "$ENUMS_FILE")
+    local allowed_areas; allowed_areas=$(echo "$enums" | jq -r '.areas[]')
+    while IFS= read -r area; do
+      [[ -z "$area" ]] && continue
+      if ! echo "$allowed_areas" | grep -qxF "$area"; then return 1; fi
+    done <<< "$areas"
+    local comp; comp=$(echo "$json" | jq -r '.component // ""')
+    if [[ -n "$comp" && "$comp" != "null" ]]; then
+      local allowed_comp; allowed_comp=$(echo "$enums" | jq -r '.components[]')
+      if ! echo "$allowed_comp" | grep -qxF "$comp"; then return 1; fi
+    fi
+    local assignee; assignee=$(echo "$json" | jq -r '.assignee_suggested // ""')
+    if [[ -z "$assignee" || "$assignee" == "null" ]]; then return 1; fi
+    local allowed_assignees; allowed_assignees=$(echo "$enums" | jq -r '.assignees[]')
+    if ! echo "$allowed_assignees" | grep -qxF "$assignee"; then return 1; fi
+    return 0
+  }
+
+  # FA-SF-33: per-test temp log file
+  TMPLOG="$(mktemp)"
+
+  # FA-SF-57/58/59: temp directory with all needed subdirs
+  TEST_TMP_DIR="$BATS_TMPDIR/sf-tests-$$"
+  mkdir -p "$TEST_TMP_DIR/fixtures/T000725" "$TEST_TMP_DIR/out"
+
+  # FA-SF-63: scout.sh deterministic tests
+  SCOUT="${REPO_ROOT}/scripts/factory/scout.sh"
+  FIXTURE="${REPO_ROOT}/tests/local/fixtures/scout-repo"
+  PIPELINE="${REPO_ROOT}/scripts/factory/pipeline.js"
+
+  _CLEANUP_PATHS=("$TMPLOG" "$TEST_TMP_DIR")
+}
+
+teardown() {
+  rm -rf "${_CLEANUP_PATHS[@]}" 2>/dev/null || true
+}
+
+# ── FA-SF-01-conflict-check ─────────────────────────────────────#
+# tests/local/factory-conflict-check.bats
+# Verifies conflict-check.sh script behavior.
+
+@test "FA-SF-01: conflict-check rejects missing args" {
+  run bash scripts/factory/conflict-check.sh
+  [ "$status" -eq 2 ]
+  [[ "$output" =~ error ]]
+}
+
+@test "FA-SF-02: conflict-check returns error for unknown ticket without files" {
+  # Set environment variables for the test to point to the dev database in k3d
+  export FACTORY_CTX="k3d-korczewski-dev"
+  export FACTORY_NS="workspace-korczewski-dev"
+  run bash scripts/factory/conflict-check.sh "T999999"
+  [ "$status" -eq 2 ]
+  [[ "$output" =~ error ]]
+}
+
+@test "FA-SF-03: conflict-check with explicit files produces valid JSON" {
+  # Set environment variables for the test to point to the dev database in k3d
+  export FACTORY_CTX="k3d-korczewski-dev"
+  export FACTORY_NS="workspace-korczewski-dev"
+  
+  # Ensure we have at least one ticket to test with, or insert/query safely
+  run bash scripts/factory/conflict-check.sh "T000413" "website/src/lib/tickets-db.ts" "k3d/website-schema.yaml"
+  # Verify the output is valid JSON (empty or array of conflicts)
+  echo "$output" | jq . > /dev/null
+}
+
+@test "FA-SF-03c: an explicit FACTORY_NS suppresses the no-BRAND WARN (keeps JSON stdout clean)" {
+  # The suppression guard must key off FACTORY_NS (what callers actually set), not the
+  # never-set FACTORY_NS_EXPLICIT. With FACTORY_NS provided, no WARN may reach stderr.
+  # `|| true`: offline (CI) conflict-check exits 2 (no cluster) — we only assert on the
+  # stderr CONTENT (the WARN), not the exit code, so the non-zero must not fail the test.
+  err="$(env -u BRAND FACTORY_CTX=k3d-korczewski-dev FACTORY_NS=workspace-korczewski-dev \
+        bash scripts/factory/conflict-check.sh T000413 website/src/lib/tickets-db.ts 2>&1 1>/dev/null || true)"
+  [[ "$err" != *"WARN: no BRAND"* ]]
+}
+
+@test "FA-SF-03b: BRAND=korczewski resolves namespace to workspace-korczewski" {
+  run env BRAND=korczewski FACTORY_DRY_RESOLVE=1 bash scripts/factory/conflict-check.sh T000001
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"workspace-korczewski"* ]]
+}
+
+@test "FA-SF-04: conflict-check detects in-flight task tickets" {
+  if [[ -z "${FACTORY_CTX:-}" ]]; then
+    skip "FACTORY_CTX not set (live-seed test skipped)"
+  fi
+  source tests/lib/factory-test-fixtures.sh
+
+  # Seed a feature ticket first
+  local brand="korczewski"
+  local file="k3d/configmap-domains.yaml"
+  local ext_id
+  ext_id=$(seed_test_feature "$brand" "$file")
+
+  # Update it to be type='task' and status='in_progress' to simulate in-flight human work
+  local ns="${FACTORY_NS:-workspace-korczewski-dev}"
+  local pod
+  pod=$(kubectl get pod -n "$ns" --context "$FACTORY_CTX" -l 'app in (shared-db, shared-db-dev)' -o name | head -1)
+  kubectl exec -i "$pod" -n "$ns" --context "$FACTORY_CTX" -c postgres -- \
+    psql -U website -d website -qtAc "UPDATE tickets.tickets SET type='task', status='in_progress' WHERE external_id = '$ext_id';"
+
+  # Verify conflict-check detects it for a different ticket ID
+  run env BRAND="$brand" FACTORY_CTX="$FACTORY_CTX" FACTORY_NS="$ns" \
+    bash scripts/factory/conflict-check.sh "T999999" "$file"
+  
+  # Clean up before assert
+  purge_factory_test_data "$brand"
+
+  # Assert
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "$ext_id" ]]
+}
+
+# ── FA-SF-04-db-schema ──────────────────────────────────────────#
+# tests/local/FA-SF-04-db-schema.bats  (renamed from factory-db-schema.bats)
+# Verifies the Software Factory pgvector tables, views, and columns.
+#
+# Both-namespaces coverage: re-run with FACTORY_NS=workspace-korczewski to
+# test the korczewski brand. The default targets workspace (mentolder).
+#   FACTORY_CTX=fleet FACTORY_NS=workspace ./tests/runner.sh local FA-SF-04
+#   FACTORY_CTX=fleet FACTORY_NS=workspace-korczewski ./tests/runner.sh local FA-SF-04
+
+psql_tickets() {
+  local query="$1"
+  local ctx="${FACTORY_CTX:-fleet}"
+  local ns="${FACTORY_NS:-workspace}"
+  local pod
+  pod=$(kubectl get pod -n "$ns" --context "$ctx" -l 'app in (shared-db, shared-db-dev)' -o name 2>/dev/null | head -1)
+  if [[ -z "$pod" ]]; then
+    echo "Error: shared-db pod not found" >&2
+    return 1
+  fi
+  kubectl exec "$pod" -n "$ns" --context "$ctx" -c postgres -- psql -U website -d website -t -A -c "$query"
+}
+
+@test "FA-SF-04: tickets.tickets has touched_files column" {
+  _skip_if_no_db
+  run psql_tickets "SELECT column_name FROM information_schema.columns WHERE table_schema='tickets' AND table_name='tickets' AND column_name='touched_files'"
+  [ "$status" -eq 0 ]
+  [ "$output" = "touched_files" ]
+}
+
+@test "FA-SF-05: tickets.tickets has pipeline_slot column" {
+  _skip_if_no_db
+  run psql_tickets "SELECT column_name FROM information_schema.columns WHERE table_schema='tickets' AND table_name='tickets' AND column_name='pipeline_slot'"
+  [ "$status" -eq 0 ]
+  [ "$output" = "pipeline_slot" ]
+}
+
+@test "FA-SF-06: tickets.ticket_embeddings table exists" {
+  _skip_if_no_db
+  run psql_tickets "SELECT tablename FROM pg_tables WHERE schemaname='tickets' AND tablename='ticket_embeddings'"
+  [ "$status" -eq 0 ]
+  [ "$output" = "ticket_embeddings" ]
+}
+
+@test "FA-SF-07: ticket_embeddings HNSW index exists" {
+  _skip_if_no_db
+  run psql_tickets "SELECT indexname FROM pg_indexes WHERE schemaname='tickets' AND indexname='ticket_embeddings_hnsw_idx'"
+  [ "$status" -eq 0 ]
+  [ "$output" = "ticket_embeddings_hnsw_idx" ]
+}
+
+@test "FA-SF-08: v_factory_metrics view exists" {
+  _skip_if_no_db
+  run psql_tickets "SELECT viewname FROM pg_views WHERE schemaname='tickets' AND viewname='v_factory_metrics'"
+  [ "$status" -eq 0 ]
+  [ "$output" = "v_factory_metrics" ]
+}
+
+@test "FA-SF-09: v_active_features view exists" {
+  _skip_if_no_db
+  run psql_tickets "SELECT viewname FROM pg_views WHERE schemaname='tickets' AND viewname='v_active_features'"
+  [ "$status" -eq 0 ]
+  [ "$output" = "v_active_features" ]
+}
+
+@test "FA-SF-10: fn_find_similar function exists" {
+  _skip_if_no_db
+  run psql_tickets "SELECT proname FROM pg_proc p JOIN pg_namespace n ON p.pronamespace = n.oid WHERE n.nspname='tickets' AND proname='fn_find_similar'"
+  [ "$status" -eq 0 ]
+  [ "$output" = "fn_find_similar" ]
+}
+
+@test "FA-SF-11: chunk_type CHECK constraint enforces valid values" {
+  _skip_if_no_db
+  run psql_tickets "
+    DO \$\$
+    BEGIN
+      INSERT INTO tickets.ticket_embeddings (ticket_id, chunk, chunk_type)
+      SELECT id, 'test', 'invalid_type' FROM tickets.tickets LIMIT 1;
+    END \$\$
+  "
+  [ "$status" -ne 0 ]
+}
+
+@test "FA-SF-12: embedding_model column exists on tickets.ticket_embeddings" {
+  _skip_if_no_db
+  # Reuse psql_tickets (has -c postgres + the pod guard); a raw `kubectl exec deployment/...`
+  # without -c postgres prints a "Defaulted container" line to stderr that bats folds into
+  # $output, breaking the exact-match assertion even when the column is present.
+  run psql_tickets "SELECT EXISTS(SELECT 1 FROM information_schema.columns WHERE table_schema='tickets' AND table_name='ticket_embeddings' AND column_name='embedding_model')"
+  [ "$status" -eq 0 ]
+  [ "$output" = "t" ]
+}
+
+@test "FA-SF-13: vector extension is enabled (ticket_embeddings hard dependency)" {
+  _skip_if_no_db
+  run psql_tickets "SELECT EXISTS(SELECT 1 FROM pg_extension WHERE extname='vector')"
+  [ "$status" -eq 0 ]
+  [ "$output" = "t" ]
+}
+
+@test "FA-SF-04: tickets.tickets has retry_count column (NOT NULL DEFAULT 0)" {
+  _skip_if_no_db
+  run psql_tickets "SELECT column_default FROM information_schema.columns WHERE table_schema='tickets' AND table_name='tickets' AND column_name='retry_count'"
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "0" ]]
+}
+
+@test "FA-SF-04: tickets.factory_control table exists with UNIQUE(key,brand)" {
+  _skip_if_no_db
+  run psql_tickets "SELECT tablename FROM pg_tables WHERE schemaname='tickets' AND tablename='factory_control'"
+  [ "$status" -eq 0 ]
+  [ "$output" = "factory_control" ]
+}
+@test "FA-SF-04: factory_control has a UNIQUE(key,brand) constraint" {
+  _skip_if_no_db
+  run psql_tickets "SELECT conname FROM pg_constraint WHERE conrelid='tickets.factory_control'::regclass AND contype='u'"
+  [ "$status" -eq 0 ]
+  [ -n "$output" ]
+}
+
+@test "FA-SF-04: tickets.feature_flags table exists" {
+  _skip_if_no_db
+  run psql_tickets "SELECT tablename FROM pg_tables WHERE schemaname='tickets' AND tablename='feature_flags'"
+  [ "$status" -eq 0 ]
+  [ "$output" = "feature_flags" ]
+}
+@test "FA-SF-04: feature_flags has brand FK to public.brands" {
+  _skip_if_no_db
+  run psql_tickets "SELECT conname FROM pg_constraint WHERE conname='feature_flags_brand_fkey'"
+  [ "$status" -eq 0 ]
+  [ "$output" = "feature_flags_brand_fkey" ]
+}
+@test "FA-SF-04: feature_flags has UNIQUE(brand,key)" {
+  _skip_if_no_db
+  run psql_tickets "SELECT count(*) FROM pg_constraint WHERE conrelid='tickets.feature_flags'::regclass AND contype='u'"
+  [ "$status" -eq 0 ]
+  [ "$output" = "1" ]
+}
+
+# ── FA-SF-05-triage ─────────────────────────────────────────────#
+# tests/local/FA-SF-05-triage.bats — Tests für auto-triage.sh Validierung & Idempotenz [T000933]
+
+# ── Enum-Validierung ──────────────────────────────────────────────────
+
+@test "FA-SF-05-01: validate_triage accepts valid JSON" {
+  run validate_triage '{
+    "type": "feature",
+    "priority": "mittel",
+    "severity": "minor",
+    "areas": ["website", "tickets"],
+    "component": "planungsbuero",
+    "assignee_suggested": "patrick",
+    "rationale": "Test"
+  }'
+  [[ "$status" -eq 0 ]]
+}
+
+@test "FA-SF-05-02: validate_triage rejects invalid type" {
+  run validate_triage '{
+    "type": "invalid",
+    "priority": "mittel",
+    "severity": "minor",
+    "areas": ["website"],
+    "component": null,
+    "assignee_suggested": "patrick"
+  }'
+  [[ "$status" -ne 0 ]]
+}
+
+@test "FA-SF-05-03: validate_triage rejects invalid severity" {
+  run validate_triage '{
+    "type": "bug",
+    "priority": "hoch",
+    "severity": "extreme",
+    "areas": ["website"],
+    "component": null,
+    "assignee_suggested": "patrick"
+  }'
+  [[ "$status" -ne 0 ]]
+}
+
+@test "FA-SF-05-04: validate_triage rejects invalid priority" {
+  run validate_triage '{
+    "type": "task",
+    "priority": "dringend",
+    "severity": "minor",
+    "areas": ["ci"],
+    "component": null,
+    "assignee_suggested": "factory"
+  }'
+  [[ "$status" -ne 0 ]]
+}
+
+@test "FA-SF-05-05: validate_triage rejects unknown area" {
+  run validate_triage '{
+    "type": "project",
+    "priority": "niedrig",
+    "severity": "trivial",
+    "areas": ["website", "unbekannt"],
+    "component": null,
+    "assignee_suggested": "patrick"
+  }'
+  [[ "$status" -ne 0 ]]
+}
+
+@test "FA-SF-05-06: validate_triage rejects unknown component" {
+  run validate_triage '{
+    "type": "bug",
+    "priority": "hoch",
+    "severity": "critical",
+    "areas": ["security"],
+    "component": "fakeservice",
+    "assignee_suggested": "patrick"
+  }'
+  [[ "$status" -ne 0 ]]
+}
+
+@test "FA-SF-05-07: validate_triage rejects unknown assignee" {
+  run validate_triage '{
+    "type": "feature",
+    "priority": "mittel",
+    "severity": "major",
+    "areas": ["tickets"],
+    "component": null,
+    "assignee_suggested": "eindringling"
+  }'
+  [[ "$status" -ne 0 ]]
+}
+
+@test "FA-SF-05-08: validate_triage rejects malformed JSON" {
+  run validate_triage '{nope}'
+  [[ "$status" -ne 0 ]]
+}
+
+@test "FA-SF-05-09: validate_triage rejects empty string" {
+  run validate_triage ''
+  [[ "$status" -ne 0 ]]
+}
+
+@test "FA-SF-05-10: validate_triage accepts null component" {
+  run validate_triage '{
+    "type": "task",
+    "priority": "hoch",
+    "severity": "major",
+    "areas": ["infra"],
+    "component": null,
+    "assignee_suggested": "factory",
+    "rationale": "ok"
+  }'
+  [[ "$status" -eq 0 ]]
+}
+
+# ── Idempotenz und DRY-RUN ────────────────────────────────────────────
+
+@test "FA-SF-05-11: FACTORY_DRY_RESOLVE shortcut exits 0 immediately" {
+  run bash -c "
+    export FACTORY_DRY_RESOLVE=1
+    export BRAND=mentolder
+    ENUMS_FILE='${ENUMS_FILE}' bash '${SCRIPT}'
+  "
+  [[ "$status" -eq 0 ]]
+  [[ "$output" =~ "DRY-RESOLVE" ]]
+}
+
+@test "FA-SF-05-12: --help exits 0 and prints usage" {
+  run bash "${SCRIPT}" --help
+  [[ "$status" -eq 0 ]]
+  [[ "$output" =~ "Usage" ]]
+}
+
+@test "FA-SF-05-13: missing BRAND exits non-zero" {
+  run bash -c "unset BRAND; bash '${SCRIPT}'" 2>&1 || true
+  [[ "$status" -ne 0 ]] || [[ "$output" =~ "BRAND" ]]
+}
+
+@test "FA-SF-05-14: --dry-run flag is recognized" {
+  export BRAND=mentolder
+  export FACTORY_DRY_RESOLVE=1
+  run bash "${SCRIPT}" --dry-run
+  [[ "$status" -eq 0 ]]
+}
+
+@test "FA-SF-05-15: triage-enums.json is valid JSON" {
+  run jq empty "${ENUMS_FILE}"
+  [[ "$status" -eq 0 ]]
+}
+
+@test "FA-SF-05-16: triage-enums.json has required keys" {
+  run bash -c "jq -e '.areas and .components and .assignees' '${ENUMS_FILE}' > /dev/null"
+  [[ "$status" -eq 0 ]]
+}
+
+@test "FA-SF-05-17: auto-triage.sh passes bash -n syntax check" {
+  run bash -n "${SCRIPT}"
+  [[ "$status" -eq 0 ]]
+}
+
+# ── FA-SF-20-pipeline-contract ──────────────────────────────────#
+# FA-SF-20: structural contract for the runnable factory pipeline (offline, no cluster).
+PIPELINE_SCRIPT="scripts/factory/pipeline.js"
+
+@test "FA-SF-20: pipeline.js exists and is syntactically valid JS" {
+  [ -f "$PIPELINE_SCRIPT" ]
+  run node --check "$PIPELINE_SCRIPT"
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-20: exports meta with the six expected phases" {
+  for p in Scout Design Plan Implement Verify Deploy; do
+    run grep -q "phase('$p')" "$PIPELINE_SCRIPT"; [ "$status" -eq 0 ]
+  done
+  run grep -Eq "export const meta" "$PIPELINE_SCRIPT"; [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-20: wires the existing factory parts (conflict-check, review prompts, ticket.sh, scout.sh)" {
+  run grep -q "conflict-check.sh" "$PIPELINE_SCRIPT"; [ "$status" -eq 0 ]
+  run grep -q "review-bug-hunter.prompt.md" "$PIPELINE_SCRIPT"; [ "$status" -eq 0 ]
+  run grep -q "review-security-auditor.prompt.md" "$PIPELINE_SCRIPT"; [ "$status" -eq 0 ]
+  run grep -q "review-pattern-enforcer.prompt.md" "$PIPELINE_SCRIPT"; [ "$status" -eq 0 ]
+  run grep -q "scripts/ticket.sh" "$PIPELINE_SCRIPT"; [ "$status" -eq 0 ]
+  # find-similar-tickets.mjs is now an implementation detail of scout.sh (not pipeline.js).
+  # Instead verify that pipeline.js invokes the deterministic scout.sh.
+  run grep -q "scout.sh" "$PIPELINE_SCRIPT"; [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-20: uses args.timestamp and not Date.now()/Math.random() (resume-safe)" {
+  run grep -q "args.timestamp" "$PIPELINE_SCRIPT"; [ "$status" -eq 0 ]
+  # Exclude comment lines (// ... and JSDoc * lines) — the pattern appears in
+  # JSDoc to document what NOT to use; only actual code-line usage is disallowed.
+  run bash -c "grep -Ev '^\s*(/[/*]|\*)' \"$PIPELINE_SCRIPT\" | grep -Eq 'Date\.now\(\)|Math\.random\(\)'"
+  [ "$status" -ne 0 ]
+}
+
+@test "FA-SF-20: Deploy phase merges from MAIN repo and deploys BOTH brands with explicit ENV" {
+  run grep -q "feature:" "$PIPELINE_SCRIPT"; [ "$status" -eq 0 ]
+  run grep -Eq "ENV=mentolder|ENV=korczewski|ENV=fleet-" "$PIPELINE_SCRIPT"; [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-20: pipeline writes a per-phase liveness touch (>=6 references)" {
+  run grep -c "ticket.sh touch" "$PIPELINE_SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$output" -ge 6 ]
+}
+
+@test "FA-SF-20: Deploy phase enforces WORK_BRANCH regex feature/*|fix/* + diff-size guard" {
+  run grep -Eq "feature/.*\|fix/|guard_check_diff_size" "$PIPELINE_SCRIPT"; [ "$status" -eq 0 ]
+  run grep -q "FACTORY_MAX_DIFF" "$PIPELINE_SCRIPT"; [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-20: Deploy asserts MAIN_REPO cwd + explicit ENV= (no bare context)" {
+  run grep -q "ENV=mentolder" "$PIPELINE_SCRIPT"; [ "$status" -eq 0 ]
+  run grep -q "ENV=korczewski" "$PIPELINE_SCRIPT"; [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-20: both escalation sites route PushNotification via ToolSearch" {
+  run grep -c "ToolSearch select:PushNotification" "$PIPELINE_SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$output" -ge 2 ]
+}
+
+@test "FA-SF-20: no scout.* reference escapes the if(!REUSE) Scout block (Deploy ReferenceError guard)" {
+  # `const scout` is block-local to `if (!REUSE) { ... }`; any scout.* appearing after
+  # the alternative `if (REUSE) {` runs outside that scope → ReferenceError at runtime
+  # (the template literal is fully evaluated when the agent() call is built). Out-of-block
+  # signals must be hoisted to a top-level var (featureComplexity / featureTouchedFiles).
+  blockend=$(grep -n '^if (REUSE) {' "$PIPELINE_SCRIPT" | head -1 | cut -d: -f1)
+  [ -n "$blockend" ]
+  run awk -v end="$blockend" 'NR > end && /scout[.?]/ { print NR": "$0; f=1 } END { exit (f?1:0) }' "$PIPELINE_SCRIPT"
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-20: defines consumeInjections and calls it after every phaseEvent(...,'entered')" {
+  run grep -q "function consumeInjections" "$PIPELINE_SCRIPT"; [ "$status" -eq 0 ]
+  # one consume per entered-boundary: scout, design, plan(x2 reuse+fresh), implement, verify, deploy
+  run grep -c "consumeInjections(" "$PIPELINE_SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$output" -ge 7 ]
+}
+
+@test "FA-SF-20: consumeInjections is best-effort (try/catch, never throws) and uses get-injections --consume" {
+  run grep -q "get-injections" "$PIPELINE_SCRIPT"; [ "$status" -eq 0 ]
+  run grep -q "'--consume'" "$PIPELINE_SCRIPT"; [ "$status" -eq 0 ]
+  # the helper body wraps in try/catch (mirrors phaseEvent)
+  run bash -c "awk '/function consumeInjections/,/^}/' \"$PIPELINE_SCRIPT\" | grep -q 'try {'"
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-20: consumeInjections materializes assets into assets-inbox" {
+  run grep -q "assets-inbox" "$PIPELINE_SCRIPT"; [ "$status" -eq 0 ]
+}
+
+# ── FA-SF-21-ticket-cli ─────────────────────────────────────────#
+# FA-SF-21: offline arg-validation contract for the new ticket.sh subcommands.
+
+@test "FA-SF-21: get requires --id" {
+  run bash scripts/ticket.sh get
+  [ "$status" -eq 2 ]
+  [[ "$output" =~ "--id" ]]
+}
+
+@test "FA-SF-21: set-touched-files requires --id and --files" {
+  run bash scripts/ticket.sh set-touched-files --id T000001
+  [ "$status" -eq 2 ]
+  [[ "$output" =~ "--files" ]]
+}
+
+@test "FA-SF-21: set-pipeline-slot requires --id and --slot" {
+  run bash scripts/ticket.sh set-pipeline-slot --id T000001
+  [ "$status" -eq 2 ]
+}
+
+@test "FA-SF-21: unknown BRAND is rejected with exit 2" {
+  run env BRAND=bogus bash scripts/ticket.sh get --id T000001
+  [ "$status" -eq 2 ]
+  [[ "$output" =~ "unknown BRAND" ]]
+}
+
+@test "FA-SF-21: dispatch lists the new commands in usage" {
+  run bash scripts/ticket.sh
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "set-touched-files" ]]
+}
+
+@test "FA-SF-21: enqueue requires --id" {
+  run bash scripts/ticket.sh enqueue --branch feature/x --plan docs/p.md
+  [ "$status" -eq 2 ]
+}
+@test "FA-SF-21: enqueue rejects unknown option" {
+  run bash scripts/ticket.sh enqueue --id T000001 --bogus z
+  [ "$status" -eq 2 ]
+}
+@test "FA-SF-21: unknown command still errors" {
+  run bash scripts/ticket.sh frobnicate
+  [ "$status" -ne 0 ]
+}
+
+# ── FA-SF-22-fixtures ───────────────────────────────────────────#
+# FA-SF-22: factory shared lib + test fixtures contract (offline assertions only).
+
+@test "FA-SF-22: lib.sh dry-resolve maps korczewski to workspace-korczewski" {
+  run env BRAND=korczewski FACTORY_DRY_RESOLVE=1 bash -c 'source scripts/factory/lib.sh; factory_resolve; echo "ns=$FACTORY_NS ctx=$FACTORY_CTX"'
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"ns=workspace-korczewski"* ]]
+}
+
+@test "FA-SF-22: lib.sh rejects unknown BRAND" {
+  run env BRAND=bogus bash -c 'source scripts/factory/lib.sh; factory_resolve'
+  [ "$status" -eq 2 ]
+}
+
+@test "FA-SF-22: fixtures refuse to seed into prod fleet without override" {
+  run env FACTORY_CTX=fleet bash -c 'source tests/lib/factory-test-fixtures.sh; seed_test_feature mentolder "tests/fixtures/x.txt"'
+  [ "$status" -ne 0 ]
+  [[ "$output" =~ "refusing" ]]
+}
+
+# ── FA-SF-23-slots ──────────────────────────────────────────────#
+# FA-SF-23: slots.sh contract. Offline assertions always run; live claim/release
+# runs only when a dev cluster is reachable (FACTORY_CTX/FACTORY_NS set to dev).
+
+@test "FA-SF-23: dry-resolve prints brand namespace" {
+  run env BRAND=mentolder FACTORY_DRY_RESOLVE=1 bash scripts/factory/slots.sh count
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"ns=workspace"* ]]
+}
+
+@test "FA-SF-23: unknown subcommand exits 2" {
+  run env BRAND=mentolder FACTORY_DRY_RESOLVE= bash scripts/factory/slots.sh bogus
+  [ "$status" -eq 2 ]
+}
+
+@test "FA-SF-23: claim is atomic — second claim on the same ticket fails" {
+  [ -n "${FACTORY_CTX:-}" ] || skip "no dev cluster context set"
+  local brand="${TEST_BRAND:-korczewski}"
+  ext=$(seed_test_feature "$brand" "tests/fixtures/sf-test-slots-$$-a.txt")
+  run env BRAND="$brand" bash scripts/factory/slots.sh claim "$ext" 1
+  [ "$status" -eq 0 ]
+  [ "$output" = "1" ]
+  run env BRAND="$brand" bash scripts/factory/slots.sh claim "$ext" 2
+  [ "$status" -eq 1 ]                       # already slotted → claim fails
+  run env BRAND="$brand" bash scripts/factory/slots.sh release "$ext"
+  [ "$status" -eq 0 ]
+}
+
+# ── FA-SF-24-queue ──────────────────────────────────────────────#
+# FA-SF-24: queue.sh lists backlog features as ordered JSON.
+
+@test "FA-SF-24: dry-resolve works" {
+  run env BRAND=mentolder FACTORY_DRY_RESOLVE=1 bash scripts/factory/queue.sh
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"ns=workspace"* ]]
+}
+
+@test "FA-SF-24: a seeded backlog feature appears in the queue JSON" {
+  [ -n "${FACTORY_CTX:-}" ] || skip "no dev cluster context set"
+  local brand="${TEST_BRAND:-korczewski}"
+  ext=$(seed_test_feature "$brand" "tests/fixtures/sf-test-queue-$$-a.txt")
+  run env BRAND="$brand" bash scripts/factory/queue.sh
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e --arg e "$ext" 'any(.[]; .external_id == $e)'
+}
+
+# ── FA-SF-25-schedule ───────────────────────────────────────────#
+# FA-SF-25: schedule.sh emits a launch plan and claims slots.
+
+@test "FA-SF-25: dry-resolve works" {
+  run env BRAND=mentolder FACTORY_DRY_RESOLVE=1 bash scripts/factory/schedule.sh
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-25: two disjoint backlog features both get scheduled with slots" {
+  [ -n "${FACTORY_CTX:-}" ] || skip "no dev cluster context set"
+  local brand="${TEST_BRAND:-korczewski}"
+  e1=$(seed_test_feature "$brand" "tests/fixtures/sf-test-sched-$$-a.txt")
+  e2=$(seed_test_feature "$brand" "tests/fixtures/sf-test-sched-$$-b.txt")
+  run env BRAND="$brand" FACTORY_GLOBAL_CAP=3 bash scripts/factory/schedule.sh
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e --arg e "$e1" 'any(.[]; .external_id == $e and (.slot|type=="number"))'
+  echo "$output" | jq -e --arg e "$e2" 'any(.[]; .external_id == $e)'
+}
+
+@test "FA-SF-25: global cap of 1 schedules at most one feature" {
+  [ -n "${FACTORY_CTX:-}" ] || skip "no dev cluster context set"
+  local brand="${TEST_BRAND:-korczewski}"
+  seed_test_feature "$brand" "tests/fixtures/sf-test-cap-$$-a.txt" >/dev/null
+  seed_test_feature "$brand" "tests/fixtures/sf-test-cap-$$-b.txt" >/dev/null
+  run env BRAND="$brand" FACTORY_GLOBAL_CAP=1 bash scripts/factory/schedule.sh
+  [ "$status" -eq 0 ]
+  count=$(echo "$output" | jq 'length')
+  [ "$count" -le 1 ]
+}
+
+# ── FA-SF-26-watchdog ───────────────────────────────────────────#
+# FA-SF-26: watchdog escalates stale in_progress features.
+
+@test "FA-SF-26: dry-resolve works" {
+  run env BRAND=mentolder FACTORY_DRY_RESOLVE=1 bash scripts/factory/watchdog.sh
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-26: a stale in_progress feature is returned to triage and its slot freed" {
+  [ -n "${FACTORY_CTX:-}" ] || skip "no dev cluster context set"
+  local brand="${TEST_BRAND:-korczewski}"
+  ext=$(seed_test_feature "$brand" "tests/fixtures/sf-test-wd-$$-a.txt")
+  env BRAND="$brand" bash scripts/factory/slots.sh claim "$ext" 1 >/dev/null
+  # Derive the namespace from the brand (do not rely on a FACTORY_NS default).
+  local ns; case "$brand" in mentolder) ns=workspace ;; korczewski) ns=workspace-korczewski ;; esac
+  # Backdate updated_at by 40 minutes to simulate a hung pipeline.
+  pod=$(kubectl get pod -n "$ns" --context "$FACTORY_CTX" -l 'app in (shared-db, shared-db-dev)' -o name | head -1)
+  kubectl exec -i "$pod" -n "$ns" --context "$FACTORY_CTX" -c postgres -- \
+    psql -U website -d website -qtAc "UPDATE tickets.tickets SET updated_at = now() - interval '40 minutes' WHERE external_id='$ext';"
+  run env BRAND="$brand" FACTORY_STALE_MIN=30 bash scripts/factory/watchdog.sh
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e --arg e "$ext" 'any(.[]; . == $e)'
+  # Confirm status=triage and pipeline_slot cleared.
+  st=$(BRAND="$brand" TICKET_CTX="$FACTORY_CTX" bash scripts/ticket.sh get --id "$ext" | jq -r '.status')
+  [ "$st" = "triage" ]
+}
+
+# ── FA-SF-27-metrics ────────────────────────────────────────────#
+# FA-SF-27: metrics.sh summarizes v_factory_metrics and posts a comment.
+
+@test "FA-SF-27: dry-resolve works" {
+  run env BRAND=mentolder FACTORY_DRY_RESOLVE=1 bash scripts/factory/metrics.sh
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-27: posts a comment to a seeded metrics ticket" {
+  [ -n "${FACTORY_CTX:-}" ] || skip "no dev cluster context set"
+  local brand="${TEST_BRAND:-korczewski}"
+  # Use a throwaway test ticket as the metrics sink so we don't touch T000413.
+  sink=$(seed_test_feature "$brand" "tests/fixtures/sf-test-metrics-$$-a.txt")
+  run env BRAND="$brand" FACTORY_METRICS_TICKET="$sink" bash scripts/factory/metrics.sh
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "Comment added" ]] || [[ "$output" =~ "Factory metrics" ]]
+}
+
+# ── FA-SF-30-dispatcher-contract ────────────────────────────────#
+# FA-SF-30: structural contract for the dispatcher Workflow script (offline).
+DISPATCHER_SCRIPT="scripts/factory/dispatcher.js"
+
+@test "FA-SF-30: dispatcher.js exists and is syntactically valid JS" {
+  [ -f "$DISPATCHER_SCRIPT" ]
+  run node --check "$DISPATCHER_SCRIPT"
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-30: exports meta with the three expected phases" {
+  run grep -Eq "export const meta" "$DISPATCHER_SCRIPT"; [ "$status" -eq 0 ]
+  for p in Prep Launch Metrics; do
+    run grep -q "phase('$p')" "$DISPATCHER_SCRIPT"; [ "$status" -eq 0 ]
+  done
+}
+
+@test "FA-SF-30: wires the primitives (watchdog, schedule, metrics, ticket.sh get)" {
+  for needle in "watchdog.sh" "schedule.sh" "metrics.sh" "ticket.sh get"; do
+    run grep -q "$needle" "$DISPATCHER_SCRIPT"; [ "$status" -eq 0 ]
+  done
+}
+
+@test "FA-SF-30: launches pipeline.js via workflow scriptPath" {
+  run grep -q "scripts/factory/pipeline.js" "$DISPATCHER_SCRIPT"; [ "$status" -eq 0 ]
+  run grep -Eq "workflow\(" "$DISPATCHER_SCRIPT"; [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-30: resume-safe (uses args.timestamp, no Date.now()/Math.random())" {
+  run grep -q "args.timestamp\|A.timestamp" "$DISPATCHER_SCRIPT"; [ "$status" -eq 0 ]
+  run grep -Eq "Date\.now\(\)|Math\.random\(\)" "$DISPATCHER_SCRIPT"; [ "$status" -ne 0 ]
+}
+
+@test "FA-SF-30: schedules across BOTH brands" {
+  run grep -q "mentolder" "$DISPATCHER_SCRIPT"; [ "$status" -eq 0 ]
+  run grep -q "korczewski" "$DISPATCHER_SCRIPT"; [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-30: PREP gate reads hard guards fresh per tick via guards.sh" {
+  run grep -q "scripts/factory/guards.sh" "$DISPATCHER_SCRIPT"; [ "$status" -eq 0 ]
+  run grep -q "guard_killswitch_on" "$DISPATCHER_SCRIPT"; [ "$status" -eq 0 ]
+  run grep -q "guard_daily_cap_reached" "$DISPATCHER_SCRIPT"; [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-30: PREP gate is fail-closed (drops the brand from launch on guard trip / read error)" {
+  run grep -Eq "fail-closed|fail closed" "$DISPATCHER_SCRIPT"; [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-30: captures the parallel() launch result (not discarded)" {
+  run grep -Eq "const +results +=.*parallel\(|= await parallel\(" "$DISPATCHER_SCRIPT"; [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-30: post-launch escalation loads PushNotification via ToolSearch and notifies on error/blocked" {
+  run grep -q "ToolSearch select:PushNotification" "$DISPATCHER_SCRIPT"; [ "$status" -eq 0 ]
+  run grep -Eq "\.error|status === 'blocked'|status: *'blocked'|blocked" "$DISPATCHER_SCRIPT"; [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-30: agent() opts do NOT pin a model (T000543/#1466 — inherit session model via run-dispatcher.sh)" {
+  # T000519/#1430 fixed the DeepSeek 400 by unsetting CLAUDE_CODE_EFFORT_LEVEL in wakeup.sh
+  # and run-dispatcher.sh, so the ambient config no longer carries reasoning_effort.
+  # T000543/#1466 then intentionally removed the model: pins so the dispatcher inherits the
+  # session model from the invoker (DeepSeek or Anthropic), keeping dispatch flexible.
+  # Guard: verify all 3 agent labels are present but none carry a hard model: pin.
+  labels=$(grep -cE "label: '(prep|escalate|metrics)'" "$DISPATCHER_SCRIPT")
+  [ "$labels" -eq 3 ]
+  pinned=$(grep -E "label: '(prep|escalate|metrics)'" "$DISPATCHER_SCRIPT" | grep "model:" | wc -l)
+  [ "$pinned" -eq 0 ]
+}
+
+# ── FA-SF-31-workflow-entrypoint ────────────────────────────────#
+# FA-SF-31: factory Workflow scripts must NOT wrap their body in a fire-and-forget
+# IIFE. The harness runs the script body and treats the run as complete when the
+# top-level statements finish; a `;(async()=>{…})()` body is never awaited, so no
+# agent() runs and the return is lost (verified: IIFE → 0 agents/22ms/undefined,
+# top-level await → agents run + return propagates). Guard both runnable scripts.
+
+@test "FA-SF-31: pipeline.js has no fire-and-forget async IIFE wrapper" {
+  run grep -Eq '\(async[[:space:]]*\([[:space:]]*\)[[:space:]]*=>' scripts/factory/pipeline.js
+  [ "$status" -ne 0 ]
+  run grep -Eq '^[[:space:]]*\}\)\(\)[[:space:]]*$' scripts/factory/pipeline.js
+  [ "$status" -ne 0 ]
+}
+
+@test "FA-SF-31: dispatcher.js has no fire-and-forget async IIFE wrapper" {
+  run grep -Eq '\(async[[:space:]]*\([[:space:]]*\)[[:space:]]*=>' scripts/factory/dispatcher.js
+  [ "$status" -ne 0 ]
+  run grep -Eq '^[[:space:]]*\}\)\(\)[[:space:]]*$' scripts/factory/dispatcher.js
+  [ "$status" -ne 0 ]
+}
+
+@test "FA-SF-31: both scripts still parse and use top-level await" {
+  run node --check scripts/factory/pipeline.js;   [ "$status" -eq 0 ]
+  run node --check scripts/factory/dispatcher.js; [ "$status" -eq 0 ]
+  run grep -Eq 'await (agent|workflow|parallel|pipeline)\(' scripts/factory/pipeline.js;   [ "$status" -eq 0 ]
+  run grep -Eq 'await (agent|workflow|parallel|pipeline)\(' scripts/factory/dispatcher.js; [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-31: pipeline.js has a dry-run branch that does NOT merge/deploy" {
+  run grep -Eq 'dry_run|FACTORY_DRY_RUN|DRY_RUN' scripts/factory/pipeline.js
+  [ "$status" -eq 0 ]
+  # In the dry-run branch the deploy agent must be guarded: assert a DRY_RUN const exists
+  run grep -Eq 'const DRY_RUN' scripts/factory/pipeline.js
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-31: pipeline.js has a plan-reuse entrypoint" {
+  run grep -Eq 'REUSE|plan_path|WORK_BRANCH' scripts/factory/pipeline.js; [ "$status" -eq 0 ]
+}
+
+# ── FA-SF-32-classify-paths ─────────────────────────────────────#
+# FA-SF-32: shared-state allowlist + classify-paths.sh escalate-class detection.
+
+@test "FA-SF-32: shared-state-allowlist.txt exists with the four required prefixes" {
+  local f="scripts/factory/shared-state-allowlist.txt"
+  [ -f "$f" ]
+  grep -qx 'k3d/' "$f"
+  grep -qx 'prod' "$f"
+  grep -qx 'environments/' "$f"
+  grep -qx 'Taskfile' "$f"
+}
+
+@test "FA-SF-32: k3d/ path is escalate-class (allowlist prefix)" {
+  source scripts/factory/classify-paths.sh
+  run paths_are_escalate_class "k3d/website.yaml"
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-32: prod-fleet path is escalate-class (prefix 'prod')" {
+  source scripts/factory/classify-paths.sh
+  run paths_are_escalate_class "prod-fleet/mentolder/kustomization.yaml"
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-32: a .sql file is escalate-class" {
+  source scripts/factory/classify-paths.sh
+  run paths_are_escalate_class "website/src/db/migrate.sql"
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-32: a path containing 'secret' is escalate-class" {
+  source scripts/factory/classify-paths.sh
+  run paths_are_escalate_class "environments/.secrets/mentolder.yaml"
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-32: a realm json is escalate-class" {
+  source scripts/factory/classify-paths.sh
+  run paths_are_escalate_class "k3d/realm-workspace-dev.json"
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-32: pure website src is NOT escalate-class" {
+  source scripts/factory/classify-paths.sh
+  run paths_are_escalate_class "website/src/pages/index.astro,website/src/lib/foo.ts"
+  [ "$status" -eq 1 ]
+}
+
+@test "FA-SF-32: mixed list with one shared-state path IS escalate-class" {
+  source scripts/factory/classify-paths.sh
+  run paths_are_escalate_class "website/src/lib/foo.ts,Taskfile.yml"
+  [ "$status" -eq 0 ]
+}
+
+# ── FA-SF-33-classify-failure ───────────────────────────────────#
+# FA-SF-33: classify-failure.sh maps a CI log to exactly one failure class.
+
+_cf() { source scripts/factory/classify-failure.sh; classify_failure "$TMPLOG"; }
+
+@test "FA-SF-33: psql/SQL error classifies as sql" {
+  printf 'psql: ERROR:  relation "tickets.foo" does not exist\n' > "$TMPLOG"
+  run _cf
+  [ "$status" -eq 0 ]
+  [ "$output" = "sql" ]
+}
+
+@test "FA-SF-33: kustomize build error classifies as manifest" {
+  printf 'Error: kustomize build failed: accumulating resources\n' > "$TMPLOG"
+  run _cf
+  [ "$output" = "manifest" ]
+}
+
+@test "FA-SF-33: sealed secret error classifies as secret" {
+  printf 'no key could decrypt secret (sealedsecret)\n' > "$TMPLOG"
+  run _cf
+  [ "$output" = "secret" ]
+}
+
+@test "FA-SF-33: keycloak realm import error classifies as realm" {
+  printf 'failed to import realm realm-workspace-dev.json\n' > "$TMPLOG"
+  run _cf
+  [ "$output" = "realm" ]
+}
+
+@test "FA-SF-33: vitest failure classifies as test" {
+  printf '1 failed | 12 passed (vitest)\nFAIL src/lib/foo.test.ts\n' > "$TMPLOG"
+  run _cf
+  [ "$output" = "test" ]
+}
+
+@test "FA-SF-33: eslint failure classifies as lint" {
+  printf '/website/src/foo.ts\n  3:1  error  Missing semicolon  eslint\n' > "$TMPLOG"
+  run _cf
+  [ "$output" = "lint" ]
+}
+
+@test "FA-SF-33: github actions step failure classifies as ci" {
+  printf '##[error]Process completed with exit code 1.\n' > "$TMPLOG"
+  run _cf
+  [ "$output" = "ci" ]
+}
+
+@test "FA-SF-33: unrecognised log classifies as other" {
+  printf 'all good, nothing to report here\n' > "$TMPLOG"
+  run _cf
+  [ "$output" = "other" ]
+}
+
+@test "FA-SF-33: missing log file classifies as other" {
+  run bash -c 'source scripts/factory/classify-failure.sh; classify_failure /nonexistent/path.log'
+  [ "$output" = "other" ]
+}
+
+@test "FA-SF-33: stale-artifact freshness failure classifies as freshness" {
+  # The fixture names route-manifest.json on purpose: freshness must win over the
+  # `manifest` class (the word 'manifest' appears in the stale file path).
+  printf "  ✗ website/src/data/route-manifest.json is stale — run 'task freshness:regenerate' locally and commit\nERROR: 1 generated artifact(s) are stale (see above).\n" > "$TMPLOG"
+  run _cf
+  [ "$status" -eq 0 ]
+  [ "$output" = "freshness" ]
+}
+
+# ── FA-SF-34-prefix-conflict ────────────────────────────────────#
+# FA-SF-34: directory-prefix conflict heuristic regression.
+#   - two website/src/pages/ features stay PARALLEL (no conflict)
+#   - two k3d/ features in the same dir SERIALIZE (conflict via prefix branch)
+
+@test "FA-SF-34: two website/src/pages features do NOT conflict (stay parallel)" {
+  [ -n "${FACTORY_CTX:-}" ] || skip "no dev cluster context set"
+  local brand="${TEST_BRAND:-korczewski}"
+  local existing
+  existing=$(seed_test_feature "$brand" "website/src/pages/foo.astro")
+  run env BRAND="$brand" FACTORY_CTX="$FACTORY_CTX" \
+    bash scripts/factory/conflict-check.sh "T999998" "website/src/pages/bar.astro"
+  [ "$status" -eq 0 ]
+  [ "$output" = "[]" ]
+}
+
+@test "FA-SF-34: two k3d/ features in same dir DO conflict (serialize)" {
+  [ -n "${FACTORY_CTX:-}" ] || skip "no dev cluster context set"
+  local brand="${TEST_BRAND:-korczewski}"
+  local existing
+  existing=$(seed_test_feature "$brand" "k3d/website.yaml")
+  run env BRAND="$brand" FACTORY_CTX="$FACTORY_CTX" \
+    bash scripts/factory/conflict-check.sh "T999997" "k3d/brett.yaml"
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "$existing" ]]
+}
+
+@test "FA-SF-34: exact-overlap base branch still conflicts (regression on @>)" {
+  [ -n "${FACTORY_CTX:-}" ] || skip "no dev cluster context set"
+  local brand="${TEST_BRAND:-korczewski}"
+  local existing
+  existing=$(seed_test_feature "$brand" "website/src/lib/shared.ts")
+  run env BRAND="$brand" FACTORY_CTX="$FACTORY_CTX" \
+    bash scripts/factory/conflict-check.sh "T999996" "website/src/lib/shared.ts"
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "$existing" ]]
+}
+
+# ── FA-SF-35-factory-cli ────────────────────────────────────────#
+# FA-SF-35: offline arg-validation for Phase 3 factory ticket.sh subcommands. [T000413]
+
+@test "FA-SF-35: retry-count requires an action verb" {
+  run bash scripts/ticket.sh retry-count --id T000001
+  [ "$status" -eq 2 ]
+  [[ "$output" =~ "get|incr|reset" ]]
+}
+@test "FA-SF-35: retry-count get requires --id" {
+  run bash scripts/ticket.sh retry-count get
+  [ "$status" -eq 2 ]
+  [[ "$output" =~ "--id" ]]
+}
+@test "FA-SF-35: factory-control set requires --key and --value" {
+  run bash scripts/ticket.sh factory-control set --key killswitch
+  [ "$status" -eq 2 ]
+  [[ "$output" =~ "--value" ]]
+}
+@test "FA-SF-35: factory-control get requires --key" {
+  run bash scripts/ticket.sh factory-control get
+  [ "$status" -eq 2 ]
+  [[ "$output" =~ "--key" ]]
+}
+@test "FA-SF-35: dispatch usage lists factory-control" {
+  run bash scripts/ticket.sh
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "factory-control" ]]
+}
+
+@test "FA-SF-35: dryrun-mark requires --id" {
+  run bash scripts/ticket.sh dryrun-mark
+  [ "$status" -eq 2 ]
+  [[ "$output" =~ "--id" ]]
+}
+@test "FA-SF-35: dryrun-check requires --id" {
+  run bash scripts/ticket.sh dryrun-check
+  [ "$status" -eq 2 ]
+  [[ "$output" =~ "--id" ]]
+}
+@test "FA-SF-35: dispatch usage lists dryrun-mark" {
+  run bash scripts/ticket.sh
+  [[ "$output" =~ "dryrun-mark" ]]
+}
+
+@test "FA-SF-35: feature-flag set requires --brand --key --enabled" {
+  run bash scripts/ticket.sh feature-flag set --brand mentolder --key new-hero
+  [ "$status" -eq 2 ]
+  [[ "$output" =~ "--enabled" ]]
+}
+@test "FA-SF-35: feature-flag set rejects a non-boolean --enabled" {
+  run bash scripts/ticket.sh feature-flag set --brand mentolder --key x --enabled maybe
+  [ "$status" -eq 2 ]
+  [[ "$output" =~ "true|false" ]]
+}
+@test "FA-SF-35: feature-flag get requires --brand and --key" {
+  run bash scripts/ticket.sh feature-flag get --brand mentolder
+  [ "$status" -eq 2 ]
+  [[ "$output" =~ "--key" ]]
+}
+@test "FA-SF-35: feature-flag list requires --brand" {
+  run bash scripts/ticket.sh feature-flag list
+  [ "$status" -eq 2 ]
+  [[ "$output" =~ "--brand" ]]
+}
+@test "FA-SF-35: dispatch usage lists feature-flag" {
+  run bash scripts/ticket.sh
+  [[ "$output" =~ "feature-flag" ]]
+}
+
+# ── FA-SF-36-guards ─────────────────────────────────────────────#
+# FA-SF-36: structural contract for scripts/factory/guards.sh (offline, no cluster).
+GUARDS_SCRIPT="scripts/factory/guards.sh"
+
+@test "FA-SF-36: guards.sh exists and passes bash -n" {
+  [ -f "$GUARDS_SCRIPT" ]
+  run bash -n "$GUARDS_SCRIPT"
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-36: defines the four guard functions" {
+  for fn in guard_killswitch_on guard_daily_cap_reached guard_dryrun_ok guard_check_diff_size; do
+    run grep -Eq "^${fn}\(\)" "$GUARDS_SCRIPT"; [ "$status" -eq 0 ]
+  done
+}
+
+@test "FA-SF-36: sources lib.sh for factory_psql (no inline kubectl)" {
+  run grep -Eq 'source .*lib\.sh|\. .*lib\.sh' "$GUARDS_SCRIPT"; [ "$status" -eq 0 ]
+  run grep -q "factory_psql" "$GUARDS_SCRIPT"; [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-36: kill-switch reads factory_control via ticket.sh factory-control get" {
+  run grep -q "factory-control get" "$GUARDS_SCRIPT"; [ "$status" -eq 0 ]
+  run grep -q "killswitch" "$GUARDS_SCRIPT"; [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-36: daily-cap honours FACTORY_DAILY_DEPLOY_CAP" {
+  run grep -q "FACTORY_DAILY_DEPLOY_CAP" "$GUARDS_SCRIPT"; [ "$status" -eq 0 ]
+}
+
+# ── FA-SF-37-retry ──────────────────────────────────────────────#
+# FA-SF-37-retry — structured ≤2 self-healing retry loop in pipeline.js
+PJS="$BATS_TEST_DIRNAME/../../scripts/factory/pipeline.js"
+
+@test "FA-SF-37-retry: pipeline.js lints clean (node --check)" {
+  run node --check "$PJS"
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-37-retry: old LLM prose is gone" {
+  run grep -F 'after 2 fix attempts' "$PJS"
+  [ "$status" -ne 0 ]
+}
+
+@test "FA-SF-37-retry: reads retry_count via ticket.sh (no raw SQL)" {
+  run grep -qE 'ticket\.sh retry-count get' "$PJS"
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-37-retry: two-gated classification (failure-class AND path-class)" {
+  run grep -qE 'classify-failure\.sh' "$PJS"
+  [ "$status" -eq 0 ]
+  run grep -qE 'paths_are_escalate_class|classify-paths\.sh' "$PJS"
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-37-retry: auto-fix gated to ci/test/lint only" {
+  run grep -qE 'ci.*test.*lint|\{ci,test,lint\}|ci/test/lint' "$PJS"
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-37-retry: at retry_count>=2 → blocked + PushNotification" {
+  run grep -qE 'retry_count.*2|retry-count.*incr' "$PJS"
+  [ "$status" -eq 0 ]
+  run grep -qE 'PushNotification' "$PJS"
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-37-retry: Verify HIGH/CRITICAL immediate-block stays separate" {
+  run grep -qE "reason: 'review-findings'" "$PJS"
+  [ "$status" -eq 0 ]
+}
+
+# ── build-loop (ralph-wiggum) tests ──
+BLS="$BATS_TEST_DIRNAME/../../scripts/factory/build-loop.sh"
+
+@test "FA-SF-37-retry: build-loop.sh sourcet sauber" {
+  run bash -n "$BLS"
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-37-retry: build_loop_sig_hash: Rauschen ändert Hash nicht" {
+  source "$BLS"
+  local log1; log1=$(mktemp); local log2; log2=$(mktemp)
+  printf 'Error: test failed\n/home/user/src/foo.ts\n[500ms]\n' > "$log1"
+  printf 'Error: test failed\n/home/other/src/bar.ts\n[200ms]\n' > "$log2"
+  local h1; h1=$(build_loop_sig_hash "$log1")
+  local h2; h2=$(build_loop_sig_hash "$log2")
+  rm -f "$log1" "$log2"
+  [ "$h1" = "$h2" ]
+}
+
+@test "FA-SF-37-retry: build_loop_sig_hash: identischer Log → gleicher Hash" {
+  source "$BLS"
+  local log; log=$(mktemp)
+  printf 'Error: test failed\n' > "$log"
+  local h1; h1=$(build_loop_sig_hash "$log")
+  local h2; h2=$(build_loop_sig_hash "$log")
+  rm -f "$log"
+  [ "$h1" = "$h2" ]
+}
+
+@test "FA-SF-37-retry: build_loop_decide: allowed classify → continue" {
+  source "$BLS"
+  run build_loop_decide "0" "3" "" "test" "" "abc"
+  echo "$output" | head -1 | grep -qE '^continue$'
+}
+
+@test "FA-SF-37-retry: build_loop_decide: disallowed classify → escalate-gate" {
+  source "$BLS"
+  run build_loop_decide "0" "3" "" "secret" "" "abc"
+  echo "$output" | head -1 | grep -qE '^abort:escalate-gate$'
+}
+
+@test "FA-SF-37-retry: build_loop_decide: max iterations → abort" {
+  source "$BLS"
+  run build_loop_decide "3" "3" "" "test" "" "abc"
+  echo "$output" | head -1 | grep -qE '^abort:max-iterations$'
+}
+
+@test "FA-SF-37-retry: build_loop_decide: no-progress → abort" {
+  source "$BLS"
+  run build_loop_decide "1" "3" "deadbeef" "test" "" "deadbeef"
+  echo "$output" | head -1 | grep -qE '^abort:no-progress$'
+}
+
+@test "FA-SF-37-retry: build_loop_decide: escalate paths → escalate-gate" {
+  source "$BLS"
+  run build_loop_decide "0" "3" "" "test" "k3d/foo.yaml" "abc"
+  echo "$output" | head -1 | grep -qE '^abort:escalate-gate$'
+}
+
+@test "FA-SF-37-retry: build_loop.cjs lints clean (node --check)" {
+  run node --check "$BATS_TEST_DIRNAME/../../scripts/factory/build-loop.cjs"
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-37-retry: build-loop unit tests pass" {
+  run node "$BATS_TEST_DIRNAME/../../scripts/factory/build-loop.test.cjs"
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-37-retry: pipeline.js hat BL.require" {
+  run grep -qE "require.*build-loop" "$PJS"
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-37-retry: pipeline.js nutzt runTaskVerifyLoop" {
+  run grep -qE "runTaskVerifyLoop" "$PJS"
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-37-retry: build-loop.cjs exportiert runTaskVerifyLoop" {
+  run node -e "const m = require('$BATS_TEST_DIRNAME/../../scripts/factory/build-loop.cjs'); console.log(typeof m.runTaskVerifyLoop)"
+  [ "$status" -eq 0 ]
+  [[ "$output" == "function" ]]
+}
+
+# ── precompact-prune tests (was FA-SF-54) ──
+
+@test "FA-SF-37-retry: precompact-prune fehlendes Transcript → exit 0" {
+  run bash scripts/hooks/precompact-prune.sh <<< '{}'
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-37-retry: precompact-prune leeres Transcript → exit 0" {
+  local t; t=$(mktemp -d); trap "rm -rf '$t'" EXIT
+  local f="$t/transcript.jsonl"
+  : > "$f"
+  run bash -c "echo '{\"transcript_path\": \"$f\"}' | bash scripts/hooks/precompact-prune.sh"
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-37-retry: precompact-prune obsoletes tool_result → pruned" {
+  local t; t=$(mktemp -d); trap "rm -rf '$t'" EXIT
+  local f="$t/transcript.jsonl"
+  cat > "$f" <<'JSON'
+{"type":"tool_use","tool_use_id":"call-init"}
+{"type":"tool_result","tool_use_id":"call-1","content":"very long obsolete output","metadata":{"original_tool":"Read"}}
+{"type":"tool_use","tool_use_id":"call-2"}
+{"type":"tool_result","tool_use_id":"call-2","content":"newer read","metadata":{"original_tool":"Read"}}
+{"type":"tool_use","tool_use_id":"call-3"}
+{"type":"tool_result","tool_use_id":"call-3","content":"even newer","metadata":{"original_tool":"Bash"}}
+JSON
+  run bash -c "echo '{\"script_path\": \"$f\"}' | bash scripts/hooks/precompact-prune.sh 2>/dev/null || true"
+  run bash -c "echo '{\"transcript_path\": \"$f\"}' | bash scripts/hooks/precompact-prune.sh"
+  [ "$status" -eq 0 ]
+  run jq -r 'select(.type == "tool_result") | select(.content | startswith("[pruned:")) | .content' "$f"
+  [ -n "$output" ]
+}
+
+@test "FA-SF-37-retry: precompact-prune jüngstes Output unangetastet" {
+  local t; t=$(mktemp -d); trap "rm -rf '$t'" EXIT
+  local f="$t/transcript.jsonl"
+  cat > "$f" <<'JSON'
+{"type":"tool_use","tool_use_id":"call-init"}
+{"type":"tool_result","tool_use_id":"call-1","content":"recent output","metadata":{"original_tool":"Read"}}
+{"type":"assistant","content":[{"type":"tool_use","tool_use_id":"call-1"}]}
+{"type":"tool_use","tool_use_id":"call-2"}
+{"type":"tool_result","tool_use_id":"call-2","content":"other","metadata":{"original_tool":"Bash"}}
+JSON
+  run bash -c "echo '{\"transcript_path\": \"$f\"}' | bash scripts/hooks/precompact-prune.sh"
+  [ "$status" -eq 0 ]
+  run jq -r 'select(.type == "tool_result") | select(.tool_use_id == "call-1") | .content' "$f"
+  [[ "$output" == "recent output" ]]
+}
+
+@test "FA-SF-37-retry: precompact-prune Idempotenz" {
+  local t; t=$(mktemp -d); trap "rm -rf '$t'" EXIT
+  local f="$t/transcript.jsonl"
+  cat > "$f" <<'JSON'
+{"type":"tool_use","tool_use_id":"call-init"}
+{"type":"tool_result","tool_use_id":"call-1","content":"long obsolete read","metadata":{"original_tool":"Grep"}}
+{"type":"tool_use","tool_use_id":"call-2"}
+{"type":"tool_result","tool_use_id":"call-2","content":"newer","metadata":{"original_tool":"Read"}}
+JSON
+  run bash -c "echo '{\"transcript_path\": \"$f\"}' | bash scripts/hooks/precompact-prune.sh"
+  [ "$status" -eq 0 ]
+  local h1; h1=$(sha256sum "$f" | cut -d' ' -f1)
+  run bash -c "echo '{\"transcript_path\": \"$f\"}' | bash scripts/hooks/precompact-prune.sh"
+  [ "$status" -eq 0 ]
+  local h2; h2=$(sha256sum "$f" | cut -d' ' -f1)
+  [ "$h2" = "$h1" ]
+}
+
+@test "FA-SF-37-retry: precompact-prune alle Zeilen valides JSON" {
+  local t; t=$(mktemp -d); trap "rm -rf '$t'" EXIT
+  local f="$t/transcript.jsonl"
+  cat > "$f" <<'JSON'
+{"type":"tool_use","tool_use_id":"call-init"}
+{"type":"tool_result","tool_use_id":"call-1","content":"long content","metadata":{"original_tool":"Bash"}}
+{"type":"tool_use","tool_use_id":"call-2"}
+{"type":"tool_result","tool_use_id":"call-2","content":"more","metadata":{"original_tool":"Read"}}
+JSON
+  run bash -c "echo '{\"transcript_path\": \"$f\"}' | bash scripts/hooks/precompact-prune.sh"
+  [ "$status" -eq 0 ]
+  run bash -c "jq -e . < '$f' >/dev/null 2>&1"
+  [ "$status" -eq 0 ]
+}
+
+# ── usage-report tests (was FA-SF-55) ──
+
+@test "FA-SF-37-retry: usage-report fehlende Dirs → Exit 0" {
+  local t; t=$(mktemp -d); trap "rm -rf '$t'" EXIT
+  export CLAUDE_USAGE_DIR="$t/nonexistent"
+  export OPENCLAW_USAGE_DIR="$t/nonexistent"
+  run bash scripts/factory/usage-report.sh
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-37-retry: usage-report Fixtures → Summen pro Tag" {
+  local t; t=$(mktemp -d); trap "rm -rf '$t'" EXIT
+  export CLAUDE_USAGE_DIR="$t/claude"; mkdir "$CLAUDE_USAGE_DIR"
+  export OPENCLAW_USAGE_DIR="$t/openclaw"; mkdir "$OPENCLAW_USAGE_DIR"
+  cat > "$CLAUDE_USAGE_DIR/usage-1.jsonl" <<'JSON'
+{"timestamp":"2026-06-15T10:00:00Z","model":"claude-sonnet-4","tokens_in":100,"tokens_out":50,"cost_usd":0.002}
+{"timestamp":"2026-06-15T11:00:00Z","model":"claude-sonnet-4","tokens_in":200,"tokens_out":100,"cost_usd":0.004}
+JSON
+  run bash scripts/factory/usage-report.sh
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"2026-06-15"* ]]
+  [[ "$output" == *"claude-sonnet-4"* ]]
+}
+
+@test "FA-SF-37-retry: usage-report --json valides JSON" {
+  local t; t=$(mktemp -d); trap "rm -rf '$t'" EXIT
+  export CLAUDE_USAGE_DIR="$t/claude"; mkdir "$CLAUDE_USAGE_DIR"
+  export OPENCLAW_USAGE_DIR="$t/openclaw"; mkdir "$OPENCLAW_USAGE_DIR"
+  cat > "$CLAUDE_USAGE_DIR/usage-1.jsonl" <<'JSON'
+{"timestamp":"2026-06-14T10:00:00Z","model":"claude-haiku-4","tokens_in":50,"tokens_out":25,"cost_usd":0.001}
+JSON
+  run bash scripts/factory/usage-report.sh --json
+  [ "$status" -eq 0 ]
+  run jq -e . <<< "$output"
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-37-retry: usage-report --otel ohne Endpoint → no-op" {
+  local t; t=$(mktemp -d); trap "rm -rf '$t'" EXIT
+  export CLAUDE_USAGE_DIR="$t/claude"; mkdir "$CLAUDE_USAGE_DIR"
+  export OPENCLAW_USAGE_DIR="$t/openclaw"; mkdir "$OPENCLAW_USAGE_DIR"
+  cat > "$CLAUDE_USAGE_DIR/usage-1.jsonl" <<'JSON'
+{"timestamp":"2026-06-13T10:00:00Z","model":"claude-opus-4","tokens_in":300,"tokens_out":150,"cost_usd":0.015}
+JSON
+  unset OTEL_EXPORTER_OTLP_ENDPOINT
+  run bash scripts/factory/usage-report.sh --otel
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-37-retry: usage-report unbekannte Felder kein Crash" {
+  local t; t=$(mktemp -d); trap "rm -rf '$t'" EXIT
+  export CLAUDE_USAGE_DIR="$t/claude"; mkdir "$CLAUDE_USAGE_DIR"
+  export OPENCLAW_USAGE_DIR="$t/openclaw"; mkdir "$OPENCLAW_USAGE_DIR"
+  cat > "$CLAUDE_USAGE_DIR/usage-1.jsonl" <<'JSON'
+{"weird_field":true,"unknown":"data"}
+{"timestamp":"2026-06-12T10:00:00Z","model":"claude-sonnet-4","tokens_in":100,"tokens_out":50,"cost_usd":0.002}
+JSON
+  run bash scripts/factory/usage-report.sh
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"2026-06-12"* ]]
+}
+
+@test "FA-SF-37-retry: usage-report beide Tools gemischt" {
+  local t; t=$(mktemp -d); trap "rm -rf '$t'" EXIT
+  export CLAUDE_USAGE_DIR="$t/claude"; mkdir "$CLAUDE_USAGE_DIR"
+  export OPENCLAW_USAGE_DIR="$t/openclaw"; mkdir "$OPENCLAW_USAGE_DIR"
+  cat > "$CLAUDE_USAGE_DIR/usage-1.jsonl" <<'JSON'
+{"timestamp":"2026-06-10T10:00:00Z","model":"claude-sonnet-4","tokens_in":100,"tokens_out":50,"cost_usd":0.002}
+JSON
+  cat > "$OPENCLAW_USAGE_DIR/usage-1.jsonl" <<'JSON'
+{"timestamp":"2026-06-10T11:00:00Z","model":"claude-sonnet-4","tokens_in":50,"tokens_out":25,"cost_usd":0.001}
+JSON
+  run bash scripts/factory/usage-report.sh
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"claude-code"* ]]
+  [[ "$output" == *"openclaw"* ]]
+}
+
+# ── FA-SF-38-canary ─────────────────────────────────────────────#
+# FA-SF-38 — Layer-4 canary/rollback contract (observe_prod in feature-promote.sh)
+CANARY_SCRIPT="$BATS_TEST_DIRNAME/../../scripts/feature-promote.sh"
+PHASES_SCRIPT="$BATS_TEST_DIRNAME/../../scripts/lib/promote-phases.sh"
+
+@test "FA-SF-38: feature-promote.sh is syntactically valid bash" {
+  run bash -n "$CANARY_SCRIPT"
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-38: observe_prod() exists" {
+  run grep -qE '^observe_prod\(\)' "$PHASES_SCRIPT"
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-38: observe_prod targets the LIVE site, not dev" {
+  run grep -E 'web\.\$\{?brand|web\.\$\{cluster|web\.mentolder\.de|web\.korczewski\.de' "$PHASES_SCRIPT"
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-38: observe_prod captures pre-deploy revision before rollback" {
+  run grep -qE 'rollout history|--to-revision' "$PHASES_SCRIPT"
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-38: observe_prod context comes from env-resolve, never dead prod_ctx" {
+  run grep -qE 'env-resolve\.sh|ENV_CONTEXT' "$PHASES_SCRIPT"
+  [ "$status" -eq 0 ]
+}
+
+# ── FA-SF-39-canary-wire ────────────────────────────────────────#
+# FA-SF-39-canary-wire — Deploy-phase canary wiring in pipeline.js
+PJS="$BATS_TEST_DIRNAME/../../scripts/factory/pipeline.js"
+
+@test "FA-SF-39-wire: pipeline.js lints clean" {
+  run node --check "$PJS"
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-39-wire: Deploy invokes observe_prod per brand" {
+  run grep -qE 'observe_prod' "$PJS"
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-39-wire: canary-red turns feature flag OFF via ticket.sh" {
+  run grep -qE 'feature-flag set .*--enabled false' "$PJS"
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-39-wire: canary-red fires PushNotification" {
+  run grep -qE 'canary|Canary' "$PJS"
+  [ "$status" -eq 0 ]
+  run grep -qE 'PushNotification' "$PJS"
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-39-wire: both brands observed (mentolder + korczewski)" {
+  run grep -qE 'mentolder' "$PJS"
+  [ "$status" -eq 0 ]
+  run grep -qE 'korczewski' "$PJS"
+  [ "$status" -eq 0 ]
+}
+
+# ── FA-SF-40-provision ──────────────────────────────────────────#
+# FA-SF-40: adaptive agent-provisioning (offline, pure function). Wraps the
+# node:test suite and asserts the pure-module contract used by pipeline.js.
+
+@test "FA-SF-40: provision.js exists and is syntactically valid ESM" {
+  [ -f "$PROVISION_MOD" ]
+  run node --check "$PROVISION_MOD"
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-40: node --test provision suite passes" {
+  run node --test "$PROVISION_SUITE"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"# fail 0"* ]]
+}
+
+@test "FA-SF-40: exports the three contract functions" {
+  for fn in "export function chooseModel" "export function chooseEffort" "export function provision"; do
+    run grep -Fq "$fn" "$PROVISION_MOD"; [ "$status" -eq 0 ]
+  done
+}
+
+@test "FA-SF-40: review/security roles are pinned to opus (correctness-critical)" {
+  run grep -Eq "ALWAYS_OPUS_ROLES.*=.*new Set" "$PROVISION_MOD"; [ "$status" -eq 0 ]
+  run grep -q "'review'" "$PROVISION_MOD"; [ "$status" -eq 0 ]
+  run grep -q "'security'" "$PROVISION_MOD"; [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-40: context is compact-hint based (no raw-dump), GPU-gated similar-tickets" {
+  run grep -q "buildContextHints" "$PROVISION_MOD"; [ "$status" -eq 0 ]
+  run grep -q "gpuEmbeddings === true" "$PROVISION_MOD"; [ "$status" -eq 0 ]
+  run grep -q "similar-tickets" "$PROVISION_MOD"; [ "$status" -eq 0 ]
+}
+
+# ── FA-SF-41-wakeup ─────────────────────────────────────────────#
+# FA-SF-41 — Phase 3 persistent dispatcher: wakeup.sh structural contract (offline grep).
+# Verifies the deliberately-dumb headless wrapper carries only the dry_run policy.
+
+WAKEUP="${BATS_TEST_DIRNAME}/../../scripts/factory/wakeup.sh"
+SERVICE="${BATS_TEST_DIRNAME}/../../scripts/factory/factory.service"
+TIMER="${BATS_TEST_DIRNAME}/../../scripts/factory/factory.timer"
+TASKFILE="${BATS_TEST_DIRNAME}/../../Taskfile.factory.yml"
+
+@test "FA-SF-41: wakeup.sh exists and is bash -n clean" {
+  [ -f "$WAKEUP" ]
+  run bash -n "$WAKEUP"
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-41: wakeup.sh cd's to the repo before anything else" {
+  run grep -E '^[[:space:]]*cd[[:space:]]+"\$\{?REPO' "$WAKEUP"
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-41: wakeup.sh single-flights via flock, default lock /tmp/factory-tick.lock, overridable" {
+  # Default preserved, but the path is sourced from FACTORY_TICK_LOCK so tests
+  # (and parallel hosts) can isolate the single-flight lock. [T000523]
+  run grep -E 'FACTORY_TICK_LOCK:-/tmp/factory-tick\.lock' "$WAKEUP"
+  [ "$status" -eq 0 ]
+  run grep -F 'flock -n 9' "$WAKEUP"
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-41: wakeup.sh detects the git-crypt GITCRYPT magic to decide unlock" {
+  run grep -F 'GITCRYPT' "$WAKEUP"
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-41: wakeup.sh unlocks via task secrets:unlock (not raw git-crypt)" {
+  run grep -E 'task[[:space:]]+secrets:unlock' "$WAKEUP"
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-41: wakeup.sh calls headless claude with the Workflow tool allowlisted" {
+  # idle-retick: claude is called without exec (so the loop can continue after it)
+  run grep -E '"\$\{CLAUDE_BIN\}"[[:space:]]+-p' "$WAKEUP"
+  [ "$status" -eq 0 ]
+  run grep -E -- '--allowedTools' "$WAKEUP"
+  [ "$status" -eq 0 ]
+  run grep -F 'Workflow' "$WAKEUP"
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-41: wakeup.sh actually forwards -p + --allowedTools + --permission-mode to the exec'd claude (not dropped by a gamed comment)" {
+  # Behavioral guard for the line-continuation bug: a stub 'claude' records its
+  # argv; the wrapper must pass the FULL flag set, not just -p PROMPT.
+  tmp="$(mktemp -d)"
+  argfile="${tmp}/argv"
+  cat > "${tmp}/claude-stub" <<STUB
+#!/usr/bin/env bash
+printf '%s\n' "\$@" > "${argfile}"
+STUB
+  chmod +x "${tmp}/claude-stub"
+  # Isolate the single-flight lock (so a real autopilot tick holding the shared
+  # /tmp/factory-tick.lock can't false-red this) AND the env file (so a present
+  # ~/.config/factory/autopilot.env can't clobber FACTORY_CLAUDE_BIN). [T000523]
+  FACTORY_REPO="${tmp}" FACTORY_CLAUDE_BIN="${tmp}/claude-stub" FACTORY_DRY_RUN=true \
+    FACTORY_TICK_LOCK="${tmp}/tick.lock" FACTORY_ENV_FILE="${tmp}/no-env" run bash "$WAKEUP"
+  [ "$status" -eq 0 ]
+  run grep -q -- '-p' "${argfile}";              [ "$status" -eq 0 ]
+  run grep -q -- '--allowedTools' "${argfile}";  [ "$status" -eq 0 ]
+  run grep -qF 'Workflow' "${argfile}";          [ "$status" -eq 0 ]
+  run grep -q -- '--permission-mode' "${argfile}"; [ "$status" -eq 0 ]
+  run grep -qF 'acceptEdits' "${argfile}";       [ "$status" -eq 0 ]
+  rm -rf "${tmp}"
+}
+
+@test "FA-SF-41: wakeup.sh single-flight honors FACTORY_TICK_LOCK (hermetic, not the shared /tmp lock)" {
+  # Regression guard for the non-hermetic flock path [T000523]: hold an ISOLATED
+  # override lock and prove the wrapper skips on IT (not the shared /tmp lock).
+  # Pre-fix the wrapper ignored the override and flock'd /tmp/factory-tick.lock,
+  # so on a free host it would RUN and exec the stub → this test fails. Post-fix
+  # it skips cleanly without ever touching the stub.
+  tmp="$(mktemp -d)"
+  argfile="${tmp}/argv"
+  cat > "${tmp}/claude-stub" <<STUB
+#!/usr/bin/env bash
+printf '%s\n' "\$@" > "${argfile}"
+STUB
+  chmod +x "${tmp}/claude-stub"
+  lock="${tmp}/tick.lock"
+  exec 8>"${lock}"
+  flock -n 8   # hold the override lock for the duration of the run
+  FACTORY_REPO="${tmp}" FACTORY_CLAUDE_BIN="${tmp}/claude-stub" FACTORY_DRY_RUN=true \
+    FACTORY_TICK_LOCK="${lock}" FACTORY_ENV_FILE="${tmp}/no-env" run bash "$WAKEUP"
+  exec 8>&-
+  [ "$status" -eq 0 ]              # skip is a clean exit 0
+  [ ! -f "${argfile}" ]           # stub was NOT exec'd → single-flight honored the override
+  echo "$output" | grep -qF "${lock}"   # skip message names the override lock
+  rm -rf "${tmp}"
+}
+
+@test "FA-SF-41: wakeup.sh threads the dry_run policy into the dispatcher prompt" {
+  run grep -F 'dry_run' "$WAKEUP"
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-41: wakeup.sh names dispatcher.js as the nested Workflow script" {
+  run grep -F 'scripts/factory/dispatcher.js' "$WAKEUP"
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-41: factory.service is a oneshot that runs wakeup.sh" {
+  [ -f "$SERVICE" ]
+  run grep -E '^Type=oneshot' "$SERVICE"
+  [ "$status" -eq 0 ]
+  run grep -E '^ExecStart=.*scripts/factory/wakeup\.sh' "$SERVICE"
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-41: factory.service kills hung runs via RuntimeMaxSec" {
+  run grep -E '^RuntimeMaxSec=' "$SERVICE"
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-41: factory.timer re-arms after exit (OnUnitInactiveSec), not fixed-rate" {
+  [ -f "$TIMER" ]
+  run grep -E '^OnUnitInactiveSec=' "$TIMER"
+  [ "$status" -eq 0 ]
+  run grep -E '^OnCalendar=' "$TIMER"
+  [ "$status" -ne 0 ]   # must NOT be a fixed wall-clock schedule (would overlap long ticks)
+}
+
+@test "FA-SF-41: factory.timer survives missed ticks via Persistent=true" {
+  run grep -E '^Persistent=true' "$TIMER"
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-41: factory.timer binds factory.service and is wanted by timers.target" {
+  run grep -E '^Unit=factory\.service' "$TIMER"
+  [ "$status" -eq 0 ]
+  run grep -E '^WantedBy=timers\.target' "$TIMER"
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-41: Taskfile defines factory:autopilot install/uninstall/status" {
+  run grep -E '^[[:space:]]+autopilot:install:' "$TASKFILE"
+  [ "$status" -eq 0 ]
+  run grep -E '^[[:space:]]+autopilot:uninstall:' "$TASKFILE"
+  [ "$status" -eq 0 ]
+  run grep -E '^[[:space:]]+autopilot:status:' "$TASKFILE"
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-41: autopilot:install symlinks both units and enables the timer" {
+  run grep -F 'factory.timer' "$TASKFILE"
+  [ "$status" -eq 0 ]
+  run grep -F 'factory.service' "$TASKFILE"
+  [ "$status" -eq 0 ]
+  run grep -E 'systemctl --user enable --now factory\.timer' "$TASKFILE"
+  [ "$status" -eq 0 ]
+}
+
+README="${BATS_TEST_DIRNAME}/../../scripts/factory/README.md"
+
+@test "FA-SF-41: README documents the autopilot install task" {
+  run grep -F 'task factory:autopilot:install' "$README"
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-41: README states the cron-poll IS the trigger" {
+  run grep -iE 'cron-poll .*(is|ist) (the |der )?trigger' "$README"
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-41: README rejects CronCreate / remote / schedule as the dispatcher" {
+  run grep -F 'CronCreate' "$README"
+  [ "$status" -eq 0 ]
+  run grep -iE 'RemoteTrigger|/schedule' "$README"
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-41: README notes the inert (not consumed) pg_notify trigger" {
+  run grep -F 'pg_notify' "$README"
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-41: wakeup.sh supports idle-retick via FACTORY_IDLE_RETICK_ENABLED" {
+  run grep -F 'FACTORY_IDLE_RETICK_ENABLED' "$WAKEUP"
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-41: wakeup.sh checks both brand queues before retick" {
+  run grep -E 'BRAND=mentolder.*queue\.sh' "$WAKEUP"
+  [ "$status" -eq 0 ]
+  run grep -E 'BRAND=korczewski.*queue\.sh' "$WAKEUP"
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-41: wakeup.sh idle-retick exits cleanly when queue is empty" {
+  # Stub: records args and exits 0. FACTORY_REPO points to a tmp dir with no queue.sh,
+  # so the queue check returns 0 items → loop exits after one tick.
+  tmp="$(mktemp -d)"
+  argfile="${tmp}/argv"
+  cat > "${tmp}/claude-stub" <<STUB
+#!/usr/bin/env bash
+printf '%s\n' "\$@" > "${argfile}"
+STUB
+  chmod +x "${tmp}/claude-stub"
+  FACTORY_REPO="${tmp}" FACTORY_CLAUDE_BIN="${tmp}/claude-stub" FACTORY_DRY_RUN=true \
+    FACTORY_TICK_LOCK="${tmp}/tick.lock" FACTORY_ENV_FILE="${tmp}/no-env" \
+    FACTORY_IDLE_RETICK_ENABLED=true run bash "$WAKEUP"
+  [ "$status" -eq 0 ]
+  [ -f "${argfile}" ]   # claude was invoked exactly once
+  rm -rf "${tmp}"
+}
+
+@test "FA-SF-41: wakeup.sh skips idle-retick when FACTORY_IDLE_RETICK_ENABLED=false" {
+  run grep -E 'IDLE_RETICK.*true' "$WAKEUP"
+  [ "$status" -eq 0 ]   # confirms the break path exists when disabled
+}
+
+# ── FA-SF-42-dashboard-route ────────────────────────────────────#
+# FA-SF-42: /api/factory-metrics enforces the getSession+isAdmin 401 gate.
+
+ROUTE="${BATS_TEST_DIRNAME}/../../website/src/pages/api/factory-metrics.ts"
+
+@test "FA-SF-42: route exists and is server-rendered" {
+  [ -f "$ROUTE" ]
+  grep -q 'export const prerender = false' "$ROUTE"
+}
+
+@test "FA-SF-42: gate returns 401 when session is absent or non-admin" {
+  grep -q "getSession(request.headers.get('cookie'))" "$ROUTE"
+  grep -q '!session || !isAdmin(session)' "$ROUTE"
+  grep -q 'status: 401' "$ROUTE"
+}
+
+@test "FA-SF-42: brand is resolved per-pod, never hardcoded" {
+  grep -q "process.env.BRAND_ID ?? process.env.BRAND" "$ROUTE"
+}
+
+@test "FA-SF-42: live preview rejects an unauthenticated request" {
+  [ -n "${WEBSITE_BASE_URL:-}" ] || skip "no WEBSITE_BASE_URL preview target"
+  run curl -s -o /dev/null -w '%{http_code}' "${WEBSITE_BASE_URL}/api/factory-metrics"
+  [ "$status" -eq 0 ]
+  [ "$output" = "401" ]
+}
+
+# ── FA-SF-43-worktree-gitcrypt ──────────────────────────────────#
+# FA-SF-43: the factory pipeline's Implement phase must create its worktree via the
+# git-crypt-safe scripts/worktree-create.sh, NOT the harness `isolation: 'worktree'`
+# option. The harness option runs a raw `git worktree add` whose checkout invokes the
+# git-crypt smudge filter and fails fatally (the new per-worktree gitdir has no key) —
+# T000473 / T000426. Verified live 2026-06-07: the first real autopilot run failed at
+# exactly this step. These are structural guards (grep + node --check), in the spirit
+# of FA-SF-20/31, because the Workflow script cannot be unit-executed offline.
+
+@test "FA-SF-43: pipeline.js does NOT pass the harness isolation:'worktree' option (code, not comments)" {
+  run bash -c "CODE_ONLY() { grep -v '^[[:space:]]*//' scripts/factory/pipeline.js | grep -v '^[[:space:]]*\*'; }; CODE_ONLY | grep -Eq \"isolation:[[:space:]]*'worktree'\""
+  [ "$status" -ne 0 ]
+}
+
+@test "FA-SF-43: pipeline.js creates the worktree via scripts/worktree-create.sh" {
+  run grep -Eq 'scripts/worktree-create\.sh[[:space:]]+\$\{WORK_BRANCH\}[[:space:]]+\$\{WORK_WT\}' scripts/factory/pipeline.js
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-43: pipeline.js fails loudly (returns blocked) when worktree setup fails" {
+  run grep -Eq "reason: 'worktree-setup'" scripts/factory/pipeline.js
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-43: spec/plan filenames are date-stamped by the agent, not from A.timestamp" {
+  # the undefined- filename bug: A.timestamp is not reliably passed → must use date +%F
+  run grep -Eq '\$\{A\.timestamp\}-\$\{slug\}' scripts/factory/pipeline.js
+  [ "$status" -ne 0 ]
+  run grep -Eq 'docs/superpowers/specs/\$\(date \+%F\)-\$\{slug\}-design\.md' scripts/factory/pipeline.js
+  [ "$status" -eq 0 ]
+  run grep -Eq 'openspec/changes/\$\{slug\}/tasks\.md' scripts/factory/pipeline.js
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-43: worktree-create.sh supports an existing branch (reuse/dev-flow path)" {
+  run grep -q 'BRANCH_EXISTS' scripts/worktree-create.sh
+  [ "$status" -eq 0 ]
+  run bash -n scripts/worktree-create.sh
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-43: pipeline.js still parses" {
+  run node --check scripts/factory/pipeline.js
+  [ "$status" -eq 0 ]
+}
+
+# ── FA-SF-44-verify-diff-killswitch ─────────────────────────────#
+# FA-SF-44: follow-ups to the first real autopilot build (T000473):
+#   - Verify/Deploy must diff the WORKTREE, not ${REPO} (whose HEAD is main → empty diff
+#     → false "no code" review blockers).
+#   - guard_check_diff_size must diff the feature branch ref, not bare HEAD.
+#   - factory.service RuntimeMaxSec must allow a real build (old 900s SIGTERM-killed it).
+#   - T000474: the kill-switch must be FAIL-CLOSED on duplicate factory_control rows,
+#     and `factory-control set` must not create NULL-brand duplicates.
+
+@test "FA-SF-44: Verify panel diffs the worktree, not bare HEAD in REPO" {
+  run grep -Eq 'git -C \$\{WORK_WT\} diff origin/main\.\.\.HEAD' scripts/factory/pipeline.js
+  [ "$status" -eq 0 ]
+  # the old empty-diff form must be gone
+  run grep -Eq 'git diff origin/main\.\.\.HEAD in \$\{REPO\}' scripts/factory/pipeline.js
+  [ "$status" -ne 0 ]
+}
+
+@test "FA-SF-44: diff-size guard is passed the feature branch ref" {
+  run grep -Eq 'guard_check_diff_size \$\{process\.env\.FACTORY_MAX_DIFF \?\? .800.\} \$\{WORK_BRANCH\}' scripts/factory/pipeline.js
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-44: guard_check_diff_size accepts a ref arg (defaults HEAD)" {
+  run grep -Eq 'ref="\$\{2:-HEAD\}"' scripts/factory/guards.sh
+  [ "$status" -eq 0 ]
+  run grep -Eq 'origin/main\.\.\.\$\{ref\}' scripts/factory/guards.sh
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-44: factory.service RuntimeMaxSec allows a real build (>=3600)" {
+  run bash -c "v=\$(grep -oE 'RuntimeMaxSec=[0-9]+' scripts/factory/factory.service | cut -d= -f2); [ \"\${v:-0}\" -ge 3600 ]"
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-44: factory-control set dedups via DELETE+INSERT (no ON CONFLICT)" {
+  run grep -Eq 'DELETE FROM tickets\.factory_control WHERE key' scripts/ticket.sh
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-44: guard_killswitch_on is FAIL-CLOSED on a duplicated off/on read (T000474)" {
+  tmp="$(mktemp -d)"
+  mkdir -p "$tmp/scripts"
+  cat > "$tmp/scripts/ticket.sh" <<'STUB'
+#!/usr/bin/env bash
+case "$*" in
+  *--brand*) printf '' ;;      # no per-brand row
+  *)         printf 'off\non\n' ;;  # duplicated global rows: one off, one on
+esac
+STUB
+  chmod +x "$tmp/scripts/ticket.sh"
+  # subshell isolates guards.sh's `set -uo pipefail`; expect exit 0 = ON (paused)
+  run bash -c "source scripts/factory/guards.sh; GUARDS_REPO='$tmp' guard_killswitch_on mentolder"
+  rm -rf "$tmp"
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-44: guard_killswitch_on returns NOT-paused when the only row is off" {
+  tmp="$(mktemp -d)"
+  mkdir -p "$tmp/scripts"
+  printf '#!/usr/bin/env bash\nprintf '"'"'off\\n'"'"'\n' > "$tmp/scripts/ticket.sh"
+  chmod +x "$tmp/scripts/ticket.sh"
+  run bash -c "source scripts/factory/guards.sh; GUARDS_REPO='$tmp' guard_killswitch_on mentolder"
+  rm -rf "$tmp"
+  [ "$status" -ne 0 ]
+}
+
+# ── FA-SF-45-conflict-gate-deadlock ─────────────────────────────#
+# FA-SF-45: the conflict gate must not deadlock the backlog when multiple queued
+# features share files (e.g. all 8 Brett tickets share messages.ts/state.ts).
+# Fix: (a) conflict-check.sh drops 'backlog' from active statuses — only
+# in_progress/in_review block; (b) pipeline.js releases slot + resets to backlog
+# on conflict (prevents wedged in_progress tickets).
+
+@test "FA-SF-45: conflict-check.sh does NOT count backlog as active" {
+  run grep -Eq "t\.status IN \('in_progress','in_review'\)" scripts/factory/conflict-check.sh
+  [ "$status" -eq 0 ]
+  run grep -Eq "'backlog'" scripts/factory/conflict-check.sh
+  [ "$status" -ne 0 ]
+}
+
+@test "FA-SF-45: pipeline.js releases slot + resets to backlog on conflict" {
+  # the conflict-block path must include release-slot (template: ${A.ticket_id})
+  run bash -c "grep -Eq 'release-slot.*--id.*ticket_id' scripts/factory/pipeline.js && grep -Eq 'update-status.*--id.*ticket_id.*backlog' scripts/factory/pipeline.js"
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-45: pipeline.js conflict-block return includes released:true" {
+  run grep -Eq "released: true" scripts/factory/pipeline.js
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-45: scheme.sh claim sets status=in_progress (the gate sees it)" {
+  run grep -Eq "status='in_progress'" scripts/factory/slots.sh
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-45: offline parsing passes" {
+  run node --check scripts/factory/pipeline.js;   [ "$status" -eq 0 ]
+  run bash -n scripts/factory/conflict-check.sh;  [ "$status" -eq 0 ]
+  run bash -n scripts/factory/slots.sh;           [ "$status" -eq 0 ]
+}
+
+# ── FA-SF-46-cleanup ────────────────────────────────────────────#
+# FA-SF-46: cleanup.sh removes factory branch + worktree after pipeline completion.
+# All operations are best-effort (always exit 0). The script is idempotent — calling
+# it with a non-existent branch/worktree is a clean no-op.
+
+@test "FA-SF-46: cleanup.sh parses without syntax errors" {
+  run bash -n scripts/factory/cleanup.sh
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-46: cleanup.sh is executable" {
+  [ -x scripts/factory/cleanup.sh ]
+}
+
+@test "FA-SF-46: cleanup.sh exits 0 with missing args (idempotent)" {
+  run bash scripts/factory/cleanup.sh
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-46: cleanup.sh exits 0 for non-existent branch" {
+  run bash scripts/factory/cleanup.sh --branch "nonexistent-fa-sf-46-deadbeef"
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "nothing to clean up" ]]
+}
+
+@test "FA-SF-46: cleanup.sh exits 0 for non-existent worktree" {
+  run bash scripts/factory/cleanup.sh --worktree "/tmp/wt-nonexistent-fa-sf-46"
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "nothing to clean up" ]]
+}
+
+@test "FA-SF-46: cleanup.sh removes a real branch + worktree" {
+  # Create a disposable branch and worktree, then clean them up.
+  git branch -D fa-sf-46-test-cleanup 2>/dev/null || true
+  git branch fa-sf-46-test-cleanup
+  git worktree add --no-checkout /tmp/wt-fa-sf-46-test fa-sf-46-test-cleanup 2>/dev/null || true
+
+  run bash scripts/factory/cleanup.sh --branch "fa-sf-46-test-cleanup" --worktree "/tmp/wt-fa-sf-46-test"
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "removed" ]]
+
+  # Verify both are gone.
+  run git show-ref --verify --quiet "refs/heads/fa-sf-46-test-cleanup" 2>/dev/null
+  [ "$status" -ne 0 ]
+  [ ! -d /tmp/wt-fa-sf-46-test ]
+}
+
+@test "FA-SF-46: cleanup.sh is idempotent (call twice in a row)" {
+  # First call cleans up (nothing exists from previous test — already cleaned).
+  run bash scripts/factory/cleanup.sh --branch "fa-sf-46-test-cleanup" --worktree "/tmp/wt-fa-sf-46-test"
+  [ "$status" -eq 0 ]
+
+  # Second call on already-cleaned targets is also a no-op.
+  run bash scripts/factory/cleanup.sh --branch "fa-sf-46-test-cleanup" --worktree "/tmp/wt-fa-sf-46-test"
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "nothing to clean up" ]]
+}
+
+@test "FA-SF-46: pipeline.js wraps main body in try/finally" {
+  # finally block must contain the cleanup agent call.
+  run grep -Eq '} finally \{' scripts/factory/pipeline.js
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-46: pipeline.js finally block calls cleanup.sh" {
+  run grep -Eq 'scripts/factory/cleanup\.sh' scripts/factory/pipeline.js
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-46: pipeline.js cleanup is wrapped in try/catch (never masks real result)" {
+  run grep -Eq 'catch[[:space:]]*\(_\)' scripts/factory/pipeline.js
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-46: pipeline.js cleanup passes both WORK_BRANCH and WORK_WT" {
+  # The invocation is inside a JS template literal: --branch ${WORK_BRANCH} --worktree ${WORK_WT}
+  run grep -Eq 'cleanup\.sh.*--branch.*WORK_BRANCH.*--worktree.*WORK_WT' scripts/factory/pipeline.js
+  [ "$status" -eq 0 ]
+}
+
+# ── FA-SF-47-wakeup-reasoning-effort ────────────────────────────#
+# FA-SF-47: wakeup.sh must NOT set reasoning_effort. [T000519]
+# The Workflow harness forces thinking.type=disabled for nested agent() spawns.
+# If reasoning_effort is ALSO set (via --effort or CLAUDE_CODE_EFFORT_LEVEL=<level>),
+# the Anthropic-compatible endpoint (e.g. DeepSeek) returns:
+#   400 thinking options type cannot be disabled when reasoning_effort is set
+# which crashes the dispatcher PREP step. The fix is to leave reasoning_effort UNSET
+# (not "low"). These cases are pure static greps — offline/CI-safe.
+WAKEUP_SCRIPT="scripts/factory/wakeup.sh"
+
+@test "FA-SF-47: wakeup.sh exists and is valid bash" {
+  [ -f "$WAKEUP_SCRIPT" ]
+  run bash -n "$WAKEUP_SCRIPT"
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-47: claude is NOT invoked with --effort" {
+  run grep -Eq -- '--effort' "$WAKEUP_SCRIPT"
+  [ "$status" -ne 0 ]
+}
+
+@test "FA-SF-47: CLAUDE_CODE_EFFORT_LEVEL is never assigned a non-empty level" {
+  # Allowed: `unset CLAUDE_CODE_EFFORT_LEVEL` or `CLAUDE_CODE_EFFORT_LEVEL=` (empty).
+  # Forbidden: `CLAUDE_CODE_EFFORT_LEVEL=low|medium|high|max|...`.
+  run grep -Eq 'CLAUDE_CODE_EFFORT_LEVEL=[A-Za-z]' "$WAKEUP_SCRIPT"
+  [ "$status" -ne 0 ]
+}
+
+@test "FA-SF-47: wakeup.sh actively neutralizes any inherited effort level" {
+  # autopilot.env may set CLAUDE_CODE_EFFORT_LEVEL; wakeup.sh must unset it.
+  run grep -Eq 'unset[[:space:]]+CLAUDE_CODE_EFFORT_LEVEL' "$WAKEUP_SCRIPT"
+  [ "$status" -eq 0 ]
+}
+
+# ── FA-SF-48-ticket-phase-cli ───────────────────────────────────#
+# FA-SF-48: offline arg-validation for the `ticket.sh phase` subcommand. [T-FACTORY-FLOOR]
+# (Renamed from the plan's FA-SF-40 — that number is taken by FA-SF-40-provision.bats.)
+# All cases validate BEFORE _pgpod, so they are deterministic without a cluster (CI-safe).
+
+@test "FA-SF-48: phase requires ext_id, phase and state" {
+  run bash scripts/ticket.sh phase
+  [ "$status" -eq 2 ]
+  [[ "$output" =~ "Usage" ]]
+}
+@test "FA-SF-48: phase rejects an invalid phase name" {
+  run bash scripts/ticket.sh phase T000001 frobnicate entered
+  [ "$status" -eq 2 ]
+  [[ "$output" =~ "phase must be one of" ]]
+}
+@test "FA-SF-48: phase rejects an invalid state" {
+  run bash scripts/ticket.sh phase T000001 scout sideways
+  [ "$status" -eq 2 ]
+  [[ "$output" =~ "state must be one of" ]]
+}
+@test "FA-SF-48: phase rejects an invalid driver" {
+  run bash scripts/ticket.sh phase T000001 scout entered --driver gemini
+  [ "$status" -eq 2 ]
+  [[ "$output" =~ "driver must be one of" ]]
+}
+@test "FA-SF-48: dispatch usage lists phase" {
+  run bash scripts/ticket.sh
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "phase" ]]
+}
+
+# ── FA-SF-49-injection-cli ──────────────────────────────────────#
+# FA-SF-49: offline arg-validation for `ticket.sh inject` + `get-injections`. [factory-injection]
+# All cases validate BEFORE _pgpod, so they are deterministic without a cluster (CI-safe).
+
+@test "FA-SF-49: inject requires --id and --kind" {
+  run bash scripts/ticket.sh inject --content "hi"
+  [ "$status" -eq 2 ]
+  [[ "$output" =~ "required" ]]
+}
+@test "FA-SF-49: inject rejects an invalid kind" {
+  run bash scripts/ticket.sh inject --id T000001 --kind frobnicate
+  [ "$status" -eq 2 ]
+  [[ "$output" =~ "kind must be one of" ]]
+}
+@test "FA-SF-49: inject rejects an invalid phase" {
+  run bash scripts/ticket.sh inject --id T000001 --kind note --phase sideways --content x
+  [ "$status" -eq 2 ]
+  [[ "$output" =~ "phase must be one of" ]]
+}
+@test "FA-SF-49: inject asset requires --file or --nc-path" {
+  run bash scripts/ticket.sh inject --id T000001 --kind asset
+  [ "$status" -eq 2 ]
+  [[ "$output" =~ "asset requires" ]]
+}
+@test "FA-SF-49: inject --file rejects a missing file" {
+  run bash scripts/ticket.sh inject --id T000001 --kind asset --file /no/such/file.png
+  [ "$status" -eq 2 ]
+  [[ "$output" =~ "not a file" ]]
+}
+@test "FA-SF-49: get-injections requires --id" {
+  run bash scripts/ticket.sh get-injections
+  [ "$status" -eq 2 ]
+  [[ "$output" =~ "required" ]]
+}
+@test "FA-SF-49: get-injections rejects an invalid --phase" {
+  run bash scripts/ticket.sh get-injections --id T000001 --phase nope
+  [ "$status" -eq 2 ]
+  [[ "$output" =~ "phase must be one of" ]]
+}
+@test "FA-SF-49: dispatch usage lists inject and get-injections" {
+  run bash scripts/ticket.sh
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "inject" ]]
+  [[ "$output" =~ "get-injections" ]]
+}
+
+# ── FA-SF-50-stage-plan ─────────────────────────────────────────#
+# FA-SF-50: offline arg-validation for `ticket.sh stage-plan` (Kommissionierung).
+# Validierung passiert VOR _pgpod (FA-SF-35-Muster) -> kein Cluster nötig.
+
+@test "FA-SF-50: stage-plan requires --id" {
+  run bash scripts/ticket.sh stage-plan --branch feature/x --plan docs/p.md
+  [ "$status" -eq 2 ]
+  [[ "$output" =~ "--id" ]]
+}
+@test "FA-SF-50: stage-plan requires --branch" {
+  run bash scripts/ticket.sh stage-plan --id T000001 --plan docs/p.md
+  [ "$status" -eq 2 ]
+  [[ "$output" =~ "--branch" ]]
+}
+@test "FA-SF-50: stage-plan requires --plan" {
+  run bash scripts/ticket.sh stage-plan --id T000001 --branch feature/x
+  [ "$status" -eq 2 ]
+  [[ "$output" =~ "--plan" ]]
+}
+@test "FA-SF-50: stage-plan rejects unknown option" {
+  run bash scripts/ticket.sh stage-plan --id T000001 --branch b --plan p --bogus x
+  [ "$status" -eq 2 ]
+  [[ "$output" =~ "Unknown" ]]
+}
+@test "FA-SF-50: dispatch usage lists stage-plan" {
+  run bash scripts/ticket.sh
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "stage-plan" ]]
+}
+
+# ── FA-SF-51-auto-enqueue ───────────────────────────────────────#
+# FA-SF-51: offline arg-validation + logic stubs für auto-enqueue.sh [T000730]
+# Alle Tests validieren VOR _pgpod / factory_psql — CI-safe ohne Cluster.
+
+@test "FA-SF-51: auto-enqueue.sh is executable" {
+  [ -x scripts/factory/auto-enqueue.sh ]
+}
+
+@test "FA-SF-51: --dry-run flag is accepted without error (no cluster)" {
+  # Setzt FACTORY_DRY_RESOLVE=1 um factory_resolve() zu kurz-schließen
+  run env FACTORY_DRY_RESOLVE=1 BRAND=mentolder bash scripts/factory/auto-enqueue.sh --dry-run
+  # Kein Crash, beliebiger Exit-Code akzeptiert (kein Cluster)
+  [[ "$output" != *"Unknown option"* ]]
+}
+
+@test "FA-SF-51: rejects unknown option" {
+  run bash scripts/factory/auto-enqueue.sh --bogus
+  [ "$status" -eq 2 ]
+  [[ "$output" =~ "Unknown" ]]
+}
+
+@test "FA-SF-51: BRAND env var is required" {
+  # Ohne BRAND gibt factory_resolve() einen Fehler
+  run env BRAND="" bash scripts/factory/auto-enqueue.sh --dry-run
+  # Erwartet entweder exit 1 oder Warnung im Output
+  [[ "$status" -ne 0 ]] || [[ "$output" =~ "BRAND" ]]
+}
+
+@test "FA-SF-51: --help shows usage" {
+  run bash scripts/factory/auto-enqueue.sh --help
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "auto-enqueue" ]]
+}
+
+# ── FA-SF-52-qa-notify ──────────────────────────────────────────#
+# FA-SF-52: offline arg-validation für scripts/factory/qa-notify.sh [T000730]
+
+@test "FA-SF-52: qa-notify.sh is executable" {
+  [ -x scripts/factory/qa-notify.sh ]
+}
+
+@test "FA-SF-52: --event is required" {
+  run bash scripts/factory/qa-notify.sh --ticket-id T000001 --title "x" --slug foo
+  [ "$status" -eq 2 ]
+  [[ "$output" =~ "--event" ]]
+}
+
+@test "FA-SF-52: rejects invalid --event" {
+  run bash scripts/factory/qa-notify.sh --event launch --ticket-id T1 --title x --slug s
+  [ "$status" -eq 2 ]
+  [[ "$output" =~ "qa_review" ]] || [[ "$output" =~ "done" ]]
+}
+
+@test "FA-SF-52: --ticket-id is required" {
+  run bash scripts/factory/qa-notify.sh --event qa_review --title "x" --slug foo
+  [ "$status" -eq 2 ]
+  [[ "$output" =~ "--ticket-id" ]]
+}
+
+@test "FA-SF-52: --slug is required" {
+  run bash scripts/factory/qa-notify.sh --event qa_review --ticket-id T1 --title "x"
+  [ "$status" -eq 2 ]
+  [[ "$output" =~ "--slug" ]]
+}
+
+@test "FA-SF-52: --help exits 0 with usage" {
+  run bash scripts/factory/qa-notify.sh --help
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "qa-notify" ]]
+}
+
+# ── FA-SF-53-decompose ──────────────────────────────────────────#
+# FA-SF-53: pipeline-decompose — offline unit tests for the decomposition helper.
+
+@test "FA-SF-53: pipeline-decompose.cjs exists and is syntactically valid" {
+  [ -f "$DECOMPOSE_MOD" ]
+  run node --check "$DECOMPOSE_MOD"
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-53: node --test suite passes" {
+  run node --test "$DECOMPOSE_SUITE"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"# fail 0"* ]]
+}
+
+@test "FA-SF-53: exports the six contract functions" {
+  for fn in "chooseModel" "chooseEffort" "buildContextHints" "provision" "assignFiles" "validateDisjoint"; do
+    run grep -Fq "$fn" "$DECOMPOSE_MOD"; [ "$status" -eq 0 ]
+  done
+}
+
+@test "FA-SF-53: exports via module.exports (CommonJS)" {
+  run grep -q "module.exports" "$DECOMPOSE_MOD"
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-53: defines SHARED_FILE_LIST with the three shared files" {
+  run grep -Fq "configmap-domains.yaml" "$DECOMPOSE_MOD"
+  [ "$status" -eq 0 ]
+  run grep -Fq "environments/schema.yaml" "$DECOMPOSE_MOD"
+  [ "$status" -eq 0 ]
+  run grep -Fq "k3d/kustomization.yaml" "$DECOMPOSE_MOD"
+  [ "$status" -eq 0 ]
+}
+
+# ── FA-SF-57-app-catalog ────────────────────────────────────────#
+# FA-SF-57: App Catalog & Installer Tests
+
+@test "FA-SF-57: validate-manifest rejects invalid manifests" {
+  cat <<EOF > "$TEST_TMP_DIR/invalid.yaml"
+name: invalid_name_UPPERCASE
+title: "Test App"
+description: "A test app"
+kustomize: k3d/test
+EOF
+
+  run node scripts/validate-manifest.mjs "$TEST_TMP_DIR/invalid.yaml"
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "Validation failed" ]]
+}
+
+@test "FA-SF-57: validate-manifest accepts valid manifests" {
+  cat <<EOF > "$TEST_TMP_DIR/valid.yaml"
+name: valid-app-name-123
+title: "Test App"
+description: "A test app description"
+kustomize: k3d/test
+domains:
+  - key: TEST_DOMAIN
+    host: "test.\${PROD_DOMAIN}"
+EOF
+
+  run node scripts/validate-manifest.mjs "$TEST_TMP_DIR/valid.yaml"
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "is valid" ]]
+}
+
+@test "FA-SF-57: app-install.sh rejects missing app manifests" {
+  run bash scripts/app-install.sh non-existent-app --dry-run
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "App manifest not found" ]]
+}
+
+@test "FA-SF-57: app-install.sh dry-run simulates deployment steps" {
+  # Mock a test catalog app
+  mkdir -p "apps/test-mock-app"
+  cat <<EOF > "apps/test-mock-app/app.yaml"
+name: test-mock-app
+title: "Mock App"
+description: "A mock app for testing"
+kustomize: k3d/whiteboard
+domains:
+  - key: MOCK_APP_DOMAIN
+    host: "mock.\${PROD_DOMAIN}"
+secrets:
+  - MOCK_APP_JWT_SECRET
+EOF
+
+  run bash scripts/app-install.sh test-mock-app --dry-run
+  local test_status=$status test_output="$output"
+  rm -rf "apps/test-mock-app"
+
+  # CI debug: log status for troubleshooting
+  if [ "$test_status" -ne 0 ]; then
+    echo "DEBUG_APP_INSTALL_STATUS=$test_status" >&3
+    echo "DEBUG_APP_INSTALL_OUTPUT=$(echo "$test_output" | head -5)" >&3
+  fi
+
+  [ "$test_status" -eq 0 ] || skip "app-install dry-run failed (status=$test_status) — CI limitation"
+  [[ "$test_output" =~ "Validating manifest schema" ]]
+  [[ "$test_output" =~ "Merging domains" ]]
+  [[ "$test_output" =~ "Would register secret" ]]
+  [[ "$test_output" =~ "Simulating deploy" ]]
+}
+
+# ── FA-SF-58-eval-harness ───────────────────────────────────────#
+# FA-SF-58: Factory Eval-Harness — Scoring logic and fixture validation (offline-safe)
+
+@test "FA-SF-58: eval.mjs loads fixtures and produces scorecard" {
+  cat > "$TEST_TMP_DIR/fixtures/T000725/ticket.json" <<'EOF'
+{"title":"Test","description":"Simple test","type":"feature","external_id":"T000725","brand":"mentolder","area":"factory"}
+EOF
+  cat > "$TEST_TMP_DIR/fixtures/T000725/expected.json" <<'EOF'
+{"files":["scripts/test.sh"],"forbidden":[],"tests":["bash -n scripts/test.sh"],"min_recall":0,"min_precision":0}
+EOF
+
+  run node scripts/factory/eval.mjs \
+    --fixtures-dir "$TEST_TMP_DIR/fixtures" \
+    --out-dir "$TEST_TMP_DIR/out" \
+    --dry-run
+  echo "exit=$status output=$output"
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "Aggregate score" ]]
+  [[ -f "$TEST_TMP_DIR/out/latest.json" ]]
+}
+
+@test "FA-SF-58: scoring rejects when forbidden files touched" {
+  run node scripts/factory/eval.mjs --dry-run --out-dir "$TEST_TMP_DIR/out2"
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "Aggregate score" ]]
+  [[ -f "$TEST_TMP_DIR/out2/latest.json" ]]
+}
+
+@test "FA-SF-58: scoreFixture calculation is deterministic" {
+  run node -e "
+    const path = require('path');
+    const fs = require('fs');
+    const REPO = path.resolve('.');
+
+    // inline the scoring logic for testing
+    function matchGlob(pattern, files) {
+      const re = new RegExp('^' + pattern
+        .replace(/\*\*/g, '<<<GS>>>')
+        .replace(/\*/g, '[^/]*')
+        .replace(/<<<GS>>>/g, '.*')
+        .replace(/\?/g, '.') + '\$');
+      return files.some(f => re.test(f));
+    }
+
+    function scoreFixture(touchedFiles, testResults) {
+      const expectedFiles = ['scripts/test.sh'];
+      const forbidden = ['k3d/configmap-domains.yaml'];
+      const minRecall = 0.5;
+      const minPrecision = 0.3;
+
+      const hitFiles = touchedFiles.filter(f =>
+        expectedFiles.some(p => matchGlob(p, [f])));
+      const falseFiles = touchedFiles.filter(f =>
+        forbidden.some(p => matchGlob(p, [f])));
+      const relevantExpected = expectedFiles.filter(p =>
+        touchedFiles.some(f => matchGlob(p, [f])));
+      const recall = expectedFiles.length > 0 ? relevantExpected.length / expectedFiles.length : 0;
+      const precision = touchedFiles.length > 0 ? hitFiles.length / touchedFiles.length : 0;
+      const scopePenalty = falseFiles.length > 0 ? falseFiles.length * 0.25 : 0;
+      const testPass = testResults.every(r => r === true);
+      const testScore = testPass ? 1.0 : 0.0;
+      const recallPass = recall >= minRecall;
+      const precisionPass = precision >= minPrecision;
+      const overall = Math.max(0, Math.min(1,
+        (recall * 0.3 + precision * 0.2 + testScore * 0.4) - scopePenalty));
+      const pass = testPass && recallPass && precisionPass && falseFiles.length === 0;
+      return { pass, score: Math.round(overall * 100) / 100,
+        dimensions: { recall: Math.round(recall*100)/100, precision: Math.round(precision*100)/100,
+          scope_penalty: scopePenalty, test_pass: testPass } };
+    }
+
+    // Test 1: perfect hit
+    let r = scoreFixture(['scripts/test.sh'], [true]);
+    console.log('perfect hit:', JSON.stringify(r));
+    if (!r.pass || r.score < 0.8) { process.exit(1); }
+
+    // Test 2: wrong file
+    r = scoreFixture(['src/wrong.ts'], [true]);
+    console.log('wrong file:', JSON.stringify(r));
+    if (r.pass) { process.exit(2); }
+    if (r.dimensions.recall !== 0) { process.exit(3); }
+
+    // Test 3: forbidden file
+    r = scoreFixture(['scripts/test.sh', 'k3d/configmap-domains.yaml'], [true]);
+    console.log('forbidden:', JSON.stringify(r));
+    if (r.pass) { process.exit(4); }
+    if (r.dimensions.scope_penalty !== 0.25) { process.exit(5); }
+
+    // Test 4: test failure
+    r = scoreFixture(['scripts/test.sh'], [false]);
+    console.log('test fail:', JSON.stringify(r));
+    if (r.pass) { process.exit(6); }
+
+    console.log('ALL PASS');
+    process.exit(0);
+  "
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "ALL PASS" ]]
+}
+
+@test "FA-SF-58: glob matching works correctly" {
+  run node -e "
+    function matchGlob(pattern, files) {
+      const re = new RegExp('^' + pattern
+        .replace(/\*\*/g, '<<<GS>>>')
+        .replace(/\*/g, '[^/]*')
+        .replace(/<<<GS>>>/g, '.*')
+        .replace(/\?/g, '.') + '\$');
+      return files.some(f => re.test(f));
+    }
+    const tests = [
+      matchGlob('scripts/*.sh', ['scripts/test.sh']) === true,
+      matchGlob('scripts/*.sh', ['src/test.sh']) === false,
+      matchGlob('website/**/*.ts', ['website/src/lib/x.ts']) === true,
+      matchGlob('website/**/*.ts', ['k3d/x.ts']) === false,
+      matchGlob('*.json', ['file.json']) === true,
+      matchGlob('*.json', ['dir/file.json']) === false,
+      matchGlob('tests/*', ['tests/x.json']) === true,
+    ];
+    const ok = tests.every(Boolean);
+    console.log(tests.map(t => t ? 'PASS' : 'FAIL').join(', '));
+    process.exit(ok ? 0 : 1);
+  "
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-58: discrimination — worse prompt lowers score" {
+  run node -e "
+    const fs = require('fs');
+    const path = require('path');
+    const REPO = path.resolve('.');
+    const fixturesDir = path.join(REPO, 'tests/factory-eval/fixtures');
+
+    // For discrimination test: verify that scoring functions produce
+    // lower scores when fewer expected files are hit
+    function matchGlob(pattern, files) {
+      const re = new RegExp('^' + pattern
+        .replace(/\*\*/g, '<<<GS>>>')
+        .replace(/\*/g, '[^/]*')
+        .replace(/<<<GS>>>/g, '.*')
+        .replace(/\?/g, '.') + '\$');
+      return files.some(f => re.test(f));
+    }
+
+    function score(touchedFiles, expectedFiles, testResults) {
+      const hitFiles = touchedFiles.filter(f =>
+        expectedFiles.some(p => matchGlob(p, [f])));
+      const relevantExpected = expectedFiles.filter(p =>
+        touchedFiles.some(f => matchGlob(p, [f])));
+      const recall = expectedFiles.length > 0 ? relevantExpected.length / expectedFiles.length : 0;
+      const precision = touchedFiles.length > 0 ? hitFiles.length / touchedFiles.length : 0;
+      const testPass = testResults.every(r => r === true);
+      const overall = recall * 0.3 + precision * 0.2 + (testPass ? 0.4 : 0);
+      return Math.round(overall * 100) / 100;
+    }
+
+    const expected = ['a.js', 'b.js', 'c.js'];
+
+    // Good: hits all 3
+    const goodScore = score(['a.js', 'b.js', 'c.js'], expected, [true]);
+    console.log('good score:', goodScore);
+
+    // Bad: hits only 1
+    const badScore = score(['a.js'], expected, [true]);
+    console.log('bad score:', badScore);
+
+    if (goodScore <= badScore) { process.exit(1); }
+    console.log('DISCRIMINATION OK: good=' + goodScore + ' > bad=' + badScore);
+    process.exit(0);
+  "
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "DISCRIMINATION OK" ]]
+}
+
+# ── FA-SF-59-aci-loop ───────────────────────────────────────────#
+# FA-SF-59: ACI Loop — tests ACI tools and auto-repair behavior (offline-safe)
+
+@test "FA-SF-59: aci.cjs module loads without errors" {
+  run node -e "const aci = require('./scripts/factory/aci.cjs'); console.log(Object.keys(aci).join(','))"
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "view" ]]
+  [[ "$output" =~ "edit" ]]
+  [[ "$output" =~ "validate" ]]
+  [[ "$output" =~ "search" ]]
+  [[ "$output" =~ "runTest" ]]
+}
+
+@test "FA-SF-59: ACI view works with line ranges" {
+  run node -e "
+    const aci = require('./scripts/factory/aci.cjs');
+    const fs = require('fs');
+    const f = '$TEST_TMP_DIR/view-test.txt';
+    fs.writeFileSync(f, Array.from({length:10}, (_,i) => 'line '+(i+1)).join('\n'), 'utf8');
+
+    let r = aci.view(f, 3, 6);
+    console.log('range:', r.data.includes('3: line 3') && r.data.includes('6: line 6') && !r.data.includes('1: line'));
+    
+    r = aci.view(f);
+    console.log('full:', r.total_lines === 10 && r.data.includes('line 10'));
+    
+    r = aci.view('/nonexistent');
+    console.log('missing:', r.failed);
+  "
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "range: true" ]]
+  [[ "$output" =~ "full: true" ]]
+  [[ "$output" =~ "missing: true" ]]
+}
+
+@test "FA-SF-59: ACI edit with auto-revert on syntax error" {
+  run node -e "
+    const aci = require('./scripts/factory/aci.cjs');
+    const fs = require('fs');
+    const f = '$TEST_TMP_DIR/edit-test.js';
+    const original = 'const x = 42;\\nmodule.exports = { x };\\n';
+    fs.writeFileSync(f, original, 'utf8');
+
+    // Valid edit
+    let r = aci.edit(f, 1, 1, 'const x = 100;');
+    const afterEdit = fs.readFileSync(f, 'utf8');
+    console.log('valid:', !r.failed && afterEdit.includes('x = 100'));
+
+    // Restore
+    fs.writeFileSync(f, original, 'utf8');
+
+    // Invalid edit - should auto-revert
+    r = aci.edit(f, 1, 1, 'const x = ;');
+    const afterRevert = fs.readFileSync(f, 'utf8');
+    console.log('revert:', r.failed && r.reverted && afterRevert === original);
+    console.log('error:', r.error.includes('Validation'));
+  "
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "valid: true" ]]
+  [[ "$output" =~ "revert: true" ]]
+  [[ "$output" =~ "error: true" ]]
+}
+
+@test "FA-SF-59: ACI validate detects syntax errors per filetype" {
+  run node -e "
+    const aci = require('./scripts/factory/aci.cjs');
+    const fs = require('fs');
+    const tmp = '$TEST_TMP_DIR';
+
+    // Good JS
+    fs.writeFileSync(tmp+'/good.js', 'const a = 1;\\n', 'utf8');
+    let v = aci.validate(tmp+'/good.js');
+    console.log('js-good:', v.valid);
+
+    // Bad JS
+    fs.writeFileSync(tmp+'/bad.js', 'const a = ;\\n', 'utf8');
+    v = aci.validate(tmp+'/bad.js');
+    console.log('js-bad:', !v.valid);
+
+    // Good SH
+    fs.writeFileSync(tmp+'/good.sh', '#!/usr/bin/env bash\\necho hi\\n', 'utf8');
+    v = aci.validate(tmp+'/good.sh');
+    console.log('sh-good:', v.valid);
+
+    // Bad SH
+    fs.writeFileSync(tmp+'/bad.sh', '#!/usr/bin/env bash\\nif true\\n', 'utf8');
+    v = aci.validate(tmp+'/bad.sh');
+    console.log('sh-bad:', !v.valid);
+
+    // Good JSON
+    fs.writeFileSync(tmp+'/good.json', '{\"a\": 1}\\n', 'utf8');
+    v = aci.validate(tmp+'/good.json');
+    console.log('json-good:', v.valid);
+
+    // Bad JSON
+    fs.writeFileSync(tmp+'/bad.json', '{a: 1}\\n', 'utf8');
+    v = aci.validate(tmp+'/bad.json');
+    console.log('json-bad:', !v.valid);
+  "
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "js-good: true" ]]
+  [[ "$output" =~ "js-bad: true" ]]
+  [[ "$output" =~ "sh-good: true" ]]
+  [[ "$output" =~ "sh-bad: true" ]]
+  [[ "$output" =~ "json-good: true" ]]
+  [[ "$output" =~ "json-bad: true" ]]
+}
+
+@test "FA-SF-59: pipeline.js loads ACI conditionally via env var" {
+  run bash -c "ACI_ENABLED=true node --check scripts/factory/pipeline.js"
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "" ]]  # node --check produces no output on success
+
+  run bash -c "ACI_ENABLED=false node --check scripts/factory/pipeline.js"
+  [ "$status" -eq 0 ]
+
+  run bash -c "node --check scripts/factory/pipeline.js"
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-59: ACI module exports match expected interface" {
+  run node -e "
+    const aci = require('./scripts/factory/aci.cjs');
+    const required = ['view','search','edit','validate','runTest','getValidator'];
+    const missing = required.filter(k => typeof aci[k] !== 'function');
+    console.log('exported:', Object.keys(aci).filter(k => typeof aci[k] === 'function').join(','));
+    console.log('missing:', missing.join(','));
+    process.exit(missing.length === 0 ? 0 : 1);
+  "
+  [ "$status" -eq 0 ]
+}
+
+# ── FA-SF-60-partial-deploy ─────────────────────────────────────#
+# FA-SF-60: structural contract for partial-deploy (offline, no cluster).
+#   - service-registry.sh maps EVERY k3d/*.yaml to a slug or INFRA
+#   - infra files are never partial-deployable
+#   - resolve_partial_services applies the ≤5 / no-infra threshold
+#   - Taskfile exposes workspace:partial-deploy
+REG="scripts/factory/service-registry.sh"
+
+@test "FA-SF-60: service-registry.sh exists and passes bash -n" {
+  [ -f "$REG" ]
+  run bash -n "$REG"
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-60: every k3d/*.yaml is classified (registry slug OR infra)" {
+  # shellcheck disable=SC1090
+  source "$REG"
+  local missing=()
+  for f in k3d/*.yaml; do
+    # kustomization.yaml is the kustomize entrypoint, not a deployable resource
+    [ "$f" = "k3d/kustomization.yaml" ] && continue
+    if [ -n "${SERVICE_REGISTRY[$f]:-}" ]; then continue; fi
+    local is_infra=0
+    for inf in "${INFRA_FILES[@]}"; do [ "$inf" = "$f" ] && is_infra=1 && break; done
+    [ "$is_infra" -eq 1 ] || missing+=("$f")
+  done
+  if [ "${#missing[@]}" -ne 0 ]; then
+    printf 'UNCLASSIFIED: %s\n' "${missing[@]}" >&2
+  fi
+  [ "${#missing[@]}" -eq 0 ]
+}
+
+@test "FA-SF-60: resolve_partial_services returns slugs for a small service-only diff" {
+  source "$REG"
+  run resolve_partial_services "k3d/brett.yaml,website/src/pages/index.astro"
+  [ "$status" -eq 0 ]
+  [ "$output" = "brett" ]
+}
+
+@test "FA-SF-60: dedups multiple files of the same service" {
+  source "$REG"
+  run resolve_partial_services "k3d/nextcloud.yaml,k3d/nextcloud-redis.yaml"
+  [ "$status" -eq 0 ]
+  [ "$output" = "nextcloud" ]
+}
+
+@test "FA-SF-60: infra change forces full deploy (non-zero, empty)" {
+  source "$REG"
+  run resolve_partial_services "k3d/namespace.yaml,k3d/brett.yaml"
+  [ "$status" -ne 0 ]
+}
+
+@test "FA-SF-60: unknown k3d file forces full deploy (fail safe)" {
+  source "$REG"
+  run resolve_partial_services "k3d/brand-new-service.yaml"
+  [ "$status" -ne 0 ]
+}
+
+@test "FA-SF-60: a diff touching no k3d service file returns non-zero" {
+  source "$REG"
+  run resolve_partial_services "website/src/pages/index.astro,Taskfile.yml"
+  [ "$status" -ne 0 ]
+}
+
+@test "FA-SF-60: more than PARTIAL_DEPLOY_MAX services forces full deploy" {
+  source "$REG"
+  PARTIAL_DEPLOY_MAX=2 run resolve_partial_services "k3d/brett.yaml,k3d/keycloak.yaml,k3d/docs.yaml"
+  [ "$status" -ne 0 ]
+}
+
+@test "FA-SF-60: kustomization.yaml change forces full deploy" {
+  source "$REG"
+  run resolve_partial_services "k3d/kustomization.yaml"
+  [ "$status" -ne 0 ]
+}
+
+@test "FA-SF-60: every registry slug appears as an app: label in the kustomize build" {
+  command -v kustomize >/dev/null || skip "kustomize not installed"
+  source "$REG"
+  local built; built=$(kustomize build k3d/ --load-restrictor=LoadRestrictionsNone 2>/dev/null) || skip "kustomize build failed offline"
+  local missing=()
+  local seen=()
+  # unique slug set — only check slugs whose files appear in kustomization.yaml
+  local kustomization; kustomization=$(cat k3d/kustomization.yaml)
+  local slug
+  for f in "${!SERVICE_REGISTRY[@]}"; do
+    # skip files not referenced by kustomization.yaml (deployed separately by workspace:deploy)
+    local basename="${f##k3d/}"
+    printf '%s' "$kustomization" | grep -qF "$basename" || continue
+    slug="${SERVICE_REGISTRY[$f]}"
+    printf '%s\n' "${seen[@]}" | grep -qx "$slug" && continue
+    seen+=("$slug")
+    grep -Eq "app: ${slug}( |$)" <<< "$built" || missing+=("$slug")
+  done
+  if [ "${#missing[@]}" -ne 0 ]; then
+    printf 'SLUG WITH NO app: LABEL IN BUILD: %s\n' "${missing[@]}" >&2
+  fi
+  [ "${#missing[@]}" -eq 0 ]
+}
+
+@test "FA-SF-60: Taskfile defines workspace:partial-deploy" {
+  run grep -Eq '^  workspace:partial-deploy:' Taskfile.yml
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-60: partial-deploy uses a label selector apply (app in (...))" {
+  # the rendered apply must filter by the PARTIAL_SERVICES label set
+  run grep -Eq 'app in \(' Taskfile.yml
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-60: partial-deploy aborts when PARTIAL_SERVICES is empty" {
+  run grep -Eq 'PARTIAL_SERVICES.*(required|must be set|empty)' Taskfile.yml
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-60: pipeline.js references the service-registry resolver" {
+  run grep -q 'resolve_partial_services' scripts/factory/pipeline.js
+  [ "$status" -eq 0 ]
+  run grep -q 'service-registry.sh' scripts/factory/pipeline.js
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-60: pipeline.js passes node --check" {
+  command -v node >/dev/null || skip "node not installed"
+  run node --check scripts/factory/pipeline.js
+  [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-60: the registry resolver invoked the JS way yields a slug for a service-only diff" {
+  run bash -c 'source scripts/factory/service-registry.sh && resolve_partial_services "k3d/brett.yaml"'
+  [ "$status" -eq 0 ]
+  [ "$output" = "brett" ]
+}
+
+# ── FA-SF-63-scout-deterministic ────────────────────────────────#
+# FA-SF-63 — deterministic Factory scout (scout.sh) contract + pipeline integrity.
+
+@test "scout.sh with no args prints usage and exits non-zero" {
+  run bash "$SCOUT"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Usage:"* ]]
+}
+
+@test "scout.sh --help exits 0" {
+  run bash "$SCOUT" --help
+  [ "$status" -eq 0 ]
+}
+
+@test "scout.sh emits valid JSON for a real feature" {
+  run bash "$SCOUT" --ticket-id T000001 \
+    --title "add booking confirmation email" \
+    --slug "add-booking-confirmation-email" \
+    --description "send email after booking" \
+    --repo "$REPO_ROOT"
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e . >/dev/null
+}
+
+@test "scout.sh touched_files is always an array (even with zero hits)" {
+  run bash "$SCOUT" --title "zzzxqq fffvvv" --slug "" --repo "$REPO_ROOT"
+  [ "$status" -eq 0 ]
+  result="$(echo "$output" | jq -e '.touched_files | type == "array"')"
+  [ "$result" = "true" ]
+}
+
+@test "scout.sh complexity is one of simple|medium|complex" {
+  out="$(bash "$SCOUT" --title "add booking email" --slug "add-booking-email" --repo "$REPO_ROOT")"
+  c="$(echo "$out" | jq -r '.complexity')"
+  [[ "$c" == "simple" || "$c" == "medium" || "$c" == "complex" ]]
+}
+
+@test "scout.sh empty slug does not crash, falls back to medium when no hits" {
+  run bash "$SCOUT" --title "zzzxqq fffvvv" --slug "" --repo "$REPO_ROOT"
+  [ "$status" -eq 0 ]
+  c="$(echo "$output" | jq -r '.complexity')"
+  [ "$c" = "medium" ]
+  slots="$(echo "$output" | jq -r '.estimated_slots')"
+  [ "$slots" = "2" ]
+}
+
+@test "scout.sh risk_areas contains k8s-manifests when a k3d path is discovered" {
+  # Fixture repo has k3d/booking-config.yaml; "config" triggers infra Strategy C.
+  out="$(bash "$SCOUT" --title "booking config" --slug "booking-config" --repo "$FIXTURE")"
+  echo "$out" | jq -e '.touched_files | any(. | test("k3d/booking-config"))' >/dev/null
+  echo "$out" | jq -e '.risk_areas | index("k8s-manifests") != null' >/dev/null
+}
+
+@test "scout.sh touched_files are absolute paths" {
+  out="$(bash "$SCOUT" --title "booking config" --slug "booking-config" --repo "$FIXTURE")"
+  # Every entry must start with '/'.
+  echo "$out" | jq -e '.touched_files | all(startswith("/"))' >/dev/null
+}
+
+@test "scout.sh similar_tickets is an array" {
+  out="$(bash "$SCOUT" --title "booking" --slug "booking" --repo "$FIXTURE")"
+  echo "$out" | jq -e '.similar_tickets | type == "array"' >/dev/null
+}
+
+@test "scout.sh estimated_slots is an integer >= 1" {
+  out="$(bash "$SCOUT" --title "add booking email" --slug "add-booking-email" --repo "$REPO_ROOT")"
+  slots="$(echo "$out" | jq -r '.estimated_slots')"
+  echo "$out" | jq -e '.estimated_slots | type == "number"' >/dev/null
+  [ "$slots" -ge 1 ]
+}
+
+@test "pipeline.js still passes node --check" {
+  run node --check "$PIPELINE"
+  [ "$status" -eq 0 ]
+}
+
+@test "pipeline.js invokes scout.sh via execFileSync (no LLM scout agent call)" {
+  # The deterministic swap must reference scout.sh and must NOT keep a
+  # label:'scout' agent() call for discovery.
+  grep -q "scout.sh" "$PIPELINE"
+  # Assert the old LLM scout prompt phrase is gone.
+  ! grep -q "Scout the feature" "$PIPELINE"
+}
+
+@test "scout.sh with SCOUT_LLM_ENABLED=false runs deterministic path only (no crash, valid JSON)" {
+  run env SCOUT_LLM_ENABLED=false bash "$SCOUT" --title "zzzxqq fffvvv" --slug "" --repo "$REPO_ROOT"
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e . >/dev/null
+  c="$(echo "$output" | jq -r '.complexity')"
+  [ "$c" = "medium" ]
+}
+
+# ── FA-SF-70-provider-router ────────────────────────────────────#
+# FA-SF-70 — provider routing CLI + wrappers (offline; DB-touching paths skipped).
+
+@test "FA-SF-70: provider-config.sh prints usage and exits non-zero with no args" {
+  run bash scripts/factory/provider-config.sh
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Usage"* ]]
+}
+
+@test "FA-SF-70: provider-config.sh set rejects tier=opus" {
+  run bash scripts/factory/provider-config.sh set --source x --tier opus --priority 1 --provider anthropic --model m
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"opus"* ]]
+}
+
+@test "FA-SF-70: provider-config.sh set requires all mandatory flags" {
+  run bash scripts/factory/provider-config.sh set --source x --tier sonnet
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Usage"* ]]
+}
+
+@test "FA-SF-70: route-provider.sh emits valid JSON keys for opus without DB" {
+  run bash scripts/factory/route-provider.sh factory-plan opus
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.modelId and (.provider=="anthropic")'
+}
+
+@test "FA-SF-70: route-provider.sh requires source and tier args" {
+  run bash scripts/factory/route-provider.sh
+  [ "$status" -ne 0 ]
+}
+
+@test "FA-SF-70: release-slot.sh requires a provider arg" {
+  run bash scripts/factory/release-slot.sh
+  [ "$status" -ne 0 ]
+}
+
+@test "FA-SF-70: release-slot.sh accepts null slotId (no-op)" {
+  run bash scripts/factory/release-slot.sh null true
+  [ "$status" -eq 0 ]
+}
+

--- a/tests/spec/test_helper.bash
+++ b/tests/spec/test_helper.bash
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# tests/spec/test_helper.bash — Weiterleitung auf tests/local/test_helper.bash
+# Notwendig weil BATS `load` relativ zur Testdatei sucht.
+# shellcheck source=../local/test_helper.bash
+source "${BATS_TEST_DIRNAME}/../local/test_helper.bash"


### PR DESCRIPTION
## Summary

- **Proof of concept** für eine neue Testkonvention: ein BATS-File pro OpenSpec SSOT-Spec
- Konsolidiert 41 `FA-SF-*.bats` Dateien (324 `@test`-Einträge) in eine einzige `tests/spec/software-factory.bats`
- Bestehende `FA-SF-*.bats` Dateien bleiben unberührt (parallele Koexistenz)

## Was wurde gebaut

| Datei | Beschreibung |
|-------|-------------|
| `tests/spec/software-factory.bats` | Konsolidierte Suite, 2800 Zeilen, 324 Tests |
| `tests/spec/test_helper.bash` | Weiterleitung zu `tests/local/test_helper.bash` |

**Technische Details:**
- Einheitliche `setup()`/`teardown()` mit `TMPLOG`, `TEST_TMP_DIR`, `validate_triage`
- `_skip_if_no_db` Helper für Live-DB-Tests (FA-SF-04..13)
- Konfliktierende `SCRIPT`/`MOD`/`SUITE`-Variablen umbenannt (`PIPELINE_SCRIPT` etc.)
- Verifiziert: 324/324 offline bestanden (11 Skip für Cluster-Tests)

## Test plan

- [x] `bats -c tests/spec/software-factory.bats` → 324 erkannt
- [x] Vollständiger BATS-Run: 313 pass, 11 skip (offline), 0 fail
- [x] `task freshness:check` grün
- [x] `task workspace:validate` grün

## Nächste Schritte (nach PoC-Akzeptanz)

1. Konvention in `dev-flow-plan`/`dev-flow-execute` Skills verankern: neue Tests → `tests/spec/<spec-slug>.bats`
2. Weitere Spec-Dateien anlegen (`backup-pipeline.bats`, `website-core.bats`, etc.)
3. Schrittweise Migration der bestehenden `tests/local/*.bats` in die Spec-Dateien

🤖 Generated with [Claude Code](https://claude.ai/claude-code)