### PR TITLE
perf(ci): drop unused arm64/QEMU build from transcriber + collabora [T001229]

### DIFF
--- a/.github/workflows/build-collabora.yml
+++ b/.github/workflows/build-collabora.yml
@@ -58,12 +58,6 @@ jobs:
           echo "upstream=$TAG" >> "$GITHUB_OUTPUT"
           echo "published=${TAG}-setcap" >> "$GITHUB_OUTPUT"
 
-      - name: Set up QEMU
-        # Needed so amd64 runners can build the arm64 variant too.
-        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130  # v3
-        with:
-          platforms: linux/arm64
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
 
@@ -78,7 +72,7 @@ jobs:
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
         with:
           context: docker/collabora
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: ${{ github.event_name != 'pull_request' }}
           build-args: |
             UPSTREAM_TAG=${{ steps.tag.outputs.upstream }}

--- a/.github/workflows/build-transcriber.yml
+++ b/.github/workflows/build-transcriber.yml
@@ -31,11 +31,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130  # v3
-        with:
-          platforms: linux/arm64
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
 
@@ -53,7 +48,7 @@ jobs:
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
         with:
           context: k3d/talk-transcriber
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: ${{ github.event_name != 'pull_request' }}
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest

--- a/openspec/changes/docker-build-speedup/tasks.md
+++ b/openspec/changes/docker-build-speedup/tasks.md
@@ -54,10 +54,10 @@ depends_on_plans: []
 - [x] **P2-T4** (2b) Geteiltes Image `ghcr.io/paddione/website`: `build-website.yml` = 1 Build + 2 Deploy-Steps; `build-website-korczewski.yml` löschen; `WEBSITE_IMAGE` in allen `environments/*.yaml` repointen
 - [x] **P2-T5** Stale Aussage in `website/CLAUDE.md` korrigieren (`LEGAL_*` Build-Zeit → Runtime)
 - [ ] **P2-T6** Rollout beider Brands verifizieren (post-merge)
-- [ ] **P3-T0** (TDD rot) Phase-3-Assertions an `tests/spec/docker-build-speedup.bats` anhängen + ausführen, Expected: FAIL (rot)
-- [ ] **P3-T1** (Pre-flight) `kubectl --context fleet get nodes -o wide` → amd64-only bestätigen
-- [ ] **P3-T2** `build-transcriber.yml` + `build-collabora.yml`: `platforms: linux/amd64` (arm64 + QEMU raus)
-- [ ] **P3-T3** Phase-3-Verifikation
+- [x] **P3-T0** (TDD rot) Phase-3-Assertions an `tests/spec/docker-build-speedup.bats` anhängen + ausführen, Expected: FAIL (rot)
+- [x] **P3-T1** (Pre-flight) `kubectl --context fleet get nodes -o wide` → amd64-only bestätigen
+- [x] **P3-T2** `build-transcriber.yml` + `build-collabora.yml`: `platforms: linux/amd64` (arm64 + QEMU raus)
+- [x] **P3-T3** Phase-3-Verifikation
 - [x] **SPEC** Spec-Delta `specs/docker-build-speedup.md` füllen + `task test:openspec` grün
 - [ ] **VERIFY** Finaler CI-Gate-Verifikations-Task (pro Phase-PR auszuführen)
 
@@ -685,7 +685,7 @@ Alle vom Change berührten Pfade, gruppiert nach Aktion (1-Wort-Zweck je Pfad):
 
 **Konkrete Schritte:**
 
-- [ ] **Step 1 — Phase-3-Block anhängen:**
+- [x] **Step 1 — Phase-3-Block anhängen:**
   ```bash
   # ── Phase 3: amd64-only ────────────────────────────────────────────────────
   @test "P3: transcriber baut amd64-only ohne QEMU" {
@@ -701,7 +701,7 @@ Alle vom Change berührten Pfade, gruppiert nach Aktion (1-Wort-Zweck je Pfad):
   }
   ```
 
-- [ ] **Step 2 — Test ausführen, Expected: FAIL (rot):** die `P3:`-Assertions schlagen fehl, weil beide Workflows noch `linux/amd64,linux/arm64` + QEMU enthalten.
+- [x] **Step 2 — Test ausführen, Expected: FAIL (rot):** die `P3:`-Assertions schlagen fehl, weil beide Workflows noch `linux/amd64,linux/arm64` + QEMU enthalten.
   ```bash
   ./tests/unit/lib/bats-core/bin/bats tests/spec/docker-build-speedup.bats --filter 'P3:'
   ```
@@ -721,13 +721,13 @@ Alle vom Change berührten Pfade, gruppiert nach Aktion (1-Wort-Zweck je Pfad):
 
 **Konkrete Schritte:**
 
-- [ ] **Step 1:**
+- [x] **Step 1:**
   ```bash
   kubectl --context fleet get nodes -o wide
   kubectl --context fleet get nodes -o jsonpath='{range .items[*]}{.metadata.name}{"="}{.status.nodeInfo.architecture}{"\n"}{end}'
   ```
   Erwartung: alle Nodes `amd64`.
-- [ ] **Step 2 — Gate:** Taucht ein `arm64`-Node auf → **STOP Phase 3** (arm64 wird gebraucht). Sonst fortsetzen.
+- [x] **Step 2 — Gate:** Taucht ein `arm64`-Node auf → **STOP Phase 3** (arm64 wird gebraucht). Sonst fortsetzen.
 
 **Acceptance-Kriterien:**
 - Nachweis (Output) im PR, dass alle fleet-Nodes amd64 sind.
