### PR TITLE
fix(infra): pin all foreign images with @sha256 digests [T001294]

### DIFF
--- a/k3d/admin-actions-cronjobs.yaml
+++ b/k3d/admin-actions-cronjobs.yaml
@@ -18,7 +18,7 @@ spec:
           restartPolicy: OnFailure
           containers:
             - name: psql
-              image: postgres:16-alpine
+              image: postgres:16-alpine@sha256:e013e867e712fec275706a6c51c966f0bb0c93cfa8f51000f85a15f9865a28cb
               resources:
                 requests:
                   cpu: "50m"
@@ -69,7 +69,7 @@ spec:
           restartPolicy: OnFailure
           containers:
             - name: psql
-              image: postgres:16-alpine
+              image: postgres:16-alpine@sha256:e013e867e712fec275706a6c51c966f0bb0c93cfa8f51000f85a15f9865a28cb
               resources:
                 requests:
                   cpu: "50m"
@@ -116,7 +116,7 @@ spec:
           restartPolicy: OnFailure
           containers:
             - name: sessions-purge
-              image: curlimages/curl:8.7.1
+              image: curlimages/curl:8.7.1@sha256:25d29daeb9b14b89e2fa8cc17c70e4b188bca1466086907c2d9a4b56b59d8e21
               resources:
                 requests:
                   cpu: "50m"

--- a/k3d/backup-cronjob.yaml
+++ b/k3d/backup-cronjob.yaml
@@ -45,7 +45,7 @@ spec:
             - name: backup
               # Debian-based image: has openssl pre-installed (unlike postgres-alpine).
               # IfNotPresent avoids pulling on every run in case DNS is unreliable.
-              image: pgvector/pgvector:0.8.0-pg16
+              image: pgvector/pgvector:0.8.0-pg16@sha256:a132765ec351c65111b5b675928a3a0515a466a40f97277329db8b8209ad8bc9
               imagePullPolicy: IfNotPresent
               env:
                 - name: NEXTCLOUD_DB_PASSWORD
@@ -184,7 +184,7 @@ spec:
             - name: filen-upload
               # Uses @filen/cli (Node.js) — rclone has no native Filen backend and
               # webdav.filen.io resolves to 127.0.0.1 (local desktop-app only).
-              image: node:22-alpine
+              image: node:22-alpine@sha256:16e22a550f3863206a3f701448c45f7912c6896a62de43add43bb9c86130c3e2
               imagePullPolicy: IfNotPresent
               securityContext:
                 allowPrivilegeEscalation: false

--- a/k3d/coturn-stack/coturn.yaml
+++ b/k3d/coturn-stack/coturn.yaml
@@ -35,7 +35,7 @@ spec:
         kubernetes.io/hostname: ${TURN_NODE}
       containers:
         - name: coturn
-          image: coturn/coturn:4.9-alpine
+          image: coturn/coturn:4.9-alpine@sha256:229f87ef2428336ca2f4b4967a961cc6ad7aceb79277bc51f5a179606228d45f
           imagePullPolicy: Always
           # TURN_SECRET is sourced from coturn-secrets at runtime so the
           # same manifests work with dev literals and production-rotated

--- a/k3d/coturn-stack/janus.yaml
+++ b/k3d/coturn-stack/janus.yaml
@@ -70,7 +70,7 @@ spec:
         kubernetes.io/hostname: ${TURN_NODE}
       containers:
         - name: janus
-          image: canyan/janus-gateway:master_cefca79700bdadd32d759ce65ba3805552a4d312
+          image: canyan/janus-gateway:master_cefca79700bdadd32d759ce65ba3805552a4d312@sha256:cddf2da2dba7947c2a3aa7b2e77b363b1200cd6874dbebe32b5148fe187a0d89
           imagePullPolicy: Always
           command: ["/usr/local/bin/janus", "--configs-folder", "/etc/janus"]
           ports:

--- a/k3d/cronjob-dunning-detection.yaml
+++ b/k3d/cronjob-dunning-detection.yaml
@@ -20,7 +20,7 @@ spec:
               type: RuntimeDefault
           containers:
           - name: detector
-            image: curlimages/curl:8.7.1
+            image: curlimages/curl:8.7.1@sha256:25d29daeb9b14b89e2fa8cc17c70e4b188bca1466086907c2d9a4b56b59d8e21
             securityContext:
               allowPrivilegeEscalation: false
               runAsNonRoot: true

--- a/k3d/cronjob-monthly-billing.yaml
+++ b/k3d/cronjob-monthly-billing.yaml
@@ -22,7 +22,7 @@ spec:
               type: RuntimeDefault
           containers:
             - name: trigger
-              image: curlimages/curl:8.7.1
+              image: curlimages/curl:8.7.1@sha256:25d29daeb9b14b89e2fa8cc17c70e4b188bca1466086907c2d9a4b56b59d8e21
               securityContext:
                 allowPrivilegeEscalation: false
                 runAsNonRoot: true

--- a/k3d/cronjob-scheduled-publish.yaml
+++ b/k3d/cronjob-scheduled-publish.yaml
@@ -23,7 +23,7 @@ spec:
               type: RuntimeDefault
           containers:
             - name: publish
-              image: curlimages/curl:8.7.1
+              image: curlimages/curl:8.7.1@sha256:25d29daeb9b14b89e2fa8cc17c70e4b188bca1466086907c2d9a4b56b59d8e21
               securityContext:
                 allowPrivilegeEscalation: false
                 runAsNonRoot: true

--- a/k3d/cronjob-systemtest-cleanup.yaml
+++ b/k3d/cronjob-systemtest-cleanup.yaml
@@ -53,7 +53,7 @@ spec:
               type: RuntimeDefault
           containers:
             - name: trigger
-              image: curlimages/curl:8.7.1
+              image: curlimages/curl:8.7.1@sha256:25d29daeb9b14b89e2fa8cc17c70e4b188bca1466086907c2d9a4b56b59d8e21
               securityContext:
                 allowPrivilegeEscalation: false
                 runAsNonRoot: true
@@ -117,7 +117,7 @@ spec:
               type: RuntimeDefault
           containers:
             - name: trigger
-              image: curlimages/curl:8.7.1
+              image: curlimages/curl:8.7.1@sha256:25d29daeb9b14b89e2fa8cc17c70e4b188bca1466086907c2d9a4b56b59d8e21
               securityContext:
                 allowPrivilegeEscalation: false
                 runAsNonRoot: true
