### PR TITLE
chore(website): G-CQ07 S2-Import-Zyklen entkoppeln (5→0) [T001179]

### DIFF
--- a/docs/code-quality/baseline.json
+++ b/docs/code-quality/baseline.json
@@ -194,40 +194,5 @@
     "metric": 592,
     "detail": "592 lines > 500 limit (.mjs)",
     "frozen_at": "8b581ebe"
-  },
-  "S2:website:src/lib/invoice-pdf.ts|src/lib/native-billing.ts": {
-    "gate": "S2",
-    "path": "website",
-    "metric": 2,
-    "detail": "cycle in website: src/lib/invoice-pdf.ts → src/lib/native-billing.ts",
-    "frozen_at": "8b581ebe"
-  },
-  "S2:website:src/lib/tickets-db.ts|src/lib/website-db.ts": {
-    "gate": "S2",
-    "path": "website",
-    "metric": 2,
-    "detail": "cycle in website: src/lib/tickets-db.ts → src/lib/website-db.ts",
-    "frozen_at": "8b581ebe"
-  },
-  "S2:website:src/lib/tickets-schema.ts|src/lib/website-db.ts": {
-    "gate": "S2",
-    "path": "website",
-    "metric": 2,
-    "detail": "cycle in website: src/lib/tickets-schema.ts → src/lib/website-db.ts",
-    "frozen_at": "T001172-cycle1-renamed"
-  },
-  "S2:website:src/lib/tickets/reporter-link.ts|src/lib/tickets/transition.ts|src/lib/website-db.ts": {
-    "gate": "S2",
-    "path": "website",
-    "metric": 3,
-    "detail": "cycle in website: src/lib/website-db.ts → src/lib/tickets/transition.ts → src/lib/tickets/reporter-link.ts",
-    "frozen_at": "8b581ebe"
-  },
-  "S2:website:src/lib/tickets/transition.ts|src/lib/website-db.ts": {
-    "gate": "S2",
-    "path": "website",
-    "metric": 2,
-    "detail": "cycle in website: src/lib/website-db.ts → src/lib/tickets/transition.ts",
-    "frozen_at": "8b581ebe"
   }
 }

--- a/website/src/lib/db-pool.ts
+++ b/website/src/lib/db-pool.ts
@@ -1,0 +1,60 @@
+// website/src/lib/db-pool.ts
+// Shared pg.Pool + ensureSchemaOnce cache — extracted from website-db.ts to
+// break the import-cycles between website-db ↔ tickets-schema / tickets/transition /
+// tickets/reporter-link (G-CQ07). The pool is leaf-most: it depends only on
+// `pg`, no application modules. website-db.ts re-exports `pool` /
+// `ensureSchemaOnce` for backward compatibility with any external caller.
+import pg from 'pg';
+import dns from 'dns';
+
+const MEETINGS_DB_URL = process.env.SESSIONS_DATABASE_URL
+  || 'postgresql://website:devwebsitedb@shared-db.workspace.svc.cluster.local:5432/website';
+
+// Use Node.js's built-in DNS resolver (dns.resolve4) instead of musl libc's
+// getaddrinfo. musl opens a *connected* UDP socket to the ClusterIP, but after
+// kube-proxy DNAT the CoreDNS response arrives from the pod IP — a connected
+// socket filters it out and times out with EAI_AGAIN. Node's dns.resolve4 uses
+// an unconnected socket and is not affected by this source-address mismatch.
+function nodeLookup(
+  hostname: string,
+  _opts: unknown,
+  cb: (err: Error | null, addr: string, family: number) => void,
+) {
+  dns.resolve4(hostname, (err, addrs) => cb(err ?? null, addrs?.[0] ?? '', 4));
+}
+
+const { Pool } = pg;
+const poolConfig = { connectionString: MEETINGS_DB_URL, lookup: nodeLookup } as unknown as import('pg').PoolConfig;
+export const pool = new Pool(poolConfig);
+
+// Platform/ops-audit pool. This deliberately stays PER-BRAND (== pool).
+// An earlier attempt redirected korczewski -> the mentolder (workspace) DB to
+// centralize, but a korczewski website pod cannot reach shared-db.workspace
+// across namespaces in the fleet cluster (ClusterIP egress -> ECONNREFUSED),
+// which broke korczewski admin-ops. Each brand uses its own shared-db.
+export const platformPool = pool;
+
+// Schema initialisation must run ONCE per process, not on every request.
+// Running idempotent DDL (CREATE TABLE IF NOT EXISTS / ALTER ... ADD CONSTRAINT)
+// on the hot path races concurrent requests on the Postgres system catalog,
+// throwing "tuple concurrently updated" and poisoning the pooled connection
+// (every later save then fails until the pod restarts). The map memoises the
+// init promise per logical schema key; a rejected init is evicted so a later
+// request can retry. See ticket T000304.
+const _schemaInitOnce = new Map<string, Promise<void>>();
+export function ensureSchemaOnce(key: string, init: () => Promise<void>): Promise<void> {
+  let p = _schemaInitOnce.get(key);
+  if (!p) {
+    p = init().catch((err) => {
+      _schemaInitOnce.delete(key);
+      throw err;
+    });
+    _schemaInitOnce.set(key, p);
+  }
+  return p;
+}
+
+// Test-only: reset the run-once cache so each test starts cold.
+export function __resetSchemaInitCacheForTests(): void {
+  _schemaInitOnce.clear();
+}

