### PR TITLE
chore(factory): Kontextlimit fuer list_tickets/export_tickets (Default 200, max 1000)

### DIFF
--- a/scripts/ticket-mcp/tools/list.js
+++ b/scripts/ticket-mcp/tools/list.js
@@ -4,16 +4,17 @@ import { runTicket } from '../lib/run-ticket.js';
 export function registerListTools(server) {
   server.tool(
     'list_tickets',
-    'Listet Tickets gefiltert nach Status, Typ, Brand oder fehlender ID.',
+    'Listet Tickets gefiltert nach Status, Typ, Brand oder fehlender ID. Standard-Limit 200 Zeilen; mit --limit erhöhbar (max 1000).',
     {
       brand: z.string().optional().describe('mentolder oder korczewski (default: mentolder)'),
       status: z.string().optional().describe('z.B. triage, planning, plan_staged, backlog'),
       type: z.string().optional().describe('bug, feature, task, project'),
       attention_mode: z.string().optional().describe('auto, ai_ready, needs_human'),
       missing_id: z.boolean().optional().describe('Nur Tickets ohne external_id zurückgeben'),
+      limit: z.number().int().min(1).max(1000).optional().describe('Maximale Anzahl Ergebnisse (default: 200)'),
     },
-    async ({ brand = 'mentolder', status, type, attention_mode, missing_id }) => {
-      const args = ['list', '--brand', brand];
+    async ({ brand = 'mentolder', status, type, attention_mode, missing_id, limit = 200 }) => {
+      const args = ['list', '--brand', brand, '--limit', String(limit)];
       if (status) args.push('--status', status);
       if (type) args.push('--type', type);
       if (attention_mode) args.push('--attention-mode', attention_mode);
@@ -39,15 +40,16 @@ export function registerListTools(server) {
 
   server.tool(
     'export_tickets',
-    'Exportiert Tickets als JSON oder Markdown (gleiche Filter wie list_tickets).',
+    'Exportiert Tickets als JSON oder Markdown (gleiche Filter wie list_tickets). Default-Limit 200; max 1000. Ohne Filter empfiehlt sich ein Status-Filter, um den Kontextverbrauch gering zu halten.',
     {
       brand: z.string().optional(),
       status: z.string().optional(),
       type: z.string().optional(),
       format: z.enum(['json', 'markdown']).optional().describe('json (default) oder markdown'),
+      limit: z.number().int().min(1).max(1000).optional().describe('Maximale Anzahl Ergebnisse (default: 200)'),
     },
-    async ({ brand = 'mentolder', status, type, format = 'json' }) => {
-      const args = ['list', '--brand', brand];
+    async ({ brand = 'mentolder', status, type, format = 'json', limit = 200 }) => {
+      const args = ['list', '--brand', brand, '--limit', String(limit)];
       if (status) args.push('--status', status);
       if (type) args.push('--type', type);
 

--- a/scripts/vda/ticket/list.sh
+++ b/scripts/vda/ticket/list.sh
@@ -2,7 +2,7 @@
 source "$(dirname "${BASH_SOURCE[0]}")/_ticket-core.sh"
 
 main() {
-  local brand="${BRAND:-mentolder}" status="" type="" attention_mode="" missing_id=false
+  local brand="${BRAND:-mentolder}" status="" type="" attention_mode="" missing_id=false limit=200
 
   while [[ $# -gt 0 ]]; do case "$1" in
     --brand)          brand="$2"; shift 2 ;;
@@ -10,6 +10,7 @@ main() {
     --type)           type="$2"; shift 2 ;;
     --attention-mode) attention_mode="$2"; shift 2 ;;
     --missing-id)     missing_id=true; shift ;;
+    --limit)          limit="$2"; shift 2 ;;
     *)                echo "Unknown list option: $1" >&2; exit 2 ;;
   esac; done
 
@@ -30,14 +31,17 @@ main() {
     -v brand="$brand" \
     -v status="$status" \
     -v type="$type" \
-    -v attn="$attention_mode" <<EOF
-SELECT COALESCE(json_agg(json_build_object(
-  'external_id', external_id, 'title', title, 'status', status,
-  'type', type, 'priority', priority, 'severity', severity,
-  'attention_mode', attention_mode, 'created_at', created_at::date
-) ORDER BY created_at ASC), '[]')
-FROM tickets.tickets
-WHERE $where;
+    -v attn="$attention_mode" \
+    -v lim="$limit" <<EOF
+SELECT COALESCE(json_agg(row ORDER BY row.created_at ASC), '[]')
+FROM (
+  SELECT external_id, title, status, type, priority, severity,
+         attention_mode, created_at::date AS created_at
+  FROM tickets.tickets
+  WHERE $where
+  ORDER BY created_at ASC
+  LIMIT :'lim'::int
+) row;
 EOF
 }
 

--- a/tests/spec/ticket-mcp.bats
+++ b/tests/spec/ticket-mcp.bats
@@ -12,6 +12,12 @@ setup() {
   echo "$output" | grep -q "DRY-RESOLVE"
 }
 
+@test "ticket.sh list accepts --limit flag" {
+  run bash "$REPO/scripts/ticket.sh" list --brand mentolder --limit 50
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "DRY-RESOLVE"
+}
+
 @test "ticket.sh list rejects unknown brand (via BRAND env)" {
   run env BRAND=unknown-brand bash "$REPO/scripts/ticket.sh" list
   [ "$status" -eq 2 ]


### PR DESCRIPTION
## Summary

- `scripts/vda/ticket/list.sh`: Neues `--limit N` Flag (Default 200); SQL-LIMIT direkt in der Query — PostgreSQL überträgt nie mehr als N Zeilen
- `scripts/ticket-mcp/tools/list.js`: `list_tickets` und `export_tickets` erhalten optionalen `limit`-Parameter (Zod: `min(1).max(1000)`, Default 200)
- `tests/spec/ticket-mcp.bats`: Neuer BATS-Test für `--limit`-Flag

## Motivation

Ungefilterte `export_tickets`-Aufrufe auf einem Brand mit 1.000+ Tickets erzeugen ~40.000 Tokens in einem einzelnen Tool-Result. Das ist ca. 8× mehr als ein typischer Triage-Workflow benötigt und kann das Kontextfenster von Agenten-Sessions erschöpfen. Mit Default 200 liegt der Worst-Case bei ~8.000 Tokens; wer mehr braucht, setzt `limit` explizit bis 1000.

## Test plan

- [x] `npx bats tests/spec/ticket-mcp.bats` — alle 4 Tests grün
- [x] `--limit` Flag in `list.sh` angenommen (dry-resolve-Pfad)
- [x] Zod-Validierung in MCP-Tools: `min(1).max(1000)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018bmDUWy4j62r6mLF226dpp