### PR TITLE
fix(quality): update plan-lint B1b fixture — unblocks auto-merge on script-change PRs [T001346]

### DIFF
--- a/tests/unit/fixtures/plan-lint/over-threshold.md
+++ b/tests/unit/fixtures/plan-lint/over-threshold.md
@@ -13,7 +13,7 @@ status: active
 
 | File | Ist | Budget |
 |------|-----|--------|
-| `website/src/components/inbox/InboxApp.svelte` | 1017 | 0 |
+| `k3d/talk-transcriber/app.py` | 648 | 0 |
 
 ## Task 1: Edit
 


### PR DESCRIPTION
The B1b fixture (over-threshold.md) referenced InboxApp.svelte with budget=0 but its computed residual was 5 (not ≤0), so B1b never fired. The linter treated the mismatch as B1a hard fail.

Switched to k3d/talk-transcriber/app.py (648 lines, effective threshold 648, residual 0) with matching budget=0. B1b now correctly warns with exit 0.

Unblocks PRs: #2338, #2340, #2341, #2342, #2343