### PR TITLE
chore(ci): fix paths-ignore on pull_request to allow docs-only PRs [T001183]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,10 +4,11 @@ on:
   pull_request:
     branches: [main]
     types: [opened, synchronize, reopened, edited]
-    paths-ignore:
-      - 'docs/**'
-      - '*.md'
-      - '**/CLAUDE.md'
+    # No `paths-ignore` here: docs-only PRs (e.g. AGENTS.md/CLAUDE.md edits) must
+    # still trigger this workflow so the 5 branch-protection required checks
+    # (Offline Tests, Security Scan, Brett TypeScript, Vitest (website),
+    # Conventional Commits) report success — otherwise mergeStateStatus stays
+    # BLOCKED indefinitely and admin-merge is required. See mishap T001149-M3.
   push:
     branches:
       - main


### PR DESCRIPTION
## Problem

Branch protection on `main` requires 5 status checks: Offline Tests, Security Scan, Brett TypeScript, Vitest (website), Conventional Commits. The `ci.yml` workflow's `pull_request` trigger had `paths-ignore: ['*.md', 'docs/**', '**/CLAUDE.md']` — so for docs-only PRs, the entire workflow was skipped and **none** of the 5 required checks reported, leaving `mergeStateStatus=BLOCKED` indefinitely. PR #2098 had to be admin-merged to work around this. (Mishap T001149-M3)

## Fix

Remove `paths-ignore` from the `pull_request` trigger only. The `push` trigger keeps its filter — direct pushes to main are admin-only and the CI cost saving on docs pushes is preserved.

## Also includes

Refresh the S2-cycles frozen-baseline guard from 4→0. The live count was already 0 after T001179 (G-CQ07 S2-Import-Zyklen entkoppeln) but the test was never updated, blocking `test:changed` on every chore PR. Caught while validating this chore.

## Verification

- `task test:changed` → 50/50 green
- `task workspace:validate` → ✓
- `task freshness:check` → ✓
- `task freshness:regenerate` → ✓

Fixes T001149-M3.
