### PR TITLE
chore(ci): skills als gültigen Commit-Scope hinzufügen [T001058]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,6 +245,7 @@ jobs:
             recovery
             openspec
             mentolder-web
+            skills
           # Ticket references like [T000436] can extend subject length
           subjectPattern: ^.{1,200}$
           subjectPatternError: |


### PR DESCRIPTION
Fügt \`skills\` zur Liste der erlaubten Conventional-Commit-Scopes in CI hinzu.

[T001058]