### PR TITLE
feat(website): move RepoHealth dashboard from frontpage to admin sidebar

### DIFF
--- a/website/src/components/admin/AdminSidebarNav.astro
+++ b/website/src/components/admin/AdminSidebarNav.astro
@@ -9,7 +9,7 @@ interface Props {
   path: string;
 }
 
-const { inboxPending, brettUrl, path } = Astro.props;
+const { inboxPending, brettUrl, path, isKore } = Astro.props;
 
 interface NavItem {
   href: string;
@@ -58,6 +58,7 @@ const navSections: { label?: string; items: NavItem[] }[] = [
       { href: '/admin/platform',                      label: 'Plattform Hub',icon: 'monitor', matches: ['/admin/monitoring', '/admin/ops', '/admin/platform', '/admin/architektur'] },
       { href: '/dev-status',                          label: 'Dev Status',   icon: 'activity', matches: ['/dev-status', '/admin/planungsbuero', '/admin/factory-budget', '/admin/factory-observability'] },
       { href: '/admin/dora',                          label: 'DORA',         icon: 'activity', matches: ['/admin/dora'] },
+      ...(!isKore ? [{ href: '/admin/repohealth', label: 'Repo Health', icon: 'activity', matches: ['/admin/repohealth'] }] : []),
       { href: '/admin/einstellungen/benachrichtigungen', label: 'Einstellungen', icon: 'settings', matches: ['/admin/einstellungen/'] },
       { href: brettUrl,                               label: 'Systembrett',  icon: 'brett', external: true },
       { href: '/admin/live',                          label: 'Live-Stream',  icon: 'broadcast', matches: ['/admin/live', '/admin/stream'] },

--- a/website/src/pages/admin/repohealth.astro
+++ b/website/src/pages/admin/repohealth.astro
@@ -1,0 +1,21 @@
+---
+export const prerender = false;
+
+import AdminLayout from '../../layouts/AdminLayout.astro';
+import { getSession, getLoginUrl, isAdmin } from '../../lib/auth';
+import GoalsDashboard from '../../components/GoalsDashboard.svelte';
+
+const session = await getSession(Astro.request.headers.get('cookie'));
+if (!session) return Astro.redirect(getLoginUrl(Astro.url.pathname));
+if (!isAdmin(session)) return Astro.redirect('/admin');
+---
+
+<AdminLayout title="Repo Health">
+  <section class="repohealth-page">
+    <GoalsDashboard client:load />
+  </section>
+</AdminLayout>
+
+<style>
+  .repohealth-page { padding: 1.5rem; }
+</style>

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -8,7 +8,6 @@ import FAQ from '../components/FAQ.svelte';
 import WhyMe from '../components/WhyMe.svelte';
 import Process from '../components/Process.astro';
 import KoreHomepage from '../components/kore/KoreHomepage.svelte';
-import GoalsDashboard from '../components/GoalsDashboard.svelte';
 import { config } from '../config/index';
 import type { DaySlots } from '../lib/caldav';
 import { getAvailableSlots } from '../lib/caldav';
@@ -159,14 +158,6 @@ const processSteps = homepage.processSteps ?? [];
         secondaryHref={`mailto:${stammdaten?.email}`}
       />
 
-      <!-- Repo Health Dashboard (only for mentolder / dev) -->
-      {BRAND_ID !== 'korczewski' && (
-        <section class="section goals-section" id="health">
-          <div class="wrap">
-            <GoalsDashboard client:visible />
-          </div>
-        </section>
-      )}
     </Fragment>
   )}
 </Layout>


### PR DESCRIPTION
## Summary

- Entfernt `GoalsDashboard` aus der mentolder-Frontpage (`index.astro`)
- Neue Admin-Seite `/admin/repohealth` mit Auth-Guard (folgt dem `dora.astro`-Muster)
- Sidebar-Eintrag „Repo Health" in der „Infrastruktur"-Section — nur für mentolder sichtbar (`!isKore`-Guard)

## Änderungen

| Datei | Was |
|-------|-----|
| `website/src/pages/index.astro` | Import + Section entfernt |
| `website/src/pages/admin/repohealth.astro` | Neue Seite erstellt |
| `website/src/components/admin/AdminSidebarNav.astro` | Nav-Item hinzugefügt, `isKore` destrukturiert |

## Test plan

- [ ] `/admin/repohealth` öffnen → GoalsDashboard erscheint
- [ ] Admin-Sidebar unter „Infrastruktur" → „Repo Health" sichtbar (mentolder)
- [ ] Frontpage (`/`) → kein Dashboard-Block mehr sichtbar
- [ ] Korczewski-Brand: kein „Repo Health"-Eintrag in der Sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JeyHEcwgFo9fxvwdYku3gL