### PR TITLE
fix(mentolder-web): move esbuild allowance to .npmrc

### DIFF
--- a/mentolder-web/.npmrc
+++ b/mentolder-web/.npmrc
@@ -1,0 +1,1 @@
+onlyBuiltDependencies[]=esbuild


### PR DESCRIPTION
## Summary
- `pnpm 10+` ignoriert das `pnpm`-Feld in `package.json` — die Warnung `The 'pnpm' field in package.json is no longer read by pnpm` bestätigt es
- Fix: `onlyBuiltDependencies[]=esbuild` in `mentolder-web/.npmrc` statt `package.json`
- Löst `ERR_PNPM_IGNORED_BUILDS: esbuild@0.25.12` im Docker Build

## Test plan
- [ ] CI `Build & Deploy mentolder-web` läuft durch
- [ ] `ghcr.io/paddione/mentolder-web:latest` wird gepusht
- [ ] Pod auf fleet startet; `react.mentolder.de` erreichbar

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018bmDUWy4j62r6mLF226dpp