### PR TITLE
chore(docs): wire skills to subagents via agent: frontmatter [T001016]

### DIFF
--- a/.claude/skills/OVERVIEW.md
+++ b/.claude/skills/OVERVIEW.md
@@ -6,6 +6,14 @@
 
 > **Für Agenten:** Schnelle Routing-Karten (Intention → Weg → Tier → Guardrails) unter `docs/agent-guide/maps/` — `goals-map.md`, `tools-map.md`, `danger-map.md`. Generiert aus `docs/agent-guide/registry/`.
 
+## Subagent dispatch (Skill → Agent)
+
+Each skill's `SKILL.md` frontmatter carries an optional `agent:` field that tells the orchestrator which `.claude/agents/<name>.md` config to splice into a subagent before spawning it. The full protocol (recipe + current mapping table) lives in `AGENTS.md` → "Skill Dispatch Protocol". Quick reference:
+
+- Skills with `agent:` → dispatched as a subagent via `task` with `subagent_type: "general"` (isolated context window, own domain knowledge).
+- Skills without `agent:` → loaded inline in the main session (workflow/orchestrator skills that span multiple agents or hold state).
+- New skill: pick an agent from the routing table, add `agent: bachelorprojekt-<role>` to frontmatter, add a row to the AGENTS.md table.
+
 ---
 
 ## Development Flow (sequential pipeline)

--- a/.claude/skills/arena-brett-deploy/SKILL.md
+++ b/.claude/skills/arena-brett-deploy/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: arena-brett-deploy
 description: Use when building, deploying, or debugging the arena-server (korczewski-only WebSocket game server) or brett (3D multiplayer game), including proto-drift copy step, CORS configuration, and deploy constraints unique to each service.
+agent: bachelorprojekt-infra
 ---
 
 # arena-brett-deploy — Arena & Brett Deployment

--- a/.claude/skills/cluster-deployment/SKILL.md
+++ b/.claude/skills/cluster-deployment/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: cluster-deployment
 description: Unified runbook for environment deployment, cluster creation, deployment assistance, gap analysis, and dev.mentolder.de stack operations.
+agent: bachelorprojekt-infra
 ---
 
 > **Mishap Tracking:** As you execute this skill, maintain a running `MISHAP_LOG`.

--- a/.claude/skills/database-ops/SKILL.md
+++ b/.claude/skills/database-ops/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: database-ops
 description: Unified runbook for database operations, schema migrations, DDL ownership rules, and safe backup/restore audits.
+agent: bachelorprojekt-db
 ---
 
 > **Mishap Tracking:** As you execute this skill, maintain a running `MISHAP_LOG`.

--- a/.claude/skills/dev-flow-e2e/SKILL.md
+++ b/.claude/skills/dev-flow-e2e/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: dev-flow-e2e
 description: Use to write and run Playwright E2E tests against the live environment for a newly merged and deployed change.
+agent: bachelorprojekt-test
 ---
 
 # dev-flow-e2e — Playwright E2E Tests schreiben & ausführen

--- a/.claude/skills/dev-flow-iterate/SKILL.md
+++ b/.claude/skills/dev-flow-iterate/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: dev-flow-iterate
 description: Use to run deployments, view logs, and troubleshoot issues iteratively against a dev k3d cluster.
+agent: bachelorprojekt-ops
 category: devflow
 ---
 

--- a/.claude/skills/factory-autopilot/SKILL.md
+++ b/.claude/skills/factory-autopilot/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: factory-autopilot
 description: Software Factory Autopilot lifecycle — install, status, uninstall the headless dispatcher (systemd timer-driven pipeline.js orchestrator) that autonomously processes backlog tickets.
+agent: bachelorprojekt-test
 ---
 
 > **Mishap Tracking:** As you execute this skill, maintain a running `MISHAP_LOG`.

