### PR TITLE
chore(ci): dedupe website vitest run in coverage gate [T001336]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,23 +201,24 @@ jobs:
           cd website
           pnpm lint
 
-      - name: Run website unit tests
+      - name: Run website unit tests (with coverage)
         # Default 5s per-test timeout is too tight for DB-heavy tests
         # (e.g. tickets/cockpit-db.test.ts seeds 1005 rows) when vitest
         # runs ~243 files in parallel on shared CI runners.
+        # --coverage is on by default here so the suite runs once, not twice —
+        # it also feeds the coverage gate step below. [T001336]
         run: |
           cd website
-          pnpm exec vitest run --testTimeout=30000
+          pnpm exec vitest run --coverage --testTimeout=30000
 
       - name: Vitest line coverage gate (>= 60% on src/lib)
         # G-TEST05 — vitest's built-in thresholds block on regression below
         # 60% lines (see website/vitest.config.ts coverage.thresholds.lines).
-        # The script below is a belt-and-braces second check: it also extracts
-        # the JSON coverage summary and asserts the threshold explicitly, so a
-        # misconfigured reporter cannot silently bypass the gate.
+        # Belt-and-braces second check against the coverage-summary.json
+        # produced by the run above, so a misconfigured reporter cannot
+        # silently bypass the gate. Does NOT re-run vitest. [T001336]
         run: |
           cd website
-          pnpm exec vitest run --coverage --testTimeout=30000
           COV=$(jq -r '.total.lines.pct' coverage/coverage-summary.json)
           echo "Total line coverage: ${COV}%"
           awk -v cov="$COV" 'BEGIN { if (cov + 0 < 60) { print "::error::Coverage gate failed: " cov "% < 60%"; exit 1 } else { print "::notice::Coverage gate passed: " cov "% >= 60%" } }'

--- a/docs/code-quality/loc-budget.json
+++ b/docs/code-quality/loc-budget.json
@@ -1,8 +1,8 @@
 {
-  "total_lines": 510895,
+  "total_lines": 511554,
   "file_count": 3924,
-  "commit": "a29d5354",
-  "measured_at": "2026-06-30T20:56:44.077Z",
+  "commit": "f88874ce",
+  "measured_at": "2026-06-30T21:03:48.721Z",
   "thresholds": {
     "warn_pct": 5,
     "fail_pct": 15,


### PR DESCRIPTION
## Summary
- Der `Vitest (website)`-Job führte die komplette 304-Datei-Testsuite zweimal aus: einmal `vitest run`, direkt danach nochmal `vitest run --coverage` für das Line-Coverage-Gate.
- Beide Läufe zu einem einzigen `vitest run --coverage` zusammengeführt; der Coverage-Gate-Step liest jetzt die bereits erzeugte `coverage-summary.json` statt vitest erneut zu starten.
- Keine Verhaltensänderung: gleiche Tests, gleiches >=60%-Lines-Gate.

## Test plan
- [x] `pnpm exec vitest run --coverage --testTimeout=30000` lokal verifiziert: 303 Testdateien grün (12 skipped), 1985 Tests grün, Coverage 61.12% (Gate-Logik gegen `coverage-summary.json` bestätigt: 61.12% >= 60% → pass)
- [x] `task workspace:validate`, `task freshness:regenerate`, `task quality:check` grün
- [ ] CI grün auf diesem PR (required check `Vitest (website)` läuft mit dem geänderten Workflow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MF3cArF2Mm4Zvz4enyiHZj