@@ -187,7 +187,7 @@ spec:
               type: RuntimeDefault
           containers:
             - name: trigger
-              image: curlimages/curl:8.7.1
+              image: curlimages/curl:8.7.1@sha256:25d29daeb9b14b89e2fa8cc17c70e4b188bca1466086907c2d9a4b56b59d8e21
               securityContext:
                 allowPrivilegeEscalation: false
                 runAsNonRoot: true

--- a/k3d/dev-cluster/kube-vip-ds.yaml
+++ b/k3d/dev-cluster/kube-vip-ds.yaml
@@ -51,7 +51,7 @@ spec:
           value: 10.0.0.20
         - name: prometheus_server
           value: :2112
-        image: ghcr.io/kube-vip/kube-vip:v0.8.7
+        image: ghcr.io/kube-vip/kube-vip:v0.8.7@sha256:32829cc6f8630eba4e1b5e4df5bcbc34c767e70703d26e64a0f7317951c7b517
         imagePullPolicy: IfNotPresent
         name: kube-vip
         securityContext:

--- a/k3d/dev-stack/oauth2-proxy-brainstorm.yaml
+++ b/k3d/dev-stack/oauth2-proxy-brainstorm.yaml
@@ -52,7 +52,7 @@ spec:
           type: RuntimeDefault
       initContainers:
         - name: write-cookie-secret
-          image: busybox:1.38.0
+          image: busybox:1.38.0@sha256:fd8d9aa63ba2f0982b5304e1ee8d3b90a210bc1ffb5314d980eb6962f1a9715d
           imagePullPolicy: Always
           command: ["/bin/sh", "-c"]
           args:
@@ -80,7 +80,7 @@ spec:
               mountPath: /run/config
       containers:
         - name: oauth2-proxy
-          image: quay.io/oauth2-proxy/oauth2-proxy:v7.9.0
+          image: quay.io/oauth2-proxy/oauth2-proxy:v7.9.0@sha256:37c1570c0427e02fc7c947ef2c04e8995b8347b7abc9fcf1dbb4e376a4b221a7
           imagePullPolicy: Always
           args:
             - --config=/run/config/oauth2-extra.cfg

--- a/k3d/dev-stack/oauth2-proxy-dev.yaml
+++ b/k3d/dev-stack/oauth2-proxy-dev.yaml
@@ -34,7 +34,7 @@ spec:
           type: RuntimeDefault
       initContainers:
         - name: write-oauth2-config
-          image: busybox:1.38.0
+          image: busybox:1.38.0@sha256:fd8d9aa63ba2f0982b5304e1ee8d3b90a210bc1ffb5314d980eb6962f1a9715d
           command: ["/bin/sh", "-c"]
           # Write both the cookie secret and the OIDC client secret into the
           # config file from mounted Secret env vars, so neither lands as a
@@ -73,7 +73,7 @@ spec:
               mountPath: /run/config
       containers:
         - name: oauth2-proxy
-          image: quay.io/oauth2-proxy/oauth2-proxy:v7.9.0
+          image: quay.io/oauth2-proxy/oauth2-proxy:v7.9.0@sha256:37c1570c0427e02fc7c947ef2c04e8995b8347b7abc9fcf1dbb4e376a4b221a7
           args:
             - --config=/run/config/oauth2-extra.cfg
             - --provider=keycloak-oidc

--- a/k3d/dev-stack/oauth2-proxy-sessions.yaml
+++ b/k3d/dev-stack/oauth2-proxy-sessions.yaml
@@ -50,7 +50,7 @@ spec:
           type: RuntimeDefault
       initContainers:
         - name: write-cookie-secret
-          image: busybox:1.38.0
+          image: busybox:1.38.0@sha256:fd8d9aa63ba2f0982b5304e1ee8d3b90a210bc1ffb5314d980eb6962f1a9715d
           imagePullPolicy: Always
           command: ["/bin/sh", "-c"]
           args:
@@ -78,7 +78,7 @@ spec:
               mountPath: /run/config
       containers:
         - name: oauth2-proxy
-          image: quay.io/oauth2-proxy/oauth2-proxy:v7.9.0
+          image: quay.io/oauth2-proxy/oauth2-proxy:v7.9.0@sha256:37c1570c0427e02fc7c947ef2c04e8995b8347b7abc9fcf1dbb4e376a4b221a7
           imagePullPolicy: Always
           args:
             - --config=/run/config/oauth2-extra.cfg

--- a/k3d/dev-stack/shared-db-dev.yaml
+++ b/k3d/dev-stack/shared-db-dev.yaml
@@ -35,7 +35,7 @@ spec:
     spec:
       containers:
         - name: postgres
-          image: pgvector/pgvector:0.8.0-pg16
+          image: pgvector/pgvector:0.8.0-pg16@sha256:a132765ec351c65111b5b675928a3a0515a466a40f97277329db8b8209ad8bc9
           ports:
             - containerPort: 5432
               name: postgres
@@ -94,7 +94,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: init
-          image: pgvector/pgvector:0.8.0-pg16
+          image: pgvector/pgvector:0.8.0-pg16@sha256:a132765ec351c65111b5b675928a3a0515a466a40f97277329db8b8209ad8bc9
           env:
             - name: PGHOST
               value: shared-db-dev

--- a/k3d/dev-stack/sish.yaml
+++ b/k3d/dev-stack/sish.yaml
@@ -32,7 +32,7 @@ spec:
     spec:
       containers:
         - name: sish
-          image: antoniomika/sish:v2.22.1
+          image: antoniomika/sish:v2.22.1@sha256:7da476e26856961705b96b85c6d8b2c648cdf8c4d6992290c7a10d0dfd2d1e86
           args:
             - --domain=${PROD_DOMAIN}
             - --ssh-address=:2222

--- a/k3d/knowledge-ingest-cronjob.yaml
+++ b/k3d/knowledge-ingest-cronjob.yaml
@@ -297,7 +297,7 @@ spec:
                         values: [gekko-hetzner-2, gekko-hetzner-3, gekko-hetzner-4, pk-hetzner, pk-hetzner-2, pk-hetzner-3]
           initContainers:
             - name: npm-install
