### PR TITLE
chore(openspec): polish — frontmatter convention, rules, telemetry opt-out, completions [T001265]

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -9,6 +9,9 @@ concurrency:
   group: ai-review-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  OPENSPEC_TELEMETRY: '0'
+
 jobs:
   ai-review:
     name: AI Code Review

--- a/.github/workflows/auto-enable-automerge.yml
+++ b/.github/workflows/auto-enable-automerge.yml
@@ -19,6 +19,9 @@ concurrency:
   group: auto-enable-automerge-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
+env:
+  OPENSPEC_TELEMETRY: '0'
+
 jobs:
   enable-automerge:
     name: Enable Auto-Merge

--- a/.github/workflows/build-brett.yml
+++ b/.github/workflows/build-brett.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
     paths: ['brett/**']
 
+env:
+  OPENSPEC_TELEMETRY: '0'
+
 jobs:
   build:
     name: Build & push Brett image

--- a/.github/workflows/build-collabora.yml
+++ b/.github/workflows/build-collabora.yml
@@ -32,6 +32,7 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: paddione/collabora-code
 
+  OPENSPEC_TELEMETRY: '0'
 jobs:
   build-push:
     name: Build and push

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -10,6 +10,9 @@ on:
       - 'scripts/docs-gen/**'
       - 'scripts/docs.Dockerfile'
 
+env:
+  OPENSPEC_TELEMETRY: '0'
+
 jobs:
   build:
     name: Build & push docs image

--- a/.github/workflows/build-mediaviewer-widget.yml
+++ b/.github/workflows/build-mediaviewer-widget.yml
@@ -9,6 +9,9 @@ on:
       - '.github/workflows/build-mediaviewer-widget.yml'
   workflow_dispatch:
 
+env:
+  OPENSPEC_TELEMETRY: '0'
+
 jobs:
   build:
     name: Build & push Mediaviewer Widget image

--- a/.github/workflows/build-mentolder-web.yml
+++ b/.github/workflows/build-mentolder-web.yml
@@ -8,6 +8,9 @@ on:
       - '.github/workflows/build-mentolder-web.yml'
   workflow_dispatch:
 
+env:
+  OPENSPEC_TELEMETRY: '0'
+
 jobs:
   build-and-deploy:
     name: Build & Deploy (react.mentolder.de)

--- a/.github/workflows/build-transcriber.yml
+++ b/.github/workflows/build-transcriber.yml
@@ -19,6 +19,7 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: paddione/talk-transcriber
 
+  OPENSPEC_TELEMETRY: '0'
 jobs:
   build-push:
     name: Build and push

--- a/.github/workflows/build-videovault.yml
+++ b/.github/workflows/build-videovault.yml
@@ -9,6 +9,9 @@ on:
       - '.github/workflows/build-videovault.yml'
   workflow_dispatch:
 
+env:
+  OPENSPEC_TELEMETRY: '0'
+
 jobs:
   build-and-deploy:
     name: Build & Deploy VideoVault (both brands)

--- a/.github/workflows/build-website.yml
+++ b/.github/workflows/build-website.yml
@@ -8,6 +8,9 @@ on:
       - '.github/workflows/build-website.yml'
   workflow_dispatch:
 
+env:
+  OPENSPEC_TELEMETRY: '0'
+
 jobs:
   build-and-deploy:
     name: Build & Deploy Website (mentolder)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ concurrency:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
+  OPENSPEC_TELEMETRY: '0'
 jobs:
   offline-tests:
     name: Offline Tests (Manifests, Configs, Unit)

--- a/.github/workflows/deploy-sealed-secrets.yml
+++ b/.github/workflows/deploy-sealed-secrets.yml
@@ -12,6 +12,9 @@ on:
 permissions:
   contents: read
 
+env:
+  OPENSPEC_TELEMETRY: '0'
+
 jobs:
   validate:
     name: Validate Sealed Secrets

--- a/.github/workflows/e2e-pr.yml
+++ b/.github/workflows/e2e-pr.yml
@@ -36,6 +36,7 @@ concurrency:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
+  OPENSPEC_TELEMETRY: '0'
 jobs:
   e2e-pr:
     # Static name — branch protection requires the context "E2E PR";

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -27,6 +27,7 @@ concurrency:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
+  OPENSPEC_TELEMETRY: '0'
 jobs:
   playwright:
     name: ${{ matrix.cluster }}

--- a/.github/workflows/factory-post-merge-e2e.yml
+++ b/.github/workflows/factory-post-merge-e2e.yml
@@ -8,6 +8,9 @@ on:
   push:
     branches: [main]
 
+env:
+  OPENSPEC_TELEMETRY: '0'
+
 jobs:
   trigger-e2e:
     runs-on: ubuntu-latest

--- a/.github/workflows/freshness-regen.yml
+++ b/.github/workflows/freshness-regen.yml
@@ -8,6 +8,9 @@ concurrency:
   group: freshness-regen-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  OPENSPEC_TELEMETRY: '0'
+
 jobs:
   regenerate:
     name: Regenerate stale artifacts

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -6,6 +6,9 @@ on:
   pull_request_review_comment:
     types: [created]
 
+env:
+  OPENSPEC_TELEMETRY: '0'
+
 jobs:
   opencode:
     # Public repo: nur Repo-Mitglieder duerfen opencode triggern (kein anonymer Trigger).

--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -10,6 +10,9 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  OPENSPEC_TELEMETRY: '0'
+
 jobs:
   mark-awaiting:
     name: Mark ticket awaiting_deploy

--- a/.github/workflows/quality-loop.yml
+++ b/.github/workflows/quality-loop.yml
@@ -19,6 +19,9 @@ on:
         required: false
         default: "2"
 
+env:
+  OPENSPEC_TELEMETRY: '0'
+
 jobs:
   quality-loop:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,6 +8,9 @@ permissions:
   contents: write
   pull-requests: write
 
+env:
+  OPENSPEC_TELEMETRY: '0'
+
 jobs:
   release-please:
     runs-on: ubuntu-latest

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -20,6 +20,9 @@ concurrency:
   group: renovate-${{ github.workflow }}
   cancel-in-progress: false
 
