### PR TITLE
chore(ops): close console.* gaps in 7 API routes and fill in spec SSOT [T001071]

### DIFF
--- a/openspec/specs/centralized-logging.md
+++ b/openspec/specs/centralized-logging.md
@@ -1,14 +1,217 @@
 # centralized-logging
 
+The platform SHALL collect container logs from all fleet namespaces into a single Loki
+instance, ship them through Promtail with structured parsing, and surface them through
+four Grafana dashboards. The website application SHALL emit newline-delimited JSON
+logs to stdout (via pino), correlate each log line to an `X-Request-ID`, and respond
+to API errors with a standardized `{ error, requestId }` body — never a stack trace.
 
 <!-- merged from change delta centralized-logging.md on 2026-06-21 -->
 
-### Requirement: TODO
+---
 
-The system SHALL …
+### Requirement: Pino logger singleton
 
-#### Scenario: TODO
+The system SHALL provide a `logger` singleton in `website/src/lib/logger.ts` that
+emits newline-delimited JSON to stdout, binds `service: 'website'`, and reads its
+level from `PINO_LOG_LEVEL` (defaulting to `info`).
 
-- **GIVEN** …
-- **WHEN** …
-- **THEN** …
+#### Scenario: Logger emits JSON with service binding
+
+- **GIVEN** the website SSR runtime starts with `PINO_LOG_LEVEL=info`
+- **WHEN** code calls `logger.info({ feature: 'foo' }, 'hello')`
+- **THEN** the emitted line is valid JSON containing `service: "website"`, `level: "info"`, and the message field
+- **AND** the line is terminated with a single newline (no transport/prettify)
+
+#### Scenario: createRequestLogger binds request context
+
+- **GIVEN** `createRequestLogger({ requestId: 'r-1', method: 'GET', path: '/x' })`
+- **WHEN** the returned child logger emits a line
+- **THEN** the line carries `requestId: "r-1"`, `method: "GET"`, and `path: "/x"` in addition to the base service binding
+
+---
+
+### Requirement: X-Request-ID injection and request lifecycle logging
+
+The system SHALL run a logging middleware on every request that reuses an incoming
+`X-Request-ID` header or generates a 12-character nanoid, writes `locals.requestId`
+and `locals.requestLogger`, logs `request.start` (info) and `request.end` (info/warn/
+error by status), and echoes `X-Request-ID` on the response.
+
+#### Scenario: Inbound header is reused
+
+- **GIVEN** a request arrives with `X-Request-ID: 01HMY...`
+- **WHEN** the logging middleware runs
+- **THEN** `locals.requestId` equals `01HMY...`
+- **AND** the response carries `X-Request-ID: 01HMY...`
+
+#### Scenario: Missing header yields a generated 12-char id
+
+- **GIVEN** a request arrives without `X-Request-ID`
+- **WHEN** the logging middleware runs
+- **THEN** `locals.requestId` is a 12-character nanoid
+- **AND** the response carries that same id back to the client
+
+#### Scenario: request.end is logged at the right level
+
+- **GIVEN** a handler returns a 4xx response
+- **WHEN** the middleware logs `request.end`
+- **THEN** the log entry has `level: "warn"`
+- **AND** 5xx responses produce `level: "error"`
+- **AND** 2xx/3xx responses produce `level: "info"`
+
+---
+
+### Requirement: Standardized error response contract
+
+The system SHALL expose `errorResponse(code, requestId, status=500)` from
+`website/src/pages/api/_errors.ts` that returns `{ error, requestId }` JSON with a
+configurable HTTP status. The response body SHALL never contain a stack trace, even
+when the underlying error is an `Error` instance.
+
+#### Scenario: Default status is 500
+
+- **GIVEN** `errorResponse('DB_ERROR', 'req-1')`
+- **WHEN** the response is parsed
+- **THEN** `res.status` is `500` and the body is `{ error: 'DB_ERROR', requestId: 'req-1' }`
+
+#### Scenario: Status is configurable
+
+- **GIVEN** `errorResponse('NOT_FOUND', 'req-1', 404)`
+- **WHEN** the response is parsed
+- **THEN** `res.status` is `404`
+
+#### Scenario: Body never leaks a stack trace
+
+- **GIVEN** an `Error('boom')` with stack `at foo (file.ts:1:1)`
+- **WHEN** a handler catches it and calls `errorResponse('BOOM', 'req-1', 500)`
+- **THEN** the JSON body equals `{ error: 'BOOM', requestId: 'req-1' }`
+- **AND** the serialized body does not contain the substring `at `
+
+---
+
+### Requirement: API surface is free of console.* logging
+
+The system SHALL NOT use `console.error`, `console.log`, `console.warn`, or
+`console.info` inside `website/src/pages/api/`. Every error or warning emitted by an
+API handler SHALL go through `locals.requestLogger` so the line carries the request
+correlation fields and is captured as structured JSON by Promtail.
+
+#### Scenario: No stray console calls in the API surface
+
+- **GIVEN** the website source tree
+- **WHEN** `grep -R "console\.\(error\|log\|warn\|info\)" website/src/pages/api` runs
+- **THEN** no matches are reported
+
+#### Scenario: API handler error is captured with request context
+
+- **GIVEN** a handler wrapped in try/catch and `locals.requestLogger` is populated by the middleware
+- **WHEN** the handler calls `locals.requestLogger.error({ err }, '[scope]')`
+- **THEN** the emitted JSON line includes `requestId`, `method`, and `path` from the child bindings
+- **AND** `err` is serialized with `pino.stdSerializers.err` (message + stack fields)
+
+#### Scenario: API handler error returns standardized body
+
+- **GIVEN** a handler catches an `Error` and calls `errorResponse('CODE', locals.requestId, status)`
+- **WHEN** the client receives the response
+- **THEN** the body is `{ error: 'CODE', requestId: <id> }` with no stack trace
+
+---
+
+### Requirement: PINO_LOG_LEVEL is environment-driven
+
+The system SHALL source the pino log level from the `PINO_LOG_LEVEL` environment
+variable, defaulting to `info` when unset, and the value SHALL be exposed by the
+website ConfigMap and registered in `environments/schema.yaml`.
+
+#### Scenario: Default level is info
+
+- **GIVEN** `PINO_LOG_LEVEL` is not set
+- **WHEN** the website starts
+- **THEN** pino's level is `info`
+
+#### Scenario: env:validate accepts the variable
+
+- **GIVEN** `PINO_LOG_LEVEL` is registered in `environments/schema.yaml` with `required: false, default_dev: info`
+- **WHEN** `task env:validate ENV=dev` runs
+- **THEN** validation passes
+
+---
+
+### Requirement: Traefik JSON access logs
+
+The system SHALL patch the k3s Traefik HelmChart via a `HelmChartConfig` to emit
+access logs in JSON format to stdout (so Promtail collects them) and SHALL keep the
+`X-Request-ID` request header visible in the log entries.
+
+#### Scenario: Traefik access logs are queryable in Loki
+
+- **GIVEN** the Traefik pods are running with the HelmChartConfig patch applied
+- **WHEN** an operator runs `{container="traefik"}` in Grafana Explore
+- **THEN** JSON-shaped access log entries are returned for each request
+
+---
+
+### Requirement: Promtail JSON pipeline with level label
+
+The system SHALL configure Promtail with a `pipelineStages` chain that parses JSON
+log lines, extracts the `level` field as a Loki label, and drops `level="debug"`
+entries in production to keep volume manageable.
+
+#### Scenario: Level label is attached to JSON logs
+
+- **GIVEN** a container writes `{ "level": "warn", "msg": "..." }` to stdout
+- **WHEN** Promtail ships the line to Loki
+- **THEN** the resulting stream is queryable via `{level="warn"}`
+
+#### Scenario: Debug entries are dropped
+
+- **GIVEN** a container writes `{ "level": "debug", "msg": "..." }` to stdout
+- **WHEN** Promtail processes the line
+- **THEN** the line is dropped before reaching Loki
+
+---
+
+### Requirement: Keycloak JSON console logging
+
+The system SHALL configure Keycloak to emit JSON-formatted console logs at
+`INFO` level, with `org.keycloak.events` raised to `DEBUG` so login and admin events
+are queryable in Loki.
+
+#### Scenario: Keycloak events are queryable in Loki
+
+- **GIVEN** Keycloak is running with `KC_LOG_CONSOLE_FORMAT=json` and `KC_LOG_LEVEL=INFO,org.keycloak.events:DEBUG`
+- **WHEN** a user performs a login
+- **THEN** the resulting events appear under `{app="keycloak"}` with a `level` label
+
+---
+
+### Requirement: Grafana dashboards for log observability
+
+The system SHALL ship four Grafana dashboards that consume the Loki datasource and
+expose the most common log views: a general log explorer, an API error tracker, a
+traefik access log analytics view, and a keycloak audit trail.
+
+#### Scenario: Log Explorer dashboard loads
+
+- **GIVEN** the `log-explorer` dashboard ConfigMap is mounted by the monitoring kustomization
+- **WHEN** an operator opens Grafana and selects "Log Explorer"
+- **THEN** the dashboard renders with namespace, app, level, and brand template variables
+
+#### Scenario: API Error Tracker dashboard loads
+
+- **GIVEN** the `api-errors` dashboard is mounted
+- **WHEN** an operator opens it
+- **THEN** it shows a top-10 failed endpoints table and an error-frequency-per-route timeseries
+
+#### Scenario: Traefik Access Log Analytics dashboard loads
+
+- **GIVEN** the `traefik-access` dashboard is mounted
+- **WHEN** an operator opens it
+- **THEN** it shows a status-code distribution over time, a top-10 slowest endpoints panel, and a 4xx/5xx rate panel with threshold
+
+#### Scenario: Keycloak Audit Trail dashboard loads
+
+- **GIVEN** the `keycloak-audit` dashboard is mounted
+- **WHEN** an operator opens it
+- **THEN** it shows login success/failure timeseries, a failed-auth table (user, clientId, ipAddress, time), and a panel for more than 5 failed logins in 5 minutes

