### PR TITLE
chore(docs): fix 9 broken internal doc links (G-DOC01) [T001188]

### DIFF
--- a/docs/db-audit/2026-05-23-phase5/README.md
+++ b/docs/db-audit/2026-05-23-phase5/README.md
@@ -18,7 +18,7 @@ Multi-phase audit of the `shared-db` on both `mentolder` and `korczewski` cluste
 [`docs/superpowers/specs/2026-05-23-db-audit-phase5-design.md`](../../superpowers/specs/2026-05-23-db-audit-phase5-design.md)
 
 ## Plan
-[`docs/superpowers/plans/2026-05-23-db-audit-phase5.md`](../../superpowers/plans/2026-05-23-db-audit-phase5.md)
+Kein separater Implementierungsplan — Audit wurde inline ausgeführt (siehe `evidence/` und Hinweis im Re-running-Abschnitt unten).
 
 ## Ticket
 [T000150](https://web.mentolder.de/admin/bugs)

--- a/docs/superpowers/plans/2026-06-22-agent-library.md
+++ b/docs/superpowers/plans/2026-06-22-agent-library.md
@@ -416,10 +416,10 @@ Jeder Agent liest nur die für seine Domäne relevanten Fragmente.
 
 | Fragment | Zweck | Referenziert von |
 |---|---|---|
-| [`behaviors/never-push-main.md`](behaviors/never-push-main.md) | Kein direkter Push auf main, immer PRs | alle 6 Agenten |
-| [`behaviors/inject-plan-context.md`](behaviors/inject-plan-context.md) | plan-context.sh vor Agent-Dispatch injizieren | infra, website, db, test, security |
-| [`behaviors/tool-use-safety.md`](behaviors/tool-use-safety.md) | Reversibility-Check vor destruktiven Operationen | infra, db, ops, security |
-| [`behaviors/commit-conventions.md`](behaviors/commit-conventions.md) | squash-merge, branch-naming, Co-Authored-By | infra, website, test |
+| [`behaviors/never-push-main.md`](../../../.claude/lib/behaviors/never-push-main.md) | Kein direkter Push auf main, immer PRs | alle 6 Agenten |
+| [`behaviors/inject-plan-context.md`](../../../.claude/lib/behaviors/inject-plan-context.md) | plan-context.sh vor Agent-Dispatch injizieren | infra, website, db, test, security |
+| [`behaviors/tool-use-safety.md`](../../../.claude/lib/behaviors/tool-use-safety.md) | Reversibility-Check vor destruktiven Operationen | infra, db, ops, security |
+| [`behaviors/commit-conventions.md`](../../../.claude/lib/behaviors/commit-conventions.md) | squash-merge, branch-naming, Co-Authored-By | infra, website, test |
 
 ## Prompts
 
@@ -427,9 +427,9 @@ Wiederverwendbare Prompt-Bausteine für Factory-Prompts und LLM-Aufrufe.
 
 | Fragment | Zweck | Referenziert von |
 |---|---|---|
-| [`prompts/review-lens-format.md`](prompts/review-lens-format.md) | HARD CONSTRAINT Block für Review-Lenses | factory review-prompts |
-| [`prompts/diff-analysis-context.md`](prompts/diff-analysis-context.md) | Diff-Scope Boilerplate (nur `+`-Zeilen) | factory lenses |
-| [`prompts/review-coordinator.md`](prompts/review-coordinator.md) | Koordinations-Logik Consolidation-Agent | factory coordinator |
+| [`prompts/review-lens-format.md`](../../../.claude/lib/prompts/review-lens-format.md) | HARD CONSTRAINT Block für Review-Lenses | factory review-prompts |
+| [`prompts/diff-analysis-context.md`](../../../.claude/lib/prompts/diff-analysis-context.md) | Diff-Scope Boilerplate (nur `+`-Zeilen) | factory lenses |
+| [`prompts/review-coordinator.md`](../../../.claude/lib/prompts/review-coordinator.md) | Koordinations-Logik Consolidation-Agent | factory coordinator |
 
 ## Wachstumsprinzip
 

--- a/docs/superpowers/specs/2026-05-31-agent-guide-docs-surface-design.md
+++ b/docs/superpowers/specs/2026-05-31-agent-guide-docs-surface-design.md
@@ -36,7 +36,7 @@ All operator-facing text on this surface is German, Du-form, friendly. This is t
   - `30-bausteine.md` — Lens 3, the platform components / enriched hub (from `components.yaml`).
 - **G3** — Ship one HAND-AUTHORED, committed, hand-edited landing page `00-anleitung.md` ("Was will ich tun?") that teaches and links into the three generated pages.
 - **G4** — Wire the emitter behind `task agent-guide:docs` (and the umbrella `task agent-guide:emit`), and add a CI freshness gate (`git diff --exit-code` over the generated trio) mirroring the existing `test-inventory.json` gate.
-- **G5** — Cross-link the four pages to each other and into existing docs pages (skills/agents) using the docs generator's native `[[wikilink]]` and `[label](file.md)` mechanisms, so the registry's `links`/`related`/`tool`/`guardrails` references become live navigation. Where a tool/agent id does not equal its discovered page slug (see §6, §7.2), the emitter maps the id to the real slug before emitting the wikilink.
+- **G5** — Cross-link the four pages to each other and into existing docs pages (skills/agents) using the docs generator's native `[[wikilink]]` and `` `[label](<rel>)` `` mechanisms, so the registry's `links`/`related`/`tool`/`guardrails` references become live navigation. Where a tool/agent id does not equal its discovered page slug (see §6, §7.2), the emitter maps the id to the real slug before emitting the wikilink.
 - **G6** — Never emit from an invalid registry: the emitter runs F+B's `validateRegistry` (or `task test:agent-guide`) first.
 
 ### Non-goals (explicit deferrals)


### PR DESCRIPTION
Fixes G-DOC01 (catalog baseline 9 → 0):

- **docs/db-audit/2026-05-23-phase5/README.md** — Remove broken plans/ link (audit was inline per evidence/ + the note in §Re-running collection).
- **docs/superpowers/specs/2026-05-31-agent-guide-docs-surface-design.md** — Escape `[label](file.md)` Prosa example to `` `[label](<rel>)` `` (regex-naive check now skips it).
- **docs/superpowers/plans/2026-06-22-agent-library.md** — Correct 7 relative paths `behaviors/X.md` / `prompts/X.md` to `../../../.claude/lib/{behaviors,prompts}/X.md` (files exist at .claude/lib/).

**Verification:** `checked=27 broken=0` (was `checked=29 broken=9`). `task workspace:validate` ✅, `task test:code-quality` ✅ (50/50), `task freshness:check` ✅.