### PR TITLE
feat(openspec): install upstream workflow commands in .opencode + .claude [T001263]

### DIFF
--- a/.claude/commands/opsx/apply.md
+++ b/.claude/commands/opsx/apply.md
@@ -1,0 +1,152 @@
+---
+name: "OPSX: Apply"
+description: Implement tasks from an OpenSpec change (Experimental)
+category: Workflow
+tags: [workflow, artifacts, experimental]
+---
+
+Implement tasks from an OpenSpec change.
+
+**Input**: Optionally specify a change name (e.g., `/opsx:apply add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and use the **AskUserQuestion tool** to let the user select
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx:apply <other>`).
+
+2. **Check status to understand the schema**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
+
+3. **Get apply instructions**
+
+   ```bash
+   openspec instructions apply --change "<name>" --json
+   ```
+
+   This returns:
+   - `contextFiles`: artifact ID -> array of concrete file paths (varies by schema)
+   - Progress (total, complete, remaining)
+   - Task list with status
+   - Dynamic instruction based on current state
+
+   **Handle states:**
+   - If `state: "blocked"` (missing artifacts): show message, suggest using `/opsx:continue`
+   - If `state: "all_done"`: congratulate, suggest archive
+   - Otherwise: proceed to implementation
+
+4. **Read context files**
+
+   Read every file path listed under `contextFiles` from the apply instructions output.
+   The files depend on the schema being used:
+   - **spec-driven**: proposal, specs, design, tasks
+   - Other schemas: follow the contextFiles from CLI output
+
+5. **Show current progress**
+
+   Display:
+   - Schema being used
+   - Progress: "N/M tasks complete"
+   - Remaining tasks overview
+   - Dynamic instruction from CLI
+
+6. **Implement tasks (loop until done or blocked)**
+
+   For each pending task:
+   - Show which task is being worked on
+   - Make the code changes required
+   - Keep changes minimal and focused
+   - Mark task complete in the tasks file: `- [ ]` → `- [x]`
+   - Continue to next task
+
+   **Pause if:**
+   - Task is unclear → ask for clarification
+   - Implementation reveals a design issue → suggest updating artifacts
+   - Error or blocker encountered → report and wait for guidance
+   - User interrupts
+
+7. **On completion or pause, show status**
+
+   Display:
+   - Tasks completed this session
+   - Overall progress: "N/M tasks complete"
+   - If all done: suggest archive
+   - If paused: explain why and wait for guidance
+
+**Output During Implementation**
+
+```
+## Implementing: <change-name> (schema: <schema-name>)
+
+Working on task 3/7: <task description>
+[...implementation happening...]
+✓ Task complete
+
+Working on task 4/7: <task description>
+[...implementation happening...]
+✓ Task complete
+```
+
+**Output On Completion**
+
+```
+## Implementation Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 7/7 tasks complete ✓
+
+### Completed This Session
+- [x] Task 1
+- [x] Task 2
+...
+
+All tasks complete! You can archive this change with `/opsx:archive`.
+```
+
+**Output On Pause (Issue Encountered)**
+
+```
+## Implementation Paused
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 4/7 tasks complete
+
+### Issue Encountered
+<description of the issue>
+
+**Options:**
+1. <option 1>
+2. <option 2>
+3. Other approach
+
+What would you like to do?
+```
+
+**Guardrails**
+- Keep going through tasks until done or blocked
+- Always read context files before starting (from the apply instructions output)
+- If task is ambiguous, pause and ask before implementing
+- If implementation reveals issues, pause and suggest artifact updates
+- Keep code changes minimal and scoped to each task
+- Update task checkbox immediately after completing each task
+- Pause on errors, blockers, or unclear requirements - don't guess
+- Use contextFiles from CLI output, don't assume specific file names
+
+**Fluid Workflow Integration**
+
+This skill supports the "actions on a change" model:
+
+- **Can be invoked anytime**: Before all artifacts are done (if tasks exist), after partial implementation, interleaved with other actions
+- **Allows artifact updates**: If implementation reveals design issues, suggest updating artifacts - not phase-locked, work fluidly

