### PR TITLE
chore(goals): exclude .codebase-memory/ from G-GIT03 >1MB gate scope [T001348]

### DIFF
--- a/.claude/lib/goals.md
+++ b/.claude/lib/goals.md
@@ -42,16 +42,22 @@ git log --since="2026-06-24" --no-merges --numstat --pretty=tformat: \
 
 ---
 
-## G-GIT03 — Dateien > 1MB im Tree (kein LFS): 7 → ≤ 6 ⚠️
+## G-GIT03 — Dateien > 1MB im Tree (kein LFS): 6 → ≤ 6 ✅
 
-**Was:** 7 git-getrackte Dateien >1MB. Nach Gitignore von `search-index.json` (generiert) ist `.codebase-memory/graph.db.zst` (12.7MB, PR #2281 intentional, `merge=ours binary`) das neue Hauptproblem. Fix: graph.db.zst zu LFS migrieren oder `.codebase-memory/` aus Gate-Scope ausschließen.
+**Was:** `.codebase-memory/graph.db.zst` (16.7MB, PR #2281 intentional, `merge=ours binary`) ist per **Policy-Entscheidung (T001348)** aus dem Gate-Scope ausgeschlossen — Begründung siehe unten. Damit zählt das Gate nur noch die verbleibenden 6 Dateien >1MB (u. a. gerenderte `kube-prometheus-stack`-Manifeste, gebaute Docs-HTML). Vorheriger Rohwert (inkl. `.codebase-memory/`): 7.
 
 ```bash
-git ls-files -z | xargs -0 -I{} sh -c 'test -f "{}" && wc -c "{}"' 2>/dev/null \
+git ls-files -z | grep -zv '^\.codebase-memory/' | xargs -0 -I{} sh -c 'test -f "{}" && wc -c "{}"' 2>/dev/null \
   | awk '$1>1048576{c++} END{print c+0}'
 ```
 
-> **A · Baseline:** 7 (unverändert; search-index.json gitignored, graph.db.zst 12.7MB bleibt) · **Target:** ≤ 6 · **Aufwand:** LFS-Migration oder Gate-Anpassung · **Messzyklus:** wöchentlich · **Reproduzierbar:** ja · Ticket: T001348 (Nachfolger von T001275/T001320, die geschlossen wurden, ohne dass graph.db.zst migriert wurde)
+**Policy-Entscheidung (T001348):** LFS-Migration von `graph.db.zst` wurde **nicht** umgesetzt (Option verworfen, nicht nur aufgeschoben):
+- `.github/workflows/codebase-memory-regen.yml` schreibt und pusht die Datei direkt (`git add`/`git commit`/`git push`) ohne jegliche LFS-Awareness — eine Migration würde einen zusätzlichen `git lfs install`/`git lfs push`-Schritt im Workflow erfordern.
+- Lokal ist `git-lfs` auf der Entwicklungsumgebung aktuell nicht funktionsfähig ("git-lfs is broken") — Contributor-seitig bräuchte es Rollout/Doku, sonst checken sie nur Pointer-Dateien aus und der codebase-memory-mcp-Server bricht.
+- Zusätzlicher GitHub-LFS-Storage-Quota-Bedarf ohne erkennbaren Gegenwert für ein intern generiertes, `merge=ours`-Binärartefakt.
+- Zwei Vorgänger-Tickets (T001275, T001320) wurden bereits als `done` geschlossen, ohne die Migration durchzuführen — wiederholtes Aufschieben verbessert den Messwert nicht nachhaltig. Der Scope-Ausschluss macht das Ziel dauerhaft grün, statt das Problem ein drittes Mal zu vertagen.
+
+> **A · Baseline:** 6 (nach Scope-Ausschluss von `.codebase-memory/`, siehe Policy oben) · **Target:** ≤ 6 · **Aufwand:** erledigt (Gate-Anpassung) · **Messzyklus:** wöchentlich · **Reproduzierbar:** ja · Ticket: T001348 (Nachfolger von T001275/T001320; **gefixt** per Policy-Entscheidung, nicht per LFS-Migration)
 
 ---
 
@@ -197,7 +203,7 @@ Auf Target, nur halten. `bash scripts/health-goals-check.sh` prüft die ✅-repr
 | **G-DORA04** | MTTR | n/a ✓ | < 24h | `git log --since="8 weeks ago" --first-parent --format='%ct %s' main \| grep -iE 'revert\|hotfix'` |
 | **G-FE03** | Stray `console.log/debug/info` | 0 ✓ | 0 | `grep -rEn 'console\.(log\|debug\|info)' website/src --include='*.ts' --include='*.svelte' --include='*.astro' \| grep -v 'browser-logger.ts' \| grep -v '\.test\.ts' \| wc -l` |
 | **G-GIT02** | Non-conventional Commits | 0/30 ✓ | 0 | `git log --format=%s -30 origin/main \| grep -vcE '^(feat\|fix\|chore\|...)'` |
-| **G-GIT03** | Dateien >1MB im Tree | 7 ⚠️ | ≤ 6 | `git ls-files -z \| xargs -0 -I{} sh -c 'test -f "{}" && wc -c "{}"' \| awk '$1>1048576{c++} END{print c+0}'` |
+| **G-GIT03** | Dateien >1MB im Tree | 6 ✓ | ≤ 6 | `git ls-files -z \| grep -zv '^\.codebase-memory/' \| xargs -0 -I{} sh -c 'test -f "{}" && wc -c "{}"' \| awk '$1>1048576{c++} END{print c+0}'` (`.codebase-memory/` per Policy-Entscheidung T001348 ausgeschlossen) |
 
 ---
 
@@ -216,13 +222,13 @@ bash scripts/health-goals-check.sh --only=G-RH01,G-CQ02
 - **Wöchentlich:** G-RH01/03, G-TEST01/03, G-SIZE01/03/04, G-CI01, G-CD01, G-CQ02/05, G-IMG01, G-K8S03, G-SPEC03, G-GIT03
 - **Monatlich/Quartal:** G-DEP02, G-SEC03/04, G-DOC02, G-FE01/02
 
-**Aktuell A-Ziele (2026-07-01):** G-SIZE04, G-CD01, G-GIT03
+**Aktuell A-Ziele (2026-07-01):** G-SIZE04, G-CD01 (G-GIT03 per T001348 auf ≤ 6 gebracht und von Prio A nach Prio C gewechselt)
 
-**Sprint-Highlights 2026-07-01:** G-CI01 erreicht Target (85 %→95 %, 19/20 grün) und wechselt von Prio A nach Prio C. G-RH03 (OpenSpec-BATS-Abdeckung 50 %→82 %) und G-DEP02 (Major-Deps 9→2) erreichen ihr Target und wechseln von Prio B nach Prio C. G-CQ01 erstmals gemessen: 0 astro-check-Fehler. G-CQ02 (explizite `any`) fällt weiter von 154 auf 8. G-SEC05-Messfehler dokumentiert: das Skript filtert nur eine von zwei GitHub-Actions-Bot-Mail-Varianten heraus, wodurch 4 Bot-Commits fälschlich als unsigniert zählen — echter Wert 0/50, Skript-Fix noch offen.
+**Sprint-Highlights 2026-07-01:** G-CI01 erreicht Target (85 %→95 %, 19/20 grün) und wechselt von Prio A nach Prio C. G-RH03 (OpenSpec-BATS-Abdeckung 50 %→82 %) und G-DEP02 (Major-Deps 9→2) erreichen ihr Target und wechseln von Prio B nach Prio C. G-CQ01 erstmals gemessen: 0 astro-check-Fehler. G-CQ02 (explizite `any`) fällt weiter von 154 auf 8. G-GIT03 (Dateien >1MB) erreicht Target 7→6 per Policy-Ausschluss von `.codebase-memory/` (T001348) und wechselt von Prio A nach Prio C. G-SEC05-Messfehler dokumentiert: das Skript filtert nur eine von zwei GitHub-Actions-Bot-Mail-Varianten heraus, wodurch 4 Bot-Commits fälschlich als unsigniert zählen — echter Wert 0/50, Skript-Fix noch offen.
 
-**Baseline-Update 2026-07-01:** G-SIZE04 +324.494→+325.521 (weiterhin im Spike-Fenster, aber Top-Diffs sind wieder normale Feature-Arbeit); G-GIT03 unverändert bei 7 (graph.db.zst-LFS-Migration noch offen); G-CD01 unverändert bei 53 % (8/15); G-CQ02 154→8; G-CQ01 ?→0; G-RH03 50 %→82 %; G-DEP02 9→2 Major; G-CI01 85 %→95 %.
+**Baseline-Update 2026-07-01:** G-SIZE04 +324.494→+325.521 (weiterhin im Spike-Fenster, aber Top-Diffs sind wieder normale Feature-Arbeit); G-GIT03 7→6 (graph.db.zst per Policy-Entscheidung T001348 aus Gate-Scope ausgeschlossen, keine LFS-Migration); G-CD01 unverändert bei 53 % (8/15); G-CQ02 154→8; G-CQ01 ?→0; G-RH03 50 %→82 %; G-DEP02 9→2 Major; G-CI01 85 %→95 %.
 
-**Offene Tickets (2026-07-01):** Für G-SIZE04, G-GIT03 und G-CD01 wurden neue Tickets angelegt, da die jeweiligen Vorgänger-Tickets als `done` geschlossen wurden, ohne dass sich der zugrundeliegende Messwert nachhaltig verbessert hat.
+**Offene Tickets (2026-07-01):** Für G-SIZE04 und G-CD01 wurden neue Tickets angelegt, da die jeweiligen Vorgänger-Tickets als `done` geschlossen wurden, ohne dass sich der zugrundeliegende Messwert nachhaltig verbessert hat. G-GIT03 (T001348) wurde per Policy-Entscheidung (Scope-Ausschluss `.codebase-memory/`) tatsächlich gefixt, statt erneut nur das Ticket zu schließen.
 
 | Ziel | Ticket | Status |
 |------|--------|--------|
@@ -230,7 +236,7 @@ bash scripts/health-goals-check.sh --only=G-RH01,G-CQ02
 | G-SIZE04 | T001347 | offen |
 | G-GIT03 | T001275 | **gefixt** (gitignore search-index.json [T001305]) |
 | G-GIT03 | T001320 | geschlossen (`done`), graph.db.zst nicht migriert → Nachfolger T001348 |
-| G-GIT03 | T001348 | offen |
+| G-GIT03 | T001348 | **gefixt** (Policy-Ausschluss `.codebase-memory/` aus Gate-Scope, keine LFS-Migration) |
 | G-CD01 | T001276 | geschlossen (`done`), Erfolgsrate unverändert → Nachfolger T001349 |
 | G-CD01 | T001349 | offen |
 | G-CQ01 | T001277 | **gefixt** (PR #2225) |

--- a/docs/code-quality/loc-budget.json
+++ b/docs/code-quality/loc-budget.json
@@ -1,8 +1,8 @@
 {
-  "total_lines": 511090,
+  "total_lines": 511756,
   "file_count": 3924,
-  "commit": "a6c9f165",
-  "measured_at": "2026-07-01T00:29:56.826Z",
+  "commit": "627df766",
+  "measured_at": "2026-07-01T00:39:01.253Z",
   "thresholds": {
     "warn_pct": 5,
     "fail_pct": 15,

--- a/scripts/health-goals-check.sh
+++ b/scripts/health-goals-check.sh
@@ -102,7 +102,14 @@ row target G-CQ10 "$(n_baseline_gate S4)" le 4  "S4 verwaiste Scripts/Manifeste"
 row target G-CQ02 "$(grep -rn ': any\|<any>\|as any' website/src --include='*.ts' --include='*.svelte' --include='*.astro' 2>/dev/null | wc -l | tr -d ' ')" le 280 "explizite any-Verwendungen"
 row target G-FE03 "$(grep -rEn 'console\.(error|warn)' website/src --include='*.ts' --include='*.svelte' --include='*.astro' 2>/dev/null | grep -v 'browser-logger\.ts' | wc -l | tr -d ' ')" le 0 "rohe console.error/warn Aufrufe (exkl. browser-logger-Stub)"
 row target G-SIZE03 "$( [ -f website/src/lib/website-db.ts ] && wc -l < website/src/lib/website-db.ts | tr -d ' ' || echo - )" le 3000 "God-File website-db.ts (Zeilen)"
-row target G-GIT03 "$(git ls-files -z 2>/dev/null | xargs -0 -I{} sh -c 'test -f "{}" && wc -c "{}"' 2>/dev/null | awk '$1>1048576{c++} END{print c+0}')" le 6 "Dateien >1MB (kein LFS)"
+# .codebase-memory/ ist bewusst aus dem Scope ausgeschlossen (Policy-Entscheidung T001348):
+# graph.db.zst ist ein generiertes, `merge=ours` Binärartefakt (PR #2281), das von
+# .github/workflows/codebase-memory-regen.yml direkt geschrieben/gepusht wird — ohne LFS-Bewusstsein.
+# Eine LFS-Migration würde `git lfs install` im Regen-Workflow sowie lokal bei allen Contributoren
+# voraussetzen (hier lokal aktuell nicht funktionsfähig: "git-lfs is broken"), zusätzlich GitHub-LFS-
+# Storage-Quota. Zwei Vorgänger-Tickets (T001275, T001320) wurden geschlossen, ohne die Migration
+# tatsächlich durchzuführen — der Aufwand/Nutzen rechtfertigt sie für dieses Artefakt nicht.
+row target G-GIT03 "$(git ls-files -z 2>/dev/null | grep -zv '^\.codebase-memory/' | xargs -0 -I{} sh -c 'test -f "{}" && wc -c "{}"' 2>/dev/null | awk '$1>1048576{c++} END{print c+0}')" le 6 "Dateien >1MB (kein LFS, exkl. .codebase-memory/ — T001348)"
 row target G-IMG01 "$(grep -rhE '^[[:space:]]*-?[[:space:]]*image:[[:space:]]+["'"'"']?[A-Za-z0-9$]' --include='*.yaml' --include='*.yml' k3d/ prod*/ 2>/dev/null | grep -v '@sha256' | grep -vE '^[[:space:]]*#' | grep -vE 'website|brett|videovault|mediaviewer-widget|mentolder-web|WEBSITE_IMAGE|STUDIO_IMAGE|STAGING_IMAGE|paddione' | sed -E 's/.*image:[[:space:]]*//; s/["'"'"']//g; s/[[:space:]]*#.*//' | sort -u | wc -l | tr -d ' ')" le 0 "ungepinnte Fremd-Images"
 row target G-DOC02 "$(wc -l < CLAUDE.md | tr -d ' ')" le 200 "CLAUDE.md Zeilen"
 row target G-DOC03 "$(c=0; for d in website brett scripts tests k3d; do ls "$d"/README* >/dev/null 2>&1 && c=$((c+1)); done; echo $c)" ge 5 "README-Index Hauptverzeichnisse"


### PR DESCRIPTION
## Summary
- G-GIT03 (Dateien >1MB im Git-Tree) blieb bei 7/≤6 rot, obwohl zwei Vorgänger-Tickets (T001275, T001320) als `done` geschlossen wurden — Hauptverursacher ist `.codebase-memory/graph.db.zst` (16.7MB, PR #2281 intentional, `merge=ours binary`).
- Policy-Entscheidung: LFS-Migration **nicht** umgesetzt (`codebase-memory-regen.yml` schreibt/pusht die Datei ohne LFS-Awareness, lokales `git-lfs` ist aktuell "broken", zusätzlicher GitHub-LFS-Storage-Bedarf ohne Gegenwert). Stattdessen wird `.codebase-memory/` explizit aus dem G-GIT03-Gate-Scope ausgeschlossen — dokumentiert in `.claude/lib/goals.md`.
- `scripts/health-goals-check.sh` filtert `.codebase-memory/` jetzt aus der Messung; Messwert ist damit nachhaltig 6/≤6 grün statt nur das Ticket erneut ohne Wirkung zu schließen.

## Test plan
- [x] `bash scripts/health-goals-check.sh --only=G-GIT03` → ✅ 6 (Ziel ≤6)
- [x] `task test:changed` grün (52/52 Tests, LOC-Budget PASS)
- [x] `task freshness:regenerate` + `task freshness:check` grün (loc-budget.json committed)
- [x] `bash scripts/preflight-pr-scope.sh` grün (scope: goals)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012xExbiq1UxErHPismACvYH