### PR TITLE
chore(website): nextcloud talk link im admin-dashboard ergänzen [T001324]

### DIFF
--- a/docs/code-quality/loc-budget.json
+++ b/docs/code-quality/loc-budget.json
@@ -1,8 +1,8 @@
 {
-  "total_lines": 510561,
+  "total_lines": 511221,
   "file_count": 3919,
-  "commit": "595b1cd9",
-  "measured_at": "2026-06-29T00:00:29.172Z",
+  "commit": "2b6cf75a",
+  "measured_at": "2026-06-30T15:47:23.439Z",
   "thresholds": {
     "warn_pct": 5,
     "fail_pct": 15,

--- a/website/src/pages/admin.astro
+++ b/website/src/pages/admin.astro
@@ -59,6 +59,7 @@ const adminLinks = [
   ...(ncBase ? [
     { href: `${ncBase}/apps/files/`,    label: 'Dateien',  icon: icons.folder,   color: '#38bdf8' },
     { href: `${ncBase}/apps/calendar/`, label: 'Kalender', icon: icons.calendar, color: 'oklch(0.80 0.09 75)' },
+    { href: `${ncBase}/apps/spreed/`,   label: 'Talk',     icon: icons.video,    color: '#818cf8' },
   ] : []),
   { href: '/admin/rechnungen',               label: 'Abrechnung', icon: icons.receipt,  color: '#34d399' },
   ...(vaultUrl ? [{ href: vaultUrl,          label: 'Passwörter', icon: icons.lock,     color: '#34d399' }] : []),


### PR DESCRIPTION
Fügt den fehlenden Nextcloud Talk Link (`/apps/spreed/`) zum Admin-Dashboard auf beiden Environments (mentolder + korczewski) hinzu. Der Link war im Portal (DiensteSection) vorhanden, fehlte aber im Admin-Dashboard (admin.astro).

## Änderung

- `website/src/pages/admin.astro`: Talk-Link (`${ncBase}/apps/spreed/`) nach Kalender eingefügt, mit `icons.video` und Indigo-Farbe `#818cf8`

## Test plan
- [ ] Admin-Dashboard öffnen → Talk-Kachel sichtbar
- [ ] Link führt zu Nextcloud Talk
- [ ] CI grün

🤖 Generated with [Claude Code](https://claude.com/claude-code)