--- a/.claude/commands/opsx/archive.md
+++ b/.claude/commands/opsx/archive.md
@@ -1,0 +1,157 @@
+---
+name: "OPSX: Archive"
+description: Archive a completed change in the experimental workflow
+category: Workflow
+tags: [workflow, archive, experimental]
+---
+
+Archive a completed change in the experimental workflow.
+
+**Input**: Optionally specify a change name after `/opsx:archive` (e.g., `/opsx:archive add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show only active changes (not already archived).
+   Include the schema used for each change if available.
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check artifact completion status**
+
+   Run `openspec status --change "<name>" --json` to check artifact completion.
+
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used
+   - `artifacts`: List of artifacts with their status (`done` or other)
+
+   **If any artifacts are not `done`:**
+   - Display warning listing incomplete artifacts
+   - Prompt user for confirmation to continue
+   - Proceed if user confirms
+
+3. **Check task completion status**
+
+   Read the tasks file (typically `tasks.md`) to check for incomplete tasks.
+
+   Count tasks marked with `- [ ]` (incomplete) vs `- [x]` (complete).
+
+   **If incomplete tasks found:**
+   - Display warning showing count of incomplete tasks
+   - Prompt user for confirmation to continue
+   - Proceed if user confirms
+
+   **If no tasks file exists:** Proceed without task-related warning.
+
+4. **Assess delta spec sync state**
+
+   Check for delta specs at `openspec/changes/<name>/specs/`. If none exist, proceed without sync prompt.
+
+   **If delta specs exist:**
+   - Compare each delta spec with its corresponding main spec at `openspec/specs/<capability>/spec.md`
+   - Determine what changes would be applied (adds, modifications, removals, renames)
+   - Show a combined summary before prompting
+
+   **Prompt options:**
+   - If changes needed: "Sync now (recommended)", "Archive without syncing"
+   - If already synced: "Archive now", "Sync anyway", "Cancel"
+
+   If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
+
+5. **Perform the archive**
+
+   Create the archive directory if it doesn't exist:
+   ```bash
+   mkdir -p openspec/changes/archive
+   ```
+
+   Generate target name using current date: `YYYY-MM-DD-<change-name>`
+
+   **Check if target already exists:**
+   - If yes: Fail with error, suggest renaming existing archive or using different date
+   - If no: Move the change directory to archive
+
+   ```bash
+   mv openspec/changes/<name> openspec/changes/archive/YYYY-MM-DD-<name>
+   ```
+
+6. **Display summary**
+
+   Show archive completion summary including:
+   - Change name
+   - Schema that was used
+   - Archive location
+   - Spec sync status (synced / sync skipped / no delta specs)
+   - Note about any warnings (incomplete artifacts/tasks)
+
+**Output On Success**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** ✓ Synced to main specs
+
+All artifacts complete. All tasks complete.
+```
+
+**Output On Success (No Delta Specs)**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** No delta specs
+
+All artifacts complete. All tasks complete.
+```
+
+**Output On Success With Warnings**
+
+```
+## Archive Complete (with warnings)
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** Sync skipped (user chose to skip)
+
+**Warnings:**
+- Archived with 2 incomplete artifacts
+- Archived with 3 incomplete tasks
+- Delta spec sync was skipped (user chose to skip)
+
+Review the archive if this was not intentional.
+```
+
+**Output On Error (Archive Exists)**
+
+```
+## Archive Failed
+
+**Change:** <change-name>
+**Target:** openspec/changes/archive/YYYY-MM-DD-<name>/
+
+Target archive directory already exists.
+
+**Options:**
+1. Rename the existing archive
+2. Delete the existing archive if it's a duplicate
+3. Wait until a different date to archive
+```
+
+**Guardrails**
+- Always prompt for change selection if not provided
+- Use artifact graph (openspec status --json) for completion checking
+- Don't block archive on warnings - just inform and confirm
+- Preserve .openspec.yaml when moving to archive (it moves with the directory)
+- Show clear summary of what happened
+- If sync is requested, use the Skill tool to invoke `openspec-sync-specs` (agent-driven)
+- If delta specs exist, always run the sync assessment and show the combined summary before prompting

--- a/.claude/commands/opsx/explore.md
+++ b/.claude/commands/opsx/explore.md
@@ -1,0 +1,173 @@
+---
+name: "OPSX: Explore"
+description: "Enter explore mode - think through ideas, investigate problems, clarify requirements"
+category: Workflow
+tags: [workflow, explore, experimental, thinking]
+---
+
+Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
+
+**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first and create a change proposal. You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
+
+**This is a stance, not a workflow.** There are no fixed steps, no required sequence, no mandatory outputs. You're a thinking partner helping the user explore.
+
+**Input**: The argument after `/opsx:explore` is whatever the user wants to think about. Could be:
+- A vague idea: "real-time collaboration"
+- A specific problem: "the auth system is getting unwieldy"
+- A change name: "add-dark-mode" (to explore in context of that change)
+- A comparison: "postgres vs sqlite for this"
+- Nothing (just enter explore mode)
+
+---
+
+## The Stance
+
+- **Curious, not prescriptive** - Ask questions that emerge naturally, don't follow a script
+- **Open threads, not interrogations** - Surface multiple interesting directions and let the user follow what resonates. Don't funnel them through a single path of questions.
+- **Visual** - Use ASCII diagrams liberally when they'd help clarify thinking
+- **Adaptive** - Follow interesting threads, pivot when new information emerges
+- **Patient** - Don't rush to conclusions, let the shape of the problem emerge
+- **Grounded** - Explore the actual codebase when relevant, don't just theorize
+
+---
+
+## What You Might Do
+
+Depending on what the user brings, you might:
+
+**Explore the problem space**
+- Ask clarifying questions that emerge from what they said
+- Challenge assumptions
+- Reframe the problem
+- Find analogies
+
+**Investigate the codebase**
+- Map existing architecture relevant to the discussion
+- Find integration points
+- Identify patterns already in use
+- Surface hidden complexity
+
+**Compare options**
+- Brainstorm multiple approaches
+- Build comparison tables
+- Sketch tradeoffs
+- Recommend a path (if asked)
+
+**Visualize**
+```
+┌─────────────────────────────────────────┐
+│     Use ASCII diagrams liberally        │
+├─────────────────────────────────────────┤
+│                                         │
+│      ┌────────┐         ┌────────┐      │
+│      │ State  │────────▶│ State  │      │
+│      │   A    │         │   B    │      │
+│      └────────┘         └────────┘      │
+│                                         │
+│   System diagrams, state machines,      │
+│   data flows, architecture sketches,    │
+│   dependency graphs, comparison tables  │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+**Surface risks and unknowns**
+- Identify what could go wrong
+- Find gaps in understanding
+- Suggest spikes or investigations
+
+---
+
+## OpenSpec Awareness
+
+You have full context of the OpenSpec system. Use it naturally, don't force it.
+
+### Check for context
+
+At the start, quickly check what exists:
+```bash
+openspec list --json
+```
+
+This tells you:
+- If there are active changes
+- Their names, schemas, and status
+- What the user might be working on
+
+If the user mentioned a specific change name, read its artifacts for context.
+
+### When no change exists
+
+Think freely. When insights crystallize, you might offer:
+
+- "This feels solid enough to start a change. Want me to create a proposal?"
+- Or keep exploring - no pressure to formalize
+
+### When a change exists
+
+If the user mentions a change or you detect one is relevant:
+
+1. **Read existing artifacts for context**
+   - `openspec/changes/<name>/proposal.md`
+   - `openspec/changes/<name>/design.md`
+   - `openspec/changes/<name>/tasks.md`
+   - etc.
+
+2. **Reference them naturally in conversation**
+   - "Your design mentions using Redis, but we just realized SQLite fits better..."
+   - "The proposal scopes this to premium users, but we're now thinking everyone..."
+
+3. **Offer to capture when decisions are made**
+
+    | Insight Type               | Where to Capture               |
+    |----------------------------|--------------------------------|
+    | New requirement discovered | `specs/<capability>/spec.md` |
+    | Requirement changed        | `specs/<capability>/spec.md` |
+    | Design decision made       | `design.md`                  |
+    | Scope changed              | `proposal.md`                |
+    | New work identified        | `tasks.md`                   |
+    | Assumption invalidated     | Relevant artifact              |
+
+   Example offers:
+   - "That's a design decision. Capture it in design.md?"
+   - "This is a new requirement. Add it to specs?"
+   - "This changes scope. Update the proposal?"
+
+4. **The user decides** - Offer and move on. Don't pressure. Don't auto-capture.
+
+---
+
+## What You Don't Have To Do
+
+- Follow a script
+- Ask the same questions every time
+- Produce a specific artifact
+- Reach a conclusion
+- Stay on topic if a tangent is valuable
+- Be brief (this is thinking time)
+
+---
+
+## Ending Discovery
+
+There's no required ending. Discovery might:
+
+- **Flow into a proposal**: "Ready to start? I can create a change proposal."
+- **Result in artifact updates**: "Updated design.md with these decisions"
+- **Just provide clarity**: User has what they need, moves on
+- **Continue later**: "We can pick this up anytime"
+
+When things crystallize, you might offer a summary - but it's optional. Sometimes the thinking IS the value.
+
+---
+
+## Guardrails
+
+- **Don't implement** - Never write code or implement features. Creating OpenSpec artifacts is fine, writing application code is not.
+- **Don't fake understanding** - If something is unclear, dig deeper
+- **Don't rush** - Discovery is thinking time, not task time
+- **Don't force structure** - Let patterns emerge naturally
+- **Don't auto-capture** - Offer to save insights, don't just do it
+- **Do visualize** - A good diagram is worth many paragraphs
+- **Do explore the codebase** - Ground discussions in reality
+- **Do question assumptions** - Including the user's and your own

--- a/.claude/commands/opsx/propose.md
+++ b/.claude/commands/opsx/propose.md
@@ -1,0 +1,106 @@
+---
+name: "OPSX: Propose"
+description: Propose a new change - create it and generate all artifacts in one step
+category: Workflow
+tags: [workflow, artifacts, experimental]
+---
+
+Propose a new change - create the change and generate all artifacts in one step.
+
+I'll create a change with artifacts:
+- proposal.md (what & why)
+- design.md (how)
+- tasks.md (implementation steps)
+
+When ready to implement, run /opsx:apply
+
+---
+
+**Input**: The argument after `/opsx:propose` is the change name (kebab-case), OR a description of what the user wants to build.
+
+**Steps**
+
+1. **If no input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   This creates a scaffolded change at `openspec/changes/<name>/` with `.openspec.yaml`.
+
+3. **Get the artifact build order**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to get:
+   - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
+   - `artifacts`: list of all artifacts with their status and dependencies
+
+4. **Create artifacts in sequence until apply-ready**
+
+   Use the **TodoWrite tool** to track progress through the artifacts.
+
+   Loop through artifacts in dependency order (artifacts with no pending dependencies first):
+
+   a. **For each artifact that is `ready` (dependencies satisfied)**:
+      - Get instructions:
+        ```bash
+        openspec instructions <artifact-id> --change "<name>" --json
+        ```
+      - The instructions JSON includes:
+        - `context`: Project background (constraints for you - do NOT include in output)
+        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+        - `template`: The structure to use for your output file
+        - `instruction`: Schema-specific guidance for this artifact type
+        - `outputPath`: Where to write the artifact
+        - `dependencies`: Completed artifacts to read for context
+      - Read any completed dependency files for context
+      - Create the artifact file using `template` as the structure
+      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
+      - Show brief progress: "Created <artifact-id>"
+
+   b. **Continue until all `applyRequires` artifacts are complete**
+      - After creating each artifact, re-run `openspec status --change "<name>" --json`
+      - Check if every artifact ID in `applyRequires` has `status: "done"` in the artifacts array
+      - Stop when all `applyRequires` artifacts are done
+
+   c. **If an artifact requires user input** (unclear context):
+      - Use **AskUserQuestion tool** to clarify
+      - Then continue with creation
+
+5. **Show final status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After completing all artifacts, summarize:
+- Change name and location
+- List of artifacts created with brief descriptions
+- What's ready: "All artifacts created! Ready for implementation."
+- Prompt: "Run `/opsx:apply` to start implementing."
+
+**Artifact Creation Guidelines**
+
+- Follow the `instruction` field from `openspec instructions` for each artifact type
+- The schema defines what each artifact should contain - follow it
+- Read dependency artifacts for context before creating new ones
+- Use `template` as the structure for your output file - fill in its sections
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
+
+**Guardrails**
+- Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`)
+- Always read dependency artifacts before creating a new one
+- If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
+- If a change with that name already exists, ask if user wants to continue it or create a new one
+- Verify each artifact file exists after writing before proceeding to next

--- a/.claude/skills/dev-flow-execute/SKILL.md
+++ b/.claude/skills/dev-flow-execute/SKILL.md
@@ -167,6 +167,11 @@ done
 
 ## Schritt 1.5: Ticket auf `in_progress` setzen und touched_files registrieren
 
+> **Optional:** Wenn der Plan via `dev-flow-plan` auf `plan_staged` steht, kannst du vor diesem
+> Schritt `/opsx:apply <slug>` aufrufen — das ist die upstream-Variante von `task openspec:apply`,
+> die den OpenSpec-Change in den Apply-Modus überführt. Fallback wenn die upstream-CLI nicht
+> installiert ist: `task openspec:apply -- <slug>`.
+
 Falls eine Ticket-ID vorhanden ist, setze das Ticket auf in_progress — **MCP-first** (`ticket-mcp`):
 
 > `mcp__ticket-mcp__transition_status({ id: "$TICKET_ID", status: "in_progress" })`

--- a/.claude/skills/dev-flow-plan/SKILL.md
+++ b/.claude/skills/dev-flow-plan/SKILL.md
@@ -110,7 +110,7 @@ Wähle einen der Pfade (Feature/Fix/Chore) basierend auf der Anfrage und kläre 
 
 Die feature/fix/chore-Wahl oben ist die *Pfad*-Wahl durch diese Skill. Davor steht die
 *Artefakt*-Wahl: die meisten Requests steigen direkt auf Change-Proposal-Ebene ein (Feature-Pfad
-→ Schritt 3.1 `openspec.sh propose`). Ein PRD ist das **schwerste** Artefakt und nur für
+→ Schritt 3.1 `/opsx:propose`). Ein PRD ist das **schwerste** Artefakt und nur für
 Epic-große Arbeit gedacht — ein PRD pro Feature kollabiert die Abstraktionsebenen und erzeugt
 Mehrfach-SSOT.
 
@@ -118,7 +118,7 @@ Mehrfach-SSOT.
 |---|---|---|
 | Großes, unscharfes Produktziel, viele Features | **PRD** | `parse_prd` (task-master) — Bootstrap/Epic-Zerlegung |
 | Architektur-/Technologieentscheidung | **ADR** | `manage_adr` / OpenSpec |
-| *Ein* konkretes Feature, Intent klar | **Change-Proposal** | `bash scripts/openspec.sh propose "<slug>" --ticket <id>` (Feature-Pfad, Schritt 3.1) |
+| *Ein* konkretes Feature, Intent klar | **Change-Proposal** | `/opsx:propose <slug>` (Feature-Pfad, Schritt 3.1) |
 | Feature, aber Design noch offen | **Brainstorming → Spec** | diese Skill, Feature-Pfad |
 | Wartung, kein Verhaltenswechsel | **Chore-Ticket** | `dev-flow-chore` |
 | Regression | **Fix + failing test** | diese Skill, Fix-Pfad |
@@ -199,7 +199,9 @@ Delta-Skeleton, setzt Ticket-Status auf `planning`). Merke den Repo-Root für Sc
 # Repo-Root für späteres Verschieben der Artefakte festhalten
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 
-bash scripts/openspec.sh propose "<slug>" --ticket "<TICKET_EXT_ID>"
+/opsx:propose <slug>     # upstream OpenSpec command (preferred)
+# Fallback (older harness without upstream CLI):
+# bash scripts/openspec.sh propose "<slug>" --ticket "<TICKET_EXT_ID>"
 ```
 
 Übertrage den Brainstorming-Output (WARUM + WAS) nach `openspec/changes/<slug>/proposal.md`.

--- a/.claude/skills/openspec-apply-change/SKILL.md
+++ b/.claude/skills/openspec-apply-change/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: openspec-apply-change
+description: Implement tasks from an OpenSpec change. Use when the user wants to start implementing, continue implementation, or work through tasks.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.1"
+---
+
+Implement tasks from an OpenSpec change.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and use the **AskUserQuestion tool** to let the user select
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx:apply <other>`).
+
+2. **Check status to understand the schema**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
+
+3. **Get apply instructions**
+
+   ```bash
+   openspec instructions apply --change "<name>" --json
+   ```
+
+   This returns:
+   - `contextFiles`: artifact ID -> array of concrete file paths (varies by schema - could be proposal/specs/design/tasks or spec/tests/implementation/docs)
+   - Progress (total, complete, remaining)
+   - Task list with status
+   - Dynamic instruction based on current state
+
+   **Handle states:**
+   - If `state: "blocked"` (missing artifacts): show message, suggest using openspec-continue-change
+   - If `state: "all_done"`: congratulate, suggest archive
+   - Otherwise: proceed to implementation
+
+4. **Read context files**
+
+   Read every file path listed under `contextFiles` from the apply instructions output.
+   The files depend on the schema being used:
+   - **spec-driven**: proposal, specs, design, tasks
+   - Other schemas: follow the contextFiles from CLI output
+
+5. **Show current progress**
+
+   Display:
+   - Schema being used
+   - Progress: "N/M tasks complete"
+   - Remaining tasks overview
+   - Dynamic instruction from CLI
+
+6. **Implement tasks (loop until done or blocked)**
+
+   For each pending task:
+   - Show which task is being worked on
+   - Make the code changes required
+   - Keep changes minimal and focused
+   - Mark task complete in the tasks file: `- [ ]` → `- [x]`
+   - Continue to next task
+
+   **Pause if:**
+   - Task is unclear → ask for clarification
+   - Implementation reveals a design issue → suggest updating artifacts
+   - Error or blocker encountered → report and wait for guidance
+   - User interrupts
+
+7. **On completion or pause, show status**
+
+   Display:
+   - Tasks completed this session
+   - Overall progress: "N/M tasks complete"
+   - If all done: suggest archive
+   - If paused: explain why and wait for guidance
+
+**Output During Implementation**
+
+```
+## Implementing: <change-name> (schema: <schema-name>)
+
+Working on task 3/7: <task description>
+[...implementation happening...]
+✓ Task complete
+
+Working on task 4/7: <task description>
+[...implementation happening...]
+✓ Task complete
+```
+
+**Output On Completion**
+
+```
+## Implementation Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 7/7 tasks complete ✓
+
+### Completed This Session
+- [x] Task 1
+- [x] Task 2
+...
+
+All tasks complete! Ready to archive this change.
+```
+
+**Output On Pause (Issue Encountered)**
+
+```
+## Implementation Paused
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 4/7 tasks complete
+
+### Issue Encountered
+<description of the issue>
+
+**Options:**
+1. <option 1>
+2. <option 2>
+3. Other approach
+
+What would you like to do?
+```
+
+**Guardrails**
+- Keep going through tasks until done or blocked
+- Always read context files before starting (from the apply instructions output)
+- If task is ambiguous, pause and ask before implementing
+- If implementation reveals issues, pause and suggest artifact updates
+- Keep code changes minimal and scoped to each task
+- Update task checkbox immediately after completing each task
+- Pause on errors, blockers, or unclear requirements - don't guess
+- Use contextFiles from CLI output, don't assume specific file names
+
+**Fluid Workflow Integration**
+
+This skill supports the "actions on a change" model:
+
+- **Can be invoked anytime**: Before all artifacts are done (if tasks exist), after partial implementation, interleaved with other actions
+- **Allows artifact updates**: If implementation reveals design issues, suggest updating artifacts - not phase-locked, work fluidly

--- a/.claude/skills/openspec-archive-change/SKILL.md
+++ b/.claude/skills/openspec-archive-change/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: openspec-archive-change
+description: Archive a completed change in the experimental workflow. Use when the user wants to finalize and archive a change after implementation is complete.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.1"
+---
+
+Archive a completed change in the experimental workflow.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show only active changes (not already archived).
+   Include the schema used for each change if available.
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check artifact completion status**
+
+   Run `openspec status --change "<name>" --json` to check artifact completion.
+
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used
+   - `artifacts`: List of artifacts with their status (`done` or other)
+
+   **If any artifacts are not `done`:**
+   - Display warning listing incomplete artifacts
+   - Use **AskUserQuestion tool** to confirm user wants to proceed
+   - Proceed if user confirms
+
+3. **Check task completion status**
+
+   Read the tasks file (typically `tasks.md`) to check for incomplete tasks.
+
+   Count tasks marked with `- [ ]` (incomplete) vs `- [x]` (complete).
+
+   **If incomplete tasks found:**
+   - Display warning showing count of incomplete tasks
+   - Use **AskUserQuestion tool** to confirm user wants to proceed
+   - Proceed if user confirms
+
+   **If no tasks file exists:** Proceed without task-related warning.
+
+4. **Assess delta spec sync state**
+
+   Check for delta specs at `openspec/changes/<name>/specs/`. If none exist, proceed without sync prompt.
+
+   **If delta specs exist:**
+   - Compare each delta spec with its corresponding main spec at `openspec/specs/<capability>/spec.md`
+   - Determine what changes would be applied (adds, modifications, removals, renames)
+   - Show a combined summary before prompting
+
+   **Prompt options:**
+   - If changes needed: "Sync now (recommended)", "Archive without syncing"
+   - If already synced: "Archive now", "Sync anyway", "Cancel"
+
+   If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
+
+5. **Perform the archive**
+
+   Create the archive directory if it doesn't exist:
+   ```bash
+   mkdir -p openspec/changes/archive
+   ```
+
+   Generate target name using current date: `YYYY-MM-DD-<change-name>`
+
+   **Check if target already exists:**
+   - If yes: Fail with error, suggest renaming existing archive or using different date
+   - If no: Move the change directory to archive
+
+   ```bash
+   mv openspec/changes/<name> openspec/changes/archive/YYYY-MM-DD-<name>
+   ```
+
+6. **Display summary**
+
+   Show archive completion summary including:
+   - Change name
+   - Schema that was used
+   - Archive location
+   - Whether specs were synced (if applicable)
+   - Note about any warnings (incomplete artifacts/tasks)
+
+**Output On Success**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** ✓ Synced to main specs (or "No delta specs" or "Sync skipped")
+
+All artifacts complete. All tasks complete.
+```
+
+**Guardrails**
+- Always prompt for change selection if not provided
+- Use artifact graph (openspec status --json) for completion checking
+- Don't block archive on warnings - just inform and confirm
+- Preserve .openspec.yaml when moving to archive (it moves with the directory)
+- Show clear summary of what happened
+- If sync is requested, use openspec-sync-specs approach (agent-driven)
+- If delta specs exist, always run the sync assessment and show the combined summary before prompting

--- a/.claude/skills/openspec-explore/SKILL.md
+++ b/.claude/skills/openspec-explore/SKILL.md
@@ -1,0 +1,288 @@
+---
+name: openspec-explore
+description: Enter explore mode - a thinking partner for exploring ideas, investigating problems, and clarifying requirements. Use when the user wants to think through something before or during a change.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.1"
+---
+
+Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
+
+**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first and create a change proposal. You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
+
+**This is a stance, not a workflow.** There are no fixed steps, no required sequence, no mandatory outputs. You're a thinking partner helping the user explore.
+
+---
+
+## The Stance
+
+- **Curious, not prescriptive** - Ask questions that emerge naturally, don't follow a script
+- **Open threads, not interrogations** - Surface multiple interesting directions and let the user follow what resonates. Don't funnel them through a single path of questions.
+- **Visual** - Use ASCII diagrams liberally when they'd help clarify thinking
+- **Adaptive** - Follow interesting threads, pivot when new information emerges
+- **Patient** - Don't rush to conclusions, let the shape of the problem emerge
+- **Grounded** - Explore the actual codebase when relevant, don't just theorize
+
+---
+
+## What You Might Do
+
+Depending on what the user brings, you might:
+
+**Explore the problem space**
+- Ask clarifying questions that emerge from what they said
+- Challenge assumptions
+- Reframe the problem
+- Find analogies
+
+**Investigate the codebase**
+- Map existing architecture relevant to the discussion
+- Find integration points
+- Identify patterns already in use
+- Surface hidden complexity
+
+**Compare options**
+- Brainstorm multiple approaches
+- Build comparison tables
+- Sketch tradeoffs
+- Recommend a path (if asked)
+
+**Visualize**
+```
+┌─────────────────────────────────────────┐
+│     Use ASCII diagrams liberally        │
+├─────────────────────────────────────────┤
+│                                         │
+│      ┌────────┐         ┌────────┐      │
+│      │ State  │────────▶│ State  │      │
+│      │   A    │         │   B    │      │
+│      └────────┘         └────────┘      │
+│                                         │
+│   System diagrams, state machines,      │
+│   data flows, architecture sketches,    │
+│   dependency graphs, comparison tables  │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+**Surface risks and unknowns**
+- Identify what could go wrong
+- Find gaps in understanding
+- Suggest spikes or investigations
+
+---
+
+## OpenSpec Awareness
+
+You have full context of the OpenSpec system. Use it naturally, don't force it.
+
+### Check for context
+
+At the start, quickly check what exists:
+```bash
+openspec list --json
+```
+
+This tells you:
+- If there are active changes
+- Their names, schemas, and status
+- What the user might be working on
+
+### When no change exists
+
+Think freely. When insights crystallize, you might offer:
+
+- "This feels solid enough to start a change. Want me to create a proposal?"
+- Or keep exploring - no pressure to formalize
+
+### When a change exists
+
+If the user mentions a change or you detect one is relevant:
+
+1. **Read existing artifacts for context**
+   - `openspec/changes/<name>/proposal.md`
+   - `openspec/changes/<name>/design.md`
+   - `openspec/changes/<name>/tasks.md`
+   - etc.
+
+2. **Reference them naturally in conversation**
+   - "Your design mentions using Redis, but we just realized SQLite fits better..."
+   - "The proposal scopes this to premium users, but we're now thinking everyone..."
+
+3. **Offer to capture when decisions are made**
+
+    | Insight Type               | Where to Capture               |
+    |----------------------------|--------------------------------|
+    | New requirement discovered | `specs/<capability>/spec.md` |
+    | Requirement changed        | `specs/<capability>/spec.md` |
+    | Design decision made       | `design.md`                  |
+    | Scope changed              | `proposal.md`                |
+    | New work identified        | `tasks.md`                   |
+    | Assumption invalidated     | Relevant artifact              |
+
+   Example offers:
+   - "That's a design decision. Capture it in design.md?"
+   - "This is a new requirement. Add it to specs?"
+   - "This changes scope. Update the proposal?"
+
+4. **The user decides** - Offer and move on. Don't pressure. Don't auto-capture.
+
+---
+
+## What You Don't Have To Do
+
+- Follow a script
+- Ask the same questions every time
+- Produce a specific artifact
+- Reach a conclusion
+- Stay on topic if a tangent is valuable
+- Be brief (this is thinking time)
+
+---
+
+## Handling Different Entry Points
+
+**User brings a vague idea:**
+```
+User: I'm thinking about adding real-time collaboration
+
+You: Real-time collab is a big space. Let me think about this...
+
+      COLLABORATION SPECTRUM
+      ════════════════════════════════════════════
+
+      Awareness          Coordination         Sync
+          │                   │                 │
+          ▼                   ▼                 ▼
+      ┌────────┐         ┌────────┐        ┌────────┐
+      │Presence│         │Cursors │        │  CRDT  │
+      │  "3    │         │ Multi  │        │Conflict│
+      │online" │         │ select │        │  free  │
+      └────────┘         └────────┘        └────────┘
+          │                   │                 │
+       trivial            moderate           complex
+
+      Where's your head at?
+```
+
+**User brings a specific problem:**
+```
+User: The auth system is a mess
+
+You: [reads codebase]
+
+     ┌─────────────────────────────────────────────┐
+     │              CURRENT AUTH FLOW              │
+     └─────────────────────────────────────────────┘
+                        │
+          ┌─────────────┼─────────────┐
+          ▼             ▼             ▼
+     ┌─────────┐  ┌─────────┐  ┌─────────┐
+     │ Google  │  │  GitHub │  │  Email  │
+     │  OAuth  │  │  OAuth  │  │  Magic  │
+     └────┬────┘  └────┬────┘  └────┬────┘
+          │             │             │
+          └─────────────┼─────────────┘
+                        ▼
+                  ┌───────────┐
+                  │  Session  │
+                  └─────┬─────┘
+                        │
+                        ▼
+                  ┌───────────┐
+                  │   Perms   │
+                  └───────────┘
+
+     I see three tangles. Which one's burning?
+```
+
+**User is stuck mid-implementation:**
+```
+User: /opsx:explore add-auth-system
+      The OAuth integration is more complex than expected
+
+You: [reads change artifacts]
+
+     You're on task 4: "Implement OAuth flow"
+
+     Let me trace what's involved...
+
+     [draws diagram, explores options, suggests paths]
+
+     Want to update the design to reflect this?
+     Or add a spike task to investigate?
+```
+
+**User wants to compare options:**
+```
+User: Should we use Postgres or SQLite?
+
+You: Generic answer is boring. What's the context?
+
+User: A CLI tool that tracks local dev environments
+
+You: That changes everything.
+
+     ┌─────────────────────────────────────────────────┐
+     │          CLI TOOL DATA STORAGE                  │
+     └─────────────────────────────────────────────────┘
+
+     Key constraints:
+     • No daemon running
+     • Must work offline
+     • Single user
+
+                  SQLite          Postgres
+     Deployment   embedded ✓      needs server ✗
+     Offline      yes ✓           no ✗
+     Single file  yes ✓           no ✗
+
+     SQLite. Not even close.
+
+     Unless... is there a sync component?
+```
+
+---
+
+## Ending Discovery
+
+There's no required ending. Discovery might:
+
+- **Flow into a proposal**: "Ready to start? I can create a change proposal."
+- **Result in artifact updates**: "Updated design.md with these decisions"
+- **Just provide clarity**: User has what they need, moves on
+- **Continue later**: "We can pick this up anytime"
+
+When it feels like things are crystallizing, you might summarize:
+
+```
+## What We Figured Out
+
+**The problem**: [crystallized understanding]
+
+**The approach**: [if one emerged]
+
+**Open questions**: [if any remain]
+
+**Next steps** (if ready):
+- Create a change proposal
+- Keep exploring: just keep talking
+```
+
+But this summary is optional. Sometimes the thinking IS the value.
+
+---
+
+## Guardrails
+
+- **Don't implement** - Never write code or implement features. Creating OpenSpec artifacts is fine, writing application code is not.
+- **Don't fake understanding** - If something is unclear, dig deeper
+- **Don't rush** - Discovery is thinking time, not task time
+- **Don't force structure** - Let patterns emerge naturally
+- **Don't auto-capture** - Offer to save insights, don't just do it
+- **Do visualize** - A good diagram is worth many paragraphs
+- **Do explore the codebase** - Ground discussions in reality
+- **Do question assumptions** - Including the user's and your own

--- a/.claude/skills/openspec-propose/SKILL.md
+++ b/.claude/skills/openspec-propose/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: openspec-propose
+description: Propose a new change with all artifacts generated in one step. Use when the user wants to quickly describe what they want to build and get a complete proposal with design, specs, and tasks ready for implementation.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.1"
+---
+
+Propose a new change - create the change and generate all artifacts in one step.
+
+I'll create a change with artifacts:
+- proposal.md (what & why)
+- design.md (how)
+- tasks.md (implementation steps)
+
+When ready to implement, run /opsx:apply
+
+---
+
+**Input**: The user's request should include a change name (kebab-case) OR a description of what they want to build.
+
+**Steps**
+
+1. **If no clear input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   This creates a scaffolded change at `openspec/changes/<name>/` with `.openspec.yaml`.
+
+3. **Get the artifact build order**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to get:
+   - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
+   - `artifacts`: list of all artifacts with their status and dependencies
+
+4. **Create artifacts in sequence until apply-ready**
+
+   Use the **TodoWrite tool** to track progress through the artifacts.
+
+   Loop through artifacts in dependency order (artifacts with no pending dependencies first):
+
+   a. **For each artifact that is `ready` (dependencies satisfied)**:
+      - Get instructions:
+        ```bash
+        openspec instructions <artifact-id> --change "<name>" --json
+        ```
+      - The instructions JSON includes:
+        - `context`: Project background (constraints for you - do NOT include in output)
+        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+        - `template`: The structure to use for your output file
+        - `instruction`: Schema-specific guidance for this artifact type
+        - `outputPath`: Where to write the artifact
+        - `dependencies`: Completed artifacts to read for context
+      - Read any completed dependency files for context
+      - Create the artifact file using `template` as the structure
+      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
+      - Show brief progress: "Created <artifact-id>"
+
+   b. **Continue until all `applyRequires` artifacts are complete**
+      - After creating each artifact, re-run `openspec status --change "<name>" --json`
+      - Check if every artifact ID in `applyRequires` has `status: "done"` in the artifacts array
+      - Stop when all `applyRequires` artifacts are done
+
+   c. **If an artifact requires user input** (unclear context):
+      - Use **AskUserQuestion tool** to clarify
+      - Then continue with creation
+
+5. **Show final status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After completing all artifacts, summarize:
+- Change name and location
+- List of artifacts created with brief descriptions
+- What's ready: "All artifacts created! Ready for implementation."
+- Prompt: "Run `/opsx:apply` or ask me to implement to start working on the tasks."
+
+**Artifact Creation Guidelines**
+
+- Follow the `instruction` field from `openspec instructions` for each artifact type
+- The schema defines what each artifact should contain - follow it
+- Read dependency artifacts for context before creating new ones
+- Use `template` as the structure for your output file - fill in its sections
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
+
+**Guardrails**
+- Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`)
+- Always read dependency artifacts before creating a new one
+- If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
+- If a change with that name already exists, ask if user wants to continue it or create a new one
+- Verify each artifact file exists after writing before proceeding to next

