### PR TITLE
chore(ci): test:changed um mentolder-web-Muster erweitern [T001063]

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -782,18 +782,20 @@ tasks:
       - |
         set -e
         CHANGED=$(git diff --name-only HEAD origin/main 2>/dev/null || git diff --name-only HEAD 2>/dev/null || true)
-        RUN_WEBSITE=false; RUN_K8S=false; RUN_SCRIPTS=false; RUN_FACTORY=false; RUN_UNIT=false
+        RUN_WEBSITE=false; RUN_MENTOLDER_WEB=false; RUN_K8S=false; RUN_SCRIPTS=false; RUN_FACTORY=false; RUN_UNIT=false
         echo "$CHANGED" | grep -qE "^website/" && RUN_WEBSITE=true || true
+        echo "$CHANGED" | grep -qE "^mentolder-web/" && RUN_MENTOLDER_WEB=true || true
         echo "$CHANGED" | grep -qE "^(k3d/|prod|prod-fleet|prod-mentolder|prod-korczewski|environments/)" && RUN_K8S=true || true
         echo "$CHANGED" | grep -qE "^scripts/" && RUN_SCRIPTS=true || true
         echo "$CHANGED" | grep -qE "^scripts/factory/" && RUN_FACTORY=true || true
         echo "$CHANGED" | grep -qE "^(tests/unit/|\.bats)" && RUN_UNIT=true || true
         if [ "$RUN_WEBSITE" = "true" ] && command -v pnpm >/dev/null 2>&1; then echo "→ website changes: pnpm vitest run --changed"; (cd website && pnpm vitest run --changed --reporter verbose); fi
+        if [ "$RUN_MENTOLDER_WEB" = "true" ] && command -v pnpm >/dev/null 2>&1; then echo "→ mentolder-web changes: pnpm --filter mentolder-web test"; pnpm --filter mentolder-web test; fi
         if [ "$RUN_K8S" = "true" ]; then echo "→ k8s changes: task test:manifests"; task test:manifests; fi
         if [ "$RUN_SCRIPTS" = "true" ]; then echo "→ script changes: task test:unit"; task test:unit; fi
         if [ "$RUN_FACTORY" = "true" ]; then echo "→ factory changes: task test:factory"; task test:factory; fi
         if [ "$RUN_UNIT" = "true" ] && [ "$RUN_SCRIPTS" = "false" ]; then echo "→ test changes: task test:unit"; task test:unit; fi
-        if [ "$RUN_WEBSITE" = "false" ] && [ "$RUN_K8S" = "false" ] && [ "$RUN_SCRIPTS" = "false" ] && [ "$RUN_FACTORY" = "false" ] && [ "$RUN_UNIT" = "false" ]; then
+        if [ "$RUN_WEBSITE" = "false" ] && [ "$RUN_MENTOLDER_WEB" = "false" ] && [ "$RUN_K8S" = "false" ] && [ "$RUN_SCRIPTS" = "false" ] && [ "$RUN_FACTORY" = "false" ] && [ "$RUN_UNIT" = "false" ]; then
           if command -v pnpm >/dev/null 2>&1; then echo "→ no domain-specific changes: vitest only"; (cd website && pnpm vitest run --reporter verbose); fi
         fi
         echo "→ quality gate (always)"; task test:code-quality


### PR DESCRIPTION
Erweitert die Smart-Selection-Logik in `Taskfile.yml::test:changed` um ein `^mentolder-web/`-Muster. Sobald Dateien unter `mentolder-web/` geändert werden, läuft die mentolder-web-Vitest-Suite (`pnpm --filter mentolder-web test`) automatisch mit.