@@ -744,8 +744,8 @@ Alle vom Change berührten Pfade, gruppiert nach Aktion (1-Wort-Zweck je Pfad):
 
 **Konkrete Schritte:**
 
-- [ ] **Step 1 — `build-transcriber.yml`:** `platforms: linux/amd64,linux/arm64` → `platforms: linux/amd64`. Den Step „Set up QEMU" (`docker/setup-qemu-action`, mit `platforms: linux/arm64`) entfernen (nur noch amd64 = nativ, kein QEMU nötig). `setup-buildx` bleibt. Cache-Konfig aus P1-T3 bleibt.
-- [ ] **Step 2 — `build-collabora.yml`:** `platforms: linux/amd64,linux/arm64` → `platforms: linux/amd64`. „Set up QEMU"-Step entfernen. Kommentar „Needed so amd64 runners can build the arm64 variant too." mit-entfernen/anpassen.
+- [x] **Step 1 — `build-transcriber.yml`:** `platforms: linux/amd64,linux/arm64` → `platforms: linux/amd64`. Den Step „Set up QEMU" (`docker/setup-qemu-action`, mit `platforms: linux/arm64`) entfernen (nur noch amd64 = nativ, kein QEMU nötig). `setup-buildx` bleibt. Cache-Konfig aus P1-T3 bleibt.
+- [x] **Step 2 — `build-collabora.yml`:** `platforms: linux/amd64,linux/arm64` → `platforms: linux/amd64`. „Set up QEMU"-Step entfernen. Kommentar „Needed so amd64 runners can build the arm64 variant too." mit-entfernen/anpassen.
 
 **Acceptance-Kriterien:**
 - Beide Workflows: `platforms: linux/amd64` (kein `arm64` mehr).
@@ -760,12 +760,12 @@ Alle vom Change berührten Pfade, gruppiert nach Aktion (1-Wort-Zweck je Pfad):
 
 **Konkrete Schritte:**
 
-- [ ] **Step 0 — P3-BATS grün:** der in P3-T0 rote Block ist nach P3-T2 grün:
+- [x] **Step 0 — P3-BATS grün:** der in P3-T0 rote Block ist nach P3-T2 grün:
   ```bash
   ./tests/unit/lib/bats-core/bin/bats tests/spec/docker-build-speedup.bats
   ```
   Erwartung: alle `@test` (P1+P2+P3) `ok`.
-- [ ] **Step 1:** Workflow-Syntax/Struktur grün (`task test:all` bzw. `yamllint` lokal).
+- [x] **Step 1:** Workflow-Syntax/Struktur grün (`task test:all` bzw. `yamllint` lokal).
 - [ ] **Step 2:** Post-merge: transcriber-Run-Duration vorher (~8 min) / nachher dokumentieren (Beleg der Halbierung durch QEMU-Wegfall).
 - [ ] **Step 3:** Bestätigen, dass die single-arch Images im Cluster ziehen (transcriber- + collabora-Pods `Running`).
 

--- a/tests/spec/docker-build-speedup.bats
+++ b/tests/spec/docker-build-speedup.bats
@@ -55,3 +55,16 @@
   ! grep -rqE 'paddione/(mentolder|korczewski)-website' \
       .github/workflows environments
 }
+
+# ── Phase 3: amd64-only ────────────────────────────────────────────────────
+@test "P3: transcriber baut amd64-only ohne QEMU" {
+  grep -qE '^\s*platforms:\s*linux/amd64\s*$' .github/workflows/build-transcriber.yml
+  ! grep -q 'linux/arm64' .github/workflows/build-transcriber.yml
+  ! grep -q 'setup-qemu-action' .github/workflows/build-transcriber.yml
+}
+
+@test "P3: collabora baut amd64-only ohne QEMU" {
+  grep -qE '^\s*platforms:\s*linux/amd64\s*$' .github/workflows/build-collabora.yml
+  ! grep -q 'linux/arm64' .github/workflows/build-collabora.yml
+  ! grep -q 'setup-qemu-action' .github/workflows/build-collabora.yml
+}


### PR DESCRIPTION
## Summary

- Remove `setup-qemu-action` step from `build-transcriber.yml` and `build-collabora.yml`
- Restrict `platforms` from `linux/amd64,linux/arm64` to `linux/amd64` in both workflows
- All 6 fleet nodes confirmed amd64-only (see pre-flight check below)

## Pre-flight Architecture Check (P3-T1)

All fleet nodes are amd64 — no arm64 nodes exist, so cross-compilation via QEMU adds build time with zero benefit:

```
gekko-hetzner-2=amd64
gekko-hetzner-3=amd64
gekko-hetzner-4=amd64
pk-hetzner-4=amd64
pk-hetzner-6=amd64
pk-hetzner-8=amd64
```

## Why QEMU can be removed

The `setup-qemu-action` step is only needed when building for a non-native architecture (arm64) on amd64 GitHub Actions runners. Since all fleet nodes are amd64, the arm64 image variant is unused. Removing it saves ~4-6 minutes per build on transcriber.

## Phase 3 BATS Tests

New `P3:` tagged tests in `tests/spec/docker-build-speedup.bats` verify:
- `platforms` is exactly `linux/amd64` in both workflows
- `setup-qemu-action` is absent from both workflows

All 13 P1+P2+P3 BATS tests pass green.

## Verification

- All P1+P2+P3 BATS tests pass (green) — 13/13
- `task workspace:validate` passes
- `task test:changed` passes (50/50)
- `task freshness:check` passes
- `bash scripts/preflight-pr-scope.sh` passes

## setup-node Cache Audit

Per P1-T4 findings (unchanged): all `setup-node` cache keys remain live — no removals.