### PR TITLE
chore(plans): archive feature-intake-knowledge-search [T001025]

### DIFF
--- a/openspec/changes/feature-intake-knowledge-search/tasks.md
+++ b/openspec/changes/feature-intake-knowledge-search/tasks.md
@@ -2,7 +2,7 @@
 title: "Feature Intake: Semantischer Duplikatcheck + dynamischer Feature-Pool"
 ticket_id: T000978
 domains: [ai/factory]
-status: plan_staged
+status: completed
 file_locks: []
 shared_changes: false
 batch_id: null


### PR DESCRIPTION
Marks the OpenSpec plan as completed (PR #1995 merged). Plan content was already archived to `tickets.ticket_plans` via `scripts/ticket.sh archive-plan`. No code changes.