### PR TITLE
fix(tickets): update ticket-links.sh kind validation to match DB schema [T001344]

### DIFF
--- a/docs/code-quality/loc-budget.json
+++ b/docs/code-quality/loc-budget.json
@@ -1,8 +1,8 @@
 {
-  "total_lines": 511077,
+  "total_lines": 511082,
   "file_count": 3924,
-  "commit": "4211a587",
-  "measured_at": "2026-06-30T23:53:57.678Z",
+  "commit": "98b9b8ef",
+  "measured_at": "2026-06-30T23:59:55.707Z",
   "thresholds": {
     "warn_pct": 5,
     "fail_pct": 15,

--- a/scripts/datamodel/2026-06-28-ticket-links-deps-kind.sql
+++ b/scripts/datamodel/2026-06-28-ticket-links-deps-kind.sql
@@ -1,4 +1,4 @@
--- Extend tickets.ticket_links kind CHECK constraint to allow 'blocks' and 'relates'.
+-- Extend tickets.ticket_links kind CHECK constraint to allow all 8 link types.
 -- Idempotent: DROP IF EXISTS + ADD is safe to re-run.
 -- Apply via: task db:migrate or kubectl exec on shared-db pod.
 
@@ -9,6 +9,6 @@ ALTER TABLE tickets.ticket_links
 
 ALTER TABLE tickets.ticket_links
   ADD CONSTRAINT ticket_links_kind_check
-    CHECK (kind IN ('pr', 'blocks', 'relates'));
+    CHECK (kind IN ('pr', 'relates_to', 'blocks', 'blocked_by', 'duplicate_of', 'fixes', 'fixed_by', 'child_of'));
 
 COMMIT;

--- a/scripts/lib/ticket-links.sh
+++ b/scripts/lib/ticket-links.sh
@@ -56,7 +56,7 @@ EOF
   echo "PR link #$pr recorded for ticket $id"
 }
 
-# cmd_link_tickets --from <ext_id> --to <ext_id> --kind blocks|relates
+# cmd_link_tickets --from <ext_id> --to <ext_id> --kind pr|relates_to|blocks|blocked_by|duplicate_of|fixes|fixed_by|child_of
 # Creates a directed dependency link between two tickets. Idempotent via ON CONFLICT DO NOTHING.
 # Offline-safe: TICKET_OFFLINE=1 skips the cluster write.
 cmd_link_tickets() {
@@ -72,10 +72,13 @@ cmd_link_tickets() {
     echo "ERROR: --from, --to, and --kind are required." >&2
     exit 2
   fi
-  if [[ "$kind" != "blocks" && "$kind" != "relates" ]]; then
-    echo "ERROR: --kind must be 'blocks' or 'relates' (got '$kind')." >&2
-    exit 2
-  fi
+  case "$kind" in
+    pr|relates_to|blocks|blocked_by|duplicate_of|fixes|fixed_by|child_of) ;;
+    *)
+      echo "ERROR: --kind must be one of: pr, relates_to, blocks, blocked_by, duplicate_of, fixes, fixed_by, child_of (got '$kind')." >&2
+      exit 2
+      ;;
+  esac
   if _ticket_offline_skip "link-tickets" "--from" "$from_ext" "--to" "$to_ext" "--kind" "$kind"; then return 0; fi
 
   local pod; pod=$(_pgpod)

--- a/scripts/ticket-mcp/go/internal/tools/links.go
+++ b/scripts/ticket-mcp/go/internal/tools/links.go
@@ -29,12 +29,12 @@ func RegisterLinkTools(s *server.MCPServer) {
 
 	s.AddTool(
 		mcp.NewTool("link_tickets",
-			mcp.WithDescription("Erstellt einen gerichteten Dependency-Link zwischen zwei Tickets (blocks oder relates). Idempotent — mehrfacher Aufruf mit gleichen Argumenten erzeugt keinen Duplikat-Eintrag. HINWEIS: CLI-Statusübergänge via ticket.sh update-status erscheinen nicht in der Timeline (bekannte Lücke)."),
+			mcp.WithDescription("Erstellt einen gerichteten Dependency-Link zwischen zwei Tickets (pr, relates_to, blocks, blocked_by, duplicate_of, fixes, fixed_by, child_of). Idempotent — mehrfacher Aufruf mit gleichen Argumenten erzeugt keinen Duplikat-Eintrag. HINWEIS: CLI-Statusübergänge via ticket.sh update-status erscheinen nicht in der Timeline (bekannte Lücke)."),
 			mcp.WithString("from", mcp.Description("external_id des Quell-Tickets, z.B. T000100"), mcp.Required()),
 			mcp.WithString("to", mcp.Description("external_id des Ziel-Tickets, z.B. T000200"), mcp.Required()),
 			mcp.WithString("kind",
-				mcp.Description("blocks: A verhindert B; relates: weiche bidirektionale Assoziation"),
-				mcp.Enum("blocks", "relates"),
+				mcp.Description("Art der Verknüpfung: pr, relates_to, blocks, blocked_by, duplicate_of, fixes, fixed_by, child_of"),
+				mcp.Enum("pr", "relates_to", "blocks", "blocked_by", "duplicate_of", "fixes", "fixed_by", "child_of"),
 				mcp.Required(),
 			),
 			mcp.WithString("brand", mcp.Description("mentolder oder korczewski (default: mentolder)")),
@@ -48,8 +48,10 @@ func RegisterLinkTools(s *server.MCPServer) {
 				return mcp.NewToolResultError("from and to are required"), nil
 			}
 			// Enum validation before shell call — matches ticket.sh validation.
-			if kind != "blocks" && kind != "relates" {
-				return mcp.NewToolResultError("kind must be 'blocks' or 'relates'"), nil
+			switch kind {
+			case "pr", "relates_to", "blocks", "blocked_by", "duplicate_of", "fixes", "fixed_by", "child_of":
+			default:
+				return mcp.NewToolResultError("kind must be one of: pr, relates_to, blocks, blocked_by, duplicate_of, fixes, fixed_by, child_of"), nil
 			}
 			return text(runner.RunTicket(
 				[]string{"link-tickets", "--from", from, "--to", to, "--kind", kind},


### PR DESCRIPTION
## Summary
- Updated `scripts/lib/ticket-links.sh` kind validation from `blocks|relates` to all 8 DB-supported kinds
- Updated `scripts/ticket-mcp/go/internal/tools/links.go` MCP enum and validation to match
- Updated `scripts/datamodel/2026-06-28-ticket-links-deps-kind.sql` CHECK constraint to include all 8 kinds

## Test Plan
- [ ] CI green

🤖 [T001344]