-              image: node:22-alpine
+              image: node:22-alpine@sha256:16e22a550f3863206a3f701448c45f7912c6896a62de43add43bb9c86130c3e2
               imagePullPolicy: IfNotPresent
               command: [sh, -c, "npm install pg --no-package-lock --silent --prefix /tmp && cp -r /tmp/node_modules/* /scripts/node_modules/"]
               volumeMounts:
@@ -313,7 +313,7 @@ spec:
                   memory: 256Mi
           containers:
             - name: ingest
-              image: node:22-alpine
+              image: node:22-alpine@sha256:16e22a550f3863206a3f701448c45f7912c6896a62de43add43bb9c86130c3e2
               imagePullPolicy: IfNotPresent
               command: [node, /scripts/ingest-prs.mjs]
               env:
@@ -381,7 +381,7 @@ spec:
                         values: [gekko-hetzner-2, gekko-hetzner-3, gekko-hetzner-4, pk-hetzner, pk-hetzner-2, pk-hetzner-3]
           containers:
             - name: ingest
-              image: node:22-alpine
+              image: node:22-alpine@sha256:16e22a550f3863206a3f701448c45f7912c6896a62de43add43bb9c86130c3e2
               imagePullPolicy: IfNotPresent
               command: [node, /scripts/ingest-markdown.mjs]
               volumeMounts:
@@ -428,7 +428,7 @@ spec:
                         values: [gekko-hetzner-2, gekko-hetzner-3, gekko-hetzner-4, pk-hetzner, pk-hetzner-2, pk-hetzner-3]
           initContainers:
             - name: npm-install
-              image: node:22-alpine
+              image: node:22-alpine@sha256:16e22a550f3863206a3f701448c45f7912c6896a62de43add43bb9c86130c3e2
               imagePullPolicy: IfNotPresent
               command: [sh, -c, "npm install pg --no-package-lock --silent --prefix /tmp && cp -r /tmp/node_modules/* /scripts/node_modules/"]
               volumeMounts:
@@ -444,7 +444,7 @@ spec:
                   memory: 256Mi
           containers:
             - name: ingest
-              image: node:22-alpine
+              image: node:22-alpine@sha256:16e22a550f3863206a3f701448c45f7912c6896a62de43add43bb9c86130c3e2
               imagePullPolicy: IfNotPresent
               command: [node, /scripts/ingest-bug-tickets.mjs]
               env:
@@ -514,7 +514,7 @@ spec:
                         values: [gekko-hetzner-2, gekko-hetzner-3, gekko-hetzner-4, pk-hetzner, pk-hetzner-2, pk-hetzner-3]
           initContainers:
             - name: npm-install
-              image: node:22-alpine
+              image: node:22-alpine@sha256:16e22a550f3863206a3f701448c45f7912c6896a62de43add43bb9c86130c3e2
               imagePullPolicy: IfNotPresent
               command: [sh, -c, "npm install pg --no-package-lock --silent --prefix /tmp && cp -r /tmp/node_modules/* /scripts/node_modules/"]
               volumeMounts:
@@ -530,7 +530,7 @@ spec:
                   memory: 256Mi
           containers:
             - name: ingest
-              image: node:22-alpine
+              image: node:22-alpine@sha256:16e22a550f3863206a3f701448c45f7912c6896a62de43add43bb9c86130c3e2
               imagePullPolicy: IfNotPresent
               command:
                 - sh

--- a/k3d/livekit.yaml
+++ b/k3d/livekit.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: redis
-          image: redis:7.4-alpine
+          image: redis:7.4-alpine@sha256:6ab0b6e7381779332f97b8ca76193e45b0756f38d4c0dcda72dbb3c32061ab99
           command: ["redis-server", "--save", "", "--appendonly", "no"]
           ports:
             - containerPort: 6379
@@ -183,7 +183,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: livekit
-          image: livekit/livekit-server:v1.11.0
+          image: livekit/livekit-server:v1.11.0@sha256:100b9a870616d02f5e3795b34e0b593b5054a26f8131a94fd3fa322ed3154b16
           args:
             - --config=/etc/livekit/config.yaml
           ports:
@@ -360,7 +360,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: ingress
-          image: livekit/ingress:v1.5.0
+          image: livekit/ingress:v1.5.0@sha256:2e1d3fcf10bfaebddaea74dc8b965410cda6377ed154451361b86ab3a9ee9f99
           ports:
             - name: rtmp
               containerPort: 1935
@@ -453,7 +453,7 @@ spec:
     spec:
       containers:
         - name: egress
-          image: livekit/egress:v1.9.0
+          image: livekit/egress:v1.9.0@sha256:d62f515668d56df24082ec722a7a78134bc14ff331a2c0402ac90e8fe0fe0067
           env:
             - name: EGRESS_CONFIG_BODY
               value: |

--- a/k3d/mailpit.yaml
+++ b/k3d/mailpit.yaml
@@ -24,7 +24,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: mailpit
-          image: axllent/mailpit:v1.29
+          image: axllent/mailpit:v1.29@sha256:757f22b56c1da03570afdb3d259effe5091018008a81bbedc8158cee7e16fdbc
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/k3d/monitoring/loki-rendered.yaml
+++ b/k3d/monitoring/loki-rendered.yaml
@@ -296,7 +296,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: loki
-          image: docker.io/grafana/loki:3.6.7
+          image: docker.io/grafana/loki:3.6.7@sha256:3c8fd3570dd9219951a60d3f919c7f31923d10baee578b77bc26c4a0b32d092d
           imagePullPolicy: IfNotPresent
           args:
             - -config.file=/etc/loki/config/config.yaml
@@ -345,7 +345,7 @@ spec:
               cpu: 100m
               memory: 256Mi
         - name: loki-sc-rules
-          image: quay.io/kiwigrid/k8s-sidecar:2.7.3
+          image: quay.io/kiwigrid/k8s-sidecar:2.7.3@sha256:694950d736c8b532eba4006527ccbdac98fefc9f30b3346ba2de50b6cad91c94
           imagePullPolicy: IfNotPresent
           env:
             - name: METHOD

--- a/k3d/monitoring/otel-collector.yaml
+++ b/k3d/monitoring/otel-collector.yaml
@@ -83,7 +83,7 @@ spec:
     spec:
       containers:
         - name: otel-collector
