### PR TITLE
fix(website): add $lib path alias to tsconfig.json for astro check

### DIFF
--- a/website/tsconfig.json
+++ b/website/tsconfig.json
@@ -3,6 +3,9 @@
   "compilerOptions": {
     "verbatimModuleSyntax": true,
     "allowImportingTsExtensions": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "paths": {
+      "$lib/*": ["./src/lib/*"]
+    }
   }
 }


### PR DESCRIPTION
## Summary
- `website/tsconfig.json`: add `$lib/*` → `./src/lib/*` to `compilerOptions.paths`

The Vite alias was set in `astro.config.mjs` but `astro check` (TypeScript compiler) couldn't resolve `$lib/browser-logger` imports, causing 2 errors in `rechnungen.astro` and `systemtest/board.astro`. The fix registers the alias in tsconfig so the TypeScript language server resolves it correctly.

## Test plan
- [ ] `npx astro check` → 0 errors ✓ (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01KadiLex2FBxSmVg18xZ3D1