### PR TITLE
chore(dev-flow): add agent escalation protocol [T001049]

### DIFF
--- a/.claude/agents/bachelorprojekt-db.md
+++ b/.claude/agents/bachelorprojekt-db.md
@@ -47,6 +47,26 @@ Otherwise the app fails to authenticate despite a valid SealedSecret.
 ## Autonomous operation
 Execute Bash commands and file edits without asking for confirmation.
 
+## When stuck: Escalation Protocol
+
+Wenn du blockiert bist — fehlender Kontext, mehrdeutige Anforderung, nicht auflösbarer Fehler, oder unsichere Operation ohne explizite Bestätigung:
+
+1. **Sofort stoppen** — nicht raten, nicht blind weitermachen
+2. **Signal senden:**
+   ```bash
+   bash scripts/agent-escalate.sh \
+     --agent "bachelorprojekt-db" \
+     --reason "<Was dich blockiert>" \
+     --tried  "<Was du versucht hast>" \
+     --needs  "<Was dich entblocken würde>"
+   ```
+3. **ESCALATION-Block als Antwort zurückgeben** — der Orchestrator re-dispatcht mit mehr Kontext
+
+**Niemals:**
+- Stumm scheitern und unvollständige Arbeit zurückgeben
+- Bei mehrdeutigen `ENV=`-Zielen, Secret-Werten oder destruktiven Operationen raten
+- Über einen 🔴 oder 🟠 Guardrail hinausgehen ohne explizite Bestätigung
+
 ## Active plans
 The orchestrator (see CLAUDE.md) injects an `<active-plans>` block built from `scripts/plan-context.sh db --with-openspec`, which reads active proposals from `openspec/changes/*/proposal.md`. **That block is authoritative — use it as the working context for the current feature.**
 

--- a/.claude/agents/bachelorprojekt-infra.md
+++ b/.claude/agents/bachelorprojekt-infra.md
@@ -55,6 +55,26 @@ task env:generate ENV=<env>             # generate fresh secrets
 ## Autonomous operation
 Execute Bash commands and file edits without asking for confirmation.
 
+## When stuck: Escalation Protocol
+
+Wenn du blockiert bist — fehlender Kontext, mehrdeutige Anforderung, nicht auflösbarer Fehler, oder unsichere Operation ohne explizite Bestätigung:
+
+1. **Sofort stoppen** — nicht raten, nicht blind weitermachen
+2. **Signal senden:**
+   ```bash
+   bash scripts/agent-escalate.sh \
+     --agent "bachelorprojekt-infra" \
+     --reason "<Was dich blockiert>" \
+     --tried  "<Was du versucht hast>" \
+     --needs  "<Was dich entblocken würde>"
+   ```
+3. **ESCALATION-Block als Antwort zurückgeben** — der Orchestrator re-dispatcht mit mehr Kontext
+
+**Niemals:**
+- Stumm scheitern und unvollständige Arbeit zurückgeben
+- Bei mehrdeutigen `ENV=`-Zielen, Secret-Werten oder destruktiven Operationen raten
+- Über einen 🔴 oder 🟠 Guardrail hinausgehen ohne explizite Bestätigung
+
 ## Active plans
 The orchestrator (see CLAUDE.md) injects an `<active-plans>` block built from `scripts/plan-context.sh infra --with-openspec`, which reads active proposals from `openspec/changes/*/proposal.md`. **That block is authoritative — use it as the working context for the current feature.**
 

--- a/.claude/agents/bachelorprojekt-ops.md
+++ b/.claude/agents/bachelorprojekt-ops.md
@@ -54,6 +54,26 @@ the GPU worker at `10.10.0.3` (WireGuard mesh, Ollama port 11434).
 ## Autonomous operation
 Execute kubectl and task commands without asking for confirmation.
 