-          image: otel/opentelemetry-collector-contrib:0.145.0
+          image: otel/opentelemetry-collector-contrib:0.145.0@sha256:a7343f01869071ea3f4c5e1e97df1bb1b3c4d5c77247db80e053a80b9df530c4
           args: ["--config=/etc/otel/config.yaml"]
           env:
             - name: FACTORY_OTLP_TOKEN

--- a/k3d/monitoring/promtail-rendered.yaml
+++ b/k3d/monitoring/promtail-rendered.yaml
@@ -222,7 +222,7 @@ spec:
         runAsUser: 0
       containers:
         - name: promtail
-          image: "docker.io/grafana/promtail:3.5.1"
+          image: "docker.io/grafana/promtail:3.5.1@sha256:65bfae480b572854180c78f7dc567a4ad2ba548b0c410e696baa1e0fa6381299"
           imagePullPolicy: IfNotPresent
           args:
             - "-config.file=/etc/promtail/promtail.yaml"

--- a/k3d/nextcloud-redis.yaml
+++ b/k3d/nextcloud-redis.yaml
@@ -24,7 +24,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: redis
-          image: redis:7.4-alpine
+          image: redis:7.4-alpine@sha256:6ab0b6e7381779332f97b8ca76193e45b0756f38d4c0dcda72dbb3c32061ab99
           imagePullPolicy: Always
           args:
             - redis-server

--- a/k3d/nextcloud.yaml
+++ b/k3d/nextcloud.yaml
@@ -52,7 +52,7 @@ spec:
           type: RuntimeDefault
       initContainers:
         - name: fix-data-perms
-          image: busybox:1.38.0
+          image: busybox:1.38.0@sha256:fd8d9aa63ba2f0982b5304e1ee8d3b90a210bc1ffb5314d980eb6962f1a9715d
           imagePullPolicy: Always
           # Nextcloud refuses to start (HTTP 503) when the data dir is
           # world-readable. local-path provisions PVCs as 2777, so we
@@ -78,7 +78,7 @@ spec:
             - name: data
               mountPath: /var/www/html/data
         - name: fix-config-perms
-          image: busybox:1.38.0
+          image: busybox:1.38.0@sha256:fd8d9aa63ba2f0982b5304e1ee8d3b90a210bc1ffb5314d980eb6962f1a9715d
           imagePullPolicy: Always
           securityContext:
             runAsNonRoot: true
@@ -97,7 +97,7 @@ spec:
             - name: app
               mountPath: /var/www/html
         - name: copy-php-conf
-          image: nextcloud:33-apache
+          image: nextcloud:33-apache@sha256:476228e615088e7d2de4bd9a87187961dfbff1577a96ff07955ec35dbe18f3c9
           imagePullPolicy: Always
           securityContext:
             runAsNonRoot: true
@@ -117,7 +117,7 @@ spec:
               mountPath: /php-conf-d
       containers:
         - name: nextcloud
-          image: nextcloud:33-apache
+          image: nextcloud:33-apache@sha256:476228e615088e7d2de4bd9a87187961dfbff1577a96ff07955ec35dbe18f3c9
           imagePullPolicy: Always
           securityContext:
             readOnlyRootFilesystem: false
@@ -255,7 +255,7 @@ spec:
               cpu: "2"
         # ── Cron sidecar: runs php cron.php every 5 min ───────────────
         - name: nextcloud-cron
-          image: nextcloud:33-apache
+          image: nextcloud:33-apache@sha256:476228e615088e7d2de4bd9a87187961dfbff1577a96ff07955ec35dbe18f3c9
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false
@@ -326,7 +326,7 @@ spec:
         # then runs it. Reads DB + Redis config from the shared app PVC.
         # Apache in the main container proxies /push/ → localhost:7867.
         - name: notify-push
-          image: nextcloud:33-apache
+          image: nextcloud:33-apache@sha256:476228e615088e7d2de4bd9a87187961dfbff1577a96ff07955ec35dbe18f3c9
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/k3d/notify-unread-cronjob.yaml
+++ b/k3d/notify-unread-cronjob.yaml
@@ -20,7 +20,7 @@ spec:
               type: RuntimeDefault
           containers:
             - name: notify
-              image: curlimages/curl:8.7.1
+              image: curlimages/curl:8.7.1@sha256:25d29daeb9b14b89e2fa8cc17c70e4b188bca1466086907c2d9a4b56b59d8e21
               securityContext:
                 allowPrivilegeEscalation: false
                 runAsNonRoot: true

--- a/k3d/ntfy.yaml
+++ b/k3d/ntfy.yaml
@@ -31,7 +31,7 @@ spec:
           type: RuntimeDefault
       initContainers:
         - name: ntfy-init
-          image: binwiederhier/ntfy:v2.24.0
+          image: binwiederhier/ntfy:v2.24.0@sha256:f8a9b104313b87cc24ae4f775f39e6328205b57dff6ede3eaf098a91e5d79f59
           imagePullPolicy: Always
           command: ["/bin/sh", "-exc"]
           args:
@@ -81,7 +81,7 @@ spec:
               memory: 64Mi
       containers:
         - name: ntfy
-          image: binwiederhier/ntfy:v2.24.0
+          image: binwiederhier/ntfy:v2.24.0@sha256:f8a9b104313b87cc24ae4f775f39e6328205b57dff6ede3eaf098a91e5d79f59
           imagePullPolicy: Always
           command: ["ntfy", "serve"]
           securityContext:

--- a/k3d/oauth2-proxy-brett.yaml
+++ b/k3d/oauth2-proxy-brett.yaml
@@ -25,7 +25,7 @@ spec:
           type: RuntimeDefault
       initContainers:
         - name: write-cookie-secret
-          image: busybox:1.38.0
+          image: busybox:1.38.0@sha256:fd8d9aa63ba2f0982b5304e1ee8d3b90a210bc1ffb5314d980eb6962f1a9715d
           imagePullPolicy: Always
           command: ["/bin/sh", "-c"]
           args:
@@ -53,7 +53,7 @@ spec:
               mountPath: /run/config
       containers:
         - name: oauth2-proxy
-          image: quay.io/oauth2-proxy/oauth2-proxy:v7.9.0
+          image: quay.io/oauth2-proxy/oauth2-proxy:v7.9.0@sha256:37c1570c0427e02fc7c947ef2c04e8995b8347b7abc9fcf1dbb4e376a4b221a7
           imagePullPolicy: Always
           args:
             - --config=/run/config/oauth2-extra.cfg

