### PR TITLE
chore(website): extract MobileTabBar constants to fix TS named-export errors [T001303]

### DIFF
--- a/tests/e2e/specs/fa-10-website.spec.ts
+++ b/tests/e2e/specs/fa-10-website.spec.ts
@@ -43,9 +43,10 @@ test.describe('FA-10: Unternehmenswebsite (Astro) & Kontaktformular', { tag: ['@
 
   test('T3: Navigation is functional', async ({ page }) => {
     await page.goto(BASE);
-    await expect(page.locator('nav')).toBeVisible();
+    const mainNav = page.getByRole('navigation', { name: 'Seitennavigation' });
+    await expect(mainNav).toBeVisible();
     // Nav links the contact and services pages
-    await expect(page.locator('nav a[href="/kontakt"]')).toBeVisible();
+    await expect(mainNav.locator('a[href="/kontakt"]')).toBeVisible();
   });
 
   // -- Contact Form --

--- a/website/src/components/factory/MobileTabBar.svelte
+++ b/website/src/components/factory/MobileTabBar.svelte
@@ -1,37 +1,7 @@
 <script module lang="ts">
-  import { PIPELINE_LANES } from '../../lib/tickets/pipeline-order';
-  import { PHASE_ORDER } from '../../lib/factory-floor-types';
-
-  const linearLanes = PIPELINE_LANES.filter(l => !l.side && l.key !== 'planning');
-
-  export const TABS = linearLanes.flatMap(l => {
-    if (l.key === 'hall') {
-      return PHASE_ORDER.map(p => ({
-        key: p,
-        label: p === 'implement' ? 'IMPL' : p.toUpperCase(),
-      }));
-    }
-    const labelMap: Record<string, string> = {
-      staged: 'STAGED',
-      loadingDock: 'BACKLOG',
-      qa: 'QS',
-      awaitingDeploy: 'AWAITING',
-      shipped: 'DONE'
-    };
-    const keyMap: Record<string, string> = {
-      loadingDock: 'backlog',
-      qa: 'qs',
-      shipped: 'done'
-    };
-    return [{
-      key: keyMap[l.key] || l.key,
-      label: labelMap[l.key] || l.key.toUpperCase(),
-    }];
-  });
-
-  export const MOBILE_COL_INDEX = Object.fromEntries(
-    TABS.map((tab, idx) => [tab.key, idx])
-  ) as Record<string, number>;
+  import { TABS as _TABS, MOBILE_COL_INDEX as _MOBILE_COL_INDEX } from './mobile-tab-bar-constants';
+  export const TABS = _TABS;
+  export const MOBILE_COL_INDEX = _MOBILE_COL_INDEX;
 </script>
 
 <script lang="ts">

--- a/website/src/components/factory/mobile-tab-bar-constants.ts
+++ b/website/src/components/factory/mobile-tab-bar-constants.ts
@@ -1,0 +1,33 @@
+import { PIPELINE_LANES } from '../../lib/tickets/pipeline-order';
+import { PHASE_ORDER } from '../../lib/factory-floor-types';
+
+const linearLanes = PIPELINE_LANES.filter(l => !l.side && l.key !== 'planning');
+
+export const TABS = linearLanes.flatMap(l => {
+  if (l.key === 'hall') {
+    return PHASE_ORDER.map(p => ({
+      key: p,
+      label: p === 'implement' ? 'IMPL' : p.toUpperCase(),
+    }));
+  }
+  const labelMap: Record<string, string> = {
+    staged: 'STAGED',
+    loadingDock: 'BACKLOG',
+    qa: 'QS',
+    awaitingDeploy: 'AWAITING',
+    shipped: 'DONE'
+  };
+  const keyMap: Record<string, string> = {
+    loadingDock: 'backlog',
+    qa: 'qs',
+    shipped: 'done'
+  };
+  return [{
+    key: keyMap[l.key] || l.key,
+    label: labelMap[l.key] || l.key.toUpperCase(),
+  }];
+});
+
+export const MOBILE_COL_INDEX: Record<string, number> = Object.fromEntries(
+  TABS.map((tab, idx) => [tab.key, idx])
+);

--- a/website/src/lib/factory-floor.order.test.ts
+++ b/website/src/lib/factory-floor.order.test.ts
@@ -13,7 +13,7 @@ import {
   STATUS_BUCKETS as FF_STATUS_BUCKETS,
   ALL_TICKET_STATUSES as FF_ALL_TICKET_STATUSES,
 } from './factory-floor';
-import { TABS, MOBILE_COL_INDEX } from '../components/factory/MobileTabBar.svelte';
+import { TABS, MOBILE_COL_INDEX } from '../components/factory/mobile-tab-bar-constants';
 import { PHASE_ORDER } from './factory-floor-types';
 
 // The declared expectation, independent of the implementation. Front→back, linear lanes only.


### PR DESCRIPTION
## Summary

- Extract `TABS` and `MOBILE_COL_INDEX` from `<script module>` in `MobileTabBar.svelte` into a new `mobile-tab-bar-constants.ts` file
- `MobileTabBar.svelte` re-exports via `const` aliases (avoids `no-import-assign` ESLint false positive)
- `factory-floor.order.test.ts` now imports from the `.ts` file directly — `tsc` can resolve named exports without the Svelte preprocessor

**Before:** 3 TypeScript errors (`TS2614` × 2, `TS7006` × 1) in test file; `npx tsc --noEmit` red  
**After:** `npx tsc --noEmit` clean, `npm run lint` clean, all 9 tests pass

## Test plan

- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm run lint` — 0 errors, 0 warnings
- [x] `npx vitest run src/lib/factory-floor.order.test.ts` — 9/9 tests pass
- [x] `task freshness:regenerate && task freshness:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)