### PR TITLE
fix(infra): pocket-id-client-seed: Init-Timeout 120s→600s, backoffLimit 5→2 [T001327]

### DIFF
--- a/docs/code-quality/loc-budget.json
+++ b/docs/code-quality/loc-budget.json
@@ -1,8 +1,8 @@
 {
-  "total_lines": 510562,
-  "file_count": 3919,
-  "commit": "082b6db1",
-  "measured_at": "2026-06-30T16:10:42.929Z",
+  "total_lines": 511258,
+  "file_count": 3920,
+  "commit": "64df8ab9",
+  "measured_at": "2026-06-30T19:19:31.736Z",
   "thresholds": {
     "warn_pct": 5,
     "fail_pct": 15,

--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 512,
+      "file_count": 513,
       "files": [
         "tests/.gitignore",
         "tests/README.md",
@@ -368,6 +368,7 @@
         "tests/spec/mcp-tooling.bats",
         "tests/spec/openspec-embedding.bats",
         "tests/spec/openspec-workflow.bats",
+        "tests/spec/pocket-id-client-seed-timeout.bats",
         "tests/spec/pocket-id-migration.bats",
         "tests/spec/react-homepage-blocks.bats",
         "tests/spec/s1-violations-batch2.bats",

--- a/docs/superpowers/specs/2026-06-30-pocket-id-client-seed-timeout-design.md
+++ b/docs/superpowers/specs/2026-06-30-pocket-id-client-seed-timeout-design.md
@@ -1,0 +1,46 @@
+---
+ticket_id: T001327
+plan_ref: null
+status: active
+date: 2026-06-30
+---
+
+# Design: pocket-id-client-seed-timeout
+
+**Datum:** 2026-06-30  
+**Slug:** `pocket-id-client-seed-timeout`  
+**Status:** approved  
+**Ticket:** T001327  
+**Spec-Link:** `openspec/specs/fleet-operations.md`  
+
+---
+
+## Kontext & Problem
+
+Der `pocket-id-client-seed` Job in `k3d/pocket-id-client-seed.yaml` hat einen Init-Container `wait-for-pocket-id`, der mit `wget` das `/.well-known/openid-configuration` von pocket-id pollt. Das Zeitfenster ist auf **60 Iterationen × 2s = 120s** begrenzt.
+
+Bei einem Kaltstart (erster Deploy nach Cluster-Reset, oder parallel zu pocket-id + shared-db) reicht diese Zeitspanne nicht aus: pocket-id braucht für DB-Migrationen und App-Init oft >2 Minuten. Der Init-Container stirbt mit `exit 1`, der Pod restartet mit exponentiellem Backoff (10s, 20s, 40s…). Dadurch:
+
+1. Läuft der Seed-Container nicht → OIDC-Clients werden nicht angelegt/aktualisiert
+2. Die Client-Konfiguration driftet bei jedem Deploy
+3. T001326 (Nextcloud/Talk-Login broken) war die Folge
+
+## Fix-Ansatz
+
+**Timeout erhöhen:** Das Poll-Intervall bleibt bei 2s, aber die maximale Iterationszahl wird von 60 auf **300** erhöht (→ 600s/10min). Dies deckt den schlimmsten Cold-Start ab (DB-Migration + App-Init). Zusätzlich wird `backoffLimit` von 5 auf **2** gesenkt, da der Init-Container intern länger wartet und nicht mehr den Pod-Restart-Mechanismus braucht.
+
+Alternative: `kubectl wait` (Ansatz D) — aufwändiger, braucht RBAC. Der schnelle Fix ist die Timeout-Erhöhung, ein robusterer Mechanismus kann in einem Follow-up (T00109x) kommen.
+
+## Betroffene Subsysteme
+
+| Subsystem | Datei | Änderung |
+|-----------|-------|----------|
+| Pocket-ID-Seed-Job | `k3d/pocket-id-client-seed.yaml` | Init-Container: `-ge 60` → `-ge 300`, `backoffLimit: 5` → `backoffLimit: 2` |
+| Test | `tests/spec/pocket-id-client-seed-timeout.bats` | Neu: reproduziert Timeout-Bug (RED→GREEN) |
+
+## Edge-Cases
+
+- **Normaler pocket-id-Restart** (ohne DB-Migration): ~5–10s → 1–5 Iterationen, irrelevant
+- **shared-db-Restart:** pocket-id ist nicht verfügbar, bis DB ready → Timeout-Puffer fängt das ab
+- **Dauerhafter Fehler:** pocket-id startet gar nicht (Config-Fehler) → Job läuft nach 10min ins Timeout → `backoffLimit: 2` → Pod failed → Admin muss eingreifen
+- **Beide Brands:** `k3d/pocket-id-client-seed.yaml` ist Base-Manifest → Fix gilt für mentolder + korczewski

--- a/k3d/pocket-id-client-seed.yaml
+++ b/k3d/pocket-id-client-seed.yaml
@@ -29,7 +29,7 @@ metadata:
   labels:
     app: pocket-id
 spec:
-  backoffLimit: 5
+  backoffLimit: 2
   template:
     metadata:
       labels:
@@ -51,10 +51,10 @@ spec:
               i=0
               until wget -q -O- "http://pocket-id:1411/.well-known/openid-configuration" >/dev/null 2>&1; do
                 i=$((i+1))
-                if [ "$i" -ge 60 ]; then
-                  echo "pocket-id not healthy after 120s"; exit 1
+                if [ "$i" -ge 300 ]; then
+                  echo "pocket-id not healthy after 600s"; exit 1
                 fi
-                echo "waiting for pocket-id health ($i/60)..."; sleep 2
+                echo "waiting for pocket-id health ($i/300)..."; sleep 2
               done
               echo "pocket-id is healthy"
           securityContext:

--- a/openspec/changes/pocket-id-client-seed-timeout/specs/pocket-id-client-seed-timeout.md
+++ b/openspec/changes/pocket-id-client-seed-timeout/specs/pocket-id-client-seed-timeout.md
@@ -1,0 +1,23 @@
+# pocket-id-client-seed-timeout
+
+<!-- SSOT: openspec/specs/fleet-operations.md -->
+
+## ADDED Requirements
+
+### Requirement: Pocket-ID-Client-Seed Init-Container-Timeouts
+
+The system SHALL configure the `pocket-id-client-seed` Job's init container with a poll timeout of at least 600 seconds (300 iterations × 2s) to accommodate cold-start scenarios, and SHALL set `backoffLimit` to 2.
+
+#### Scenario: Init-Container-Timeout wird bei Kaltstart nicht überschritten
+
+- **GIVEN** ein frisch deploytes `pocket-id-client-seed` Job (Init-Container `wait-for-pocket-id`)
+- **WHEN** pocket-id und shared-db starten kalt und brauchen >2 Minuten für DB-Migration + App-Init
+- **THEN** der Init-Container wartet bis zu 600 Sekunden (300 Iterationen × 2s Poll-Intervall) auf pocket-id
+- **AND** der Job hat `backoffLimit: 2`, da der Init-Container intern länger wartet
+
+#### Scenario: Manifest enthält korrekte Timeout-Werte
+
+- **GIVEN** die Datei `k3d/pocket-id-client-seed.yaml`
+- **WHEN** der Init-Container-Befehl geprüft wird
+- **THEN** enthält er `if [ "$i" -ge 300 ]; then`
+- **AND** der Manifest hat `backoffLimit: 2`

--- a/openspec/changes/pocket-id-client-seed-timeout/tasks.md
+++ b/openspec/changes/pocket-id-client-seed-timeout/tasks.md
@@ -1,0 +1,81 @@
+---
+title: "pocket-id-client-seed: Init-Container-Timeout für Cold-Start erhöhen (T001327)"
+ticket_id: T001327
+domains: [infra, auth, ops]
+status: active
+file_locks: [k3d/pocket-id-client-seed.yaml, tests/spec/pocket-id-client-seed-timeout.bats, openspec/changes/pocket-id-client-seed-timeout/, docs/superpowers/specs/2026-06-30-pocket-id-client-seed-timeout-design.md, .lavish/pocket-id-client-seed-timeout-brainstorm.html]
+shared_changes: true
+batch_id: null
+parent_feature: null
+depends_on_plans: []
+---
+
+# pocket-id-client-seed-timeout — Implementation Plan
+
+**Ticket:** T001327 (Root Cause von T001326)  
+**Branch:** `fix/t001327-pocket-id-client-seed-timeout`  
+**Worktree:** `/home/patrick/Bachelorprojekt/tmp/wt-pocket-id-seed`  
+**Spec:** `docs/superpowers/specs/2026-06-30-pocket-id-client-seed-timeout-design.md`  
+**Brainstorm:** `.lavish/pocket-id-client-seed-timeout-brainstorm.html`
+
+## File Structure
+
+**Geändert (1):**
+- `k3d/pocket-id-client-seed.yaml` — Init-Container: Poll-Timeout `-ge 60` → `-ge 300` (600s statt 120s), `backoffLimit: 5` → `backoffLimit: 2`.
+
+**Neu (1):**
+- `tests/spec/pocket-id-client-seed-timeout.bats` — 2 BATS-Tests (RED: init timeout zu niedrig, backoffLimit zu hoch).
+
+**Nicht geändert (SSOT-Schutz):**
+- `k3d/pocket-id.yaml` — pocket-id Deployment (Keine Änderung nötig — wird durch readiness/liveness probes gesteuert)
+- `k3d/kustomization.yaml` — registriert bereits pocket-id-client-seed.yaml
+- `openspec/specs/fleet-operations.md` — Spezifikation, kein Delta nötig
+
+## Vorgehen
+
+- [ ] **Task 0: Failing-Test ist bereits rot im Branch — `tests/spec/pocket-id-client-seed-timeout.bats` (RED, Step 1)**
+  - Branch enthält 2 BATS-Tests in `tests/spec/pocket-id-client-seed-timeout.bats`:
+    - **Test 1 (RED)**: init container darf nicht `-ge 60` haben (Bug-Wert). Aktuell FAIL — der BUG: der Manifest hat noch den zu niedrigen Timeout.
+    - **Test 2 (RED)**: backoffLimit darf nicht `5` sein (zu hoch für das erhöhte Init-Timeout). Aktuell FAIL — noch Bug-Wert.
+  - **Step 1: verify test fails (RED-Sanity, reproduces the bug):**
+    ```bash
+    tests/unit/lib/bats-core/bin/bats tests/spec/pocket-id-client-seed-timeout.bats
+    ```
+    **expected: FAIL** — mindestens Test 1 und 2 scheitern, weil der Manifest noch den Bug-Wert enthält.
+
+- [ ] **Task 1: Fix in `k3d/pocket-id-client-seed.yaml` anwenden (GREEN, Step 2)**
+  - Datei: `k3d/pocket-id-client-seed.yaml`.
+  - **Schritt 2a: Init-Container-Timeout erhöhen:** In der Init-Container-Logik den Schwellwert von 60 auf 300 ändern:
+    ```bash
+    if [ "$i" -ge 300 ]; then
+      echo "pocket-id not healthy after 600s"; exit 1
+    fi
+    ```
+  - **Schritt 2b: backoffLimit senken:** `backoffLimit: 5` → `backoffLimit: 2`. Da der Init-Container jetzt intern bis zu 600s wartet, braucht es weniger Pod-Restarts.
+  - **Schritt 2c: Meldung im Init-Container anpassen:** `echo "waiting for pocket-id health ($i/300)..."` (optional, zur Konsistenz).
+
+- [ ] **Task 2: GREEN-Sanity — die 2 neuen Tests sind jetzt grün**
+  - **Step 2: run the test, expect PASS (GREEN) after fix is applied:**
+    ```bash
+    tests/unit/lib/bats-core/bin/bats tests/spec/pocket-id-client-seed-timeout.bats
+    ```
+    **expected: PASS** — beide Tests laufen grün durch, weil der Manifest die erhöhten Timeout-Werte enthält.
+
+- [ ] **Task 3: Verifikation — alle Quality-Gates grün (Verify-Task)**
+  - `task test:changed` — fokussierte Tests für die geänderten Dateien (`k3d/pocket-id-client-seed.yaml`, `tests/spec/pocket-id-client-seed-timeout.bats`). Expect PASS.
+  - `task freshness:regenerate && task freshness:check` — generierte Artefakte (test-inventory.json, route-manifest, baseline.json) bleiben aktuell. Expect grün.
+  - `task workspace:validate` — k3d-Kustomize-Manifests valid. Expect Exit 0.
+  - `bash scripts/openspec.sh validate` — OpenSpec-Change-Struktur gültig. Expect Exit 0.
+
+- [ ] **Task 4: Branch-Lock prüfen + Commit + Push + PR**
+  - Branch-Lock steht bereits (`fix/t001327-pocket-id-client-seed-timeout` claimed via `agent-lock.sh`).
+  - Commit-Message: `fix(infra): pocket-id-client-seed: Init-Timeout 120s→600s, backoffLimit 5→2 [T001327]`
+  - `git push -u origin fix/t001327-pocket-id-client-seed-timeout` → PR via `gh-axi pr create`.
+  - PR-Body muss verlinken: T001327 (this), T001326 (Root-Cause-of).
+  - `agent-lock.sh release ticket T001327` und `release branch fix/t001327-pocket-id-client-seed-timeout` nach erfolgreichem Push.
+
+> **Verifikations-Resultate (nach Task 3):**
+> - `task test:changed`: ✓ (pocket-id-client-seed-timeout.bats: 2/2 PASS)
+> - `task freshness:check`: ✓ 0 neue Violations
+> - `task workspace:validate`: ✓ Exit 0
+> - `bash scripts/openspec.sh validate pocket-id-client-seed-timeout`: ✓ keine Errors

--- a/tests/spec/pocket-id-client-seed-timeout.bats
+++ b/tests/spec/pocket-id-client-seed-timeout.bats
@@ -1,0 +1,37 @@
+#!/usr/bin/env bats
+# tests/spec/pocket-id-client-seed-timeout.bats
+# SSOT: openspec/changes/pocket-id-client-seed-timeout/tasks.md (T001327)
+#
+# Verifies that the pocket-id-client-seed init container timeout is raised
+# to accommodate cold-start scenarios. RED phase: expects -ge 60 (the
+# too-low default); GREEN phase: expects -ge 300 (the fix).
+#
+# Run: tests/unit/lib/bats-core/bin/bats tests/spec/pocket-id-client-seed-timeout.bats
+# or:  task test:unit SPEC=pocket-id-client-seed-timeout
+
+REPO_ROOT="${REPO_ROOT:-$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)}"
+K3D="${REPO_ROOT}/k3d"
+MANIFEST="${K3D}/pocket-id-client-seed.yaml"
+
+setup() {
+  load 'test_helper'
+}
+
+# ── RED phase: reproduces the bug ──────────────────────────────────────────
+
+@test "pocket-id-client-seed: init container timeout is sufficient for cold start (RED: -ge 60 is too low)" {
+  # The bug: init container fails after 60 iterations (120s) when pocket-id
+  # + shared-db are still starting. This test FAILS because we expect the
+  # timeout to be higher than the buggy value.
+  #
+  # RED → after fix: change expectation from 60 to 300
+  grep -qE 'if \[ "\$i" -ge 60 \];' "$MANIFEST" && return 1 || return 0
+}
+
+@test "pocket-id-client-seed: backoffLimit is reasonable for the increased timeout" {
+  # The job's backoffLimit should be lowered (from 5 to 2) since the
+  # init container now waits much longer internally.
+  #
+  # RED → after fix: change expectation from 5 to 2
+  grep -qE 'backoffLimit: 5' "$MANIFEST" && return 1 || return 0
+}


### PR DESCRIPTION
## Problem
T001327 (Root cause of T001326): Der `pocket-id-client-seed` Job-Init-Container pollt pocket-id mit 60 Iterationen × 2s = 120s Timeout. Bei Kaltstart (Cluster-Reset, parallel zu shared-db + pocket-id) reicht das nicht — DB-Migration + App-Init brauchen oft >2 Minuten.

## Solution
- **Init-Container-Timeout:** 60 → 300 Iterationen (600s statt 120s)
- **backoffLimit:** 5 → 2 (redundant mit längerem internem Timeout)

## Tests
- `tests/spec/pocket-id-client-seed-timeout.bats`: 2 BATS-Tests (RED→GREEN, reproduzieren Bug + verifizieren Fix)
- `task workspace:validate`: ✅
- `task test:changed`: ✅ (openspec-validate 12/12, code-quality 52/52)
- `task freshness:check`: ✅

Closes T001327
Relates-to T001326