### PR TITLE
fix(infra): sessions-server switch probes to tcpSocket — httpGet / hit default_server 404 [T001314]

### DIFF
--- a/k3d/sessions-server.yaml
+++ b/k3d/sessions-server.yaml
@@ -18,6 +18,10 @@ data:
     }
     server {
         listen 80 default_server;
+        location /health {
+            return 200 "ok\n";
+            add_header Content-Type text/plain;
+        }
         return 404;
     }
 ---
@@ -44,16 +48,14 @@ spec:
           ports:
             - containerPort: 80
           readinessProbe:
-            httpGet:
-              path: /
+            tcpSocket:
               port: 80
             initialDelaySeconds: 3
             periodSeconds: 10
             timeoutSeconds: 3
             failureThreshold: 3
           livenessProbe:
-            httpGet:
-              path: /
+            tcpSocket:
               port: 80
             initialDelaySeconds: 10
             periodSeconds: 30


### PR DESCRIPTION
## Problem

Rolling update nach Deploy triggerte CrashLoopBackOff auf sessions-server in beiden Brands (mentolder: 111 Restarts, korczewski: 8+ Restarts in 30min).

**Root Cause:** Die nginx-Config hat einen `default_server`-Block der bewusst `return 404` für alle Requests zurückgibt die nicht zum Host-Pattern `session-*.sessions.mentolder.de` passen. Die liveness/readiness-Probe schickte `GET / HTTP/1.1` ohne passenden Host-Header → traf default_server → 404 → Pod-Kill.

Der alte Pod (8 Tage alt, anderes ReplicaSet) hatte die Probe noch nicht in seiner Spec und überlebte daher.

## Fix

- `livenessProbe` + `readinessProbe`: `httpGet` → `tcpSocket port: 80`
- TCP-Socket prüft nur ob nginx läuft und den Port öffnet, ignoriert HTTP-Antwortcodes
- Zusätzlich `/health` location im default_server als Defence-in-Depth für zukünftige httpGet-Probes

## Status

Bereits live gefixt via `kubectl patch` auf beiden Brands (beide sessions-server 1/1 Running).

## Test plan

- [x] mentolder sessions-server: 1/1 Running, 0 Restarts
- [x] korczewski sessions-server: 1/1 Running, 0 Restarts
- [x] `task workspace:validate` grün

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012AKZxEc1xrVSKoLxdn6PCc