### PR TITLE
fix(website): restore G-CQ03 --max-warnings 0 lint gate [T001337]

### DIFF
--- a/docs/code-quality/loc-budget.json
+++ b/docs/code-quality/loc-budget.json
@@ -1,8 +1,8 @@
 {
-  "total_lines": 511003,
+  "total_lines": 511469,
   "file_count": 3924,
-  "commit": "98c2770e",
-  "measured_at": "2026-06-30T22:17:38.206Z",
+  "commit": "57da2f94",
+  "measured_at": "2026-06-30T22:42:34.671Z",
   "thresholds": {
     "warn_pct": 5,
     "fail_pct": 15,

--- a/docs/code-quality/loc-budget.json
+++ b/docs/code-quality/loc-budget.json
@@ -1,8 +1,8 @@
 {
-  "total_lines": 511469,
+  "total_lines": 511577,
   "file_count": 3924,
-  "commit": "57da2f94",
-  "measured_at": "2026-06-30T22:42:34.671Z",
+  "commit": "3fb6b581",
+  "measured_at": "2026-06-30T22:47:12.817Z",
   "thresholds": {
     "warn_pct": 5,
     "fail_pct": 15,

--- a/openspec/changes/website-strict-lint-gate-regression/proposal.md
+++ b/openspec/changes/website-strict-lint-gate-regression/proposal.md
@@ -1,0 +1,55 @@
+# Proposal: website-strict-lint-gate-regression
+
+_Ticket: T001337_
+
+## Why
+
+G-CQ03 (T001204, PR #2146, `done`) shipped `website/`'s ESLint setup with a fail-closed
+`--max-warnings 0` gate — 0 warnings at merge time. Two days later, PR #2296 (commit
+`02eb3da8`, "chore: ts hygiene configs", sub-commit "fix(website): relax legacy TS lint
+gates") silently removed `--max-warnings 0` from `website/package.json`'s `lint`/`lint:fix`
+scripts and set `noUnusedLocals`/`noUnusedParameters` to explicit `false` in
+`website/tsconfig.json`, while only downgrading `no-explicit-any`/`no-unused-vars` from `off`
+to `warn` (not `error`). The CI step still named "Run ESLint (--max-warnings 0 fail-closed
+gate)" (`.github/workflows/ci.yml`, `vitest-website` job) has not enforced what its own name
+claims since that commit. Verified now: `website/` carries 431 ESLint warnings and `pnpm lint`
+exits 0 regardless.
+
+The regression is independently confirmed by a pre-existing, currently-RED test:
+`tests/spec/ci-cd.bats` — `"G-CQ03: website package.json has a lint script with
+--max-warnings 0"` and `"G-CQ03: ESLint runs clean (0 warnings) when deps are installed"` both
+fail on `main` today.
+
+Out of scope / not affected: the separate `astro-check` CI job ("Astro TypeScript Check",
+REQ-ASTRO-TC-004 in `openspec/specs/astro-type-check.md`) already gates real TypeScript errors
+independently of ESLint and currently passes (0 errors) — this bug is scoped to the ESLint
+warnings gate only, no new TS-error CI job is needed.
+
+## What
+
+- Restore `website/eslint.config.js`'s `@typescript-eslint/no-explicit-any` and
+  `@typescript-eslint/no-unused-vars` to `'error'` (their pre-regression-attempt intent —
+  PR #2296 only got as far as `'warn'` before giving up).
+- Re-enable `noUnusedLocals`/`noUnusedParameters` in `website/tsconfig.json`.
+- Fix all resulting findings in `website/` source (currently 431 ESLint warnings + ~233
+  `astro check` hints, expected to mostly overlap) — no behavior change, pure
+  cleanup/typing.
+- Restore `--max-warnings 0` on `website/package.json`'s `lint`/`lint:fix` scripts so the
+  existing CI step actually does what its name says.
+- Confirm `tests/spec/ci-cd.bats` G-CQ03 cases go GREEN.
+
+## Impact
+
+- **Modified:** `website/eslint.config.js`, `website/tsconfig.json`, `website/package.json`,
+  and whichever `website/src/**` / `website/tests/**` files carry findings.
+- **Not modified:** `.github/workflows/ci.yml` (the gate step already exists and is correctly
+  wired — only the script it calls was defanged), `tests/spec/ci-cd.bats` (test already
+  exists and is correct, no edit needed — it just needs to turn green).
+- **Risk:** none beyond a large mechanical diff — every change is either deleting genuinely
+  unused code/imports or narrowing `any` to concrete/`unknown` types based on existing usage;
+  no runtime behavior changes. Tests must stay green throughout as the behavior-preservation
+  check.
+- **Out of scope:** any subproject other than `website/` (VideoVault, brett, mentolder-web,
+  mediaviewer-widget, packages/videovault-player, studio-server — separately scoped, much
+  larger debt, decided out-of-scope for this fix); adopting type-aware/`strict-type-checked`
+  ESLint rules beyond what was already configured pre-regression.

--- a/openspec/changes/website-strict-lint-gate-regression/specs/ci-cd.md
+++ b/openspec/changes/website-strict-lint-gate-regression/specs/ci-cd.md
@@ -1,0 +1,29 @@
+## ADDED Requirements
+
+### Requirement: website ESLint fail-closed gate stays enforced
+
+The `website/` ESLint flat config (`website/eslint.config.js`) SHALL set
+`@typescript-eslint/no-explicit-any` and `@typescript-eslint/no-unused-vars` to `error`
+severity, and `website/package.json`'s `lint`/`lint:fix` scripts SHALL invoke ESLint with
+`--max-warnings 0`, so that any future warning regression fails the PR-gate ESLint CI step
+("Run ESLint (--max-warnings 0 fail-closed gate)" in the `vitest-website` job) instead of
+being silently downgraded to a non-blocking warning.
+
+#### Scenario: lint script enforces zero warnings
+
+- **GIVEN** `website/package.json` is checked out
+- **WHEN** the `scripts.lint` entry is read
+- **THEN** it invokes `eslint . --max-warnings 0`
+
+#### Scenario: no-explicit-any and no-unused-vars are errors, not warnings
+
+- **GIVEN** `website/eslint.config.js` is checked out
+- **WHEN** the `rules` block is read
+- **THEN** `@typescript-eslint/no-explicit-any` and `@typescript-eslint/no-unused-vars` are both
+  set to `'error'` (the latter with `argsIgnorePattern: '^_'` / `varsIgnorePattern: '^_'`)
+
+#### Scenario: ESLint runs clean
+
+- **GIVEN** `website/` dependencies are installed (`pnpm install`)
+- **WHEN** `pnpm --prefix website lint` runs
+- **THEN** it exits 0 with zero errors and zero warnings

--- a/openspec/changes/website-strict-lint-gate-regression/tasks.md
+++ b/openspec/changes/website-strict-lint-gate-regression/tasks.md
@@ -9,12 +9,27 @@ shared_changes: false
 
 # Tasks: website-strict-lint-gate-regression (T001337)
 
-- [ ] Task 0: Bestehenden Regressionstest bestätigen (RED) — `tests/spec/ci-cd.bats`
-- [ ] Task 1: `@typescript-eslint/no-unused-vars`-Befunde beheben
-- [ ] Task 2: `@typescript-eslint/no-explicit-any`-Befunde beheben
-- [ ] Task 3: `noUnusedLocals`/`noUnusedParameters` in `website/tsconfig.json` reaktivieren
-- [ ] Task 4: ESLint-Regeln auf `error` + `--max-warnings 0` wiederherstellen
-- [ ] Task 5 (Final): Verifikation + Commit/PR
+- [x] Task 0: Bestehenden Regressionstest bestätigen (RED) — `tests/spec/ci-cd.bats`
+- [x] Task 1: `@typescript-eslint/no-unused-vars`-Befunde beheben
+- [x] Task 2: `@typescript-eslint/no-explicit-any`-Befunde beheben
+- [x] Task 3: `noUnusedLocals`/`noUnusedParameters` in `website/tsconfig.json` reaktivieren (Abweichung: nur `noUnusedParameters` aktiviert, siehe Hinweis unten)
+- [x] Task 4: ESLint-Regeln auf `error` + `--max-warnings 0` wiederherstellen
+- [x] Task 5 (Final): Verifikation + Commit/PR
+
+## Deviation note (Task 3)
+
+`noUnusedLocals: true` was **not** enabled. Empirically confirmed (minimal `.astro` repro) that
+Astro's `check` compiler has a false-positive bug: any identifier whose only usage is inside a
+frontmatter-level `return <expr>;` (the standard early-redirect-guard pattern, e.g.
+`if (!session) return Astro.redirect(getLoginUrl(...));`) is reported as `error ts(6133)
+declared but never read`, even though it is genuinely read. This pattern is used in 76 files
+across `website/src/pages/` for auth guards. Enabling `noUnusedLocals` turned this into 91 hard
+errors in the separate "Astro TypeScript Check" CI job (REQ-ASTRO-TC-004) — a job this plan's
+own proposal explicitly states is "Out of scope / not affected". `noUnusedParameters: true` alone
+does not trigger the bug (verified) and surfaced exactly one genuine unused parameter
+(`src/pages/admin/termine.astro:388`, fixed). Final state: `noUnusedLocals: false`,
+`noUnusedParameters: true`, `astro check` → 0 errors/0 warnings/115 hints (all 115 are the
+known false-positive pattern, non-blocking).
 
 ---
 

--- a/openspec/changes/website-strict-lint-gate-regression/tasks.md
+++ b/openspec/changes/website-strict-lint-gate-regression/tasks.md
@@ -1,0 +1,321 @@
+---
+title: "website-strict-lint-gate-regression: restore G-CQ03 --max-warnings 0 gate"
+ticket_id: T001337
+domains: [website, cq, lint, ci]
+status: plan_staged
+file_locks: []
+shared_changes: false
+---
+
+# Tasks: website-strict-lint-gate-regression (T001337)
+
+- [ ] Task 0: Bestehenden Regressionstest bestätigen (RED) — `tests/spec/ci-cd.bats`
+- [ ] Task 1: `@typescript-eslint/no-unused-vars`-Befunde beheben
+- [ ] Task 2: `@typescript-eslint/no-explicit-any`-Befunde beheben
+- [ ] Task 3: `noUnusedLocals`/`noUnusedParameters` in `website/tsconfig.json` reaktivieren
+- [ ] Task 4: ESLint-Regeln auf `error` + `--max-warnings 0` wiederherstellen
+- [ ] Task 5 (Final): Verifikation + Commit/PR
+
+---
+
+# website-strict-lint-gate-regression — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:executing-plans — execute tasks in
+> order, RED before GREEN, verify each gate before moving on.
+
+**Goal:** Die in G-CQ03 (T001204) bereits gebaute, aber durch PR #2296 (commit `02eb3da8`)
+wieder entschärfte ESLint-`--max-warnings 0`-Gate in `website/` wiederherstellen — ohne
+Verhaltensänderung am ausgelieferten Code, nur Code-Hygiene und Config.
+
+**Architecture:** Kein neues Tooling, keine neuen ESLint-Regeln — ausschließlich die bereits in
+`website/eslint.config.js` und `website/tsconfig.json` konfigurierten, aber teils auf `warn`
+bzw. `false` gedrosselten Regeln auf ihre ursprünglich beabsichtigte Schärfe zurücksetzen. Die
+separate `astro-check`-CI-Job ("Astro TypeScript Check", REQ-ASTRO-TC-004) deckt bereits echte
+TS-Fehler ab und bleibt unverändert — dieser Plan fasst sie nicht an.
+
+**Reihenfolge ist bewusst gewählt:** zuerst der Code-Cleanup (Task 1-2, kein Gate-Wechsel,
+`main` bleibt während der Umsetzung grün lintbar mit der aktuell laufenden Konfiguration), dann
+erst die Konfiguration scharf stellen (Task 3-4). Würde man zuerst die Konfiguration
+verschärfen, wäre der Branch zwischen den Schritten lokal nicht mehr grün lintbar, was die
+Zwischenverifikation nach jeder Datei erschwert.
+
+**Tech Stack:** ESLint 9 (`typescript-eslint`, bereits installiert), TypeScript 6 (`astro
+check`), BATS (bestehender Regressionstest), pnpm (`website/pnpm-lock.yaml`).
+
+## Global Constraints
+
+- Geltungsbereich ausschließlich `website/`. Keine andere Datei außerhalb von `website/`
+  anfassen (insbesondere `.github/workflows/ci.yml` NICHT ändern — der Gate-Schritt dort ist
+  bereits korrekt verdrahtet, nur das von ihm aufgerufene `pnpm lint`-Script war entschärft).
+- Paket-Manager im `website/`-Verzeichnis ist **pnpm** (Lockfile `website/pnpm-lock.yaml`) —
+  niemals `npm install` dort ausführen.
+- Kein API-/Runtime-Verhalten ändert sich — jede Änderung ist entweder das Entfernen
+  nachweislich ungenutzten Codes oder das Verengen eines `any`-Typs auf einen konkreten Typ
+  bzw. `unknown` anhand der tatsächlichen Verwendung. Die bestehende Test-Suite
+  (`pnpm exec vitest run`) muss nach jedem bearbeiteten Verzeichnis grün bleiben — ein roter
+  Test bedeutet, eine "ungenutzte" Variable hatte doch einen Seiteneffekt; in diesem Fall die
+  Änderung an dieser Stelle zurücknehmen statt den Test anzupassen.
+- `website/eslint.config.js` (.js, S1-Limit 600 Zeilen) und `website/tsconfig.json` (.json,
+  S1-ungated) sind bestehende, kleine Dateien — Restbudget unkritisch, keine Split-Maßnahme
+  nötig.
+- Fälle, in denen die Ersatz-Typisierung für ein `any` nicht eindeutig aus dem unmittelbaren
+  Funktionskontext ableitbar ist: nicht raten. Solche Fälle sammeln und vor dem Commit dem
+  Menschen vorlegen statt einen falschen Typ zu erfinden.
+
+## File Structure
+
+```
+website/eslint.config.js     ← MODIFY: no-explicit-any/no-unused-vars 'warn' → 'error'
+website/tsconfig.json        ← MODIFY: noUnusedLocals/noUnusedParameters false → true
+website/package.json         ← MODIFY: lint/lint:fix Scripts bekommen --max-warnings 0 zurück
+website/src/**                ← MODIFY: nur von ESLint/astro check markierte Dateien
+website/tests/**              ← MODIFY: nur von ESLint/astro check markierte Dateien
+```
+
+---
+
+## Task 0: Bestehenden Regressionstest bestätigen (RED)
+
+**Files:** keine — der Test existiert bereits (`tests/spec/ci-cd.bats`), wird hier nur erneut
+ausgeführt, um den Ausgangszustand zu bestätigen.
+
+### Step 1: Regressionstest laufen lassen
+
+```bash
+tests/unit/lib/bats-core/bin/bats tests/spec/ci-cd.bats
+```
+
+**Expected: FAIL** — die Fälle `"G-CQ03: website package.json has a lint script with
+--max-warnings 0"` und `"G-CQ03: ESLint runs clean (0 warnings) when deps are installed"`
+müssen rot sein. Run the test to verify it fails before any further change in diesem Branch.
+Alle anderen `@test`-Fälle in dieser Datei (G-CD01/G-CD02/G-CI01/G-SIZE04) dürfen bereits grün
+sein — sie gehören zu anderen, unabhängigen SSOT-Specs.
+
+---
+
+## Task 1: `@typescript-eslint/no-unused-vars`-Befunde beheben
+
+**Files:** nur Dateien, die im Report aus Step 1 unten auftauchen (Pfade vorab nicht bekannt —
+Umfang wird zur Laufzeit über den ESLint-Report ermittelt, nicht hier aufgezählt).
+
+### Step 1: Aktuellen Stand ermitteln
+
+```bash
+cd website && pnpm lint --format json > /tmp/lint-report.json
+node -e "
+const d = require('/tmp/lint-report.json');
+let errors=0, warnings=0; const byRule = {};
+for (const f of d) { errors+=f.errorCount; warnings+=f.warningCount;
+  for (const m of f.messages) byRule[m.ruleId] = (byRule[m.ruleId]||0)+1; }
+console.log('errors:', errors, 'warnings:', warnings); console.log(byRule);
+"
+```
+
+Erwartung: 0 errors, Warnings ganz überwiegend in `@typescript-eslint/no-unused-vars` und
+`@typescript-eslint/no-explicit-any`. Taucht eine dritte Regel mit nennenswerter Anzahl auf,
+die hier nicht behandelt wird: Umsetzung an dieser Stelle pausieren und dem Menschen vorlegen,
+statt eigenmächtig zu entscheiden.
+
+### Step 2: Entscheidungsbaum je Fund anwenden
+
+Für jede Meldung der Regel `@typescript-eslint/no-unused-vars` an `message.line`/`column`:
+
+| Fall | Aktion |
+|---|---|
+| Named Import, einziger Specifier in der Zeile, nirgends sonst referenziert | Ganze `import`-Zeile löschen |
+| Named Import, einer von mehreren Specifiers | Nur diesen Specifier (samt Komma) entfernen |
+| Lokale Deklaration ohne weitere Verwendung, Initializer ohne erkennbaren Seiteneffekt (Literal, reiner Property-Read, einfacher interner Funktionsaufruf ohne I/O) | Ganze Zeile löschen |
+| Lokale Deklaration, Initializer mit möglichem Seiteneffekt (I/O, DB-Query, Logging, externer Aufruf) | NICHT löschen — Bezeichner zu `_` umbenennen, Aufruf bleibt stehen |
+| Funktionsparameter, der nicht der letzte in der Signatur ist | Wird vom Default (`args: 'after-used'`) meist gar nicht gemeldet; taucht er trotzdem auf: zu `_<name>` umbenennen und `argsIgnorePattern: '^_'` zur Regel-Option in `website/eslint.config.js` ergänzen |
+| Letzter/einziger Parameter, ersatzlos entfernbar (kein externer Signatur-Constraint) | Aus der Signatur entfernen |
+| Letzter/einziger Parameter, durch Interface/Callback-Typ erzwungen | `_`-Präfix + `argsIgnorePattern` wie oben |
+| Destrukturierte Variable aus Objekt, nur ein Feld ungenutzt | Nur dieses Feld aus der Destrukturierung entfernen |
+| `catch (e)` mit ungenutztem `e` | `catch {` ohne Parameter (gültiges modernes JS/TS) |
+
+Nach jeder Datei sofort prüfen, dass nichts kaputt ist:
+
+```bash
+npx tsc --noEmit -p website/tsconfig.json 2>&1 | grep "error TS"
+```
+
+### Step 3: Verzeichnisweise verifizieren
+
+Reihenfolge: `website/src/lib/` → `website/src/pages/` → `website/src/components/` →
+`website/tests/`. Nach jedem abgeschlossenen Verzeichnis:
+
+```bash
+cd website && pnpm lint --format json | node -e "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>{const d=JSON.parse(s);let w=0,e=0;for(const f of d){w+=f.warningCount;e+=f.errorCount;}console.log('errors:',e,'warnings:',w);})"
+pnpm exec vitest run --testTimeout=30000
+```
+
+Die Warning-Zahl muss sinken, darf nie steigen. Tests müssen grün bleiben — ein roter Test
+bedeutet einen übersehenen Seiteneffekt; Änderung an dieser Stelle zurücknehmen.
+
+---
+
+## Task 2: `@typescript-eslint/no-explicit-any`-Befunde beheben
+
+**Files:** nur Dateien aus dem Report (siehe Task 1, Step 1).
+
+### Step 1: Entscheidungsbaum je Fund anwenden
+
+| Fall | Aktion |
+|---|---|
+| `catch (e: any)` | Ersetzen durch `catch (e)` (TS strict gibt `e` automatisch `unknown`); Folgenutzung mit `e instanceof Error ? e.message : String(e)` absichern |
+| Wert wird nur durchgereicht, nie selbst gelesen (generischer Wrapper/Logging-Helper) | Generisches Typparameter `<T>` einführen, sonst `unknown` |
+| Wert aus `JSON.parse(...)` oder `await res.json()`, danach mit `.prop`-Zugriffen gelesen | `unknown` deklarieren, lokales `interface`/`type` mit genau den nachfolgend gelesenen Properties definieren, direkt danach `as <NeuerTypName>` casten mit kurzem Kommentar zur Quelle |
+| Mock-HTTP-Response/Mock-DB-Row in einer Testdatei | `Record<string, unknown>` falls nur durchgereicht, sonst lokales `interface Mock<Name>` mit den genutzten Feldern |
+| Drittanbieter-Callback ohne Typdeklaration, aber `@types/<paket>` bereits installiert (`grep '"@types/' website/package.json`) | Korrekten Typ aus der Lib importieren |
+| Generisches Utility, das absichtlich beliebige Eingaben akzeptiert | Generisches Typparameter `<T>` statt `any` |
+| Shape nicht eindeutig aus dem unmittelbaren Funktionskontext ableitbar | Nicht raten — Fall sammeln und vor dem Commit dem Menschen vorlegen |
+
+Nach jeder Datei:
+
+```bash
+npx tsc --noEmit -p website/tsconfig.json 2>&1 | grep "error TS"
+```
+
+### Step 2: Gesamtstand nach Task 1+2
+
+```bash
+cd website && pnpm lint
+```
+
+**Erwartung:** `0 problems` (0 errors, 0 warnings) mit der aktuell noch unveränderten
+Konfiguration (Task 3/4 verschärfen die Konfiguration erst danach).
+
+---
+
+## Task 3: `noUnusedLocals`/`noUnusedParameters` reaktivieren
+
+**Files:** Modify: `website/tsconfig.json`
+
+### Step 1: Flags umstellen
+
+In `website/tsconfig.json` die beiden Zeilen
+
+```json
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+```
+
+ändern zu
+
+```json
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+```
+
+### Step 2: Neu auftauchende Hints beheben
+
+```bash
+cd website && npx astro check
+```
+
+Verbleibende Hints nach derselben Entscheidungstabelle wie Task 1, Step 2 beheben (Astro
+meldet unused locals/params als Hints, nicht als Errors — `astro check` selbst bricht dadurch
+nicht ab; die eigentliche Durchsetzung erfolgt über die ESLint-Regel `no-unused-vars` aus
+Task 1, weshalb hier nur noch wenige Restfälle erwartet werden, die ESLint nicht erfasst hat,
+z. B. reine `.astro`-Frontmatter-Spezialfälle).
+
+**Erwartung:** `0 errors, 0 warnings, 0 hints`.
+
+---
+
+## Task 4: ESLint-Regeln auf `error` + `--max-warnings 0` wiederherstellen
+
+**Files:** Modify: `website/eslint.config.js`, `website/package.json`
+
+### Step 1: Regel-Severity in `website/eslint.config.js`
+
+Im `rules`-Block die beiden Zeilen
+
+```js
+      '@typescript-eslint/no-explicit-any': 'warn',
+      '@typescript-eslint/no-unused-vars': 'warn',
+```
+
+ändern zu
+
+```js
+      '@typescript-eslint/no-explicit-any': 'error',
+      '@typescript-eslint/no-unused-vars': 'error',
+```
+
+Falls in Task 1 der Fall "Parameter mit `_`-Präfix" aufgetreten ist, stattdessen:
+
+```js
+      '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+```
+
+### Step 2: `--max-warnings 0` in `website/package.json`
+
+```json
+    "lint": "eslint . --max-warnings 0",
+    "lint:fix": "eslint . --max-warnings 0 --fix",
+```
+
+### Step 3: Verifizieren
+
+```bash
+cd website && pnpm lint
+```
+
+**Erwartung:** Exit 0, `0 problems`. Taucht hier noch ein Fund auf: Task 1/2 hat einen Fall
+übersehen — dorthin zurück, betroffene Datei nach der jeweiligen Tabelle nachbehandeln, dann
+hier erneut prüfen.
+
+---
+
+## Task 5 (Final): Verifikation, Freshness, Commit + PR
+
+**Files:** keine neuen — nur Verifikation und Commit der bisherigen Änderungen.
+
+### Step 1: Regressionstest GREEN bestätigen
+
+```bash
+tests/unit/lib/bats-core/bin/bats tests/spec/ci-cd.bats
+```
+
+Alle `G-CQ03`-Fälle aus Task 0 müssen jetzt grün sein.
+
+### Step 2: Vollständige Verifikation
+
+```bash
+cd website && pnpm lint && npx astro check && pnpm exec vitest run --testTimeout=30000
+```
+
+Alle drei müssen grün sein (lint exit 0, astro check 0/0/0, Tests grün).
+
+### Step 3: Pflicht-Gates
+
+```bash
+task test:changed
+task freshness:regenerate
+task freshness:check
+```
+
+Alle drei müssen exit 0 liefern. `task freshness:regenerate` regeneriert ggf. generierte
+Artefakte (z. B. Test-Inventar) — etwaige Änderungen mitcommitten.
+
+### Step 4: Commit, Push, PR
+
+```bash
+git add website/eslint.config.js website/tsconfig.json website/package.json website/src website/tests
+git commit -m "fix(website): restore G-CQ03 --max-warnings 0 lint gate [T001337]"
+git push -u origin fix/website-strict-lint-gate-regression
+bash scripts/preflight-pr-scope.sh "fix(website): restore G-CQ03 --max-warnings 0 lint gate [T001337]"
+gh pr create --title "fix(website): restore G-CQ03 --max-warnings 0 lint gate [T001337]" \
+  --body "Regression fix: PR #2296 silently dropped the --max-warnings 0 gate that G-CQ03/T001204 shipped. Restores it, fixes the 431 warnings that had accumulated unenforced, and re-enables noUnusedLocals/noUnusedParameters. No CI workflow changes — the existing gate step already calls the right script, it just needed the script itself fixed. tests/spec/ci-cd.bats G-CQ03 cases go from RED to GREEN."
+gh pr merge --auto --squash --delete-branch
+```
+
+**Definition of Done:**
+- `tests/spec/ci-cd.bats` — alle `G-CQ03`-Fälle grün.
+- `cd website && pnpm lint` → exit 0, `0 problems`.
+- `cd website && npx astro check` → `0 errors, 0 warnings, 0 hints`.
+- `website/eslint.config.js`: `no-explicit-any`/`no-unused-vars` auf `error`.
+- `website/tsconfig.json`: `noUnusedLocals`/`noUnusedParameters` auf `true`.
+- `website/package.json`: `lint`-Script enthält `--max-warnings 0`.
+- `task test:changed`, `task freshness:regenerate`, `task freshness:check` grün.
+- Keine Datei außerhalb von `website/` verändert.

--- a/website/eslint.config.js
+++ b/website/eslint.config.js
@@ -21,9 +21,9 @@ export default tseslint.config(
   {
     languageOptions: { globals: { ...globals.browser, ...globals.node } },
     rules: {
-      '@typescript-eslint/no-explicit-any': 'warn',
+      '@typescript-eslint/no-explicit-any': 'error',
       'svelte/require-each-key': 'off',
-      '@typescript-eslint/no-unused-vars': 'warn',
+      '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }],
       'svelte/prefer-svelte-reactivity': 'off',
       'no-useless-assignment': 'off',
       'no-useless-escape': 'off',

--- a/website/package.json
+++ b/website/package.json
@@ -14,8 +14,8 @@
     "test": "node tests/api.test.mjs",
     "test:api": "node tests/api.test.mjs",
     "test:unit": "vitest run",
-    "lint": "eslint .",
-    "lint:fix": "eslint . --fix",
+    "lint": "eslint . --max-warnings 0",
+    "lint:fix": "eslint . --max-warnings 0 --fix",
     "knip": "knip",
     "astro:check": "astro check"
   },

--- a/website/src/components/DependencyGraph.svelte
+++ b/website/src/components/DependencyGraph.svelte
@@ -195,13 +195,6 @@
 
   const layout = $derived(graphData ? layoutNodes(graphData) : []);
   const nodePos = $derived(new Map(layout.map(n => [n.id, n])));
-  const maxLayer = $derived(layout.reduce((m, n) => Math.max(m, n.layer), 0));
-  const maxPerLayer = $derived(layout.reduce((acc, n) => {
-    acc[n.layer] = (acc[n.layer] ?? 0) + 1;
-    return acc;
-  }, {} as Record<number, number>));
-  const svgW = $derived(PAD * 2 + (maxLayer + 1) * LAYER_GAP_X);
-  const svgH = $derived(PAD * 2 + Math.max(...Object.values(maxPerLayer), 1) * NODE_GAP_Y);
 </script>
 
 <div class="dag-container">

--- a/website/src/components/FactoryFloor.svelte
+++ b/website/src/components/FactoryFloor.svelte
@@ -24,7 +24,7 @@
   import type { QaItem } from '../lib/qa-dal';
   import type { CiRollup } from '../lib/factory-ci';
   import { SSE_RECONNECT_MS } from '../lib/factory-constants';
-  import { relTime, minutesSince, prUrl, ticketUrl, planUrl, prioDot } from '../lib/factory-floor-client';
+  import { relTime, prUrl, ticketUrl, planUrl, prioDot } from '../lib/factory-floor-client';
 
   let { initial }: { initial: FloorPayload | null } = $props();
 
@@ -99,7 +99,7 @@
       void refreshCi(data.hall.filter(w => w.prNumber).map(w => w.extId));
       window.dispatchEvent(new CustomEvent('factory-floor-refreshed', {
         detail: {
-          planningCount: (data as any).planningCount,
+          planningCount: data?.planningCount,
           hallActive: data?.hall.length ?? 0,
         },
       }));

--- a/website/src/components/Footer.astro
+++ b/website/src/components/Footer.astro
@@ -19,8 +19,9 @@ const footerTagline = config.legal.tagline  || kontaktOverride?.footerTagline?.t
 const gestaltetsIn  = stammdaten?.city      || kontaktOverride?.footerCity?.trim()    || config.contact.city || 'Lüneburg';
 
 // Copyright: effective footer config (DB) wins; legacy kontaktOverride; static config; hardcoded fallback
+// footerCopyright is persisted alongside KontaktContent but not part of its declared type
 const copyrightText = effectiveFooter?.copyright
-  || (kontaktOverride as any)?.footerCopyright?.trim()
+  || (kontaktOverride as (typeof kontaktOverride & { footerCopyright?: string }))?.footerCopyright?.trim()
   || config.footer.copyright
   || `© ${new Date().getFullYear()} mentolder — Alle Rechte vorbehalten`;
 

--- a/website/src/components/NavMobile.svelte
+++ b/website/src/components/NavMobile.svelte
@@ -20,7 +20,7 @@
     user = null,
     authChecked = false,
     streamLive = false,
-    pathname,
+    pathname: _pathname,
   }: Props = $props();
 
   function initial(name: string) {

--- a/website/src/components/Navigation.test.ts
+++ b/website/src/components/Navigation.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, fireEvent } from '@testing-library/svelte';
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/svelte';
 import NavMobile from './NavMobile.svelte';
 
 describe('NavMobile.svelte', () => {

--- a/website/src/components/PlanningOffice.svelte
+++ b/website/src/components/PlanningOffice.svelte
@@ -5,7 +5,7 @@
   import PlanningOfficeTriage from './PlanningOfficeTriage.svelte';
   import PlanningOfficeItem from './PlanningOfficeItem.svelte';
 
-  const { brand }: { brand: string } = $props();
+  const { brand: _brand }: { brand: string } = $props();
 
   interface PlanItem {
     extId: string;
@@ -49,7 +49,6 @@
   let dropTargetIdx: number | null = $state(null);
   let newDep = $state('');
   let touchDragExtId: string | null = $state(null);
-  let touchStartY = $state(0);
   let sheetSwipeStartY = $state(0);
 
   let isMobile = $derived(
@@ -169,7 +168,6 @@
   function onHandlePointerDown(e: PointerEvent, it: PlanItem) {
     if (!isMobile) return;
     touchDragExtId = it.extId;
-    touchStartY = e.clientY;
     (e.target as HTMLElement).setPointerCapture(e.pointerId);
   }
 
@@ -185,7 +183,7 @@
     }
   }
 
-  async function onHandlePointerUp(e: PointerEvent) {
+  async function onHandlePointerUp(_e: PointerEvent) {
     if (!touchDragExtId) return;
     if (dropTargetIdx !== null) {
       await patch(touchDragExtId, { rank: dropTargetIdx });

--- a/website/src/components/PortalSidekick.svelte
+++ b/website/src/components/PortalSidekick.svelte
@@ -43,8 +43,6 @@
   let pendingJump = $state<string | null>(null);
 
   // User identity for header / avatar
-  let userGivenName = $state('');
-  let userFamilyName = $state('');
   let userAvailable = $state(true);
 
   const STANDARD_WIDTH = 460;
@@ -104,9 +102,6 @@
           user?: { givenName?: string; familyName?: string };
         };
         if (!data.authenticated) return;
-
-        userGivenName = data.user?.givenName ?? '';
-        userFamilyName = data.user?.familyName ?? '';
 
         const qRes = await fetch('/api/portal/questionnaires');
         if (qRes.ok) {

--- a/website/src/components/QaModal.svelte
+++ b/website/src/components/QaModal.svelte
@@ -57,8 +57,8 @@
       }
       dispatch('submitted', { verdict });
       dispatch('close');
-    } catch (err: any) {
-      error = err.message;
+    } catch (err) {
+      error = err instanceof Error ? err.message : String(err);
     } finally {
       submitting = false;
     }

--- a/website/src/components/ServiceRow.svelte
+++ b/website/src/components/ServiceRow.svelte
@@ -29,7 +29,6 @@
     price,
     priceUnit,
     href,
-    icon,
     iconSpriteId,
     iconSpriteBrand,
   }: Props = $props();

--- a/website/src/components/SessionsListView.test.ts
+++ b/website/src/components/SessionsListView.test.ts
@@ -23,7 +23,7 @@ describe('SessionsListView', () => {
 
   it('dispatches mediaviewer:open-session on card click', async () => {
     const handler = vi.fn();
-    window.addEventListener('mediaviewer:open-session', handler as any);
+    window.addEventListener('mediaviewer:open-session', handler as EventListener);
     const { getByRole } = render(SessionsListView);
     await waitFor(() => getByRole('button', { name: /Feature-Intake/i }));
     await fireEvent.click(getByRole('button', { name: /Feature-Intake/i }));
@@ -31,7 +31,7 @@ describe('SessionsListView', () => {
     const ev = handler.mock.calls[0][0] as CustomEvent;
     expect(ev.detail.url).toBe('https://session-feature-intake.dev.example.test');
     expect(ev.detail.slug).toBe('feature-intake');
-    window.removeEventListener('mediaviewer:open-session', handler as any);
+    window.removeEventListener('mediaviewer:open-session', handler as EventListener);
   });
 
   it('shows an empty state when there are no sessions', async () => {

--- a/website/src/components/ShareFileInline.svelte
+++ b/website/src/components/ShareFileInline.svelte
@@ -4,8 +4,8 @@
   const {
     messagesBaseUrl,
     roomId,
-    role,
-    senderId,
+    role: _role,
+    senderId: _senderId,
     onclose,
     onshare,
   }: {
@@ -17,7 +17,6 @@
     onshare?: (msg: ChatMessage) => void;
   } = $props();
 
-  let closed = $state(false);
   let sharePath = $state('');
   let shareType = $state(3);
   let sharePassword = $state('');

--- a/website/src/components/TicketQuickEditFields.svelte
+++ b/website/src/components/TicketQuickEditFields.svelte
@@ -27,9 +27,9 @@
     editNotes: string;
     savingField: string | null;
     savedField: string | null;
-    selectedTicket: any;
+    selectedTicket: { status: TicketStatus };
     saveStatusFn: () => void;
-    saveFieldFn: (field: 'priority' | 'component' | 'notes', value: any) => void;
+    saveFieldFn: (field: 'priority' | 'component' | 'notes', value: string | Priority) => void;
   } = $props();
 </script>
 

--- a/website/src/components/admin/AdminShortcuts.svelte
+++ b/website/src/components/admin/AdminShortcuts.svelte
@@ -86,7 +86,7 @@
       } else {
         showError(await readError(res, 'Speichern fehlgeschlagen.'));
       }
-    } catch (e) {
+    } catch {
       showError('Netzwerkfehler beim Speichern.');
     } finally {
       saving = false;
@@ -105,7 +105,7 @@
       } else {
         showError(await readError(res, 'Löschen fehlgeschlagen.'));
       }
-    } catch (e) {
+    } catch {
       showError('Netzwerkfehler beim Löschen.');
     }
   }

--- a/website/src/components/admin/AdminSidebarNav.astro
+++ b/website/src/components/admin/AdminSidebarNav.astro
@@ -9,7 +9,7 @@ interface Props {
   path: string;
 }
 
-const { inboxPending, brettUrl, path, isKore } = Astro.props;
+const { inboxPending, brettUrl, path } = Astro.props;
 
 interface NavItem {
   href: string;

--- a/website/src/components/admin/ArchitekturGraph.svelte
+++ b/website/src/components/admin/ArchitekturGraph.svelte
@@ -24,7 +24,6 @@
   let graphEdges: GraphEdge[] = $state([]);
   let resolvedNamespaces: string[] = $state([]);
   let statusMap: Map<string, NodeStatus> = $state(new Map());
-  let podsByNamespace: Map<string, PodEntry[]> = $state(new Map());
   let warnings: Warning[] = $state([]);
   let selectedNode: GraphNode | null = $state(null);
   let graphLoaded = $state(false);
@@ -51,8 +50,8 @@
       graphEdges = data.edges;
       resolvedNamespaces = data.resolvedNamespaces ?? [];
       graphLoaded = true;
-    } catch (e: any) {
-      errorGraph = e.message ?? 'Graph-Ladefehler';
+    } catch (e) {
+      errorGraph = e instanceof Error ? e.message : 'Graph-Ladefehler';
     }
   }
 
@@ -70,13 +69,12 @@
           newMap.set(r.value.namespace, r.value.pods);
         }
       }
-      podsByNamespace = newMap;
       statusMap = buildStatusMap(graphNodes, newMap);
       unassignedCount = [...statusMap.values()].filter(s => !s.matched && s.color !== '#6b7280').length;
       lastUpdated = new Date();
       errorPods = '';
-    } catch (e: any) {
-      errorPods = e.message ?? 'Pod-Status-Fehler';
+    } catch (e) {
+      errorPods = e instanceof Error ? e.message : 'Pod-Status-Fehler';
     }
   }
 

--- a/website/src/components/admin/BulkToast.svelte
+++ b/website/src/components/admin/BulkToast.svelte
@@ -12,7 +12,7 @@
   export let onUndo: (token: string) => void;
   export let onDismiss: () => void;
 
-  let timerId: any;
+  let timerId: ReturnType<typeof setTimeout> | undefined;
 
   function startTimer() {
     if (result && result.failed === 0) {

--- a/website/src/components/admin/ClientContractsPanel.svelte
+++ b/website/src/components/admin/ClientContractsPanel.svelte
@@ -5,7 +5,7 @@
     isNewsletterSubscribed: boolean;
   };
 
-  const { keycloakUserId, clientEmail, isNewsletterSubscribed }: Props = $props();
+  const { keycloakUserId, clientEmail: _clientEmail, isNewsletterSubscribed }: Props = $props();
 
   type Template = { id: string; title: string };
   type Assignment = {

--- a/website/src/components/admin/ClientQuestionnairesPanel.svelte
+++ b/website/src/components/admin/ClientQuestionnairesPanel.svelte
@@ -4,7 +4,7 @@
   const { keycloakUserId }: Props = $props();
 
   type Assignment = { id: string; template_title: string; status: string; assigned_at: string; submitted_at: string | null };
-  type Template = { id: string; title: string };
+  type Template = { id: string; title: string; status: string };
 
   let assignments: Assignment[] = $state([]);
   let templates: Template[] = $state([]);
@@ -23,7 +23,7 @@
     ]);
     assignments = aRes.ok ? await aRes.json() : [];
     const allTpls: Template[] = tRes.ok ? await tRes.json() : [];
-    templates = allTpls.filter((t: any) => t.status === 'published');
+    templates = allTpls.filter((t) => t.status === 'published');
   }
 
   $effect(() => { loadData(); });

--- a/website/src/components/admin/Cockpit.svelte
+++ b/website/src/components/admin/Cockpit.svelte
@@ -100,36 +100,9 @@
     finally { setLoading(false); }
   }
 
-  async function pickFeature(extId: string) {
-    selectFeature(extId);
-    await loadFeature(extId);
-  }
-
   async function refetch() {
     if ($cockpitStore.selectedFeature) await loadFeature($cockpitStore.selectedFeature);
     await loadPortfolio();
-  }
-
-  async function featureAction(featureId: string, action: string, value?: boolean | string) {
-    try {
-      const res = await fetch('/api/admin/cockpit/feature-action', {
-        method: 'POST', headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ featureId, action, value }),
-      });
-      if (!res.ok) throw new Error(`feature-action ${res.status}`);
-      await loadPortfolio();
-    } catch (e) { setError(String((e as Error).message)); }
-  }
-
-  async function batchFeatureAction(actions: { featureId: string; action: string; value?: boolean | string }[]) {
-    try {
-      const res = await fetch('/api/admin/cockpit/feature-actions', {
-        method: 'POST', headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ actions }),
-      });
-      if (!res.ok) throw new Error(`feature-actions ${res.status}`);
-      await loadPortfolio();
-    } catch (e) { setError(String((e as Error).message)); }
   }
 </script>
 

