### PR TITLE
chore(ci): add health-goal scopes to scope-enum (test01-05, cq01-08, …)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -347,6 +347,54 @@ jobs:
             openspec
             mentolder-web
             skills
+            test01
+            test02
+            test03
+            test04
+            test05
+            cq01
+            cq02
+            cq03
+            cq04
+            cq05
+            cq06
+            cq07
+            cq08
+            size01
+            size02
+            size03
+            size04
+            ci01
+            ci02
+            ci03
+            cd01
+            cd02
+            dora01
+            dora02
+            dora03
+            dep01
+            dep02
+            dep03
+            doc01
+            doc02
+            doc03
+            doc04
+            fe01
+            fe02
+            fe03
+            img01
+            img02
+            k8s01
+            k8s02
+            k8s03
+            spec01
+            spec02
+            spec03
+            sec01
+            sec02
+            sec03
+            sec04
+            sec05
           # Ticket references like [T000436] can extend subject length
           subjectPattern: ^.{1,200}$
           subjectPatternError: |

--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -43,7 +43,19 @@ module.exports = {
         'dev-flow',
         'prompt-library',
         'tickets',
-        'recovery'
+        'recovery',
+        'test01', 'test02', 'test03', 'test04', 'test05',
+        'cq01', 'cq02', 'cq03', 'cq04', 'cq05', 'cq06', 'cq07', 'cq08',
+        'size01', 'size02', 'size03', 'size04',
+        'ci01', 'ci02', 'ci03', 'cd01', 'cd02',
+        'dora01', 'dora02', 'dora03',
+        'dep01', 'dep02', 'dep03',
+        'doc01', 'doc02', 'doc03', 'doc04',
+        'fe01', 'fe02', 'fe03',
+        'img01', 'img02',
+        'k8s01', 'k8s02', 'k8s03',
+        'spec01', 'spec02', 'spec03',
+        'sec01', 'sec02', 'sec03', 'sec04', 'sec05'
       ]
     ]
   },


### PR DESCRIPTION
## Summary

- Adds health-goal-type scopes (`test01`–`test05`, `cq01`–`cq08`, `size01`–`size04`, `ci01`–`ci03`, `cd01`–`cd02`, `dora01`–`dora03`, `dep01`–`dep03`, `doc01`–`doc04`, `fe01`–`fe03`, `img01`–`img02`, `k8s01`–`k8s03`, `spec01`–`spec03`, `sec01`–`sec05`) to both `ci.yml` scope-enum and `commitlint.config.cjs`
- The dev-flow system generates PR titles with goal-specific scopes (e.g. `feat(test05-vitest)`, `feat(cq05)`, `feat(size03)`) that were missing from the allowed list, causing Conventional Commits CI checks to fail on every health-goal PR
- Unblocks PRs #2243, #2247, and future goal-tracking PRs

## Test plan
- [x] `chore(ci)` type and `ci` scope are valid → Conventional Commits should pass on this PR itself
- [x] No new code-quality violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G2r1xaHJAVYrAm6gftoJ7x