+## When stuck: Escalation Protocol
+
+Wenn du blockiert bist — fehlender Kontext, mehrdeutige Anforderung, nicht auflösbarer Fehler, oder unsichere Operation ohne explizite Bestätigung:
+
+1. **Sofort stoppen** — nicht raten, nicht blind weitermachen
+2. **Signal senden:**
+   ```bash
+   bash scripts/agent-escalate.sh \
+     --agent "bachelorprojekt-ops" \
+     --reason "<Was dich blockiert>" \
+     --tried  "<Was du versucht hast>" \
+     --needs  "<Was dich entblocken würde>"
+   ```
+3. **ESCALATION-Block als Antwort zurückgeben** — der Orchestrator re-dispatcht mit mehr Kontext
+
+**Niemals:**
+- Stumm scheitern und unvollständige Arbeit zurückgeben
+- Bei mehrdeutigen `ENV=`-Zielen, Secret-Werten oder destruktiven Operationen raten
+- Über einen 🔴 oder 🟠 Guardrail hinausgehen ohne explizite Bestätigung
+
 ## Active plans
 The orchestrator (see CLAUDE.md) injects an `<active-plans>` block built from `scripts/plan-context.sh ops --with-openspec`, which reads active proposals from `openspec/changes/*/proposal.md`. **That block is authoritative — use it as the working context for the current feature.**
 

--- a/.claude/agents/bachelorprojekt-security.md
+++ b/.claude/agents/bachelorprojekt-security.md
@@ -44,6 +44,26 @@ task workspace:dsgvo-check    # NFA-01: run DSGVO compliance verification
 ## Autonomous operation
 Execute Bash commands and file edits without asking for confirmation.
 
+## When stuck: Escalation Protocol
+
+Wenn du blockiert bist — fehlender Kontext, mehrdeutige Anforderung, nicht auflösbarer Fehler, oder unsichere Operation ohne explizite Bestätigung:
+
+1. **Sofort stoppen** — nicht raten, nicht blind weitermachen
+2. **Signal senden:**
+   ```bash
+   bash scripts/agent-escalate.sh \
+     --agent "bachelorprojekt-security" \
+     --reason "<Was dich blockiert>" \
+     --tried  "<Was du versucht hast>" \
+     --needs  "<Was dich entblocken würde>"
+   ```
+3. **ESCALATION-Block als Antwort zurückgeben** — der Orchestrator re-dispatcht mit mehr Kontext
+
+**Niemals:**
+- Stumm scheitern und unvollständige Arbeit zurückgeben
+- Bei mehrdeutigen `ENV=`-Zielen, Secret-Werten oder destruktiven Operationen raten
+- Über einen 🔴 oder 🟠 Guardrail hinausgehen ohne explizite Bestätigung
+
 ## Active plans
 The orchestrator (see CLAUDE.md) injects an `<active-plans>` block built from `scripts/plan-context.sh security --with-openspec`, which reads active proposals from `openspec/changes/*/proposal.md`. **That block is authoritative — use it as the working context for the current feature.**
 

--- a/.claude/agents/bachelorprojekt-test.md
+++ b/.claude/agents/bachelorprojekt-test.md
@@ -50,6 +50,26 @@ The old standalone `mentolder` and `korczewski` kubeconfig contexts are DEAD —
 ## Autonomous operation
 Execute test commands and file edits without asking for confirmation.
 
