### PR TITLE
fix(mentolder-web): fix React error #310 on edit homepage page

### DIFF
--- a/mentolder-web/src/pages/admin/HomepageEditorPage.tsx
+++ b/mentolder-web/src/pages/admin/HomepageEditorPage.tsx
@@ -137,6 +137,15 @@ export function HomepageEditorPage() {
     }
   }, [loading, authenticated]);
 
+  // Escape key closes fullscreen preview — must be here (before early returns) to
+  // satisfy Rules of Hooks (hooks cannot appear after conditional returns).
+  useEffect(() => {
+    if (!previewFullscreen) return;
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') setPreviewFullscreen(false); };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [previewFullscreen]);
+
   if (loading) return <PageShell>Lädt…</PageShell>;
   if (authenticated && !isAdmin) return <Navigate to="/" replace />;
   if (!authenticated) return <PageShell>Weiterleitung zum Login…</PageShell>;
@@ -184,13 +193,6 @@ export function HomepageEditorPage() {
     }
     setConfirmOpen(false);
   };
-
-  useEffect(() => {
-    if (!previewFullscreen) return;
-    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') setPreviewFullscreen(false); };
-    window.addEventListener('keydown', onKey);
-    return () => window.removeEventListener('keydown', onKey);
-  }, [previewFullscreen]);
 
   return (
     <>


### PR DESCRIPTION
## Summary
- The `useEffect` for the fullscreen preview Escape-key listener was placed **after** conditional early returns (loading/auth guards), violating React's Rules of Hooks
- React counts hooks per render; when an early return was hit, the hook count changed between renders → React error #310 ("rendered more hooks than during the previous render")
- Fix: moved the `useEffect` above all early returns, alongside the other two hooks in the component

## Test plan
- [ ] Navigate to `react.mentolder.de` → "Edit Homepage" link should load without error
- [ ] Open fullscreen preview, press Escape — should close correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014DHyvjCqjQHDAehbpVuSLS