--- a/.opencode/commands/opsx-apply.md
+++ b/.opencode/commands/opsx-apply.md
@@ -1,0 +1,149 @@
+---
+description: Implement tasks from an OpenSpec change (Experimental)
+---
+
+Implement tasks from an OpenSpec change.
+
+**Input**: Optionally specify a change name (e.g., `/opsx-apply add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and use the **AskUserQuestion tool** to let the user select
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx-apply <other>`).
+
+2. **Check status to understand the schema**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
+
+3. **Get apply instructions**
+
+   ```bash
+   openspec instructions apply --change "<name>" --json
+   ```
+
+   This returns:
+   - `contextFiles`: artifact ID -> array of concrete file paths (varies by schema)
+   - Progress (total, complete, remaining)
+   - Task list with status
+   - Dynamic instruction based on current state
+
+   **Handle states:**
+   - If `state: "blocked"` (missing artifacts): show message, suggest using `/opsx-continue`
+   - If `state: "all_done"`: congratulate, suggest archive
+   - Otherwise: proceed to implementation
+
+4. **Read context files**
+
+   Read every file path listed under `contextFiles` from the apply instructions output.
+   The files depend on the schema being used:
+   - **spec-driven**: proposal, specs, design, tasks
+   - Other schemas: follow the contextFiles from CLI output
+
+5. **Show current progress**
+
+   Display:
+   - Schema being used
+   - Progress: "N/M tasks complete"
+   - Remaining tasks overview
+   - Dynamic instruction from CLI
+
+6. **Implement tasks (loop until done or blocked)**
+
+   For each pending task:
+   - Show which task is being worked on
+   - Make the code changes required
+   - Keep changes minimal and focused
+   - Mark task complete in the tasks file: `- [ ]` → `- [x]`
+   - Continue to next task
+
+   **Pause if:**
+   - Task is unclear → ask for clarification
+   - Implementation reveals a design issue → suggest updating artifacts
+   - Error or blocker encountered → report and wait for guidance
+   - User interrupts
+
+7. **On completion or pause, show status**
+
+   Display:
+   - Tasks completed this session
+   - Overall progress: "N/M tasks complete"
+   - If all done: suggest archive
+   - If paused: explain why and wait for guidance
+
+**Output During Implementation**
+
+```
+## Implementing: <change-name> (schema: <schema-name>)
+
+Working on task 3/7: <task description>
+[...implementation happening...]
+✓ Task complete
+
+Working on task 4/7: <task description>
+[...implementation happening...]
+✓ Task complete
+```
+
+**Output On Completion**
+
+```
+## Implementation Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 7/7 tasks complete ✓
+
+### Completed This Session
+- [x] Task 1
+- [x] Task 2
+...
+
+All tasks complete! You can archive this change with `/opsx-archive`.
+```
+
+**Output On Pause (Issue Encountered)**
+
+```
+## Implementation Paused
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 4/7 tasks complete
+
+### Issue Encountered
+<description of the issue>
+
+**Options:**
+1. <option 1>
+2. <option 2>
+3. Other approach
+
+What would you like to do?
+```
+
+**Guardrails**
+- Keep going through tasks until done or blocked
+- Always read context files before starting (from the apply instructions output)
+- If task is ambiguous, pause and ask before implementing
+- If implementation reveals issues, pause and suggest artifact updates
+- Keep code changes minimal and scoped to each task
+- Update task checkbox immediately after completing each task
+- Pause on errors, blockers, or unclear requirements - don't guess
+- Use contextFiles from CLI output, don't assume specific file names
+
+**Fluid Workflow Integration**
+
+This skill supports the "actions on a change" model:
+
+- **Can be invoked anytime**: Before all artifacts are done (if tasks exist), after partial implementation, interleaved with other actions
+- **Allows artifact updates**: If implementation reveals design issues, suggest updating artifacts - not phase-locked, work fluidly

