### PR TITLE
chore(ci): fix FLEET_KUBECONFIG unbound variable in post-merge [T001089]

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -87,6 +87,8 @@ jobs:
       - name: Mark ticket done
         id: close
         if: success()
+        env:
+          FLEET_KUBECONFIG: ${{ secrets.FLEET_KUBECONFIG }}
         run: |
           set -euo pipefail
           TICKET_ID="$(git log -1 --pretty=%B | grep -oE 'T[0-9]{6}' | head -1 || true)"


### PR DESCRIPTION
Fixes unbound variable error on post-merge workflow execution by adding missing env definition for FLEET_KUBECONFIG in 'Mark ticket done' step.