### PR TITLE
chore(ci): add GPG commit signing for freshness auto-regen workflow [T001200]

### DIFF
--- a/.github/workflows/freshness-regen.yml
+++ b/.github/workflows/freshness-regen.yml
@@ -50,6 +50,14 @@ jobs:
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Import GPG key for commit signing
+        if: steps.diff.outputs.changed == 'true'
+        uses: crazy-max/ghaction-import-gpg@d46b8ef5e6e7b4d1a8ef73f09f7a7d5e26fccc07  # v6.3.0
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+
       - name: Commit and push if changed
         if: steps.diff.outputs.changed == 'true'
         env:


### PR DESCRIPTION
## G-SEC05 — Commit-Signing für CI-Bot

**Setup:**
- GPG key (ed25519) generiert und als GitHub Signing Key registriert
- Privater Schlüssel als `GPG_PRIVATE_KEY` secret hinterlegt
- `freshness-regen.yml`: GPG-Import vor Commit-Schritt (crazy-max/ghaction-import-gpg)

**Effekt:** Künftige Auto-Regeneration-Commits (`chore: auto-regenerate freshness artifacts`) werden signiert (`%G?` = `G` statt `N`).

**Lokales Setup:** `bash scripts/setup-dev-env.sh` auf diesem Host ausgeführt (allowed_signers, commit.gpgsign).

Closes G-SEC05