### PR TITLE
chore(ci): enable built-in LSP servers for auto-activation on file-open

### DIFF
--- a/.opencode/opencode.jsonc
+++ b/.opencode/opencode.jsonc
@@ -2,6 +2,7 @@
   "$schema": "https://opencode.ai/config.json",
   "model": "lmstudio/hermes-3-llama-3.1-8b",
   "permission": "allow",
+  "lsp": true,
   "mcp": {
     // ── Monolith HTTP-Endpunkte (kubectl portforward via Taskfile) ────────
     "mcp-kubernetes": {


### PR DESCRIPTION
## Summary
- Adds `"lsp": true` to `.opencode/opencode.jsonc` to opt in to opencode's built-in language servers.
- Without this flag, **LSP is disabled by default** — no diagnostics flow back to the agent.
- With it, the matching built-in server auto-activates the moment a file with a registered extension is opened/read:
  - `.ts/.tsx/.js/.jsx` → typescript
  - `.astro` → astro, `.svelte` → svelte
  - `.yaml/.yml` → yaml-ls
  - `.tf/.tfvars` → terraform
  - `.sh/.bash/.zsh` → bash-language-server
  - `.py` → pyright (if installed)
  - etc.

## Why
Agent quality improves when language-server diagnostics (type errors, lint hints, undefined refs) feed back into the loop. Today the agent has to manually run `tsc` / `eslint` / etc., which costs tool round-trips and context.

## Test Plan
- [ ] Merge → restart opencode session
- [ ] Open `website/src/pages/index.astro` and confirm `astro` LSP attaches (diagnostics surface)
- [ ] Open a `.ts` file and confirm `typescript` LSP attaches

🤖 chore (no ticket — single-line tooling opt-in)