+env:
+  OPENSPEC_TELEMETRY: '0'
+
 jobs:
   renovate:
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -198,3 +198,11 @@ Registered as `codebase-memory-mcp` in both `.mcp.json` (Claude Code) and `.open
 - `docs/agent-guide/README.md` — agent operating guide registry (taxonomy, guardrails, tools, goals)
 - `CONTRIBUTING.md` — human-readable dev workflow
 - `.agents/skills/OVERVIEW.md` — skill layering contract (dev-flow → superpowers)
+
+## OpenSpec conventions
+
+Proposal and task files (`openspec/changes/<slug>/proposal.md`, `tasks.md`, `specs/*.md`) may include YAML frontmatter parsed by `scripts/openspec-embed.mjs` (used to index changes in pgvector for `plan-context.sh --semantic`). Language convention: **Purpose sections in German; Requirements and Scenarios in English** (GIVEN/WHEN/THEN). Rule source: `openspec/config.yaml` (keys: `proposal`, `tasks`, `specs`, `design`).
+
+## Dev experience
+
+After installing the OpenSpec CLI (`npm i -g @fission-ai/openspec@1.3.1`), run `openspec completion install` once to enable shell completions (bash/zsh/fish/powershell). Upstream workflow commands live under `.opencode/commands/opsx-*.md` and `.claude/skills/openspec-*/SKILL.md`; use them via `/opsx:propose`, `/opsx:apply`, `/opsx:archive` instead of the older `task openspec:*` wrappers.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -762,6 +762,10 @@ tasks:
     desc: "Bulk-add ## Purpose + ## Requirements H2 headers to SSOT specs under openspec/specs/. Usage: task openspec:header-inject [-- --dry-run]"
     cmds:
       - bash scripts/openspec-header-inject.sh {{.CLI_ARGS}} openspec/specs/
+  openspec:ci-telemetry-optout:
+    desc: "Add OPENSPEC_TELEMETRY: '0' to every .github/workflows/*.yml that lacks it. Usage: task openspec:ci-telemetry-optout [-- --dry-run]"
+    cmds:
+      - python3 scripts/openspec-telemetry-optout.py {{.CLI_ARGS}} .github/workflows/*.yml .github/workflows/*.yaml
 
   test:agent-lock:
     desc: "Run the offline agent-lock session-coordination bats (tests/local/AGENT-LOCK-*)."

--- a/openspec/changes/migrate-to-upstream-openspec/tasks.md
+++ b/openspec/changes/migrate-to-upstream-openspec/tasks.md
@@ -18,10 +18,10 @@ depends_on_plans: []
 - [x] Task 3 (T001261-c): Bulk-add `## Purpose` + `## Requirements` H2 headers to all 60 SSOT specs via awk pass; manual review of every changed spec
 - [x] Task 4 (T001261-d): Update `scripts/openspec-validate.ts` to enforce `## Purpose` and `## Requirements`; run `task test:openspec` — expected: PASS
 - [x] Task 5 (T001261-e): Open PR `chore(openspec): backfill 11 SSOT stubs + add Purpose/Requirements headers [T001261]`; merge after CI green
-- [ ] Task 6 (T001263-a): Run `openspec init --tools opencode,claude --profile core --force`; verify 4 `.opencode/commands/opsx-*.md` + 4 `.claude/skills/openspec-*/SKILL.md` created
-- [ ] Task 7 (T001263-b): Update `.claude/skills/dev-flow-plan/SKILL.md` — replace `task openspec:propose` with `/opsx:propose`
-- [ ] Task 8 (T001263-c): Update `.claude/skills/dev-flow-execute/SKILL.md` — replace `task openspec:apply` with `/opsx:apply`
-- [ ] Task 9 (T001263-d): Open PR `feat(openspec): install upstream workflow commands in .opencode + .claude [T001263]`; merge after CI green
+- [x] Task 6 (T001263-a): Run `openspec init --tools opencode,claude --profile core --force`; verify 4 `.opencode/commands/opsx-*.md` + 4 `.claude/skills/openspec-*/SKILL.md` created
+- [x] Task 7 (T001263-b): Update `.claude/skills/dev-flow-plan/SKILL.md` — replace `task openspec:propose` with `/opsx:propose`
+- [x] Task 8 (T001263-c): Update `.claude/skills/dev-flow-execute/SKILL.md` — replace `task openspec:apply` with `/opsx:apply`
+- [x] Task 9 (T001263-d): Open PR `feat(openspec): install upstream workflow commands in .opencode + .claude [T001263]`; merge after CI green
 - [ ] Task 10 (T001265-a): Add `specs:` and `design:` keys to `openspec/config.yaml` under `rules:`
 - [ ] Task 11 (T001265-b): Add `OPENSPEC_TELEMETRY: '0'` to workflow-level `env:` in every `.github/workflows/*.yml`
 - [ ] Task 12 (T001265-c): Add "OpenSpec conventions" + "Dev experience" subsections to `AGENTS.md`

--- a/openspec/changes/migrate-to-upstream-openspec/tasks.md
+++ b/openspec/changes/migrate-to-upstream-openspec/tasks.md
@@ -12,12 +12,12 @@ depends_on_plans: []
 
 # Tasks: openspec-improvements-batch (T001267)
 
-- [ ] Task 0: Write failing tests in `tests/spec/openspec-workflow.bats`; run `bats tests/spec/openspec-workflow.bats` to verify it fails before any changes (expected: FAIL on all three guards)
-- [ ] Task 1 (T001261-a): Investigate each of the 11 stub specs — backfill from archive or delete
-- [ ] Task 2 (T001261-b): Backfill confirmed stubs from `openspec/changes/archive/<date>-<slug>/tasks.md`; delete phantom spec+change pairs
-- [ ] Task 3 (T001261-c): Bulk-add `## Purpose` + `## Requirements` H2 headers to all 60 SSOT specs via awk pass; manual review of every changed spec
-- [ ] Task 4 (T001261-d): Update `scripts/openspec-validate.ts` to enforce `## Purpose` and `## Requirements`; run `task test:openspec` — expected: PASS
-- [ ] Task 5 (T001261-e): Open PR `chore(openspec): backfill 11 SSOT stubs + add Purpose/Requirements headers [T001261]`; merge after CI green
+- [x] Task 0: Write failing tests in `tests/spec/openspec-workflow.bats`; run `bats tests/spec/openspec-workflow.bats` to verify it fails before any changes (expected: FAIL on all three guards)
+- [x] Task 1 (T001261-a): Investigate each of the 11 stub specs — backfill from archive or delete
+- [x] Task 2 (T001261-b): Backfill confirmed stubs from `openspec/changes/archive/<date>-<slug>/tasks.md`; delete phantom spec+change pairs
+- [x] Task 3 (T001261-c): Bulk-add `## Purpose` + `## Requirements` H2 headers to all 60 SSOT specs via awk pass; manual review of every changed spec
+- [x] Task 4 (T001261-d): Update `scripts/openspec-validate.ts` to enforce `## Purpose` and `## Requirements`; run `task test:openspec` — expected: PASS
+- [x] Task 5 (T001261-e): Open PR `chore(openspec): backfill 11 SSOT stubs + add Purpose/Requirements headers [T001261]`; merge after CI green
 - [ ] Task 6 (T001263-a): Run `openspec init --tools opencode,claude --profile core --force`; verify 4 `.opencode/commands/opsx-*.md` + 4 `.claude/skills/openspec-*/SKILL.md` created
 - [ ] Task 7 (T001263-b): Update `.claude/skills/dev-flow-plan/SKILL.md` — replace `task openspec:propose` with `/opsx:propose`
 - [ ] Task 8 (T001263-c): Update `.claude/skills/dev-flow-execute/SKILL.md` — replace `task openspec:apply` with `/opsx:apply`

--- a/openspec/changes/migrate-to-upstream-openspec/tasks.md
+++ b/openspec/changes/migrate-to-upstream-openspec/tasks.md
@@ -1,73 +1,289 @@
-# Tasks: OpenSpec improvements batch (T001267 umbrella)
+---
+title: "OpenSpec improvements batch: backfill + /opsx:* commands + polish [T001267]"
+ticket_id: T001267
+domains: [openspec, ci, docs, tooling]
+status: plan_staged
+file_locks: []
+shared_changes: false
+batch_id: null
+parent_feature: null
+depends_on_plans: []
+---
 
-_Umbrella for: T001261, T001263, T001264 (done), T001265. Out of scope: T001262 + T001266 (parked)._
-_Factory input format: `- [ ]` checkboxes, hierarchical numbering per ticket._
+# Tasks: openspec-improvements-batch (T001267)
 
