### PR TITLE
chore(mentolder-web): deploy React site to react.mentolder.de

### DIFF
--- a/.github/workflows/build-mentolder-web.yml
+++ b/.github/workflows/build-mentolder-web.yml
@@ -1,0 +1,82 @@
+name: Build & Deploy mentolder-web
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'mentolder-web/**'
+      - '.github/workflows/build-mentolder-web.yml'
+  workflow_dispatch:
+
+jobs:
+  build-and-deploy:
+    name: Build & Deploy (react.mentolder.de)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda  # v4.1.0
+        with:
+          version: 10
+
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444  # v5
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+          cache-dependency-path: mentolder-web/pnpm-lock.yaml
+
+      - name: Typecheck
+        run: |
+          cd mentolder-web
+          pnpm install --frozen-lockfile
+          pnpm run typecheck
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get short SHA
+        id: version
+        run: echo "sha=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Build & push Docker image
+        env:
+          VITE_FORMSPREE_ENDPOINT: ${{ secrets.MENTOLDER_WEB_FORMSPREE_ENDPOINT }}
+          SHA_TAG: ${{ steps.version.outputs.sha }}
+        run: |
+          IMAGE="ghcr.io/paddione/mentolder-web"
+
+          docker build \
+            --build-arg VITE_FORMSPREE_ENDPOINT="${VITE_FORMSPREE_ENDPOINT}" \
+            --tag "${IMAGE}:latest" \
+            --tag "${IMAGE}:${SHA_TAG}" \
+            --file mentolder-web/Dockerfile \
+            .
+
+          docker push "${IMAGE}:latest"
+          docker push "${IMAGE}:${SHA_TAG}"
+
+      - name: Deploy to fleet (react.mentolder.de)
+        env:
+          KUBECONFIG_DATA: ${{ secrets.FLEET_KUBECONFIG }}
+          SHA_TAG: ${{ steps.version.outputs.sha }}
+        run: |
+          curl -sSL "https://dl.k8s.io/release/v1.31.0/bin/linux/amd64/kubectl" \
+            -o /usr/local/bin/kubectl && chmod +x /usr/local/bin/kubectl
+          mkdir -p ~/.kube
+          echo "$KUBECONFIG_DATA" | base64 -d > ~/.kube/config
+          chmod 600 ~/.kube/config
+
+          # Pin to exact SHA — forces rollout of the freshly built image
+          kubectl set image deployment/mentolder-web \
+            "mentolder-web=ghcr.io/paddione/mentolder-web:${SHA_TAG}" \
+            -n workspace
+          kubectl rollout status deployment/mentolder-web -n workspace --timeout=120s

--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -2104,7 +2104,7 @@
       "id": "infra-manifests",
       "name": "Kubernetes manifests, overlays, env registry",
       "owner_agent": "bachelorprojekt-infra",
