### PR TITLE
chore(docs): full re-index codebase-memory graph + refresh LOC baseline [T001322]

### DIFF
--- a/.codebase-memory/artifact.json
+++ b/.codebase-memory/artifact.json
@@ -1,11 +1,11 @@
 {
     "schema_version": 1,
-    "commit": "975b6100ce35d11b49e1bb5e4db856007a6358a4",
-    "indexed_at": "2026-06-28T21:34:15Z",
-    "project": "home-runner-work-Bachelorprojekt-Bachelorprojekt",
-    "nodes": 44107,
-    "edges": 112620,
-    "original_size": 111804416,
-    "compressed_size": 16820581,
+    "commit": "d4f850071da00e36d1d6d52ce1ca7988454093b1",
+    "indexed_at": "2026-06-28T22:32:26Z",
+    "project": "home-patrick-Bachelorprojekt",
+    "nodes": 44877,
+    "edges": 114728,
+    "original_size": 94240768,
+    "compressed_size": 16731701,
     "compression_level": 3
 }

--- a/docs/code-quality/loc-budget.json
+++ b/docs/code-quality/loc-budget.json
@@ -1,8 +1,8 @@
 {
-  "total_lines": 510446,
+  "total_lines": 511105,
   "file_count": 3918,
-  "commit": "a49b6a6b",
-  "measured_at": "2026-06-28T22:24:29.708Z",
+  "commit": "fabe63cb",
+  "measured_at": "2026-06-28T22:33:03.353Z",
   "thresholds": {
     "warn_pct": 5,
     "fail_pct": 15,


### PR DESCRIPTION
## Summary
- Full re-index of codebase-memory graph (full mode, persistence=true): **44 877 nodes, 114 728 edges**
- HTML docs (`k3d/docs-content-built/`) already up-to-date — no changes needed
- LOC baseline updated: 510 446 → 511 105 lines (+659, commit fabe63cb)

## Test plan
- [ ] CI freshness:check passes (loc-budget.json correctly reflects current LOC)
- [ ] `.codebase-memory/graph.db.zst` and `artifact.json` contain the latest graph

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012AKZxEc1xrVSKoLxdn6PCc