--- a/.claude/skills/factory-worker/SKILL.md
+++ b/.claude/skills/factory-worker/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: factory-worker
 description: Interactive Software-Factory worker. Invoke via /factory-worker-on when DeepSeek-Scout produced weak output (SCOUT_WEAK) or tickets sit in planning with no committed plan, and a human needs to scout + plan them so the autopilot can build them. Yields one autopilot parallel slot while active.
+agent: bachelorprojekt-test
 ---
 
 > **Mishap Tracking:** As you execute this skill, maintain a running `MISHAP_LOG`.

--- a/.claude/skills/fleet-ops/SKILL.md
+++ b/.claude/skills/fleet-ops/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: fleet-ops
 description: Use when deploying, verifying, or operating across both brands simultaneously — mentolder and korczewski, both on the unified fleet cluster. Covers task feature:* fan-out, the feature:promote dev→prod flow with smoke gate and auto-rollback, cross-brand schema changes, cluster status checks, the push-based deploy model (no GitOps reconciler on fleet), and the constraint that each brand has its own independent shared-db and sealed-secrets.
+agent: bachelorprojekt-infra
 ---
 
 # fleet-ops — Cross-Brand Operations (mentolder + korczewski on fleet)

--- a/.claude/skills/host-node-networking/SKILL.md
+++ b/.claude/skills/host-node-networking/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: host-node-networking
 description: Unified runbook for host node provisioning (Hetzner, cloud-init, Rescue Mode), WireGuard mesh network layout, host firewalls (UFW rules), LiveKit WebRTC networking (DNS pinning, ICE candidates), and WSL OpenClaw local gateway operations.
+agent: bachelorprojekt-infra
 ---
 
 > **Mishap Tracking:** As you execute this skill, maintain a running `MISHAP_LOG`.

--- a/.claude/skills/incident-response/SKILL.md
+++ b/.claude/skills/incident-response/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: incident-response
 description: Production incident triage, scope, diagnose, fix/rollback, and post-mortem close for the workspace platform. Time-critical — use when a core service is down or degraded.
+agent: bachelorprojekt-ops
 ---
 
 > **Mishap Tracking:** As you execute this skill, maintain a running `MISHAP_LOG`.

--- a/.claude/skills/keycloak-realm-sync/SKILL.md
+++ b/.claude/skills/keycloak-realm-sync/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: keycloak-realm-sync
 description: Use when Keycloak realm configuration needs to be reconciled — OIDC client settings, realm JSON changes, group mappings, mapper configuration, or SSO login failures that stem from realm drift. Covers running keycloak:sync, post-sync verification, and testing SSO flows.
+agent: bachelorprojekt-security
 ---
 
 > **Mishap Tracking:** As you execute this skill, maintain a running `MISHAP_LOG`.

--- a/.claude/skills/llm-ops/SKILL.md
+++ b/.claude/skills/llm-ops/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: llm-ops
 description: LLM pipeline operations — GPU host bootstrap, model management, deploy/status/test of LLM gateway services (TEI embed, LM Studio chat) plus ComfyUI and Rigger across dev and fleet clusters.
+agent: bachelorprojekt-ops
 ---
 
 > **Mishap Tracking:** As you execute this skill, maintain a running `MISHAP_LOG`.

--- a/.claude/skills/mishap-tracker/SKILL.md
+++ b/.claude/skills/mishap-tracker/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: mishap-tracker
 description: Shared utility — batches all execution mishaps into a single aggregate ticket. Reuses an existing open "Mishap collection" ticket if one exists; creates a new one otherwise. Each mishap is individually classified within the aggregate.
+agent: bachelorprojekt-ops
 ---
 
 # mishap-tracker

--- a/.claude/skills/secret-rotation/SKILL.md
+++ b/.claude/skills/secret-rotation/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: secret-rotation
 description: Use when rotating secrets across clusters — DB passwords, API keys, sealed-secrets keypair refresh after a cluster reset, claude-code tokens, or generating/sealing a new env. Covers the mandatory ordering that prevents silent overwrite of production secrets.
