### PR TITLE
chore(website): case-insensitive admin username check [T001123]

### DIFF
--- a/website/src/lib/auth.ts
+++ b/website/src/lib/auth.ts
@@ -186,7 +186,7 @@ export async function exchangeCode(code: string): Promise<{ sessionId: string; u
 }
 
 const ADMIN_USERNAMES = new Set(
-  (process.env.PORTAL_ADMIN_USERNAME || 'admin').split(',').map(s => s.trim()).filter(Boolean)
+  (process.env.PORTAL_ADMIN_USERNAME || 'admin').split(',').map(s => s.trim().toLowerCase()).filter(Boolean)
 );
 
 export function isAdmin(session: UserSession): boolean {
@@ -194,7 +194,7 @@ export function isAdmin(session: UserSession): boolean {
   // PORTAL_ADMIN_USERNAME list is kept as a fallback for non-OIDC paths
   // (e.g. magic-link-redeem where isAdmin is missing).
   if (session.realmRoles.includes('admin')) return true;
-  return ADMIN_USERNAMES.has(session.preferred_username);
+  return ADMIN_USERNAMES.has(session.preferred_username.toLowerCase());
 }
 
 export async function getSession(cookieHeader: string | null): Promise<UserSession | null> {


### PR DESCRIPTION
## Summary

- Pocket ID sends `preferred_username` with a capital first letter (e.g. `"Paddione"`) while `PORTAL_ADMIN_USERNAME` is stored lowercase — `Set.has()` was failing silently
- Normalize both sides with `.toLowerCase()` so the admin menu appears for all users in the list regardless of casing in the OIDC token

## Test plan

- [ ] Log in as `paddione` on `web.mentolder.de` — Admin menu should now appear in the user dropdown
- [ ] CI: Offline Tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QAYJigdKmtZGK1DdpU3kjL