--- a/k3d/oauth2-proxy-comfy.yaml
+++ b/k3d/oauth2-proxy-comfy.yaml
@@ -25,7 +25,7 @@ spec:
           type: RuntimeDefault
       initContainers:
         - name: write-cookie-secret
-          image: busybox:1.38.0
+          image: busybox:1.38.0@sha256:fd8d9aa63ba2f0982b5304e1ee8d3b90a210bc1ffb5314d980eb6962f1a9715d
           imagePullPolicy: Always
           command: ["/bin/sh", "-c"]
           args:
@@ -53,7 +53,7 @@ spec:
               mountPath: /run/config
       containers:
         - name: oauth2-proxy
-          image: quay.io/oauth2-proxy/oauth2-proxy:v7.9.0
+          image: quay.io/oauth2-proxy/oauth2-proxy:v7.9.0@sha256:37c1570c0427e02fc7c947ef2c04e8995b8347b7abc9fcf1dbb4e376a4b221a7
           imagePullPolicy: Always
           args:
             - --config=/run/config/oauth2-extra.cfg

--- a/k3d/oauth2-proxy-docs.yaml
+++ b/k3d/oauth2-proxy-docs.yaml
@@ -25,7 +25,7 @@ spec:
           type: RuntimeDefault
       initContainers:
         - name: write-cookie-secret
-          image: busybox:1.38.0
+          image: busybox:1.38.0@sha256:fd8d9aa63ba2f0982b5304e1ee8d3b90a210bc1ffb5314d980eb6962f1a9715d
           imagePullPolicy: Always
           # Write a TOML config with the cookie_secret truncated to 32 bytes.
           # env-generate produces a 64-char hex string which is too long for AES.
@@ -56,7 +56,7 @@ spec:
               mountPath: /run/config
       containers:
         - name: oauth2-proxy
-          image: quay.io/oauth2-proxy/oauth2-proxy:v7.9.0
+          image: quay.io/oauth2-proxy/oauth2-proxy:v7.9.0@sha256:37c1570c0427e02fc7c947ef2c04e8995b8347b7abc9fcf1dbb4e376a4b221a7
           imagePullPolicy: Always
           args:
             - --config=/run/config/oauth2-extra.cfg

--- a/k3d/oauth2-proxy-mailpit.yaml
+++ b/k3d/oauth2-proxy-mailpit.yaml
@@ -38,7 +38,7 @@ spec:
           type: RuntimeDefault
       initContainers:
         - name: write-cookie-secret
-          image: busybox:1.38.0
+          image: busybox:1.38.0@sha256:fd8d9aa63ba2f0982b5304e1ee8d3b90a210bc1ffb5314d980eb6962f1a9715d
           imagePullPolicy: Always
           command: ["/bin/sh", "-c"]
           args:
@@ -66,7 +66,7 @@ spec:
               mountPath: /run/config
       containers:
         - name: oauth2-proxy
-          image: quay.io/oauth2-proxy/oauth2-proxy:v7.9.0
+          image: quay.io/oauth2-proxy/oauth2-proxy:v7.9.0@sha256:37c1570c0427e02fc7c947ef2c04e8995b8347b7abc9fcf1dbb4e376a4b221a7
           imagePullPolicy: Always
           args:
             - --config=/run/config/oauth2-extra.cfg

--- a/k3d/oauth2-proxy-mediaviewer.yaml
+++ b/k3d/oauth2-proxy-mediaviewer.yaml
@@ -25,7 +25,7 @@ spec:
           type: RuntimeDefault
       initContainers:
         - name: write-cookie-secret
-          image: busybox:1.38.0
+          image: busybox:1.38.0@sha256:fd8d9aa63ba2f0982b5304e1ee8d3b90a210bc1ffb5314d980eb6962f1a9715d
           imagePullPolicy: Always
           command: ["/bin/sh", "-c"]
           args:
@@ -53,7 +53,7 @@ spec:
               mountPath: /run/config
       containers:
         - name: oauth2-proxy
-          image: quay.io/oauth2-proxy/oauth2-proxy:v7.9.0
+          image: quay.io/oauth2-proxy/oauth2-proxy:v7.9.0@sha256:37c1570c0427e02fc7c947ef2c04e8995b8347b7abc9fcf1dbb4e376a4b221a7
           imagePullPolicy: Always
           args:
             - --config=/run/config/oauth2-extra.cfg

--- a/k3d/oauth2-proxy-studio.yaml
+++ b/k3d/oauth2-proxy-studio.yaml
@@ -42,7 +42,7 @@ spec:
           type: RuntimeDefault
       initContainers:
         - name: write-cookie-secret
-          image: busybox:1.38.0
+          image: busybox:1.38.0@sha256:fd8d9aa63ba2f0982b5304e1ee8d3b90a210bc1ffb5314d980eb6962f1a9715d
           imagePullPolicy: Always
           command: ["/bin/sh", "-c"]
           args:
@@ -70,7 +70,7 @@ spec:
               mountPath: /run/config
       containers:
         - name: oauth2-proxy
-          image: quay.io/oauth2-proxy/oauth2-proxy:v7.9.0
+          image: quay.io/oauth2-proxy/oauth2-proxy:v7.9.0@sha256:37c1570c0427e02fc7c947ef2c04e8995b8347b7abc9fcf1dbb4e376a4b221a7
           imagePullPolicy: Always
           args:
             - --config=/run/config/oauth2-extra.cfg

--- a/k3d/oauth2-proxy-traefik.yaml
+++ b/k3d/oauth2-proxy-traefik.yaml
@@ -39,7 +39,7 @@ spec:
           type: RuntimeDefault
       initContainers:
         - name: write-cookie-secret
-          image: busybox:1.38.0
+          image: busybox:1.38.0@sha256:fd8d9aa63ba2f0982b5304e1ee8d3b90a210bc1ffb5314d980eb6962f1a9715d
           imagePullPolicy: Always
           command: ["/bin/sh", "-c"]
           args:
@@ -67,7 +67,7 @@ spec:
               mountPath: /run/config
       containers:
         - name: oauth2-proxy