--- a/website/src/components/admin/Cockpit.test.ts
+++ b/website/src/components/admin/Cockpit.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, fireEvent, waitFor } from '@testing-library/svelte';
 import Cockpit from './Cockpit.svelte';
 import { makePortfolio, makeProduct, makeFeature } from '../../lib/tickets/__tests__/fixtures';
+import type { PortfolioPayload } from '../../lib/tickets/cockpit-types';
 
 const portfolioWithFeature = makePortfolio([
   makeProduct({ features: [makeFeature({ health: 'amber' })] }),
@@ -13,7 +14,7 @@ afterEach(() => vi.restoreAllMocks());
 describe('Cockpit shell', () => {
   it('does not crash when portfolioInitial has no products field', () => {
     expect(() =>
-      render(Cockpit, { portfolioInitial: { error: 'db_error' } as any, brand: 'mentolder' })
+      render(Cockpit, { portfolioInitial: { error: 'db_error' } as unknown as PortfolioPayload, brand: 'mentolder' })
     ).not.toThrow();
   });
 

--- a/website/src/components/admin/Cockpit/FilterBar.svelte
+++ b/website/src/components/admin/Cockpit/FilterBar.svelte
@@ -68,7 +68,7 @@
     try {
       await navigator.clipboard.writeText(url);
       showToast('URL kopiert');
-    } catch (err) {
+    } catch {
       showToast('Kopieren fehlgeschlagen');
     }
   }

--- a/website/src/components/admin/Cockpit/FilterBar.test.ts
+++ b/website/src/components/admin/Cockpit/FilterBar.test.ts
@@ -2,7 +2,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, fireEvent } from '@testing-library/svelte';
 import FilterBar from './FilterBar.svelte';
-import { DEFAULT_PRESETS, savePreset, loadPresets, quotaEvictedFlag } from '../../../lib/cockpit-presets';
+import { DEFAULT_PRESETS, savePreset, loadPresets } from '../../../lib/cockpit-presets';
 
 describe('FilterBar Component', () => {
   beforeEach(() => {

--- a/website/src/components/admin/Cockpit/cockpit-mobile.test.ts
+++ b/website/src/components/admin/Cockpit/cockpit-mobile.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { render, fireEvent } from '@testing-library/svelte';
 import MobileToggle from './MobileToggle.svelte';
 import Cockpit from '../Cockpit.svelte';

--- a/website/src/components/admin/CockpitTable.svelte
+++ b/website/src/components/admin/CockpitTable.svelte
@@ -19,7 +19,8 @@
   let busy: Record<string, boolean> = {};
   let dragId: string | null = null;
   let search = '';
-  let toastResult: any = null;
+  type ToastResult = { changed: number; skipped: number; failed: number; status: string; undoToken?: string } | null;
+  let toastResult: ToastResult = null;
   // Default to "active" so the ~97% done tickets don't drown the few open ones.
   let statusFilter = 'active';
   const PAGE = 50;

--- a/website/src/components/admin/DatevExportWidget.svelte
+++ b/website/src/components/admin/DatevExportWidget.svelte
@@ -33,8 +33,8 @@
       const data = await res.json();
       statusMsg = `${data.count} Buchung${data.count !== 1 ? 'en' : ''} gesendet an ${data.to}`;
       status = 'success';
-    } catch (err: any) {
-      statusMsg = err.message ?? 'Unbekannter Fehler';
+    } catch (err) {
+      statusMsg = err instanceof Error ? err.message : 'Unbekannter Fehler';
       status = 'error';
     }
   }

--- a/website/src/components/admin/DorPanel.svelte
+++ b/website/src/components/admin/DorPanel.svelte
@@ -33,7 +33,7 @@
       } else {
         toast = 'Speichern fehlgeschlagen';
       }
-    } catch (e) {
+    } catch {
       toast = 'Speichern fehlgeschlagen';
     } finally {
       saving = false;

--- a/website/src/components/admin/DraftsInbox.svelte
+++ b/website/src/components/admin/DraftsInbox.svelte
@@ -184,7 +184,7 @@
           {#each list as d}
             <li class:active={detail?.id === d.id}>
               <button on:click={() => open(d.id)}>
-                {(d.suggestedPayload as any)?.title ?? '(ohne Titel)'}
+                {(d.suggestedPayload.title as string | undefined) ?? '(ohne Titel)'}
               </button>
             </li>
           {/each}

--- a/website/src/components/admin/GrillingStepper.test.ts
+++ b/website/src/components/admin/GrillingStepper.test.ts
@@ -40,10 +40,10 @@ describe('GrillingStepper', () => {
     await fireEvent.input(ta, { target: { value: 'Meine Antwort' } });
     await new Promise((r) => setTimeout(r, 1000));
     await waitFor(() => expect(global.fetch).toHaveBeenCalled());
-    const [url, opts] = (global.fetch as any).mock.calls.at(-1);
+    const [url, opts] = vi.mocked(global.fetch).mock.calls.at(-1)!;
     expect(url).toBe('/api/admin/tickets/t1');
-    expect(opts.method).toBe('PATCH');
-    const body = JSON.parse(opts.body);
+    expect(opts?.method).toBe('PATCH');
+    const body = JSON.parse(opts?.body as string);
     expect(body.grillingAnswers[QN].q1).toBe('Meine Antwort');
   });
 
@@ -53,8 +53,8 @@ describe('GrillingStepper', () => {
     expect(screen.getByText(first)).toBeTruthy();
     await fireEvent.click(screen.getByRole('button', { name: /Verwerfen/ }));
     await waitFor(() => expect(global.fetch).toHaveBeenCalled());
-    const [, opts] = (global.fetch as any).mock.calls.at(-1);
-    const body = JSON.parse(opts.body);
+    const [, opts] = vi.mocked(global.fetch).mock.calls.at(-1)!;
+    const body = JSON.parse(opts?.body as string);
     expect(body.grillingMeta[QN].dismissed).toContain('q1');
     expect(screen.getByText(QUESTIONNAIRES[QN].sections[0].questions[1].label)).toBeTruthy();
   });

--- a/website/src/components/admin/InhalteEditor.svelte
+++ b/website/src/components/admin/InhalteEditor.svelte
@@ -8,7 +8,7 @@
   import UebermichSection from './inhalte/UebermichSection.svelte';
   import SchemaEditor from './framework/SchemaEditor.svelte';
   import { schemaFor } from '../../lib/admin/schemas/index';
-  import ServicePageSection from './inhalte/ServicePageSection.svelte';
+  import ServicePageSection, { type ServicePageData } from './inhalte/ServicePageSection.svelte';
   import AngeboteSection from './inhalte/AngeboteSection.svelte';
   import FaqSection from './inhalte/FaqSection.svelte';
   import KontaktSection from './inhalte/KontaktSection.svelte';
@@ -22,8 +22,10 @@
   import type { HomepageContent, UebermichContent, FaqItem, KontaktContent, ReferenzenConfig, CustomSection as CustomSectionType, ServiceOverride, LeistungCategoryOverride, NavItem, FooterConfig, Stammdaten, KoreFlags } from '../../lib/website-db';
   type InitialData = {
     startseite: HomepageContent; uebermich: UebermichContent;
-    coaching: { value: any; version: number }; fuehrung: { value: any; version: number };
-    '50plus-digital': any; 'ki-transition': any; beratung: any;
+    coaching: { value: Record<string, unknown> | null; version: number }; fuehrung: { value: Record<string, unknown> | null; version: number };
+    '50plus-digital': ServicePageData & { isCatalogLinked?: boolean; catalogTiers?: Array<{ label: string; price: string; unit: string; highlight: boolean }> };
+    'ki-transition': ServicePageData & { isCatalogLinked?: boolean; catalogTiers?: Array<{ label: string; price: string; unit: string; highlight: boolean }> };
+    beratung: ServicePageData & { isCatalogLinked?: boolean; catalogTiers?: Array<{ label: string; price: string; unit: string; highlight: boolean }> };
     services: ServiceOverride[]; leistungen: LeistungCategoryOverride[];
     priceListUrl: string; faq: FaqItem[]; kontakt: KontaktContent;
     referenzen: ReferenzenConfig; rechtliches: Record<string, string>;

--- a/website/src/components/admin/KiCoachingDrawer.svelte
+++ b/website/src/components/admin/KiCoachingDrawer.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { interfaceById, type InterfaceDef } from '../../lib/ki-catalog';
+  import type { InterfaceDef } from '../../lib/ki-catalog';
 
   interface KiConfig {
     id: number; brand: string; provider: string;
@@ -57,10 +57,6 @@
   }
 
   $effect(() => { load(); });
-
-  function catalogEntryFor(provider: string): InterfaceDef | undefined {
-    return interfaceById(provider) ?? catalog.find((c) => c.id === provider);
-  }
 
   function startEdit(p: KiConfig) {
     editId = p.id;
@@ -149,8 +145,6 @@
     }
     await load();
   }
-
-  const activeId = $derived(providers.find((p) => p.isActive)?.id ?? null);
 </script>
 
 <div class="scrim" onclick={onclose} role="presentation"></div>

--- a/website/src/components/admin/KiProviderDrawer.svelte
+++ b/website/src/components/admin/KiProviderDrawer.svelte
@@ -39,7 +39,7 @@
   let {
     title, entries, health, catalog, editId, form, confirmingDelete,
     onclose, onsave, onedit, onnew, oncanceledit, ondelete, onconfirmdelete,
-    onchangepriority, onproviderchange, showtoast,
+    onchangepriority, onproviderchange, showtoast: _showtoast,
   }: Props = $props();
 
   function inCooldown(provider: string): boolean {

--- a/website/src/components/admin/KnowledgeJsonImport.svelte
+++ b/website/src/components/admin/KnowledgeJsonImport.svelte
@@ -6,7 +6,6 @@
   let done = $state(0);
   let total = $state(0);
   let errorMsg = $state('');
-  let collectionId = $state('');
 
   function onFileChange(e: Event) {
     const input = e.target as HTMLInputElement;
@@ -22,7 +21,6 @@
     done = 0;
     total = 0;
     errorMsg = '';
-    collectionId = '';
   }
 
   function closeModal() {
@@ -75,7 +73,6 @@
           if (event.type === 'progress') done = event.done as number;
           if (event.type === 'done') {
             done = total;
-            collectionId = event.collectionId as string;
             status = 'done';
           }
           if (event.type === 'error') {

--- a/website/src/components/admin/TicketDetailSections.astro
+++ b/website/src/components/admin/TicketDetailSections.astro
@@ -1,9 +1,19 @@
 ---
 import TicketActivityTimeline from './TicketActivityTimeline.svelte';
+import type { TimelineEntry } from '../../lib/tickets/admin';
 
+// Local shape matching the (unexported) TicketDetail fields this component actually reads.
+interface TicketLink {
+  id: number;
+  direction: 'out' | 'in';
+  kind: string;
+  otherId: string;
+  otherTitle: string;
+  prNumber: number | null;
+}
 interface Props {
-  ticket: any;
-  timeline: any[];
+  ticket: { id: string; links: TicketLink[] };
+  timeline: TimelineEntry[];
 }
 
 const { ticket, timeline } = Astro.props;
@@ -16,7 +26,7 @@ const { ticket, timeline } = Astro.props;
       Verknüpfungen ({ticket.links.length})
     </h2>
     <ul class="space-y-2">
-      {ticket.links.map((l: any) => (
+      {ticket.links.map((l: TicketLink) => (
         <li class="flex items-center gap-3 text-sm">
           <span class="text-xs text-muted w-32 shrink-0">
             {l.direction === 'out' ? l.kind : `${l.kind} (← in)`}

--- a/website/src/components/admin/TicketPlanPanel.test.ts
+++ b/website/src/components/admin/TicketPlanPanel.test.ts
@@ -37,7 +37,7 @@ describe('TicketPlanPanel', () => {
 
   it('clicking download button triggers blob download with correct filename', async () => {
     const createObjectURL = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:mock');
-    const revokeObjectURL = vi.spyOn(URL, 'revokeObjectURL').mockReturnValue();
+    const _revokeObjectURL = vi.spyOn(URL, 'revokeObjectURL').mockReturnValue();
 
     render(TicketPlanPanel, {
       props: { plan: mockPlan, renderedHtml: '', planContent: '# Test' },

--- a/website/src/components/admin/aktionen/AuditLog.svelte
+++ b/website/src/components/admin/aktionen/AuditLog.svelte
@@ -16,7 +16,7 @@
     error?: string;
     created_at: string;
     completed_at?: string;
-    payload?: any;
+    payload?: unknown;
   };
 
   let actions: Action[] = [];

--- a/website/src/components/admin/aktionen/KnowledgeTab.svelte
+++ b/website/src/components/admin/aktionen/KnowledgeTab.svelte
@@ -5,6 +5,7 @@
   export let cluster: string = 'mentolder';
 
   type Collection = { id: string; name: string; chunk_count: number; last_indexed_at: string | null; embedding_model: string };
+  type AuditAction = { target?: string; status: string };
 
   let collections: Collection[] = [];
   let loading = true;
@@ -27,9 +28,9 @@
     if (r.ok) {
       toast('success', `Reindex von "${c.name}" gestartet`);
       const poller = setInterval(async () => {
-        const status = await apiCall<{ actions: any[] }>(`/api/admin/ops/audit/log?action_filter=ai_reindex&limit=5`);
+        const status = await apiCall<{ actions: AuditAction[] }>(`/api/admin/ops/audit/log?action_filter=ai_reindex&limit=5`);
         if (status.ok) {
-          const last = status.data.actions?.find((a: any) => a.target === c.id);
+          const last = status.data.actions?.find((a) => a.target === c.id);
           if (last && (last.status === 'success' || last.status === 'failed')) {
             clearInterval(poller); pending[c.id] = false; pending = pending; load();
           }

--- a/website/src/components/admin/aktionen/ReleasesTab.svelte
+++ b/website/src/components/admin/aktionen/ReleasesTab.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onMount, onDestroy } from 'svelte';
+  import { onDestroy } from 'svelte';
   import { apiCall, toast } from '../../../lib/admin-api';
 
   export let cluster: string = 'mentolder';

--- a/website/src/components/admin/coaching/SessionsOverview.svelte
+++ b/website/src/components/admin/coaching/SessionsOverview.svelte
@@ -29,10 +29,6 @@
   function badgeCls(status: string) {
     return STATUS_OPTIONS.find(s => s.value === status)?.cls ?? 'badge-abandoned';
   }
-  function statusLabel(status: string) {
-    return STATUS_OPTIONS.find(s => s.value === status)?.label ?? status;
-  }
-
   async function load(p = page) {
     loading = true;
     const params = new URLSearchParams({

--- a/website/src/components/admin/framework/SchemaEditor.svelte
+++ b/website/src/components/admin/framework/SchemaEditor.svelte
@@ -45,11 +45,6 @@
     store.setValue(currentValue);
   }
 
-  function setNestedField(parentKey: string, childKey: string, val: unknown) {
-    const parent = (currentValue[parentKey] as Record<string, unknown>) ?? {};
-    currentValue = { ...currentValue, [parentKey]: { ...parent, [childKey]: val } };
-    store.setValue(currentValue);
-  }
 
   function getErrors(fieldKey: string): string[] {
     return store.get().errors.filter((e) => e.field === fieldKey).map((e) => e.message);

--- a/website/src/components/admin/framework/SectionFrame.svelte
+++ b/website/src/components/admin/framework/SectionFrame.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount, onDestroy } from 'svelte';
-  import type { createBehaviorStore, SaveState } from '$lib/admin/behaviorStore';
+  import type { createBehaviorStore } from '$lib/admin/behaviorStore';
   import { publicRouteFor } from '$lib/content-registry';
   import VersionDrawer from './VersionDrawer.svelte';
   import PreviewPane from './PreviewPane.svelte';

--- a/website/src/components/admin/framework/VersionDrawer.svelte
+++ b/website/src/components/admin/framework/VersionDrawer.svelte
@@ -23,8 +23,8 @@
       const res = await fetch(`/api/admin/content/versions?key=${encodeURIComponent(contentKey)}`);
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       versions = await res.json();
-    } catch (e: any) {
-      errorMsg = `Verlauf konnte nicht geladen werden: ${e?.message ?? 'Unbekannter Fehler'}`;
+    } catch (e) {
+      errorMsg = `Verlauf konnte nicht geladen werden: ${e instanceof Error ? e.message : 'Unbekannter Fehler'}`;
     } finally {
       loading = false;
     }
@@ -40,8 +40,8 @@
       });
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       window.location.reload();
-    } catch (e: any) {
-      alert(`Wiederherstellen fehlgeschlagen: ${e?.message ?? 'Unbekannter Fehler'}`);
+    } catch (e) {
+      alert(`Wiederherstellen fehlgeschlagen: ${e instanceof Error ? e.message : 'Unbekannter Fehler'}`);
     } finally {
       restoringId = null;
     }

--- a/website/src/components/admin/graph/GraphCanvas.svelte
+++ b/website/src/components/admin/graph/GraphCanvas.svelte
@@ -172,7 +172,7 @@
         <text x={rect.x + 8} y={rect.y + 16} fill="#64748b" font-size="11" font-family="ui-monospace, monospace">{rect.ns}</text>
       {/each}
 
-      {#each simEdges as edge, i}
+      {#each simEdges as edge}
         <line
           x1={edgeSource(edge).x} y1={edgeSource(edge).y}
           x2={edgeTarget(edge).x} y2={edgeTarget(edge).y}

--- a/website/src/components/admin/inhalte/FooterSection.svelte
+++ b/website/src/components/admin/inhalte/FooterSection.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { FooterConfig, FooterColumn, FooterLink } from '../../../lib/website-db';
+  import type { FooterConfig, FooterColumn } from '../../../lib/website-db';
 
   let { initialData }: { initialData: FooterConfig } = $props();
   let footerData = $state<FooterConfig>(JSON.parse(JSON.stringify(initialData)));

--- a/website/src/components/admin/inhalte/KontaktSection.svelte
+++ b/website/src/components/admin/inhalte/KontaktSection.svelte
@@ -4,7 +4,7 @@
   let { initialData }: { initialData: KontaktContent } = $props();
   let data = $state(JSON.parse(JSON.stringify(initialData)));
   // footerCopyright ist nicht im KontaktContent-Typ, aber wir laden/speichern es extra
-  let footerCopyright = $state((initialData as any).footerCopyright ?? '');
+  let footerCopyright = $state((initialData as KontaktContent & { footerCopyright?: string }).footerCopyright ?? '');
   let saving = $state(false); let msg = $state(''); let msgOk = $state(true);
 
   async function save() {

--- a/website/src/components/admin/inhalte/ReferenzenSection.svelte
+++ b/website/src/components/admin/inhalte/ReferenzenSection.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { ReferenzenConfig } from '../../../lib/website-db';
+  import type { ReferenzenConfig, ReferenzItem } from '../../../lib/website-db';
   let { initialData }: { initialData: ReferenzenConfig } = $props();
   let data=$state(JSON.parse(JSON.stringify(initialData)));
   if(!data.types)data.types=[];
@@ -16,7 +16,7 @@
   }
 
   function addType(){data.types=[...data.types,{id:crypto.randomUUID().slice(0,8),label:''}];}
-  function removeType(i:number){const id=data.types[i].id;data.types=data.types.filter((_:unknown,idx:number)=>idx!==i);data.items=data.items.map((it:any)=>it.type===id?{...it,type:undefined}:it);}
+  function removeType(i:number){const id=data.types[i].id;data.types=data.types.filter((_:unknown,idx:number)=>idx!==i);data.items=data.items.map((it:ReferenzItem)=>it.type===id?{...it,type:undefined}:it);}
   function addItem(){data.items=[...data.items,{id:crypto.randomUUID().slice(0,8),name:'',url:'',logoUrl:'',description:'',type:''}];}
   function removeItem(i:number){data.items=data.items.filter((_:unknown,idx:number)=>idx!==i);}
 

--- a/website/src/components/admin/inhalte/StartseiteSection.svelte
+++ b/website/src/components/admin/inhalte/StartseiteSection.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { HomepageContent, ProcessStep } from '../../../lib/website-db';
+  import type { HomepageContent } from '../../../lib/website-db';
 
   let { initialData }: { initialData: HomepageContent } = $props();
   let data = $state(JSON.parse(JSON.stringify(initialData)));

--- a/website/src/components/admin/ops/LogsTab.svelte
+++ b/website/src/components/admin/ops/LogsTab.svelte
@@ -23,14 +23,13 @@
 
   let lines: string[] = [];
   let streaming = false;
-  let podsLoading = false;
   let podsError: string | null = null;
 
   let logEl: HTMLElement;
   let es: EventSource | null = null;
 
   async function loadPods() {
-    podsLoading = true; podsError = null;
+    podsError = null;
     try {
       const res = await fetch(`/api/admin/cluster/pods-list?ns=${encodeURIComponent(ns)}`);
       const j = await res.json();
@@ -39,7 +38,6 @@
       selectedPod = pods[0]?.name ?? '';
       selectedContainer = pods[0]?.containers?.[0] ?? '';
     } catch (e) { podsError = (e as Error).message; }
-    finally { podsLoading = false; }
   }
 
   function startStream() {

--- a/website/src/components/admin/platform/AssetModal.svelte
+++ b/website/src/components/admin/platform/AssetModal.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
   import { createEventDispatcher } from 'svelte';
+  import type { SoftwareAsset } from '../../../lib/platform-db';
   const dispatch = createEventDispatcher();
 
-  export let asset: any;
+  export let asset: Partial<SoftwareAsset> & { clusters: string[] };
 
   let loading = false;
   let error: string | null = null;

--- a/website/src/components/admin/platform/AssetTicketDrawer.svelte
+++ b/website/src/components/admin/platform/AssetTicketDrawer.svelte
@@ -4,7 +4,15 @@
 
   export let slug: string;
 
-  let tickets: any[] = [];
+  interface AssetTicket {
+    id: string;
+    external_id: string;
+    title: string;
+    status: string;
+    created_at: string;
+  }
+
+  let tickets: AssetTicket[] = [];
   let loading = true;
   let error: string | null = null;
 

--- a/website/src/components/admin/platform/BackupStatusCard.svelte
+++ b/website/src/components/admin/platform/BackupStatusCard.svelte
@@ -26,8 +26,8 @@
       if (!r.ok) throw new Error(`Backup-Status nicht verfügbar (${r.status})`);
       const data = await r.json();
       pipelines = data.pipelines ?? [];
-    } catch (e: any) {
-      error = e.message;
+    } catch (e) {
+      error = e instanceof Error ? e.message : 'Backup-Status nicht verfügbar';
     } finally {
       loading = false;
     }

--- a/website/src/components/admin/platform/HardwareTab.svelte
+++ b/website/src/components/admin/platform/HardwareTab.svelte
@@ -1,9 +1,13 @@
 <script lang="ts">
   import { onMount } from 'svelte';
+  import type { HardwareAsset } from '../../../lib/platform-db';
 
   export let cluster: string;
 
-  let assets: any[] = [];
+  // Enriched server-side with live k8s node status — see GET /api/admin/platform/hardware.
+  type EnrichedHardwareAsset = HardwareAsset & { live_status: string; ready_status: string };
+
+  let assets: EnrichedHardwareAsset[] = [];
   let loading = true;
   let error: string | null = null;
 
@@ -15,7 +19,7 @@
       const data = await res.json();
       assets = data.assets;
     } catch (e) {
-      error = e.message;
+      error = e instanceof Error ? e.message : 'Failed to fetch hardware';
     } finally {
       loading = false;
     }

--- a/website/src/components/admin/platform/HealthTab.svelte
+++ b/website/src/components/admin/platform/HealthTab.svelte
@@ -1,19 +1,34 @@
 <script lang="ts">
   import { onMount } from 'svelte';
-  
+
   export let cluster: string;
-  
-  let data: any = null;
+
+  // Mirrors the (unexported) ServiceCheck type in src/pages/api/admin/ops/health.ts
+  interface ServiceCheck {
+    name: string;
+    slug: string;
+    url: string;
+    status: 'ok' | 'slow' | 'error' | 'optional';
+    latencyMs: number | null;
+    optional: boolean;
+    error?: string;
+  }
+  interface HealthData {
+    results: Record<string, ServiceCheck[]>;
+    checkedAt: string;
+  }
+
+  let data: HealthData | null = null;
   let loading = true;
   let error: string | null = null;
-  
+
   async function fetchHealth() {
     try {
       const r = await fetch('/api/admin/ops/health');
       if (!r.ok) throw new Error('Health fetch failed');
       data = await r.json();
-    } catch (e: any) {
-      error = e.message;
+    } catch (e) {
+      error = e instanceof Error ? e.message : 'Health fetch failed';
     } finally {
       loading = false;
     }

--- a/website/src/components/admin/platform/SoftwareTab.svelte
+++ b/website/src/components/admin/platform/SoftwareTab.svelte
@@ -2,14 +2,24 @@
   import { onMount } from 'svelte';
   import AssetModal from './AssetModal.svelte';
   import AssetTicketDrawer from './AssetTicketDrawer.svelte';
+  import type { SoftwareAsset } from '../../../lib/platform-db';
 
   export let cluster: string;
 
-  let assets: any[] = [];
+  // Enriched server-side with live k8s status — see GET /api/admin/platform/software.
+  type EnrichedAsset = SoftwareAsset & {
+    live_status: string;
+    replicas: { ready: number; total: number };
+    serviceUrl: string | null;
+  };
+
+  type EditableAsset = Partial<EnrichedAsset> & { clusters: string[] };
+
+  let assets: EnrichedAsset[] = [];
   let loading = true;
   let error: string | null = null;
   let showModal = false;
-  let selectedAsset: any = null;
+  let selectedAsset: EditableAsset | null = null;
   let showTickets = false;
   let ticketSlug = '';
 
@@ -21,13 +31,13 @@
       const data = await res.json();
       assets = data.assets;
     } catch (e) {
-      error = e.message;
+      error = e instanceof Error ? e.message : 'Failed to fetch assets';
     } finally {
       loading = false;
     }
   }
 
-  function openEdit(asset: any) {
+  function openEdit(asset: EnrichedAsset) {
     selectedAsset = { ...asset };
     showModal = true;
   }

--- a/website/src/components/admin/ui/AdminBadge.svelte
+++ b/website/src/components/admin/ui/AdminBadge.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import type { Snippet } from 'svelte';
+
   interface Props {
     variant?: 'success' | 'warning' | 'error' | 'info' | 'neutral';
     size?: 'sm' | 'md';
@@ -10,7 +12,7 @@
     size = 'md',
     dot = false,
     children,
-  }: Props & { children?: any } = $props();
+  }: Props & { children?: Snippet } = $props();
 </script>
 
 <span

--- a/website/src/components/assistant/AgentGuideView.svelte
+++ b/website/src/components/assistant/AgentGuideView.svelte
@@ -7,7 +7,6 @@
   } from '../../lib/agentGuideSearch';
   import GuideFindBar from './agent-guide/GuideFindBar.svelte';
   import GuideGroup from './agent-guide/GuideGroup.svelte';
-  import GuideCard from './agent-guide/GuideCard.svelte';
   import GuideMap from './agent-guide/GuideMap.svelte';
 
   let { jumpTo: jumpToProp = null }: { jumpTo?: string | null } = $props();

--- a/website/src/components/assistant/PipelineSidekickView.svelte
+++ b/website/src/components/assistant/PipelineSidekickView.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-  import { PIPELINE_LANES, STATUS_BUCKETS } from '../../lib/tickets/pipeline-order';
+  import { PIPELINE_LANES } from '../../lib/tickets/pipeline-order';
   import type { FloorPayload, HallItem, StagedItem, LoadingDockItem, ShippedItem } from '../../lib/factory-floor-types';
   import PhaseStepper from '../factory/PhaseStepper.svelte';
 
-  let { onClose }: { onClose: () => void } = $props();
+  let { onClose: _onClose }: { onClose: () => void } = $props();
 
   let floor = $state<FloorPayload | null>(null);
   let qaItems = $state<{ extId: string }[]>([]);
@@ -54,15 +54,15 @@
     return typeof t === 'object' && t !== null && 'phase' in t;
   }
 
-  function ticketLabel(t: { extId: string }): string {
-    if ('title' in t && typeof (t as any).title === 'string' && (t as any).title) {
-      return (t as any).title;
+  function ticketLabel(t: { extId: string; title?: string }): string {
+    if ('title' in t && typeof t.title === 'string' && t.title) {
+      return t.title;
     }
     return t.extId;
   }
 
-  function ticketPrio(t: { extId: string }): string {
-    return 'priority' in t ? (t as any).priority as string : '';
+  function ticketPrio(t: { extId: string; priority?: string }): string {
+    return 'priority' in t ? (t.priority ?? '') : '';
   }
 
   function toggleLane(key: string) {
@@ -137,7 +137,7 @@
   {#if error}
     <p class="err">{error}</p>
   {:else if loading && !floor}
-    {#each lanes as lane}
+    {#each lanes as _lane}
       <div class="pv-skeleton" aria-hidden="true"></div>
     {/each}
   {:else}

--- a/website/src/components/assistant/QuestionnaireView.svelte
+++ b/website/src/components/assistant/QuestionnaireView.svelte
@@ -19,7 +19,7 @@
 
   type AnswerRecord = { question_id: string; option_key: string; details_text?: string | null };
 
-  let { onCloseView }: { onCloseView?: () => void } = $props();
+  let { onCloseView: _onCloseView }: { onCloseView?: () => void } = $props();
 
   let loading = $state(true);
   let assignments = $state<Assignment[]>([]);

--- a/website/src/components/assistant/SidekickHeader.svelte
+++ b/website/src/components/assistant/SidekickHeader.svelte
@@ -14,8 +14,6 @@
     onToggleExpand?: () => void;
     available?: boolean;
   } = $props();
-
-  const isHome = $derived(!onBack);
 </script>
 
 <div class="sk-header">

--- a/website/src/components/assistant/agent-guide/GuideMap.svelte
+++ b/website/src/components/assistant/agent-guide/GuideMap.svelte
@@ -8,7 +8,6 @@
   let {
     map,
     active = null,
-    glossaryTerms = [],
     onSelect,
   }: {
     map: MapData;

--- a/website/src/components/factory/BudgetPanel.svelte
+++ b/website/src/components/factory/BudgetPanel.svelte
@@ -47,8 +47,8 @@
 
       summary = await summaryRes.json();
       recentRuns = await recentRes.json();
-    } catch (err: any) {
-      error = err.message || 'Ein unbekannter Fehler ist aufgetreten';
+    } catch (err) {
+      error = err instanceof Error ? err.message : 'Ein unbekannter Fehler ist aufgetreten';
     } finally {
       loading = false;
     }

--- a/website/src/components/factory/ControlCard.svelte
+++ b/website/src/components/factory/ControlCard.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
+  import type { Snippet } from 'svelte';
+
   let {
     title = '',
     children,
   }: {
     title?: string;
-    children?: any;
+    children?: Snippet;
   } = $props();
 </script>
 

--- a/website/src/components/factory/FactoryBudgetPage.svelte
+++ b/website/src/components/factory/FactoryBudgetPage.svelte
@@ -60,8 +60,8 @@
       summary = await sRes.json();
       recentRuns = await rRes.json();
       if (summary) limitInput = summary.limit !== null ? summary.limit.toString() : '';
-    } catch (err: any) {
-      error = err.message || 'Fehler beim Laden';
+    } catch (err) {
+      error = err instanceof Error ? err.message : 'Fehler beim Laden';
     } finally {
       loading = false;
     }
@@ -81,8 +81,8 @@
       if (!res.ok) throw new Error('Fehler beim Speichern');
       saveSuccess = true;
       if (summary) summary.limit = parsed;
-    } catch (err: any) {
-      saveError = err.message || 'Fehler beim Speichern';
+    } catch (err) {
+      saveError = err instanceof Error ? err.message : 'Fehler beim Speichern';
     } finally {
       saving = false;
     }
@@ -97,8 +97,8 @@
       if (!res.ok) throw new Error('Ticket nicht gefunden');
       ticketRows = await res.json();
       if (ticketRows.length === 0) ticketSearchError = 'Keine Budgetdaten gefunden.';
-    } catch (err: any) {
-      ticketSearchError = err.message || 'Fehler bei der Suche';
+    } catch (err) {
+      ticketSearchError = err instanceof Error ? err.message : 'Fehler bei der Suche';
     } finally {
       searchingTicket = false;
     }

--- a/website/src/components/factory/FactoryObservability.svelte
+++ b/website/src/components/factory/FactoryObservability.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { onMount } from 'svelte';
   import FactoryKpiCard from './FactoryKpiCard.svelte';
-  import { TEXT_MUTED, SURFACE, BORDER, ACCENT } from './factory-chart-colors';
+  import { ACCENT } from './factory-chart-colors';
 
   interface PromResult {
     metric: Record<string, string>;
@@ -51,14 +51,6 @@
     return Math.round(s * 100) / 100;
   }
 
-  function latestValue(result: PromResult[]): number {
-    for (const r of result) {
-      const vals = r.values;
-      if (vals.length > 0) return parseFloat(vals[vals.length - 1][1]) || 0;
-    }
-    return 0;
-  }
-
   function phaseDurationTotals(dur: PromMatrix | null): Record<string, number> {
     const out: Record<string, number> = {};
     if (!dur?.data?.result) return out;
@@ -71,15 +63,6 @@
     return out;
   }
 
-  function phaseStateCounts(timeline: TimelineRow[]): Map<string, number> {
-    const m = new Map<string, number>();
-    for (const t of timeline) {
-      const k = `${t.brand}:${t.phase}`;
-      m.set(k, (m.get(k) || 0) + 1);
-    }
-    return m;
-  }
-
   function brandBadge(b: string): string {
     return b === 'korczewski' ? 'KOR' : 'MEN';
   }
@@ -89,8 +72,8 @@
       const res = await fetch('/api/factory-observability', { credentials: 'same-origin' });
       if (!res.ok) throw new Error(`API ${res.status}`);
       data = await res.json();
-    } catch (e: any) {
-      error = e.message || 'Fehler beim Laden';
+    } catch (e) {
+      error = e instanceof Error ? e.message : 'Fehler beim Laden';
     } finally {
       loading = false;
     }

--- a/website/src/components/factory/FactoryPhaseHeatmap.svelte
+++ b/website/src/components/factory/FactoryPhaseHeatmap.svelte
@@ -2,14 +2,6 @@
   import { onMount } from 'svelte';
   import { PHASE_LABELS, DAY_LABELS, heatmapColor } from './factory-chart-colors';
 
-  interface PhaseEvent {
-    phase: string;
-    state: string;
-    detail: string | null;
-    driver: string;
-    at: string;
-  }
-
   interface HallItem {
     extId: string;
     phase: string | null;

--- a/website/src/components/factory/StagedColumn.svelte
+++ b/website/src/components/factory/StagedColumn.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   let {
     staged,
-    stagedWaiting,
+    stagedWaiting: _stagedWaiting,
     releasing,
     releaseErr,
     manualHintFor,

--- a/website/src/components/factory/WorkpieceCard.svelte
+++ b/website/src/components/factory/WorkpieceCard.svelte
@@ -36,7 +36,6 @@
   let displayPrio  = $derived((item?.priority ?? ticket?.priority ?? 'low').toLowerCase());
   let isBlocked    = $derived(item?.phaseState === 'blocked');
   let isDevflow    = $derived(item?.driver === 'devflow');
-  let isAlert      = $derived(isBlocked);
   let edgeStyle    = $derived(PRIO_EDGE[displayPrio] ?? PRIO_EDGE.low);
   let prioLabel    = $derived(PRIO_LABEL[displayPrio] ?? displayPrio);
 

--- a/website/src/components/factory/factory-chart-colors.ts
+++ b/website/src/components/factory/factory-chart-colors.ts
@@ -1,13 +1,8 @@
-const BG = '#0a0a0a';
 export const SURFACE = '#141414';
-const SURFACE_ELEVATED = '#1a1a1a';
 export const BORDER = '#2a2a2a';
-const TEXT_PRIMARY = '#e5e5e5';
-const TEXT_SECONDARY = '#a3a3a3';
 export const TEXT_MUTED = '#737373';
 export const ACCENT = '#f59e0b';
 export const SUCCESS = '#10b981';
-const ERROR = '#ef4444';
 
 const HEATMAP_MIN = '#1a2634';
 const HEATMAP_MAX = '#f59e0b';

--- a/website/src/components/inbox/InboxApp.svelte
+++ b/website/src/components/inbox/InboxApp.svelte
@@ -282,11 +282,6 @@
     selectedId = visible[next].id;
   }
 
-  /** Map the public UI status label ("done") to the DB status ("actioned"). */
-  function uiToDb(s: string): InboxStatus {
-    if (s === 'done') return 'actioned';
-    return s as InboxStatus;
-  }
 
   function setStatus(s: InboxStatus): void {
     // Always mirror the active status into the URL so that the test assertion

--- a/website/src/components/inbox/InboxDetail.svelte
+++ b/website/src/components/inbox/InboxDetail.svelte
@@ -2,7 +2,7 @@
      Right-hand pane. Shared header (avatar, title, meta, ↑↓ nav) +
      per-type body block + footer with actions. -->
 <script lang="ts">
-  import type { InboxItem, InboxType, Message } from '../../lib/messaging-db';
+  import type { InboxItem, Message } from '../../lib/messaging-db';
   import { TYPE_META, initialsOf } from './type-meta';
 
   interface Props {

--- a/website/src/components/kore/KoreHomepage.svelte
+++ b/website/src/components/kore/KoreHomepage.svelte
@@ -46,8 +46,6 @@
   export let initialTimeline: TimelineRow[] = [];
   export let wantsTimeline: boolean = false;
 
-  // Nav active section
-  let activeSection = 'leistungen';
 
   // Booking slot picker
   let pickedSlot: string | null = null;

--- a/website/src/components/live/rooms/PollBroadcastModal.svelte
+++ b/website/src/components/live/rooms/PollBroadcastModal.svelte
@@ -97,7 +97,7 @@
             class="w-full bg-dark-light border border-dark-lighter rounded-lg px-3 py-2 text-sm text-light focus:outline-none focus:border-gold" />
           {#if kind === 'multiple_choice'}
             <div class="flex flex-col gap-1.5">
-              {#each options as opt, i}
+              {#each options as _opt, i}
                 <div class="flex gap-1.5">
                   <input type="text" bind:value={options[i]} maxlength="100" placeholder="Option…"
                     class="flex-1 bg-dark-light border border-dark-lighter rounded-lg px-3 py-1.5 text-sm text-light focus:outline-none focus:border-gold" />

--- a/website/src/components/portal/DiensteSection.astro
+++ b/website/src/components/portal/DiensteSection.astro
@@ -6,7 +6,7 @@ interface Props {
   keycloakBase: string;
   isKore?: boolean;
 }
-const { ncBase, vaultUrl, bretUrl = '', keycloakBase, isKore = false } = Astro.props;
+const { ncBase, vaultUrl, bretUrl = '' } = Astro.props;
 
 const services = [
   ...(ncBase ? [

--- a/website/src/components/sessions/SessionsHistory.svelte
+++ b/website/src/components/sessions/SessionsHistory.svelte
@@ -1,15 +1,15 @@
 <script lang="ts">
   import { onDestroy } from 'svelte';
+  import type { ArchivedSession } from '../../lib/sessions/archive';
 
   // Svelte 5 runes
-  let items = $state<any[]>([]);
+  let items = $state<ArchivedSession[]>([]);
   let loading = $state(false);
   let error = $state<string | null>(null);
   let offset = $state(0);
   let hasMore = $state(false);
   let typeFilter = $state('');
   let selectedMarkdown = $state<string | null>(null);
-  let selectedId = $state<string | null>(null);
 
   let abortController: AbortController | null = null;
 
@@ -49,9 +49,9 @@
         items = [...items, ...data.items];
       }
       hasMore = data.hasMore;
-    } catch (err: any) {
-      if (err.name !== 'AbortError') {
-        error = err.message || 'Ein Fehler ist aufgetreten';
+    } catch (err) {
+      if (!(err instanceof Error) || err.name !== 'AbortError') {
+        error = err instanceof Error ? err.message : 'Ein Fehler ist aufgetreten';
       }
     } finally {
       loading = false;
@@ -69,8 +69,7 @@
     if (abortController) abortController.abort();
   });
 
-  async function openSession(item: any) {
-    selectedId = item.id;
+  async function openSession(item: ArchivedSession) {
     selectedMarkdown = null;
     loading = true;
     try {
@@ -88,7 +87,6 @@
 
   function closeSession() {
     selectedMarkdown = null;
-    selectedId = null;
   }
 </script>
 

--- a/website/src/components/sessions/TemplatePicker.test.ts
+++ b/website/src/components/sessions/TemplatePicker.test.ts
@@ -30,11 +30,11 @@ describe('TemplatePicker', () => {
 
   it('dispatches template:select on card click', async () => {
     const handler = vi.fn();
-    window.addEventListener('template:select', handler as any);
+    window.addEventListener('template:select', handler as EventListener);
     const { getByRole } = render(TemplatePicker);
     await waitFor(() => getByRole('button', { name: /Feature-Intake/i }));
     await fireEvent.click(getByRole('button', { name: /Feature-Intake/i }));
     expect(handler).toHaveBeenCalledOnce();
-    window.removeEventListener('template:select', handler as any);
+    window.removeEventListener('template:select', handler as EventListener);
   });
 });

--- a/website/src/layouts/AdminLayout.astro
+++ b/website/src/layouts/AdminLayout.astro
@@ -4,7 +4,6 @@ import '../styles/admin-foundation.css';
 import '../styles/admin-premium.css';
 import '../styles/sidekick-panels.css';
 import { config } from '../config/index';
-import { icons } from './admin-icons';
 import TicketWidgetBar from '../components/TicketWidgetBar.astro';
 import AssistantWidget from '../components/assistant/AssistantWidget.svelte';
 const ASSISTANT_ENABLED = (process.env.ENABLE_ASSISTANT_ADMIN ?? 'false') === 'true';
@@ -20,15 +19,6 @@ import AdminSidebarNav from '../components/admin/AdminSidebarNav.astro';
 
 interface Props {
   title: string;
-}
-
-interface NavItem {
-  href: string;
-  label: string;
-  icon: string;
-  matches?: string[];
-  badge?: number;
-  external?: boolean;
 }
 
 const { title } = Astro.props;
@@ -84,7 +74,7 @@ const brandWord = config.meta.siteTitle.replace(/\.de$/i, '').toLowerCase();
         if (localStorage.getItem('admin-sidebar-collapsed') === '1') {
           document.documentElement.classList.add('sidebar-collapsed');
         }
-      } catch (_) {}
+      } catch {}
     </script>
   </head>
   <body class={isKore ? 'kore' : ''} style="min-height:100vh; background:var(--admin-bg); color:var(--admin-text); display:flex; font-family:var(--font-sans); overflow-x:hidden;">

--- a/website/src/lib/__tests__/admin-actions.test.ts
+++ b/website/src/lib/__tests__/admin-actions.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import type { Pool } from 'pg';
 import { startAction, finishAction, checkConcurrent, ConcurrentActionError } from '../admin-actions';
 
@@ -39,7 +39,7 @@ describe('checkConcurrent', () => {
 describe('finishAction', () => {
   it('updates status to success', async () => {
     const queries: string[] = [];
-    const pool = mockPool((q, params) => { queries.push(q); return { rows: [] }; });
+    const pool = mockPool((q, _params) => { queries.push(q); return { rows: [] }; });
     await finishAction(pool, 42, { status: 'success', payload: { ok: true } });
     expect(queries[0]).toMatch(/UPDATE public\.admin_actions/);
   });

--- a/website/src/lib/__tests__/sanitize.test.ts
+++ b/website/src/lib/__tests__/sanitize.test.ts
@@ -23,7 +23,7 @@ describe('sanitizeForLog', () => {
   });
 
   it('handles undefined input', () => {
-    expect(sanitizeForLog(undefined as any)).toBe('');
+    expect(sanitizeForLog(undefined)).toBe('');
   });
 
   it('truncates very long messages', () => {

--- a/website/src/lib/admin-actions.ts
+++ b/website/src/lib/admin-actions.ts
@@ -1,7 +1,5 @@
 import type { Pool } from 'pg';
 
-type ActionStatus = 'in_progress' | 'success' | 'failed' | 'partial_success';
-
 interface StartActionInput {
   actor: string;
   action: string;
@@ -57,7 +55,20 @@ export async function finishAction(pool: Pool, id: number, input: FinishActionIn
   );
 }
 
-export async function listActions(pool: Pool, opts: { actionFilter?: string; limit?: number } = {}): Promise<any[]> {
+export interface AdminActionRow {
+  id: number;
+  actor: string;
+  action: string;
+  target: string | null;
+  cluster: string | null;
+  status: string;
+  error: string | null;
+  created_at: Date;
+  completed_at: Date | null;
+  payload: unknown;
+}
+
+export async function listActions(pool: Pool, opts: { actionFilter?: string; limit?: number } = {}): Promise<AdminActionRow[]> {
   const limit = Math.min(opts.limit ?? 50, 500);
   const result = await pool.query(
     `SELECT id, actor, action, target, cluster, status, error, created_at, completed_at, payload

--- a/website/src/lib/admin-api.test.ts
+++ b/website/src/lib/admin-api.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { toast, apiCall } from './admin-api';
 
 describe('admin-api.toast', () => {

--- a/website/src/lib/admin-api.ts
+++ b/website/src/lib/admin-api.ts
@@ -43,7 +43,7 @@ export function toast(kind: ToastKind, message: string) {
  * @param opts Retry options (retries, retryDelay)
  * @returns Promise resolving to ApiResult<T>
  */
-export async function apiCall<T = any>(
+export async function apiCall<T = unknown>(
   url: string,
   init: RequestInit = {},
   opts: ApiCallOptions = {}
@@ -63,7 +63,7 @@ export async function apiCall<T = any>(
       }
 
       // Parse JSON response
-      let json: any = {};
+      let json: unknown = {};
       const contentType = res.headers.get('content-type');
       if (contentType?.includes('application/json')) {
         json = await res.json().catch(() => ({}));
@@ -71,7 +71,7 @@ export async function apiCall<T = any>(
 
       // Non-2xx status
       if (!res.ok) {
-        const errorMsg = (json as any)?.error || `Fehler ${res.status}`;
+        const errorMsg = (json as { error?: string } | null)?.error || `Fehler ${res.status}`;
         const toastKind = res.status >= 500 ? 'err' : 'warn';
         toast(toastKind, errorMsg);
         return { ok: false, error: errorMsg, status: res.status };

--- a/website/src/lib/admin/behaviorStore.test.ts
+++ b/website/src/lib/admin/behaviorStore.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { it, expect, vi, beforeEach } from 'vitest';
 import { createBehaviorStore } from './behaviorStore';
 
 beforeEach(() => vi.useFakeTimers());

--- a/website/src/lib/admin/content-client.test.ts
+++ b/website/src/lib/admin/content-client.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { postContentSave } from './content-client';
 
 describe('admin/content-client.postContentSave', () => {

--- a/website/src/lib/admin/content-client.ts
+++ b/website/src/lib/admin/content-client.ts
@@ -1,7 +1,7 @@
 export async function postContentSave(
   contentKey: string,
   baseVersion: number,
-  value: any,
+  value: unknown,
 ): Promise<{ version: number }> {
   const res = await fetch('/api/admin/content/save', {
     method: 'POST',

--- a/website/src/lib/admin/schemas/index.ts
+++ b/website/src/lib/admin/schemas/index.ts
@@ -28,7 +28,7 @@ export function schemaFor(contentKey: string): SectionSchema | undefined {
   return REGISTRY[contentKey];
 }
 
-export function validateSection(contentKey: string, payload: any): FieldError[] {
+export function validateSection(contentKey: string, payload: Record<string, unknown>): FieldError[] {
   const s = schemaFor(contentKey);
   if (!s) return [];
   return validateAgainst(s.fields, payload);

--- a/website/src/lib/admin/validate.ts
+++ b/website/src/lib/admin/validate.ts
@@ -11,7 +11,7 @@ function isUrl(v: string): boolean {
   }
 }
 
-export function validateAgainst(fields: FieldSchema[], value: Record<string, any>): FieldError[] {
+export function validateAgainst(fields: FieldSchema[], value: Record<string, unknown>): FieldError[] {
   const errs: FieldError[] = [];
 
   for (const f of fields) {

--- a/website/src/lib/audit-log.test.ts
+++ b/website/src/lib/audit-log.test.ts
@@ -67,7 +67,7 @@ describe('recordAudit', () => {
   });
 
   it('ist fail-soft: Insert-Fehler bricht nicht den Aufrufer', async () => {
-    const warnSpy = vi.spyOn(loggerModule.logger, 'warn').mockReturnValue(undefined as any);
+    const warnSpy = vi.spyOn(loggerModule.logger, 'warn').mockReturnValue(undefined);
     await pool.query('DROP TABLE audit.audit_log CASCADE');
     await expect(
       recordAudit(pool, { action: 'fail.action' }),

--- a/website/src/lib/caldav.ts
+++ b/website/src/lib/caldav.ts
@@ -3,10 +3,6 @@
 import { logger } from './logger';
 import { config } from '../config/index.js';
 import {
-  NC_URL,
-  NC_USER,
-  NC_PASS,
-  CALENDAR_NAME,
   WORK_START_HOUR,
   WORK_END_HOUR,
   SLOT_DURATION_MIN,
@@ -17,7 +13,6 @@ import {
   BRAND_NAME,
   CALDAV_TIMEOUT_MS,
   getAuthHeader,
-  unfoldIcal,
   fetchEventsRaw,
   extractICalProp,
   parseICalDate

--- a/website/src/lib/claude.test.ts
+++ b/website/src/lib/claude.test.ts
@@ -52,7 +52,7 @@ describe('claude.generateMeetingInsights', () => {
   it('returns null and logs the error when the SDK throws', async () => {
     getProviderConfig.mockResolvedValueOnce({ provider: 'anthropic', modelId: 'sonnet', apiKey: 'k', baseUrl: null });
     mockCreate.mockRejectedValueOnce(new Error('upstream 500'));
-    const errSpy = vi.spyOn(loggerModule.logger, 'error').mockReturnValue(undefined as any);
+    const errSpy = vi.spyOn(loggerModule.logger, 'error').mockReturnValue(undefined);
     const out = await generateMeetingInsights({ customerName: 'C', meetingType: '1:1', transcript: 'hi' });
     expect(out).toBeNull();
     expect(errSpy).toHaveBeenCalled();

--- a/website/src/lib/coaching-classifier.test.ts
+++ b/website/src/lib/coaching-classifier.test.ts
@@ -1,5 +1,6 @@
 // website/src/lib/coaching-classifier.test.ts
 import { describe, it, expect, vi } from 'vitest';
+import type Anthropic from '@anthropic-ai/sdk';
 import { classifyChunk } from './coaching-classifier';
 
 function fakeClient(responses: string[]) {
@@ -11,7 +12,7 @@ function fakeClient(responses: string[]) {
         return { content: [{ type: 'text', text }] };
       }),
     },
-  } as any;
+  } as unknown as Anthropic;
 }
 
 describe('classifyChunk', () => {
@@ -39,7 +40,7 @@ describe('classifyChunk', () => {
     ]);
     const r = await classifyChunk('...', { client, model: 'test' });
     expect(r.kind).toBe('exercise');
-    expect((r.payload as any).phases).toHaveLength(1);
+    expect((r.payload as { phases: unknown[] } | null)?.phases).toHaveLength(1);
   });
 
   it('returns case_example with summary', async () => {

--- a/website/src/lib/coaching-content.ts
+++ b/website/src/lib/coaching-content.ts
@@ -3,7 +3,6 @@
 // sofort auf /coaching sichtbar sind.
 
 import { getServiceConfig } from './website-db';
-import { config } from '../config/index';
 
 export interface CoachingProcessStep {
   step: string;

--- a/website/src/lib/cockpit-presets.test.ts
+++ b/website/src/lib/cockpit-presets.test.ts
@@ -9,10 +9,6 @@ import {
   decodeState,
   parsePresetFromUrl,
   buildShareUrl,
-  isLocalStorageAvailable,
-  evictOldestNonDefault,
-  DEFAULT_PRESETS,
-  quotaEvictedFlag,
 } from './cockpit-presets';
 
 describe('cockpit-presets pure logic', () => {
@@ -149,7 +145,7 @@ describe('cockpit-presets pure logic', () => {
 
   it('evicts oldest non-default preset on QuotaExceededError', () => {
     const filterState = { status: ['offen'], area: [], brand: [] };
-    const p1 = savePreset('Oldest', filterState);
+    savePreset('Oldest', filterState);
     // Mock setItem to throw QuotaExceededError on next save unless we have reduced size
     let callCount = 0;
     const storeMock = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(function (this: Storage, key, value) {

--- a/website/src/lib/cockpit-presets.ts
+++ b/website/src/lib/cockpit-presets.ts
@@ -45,7 +45,7 @@ export function isLocalStorageAvailable(): boolean {
     localStorage.setItem(testKey, testKey);
     localStorage.removeItem(testKey);
     return true;
-  } catch (e) {
+  } catch {
     return false;
   }
 }
@@ -97,10 +97,11 @@ export function savePreset(name: string, state: CockpitFilterState): Preset {
     try {
       localStorage.setItem('cockpit:presets:user', JSON.stringify(userPresets));
       saved = true;
-    } catch (e: any) {
+    } catch (e) {
       attempts++;
       // standard localStorage full indicators
-      if (e.name === 'QuotaExceededError' || e.code === 22 || e.name === 'NS_ERROR_DOM_QUOTA_REACHED') {
+      const err = e as { name?: string; code?: number };
+      if (err.name === 'QuotaExceededError' || err.code === 22 || err.name === 'NS_ERROR_DOM_QUOTA_REACHED') {
         if (userPresets.length <= 1) {
           break;
         }

--- a/website/src/lib/components-db.ts
+++ b/website/src/lib/components-db.ts
@@ -1,5 +1,4 @@
 // website/src/lib/components-db.ts
-import type { Pool } from 'pg';
 import { pool } from './website-db';
 
 interface ComponentRow {

--- a/website/src/lib/content-effective.test.ts
+++ b/website/src/lib/content-effective.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { it, expect, vi, beforeEach } from 'vitest';
 
 // Mock the DB layer so getEffective* is pure to test.
 vi.mock('./website-db', async (orig) => {
@@ -12,10 +12,10 @@ import { getEffectiveServices } from './content';
 beforeEach(() => vi.clearAllMocks());
 
 it('card headline price comes from the linked catalog row, not a stored price', async () => {
-  (db.getLeistungenConfig as any).mockResolvedValue([
+  vi.mocked(db.getLeistungenConfig).mockResolvedValue([
     { id: 'digital-50plus', title: '50+ Digital', services: [
       { key: '50plus-digital-einzel', name: 'Einzelstunde', price: '60 €', unit: '/ Stunde' }] }]);
-  (db.getServiceConfig as any).mockResolvedValue([
+  vi.mocked(db.getServiceConfig).mockResolvedValue([
     { slug: 'digital-50plus', title: '50+ Digital', description: 'd', icon: '💻', features: [],
       leistungCategoryId: 'digital-50plus', headlineKey: '50plus-digital-einzel', headlinePrefix: true }]);
   const svcs = await getEffectiveServices();

--- a/website/src/lib/content-hub-migrate.ts
+++ b/website/src/lib/content-hub-migrate.ts
@@ -58,6 +58,7 @@ export function linkCardsToCatalog(
 
     // Strip legacy price fields
     const { price: _price, pageContent, ...rest } = card;
+    void _price;
     const newPageContent = pageContent
       ? { ...pageContent, pricing: undefined }
       : undefined;

--- a/website/src/lib/content-projection.test.ts
+++ b/website/src/lib/content-projection.test.ts
@@ -63,7 +63,7 @@ describe('resolveStammdaten', () => {
     expect(resolveStammdaten(db, fallback).email).toBe('db@x.de');
   });
   it('fills missing DB fields from the static fallback', () => {
-    const partial = { email: 'db@x.de' } as any;
+    const partial = { email: 'db@x.de' };
     const r = resolveStammdaten(partial, fallback);
     expect(r.email).toBe('db@x.de');
     expect(r.city).toBe('c');

--- a/website/src/lib/content.ts
+++ b/website/src/lib/content.ts
@@ -60,7 +60,10 @@ export async function getEffectiveServices(): Promise<(HomepageService & { hidde
     o.leistungCategoryId && catById.get(o.leistungCategoryId)
       ? deriveHeadlinePrice(catById.get(o.leistungCategoryId)!, o.headlineKey, o.headlinePrefix ?? false)
       : (o.price ?? staticPrice);
-  const tiersFor = (o: typeof overrides[number], staticTiers: any[]) =>
+  const tiersFor = (
+    o: typeof overrides[number],
+    staticTiers: { label: string; price: string; unit?: string; highlight?: boolean }[],
+  ) =>
     o.leistungCategoryId && catById.get(o.leistungCategoryId)
       ? detailTiers(catById.get(o.leistungCategoryId))
       : staticTiers;

--- a/website/src/lib/einvoice/types.ts
+++ b/website/src/lib/einvoice/types.ts
@@ -14,7 +14,6 @@ const SellerConfigSchema = z.object({
   iban: z.string().min(15),
   bic: z.string().optional(),
 });
-type SellerConfig = z.infer<typeof SellerConfigSchema>;
 
 const BuyerConfigSchema = z.object({
   name: z.string().min(1),
@@ -26,7 +25,6 @@ const BuyerConfigSchema = z.object({
   vatId: z.string().optional(),
   leitwegId: z.string().regex(LEITWEG_ID_REGEX).optional(),
 });
-type BuyerConfig = z.infer<typeof BuyerConfigSchema>;
 
 export const InvoiceLineSchema = z.object({
   description: z.string().min(1),

--- a/website/src/lib/elster-xml.ts
+++ b/website/src/lib/elster-xml.ts
@@ -6,7 +6,15 @@ export interface UstvaData {
   brand: string;
 }
 
-export async function getUstvaKennzahlen(data: UstvaData) {
+export interface UstvaKennzahlen {
+  kz81: number;
+  kz86: number;
+  kz41: number;
+  kz43: number;
+  kz66: number;
+}
+
+export async function getUstvaKennzahlen(data: UstvaData): Promise<UstvaKennzahlen> {
   await initBillingTables();
   // Simplified aggregation logic for demonstration
   // In a real app, this would query billing_invoices and eur_bookkeeping
@@ -42,7 +50,7 @@ export async function getUstvaKennzahlen(data: UstvaData) {
   };
 }
 
-export function buildUstvaXml(kennzahlen: any, data: UstvaData) {
+export function buildUstvaXml(kennzahlen: UstvaKennzahlen, data: UstvaData) {
   const { kz81, kz86, kz41, kz43, kz66 } = kennzahlen;
   const steuer81 = Math.round(kz81 * 0.19 * 100) / 100;
   const steuer86 = Math.round(kz86 * 0.07 * 100) / 100;

--- a/website/src/lib/embeddings.test.ts
+++ b/website/src/lib/embeddings.test.ts
@@ -118,7 +118,7 @@ describe('embeddings client — router mode (LLM_ENABLED=true)', () => {
   });
 
   test('voyage model: ECONNREFUSED from router → falls back to Voyage with structured logger warn', async () => {
-    const warnSpy = vi.spyOn(loggerModule.logger, 'warn').mockReturnValue(undefined as any);
+    const warnSpy = vi.spyOn(loggerModule.logger, 'warn').mockReturnValue(undefined);
     let callCount = 0;
     global.fetch = vi.fn().mockImplementation((url: string) => {
       callCount++;

--- a/website/src/lib/factory-ci.test.ts
+++ b/website/src/lib/factory-ci.test.ts
@@ -6,7 +6,7 @@ describe('factory-ci normalization', () => {
     const out = normalizeChecks([
       { name: 'CI', status: 'completed', conclusion: 'success', details_url: 'u1' },
       { name: 'e2e', status: 'in_progress', conclusion: null, details_url: 'u2' },
-    ] as any);
+    ]);
     expect(out).toEqual([
       { name: 'CI', status: 'completed', conclusion: 'success', url: 'u1' },
       { name: 'e2e', status: 'in_progress', conclusion: null, url: 'u2' },

--- a/website/src/lib/factory-ci.ts
+++ b/website/src/lib/factory-ci.ts
@@ -10,7 +10,16 @@ export interface CiCheck {
 }
 export type CiRollup = 'success' | 'pending' | 'failure' | null;
 
-export function normalizeChecks(runs: any[]): CiCheck[] {
+// Shape of a single entry in GitHub's `check-runs` API response.
+interface GhCheckRun {
+  name: string;
+  status: string;
+  conclusion: string | null;
+  details_url?: string | null;
+  html_url?: string | null;
+}
+
+export function normalizeChecks(runs: GhCheckRun[]): CiCheck[] {
   return (runs ?? []).map(r => ({
     name: r.name, status: r.status, conclusion: r.conclusion ?? null,
     url: r.details_url ?? r.html_url ?? null,

--- a/website/src/lib/factory-metrics.test.ts
+++ b/website/src/lib/factory-metrics.test.ts
@@ -9,7 +9,7 @@ vi.mock('pg', () => {
     name: 'to_char',
     args: [DataType.date, DataType.text],
     returns: DataType.text,
-    implementation: (date: Date | string | null, format: string) => {
+    implementation: (date: Date | string | null, _format: string) => {
       if (!date) return null;
       const d = new Date(date);
       if (isNaN(d.getTime())) return String(date);

--- a/website/src/lib/factory-observability.test.ts
+++ b/website/src/lib/factory-observability.test.ts
@@ -14,14 +14,14 @@ describe('buildPromQL', () => {
 describe('queryRange', () => {
   it('proxies Prometheus /api/v1/query_range and returns matrix data', async () => {
     const fakeResp = { status: 'success', data: { resultType: 'matrix', result: [{ metric: {}, values: [[1, '5']] }] } };
-    global.fetch = vi.fn(async () => ({ ok: true, json: async () => fakeResp })) as any;
+    global.fetch = vi.fn(async () => ({ ok: true, json: async () => fakeResp })) as unknown as typeof fetch;
     const r = await queryRange('up', Date.now() / 1000 - 3600, Date.now() / 1000, 60);
     expect(r.data.result.length).toBe(1);
-    expect((global.fetch as any).mock.calls[0][0]).toContain('/api/v1/query_range');
+    expect(vi.mocked(global.fetch).mock.calls[0][0]).toContain('/api/v1/query_range');
   });
 
   it('throws a typed error when Prometheus is unreachable', async () => {
-    global.fetch = vi.fn(async () => { throw new Error('ECONNREFUSED'); }) as any;
+    global.fetch = vi.fn(async () => { throw new Error('ECONNREFUSED'); }) as unknown as typeof fetch;
     await expect(queryRange('up', 0, 1, 60)).rejects.toThrow();
   });
 });

--- a/website/src/lib/generate-3d-pipeline.test.ts
+++ b/website/src/lib/generate-3d-pipeline.test.ts
@@ -82,7 +82,7 @@ describe('generate-3d pipeline', () => {
     await finaliseJob('j1', 'p1', 'fig', { comfyFetch: comfyDoneFetch(), riggerFetch, brettFetch });
     const doneCall = stageCalls.find((c) => c.stage === 'done');
     expect(doneCall).toBeDefined();
-    expect((doneCall?.extra as any)?.skin_id).toBe('s1');
+    expect((doneCall?.extra as { skin_id?: string } | undefined)?.skin_id).toBe('s1');
   });
 
   it('Integration: full pipeline reaches done in one tick and registers the asset', async () => {
@@ -106,7 +106,7 @@ describe('generate-3d pipeline', () => {
     await finaliseJob('j1', 'p1', 'fig', { comfyFetch: comfyDoneFetch(), riggerFetch });
     const err = stageCalls.find((c) => c.stage === 'error');
     expect(err).toBeDefined();
-    expect((err?.extra as any)?.error_msg).toMatch(/Rigging failed/);
+    expect((err?.extra as { error_msg?: string } | undefined)?.error_msg).toMatch(/Rigging failed/);
   });
 
   it('Error: Brett validation 422 → stage error with brett message', async () => {
@@ -115,6 +115,6 @@ describe('generate-3d pipeline', () => {
     await finaliseJob('j1', 'p1', 'fig', { comfyFetch: comfyDoneFetch(), riggerFetch, brettFetch });
     const err = stageCalls.find((c) => c.stage === 'error');
     expect(err).toBeDefined();
-    expect((err?.extra as any)?.error_msg).toMatch(/Brett upload failed/);
+    expect((err?.extra as { error_msg?: string } | undefined)?.error_msg).toMatch(/Brett upload failed/);
   });
 });

--- a/website/src/lib/homepage-blocks-store.test.ts
+++ b/website/src/lib/homepage-blocks-store.test.ts
@@ -24,7 +24,6 @@ import {
   readCurrent,
   save,
   restore,
-  HomepageConflictError,
   HomepageValidationError,
   __setTablesReadyForTests,
 } from './homepage-blocks-store';

--- a/website/src/lib/homepage-blocks-store.ts
+++ b/website/src/lib/homepage-blocks-store.ts
@@ -153,7 +153,7 @@ export async function save(
       `SELECT id FROM homepage_block_versions WHERE brand=$1 ORDER BY created_at DESC`,
       [brand],
     );
-    const prune = idsToPrune(ids.rows.map((row: any) => Number(row.id)));
+    const prune = idsToPrune(ids.rows.map((row: { id: number | string }) => Number(row.id)));
     if (prune.length) {
       await client.query(`DELETE FROM homepage_block_versions WHERE id = ANY($1)`, [prune]);
     }
@@ -172,13 +172,13 @@ export async function save(
   }
 }
 
-export async function listVersions(brand: string): Promise<Array<{ id: number; editor: string; createdAt: any }>> {
+export async function listVersions(brand: string): Promise<Array<{ id: number; editor: string; createdAt: Date }>> {
   await ensureTables();
   const r = await pool.query(
     `SELECT id, editor, created_at FROM homepage_block_versions WHERE brand=$1 ORDER BY created_at DESC`,
     [brand],
   );
-  return r.rows.map((row: any) => ({ id: Number(row.id), editor: row.editor, createdAt: row.created_at }));
+  return r.rows.map((row: { id: number | string; editor: string; created_at: Date }) => ({ id: Number(row.id), editor: row.editor, createdAt: row.created_at }));
 }
 
 /**

--- a/website/src/lib/invoice-html.test.ts
+++ b/website/src/lib/invoice-html.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { renderInvoiceHtml, renderDunningHtml, sampleInvoiceForPreview } from './invoice-html';
 import type { Invoice } from './native-billing';
+import type { Dunning } from './invoice-pdf';
 
 const baseInvoice: Invoice = {
   id: 'inv-1',
@@ -134,14 +135,15 @@ describe('renderDunningHtml', () => {
   it('renders a dunning document with the level', () => {
     const out = renderDunningHtml({
       dunning: {
+        id: 'dun-1',
+        invoiceId: baseInvoice.id,
+        brand: baseInvoice.brand,
         level: 1,
         outstandingAtGeneration: 100,
         feeAmount: 5,
         interestAmount: 0,
-        totalAmount: 105,
-        dueDate: '2026-07-11',
         generatedAt: '2026-07-12T00:00:00Z',
-      } as any,
+      } satisfies Dunning,
       invoice: baseInvoice,
       customer: baseCustomer,
       seller: baseSeller,
@@ -153,14 +155,15 @@ describe('renderDunningHtml', () => {
   it('switches to "Mahnung" title when level >= 2', () => {
     const out = renderDunningHtml({
       dunning: {
+        id: 'dun-2',
+        invoiceId: baseInvoice.id,
+        brand: baseInvoice.brand,
         level: 2,
         outstandingAtGeneration: 100,
         feeAmount: 10,
         interestAmount: 5,
-        totalAmount: 115,
-        dueDate: '2026-07-11',
         generatedAt: '2026-07-12T00:00:00Z',
-      } as any,
+      } satisfies Dunning,
       invoice: baseInvoice,
       customer: baseCustomer,
       seller: baseSeller,

--- a/website/src/lib/invoice-pdf.test.ts
+++ b/website/src/lib/invoice-pdf.test.ts
@@ -33,6 +33,7 @@ it('includes reverse charge notice when supplyType is eu_b2b_services', async ()
     currency: 'EUR', currencyRate: null,
     netAmountEur: 500, grossAmountEur: 500,
     supplyType: 'eu_b2b_services',
+    kind: 'regular' as const,
   };
   const baseSeller = {
     name: 'Test GmbH', address: 'Musterstr 1', postalCode: '10115',
@@ -41,7 +42,7 @@ it('includes reverse charge notice when supplyType is eu_b2b_services', async ()
     bic: 'COBADEFFXXX', bankName: 'Commerzbank',
   };
   const pdf = await generateInvoicePdf({
-    invoice: baseInvoice as any,
+    invoice: baseInvoice,
     lines: [{ description: 'Consulting', quantity: 1, unitPrice: 500, netAmount: 500 }],
     customer: { name: 'Acme SA', email: 'acme@fr.com', country: 'FR', vatNumber: 'FR12345678901' },
     seller: baseSeller,

--- a/website/src/lib/invoice-pdf.ts
+++ b/website/src/lib/invoice-pdf.ts
@@ -196,7 +196,7 @@ export async function generateInvoicePdf(p: {
   templateTexts?: InvoicePdfTemplateTexts;
   profile?: EInvoiceProfile;
 }): Promise<Buffer> {
-  const supplyTypeForMeta = (p.invoice as any).supplyType as string | undefined;
+  const supplyTypeForMeta = p.invoice.supplyType;
   const supplyNoticeMap: Record<string, string> = {
     eu_b2b_services: 'Die Steuerschuldnerschaft geht auf den Leistungsempfänger über (§ 13b UStG / Art. 196 MwStSystRL).',
     eu_b2b_goods:    'Steuerfreie innergemeinschaftliche Lieferung gem. § 4 Nr. 1b UStG. Gelangensbestätigung liegt vor.',
@@ -414,7 +414,7 @@ export async function generateInvoicePdf(p: {
            .text(`USt-IdNr.: ${seller.vatId}`, L, y, { width: W });
         y = doc.y + 4;
       }
-      const supplyType = (inv as any).supplyType as string | undefined;
+      const supplyType = inv.supplyType;
       if (supplyType && supplyNoticeMap[supplyType]) {
         doc.font('Helvetica').fontSize(7.5).fillColor(C.inkMute)
            .text(supplyNoticeMap[supplyType], L, y, { width: W });

--- a/website/src/lib/invoice-storno.ts
+++ b/website/src/lib/invoice-storno.ts
@@ -24,7 +24,6 @@ export async function createCreditNote(invoiceId: string, reason: string, actor?
     if (orig.status === 'draft' || orig.status === 'cancelled') throw new Error('invoice cannot be cancelled');
     if (orig.kind === 'gutschrift') throw new Error('credit note cannot be cancelled again');
 
-    const year = new Date(orig.issue_date).getFullYear();
     const number = await getNextInvoiceNumber(orig.brand, 'gutschrift');
     const issueDate = iso(new Date());
     const dueDate = issueDate;

--- a/website/src/lib/ki-config-db.test.ts
+++ b/website/src/lib/ki-config-db.test.ts
@@ -4,8 +4,8 @@ const query = vi.fn();
 vi.mock('./website-db', () => ({ pool: { query: (...a: unknown[]) => query(...a) } }));
 
 import {
-  listProviders, listHealth, createProvider, updateProvider,
-  deleteProvider, countEnabledForSource, EMBED_PRIMARY_KEY, EMBED_FALLBACK_KEY,
+  listProviders, createProvider, updateProvider,
+  countEnabledForSource, EMBED_PRIMARY_KEY, EMBED_FALLBACK_KEY,
 } from './ki-config-db';
 
 beforeEach(() => query.mockReset());

--- a/website/src/lib/legal-tokens.test.ts
+++ b/website/src/lib/legal-tokens.test.ts
@@ -18,7 +18,7 @@ describe('resolveTokens', () => {
   });
 });
 
-import { getDefaultDatenschutz, getDefaultAgb } from './legal-defaults';
+import { getDefaultDatenschutz } from './legal-defaults';
 it('defaults emit tokens, not baked contact values', () => {
   const ds = getDefaultDatenschutz();
   expect(ds).toContain('{{stammdaten.email}}');
@@ -29,7 +29,7 @@ describe('proposeRetokenize', () => {
   it('proposes replacing baked contact strings with tokens', async () => {
     const { proposeRetokenize } = await import('./legal-tokens');
     const html = '<p>Mail: a@b.de, Stadt: Lüneburg</p>';
-    const sd = { email: 'a@b.de', city: 'Lüneburg' } as any;
+    const sd = { email: 'a@b.de', city: 'Lüneburg' };
     const { result, replacements } = proposeRetokenize(html, sd);
     expect(result).toBe('<p>Mail: {{stammdaten.email}}, Stadt: {{stammdaten.city}}</p>');
     expect(replacements).toContainEqual({ from: 'a@b.de', to: '{{stammdaten.email}}' });

--- a/website/src/lib/legal-tokens.ts
+++ b/website/src/lib/legal-tokens.ts
@@ -8,7 +8,7 @@ export const STAMMDATEN_TOKENS = STAMMDATEN_FIELDS.map((f) => `{{stammdaten.${f}
 const TOKEN_RE = /\{\{\s*stammdaten\.([a-zA-Z]+)\s*\}\}/g;
 
 export function resolveTokens(html: string, sd: Partial<Stammdaten>): string {
-  return html.replace(TOKEN_RE, (_m, key: string) => String((sd as any)?.[key] ?? ''));
+  return html.replace(TOKEN_RE, (_m, key: string) => String(sd[key as keyof Stammdaten] ?? ''));
 }
 
 export function proposeRetokenize(html: string, sd: Partial<Stammdaten>): { result: string; replacements: { from: string; to: string }[] } {
@@ -16,7 +16,7 @@ export function proposeRetokenize(html: string, sd: Partial<Stammdaten>): { resu
   let result = html;
   // Process longest values first to avoid partial overlaps
   const entries = STAMMDATEN_FIELDS
-    .map((f) => ({ field: f, value: (sd as any)[f] as string }))
+    .map((f) => ({ field: f, value: sd[f] as string }))
     .filter((e) => e.value && e.value.length > 2)
     .sort((a, b) => b.value.length - a.value.length);
   for (const { field, value } of entries) {

--- a/website/src/lib/live-state.fetch.test.ts
+++ b/website/src/lib/live-state.fetch.test.ts
@@ -46,7 +46,7 @@ describe('live-state.fetchLiveCockpitData', () => {
     listActiveCallRooms.mockResolvedValueOnce([]);
     query.mockRejectedValueOnce(new Error('polls broken'));
     listAllMeetings.mockResolvedValueOnce([]);
-    const errSpy = vi.spyOn(loggerModule.logger, 'error').mockReturnValue(undefined as any);
+    const errSpy = vi.spyOn(loggerModule.logger, 'error').mockReturnValue(undefined);
     const out = await fetchLiveCockpitData();
     expect(out.pollActive).toBeNull();
     expect(errSpy).toHaveBeenCalled();
@@ -57,7 +57,7 @@ describe('live-state.fetchLiveCockpitData', () => {
     listActiveCallRooms.mockResolvedValueOnce([]);
     query.mockResolvedValueOnce({ rows: [] });
     listAllMeetings.mockRejectedValueOnce(new Error('meetings broken'));
-    const errSpy = vi.spyOn(loggerModule.logger, 'error').mockReturnValue(undefined as any);
+    const errSpy = vi.spyOn(loggerModule.logger, 'error').mockReturnValue(undefined);
     const out = await fetchLiveCockpitData();
     expect(out.recentSessions).toEqual([]);
     errSpy.mockRestore();

--- a/website/src/lib/messaging-db.test.ts
+++ b/website/src/lib/messaging-db.test.ts
@@ -2,11 +2,11 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const { Pool, query, end } = vi.hoisted(() => {
   const query = vi.fn(async (..._args: unknown[]) => ({ rows: [], rowCount: 0 }));
-  const end = vi.fn(async (..._args: any[]) => undefined);
+  const end = vi.fn(async (..._args: unknown[]) => undefined);
   class Pool {
     constructor(_opts: unknown) { /* ignore config */ }
-    query(...a: any[]) { return query(...a); }
-    end(...a: any[]) { return end(...a); }
+    query(...a: unknown[]) { return query(...a); }
+    end(...a: unknown[]) { return end(...a); }
   }
   return { Pool, query, end };
 });

--- a/website/src/lib/native-billing.test.ts
+++ b/website/src/lib/native-billing.test.ts
@@ -70,7 +70,7 @@ it('finalize stores hash, persists PDF, writes audit row (no EÜR booking yet)',
   expect(eurAfterFinalize.rows[0].n).toBe(0);  // PR-A: bookings emit on payment, not finalize
 });
 
-import { recordPayment, listPayments } from './invoice-payments';
+import { listPayments } from './invoice-payments';
 
 it('markInvoicePaid records a single full-gross payment', async () => {
   const c = await createCustomer({ brand: 'test', name: 'F', email: `f-${Date.now()}@t.de` });

--- a/website/src/lib/native-billing.ts
+++ b/website/src/lib/native-billing.ts
@@ -167,7 +167,7 @@ export interface FinalizeOpts {
   actor?: BillingActor;
   pdfBlob?: Buffer;
   pdfMime?: string;
-  invoiceInput?: any;
+  invoiceInput?: InvoiceInput;
 }
 
 export async function finalizeInvoice(id: string, opts: FinalizeOpts = {}): Promise<Invoice | null> {
@@ -198,7 +198,7 @@ export async function finalizeInvoice(id: string, opts: FinalizeOpts = {}): Prom
       const xrechnungXml = opts.invoiceInput.buyer.leitwegId ? generateXRechnung(opts.invoiceInput) : null;
 
       let pdfA3: Buffer | undefined = opts.pdfBlob;
-      let validation: any = null;
+      let validation: Awaited<ReturnType<ReturnType<typeof createSidecarClient>['validate']>> | null = null;
 
       if (opts.pdfBlob && process.env.EINVOICE_SIDECAR_ENABLED === 'true') {
         try {
@@ -405,6 +405,7 @@ function mapCustomer(row: Record<string, unknown>): Customer {
 }
 
 import type { EInvoiceInput } from './einvoice-types';
+import type { InvoiceInput } from './einvoice/types';
 
 /**
  * Loads a finalized invoice and assembles the EInvoiceInput payload used by

--- a/website/src/lib/newsletter-db.test.ts
+++ b/website/src/lib/newsletter-db.test.ts
@@ -7,11 +7,11 @@ const { Pool, resolve4, query, end } = vi.hoisted(() => {
     if (next) return next;
     return { rows: [], rowCount: 0 };
   });
-  const end = vi.fn(async (..._args: any[]) => undefined);
+  const end = vi.fn(async (..._args: unknown[]) => undefined);
   class Pool {
     constructor(_opts: unknown) { /* ignore config */ }
-    query(...a: any[]) { return query(...a); }
-    end(...a: any[]) { return end(...a); }
+    query(...a: unknown[]) { return query(...a); }
+    end(...a: unknown[]) { return end(...a); }
   }
   const resolve4 = vi.fn();
   return { Pool, resolve4, query, end, queue };
@@ -20,7 +20,7 @@ vi.mock('pg', () => ({ default: { Pool }, Pool }));
 vi.mock('dns', () => ({ default: { resolve4: (...a: unknown[]) => resolve4(...a) }, resolve4: (...a: unknown[]) => resolve4(...a) }));
 vi.mock('./email', () => ({ sendNewsletterCampaign: vi.fn() }));
 
-import { listSubscribers, getSubscriberByEmail, getSubscriberByConfirmToken, createSubscriber, updateSubscriberToken, confirmSubscriber, unsubscribeByToken, deleteSubscriber, listCampaigns, getCampaign, createCampaign, updateCampaign, countSentCampaigns, sendCampaignById, listDueCampaignIds, lockDueCampaign, unlockCampaignToScheduled, resetStaleSendingCampaigns } from './newsletter-db';
+import { listSubscribers, getSubscriberByEmail, getSubscriberByConfirmToken, createSubscriber, updateSubscriberToken, confirmSubscriber, unsubscribeByToken, deleteSubscriber, listCampaigns, getCampaign, createCampaign, countSentCampaigns, sendCampaignById, listDueCampaignIds, lockDueCampaign, unlockCampaignToScheduled, resetStaleSendingCampaigns } from './newsletter-db';
 
 beforeEach(() => { query.mockClear(); end.mockClear(); });
 // Silence unused vars

--- a/website/src/lib/nextcloud-files.ts
+++ b/website/src/lib/nextcloud-files.ts
@@ -130,8 +130,7 @@ export async function uploadFile(
       Authorization: authHeader(),
       'Content-Type': contentType,
     },
-     
-    body: body as any,
+    body,
   });
   // 201 = created, 204 = overwritten — both are fine
   if (res.status !== 201 && res.status !== 204) {

--- a/website/src/lib/nextcloud-shares.ts
+++ b/website/src/lib/nextcloud-shares.ts
@@ -93,7 +93,6 @@ export async function createShareLink(opts: ShareOptions): Promise<ShareResult> 
   if (NC_EXTERNAL_URL && url) {
     try {
       const parsed = new URL(url);
-      const extHost = new URL(NC_EXTERNAL_URL).host;
       url = new URL(parsed.pathname + parsed.search, NC_EXTERNAL_URL).href;
     } catch { /* keep original URL */ }
   }

--- a/website/src/lib/notifications.test.ts
+++ b/website/src/lib/notifications.test.ts
@@ -92,7 +92,7 @@ describe('sendAdminNotification', () => {
       return undefined;
     });
     mockSend.mockResolvedValue(false);
-    const warnSpy = vi.spyOn(loggerModule.logger, 'warn').mockReturnValue(undefined as any);
+    const warnSpy = vi.spyOn(loggerModule.logger, 'warn').mockReturnValue(undefined);
     try {
       await expect(
         sendAdminNotification({ type: 'contact', subject: 'x', text: 'y' }),

--- a/website/src/lib/openspec/proposal.test.ts
+++ b/website/src/lib/openspec/proposal.test.ts
@@ -4,8 +4,6 @@ import * as path from 'path';
 import { isValidSlug, readProposal, writeProposal, proposalPath } from './proposal';
 
 describe('proposal lib', () => {
-  const testSlug = 'cockpit-dor-inline-editor';
-
   afterEach(async () => {
     // Clean up test file if it was created
     const testPath = proposalPath('test-slug');

--- a/website/src/lib/openspec/proposal.ts
+++ b/website/src/lib/openspec/proposal.ts
@@ -34,8 +34,8 @@ export async function readProposal(slug: string): Promise<string | null> {
   const filePath = proposalPath(slug);
   try {
     return await fs.readFile(filePath, 'utf-8');
-  } catch (error: any) {
-    if (error.code === 'ENOENT') {
+  } catch (error) {
+    if (error instanceof Error && 'code' in error && error.code === 'ENOENT') {
       return null;
     }
     throw error;

--- a/website/src/lib/questionnaire-archive.test.ts
+++ b/website/src/lib/questionnaire-archive.test.ts
@@ -278,7 +278,7 @@ describe.skipIf(!dbAvailable)('getDisplayScores', () => {
     await upsertQAnswer({ assignmentId: a.id, questionId: q.id, optionKey: '4' });
     await updateQAssignment(a.id, { status: 'submitted' });
 
-    const live = await getDisplayScores(await getQAssignment(a.id) as any);
+    const live = await getDisplayScores((await getQAssignment(a.id))!);
     expect(live[0].final_score).toBe(4);
     expect(live[0].name).toBe('D');
 
@@ -287,7 +287,7 @@ describe.skipIf(!dbAvailable)('getDisplayScores', () => {
       id: dim.id, templateId: tpl.id, name: 'D-renamed', position: 0,
       thresholdMid: 1, thresholdHigh: 2,
     });
-    const frozen = await getDisplayScores(await getQAssignment(a.id) as any);
+    const frozen = await getDisplayScores((await getQAssignment(a.id))!);
     expect(frozen[0].final_score).toBe(4);
     expect(frozen[0].name).toBe('D');
   });

--- a/website/src/lib/questionnaire-db/queries.test.ts
+++ b/website/src/lib/questionnaire-db/queries.test.ts
@@ -11,7 +11,7 @@ vi.mock('./schema', () => ({
 }));
 
 import {
-  getQTemplate, getQQuestion, getQAssignment, listQTemplates, createQTemplate, updateQTemplate, deleteQTemplate,
+  getQTemplate, listQTemplates, createQTemplate, updateQTemplate, deleteQTemplate,
   listQDimensions, upsertQDimension, deleteQDimension,
   listQQuestions, upsertQQuestion, deleteQQuestion,
   listQAnswerOptions, listQAnswerOptionsForTemplate, replaceQAnswerOptions,
@@ -126,7 +126,7 @@ describe('questionnaire-db/queries', () => {
     it('INSERT with the right columns', async () => {
       query.mockResolvedValueOnce({ rows: [{ id: 'q1' }] });
       await upsertQQuestion({
-        templateId: 't1', position: 0, questionText: '?', questionType: 'free_text' as any,
+        templateId: 't1', position: 0, questionText: '?', questionType: 'likert_5',
         testExpectedResult: null, testFunctionUrl: null, testMenuPath: null, testRole: null,
       });
       const sql = query.mock.calls[0][0] as string;

--- a/website/src/lib/questionnaire-db/queries.ts
+++ b/website/src/lib/questionnaire-db/queries.ts
@@ -380,7 +380,7 @@ export async function archiveQAssignment(id: string): Promise<
     );
 
     const { computeScores } = await import('../compute-scores');
-    const scores = computeScores(dimsRes.rows, optsRes.rows, ansRes.rows);
+    computeScores(dimsRes.rows, optsRes.rows, ansRes.rows);
 
     await client.query('COMMIT');
     const updated = await getQAssignment(id);

--- a/website/src/lib/questionnaire-display.test.ts
+++ b/website/src/lib/questionnaire-display.test.ts
@@ -15,7 +15,7 @@ type ScoreSnapshot = {
 };
 
 vi.mock('./questionnaire-db/queries', () => ({
-  listQDimensions: async (templateId: string) => [
+  listQDimensions: async (_templateId: string) => [
     { id: 'd1', name: 'D1', position: 1, score_multiplier: 1, threshold_mid: 5, threshold_high: 10 },
   ],
   listQAnswerOptionsForTemplate: async (_templateId: string) => [],

--- a/website/src/lib/session-tools.test.ts
+++ b/website/src/lib/session-tools.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { newDb, DataType } from 'pg-mem';
 import type { Pool } from 'pg';
 import { getSessionStepTool, draftSessionReportTool, __setPoolForTests } from './session-tools';

--- a/website/src/lib/sessions/archive.ts
+++ b/website/src/lib/sessions/archive.ts
@@ -105,7 +105,7 @@ export async function purgeOldSessions({ maxAgeDays = 30 }: { maxAgeDays?: numbe
           markdownContent = await res.text();
           contentAvailable = true;
         }
-      } catch (err) {
+      } catch {
         // Fetch failed or timed out
       } finally {
         clearTimeout(timeoutId);
@@ -132,7 +132,7 @@ export async function purgeOldSessions({ maxAgeDays = 30 }: { maxAgeDays?: numbe
 
   try {
     await writeAtomically(registryPath, JSON.stringify(toKeep, null, 2));
-  } catch (err) {
+  } catch {
     warnings.push('write-failed');
   }
 

--- a/website/src/lib/stores/cockpitStore.ts
+++ b/website/src/lib/stores/cockpitStore.ts
@@ -1,4 +1,4 @@
-import { writable, derived } from 'svelte/store';
+import { writable } from 'svelte/store';
 import type { CockpitFilterState } from '../cockpit-presets';
 
 interface OptimisticEdit {
@@ -34,7 +34,6 @@ const initial: CockpitState = {
 };
 
 export const cockpitStore = writable<CockpitState>(initial);
-const selectedCount = derived(cockpitStore, ($s) => $s.selectedTickets.size);
 
 function syncUrl(s: CockpitState): void {
   if (typeof window === 'undefined') return;
@@ -92,7 +91,6 @@ function rollbackOptimistic(ticketId: string, field: string): void {
   cockpitStore.update((s) => { const { [key]: _drop, ...rest } = s.optimistic; return { ...s, optimistic: rest }; });
 }
 
-function clearOptimistic(ticketId: string, field: string): void { rollbackOptimistic(ticketId, field); }
 export function setError(error: string | null): void { cockpitStore.update((s) => ({ ...s, error })); }
 export function setLoading(isLoading: boolean): void { cockpitStore.update((s) => ({ ...s, isLoading })); }
 

--- a/website/src/lib/stripe-billing.ts
+++ b/website/src/lib/stripe-billing.ts
@@ -121,10 +121,6 @@ function mapAdminRow(row: Record<string, unknown>): AdminBillingInvoice {
 
 // ---- Functions ----
 
-function stripeInvoiceDashboardUrl(_invoiceId: string): string {
-  return '#';
-}
-
 export async function getOrCreateCustomer(params: {
   brand: string; name: string; email: string; company?: string;
 }): Promise<BillingCustomer> {
@@ -162,16 +158,6 @@ export async function getDraftInvoices(): Promise<AdminBillingInvoice[]> {
     [brand]
   );
   return r.rows.map(mapAdminRow);
-}
-
-async function getDraftInvoiceCount(): Promise<number> {
-  await initBillingTables();
-  const brand = process.env.BRAND || 'mentolder';
-  const r = await pool.query(
-    `SELECT COUNT(*)::int AS count FROM billing_invoices WHERE brand = $1 AND status = 'draft'`,
-    [brand]
-  );
-  return r.rows[0]?.count ?? 0;
 }
 
 export async function getCustomerInvoices(customerEmail: string): Promise<BillingInvoice[]> {
@@ -298,19 +284,6 @@ export async function createBillingQuote(_params: unknown): Promise<unknown> {
 export async function createMonthlyDraftInvoices(_params: unknown): Promise<unknown[]> {
   logger.warn('[stripe-billing] createMonthlyDraftInvoices: native billing only');
   return [];
-}
-
-async function sendDraftInvoice(_invoiceId: string): Promise<void> {
-  logger.warn('[stripe-billing] sendDraftInvoice: use /api/admin/billing/[id]/send instead');
-}
-
-async function discardDraftInvoice(invoiceId: string): Promise<void> {
-  await initBillingTables();
-  const brand = process.env.BRAND || 'mentolder';
-  await pool.query(
-    `DELETE FROM billing_invoices WHERE id = $1 AND brand = $2 AND status = 'draft'`,
-    [invoiceId, brand]
-  );
 }
 
 export async function updateDraftInvoiceItem(_itemId: string, _params: unknown): Promise<void> {

--- a/website/src/lib/stripe.ts
+++ b/website/src/lib/stripe.ts
@@ -1,2 +1,27 @@
-// Stripe SDK removed — all billing is now handled natively via billing_invoices table
-export const stripe = null as any;
+// Stripe SDK removed — all billing is now handled natively via billing_invoices table.
+// The `stripe` package itself is no longer a dependency, so there is no real SDK type to
+// import. This stub only models the slice of the SDK surface actually called by the two
+// remaining consumers (src/pages/api/admin/billing/[id]/item.ts,
+// src/pages/stripe/success.astro) so callers keep type-checking without `any`.
+interface StripeStub {
+  invoices: {
+    retrieve: (id: string) => Promise<unknown>;
+  };
+  invoiceItems: {
+    retrieve: (id: string) => Promise<{ invoice: string | null }>;
+  };
+  checkout: {
+    sessions: {
+      retrieve: (
+        id: string,
+        opts?: { expand?: string[] },
+      ) => Promise<{
+        line_items?: { data: Array<{ description?: string | null }> };
+        amount_total?: number | null;
+        customer_details?: { email?: string | null } | null;
+      }>;
+    };
+  };
+}
+
+export const stripe = null as unknown as StripeStub;

--- a/website/src/lib/ticket-graph.ts
+++ b/website/src/lib/ticket-graph.ts
@@ -44,8 +44,16 @@ export async function getTicketGraph(): Promise<TicketGraph> {
     WHERE depends_on IS NOT NULL AND array_length(depends_on, 1) > 0
   `);
 
-  const nodeSet = new Set(rows.map((r: any) => r.external_id));
-  const nodes: GraphNode[] = rows.map((r: any) => ({
+  interface DepGraphRow {
+    external_id: string;
+    title: string;
+    status: string;
+    priority: string;
+    depth: number;
+  }
+
+  const nodeSet = new Set(rows.map((r: DepGraphRow) => r.external_id));
+  const nodes: GraphNode[] = rows.map((r: DepGraphRow) => ({
     id: r.external_id,
     title: r.title,
     status: r.status,

--- a/website/src/lib/ticket-readiness.ts
+++ b/website/src/lib/ticket-readiness.ts
@@ -6,7 +6,7 @@ export async function allPredecessorsDone(dependsOn: string[], pool: Pool): Prom
     `SELECT external_id, status FROM tickets.tickets WHERE external_id = ANY($1)`,
     [dependsOn],
   );
-  return rows.length === dependsOn.length && rows.every((r: any) => r.status === 'done');
+  return rows.length === dependsOn.length && rows.every((r: { status: string }) => r.status === 'done');
 }
 
 export async function updateSuccessorReadiness(ticketId: string, pool: Pool): Promise<number> {

--- a/website/src/lib/tickets/admin.ts
+++ b/website/src/lib/tickets/admin.ts
@@ -7,7 +7,7 @@
 // Status changes go through transitionTicket() (lib/tickets/transition.ts) —
 // these helpers do NOT mutate `status` or `resolution`.
 
-import { pool, type Customer } from '../website-db';
+import { pool } from '../website-db';
 import { initTicketsSchema } from '../tickets-db';
 import type { GrillingAnswers, GrillingMeta } from './grilling';
 
@@ -630,48 +630,3 @@ export async function addAttachment(p: {
   return { id: r.rows[0].id };
 }
 
-// ── Lookups for the action bar dropdowns ───────────────────────────────────
-
-async function listAdminUsersForBrand(): Promise<Customer[]> {
-  // Admin users are global (no brand) — same as the projekte page.
-  const { listAdminUsers } = await import('../website-db');
-  return listAdminUsers();
-}
-
-async function listCustomersForBrand(): Promise<Customer[]> {
-  const { listAllCustomers } = await import('../website-db');
-  return listAllCustomers();
-}
-
-async function searchTicketsForLink(brand: string, q: string, limit = 10): Promise<ListedTicket[]> {
-  await initTicketsSchema();
-  if (q.trim().length < 2) return [];
-  const r = await pool.query<ListedTicket>(
-    `${LIST_SELECT}
-     WHERE t.brand = $1
-       AND (t.title ILIKE '%' || $2 || '%' OR t.external_id ILIKE '%' || $2 || '%')
-     ${LIST_ORDER}
-     LIMIT $3`,
-    [brand, q, limit]);
-  return r.rows;
-}
-
-// ── Distinct components for the filter dropdown ─────────────────────────────
-
-async function listKnownComponents(brand: string, opts: { includeTestData?: boolean } = {}): Promise<string[]> {
-  await initTicketsSchema();
-  const filter = opts.includeTestData ? '' : ' AND is_test_data = false';
-  const r = await pool.query<{ component: string }>(
-    `SELECT DISTINCT component FROM tickets.tickets
-      WHERE brand = $1 AND component IS NOT NULL${filter} ORDER BY component`,
-    [brand]);
-  return r.rows.map(x => x.component);
-}
-async function listKnownThesisTags(brand: string): Promise<string[]> {
-  await initTicketsSchema();
-  const r = await pool.query<{ thesis_tag: string }>(
-    `SELECT DISTINCT thesis_tag FROM tickets.tickets
-      WHERE brand = $1 AND thesis_tag IS NOT NULL ORDER BY thesis_tag`,
-    [brand]);
-  return r.rows.map(x => x.thesis_tag);
-}

--- a/website/src/lib/tickets/cockpit-table-actions.test.ts
+++ b/website/src/lib/tickets/cockpit-table-actions.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import * as actions from './cockpit-table-actions';
+import type { TicketRow } from './cockpit-types';
 
 beforeEach(() => vi.restoreAllMocks());
 
@@ -36,7 +37,7 @@ describe('cockpit-table-actions', () => {
   });
   it('reorderTickets POSTs planningRank updates', async () => {
     const spy = vi.spyOn(global, 'fetch').mockResolvedValue(new Response('{}', { status: 200 }));
-    await actions.reorderTickets([{ id: 'a' }, { id: 'b' }] as any);
+    await actions.reorderTickets([{ id: 'a' }, { id: 'b' }] as unknown as TicketRow[]);
     const body = JSON.parse((spy.mock.calls[0][1] as RequestInit).body as string);
     expect(spy).toHaveBeenCalledWith('/api/admin/cockpit/reorder', expect.anything());
     expect(body.updates).toEqual([

--- a/website/src/lib/tickets/cockpit-table-actions.ts
+++ b/website/src/lib/tickets/cockpit-table-actions.ts
@@ -29,22 +29,6 @@ export async function patchPriority(id: string, priority: string): Promise<boole
   return res.ok;
 }
 
-async function patchTitle(id: string, title: string): Promise<boolean> {
-  const res = await fetch(`/api/admin/tickets/${id}`, {
-    method: 'PATCH', headers: JSON_HEADERS, credentials: 'same-origin',
-    body: JSON.stringify({ title }),
-  });
-  return res.ok;
-}
-
-async function patchDescription(id: string, description: string): Promise<boolean> {
-  const res = await fetch(`/api/admin/tickets/${id}`, {
-    method: 'PATCH', headers: JSON_HEADERS, credentials: 'same-origin',
-    body: JSON.stringify({ description }),
-  });
-  return res.ok;
-}
-
 export async function reorderTickets(ordered: TicketRow[]): Promise<boolean> {
   const updates = ordered.map((t, i) => ({ ticketId: t.id, planningRank: i }));
   const res = await fetch('/api/admin/cockpit/reorder', {

--- a/website/src/lib/website-db.ts
+++ b/website/src/lib/website-db.ts
@@ -1,4 +1,6 @@
-import type { ReferenzItem, ReferenzenType, ReferenzenConfig } from '../config/types';
+// Types re-exported from config/types.ts for backward compatibility.
+import type { ReferenzItem, ReferenzenConfig } from '../config/types';
+export type { ReferenzItem, ReferenzenType, ReferenzenConfig } from '../config/types';
 
 // Meeting Knowledge Pipeline — PostgreSQL client.
 // Writes meeting data, transcripts, and artifacts to the meetings DB.
@@ -19,8 +21,9 @@ import type { MeetingWithDetails } from './meetings-db';
 // tickets modules can depend on the leaf-most pool without re-entering
 // website-db. Re-export for backward compatibility with any external caller
 // that imports these names from website-db.
-import { pool, platformPool, ensureSchemaOnce, __resetSchemaInitCacheForTests } from './db-pool';
-export { pool, platformPool, ensureSchemaOnce, __resetSchemaInitCacheForTests } from './db-pool';
+import { pool, ensureSchemaOnce, __resetSchemaInitCacheForTests } from './db-pool';
+export { pool, ensureSchemaOnce, __resetSchemaInitCacheForTests } from './db-pool';
+export { platformPool } from './db-pool';
 import type { Pool, PoolClient } from 'pg';
 
 // Eager boot-time init so tracker schema migrations apply on rollout rather
@@ -782,9 +785,6 @@ export async function saveLegalPage(brand: string, pageKey: string, contentHtml:
 }
 
 // ── Referenzen Config ─────────────────────────────────────────────────────────
-// Types re-exported from config/types.ts for backward compatibility.
-
-export type { ReferenzItem, ReferenzenType, ReferenzenConfig } from '../config/types';
 
 export async function initReferenzenTable(): Promise<void> {
   return ensureSchemaOnce('referenzen_config', async () => {

--- a/website/src/lib/zugferd.ts
+++ b/website/src/lib/zugferd.ts
@@ -15,7 +15,7 @@ function esc(s: string | null | undefined): string {
 }
 
 export interface ZugferdNativeInput {
-  invoice: { number: string; issueDate: string; grossAmount: number; netAmount: number; taxAmount: number; taxMode: string; taxRate: number };
+  invoice: { number: string; issueDate: string; grossAmount: number; netAmount: number; taxAmount: number; taxMode: 'kleinunternehmer' | 'regelbesteuerung'; taxRate: number };
   lines: Array<{ description: string; netAmount: number }>;
   customer: { name: string; email: string };
   seller: { name: string; address: string; postalCode: string; city: string; country: string; vatId: string; taxNumber?: string };
@@ -25,30 +25,18 @@ export function generateZugferdXml(): string {
   throw new Error('generateZugferdXml is deprecated. Use generateFacturX from ./einvoice/factur-x.ts.');
 }
 
-// Local type — only the fields used in generateZugferdXmlLegacy
-interface FullInvoice {
-  number: string;
-  date: string;
-  amountDue: number;
-  subtotalExclTax: number;
-  taxAmount: number;
-  currency: string;
-  customerName: string;
-  customerEmail: string;
-}
-
-export function generateZugferdXmlFromNative(input: any): string {
+export function generateZugferdXmlFromNative(input: ZugferdNativeInput): string {
   const mapped: InvoiceInput = {
     number: input.invoice.number,
     issueDate: input.invoice.issueDate,
-    dueDate: input.invoice.dueDate ?? input.invoice.issueDate,
+    dueDate: input.invoice.issueDate,
     currency: 'EUR',
     taxMode: input.invoice.taxMode,
-    lines: input.lines.map((l: any) => ({
+    lines: input.lines.map((l) => ({
       description: l.description,
-      quantity: l.quantity || 1,
+      quantity: 1,
       unit: 'C62',
-      unitPrice: l.unitPrice ?? l.netAmount,
+      unitPrice: l.netAmount,
       netAmount: l.netAmount,
       taxRate: input.invoice.taxMode === 'kleinunternehmer' ? 0 : input.invoice.taxRate,
       taxCategory: input.invoice.taxMode === 'kleinunternehmer' ? 'E' : 'S',

--- a/website/src/middleware/logging.test.ts
+++ b/website/src/middleware/logging.test.ts
@@ -6,7 +6,7 @@ function makeContext(headers: Record<string, string> = {}) {
   return {
     request: new Request('https://example.test/api/x', { method: 'POST', headers }),
     locals,
-  } as any;
+  } as unknown as Parameters<typeof loggingMiddleware>[0];
 }
 
 describe('loggingMiddleware', () => {

--- a/website/src/pages/[service].astro
+++ b/website/src/pages/[service].astro
@@ -28,12 +28,12 @@ const nextSvc = svcIndex < visibleServices.length - 1 ? visibleServices[svcIndex
 
 // SEO: DB-Override > pageContent.seoTitle > svc.title
 const dbSeoTitle = await getSeoTitle(BRAND_ID, svc.slug).catch(() => null);
-const seoTitle = dbSeoTitle ?? (pc as any).seoTitle ?? svc.title;
+const seoTitle = dbSeoTitle ?? pc.seoTitle ?? svc.title;
 const useRawTitle = seoTitle !== svc.title;
 
 // SEO: DB-Override > pageContent.seoDescription > svc.description
 const dbSeoDesc = await getSiteSetting(BRAND_ID, `seo_meta_desc_${svc.slug}`).catch(() => null);
-const seoDesc = dbSeoDesc ?? (pc as any).seoDescription ?? svc.description;
+const seoDesc = dbSeoDesc ?? pc.seoDescription ?? svc.description;
 
 const seoOgImage = await getSeoOgImage(BRAND_ID, svc.slug).catch(() => null);
 

--- a/website/src/pages/admin/brett/[...path].astro
+++ b/website/src/pages/admin/brett/[...path].astro
@@ -54,7 +54,8 @@ try {
     status: upstreamRes.status,
     headers: { 'content-type': contentType },
   });
-} catch (e: any) {
-  return new Response(`Proxy error: ${e.message}`, { status: 502 });
+} catch (e) {
+  const message = e instanceof Error ? e.message : String(e);
+  return new Response(`Proxy error: ${message}`, { status: 502 });
 }
 ---

--- a/website/src/pages/admin/buchhaltung.astro
+++ b/website/src/pages/admin/buchhaltung.astro
@@ -2,12 +2,10 @@
 import AdminLayout from '../../layouts/AdminLayout.astro';
 import AdminPageHeader from '../../components/admin/ui/AdminPageHeader.svelte';
 import { getSession, getLoginUrl, isAdmin } from '../../lib/auth';
-import EurReport from '../../components/admin/EurReport.svelte';
 
 const session = await getSession(Astro.request.headers.get('cookie'));
 if (!session) return Astro.redirect(getLoginUrl(Astro.url.pathname));
 if (!isAdmin(session)) return Astro.redirect('/admin');
-const year = new Date().getFullYear();
 ---
 <AdminLayout title="Buchhaltung / EÜR">
   <div style="border-bottom:1px solid var(--line);padding:0 2rem;display:flex;gap:0;overflow-x:auto;flex-shrink:0;">

--- a/website/src/pages/admin/clients.astro
+++ b/website/src/pages/admin/clients.astro
@@ -2,7 +2,6 @@
 import AdminLayout from '../../layouts/AdminLayout.astro';
 import AdminPageHeader from '../../components/admin/ui/AdminPageHeader.svelte';
 import AdminTabs from '../../components/admin/ui/AdminTabs.svelte';
-import AdminBadge from '../../components/admin/ui/AdminBadge.svelte';
 import { getSession, getLoginUrl, isAdmin } from '../../lib/auth';
 import { listUsers } from '../../lib/identity';
 import type { KcUser } from '../../lib/identity';

--- a/website/src/pages/admin/coaching/projekte/index.astro
+++ b/website/src/pages/admin/coaching/projekte/index.astro
@@ -4,16 +4,15 @@ import AdminPageHeader from '../../../../components/admin/ui/AdminPageHeader.sve
 import { getSession, getLoginUrl, isAdmin } from '../../../../lib/auth';
 import { listProjects, type ListProjectsResult } from '../../../../lib/coaching-project-db';
 import { pool } from '../../../../lib/website-db';
-import ProjectsOverview from '../../../../components/admin/coaching/ProjectsOverview.svelte';
 
 const session = await getSession(Astro.request.headers.get('cookie'));
 if (!session) return Astro.redirect(getLoginUrl(Astro.url.pathname));
 if (!isAdmin(session)) return Astro.redirect('/admin');
 
 const brand = process.env.BRAND || 'mentolder';
-let initialResult: ListProjectsResult = { projects: [], total: 0, page: 1, pageSize: 20 };
+let _initialResult: ListProjectsResult = { projects: [], total: 0, page: 1, pageSize: 20 };
 try {
-  initialResult = await listProjects(pool, brand, { page: 1, pageSize: 20 });
+  _initialResult = await listProjects(pool, brand, { page: 1, pageSize: 20 });
 } catch { /* coaching schema existiert noch nicht */ }
 ---
 

--- a/website/src/pages/admin/coaching/sessions/[id].astro
+++ b/website/src/pages/admin/coaching/sessions/[id].astro
@@ -61,8 +61,6 @@ const report = coachingSession.status === 'completed'
   ? coachingSession.steps.find(s => s.stepNumber === 0)
   : null;
 
-const session = coachingSession;
-
 const displayClient = customers.find(c => c.id === coachingSession.clientId)?.name ?? coachingSession.clientName ?? '—';
 const displayKi = kiProviders.find(p => p.id === coachingSession.kiConfigId)?.displayName
   ?? kiProviders.find(p => p.isActive)?.displayName

--- a/website/src/pages/admin/coaching/settings.astro
+++ b/website/src/pages/admin/coaching/settings.astro
@@ -5,18 +5,17 @@ import { getSession, getLoginUrl, isAdmin } from '../../../lib/auth';
 import { listKiProviders } from '../../../lib/coaching-ki-config-db';
 import { listStepTemplates } from '../../../lib/coaching-templates-db';
 import { pool } from '../../../lib/website-db';
-import CoachingSettings from '../../../components/admin/coaching/CoachingSettings.svelte';
 
 const session = await getSession(Astro.request.headers.get('cookie'));
 if (!session) return Astro.redirect(getLoginUrl(Astro.url.pathname));
 if (!isAdmin(session)) return Astro.redirect('/admin');
 
 const brand = process.env.BRAND || 'mentolder';
-let initialProviders = [];
-let initialTemplates = [];
+let _initialProviders = [];
+let _initialTemplates = [];
 try {
-  initialProviders = await listKiProviders(pool, brand);
-  initialTemplates = await listStepTemplates(pool, brand);
+  _initialProviders = await listKiProviders(pool, brand);
+  _initialTemplates = await listStepTemplates(pool, brand);
 } catch {}
 ---
 

--- a/website/src/pages/admin/einstellungen/backup.astro
+++ b/website/src/pages/admin/einstellungen/backup.astro
@@ -1,8 +1,6 @@
 ---
 import AdminLayout from '../../../layouts/AdminLayout.astro';
 import AdminPageHeader from '../../../components/admin/ui/AdminPageHeader.svelte';
-import AdminCard from '../../../components/admin/ui/AdminCard.svelte';
-import AdminFormField from '../../../components/admin/ui/AdminFormField.svelte';
 import AdminEinstellungenTabs from '../../../components/AdminEinstellungenTabs.astro';
 import { getSession, getLoginUrl, isAdmin } from '../../../lib/auth';
 import { getSiteSetting } from '../../../lib/website-db';

--- a/website/src/pages/admin/einstellungen/benachrichtigungen.astro
+++ b/website/src/pages/admin/einstellungen/benachrichtigungen.astro
@@ -1,8 +1,6 @@
 ---
 import AdminLayout from '../../../layouts/AdminLayout.astro';
 import AdminPageHeader from '../../../components/admin/ui/AdminPageHeader.svelte';
-import AdminCard from '../../../components/admin/ui/AdminCard.svelte';
-import AdminFormField from '../../../components/admin/ui/AdminFormField.svelte';
 import AdminEinstellungenTabs from '../../../components/AdminEinstellungenTabs.astro';
 import { getSession, getLoginUrl, isAdmin } from '../../../lib/auth';
 import { getSiteSetting } from '../../../lib/website-db';

--- a/website/src/pages/admin/einstellungen/branding.astro
+++ b/website/src/pages/admin/einstellungen/branding.astro
@@ -1,8 +1,6 @@
 ---
 import AdminLayout from '../../../layouts/AdminLayout.astro';
 import AdminPageHeader from '../../../components/admin/ui/AdminPageHeader.svelte';
-import AdminCard from '../../../components/admin/ui/AdminCard.svelte';
-import AdminFormField from '../../../components/admin/ui/AdminFormField.svelte';
 import AdminEinstellungenTabs from '../../../components/AdminEinstellungenTabs.astro';
 import { getSession, getLoginUrl, isAdmin } from '../../../lib/auth';
 import { getSiteSetting } from '../../../lib/website-db';
@@ -168,7 +166,7 @@ const s = Object.fromEntries(keys.map((k, i) => [k, results[i] ?? ''])) as Recor
       if (urlInput) urlInput.value = data.src;
       renderPreview(data.src);
       setStatus('Logo aktualisiert. Klicken Sie auf "Speichern", um es zu übernehmen.', 'ok');
-    } catch (err) {
+    } catch {
       setStatus('Netzwerkfehler beim Upload.', 'error');
     } finally {
       fileInput.disabled = false;

--- a/website/src/pages/admin/einstellungen/email.astro
+++ b/website/src/pages/admin/einstellungen/email.astro
@@ -1,8 +1,6 @@
 ---
 import AdminLayout from '../../../layouts/AdminLayout.astro';
 import AdminPageHeader from '../../../components/admin/ui/AdminPageHeader.svelte';
-import AdminCard from '../../../components/admin/ui/AdminCard.svelte';
-import AdminFormField from '../../../components/admin/ui/AdminFormField.svelte';
 import AdminEinstellungenTabs from '../../../components/AdminEinstellungenTabs.astro';
 import { getSession, getLoginUrl, isAdmin } from '../../../lib/auth';
 import { getSiteSetting } from '../../../lib/website-db';

--- a/website/src/pages/admin/einstellungen/rechnungen.astro
+++ b/website/src/pages/admin/einstellungen/rechnungen.astro
@@ -1,8 +1,6 @@
 ---
 import AdminLayout from '../../../layouts/AdminLayout.astro';
 import AdminPageHeader from '../../../components/admin/ui/AdminPageHeader.svelte';
-import AdminCard from '../../../components/admin/ui/AdminCard.svelte';
-import AdminFormField from '../../../components/admin/ui/AdminFormField.svelte';
 import AdminEinstellungenTabs from '../../../components/AdminEinstellungenTabs.astro';
 import { getSession, getLoginUrl, isAdmin } from '../../../lib/auth';
 import { getSiteSetting } from '../../../lib/website-db';

--- a/website/src/pages/admin/fragebogen/[assignmentId].astro
+++ b/website/src/pages/admin/fragebogen/[assignmentId].astro
@@ -8,7 +8,6 @@ import {
 } from '../../../lib/questionnaire-db';
 import { getDisplayScores } from '../../../lib/questionnaire-display';
 import { isSystemtestLoopEnabled } from '../../../lib/systemtest/feature-flag';
-import SystemtestReplayDrawer from '../../../components/SystemtestReplayDrawer.svelte';
 
 const session = await getSession(Astro.request.headers.get('cookie'));
 if (!session) return Astro.redirect(getLoginUrl(Astro.url.pathname));
@@ -20,7 +19,7 @@ if (!assignmentId) return Astro.redirect('/admin');
 const assignment = await getQAssignment(assignmentId).catch(() => null);
 if (!assignment) return Astro.redirect('/admin');
 
-const [dimensions, questions, allOptions, answers, evidenceList] = await Promise.all([
+const [_dimensions, questions, _allOptions, answers, evidenceList] = await Promise.all([
   listQDimensions(assignment.template_id),
   listQQuestions(assignment.template_id),
   listQAnswerOptionsForTemplate(assignment.template_id),
@@ -276,8 +275,8 @@ const maxScore = Math.max(...scores.map(s => s.threshold_high ?? s.final_score ?
       {assignment.status === 'dismissed' && (
         <div class="mb-8 p-5 bg-red-500/5 rounded-xl border border-red-500/20">
           <h2 class="text-sm font-medium text-red-400 uppercase tracking-wide mb-2">Fragebogen abgelehnt</h2>
-          {(assignment as any).dismiss_reason ? (
-            <p class="text-muted text-sm">Begründung: {(assignment as any).dismiss_reason}</p>
+          {assignment.dismiss_reason ? (
+            <p class="text-muted text-sm">Begründung: {assignment.dismiss_reason}</p>
           ) : (
             <p class="text-muted text-sm italic">Keine Begründung angegeben.</p>
           )}

--- a/website/src/pages/admin/termine.astro
+++ b/website/src/pages/admin/termine.astro
@@ -385,7 +385,7 @@ function formatTime(d: Date) {
       <h2 class="text-xl font-semibold text-light mb-4">Urlaubsplanung <span class="text-sm font-normal text-muted">/ Auszeiten</span></h2>
       <p class="text-sm text-muted mb-4">Geblockte Zeiträume erscheinen nicht in der Buchungsansicht. Änderungen wirken sofort.</p>
       <div id="vacation-list" class="space-y-2 mb-4">
-        {vacationPeriods.map((p, i) => (
+        {vacationPeriods.map((p, _i) => (
           <div class="vacation-row flex gap-2 items-center flex-wrap p-3 bg-dark-light rounded-lg border border-dark-lighter" data-id={p.id}>
             <input type="text" class="vacation-label flex-1 min-w-32 bg-dark border border-dark-lighter rounded px-2 py-1 text-light text-sm focus:border-gold outline-none" value={p.label} placeholder="Bezeichnung (z.B. Sommerurlaub)" />
             <input type="date" class="vacation-start bg-dark border border-dark-lighter rounded px-2 py-1 text-light text-sm focus:border-gold outline-none" value={p.start} />

--- a/website/src/pages/admin/zeiterfassung.astro
+++ b/website/src/pages/admin/zeiterfassung.astro
@@ -41,9 +41,6 @@ try {
 
 const totalMinutes    = entries.reduce((s, e) => s + e.minutes, 0);
 const billableMinutes = entries.filter(e => e.billable).reduce((s, e) => s + e.minutes, 0);
-const billableAmount  = entries
-  .filter(e => e.billable && e.rateCents > 0)
-  .reduce((sum, e) => sum + (e.minutes / 60) * (e.rateCents / 100), 0);
 
 function fmtMin(m: number): string {
   return `${Math.floor(m / 60)}h ${(m % 60).toString().padStart(2, '0')}m`;

--- a/website/src/pages/agb.astro
+++ b/website/src/pages/agb.astro
@@ -4,11 +4,12 @@ import { getLegalPage } from '../lib/website-db';
 import { getDefaultAgb } from '../lib/legal-defaults';
 import { resolveTokens } from '../lib/legal-tokens';
 import { getEffectiveStammdaten } from '../lib/content';
+import type { Stammdaten } from '../lib/website-db';
 
 const BRAND = process.env.BRAND || 'mentolder';
 const BRAND_ID = process.env.BRAND_ID ?? BRAND;
 const isKore = BRAND_ID === 'korczewski';
-const sd = await getEffectiveStammdaten().catch(() => ({} as any));
+const sd = await getEffectiveStammdaten().catch(() => ({} as Stammdaten));
 const stored = await getLegalPage(BRAND, 'agb').catch(() => null);
 const contentHtml = resolveTokens(stored?.trim() ? stored : getDefaultAgb(), sd);
 ---

--- a/website/src/pages/api/admin/art-library.ts
+++ b/website/src/pages/api/admin/art-library.ts
@@ -18,7 +18,12 @@ export const GET: APIRoute = async ({ request }) => {
 
   try {
     const manifest = JSON.parse(readFileSync(MANIFEST_PATH, 'utf8'));
-    const assets = (manifest.assets ?? []).map((a: any) => ({
+    // Asset shape from manifest.json: arbitrary metadata plus a `files` map of slot -> relative path.
+    interface ArtLibraryAsset {
+      files?: Record<string, unknown>;
+      [key: string]: unknown;
+    }
+    const assets = (manifest.assets ?? []).map((a: ArtLibraryAsset) => ({
       ...a,
       files: Object.fromEntries(
         Object.entries(a.files ?? {}).map(([slot, rel]) => [slot, toPublicUrl(String(rel))]),

--- a/website/src/pages/api/admin/assets/upload.ts
+++ b/website/src/pages/api/admin/assets/upload.ts
@@ -89,7 +89,7 @@ export const POST: APIRoute = async ({ request }) => {
     }), {
       headers: { 'Content-Type': 'application/json' },
     });
-  } catch (err) {
+  } catch {
     return new Response(JSON.stringify({ error: 'Upload fehlgeschlagen' }), {
       status: 500, headers: { 'Content-Type': 'application/json' },
     });

--- a/website/src/pages/api/admin/backup-status.test.ts
+++ b/website/src/pages/api/admin/backup-status.test.ts
@@ -146,7 +146,7 @@ describe('GET /api/admin/backup-status', () => {
   it('returns 401 without session', async () => {
     vi.mocked(getSession).mockResolvedValue(null);
     const req = new Request('http://x/api/admin/backup-status');
-    const res = await GET({ request: req } as any);
+    const res = await GET({ request: req } as Parameters<typeof GET>[0]);
     expect(res.status).toBe(401);
   });
 
@@ -154,7 +154,7 @@ describe('GET /api/admin/backup-status', () => {
     vi.mocked(getSession).mockResolvedValue({ sub: 'u1' } as never);
     vi.mocked(isAdmin).mockReturnValue(false);
     const req = new Request('http://x/api/admin/backup-status');
-    const res = await GET({ request: req } as any);
+    const res = await GET({ request: req } as Parameters<typeof GET>[0]);
     expect(res.status).toBe(401);
   });
 });

--- a/website/src/pages/api/admin/billing/[id]/finalize-from-prepayment.ts
+++ b/website/src/pages/api/admin/billing/[id]/finalize-from-prepayment.ts
@@ -1,6 +1,6 @@
 import type { APIRoute } from 'astro';
 import { getSession, isAdmin } from '../../../../../lib/auth';
-import { pool, initBillingTables } from '../../../../../lib/website-db';
+import { pool } from '../../../../../lib/website-db';
 import { getInvoice, createInvoice, type InvoiceLine } from '../../../../../lib/native-billing';
 
 export const POST: APIRoute = async ({ params, request , locals }) => {

--- a/website/src/pages/api/admin/billing/[id]/item.ts
+++ b/website/src/pages/api/admin/billing/[id]/item.ts
@@ -13,10 +13,7 @@ export const POST: APIRoute = async ({ request, params }) => {
 
   const body = await request.json();
    
-  const inv  = await stripe.invoices.retrieve(params.id!);
-  const customerId = typeof inv.customer === 'string'
-    ? inv.customer
-    : (inv.customer as { id: string } | null)?.id ?? '';
+  await stripe.invoices.retrieve(params.id!);
 
   await addDraftInvoiceItem(params.id!, {
     description: String(body.description ?? ''),

--- a/website/src/pages/api/admin/billing/[id]/send.ts
+++ b/website/src/pages/api/admin/billing/[id]/send.ts
@@ -73,13 +73,6 @@ export const POST: APIRoute = async ({ request, params , locals }) => {
     unit: l.unit as string | undefined,
   }));
 
-  // Generate PDF + XML before finalizing so we can roll back on failure
-  const zugferdSeller = {
-    name: seller.name, address: seller.address,
-    postalCode: seller.postalCode, city: seller.city,
-    country: seller.country, vatId: seller.vatId,
-  };
-
   // Use a temporary invoice object for generation (same data as draft row)
   const draftRow = draftCheck.rows[0];
   const tempInvoice = {
@@ -213,7 +206,9 @@ export const POST: APIRoute = async ({ request, params , locals }) => {
     vars
   );
 
-  const attachments: any[] = [{ filename: `${finalized.number}.pdf`, content: pdf }];
+  const attachments: { filename: string; content: Buffer; contentType?: string }[] = [
+    { filename: `${finalized.number}.pdf`, content: pdf },
+  ];
   if (finalized.leitwegId) {
     const r = await pool.query<{ content: Buffer | null }>(`SELECT content FROM billing_invoice_documents WHERE invoice_id=$1 AND format='xrechnung'`, [id]);
     if (r.rows[0]?.content) {

--- a/website/src/pages/api/admin/billing/create-invoice.ts
+++ b/website/src/pages/api/admin/billing/create-invoice.ts
@@ -10,7 +10,7 @@ export const POST: APIRoute = async ({ request , locals }) => {
   try {
     const body = await request.json();
     const {
-      name, email, company, addressLine1, city, postalCode, vatNumber, landIso,
+      name, email, company, addressLine1, city, postalCode, vatNumber,
       lines, notes, servicePeriodStart, servicePeriodEnd, leitwegId,
       currency, supplyType, kind, parentInvoiceId,
       dueDays = 14, taxMode = 'regelbesteuerung', taxRate = 19

--- a/website/src/pages/api/admin/cluster/graph.test.ts
+++ b/website/src/pages/api/admin/cluster/graph.test.ts
@@ -135,7 +135,7 @@ describe('GET /api/admin/cluster/graph', () => {
   it('returns 401 without session', async () => {
     vi.mocked(getSession).mockResolvedValue(null);
     const req = new Request('http://x/api/admin/cluster/graph');
-    const res = await GET({ request: req } as any);
+    const res = await GET({ request: req } as Parameters<typeof GET>[0]);
     expect(res.status).toBe(401);
   });
 
@@ -143,7 +143,7 @@ describe('GET /api/admin/cluster/graph', () => {
     vi.mocked(getSession).mockResolvedValue({ sub: 'u1' } as never);
     vi.mocked(isAdmin).mockReturnValue(false);
     const req = new Request('http://x/api/admin/cluster/graph');
-    const res = await GET({ request: req } as any);
+    const res = await GET({ request: req } as Parameters<typeof GET>[0]);
     expect(res.status).toBe(401);
   });
 });

--- a/website/src/pages/api/admin/cluster/logs.ts
+++ b/website/src/pages/api/admin/cluster/logs.ts
@@ -70,7 +70,8 @@ export const GET: APIRoute = async ({ request }) => {
       status: 200,
       headers: { 'Content-Type': 'text/plain; charset=utf-8' },
     });
-  } catch (error: any) {
-    return new Response(`Error: ${error.message ?? 'unknown'}`, { status: 500 });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'unknown';
+    return new Response(`Error: ${message}`, { status: 500 });
   }
 };

--- a/website/src/pages/api/admin/coaching/books/upload.ts
+++ b/website/src/pages/api/admin/coaching/books/upload.ts
@@ -53,7 +53,7 @@ export const POST: APIRoute = async ({ request , locals }) => {
       text = result.text;
       pageCount = result.total;
     } else {
-      const epub = await (EPub as any).createAsync(tmpPath);
+      const epub = await EPub.createAsync(tmpPath);
       const chapters: string[] = [];
       for (const item of epub.flow) {
         const html = await new Promise<string>((res, rej) =>

--- a/website/src/pages/api/admin/coaching/ki-config/active.ts
+++ b/website/src/pages/api/admin/coaching/ki-config/active.ts
@@ -19,7 +19,7 @@ export const PATCH: APIRoute = async ({ request }) => {
   const brand = process.env.BRAND || 'mentolder';
   try {
     await setActiveProvider(pool, brand, body.provider as KiConfig['provider']);
-  } catch (e) {
+  } catch {
     return new Response(JSON.stringify({ error: 'Provider nicht gefunden' }), { status: 404, headers: { 'content-type': 'application/json' } });
   }
   return new Response(JSON.stringify({ ok: true }), { headers: { 'content-type': 'application/json' } });

--- a/website/src/pages/api/admin/coaching/step-templates/[id].ts
+++ b/website/src/pages/api/admin/coaching/step-templates/[id].ts
@@ -5,7 +5,7 @@ import { pool } from '../../../../../lib/website-db';
 
 export const prerender = false;
 
-export const PATCH: APIRoute = async ({ request, params }) => {
+export const PATCH: APIRoute = async ({ request }) => {
   const session = await getSession(request.headers.get('cookie'));
   if (!session || !isAdmin(session)) return new Response('Unauthorized', { status: 401 });
   const brand = process.env.BRAND || 'mentolder';

--- a/website/src/pages/api/admin/content/restore.test.ts
+++ b/website/src/pages/api/admin/content/restore.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { it, expect, vi, beforeEach } from 'vitest';
 
 vi.mock('../../../../lib/auth', () => ({ getSession: vi.fn(), isAdmin: vi.fn() }));
 vi.mock('../../../../lib/website-db', () => ({
@@ -29,7 +29,7 @@ beforeEach(() => {
 
 it('returns 401 when not authenticated', async () => {
   vi.mocked(getSession).mockResolvedValue(null);
-  const res = await POST({ request: jsonReq({ contentKey: 'kontakt', versionId: 1 }) } as any);
+  const res = await POST({ request: jsonReq({ contentKey: 'kontakt', versionId: 1 }) } as Parameters<typeof POST>[0]);
   expect(res.status).toBe(401);
 });
 
@@ -37,7 +37,7 @@ it('returns 404 for unknown versionId', async () => {
   vi.mocked(getSession).mockResolvedValue({ user: { sub: 'admin' } } as never);
   vi.mocked(isAdmin).mockReturnValue(true);
   vi.mocked(listVersions).mockResolvedValue([{ id: 99, editor: 'x', createdAt: new Date(), snapshot: {} }]);
-  const res = await POST({ request: jsonReq({ contentKey: 'kontakt', versionId: 1 }) } as any);
+  const res = await POST({ request: jsonReq({ contentKey: 'kontakt', versionId: 1 }) } as Parameters<typeof POST>[0]);
   expect(res.status).toBe(404);
 });
 
@@ -47,7 +47,7 @@ it('restores version by writing snapshot value with current live version as base
   vi.mocked(listVersions).mockResolvedValue([{ id: 5, editor: 'x', createdAt: new Date(), snapshot: { value: { footerEmail: 'old@b.de' }, version: 1 } }]);
   vi.mocked(readContent).mockResolvedValue({ value: { footerEmail: 'new@b.de' }, version: 3 });
   vi.mocked(writeContent).mockResolvedValue({ version: 4 });
-  const res = await POST({ request: jsonReq({ contentKey: 'kontakt', versionId: 5 }) } as any);
+  const res = await POST({ request: jsonReq({ contentKey: 'kontakt', versionId: 5 }) } as Parameters<typeof POST>[0]);
   expect(res.status).toBe(200);
   expect(await res.json()).toEqual({ version: 4 });
   expect(writeContent).toHaveBeenCalledWith(expect.any(String), 'kontakt', { footerEmail: 'old@b.de' }, 3, 'admin@x.de');

--- a/website/src/pages/api/admin/content/versions.test.ts
+++ b/website/src/pages/api/admin/content/versions.test.ts
@@ -17,7 +17,7 @@ describe('GET /api/admin/content/versions', () => {
   it('returns 401 when not authenticated', async () => {
     vi.mocked(getSession).mockResolvedValue(null);
     const url = new URL('http://x/api/admin/content/versions?key=kontakt');
-    const res = await GET({ request: new Request(url), url } as any);
+    const res = await GET({ request: new Request(url), url } as Parameters<typeof GET>[0]);
     expect(res.status).toBe(401);
   });
 
@@ -30,7 +30,7 @@ describe('GET /api/admin/content/versions', () => {
     ];
     vi.mocked(listVersions).mockResolvedValue(mockVersions as never);
     const url = new URL('http://x/api/admin/content/versions?key=kontakt');
-    const res = await GET({ request: new Request(url), url } as any);
+    const res = await GET({ request: new Request(url), url } as Parameters<typeof GET>[0]);
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body).toHaveLength(2);
@@ -44,7 +44,7 @@ describe('GET /api/admin/content/versions', () => {
     vi.mocked(getSession).mockResolvedValue({ user: { sub: 'admin' } } as never);
     vi.mocked(isAdmin).mockReturnValue(true);
     const url = new URL('http://x/api/admin/content/versions');
-    const res = await GET({ request: new Request(url), url } as any);
+    const res = await GET({ request: new Request(url), url } as Parameters<typeof GET>[0]);
     expect(res.status).toBe(400);
   });
 });

--- a/website/src/pages/api/admin/homepage/save.test.ts
+++ b/website/src/pages/api/admin/homepage/save.test.ts
@@ -46,7 +46,7 @@ const post = (body: unknown, origin: string | null = REACT) =>
       body: JSON.stringify(body),
     }),
     locals: { requestLogger: { error: vi.fn() } },
-  } as any);
+  } as unknown as Parameters<typeof POST>[0]);
 
 const adminSession: UserSession = { sub: 'u-1', email: 'g@mentolder.de', name: 'Gerald', preferred_username: 'gekko', realmRoles: ['admin'], brand: null, access_token: 'tok', refresh_token: 'rtok', expires_at: 9999999999 };
 

--- a/website/src/pages/api/admin/ki/embeddings.test.ts
+++ b/website/src/pages/api/admin/ki/embeddings.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { it, expect, vi, beforeEach } from 'vitest';
 
 const session = { sub: 'u1', preferred_username: 'admin', roles: ['admin'] };
 const getSession = vi.fn();

--- a/website/src/pages/api/admin/ki/env-status.test.ts
+++ b/website/src/pages/api/admin/ki/env-status.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 const session = { sub: 'u1', preferred_username: 'admin', roles: ['admin'] };
 const getSession = vi.fn();

--- a/website/src/pages/api/admin/knowledge/collections/[id]/context7.ts
+++ b/website/src/pages/api/admin/knowledge/collections/[id]/context7.ts
@@ -74,7 +74,7 @@ export const POST: APIRoute = async ({ request, params , locals }) => {
   );
 };
 
-export const GET: APIRoute = async ({ request, params , locals }) => {
+export const GET: APIRoute = async ({ request, params , locals: _locals }) => {
   const session = await getSession(request.headers.get('cookie'));
   if (!session || !isAdmin(session)) return new Response('Unauthorized', { status: 401 });
   const id = params.id!;

--- a/website/src/pages/api/admin/knowledge/collections/[id]/crawl.ts
+++ b/website/src/pages/api/admin/knowledge/collections/[id]/crawl.ts
@@ -72,7 +72,7 @@ export const POST: APIRoute = async ({ request, params , locals }) => {
   );
 };
 
-export const GET: APIRoute = async ({ request, params , locals }) => {
+export const GET: APIRoute = async ({ request, params , locals: _locals }) => {
   const session = await getSession(request.headers.get('cookie'));
   if (!session || !isAdmin(session)) return new Response('Unauthorized', { status: 401 });
   const id = params.id!;

--- a/website/src/pages/api/admin/openspec/save-proposal.ts
+++ b/website/src/pages/api/admin/openspec/save-proposal.ts
@@ -28,7 +28,7 @@ export const POST: APIRoute = async ({ request }) => {
       status: 200,
       headers: { 'Content-Type': 'application/json' },
     });
-  } catch (error) {
+  } catch {
     return new Response(JSON.stringify({ error: 'save failed' }), { status: 500, headers: { 'Content-Type': 'application/json' } });
   }
 };

--- a/website/src/pages/api/admin/ops/certs.ts
+++ b/website/src/pages/api/admin/ops/certs.ts
@@ -27,8 +27,8 @@ export const GET: APIRoute = async ({ request }) => {
       const notAfter = cert.validTo;
       const daysLeft = Math.floor((new Date(notAfter).getTime() - Date.now()) / 86400000);
       results[cluster] = { notAfter, daysLeft };
-    } catch (e: any) {
-      results[cluster] = { notAfter: null, daysLeft: null, error: e.message };
+    } catch (e) {
+      results[cluster] = { notAfter: null, daysLeft: null, error: e instanceof Error ? e.message : String(e) };
     }
   }
 

--- a/website/src/pages/api/admin/ops/dns/pin.ts
+++ b/website/src/pages/api/admin/ops/dns/pin.ts
@@ -25,12 +25,18 @@ function ipv64Get(path: string, apiKey?: string): Promise<string> {
   });
 }
 
+// Shape of an entry in ipv64's /api.php?get_domains response, restricted to the fields we read.
+interface Ipv64DomainEntry {
+  domain?: string;
+  domain_update_hash?: string;
+}
+
 async function fetchDomainUpdateHash(apiKey: string, domain: string): Promise<string | null> {
   const raw = await ipv64Get('/api.php?get_domains', apiKey);
-  const data = JSON.parse(raw);
+  const data = JSON.parse(raw) as { subdomains?: Record<string, Ipv64DomainEntry>; domains?: Record<string, Ipv64DomainEntry> };
   // ipv64 returns { subdomains: { "domain.de": { domain_update_hash, ... } } }
-  const subdomains: Record<string, any> = data.subdomains ?? data.domains ?? {};
-  const entry = subdomains[domain] ?? Object.values(subdomains).find((v: any) => v?.domain === domain);
+  const subdomains: Record<string, Ipv64DomainEntry> = data.subdomains ?? data.domains ?? {};
+  const entry = subdomains[domain] ?? Object.values(subdomains).find((v) => v?.domain === domain);
   return entry?.domain_update_hash ?? null;
 }
 
@@ -49,8 +55,9 @@ export const POST: APIRoute = async ({ request }) => {
   let hash: string | null;
   try {
     hash = await fetchDomainUpdateHash(apiKey, cfg.domain);
-  } catch (e: any) {
-    return new Response(JSON.stringify({ error: `ipv64 API Fehler: ${e.message}` }), { status: 502 });
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    return new Response(JSON.stringify({ error: `ipv64 API Fehler: ${message}` }), { status: 502 });
   }
 
   if (!hash) {

--- a/website/src/pages/api/admin/ops/health.ts
+++ b/website/src/pages/api/admin/ops/health.ts
@@ -40,9 +40,10 @@ export const GET: APIRoute = async ({ request }) => {
   let assets;
   try {
     assets = await listSoftwareAssets();
-  } catch (e: any) {
+  } catch (e) {
+    const message = e instanceof Error ? e.message : 'unknown';
     return new Response(
-      JSON.stringify({ error: `DB unreachable: ${e?.message ?? 'unknown'}` }),
+      JSON.stringify({ error: `DB unreachable: ${message}` }),
       { status: 503, headers: { 'Content-Type': 'application/json' } },
     );
   }
@@ -61,11 +62,11 @@ export const GET: APIRoute = async ({ request }) => {
         if (!ok) status = optional ? 'optional' : 'error';
         else status = latencyMs > 2000 ? 'slow' : 'ok';
         return { name: asset.name, slug: asset.slug, url, status, latencyMs, optional } satisfies ServiceCheck;
-      } catch (e: any) {
+      } catch (e) {
         return {
           name: asset.name, slug: asset.slug, url,
           status: optional ? 'optional' : 'error',
-          latencyMs: null, optional, error: e?.message,
+          latencyMs: null, optional, error: e instanceof Error ? e.message : undefined,
         } satisfies ServiceCheck;
       }
     }),

--- a/website/src/pages/api/admin/platform/hardware.ts
+++ b/website/src/pages/api/admin/platform/hardware.ts
@@ -33,7 +33,7 @@ export const GET: APIRoute = async ({ request, locals }) => {
           const readyCond = node.status?.conditions?.find((c) => c.type === 'Ready');
           readyStatus = readyCond?.status || 'Unknown';
           liveStatus = readyStatus === 'True' ? 'ready' : 'failing';
-        } catch (e) {
+        } catch {
           liveStatus = 'missing';
         }
       }

--- a/website/src/pages/api/admin/prompt-library/[id].ts
+++ b/website/src/pages/api/admin/prompt-library/[id].ts
@@ -53,7 +53,7 @@ export const PUT: APIRoute = async ({ request, params , locals }) => {
   }
 };
 
-export const DELETE: APIRoute = async ({ request, params , locals }) => {
+export const DELETE: APIRoute = async ({ request, params , locals: _locals }) => {
   const session = await getSession(request.headers.get('cookie'));
   if (!session || !isAdmin(session)) return json({ error: 'Unauthorized' }, 401);
 

--- a/website/src/pages/api/admin/prompt-library/index.ts
+++ b/website/src/pages/api/admin/prompt-library/index.ts
@@ -14,7 +14,7 @@ function json(body: unknown, status = 200): Response {
   });
 }
 
-export const GET: APIRoute = async ({ request, url , locals }) => {
+export const GET: APIRoute = async ({ request, url , locals: _locals }) => {
   const session = await getSession(request.headers.get('cookie'));
   if (!session || !isAdmin(session)) return json({ error: 'Unauthorized' }, 401);
   // The compose-box dropdown only wants active templates; the admin manager

--- a/website/src/pages/api/admin/service-page/save.ts
+++ b/website/src/pages/api/admin/service-page/save.ts
@@ -15,8 +15,26 @@ export const POST: APIRoute = async ({ request, url , locals }) => {
     status: 400, headers: { 'Content-Type': 'application/json' },
   });
 
-  let body: any;
-  try { body = await request.json(); }
+  // Request payload shape, restricted to the fields read below.
+  interface ServicePageSaveBody {
+    introNote?: string;
+    sections?: Array<{ title: string; items: string[] }>;
+    cardTitle?: string;
+    cardDescription?: string;
+    cardIcon?: string;
+    cardFeatures?: string[];
+    cardPrice?: string;
+    headline?: string;
+    intro?: string;
+    forWhom?: string[];
+    pricing?: Array<{ label: string; price: string; unit?: string; highlight?: boolean }>;
+    faq?: Array<{ question: string; answer: string }>;
+    seoTitle?: string;
+    seoDescription?: string;
+  }
+
+  let body: ServicePageSaveBody;
+  try { body = (await request.json()) as ServicePageSaveBody; }
   catch { return new Response(JSON.stringify({ error: 'Invalid JSON' }), {
     status: 400, headers: { 'Content-Type': 'application/json' },
   }); }

--- a/website/src/pages/api/admin/sessions/index.ts
+++ b/website/src/pages/api/admin/sessions/index.ts
@@ -60,7 +60,7 @@ export const GET: APIRoute = async ({ request, locals }) => {
   }
 };
 
-async function runHub(args: string[], locals: any): Promise<Response> {
+async function runHub(args: string[], locals: App.Locals): Promise<Response> {
   if (process.env.SESSION_HUB_REGISTRY_WRITABLE !== 'true') {
     return json({ error: 'not_implemented', detail: 'registry is read-only in this environment' }, 501);
   }

--- a/website/src/pages/api/admin/systemtest/purge-all-test-data.ts
+++ b/website/src/pages/api/admin/systemtest/purge-all-test-data.ts
@@ -49,7 +49,7 @@ export const POST: APIRoute = async ({ request , locals }) => {
   }
 };
 
-export const ALL: APIRoute = async ({ request , locals }) => {
+export const ALL: APIRoute = async ({ request , locals: _locals }) => {
   if (request.method !== 'POST') {
     return new Response('Method Not Allowed', {
       status: 405,

--- a/website/src/pages/api/admin/tickets/[id]/classify.ts
+++ b/website/src/pages/api/admin/tickets/[id]/classify.ts
@@ -62,7 +62,7 @@ Rules:
         parsed = JSON.parse(jsonMatch[0]);
         break;
       }
-    } catch (err) {
+    } catch {
       if (attempt === 1) {
         await setProviderCooldown(pool, SOURCE.ticketTriage, cfg.provider, 5);
         return new Response(JSON.stringify({ error: 'LLM nicht erreichbar' }), { status: 503 });

--- a/website/src/pages/api/admin/tickets/index.ts
+++ b/website/src/pages/api/admin/tickets/index.ts
@@ -9,7 +9,7 @@ import { autoTriage } from '../../../../lib/ticket-triage';
 
 const BRAND = (): string => process.env.BRAND_ID ?? process.env.BRAND ?? 'mentolder';
 
-export const GET: APIRoute = async ({ request, url , locals }) => {
+export const GET: APIRoute = async ({ request, url , locals: _locals }) => {
   const session = await getSession(request.headers.get('cookie'));
   if (!session || !isAdmin(session)) return new Response(null, { status: 403 });
 

--- a/website/src/pages/api/auth/callback.test.ts
+++ b/website/src/pages/api/auth/callback.test.ts
@@ -37,7 +37,7 @@ function call(state: string | null, code = 'abc') {
   if (code !== '') u.searchParams.set('code', code);
   if (state !== null) u.searchParams.set('state', state);
   const ctx = { url: u, locals: { requestLogger: { error: vi.fn() } } };
-  return GET(ctx as any);
+  return GET(ctx as unknown as Parameters<typeof GET>[0]);
 }
 
 describe('callback returnTo allowlist', () => {

--- a/website/src/pages/api/billing/create-invoice.ts
+++ b/website/src/pages/api/billing/create-invoice.ts
@@ -11,7 +11,7 @@ export const POST: APIRoute = async ({ request , locals }) => {
   try {
     const body = await request.json();
     const {
-      name, email, phone, company, address1, city, postalCode, vatNumber,
+      name, email, company,
       serviceKey, quantity, asQuote, sendEmail: shouldSendEmail,
     } = body;
 

--- a/website/src/pages/api/brett/bot.ts
+++ b/website/src/pages/api/brett/bot.ts
@@ -13,8 +13,15 @@ export const POST: APIRoute = async ({ request }) => {
     return new Response('forbidden', { status: 401 });
   }
 
-  let evt: any;
-  try { evt = JSON.parse(body); } catch { return new Response(null, { status: 200 }); }
+  // Nextcloud Talk webhook event shape, restricted to the fields read below.
+  interface TalkBotEvent {
+    type?: string;
+    object?: { name?: string; content?: string };
+    target?: { id?: string };
+  }
+
+  let evt: TalkBotEvent;
+  try { evt = JSON.parse(body) as TalkBotEvent; } catch { return new Response(null, { status: 200 }); }
 
   if (evt.type !== 'Create' || evt.object?.name !== 'message') {
     return new Response(null, { status: 200 });
@@ -22,7 +29,7 @@ export const POST: APIRoute = async ({ request }) => {
 
   let messageText = '';
   try {
-    const content = JSON.parse(evt.object.content);
+    const content = JSON.parse(evt.object?.content ?? '');
     messageText = (content?.message || '').trim();
   } catch { /* ignore */ }
 

--- a/website/src/pages/api/meeting/transcribe.ts
+++ b/website/src/pages/api/meeting/transcribe.ts
@@ -10,8 +10,6 @@ export const POST: APIRoute = async ({ request , locals }) => {
   try {
     const formData = await request.formData();
     const file = formData.get('file') as File | null;
-    const channelId = formData.get('channelId') as string | null;
-    const customerName = formData.get('customerName') as string | null;
 
     if (!file) {
       return new Response(

--- a/website/src/pages/barrierefreiheit.astro
+++ b/website/src/pages/barrierefreiheit.astro
@@ -4,11 +4,12 @@ import { getLegalPage } from '../lib/website-db';
 import { getDefaultBarrierefreiheit } from '../lib/legal-defaults';
 import { resolveTokens } from '../lib/legal-tokens';
 import { getEffectiveStammdaten } from '../lib/content';
+import type { Stammdaten } from '../lib/website-db';
 
 const BRAND = process.env.BRAND || 'mentolder';
 const BRAND_ID = process.env.BRAND_ID ?? BRAND;
 const isKore = BRAND_ID === 'korczewski';
-const sd = await getEffectiveStammdaten().catch(() => ({} as any));
+const sd = await getEffectiveStammdaten().catch(() => ({} as Stammdaten));
 const stored = await getLegalPage(BRAND, 'barrierefreiheit').catch(() => null);
 const contentHtml = resolveTokens(stored?.trim() ? stored : getDefaultBarrierefreiheit(), sd);
 ---

--- a/website/src/pages/datenschutz.astro
+++ b/website/src/pages/datenschutz.astro
@@ -4,11 +4,12 @@ import { getLegalPage } from '../lib/website-db';
 import { getDefaultDatenschutz } from '../lib/legal-defaults';
 import { resolveTokens } from '../lib/legal-tokens';
 import { getEffectiveStammdaten } from '../lib/content';
+import type { Stammdaten } from '../lib/website-db';
 
 const BRAND = process.env.BRAND || 'mentolder';
 const BRAND_ID = process.env.BRAND_ID ?? BRAND;
 const isKore = BRAND_ID === 'korczewski';
-const sd = await getEffectiveStammdaten().catch(() => ({} as any));
+const sd = await getEffectiveStammdaten().catch(() => ({} as Stammdaten));
 const stored = await getLegalPage(BRAND, 'datenschutz').catch(() => null);
 const contentHtml = resolveTokens(stored?.trim() ? stored : getDefaultDatenschutz(), sd);
 ---

--- a/website/src/pages/en/[service].astro
+++ b/website/src/pages/en/[service].astro
@@ -1,6 +1,7 @@
 ---
 import DePage from '../[service].astro';
+import type { GetStaticPaths } from 'astro';
 Astro.locals.locale = 'en';
-export const getStaticPaths = (DePage as any).getStaticPaths;
+export const getStaticPaths = (DePage as unknown as { getStaticPaths?: GetStaticPaths }).getStaticPaths;
 ---
 <DePage />

--- a/website/src/pages/en/poll/[id].astro
+++ b/website/src/pages/en/poll/[id].astro
@@ -1,6 +1,7 @@
 ---
 import DePage from '../../poll/[id].astro';
+import type { GetStaticPaths } from 'astro';
 Astro.locals.locale = 'en';
-export const getStaticPaths = (DePage as any).getStaticPaths;
+export const getStaticPaths = (DePage as unknown as { getStaticPaths?: GetStaticPaths }).getStaticPaths;
 ---
 <DePage />

--- a/website/src/pages/en/poll/[id]/results.astro
+++ b/website/src/pages/en/poll/[id]/results.astro
@@ -1,6 +1,7 @@
 ---
 import DePage from '../../../poll/[id]/results.astro';
+import type { GetStaticPaths } from 'astro';
 Astro.locals.locale = 'en';
-export const getStaticPaths = (DePage as any).getStaticPaths;
+export const getStaticPaths = (DePage as unknown as { getStaticPaths?: GetStaticPaths }).getStaticPaths;
 ---
 <DePage />

--- a/website/src/pages/impressum.astro
+++ b/website/src/pages/impressum.astro
@@ -4,11 +4,12 @@ import { getLegalPage } from '../lib/website-db';
 import { getDefaultImpressum } from '../lib/legal-defaults';
 import { resolveTokens } from '../lib/legal-tokens';
 import { getEffectiveStammdaten } from '../lib/content';
+import type { Stammdaten } from '../lib/website-db';
 
 const BRAND = process.env.BRAND || 'mentolder';
 const BRAND_ID = process.env.BRAND_ID ?? BRAND;
 const isKore = BRAND_ID === 'korczewski';
-const sd = await getEffectiveStammdaten().catch(() => ({} as any));
+const sd = await getEffectiveStammdaten().catch(() => ({} as Stammdaten));
 const stored = await getLegalPage(BRAND, 'impressum').catch(() => null);
 // Admin: reset via admin panel Verlauf → SchemaEditor "Reset" button
 const contentHtml = resolveTokens(stored?.trim() ? stored : getDefaultImpressum(), sd);

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -32,7 +32,7 @@ const homeOgImage = !isKore
   ? await getSeoOgImage(BRAND_ID, 'home').catch(() => null)
   : null;
 
-const [homepage, faq, allServices, stammdaten, effectiveNav, effectiveFooter, effectiveKoreFlags] = await Promise.all([
+const [homepage, faq, allServices, stammdaten, _effectiveNav, effectiveFooter, effectiveKoreFlags] = await Promise.all([
   getEffectiveHomepage(),
   getEffectiveFaq(),
   getEffectiveServices(),

--- a/website/src/pages/login.astro
+++ b/website/src/pages/login.astro
@@ -1,7 +1,6 @@
 ---
 // Force-redirect to Keycloak SSO — /login is a stable public entry point
 // that SA-02 T4 and any external link can use.
-import type { APIContext } from 'astro';
 export const prerender = false;
 
 const { redirect } = Astro;

--- a/website/src/pages/portal.astro
+++ b/website/src/pages/portal.astro
@@ -48,7 +48,6 @@ const bretDomain   = process.env.BRETT_DOMAIN ?? '';
 const bretUrl      = bretDomain ? `https://${bretDomain}` : '';
 
 // ── Badge counts (always fetched — needed for sidebar) ────────────
-let unreadMessages        = 0;
 let pendingSignatures     = 0;
 let pendingQuestionnaires = 0;
 
@@ -57,8 +56,7 @@ await upsertCustomer({ name: session.name, email: session.email, keycloakUserId:
 const customer = await getCustomerByEmail(session.email).catch(() => null);
 const crmProfile = await getCustomerProfile(session.sub).catch(() => null);
 if (customer) {
-  const rooms = await listRoomsWithInboxData(customer.id).catch(() => []);
-  unreadMessages = rooms.reduce((s, r) => s + r.unreadCount, 0);
+  await listRoomsWithInboxData(customer.id).catch(() => []);
 }
 
 try {

--- a/website/src/pages/portal/sign/[assignmentId].astro
+++ b/website/src/pages/portal/sign/[assignmentId].astro
@@ -1,7 +1,7 @@
 ---
 import PortalLayout from '../../../layouts/PortalLayout.astro';
 import { getSession, getLoginUrl } from '../../../lib/auth';
-import { getDocumentAssignmentById, getDocumentTemplate, listAssignmentsForCustomer } from '../../../lib/documents-db';
+import { getDocumentTemplate, listAssignmentsForCustomer } from '../../../lib/documents-db';
 import { renderTemplate } from '../../../lib/signing/template-renderer';
 import { getCustomerByEmail } from '../../../lib/website-db';
 import { logSigningEvent } from '../../../lib/signing/audit';

--- a/website/src/pages/sitemap.xml.ts
+++ b/website/src/pages/sitemap.xml.ts
@@ -2,7 +2,6 @@ import type { APIRoute } from 'astro';
 import { getEffectiveServices } from '../lib/content';
 import { listCustomSections } from '../lib/website-db';
 
-const BRAND = process.env.BRAND || 'mentolder';
 const PROD_DOMAIN = process.env.PROD_DOMAIN || 'localhost';
 const DOMAIN = `web.${PROD_DOMAIN}`;
 

--- a/website/tests/api.test.mjs
+++ b/website/tests/api.test.mjs
@@ -7,7 +7,6 @@ const BASE_URL = process.env.BASE_URL || 'http://localhost:4321';
 // -- Colors --
 const GREEN = '\x1b[32m';
 const RED = '\x1b[31m';
-const YELLOW = '\x1b[33m';
 const DIM = '\x1b[2m';
 const BOLD = '\x1b[1m';
 const RESET = '\x1b[0m';
@@ -520,8 +519,6 @@ async function run() {
 
   section('Questionnaire Templates (admin)');
 
-  let qTplId;
-
   await assert('GET /api/admin/questionnaires/templates returns 401 without auth', async () => {
     const r = await fetch(`${BASE_URL}/api/admin/questionnaires/templates`);
     if (r.status !== 401) throw new Error(`Expected 401, got ${r.status}`);
@@ -583,7 +580,7 @@ try {
   if (!probe.ok && probe.status !== 302) {
     // Server responded but not as expected — still run the tests
   }
-} catch (err) {
+} catch {
   console.error(`\n${RED}${BOLD}Error:${RESET} Cannot reach ${BASE_URL}`);
   console.error(`${DIM}Make sure the dev server is running: npm run dev${RESET}\n`);
   process.exit(1);

--- a/website/tests/api/documents-db.test.ts
+++ b/website/tests/api/documents-db.test.ts
@@ -4,18 +4,23 @@ import type { SignatureData } from '../../src/lib/signing/types';
 
 let db: IMemoryDb;
 
+// pg-mem's `db.public.query` only declares a single-arg signature, but the mocked
+// `pg.Pool#query` is invoked with the full node-postgres arg list (text, params, callback).
+// This local type lets us forward those args without widening to `any`.
+type FlexibleQueryable = { query: (...args: unknown[]) => unknown };
+
 vi.mock('pg', () => {
   return {
     default: {
       Pool: class MockPool {
         query(...args: unknown[]) {
-          return (db.public as any).query(...args);
+          return (db.public as unknown as FlexibleQueryable).query(...args);
         }
       },
     },
     Pool: class MockPool {
       query(...args: unknown[]) {
-        return (db.public as any).query(...args);
+        return (db.public as unknown as FlexibleQueryable).query(...args);
       }
     },
   };
@@ -114,6 +119,16 @@ describe('documents-db signing functions', () => {
        VALUES ('${cust[0].id}', '${tpl[0].id}', 'pending')`,
     );
 
+    interface AssignmentJoinRow {
+      id: string;
+      customer_id: string;
+      customer_name: string;
+      customer_email: string;
+      template_id: string;
+      template_title: string;
+      status: string;
+    }
+
     const { rows } = db.public.query(
       `SELECT a.id, a.customer_id,
               c.name  AS customer_name,
@@ -124,7 +139,7 @@ describe('documents-db signing functions', () => {
        JOIN document_templates t ON t.id = a.template_id
        LEFT JOIN customers c ON c.id = a.customer_id
        ORDER BY a.assigned_at DESC`,
-    ) as unknown as { rows: any[] };
+    ) as unknown as { rows: AssignmentJoinRow[] };
 
     expect(rows.length).toBe(1);
     expect(rows[0].template_title).toBe('Vertrag');

--- a/website/tests/api/ops/ai-reindex.test.ts
+++ b/website/tests/api/ops/ai-reindex.test.ts
@@ -20,34 +20,34 @@ vi.mock('../../../src/lib/website-db', () => {
 
 import { POST } from '../../../src/pages/api/admin/ops/ai/reindex';
 
-const adminReq = (body: any) => new Request('http://test', {
+const adminReq = (body: unknown) => new Request('http://test', {
   method: 'POST', body: JSON.stringify(body),
   headers: { Cookie: 'session=ok', 'Content-Type': 'application/json' },
 });
 
 describe('POST /api/admin/ops/ai/reindex', () => {
   it('creates k8s Job for valid collection', async () => {
-    const res = await POST({ request: adminReq({ collection: 'coaching-original' }) } as any);
+    const res = await POST({ request: adminReq({ collection: 'coaching-original' }) } as unknown as Parameters<typeof POST>[0]);
     expect(res.status).toBe(200);
     expect(createJobMock).toHaveBeenCalled();
   });
 
   it('returns 400 for invalid collection name', async () => {
-    const res = await POST({ request: adminReq({ collection: 'evil; DROP TABLE x' }) } as any);
+    const res = await POST({ request: adminReq({ collection: 'evil; DROP TABLE x' }) } as unknown as Parameters<typeof POST>[0]);
     expect(res.status).toBe(400);
   });
 
   it('returns 401 when no session', async () => {
     const { getSession } = await import('../../../src/lib/auth');
-    (getSession as any).mockResolvedValueOnce(null);
-    const res = await POST({ request: adminReq({ collection: 'coaching-original' }) } as any);
+    vi.mocked(getSession).mockResolvedValueOnce(null);
+    const res = await POST({ request: adminReq({ collection: 'coaching-original' }) } as unknown as Parameters<typeof POST>[0]);
     expect(res.status).toBe(401);
   });
 
   it('returns 403 when not admin', async () => {
     const { isAdmin } = await import('../../../src/lib/auth');
-    (isAdmin as any).mockReturnValueOnce(false);
-    const res = await POST({ request: adminReq({ collection: 'coaching-original' }) } as any);
+    vi.mocked(isAdmin).mockReturnValueOnce(false);
+    const res = await POST({ request: adminReq({ collection: 'coaching-original' }) } as unknown as Parameters<typeof POST>[0]);
     expect(res.status).toBe(403);
   });
 });

--- a/website/tests/api/ops/audit-log.test.ts
+++ b/website/tests/api/ops/audit-log.test.ts
@@ -21,7 +21,7 @@ describe('GET /api/admin/ops/audit/log', () => {
     const res = await GET({
       url: new URL('http://test/?action_filter=&limit=10'),
       request: new Request('http://test', { headers: { Cookie: 'session=ok' } })
-    } as any);
+    } as unknown as Parameters<typeof GET>[0]);
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.actions[0].id).toBe(5);
@@ -29,21 +29,21 @@ describe('GET /api/admin/ops/audit/log', () => {
 
   it('returns 401 when no session', async () => {
     const { getSession } = await import('../../../src/lib/auth');
-    (getSession as any).mockResolvedValueOnce(null);
+    vi.mocked(getSession).mockResolvedValueOnce(null);
     const res = await GET({
       url: new URL('http://test/?action_filter=&limit=10'),
       request: new Request('http://test', { headers: { Cookie: 'session=ok' } })
-    } as any);
+    } as unknown as Parameters<typeof GET>[0]);
     expect(res.status).toBe(401);
   });
 
   it('returns 403 when not admin', async () => {
     const { isAdmin } = await import('../../../src/lib/auth');
-    (isAdmin as any).mockReturnValueOnce(false);
+    vi.mocked(isAdmin).mockReturnValueOnce(false);
     const res = await GET({
       url: new URL('http://test/?action_filter=&limit=10'),
       request: new Request('http://test', { headers: { Cookie: 'session=ok' } })
-    } as any);
+    } as unknown as Parameters<typeof GET>[0]);
     expect(res.status).toBe(403);
   });
 });

--- a/website/tests/api/ops/redeploy.test.ts
+++ b/website/tests/api/ops/redeploy.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 
 vi.mock('../../../src/lib/k8s', () => ({
   createK8sClient: vi.fn(async () => ({
@@ -31,28 +31,28 @@ function makeReq(body: object, sessionCookie = 'session=ok'): Request {
 
 describe('POST /api/admin/ops/redeploy/website', () => {
   it('returns 200 + action_id on happy path', async () => {
-    const res = await redeployWebsite({ request: makeReq({ cluster: 'mentolder' }) } as any);
+    const res = await redeployWebsite({ request: makeReq({ cluster: 'mentolder' }) } as unknown as Parameters<typeof redeployWebsite>[0]);
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.action_id).toBeDefined();
   });
 
   it('returns 400 for invalid cluster', async () => {
-    const res = await redeployWebsite({ request: makeReq({ cluster: 'invalid' }) } as any);
+    const res = await redeployWebsite({ request: makeReq({ cluster: 'invalid' }) } as unknown as Parameters<typeof redeployWebsite>[0]);
     expect(res.status).toBe(400);
   });
 
   it('returns 401 when no session', async () => {
     const { getSession } = await import('../../../src/lib/auth');
-    (getSession as any).mockResolvedValueOnce(null);
-    const res = await redeployWebsite({ request: makeReq({ cluster: 'mentolder' }) } as any);
+    vi.mocked(getSession).mockResolvedValueOnce(null);
+    const res = await redeployWebsite({ request: makeReq({ cluster: 'mentolder' }) } as unknown as Parameters<typeof redeployWebsite>[0]);
     expect(res.status).toBe(401);
   });
 
   it('returns 403 when not admin', async () => {
     const { isAdmin } = await import('../../../src/lib/auth');
-    (isAdmin as any).mockReturnValueOnce(false);
-    const res = await redeployWebsite({ request: makeReq({ cluster: 'mentolder' }) } as any);
+    vi.mocked(isAdmin).mockReturnValueOnce(false);
+    const res = await redeployWebsite({ request: makeReq({ cluster: 'mentolder' }) } as unknown as Parameters<typeof redeployWebsite>[0]);
     expect(res.status).toBe(403);
   });
 });

--- a/website/tests/api/ops/users.test.ts
+++ b/website/tests/api/ops/users.test.ts
@@ -27,7 +27,7 @@ vi.mock('../../../src/lib/website-db', () => {
 import { GET as listUsersHandler } from '../../../src/pages/api/admin/ops/users/list';
 import { POST as createUserHandler } from '../../../src/pages/api/admin/ops/users/create';
 
-const adminReq = (body?: any) => new Request('http://test', {
+const adminReq = (body?: unknown) => new Request('http://test', {
   method: body ? 'POST' : 'GET',
   body: body ? JSON.stringify(body) : undefined,
   headers: { Cookie: 'session=ok', 'Content-Type': 'application/json' },
@@ -35,7 +35,7 @@ const adminReq = (body?: any) => new Request('http://test', {
 
 describe('GET /api/admin/ops/users/list', () => {
   it('returns user list', async () => {
-    const res = await listUsersHandler({ request: adminReq() } as any);
+    const res = await listUsersHandler({ request: adminReq() } as unknown as Parameters<typeof listUsersHandler>[0]);
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(Array.isArray(json.users)).toBe(true);
@@ -44,26 +44,26 @@ describe('GET /api/admin/ops/users/list', () => {
 
 describe('POST /api/admin/ops/users/create', () => {
   it('creates user + sends invite by default', async () => {
-    const res = await createUserHandler({ request: adminReq({ firstName: 'X', lastName: 'Y', email: 'x@y.de', groupIds: ['g2'] }) } as any);
+    const res = await createUserHandler({ request: adminReq({ firstName: 'X', lastName: 'Y', email: 'x@y.de', groupIds: ['g2'] }) } as unknown as Parameters<typeof createUserHandler>[0]);
     expect(res.status).toBe(200);
     const kc = await import('../../../src/lib/identity');
     expect(kc.createUser).toHaveBeenCalled();
   });
 
   it('returns 400 for invalid email', async () => {
-    const res = await createUserHandler({ request: adminReq({ firstName: 'X', lastName: 'Y', email: 'not-email', groupIds: ['g2'] }) } as any);
+    const res = await createUserHandler({ request: adminReq({ firstName: 'X', lastName: 'Y', email: 'not-email', groupIds: ['g2'] }) } as unknown as Parameters<typeof createUserHandler>[0]);
     expect(res.status).toBe(400);
   });
 
   it('returns 400 when groupIds is empty', async () => {
-    const res = await createUserHandler({ request: adminReq({ firstName: 'X', lastName: 'Y', email: 'x@y.de', groupIds: [] }) } as any);
+    const res = await createUserHandler({ request: adminReq({ firstName: 'X', lastName: 'Y', email: 'x@y.de', groupIds: [] }) } as unknown as Parameters<typeof createUserHandler>[0]);
     expect(res.status).toBe(400);
   });
 
   it('returns partial_success when invite email fails', async () => {
     const pi = await import('../../../src/lib/identity');
-    (pi.sendPasswordResetEmail as any).mockRejectedValueOnce(new Error('smtp down'));
-    const res = await createUserHandler({ request: adminReq({ firstName: 'X', lastName: 'Y', email: 'x@y.de', groupIds: ['g2'], sendInvite: true }) } as any);
+    vi.mocked(pi.sendPasswordResetEmail).mockRejectedValueOnce(new Error('smtp down'));
+    const res = await createUserHandler({ request: adminReq({ firstName: 'X', lastName: 'Y', email: 'x@y.de', groupIds: ['g2'], sendInvite: true }) } as unknown as Parameters<typeof createUserHandler>[0]);
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.partial).toBe(true);

--- a/website/tests/api/portal-sign.test.ts
+++ b/website/tests/api/portal-sign.test.ts
@@ -13,7 +13,7 @@ vi.mock('../../src/lib/signing/audit', () => ({
   logSigningEvent: vi.fn().mockResolvedValue(undefined),
 }));
 
-import { getDocumentAssignmentById, getDocumentTemplate } from '../../src/lib/documents-db';
+import { getDocumentAssignmentById } from '../../src/lib/documents-db';
 
 describe('POST /api/portal/sign/[assignmentId] validation', () => {
   beforeEach(() => { vi.clearAllMocks(); });

--- a/website/tsconfig.json
+++ b/website/tsconfig.json
@@ -5,7 +5,7 @@
     "allowImportingTsExtensions": true,
     "resolveJsonModule": true,
     "noUnusedLocals": false,
-    "noUnusedParameters": false,
+    "noUnusedParameters": true,
     "paths": {
       "$lib/*": ["./src/lib/*"]
     }


### PR DESCRIPTION
## Summary
- PR #2296 silently dropped the `--max-warnings 0` gate that G-CQ03/T001204 shipped: `@typescript-eslint/no-explicit-any`/`no-unused-vars` were downgraded `error` → `warn`, and `tsconfig.json`'s `noUnusedLocals`/`noUnusedParameters` were set to `false`. The CI step still named "Run ESLint (--max-warnings 0 fail-closed gate)" had not enforced what its name claimed since that commit.
- Restores `--max-warnings 0` on `website/package.json`'s `lint`/`lint:fix` scripts and `error` severity on both ESLint rules.
- Fixes the 431 accumulated warnings (129 `no-unused-vars`, 184 `no-explicit-any`, 118 from re-enabling `noUnusedParameters`) — pure code-hygiene, no runtime behavior change. One ambiguous `any` (`src/lib/stripe.ts`, a removed-SDK stub) was resolved by reading its two actual consumers and typing only the call surface they use, rather than guessing.
- **Deviation from plan:** `noUnusedLocals` was *not* enabled (left `false`). Confirmed via isolated repro that Astro's `check` compiler has a false-positive bug: any identifier whose only usage is inside a frontmatter-level `return <expr>;` (the standard auth-redirect-guard pattern used in 76 files under `website/src/pages/`) is reported as a hard `error ts(6133)` even though it's genuinely read. Enabling it would have broken the separate "Astro TypeScript Check" CI job, which this plan's own proposal explicitly scopes out. `noUnusedParameters: true` alone doesn't trigger the bug and surfaced one real fixable case. Full writeup in `openspec/changes/website-strict-lint-gate-regression/tasks.md`.
- `tests/spec/ci-cd.bats` G-CQ03 cases go from RED to GREEN.

## Test plan
- [x] `tests/unit/lib/bats-core/bin/bats tests/spec/ci-cd.bats` — all 24 cases green, both G-CQ03 cases RED→GREEN
- [x] `cd website && pnpm lint` — exit 0, 0 problems
- [x] `cd website && npx astro check` — 0 errors, 0 warnings, 115 hints (known Astro false-positive, non-blocking)
- [x] `cd website && pnpm exec vitest run` — 1985 passed / 88 skipped (matches pre-change baseline exactly)
- [x] `task test:changed` — green
- [x] `task freshness:regenerate && task freshness:check` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U734TuVyCTbXqwzxS96sBE