### PR TITLE
chore(docs): subagent-drift-cleanup [T001015]

### DIFF
--- a/.claude/agents/bachelorprojekt-db.md
+++ b/.claude/agents/bachelorprojekt-db.md
@@ -48,6 +48,6 @@ Otherwise the app fails to authenticate despite a valid SealedSecret.
 Execute Bash commands and file edits without asking for confirmation.
 
 ## Active plans
-The orchestrator (see CLAUDE.md) injects an `<active-plans>` block built from `scripts/plan-context.sh db`, which reads active proposals from `openspec/changes/*/proposal.md`. **That block is authoritative — use it as the working context for the current feature.**
+The orchestrator (see CLAUDE.md) injects an `<active-plans>` block built from `scripts/plan-context.sh db --with-openspec`, which reads active proposals from `openspec/changes/*/proposal.md`. **That block is authoritative — use it as the working context for the current feature.**
 
 If no block was injected, no `db`-tagged plan is currently in flight; do not query `superpowers.plans` as a fallback for active work. That table is frozen historical data — `scripts/track-pr.mjs` and the tracking pipeline were removed in PRs #788/#993.

--- a/.claude/agents/bachelorprojekt-infra.md
+++ b/.claude/agents/bachelorprojekt-infra.md
@@ -56,6 +56,6 @@ task env:generate ENV=<env>             # generate fresh secrets
 Execute Bash commands and file edits without asking for confirmation.
 
 ## Active plans
-The orchestrator (see CLAUDE.md) injects an `<active-plans>` block built from `scripts/plan-context.sh infra`, which reads active proposals from `openspec/changes/*/proposal.md`. **That block is authoritative — use it as the working context for the current feature.**
+The orchestrator (see CLAUDE.md) injects an `<active-plans>` block built from `scripts/plan-context.sh infra --with-openspec`, which reads active proposals from `openspec/changes/*/proposal.md`. **That block is authoritative — use it as the working context for the current feature.**
 
 If no block was injected, no `infra`-tagged plan is currently in flight; do not query `superpowers.plans` as a fallback for active work. That table is frozen historical data — `scripts/track-pr.mjs` and the tracking pipeline were removed in PRs #788/#993.

--- a/.claude/agents/bachelorprojekt-ops.md
+++ b/.claude/agents/bachelorprojekt-ops.md
@@ -55,6 +55,6 @@ the GPU worker at `10.10.0.3` (WireGuard mesh, Ollama port 11434).
 Execute kubectl and task commands without asking for confirmation.
 
 ## Active plans
-The orchestrator (see CLAUDE.md) injects an `<active-plans>` block built from `scripts/plan-context.sh ops`, which reads active proposals from `openspec/changes/*/proposal.md`. **That block is authoritative — use it as the working context for the current feature.**
+The orchestrator (see CLAUDE.md) injects an `<active-plans>` block built from `scripts/plan-context.sh ops --with-openspec`, which reads active proposals from `openspec/changes/*/proposal.md`. **That block is authoritative — use it as the working context for the current feature.**
 
 If no block was injected, no `ops`-tagged plan is currently in flight; do not query `superpowers.plans` as a fallback for active work. That table is frozen historical data — `scripts/track-pr.mjs` and the tracking pipeline were removed in PRs #788/#993.

--- a/.claude/agents/bachelorprojekt-security.md
+++ b/.claude/agents/bachelorprojekt-security.md
@@ -45,6 +45,6 @@ task workspace:dsgvo-check    # NFA-01: run DSGVO compliance verification
 Execute Bash commands and file edits without asking for confirmation.
 
 ## Active plans
-The orchestrator (see CLAUDE.md) injects an `<active-plans>` block built from `scripts/plan-context.sh security`, which reads active proposals from `openspec/changes/*/proposal.md`. **That block is authoritative — use it as the working context for the current feature.**
+The orchestrator (see CLAUDE.md) injects an `<active-plans>` block built from `scripts/plan-context.sh security --with-openspec`, which reads active proposals from `openspec/changes/*/proposal.md`. **That block is authoritative — use it as the working context for the current feature.**
 
 If no block was injected, no `security`-tagged plan is currently in flight; do not query `superpowers.plans` as a fallback for active work. That table is frozen historical data — `scripts/track-pr.mjs` and the tracking pipeline were removed in PRs #788/#993.