--- a/.opencode/commands/opsx-archive.md
+++ b/.opencode/commands/opsx-archive.md
@@ -1,0 +1,154 @@
+---
+description: Archive a completed change in the experimental workflow
+---
+
+Archive a completed change in the experimental workflow.
+
+**Input**: Optionally specify a change name after `/opsx-archive` (e.g., `/opsx-archive add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show only active changes (not already archived).
+   Include the schema used for each change if available.
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check artifact completion status**
+
+   Run `openspec status --change "<name>" --json` to check artifact completion.
+
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used
+   - `artifacts`: List of artifacts with their status (`done` or other)
+
+   **If any artifacts are not `done`:**
+   - Display warning listing incomplete artifacts
+   - Prompt user for confirmation to continue
+   - Proceed if user confirms
+
+3. **Check task completion status**
+
+   Read the tasks file (typically `tasks.md`) to check for incomplete tasks.
+
+   Count tasks marked with `- [ ]` (incomplete) vs `- [x]` (complete).
+
+   **If incomplete tasks found:**
+   - Display warning showing count of incomplete tasks
+   - Prompt user for confirmation to continue
+   - Proceed if user confirms
+
+   **If no tasks file exists:** Proceed without task-related warning.
+
+4. **Assess delta spec sync state**
+
+   Check for delta specs at `openspec/changes/<name>/specs/`. If none exist, proceed without sync prompt.
+
+   **If delta specs exist:**
+   - Compare each delta spec with its corresponding main spec at `openspec/specs/<capability>/spec.md`
+   - Determine what changes would be applied (adds, modifications, removals, renames)
+   - Show a combined summary before prompting
+
+   **Prompt options:**
+   - If changes needed: "Sync now (recommended)", "Archive without syncing"
+   - If already synced: "Archive now", "Sync anyway", "Cancel"
+
+   If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
+
+5. **Perform the archive**
+
+   Create the archive directory if it doesn't exist:
+   ```bash
+   mkdir -p openspec/changes/archive
+   ```
+
+   Generate target name using current date: `YYYY-MM-DD-<change-name>`
+
+   **Check if target already exists:**
+   - If yes: Fail with error, suggest renaming existing archive or using different date
+   - If no: Move the change directory to archive
+
+   ```bash
+   mv openspec/changes/<name> openspec/changes/archive/YYYY-MM-DD-<name>
+   ```
+
+6. **Display summary**
+
+   Show archive completion summary including:
+   - Change name
+   - Schema that was used
+   - Archive location
+   - Spec sync status (synced / sync skipped / no delta specs)
+   - Note about any warnings (incomplete artifacts/tasks)
+
+**Output On Success**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** ✓ Synced to main specs
+
+All artifacts complete. All tasks complete.
+```
+
+**Output On Success (No Delta Specs)**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** No delta specs
+
+All artifacts complete. All tasks complete.
+```
+
+**Output On Success With Warnings**
+
+```
+## Archive Complete (with warnings)
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** Sync skipped (user chose to skip)
+
+**Warnings:**
+- Archived with 2 incomplete artifacts
+- Archived with 3 incomplete tasks
+- Delta spec sync was skipped (user chose to skip)
+
+Review the archive if this was not intentional.
+```
+
+**Output On Error (Archive Exists)**
+
+```
+## Archive Failed
+
+**Change:** <change-name>
+**Target:** openspec/changes/archive/YYYY-MM-DD-<name>/
+
+Target archive directory already exists.
+
+**Options:**
+1. Rename the existing archive
+2. Delete the existing archive if it's a duplicate
+3. Wait until a different date to archive
+```
+
+**Guardrails**
+- Always prompt for change selection if not provided
+- Use artifact graph (openspec status --json) for completion checking
+- Don't block archive on warnings - just inform and confirm
+- Preserve .openspec.yaml when moving to archive (it moves with the directory)
+- Show clear summary of what happened
+- If sync is requested, use the Skill tool to invoke `openspec-sync-specs` (agent-driven)
+- If delta specs exist, always run the sync assessment and show the combined summary before prompting

--- a/.opencode/commands/opsx-explore.md
+++ b/.opencode/commands/opsx-explore.md
@@ -1,0 +1,170 @@
+---
+description: Enter explore mode - think through ideas, investigate problems, clarify requirements
+---
+
+Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
+
+**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first and create a change proposal. You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
+
+**This is a stance, not a workflow.** There are no fixed steps, no required sequence, no mandatory outputs. You're a thinking partner helping the user explore.
+
+**Input**: The argument after `/opsx-explore` is whatever the user wants to think about. Could be:
+- A vague idea: "real-time collaboration"
+- A specific problem: "the auth system is getting unwieldy"
+- A change name: "add-dark-mode" (to explore in context of that change)
+- A comparison: "postgres vs sqlite for this"
+- Nothing (just enter explore mode)
+
+---
+
+## The Stance
+
+- **Curious, not prescriptive** - Ask questions that emerge naturally, don't follow a script
+- **Open threads, not interrogations** - Surface multiple interesting directions and let the user follow what resonates. Don't funnel them through a single path of questions.
+- **Visual** - Use ASCII diagrams liberally when they'd help clarify thinking
+- **Adaptive** - Follow interesting threads, pivot when new information emerges
+- **Patient** - Don't rush to conclusions, let the shape of the problem emerge
+- **Grounded** - Explore the actual codebase when relevant, don't just theorize
+
+---
+
+## What You Might Do
+
+Depending on what the user brings, you might:
+
+**Explore the problem space**
+- Ask clarifying questions that emerge from what they said
+- Challenge assumptions
+- Reframe the problem
+- Find analogies
+
+**Investigate the codebase**
+- Map existing architecture relevant to the discussion
+- Find integration points
+- Identify patterns already in use
+- Surface hidden complexity
+
+**Compare options**
+- Brainstorm multiple approaches
+- Build comparison tables
+- Sketch tradeoffs
+- Recommend a path (if asked)
+
+**Visualize**
+```
+┌─────────────────────────────────────────┐
+│     Use ASCII diagrams liberally        │
+├─────────────────────────────────────────┤
+│                                         │
+│      ┌────────┐         ┌────────┐      │
+│      │ State  │────────▶│ State  │      │
+│      │   A    │         │   B    │      │
+│      └────────┘         └────────┘      │
+│                                         │
+│   System diagrams, state machines,      │
+│   data flows, architecture sketches,    │
+│   dependency graphs, comparison tables  │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+**Surface risks and unknowns**
+- Identify what could go wrong
+- Find gaps in understanding
+- Suggest spikes or investigations
+
+---
+
+## OpenSpec Awareness
+
+You have full context of the OpenSpec system. Use it naturally, don't force it.
+
+### Check for context
+
+At the start, quickly check what exists:
+```bash
+openspec list --json
+```
+
+This tells you:
+- If there are active changes
+- Their names, schemas, and status
+- What the user might be working on
+
+If the user mentioned a specific change name, read its artifacts for context.
+
+### When no change exists
+
+Think freely. When insights crystallize, you might offer:
+
+- "This feels solid enough to start a change. Want me to create a proposal?"
+- Or keep exploring - no pressure to formalize
+
+### When a change exists
+
+If the user mentions a change or you detect one is relevant:
+
+1. **Read existing artifacts for context**
+   - `openspec/changes/<name>/proposal.md`
+   - `openspec/changes/<name>/design.md`
+   - `openspec/changes/<name>/tasks.md`
+   - etc.
+
+2. **Reference them naturally in conversation**
+   - "Your design mentions using Redis, but we just realized SQLite fits better..."
+   - "The proposal scopes this to premium users, but we're now thinking everyone..."
+
+3. **Offer to capture when decisions are made**
+
+    | Insight Type               | Where to Capture               |
+    |----------------------------|--------------------------------|
+    | New requirement discovered | `specs/<capability>/spec.md` |
+    | Requirement changed        | `specs/<capability>/spec.md` |
+    | Design decision made       | `design.md`                  |
+    | Scope changed              | `proposal.md`                |
+    | New work identified        | `tasks.md`                   |
+    | Assumption invalidated     | Relevant artifact              |
+
+   Example offers:
+   - "That's a design decision. Capture it in design.md?"
+   - "This is a new requirement. Add it to specs?"
+   - "This changes scope. Update the proposal?"
+
+4. **The user decides** - Offer and move on. Don't pressure. Don't auto-capture.
+
+---
+
+## What You Don't Have To Do
+
+- Follow a script
+- Ask the same questions every time
+- Produce a specific artifact
+- Reach a conclusion
+- Stay on topic if a tangent is valuable
+- Be brief (this is thinking time)
+
+---
+
+## Ending Discovery
+
+There's no required ending. Discovery might:
+
+- **Flow into a proposal**: "Ready to start? I can create a change proposal."
+- **Result in artifact updates**: "Updated design.md with these decisions"
+- **Just provide clarity**: User has what they need, moves on
+- **Continue later**: "We can pick this up anytime"
+
+When things crystallize, you might offer a summary - but it's optional. Sometimes the thinking IS the value.
+
+---
+
+## Guardrails
+
+- **Don't implement** - Never write code or implement features. Creating OpenSpec artifacts is fine, writing application code is not.
+- **Don't fake understanding** - If something is unclear, dig deeper
+- **Don't rush** - Discovery is thinking time, not task time
+- **Don't force structure** - Let patterns emerge naturally
+- **Don't auto-capture** - Offer to save insights, don't just do it
+- **Do visualize** - A good diagram is worth many paragraphs
+- **Do explore the codebase** - Ground discussions in reality
+- **Do question assumptions** - Including the user's and your own

--- a/.opencode/commands/opsx-propose.md
+++ b/.opencode/commands/opsx-propose.md
@@ -1,0 +1,103 @@
+---
+description: Propose a new change - create it and generate all artifacts in one step
+---
+
+Propose a new change - create the change and generate all artifacts in one step.
+
+I'll create a change with artifacts:
+- proposal.md (what & why)
+- design.md (how)
+- tasks.md (implementation steps)
+
+When ready to implement, run /opsx-apply
+
+---
+
+**Input**: The argument after `/opsx-propose` is the change name (kebab-case), OR a description of what the user wants to build.
+
+**Steps**
+
+1. **If no input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   This creates a scaffolded change at `openspec/changes/<name>/` with `.openspec.yaml`.
+
+3. **Get the artifact build order**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to get:
+   - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
+   - `artifacts`: list of all artifacts with their status and dependencies
+
+4. **Create artifacts in sequence until apply-ready**
+
+   Use the **TodoWrite tool** to track progress through the artifacts.
+
+   Loop through artifacts in dependency order (artifacts with no pending dependencies first):
+
+   a. **For each artifact that is `ready` (dependencies satisfied)**:
+      - Get instructions:
+        ```bash
+        openspec instructions <artifact-id> --change "<name>" --json
+        ```
+      - The instructions JSON includes:
+        - `context`: Project background (constraints for you - do NOT include in output)
+        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+        - `template`: The structure to use for your output file
+        - `instruction`: Schema-specific guidance for this artifact type
+        - `outputPath`: Where to write the artifact
+        - `dependencies`: Completed artifacts to read for context
+      - Read any completed dependency files for context
+      - Create the artifact file using `template` as the structure
+      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
+      - Show brief progress: "Created <artifact-id>"
+
+   b. **Continue until all `applyRequires` artifacts are complete**
+      - After creating each artifact, re-run `openspec status --change "<name>" --json`
+      - Check if every artifact ID in `applyRequires` has `status: "done"` in the artifacts array
+      - Stop when all `applyRequires` artifacts are done
+
+   c. **If an artifact requires user input** (unclear context):
+      - Use **AskUserQuestion tool** to clarify
+      - Then continue with creation
+
+5. **Show final status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After completing all artifacts, summarize:
+- Change name and location
+- List of artifacts created with brief descriptions
+- What's ready: "All artifacts created! Ready for implementation."
+- Prompt: "Run `/opsx-apply` to start implementing."
+
+**Artifact Creation Guidelines**
+
+- Follow the `instruction` field from `openspec instructions` for each artifact type
+- The schema defines what each artifact should contain - follow it
+- Read dependency artifacts for context before creating new ones
+- Use `template` as the structure for your output file - fill in its sections
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
+
+**Guardrails**
+- Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`)
+- Always read dependency artifacts before creating a new one
+- If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
+- If a change with that name already exists, ask if user wants to continue it or create a new one
+- Verify each artifact file exists after writing before proceeding to next

--- a/.opencode/skills/openspec-apply-change/SKILL.md
+++ b/.opencode/skills/openspec-apply-change/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: openspec-apply-change
+description: Implement tasks from an OpenSpec change. Use when the user wants to start implementing, continue implementation, or work through tasks.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.1"
+---
+
+Implement tasks from an OpenSpec change.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and use the **AskUserQuestion tool** to let the user select
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx-apply <other>`).
+
+2. **Check status to understand the schema**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
+
+3. **Get apply instructions**
+
+   ```bash
+   openspec instructions apply --change "<name>" --json
+   ```
+
+   This returns:
+   - `contextFiles`: artifact ID -> array of concrete file paths (varies by schema - could be proposal/specs/design/tasks or spec/tests/implementation/docs)
+   - Progress (total, complete, remaining)
+   - Task list with status
+   - Dynamic instruction based on current state
+
+   **Handle states:**
+   - If `state: "blocked"` (missing artifacts): show message, suggest using openspec-continue-change
+   - If `state: "all_done"`: congratulate, suggest archive
+   - Otherwise: proceed to implementation
+
+4. **Read context files**
+
+   Read every file path listed under `contextFiles` from the apply instructions output.
+   The files depend on the schema being used:
+   - **spec-driven**: proposal, specs, design, tasks
+   - Other schemas: follow the contextFiles from CLI output
+
+5. **Show current progress**
+
+   Display:
+   - Schema being used
+   - Progress: "N/M tasks complete"
+   - Remaining tasks overview
+   - Dynamic instruction from CLI
+
+6. **Implement tasks (loop until done or blocked)**
+
+   For each pending task:
+   - Show which task is being worked on
+   - Make the code changes required
+   - Keep changes minimal and focused
+   - Mark task complete in the tasks file: `- [ ]` → `- [x]`
+   - Continue to next task
+
+   **Pause if:**
+   - Task is unclear → ask for clarification
+   - Implementation reveals a design issue → suggest updating artifacts
+   - Error or blocker encountered → report and wait for guidance
+   - User interrupts
+
+7. **On completion or pause, show status**
+
+   Display:
+   - Tasks completed this session
+   - Overall progress: "N/M tasks complete"
+   - If all done: suggest archive
+   - If paused: explain why and wait for guidance
+
+**Output During Implementation**
+
+```
+## Implementing: <change-name> (schema: <schema-name>)
+
+Working on task 3/7: <task description>
+[...implementation happening...]
+✓ Task complete
+
+Working on task 4/7: <task description>
+[...implementation happening...]
+✓ Task complete
+```
+
+**Output On Completion**
+
+```
+## Implementation Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 7/7 tasks complete ✓
+
+### Completed This Session
+- [x] Task 1
+- [x] Task 2
+...
+
+All tasks complete! Ready to archive this change.
+```
+
+**Output On Pause (Issue Encountered)**
+
+```
+## Implementation Paused
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 4/7 tasks complete
+
+### Issue Encountered
+<description of the issue>
+
+**Options:**
+1. <option 1>
+2. <option 2>
+3. Other approach
+
+What would you like to do?
+```
+
+**Guardrails**
+- Keep going through tasks until done or blocked
+- Always read context files before starting (from the apply instructions output)
+- If task is ambiguous, pause and ask before implementing
+- If implementation reveals issues, pause and suggest artifact updates
+- Keep code changes minimal and scoped to each task
+- Update task checkbox immediately after completing each task
+- Pause on errors, blockers, or unclear requirements - don't guess
+- Use contextFiles from CLI output, don't assume specific file names
+
+**Fluid Workflow Integration**
+
+This skill supports the "actions on a change" model:
+
+- **Can be invoked anytime**: Before all artifacts are done (if tasks exist), after partial implementation, interleaved with other actions
+- **Allows artifact updates**: If implementation reveals design issues, suggest updating artifacts - not phase-locked, work fluidly

