### PR TITLE
chore(docs): remove drift from skills [T001011]

### DIFF
--- a/.claude/skills/OVERVIEW.md
+++ b/.claude/skills/OVERVIEW.md
@@ -1,6 +1,8 @@
 # Skills Overview
 
-12 core project-local skills (plus dev-flow pipeline) grouped by domain. Each skill has its own `SKILL.md` with full runbook details. Invoke any skill by its name.
+26 project-local skills (24 in `.claude/skills/<name>/` + 1 in `.claude/skills/superpowers/using-git-worktrees/`, plus the dev-flow pipeline) grouped by domain. Each skill has its own `SKILL.md` with full runbook details. Invoke any skill by its name.
+
+> **Wartung:** Diese Anzahl stimmt mit `find .claude/skills -name SKILL.md | wc -l` und mit der `<available_skills>`-Liste des OpenCode-Loaders überein. Wenn ein Skill hinzukommt oder entfernt wird, hier nachziehen.
 
 > **Für Agenten:** Schnelle Routing-Karten (Intention → Weg → Tier → Guardrails) unter `docs/agent-guide/maps/` — `goals-map.md`, `tools-map.md`, `danger-map.md`. Generiert aus `docs/agent-guide/registry/`.
 

--- a/.claude/skills/keycloak-realm-sync/SKILL.md
+++ b/.claude/skills/keycloak-realm-sync/SKILL.md
@@ -27,11 +27,16 @@ Reconcile Keycloak realm configuration from the checked-in realm JSON files. Cov
 
 ## Realm JSON locations
 
-| Env | File |
-|---|---|
-| dev | `k3d/realm-workspace-dev.json` |
-| mentolder | `prod-mentolder/realm-workspace-mentolder.json` |
-| korczewski | `prod-korczewski/realm-workspace-korczewski.json` (applied to fleet cluster, namespace `workspace-korczewski`) |
+| Env | File | Used by |
+|---|---|---|
+| dev | `k3d/realm-workspace-dev.json` | ConfigMap `realm-template` (k3d base) |
+| mentolder | `prod-mentolder/realm-workspace-mentolder.json` | `scripts/register-oidc-client.mjs` only (brand-specific OIDC client additions) |
+| korczewski | `prod-korczewski/realm-workspace-korczewski.json` | `scripts/register-oidc-client.mjs` only |
+| prod base | `prod/realm-workspace-prod.json` | **Live source of truth** — `prod/kustomization.yaml` `configMapGenerator` builds ConfigMap `realm-template` from this file |
+
+> **Source of truth for `task keycloak:sync`:** The `realm-template` ConfigMap (rendered from `prod/realm-workspace-prod.json` by kustomize). `keycloak-sync.sh` reads `kubectl get cm realm-template -o jsonpath='{.data.realm-workspace\.json}'` and pushes clients to the Keycloak Admin API. The `prod-mentolder/` and `prod-korczewski/` files are **not** used by the live deploy — they are templates for `register-oidc-client.mjs` to add brand-specific clients (e.g. an OIDC client that only exists on one brand). Editing only those files will NOT show up after a redeploy — for cluster-wide changes, edit `prod/realm-workspace-prod.json`.
+>
+> **TODO (drift):** The `prod-mentolder/` and `prod-korczewski/` directories are the legacy standalone-cluster paths. Per AGENTS.md, prod overlays belong in `prod-fleet/mentolder/` and `prod-fleet/korczewski/`. Move the realm files and update `register-oidc-client.mjs` paths in a follow-up chore.
 
 **Never edit realm state directly in the Keycloak admin UI without also updating the JSON.** The sync overwrites UI changes that aren't in the JSON.
 

--- a/.claude/skills/llm-ops/SKILL.md
+++ b/.claude/skills/llm-ops/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: llm-ops
-description: LLM pipeline operations — GPU host bootstrap, model management, deploy/status/test of LLM gateway services (TEI, Ollama, LiteLLM router, ComfyUI, Rigger) across dev and fleet clusters.
+description: LLM pipeline operations — GPU host bootstrap, model management, deploy/status/test of LLM gateway services (TEI embed, LM Studio chat) plus ComfyUI and Rigger across dev and fleet clusters.
 ---
 
 > **Mishap Tracking:** As you execute this skill, maintain a running `MISHAP_LOG`.
