### PR TITLE
chore(docs): align AGENTS.md awaiting_deploy with T001092 (Merge = Abschluss) [T001271]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,7 @@ task feature:deploy  # fan-out to both brands
   - `/opsx:archive <slug>` — archive a completed change + merge its delta into the SSOT spec.
   - `/opsx:explore` — think-through / requirements clarification (no implementation).
   - The `task openspec:propose|apply|archive` wrappers are **equivalent fallbacks** for environments without the OpenSpec CLI; `task openspec:validate` is the fail-closed CI gate. Authoring conventions are SSOT in `openspec/config.yaml` — see [OpenSpec conventions](#openspec-conventions) below.
-- **awaiting_deploy status**: A transition state for tickets that are merged to `main` but not yet deployed to production (the "merge ≠ prod" lane on the dashboard cockpit).
+- **Merge = closure (T001092)**: Tickets close directly on green auto-merge to `main` (`done · resolution=shipped`). The prod deploy is **decoupled** (push-based) and does NOT change ticket status. `awaiting_deploy`/`qa_review` are **removed from the happy-path** but stay valid enum values for historical rows, manual holds, and the watchdog safety net (`awaiting_deploy > 24h`); the cockpit hides the `awaiting_deploy` lane unless a ticket is manually held. Source: CLAUDE.md → "Domain conventions: Merge = Abschluss".
 - CI gate: `task test:changed` (smart selection) + `task freshness:check` + `task workspace:validate`.
 - Pre-commit hook (`.githooks/pre-commit`) auto-runs freshness regeneration, secret scanning, agent-lock guard. Install with `git config core.hooksPath .githooks`.
 

--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 491,
+      "file_count": 492,
       "files": [
         "tests/.gitignore",
         "tests/batch/batch-gap-analysis.bats",


### PR DESCRIPTION
## Was

Behebt eine Inkonsistenz in AGENTS.md: `awaiting_deploy` wurde noch als Happy-Path-Status („merged to main but not yet deployed") beschrieben — im Widerspruch zu CLAUDE.md → **„Domain conventions: Merge = Abschluss (T001092)"**.

### Korrektur
AGENTS.md sagt jetzt konsistent: Tickets schließen bei grünem Auto-Merge direkt (`done · resolution=shipped`); der Prod-Deploy ist **entkoppelt** (push-based) und ändert den Ticket-Status nicht; `awaiting_deploy`/`qa_review` sind aus dem Happy-Path entfernt, bleiben aber gültige Enum-Werte für historische Zeilen, manuelle Holds und das Watchdog-Sicherheitsnetz (`awaiting_deploy > 24h`). Quelle: CLAUDE.md.

### Nebenbei
`repo-index.json` regeneriert — gleicht eine **vorbestehende main-Inkonsistenz** an (tests `file_count` 491 vs. 492 tatsächliche Array-Einträge — ein `merge=ours`-Artefakt; das `files`-Array selbst ist unverändert, nur das Count-Feld). Von `freshness:check` erzwungen.

### Verifikation
- `task freshness:check` → exit 0 ✓
- PR-Scope-Preflight `docs` ✓
- Reine Docs-Änderung (+ generierter Index-Fix), keine Code-/Manifest-/Test-Pfade

🤖 Generated with [Claude Code](https://claude.com/claude-code)