--- a/.opencode/skills/openspec-archive-change/SKILL.md
+++ b/.opencode/skills/openspec-archive-change/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: openspec-archive-change
+description: Archive a completed change in the experimental workflow. Use when the user wants to finalize and archive a change after implementation is complete.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.1"
+---
+
+Archive a completed change in the experimental workflow.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show only active changes (not already archived).
+   Include the schema used for each change if available.
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check artifact completion status**
+
+   Run `openspec status --change "<name>" --json` to check artifact completion.
+
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used
+   - `artifacts`: List of artifacts with their status (`done` or other)
+
+   **If any artifacts are not `done`:**
+   - Display warning listing incomplete artifacts
+   - Use **AskUserQuestion tool** to confirm user wants to proceed
+   - Proceed if user confirms
+
+3. **Check task completion status**
+
+   Read the tasks file (typically `tasks.md`) to check for incomplete tasks.
+
+   Count tasks marked with `- [ ]` (incomplete) vs `- [x]` (complete).
+
+   **If incomplete tasks found:**
+   - Display warning showing count of incomplete tasks
+   - Use **AskUserQuestion tool** to confirm user wants to proceed
+   - Proceed if user confirms
+
+   **If no tasks file exists:** Proceed without task-related warning.
+
+4. **Assess delta spec sync state**
+
+   Check for delta specs at `openspec/changes/<name>/specs/`. If none exist, proceed without sync prompt.
+
+   **If delta specs exist:**
+   - Compare each delta spec with its corresponding main spec at `openspec/specs/<capability>/spec.md`
+   - Determine what changes would be applied (adds, modifications, removals, renames)
+   - Show a combined summary before prompting
+
+   **Prompt options:**
+   - If changes needed: "Sync now (recommended)", "Archive without syncing"
+   - If already synced: "Archive now", "Sync anyway", "Cancel"
+
+   If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
+
+5. **Perform the archive**
+
+   Create the archive directory if it doesn't exist:
+   ```bash
+   mkdir -p openspec/changes/archive
+   ```
+
+   Generate target name using current date: `YYYY-MM-DD-<change-name>`
+
+   **Check if target already exists:**
+   - If yes: Fail with error, suggest renaming existing archive or using different date
+   - If no: Move the change directory to archive
+
+   ```bash
+   mv openspec/changes/<name> openspec/changes/archive/YYYY-MM-DD-<name>
+   ```
+
+6. **Display summary**
+
+   Show archive completion summary including:
+   - Change name
+   - Schema that was used
+   - Archive location
+   - Whether specs were synced (if applicable)
+   - Note about any warnings (incomplete artifacts/tasks)
+
+**Output On Success**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** ✓ Synced to main specs (or "No delta specs" or "Sync skipped")
+
+All artifacts complete. All tasks complete.
+```
+
+**Guardrails**
+- Always prompt for change selection if not provided
+- Use artifact graph (openspec status --json) for completion checking
+- Don't block archive on warnings - just inform and confirm
+- Preserve .openspec.yaml when moving to archive (it moves with the directory)
+- Show clear summary of what happened
+- If sync is requested, use openspec-sync-specs approach (agent-driven)
+- If delta specs exist, always run the sync assessment and show the combined summary before prompting

--- a/.opencode/skills/openspec-explore/SKILL.md
+++ b/.opencode/skills/openspec-explore/SKILL.md
@@ -1,0 +1,288 @@
+---
+name: openspec-explore
+description: Enter explore mode - a thinking partner for exploring ideas, investigating problems, and clarifying requirements. Use when the user wants to think through something before or during a change.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.1"
+---
+
+Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
+
+**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first and create a change proposal. You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
+
+**This is a stance, not a workflow.** There are no fixed steps, no required sequence, no mandatory outputs. You're a thinking partner helping the user explore.
+
+---
+
+## The Stance
+
+- **Curious, not prescriptive** - Ask questions that emerge naturally, don't follow a script
+- **Open threads, not interrogations** - Surface multiple interesting directions and let the user follow what resonates. Don't funnel them through a single path of questions.
+- **Visual** - Use ASCII diagrams liberally when they'd help clarify thinking
+- **Adaptive** - Follow interesting threads, pivot when new information emerges
+- **Patient** - Don't rush to conclusions, let the shape of the problem emerge
+- **Grounded** - Explore the actual codebase when relevant, don't just theorize
+
+---
+
+## What You Might Do
+
+Depending on what the user brings, you might:
+
+**Explore the problem space**
+- Ask clarifying questions that emerge from what they said
+- Challenge assumptions
+- Reframe the problem
+- Find analogies
+
+**Investigate the codebase**
+- Map existing architecture relevant to the discussion
+- Find integration points
+- Identify patterns already in use
+- Surface hidden complexity
+
+**Compare options**
+- Brainstorm multiple approaches
+- Build comparison tables
+- Sketch tradeoffs
+- Recommend a path (if asked)
+
+**Visualize**
+```
+┌─────────────────────────────────────────┐
+│     Use ASCII diagrams liberally        │
+├─────────────────────────────────────────┤
+│                                         │
+│      ┌────────┐         ┌────────┐      │
+│      │ State  │────────▶│ State  │      │
+│      │   A    │         │   B    │      │
+│      └────────┘         └────────┘      │
+│                                         │
+│   System diagrams, state machines,      │
+│   data flows, architecture sketches,    │
+│   dependency graphs, comparison tables  │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+**Surface risks and unknowns**
+- Identify what could go wrong
+- Find gaps in understanding
+- Suggest spikes or investigations
+
+---
+
+## OpenSpec Awareness
+
+You have full context of the OpenSpec system. Use it naturally, don't force it.
+
+### Check for context
+
+At the start, quickly check what exists:
+```bash
+openspec list --json
+```
+
+This tells you:
+- If there are active changes
+- Their names, schemas, and status
+- What the user might be working on
+
+### When no change exists
+
+Think freely. When insights crystallize, you might offer:
+
+- "This feels solid enough to start a change. Want me to create a proposal?"
+- Or keep exploring - no pressure to formalize
+
+### When a change exists
+
+If the user mentions a change or you detect one is relevant:
+
+1. **Read existing artifacts for context**
+   - `openspec/changes/<name>/proposal.md`
+   - `openspec/changes/<name>/design.md`
+   - `openspec/changes/<name>/tasks.md`
+   - etc.
+
+2. **Reference them naturally in conversation**
+   - "Your design mentions using Redis, but we just realized SQLite fits better..."
+   - "The proposal scopes this to premium users, but we're now thinking everyone..."
+
+3. **Offer to capture when decisions are made**
+
+    | Insight Type               | Where to Capture               |
+    |----------------------------|--------------------------------|
+    | New requirement discovered | `specs/<capability>/spec.md` |
+    | Requirement changed        | `specs/<capability>/spec.md` |
+    | Design decision made       | `design.md`                  |
+    | Scope changed              | `proposal.md`                |
+    | New work identified        | `tasks.md`                   |
+    | Assumption invalidated     | Relevant artifact              |
+
+   Example offers:
+   - "That's a design decision. Capture it in design.md?"
+   - "This is a new requirement. Add it to specs?"
+   - "This changes scope. Update the proposal?"
+
+4. **The user decides** - Offer and move on. Don't pressure. Don't auto-capture.
+
+---
+
+## What You Don't Have To Do
+
+- Follow a script
+- Ask the same questions every time
+- Produce a specific artifact
+- Reach a conclusion
+- Stay on topic if a tangent is valuable
+- Be brief (this is thinking time)
+
+---
+
+## Handling Different Entry Points
+
+**User brings a vague idea:**
+```
+User: I'm thinking about adding real-time collaboration
+
+You: Real-time collab is a big space. Let me think about this...
+
+      COLLABORATION SPECTRUM
+      ════════════════════════════════════════════
+
+      Awareness          Coordination         Sync
+          │                   │                 │
+          ▼                   ▼                 ▼
+      ┌────────┐         ┌────────┐        ┌────────┐
+      │Presence│         │Cursors │        │  CRDT  │
+      │  "3    │         │ Multi  │        │Conflict│
+      │online" │         │ select │        │  free  │
+      └────────┘         └────────┘        └────────┘
+          │                   │                 │
+       trivial            moderate           complex
+
+      Where's your head at?
+```
+
+**User brings a specific problem:**
+```
+User: The auth system is a mess
+
+You: [reads codebase]
+
+     ┌─────────────────────────────────────────────┐
+     │              CURRENT AUTH FLOW              │
+     └─────────────────────────────────────────────┘
+                        │
+          ┌─────────────┼─────────────┐
+          ▼             ▼             ▼
+     ┌─────────┐  ┌─────────┐  ┌─────────┐
+     │ Google  │  │  GitHub │  │  Email  │
+     │  OAuth  │  │  OAuth  │  │  Magic  │
+     └────┬────┘  └────┬────┘  └────┬────┘
+          │             │             │
+          └─────────────┼─────────────┘
+                        ▼
+                  ┌───────────┐
+                  │  Session  │
+                  └─────┬─────┘
+                        │
+                        ▼
+                  ┌───────────┐
+                  │   Perms   │
+                  └───────────┘
+
+     I see three tangles. Which one's burning?
+```
+
+**User is stuck mid-implementation:**
+```
+User: /opsx-explore add-auth-system
+      The OAuth integration is more complex than expected
+
+You: [reads change artifacts]
+
+     You're on task 4: "Implement OAuth flow"
+
+     Let me trace what's involved...
+
+     [draws diagram, explores options, suggests paths]
+
+     Want to update the design to reflect this?
+     Or add a spike task to investigate?
+```
+
+**User wants to compare options:**
+```
+User: Should we use Postgres or SQLite?
+
+You: Generic answer is boring. What's the context?
+
+User: A CLI tool that tracks local dev environments
+
+You: That changes everything.
+
+     ┌─────────────────────────────────────────────────┐
+     │          CLI TOOL DATA STORAGE                  │
+     └─────────────────────────────────────────────────┘
+
+     Key constraints:
+     • No daemon running
+     • Must work offline
+     • Single user
+
+                  SQLite          Postgres
+     Deployment   embedded ✓      needs server ✗
+     Offline      yes ✓           no ✗
+     Single file  yes ✓           no ✗
+
+     SQLite. Not even close.
+
+     Unless... is there a sync component?
+```
+
+---
+
+## Ending Discovery
+
+There's no required ending. Discovery might:
+
+- **Flow into a proposal**: "Ready to start? I can create a change proposal."
+- **Result in artifact updates**: "Updated design.md with these decisions"
+- **Just provide clarity**: User has what they need, moves on
+- **Continue later**: "We can pick this up anytime"
+
+When it feels like things are crystallizing, you might summarize:
+
+```
+## What We Figured Out
+
+**The problem**: [crystallized understanding]
+
+**The approach**: [if one emerged]
+
+**Open questions**: [if any remain]
+
+**Next steps** (if ready):
+- Create a change proposal
+- Keep exploring: just keep talking
+```
+
+But this summary is optional. Sometimes the thinking IS the value.
+
+---
+
+## Guardrails
+
+- **Don't implement** - Never write code or implement features. Creating OpenSpec artifacts is fine, writing application code is not.
+- **Don't fake understanding** - If something is unclear, dig deeper
+- **Don't rush** - Discovery is thinking time, not task time
+- **Don't force structure** - Let patterns emerge naturally
+- **Don't auto-capture** - Offer to save insights, don't just do it
+- **Do visualize** - A good diagram is worth many paragraphs
+- **Do explore the codebase** - Ground discussions in reality
+- **Do question assumptions** - Including the user's and your own

--- a/.opencode/skills/openspec-propose/SKILL.md
+++ b/.opencode/skills/openspec-propose/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: openspec-propose
+description: Propose a new change with all artifacts generated in one step. Use when the user wants to quickly describe what they want to build and get a complete proposal with design, specs, and tasks ready for implementation.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.1"
+---
+
+Propose a new change - create the change and generate all artifacts in one step.
+
+I'll create a change with artifacts:
+- proposal.md (what & why)
+- design.md (how)
+- tasks.md (implementation steps)
+
+When ready to implement, run /opsx-apply
+
+---
+
+**Input**: The user's request should include a change name (kebab-case) OR a description of what they want to build.
+
+**Steps**
+
+1. **If no clear input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   This creates a scaffolded change at `openspec/changes/<name>/` with `.openspec.yaml`.
+
+3. **Get the artifact build order**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to get:
+   - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
+   - `artifacts`: list of all artifacts with their status and dependencies
+
+4. **Create artifacts in sequence until apply-ready**
+
+   Use the **TodoWrite tool** to track progress through the artifacts.
+
+   Loop through artifacts in dependency order (artifacts with no pending dependencies first):
+
+   a. **For each artifact that is `ready` (dependencies satisfied)**:
+      - Get instructions:
+        ```bash
+        openspec instructions <artifact-id> --change "<name>" --json
+        ```
+      - The instructions JSON includes:
+        - `context`: Project background (constraints for you - do NOT include in output)
+        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+        - `template`: The structure to use for your output file
+        - `instruction`: Schema-specific guidance for this artifact type
+        - `outputPath`: Where to write the artifact
+        - `dependencies`: Completed artifacts to read for context
+      - Read any completed dependency files for context
+      - Create the artifact file using `template` as the structure
+      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
+      - Show brief progress: "Created <artifact-id>"
+
+   b. **Continue until all `applyRequires` artifacts are complete**
+      - After creating each artifact, re-run `openspec status --change "<name>" --json`
+      - Check if every artifact ID in `applyRequires` has `status: "done"` in the artifacts array
+      - Stop when all `applyRequires` artifacts are done
+
+   c. **If an artifact requires user input** (unclear context):
+      - Use **AskUserQuestion tool** to clarify
+      - Then continue with creation
+
+5. **Show final status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After completing all artifacts, summarize:
+- Change name and location
+- List of artifacts created with brief descriptions
+- What's ready: "All artifacts created! Ready for implementation."
+- Prompt: "Run `/opsx-apply` or ask me to implement to start working on the tasks."
+
+**Artifact Creation Guidelines**
+
+- Follow the `instruction` field from `openspec instructions` for each artifact type
+- The schema defines what each artifact should contain - follow it
+- Read dependency artifacts for context before creating new ones
+- Use `template` as the structure for your output file - fill in its sections
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
+
+**Guardrails**
+- Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`)
+- Always read dependency artifacts before creating a new one
+- If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
+- If a change with that name already exists, ask if user wants to continue it or create a new one
+- Verify each artifact file exists after writing before proceeding to next

--- a/openspec/changes/migrate-to-upstream-openspec/tasks.md
+++ b/openspec/changes/migrate-to-upstream-openspec/tasks.md
@@ -12,12 +12,12 @@ depends_on_plans: []
 
 # Tasks: openspec-improvements-batch (T001267)
 
-- [ ] Task 0: Write failing tests in `tests/spec/openspec-workflow.bats`; run `bats tests/spec/openspec-workflow.bats` to verify it fails before any changes (expected: FAIL on all three guards)
-- [ ] Task 1 (T001261-a): Investigate each of the 11 stub specs — backfill from archive or delete
-- [ ] Task 2 (T001261-b): Backfill confirmed stubs from `openspec/changes/archive/<date>-<slug>/tasks.md`; delete phantom spec+change pairs
-- [ ] Task 3 (T001261-c): Bulk-add `## Purpose` + `## Requirements` H2 headers to all 60 SSOT specs via awk pass; manual review of every changed spec
-- [ ] Task 4 (T001261-d): Update `scripts/openspec-validate.ts` to enforce `## Purpose` and `## Requirements`; run `task test:openspec` — expected: PASS
-- [ ] Task 5 (T001261-e): Open PR `chore(openspec): backfill 11 SSOT stubs + add Purpose/Requirements headers [T001261]`; merge after CI green
+- [x] Task 0: Write failing tests in `tests/spec/openspec-workflow.bats`; run `bats tests/spec/openspec-workflow.bats` to verify it fails before any changes (expected: FAIL on all three guards)
+- [x] Task 1 (T001261-a): Investigate each of the 11 stub specs — backfill from archive or delete
+- [x] Task 2 (T001261-b): Backfill confirmed stubs from `openspec/changes/archive/<date>-<slug>/tasks.md`; delete phantom spec+change pairs
+- [x] Task 3 (T001261-c): Bulk-add `## Purpose` + `## Requirements` H2 headers to all 60 SSOT specs via awk pass; manual review of every changed spec
+- [x] Task 4 (T001261-d): Update `scripts/openspec-validate.ts` to enforce `## Purpose` and `## Requirements`; run `task test:openspec` — expected: PASS
+- [x] Task 5 (T001261-e): Open PR `chore(openspec): backfill 11 SSOT stubs + add Purpose/Requirements headers [T001261]`; merge after CI green
 - [ ] Task 6 (T001263-a): Run `openspec init --tools opencode,claude --profile core --force`; verify 4 `.opencode/commands/opsx-*.md` + 4 `.claude/skills/openspec-*/SKILL.md` created
 - [ ] Task 7 (T001263-b): Update `.claude/skills/dev-flow-plan/SKILL.md` — replace `task openspec:propose` with `/opsx:propose`
 - [ ] Task 8 (T001263-c): Update `.claude/skills/dev-flow-execute/SKILL.md` — replace `task openspec:apply` with `/opsx:apply`