+## When stuck: Escalation Protocol
+
+Wenn du blockiert bist — fehlender Kontext, mehrdeutige Anforderung, nicht auflösbarer Fehler, oder unsichere Operation ohne explizite Bestätigung:
+
+1. **Sofort stoppen** — nicht raten, nicht blind weitermachen
+2. **Signal senden:**
+   ```bash
+   bash scripts/agent-escalate.sh \
+     --agent "bachelorprojekt-test" \
+     --reason "<Was dich blockiert>" \
+     --tried  "<Was du versucht hast>" \
+     --needs  "<Was dich entblocken würde>"
+   ```
+3. **ESCALATION-Block als Antwort zurückgeben** — der Orchestrator re-dispatcht mit mehr Kontext
+
+**Niemals:**
+- Stumm scheitern und unvollständige Arbeit zurückgeben
+- Bei mehrdeutigen `ENV=`-Zielen, Secret-Werten oder destruktiven Operationen raten
+- Über einen 🔴 oder 🟠 Guardrail hinausgehen ohne explizite Bestätigung
+
 ## Active plans
 The orchestrator (see CLAUDE.md) injects an `<active-plans>` block built from `scripts/plan-context.sh test --with-openspec`, which reads active proposals from `openspec/changes/*/proposal.md`. **That block is authoritative — use it as the working context for the current feature.**
 

--- a/.claude/agents/bachelorprojekt-website.md
+++ b/.claude/agents/bachelorprojekt-website.md
@@ -44,6 +44,26 @@ task website:dev   # hot-reload Astro dev server, no ENV needed
 ## Autonomous operation
 Execute Bash commands and file edits without asking for confirmation.
 
+## When stuck: Escalation Protocol
+
+Wenn du blockiert bist — fehlender Kontext, mehrdeutige Anforderung, nicht auflösbarer Fehler, oder unsichere Operation ohne explizite Bestätigung:
+
+1. **Sofort stoppen** — nicht raten, nicht blind weitermachen
+2. **Signal senden:**
+   ```bash
+   bash scripts/agent-escalate.sh \
+     --agent "bachelorprojekt-website" \
+     --reason "<Was dich blockiert>" \
+     --tried  "<Was du versucht hast>" \
+     --needs  "<Was dich entblocken würde>"
+   ```
+3. **ESCALATION-Block als Antwort zurückgeben** — der Orchestrator re-dispatcht mit mehr Kontext
+
+**Niemals:**
+- Stumm scheitern und unvollständige Arbeit zurückgeben
+- Bei mehrdeutigen `ENV=`-Zielen, Secret-Werten oder destruktiven Operationen raten
+- Über einen 🔴 oder 🟠 Guardrail hinausgehen ohne explizite Bestätigung
+
 ## Active plans
 The orchestrator (see CLAUDE.md) injects an `<active-plans>` block built from `scripts/plan-context.sh website --with-openspec`, which reads active proposals from `openspec/changes/*/proposal.md`. **That block is authoritative — use it as the working context for the current feature.**
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,6 +109,20 @@ bash scripts/agent-lock.sh list    # see who is doing what
 
 Session messaging: `bash scripts/agent-msg.sh read --unread` (incoming), `bash scripts/agent-msg.sh post "msg"` (broadcast to live sessions).
 
+## Escalation Protocol (when stuck)
+
+If a subagent cannot continue — missing context, ambiguous target, unresolvable error, or unsafe action without confirmation:
+
+```bash
+bash scripts/agent-escalate.sh \
+  --agent "bachelorprojekt-<role>" \
+  --reason "<what is blocking you>" \
+  --tried  "<what you attempted>" \
+  --needs  "<what would unblock you>"
+```
+
+The script posts to the session-message channel and emits a structured `=== AGENT ESCALATION ===` block. **Orchestrators** that see this block should re-dispatch with the missing context in `<active-plans>` tags or ask the user before retrying. Never guess ambiguous `ENV=` targets, secret values, or destructive operations.
+
 ## Skill Dispatch Protocol
 
 Every skill in `.claude/skills/<name>/SKILL.md` declares its dispatch target in the YAML frontmatter:

--- a/docs/code-quality/gates.yaml
+++ b/docs/code-quality/gates.yaml
@@ -102,6 +102,9 @@ s4:
     # (e.g. dev-flow-execute → scripts/devflow-ci-watch.sh). Without this entry,
     # those scripts are flagged as S4-orphans. Added in T001007.
     - ".claude/skills/**/*.md"
