### PR TITLE
fix(mentolder-web): also copy pnpm-workspace.yaml before pnpm install

### DIFF
--- a/mentolder-web/Dockerfile
+++ b/mentolder-web/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 
 RUN corepack enable && corepack prepare pnpm@latest --activate
 
-COPY mentolder-web/package.json mentolder-web/pnpm-lock.yaml mentolder-web/.npmrc ./
+COPY mentolder-web/package.json mentolder-web/pnpm-lock.yaml mentolder-web/.npmrc mentolder-web/pnpm-workspace.yaml ./
 RUN pnpm install --frozen-lockfile
 
 COPY mentolder-web/ .


### PR DESCRIPTION
## Summary
- `pnpm-workspace.yaml` (containing `allowBuilds: esbuild: true`) was copied **after** `pnpm install` — same Docker layer-ordering problem as `.npmrc`
- pnpm v10 reads `allowBuilds` from `pnpm-workspace.yaml` at install time → esbuild still blocked
- Fix: add `pnpm-workspace.yaml` to the early `COPY` line, alongside `package.json`, `pnpm-lock.yaml`, und `.npmrc`

Follows up on #1997 which fixed `.npmrc` but missed `pnpm-workspace.yaml`.

## Test plan
- [ ] CI `build-mentolder-web.yml` passes (Docker build + push succeeds)
- [ ] Pod `mentolder-web` kommt auf fleet als Running hoch
- [ ] `https://react.mentolder.de` liefert die React-Site aus

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01HxZMDa6vNXZAYyZiMKJENH