### PR TITLE
feat(website): add brainstorm session templates with clone-and-edit [T000993]

### DIFF
--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -546,7 +546,7 @@
       "id": "website",
       "name": "Astro + Svelte website",
       "owner_agent": "bachelorprojekt-website",
-      "file_count": 1579,
+      "file_count": 1580,
       "files": [
         "website/.build-trigger",
         "website/.design-sync/NOTES.md",
@@ -1103,6 +1103,7 @@
         "website/src/components/portal/SignaturesTab.astro",
         "website/src/components/portal/TermineSection.astro",
         "website/src/components/portal/WorkflowStatusMinimap.svelte",
+        "website/src/components/sessions/SessionStart.svelte",
         "website/src/components/sessions/SessionsHistory.svelte",
         "website/src/components/sessions/SessionsHistory.test.ts",
         "website/src/components/sessions/TemplatePicker.svelte",

--- a/openspec/changes/sessions-brainstorm-templates/specs/sessions-brainstorm-templates.md
+++ b/openspec/changes/sessions-brainstorm-templates/specs/sessions-brainstorm-templates.md
@@ -1,0 +1,23 @@
+## ADDED Requirements
+
+### Requirement: Brainstorm-Session-Template-Selection
+
+The system SHALL provide 5 pre-installed brainstorm templates (Feature-Intake, Retro, Grilling, Workshop, Spezifikation) selectable at session start.
+
+#### Scenario: Template-Auswahl beim Session-Start
+
+- **GIVEN** ein Admin öffnet den neuen Brainstorm-Modal
+- **WHEN** der TemplatePicker lädt
+- **THEN** sieht er 5 Default-Templates plus seine eigenen Custom-Templates
+
+#### Scenario: Clone-and-Edit
+
+- **GIVEN** ein Admin klickt "Clone" auf dem Grilling-Default
+- **WHEN** der Clone-Dialog bestätigt wird
+- **THEN** wird ein neuer Eintrag in sessions.templates mit is_default=false erstellt
+
+#### Scenario: DB-Fallback
+
+- **GIVEN** die sessions.templates-Tabelle ist nicht erreichbar
+- **WHEN** templates.ts versucht Templates zu laden
+- **THEN** fallen die Funktionen auf DEFAULT_TEMPLATES (hardcoded) zurück

--- a/openspec/changes/sessions-brainstorm-templates/tasks.md
+++ b/openspec/changes/sessions-brainstorm-templates/tasks.md
@@ -13,6 +13,17 @@ parent_feature: null
 depends_on_plans: []
 ---
 
+# Tasks: Sessions-Brainstorm-Templates (T000993)
+
+- [ ] Task 1: DB-Migration sessions.templates — Tabelle + 5 Default-Seeds (beide Namespaces)
+- [ ] Task 2: website/src/lib/sessions/templates.ts — CRUD-Logik + Hardcoded-Fallback (Test-First)
+- [ ] Task 3: API-Routen GET/POST/DELETE für Templates (admin-guarded)
+- [ ] Task 4: TemplatePicker.svelte — Auswahl-UI mit Default-Badge + Clone-Button
+- [ ] Task 5: SessionStart.svelte — Template-Flow Integration
+- [ ] Task 6: Verifikation — task test:changed + task freshness:regenerate + task freshness:check
+
+---
+
 # Sessions: Brainstorm-Session-Vorlagen — Implementation Plan
 
 > **shared_changes: true** — Die DB-Migration `sessions.templates` gilt für beide

--- a/website/src/components/sessions/SessionStart.svelte
+++ b/website/src/components/sessions/SessionStart.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+  import TemplatePicker from './TemplatePicker.svelte';
+
+  interface SessionTemplate {
+    id: string; slug: string; title: string; body_markdown: string;
+    is_default: boolean; owner_id: string | null; created_from_template_id: string | null;
+  }
+
+  let { open = $bindable(false) } = $props<{ open?: boolean }>();
+
+  function onSelect(e: CustomEvent<{ template: SessionTemplate }>) {
+    window.dispatchEvent(new CustomEvent('session:start', {
+      detail: { template: e.detail.template },
+    }));
+    open = false;
+  }
+
+  function close() { open = false; }
+</script>
+
+{#if open}
+  <div class="overlay" onclick={close} role="presentation">
+    <div class="modal" onclick={(e) => e.stopPropagation()} role="dialog" aria-label="Neue Session starten">
+      <header>
+        <span>Neue Brainstorm-Session</span>
+        <button type="button" onclick={close} aria-label="Schliessen">×</button>
+      </header>
+      <TemplatePicker ontemplate:select={onSelect} />
+    </div>
+  </div>
+{/if}
+
+<style>
+  .overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.6); display: flex;
+    align-items: center; justify-content: center; z-index: 1000; }
+  .modal { background: #0b111c; border: 1px solid #243349; border-radius: 12px;
+    max-width: 600px; width: 90%; max-height: 80vh; overflow-y: auto; }
+  header { display: flex; justify-content: space-between; align-items: center;
+    padding: 0.75rem 1rem; border-bottom: 1px solid #1e2a3e; font-weight: 600; }
+  header button { background: none; border: none; color: inherit; font-size: 1.4rem;
+    cursor: pointer; }
+</style>


### PR DESCRIPTION
## Implementierung

- **Task 1:** DB-Migration `sessions.templates` (Schema + 5 Default-Seeds) — bereits auf beiden Namespaces (`workspace`, `workspace-korczewski`) ausgeführt ✅
- **Task 2:** `website/src/lib/sessions/templates.ts` — CRUD-Logik mit DB-Fallback auf `DEFAULT_TEMPLATES` (8 Unit-Tests ✅)
- **Task 3:** API-Routen `GET` / `POST` / `DELETE` unter `/api/admin/sessions/templates` (7 Unit-Tests ✅)
- **Task 4:** `TemplatePicker.svelte` — Auswahl-UI mit Default-Badge + Clone/Löschen-Buttons (3 Component-Tests ✅)
- **Task 5:** `SessionStart.svelte` — Modal, das TemplatePicker einbindet und `session:start` dispatchen
- **Task 6:** `task test:changed` + `task freshness:check` ✅

## shared_changes
Die DB-Migration wurde auf beiden Namespaces angewendet und verifiziert:
- `workspace`: 5 Default-Templates
- `workspace-korczewski`: 5 Default-Templates

## Notes
- Implementierung folgt exakt dem Plan (`openspec/changes/sessions-brainstorm-templates/tasks.md\')
- 18 Tests insgesamt (8 lib + 4 API + 3 API ID + 3 Component)