### PR TITLE
chore(admin): ticket- und projektansichten visuell aufwerten [T001112]

### DIFF
--- a/website/src/components/admin/CockpitTable.svelte
+++ b/website/src/components/admin/CockpitTable.svelte
@@ -169,8 +169,14 @@
 
 <section class="cockpit-table" data-testid="cockpit-table">
   <div class="toolbar">
-    <input class="search" data-testid="table-search" type="search"
-      placeholder="Suche (Titel oder T-ID)…" bind:value={search} aria-label="Tickets durchsuchen" />
+    <div class="search-wrap">
+      <svg class="search-icon" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+        <circle cx="6.5" cy="6.5" r="5" stroke="currentColor" stroke-width="1.5"/>
+        <path d="M10.5 10.5L14 14" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+      </svg>
+      <input class="search" data-testid="table-search" type="search"
+        placeholder="Suche (Titel oder T-ID)…" bind:value={search} aria-label="Tickets durchsuchen" />
+    </div>
     <div class="chips" role="group" aria-label="Status-Filter">
       {#each CHIPS as c}
         <button class="chip" class:active={statusFilter === c.value}
@@ -233,30 +239,94 @@
 </section>
 
 <style>
-  .cockpit-table { display: flex; flex-direction: column; gap: 0.5rem; min-height: 0; }
-  .table-scroll-container { overflow-x: auto; width: 100%; }
+  .cockpit-table { display: flex; flex-direction: column; gap: 0.6rem; min-height: 0; }
+  .table-scroll-container { overflow-x: auto; width: 100%; border: 1px solid var(--admin-border, rgba(255,255,255,0.07)); border-radius: 10px; }
+
   .toolbar { display: flex; gap: 0.5rem; align-items: center; flex-wrap: wrap; }
-  .search { flex: 1 1 180px; min-width: 140px; background: var(--admin-bg, #1c1f26);
-    border: 1px solid var(--admin-border, #2a2e37); color: inherit; border-radius: 6px; padding: 0.4rem 0.6rem; }
-  .chips { display: flex; gap: 0.25rem; overflow-x: auto; }
-  .chip { background: transparent; border: 1px solid var(--admin-border, #2a2e37);
-    color: var(--admin-text-mute, #9ca3af); border-radius: 999px; padding: 0.25rem 0.65rem;
-    font-size: 0.78rem; cursor: pointer; white-space: nowrap; }
-  .chip.active { background: var(--admin-primary, #6ea8fe); color: var(--admin-bg, #0b0d12); border-color: transparent; font-weight: 600; }
-  .create { background: var(--admin-primary, #6ea8fe); color: var(--admin-bg, #0b0d12);
-    border: none; border-radius: 6px; padding: 0.4rem 0.8rem; cursor: pointer; font-weight: 600; white-space: nowrap; }
-  .feature-title { margin: 0; font-size: 1rem; font-weight: 600; display: flex; align-items: baseline; gap: 0.4rem; flex-wrap: wrap; }
-  .feature-meta { font-size: 0.72rem; font-weight: 400; color: var(--admin-text-mute, #9ca3af); }
-  .counts { margin: 0; font-size: 0.72rem; color: var(--admin-text-mute, #9ca3af); }
-  .row-header { display: grid; grid-template-columns: auto auto auto 1fr auto auto auto auto;
-    gap: 0.5rem; align-items: center; padding: 0.25rem 0.5rem; border-bottom: 1px solid var(--admin-border, #2a2e37);
-    border-left: 3px solid transparent; font-size: 0.68rem; text-transform: uppercase; letter-spacing: 0.04em;
-    color: var(--admin-text-mute, #9ca3af); position: sticky; top: 0; background: var(--admin-surface, #14171d); z-index: 1; }
+  .search-wrap { position: relative; flex: 1 1 180px; min-width: 140px; }
+  .search-icon { position: absolute; left: 0.55rem; top: 50%; transform: translateY(-50%); width: 14px; height: 14px; opacity: 0.45; pointer-events: none; }
+  .search {
+    width: 100%; background: var(--admin-surface, rgba(255,255,255,0.04));
+    border: 1px solid var(--admin-border, rgba(255,255,255,0.07));
+    color: var(--admin-text, #eef1f3); border-radius: 8px;
+    padding: 0.42rem 0.6rem 0.42rem 2rem;
+    font-size: 0.82rem;
+    transition: border-color 0.15s, box-shadow 0.15s;
+    outline: none;
+    box-sizing: border-box;
+  }
+  .search:focus { border-color: var(--admin-primary, oklch(0.80 0.09 75)); box-shadow: 0 0 0 2px oklch(0.80 0.09 75 / 0.15); }
+
+  .chips { display: flex; gap: 0.25rem; overflow-x: auto; scrollbar-width: none; }
+  .chips::-webkit-scrollbar { display: none; }
+  .chip {
+    background: transparent;
+    border: 1px solid var(--admin-border, rgba(255,255,255,0.07));
+    color: var(--admin-text-mute, #8c96a3);
+    border-radius: 999px;
+    padding: 0.28rem 0.7rem;
+    font-size: 0.78rem;
+    cursor: pointer;
+    white-space: nowrap;
+    transition: background 0.12s, color 0.12s, border-color 0.12s;
+  }
+  .chip:hover { background: var(--admin-surface-hover, rgba(255,255,255,0.06)); color: var(--admin-text, #eef1f3); }
+  .chip.active {
+    background: var(--admin-primary, oklch(0.80 0.09 75));
+    color: var(--admin-bg, #0b111c);
+    border-color: transparent;
+    font-weight: 600;
+  }
+
+  .create {
+    background: var(--admin-primary, oklch(0.80 0.09 75));
+    color: var(--admin-bg, #0b111c);
+    border: none; border-radius: 8px;
+    padding: 0.42rem 0.9rem;
+    cursor: pointer; font-weight: 700; font-size: 0.82rem;
+    white-space: nowrap;
+    transition: filter 0.12s;
+  }
+  .create:hover { filter: brightness(1.1); }
+
+  .feature-title { margin: 0.25rem 0 0; font-size: 1rem; font-weight: 600; display: flex; align-items: baseline; gap: 0.4rem; flex-wrap: wrap; }
+  .feature-meta { font-size: 0.72rem; font-weight: 400; color: var(--admin-text-mute, #8c96a3); }
+  .counts { margin: 0; font-size: 0.7rem; color: var(--admin-text-mute, #8c96a3); }
+
+  .row-header {
+    display: grid;
+    grid-template-columns: auto auto auto 1fr auto auto auto auto;
+    gap: 0.5rem;
+    align-items: center;
+    padding: 0.3rem 0.75rem;
+    border-bottom: 1px solid var(--admin-border, rgba(255,255,255,0.07));
+    border-left: 3px solid transparent;
+    font-size: 0.67rem; text-transform: uppercase; letter-spacing: 0.06em;
+    color: var(--admin-text-mute, #8c96a3);
+    position: sticky; top: 0;
+    background: var(--admin-bg, #0b111c);
+    border-radius: 9px 9px 0 0;
+    z-index: 1;
+  }
+
   .rows { display: flex; flex-direction: column; }
-  .empty { opacity: 0.6; padding: 0.5rem; }
-  .more { align-self: flex-start; background: transparent; border: 1px solid var(--admin-border, #2a2e37);
-    color: var(--admin-text-mute, #9ca3af); border-radius: 6px; padding: 0.35rem 0.8rem; cursor: pointer; font-size: 0.8rem; }
-  .more:hover { color: var(--admin-text, #e5e7eb); }
+  .empty {
+    padding: 2.5rem 1rem;
+    text-align: center;
+    color: var(--admin-text-mute, #8c96a3);
+    font-size: 0.85rem;
+  }
+  .more {
+    align-self: flex-start;
+    background: transparent;
+    border: 1px solid var(--admin-border, rgba(255,255,255,0.07));
+    color: var(--admin-text-mute, #8c96a3);
+    border-radius: 8px;
+    padding: 0.38rem 0.9rem;
+    cursor: pointer; font-size: 0.8rem;
+    transition: color 0.1s, border-color 0.1s;
+  }
+  .more:hover { color: var(--admin-text, #eef1f3); border-color: var(--admin-border-bright, rgba(255,255,255,0.12)); }
 
   @media (max-width: 767px) {
     .row-header .col-prio, .row-header .col-date, .row-header .col-openspec { display: none; }

--- a/website/src/components/admin/TicketRow.svelte
+++ b/website/src/components/admin/TicketRow.svelte
@@ -57,13 +57,18 @@
   <input type="checkbox" data-testid="row-checkbox" checked={selected}
     on:change={handleSelectToggle} aria-label={`Select ${ticket.title}`} />
   <span class="handle" draggable="true" role="button" tabindex="0" aria-label="Reorder (Shift+Up/Down)"
-    on:dragstart={handleDragStart}>⋮⋮</span>
+    on:dragstart={handleDragStart}>⠿</span>
   <code class="ext ticket-col-id">{ticket.extId}</code>
-  <a class="title-link cockpit-ticket-title" href="/admin/tickets/{ticket.id}" title={ticket.title}>{ticket.title}</a>
-  <select data-testid="status-select" value={ticket.status} on:change={handleStatus} disabled={busy}>
+  <a class="title-link cockpit-ticket-title" href="/admin/tickets/{ticket.id}" title={ticket.title}>
+    <span class="type-dot type-dot--{ticket.type}"></span>
+    {ticket.title}
+  </a>
+  <select data-testid="status-select" class="status-sel" data-s={ticket.status}
+    value={ticket.status} on:change={handleStatus} disabled={busy}>
     {#each STATUSES as s}<option value={s}>{statusLabel(s)}</option>{/each}
   </select>
-  <select class="priority-select" data-testid="priority-select" value={ticket.priority} on:change={handlePriority} disabled={busy}>
+  <select class="prio-sel priority-select" data-testid="priority-select" value={ticket.priority}
+    on:change={handlePriority} disabled={busy}>
     {#each PRIORITIES as p}<option value={p}>{priorityLabel(p)}</option>{/each}
   </select>
   <span class="created ticket-col-created">{relDate(ticket.createdAt)}</span>
@@ -79,26 +84,133 @@
 </div>
 
 <style>
-  .row { display: grid;
-    grid-template-columns: auto auto auto 1fr auto auto auto auto; gap: 0.5rem;
-    align-items: center; padding: 0.4rem 0.5rem; border-bottom: 1px solid var(--admin-border, #2a2e37);
-    border-left: 3px solid transparent; }
-  .row.selected { background: rgba(110,168,254,0.12); }
+  .row {
+    display: grid;
+    grid-template-columns: auto auto auto 1fr auto auto auto auto;
+    gap: 0.5rem;
+    align-items: center;
+    padding: 0.45rem 0.75rem;
+    border-bottom: 1px solid var(--admin-border, rgba(255,255,255,0.07));
+    border-left: 3px solid transparent;
+    transition: background 0.1s ease;
+  }
+  .row:hover { background: var(--admin-surface-hover, rgba(255,255,255,0.05)); }
+  .row.selected { background: rgba(110,168,254,0.08); border-left-color: #6ea8fe; }
+  .row[aria-busy="true"] { opacity: 0.6; pointer-events: none; }
   .row.prio-niedrig { border-left-color: #10b981; }
   .row.prio-mittel  { border-left-color: #f59e0b; }
   .row.prio-hoch    { border-left-color: #f97316; }
   .row.prio-kritisch{ border-left-color: #ef4444; }
-  .handle { cursor: grab; opacity: 0.5; }
-  .title-link { color: inherit; text-decoration: none; cursor: pointer; }
-  .title-link:hover { text-decoration: underline; }
-  .ext { opacity: 0.6; font-size: 0.75rem; font-family: var(--font-mono, monospace); }
-  .created { opacity: 0.6; font-size: 0.72rem; white-space: nowrap; }
+
+  .handle {
+    cursor: grab;
+    color: var(--admin-text-mute, #8c96a3);
+    font-size: 0.88rem;
+    user-select: none;
+    transition: color 0.1s;
+    line-height: 1;
+  }
+  .handle:hover { color: var(--admin-text, #eef1f3); }
+
+  .ext {
+    font-family: var(--font-mono, monospace);
+    font-size: 0.68rem;
+    color: var(--admin-primary, oklch(0.80 0.09 75));
+    background: oklch(0.80 0.09 75 / 0.1);
+    padding: 1px 5px;
+    border-radius: 4px;
+    white-space: nowrap;
+    letter-spacing: 0.01em;
+  }
+
+  .title-link {
+    color: var(--admin-text, #eef1f3);
+    text-decoration: none;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    gap: 0.45rem;
+    overflow: hidden;
+    font-size: 0.855rem;
+    min-width: 0;
+  }
+  .title-link:hover { color: var(--admin-primary, oklch(0.80 0.09 75)); }
+
+  .type-dot {
+    display: inline-block;
+    width: 6px; height: 6px;
+    border-radius: 50%;
+    flex-shrink: 0;
+  }
+  .type-dot--bug      { background: #f87171; }
+  .type-dot--task     { background: #60a5fa; }
+  .type-dot--feature  { background: #34d399; }
+  .type-dot--project  { background: var(--admin-primary, oklch(0.80 0.09 75)); }
+  .type-dot--story    { background: #a78bfa; }
+  .type-dot--spike    { background: #fb923c; }
+
+  /* Status as colored pill-select */
+  .status-sel {
+    appearance: none; -webkit-appearance: none;
+    font-size: 0.72rem; font-weight: 600;
+    padding: 0.22rem 1.3rem 0.22rem 0.55rem;
+    border-radius: 9999px;
+    cursor: pointer;
+    border: 1px solid;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6'%3E%3Cpath d='M0 0l5 6 5-6z' fill='%238c96a3'/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-position: right 0.42rem center;
+    background-size: 7px;
+    white-space: nowrap;
+    transition: filter 0.1s, opacity 0.1s;
+    outline: none;
+  }
+  .status-sel:hover:not(:disabled) { filter: brightness(1.15); }
+  .status-sel:focus { outline: 2px solid var(--admin-primary, oklch(0.80 0.09 75)); outline-offset: 1px; }
+  .status-sel:disabled { opacity: 0.55; cursor: default; }
+  .status-sel[data-s="triage"]          { background-color: rgba(168,85,247,0.14); color: #d8b4fe; border-color: rgba(168,85,247,0.34); }
+  .status-sel[data-s="backlog"]         { background-color: rgba(100,116,139,0.14); color: #94a3b8; border-color: rgba(100,116,139,0.28); }
+  .status-sel[data-s="in_progress"]     { background-color: rgba(234,179,8,0.18);  color: #fde68a; border-color: rgba(234,179,8,0.34); }
+  .status-sel[data-s="in_review"]       { background-color: rgba(99,102,241,0.16); color: #a5b4fc; border-color: rgba(99,102,241,0.34); }
+  .status-sel[data-s="blocked"]         { background-color: rgba(239,68,68,0.16);  color: #fca5a5; border-color: rgba(239,68,68,0.34); }
+  .status-sel[data-s="done"]            { background-color: rgba(16,185,129,0.14); color: #6ee7b7; border-color: rgba(16,185,129,0.28); }
+  .status-sel[data-s="awaiting_deploy"] { background-color: rgba(6,182,212,0.14);  color: #67e8f9; border-color: rgba(6,182,212,0.28); }
+  .status-sel[data-s="archived"]        { background-color: rgba(255,255,255,0.04); color: #6b7280; border-color: rgba(255,255,255,0.1); }
+
+  /* Priority select */
+  .prio-sel {
+    appearance: none; -webkit-appearance: none;
+    font-size: 0.72rem; font-weight: 500;
+    padding: 0.22rem 1.1rem 0.22rem 0.45rem;
+    border-radius: 6px;
+    cursor: pointer;
+    background-color: var(--admin-surface, rgba(255,255,255,0.04));
+    border: 1px solid var(--admin-border, rgba(255,255,255,0.07));
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6'%3E%3Cpath d='M0 0l5 6 5-6z' fill='%238c96a3'/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-position: right 0.3rem center;
+    background-size: 7px;
+    white-space: nowrap;
+    outline: none;
+    transition: opacity 0.1s;
+  }
+  .prio-sel:disabled { opacity: 0.55; cursor: default; }
+  .row.prio-niedrig  .prio-sel { color: #10b981; }
+  .row.prio-mittel   .prio-sel { color: #f59e0b; }
+  .row.prio-hoch     .prio-sel { color: #f97316; }
+  .row.prio-kritisch .prio-sel { color: #ef4444; }
+
+  .created { color: var(--admin-text-mute, #8c96a3); font-size: 0.7rem; white-space: nowrap; }
+
   .os-badges { display: flex; gap: 0.25rem; align-items: center; }
-  .os-badge { font-size: 0.65rem; font-weight: 700; padding: 0.15rem 0.4rem; border-radius: 4px;
-    letter-spacing: 0.04em; white-space: nowrap; }
-  .os-badge--planning   { background: #78350f; color: #fde68a; }
-  .os-badge--plan_staged{ background: #14532d; color: #86efac; }
-  .os-badge--archived   { background: #374151; color: #9ca3af; }
+  .os-badge {
+    font-size: 0.62rem; font-weight: 700;
+    padding: 0.15rem 0.4rem; border-radius: 4px;
+    letter-spacing: 0.04em; white-space: nowrap;
+  }
+  .os-badge--planning    { background: rgba(120,53,15,0.6);  color: #fde68a; }
+  .os-badge--plan_staged { background: rgba(20,83,45,0.6);   color: #86efac; }
+  .os-badge--archived    { background: rgba(55,65,81,0.6);   color: #9ca3af; }
 
   @media (max-width: 767px) {
     .row { grid-template-columns: auto auto 1fr auto; }

--- a/website/src/pages/admin/projekte.astro
+++ b/website/src/pages/admin/projekte.astro
@@ -147,13 +147,13 @@ const labelCls  = 'block text-xs text-muted mb-1';
       <div class="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-8">
         {[
           { label: 'Gesamt',     value: stats.total,        cls: 'border-dark-lighter' },
-          { label: 'Aktiv',      value: stats.aktiv,        cls: 'border-yellow-800' },
-          { label: 'Überfällig', value: stats.ueberfaellig, cls: stats.ueberfaellig > 0 ? 'border-red-800' : 'border-dark-lighter' },
-          { label: 'Erledigt',   value: stats.erledigt,     cls: 'border-green-800' },
+          { label: 'Aktiv',      value: stats.aktiv,        cls: 'border-yellow-800/70' },
+          { label: 'Überfällig', value: stats.ueberfaellig, cls: stats.ueberfaellig > 0 ? 'border-red-700/70' : 'border-dark-lighter' },
+          { label: 'Erledigt',   value: stats.erledigt,     cls: 'border-green-800/70' },
         ].map(s => (
-          <div class={`p-4 bg-dark-light rounded-xl border ${s.cls}`}>
-            <div class="text-2xl font-bold text-light">{s.value}</div>
-            <div class="text-xs text-muted mt-0.5">{s.label}</div>
+          <div class={`p-5 bg-dark-light rounded-xl border ${s.cls} flex flex-col`}>
+            <div class="text-3xl font-bold text-light tabular-nums">{s.value}</div>
+            <div class="text-xs text-muted uppercase tracking-wide">{s.label}</div>
           </div>
         ))}
       </div>
@@ -221,17 +221,17 @@ const labelCls  = 'block text-xs text-muted mb-1';
       <div class="bg-dark-light rounded-2xl border border-dark-lighter overflow-hidden mb-10">
         <table class="w-full">
           <thead>
-            <tr class="border-b border-dark-lighter">
-              <th class="text-left px-4 py-3 text-xs text-muted uppercase tracking-wide font-medium">Projekt</th>
-              <th class="text-left px-4 py-3 text-xs text-muted uppercase tracking-wide font-medium">Kunde</th>
-              <th class="text-left px-4 py-3 text-xs text-muted uppercase tracking-wide font-medium">Status</th>
-              <th class="text-left px-4 py-3 text-xs text-muted uppercase tracking-wide font-medium">Prio</th>
-              <th class="text-left px-4 py-3 text-xs text-muted uppercase tracking-wide font-medium">Erfasst</th>
-              <th class="text-left px-4 py-3 text-xs text-muted uppercase tracking-wide font-medium">Start</th>
-              <th class="text-left px-4 py-3 text-xs text-muted uppercase tracking-wide font-medium">Fälligkeit</th>
-              <th class="text-center px-4 py-3 text-xs text-muted uppercase tracking-wide font-medium">TP</th>
-              <th class="text-center px-4 py-3 text-xs text-muted uppercase tracking-wide font-medium">Aufg.</th>
-              <th class="text-right px-4 py-3 text-xs text-muted uppercase tracking-wide font-medium">Aktionen</th>
+            <tr class="border-b border-dark-lighter bg-dark/40">
+              <th class="text-left px-4 py-3 text-xs text-muted/70 uppercase tracking-wider font-semibold">Projekt</th>
+              <th class="text-left px-4 py-3 text-xs text-muted/70 uppercase tracking-wider font-semibold">Kunde</th>
+              <th class="text-left px-4 py-3 text-xs text-muted/70 uppercase tracking-wider font-semibold">Status</th>
+              <th class="text-left px-4 py-3 text-xs text-muted/70 uppercase tracking-wider font-semibold">Prio</th>
+              <th class="text-left px-4 py-3 text-xs text-muted/70 uppercase tracking-wider font-semibold">Erfasst</th>
+              <th class="text-left px-4 py-3 text-xs text-muted/70 uppercase tracking-wider font-semibold">Start</th>
+              <th class="text-left px-4 py-3 text-xs text-muted/70 uppercase tracking-wider font-semibold">Fällig</th>
+              <th class="text-center px-4 py-3 text-xs text-muted/70 uppercase tracking-wider font-semibold">TP</th>
+              <th class="text-center px-4 py-3 text-xs text-muted/70 uppercase tracking-wider font-semibold">Aufg.</th>
+              <th class="text-right px-4 py-3 text-xs text-muted/70 uppercase tracking-wider font-semibold">Aktionen</th>
             </tr>
           </thead>
           <tbody>
@@ -244,9 +244,9 @@ const labelCls  = 'block text-xs text-muted mb-1';
             ) : projects.map(p => {
               const isOverdue = p.dueDate && new Date(p.dueDate) < today && !['erledigt','archiviert'].includes(p.status);
               return (
-                <tr class={`border-b border-dark-lighter/50 hover:bg-dark/30 transition-colors ${p.status === 'archiviert' ? 'opacity-40' : ''}`}>
-                  <td class="px-4 py-3">
-                    <a href={`/admin/projekte/${p.id}`} class="text-light hover:text-gold font-medium text-sm transition-colors">
+                <tr class={`border-b border-dark-lighter/50 hover:bg-white/[.025] transition-colors ${p.status === 'archiviert' ? 'opacity-40' : ''}`}>
+                  <td class="px-4 py-3.5">
+                    <a href={`/admin/projekte/${p.id}`} class="text-light hover:text-gold font-semibold text-sm transition-colors">
                       {p.name}
                     </a>
                     {p.description && <p class="text-xs text-muted mt-0.5 max-w-[220px] truncate">{p.description}</p>}

--- a/website/src/pages/admin/tickets/[id].astro
+++ b/website/src/pages/admin/tickets/[id].astro
@@ -108,37 +108,36 @@ function fmtDateTime(d: Date | string | null): string {
     <div class="max-w-6xl mx-auto px-6">
 
       {/* Breadcrumb */}
-      <nav class="text-sm text-muted mb-4">
-        <a href="/admin/tickets" class="hover:text-gold">Tickets</a>
-        <span class="mx-2">/</span>
-        <span class="font-mono text-gold">{ticket.externalId ?? ticket.id.slice(0, 8)}</span>
+      <nav class="text-sm mb-6 flex items-center gap-2">
+        <a href="/admin/tickets" class="text-muted hover:text-gold transition-colors">Tickets</a>
+        <span class="text-muted/30 select-none">›</span>
+        <span class="font-mono text-xs bg-gold/10 text-gold px-2 py-0.5 rounded">{ticket.externalId ?? ticket.id.slice(0, 8)}</span>
       </nav>
 
       {/* Header */}
       <div class="mb-6 flex items-start gap-4 flex-wrap">
         <div class="flex-1 min-w-0">
-          <div class="flex items-center gap-3 flex-wrap mb-2">
-            <span class="text-xs px-2 py-1 rounded bg-dark-light border border-dark-lighter text-muted whitespace-nowrap">
+          <div class="flex items-center gap-2.5 flex-wrap mb-3">
+            <span class="text-xs px-2.5 py-1 rounded-full bg-dark border border-dark-lighter/80 text-muted/80 whitespace-nowrap font-medium">
               {typeLabel(ticket.type)}
             </span>
-            <span class={`text-xs px-2 py-0.5 rounded-full border ${STATUS_CLS[ticket.status] ?? ''}`}>
-              {statusLabel(ticket.status)}
-              {ticket.resolution && ` (${ticket.resolution})`}
+            <span class={`text-xs px-3 py-1 rounded-full border font-semibold whitespace-nowrap ${STATUS_CLS[ticket.status] ?? ''}`}>
+              {statusLabel(ticket.status)}{ticket.resolution ? ` · ${ticket.resolution}` : ''}
             </span>
-            <span class={`text-sm font-semibold ${PRIO_CLS[ticket.priority] ?? ''}`}>
+            <span class={`text-sm font-bold ${PRIO_CLS[ticket.priority] ?? ''}`}>
               {PRIO_ICON[ticket.priority]} {ticket.priority}
             </span>
             {ticket.severity && (
-              <span class="text-xs px-2 py-0.5 rounded bg-dark border border-dark-lighter text-muted">
+              <span class="text-xs px-2 py-0.5 rounded-full bg-dark border border-dark-lighter text-muted/80">
                 {ticket.severity}
               </span>
             )}
           </div>
-          <h1 class="text-2xl font-bold text-light font-serif">{ticket.title}</h1>
+          <h1 class="text-2xl font-bold text-light font-serif leading-snug">{ticket.title}</h1>
           {ticket.tagNames.length > 0 && (
-            <div class="flex flex-wrap gap-1 mt-2">
+            <div class="flex flex-wrap gap-1.5 mt-2.5">
               {ticket.tagNames.map(tag => (
-                <span class="text-[10px] px-1.5 py-0.5 rounded bg-dark border border-dark-lighter text-muted">
+                <span class="text-[10px] px-2 py-0.5 rounded-full bg-dark border border-dark-lighter/60 text-muted/70">
                   {tag}
                 </span>
               ))}
@@ -167,7 +166,7 @@ function fmtDateTime(d: Date | string | null): string {
 
           {/* Description */}
           <div class="bg-dark-light rounded-2xl border border-dark-lighter p-6">
-            <h2 class="text-sm font-semibold text-light mb-2 font-serif uppercase tracking-wide">Beschreibung</h2>
+            <h2 class="text-xs font-semibold text-muted uppercase tracking-widest mb-3 pb-2 border-b border-dark-lighter/50">Beschreibung</h2>
             {ticket.description ? (
               <div class="md-body text-light/90" set:html={renderMarkdown(ticket.description)} />
             ) : (
@@ -205,7 +204,7 @@ function fmtDateTime(d: Date | string | null): string {
           {/* Linked tickets */}
           {ticket.links.length > 0 && (
             <div class="bg-dark-light rounded-2xl border border-dark-lighter p-6">
-              <h2 class="text-sm font-semibold text-light mb-3 font-serif uppercase tracking-wide">
+              <h2 class="text-xs font-semibold text-muted uppercase tracking-widest mb-3 pb-2 border-b border-dark-lighter/50">
                 Verknüpfungen ({ticket.links.length})
               </h2>
               <ul class="space-y-2">
@@ -237,7 +236,7 @@ function fmtDateTime(d: Date | string | null): string {
 
           {/* Activity timeline */}
           <div class="bg-dark-light rounded-2xl border border-dark-lighter p-6">
-            <h2 class="text-sm font-semibold text-light mb-3 font-serif uppercase tracking-wide">Verlauf</h2>
+            <h2 class="text-xs font-semibold text-muted uppercase tracking-widest mb-3 pb-2 border-b border-dark-lighter/50">Verlauf</h2>
             <TicketActivityTimeline client:load entries={timeline} />
           </div>
 
@@ -253,58 +252,58 @@ function fmtDateTime(d: Date | string | null): string {
           <div class="bg-dark-light rounded-2xl border border-dark-lighter p-5 text-sm">
             <dl class="space-y-3">
               <div>
-                <dt class="text-xs text-muted uppercase tracking-wide mb-0.5">Erstellt</dt>
+                <dt class="text-[10px] text-muted/70 uppercase tracking-widest mb-0.5">Erstellt</dt>
                 <dd class="text-light">{fmtDateTime(ticket.createdAt)}</dd>
               </div>
               <div>
-                <dt class="text-xs text-muted uppercase tracking-wide mb-0.5">Aktualisiert</dt>
+                <dt class="text-[10px] text-muted/70 uppercase tracking-widest mb-0.5">Aktualisiert</dt>
                 <dd class="text-light">{fmtDateTime(ticket.updatedAt)}</dd>
               </div>
               {ticket.startDate && (
                 <div>
-                  <dt class="text-xs text-muted uppercase tracking-wide mb-0.5">Start</dt>
+                  <dt class="text-[10px] text-muted/70 uppercase tracking-widest mb-0.5">Start</dt>
                   <dd class="text-light">{fmt(ticket.startDate)}</dd>
                 </div>
               )}
               {ticket.dueDate && (
                 <div>
-                  <dt class="text-xs text-muted uppercase tracking-wide mb-0.5">Fällig</dt>
+                  <dt class="text-[10px] text-muted/70 uppercase tracking-widest mb-0.5">Fällig</dt>
                   <dd class="text-light">{fmt(ticket.dueDate)}</dd>
                 </div>
               )}
               {ticket.assigneeLabel && (
                 <div>
-                  <dt class="text-xs text-muted uppercase tracking-wide mb-0.5">Zuständig</dt>
+                  <dt class="text-[10px] text-muted/70 uppercase tracking-widest mb-0.5">Zuständig</dt>
                   <dd class="text-light">{ticket.assigneeLabel}</dd>
                 </div>
               )}
               {ticket.customerLabel && (
                 <div>
-                  <dt class="text-xs text-muted uppercase tracking-wide mb-0.5">Kunde</dt>
+                  <dt class="text-[10px] text-muted/70 uppercase tracking-widest mb-0.5">Kunde</dt>
                   <dd class="text-light">{ticket.customerLabel}</dd>
                 </div>
               )}
               {ticket.reporterEmail && (
                 <div>
-                  <dt class="text-xs text-muted uppercase tracking-wide mb-0.5">Reporter</dt>
+                  <dt class="text-[10px] text-muted/70 uppercase tracking-widest mb-0.5">Reporter</dt>
                   <dd class="text-light truncate">{ticket.reporterEmail}</dd>
                 </div>
               )}
               {ticket.component && (
                 <div>
-                  <dt class="text-xs text-muted uppercase tracking-wide mb-0.5">Komponente</dt>
+                  <dt class="text-[10px] text-muted/70 uppercase tracking-widest mb-0.5">Komponente</dt>
                   <dd class="text-light">{ticket.component}</dd>
                 </div>
               )}
               {ticket.thesisTag && (
                 <div>
-                  <dt class="text-xs text-muted uppercase tracking-wide mb-0.5">Thesis-Tag</dt>
+                  <dt class="text-[10px] text-muted/70 uppercase tracking-widest mb-0.5">Thesis-Tag</dt>
                   <dd class="text-light font-mono">{ticket.thesisTag}</dd>
                 </div>
               )}
               {ticket.parentId && (
                 <div>
-                  <dt class="text-xs text-muted uppercase tracking-wide mb-0.5">Parent</dt>
+                  <dt class="text-[10px] text-muted/70 uppercase tracking-widest mb-0.5">Parent</dt>
                   <dd>
                     <a href={`/admin/tickets/${ticket.parentId}`} class="text-gold hover:underline">
                       Parent öffnen
@@ -316,7 +315,7 @@ function fmtDateTime(d: Date | string | null): string {
           </div>
 
           <div class="bg-dark-light rounded-2xl border border-dark-lighter p-5 text-sm">
-            <h3 class="text-xs text-muted uppercase tracking-wide mb-2">Watcher ({ticket.watchers.length})</h3>
+            <h3 class="text-[10px] text-muted/70 uppercase tracking-widest mb-2 pb-1.5 border-b border-dark-lighter/40">Watcher ({ticket.watchers.length})</h3>
             {ticket.watchers.length === 0 ? (
               <p class="text-muted italic text-xs">Keine Watcher.</p>
             ) : (


### PR DESCRIPTION
## Summary

- **TicketRow**: Status-Selects als farbige Pill-Badges (per Status eingefärbt mit `appearance:none` + SVG-Chevron), Typ-Indikator-Punkt (6px farbiger Dot) vor dem Ticket-Titel, externe ID als Brass-Badge mit Hintergrundfarbe, Prioritäts-Select erbt Prio-Farbe, Hover-Transitions
- **CockpitTable**: Suchfeld mit SVG-Lupe, Chips mit Hover-Transition, Tabellen-Container mit `border + border-radius`, verbesserte Header-Row
- **projekte.astro**: Stat-Chips mit `text-3xl` + `tabular-nums`, Header dunkler Hintergrund + `tracking-wider`, Zeilen `font-semibold`
- **tickets/[id].astro**: Breadcrumb als Brass-Badge, Status-Pill `font-semibold`, Section-h2 mit `border-b`-Trenner, Sidebar-Labels `text-[10px] tracking-widest`

## Test plan

- [ ] Alle 1466 Vitest-Tests bestehen (227 Dateien)
- [ ] `task quality:check`: 0 blocking violations
- [ ] `task freshness:check`: route-manifest OK
- [ ] S1-Zeilenlimits eingehalten: TicketRow 220/500, CockpitTable 335/500, projekte.astro 407/407 (Baseline), tickets/[id].astro 346/400

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y2fFoKCMNPkbS5n2aFBNrf