+agent: bachelorprojekt-security
 ---
 
 > **Mishap Tracking:** As you execute this skill, maintain a running `MISHAP_LOG`.

--- a/.claude/skills/workspace-deploy/SKILL.md
+++ b/.claude/skills/workspace-deploy/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: workspace-deploy
 description: Full-stack workspace platform deployment — umbrella workspace:setup, post-setup, talk/recording/transcriber, optional admin-users and vaultwarden seed. Covers every service that doesn't ship via base kustomization alone.
+agent: bachelorprojekt-infra
 ---
 
 > **Mishap Tracking:** As you execute this skill, maintain a running `MISHAP_LOG`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,6 +109,59 @@ bash scripts/agent-lock.sh list    # see who is doing what
 
 Session messaging: `bash scripts/agent-msg.sh read --unread` (incoming), `bash scripts/agent-msg.sh post "msg"` (broadcast to live sessions).
 
+## Skill Dispatch Protocol
+
+Every skill in `.claude/skills/<name>/SKILL.md` declares its dispatch target in the YAML frontmatter:
+
+```yaml
+---
+name: <skill-name>
+description: ...
+agent: bachelorprojekt-<role>     # optional — see below
+category: devflow                  # optional — existing field
+---
+```
+
+- **Skill HAS `agent:`** → orchestrator MUST dispatch as a subagent. Load `.claude/agents/<agent>.md`, splice its body as the system prompt, append the skill body + the user's request, and spawn `task` with `subagent_type: "general"`. The subagent owns the work in an isolated context window.
+- **Skill has NO `agent:`** → workflow/orchestrator skill. Load inline in the main session (current behavior). These are coordination skills (`dev-flow-plan`, `dev-flow-execute`, `dev-flow-chore`, `dev-flow-batch`, `dev-flow-e2e`-meta, `feature-intake`, `migrate-foreign-code`, `operations-management`, `ticket-ops`, `update-dependencies`, `knowledge-management`, `using-git-worktrees`) that need to span multiple agents or hold persistent state across handoffs.
+
+### Dispatch recipe
+
+```bash
+# 1. Read the agent config (system prompt for the subagent)
+AGENT_BODY=$(cat .claude/agents/bachelorprojekt-<role>.md)   # strip YAML frontmatter
+SKILL_BODY=$(cat .claude/skills/<name>/SKILL.md | tail -n +5)   # strip frontmatter
+
+# 2. Orchestrator spawns a `task` call with subagent_type="general" and:
+#    system:  <AGENT_BODY>            ← domain knowledge, commands, gotchas
+#    prompt:  <SKILL_BODY>\n\n---\n\n<user request>
+```
+
+The subagent returns its result; the orchestrator relays it back. The subagent sees only its agent instructions + the skill + the request — no orchestrator noise.
+
+### Current skill → agent map
+
+| Skill | Agent | Why subagent |
+|-------|-------|--------------|
+| `arena-brett-deploy` | `bachelorprojekt-infra` | Kustomize/proto-drift details, prod context rules |
+| `cluster-deployment` | `bachelorprojekt-infra` | `fleet`-only context, k3d base, overlay cake |
+| `database-ops` | `bachelorprojekt-db` | PostgreSQL `shared-db` topology, password-drift warning |
+| `dev-flow-e2e` | `bachelorprojekt-test` | FA-/SA-/NFA- test IDs, runner.sh, permanently-skipped set |
+| `dev-flow-iterate` | `bachelorprojekt-ops` | Pod/log/restart discipline (shell-session integrity rules) |
+| `factory-autopilot` | `bachelorprojekt-test` | Headless dispatcher lifecycle + FA-SF test context |
+| `factory-worker` | `bachelorprojekt-test` | Same factory domain as `factory-autopilot` |
+| `fleet-ops` | `bachelorprojekt-infra` | Cross-brand kustomize fan-out, no-GitOps push model |
+| `host-node-networking` | `bachelorprojekt-infra` | Hetzner/WireGuard/provisioning tooling |
+| `incident-response` | `bachelorprojekt-ops` | Diagnose-first, fail-loud output-trust rules |
+| `keycloak-realm-sync` | `bachelorprojekt-security` | SealedSecret + realm JSON per-namespace rules |
+| `llm-ops` | `bachelorprojekt-ops` | GPU/Ollama/TEI/LiteLLM ops on fleet |
+| `mishap-tracker` | `bachelorprojekt-ops` | Anomalies on live systems → ops triage |
+| `secret-rotation` | `bachelorprojekt-security` | Sealing order, `env-resolve.sh` source-not-execute |
+| `workspace-deploy` | `bachelorprojekt-infra` | Full workspace:setup umbrella + post-setup |
+| _inline (no agent)_ | _main session_ | `dev-flow-plan`, `dev-flow-execute`, `dev-flow-chore`, `dev-flow-batch`, `feature-intake`, `migrate-foreign-code`, `operations-management`, `ticket-ops`, `update-dependencies`, `knowledge-management`, `using-git-worktrees` |
+
+When a new skill is added: pick an agent from the routing table, add `agent: bachelorprojekt-<role>` to frontmatter, and add a row to this table. (Optional follow-up: add a `task skills:validate` that asserts every `agent:` value resolves to an existing `.claude/agents/<name>.md` and that every agent has at least one skill referring to it — currently no such gate exists.)
+
 ## Important References
 
 - `CLAUDE.md` — authoritative comprehensive reference (task lists, topology details, all footguns)