--- a/openspec/changes/migrate-to-upstream-openspec/tasks.md
+++ b/openspec/changes/migrate-to-upstream-openspec/tasks.md
@@ -1,289 +1,73 @@
+# Tasks: OpenSpec improvements batch (T001267 umbrella)
+
+_Umbrella for: T001261, T001263, T001264 (done), T001265. Out of scope: T001262 + T001266 (parked)._
+_Factory input format: `- [ ]` checkboxes, hierarchical numbering per ticket._
+
+## T001261 — Backfill SSOT specs (hoch, mittel)
+
+- [ ] 1.1 Investigate each of the 11 stub specs; for each, decide: backfill (source from archive) OR delete (work never done)
+- [ ] 1.2 For each backfill target, read the corresponding `openspec/changes/archive/<date>-<slug>/tasks.md` + delta
+- [ ] 1.3 Rewrite each stub spec with real Requirements/Scenarios; cite the source as `<!-- from archive/.../tasks.md line N -->` comments
+- [ ] 1.4 For each delete target, remove the spec file and any associated change folder (do NOT touch archived changes)
+- [ ] 1.5 Run a sed/awk pass to wrap the intro paragraph of all 60 specs in `## Purpose` H2
+- [ ] 1.6 Run a second pass to add `## Requirements` H2 before the first `### Requirement:` in each spec
+- [ ] 1.7 Manual review of every modified spec; `git diff openspec/specs/` before commit
+- [ ] 1.8 Update `scripts/openspec-validate.ts` to require `## Purpose` and `## Requirements` H2 (so future stubs can't slip through)
+- [ ] 1.9 `task test:openspec` still passes
+- [ ] 1.10 Open PR: `chore(openspec): backfill 11 SSOT stubs + add Purpose/Requirements headers [T001261]`
+
+## T001263 — Install /opsx:* workflow commands (mittel, klein)
+
+- [ ] 2.1 (host setup, not committed) `npm i -g @fission-ai/openspec@1.3.1`
+- [ ] 2.2 `openspec init --tools opencode,claude --profile core --force`
+- [ ] 2.3 Verify 4 files in `.opencode/commands/opsx-*.md`
+- [ ] 2.4 Verify 4 dirs in `.claude/skills/openspec-*/SKILL.md`
+- [ ] 2.5 `openspec config list` — confirm `profile: core`, `workflows: propose,explore,apply,archive`
+- [ ] 2.6 Update `.agents/skills/dev-flow-plan/SKILL.md` — replace `task openspec:propose` reference with `/opsx:propose`
+- [ ] 2.7 Update `.agents/skills/dev-flow-execute/SKILL.md` — replace `task openspec:apply` reference with `/opsx:apply`
+- [ ] 2.8 Smoke test in a worktree: invoke `/opsx:propose` via agent prompt path; confirm change dir is created
+- [ ] 2.9 Open PR: `feat(openspec): install upstream workflow commands in .opencode + .claude [T001263]`
+
+## T001264 — Remove openspec-mcp + delete project.md (niedrig) [DONE 2026-06-27]
+
+- [x] 3.1 Remove `openspec` entry from `.opencode/opencode.jsonc`
+- [x] 3.2 Remove `openspec` entry from `.mcp.json`
+- [x] 3.3 Delete `openspec/project.md`
+- [x] 3.4 Transition T001264 → `done` with `resolution: shipped`
+- [x] 3.5 Commit: `chore(openspec): remove unused openspec-mcp + delete dead project.md [T001264]` (commit cdc8d61f)
+
+## T001265 — Polish (niedrig, klein)
+
+- [ ] 4.1 Document the frontmatter convention in `AGENTS.md` (new "OpenSpec conventions" section)
+- [ ] 4.2 Add to `openspec/config.yaml:rules:`:
+    - `specs: ["Purpose auf Deutsch, Requirements auf Englisch, Scenarios auf Englisch (GIVEN/WHEN/THEN)"]`
+    - `design: ["Goals/Non-Goals explizit trennen", "Decisions mit Begründung"]`
+- [ ] 4.3 Audit all `.github/workflows/*.yml` for missing `OPENSPEC_TELEMETRY: '0'` env; add to each (workflow-level or per-job)
+- [ ] 4.4 Add `openspec completion install` note to `AGENTS.md` under a new "Dev experience" section
+- [ ] 4.5 `task test:openspec` still passes
+- [ ] 4.6 Open PR: `chore(openspec): polish — frontmatter convention, rules, telemetry opt-out, completions [T001265]`
+
+## Out of scope (parked)
+
+- T001262 — Adopt upstream CLI (user instruction 2026-06-27: "leave as is for now")
+- T001266 — Rewrite `openspec-workflow.md` SSOT (depends on T001262)
+
+## Verification (after all PRs merge)
+
+- [ ] `task test:openspec` passes
+- [ ] `task test:changed` passes
+- [ ] `task freshness:check` passes
+- [ ] Manual review: in opencode, `/opsx:propose "test" --ticket T000001` (with a test ticket) creates `openspec/changes/test/specs/test.md` with non-stub content within 1 minute
+- [ ] `task openspec:archive` (the bash wrapper) is still callable as a backward-compat fallback
+
 ---
-title: "OpenSpec improvements batch: backfill + /opsx:* commands + polish [T001267]"
-ticket_id: T001267
-domains: [openspec, ci, docs, tooling]
-status: plan_staged
-file_locks: []
-shared_changes: false
-batch_id: null
-parent_feature: null
-depends_on_plans: []
----
 
-# Tasks: openspec-improvements-batch (T001267)
+## Rollback
 
-- [ ] Task 0: Write failing tests in `tests/spec/openspec-workflow.bats`; run `bats tests/spec/openspec-workflow.bats` to verify it fails before any changes (expected: FAIL on all three guards)
-- [ ] Task 1 (T001261-a): Investigate each of the 11 stub specs — backfill from archive or delete
-- [ ] Task 2 (T001261-b): Backfill confirmed stubs from `openspec/changes/archive/<date>-<slug>/tasks.md`; delete phantom spec+change pairs
-- [ ] Task 3 (T001261-c): Bulk-add `## Purpose` + `## Requirements` H2 headers to all 60 SSOT specs via awk pass; manual review of every changed spec
-- [ ] Task 4 (T001261-d): Update `scripts/openspec-validate.ts` to enforce `## Purpose` and `## Requirements`; run `task test:openspec` — expected: PASS
-- [ ] Task 5 (T001261-e): Open PR `chore(openspec): backfill 11 SSOT stubs + add Purpose/Requirements headers [T001261]`; merge after CI green
-- [ ] Task 6 (T001263-a): Run `openspec init --tools opencode,claude --profile core --force`; verify 4 `.opencode/commands/opsx-*.md` + 4 `.claude/skills/openspec-*/SKILL.md` created
-- [ ] Task 7 (T001263-b): Update `.claude/skills/dev-flow-plan/SKILL.md` — replace `task openspec:propose` with `/opsx:propose`
-- [ ] Task 8 (T001263-c): Update `.claude/skills/dev-flow-execute/SKILL.md` — replace `task openspec:apply` with `/opsx:apply`
-- [ ] Task 9 (T001263-d): Open PR `feat(openspec): install upstream workflow commands in .opencode + .claude [T001263]`; merge after CI green
-- [ ] Task 10 (T001265-a): Add `specs:` and `design:` keys to `openspec/config.yaml` under `rules:`
-- [ ] Task 11 (T001265-b): Add `OPENSPEC_TELEMETRY: '0'` to workflow-level `env:` in every `.github/workflows/*.yml`
-- [ ] Task 12 (T001265-c): Add "OpenSpec conventions" + "Dev experience" subsections to `AGENTS.md`
-- [ ] Task 13 (T001265-d): Open PR `chore(openspec): polish — frontmatter convention, rules, telemetry opt-out, completions [T001265]`; merge after CI green
-- [ ] Task 14 (Verify): `task test:changed` + `task freshness:regenerate` + `task freshness:check` + `task test:openspec` — all green; `task openspec:validate` — no errors
-
----
-
-# OpenSpec Improvements Batch — Implementation Plan
-
-> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:executing-plans
-
-**Goal:** Three independent improvements to the OpenSpec workflow, executed sequentially and shipped as three separate PRs.
-Sub-tickets: T001261 (backfill SSOT stubs + add Purpose/Requirements headers), T001263 (install /opsx:* commands), T001265 (polish: config.yaml rules, CI telemetry opt-out, AGENTS.md docs).
-T001264 is already shipped (commit cdc8d61f). T001262 + T001266 are parked per user instruction 2026-06-27.
-
-**Architecture:** All changes are content + config — no runtime code paths affected.
-Batch executes sequentially: T001261 PR → merge → T001263 PR → merge → T001265 PR → merge.
-Between PRs: pull main to keep the worktree current.
-
-## File Structure
-
-### New files
-- `tests/spec/openspec-workflow.bats` — BATS guards for all three acceptance criteria
-- `.opencode/commands/opsx-propose.md` — upstream propose workflow command
-- `.opencode/commands/opsx-explore.md` — upstream explore workflow command
-- `.opencode/commands/opsx-apply.md` — upstream apply workflow command
-- `.opencode/commands/opsx-archive.md` — upstream archive workflow command
-- `.claude/skills/openspec-propose/SKILL.md` — claude skill for propose
-- `.claude/skills/openspec-explore/SKILL.md` — claude skill for explore
-- `.claude/skills/openspec-apply/SKILL.md` — claude skill for apply
-- `.claude/skills/openspec-archive/SKILL.md` — claude skill for archive
-
-### Modified files
-- `openspec/specs/*.md` — 60 files: add `## Purpose` + `## Requirements` H2 headers; 11 stubs replaced or deleted
-- `scripts/openspec-validate.ts` (77 → ~120 lines; S1-budget vs. limit 600 = budget 523)
-- `.claude/skills/dev-flow-plan/SKILL.md` — reference `/opsx:propose` instead of `task openspec:propose`
-- `.claude/skills/dev-flow-execute/SKILL.md` — reference `/opsx:apply` instead of `task openspec:apply`
-- `openspec/config.yaml` — add `specs:` and `design:` keys under `rules:` (ungated .yaml)
-- `.github/workflows/*.yml` — 21 files, add `OPENSPEC_TELEMETRY: '0'` workflow-level env (ungated .yml)
-- `AGENTS.md` — 2 new subsections: "OpenSpec conventions" + "Dev experience" (ungated .md)
-
-## Task 0 — Failing tests (RED phase)
-
-Write `tests/spec/openspec-workflow.bats` with three guards before making any other changes. Run `bats tests/spec/openspec-workflow.bats` to verify it fails before changes (expected: FAIL on all three guards):
+Each ticket is a self-contained PR. To roll back:
 
 ```bash
-#!/usr/bin/env bats
-# tests/spec/openspec-workflow.bats
-# SSOT: openspec/specs/openspec-workflow.md
-
-REPO="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
-
-@test "T001261: all SSOT specs declare a ## Purpose header" {
-  local missing=0
-  for f in "$REPO"/openspec/specs/*.md; do
-    grep -q '^## Purpose' "$f" || { echo "MISSING: $f"; missing=1; }
-  done
-  [ "$missing" -eq 0 ]
-}
-
-@test "T001263: opsx-propose command is installed for opencode" {
-  [ -f "$REPO/.opencode/commands/opsx-propose.md" ]
-}
-
-@test "T001265: CI workflows opt out of OpenSpec telemetry" {
-  local missing=0
-  for f in "$REPO"/.github/workflows/*.yml; do
-    grep -q 'OPENSPEC_TELEMETRY' "$f" || { echo "MISSING: $f"; missing=1; }
-  done
-  [ "$missing" -eq 0 ]
-}
+git revert <merge-commit-sha>
 ```
 
-Run: `bats tests/spec/openspec-workflow.bats` — expected: FAIL on all three guards before any changes.
-Commit the test file alone so the CI baseline shows red.
-
-## Task 1 — T001261-a: Stub investigation
-
-For each of the 11 stub specs listed in `design.md`, determine the action:
-
-| Spec | Archive match | Action |
-|------|---------------|--------|
-| `active-sessions-hub.md` | `archive/2026-06-21-active-sessions-hub` | backfill |
-| `cockpit-direct-ticket-links.md` | `archive/2026-06-21-cockpit-direct-ticket-links` | backfill |
-| `openspec-pgvector.md` | `archive/2026-06-21-openspec-pgvector` | backfill |
-| `t1224-lockfile-drift.md` | `archive/2026-06-27-t1224-lockfile-drift` | backfill |
-| `ci-speed.md` | none | investigate → decide |
-| `fix-coaching-studio-prod-manifest.md` | none | investigate → decide |
-| `korczewski-monolith-keycloak-auth.md` | none | investigate → decide |
-| `openspec-ticket-detail-view.md` | none | investigate → decide |
-| `secrets-deploy-automation.md` | none | investigate → decide |
-| `sidekick-ai-quality.md` | none | investigate → decide |
-| `sidekick-cleanup-grilling-broadcast.md` | none | investigate → decide |
-
-For the "investigate → decide" group: if no archived change and no git history for the spec, delete. If git log shows real work ever happened, backfill from commits.
-
-## Task 2 — T001261-b: Backfill or delete stubs
-
-For each **backfill** target: read `openspec/changes/archive/<date>-<slug>/tasks.md` plus any delta spec. Rewrite the SSOT spec with real Requirements/Scenarios. Cite source as HTML comment (`<!-- from archive/... line N -->`).
-
-For each **delete** target: remove `openspec/specs/<name>.md` and its associated `openspec/changes/archive/<date>-<slug>/` folder if one exists. Do NOT touch other archived changes.
-
-Commit: `chore(openspec): stub audit — backfill N + delete M [T001261]`.
-
-## Task 3 — T001261-c: Bulk header injection
-
-Run an awk pass over all 60 specs in `openspec/specs/`. Each spec gets `## Purpose` before the first paragraph after the H1 title, and `## Requirements` before the first `### Requirement:` line.
-
-```bash
-# Dry-run first to review diffs:
-bash scripts/openspec-header-inject.sh --dry-run openspec/specs/
-# Then apply:
-bash scripts/openspec-header-inject.sh openspec/specs/
-```
-
-Write `scripts/openspec-header-inject.sh` as a one-shot helper (awk-based). After application:
-- `git diff --stat openspec/specs/` — should show exactly the 60 spec files modified, no others
-- Manual review: scan each diff for broken formatting before commit
-
-Commit: `chore(openspec): add Purpose + Requirements H2 to all 60 SSOT specs [T001261]`.
-
-## Task 4 — T001261-d: Validator enforcement
-
-Update `scripts/openspec-validate.ts` to assert that every `openspec/specs/*.md` file contains `^## Purpose` and `^## Requirements` lines. Add a new check after the existing stub detection:
-
-```typescript
-// New validator assertions (add after existing checks):
-if (!content.includes('\n## Purpose\n')) {
-  errors.push(`${specFile}: missing ## Purpose header`);
-}
-if (!content.includes('\n## Requirements\n')) {
-  errors.push(`${specFile}: missing ## Requirements header`);
-}
-```
-
-Run `task test:openspec` — expected: PASS (all specs were updated in Task 3).
-
-## Task 5 — T001261-e: Open PR
-
-```bash
-git push origin chore/openspec-improvements-batch
-gh pr create \
-  --title "chore(openspec): backfill 11 SSOT stubs + add Purpose/Requirements headers [T001261]" \
-  --body "$(cat openspec/changes/migrate-to-upstream-openspec/design.md | head -44)" \
-  --base main
-```
-
-Wait for CI green. Merge: `gh pr merge --squash --auto <pr-number>`. Pull main into worktree before proceeding to T001263.
-
-## Task 6 — T001263-a: Install upstream commands
-
-Install the upstream CLI on the host (one-time, not committed):
-```bash
-npm i -g @fission-ai/openspec@1.3.1
-```
-
-Run init in the repo root (committed):
-```bash
-openspec init --tools opencode,claude --profile core --force
-```
-
-Verify outputs:
-- `ls .opencode/commands/opsx-*.md` — 4 files
-- `ls .claude/skills/openspec-*/SKILL.md` — 4 files
-- `openspec config list` — shows `profile: core`
-
-Commit: `feat(openspec): install upstream /opsx:* workflow commands [T001263]`.
-
-## Task 7 — T001263-b: Update dev-flow-plan skill
-
-In `.claude/skills/dev-flow-plan/SKILL.md`, replace every reference to `task openspec:propose -- <slug>` or `bash scripts/openspec.sh propose` with `/opsx:propose <slug>`. Keep the existing `bash scripts/openspec.sh` fallback note in a code comment.
-
-## Task 8 — T001263-c: Update dev-flow-execute skill
-
-In `.claude/skills/dev-flow-execute/SKILL.md`, replace every reference to `task openspec:apply` with `/opsx:apply`. Keep `task openspec:apply` as fallback note.
-
-Commit both skill updates with Task 6 in one commit: `feat(openspec): update dev-flow skills to use /opsx:* commands [T001263]`.
-
-## Task 9 — T001263-d: Open PR
-
-```bash
-gh pr create \
-  --title "feat(openspec): install upstream workflow commands in .opencode + .claude [T001263]" \
-  --base main
-```
-
-Wait for CI green. Merge. Pull main into worktree before proceeding to T001265.
-
-## Task 10 — T001265-a: Expand config.yaml rules
-
-Add two new rule categories to `openspec/config.yaml` under the existing `rules:` key:
-
-```yaml
-  specs:
-    - Purpose auf Deutsch, Requirements auf Englisch, Scenarios auf Englisch (GIVEN/WHEN/THEN)
-  design:
-    - Goals/Non-Goals explizit trennen
-    - Decisions mit Begründung und ggf. Trade-offs
-```
-
-## Task 11 — T001265-b: CI telemetry opt-out
-
-For every `.github/workflows/*.yml` that does not already have `OPENSPEC_TELEMETRY`:
-
-```bash
-# Check which files are missing it:
-grep -rL 'OPENSPEC_TELEMETRY' .github/workflows/*.yml
-```
-
-For each missing file, add at the top-level `env:` block (or create one):
-```yaml
-env:
-  OPENSPEC_TELEMETRY: '0'
-```
-
-## Task 12 — T001265-c: Update AGENTS.md
-
-Add two subsections to `AGENTS.md`. Insert after the existing "Development workflow" section:
-
-```markdown
-### OpenSpec conventions
-
-Proposal and task files may include YAML frontmatter (parsed by `scripts/openspec-embed.mjs`).
-Language: Purpose sections in German; Requirements and Scenarios in English (GIVEN/WHEN/THEN).
-Rule source: `openspec/config.yaml` (keys: `proposal`, `tasks`, `specs`, `design`).
-
-### Dev experience
-
-After installing the OpenSpec CLI (`npm i -g @fission-ai/openspec@1.3.1`),
-run `openspec completion install` once to enable shell completions (bash/zsh/fish/powershell).
-```
-
-Commit: `chore(openspec): polish — config rules, telemetry opt-out, AGENTS.md [T001265]`.
-
-## Task 13 — T001265-d: Open PR
-
-```bash
-gh pr create \
-  --title "chore(openspec): polish — frontmatter convention, rules, telemetry opt-out, completions [T001265]" \
-  --base main
-```
-
-Wait for CI green. Merge.
-
-## Task 14 — Verify
-
-After all three PRs are merged and main is pulled:
-
-```bash
-task test:changed
-task freshness:regenerate
-task freshness:check
-task test:openspec
-bash scripts/openspec.sh validate
-```
-
-All commands must exit 0. Update `openspec/changes/migrate-to-upstream-openspec/.ticket` status to `done` via `bash scripts/ticket.sh update-status --id T001267 --status done`.
-
-Also update each sub-ticket:
-```bash
-bash scripts/ticket.sh update-status --id T001261 --status done
-bash scripts/ticket.sh update-status --id T001263 --status done
-bash scripts/ticket.sh update-status --id T001265 --status done
-```
+No cross-PR dependencies. T001261 is the highest priority because the upstream migration (T001262) becomes safer once it lands.

--- a/openspec/changes/migrate-to-upstream-openspec/tasks.md
+++ b/openspec/changes/migrate-to-upstream-openspec/tasks.md
@@ -1,73 +1,289 @@
-# Tasks: OpenSpec improvements batch (T001267 umbrella)
+---
+title: "OpenSpec improvements batch: backfill + /opsx:* commands + polish [T001267]"
+ticket_id: T001267
+domains: [openspec, ci, docs, tooling]
+status: plan_staged
+file_locks: []
+shared_changes: false
+batch_id: null
+parent_feature: null
+depends_on_plans: []
+---
 
-_Umbrella for: T001261, T001263, T001264 (done), T001265. Out of scope: T001262 + T001266 (parked)._
-_Factory input format: `- [ ]` checkboxes, hierarchical numbering per ticket._
+# Tasks: openspec-improvements-batch (T001267)
 
-## T001261 — Backfill SSOT specs (hoch, mittel)
-
-- [ ] 1.1 Investigate each of the 11 stub specs; for each, decide: backfill (source from archive) OR delete (work never done)
-- [ ] 1.2 For each backfill target, read the corresponding `openspec/changes/archive/<date>-<slug>/tasks.md` + delta
-- [ ] 1.3 Rewrite each stub spec with real Requirements/Scenarios; cite the source as `<!-- from archive/.../tasks.md line N -->` comments
-- [ ] 1.4 For each delete target, remove the spec file and any associated change folder (do NOT touch archived changes)
-- [ ] 1.5 Run a sed/awk pass to wrap the intro paragraph of all 60 specs in `## Purpose` H2
-- [ ] 1.6 Run a second pass to add `## Requirements` H2 before the first `### Requirement:` in each spec
-- [ ] 1.7 Manual review of every modified spec; `git diff openspec/specs/` before commit
-- [ ] 1.8 Update `scripts/openspec-validate.ts` to require `## Purpose` and `## Requirements` H2 (so future stubs can't slip through)
-- [ ] 1.9 `task test:openspec` still passes
-- [ ] 1.10 Open PR: `chore(openspec): backfill 11 SSOT stubs + add Purpose/Requirements headers [T001261]`
-
-## T001263 — Install /opsx:* workflow commands (mittel, klein)
-
-- [ ] 2.1 (host setup, not committed) `npm i -g @fission-ai/openspec@1.3.1`
-- [ ] 2.2 `openspec init --tools opencode,claude --profile core --force`
-- [ ] 2.3 Verify 4 files in `.opencode/commands/opsx-*.md`
-- [ ] 2.4 Verify 4 dirs in `.claude/skills/openspec-*/SKILL.md`
-- [ ] 2.5 `openspec config list` — confirm `profile: core`, `workflows: propose,explore,apply,archive`
-- [ ] 2.6 Update `.agents/skills/dev-flow-plan/SKILL.md` — replace `task openspec:propose` reference with `/opsx:propose`
-- [ ] 2.7 Update `.agents/skills/dev-flow-execute/SKILL.md` — replace `task openspec:apply` reference with `/opsx:apply`
-- [ ] 2.8 Smoke test in a worktree: invoke `/opsx:propose` via agent prompt path; confirm change dir is created
-- [ ] 2.9 Open PR: `feat(openspec): install upstream workflow commands in .opencode + .claude [T001263]`
-
-## T001264 — Remove openspec-mcp + delete project.md (niedrig) [DONE 2026-06-27]
-
-- [x] 3.1 Remove `openspec` entry from `.opencode/opencode.jsonc`
-- [x] 3.2 Remove `openspec` entry from `.mcp.json`
-- [x] 3.3 Delete `openspec/project.md`
-- [x] 3.4 Transition T001264 → `done` with `resolution: shipped`
-- [x] 3.5 Commit: `chore(openspec): remove unused openspec-mcp + delete dead project.md [T001264]` (commit cdc8d61f)
-
-## T001265 — Polish (niedrig, klein)
-
-- [ ] 4.1 Document the frontmatter convention in `AGENTS.md` (new "OpenSpec conventions" section)
-- [ ] 4.2 Add to `openspec/config.yaml:rules:`:
-    - `specs: ["Purpose auf Deutsch, Requirements auf Englisch, Scenarios auf Englisch (GIVEN/WHEN/THEN)"]`
-    - `design: ["Goals/Non-Goals explizit trennen", "Decisions mit Begründung"]`
-- [ ] 4.3 Audit all `.github/workflows/*.yml` for missing `OPENSPEC_TELEMETRY: '0'` env; add to each (workflow-level or per-job)
-- [ ] 4.4 Add `openspec completion install` note to `AGENTS.md` under a new "Dev experience" section
-- [ ] 4.5 `task test:openspec` still passes
-- [ ] 4.6 Open PR: `chore(openspec): polish — frontmatter convention, rules, telemetry opt-out, completions [T001265]`
-
-## Out of scope (parked)
-
-- T001262 — Adopt upstream CLI (user instruction 2026-06-27: "leave as is for now")
-- T001266 — Rewrite `openspec-workflow.md` SSOT (depends on T001262)
-
-## Verification (after all PRs merge)
-
-- [ ] `task test:openspec` passes
-- [ ] `task test:changed` passes
-- [ ] `task freshness:check` passes
-- [ ] Manual review: in opencode, `/opsx:propose "test" --ticket T000001` (with a test ticket) creates `openspec/changes/test/specs/test.md` with non-stub content within 1 minute
-- [ ] `task openspec:archive` (the bash wrapper) is still callable as a backward-compat fallback
+- [ ] Task 0: Write failing tests in `tests/spec/openspec-workflow.bats`; run `bats tests/spec/openspec-workflow.bats` to verify it fails before any changes (expected: FAIL on all three guards)
+- [ ] Task 1 (T001261-a): Investigate each of the 11 stub specs — backfill from archive or delete
+- [ ] Task 2 (T001261-b): Backfill confirmed stubs from `openspec/changes/archive/<date>-<slug>/tasks.md`; delete phantom spec+change pairs
+- [ ] Task 3 (T001261-c): Bulk-add `## Purpose` + `## Requirements` H2 headers to all 60 SSOT specs via awk pass; manual review of every changed spec
+- [ ] Task 4 (T001261-d): Update `scripts/openspec-validate.ts` to enforce `## Purpose` and `## Requirements`; run `task test:openspec` — expected: PASS
+- [ ] Task 5 (T001261-e): Open PR `chore(openspec): backfill 11 SSOT stubs + add Purpose/Requirements headers [T001261]`; merge after CI green
+- [ ] Task 6 (T001263-a): Run `openspec init --tools opencode,claude --profile core --force`; verify 4 `.opencode/commands/opsx-*.md` + 4 `.claude/skills/openspec-*/SKILL.md` created
+- [ ] Task 7 (T001263-b): Update `.claude/skills/dev-flow-plan/SKILL.md` — replace `task openspec:propose` with `/opsx:propose`
+- [ ] Task 8 (T001263-c): Update `.claude/skills/dev-flow-execute/SKILL.md` — replace `task openspec:apply` with `/opsx:apply`
+- [ ] Task 9 (T001263-d): Open PR `feat(openspec): install upstream workflow commands in .opencode + .claude [T001263]`; merge after CI green
+- [ ] Task 10 (T001265-a): Add `specs:` and `design:` keys to `openspec/config.yaml` under `rules:`
+- [ ] Task 11 (T001265-b): Add `OPENSPEC_TELEMETRY: '0'` to workflow-level `env:` in every `.github/workflows/*.yml`
+- [ ] Task 12 (T001265-c): Add "OpenSpec conventions" + "Dev experience" subsections to `AGENTS.md`
+- [ ] Task 13 (T001265-d): Open PR `chore(openspec): polish — frontmatter convention, rules, telemetry opt-out, completions [T001265]`; merge after CI green
+- [ ] Task 14 (Verify): `task test:changed` + `task freshness:regenerate` + `task freshness:check` + `task test:openspec` — all green; `task openspec:validate` — no errors
 
 ---
 
-## Rollback
+# OpenSpec Improvements Batch — Implementation Plan
 
-Each ticket is a self-contained PR. To roll back:
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:executing-plans
+
+**Goal:** Three independent improvements to the OpenSpec workflow, executed sequentially and shipped as three separate PRs.
+Sub-tickets: T001261 (backfill SSOT stubs + add Purpose/Requirements headers), T001263 (install /opsx:* commands), T001265 (polish: config.yaml rules, CI telemetry opt-out, AGENTS.md docs).
+T001264 is already shipped (commit cdc8d61f). T001262 + T001266 are parked per user instruction 2026-06-27.
+
+**Architecture:** All changes are content + config — no runtime code paths affected.
+Batch executes sequentially: T001261 PR → merge → T001263 PR → merge → T001265 PR → merge.
+Between PRs: pull main to keep the worktree current.
+
+## File Structure
+
+### New files
+- `tests/spec/openspec-workflow.bats` — BATS guards for all three acceptance criteria
+- `.opencode/commands/opsx-propose.md` — upstream propose workflow command
+- `.opencode/commands/opsx-explore.md` — upstream explore workflow command
+- `.opencode/commands/opsx-apply.md` — upstream apply workflow command
+- `.opencode/commands/opsx-archive.md` — upstream archive workflow command
+- `.claude/skills/openspec-propose/SKILL.md` — claude skill for propose
+- `.claude/skills/openspec-explore/SKILL.md` — claude skill for explore
+- `.claude/skills/openspec-apply/SKILL.md` — claude skill for apply
+- `.claude/skills/openspec-archive/SKILL.md` — claude skill for archive
+
+### Modified files
+- `openspec/specs/*.md` — 60 files: add `## Purpose` + `## Requirements` H2 headers; 11 stubs replaced or deleted
+- `scripts/openspec-validate.ts` (77 → ~120 lines; S1-budget vs. limit 600 = budget 523)
+- `.claude/skills/dev-flow-plan/SKILL.md` — reference `/opsx:propose` instead of `task openspec:propose`
+- `.claude/skills/dev-flow-execute/SKILL.md` — reference `/opsx:apply` instead of `task openspec:apply`
+- `openspec/config.yaml` — add `specs:` and `design:` keys under `rules:` (ungated .yaml)
+- `.github/workflows/*.yml` — 21 files, add `OPENSPEC_TELEMETRY: '0'` workflow-level env (ungated .yml)
+- `AGENTS.md` — 2 new subsections: "OpenSpec conventions" + "Dev experience" (ungated .md)
+
+## Task 0 — Failing tests (RED phase)
+
+Write `tests/spec/openspec-workflow.bats` with three guards before making any other changes. Run `bats tests/spec/openspec-workflow.bats` to verify it fails before changes (expected: FAIL on all three guards):
 
 ```bash
-git revert <merge-commit-sha>
+#!/usr/bin/env bats
+# tests/spec/openspec-workflow.bats
+# SSOT: openspec/specs/openspec-workflow.md
+
+REPO="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+
+@test "T001261: all SSOT specs declare a ## Purpose header" {
+  local missing=0
+  for f in "$REPO"/openspec/specs/*.md; do
+    grep -q '^## Purpose' "$f" || { echo "MISSING: $f"; missing=1; }
+  done
+  [ "$missing" -eq 0 ]
+}
+
+@test "T001263: opsx-propose command is installed for opencode" {
+  [ -f "$REPO/.opencode/commands/opsx-propose.md" ]
+}
+
+@test "T001265: CI workflows opt out of OpenSpec telemetry" {
+  local missing=0
+  for f in "$REPO"/.github/workflows/*.yml; do
+    grep -q 'OPENSPEC_TELEMETRY' "$f" || { echo "MISSING: $f"; missing=1; }
+  done
+  [ "$missing" -eq 0 ]
+}
 ```
 
-No cross-PR dependencies. T001261 is the highest priority because the upstream migration (T001262) becomes safer once it lands.
+Run: `bats tests/spec/openspec-workflow.bats` — expected: FAIL on all three guards before any changes.
+Commit the test file alone so the CI baseline shows red.
+
+## Task 1 — T001261-a: Stub investigation
+
+For each of the 11 stub specs listed in `design.md`, determine the action:
+
+| Spec | Archive match | Action |
+|------|---------------|--------|
+| `active-sessions-hub.md` | `archive/2026-06-21-active-sessions-hub` | backfill |
+| `cockpit-direct-ticket-links.md` | `archive/2026-06-21-cockpit-direct-ticket-links` | backfill |
+| `openspec-pgvector.md` | `archive/2026-06-21-openspec-pgvector` | backfill |
+| `t1224-lockfile-drift.md` | `archive/2026-06-27-t1224-lockfile-drift` | backfill |
+| `ci-speed.md` | none | investigate → decide |
+| `fix-coaching-studio-prod-manifest.md` | none | investigate → decide |
+| `korczewski-monolith-keycloak-auth.md` | none | investigate → decide |
+| `openspec-ticket-detail-view.md` | none | investigate → decide |
+| `secrets-deploy-automation.md` | none | investigate → decide |
+| `sidekick-ai-quality.md` | none | investigate → decide |
+| `sidekick-cleanup-grilling-broadcast.md` | none | investigate → decide |
+
+For the "investigate → decide" group: if no archived change and no git history for the spec, delete. If git log shows real work ever happened, backfill from commits.
+
+## Task 2 — T001261-b: Backfill or delete stubs
+
+For each **backfill** target: read `openspec/changes/archive/<date>-<slug>/tasks.md` plus any delta spec. Rewrite the SSOT spec with real Requirements/Scenarios. Cite source as HTML comment (`<!-- from archive/... line N -->`).
+
+For each **delete** target: remove `openspec/specs/<name>.md` and its associated `openspec/changes/archive/<date>-<slug>/` folder if one exists. Do NOT touch other archived changes.
+
+Commit: `chore(openspec): stub audit — backfill N + delete M [T001261]`.
+
+## Task 3 — T001261-c: Bulk header injection
+
+Run an awk pass over all 60 specs in `openspec/specs/`. Each spec gets `## Purpose` before the first paragraph after the H1 title, and `## Requirements` before the first `### Requirement:` line.
+
+```bash
+# Dry-run first to review diffs:
+bash scripts/openspec-header-inject.sh --dry-run openspec/specs/
+# Then apply:
+bash scripts/openspec-header-inject.sh openspec/specs/
+```
+
+Write `scripts/openspec-header-inject.sh` as a one-shot helper (awk-based). After application:
+- `git diff --stat openspec/specs/` — should show exactly the 60 spec files modified, no others
+- Manual review: scan each diff for broken formatting before commit
+
+Commit: `chore(openspec): add Purpose + Requirements H2 to all 60 SSOT specs [T001261]`.
+
+## Task 4 — T001261-d: Validator enforcement
+
+Update `scripts/openspec-validate.ts` to assert that every `openspec/specs/*.md` file contains `^## Purpose` and `^## Requirements` lines. Add a new check after the existing stub detection:
+
+```typescript
+// New validator assertions (add after existing checks):
+if (!content.includes('\n## Purpose\n')) {
+  errors.push(`${specFile}: missing ## Purpose header`);
+}
+if (!content.includes('\n## Requirements\n')) {
+  errors.push(`${specFile}: missing ## Requirements header`);
+}
+```
+
+Run `task test:openspec` — expected: PASS (all specs were updated in Task 3).
+
+## Task 5 — T001261-e: Open PR
+
+```bash
+git push origin chore/openspec-improvements-batch
+gh pr create \
+  --title "chore(openspec): backfill 11 SSOT stubs + add Purpose/Requirements headers [T001261]" \
+  --body "$(cat openspec/changes/migrate-to-upstream-openspec/design.md | head -44)" \
+  --base main
+```
+
+Wait for CI green. Merge: `gh pr merge --squash --auto <pr-number>`. Pull main into worktree before proceeding to T001263.
+
+## Task 6 — T001263-a: Install upstream commands
+
+Install the upstream CLI on the host (one-time, not committed):
+```bash
+npm i -g @fission-ai/openspec@1.3.1
+```
+
+Run init in the repo root (committed):
+```bash
+openspec init --tools opencode,claude --profile core --force
+```
+
+Verify outputs:
+- `ls .opencode/commands/opsx-*.md` — 4 files
+- `ls .claude/skills/openspec-*/SKILL.md` — 4 files
+- `openspec config list` — shows `profile: core`
+
+Commit: `feat(openspec): install upstream /opsx:* workflow commands [T001263]`.
+
+## Task 7 — T001263-b: Update dev-flow-plan skill
+
+In `.claude/skills/dev-flow-plan/SKILL.md`, replace every reference to `task openspec:propose -- <slug>` or `bash scripts/openspec.sh propose` with `/opsx:propose <slug>`. Keep the existing `bash scripts/openspec.sh` fallback note in a code comment.
+
+## Task 8 — T001263-c: Update dev-flow-execute skill
+
+In `.claude/skills/dev-flow-execute/SKILL.md`, replace every reference to `task openspec:apply` with `/opsx:apply`. Keep `task openspec:apply` as fallback note.
+
+Commit both skill updates with Task 6 in one commit: `feat(openspec): update dev-flow skills to use /opsx:* commands [T001263]`.
+
+## Task 9 — T001263-d: Open PR
+
+```bash
+gh pr create \
+  --title "feat(openspec): install upstream workflow commands in .opencode + .claude [T001263]" \
+  --base main
+```
+
+Wait for CI green. Merge. Pull main into worktree before proceeding to T001265.
+
+## Task 10 — T001265-a: Expand config.yaml rules
+
+Add two new rule categories to `openspec/config.yaml` under the existing `rules:` key:
+
+```yaml
+  specs:
+    - Purpose auf Deutsch, Requirements auf Englisch, Scenarios auf Englisch (GIVEN/WHEN/THEN)
+  design:
+    - Goals/Non-Goals explizit trennen
+    - Decisions mit Begründung und ggf. Trade-offs
+```
+
+## Task 11 — T001265-b: CI telemetry opt-out
+
+For every `.github/workflows/*.yml` that does not already have `OPENSPEC_TELEMETRY`:
+
+```bash
+# Check which files are missing it:
+grep -rL 'OPENSPEC_TELEMETRY' .github/workflows/*.yml
+```
+
+For each missing file, add at the top-level `env:` block (or create one):
+```yaml
+env:
+  OPENSPEC_TELEMETRY: '0'
+```
+
+## Task 12 — T001265-c: Update AGENTS.md
+
+Add two subsections to `AGENTS.md`. Insert after the existing "Development workflow" section:
+
+```markdown
+### OpenSpec conventions
+
+Proposal and task files may include YAML frontmatter (parsed by `scripts/openspec-embed.mjs`).
+Language: Purpose sections in German; Requirements and Scenarios in English (GIVEN/WHEN/THEN).
+Rule source: `openspec/config.yaml` (keys: `proposal`, `tasks`, `specs`, `design`).
+
+### Dev experience
+
+After installing the OpenSpec CLI (`npm i -g @fission-ai/openspec@1.3.1`),
+run `openspec completion install` once to enable shell completions (bash/zsh/fish/powershell).
+```
+
+Commit: `chore(openspec): polish — config rules, telemetry opt-out, AGENTS.md [T001265]`.
+
+## Task 13 — T001265-d: Open PR
+
+```bash
+gh pr create \
+  --title "chore(openspec): polish — frontmatter convention, rules, telemetry opt-out, completions [T001265]" \
+  --base main
+```
+
+Wait for CI green. Merge.
+
+## Task 14 — Verify
+
+After all three PRs are merged and main is pulled:
+
+```bash
+task test:changed
+task freshness:regenerate
+task freshness:check
+task test:openspec
+bash scripts/openspec.sh validate
+```
+
+All commands must exit 0. Update `openspec/changes/migrate-to-upstream-openspec/.ticket` status to `done` via `bash scripts/ticket.sh update-status --id T001267 --status done`.
+
+Also update each sub-ticket:
+```bash
+bash scripts/ticket.sh update-status --id T001261 --status done
+bash scripts/ticket.sh update-status --id T001263 --status done
+bash scripts/ticket.sh update-status --id T001265 --status done
+```

--- a/tests/spec/openspec-workflow.bats
+++ b/tests/spec/openspec-workflow.bats
@@ -52,8 +52,8 @@ setup() {
   [ -f "$REPO/.claude/skills/openspec-propose/SKILL.md" ]
 }
 
-@test "T001263: .claude/skills/openspec-apply/SKILL.md is installed" {
-  [ -f "$REPO/.claude/skills/openspec-apply/SKILL.md" ]
+@test "T001263: .claude/skills/openspec-apply-change/SKILL.md is installed" {
+  [ -f "$REPO/.claude/skills/openspec-apply-change/SKILL.md" ]
 }
 
 @test "T001263: dev-flow-plan SKILL.md references /opsx:propose" {


### PR DESCRIPTION
Closes T001263

Two deliverables land in one PR:

1. **Upstream /opsx:* commands installed** (Task 6) via
   `openspec init --tools opencode,claude --profile core --force`
   (uses @fission-ai/openspec@1.3.1). Created 4 opencode commands
   (.opencode/commands/opsx-{propose,explore,apply,archive}.md),
   4 opencode skills (.opencode/skills/openspec-*),
   4 claude commands (.claude/commands/opsx/*.md), and
   4 claude skills (.claude/skills/openspec-*/SKILL.md).

2. **dev-flow-* skills reference the new commands** (Tasks 7+8):
   - dev-flow-plan SKILL.md now references /opsx:propose in 3 places
     (artefakt-ebene explanation, table cell, Schritt 3.1).
   - dev-flow-execute SKILL.md gains a /opsx:apply reference at
     Schritt 1.5, with a 'task openspec:apply' fallback comment for
     harnesses without the upstream CLI installed.

Tests:
- tests/spec/openspec-workflow.bats — T001263 guards (6/6 green).
  (Guard 7 was adjusted to use the upstream 'openspec-apply-change'
  skill name, which matches @fission-ai/openspec's convention:
  apply/archive carry the -change suffix, propose/explore do not.)