### PR TITLE
chore(mcp): mishap-tracker + ticket-mcp synergy [T001046]

### DIFF
--- a/.claude/skills/mishap-tracker/SKILL.md
+++ b/.claude/skills/mishap-tracker/SKILL.md
@@ -6,31 +6,9 @@ agent: bachelorprojekt-ops
 
 # mishap-tracker
 
-Batches all execution mishaps into **one aggregate ticket** rather than creating N individual tickets. If an open "Mishap collection" ticket already exists, new mishaps are appended to it. Otherwise a new collection is created.
+Batches all execution mishaps into **one aggregate ticket** rather than creating N individual tickets.
 
 Called as the final step of runbook skills that maintain a `MISHAP_LOG`.
-
-## Mishap melden (via ticket-mcp)
-
-Statt direkt ein Ticket zu erstellen, nutze das `report_mishap` MCP-Tool.
-Der Buffer sammelt Mishaps — bei 3 Einträgen wird automatisch ein Bundle-Ticket
-mit `attention_mode: ai_ready` angelegt das im nächsten Factory-Tick verarbeitet wird.
-
-Für jeden Mishap im MISHAP_LOG aufrufen:
-
-```
-mcp__ticket-mcp__report_mishap({
-  title: "<titel>",
-  description: "<beschreibung>",
-  component: "<komponente>",
-  type: "<broken|degraded|suspicious|security|drift>",
-  brand: "<brand>"
-})
-```
-
-**Rückmeldung auswerten:**
-- "2/3 bis zum automatischen Bundle-Ticket" → weitere Mishaps sammeln
-- "Bundle-Ticket angelegt: T000xxx" → Ticket existiert, Factory-Tick übernimmt
 
 ---
 
@@ -42,208 +20,91 @@ The calling skill accumulates a `MISHAP_LOG` — a list of entries, each with:
 - `description`: What was observed and why it matters
 - `component`: Affected subsystem (e.g., `kubeconfig`, `repo/chore/…`, `skills/<name>`)
 
-Calling skill **must** export `SKILL_NAME` (e.g. `SKILL_NAME=operations-management`) for batch labeling.
-
-If the log is empty or no mishaps were found, report that and stop — nothing to track.
+If the log is empty, report that and stop — nothing to track.
 
 ---
 
 ## Step 0: Verify Before Creating (False-Positive Guard)
 
-Before including any mishap, verify the claim with a concrete check:
+Before reporting any mishap, verify the claim with a concrete check:
 
 | Mishap type | Required verification |
 |---|---|
 | `broken` (import cycle) | `grep -r 'import.*<file>' <target>` to confirm the cycle actually exists |
-| `broken` (file missing/stale) | `ls` or `git show HEAD:<file>` to confirm the file is actually absent or stale |
+| `broken` (file missing/stale) | `ls` or `git show HEAD:<file>` to confirm absence |
 | `drift` (version mismatch) | Check current value via kubectl/grep before asserting drift |
-| `suspicious` (unexpected state) | Run the command that would reveal the state and confirm it |
-| `process` | These are observations, not assertions — no verification needed |
-| `security` | These are always created without suppression |
+| `suspicious` (unexpected state) | Run the command that reveals the state and confirm it |
+| `process` | Observations, not assertions — no verification needed |
+| `security` | Always report without suppression |
 
-**If verification contradicts the observation:** drop the mishap entry and log `[mishap-tracker] SKIP <title> — verified false positive: <reason>`.
+**If verification contradicts the observation:** drop the mishap and log `[mishap-tracker] SKIP <title> — verified false positive: <reason>`.
 
-**If verification is not feasible in context** (e.g. no cluster access): include the mishap but add `[UNVERIFIED — <reason>]` to its description.
-
----
-
-## Step 1: Individual Mishap Classification
-
-Each mishap type maps to its own triage values — these are used in the per-mishap listing within the aggregate:
-
-| Mishap type | maps-to type | Severity | Priority | Attention mode |
-|---|---|---|---|---|
-| `broken` | `bug` | `major` | `hoch` | `needs_human` |
-| `security` | `bug` | `critical` | `hoch` | `needs_human` |
-| `degraded` | `bug` | `minor` | `mittel` | `needs_human` |
-| `suspicious` | `task` | `minor` | `mittel` | `ai_ready` |
-| `drift` | `task` | `trivial` | `niedrig` | `ai_ready` |
-| `process` | `task` | `trivial` | `niedrig` | `ai_ready` |
-
-For `process` mishaps, always set `component = 'skills/<skill-name>'`.
-
-### Aggregate Ticket Triage
-
-The **ticket-level** triage is computed across all mishaps in the ticket:
-
-| Field | Rule |
-|---|---|
-| `type` | `bug` if any mishap maps to `bug`; else `task` |
-| `severity` | worst across all: `critical > major > minor > trivial` |
-| `priority` | worst across all: `hoch > mittel > niedrig` |
-| `attention_mode` | `needs_human` if any mishap maps to `needs_human`; else `ai_ready` |
+**If verification is not feasible** (e.g. no cluster access): include the mishap but add `[UNVERIFIED — <reason>]` to its description.
 
 ---
 