-          image: quay.io/oauth2-proxy/oauth2-proxy:v7.9.0
+          image: quay.io/oauth2-proxy/oauth2-proxy:v7.9.0@sha256:37c1570c0427e02fc7c947ef2c04e8995b8347b7abc9fcf1dbb4e376a4b221a7
           imagePullPolicy: Always
           args:
             - --config=/run/config/oauth2-extra.cfg

--- a/k3d/oauth2-proxy-videovault.yaml
+++ b/k3d/oauth2-proxy-videovault.yaml
@@ -25,7 +25,7 @@ spec:
           type: RuntimeDefault
       initContainers:
         - name: write-cookie-secret
-          image: busybox:1.38.0
+          image: busybox:1.38.0@sha256:fd8d9aa63ba2f0982b5304e1ee8d3b90a210bc1ffb5314d980eb6962f1a9715d
           imagePullPolicy: Always
           command: ["/bin/sh", "-c"]
           args:
@@ -53,7 +53,7 @@ spec:
               mountPath: /run/config
       containers:
         - name: oauth2-proxy
-          image: quay.io/oauth2-proxy/oauth2-proxy:v7.9.0
+          image: quay.io/oauth2-proxy/oauth2-proxy:v7.9.0@sha256:37c1570c0427e02fc7c947ef2c04e8995b8347b7abc9fcf1dbb4e376a4b221a7
           imagePullPolicy: Always
           args:
             - --config=/run/config/oauth2-extra.cfg

--- a/k3d/office-stack/collabora.yaml
+++ b/k3d/office-stack/collabora.yaml
@@ -45,7 +45,7 @@ spec:
           # without needing `runAsUser: 0` (coolwsd refuses to start
           # as root). Built by .github/workflows/build-collabora.yml
           # as a multi-arch (amd64+arm64) image.
-          image: ghcr.io/paddione/collabora-code:25.04.9.4.1-setcap
+          image: ghcr.io/paddione/collabora-code:25.04.9.4.1-setcap@sha256:4f671c72094acd30e03b29088395449ba6d4b2488ff8a59a92edae13e0b46eb8
           imagePullPolicy: Always
           # - capabilities: in the bounding set so the kernel doesn't
           #   strip them on exec (file caps make them effective).

--- a/k3d/pocket-id-client-seed.yaml
+++ b/k3d/pocket-id-client-seed.yaml
@@ -43,7 +43,7 @@ spec:
           type: RuntimeDefault
       initContainers:
         - name: wait-for-pocket-id
-          image: busybox:1.38.0
+          image: busybox:1.38.0@sha256:fd8d9aa63ba2f0982b5304e1ee8d3b90a210bc1ffb5314d980eb6962f1a9715d
           command:
             - sh
             - -ec
@@ -70,7 +70,7 @@ spec:
             limits:   { cpu: "100m", memory: "64Mi" }
       containers:
         - name: seed
-          image: curlimages/curl:8.7.1
+          image: curlimages/curl:8.7.1@sha256:25d29daeb9b14b89e2fa8cc17c70e4b188bca1466086907c2d9a4b56b59d8e21
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/k3d/pocket-id.yaml
+++ b/k3d/pocket-id.yaml
@@ -31,7 +31,7 @@ spec:
           type: RuntimeDefault
       initContainers:
         - name: wait-for-db
-          image: busybox:1.38.0
+          image: busybox:1.38.0@sha256:fd8d9aa63ba2f0982b5304e1ee8d3b90a210bc1ffb5314d980eb6962f1a9715d
           command: ['sh', '-c', 'until nc -w1 -z shared-db 5432 2>/dev/null; do echo "waiting for shared-db..."; sleep 3; done']
           securityContext:
             allowPrivilegeEscalation: false
@@ -50,7 +50,7 @@ spec:
               memory: "64Mi"
       containers:
         - name: psql
-          image: postgres:16-alpine
+          image: postgres:16-alpine@sha256:e013e867e712fec275706a6c51c966f0bb0c93cfa8f51000f85a15f9865a28cb
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -129,7 +129,7 @@ spec:
           type: RuntimeDefault
       initContainers:
         - name: wait-for-db
-          image: busybox:1.38.0
+          image: busybox:1.38.0@sha256:fd8d9aa63ba2f0982b5304e1ee8d3b90a210bc1ffb5314d980eb6962f1a9715d
           command: ['sh', '-c', 'until nc -w1 -z shared-db 5432 2>/dev/null; do echo "waiting for shared-db..."; sleep 3; done']
           securityContext:
             allowPrivilegeEscalation: false
@@ -148,7 +148,7 @@ spec:
               memory: "64Mi"
       containers:
         - name: pocket-id
-          image: ghcr.io/pocket-id/pocket-id:v2.9.0
+          image: ghcr.io/pocket-id/pocket-id:v2.9.0@sha256:a2a38a96699d7483d65b5849b015d954f294938306a03a9c0699bc5b79554e86
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/k3d/pvc-backup-cronjob.yaml
+++ b/k3d/pvc-backup-cronjob.yaml
@@ -41,7 +41,7 @@ spec:
               type: RuntimeDefault
           containers:
             - name: orchestrator
-              image: alpine/k8s:1.34.0
+              image: alpine/k8s:1.34.0@sha256:b5f6edfeac5279f3e182d938d1ffecb62f7c980756ac4b6b66d7f0d566782f77
               imagePullPolicy: IfNotPresent
               securityContext:
                 allowPrivilegeEscalation: false
@@ -178,7 +178,7 @@ spec:
                           seccompProfile: { type: RuntimeDefault }
                         containers:
                           - name: backup
-                            image: pgvector/pgvector:0.8.0-pg16
+                            image: pgvector/pgvector:0.8.0-pg16@sha256:a132765ec351c65111b5b675928a3a0515a466a40f97277329db8b8209ad8bc9
                             imagePullPolicy: IfNotPresent
                             securityContext:
                               allowPrivilegeEscalation: false
@@ -237,7 +237,7 @@ spec:
                               requests: { memory: 256Mi, cpu: "200m" }
                               limits:   { memory: 1Gi,   cpu: "1" }
                           - name: filen-upload
-                            image: node:22-alpine
+                            image: node:22-alpine@sha256:16e22a550f3863206a3f701448c45f7912c6896a62de43add43bb9c86130c3e2
                             imagePullPolicy: IfNotPresent
                             securityContext:
                               allowPrivilegeEscalation: false

