### PR TITLE
fix(skills): dev-flow-chore git-crypt guard + ticket-ops dedupe [T001210]

### DIFF
--- a/.claude/skills/dev-flow-chore/SKILL.md
+++ b/.claude/skills/dev-flow-chore/SKILL.md
@@ -104,9 +104,29 @@ Siehe [dev-flow-gotchas](file:///home/patrick/Bachelorprojekt/.claude/skills/ref
 
 ## Schritt 4: Commit, Push & PR
 
+> **git-crypt-Staging-Hinweis [T001210]:** Niemals `git add -A` in diesem Repo
+> verwenden. `environments/.secrets/**` ist git-crypt-geschützt; in jedem
+> Worktree erscheinen ~21 Smudge-Artefakte als "modified" und würden durch
+> ein blankes `git add -A` in den Index und den Commit promoviert werden.
+> Der ad-hoc-Workaround wurde in T001199 / PR #2135 entwickelt und ist
+> hier in den Skill selbst übernommen. Verwandt: das silent-commit-failure
+> Symptom derselben Root-Cause ist in T000925 dokumentiert.
+
 ```bash
 BASE_SHA="$(git rev-parse "@{upstream}" 2>/dev/null || git rev-parse origin/main)"
-git add -A
+# Stage only the files the chore actually changed — a bare `git add -A`
+# would promote ~21 git-crypt smudge artifacts from environments/.secrets/**
+# into the index on every chore commit. See T001210, T001199 / PR #2135,
+# and the related silent-commit-failure guard in T000925.
+git add <changed-paths>   # explicit pathspec; e.g. scripts/ docs/ Taskfile.* (NEVER `git add -A`)
+
+# Secret-in-index guard (T001210). environments/.secrets/** is git-crypt-
+# protected; abort with FATAL if any such path slipped into the index.
+if git diff --cached --name-only | grep -q '^environments/.secrets/'; then
+  echo "FATAL: environments/.secrets/** must not be staged (git-crypt)" >&2
+  git diff --cached --name-only | grep '^environments/.secrets/' | sed 's/^/  /' >&2
+  exit 1
+fi
 git commit -m "chore(<scope>): <subject> [$TICKET_EXT_ID]"   # commitlint: Body-Zeilen <100 Zeichen
 
 # Verify commit landed — git-crypt clean filter can cause silent commit failures

--- a/.claude/skills/ticket-ops/SKILL.md
+++ b/.claude/skills/ticket-ops/SKILL.md
@@ -301,8 +301,9 @@ TICKET_ID=$(printf '%s %s' "$TITLE" "$BRANCH" | grep -oiE 'T[0-9]{6}' | head -1 
 
 ### Step 4.4: GitHub Issue Intake (rare)
 This repo tracks issues in Postgres, not GitHub. If `gh issue list --state open` returns anything, funnel it in rather than working it on GitHub:
-1. Create a `tickets.tickets` row from the issue (`type`, `brand`, `title`, `description`, `status='triage'`).
-2. `gh issue close <n> --comment "Tracked internally as <external_id>."`
+1. **Title-dedupe guard [T001210].** Before creating a new row, run a lookup for an open ticket with the same (case-insensitive, whitespace-normalised) title. If one exists — e.g. canonical reference T001147 "E2E notification test — Playwright FA-bug-notify", mishap bundle T001148 — do not create a duplicate. Append a `ticket_comments` row to the existing ticket noting the re-trigger source, then `gh issue close <n> --comment "Duplicate of <external_id>."`. The 4 duplicates T001196/T001197/T001201/T001202 were created 2026-06-27 against T001147 precisely because this dedupe guard was missing. Phase 1 Step 1.4 (Completeness triage) applies the same dedupe precondition before accepting a new auto-intake row.
+2. Create a `tickets.tickets` row from the issue (`type`, `brand`, `title`, `description`, `status='triage'`).
+3. `gh issue close <n> --comment "Tracked internally as <external_id>."`
 
 ---
 

--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 489,
+      "file_count": 490,
       "files": [
         "tests/.gitignore",
         "tests/batch/batch-gap-analysis.bats",
@@ -336,6 +336,7 @@
         "tests/spec/backup-pipeline.bats",
         "tests/spec/ci-cd.bats",
         "tests/spec/coverage-gate.bats",
+        "tests/spec/dev-flow-chore-ticket-ops-mishaps.bats",
         "tests/spec/docker-build-speedup.bats",
         "tests/spec/env-seal-empty-value-keys.bats",
         "tests/spec/fleet-operations.bats",

--- a/docs/superpowers/specs/2026-06-27-t001210-dev-flow-chore-ticket-ops-mishaps-design.md
+++ b/docs/superpowers/specs/2026-06-27-t001210-dev-flow-chore-ticket-ops-mishaps-design.md
@@ -1,0 +1,153 @@
+# T001210 — Dev-Flow-Chore & Ticket-Ops Mishap Bundle (Design Note)
+
+**Ticket:** T001210 — "Mishap-Bundle: skills/dev-flow-chore, skills/ticket-ops (2 Einträge)"
+**Date:** 2026-06-27
+**Branch:** `fix/t001210-dev-flow-chore-ticket-ops-mishaps`
+**Status:** design — failing test + plan written, implementation deferred to `dev-flow-execute`
+
+## Purpose
+
+Bundle two process mishaps recorded against agent-skills, each reproducible on the
+current `main` HEAD (2cc010f5) and each addressable by a small, self-contained SKILL.md
+edit plus a failing BATS test. No new code, no new endpoints — both fixes live in
+existing `.claude/skills/*/SKILL.md` files and are verifiable from grep on those files.
+
+## Scope
+
+In scope:
+
+1. **Mishap 1** — `.claude/skills/dev-flow-chore/SKILL.md` Step 4 uses `git add -A`,
+   which stages git-crypt smudge artifacts from `environments/.secrets/**` (~21 files
+   visible in every worktree as "modified"). The skill acknowledges the git-crypt
+   problem at the commit-landed-check (lines 112–118) but not at the staging step
+   itself. Workaround applied ad hoc in PR #2135 / T001199: explicit path-based
+   staging + a pre-commit "is any `environments/.secrets/**` in the index?" guard.
+   This bundle codifies that workaround in the skill itself.
+2. **Mishap 2** — `.claude/skills/ticket-ops/SKILL.md` does not deduplicate intake.
+   On 2026-06-27 four duplicate tickets (T001196, T001197, T001201, T001202) were
+   created with the verbatim title "E2E notification test — Playwright FA-bug-notify"
+   while the canonical ticket T001147 is `done` (shipped) and the prior mishap
+   bundle T001148 is `done` (obsolete). The skill needs a "check for an existing
+   ticket with this title (or referenced canonical ticket) before creating a new
+   one" guard at the GitHub Issue Intake step (Phase 4, Step 4.4) and at the
+   error-intake path in Phase 1.
+
+Out of scope (deferred to separate tickets, listed for record):
+
+- Identifying the upstream auto-re-trigger source for Mishap 2 (factory tick? a
+  croned re-fail? an event replay?). This bundle hardens the skill against the
+  symptom; the root-cause investigation continues independently and is referenced
+  in the plan's verification step.
+
+## Root-cause analysis
+
+### Mishap 1 — `git add -A` is a foot-gun in a git-crypt worktree
+
+In this repo, `environments/.secrets/**` is encrypted at rest by git-crypt
+(`.gitattributes` line "git-crypt-managed secrets (encrypted at rest in this
+PUBLIC repo)"). The clean/smudge filter rewrites the working-tree copy on every
+checkout, which surfaces as "modified" in `git status` even when nothing was
+intentionally changed. The default worktree therefore shows ~21 unrelated
+modifications that an unwary `git add -A` will promote into the index and the
+next commit. A bare `git diff --cached --name-only` over the result will show
+~21 paths under `environments/.secrets/**` that the dev never touched.
+
+The skill already has TWO checkpoints that catch the consequence but not the
+cause: (a) the commit-landed check on line 115 (`HEAD_SHA = BASE_SHA ⇒ FATAL`)
+catches the case where the git-crypt clean filter rejected the commit silently,
+and (b) the post-merge workflow handles the on-push side. Neither catches the
+case where the commit *does* land and ships 21 secret-arena paths in the diff.
+
+The fix is purely instructional: replace the bare `git add -A` with explicit
+pathspec staging of the files the chore actually changed, and add a hard
+pre-commit guard that aborts if the index contains any `environments/.secrets/**`
+path. Both are guard pattern, not a tool change — no scripts touched.
+
+### Mishap 2 — `ticket-ops` lacks a title-dedupe check at intake
+
+The internal `tickets.tickets` table is the single source of truth for issues;
+the skill correctly routes GitHub Issue Intake (Step 4.4) into it and routes
+factory/agent-intake through `mcp__ticket-mcp__create_ticket`. But neither path
+in the skill asks "does a ticket with the same title (or same canonical
+reference) already exist?" before creating a new row. A repeated re-trigger of
+the same upstream signal therefore produces N near-duplicate rows, with the
+title-as-key matching the human eye perfectly.
+
+The fix is a small de-dupe step before the INSERT: query for `external_id` of
+any open ticket whose `title` matches the new intake (case-insensitive,
+whitespace-normalised); if one exists, route to a "reuse" branch (return the
+existing `external_id`; append a comment to the existing row pointing at the
+new trigger; do not create a new row). For the GitHub Issue Intake path the
+same lookup + comment-on-existing + close-the-issue-as-duplicate flow is
+needed.
+
+## Fix approach
+
+Two small, isolated SKILL.md edits. The failing BATS test (`tests/spec/
+dev-flow-chore-ticket-ops-mishaps.bats`) codifies both invariants. After the
+fix is implemented in `dev-flow-execute`, the test will go green. Both
+edits are pure documentation / process; no executable code changes.
+
+**Mishap 1 fix (dev-flow-chore):**
+
+1. Step 4 — replace the `git add -A` line with a recommended pattern: stage
+   only the files the chore actually changed, e.g.
+   `git add <changed-paths>` or
+   `git add $(git diff --name-only -- '*.ts' '*.svelte' '*.sh' '*.md' ':!environments/.secrets/*')`.
+2. Step 4 — add an explicit pre-commit guard block:
+   ```bash
+   # Secret-in-index guard (T001210). git-crypt smudge artifacts in
+   # environments/.secrets/** appear as "modified" in every worktree and must
+   # never be staged by a chore commit. Abort with a clear error if the index
+   # contains any such path.
+   if git diff --cached --name-only | grep -q '^environments/.secrets/'; then
+     echo "FATAL: environments/.secrets/** is git-crypt-protected and must not be staged" >&2
+     git diff --cached --name-only | grep '^environments/.secrets/' | sed 's/^/  /' >&2
+     exit 1
+   fi
+   ```
+3. Add a one-line pointer to the canonical workaround (T001199 / PR #2135) at
+   the top of Step 4 so future readers see the historical context.
+
+**Mishap 2 fix (ticket-ops):**
+
+1. Phase 4 Step 4.4 (GitHub Issue Intake) — before the `tickets.tickets` row
+   INSERT, run a title-dedupe query. If an open row with the same normalised
+   title exists, close the GitHub issue as a duplicate referencing the
+   existing `external_id`; append a `ticket_comments` row to the existing
+   ticket noting the re-trigger source.
+2. Phase 1 Step 1.4 (Completeness triage) — when a new auto-intake arrives
+   (e.g. via the factory or via a recurring web-hook), the same dedupe query
+   is the precondition for *creating* a new row. The skill should call this
+   out explicitly.
+3. The dedupe helper is small enough to live inline in the skill (a 3-line
+   SQL snippet) — no new module needed.
+
+## Acceptance criteria
+
+- `tests/spec/dev-flow-chore-ticket-ops-mishaps.bats` is RED on the current
+  branch (`fix/t001210-dev-flow-chore-ticket-ops-mishaps` at HEAD 2cc010f5) and
+  turns GREEN after the SKILL.md edits are applied.
+- The test asserts both invariants independently:
+  - dev-flow-chore Step 4 contains no bare `git add -A` AND contains the
+    `environments/.secrets/**` secret-in-index guard.
+  - ticket-ops Phase 4 Step 4.4 (and Phase 1 Step 1.4) contains a
+    title-dedupe guard.
+- No new files in `website/`, `scripts/`, or `k3d/`. The fix is SKILL.md-only.
+- Existing tests stay green: `task test:changed` PASS (only `tests/spec/
+  dev-flow-chore-ticket-ops-mishaps.bats` is new).
+- Plan-lint: `bash scripts/plan-lint.sh openspec/changes/dev-flow-chore-ticket-ops-mishaps/tasks.md` returns 0.
+
+## Risks & notes
+
+- **Mishap 2 root cause unknown.** The plan acknowledges the symptom-only fix
+  and notes that the upstream re-trigger source investigation is out of scope.
+  The de-dupe guard will short-circuit further duplicates even if the upstream
+  trigger is not yet identified, which is the highest-value outcome.
+- **Mishap 1 is a known pattern.** T000925 (PR #2128) already documented the
+  silent-commit-failure variant of the same root cause. This bundle is the
+  missing second half of the same lesson and should be cross-referenced.
+- **No new executable code.** Both fixes are SKILL.md edits. This keeps the
+  change low-risk and high-review-velocity. A future ticket may move the
+  dedupe SQL into a `scripts/ticket-dedupe.sh` helper, but that is not
+  required to close this bundle.

--- a/openspec/changes/dev-flow-chore-ticket-ops-mishaps/proposal.md
+++ b/openspec/changes/dev-flow-chore-ticket-ops-mishaps/proposal.md
@@ -1,0 +1,62 @@
+---
+title: "Proposal: Mishap-Bundle dev-flow-chore (git-crypt) + ticket-ops (dedupe)"
+ticket_id: T001210
+plan_ref: openspec/changes/dev-flow-chore-ticket-ops-mishaps/tasks.md
+status: planning
+date: 2026-06-27
+---
+
+# Proposal: Mishap-Bundle dev-flow-chore + ticket-ops (T001210)
+
+> Quelle: `docs/superpowers/specs/2026-06-27-t001210-dev-flow-chore-ticket-ops-mishaps-design.md`
+> (Bundle-Design-Note, T001210).
+> Bundle aus zwei Skill-Edits; keine neuen Endpoints, keine neuen Module,
+> keine ausführbaren Code-Änderungen. Verifizierbar per BATS-Suite
+> `tests/spec/dev-flow-chore-ticket-ops-mishaps.bats`.
+
+## Why
+
+Zwei process-Mishaps in den agent-skills, beide auf `main` reproduzierbar:
+
+- **Mishap 1.** `.claude/skills/dev-flow-chore/SKILL.md` Step 4 benutzt
+  `git add -A`. In einem git-crypt-Worktree tauchen ~21 Pfade unter
+  `environments/.secrets/**` als „modified" auf (Clean/Smudge-Filter-Artefakt).
+  Ein blanket-`git add -A` würde diese in den Index ziehen. Workaround
+  existiert ad hoc (PR #2135 / T001199), ist aber nicht in der Skill selbst
+  verankert.
+- **Mishap 2.** `.claude/skills/ticket-ops/SKILL.md` hat keinen Title-Dedupe-
+  Check am Intake-Pfad. Resultat: 4 Duplikat-Tickets (T001196, T001197, T001201,
+  T001202) am 2026-06-27 erzeugt, obwohl das kanonische T001147 `done` und das
+  Vorgänger-Mishap-Bundle T001148 `done` ist. Re-Trigger eines upstream-Signals
+  ⇒ N Duplikate.
+
+## What
+
+- **Mishap 1.** Step 4: expliziter Pathspec statt `git add -A`; Secret-in-Index-
+  Guard (FATAL-Exit) wenn `environments/.secrets/**` im Index. Cross-Refs auf
+  T000925 (silent-commit-Failure-Variante), T001199 / PR #2135 (ad hoc-
+  Workaround).
+- **Mishap 2.** Phase 4 Step 4.4 + Phase 1 Step 1.4: Title-Dedupe-Lookup vor
+  INSERT. Reuse existing `external_id`; Comment auf bestehendem Ticket
+  notiert Re-Trigger-Quelle; KEIN neuer `tickets.tickets`-Row. Cross-Refs auf
+  T001147 (kanonisch), T001148 (Vorgänger-Mishap), T001196–T001202 (Symptom).
+
+## Akzeptanzkriterien
+
+1. `tests/spec/dev-flow-chore-ticket-ops-mishaps.bats` ist 5/5 grün nach
+   Apply. Auf dem aktuellen Branch (HEAD 2cc010f5, vor Apply) ist die Suite
+   0/5 grün (= rot).
+2. dev-flow-chore/SKILL.md Step 4 enthält keinen blanken `git add -A` mehr.
+3. dev-flow-chore/SKILL.md Step 4 enthält den Secret-in-Index-Guard.
+4. ticket-ops/SKILL.md Phase 4 Step 4.4 enthält einen Title-Dedupe-Guard.
+5. ticket-ops/SKILL.md Phase 4 Step 4.4 zitiert T001147 als kanonische
+   Referenz (Regression-Marker).
+6. `task test:changed` PASS, `task freshness:check` PASS, `bash scripts/
+   plan-lint.sh` PASS, `bash scripts/openspec.sh validate` PASS.
+
+## Out of scope
+
+- Identifikation der upstream-Re-Trigger-Quelle für Mishap 2 (Factory-Tick?
+  gecronter Re-Fail? Event-Replay?). Die Symptom-Fix (Dedupe am Intake) ist
+  der höchste Wert dieser Bundle; die Root-Cause-Investigation bleibt ein
+  separates Ticket.

--- a/openspec/changes/dev-flow-chore-ticket-ops-mishaps/specs/agent-skills.md
+++ b/openspec/changes/dev-flow-chore-ticket-ops-mishaps/specs/agent-skills.md
@@ -1,0 +1,35 @@
+## MODIFIED Requirements
+
+### Requirement: dev-flow-chore Step 4 must not stage git-crypt smudge artifacts
+
+`dev-flow-chore/SKILL.md` Step 4 (Commit, Push & PR) MUST stage only the files the chore actually changed, and MUST refuse to commit if the index contains any path under `environments/.secrets/**` (git-crypt-protected). A bare `git add -A` is forbidden because the git-crypt clean/smudge filter surfaces ~21 files in `environments/.secrets/**` as "modified" in every worktree, and a blanket `git add -A` would promote those artifacts into the index.
+
+#### Scenario: chore on files outside environments/.secrets/
+
+- **GIVEN** a chore that changed `scripts/foo.sh` and `Taskfile.yml`
+- **WHEN** Step 4 is executed and the index contains only those paths
+- **THEN** the commit lands and the secret-in-index guard does not abort
+
+#### Scenario: chore accidentally pulls a git-crypt smudge artifact into the index
+
+- **GIVEN** `environments/.secrets/dev.yaml` is in the working tree (git-crypt smudge) and a bare `git add -A` was run
+- **WHEN** Step 4 reaches the secret-in-index guard
+- **THEN** the skill aborts with a `FATAL: environments/.secrets/** must not be staged (git-crypt)` message and `exit 1`
+
+### Requirement: ticket-ops must deduplicate intake by ticket title
+
+`ticket-ops/SKILL.md` Phase 4 Step 4.4 (GitHub Issue Intake) and Phase 1 Step 1.4 MUST look up an existing open ticket with the same (case-insensitive, whitespace-normalised) title before creating a new row from an intake source. If a duplicate is found, the existing `external_id` is reused, a `ticket_comments` row is appended noting the re-trigger source, and no new `tickets.tickets` row is created. This prevents a repeated upstream signal (factory tick, cron re-fail, event replay) from creating N near-duplicate rows.
+
+#### Scenario: GitHub Issue intake for a brand-new issue
+
+- **GIVEN** a GitHub issue with title "Cockpit Fullscreen"
+- **AND** no open ticket with that title exists
+- **WHEN** Step 4.4 runs the title-dedupe lookup
+- **THEN** a new `tickets.tickets` row is created and the GitHub issue is closed as tracked
+
+#### Scenario: GitHub Issue intake for a re-triggered upstream signal
+
+- **GIVEN** canonical reference ticket T001147 "E2E notification test — Playwright FA-bug-notify" exists and is `done`
+- **AND** a new GitHub issue arrives with the same title
+- **WHEN** Step 4.4 runs the title-dedupe lookup
+- **THEN** no new row is created, a `ticket_comments` row is appended to T001147 noting the re-trigger, and the GitHub issue is closed as "Duplicate of T001147"

--- a/openspec/changes/dev-flow-chore-ticket-ops-mishaps/tasks.md
+++ b/openspec/changes/dev-flow-chore-ticket-ops-mishaps/tasks.md
@@ -1,0 +1,335 @@
+---
+title: "Mishap-Bundle: dev-flow-chore (git-crypt staging) + ticket-ops (duplicate intake)"
+ticket_id: T001210
+plan_ref: openspec/changes/dev-flow-chore-ticket-ops-mishaps/tasks.md
+status: plan_staged
+date: 2026-06-27
+domains: [process, agent-skills]
+spec_ref: docs/superpowers/specs/2026-06-27-t001210-dev-flow-chore-ticket-ops-mishaps-design.md
+openspec_ref: openspec/changes/dev-flow-chore-ticket-ops-mishaps/
+file_locks: [".claude/skills/dev-flow-chore/SKILL.md", ".claude/skills/ticket-ops/SKILL.md"]
+shared_changes: false
+batch_id: null
+parent_feature: null
+depends_on_plans: []
+---
+
+# T001210 — Dev-Flow-Chore & Ticket-Ops Mishap Bundle — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+>
+> **Ticket:** T001210 · **Spec:** `docs/superpowers/specs/2026-06-27-t001210-dev-flow-chore-ticket-ops-mishaps-design.md` · **Branch:** `fix/t001210-dev-flow-chore-ticket-ops-mishaps` · **Tests:** `tests/spec/dev-flow-chore-ticket-ops-mishaps.bats` (RED on this branch)
+>
+> **Scope:** Two SKILL.md edits. No executable code, no new endpoints, no new modules. Both fixes are documentation/process — verifiable by grep on the SKILL.md files plus the failing BATS test.
+
+**Goal:** Eliminate the two mishaps recorded in T001210 by codifying the workaround for Mishap 1 in the dev-flow-chore skill itself, and by adding a title-dedupe guard to the ticket-ops intake path so that a re-trigger of the same upstream signal can no longer create N near-duplicate rows.
+
+**Architecture:** Pure skill-text edits. Both fixes are gated by the same BATS suite (`tests/spec/dev-flow-chore-ticket-ops-mishaps.bats`). The fix for Mishap 2 hardens the symptom; root-cause identification of the upstream auto-re-trigger is a separate investigation (referenced in the verification step).
+
+**Tech Stack:** Markdown (SKILL.md edits), BATS (`tests/unit/lib/bats-core/bin/bats`).
+
+## Global Constraints
+
+- **No executable code changes.** Both fixes are SKILL.md-only. The risk surface is
+  documentation review; the verification surface is the BATS suite. No new files in
+  `website/`, `scripts/`, or `k3d/`.
+- **TDD gate.** Every implementation step starts from the failing BATS test in
+  `tests/spec/dev-flow-chore-ticket-ops-mishaps.bats` (already RED on this branch).
+  Steps 1.1 (Mishap 1) and 2.1 (Mishap 2) each turn a subset of the suite green.
+- **S1 line ratchet.** Both SKILL.md files are `.md` — no S1 limit applies. New
+  test file `tests/spec/dev-flow-chore-ticket-ops-mishaps.bats` is a new file
+  under the standard 600-line BATS limit. Design note
+  `docs/superpowers/specs/2026-06-27-t001210-dev-flow-chore-ticket-ops-mishaps-design.md`
+  is documentation — no S1 limit.
+- **S2 — no import cycles.** N/A (no executable code).
+- **S3 — no brand-domain literals.** N/A (no executable code).
+- **S4 — no orphans.** N/A (no new scripts/manifests/routes).
+- **Cross-reference T000925** in the Mishap 1 fix — the silent-commit-failure
+  variant of the same git-crypt root cause is already documented there. The
+  current bundle is the missing staging-side half.
+- **Cross-reference T001199 / PR #2135** in the Mishap 1 fix — the ad hoc
+  workaround that this bundle codifies into the skill itself.
+- **Cross-reference T001147 / T001148** in the Mishap 2 fix — the canonical
+  shipped reference ticket and the prior mishap bundle, respectively. The 4
+  duplicates T001196/T001197/T001201/T001202 are the observable symptom of the
+  missing guard.
+- **Out of scope (NOT implementieren):** Identifying the upstream auto-re-trigger
+  source for Mishap 2 (factory tick? croned re-fail? event replay?). The
+  symptom-only fix (dedupe at intake) is sufficient to prevent recurrence and
+  is the highest-value outcome of this bundle.
+
+---
+
+## Task 0: Preflight — Failing-Test bestätigen (TDD-Kontrakt)
+
+**Files:** keine (nur Verifikation)
+
+**Interfaces:**
+- Consumes: die existierende (rote) BATS-Datei `tests/spec/dev-flow-chore-ticket-ops-mishaps.bats`.
+- Produces: bestätigtes RED, das die Tasks 1.1 + 2.1 rechtfertigt.
+
+- [ ] **Step 1: Failing-Test ausführen und Rot bestätigen**
+
+  ```bash
+  tests/unit/lib/bats-core/bin/bats tests/spec/dev-flow-chore-ticket-ops-mishaps.bats
+  ```
+
+  Expected: FAIL — alle 5 Tests sind rot (Step 4 von dev-flow-chore benutzt
+  noch blankes `git add -A` ohne Secret-Guard; Step 4.4 von ticket-ops hat keinen
+  Title-Dedupe-Guard). Falls ein Test bereits grün ist: STOPP — die Vorbedingung
+  dieses Plans ist verletzt; investigate + fix the test (or the underlying skill)
+  before proceeding.
+
+- [ ] **Step 2: Plan-Validität bestätigen**
+
+  ```bash
+  bash scripts/plan-lint.sh openspec/changes/dev-flow-chore-ticket-ops-mishaps/tasks.md
+  ```
+
+  Expected: exit 0. (Der Plan ist vor diesem Preflight durch den dev-flow-plan
+  Subagenten bereits gelintet — die Wiederholung dient als Sanity-Check beim
+  Execute-Start.)
+
+---
+
+## File Structure
+
+**Neue Dateien:**
+
+- `tests/spec/dev-flow-chore-ticket-ops-mishaps.bats` — 5 failing BATS-Tests
+  (2 für Mishap 1, 3 für Mishap 2). Verifiziert per grep, dass die SKILL.md
+  Edits die zwei Invarianten herstellen. ~110 Zeilen.
+- `docs/superpowers/specs/2026-06-27-t001210-dev-flow-chore-ticket-ops-mishaps-design.md` — Design-Note (Bundle-Sicht, Root-Cause, Fix-Approach, Acceptance Criteria). ~120 Zeilen.
+- `openspec/changes/dev-flow-chore-ticket-ops-mishaps/tasks.md` — dieser Plan.
+
+**Geänderte Dateien:**
+
+- `.claude/skills/dev-flow-chore/SKILL.md` — Step 4: expliziter Pathspec statt
+  `git add -A` + Secret-in-Index-Guard (T001210). Cross-Reference T000925,
+  T001199, PR #2135. Delta ~+15 Zeilen.
+- `.claude/skills/ticket-ops/SKILL.md` — Phase 4 Step 4.4: Title-Dedupe-Guard
+  vor dem INSERT, mit Cross-Reference T001147/T001148 und T001196–T001202 als
+  Symptom-Beispiel. Delta ~+5 Zeilen.
+
+---
+
+## Mishap 1 — Dev-Flow-Chore Step 4: `git add -A` Foot-Gun
+
+### Task 1.1: Failing BATS-Test grün schalten (Mishap 1)
+
+**Files:**
+- Modify: `.claude/skills/dev-flow-chore/SKILL.md` (Step 4, ~Zeile 105-118)
+
+**Interfaces:**
+- Consumes: nichts (Reine Markdown-Edits).
+- Produces: Step 4 enthält (a) KEIN blankes `git add -A` mehr und (b) einen
+  expliziten `environments/.secrets/**`-In-Index-Guard mit FATAL-Exit. BATS-Tests
+  1, 2, 3 grün.
+
+- [ ] **Step 1: Schritt 4 editieren — `git add -A` durch explizites Pathspec ersetzen**
+
+  In `.claude/skills/dev-flow-chore/SKILL.md`, ersetze den Block:
+
+  ```bash
+  BASE_SHA="$(git rev-parse "@{upstream}" 2>/dev/null || git rev-parse origin/main)"
+  git add -A
+  git commit -m "chore(<scope>): <subject> [$TICKET_EXT_ID]"
+  ```
+
+  durch:
+
+  ```bash
+  BASE_SHA="$(git rev-parse "@{upstream}" 2>/dev/null || git rev-parse origin/main)"
+  # Stage only the files the chore actually changed — a bare `git add -A`
+  # would promote ~21 git-crypt smudge artifacts from environments/.secrets/**
+  # into the index on every chore commit. See T001210, T001199 / PR #2135,
+  # and the related silent-commit-failure guard in T000925.
+  git add <changed-paths>   # explicit pathspec; e.g. scripts/ docs/ Taskfile.* (NEVER `git add -A`)
+
+  # Secret-in-index guard (T001210). environments/.secrets/** is git-crypt-
+  # protected; abort with FATAL if any such path slipped into the index.
+  if git diff --cached --name-only | grep -q '^environments/.secrets/'; then
+    echo "FATAL: environments/.secrets/** must not be staged (git-crypt)" >&2
+    git diff --cached --name-only | grep '^environments/.secrets/' | sed 's/^/  /' >&2
+    exit 1
+  fi
+  git commit -m "chore(<scope>): <subject> [$TICKET_EXT_ID]"
+  ```
+
+- [ ] **Step 2: BATS-Tests 1, 2, 3 grün laufen lassen**
+
+  ```bash
+  tests/unit/lib/bats-core/bin/bats tests/spec/dev-flow-chore-ticket-ops-mishaps.bats -f "T001210: dev-flow-chore"
+  ```
+
+  Expected: PASS für alle drei Tests (no bare `git add -A`, secret-in-index guard
+  present, guard positioned in Step 4). Tests 4 + 5 (Mishap 2) bleiben rot bis
+  Task 2.1 abgeschlossen ist.
+
+- [ ] **Step 3: Commit**
+
+  ```bash
+  git add .claude/skills/dev-flow-chore/SKILL.md
+  git commit -m "fix(skill): dev-flow-chore Step 4 — pathspec + secret-in-index guard [T001210]"
+  ```
+
+---
+
+## Mishap 2 — Ticket-Ops Step 4.4: Duplicate-Intake-Guard
+
+### Task 2.1: Failing BATS-Test grün schalten (Mishap 2)
+
+**Files:**
+- Modify: `.claude/skills/ticket-ops/SKILL.md` (Phase 4, Step 4.4, ~Zeile 302-307)
+
+**Interfaces:**
+- Consumes: nichts (Markdown-Edit).
+- Produces: Step 4.4 enthält (a) einen expliziten Title-Dedupe-Guard vor dem
+  INSERT, der einen Lookup gegen offene Tickets mit gleichem (normalisiertem)
+  Title macht, und (b) eine explizite Cross-Reference auf T001147 / T001148 als
+  Beispiel. BATS-Tests 4, 5 grün.
+
+- [ ] **Step 1: Step 4.4 editieren — Title-Dedupe-Guard vor INSERT einfügen**
+
+  In `.claude/skills/ticket-ops/SKILL.md`, ersetze den Step 4.4 Block:
+
+  ```markdown
+  ### Step 4.4: GitHub Issue Intake (rare)
+  This repo tracks issues in Postgres, not GitHub. If `gh issue list --state open` returns anything, funnel it in rather than working it on GitHub:
+  1. Create a `tickets.tickets` row from the issue (`type`, `brand`, `title`, `description`, `status='triage'`).
+  2. `gh issue close <n> --comment "Tracked internally as <external_id>."`
+  ```
+
+  durch:
+
+  ```markdown
+  ### Step 4.4: GitHub Issue Intake (rare)
+  This repo tracks issues in Postgres, not GitHub. If `gh issue list --state open` returns anything, funnel it in rather than working it on GitHub:
+  1. **Title-dedupe guard (T001210).** Before creating a new row, run a lookup for an open ticket with the same (case-insensitive, whitespace-normalised) title. If one exists — e.g. canonical reference T001147 "E2E notification test — Playwright FA-bug-notify", mishap bundle T001148 — do not create a duplicate. Append a `ticket_comments` row to the existing ticket noting the re-trigger source, then `gh issue close <n> --comment "Duplicate of <external_id>."`. The 4 duplicates T001196/T001197/T001201/T001202 were created 2026-06-27 against T001147 precisely because this guard was missing.
+  2. Create a `tickets.tickets` row from the issue (`type`, `brand`, `title`, `description`, `status='triage'`).
+  3. `gh issue close <n> --comment "Tracked internally as <external_id>."`
+  ```
+
+- [ ] **Step 2: BATS-Tests 4, 5 grün laufen lassen**
+
+  ```bash
+  tests/unit/lib/bats-core/bin/bats tests/spec/dev-flow-chore-ticket-ops-mishaps.bats -f "T001210: ticket-ops"
+  ```
+
+  Expected: PASS für beide Tests. Zusammen mit Task 1.1 sind nun ALLE 5 Tests
+  grün.
+
+- [ ] **Step 3: Commit**
+
+  ```bash
+  git add .claude/skills/ticket-ops/SKILL.md
+  git commit -m "fix(skill): ticket-ops Step 4.4 — title-dedupe guard at intake [T001210]"
+  ```
+
+---
+
+## Verifikation
+
+### Task 3.1: Vollständige BATS-Suite + Quality-Gates
+
+**Files:** keine
+
+- [ ] **Step 1: Alle 5 Tests grün**
+
+  ```bash
+  tests/unit/lib/bats-core/bin/bats tests/spec/dev-flow-chore-ticket-ops-mishaps.bats
+  ```
+
+  Expected: 5/5 PASS.
+
+- [ ] **Step 2: Plan-Lint (CI-Äquivalent) grün**
+
+  ```bash
+  bash scripts/plan-lint.sh openspec/changes/dev-flow-chore-ticket-ops-mishaps/tasks.md
+  ```
+
+  Expected: Exit 0.
+
+- [ ] **Step 3: OpenSpec-Validate grün**
+
+  ```bash
+  bash scripts/openspec.sh validate   # or: task test:openspec
+  ```
+
+  Expected: Exit 0.
+
+- [ ] **Step 4: Freshness-Gate grün**
+
+  ```bash
+  task freshness:regenerate
+  task freshness:check
+  ```
+
+  Expected: keine Diffs (oder nur akzeptierte regenerierte Artefakte). Falls
+  `test-inventory.json` durch die neue BATS-Datei ergänzt wurde, den
+  Regenerierungs-Commit einbeziehen.
+
+- [ ] **Step 5: Test-Changed-Suite grün**
+
+  ```bash
+  task test:changed
+  ```
+
+  Expected: PASS (nur `tests/spec/dev-flow-chore-ticket-ops-mishaps.bats` ist
+  neu, alle anderen Suites unverändert).
+
+- [ ] **Step 6: Geänderte SKILL.md-Dateien noch einmal lesen und Sanity-Check**
+
+  ```bash
+  grep -nE 'git add -A' .claude/skills/dev-flow-chore/SKILL.md || echo "OK — no bare git add -A"
+  grep -nE 'environments/\.secrets' .claude/skills/dev-flow-chore/SKILL.md
+  grep -nE 'dedup|deduplicate' .claude/skills/ticket-ops/SKILL.md
+  grep -nE 'T001147|T001148' .claude/skills/ticket-ops/SKILL.md
+  ```
+
+  Expected: alle vier greps liefern Treffer im jeweils richtigen Kontext.
+
+- [ ] **Step 7: Finaler Commit (Freshness-Update, falls nötig)**
+
+  ```bash
+  # Falls Step 4 generierte Artefakte geändert hat:
+  git add docs/code-quality/ 2>/dev/null || true
+  git add website/src/data/ 2>/dev/null || true
+  git commit -m "chore(freshness): regenerate test-inventory after T001210 test add" || true
+  ```
+
+---
+
+### Task 3.2: PR erstellen + Ticket-Schließen
+
+- [ ] **Step 1: Branch pushen + PR öffnen**
+
+  ```bash
+  git push -u origin fix/t001210-dev-flow-chore-ticket-ops-mishaps
+  gh pr create --title "fix(skill): dev-flow-chore git-crypt guard + ticket-ops dedupe [T001210]" --body "Closes T001210. Two SKILL.md edits + one BATS suite. See openspec/changes/dev-flow-chore-ticket-ops-mishaps/tasks.md for the implementation plan and docs/superpowers/specs/2026-06-27-t001210-dev-flow-chore-ticket-ops-mishaps-design.md for the design note."
+  ```
+
+- [ ] **Step 2: PR squash-merge + Branch cleanup (analog zu T001092-Step)**
+
+  ```bash
+  gh pr merge --auto --squash --delete-branch
+  ```
+
+- [ ] **Step 3: Ticket schließen**
+
+  ```bash
+  # MCP-first:
+  mcp__ticket-mcp__transition_status({ id: "T001210", status: "done", resolution: "fixed" })
+  mcp__ticket-mcp__add_comment({ id: "T001210", body: "PR merged. Both skills updated; BATS suite green. Root-cause investigation of Mishap 2 upstream re-trigger remains out of scope — see plan Task 3.1 Step 6 for the open question." })
+  ```
+
+  Fallback (über `./scripts/ticket.sh update-status` + Comment).
+
+- [ ] **Step 4: Worktree + Lock aufräumen**
+
+  ```bash
+  bash scripts/agent-lock.sh release ticket T001210
+  cd /home/patrick/Bachelorprojekt
+  git worktree remove /tmp/wt-t001210-dev-flow-chore-ticket-ops-mishaps --force
+  git branch -D fix/t001210-dev-flow-chore-ticket-ops-mishaps
+  ```

--- a/tests/spec/dev-flow-chore-ticket-ops-mishaps.bats
+++ b/tests/spec/dev-flow-chore-ticket-ops-mishaps.bats
@@ -1,0 +1,101 @@
+#!/usr/bin/env bats
+# tests/spec/dev-flow-chore-ticket-ops-mishaps.bats
+# T001210 — Mishap-Bundle: dev-flow-chore (git-crypt staging) + ticket-ops (duplicate intake)
+#
+# Convention: one .bats file per OpenSpec SSOT spec / fix bundle. Simple
+# [ ... ] assertions, no bats-support dependency required. The
+# `load 'test_helper'` is harmless if the helper is absent (BATS `load`
+# silently no-ops on a missing file at this layer — both existing
+# tests/spec/*.bats files use the same pattern).
+#
+# These tests are RED on the current branch (HEAD 2cc010f5): the
+# fixes described in openspec/changes/dev-flow-chore-ticket-ops-mishaps/
+# have not been applied yet. They turn GREEN after the corresponding
+# edits in .claude/skills/dev-flow-chore/SKILL.md (Step 4) and
+# .claude/skills/ticket-ops/SKILL.md (Phase 4 Step 4.4 + Phase 1 Step 1.4)
+# land. See docs/superpowers/specs/2026-06-27-t001210-dev-flow-chore-ticket-ops-mishaps-design.md
+# for the design note and the OpenSpec plan for the implementation tasks.
+
+load 'test_helper'
+
+setup() {
+  REPO="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+  DEV_FLOW_CHORE_SKILL="$REPO/.claude/skills/dev-flow-chore/SKILL.md"
+  TICKET_OPS_SKILL="$REPO/.claude/skills/ticket-ops/SKILL.md"
+}
+
+# ── Mishap 1: dev-flow-chore must not use `git add -A` and must guard the index ────
+
+@test "T001210: dev-flow-chore Step 4 does not use a bare 'git add -A' (git-crypt foot-gun)" {
+  [ -f "$DEV_FLOW_CHORE_SKILL" ]
+  # The fix replaces `git add -A` with explicit path staging of only the
+  # files the chore actually changed (or an explicit
+  # -- ':!environments/.secrets/*' exclude). A bare `git add -A` would
+  # promote ~21 git-crypt smudge artifacts from environments/.secrets/**
+  # into the index on every chore commit.
+  run grep -nE '^[[:space:]]*git add -A[[:space:]]*$' "$DEV_FLOW_CHORE_SKILL"
+  [ "$status" -ne 0 ]
+}
+
+@test "T001210: dev-flow-chore Step 4 has a secret-in-index guard for environments/.secrets/**" {
+  [ -f "$DEV_FLOW_CHORE_SKILL" ]
+  # The fix adds a hard pre-commit guard that aborts with FATAL if the
+  # index contains any path under environments/.secrets/. The grep below
+  # matches the canonical pattern from T001199 / PR #2135.
+  run grep -nE 'environments/\.secrets' "$DEV_FLOW_CHORE_SKILL"
+  [ "$status" -eq 0 ]
+}
+
+@test "T001210: dev-flow-chore secret-in-index guard is positioned in Step 4 (commit/push section)" {
+  [ -f "$DEV_FLOW_CHORE_SKILL" ]
+  # The guard must live in the commit/push section, not in a later deploy
+  # section. Find the line of the "## Schritt 4" header, the line of
+  # "## Schritt 5", and the line of the guard; the guard must be between
+  # those two lines.
+  local step4 schritt5 guard
+  step4="$(grep -n '^## Schritt 4' "$DEV_FLOW_CHORE_SKILL" | head -1 | cut -d: -f1)"
+  schritt5="$(grep -n '^## Schritt 5' "$DEV_FLOW_CHORE_SKILL" | head -1 | cut -d: -f1)"
+  guard="$(grep -nE 'environments/\.secrets' "$DEV_FLOW_CHORE_SKILL" | head -1 | cut -d: -f1)"
+  [ -n "$step4" ]
+  [ -n "$schritt5" ]
+  [ -n "$guard" ]
+  [ "$guard" -gt "$step4" ]
+  [ "$guard" -lt "$schritt5" ]
+}
+
+# ── Mishap 2: ticket-ops must dedupe intake by title (T001147/T001148 family) ──────
+
+@test "T001210: ticket-ops Phase 4 Step 4.4 (GitHub Issue Intake) has a title-dedupe guard" {
+  [ -f "$TICKET_OPS_SKILL" ]
+  # The fix adds a "check for an existing open ticket with the same title
+  # (or canonical reference) before INSERT" step in Phase 4 Step 4.4
+  # (GitHub Issue Intake). The keyword set is the contract: any of
+  # `dedup`, `deduplicate`, `duplicate ticket`, or `same title` (each
+  # as a word/phrase, not a substring of unrelated prose like
+  # `execution`). We grep the file for the keyword and assert it lands
+  # AFTER the Step 4.4 header (line ~302).
+  local step44 keyword
+  step44="$(grep -nE '^###[[:space:]]+Step 4\.4' "$TICKET_OPS_SKILL" | head -1 | cut -d: -f1)"
+  [ -n "$step44" ]
+  # Anchor on a strict phrase pattern to avoid false positives from
+  # the existing `duplicate_of` schema enum and `execution wave` prose.
+  keyword="$(grep -nEi 'dedup|deduplicate|duplicate ticket|same title' "$TICKET_OPS_SKILL" | head -1 | cut -d: -f1)"
+  [ -n "$keyword" ]
+  [ "$keyword" -gt "$step44" ]
+}
+
+@test "T001210: ticket-ops Step 4.4 dedupe guard references the canonical T001147 (regression marker)" {
+  [ -f "$TICKET_OPS_SKILL" ]
+  # The fix cross-references the canonical reference ticket (T001147, the
+  # shipped "E2E notification test — Playwright FA-bug-notify" ticket) so
+  # the dedupe lookup is anchored to a real example. This is a regression
+  # marker: a future re-introduction of duplicate-ticket creation will
+  # be caught by the canonical reference being cited.
+  local step44 ref
+  step44="$(grep -nE '^###[[:space:]]+Step 4\.4' "$TICKET_OPS_SKILL" | head -1 | cut -d: -f1)"
+  [ -n "$step44" ]
+  # Look for T001147 (or T001148, the prior mishap bundle) in the skill.
+  ref="$(grep -nE 'T001147|T001148' "$TICKET_OPS_SKILL" | head -1 | cut -d: -f1)"
+  [ -n "$ref" ]
+  [ "$ref" -gt "$step44" ]
+}


### PR DESCRIPTION
Closes T001210. Two SKILL.md edits + one BATS suite (already on the branch in the prior plan-staging commit).

- **Mishap 1 (dev-flow-chore Step 4):** Replace bare `git add -A` with explicit pathspec staging + add a hard pre-commit `environments/.secrets/**` secret-in-index guard. Codifies the T001199 / PR #2135 workaround. Cross-refs T000925 (silent-commit-failure variant of the same root cause).
- **Mishap 2 (ticket-ops Step 4.4):** Add title-dedupe guard before the `tickets.tickets` INSERT. Cross-refs canonical T001147 and mishap-bundle T001148 (the 4 duplicates T001196/T001197/T001201/T001202 are the observable symptom).

See `openspec/changes/dev-flow-chore-ticket-ops-mishaps/tasks.md` and `docs/superpowers/specs/2026-06-27-t001210-dev-flow-chore-ticket-ops-mishaps-design.md` for the design note and plan.