### PR TITLE
test(e2e): bypass inherited storageState for content-hub auth-gate tests

### DIFF
--- a/tests/e2e/specs/fa-content-hub-concurrency.spec.ts
+++ b/tests/e2e/specs/fa-content-hub-concurrency.spec.ts
@@ -17,6 +17,14 @@ import { assertReachable } from '../lib/health-assertions';
 
 const BASE = (process.env.WEBSITE_URL ?? 'https://web.mentolder.de').replace(/\/$/, '');
 
+// These tests run under the `mentolder` project which carries an admin
+// storageState. To assert the auth gate is wired we must POST without that
+// session cookie — using a fresh APIRequestContext via `playwright.request`
+// bypasses the inherited cookies entirely. [fix/content-hub-service-page-config]
+async function anonContext(playwright: import('@playwright/test').Playwright) {
+  return playwright.request.newContext({ baseURL: BASE, ignoreHTTPSErrors: true });
+}
+
 test.describe('FA content-hub: concurrency safety (AC 6)', { tag: ['@content-hub'] }, () => {
   test.beforeEach(async ({ request }, testInfo) => {
     await assertReachable(
@@ -27,35 +35,49 @@ test.describe('FA content-hub: concurrency safety (AC 6)', { tag: ['@content-hub
     );
   });
 
-  test('save endpoint rejects request without auth (401)', async ({ request }) => {
-    // services project has no storageState — confirm the auth gate is wired.
-    const res = await request.post(`${BASE}/api/admin/content/save`, {
-      data: { contentKey: 'stammdaten', baseVersion: 0, payload: {} },
-    });
-    expect([401, 403], 'unauthenticated save is rejected').toContain(res.status());
+  test('save endpoint rejects request without auth (401)', async ({ playwright }) => {
+    const request = await anonContext(playwright);
+    try {
+      const res = await request.post(`/api/admin/content/save`, {
+        data: { contentKey: 'stammdaten', baseVersion: 0, payload: {} },
+      });
+      expect([401, 403], 'unauthenticated save is rejected').toContain(res.status());
+    } finally {
+      await request.dispose();
+    }
   });
 
-  test('two saves with the same baseVersion — second gets 409 (API contract)', async ({ request }) => {
+  test('two saves with the same baseVersion — second gets 409 (API contract)', async ({ playwright }) => {
     // Without admin credentials in this project we can only verify the auth gate
     // from here. The full optimistic-lock 409 path is covered by:
     //   website/src/pages/api/admin/content/save.test.ts (unit mock)
     //   website/src/lib/admin/conflict.test.ts (pure helper)
     // This test documents the expected API contract so future authenticated
     // runners (dev-flow-iterate against a live cluster) can exercise it.
-    const payload = { contentKey: 'stammdaten', baseVersion: -1, payload: {} };
-    const res1 = await request.post(`${BASE}/api/admin/content/save`, { data: payload });
-    const res2 = await request.post(`${BASE}/api/admin/content/save`, { data: payload });
-    // Both should return 401 without auth; with auth the second should return 409.
-    // We assert both are consistent (same status) as a sanity check.
-    expect([401, 403]).toContain(res1.status());
-    expect([401, 403]).toContain(res2.status());
+    const request = await anonContext(playwright);
+    try {
+      const payload = { contentKey: 'stammdaten', baseVersion: -1, payload: {} };
+      const res1 = await request.post(`/api/admin/content/save`, { data: payload });
+      const res2 = await request.post(`/api/admin/content/save`, { data: payload });
+      // Both should return 401 without auth; with auth the second should return 409.
+      // We assert both are consistent (same status) as a sanity check.
+      expect([401, 403]).toContain(res1.status());
+      expect([401, 403]).toContain(res2.status());
+    } finally {
+      await request.dispose();
+    }
   });
 
-  test('save returns 400 for unknown contentKey (auth gate check)', async ({ request }) => {
-    const res = await request.post(`${BASE}/api/admin/content/save`, {
-      data: { contentKey: '__bad_key__', baseVersion: 0, payload: {} },
-    });
-    // 401/403 before auth; 400 after auth with bad key.
-    expect([400, 401, 403]).toContain(res.status());
+  test('save returns 400 for unknown contentKey (auth gate check)', async ({ playwright }) => {
+    const request = await anonContext(playwright);
+    try {
+      const res = await request.post(`/api/admin/content/save`, {
+        data: { contentKey: '__bad_key__', baseVersion: 0, payload: {} },
+      });
+      // 401/403 before auth; 400 after auth with bad key.
+      expect([400, 401, 403]).toContain(res.status());
+    } finally {
+      await request.dispose();
+    }
   });
 });

--- a/tests/e2e/specs/fa-content-hub-editor.spec.ts
+++ b/tests/e2e/specs/fa-content-hub-editor.spec.ts
@@ -57,10 +57,18 @@ test.describe('FA content-hub: unified editor (AC 4)', { tag: ['@content-hub'] }
     await ctx.close();
   });
 
-  test('restore endpoint rejects unauthenticated requests', async ({ request }) => {
-    const res = await request.post(`${BASE}/api/admin/content/restore`, {
-      data: { contentKey: 'stammdaten', versionId: 1 },
-    });
-    expect([401, 403], 'restore requires auth').toContain(res.status());
+  test('restore endpoint rejects unauthenticated requests', async ({ playwright }) => {
+    // The `mentolder` project ships an admin storageState; use a fresh request
+    // context so the session cookie is NOT sent and the auth gate is actually
+    // exercised. [fix/content-hub-service-page-config]
+    const request = await playwright.request.newContext({ baseURL: BASE, ignoreHTTPSErrors: true });
+    try {
+      const res = await request.post(`/api/admin/content/restore`, {
+        data: { contentKey: 'stammdaten', versionId: 1 },
+      });
+      expect([401, 403], 'restore requires auth').toContain(res.status());
+    } finally {
+      await request.dispose();
+    }
   });
 });

--- a/tests/e2e/specs/fa-content-hub-legal-ssot.spec.ts
+++ b/tests/e2e/specs/fa-content-hub-legal-ssot.spec.ts
@@ -59,15 +59,28 @@ test.describe('FA content-hub: legal SSOT token resolution', { tag: ['@content-h
     expect(html, 'korczewski impressum contains stammdaten email').toMatch(EMAIL_RE);
   });
 
-  test('save endpoint rejects unauthenticated requests', async ({ request }) => {
-    const res = await request.post(`${MENTOLDER_BASE}/api/admin/content/save`, {
-      data: { contentKey: 'stammdaten', baseVersion: 0, payload: {} },
-    });
-    expect([401, 403], 'save requires auth').toContain(res.status());
+  test('save endpoint rejects unauthenticated requests', async ({ playwright }) => {
+    // The `mentolder` project ships an admin storageState; use a fresh request
+    // context so the session cookie is NOT sent and the auth gate is actually
+    // exercised. [fix/content-hub-service-page-config]
+    const request = await playwright.request.newContext({ baseURL: MENTOLDER_BASE, ignoreHTTPSErrors: true });
+    try {
+      const res = await request.post(`/api/admin/content/save`, {
+        data: { contentKey: 'stammdaten', baseVersion: 0, payload: {} },
+      });
+      expect([401, 403], 'save requires auth').toContain(res.status());
+    } finally {
+      await request.dispose();
+    }
   });
 
-  test('versions endpoint rejects unauthenticated requests', async ({ request }) => {
-    const res = await request.get(`${MENTOLDER_BASE}/api/admin/content/versions?key=stammdaten`);
-    expect([401, 403], 'versions requires auth').toContain(res.status());
+  test('versions endpoint rejects unauthenticated requests', async ({ playwright }) => {
+    const request = await playwright.request.newContext({ baseURL: MENTOLDER_BASE, ignoreHTTPSErrors: true });
+    try {
+      const res = await request.get(`/api/admin/content/versions?key=stammdaten`);
+      expect([401, 403], 'versions requires auth').toContain(res.status());
+    } finally {
+      await request.dispose();
+    }
   });
 });


### PR DESCRIPTION
## Summary

Fixes the 4 content-hub E2E auth-gate tests that started failing once
`fa-content-hub-*.spec.ts` was matched to the `mentolder` Playwright
project (which carries an admin `storageState`).

## Root cause

`fa-content-hub-concurrency`, `fa-content-hub-editor`, and
`fa-content-hub-legal-ssot` all have tests that use `{ request }` and
assert the unauthenticated save/restore/versions endpoints return
`[401, 403]`. The test file comments said "services project has no
storageState — confirm the auth gate is wired", but the actual project
match in `playwright.pr.config.ts` is `mentolder` with
`storageState: '.auth/mentolder-website-admin.json'`. The session cookie
is silently inherited, the auth check passes, validation fails on
`payload: {}`, and the response is 422.

## Fix

Each affected test now creates a fresh `APIRequestContext` via
`playwright.request.newContext({ baseURL })`, so the session cookie is
NOT sent and the auth gate is actually exercised. `request.dispose()`
is called in `finally` to avoid leaks.

## Why this is a chore (not a fix)

Caught by `E2E PR` on #1944 (content-hub-service-page-config). Every
future content-hub PR will re-trip these tests until the auth-gate is
isolated from the project storageState. The /admin/inhalte mobile
horizontal overflow (`218px > 2px`) is a separate UI bug in
`InhalteEditor.svelte` and is left for a follow-up ticket.

## Verification

```bash
WEBSITE_URL=https://web.mentolder.de \
  npx playwright test fa-content-hub-concurrency fa-content-hub-editor fa-content-hub-legal-ssot \
  --config playwright.pr.config.ts --grep "@content-hub"
```

Expected: 4 auth-gate tests now return 401/403 (the live prod endpoint
does enforce the gate).