--- a/k3d/recovery-browser.yaml
+++ b/k3d/recovery-browser.yaml
@@ -35,7 +35,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: filebrowser
-          image: filebrowser/filebrowser:v2.63.5  # pinned (was floating :v2) — see https://github.com/filebrowser/filebrowser/releases
+          image: filebrowser/filebrowser:v2.63.5@sha256:aefb0c20de10ef8b617995ca5522479ad40d41e6386bd01946a345c6026ff31c  # pinned (was floating :v2) — see https://github.com/filebrowser/filebrowser/releases
           imagePullPolicy: IfNotPresent
           args:
             - --noauth           # auth is handled by oauth2-proxy in front
@@ -108,7 +108,7 @@ spec:
           type: RuntimeDefault
       initContainers:
         - name: write-cookie-secret
-          image: busybox:1.38.0
+          image: busybox:1.38.0@sha256:fd8d9aa63ba2f0982b5304e1ee8d3b90a210bc1ffb5314d980eb6962f1a9715d
           imagePullPolicy: Always
           # Write a TOML config with the cookie_secret truncated to 32 bytes.
           # env-generate produces a 64-char hex string which is too long for AES.
@@ -139,7 +139,7 @@ spec:
               mountPath: /run/config
       containers:
         - name: oauth2-proxy
-          image: quay.io/oauth2-proxy/oauth2-proxy:v7.9.0
+          image: quay.io/oauth2-proxy/oauth2-proxy:v7.9.0@sha256:37c1570c0427e02fc7c947ef2c04e8995b8347b7abc9fcf1dbb4e376a4b221a7
           imagePullPolicy: Always
           args:
             - --config=/run/config/oauth2-extra.cfg

--- a/k3d/sealed-secrets-controller.yaml
+++ b/k3d/sealed-secrets-controller.yaml
@@ -70,7 +70,7 @@ spec:
       serviceAccountName: sealed-secrets-controller
       containers:
       - name: sealed-secrets-controller
-        image: docker.io/bitnami/sealed-secrets-controller:0.27.3
+        image: docker.io/bitnami/sealed-secrets-controller:0.27.3@sha256:76f8c93c9e2e5450f90a416674f62ed9b9638b939561298f3218ed2a1cbe69d1
         imagePullPolicy: Always
         args:
         - --update-status

--- a/k3d/sessions-server.yaml
+++ b/k3d/sessions-server.yaml
@@ -40,7 +40,7 @@ spec:
     spec:
       containers:
         - name: nginx
-          image: nginx:1.27-alpine
+          image: nginx:1.27-alpine@sha256:65645c7bb6a0661892a8b03b89d0743208a18dd2f3f17a54ef4b76fb8e2f2a10
           ports:
             - containerPort: 80
           readinessProbe:

--- a/k3d/shared-db.yaml
+++ b/k3d/shared-db.yaml
@@ -104,7 +104,7 @@ spec:
         # TLS opportunistisch aus. NetworkPolicies (Default-Deny-Ingress)
         # bilden die primäre Vertrauensgrenze.
         - name: generate-tls-cert
-          image: pgvector/pgvector:0.8.0-pg16
+          image: pgvector/pgvector:0.8.0-pg16@sha256:a132765ec351c65111b5b675928a3a0515a466a40f97277329db8b8209ad8bc9
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false
@@ -134,7 +134,7 @@ spec:
               mountPath: /etc/postgresql/certs
       containers:
         - name: postgres
-          image: pgvector/pgvector:0.8.0-pg16
+          image: pgvector/pgvector:0.8.0-pg16@sha256:a132765ec351c65111b5b675928a3a0515a466a40f97277329db8b8209ad8bc9
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/k3d/staging-stack/shared-db-staging.yaml
+++ b/k3d/staging-stack/shared-db-staging.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
         - name: postgres
-          image: pgvector/pgvector:0.8.0-pg16
+          image: pgvector/pgvector:0.8.0-pg16@sha256:a132765ec351c65111b5b675928a3a0515a466a40f97277329db8b8209ad8bc9
           ports:
             - containerPort: 5432
               name: postgres
@@ -87,7 +87,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: init
-          image: pgvector/pgvector:0.8.0-pg16
+          image: pgvector/pgvector:0.8.0-pg16@sha256:a132765ec351c65111b5b675928a3a0515a466a40f97277329db8b8209ad8bc9
           env:
             - name: PGHOST
               value: shared-db-staging

--- a/k3d/talk-hpb.yaml
+++ b/k3d/talk-hpb.yaml
@@ -30,7 +30,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: nats
-          image: nats:2.10-alpine
+          image: nats:2.10-alpine@sha256:b83efabe3e7def1e0a4a31ec6e078999bb17c80363f881df35edc70fcb6bb927
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false
@@ -186,7 +186,7 @@ spec:
         # Uses busybox sed (POSIX, no external tools) and `|` as the sed
         # delimiter so base64-safe secret values don't collide.
         - name: render-config
-          image: busybox:1.38.0
+          image: busybox:1.38.0@sha256:fd8d9aa63ba2f0982b5304e1ee8d3b90a210bc1ffb5314d980eb6962f1a9715d
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false
@@ -242,7 +242,7 @@ spec:
               mountPath: /shared
       containers:
         - name: signaling
-          image: strukturag/nextcloud-spreed-signaling:2.1.1
+          image: strukturag/nextcloud-spreed-signaling:2.1.1@sha256:b306eae9d1e62c4b2eaf10a6683dfe1fe76b833bd0f68d1606861e33aff5bca1
           imagePullPolicy: Always
           # Bypass su-exec (needs CAP_SETGID which is dropped) by calling binary directly.
           # The image entrypoint uses su-exec to switch users, but we're already UID 65534.

--- a/k3d/talk-recording.yaml
+++ b/k3d/talk-recording.yaml
@@ -34,7 +34,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: recording
-          image: nextcloud/aio-talk-recording:20260409_094910
+          image: nextcloud/aio-talk-recording:20260409_094910@sha256:add76fbe1a9b2f402fbfec9685bbca52d7fd34f8cda68a74dfbcd0743c9ddcbd
           imagePullPolicy: Always
           env:
             - name: NC_DOMAIN

