### PR TITLE
fix(infra): drop invalid externalTrafficPolicy under ClusterIP for kube-system/traefik

### DIFF
--- a/docs/code-quality/loc-budget.json
+++ b/docs/code-quality/loc-budget.json
@@ -1,8 +1,8 @@
 {
-  "total_lines": 511046,
+  "total_lines": 511706,
   "file_count": 3924,
-  "commit": "642d1471",
-  "measured_at": "2026-06-30T23:38:38.239Z",
+  "commit": "d3c0eaee",
+  "measured_at": "2026-06-30T23:43:10.636Z",
   "thresholds": {
     "warn_pct": 5,
     "fail_pct": 15,

--- a/prod/cloud-init.yaml
+++ b/prod/cloud-init.yaml
@@ -174,9 +174,9 @@ runcmd:
   # Install Traefik via Helm
   - su - patrick -c "helm repo add traefik https://traefik.github.io/charts"
   - su - patrick -c "helm repo update"
-  # Values file (DaemonSet on the 3 public nodes, hostPort 80/443,
-  # externalTrafficPolicy: Local for real client IPs — see T001328) lives in
-  # the repo so it's testable and shared with the manual live-upgrade
+  # Values file (DaemonSet on the 3 public nodes, hostPort 80/443 + ClusterIP
+  # service type — no ServiceLB hop — for real client IPs, see T001341) lives
+  # in the repo so it's testable and shared with the manual live-upgrade
   # runbook; fetched the same way install-dev-tools.sh is above.
   # The Traefik chart creates an IngressClass named "traefik" by default;
   # we deliberately do NOT pass providers.kubernetesingress.ingressClass=traefik

--- a/prod/traefik-values.yaml
+++ b/prod/traefik-values.yaml
@@ -56,26 +56,22 @@ affinity:
                 - pk-hetzner-6
                 - pk-hetzner-8
 
-# T001328: preserves the real client IP all the way to backend services
-# (e.g. pocket-id's internal rate limiter / audit log). Without this,
-# kube-proxy SNATs traffic forwarded from the k3s ServiceLB (svclb-traefik)
-# hop to the Traefik Service ClusterIP under the default
-# externalTrafficPolicy=Cluster — every backend behind Traefik then sees a
-# cluster-internal pseudo-IP (the svclb pod's own IP) instead of the real
-# client, which broke pocket-id's per-IP rate limiting (network-wide 429s).
-# Traefik itself already forwards X-Forwarded-For correctly by default; the
-# value was simply wrong before it ever reached Traefik. Safe only because
-# the affinity above ensures Traefik runs on every node that can receive
-# inbound traffic — see rollout sequencing note in tasks.md.
 # T001341: removes k3s' ServiceLB (klipper-lb) for this Service entirely —
 # k3s' ServiceLB controller only manages Services of type: LoadBalancer.
 # Without this, klipper-lb's svclb-traefik DaemonSet keeps claiming
 # hostPort 80/443 on the same 3 nodes Traefik's own pods now also bind
 # directly (see ports.web/websecure.hostPort above), and the new Traefik
 # pods would stay Pending ("didn't have free ports for the requested pod
-# ports"). externalTrafficPolicy has no effect once type is ClusterIP —
-# left in place as a harmless no-op rather than removed in this PR.
+# ports"). Real client IP now reaches backends (e.g. pocket-id's rate
+# limiter) via the hostPort bind directly, with no ServiceLB hop to SNAT it.
+#
+# T001328's externalTrafficPolicy: Local is INTENTIONALLY NOT carried over
+# here — found live during the T001341 rollout that the Kubernetes API
+# hard-rejects it once type is ClusterIP ("spec.externalTrafficPolicy:
+# Invalid value: \"Local\": may only be set for externally-accessible
+# services"), it is not merely a silent no-op. The field only applies to
+# LoadBalancer/NodePort Services; ClusterIP has no SNAT hop left for it to
+# fix anyway, since Traefik's own pods now bind the host ports directly.
 service:
   spec:
     type: ClusterIP
-    externalTrafficPolicy: Local

--- a/prod/traefik-values.yaml
+++ b/prod/traefik-values.yaml
@@ -38,12 +38,11 @@ updateStrategy:
 
 # Restrict Traefik to the 3 public Hetzner nodes — these are the only nodes
 # DNS for *.${PROD_DOMAIN} ever resolves to (pk-hetzner-4/6/8). Running on
-# exactly these nodes keeps the DaemonSet's footprint aligned with where the
-# k3s ServiceLB (svclb-traefik) DaemonSet actually receives external
-# connections, which matters once externalTrafficPolicy is set to Local
-# below — kube-proxy drops Service traffic on any node lacking a local
-# backend pod, so topology MUST cover every node that can receive ingress
-# traffic before Local is safe to enable (see T001328 rollout task).
+# exactly these nodes keeps the DaemonSet's footprint aligned with where
+# ingress traffic actually arrives: since Traefik binds ports 80/443 via
+# hostPort directly (see ports.* below, T001341), the affinity MUST cover
+# every node that can receive inbound traffic, or DNS round-robin will hit
+# a node with no Traefik pod listening on those ports.
 affinity:
   nodeAffinity:
     requiredDuringSchedulingIgnoredDuringExecution:

--- a/tests/spec/fleet-operations.bats
+++ b/tests/spec/fleet-operations.bats
@@ -60,21 +60,26 @@ for s in schema.get('secrets', []):
   done
 }
 
-# ── T001328: Traefik externalTrafficPolicy=Local (real client IP) ─────────
+# ── T001328/T001341: Traefik client-IP preservation ────────────────────────
 # Manifest-structure assertions only — there is no live cluster in CI, so
-# the actual SNAT/X-Forwarded-For fix can only be verified against the live
-# fleet (see the manual rollout task in
-# openspec/changes/pocket-id-rate-limit/tasks.md). These guard the static
-# config that (a) the live `helm upgrade` rollout is based on and (b) future
+# the actual SNAT fix can only be verified against the live fleet (see the
+# manual rollout tasks in openspec/changes/pocket-id-rate-limit/tasks.md and
+# openspec/changes/traefik-hostport-clientip/tasks.md). These guard the
+# static config that (a) the live rollout is based on and (b) future
 # full-cluster-rebuilds (prod/cloud-init.yaml) will install by default.
 
-@test "prod/traefik-values.yaml sets externalTrafficPolicy: Local" {
+@test "prod/traefik-values.yaml does not set externalTrafficPolicy (invalid once type is ClusterIP)" {
   if ! command -v yq >/dev/null 2>&1; then
     skip "yq is not installed"
   fi
+  # T001328 originally set this to "Local"; T001341 found live that the
+  # Kubernetes API hard-rejects externalTrafficPolicy on a ClusterIP Service
+  # ("may only be set for externally-accessible services") — it is not a
+  # silent no-op as design.md assumed. Regression guard: this key must stay
+  # absent (null) as long as service.spec.type is ClusterIP below.
   run yq eval '.service.spec.externalTrafficPolicy' "${REPO_ROOT}/prod/traefik-values.yaml"
   [ "$status" -eq 0 ]
-  [ "$output" = "Local" ]
+  [ "$output" = "null" ]
 }
 
 @test "prod/traefik-values.yaml runs Traefik as a DaemonSet on exactly the 3 public Hetzner nodes" {
@@ -85,8 +90,8 @@ for s in schema.get('secrets', []):
   [ "$status" -eq 0 ]
   [ "$output" = "DaemonSet" ]
 
-  # Regression guard: externalTrafficPolicy=Local silently drops traffic on
-  # any node lacking a local Traefik pod. The node affinity MUST cover
+  # Regression guard: hostPort-based ingress only works on nodes that can
+  # actually receive inbound DNS traffic. The node affinity MUST cover
   # exactly the nodes DNS for *.${PROD_DOMAIN} resolves to.
   run yq eval '.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].values | sort | join(",")' "${REPO_ROOT}/prod/traefik-values.yaml"
   [ "$status" -eq 0 ]


### PR DESCRIPTION
## Summary

Closes T001341 follow-up. Discovered live during the T001341 production rollout (klipper-lb removal for `kube-system/traefik`): the Kubernetes API hard-rejects `externalTrafficPolicy: Local` once `service.spec.type` is `ClusterIP` ("may only be set for externally-accessible services") — `design.md`'s assumption that the field would be a harmless vestigial no-op was wrong, and the combined live patch failed outright (Helm release marked `failed`) until the field was removed.

- `prod/traefik-values.yaml`: removes `service.spec.externalTrafficPolicy: Local`, corrects the affinity-rationale comment and the T001328/T001341 history comment.
- `prod/cloud-init.yaml`: corrects a provisioning comment that still described the values file as setting `externalTrafficPolicy: Local`.
- `tests/spec/fleet-operations.bats`: updates the regression-guard test to assert the field is absent (`null`) rather than `"Local"`.

Live rollout (this same session) was already corrected and verified against the real fleet cluster: all 3 public IPs × both brands return HTTP 200, `klipper-lb` (svclb-traefik) is gone, and Pocket ID logs show real external client IPs for new requests. This PR brings the committed manifest back in line with what is now actually running.

## Test plan
- [x] `tests/unit/lib/bats-core/bin/bats tests/spec/fleet-operations.bats` — all pass except the pre-existing, documented, unrelated sealed-secrets drift (T001328)
- [x] `task test:changed`, `task freshness:regenerate`, `task freshness:check` — all green
- [x] Independent code review (pr-review-toolkit:code-reviewer) — approved after two stale-comment fixes
- [x] Verified live against the fleet cluster (manual, this session)