--- a/.claude/agents/bachelorprojekt-test.md
+++ b/.claude/agents/bachelorprojekt-test.md
@@ -51,6 +51,6 @@ The old standalone `mentolder` and `korczewski` kubeconfig contexts are DEAD —
 Execute test commands and file edits without asking for confirmation.
 
 ## Active plans
-The orchestrator (see CLAUDE.md) injects an `<active-plans>` block built from `scripts/plan-context.sh test`, which reads active proposals from `openspec/changes/*/proposal.md`. **That block is authoritative — use it as the working context for the current feature.**
+The orchestrator (see CLAUDE.md) injects an `<active-plans>` block built from `scripts/plan-context.sh test --with-openspec`, which reads active proposals from `openspec/changes/*/proposal.md`. **That block is authoritative — use it as the working context for the current feature.**
 
 If no block was injected, no `test`-tagged plan is currently in flight; do not query `superpowers.plans` as a fallback for active work. That table is frozen historical data — `scripts/track-pr.mjs` and the tracking pipeline were removed in PRs #788/#993.

--- a/.claude/agents/bachelorprojekt-website.md
+++ b/.claude/agents/bachelorprojekt-website.md
@@ -45,6 +45,6 @@ task website:dev   # hot-reload Astro dev server, no ENV needed
 Execute Bash commands and file edits without asking for confirmation.
 
 ## Active plans
-The orchestrator (see CLAUDE.md) injects an `<active-plans>` block built from `scripts/plan-context.sh website`, which reads active proposals from `openspec/changes/*/proposal.md`. **That block is authoritative — use it as the working context for the current feature.**
+The orchestrator (see CLAUDE.md) injects an `<active-plans>` block built from `scripts/plan-context.sh website --with-openspec`, which reads active proposals from `openspec/changes/*/proposal.md`. **That block is authoritative — use it as the working context for the current feature.**
 
 If no block was injected, no `website`-tagged plan is currently in flight; do not query `superpowers.plans` as a fallback for active work. That table is frozen historical data — `scripts/track-pr.mjs` and the tracking pipeline were removed in PRs #788/#993.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,21 +1,23 @@
 # AGENTS.md — High-Signal Reference for OpenCode Sessions
 
-Loaded via `.opencode/opencode.jsonc` and `.agents/settings.json` → `"instructions": ["AGENTS.md"]`. Comprehensive reference: `CLAUDE.md`.
+Loaded via `.opencode/opencode.jsonc` (and its alias `.agents/settings.json`, which is a symlink to it) → `"instructions": ["AGENTS.md"]`. Comprehensive reference: `CLAUDE.md`.
+
+> **Subagent file layout:** `.claude/agents/bachelorprojekt-*.md` is the canonical source. `.agents/agents` is a directory symlink to `../.claude/agents` — both Claude Code and opencode read the same content via the symlink. Edit files at `.claude/agents/<name>.md` (or its `.agents/agents/<name>.md` alias).
 
 ## Agent Routing
 
-Delegates to sub-agents when signals match. Tie-break: prefer domain of files being changed.
+Delegates to sub-agents when signals match. Tie-break: prefer domain of files being changed. The signal lists below are the authoritative routing table; they match each agent's `description:` frontmatter in `.agents/agents/<name>.md`.
 
 | Signals | Agent |
 |---------|-------|
