### PR TITLE
chore(agent-guide): align OVERVIEW/AGENTS dispatch table with existing skills [T001047]

### DIFF
--- a/.claude/agents/bachelorprojekt-test.md
+++ b/.claude/agents/bachelorprojekt-test.md
@@ -9,11 +9,10 @@ description: >
 
 You are a test specialist for the Bachelorprojekt platform.
 
-## Software Factory Autopilot (factory-autopilot)
+## Software Factory Autopilot
 The headless timer-driven dispatcher (`systemd --user timer`, 5‑min tick) that
-autonomously processes backlog tickets. For install/status/uninstall, use the
-`.claude/skills/factory-autopilot/SKILL.md` runbook. The autopilot is closely
-related to FA tests (FA-SF-* suite) and runs against the same fleet cluster.
+autonomously processes backlog tickets via `scripts/factory/dispatcher.js`.
+Related: FA-SF-* test suite runs against the same fleet cluster.
 
 ## Test categories and IDs
 - `FA-01`–`FA-29` — Functional acceptance tests

--- a/.claude/skills/OVERVIEW.md
+++ b/.claude/skills/OVERVIEW.md
@@ -1,6 +1,6 @@
 # Skills Overview
 
-26 project-local skills (25 in `.claude/skills/<name>/` + 1 in `.claude/skills/superpowers/using-git-worktrees/`) grouped by domain. Each skill has its own `SKILL.md` with full runbook details. Invoke any skill by its name.
+18 project-local skills (17 in `.claude/skills/<name>/` + 1 in `.claude/skills/superpowers/using-git-worktrees/`) grouped by domain. Each skill has its own `SKILL.md` with full runbook details. Invoke any skill by its name.
 
 > **Wartung:** Diese Anzahl stimmt mit `find .claude/skills -name SKILL.md | wc -l` und mit der `<available_skills>`-Liste des OpenCode-Loaders überein. Wenn ein Skill hinzukommt oder entfernt wird, hier nachziehen.
 