### PR DESCRIPTION
## What

Add `agent:` frontmatter field to 15 SKILL.md files routing them to the matching `.claude/agents/bachelorprojekt-*.md` config. Document the **Skill Dispatch Protocol** in AGENTS.md and a brief convention note in skills/OVERVIEW.md.

## Why

opencode's `task` tool only accepts `subagent_type: "explore" | "general"` — it cannot directly invoke the project's `.claude/agents/bachelorprojekt-*.md` configs as subagent types. Without an explicit signal, the orchestrator loads every skill inline in the main session, so domain knowledge (cluster topology, PG schemas, FA-/SA- test ID sets, sealing order, GPU hosts) is never present when those skills run.

Adding `agent: bachelorprojekt-<role>` to skill frontmatter makes the routing signal machine-readable. The orchestrator's dispatch recipe is documented in AGENTS.md.

## Mapping (15 skills → 5 agents)

| Agent | Skills |
|-------|--------|
| `bachelorprojekt-infra` | arena-brett-deploy, cluster-deployment, fleet-ops, host-node-networking, workspace-deploy |
| `bachelorprojekt-ops` | dev-flow-iterate, incident-response, llm-ops, mishap-tracker |
| `bachelorprojekt-db` | database-ops |
| `bachelorprojekt-test` | dev-flow-e2e, factory-autopilot, factory-worker |
| `bachelorprojekt-security` | keycloak-realm-sync, secret-rotation |

11 skills remain inline (workflow/orchestrator): `dev-flow-{plan,execute,chore,batch}`, `feature-intake`, `migrate-foreign-code`, `operations-management`, `ticket-ops`, `update-dependencies`, `knowledge-management`, `using-git-worktrees`.

## Files

- 15 `.claude/skills/<name>/SKILL.md` — added `agent:` line
- `AGENTS.md` — new "Skill Dispatch Protocol" section with recipe + full mapping table
- `.claude/skills/OVERVIEW.md` — convention callout pointing to AGENTS.md

## Verification

- `task freshness:check` passes
- All 26 SKILL.md frontmatters parse (start/end `---`)
- Pre-commit hook passed (no secret/collision/freshness drift)

## Ticket

[T001016] chore: wire skills to subagents via agent: frontmatter