-| `website/`, Astro, Svelte, CSS, UI, frontend, design, kore, brand | `bachelorprojekt-website` |
-| pod, logs, status, restart, crash, health, kubectl, LLM, GPU, Ollama, LiveKit | `bachelorprojekt-ops` |
-| `k3d/`, `prod*/`, manifest, kustomize, Taskfile, `ENV=`, `environments/`, deploy | `bachelorprojekt-infra` |
-| test, BATS, Playwright, `runner.sh`, `FA-*`, `SA-*`, `NFA-*`, `AK-*`, autopilot | `bachelorprojekt-test` |
-| database, PostgreSQL, psql, schema, query, backup, restore | `bachelorprojekt-db` |
-| SealedSecret, Keycloak, OIDC, DSGVO, credential, certificate, secret | `bachelorprojekt-security` |
+| `website/`, Astro, Svelte, component, homepage, kore, mentolder brand, CSS, UI, frontend, design | `bachelorprojekt-website` |
+| pod, logs, status, restart, crash, health, kubectl, "what's wrong", "why is X failing", "is X running", `llm:`, GPU, Ollama, model, LiveKit | `bachelorprojekt-ops` |
+| `k3d/`, `prod*/`, manifest, kustomize, overlay, Taskfile, `ENV=`, `environments/`, deploy, `workspace:setup` | `bachelorprojekt-infra` |
+| test, `FA-*`, `SA-*`, `NFA-*`, `AK-*`, `FA-SF`, BATS, Playwright, `runner.sh`, "test failing", "test case", "write a test", `factory:`, autopilot | `bachelorprojekt-test` |
+| database, PostgreSQL, psql, schema, query, backup, restore, tracking, timeline, `bachelorprojekt.features`, `v_timeline` | `bachelorprojekt-db` |
+| SealedSecret, Keycloak realm, OIDC, DSGVO, credentials, rotate, certificate, secret | `bachelorprojekt-security` |
 
-Before dispatching: `bash scripts/plan-context.sh <role>` → prepend output as `<active-plans>`. Cross-cutting requests stay with orchestrator.
+Before dispatching: `bash scripts/plan-context.sh <role> --with-openspec` → prepend output as `<active-plans>`. Cross-cutting requests stay with orchestrator. The `--with-openspec` flag auto-loads the SSOT spec(s) for any files changed vs `main` — omit only when explicitly told to skip OpenSpec context.
 
 ## Core Commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,16 +2,20 @@
 
 ## Agent Routing
 