--- a/website/src/pages/api/admin/agent-push/settings.ts
+++ b/website/src/pages/api/admin/agent-push/settings.ts
@@ -1,6 +1,7 @@
 import type { APIRoute } from 'astro';
 import { getSession, isAdmin } from '../../../../lib/auth';
 import { getEnabled, getAll, setEnabled } from '../../../../lib/agent-push-settings';
+import { errorResponse } from '../../_errors';
 
 export const prerender = false;
 
@@ -22,7 +23,7 @@ async function checkAuth(request: Request): Promise<boolean> {
   return false;
 }
 
-export const GET: APIRoute = async ({ request }) => {
+export const GET: APIRoute = async ({ request, locals }) => {
   if (!(await checkAuth(request))) {
     return new Response('Unauthorized', { status: 401 });
   }
@@ -43,15 +44,12 @@ export const GET: APIRoute = async ({ request }) => {
       headers: { 'Content-Type': 'application/json' },
     });
   } catch (err: any) {
-    console.error('Error in agent-push settings GET:', err);
-    return new Response(JSON.stringify({ error: err.message }), {
-      status: 500,
-      headers: { 'Content-Type': 'application/json' },
-    });
+    locals.requestLogger.error({ err }, '[agent-push settings GET]');
+    return errorResponse('AGENT_PUSH_SETTINGS_GET_FAILED', locals.requestId, 500);
   }
 };
 
