### PR TITLE
chore(docs): allowlist /api/openspec/search endpoint [T001013]

### DIFF
--- a/website/api-public-allowlist.json
+++ b/website/api-public-allowlist.json
@@ -20,6 +20,7 @@
   { "path": "/api/newsletter/confirm", "methods": ["GET"], "reason": "baseline — not individually audited" },
   { "path": "/api/newsletter/subscribe", "methods": ["POST"], "reason": "baseline — not individually audited" },
   { "path": "/api/newsletter/unsubscribe", "methods": ["GET"], "reason": "baseline — not individually audited" },
+  { "path": "/api/openspec/search", "methods": ["GET"], "reason": "public OpenSpec change search; knowledge-base pgvector query (added in #1972, allowlist entry missed)" },
   { "path": "/api/poll/{id}", "methods": ["GET"], "reason": "baseline — not individually audited" },
   { "path": "/api/poll/{id}/answer", "methods": ["POST"], "reason": "baseline — not individually audited" },
   { "path": "/api/poll/{id}/results", "methods": ["GET"], "reason": "baseline — not individually audited" },


### PR DESCRIPTION
## Fix api-auth gate (red on main since #1972)

Add `/api/openspec/search` (GET) to `website/api-public-allowlist.json`.

### Why
The endpoint was added in PR #1972 (`feat(openspec): pgvector indexing for specs and plans`) but the allowlist entry was missed. The api-auth gate has been red on main since that merge (CI run 27882908885 onwards).

### Source-of-truth auth tier
The route handler at `website/src/pages/api/openspec/search.ts` has `prerender = false` and no isAdmin/requireAuth/getSession pattern — it's a public knowledge-base search returning OpenSpec change metadata via pgvector. `build-api-map.mjs` correctly tags it `auth=unclassified`; the allowlist is the right place.

### Discovered while
Running the `chore(skills): remove drift from skills` PR (#1976). That chore re-triggered the failing gate on its push to main, which surfaced a silently-red gate since the openspec merge.

### Verified
`node scripts/api-auth-check.mjs --regression --main-map /tmp/api-map-main.json` — exits 0.