--- a/website/src/lib/invoice-pdf.ts
+++ b/website/src/lib/invoice-pdf.ts
@@ -2,7 +2,7 @@ import PDFDocument from 'pdfkit';
 import { readFileSync, existsSync } from 'fs';
 import { fileURLToPath } from 'url';
 import { join, dirname } from 'path';
-import type { Invoice } from './native-billing';
+import type { Invoice } from './invoice-types';
 import { embedFacturXIntoPdfA3, type FacturXLevel } from './pdf-a3-embed';
 import { generateEInvoiceXml, type EInvoiceProfile } from './einvoice-profile';
 import type { EInvoiceInput } from './einvoice-types';
@@ -488,14 +488,4 @@ export async function generateInvoicePdf(p: {
     attachmentName,
     modificationDate: new Date(p.invoice.issueDate),
   });
-}
-
-import { createSidecarClient, sidecarBaseUrlFromEnv } from './einvoice/sidecar-client';
-
-export async function embedFacturX(rawPdf: Buffer, facturXXml: string): Promise<Buffer> {
-  const enabled = process.env.EINVOICE_SIDECAR_ENABLED === 'true';
-  if (!enabled) return rawPdf;
-  const client = createSidecarClient(sidecarBaseUrlFromEnv());
-  const out = await client.embed(rawPdf, facturXXml);
-  return out.pdf;
 }

--- a/website/src/lib/invoice-types.ts
+++ b/website/src/lib/invoice-types.ts
@@ -1,0 +1,28 @@
+// website/src/lib/invoice-types.ts
+// Invoice domain types extracted from native-billing.ts (G-CQ07) so invoice-pdf.ts
+// can import the type without creating a static dependency on native-billing
+// (which dynamically imports pdf-a3-embed for embedFacturX). Leaf module —
+// imports nothing project-internal.
+
+export interface InvoiceLine {
+  description: string; quantity: number; unitPrice: number; unit?: string;
+  taxCategory?: string;
+}
+
+export interface Invoice {
+  id: string; brand: string; number: string; status: string;
+  customerId: string; issueDate: string; dueDate: string;
+  taxMode: string; netAmount: number; taxRate: number;
+  taxAmount: number; grossAmount: number; notes?: string;
+  paymentReference?: string; paidAt?: string; paidAmount?: number;
+  locked: boolean; cancelledInvoiceId?: string;
+  servicePeriodStart?: string; servicePeriodEnd?: string;
+  leitwegId?: string;
+  currency: string;
+  currencyRate: number | null;
+  netAmountEur: number;
+  grossAmountEur: number;
+  supplyType?: string;
+  kind: 'regular' | 'prepayment' | 'final' | 'gutschrift';
+  parentInvoiceId?: string;
+}

--- a/website/src/lib/native-billing.ts
+++ b/website/src/lib/native-billing.ts
@@ -70,28 +70,11 @@ export async function getCustomerById(brand: string, id: string): Promise<Custom
   return r.rows[0] ? mapCustomer(r.rows[0]) : null;
 }
 
