### PR TITLE
feat(mcp): factory-mcp registration, tool-guide SSOT, re-drift guardrail [T001211]

### DIFF
--- a/.claude/skills/operations-management/SKILL.md
+++ b/.claude/skills/operations-management/SKILL.md
@@ -33,6 +33,16 @@ Is a core service DOWN or DEGRADED right now?
 
 ---
 
+## Software-Factory operations (MCP-first)
+
+Für Factory-Queue-Status und manuelles Anstoßen die `factory-mcp`-Tools bevorzugen (HTTP-Daemon auf `127.0.0.1:13003`). **Verfügbarkeits-Guard zuerst:** `curl -sf --max-time 2 http://127.0.0.1:13003/health`.
+
+> `mcp__factory-mcp__factory_status()` · `mcp__factory-mcp__factory_queue()` · `mcp__factory-mcp__factory_trigger()` · `mcp__factory-mcp__factory_enqueue({ ticket_id })` · `mcp__factory-mcp__factory_recent({ limit })`
+
+Fallback (Daemon nicht erreichbar): Status/Queue über `mcp__mcp-postgres__query`/`psql`, Tick über `bash scripts/factory/wakeup.sh`. Details in [`ticket-ops`](file:///home/patrick/Bachelorprojekt/.claude/skills/ticket-ops/SKILL.md) und im [`MCP-Tool-Guide`](file:///home/patrick/Bachelorprojekt/.claude/skills/references/mcp-tool-guide.md).
+
+---
+
 ## Mishap Tracking
 
 Both sub-skills carry the mishap tracking preamble. After completing either, invoke `mishap-tracker` if any mishaps were accumulated.

--- a/.claude/skills/references/mcp-tool-guide.md
+++ b/.claude/skills/references/mcp-tool-guide.md
@@ -1,56 +1,118 @@
 # MCP-Tool-Guide
 
 SSOT für die MCP-native Tool-Nutzung in Skills und Subagents. Skills verlinken hierher statt die
-Tabelle zu duplizieren. Die MCP-Server sind via MCP-Client direkt erreichbar (registriert in
-`.mcp.json`).
+Tabellen zu duplizieren. Pro Server: **Tools · Wann bevorzugen · Fallback**. Die mechanische
+CI-Guard `tests/spec/mcp-tooling.bats` prüft, dass (1) jeder skill-kritische `ticket.sh`-Verb einen
+`ticket-mcp`-Wrapper hat und (2) **jedes** im Go-Quellcode exponierte `ticket-mcp`-Tool hier gelistet
+ist. Wer ein Tool ergänzt/entfernt, pflegt diese Datei mit — sonst wird CI rot.
 
-### Server → Port → Tool → Anwendungsfall
+Registriert in `.mcp.json` (Claude Code) und `.opencode/opencode.jsonc` (opencode).
 
-| MCP-Server | Endpoint | Tool / Prefix | Anwendungsfall |
-|---|---|---|---|
-| `mcp-postgres` | `http://localhost:13001/mcp` | `mcp__mcp-postgres__query` (Param: `sql`) | **Read-only** SQL (SELECT) als `website`-User — Ticket-Pool, staged-plans, planning-Count, Timeline-Reads |
-| `mcp-kubernetes` | `http://localhost:18080/sse` | `mcp__mcp-kubernetes__*` | Strukturierte k8s-Status-/Read-Operationen (Pods, Logs, Describe) |
-| `mcp-task-runner` | stdio (local binary) | `plan_tasks`, `run_task`, `execute_plan` | go-task parallel ausführen + OTel-Logging; OTel via `localhost:4317` (portforward) |
+---
+
+## Globale Invarianten (gelten für ALLE Server)
 
 > **`mcp__mcp-postgres__query` ist READ-ONLY und nimmt NUR `sql`.** Kein `connectionString`-Argument
-> — die Verbindung ist serverseitig fest (`localhost:13001`, siehe `.mcp.json`). INSERT/UPDATE/DELETE
+> — die Verbindung ist serverseitig fest (`localhost:13001`, als `website`-User). INSERT/UPDATE/DELETE
 > gehen NICHT über dieses Tool.
 
-### Verfügbarkeits-Check (vor MCP-Nutzung prüfen)
+> **Writes/DDL/Superuser bleiben kubectl.** Schreibende SQL (INSERT/UPDATE/DELETE/UPSERT), DDL als
+> `postgres`-Superuser und sämtliche Cluster-Mutationen (`kubectl apply`, `rollout restart`, scale,
+> delete, Sealed Secrets, RBAC) laufen über `kubectl exec … psql` bzw. `kubectl`, **nie** über ein
+> MCP-Read-Tool. Ticket-Lifecycle-Writes gehen über die `ticket-mcp`-Wrapper (die shellen zu
+> `ticket.sh`, dem sanktionierten Write-Pfad) — nicht über `mcp-postgres`.
 
-Das MCP-Tool ist direkt verfügbar, wenn der MCP-Server läuft. Prüfe mit einem einfachen Query:
+### Verfügbarkeits-Check (Portforward-Guard — vor MCP-Nutzung prüfen)
 
-```sql
--- via MCP-Client: SELECT 1 AS ok
-```
+Das MCP-Tool ist direkt verfügbar, wenn der Server läuft. Schneller Health-Check (Beispiel
+`mcp-postgres` auf `:13001`, `factory-mcp` auf `:13003` mit `/health`):
 
-Alternativ per curl auf den SSE-Endpoint (z.B. `mcp-postgres` auf Port 13001):
 ```bash
+# Generischer JSON-RPC-Probe (mcp-postgres/-kubernetes/-browser/-github):
 curl -s --max-time 2 -o /dev/null -w '%{http_code}' \
   -X POST -H "Content-Type: application/json" -H "Accept: application/json, text/event-stream" \
   -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"hc","version":"1"}}}' \
   http://localhost:13001/mcp
-# 200 → MCP erreichbar; alles andere → kubectl-Fallback nutzen
+# 200 → MCP erreichbar; alles andere → Skript-/kubectl-Fallback nutzen.
+
+# factory-mcp hat einen dedizierten Health-Endpoint:
+curl -sf --max-time 2 http://127.0.0.1:13003/health && echo " → factory-mcp up"
 ```
 
-Schlägt der MCP-Zugriff fehl oder ist der Cluster-Kontext nicht gesetzt → **kubectl-Fallback**
-(der jeweilige `psql`-/`kubectl`-Block im Skill).
+Schlägt der MCP-Zugriff fehl oder ist der Cluster-Kontext nicht gesetzt → **Fallback** (der jeweilige
+`psql`-/`kubectl`-/Skript-Block im Skill).
 
-### Wann MCP, wann kubectl
+---
 
-**MCP bevorzugen** (wenn Guard = erreichbar):
-- Read-only SELECTs gegen `tickets.*`, `knowledge.*`, `v_timeline` → `mcp__mcp-postgres__query`
-- k8s-Status/Read (Pod-Liste, Logs, Describe) → `mcp__mcp-kubernetes__*`
+## `mcp-postgres` — Read-only SQL
 
+- **Endpoint:** `http://localhost:13001/mcp`
+- **Tool:** `mcp__mcp-postgres__query` (Param: **nur** `sql`)
+- **Wann bevorzugen:** Read-only SELECTs gegen `tickets.*`, `knowledge.*`, `v_timeline` — Ticket-Pool,
+  staged-plans, planning-Count, Timeline-/DoR-Reads.
+- **Fallback:** `psql -c "<SELECT>"` via `kubectl exec … -c postgres -- psql -U website -d website`.
+- ⚠️ `tickets.ticket_plans`: nie `SELECT *` oder die `content`-Spalte über die ganze Tabelle (MB-Transfer
+  über `kubectl exec` → Timeout). Immer Metadaten (`id`, `ticket_id`, `slug`, `branch`, `pr_number`,
+  `archived_at`) oder gezielt nach `ticket_id`/`slug` filtern.
 
-**Bleibt kubectl (Pflicht, kein MCP-Äquivalent / fehlende Rechte):**
-- **DDL als `postgres`-Superuser** auf den Schemas `bachelorprojekt`, `coaching`, `knowledge`
-  (Tabellen-Owner = `postgres`). MCP-Postgres verbindet als `website` ohne Superuser-Rechte → DDL
-  schlägt mit „must be owner" fehl. Pflicht:
-  ```bash
-  PGPOD=$(kubectl get pod -n workspace --context <env> -l app=shared-db -o name | head -1)
-  kubectl exec -i "$PGPOD" -n workspace --context <env> -- psql -U postgres -d website < migration.sql
-  ```
-- **Schreibende SQL** (INSERT/UPDATE/DELETE/UPSERT) — `mcp__mcp-postgres__query` ist read-only → kubectl.
-- **`kubectl apply` / `kubectl rollout restart`** und sonstige Manifest-Mutationen.
-- **Sealed Secrets / RBAC / Cluster-Level-Operationen.**
+## `mcp-kubernetes` — k8s-Status/Read
+
+- **Endpoint:** `http://localhost:18080/mcp`
+- **Tools (Auswahl):** `mcp__mcp-kubernetes__pods_list_in_namespace`, `pods_list`, `pods_log`,
+  `pods_get`, `resources_get`, `resources_list`, `events_list`, `namespaces_list`.
+- **Wann bevorzugen:** strukturierte Status-/Read-Operationen (Pod-Liste, Logs, Describe, Events).
+- **Fallback:** `task workspace:status` / `task workspace:logs` bzw. `kubectl get/logs/describe`.
+- **Mutations bleiben kubectl:** `pods_delete`, `resources_create_or_update`, `resources_scale`,
+  `resources_delete` existieren, aber Manifest-Mutationen laufen bewusst über `kubectl apply` /
+  Taskfile-Deploys (siehe globale Invariante).
+
+## `ticket-mcp` — Ticket-Lifecycle (Go-Adapter über `ticket.sh`)
+
+- **Transport:** lokales Go-Binary `scripts/ticket-mcp/ticket-mcp-go` (stdio; optional HTTP via
+  `TICKET_MCP_HTTP=1` auf `:13004`). Dünne Adapter — `ticket.sh` ist die Business-Logik-SSOT.
+- **Wann bevorzugen:** alle Ticket-Reads + Lifecycle-Writes (die Wrapper shellen zu `ticket.sh`).
+- **Fallback:** der jeweilige `./scripts/ticket.sh <verb>` / `./scripts/vda.sh ticket <verb>`-Aufruf.
+
+**Alle Tools (Go-SSOT — diese Liste deckt den Guardrail ab):**
+
+| Gruppe | Tools |
+|---|---|
+| List/Get | `list_tickets`, `get_ticket`, `export_tickets`, `backfill_ticket_id` |
+| Triage/Planning | `triage_ticket`, `set_plan_meta`, `set_readiness_flag`, `prepare_feature` |
+| Lifecycle | `transition_status`, `add_comment`, `update_fields` |
+| Workflow | `record_phase_event`, `record_grill_answers`, `stage_plan`, `create_ticket`, `enqueue_ticket`, `set_touched_files`, `get_attachments`, `archive_plan`, `add_pr_link` |
+| Mishap | `report_mishap`, `get_mishap_buffer`, `flush_mishap_buffer` |
+
+> `create_ticket` gibt `external_id|uuid` zurück (Skills parsen `cut -d'|' -f1`). `record_phase_event`
+> ist positional (`phase <id> <phase> <state>`); `get_attachments` braucht `out_dir`; `archive_plan`
+> braucht `slug`+`branch`+`plan_file`. `report_mishap` akzeptiert `type ∈ {broken, degraded,
+> suspicious, security, drift, process}`.
+
+## `factory-mcp` — Software-Factory (HTTP, Daemon erforderlich)
+
+- **Endpoint:** `http://localhost:13003/mcp` (StreamableHTTP), Health: `GET http://127.0.0.1:13003/health`.
+- **Tools:** `factory_status`, `factory_queue`, `factory_enqueue`, `factory_trigger`, `factory_recent`,
+  `openspec_find_similar`.
+- **Wann bevorzugen:** Factory-Queue-Status, Backlog-Übersicht, manuelles Anstoßen eines Ticks,
+  OpenSpec-Ähnlichkeitssuche. **Voraussetzung:** der Daemon `:13003` läuft (Health-Guard zuerst).
+- **Fallback (Daemon down):** Status/Queue → `mcp__mcp-postgres__query`/`psql` auf
+  `tickets.tickets WHERE status IN ('backlog','plan_staged')`; Tick → `bash scripts/factory/wakeup.sh`.
+
+## `mcp-task-runner` — go-task-Ausführung + OTel
+
+- **Transport:** lokales Binary (`mcp-task-runner`), OTel-Endpoint `localhost:4317`.
+- **Tools:** `plan_tasks`, `run_task`, `execute_plan`.
+- **Wann bevorzugen:** go-task-Targets parallel ausführen mit strukturiertem OTel-Logging.
+- **Fallback:** `task <target>` direkt in der Shell.
+
+## `task-master-ai` — optional/verfügbar (kein Skill-Logik-Pfad)
+
+- **Transport:** `npx -y task-master-ai` (lokal).
+- **Wann:** **optional** für PRD-Parsing/Komplexitätsanalyse. **Keine** Skill-Logik hängt daran —
+  nur als verfügbares Werkzeug gelistet. OpenSpec ist der SSOT-Plan-Workflow, nicht task-master-ai.
+
+## `mcp-browser` — Playwright (unverändert)
+
+- **Endpoint:** `http://localhost:13000/mcp`.
+- **Tools:** `mcp__mcp-browser__browser_*` (navigate, click, snapshot, evaluate, …).
+- **Wann:** Browser-Automation/E2E-Inspektion. Unangetastet von der MCP↔Skill-Integration.

--- a/.claude/skills/ticket-ops/SKILL.md
+++ b/.claude/skills/ticket-ops/SKILL.md
@@ -306,6 +306,23 @@ This repo tracks issues in Postgres, not GitHub. If `gh issue list --state open`
 
 ---
 
+## Software-Factory-Queue (MCP-first)
+
+Für Factory-Queue-Status und manuelles Anstoßen die `factory-mcp`-Tools bevorzugen (HTTP-Daemon auf `127.0.0.1:13003`). **Verfügbarkeits-Guard zuerst:** `curl -sf --max-time 2 http://127.0.0.1:13003/health` — bei Erfolg MCP, sonst Skript-Fallback.
+
+**MCP-first** (`factory-mcp`):
+
+> `mcp__factory-mcp__factory_status()` — Queue-Tiefe + ob gerade ein Tick läuft
+> `mcp__factory-mcp__factory_queue()` — wartende Tickets (backlog + plan_staged)
+> `mcp__factory-mcp__factory_trigger()` — sofortigen Factory-Tick auslösen
+> `mcp__factory-mcp__factory_enqueue({ ticket_id: "T000XXX" })` · `mcp__factory-mcp__factory_recent({ limit: 10 })`
+
+Fallback (Daemon `:13003` nicht erreichbar):
+- Status/Queue → `mcp__mcp-postgres__query` bzw. `psql` SELECT auf `tickets.tickets WHERE status IN ('backlog','plan_staged')`.
+- Tick auslösen → `bash scripts/factory/wakeup.sh`.
+
+---
+
 ## Post-Execution: Mishap Report
 
 After completing all steps in this skill, invoke `mishap-tracker` with your accumulated `MISHAP_LOG`. If no mishaps were found, `mishap-tracker` exits cleanly.

--- a/.mcp.json
+++ b/.mcp.json
@@ -34,6 +34,10 @@
       "type": "http",
       "url": "http://localhost:13002/mcp"
     },
