### PR TITLE
fix(dev-flow): add explicit worktree check to dev-flow-execute [T001363]

### DIFF
--- a/.claude/skills/dev-flow-execute/SKILL.md
+++ b/.claude/skills/dev-flow-execute/SKILL.md
@@ -95,6 +95,25 @@ if [[ "$CURRENT_BRANCH" != "$EXPECTED_BRANCH" ]]; then
 fi
 ```
 
+`dev-flow-execute` erwartet normalerweise, dass `dev-flow-plan` bereits einen isolierten Worktree unter
+`tmp/wt-*` übergeben hat. Das wird hier nie explizit geprüft — läuft die Execute-Phase versehentlich im
+Haupt-Checkout (z.B. nach einem Session-Neustart), schreibt der Implementer-Subagent direkt ins
+Haupt-Repo statt in eine isolierte Kopie [T001363]:
+
+```bash
+# Worktree-Isolation-Check [T001363]
+# Wir sind entweder schon in einem tmp/wt-*-Worktree ODER müssen einen anlegen.
+if [[ "$PWD" != *"/tmp/wt-"* ]]; then
+  echo "⚠️  Kein isolierter Worktree unter tmp/wt-* erkannt (PWD=$PWD)."
+  SLUG=$(echo "$EXPECTED_BRANCH" | sed 's#^[a-z]*/##')
+  WORKTREE_PATH="tmp/wt-${SLUG}"
+  echo "→ Lege isolierten Worktree an: scripts/worktree-create.sh $EXPECTED_BRANCH $WORKTREE_PATH"
+  bash scripts/worktree-create.sh "$EXPECTED_BRANCH" "$WORKTREE_PATH"
+  echo "✅ Worktree bereit unter $WORKTREE_PATH — dorthin wechseln, bevor mit Schritt 1 fortgefahren wird."
+  exit 1
+fi
+```
+
 ---
 
 ## Schritt 0.5: Sync mit main & Rebase

--- a/docs/code-quality/loc-budget.json
+++ b/docs/code-quality/loc-budget.json
@@ -1,8 +1,8 @@
 {
-  "total_lines": 522458,
+  "total_lines": 523117,
   "file_count": 3958,
-  "commit": "d8a1f301",
-  "measured_at": "2026-07-01T06:13:11.108Z",
+  "commit": "ae0f76c5",
+  "measured_at": "2026-07-01T06:22:00.698Z",
   "thresholds": {
     "warn_pct": 5,
     "fail_pct": 15,

--- a/docs/code-quality/loc-budget.json
+++ b/docs/code-quality/loc-budget.json
@@ -1,8 +1,8 @@
 {
-  "total_lines": 523117,
-  "file_count": 3958,
-  "commit": "ae0f76c5",
-  "measured_at": "2026-07-01T06:22:00.698Z",
+  "total_lines": 523150,
+  "file_count": 3959,
+  "commit": "891e1645",
+  "measured_at": "2026-07-01T06:37:12.608Z",
   "thresholds": {
     "warn_pct": 5,
     "fail_pct": 15,

--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 519,
+      "file_count": 520,
       "files": [
         "tests/.gitignore",
         "tests/README.md",
@@ -386,6 +386,7 @@
         "tests/spec/t001269-mishap-bundle-skills-dev-flow-execute-repo-worktree-state-ticket-mcp.bats",
         "tests/spec/t001353-mishap-bundle-ci-tickets.bats",
         "tests/spec/t001356-git02-conventional-commit.bats",
+        "tests/spec/t001363-mishap-bundle.bats",
         "tests/spec/test_helper.bash",
         "tests/spec/ticket-mcp.bats",
         "tests/spec/ts-suppression.bats",

--- a/openspec/changes/t001363-mishap-bundle/proposal.md
+++ b/openspec/changes/t001363-mishap-bundle/proposal.md
@@ -1,0 +1,34 @@
+# Proposal: t001363-mishap-bundle
+
+## Why
+
+Mishap-Bundle mit 3 gemeldeten Einträgen (git-worktree, `dev-flow-execute`, git-crypt). Audit vor der
+Implementierung ergab:
+
+1. **git-worktree**: `scripts/agent-lock.sh reap` prunt bereits verwaiste `git worktree`-Admin-Einträge
+   und killt Orphan-Prozesse toter Worktrees (siehe `reap()` in `scripts/agent-lock.sh`). **Kein Gap.**
+2. **`dev-flow-execute`**: Das Skill (`.claude/skills/dev-flow-execute/SKILL.md`) geht ab Schritt 0 davon
+   aus, dass ein Worktree bereits existiert (von `dev-flow-plan` übergeben), prüft das aber nie explizit
+   und ruft `scripts/worktree-create.sh` an keiner Stelle auf. Läuft die Execute-Phase versehentlich im
+   Haupt-Checkout statt im Worktree (z.B. nach einem Session-Neustart), schreibt der Implementer-Subagent
+   direkt ins Haupt-Repo. **Echter Gap.**
+3. **git-crypt**: `scripts/git-crypt-guard.sh check-tracked` läuft aktuell grün (exit 0) — keine
+   Klartext-Secrets in verwalteten Pfaden. **Kein Gap**, aber es fehlt ein Regressions-Test, der das
+   dauerhaft absichert.
+
+## What
+
+1. `dev-flow-execute` SKILL.md Schritt 0 erweitern: explizite Prüfung, ob `$PWD` unter einem
+   `tmp/wt-*`-Worktree-Pfad liegt; falls nicht, `scripts/worktree-create.sh <branch> tmp/wt-<slug>`
+   aufrufen, bevor implementiert wird.
+2. Regressions-Guard-Tests für alle 3 Einträge in `tests/spec/t001363-mishap-bundle.bats` (Pattern:
+   `tests/spec/mishap-bundle-2026-06-30.bats`) — grep-basierte Assertions, die den aktuellen (bereits
+   guten) Zustand von Punkt 1 und 3 dauerhaft absichern, plus Test für den neuen Worktree-Check in
+   Punkt 2.
+
+## Non-Goals
+
+- Keine git-crypt → SealedSecrets Migration (das ist ein eigenständiges, großes Vorhaben — außerhalb des
+  2h-Task-Scopes einer Mishap-Bundle-Fix-PR).
+
+_Ticket: T001363_

--- a/openspec/changes/t001363-mishap-bundle/specs/t001363-mishap-bundle.md
+++ b/openspec/changes/t001363-mishap-bundle/specs/t001363-mishap-bundle.md
@@ -1,0 +1,19 @@
+## ADDED Requirements
+
+### Requirement: dev-flow-execute verifies worktree isolation before implementing
+
+The `dev-flow-execute` skill SHALL verify that the current working directory is a git worktree
+(created via `scripts/worktree-create.sh`) before delegating implementation to a subagent. If the
+current working directory is not a worktree, the skill SHALL create one before proceeding.
+
+#### Scenario: Execute skill invoked from the main checkout
+
+- **GIVEN** a session runs `dev-flow-execute` for a staged plan
+- **WHEN** the current working directory is the main repo checkout, not a `tmp/wt-*` worktree
+- **THEN** the skill invokes `scripts/worktree-create.sh <branch> tmp/wt-<slug>` before Schritt 2 (Implementierung)
+
+#### Scenario: Execute skill invoked from an existing worktree
+
+- **GIVEN** a session runs `dev-flow-execute` for a staged plan
+- **WHEN** the current working directory is already a `tmp/wt-*` worktree for the target branch
+- **THEN** the skill proceeds directly to Schritt 2 without creating a duplicate worktree

--- a/openspec/changes/t001363-mishap-bundle/tasks.md
+++ b/openspec/changes/t001363-mishap-bundle/tasks.md
@@ -1,0 +1,45 @@
+---
+title: "t001363-mishap-bundle — Implementation Plan"
+ticket_id: T001363
+domains: [skills, documentation]
+status: plan_staged
+file_locks: []
+shared_changes: false
+batch_id: null
+parent_feature: null
+depends_on_plans: []
+---
+
+# t001363-mishap-bundle — Implementation Plan
+
+_Ticket: T001363_
+
+## File Structure
+
+The following files will be created or modified:
+- `.claude/skills/dev-flow-execute/SKILL.md` (modified: Schritt 0 — expliziter Worktree-Check + Aufruf von `scripts/worktree-create.sh` falls nicht in einem Worktree)
+- `tests/spec/t001363-mishap-bundle.bats` (created: Regressions-Guard für alle 3 Mishap-Einträge)
+
+## Verify (RED → GREEN)
+
+- [ ] **Failing-Test-Step (RED).** Run the newly created BATS test suite to confirm the worktree-check test fails on the current SKILL.md.
+
+```bash
+tests/unit/lib/bats-core/bin/bats tests/spec/t001363-mishap-bundle.bats
+# expected: worktree-check test FAILS (red); git-worktree-reap and git-crypt-guard tests PASS (already fixed)
+```
+
+- [ ] **Fix-Step (GREEN).** Add the explicit worktree-existence check + `scripts/worktree-create.sh` call to `.claude/skills/dev-flow-execute/SKILL.md` Schritt 0. All tests in the suite must now pass.
+
+```bash
+tests/unit/lib/bats-core/bin/bats tests/spec/t001363-mishap-bundle.bats
+# expected: PASS
+```
+
+- [ ] **Final Verification.** Run the mandatory CI gates:
+
+```bash
+task test:changed
+task freshness:regenerate
+task freshness:check
+```

--- a/tests/spec/t001363-mishap-bundle.bats
+++ b/tests/spec/t001363-mishap-bundle.bats
@@ -1,0 +1,33 @@
+#!/usr/bin/env bats
+# tests/spec/t001363-mishap-bundle.bats
+# T001363 — Mishap-Bundle: git-worktree reap, dev-flow-execute worktree-check, git-crypt-guard
+
+load 'test_helper'
+
+setup() {
+  REPO="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+}
+
+# ── Mishap 1: git-worktree — already fixed (regression guard) ─────────────
+
+@test "T001363: agent-lock.sh reap() prunes orphaned git worktree admin entries" {
+  [ -f "$REPO/scripts/agent-lock.sh" ]
+  run grep -F 'git worktree prune' "$REPO/scripts/agent-lock.sh"
+  [ "$status" -eq 0 ]
+}
+
+# ── Mishap 2: dev-flow-execute — THE FIX ───────────────────────────────────
+
+@test "T001363: dev-flow-execute SKILL.md Schritt 0 creates a worktree via worktree-create.sh when not already isolated" {
+  [ -f "$REPO/.claude/skills/dev-flow-execute/SKILL.md" ]
+  run grep -F 'worktree-create.sh' "$REPO/.claude/skills/dev-flow-execute/SKILL.md"
+  [ "$status" -eq 0 ]
+}
+
+# ── Mishap 3: git-crypt — already fixed (regression guard) ────────────────
+
+@test "T001363: git-crypt-guard.sh has a check-tracked function/case" {
+  [ -f "$REPO/scripts/git-crypt-guard.sh" ]
+  run grep -F 'check-tracked' "$REPO/scripts/git-crypt-guard.sh"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary
- Audit of the T001363 mishap-bundle (3 entries) found 2 of 3 already fixed (worktree reap, git-crypt-guard). Only dev-flow-execute lacked an explicit worktree-existence check.
- Adds a check to dev-flow-execute Schritt 0 that creates a worktree via scripts/worktree-create.sh if the current context isn't already one.
- Adds tests/spec/t001363-mishap-bundle.bats as a regression guard for all 3 mishap entries.

Closes T001363

🤖 Generated with Claude Code