### PR TITLE
fix(website): suppress admin notification emails during E2E tests

### DIFF
--- a/docs/code-quality/loc-budget.json
+++ b/docs/code-quality/loc-budget.json
@@ -1,8 +1,8 @@
 {
-  "total_lines": 511082,
+  "total_lines": 511741,
   "file_count": 3924,
-  "commit": "98b9b8ef",
-  "measured_at": "2026-06-30T23:59:55.707Z",
+  "commit": "9a832a7d",
+  "measured_at": "2026-07-01T00:08:18.279Z",
   "thresholds": {
     "warn_pct": 5,
     "fail_pct": 15,

--- a/website/src/lib/notifications.test.ts
+++ b/website/src/lib/notifications.test.ts
@@ -50,6 +50,7 @@ describe('sendAdminNotification', () => {
     await sendAdminNotification({ type: 'contact', subject: 'New ticket', text: 'Hello' });
     expect(mockSend).toHaveBeenCalledWith(
       expect.objectContaining({ to: 'admin@example.com', subject: 'New ticket' }),
+      undefined,
     );
   });
 

--- a/website/src/lib/notifications.ts
+++ b/website/src/lib/notifications.ts
@@ -28,7 +28,7 @@ export async function sendAdminNotification(params: {
   text: string;
   html?: string;
   replyTo?: string;
-}): Promise<void> {
+}, request?: Request): Promise<void> {
   const brand = process.env.BRAND || 'mentolder';
 
   const [notifEmail, enabled, fromName, fromAddress] = await Promise.all([
@@ -46,6 +46,6 @@ export async function sendAdminNotification(params: {
   const from =
     fromName && fromAddress ? `"${fromName.replace(/"/g, "'")}" <${fromAddress}>` : undefined;
 
-  const ok = await sendEmail({ to, subject: params.subject, text: params.text, html: withInboxLink(params.html), replyTo: params.replyTo, from });
+  const ok = await sendEmail({ to, subject: params.subject, text: params.text, html: withInboxLink(params.html), replyTo: params.replyTo, from }, request);
   if (!ok) logger.warn({ type: params.type, to }, `[notifications] sendEmail failed for type="${params.type}"`);
 }

--- a/website/src/pages/api/admin/bookings/create.ts
+++ b/website/src/pages/api/admin/bookings/create.ts
@@ -109,7 +109,7 @@ export const POST: APIRoute = async ({ request , locals }) => {
       text: isCallback
         ? `Hallo ${clientName},\n\nIhr Termin wurde vom Admin eingetragen.\n\nWir melden uns in Kürze unter ${phone} bei Ihnen.\n\nMit freundlichen Grüßen\n${BRAND_NAME}`
         : `Hallo ${clientName},\n\nIhr Termin wurde vom Admin eingetragen.\n\nTyp:     ${typeLabel}\nDatum:   ${dateFormatted}\nUhrzeit: ${slotDisplay}\n\nMit freundlichen Grüßen\n${BRAND_NAME}`,
-    });
+    }, request);
 
     sendAdminNotification({
       type: 'booking',
@@ -118,7 +118,7 @@ export const POST: APIRoute = async ({ request , locals }) => {
         ? `Admin-Buchung/Rückruf eingetragen.\n\nKunde: ${clientName} (${clientEmail})\nTyp: Rückruf${phone ? `\nTelefon: ${phone}` : ''}${message ? `\n\nAnmerkungen:\n${message}` : ''}`
         : `Admin-Buchung eingetragen.\n\nKunde: ${clientName} (${clientEmail})\nTyp: ${typeLabel}\nDatum: ${dateFormatted}\nUhrzeit: ${slotDisplay}${leistungKey ? `\nLeistung: ${leistungKey}` : ''}${projectId ? `\nProjekt: ${projectId}` : ''}${message ? `\n\nAnmerkungen:\n${message}` : ''}`,
       replyTo: clientEmail,
-    }).catch(err => locals.requestLogger.error({ err }, '[admin/bookings/create] Failed to send admin notification:'));
+    }, request).catch(err => locals.requestLogger.error({ err }, '[admin/bookings/create] Failed to send admin notification:'));
 
     return new Response(JSON.stringify({ success: true }), { status: 200, headers: { 'Content-Type': 'application/json' } });
   } catch (err) {

--- a/website/src/pages/api/booking.ts
+++ b/website/src/pages/api/booking.ts
@@ -98,7 +98,7 @@ export const POST: APIRoute = async ({ request , locals }) => {
       text: adminText,
       html: `<p>${adminText.replace(/\n\n/g, '</p><p>').replace(/\n/g, '<br>')}</p>`,
       replyTo: email,
-    });
+    }, request);
 
     return new Response(
       JSON.stringify({ success: true }),

--- a/website/src/pages/api/contact.ts
+++ b/website/src/pages/api/contact.ts
@@ -57,7 +57,7 @@ export const POST: APIRoute = async ({ request , locals }) => {
       replyTo: email,
       text: `Neue Anfrage über das Kontaktformular auf ${BRAND_NAME}.\n\nName: ${name}\nE-Mail: ${email}${phoneInfo}\nTyp: ${typeLabel}\n\nNachricht:\n${message}`,
       html: `<p><strong>Neue Anfrage über das Kontaktformular auf ${BRAND_NAME}.</strong></p><p>Name: ${name}<br>E-Mail: <a href="mailto:${email}">${email}</a>${phone ? `<br>Telefon: ${phone}` : ''}<br>Typ: ${typeLabel}</p><p><strong>Nachricht:</strong><br>${message.replace(/\n/g, '<br>')}</p>`,
-    }).catch(err => locals.requestLogger.error({ err }, '[contact] Failed to send admin notification:'));
+    }, request).catch(err => locals.requestLogger.error({ err }, '[contact] Failed to send admin notification:'));
 
     return new Response(
       JSON.stringify({ success: true }),

--- a/website/src/pages/api/dsgvo-request.ts
+++ b/website/src/pages/api/dsgvo-request.ts
@@ -54,7 +54,7 @@ export const POST: APIRoute = async ({ request , locals }) => {
       subject: `[DSGVO] ${subject} von ${name}`,
       text: `${subject}\n\nName: ${name}\nE-Mail: ${email}\nEingegangen: ${new Date().toLocaleString('de-DE')}\nFrist: ${deadline}\n\nBitte bearbeiten Sie diese Anfrage innerhalb von 30 Tagen gemäß Art. ${articleNum} DSGVO.`,
       replyTo: email,
-    }).catch(err => locals.requestLogger.error({ err }, '[dsgvo-request] Failed to send admin notification:'));
+    }, request).catch(err => locals.requestLogger.error({ err }, '[dsgvo-request] Failed to send admin notification:'));
 
     return new Response(JSON.stringify({ success: true }), {
       status: 200, headers: { 'Content-Type': 'application/json' },

--- a/website/src/pages/api/register.ts
+++ b/website/src/pages/api/register.ts
@@ -44,7 +44,7 @@ export const POST: APIRoute = async ({ request , locals }) => {
       type: 'registration',
       subject: `[Neue Registrierung] ${fullName}`,
       text: `Neue Registrierungsanfrage eingegangen.\n\nName: ${fullName}\nE-Mail: ${email}\n\nZum Bearbeiten: /admin/inbox`,
-    }).catch(err => locals.requestLogger.error({ err }, '[register] Failed to send admin notification:'));
+    }, request).catch(err => locals.requestLogger.error({ err }, '[register] Failed to send admin notification:'));
 
     return new Response(
       JSON.stringify({ success: true }),


### PR DESCRIPTION
## Summary
- `sendAdminNotification()` didn't accept or forward the `Request` object, so `sendEmail()`'s E2E guard (`isE2ETestRequest`) never fired for admin notification emails
- Added optional `request` parameter to `sendAdminNotification()` → passes through to `sendEmail()` → silently skips sending when `X-E2E-Test: 1` header is present
- Updated all 5 callers across contact, DSGVO, registration, booking, and admin-created booking endpoints

## Test Plan
- [ ] `astro check` passes (0 errors, 0 warnings)
- [ ] E2E test suite runs without firing real admin notification emails