### PR TITLE
test(fe03): update plan-lint baseline expectation to 1018 [T001299]

### DIFF
--- a/tests/unit/plan-lint.bats
+++ b/tests/unit/plan-lint.bats
@@ -52,12 +52,12 @@ setup() {
 }
 
 @test "B1 math: baselined file uses max(limit, baseline.metric)" {
-  # website/src/components/inbox/InboxApp.svelte is baselined at 1017 (> 500 .svelte limit) in baseline.json
+  # website/src/components/inbox/InboxApp.svelte is baselined at 1018 (> 500 .svelte limit) in baseline.json
   # (After T001155/G-RH01 Batch 2, scripts/backup-restore.sh is no longer in baseline.json
-  # because the refactor brought it under 500 LOC.)
+  # because the refactor brought it under 500 LOC. G-FE03 added browserLogger import → 1018.)
   run env PLAN_LINT_SELFTEST=1 bash "$LINT" effective_threshold "website/src/components/inbox/InboxApp.svelte"
   [ "$status" -eq 0 ]
-  [ "$output" = "1017" ]
+  [ "$output" = "1018" ]
 }
 
 @test "B1 math: residual_budget = threshold - wc -l on a live file" {


### PR DESCRIPTION
## Summary

- G-FE03 (`feat(fe03)` PR #2253) added a `browserLogger` import to `InboxApp.svelte`, raising it from 1017 to 1018 lines
- `baseline.json` was correctly updated to 1018 in that PR
- The test fixture in `tests/unit/plan-lint.bats` was not updated (commit was created after auto-merge)

## Test plan

- [x] `tests/unit/plan-lint.bats` now expects 1018 (matching current baseline.json)
- [x] `./tests/unit/lib/bats-core/bin/bats tests/unit/plan-lint.bats` → 13/13 ok

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01KadiLex2FBxSmVg18xZ3D1