### PR TITLE
chore(infra): add mentolder-web to :latest image-pin exemption list [T001365]

### DIFF
--- a/docs/code-quality/loc-budget.json
+++ b/docs/code-quality/loc-budget.json
@@ -1,8 +1,8 @@
 {
-  "total_lines": 522458,
+  "total_lines": 523117,
   "file_count": 3958,
-  "commit": "1c483baf",
-  "measured_at": "2026-07-01T05:56:04.215Z",
+  "commit": "128a4228",
+  "measured_at": "2026-07-01T06:07:41.315Z",
   "thresholds": {
     "warn_pct": 5,
     "fail_pct": 15,

--- a/openspec/specs/workspace-deploy.md
+++ b/openspec/specs/workspace-deploy.md
@@ -382,7 +382,7 @@ ConfigMap, a `nextcloud-oidc-config` ConfigMap, and Pod Security Standards label
 The system SHALL ensure that no core service container image uses the `:latest` tag, that
 all images carry either an explicit version tag or a digest, and that MCP sidecar images,
 internal build images (`paddione/bachelorprojekt`, `workspace-brett`, `docs`, `videovault`,
-`mediaviewer-widget`) are exempt from the `:latest` prohibition.
+`mediaviewer-widget`, `mentolder-web`) are exempt from the `:latest` prohibition.
 
 #### Scenario: Core-Images ohne :latest
 
@@ -393,8 +393,10 @@ internal build images (`paddione/bachelorprojekt`, `workspace-brett`, `docs`, `v
 
 #### Scenario: :latest bei internen Build-Images erlaubt
 
-- **GIVEN** `k3d/website.yaml`, `k3d/brett.yaml`, `k3d/docs.yaml` u.a. nutzen `:latest`
-  für intern gebaute Images (`paddione/bachelorprojekt*`, `workspace-brett`, `docs`, etc.)
+- **GIVEN** `k3d/website.yaml`, `k3d/brett.yaml`, `k3d/docs.yaml`, `k3d/videovault.yaml`,
+  `k3d/mediaviewer-widget.yaml`, `k3d/mentolder-web.yaml` u.a. nutzen `:latest`
+  für intern gebaute Images (`paddione/bachelorprojekt*`, `workspace-brett`, `docs`,
+  `videovault`, `mediaviewer-widget`, `mentolder-web`, etc.)
 - **WHEN** der Image-Pinning-Check ausgeführt wird
 - **THEN** werden diese Images von der `:latest`-Prüfung ausgenommen
 - **AND** der Check schlägt nur fehl, wenn ein Drittanbieter-Core-Image `:latest` trägt

--- a/tests/unit/manifests.bats
+++ b/tests/unit/manifests.bats
@@ -153,7 +153,7 @@ all_images() {
 @test "no core service images use :latest tag" {
   # MCP sidecar images may use :latest (upstream-controlled); skip those
   local latest_images
-  latest_images=$(all_images | grep ':latest$' | grep -ivE '(mcp|openapi-mcp|github-mcp|keycloak-mcp|nextcloud-mcp|curlimages/curl|talk-transcriber|paddione/bachelorprojekt|workspace-brett|docs|videovault|mediaviewer-widget)' || true)
+  latest_images=$(all_images | grep ':latest$' | grep -ivE '(mcp|openapi-mcp|github-mcp|keycloak-mcp|nextcloud-mcp|curlimages/curl|talk-transcriber|paddione/bachelorprojekt|workspace-brett|docs|videovault|mediaviewer-widget|mentolder-web)' || true)
   if [[ -n "$latest_images" ]]; then
     echo "Core images using :latest: ${latest_images}"
     return 1


### PR DESCRIPTION
## Summary
- A maintenance health check flagged `k3d/mentolder-web.yaml`, `k3d/videovault.yaml`, and `k3d/mediaviewer-widget.yaml` as using `:latest` without being on the explicit exemption list.
- Verified: all three have `imagePullPolicy: Always` and dedicated build workflows (`build-mentolder-web.yml`, `build-videovault.yml`, `build-mediaviewer-widget.yml`), same pattern as the already-exempt `website`, `brett`, `docs` images — `:latest` is intentional here.
- Found `videovault` and `mediaviewer-widget` were already covered in `tests/unit/manifests.bats` and `openspec/specs/workspace-deploy.md`; `mentolder-web` was the actual gap in both. Closed it.
- `scripts/health-goals-check.sh` and `docs/superpowers/references/gotchas-footguns.md` already listed all three — no changes needed there.

## Test plan
- [x] `bats tests/unit/manifests.bats` — all 35 tests pass, including "no core service images use :latest tag"
- [x] `task openspec:validate` — passes
- [x] `task workspace:validate` — manifests valid
- [x] `task freshness:regenerate && task freshness:check` — clean, no stale artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FCsDX51JQAdQcx8GeKFpzg