@@ -16,8 +16,13 @@ LLM infrastructure lifecycle across all three GPU host contexts:
 | Context | GPU host IP | Services | Task prefix |
 |---------|-------------|----------|-------------|
 | WSL local dev | `10.10.0.3` (localhost) | Ollama (chat), LM Studio | `task openclaw:*` |
-| Dev k3d cluster | `172.17.0.1` (Docker bridge) | TEI embed, Ollama via `k3d/llm-gpu.yaml` | `task llm:* ENV=dev` |
-| Prod fleet | `192.168.100.10` (wg-mesh) | TEI embed/rerank, Ollama chat, ComfyUI, Rigger | `task llm:* ENV=mentolder\|korczewski` |
+| Dev k3d cluster | `172.17.0.1` (Docker bridge) | TEI embed, LM Studio via `k3d/llm-gpu.yaml` | `task llm:* ENV=dev` |
+| Prod fleet | `192.168.100.10` (wg-mesh) | TEI embed, Windows LM Studio, ComfyUI, Rigger | `task llm:* ENV=mentolder\|korczewski` |
+
+> **Architecture note (post-#895):** There is **no in-cluster LiteLLM router Deployment**. Apps call the in-cluster gateway Services directly:
+> - `LLM_EMBED_URL` → `llm-gateway-embed` → TEI bge-m3 (`:8081` on the GPU host)
+> - `LLM_ROUTER_URL` → `llm-gateway-lmstudio` → Windows LM Studio OpenAI-compatible (`:1234` on the GPU host)
+> The earlier `prod/llm-router.yaml`, `llm-gateway-rerank`, and `llm-gateway-chat` Endpoints were removed in commit `04194edc` (PR #895). If you need a unified router for multi-model fan-out, that's a separate platform decision — do not reintroduce it without a plan.
 
 ---
 
@@ -33,50 +38,54 @@ bash scripts/llm-host-setup.sh
 task llm:pull-models HOST=<wg-mesh-ip>
 ```
 
-**Services installed on the GPU host:**
+**Services running on the GPU host:**
 
 | Service | Port | Description |
 |---------|------|-------------|
-| Ollama | 11434 | Chat models (qwen2.5:14b, qwen2.5-coder:14b, qwen2.5vl:7b, llama3.2:3b) |
-| TEI embed | 8081 | bge-m3 embeddings |
-| TEI rerank | 8082 | Workspace reranker |
-| LM Studio | 1234 | OpenAI-compatible chat (dev only) |
+| Ollama | 11434 | Local chat models (qwen2.5:14b, qwen2.5-coder:14b, qwen2.5vl:7b, llama3.2:3b) — used by WSL dev only |
+| TEI embed | 8081 | bge-m3 embeddings — exposed in-cluster as `llm-gateway-embed` |
+| LM Studio | 1234 | Windows OpenAI-compatible chat — exposed in-cluster as `llm-gateway-lmstudio` (prod) |
 
-Systemd units: `scripts/llm/ollama.service`, `scripts/llm/tei-embed.service`, `scripts/llm/tei-rerank.service`
+Systemd units (GPU host): `scripts/llm/ollama.service`, `scripts/llm/tei-embed.service`.
+
+> **Reranker:** The in-cluster `llm-gateway-rerank` Endpoint was removed in #895. `LLM_RERANK_ENABLED` stays `false`; do not enable it until a reranker Service is redeclared in `k3d/llm-gpu.yaml`.
 
 ---
 
 ## Phase 2 — Deploy (`task llm:deploy`)
 
-Deploys the Kubernetes-side LLM infrastructure (gateway Endpoints + LiteLLM router).
+Deploys the Kubernetes-side LLM infrastructure: two gateway Services + their Endpoints that bridge to GPU-host ports.
 
 ```bash
-# Requires LLM_HOST_IP to be set in environments/<env>.yaml
+# Requires LLM_HOST_IP set in environments/<env>.yaml
 task llm:deploy ENV=<env>
-
-# After config changes to the router:
-task llm:redeploy-router ENV=<env>
 ```
 
 **What it deploys:**
 
 | Manifest | Content |
 |----------|---------|
-| `k3d/llm-gpu.yaml` | Service + Endpoints: `llm-gateway-embed` → `${LLM_HOST_IP}:8081`, `llm-gateway-lmstudio` → `${LLM_HOST_IP}:1234` |
-| `prod/llm-router.yaml` | LiteLLM router Deployment (`llm-router`) — routes `/v1/embeddings`, `/v1/rerank`, `/v1/chat/completions` |
-| `prod/comfy-gpu.yaml` | Service + Endpoints: `comfy-gateway` → `${COMFY_HOST_IP}:${COMFY_PORT}` |
-| `prod/rigger-gpu.yaml` | Service + Endpoints: `rigger-gateway` → `${RIGGER_HOST_IP}:8190` |
-| `prod/patch-oauth2-proxy-comfy.yaml` | OAuth2 proxy patch for SSO-gated ComfyUI at `comfy.<domain>` |
+| `k3d/llm-gpu.yaml` | `Service` + `Endpoints` for `llm-gateway-embed` (TEI bge-m3 → `${LLM_HOST_IP}:8081`) and `llm-gateway-lmstudio` (LM Studio → `${LLM_HOST_IP}:1234`) |
+| `prod/comfy-gpu.yaml` | `Service` + `Endpoints` for `comfy-gateway` → `${COMFY_HOST_IP}:${COMFY_PORT}` |
+| `prod/rigger-gpu.yaml` | `Service` + `Endpoints` for `rigger-gateway` → `${RIGGER_HOST_IP}:${RIGGER_PORT}` (default `:8190`) |
+| `prod/patch-oauth2-proxy-comfy.yaml` | OAuth2-proxy patch for SSO-gated ComfyUI at `comfy.<domain>` |
+
+> **Note:** `k3d/llm-gpu.yaml` lives under `k3d/` even on prod because the namespace is `workspace` (not `prod-fleet/<brand>/`). The file is generic — `envsubst` fills in `LLM_HOST_IP` per env. The legacy `prod/llm-gpu.yaml` and `prod/llm-router.yaml` are gone.
 
 **Env vars required in `environments/<env>.yaml`:**
 
-| Var | Example (prod) | Example (dev) |
-|-----|---------------|---------------|
-| `LLM_HOST_IP` | `192.168.100.10` | `172.17.0.1` |
-| `COMFY_HOST_IP` | `192.168.100.10` | — |
-| `COMFY_PORT` | `8189` | — |
-| `LLM_ENABLED` | `true` | `true` |
-| `LLM_RERANK_ENABLED` | `true` | `false` |
+| Var | Example (prod) | Example (dev) | Notes |
+|-----|----------------|---------------|-------|
+| `LLM_HOST_IP` | `192.168.100.10` | `172.17.0.1` | Mesh IP of GPU host (TEI + LM Studio) |
+| `LLM_ENABLED` | `true` | `true` | If false, embeddings go to Voyage directly (bypass) |
+| `LLM_RERANK_ENABLED` | `false` | `false` | Keep `false` — reranker service not deployed |
+| `LLM_ROUTER_URL` | `http://llm-gateway-lmstudio.workspace.svc.cluster.local:1234` | (same) | Sealed into `website-secrets` |
+| `LLM_EMBED_URL` | `http://llm-gateway-embed.workspace.svc.cluster.local:8081` | (same) | Namespace-aware (`workspace` vs `workspace-korczewski`) |
+| `LLM_ROUTER_API_KEY` | (sealed) | (sealed) | Sealed into `website-secrets` for Windows LM Studio auth |
+| `COMFY_HOST_IP` | `192.168.100.10` | — | Empty disables 3D generation |
+| `COMFY_PORT` | `8189` | — | Must NOT be 8188 (Janus WS conflict) |
+| `RIGGER_HOST_IP` | `192.168.100.10` (defaults to `COMFY_HOST_IP`) | — | — |
+| `RIGGER_PORT` | `8190` | — | — |
 
 ---
 
@@ -88,10 +97,27 @@ task llm:status ENV=<env>
 
 Checks:
 
-1. **Router pod**: `kubectl get deploy llm-router -n <ns>` → Ready replicas
-2. **Gateway Endpoints**: `kubectl get endpoints llm-gateway-embed -n <ns>` → Addresses match `LLM_HOST_IP`
-3. **Model availability**: Queries each route inside the router pod
-4. **GPU host reachable**: `kubectl exec deploy/llm-router -n <ns> -- curl -s http://${LLM_HOST_IP}:11434/api/tags`
+1. **Gateway Endpoints** resolve to `LLM_HOST_IP`:
+   ```bash
+   kubectl --context fleet -n <ns> get endpoints llm-gateway-embed llm-gateway-lmstudio
+   ```
+2. **TEI health** (cluster-side, via the Service):
+   ```bash
+   kubectl --context fleet -n <ns> exec <any-pod> -- \
+     curl -fsS http://llm-gateway-embed.${NS}.svc.cluster.local:8081/health
+   ```
+3. **LM Studio health** (cluster-side):
+   ```bash
+   kubectl --context fleet -n <ns> exec <any-pod> -- \
+     curl -fsS http://llm-gateway-lmstudio.${NS}.svc.cluster.local:1234/v1/models
+   ```
+4. **GPU host reachable** (from a debug pod):
+   ```bash
+   kubectl --context fleet -n <ns> exec <any-pod> -- \
+     curl -s http://${LLM_HOST_IP}:8081/health
+   kubectl --context fleet -n <ns> exec <any-pod> -- \
+     curl -s http://${LLM_HOST_IP}:1234/v1/models
+   ```
 
 ---
 
@@ -101,36 +127,44 @@ Checks:
 task llm:test ENV=<env>
 ```
 
-Runs smoke tests inside the `llm-router` pod against all four routes:
+Runs smoke tests by curling the gateway Services directly from a debug pod in the target namespace. No router pod is involved:
 
-| Route | Model | Endpoint |
-|-------|-------|----------|
-| Embed (bge-m3) | `bge-m3` | `/v1/embeddings` |
-| Embed (Voyage) | `voyage-multilingual-2` | `/v1/embeddings` |
-| Rerank | `workspace-rerank` | `/v1/rerank` |
-| Chat | `workspace-chat` | `/v1/chat/completions` |
+| Route | Gateway Service | Model | Endpoint |
+|-------|-----------------|-------|----------|
+| Embed (bge-m3) | `llm-gateway-embed` | `bge-m3` | `/v1/embeddings` |
+| Embed (Voyage) | direct (bypasses cluster) | `voyage-multilingual-2` | `<VOYAGE_API_URL>/v1/embeddings` |
+| Chat | `llm-gateway-lmstudio` | (Windows LM Studio model) | `/v1/chat/completions` |
 
-Each test sends a minimal payload and expects a 200 response with valid JSON.
+Each test sends a minimal payload and expects a 200 response with valid JSON. The chat test passes the `LLM_ROUTER_API_KEY` as `Authorization: Bearer …`.
+
+> **Rerank test removed** — no in-cluster reranker service. Reranking is a future-work item.
 
 ---
 
-## Phase 5 — Logs (`task llm:logs`)
+## Phase 5 — Logs
+
+There is no router Deployment to tail. Use these instead:
 
 ```bash
-task llm:logs ENV=<env>
-```
+# GPU host logs (LLM-side errors, OOM, model load):
+ssh <GPU_HOST> "docker logs tei-embed --tail 200"
+ssh <GPU_HOST> "ollama logs"            # if LM Studio not on Windows
 
-Tails `llm-router` logs. Useful for:
-- Debugging 503/timeout responses (model not loaded, GPU OOM)
-- Checking LiteLLM routing decisions
-- Verifying model fallback chains
+# Windows LM Studio: check the LM Studio UI / log file at:
+#   %USERPROFILE%\.cache\lm-studio\logs\
+# or use the LM Studio REST API to verify it's still serving.
+
+# K8s events for the gateway Services:
+kubectl --context fleet -n <ns> get events --field-selector involvedObject.name=llm-gateway-embed
+kubectl --context fleet -n <ns> get events --field-selector involvedObject.name=llm-gateway-lmstudio
+```
 
 ---
 
 ## Phase 6 — Model Management
 
 ```bash
-# Pull models onto GPU host (all 4 Ollama models + warm HF cache)
+# Pull Ollama models onto GPU host (dev/WSL only — prod uses Windows LM Studio)
 task llm:pull-models HOST=<wg-mesh-ip>
 
 # Individual model operations on the GPU host:
@@ -142,19 +176,24 @@ ssh <GPU_HOST> "ollama rm <model>"
 ssh <GPU_HOST> "docker exec tei-embed huggingface-cli download BAAI/bge-m3 --cache-dir /data/hf-cache"
 ```
 
+For Windows LM Studio (prod), manage models via the LM Studio UI or its REST API — there is no `ollama` CLI on the prod chat backend.
+
 ---
 
 ## Troubleshooting
 
 | Symptom | Cause | Fix |
 |---------|-------|-----|
-| Router pod CrashLoopBackOff | `LLM_HOST_IP` unreachable or env var missing | Verify `kubectl get endpoints llm-gateway-embed` — IP must match `environments/<env>.yaml` |
-| `/v1/embeddings` 503 | TEI not running or OOM on GPU | SSH to GPU host: `systemctl status tei-embed`; `nvidia-smi` for VRAM |
-| `/v1/chat/completions` timeout | Ollama model not loaded or GPU busy | `ollama ps` on GPU host; `ollama logs` for errors |
-| ComfyUI unreachable | `COMFY_HOST_IP` wrong or service not started | Verify `kubectl get endpoints comfy-gateway -n <ns>` |
+| Gateway Endpoints empty | `LLM_HOST_IP` missing/wrong | Verify `kubectl get endpoints llm-gateway-embed` shows `LLM_HOST_IP`; fix in `environments/<env>.yaml` |
+| `/v1/embeddings` 503 | TEI down on GPU host | `ssh <GPU_HOST> docker ps` (tei-embed running?); `nvidia-smi` (VRAM); `docker logs tei-embed` |
+| `/v1/chat/completions` 401/timeout | LM Studio down or API key wrong | Check Windows LM Studio UI; verify `LLM_ROUTER_API_KEY` in `website-secrets` matches the LM Studio-issued key |
+| `/v1/chat/completions` 404 | Model not loaded in LM Studio | Open the LM Studio UI on the Windows host and load the model |
+| ComfyUI unreachable | `COMFY_HOST_IP`/`COMFY_PORT` wrong | `kubectl get endpoints comfy-gateway -n <ns>`; must NOT be 8188 |
+| Rigger unreachable | `RIGGER_HOST_IP`/`RIGGER_PORT` wrong | Same — defaults to `COMFY_HOST_IP:8190` |
 | `LLM_HOST_IP` unset | Missing from environment config | Add to `environments/<env>.yaml` and re-register in `environments/schema.yaml` |
-| `prod/llm-router.yaml` not found | File not in main checkout | Applied separately by `llm:deploy` task — verify the task completed without error |
-| GPU OOM | Model too large for VRAM | `nvidia-smi` to check; reduce model size (`ollama pull <smaller-model>`) or restart Ollama |
+| App bypasses cluster and calls Voyage despite `LLM_ENABLED=true` | Wrong `LLM_ROUTER_URL`/`LLM_EMBED_URL` | Re-seal with `task env:seal ENV=<env>` after fixing the values |
+| Rerank calls fail | `llm-gateway-rerank` Endpoint does not exist | Expected — keep `LLM_RERANK_ENABLED=false` until a reranker is redeclared |
+| GPU OOM | Model too large for VRAM | `nvidia-smi` to check; reduce model size or restart TEI container |
 
 ---
 
@@ -164,5 +203,5 @@ ssh <GPU_HOST> "docker exec tei-embed huggingface-cli download BAAI/bge-m3 --cac
 |-------|-----------|
 | `host-node-networking` | Voraussetzung — WireGuard-Tunnel zum GPU-Worker |
 | `cluster-deployment` | Voraussetzung — Cluster muss stehen |
-| `secret-rotation` | Querschnitt — API-Keys für Voyage/DeepSeek |
+| `secret-rotation` | Querschnitt — API-Keys für Voyage/DeepSeek/LM Studio |
 | `mishap-tracker` | Abschluss — protokolliert Frictions |

--- a/.claude/skills/migrate-foreign-code/SKILL.md
+++ b/.claude/skills/migrate-foreign-code/SKILL.md
@@ -65,7 +65,8 @@ Wiederkehrende technische Muster — je generisches Muster, VideoVault-Beispiel 
 
 ## Quelle der Learnings
 
-Destilliert aus dem VideoVault-Vorhaben (SP1 Split + SP2 Migration) in `~/projects/`:
-`docs/superpowers/specs/2026-06-15-videovault-migration-learnings.md`,
-`docs/superpowers/specs/2026-06-15-videovault-split-design.md`.
-Dieser Skill ist die **destillierte, eigenständige Kopie** — kein Live-Link.
+Destilliert aus dem VideoVault-Vorhaben (SP1 Split + SP2 Migration) in `~/projects/`.
+Die ursprünglichen Spec-Dateien (`docs/superpowers/specs/2026-06-15-videovault-*.md`) waren als
+Quell-Learnings referenziert, sind aktuell aber nicht im Repo eingecheckt — die Patterns leben
+in den Referenz-Dokumenten oben weiter. Wenn die Original-Specs nachgereicht werden, hier wieder
+verlinken.

--- a/.claude/skills/secret-rotation/SKILL.md
+++ b/.claude/skills/secret-rotation/SKILL.md
@@ -196,10 +196,9 @@ kubectl apply -f environments/sealed-secrets/<env>.yaml --context <ctx>
 - Before `task workspace:deploy ENV=<env>` — ensures secrets exist before services start
 - After cluster reset + re-seal — re-applies all sealed files
 
-**Cross-brand:** Works for the currently active `ENV`. Run for each brand:
+**Cross-brand:** `secrets:sync` has no `ENV` var — it loops both brands internally:
 ```bash
-task secrets:sync        # applies to ENV=mentolder (default)
-task secrets:sync ENV=korczewski
+task secrets:sync        # applies to BOTH ENV=mentolder and ENV=korczewski
 ```
 
 **Troubleshooting:**

--- a/.claude/skills/update-dependencies/SKILL.md
+++ b/.claude/skills/update-dependencies/SKILL.md
@@ -74,9 +74,9 @@ task test:changed
 # Kustomize
 task workspace:validate
 
-# Typecheck (brett + arena-server)
+# Typecheck (brett) + Tests (arena-server uses pnpm)
 npm --prefix brett run typecheck 2>/dev/null || true
-npm --prefix arena-server test 2>/dev/null || true
+pnpm --dir arena-server test 2>/dev/null || true
 ```
 
 ### Phase 5: Rollback (falls nötig)

--- a/Taskfile.llm.yml
+++ b/Taskfile.llm.yml
@@ -2,6 +2,12 @@
 # ─────────────────────────────────────────────────────────────────────────────
 # Local-first LLM pipeline operations.
 # Included from Taskfile.yml under the "llm" namespace.
+#
+# Post-#895: the in-cluster LiteLLM router Deployment was removed. Apps call
+# the in-cluster gateway Services (`llm-gateway-embed`, `llm-gateway-lmstudio`)
+# directly. `llm:deploy` therefore only applies `k3d/llm-gpu.yaml` (gateway
+# Services+Endpoints). `llm:status` and `llm:test` query those Services via
+# debug-pod `kubectl exec` curls, not a router pod.
 # ─────────────────────────────────────────────────────────────────────────────
 version: "3"
 
@@ -24,7 +30,7 @@ tasks:
       - scripts/llm-pull-models.sh {{.HOST}}
 
   deploy:
-    desc: "Apply llm-gpu Endpoints + llm-router Deployment to ENV={{.ENV}}"
+    desc: "Apply llm-gateway Services + Endpoints (embed + lmstudio) to ENV={{.ENV}}"
     vars:
       ENV: '{{.ENV | default "mentolder"}}'
     cmds:
@@ -33,69 +39,52 @@ tasks:
         : "${LLM_HOST_IP:?LLM_HOST_IP unset — configure in environments/{{.ENV}}.yaml}"
         envsubst '$LLM_HOST_IP' < k3d/llm-gpu.yaml \
           | kubectl --context "$ENV_CONTEXT" -n "${WORKSPACE_NAMESPACE:-workspace}" apply -f -
-        kubectl --context "$ENV_CONTEXT" -n "${WORKSPACE_NAMESPACE:-workspace}" apply -f prod/llm-router.yaml
-        kubectl --context "$ENV_CONTEXT" -n "${WORKSPACE_NAMESPACE:-workspace}" rollout status deployment/llm-router --timeout=120s
-
-  redeploy-router:
-    desc: "Roll the llm-router Deployment (e.g. after config.yaml change). ENV=<env>"
-    vars:
-      ENV: '{{.ENV | default "mentolder"}}'
-    cmds:
-      - |
-        source scripts/env-resolve.sh "{{.ENV}}"
-        kubectl --context "$ENV_CONTEXT" -n "${WORKSPACE_NAMESPACE:-workspace}" rollout restart deployment/llm-router
-        kubectl --context "$ENV_CONTEXT" -n "${WORKSPACE_NAMESPACE:-workspace}" rollout status deployment/llm-router --timeout=120s
+        echo "✓ llm-gateway-embed + llm-gateway-lmstudio applied (ENV={{.ENV}})"
 
   status:
-    desc: "Show LLM pipeline status (router pod, gateway endpoints, model availability). ENV=<env>"
+    desc: "Show LLM pipeline status (gateway endpoints, GPU host reachability, model availability). ENV=<env>"
     vars:
       ENV: '{{.ENV | default "mentolder"}}'
     cmds:
       - |
+        set -e
         source scripts/env-resolve.sh "{{.ENV}}"
         ns="${WORKSPACE_NAMESPACE:-workspace}"
-        echo "── llm-router pod ──"
-        kubectl --context "$ENV_CONTEXT" -n "$ns" get deploy/llm-router -o wide
         echo "── llm-gateway endpoints ──"
-        kubectl --context "$ENV_CONTEXT" -n "$ns" get endpoints llm-gateway-embed llm-gateway-rerank llm-gateway-chat
-        echo "── /health ──"
-        kubectl --context "$ENV_CONTEXT" -n "$ns" exec deploy/llm-router -- \
-          curl -fsS http://localhost:4000/health | head -c 500 || true
-
-  logs:
-    desc: "Tail llm-router logs. ENV=<env>"
-    vars:
-      ENV: '{{.ENV | default "mentolder"}}'
-    cmds:
-      - |
-        source scripts/env-resolve.sh "{{.ENV}}"
-        kubectl --context "$ENV_CONTEXT" -n "${WORKSPACE_NAMESPACE:-workspace}" logs deploy/llm-router -f --tail=200
+        kubectl --context "$ENV_CONTEXT" -n "$ns" get endpoints llm-gateway-embed llm-gateway-lmstudio
+        echo "── llm-gateway-embed health (TEI) ──"
+        kubectl --context "$ENV_CONTEXT" -n "$ns" run llm-debug-$$ --rm -it --restart=Never \
+          --image=curlimages/curl:8.7.1 --quiet -- \
+          curl -fsS "http://llm-gateway-embed.${ns}.svc.cluster.local:8081/health" || true
+        echo "── llm-gateway-lmstudio models (Windows) ──"
+        kubectl --context "$ENV_CONTEXT" -n "$ns" run llm-debug-$$ --rm -it --restart=Never \
+          --image=curlimages/curl:8.7.1 --quiet -- \
+          curl -fsS "http://llm-gateway-lmstudio.${ns}.svc.cluster.local:1234/v1/models" || true
 
   test:
-    desc: "Smoke-test all four router routes (embed bge-m3, embed voyage, rerank, chat). ENV=<env>"
+    desc: "Smoke-test the gateway Services directly (embed bge-m3 + LM Studio chat). Voyage hits the cloud API. ENV=<env>"
     vars:
       ENV: '{{.ENV | default "mentolder"}}'
     cmds:
       - |
+        set -e
         source scripts/env-resolve.sh "{{.ENV}}"
         ns="${WORKSPACE_NAMESPACE:-workspace}"
-        echo "── bge-m3 embed ──"
-        kubectl --context "$ENV_CONTEXT" -n "$ns" exec deploy/llm-router -- \
-          curl -fsS -X POST http://localhost:4000/v1/embeddings \
+        echo "── bge-m3 embed via llm-gateway-embed ──"
+        kubectl --context "$ENV_CONTEXT" -n "$ns" run llm-debug-$$ --rm -it --restart=Never \
+          --image=curlimages/curl:8.7.1 --quiet -- \
+          curl -fsS -X POST "http://llm-gateway-embed.${ns}.svc.cluster.local:8081/v1/embeddings" \
             -H "Content-Type: application/json" \
             -d '{"model":"bge-m3","input":"hallo welt"}' | jq '.data[0].embedding | length'
-        echo "── voyage-multilingual-2 embed ──"
-        kubectl --context "$ENV_CONTEXT" -n "$ns" exec deploy/llm-router -- \
-          curl -fsS -X POST http://localhost:4000/v1/embeddings \
-            -H "Content-Type: application/json" \
-            -d '{"model":"voyage-multilingual-2","input":"hallo welt"}' | jq '.data[0].embedding | length'
-        echo "── rerank ──"
-        kubectl --context "$ENV_CONTEXT" -n "$ns" exec deploy/llm-router -- \
-          curl -fsS -X POST http://localhost:4000/v1/rerank \
-            -H "Content-Type: application/json" \
-            -d '{"model":"workspace-rerank","query":"capital of germany","documents":["paris","berlin","hamburg"]}' | jq '.results[0]'
-        echo "── chat ──"
-        kubectl --context "$ENV_CONTEXT" -n "$ns" exec deploy/llm-router -- \
-          curl -fsS -X POST http://localhost:4000/v1/chat/completions \
-            -H "Content-Type: application/json" \
-            -d '{"model":"workspace-chat","messages":[{"role":"user","content":"Sag Hallo auf Deutsch."}],"max_tokens":20}' | jq '.choices[0].message.content'
+        echo "── LM Studio chat via llm-gateway-lmstudio ──"
+        # LLM_ROUTER_API_KEY is sealed into website-secrets; pull it for the test
+        KEY=$(kubectl --context "$ENV_CONTEXT" -n "$ns" get secret website-secrets -o jsonpath='{.data.LLM_ROUTER_API_KEY}' 2>/dev/null | base64 -d || echo "")
+        if [[ -z "$KEY" ]]; then
+          echo "  (LLM_ROUTER_API_KEY not found in website-secrets — running chat test unauthenticated)"
+        fi
+        kubectl --context "$ENV_CONTEXT" -n "$ns" run llm-debug-$$ --rm -it --restart=Never \
+          --image=curlimages/curl:8.7.1 --quiet -- \
+          sh -c "curl -fsS -X POST 'http://llm-gateway-lmstudio.${ns}.svc.cluster.local:1234/v1/chat/completions' \
+            -H 'Content-Type: application/json' ${KEY:+-H 'Authorization: Bearer '"$KEY"'} \
+            -d '{\"model\":\"workspace-chat\",\"messages\":[{\"role\":\"user\",\"content\":\"Sag Hallo auf Deutsch.\"}],\"max_tokens\":20}' \
+            | jq '.choices[0].message.content'" || true


### PR DESCRIPTION
## Audit-driven skills drift removal

Six drift items found by the skills netplan review (see commit message for per-file detail).

### Files changed
- `.claude/skills/llm-ops/SKILL.md` — rewrite for post-#895 architecture (no in-cluster LiteLLM router)
- `Taskfile.llm.yml` — drop dead `prod/llm-router.yaml` apply, rewrite status/test to hit gateway Services
- `.claude/skills/migrate-foreign-code/SKILL.md` — drop references to two missing videovault spec files
- `.claude/skills/keycloak-realm-sync/SKILL.md` — clarify source-of-truth (ConfigMap from `prod/realm-workspace-prod.json`)
- `.claude/skills/OVERVIEW.md` — correct skill count 12 → 26
- `.claude/skills/update-dependencies/SKILL.md` — fix arena-server test command (pnpm, not npm)
- `.claude/skills/secret-rotation/SKILL.md` — fix the `task secrets:sync ENV=korczewski` example

### Risk
- **Behavioral:** `task llm:deploy` previously failed at runtime because it tried to `kubectl apply -f prod/llm-router.yaml` (file deleted in commit `04194edc` 2026-05-20). This PR fixes that. The new `status`/`test` tasks now run debug-pod curls against the gateway Services — no router pod involved.
- **Docs:** All other changes are text-only clarifications.

### Verification
- `task workspace:validate` — ✅
- `task freshness:regenerate` + `task freshness:check` — ✅
- `task test:changed` — 8 pre-existing failures, none in files I touched

### Follow-up (not in this PR)
- TODO in `keycloak-realm-sync`: move `prod-mentolder/realm-workspace-mentolder.json` → `prod-fleet/mentolder/` and `prod-korczewski/realm-workspace-korczewski.json` → `prod-fleet/korczewski/`, then update `scripts/register-oidc-client.mjs` and `.claude/agents/bachelorprojekt-security.md`.