### PR TITLE
chore(quality): add plan-lint W1/W2 advisories, CQ02 sub-gates, PR auto-title workflow

### DIFF
--- a/.claude/skills/references/plan-quality-gates.md
+++ b/.claude/skills/references/plan-quality-gates.md
@@ -64,6 +64,34 @@ Brand-Domains in Code-Snippets vorgeben.
 Jedes neue `k3d/*.yaml` muss in einer `kustomization.yaml` referenziert sein, jedes neue
 `scripts/*.sh`/`*.mjs` von Taskfile/CI/Doku/anderem Skript aus erreichbar — sonst Orphan-Violation.
 
+### CQ02 — Explizite `any`-Typen in `website/src` (Health-Goal)
+
+**Aktuelles Limit:** ≤ 200 explizite `any`-Verwendungen global (Gate: `tests/spec/g-cq02-any-types.bats`).
+
+Beim Plan-Schreiben für alle Dateien in `website/src/**`:
+
+```bash
+# Ist-Zählung vor der Änderung (Baseline für den Plan)
+grep -rn ': any\|<any>\|as any' website/src --include='*.ts' --include='*.svelte' --include='*.astro' | wc -l
+```
+
+**Pflicht:** Kein Plan darf die `any`-Anzahl erhöhen. Jede neue exportierte Funktion / jeder neue API-Handler muss typisiert sein — kein `as any`, kein `catch (e: any)`. Pläne, die `any`-Typen einführen müssen (z.B. Drittanbieter-Interop), MÜSSEN einen eigenen Task „CQ02: any-Typen eliminieren" enthalten.
+
+**Prüfbefehl für den Verify-Task:**
+```bash
+bash -c "count=\$(grep -rn ': any\|<any>\|as any' website/src --include='*.ts' --include='*.svelte' --include='*.astro' | wc -l | tr -d ' '); echo \"any count: \$count (limit: 200)\"; [ \$count -le 200 ]"
+```
+
+### Vitest-Abdeckung (Health-Goal)
+
+Jeder Plan, der in `website/src/lib/**` oder `website/src/pages/api/**` neue Dateien anlegt oder bestehende wesentlich ändert, MUSS mindestens einen Vitest-Test-Task enthalten:
+
+- **Neue Lib-Datei** (`website/src/lib/<name>.ts`) → zugehöriger Test in `website/src/lib/__tests__/<name>.test.ts` (oder in der nächstgelegenen bestehenden Test-Datei erweitern, bevorzugt).
+- **Neuer API-Endpunkt** (`website/src/pages/api/**`) → Vitest-Test im zugehörigen Test-Bundle (`website/src/**/__tests__/`).
+- **Keine Test-Datei anlegen** ohne den `task test:inventory`-Schritt im Plan (CI-Inventar-Check flägt neue Tests).
+
+**Abweichung explizit begründen:** Wenn ein Plan `.ts`/`.svelte`-Dateien ändert aber bewusst KEINEN neuen Vitest-Test braucht (rein konfigurativ, Refactor ohne Logikänderung), muss der Plan einen Kommentar enthalten: `<!-- vitest: kein neuer Test nötig, weil … -->`.
+
 ### Weitere CI-Gates (Pflicht im finalen Verifikations-Task jedes Plans)
 
 Der letzte Task jedes Plans MUSS diese Kommandos als Steps enthalten:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -347,6 +347,7 @@ jobs:
             openspec
             mentolder-web
             skills
+            quality
             test01
             test02
             test03

