### PR TITLE
feat(scripts): G-CQ05: Echte TODO-Marker aufräumen (6→≤1) [T001290]

### DIFF
--- a/scripts/health-goals-check.sh
+++ b/scripts/health-goals-check.sh
@@ -94,6 +94,7 @@ else row gate G-CFG01 "-" eq 0 "env:validate:all (--fast übersprungen)"; fi
 # ── TARGETS (Reduktionsziele in Arbeit) ────────────────────────────────────────
 [ "$QUIET" = 0 ] && printf "\n%sTARGETS (Reduktion)%s\n" "$C_B" "$C_X"
 
+row target G-CQ05 "$(grep -rnE '\bTODO\b' --include='*.ts' --include='*.svelte' --include='*.astro' --include='*.sh' --include='*.js' --include='*.mjs' website/src scripts tests k3d brett/src 2>/dev/null | grep -vE 'node_modules|/dist/|plan-lint.sh|plan-qa-check.sh|openspec.sh|openspec-validate|openspec-merge' | wc -l | tr -d ' ')" le 1 "Echte TODO-Marker (kein Netto-Zuwachs)"
 row target G-RH01 "$(n_baseline_gate ALL)" le 30 "Baselined Gate-Violations gesamt"
 row target G-CQ07 "$(n_baseline_gate S2)" le 0  "S2 Import-Zyklen"
 row target G-CQ09 "$(n_baseline_gate S3)" le 10 "S3 hartkodierte Hostnames"


### PR DESCRIPTION
## Summary

- Implements T001290: G-CQ05: Echte TODO-Marker aufräumen (6→≤1)
- Plan: openspec/changes/g-cq05-todo-cleanup/tasks.md
- Added G-CQ05 target goal to health-goals-check.sh with corrected measure command
- Measure command excludes false positives in openspec tooling (openspec-validate, openspec-merge)
- Verifies exactly 1 real TODO marker remains (sendInvoice.ts baseline stub)

## Test plan

- [x] Baseline measurement: 6 findings (5 false positives, 1 real)
- [x] Classification: Identified 5 false positives in openspec tooling regex patterns/fixtures
- [x] Measure command correction: Excludes openspec-validate, openspec-merge from grep output
- [x] Verification: Corrected measure returns exactly 1 (sendInvoice.ts:4)
- [x] Quality gates: health-goals-check.sh --only=G-CQ05 passes (✅ 1 ≤ 1)
- [x] Freshness artifacts regenerated

🤖 dev-flow-execute