### PR TITLE
fix(mentolder-web): exclude node_modules from Docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 # Exclude large directories not needed for Docker build
 website/node_modules
+mentolder-web/node_modules
 website/dist
 website/.env
 website/.env.*


### PR DESCRIPTION
## Root cause
CI workflow runs `pnpm install` in `mentolder-web/` for the typecheck step **before** the Docker build. This creates `mentolder-web/node_modules/`, which then gets copied into the image via `COPY mentolder-web/ .`.

When the Dockerfile's `pnpm install --frozen-lockfile` runs, pnpm finds an existing `node_modules` directory and tries to remove it — but aborts because there's no TTY (`ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY`).

## Fix
Add `mentolder-web/node_modules` to `.dockerignore` (mirrors the existing `website/node_modules` entry).

## Test plan
- [ ] CI `build-mentolder-web.yml` passes (Docker build + push succeeds)
- [ ] Pod `mentolder-web` kommt als Running hoch
- [ ] `https://react.mentolder.de` liefert die React-Site

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01HxZMDa6vNXZAYyZiMKJENH