### PR TITLE
fix(mentolder-web): allow esbuild build script for pnpm 10

### DIFF
--- a/mentolder-web/package.json
+++ b/mentolder-web/package.json
@@ -32,5 +32,8 @@
   },
   "engines": {
     "node": ">=20"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": ["esbuild"]
   }
 }


### PR DESCRIPTION
pnpm 10 blockiert Postinstall-Scripts standardmäßig (`ERR_PNPM_IGNORED_BUILDS`). Fix: `onlyBuiltDependencies: ["esbuild"]` in `package.json` — erlaubt esbuild sein Platform-Binary zu installieren.