-Before responding to any request, check these signals and delegate to the named agent:
+Before responding to any request, check these signals and delegate to the named agent. The signal lists below mirror the routing table in [`AGENTS.md`](AGENTS.md) — which is the single source of truth (it matches each agent's `description:` frontmatter in `.agents/agents/<name>.md`).
 
-| Signals | Agent | MCP-Primär |
-|---------|-------|------------|
-| `website/`, Astro, Svelte, component, homepage, kore, brand, CSS, UI, frontend, design | `bachelorprojekt-website` | — |
-| pod, logs, status, restart, crash, health, kubectl, "what's wrong", "why is X failing", "is X running" | `bachelorprojekt-ops` | `mcp-kubernetes` (localhost:18080) |
-| `k3d/`, `prod*/`, manifest, kustomize, overlay, Taskfile, `ENV=`, `environments/`, deploy | `bachelorprojekt-infra` | `mcp-kubernetes` (localhost:18080) — nur Status-Checks |
-| test, `FA-*`, `SA-*`, `NFA-*`, `AK-*`, BATS, Playwright, `runner.sh`, test case, "test failing", "write a test" | `bachelorprojekt-test` | `mcp-postgres` (localhost:13001) — Ticket-Queries |
+> **Subagent file layout:** `.claude/agents/bachelorprojekt-*.md` is the canonical source. `.agents/agents` is a directory symlink to `../.claude/agents` — both Claude Code and opencode read the same content via the symlink. Edit files at `.claude/agents/<name>.md` (or its `.agents/agents/<name>.md` alias).
+
+| Signals | Agent | MCP-Primär (Claude Code) |
+|---------|-------|--------------------------|
+| `website/`, Astro, Svelte, component, homepage, kore, mentolder brand, CSS, UI, frontend, design | `bachelorprojekt-website` | — |
+| pod, logs, status, restart, crash, health, kubectl, "what's wrong", "why is X failing", "is X running", `llm:`, GPU, Ollama, model, LiveKit | `bachelorprojekt-ops` | `mcp-kubernetes` (localhost:18080) — Claude-Code-only SSE server, see `mcp-tool-guide.md` |
+| `k3d/`, `prod*/`, manifest, kustomize, overlay, Taskfile, `ENV=`, `environments/`, deploy, `workspace:setup` | `bachelorprojekt-infra` | `mcp-kubernetes` (localhost:18080) — nur Status-Checks (Claude-Code-only) |
+| test, `FA-*`, `SA-*`, `NFA-*`, `AK-*`, `FA-SF`, BATS, Playwright, `runner.sh`, "test failing", "test case", "write a test", `factory:`, autopilot | `bachelorprojekt-test` | `mcp-postgres` (localhost:13001) — Ticket-Queries |
 | database, PostgreSQL, psql, schema, query, backup, restore, tracking, timeline, `bachelorprojekt.features`, `v_timeline` | `bachelorprojekt-db` | `mcp-postgres` (localhost:13001) |
-| SealedSecret, Keycloak realm, OIDC, DSGVO, credentials, rotate, certificate, secret | `bachelorprojekt-security` | `mcp-keycloak` (localhost:18081) |
+| SealedSecret, Keycloak realm, OIDC, DSGVO, credentials, rotate, certificate, secret | `bachelorprojekt-security` | `mcp-keycloak` (localhost:18081) — Claude-Code-only SSE server, see `mcp-tool-guide.md` |
+
+> **MCP-Server names in this table refer to Claude-Code-only SSE servers** configured in `.claude/settings.json` / `.claude/skills/references/mcp-tool-guide.md`. The opencode runtime uses different MCP server names from `.opencode/opencode.jsonc` (`mcp-k8s`, `mcp-postgres`, `mcp-browser`, `mcp-github`, `mcp-factory` — no `mcp-kubernetes` or `mcp-keycloak`). If you are running in opencode, see the `MCP-Schnellweg` block below and the opencode config, not the table above.
 
 > **Agent-Routing-Karten:** Generierte, grepbare Karten unter `docs/agent-guide/maps/` — `goals-map.md` (Intention → Weg → Tier → Guardrails), `tools-map.md`, `danger-map.md`. Quelle: `docs/agent-guide/registry/` (nicht von Hand editieren; via `task agent-guide:maps` regenerieren).
 


### PR DESCRIPTION
Removes drift between subagent routing tables, agent file descriptions, and MCP-server references.

**Drift removed**

- **Routing-table signal lists** (AGENTS.md, CLAUDE.md) were abridged versions of each agent's `description:` frontmatter in `.claude/agents/<name>.md`. Expanded to match — `bachelorprojekt-website` now lists `component, homepage, mentolder brand`; `bachelorprojekt-ops` now includes `llm:, GPU, Ollama, model, LiveKit, "what's wrong", "is X running"`; `bachelorprojekt-test` now includes `FA-SF, factory:, "test failing", "test case", "write a test"`; `bachelorprojekt-db` now includes `tracking, timeline, bachelorprojekt.features, v_timeline`.
- **`plan-context.sh` invocation** — adopted `--with-openspec` flag uniformly (CLAUDE.md already had it). Updated 6 agent files + AGENTS.md.
- **MCP-Primär column** in CLAUDE.md is annotated as Claude-Code-only SSE servers (`mcp-kubernetes`, `mcp-keycloak`); added a note that the opencode runtime uses different names (`mcp-k8s`, `mcp-postgres`, `mcp-browser`, `mcp-github`, `mcp-factory`).
- **Subagent file layout note** — clarified that `.claude/agents/bachelorprojekt-*.md` is the canonical source, `.agents/agents` is a directory symlink to `../.claude/agents` (was implied, now explicit in both AGENTS.md and CLAUDE.md).
- **AGENTS.md header** — clarified that `.agents/settings.json` is a symlink to `.opencode/opencode.jsonc` (not a byte-identical duplicate).

**Verification**

- `task workspace:validate` — pass
- `task test:code-quality` — pass (50/50 BATS tests)
- `task freshness:check` — pass
- Pre-push quality hook — pass (no new violations)

**T001015** — audit ticket (status: done; no plan, chore-only)