-## Step 2: Find or Create Aggregate Ticket
+## Step 1: Mishap-Typ Klassifikation
 
-### 2a. Set up DB access
+| Mishap type | Severity | Priority | Attention mode |
+|---|---|---|---|
+| `broken` | `major` | `hoch` | `needs_human` |
+| `security` | `critical` | `hoch` | `needs_human` |
+| `degraded` | `minor` | `mittel` | `needs_human` |
+| `suspicious` | `minor` | `mittel` | `ai_ready` |
+| `drift` | `trivial` | `niedrig` | `ai_ready` |
+| `process` | `trivial` | `niedrig` | `ai_ready` |
 
-**DB-Zugriff — MCP-Postgres für Reads bevorzugen.** Bei erreichbarem `mcp-postgres` lese SELECTs via
-`mcp__mcp-postgres__query`. Das `$PSQL`-Konstrukt unten ist der Read-Fallback **und** der Pflichtweg
-für schreibende Statements (INSERT/UPDATE) — das MCP-Query-Tool ist read-only.
-Siehe [`MCP-Tool-Guide`](file:///home/patrick/Bachelorprojekt/.claude/skills/references/references.md#mcp-tool-guide).
-
-```bash
-PGPOD=$(kubectl get pod -n workspace --context fleet -l app=shared-db -o name | head -1)
-PSQL="kubectl exec $PGPOD -n workspace --context fleet -c postgres -- psql -U website -d website"
-```
-
-### 2b. Look for existing open mishap collection
-
-```bash
-EXISTING=$($PSQL -At -c \
-  "SELECT external_id, severity, priority, attention_mode::text
-   FROM tickets.tickets
-   WHERE status NOT IN ('done', 'archived')
-     AND title LIKE 'Mishap collection:%'
-   ORDER BY created_at DESC LIMIT 1;")
-
-if [ -n "$EXISTING" ]; then
-  COLLECT_ID=$(echo "$EXISTING" | cut -d'|' -f1)
-  COLLECT_SEV=$(echo "$EXISTING" | cut -d'|' -f2)
-  COLLECT_PRIO=$(echo "$EXISTING" | cut -d'|' -f3)
-  COLLECT_ATTN=$(echo "$EXISTING" | cut -d'|' -f4)
-else
-  COLLECT_ID=""
-fi
-```
+For `process` mishaps, set `component = 'skills/<skill-name>'`.
 
 ---
 
-## Step 3: Append to Aggregate Ticket
+## Step 2: Mishaps via ticket-mcp melden
 
-### 3a. Build the batch block
-
-Format all mishaps of this execution into a single markdown block:
+Für jeden verifizierten Mishap im MISHAP_LOG:
 
 ```
---- ${SKILL_NAME} — $(date +%Y-%m-%d\ %H:%M) ---
-
-| # | Type | Severity | Priority | Attention | Component |
-|---|---|---|---|---|---|
-| 1 | broken | major | hoch | needs_human | <component> |
-| 2 | drift | trivial | niedrig | ai_ready | <component> |
-
-<details>
-<summary>Descriptions</summary>
-
-**1. [broken] <title>**
-<description> [UNVERIFIED — <reason>]
-
-**2. [drift] <title>**
-<description>
-</details>
+mcp__ticket-mcp__report_mishap({
+  title: "<titel>",
+  description: "<beschreibung>",
+  component: "<komponente>",
+  type: "<broken|degraded|suspicious|security|drift|process>",
+  brand: "<brand>"
+})
 ```
 
-Also compute the aggregate triage across **all current mishaps** (the new batch only, if appending):
-- `BATCH_TYPE`: `bug` if any mishap is `broken`/`security`/`degraded`; else `task`
-- `BATCH_SEV`: worst severity in the batch
-- `BATCH_PRIO`: worst priority in the batch
-- `BATCH_ATTN`: `needs_human` if any; else `ai_ready`
-
-### 3b. Insert or append
-
-**New ticket** (no existing collection):
-
-```bash
-TITLE="Mishap collection: $(date +%Y-%m-%d)"
-NEW_ID=$($PSQL -At -c \
-  "INSERT INTO tickets.tickets (type, brand, title, description, severity, priority, attention_mode, status, component)
-   VALUES ('$BATCH_TYPE', 'mentolder', '$TITLE', '$(echo "$BATCH_BLOCK" | sed "s/'/''/g")', '$BATCH_SEV', '$BATCH_PRIO', '$BATCH_ATTN', 'triage', 'mishap-tracker')
-   RETURNING external_id;")
-echo "Created mishap collection ticket: $NEW_ID"
-```
-
-**Existing ticket** (append) — update description & triage, add a comment:
-
-```bash
-# Compute combined triage (worst of existing + new batch)
-COMBINED_SEV=$($PSQL -At -c \
-  "SELECT CASE
-    WHEN severity = 'critical' OR '$BATCH_SEV' = 'critical' THEN 'critical'
-    WHEN severity = 'major'    OR '$BATCH_SEV' = 'major'    THEN 'major'
-    WHEN severity = 'minor'    OR '$BATCH_SEV' = 'minor'    THEN 'minor'
-    ELSE 'trivial'
-  END FROM tickets.tickets WHERE external_id = '$COLLECT_ID';")
-
-COMBINED_PRIO=$($PSQL -At -c \
-  "SELECT CASE
-    WHEN priority = 'hoch'   OR '$BATCH_PRIO' = 'hoch'   THEN 'hoch'
-    WHEN priority = 'mittel' OR '$BATCH_PRIO' = 'mittel' THEN 'mittel'
-    ELSE 'niedrig'
-  END FROM tickets.tickets WHERE external_id = '$COLLECT_ID';")
-
-COMBINED_ATTN=$($PSQL -At -c \
-  "SELECT CASE
-    WHEN attention_mode::text = 'needs_human' OR '$BATCH_ATTN' = 'needs_human' THEN 'needs_human'
-    ELSE 'ai_ready'
-  END FROM tickets.tickets WHERE external_id = '$COLLECT_ID';")
-
-$PSQL -At -c \
-  "UPDATE tickets.tickets
-   SET description = description || E'\n\n' || '$(echo "$BATCH_BLOCK" | sed "s/'/''/g")',
-       severity = '$COMBINED_SEV',
-       priority = '$COMBINED_PRIO',
-       attention_mode = '$COMBINED_ATTN',
-       type = CASE WHEN '$BATCH_TYPE' = 'bug' OR type = 'bug' THEN 'bug' ELSE 'task' END
-   WHERE external_id = '$COLLECT_ID';
-
-   INSERT INTO tickets.ticket_comments (ticket_id, author_label, body, visibility)
-   SELECT id, 'mishap-tracker', 'Appended ${MISHAP_COUNT} mishaps from ${SKILL_NAME}.', 'internal'
-   FROM tickets.tickets WHERE external_id = '$COLLECT_ID';"
-
-echo "Appended $MISHAP_COUNT mishaps to $COLLECT_ID"
-```
-
-### 3c. Auto-categorize (new tickets only)
-
-If a new ticket was created, run auto-categorization:
-
-```bash
-bash scripts/mishap-categorize.sh "$NEW_ID" "Mishap collection" "$BATCH_BLOCK"
-```
-
-For existing tickets, categorization already ran — skip.
+**Rückmeldung auswerten:**
+- `"2/3 bis zum automatischen Bundle-Ticket"` → weiter melden, Buffer sammelt
+- `"Bundle-Ticket angelegt: T000xxx"` → Ticket existiert, Factory-Tick übernimmt
 
 ---
 
-## Step 4: Fallback — Manual Creation
+## Step 3: Buffer am Ende flushen
 
-If the database is unreachable (no pod, wrong context, connection refused), output a single formatted block for manual entry at `https://web.mentolder.de/admin/bugs`:
+Nach dem letzten `report_mishap`-Aufruf immer prüfen, ob noch Einträge im Buffer liegen:
 
 ```
---- Mishap collection ($(date +%Y-%m-%d)) ---
+mcp__ticket-mcp__get_mishap_buffer()
+```
 
-Aggregate triage: type=<aggregate_type> severity=<aggregate_severity> priority=<aggregate_priority> attention=<aggregate_attention>
+Wenn Einträge vorhanden und weniger als 3 (kein Auto-Trigger):
 
-Entries:
-  [<type>] <title>
-  Severity: <severity> | Priority: <priority> | Attention: <attention_mode> | Component: <component>
-  <description>
+```
+mcp__ticket-mcp__flush_mishap_buffer({ brand: "<brand>" })
+```
 
-  [<type>] <title>
-  ...
+Dies erzwingt ein Bundle-Ticket auch bei 1–2 Einträgen, damit am Session-Ende nichts verloren geht.
+
+---
+
+## Step 4: Fallback — Kein ticket-mcp erreichbar
+
+Falls der MCP-Server nicht antwortet, einen formatierten Block ausgeben für manuelle Eingabe unter `https://web.mentolder.de/admin/bugs`:
+
+```
+--- Mishap-Report ---
+Typ | Titel | Komponente | Beschreibung
+<type> | <title> | <component> | <description>
+...
 ```
 
 ---
@@ -251,10 +112,11 @@ Entries:
 ## Step 5: Summary
 
 Report:
-- Whether a new ticket was created or mishaps were appended to an existing one
-- The external_id of the collection ticket
-- Total mishap count in this batch
-- If fallback was used, note that tickets need manual creation
+- Anzahl gemeldeter Mishaps
+- Ob ein Bundle-Ticket ausgelöst wurde (und welches `T000xxx`)
+- Ob Buffer-Flush am Ende nötig war
+
+---
 
 ## Verwandte Skills
 

--- a/scripts/ticket-mcp/lib/mishap-buffer.js
+++ b/scripts/ticket-mcp/lib/mishap-buffer.js
@@ -1,9 +1,20 @@
 import { readFileSync, writeFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '../../../..');
-export const DEFAULT_BUFFER_PATH = path.join(REPO_ROOT, '.git', 'mishap-buffer.json');
+
+function resolveGitCommonDir() {
+  try {
+    const dir = execFileSync('git', ['rev-parse', '--git-common-dir'], { cwd: REPO_ROOT, encoding: 'utf8' }).trim();
+    return path.resolve(REPO_ROOT, dir);
+  } catch {
+    return path.join(REPO_ROOT, '.git');
+  }
+}
+
+export const DEFAULT_BUFFER_PATH = path.join(resolveGitCommonDir(), 'mishap-buffer.json');
 
 export function readBuffer(bufferPath = DEFAULT_BUFFER_PATH) {
   try {

--- a/scripts/ticket-mcp/tools/mishap.js
+++ b/scripts/ticket-mcp/tools/mishap.js
@@ -1,20 +1,38 @@
 import { z } from 'zod';
 import { runTicket } from '../lib/run-ticket.js';
-import { readBuffer, writeBuffer, classifyBundle, DEFAULT_BUFFER_PATH } from '../lib/mishap-buffer.js';
+import { readBuffer, writeBuffer, classifyBundle } from '../lib/mishap-buffer.js';
 
 const MISHAP_TRIGGER = 3;
+
+const MISHAP_TYPE = z.enum(['broken', 'degraded', 'suspicious', 'security', 'drift', 'process']);
+
+async function createBundleTicket(bundle, brand) {
+  const classified = classifyBundle(bundle);
+  const result = await runTicket([
+    'create',
+    '--type',           'task',
+    '--brand',          brand,
+    '--title',          classified.title,
+    '--description',    classified.description,
+    '--status',         'triage',
+    '--severity',       classified.severity,
+    '--priority',       classified.priority,
+    '--attention-mode', 'ai_ready',
+    '--areas',          classified.areas,
+  ], { BRAND: brand });
+  return result.trim().split('|')[0];
+}
 
 export function registerMishapTools(server) {
   server.tool(
     'report_mishap',
     `Fügt einen Mishap in den Buffer ein. Bei ≥${MISHAP_TRIGGER} Einträgen wird automatisch ein gebündeltes Ticket mit attention_mode=ai_ready angelegt.`,
     {
-      title: z.string().describe('Kurztitel des Mishaps'),
+      title:       z.string().describe('Kurztitel des Mishaps'),
       description: z.string().describe('Ausführliche Beschreibung'),
-      component: z.string().describe('Betroffene Komponente z.B. auth, chat, infra'),
-      type: z.enum(['broken', 'degraded', 'suspicious', 'security', 'drift'])
-        .describe('Mishap-Typ (broken/security → severity major)'),
-      brand: z.string().optional(),
+      component:   z.string().describe('Betroffene Komponente z.B. auth, chat, infra'),
+      type:        MISHAP_TYPE.describe('Mishap-Typ (broken/security → severity major; process → Prozessbeobachtung)'),
+      brand:       z.string().optional(),
     },
     async ({ title, description, component, type, brand = 'mentolder' }) => {
       const entry = {
@@ -36,22 +54,9 @@ export function registerMishapTools(server) {
       }
 
       const bundle = buffer.slice(0, MISHAP_TRIGGER);
-      const classified = classifyBundle(bundle);
-
-      let ticketResult;
+      let extId;
       try {
-        ticketResult = await runTicket([
-          'create',
-          '--type',     'task',
-          '--brand',    brand,
-          '--title',    classified.title,
-          '--description', classified.description,
-          '--status',   'triage',
-          '--severity', classified.severity,
-          '--priority', classified.priority,
-          '--attention-mode', 'ai_ready',
-          '--areas',    classified.areas,
-        ], { BRAND: brand });
+        extId = await createBundleTicket(bundle, brand);
       } catch (err) {
         writeBuffer(buffer);
         throw err;
@@ -59,11 +64,61 @@ export function registerMishapTools(server) {
 
       writeBuffer(buffer.slice(MISHAP_TRIGGER));
 
-      const extId = ticketResult.trim().split('|')[0];
       return {
         content: [{
           type: 'text',
           text: `Bundle-Ticket angelegt: ${extId}\nBuffer geleert. Verbleibende Mishaps: ${buffer.length - MISHAP_TRIGGER}\n\nTicket landet im nächsten Factory-Tick (attention_mode=ai_ready).`,
+        }],
+      };
+    }
+  );
+
+  server.tool(
+    'get_mishap_buffer',
+    'Zeigt den aktuellen Inhalt des Mishap-Buffers an (noch nicht zu Tickets gebündelt).',
+    {},
+    () => {
+      const buffer = readBuffer();
+      if (buffer.length === 0) {
+        return { content: [{ type: 'text', text: 'Mishap-Buffer ist leer.' }] };
+      }
+      const lines = buffer.map((e, i) =>
+        `${i + 1}. [${e.type}] ${e.title} (${e.component}) — ${e.reported_at}`
+      );
+      return {
+        content: [{
+          type: 'text',
+          text: `Buffer: ${buffer.length}/${MISHAP_TRIGGER} Einträge\n\n${lines.join('\n')}`,
+        }],
+      };
+    }
+  );
+
+  server.tool(
+    'flush_mishap_buffer',
+    'Erzwingt die Erstellung eines Bundle-Tickets aus dem aktuellen Buffer — auch bei weniger als 3 Einträgen. Nützlich am Ende einer Session.',
+    {
+      brand: z.string().optional(),
+    },
+    async ({ brand = 'mentolder' }) => {
+      const buffer = readBuffer();
+      if (buffer.length === 0) {
+        return { content: [{ type: 'text', text: 'Mishap-Buffer ist leer — nichts zu flushen.' }] };
+      }
+
+      let extId;
+      try {
+        extId = await createBundleTicket(buffer, brand);
+      } catch (err) {
+        throw err;
+      }
+
+      writeBuffer([]);
+
+      return {
+        content: [{
+          type: 'text',
+          text: `Bundle-Ticket angelegt: ${extId} (${buffer.length} Mishap${buffer.length !== 1 ? 's' : ''})\nBuffer geleert.`,
         }],
       };
     }


### PR DESCRIPTION
## Summary

- Add `process` type to `report_mishap` enum (was missing vs. skill docs)
- Add `get_mishap_buffer` tool — inspect pending buffer entries without side effects
- Add `flush_mishap_buffer` tool — force-flush < 3 entries at session end so nothing gets lost
- Fix `mishap-buffer.js` to resolve `git-common-dir` instead of `.git` directly (worktree-safe)
- Switch `execSync` → `execFileSync` (no shell involved, security improvement)
- Simplify `mishap-tracker` SKILL.md: MCP-only path, drop raw SQL steps (kubectl + postgres INSERT/UPDATE)

## Test plan

- [x] `node --test tests/unit/ticket-mcp/mishap-buffer.test.js` — 6/6 pass
- [x] Buffer path resolves to main repo `.git/mishap-buffer.json` even when called from a worktree
- [x] `process` type accepted by zod enum, unknown types rejected
- [x] `quality:check` — 0 new violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QmUvAVbhUMCTEtJqhL5tf3