### PR TITLE
fix(infra): pocket-id nextcloud callback url cloud → files [T001325]

### DIFF
--- a/docs/code-quality/loc-budget.json
+++ b/docs/code-quality/loc-budget.json
@@ -1,8 +1,8 @@
 {
-  "total_lines": 510562,
+  "total_lines": 511221,
   "file_count": 3919,
-  "commit": "e3e8b79d",
-  "measured_at": "2026-06-30T15:52:39.844Z",
+  "commit": "5897cf39",
+  "measured_at": "2026-06-30T16:05:29.990Z",
   "thresholds": {
     "warn_pct": 5,
     "fail_pct": 15,

--- a/k3d/pocket-id-client-seed.yaml
+++ b/k3d/pocket-id-client-seed.yaml
@@ -148,7 +148,7 @@ spec:
               session-hub|SECRET_sessionhub|${SCHEME}://session-hub.${SUFFIX}/oauth2/callback
               brainstorm|SECRET_brainstorm|${SCHEME}://brainstorm.${SUFFIX}/oauth2/callback
               vaultwarden|SECRET_vaultwarden|${SCHEME}://vault.${SUFFIX}/identity/connect/oidc-signin
-              nextcloud|SECRET_nextcloud|${SCHEME}://cloud.${SUFFIX}/apps/oidc_login/oidc
+              nextcloud|SECRET_nextcloud|${SCHEME}://files.${SUFFIX}/apps/oidc_login/oidc
               grafana|SECRET_grafana|${SCHEME}://grafana.${SUFFIX}/login/generic_oauth
               website|SECRET_website|${SCHEME}://web.${SUFFIX}/api/auth/callback
               "


### PR DESCRIPTION
## Problem

Der PocketID Client-Seed (`k3d/pocket-id-client-seed.yaml`) registrierte `cloud.${SUFFIX}` als OIDC Callback-URL für Nextcloud. Nextcloud läuft aber auf `files.${SUFFIX}` (NC_DOMAIN = `files.${PROD_DOMAIN}`). Frische OIDC-Logins schlugen mit "Invalid callback url" fehl — bestehende Sessions waren nicht betroffen.

Aufgedeckt durch den neuen Nextcloud Talk Link im Admin-Dashboard (#2320), der eine frische OIDC-Anfrage auslöste.

## Fix

```diff
- nextcloud|SECRET_nextcloud|${SCHEME}://cloud.${SUFFIX}/apps/oidc_login/oidc
+ nextcloud|SECRET_nextcloud|${SCHEME}://files.${SUFFIX}/apps/oidc_login/oidc
```

Konsistent mit `NC_DOMAIN: "files.${PROD_DOMAIN}"` (prod/configmap-domains.yaml) und `NC_DOMAIN: "files.localhost"` (k3d/configmap-domains.yaml).

## Nach dem Merge

Seed-Job auf beiden Environments neu ausführen (`task workspace:deploy ENV=fleet-korczewski` / `ENV=fleet-mentolder`) damit PocketID sofort die korrigierte Callback-URL erhält.

## Test plan
- [ ] CI grün
- [ ] Nach Deploy: Nextcloud Talk Link → OIDC Login → kein "Invalid callback url"
- [ ] Files/Calendar weiterhin funktionsfähig

🤖 Generated with [Claude Code](https://claude.com/claude-code)