### PR TITLE
fix(mentolder-web): pin pnpm@10 and simplify Dockerfile

### DIFF
--- a/mentolder-web/Dockerfile
+++ b/mentolder-web/Dockerfile
@@ -2,10 +2,7 @@
 FROM node:22-alpine AS build
 WORKDIR /app
 
-RUN corepack enable && corepack prepare pnpm@latest --activate
-
-COPY mentolder-web/package.json mentolder-web/pnpm-lock.yaml mentolder-web/.npmrc mentolder-web/pnpm-workspace.yaml ./
-RUN pnpm install --frozen-lockfile
+RUN corepack enable && corepack prepare pnpm@10 --activate
 
 COPY mentolder-web/ .
 
@@ -15,7 +12,7 @@ COPY mentolder-web/ .
 ARG VITE_FORMSPREE_ENDPOINT=""
 ENV VITE_FORMSPREE_ENDPOINT=${VITE_FORMSPREE_ENDPOINT}
 
-RUN pnpm run build
+RUN pnpm install --frozen-lockfile && pnpm run build
 
 # ── Runtime stage ─────────────────────────────────────────────────
 FROM nginx:1.27-alpine AS runtime


### PR DESCRIPTION
## Summary
- pnpm@latest resolved to v11.8.0 which throws `ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY` in non-TTY Docker builds when it tries to remove node_modules (triggered by the two-step COPY overwriting workspace files)
- lockfileVersion 9.0 targets pnpm 9/10 — pin to `pnpm@10` for compatibility
- Simplified Dockerfile: copy everything first, then `pnpm install --frozen-lockfile && pnpm run build` in one step — eliminates all layer-ordering issues with `.npmrc` / `pnpm-workspace.yaml`

Follows up on #1997 and #1999.

## Test plan
- [ ] CI `build-mentolder-web.yml` passes
- [ ] Pod `mentolder-web` läuft auf fleet
- [ ] `https://react.mentolder.de` zeigt die React-Site

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01HxZMDa6vNXZAYyZiMKJENH