+    # AGENTS.md is the canonical reference for agent coordination scripts (agent-lock.sh,
+    # agent-msg.sh, agent-escalate.sh). Added in T001049.
+    - "AGENTS.md"
   allowlist_globs:
     - "k3d/office-stack/**"
     - "k3d/coturn-stack/**"

--- a/scripts/agent-escalate.sh
+++ b/scripts/agent-escalate.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Strukturiertes Eskalations-Signal für feststeckende Agenten.
+# Agenten rufen dieses Script auf, wenn sie blockiert sind — statt blind weiterzumachen.
+
+set -euo pipefail
+
+AGENT=""
+REASON=""
+TRIED=""
+NEEDS=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --agent)  AGENT="$2";  shift 2 ;;
+    --reason) REASON="$2"; shift 2 ;;
+    --tried)  TRIED="$2";  shift 2 ;;
+    --needs)  NEEDS="$2";  shift 2 ;;
+    *) shift ;;
+  esac
+done
+
+[[ -z "$AGENT" ]]  && { echo "Usage: $0 --agent <name> --reason <text> [--tried <text>] [--needs <text>]" >&2; exit 1; }
+[[ -z "$REASON" ]] && { echo "--reason ist Pflicht" >&2; exit 1; }
+
+REPO_ROOT="$(git -C "$(dirname "$0")" rev-parse --show-toplevel 2>/dev/null || echo ".")"
+
+# Nachricht an alle lebenden Sessions posten
+if [[ -f "${REPO_ROOT}/scripts/agent-msg.sh" ]]; then
+  bash "${REPO_ROOT}/scripts/agent-msg.sh" post "ESCALATION [${AGENT}]: ${REASON}" 2>/dev/null || true
+fi
+
+# Strukturierter Eskalations-Block — Orchestrator parst diesen Block
+cat <<EOF
+
+=== AGENT ESCALATION ===
+Agent:  ${AGENT}
+Reason: ${REASON}
+Tried:  ${TRIED:-"(nicht angegeben)"}
+Needs:  ${NEEDS:-"(nicht angegeben)"}
+Time:   $(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+Wissensdatenbanken zum Nachschlagen:
+  • docs/agent-guide/maps/goals-map.md  — Intention → Flow → Gefahr-Tier
+  • CLAUDE.md#gotchas-footguns          — domain-spezifische Fallstricke
+  • AGENTS.md                           — Routing, Koordinations-Commands
+  • .claude/agents/${AGENT}.md          — Vollständiges Agent-Profil
+
+Orchestrator-Aktion:
+  Mit fehlendem Kontext in <active-plans>-Tags neu dispatchen
+  oder User um Klärung bitten, bevor erneut versucht wird.
+========================
+
+EOF


### PR DESCRIPTION
## Summary

- Adds `scripts/agent-escalate.sh` — strukturiertes Signal für feststeckende Agenten (postet in agent-msg-Kanal, gibt `=== AGENT ESCALATION ===`-Block aus)
- Ergänzt alle 6 Agent-Profile (`.claude/agents/bachelorprojekt-*.md`) um `## When stuck: Escalation Protocol`-Abschnitt mit konkretem Aufruf-Pattern
- Ergänzt `AGENTS.md` mit Escalation-Abschnitt im Koordinations-Kapitel
- Fügt `AGENTS.md` als S4-`reference_source` in `docs/code-quality/gates.yaml` hinzu

## Test plan

- [x] `scripts/agent-escalate.sh` manuell getestet — gibt korrekten ESCALATION-Block aus
- [x] `task workspace:validate` grün
- [x] `task freshness:check` grün — alle Artefakte aktuell
- [x] S4-Gate grün — 0 neue Verletzungen nach gates.yaml-Fix
- [x] Pre-push Hook bestanden

🤖 Generated with [Claude Code](https://claude.com/claude-code)