### PR TITLE
fix(infra): add securityContext to 3 deployments [T001295]

### DIFF
--- a/docs/code-quality/loc-budget.json
+++ b/docs/code-quality/loc-budget.json
@@ -1,8 +1,8 @@
 {
-  "total_lines": 507823,
-  "file_count": 3904,
-  "commit": "440550f3",
-  "measured_at": "2026-06-28T09:45:44.179Z",
+  "total_lines": 507649,
+  "file_count": 3900,
+  "commit": "1b3e3b23",
+  "measured_at": "2026-06-28T09:18:46.102Z",
   "thresholds": {
     "warn_pct": 2,
     "fail_pct": 15,

--- a/docs/code-quality/loc-budget.json
+++ b/docs/code-quality/loc-budget.json
@@ -1,8 +1,8 @@
 {
-  "total_lines": 507649,
+  "total_lines": 507661,
   "file_count": 3900,
-  "commit": "1b3e3b23",
-  "measured_at": "2026-06-28T09:18:46.102Z",
+  "commit": "251b7d4e",
+  "measured_at": "2026-06-28T09:20:54.039Z",
   "thresholds": {
     "warn_pct": 2,
     "fail_pct": 15,

--- a/docs/code-quality/loc-budget.json
+++ b/docs/code-quality/loc-budget.json
@@ -1,8 +1,8 @@
 {
-  "total_lines": 507827,
+  "total_lines": 507837,
   "file_count": 3905,
-  "commit": "92a6218d",
-  "measured_at": "2026-06-28T09:56:41.998Z",
+  "commit": "d060e797",
+  "measured_at": "2026-06-28T09:59:09.442Z",
   "thresholds": {
     "warn_pct": 2,
     "fail_pct": 15,

--- a/k3d/livekit.yaml
+++ b/k3d/livekit.yaml
@@ -481,6 +481,8 @@ spec:
             limits:
               memory: 2Gi
               cpu: 2000m
+          securityContext:
+            allowPrivilegeEscalation: false
           volumeMounts:
             - name: recordings
               mountPath: /recordings

--- a/k3d/sealed-secrets-controller.yaml
+++ b/k3d/sealed-secrets-controller.yaml
@@ -96,6 +96,12 @@ spec:
           limits:
             cpu: "500m"
             memory: 256Mi
+        securityContext:
+          runAsNonRoot: true
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
 ---
 apiVersion: v1
 kind: Service

--- a/k3d/sessions-server.yaml
+++ b/k3d/sessions-server.yaml
@@ -71,6 +71,8 @@ spec:
             limits:
               cpu: 100m
               memory: 64Mi
+          securityContext:
+            allowPrivilegeEscalation: false
       volumes:
         - name: nginx-conf
           configMap:

--- a/k3d/sessions-server.yaml
+++ b/k3d/sessions-server.yaml
@@ -93,3 +93,4 @@ spec:
   ports:
     - port: 80
       targetPort: 80
+

--- a/k3d/sessions-server.yaml
+++ b/k3d/sessions-server.yaml
@@ -93,4 +93,3 @@ spec:
   ports:
     - port: 80
       targetPort: 80
-


### PR DESCRIPTION
Adds container-level securityContext to three Deployments that were missing it, closing G-K8S03.

- k3d/sessions-server.yaml: allowPrivilegeEscalation: false
- k3d/livekit.yaml (livekit-egress): allowPrivilegeEscalation: false
- k3d/sealed-secrets-controller.yaml: runAsNonRoot: true, allowPrivilegeEscalation: false, capabilities.drop: [ALL]

Closes T001295.