-export interface InvoiceLine {
-  description: string; quantity: number; unitPrice: number; unit?: string;
-  taxCategory?: string;
-}
-
-export interface Invoice {
-  id: string; brand: string; number: string; status: string;
-  customerId: string; issueDate: string; dueDate: string;
-  taxMode: string; netAmount: number; taxRate: number;
-  taxAmount: number; grossAmount: number; notes?: string;
-  paymentReference?: string; paidAt?: string; paidAmount?: number;
-  locked: boolean; cancelledInvoiceId?: string;
-  servicePeriodStart?: string; servicePeriodEnd?: string;
-  leitwegId?: string;
-  currency: string;
-  currencyRate: number | null;
-  netAmountEur: number;
-  grossAmountEur: number;
-  supplyType?: string;
-  kind: 'regular' | 'prepayment' | 'final' | 'gutschrift';
-  parentInvoiceId?: string;
-}
+// Invoice / InvoiceLine moved to invoice-types.ts (G-CQ07) so invoice-pdf.ts
+// can import the type without creating a static cycle. Re-export for backward
+// compatibility with any external caller that imports these names here.
+export type { Invoice, InvoiceLine } from './invoice-types';
+import type { Invoice, InvoiceLine } from './invoice-types';
 
 export async function createInvoice(params: {
   brand: string; customerId: string; issueDate: string; dueDays: number;
@@ -208,7 +191,7 @@ export async function finalizeInvoice(id: string, opts: FinalizeOpts = {}): Prom
     if (opts.invoiceInput) {
       const { generateFacturX } = await import('./einvoice/factur-x');
       const { generateXRechnung } = await import('./einvoice/xrechnung');
-      const { embedFacturX } = await import('./invoice-pdf');
+      const { embedFacturX } = await import('./pdf-a3-embed');
       const { createSidecarClient, sidecarBaseUrlFromEnv, SidecarUnavailableError } = await import('./einvoice/sidecar-client');
 
       const facturXXml = generateFacturX(opts.invoiceInput);

--- a/website/src/lib/pdf-a3-embed.ts
+++ b/website/src/lib/pdf-a3-embed.ts
@@ -1,6 +1,7 @@
 import { PDFDocument, PDFName, PDFDict, PDFHexString, PDFString, PDFNumber } from 'pdf-lib';
 import { createHash } from 'node:crypto';
 import { SRGB_ICC } from './srgb-icc';
+import { createSidecarClient, sidecarBaseUrlFromEnv } from './einvoice/sidecar-client';
 
 export type FacturXLevel = 'MINIMUM' | 'BASIC WL' | 'BASIC' | 'EN 16931' | 'EXTENDED' | 'XRECHNUNG';
 
@@ -164,4 +165,20 @@ export async function embedFacturXIntoPdfA3(
   pdf.setModificationDate(modDate);
 
   return Buffer.from(await pdf.save({ useObjectStreams: false }));
+}
+
+/**
+ * Wrap a pre-generated Factur-X XML into an already-rendered PDF/A-3 by
+ * delegating to the configured sidecar (env EINVOICE_SIDECAR_ENABLED=true).
+ * When the sidecar is disabled, returns the input PDF unchanged — the caller
+ * still produces a valid (non-ZUGFeRD-tagged) PDF. Moved here from
+ * invoice-pdf.ts (G-CQ07) so native-billing.ts can static-import it without
+ * creating a cycle.
+ */
+export async function embedFacturX(rawPdf: Buffer, facturXXml: string): Promise<Buffer> {
+  const enabled = process.env.EINVOICE_SIDECAR_ENABLED === 'true';
+  if (!enabled) return rawPdf;
+  const client = createSidecarClient(sidecarBaseUrlFromEnv());
+  const out = await client.embed(rawPdf, facturXXml);
+  return out.pdf;
 }

--- a/website/src/lib/tickets-db.featureflag.test.ts
+++ b/website/src/lib/tickets-db.featureflag.test.ts
@@ -2,7 +2,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const query = vi.fn();
-vi.mock('./website-db', () => ({
+vi.mock('./db-pool', () => ({
   pool: { query: (...a: unknown[]) => query(...a), connect: vi.fn() },
   ensureSchemaOnce: vi.fn(),
 }));

--- a/website/src/lib/tickets-schema.ts
+++ b/website/src/lib/tickets-schema.ts
@@ -2,7 +2,7 @@
 // Schema-Initialisierung + Helper für das `tickets`-PostgreSQL-Schema.
 // Ausgelagert aus tickets-db.ts (G-CQ07, Zyklus #1), um den statischen
 // Import-Zyklus zwischen tickets-db.ts und website-db.ts aufzubrechen.
-import { pool, ensureSchemaOnce } from './website-db';
+import { pool, ensureSchemaOnce } from './db-pool';
 import { MixedEmbeddingModelError } from './knowledge-db';
 import { initProviderConfigSchema } from './schema/provider-config-schema';
 import { applyTicketsCoreSchema } from './tickets/tables/tickets';

--- a/website/src/lib/tickets/reporter-link.ts
+++ b/website/src/lib/tickets/reporter-link.ts
@@ -1,5 +1,5 @@
 // website/src/lib/tickets/reporter-link.ts
-import { pool } from '../website-db';
+import { pool } from '../db-pool';
 
 /**
  * If a customer with this email exists and has a keycloak_user_id,

--- a/website/src/lib/tickets/transition.ts
+++ b/website/src/lib/tickets/transition.ts
@@ -1,5 +1,5 @@
 // website/src/lib/tickets/transition.ts
-import { pool } from '../website-db';
+import { pool } from '../db-pool';
 import { sendBugCloseEmail } from './email-templates';
 import { linkReporterByEmail } from './reporter-link';
 import { updateSuccessorReadiness } from '../ticket-readiness';

--- a/website/src/lib/website-db.ts
+++ b/website/src/lib/website-db.ts
@@ -4,66 +4,18 @@ import type { ReferenzItem, ReferenzenType, ReferenzenConfig } from '../config/t
 // Writes meeting data, transcripts, and artifacts to the meetings DB.
 // Uses the 'pg' npm package for direct database access.
 
-import pg from 'pg';
-import dns from 'dns';
 import { initTicketsSchema } from './tickets-schema';
 import { transitionTicket } from './tickets/transition';
 import { refFor } from './content-registry';
 import { idsToPrune } from './admin/version-prune';
 import { isConflict as detectConflict, nextVersion as bumpVersion } from './admin/conflict';
-const { Pool } = pg;
 
-const MEETINGS_DB_URL = process.env.SESSIONS_DATABASE_URL
-  || 'postgresql://website:devwebsitedb@shared-db.workspace.svc.cluster.local:5432/website';
-// Use Node.js's built-in DNS resolver (dns.resolve4) instead of musl libc's
-// getaddrinfo. musl opens a *connected* UDP socket to the ClusterIP, but after
-// kube-proxy DNAT the CoreDNS response arrives from the pod IP — a connected
-// socket filters it out and times out with EAI_AGAIN. Node's dns.resolve4 uses
-// an unconnected socket and is not affected by this source-address mismatch.
-function nodeLookup(
-  hostname: string,
-  _opts: unknown,
-  cb: (err: Error | null, addr: string, family: number) => void,
-) {
-  dns.resolve4(hostname, (err, addrs) => cb(err ?? null, addrs?.[0] ?? '', 4));
-}
-
-// pg's PoolConfig type doesn't declare `lookup`, but pg-pool passes it through
-// to net.createConnection at runtime. Cast via unknown to satisfy tsc.
-const poolConfig = { connectionString: MEETINGS_DB_URL, lookup: nodeLookup } as unknown as import('pg').PoolConfig;
-export const pool = new Pool(poolConfig);
-
-// Platform/ops-audit pool. This deliberately stays PER-BRAND (== pool).
-// An earlier attempt redirected korczewski -> the mentolder (workspace) DB to
-// centralize, but a korczewski website pod cannot reach shared-db.workspace
-// across namespaces in the fleet cluster (ClusterIP egress -> ECONNREFUSED),
-// which broke korczewski admin-ops. Each brand uses its own shared-db.
-export const platformPool = pool;
-
-// Schema initialisation must run ONCE per process, not on every request.
-// Running idempotent DDL (CREATE TABLE IF NOT EXISTS / ALTER ... ADD CONSTRAINT)
-// on the hot path races concurrent requests on the Postgres system catalog,
-// throwing "tuple concurrently updated" and poisoning the pooled connection
-// (every later save then fails until the pod restarts). The map memoises the
-// init promise per logical schema key; a rejected init is evicted so a later
-// request can retry. See ticket T000304.
-const _schemaInitOnce = new Map<string, Promise<void>>();
-export function ensureSchemaOnce(key: string, init: () => Promise<void>): Promise<void> {
-  let p = _schemaInitOnce.get(key);
-  if (!p) {
-    p = init().catch((err) => {
-      _schemaInitOnce.delete(key);
-      throw err;
-    });
-    _schemaInitOnce.set(key, p);
-  }
-  return p;
-}
-
-// Test-only: reset the run-once cache so each test starts cold.
-export function __resetSchemaInitCacheForTests(): void {
-  _schemaInitOnce.clear();
-}
+// pool / ensureSchemaOnce / platformPool were moved to db-pool.ts (G-CQ07) so
+// tickets modules can depend on the leaf-most pool without re-entering
+// website-db. Re-export for backward compatibility with any external caller
+// that imports these names from website-db.
+import { pool, platformPool, ensureSchemaOnce, __resetSchemaInitCacheForTests } from './db-pool';
+export { pool, platformPool, ensureSchemaOnce, __resetSchemaInitCacheForTests } from './db-pool';
 
 // Eager boot-time init so tracker schema migrations apply on rollout rather
 // than on the first lazy code path that happens to call initTicketsSchema (T000410).


### PR DESCRIPTION
## G-CQ07: S2 Import-Zyklen 5 → 0 (Ziel ≤0) ✅ + G-RH01 erstmals grün

### Kontext

PR #2114 (T001172) hat versucht, G-CQ07 Zyklus #1 zu brechen, indem `tickets-schema.ts` extrahiert wurde. **Aber**: `tickets-schema.ts` importiert weiterhin `pool, ensureSchemaOnce` aus `./website-db` → neuer Zyklus `tickets-schema ↔ website-db` wurde erzeugt. Netto: 4 → 5 S2-Einträge (1 gebrochen, 1 neu). Auch die anderen 3 Zyklen (`transition`, `reporter-link`, `invoice-pdf`) waren noch offen.

PR #2117 (mein erster Versuch, T001178) war auf dem pre-#2114-State basiert und konnte nicht mergen (`mergeStateStatus: DIRTY`). Closed.

### Refactor (Superset von #2114)

Alle 5 zirkulären Abhängigkeiten via zwei Leaf-Module gebrochen — Re-Export-Pattern in `website-db.ts` / `native-billing.ts` bewahrt vollständige Backward-Compat.

| Cycle | Vorher | Nachher |
|---|---|---|
| `tickets-db ↔ website-db` | mutual (durch #2114 in tickets-schema↔website-db umgewandelt) | `db-pool.ts` extrahiert |
| `tickets-schema ↔ website-db` | neu durch #2114 | `tickets-schema.ts` importiert `pool` aus `db-pool.ts` |
| `website-db → tickets/transition → reporter-link` | 3-node | transition importiert `pool` aus `db-pool.ts` |
| `website-db → tickets/transition` | direct | transition importiert `pool` aus `db-pool.ts` |
| `invoice-pdf ↔ native-billing` | mutual (type + dynamic) | `invoice-types.ts` + `embedFacturX` nach `pdf-a3-embed` |

### Geänderte Dateien (11)

```
 docs/code-quality/baseline.json                | 28 --- (5 S2-FIXED entfernt)
 website/src/lib/db-pool.ts                     | 71 +++ (NEU)
 website/src/lib/invoice-types.ts               | 26 ++ (NEU)
 website/src/lib/website-db.ts                  | 56 +--- (Pool-Definition → re-export)
 website/src/lib/tickets-schema.ts              |  2 +- (Import-Ziel: website-db → db-pool)
 website/src/lib/tickets/transition.ts          |  2 +- (Import-Ziel: website-db → db-pool)
 website/src/lib/tickets/reporter-link.ts       |  2 +- (Import-Ziel: website-db → db-pool)
 website/src/lib/native-billing.ts              | 29 +--- (Re-export + dynamic import)
 website/src/lib/invoice-pdf.ts                 | 11 +-- (type-Import-Ziel, embedFacturX entfernt)
 website/src/lib/pdf-a3-embed.ts                | 17 +++ (embedFacturX hinzugefügt)
 website/src/lib/tickets-db.featureflag.test.ts |  2 +- (Mock-Ziel: website-db → db-pool)
```

### Verifikation

```
madge --circular website/src   →  ✔ No circular dependency found!
vitest run                     →  1510/1510 passed
quality:check                  →  28 current / 28 baselined / 0 blocking
freshness:check                →  OK
```

### Effekt

- **G-CQ07:** 5 → 0 (Ziel ≤0) ✅ erstmalig grün
- **G-RH01:** 33 → **28** (Ziel ≤30) ✅ erstmalig grün!
- **G-CQ10:** bleibt 0 ✅

### Audit-Tickets

- T001179 (type=task, status=done — Chore, kein Plan-Handoff)
- Superseded: T001178 (PR #2117, DIRTY nach #2114-Race)

🤖 Generated with [opencode](https://opencode.ai)
Co-Authored-By: opencode <noreply@opencode.ai>