### PR TITLE
fix(coaching): ILIKE-Suche korrigiert (ESCAPE-Fehler → 302/404)

### DIFF
--- a/website/src/lib/coaching-project-db.ts
+++ b/website/src/lib/coaching-project-db.ts
@@ -100,12 +100,8 @@ export async function listProjects(
   let p = 2;
 
   if (opts.q) {
-    const hasSpecial = /[%_\\]/.test(opts.q);
     const pattern = `%${opts.q.replace(/[%_\\]/g, c => `\\${c}`)}%`;
-    const ilike = hasSpecial
-      ? `(p.customer_number ILIKE $${p} ESCAPE '\\\\' OR p.display_alias ILIKE $${p} ESCAPE '\\\\')`
-      : `(p.customer_number ILIKE $${p} OR p.display_alias ILIKE $${p})`;
-    whereParts.push(ilike);
+    whereParts.push(`(p.customer_number ILIKE $${p} OR p.display_alias ILIKE $${p})`);
     params.push(pattern);
     p++;
   }

--- a/website/src/lib/coaching-session-db.test.ts
+++ b/website/src/lib/coaching-session-db.test.ts
@@ -237,15 +237,6 @@ describe('listSessions paginiert', () => {
     expect(found.sessions.every(s => s.title.includes('Coaching'))).toBe(true);
   });
 
-  it('sucht Sessions mit Sonderzeichen im Titel (%, _)', async () => {
-    const brand = 'test-special-brand';
-    await createSession(pool, { brand, title: '100% Sicher', mode: 'live', createdBy: 'c' });
-    await createSession(pool, { brand, title: 'Platz_halter', mode: 'live', createdBy: 'c' });
-    await createSession(pool, { brand, title: 'Normal', mode: 'live', createdBy: 'c' });
-    const found = await listSessions(pool, brand, { q: '100%' });
-    expect(found.total).toBe(1);
-    expect(found.sessions[0]?.title).toBe('100% Sicher');
-  });
 });
 
 describe('updateSessionFields', () => {

--- a/website/src/lib/coaching-session-db.test.ts
+++ b/website/src/lib/coaching-session-db.test.ts
@@ -226,6 +226,26 @@ describe('listSessions paginiert', () => {
     expect(result.total).toBe(3);
     expect(result.sessions).toHaveLength(3);
   });
+
+  it('sucht Sessions per Titel (q-Parameter)', async () => {
+    const brand = 'test-search-brand';
+    await createSession(pool, { brand, title: 'Coaching Alpha', mode: 'live', createdBy: 'c' });
+    await createSession(pool, { brand, title: 'Coaching Beta', mode: 'live', createdBy: 'c' });
+    await createSession(pool, { brand, title: 'Anderes Thema', mode: 'live', createdBy: 'c' });
+    const found = await listSessions(pool, brand, { q: 'Coaching' });
+    expect(found.total).toBe(2);
+    expect(found.sessions.every(s => s.title.includes('Coaching'))).toBe(true);
+  });
+
+  it('sucht Sessions mit Sonderzeichen im Titel (%, _)', async () => {
+    const brand = 'test-special-brand';
+    await createSession(pool, { brand, title: '100% Sicher', mode: 'live', createdBy: 'c' });
+    await createSession(pool, { brand, title: 'Platz_halter', mode: 'live', createdBy: 'c' });
+    await createSession(pool, { brand, title: 'Normal', mode: 'live', createdBy: 'c' });
+    const found = await listSessions(pool, brand, { q: '100%' });
+    expect(found.total).toBe(1);
+    expect(found.sessions[0]?.title).toBe('100% Sicher');
+  });
 });
 
 describe('updateSessionFields', () => {

--- a/website/src/lib/coaching-session-db.ts
+++ b/website/src/lib/coaching-session-db.ts
@@ -174,7 +174,7 @@ export async function listSessions(
     whereParts.push(`s.archived_at IS NULL`);
   }
   if (searchPattern) {
-    whereParts.push(`(s.title ILIKE $${p} ESCAPE '\\\\' OR s.client_name ILIKE $${p} ESCAPE '\\\\')`);
+    whereParts.push(`(s.title ILIKE $${p} OR s.client_name ILIKE $${p})`);
     baseParams.push(searchPattern);
     p++;
   }


### PR DESCRIPTION
## Summary

- **Bug:** Suche in Coaching-Sessions und -Projekten lieferte immer eine 302→/404-Weiterleitung statt Ergebnissen
- **Ursache:** `ESCAPE '\\\\'` in JS-Template erzeugt im SQL `ESCAPE '\\'` — mit PostgreSQL-Standard `standard_conforming_strings=on` ist das ein **zwei-Zeichen-String**; `ESCAPE` erwartet aber exakt ein Zeichen → unbehandelte DB-Exception → Astro leitet auf `/404` um
- **Fix:** `ESCAPE`-Klausel in beiden Dateien entfernt; Sonderzeichen (`%`, `_`, `\`) werden bereits clientseitig escaped, PostgreSQL-Default-Escape `\` greift korrekt
- **Tests:** Zwei neue Testfälle für `listSessions` mit `q`-Parameter (normaler Text + Sonderzeichen)

## Betroffene Dateien

- `website/src/lib/coaching-session-db.ts` — `listSessions` ILIKE-Fix
- `website/src/lib/coaching-project-db.ts` — `listProjects` ILIKE-Fix  
- `website/src/lib/coaching-session-db.test.ts` — Suche-Testfälle ergänzt

## Test plan

- [ ] CI (Vitest) grün — neue Tests decken Suche mit normalem Text und Sonderzeichen ab
- [ ] Nach Merge: `https://web.mentolder.de/admin/coaching/sessions` → Suche nach „FA-54 Meta" liefert Ergebnisse statt Lade-Spinner

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QmUvAVbhUMCTEtJqhL5tf3