### PR TITLE
docs(dev-flow): add artifact-selection table + PRD-vs-propose checklist [T001094]

### DIFF
--- a/.claude/skills/dev-flow-plan/SKILL.md
+++ b/.claude/skills/dev-flow-plan/SKILL.md
@@ -100,6 +100,40 @@ Wähle einen der Pfade (Feature/Fix/Chore) basierend auf der Anfrage und kläre 
 > Diese Skill plant nur (Feature/Fix) und stoppt vor der Umsetzung. Die Umsetzung übernimmt
 > `dev-flow-execute`. Chores laufen vollständig in `dev-flow-chore`.
 
+### Artefakt-Ebene: braucht der Request ein PRD davor?
+
+Die feature/fix/chore-Wahl oben ist die *Pfad*-Wahl durch diese Skill. Davor steht die
+*Artefakt*-Wahl: die meisten Requests steigen direkt auf Change-Proposal-Ebene ein (Feature-Pfad
+→ Schritt 3.1 `openspec.sh propose`). Ein PRD ist das **schwerste** Artefakt und nur für
+Epic-große Arbeit gedacht — ein PRD pro Feature kollabiert die Abstraktionsebenen und erzeugt
+Mehrfach-SSOT.
+
+| Gestalt der Arbeit | Artefakt | Bei dir konkret |
+|---|---|---|
+| Großes, unscharfes Produktziel, viele Features | **PRD** | `parse_prd` (task-master) — Bootstrap/Epic-Zerlegung |
+| Architektur-/Technologieentscheidung | **ADR** | `manage_adr` / OpenSpec |
+| *Ein* konkretes Feature, Intent klar | **Change-Proposal** | `bash scripts/openspec.sh propose "<slug>" --ticket <id>` (Feature-Pfad, Schritt 3.1) |
+| Feature, aber Design noch offen | **Brainstorming → Spec** | diese Skill, Feature-Pfad |
+| Wartung, kein Verhaltenswechsel | **Chore-Ticket** | `dev-flow-chore` |
+| Regression | **Fix + failing test** | diese Skill, Fix-Pfad |
+
+**Checkliste — PRD davor, oder direkt `openspec:propose`?**
+
+PRD davorschalten, wenn MINDESTENS EINE zutrifft:
+- **Mehrere Capabilities** — der Request zerfällt in >1 OpenSpec-Change (Epic).
+- **„Warum" strittig** — Problem/Zielgruppe/Erfolgsmetrik offen, nicht nur das „Wie".
+- **Neues Teilprodukt/Service** — net-new Surface, keine bestehende Spec zum Anknüpfen.
+- **Cross-Brand/Cross-Subsystem** mit echtem Priorisierungsbedarf.
+
+Direkt `openspec:propose` (kein PRD), wenn ALLE zutreffen:
+- Genau **eine** Capability betroffen.
+- Intent klar, nur das „Wie" offen → klärt das Brainstorming (Schritt 3) ohnehin.
+- Es gibt eine bestehende Spec in `openspec/specs/`, in die der Delta einfließt (oder klar genau eine neue).
+
+> **Faustregel:** PRD nur, wenn die Arbeit größer ist als ein einzelner Change — sonst Overhead.
+> Im PRD-Fall: `parse_prd` → N Tickets/Changes → für *jeden* Change wieder dieser normale Pfad.
+> Das PRD bleibt **Upstream-Kontext, wird nie SSOT** (die konsolidierte `openspec/specs/`-Spec ist SSOT).
+
 ---
 
 ## Feature-Pfad


### PR DESCRIPTION
## Was
Ergänzt in `.claude/skills/dev-flow-plan/SKILL.md` (**Schritt 0: Pfad bestimmen**) eine
**Artefakt-Auswahl-Tabelle** und eine **Checkliste** „PRD davor, oder direkt `openspec:propose`?".

## Warum
Die bisherige Schritt-0-Liste deckt nur die feature/fix/chore-*Pfad*-Wahl ab. Es fehlte die
vorgelagerte *Artefakt*-Ebene: wann ein Request ein PRD (Epic-Skala) braucht versus direkten
Einstieg auf Change-Proposal-Ebene. Die Faustregel „PRD nur, wenn die Arbeit größer ist als ein
einzelner Change" verhindert „ein PRD pro Feature" (Mehrfach-SSOT).

## Scope
- Reine Doku-Ergänzung, **keine Verhaltensänderung**.
- 1 Datei, +34 Zeilen.
- Audit-Ticket: `T001094`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01188uJNuSNmvDYi7XLpHmm6