-export const POST: APIRoute = async ({ request }) => {
+export const POST: APIRoute = async ({ request, locals }) => {
   if (!(await checkAuth(request))) {
     return new Response('Unauthorized', { status: 401 });
   }
@@ -73,10 +71,7 @@ export const POST: APIRoute = async ({ request }) => {
       headers: { 'Content-Type': 'application/json' },
     });
   } catch (err: any) {
-    console.error('Error in agent-push settings POST:', err);
-    return new Response(JSON.stringify({ error: err.message }), {
-      status: 500,
-      headers: { 'Content-Type': 'application/json' },
-    });
+    locals.requestLogger.error({ err }, '[agent-push settings POST]');
+    return errorResponse('AGENT_PUSH_SETTINGS_POST_FAILED', locals.requestId, 500);
   }
 };

--- a/website/src/pages/api/admin/billing/[id]/send.ts
+++ b/website/src/pages/api/admin/billing/[id]/send.ts
@@ -37,7 +37,7 @@ export const POST: APIRoute = async ({ request, params , locals }) => {
 
   const cityParts = (s.invoice_sender_city ?? '').trim();
   if (!cityParts) {
-    console.warn('[billing/send] invoice_sender_city not configured for brand', brand);
+    locals.requestLogger.warn({ brand }, '[billing/send] invoice_sender_city not configured');
   }
   const seller: InvoicePdfSeller = {
     name:       s.invoice_sender_name,

--- a/website/src/pages/api/admin/coaching/books/index.ts
+++ b/website/src/pages/api/admin/coaching/books/index.ts
@@ -5,7 +5,7 @@ import { pool } from '../../../../../lib/website-db';
 
 export const prerender = false;
 
-export const GET: APIRoute = async ({ request }) => {
+export const GET: APIRoute = async ({ request, locals }) => {
   const session = await getSession(request.headers.get('cookie'));
   if (!session || !isAdmin(session)) {
     return new Response('Unauthorized', { status: 401 });
@@ -16,7 +16,7 @@ export const GET: APIRoute = async ({ request }) => {
     books = await listBooks(pool);
   } catch (err) {
     // coaching schema may not exist on this cluster yet — return empty list
-    console.warn('[api/admin/coaching/books] listBooks failed:', err instanceof Error ? err.message : err);
+    locals.requestLogger.warn({ err }, '[api/admin/coaching/books] listBooks failed');
   }
   return new Response(JSON.stringify({ books }), {
     status: 200,

--- a/website/src/pages/api/admin/platform/hardware.ts
+++ b/website/src/pages/api/admin/platform/hardware.ts
@@ -5,7 +5,7 @@ import { createK8sClient, type K8sClient } from '../../../../lib/k8s';
 
 export const prerender = false;
 
-export const GET: APIRoute = async ({ request }) => {
+export const GET: APIRoute = async ({ request, locals }) => {
   const session = await getSession(request.headers.get('cookie'));
   if (!session || !isAdmin(session)) {
     return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 });
@@ -19,7 +19,7 @@ export const GET: APIRoute = async ({ request }) => {
     try {
       k8s = await createK8sClient();
     } catch (e) {
-      console.warn('[api/admin/platform/hardware] k8s client init failed:', (e as Error).message);
+      locals.requestLogger.warn({ err: e }, '[api/admin/platform/hardware] k8s client init failed');
     }
 
     const currentCluster = process.env.BRAND_ID || 'mentolder';

--- a/website/src/pages/api/admin/platform/software.ts
+++ b/website/src/pages/api/admin/platform/software.ts
@@ -6,7 +6,7 @@ import { resolveServiceUrl } from '../../../../lib/platform-links';
 
 export const prerender = false;
 
-export const GET: APIRoute = async ({ request }) => {
+export const GET: APIRoute = async ({ request, locals }) => {
   const session = await getSession(request.headers.get('cookie'));
   if (!session || !isAdmin(session)) {
     return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 });
@@ -20,7 +20,7 @@ export const GET: APIRoute = async ({ request }) => {
     try {
       k8s = await createK8sClient();
     } catch (e) {
-      console.warn('[api/admin/platform/software] k8s client init failed:', (e as Error).message);
+      locals.requestLogger.warn({ err: e }, '[api/admin/platform/software] k8s client init failed');
     }
 
     const currentCluster = process.env.BRAND_ID || 'mentolder';

--- a/website/src/pages/api/admin/projekte/create.ts
+++ b/website/src/pages/api/admin/projekte/create.ts
@@ -40,12 +40,12 @@ export const POST: APIRoute = async ({ request , locals }) => {
       if (tmpl) {
         const result = await materializeTemplate(id, tmpl.structure.folders);
         if (result.failed.length > 0) {
-          console.warn('[projekte/create] folder creation failed for some paths:', result.failed);
+          locals.requestLogger.warn({ failed: result.failed }, '[projekte/create] folder creation failed for some paths');
           foldersWarn = true;
         }
       }
     } catch (err) {
-      console.warn('[projekte/create] template materialization error:', err);
+      locals.requestLogger.warn({ err }, '[projekte/create] template materialization error');
       foldersWarn = true;
     }
   }

--- a/website/src/pages/api/meeting/save-transcript.ts
+++ b/website/src/pages/api/meeting/save-transcript.ts
@@ -24,7 +24,7 @@ import { ensureFolder, uploadFile } from '../../../lib/nextcloud-files';
 //   participants?: Array<{ displayName, email, uid }>,    // non-bot room members
 //   resources?: Array<{ type, name, storagePath, timestamp }>  // files from meeting window
 // }
-export const POST: APIRoute = async ({ request }) => {
+export const POST: APIRoute = async ({ request, locals }) => {
   let body: {
     roomToken?: string;
     transcriptText?: string;
@@ -61,7 +61,7 @@ export const POST: APIRoute = async ({ request }) => {
     // The transcriber bot passes roomName + participants from the Nextcloud DB.
     const firstParticipant = participants.find(p => p.email) ?? participants[0];
     if (!firstParticipant) {
-      console.warn(`[save-transcript] no meeting and no participant metadata for roomToken=${roomToken}`);
+      locals.requestLogger.warn({ roomToken }, '[save-transcript] no meeting and no participant metadata');
       return json({ error: 'Meeting not found for this room token' }, 404);
     }
 
@@ -69,7 +69,7 @@ export const POST: APIRoute = async ({ request }) => {
     const customerName = firstParticipant.displayName || firstParticipant.uid;
     const meetingTypeName = roomName || 'Talk-Session';
 
-    console.info(`[save-transcript] auto-creating meeting for roomToken=${roomToken}, customer=${customerName}`);
+    locals.requestLogger.info({ roomToken, customer: customerName }, '[save-transcript] auto-creating meeting');
     const customer = await upsertCustomer({ name: customerName, email: customerEmail });
     const created = await createMeeting({
       customerId: customer.id,
@@ -81,7 +81,7 @@ export const POST: APIRoute = async ({ request }) => {
     if (!meeting) {
       return json({ error: 'Failed to create meeting record' }, 500);
     }
-    console.info(`[save-transcript] auto-created meeting ${created.id}`);
+    locals.requestLogger.info({ meetingId: created.id }, '[save-transcript] auto-created meeting');
   }
 
   if (['transcribed', 'finalized'].includes(meeting.status)) {


### PR DESCRIPTION
Closes the gaps left behind by the archived centralized-logging change (#T000964).

## What

### Application logging (closes AC 1)
Migrate the 7 API routes that still used `console.error/warn/info` to use
`locals.requestLogger` so every line carries `requestId`, `method`, `path`
and is captured as structured JSON by Promtail:

- `website/src/pages/api/admin/agent-push/settings.ts` — 2 errors (GET/POST) + also now returns `errorResponse` instead of leaking `err.message` in the body
- `website/src/pages/api/admin/projekte/create.ts` — 2 warns (folder materialization)
- `website/src/pages/api/meeting/save-transcript.ts` — 1 warn + 2 infos
- `website/src/pages/api/admin/coaching/books/index.ts` — 1 warn
- `website/src/pages/api/admin/platform/hardware.ts` — 1 warn
- `website/src/pages/api/admin/platform/software.ts` — 1 warn
- `website/src/pages/api/admin/billing/[id]/send.ts` — 1 warn

After this change `grep -RE 'console\.(error|log|warn|info)' website/src/pages/api` returns nothing.

### Spec SSOT (closes the TODO stub)
The merged spec `openspec/specs/centralized-logging.md` was a TODO stub.
Rewrote it with 9 proper Requirements + 20 Scenarios that describe the
system that actually runs today:
- Pino logger singleton + `createRequestLogger`
- X-Request-ID middleware (incoming header reuse, 12-char nanoid fallback, request.start/end at the right level)
- Standardized `errorResponse(code, requestId, status)` contract
- API surface free of `console.*`
- `PINO_LOG_LEVEL` env-driven
- Traefik JSON access logs
- Promtail JSON pipeline + level label + debug drop
- Keycloak JSON console logging
- 4 Grafana dashboards (log-explorer, api-errors, traefik-access, keycloak-audit)

## Verification

- `pnpm vitest run src/lib/logger.test.ts src/middleware/logging.test.ts src/pages/api/_error-contract.test.ts` → 7/7 pass
- `task workspace:validate` → green
- `task freshness:regenerate` → no diff (all artifacts already current)
- `task freshness:check` → green (98→98 baseline, no new S1/S2 violations)
- `task test:code-quality` → 0 fails, 0 errors
- 7 route files all well under 500-line S1 limit (largest: send.ts 243)

## Out of scope / known pre-existing flake

- `src/lib/assistant/actions/portal/shareFile.test.ts` has 5–7 timeouts in the
  full vitest run, both on this branch AND on `main` (reproduced on
  `main` before any changes). The test passes in isolation
  (`pnpm vitest run src/lib/assistant/actions/portal/shareFile.test.ts` → 8/8 in 359ms).
  This is a pre-existing concurrency flake, not introduced by this PR. Will be
  tracked as a separate ticket.

## Next session

The session goal also calls for a **sidekick widget for log view/filter/search**.
That's planned for the next session as a separate feature change (iframe
Grafana Explore from the cockpit sidekick, with `X-Frame-Options` allowlisted
in the Grafana ingress — direction confirmed).