+    "factory-mcp": {
+      "type": "http",
+      "url": "http://localhost:13003/mcp"
+    },
     "mcp-task-runner": {
       "command": "mcp-task-runner",
       "args": [

--- a/.opencode/opencode.jsonc
+++ b/.opencode/opencode.jsonc
@@ -24,6 +24,11 @@
       "url": "http://localhost:13002/mcp",
       "enabled": true
     },
+    "factory-mcp": {
+      "type": "remote",
+      "url": "http://localhost:13003/mcp",
+      "enabled": true
+    },
     // ── Stdio-Server (lokale Prozesse) ────────────────────────────────────
     "task-master-ai": {
       "type": "local",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ Before responding to any request, check these signals and delegate to the named 
 | database, PostgreSQL, psql, schema, query, backup, restore, tracking, timeline, `bachelorprojekt.features`, `v_timeline` | `bachelorprojekt-db` | `mcp-postgres` (localhost:13001) |
 | SealedSecret, Keycloak realm, OIDC, DSGVO, credentials, rotate, certificate, secret | `bachelorprojekt-security` | — |
 
-> **MCP-Server names in this table refer to Claude-Code-only SSE servers** configured in `.claude/settings.json` / `.claude/skills/references/mcp-tool-guide.md`. The opencode runtime uses different MCP server names from `.opencode/opencode.jsonc` (`mcp-k8s`, `mcp-postgres`, `mcp-browser`, `mcp-github`, `mcp-factory` — no `mcp-kubernetes`). If you are running in opencode, see the `MCP-Schnellweg` block below and the opencode config, not the table above.
+> **MCP-Server names in this table refer to Claude-Code-only SSE servers** configured in `.claude/settings.json` / `.claude/skills/references/mcp-tool-guide.md`. The opencode runtime registers its MCP servers in `.opencode/opencode.jsonc`: `mcp-kubernetes`, `mcp-browser`, `mcp-postgres`, `mcp-github`, `factory-mcp`, `mcp-task-runner`, `ticket-mcp`, `task-master-ai`, `openspec` (same `mcp-kubernetes` name as the table; `factory-mcp` is the HTTP factory server on `:13003`). If you are running in opencode, see the `MCP-Schnellweg` block below and the opencode config, not the table above.
 
 > **Agent-Routing-Karten:** Generierte, grepbare Karten unter `docs/agent-guide/maps/` — `goals-map.md` (Intention → Weg → Tier → Guardrails), `tools-map.md`, `danger-map.md`. Quelle: `docs/agent-guide/registry/` (nicht von Hand editieren; via `task agent-guide:maps` regenerieren).
 

--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -541,7 +541,7 @@
       "id": "website",
       "name": "Astro + Svelte website",
       "owner_agent": "bachelorprojekt-website",
-      "file_count": 1612,
+      "file_count": 1613,
       "files": [
         "website/.build-trigger",
         "website/.design-sync/NOTES.md",
@@ -592,6 +592,7 @@
         "website/docs/superpowers/specs/2026-04-10-document-signing-design.md",
         "website/docs/superpowers/specs/2026-04-10-meeting-history-design.md",
         "website/docs/superpowers/specs/2026-04-10-slot-widget-design.md",
+        "website/eslint.config.js",
         "website/package-lock.json",
         "website/package.json",
         "website/pnpm-lock.yaml",

--- a/openspec/changes/mcp-skill-integration/tasks.md
+++ b/openspec/changes/mcp-skill-integration/tasks.md
@@ -742,7 +742,7 @@ Apply the same shape to `stage_plan`, `get_attachments`, `archive_plan`, `add_co
 - [x] **Step 2: Fallbacks intact.** Run: `grep -rn "ticket.sh\|kubectl exec" .claude/skills/{dev-flow-execute,dev-flow-plan,ticket-ops,incident-response,infra-ops}/SKILL.md` — every former call still exists as a labelled fallback (nothing deleted outright).
 - [x] **Step 3: S4 — scripts still referenced.** The skills still name `scripts/ticket.sh` etc. (fallbacks), so no script becomes an orphan. Run: `task test:code-quality` → S4 clean.
 - [x] **Step 4: CI-equivalent.** Run: `task test:changed && task freshness:check`. Expected: green.
-- [ ] **Step 5: Open PR #2.** Title: `feat(skills): MCP-first routing for the 5 high-frequency skills [T001211]`. Merge before Slice 3.
+- [x] **Step 5: Open PR #2.** Title: `feat(skills): MCP-first routing for the 5 high-frequency skills [T001211]`. Merge before Slice 3.
 
 ---
 
@@ -756,7 +756,7 @@ Apply the same shape to `stage_plan`, `get_attachments`, `archive_plan`, `add_co
 
 factory-mcp (`scripts/factory/mcp-server.mjs`) serves StreamableHTTP at `127.0.0.1:13003/mcp` (health: `GET /health`), tools: `factory_status`, `factory_queue`, `factory_enqueue`, `factory_trigger`, `factory_recent`, `openspec_find_similar`.
 
-- [ ] **Step 1: Add to `.mcp.json`** (alongside the other HTTP servers):
+- [x] **Step 1: Add to `.mcp.json`** (alongside the other HTTP servers):
 
 ```json
     "factory-mcp": {
@@ -765,7 +765,7 @@ factory-mcp (`scripts/factory/mcp-server.mjs`) serves StreamableHTTP at `127.0.0
     }
 ```
 
-- [ ] **Step 2: Add to `.opencode/opencode.jsonc`** (alongside the other `"type": "remote"` HTTP servers):
+- [x] **Step 2: Add to `.opencode/opencode.jsonc`** (alongside the other `"type": "remote"` HTTP servers):
 
 ```jsonc
     "factory-mcp": {
@@ -775,9 +775,9 @@ factory-mcp (`scripts/factory/mcp-server.mjs`) serves StreamableHTTP at `127.0.0
     }
 ```
 
-- [ ] **Step 3: Wire `ticket-ops` + `operations-management`** to prefer `mcp__factory-mcp__factory_status` / `factory_queue` / `factory_trigger` over equivalent script calls, with the script path retained as a fallback for when the daemon (`:13003`) is down. Document the health guard: `curl -sf --max-time 2 http://127.0.0.1:13003/health`.
-- [ ] **Step 4: Validate configs.** Run: `jq empty .mcp.json && jq -r '.mcp["factory-mcp"].url' <(sed 's://.*::' .opencode/opencode.jsonc 2>/dev/null) 2>/dev/null || node -e "require('fs').readFileSync('.opencode/opencode.jsonc','utf8')"; echo OK`. Expected: `.mcp.json` valid; jsonc readable.
-- [ ] **Step 5: Commit.** `git add .mcp.json .opencode/opencode.jsonc .claude/skills/ticket-ops/SKILL.md .claude/skills/operations-management/SKILL.md && git commit -m "feat(mcp): register factory-mcp (HTTP :13003) in both runtimes + wire ops skills"`
+- [x] **Step 3: Wire `ticket-ops` + `operations-management`** to prefer `mcp__factory-mcp__factory_status` / `factory_queue` / `factory_trigger` over equivalent script calls, with the script path retained as a fallback for when the daemon (`:13003`) is down. Document the health guard: `curl -sf --max-time 2 http://127.0.0.1:13003/health`.
+- [x] **Step 4: Validate configs.** Run: `jq empty .mcp.json && jq -r '.mcp["factory-mcp"].url' <(sed 's://.*::' .opencode/opencode.jsonc 2>/dev/null) 2>/dev/null || node -e "require('fs').readFileSync('.opencode/opencode.jsonc','utf8')"; echo OK`. Expected: `.mcp.json` valid; jsonc readable.
+- [x] **Step 5: Commit.** `git add .mcp.json .opencode/opencode.jsonc .claude/skills/ticket-ops/SKILL.md .claude/skills/operations-management/SKILL.md && git commit -m "feat(mcp): register factory-mcp (HTTP :13003) in both runtimes + wire ops skills"`
 
 **Acceptance:** both runtime configs contain `factory-mcp` at `:13003/mcp`; ops skills prefer factory tools with script fallback.
 
@@ -785,9 +785,9 @@ factory-mcp (`scripts/factory/mcp-server.mjs`) serves StreamableHTTP at `127.0.0
 
 **Files:** Modify `CLAUDE.md` (277 lines · `.md` N/A), `AGENTS.md` (178 lines · `.md` N/A)
 
-- [ ] **Step 1: Locate drift.** Run: `grep -rn "mcp-k8s\|mcp-factory" CLAUDE.md AGENTS.md`.
-- [ ] **Step 2: Fix.** In the opencode MCP descriptions, replace `mcp-k8s` → `mcp-kubernetes`. Replace `mcp-factory` claims with the now-real `factory-mcp` (registered in Task 3.1). Ensure the opencode server list reads: `mcp-kubernetes`, `mcp-browser`, `mcp-postgres`, `mcp-github`, `mcp-task-runner`, `task-master-ai`, `openspec`, `ticket-mcp`, `factory-mcp`.
-- [ ] **Step 3: Commit.** `git add CLAUDE.md AGENTS.md && git commit -m "docs: fix opencode MCP server-name drift (mcp-kubernetes; factory-mcp now real)"`
+- [x] **Step 1: Locate drift.** Run: `grep -rn "mcp-k8s\|mcp-factory" CLAUDE.md AGENTS.md`.
+- [x] **Step 2: Fix.** In the opencode MCP descriptions, replace `mcp-k8s` → `mcp-kubernetes`. Replace `mcp-factory` claims with the now-real `factory-mcp` (registered in Task 3.1). Ensure the opencode server list reads: `mcp-kubernetes`, `mcp-browser`, `mcp-postgres`, `mcp-github`, `mcp-task-runner`, `task-master-ai`, `openspec`, `ticket-mcp`, `factory-mcp`.
+- [x] **Step 3: Commit.** `git add CLAUDE.md AGENTS.md && git commit -m "docs: fix opencode MCP server-name drift (mcp-kubernetes; factory-mcp now real)"`
 
 **Acceptance:** no `mcp-k8s` remains; `factory-mcp` is described as registered; `grep -rn "mcp-factory\b" CLAUDE.md AGENTS.md` returns nothing (or only as the registered server name).
 
@@ -795,16 +795,16 @@ factory-mcp (`scripts/factory/mcp-server.mjs`) serves StreamableHTTP at `127.0.0
 
 **Files:** Modify `.claude/skills/references/mcp-tool-guide.md` (56 lines · `.md` N/A)
 
-- [ ] **Step 1: Enumerate the live Go tool set** (the guardrail in Task 3.4 checks this exact set is listed). Run:
+- [x] **Step 1: Enumerate the live Go tool set** (the guardrail in Task 3.4 checks this exact set is listed). Run:
 
 ```bash
 grep -rhoE 'mcp\.NewTool\("[a-z_]+"' scripts/ticket-mcp/go/internal/tools/ | sed -E 's/.*"([a-z_]+)"/\1/' | sort -u
 ```
 
 Expected ~23 names (12 pre-existing + `get_mishap_buffer`,`flush_mishap_buffer` + the 9 workflow tools).
-- [ ] **Step 2: Rewrite the guide** with one section per server: `mcp-postgres` (read-only `query`), `mcp-kubernetes` (status/read tools), `ticket-mcp` (**list every tool name from Step 1**, grouped: list/get, triage/planning, lifecycle, workflow, mishap), `factory-mcp` (`factory_status/queue/enqueue/trigger/recent/openspec_find_similar`, requires `:13003` daemon), `mcp-task-runner` (task execution + OTel), `task-master-ai` (**optional/available** — PRD/complexity, no skill logic), `mcp-browser` (untouched, Playwright). For each: Tools · When to prefer · Fallback.
-- [ ] **Step 3: Preserve the invariants** verbatim: the portforward/availability guard (curl health check), the "READ-ONLY, only `sql`" note for mcp-postgres, and the **kubectl-for-writes/DDL/superuser** rule.
-- [ ] **Step 4: Self-check guide completeness now** (pre-empt the guardrail). Run:
+- [x] **Step 2: Rewrite the guide** with one section per server: `mcp-postgres` (read-only `query`), `mcp-kubernetes` (status/read tools), `ticket-mcp` (**list every tool name from Step 1**, grouped: list/get, triage/planning, lifecycle, workflow, mishap), `factory-mcp` (`factory_status/queue/enqueue/trigger/recent/openspec_find_similar`, requires `:13003` daemon), `mcp-task-runner` (task execution + OTel), `task-master-ai` (**optional/available** — PRD/complexity, no skill logic), `mcp-browser` (untouched, Playwright). For each: Tools · When to prefer · Fallback.
+- [x] **Step 3: Preserve the invariants** verbatim: the portforward/availability guard (curl health check), the "READ-ONLY, only `sql`" note for mcp-postgres, and the **kubectl-for-writes/DDL/superuser** rule.
+- [x] **Step 4: Self-check guide completeness now** (pre-empt the guardrail). Run:
 
 ```bash
 for t in $(grep -rhoE 'mcp\.NewTool\("[a-z_]+"' scripts/ticket-mcp/go/internal/tools/ | sed -E 's/.*"([a-z_]+)"/\1/' | sort -u); do
@@ -813,7 +813,7 @@ done
 ```
 
 Expected: no `MISSING:` lines.
-- [ ] **Step 5: Commit.** `git add .claude/skills/references/mcp-tool-guide.md && git commit -m "docs(mcp-tool-guide): rewrite as server→tool→when→fallback SSOT (lists all ticket-mcp + factory-mcp tools)"`
+- [x] **Step 5: Commit.** `git add .claude/skills/references/mcp-tool-guide.md && git commit -m "docs(mcp-tool-guide): rewrite as server→tool→when→fallback SSOT (lists all ticket-mcp + factory-mcp tools)"`
 
 **Acceptance:** guide lists every Go tool name + factory-mcp tools; invariants retained; Step-4 check clean.
 
@@ -828,13 +828,13 @@ fail against an un-updated guide, and Task 3.3's rewrite is what makes it pass.
 **Files:**
 - Modify: `tests/spec/mcp-tooling.bats` (`.bats` not gated → S1 N/A) — append the guide-completeness `@test` and add `GUIDE` to `setup()`.
 
-- [ ] **Step 1: Add `GUIDE` to `setup()`.** In `tests/spec/mcp-tooling.bats`, add to the existing `setup()`:
+- [x] **Step 1: Add `GUIDE` to `setup()`.** In `tests/spec/mcp-tooling.bats`, add to the existing `setup()`:
 
 ```bash
   GUIDE="$REPO_ROOT/.claude/skills/references/mcp-tool-guide.md"
 ```
 
-- [ ] **Step 2: Append the guide-completeness `@test`** to `tests/spec/mcp-tooling.bats`:
+- [x] **Step 2: Append the guide-completeness `@test`** to `tests/spec/mcp-tooling.bats`:
 
 ```bash
 @test "every ticket-mcp Go tool is listed in mcp-tool-guide.md" {
@@ -852,22 +852,22 @@ fail against an un-updated guide, and Task 3.3's rewrite is what makes it pass.
 }
 ```
 
-- [ ] **Step 3: Run the full guard — expected: pass** (Task 3.3 rewrote the guide to list every tool; Slice 1 wrapped every verb). Run: `task test:mcp-tooling`. Expected: `2 tests, 0 failures`.
-- [ ] **Step 4: Sanity — prove the new `@test` fails on drift** (temporary). Delete one tool line from `mcp-tool-guide.md`, run `task test:mcp-tooling` → expect 1 failure naming the missing tool; then `git checkout .claude/skills/references/mcp-tool-guide.md` to restore.
-- [ ] **Step 5: Verify wiring is intact.** Run: `grep -n "test:mcp-tooling" Taskfile.yml` → still appears in the task def, the `test:unit` list, and `test:changed` (all added in Slice 1; this task changes none of them).
-- [ ] **Step 6: Regenerate test inventory (likely no-op).** Run: `task test:inventory`. NOTE: `scripts/build-test-inventory.sh` scans only `tests/local`, `tests/prod`, `tests/e2e/specs` — NOT `tests/spec/` — so `website/src/data/test-inventory.json` is expected to be **unchanged**. If `git status` shows it changed, commit it.
-- [ ] **Step 7: Commit.** `git add tests/spec/mcp-tooling.bats && git add -A website/src/data/test-inventory.json 2>/dev/null; git commit -m "test(mcp): extend guardrail with guide-completeness @test"`
+- [x] **Step 3: Run the full guard — expected: pass** (Task 3.3 rewrote the guide to list every tool; Slice 1 wrapped every verb). Run: `task test:mcp-tooling`. Expected: `2 tests, 0 failures`.
+- [x] **Step 4: Sanity — prove the new `@test` fails on drift** (temporary). Delete one tool line from `mcp-tool-guide.md`, run `task test:mcp-tooling` → expect 1 failure naming the missing tool; then `git checkout .claude/skills/references/mcp-tool-guide.md` to restore.
+- [x] **Step 5: Verify wiring is intact.** Run: `grep -n "test:mcp-tooling" Taskfile.yml` → still appears in the task def, the `test:unit` list, and `test:changed` (all added in Slice 1; this task changes none of them).
+- [x] **Step 6: Regenerate test inventory (likely no-op).** Run: `task test:inventory`. NOTE: `scripts/build-test-inventory.sh` scans only `tests/local`, `tests/prod`, `tests/e2e/specs` — NOT `tests/spec/` — so `website/src/data/test-inventory.json` is expected to be **unchanged**. If `git status` shows it changed, commit it.
+- [x] **Step 7: Commit.** `git add tests/spec/mcp-tooling.bats && git add -A website/src/data/test-inventory.json 2>/dev/null; git commit -m "test(mcp): extend guardrail with guide-completeness @test"`
 
 **Acceptance:** `task test:mcp-tooling` runs both `@test`s and passes; the guide-completeness `@test` fails on injected guide drift; Taskfile wiring from Slice 1 unchanged.
 
 ### Task 3.5 (Slice 3 verification gate = FINAL CI-equivalent gate)
 
-- [ ] **Step 1: OpenSpec validation (must be green before commit/push).** Run: `task test:openspec` (≡ `bash scripts/openspec.sh validate`). Expected: `openspec validate: OK` (the change delta has `## ADDED Requirements`, `### Requirement:` H3 entries, no H2 `## Requirement:`).
-- [ ] **Step 2: Guardrail green.** Run: `task test:mcp-tooling`. Expected: `2 tests, 0 failures`.
-- [ ] **Step 3: Targeted tests for changed domains.** Run: `task test:changed`. Expected: green (this Slice's changes under `.claude/skills/`, `.mcp.json`, `.opencode/`, `tests/spec/` trigger the new `RUN_MCP` branch → the guardrail runs).
-- [ ] **Step 4: Regenerate generated artifacts.** Run: `task freshness:regenerate`. Then re-run `task test:inventory` (no diff expected, per Task 3.4 Step 8). Commit any regen output (resolve generated-artifact conflicts with `git checkout --ours` per CLAUDE.md if a freshness regen collides on rebase).
-- [ ] **Step 5: Freshness + quality ratchet (CI equivalent).** Run: `task freshness:check`. Expected: green — S1 (no gated file touched), S2 (no new cycle), S3 (no host literals), S4 (no orphan; guard is wired, scripts still referenced by fallbacks), and **baseline key-count unchanged**.
-- [ ] **Step 6: Go suite still green** (in case of rebase). Run: `cd scripts/ticket-mcp/go && go vet ./... && go test ./... && make build`.
+- [x] **Step 1: OpenSpec validation (must be green before commit/push).** Run: `task test:openspec` (≡ `bash scripts/openspec.sh validate`). Expected: `openspec validate: OK` (the change delta has `## ADDED Requirements`, `### Requirement:` H3 entries, no H2 `## Requirement:`).
+- [x] **Step 2: Guardrail green.** Run: `task test:mcp-tooling`. Expected: `2 tests, 0 failures`.
+- [x] **Step 3: Targeted tests for changed domains.** Run: `task test:changed`. Expected: green (this Slice's changes under `.claude/skills/`, `.mcp.json`, `.opencode/`, `tests/spec/` trigger the new `RUN_MCP` branch → the guardrail runs).
+- [x] **Step 4: Regenerate generated artifacts.** Run: `task freshness:regenerate`. Then re-run `task test:inventory` (no diff expected, per Task 3.4 Step 8). Commit any regen output (resolve generated-artifact conflicts with `git checkout --ours` per CLAUDE.md if a freshness regen collides on rebase).
+- [x] **Step 5: Freshness + quality ratchet (CI equivalent).** Run: `task freshness:check`. Expected: green — S1 (no gated file touched), S2 (no new cycle), S3 (no host literals), S4 (no orphan; guard is wired, scripts still referenced by fallbacks), and **baseline key-count unchanged**.
+- [x] **Step 6: Go suite still green** (in case of rebase). Run: `cd scripts/ticket-mcp/go && go vet ./... && go test ./... && make build`.
 - [ ] **Step 7: Open PR #3.** Title: `feat(mcp): factory-mcp registration, tool-guide SSOT, re-drift guardrail [T001211]`. Ensure required checks (`Offline Tests`, `Security Scan`, `Brett TypeScript`, `Vitest (website)`, `Conventional Commits`) are green; auto-merge with `--squash`.
 
 ---

--- a/tests/spec/mcp-tooling.bats
+++ b/tests/spec/mcp-tooling.bats
@@ -8,6 +8,7 @@
 setup() {
   REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
   TOOLS_DIR="$REPO_ROOT/scripts/ticket-mcp/go/internal/tools"
+  GUIDE="$REPO_ROOT/.claude/skills/references/mcp-tool-guide.md"
 }
 
 @test "every skill-critical ticket.sh verb has a ticket-mcp wrapper" {
@@ -20,6 +21,20 @@ setup() {
   done
   if [ "${#missing[@]}" -gt 0 ]; then
     echo "# Verbs without a ticket-mcp wrapper: ${missing[*]}" >&2
+  fi
+  [ "${#missing[@]}" -eq 0 ]
+}
+
+@test "every ticket-mcp Go tool is listed in mcp-tool-guide.md" {
+  [ -d "$TOOLS_DIR" ]
+  [ -f "$GUIDE" ]
+  missing=()
+  while IFS= read -r tool; do
+    [ -z "$tool" ] && continue
+    grep -qF "$tool" "$GUIDE" || missing+=("$tool")
+  done < <(grep -rhoE 'mcp\.NewTool\("[a-z_]+"' "$TOOLS_DIR" | sed -E 's/.*"([a-z_]+)"/\1/' | sort -u)
+  if [ "${#missing[@]}" -gt 0 ]; then
+    echo "# Tools missing from mcp-tool-guide.md: ${missing[*]}" >&2
   fi
   [ "${#missing[@]}" -eq 0 ]
 }

--- a/website/src/data/openspec-status.json
+++ b/website/src/data/openspec-status.json
@@ -207,9 +207,21 @@
       "status": "plan_staged"
     }
   ],
+  "T001203": [
+    {
+      "slug": "g-cd02-post-merge-race-guard",
+      "status": "plan_staged"
+    }
+  ],
   "T001204": [
     {
       "slug": "g-cq03-eslint-website",
+      "status": "plan_staged"
+    }
+  ],
+  "T001207": [
+    {
+      "slug": "g-fe02-bundle-budget",
       "status": "plan_staged"
     }
   ],


### PR DESCRIPTION
## Slice 3/3 — Hygiene, SSOT doc, hard guardrail (T001211)

Final slice: registers `factory-mcp`, fixes server-name drift, rewrites the tool-guide as the mapping SSOT, and extends the CI guardrail to enforce guide completeness.

### Changes
- **`factory-mcp` registered** in both runtimes — `.mcp.json` (`type: http`) and `.opencode/opencode.jsonc` (`type: remote`) at `http://localhost:13003/mcp`. Wired into `ticket-ops` + `operations-management` as MCP-first (`factory_status`/`factory_queue`/`factory_trigger`/`factory_enqueue`/`factory_recent`) with a `curl -sf http://127.0.0.1:13003/health` guard and script fallback (`scripts/factory/wakeup.sh`).
- **Server-name drift fixed** in `CLAUDE.md` — the bogus `mcp-k8s`/`mcp-factory` opencode names replaced with the real list (`mcp-kubernetes`, …, `factory-mcp`). (AGENTS.md carries no such list — nothing to change there.)
- **`mcp-tool-guide.md` rewritten** as the server→tool→when→fallback SSOT: one section per server (`mcp-postgres`, `mcp-kubernetes`, `ticket-mcp` listing **all 23** Go tools, `factory-mcp`, `mcp-task-runner`, `task-master-ai`, `mcp-browser`). Invariants preserved verbatim: READ-ONLY `mcp-postgres` (only `sql`), the portforward/health guard, and **kubectl-for-writes/DDL/superuser**.
- **Guardrail extended** (`tests/spec/mcp-tooling.bats`) with a second `@test`: every `mcp.NewTool("…")` name in the Go source must appear in the guide. Proven to fail on injected drift (removing one tool line → `not ok`) and restored to green.

### Verification
- `task test:mcp-tooling` → `2 tests, 0 failures`; guide-completeness fails on drift.
- `task test:changed` green (vitest found no test files for the data-only regen; MCP guardrail both tests pass; quality gate clean).
- `task freshness:check` green; baseline key-count unchanged.
- This change's OpenSpec delta is well-formed (`## ADDED Requirements`, six `### Requirement:` H3 entries, no H2). Note: the global `task test:openspec` reports pre-existing failures for unrelated changes (cockpit-*, ticket-mcp-go, …) that already exist on main and are not gated by CI's required Offline Tests.

Requires Slice 1 (#2144) + Slice 2 (#2148), both merged. Closes the MCP↔Skill integration (T001211).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EXaHdV2ELfigenj6vVBqtV