-      "file_count": 432,
+      "file_count": 433,
       "files": [
         "claude-code/gekko-android-mcp-guide.md",
         "claude-code/settings.json",
@@ -2338,6 +2338,7 @@
         "k3d/mail-ingressroute-dev.yaml",
         "k3d/mailpit.yaml",
         "k3d/mediaviewer-widget.yaml",
+        "k3d/mentolder-web.yaml",
         "k3d/monitoring/alertmanager-config.yaml",
         "k3d/monitoring/alertmanager-pushover-secret.yaml",
         "k3d/monitoring/alertmanager-smtp-secret.yaml",

--- a/docs/generated/blast-radius.md
+++ b/docs/generated/blast-radius.md
@@ -1,6 +1,6 @@
 # Blast-Radius-Report
-> Generated: 2026-06-20T16:50:11.405Z
-> Nodes: 86 | Edges: 1860 | Isolated: 2
+> Generated: 2026-06-21T05:05:40.820Z
+> Nodes: 87 | Edges: 1862 | Isolated: 2
 
 ## Ranking (transitive Abhängige)
 
@@ -10,79 +10,80 @@
 | 2 | mailpit | 4 | 56 | 4 |
 | 3 | janus | 3 | 56 | 3 |
 | 4 | sish | 2 | 56 | 2 |
-| 5 | otel-collector | 2 | 56 | 2 |
-| 6 | ntfy | 2 | 56 | 2 |
-| 7 | collabora | 2 | 56 | 2 |
-| 8 | recovery-browser | 2 | 56 | 2 |
-| 9 | sessions-server | 2 | 56 | 2 |
-| 10 | nats | 2 | 56 | 2 |
-| 11 | brett | 43 | 55 | 43 |
-| 12 | keycloak | 43 | 55 | 43 |
-| 13 | nextcloud | 43 | 55 | 43 |
-| 14 | oauth2-proxy-brainstorm | 42 | 55 | 42 |
-| 15 | oauth2-proxy-dev | 42 | 55 | 42 |
-| 16 | oauth2-proxy-session-hub | 42 | 55 | 42 |
-| 17 | livekit-server | 42 | 55 | 42 |
-| 18 | oauth2-proxy-studio | 42 | 55 | 42 |
-| 19 | oauth2-proxy-videovault | 42 | 55 | 42 |
-| 20 | oauth2-proxy-recovery | 42 | 55 | 42 |
-| 21 | shared-db | 42 | 55 | 42 |
-| 22 | spreed-signaling | 42 | 55 | 42 |
-| 23 | vaultwarden | 42 | 55 | 42 |
-| 24 | whiteboard | 42 | 55 | 42 |
-| 25 | arena-server | 42 | 55 | 42 |
-| 26 | mcp-github | 41 | 55 | 41 |
-| 27 | claude-code-mcp-ops | 41 | 55 | 41 |
-| 28 | oauth2-proxy-brett | 41 | 55 | 41 |
-| 29 | oauth2-proxy-comfy | 41 | 55 | 41 |
-| 30 | oauth2-proxy-docs | 41 | 55 | 41 |
-| 31 | oauth2-proxy-mailpit | 41 | 55 | 41 |
-| 32 | oauth2-proxy-mediaviewer | 41 | 55 | 41 |
-| 33 | oauth2-proxy-traefik | 41 | 55 | 41 |
-| 34 | talk-recording | 41 | 55 | 41 |
-| 35 | videovault | 41 | 55 | 41 |
-| 36 | talk-transcriber | 41 | 55 | 41 |
-| 37 | admin-actions-cleanup | 40 | 55 | 40 |
-| 38 | admin-actions-prune | 40 | 55 | 40 |
-| 39 | db-backup | 40 | 55 | 40 |
-| 40 | billing-dunning-detection | 40 | 55 | 40 |
-| 41 | monthly-billing | 40 | 55 | 40 |
-| 42 | scheduled-publish | 40 | 55 | 40 |
-| 43 | knowledge-ingest-prs | 40 | 55 | 40 |
-| 44 | knowledge-ingest-bugs | 40 | 55 | 40 |
-| 45 | knowledge-reindex-all | 40 | 55 | 40 |
-| 46 | livekit-ingress | 40 | 55 | 40 |
-| 47 | livekit-egress | 40 | 55 | 40 |
-| 48 | notify-unread | 40 | 55 | 40 |
-| 49 | studio-server | 40 | 55 | 40 |
-| 50 | dev-db-refresh | 40 | 55 | 40 |
-| 51 | ddns-updater | 40 | 55 | 40 |
-| 52 | website | 23 | 55 | 23 |
-| 53 | traefik | 7 | 55 | 7 |
-| 54 | livekit | 6 | 55 | 6 |
-| 55 | shared-db-dev | 4 | 55 | 4 |
-| 56 | systemtest-cleanup | 3 | 55 | 3 |
-| 57 | systemtest-purge-all | 3 | 55 | 3 |
-| 58 | systemtest-outbox | 3 | 55 | 3 |
-| 59 | claude-code-mcp-monolith | 2 | 55 | 2 |
-| 60 | shared-db-staging | 2 | 55 | 2 |
-| 61 | monitoring-grafana | 1 | 55 | 1 |
-| 62 | api@internal | 1 | 55 | 1 |
-| 63 | old-webspace | 1 | 55 | 1 |
-| 64 | bachelorprojekt | 1 | 55 | 1 |
-| 65 | tracking | 1 | 55 | 1 |
-| 66 | docuseal | 1 | 55 | 1 |
-| 67 | loki | 3 | 3 | 3 |
-| 68 | mcp-browser | 1 | 1 | 1 |
-| 69 | mcp-auth-proxy-dev | 1 | 1 | 1 |
-| 70 | docs | 1 | 1 | 1 |
-| 71 | einvoice-sidecar | 1 | 1 | 1 |
-| 72 | mediaviewer-widget | 1 | 1 | 1 |
-| 73 | monitoring-kube-state-metrics | 1 | 1 | 1 |
-| 74 | monitoring-operator | 1 | 1 | 1 |
-| 75 | nextcloud-redis | 1 | 1 | 1 |
-| 76 | sealed-secrets-controller | 1 | 1 | 1 |
-| 77 | whisper | 1 | 1 | 1 |
+| 5 | mentolder-web | 2 | 56 | 2 |
+| 6 | otel-collector | 2 | 56 | 2 |
+| 7 | ntfy | 2 | 56 | 2 |
+| 8 | collabora | 2 | 56 | 2 |
+| 9 | recovery-browser | 2 | 56 | 2 |
+| 10 | sessions-server | 2 | 56 | 2 |
+| 11 | nats | 2 | 56 | 2 |
+| 12 | brett | 43 | 55 | 43 |
+| 13 | keycloak | 43 | 55 | 43 |
+| 14 | nextcloud | 43 | 55 | 43 |
+| 15 | oauth2-proxy-brainstorm | 42 | 55 | 42 |
+| 16 | oauth2-proxy-dev | 42 | 55 | 42 |
+| 17 | oauth2-proxy-session-hub | 42 | 55 | 42 |
+| 18 | livekit-server | 42 | 55 | 42 |
+| 19 | oauth2-proxy-studio | 42 | 55 | 42 |
+| 20 | oauth2-proxy-videovault | 42 | 55 | 42 |
+| 21 | oauth2-proxy-recovery | 42 | 55 | 42 |
+| 22 | shared-db | 42 | 55 | 42 |
+| 23 | spreed-signaling | 42 | 55 | 42 |
+| 24 | vaultwarden | 42 | 55 | 42 |
+| 25 | whiteboard | 42 | 55 | 42 |
+| 26 | arena-server | 42 | 55 | 42 |
+| 27 | mcp-github | 41 | 55 | 41 |
+| 28 | claude-code-mcp-ops | 41 | 55 | 41 |
+| 29 | oauth2-proxy-brett | 41 | 55 | 41 |
+| 30 | oauth2-proxy-comfy | 41 | 55 | 41 |
+| 31 | oauth2-proxy-docs | 41 | 55 | 41 |
+| 32 | oauth2-proxy-mailpit | 41 | 55 | 41 |
+| 33 | oauth2-proxy-mediaviewer | 41 | 55 | 41 |
+| 34 | oauth2-proxy-traefik | 41 | 55 | 41 |
+| 35 | talk-recording | 41 | 55 | 41 |
+| 36 | videovault | 41 | 55 | 41 |
+| 37 | talk-transcriber | 41 | 55 | 41 |
+| 38 | admin-actions-cleanup | 40 | 55 | 40 |
+| 39 | admin-actions-prune | 40 | 55 | 40 |
+| 40 | db-backup | 40 | 55 | 40 |
+| 41 | billing-dunning-detection | 40 | 55 | 40 |
+| 42 | monthly-billing | 40 | 55 | 40 |
+| 43 | scheduled-publish | 40 | 55 | 40 |
+| 44 | knowledge-ingest-prs | 40 | 55 | 40 |
+| 45 | knowledge-ingest-bugs | 40 | 55 | 40 |
+| 46 | knowledge-reindex-all | 40 | 55 | 40 |
+| 47 | livekit-ingress | 40 | 55 | 40 |
+| 48 | livekit-egress | 40 | 55 | 40 |
+| 49 | notify-unread | 40 | 55 | 40 |
+| 50 | studio-server | 40 | 55 | 40 |
+| 51 | dev-db-refresh | 40 | 55 | 40 |
+| 52 | ddns-updater | 40 | 55 | 40 |
+| 53 | website | 23 | 55 | 23 |
+| 54 | traefik | 7 | 55 | 7 |
+| 55 | livekit | 6 | 55 | 6 |
+| 56 | shared-db-dev | 4 | 55 | 4 |
+| 57 | systemtest-cleanup | 3 | 55 | 3 |
+| 58 | systemtest-purge-all | 3 | 55 | 3 |
+| 59 | systemtest-outbox | 3 | 55 | 3 |
+| 60 | claude-code-mcp-monolith | 2 | 55 | 2 |
+| 61 | shared-db-staging | 2 | 55 | 2 |
+| 62 | monitoring-grafana | 1 | 55 | 1 |
+| 63 | api@internal | 1 | 55 | 1 |
+| 64 | old-webspace | 1 | 55 | 1 |
+| 65 | bachelorprojekt | 1 | 55 | 1 |
+| 66 | tracking | 1 | 55 | 1 |
+| 67 | docuseal | 1 | 55 | 1 |
+| 68 | loki | 3 | 3 | 3 |
+| 69 | mcp-browser | 1 | 1 | 1 |
+| 70 | mcp-auth-proxy-dev | 1 | 1 | 1 |
+| 71 | docs | 1 | 1 | 1 |
+| 72 | einvoice-sidecar | 1 | 1 | 1 |
+| 73 | mediaviewer-widget | 1 | 1 | 1 |
+| 74 | monitoring-kube-state-metrics | 1 | 1 | 1 |
+| 75 | monitoring-operator | 1 | 1 | 1 |
+| 76 | nextcloud-redis | 1 | 1 | 1 |
+| 77 | sealed-secrets-controller | 1 | 1 | 1 |
+| 78 | whisper | 1 | 1 | 1 |
 
 ## Details
 
@@ -104,6 +105,11 @@
 ### sish
 **Direkte Abhängige:** 2 — sish, traefik
 **Transitive Abhängige:** 56 — admin-actions-cleanup, admin-actions-prune, arena-server, billing-dunning-detection, brett, claude-code-mcp-monolith, claude-code-mcp-ops, db-backup, ddns-updater, dev-db-refresh, keycloak, knowledge-ingest-bugs, knowledge-ingest-markdown, knowledge-ingest-prs, knowledge-reindex-all, livekit-egress, livekit-ingress, livekit-server, mcp-auth-proxy-dev, mcp-github, monitoring-grafana, monthly-billing, nextcloud, notify-unread, oauth2-proxy-brainstorm, oauth2-proxy-brett, oauth2-proxy-comfy, oauth2-proxy-dev, oauth2-proxy-docs, oauth2-proxy-mailpit, oauth2-proxy-mediaviewer, oauth2-proxy-recovery, oauth2-proxy-session-hub, oauth2-proxy-studio, oauth2-proxy-traefik, oauth2-proxy-videovault, pvc-backup, scheduled-publish, shared-db, shared-db-dev, shared-db-dev-lb, shared-db-staging, sish, spreed-signaling, studio-server, systemtest-cleanup, systemtest-outbox, systemtest-purge-all, talk-recording, talk-transcriber, tests-results-retention, traefik, vaultwarden, videovault, website, whiteboard
+**Upstream (In-Degree):** 2
+
+### mentolder-web
+**Direkte Abhängige:** 2 — mentolder-web, traefik
+**Transitive Abhängige:** 56 — admin-actions-cleanup, admin-actions-prune, arena-server, billing-dunning-detection, brett, claude-code-mcp-monolith, claude-code-mcp-ops, db-backup, ddns-updater, dev-db-refresh, keycloak, knowledge-ingest-bugs, knowledge-ingest-markdown, knowledge-ingest-prs, knowledge-reindex-all, livekit-egress, livekit-ingress, livekit-server, mcp-auth-proxy-dev, mcp-github, mentolder-web, monitoring-grafana, monthly-billing, nextcloud, notify-unread, oauth2-proxy-brainstorm, oauth2-proxy-brett, oauth2-proxy-comfy, oauth2-proxy-dev, oauth2-proxy-docs, oauth2-proxy-mailpit, oauth2-proxy-mediaviewer, oauth2-proxy-recovery, oauth2-proxy-session-hub, oauth2-proxy-studio, oauth2-proxy-traefik, oauth2-proxy-videovault, pvc-backup, scheduled-publish, shared-db, shared-db-dev, shared-db-dev-lb, shared-db-staging, spreed-signaling, studio-server, systemtest-cleanup, systemtest-outbox, systemtest-purge-all, talk-recording, talk-transcriber, tests-results-retention, traefik, vaultwarden, videovault, website, whiteboard
 **Upstream (In-Degree):** 2
 
 ### otel-collector

--- a/docs/generated/graph.json
+++ b/docs/generated/graph.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-20T16:50:11.234Z",
+  "generatedAt": "2026-06-21T05:05:40.655Z",
   "nodes": [
     {
       "id": "admin-actions-cleanup",
@@ -216,6 +216,12 @@
       "namespace": "mentolder",
       "type": "Deployment",
       "name": "mediaviewer-widget"
+    },
+    {
+      "id": "mentolder-web",
+      "namespace": "mentolder",
+      "type": "Deployment",
+      "name": "mentolder-web"
     },
     {
       "id": "monitoring-grafana",
@@ -1313,6 +1319,12 @@
     },
     {
       "from": "traefik",
+      "to": "mentolder-web",
+      "via": "ingress",
+      "kind": "ingress"
+    },
+    {
+      "from": "traefik",
       "to": "oauth2-proxy-docs",
       "via": "ingress",
       "kind": "ingress"
@@ -1536,6 +1548,12 @@
     {
       "from": "mediaviewer-widget",
       "to": "mediaviewer-widget",
+      "via": "selector",
+      "kind": "selector"
+    },
+    {
+      "from": "mentolder-web",
+      "to": "mentolder-web",
       "via": "selector",
       "kind": "selector"
     },

--- a/k3d/docs-content-built/architecture/index.html
+++ b/k3d/docs-content-built/architecture/index.html
@@ -178,16 +178,16 @@
 <body>
   <div class="header">
     <h1>⬡ Architektur — Living Docs</h1>
-    <span class="meta">Generiert: 2026-06-20T19:24:35.783Z</span>
+    <span class="meta">Generiert: 2026-06-21T05:05:40.777Z</span>
   </div>
 
   <div class="stats">
     <div class="stat">
-      <span class="stat-value">86</span>
+      <span class="stat-value">87</span>
       <span class="stat-label">Services</span>
     </div>
     <div class="stat">
-      <span class="stat-value">1860</span>
+      <span class="stat-value">1862</span>
       <span class="stat-label">Abhängigkeiten</span>
     </div>
     <div class="stat">
@@ -248,6 +248,7 @@ flowchart LR
   livekit_egress["livekit-egress"]:::default
   mailpit["mailpit"]:::default
   mediaviewer_widget["mediaviewer-widget"]:::default
+  mentolder_web["mentolder-web"]:::default
   monitoring_grafana["monitoring-grafana"]:::default
   monitoring_kube_state_metrics["monitoring-kube-state-metrics"]:::default
   monitoring_operator["monitoring-operator"]:::default
@@ -411,6 +412,7 @@ flowchart LR
   traefik -->|"ingress"| whiteboard
   traefik -->|"ingress"| spreed_signaling
   traefik -->|"ingress"| vaultwarden
+  traefik -->|"ingress"| mentolder_web
   traefik -->|"ingress"| oauth2_proxy_docs
   traefik -->|"ingress"| oauth2_proxy_brett
   traefik -->|"ingress"| oauth2_proxy_comfy
@@ -449,6 +451,7 @@ flowchart LR
   einvoice_sidecar -->|"selector"| einvoice_sidecar
   mailpit -->|"selector"| mailpit
   mediaviewer_widget -->|"selector"| mediaviewer_widget
+  mentolder_web -->|"selector"| mentolder_web
   monitoring_kube_state_metrics -->|"selector"| monitoring_kube_state_metrics
   monitoring_operator -->|"selector"| monitoring_operator
   loki_memberlist -->|"selector"| loki
@@ -2082,7 +2085,7 @@ flowchart LR
   website -->|"secret:staging-db-…"| shared_db_staging
       </div>
     </div>
-    <p class="diagram-caption">Alle 86 K8s-Services und ihre 1860 Abhängigkeitskanten (env-Refs, initContainer-Waits, Ingress-Backends)</p>
+    <p class="diagram-caption">Alle 87 K8s-Services und ihre 1862 Abhängigkeitskanten (env-Refs, initContainer-Waits, Ingress-Backends)</p>
   </div>
 
   <!-- K8s Topology Tab -->
@@ -2122,6 +2125,7 @@ flowchart TB
     livekit_egress["livekit-egress"]
     mailpit["mailpit"]
     mediaviewer_widget["mediaviewer-widget"]
+    mentolder_web["mentolder-web"]
     nextcloud_redis["nextcloud-redis"]
     nextcloud["nextcloud"]
     notify_unread(["notify-unread"])

--- a/k3d/ingress.yaml
+++ b/k3d/ingress.yaml
@@ -74,6 +74,16 @@ spec:
                 name: vaultwarden
                 port:
                   number: 80
+    - host: react.localhost
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: mentolder-web
+                port:
+                  number: 80
 ---
 
 # ─── Interne Tools (Docs, Brett — oauth2-proxy-protected) ────────

--- a/k3d/kustomization.yaml
+++ b/k3d/kustomization.yaml
@@ -55,6 +55,8 @@ resources:
   - livekit.yaml
   # Systemisches Brett
   - brett.yaml
+  # mentolder.de React-Site (react.mentolder.de / react.localhost)
+  - mentolder-web.yaml
   # Mediaviewer Widget
   - mediaviewer-widget.yaml
   # Agent-Push ntfy-Server (T000991)

--- a/k3d/mentolder-web.yaml
+++ b/k3d/mentolder-web.yaml
@@ -1,0 +1,59 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mentolder-web
+  labels:
+    app: mentolder-web
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mentolder-web
+  template:
+    metadata:
+      labels:
+        app: mentolder-web
+    spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      imagePullSecrets:
+        - name: ghcr-pull-secret
+      nodeSelector:
+        kubernetes.io/arch: amd64
+      containers:
+        - name: mentolder-web
+          image: ghcr.io/paddione/mentolder-web:latest
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: [ALL]
+              add: [NET_BIND_SERVICE, CHOWN, SETUID, SETGID]
+          ports:
+            - containerPort: 80
+          readinessProbe:
+            httpGet: { path: /, port: 80 }
+            initialDelaySeconds: 3
+            periodSeconds: 10
+          livenessProbe:
+            httpGet: { path: /, port: 80 }
+            initialDelaySeconds: 5
+            periodSeconds: 30
+          resources:
+            requests: { cpu: 10m, memory: 32Mi }
+            limits: { cpu: 100m, memory: 64Mi }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mentolder-web
+  labels:
+    app: mentolder-web
+spec:
+  selector:
+    app: mentolder-web
+  ports:
+    - name: http
+      port: 80
+      targetPort: 80

--- a/mentolder-web/Dockerfile
+++ b/mentolder-web/Dockerfile
@@ -1,0 +1,26 @@
+# ── Build stage ───────────────────────────────────────────────────
+FROM node:22-alpine AS build
+WORKDIR /app
+
+RUN corepack enable && corepack prepare pnpm@latest --activate
+
+COPY mentolder-web/package.json mentolder-web/pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile
+
+COPY mentolder-web/ .
+
+# VITE_* vars are baked into the JS bundle at build time.
+# Pass VITE_FORMSPREE_ENDPOINT via --build-arg (GitHub Actions secret).
+# When empty, ContactForm falls back to a mailto: link.
+ARG VITE_FORMSPREE_ENDPOINT=""
+ENV VITE_FORMSPREE_ENDPOINT=${VITE_FORMSPREE_ENDPOINT}
+
+RUN pnpm run build
+
+# ── Runtime stage ─────────────────────────────────────────────────
+FROM nginx:1.27-alpine AS runtime
+
+COPY mentolder-web/nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=build /app/dist /usr/share/nginx/html
+
+EXPOSE 80

--- a/mentolder-web/nginx.conf
+++ b/mentolder-web/nginx.conf
@@ -1,0 +1,22 @@
+server {
+    listen 80;
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # SPA routing — unknown paths → index.html (React Router handles them)
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # Cache static assets aggressively (content-hashed by Vite)
+    location ~* \.(js|css|woff2?|ttf|svg|png|jpg|webp|ico)$ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+
+    # No-cache for index.html so new deploys take effect immediately
+    location = /index.html {
+        add_header Cache-Control "no-cache, no-store, must-revalidate";
+    }
+}

--- a/prod/ingress.yaml
+++ b/prod/ingress.yaml
@@ -267,6 +267,30 @@ spec:
                 port:
                   number: 4180
 ---
+# ── mentolder React-Site (react.PROD_DOMAIN) — öffentlich ─────
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: workspace-ingress-mentolder-web
+  annotations:
+    traefik.ingress.kubernetes.io/router.middlewares: "${WORKSPACE_NAMESPACE}-redirect-https@kubernetescrd,${WORKSPACE_NAMESPACE}-hsts-headers@kubernetescrd,${WORKSPACE_NAMESPACE}-security-headers@kubernetescrd"
+spec:
+  tls:
+    - hosts:
+        - react.${PROD_DOMAIN}
+      secretName: ${TLS_SECRET_NAME}
+  rules:
+    - host: react.${PROD_DOMAIN}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: mentolder-web
+                port:
+                  number: 80
+---
 # ── VideoVault — SSO via oauth2-proxy ──────────────────────────
 apiVersion: networking.k8s.io/v1
 kind: Ingress


### PR DESCRIPTION
## Summary

- **Dockerfile** für `mentolder-web/`: Multi-stage Build (pnpm + nginx:alpine), `VITE_FORMSPREE_ENDPOINT` als Build-ARG gebacken
- **nginx.conf**: SPA-Routing (`try_files`), Caching für Vite-Content-Hashed-Assets
- **k3d/mentolder-web.yaml**: Deployment + Service im `workspace`-Namespace
- **k3d/ingress.yaml**: Dev-Route `react.localhost`
- **prod/ingress.yaml**: Prod-Ingress `react.mentolder.de` mit Wildcard-TLS (`*.mentolder.de`)
- **k3d/kustomization.yaml**: neues Manifest registriert
- **.github/workflows/build-mentolder-web.yml**: CI baut Image + rollt auf Fleet aus; Formspree-Endpoint via GitHub-Secret `MENTOLDER_WEB_FORMSPREE_ENDPOINT`

## Formspree einrichten (nach Merge)

1. Account unter [formspree.io](https://formspree.io) anlegen → neues Formular erstellen
2. Form-ID kopieren (Format: `https://formspree.io/f/XXXXXXXX`)
3. GitHub → Repository Settings → Secrets → `MENTOLDER_WEB_FORMSPREE_ENDPOINT` = `https://formspree.io/f/XXXXXXXX`
4. Workflow manuell triggern (oder nächsten Push auf `mentolder-web/**`) → das Build bäckt die ID in das Bundle

Ohne gesetztes Secret greift der mailto-Fallback automatisch.

## Deploy nach Merge

```bash
task workspace:deploy ENV=mentolder
```

## Test plan

- [ ] `react.localhost` zeigt die React-Site in k3d
- [ ] `task workspace:validate` ✅
- [ ] `task freshness:check` ✅
- [ ] Nach Merge: `build-mentolder-web` Workflow läuft grün durch
- [ ] `react.mentolder.de` zeigt die Site nach `task workspace:deploy ENV=mentolder`
- [ ] Kontaktformular sendet via Formspree (nach Setzen des Secrets)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018bmDUWy4j62r6mLF226dpp