### PR TITLE
fix(website): copy pnpm-workspace.yaml in Dockerfile to fix frozen-lockfile builds

### DIFF
--- a/website/Dockerfile
+++ b/website/Dockerfile
@@ -12,8 +12,11 @@ ENV PNPM_HOME=/pnpm
 ENV PATH=/pnpm:$PATH
 RUN corepack enable && corepack prepare pnpm@10.15.0 --activate
 
-# Copy ONLY the manifest + lockfile first so dependency layer caches cleanly.
-COPY website/package.json website/pnpm-lock.yaml ./
+# Copy ONLY the manifest + lockfile + workspace config first so dependency layer caches cleanly.
+# pnpm-workspace.yaml must be present alongside pnpm-lock.yaml — it contains the
+# overrides section that the lockfile was generated with; omitting it causes
+# ERR_PNPM_LOCKFILE_CONFIG_MISMATCH on --frozen-lockfile installs.
+COPY website/package.json website/pnpm-lock.yaml website/pnpm-workspace.yaml ./
 RUN --mount=type=cache,target=/pnpm/store pnpm install --frozen-lockfile
 
 COPY website/ .


### PR DESCRIPTION
## Problem

`build-website.yml` schlägt seit mindestens 3 Runs fehl mit:
```
ERR_PNPM_LOCKFILE_CONFIG_MISMATCH  Cannot proceed with the frozen installation.
The current "overrides" configuration doesn't match the value found in the lockfile
```

## Root Cause

Das Dockerfile kopiert nur `package.json` + `pnpm-lock.yaml`, aber **nicht** `pnpm-workspace.yaml`. Seit pnpm v11 wanderten die `overrides` (yaml, esbuild, undici, ws, js-yaml, @babel/core) aus dem `"pnpm"` Block in `package.json` in `pnpm-workspace.yaml`. Das Lockfile wurde mit den Overrides generiert — ohne die Workspace-Config schlägt `--frozen-lockfile` im Container fehl.

## Fix

```dockerfile
COPY website/package.json website/pnpm-lock.yaml website/pnpm-workspace.yaml ./
```

## Test plan

- [ ] `build-website.yml` schlägt nicht mehr mit LOCKFILE_CONFIG_MISMATCH fehl
- [ ] `build-website-korczewski.yml` unbeeinflusst (war bereits grün)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01KadiLex2FBxSmVg18xZ3D1