### PR TITLE
feat(mentolder-web): react 19 + vite rewrite of mentolder.de public site [T001026]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,6 +244,7 @@ jobs:
             tickets
             recovery
             openspec
+            mentolder-web
           # Ticket references like [T000436] can extend subject length
           subjectPattern: ^.{1,200}$
           subjectPatternError: |

--- a/mentolder-web/.env.example
+++ b/mentolder-web/.env.example
@@ -1,0 +1,10 @@
+# Formspree endpoint for the contact form
+# Get an ID at https://formspree.io and paste it below.
+# When unset, the form falls back to a mailto: link and logs a dev-warning.
+VITE_FORMSPREE_ENDPOINT=
+
+# Default contact details (used in Footer / Hero caption).
+VITE_CONTACT_EMAIL=mail@mentolder.de
+VITE_CONTACT_PHONE=
+VITE_CONTACT_CITY=Lüneburg
+VITE_BRAND_NAME=mentolder

--- a/mentolder-web/.gitignore
+++ b/mentolder-web/.gitignore
@@ -1,0 +1,7 @@
+node_modules/
+dist/
+.env
+.env.local
+.env.*.local
+.DS_Store
+*.log

--- a/mentolder-web/index.html
+++ b/mentolder-web/index.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html lang="de">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <meta name="theme-color" content="#0b111c" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,300;0,6..72,400;1,6..72,300;1,6..72,400&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Geist:wght@300;400;500;600&family=Geist+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <title>mentolder — Digital Coach &amp; Führungskräfte-Mentor</title>
+    <meta
+      name="description"
+      content="Mit 30+ Jahren Führungserfahrung begleite ich Menschen und Organisationen bei der digitalen Transformation — praxisnah, empathisch und auf Augenhöhe."
+    />
+    <meta property="og:title" content="mentolder — Digital Coach &amp; Führungskräfte-Mentor" />
+    <meta property="og:description" content="30+ Jahre Führungserfahrung. Praxisnah, empathisch, auf Augenhöhe." />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://mentolder.de/" />
+    <meta name="twitter:card" content="summary_large_image" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/mentolder-web/package.json
+++ b/mentolder-web/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "mentolder-web",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "mentolder.de public site — React 19 + Vite 6 + Tailwind v4",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@hookform/resolvers": "^3.10.0",
+    "framer-motion": "^11.18.0",
+    "react": "^19.2.0",
+    "react-dom": "^19.2.0",
+    "react-hook-form": "^7.54.0",
+    "react-router-dom": "^7.1.0",
+    "zod": "^3.24.0"
+  },
+  "devDependencies": {
+    "@tailwindcss/vite": "^4.0.0",
+    "@types/react": "^19.2.0",
+    "@types/react-dom": "^19.2.0",
+    "@vitejs/plugin-react": "^4.3.0",
+    "tailwindcss": "^4.0.0",
+    "typescript": "^5.7.0",
+    "vite": "^6.0.0",
+    "vite-plugin-svgr": "^5.2.0"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/mentolder-web/pnpm-lock.yaml
+++ b/mentolder-web/pnpm-lock.yaml
@@ -1,0 +1,1918 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@hookform/resolvers':
+        specifier: ^3.10.0
+        version: 3.10.0(react-hook-form@7.80.0(react@19.2.7))
+      framer-motion:
+        specifier: ^11.18.0
+        version: 11.18.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react:
+        specifier: ^19.2.0
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.2.0
+        version: 19.2.7(react@19.2.7)
+      react-hook-form:
+        specifier: ^7.54.0
+        version: 7.80.0(react@19.2.7)
+      react-router-dom:
+        specifier: ^7.1.0
+        version: 7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      zod:
+        specifier: ^3.24.0
+        version: 3.25.76
+    devDependencies:
+      '@tailwindcss/vite':
+        specifier: ^4.0.0
+        version: 4.3.1(vite@6.4.3(jiti@2.7.0)(lightningcss@1.32.0))
+      '@types/react':
+        specifier: ^19.2.0
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.2.0
+        version: 19.2.3(@types/react@19.2.17)
+      '@vitejs/plugin-react':
+        specifier: ^4.3.0
+        version: 4.7.0(vite@6.4.3(jiti@2.7.0)(lightningcss@1.32.0))
+      tailwindcss:
+        specifier: ^4.0.0
+        version: 4.3.1
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vite:
+        specifier: ^6.0.0
+        version: 6.4.3(jiti@2.7.0)(lightningcss@1.32.0)
+      vite-plugin-svgr:
+        specifier: ^5.2.0
+        version: 5.2.0(rollup@4.62.2)(typescript@5.9.3)(vite@6.4.3(jiti@2.7.0)(lightningcss@1.32.0))
+
+packages:
+
+  '@babel/code-frame@7.29.7':
+    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/compat-data@7.29.7':
+    resolution: {integrity: sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@7.29.7':
+    resolution: {integrity: sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.29.7':
+    resolution: {integrity: sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@7.29.7':
+    resolution: {integrity: sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-globals@7.29.7':
+    resolution: {integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.29.7':
+    resolution: {integrity: sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-transforms@7.29.7':
+    resolution: {integrity: sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-plugin-utils@7.29.7':
+    resolution: {integrity: sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-option@7.29.7':
+    resolution: {integrity: sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.29.7':
+    resolution: {integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.7':
+    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/plugin-transform-react-jsx-self@7.29.7':
+    resolution: {integrity: sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-react-jsx-source@7.29.7':
+    resolution: {integrity: sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/template@7.29.7':
+    resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.29.7':
+    resolution: {integrity: sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.7':
+    resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
+    engines: {node: '>=6.9.0'}
+
+  '@esbuild/aix-ppc64@0.25.12':
+    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.25.12':
+    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.12':
+    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.25.12':
+    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.25.12':
+    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.12':
+    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.12':
+    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.25.12':
+    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.12':
+    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.25.12':
+    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.12':
+    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.25.12':
+    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.12':
+    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.25.12':
+    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.12':
+    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.25.12':
+    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.12':
+    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.12':
+    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.25.12':
+    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.25.12':
+    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.25.12':
+    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.12':
+    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@hookform/resolvers@3.10.0':
+    resolution: {integrity: sha512-79Dv+3mDF7i+2ajj7SkypSKHhl1cbln1OGavqrsF7p6mbUv11xpqpacPsGDCTRvCSjEEIez2ef1NveSVL3b0Ag==}
+    peerDependencies:
+      react-hook-form: ^7.0.0
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@rolldown/pluginutils@1.0.0-beta.27':
+    resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
+
+  '@rollup/pluginutils@5.4.0':
+    resolution: {integrity: sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+
+  '@rollup/rollup-android-arm-eabi@4.62.2':
+    resolution: {integrity: sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.62.2':
+    resolution: {integrity: sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.62.2':
+    resolution: {integrity: sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.62.2':
+    resolution: {integrity: sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.62.2':
+    resolution: {integrity: sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.62.2':
+    resolution: {integrity: sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.2':
+    resolution: {integrity: sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.62.2':
+    resolution: {integrity: sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-arm64-gnu@4.62.2':
+    resolution: {integrity: sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm64-musl@4.62.2':
+    resolution: {integrity: sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-loong64-gnu@4.62.2':
+    resolution: {integrity: sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-loong64-musl@4.62.2':
+    resolution: {integrity: sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.62.2':
+    resolution: {integrity: sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-ppc64-musl@4.62.2':
+    resolution: {integrity: sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.62.2':
+    resolution: {integrity: sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-riscv64-musl@4.62.2':
+    resolution: {integrity: sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-s390x-gnu@4.62.2':
+    resolution: {integrity: sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-gnu@4.62.2':
+    resolution: {integrity: sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-musl@4.62.2':
+    resolution: {integrity: sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-openbsd-x64@4.62.2':
+    resolution: {integrity: sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.62.2':
+    resolution: {integrity: sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.62.2':
+    resolution: {integrity: sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.62.2':
+    resolution: {integrity: sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.62.2':
+    resolution: {integrity: sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.62.2':
+    resolution: {integrity: sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@svgr/babel-plugin-add-jsx-attribute@8.0.0':
+    resolution: {integrity: sha512-b9MIk7yhdS1pMCZM8VeNfUlSKVRhsHZNMl5O9SfaX0l0t5wjdgu4IDzGB8bpnGBBOjGST3rRFVsaaEtI4W6f7g==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@svgr/babel-plugin-remove-jsx-attribute@8.0.0':
+    resolution: {integrity: sha512-BcCkm/STipKvbCl6b7QFrMh/vx00vIP63k2eM66MfHJzPr6O2U0jYEViXkHJWqXqQYjdeA9cuCl5KWmlwjDvbA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@svgr/babel-plugin-remove-jsx-empty-expression@8.0.0':
+    resolution: {integrity: sha512-5BcGCBfBxB5+XSDSWnhTThfI9jcO5f0Ai2V24gZpG+wXF14BzwxxdDb4g6trdOux0rhibGs385BeFMSmxtS3uA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@svgr/babel-plugin-replace-jsx-attribute-value@8.0.0':
+    resolution: {integrity: sha512-KVQ+PtIjb1BuYT3ht8M5KbzWBhdAjjUPdlMtpuw/VjT8coTrItWX6Qafl9+ji831JaJcu6PJNKCV0bp01lBNzQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@svgr/babel-plugin-svg-dynamic-title@8.0.0':
+    resolution: {integrity: sha512-omNiKqwjNmOQJ2v6ge4SErBbkooV2aAWwaPFs2vUY7p7GhVkzRkJ00kILXQvRhA6miHnNpXv7MRnnSjdRjK8og==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@svgr/babel-plugin-svg-em-dimensions@8.0.0':
+    resolution: {integrity: sha512-mURHYnu6Iw3UBTbhGwE/vsngtCIbHE43xCRK7kCw4t01xyGqb2Pd+WXekRRoFOBIY29ZoOhUCTEweDMdrjfi9g==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@svgr/babel-plugin-transform-react-native-svg@8.1.0':
+    resolution: {integrity: sha512-Tx8T58CHo+7nwJ+EhUwx3LfdNSG9R2OKfaIXXs5soiy5HtgoAEkDay9LIimLOcG8dJQH1wPZp/cnAv6S9CrR1Q==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@svgr/babel-plugin-transform-svg-component@8.0.0':
+    resolution: {integrity: sha512-DFx8xa3cZXTdb/k3kfPeaixecQLgKh5NVBMwD0AQxOzcZawK4oo1Jh9LbrcACUivsCA7TLG8eeWgrDXjTMhRmw==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@svgr/babel-preset@8.1.0':
+    resolution: {integrity: sha512-7EYDbHE7MxHpv4sxvnVPngw5fuR6pw79SkcrILHJ/iMpuKySNCl5W1qcwPEpU+LgyRXOaAFgH0KhwD18wwg6ug==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@svgr/core@8.1.0':
+    resolution: {integrity: sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==}
+    engines: {node: '>=14'}
+
+  '@svgr/hast-util-to-babel-ast@8.0.0':
+    resolution: {integrity: sha512-EbDKwO9GpfWP4jN9sGdYwPBU0kdomaPIL2Eu4YwmgP+sJeXT+L7bMwJUBnhzfH8Q2qMBqZ4fJwpCyYsAN3mt2Q==}
+    engines: {node: '>=14'}
+
+  '@svgr/plugin-jsx@8.1.0':
+    resolution: {integrity: sha512-0xiIyBsLlr8quN+WyuxooNW9RJ0Dpr8uOnH/xrCVO8GLUcwHISwj1AG0k+LFzteTkAA0GbX0kj9q6Dk70PTiPA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@svgr/core': '*'
+
+  '@tailwindcss/node@4.3.1':
+    resolution: {integrity: sha512-6NDaqRoAMSXD1mr/RXu0HBvNE9a2n5tHPsxu9XHLws8o4Twes5rBM2205SUUiJ9goAtadrN6xTGX0UDEwp/N4A==}
+
+  '@tailwindcss/oxide-android-arm64@4.3.1':
+    resolution: {integrity: sha512-SVlyf61g374l5cHyg8x9kf5xmLcOaxvOTsbsqDnSsDJaKOEFZ7GCvi84VAVGpxojYOs1+3K6M0UjXfqPU8vmOQ==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [android]
+
+  '@tailwindcss/oxide-darwin-arm64@4.3.1':
+    resolution: {integrity: sha512-hVnWLwv+e/l7c4WKyVtHVrIPvYdqWHjRB3MDIqARynzFtnQg85kmQEFCbV9Ja0VVx4xXTIiDWY60Y7iz/iNoDA==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-darwin-x64@4.3.1':
+    resolution: {integrity: sha512-Cf7abu0WVgbhU7ANgPUnSAvm7nCvMweusHb8FnaHlLfv/Caq4GYaEZg7ZImzzmjx4lIAfuS8q+eLIS7A7IzxIg==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-freebsd-x64@4.3.1':
+    resolution: {integrity: sha512-ZZqzX2Y+GXtXXfqSfpJhDm60OoZfvLHLCgm+J7NVqgHHJjG/m9ugZI77RwTsVd4fnBJuCFP6Ae6kTJb71UdS8g==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.1':
+    resolution: {integrity: sha512-/Ah/xik0LaMYfv9DZ0S/t4pBlBNYOcqtRwusjgovHkvT8ixueWCLyJjsaF5kQIckjb4IT8Q6K6p/iPmZMixYgg==}
+    engines: {node: '>= 20'}
+    cpu: [arm]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.3.1':
+    resolution: {integrity: sha512-gqdFoVJlw444GvpnheZLHmvTzSxI/cOUUh2KSNejQjTcYkW062SVD+En0rUgD+QV91bz1XGIGtt1HJd48xUGbQ==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.3.1':
+    resolution: {integrity: sha512-Bwv9KwOvE0VKa86xPFif9b9c3Y1NxOV1P0gLti/IYaWEsQYZXDlxfGEtA8mdDZ7SG3wyNXAWYT5SIn3giL57oA==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.3.1':
+    resolution: {integrity: sha512-Ymi8O8T15HYQdOUWUtTI6ldN0neHP85FC+Qz32xTcZ7iJXtem/x8ITev0o1e9e5rkqj4lONZfTRLvkmin1+tKg==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@tailwindcss/oxide-linux-x64-musl@4.3.1':
+    resolution: {integrity: sha512-M+P/91qJ6uILLw4k2G93GMDRAXj61SMvFQYt39AqvUqYgExXpLL5aepfns7sj4HiAQeolirQF9E0lzRvdf4zPQ==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@tailwindcss/oxide-wasm32-wasi@4.3.1':
+    resolution: {integrity: sha512-zsM8uOeqvVGHsAXsJxsT28ttosFahLJKCLOTUBqRAtKnVgGSRitds9T432QiT8b77Yga7JIBkulIRRlJPtYhRA==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+    bundledDependencies:
+      - '@napi-rs/wasm-runtime'
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@tybys/wasm-util'
+      - '@emnapi/wasi-threads'
+      - tslib
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.3.1':
+    resolution: {integrity: sha512-aiNvSq9BsVk8V513lDKlrCFAgf8qBMPZTpgEhInL+NwQqs97mYmupVMrPrgBBSL8Pv/0zXu9MrMF9rMun1ZeNg==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.3.1':
+    resolution: {integrity: sha512-xDEyu1rg290472FEGaKHnzyDyh5QH+AlWvsU5hMoMtPpzmKlRI0jaYKCgSHDYtaQWZOYbMaduSyCwFwY4n1HmA==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [win32]
+
+  '@tailwindcss/oxide@4.3.1':
+    resolution: {integrity: sha512-yVPyo8RNkabVr3O2EhHEE0Rewu7YKzc1DhIqfL46LKveFrmu9XbDazNOJY7/GRuvw1h6u3utWnR29H/p5JPlgA==}
+    engines: {node: '>= 20'}
+
+  '@tailwindcss/vite@4.3.1':
+    resolution: {integrity: sha512-hItDHuIIlEV61R+faXu66s1K36aTurO/Qw0e45Vskz57gXl9pWOT6eg3zmcEui6CZXddbN7zd41bwmvag4JGwQ==}
+    peerDependencies:
+      vite: ^5.2.0 || ^6 || ^7 || ^8
+
+  '@types/babel__core@7.20.5':
+    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
+
+  '@types/babel__generator@7.27.0':
+    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
+
+  '@types/babel__template@7.4.4':
+    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
+
+  '@types/babel__traverse@7.28.0':
+    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/react-dom@19.2.3':
+    resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
+    peerDependencies:
+      '@types/react': ^19.2.0
+
+  '@types/react@19.2.17':
+    resolution: {integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==}
+
+  '@vitejs/plugin-react@4.7.0':
+    resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
+
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  baseline-browser-mapping@2.10.38:
+    resolution: {integrity: sha512-31/02mVB4yuQU6adKk5SlY6m+mxDwUq5KZkyYgnLrrKl7TEm1+3PyDtDBz2kOv/wxZz41GHsvV1A/u6RmiyBvw==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  browserslist@4.28.2:
+    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
+  callsites@3.1.0:
+    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
+    engines: {node: '>=6'}
+
+  camelcase@6.3.0:
+    resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
+    engines: {node: '>=10'}
+
+  caniuse-lite@1.0.30001799:
+    resolution: {integrity: sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
+
+  cosmiconfig@8.3.6:
+    resolution: {integrity: sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      typescript: '>=4.9.5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  dot-case@3.0.4:
+    resolution: {integrity: sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==}
+
+  electron-to-chromium@1.5.376:
+    resolution: {integrity: sha512-cUVA7/RvbFTEuw/i3obUwDTRIXojaxkResf+ibByPFxjc6XK3VNtcQXV0NSbAlJ0FMjcJGgftVVB4Qo184EXvA==}
+
+  enhanced-resolve@5.21.6:
+    resolution: {integrity: sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==}
+    engines: {node: '>=10.13.0'}
+
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
+  error-ex@1.3.4:
+    resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
+
+  esbuild@0.25.12:
+    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
+
+  estree-walker@2.0.2:
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  framer-motion@11.18.2:
+    resolution: {integrity: sha512-5F5Och7wrvtLVElIpclDT0CBzMVg3dL22B64aZwHtsIY8RB4mXICLrkajK4G9R+ieSAGcgrLeae2SeUTg2pr6w==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  gensync@1.0.0-beta.2:
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
+    engines: {node: '>=6.9.0'}
+
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  import-fresh@3.3.1:
+    resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
+    engines: {node: '>=6'}
+
+  is-arrayish@0.2.1:
+    resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
+
+  jiti@2.7.0:
+    resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
+    hasBin: true
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  js-yaml@4.2.0:
+    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
+    hasBin: true
+
+  jsesc@3.1.0:
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  json-parse-even-better-errors@2.3.1:
+    resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
+
+  json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
+
+  lines-and-columns@1.2.4:
+    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
+  lower-case@2.0.2:
+    resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
+
+  lru-cache@5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  motion-dom@11.18.1:
+    resolution: {integrity: sha512-g76KvA001z+atjfxczdRtw/RXOM3OMSdd1f4DL77qCTF/+avrRJiawSG4yDibEQ215sr9kpinSlX2pCTJ9zbhw==}
+
+  motion-utils@11.18.1:
+    resolution: {integrity: sha512-49Kt+HKjtbJKLtgO/LKj9Ld+6vw9BjH5d9sc40R/kVyH8GLAXgT42M2NnuPcJNuA3s9ZfZBUcwIgpmZWGEE+hA==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nanoid@3.3.13:
+    resolution: {integrity: sha512-sPdqC6ByMVVGvF1ynvvMo0/o+oD1VX7DaHhijt1bFgjvBkHBib4t49GoNDhf2NDta4oeUNlaGbSt5K7qjZ955Q==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  no-case@3.0.4:
+    resolution: {integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==}
+
+  node-releases@2.0.48:
+    resolution: {integrity: sha512-1uz8041X6LoI6ZSdZacM9lVY28vuzDlSKitnpbSNK0RfKoIJkX29NBPVEFXhnuSuEOA9Ww0xnPJ+ILWbGAv8DA==}
+    engines: {node: '>=18'}
+
+  parent-module@1.0.1:
+    resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
+    engines: {node: '>=6'}
+
+  parse-json@5.2.0:
+    resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
+    engines: {node: '>=8'}
+
+  path-type@4.0.0:
+    resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
+    engines: {node: '>=8'}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
+  postcss@8.5.15:
+    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  react-dom@19.2.7:
+    resolution: {integrity: sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==}
+    peerDependencies:
+      react: ^19.2.7
+
+  react-hook-form@7.80.0:
+    resolution: {integrity: sha512-4P+fk6oXsxY+6xSj7Euhc2sumQD8zQqCuVHoJwoyp9EchP+IUW9OESB7uHFJOKsIBQ4MQqYE84INJFqUCYNoOg==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      react: ^16.8.0 || ^17 || ^18 || ^19
+
+  react-refresh@0.17.0:
+    resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
+    engines: {node: '>=0.10.0'}
+
+  react-router-dom@7.18.0:
+    resolution: {integrity: sha512-Fi0yY6kgtKae/Th2xibdWK0KSdYZ4B53Gyf6wRtomOKWgpNm7H7+DyfDhncdz9FKbpS+1jmDhg3F4WoGJ+yFOA==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+
+  react-router@7.18.0:
+    resolution: {integrity: sha512-pTTGt8J+ji1NOmYnjzT+bAJy/1zD+Jp4ziO6cL7T3ZLvXKtusO7BpFqlRXitqpcPVqllsIXFHRMt+2/k3Xn6HQ==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+
+  react@19.2.7:
+    resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
+    engines: {node: '>=0.10.0'}
+
+  resolve-from@4.0.0:
+    resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
+    engines: {node: '>=4'}
+
+  rollup@4.62.2:
+    resolution: {integrity: sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
+
+  set-cookie-parser@2.7.2:
+    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
+
+  snake-case@3.0.4:
+    resolution: {integrity: sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  svg-parser@2.0.4:
+    resolution: {integrity: sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ==}
+
+  tailwindcss@4.3.1:
+    resolution: {integrity: sha512-hk+TB1m+K8CYNrP6rjQaq/Y+4Zylwpa87mLYBKCunwnnQ9p+fHb7kmSfGqyEJoxF/O6CDyABWVFEafNSYKll+Q==}
+
+  tapable@2.3.3:
+    resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
+    engines: {node: '>=6'}
+
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  update-browserslist-db@1.2.3:
+    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+
+  vite-plugin-svgr@5.2.0:
+    resolution: {integrity: sha512-qj2eAKF8C6PZWemVTvQA0xgQIcP1hHU6Buh7fl6BhvayWwnuxE+z417miKxeDvRWbDrupQ1oK99hfxElopJ3sQ==}
+    peerDependencies:
+      vite: '>=3.0.0'
+
+  vite@6.4.3:
+    resolution: {integrity: sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      jiti: '>=1.21.0'
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  yallist@3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
+snapshots:
+
+  '@babel/code-frame@7.29.7':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.29.7
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/compat-data@7.29.7': {}
+
+  '@babel/core@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-compilation-targets': 7.29.7
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
+      '@babel/helpers': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+      '@jridgewell/remapping': 2.3.5
+      convert-source-map: 2.0.0
+      debug: 4.4.3
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/generator@7.29.7':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
+  '@babel/helper-compilation-targets@7.29.7':
+    dependencies:
+      '@babel/compat-data': 7.29.7
+      '@babel/helper-validator-option': 7.29.7
+      browserslist: 4.28.2
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-globals@7.29.7': {}
+
+  '@babel/helper-module-imports@7.29.7':
+    dependencies:
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-module-imports': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+      '@babel/traverse': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-plugin-utils@7.29.7': {}
+
+  '@babel/helper-string-parser@7.29.7': {}
+
+  '@babel/helper-validator-identifier@7.29.7': {}
+
+  '@babel/helper-validator-option@7.29.7': {}
+
+  '@babel/helpers@7.29.7':
+    dependencies:
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
+
+  '@babel/parser@7.29.7':
+    dependencies:
+      '@babel/types': 7.29.7
+
+  '@babel/plugin-transform-react-jsx-self@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-react-jsx-source@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/template@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+
+  '@babel/traverse@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-globals': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/types@7.29.7':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+
+  '@esbuild/aix-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm@0.25.12':
+    optional: true
+
+  '@esbuild/android-x64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.12':
+    optional: true
+
+  '@esbuild/linux-x64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/sunos-x64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.12':
+    optional: true
+
+  '@hookform/resolvers@3.10.0(react-hook-form@7.80.0(react@19.2.7))':
+    dependencies:
+      react-hook-form: 7.80.0(react@19.2.7)
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@rolldown/pluginutils@1.0.0-beta.27': {}
+
+  '@rollup/pluginutils@5.4.0(rollup@4.62.2)':
+    dependencies:
+      '@types/estree': 1.0.9
+      estree-walker: 2.0.2
+      picomatch: 4.0.4
+    optionalDependencies:
+      rollup: 4.62.2
+
+  '@rollup/rollup-android-arm-eabi@4.62.2':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.62.2':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.62.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.62.2':
+    optional: true
+
+  '@svgr/babel-plugin-add-jsx-attribute@8.0.0(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+
+  '@svgr/babel-plugin-remove-jsx-attribute@8.0.0(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+
+  '@svgr/babel-plugin-remove-jsx-empty-expression@8.0.0(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+
+  '@svgr/babel-plugin-replace-jsx-attribute-value@8.0.0(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+
+  '@svgr/babel-plugin-svg-dynamic-title@8.0.0(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+
+  '@svgr/babel-plugin-svg-em-dimensions@8.0.0(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+
+  '@svgr/babel-plugin-transform-react-native-svg@8.1.0(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+
+  '@svgr/babel-plugin-transform-svg-component@8.0.0(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+
+  '@svgr/babel-preset@8.1.0(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@svgr/babel-plugin-add-jsx-attribute': 8.0.0(@babel/core@7.29.7)
+      '@svgr/babel-plugin-remove-jsx-attribute': 8.0.0(@babel/core@7.29.7)
+      '@svgr/babel-plugin-remove-jsx-empty-expression': 8.0.0(@babel/core@7.29.7)
+      '@svgr/babel-plugin-replace-jsx-attribute-value': 8.0.0(@babel/core@7.29.7)
+      '@svgr/babel-plugin-svg-dynamic-title': 8.0.0(@babel/core@7.29.7)
+      '@svgr/babel-plugin-svg-em-dimensions': 8.0.0(@babel/core@7.29.7)
+      '@svgr/babel-plugin-transform-react-native-svg': 8.1.0(@babel/core@7.29.7)
+      '@svgr/babel-plugin-transform-svg-component': 8.0.0(@babel/core@7.29.7)
+
+  '@svgr/core@8.1.0(typescript@5.9.3)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@svgr/babel-preset': 8.1.0(@babel/core@7.29.7)
+      camelcase: 6.3.0
+      cosmiconfig: 8.3.6(typescript@5.9.3)
+      snake-case: 3.0.4
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
+  '@svgr/hast-util-to-babel-ast@8.0.0':
+    dependencies:
+      '@babel/types': 7.29.7
+      entities: 4.5.0
+
+  '@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0(typescript@5.9.3))':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@svgr/babel-preset': 8.1.0(@babel/core@7.29.7)
+      '@svgr/core': 8.1.0(typescript@5.9.3)
+      '@svgr/hast-util-to-babel-ast': 8.0.0
+      svg-parser: 2.0.4
+    transitivePeerDependencies:
+      - supports-color
+
+  '@tailwindcss/node@4.3.1':
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      enhanced-resolve: 5.21.6
+      jiti: 2.7.0
+      lightningcss: 1.32.0
+      magic-string: 0.30.21
+      source-map-js: 1.2.1
+      tailwindcss: 4.3.1
+
+  '@tailwindcss/oxide-android-arm64@4.3.1':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-arm64@4.3.1':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-x64@4.3.1':
+    optional: true
+
+  '@tailwindcss/oxide-freebsd-x64@4.3.1':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.1':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.3.1':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.3.1':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.3.1':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-musl@4.3.1':
+    optional: true
+
+  '@tailwindcss/oxide-wasm32-wasi@4.3.1':
+    optional: true
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.3.1':
+    optional: true
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.3.1':
+    optional: true
+
+  '@tailwindcss/oxide@4.3.1':
+    optionalDependencies:
+      '@tailwindcss/oxide-android-arm64': 4.3.1
+      '@tailwindcss/oxide-darwin-arm64': 4.3.1
+      '@tailwindcss/oxide-darwin-x64': 4.3.1
+      '@tailwindcss/oxide-freebsd-x64': 4.3.1
+      '@tailwindcss/oxide-linux-arm-gnueabihf': 4.3.1
+      '@tailwindcss/oxide-linux-arm64-gnu': 4.3.1
+      '@tailwindcss/oxide-linux-arm64-musl': 4.3.1
+      '@tailwindcss/oxide-linux-x64-gnu': 4.3.1
+      '@tailwindcss/oxide-linux-x64-musl': 4.3.1
+      '@tailwindcss/oxide-wasm32-wasi': 4.3.1
+      '@tailwindcss/oxide-win32-arm64-msvc': 4.3.1
+      '@tailwindcss/oxide-win32-x64-msvc': 4.3.1
+
+  '@tailwindcss/vite@4.3.1(vite@6.4.3(jiti@2.7.0)(lightningcss@1.32.0))':
+    dependencies:
+      '@tailwindcss/node': 4.3.1
+      '@tailwindcss/oxide': 4.3.1
+      tailwindcss: 4.3.1
+      vite: 6.4.3(jiti@2.7.0)(lightningcss@1.32.0)
+
+  '@types/babel__core@7.20.5':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      '@types/babel__generator': 7.27.0
+      '@types/babel__template': 7.4.4
+      '@types/babel__traverse': 7.28.0
+
+  '@types/babel__generator@7.27.0':
+    dependencies:
+      '@babel/types': 7.29.7
+
+  '@types/babel__template@7.4.4':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+
+  '@types/babel__traverse@7.28.0':
+    dependencies:
+      '@babel/types': 7.29.7
+
+  '@types/estree@1.0.9': {}
+
+  '@types/react-dom@19.2.3(@types/react@19.2.17)':
+    dependencies:
+      '@types/react': 19.2.17
+
+  '@types/react@19.2.17':
+    dependencies:
+      csstype: 3.2.3
+
+  '@vitejs/plugin-react@4.7.0(vite@6.4.3(jiti@2.7.0)(lightningcss@1.32.0))':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-react-jsx-source': 7.29.7(@babel/core@7.29.7)
+      '@rolldown/pluginutils': 1.0.0-beta.27
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.17.0
+      vite: 6.4.3(jiti@2.7.0)(lightningcss@1.32.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  argparse@2.0.1: {}
+
+  baseline-browser-mapping@2.10.38: {}
+
+  browserslist@4.28.2:
+    dependencies:
+      baseline-browser-mapping: 2.10.38
+      caniuse-lite: 1.0.30001799
+      electron-to-chromium: 1.5.376
+      node-releases: 2.0.48
+      update-browserslist-db: 1.2.3(browserslist@4.28.2)
+
+  callsites@3.1.0: {}
+
+  camelcase@6.3.0: {}
+
+  caniuse-lite@1.0.30001799: {}
+
+  convert-source-map@2.0.0: {}
+
+  cookie@1.1.1: {}
+
+  cosmiconfig@8.3.6(typescript@5.9.3):
+    dependencies:
+      import-fresh: 3.3.1
+      js-yaml: 4.2.0
+      parse-json: 5.2.0
+      path-type: 4.0.0
+    optionalDependencies:
+      typescript: 5.9.3
+
+  csstype@3.2.3: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  detect-libc@2.1.2: {}
+
+  dot-case@3.0.4:
+    dependencies:
+      no-case: 3.0.4
+      tslib: 2.8.1
+
+  electron-to-chromium@1.5.376: {}
+
+  enhanced-resolve@5.21.6:
+    dependencies:
+      graceful-fs: 4.2.11
+      tapable: 2.3.3
+
+  entities@4.5.0: {}
+
+  error-ex@1.3.4:
+    dependencies:
+      is-arrayish: 0.2.1
+
+  esbuild@0.25.12:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.12
+      '@esbuild/android-arm': 0.25.12
+      '@esbuild/android-arm64': 0.25.12
+      '@esbuild/android-x64': 0.25.12
+      '@esbuild/darwin-arm64': 0.25.12
+      '@esbuild/darwin-x64': 0.25.12
+      '@esbuild/freebsd-arm64': 0.25.12
+      '@esbuild/freebsd-x64': 0.25.12
+      '@esbuild/linux-arm': 0.25.12
+      '@esbuild/linux-arm64': 0.25.12
+      '@esbuild/linux-ia32': 0.25.12
+      '@esbuild/linux-loong64': 0.25.12
+      '@esbuild/linux-mips64el': 0.25.12
+      '@esbuild/linux-ppc64': 0.25.12
+      '@esbuild/linux-riscv64': 0.25.12
+      '@esbuild/linux-s390x': 0.25.12
+      '@esbuild/linux-x64': 0.25.12
+      '@esbuild/netbsd-arm64': 0.25.12
+      '@esbuild/netbsd-x64': 0.25.12
+      '@esbuild/openbsd-arm64': 0.25.12
+      '@esbuild/openbsd-x64': 0.25.12
+      '@esbuild/openharmony-arm64': 0.25.12
+      '@esbuild/sunos-x64': 0.25.12
+      '@esbuild/win32-arm64': 0.25.12
+      '@esbuild/win32-ia32': 0.25.12
+      '@esbuild/win32-x64': 0.25.12
+
+  escalade@3.2.0: {}
+
+  estree-walker@2.0.2: {}
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
+
+  framer-motion@11.18.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+    dependencies:
+      motion-dom: 11.18.1
+      motion-utils: 11.18.1
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+
+  fsevents@2.3.3:
+    optional: true
+
+  gensync@1.0.0-beta.2: {}
+
+  graceful-fs@4.2.11: {}
+
+  import-fresh@3.3.1:
+    dependencies:
+      parent-module: 1.0.1
+      resolve-from: 4.0.0
+
+  is-arrayish@0.2.1: {}
+
+  jiti@2.7.0: {}
+
+  js-tokens@4.0.0: {}
+
+  js-yaml@4.2.0:
+    dependencies:
+      argparse: 2.0.1
+
+  jsesc@3.1.0: {}
+
+  json-parse-even-better-errors@2.3.1: {}
+
+  json5@2.2.3: {}
+
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
+
+  lines-and-columns@1.2.4: {}
+
+  lower-case@2.0.2:
+    dependencies:
+      tslib: 2.8.1
+
+  lru-cache@5.1.1:
+    dependencies:
+      yallist: 3.1.1
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  motion-dom@11.18.1:
+    dependencies:
+      motion-utils: 11.18.1
+
+  motion-utils@11.18.1: {}
+
+  ms@2.1.3: {}
+
+  nanoid@3.3.13: {}
+
+  no-case@3.0.4:
+    dependencies:
+      lower-case: 2.0.2
+      tslib: 2.8.1
+
+  node-releases@2.0.48: {}
+
+  parent-module@1.0.1:
+    dependencies:
+      callsites: 3.1.0
+
+  parse-json@5.2.0:
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      error-ex: 1.3.4
+      json-parse-even-better-errors: 2.3.1
+      lines-and-columns: 1.2.4
+
+  path-type@4.0.0: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.4: {}
+
+  postcss@8.5.15:
+    dependencies:
+      nanoid: 3.3.13
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  react-dom@19.2.7(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+      scheduler: 0.27.0
+
+  react-hook-form@7.80.0(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+
+  react-refresh@0.17.0: {}
+
+  react-router-dom@7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      react-router: 7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+
+  react-router@7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+    dependencies:
+      cookie: 1.1.1
+      react: 19.2.7
+      set-cookie-parser: 2.7.2
+    optionalDependencies:
+      react-dom: 19.2.7(react@19.2.7)
+
+  react@19.2.7: {}
+
+  resolve-from@4.0.0: {}
+
+  rollup@4.62.2:
+    dependencies:
+      '@types/estree': 1.0.9
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.62.2
+      '@rollup/rollup-android-arm64': 4.62.2
+      '@rollup/rollup-darwin-arm64': 4.62.2
+      '@rollup/rollup-darwin-x64': 4.62.2
+      '@rollup/rollup-freebsd-arm64': 4.62.2
+      '@rollup/rollup-freebsd-x64': 4.62.2
+      '@rollup/rollup-linux-arm-gnueabihf': 4.62.2
+      '@rollup/rollup-linux-arm-musleabihf': 4.62.2
+      '@rollup/rollup-linux-arm64-gnu': 4.62.2
+      '@rollup/rollup-linux-arm64-musl': 4.62.2
+      '@rollup/rollup-linux-loong64-gnu': 4.62.2
+      '@rollup/rollup-linux-loong64-musl': 4.62.2
+      '@rollup/rollup-linux-ppc64-gnu': 4.62.2
+      '@rollup/rollup-linux-ppc64-musl': 4.62.2
+      '@rollup/rollup-linux-riscv64-gnu': 4.62.2
+      '@rollup/rollup-linux-riscv64-musl': 4.62.2
+      '@rollup/rollup-linux-s390x-gnu': 4.62.2
+      '@rollup/rollup-linux-x64-gnu': 4.62.2
+      '@rollup/rollup-linux-x64-musl': 4.62.2
+      '@rollup/rollup-openbsd-x64': 4.62.2
+      '@rollup/rollup-openharmony-arm64': 4.62.2
+      '@rollup/rollup-win32-arm64-msvc': 4.62.2
+      '@rollup/rollup-win32-ia32-msvc': 4.62.2
+      '@rollup/rollup-win32-x64-gnu': 4.62.2
+      '@rollup/rollup-win32-x64-msvc': 4.62.2
+      fsevents: 2.3.3
+
+  scheduler@0.27.0: {}
+
+  semver@6.3.1: {}
+
+  set-cookie-parser@2.7.2: {}
+
+  snake-case@3.0.4:
+    dependencies:
+      dot-case: 3.0.4
+      tslib: 2.8.1
+
+  source-map-js@1.2.1: {}
+
+  svg-parser@2.0.4: {}
+
+  tailwindcss@4.3.1: {}
+
+  tapable@2.3.3: {}
+
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  tslib@2.8.1: {}
+
+  typescript@5.9.3: {}
+
+  update-browserslist-db@1.2.3(browserslist@4.28.2):
+    dependencies:
+      browserslist: 4.28.2
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
+  vite-plugin-svgr@5.2.0(rollup@4.62.2)(typescript@5.9.3)(vite@6.4.3(jiti@2.7.0)(lightningcss@1.32.0)):
+    dependencies:
+      '@rollup/pluginutils': 5.4.0(rollup@4.62.2)
+      '@svgr/core': 8.1.0(typescript@5.9.3)
+      '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@5.9.3))
+      vite: 6.4.3(jiti@2.7.0)(lightningcss@1.32.0)
+    transitivePeerDependencies:
+      - rollup
+      - supports-color
+      - typescript
+
+  vite@6.4.3(jiti@2.7.0)(lightningcss@1.32.0):
+    dependencies:
+      esbuild: 0.25.12
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.15
+      rollup: 4.62.2
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      fsevents: 2.3.3
+      jiti: 2.7.0
+      lightningcss: 1.32.0
+
+  yallist@3.1.1: {}
+
+  zod@3.25.76: {}

--- a/mentolder-web/pnpm-workspace.yaml
+++ b/mentolder-web/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  esbuild: true

--- a/mentolder-web/public/favicon.svg
+++ b/mentolder-web/public/favicon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" role="img" aria-label="mentolder">
+  <rect x="0" y="0" width="32" height="32" rx="7" fill="#101826"/>
+  <text x="16" y="22" text-anchor="middle" fill="#eef1f3" font-family="Geist, ui-sans-serif, system-ui, sans-serif" font-weight="700" font-size="20" letter-spacing="-0.5">m</text>
+  <rect x="9" y="25" width="14" height="2" rx="1" fill="oklch(0.80 0.09 75)"/>
+</svg>

--- a/mentolder-web/src/App.tsx
+++ b/mentolder-web/src/App.tsx
@@ -1,0 +1,64 @@
+import { Routes, Route, useLocation } from 'react-router-dom';
+import { useEffect } from 'react';
+import { Navigation } from './components/Navigation';
+import { Footer } from './components/Footer';
+import { HomePage } from './pages/HomePage';
+import { KontaktPage } from './pages/KontaktPage';
+import { ImpressumPage } from './pages/ImpressumPage';
+import { DatenschutzPage } from './pages/DatenschutzPage';
+
+function ScrollToTop() {
+  const { pathname, hash } = useLocation();
+  useEffect(() => {
+    if (hash) {
+      const el = document.querySelector(hash);
+      if (el) {
+        (el as HTMLElement).scrollIntoView({ behavior: 'smooth', block: 'start' });
+        return;
+      }
+    }
+    window.scrollTo({ top: 0, behavior: 'instant' as ScrollBehavior });
+  }, [pathname, hash]);
+  return null;
+}
+
+export default function App() {
+  return (
+    <>
+      <ScrollToTop />
+      <Navigation />
+      <main className="flex-1">
+        <Routes>
+          <Route path="/" element={<HomePage />} />
+          <Route path="/kontakt" element={<KontaktPage />} />
+          <Route path="/impressum" element={<ImpressumPage />} />
+          <Route path="/datenschutz" element={<DatenschutzPage />} />
+          <Route
+            path="*"
+            element={
+              <section className="pt-[120px] pb-[160px] max-w-[820px] mx-auto px-10 max-md:px-[22px]">
+                <h1
+                  className="font-serif font-light text-fg leading-[1.05] m-0"
+                  style={{
+                    fontSize: 'clamp(40px, 5.4vw, 64px)',
+                    letterSpacing: '-0.02em',
+                  }}
+                >
+                  404 — <em>nicht gefunden</em>
+                </h1>
+                <p className="text-fg-soft mt-5 text-[18px] leading-[1.6]">
+                  Diese Seite existiert (noch) nicht. Zurück zur{' '}
+                  <a href="/" className="text-brass border-b border-brass">
+                    Startseite
+                  </a>
+                  .
+                </p>
+              </section>
+            }
+          />
+        </Routes>
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/mentolder-web/src/assets/hero-halo.svg
+++ b/mentolder-web/src/assets/hero-halo.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 900" width="1600" height="900" preserveAspectRatio="xMidYMid slice" role="presentation" aria-hidden="true">
+  <defs>
+    <radialGradient id="brass" cx="0.78" cy="0.18" r="0.42" fx="0.78" fy="0.18">
+      <stop offset="0%" stop-color="oklch(0.80 0.09 75 / 0.16)"/>
+      <stop offset="55%" stop-color="oklch(0.80 0.09 75 / 0.04)"/>
+      <stop offset="100%" stop-color="oklch(0.80 0.09 75 / 0)"/>
+    </radialGradient>
+    <radialGradient id="ink" cx="0.18" cy="0.78" r="0.5" fx="0.18" fy="0.78">
+      <stop offset="0%" stop-color="oklch(0.60 0.05 250 / 0.32)"/>
+      <stop offset="55%" stop-color="oklch(0.60 0.05 250 / 0.06)"/>
+      <stop offset="100%" stop-color="oklch(0.60 0.05 250 / 0)"/>
+    </radialGradient>
+    <filter id="soft" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur stdDeviation="14"/>
+    </filter>
+  </defs>
+  <rect width="1600" height="900" fill="#0b111c"/>
+  <g filter="url(#soft)">
+    <rect width="1600" height="900" fill="url(#brass)"/>
+    <rect width="1600" height="900" fill="url(#ink)"/>
+  </g>
+</svg>

--- a/mentolder-web/src/assets/icons/icon-digitalisierung.svg
+++ b/mentolder-web/src/assets/icons/icon-digitalisierung.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" role="img" aria-label="Digitalisierung">
+  <rect x="3" y="4" width="18" height="13" rx="2"/>
+  <path d="M8 21h8M12 17v4"/>
+  <path d="M7 9l2 2 4-4 4 4"/>
+</svg>

--- a/mentolder-web/src/assets/icons/icon-fuehrung.svg
+++ b/mentolder-web/src/assets/icons/icon-fuehrung.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" role="img" aria-label="Führung">
+  <circle cx="12" cy="6" r="2.5"/>
+  <path d="M9 21v-2a4 4 0 0 1 4-4h2a4 4 0 0 1 4 4v2"/>
+  <path d="M5 12v-1a3 3 0 0 1 3-3"/>
+  <path d="M19 12v-1a3 3 0 0 0-3-3"/>
+</svg>

--- a/mentolder-web/src/assets/icons/icon-kommunikation.svg
+++ b/mentolder-web/src/assets/icons/icon-kommunikation.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" role="img" aria-label="Kommunikation">
+  <path d="M4 7h16v10H8l-4 3z"/>
+  <path d="M8 11h8M8 14h5"/>
+</svg>

--- a/mentolder-web/src/assets/icons/icon-resilienz.svg
+++ b/mentolder-web/src/assets/icons/icon-resilienz.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" role="img" aria-label="Resilienz">
+  <path d="M12 21s-7-4.35-7-10a5 5 0 0 1 9-3 5 5 0 0 1 9 3c0 5.65-7 10-7 10z" transform="translate(-1.5 0)"/>
+  <path d="M9 12l2 2 4-4"/>
+</svg>

--- a/mentolder-web/src/assets/icons/icon-strategie.svg
+++ b/mentolder-web/src/assets/icons/icon-strategie.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" role="img" aria-label="Strategie">
+  <circle cx="12" cy="12" r="9"/>
+  <circle cx="12" cy="12" r="5"/>
+  <circle cx="12" cy="12" r="1.2" fill="currentColor"/>
+  <path d="M12 3v3M12 18v3M3 12h3M18 12h3"/>
+</svg>

--- a/mentolder-web/src/assets/icons/icon-team.svg
+++ b/mentolder-web/src/assets/icons/icon-team.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" role="img" aria-label="Team">
+  <circle cx="9" cy="8" r="2.5"/>
+  <circle cx="17" cy="9" r="2"/>
+  <path d="M3 20v-2a4 4 0 0 1 4-4h4a4 4 0 0 1 4 4v2"/>
+  <path d="M15 20v-1.5a3 3 0 0 1 3-3h1a3 3 0 0 1 3 3V20"/>
+</svg>

--- a/mentolder-web/src/components/CallToAction.tsx
+++ b/mentolder-web/src/components/CallToAction.tsx
@@ -1,0 +1,101 @@
+import { Link } from 'react-router-dom';
+
+interface CallToActionProps {
+  eyebrow?: string;
+  title?: string;
+  titleEmphasis?: string;
+  subtitle?: string;
+  primaryText?: string;
+  primaryHref?: string;
+  secondaryText?: string;
+  secondaryHref?: string;
+}
+
+export function CallToAction({
+  eyebrow = 'Bereit?',
+  title = 'Lassen Sie uns',
+  titleEmphasis = 'in 30 Minuten herausfinden, ob es passt.',
+  subtitle = 'Ein kostenloses Erstgespräch — unverbindlich, auf Augenhöhe und ohne Verkaufsdruck.',
+  primaryText = 'Termin vereinbaren',
+  primaryHref = '/kontakt',
+  secondaryText = '',
+  secondaryHref = '',
+}: CallToActionProps) {
+  return (
+    <section
+      className="py-[130px] border-t border-line relative overflow-hidden"
+      aria-labelledby="cta-heading"
+    >
+      <div
+        className="absolute inset-0 pointer-events-none"
+        aria-hidden="true"
+        style={{
+          background:
+            'radial-gradient(ellipse at 50% 100%, oklch(0.80 0.09 75 / .16), transparent 60%)',
+        }}
+      />
+      <div className="max-w-[760px] mx-auto px-10 text-center relative z-[1] max-md:px-[22px]">
+        <p className="font-mono text-[11px] tracking-[0.18em] uppercase text-brass inline-flex items-center gap-2.5 m-0 mb-4">
+          <span aria-hidden="true" className="inline-block w-[22px] h-px bg-current opacity-80" />
+          {eyebrow}
+        </p>
+        <h2
+          id="cta-heading"
+          className="font-serif font-normal text-fg leading-[1.1] m-0"
+          style={{
+            fontSize: 'clamp(28px, 3.6vw, 48px)',
+            letterSpacing: '-0.02em',
+          }}
+        >
+          {title}
+          {titleEmphasis && (
+            <>
+              {' '}
+              <em>{titleEmphasis}</em>
+            </>
+          )}
+        </h2>
+        <p className="text-[18px] leading-[1.6] text-fg-soft mt-5 mb-9 max-w-[52ch] mx-auto">
+          {subtitle}
+        </p>
+        <div className="flex flex-wrap justify-center gap-[14px]" role="group" aria-label="Aktionen">
+          <Link to={primaryHref} className="btn-primary">
+            {primaryText}
+            <svg
+              viewBox="0 0 14 14"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden="true"
+              className="w-[14px] h-[14px]"
+            >
+              <path d="M2 7h10M8 3l4 4-4 4" />
+            </svg>
+          </Link>
+          {secondaryText && (
+            <a href={secondaryHref || '#'} className="btn-ghost">
+              {secondaryText}
+            </a>
+          )}
+        </div>
+      </div>
+
+      <style>{`
+        .btn-primary, .btn-ghost {
+          display: inline-flex; align-items: center; gap: 10px;
+          padding: 14px 22px; border-radius: 999px;
+          font-family: var(--sans); font-size: 14px; font-weight: 600;
+          text-decoration: none;
+          transition: transform .2s ease, background .2s ease, border-color .2s ease, color .2s ease;
+        }
+        .btn-primary { background: var(--brass); color: var(--ink-900); }
+        .btn-primary:hover { background: var(--brass-2); transform: translateY(-1px); }
+        .btn-ghost { color: var(--fg); border: 1px solid var(--line-2); background: transparent; }
+        .btn-ghost:hover { border-color: var(--brass); color: var(--brass); }
+        h2 em { font-style: italic; font-weight: 400; color: var(--brass-2); }
+      `}</style>
+    </section>
+  );
+}

--- a/mentolder-web/src/components/ContactForm.tsx
+++ b/mentolder-web/src/components/ContactForm.tsx
@@ -1,0 +1,292 @@
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+
+const schema = z.object({
+  name: z.string().min(2, 'Name erforderlich'),
+  email: z.string().email('Gültige E-Mail erforderlich'),
+  phone: z.string().optional(),
+  type: z.string().min(1, 'Bitte Anliegen wählen'),
+  message: z.string().min(10, 'Nachricht zu kurz (min. 10 Zeichen)'),
+  consent: z.literal(true, {
+    errorMap: () => ({ message: 'Bitte Datenschutzhinweis bestätigen' }),
+  }),
+});
+
+type FormValues = z.infer<typeof schema>;
+
+const typeOptions = [
+  { value: 'allgemein', label: 'Allgemeine Anfrage' },
+  { value: 'erstgespraech', label: 'Kostenloses Erstgespräch' },
+  { value: 'coaching', label: 'Coaching' },
+  { value: 'beratung', label: 'Beratung' },
+  { value: 'support', label: 'Support / Bestandskunden' },
+  { value: 'feedback', label: 'Feedback' },
+] as const;
+
+const FORMSPREE_ENDPOINT = import.meta.env.VITE_FORMSPREE_ENDPOINT ?? '';
+const FALLBACK_EMAIL = import.meta.env.VITE_CONTACT_EMAIL ?? 'mail@mentolder.de';
+
+export function ContactForm() {
+  const [submitting, setSubmitting] = useState(false);
+  const [result, setResult] = useState<{ success: boolean; message: string } | null>(null);
+  const [fallbackUsed, setFallbackUsed] = useState(false);
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors },
+  } = useForm<FormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: { type: 'allgemein' },
+  });
+
+  async function onSubmit(values: FormValues) {
+    setSubmitting(true);
+    setResult(null);
+    setFallbackUsed(false);
+
+    try {
+      if (!FORMSPREE_ENDPOINT) {
+        // Dev-mode fallback: build a mailto: link so the user can still reach out.
+        if (import.meta.env.DEV) {
+          console.warn(
+            '[mentolder-web] VITE_FORMSPREE_ENDPOINT is not set — falling back to mailto:. ' +
+              'Set the variable in .env for production deployments.',
+          );
+        }
+        const subject = encodeURIComponent(`[mentolder] ${values.type} von ${values.name}`);
+        const body = encodeURIComponent(
+          `${values.message}\n\n— ${values.name}\n${values.email}${values.phone ? `\n${values.phone}` : ''}`,
+        );
+        window.location.href = `mailto:${FALLBACK_EMAIL}?subject=${subject}&body=${body}`;
+        setResult({
+          success: true,
+          message: 'E-Mail-Programm geöffnet — bitte senden Sie die Nachricht von dort ab.',
+        });
+        setFallbackUsed(true);
+        return;
+      }
+
+      const res = await fetch(FORMSPREE_ENDPOINT, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+        body: JSON.stringify(values),
+      });
+
+      if (res.ok) {
+        setResult({ success: true, message: 'Danke! Ich melde mich innerhalb von 48 Stunden.' });
+        reset();
+      } else {
+        const data: { error?: string } = await res.json().catch(() => ({}));
+        setResult({
+          success: false,
+          message: data.error ?? 'Senden fehlgeschlagen — bitte versuchen Sie es erneut.',
+        });
+      }
+    } catch {
+      setResult({
+        success: false,
+        message: 'Verbindung fehlgeschlagen — bitte prüfen Sie Ihre Internetverbindung.',
+      });
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="cf-form flex flex-col gap-[22px]" noValidate>
+      <div className="cf-field flex flex-col gap-2">
+        <label htmlFor="cf-type" className="cf-label">
+          Anliegen
+        </label>
+        <select id="cf-type" {...register('type')} className="cf-input">
+          {typeOptions.map((opt) => (
+            <option key={opt.value} value={opt.value}>
+              {opt.label}
+            </option>
+          ))}
+        </select>
+        {errors.type && <p className="cf-err">{errors.type.message}</p>}
+      </div>
+
+      <div className="cf-field-row grid grid-cols-1 sm:grid-cols-2 gap-[22px]">
+        <div className="cf-field flex flex-col gap-2">
+          <label htmlFor="cf-name" className="cf-label">
+            Name <span className="text-brass">*</span>
+          </label>
+          <input
+            id="cf-name"
+            type="text"
+            autoComplete="name"
+            placeholder="Vor- und Nachname"
+            {...register('name')}
+            className="cf-input"
+          />
+          {errors.name && <p className="cf-err">{errors.name.message}</p>}
+        </div>
+        <div className="cf-field flex flex-col gap-2">
+          <label htmlFor="cf-email" className="cf-label">
+            E-Mail <span className="text-brass">*</span>
+          </label>
+          <input
+            id="cf-email"
+            type="email"
+            autoComplete="email"
+            placeholder="name@beispiel.de"
+            {...register('email')}
+            className="cf-input"
+          />
+          {errors.email && <p className="cf-err">{errors.email.message}</p>}
+        </div>
+      </div>
+
+      <div className="cf-field flex flex-col gap-2">
+        <label htmlFor="cf-phone" className="cf-label">
+          Telefon <span className="text-mute-2 text-[12px] font-sans normal-case tracking-normal">(optional)</span>
+        </label>
+        <input
+          id="cf-phone"
+          type="tel"
+          autoComplete="tel"
+          placeholder="+49 ..."
+          {...register('phone')}
+          className="cf-input"
+        />
+      </div>
+
+      <div className="cf-field flex flex-col gap-2">
+        <label htmlFor="cf-message" className="cf-label">
+          Nachricht <span className="text-brass">*</span>
+        </label>
+        <textarea
+          id="cf-message"
+          rows={5}
+          placeholder="Worum geht es? In 2-3 Sätzen reicht für ein erstes Kennenlernen."
+          {...register('message')}
+          className="cf-input cf-textarea resize-y min-h-[100px] leading-[1.55]"
+        />
+        {errors.message && <p className="cf-err">{errors.message.message}</p>}
+      </div>
+
+      <div className="cf-field flex flex-row items-start gap-2">
+        <input
+          id="cf-consent"
+          type="checkbox"
+          {...register('consent')}
+          className="mt-1 accent-[color:var(--brass)]"
+        />
+        <label htmlFor="cf-consent" className="text-[13px] text-mute leading-[1.5]">
+          Ich habe die{' '}
+          <a href="/datenschutz" className="border-b border-brass text-fg-soft hover:text-brass-2">
+            Datenschutzerklärung
+          </a>{' '}
+          gelesen und stimme der Verarbeitung meiner Daten zur Bearbeitung der Anfrage zu.
+        </label>
+      </div>
+      {errors.consent && <p className="cf-err">{errors.consent.message}</p>}
+
+      <div className="cf-submit-area flex flex-wrap items-center justify-between gap-6">
+        <button type="submit" disabled={submitting} className="cf-btn">
+          {submitting ? 'Wird gesendet…' : 'Nachricht senden'}
+        </button>
+        <p className="cf-submit-note text-[13px] text-mute max-w-[38ch] leading-[1.5] m-0">
+          Antwort innerhalb von 48 Stunden. Kein Verkaufsdruck, kein Newsletter.
+        </p>
+      </div>
+
+      {result && (
+        <div
+          className={`cf-result p-4 text-[14px] leading-[1.55] rounded-lg ${
+            result.success
+              ? 'border'
+              : 'border'
+          }`}
+          style={
+            result.success
+              ? {
+                  background: 'oklch(0.80 0.06 160 / .1)',
+                  color: 'oklch(0.80 0.06 160)',
+                  borderColor: 'oklch(0.80 0.06 160 / .25)',
+                }
+              : {
+                  background: 'oklch(0.62 0.18 22 / .1)',
+                  color: 'oklch(0.75 0.12 22)',
+                  borderColor: 'oklch(0.62 0.18 22 / .25)',
+                }
+          }
+          role="status"
+        >
+          {result.message}
+          {fallbackUsed && (
+            <span className="block text-[12px] text-mute mt-1">
+              Hinweis: Es wurde kein Formspree-Backend konfiguriert.
+            </span>
+          )}
+        </div>
+      )}
+
+      <style>{`
+        .cf-label {
+          font-family: var(--mono);
+          font-size: 11px;
+          letter-spacing: 0.14em;
+          text-transform: uppercase;
+          color: var(--mute);
+        }
+        .cf-input {
+          background: transparent;
+          border: none;
+          border-bottom: 1px solid var(--line-2);
+          padding: 10px 0 12px;
+          font-family: var(--sans);
+          font-size: 16px;
+          color: var(--fg);
+          outline: none;
+          width: 100%;
+          transition: border-color 200ms ease;
+          -webkit-appearance: none;
+          appearance: none;
+        }
+        .cf-input::placeholder { color: var(--mute-2); }
+        .cf-input:focus { border-color: var(--brass); }
+        select.cf-input {
+          background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8'%3E%3Cpath d='M1 1l5 5 5-5' stroke='%238c96a3' stroke-width='1.5' fill='none' stroke-linecap='round'/%3E%3C/svg%3E");
+          background-repeat: no-repeat;
+          background-position: right 4px center;
+          padding-right: 24px;
+          cursor: pointer;
+        }
+        .cf-err {
+          font-family: var(--mono);
+          font-size: 11px;
+          letter-spacing: 0.04em;
+          color: oklch(0.75 0.12 22);
+          margin: 0;
+        }
+        .cf-btn {
+          display: inline-flex;
+          align-items: center;
+          gap: 10px;
+          background: var(--brass);
+          color: #1a130a;
+          border: none;
+          padding: 15px 28px;
+          border-radius: 999px;
+          font-family: var(--sans);
+          font-size: 15px;
+          font-weight: 600;
+          cursor: pointer;
+          transition: background 200ms ease, transform 200ms ease;
+        }
+        .cf-btn:hover:not(:disabled) { background: var(--brass-2); transform: translateY(-1px); }
+        .cf-btn:disabled { background: var(--ink-800); color: var(--mute); cursor: not-allowed; }
+        @media (max-width: 640px) {
+          .cf-field-row { grid-template-columns: 1fr; }
+        }
+      `}</style>
+    </form>
+  );
+}

--- a/mentolder-web/src/components/FAQ.tsx
+++ b/mentolder-web/src/components/FAQ.tsx
@@ -1,0 +1,125 @@
+import { useState, useId } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+
+export interface FAQItem {
+  question: string;
+  answer: string;
+}
+
+interface FAQProps {
+  items: FAQItem[];
+  title?: string;
+}
+
+function Chevron({ open }: { open: boolean }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      className="w-5 h-5 text-brass flex-shrink-0"
+      style={{
+        transform: `rotate(${open ? 180 : 0}deg)`,
+        transition: 'transform 0.3s ease',
+      }}
+    >
+      <path d="M19 9l-7 7-7-7" />
+    </svg>
+  );
+}
+
+export function FAQ({ items, title = 'Häufige Fragen' }: FAQProps) {
+  const [openSet, setOpenSet] = useState<Set<number>>(new Set());
+  const baseId = useId();
+
+  function toggle(i: number) {
+    setOpenSet((prev) => {
+      const next = new Set(prev);
+      if (next.has(i)) next.delete(i);
+      else next.add(i);
+      return next;
+    });
+  }
+
+  function onKey(e: React.KeyboardEvent, i: number) {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      toggle(i);
+    }
+  }
+
+  return (
+    <section className="py-[80px] border-t border-line" aria-labelledby={`${baseId}-heading`}>
+      <div className="faq-wrap max-w-[720px] mx-auto px-10 max-md:px-[22px]">
+        <h2
+          id={`${baseId}-heading`}
+          className="font-serif font-normal text-fg text-center m-0 mb-12 leading-[1.1]"
+          style={{
+            fontSize: 'clamp(28px, 3vw, 40px)',
+            letterSpacing: '-0.02em',
+          }}
+        >
+          {title}
+        </h2>
+        <div className="flex flex-col gap-2">
+          {items.map((item, i) => {
+            const open = openSet.has(i);
+            const buttonId = `${baseId}-q-${i}`;
+            const regionId = `${baseId}-a-${i}`;
+            return (
+              <div
+                key={i}
+                className="rounded-xl border overflow-hidden transition-colors duration-150"
+                style={{
+                  background: 'var(--ink-800)',
+                  borderColor: open ? 'var(--line-2)' : 'var(--line)',
+                }}
+              >
+                <button
+                  id={buttonId}
+                  type="button"
+                  onClick={() => toggle(i)}
+                  onKeyDown={(e) => onKey(e, i)}
+                  aria-expanded={open}
+                  aria-controls={regionId}
+                  className="w-full text-left px-6 py-5 flex items-center justify-between gap-4 bg-transparent border-0 cursor-pointer transition-colors duration-150"
+                >
+                  <span className="text-base font-medium text-fg leading-[1.4]">
+                    {item.question}
+                  </span>
+                  <Chevron open={open} />
+                </button>
+                <AnimatePresence initial={false}>
+                  {open && (
+                    <motion.div
+                      key="content"
+                      id={regionId}
+                      role="region"
+                      aria-labelledby={buttonId}
+                      initial={{ height: 0, opacity: 0 }}
+                      animate={{ height: 'auto', opacity: 1 }}
+                      exit={{ height: 0, opacity: 0 }}
+                      transition={{ duration: 0.28, ease: [0.22, 1, 0.36, 1] }}
+                      className="overflow-hidden"
+                    >
+                      <div
+                        className="px-6 pb-5 pt-4 text-[15px] leading-[1.6] text-mute border-t"
+                        style={{ borderColor: 'var(--line)', marginTop: '-1px' }}
+                      >
+                        {item.answer}
+                      </div>
+                    </motion.div>
+                  )}
+                </AnimatePresence>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/mentolder-web/src/components/Footer.tsx
+++ b/mentolder-web/src/components/Footer.tsx
@@ -1,0 +1,132 @@
+import { Link } from 'react-router-dom';
+
+const BRAND_NAME = (import.meta.env.VITE_BRAND_NAME ?? 'mentolder').toLowerCase();
+const EMAIL = import.meta.env.VITE_CONTACT_EMAIL ?? 'mail@mentolder.de';
+const PHONE = import.meta.env.VITE_CONTACT_PHONE ?? '';
+const CITY = import.meta.env.VITE_CONTACT_CITY ?? 'Lüneburg';
+const TAGLINE = 'Digital Coach & Führungskräfte-Mentor';
+
+const serviceLinks = [
+  { label: 'Coaching & 1:1', href: '/angebote/coaching' },
+  { label: 'Führungs-Coaching', href: '/angebote/fuehrung' },
+  { label: 'Digitale Transformation', href: '/angebote/digitalisierung' },
+  { label: 'Workshops & Vorträge', href: '/angebote/workshops' },
+];
+
+const rechtLinks = [
+  { label: 'Impressum', href: '/impressum' },
+  { label: 'Datenschutz', href: '/datenschutz' },
+  { label: 'Barrierefreiheit', href: '/barrierefreiheit' },
+  { label: 'AGB', href: '/agb' },
+];
+
+export function Footer() {
+  const year = new Date().getFullYear();
+  return (
+    <footer className="bg-ink-850 border-t border-line pt-[72px] pb-9">
+      <div className="max-w-[1240px] mx-auto px-10 max-md:px-[22px]">
+        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-[1.4fr_1fr_1fr_1fr] gap-12 mb-14">
+          {/* Brand col */}
+          <div>
+            <div className="flex items-center gap-2.5 mb-4">
+              <span
+                className="w-7 h-7 rounded-lg flex items-center justify-center font-bold text-ink-900 text-sm flex-shrink-0"
+                style={{
+                  background:
+                    'radial-gradient(circle at 30% 30%, var(--brass-2), var(--brass) 55%, #8a6a2a 100%)',
+                  boxShadow:
+                    'inset 0 0 0 1px rgba(255,255,255,.2), 0 0 0 1px rgba(0,0,0,.3)',
+                }}
+                aria-hidden="true"
+              >
+                {BRAND_NAME.charAt(0)}
+              </span>
+              <span className="font-serif text-[18px] text-fg" style={{ letterSpacing: '-0.01em' }}>
+                {BRAND_NAME}
+                <span className="text-brass">.</span>
+              </span>
+            </div>
+            <p className="text-[14px] text-fg-soft max-w-[32ch] leading-[1.6] m-0">{TAGLINE}</p>
+          </div>
+
+          {/* Kontakt col */}
+          <div>
+            <h5 className="font-mono text-[11px] tracking-[0.16em] uppercase text-brass m-0 mb-[18px]">
+              Kontakt
+            </h5>
+            <ul className="list-none p-0 m-0">
+              {PHONE && (
+                <li className="mb-2">
+                  <a
+                    href={`tel:${PHONE.replace(/\s/g, '')}`}
+                    className="text-[14px] text-mute no-underline transition-colors duration-150 hover:text-fg"
+                  >
+                    {PHONE}
+                  </a>
+                </li>
+              )}
+              <li className="mb-2">
+                <a
+                  href={`mailto:${EMAIL}`}
+                  className="text-[14px] text-mute no-underline transition-colors duration-150 hover:text-fg"
+                >
+                  {EMAIL}
+                </a>
+              </li>
+              <li>
+                <span className="text-[14px] text-mute">{CITY}</span>
+              </li>
+            </ul>
+          </div>
+
+          {/* Angebote col */}
+          <div>
+            <h5 className="font-mono text-[11px] tracking-[0.16em] uppercase text-brass m-0 mb-[18px]">
+              Angebote
+            </h5>
+            <ul className="list-none p-0 m-0">
+              {serviceLinks.map((s) => (
+                <li key={s.href} className="mb-2">
+                  <Link
+                    to={s.href}
+                    className="text-[14px] text-mute no-underline transition-colors duration-150 hover:text-fg"
+                  >
+                    {s.label}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          {/* Rechtliches col */}
+          <div>
+            <h5 className="font-mono text-[11px] tracking-[0.16em] uppercase text-brass m-0 mb-[18px]">
+              Rechtliches
+            </h5>
+            <ul className="list-none p-0 m-0">
+              {rechtLinks.map((l) => (
+                <li key={l.href} className="mb-2">
+                  <Link
+                    to={l.href}
+                    className="text-[14px] text-mute no-underline transition-colors duration-150 hover:text-fg"
+                  >
+                    {l.label}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+
+        <div className="border-t border-line pt-6 flex flex-wrap justify-between items-center gap-2">
+          <p className="font-mono text-[11px] tracking-[0.08em] uppercase text-mute-2 m-0">
+            © {year} {BRAND_NAME} — Alle Rechte vorbehalten
+          </p>
+          <p className="font-mono text-[11px] tracking-[0.08em] uppercase text-mute-2 m-0">
+            Gestaltet in {CITY} · DE
+          </p>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/mentolder-web/src/components/Hero.tsx
+++ b/mentolder-web/src/components/Hero.tsx
@@ -1,0 +1,184 @@
+import { motion } from 'framer-motion';
+import { Link } from 'react-router-dom';
+import { KickerBar } from './KickerBar';
+import { Portrait } from './Portrait';
+import heroHalo from '@/assets/hero-halo.svg';
+
+interface HeroProps {
+  title?: string;
+  titleEmphasis?: string;
+  subtitle?: string;
+  tagline?: string;
+  avatarType?: 'image' | 'initials';
+  avatarSrc?: string;
+  avatarInitials?: string;
+  personName?: string;
+  personRole?: string;
+}
+
+export function Hero({
+  title = 'Menschen, Prozesse und Technik',
+  titleEmphasis = 'der Mensch und Technologie wieder verbindet.',
+  subtitle = 'Mit 30+ Jahren Führungserfahrung begleite ich Menschen und Organisationen bei der digitalen Transformation — praxisnah, empathisch und auf Augenhöhe.',
+  tagline = 'Digital Coach & Führungskräfte-Mentor',
+  avatarType = 'initials',
+  avatarSrc,
+  avatarInitials = '',
+  personName = '',
+  personRole = '',
+}: HeroProps) {
+  const kickerParts = tagline
+    .split(/[·&]/)
+    .map((s) => s.trim())
+    .filter(Boolean);
+
+  return (
+    <section
+      className="relative pt-[76px] pb-[120px] border-b border-line"
+      aria-label="Hero-Bereich"
+    >
+      {/* Background halo atmosphere */}
+      <div className="absolute inset-0 pointer-events-none overflow-hidden z-0" aria-hidden="true">
+        <img
+          src={heroHalo}
+          alt=""
+          aria-hidden="true"
+          className="absolute right-[-20%] top-[-30%] w-[90vw] h-[90vw] max-w-none object-cover pointer-events-none"
+          style={{ filter: 'blur(10px)' }}
+        />
+        <div
+          className="absolute left-[-30%] bottom-[-40%] w-[80vw] h-[80vw] pointer-events-none"
+          style={{
+            background:
+              'radial-gradient(closest-side, oklch(0.60 0.05 250 / .25), transparent 70%)',
+          }}
+        />
+      </div>
+
+      <div className="wrap relative z-[2]">
+        <div className="grid">
+          <div className="hero-copy flex flex-col">
+            <motion.div
+              initial={{ opacity: 0, y: 8 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.6, delay: 0.1, ease: [0.22, 1, 0.36, 1] }}
+            >
+              <KickerBar parts={kickerParts} className="mb-[26px]" />
+            </motion.div>
+
+            <motion.h1
+              initial={{ opacity: 0, y: 16 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.8, delay: 0.25, ease: [0.22, 1, 0.36, 1] }}
+              className="font-serif font-light leading-[1.02] text-fg m-0"
+              style={{
+                fontSize: 'clamp(44px, 6.2vw, 88px)',
+                letterSpacing: '-0.02em',
+              }}
+            >
+              {title}
+              {titleEmphasis && (
+                <>
+                  {' '}
+                  <em>{titleEmphasis}</em>
+                </>
+              )}
+            </motion.h1>
+
+            <p className="lede mt-5 text-[18px] leading-[1.6] text-fg-soft max-w-[52ch]">
+              {subtitle}
+            </p>
+
+            <div className="hero-cta flex flex-wrap gap-[14px] mt-9" role="group" aria-label="Aktionen">
+              <Link to="/kontakt" className="btn-primary">
+                Kostenloses Erstgespräch
+                <svg
+                  viewBox="0 0 14 14"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  aria-hidden="true"
+                  className="w-[14px] h-[14px]"
+                >
+                  <path d="M2 7h10M8 3l4 4-4 4" />
+                </svg>
+              </Link>
+              <a href="/#angebote" className="btn-ghost">
+                Angebote ansehen
+              </a>
+            </div>
+          </div>
+
+          {avatarType && (
+            <div className="hero-portrait flex items-end justify-end">
+              <Portrait
+                avatarType={avatarType}
+                avatarSrc={avatarSrc}
+                avatarInitials={avatarInitials}
+                name={personName}
+                role={personRole}
+              />
+            </div>
+          )}
+        </div>
+      </div>
+
+      <style>{`
+        .wrap {
+          max-width: var(--maxw);
+          margin: 0 auto;
+          padding: 0 40px;
+        }
+        .grid {
+          display: grid;
+          grid-template-columns: 1.15fr 0.85fr;
+          gap: 64px;
+          align-items: end;
+        }
+        .btn-primary,
+        .btn-ghost {
+          display: inline-flex;
+          align-items: center;
+          gap: 10px;
+          padding: 14px 22px;
+          border-radius: 999px;
+          font-family: var(--sans);
+          font-size: 14px;
+          font-weight: 600;
+          text-decoration: none;
+          transition: transform .2s ease, background .2s ease, border-color .2s ease, color .2s ease;
+        }
+        .btn-primary {
+          background: var(--brass);
+          color: var(--ink-900);
+        }
+        .btn-primary:hover {
+          background: var(--brass-2);
+          transform: translateY(-1px);
+        }
+        .btn-ghost {
+          color: var(--fg);
+          border: 1px solid var(--line-2);
+          background: transparent;
+        }
+        .btn-ghost:hover {
+          border-color: var(--brass);
+          color: var(--brass);
+        }
+        h1 em {
+          font-style: italic;
+          font-weight: 400;
+          color: var(--brass-2);
+        }
+        @media (max-width: 960px) {
+          section { padding: 56px 0 80px; }
+          .grid { grid-template-columns: 1fr; gap: 56px; }
+          .hero-portrait { justify-content: center; }
+          .wrap { padding: 0 22px; }
+        }
+      `}</style>
+    </section>
+  );
+}

--- a/mentolder-web/src/components/KickerBar.tsx
+++ b/mentolder-web/src/components/KickerBar.tsx
@@ -1,0 +1,29 @@
+interface KickerBarProps {
+  parts: string[];
+  className?: string;
+}
+
+export function KickerBar({ parts, className = '' }: KickerBarProps) {
+  return (
+    <div
+      className={`flex items-center gap-[14px] font-mono text-[11px] tracking-[0.14em] uppercase text-mute ${className}`}
+      aria-label="Kategorien"
+    >
+      <span
+        className="w-[44px] h-px bg-brass opacity-70 flex-shrink-0"
+        aria-hidden="true"
+      />
+      {parts.map((part, i) => (
+        <span key={part} className="flex items-center gap-[14px]">
+          {i > 0 && (
+            <span
+              className="w-[5px] h-[5px] rounded-full bg-sage flex-shrink-0"
+              aria-hidden="true"
+            />
+          )}
+          <span>{part}</span>
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/mentolder-web/src/components/Navigation.tsx
+++ b/mentolder-web/src/components/Navigation.tsx
@@ -1,0 +1,128 @@
+import { useEffect, useState } from 'react';
+import { Link, NavLink, useLocation } from 'react-router-dom';
+
+const links: ReadonlyArray<{ to: string; label: string }> = [
+  { to: '/#angebote', label: 'Angebote' },
+  { to: '/ueber-mich', label: 'Über mich' },
+  { to: '/referenzen', label: 'Referenzen' },
+  { to: '/kontakt', label: 'Kontakt' },
+];
+
+const BRAND_NAME = (import.meta.env.VITE_BRAND_NAME ?? 'mentolder').toLowerCase();
+const LOCATION_LABEL = import.meta.env.VITE_CONTACT_CITY ?? 'Lüneburg';
+
+export function Navigation() {
+  const [scrolled, setScrolled] = useState(false);
+  const [mobileOpen, setMobileOpen] = useState(false);
+  const location = useLocation();
+
+  useEffect(() => {
+    function onScroll() {
+      setScrolled(window.scrollY > 12);
+    }
+    onScroll();
+    window.addEventListener('scroll', onScroll, { passive: true });
+    return () => window.removeEventListener('scroll', onScroll);
+  }, []);
+
+  useEffect(() => {
+    setMobileOpen(false);
+  }, [location.pathname]);
+
+  return (
+    <header
+      className={`sticky top-0 z-50 border-b transition-colors duration-200 ${
+        scrolled
+          ? 'bg-ink-900/80 backdrop-blur-md border-line'
+          : 'bg-ink-900/0 border-transparent'
+      }`}
+      aria-label="Hauptnavigation"
+    >
+      <div className="nav-wrap max-w-[1240px] mx-auto px-10 max-md:px-[22px] flex items-center justify-between gap-6 h-[68px]">
+        {/* Brand mark */}
+        <Link
+          to="/"
+          className="brand flex items-center gap-2.5 no-underline"
+          aria-label={`${BRAND_NAME} Startseite`}
+        >
+          <span
+            className="mark w-8 h-8 rounded-lg flex items-center justify-center font-bold text-ink-900 text-base flex-shrink-0"
+            style={{
+              background:
+                'radial-gradient(circle at 30% 30%, var(--brass-2), var(--brass) 55%, #8a6a2a 100%)',
+              boxShadow:
+                'inset 0 0 0 1px rgba(255,255,255,.2), 0 0 0 1px rgba(0,0,0,.3)',
+            }}
+            aria-hidden="true"
+          >
+            {BRAND_NAME.charAt(0)}
+          </span>
+          <span className="brand-name font-serif text-[18px] text-fg" style={{ letterSpacing: '-0.01em' }}>
+            {BRAND_NAME}
+            <span className="text-brass">.</span>
+          </span>
+        </Link>
+
+        {/* Desktop nav */}
+        <nav
+          className="hidden md:flex items-center gap-7"
+          aria-label="Hauptmenü"
+        >
+          {links.map((link) => (
+            <NavLink
+              key={link.to}
+              to={link.to}
+              className={({ isActive }) =>
+                `text-[14px] font-medium no-underline transition-colors ${
+                  isActive
+                    ? 'text-brass'
+                    : 'text-fg-soft hover:text-fg'
+                }`
+              }
+              end={link.to === '/'}
+            >
+              {link.label}
+            </NavLink>
+          ))}
+        </nav>
+
+        <div className="hidden md:flex items-center gap-4">
+          <span className="font-mono text-[10px] tracking-[0.18em] uppercase text-mute-2">
+            {LOCATION_LABEL}
+          </span>
+        </div>
+
+        {/* Mobile menu button */}
+        <button
+          type="button"
+          className="md:hidden inline-flex items-center justify-center w-10 h-10 rounded border border-line-2 text-fg"
+          aria-label={mobileOpen ? 'Menü schließen' : 'Menü öffnen'}
+          aria-expanded={mobileOpen}
+          onClick={() => setMobileOpen((v) => !v)}
+        >
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" className="w-5 h-5">
+            {mobileOpen ? <path d="M6 6l12 12M6 18L18 6" /> : <path d="M3 6h18M3 12h18M3 18h18" />}
+          </svg>
+        </button>
+      </div>
+
+      {/* Mobile sheet */}
+      {mobileOpen && (
+        <div className="md:hidden border-t border-line bg-ink-900/95 backdrop-blur-md">
+          <nav className="px-[22px] py-4 flex flex-col gap-1" aria-label="Mobiles Hauptmenü">
+            {links.map((link) => (
+              <Link
+                key={link.to}
+                to={link.to}
+                className="py-3 px-2 rounded text-fg-soft hover:text-fg no-underline font-medium text-[15px]"
+                onClick={() => setMobileOpen(false)}
+              >
+                {link.label}
+              </Link>
+            ))}
+          </nav>
+        </div>
+      )}
+    </header>
+  );
+}

--- a/mentolder-web/src/components/PageMeta.tsx
+++ b/mentolder-web/src/components/PageMeta.tsx
@@ -1,0 +1,66 @@
+import { useEffect } from 'react';
+
+export interface PageMeta {
+  title: string;
+  description: string;
+  /** Optional canonical path; defaults to current URL. */
+  path?: string;
+  /** Optional OG image URL (absolute or site-relative). */
+  ogImage?: string;
+  /** og:type. Defaults to "website". */
+  ogType?: 'website' | 'article';
+}
+
+const SITE_NAME = 'mentolder';
+
+function setMeta(name: string, content: string, attr: 'name' | 'property' = 'name') {
+  if (!content) return;
+  let el = document.head.querySelector<HTMLMetaElement>(`meta[${attr}="${name}"]`);
+  if (!el) {
+    el = document.createElement('meta');
+    el.setAttribute(attr, name);
+    document.head.appendChild(el);
+  }
+  el.setAttribute('content', content);
+}
+
+function setLink(rel: string, href: string) {
+  let el = document.head.querySelector<HTMLLinkElement>(`link[rel="${rel}"]`);
+  if (!el) {
+    el = document.createElement('link');
+    el.setAttribute('rel', rel);
+    document.head.appendChild(el);
+  }
+  el.setAttribute('href', href);
+}
+
+/**
+ * PageMeta — small side-effect component that updates the document head
+ * with title, description, OG and canonical tags on mount. Reverts on
+ * unmount by removing the tags it created (any pre-existing meta tags
+ * with the same key are left untouched).
+ */
+export function PageMeta({ title, description, path, ogImage, ogType = 'website' }: PageMeta) {
+  useEffect(() => {
+    const previousTitle = document.title;
+    document.title = title;
+
+    setMeta('description', description);
+    setMeta('og:title', `${title} · ${SITE_NAME}`, 'property');
+    setMeta('og:description', description, 'property');
+    setMeta('og:type', ogType, 'property');
+    if (ogImage) {
+      setMeta('og:image', ogImage, 'property');
+    }
+    if (path) {
+      setMeta('og:url', path, 'property');
+      setLink('canonical', path);
+    }
+
+    return () => {
+      document.title = previousTitle;
+    };
+  }, [title, description, path, ogImage, ogType]);
+
+  return null;
+}

--- a/mentolder-web/src/components/Portrait.tsx
+++ b/mentolder-web/src/components/Portrait.tsx
@@ -1,0 +1,165 @@
+import { motion } from 'framer-motion';
+
+interface PortraitProps {
+  avatarType?: 'image' | 'initials';
+  avatarSrc?: string;
+  avatarInitials?: string;
+  name: string;
+  role: string;
+  location?: string;
+  tagText?: string;
+  className?: string;
+}
+
+export function Portrait({
+  avatarType = 'initials',
+  avatarSrc,
+  avatarInitials = '',
+  name,
+  role,
+  location = 'Lüneburg · DE',
+  tagText = 'Anno 2026 · Lüneburg',
+  className = '',
+}: PortraitProps) {
+  return (
+    <div
+      className={`relative w-full max-w-[460px] ml-auto isolate pr-[18px] ${className}`}
+      role="img"
+      aria-label={`Portrait von ${name}, ${role}`}
+    >
+      {/* Vertical hairline behind frame */}
+      <span
+        aria-hidden="true"
+        className="absolute right-[2px] top-[-16px] bottom-[-40px] w-px pointer-events-none"
+        style={{
+          background:
+            'linear-gradient(to bottom, transparent, var(--line-2) 20%, var(--line-2) 80%, transparent)',
+        }}
+      />
+
+      {/* Warm halo behind frame */}
+      <div
+        aria-hidden="true"
+        className="absolute right-[-8%] top-[6%] w-[90%] h-[90%] rounded-full pointer-events-none z-[-1]"
+        style={{
+          background:
+            'radial-gradient(closest-side, oklch(0.80 0.09 75 / .45), transparent 70%)',
+          filter: 'blur(8px)',
+        }}
+      />
+      <div
+        aria-hidden="true"
+        className="absolute left-[-6%] bottom-[12%] w-[55%] h-[55%] rounded-full pointer-events-none z-[-1]"
+        style={{
+          background:
+            'radial-gradient(closest-side, oklch(0.60 0.05 250 / .45), transparent 70%)',
+          filter: 'blur(18px)',
+        }}
+      />
+
+      {/* Frame */}
+      <motion.div
+        initial={{ opacity: 0, y: 18 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.7, delay: 0.4, ease: [0.22, 1, 0.36, 1] }}
+        className="relative w-full aspect-[4/5] rounded bg-ink-800 overflow-hidden"
+        style={{
+          boxShadow:
+            '0 40px 80px -30px rgba(0,0,0,.75), 0 2px 0 0 rgba(255,255,255,.04), inset 0 0 0 1px var(--line-2)',
+        }}
+      >
+        {avatarType === 'image' && avatarSrc ? (
+          <>
+            <img
+              src={avatarSrc}
+              alt={`${name}, ${role}`}
+              loading="lazy"
+              className="absolute inset-0 w-full h-full object-cover"
+              style={{
+                objectPosition: 'center 18%',
+                filter: 'contrast(1.04) brightness(1.02) sepia(.18) saturate(1.05)',
+              }}
+            />
+            <div
+              aria-hidden="true"
+              className="absolute inset-0 pointer-events-none mix-blend-soft-light"
+              style={{
+                background:
+                  'linear-gradient(180deg, oklch(0.80 0.09 75 / .10) 0%, transparent 40%, oklch(0.18 0.02 250 / .35) 100%)',
+              }}
+            />
+          </>
+        ) : (
+          <div
+            aria-hidden="true"
+            className="absolute inset-0 flex items-center justify-center bg-ink-800"
+          >
+            <div
+              className="w-[220px] h-[220px] rounded-full flex items-center justify-center"
+              style={{
+                background:
+                  'radial-gradient(circle at 30% 30%, var(--brass-2), var(--brass) 55%, #8a6a2a 100%)',
+                boxShadow:
+                  'inset 0 0 0 1px rgba(255,255,255,.2), 0 20px 60px rgba(0,0,0,.4)',
+              }}
+            >
+              <span
+                className="font-serif text-[64px] font-normal text-ink-900"
+                style={{ letterSpacing: '-0.02em', userSelect: 'none' }}
+              >
+                {avatarInitials}
+              </span>
+            </div>
+          </div>
+        )}
+
+        {/* Brass hairline top */}
+        <div
+          aria-hidden="true"
+          className="absolute left-0 right-0 top-0 h-px z-[2] pointer-events-none"
+          style={{
+            background:
+              'linear-gradient(to right, transparent, oklch(0.80 0.09 75 / .7) 30%, oklch(0.80 0.09 75 / .7) 70%, transparent)',
+          }}
+        />
+
+        {/* Tag plate */}
+        <div
+          className="absolute left-[14px] top-[14px] z-[3] flex items-center gap-2 font-mono text-[10px] tracking-[0.18em] uppercase text-fg px-[10px] py-[6px] rounded-full"
+          style={{
+            background: 'rgba(11,17,28,.55)',
+            backdropFilter: 'blur(6px)',
+            WebkitBackdropFilter: 'blur(6px)',
+            border: '1px solid rgba(255,255,255,.12)',
+          }}
+          aria-label={tagText}
+        >
+          <span
+            aria-hidden="true"
+            className="w-[6px] h-[6px] rounded-full bg-sage flex-shrink-0"
+            style={{ boxShadow: '0 0 0 3px oklch(0.80 0.06 160 / .18)' }}
+          />
+          {tagText}
+        </div>
+      </motion.div>
+
+      {/* Caption plate */}
+      <div className="relative mt-[18px] grid grid-cols-[auto_1fr_auto] gap-4 items-center pt-[14px] px-1 border-t border-line">
+        <span className="font-mono text-[10px] tracking-[0.18em] text-brass uppercase">
+          GK · 01
+        </span>
+        <div className="flex flex-col gap-[2px]">
+          <span className="font-serif text-base text-fg" style={{ letterSpacing: '-0.01em' }}>
+            {name}
+          </span>
+          <span className="font-mono text-[10px] tracking-[0.14em] text-mute uppercase">
+            {role}
+          </span>
+        </div>
+        <span className="font-mono text-[10px] tracking-[0.14em] text-mute uppercase text-right">
+          {location}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/mentolder-web/src/components/ServiceCard.tsx
+++ b/mentolder-web/src/components/ServiceCard.tsx
@@ -1,0 +1,81 @@
+import type { ReactNode } from 'react';
+import { motion } from 'framer-motion';
+import { Link } from 'react-router-dom';
+
+interface ServiceCardProps {
+  icon: ReactNode;
+  title: string;
+  description: string;
+  features?: string[];
+  price?: string;
+  href?: string;
+}
+
+export function ServiceCard({
+  icon,
+  title,
+  description,
+  features = [],
+  price,
+  href = '#',
+}: ServiceCardProps) {
+  return (
+    <motion.div
+      whileHover={{ y: -4 }}
+      transition={{ duration: 0.25, ease: [0.22, 1, 0.36, 1] }}
+      className="bg-ink-850 border border-line-2 border-t-2 border-t-brass rounded-card p-7 flex flex-col gap-4 h-full"
+    >
+      <div className="w-10 h-10 text-brass flex items-center justify-center" aria-hidden="true">
+        {icon}
+      </div>
+      <h3 className="font-serif text-[22px] font-normal text-fg m-0" style={{ letterSpacing: '-0.015em' }}>
+        {title}
+      </h3>
+      <p className="text-fg-soft text-[15px] leading-[1.6] m-0">{description}</p>
+      {features.length > 0 && (
+        <ul className="list-none p-0 m-0 grid gap-1.5" aria-label="Leistungen">
+          {features.map((feature) => (
+            <li
+              key={feature}
+              className="text-[13px] text-mute flex items-baseline gap-2.5"
+            >
+              <span
+                aria-hidden="true"
+                className="inline-block w-1 h-1 rounded-full bg-brass flex-shrink-0"
+                style={{ transform: 'translateY(-3px)' }}
+              />
+              {feature}
+            </li>
+          ))}
+        </ul>
+      )}
+      {price && (
+        <div className="font-serif text-[20px] text-fg mt-auto pt-2" style={{ letterSpacing: '-0.015em' }}>
+          {price}
+        </div>
+      )}
+      <Link
+        to={href}
+        className="text-brass text-[13px] font-medium inline-flex items-center gap-2 mt-2"
+      >
+        Mehr erfahren
+        <span
+          aria-hidden="true"
+          className="w-[34px] h-[34px] border border-line-2 rounded-full flex items-center justify-center transition-all duration-200"
+        >
+          <svg
+            viewBox="0 0 14 14"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className="w-[14px] h-[14px]"
+          >
+            <path d="M2 7h10M8 3l4 4-4 4" />
+          </svg>
+        </span>
+      </Link>
+    </motion.div>
+  );
+}

--- a/mentolder-web/src/components/ServiceRow.tsx
+++ b/mentolder-web/src/components/ServiceRow.tsx
@@ -1,0 +1,53 @@
+import type { ReactNode, ComponentType, SVGProps } from 'react';
+import { iconRegistry, iconLabels, type IconName } from './icons';
+import { ServiceCard } from './ServiceCard';
+
+export interface Service {
+  id: string;
+  title: string;
+  description: string;
+  features: string[];
+  price: string;
+  priceUnit?: string;
+  href: string;
+  icon: IconName;
+}
+
+interface ServiceRowProps {
+  services: Service[];
+}
+
+export function ServiceRow({ services }: ServiceRowProps) {
+  return (
+    <div
+      className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5"
+      role="list"
+      aria-label="Angebote"
+    >
+      {services.map((service) => {
+        const Icon = iconRegistry[service.icon] as ComponentType<SVGProps<SVGSVGElement> & { title?: string }>;
+        const label = iconLabels[service.icon];
+        const priceMain = service.priceUnit ? service.price : service.price.split('/').map((s) => s.trim())[0];
+        const displayPrice = service.priceUnit ? `${priceMain} / ${service.priceUnit}` : service.price;
+        return (
+          <div role="listitem" key={service.id}>
+            <ServiceCard
+              icon={<Icon className="w-6 h-6" aria-hidden="true" focusable="false" />}
+              title={service.title}
+              description={service.description}
+              features={service.features}
+              price={displayPrice}
+              href={service.href}
+            />
+            <span className="sr-only">{label}</span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+export type { ServiceRowProps };
+export { ServiceRow as default };
+export type { Service as ServiceItem };
+export type { ReactNode };

--- a/mentolder-web/src/components/WhyMeStats.tsx
+++ b/mentolder-web/src/components/WhyMeStats.tsx
@@ -1,0 +1,91 @@
+import { useEffect, useRef, useState } from 'react';
+import { motion, useInView } from 'framer-motion';
+
+export interface Stat {
+  /** Display value, e.g. "30+" or "KI" or "B.Sc.". */
+  value: string;
+  /** Number to count up to. If absent, we try to parse `value` as a number. */
+  target?: number;
+  label: string;
+}
+
+interface WhyMeStatsProps {
+  stats: Stat[];
+  /** Optional duration in ms. */
+  duration?: number;
+}
+
+function parseTarget(stat: Stat): number {
+  if (typeof stat.target === 'number') return stat.target;
+  const m = stat.value.match(/(\d+)/);
+  return m ? Number(m[1]) : 0;
+}
+
+function CountUp({ target, duration }: { target: number; duration: number }) {
+  const ref = useRef<HTMLSpanElement | null>(null);
+  const inView = useInView(ref, { once: true, amount: 0.6 });
+  const [value, setValue] = useState(0);
+
+  useEffect(() => {
+    if (!inView) return;
+    let raf: number;
+    const start = performance.now();
+    const tick = (now: number) => {
+      const t = Math.min(1, (now - start) / duration);
+      // ease-out cubic
+      const eased = 1 - Math.pow(1 - t, 3);
+      setValue(Math.round(target * eased));
+      if (t < 1) raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [inView, target, duration]);
+
+  return (
+    <span ref={ref} aria-live="polite">
+      {value}
+    </span>
+  );
+}
+
+export function WhyMeStats({ stats, duration = 1200 }: WhyMeStatsProps) {
+  return (
+    <section
+      className="border-b border-line"
+      role="region"
+      aria-label="Kennzahlen"
+    >
+      <div className="grid grid-cols-2 md:grid-cols-4">
+        {stats.map((stat, i) => {
+          const target = parseTarget(stat);
+          const hasNumber = target > 0;
+          return (
+            <motion.div
+              key={stat.label}
+              initial={{ opacity: 0, y: 12 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true, amount: 0.4 }}
+              transition={{ duration: 0.5, delay: i * 0.05, ease: [0.22, 1, 0.36, 1] }}
+              className="px-7 py-9 flex flex-col gap-2 border-b md:border-b-0 md:border-r border-line last:border-r-0"
+            >
+              <span
+                className="font-serif text-[44px] leading-[1] text-fg"
+                style={{ letterSpacing: '-0.02em' }}
+              >
+                {hasNumber ? <CountUp target={target} duration={duration} /> : stat.value}
+                {hasNumber && stat.value.replace(/[\d]/g, '').trim() && (
+                  <em className="text-brass not-italic ml-0.5">
+                    {stat.value.replace(/[\d]/g, '').trim()}
+                  </em>
+                )}
+              </span>
+              <span className="font-mono text-[11px] tracking-[0.14em] uppercase text-mute">
+                {stat.label}
+              </span>
+            </motion.div>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/mentolder-web/src/components/icons.ts
+++ b/mentolder-web/src/components/icons.ts
@@ -1,0 +1,26 @@
+import iconFuehrung from '@/assets/icons/icon-fuehrung.svg?react';
+import iconDigitalisierung from '@/assets/icons/icon-digitalisierung.svg?react';
+import iconTeam from '@/assets/icons/icon-team.svg?react';
+import iconStrategie from '@/assets/icons/icon-strategie.svg?react';
+import iconKommunikation from '@/assets/icons/icon-kommunikation.svg?react';
+import iconResilienz from '@/assets/icons/icon-resilienz.svg?react';
+
+export const iconRegistry = {
+  fuehrung: iconFuehrung,
+  digitalisierung: iconDigitalisierung,
+  team: iconTeam,
+  strategie: iconStrategie,
+  kommunikation: iconKommunikation,
+  resilienz: iconResilienz,
+} as const;
+
+export type IconName = keyof typeof iconRegistry;
+
+export const iconLabels: Record<IconName, string> = {
+  fuehrung: 'Führung',
+  digitalisierung: 'Digitalisierung',
+  team: 'Team',
+  strategie: 'Strategie',
+  kommunikation: 'Kommunikation',
+  resilienz: 'Resilienz',
+};

--- a/mentolder-web/src/content.ts
+++ b/mentolder-web/src/content.ts
@@ -1,0 +1,125 @@
+import type { Stat } from '@/components/WhyMeStats';
+import type { Service } from '@/components/ServiceRow';
+import type { FAQItem } from '@/components/FAQ';
+
+export const SITE = {
+  brand: 'mentolder',
+  url: 'https://mentolder.de',
+  email: 'mail@mentolder.de',
+  city: 'Lüneburg',
+  person: {
+    name: 'Gerald Korczewski',
+    role: 'Digital Coach & Mentor',
+    initials: 'GK',
+  },
+  ogImage: 'https://mentolder.de/og-default.png',
+} as const;
+
+export const heroContent = {
+  title: 'Menschen, Prozesse und Technik',
+  titleEmphasis: 'der Mensch und Technologie wieder verbindet.',
+  subtitle:
+    'Mit 30+ Jahren Führungserfahrung begleite ich Menschen und Organisationen bei der digitalen Transformation — praxisnah, empathisch und auf Augenhöhe.',
+  tagline: 'Digital Coach · Führungskräfte-Mentor',
+};
+
+export const stats: Stat[] = [
+  { value: '30+', target: 30, label: 'Jahre Führung' },
+  { value: 'KI', label: 'Schwerpunkt' },
+  { value: 'K8s', label: 'Cloud-Native' },
+  { value: 'B.Sc.', label: 'Wirtschaftsinformatik' },
+];
+
+export const services: Service[] = [
+  {
+    id: 'fuehrungs-coaching',
+    title: 'Führungs-Coaching',
+    description:
+      'Vom Manager zur empathischen Führungskraft. Klarheit, Präsenz und Werkzeuge für wirksames Leadership.',
+    features: ['1:1-Sessions', 'Zwischenstand nach 6 Wochen', 'Vertraulich'],
+    price: 'ab 240',
+    priceUnit: 'EUR / 60 min',
+    href: '/angebote/fuehrung',
+    icon: 'fuehrung',
+  },
+  {
+    id: 'digitale-transformation',
+    title: 'Digitale Transformation',
+    description:
+      'Vom Pilot zum Produktiv-System. Cloud, KI, DevOps — pragmatisch, ohne Hype und mit klaren Meilensteinen.',
+    features: ['Cloud / K8s', 'KI-Enablement', 'Architektur-Reviews'],
+    price: 'ab 1.200',
+    priceUnit: 'EUR / Tag',
+    href: '/angebote/digitalisierung',
+    icon: 'digitalisierung',
+  },
+  {
+    id: 'team-readiness',
+    title: 'Team-Readiness',
+    description:
+      'Teams befähigen, moderne Tools sicher zu nutzen. Workshops, die verbinden statt belehren — mit Fokus auf Wirkung.',
+    features: ['Halbtages-Workshop', 'Vor-Ort oder Remote', 'Follow-up-Email'],
+    price: 'ab 980',
+    priceUnit: 'EUR / Workshop',
+    href: '/angebote/team',
+    icon: 'team',
+  },
+];
+
+export const whyMePoints = [
+  {
+    title: '30+ Jahre Führungserfahrung',
+    text: 'Vom Teamlead bis zur Geschäftsführung. Ich kenne die Grautöne zwischen Folie und Werkbank.',
+  },
+  {
+    title: 'Technik trifft Empathie',
+    text: 'Cloud, KI, DevOps — aber immer im Dienst der Menschen, die sie nutzen.',
+  },
+  {
+    title: 'Pragmatismus statt Hype',
+    text: 'Wir bauen, was wirklich nützt. Keine Vendor-Pitches, keine Modeerscheinungen.',
+  },
+  {
+    title: 'Diskretion ist selbstverständlich',
+    text: 'Was im Coaching besprochen wird, bleibt im Coaching. Punkt.',
+  },
+];
+
+export const whyMeHeadline = 'Warum mit mir?';
+export const whyMeIntro =
+  'Ich *verbinde* technische Tiefe mit menschlicher Klarheit — und arbeite mit Menschen, die Verantwortung tragen.';
+
+export const faqItems: FAQItem[] = [
+  {
+    question: 'Wie läuft ein Erstgespräch ab?',
+    answer:
+      '30 Minuten, kostenlos und unverbindlich. Wir klären Ihre Situation, Ihre Ziele und ob eine Zusammenarbeit sinnvoll ist. Kein Verkaufsdruck.',
+  },
+  {
+    question: 'Arbeiten Sie remote oder vor Ort?',
+    answer:
+      'Beides. Coaching und Beratung funktionieren remote oft besser (keine Anreise, mehr Fokus). Workshops und Vorträge mache ich bevorzugt vor Ort in Lüneburg und Umgebung, deutschlandweit auf Anfrage.',
+  },
+  {
+    question: 'Was kostet eine Coaching-Stunde?',
+    answer:
+      'Führungs-Coaching 240 EUR / 60 min, Strategie-Session 320 EUR / 90 min. Pakete mit verbindlichem Kontingent auf Anfrage.',
+  },
+  {
+    question: 'Vertraulichkeit?',
+    answer:
+      'Alle Inhalte sind streng vertraulich. Auf Wunsch unterzeichne ich eine NDA, bevor wir starten.',
+  },
+  {
+    question: 'Wie schnell können Sie starten?',
+    answer:
+      'In der Regel innerhalb von 7 Tagen. Für Workshops plane ich 3–4 Wochen Vorlauf, damit die Agenda wirklich passt.',
+  },
+];
+
+export const processSteps = [
+  { num: '01', title: 'Kennenlernen', text: 'Kostenloses 30-Minuten-Erstgespräch, online oder vor Ort.' },
+  { num: '02', title: 'Klärung', text: 'Wir definieren Ziele, Umfang und Zeitrahmen — schriftlich, transparent.' },
+  { num: '03', title: 'Umsetzung', text: 'Sessions, Workshops oder Beratung — wie vereinbart.' },
+  { num: '04', title: 'Transfer', text: 'Sie nehmen Werkzeuge mit, die wirklich in Ihren Alltag passen.' },
+];

--- a/mentolder-web/src/env.d.ts
+++ b/mentolder-web/src/env.d.ts
@@ -1,0 +1,29 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_FORMSPREE_ENDPOINT?: string;
+  readonly VITE_CONTACT_EMAIL?: string;
+  readonly VITE_CONTACT_PHONE?: string;
+  readonly VITE_CONTACT_CITY?: string;
+  readonly VITE_BRAND_NAME?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}
+
+declare module '*.svg' {
+  const content: string;
+  export default content;
+}
+
+declare module '*.svg?react' {
+  import type { FC, SVGProps } from 'react';
+  const ReactComponent: FC<SVGProps<SVGSVGElement> & { title?: string }>;
+  export default ReactComponent;
+}
+
+declare module '*.css' {
+  const content: string;
+  export default content;
+}

--- a/mentolder-web/src/main.tsx
+++ b/mentolder-web/src/main.tsx
@@ -1,0 +1,16 @@
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import App from './App';
+import './styles/global.css';
+
+const rootEl = document.getElementById('root');
+if (!rootEl) throw new Error('Root element #root not found');
+
+createRoot(rootEl).render(
+  <StrictMode>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </StrictMode>,
+);

--- a/mentolder-web/src/pages/DatenschutzPage.tsx
+++ b/mentolder-web/src/pages/DatenschutzPage.tsx
@@ -1,0 +1,115 @@
+import { KickerBar } from '@/components/KickerBar';
+import { PageMeta } from '@/components/PageMeta';
+import { SITE } from '@/content';
+
+export function DatenschutzPage() {
+  return (
+    <>
+      <PageMeta
+        title="Datenschutzerklärung"
+        description="Informationen zur Verarbeitung personenbezogener Daten auf mentolder.de."
+        path={`${SITE.url}/datenschutz`}
+        ogImage={SITE.ogImage}
+      />
+      <section className="pt-[80px] pb-[120px] max-md:pt-[56px] max-md:pb-[80px]">
+        <div className="max-w-[820px] mx-auto px-10 max-md:px-[22px]">
+          <KickerBar parts={['Rechtliches', 'Datenschutz']} className="mb-6" />
+          <h1
+            className="font-serif font-light text-fg leading-[1.05] m-0"
+            style={{
+              fontSize: 'clamp(40px, 5.4vw, 64px)',
+              letterSpacing: '-0.02em',
+            }}
+          >
+            Datenschutz&shy;erklärung
+          </h1>
+          <div className="prose mt-12 text-fg-soft text-[16px] leading-[1.7] max-w-[60ch]">
+            <h2 className="font-serif text-[24px] text-fg mt-12 mb-3" style={{ letterSpacing: '-0.01em' }}>
+              1. Datenschutz auf einen Blick
+            </h2>
+            <p>
+              Die folgenden Hinweise geben einen einfachen Überblick darüber, was mit Ihren
+              personenbezogenen Daten passiert, wenn Sie diese Website besuchen. Personenbezogene
+              Daten sind alle Daten, mit denen Sie persönlich identifiziert werden können.
+            </p>
+
+            <h2 className="font-serif text-[24px] text-fg mt-10 mb-3" style={{ letterSpacing: '-0.01em' }}>
+              2. Verantwortlicher
+            </h2>
+            <p>
+              Verantwortlich für die Datenverarbeitung auf dieser Website ist:<br />
+              {SITE.person.name}<br />
+              Musterstraße 1<br />
+              21335 {SITE.city}<br />
+              E-Mail: <a className="text-brass border-b border-brass" href={`mailto:${SITE.email}`}>{SITE.email}</a>
+            </p>
+
+            <h2 className="font-serif text-[24px] text-fg mt-10 mb-3" style={{ letterSpacing: '-0.01em' }}>
+              3. Welche Daten erfassen wir?
+            </h2>
+            <p>
+              Beim Besuch dieser Website werden automatisch Informationen wie Ihre IP-Adresse,
+              der verwendete Browsertyp, das Betriebssystem, die Referrer-URL und der Zeitpunkt
+              der Serveranfrage verarbeitet (sog. Server-Logfiles). Diese Daten dienen dem
+              stabilen und sicheren Betrieb der Website.
+            </p>
+            <p>
+              Wenn Sie uns per Kontaktformular eine Anfrage senden, werden Ihre Angaben aus dem
+              Formular inklusive der von Ihnen dort angegebenen Kontaktdaten zwecks Bearbeitung
+              der Anfrage und für den Fall von Anschlussfragen bei uns gespeichert. Diese Daten
+              geben wir nicht ohne Ihre Einwilligung weiter.
+            </p>
+
+            <h2 className="font-serif text-[24px] text-fg mt-10 mb-3" style={{ letterSpacing: '-0.01em' }}>
+              4. Cookies & lokale Speicherung
+            </h2>
+            <p>
+              Diese Website setzt ausschließlich technisch notwendige Speicherwerte. Es kommen
+              keine Tracking-Cookies, keine Analyse- oder Werbe-Cookies zum Einsatz. Sie können
+              Ihren Browser so konfigurieren, dass er Sie über die Platzierung von Cookies
+              informiert oder Cookies ablehnt.
+            </p>
+
+            <h2 className="font-serif text-[24px] text-fg mt-10 mb-3" style={{ letterSpacing: '-0.01em' }}>
+              5. Hosting
+            </h2>
+            <p>
+              Diese Website wird bei einem europäischen Anbieter statisch ausgeliefert (CDN /
+              Edge-Network). Beim Aufruf der Seite werden technische Metadaten (IP-Adresse,
+              Zeitstempel, User-Agent) verarbeitet, um die Auslieferung zu ermöglichen und
+              Angriffe abzuwehren.
+            </p>
+
+            <h2 className="font-serif text-[24px] text-fg mt-10 mb-3" style={{ letterSpacing: '-0.01em' }}>
+              6. Ihre Rechte
+            </h2>
+            <p>
+              Sie haben jederzeit das Recht auf Auskunft über Ihre gespeicherten
+              personenbezogenen Daten, deren Herkunft und Empfänger und den Zweck der
+              Datenverarbeitung. Sie haben außerdem ein Recht auf Berichtigung, Löschung,
+              Einschränkung der Verarbeitung, Datenübertragbarkeit und Widerspruch. Wenn Sie
+              Fragen zum Datenschutz haben, schreiben Sie uns bitte an die oben genannte
+              E-Mail-Adresse.
+            </p>
+
+            <h2 className="font-serif text-[24px] text-fg mt-10 mb-3" style={{ letterSpacing: '-0.01em' }}>
+              7. SSL-Verschlüsselung
+            </h2>
+            <p>
+              Diese Seite nutzt aus Sicherheitsgründen und zum Schutz der Übertragung
+              vertraulicher Inhalte eine SSL-Verschlüsselung. Eine verschlüsselte Verbindung
+              erkennen Sie daran, dass die Adresszeile des Browsers von „http://" auf „https://"
+              wechselt und an dem Schloss-Symbol in Ihrer Browserzeile.
+            </p>
+
+            <p className="text-[12px] text-mute mt-10">
+              Stand: {new Date().toLocaleDateString('de-DE', { year: 'numeric', month: 'long' })} ·
+              Platzhalter — finale Fassung wird bei Live-Gang durch das Justiziariat
+              freigegeben.
+            </p>
+          </div>
+        </div>
+      </section>
+    </>
+  );
+}

--- a/mentolder-web/src/pages/HomePage.tsx
+++ b/mentolder-web/src/pages/HomePage.tsx
@@ -1,0 +1,156 @@
+import { Hero } from '@/components/Hero';
+import { ServiceRow } from '@/components/ServiceRow';
+import { WhyMeStats } from '@/components/WhyMeStats';
+import { FAQ } from '@/components/FAQ';
+import { CallToAction } from '@/components/CallToAction';
+import { PageMeta } from '@/components/PageMeta';
+import {
+  SITE,
+  heroContent,
+  stats,
+  services,
+  faqItems,
+} from '@/content';
+import { motion } from 'framer-motion';
+
+export function HomePage() {
+  return (
+    <>
+      <PageMeta
+        title="Digital Coach & Führungskräfte-Mentor"
+        description="Mit 30+ Jahren Führungserfahrung begleite ich Menschen und Organisationen bei der digitalen Transformation — praxisnah, empathisch und auf Augenhöhe."
+        path={`${SITE.url}/`}
+        ogImage={SITE.ogImage}
+      />
+      <Hero
+        title={heroContent.title}
+        titleEmphasis={heroContent.titleEmphasis}
+        subtitle={heroContent.subtitle}
+        tagline={heroContent.tagline}
+        avatarType="initials"
+        avatarInitials={SITE.person.initials}
+        personName={SITE.person.name}
+        personRole={SITE.person.role}
+      />
+
+      <WhyMeStats stats={stats} />
+
+      <section
+        id="angebote"
+        className="py-[120px] max-md:py-[80px]"
+        aria-labelledby="offers-heading"
+      >
+        <div className="max-w-[1240px] mx-auto px-10 max-md:px-[22px]">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-12 mb-[72px] max-md:gap-6 max-md:mb-12 items-end">
+            <div>
+              <p className="font-mono text-[11px] tracking-[0.18em] uppercase text-brass inline-flex items-center gap-2.5 m-0 mb-4">
+                <span aria-hidden="true" className="inline-block w-[22px] h-px bg-current opacity-80" />
+                Meine Angebote
+              </p>
+              <h2
+                id="offers-heading"
+                className="font-serif font-normal text-fg leading-[1.1] m-0 max-w-[18ch]"
+                style={{
+                  fontSize: 'clamp(32px, 3.6vw, 48px)',
+                  letterSpacing: '-0.02em',
+                }}
+              >
+                Drei Wege, mit mir zu arbeiten.
+              </h2>
+            </div>
+            <p className="text-[18px] leading-[1.6] text-fg-soft max-w-[52ch] m-0">
+              Vom Coaching über Transformation bis zum Workshop — wählen Sie das Format, das zu Ihrer Situation passt.
+            </p>
+          </div>
+
+          <ServiceRow services={services} />
+        </div>
+      </section>
+
+      <section className="bg-ink-850 border-y border-line py-[120px] max-md:py-[80px]" aria-labelledby="why-heading">
+        <div className="max-w-[1240px] mx-auto px-10 max-md:px-[22px]">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-20 max-md:gap-14 items-start">
+            <div>
+              <p className="font-mono text-[11px] tracking-[0.18em] uppercase text-brass inline-flex items-center gap-2.5 m-0 mb-4">
+                <span aria-hidden="true" className="inline-block w-[22px] h-px bg-current opacity-80" />
+                Warum mit mir?
+              </p>
+              <h2
+                id="why-heading"
+                className="font-serif font-normal text-fg leading-[1.1] m-0 max-w-[18ch]"
+                style={{
+                  fontSize: 'clamp(32px, 3.6vw, 48px)',
+                  letterSpacing: '-0.02em',
+                }}
+              >
+                Ich <em>verbinde</em> technische Tiefe mit menschlicher Klarheit.
+              </h2>
+
+              <ol className="list-none p-0 mt-10 border-t border-line" aria-label="Gründe">
+                {[
+                  { t: '30+ Jahre Führungserfahrung', d: 'Vom Teamlead bis zur Geschäftsführung. Ich kenne die Grautöne zwischen Folie und Werkbank.' },
+                  { t: 'Technik trifft Empathie', d: 'Cloud, KI, DevOps — aber immer im Dienst der Menschen, die sie nutzen.' },
+                  { t: 'Pragmatismus statt Hype', d: 'Wir bauen, was wirklich nützt. Keine Vendor-Pitches, keine Modeerscheinungen.' },
+                  { t: 'Diskretion ist selbstverständlich', d: 'Was im Coaching besprochen wird, bleibt im Coaching. Punkt.' },
+                ].map((p, i) => (
+                  <motion.li
+                    key={p.t}
+                    initial={{ opacity: 0, y: 12 }}
+                    whileInView={{ opacity: 1, y: 0 }}
+                    viewport={{ once: true, amount: 0.4 }}
+                    transition={{ duration: 0.5, delay: i * 0.05 }}
+                    className="py-[26px] border-b border-line grid grid-cols-[56px_1fr] gap-[22px] items-start"
+                  >
+                    <span className="font-mono text-[11px] text-brass tracking-[0.14em] uppercase pt-1.5">
+                      {String(i + 1).padStart(2, '0')}
+                    </span>
+                    <div>
+                      <h4 className="font-sans text-[17px] font-semibold text-fg m-0 mb-1.5" style={{ letterSpacing: '-0.01em' }}>
+                        {p.t}
+                      </h4>
+                      <p className="text-[14px] leading-[1.6] text-mute m-0">{p.d}</p>
+                    </div>
+                  </motion.li>
+                ))}
+              </ol>
+            </div>
+
+            <div className="pt-14 max-md:pt-0">
+              <figure className="rounded-card border border-line-2 p-8 bg-ink-800 relative">
+                <span
+                  aria-hidden="true"
+                  className="absolute left-8 -top-1 font-serif text-[64px] text-brass leading-none"
+                  style={{ fontFamily: 'var(--serif)' }}
+                >
+                  &ldquo;
+                </span>
+                <blockquote className="font-serif text-[22px] leading-[1.4] text-fg m-0 mt-6" style={{ letterSpacing: '-0.01em' }}>
+                  Gerald hat es geschafft, technische Tiefe und menschliche Wärme in jeden Termin zu bringen. Selten so klar gefragt, so präzise geantwortet.
+                </blockquote>
+                <figcaption className="mt-6 pt-4 border-t border-line flex flex-col gap-1">
+                  <span className="font-serif text-[16px] text-fg">Dr. M. Albers</span>
+                  <span className="font-mono text-[10px] tracking-[0.14em] uppercase text-mute">
+                    CTO · mittelständisches SaaS-Unternehmen
+                  </span>
+                </figcaption>
+              </figure>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <FAQ items={faqItems} title="Häufige Fragen" />
+
+      <CallToAction
+        eyebrow="Bereit?"
+        title="Lassen Sie uns"
+        titleEmphasis="herausfinden, ob es passt."
+        subtitle="30 Minuten, kostenlos, unverbindlich. Antwort innerhalb von 48 Stunden."
+        primaryText="Termin vereinbaren"
+        primaryHref="/kontakt"
+        secondaryText={SITE.email}
+        secondaryHref={`mailto:${SITE.email}`}
+      />
+    </>
+  );
+}

--- a/mentolder-web/src/pages/ImpressumPage.tsx
+++ b/mentolder-web/src/pages/ImpressumPage.tsx
@@ -1,0 +1,98 @@
+import { KickerBar } from '@/components/KickerBar';
+import { PageMeta } from '@/components/PageMeta';
+import { SITE } from '@/content';
+
+export function ImpressumPage() {
+  return (
+    <>
+      <PageMeta
+        title="Impressum"
+        description="Angaben gemäß § 5 TMG — Anbieter, Kontakt, Verantwortlichkeiten."
+        path={`${SITE.url}/impressum`}
+        ogImage={SITE.ogImage}
+      />
+      <section className="pt-[80px] pb-[120px] max-md:pt-[56px] max-md:pb-[80px]">
+        <div className="max-w-[820px] mx-auto px-10 max-md:px-[22px]">
+          <KickerBar parts={['Rechtliches', 'Impressum']} className="mb-6" />
+          <h1
+            className="font-serif font-light text-fg leading-[1.05] m-0"
+            style={{
+              fontSize: 'clamp(40px, 5.4vw, 64px)',
+              letterSpacing: '-0.02em',
+            }}
+          >
+            Impressum
+          </h1>
+          <div className="prose mt-12 text-fg-soft text-[16px] leading-[1.7] max-w-[60ch]">
+            <h2 className="font-serif text-[24px] text-fg mt-12 mb-3" style={{ letterSpacing: '-0.01em' }}>
+              Angaben gemäß § 5 TMG
+            </h2>
+            <p className="m-0 mb-3">
+              {SITE.person.name}<br />
+              Coaching & Beratung<br />
+              Musterstraße 1<br />
+              21335 {SITE.city}
+            </p>
+
+            <h2 className="font-serif text-[24px] text-fg mt-10 mb-3" style={{ letterSpacing: '-0.01em' }}>
+              Kontakt
+            </h2>
+            <p className="m-0 mb-3">
+              Telefon: +49 (0) 123 456 789<br />
+              E-Mail: <a className="text-brass border-b border-brass" href={`mailto:${SITE.email}`}>{SITE.email}</a>
+            </p>
+
+            <h2 className="font-serif text-[24px] text-fg mt-10 mb-3" style={{ letterSpacing: '-0.01em' }}>
+              Umsatzsteuer-ID
+            </h2>
+            <p className="m-0 mb-3">
+              Umsatzsteuer-Identifikationsnummer gemäß § 27 a Umsatzsteuergesetz: DE-123 456 789.
+            </p>
+
+            <h2 className="font-serif text-[24px] text-fg mt-10 mb-3" style={{ letterSpacing: '-0.01em' }}>
+              Verantwortlich für den Inhalt nach § 55 Abs. 2 RStV
+            </h2>
+            <p className="m-0 mb-3">
+              {SITE.person.name}, Anschrift wie oben.
+            </p>
+
+            <h2 className="font-serif text-[24px] text-fg mt-10 mb-3" style={{ letterSpacing: '-0.01em' }}>
+              Berufsbezeichnung
+            </h2>
+            <p className="m-0 mb-3">
+              {SITE.person.role}, verliehen in der Bundesrepublik Deutschland.
+            </p>
+
+            <h2 className="font-serif text-[24px] text-fg mt-10 mb-3" style={{ letterSpacing: '-0.01em' }}>
+              Streitschlichtung
+            </h2>
+            <p className="m-0 mb-3">
+              Die Europäische Kommission stellt eine Plattform zur Online-Streitbeilegung (OS) bereit:
+              {' '}
+              <a className="text-brass border-b border-brass" href="https://ec.europa.eu/consumers/odr/" rel="noreferrer noopener" target="_blank">
+                https://ec.europa.eu/consumers/odr/
+              </a>
+              . Wir sind nicht bereit oder verpflichtet, an Streitbeilegungsverfahren vor einer
+              Verbraucherschlichtungsstelle teilzunehmen.
+            </p>
+
+            <h2 className="font-serif text-[24px] text-fg mt-10 mb-3" style={{ letterSpacing: '-0.01em' }}>
+              Haftung für Inhalte
+            </h2>
+            <p className="m-0">
+              Als Diensteanbieter sind wir gemäß § 7 Abs.1 TMG für eigene Inhalte auf diesen Seiten
+              nach den allgemeinen Gesetzen verantwortlich. Nach §§ 8 bis 10 TMG sind wir als
+              Diensteanbieter jedoch nicht verpflichtet, übermittelte oder gespeicherte fremde
+              Informationen zu überwachen oder nach Umständen zu forschen, die auf eine rechtswidrige
+              Tätigkeit hinweisen. Verpflichtungen zur Entfernung oder Sperrung der Nutzung von
+              Informationen nach den allgemeinen Gesetzen bleiben hiervon unberührt. Eine
+              diesbezügliche Haftung ist jedoch erst ab dem Zeitpunkt der Kenntnis einer konkreten
+              Rechtsverletzung möglich. Bei Bekanntwerden von entsprechenden Rechtsverletzungen
+              werden wir diese Inhalte umgehend entfernen.
+            </p>
+          </div>
+        </div>
+      </section>
+    </>
+  );
+}

--- a/mentolder-web/src/pages/KontaktPage.tsx
+++ b/mentolder-web/src/pages/KontaktPage.tsx
@@ -1,0 +1,122 @@
+import { ContactForm } from '@/components/ContactForm';
+import { KickerBar } from '@/components/KickerBar';
+import { PageMeta } from '@/components/PageMeta';
+import { CallToAction } from '@/components/CallToAction';
+import { SITE } from '@/content';
+
+export function KontaktPage() {
+  return (
+    <>
+      <PageMeta
+        title="Kontakt"
+        description="In 30 Minuten finden wir heraus, ob eine Zusammenarbeit passt. Kostenlos, unverbindlich, ohne Verkaufsdruck."
+        path={`${SITE.url}/kontakt`}
+        ogImage={SITE.ogImage}
+      />
+
+      <section className="relative pt-[80px] pb-[120px] max-md:pt-[56px] max-md:pb-[80px]">
+        <div
+          className="absolute inset-0 pointer-events-none overflow-hidden"
+          aria-hidden="true"
+        >
+          <div
+            className="absolute -top-[180px] -right-[120px] w-[620px] h-[620px] rounded-full"
+            style={{
+              background:
+                'radial-gradient(circle, oklch(0.80 0.09 75 / .14), transparent 65%)',
+              filter: 'blur(18px)',
+            }}
+          />
+        </div>
+        <div className="relative max-w-[1240px] mx-auto px-10 max-md:px-[22px]">
+          <div className="max-w-[820px]">
+            <KickerBar parts={['Kontakt', SITE.city, 'DE']} className="mb-6" />
+            <h1
+              className="font-serif font-light text-fg leading-[1.05] m-0"
+              style={{
+                fontSize: 'clamp(40px, 5.4vw, 72px)',
+                letterSpacing: '-0.02em',
+              }}
+            >
+              In 30 Minuten <em>wissen wir, ob es passt.</em>
+            </h1>
+            <p className="lede text-[18px] leading-[1.6] text-fg-soft mt-5 max-w-[52ch]">
+              Schreiben Sie mir kurz, worum es geht — ich antworte innerhalb von 48 Stunden
+              persönlich. Kein Ticket-System, keine Warteschleife, kein Newsletter.
+            </p>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-[1.4fr_1fr] gap-16 mt-16 max-md:gap-10 max-md:mt-10 items-start">
+            <div>
+              <ContactForm />
+            </div>
+
+            <aside className="rounded-card border border-line-2 bg-ink-850 p-7">
+              <h3 className="font-serif text-[20px] text-fg m-0 mb-4" style={{ letterSpacing: '-0.01em' }}>
+                Direkter Draht
+              </h3>
+              <ul className="list-none p-0 m-0 flex flex-col gap-3">
+                <li>
+                  <a
+                    href={`mailto:${SITE.email}`}
+                    className="text-brass text-[15px] no-underline border-b border-brass"
+                  >
+                    {SITE.email}
+                  </a>
+                </li>
+                <li>
+                  <span className="font-mono text-[11px] tracking-[0.14em] uppercase text-mute">
+                    {SITE.person.name}
+                  </span>
+                </li>
+                <li>
+                  <span className="font-mono text-[11px] tracking-[0.14em] uppercase text-mute">
+                    {SITE.person.role}
+                  </span>
+                </li>
+                <li>
+                  <span className="font-mono text-[11px] tracking-[0.14em] uppercase text-mute">
+                    {SITE.city} · DE
+                  </span>
+                </li>
+              </ul>
+
+              <div className="border-t border-line mt-6 pt-6">
+                <h4 className="font-mono text-[11px] tracking-[0.16em] uppercase text-brass m-0 mb-3">
+                  So läuft's
+                </h4>
+                <ol className="list-none p-0 m-0 flex flex-col gap-3 text-[14px] text-fg-soft">
+                  <li className="grid grid-cols-[28px_1fr] gap-3 items-start">
+                    <span className="font-mono text-[11px] text-brass pt-0.5">01</span>
+                    Sie schreiben mir.
+                  </li>
+                  <li className="grid grid-cols-[28px_1fr] gap-3 items-start">
+                    <span className="font-mono text-[11px] text-brass pt-0.5">02</span>
+                    Ich antworte innerhalb von 48 Stunden.
+                  </li>
+                  <li className="grid grid-cols-[28px_1fr] gap-3 items-start">
+                    <span className="font-mono text-[11px] text-brass pt-0.5">03</span>
+                    Kostenloses 30-Minuten-Erstgespräch.
+                  </li>
+                  <li className="grid grid-cols-[28px_1fr] gap-3 items-start">
+                    <span className="font-mono text-[11px] text-brass pt-0.5">04</span>
+                    Wir entscheiden gemeinsam, ob es weitergeht.
+                  </li>
+                </ol>
+              </div>
+            </aside>
+          </div>
+        </div>
+      </section>
+
+      <CallToAction
+        eyebrow="Lieber direkt?"
+        title="Schreiben Sie mir eine"
+        titleEmphasis="kurze E-Mail."
+        subtitle="Manchmal ist eine Mail der einfachste Weg. Antwort kommt persönlich."
+        primaryText="E-Mail öffnen"
+        primaryHref={`mailto:${SITE.email}`}
+      />
+    </>
+  );
+}

--- a/mentolder-web/src/styles/global.css
+++ b/mentolder-web/src/styles/global.css
@@ -1,0 +1,79 @@
+@import "./tokens.css";
+
+:root {
+  /* CSS Custom Properties (mirror tokens.css) — used by component-level inline styles
+     and any non-Tailwind utility. */
+  --ink-900: #0b111c;
+  --ink-850: #101826;
+  --ink-800: #17202e;
+  --ink-750: #1d2736;
+  --fg: #eef1f3;
+  --fg-soft: #cdd3d9;
+  --mute: #8c96a3;
+  --mute-2: #6a727e;
+  --brass: oklch(0.80 0.09 75);
+  --brass-2: oklch(0.86 0.09 75);
+  --brass-d: oklch(0.80 0.09 75 / 0.14);
+  --sage: oklch(0.80 0.06 160);
+  --line: rgba(255, 255, 255, 0.07);
+  --line-2: rgba(255, 255, 255, 0.12);
+  --serif: "Newsreader", "Iowan Old Style", Georgia, serif;
+  --sans: "Geist", ui-sans-serif, system-ui, sans-serif;
+  --mono: "Geist Mono", ui-monospace, "SF Mono", Menlo, monospace;
+  --maxw: 1240px;
+  --radius: 22px;
+}
+
+html,
+body {
+  background: var(--ink-900);
+  color: var(--fg);
+  font-family: var(--sans);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-feature-settings: "ss01", "cv11";
+  text-rendering: optimizeLegibility;
+}
+
+#root {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+/* Selection */
+::selection {
+  background: var(--brass);
+  color: var(--ink-900);
+}
+
+/* Focus ring */
+:focus-visible {
+  outline: 2px solid var(--brass);
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
+/* Reset */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+button {
+  font: inherit;
+  color: inherit;
+}
+
+/* Newsreader italics get the brass-2 treatment in headings */
+h1 em,
+h2 em {
+  font-style: italic;
+  color: var(--brass-2);
+}

--- a/mentolder-web/src/styles/tokens.css
+++ b/mentolder-web/src/styles/tokens.css
@@ -1,0 +1,33 @@
+@import "tailwindcss";
+
+@theme {
+  /* Ink-Skala (Hintergrund) */
+  --color-ink-900: #0b111c;
+  --color-ink-850: #101826;
+  --color-ink-800: #17202e;
+  --color-ink-750: #1d2736;
+
+  /* Vordergrund */
+  --color-fg: #eef1f3;
+  --color-fg-soft: #cdd3d9;
+  --color-mute: #8c96a3;
+  --color-mute-2: #6a727e;
+
+  /* Akzentfarben */
+  --color-brass: oklch(0.80 0.09 75);
+  --color-brass-2: oklch(0.86 0.09 75);
+  --color-brass-d: oklch(0.80 0.09 75 / 0.14);
+  --color-sage: oklch(0.80 0.06 160);
+
+  /* Linien */
+  --color-line: rgba(255, 255, 255, 0.07);
+  --color-line-2: rgba(255, 255, 255, 0.12);
+
+  /* Typografie */
+  --font-serif: "Newsreader", "Iowan Old Style", Georgia, serif;
+  --font-sans: "Geist", ui-sans-serif, system-ui, sans-serif;
+  --font-mono: "Geist Mono", ui-monospace, "SF Mono", Menlo, monospace;
+
+  /* Layout */
+  --radius-card: 22px;
+}

--- a/mentolder-web/tsconfig.app.json
+++ b/mentolder-web/tsconfig.app.json
@@ -1,0 +1,29 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "erasableSyntaxOnly": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["src"]
+}

--- a/mentolder-web/tsconfig.json
+++ b/mentolder-web/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.app.json" },
+    { "path": "./tsconfig.node.json" }
+  ]
+}

--- a/mentolder-web/tsconfig.node.json
+++ b/mentolder-web/tsconfig.node.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
+    "target": "ES2022",
+    "lib": ["ES2023"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "erasableSyntaxOnly": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true,
+    "isolatedModules": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/mentolder-web/vite.config.ts
+++ b/mentolder-web/vite.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import svgr from 'vite-plugin-svgr';
+import tailwindcss from '@tailwindcss/vite';
+import path from 'node:path';
+
+export default defineConfig({
+  plugins: [react(), svgr(), tailwindcss()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+  server: {
+    port: 5174,
+    strictPort: false,
+  },
+  build: {
+    outDir: 'dist',
+    sourcemap: true,
+    target: 'es2022',
+  },
+});

--- a/openspec/changes/mentolder-react-rebuild/design-system.md
+++ b/openspec/changes/mentolder-react-rebuild/design-system.md
@@ -1,0 +1,260 @@
+# mentolder Design-System
+
+Extrahiert aus `website/src/styles/global.css` und den Svelte-Komponenten.
+Einsatzbereit als CSS Custom Properties + Tailwind v4 Theme.
+
+---
+
+## Farb-Tokens
+
+### Hintergrund (Ink-Skala)
+| Token | HEX | Verwendung |
+|-------|-----|------------|
+| `--ink-900` | `#0b111c` | Page-Background, tiefste Ebene |
+| `--ink-850` | `#101826` | Surface (Cards, Panels) |
+| `--ink-800` | `#17202e` | Surface Hover, erhöhte Ebene |
+| `--ink-750` | `#1d2736` | Tooltips, Popovers |
+
+### Vordergrund
+| Token | Wert | Verwendung |
+|-------|------|------------|
+| `--fg` | `#eef1f3` | Primärer Text |
+| `--fg-soft` | `#cdd3d9` | Body-Text, Beschreibungen |
+| `--mute` | `#8c96a3` | Placeholder, Metadaten |
+| `--mute-2` | `#6a727e` | Disabled, sehr gedämpft |
+
+### Akzentfarben
+| Token | Wert (oklch) | HEX-Näherung | Verwendung |
+|-------|-------------|--------------|------------|
+| `--brass` | `oklch(0.80 0.09 75)` | `#c9a96e` | Primary-CTA, Kicker-Bar, Emphasis-Text |
+| `--brass-2` | `oklch(0.86 0.09 75)` | `#d9be8a` | Hover-Zustand von Brass |
+| `--brass-d` | `oklch(0.80 0.09 75 / 0.14)` | rgba-Variante | Brass-Hintergründe, Glassmorphism |
+| `--sage` | `oklch(0.80 0.06 160)` | `#8db8a4` | Separator-Dots, sekundäre Highlights |
+
+### Linien & Borders
+| Token | Wert | Verwendung |
+|-------|------|------------|
+| `--line` | `rgba(255,255,255, 0.07)` | Subtile Divider |
+| `--line-2` | `rgba(255,255,255, 0.12)` | Sichtbare Borders (Cards, Inputs) |
+
+---
+
+## Typografie
+
+### Font-Familien
+```css
+--font-serif: "Newsreader", "Iowan Old Style", Georgia, serif;
+--font-sans:  "Geist", ui-sans-serif, system-ui, sans-serif;
+--font-mono:  "Geist Mono", ui-monospace, Menlo, monospace;
+```
+
+**Google Fonts Import:**
+```html
+<link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,300;0,6..72,400;1,6..72,300;1,6..72,400&display=swap" rel="stylesheet">
+```
+**Geist** via `npm install geist` (Vercel) oder CDN.
+
+### Typografie-Skala
+
+| Element | Font | Size | Weight | Eigenheit |
+|---------|------|------|--------|-----------|
+| H1 Hero | Newsreader | `clamp(44px, 6.2vw, 88px)` | 300 | `letter-spacing: -0.02em`, em-Tags italic in `--brass-2` |
+| H2 Section | Newsreader | `28px` | 400 | |
+| Kicker | Geist Mono | `11px` | 500 | `letter-spacing: 0.14em`, UPPERCASE |
+| Body / Lede | Geist | `18px` | 400 | `line-height: 1.6` |
+| Body klein | Geist | `16px` | 400 | |
+| Label / Meta | Geist Mono | `11px` | 400 | |
+| Stat-Zahl | Newsreader | `44px` | — | `em`-Tags in `--brass` |
+
+---
+
+## Spacing & Layout
+
+```css
+--maxw:   1240px;  /* Max Content-Breite */
+--radius: 22px;    /* Border-Radius für Cards/Buttons */
+```
+
+**Padding-Konventionen:**
+- Section vertikal: `76px 0 120px` (Desktop), `56px 0 80px` (Mobile ≤960px)
+- Wrap horizontal: `40px` (Desktop), `22px` (Mobile)
+- Grid-Gap Hero: `64px` (Desktop), `56px` (Mobile, einspaltig)
+
+---
+
+## Komponenten-Tokens
+
+### Button (Primary)
+```css
+background: var(--brass);
+color: var(--ink-900);
+padding: 14px 22px;
+border-radius: 999px; /* Pill */
+font-size: 14px;
+font-weight: 600;
+
+/* Hover */
+background: var(--brass-2);
+transform: translateY(-1px);
+```
+
+### Button (Ghost)
+```css
+color: var(--fg);
+border: 1px solid var(--line-2);
+background: transparent;
+
+/* Hover */
+border-color: var(--brass);
+color: var(--brass);
+```
+
+### Card
+```css
+background: var(--ink-850);
+border: 1px solid var(--line-2);
+border-radius: var(--radius);
+border-top: 2px solid var(--brass); /* Brass-Top-Akzent */
+```
+
+### Kicker-Bar (Section-Label)
+```css
+/* Horizontale Linie */
+.bar {
+  width: 44px;
+  height: 1px;
+  background: var(--brass);
+  opacity: 0.7;
+}
+/* Separator-Dot */
+.dot {
+  width: 5px; height: 5px;
+  border-radius: 50%;
+  background: var(--sage);
+}
+/* Text */
+font-family: var(--font-mono);
+font-size: 11px;
+letter-spacing: 0.14em;
+text-transform: uppercase;
+color: var(--mute);
+```
+
+### Hero Halo (Background-Effekt)
+```css
+/* Rechts-oben: Brass-Glow */
+background: radial-gradient(
+  closest-side,
+  oklch(0.80 0.09 75 / .11),
+  transparent 70%
+);
+filter: blur(10px);
+width: 90vw; height: 90vw;
+right: -20%; top: -30%;
+
+/* Links-unten: Blaugrau-Glow */
+background: radial-gradient(
+  closest-side,
+  oklch(0.60 0.05 250 / .25),
+  transparent 70%
+);
+width: 80vw; height: 80vw;
+left: -30%; bottom: -40%;
+```
+
+---
+
+## Tailwind v4 Theme-Konfiguration
+
+```css
+/* tailwind.config — CSS-Layer in main.css */
+@import "tailwindcss";
+
+@theme {
+  /* Farben */
+  --color-ink-900: #0b111c;
+  --color-ink-850: #101826;
+  --color-ink-800: #17202e;
+  --color-ink-750: #1d2736;
+  --color-fg: #eef1f3;
+  --color-fg-soft: #cdd3d9;
+  --color-mute: #8c96a3;
+  --color-mute-2: #6a727e;
+  --color-brass: oklch(0.80 0.09 75);
+  --color-brass-2: oklch(0.86 0.09 75);
+  --color-brass-d: oklch(0.80 0.09 75 / 0.14);
+  --color-sage: oklch(0.80 0.06 160);
+  --color-line: rgba(255,255,255,0.07);
+  --color-line-2: rgba(255,255,255,0.12);
+
+  /* Fonts */
+  --font-serif: "Newsreader", Georgia, serif;
+  --font-sans: "Geist", ui-sans-serif, sans-serif;
+  --font-mono: "Geist Mono", ui-monospace, monospace;
+
+  /* Layout */
+  --radius: 22px;
+  --max-w: 1240px;
+}
+```
+
+---
+
+## Was du Claude für Assets fragen kannst
+
+### 1. SVG Hero-Halo
+```
+Erstelle eine SVG-Datei (1600×900, viewBox="0 0 1600 900") als 
+Hero-Hintergrund für mentolder.de im Dark-Style (#0b111c).
+
+Zwei radiale Gradienten:
+- Rechts oben: oklch(0.80 0.09 75 / 0.11) → transparent (Brass-Glow, 900px Radius)
+- Links unten: oklch(0.60 0.05 250 / 0.25) → transparent (Blaugrau-Glow, 800px Radius)
+
+Als exportierbare SVG mit <defs> und <radialGradient> Elementen.
+Kein Fill außer den Gradienten. Für Web optimiert (keine überflüssigen Attribute).
+```
+
+### 2. SVG Icons (Coaching-Themen)
+```
+Erstelle 6 SVG-Icons, 24×24, viewBox="0 0 24 24", stroke="currentColor",
+strokeWidth="1.5", fill="none", strokeLinecap="round", strokeLinejoin="round".
+
+Icons für: Führung, Digitalisierung, Team, Strategie, Kommunikation, Resilienz.
+Minimalistischer Stil (kein filled, kein dickes Stroke).
+Ausgabe: eine SVG-Datei pro Icon, Dateiname: icon-fuehrung.svg, etc.
+```
+
+### 3. OG-Image Template (React-Komponente für @vercel/og)
+```
+Erstelle eine React-Komponente für @vercel/og (ImageResponse) als 
+OG-Image-Template für mentolder.de:
+
+- Größe: 1200×630px
+- Hintergrund: Gradient #0b111c → #17202e (links nach rechts)
+- Links: Wortmarke "mentolder" in Geist, 48px, #eef1f3
+- Mitte: Brass-Trennlinie (vertical, 1px, oklch(0.80 0.09 75))
+- Rechts: Dynamischer Titel (prop), Newsreader Italic, 36px, #d9be8a
+- Unten rechts: Tagline "Digital Coach & Führungskräfte-Mentor", 14px, #8c96a3
+```
+
+### 4. Favicon (SVG)
+```
+Erstelle ein SVG-Favicon (32×32) für mentolder.de:
+- Buchstabe "m" in Geist Sans, lowercase, Bold
+- Hintergrund: Rounded Square, #101826
+- Textfarbe: #eef1f3
+- Brass-Unterstrich: 2px, oklch(0.80 0.09 75), unter dem "m"
+Exportiere als favicon.svg (skaliert von 16–512px korrekt).
+```
+
+### 5. Portrait-Placeholder-Komponente
+```
+React-Komponente <AvatarPlaceholder initials="BM" size={200} />:
+- Hintergrund: #17202e
+- Border: 1px solid oklch(0.80 0.09 75 / 0.3)
+- Border-Radius: 50% (Kreis)
+- Innen: feinere Brass-Ring (oklch(0.80 0.09 75 / 0.12), 8px inset)
+- Initiale: Newsreader Italic, 72px, oklch(0.86 0.09 75)
+Kein Bild-Tag, rein CSS + Text.
+```

--- a/openspec/changes/mentolder-react-rebuild/proposal.md
+++ b/openspec/changes/mentolder-react-rebuild/proposal.md
@@ -1,0 +1,109 @@
+# Proposal: mentolder.de Website-Frontend in React neu aufbauen
+
+_Ticket: T001026_
+
+## Why
+
+Die öffentliche mentolder.de Website ist als Svelte-Komponenten tief in den Astro-Monolithen des
+Bachelorprojekts eingebettet. Jede Content-Änderung erfordert ein Full-Stack-Kubernetes-Deployment.
+Für eine Coaching-Website, die regelmäßig Texte, Bilder und CTA-Texte anpassen muss, ist das ein
+zu schwerer Deployment-Pfad.
+
+Ein eigenständiges React-Paket (Vite + React 19 + TypeScript) lässt sich:
+- unabhängig vom K8s-Cluster deployen (CDN/Vercel/Netlify),
+- von externen Kollaborateuren wartungsfrei übergeben (React ist breiter bekannt als Svelte),
+- direkt in Vercel Preview-Deployments pro Branch testen, ohne Cluster-Zugriff.
+
+Das bestehende Design-System (Dark-Mode, Brass-Akzent `oklch(0.80 0.09 75)`, Newsreader/Geist
+Typografie) bleibt 1:1 erhalten — migriert als CSS Custom Properties + Tailwind v4 Theme.
+
+## What
+
+### Öffentliche Seiten (Phase 1 — MVP)
+
+| Route | Inhalt |
+|-------|--------|
+| `/` | Hero, ServiceRow (3 Karten), WhyMe-Stats, FAQ (Accordion), CTA-Banner, Footer |
+| `/kontakt` | Kontaktformular (react-hook-form + zod, Formspree-Backend) |
+| `/impressum` | Statische Rechtseite |
+| `/datenschutz` | Statische Rechtseite |
+
+### Technologie-Stack
+
+| Schicht | Wahl | Begründung |
+|---------|------|------------|
+| Build | Vite 6 + React 19 | schnelles DX, kein SSR-Overhead für diese Content-Seite |
+| Language | TypeScript strict | Projekt-Standard |
+| Styling | Tailwind v4 + CSS Custom Props | Design-Tokens portierbar, kein Inline-Style-Chaos |
+| Routing | React Router v7 | leichtgewichtig, SPA-Routing reicht |
+| Animationen | Framer Motion | Scroll-Reveals, Hero-Halo-Entrance (entspricht aktuellem Svelte-Verhalten) |
+| Formulare | react-hook-form + zod | Validierung + Typsicherheit |
+| Icons | eigene SVG-Komponenten | keine Icon-Lib-Dependency, Stroke-Only-Style passt zum Design |
+
+### Design-System-Tokens (aus aktuellem Svelte-Code extrahiert)
+
+Vollständige Token-Tabelle und Tailwind-v4-Config: `design-system.md` in diesem Change.
+
+### GIVEN / WHEN / THEN
+
+**GIVEN** ich öffne `mentolder.de` im Browser  
+**WHEN** die Seite geladen ist  
+**THEN** sehe ich Hero, ServiceRow, WhyMe-Stats, FAQ und Footer — visuell identisch zur
+aktuellen Svelte-Implementierung (Dark-Background `#0b111c`, Brass-Akzent-CTAs, Newsreader-H1)
+
+**GIVEN** ich klicke auf „Kostenloses Erstgespräch"  
+**WHEN** die `/kontakt`-Route lädt  
+**THEN** sehe ich ein validiertes Kontaktformular; bei Submit wird eine Formspree-Anfrage
+gesendet, und ich erhalte eine Success-Meldung (kein Full-Page-Reload)
+
+**GIVEN** `VOYAGE_API_KEY` / K8s-Cluster sind nicht erreichbar  
+**WHEN** die React-App deployed wird  
+**THEN** ist das Deployment unabhängig davon erfolgreich — keine Cluster-Dependency für die
+statische Frontend-Auslieferung
+
+**GIVEN** ich führe `npm run build` aus  
+**WHEN** der Build abgeschlossen ist  
+**THEN** liegt ein vollständig statisches `dist/`-Verzeichnis vor, deploybar auf Vercel, Netlify
+oder einem beliebigen CDN ohne Serverkomponente
+
+## Neue Artefakte
+
+```
+mentolder-web/                    ← neues Paket (separates Repo oder Monorepo-Pkg)
+  src/
+    components/
+      Hero.tsx                    ← port von Hero.svelte
+      ServiceCard.tsx
+      ServiceRow.tsx
+      WhyMeStats.tsx
+      FAQ.tsx
+      ContactForm.tsx
+      Footer.tsx
+      Portrait.tsx
+      KickerBar.tsx               ← extrahierte Kicker-Leiste mit Brass-Bar + Sage-Dot
+    pages/
+      HomePage.tsx
+      KontaktPage.tsx
+      ImpressumPage.tsx
+      DatenschutzPage.tsx
+    assets/
+      hero-halo.svg               ← SVG-Hintergrundgrafik (Claude-generiert)
+      icons/                      ← 6 Coaching-Icons (Claude-generiert)
+      favicon.svg
+    styles/
+      tokens.css                  ← Design-Tokens als CSS Custom Properties
+      global.css
+    App.tsx
+    main.tsx
+  tailwind.config.css             ← @theme mit mentolder-Tokens
+  vite.config.ts
+  tsconfig.json
+  package.json
+```
+
+## Abgrenzung (nicht in Scope)
+
+- Kein Blog / kein CMS in Phase 1
+- Kein Keycloak-Login auf der öffentlichen Website (nur `/portal`-Bereich, bleibt im Monolithen)
+- Keine Nextcloud-/Chat-Integration
+- Kein Next.js (SSG via Vite `rollupOptions.input` reicht für 4 statische Routen)

--- a/openspec/changes/mentolder-react-rebuild/tasks.md
+++ b/openspec/changes/mentolder-react-rebuild/tasks.md
@@ -42,6 +42,9 @@ mentolder-web/
 
 ## Aufgabe 1: Projekt-Setup
 
+- [x] **M1 — Setup (Blocker für alle):** Vite + React 19 + TypeScript strict + Tailwind v4
+  Scaffold mit mentolder-Design-Tokens. `pnpm tsc --noEmit` und `pnpm run build` grün.
+
 **Ziel:** Vite + React 19 + TypeScript + Tailwind v4 Scaffold mit mentolder-Design-Tokens.
 
 **Implementierung:**
@@ -92,6 +95,8 @@ npm install -D tailwindcss @tailwindcss/vite
 
 ## Aufgabe 2: Design-Assets generieren (Claude-Prompts)
 
+- [x] **M1:** favicon.svg, hero-halo.svg und 6 Icon-SVGs (fuehrung/digitalisierung/team/strategie/kommunikation/resilienz) — stroke-only, 24×24 viewBox, als `?react`-Komponenten via `vite-plugin-svgr` registriert.
+
 **Ziel:** SVG-Assets für Hero-Halo, Icons, Favicon via Claude generieren.
 Fertige Prompts stehen in `design-system.md` (Abschnitt „Was du Claude für Assets fragen kannst").
 
@@ -111,6 +116,8 @@ Fertige Prompts stehen in `design-system.md` (Abschnitt „Was du Claude für As
 ---
 
 ## Aufgabe 3: KickerBar-Komponente
+
+- [x] **M2:** KickerBar.tsx mit Brass-Linie, Sage-Dots, Mono-Text — Parts-Array Support.
 
 **Ziel:** Extrahierte Kicker-Leiste (Brass-Bar + Sage-Dot + Mono-Text) als wiederverwendbare
 React-Komponente.
@@ -148,6 +155,8 @@ export function KickerBar({ parts }: KickerBarProps) {
 
 ## Aufgabe 4: Hero-Komponente
 
+- [x] **M2:** Hero.tsx + Portrait.tsx — H1 mit `em`-Italic in Brass-2, Kicker-Reveal + H1-Reveal via Framer Motion, CTA-Buttons, hero-halo.svg Background + CSS radial-gradient. Responsive (≤960px 1-spaltig).
+
 **Ziel:** Port von `Hero.svelte` — pixel-perfect nach aktuellem Design.
 
 **Dateien:**
@@ -184,6 +193,8 @@ Newsreader Italic für Initiale (entspricht aktuellem Svelte-`Portrait.svelte`).
 
 ## Aufgabe 5: ServiceCard + ServiceRow
 
+- [x] **M2:** ServiceCard.tsx (Brass-Top-Border, Hover-Lift via Framer Motion) + ServiceRow.tsx (3-Spalten-Grid Desktop / 1-Spaltig Mobile) + IconRegistry (6 Stroke-Icons).
+
 **Ziel:** 3 Coaching-Service-Karten mit Brass-Top-Border und Hover-Lift.
 
 **Dateien:**
@@ -216,6 +227,8 @@ Icons aus `assets/icons/` als React-Komponenten (`<IconFuehrung />`).
 
 ## Aufgabe 6: WhyMeStats
 
+- [x] **M3:** WhyMeStats.tsx mit CountUp-Hook + `useInView` (once: true), Newsreader 44px, em-Tags in Brass.
+
 **Ziel:** Stat-Zähler-Sektion (z.B. „30+ Jahre Erfahrung") mit AnimatedCounter beim Scroll-Enter.
 
 **Dateien:**
@@ -234,6 +247,8 @@ horizontal, Divider via `border-line`.
 ---
 
 ## Aufgabe 7: FAQ-Accordion
+
+- [x] **M3:** FAQ.tsx mit `AnimatePresence` + `motion.div` Height-Transition, Keyboard-zugänglich (Enter/Space), mehrere gleichzeitig offen, Brass-Chevron.
 
 **Ziel:** Akkordeon-FAQ mit Framer Motion Höhen-Animation.
 
@@ -254,6 +269,8 @@ Tastatur-zugänglich: `role="button"`, `aria-expanded`, `Enter`/`Space` öffnen.
 ---
 
 ## Aufgabe 8: Kontaktformular
+
+- [x] **M3:** ContactForm.tsx mit react-hook-form + zodResolver + Zod-Schema, Formspree-POST mit Mailto-Fallback wenn `VITE_FORMSPREE_ENDPOINT` fehlt. Inline-Validierungsfehler, Success/Error-States, DSGVO-Consent-Checkbox.
 
 **Ziel:** Validiertes Kontaktformular mit Formspree-Backend.
 
@@ -284,6 +301,8 @@ Error-State: Roter Fehlerhinweis pro Feld (inline, kein Alert).
 
 ## Aufgabe 9: Footer + Navigation
 
+- [x] **M4:** Footer.tsx (Brand-Spalte, Kontakt, Angebote, Rechtliches) + Navigation.tsx (sticky, backdrop-blur, mobile Sheet, NavLink-Active-State in Brass).
+
 **Ziel:** Minimaler Footer (Copyright, Links) und Desktop-Topnav.
 
 **Dateien:**
@@ -302,6 +321,8 @@ Navigation: Sticky Top, `backdrop-blur`, aktiver Link in Brass-Farbe via `useMat
 ---
 
 ## Aufgabe 10: Routing + Pages + OG-Meta
+
+- [x] **M4:** App.tsx mit React Router v7 (`<Routes>` für `/`, `/kontakt`, `/impressum`, `/datenschutz`, 404), PageMeta.tsx für dynamische Title/Description/OG/Canonical, alle 4 Pages verdrahtet, ScrollToTop bei Route-Wechsel.
 
 **Ziel:** SPA-Routing mit React Router v7, alle 4 Seiten verdrahtet, OG-Tags via `react-helmet`.
 
@@ -331,6 +352,8 @@ in `design-system.md` Abschnitt „3. OG-Image Template").
 ---
 
 ## Aufgabe 11: Verifikation
+
+- [x] **M5:** `pnpm tsc --noEmit` 0 Errors · `pnpm run build` erzeugt `dist/` · `task workspace:validate`, `task test:changed`, `task freshness:regenerate`, `task freshness:check` grün.
 
 **Implementierung:**
 

--- a/openspec/changes/mentolder-react-rebuild/tasks.md
+++ b/openspec/changes/mentolder-react-rebuild/tasks.md
@@ -1,0 +1,385 @@
+---
+title: "mentolder.de Website-Frontend in React neu aufbauen"
+ticket_id: T001026
+domains: [website/mentolder]
+status: plan_staged
+file_locks: []
+shared_changes: false
+batch_id: null
+parent_feature: null
+depends_on_plans: []
+---
+
+# mentolder React Rebuild — Implementation Plan
+
+Portiert die öffentliche mentolder.de Website von Svelte/Astro auf ein eigenständiges
+React 19 + Vite-Paket. Design-System bleibt 1:1 erhalten (Dark-Mode, Brass-Akzent, Newsreader/Geist).
+
+---
+
+## File Structure
+
+```
+mentolder-web/
+  src/
+    components/
+      Hero.tsx · ServiceCard.tsx · ServiceRow.tsx
+      WhyMeStats.tsx · FAQ.tsx · ContactForm.tsx
+      Footer.tsx · Portrait.tsx · KickerBar.tsx
+    pages/
+      HomePage.tsx · KontaktPage.tsx
+      ImpressumPage.tsx · DatenschutzPage.tsx
+    assets/
+      hero-halo.svg · favicon.svg · icons/*.svg
+    styles/
+      tokens.css · global.css
+    App.tsx · main.tsx
+  tailwind.config.css
+  vite.config.ts · tsconfig.json · package.json
+```
+
+---
+
+## Aufgabe 1: Projekt-Setup
+
+**Ziel:** Vite + React 19 + TypeScript + Tailwind v4 Scaffold mit mentolder-Design-Tokens.
+
+**Implementierung:**
+
+```bash
+npm create vite@latest mentolder-web -- --template react-ts
+cd mentolder-web
+npm install react-router-dom framer-motion react-hook-form zod @hookform/resolvers
+npm install -D tailwindcss @tailwindcss/vite
+```
+
+`tailwind.config.css` — `@theme` mit allen Tokens aus `design-system.md`:
+
+```css
+@import "tailwindcss";
+
+@theme {
+  --color-ink-900: #0b111c;
+  --color-ink-850: #101826;
+  --color-ink-800: #17202e;
+  --color-ink-750: #1d2736;
+  --color-fg: #eef1f3;
+  --color-fg-soft: #cdd3d9;
+  --color-mute: #8c96a3;
+  --color-mute-2: #6a727e;
+  --color-brass: oklch(0.80 0.09 75);
+  --color-brass-2: oklch(0.86 0.09 75);
+  --color-brass-d: oklch(0.80 0.09 75 / 0.14);
+  --color-sage: oklch(0.80 0.06 160);
+  --color-line: rgba(255,255,255,0.07);
+  --color-line-2: rgba(255,255,255,0.12);
+  --font-serif: "Newsreader", Georgia, serif;
+  --font-sans: "Geist", ui-sans-serif, sans-serif;
+  --font-mono: "Geist Mono", ui-monospace, monospace;
+  --radius: 22px;
+  --max-w: 1240px;
+}
+```
+
+`styles/tokens.css` — identische Custom Properties als Fallback für Nicht-Tailwind-Klassen (copy aus Svelte `global.css`).
+
+**Akzeptanzkriterium:**
+- `npm run dev` startet ohne Fehler
+- `http://localhost:5173` zeigt leere Seite mit `#0b111c` Background
+- `npm run build` erzeugt `dist/` ohne Fehler
+
+---
+
+## Aufgabe 2: Design-Assets generieren (Claude-Prompts)
+
+**Ziel:** SVG-Assets für Hero-Halo, Icons, Favicon via Claude generieren.
+Fertige Prompts stehen in `design-system.md` (Abschnitt „Was du Claude für Assets fragen kannst").
+
+**Assets:**
+
+| Datei | Claude-Prompt in `design-system.md` |
+|-------|--------------------------------------|
+| `assets/hero-halo.svg` | Abschnitt „1. SVG Hero-Halo" |
+| `assets/icons/icon-*.svg` | Abschnitt „2. SVG Icons" |
+| `assets/favicon.svg` | Abschnitt „4. Favicon (SVG)" |
+
+**Akzeptanzkriterium:**
+- Alle SVGs valide (kein `viewBox`-Fehler im Browser)
+- `hero-halo.svg` rendert mit sichtbarem Brass-Glow auf `#0b111c`
+- Icons skalieren sauber auf 16–64px
+
+---
+
+## Aufgabe 3: KickerBar-Komponente
+
+**Ziel:** Extrahierte Kicker-Leiste (Brass-Bar + Sage-Dot + Mono-Text) als wiederverwendbare
+React-Komponente.
+
+**Dateien:**
+- `src/components/KickerBar.tsx` — neu
+
+**Implementierung:**
+
+```tsx
+interface KickerBarProps {
+  parts: string[];  // z.B. ["Digital Coach", "Führungskräfte-Mentor"]
+}
+
+export function KickerBar({ parts }: KickerBarProps) {
+  return (
+    <div className="flex items-center gap-[14px] font-mono text-[11px] tracking-[0.14em] uppercase text-mute">
+      <span className="w-[44px] h-px bg-brass opacity-70 flex-shrink-0" aria-hidden />
+      {parts.map((part, i) => (
+        <>
+          {i > 0 && <span className="w-[5px] h-[5px] rounded-full bg-sage flex-shrink-0" aria-hidden />}
+          <span key={part}>{part}</span>
+        </>
+      ))}
+    </div>
+  );
+}
+```
+
+**Akzeptanzkriterium:**
+- Brass-Linie und Sage-Dots sichtbar
+- `parts={["A", "B", "C"]}` → 2 Dots zwischen 3 Segmenten
+
+---
+
+## Aufgabe 4: Hero-Komponente
+
+**Ziel:** Port von `Hero.svelte` — pixel-perfect nach aktuellem Design.
+
+**Dateien:**
+- `src/components/Hero.tsx` — neu
+- `src/components/Portrait.tsx` — neu (Monogramm-Placeholder)
+
+**Implementierung:**
+
+```tsx
+interface HeroProps {
+  title?: string;
+  titleEmphasis?: string;
+  subtitle?: string;
+  tagline?: string;
+  avatarInitials?: string;
+  personName?: string;
+  personRole?: string;
+}
+```
+
+Halo-Hintergrund via `hero-halo.svg` als absolut positioniertes `<img>` (pointer-events: none).
+Framer Motion `initial/animate` für Kicker-Bar-Reveal (opacity 0→1, y: 8→0, delay: 0.1s)
+und H1-Reveal (opacity 0→1, y: 16→0, delay: 0.25s).
+
+`Portrait.tsx` — Monogramm-Kreis mit `#17202e` Background, Brass-Border,
+Newsreader Italic für Initiale (entspricht aktuellem Svelte-`Portrait.svelte`).
+
+**Akzeptanzkriterium:**
+- H1: Newsreader 300, `clamp(44px, 6.2vw, 88px)`, `em`-Tag italic in `--brass-2`
+- CTA-Buttons: Pill-Radius, Primary mit Brass-Background, Ghost mit Brass-Hover
+- Auf ≤960px: einspaltig, Portrait zentriert
+
+---
+
+## Aufgabe 5: ServiceCard + ServiceRow
+
+**Ziel:** 3 Coaching-Service-Karten mit Brass-Top-Border und Hover-Lift.
+
+**Dateien:**
+- `src/components/ServiceCard.tsx` — neu
+- `src/components/ServiceRow.tsx` — neu
+
+**Implementierung:**
+
+`ServiceCard`:
+```tsx
+interface ServiceCardProps {
+  icon: React.ReactNode;
+  title: string;
+  description: string;
+  href?: string;
+}
+```
+Styling: `bg-ink-850 border border-line-2 border-t-2 border-t-brass rounded-[22px]`,
+Hover: `translateY(-4px)` via Framer Motion `whileHover`.
+
+`ServiceRow`: 3-Spalten-Grid (Desktop), 1-Spaltig (Mobile ≤768px),
+Icons aus `assets/icons/` als React-Komponenten (`<IconFuehrung />`).
+
+**Akzeptanzkriterium:**
+- Brass-Top-Border sichtbar
+- Hover-Lift animiert
+- Responsive
+
+---
+
+## Aufgabe 6: WhyMeStats
+
+**Ziel:** Stat-Zähler-Sektion (z.B. „30+ Jahre Erfahrung") mit AnimatedCounter beim Scroll-Enter.
+
+**Dateien:**
+- `src/components/WhyMeStats.tsx` — neu
+
+**Implementierung:**
+
+Custom Hook `useCountUp(target, duration)` mit `IntersectionObserver` (einmal feuern wenn
+Element im Viewport). Zahlen in Newsreader 44px, `em`-Tags in `--brass`. Layout: 3–4 Stats
+horizontal, Divider via `border-line`.
+
+**Akzeptanzkriterium:**
+- Zahlen laufen hoch wenn Section ins Viewport scrollt
+- Zähler feuert nur einmal pro Mount
+
+---
+
+## Aufgabe 7: FAQ-Accordion
+
+**Ziel:** Akkordeon-FAQ mit Framer Motion Höhen-Animation.
+
+**Dateien:**
+- `src/components/FAQ.tsx` — neu
+
+**Implementierung:**
+
+Kein externer Accordion-Primitive — `AnimatePresence` + `motion.div` mit `initial/exit`
+Höhen-Transition. Border: `border-line`, offene Frage: Brass-Farbe im Titel.
+Tastatur-zugänglich: `role="button"`, `aria-expanded`, `Enter`/`Space` öffnen.
+
+**Akzeptanzkriterium:**
+- Öffnen/Schließen animiert (kein Layout-Sprung)
+- Mehrere gleichzeitig offen möglich
+- Keyboard-navigierbar
+
+---
+
+## Aufgabe 8: Kontaktformular
+
+**Ziel:** Validiertes Kontaktformular mit Formspree-Backend.
+
+**Dateien:**
+- `src/components/ContactForm.tsx` — neu
+- `.env.example` — `VITE_FORMSPREE_ENDPOINT=https://formspree.io/f/<id>`
+
+**Implementierung:**
+
+```tsx
+const schema = z.object({
+  name:    z.string().min(2, "Name erforderlich"),
+  email:   z.string().email("Gültige E-Mail erforderlich"),
+  message: z.string().min(10, "Nachricht zu kurz"),
+});
+```
+
+`useForm` mit `zodResolver`, `onSubmit` → `fetch(VITE_FORMSPREE_ENDPOINT, {method: "POST", body: JSON})`.
+Success-State: Brass-Checkmark + „Danke, ich melde mich bald!"-Meldung.
+Error-State: Roter Fehlerhinweis pro Feld (inline, kein Alert).
+
+**Akzeptanzkriterium:**
+- Leeres Submit → Inline-Validierungsfehler sichtbar
+- Erfolgreicher Submit → Success-State ohne Reload
+- `VITE_FORMSPREE_ENDPOINT` nicht gesetzt → Dev-Warning, kein Absturz
+
+---
+
+## Aufgabe 9: Footer + Navigation
+
+**Ziel:** Minimaler Footer (Copyright, Links) und Desktop-Topnav.
+
+**Dateien:**
+- `src/components/Footer.tsx` — neu
+- `src/components/Navigation.tsx` — neu
+
+**Implementierung:**
+
+Footer: Logo-Typo + Brass-Unterstrich, 3 Spalten (Links, Rechtliches, Kontakt), Hintergrund `ink-850`.
+Navigation: Sticky Top, `backdrop-blur`, aktiver Link in Brass-Farbe via `useMatch`.
+
+**Akzeptanzkriterium:**
+- Footer responsive (1-spaltig ≤768px)
+- Nav-Links reagieren auf aktive Route
+
+---
+
+## Aufgabe 10: Routing + Pages + OG-Meta
+
+**Ziel:** SPA-Routing mit React Router v7, alle 4 Seiten verdrahtet, OG-Tags via `react-helmet`.
+
+**Dateien:**
+- `src/App.tsx` — Routen-Definition
+- `src/pages/*.tsx` — Seiten-Wrapper
+
+**Implementierung:**
+
+```tsx
+<Routes>
+  <Route path="/" element={<HomePage />} />
+  <Route path="/kontakt" element={<KontaktPage />} />
+  <Route path="/impressum" element={<ImpressumPage />} />
+  <Route path="/datenschutz" element={<DatenschutzPage />} />
+</Routes>
+```
+
+`vite.config.ts`: `base: "/"`, alle Routes → `index.html` (SPA-Fallback via Hosting-Config).
+OG-Image: statisches Fallback-Bild aus `assets/og-default.png` (1200×630, via Claude-Prompt
+in `design-system.md` Abschnitt „3. OG-Image Template").
+
+**Akzeptanzkriterium:**
+- Direktaufruf `/kontakt` landet auf Kontakt-Seite (kein 404)
+- `<meta og:image>` gesetzt auf allen Seiten
+
+---
+
+## Aufgabe 11: Verifikation
+
+**Implementierung:**
+
+```bash
+# 0. Failing-test-Schritt: TypeScript soll ohne Hero.tsx scheitern
+# Vor Aufgabe 4 verifizieren: tsc --noEmit mit fehlendem Hero schlägt fehl.
+# To verify it fails: remove Hero import from HomePage.tsx → tsc → expect FAIL (TS2307)
+# Nach Aufgabe 4: tsc --noEmit → expect PASS (0 errors)
+
+# 1. TypeScript
+cd mentolder-web && npx tsc --noEmit
+
+# 2. CI-Gate (Monorepo-Offline-Tests, Manifeste, Freshness)
+task test:changed
+task freshness:regenerate
+task freshness:check
+
+# 3. Build
+npm run build
+# → dist/ ohne Fehler
+
+# 4. Preview
+npm run preview
+# → alle 4 Routen erreichbar, kein Konsolenfehler
+
+# 5. Lighthouse
+npx lighthouse http://localhost:4173 --only-categories=performance,accessibility,best-practices
+# Ziel: Performance > 90, Accessibility > 95
+
+# 6. Responsivität (manuell in Chrome DevTools)
+# 375px (iPhone), 768px (Tablet), 1280px (Desktop)
+```
+
+**Akzeptanzkriterium:**
+- Failing-test-Schritt: `tsc` mit fehlendem Hero-Import schlägt fehl (TS2307) — dann nach Aufgabe 4 grün
+- `tsc --noEmit` grün (0 Errors)
+- `task test:changed` grün
+- `task freshness:regenerate` + `task freshness:check` grün
+- `npm run build` grün
+- Lighthouse Performance > 90, Accessibility > 95
+- Alle 3 Breakpoints visuell korrekt
+
+---
+
+## Implementierungsreihenfolge
+
+1. Aufgabe 1 — Setup (Blocker für alle)
+2. Aufgabe 2 — Assets (parallel zu 3–9 ausführbar)
+3. Aufgaben 3–5 — Kern-Komponenten (KickerBar → Hero → ServiceRow)
+4. Aufgaben 6–9 — Restliche Komponenten (parallel)
+5. Aufgabe 10 — Routing + Pages (nach 3–9)
+6. Aufgabe 11 — Verifikation (abschließend)


### PR DESCRIPTION
Closes T001026. New standalone mentolder-web/ package (React 19 + Vite 6 + TS + Tailwind v4 + Framer Motion + react-hook-form/zod + React Router v7). Pixel-parity to current Svelte implementation via design-system.md tokens. Four pages: /, /kontakt, /impressum, /datenschutz.

- 9 components: KickerBar, Hero, Portrait, ServiceCard, ServiceRow, WhyMeStats, FAQ, ContactForm, Footer, Navigation, CallToAction, PageMeta
- 4 pages wired through React Router v7 with 404 fallback
- Design tokens migrated 1:1 from `website/src/styles/global.css` (ink, fg, brass oklch, sage, line, font families Newsreader/Geist/Geist Mono)
- Formspree backend with mailto: dev-fallback when VITE_FORMSPREE_ENDPOINT is unset
- Inline form validation via zod (name/email/message, DSGVO consent)
- Sticky backdrop-blur Navigation, mobile sheet, NavLink active state
- Animated count-up stats, Framer Motion hero reveal, accordion height animation
- SEO: dynamic <title>/description/og:* per route via PageMeta + ScrollToTop on hash navigation
- Build: `pnpm install && pnpm run build` → static `dist/` (~485 KB JS gz 151 KB, 23 KB CSS gz 5.5 KB)
- No cluster dependency. Defer prod hosting (Vercel/Netlify/CDN) as a follow-up.