### PR TITLE
fix(mentolder-web): copy .npmrc before pnpm install in Dockerfile

### DIFF
--- a/mentolder-web/Dockerfile
+++ b/mentolder-web/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 
 RUN corepack enable && corepack prepare pnpm@latest --activate
 
-COPY mentolder-web/package.json mentolder-web/pnpm-lock.yaml ./
+COPY mentolder-web/package.json mentolder-web/pnpm-lock.yaml mentolder-web/.npmrc ./
 RUN pnpm install --frozen-lockfile
 
 COPY mentolder-web/ .


### PR DESCRIPTION
## Summary
- `.npmrc` (containing `onlyBuiltDependencies[]=esbuild`) was copied **after** `pnpm install` due to Docker layer ordering
- pnpm v10+ checks `onlyBuiltDependencies` at install time → `ERR_PNPM_IGNORED_BUILDS esbuild@0.25.12` → build fails
- Fix: add `.npmrc` to the initial COPY line, before `pnpm install --frozen-lockfile`

## Test plan
- [ ] CI `build-mentolder-web.yml` passes (Docker build succeeds)
- [ ] `react.mentolder.de` shows the React site (Deployment already applied to fleet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01HxZMDa6vNXZAYyZiMKJENH