### PR TITLE
fix(website): reduce explicit any count to <=200 in website/src (G-CQ02) [T001285]

### DIFF
--- a/docs/code-quality/loc-budget.json
+++ b/docs/code-quality/loc-budget.json
@@ -1,8 +1,8 @@
 {
-  "total_lines": 498312,
-  "file_count": 3840,
-  "commit": "0466726a",
-  "measured_at": "2026-06-28T02:04:54.550Z",
+  "total_lines": 498112,
+  "file_count": 3839,
+  "commit": "3c9ec1d6",
+  "measured_at": "2026-06-28T02:10:22.574Z",
   "thresholds": {
     "warn_pct": 5,
     "fail_pct": 15,

--- a/docs/code-quality/loc-budget.json
+++ b/docs/code-quality/loc-budget.json
@@ -1,8 +1,8 @@
 {
-  "total_lines": 498112,
-  "file_count": 3839,
-  "commit": "3c9ec1d6",
-  "measured_at": "2026-06-28T02:10:22.574Z",
+  "total_lines": 498128,
+  "file_count": 3840,
+  "commit": "16e3db43",
+  "measured_at": "2026-06-28T01:30:46.229Z",
   "thresholds": {
     "warn_pct": 5,
     "fail_pct": 15,

--- a/docs/code-quality/loc-budget.json
+++ b/docs/code-quality/loc-budget.json
@@ -1,8 +1,8 @@
 {
-  "total_lines": 498128,
+  "total_lines": 498312,
   "file_count": 3840,
-  "commit": "16e3db43",
-  "measured_at": "2026-06-28T01:30:46.229Z",
+  "commit": "0466726a",
+  "measured_at": "2026-06-28T02:04:54.550Z",
   "thresholds": {
     "warn_pct": 5,
     "fail_pct": 15,

--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 502,
+      "file_count": 503,
       "files": [
         "tests/.gitignore",
         "tests/batch/batch-gap-analysis.bats",
@@ -350,6 +350,7 @@
         "tests/spec/docker-build-speedup.bats",
         "tests/spec/env-seal-empty-value-keys.bats",
         "tests/spec/fleet-operations.bats",
+        "tests/spec/g-cq02-any-types.bats",
         "tests/spec/g-cq08-knip-dead-code.bats",
         "tests/spec/g-dep01-npm-vuln.bats",
         "tests/spec/g-fe02-bundle-budget.bats",

--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 503,
+      "file_count": 502,
       "files": [
         "tests/.gitignore",
         "tests/batch/batch-gap-analysis.bats",
@@ -350,7 +350,6 @@
         "tests/spec/docker-build-speedup.bats",
         "tests/spec/env-seal-empty-value-keys.bats",
         "tests/spec/fleet-operations.bats",
-        "tests/spec/g-cq02-any-types.bats",
         "tests/spec/g-cq08-knip-dead-code.bats",
         "tests/spec/g-dep01-npm-vuln.bats",
         "tests/spec/g-fe02-bundle-budget.bats",

--- a/openspec/changes/cq02-any-types-200/proposal.md
+++ b/openspec/changes/cq02-any-types-200/proposal.md
@@ -1,0 +1,32 @@
+---
+title: "G-CQ02: any-Typen 463→≤200 — TypeScript-Sicherheitsnetz stärken"
+ticket_id: T001285
+domains: [website, quality]
+status: plan_staged
+file_locks: []
+shared_changes: false
+batch_id: null
+parent_feature: null
+depends_on_plans: []
+---
+
+# Proposal: cq02-any-types-200 (G-CQ02)
+
+## Why
+
+Das Website-Projekt zeigt eine TypeScript-Regression: 463 explizite `any`-Verwendungen (`:any`, `<any>`, `as any`) in `website/src` — gegenüber dem Baseline-Stand von 424 ein Anstieg von +39. Das `any`-Keyword hebelt TypeScript-Typprüfungen vollständig aus, verbreitet sich viral (jeder Aufrufer erhält `any` zurück) und maskiert echte Bugs bis zur Laufzeit. Ziel ist eine Reduktion auf ≤200, was ca. 263 gezielte Ersetzungen erfordert.
+
+Messung:
+```bash
+grep -rn ': any\|<any>\|as any' website/src --include=*.ts --include=*.svelte --include=*.astro | wc -l
+```
+
+## What
+
+- **Test-Dateien** (~180 Vorkommen in Top-Hotspots): `as any` in Vitest-Kontexten (Mocks, Locals, Session-Objekte) durch `unknown`, konkrete Typen oder `Parameters<typeof fn>` ersetzen
+- **API-Handler** (~25 Vorkommen: monitoring.ts, pods-list.ts, warnings.ts, dora-metrics.ts): Interfaces für K8s-API-Response-Shapes einführen
+- **Library-Dateien** (~30 Vorkommen: factory-floor.ts, website-db.ts, knowledge-db.test.ts, behaviorStore.ts): Generics statt `any`, Record-Typen, explizite Interfaces
+- **Svelte/Astro-Komponenten** (~20 Vorkommen: KoreHomepage.svelte, SchemaEditor.svelte, inhalte.astro): Event-Handler-Typen und Store-Generics ergänzen
+- Failing-Test hinzufügen der ≤200 prüft (RED → GREEN nach Implementierung)
+
+_Ticket: T001285_

--- a/openspec/changes/cq02-any-types-200/specs/cq02-any-types-200.md
+++ b/openspec/changes/cq02-any-types-200/specs/cq02-any-types-200.md
@@ -1,0 +1,34 @@
+## ADDED Requirements
+
+### Requirement: Obergrenze für explizite any-Typen in website/src
+
+The system SHALL keep the number of explicit `any` usages in `website/src` at or below 200,
+counted as occurrences of `: any`, `<any>`, or `as any` across `*.ts`, `*.svelte`, and `*.astro`
+files. Type assertions that bridge through `unknown` (`as unknown as T`), generic type parameters,
+and locally declared interfaces SHALL be preferred over `any`; `@ts-ignore` and `@ts-expect-error`
+SHALL NOT be introduced as substitutes for `any`.
+
+#### Scenario: any-Zähler liegt unter der Obergrenze
+
+- **GIVEN** das `website/`-Paket ist ausgecheckt
+- **WHEN** `grep -rn ': any\|<any>\|as any' website/src --include='*.ts' --include='*.svelte' --include='*.astro' | wc -l` ausgeführt wird
+- **THEN** ist das Ergebnis ≤ 200
+
+#### Scenario: TypeScript-Check bleibt grün
+
+- **GIVEN** die any-Reduktion ist angewandt
+- **WHEN** `pnpm --dir website run astro:check` ausgeführt wird
+- **THEN** beendet sich der Check mit 0 TypeScript-Fehlern — die Typsicherheit wurde nicht durch
+  Unterdrückungs-Kommentare erkauft
+
+### Requirement: Fail-Closed BATS-Gate für any-Obergrenze
+
+The system SHALL enforce the ≤200 any-budget via a BATS test at
+`tests/spec/g-cq02-any-types.bats` that fails when the explicit-any count in `website/src` exceeds
+200, so that regressions are blocked by the offline test suite.
+
+#### Scenario: BATS-Test blockiert Regression
+
+- **GIVEN** `tests/spec/g-cq02-any-types.bats` ist vorhanden
+- **WHEN** der any-Zähler in `website/src` über 200 steigt
+- **THEN** schlägt der BATS-Test fehl (Exit-Code ≠ 0) und das Offline-Test-Gate blockiert den Merge

--- a/openspec/changes/cq02-any-types-200/tasks.md
+++ b/openspec/changes/cq02-any-types-200/tasks.md
@@ -1,0 +1,602 @@
+---
+title: "G-CQ02: any-Typen 463→≤200 — TypeScript-Sicherheitsnetz stärken"
+ticket_id: T001285
+domains: [website, quality]
+status: plan_staged
+file_locks: []
+shared_changes: false
+batch_id: null
+parent_feature: null
+depends_on_plans: []
+---
+
+# cq02-any-types-200 — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:executing-plans
+
+**Goal:** Explizite `any`-Verwendungen in `website/src` von 463 auf ≤200 reduzieren. Messgröße:
+```bash
+grep -rn ': any\|<any>\|as any' website/src --include=*.ts --include=*.svelte --include=*.astro | wc -l
+```
+
+**Strategie:** Test-Dateien zuerst (einfache Mock-Patterns, hoher Impact), dann API-Handler (K8s-Interfaces), dann Library-Dateien (Generics), schließlich Svelte/Astro-Komponenten.
+
+**Architecture:** Keine neuen Abhängigkeiten. Alle Ersetzungen bleiben innerhalb `website/src`. Wo Typen fehlen, werden lokale Interfaces angelegt — keine separaten Type-Dateien außer explizit genannt.
+
+## Global Constraints
+
+- `as any` in Tests → `as unknown as T` (konkrete Typ-Assertion) oder direkt typisiertes Objekt
+- `vi.fn()` Parameter: `(..._args: any[])` → `(..._args: unknown[])`
+- `{ ... } as any` für Mock-Locals → explizite `MockLocals`-Interface oder `Partial<APIContext>`
+- `getSession(...)` Mock-Return: `as any` → konkrete `SessionData`-Typ-Assertion oder `satisfies`
+- K8s-API-Responses: `any` in `.map((pod: any) => ...)` → `(pod: K8sPod)` mit lokalem Interface
+- `rows.map((row: any) => ...)` → `(row: Record<string, unknown>)` oder konkrete Row-Interfaces
+- Keine Einführung von `@ts-ignore` oder `@ts-expect-error` als Ersatz für `any`
+
+## File Structure
+
+Dateien geordnet nach Impact (Anzahl `any`-Vorkommen, absteigend):
+
+```
+# Task 1 — Test-Mocks: Session/Locals-Pattern (~72 any)
+website/src/pages/api/admin/sessions/history/index.test.ts    23 any
+website/src/pages/api/admin/sessions/templates/index.test.ts   8 any
+website/src/pages/api/admin/sessions/index.test.ts             8 any
+website/src/pages/api/admin/sessions/templates/[id].test.ts    6 any
+website/src/pages/api/auth/me.test.ts                          5 any
+
+# Task 2 — Test-Mocks: Billing/Admin-API (~40 any)
+website/src/pages/api/admin/billing/datev-export.test.ts       8 any
+website/src/pages/api/admin/billing/[id]/payments.test.ts      8 any
+website/src/pages/api/admin/dora-metrics.test.ts               8 any
+website/src/pages/api/admin/billing/sepa-export.test.ts        5 any
+website/src/pages/api/admin/billing/[id]/validate.test.ts      3 any
+website/src/pages/api/billing/invoice/[id]/xrechnung.xml.test.ts 4 any
+
+# Task 3 — Test-Mocks: System/Content/Factory (~34 any)
+website/src/pages/api/admin/systemtest/seed.test.ts            7 any
+website/src/pages/api/admin/content-sections-save.test.ts      7 any
+website/src/pages/api/factory-floor/inject.test.ts             6 any
+website/src/pages/api/admin/systemtest/board.test.ts           6 any
+website/src/pages/api/admin/content/save.test.ts               4 any
+website/src/pages/api/factory-floor/ci.test.ts                 3 any
+
+# Task 4 — Test-Mocks: Questionnaires/Evidence/Openspec (~22 any)
+website/src/pages/api/admin/questionnaires/assignments/[id]/archive.test.ts 6 any
+website/src/pages/api/admin/questionnaires/assignments/[id]/reassign.test.ts 5 any
+website/src/pages/api/admin/openspec/save-proposal.test.ts     3 any
+website/src/pages/api/admin/evidence/upload.test.ts            3 any
+website/src/pages/api/admin/angebote/save.test.ts              3 any
+website/src/pages/api/admin/ai-quality.test.ts                 4 any
+
+# Task 5 — Test-Mocks: Lib Tests (~19 any)
+website/src/lib/knowledge-db.test.ts                          17 any
+website/src/lib/tickets/__tests__/cockpit-api.test.ts          5 any
+website/src/lib/sessions/templates.test.ts                     5 any
+website/src/lib/factory-floor.test.ts                          5 any
+website/src/lib/comfy-client.test.ts                           5 any
+website/src/lib/delivery-metrics.test.ts                       4 any
+
+# Task 6 — API-Handler: Kubernetes-Responses (~28 any)
+website/src/pages/api/admin/monitoring.ts                     13 any
+website/src/pages/api/admin/cluster/pods-list.ts               6 any
+website/src/pages/api/admin/dora-metrics.ts                    3 any
+website/src/pages/api/admin/cluster/warnings.ts                3 any
+website/src/pages/api/admin/billing/[id]/item.ts               3 any
+
+# Task 7 — Library-Dateien: DB-Queries, Store, Factory (~26 any)
+website/src/lib/website-db.ts                                  9 any
+website/src/lib/factory-floor.ts                               9 any
+website/src/lib/admin/behaviorStore.ts                         8 any
+
+# Task 8 — Svelte/Astro-Komponenten (~21 any)
+website/src/components/kore/KoreHomepage.svelte                6 any
+website/src/components/admin/framework/SchemaEditor.svelte     6 any
+website/src/pages/admin/inhalte.astro                          6 any
+website/src/pages/admin/coaching/sessions/[id].astro           3 any
+
+# Task 9 — Kleinere verbleibende Dateien (Rest)
+website/src/lib/sessions/archive.ts                            6 any
+website/src/lib/k8s.ts                                         6 any
+website/src/lib/tickets/cockpit-table-actions.ts               4 any
+website/src/lib/bulk-status.ts                                 4 any
+website/src/lib/planning-office.ts                             3 any
+website/src/pages/api/admin/coaching/drafts/[id]/accept.ts     4 any
+website/src/pages/kontakt.astro                                3 any
+```
+
+---
+
+## Task 0: Failing-Test anlegen (RED)
+
+**Files:**
+- Create: `tests/spec/g-cq02-any-types.bats`
+
+Der Test soll RED sein (463 > 200) und nach Implementierung GREEN werden.
+
+```bash
+#!/usr/bin/env bats
+# SSOT: openspec/changes/cq02-any-types-200/proposal.md
+# G-CQ02: any-Typen in website/src auf ≤200 reduzieren.
+
+setup() {
+  REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+}
+
+@test "G-CQ02: explicit any count in website/src is at most 200" {
+  run bash -c "grep -rn ': any\|<any>\|as any' '$REPO_ROOT/website/src' \
+    --include='*.ts' --include='*.svelte' --include='*.astro' | wc -l"
+  echo "any count: $output"
+  [ "$output" -le 200 ]
+}
+```
+
+Vor Implementierung: `bats tests/spec/g-cq02-any-types.bats` → FAIL (463 > 200). Expected.
+
+---
+
+## Task 1: Test-Mocks — Session/Locals-Pattern (~72 any eliminiert)
+
+**Zieldateien:**
+- `website/src/pages/api/admin/sessions/history/index.test.ts` (23)
+- `website/src/pages/api/admin/sessions/templates/index.test.ts` (8)
+- `website/src/pages/api/admin/sessions/index.test.ts` (8)
+- `website/src/pages/api/admin/sessions/templates/[id].test.ts` (6)
+- `website/src/pages/api/auth/me.test.ts` (5)
+
+**Muster und Ersetzungen:**
+
+1. `locals as any` — die Konstante `const locals = { requestLogger: { error: vi.fn() } } as any` tritt in vielen Test-Dateien auf. Durch ein lokales Interface ersetzen:
+   ```typescript
+   // Vorher:
+   const locals = { requestLogger: { error: vi.fn() } } as any;
+
+   // Nachher — direkt typisiert:
+   interface MockLocals {
+     requestLogger: { error: ReturnType<typeof vi.fn> };
+   }
+   const locals: MockLocals = { requestLogger: { error: vi.fn() } };
+   ```
+
+2. `{ request: req, locals } as any` bei API-Handler-Aufrufen → `as Parameters<typeof GET>[0]` oder `as { request: Request; locals: MockLocals }`:
+   ```typescript
+   // Vorher:
+   const res = await getHistoryList({ request: req, locals } as any);
+
+   // Nachher:
+   const res = await getHistoryList({ request: req, locals } as { request: Request; locals: MockLocals });
+   ```
+
+3. `getSession(...).mockResolvedValue({ preferred_username: 'gekko' } as any)` → Session-Shape explizit tippen:
+   ```typescript
+   // Vorher:
+   vi.mocked(getSession).mockResolvedValue({ preferred_username: 'gekko' } as any);
+
+   // Nachher:
+   vi.mocked(getSession).mockResolvedValue({
+     preferred_username: 'gekko',
+     sub: 'mock-sub',
+     email: 'mock@test.de',
+   } satisfies Partial<SessionData> as SessionData);
+   ```
+   Oder mit `as unknown as SessionData` wenn `SessionData`-Import verfügbar.
+
+4. `getHistoryItem({ ..., params: { id: 'g1' }, locals } as any)` → konkrete Assertion:
+   ```typescript
+   getHistoryItem({ request: new Request('http://x'), params: { id: 'g1' }, locals } as {
+     request: Request; params: { id: string }; locals: MockLocals;
+   });
+   ```
+
+**Geschätzte Reduktion:** ~72 any → ~8 verbleibend (einige schwer vermeidbare Stellen in Edge-Cases)
+
+---
+
+## Task 2: Test-Mocks — Billing/Admin-API (~36 any eliminiert)
+
+**Zieldateien:**
+- `website/src/pages/api/admin/billing/datev-export.test.ts` (8)
+- `website/src/pages/api/admin/billing/[id]/payments.test.ts` (8)
+- `website/src/pages/api/admin/dora-metrics.test.ts` (8)
+- `website/src/pages/api/admin/billing/sepa-export.test.ts` (5)
+- `website/src/pages/api/admin/billing/[id]/validate.test.ts` (3)
+- `website/src/pages/api/billing/invoice/[id]/xrechnung.xml.test.ts` (4)
+
+**Muster:**
+
+1. Identisches `locals`-Mock-Pattern wie in Task 1 → gleiche `MockLocals`-Interface-Lösung.
+
+2. `mockResponse as any` in Billing-Tests → konkrete Typen. Wenn der Test `new Response(...)` zurückgibt und `.json()` aufruft:
+   ```typescript
+   // Vorher:
+   const body = (await res.json()) as any;
+   expect(body.total).toBe(3);
+
+   // Nachher:
+   const body = (await res.json()) as { total: number; items: unknown[] };
+   expect(body.total).toBe(3);
+   ```
+
+3. `vi.fn().mockResolvedValue({ ... } as any)` für DB-Mocks → explizite Return-Typen:
+   ```typescript
+   // Vorher:
+   vi.mocked(getInvoice).mockResolvedValue({ id: '1', amount: 100 } as any);
+
+   // Nachher:
+   vi.mocked(getInvoice).mockResolvedValue({ id: '1', amount: 100 } as Awaited<ReturnType<typeof getInvoice>>);
+   ```
+
+**Geschätzte Reduktion:** ~36 any → ~0-2 verbleibend
+
+---
+
+## Task 3: Test-Mocks — System/Content/Factory (~33 any eliminiert)
+
+**Zieldateien:**
+- `website/src/pages/api/admin/systemtest/seed.test.ts` (7)
+- `website/src/pages/api/admin/content-sections-save.test.ts` (7)
+- `website/src/pages/api/factory-floor/inject.test.ts` (6)
+- `website/src/pages/api/admin/systemtest/board.test.ts` (6)
+- `website/src/pages/api/admin/content/save.test.ts` (4)
+- `website/src/pages/api/factory-floor/ci.test.ts` (3)
+
+**Muster:**
+
+1. `locals`-Pattern → `MockLocals` (wie Task 1).
+
+2. `inject.test.ts` und `ci.test.ts` (factory-floor): Mock-Objekte für Factory-API-Requests:
+   ```typescript
+   // Vorher:
+   const res = await POST({ request: new Request('http://x', { method: 'POST', body: JSON.stringify(payload) }), locals } as any);
+
+   // Nachher:
+   type MockContext = { request: Request; locals: MockLocals };
+   const res = await POST({ request: new Request('http://x', { method: 'POST', body: JSON.stringify(payload) }), locals } as MockContext);
+   ```
+
+3. `content-sections-save.test.ts`: `body as any` nach `res.json()` → `as { success: boolean; message?: string }`.
+
+**Geschätzte Reduktion:** ~33 any → ~0 verbleibend
+
+---
+
+## Task 4: Test-Mocks — Questionnaires/Evidence/Openspec (~24 any eliminiert)
+
+**Zieldateien:**
+- `website/src/pages/api/admin/questionnaires/assignments/[id]/archive.test.ts` (6)
+- `website/src/pages/api/admin/questionnaires/assignments/[id]/reassign.test.ts` (5)
+- `website/src/pages/api/admin/openspec/save-proposal.test.ts` (3)
+- `website/src/pages/api/admin/evidence/upload.test.ts` (3)
+- `website/src/pages/api/admin/angebote/save.test.ts` (3)
+- `website/src/pages/api/admin/ai-quality.test.ts` (4)
+
+**Muster:** Identisch zu Tasks 1-3. Alle nutzen dasselbe `locals as any` + `{ request, locals } as any`-Schema. `MockLocals`-Interface aus Task 1 in eine gemeinsame `tests/helpers/mockLocals.ts` auslagern oder je Datei lokal definieren (lokale Definition bevorzugt für Test-Isolation).
+
+**Geschätzte Reduktion:** ~24 any → ~0 verbleibend
+
+---
+
+## Task 5: Test-Mocks — Lib Tests (~36 any eliminiert)
+
+**Zieldateien:**
+- `website/src/lib/knowledge-db.test.ts` (17)
+- `website/src/lib/tickets/__tests__/cockpit-api.test.ts` (5)
+- `website/src/lib/sessions/templates.test.ts` (5)
+- `website/src/lib/factory-floor.test.ts` (5)
+- `website/src/lib/comfy-client.test.ts` (5)
+- `website/src/lib/delivery-metrics.test.ts` (4)
+
+**Muster knowledge-db.test.ts** (17 any — höchster Einzelwert unter Lib-Tests):
+
+Das File nutzt `pg-mem` mit einem komplexen Pool-Setup. Die `any`-Vorkommen entstehen typischerweise durch:
+
+1. Pool-Ergebnis-Typen: `rows.map((row: any) => ...)` aus `pgmem`-Abfragen → `Record<string, unknown>`:
+   ```typescript
+   // Vorher:
+   const rows: any[] = result.rows;
+
+   // Nachher:
+   const rows: Record<string, unknown>[] = result.rows;
+   ```
+
+2. `pgmem`-Rückgabewerte: Wenn der Pool-Typ nicht exportiert wird, `typeof pool` nutzen (die komplexe Typ-Herleitung in Zeile 5 des Files ist bereits korrekt — dort `any` nicht nötig, aber der Pool selbst):
+   ```typescript
+   // Vorher:
+   let pool: any;
+
+   // Nachher (wie Zeile 5 schon beginnt):
+   let pool: ReturnType<...>; // bereits korrekt, prüfen ob alle pool-Stellen typisiert sind
+   ```
+
+3. Mock-Funktions-Parameter: `vi.fn(async (..._args: any[]) => ...)` → `vi.fn(async (..._args: unknown[]) => ...)`.
+
+**Muster factory-floor.test.ts / cockpit-api.test.ts:**
+- `mockDb.query.mockResolvedValue({ rows: [...] } as any)` → `as { rows: Array<Record<string, unknown>> }`
+- `vi.mocked(fn).mockResolvedValue(x as any)` → `as Awaited<ReturnType<typeof fn>>`
+
+**Geschätzte Reduktion:** ~36 any → ~3 verbleibend (pg-mem interne Typen teils schwer vollständig auszudrücken)
+
+---
+
+## Task 6: API-Handler — Kubernetes-Response-Interfaces (~28 any eliminiert)
+
+**Zieldateien:**
+- `website/src/pages/api/admin/monitoring.ts` (13)
+- `website/src/pages/api/admin/cluster/pods-list.ts` (6)
+- `website/src/pages/api/admin/dora-metrics.ts` (3)
+- `website/src/pages/api/admin/cluster/warnings.ts` (3)
+- `website/src/pages/api/admin/billing/[id]/item.ts` (3)
+
+**Muster monitoring.ts** (13 any):
+
+Alle `any`-Stellen entstehen durch untypisierte K8s-API-Responses. Lokale Interfaces am Dateianfang einführen:
+
+```typescript
+// Interfaces oben in monitoring.ts einfügen:
+interface K8sContainer {
+  ready: boolean;
+  restartCount: number;
+  usage?: { cpu: string; memory: string };
+}
+
+interface K8sPod {
+  metadata: { name: string; labels?: Record<string, string> };
+  status: {
+    phase: string;
+    containerStatuses?: K8sContainer[];
+  };
+}
+
+interface K8sPodMetrics {
+  metadata: { name: string };
+  containers: Array<{ usage?: { cpu: string; memory: string } }>;
+}
+
+interface K8sEvent {
+  type: string;
+  reason: string;
+  message: string;
+  lastTimestamp?: string;
+  eventTime?: string;
+  involvedObject: { name: string };
+}
+
+interface K8sNode {
+  metadata: { name: string };
+  status: { capacity: { cpu: string; memory: string } };
+  usage?: { cpu: string; memory: string };
+}
+
+interface K8sListResponse<T> {
+  items: T[];
+}
+```
+
+Dann Ersetzungen:
+- `pods.value.items.map((pod: any) => ...)` → `(pod: K8sPod)`
+- `(podMetricsResult as PromiseFulfilledResult<any>).value` → `(podMetricsResult as PromiseFulfilledResult<K8sListResponse<K8sPodMetrics>>).value`
+- `containerStatuses.every((c: any) => c.ready)` → `(c: K8sContainer)`
+- `events.items.sort((a: any, b: any) => ...)` → `(a: K8sEvent, b: K8sEvent)`
+- `events.items.map((event: any) => ...)` → `(event: K8sEvent)`
+- `capacityItems.find((n: any) => ...)` → `(n: K8sNode)`
+
+**Muster pods-list.ts** (6 any): Identische K8sPod/K8sContainer-Interfaces verwenden.
+
+**Muster billing/[id]/item.ts** (3 any): Konkrete DB-Row-Interfaces für Billing-Zeilen einführen:
+```typescript
+interface BillingItemRow {
+  id: string;
+  description: string;
+  amount: number;
+  // weitere Felder nach Schema
+}
+```
+
+**Geschätzte Reduktion:** ~28 any → ~2 verbleibend (PromiseFulfilledResult-Cast-Stellen können resilienter sein)
+
+---
+
+## Task 7: Library-Dateien — DB-Queries, Store, Factory (~26 any eliminiert)
+
+**Zieldateien:**
+- `website/src/lib/website-db.ts` (9)
+- `website/src/lib/factory-floor.ts` (9)
+- `website/src/lib/admin/behaviorStore.ts` (8)
+
+**Muster website-db.ts** (9 any — DB-Row-Mappings):
+
+```typescript
+// Vorher:
+return r.rows.map((row: any) => ({ id: row.id, name: row.name }));
+
+// Nachher — konkrete Row-Interface pro Abfrage:
+interface TicketRow { id: string; name: string; /* weitere Felder */ }
+return r.rows.map((row: TicketRow) => ({ id: row.id, name: row.name }));
+```
+
+Alternativ für alle DB-Row-Stellen die generische Form:
+```typescript
+return r.rows.map((row: Record<string, unknown>) => ({
+  id: row.id as string,
+  name: row.name as string,
+}));
+```
+
+**Muster factory-floor.ts** (9 any):
+- `return r.rows.map((row: any) => ...)` → `(row: Record<string, unknown>)` + Cast bei Feldzugriff
+- `function mapInjection(r: any): InjectionRow` → `function mapInjection(r: Record<string, unknown>): InjectionRow`
+
+**Muster behaviorStore.ts** (8 any):
+
+```typescript
+// Vorher:
+export interface Conflict { currentVersion: number; currentValue: any }
+initialValue: any;
+validate: (value: any) => Errors;
+saveFn: (contentKey: string, baseVersion: number, value: any) => Promise<{ version: number }>;
+interface Snapshot { value: any; version: number; ... }
+let timer: any = null;
+
+// Nachher — Generic Store:
+export interface Conflict<T = unknown> { currentVersion: number; currentValue: T }
+
+export interface BehaviorStoreOptions<T> {
+  initialValue: T;
+  validate: (value: T) => Errors;
+  saveFn: (contentKey: string, baseVersion: number, value: T) => Promise<{ version: number }>;
+}
+
+interface Snapshot<T> { value: T; version: number; state: SaveState; errors: Errors; conflict?: Conflict<T> }
+let timer: ReturnType<typeof setTimeout> | null = null;
+
+// catch (e: any) → catch (e: unknown)
+} catch (e: unknown) {
+  const message = e instanceof Error ? e.message : String(e);
+  // ...
+}
+
+// setValue(value: any) → parametrisierter Store:
+setValue(value: T) { ... }
+```
+
+**Geschätzte Reduktion:** ~26 any → ~1 verbleibend
+
+---
+
+## Task 8: Svelte/Astro-Komponenten (~21 any eliminiert)
+
+**Zieldateien:**
+- `website/src/components/kore/KoreHomepage.svelte` (6)
+- `website/src/components/admin/framework/SchemaEditor.svelte` (6)
+- `website/src/pages/admin/inhalte.astro` (6)
+- `website/src/pages/admin/coaching/sessions/[id].astro` (3)
+
+**Muster KoreHomepage.svelte** (6 any — Event-Handler und Store-Typen):
+
+```typescript
+// Vorher (typische Svelte-Event-Handler):
+function handleClick(e: any) { ... }
+let data: any = null;
+
+// Nachher:
+function handleClick(e: MouseEvent) { ... }
+// oder für CustomEvent:
+function handleCustom(e: CustomEvent<{ detail: string }>) { ... }
+let data: TimelineItem | null = null;
+```
+
+**Muster SchemaEditor.svelte** (6 any):
+- `let schema: any` → `let schema: Record<string, unknown> | null = null`
+- Event-Handler-Typen: `(e: any) =>` → `(e: Event) =>` oder `(e: InputEvent) =>`
+- Fetch-Response-Parsing: `const data: any = await res.json()` → typisierte Interfaces
+
+**Muster inhalte.astro** (6 any):
+- Props-Typen: `const { sections }: any = Astro.props` → explizite `Props`-Interface
+- API-Response-Shapes beim `fetch()` → lokale Interfaces
+
+**Muster coaching/sessions/[id].astro** (3 any): Analog zu inhalte.astro.
+
+**Geschätzte Reduktion:** ~21 any → ~2 verbleibend (einige Svelte-interne Typ-Lücken)
+
+---
+
+## Task 9: Verbleibende kleinere Dateien (~20 any eliminiert)
+
+**Zieldateien (3-6 any each):**
+- `website/src/lib/sessions/archive.ts` (6)
+- `website/src/lib/k8s.ts` (6)
+- `website/src/lib/tickets/cockpit-table-actions.ts` (4)
+- `website/src/lib/bulk-status.ts` (4)
+- `website/src/lib/planning-office.ts` (3)
+- `website/src/pages/api/admin/coaching/drafts/[id]/accept.ts` (4)
+- `website/src/pages/kontakt.astro` (3)
+
+**Muster k8s.ts** (6 any): Der K8s-Client wrapping-Layer — Interfaces für K8s-Antworten, analog zu Task 6.
+
+**Muster archive.ts** (6 any): Metadata-Objekte typisieren:
+```typescript
+// Vorher:
+const meta: any = JSON.parse(content);
+
+// Nachher:
+interface SessionMeta { id: string; slug: string; type: string; title: string; date: string; owner: string; participants: string[]; content_available: boolean; }
+const meta = JSON.parse(content) as SessionMeta;
+```
+
+**Muster cockpit-table-actions.ts** / **bulk-status.ts** (4 each): Action-Objekte und DB-Rows typisieren.
+
+**Muster coaching drafts accept.ts** (4 any): Request-Body und Response-Shape mit lokalen Interfaces.
+
+**Geschätzte Reduktion:** ~30 any → ~10 verbleibend (einige echte Grenzfälle)
+
+---
+
+## Task 10: Verify — Measure, Test, Regenerate, PR
+
+### Step 1: Count prüfen
+
+```bash
+cd website
+grep -rn ': any\|<any>\|as any' src --include=*.ts --include=*.svelte --include=*.astro | wc -l
+# Erwartung: ≤200
+```
+
+### Step 2: BATS-Test ausführen (muss GREEN sein)
+
+```bash
+bats tests/spec/g-cq02-any-types.bats
+# Erwartung: 1 test, 0 failures
+```
+
+### Step 3: TypeScript-Build prüfen (kein Rückschritt durch falsche Typen)
+
+```bash
+bash scripts/vda.sh oracle 'run astro type check website'
+```
+
+### Step 4: Vitest läuft durch
+
+```bash
+bash scripts/vda.sh oracle 'run website unit tests'
+```
+
+### Step 5: Test-Inventory regenerieren (CI-Gate)
+
+```bash
+bash scripts/vda.sh oracle 'regenerate test inventory'
+```
+
+### Step 6: Freshness regenerieren und prüfen
+
+```bash
+bash scripts/vda.sh oracle 'regenerate freshness artifacts'
+task freshness:check
+```
+
+### Step 7: PR erstellen
+
+```bash
+gh pr create \
+  --title "fix(types): reduce any count 463→≤200 (G-CQ02) [T001285]" \
+  --body "..."
+gh pr merge <n> --squash --auto
+```
+
+---
+
+## Reduction Summary
+
+| Task | Dateien | any vorher | any danach (est.) | Reduktion |
+|------|---------|-----------|-------------------|-----------|
+| 1 — Session/Locals Tests | 5 | 50 | ~5 | ~45 |
+| 2 — Billing/Admin Tests | 6 | 36 | ~2 | ~34 |
+| 3 — System/Content/Factory Tests | 6 | 33 | ~0 | ~33 |
+| 4 — Questionnaires/Evidence Tests | 6 | 24 | ~0 | ~24 |
+| 5 — Lib Tests | 6 | 41 | ~3 | ~38 |
+| 6 — API-Handler K8s | 5 | 28 | ~2 | ~26 |
+| 7 — Library-Dateien | 3 | 26 | ~1 | ~25 |
+| 8 — Svelte/Astro-Komponenten | 4 | 21 | ~2 | ~19 |
+| 9 — Verbleibende Dateien | 7 | 30 | ~10 | ~20 |
+| **Gesamt** | **48** | **289** | **~25** | **~264** |
+
+Ausgehend von 463 total ergibt eine Reduktion um ~264 einen Zielwert von **~199** — knapp unter der 200er-Grenze. Puffer: Tasks 1-5 sind konservativ geschätzt; die meisten Mock-`as any`-Ersetzungen sind 1:1-Substitutionen ohne Restrisiko.

--- a/tests/spec/g-cq02-any-types.bats
+++ b/tests/spec/g-cq02-any-types.bats
@@ -1,0 +1,16 @@
+#!/usr/bin/env bats
+# SSOT: openspec/changes/cq02-any-types-200/proposal.md
+# G-CQ02: Explizite any-Verwendungen in website/src auf ≤200 reduzieren.
+# RED  (pre-impl):  463 > 200 → FAIL
+# GREEN (post-impl): ≤200     → PASS
+
+setup() {
+  REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+}
+
+@test "G-CQ02: explicit any count in website/src is at most 200" {
+  run bash -c "grep -rn ': any\|<any>\|as any' '$REPO_ROOT/website/src' \
+    --include='*.ts' --include='*.svelte' --include='*.astro' | wc -l | tr -d ' '"
+  echo "any count: $output (limit: 200)"
+  [ "$output" -le 200 ]
+}

--- a/website/src/components/admin/framework/SchemaEditor.svelte
+++ b/website/src/components/admin/framework/SchemaEditor.svelte
@@ -7,11 +7,13 @@
   import type { SectionSchema, FieldSchema } from '$lib/admin/schema-types';
   import SectionFrame from './SectionFrame.svelte';
 
+  type ContentValue = Record<string, unknown>;
+
   interface Props {
     schema: SectionSchema;
-    initialValue: any;
+    initialValue: ContentValue;
     initialVersion: number;
-    saveFn?: (contentKey: string, baseVersion: number, value: any) => Promise<{ version: number }>;
+    saveFn?: (contentKey: string, baseVersion: number, value: ContentValue) => Promise<{ version: number }>;
   }
 
   let { schema, initialValue, initialVersion, saveFn }: Props = $props();
@@ -26,7 +28,7 @@
     saveFn: resolvedSaveFn,
   });
 
-  let currentValue = $state<any>({ ...initialValue });
+  let currentValue = $state<ContentValue>({ ...initialValue });
 
   onMount(() => {
     const unsub = store.subscribe((s) => {
@@ -38,13 +40,13 @@
     return unsub;
   });
 
-  function setField(key: string, val: any) {
+  function setField(key: string, val: unknown) {
     currentValue = { ...currentValue, [key]: val };
     store.setValue(currentValue);
   }
 
-  function setNestedField(parentKey: string, childKey: string, val: any) {
-    const parent = currentValue[parentKey] ?? {};
+  function setNestedField(parentKey: string, childKey: string, val: unknown) {
+    const parent = (currentValue[parentKey] as Record<string, unknown>) ?? {};
     currentValue = { ...currentValue, [parentKey]: { ...parent, [childKey]: val } };
     store.setValue(currentValue);
   }
@@ -72,7 +74,7 @@
   const errorCls = 'text-xs text-red-400 mt-1';
 </script>
 
-{#snippet fieldRenderer(field: FieldSchema, value: any, onChange: (val: any) => void)}
+{#snippet fieldRenderer(field: FieldSchema, value: unknown, onChange: (val: unknown) => void)}
   <div class="space-y-1">
     {#if field.type !== 'toggle'}
       <label class={labelCls}>{field.label}{field.validation?.required ? ' *' : ''}</label>
@@ -81,7 +83,7 @@
     {#if field.type === 'text' || field.type === 'image'}
       <input
         type="text"
-        value={value ?? ''}
+        value={(value as string | undefined) ?? ''}
         oninput={(e) => onChange((e.target as HTMLInputElement).value)}
         class={inputCls}
       />
@@ -89,7 +91,7 @@
     {:else if field.type === 'textarea'}
       <textarea
         rows={4}
-        value={value ?? ''}
+        value={(value as string | undefined) ?? ''}
         oninput={(e) => onChange((e.target as HTMLTextAreaElement).value)}
         class="{inputCls} resize-y"
       ></textarea>
@@ -112,7 +114,7 @@
       <div class="field-html-wrap">
         <textarea
           rows={6}
-          value={value ?? ''}
+          value={(value as string | undefined) ?? ''}
           oninput={(e) => onChange((e.target as HTMLTextAreaElement).value)}
           class="{inputCls} resize-y font-mono text-xs"
         ></textarea>
@@ -120,7 +122,7 @@
 
     {:else if field.type === 'select'}
       <select
-        value={value ?? ''}
+        value={(value as string | undefined) ?? ''}
         onchange={(e) => onChange((e.target as HTMLSelectElement).value)}
         class={inputCls}
       >
@@ -145,7 +147,7 @@
       <div class="space-y-2">
         {#if field.fields}
           <!-- Object list: each item is a sub-form -->
-          {#each ((value ?? []) as Record<string, any>[]) as item, idx (idx)}
+          {#each ((value ?? []) as Record<string, unknown>[]) as item, idx (idx)}
             <div class="flex gap-2 items-start p-3 bg-dark/50 border border-dark-lighter rounded-lg">
               <div class="flex-1 space-y-2">
                 {#each (field.fields ?? []) as subField (subField.key)}
@@ -153,7 +155,7 @@
                     subField,
                     (item ?? {})[subField.key],
                     (val) => {
-                      const arr = [...(value ?? [])];
+                      const arr = [...((value as Record<string, unknown>[]) ?? [])];
                       arr[idx] = { ...(arr[idx] ?? {}), [subField.key]: val };
                       onChange(arr);
                     }
@@ -163,7 +165,7 @@
               <button
                 type="button"
                 onclick={() => {
-                  const arr = [...(value ?? [])];
+                  const arr = [...((value as Record<string, unknown>[]) ?? [])];
                   arr.splice(idx, 1);
                   onChange(arr);
                 }}
@@ -174,9 +176,9 @@
           <button
             type="button"
             onclick={() => {
-              const empty: Record<string, any> = {};
+              const empty: Record<string, unknown> = {};
               for (const sf of field.fields ?? []) empty[sf.key] = '';
-              onChange([...(value ?? []), empty]);
+              onChange([...((value as unknown[]) ?? []), empty]);
             }}
             class="px-3 py-1.5 text-xs bg-dark border border-dark-lighter text-muted hover:text-light hover:border-gold/50 rounded-lg transition-colors"
           >+ Hinzufügen</button>
@@ -188,7 +190,7 @@
                 type="text"
                 value={item}
                 oninput={(e) => {
-                  const arr = [...(value ?? [])];
+                  const arr = [...((value as string[]) ?? [])];
                   arr[idx] = (e.target as HTMLInputElement).value;
                   onChange(arr);
                 }}
@@ -197,7 +199,7 @@
               <button
                 type="button"
                 onclick={() => {
-                  const arr = [...(value ?? [])];
+                  const arr = [...((value as string[]) ?? [])];
                   arr.splice(idx, 1);
                   onChange(arr);
                 }}
@@ -207,7 +209,7 @@
           {/each}
           <button
             type="button"
-            onclick={() => onChange([...(value ?? []), ''])}
+            onclick={() => onChange([...((value as string[]) ?? []), ''])}
             class="px-3 py-1.5 text-xs bg-dark border border-dark-lighter text-muted hover:text-light hover:border-gold/50 rounded-lg transition-colors"
           >+ Hinzufügen</button>
         {/if}
@@ -218,8 +220,8 @@
         {#each (field.fields ?? []) as subField (subField.key)}
           {@render fieldRenderer(
             subField,
-            (value ?? {})[subField.key],
-            (val) => onChange({ ...(value ?? {}), [subField.key]: val })
+            ((value as Record<string, unknown>) ?? {})[subField.key],
+            (val) => onChange({ ...((value as Record<string, unknown>) ?? {}), [subField.key]: val })
           )}
         {/each}
       </div>

--- a/website/src/components/kore/KoreHomepage.svelte
+++ b/website/src/components/kore/KoreHomepage.svelte
@@ -1,15 +1,48 @@
 <script lang="ts">
   import Timeline from '../Timeline.svelte';
   import type { DaySlots } from '../../lib/caldav';
+  import type { BrandConfig, FooterConfig, HomepageService } from '../../config/types';
 
-  export let services: any[] = [];
-  export let homepage: any = {};
-  export let contact: any = {};
-  export let legal: any = {};
-  export let footerColumns: any[] = [];
+  interface KoreContact {
+    name?: string;
+    email?: string;
+    phone?: string;
+    city?: string;
+  }
+
+  interface KoreLegal {
+    jobtitle?: string;
+    tagline?: string;
+    street?: string;
+    zip?: string;
+    ustId?: string;
+    website?: string;
+    chamber?: string;
+  }
+
+  interface TimelineRow {
+    id: number;
+    day: string;
+    pr_number: number | null;
+    title: string;
+    description: string | null;
+    category: string;
+    scope: string | null;
+    brand: string | null;
+    requirement_id: string | null;
+    bugs_fixed: number;
+    ticket_external_id: string | null;
+    ticket_id: string | null;
+  }
+
+  export let services: HomepageService[] = [];
+  export let homepage: Partial<BrandConfig['homepage']> = {};
+  export let contact: KoreContact = {};
+  export let legal: KoreLegal = {};
+  export let footerColumns: FooterConfig['columns'] = [];
   export let footerCopyright: string = '';
   export let nextDay: DaySlots | null = null;
-  export let initialTimeline: any[] = [];
+  export let initialTimeline: TimelineRow[] = [];
   export let wantsTimeline: boolean = false;
 
   // Nav active section

--- a/website/src/lib/admin/behaviorStore.ts
+++ b/website/src/lib/admin/behaviorStore.ts
@@ -1,27 +1,27 @@
 export type SaveState = 'pristine' | 'dirty' | 'saving' | 'saved' | 'conflict' | 'error';
 type Errors = { field: string; message: string }[];
-export interface Conflict { currentVersion: number; currentValue: any }
+export interface Conflict<T = unknown> { currentVersion: number; currentValue: T }
 
-interface Opts {
+interface Opts<T = unknown> {
   contentKey: string;
-  initialValue: any;
+  initialValue: T;
   initialVersion: number;
-  validate: (value: any) => Errors;
-  saveFn: (contentKey: string, baseVersion: number, value: any) => Promise<{ version: number }>;
+  validate: (value: T) => Errors;
+  saveFn: (contentKey: string, baseVersion: number, value: T) => Promise<{ version: number }>;
   debounceMs?: number;
   onPreviewRefresh?: () => void;
 }
 
-interface Snapshot { value: any; version: number; state: SaveState; errors: Errors; conflict?: Conflict }
+interface Snapshot<T = unknown> { value: T; version: number; state: SaveState; errors: Errors; conflict?: Conflict<T> }
 
-export function createBehaviorStore(opts: Opts) {
+export function createBehaviorStore<T = unknown>(opts: Opts<T>) {
   const debounceMs = opts.debounceMs ?? 2000;
-  let snap: Snapshot = { value: opts.initialValue, version: opts.initialVersion, state: 'pristine', errors: [] };
-  const subs = new Set<(s: Snapshot) => void>();
-  let timer: any = null;
+  let snap: Snapshot<T> = { value: opts.initialValue, version: opts.initialVersion, state: 'pristine', errors: [] };
+  const subs = new Set<(s: Snapshot<T>) => void>();
+  let timer: ReturnType<typeof setTimeout> | null = null;
 
   const emit = () => subs.forEach((f) => f(snap));
-  const set = (p: Partial<Snapshot>) => { snap = { ...snap, ...p }; emit(); };
+  const set = (p: Partial<Snapshot<T>>) => { snap = { ...snap, ...p }; emit(); };
 
   async function flush() {
     const errors = opts.validate(snap.value);
@@ -32,8 +32,9 @@ export function createBehaviorStore(opts: Opts) {
       const { version } = await opts.saveFn(opts.contentKey, snap.version, snap.value);
       set({ state: 'saved', version });
       opts.onPreviewRefresh?.();
-    } catch (e: any) {
-      if (e?.status === 409) set({ state: 'conflict', conflict: e.body });
+    } catch (e: unknown) {
+      const err = e as { status?: number; body?: Conflict<T> };
+      if (err?.status === 409) set({ state: 'conflict', conflict: err.body });
       else set({ state: 'error', errors: [{ field: '', message: 'Speichern fehlgeschlagen' }] });
     }
   }
@@ -42,8 +43,8 @@ export function createBehaviorStore(opts: Opts) {
 
   return {
     get: () => snap,
-    subscribe(f: (s: Snapshot) => void) { subs.add(f); f(snap); return () => subs.delete(f); },
-    setValue(value: any) { if (snap.state === 'conflict') return; set({ value, state: 'dirty' }); schedule(); },
+    subscribe(f: (s: Snapshot<T>) => void) { subs.add(f); f(snap); return () => subs.delete(f); },
+    setValue(value: T) { if (snap.state === 'conflict') return; set({ value, state: 'dirty' }); schedule(); },
     saveNow() { if (timer) clearTimeout(timer); return flush(); },
     resolveConflictTakeTheirs() { const c = snap.conflict!; set({ value: c.currentValue, version: c.currentVersion, state: 'dirty', conflict: undefined }); },
     resolveConflictTakeMine() { const c = snap.conflict!; set({ version: c.currentVersion, state: 'dirty', conflict: undefined }); return flush(); },

--- a/website/src/lib/bulk-status.ts
+++ b/website/src/lib/bulk-status.ts
@@ -6,14 +6,14 @@ export const MAX_BULK_SELECT = 10;
 export interface BulkChangeResult {
   changed: { id: string; oldStatus: string }[];
   skipped: { id: string; oldStatus: string; reason: string }[];
-  failed: { id: string; error: any }[];
+  failed: { id: string; error: unknown }[];
   undoToken?: string;
   oldStatuses: Record<string, string>;
 }
 
 export interface UndoResult {
   restored: string[];
-  failed: { id: string; error: any }[];
+  failed: { id: string; error: unknown }[];
 }
 
 interface UndoStoreItem {
@@ -39,7 +39,7 @@ export async function bulkChangeStatus(
 
   const changed: { id: string; oldStatus: string }[] = [];
   const skipped: { id: string; oldStatus: string; reason: string }[] = [];
-  const failed: { id: string; error: any }[] = [];
+  const failed: { id: string; error: unknown }[] = [];
   const oldStatuses: Record<string, string> = {};
 
   for (const id of ids) {
@@ -123,7 +123,7 @@ export async function undoBulkStatus(token: string): Promise<UndoResult> {
 
   const { oldStatuses, newStatus, brand } = item;
   const restored: string[] = [];
-  const failed: { id: string; error: any }[] = [];
+  const failed: { id: string; error: unknown }[] = [];
 
   for (const [id, oldStatus] of Object.entries(oldStatuses)) {
     const client = await pool.connect();

--- a/website/src/lib/comfy-client.test.ts
+++ b/website/src/lib/comfy-client.test.ts
@@ -3,7 +3,7 @@ import { uploadImage, queuePrompt, getHistory, downloadOutput, findGlbOutput } f
 
 const BASE = 'http://comfy-gateway:8189';
 
-function mockFetch(responses: Record<string, unknown>) {
+function mockFetch(responses: Record<string, unknown>): typeof fetch {
   return vi.fn(async (url: string) => {
     const key = Object.keys(responses).find(k => url.includes(k));
     if (!key) throw new Error(`unmocked url: ${url}`);
@@ -12,7 +12,7 @@ function mockFetch(responses: Record<string, unknown>) {
       json: async () => responses[key],
       arrayBuffer: async () => responses[key] as ArrayBuffer,
     };
-  });
+  }) as unknown as typeof fetch;
 }
 
 beforeEach(() => { vi.restoreAllMocks(); });
@@ -20,7 +20,7 @@ beforeEach(() => { vi.restoreAllMocks(); });
 describe('uploadImage', () => {
   it('POSTs to /upload/image and returns filename', async () => {
     const fetch = mockFetch({ '/upload/image': { name: 'abc123.png', subfolder: '', type: 'input' } });
-    const result = await uploadImage(BASE, new Uint8Array([1, 2, 3]).buffer, 'photo.png', fetch as any);
+    const result = await uploadImage(BASE, new Uint8Array([1, 2, 3]).buffer, 'photo.png', fetch);
     expect(result).toBe('abc123.png');
     expect(fetch).toHaveBeenCalledWith(
       `${BASE}/upload/image`,
@@ -32,7 +32,7 @@ describe('uploadImage', () => {
 describe('queuePrompt', () => {
   it('POSTs workflow to /prompt and returns prompt_id', async () => {
     const fetch = mockFetch({ '/prompt': { prompt_id: 'pid-001' } });
-    const id = await queuePrompt(BASE, { nodes: {} }, fetch as any);
+    const id = await queuePrompt(BASE, { nodes: {} }, fetch);
     expect(id).toBe('pid-001');
   });
 });
@@ -40,7 +40,7 @@ describe('queuePrompt', () => {
 describe('getHistory', () => {
   it('returns empty object when job is still queued', async () => {
     const fetch = mockFetch({ '/history/pid-001': {} });
-    const h = await getHistory(BASE, 'pid-001', fetch as any);
+    const h = await getHistory(BASE, 'pid-001', fetch);
     expect(h).toEqual({});
   });
 
@@ -52,7 +52,7 @@ describe('getHistory', () => {
       },
     };
     const fetch = mockFetch({ '/history/pid-001': completed });
-    const h = await getHistory(BASE, 'pid-001', fetch as any);
+    const h = await getHistory(BASE, 'pid-001', fetch);
     expect(h['pid-001'].status.completed).toBe(true);
   });
 });
@@ -75,7 +75,7 @@ describe('downloadOutput', () => {
   it('GETs /view with filename and returns ArrayBuffer', async () => {
     const buf = new Uint8Array([0x67, 0x6c, 0x54, 0x46]).buffer;
     const fetch = mockFetch({ '/view': buf });
-    const result = await downloadOutput(BASE, 'output.glb', fetch as any);
+    const result = await downloadOutput(BASE, 'output.glb', fetch);
     expect(result).toBe(buf);
   });
 });

--- a/website/src/lib/delivery-metrics.test.ts
+++ b/website/src/lib/delivery-metrics.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { calcDurationH, toDeliveryMetric, summarize, modelMixPercent } from './delivery-metrics';
-import type { DeliveryRow } from './delivery-metrics';
+import type { DeliveryRow, DeliveryMetric } from './delivery-metrics';
 
 describe('calcDurationH', () => {
   it('returns null when from is null', () => {
@@ -84,9 +84,9 @@ describe('modelMixPercent', () => {
 describe('summarize', () => {
   it('computes averages ignoring null entries', () => {
     const metrics = [
-      { hoursTicketToPrOpen: 10, hoursPrOpenToMerged: 20, hoursMergedToLive: 5, hoursTotal: 35 } as any,
-      { hoursTicketToPrOpen: null, hoursPrOpenToMerged: null, hoursMergedToLive: null, hoursTotal: null } as any,
-      { hoursTicketToPrOpen: 30, hoursPrOpenToMerged: 40, hoursMergedToLive: 10, hoursTotal: 80 } as any,
+      { hoursTicketToPrOpen: 10, hoursPrOpenToMerged: 20, hoursMergedToLive: 5, hoursTotal: 35 } as unknown as DeliveryMetric,
+      { hoursTicketToPrOpen: null, hoursPrOpenToMerged: null, hoursMergedToLive: null, hoursTotal: null } as unknown as DeliveryMetric,
+      { hoursTicketToPrOpen: 30, hoursPrOpenToMerged: 40, hoursMergedToLive: 10, hoursTotal: 80 } as unknown as DeliveryMetric,
     ];
 
     const s = summarize(metrics, 2, 14, {});
@@ -98,7 +98,7 @@ describe('summarize', () => {
   });
 
   it('mishap rate is bugCount / deliveries', () => {
-    const metrics = [{ hoursTicketToPrOpen: 1 } as any, { hoursTicketToPrOpen: 2 } as any];
+    const metrics = [{ hoursTicketToPrOpen: 1 } as unknown as DeliveryMetric, { hoursTicketToPrOpen: 2 } as unknown as DeliveryMetric];
     const s = summarize(metrics, 1, 7, {});
     expect(s.mishapRate).toBe(0.5);
     expect(s.mishapCount).toBe(1);

--- a/website/src/lib/factory-floor.test.ts
+++ b/website/src/lib/factory-floor.test.ts
@@ -77,6 +77,7 @@ import { getHall, getLoadingDock, getShipped, getMetrics, getControl,
          getStaged, releaseToBacklog, getProviderHealth, getAwaitingDeploy,
          phaseProgress, STATUS_BUCKETS, ALL_TICKET_STATUSES,
          buildAttention, phaseDurations } from './factory-floor';
+import type { HallItem, ProviderStatus, PhaseEventRow } from './factory-floor';
 import { aggregateCheckRuns } from './github-ci';
 
 describe('factory-floor DAL', () => {
@@ -342,11 +343,11 @@ describe('buildAttention', () => {
     { extId: 'A', phaseState: 'blocked', blockReason: 'review', phaseSince: new Date(Date.now() - 60_000).toISOString() },
     { extId: 'B', phaseState: 'entered', blockReason: null, phaseSince: new Date(Date.now() - 30 * 60_000).toISOString() },
     { extId: 'C', phaseState: 'entered', blockReason: null, phaseSince: new Date().toISOString() },
-  ] as any;
+  ] as unknown as HallItem[];
   const providers = [
     { provider: 'deepseek', status: 'cooldown', cooldownUntil: new Date(Date.now() + 60_000).toISOString() },
     { provider: 'anthropic', status: 'healthy', cooldownUntil: null },
-  ] as any;
+  ] as unknown as ProviderStatus[];
 
   it('collects blocked, stuck (>15min) and cooled-down providers', () => {
     const a = buildAttention(hall, providers, 15);
@@ -358,8 +359,8 @@ describe('buildAttention', () => {
 
   it('is empty when nothing needs attention', () => {
     const a = buildAttention(
-      [{ extId: 'C', phaseState: 'entered', blockReason: null, phaseSince: new Date().toISOString() }] as any,
-      [{ provider: 'x', status: 'healthy', cooldownUntil: null }] as any, 15);
+      [{ extId: 'C', phaseState: 'entered', blockReason: null, phaseSince: new Date().toISOString() }] as unknown as HallItem[],
+      [{ provider: 'x', status: 'healthy', cooldownUntil: null }] as unknown as ProviderStatus[], 15);
     expect(a.isEmpty).toBe(true);
   });
 });
@@ -369,7 +370,7 @@ describe('phaseDurations', () => {
     const events = [
       { phase: 'scout', state: 'entered', at: '2026-06-12T10:00:00.000Z' },
       { phase: 'scout', state: 'done',    at: '2026-06-12T10:05:00.000Z' },
-    ] as any;
+    ] as unknown as PhaseEventRow[];
     const d = phaseDurations(events);
     expect(d[0]).toMatchObject({ phase: 'scout', state: 'entered', durationSec: null });
     expect(d[1]).toMatchObject({ phase: 'scout', state: 'done', durationSec: 300 });

--- a/website/src/lib/factory-floor.ts
+++ b/website/src/lib/factory-floor.ts
@@ -182,7 +182,7 @@ export async function getMetrics(): Promise<FloorMetrics> {
 
 /** Backlog features waiting for a slot, with a derived wait reason. */
 export async function getLoadingDock(slotsUsed: number, slotsCap: number): Promise<LoadingDockItem[]> {
-  const r = await pool.query(
+  const r = await pool.query<{ external_id: string; title: string; priority: string; retry_count: number | null }>(
     `SELECT external_id, title, priority, retry_count
        FROM tickets.tickets
       WHERE type = 'feature' AND status = 'backlog' AND pipeline_slot IS NULL
@@ -190,7 +190,7 @@ export async function getLoadingDock(slotsUsed: number, slotsCap: number): Promi
                created_at`,
   );
   const slotsFull = slotsUsed >= slotsCap;
-  return r.rows.map((row: any) => ({
+  return r.rows.map((row) => ({
     extId: row.external_id,
     title: row.title,
     priority: row.priority,
@@ -204,7 +204,12 @@ export async function getHall(): Promise<HallItem[]> {
   // latest phase event per ticket via DISTINCT ON, then LEFT JOIN. A ticket
   // qualifies for the Hall if it holds a pipeline_slot (Factory) OR if it has
   // at least one driver='devflow' phase event (dev-flow-execute run, no slot).
-  const r = await pool.query(
+  const r = await pool.query<{
+    external_id: string; title: string; priority: string;
+    pipeline_slot: number | null; retry_count: number | null;
+    phase: Phase | null; state: PhaseState | null; detail: string | null;
+    driver: 'factory' | 'devflow' | null; at: string | null;
+  }>(
     `SELECT t.external_id, t.title, t.priority, t.pipeline_slot, t.retry_count,
             e.phase, e.state, e.detail, e.driver, e.at
        FROM tickets.tickets t
@@ -220,7 +225,7 @@ export async function getHall(): Promise<HallItem[]> {
         AND (t.pipeline_slot IS NOT NULL OR dv.ticket_id IS NOT NULL)
       ORDER BY t.pipeline_slot NULLS LAST, t.external_id`,
   );
-  return r.rows.map((row: any) => ({
+  return r.rows.map((row) => ({
     extId: row.external_id,
     title: row.title,
     priority: row.priority,
@@ -243,7 +248,7 @@ export async function getShipped(limit = 8): Promise<ShippedItem[]> {
   // a correlated scalar subquery referencing the outer alias t.id). LIMIT is cast
   // to int so a string-bound param works under both pg-mem and real Postgres.
   // The nested subquery is constrained to done tickets to avoid unbounded scans.
-  const r = await pool.query(
+  const r = await pool.query<{ external_id: string; title: string; done_at: string | null; pr_number: number | null }>(
     `SELECT t.external_id, t.title, t.done_at, l.pr_number
        FROM tickets.tickets t
        LEFT JOIN (
@@ -260,13 +265,13 @@ export async function getShipped(limit = 8): Promise<ShippedItem[]> {
       LIMIT $1::int`,
     [limit],
   );
-  return r.rows.map((row: any) => mapShippedRow(row));
+  return r.rows.map((row) => mapShippedRow(row));
 }
 
 /** Tickets merged to main but not yet deployed to fleet (the "merge ≠ prod" lane). */
 export async function getAwaitingDeploy(limit = 12): Promise<AwaitingDeployItem[]> {
   // Bounded query targeting only awaiting_deploy tickets for performance.
-  const r = await pool.query(
+  const r = await pool.query<{ external_id: string; title: string; updated_at: string | null; pr_number: number | null }>(
     `SELECT t.external_id, t.title, t.updated_at, l.pr_number
        FROM tickets.tickets t
        LEFT JOIN (
@@ -283,13 +288,13 @@ export async function getAwaitingDeploy(limit = 12): Promise<AwaitingDeployItem[
       LIMIT $1::int`,
     [limit],
   );
-  return r.rows.map((row: any) => mapAwaitingRow(row));
+  return r.rows.map((row) => mapAwaitingRow(row));
 }
 
 /** Plan_staged features (Kommissionierung) with branch/plan parsed from the latest
  *  FACTORY-PLAN-REF comment. Newest first. branch/planPath are null when no ref. */
 export async function getStaged(limit = 12): Promise<StagedItem[]> {
-  const r = await pool.query(
+  const r = await pool.query<{ external_id: string; title: string; priority: string; created_at: string | null; ref_body: string | null }>(
     `SELECT t.external_id, t.title, t.priority, t.created_at, c.body AS ref_body
        FROM tickets.tickets t
        LEFT JOIN (
@@ -304,7 +309,7 @@ export async function getStaged(limit = 12): Promise<StagedItem[]> {
       LIMIT $1::int`,
     [limit],
   );
-  return r.rows.map((row: any) => {
+  return r.rows.map((row) => {
     const { branch, planPath } = parsePlanRef(row.ref_body);
     return {
       extId: row.external_id,
@@ -380,7 +385,10 @@ export async function deployFromAwaiting(extId: string): Promise<boolean> {
 }
 
 export async function getProviderHealth(): Promise<ProviderStatus[]> {
-  const { rows } = await pool.query(`
+  const { rows } = await pool.query<{
+    provider: string; active_agents: number | string; cooldown_until: string | null;
+    max_concurrent: number | string; tiers: string[] | null;
+  }>(`
     SELECT ph.provider,
            ph.active_agents,
            ph.cooldown_until,
@@ -391,7 +399,7 @@ export async function getProviderHealth(): Promise<ProviderStatus[]> {
      GROUP BY ph.provider, ph.active_agents, ph.cooldown_until
      ORDER BY ph.provider`);
   const now = Date.now();
-  return rows.map((r: any) => ({
+  return rows.map((r) => ({
     provider: r.provider,
     status: r.cooldown_until && new Date(r.cooldown_until).getTime() > now ? 'cooldown' : 'healthy' as const,
     activeAgents: Number(r.active_agents),
@@ -464,12 +472,12 @@ export async function getTicketDetail(extId: string): Promise<TicketDetail | nul
   if (!t.rows.length) return null;
   const row = t.rows[0];
   const [events, breadcrumbs, pr, injections] = await Promise.all([
-    pool.query(
+    pool.query<{ phase: Phase; state: PhaseState; detail: string | null; driver: string; at: string }>(
       `SELECT phase, state, detail, driver, at FROM tickets.factory_phase_events
          WHERE ticket_id = $1 ORDER BY at DESC`,
       [row.id],
     ),
-    pool.query(
+    pool.query<{ author_label: string; body: string; created_at: string }>(
       `SELECT author_label, body, created_at FROM tickets.ticket_comments
          WHERE ticket_id = $1 ORDER BY created_at DESC LIMIT 8`,
       [row.id],
@@ -502,11 +510,11 @@ export async function getTicketDetail(extId: string): Promise<TicketDetail | nul
     priority: row.priority,
     retryCount: row.retry_count ?? 0,
     prNumber: pr.rows[0]?.pr_number ?? null,
-    events: events.rows.map((e: any) => ({
+    events: events.rows.map((e) => ({
       phase: e.phase, state: e.state, detail: e.detail ?? null, driver: e.driver,
       at: new Date(e.at).toISOString(),
     })),
-    breadcrumbs: breadcrumbs.rows.map((b: any) => ({
+    breadcrumbs: breadcrumbs.rows.map((b) => ({
       authorLabel: b.author_label, body: b.body, at: new Date(b.created_at).toISOString(),
     })),
     injections: injections.rows.map(mapInjection),
@@ -514,15 +522,15 @@ export async function getTicketDetail(extId: string): Promise<TicketDetail | nul
   };
 }
 
-function mapInjection(r: any): InjectionRow {
+function mapInjection(r: Record<string, unknown>): InjectionRow {
   return {
-    id: String(r.id), phase: r.phase ?? null, kind: r.kind,
-    title: r.title ?? null, content: r.content ?? null,
-    targetFiles: r.target_files ?? null,
-    dataUrl: r.data_url ?? null, ncPath: r.nc_path ?? null,
-    filename: r.filename ?? null, mimeType: r.mime_type ?? null,
-    injectedBy: r.injected_by, injectedAt: new Date(r.injected_at).toISOString(),
-    consumedAt: r.consumed_at ? new Date(r.consumed_at).toISOString() : null,
+    id: String(r.id), phase: (r.phase as Phase | null) ?? null, kind: r.kind as InjectionKind,
+    title: (r.title as string | null) ?? null, content: (r.content as string | null) ?? null,
+    targetFiles: (r.target_files as string[] | null) ?? null,
+    dataUrl: (r.data_url as string | null) ?? null, ncPath: (r.nc_path as string | null) ?? null,
+    filename: (r.filename as string | null) ?? null, mimeType: (r.mime_type as string | null) ?? null,
+    injectedBy: r.injected_by as string, injectedAt: new Date(r.injected_at as string).toISOString(),
+    consumedAt: r.consumed_at ? new Date(r.consumed_at as string).toISOString() : null,
   };
 }
 

--- a/website/src/lib/k8s.ts
+++ b/website/src/lib/k8s.ts
@@ -13,19 +13,19 @@ export class K8sApiError extends Error {
 }
 
 export type K8sClient = {
-  get: (path: string) => Promise<any>;
-  patch: (path: string, body: object) => Promise<any>;
-  mergePatch: (path: string, body: object) => Promise<any>;
-  post: (path: string, body: object) => Promise<any>;
-  delete: (path: string) => Promise<any>;
+  get: <T = unknown>(path: string) => Promise<T>;
+  patch: <T = unknown>(path: string, body: object) => Promise<T>;
+  mergePatch: <T = unknown>(path: string, body: object) => Promise<T>;
+  post: <T = unknown>(path: string, body: object) => Promise<T>;
+  delete: <T = unknown>(path: string) => Promise<T>;
 };
 
 export async function createK8sClient(): Promise<K8sClient> {
   const token = await fs.readFile('/var/run/secrets/kubernetes.io/serviceaccount/token', 'utf-8');
   const ca = await fs.readFile('/var/run/secrets/kubernetes.io/serviceaccount/ca.crt', 'utf-8');
 
-  function request(path: string, method: string, body?: object, contentType = 'application/strategic-merge-patch+json'): Promise<any> {
-    return new Promise((resolve, reject) => {
+  function request<T = unknown>(path: string, method: string, body?: object, contentType = 'application/strategic-merge-patch+json'): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
       const bodyStr = body ? JSON.stringify(body) : undefined;
       const req = https.request(
         {
@@ -61,11 +61,11 @@ export async function createK8sClient(): Promise<K8sClient> {
   }
 
   return {
-    get: (path) => request(path, 'GET'),
-    patch: (path, body) => request(path, 'PATCH', body),
-    mergePatch: (path, body) => request(path, 'PATCH', body, 'application/merge-patch+json'),
-    post: (path, body) => request(path, 'POST', body, 'application/json'),
-    delete: (path) => request(path, 'DELETE'),
+    get: <T = unknown>(path: string) => request<T>(path, 'GET'),
+    patch: <T = unknown>(path: string, body: object) => request<T>(path, 'PATCH', body),
+    mergePatch: <T = unknown>(path: string, body: object) => request<T>(path, 'PATCH', body, 'application/merge-patch+json'),
+    post: <T = unknown>(path: string, body: object) => request<T>(path, 'POST', body, 'application/json'),
+    delete: <T = unknown>(path: string) => request<T>(path, 'DELETE'),
   };
 }
 

--- a/website/src/lib/knowledge-db.test.ts
+++ b/website/src/lib/knowledge-db.test.ts
@@ -1,8 +1,15 @@
 import { describe, test, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
 import { newDb, DataType } from 'pg-mem';
+import type { Pool } from 'pg';
 import * as kdb from './knowledge-db';
 
-let pool: ReturnType<ReturnType<typeof newDb>['adapters']['createPg']>['Pool'] extends new (...args: unknown[]) => infer T ? T : never;
+// pg-mem types its generated Pool as `any`; model the surface the tests use.
+type TestPool = {
+  query: (text: string, values?: unknown[]) => Promise<{ rows: Array<Record<string, unknown>> }>;
+  end: () => Promise<void>;
+};
+
+let pool: TestPool;
 
 let pgmem: ReturnType<typeof newDb>;
 
@@ -62,16 +69,16 @@ beforeAll(async () => {
   `);
   const { Pool } = pgmem.adapters.createPg();
   pool = new Pool();
-  kdb.__setPoolForTests(pool as any);
+  kdb.__setPoolForTests(pool as unknown as Pool);
 });
 
-afterAll(() => (pool as any).end());
+afterAll(() => pool.end());
 
 beforeEach(async () => {
-  await (pool as any).query('DELETE FROM knowledge.chunks');
-  await (pool as any).query('DELETE FROM knowledge.documents');
-  await (pool as any).query('DELETE FROM coaching.books');
-  await (pool as any).query('DELETE FROM knowledge.collections');
+  await pool.query('DELETE FROM knowledge.chunks');
+  await pool.query('DELETE FROM knowledge.documents');
+  await pool.query('DELETE FROM coaching.books');
+  await pool.query('DELETE FROM knowledge.collections');
 });
 
 describe('knowledge-db', () => {
@@ -104,10 +111,10 @@ describe('knowledge-db — model-aware query path', () => {
   const ORIGINAL_LLM_ENABLED = process.env.LLM_ENABLED;
 
   beforeEach(async () => {
-    await (pool as any).query('DELETE FROM knowledge.chunks');
-    await (pool as any).query('DELETE FROM knowledge.documents');
-    await (pool as any).query('DELETE FROM coaching.books');
-    await (pool as any).query('DELETE FROM knowledge.collections');
+    await pool.query('DELETE FROM knowledge.chunks');
+    await pool.query('DELETE FROM knowledge.documents');
+    await pool.query('DELETE FROM coaching.books');
+    await pool.query('DELETE FROM knowledge.collections');
     process.env.LLM_ENABLED = 'false';
   });
 
@@ -148,20 +155,20 @@ describe('knowledge-db — model-aware query path', () => {
 
 describe('mergeCollections', () => {
   async function seedCollection(name: string, source: 'custom' | 'web_crawl' | 'pr_history', chunks: number, model = 'voyage-multilingual-2') {
-    const r = await (pool as any).query(
+    const r = await pool.query(
       `INSERT INTO knowledge.collections (name, source, chunk_count, embedding_model)
        VALUES ($1, $2, $3, $4) RETURNING id`,
       [name, source, chunks, model],
     );
-    const colId: string = r.rows[0].id;
-    const docR = await (pool as any).query(
+    const colId = r.rows[0].id as string;
+    const docR = await pool.query(
       `INSERT INTO knowledge.documents (collection_id, title, source_uri, raw_text)
        VALUES ($1, $2, $3, $4) RETURNING id`,
       [colId, `${name}-doc`, `uri:${name}`, `text of ${name}`],
     );
-    const docId: string = docR.rows[0].id;
+    const docId = docR.rows[0].id as string;
     for (let i = 0; i < chunks; i++) {
-      await (pool as any).query(
+      await pool.query(
         `INSERT INTO knowledge.chunks (document_id, collection_id, position, text, embedding)
          VALUES ($1, $2, $3, $4, $5)`,
         [docId, colId, i, `chunk ${i} of ${name}`, '[0.1,0.2]'],
@@ -193,12 +200,12 @@ describe('mergeCollections', () => {
 
     const merged = await kdb.mergeCollections({ sourceIds: [a, b], name: 'docs-merged' });
 
-    const docs = await (pool as any).query(
+    const docs = await pool.query(
       'SELECT * FROM knowledge.documents WHERE collection_id = $1', [merged.id],
     );
     expect(docs.rows).toHaveLength(2);
 
-    const chunks = await (pool as any).query(
+    const chunks = await pool.query(
       'SELECT * FROM knowledge.chunks WHERE collection_id = $1', [merged.id],
     );
     expect(chunks.rows).toHaveLength(5);
@@ -207,14 +214,14 @@ describe('mergeCollections', () => {
   test('deletes coaching.books records for source collections', async () => {
     const a = await seedCollection('book-src', 'custom', 2);
     const b = await seedCollection('book-src2', 'custom', 1);
-    await (pool as any).query(
+    await pool.query(
       `INSERT INTO coaching.books (knowledge_collection_id, title) VALUES ($1, $2)`,
       [a, 'Test Book'],
     );
 
     await kdb.mergeCollections({ sourceIds: [a, b], name: 'book-merged' });
 
-    const books = await (pool as any).query(
+    const books = await pool.query(
       'SELECT * FROM coaching.books WHERE knowledge_collection_id = $1', [a],
     );
     expect(books.rows).toHaveLength(0);

--- a/website/src/lib/planning-office.ts
+++ b/website/src/lib/planning-office.ts
@@ -30,9 +30,26 @@ export function dorScore(r: Readiness | null): number {
   return DOR_KEYS.reduce((n, k) => n + (r[k] === true ? 1 : 0), 0);
 }
 
-function mapRow(row: any): OfficeItem {
+interface OfficeRow {
+  external_id: string;
+  title: string;
+  value_prop: string | null;
+  priority: string;
+  effort: string | null;
+  areas: string[] | null;
+  depends_on: string[] | null;
+  planning_rank: number | null;
+  readiness: Readiness | null;
+  pinned: boolean | null;
+  created_at: string;
+  updated_at: string;
+  requirements_list: string[] | null;
+  grilling_meta: Record<string, unknown> | null;
+}
+
+function mapRow(row: OfficeRow): OfficeItem {
   const readiness: Readiness = row.readiness ?? {};
-  const grillingMeta = row.grilling_meta ?? {};
+  const grillingMeta: Record<string, unknown> = row.grilling_meta ?? {};
   return {
     extId: row.external_id, title: row.title, valueProp: row.value_prop,
     priority: row.priority, effort: row.effort,
@@ -99,8 +116,8 @@ export async function patchItem(extId: string, p: PatchInput): Promise<boolean> 
     if (!canLock(effective)) throw new Error('lastenheft_empty');
   }
 
-  const sets: string[] = []; const vals: any[] = []; let i = 1;
-  const add = (col: string, v: any) => { sets.push(`${col} = $${i++}`); vals.push(v); };
+  const sets: string[] = []; const vals: unknown[] = []; let i = 1;
+  const add = (col: string, v: unknown) => { sets.push(`${col} = $${i++}`); vals.push(v); };
   if (p.valueProp !== undefined) add('value_prop', p.valueProp);
   if (p.priority !== undefined) add('priority', p.priority);
   if (p.effort !== undefined) add('effort', p.effort);

--- a/website/src/lib/sessions/archive.ts
+++ b/website/src/lib/sessions/archive.ts
@@ -21,13 +21,24 @@ async function writeAtomically(filePath: string, data: string): Promise<void> {
   await rename(tmpPath, filePath);
 }
 
-async function readRegistry(filePath: string): Promise<any[]> {
+interface RegistryEntry {
+  slug: string;
+  started_at?: string;
+  type?: string;
+  title?: string;
+  participants?: string[];
+  owner?: string;
+  preferred_username?: string;
+  local_url?: string;
+}
+
+async function readRegistry(filePath: string): Promise<RegistryEntry[]> {
   const raw = await readFile(filePath, 'utf8');
   const parsed = JSON.parse(raw);
   if (!Array.isArray(parsed)) {
     throw new Error('Registry is not an array');
   }
-  return parsed;
+  return parsed as RegistryEntry[];
 }
 
 export async function purgeOldSessions({ maxAgeDays = 30 }: { maxAgeDays?: number } = {}): Promise<{ purged: number; warnings: string[] }> {
@@ -35,11 +46,11 @@ export async function purgeOldSessions({ maxAgeDays = 30 }: { maxAgeDays?: numbe
   const archiveDir = getArchiveDir();
   const warnings: string[] = [];
 
-  let registry: any[] = [];
+  let registry: RegistryEntry[] = [];
   try {
     registry = await readRegistry(registryPath);
-  } catch (err: any) {
-    if (err.code === 'ENOENT') {
+  } catch (err: unknown) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
       registry = [];
     } else {
       warnings.push('corrupt-registry');
@@ -50,8 +61,8 @@ export async function purgeOldSessions({ maxAgeDays = 30 }: { maxAgeDays?: numbe
   const now = new Date();
   const maxAgeMs = maxAgeDays * 24 * 60 * 60 * 1000;
 
-  const toKeep: any[] = [];
-  const toPurge: any[] = [];
+  const toKeep: RegistryEntry[] = [];
+  const toPurge: RegistryEntry[] = [];
 
   for (const entry of registry) {
     if (!entry.started_at) {
@@ -156,8 +167,8 @@ export async function listArchivedSessions({
   let files: string[] = [];
   try {
     files = await readdir(archiveDir);
-  } catch (err: any) {
-    if (err.code === 'ENOENT') {
+  } catch (err: unknown) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
       return { items: [], total: 0, hasMore: false };
     }
     throw err;
@@ -223,7 +234,7 @@ export async function getArchivedMarkdown(id: string): Promise<string | null> {
   const filePath = join(archiveDir, `${id}.md`);
   try {
     return await readFile(filePath, 'utf8');
-  } catch (err: any) {
+  } catch {
     return null;
   }
 }

--- a/website/src/lib/sessions/templates.test.ts
+++ b/website/src/lib/sessions/templates.test.ts
@@ -28,7 +28,7 @@ describe('listTemplates — DB fallback', () => {
   beforeEach(() => vi.clearAllMocks());
 
   it('falls back to DEFAULT_TEMPLATES when DB query throws', async () => {
-    (pool.query as any).mockRejectedValue(new Error('connection refused'));
+    vi.mocked(pool.query).mockRejectedValue(new Error('connection refused'));
     const result = await listTemplates('user-123');
     expect(result).toHaveLength(5);
     expect(result[0].is_default).toBe(true);
@@ -41,7 +41,7 @@ describe('listTemplates — DB fallback', () => {
       { id: 'b', slug: 'my-custom', title: 'My Custom', body_markdown: '# y',
         is_default: false, owner_id: 'user-123', created_from_template_id: 'a' },
     ];
-    (pool.query as any).mockResolvedValue({ rows: dbRows });
+    vi.mocked(pool.query).mockResolvedValue({ rows: dbRows } as unknown as Awaited<ReturnType<typeof pool.query>>);
     const result = await listTemplates('user-123');
     expect(result).toHaveLength(2);
     expect(result[1].slug).toBe('my-custom');
@@ -52,7 +52,7 @@ describe('cloneTemplate', () => {
   beforeEach(() => vi.clearAllMocks());
 
   it('throws when templateId not found', async () => {
-    (pool.query as any).mockResolvedValue({ rows: [] });
+    vi.mocked(pool.query).mockResolvedValue({ rows: [] } as unknown as Awaited<ReturnType<typeof pool.query>>);
     await expect(cloneTemplate('nonexistent', 'user-123', {}))
       .rejects.toThrow('template not found');
   });
@@ -62,17 +62,17 @@ describe('deleteTemplate', () => {
   beforeEach(() => vi.clearAllMocks());
 
   it('throws when trying to delete a default template', async () => {
-    (pool.query as any).mockResolvedValue({
+    vi.mocked(pool.query).mockResolvedValue({
       rows: [{ id: 'a', is_default: true, owner_id: null }],
-    });
+    } as unknown as Awaited<ReturnType<typeof pool.query>>);
     await expect(deleteTemplate('a', 'user-123'))
       .rejects.toThrow('cannot delete default template');
   });
 
   it('throws when template belongs to another user', async () => {
-    (pool.query as any).mockResolvedValue({
+    vi.mocked(pool.query).mockResolvedValue({
       rows: [{ id: 'b', is_default: false, owner_id: 'other-user' }],
-    });
+    } as unknown as Awaited<ReturnType<typeof pool.query>>);
     await expect(deleteTemplate('b', 'user-123'))
       .rejects.toThrow('not owner');
   });

--- a/website/src/lib/tickets/__tests__/cockpit-api.test.ts
+++ b/website/src/lib/tickets/__tests__/cockpit-api.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { APIRoute, APIContext } from 'astro';
 
 // Mock openai for suggest endpoint tests — must be before any imports
 const openaiMocks = vi.hoisted(() => ({
@@ -64,13 +65,13 @@ beforeEach(() => { vi.clearAllMocks(); process.env.BRAND_ID = 'mentolder'; });
 describe('GET /cockpit/portfolio', () => {
   it('403 when not admin', async () => {
     mocks.getSession.mockResolvedValue({ user: {} }); mocks.isAdmin.mockReturnValue(false);
-    const res = await GET({ request: req() } as any);
+    const res = await GET({ request: req() } as unknown as APIContext);
     expect(res.status).toBe(403);
   });
   it('returns PortfolioPayload for admin', async () => {
     mocks.getSession.mockResolvedValue({ user: {} }); mocks.isAdmin.mockReturnValue(true);
     mocks.getPortfolio.mockResolvedValue({ products: [{ extId: 'p1', features: [] }] });
-    const res = await GET({ request: req() } as any);
+    const res = await GET({ request: req() } as unknown as APIContext);
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.products[0].extId).toBe('p1');
@@ -87,7 +88,7 @@ describe('GET /cockpit/feature', () => {
   const ctx = (id?: string) => ({
     request: new Request(url(id), { headers: { cookie: 'sid=1' } }),
     url: url(id),
-  } as any);
+  } as unknown as APIContext);
 
   beforeEach(() => { mocks.getSession.mockResolvedValue({ user: {} }); mocks.isAdmin.mockReturnValue(true); });
 
@@ -112,9 +113,9 @@ describe('GET /cockpit/feature', () => {
 // ---------------------------------------------------------------------------
 // Task 9: POST /cockpit/reorder
 // ---------------------------------------------------------------------------
-const post = (route: (args: any) => Response | Promise<Response>, body: unknown): Promise<Response> => Promise.resolve(route({
+const post = (route: APIRoute, body: unknown): Promise<Response> => Promise.resolve(route({
   request: new Request('http://x', { method: 'POST', headers: { cookie: 'sid=1' }, body: JSON.stringify(body) }),
-} as any) as Response);
+} as unknown as APIContext) as Response);
 
 describe('POST /cockpit/reorder', () => {
   beforeEach(() => { mocks.getSession.mockResolvedValue({ user: {} }); mocks.isAdmin.mockReturnValue(true); });

--- a/website/src/lib/tickets/cockpit-table-actions.ts
+++ b/website/src/lib/tickets/cockpit-table-actions.ts
@@ -88,23 +88,23 @@ export async function createTicket(p: CreatePayload): Promise<CreateResult> {
 }
 
 export async function bulkStatusChange(
-  ticketIds: string[], status: string): Promise<{ ok: boolean; body?: any }> {
+  ticketIds: string[], status: string): Promise<{ ok: boolean; body?: Record<string, unknown> }> {
   const res = await fetch('/api/admin/tickets/bulk-status', {
     method: 'POST', headers: JSON_HEADERS, credentials: 'same-origin',
     body: JSON.stringify({ ticketIds, status }),
   });
-  let body: any;
+  let body: Record<string, unknown> | undefined;
   try { body = await res.json(); } catch { body = undefined; }
   return { ok: res.ok, body };
 }
 
 export async function undoBulkStatus(
-  undoToken: string): Promise<{ ok: boolean; body?: any }> {
+  undoToken: string): Promise<{ ok: boolean; body?: Record<string, unknown> }> {
   const res = await fetch('/api/admin/tickets/bulk-status/undo', {
     method: 'POST', headers: JSON_HEADERS, credentials: 'same-origin',
     body: JSON.stringify({ undoToken }),
   });
-  let body: any;
+  let body: Record<string, unknown> | undefined;
   try { body = await res.json(); } catch { body = undefined; }
   return { ok: res.ok, body };
 }

--- a/website/src/lib/website-db.ts
+++ b/website/src/lib/website-db.ts
@@ -16,6 +16,7 @@ import { isConflict as detectConflict, nextVersion as bumpVersion } from './admi
 // that imports these names from website-db.
 import { pool, platformPool, ensureSchemaOnce, __resetSchemaInitCacheForTests } from './db-pool';
 export { pool, platformPool, ensureSchemaOnce, __resetSchemaInitCacheForTests } from './db-pool';
+import type { Pool, PoolClient } from 'pg';
 
 // Eager boot-time init so tracker schema migrations apply on rollout rather
 // than on the first lazy code path that happens to call initTicketsSchema (T000410).
@@ -4253,27 +4254,27 @@ async function initServicePageConfigTable(): Promise<void> {
 
 // ─── Content-Store accessors (T000306) ────────────────────────────────────────
 
-export interface ContentRead { value: any | null; version: number }
+export interface ContentRead { value: unknown; version: number }
 
 export class ContentConflictError extends Error {
   code = 'CONFLICT' as const;
   constructor(
     public currentVersion: number,
-    public currentValue: any,
+    public currentValue: unknown,
     public editor: string | null,
   ) {
     super('content version conflict');
   }
 }
 
-function safeJson(v: any): any {
+function safeJson(v: unknown): unknown {
   if (v == null) return null;
   if (typeof v !== 'string') return v;
   try { return JSON.parse(v); } catch { return v; }
 }
 
 async function liveRead(
-  client: any,
+  client: Pool | PoolClient,
   brand: string,
   ref: { contentType: string; storeKey: string },
 ): Promise<ContentRead> {
@@ -4321,10 +4322,10 @@ async function liveRead(
 }
 
 async function liveWrite(
-  client: any,
+  client: Pool | PoolClient,
   brand: string,
   ref: { contentType: string; storeKey: string },
-  value: any,
+  value: unknown,
   version: number,
 ): Promise<void> {
   switch (ref.contentType) {
@@ -4369,7 +4370,7 @@ export async function readContent(brand: string, contentKey: string): Promise<Co
 export async function writeContent(
   brand: string,
   contentKey: string,
-  value: any,
+  value: unknown,
   baseVersion: number,
   editor: string,
 ): Promise<{ version: number }> {
@@ -4400,7 +4401,7 @@ export async function writeContent(
       `SELECT id FROM content_versions WHERE brand=$1 AND content_key=$2 ORDER BY created_at DESC`,
       [brand, contentKey],
     );
-    const prune = idsToPrune(ids.rows.map((r: any) => Number(r.id)));
+    const prune = idsToPrune(ids.rows.map((r: Record<string, unknown>) => Number(r.id)));
     if (prune.length) {
       await client.query(`DELETE FROM content_versions WHERE id = ANY($1)`, [prune]);
     }
@@ -4426,7 +4427,7 @@ export async function listVersions(brand: string, contentKey: string) {
      ORDER BY created_at DESC`,
     [brand, contentKey],
   );
-  return r.rows.map((row: any) => ({
+  return r.rows.map((row: Record<string, unknown>) => ({
     id: Number(row.id),
     editor: row.editor,
     createdAt: row.created_at,

--- a/website/src/pages/admin/coaching/sessions/[id].astro
+++ b/website/src/pages/admin/coaching/sessions/[id].astro
@@ -161,9 +161,9 @@ const displayKi = kiProviders.find(p => p.id === coachingSession.kiConfigId)?.di
               </span>
               <div class="flex-1 min-w-0">
                 <span class="text-light">
-                  {e.eventType === 'status_change' && `Status: ${(e.payload as any).from ?? ''} → ${(e.payload as any).to ?? (e.payload as any).action ?? ''}`}
-                  {e.eventType === 'field_change'  && `Feld ${(e.payload as any).field}: "${(e.payload as any).from}" → "${(e.payload as any).to}"`}
-                  {e.eventType === 'ai_request'    && `KI-Anfrage Schritt ${e.stepNumber} (${(e.payload as any).provider}, ${(e.payload as any).duration_ms}ms)`}
+                  {e.eventType === 'status_change' && `Status: ${(e.payload as Record<string, string>).from ?? ''} → ${(e.payload as Record<string, string>).to ?? (e.payload as Record<string, string>).action ?? ''}`}
+                  {e.eventType === 'field_change'  && `Feld ${(e.payload as Record<string, string>).field}: "${(e.payload as Record<string, string>).from}" → "${(e.payload as Record<string, string>).to}"`}
+                  {e.eventType === 'ai_request'    && `KI-Anfrage Schritt ${e.stepNumber} (${(e.payload as Record<string, string>).provider}, ${(e.payload as Record<string, string>).duration_ms}ms)`}
                   {e.eventType === 'notes_change'  && `Notiz Schritt ${e.stepNumber} geändert`}
                 </span>
                 <span class="ml-2 text-xs">{new Date(e.changedAt).toLocaleString('de-DE')} · {e.actor}</span>

--- a/website/src/pages/admin/inhalte.astro
+++ b/website/src/pages/admin/inhalte.astro
@@ -7,6 +7,9 @@ import { getEffectiveHomepage, getEffectiveUebermich, getEffectiveServices, getE
 import { getLegalPage, listCustomSections, getSiteSetting, readContent } from '../../lib/website-db';
 import { getDefaultDatenschutz, getDefaultAgb, getDefaultBarrierefreiheit, getDefaultImpressumZusatz } from '../../lib/legal-defaults';
 import { config } from '../../config/index';
+import type { HomepageService, ServicePageContent, LeistungCategory, LeistungService } from '../../config/types';
+
+type EditorService = HomepageService & { hidden?: boolean; meta?: string; leistungCategoryId?: string };
 
 const session = await getSession(Astro.request.headers.get('cookie'));
 if (!session) return Astro.redirect(getLoginUrl(Astro.url.pathname));
@@ -14,11 +17,11 @@ if (!isAdmin(session)) return Astro.redirect('/admin');
 
 const BRAND = import.meta.env.BRAND || process.env.BRAND || 'mentolder';
 
-function serviceToEditorData(svc: any) {
-  const pc = svc?.pageContent ?? {};
-  const introNoteSection = (pc.sections ?? []).find((s: any) => s.title === '__introNote__');
+function serviceToEditorData(svc: EditorService | undefined) {
+  const pc: Partial<ServicePageContent> = svc?.pageContent ?? {};
+  const introNoteSection = (pc.sections ?? []).find((s) => s.title === '__introNote__');
   const introNote = introNoteSection?.items?.join('\n\n') ?? '';
-  const visibleSections = (pc.sections ?? []).filter((s: any) => s.title !== '__introNote__');
+  const visibleSections = (pc.sections ?? []).filter((s) => s.title !== '__introNote__');
   return {
     cardTitle: svc?.title ?? '',
     cardDescription: svc?.description ?? '',
@@ -34,11 +37,11 @@ function serviceToEditorData(svc: any) {
     faq: pc.faq ?? [],
     ctaText: pc.pricing?.[0]?.label ?? 'Kostenloses Erstgespräch buchen',
     ctaHref: '/termin',
-    seoTitle: (pc as any).seoTitle ?? '',
-    seoDescription: (pc as any).seoDescription ?? svc?.description ?? '',
+    seoTitle: pc.seoTitle ?? '',
+    seoDescription: pc.seoDescription ?? svc?.description ?? '',
     isCatalogLinked: !!svc?.leistungCategoryId,
     catalogTiers: (svc?.leistungCategoryId
-      ? leistungen.find((c: any) => c.id === svc.leistungCategoryId)?.services?.map((r: any) => ({
+      ? leistungen.find((c: LeistungCategory) => c.id === svc?.leistungCategoryId)?.services?.map((r: LeistungService) => ({
           label: r.name ?? '', price: r.price ?? '', unit: r.unit ?? '', highlight: r.highlight ?? false,
         })) ?? []
       : []),

--- a/website/src/pages/api/admin/ai-quality.test.ts
+++ b/website/src/pages/api/admin/ai-quality.test.ts
@@ -26,15 +26,15 @@ describe('GET /api/admin/ai-quality', () => {
   test('401 ohne Admin-Session', async () => {
     vi.mocked(getSession).mockResolvedValue(null);
     vi.mocked(isAdmin).mockReturnValue(false);
-    const res = await route.GET({ request: req() } as any);
+    const res = await route.GET({ request: req() } as unknown as Parameters<typeof route.GET>[0]);
     expect(res.status).toBe(401);
   });
 
   test('200 mit vollständigem Response-Shape', async () => {
-    vi.mocked(getSession).mockResolvedValue({ sub: 'admin' } as any);
+    vi.mocked(getSession).mockResolvedValue({ sub: 'admin' } as unknown as Awaited<ReturnType<typeof getSession>>);
     vi.mocked(isAdmin).mockReturnValue(true);
     queryMock.mockResolvedValue({ rows: [] });
-    const res = await route.GET({ request: req() } as any);
+    const res = await route.GET({ request: req() } as unknown as Parameters<typeof route.GET>[0]);
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body).toHaveProperty('health');
@@ -47,7 +47,7 @@ describe('GET /api/admin/ai-quality', () => {
   });
 
   test('Health-Klassifikation: green bei niedriger Latenz/Fehlerrate', async () => {
-    vi.mocked(getSession).mockResolvedValue({ sub: 'admin' } as any);
+    vi.mocked(getSession).mockResolvedValue({ sub: 'admin' } as unknown as Awaited<ReturnType<typeof getSession>>);
     vi.mocked(isAdmin).mockReturnValue(true);
     expect(route.computeHealth({ avg_latency_ms: 300, error_rate: 0.01, calls: 10 })).toBe('green');
     expect(route.computeHealth({ avg_latency_ms: 1500, error_rate: 0.1, calls: 10 })).toBe('yellow');

--- a/website/src/pages/api/admin/angebote/save.test.ts
+++ b/website/src/pages/api/admin/angebote/save.test.ts
@@ -51,7 +51,7 @@ describe('POST /api/admin/angebote/save — catalog link persistence', () => {
       headlineKey: 'fuehrung-einzel',
       headlinePrefix: true,
     };
-    const r = await POST({ request: jsonReq({ services: [card], leistungen: [], priceListUrl: '' }) } as any);
+    const r = await POST({ request: jsonReq({ services: [card], leistungen: [], priceListUrl: '' }) } as unknown as Parameters<typeof POST>[0]);
     expect(r.status).toBe(200);
 
     const saved = vi.mocked(saveServiceConfig).mock.calls[0][1];
@@ -76,7 +76,7 @@ describe('POST /api/admin/angebote/save — catalog link persistence', () => {
         pricing: [{ label: 'Einzelstunde', price: '150 €' }],
       },
     };
-    const r = await POST({ request: jsonReq({ services: [card], leistungen: [], priceListUrl: '' }) } as any);
+    const r = await POST({ request: jsonReq({ services: [card], leistungen: [], priceListUrl: '' }) } as unknown as Parameters<typeof POST>[0]);
     expect(r.status).toBe(200);
 
     const saved = vi.mocked(saveServiceConfig).mock.calls[0][1];
@@ -95,7 +95,7 @@ describe('POST /api/admin/angebote/save — catalog link persistence', () => {
       features: [],
       price: 'auf Anfrage',
     };
-    const r = await POST({ request: jsonReq({ services: [card], leistungen: [], priceListUrl: '' }) } as any);
+    const r = await POST({ request: jsonReq({ services: [card], leistungen: [], priceListUrl: '' }) } as unknown as Parameters<typeof POST>[0]);
     expect(r.status).toBe(200);
 
     const saved = vi.mocked(saveServiceConfig).mock.calls[0][1];

--- a/website/src/pages/api/admin/backup-status.ts
+++ b/website/src/pages/api/admin/backup-status.ts
@@ -87,7 +87,12 @@ export function derivePipelineStatus(
   return { id: '', light: 'gray', lastRun, lastSuccessfulUpload, succeeded: 0, failed: 0, active: 0, schedule };
 }
 
-function mapJob(j: any): PipelineJob {
+interface K8sJobRaw {
+  metadata: { name: string; labels?: Record<string, string> };
+  status?: { startTime?: string; completionTime?: string; succeeded?: number; failed?: number; active?: number };
+}
+
+function mapJob(j: K8sJobRaw): PipelineJob {
   return {
     name: j.metadata.name,
     startTime: j.status?.startTime ?? null,
@@ -128,8 +133,8 @@ export const GET: APIRoute = async ({ request }) => {
   const results = await Promise.allSettled(
     pipelineDefs.map(async (def) => {
       const [jobsData, cronData] = await Promise.all([
-        k8s.get(`/apis/batch/v1/namespaces/${ns}/jobs?labelSelector=app%3D${def.label}`),
-        k8s.get(`/apis/batch/v1/namespaces/${ns}/cronjobs/${def.label}`).catch(() => null),
+        k8s.get<{ items?: K8sJobRaw[] }>(`/apis/batch/v1/namespaces/${ns}/jobs?labelSelector=app%3D${def.label}`),
+        k8s.get<{ spec?: { schedule?: string } }>(`/apis/batch/v1/namespaces/${ns}/cronjobs/${def.label}`).catch(() => null),
       ]);
       const jobs = (jobsData.items ?? []).map(mapJob);
       const status = derivePipelineStatus(jobs, cronData, now, def.maxAgeH);

--- a/website/src/pages/api/admin/billing/[id]/item.ts
+++ b/website/src/pages/api/admin/billing/[id]/item.ts
@@ -13,7 +13,7 @@ export const POST: APIRoute = async ({ request, params }) => {
 
   const body = await request.json();
    
-  const inv  = await (stripe as any).invoices.retrieve(params.id!);
+  const inv  = await stripe.invoices.retrieve(params.id!);
   const customerId = typeof inv.customer === 'string'
     ? inv.customer
     : (inv.customer as { id: string } | null)?.id ?? '';
@@ -35,7 +35,7 @@ export const PATCH: APIRoute = async ({ request, params }) => {
   if (!invoiceItemId) return new Response(null, { status: 400 });
 
    
-  const item = await (stripe as any).invoiceItems.retrieve(invoiceItemId);
+  const item = await stripe.invoiceItems.retrieve(invoiceItemId);
   if (item.invoice !== params.id) return new Response(null, { status: 403 });
 
   await updateDraftInvoiceItem(invoiceItemId, {
@@ -55,7 +55,7 @@ export const DELETE: APIRoute = async ({ request, params }) => {
   if (!invoiceItemId) return new Response(null, { status: 400 });
 
    
-  const item = await (stripe as any).invoiceItems.retrieve(invoiceItemId);
+  const item = await stripe.invoiceItems.retrieve(invoiceItemId);
   if (item.invoice !== params.id) return new Response(null, { status: 403 });
 
   await deleteDraftInvoiceItem(invoiceItemId);

--- a/website/src/pages/api/admin/billing/[id]/payments.test.ts
+++ b/website/src/pages/api/admin/billing/[id]/payments.test.ts
@@ -25,12 +25,12 @@ describe('GET /api/admin/billing/[id]/payments', () => {
 
   it('returns 403 when not authenticated', async () => {
     vi.mocked(getSession).mockResolvedValue(null);
-    const res = await GET({ request: new Request('http://localhost'), params: { id: 'inv1' } } as any);
+    const res = await GET({ request: new Request('http://localhost'), params: { id: 'inv1' } } as unknown as Parameters<typeof GET>[0]);
     expect(res.status).toBe(403);
   });
 
   it('returns payments list', async () => {
-    const res = await GET({ request: new Request('http://localhost'), params: { id: 'inv1' } } as any);
+    const res = await GET({ request: new Request('http://localhost'), params: { id: 'inv1' } } as unknown as Parameters<typeof GET>[0]);
     expect(res.status).toBe(200);
     const data = await res.json();
     expect(data.payments).toEqual([{ id: 'p1', amount: 100 }]);
@@ -47,7 +47,7 @@ describe('POST /api/admin/billing/[id]/payments', () => {
 
   it('returns 403 when not authenticated', async () => {
     vi.mocked(getSession).mockResolvedValue(null);
-    const res = await POST({ request: new Request('http://localhost'), params: { id: 'inv1' } } as any);
+    const res = await POST({ request: new Request('http://localhost'), params: { id: 'inv1' } } as unknown as Parameters<typeof POST>[0]);
     expect(res.status).toBe(403);
   });
 
@@ -56,7 +56,7 @@ describe('POST /api/admin/billing/[id]/payments', () => {
       method: 'POST',
       body: JSON.stringify({ paidAt: '2026-01-01' }), // missing amount and method
     });
-    const res = await POST({ request: req, params: { id: 'inv1' } } as any);
+    const res = await POST({ request: req, params: { id: 'inv1' } } as unknown as Parameters<typeof POST>[0]);
     expect(res.status).toBe(400);
   });
 
@@ -65,7 +65,7 @@ describe('POST /api/admin/billing/[id]/payments', () => {
       method: 'POST',
       body: JSON.stringify({ paidAt: '2026-01-01', amount: 100, method: 'invalid' }),
     });
-    const res = await POST({ request: req, params: { id: 'inv1' } } as any);
+    const res = await POST({ request: req, params: { id: 'inv1' } } as unknown as Parameters<typeof POST>[0]);
     expect(res.status).toBe(400);
   });
 
@@ -74,7 +74,7 @@ describe('POST /api/admin/billing/[id]/payments', () => {
       method: 'POST',
       body: JSON.stringify({ paidAt: '2026-01-01', amount: -10, method: 'sepa' }),
     });
-    const res = await POST({ request: req, params: { id: 'inv1' } } as any);
+    const res = await POST({ request: req, params: { id: 'inv1' } } as unknown as Parameters<typeof POST>[0]);
     expect(res.status).toBe(400);
   });
 
@@ -83,7 +83,7 @@ describe('POST /api/admin/billing/[id]/payments', () => {
       method: 'POST',
       body: JSON.stringify({ paidAt: '2026-01-01', amount: 100, method: 'bank', reference: 'ref1' }),
     });
-    const res = await POST({ request: req, params: { id: 'inv1' } } as any);
+    const res = await POST({ request: req, params: { id: 'inv1' } } as unknown as Parameters<typeof POST>[0]);
     expect(res.status).toBe(201);
     expect(vi.mocked(recordPayment)).toHaveBeenCalledWith({
       invoiceId: 'inv1',
@@ -104,7 +104,7 @@ describe('POST /api/admin/billing/[id]/payments', () => {
       method: 'POST',
       body: JSON.stringify({ paidAt: '2026-01-01', amount: 100, method: 'bank' }),
     });
-    const res = await POST({ request: req, params: { id: 'inv1' } } as any);
+    const res = await POST({ request: req, params: { id: 'inv1' } } as unknown as Parameters<typeof POST>[0]);
     expect(res.status).toBe(400);
     expect(await res.text()).toBe('cannot exceed gross amount');
   });

--- a/website/src/pages/api/admin/billing/[id]/validate.test.ts
+++ b/website/src/pages/api/admin/billing/[id]/validate.test.ts
@@ -34,13 +34,13 @@ describe('POST /api/admin/billing/[id]/validate', () => {
 
   it('returns 401 when not authenticated', async () => {
     vi.mocked(getSession).mockResolvedValue(null);
-    const res = await POST({ request: new Request('http://localhost'), params: { id: 'inv1' } } as any);
+    const res = await POST({ request: new Request('http://localhost'), params: { id: 'inv1' } } as unknown as Parameters<typeof POST>[0]);
     expect(res.status).toBe(401);
   });
 
   it('returns 404 when invoice has no PDF/A-3 blob', async () => {
     mockQuery.mockResolvedValueOnce({ rowCount: 1, rows: [{ pdf_a3_blob: null }] });
-    const res = await POST({ request: new Request('http://localhost'), params: { id: 'inv1' } } as any);
+    const res = await POST({ request: new Request('http://localhost'), params: { id: 'inv1' } } as unknown as Parameters<typeof POST>[0]);
     expect(res.status).toBe(404);
   });
 
@@ -49,7 +49,7 @@ describe('POST /api/admin/billing/[id]/validate', () => {
     mockValidate.mockResolvedValueOnce({ valid: true, report: 'OK' });
     mockQuery.mockResolvedValueOnce({ rowCount: 1 }); // UPDATE
 
-    const res = await POST({ request: new Request('http://localhost'), params: { id: 'inv1' } } as any);
+    const res = await POST({ request: new Request('http://localhost'), params: { id: 'inv1' } } as unknown as Parameters<typeof POST>[0]);
     expect(res.status).toBe(200);
     expect(mockValidate).toHaveBeenCalledWith({ pdf: Buffer.from('pdf') });
     expect(mockQuery).toHaveBeenCalledTimes(2);

--- a/website/src/pages/api/admin/billing/datev-export.test.ts
+++ b/website/src/pages/api/admin/billing/datev-export.test.ts
@@ -30,23 +30,23 @@ describe('GET /api/admin/billing/datev-export', () => {
 
   it('returns 401 when not authenticated', async () => {
     vi.mocked(getSession).mockResolvedValue(null);
-    const res = await GET({ request: makeRequest({ year: '2026' }), url: new URL('http://localhost?year=2026') } as any);
+    const res = await GET({ request: makeRequest({ year: '2026' }), url: new URL('http://localhost?year=2026') } as unknown as Parameters<typeof GET>[0]);
     expect(res.status).toBe(401);
   });
 
   it('returns 400 when year is missing', async () => {
-    const res = await GET({ request: makeRequest(), url: new URL('http://localhost') } as any);
+    const res = await GET({ request: makeRequest(), url: new URL('http://localhost') } as unknown as Parameters<typeof GET>[0]);
     expect(res.status).toBe(400);
   });
 
   it('returns CSV with correct Content-Type', async () => {
-    const res = await GET({ request: makeRequest({ year: '2026', month: '1' }), url: new URL('http://localhost?year=2026&month=1') } as any);
+    const res = await GET({ request: makeRequest({ year: '2026', month: '1' }), url: new URL('http://localhost?year=2026&month=1') } as unknown as Parameters<typeof GET>[0]);
     expect(res.status).toBe(200);
     expect(res.headers.get('Content-Type')).toContain('text/csv');
   });
 
   it('sets Content-Disposition attachment with filename', async () => {
-    const res = await GET({ request: makeRequest({ year: '2026', month: '1' }), url: new URL('http://localhost?year=2026&month=1') } as any);
+    const res = await GET({ request: makeRequest({ year: '2026', month: '1' }), url: new URL('http://localhost?year=2026&month=1') } as unknown as Parameters<typeof GET>[0]);
     expect(res.headers.get('Content-Disposition')).toMatch(/attachment.*filename/);
     expect(res.headers.get('Content-Disposition')).toContain('datev-');
   });
@@ -73,7 +73,7 @@ describe('POST /api/admin/billing/datev-email', () => {
       headers: { 'Content-Type': 'application/json', cookie: 'session=test' },
       body: JSON.stringify({ year: 2026, month: 1, to: 'stb@example.de' }),
     });
-    const res = await POST({ request: req } as any);
+    const res = await POST({ request: req } as unknown as Parameters<typeof POST>[0]);
     expect(res.status).toBe(401);
   });
 
@@ -83,7 +83,7 @@ describe('POST /api/admin/billing/datev-email', () => {
       headers: { 'Content-Type': 'application/json', cookie: 'session=test' },
       body: JSON.stringify({ month: 1, to: 'stb@example.de' }),
     });
-    const res = await POST({ request: req } as any);
+    const res = await POST({ request: req } as unknown as Parameters<typeof POST>[0]);
     expect(res.status).toBe(400);
   });
 
@@ -93,7 +93,7 @@ describe('POST /api/admin/billing/datev-email', () => {
       headers: { 'Content-Type': 'application/json', cookie: 'session=test' },
       body: JSON.stringify({ year: 2026, month: 1 }),
     });
-    const res = await POST({ request: req } as any);
+    const res = await POST({ request: req } as unknown as Parameters<typeof POST>[0]);
     expect(res.status).toBe(400);
   });
 
@@ -103,7 +103,7 @@ describe('POST /api/admin/billing/datev-email', () => {
       headers: { 'Content-Type': 'application/json', cookie: 'session=test' },
       body: JSON.stringify({ year: 2026, month: 1, to: 'stb@example.de' }),
     });
-    const res = await POST({ request: req } as any);
+    const res = await POST({ request: req } as unknown as Parameters<typeof POST>[0]);
     expect(res.status).toBe(200);
     expect(vi.mocked(sendEmail)).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/website/src/pages/api/admin/billing/sepa-export.test.ts
+++ b/website/src/pages/api/admin/billing/sepa-export.test.ts
@@ -41,24 +41,24 @@ describe('GET /api/admin/billing/sepa-export', () => {
 
   it('returns 401 when not authenticated', async () => {
     vi.mocked(getSession).mockResolvedValue(null);
-    const res = await GET({ request: new Request('http://localhost'), url: new URL('http://localhost') } as any);
+    const res = await GET({ request: new Request('http://localhost'), url: new URL('http://localhost') } as unknown as Parameters<typeof GET>[0]);
     expect(res.status).toBe(401);
   });
 
   it('returns 503 when SEPA env vars are missing', async () => {
     delete process.env.SEPA_CREDITOR_IBAN;
-    const res = await GET({ request: new Request('http://localhost'), url: new URL('http://localhost') } as any);
+    const res = await GET({ request: new Request('http://localhost'), url: new URL('http://localhost') } as unknown as Parameters<typeof GET>[0]);
     expect(res.status).toBe(503);
   });
 
   it('returns 400 when date is invalid', async () => {
-    const res = await GET({ request: new Request('http://localhost'), url: new URL('http://localhost?date=invalid') } as any);
+    const res = await GET({ request: new Request('http://localhost'), url: new URL('http://localhost?date=invalid') } as unknown as Parameters<typeof GET>[0]);
     expect(res.status).toBe(400);
   });
 
   it('returns 404 when no open invoices found', async () => {
     mockQuery.mockResolvedValueOnce({ rows: [] });
-    const res = await GET({ request: new Request('http://localhost'), url: new URL('http://localhost?date=2026-05-01') } as any);
+    const res = await GET({ request: new Request('http://localhost'), url: new URL('http://localhost?date=2026-05-01') } as unknown as Parameters<typeof GET>[0]);
     expect(res.status).toBe(404);
   });
 
@@ -78,7 +78,7 @@ describe('GET /api/admin/billing/sepa-export', () => {
       ]
     });
     
-    const res = await GET({ request: new Request('http://localhost'), url: new URL('http://localhost?date=2026-05-01') } as any);
+    const res = await GET({ request: new Request('http://localhost'), url: new URL('http://localhost?date=2026-05-01') } as unknown as Parameters<typeof GET>[0]);
     expect(res.status).toBe(200);
     expect(res.headers.get('Content-Type')).toContain('application/xml');
     expect(res.headers.get('Content-Disposition')).toContain('attachment; filename="sepa-lastschrift-2026-05-01.xml"');

--- a/website/src/pages/api/admin/cluster/pods-list.ts
+++ b/website/src/pages/api/admin/cluster/pods-list.ts
@@ -9,6 +9,21 @@ const CONTEXT_TO_NS: Record<string, string> = {
 
 const SAFE_NS = /^[a-z0-9][a-z0-9-]{0,62}$/;
 
+interface K8sContainerStatus { ready: boolean; restartCount?: number }
+interface K8sPod {
+  metadata: { name: string; labels?: Record<string, string> };
+  status?: { phase?: string; containerStatuses?: K8sContainerStatus[] };
+  spec?: { containers?: { name: string }[] };
+}
+interface CompactPod {
+  name: string;
+  phase: string;
+  ready: boolean;
+  restarts: number;
+  containers: string[];
+  labels: Record<string, string>;
+}
+
 // Compact pod list with phase/restarts — used by the Logs tab to populate
 // the pod dropdown without fetching the full /api/admin/monitoring payload.
 export const GET: APIRoute = async ({ request }) => {
@@ -35,21 +50,22 @@ export const GET: APIRoute = async ({ request }) => {
   }
 
   try {
-    const data = await k8s.get(`/api/v1/namespaces/${encodeURIComponent(ns)}/pods`);
-    const pods = (data.items ?? []).map((p: any) => ({
+    const data = await k8s.get<{ items?: K8sPod[] }>(`/api/v1/namespaces/${encodeURIComponent(ns)}/pods`);
+    const pods: CompactPod[] = (data.items ?? []).map((p: K8sPod) => ({
       name: p.metadata.name,
       phase: p.status?.phase ?? 'Unknown',
-      ready: p.status?.containerStatuses?.every((c: any) => c.ready) ?? false,
-      restarts: (p.status?.containerStatuses ?? []).reduce((a: number, c: any) => a + (c.restartCount ?? 0), 0),
-      containers: (p.spec?.containers ?? []).map((c: any) => c.name),
+      ready: p.status?.containerStatuses?.every((c: K8sContainerStatus) => c.ready) ?? false,
+      restarts: (p.status?.containerStatuses ?? []).reduce((a: number, c: K8sContainerStatus) => a + (c.restartCount ?? 0), 0),
+      containers: (p.spec?.containers ?? []).map((c) => c.name),
       labels: p.metadata.labels ?? {},
     }));
-    pods.sort((a: any, b: any) => a.name.localeCompare(b.name));
+    pods.sort((a: CompactPod, b: CompactPod) => a.name.localeCompare(b.name));
     return new Response(JSON.stringify({ pods, namespace: ns }), {
       status: 200, headers: { 'Content-Type': 'application/json' },
     });
-  } catch (error: any) {
-    return new Response(JSON.stringify({ error: error.message ?? 'Kubernetes API error' }), {
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : 'Kubernetes API error';
+    return new Response(JSON.stringify({ error: message }), {
       status: 500, headers: { 'Content-Type': 'application/json' },
     });
   }

--- a/website/src/pages/api/admin/cluster/warnings.ts
+++ b/website/src/pages/api/admin/cluster/warnings.ts
@@ -4,6 +4,17 @@ import { getSession, isAdmin } from '../../../../lib/auth';
 
 const NAMESPACES = ['workspace', 'workspace-korczewski', 'website', 'website-korczewski'];
 
+interface K8sEvent {
+  type?: string;
+  reason?: string;
+  message?: string;
+  lastTimestamp?: string;
+  eventTime?: string;
+  count?: number;
+  involvedObject?: { kind?: string; name?: string };
+}
+interface K8sEventList { items?: K8sEvent[] }
+
 export const GET: APIRoute = async ({ request }) => {
   const session = await getSession(request.headers.get('cookie'));
   if (!session || !isAdmin(session)) {
@@ -23,10 +34,10 @@ export const GET: APIRoute = async ({ request }) => {
   try {
     const results = await Promise.allSettled(
       NAMESPACES.map((ns) =>
-        k8s.get(
+        k8s.get<K8sEventList>(
           `/api/v1/namespaces/${ns}/events?fieldSelector=type%3DWarning&limit=100`
-        ).then((data: any) =>
-          (data.items ?? []).map((e: any) => ({
+        ).then((data: K8sEventList) =>
+          (data.items ?? []).map((e: K8sEvent) => ({
             namespace: ns,
             type: e.type as string,
             reason: e.reason as string,
@@ -48,8 +59,9 @@ export const GET: APIRoute = async ({ request }) => {
       status: 200,
       headers: { 'Content-Type': 'application/json' },
     });
-  } catch (error: any) {
-    return new Response(JSON.stringify({ error: error.message ?? 'Unbekannter Fehler' }), {
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : 'Unbekannter Fehler';
+    return new Response(JSON.stringify({ error: message }), {
       status: 500,
       headers: { 'Content-Type': 'application/json' },
     });

--- a/website/src/pages/api/admin/coaching/drafts/[id]/accept.ts
+++ b/website/src/pages/api/admin/coaching/drafts/[id]/accept.ts
@@ -9,16 +9,16 @@ export const POST: APIRoute = async ({ request, params, url }) => {
   const session = await getSession(request.headers.get('cookie'));
   if (!session || !isAdmin(session)) return new Response('Unauthorized', { status: 401 });
   const id = params.id as string;
-  const body = await request.json().catch(() => ({} as Record<string, unknown>));
-  const reviewedBy = (session as any).email ?? (session as any).user ?? 'admin';
+  const body: Record<string, unknown> = await request.json().catch(() => ({}));
+  const reviewedBy = session.email ?? 'admin';
   const then = url.searchParams.get('then');
 
   try {
     const result = await acceptDraft(pool, id, {
       reviewedBy,
-      payloadOverrides: (body as any).payload_overrides as Record<string, unknown> | undefined,
-      snippetTitleOverride: (body as any).snippet_title as string | undefined,
-      tags: (body as any).tags as string[] | undefined,
+      payloadOverrides: body.payload_overrides as Record<string, unknown> | undefined,
+      snippetTitleOverride: body.snippet_title as string | undefined,
+      tags: body.tags as string[] | undefined,
     });
     const out: Record<string, unknown> = {
       draft: result.draft,

--- a/website/src/pages/api/admin/content-sections-save.test.ts
+++ b/website/src/pages/api/admin/content-sections-save.test.ts
@@ -19,6 +19,8 @@ import { POST as footerPOST } from './footer/save';
 import { POST as stammdatenPOST } from './stammdaten/save';
 import { POST as koreFlagsPOST } from './kore-flags/save';
 
+type Ctx = Parameters<typeof navPOST>[0];
+
 function jsonReq(body: unknown): Request {
   return new Request('http://x/api/admin/x/save', {
     method: 'POST',
@@ -43,7 +45,7 @@ describe('content-section save endpoints', () => {
   it('navigation/save persists the posted array under NAV_KEY', async () => {
     asAdmin();
     const nav = [{ label: 'Leistungen', href: '/leistungen', order: 1 }];
-    const r = await navPOST({ request: jsonReq(nav) } as any);
+    const r = await navPOST({ request: jsonReq(nav) } as unknown as Ctx);
     expect(r.status).toBe(200);
     expect(vi.mocked(setJsonSetting)).toHaveBeenCalledWith('mentolder', 'navigation', nav);
   });
@@ -51,7 +53,7 @@ describe('content-section save endpoints', () => {
   it('footer/save persists columns + copyright under FOOTER_KEY', async () => {
     asAdmin();
     const footer = { columns: [{ heading: 'Mehr', links: [{ label: 'Blog', href: '/blog' }] }], copyright: '© 2026' };
-    const r = await footerPOST({ request: jsonReq(footer) } as any);
+    const r = await footerPOST({ request: jsonReq(footer) } as unknown as Ctx);
     expect(r.status).toBe(200);
     expect(vi.mocked(setJsonSetting)).toHaveBeenCalledWith('mentolder', 'footer', footer);
   });
@@ -59,14 +61,14 @@ describe('content-section save endpoints', () => {
   it('stammdaten/save persists the master-data object under STAMMDATEN_KEY', async () => {
     asAdmin();
     const sd = { name: 'P', role: 'Coach', email: 'a@b.de', phone: '', street: '', zip: '', city: 'Berlin', ustId: '', website: '', avatarInitials: 'P' };
-    const r = await stammdatenPOST({ request: jsonReq(sd) } as any);
+    const r = await stammdatenPOST({ request: jsonReq(sd) } as unknown as Ctx);
     expect(r.status).toBe(200);
     expect(vi.mocked(setJsonSetting)).toHaveBeenCalledWith('mentolder', 'stammdaten', sd);
   });
 
   it('kore-flags/save coerces timeline to boolean under KORE_FLAGS_KEY', async () => {
     asAdmin();
-    const r = await koreFlagsPOST({ request: jsonReq({ timeline: 1 }) } as any);
+    const r = await koreFlagsPOST({ request: jsonReq({ timeline: 1 }) } as unknown as Ctx);
     expect(r.status).toBe(200);
     expect(vi.mocked(setJsonSetting)).toHaveBeenCalledWith('mentolder', 'kore_flags', { timeline: true });
   });
@@ -74,16 +76,16 @@ describe('content-section save endpoints', () => {
   it('rejects non-admin with 403 and never writes', async () => {
     vi.mocked(getSession).mockResolvedValue(null as never);
     vi.mocked(isAdmin).mockReturnValue(false);
-    const r = await navPOST({ request: jsonReq([]) } as any);
+    const r = await navPOST({ request: jsonReq([]) } as unknown as Ctx);
     expect(r.status).toBe(403);
     expect(vi.mocked(setJsonSetting)).not.toHaveBeenCalled();
   });
 
   it('rejects a malformed body shape with 400', async () => {
     asAdmin();
-    const r = await navPOST({ request: jsonReq({ not: 'an array' }) } as any);
+    const r = await navPOST({ request: jsonReq({ not: 'an array' }) } as unknown as Ctx);
     expect(r.status).toBe(400);
-    const rf = await footerPOST({ request: jsonReq({ columns: 'nope' }) } as any);
+    const rf = await footerPOST({ request: jsonReq({ columns: 'nope' }) } as unknown as Ctx);
     expect(rf.status).toBe(400);
     expect(vi.mocked(setJsonSetting)).not.toHaveBeenCalled();
   });

--- a/website/src/pages/api/admin/content/restore.ts
+++ b/website/src/pages/api/admin/content/restore.ts
@@ -14,7 +14,8 @@ export const POST: APIRoute = async ({ request }) => {
   if (!target) return new Response('version not found', { status: 404 });
 
   const current = await readContent(BRAND, contentKey);
-  const editor = (session as any).email ?? (session as any).name ?? 'unknown';
-  const { version } = await writeContent(BRAND, contentKey, target.snapshot.value, current.version, editor);
+  const editor = session.email ?? session.name ?? 'unknown';
+  const snapshot = target.snapshot as { value: unknown };
+  const { version } = await writeContent(BRAND, contentKey, snapshot.value, current.version, editor);
   return new Response(JSON.stringify({ version }), { status: 200, headers: { 'content-type': 'application/json' } });
 };

--- a/website/src/pages/api/admin/content/save.test.ts
+++ b/website/src/pages/api/admin/content/save.test.ts
@@ -41,7 +41,7 @@ function asAdmin() {
 describe('POST /api/admin/content/save', () => {
   it('returns 401 when not authenticated', async () => {
     vi.mocked(getSession).mockResolvedValue(null);
-    const res = await POST({ request: jsonReq({ contentKey: 'kontakt', baseVersion: 0, payload: {} }), url: new URL('http://x/') } as any);
+    const res = await POST({ request: jsonReq({ contentKey: 'kontakt', baseVersion: 0, payload: {} }), url: new URL('http://x/') } as unknown as Parameters<typeof POST>[0]);
     expect(res.status).toBe(401);
   });
 
@@ -50,7 +50,7 @@ describe('POST /api/admin/content/save', () => {
     vi.mocked(refFor).mockReturnValue({ contentKey: 'kontakt', contentType: 'site_setting', storeKey: 'kontakt', publicRoute: '/kontakt' });
     vi.mocked(validateSection).mockReturnValue([]);
     vi.mocked(writeContent).mockResolvedValue({ version: 3 });
-    const res = await POST({ request: jsonReq({ contentKey: 'kontakt', baseVersion: 2, payload: { email: 'a@b.de' } }), url: new URL('http://x/') } as any);
+    const res = await POST({ request: jsonReq({ contentKey: 'kontakt', baseVersion: 2, payload: { email: 'a@b.de' } }), url: new URL('http://x/') } as unknown as Parameters<typeof POST>[0]);
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ version: 3 });
   });
@@ -60,7 +60,7 @@ describe('POST /api/admin/content/save', () => {
     vi.mocked(refFor).mockReturnValue({ contentKey: 'kontakt', contentType: 'site_setting', storeKey: 'kontakt', publicRoute: '/kontakt' });
     vi.mocked(validateSection).mockReturnValue([]);
     vi.mocked(writeContent).mockRejectedValue(new ContentConflictError(5, { old: 'value' }, null));
-    const res = await POST({ request: jsonReq({ contentKey: 'kontakt', baseVersion: 2, payload: {} }), url: new URL('http://x/') } as any);
+    const res = await POST({ request: jsonReq({ contentKey: 'kontakt', baseVersion: 2, payload: {} }), url: new URL('http://x/') } as unknown as Parameters<typeof POST>[0]);
     expect(res.status).toBe(409);
     const body = await res.json();
     expect(body).toHaveProperty('currentVersion', 5);
@@ -70,7 +70,7 @@ describe('POST /api/admin/content/save', () => {
     asAdmin();
     vi.mocked(refFor).mockReturnValue({ contentKey: 'kontakt', contentType: 'site_setting', storeKey: 'kontakt', publicRoute: '/kontakt' });
     vi.mocked(validateSection).mockReturnValue([{ field: 'email', message: 'invalid' }]);
-    const res = await POST({ request: jsonReq({ contentKey: 'kontakt', baseVersion: 0, payload: { email: 'bad' } }), url: new URL('http://x/') } as any);
+    const res = await POST({ request: jsonReq({ contentKey: 'kontakt', baseVersion: 0, payload: { email: 'bad' } }), url: new URL('http://x/') } as unknown as Parameters<typeof POST>[0]);
     expect(res.status).toBe(422);
   });
 });

--- a/website/src/pages/api/admin/deployments.ts
+++ b/website/src/pages/api/admin/deployments.ts
@@ -32,11 +32,16 @@ export const GET: APIRoute = async ({ request }) => {
   const ns = brand === 'korczewski' ? 'workspace-korczewski' : 'workspace';
 
   try {
-    const data = await k8s.get(`/apis/apps/v1/namespaces/${ns}/deployments`);
-    const deployments = (data.items ?? []).map((d: any) => {
-      const desired: number = d.spec.replicas ?? 1;
-      const ready: number = d.status.readyReplicas ?? 0;
-      const available: number = d.status.availableReplicas ?? 0;
+    interface K8sDeployment {
+      metadata: { name: string };
+      spec?: { replicas?: number };
+      status?: { readyReplicas?: number; availableReplicas?: number };
+    }
+    const data = await k8s.get<{ items?: K8sDeployment[] }>(`/apis/apps/v1/namespaces/${ns}/deployments`);
+    const deployments = (data.items ?? []).map((d: K8sDeployment) => {
+      const desired: number = d.spec?.replicas ?? 1;
+      const ready: number = d.status?.readyReplicas ?? 0;
+      const available: number = d.status?.availableReplicas ?? 0;
       return {
         name: d.metadata.name,
         desired,

--- a/website/src/pages/api/admin/dora-metrics.test.ts
+++ b/website/src/pages/api/admin/dora-metrics.test.ts
@@ -9,29 +9,32 @@ import { GET } from './dora-metrics';
 
 const mkReq = (w = '7d') =>
   new Request(`http://x/api/admin/dora-metrics?window=${w}`, { headers: { cookie: 's=1' } });
-const locals = { requestLogger: { error: vi.fn() } } as any;
+interface MockLocals {
+  requestLogger: { error: ReturnType<typeof vi.fn> };
+}
+const locals: MockLocals = { requestLogger: { error: vi.fn() } };
 
 describe('GET /api/admin/dora-metrics', () => {
   beforeEach(() => vi.clearAllMocks());
 
   it('401 when not admin', async () => {
     vi.mocked(getSession).mockResolvedValue(null);
-    const res = await GET({ request: mkReq(), locals } as any);
+    const res = await GET({ request: mkReq(), locals } as unknown as Parameters<typeof GET>[0]);
     expect(res.status).toBe(401);
   });
 
   it('returns DORA metrics for an admin', async () => {
-    vi.mocked(getSession).mockResolvedValue({ preferred_username: 'admin', sub: 'a', email: 'a@x' } as any);
+    vi.mocked(getSession).mockResolvedValue({ preferred_username: 'admin', sub: 'a', email: 'a@x' } as unknown as Awaited<ReturnType<typeof getSession>>);
     vi.mocked(isAdmin).mockReturnValue(true);
     // first query = merges, second = bugs (order matches the route's Promise.all)
-    (pool.query as any)
+    (pool.query as unknown as import('vitest').Mock)
       .mockResolvedValueOnce({ rows: [
         { ticket_id: 'A', type: 'feature', driver: 'factory', created_at: '2026-06-01T00:00:00Z', merged_at: '2026-06-01T10:00:00Z', pr_number: 1, reverted: false },
       ] })
       .mockResolvedValueOnce({ rows: [
         { ticket_id: 'BUG1', type: 'bug', driver: 'devflow', created_at: '2026-06-01T00:00:00Z', merged_at: '2026-06-01T04:00:00Z', pr_number: 2, reverted: false },
       ] });
-    const res = await GET({ request: mkReq('30d'), locals } as any);
+    const res = await GET({ request: mkReq('30d'), locals } as unknown as Parameters<typeof GET>[0]);
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.metrics.deploymentFrequency.merges).toBe(1);
@@ -41,10 +44,10 @@ describe('GET /api/admin/dora-metrics', () => {
   });
 
   it('returns 500 on a query failure (logged, not thrown)', async () => {
-    vi.mocked(getSession).mockResolvedValue({ preferred_username: 'admin', sub: 'a', email: 'a@x' } as any);
+    vi.mocked(getSession).mockResolvedValue({ preferred_username: 'admin', sub: 'a', email: 'a@x' } as unknown as Awaited<ReturnType<typeof getSession>>);
     vi.mocked(isAdmin).mockReturnValue(true);
-    (pool.query as any).mockRejectedValue(new Error('db down'));
-    const res = await GET({ request: mkReq(), locals } as any);
+    (pool.query as unknown as import('vitest').Mock).mockRejectedValue(new Error('db down'));
+    const res = await GET({ request: mkReq(), locals } as unknown as Parameters<typeof GET>[0]);
     expect(res.status).toBe(500);
     expect(locals.requestLogger.error).toHaveBeenCalled();
   });

--- a/website/src/pages/api/admin/dora-metrics.ts
+++ b/website/src/pages/api/admin/dora-metrics.ts
@@ -19,14 +19,14 @@ function resolveWindow(w: string): { interval: string; days: number; label: stri
   }
 }
 
-function toRow(r: any): DoraDeliveryRow {
+function toRow(r: Record<string, unknown>): DoraDeliveryRow {
   return {
-    ticketId: r.ticket_id,
-    type: r.type,
-    driver: r.driver ?? null,
-    createdAt: r.created_at ?? null,
-    mergedAt: r.merged_at ?? null,
-    prNumber: r.pr_number ?? null,
+    ticketId: r.ticket_id as string,
+    type: r.type as string,
+    driver: (r.driver ?? null) as DoraDeliveryRow['driver'],
+    createdAt: (r.created_at ?? null) as string | null,
+    mergedAt: (r.merged_at ?? null) as string | null,
+    prNumber: (r.pr_number ?? null) as number | null,
     reverted: r.reverted === true || r.reverted === 'reverted',
   };
 }
@@ -78,8 +78,8 @@ export const GET: APIRoute = async ({ request, locals }) => {
       ),
     ]);
 
-    const merges = (mergesRes.rows as any[]).map(toRow);
-    const bugs = (bugsRes.rows as any[]).map(toRow);
+    const merges = (mergesRes.rows as Record<string, unknown>[]).map(toRow);
+    const bugs = (bugsRes.rows as Record<string, unknown>[]).map(toRow);
     const metrics = computeDora(merges, bugs, days, label);
 
     return json({ metrics }, 200);

--- a/website/src/pages/api/admin/evidence/upload.test.ts
+++ b/website/src/pages/api/admin/evidence/upload.test.ts
@@ -44,7 +44,7 @@ describe.skipIf(!dbAvailable)('POST /api/admin/evidence/upload', () => {
 
   it('rejects when not authenticated', async () => {
     vi.mocked(getSession).mockResolvedValue(null);
-    const res = await POST({ request: makeReq({}) } as any);
+    const res = await POST({ request: makeReq({}) } as unknown as Parameters<typeof POST>[0]);
     expect(res.status).toBe(401);
   });
 
@@ -52,7 +52,7 @@ describe.skipIf(!dbAvailable)('POST /api/admin/evidence/upload', () => {
     const res = await POST({ request: makeReq({
       assignmentId: 'not-a-uuid', questionId: 'also-not', attempt: 0,
       chunk: { events: [], chunkIndex: 0, isFinal: true },
-    }) } as any);
+    }) } as unknown as Parameters<typeof POST>[0]);
     expect(res.status).toBe(400);
   });
 
@@ -78,7 +78,7 @@ describe.skipIf(!dbAvailable)('POST /api/admin/evidence/upload', () => {
       chunk: { events: [{ type: 0, data: {}, timestamp: 1 }], chunkIndex: 0, isFinal: true },
       consoleLog: [],
       networkLog: [],
-    }) } as any);
+    }) } as unknown as Parameters<typeof POST>[0]);
     const json = await res.json();
     expect(res.status).toBe(200);
     expect(json.evidenceId).toMatch(/^[0-9a-f-]{36}$/i);

--- a/website/src/pages/api/admin/monitoring.ts
+++ b/website/src/pages/api/admin/monitoring.ts
@@ -2,6 +2,25 @@ import type { APIRoute } from 'astro';
 import { createK8sClient } from '../../../lib/k8s';
 import { getSession, isAdmin } from '../../../lib/auth';
 
+interface K8sContainerStatus { ready: boolean; restartCount: number }
+interface K8sPod {
+  metadata: { name: string; labels?: Record<string, string> };
+  status: { phase: string; containerStatuses?: K8sContainerStatus[] };
+}
+interface K8sMetricContainer { usage?: { cpu?: string; memory?: string } }
+interface K8sPodMetric { metadata: { name: string }; containers?: K8sMetricContainer[] }
+interface K8sEvent {
+  type: string;
+  reason: string;
+  message: string;
+  lastTimestamp?: string;
+  eventTime?: string;
+  involvedObject: { name: string };
+}
+interface K8sNodeMetric { metadata: { name: string }; usage: { cpu: string; memory: string } }
+interface K8sNode { metadata: { name: string }; status: { capacity: { cpu: string; memory: string } } }
+interface K8sList<T> { items: T[] }
+
 function parseCpuToNano(val: string): number {
   if (val.endsWith('n')) return parseInt(val);
   if (val.endsWith('u')) return parseInt(val) * 1_000;
@@ -38,11 +57,11 @@ export const GET: APIRoute = async ({ request }) => {
   try {
     const [podsData, eventsData, podMetricsResult, nodeMetricsResult, nodeCapacityResult] =
       await Promise.allSettled([
-        k8s.get(`/api/v1/namespaces/${ns}/pods`),
-        k8s.get(`/api/v1/namespaces/${ns}/events`),
-        k8s.get(`/apis/metrics.k8s.io/v1beta1/namespaces/${ns}/pods`),
-        k8s.get('/apis/metrics.k8s.io/v1beta1/nodes'),
-        k8s.get('/api/v1/nodes'),
+        k8s.get<K8sList<K8sPod>>(`/api/v1/namespaces/${ns}/pods`),
+        k8s.get<K8sList<K8sEvent>>(`/api/v1/namespaces/${ns}/events`),
+        k8s.get<K8sList<K8sPodMetric>>(`/apis/metrics.k8s.io/v1beta1/namespaces/${ns}/pods`),
+        k8s.get<K8sList<K8sNodeMetric>>('/apis/metrics.k8s.io/v1beta1/nodes'),
+        k8s.get<K8sList<K8sNode>>('/api/v1/nodes'),
       ]);
 
     if (podsData.status === 'rejected') throw podsData.reason;
@@ -50,26 +69,31 @@ export const GET: APIRoute = async ({ request }) => {
 
     const metricsAvailable =
       podMetricsResult.status === 'fulfilled' && nodeMetricsResult.status === 'fulfilled';
-    const podMetrics = metricsAvailable ? (podMetricsResult as PromiseFulfilledResult<any>).value : null;
-    const nodeMetrics = metricsAvailable ? (nodeMetricsResult as PromiseFulfilledResult<any>).value : null;
+    const podMetrics = metricsAvailable
+      ? (podMetricsResult as PromiseFulfilledResult<K8sList<K8sPodMetric>>).value
+      : null;
+    const nodeMetrics = metricsAvailable
+      ? (nodeMetricsResult as PromiseFulfilledResult<K8sList<K8sNodeMetric>>).value
+      : null;
 
-    const pods = podsData.value.items.map((pod: any) => {
+    const pods = (podsData.value.items as K8sPod[]).map((pod: K8sPod) => {
       const name = pod.metadata.labels?.app || pod.metadata.name;
       const phase = pod.status.phase;
       let ready = false;
       let restarts = 0;
       if (pod.status.containerStatuses) {
-        ready = pod.status.containerStatuses.every((c: any) => c.ready);
+        ready = pod.status.containerStatuses.every((c: K8sContainerStatus) => c.ready);
         restarts = pod.status.containerStatuses.reduce(
-          (acc: number, c: any) => acc + c.restartCount, 0
+          (acc: number, c: K8sContainerStatus) => acc + c.restartCount, 0
         );
       }
       let cpu = undefined;
       let memory = undefined;
       if (metricsAvailable && podMetrics) {
-        const metrics = podMetrics.items.find((m: any) => m.metadata.name === pod.metadata.name);
-        if (metrics?.containers?.length > 0) {
-          const cpuUsage = metrics.containers.reduce((acc: number, c: any) => {
+        const metrics = podMetrics.items.find((m) => m.metadata.name === pod.metadata.name);
+        const containers = metrics?.containers ?? [];
+        if (containers.length > 0) {
+          const cpuUsage = containers.reduce((acc, c) => {
             const val = c.usage?.cpu;
             if (!val) return acc;
             if (val.endsWith('n')) return acc + parseInt(val) / 1_000_000;
@@ -78,7 +102,7 @@ export const GET: APIRoute = async ({ request }) => {
             return acc + parseInt(val) * 1000;
           }, 0);
           cpu = `${Math.round(cpuUsage)}m`;
-          const memUsage = metrics.containers.reduce((acc: number, c: any) => {
+          const memUsage = containers.reduce((acc, c) => {
             const val = c.usage?.memory;
             if (!val) return acc;
             if (val.endsWith('Ki')) return acc + parseInt(val) / 1024;
@@ -92,14 +116,14 @@ export const GET: APIRoute = async ({ request }) => {
       return { name, phase, ready, restarts, ...(cpu && { cpu }), ...(memory && { memory }) };
     });
 
-    const events = eventsData.value.items
-      .sort((a: any, b: any) => {
+    const events = (eventsData.value.items as K8sEvent[])
+      .sort((a: K8sEvent, b: K8sEvent) => {
         const tA = new Date(a.lastTimestamp ?? a.eventTime ?? 0).getTime();
         const tB = new Date(b.lastTimestamp ?? b.eventTime ?? 0).getTime();
         return tB - tA;
       })
       .slice(0, 10)
-      .map((event: any) => {
+      .map((event: K8sEvent) => {
         const ts = event.lastTimestamp ?? event.eventTime;
         const ageMs = ts ? Date.now() - new Date(ts).getTime() : 0;
         const ageMins = Math.floor(ageMs / 60000);
@@ -116,14 +140,14 @@ export const GET: APIRoute = async ({ request }) => {
     const nodes: Array<{ name: string; cpu: string; memory: string }> = [];
     if (
       metricsAvailable &&
-      nodeMetrics?.items?.length > 0 &&
+      (nodeMetrics?.items?.length ?? 0) > 0 &&
       nodeCapacityResult.status === 'fulfilled' &&
       nodeCapacityResult.value?.items?.length > 0
     ) {
-      const capacityItems = (nodeCapacityResult as PromiseFulfilledResult<any>).value.items;
-      for (const nodeMetric of nodeMetrics.items) {
+      const capacityItems = (nodeCapacityResult as PromiseFulfilledResult<K8sList<K8sNode>>).value.items;
+      for (const nodeMetric of nodeMetrics!.items) {
         const nodeName = nodeMetric.metadata.name;
-        const capacityItem = capacityItems.find((n: any) => n.metadata.name === nodeName);
+        const capacityItem = capacityItems.find((n: K8sNode) => n.metadata.name === nodeName);
         if (!capacityItem) continue;
         const cpuPercent = Math.round(
           (parseCpuToNano(nodeMetric.usage.cpu) / parseCpuToNano(capacityItem.status.capacity.cpu)) * 100
@@ -143,11 +167,12 @@ export const GET: APIRoute = async ({ request }) => {
       JSON.stringify({ pods, events, nodes, metricsAvailable, fetchedAt: new Date().toISOString() }),
       { status: 200, headers: { 'Content-Type': 'application/json' } }
     );
-  } catch (error: any) {
+  } catch (error: unknown) {
+    const e = error as { code?: string; message?: string };
     const msg =
-      error.code === 'ECONNREFUSED'
+      e.code === 'ECONNREFUSED'
         ? 'Kubernetes API-Server nicht erreichbar. Bitte Netzwerkrichtlinien und RBAC prüfen.'
-        : error.message;
+        : (e.message ?? 'Unbekannter Fehler');
     return new Response(JSON.stringify({ error: msg }), {
       status: 500,
       headers: { 'Content-Type': 'application/json' },

--- a/website/src/pages/api/admin/openspec/save-proposal.test.ts
+++ b/website/src/pages/api/admin/openspec/save-proposal.test.ts
@@ -33,7 +33,7 @@ function asAdmin() {
 describe('POST /api/admin/openspec/save-proposal', () => {
   it('returns 403 when not authenticated', async () => {
     vi.mocked(getSession).mockResolvedValue(null);
-    const res = await POST({ request: jsonReq({ slug: 's1', content: 'hello' }) } as any);
+    const res = await POST({ request: jsonReq({ slug: 's1', content: 'hello' }) } as unknown as Parameters<typeof POST>[0]);
     expect(res.status).toBe(403);
   });
 
@@ -42,7 +42,7 @@ describe('POST /api/admin/openspec/save-proposal', () => {
     vi.mocked(isValidSlug).mockReturnValue(true);
     vi.mocked(writeProposal).mockResolvedValue();
 
-    const res = await POST({ request: jsonReq({ slug: 's1', content: 'hello' }) } as any);
+    const res = await POST({ request: jsonReq({ slug: 's1', content: 'hello' }) } as unknown as Parameters<typeof POST>[0]);
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ ok: true });
     expect(writeProposal).toHaveBeenCalledWith('s1', 'hello');
@@ -52,7 +52,7 @@ describe('POST /api/admin/openspec/save-proposal', () => {
     asAdmin();
     vi.mocked(isValidSlug).mockReturnValue(false);
 
-    const res = await POST({ request: jsonReq({ slug: '../x', content: 'hello' }) } as any);
+    const res = await POST({ request: jsonReq({ slug: '../x', content: 'hello' }) } as unknown as Parameters<typeof POST>[0]);
     expect(res.status).toBe(400);
   });
 });

--- a/website/src/pages/api/admin/ops/backup/list.ts
+++ b/website/src/pages/api/admin/ops/backup/list.ts
@@ -17,9 +17,13 @@ export const GET: APIRoute = async ({ request }) => {
   try { k8s = await createK8sClient(); }
   catch { return new Response(JSON.stringify({ error: 'Kein Service-Account-Token.' }), { status: 503 }); }
 
-  const data = await k8s.get(`/apis/batch/v1/namespaces/${ns}/jobs?labelSelector=app%3Ddb-backup`);
+  interface K8sJobRaw {
+    metadata: { name: string; labels?: Record<string, string> };
+    status?: { startTime?: string; completionTime?: string; succeeded?: number; failed?: number };
+  }
+  const data = await k8s.get<{ items?: K8sJobRaw[] }>(`/apis/batch/v1/namespaces/${ns}/jobs?labelSelector=app%3Ddb-backup`);
   const jobs = (data.items ?? [])
-    .map((j: any) => ({
+    .map((j: K8sJobRaw) => ({
       name: j.metadata.name,
       trigger: j.metadata.labels?.trigger ?? 'cron',
       startTime: j.status?.startTime ?? null,
@@ -27,7 +31,7 @@ export const GET: APIRoute = async ({ request }) => {
       succeeded: (j.status?.succeeded ?? 0) > 0,
       failed: (j.status?.failed ?? 0) > 0,
     }))
-    .sort((a: any, b: any) => new Date(b.startTime ?? 0).getTime() - new Date(a.startTime ?? 0).getTime())
+    .sort((a, b) => new Date(b.startTime ?? 0).getTime() - new Date(a.startTime ?? 0).getTime())
     .slice(0, 20);
 
   return new Response(JSON.stringify({ jobs }), { headers: { 'Content-Type': 'application/json' } });

--- a/website/src/pages/api/admin/ops/backup/trigger.ts
+++ b/website/src/pages/api/admin/ops/backup/trigger.ts
@@ -17,7 +17,7 @@ export const POST: APIRoute = async ({ request }) => {
   try { k8s = await createK8sClient(); }
   catch { return new Response(JSON.stringify({ error: 'Kein Service-Account-Token.' }), { status: 503 }); }
 
-  const cronJob = await k8s.get(`/apis/batch/v1/namespaces/${ns}/cronjobs/db-backup`);
+  const cronJob = await k8s.get<{ spec: { jobTemplate: { spec: unknown } } }>(`/apis/batch/v1/namespaces/${ns}/cronjobs/db-backup`);
   const jobName = `db-backup-manual-${Date.now()}`;
   const job = {
     apiVersion: 'batch/v1',

--- a/website/src/pages/api/admin/ops/certs.ts
+++ b/website/src/pages/api/admin/ops/certs.ts
@@ -20,7 +20,7 @@ export const GET: APIRoute = async ({ request }) => {
 
   for (const [cluster, { ns, name }] of Object.entries(TLS_SECRETS)) {
     try {
-      const secret = await k8s.get(`/api/v1/namespaces/${ns}/secrets/${name}`);
+      const secret = await k8s.get<{ data?: Record<string, string> }>(`/api/v1/namespaces/${ns}/secrets/${name}`);
       const certBase64 = secret.data?.['tls.crt'];
       if (!certBase64) { results[cluster] = { notAfter: null, daysLeft: null, error: 'Kein tls.crt im Secret' }; continue; }
       const cert = new X509Certificate(Buffer.from(certBase64, 'base64'));

--- a/website/src/pages/api/admin/ops/deployments/list.ts
+++ b/website/src/pages/api/admin/ops/deployments/list.ts
@@ -21,7 +21,12 @@ export const GET: APIRoute = async ({ request }) => {
 
   await Promise.allSettled(
     NAMESPACES.map(async ({ ns, label }) => {
-      const data = await k8s.get(`/apis/apps/v1/namespaces/${ns}/deployments`);
+      interface K8sDeployment {
+        metadata: { name: string };
+        spec?: { replicas?: number };
+        status?: { readyReplicas?: number };
+      }
+      const data = await k8s.get<{ items?: K8sDeployment[] }>(`/apis/apps/v1/namespaces/${ns}/deployments`);
       for (const d of data.items ?? []) {
         const desired = d.spec?.replicas ?? 0;
         const ready = d.status?.readyReplicas ?? 0;

--- a/website/src/pages/api/admin/ops/restore.ts
+++ b/website/src/pages/api/admin/ops/restore.ts
@@ -25,7 +25,7 @@ export const POST: APIRoute = async ({ request }) => {
   try { k8s = await createK8sClient(); }
   catch { return new Response(JSON.stringify({ error: 'Kein Service-Account-Token.' }), { status: 503 }); }
 
-  const jobData = await k8s.get(`/apis/batch/v1/namespaces/${ns}/jobs/${backupJobName}`);
+  const jobData = await k8s.get<{ status?: { startTime?: string } }>(`/apis/batch/v1/namespaces/${ns}/jobs/${backupJobName}`);
   const startTime = jobData.status?.startTime;
   if (!startTime) return new Response(JSON.stringify({ error: 'Backup-Job hat keinen Startzeitstempel' }), { status: 400 });
 
@@ -40,7 +40,10 @@ export const POST: APIRoute = async ({ request }) => {
     String(ts.getUTCSeconds()).padStart(2, '0'),
   ].join('');
 
-  const cronJob = await k8s.get(`/apis/batch/v1/namespaces/${ns}/cronjobs/db-backup`);
+  interface JobSpec {
+    template: { spec: { containers: Array<{ env?: Array<{ name: string; value: string }> }> } };
+  }
+  const cronJob = await k8s.get<{ spec: { jobTemplate: { spec: JobSpec } } }>(`/apis/batch/v1/namespaces/${ns}/cronjobs/db-backup`);
   const jobName = `db-restore-${db}-${Date.now()}`;
   const spec = structuredClone(cronJob.spec.jobTemplate.spec);
 

--- a/website/src/pages/api/admin/platform/hardware.ts
+++ b/website/src/pages/api/admin/platform/hardware.ts
@@ -29,8 +29,8 @@ export const GET: APIRoute = async ({ request, locals }) => {
 
       if (k8s && asset.cluster === currentCluster && asset.k8s_node_name) {
         try {
-          const node = await k8s.get(`/api/v1/nodes/${asset.k8s_node_name}`);
-          const readyCond = node.status?.conditions?.find((c: any) => c.type === 'Ready');
+          const node = await k8s.get<{ status?: { conditions?: Array<{ type: string; status: string }> } }>(`/api/v1/nodes/${asset.k8s_node_name}`);
+          const readyCond = node.status?.conditions?.find((c) => c.type === 'Ready');
           readyStatus = readyCond?.status || 'Unknown';
           liveStatus = readyStatus === 'True' ? 'ready' : 'failing';
         } catch (e) {

--- a/website/src/pages/api/admin/platform/software.ts
+++ b/website/src/pages/api/admin/platform/software.ts
@@ -45,7 +45,7 @@ export const GET: APIRoute = async ({ request, locals }) => {
         }
       } else if (k8s) {
         try {
-          const dep = await k8s.get(`/apis/apps/v1/namespaces/${asset.namespace}/deployments/${asset.deployment_name}`);
+          const dep = await k8s.get<{ status?: { readyReplicas?: number }; spec?: { replicas?: number } }>(`/apis/apps/v1/namespaces/${asset.namespace}/deployments/${asset.deployment_name}`);
           readyReplicas = dep.status?.readyReplicas || 0;
           totalReplicas = dep.spec?.replicas || 0;
           liveStatus = readyReplicas > 0 ? (readyReplicas >= totalReplicas ? 'ready' : 'degraded') : 'failing';

--- a/website/src/pages/api/admin/questionnaires/assignments/[id]/archive.test.ts
+++ b/website/src/pages/api/admin/questionnaires/assignments/[id]/archive.test.ts
@@ -25,21 +25,21 @@ beforeEach(() => {
 describe('POST /api/admin/questionnaires/assignments/[id]/archive', () => {
   it('401 when no session', async () => {
     vi.mocked(getSession).mockResolvedValue(null);
-    const r = await POST({ request: req(), params: { id: 'a' } } as any);
+    const r = await POST({ request: req(), params: { id: 'a' } } as unknown as Parameters<typeof POST>[0]);
     expect(r.status).toBe(401);
   });
 
   it('401 when not admin', async () => {
     vi.mocked(getSession).mockResolvedValue({ user: { sub: 'u' } } as never);
     vi.mocked(isAdmin).mockReturnValue(false);
-    const r = await POST({ request: req(), params: { id: 'a' } } as any);
+    const r = await POST({ request: req(), params: { id: 'a' } } as unknown as Parameters<typeof POST>[0]);
     expect(r.status).toBe(401);
   });
 
   it('400 when id missing', async () => {
     vi.mocked(getSession).mockResolvedValue({ user: { sub: 'u' } } as never);
     vi.mocked(isAdmin).mockReturnValue(true);
-    const r = await POST({ request: req(), params: {} } as any);
+    const r = await POST({ request: req(), params: {} } as unknown as Parameters<typeof POST>[0]);
     expect(r.status).toBe(400);
   });
 
@@ -47,7 +47,7 @@ describe('POST /api/admin/questionnaires/assignments/[id]/archive', () => {
     vi.mocked(getSession).mockResolvedValue({ user: { sub: 'u' } } as never);
     vi.mocked(isAdmin).mockReturnValue(true);
     vi.mocked(archiveQAssignment).mockResolvedValue({ reason: 'not_found' } as never);
-    const r = await POST({ request: req(), params: { id: 'a' } } as any);
+    const r = await POST({ request: req(), params: { id: 'a' } } as unknown as Parameters<typeof POST>[0]);
     expect(r.status).toBe(404);
   });
 
@@ -57,7 +57,7 @@ describe('POST /api/admin/questionnaires/assignments/[id]/archive', () => {
     vi.mocked(archiveQAssignment).mockResolvedValue({
       reason: 'not_archivable',       status: 'pending',
     } as never);
-    const r = await POST({ request: req(), params: { id: 'a' } } as any);
+    const r = await POST({ request: req(), params: { id: 'a' } } as unknown as Parameters<typeof POST>[0]);
     expect(r.status).toBe(409);
     const body = await r.json();
     expect(body.status).toBe('pending');
@@ -69,7 +69,7 @@ describe('POST /api/admin/questionnaires/assignments/[id]/archive', () => {
     vi.mocked(archiveQAssignment).mockResolvedValue({
       assignment: { id: 'a', status: 'archived' } as never,
     });
-    const r = await POST({ request: req(), params: { id: 'a' } } as any);
+    const r = await POST({ request: req(), params: { id: 'a' } } as unknown as Parameters<typeof POST>[0]);
     expect(r.status).toBe(200);
     const body = await r.json();
     expect(body.assignment.id).toBe('a');

--- a/website/src/pages/api/admin/questionnaires/assignments/[id]/reassign.test.ts
+++ b/website/src/pages/api/admin/questionnaires/assignments/[id]/reassign.test.ts
@@ -26,14 +26,14 @@ beforeEach(() => {
 describe('POST /api/admin/questionnaires/assignments/[id]/reassign', () => {
   it('401 when not admin', async () => {
     vi.mocked(getSession).mockResolvedValue(null);
-    const r = await POST({ request: req(), params: { id: 'a' } } as any);
+    const r = await POST({ request: req(), params: { id: 'a' } } as unknown as Parameters<typeof POST>[0]);
     expect(r.status).toBe(401);
   });
 
   it('400 when id missing', async () => {
     vi.mocked(getSession).mockResolvedValue({} as never);
     vi.mocked(isAdmin).mockReturnValue(true);
-    const r = await POST({ request: req(), params: {} } as any);
+    const r = await POST({ request: req(), params: {} } as unknown as Parameters<typeof POST>[0]);
     expect(r.status).toBe(400);
   });
 
@@ -41,7 +41,7 @@ describe('POST /api/admin/questionnaires/assignments/[id]/reassign', () => {
     vi.mocked(getSession).mockResolvedValue({} as never);
     vi.mocked(isAdmin).mockReturnValue(true);
     vi.mocked(reassignQAssignment).mockResolvedValue({ reason: 'not_found' } as never);
-    const r = await POST({ request: req(), params: { id: 'a' } } as any);
+    const r = await POST({ request: req(), params: { id: 'a' } } as unknown as Parameters<typeof POST>[0]);
     expect(r.status).toBe(404);
   });
 
@@ -51,7 +51,7 @@ describe('POST /api/admin/questionnaires/assignments/[id]/reassign', () => {
     vi.mocked(reassignQAssignment).mockResolvedValue({
       assignment: { id: 'newId' } as never,
     });
-    const r = await POST({ request: req(), params: { id: 'a' } } as any);
+    const r = await POST({ request: req(), params: { id: 'a' } } as unknown as Parameters<typeof POST>[0]);
     expect(r.status).toBe(200);
     const body = await r.json();
     expect(body.assignment.id).toBe('newId');
@@ -65,7 +65,7 @@ describe('POST /api/admin/questionnaires/assignments/[id]/reassign', () => {
     vi.mocked(reassignQAssignment).mockResolvedValue({
       assignment: { id: 'newId' } as never,
     });
-    const r = await POST({ request: req(), params: { id: 'a' } } as any);
+    const r = await POST({ request: req(), params: { id: 'a' } } as unknown as Parameters<typeof POST>[0]);
     const body = await r.json();
     expect(body.portalUrl).toBe('https://web.example.com/portal/fragebogen/newId');
   });

--- a/website/src/pages/api/admin/sessions/history/index.test.ts
+++ b/website/src/pages/api/admin/sessions/history/index.test.ts
@@ -13,7 +13,11 @@ import { GET as getHistoryList } from './index';
 import { GET as getHistoryItem } from './[id]';
 import { POST as triggerPurge } from '../purge';
 
-const locals = { requestLogger: { error: vi.fn() } } as any;
+interface MockLocals {
+  requestLogger: { error: ReturnType<typeof vi.fn> };
+}
+const locals: MockLocals = { requestLogger: { error: vi.fn() } };
+type RouteContext = Parameters<typeof getHistoryList>[0];
 
 describe('History and Purge API Endpoints', () => {
   let tmpDirInstance: string;
@@ -40,7 +44,7 @@ describe('History and Purge API Endpoints', () => {
     it('returns 401 when anonymous', async () => {
       vi.mocked(getSession).mockResolvedValue(null);
       const req = new Request('http://x/api/admin/sessions/history');
-      const res = await getHistoryList({ request: req, locals } as any);
+      const res = await getHistoryList({ request: req, locals } as unknown as RouteContext);
       expect(res.status).toBe(401);
     });
 
@@ -56,22 +60,22 @@ describe('History and Purge API Endpoints', () => {
       writeFileSync(join(tmpArchiveDir, 'p1.meta.json'), JSON.stringify(metaPaddione));
 
       // 1. Non-admin Gekko user
-      vi.mocked(getSession).mockResolvedValue({ preferred_username: 'gekko' } as any);
+      vi.mocked(getSession).mockResolvedValue({ preferred_username: 'gekko' } as unknown as Awaited<ReturnType<typeof getSession>>);
       vi.mocked(isAdmin).mockReturnValue(false);
 
       let req = new Request('http://x/api/admin/sessions/history');
-      let res = await getHistoryList({ request: req, locals } as any);
+      let res = await getHistoryList({ request: req, locals } as unknown as RouteContext);
       expect(res.status).toBe(200);
       let body = await res.json();
       expect(body.total).toBe(2);
       expect(body.items.map((i: { id: string }) => i.id)).toEqual(['g1', 'g2']);
 
       // 2. Admin user sees all
-      vi.mocked(getSession).mockResolvedValue({ preferred_username: 'gekko' } as any);
+      vi.mocked(getSession).mockResolvedValue({ preferred_username: 'gekko' } as unknown as Awaited<ReturnType<typeof getSession>>);
       vi.mocked(isAdmin).mockReturnValue(true);
 
       req = new Request('http://x/api/admin/sessions/history');
-      res = await getHistoryList({ request: req, locals } as any);
+      res = await getHistoryList({ request: req, locals } as unknown as RouteContext);
       expect(res.status).toBe(200);
       body = await res.json();
       expect(body.total).toBe(3);
@@ -94,11 +98,11 @@ describe('History and Purge API Endpoints', () => {
         writeFileSync(join(tmpArchiveDir, `s-${i}.meta.json`), JSON.stringify(meta));
       }
 
-      vi.mocked(getSession).mockResolvedValue({ preferred_username: 'gekko' } as any);
+      vi.mocked(getSession).mockResolvedValue({ preferred_username: 'gekko' } as unknown as Awaited<ReturnType<typeof getSession>>);
       vi.mocked(isAdmin).mockReturnValue(false);
 
       const req = new Request('http://x/api/admin/sessions/history?offset=0&limit=2');
-      const res = await getHistoryList({ request: req, locals } as any);
+      const res = await getHistoryList({ request: req, locals } as unknown as RouteContext);
       expect(res.status).toBe(200);
       const body = await res.json();
       expect(body.items.length).toBe(2);
@@ -115,11 +119,11 @@ describe('History and Purge API Endpoints', () => {
       writeFileSync(join(tmpArchiveDir, 's1.meta.json'), JSON.stringify(metaForm));
       writeFileSync(join(tmpArchiveDir, 's2.meta.json'), JSON.stringify(metaBrainstorm));
 
-      vi.mocked(getSession).mockResolvedValue({ preferred_username: 'gekko' } as any);
+      vi.mocked(getSession).mockResolvedValue({ preferred_username: 'gekko' } as unknown as Awaited<ReturnType<typeof getSession>>);
       vi.mocked(isAdmin).mockReturnValue(false);
 
       const req = new Request('http://x/api/admin/sessions/history?type=form');
-      const res = await getHistoryList({ request: req, locals } as any);
+      const res = await getHistoryList({ request: req, locals } as unknown as RouteContext);
       expect(res.status).toBe(200);
       const body = await res.json();
       expect(body.total).toBe(1);
@@ -135,30 +139,30 @@ describe('History and Purge API Endpoints', () => {
 
       // 1. Unauthenticated -> 401
       vi.mocked(getSession).mockResolvedValue(null);
-      let res = await getHistoryItem({ request: new Request('http://x'), params: { id: 'g1' }, locals } as any);
+      let res = await getHistoryItem({ request: new Request('http://x'), params: { id: 'g1' }, locals } as unknown as RouteContext);
       expect(res.status).toBe(401);
 
       // 2. Authenticated non-owner -> 403
-      vi.mocked(getSession).mockResolvedValue({ preferred_username: 'paddione' } as any);
+      vi.mocked(getSession).mockResolvedValue({ preferred_username: 'paddione' } as unknown as Awaited<ReturnType<typeof getSession>>);
       vi.mocked(isAdmin).mockReturnValue(false);
-      res = await getHistoryItem({ request: new Request('http://x'), params: { id: 'g1' }, locals } as any);
+      res = await getHistoryItem({ request: new Request('http://x'), params: { id: 'g1' }, locals } as unknown as RouteContext);
       expect(res.status).toBe(403);
 
       // 3. Authenticated owner -> 200
-      vi.mocked(getSession).mockResolvedValue({ preferred_username: 'gekko' } as any);
+      vi.mocked(getSession).mockResolvedValue({ preferred_username: 'gekko' } as unknown as Awaited<ReturnType<typeof getSession>>);
       vi.mocked(isAdmin).mockReturnValue(false);
-      res = await getHistoryItem({ request: new Request('http://x'), params: { id: 'g1' }, locals } as any);
+      res = await getHistoryItem({ request: new Request('http://x'), params: { id: 'g1' }, locals } as unknown as RouteContext);
       expect(res.status).toBe(200);
       expect(await res.text()).toBe('# Gekko Markdown Content');
 
       // 4. Admin sees others -> 200
-      vi.mocked(getSession).mockResolvedValue({ preferred_username: 'admin' } as any);
+      vi.mocked(getSession).mockResolvedValue({ preferred_username: 'admin' } as unknown as Awaited<ReturnType<typeof getSession>>);
       vi.mocked(isAdmin).mockReturnValue(true);
-      res = await getHistoryItem({ request: new Request('http://x'), params: { id: 'g1' }, locals } as any);
+      res = await getHistoryItem({ request: new Request('http://x'), params: { id: 'g1' }, locals } as unknown as RouteContext);
       expect(res.status).toBe(200);
 
       // 5. Invalid path/traversal check -> 400
-      res = await getHistoryItem({ request: new Request('http://x'), params: { id: '../g1' }, locals } as any);
+      res = await getHistoryItem({ request: new Request('http://x'), params: { id: '../g1' }, locals } as unknown as RouteContext);
       expect(res.status).toBe(400);
     });
   });
@@ -171,7 +175,7 @@ describe('History and Purge API Endpoints', () => {
       vi.mocked(getSession).mockResolvedValue(null);
       vi.mocked(isAdmin).mockReturnValue(false);
       let req = new Request('http://x', { method: 'POST' });
-      let res = await triggerPurge({ request: req, locals } as any);
+      let res = await triggerPurge({ request: req, locals } as unknown as RouteContext);
       expect(res.status).toBe(401);
 
       // 2. Bad cron token -> 401
@@ -179,14 +183,14 @@ describe('History and Purge API Endpoints', () => {
         method: 'POST',
         headers: { 'X-Cron-Token': 'wrong-token' }
       });
-      res = await triggerPurge({ request: req, locals } as any);
+      res = await triggerPurge({ request: req, locals } as unknown as RouteContext);
       expect(res.status).toBe(401);
 
       // 3. Admin session cookie -> 200
-      vi.mocked(getSession).mockResolvedValue({ preferred_username: 'admin' } as any);
+      vi.mocked(getSession).mockResolvedValue({ preferred_username: 'admin' } as unknown as Awaited<ReturnType<typeof getSession>>);
       vi.mocked(isAdmin).mockReturnValue(true);
       req = new Request('http://x', { method: 'POST' });
-      res = await triggerPurge({ request: req, locals } as any);
+      res = await triggerPurge({ request: req, locals } as unknown as RouteContext);
       expect(res.status).toBe(200);
       let body = await res.json();
       expect(body.purged).toBeDefined();
@@ -198,7 +202,7 @@ describe('History and Purge API Endpoints', () => {
         method: 'POST',
         headers: { 'X-Cron-Token': 'my-secret-cron-token' }
       });
-      res = await triggerPurge({ request: req, locals } as any);
+      res = await triggerPurge({ request: req, locals } as unknown as RouteContext);
       expect(res.status).toBe(200);
       body = await res.json();
       expect(body.purged).toBeDefined();

--- a/website/src/pages/api/admin/sessions/index.test.ts
+++ b/website/src/pages/api/admin/sessions/index.test.ts
@@ -11,21 +11,25 @@ import { getSession, isAdmin } from '../../../../lib/auth';
 import { GET } from './index';
 
 const mkReq = () => new Request('http://x/api/admin/sessions', { headers: { cookie: 's=1' } });
-const locals = { requestLogger: { error: vi.fn() } } as any;
+interface MockLocals {
+  requestLogger: { error: ReturnType<typeof vi.fn> };
+}
+const locals: MockLocals = { requestLogger: { error: vi.fn() } };
+type RouteContext = Parameters<typeof GET>[0];
 
 describe('GET /api/admin/sessions', () => {
   beforeEach(() => vi.clearAllMocks());
 
   it('401 when anonymous', async () => {
     vi.mocked(getSession).mockResolvedValue(null);
-    const res = await GET({ request: mkReq(), locals } as any);
+    const res = await GET({ request: mkReq(), locals } as unknown as RouteContext);
     expect(res.status).toBe(401);
   });
 
   it('403 when non-admin', async () => {
-    vi.mocked(getSession).mockResolvedValue({ preferred_username: 'bob', sub: 'b', email: 'b@x' } as any);
+    vi.mocked(getSession).mockResolvedValue({ preferred_username: 'bob', sub: 'b', email: 'b@x' } as unknown as Awaited<ReturnType<typeof getSession>>);
     vi.mocked(isAdmin).mockReturnValue(false);
-    const res = await GET({ request: mkReq(), locals } as any);
+    const res = await GET({ request: mkReq(), locals } as unknown as RouteContext);
     expect(res.status).toBe(403);
   });
 
@@ -36,9 +40,9 @@ describe('GET /api/admin/sessions', () => {
       { slug: 'foo', type: 'form', title: 'Foo', port: 1, public_url: 'https://session-foo.dev.example.test', local_url: 'http://localhost:1/', started_at: '2026-06-20T00:00:00Z' },
     ]));
     process.env.SESSION_HUB_REGISTRY = reg;
-    vi.mocked(getSession).mockResolvedValue({ preferred_username: 'admin', sub: 'a', email: 'a@x' } as any);
+    vi.mocked(getSession).mockResolvedValue({ preferred_username: 'admin', sub: 'a', email: 'a@x' } as unknown as Awaited<ReturnType<typeof getSession>>);
     vi.mocked(isAdmin).mockReturnValue(true);
-    const res = await GET({ request: mkReq(), locals } as any);
+    const res = await GET({ request: mkReq(), locals } as unknown as RouteContext);
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.sessions[0].slug).toBe('foo');
@@ -46,9 +50,9 @@ describe('GET /api/admin/sessions', () => {
 
   it('returns an empty list when the registry file is absent', async () => {
     process.env.SESSION_HUB_REGISTRY = join(tmpdir(), 'does-not-exist-' + Date.now() + '.json');
-    vi.mocked(getSession).mockResolvedValue({ preferred_username: 'admin', sub: 'a', email: 'a@x' } as any);
+    vi.mocked(getSession).mockResolvedValue({ preferred_username: 'admin', sub: 'a', email: 'a@x' } as unknown as Awaited<ReturnType<typeof getSession>>);
     vi.mocked(isAdmin).mockReturnValue(true);
-    const res = await GET({ request: mkReq(), locals } as any);
+    const res = await GET({ request: mkReq(), locals } as unknown as RouteContext);
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.sessions).toEqual([]);

--- a/website/src/pages/api/admin/sessions/templates/[id].test.ts
+++ b/website/src/pages/api/admin/sessions/templates/[id].test.ts
@@ -14,32 +14,36 @@ import { DELETE } from './[id]';
 const mkReq = () => new Request('http://x/api/admin/sessions/templates/abc', {
   method: 'DELETE', headers: { cookie: 's=1' },
 });
-const locals = { requestLogger: { error: vi.fn() } } as any;
+interface MockLocals {
+  requestLogger: { error: ReturnType<typeof vi.fn> };
+}
+const locals: MockLocals = { requestLogger: { error: vi.fn() } };
+type RouteContext = Parameters<typeof DELETE>[0];
 
 describe('DELETE /api/admin/sessions/templates/[id]', () => {
   beforeEach(() => vi.clearAllMocks());
 
   it('401 when anonymous', async () => {
     vi.mocked(getSession).mockResolvedValue(null);
-    const res = await DELETE({ request: mkReq(), locals, params: { id: 'abc' } } as any);
+    const res = await DELETE({ request: mkReq(), locals, params: { id: 'abc' } } as unknown as RouteContext);
     expect(res.status).toBe(401);
   });
 
   it('200 deletes own custom template', async () => {
-    vi.mocked(getSession).mockResolvedValue({ sub: 'a', email: 'a@x', preferred_username: 'admin' } as any);
+    vi.mocked(getSession).mockResolvedValue({ sub: 'a', email: 'a@x', preferred_username: 'admin' } as unknown as Awaited<ReturnType<typeof getSession>>);
     vi.mocked(isAdmin).mockReturnValue(true);
     vi.mocked(deleteTemplate).mockResolvedValue(undefined);
-    const res = await DELETE({ request: mkReq(), locals, params: { id: 'abc' } } as any);
+    const res = await DELETE({ request: mkReq(), locals, params: { id: 'abc' } } as unknown as RouteContext);
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.ok).toBe(true);
   });
 
   it('400 when deleteTemplate throws', async () => {
-    vi.mocked(getSession).mockResolvedValue({ sub: 'a', email: 'a@x', preferred_username: 'admin' } as any);
+    vi.mocked(getSession).mockResolvedValue({ sub: 'a', email: 'a@x', preferred_username: 'admin' } as unknown as Awaited<ReturnType<typeof getSession>>);
     vi.mocked(isAdmin).mockReturnValue(true);
     vi.mocked(deleteTemplate).mockRejectedValue(new Error('cannot delete default template'));
-    const res = await DELETE({ request: mkReq(), locals, params: { id: 'abc' } } as any);
+    const res = await DELETE({ request: mkReq(), locals, params: { id: 'abc' } } as unknown as RouteContext);
     expect(res.status).toBe(400);
   });
 });

--- a/website/src/pages/api/admin/sessions/templates/index.test.ts
+++ b/website/src/pages/api/admin/sessions/templates/index.test.ts
@@ -18,31 +18,35 @@ const mkReq = (opts: { method?: string; body?: unknown } = {}) =>
     headers: { cookie: 's=1' },
     body: opts.body ? JSON.stringify(opts.body) : undefined,
   });
-const locals = { requestLogger: { error: vi.fn() } } as any;
+interface MockLocals {
+  requestLogger: { error: ReturnType<typeof vi.fn> };
+}
+const locals: MockLocals = { requestLogger: { error: vi.fn() } };
+type RouteContext = Parameters<typeof GET>[0];
 
 describe('GET /api/admin/sessions/templates', () => {
   beforeEach(() => vi.clearAllMocks());
 
   it('401 when anonymous', async () => {
     vi.mocked(getSession).mockResolvedValue(null);
-    const res = await GET({ request: mkReq(), locals } as any);
+    const res = await GET({ request: mkReq(), locals } as unknown as RouteContext);
     expect(res.status).toBe(401);
   });
 
   it('403 when non-admin', async () => {
-    vi.mocked(getSession).mockResolvedValue({ sub: 'b', email: 'b@x', preferred_username: 'bob' } as any);
+    vi.mocked(getSession).mockResolvedValue({ sub: 'b', email: 'b@x', preferred_username: 'bob' } as unknown as Awaited<ReturnType<typeof getSession>>);
     vi.mocked(isAdmin).mockReturnValue(false);
-    const res = await GET({ request: mkReq(), locals } as any);
+    const res = await GET({ request: mkReq(), locals } as unknown as RouteContext);
     expect(res.status).toBe(403);
   });
 
   it('200 with templates for admin', async () => {
-    vi.mocked(getSession).mockResolvedValue({ sub: 'a', email: 'a@x', preferred_username: 'admin' } as any);
+    vi.mocked(getSession).mockResolvedValue({ sub: 'a', email: 'a@x', preferred_username: 'admin' } as unknown as Awaited<ReturnType<typeof getSession>>);
     vi.mocked(isAdmin).mockReturnValue(true);
     vi.mocked(listTemplates).mockResolvedValue([
       { id: '1', slug: 'feature-intake', title: 'Feature-Intake', body_markdown: '', is_default: true, owner_id: null, created_from_template_id: null },
     ]);
-    const res = await GET({ request: mkReq(), locals } as any);
+    const res = await GET({ request: mkReq(), locals } as unknown as RouteContext);
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.templates[0].slug).toBe('feature-intake');
@@ -53,13 +57,13 @@ describe('POST /api/admin/sessions/templates', () => {
   beforeEach(() => vi.clearAllMocks());
 
   it('200 clones a template', async () => {
-    vi.mocked(getSession).mockResolvedValue({ sub: 'a', email: 'a@x', preferred_username: 'admin' } as any);
+    vi.mocked(getSession).mockResolvedValue({ sub: 'a', email: 'a@x', preferred_username: 'admin' } as unknown as Awaited<ReturnType<typeof getSession>>);
     vi.mocked(isAdmin).mockReturnValue(true);
     vi.mocked(cloneTemplate).mockResolvedValue({
       id: '2', slug: 'grilling-copy', title: 'Grilling (Kopie)',
       body_markdown: '# x', is_default: false, owner_id: 'a', created_from_template_id: '1',
     });
-    const res = await POST({ request: mkReq({ method: 'POST', body: { templateId: '1' } }), locals } as any);
+    const res = await POST({ request: mkReq({ method: 'POST', body: { templateId: '1' } }), locals } as unknown as RouteContext);
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.template.slug).toBe('grilling-copy');

--- a/website/src/pages/api/admin/systemtest/board.test.ts
+++ b/website/src/pages/api/admin/systemtest/board.test.ts
@@ -28,7 +28,7 @@ const dbAvailable = !!(
   process.env.SESSIONS_DATABASE_URL
 );
 
-const mockSession = { sub: 'admin', preferred_username: 'admin' } as any;
+const mockSession = { sub: 'admin', preferred_username: 'admin' } as unknown as Awaited<ReturnType<typeof getSession>>;
 
 function makeReq(): Request {
   return new Request('http://test/api/admin/systemtest/board', {
@@ -131,12 +131,12 @@ describe.skipIf(!dbAvailable)('GET /api/admin/systemtest/board', () => {
 
   it('rejects when not authenticated', async () => {
     vi.mocked(getSession).mockResolvedValue(null);
-    const res = await GET({ request: makeReq() } as any);
+    const res = await GET({ request: makeReq() } as unknown as Parameters<typeof GET>[0]);
     expect(res.status).toBe(401);
   });
 
   it('returns the canonical {columns, undelivered} shape with all four columns present', async () => {
-    const res = await GET({ request: makeReq() } as any);
+    const res = await GET({ request: makeReq() } as unknown as Parameters<typeof GET>[0]);
     expect(res.status).toBe(200);
     const body = (await res.json()) as BoardResponse;
     expect(body).toHaveProperty('columns');
@@ -153,7 +153,7 @@ describe.skipIf(!dbAvailable)('GET /api/admin/systemtest/board', () => {
     const f = await seedFailure();
     pending.push(f.cleanup);
 
-    const res = await GET({ request: makeReq() } as any);
+    const res = await GET({ request: makeReq() } as unknown as Parameters<typeof GET>[0]);
     expect(res.status).toBe(200);
     const body = (await res.json()) as BoardResponse;
 
@@ -178,7 +178,7 @@ describe.skipIf(!dbAvailable)('GET /api/admin/systemtest/board', () => {
       [f.questionId],
     );
 
-    const res = await GET({ request: makeReq() } as any);
+    const res = await GET({ request: makeReq() } as unknown as Parameters<typeof GET>[0]);
     const body = (await res.json()) as BoardResponse;
     const found = body.columns.retest_pending.find(r => r.ticket_id === f.ticketId);
     expect(found).toBeTruthy();
@@ -198,7 +198,7 @@ describe.skipIf(!dbAvailable)('GET /api/admin/systemtest/board', () => {
       await pool.query(`DELETE FROM systemtest_failure_outbox WHERE assignment_id = $1`, [aId]);
     });
 
-    const res = await GET({ request: makeReq() } as any);
+    const res = await GET({ request: makeReq() } as unknown as Parameters<typeof GET>[0]);
     const body = (await res.json()) as BoardResponse;
     expect(body.undelivered).toBeGreaterThanOrEqual(1);
   });

--- a/website/src/pages/api/admin/systemtest/seed.test.ts
+++ b/website/src/pages/api/admin/systemtest/seed.test.ts
@@ -25,7 +25,7 @@ const dbAvailable = !!(
   process.env.SESSIONS_DATABASE_URL
 );
 
-const mockSession = { sub: 'admin', preferred_username: 'admin' } as any;
+const mockSession = { sub: 'admin', preferred_username: 'admin' } as unknown as Awaited<ReturnType<typeof getSession>>;
 
 function makeReq(body: unknown): Request {
   return new Request('http://test/api/admin/systemtest/seed', {
@@ -58,12 +58,12 @@ describe.skipIf(!dbAvailable)('POST /api/admin/systemtest/seed', () => {
 
   it('rejects when not authenticated', async () => {
     vi.mocked(getSession).mockResolvedValue(null);
-    const res = await POST({ request: makeReq({ assignmentId: 'x', questionId: 'y' }) } as any);
+    const res = await POST({ request: makeReq({ assignmentId: 'x', questionId: 'y' }) } as unknown as Parameters<typeof POST>[0]);
     expect(res.status).toBe(401);
   });
 
   it('rejects non-UUID assignmentId', async () => {
-    const res = await POST({ request: makeReq({ assignmentId: 'not-a-uuid', questionId: 'also-not' }) } as any);
+    const res = await POST({ request: makeReq({ assignmentId: 'not-a-uuid', questionId: 'also-not' }) } as unknown as Parameters<typeof POST>[0]);
     expect(res.status).toBe(400);
   });
 
@@ -82,7 +82,7 @@ describe.skipIf(!dbAvailable)('POST /api/admin/systemtest/seed', () => {
       [tplId],
     )).rows[0].id;
 
-    const res = await POST({ request: makeReq({ assignmentId: aId, questionId: qId }) } as any);
+    const res = await POST({ request: makeReq({ assignmentId: aId, questionId: qId }) } as unknown as Parameters<typeof POST>[0]);
     expect(res.status).toBe(404);
   });
 
@@ -106,7 +106,7 @@ describe.skipIf(!dbAvailable)('POST /api/admin/systemtest/seed', () => {
       [tplId],
     )).rows[0].id;
 
-    const res = await POST({ request: makeReq({ assignmentId: aId, questionId: qId }) } as any);
+    const res = await POST({ request: makeReq({ assignmentId: aId, questionId: qId }) } as unknown as Parameters<typeof POST>[0]);
     const body = await res.json();
     expect(res.status).toBe(200);
     expect(body.testUser.email).toMatch(/^test-.*@systemtest\.local$/);
@@ -144,7 +144,7 @@ describe.skipIf(!dbAvailable)('POST /api/admin/systemtest/seed', () => {
       [tplId],
     )).rows[0].id;
 
-    const res = await POST({ request: makeReq({ assignmentId: aId, questionId: qId }) } as any);
+    const res = await POST({ request: makeReq({ assignmentId: aId, questionId: qId }) } as unknown as Parameters<typeof POST>[0]);
     expect(res.status).toBe(200);
   });
 
@@ -178,7 +178,7 @@ describe.skipIf(!dbAvailable)('POST /api/admin/systemtest/seed', () => {
       [tplId],
     )).rows[0].id;
 
-    const res = await POST({ request: makeReq({ assignmentId: aId, questionId: qId }) } as any);
+    const res = await POST({ request: makeReq({ assignmentId: aId, questionId: qId }) } as unknown as Parameters<typeof POST>[0]);
     expect(res.status).toBe(500);
 
     // No fixture rows written.

--- a/website/src/pages/api/auth/me.test.ts
+++ b/website/src/pages/api/auth/me.test.ts
@@ -9,6 +9,8 @@ vi.mock('../../../lib/auth', () => ({
 
 import { GET, OPTIONS } from './me';
 
+type RouteContext = Parameters<typeof GET>[0];
+
 const REACT = 'https://react.example.test';
 const EVIL = 'https://evil.example';
 
@@ -31,14 +33,14 @@ const req = (origin: string | null, method = 'GET') =>
 
 describe('me OPTIONS preflight', () => {
   it('answers an allowlisted preflight with 204 + Allow-Origin', () => {
-    const res = OPTIONS({ request: req(REACT, 'OPTIONS') } as any) as Response;
+    const res = OPTIONS({ request: req(REACT, 'OPTIONS') } as unknown as RouteContext) as Response;
     expect(res.status).toBe(204);
     expect(res.headers.get('Access-Control-Allow-Origin')).toBe(REACT);
     expect(res.headers.get('Access-Control-Allow-Credentials')).toBe('true');
   });
 
   it('answers a foreign preflight with 204 but no Allow-Origin', () => {
-    const res = OPTIONS({ request: req(EVIL, 'OPTIONS') } as any) as Response;
+    const res = OPTIONS({ request: req(EVIL, 'OPTIONS') } as unknown as RouteContext) as Response;
     expect(res.status).toBe(204);
     expect(res.headers.get('Access-Control-Allow-Origin')).toBeNull();
   });
@@ -46,7 +48,7 @@ describe('me OPTIONS preflight', () => {
 
 describe('me GET', () => {
   it('includes CORS headers for an allowlisted origin when logged out', async () => {
-    const res = await GET({ request: req(REACT) } as any);
+    const res = await GET({ request: req(REACT) } as unknown as RouteContext);
     expect(res.headers.get('Access-Control-Allow-Origin')).toBe(REACT);
     expect(res.headers.get('Access-Control-Allow-Credentials')).toBe('true');
     const body = await res.json();
@@ -67,7 +69,7 @@ describe('me GET', () => {
       refresh_token: 'rtok',
       expires_at: 123,
     };
-    const res = await GET({ request: req(REACT) } as any);
+    const res = await GET({ request: req(REACT) } as unknown as RouteContext);
     expect(res.headers.get('Access-Control-Allow-Origin')).toBe(REACT);
     const body = await res.json();
     expect(body.authenticated).toBe(true);
@@ -76,7 +78,7 @@ describe('me GET', () => {
   });
 
   it('emits NO Allow-Origin for a foreign origin (fail-closed)', async () => {
-    const res = await GET({ request: req(EVIL) } as any);
+    const res = await GET({ request: req(EVIL) } as unknown as RouteContext);
     expect(res.headers.get('Access-Control-Allow-Origin')).toBeNull();
   });
 });

--- a/website/src/pages/api/billing/invoice/[id]/xrechnung.xml.test.ts
+++ b/website/src/pages/api/billing/invoice/[id]/xrechnung.xml.test.ts
@@ -25,25 +25,25 @@ describe('GET /api/billing/invoice/[id]/xrechnung.xml', () => {
 
   it('returns 401 when not authenticated', async () => {
     vi.mocked(getSession).mockResolvedValue(null);
-    const res = await GET({ request: new Request('http://localhost'), params: { id: 'inv1' } } as any);
+    const res = await GET({ request: new Request('http://localhost'), params: { id: 'inv1' } } as unknown as Parameters<typeof GET>[0]);
     expect(res.status).toBe(401);
   });
 
   it('returns 404 when invoice not found', async () => {
     mockQuery.mockResolvedValueOnce({ rowCount: 0 });
-    const res = await GET({ request: new Request('http://localhost'), params: { id: 'inv1' } } as any);
+    const res = await GET({ request: new Request('http://localhost'), params: { id: 'inv1' } } as unknown as Parameters<typeof GET>[0]);
     expect(res.status).toBe(404);
   });
 
   it('returns 404 when invoice has no XRechnung XML', async () => {
     mockQuery.mockResolvedValueOnce({ rowCount: 1, rows: [{ xrechnung_xml: null, number: 'INV-1' }] });
-    const res = await GET({ request: new Request('http://localhost'), params: { id: 'inv1' } } as any);
+    const res = await GET({ request: new Request('http://localhost'), params: { id: 'inv1' } } as unknown as Parameters<typeof GET>[0]);
     expect(res.status).toBe(404);
   });
 
   it('returns XML when available', async () => {
     mockQuery.mockResolvedValueOnce({ rowCount: 1, rows: [{ xrechnung_xml: '<xml>xr</xml>', number: 'INV-1' }] });
-    const res = await GET({ request: new Request('http://localhost'), params: { id: 'inv1' } } as any);
+    const res = await GET({ request: new Request('http://localhost'), params: { id: 'inv1' } } as unknown as Parameters<typeof GET>[0]);
     expect(res.status).toBe(200);
     expect(res.headers.get('Content-Type')).toContain('application/xml');
     expect(res.headers.get('Content-Disposition')).toContain('attachment; filename="xrechnung-INV-1.xml"');

--- a/website/src/pages/api/factory-floor/ci.test.ts
+++ b/website/src/pages/api/factory-floor/ci.test.ts
@@ -14,19 +14,19 @@ const req = (c: string | null) => new Request('http://x/api/factory-floor/T1/ci'
 
 describe('GET /api/factory-floor/[extId]/ci', () => {
   it('401 without admin', async () => {
-    const res = await GET({ request: req(null), params: { extId: 'T1' } } as any);
+    const res = await GET({ request: req(null), params: { extId: 'T1' } } as unknown as Parameters<typeof GET>[0]);
     expect(res.status).toBe(401);
   });
   it('200 with {checks, rollup:null} when ticket has no PR', async () => {
     getTicketDetail.mockResolvedValueOnce({ prNumber: null });
-    const res = await GET({ request: req('admin'), params: { extId: 'T1' } } as any);
+    const res = await GET({ request: req('admin'), params: { extId: 'T1' } } as unknown as Parameters<typeof GET>[0]);
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ prNumber: null, checks: [], rollup: null });
   });
   it('200 with checks when ticket has a PR', async () => {
     getTicketDetail.mockResolvedValueOnce({ prNumber: 42 });
     fetchCiChecks.mockResolvedValueOnce({ checks: [{ name: 'CI', status: 'completed', conclusion: 'success', url: 'u' }], rollup: 'success' });
-    const res = await GET({ request: req('admin'), params: { extId: 'T1' } } as any);
+    const res = await GET({ request: req('admin'), params: { extId: 'T1' } } as unknown as Parameters<typeof GET>[0]);
     expect(await res.json()).toMatchObject({ prNumber: 42, rollup: 'success' });
   });
 });

--- a/website/src/pages/api/factory-floor/inject.test.ts
+++ b/website/src/pages/api/factory-floor/inject.test.ts
@@ -7,8 +7,8 @@ vi.mock('../../../lib/auth', () => ({
   getSession: vi.fn(async (cookie: string | null) => (cookie === 'admin' ? { preferred_username: 'admin', groups: ['admins'] } : null)),
   isAdmin: vi.fn((s: { groups?: string[] } | null | undefined) => s?.groups?.includes('admins') ?? false),
 }));
-const insertInjection = vi.fn(async (..._args: any[]) => ({ id: 'x' }));
-vi.mock('../../../lib/factory-floor', () => ({ insertInjection: (...a: any[]) => insertInjection(...a) }));
+const insertInjection = vi.fn(async (..._args: unknown[]) => ({ id: 'x' }));
+vi.mock('../../../lib/factory-floor', () => ({ insertInjection: (...a: unknown[]) => insertInjection(...a) }));
 
 import { POST } from './[extId]/inject';
 
@@ -22,24 +22,24 @@ function req(cookie: string | null, body: unknown): Request {
 
 describe('POST /api/factory-floor/[extId]/inject', () => {
   it('401 without an admin session', async () => {
-    const res = await POST({ request: req(null, { kind: 'note', content: 'x' }), params: { extId: 'T000459' } } as any);
+    const res = await POST({ request: req(null, { kind: 'note', content: 'x' }), params: { extId: 'T000459' } } as unknown as Parameters<typeof POST>[0]);
     expect(res.status).toBe(401);
   });
 
   it('400 on missing kind', async () => {
-    const res = await POST({ request: req('admin', { content: 'x' }), params: { extId: 'T000459' } } as any);
+    const res = await POST({ request: req('admin', { content: 'x' }), params: { extId: 'T000459' } } as unknown as Parameters<typeof POST>[0]);
     expect(res.status).toBe(400);
   });
 
   it('201 inserts a context injection for an admin', async () => {
     insertInjection.mockResolvedValueOnce({ id: 'abc' } as never);
-    const res = await POST({ request: req('admin', { kind: 'context', content: 'hi', phase: 'implement' }), params: { extId: 'T000459' } } as any);
+    const res = await POST({ request: req('admin', { kind: 'context', content: 'hi', phase: 'implement' }), params: { extId: 'T000459' } } as unknown as Parameters<typeof POST>[0]);
     expect(res.status).toBe(201);
     expect(insertInjection).toHaveBeenCalled();
   });
 
   it('413 when content exceeds the cap', async () => {
-    const res = await POST({ request: req('admin', { kind: 'note', content: 'a'.repeat(9000) }), params: { extId: 'T000459' } } as any);
+    const res = await POST({ request: req('admin', { kind: 'note', content: 'a'.repeat(9000) }), params: { extId: 'T000459' } } as unknown as Parameters<typeof POST>[0]);
     expect(res.status).toBe(413);
   });
 });

--- a/website/src/pages/kontakt.astro
+++ b/website/src/pages/kontakt.astro
@@ -16,9 +16,9 @@ const kontakt = await getEffectiveKontakt();
 const stammdaten = await getEffectiveStammdaten().catch(() => null);
 
 // Kontaktdaten: stammdaten (DB site_settings) wins; legacy kontaktOverride.footer* as fallback; static config as final fallback
-const displayPhone = stammdaten?.phone || (kontakt as any).footerPhone?.trim() || (config.contact.phone && config.contact.phone !== '***' ? config.contact.phone : '');
-const displayEmail = stammdaten?.email || (kontakt as any).footerEmail?.trim() || config.contact.email;
-const displayCity  = stammdaten?.city  || (kontakt as any).footerCity?.trim()  || config.contact.city;
+const displayPhone = stammdaten?.phone || kontakt.footerPhone?.trim() || (config.contact.phone && config.contact.phone !== '***' ? config.contact.phone : '');
+const displayEmail = stammdaten?.email || kontakt.footerEmail?.trim() || config.contact.email;
+const displayCity  = stammdaten?.city  || kontakt.footerCity?.trim()  || config.contact.city;
 
 const rawMode = Astro.url.searchParams.get('mode') ?? '';
 const initialMode = ['message', 'termin', 'callback'].includes(rawMode)


### PR DESCRIPTION
## Summary

- Reduces explicit `any` count in `website/src` from 463 to 168 (G-CQ02 quality gate, target ≤200)
- Fixes test mocks: `MockLocals` interfaces, `Parameters<typeof handler>[0]` / `as unknown as APIContext` assertions, `unknown[]` for vi.fn() params, `Awaited<ReturnType<typeof fn>>` for mock return values
- Fixes API handlers: K8s response interfaces (K8sPod, K8sContainerStatus, K8sEvent, K8sNode, K8sList<T>) and typed `k8s.get<T>()` call sites across monitoring, cluster, ops, platform handlers
- Fixes library files: generic `createBehaviorStore<T>`, `Record<string, unknown>` DB rows, `unknown` error handling, generic `K8sClient` methods
- Fixes Svelte/Astro components: typed event handlers, explicit prop interfaces
- BATS test `tests/spec/g-cq02-any-types.bats` enforces ≤200 going forward (GREEN)

## Test plan
- [x] BATS: `bats tests/spec/g-cq02-any-types.bats` (GREEN: count 168 ≤ 200)
- [x] TypeScript: `pnpm run astro:check` passes with 0 errors
- [x] Vitest: `pnpm run test:unit` — 1976 passed, 0 failures
- [x] Test inventory + freshness artifacts regenerated

Closes T001285

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GSZp2icAAH9WUUB7tk2sXW