### PR TITLE
chore(website): remove DE/EN language switcher from navigation

### DIFF
--- a/website/src/components/NavMobile.svelte
+++ b/website/src/components/NavMobile.svelte
@@ -11,9 +11,6 @@
     authChecked?: boolean;
     streamLive?: boolean;
     pathname: string;
-    /** Reference to LanguageSwitcher.svelte (passed in to avoid eager
-     *  import-cycle / Svelte 5 instance issues). */
-    LanguageSwitcher: any;
   }
 
   let {
@@ -24,7 +21,6 @@
     authChecked = false,
     streamLive = false,
     pathname,
-    LanguageSwitcher,
   }: Props = $props();
 
   function initial(name: string) {
@@ -75,9 +71,6 @@
       {/if}
     {/if}
 
-    <div class="mobile-lang-row">
-      <LanguageSwitcher {pathname} />
-    </div>
     <a href="/kontakt" class="mobile-cta" onclick={() => (open = false)}>
       {t(locale, 'hero.cta-primary')}
     </a>
@@ -218,12 +211,6 @@
 
   .mobile-cta:hover {
     background: var(--brass-2) !important;
-  }
-
-  .mobile-lang-row {
-    display: flex;
-    justify-content: center;
-    padding: 10px 0;
   }
 
   @media (max-width: 860px) {

--- a/website/src/components/Navigation.svelte
+++ b/website/src/components/Navigation.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { onMount } from 'svelte';
   import type { NavigationLink } from '../config/types';
-  import LanguageSwitcher from './LanguageSwitcher.svelte';
   import NavMobile from './NavMobile.svelte';
   import { t, type Locale } from '../i18n/index';
 
@@ -201,7 +200,6 @@
       </a>
 
       <!-- Mobile toggle -->
-      <LanguageSwitcher {pathname} />
       <button
         class="mobile-toggle"
         onclick={() => (mobileOpen = !mobileOpen)}
@@ -228,7 +226,6 @@
     {authChecked}
     {streamLive}
     {pathname}
-    {LanguageSwitcher}
   />
 </header>
 

--- a/website/src/components/Navigation.test.ts
+++ b/website/src/components/Navigation.test.ts
@@ -15,7 +15,6 @@ describe('NavMobile.svelte', () => {
     user: null,
     authChecked: false,
     streamLive: false,
-    LanguageSwitcher: null,
   };
 
   it('renders the link list when open is true', () => {


### PR DESCRIPTION
## Summary
- Removed the LanguageSwitcher component from desktop and mobile navigation
- No English pages needed for now

## Test Plan
- [x] Unit tests pass (4/4)
- [x] CI grün