--- a/.github/workflows/pr-auto-title.yml
+++ b/.github/workflows/pr-auto-title.yml
@@ -1,0 +1,122 @@
+name: PR Auto-Title
+
+# Automatically renames newly-opened PRs whose titles don't follow the
+# Conventional Commits format enforced by the commit-lint required check.
+# Derives type (feat/fix/chore/…) and scope from the branch name so the
+# PR passes the amannn/action-semantic-pull-request gate without human
+# intervention.
+#
+# Only fires on `opened` — avoids loops on synchronize/edited and does not
+# override titles that were already manually set to a valid format.
+#
+# Security model: all untrusted GitHub context values (pr.title, head_ref,
+# pr.number) are passed via env:, never interpolated directly into run:
+# commands. PR_NUMBER is validated as numeric before use in the API path.
+# BRANCH is sanitized to [a-zA-Z0-9/_-] before case/sed/grep use.
+# PR_TITLE is passed only as stdin to grep (static pattern), never as a
+# grep pattern argument.
+
+on:
+  pull_request:
+    types: [opened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  auto-title:
+    name: Auto-title PR from branch name
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    # Skip bots (renovate, release-please) — they set correct titles already.
+    if: >
+      github.actor != 'renovate[bot]' &&
+      github.actor != 'github-actions[bot]' &&
+      github.actor != 'release-please[bot]'
+    steps:
+      - name: Check and fix PR title
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          BRANCH_RAW: ${{ github.head_ref }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          # ── 0. Validate / sanitize untrusted inputs ────────────────────────
+          # PR_NUMBER must be numeric (guards the REST API path).
+          if ! printf '%s' "$PR_NUMBER" | grep -qE '^[0-9]+$'; then
+            echo "FATAL: PR_NUMBER is not numeric: $PR_NUMBER" >&2
+            exit 1
+          fi
+
+          # BRANCH: strip any character outside [a-zA-Z0-9/_-] to prevent
+          # shell metacharacter injection from github.head_ref.
+          BRANCH="${BRANCH_RAW//[^a-zA-Z0-9\/_-]/}"
+          if [[ -z "$BRANCH" ]]; then
+            echo "FATAL: BRANCH is empty after sanitization (raw: $BRANCH_RAW)" >&2
+            exit 1
+          fi
+
+          echo "PR title : $PR_TITLE"
+          echo "Branch   : $BRANCH"
+
+          # ── 1. Check if the existing title is already valid ────────────────
+          # Pattern: <type>[(<scope>)][!]: <subject>
+          # PR_TITLE is passed as stdin to grep; the pattern is static.
+          if printf '%s' "$PR_TITLE" | grep -qP '^(feat|fix|chore|docs|refactor|test|build|ci|perf|revert)(\([a-z0-9][a-z0-9-]*\))?!?: .{1,}'; then
+            echo "✅ PR title already follows Conventional Commits — no rename needed."
+            exit 0
+          fi
+
+          echo "⚠️  PR title does not match Conventional Commits. Deriving title from branch name…"
+
+          # ── 2. Derive type from branch prefix ──────────────────────────────
+          case "$BRANCH" in
+            feature/*)  TYPE="feat"    ; SLUG="${BRANCH#feature/}" ;;
+            fix/*)      TYPE="fix"     ; SLUG="${BRANCH#fix/}" ;;
+            chore/*)    TYPE="chore"   ; SLUG="${BRANCH#chore/}" ;;
+            docs/*)     TYPE="docs"    ; SLUG="${BRANCH#docs/}" ;;
+            test/*)     TYPE="test"    ; SLUG="${BRANCH#test/}" ;;
+            refactor/*) TYPE="refactor"; SLUG="${BRANCH#refactor/}" ;;
+            perf/*)     TYPE="perf"    ; SLUG="${BRANCH#perf/}" ;;
+            ci/*)       TYPE="ci"      ; SLUG="${BRANCH#ci/}" ;;
+            *)          TYPE="chore"   ; SLUG="$BRANCH" ;;
+          esac
+
+          # ── 3. Try to extract a scope from the slug ────────────────────────
+          # Slug patterns we recognise:
+          #   g-fe03-structured-logger  → scope=fe03
+          #   cq02-any-types            → scope=cq02
+          #   T001234-some-fix          → no scope (ticket ref, not a spec code)
+          #   plain-description         → no scope
+          # SLUG is sanitized (alphanumeric + hyphens only after BRANCH sanitization).
+          SCOPE=""
+          # Pattern: optional "g-" then 2-4 alpha chars + 2-3 digits (OpenSpec category code)
+          if printf '%s' "$SLUG" | grep -qP '^(?:g-)?([a-z]{1,4}\d{2,3})-'; then
+            SCOPE=$(printf '%s' "$SLUG" | sed -nP 's/^(?:g-)?([a-z]{1,4}\d{2,3})-.*/\1/p')
+          fi
+
+          # ── 4. Build the subject from the slug (replace hyphens with spaces) ──
+          # Strip the scope prefix (and optional "g-" prefix) if we extracted one.
+          if [[ -n "$SCOPE" ]]; then
+            SUBJECT_SLUG=$(printf '%s' "$SLUG" | sed -E "s|^(g-)?${SCOPE}-||")
+          else
+            SUBJECT_SLUG="$SLUG"
+          fi
+          SUBJECT=$(printf '%s' "$SUBJECT_SLUG" | tr '-' ' ')
+
+          # ── 5. Compose the new title ───────────────────────────────────────
+          if [[ -n "$SCOPE" ]]; then
+            NEW_TITLE="${TYPE}(${SCOPE}): ${SUBJECT}"
+          else
+            NEW_TITLE="${TYPE}: ${SUBJECT}"
+          fi
+
+          echo "📝 New title: $NEW_TITLE"
+
+          # ── 6. Apply via REST (gh pr edit can fail on Projects Classic) ────
+          # PR_NUMBER is validated numeric above; REPO is a trusted context value.
+          gh api -X PATCH "repos/${REPO}/pulls/${PR_NUMBER}" -f title="$NEW_TITLE"
+          echo "✅ PR title updated to: $NEW_TITLE"

--- a/openspec/specs/size04-loc-velocity.md
+++ b/openspec/specs/size04-loc-velocity.md
@@ -1,0 +1,7 @@
+# size04-loc-velocity
+
+## Purpose
+
+SSOT spec.
+
+## Requirements

--- a/openspec/specs/size04-loc-velocity.md
+++ b/openspec/specs/size04-loc-velocity.md
@@ -2,6 +2,24 @@
 
 ## Purpose
 
-SSOT spec.
+CI gate that tracks lines-of-code growth velocity and warns when a PR introduces
+more than a configurable threshold of new LOC per commit.
 
 ## Requirements
+
+### Requirement: LOC Velocity Warning Threshold
+
+The CI gate SHALL warn (non-blocking) when a PR introduces more than the configured
+`warn_pct` increase in total LOC compared to the committed `loc-budget.json` baseline.
+
+#### Scenario: PR within budget passes silently
+
+- **GIVEN** a PR increases total LOC by less than `warn_pct` percent
+- **WHEN** the CI LOC gate runs
+- **THEN** the gate exits 0 with no warning output
+
+#### Scenario: PR exceeding warn threshold emits advisory
+
+- **GIVEN** a PR increases total LOC by more than `warn_pct` percent
+- **WHEN** the CI LOC gate runs
+- **THEN** the gate exits 0 but logs a warning message indicating the delta

--- a/scripts/plan-lint.sh
+++ b/scripts/plan-lint.sh
@@ -140,6 +140,20 @@ while IFS= read -r path; do
   fi
 done < <(grep -oE '`[A-Za-z0-9_./-]+\.(sh|bash|ts|tsx|js|jsx|mjs|mts|cjs|py|svelte|astro|java|php)`' <<<"$PLAN_PROSE" | tr -d '`' | sort -u)
 
+# === W1: Vitest advisory — website/src .ts/.svelte/.astro files without a test mention ===
+# If the plan lists website/src lib or API files but never mentions vitest/test, warn.
+if grep -qE '`website/src/(lib|pages/api)/[^`]+\.(ts|svelte|astro)`' <<<"$PLAN_PROSE"; then
+  if ! grep -qiE 'vitest|\.test\.ts|__tests__|test:inventory' <<<"$PLAN_PROSE"; then
+    warn "W1: plan touches website/src lib/api files but mentions no Vitest test — add a test task or a '<!-- vitest: kein neuer Test nötig, weil … -->' comment"
+  fi
+fi
+
+# === W2: CQ02 advisory — new `any` usage planned in website/src ===
+# Warn if the plan's prose or code snippets suggest introducing `: any` / `as any`.
+if grep -qE ': any\b|as any\b|<any>' "$PLAN"; then
+  warn "W2: plan contains explicit 'any' usage — review CQ02 gate (limit ≤200 in website/src); ensure no net increase"
+fi
+
 # === G1: granularity warning — a single task touching >3 files (warn only) ===
 # Count `path` tokens inside each "## Task" block; warn if any block lists >3.
 while IFS= read -r g; do warn "${g/G1:/G1: }"; done < <(awk '

--- a/tests/spec/g-cq02-any-types.bats
+++ b/tests/spec/g-cq02-any-types.bats
@@ -1,8 +1,7 @@
 #!/usr/bin/env bats
 # SSOT: openspec/changes/cq02-any-types-200/proposal.md
 # G-CQ02: Explizite any-Verwendungen in website/src auf ≤200 reduzieren.
-# RED  (pre-impl):  463 > 200 → FAIL
-# GREEN (post-impl): ≤200     → PASS
+# GREEN (post-impl): ≤200 → PASS
 
 setup() {
   REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
@@ -13,4 +12,19 @@ setup() {
     --include='*.ts' --include='*.svelte' --include='*.astro' | wc -l | tr -d ' '"
   echo "any count: $output (limit: 200)"
   [ "$output" -le 200 ]
+}
+
+@test "G-CQ02: monitoring.ts has no more than 2 explicit any (was 13)" {
+  count=$(grep -c ': any\|<any>\|as any' \
+    "$REPO_ROOT/website/src/pages/api/admin/monitoring.ts" || true)
+  echo "monitoring.ts any count: $count (target: <=2)"
+  [ "$count" -le 2 ]
+}
+
+@test "G-CQ02: catch-blocks in admin API use err: unknown not err: any" {
+  hits=$(grep -rn 'catch (err: any)\|catch (error: any)' \
+    "$REPO_ROOT/website/src/pages/api/admin" --include='*.ts' \
+    | wc -l | tr -d ' ')
+  echo "remaining err: any catch blocks: $hits (target: 0)"
+  [ "$hits" -eq 0 ]
 }


### PR DESCRIPTION
## Summary
- `scripts/plan-lint.sh`: W1 advisory (Vitest warning for lib/api plans without test mention), W2 advisory (warn on `any` usage in plan prose)
- `.claude/skills/references/plan-quality-gates.md`: document CQ02 any-type limit (≤200) and Vitest coverage rules for plan authors
- `tests/spec/g-cq02-any-types.bats`: fix SSOT path; add stricter sub-gates for monitoring.ts (≤2 any) and admin catch-blocks (0 err:any)
- `.github/workflows/pr-auto-title.yml`: auto-title newly-opened PRs from branch name (Conventional Commits)
- `openspec/specs/size04-loc-velocity.md`: stub spec for LOC velocity gate

## Test plan
- [ ] CI must pass (plan-lint, BATS, freshness checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KadiLex2FBxSmVg18xZ3D1