@@ -23,9 +23,7 @@ Each skill's `SKILL.md` frontmatter carries an optional `agent:` field that tell
 | [`dev-flow-plan`](https://github.com/Paddione/Bachelorprojekt/blob/main/k3d/docs-content-built/skills/dev-flow-plan.html) | **Entry point** for feature/fix changes — runs brainstorming, creates spec + plan, commits to branch, then **stops**. Routes chores to [`dev-flow-chore`](https://github.com/Paddione/Bachelorprojekt/blob/main/k3d/docs-content-built/skills/dev-flow-chore.html). |
 | [`dev-flow-chore`](https://github.com/Paddione/Bachelorprojekt/blob/main/k3d/docs-content-built/skills/dev-flow-chore.html) | Maintenance with no behavior change (docs, dep bumps, config, CI) — executes and merges **inline**, no plan/execute handoff. |
 | [`dev-flow-execute`](https://github.com/Paddione/Bachelorprojekt/blob/main/k3d/docs-content-built/skills/dev-flow-execute.html) | After [`dev-flow-plan`](https://github.com/Paddione/Bachelorprojekt/blob/main/k3d/docs-content-built/skills/dev-flow-plan.html) has pushed a staged plan — implements, verifies, opens PR, merges, deploys. |
-| [`dev-flow-iterate`](https://github.com/Paddione/Bachelorprojekt/blob/main/k3d/docs-content-built/skills/dev-flow-iterate.html) | **Sub-routine of [`dev-flow-execute`](https://github.com/Paddione/Bachelorprojekt/blob/main/k3d/docs-content-built/skills/dev-flow-execute.html)** (Schritt 4) + standalone dev-cluster loop — deploys a surface, browses with Playwright MCP, tails logs, applies small fixes. **Not** an alternative to execute. |
 | [`dev-flow-e2e`](https://github.com/Paddione/Bachelorprojekt/blob/main/k3d/docs-content-built/skills/dev-flow-e2e.html) | After [`dev-flow-execute`](https://github.com/Paddione/Bachelorprojekt/blob/main/k3d/docs-content-built/skills/dev-flow-execute.html) has merged and deployed — writes + runs Playwright E2E tests against live environment. |
-| [`dev-flow-batch`](https://github.com/Paddione/Bachelorprojekt/blob/main/k3d/docs-content-built/skills/dev-flow-batch.html) | **Batch variant** of [`dev-flow-plan`](https://github.com/Paddione/Bachelorprojekt/blob/main/k3d/docs-content-built/skills/dev-flow-plan.html) — plans multiple `status=planning` tickets in parallel (Modus 1) or splits a single large feature into parallel sub-plans (Modus 2). Routes through the same `Workflow` orchestration that the Factory uses. |
 
 ---
 
@@ -103,7 +101,6 @@ unabhängiger Beweis ist. Stufen 3+4 prüfen andere Dimensionen (Review-Qualitä
 
 | Skill | When to use |
 |---|---|
-| [`arena-brett-deploy`](https://github.com/Paddione/Bachelorprojekt/blob/main/k3d/docs-content-built/skills/arena-brett-deploy.html) | Build, push, and deploy arena-server (korczewski brand on fleet only) or brett (both brands on the fleet cluster). Covers proto-drift copy step. |
 | [`workspace-deploy`](https://github.com/Paddione/Bachelorprojekt/blob/main/k3d/docs-content-built/skills/workspace-deploy.html) | Full-stack workspace platform deployment — umbrella `workspace:setup`, post-setup, talk/recording/transcriber setup, optional admin-users and vaultwarden seed. Every service that doesn't ship via base kustomize alone. |
 | [`llm-ops`](https://github.com/Paddione/Bachelorprojekt/blob/main/k3d/docs-content-built/skills/llm-ops.html) | LLM pipeline operations — GPU host bootstrap, model management, deploy/status/test of LLM gateway services (TEI, Ollama, LiteLLM router, ComfyUI, Rigger). |
 
@@ -125,8 +122,6 @@ unabhängiger Beweis ist. Stufen 3+4 prüfen andere Dimensionen (Review-Qualitä
 | [`incident-response`](https://github.com/Paddione/Bachelorprojekt/blob/main/k3d/docs-content-built/skills/incident-response.html) | Production incident triage & recovery — scope, diagnose, fix/rollback, post-mortem. Use when a core service is down or degraded. |
 | [`ticket-ops`](https://github.com/Paddione/Bachelorprojekt/blob/main/k3d/docs-content-built/skills/ticket-ops.html) | Daily operations — DB ticket triage, stale worktrees/branches, PR merge→close workflow, GitHub issue intake. Non-incident operational work. |
 | [`update-dependencies`](https://github.com/Paddione/Bachelorprojekt/blob/main/k3d/docs-content-built/skills/update-dependencies.html) | Update workspace packages, fix deprecation warnings, and handle security audits/Major version bumps across all directories. |
-| [`factory-autopilot`](https://github.com/Paddione/Bachelorprojekt/blob/main/k3d/docs-content-built/skills/factory-autopilot.html) | Software Factory Autopilot lifecycle — install, status, uninstall the headless timer-driven dispatcher that autonomously processes backlog tickets. |
-| [`factory-worker`](https://github.com/Paddione/Bachelorprojekt/blob/main/k3d/docs-content-built/skills/factory-worker.html) | **Interactive counterpart to [`factory-autopilot`](https://github.com/Paddione/Bachelorprojekt/blob/main/k3d/docs-content-built/skills/factory-autopilot.html)** — `/factory-worker-on` yields one autopilot slot so a human can scout + plan SCOUT_WEAK or un-planned tickets via [`dev-flow-plan`](https://github.com/Paddione/Bachelorprojekt/blob/main/k3d/docs-content-built/skills/dev-flow-plan.html), then hand back to the autopilot. |
 | [`mishap-tracker`](https://github.com/Paddione/Bachelorprojekt/blob/main/k3d/docs-content-built/skills/mishap-tracker.html) | **End-of-skill routine** — batches accumulated `MISHAP_LOG` entries from runbook skills into a single aggregate `tickets.tickets` row. Reuses an open "Mishap collection" ticket if one exists. |
 
 ---
@@ -140,10 +135,7 @@ graph TD
     subgraph "Dev-Flow Pipeline (sequentiell)"
         DP[dev-flow-plan] -->|feature/fix| DE[dev-flow-execute]
         DP -->|chore| DC[dev-flow-chore]
-        DP -->|batch| DFB[dev-flow-batch]
-        DE -->|Schritt 4 Sub-Routine| DI[dev-flow-iterate]
         DE --> DEE[dev-flow-e2e]
-        DFB --> DP
     end
 
     subgraph "superpowers (Disziplin-Schicht)"
@@ -168,11 +160,9 @@ graph TD
         HN[host-node-networking]
         SR[secret-rotation]
         KR[keycloak-realm-sync]
-        AD[arena-brett-deploy]
         UD[update-dependencies]
         WD[workspace-deploy]
         LO[llm-ops]
-        FA[factory-autopilot]
     end
 
     subgraph "Support"
@@ -182,21 +172,11 @@ graph TD
         TO[ticket-ops]
     end
 
-    subgraph "Factory (Software-Fabrik)"
-        FA[factory-autopilot]
-        FW[factory-worker]
-    end
-
-    FA -.->|Gegenstück| FW
-
     DP --> CD
     DE --> DO
     DE --> SR
     DE --> KR
-    DE --> AD
     DE --> WD
-    DI --> DO
-    DI --> HN
     DEE --> CD
 
     OM --> IR
@@ -222,7 +202,6 @@ graph TD
 | Start | Verlauf | Ergebnis |
 |-------|---------|----------|
 | Feature entwickeln | [`dev-flow-plan`](https://github.com/Paddione/Bachelorprojekt/blob/main/k3d/docs-content-built/skills/dev-flow-plan.html) → [`dev-flow-execute`](https://github.com/Paddione/Bachelorprojekt/blob/main/k3d/docs-content-built/skills/dev-flow-execute.html) → [`dev-flow-e2e`](https://github.com/Paddione/Bachelorprojekt/blob/main/k3d/docs-content-built/skills/dev-flow-e2e.html) | Gemergetes + getestetes Feature |
-| Mehrere Features parallel planen | [`dev-flow-batch`](https://github.com/Paddione/Bachelorprojekt/blob/main/k3d/docs-content-built/skills/dev-flow-batch.html) (Modus 1) → [`dev-flow-execute`](https://github.com/Paddione/Bachelorprojekt/blob/main/k3d/docs-content-built/skills/dev-flow-execute.html) (pro Sub-Feature) | Mehrere Pläne auf einmal in `plan_staged` |
 | Wartung (Chore) | [`dev-flow-chore`](https://github.com/Paddione/Bachelorprojekt/blob/main/k3d/docs-content-built/skills/dev-flow-chore.html) (inline) | Gemergte Wartung ohne Plan-Handoff |
 | Cluster aufsetzen | [`cluster-deployment`](https://github.com/Paddione/Bachelorprojekt/blob/main/k3d/docs-content-built/skills/cluster-deployment.html) → [`secret-rotation`](https://github.com/Paddione/Bachelorprojekt/blob/main/k3d/docs-content-built/skills/secret-rotation.html) | Produktions-Cluster |
 | DB-Migration | [`database-ops`](https://github.com/Paddione/Bachelorprojekt/blob/main/k3d/docs-content-built/skills/database-ops.html) → [`dev-flow-execute`](https://github.com/Paddione/Bachelorprojekt/blob/main/k3d/docs-content-built/skills/dev-flow-execute.html) (Schema-Change) | Gemergte Migration |

--- a/.claude/skills/mishap-tracker/SKILL.md
+++ b/.claude/skills/mishap-tracker/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: mishap-tracker
 description: Shared utility — batches all execution mishaps into a single aggregate ticket. Reuses an existing open "Mishap collection" ticket if one exists; creates a new one otherwise. Each mishap is individually classified within the aggregate.
-agent: bachelorprojekt-ops
 ---
 
 # mishap-tracker

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,22 +143,16 @@ The subagent returns its result; the orchestrator relays it back. The subagent s
 
 | Skill | Agent | Why subagent |
 |-------|-------|--------------|
-| `arena-brett-deploy` | `bachelorprojekt-infra` | Kustomize/proto-drift details, prod context rules |
 | `cluster-deployment` | `bachelorprojekt-infra` | `fleet`-only context, k3d base, overlay cake |
 | `database-ops` | `bachelorprojekt-db` | PostgreSQL `shared-db` topology, password-drift warning |
 | `dev-flow-e2e` | `bachelorprojekt-test` | FA-/SA-/NFA- test IDs, runner.sh, permanently-skipped set |
-| `dev-flow-iterate` | `bachelorprojekt-ops` | Pod/log/restart discipline (shell-session integrity rules) |
-| `factory-autopilot` | `bachelorprojekt-test` | Headless dispatcher lifecycle + FA-SF test context |
-| `factory-worker` | `bachelorprojekt-test` | Same factory domain as `factory-autopilot` |
-| `fleet-ops` | `bachelorprojekt-infra` | Cross-brand kustomize fan-out, no-GitOps push model |
 | `host-node-networking` | `bachelorprojekt-infra` | Hetzner/WireGuard/provisioning tooling |
 | `incident-response` | `bachelorprojekt-ops` | Diagnose-first, fail-loud output-trust rules |
 | `keycloak-realm-sync` | `bachelorprojekt-security` | SealedSecret + realm JSON per-namespace rules |
 | `llm-ops` | `bachelorprojekt-ops` | GPU/Ollama/TEI/LiteLLM ops on fleet |
-| `mishap-tracker` | `bachelorprojekt-ops` | Anomalies on live systems → ops triage |
 | `secret-rotation` | `bachelorprojekt-security` | Sealing order, `env-resolve.sh` source-not-execute |
 | `workspace-deploy` | `bachelorprojekt-infra` | Full workspace:setup umbrella + post-setup |
-| _inline (no agent)_ | _main session_ | `dev-flow-plan`, `dev-flow-execute`, `dev-flow-chore`, `dev-flow-batch`, `migrate-foreign-code`, `operations-management`, `ticket-ops`, `update-dependencies`, `knowledge-management`, `using-git-worktrees` |
+| _inline (no agent)_ | _main session_ | `dev-flow-plan`, `dev-flow-execute`, `dev-flow-chore`, `dev-flow-e2e`-meta, `mishap-tracker`, `operations-management`, `ticket-ops`, `update-dependencies`, `using-git-worktrees` |
 
 When a new skill is added: pick an agent from the routing table, add `agent: bachelorprojekt-<role>` to frontmatter, and add a row to this table. (Optional follow-up: add a `task skills:validate` that asserts every `agent:` value resolves to an existing `.claude/agents/<name>.md` and that every agent has at least one skill referring to it — currently no such gate exists.)
 


### PR DESCRIPTION
## Summary

- Removes stale references to 6 deleted skills (`dev-flow-iterate`, `dev-flow-batch`, `factory-autopilot`, `factory-worker`, `arena-brett-deploy`, `fleet-ops`) from `OVERVIEW.md` and `AGENTS.md` dispatch table
- Fixes `mishap-tracker` agent assignment: was `bachelorprojekt-ops` (restricted tool set, no MCP access) → now inline (no agent), consistent with its role as a shared end-of-skill utility
- Updates skill count in `OVERVIEW.md`: 26 → 18 (17 in `.claude/skills/` + 1 superpowers sub-skill)
- Cleans up inline-skills list in `AGENTS.md`: removes `dev-flow-batch`, `migrate-foreign-code`, `knowledge-management`
- Fixes stale `factory-autopilot/SKILL.md` path reference in `bachelorprojekt-test.md`

## Test plan

- [x] `task workspace:validate` passes
- [x] `task freshness:check` passes (no generated artifact changes)
- [x] All 4 files changed are doc/config only — no runtime code affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AqCHmebX6sqDLaonV2cXmv