--- a/k3d/tests-retention-cronjob.yaml
+++ b/k3d/tests-retention-cronjob.yaml
@@ -26,7 +26,7 @@ spec:
               # `bitnami/kubectl:1.31` was both version-mismatched and pulled
               # from a Bitnami tag that has since been removed from Docker Hub
               # (ImagePullBackOff: "docker.io/bitnami/kubectl:1.31: not found").
-              image: alpine/k8s:1.34.0
+              image: alpine/k8s:1.34.0@sha256:b5f6edfeac5279f3e182d938d1ffecb62f7c980756ac4b6b66d7f0d566782f77
               resources:
                 requests:
                   cpu: 50m

--- a/k3d/vaultwarden-seed-job.yaml
+++ b/k3d/vaultwarden-seed-job.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
         - name: seeder
-          image: node:22-alpine
+          image: node:22-alpine@sha256:16e22a550f3863206a3f701448c45f7912c6896a62de43add43bb9c86130c3e2
           imagePullPolicy: Always
           resources:
             requests:

--- a/k3d/vaultwarden.yaml
+++ b/k3d/vaultwarden.yaml
@@ -41,7 +41,7 @@ spec:
           type: RuntimeDefault
       initContainers:
         - name: wait-for-db
-          image: busybox:1.38.0
+          image: busybox:1.38.0@sha256:fd8d9aa63ba2f0982b5304e1ee8d3b90a210bc1ffb5314d980eb6962f1a9715d
           command: ['sh', '-c', 'until nc -w1 -z shared-db 5432 2>/dev/null; do echo "waiting for shared-db..."; sleep 3; done']
           securityContext:
             allowPrivilegeEscalation: false
@@ -60,7 +60,7 @@ spec:
               memory: "64Mi"
       containers:
         - name: vaultwarden
-          image: vaultwarden/server:1.35.3-alpine
+          image: vaultwarden/server:1.35.3-alpine@sha256:c40957876ec13c1cb0d2b08f86e8f738e6d06f7460bad9cdae216cded174c10d
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/k3d/whiteboard/whiteboard.yaml
+++ b/k3d/whiteboard/whiteboard.yaml
@@ -29,7 +29,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: whiteboard
-          image: ghcr.io/nextcloud-releases/whiteboard:v1.5.7
+          image: ghcr.io/nextcloud-releases/whiteboard:v1.5.7@sha256:4ca6103eeab072c010b1d7acb04e0af08d48b1f6f53b0328c4180a40ae5d89ad
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/prod-korczewski/ddns-updater.yaml
+++ b/prod-korczewski/ddns-updater.yaml
@@ -35,7 +35,7 @@ spec:
           restartPolicy: OnFailure
           containers:
             - name: updater
-              image: curlimages/curl:8.7.1
+              image: curlimages/curl:8.7.1@sha256:25d29daeb9b14b89e2fa8cc17c70e4b188bca1466086907c2d9a4b56b59d8e21
               imagePullPolicy: IfNotPresent
               resources:
                 requests:

--- a/prod-korczewski/dev-db-refresh-cron.yaml
+++ b/prod-korczewski/dev-db-refresh-cron.yaml
@@ -35,7 +35,7 @@ spec:
             kubernetes.io/hostname: ${DEV_NODE}
           containers:
             - name: refresh
-              image: pgvector/pgvector:0.8.0-pg16
+              image: pgvector/pgvector:0.8.0-pg16@sha256:a132765ec351c65111b5b675928a3a0515a466a40f97277329db8b8209ad8bc9
               command: [/bin/bash, /scripts/dev-db-refresh.sh]
               env:
                 # Destination: dev k3d Postgres via the k3d NodePort.

--- a/prod-korczewski/oauth2-proxy-dev.yaml
+++ b/prod-korczewski/oauth2-proxy-dev.yaml
@@ -35,7 +35,7 @@ spec:
           type: RuntimeDefault
       initContainers:
         - name: write-cookie-secret
-          image: busybox:1.38.0
+          image: busybox:1.38.0@sha256:fd8d9aa63ba2f0982b5304e1ee8d3b90a210bc1ffb5314d980eb6962f1a9715d
           command: ["/bin/sh", "-c"]
           args:
             - printf 'cookie_secret = "%s"\n' "$(printf '%s' "$DEV_OAUTH2_PROXY_COOKIE_SECRET" | cut -c1-32)" > /run/config/oauth2-extra.cfg
@@ -62,7 +62,7 @@ spec:
               mountPath: /run/config
       containers:
         - name: oauth2-proxy
-          image: quay.io/oauth2-proxy/oauth2-proxy:v7.9.0
+          image: quay.io/oauth2-proxy/oauth2-proxy:v7.9.0@sha256:37c1570c0427e02fc7c947ef2c04e8995b8347b7abc9fcf1dbb4e376a4b221a7
           args:
             - --config=/run/config/oauth2-extra.cfg
             - --provider=keycloak-oidc

--- a/prod-mentolder/dev-db-refresh-cron.yaml
+++ b/prod-mentolder/dev-db-refresh-cron.yaml
@@ -37,7 +37,7 @@ spec:
             kubernetes.io/hostname: ${DEV_NODE}
           containers:
             - name: refresh
-              image: pgvector/pgvector:0.8.0-pg16
+              image: pgvector/pgvector:0.8.0-pg16@sha256:a132765ec351c65111b5b675928a3a0515a466a40f97277329db8b8209ad8bc9
               command: [/bin/bash, /scripts/dev-db-refresh.sh]
               env:
                 # Destination: dev Postgres via the HA dev-cluster VIP LoadBalancer.

--- a/renovate.json5
+++ b/renovate.json5
@@ -149,6 +149,8 @@
       "^prod-mentolder/.+\\.yaml$",
       "^prod-korczewski/.+\\.yaml$",
       "^prod-fleet/.+\\.yaml$"
-    ]
+    ],
+    // pinDigests: automatically update @sha256 digests on every update.
+    "pinDigests": true
   }
 }


### PR DESCRIPTION
## Summary
- Pins all foreign (non-self-built) Kubernetes images with @sha256 digests to prevent supply chain drift [T001294]

## Test plan
- [x] Offline tests pass (52/52)
- [x] Manifest structure validated (kustomize build passes)
- [x] Security scan: no new hardcoded secrets or unpinned images

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012AKZxEc1xrVSKoLxdn6PCc