### PR TITLE
fix(website): add missing errorResponse import in scheduled-publish cron

### DIFF
--- a/website/src/pages/api/cron/scheduled-publish.ts
+++ b/website/src/pages/api/cron/scheduled-publish.ts
@@ -6,6 +6,7 @@ import {
   resetStaleSendingCampaigns,
   sendCampaignById,
 } from '../../../lib/newsletter-db';
+import { errorResponse } from '../_errors';
 
 const CRON_SECRET = process.env.CRON_SECRET ?? '';
 


### PR DESCRIPTION
## Summary

- `scheduled-publish.ts` called `errorResponse()` in both the auth check and error catch block but never imported it from `../_errors`
- This caused a `ReferenceError: errorResponse is not defined` every 5 minutes (cron interval), visible in website pod logs
- One-line fix: add `import { errorResponse } from '../_errors';`

## Test plan

- [ ] Website pod logs show no more `ReferenceError: errorResponse is not defined` after deploy
- [ ] `/api/cron/scheduled-publish` responds correctly (401 without valid CRON_SECRET)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QiEPXsjoTyWNc9XDD9i5VX