### PR TITLE
fix(website): add missing yaml dependency [T001207]

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -53,6 +53,7 @@
     "signature_pad": "^4.2.0",
     "socket.io-client": "^4.8.3",
     "svelte": "^5.56.4",
+    "yaml": "^2.9.0",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -5,6 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  yaml: ^2.9.0
   esbuild: ^0.28.1
   undici: 7.28.0
   ws: 8.21.0
@@ -126,7 +127,7 @@ importers:
         specifier: ^5.56.4
         version: 5.56.4
       yaml:
-        specifier: ^2.8.3
+        specifier: ^2.9.0
         version: 2.9.0
       zod:
         specifier: ^4.4.3
@@ -3527,7 +3528,7 @@ packages:
       sugarss: ^5.0.0
       terser: ^5.16.0
       tsx: ^4.8.1
-      yaml: ^2.8.3
+      yaml: ^2.9.0
     peerDependenciesMeta:
       '@types/node':
         optional: true

--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  yaml: ^2.8.3
+  yaml: ^2.9.0
   esbuild: ^0.28.1
   undici: 7.28.0
   ws: 8.21.0

--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -5,7 +5,6 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  yaml: ^2.9.0
   esbuild: ^0.28.1
   undici: 7.28.0
   ws: 8.21.0
@@ -127,7 +126,7 @@ importers:
         specifier: ^5.56.4
         version: 5.56.4
       yaml:
-        specifier: ^2.9.0
+        specifier: ^2.8.3
         version: 2.9.0
       zod:
         specifier: ^4.4.3

--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -126,6 +126,9 @@ importers:
       svelte:
         specifier: ^5.56.4
         version: 5.56.4
+      yaml:
+        specifier: ^2.9.0
+        version: 2.9.0
       zod:
         specifier: ^4.4.3
         version: 4.4.3

--- a/website/pnpm-workspace.yaml
+++ b/website/pnpm-workspace.yaml
@@ -22,7 +22,7 @@ minimumReleaseAgeExclude:
   - livekit-client@2.20.0
 
 overrides:
-  yaml: "^2.8.3"
+  yaml: "^2.9.0"
   esbuild: "^0.28.1"
   undici: "7.28.0"
   ws: "8.21.0"


### PR DESCRIPTION
## What

Adds the `yaml` dependency to `website/package.json` — it was imported in `src/pages/admin/app-catalog.astro` but never declared, causing the CI build to fail.

## Why

PR #2141 (G-FE02 bundle-budget) was merged but the CI `bundle-budget` job couldn't build the website due to this pre-existing missing dependency. This fix unblocks that CI check.

## Testing

- `pnpm --dir website build` now succeeds
- Bundle size is unchanged (846 KB / 112 files)