### PR TITLE
fix(infra): use correct ghcr.io registry for pocket-id image [T001068]

### DIFF
--- a/k3d/pocket-id.yaml
+++ b/k3d/pocket-id.yaml
@@ -1,6 +1,6 @@
 # ═══════════════════════════════════════════════════════════════════
 # Pocket ID — passkey-first OIDC identity provider
-# Replaces Keycloak for the workspace tenants. Image: stonith404/pocket-id.
+# Replaces Keycloak for the workspace tenants. Image: ghcr.io/pocket-id/pocket-id.
 # Container port 1411. Cluster-internal Service: http://pocket-id:1411.
 # Public hostname: ${POCKET_ID_DOMAIN} (id.localhost in dev, id.${PROD_DOMAIN} in prod).
 # ═══════════════════════════════════════════════════════════════════
@@ -147,7 +147,7 @@ spec:
               memory: "64Mi"
       containers:
         - name: pocket-id
-          image: stonith404/pocket-id:v2.9.0
+          image: ghcr.io/pocket-id/pocket-id:v2.9.0
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary

- `stonith404/pocket-id` on Docker Hub is no longer maintained; the Pocket ID project migrated to `ghcr.io/pocket-id/pocket-id`
- Discovered during mentolder production deploy when the pod failed to pull the image (`ImagePullBackOff`)
- Fixed `k3d/pocket-id.yaml`: image tag + header comment updated to `ghcr.io/pocket-id/pocket-id:v2.9.0`

## Test plan

- [ ] CI passes (manifest validation)
- [ ] After merge + deploy: `pocket-id` pod starts successfully on fleet (`1/1 Running`)
- [ ] `https://id.mentolder.de` returns HTTP 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rp4jVn1ZKGScN6434HcZLU