-## T001261 — Backfill SSOT specs (hoch, mittel)
-
-- [ ] 1.1 Investigate each of the 11 stub specs; for each, decide: backfill (source from archive) OR delete (work never done)
-- [ ] 1.2 For each backfill target, read the corresponding `openspec/changes/archive/<date>-<slug>/tasks.md` + delta
-- [ ] 1.3 Rewrite each stub spec with real Requirements/Scenarios; cite the source as `<!-- from archive/.../tasks.md line N -->` comments
-- [ ] 1.4 For each delete target, remove the spec file and any associated change folder (do NOT touch archived changes)
-- [ ] 1.5 Run a sed/awk pass to wrap the intro paragraph of all 60 specs in `## Purpose` H2
-- [ ] 1.6 Run a second pass to add `## Requirements` H2 before the first `### Requirement:` in each spec
-- [ ] 1.7 Manual review of every modified spec; `git diff openspec/specs/` before commit
-- [ ] 1.8 Update `scripts/openspec-validate.ts` to require `## Purpose` and `## Requirements` H2 (so future stubs can't slip through)
-- [ ] 1.9 `task test:openspec` still passes
-- [ ] 1.10 Open PR: `chore(openspec): backfill 11 SSOT stubs + add Purpose/Requirements headers [T001261]`
-
-## T001263 — Install /opsx:* workflow commands (mittel, klein)
-
-- [ ] 2.1 (host setup, not committed) `npm i -g @fission-ai/openspec@1.3.1`
-- [ ] 2.2 `openspec init --tools opencode,claude --profile core --force`
-- [ ] 2.3 Verify 4 files in `.opencode/commands/opsx-*.md`
-- [ ] 2.4 Verify 4 dirs in `.claude/skills/openspec-*/SKILL.md`
-- [ ] 2.5 `openspec config list` — confirm `profile: core`, `workflows: propose,explore,apply,archive`
-- [ ] 2.6 Update `.agents/skills/dev-flow-plan/SKILL.md` — replace `task openspec:propose` reference with `/opsx:propose`
-- [ ] 2.7 Update `.agents/skills/dev-flow-execute/SKILL.md` — replace `task openspec:apply` reference with `/opsx:apply`
-- [ ] 2.8 Smoke test in a worktree: invoke `/opsx:propose` via agent prompt path; confirm change dir is created
-- [ ] 2.9 Open PR: `feat(openspec): install upstream workflow commands in .opencode + .claude [T001263]`
-
-## T001264 — Remove openspec-mcp + delete project.md (niedrig) [DONE 2026-06-27]
-
-- [x] 3.1 Remove `openspec` entry from `.opencode/opencode.jsonc`
-- [x] 3.2 Remove `openspec` entry from `.mcp.json`
-- [x] 3.3 Delete `openspec/project.md`
-- [x] 3.4 Transition T001264 → `done` with `resolution: shipped`
-- [x] 3.5 Commit: `chore(openspec): remove unused openspec-mcp + delete dead project.md [T001264]` (commit cdc8d61f)
-
-## T001265 — Polish (niedrig, klein)
-
-- [ ] 4.1 Document the frontmatter convention in `AGENTS.md` (new "OpenSpec conventions" section)
-- [ ] 4.2 Add to `openspec/config.yaml:rules:`:
-    - `specs: ["Purpose auf Deutsch, Requirements auf Englisch, Scenarios auf Englisch (GIVEN/WHEN/THEN)"]`
-    - `design: ["Goals/Non-Goals explizit trennen", "Decisions mit Begründung"]`
-- [ ] 4.3 Audit all `.github/workflows/*.yml` for missing `OPENSPEC_TELEMETRY: '0'` env; add to each (workflow-level or per-job)
-- [ ] 4.4 Add `openspec completion install` note to `AGENTS.md` under a new "Dev experience" section
-- [ ] 4.5 `task test:openspec` still passes
-- [ ] 4.6 Open PR: `chore(openspec): polish — frontmatter convention, rules, telemetry opt-out, completions [T001265]`
-
-## Out of scope (parked)
-
-- T001262 — Adopt upstream CLI (user instruction 2026-06-27: "leave as is for now")
-- T001266 — Rewrite `openspec-workflow.md` SSOT (depends on T001262)
-
-## Verification (after all PRs merge)
-
-- [ ] `task test:openspec` passes
-- [ ] `task test:changed` passes
-- [ ] `task freshness:check` passes
-- [ ] Manual review: in opencode, `/opsx:propose "test" --ticket T000001` (with a test ticket) creates `openspec/changes/test/specs/test.md` with non-stub content within 1 minute
-- [ ] `task openspec:archive` (the bash wrapper) is still callable as a backward-compat fallback
+- [ ] Task 0: Write failing tests in `tests/spec/openspec-workflow.bats`; run `bats tests/spec/openspec-workflow.bats` to verify it fails before any changes (expected: FAIL on all three guards)
+- [ ] Task 1 (T001261-a): Investigate each of the 11 stub specs — backfill from archive or delete
+- [ ] Task 2 (T001261-b): Backfill confirmed stubs from `openspec/changes/archive/<date>-<slug>/tasks.md`; delete phantom spec+change pairs
+- [ ] Task 3 (T001261-c): Bulk-add `## Purpose` + `## Requirements` H2 headers to all 60 SSOT specs via awk pass; manual review of every changed spec
+- [ ] Task 4 (T001261-d): Update `scripts/openspec-validate.ts` to enforce `## Purpose` and `## Requirements`; run `task test:openspec` — expected: PASS
+- [ ] Task 5 (T001261-e): Open PR `chore(openspec): backfill 11 SSOT stubs + add Purpose/Requirements headers [T001261]`; merge after CI green
+- [ ] Task 6 (T001263-a): Run `openspec init --tools opencode,claude --profile core --force`; verify 4 `.opencode/commands/opsx-*.md` + 4 `.claude/skills/openspec-*/SKILL.md` created
+- [ ] Task 7 (T001263-b): Update `.claude/skills/dev-flow-plan/SKILL.md` — replace `task openspec:propose` with `/opsx:propose`
+- [ ] Task 8 (T001263-c): Update `.claude/skills/dev-flow-execute/SKILL.md` — replace `task openspec:apply` with `/opsx:apply`
+- [ ] Task 9 (T001263-d): Open PR `feat(openspec): install upstream workflow commands in .opencode + .claude [T001263]`; merge after CI green
+- [ ] Task 10 (T001265-a): Add `specs:` and `design:` keys to `openspec/config.yaml` under `rules:`
+- [ ] Task 11 (T001265-b): Add `OPENSPEC_TELEMETRY: '0'` to workflow-level `env:` in every `.github/workflows/*.yml`
+- [ ] Task 12 (T001265-c): Add "OpenSpec conventions" + "Dev experience" subsections to `AGENTS.md`
+- [ ] Task 13 (T001265-d): Open PR `chore(openspec): polish — frontmatter convention, rules, telemetry opt-out, completions [T001265]`; merge after CI green
+- [ ] Task 14 (Verify): `task test:changed` + `task freshness:regenerate` + `task freshness:check` + `task test:openspec` — all green; `task openspec:validate` — no errors
 
 ---
 
-## Rollback
+# OpenSpec Improvements Batch — Implementation Plan
 
-Each ticket is a self-contained PR. To roll back:
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:executing-plans
+
+**Goal:** Three independent improvements to the OpenSpec workflow, executed sequentially and shipped as three separate PRs.
+Sub-tickets: T001261 (backfill SSOT stubs + add Purpose/Requirements headers), T001263 (install /opsx:* commands), T001265 (polish: config.yaml rules, CI telemetry opt-out, AGENTS.md docs).
+T001264 is already shipped (commit cdc8d61f). T001262 + T001266 are parked per user instruction 2026-06-27.
+
+**Architecture:** All changes are content + config — no runtime code paths affected.
+Batch executes sequentially: T001261 PR → merge → T001263 PR → merge → T001265 PR → merge.
+Between PRs: pull main to keep the worktree current.
+
+## File Structure
+
+### New files
+- `tests/spec/openspec-workflow.bats` — BATS guards for all three acceptance criteria
+- `.opencode/commands/opsx-propose.md` — upstream propose workflow command
+- `.opencode/commands/opsx-explore.md` — upstream explore workflow command
+- `.opencode/commands/opsx-apply.md` — upstream apply workflow command
+- `.opencode/commands/opsx-archive.md` — upstream archive workflow command
+- `.claude/skills/openspec-propose/SKILL.md` — claude skill for propose
+- `.claude/skills/openspec-explore/SKILL.md` — claude skill for explore
+- `.claude/skills/openspec-apply/SKILL.md` — claude skill for apply
+- `.claude/skills/openspec-archive/SKILL.md` — claude skill for archive
+
+### Modified files
+- `openspec/specs/*.md` — 60 files: add `## Purpose` + `## Requirements` H2 headers; 11 stubs replaced or deleted
+- `scripts/openspec-validate.ts` (77 → ~120 lines; S1-budget vs. limit 600 = budget 523)
+- `.claude/skills/dev-flow-plan/SKILL.md` — reference `/opsx:propose` instead of `task openspec:propose`
+- `.claude/skills/dev-flow-execute/SKILL.md` — reference `/opsx:apply` instead of `task openspec:apply`
+- `openspec/config.yaml` — add `specs:` and `design:` keys under `rules:` (ungated .yaml)
+- `.github/workflows/*.yml` — 21 files, add `OPENSPEC_TELEMETRY: '0'` workflow-level env (ungated .yml)
+- `AGENTS.md` — 2 new subsections: "OpenSpec conventions" + "Dev experience" (ungated .md)
+
+## Task 0 — Failing tests (RED phase)
+
+Write `tests/spec/openspec-workflow.bats` with three guards before making any other changes. Run `bats tests/spec/openspec-workflow.bats` to verify it fails before changes (expected: FAIL on all three guards):
 
 ```bash
-git revert <merge-commit-sha>
+#!/usr/bin/env bats
+# tests/spec/openspec-workflow.bats
+# SSOT: openspec/specs/openspec-workflow.md
+
+REPO="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+
+@test "T001261: all SSOT specs declare a ## Purpose header" {
+  local missing=0
+  for f in "$REPO"/openspec/specs/*.md; do
+    grep -q '^## Purpose' "$f" || { echo "MISSING: $f"; missing=1; }
+  done
+  [ "$missing" -eq 0 ]
+}
+
+@test "T001263: opsx-propose command is installed for opencode" {
+  [ -f "$REPO/.opencode/commands/opsx-propose.md" ]
+}
+
+@test "T001265: CI workflows opt out of OpenSpec telemetry" {
+  local missing=0
+  for f in "$REPO"/.github/workflows/*.yml; do
+    grep -q 'OPENSPEC_TELEMETRY' "$f" || { echo "MISSING: $f"; missing=1; }
+  done
+  [ "$missing" -eq 0 ]
+}
 ```
 
-No cross-PR dependencies. T001261 is the highest priority because the upstream migration (T001262) becomes safer once it lands.
+Run: `bats tests/spec/openspec-workflow.bats` — expected: FAIL on all three guards before any changes.
+Commit the test file alone so the CI baseline shows red.
+
+## Task 1 — T001261-a: Stub investigation
+
+For each of the 11 stub specs listed in `design.md`, determine the action:
+
+| Spec | Archive match | Action |
+|------|---------------|--------|
+| `active-sessions-hub.md` | `archive/2026-06-21-active-sessions-hub` | backfill |
+| `cockpit-direct-ticket-links.md` | `archive/2026-06-21-cockpit-direct-ticket-links` | backfill |
+| `openspec-pgvector.md` | `archive/2026-06-21-openspec-pgvector` | backfill |
+| `t1224-lockfile-drift.md` | `archive/2026-06-27-t1224-lockfile-drift` | backfill |
+| `ci-speed.md` | none | investigate → decide |
+| `fix-coaching-studio-prod-manifest.md` | none | investigate → decide |
+| `korczewski-monolith-keycloak-auth.md` | none | investigate → decide |
+| `openspec-ticket-detail-view.md` | none | investigate → decide |
+| `secrets-deploy-automation.md` | none | investigate → decide |
+| `sidekick-ai-quality.md` | none | investigate → decide |
+| `sidekick-cleanup-grilling-broadcast.md` | none | investigate → decide |
+
+For the "investigate → decide" group: if no archived change and no git history for the spec, delete. If git log shows real work ever happened, backfill from commits.
+
+## Task 2 — T001261-b: Backfill or delete stubs
+
+For each **backfill** target: read `openspec/changes/archive/<date>-<slug>/tasks.md` plus any delta spec. Rewrite the SSOT spec with real Requirements/Scenarios. Cite source as HTML comment (`<!-- from archive/... line N -->`).
+
+For each **delete** target: remove `openspec/specs/<name>.md` and its associated `openspec/changes/archive/<date>-<slug>/` folder if one exists. Do NOT touch other archived changes.
+
+Commit: `chore(openspec): stub audit — backfill N + delete M [T001261]`.
+
+## Task 3 — T001261-c: Bulk header injection
+
+Run an awk pass over all 60 specs in `openspec/specs/`. Each spec gets `## Purpose` before the first paragraph after the H1 title, and `## Requirements` before the first `### Requirement:` line.
+
+```bash
+# Dry-run first to review diffs:
+bash scripts/openspec-header-inject.sh --dry-run openspec/specs/
+# Then apply:
+bash scripts/openspec-header-inject.sh openspec/specs/
+```
+
+Write `scripts/openspec-header-inject.sh` as a one-shot helper (awk-based). After application:
+- `git diff --stat openspec/specs/` — should show exactly the 60 spec files modified, no others
+- Manual review: scan each diff for broken formatting before commit
+
+Commit: `chore(openspec): add Purpose + Requirements H2 to all 60 SSOT specs [T001261]`.
+
+## Task 4 — T001261-d: Validator enforcement
+
+Update `scripts/openspec-validate.ts` to assert that every `openspec/specs/*.md` file contains `^## Purpose` and `^## Requirements` lines. Add a new check after the existing stub detection:
+
+```typescript
+// New validator assertions (add after existing checks):
+if (!content.includes('\n## Purpose\n')) {
+  errors.push(`${specFile}: missing ## Purpose header`);
+}
+if (!content.includes('\n## Requirements\n')) {
+  errors.push(`${specFile}: missing ## Requirements header`);
+}
+```
+
+Run `task test:openspec` — expected: PASS (all specs were updated in Task 3).
+
+## Task 5 — T001261-e: Open PR
+
+```bash
+git push origin chore/openspec-improvements-batch
+gh pr create \
+  --title "chore(openspec): backfill 11 SSOT stubs + add Purpose/Requirements headers [T001261]" \
+  --body "$(cat openspec/changes/migrate-to-upstream-openspec/design.md | head -44)" \
+  --base main
+```
+
+Wait for CI green. Merge: `gh pr merge --squash --auto <pr-number>`. Pull main into worktree before proceeding to T001263.
+
+## Task 6 — T001263-a: Install upstream commands
+
+Install the upstream CLI on the host (one-time, not committed):
+```bash
+npm i -g @fission-ai/openspec@1.3.1
+```
+
+Run init in the repo root (committed):
+```bash
+openspec init --tools opencode,claude --profile core --force
+```
+
+Verify outputs:
+- `ls .opencode/commands/opsx-*.md` — 4 files
+- `ls .claude/skills/openspec-*/SKILL.md` — 4 files
+- `openspec config list` — shows `profile: core`
+
+Commit: `feat(openspec): install upstream /opsx:* workflow commands [T001263]`.
+
+## Task 7 — T001263-b: Update dev-flow-plan skill
+
+In `.claude/skills/dev-flow-plan/SKILL.md`, replace every reference to `task openspec:propose -- <slug>` or `bash scripts/openspec.sh propose` with `/opsx:propose <slug>`. Keep the existing `bash scripts/openspec.sh` fallback note in a code comment.
+
+## Task 8 — T001263-c: Update dev-flow-execute skill
+
+In `.claude/skills/dev-flow-execute/SKILL.md`, replace every reference to `task openspec:apply` with `/opsx:apply`. Keep `task openspec:apply` as fallback note.
+
+Commit both skill updates with Task 6 in one commit: `feat(openspec): update dev-flow skills to use /opsx:* commands [T001263]`.
+
+## Task 9 — T001263-d: Open PR
+
+```bash
+gh pr create \
+  --title "feat(openspec): install upstream workflow commands in .opencode + .claude [T001263]" \
+  --base main
+```
+
+Wait for CI green. Merge. Pull main into worktree before proceeding to T001265.
+
+## Task 10 — T001265-a: Expand config.yaml rules
+
+Add two new rule categories to `openspec/config.yaml` under the existing `rules:` key:
+
+```yaml
+  specs:
+    - Purpose auf Deutsch, Requirements auf Englisch, Scenarios auf Englisch (GIVEN/WHEN/THEN)
+  design:
+    - Goals/Non-Goals explizit trennen
+    - Decisions mit Begründung und ggf. Trade-offs
+```
+
+## Task 11 — T001265-b: CI telemetry opt-out
+
+For every `.github/workflows/*.yml` that does not already have `OPENSPEC_TELEMETRY`:
+
+```bash
+# Check which files are missing it:
+grep -rL 'OPENSPEC_TELEMETRY' .github/workflows/*.yml
+```
+
+For each missing file, add at the top-level `env:` block (or create one):
+```yaml
+env:
+  OPENSPEC_TELEMETRY: '0'
+```
+
+## Task 12 — T001265-c: Update AGENTS.md
+
+Add two subsections to `AGENTS.md`. Insert after the existing "Development workflow" section:
+
+```markdown
+### OpenSpec conventions
+
+Proposal and task files may include YAML frontmatter (parsed by `scripts/openspec-embed.mjs`).
+Language: Purpose sections in German; Requirements and Scenarios in English (GIVEN/WHEN/THEN).
+Rule source: `openspec/config.yaml` (keys: `proposal`, `tasks`, `specs`, `design`).
+
+### Dev experience
+
+After installing the OpenSpec CLI (`npm i -g @fission-ai/openspec@1.3.1`),
+run `openspec completion install` once to enable shell completions (bash/zsh/fish/powershell).
+```
+
+Commit: `chore(openspec): polish — config rules, telemetry opt-out, AGENTS.md [T001265]`.
+
+## Task 13 — T001265-d: Open PR
+
+```bash
+gh pr create \
+  --title "chore(openspec): polish — frontmatter convention, rules, telemetry opt-out, completions [T001265]" \
+  --base main
+```
+
+Wait for CI green. Merge.
+
+## Task 14 — Verify
+
+After all three PRs are merged and main is pulled:
+
+```bash
+task test:changed
+task freshness:regenerate
+task freshness:check
+task test:openspec
+bash scripts/openspec.sh validate
+```
+
+All commands must exit 0. Update `openspec/changes/migrate-to-upstream-openspec/.ticket` status to `done` via `bash scripts/ticket.sh update-status --id T001267 --status done`.
+
+Also update each sub-ticket:
+```bash
+bash scripts/ticket.sh update-status --id T001261 --status done
+bash scripts/ticket.sh update-status --id T001263 --status done
+bash scripts/ticket.sh update-status --id T001265 --status done
+```

--- a/openspec/changes/migrate-to-upstream-openspec/tasks.md
+++ b/openspec/changes/migrate-to-upstream-openspec/tasks.md
@@ -1,289 +1,73 @@
+# Tasks: OpenSpec improvements batch (T001267 umbrella)
+
+_Umbrella for: T001261, T001263, T001264 (done), T001265. Out of scope: T001262 + T001266 (parked)._
+_Factory input format: `- [ ]` checkboxes, hierarchical numbering per ticket._
+
+## T001261 — Backfill SSOT specs (hoch, mittel)
+
+- [ ] 1.1 Investigate each of the 11 stub specs; for each, decide: backfill (source from archive) OR delete (work never done)
+- [ ] 1.2 For each backfill target, read the corresponding `openspec/changes/archive/<date>-<slug>/tasks.md` + delta
+- [ ] 1.3 Rewrite each stub spec with real Requirements/Scenarios; cite the source as `<!-- from archive/.../tasks.md line N -->` comments
+- [ ] 1.4 For each delete target, remove the spec file and any associated change folder (do NOT touch archived changes)
+- [ ] 1.5 Run a sed/awk pass to wrap the intro paragraph of all 60 specs in `## Purpose` H2
+- [ ] 1.6 Run a second pass to add `## Requirements` H2 before the first `### Requirement:` in each spec
+- [ ] 1.7 Manual review of every modified spec; `git diff openspec/specs/` before commit
+- [ ] 1.8 Update `scripts/openspec-validate.ts` to require `## Purpose` and `## Requirements` H2 (so future stubs can't slip through)
+- [ ] 1.9 `task test:openspec` still passes
+- [ ] 1.10 Open PR: `chore(openspec): backfill 11 SSOT stubs + add Purpose/Requirements headers [T001261]`
+
+## T001263 — Install /opsx:* workflow commands (mittel, klein)
+
+- [ ] 2.1 (host setup, not committed) `npm i -g @fission-ai/openspec@1.3.1`
+- [ ] 2.2 `openspec init --tools opencode,claude --profile core --force`
+- [ ] 2.3 Verify 4 files in `.opencode/commands/opsx-*.md`
+- [ ] 2.4 Verify 4 dirs in `.claude/skills/openspec-*/SKILL.md`
+- [ ] 2.5 `openspec config list` — confirm `profile: core`, `workflows: propose,explore,apply,archive`
+- [ ] 2.6 Update `.agents/skills/dev-flow-plan/SKILL.md` — replace `task openspec:propose` reference with `/opsx:propose`
+- [ ] 2.7 Update `.agents/skills/dev-flow-execute/SKILL.md` — replace `task openspec:apply` reference with `/opsx:apply`
+- [ ] 2.8 Smoke test in a worktree: invoke `/opsx:propose` via agent prompt path; confirm change dir is created
+- [ ] 2.9 Open PR: `feat(openspec): install upstream workflow commands in .opencode + .claude [T001263]`
+
+## T001264 — Remove openspec-mcp + delete project.md (niedrig) [DONE 2026-06-27]
+
+- [x] 3.1 Remove `openspec` entry from `.opencode/opencode.jsonc`
+- [x] 3.2 Remove `openspec` entry from `.mcp.json`
+- [x] 3.3 Delete `openspec/project.md`
+- [x] 3.4 Transition T001264 → `done` with `resolution: shipped`
+- [x] 3.5 Commit: `chore(openspec): remove unused openspec-mcp + delete dead project.md [T001264]` (commit cdc8d61f)
+
+## T001265 — Polish (niedrig, klein)
+
+- [ ] 4.1 Document the frontmatter convention in `AGENTS.md` (new "OpenSpec conventions" section)
+- [ ] 4.2 Add to `openspec/config.yaml:rules:`:
+    - `specs: ["Purpose auf Deutsch, Requirements auf Englisch, Scenarios auf Englisch (GIVEN/WHEN/THEN)"]`
+    - `design: ["Goals/Non-Goals explizit trennen", "Decisions mit Begründung"]`
+- [ ] 4.3 Audit all `.github/workflows/*.yml` for missing `OPENSPEC_TELEMETRY: '0'` env; add to each (workflow-level or per-job)
+- [ ] 4.4 Add `openspec completion install` note to `AGENTS.md` under a new "Dev experience" section
+- [ ] 4.5 `task test:openspec` still passes
+- [ ] 4.6 Open PR: `chore(openspec): polish — frontmatter convention, rules, telemetry opt-out, completions [T001265]`
+
+## Out of scope (parked)
+
+- T001262 — Adopt upstream CLI (user instruction 2026-06-27: "leave as is for now")
+- T001266 — Rewrite `openspec-workflow.md` SSOT (depends on T001262)
+
+## Verification (after all PRs merge)
+
+- [ ] `task test:openspec` passes
+- [ ] `task test:changed` passes
+- [ ] `task freshness:check` passes
+- [ ] Manual review: in opencode, `/opsx:propose "test" --ticket T000001` (with a test ticket) creates `openspec/changes/test/specs/test.md` with non-stub content within 1 minute
+- [ ] `task openspec:archive` (the bash wrapper) is still callable as a backward-compat fallback
+
 ---
-title: "OpenSpec improvements batch: backfill + /opsx:* commands + polish [T001267]"
-ticket_id: T001267
-domains: [openspec, ci, docs, tooling]
-status: plan_staged
-file_locks: []
-shared_changes: false
-batch_id: null
-parent_feature: null
-depends_on_plans: []
----
 
-# Tasks: openspec-improvements-batch (T001267)
+## Rollback
 
-- [x] Task 0: Write failing tests in `tests/spec/openspec-workflow.bats`; run `bats tests/spec/openspec-workflow.bats` to verify it fails before any changes (expected: FAIL on all three guards)
-- [x] Task 1 (T001261-a): Investigate each of the 11 stub specs — backfill from archive or delete
-- [x] Task 2 (T001261-b): Backfill confirmed stubs from `openspec/changes/archive/<date>-<slug>/tasks.md`; delete phantom spec+change pairs
-- [x] Task 3 (T001261-c): Bulk-add `## Purpose` + `## Requirements` H2 headers to all 60 SSOT specs via awk pass; manual review of every changed spec
-- [x] Task 4 (T001261-d): Update `scripts/openspec-validate.ts` to enforce `## Purpose` and `## Requirements`; run `task test:openspec` — expected: PASS
-- [x] Task 5 (T001261-e): Open PR `chore(openspec): backfill 11 SSOT stubs + add Purpose/Requirements headers [T001261]`; merge after CI green
-- [ ] Task 6 (T001263-a): Run `openspec init --tools opencode,claude --profile core --force`; verify 4 `.opencode/commands/opsx-*.md` + 4 `.claude/skills/openspec-*/SKILL.md` created
-- [ ] Task 7 (T001263-b): Update `.claude/skills/dev-flow-plan/SKILL.md` — replace `task openspec:propose` with `/opsx:propose`
-- [ ] Task 8 (T001263-c): Update `.claude/skills/dev-flow-execute/SKILL.md` — replace `task openspec:apply` with `/opsx:apply`
-- [ ] Task 9 (T001263-d): Open PR `feat(openspec): install upstream workflow commands in .opencode + .claude [T001263]`; merge after CI green
-- [ ] Task 10 (T001265-a): Add `specs:` and `design:` keys to `openspec/config.yaml` under `rules:`
-- [ ] Task 11 (T001265-b): Add `OPENSPEC_TELEMETRY: '0'` to workflow-level `env:` in every `.github/workflows/*.yml`
-- [ ] Task 12 (T001265-c): Add "OpenSpec conventions" + "Dev experience" subsections to `AGENTS.md`
-- [ ] Task 13 (T001265-d): Open PR `chore(openspec): polish — frontmatter convention, rules, telemetry opt-out, completions [T001265]`; merge after CI green
-- [ ] Task 14 (Verify): `task test:changed` + `task freshness:regenerate` + `task freshness:check` + `task test:openspec` — all green; `task openspec:validate` — no errors
-
----
-
-# OpenSpec Improvements Batch — Implementation Plan
-
-> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:executing-plans
-
-**Goal:** Three independent improvements to the OpenSpec workflow, executed sequentially and shipped as three separate PRs.
-Sub-tickets: T001261 (backfill SSOT stubs + add Purpose/Requirements headers), T001263 (install /opsx:* commands), T001265 (polish: config.yaml rules, CI telemetry opt-out, AGENTS.md docs).
-T001264 is already shipped (commit cdc8d61f). T001262 + T001266 are parked per user instruction 2026-06-27.
-
-**Architecture:** All changes are content + config — no runtime code paths affected.
-Batch executes sequentially: T001261 PR → merge → T001263 PR → merge → T001265 PR → merge.
-Between PRs: pull main to keep the worktree current.
-
-## File Structure
-
-### New files
-- `tests/spec/openspec-workflow.bats` — BATS guards for all three acceptance criteria
-- `.opencode/commands/opsx-propose.md` — upstream propose workflow command
-- `.opencode/commands/opsx-explore.md` — upstream explore workflow command
-- `.opencode/commands/opsx-apply.md` — upstream apply workflow command
-- `.opencode/commands/opsx-archive.md` — upstream archive workflow command
-- `.claude/skills/openspec-propose/SKILL.md` — claude skill for propose
-- `.claude/skills/openspec-explore/SKILL.md` — claude skill for explore
-- `.claude/skills/openspec-apply/SKILL.md` — claude skill for apply
-- `.claude/skills/openspec-archive/SKILL.md` — claude skill for archive
-
-### Modified files
-- `openspec/specs/*.md` — 60 files: add `## Purpose` + `## Requirements` H2 headers; 11 stubs replaced or deleted
-- `scripts/openspec-validate.ts` (77 → ~120 lines; S1-budget vs. limit 600 = budget 523)
-- `.claude/skills/dev-flow-plan/SKILL.md` — reference `/opsx:propose` instead of `task openspec:propose`
-- `.claude/skills/dev-flow-execute/SKILL.md` — reference `/opsx:apply` instead of `task openspec:apply`
-- `openspec/config.yaml` — add `specs:` and `design:` keys under `rules:` (ungated .yaml)
-- `.github/workflows/*.yml` — 21 files, add `OPENSPEC_TELEMETRY: '0'` workflow-level env (ungated .yml)
-- `AGENTS.md` — 2 new subsections: "OpenSpec conventions" + "Dev experience" (ungated .md)
-
-## Task 0 — Failing tests (RED phase)
-
-Write `tests/spec/openspec-workflow.bats` with three guards before making any other changes. Run `bats tests/spec/openspec-workflow.bats` to verify it fails before changes (expected: FAIL on all three guards):
+Each ticket is a self-contained PR. To roll back:
 
 ```bash
-#!/usr/bin/env bats
-# tests/spec/openspec-workflow.bats
-# SSOT: openspec/specs/openspec-workflow.md
-
-REPO="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
-
-@test "T001261: all SSOT specs declare a ## Purpose header" {
-  local missing=0
-  for f in "$REPO"/openspec/specs/*.md; do
-    grep -q '^## Purpose' "$f" || { echo "MISSING: $f"; missing=1; }
-  done
-  [ "$missing" -eq 0 ]
-}
-
-@test "T001263: opsx-propose command is installed for opencode" {
-  [ -f "$REPO/.opencode/commands/opsx-propose.md" ]
-}
-
-@test "T001265: CI workflows opt out of OpenSpec telemetry" {
-  local missing=0
-  for f in "$REPO"/.github/workflows/*.yml; do
-    grep -q 'OPENSPEC_TELEMETRY' "$f" || { echo "MISSING: $f"; missing=1; }
-  done
-  [ "$missing" -eq 0 ]
-}
+git revert <merge-commit-sha>
 ```
 
-Run: `bats tests/spec/openspec-workflow.bats` — expected: FAIL on all three guards before any changes.
-Commit the test file alone so the CI baseline shows red.
-
-## Task 1 — T001261-a: Stub investigation
-
-For each of the 11 stub specs listed in `design.md`, determine the action:
-
-| Spec | Archive match | Action |
-|------|---------------|--------|
-| `active-sessions-hub.md` | `archive/2026-06-21-active-sessions-hub` | backfill |
-| `cockpit-direct-ticket-links.md` | `archive/2026-06-21-cockpit-direct-ticket-links` | backfill |
-| `openspec-pgvector.md` | `archive/2026-06-21-openspec-pgvector` | backfill |
-| `t1224-lockfile-drift.md` | `archive/2026-06-27-t1224-lockfile-drift` | backfill |
-| `ci-speed.md` | none | investigate → decide |
-| `fix-coaching-studio-prod-manifest.md` | none | investigate → decide |
-| `korczewski-monolith-keycloak-auth.md` | none | investigate → decide |
-| `openspec-ticket-detail-view.md` | none | investigate → decide |
-| `secrets-deploy-automation.md` | none | investigate → decide |
-| `sidekick-ai-quality.md` | none | investigate → decide |
-| `sidekick-cleanup-grilling-broadcast.md` | none | investigate → decide |
-
-For the "investigate → decide" group: if no archived change and no git history for the spec, delete. If git log shows real work ever happened, backfill from commits.
-
-## Task 2 — T001261-b: Backfill or delete stubs
-
-For each **backfill** target: read `openspec/changes/archive/<date>-<slug>/tasks.md` plus any delta spec. Rewrite the SSOT spec with real Requirements/Scenarios. Cite source as HTML comment (`<!-- from archive/... line N -->`).
-
-For each **delete** target: remove `openspec/specs/<name>.md` and its associated `openspec/changes/archive/<date>-<slug>/` folder if one exists. Do NOT touch other archived changes.
-
-Commit: `chore(openspec): stub audit — backfill N + delete M [T001261]`.
-
-## Task 3 — T001261-c: Bulk header injection
-
-Run an awk pass over all 60 specs in `openspec/specs/`. Each spec gets `## Purpose` before the first paragraph after the H1 title, and `## Requirements` before the first `### Requirement:` line.
-
-```bash
-# Dry-run first to review diffs:
-bash scripts/openspec-header-inject.sh --dry-run openspec/specs/
-# Then apply:
-bash scripts/openspec-header-inject.sh openspec/specs/
-```
-
-Write `scripts/openspec-header-inject.sh` as a one-shot helper (awk-based). After application:
-- `git diff --stat openspec/specs/` — should show exactly the 60 spec files modified, no others
-- Manual review: scan each diff for broken formatting before commit
-
-Commit: `chore(openspec): add Purpose + Requirements H2 to all 60 SSOT specs [T001261]`.
-
-## Task 4 — T001261-d: Validator enforcement
-
-Update `scripts/openspec-validate.ts` to assert that every `openspec/specs/*.md` file contains `^## Purpose` and `^## Requirements` lines. Add a new check after the existing stub detection:
-
-```typescript
-// New validator assertions (add after existing checks):
-if (!content.includes('\n## Purpose\n')) {
-  errors.push(`${specFile}: missing ## Purpose header`);
-}
-if (!content.includes('\n## Requirements\n')) {
-  errors.push(`${specFile}: missing ## Requirements header`);
-}
-```
-
-Run `task test:openspec` — expected: PASS (all specs were updated in Task 3).
-
-## Task 5 — T001261-e: Open PR
-
-```bash
-git push origin chore/openspec-improvements-batch
-gh pr create \
-  --title "chore(openspec): backfill 11 SSOT stubs + add Purpose/Requirements headers [T001261]" \
-  --body "$(cat openspec/changes/migrate-to-upstream-openspec/design.md | head -44)" \
-  --base main
-```
-
-Wait for CI green. Merge: `gh pr merge --squash --auto <pr-number>`. Pull main into worktree before proceeding to T001263.
-
-## Task 6 — T001263-a: Install upstream commands
-
-Install the upstream CLI on the host (one-time, not committed):
-```bash
-npm i -g @fission-ai/openspec@1.3.1
-```
-
-Run init in the repo root (committed):
-```bash
-openspec init --tools opencode,claude --profile core --force
-```
-
-Verify outputs:
-- `ls .opencode/commands/opsx-*.md` — 4 files
-- `ls .claude/skills/openspec-*/SKILL.md` — 4 files
-- `openspec config list` — shows `profile: core`
-
-Commit: `feat(openspec): install upstream /opsx:* workflow commands [T001263]`.
-
-## Task 7 — T001263-b: Update dev-flow-plan skill
-
-In `.claude/skills/dev-flow-plan/SKILL.md`, replace every reference to `task openspec:propose -- <slug>` or `bash scripts/openspec.sh propose` with `/opsx:propose <slug>`. Keep the existing `bash scripts/openspec.sh` fallback note in a code comment.
-
-## Task 8 — T001263-c: Update dev-flow-execute skill
-
-In `.claude/skills/dev-flow-execute/SKILL.md`, replace every reference to `task openspec:apply` with `/opsx:apply`. Keep `task openspec:apply` as fallback note.
-
-Commit both skill updates with Task 6 in one commit: `feat(openspec): update dev-flow skills to use /opsx:* commands [T001263]`.
-
-## Task 9 — T001263-d: Open PR
-
-```bash
-gh pr create \
-  --title "feat(openspec): install upstream workflow commands in .opencode + .claude [T001263]" \
-  --base main
-```
-
-Wait for CI green. Merge. Pull main into worktree before proceeding to T001265.
-
-## Task 10 — T001265-a: Expand config.yaml rules
-
-Add two new rule categories to `openspec/config.yaml` under the existing `rules:` key:
-
-```yaml
-  specs:
-    - Purpose auf Deutsch, Requirements auf Englisch, Scenarios auf Englisch (GIVEN/WHEN/THEN)
-  design:
-    - Goals/Non-Goals explizit trennen
-    - Decisions mit Begründung und ggf. Trade-offs
-```
-
-## Task 11 — T001265-b: CI telemetry opt-out
-
-For every `.github/workflows/*.yml` that does not already have `OPENSPEC_TELEMETRY`:
-
-```bash
-# Check which files are missing it:
-grep -rL 'OPENSPEC_TELEMETRY' .github/workflows/*.yml
-```
-
-For each missing file, add at the top-level `env:` block (or create one):
-```yaml
-env:
-  OPENSPEC_TELEMETRY: '0'
-```
-
-## Task 12 — T001265-c: Update AGENTS.md
-
-Add two subsections to `AGENTS.md`. Insert after the existing "Development workflow" section:
-
-```markdown
-### OpenSpec conventions
-
-Proposal and task files may include YAML frontmatter (parsed by `scripts/openspec-embed.mjs`).
-Language: Purpose sections in German; Requirements and Scenarios in English (GIVEN/WHEN/THEN).
-Rule source: `openspec/config.yaml` (keys: `proposal`, `tasks`, `specs`, `design`).
-
-### Dev experience
-
-After installing the OpenSpec CLI (`npm i -g @fission-ai/openspec@1.3.1`),
-run `openspec completion install` once to enable shell completions (bash/zsh/fish/powershell).
-```
-
-Commit: `chore(openspec): polish — config rules, telemetry opt-out, AGENTS.md [T001265]`.
-
-## Task 13 — T001265-d: Open PR
-
-```bash
-gh pr create \
-  --title "chore(openspec): polish — frontmatter convention, rules, telemetry opt-out, completions [T001265]" \
-  --base main
-```
-
-Wait for CI green. Merge.
-
-## Task 14 — Verify
-
-After all three PRs are merged and main is pulled:
-
-```bash
-task test:changed
-task freshness:regenerate
-task freshness:check
-task test:openspec
-bash scripts/openspec.sh validate
-```
-
-All commands must exit 0. Update `openspec/changes/migrate-to-upstream-openspec/.ticket` status to `done` via `bash scripts/ticket.sh update-status --id T001267 --status done`.
-
-Also update each sub-ticket:
-```bash
-bash scripts/ticket.sh update-status --id T001261 --status done
-bash scripts/ticket.sh update-status --id T001263 --status done
-bash scripts/ticket.sh update-status --id T001265 --status done
-```
+No cross-PR dependencies. T001261 is the highest priority because the upstream migration (T001262) becomes safer once it lands.

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -26,3 +26,10 @@ rules:
   tasks:
     - Aufgaben auf max. 2 Stunden Aufwand begrenzen
     - Jeden Task einem konkreten Dateipfad zuordnen wenn möglich
+  specs:
+    - Jede SSOT-Spec deklariert ## Purpose + ## Requirements H2-Header (enforced by scripts/openspec-validate.ts)
+    - Purpose-Text auf Deutsch, Requirements + Scenarios auf Englisch (GIVEN/WHEN/THEN)
+    - H3 ist ### Requirement: (H2 Requirement: ist verboten)
+  design:
+    - Goals und Non-Goals explizit trennen
+    - Decisions mit Begründung und ggf. Trade-offs dokumentieren

--- a/scripts/openspec-telemetry-optout.py
+++ b/scripts/openspec-telemetry-optout.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""
+scripts/openspec-telemetry-optout.py
+
+One-shot helper: add `OPENSPEC_TELEMETRY: '0'` to the workflow-level
+`env:` block of every GitHub Actions workflow under `.github/workflows/`
+that does not already declare it. If no workflow-level `env:` exists,
+insert a new one immediately before `jobs:`.
+
+Used by the OpenSpec improvements batch (T001265) to opt the entire
+CI fleet out of OpenSpec telemetry.
+
+Usage:
+  python3 scripts/openspec-telemetry-optout.py --dry-run .github/workflows/*.yml
+  python3 scripts/openspec-telemetry-optout.py .github/workflows/*.yml
+"""
+from __future__ import annotations
+
+import sys
+import argparse
+from pathlib import Path
+import re
+
+
+def process(path: Path, dry_run: bool) -> str:
+    text = path.read_text()
+    if 'OPENSPEC_TELEMETRY' in text:
+        return "ok-already"
+
+    lines = text.splitlines(keepends=True)
+
+    # Find top-level "env:" (column 0)
+    env_idx = None
+    for i, line in enumerate(lines):
+        if re.match(r'^env:\s*$', line):
+            env_idx = i
+            break
+
+    if env_idx is not None:
+        # Add OPENSPEC_TELEMETRY: '0' as a new entry under the existing env: block
+        # Find the end of the env block (first non-indented, non-blank line)
+        end_idx = env_idx + 1
+        while end_idx < len(lines):
+            l = lines[end_idx]
+            if l.strip() == '' or l.startswith(' ') or l.startswith('\t'):
+                end_idx += 1
+                continue
+            break
+        # Insert just before end_idx
+        insert = "  OPENSPEC_TELEMETRY: '0'\n"
+        lines.insert(end_idx, insert)
+    else:
+        # No env: — insert a new env: block before jobs:
+        jobs_idx = None
+        for i, line in enumerate(lines):
+            if re.match(r'^jobs:\s*$', line):
+                jobs_idx = i
+                break
+        if jobs_idx is None:
+            return "skip-no-jobs"
+        # Insert env: block with proper spacing
+        # Check if previous non-blank line is `---` (YAML doc separator) or has a blank line before
+        insert_at = jobs_idx
+        # If the line just before jobs is a block end (no blank), add a blank
+        if insert_at > 0 and lines[insert_at - 1].strip() != '':
+            lines.insert(insert_at, '\n')
+            insert_at += 1
+        # Ensure there's a blank line AFTER the env block, before jobs:
+        new_block = "env:\n  OPENSPEC_TELEMETRY: '0'\n\n"
+        lines.insert(insert_at, new_block)
+
+    new_text = ''.join(lines)
+    if new_text == text:
+        return "no-change"
+
+    if not dry_run:
+        path.write_text(new_text)
+    return "modified"
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument('files', nargs='+', help='GitHub Actions workflow YAML files')
+    ap.add_argument('--dry-run', action='store_true', help='Report changes without writing')
+    args = ap.parse_args()
+
+    counts = {"modified": 0, "ok-already": 0, "skip-no-jobs": 0, "no-change": 0}
+    for f in args.files:
+        p = Path(f)
+        if not p.exists():
+            print(f"MISSING: {f}", file=sys.stderr)
+            continue
+        result = process(p, args.dry_run)
+        if result == "modified":
+            prefix = "WOULD MODIFY" if args.dry_run else "MODIFIED"
+            print(f"{prefix}: {f}")
+        counts[result] = counts.get(result, 0) + 1
+
+    print()
+    print("=== summary ===")
+    for k, v in counts.items():
+        print(f"{k:20s} {v}")
+    if args.dry_run:
+        print("(dry-run — no files changed)")
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Closes T001265

Three small polish items land in one PR:

1. **Expand openspec/config.yaml rules.** Add `specs:` and `design:`
   rule categories under `rules:` to make the German/English language
   split and the ## Purpose + ## Requirements H2 contract explicit.
   `scripts/openspec-validate.ts` already enforces the H2 structure
   (T001261); the YAML now mirrors it.

2. **Opt all 21 CI workflows out of OpenSpec telemetry.** Add
   `OPENSPEC_TELEMETRY: '0'` to the workflow-level `env:` block of
   every `.github/workflows/*.yml`. For 5 files with an existing
   top-level env, the key is merged. For 16 files, a fresh env block
   is inserted before jobs:. Helper script
   `scripts/openspec-telemetry-optout.py` (idempotent, --dry-run)
   is committed for future re-application. Wired via
   `task openspec:ci-telemetry-optout`.

3. **Document the convention + dev experience in AGENTS.md.** Add
   two new H2 sections: 'OpenSpec conventions' (frontmatter, language,
   config.yaml keys) and 'Dev experience' (npm CLI install +
   `openspec completion install` + the /opsx:* slash-command
   workflow).

Tests:
- tests/spec/openspec-workflow.bats — T001265 guards (5/5 green)
- npm run test:openspec — passes
- bash scripts/openspec.sh validate — OK