### PR TITLE
feat(skills): MCP-first routing for the 5 high-frequency skills [T001211]

### DIFF
--- a/.claude/skills/dev-flow-execute/SKILL.md
+++ b/.claude/skills/dev-flow-execute/SKILL.md
@@ -55,10 +55,13 @@ Du bist auf einem `feature/*` oder `fix/*` Branch. `dev-flow-plan` hat Spec und 
 
 Falls `TICKET_ID` nicht bereits im Kontext gesetzt ist (z.B. vom User oder aus dem Branch-Namen ableitbar):
 
+Plan-Metadaten aus der DB holen — **MCP-first** (`mcp-postgres`, READ-ONLY, nimmt nur `sql`):
+
+> `mcp__mcp-postgres__query({ sql: "SELECT external_id, title FROM tickets.tickets WHERE status='plan_staged' ORDER BY planning_rank ASC NULLS LAST, created_at DESC LIMIT 10;" })`
+
+Fallback (mcp-postgres nicht erreichbar — Verfügbarkeits-Guard siehe [`mcp-tool-guide.md`](file:///home/patrick/Bachelorprojekt/.claude/skills/references/mcp-tool-guide.md)):
+
 ```bash
-# Plan-Metadaten aus der DB holen (MCP-Schnellweg wenn mcp-postgres erreichbar):
-# sql: SELECT external_id, title FROM tickets.tickets WHERE status='plan_staged' ORDER BY planning_rank ASC NULLS LAST, created_at DESC LIMIT 10;
-# Fallback:
 kubectl exec -n workspace deploy/shared-db -- psql -U postgres -d website -t -A -F '|' -c \
   "SELECT external_id, title FROM tickets.tickets WHERE status='plan_staged' ORDER BY planning_rank ASC NULLS LAST, created_at DESC LIMIT 10;"
 ```
@@ -164,16 +167,25 @@ done
 
 ## Schritt 1.5: Ticket auf `in_progress` setzen und touched_files registrieren
 
-Falls eine Ticket-ID vorhanden ist, setze das Ticket auf in_progress:
+Falls eine Ticket-ID vorhanden ist, setze das Ticket auf in_progress — **MCP-first** (`ticket-mcp`):
+
+> `mcp__ticket-mcp__transition_status({ id: "$TICKET_ID", status: "in_progress" })`
+> `mcp__ticket-mcp__record_phase_event({ id: "$TICKET_ID", phase: "plan", state: "entered", driver: "devflow", detail: "Plan: <slug> · $TICKET_ID" })`
+
+Fallback (ticket-mcp nicht erreichbar; Live-Floor-Telemetrie ist best-effort und darf den Flow nie stoppen):
 
 ```bash
 ./scripts/vda.sh ticket update-status --id "$TICKET_ID" --status in_progress
-# Live-Floor-Telemetrie (best-effort; --driver devflow; darf den Flow nie stoppen)
 SLUG=$(basename "$PLAN_FILE" .md)
 ./scripts/ticket.sh phase "$TICKET_ID" plan entered --driver devflow --detail "Plan: $SLUG · $TICKET_ID" || true
 ```
 
-Falls der Plan die berührten Dateien kennt, registriere sie für die Conflict-Gate (parallele Sessions sehen die Kollision via `agent-collision.sh`):
+Falls der Plan die berührten Dateien kennt, registriere sie für die Conflict-Gate (parallele Sessions sehen die Kollision via `agent-collision.sh`) — **MCP-first**:
+
+> `mcp__ticket-mcp__set_touched_files({ id: "$TICKET_ID", files: "<comma-separated-paths>" })`
+> `mcp__ticket-mcp__record_phase_event({ id: "$TICKET_ID", phase: "plan", state: "done", driver: "devflow", detail: "Plan geladen · Assets folgen" })`
+
+Fallback:
 
 ```bash
 ./scripts/ticket.sh set-touched-files --id "$TICKET_ID" --files "<comma-separated-paths>"
@@ -184,7 +196,11 @@ Falls der Plan die berührten Dateien kennt, registriere sie für die Conflict-G
 
 ## Schritt 1.7: Visual & Textual Assets laden (Visual Handoff)
 
-Falls eine Ticket-ID vorhanden ist, lade alle Anhänge (wie Screenshots, Logdateien, Mockups) herunter:
+Falls eine Ticket-ID vorhanden ist, lade alle Anhänge (wie Screenshots, Logdateien, Mockups) herunter — **MCP-first** (`ticket-mcp`):
+
+> `mcp__ticket-mcp__get_attachments({ id: "$TICKET_ID", out_dir: "/tmp/ticket-attachments-$TICKET_ID" })`
+
+Fallback (ticket-mcp nicht erreichbar):
 
 ```bash
 ATTACHMENT_DIR="/tmp/ticket-attachments-$TICKET_ID"
@@ -197,8 +213,13 @@ ATTACHMENT_DIR="/tmp/ticket-attachments-$TICKET_ID"
 
 ## Schritt 2: Implementierung an frischen Implementer-Subagenten delegieren
 
+Live-Floor-Telemetrie (best-effort): Implementer-Subagent wird gespawnt — **MCP-first**:
+
+> `mcp__ticket-mcp__record_phase_event({ id: "$TICKET_ID", phase: "implement", state: "entered", driver: "devflow", detail: "Subagent gestartet" })`
+
+Fallback:
+
 ```bash
-# Live-Floor-Telemetrie (best-effort): Implementer-Subagent wird gespawnt
 ./scripts/ticket.sh phase "$TICKET_ID" implement entered --driver devflow --detail "Subagent gestartet" || true
 ```
 
@@ -282,15 +303,31 @@ bash scripts/devflow-build-loop.sh "$TICKET_ID"
 
 Rufe das Skill **`verification-before-completion`** auf, um die Verifikation strukturiert zu steuern.
 
+Phasen-Telemetrie (best-effort) — **MCP-first** (`ticket-mcp`):
+
+> `mcp__ticket-mcp__record_phase_event({ id: "$TICKET_ID", phase: "implement", state: "done", driver: "devflow", detail: "Implementierung fertig" })`
+> `mcp__ticket-mcp__record_phase_event({ id: "$TICKET_ID", phase: "verify", state: "entered", driver: "devflow", detail: "task test:changed + freshness" })`
+
+Verifikation ausführen:
+
 ```bash
-# Live-Floor-Telemetrie (best-effort; --driver devflow; darf den Flow nie stoppen)
-./scripts/ticket.sh phase "$TICKET_ID" implement done --driver devflow --detail "Implementierung fertig" || true
-./scripts/ticket.sh phase "$TICKET_ID" verify entered --driver devflow --detail "task test:changed + freshness" || true
 task workspace:validate
 ./tests/runner.sh local <FA-XX oder SA-XX>
 task test:changed
 task freshness:regenerate
 task freshness:check        # CI-Äquivalent — failt lokal GENAU wie CI (S1–S4-Ratchet + Baseline-Assertion)
+```
+
+Nach grünen Tests — **MCP-first**:
+
+> `mcp__ticket-mcp__record_phase_event({ id: "$TICKET_ID", phase: "verify", state: "done", driver: "devflow", detail: "Tests grün · freshness OK" })`
+
+Fallback (ticket-mcp nicht erreichbar; Telemetrie ist best-effort und darf den Flow nie stoppen):
+
+```bash
+./scripts/ticket.sh phase "$TICKET_ID" implement done --driver devflow --detail "Implementierung fertig" || true
+./scripts/ticket.sh phase "$TICKET_ID" verify entered --driver devflow --detail "task test:changed + freshness" || true
+# nach den Tests:
 ./scripts/ticket.sh phase "$TICKET_ID" verify done --driver devflow --detail "Tests grün · freshness OK" || true
 ```
 
@@ -443,19 +480,26 @@ done
 
 Falls eine Ticket-ID vorhanden ist, schließe das Ticket:
 
+PR-Nummer ermitteln (falls nicht aus Schritt 6.4 bekannt):
+
 ```bash
 RESOLUTION="shipped" # oder "fixed" bei Fixes
-# PR_NUM wurde in Schritt 6.4 bereits ermittelt; hier nur falls separat aufgerufen:
 : "${PR_NUM:=$(gh pr view --json number -q '.number' 2>/dev/null || echo "")}"
+```
 
-# PR-Nummer in ticket_links eintragen, damit der Shipped-Tab sie zeigt (Fix 1):
+Abschluss-Lifecycle — **MCP-first** (`ticket-mcp`). Merge = Abschluss (T001092): Schritt 6.4 hat bestätigt, dass der PR gemergt ist; der Prod-Deploy (Schritt 8) ist entkoppelt und ändert den Ticket-Status NICHT.
+
+> `mcp__ticket-mcp__add_pr_link({ id: "$TICKET_ID", pr: "$PR_NUM" })`
+> `mcp__ticket-mcp__transition_status({ id: "$TICKET_ID", status: "done", resolution: "<shipped|fixed>" })`
+> `mcp__ticket-mcp__record_phase_event({ id: "$TICKET_ID", phase: "verify", state: "done", driver: "devflow", detail: "gate=ci result=pass" })`
+> `mcp__ticket-mcp__record_phase_event({ id: "$TICKET_ID", phase: "deploy", state: "done", driver: "devflow", detail: "PR #$PR_NUM merged · done/shipped" })`
+> `mcp__ticket-mcp__add_comment({ id: "$TICKET_ID", body: "PR #$PR_NUM merged. Plan archived to tickets.ticket_plans." })`
+
+Fallback (ticket-mcp nicht erreichbar; die Phasen-Events sind best-effort und nie blockierend):
+
+```bash
 ./scripts/ticket.sh add-pr-link --id "$TICKET_ID" --pr "$PR_NUM"
-
-# Merge = Abschluss (T001092): Schritt 6.4 hat bestätigt, dass der PR gemergt ist;
-# Ticket kann jetzt sauber auf done gehen. Prod-Deploy (Schritt 8) ist entkoppelt
-# und ändert den Ticket-Status NICHT.
 ./scripts/vda.sh ticket update-status --id "$TICKET_ID" --status done --resolution "$RESOLUTION"
-# Quality-Gate-Outcome + Live-Floor-Telemetrie (best-effort; --driver devflow; nie blockierend)
 ./scripts/ticket.sh phase "$TICKET_ID" verify done --driver devflow --detail "gate=ci result=pass" || true
 ./scripts/ticket.sh phase "$TICKET_ID" deploy done --driver devflow --detail "PR #$PR_NUM merged · done/shipped" || true
 ./scripts/ticket.sh add-comment --id "$TICKET_ID" --body "PR #$PR_NUM merged. Plan archived to tickets.ticket_plans."
@@ -474,17 +518,26 @@ PR_NUM=$(gh pr view --json number -q '.number' 2>/dev/null || echo "")
 
 # 1. Plan-Frontmatter auf completed setzen, BEVOR der Inhalt archiviert wird:
 sed -i 's/^status: active$/status: completed/' "$PLAN_FILE"
+```
 
-# 2. tasks.md → postgres (tickets.ticket_plans)
+2. tasks.md → postgres (`tickets.ticket_plans`) — **MCP-first** (`ticket-mcp`):
+
+> `mcp__ticket-mcp__archive_plan({ id: "$TICKET_ID", slug: "$SLUG", branch: "$BRANCH", plan_file: "$PLAN_FILE", pr: "$PR_NUM" })`
+
+Fallback (ticket-mcp nicht erreichbar):
+
+```bash
 ./scripts/ticket.sh archive-plan \
   --id "$TICKET_ID" \
   --slug "$SLUG" \
   --branch "$BRANCH" \
   --plan-file "$PLAN_FILE" \
   --pr "$PR_NUM"
+```
 
-# 3. OpenSpec-Change archivieren: openspec/changes/<slug>/ → openspec/changes/archive/<date>-<slug>/
-#    Verschiebt proposal.md, tasks.md, specs/, assets/ ins Archiv und aktualisiert den SSOT-Delta.
+3. OpenSpec-Change archivieren: `openspec/changes/<slug>/` → `openspec/changes/archive/<date>-<slug>/`. Verschiebt proposal.md, tasks.md, specs/, assets/ ins Archiv und aktualisiert den SSOT-Delta.
+
+```bash
 bash scripts/openspec.sh archive "$SLUG"
 # Alternativ: task openspec:archive -- "$SLUG"
 

--- a/.claude/skills/dev-flow-plan/SKILL.md
+++ b/.claude/skills/dev-flow-plan/SKILL.md
@@ -38,7 +38,13 @@ Wenn das Feature komplex oder unklar ist, frage den User nach einer Grilling-Ses
 
 **Nutze `lavish` für die Q/A-Session:** Erstelle `.lavish/<slug>-grilling.html` mit den Fragen als interaktivem Formular (Input-Playbook), öffne es mit `npx -y lavish-axi .lavish/<slug>-grilling.html` und poll auf Antworten. So kann der User strukturiert antworten, annotieren und Feedback geben.
 
-Falls durchgeführt, erstelle das Grilling-Ticket mit dem CLI-Helper:
+Falls durchgeführt, erstelle das Grilling-Ticket — **MCP-first** (`ticket-mcp`). Der zurückgegebene Text ist `external_id|uuid` (identisch zu `ticket.sh create`): `external_id` = Feld 1 (`cut -d'|' -f1`), `uuid` = Feld 2.
+
+> `mcp__ticket-mcp__create_ticket({ type: "task", brand: "mentolder", title: "Grilling: <kurzer-titel>", priority: "mittel", description: "FUNKTIONALE ANFORDERUNGEN:\n<requirements>\n\nASSETS ZU BESCHAFFEN:\n<assets-todo>" })`
+
+Setze `GRILLING_TICKET_EXT_ID` (Feld 1) und `GRILLING_TICKET_UUID` (Feld 2) aus der Rückgabe.
+
+Fallback (ticket-mcp nicht erreichbar):
 
 ```bash
 TICKET_RESULT=$(./scripts/ticket.sh create \
@@ -254,7 +260,19 @@ Du behältst deinen vollen Brainstorming-Kontext: lies den vom Subagenten zurüc
 
 ### Schritt 4.5: Ticket anlegen oder wiederverwenden
 
-Prüfe ob ein bestehendes Ticket-ID übergeben wurde (z.B. von `feature-intake`):
+Prüfe ob ein bestehendes Ticket-ID übergeben wurde (z.B. von `feature-intake`).
+
+**MCP-first** (`ticket-mcp`) — wenn noch kein `TICKET_EXT_ID` gesetzt ist, ein neues Ticket anlegen. Rückgabe ist `external_id|uuid`: Feld 1 (`cut -d'|' -f1`) = `TICKET_EXT_ID`, Feld 2 = `TICKET_UUID`.
+
+> `mcp__ticket-mcp__create_ticket({ type: "task", brand: "mentolder", title: "Plan: <slug>", priority: "mittel", description: "Branch: feature/<slug>\nPlan: openspec/changes/<slug>/tasks.md\nSpec: docs/superpowers/specs/<date>-<slug>-design.md\n<grilling-ref>" })`
+
+Bei vorhandenem Ticket stattdessen die UUID lesen: `mcp__ticket-mcp__get_ticket({ id: "$TICKET_EXT_ID" })` → `.id` ist die UUID.
+
+Plan stagen (Branch + Plan-Pfad im Ticket verankern — SSOT für dev-flow-execute) — **MCP-first**:
+
+> `mcp__ticket-mcp__stage_plan({ id: "$TICKET_EXT_ID", branch: "feature/<slug>", plan: "openspec/changes/<slug>/tasks.md" })`
+
+Fallback (ticket-mcp nicht erreichbar):
 
 ```bash
 # Falls TICKET_EXT_ID bereits gesetzt ist (von feature-intake oder User-Input),
@@ -329,7 +347,12 @@ Details siehe [plan-review-ui](file:///home/patrick/Bachelorprojekt/.claude/skil
 ## Fix-Pfad
 
 ### Schritt 1: T-###### Ticket
-Frage den User nach der Ticket-ID. Falls keins vorhanden ist, lege ein neues Ticket an:
+Frage den User nach der Ticket-ID. Falls keins vorhanden ist, lege ein neues Ticket an — **MCP-first** (`ticket-mcp`, Rückgabe `external_id|uuid`: Feld 1 = `TICKET_EXT_ID`, Feld 2 = `TICKET_UUID`):
+
+> `mcp__ticket-mcp__create_ticket({ type: "bug", brand: "mentolder", title: "<titel>", description: "<beschreibung>", status: "triage", severity: "<critical|major|minor|trivial>", priority: "hoch" })`
+
+Fallback (ticket-mcp nicht erreichbar):
+
 ```bash
 TICKET_RESULT=$(./scripts/ticket.sh create \
   --type bug \
@@ -377,12 +400,20 @@ Schreibe einen automatisierten Test, der den Bug reproduziert und fehlschlägt (
 Rufe `superpowers:writing-plans` auf. Wende das Frontmatter an und trage die Ticket-ID ein. Committe und pushe den Plan.
 
 ### Schritt 4.5: Plan stagen (Fix 6)
+
+**MCP-first** (`ticket-mcp`):
+
+> `mcp__ticket-mcp__stage_plan({ id: "$TICKET_EXT_ID", branch: "fix/<slug>", plan: "openspec/changes/<slug>/tasks.md" })`
+
+Fallback (ticket-mcp nicht erreichbar):
+
 ```bash
 ./scripts/ticket.sh stage-plan \
   --id "$TICKET_EXT_ID" \
   --branch "fix/<slug>" \
   --plan "openspec/changes/<slug>/tasks.md"
 ```
+
 Damit ist das Fix-Ticket als `plan_staged` in der DB verankert und für `dev-flow-execute` bereit.
 
 ### Schritt 5: Commit & Push

--- a/.claude/skills/incident-response/SKILL.md
+++ b/.claude/skills/incident-response/SKILL.md
@@ -56,9 +56,18 @@ kubectl exec "$PGPOD" -n workspace --context fleet -c postgres -- psql -U websit
 
 ## Step 3 — Diagnose
 
+Cluster-Status-Reads — **MCP-first** (`mcp-kubernetes`, read-only):
+
+> Pod-Status: `mcp__mcp-kubernetes__pods_list_in_namespace({ namespace: "workspace" })` — CrashLoopBackOff, OOMKilled, Pending erkennen.
+> Logs: `mcp__mcp-kubernetes__pods_log({ namespace: "workspace", name: "<pod>" })`
+> Einzelnes Pod-Detail: `mcp__mcp-kubernetes__pods_get({ namespace: "workspace", name: "<pod>" })`
+
+Fallback (mcp-kubernetes nicht erreichbar — Verfügbarkeits-Guard siehe [`MCP-Tool-Guide`](file:///home/patrick/Bachelorprojekt/.claude/skills/references/mcp-tool-guide.md)):
+
 * **Pod status:** `task workspace:status ENV=mentolder` (CrashLoopBackOff, OOMKilled, Pending).
 * **Logs:** `task workspace:logs ENV=<env> -- <service>`.
-* **Recent Deploys:** `git log --oneline -10`.
+
+**Recent Deploys** (kein Cluster-Read): `git log --oneline -10`.
 
 ## Step 4 — Fix or Rollback
 

--- a/.claude/skills/infra-ops/SKILL.md
+++ b/.claude/skills/infra-ops/SKILL.md
@@ -291,8 +291,10 @@ Keycloak-Realm aus JSON reconcilen — OIDC-Clients, Gruppen, Mapper, SSO-Login-
 
 ### Phases
 
+> **Status-Reads MCP-first:** Pod-Status/Logs bevorzugt über `mcp__mcp-kubernetes__pods_list_in_namespace({ namespace: "workspace" })` / `mcp__mcp-kubernetes__pods_log({ namespace: "workspace", name: "<keycloak-pod>" })` (read-only); die `task workspace:status`/`logs`-Aufrufe unten sind der Fallback. Mutations (`task secrets:sync`, `register-oidc-client.mjs`, deploys) bleiben unverändert.
+
 ```bash
-# Phase 1: Pre-sync check
+# Phase 1: Pre-sync check (Fallback — siehe MCP-first oben)
 task workspace:status ENV=<env>  # keycloak pod: 1/1 Running?
 task workspace:logs ENV=<env> -- keycloak
 
@@ -463,6 +465,13 @@ task workspace:deploy ENV=mentolder && task workspace:deploy ENV=korczewski
 ```
 
 ### Verification
+
+Status-Reads — **MCP-first** (`mcp-kubernetes`, read-only):
+
+> `mcp__mcp-kubernetes__pods_list_in_namespace({ namespace: "workspace" })` — alle Pods 1/1 Running?
+> `mcp__mcp-kubernetes__pods_log({ namespace: "workspace", name: "<keycloak|nextcloud|website>-pod" })`
+
+Fallback (mcp-kubernetes nicht erreichbar):
 
 ```bash
 task workspace:status ENV=<env>

--- a/.claude/skills/ticket-ops/SKILL.md
+++ b/.claude/skills/ticket-ops/SKILL.md
@@ -67,6 +67,9 @@ psql() { kubectl exec "$PGPOD" -n workspace --context fleet -c postgres -- psql 
 Fetch every open ticket and compute, per ticket, **what is missing** before it can be worked. This is a two-tier rubric: a lightweight field check for *all* tickets, plus the DoR check for planning-stage features.
 
 ### Step 1.1: Fetch open tickets (enriched)
+
+**MCP-first** (`mcp-postgres`, read-only): pass the query below to `mcp__mcp-postgres__query({ sql: "…" })`. Fallback: `psql -c "<query>"` via the `psql()` helper above.
+
 ```sql
 SELECT external_id, title, type, status, priority, severity, component, areas,
        depends_on, attention_mode, planning_rank, readiness,
@@ -140,7 +143,14 @@ Mirror `website/src/lib/clarification-questions.ts` (`deriveSections`) — the s
 One `AskUserQuestion` round per ticket (≤4 questions per call — split into multiple calls if a ticket has more), in priority order. Use the radio/checkbox option sets from `clarification-questions.ts` where they exist; free-text otherwise. If you are running without the `AskUserQuestion` tool (e.g. dispatched as a subagent), fall back to one consolidated plain-text question per ticket.
 
 ### Step 2.4: Write answers back to the DB
-Writes go through `psql()` (the MCP query tool is read-only). Per ticket, set the now-satisfied DoR flags via a JSONB merge (never clobber other flags), update the answered fields, and append a clarification comment:
+
+**MCP-first** (`ticket-mcp` lifecycle, where a wrapper exists — these shell out to `ticket.sh`, the sanctioned write path, NOT via the read-only `mcp-postgres`): set DoR flags via `set_readiness_flag` (one per flag) or `prepare_feature`; set effort/areas/depends_on via `set_plan_meta`; append the clarification comment via `add_comment`.
+
+> `mcp__ticket-mcp__set_readiness_flag({ id: "T000XXX", flag: "spec_skizziert", value: true })`
+> `mcp__ticket-mcp__set_plan_meta({ id: "T000XXX", effort: "mittel", depends_on: "T000YYY" })`
+> `mcp__ticket-mcp__add_comment({ id: "T000XXX", body: "## Klärungsrunde …" })`
+
+Fallback / bulk path (ticket-mcp nicht erreichbar, oder für Felder ohne Wrapper wie ein direkter `priority`-Set + eine einzelne JSONB-Readiness-Merge): Writes go through `psql()` (the MCP query tool is read-only). Per ticket, set the now-satisfied DoR flags via a JSONB merge (never clobber other flags), update the answered fields, and append a clarification comment:
 
 ```bash
 psql -c "
@@ -272,7 +282,11 @@ TICKET_ID=$(printf '%s %s' "$TITLE" "$BRANCH" | grep -oiE 'T[0-9]{6}' | head -1 
   > ```
   Use `--auto` instead when CI is still running — GitHub merges once checks pass.
 
-* **Close the ticket once `mergedAt` is set** (only if `$TICKET_ID` was found; `resolution`: `fixed` for `fix/*`, `shipped` for `feature/*`):
+* **Close the ticket once `mergedAt` is set** (only if `$TICKET_ID` was found; `resolution`: `fixed` for `fix/*`, `shipped` for `feature/*`) — **MCP-first** (`ticket-mcp` lifecycle; the wrappers write via `ticket.sh`, not via the read-only `mcp-postgres`):
+  > `mcp__ticket-mcp__transition_status({ id: "$TICKET_ID", status: "done", resolution: "<fixed|shipped>" })`
+  > `mcp__ticket-mcp__add_comment({ id: "$TICKET_ID", body: "PR #<number> merged." })`
+
+  Fallback (ticket-mcp nicht erreichbar — direkte Writes über `psql`):
   ```bash
   psql -c \
     "UPDATE tickets.tickets SET status='done', resolution='fixed', done_at=now()

--- a/openspec/changes/mcp-skill-integration/tasks.md
+++ b/openspec/changes/mcp-skill-integration/tasks.md
@@ -667,11 +667,11 @@ git commit -m "refactor(ticket-mcp): consolidate on Go binary; point opencode at
 
 ### Task 1.5 (Slice 1 verification gate)
 
-- [ ] **Step 1: Go suite + build.** Run: `cd scripts/ticket-mcp/go && go vet ./... && go test ./... && make build`. Expected: all green.
-- [ ] **Step 2: Tool inventory (parity + completeness).** Re-run the stdio smoke from Task 1.2 Step 9; confirm all 9 workflow tools + `get_mishap_buffer` + `flush_mishap_buffer` + the pre-existing 12 are present (≥23 tool names). Also re-run `task test:mcp-tooling` → `1 test, 0 failures`.
-- [ ] **Step 3: No Node residue.** Run: `ls scripts/ticket-mcp/` — expect only `go/`, `.gitignore`, and the gitignored `ticket-mcp-go`. No `server.js`/`tools/`/`lib/`/`package*.json`.
-- [ ] **Step 4: CI-equivalent (changed-scope).** Run: `task test:changed && task freshness:check`. Expected: green (Go changes trigger `test:unit`; quality gate clean — no S1/baseline movement).
-- [ ] **Step 5: Open PR #1.** Title: `feat(ticket-mcp): Go-SSOT consolidation + complete adapter surface [T001211]`. Merge before starting Slice 2.
+- [x] **Step 1: Go suite + build.** Run: `cd scripts/ticket-mcp/go && go vet ./... && go test ./... && make build`. Expected: all green.
+- [x] **Step 2: Tool inventory (parity + completeness).** Re-run the stdio smoke from Task 1.2 Step 9; confirm all 9 workflow tools + `get_mishap_buffer` + `flush_mishap_buffer` + the pre-existing 12 are present (≥23 tool names). Also re-run `task test:mcp-tooling` → `1 test, 0 failures`.
+- [x] **Step 3: No Node residue.** Run: `ls scripts/ticket-mcp/` — expect only `go/`, `.gitignore`, and the gitignored `ticket-mcp-go`. No `server.js`/`tools/`/`lib/`/`package*.json`.
+- [x] **Step 4: CI-equivalent (changed-scope).** Run: `task test:changed && task freshness:check`. Expected: green (Go changes trigger `test:unit`; quality gate clean — no S1/baseline movement).
+- [x] **Step 5: Open PR #1.** Title: `feat(ticket-mcp): Go-SSOT consolidation + complete adapter surface [T001211]`. Merge before starting Slice 2.
 
 ---
 
@@ -686,8 +686,8 @@ git commit -m "refactor(ticket-mcp): consolidate on Go binary; point opencode at
 
 **Files:** Modify `.claude/skills/dev-flow-execute/SKILL.md` (558 lines · `.md` not gated → S1 N/A)
 
-- [ ] **Step 1: Inventory the call sites.** Run: `grep -n "ticket.sh\|kubectl exec.*psql\|psql " .claude/skills/dev-flow-execute/SKILL.md`. Map each to its MCP tool: `phase`→`record_phase_event`, `stage-plan`→`stage_plan`, `get-attachments`→`get_attachments`, `archive-plan`→`archive_plan`, `add-comment`→`add_comment`, `add-pr-link`→`add_pr_link`, plan-metadata **read** (`psql SELECT …`) → `mcp__mcp-postgres__query`.
-- [ ] **Step 2: Rewrite each lifecycle call site to MCP-first + Fallback.** For every mapped call, restructure to (exemplar for `phase`):
+- [x] **Step 1: Inventory the call sites.** Run: `grep -n "ticket.sh\|kubectl exec.*psql\|psql " .claude/skills/dev-flow-execute/SKILL.md`. Map each to its MCP tool: `phase`→`record_phase_event`, `stage-plan`→`stage_plan`, `get-attachments`→`get_attachments`, `archive-plan`→`archive_plan`, `add-comment`→`add_comment`, `add-pr-link`→`add_pr_link`, plan-metadata **read** (`psql SELECT …`) → `mcp__mcp-postgres__query`.
+- [x] **Step 2: Rewrite each lifecycle call site to MCP-first + Fallback.** For every mapped call, restructure to (exemplar for `phase`):
 
 ```markdown
 Phasen-Event setzen (MCP-first):
@@ -699,9 +699,9 @@ Fallback (MCP nicht erreichbar):
 ```
 
 Apply the same shape to `stage_plan`, `get_attachments`, `archive_plan`, `add_comment`, `add_pr_link`.
-- [ ] **Step 3: Convert plan-metadata READS to `mcp__mcp-postgres__query` first, kubectl fallback** (keep any INSERT/UPDATE on kubectl). Link the availability guard to `.claude/skills/references/mcp-tool-guide.md` rather than re-explaining it.
-- [ ] **Step 4: Verify no write-path was switched to mcp-postgres.** Run: `grep -n "mcp__mcp-postgres__query" .claude/skills/dev-flow-execute/SKILL.md` and eyeball that each is a SELECT.
-- [ ] **Step 5: Commit.** `git add .claude/skills/dev-flow-execute/SKILL.md && git commit -m "feat(skills): dev-flow-execute MCP-first (ticket-mcp + mcp-postgres reads), script fallback retained"`
+- [x] **Step 3: Convert plan-metadata READS to `mcp__mcp-postgres__query` first, kubectl fallback** (keep any INSERT/UPDATE on kubectl). Link the availability guard to `.claude/skills/references/mcp-tool-guide.md` rather than re-explaining it.
+- [x] **Step 4: Verify no write-path was switched to mcp-postgres.** Run: `grep -n "mcp__mcp-postgres__query" .claude/skills/dev-flow-execute/SKILL.md` and eyeball that each is a SELECT.
+- [x] **Step 5: Commit.** `git add .claude/skills/dev-flow-execute/SKILL.md && git commit -m "feat(skills): dev-flow-execute MCP-first (ticket-mcp + mcp-postgres reads), script fallback retained"`
 
 **Acceptance:** every lifecycle call site shows the MCP tool first and the script as labelled fallback; reads use mcp-postgres, writes/DDL stay kubectl.
 
@@ -709,9 +709,9 @@ Apply the same shape to `stage_plan`, `get_attachments`, `archive_plan`, `add_co
 
 **Files:** Modify `.claude/skills/dev-flow-plan/SKILL.md` (434 lines · `.md` N/A)
 
-- [ ] **Step 1:** `grep -n "ticket.sh" .claude/skills/dev-flow-plan/SKILL.md`. Map `create`→`create_ticket` (parse `external_id|uuid` → `cut -d'|' -f1` still applies to the tool's returned text), `stage-plan`→`stage_plan`.
-- [ ] **Step 2:** Rewrite both to MCP-first + Fallback (same shape as Task 2.1 Step 2). For `create_ticket`, document that the returned text is still `external_id|uuid` so existing parsing holds.
-- [ ] **Step 3: Commit.** `git add .claude/skills/dev-flow-plan/SKILL.md && git commit -m "feat(skills): dev-flow-plan MCP-first (create_ticket/stage_plan), script fallback retained"`
+- [x] **Step 1:** `grep -n "ticket.sh" .claude/skills/dev-flow-plan/SKILL.md`. Map `create`→`create_ticket` (parse `external_id|uuid` → `cut -d'|' -f1` still applies to the tool's returned text), `stage-plan`→`stage_plan`.
+- [x] **Step 2:** Rewrite both to MCP-first + Fallback (same shape as Task 2.1 Step 2). For `create_ticket`, document that the returned text is still `external_id|uuid` so existing parsing holds.
+- [x] **Step 3: Commit.** `git add .claude/skills/dev-flow-plan/SKILL.md && git commit -m "feat(skills): dev-flow-plan MCP-first (create_ticket/stage_plan), script fallback retained"`
 
 **Acceptance:** create + stage-plan are MCP-first; the `cut -d'|' -f1` parse note is present.
 
@@ -719,9 +719,9 @@ Apply the same shape to `stage_plan`, `get_attachments`, `archive_plan`, `add_co
 
 **Files:** Modify `.claude/skills/ticket-ops/SKILL.md` (309 lines · `.md` N/A)
 
-- [ ] **Step 1:** `grep -n "ticket.sh\|psql\|kubectl exec" .claude/skills/ticket-ops/SKILL.md`. DB **reads** → `mcp__mcp-postgres__query`; lifecycle → ticket-mcp tools (`transition_status`, `add_comment`, `triage_ticket`, `set_plan_meta`, `add_pr_link`, etc.).
-- [ ] **Step 2:** Rewrite reads + lifecycle to MCP-first + fallback. Do NOT pre-reference the unregistered `factory-mcp` server here — its wiring lands in Slice 3, Task 3.1; keep this task scoped to `mcp-postgres` reads + `ticket-mcp` lifecycle only.
-- [ ] **Step 3: Commit.** `git add .claude/skills/ticket-ops/SKILL.md && git commit -m "feat(skills): ticket-ops MCP-first (mcp-postgres reads + ticket-mcp lifecycle)"`
+- [x] **Step 1:** `grep -n "ticket.sh\|psql\|kubectl exec" .claude/skills/ticket-ops/SKILL.md`. DB **reads** → `mcp__mcp-postgres__query`; lifecycle → ticket-mcp tools (`transition_status`, `add_comment`, `triage_ticket`, `set_plan_meta`, `add_pr_link`, etc.).
+- [x] **Step 2:** Rewrite reads + lifecycle to MCP-first + fallback. Do NOT pre-reference the unregistered `factory-mcp` server here — its wiring lands in Slice 3, Task 3.1; keep this task scoped to `mcp-postgres` reads + `ticket-mcp` lifecycle only.
+- [x] **Step 3: Commit.** `git add .claude/skills/ticket-ops/SKILL.md && git commit -m "feat(skills): ticket-ops MCP-first (mcp-postgres reads + ticket-mcp lifecycle)"`
 
 **Acceptance:** ticket-pool/staged-plan reads use mcp-postgres; lifecycle uses ticket-mcp; writes stay kubectl.
 
@@ -729,19 +729,19 @@ Apply the same shape to `stage_plan`, `get_attachments`, `archive_plan`, `add_co
 
 **Files:** Modify `.claude/skills/incident-response/SKILL.md` (93 lines · `.md` N/A), `.claude/skills/infra-ops/SKILL.md` (586 lines · `.md` N/A)
 
-- [ ] **Step 1:** In both, map cluster **status reads** (`kubectl get pods/logs/describe`) → `mcp__mcp-kubernetes__pods_list / pods_log / pods_get / resources_get` (first), kubectl as fallback. DB **reads** → `mcp__mcp-postgres__query`.
-- [ ] **Step 2:** Keep ALL mutations on kubectl: `kubectl apply`, `rollout restart`, scale, delete, SealedSecrets, DDL, writes — these must stay (per guide). Only reads flip.
-- [ ] **Step 3:** Rewrite the read steps to MCP-first + fallback; link the guard to `mcp-tool-guide.md`.
-- [ ] **Step 4: Commit.** `git add .claude/skills/incident-response/SKILL.md .claude/skills/infra-ops/SKILL.md && git commit -m "feat(skills): incident-response + infra-ops read-paths MCP-first (mcp-kubernetes/mcp-postgres), mutations stay kubectl"`
+- [x] **Step 1:** In both, map cluster **status reads** (`kubectl get pods/logs/describe`) → `mcp__mcp-kubernetes__pods_list / pods_log / pods_get / resources_get` (first), kubectl as fallback. DB **reads** → `mcp__mcp-postgres__query`.
+- [x] **Step 2:** Keep ALL mutations on kubectl: `kubectl apply`, `rollout restart`, scale, delete, SealedSecrets, DDL, writes — these must stay (per guide). Only reads flip.
+- [x] **Step 3:** Rewrite the read steps to MCP-first + fallback; link the guard to `mcp-tool-guide.md`.
+- [x] **Step 4: Commit.** `git add .claude/skills/incident-response/SKILL.md .claude/skills/infra-ops/SKILL.md && git commit -m "feat(skills): incident-response + infra-ops read-paths MCP-first (mcp-kubernetes/mcp-postgres), mutations stay kubectl"`
 
 **Acceptance:** status/read steps are MCP-first; every mutation remains kubectl.
 
 ### Task 2.5 (Slice 2 verification gate)
 
-- [ ] **Step 1: No accidental write-over-MCP.** Run: `grep -rn "mcp__mcp-postgres__query" .claude/skills/{dev-flow-execute,ticket-ops,incident-response,infra-ops}/SKILL.md` and confirm each adjacent SQL is a SELECT.
-- [ ] **Step 2: Fallbacks intact.** Run: `grep -rn "ticket.sh\|kubectl exec" .claude/skills/{dev-flow-execute,dev-flow-plan,ticket-ops,incident-response,infra-ops}/SKILL.md` — every former call still exists as a labelled fallback (nothing deleted outright).
-- [ ] **Step 3: S4 — scripts still referenced.** The skills still name `scripts/ticket.sh` etc. (fallbacks), so no script becomes an orphan. Run: `task test:code-quality` → S4 clean.
-- [ ] **Step 4: CI-equivalent.** Run: `task test:changed && task freshness:check`. Expected: green.
+- [x] **Step 1: No accidental write-over-MCP.** Run: `grep -rn "mcp__mcp-postgres__query" .claude/skills/{dev-flow-execute,ticket-ops,incident-response,infra-ops}/SKILL.md` and confirm each adjacent SQL is a SELECT.
+- [x] **Step 2: Fallbacks intact.** Run: `grep -rn "ticket.sh\|kubectl exec" .claude/skills/{dev-flow-execute,dev-flow-plan,ticket-ops,incident-response,infra-ops}/SKILL.md` — every former call still exists as a labelled fallback (nothing deleted outright).
+- [x] **Step 3: S4 — scripts still referenced.** The skills still name `scripts/ticket.sh` etc. (fallbacks), so no script becomes an orphan. Run: `task test:code-quality` → S4 clean.
+- [x] **Step 4: CI-equivalent.** Run: `task test:changed && task freshness:check`. Expected: green.
 - [ ] **Step 5: Open PR #2.** Title: `feat(skills): MCP-first routing for the 5 high-frequency skills [T001211]`. Merge before Slice 3.
 
 ---


### PR DESCRIPTION
## Slice 2/3 — Skills MCP-first (script fallback retained) (T001211)

Flips the five high-frequency skills to present the MCP tools as the **primary** path, with the existing `ticket.sh` / `kubectl exec psql` block kept as a clearly labelled fallback. Pattern exemplar: `mishap-tracker` (MCP call first, fallback in a labelled step).

### Changes
- **`dev-flow-execute`** — lifecycle calls (`phase`/`stage`/`get-attachments`/`archive-plan`/`add-comment`/`add-pr-link`/`update-status`) → `mcp__ticket-mcp__*`; the `plan_staged` read → `mcp__mcp-postgres__query` (SELECT). 15 MCP-first tool calls.
- **`dev-flow-plan`** — `create` → `create_ticket`, `stage-plan` → `stage_plan`, plus `get` → `get_ticket`. The returned `external_id|uuid` text is documented so the `cut -d'|' -f1` parse still holds.
- **`ticket-ops`** — ticket-pool/DoR reads → `mcp__mcp-postgres__query`; lifecycle (close-out status + comment, readiness/meta) → `ticket-mcp` tools. `factory-mcp` intentionally **not** referenced here (its wiring lands in Slice 3).
- **`incident-response` + `infra-ops`** — cluster status reads (`pods`/`logs`) → `mcp__mcp-kubernetes__pods_list_in_namespace`/`pods_log`/`pods_get`; DB reads → `mcp-postgres`.

### Invariants held
- **Writes/DDL/superuser SQL stay on `kubectl exec … psql`** — `mcp-postgres` is used only for SELECTs; ticket lifecycle writes go through `ticket-mcp` wrappers (which shell out to `ticket.sh`, the sanctioned write path), never through the read-only `mcp-postgres`.
- Every former `ticket.sh`/`kubectl` call is **retained as a labelled fallback** — nothing deleted outright (S4: scripts still referenced, no orphans).

### Verification
- `task test:changed` runs the MCP guardrail (`every skill-critical verb has a ticket-mcp wrapper`) + quality gate — green.
- `task freshness:check` green; no generated-artifact drift from the `.md` edits.

Requires Slice 1 (merged: #2144). Slice 3 (factory-mcp registration + tool-guide SSOT + guide-completeness guard) follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EXaHdV2ELfigenj6vVBqtV