### PR TITLE
chore: gitignore presentation/ and drop unused ContactHub sidebarTitle prop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# ── Lokale Artefakte (nicht versioniert) ────────
+presentation/
+
 # ── Secrets (niemals committen!) ────────────────
 .env
 .env.*

--- a/website/src/components/ContactHub.svelte
+++ b/website/src/components/ContactHub.svelte
@@ -14,7 +14,6 @@
     showPhone?: boolean;
     email?: string;
     city?: string;
-    sidebarTitle?: string;
     sidebarText?: string;
     sidebarCta?: string;
     showSteps?: boolean;
@@ -31,7 +30,6 @@
     showPhone = false,
     email = '',
     city = '',
-    sidebarTitle = '',
     sidebarText = '',
     sidebarCta = '',
     showSteps = false,

--- a/website/src/pages/kontakt.astro
+++ b/website/src/pages/kontakt.astro
@@ -78,7 +78,6 @@ const seoOgImage = await getSeoOgImage(BRAND_ID, 'kontakt').catch(() => null);
     showPhone={kontakt.showPhone}
     email={displayEmail}
     city={displayCity}
-    sidebarTitle={kontakt.sidebarTitle}
     sidebarText={kontakt.sidebarText}
     sidebarCta={kontakt.sidebarCta}
     showSteps={kontakt.showSteps}


### PR DESCRIPTION
## Summary
- `presentation/` (lokaler Mentolder-Design-Deck-Workdir, große Binär-Assets) zur `.gitignore` hinzugefügt
- nicht mehr genutztes `sidebarTitle`-Prop aus `ContactHub.svelte` entfernt

## Test plan
- [x] `task workspace:validate` / quality-check liefen beim Commit-Hook (0 neue Violations)
- [ ] CI grün abwarten

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MF3cArF2Mm4Zvz4enyiHZj