### PR TITLE
chore(dev-flow): verankere tests/spec/ BATS-Konvention in Skills + CLAUDE.md [T000985]

### DIFF
--- a/.claude/skills/dev-flow-execute/SKILL.md
+++ b/.claude/skills/dev-flow-execute/SKILL.md
@@ -351,13 +351,19 @@ Spawne den Subagenten:
   - Absoluter Worktree-Pfad + Branch-Name; er arbeitet NUR relativ dazu.
   - Plan-Datei `$PLAN_FILE` (aus Schritt 1, via DB aufgelöst) + Ticket-ID.
   - Attachment-Verzeichnis `$ATTACHMENT_DIR` — bei UI-Arbeit ALLE Bilder/Texte mit dem `Read`-Tool einlesen.
-- **⚠️ BATS-Pflicht (kein neues File ohne Prüfung):**
-  Bevor du eine neue `.bats`-Datei erstellst, suche erst in `tests/unit/` nach einer thematisch passenden bestehenden Datei und erweitere diese stattdessen:
+- **⚠️ BATS-Pflicht — Konvention: ein File pro OpenSpec-Spec:**
+  Neue `@test`-Einträge gehören in `tests/spec/<spec-slug>.bats` (die Spec zum Feature/Fix aus `openspec/specs/`).
+  Reihenfolge:
+  1. **Spec-Slug ermitteln:** Welche OpenSpec-Spec (`openspec/specs/*.md`) deckt das zu testende Verhalten ab?
+  2. **Spec-File prüfen/anlegen:** Existiert `tests/spec/<spec-slug>.bats`? Falls ja → `@test`-Block einfügen. Falls nein → neue Datei anlegen (Vorlage: `tests/spec/software-factory.bats`).
+  3. **Fallback:** Für übergreifende Tests ohne Spec-Zuordnung → passende Datei in `tests/unit/` erweitern.
   ```bash
-  # Beispiel: testest du ein Script → scripts.bats; Ticket-Logik → tickets-*.bats; Website → website-*.bats
-  grep -rl "<modul-stichwort>" tests/unit/ tests/local/
+  # Spec-Slug herausfinden:
+  ls openspec/specs/          # alle SSOT-Specs
+  ls tests/spec/              # bereits konsolidierte Spec-Dateien
+  # @test in tests/spec/<slug>.bats einfügen, nicht neue tests/local/FA-XY-*.bats Datei
   ```
-  **Neue `.bats`-Datei nur wenn:** das zu testende Modul hat bisher NULL Testabdeckung UND kein thematisch verwandter Dateiname existiert. In allen anderen Fällen: `@test`-Block in die passende bestehende Datei einfügen. Ziel: die Gesamtzahl der `.bats`-Dateien in `tests/unit/` sinkt oder bleibt konstant.
+  **Ziel:** Die Gesamtzahl der `.bats`-Dateien in `tests/local/` sinkt oder bleibt konstant. Ticket-nummerierte Dateien (`FA-SF-42.bats`) sind Legacy — nicht neu anlegen.
 
 - **Auftrag:**
   - **/goal: Finish dev-flow-execute and merge the PR cleanly.**

--- a/.claude/skills/dev-flow-plan/SKILL.md
+++ b/.claude/skills/dev-flow-plan/SKILL.md
@@ -380,6 +380,8 @@ Exit 1 = eine lebende Session arbeitet schon daran → koordinieren, nicht dupli
 ### Schritt 3: Failing Test schreiben
 Schreibe einen automatisierten Test, der den Bug reproduziert und fehlschlägt (PASS/FAIL rot-grün Prinzip). Dies ist eine **harte Voraussetzung** für den Fix-Pfad.
 
+**Wo:** In `tests/spec/<spec-slug>.bats` (Spec zu diesem Fix aus `openspec/specs/`), nicht in eine neue `tests/local/FA-XY-*.bats` Ticket-Datei. Falls `tests/spec/<spec-slug>.bats` noch nicht existiert, anlegen (Vorlage: `tests/spec/software-factory.bats`).
+
 ### Schritt 4: Plan schreiben
 Rufe `superpowers:writing-plans` auf. Wende das Frontmatter an und trage die Ticket-ID ein. Committe und pushe den Plan.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,6 +134,7 @@ Services: Traefik → Keycloak (OIDC), Nextcloud+Talk, Collabora, Talk-HPB+cotur
 GitHub Actions (`.github/workflows/ci.yml`) runs on every PR:
 - Offline tests: `task test:all` (BATS unit tests, kustomize manifest structure, Taskfile dry-run)
 - **Test inventory check**: re-runs `task test:inventory` and fails the job if `website/src/data/test-inventory.json` differs from the committed version — regenerate it locally and commit alongside any test additions.
+- **BATS convention (tests/spec/)**: New `@test` entries belong in `tests/spec/<spec-slug>.bats` (one file per OpenSpec SSOT spec in `openspec/specs/`). Do NOT create new ticket-numbered files (`FA-SF-42.bats`). If the spec file doesn't exist yet, create it (see `tests/spec/software-factory.bats` as template). Fallback for cross-cutting tests without a clear spec: `tests/unit/`.
 - **Release notes**: Generate structured release notes from merged PRs via `bash scripts/vda.sh release-notes generate` or `task release:notes` (LLM/DeepSeek-gestützt mit deterministischem Fallback). Publish to GitHub Release body with `publish-github` or prepend to `CHANGELOG.md` with `publish-changelog`.
 - Systembrett template validation (`scripts/tests/systembrett-template.test.sh`)
 - Security scan: image-pin advisory + hardcoded-secret detection in `k3d/*.yaml`


### PR DESCRIPTION
## Summary

- Verankert die neue `tests/spec/<spec-slug>.bats` Konvention (ein File pro OpenSpec SSOT-Spec) als verbindliche Regel in den dev-flow Skills
- Verhindert künftig neue ticket-nummerierte `tests/local/FA-XY-*.bats` Dateien
- Follow-up zu PR #1945 (software-factory.bats PoC)

## Geänderte Dateien

| Datei | Änderung |
|-------|----------|
| `.claude/skills/dev-flow-execute/SKILL.md` | BATS-Pflicht neu: erst `tests/spec/<slug>.bats`, dann `tests/unit/`, nie neue Ticket-Datei |
| `.claude/skills/dev-flow-plan/SKILL.md` | Fix-Pfad Schritt 3: Zieldatei explizit auf `tests/spec/` gesetzt |
| `CLAUDE.md` | BATS-Konvention als Hinweis im CI/CD-Abschnitt |

## Test plan

- [x] `task workspace:validate` grün
- [x] `task freshness:check` grün
- [x] Kein produktiver Code geändert, nur Skill-Dokumentation

🤖 Generated with [Claude Code](https://claude.ai/claude-code)