### PR TITLE
feat(mentolder-web): homepage editor — collapsible preview + save confirmation step

### DIFF
--- a/docs/superpowers/specs/2026-06-27-homepage-editor-confirm-preview-design.md
+++ b/docs/superpowers/specs/2026-06-27-homepage-editor-confirm-preview-design.md
@@ -1,0 +1,162 @@
+---
+title: Homepage-Editor — einklappbare Live-Vorschau + Bestätigungs-Schritt beim Speichern
+date: 2026-06-27
+status: draft
+domains: [website, mentolder-web]
+ticket_id: TBD
+plan_ref: TBD
+---
+
+# Homepage-Editor: einklappbare Vorschau + Bestätigungs-Modal
+
+## Problem / Ziel
+
+Die „Edit Homepage"-Seite der React-App `mentolder-web` (`/admin/homepage`,
+`src/pages/admin/HomepageEditorPage.tsx`) zeigt aktuell **bedingungslos** eine
+volle Live-Vorschau in der rechten Spalte (`<BlockRenderer document={doc} />`)
+und speichert beim Klick auf „Speichern" **sofort** ohne Zwischenschritt.
+
+Gewünscht:
+
+1. Die Live-Vorschau soll **nicht standardmäßig** sichtbar sein, aber erhalten
+   bleiben: die rechte Spalte wird **einklappbar (retractable)**, Default
+   **eingeklappt**.
+2. Im ausgeklappten Zustand sollen Editor-Karte (Spalte 1) und der gerenderte
+   Block (Spalte 2) **zeilenweise fluchten** — Block *i* links liegt in derselben
+   Reihe wie Block *i* rechts (Oberkanten bündig).
+3. „Speichern" öffnet einen **Bestätigungs-Schritt** (Modal), der **nur die
+   geänderten Blöcke** als **Vorher/Nachher** rendert. Erst „Bestätigen" schreibt
+   tatsächlich via `POST /api/admin/homepage/save`.
+4. Der „Speichern"-Button ist **deaktiviert**, solange kein Block geändert wurde.
+
+Nicht-Ziele (YAGNI): Block-Hinzufügen/Löschen/Umsortieren (dieser Editor mutiert
+nur `props`), Auto-Save, Feld-genaues Inline-Diff, neue API-Endpunkte.
+
+## Kontext (Ist-Zustand)
+
+- `HomepageEditorPage.tsx` hält `doc` (Arbeitsstand inkl. Edits), `baseVersion`,
+  `loaded`, `status`. Es gibt **keinen** Baseline-Snapshot des geladenen Docs.
+- Mutation nur über `updateBlockProps(index, props)` → ersetzt `block.props`.
+- Layout: `grid grid-cols-1 lg:grid-cols-2 gap-8` — links Liste aller Editor-
+  Karten, rechts **eine** monolithische `BlockRenderer`-Ausgabe des ganzen Docs.
+  Dadurch fluchten linke Karten und rechte Blöcke höhenbedingt nicht.
+- `BlockRenderer({ document })` rendert `document.blocks` über eine Typ→Komponente-
+  Registry. Fällt auf `homepageSeed` zurück, wenn `safeParse` scheitert **oder**
+  `schemaVersion !== SCHEMA_VERSION`. Ein Doc `{ schemaVersion, blocks: [b] }`
+  rendert genau einen Block.
+- Blöcke haben stabile `id` und `type`. Diff je `id` über `props` genügt.
+- Save: `handleSave` → `saveHomepage(baseVersion, doc)` → 200/409/422/Fehler,
+  Feedback via `StatusBanner`.
+- Bestehende Tests (`HomepageEditorPage.test.tsx`) klicken „Speichern" und
+  erwarten direkten `saveHomepage`-Aufruf; zwei davon ohne vorheriges Editieren.
+
+## Design
+
+### Neuer State (in `HomepageEditorPage`)
+- `originalDoc: HomepageBlocksDocumentType | null` — Baseline, gesetzt beim Load
+  **und** nach erfolgreichem Save (`originalDoc ← doc`). Quelle für „Vorher" und
+  die Änderungs-Erkennung.
+- `previewOpen: boolean` — steuert Spalte 2. **Default `false`** (eingeklappt).
+- `confirmOpen: boolean` — steuert das Bestätigungs-Modal.
+
+### Helfer
+- `changedBlockIds(original, current): string[]` — pure Funktion. Vergleicht je
+  `block.id` die `props` (Deep-Equal via stabilem `JSON.stringify` der Props).
+  Liefert die IDs geänderter Blöcke. (Block-Mengen sind deckungsgleich, da keine
+  Add/Remove-Mutationen.) Eigene Datei `src/pages/admin/homepageDiff.ts` (klein,
+  pur, unit-testbar, ohne Import-Zyklus).
+- `singleBlockDoc(doc, block)` → `{ schemaVersion: doc.schemaVersion, blocks: [block] }`
+  für Einzelblock-Rendering (inline, kein eigenes Modul nötig).
+
+### Layout-Umbau (Zeilen-Alignment)
+Statt zweier unabhängiger Spalten → **eine Grid-Reihe pro Block**:
+
+```
+{doc.blocks.map((block, index) => (
+  <div
+    key={block.id}
+    className={previewOpen
+      ? 'grid grid-cols-1 lg:grid-cols-2 gap-8 items-start mb-6'
+      : 'mb-6'}
+  >
+    <EditorCard … />                              {/* Spalte 1 */}
+    {previewOpen && <PreviewCell block={block} />} {/* Spalte 2 */}
+  </div>
+))}
+```
+
+`items-start` + identische Reihenfolge garantieren im ausgeklappten Zustand:
+Block *i* links und rechts starten oben bündig in derselben Reihe. **Eingeklappt
+(`!previewOpen`)** ist die Reihe ein einfacher Block-Container (`mb-6`, kein
+Grid) und Spalte 2 entfällt → die Editor-Karte nimmt die **volle Breite** ein
+(nicht die halbe — ein einzelnes Kind in `lg:grid-cols-2` bliebe sonst
+halbbreit). Pixelgenaue Gleich-Höhe ist bei unterschiedlich hohen Blöcken nicht
+möglich und kein Ziel; die **Oberkanten fluchten**.
+
+### Retract-Toggle
+Button im Header (neben „Speichern"), z. B. „Vorschau einblenden/ausblenden"
+mit `aria-expanded={previewOpen}`, togglet `previewOpen`.
+
+### Bestätigungs-Modal — `SaveConfirmDialog`
+Neue Komponente `src/pages/admin/SaveConfirmDialog.tsx`:
+- Props: `changedBlocks: { block, before, after }[]`, `saving: boolean`,
+  `onConfirm()`, `onCancel()`.
+- Overlay (`role="dialog"`, `aria-modal`, abgedunkelter Hintergrund), Schließen
+  per Esc und Klick außerhalb = `onCancel`. Fokus initial auf „Bestätigen".
+- Inhalt: je geändertem Block eine Sektion mit Block-Label (`BLOCK_LABELS`) und
+  zwei gerenderten Fassungen nebeneinander: **Vorher** (aus `originalDoc`) und
+  **Nachher** (aus `doc`), jeweils via `BlockRenderer` mit `singleBlockDoc`.
+- Buttons: **„Abbrechen"** (`onCancel`) und **„Bestätigen"** (`onConfirm`,
+  während `saving` deaktiviert + „Speichert…"). Bewusst **ohne** das Wort
+  „Speichern", damit Test-Selektoren („Speichern" vs. „Bestätigen") eindeutig
+  bleiben.
+- Styling Tailwind, am bestehenden App-Look orientiert (vgl. `UserMenu`,
+  `StatusBanner`).
+
+### Flow
+1. `const changedIds = changedBlockIds(originalDoc, doc)`.
+2. Header-„Speichern": `disabled = saving || changedIds.length === 0`. Klick
+   setzt `confirmOpen = true` (kein direkter Save).
+3. Modal „Bestätigen" → bisherige `saveHomepage(baseVersion, doc)`-Logik. Bei
+   200: `baseVersion ← version`, `originalDoc ← doc`, `confirmOpen = false`,
+   „Gespeichert"-Banner. Bei 409/422/Fehler: bestehende Behandlung; Modal kann
+   offen bleiben und Status anzeigen oder schließen + Banner (Implementierung:
+   schließen + bestehender `StatusBanner`, da der die Fälle bereits abdeckt).
+4. „Abbrechen"/Esc/Außen-Klick → `confirmOpen = false`, kein Save.
+
+## Fehlerbehandlung
+- Keine Änderung → Button disabled, Modal öffnet nicht.
+- 409 Konflikt / 422 Validierung / Netzfehler → unverändert über `SaveStatus`/
+  `StatusBanner`; nach Konflikt bleibt `originalDoc` unverändert (Diff weiter gültig).
+- `BlockRenderer`-Seed-Fallback wird durch Mitgabe von `doc.schemaVersion`
+  vermieden.
+
+## Tests (vitest + @testing-library/react)
+Bestehende Tests in `HomepageEditorPage.test.tsx` an den neuen Flow anpassen
+(editieren → „Speichern" → „Bestätigen") und ergänzen:
+- **Disable:** ohne Edit ist „Speichern" disabled; nach Edit enabled.
+- **Kein Direkt-Save:** Klick „Speichern" ruft `saveHomepage` **nicht**; Modal erscheint.
+- **Nur geänderte Blöcke:** Modal listet ausschließlich geänderte Block-Labels
+  (Vorher+Nachher sichtbar).
+- **Bestätigen speichert:** „Bestätigen" ruft `saveHomepage(baseVersion=4, doc)`
+  genau einmal, Modal schließt, „Gespeichert"-Banner; danach „Speichern" wieder
+  disabled (Baseline = doc).
+- **Abbrechen:** „Abbrechen"/Esc schließt Modal ohne `saveHomepage`-Aufruf.
+- **409:** nach Edit → Speichern → Bestätigen → Konflikt-Hinweis.
+- **Retract-Toggle:** Default keine Vorschau-Zelle; nach Toggle erscheint die
+  gerenderte Block-Ausgabe in Spalte 2.
+- Pure-Unit-Test für `changedBlockIds` (`homepageDiff.test.ts`).
+
+## Betroffene Dateien
+- `mentolder-web/src/pages/admin/HomepageEditorPage.tsx` (Umbau)
+- `mentolder-web/src/pages/admin/SaveConfirmDialog.tsx` (neu)
+- `mentolder-web/src/pages/admin/homepageDiff.ts` (neu)
+- `mentolder-web/src/pages/admin/homepageDiff.test.ts` (neu)
+- `mentolder-web/src/pages/admin/HomepageEditorPage.test.tsx` (angepasst/erweitert)
+
+## Verifikation
+- `cd mentolder-web && npm run test` (vitest) grün.
+- `cd mentolder-web && npm run build` (tsc + vite) ohne Fehler.
+- Manuell (optional): `/admin/homepage` — Vorschau standardmäßig aus, Toggle
+  blendet zeilen-aligned ein; Speichern disabled ohne Änderung; mit Änderung
+  öffnet Modal mit Vorher/Nachher der geänderten Blöcke; Bestätigen speichert.

--- a/mentolder-web/src/pages/admin/HomepageEditorPage.test.tsx
+++ b/mentolder-web/src/pages/admin/HomepageEditorPage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import { HomepageEditorPage } from './HomepageEditorPage';
 
@@ -13,7 +13,9 @@ vi.mock('../../lib/homepageApi', () => ({
 import { useAuth } from '../../auth/useAuth';
 import { getHomepage, saveHomepage } from '../../lib/homepageApi';
 
-const heroDoc = {
+// Two blocks so "only the changed block is previewed" is meaningful: edit hero,
+// the faq block must NOT appear in the confirmation dialog.
+const baseDoc = {
   schemaVersion: 1,
   blocks: [
     {
@@ -30,10 +32,16 @@ const heroDoc = {
         personRole: 'Coach',
       },
     },
+    { id: 'faq', type: 'faq', props: { title: 'Häufige Fragen', items: [] } },
   ],
 };
 
-const admin = { authenticated: true, isAdmin: true, loading: false, user: { name: 'G', email: 'g@m.de', username: 'gekko', isAdmin: true } };
+const admin = {
+  authenticated: true,
+  isAdmin: true,
+  loading: false,
+  user: { name: 'G', email: 'g@m.de', username: 'gekko', isAdmin: true },
+};
 
 function renderEditor() {
   return render(
@@ -46,12 +54,20 @@ function renderEditor() {
   );
 }
 
+const saveButton = () => screen.getByRole('button', { name: 'Speichern' });
+
+async function loadAndEditTitle(value = 'New Title') {
+  const titleInput = await screen.findByDisplayValue('Old Title');
+  fireEvent.change(titleInput, { target: { value } });
+}
+
 beforeEach(() => {
   (useAuth as any).mockReset();
   (getHomepage as any).mockReset();
   (saveHomepage as any).mockReset();
-  (getHomepage as any).mockResolvedValue({ document: heroDoc, version: 4 });
+  (getHomepage as any).mockResolvedValue({ document: baseDoc, version: 4 });
   (saveHomepage as any).mockResolvedValue({ ok: true, status: 200, version: 5 });
+  (useAuth as any).mockReturnValue(admin);
 });
 
 describe('HomepageEditorPage guard', () => {
@@ -63,38 +79,80 @@ describe('HomepageEditorPage guard', () => {
   });
 });
 
-describe('HomepageEditorPage editing', () => {
-  it('loads the document and saves an edited field with the base version', async () => {
-    (useAuth as any).mockReturnValue(admin);
+describe('HomepageEditorPage — save confirmation flow', () => {
+  it('disables Speichern until a block is actually changed', async () => {
     renderEditor();
+    await screen.findByDisplayValue('Old Title');
+    expect(saveButton()).toBeDisabled();
+    await loadAndEditTitle();
+    expect(saveButton()).toBeEnabled();
+  });
 
-    const titleInput = await screen.findByDisplayValue('Old Title');
-    fireEvent.change(titleInput, { target: { value: 'New Title' } });
+  it('opens a confirmation dialog on Speichern instead of saving immediately', async () => {
+    renderEditor();
+    await loadAndEditTitle();
+    fireEvent.click(saveButton());
+    expect(saveHomepage).not.toHaveBeenCalled();
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
 
-    fireEvent.click(screen.getByRole('button', { name: /speichern|save/i }));
+  it('previews only the changed block (before/after) in the dialog', async () => {
+    renderEditor();
+    await loadAndEditTitle();
+    fireEvent.click(saveButton());
+    const dialog = screen.getByRole('dialog');
+    expect(within(dialog).getByText('Hero')).toBeInTheDocument();
+    expect(within(dialog).queryByText('FAQ')).not.toBeInTheDocument();
+    expect(within(dialog).getByText('Vorher')).toBeInTheDocument();
+    expect(within(dialog).getByText('Nachher')).toBeInTheDocument();
+  });
+
+  it('saves with the base version and closes the dialog on confirm', async () => {
+    renderEditor();
+    await loadAndEditTitle('New Title');
+    fireEvent.click(saveButton());
+    fireEvent.click(screen.getByRole('button', { name: 'Bestätigen' }));
 
     await waitFor(() => expect(saveHomepage).toHaveBeenCalledTimes(1));
     const [baseVersion, payload] = (saveHomepage as any).mock.calls[0];
     expect(baseVersion).toBe(4);
     expect(payload.blocks[0].props.title).toBe('New Title');
-    // unrelated fields preserved
-    expect(payload.blocks[0].props.personName).toBe('Gerald');
+    expect(payload.blocks[0].props.personName).toBe('Gerald'); // unrelated fields preserved
+
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+    expect(screen.getByText(/gespeichert|version 5/i)).toBeInTheDocument();
+    // baseline advanced to the saved doc → nothing left to save
+    expect(saveButton()).toBeDisabled();
+  });
+
+  it('does not save when the dialog is cancelled', async () => {
+    renderEditor();
+    await loadAndEditTitle();
+    fireEvent.click(saveButton());
+    fireEvent.click(screen.getByRole('button', { name: 'Abbrechen' }));
+    expect(saveHomepage).not.toHaveBeenCalled();
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(saveButton()).toBeEnabled();
   });
 
   it('shows a conflict notice on a 409 save', async () => {
-    (useAuth as any).mockReturnValue(admin);
     (saveHomepage as any).mockResolvedValue({ ok: false, status: 409, currentVersion: 9 });
     renderEditor();
-    await screen.findByDisplayValue('Old Title');
-    fireEvent.click(screen.getByRole('button', { name: /speichern|save/i }));
-    await waitFor(() => expect(screen.getByText(/anderswo geändert|neu laden|konflikt/i)).toBeInTheDocument());
+    await loadAndEditTitle();
+    fireEvent.click(saveButton());
+    fireEvent.click(screen.getByRole('button', { name: 'Bestätigen' }));
+    await waitFor(() =>
+      expect(screen.getByText(/anderswo geändert|neu laden|konflikt/i)).toBeInTheDocument(),
+    );
   });
+});
 
-  it('shows a success notice after a 200 save', async () => {
-    (useAuth as any).mockReturnValue(admin);
+describe('HomepageEditorPage — collapsible live preview', () => {
+  it('keeps the live preview collapsed by default and reveals it on toggle', async () => {
     renderEditor();
     await screen.findByDisplayValue('Old Title');
-    fireEvent.click(screen.getByRole('button', { name: /speichern|save/i }));
-    await waitFor(() => expect(screen.getByText(/gespeichert|version 5/i)).toBeInTheDocument());
+    expect(screen.queryByRole('region', { name: 'Hero-Bereich' })).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /vorschau/i }));
+    expect(screen.getByRole('region', { name: 'Hero-Bereich' })).toBeInTheDocument();
   });
 });

--- a/mentolder-web/src/pages/admin/HomepageEditorPage.tsx
+++ b/mentolder-web/src/pages/admin/HomepageEditorPage.tsx
@@ -6,6 +6,8 @@ import { BlockRenderer } from '@/blocks/BlockRenderer';
 import { homepageSeed } from '@/blocks/seed';
 import type { HomepageBlocksDocumentType } from '@/blocks/schema';
 import { fieldsForBlock, getAtPath, setAtPath, BLOCK_LABELS, type FieldDef } from './blockFields';
+import { changedBlockIds } from './homepageDiff';
+import { SaveConfirmDialog, type ChangedBlockPreview } from './SaveConfirmDialog';
 
 type SaveStatus =
   | { kind: 'idle' }
@@ -100,9 +102,15 @@ function FieldInput({ def, value, onChange }: { def: FieldDef; value: any; onCha
 export function HomepageEditorPage() {
   const { authenticated, isAdmin, loading } = useAuth();
   const [doc, setDoc] = useState<HomepageBlocksDocumentType | null>(null);
+  // Baseline = the last persisted document; drives the change detection that
+  // gates the save button and the before/after confirmation preview.
+  const [originalDoc, setOriginalDoc] = useState<HomepageBlocksDocumentType | null>(null);
   const [baseVersion, setBaseVersion] = useState(0);
   const [loaded, setLoaded] = useState(false);
   const [status, setStatus] = useState<SaveStatus>({ kind: 'idle' });
+  // Live preview is collapsed by default; admins opt in via the header toggle.
+  const [previewOpen, setPreviewOpen] = useState(false);
+  const [confirmOpen, setConfirmOpen] = useState(false);
 
   // Load the current document once the admin gate is satisfied.
   useEffect(() => {
@@ -110,7 +118,9 @@ export function HomepageEditorPage() {
     let active = true;
     getHomepage<HomepageBlocksDocumentType>().then(({ document, version }) => {
       if (!active) return;
-      setDoc(document ?? homepageSeed);
+      const loadedDoc = document ?? homepageSeed;
+      setDoc(loadedDoc);
+      setOriginalDoc(loadedDoc);
       setBaseVersion(version);
       setLoaded(true);
     });
@@ -136,12 +146,33 @@ export function HomepageEditorPage() {
     setStatus({ kind: 'idle' });
   };
 
-  const handleSave = async () => {
+  const saving = status.kind === 'saving';
+  const changedIds = changedBlockIds(originalDoc, doc);
+  const hasChanges = changedIds.length > 0;
+
+  // Before/after pairs for the confirmation dialog — only the changed blocks,
+  // each wrapped as a single-block document so BlockRenderer renders just it.
+  const changedBlocks: ChangedBlockPreview[] =
+    originalDoc && doc
+      ? changedIds.map((id) => {
+          const before = originalDoc.blocks.find((b) => b.id === id)!;
+          const after = doc.blocks.find((b) => b.id === id)!;
+          return {
+            label: BLOCK_LABELS[after.type] ?? after.type,
+            before: { schemaVersion: doc.schemaVersion, blocks: [before] },
+            after: { schemaVersion: doc.schemaVersion, blocks: [after] },
+          };
+        })
+      : [];
+
+  // Persist only after the admin confirms the previewed changes.
+  const handleConfirm = async () => {
     if (!doc) return;
     setStatus({ kind: 'saving' });
     const r = await saveHomepage(baseVersion, doc);
     if (r.ok) {
       setBaseVersion(r.version ?? baseVersion);
+      setOriginalDoc(doc); // baseline advances → no pending changes
       setStatus({ kind: 'saved', version: r.version });
     } else if (r.status === 409) {
       setStatus({ kind: 'conflict', currentVersion: r.currentVersion });
@@ -150,6 +181,7 @@ export function HomepageEditorPage() {
     } else {
       setStatus({ kind: 'error' });
     }
+    setConfirmOpen(false);
   };
 
   return (
@@ -158,25 +190,38 @@ export function HomepageEditorPage() {
         <h1 className="font-serif font-light text-fg m-0" style={{ fontSize: 'clamp(28px, 4vw, 44px)' }}>
           Edit Homepage
         </h1>
-        <button
-          type="button"
-          onClick={handleSave}
-          disabled={status.kind === 'saving'}
-          className="inline-flex items-center gap-2 rounded-full px-5 py-2.5 text-ink-900 font-medium disabled:opacity-60"
-          style={{ background: 'var(--brass)' }}
-        >
-          {status.kind === 'saving' ? 'Speichert…' : 'Speichern'}
-        </button>
+        <div className="flex items-center gap-3">
+          <button
+            type="button"
+            onClick={() => setPreviewOpen((v) => !v)}
+            aria-expanded={previewOpen}
+            className="rounded-full border border-line-2 px-4 py-2.5 text-[14px] font-medium text-fg"
+          >
+            {previewOpen ? 'Vorschau ausblenden' : 'Vorschau einblenden'}
+          </button>
+          <button
+            type="button"
+            onClick={() => setConfirmOpen(true)}
+            disabled={saving || !hasChanges}
+            className="inline-flex items-center gap-2 rounded-full px-5 py-2.5 text-ink-900 font-medium disabled:opacity-60"
+            style={{ background: 'var(--brass)' }}
+          >
+            Speichern
+          </button>
+        </div>
       </div>
 
       <StatusBanner status={status} />
 
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
-        <div>
-          {doc.blocks.map((block, index) => {
-            const fields = fieldsForBlock(block.type);
-            return (
-              <section key={block.id} className="mb-6 rounded-lg border border-line/60 p-4">
+      <div>
+        {doc.blocks.map((block, index) => {
+          const fields = fieldsForBlock(block.type);
+          return (
+            <div
+              key={block.id}
+              className={previewOpen ? 'grid grid-cols-1 lg:grid-cols-2 gap-8 items-start mb-6' : 'mb-6'}
+            >
+              <section className="rounded-lg border border-line/60 p-4">
                 <h2 className="text-[15px] font-semibold text-fg mb-3">
                   {BLOCK_LABELS[block.type] ?? block.type}
                 </h2>
@@ -190,17 +235,25 @@ export function HomepageEditorPage() {
                   />
                 ))}
               </section>
-            );
-          })}
-        </div>
 
-        <div className="lg:sticky lg:top-[90px] self-start">
-          <div className="text-[12px] uppercase tracking-wide text-mute mb-2">Live-Vorschau</div>
-          <div className="rounded-lg border border-line/60 overflow-hidden" aria-label="Live-Vorschau">
-            <BlockRenderer document={doc} />
-          </div>
-        </div>
+              {previewOpen && (
+                <div className="self-start rounded-lg border border-line/60 overflow-hidden">
+                  <BlockRenderer document={{ schemaVersion: doc.schemaVersion, blocks: [block] }} />
+                </div>
+              )}
+            </div>
+          );
+        })}
       </div>
+
+      {confirmOpen && (
+        <SaveConfirmDialog
+          changedBlocks={changedBlocks}
+          saving={saving}
+          onConfirm={handleConfirm}
+          onCancel={() => setConfirmOpen(false)}
+        />
+      )}
     </section>
   );
 }

--- a/mentolder-web/src/pages/admin/SaveConfirmDialog.tsx
+++ b/mentolder-web/src/pages/admin/SaveConfirmDialog.tsx
@@ -1,0 +1,98 @@
+import { useEffect, useRef } from 'react';
+import { BlockRenderer } from '@/blocks/BlockRenderer';
+import type { HomepageBlocksDocumentType } from '@/blocks/schema';
+
+// One changed block, rendered before (baseline) and after (working copy).
+export interface ChangedBlockPreview {
+  label: string;
+  before: HomepageBlocksDocumentType;
+  after: HomepageBlocksDocumentType;
+}
+
+interface Props {
+  changedBlocks: ChangedBlockPreview[];
+  saving: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+// Confirmation step shown when the admin clicks "Speichern": it renders ONLY
+// the changed blocks as before/after, and only "Bestätigen" actually persists.
+export function SaveConfirmDialog({ changedBlocks, saving, onConfirm, onCancel }: Props) {
+  const confirmRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    confirmRef.current?.focus();
+  }, []);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onCancel();
+    };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [onCancel]);
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto bg-ink-900/70 p-6"
+      onMouseDown={(e) => {
+        if (e.target === e.currentTarget) onCancel();
+      }}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="Änderungen bestätigen"
+        className="my-10 w-full max-w-[920px] rounded-xl border border-line-2 bg-ink-900 p-6 shadow-lg"
+      >
+        <h2 className="mb-1 font-serif text-[22px] font-light text-fg">Änderungen bestätigen</h2>
+        <p className="mb-5 text-[14px] text-fg-soft">
+          Nur die geänderten Blöcke werden gezeigt. „Bestätigen“ speichert die Homepage.
+        </p>
+
+        <div className="space-y-6">
+          {changedBlocks.map((cb, i) => (
+            <section key={i} className="rounded-lg border border-line/60 p-4">
+              <h3 className="mb-3 text-[15px] font-semibold text-fg">{cb.label}</h3>
+              <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+                <div>
+                  <div className="mb-2 text-[12px] uppercase tracking-wide text-mute">Vorher</div>
+                  <div className="overflow-hidden rounded border border-line/60">
+                    <BlockRenderer document={cb.before} />
+                  </div>
+                </div>
+                <div>
+                  <div className="mb-2 text-[12px] uppercase tracking-wide text-mute">Nachher</div>
+                  <div className="overflow-hidden rounded border border-line/60">
+                    <BlockRenderer document={cb.after} />
+                  </div>
+                </div>
+              </div>
+            </section>
+          ))}
+        </div>
+
+        <div className="mt-6 flex items-center justify-end gap-3">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="rounded-full border border-line-2 px-5 py-2.5 text-[14px] font-medium text-fg"
+          >
+            Abbrechen
+          </button>
+          <button
+            ref={confirmRef}
+            type="button"
+            onClick={onConfirm}
+            disabled={saving}
+            className="rounded-full px-5 py-2.5 text-[14px] font-medium text-ink-900 disabled:opacity-60"
+            style={{ background: 'var(--brass)' }}
+          >
+            {saving ? 'Speichert…' : 'Bestätigen'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/mentolder-web/src/pages/admin/homepageDiff.test.ts
+++ b/mentolder-web/src/pages/admin/homepageDiff.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { changedBlockIds } from './homepageDiff';
+
+const doc = (blocks: any[]) => ({ schemaVersion: 1, blocks }) as any;
+const hero = (title: string) => ({ id: 'hero', type: 'hero', props: { title, subtitle: 'S' } });
+const cta = (title: string) => ({ id: 'cta', type: 'cta', props: { title } });
+
+describe('changedBlockIds', () => {
+  it('returns an empty array when nothing changed', () => {
+    expect(changedBlockIds(doc([hero('A'), cta('X')]), doc([hero('A'), cta('X')]))).toEqual([]);
+  });
+
+  it('returns the id of a single block whose props changed', () => {
+    expect(changedBlockIds(doc([hero('A'), cta('X')]), doc([hero('B'), cta('X')]))).toEqual(['hero']);
+  });
+
+  it('returns all changed ids in document order', () => {
+    expect(changedBlockIds(doc([hero('A'), cta('X')]), doc([hero('B'), cta('Y')]))).toEqual([
+      'hero',
+      'cta',
+    ]);
+  });
+
+  it('detects a change in a nested prop', () => {
+    const a = doc([{ id: 'hero', type: 'hero', props: { intro: { emphasis: 'old' } } }]);
+    const b = doc([{ id: 'hero', type: 'hero', props: { intro: { emphasis: 'new' } } }]);
+    expect(changedBlockIds(a, b)).toEqual(['hero']);
+  });
+
+  it('returns an empty array when either side is null', () => {
+    expect(changedBlockIds(null, doc([hero('A')]))).toEqual([]);
+    expect(changedBlockIds(doc([hero('A')]), null)).toEqual([]);
+  });
+});

--- a/mentolder-web/src/pages/admin/homepageDiff.ts
+++ b/mentolder-web/src/pages/admin/homepageDiff.ts
@@ -1,0 +1,19 @@
+import type { HomepageBlocksDocumentType } from '@/blocks/schema';
+
+// Which homepage blocks changed between a baseline document and the working
+// copy. This editor only mutates block `props` (no add/remove/reorder), so a
+// per-id deep compare of `props` is sufficient. Props are updated immutably via
+// setAtPath, preserving key order, so a JSON.stringify compare is stable.
+export function changedBlockIds(
+  original: HomepageBlocksDocumentType | null,
+  current: HomepageBlocksDocumentType | null,
+): string[] {
+  if (!original || !current) return [];
+  const originalById = new Map(original.blocks.map((b) => [b.id, b]));
+  return current.blocks
+    .filter((b) => {
+      const prev = originalById.get(b.id);
+      return !prev || JSON.stringify(prev.props) !== JSON.stringify(b.props);
+    })
+    .map((b) => b.id);
+}


### PR DESCRIPTION
## Was

Die „Edit Homepage"-Seite der React-App `mentolder-web` (`/admin/homepage`) bekommt zwei Verhaltensänderungen:

1. **Live-Vorschau einklappbar, Default eingeklappt.** Die rechte Vorschau-Spalte wird nicht mehr bedingungslos gerendert. Ein Header-Toggle („Vorschau einblenden/ausblenden", `aria-expanded`) schaltet sie um; beim Öffnen der Seite ist sie aus.
2. **Zeilen-Alignment.** Im ausgeklappten Zustand liegt jede Editor-Karte (Spalte 1) in derselben Grid-Reihe wie ihr gerenderter Block (Spalte 2) — Oberkanten fluchten (`items-start`). Eingeklappt nimmt die Editor-Karte die volle Breite ein.
3. **Bestätigungs-Schritt beim Speichern.** „Speichern" öffnet ein Modal (`SaveConfirmDialog`), das **nur die geänderten Blöcke** als **Vorher/Nachher** rendert. Erst „Bestätigen" schreibt via `POST /api/admin/homepage/save`.
4. **Speichern deaktiviert ohne Änderung** — diff-basiert über `changedBlockIds` (Deep-Compare der Block-`props` gegen einen Baseline-Snapshot des geladenen Dokuments).

## Wie

- Neuer State im Editor: `originalDoc` (Baseline, gesetzt bei Load + nach erfolgreichem Save), `previewOpen`, `confirmOpen`.
- `homepageDiff.ts` — reine, unit-getestete `changedBlockIds(original, current)`-Funktion.
- `SaveConfirmDialog.tsx` — Overlay-Dialog (`role="dialog"`, Esc/Klick-außen = Abbrechen, Fokus auf „Bestätigen"), nutzt den bestehenden `BlockRenderer` mit Einzelblock-Dokumenten.
- Konflikt (409)/Validierung (422)/Fehler unverändert über den bestehenden `StatusBanner`.

## Tests

- `homepageDiff.test.ts` — Diff-Logik (5 Fälle).
- `HomepageEditorPage.test.tsx` — an den neuen Flow angepasst + erweitert: Disable-Logik, kein Direkt-Save, nur geänderte Blöcke im Modal, Bestätigen speichert + setzt Baseline neu, Abbrechen, 409-Konflikt, Retract-Toggle.
- Lokal: **128/128 Tests grün**, `npm run build` (tsc -b + vite) **fehlerfrei**.

## Spec

`docs/superpowers/specs/2026-06-27-homepage-editor-confirm-preview-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
