### PR TITLE
chore(goals): add script to auto-update goals.md baselines [T001368]

### DIFF
--- a/.claude/lib/README.md
+++ b/.claude/lib/README.md
@@ -31,7 +31,7 @@ Quantifizierbare Repository-Health-Ziele — je mit Mess-Befehl, real gemessenem
 
 | Datei | Zweck | Referenziert von |
 |---|---|---|
-| [`goals.md`](goals.md) | 65 Health-Ziele in 11 Kategorien (Tests, Deps, Supply-Chain, Secrets, K8s, CI/CD, DORA, Docs, Frontend). Die Gate-IDs `G-RH01`–`G-RH07` sind stabile Anker (referenziert in `docs/code-quality/gates.yaml`, Plänen, OpenSpec) — nie umnummerieren. | [`scripts/health-goals-check.sh`](../../scripts/health-goals-check.sh) (Ampel-Report) |
+| [`goals.md`](goals.md) | 65 Health-Ziele in 11 Kategorien (Tests, Deps, Supply-Chain, Secrets, K8s, CI/CD, DORA, Docs, Frontend). Die Gate-IDs `G-RH01`–`G-RH07` sind stabile Anker (referenziert in `docs/code-quality/gates.yaml`, Plänen, OpenSpec) — nie umnummerieren. | [`scripts/health-goals-check.sh`](../../scripts/health-goals-check.sh) (Ampel-Report), [`scripts/health-goals-update.sh`](../../scripts/health-goals-update.sh) (schreibt frische Werte in die Prio-C-Tabelle; `task health:goals:update`) |
 
 ## Wachstumsprinzip
 

--- a/.claude/lib/goals.md
+++ b/.claude/lib/goals.md
@@ -154,7 +154,7 @@ Auf Target, nur halten. `bash scripts/health-goals-check.sh` prüft die ✅-repr
 
 | ID | Ziel | Aktuell | Target | Basis-Messung |
 |----|------|---------|--------|---------------|
-| **G-RH01** | Gate-Violations (baseline.json) | 28 ✓ | ≤ 30 | `python3 -c "import json,sys; print(len(json.load(sys.stdin)))" < docs/code-quality/baseline.json` |
+| **G-RH01** | Gate-Violations (baseline.json) | 26 ✓ | ≤ 30 | `python3 -c "import json,sys; print(len(json.load(sys.stdin)))" < docs/code-quality/baseline.json` |
 | **G-RH02** | TypeScript-Suppressionen | 0 ✓ | 0 | `grep -r '@ts-ignore\|@ts-expect-error' website/src --include='*.ts' \| grep -v goals-data.ts \| wc -l` |
 | **G-RH04** | Stale Remote Branches | 0 ✓ | 0 | `git for-each-ref ... refs/remotes/origin \| while IFS='|' read b ts; do [[ $ts -lt $CUTOFF ]] && echo $b; done \| wc -l` |
 | **G-RH05** | Plan-Staged idle >14d | 0 ✓ | 0 | `bash scripts/vda.sh oracle 'list plan_staged tickets'` |
@@ -164,7 +164,7 @@ Auf Target, nur halten. `bash scripts/health-goals-check.sh` prüft die ✅-repr
 | **G-TEST02** | Vitest `.only` | 0 ✓ | 0 | `grep -rnE '\.only\b' website/src --include='*.test.ts' \| wc -l` |
 | **G-TEST03** | Vitest Skipped/Todo-Suiten | 0 ✓ | 0 | `grep -rnE "(describe\|it\|test)\.(skip\|todo)\b" website/src --include="*.ts" \| wc -l` |
 | **G-TEST04** | Test-Inventory-Drift | 0 ✓ | 0 | `git status --porcelain website/src/data/test-inventory.json \| wc -l` |
-| **G-CQ02** | Explizite `any`-Verwendungen | 8 ✓ | ≤ 280 | `grep -rn ': any\|<any>\|as any' website/src --include=*.ts --include=*.svelte --include=*.astro \| wc -l` |
+| **G-CQ02** | Explizite `any`-Verwendungen | 11 ✓ | ≤ 280 | `grep -rn ': any\|<any>\|as any' website/src --include=*.ts --include=*.svelte --include=*.astro \| wc -l` |
 | **G-CQ04** | FIXME/HACK/XXX (echt) | 3 ✓ | ≤4 | `grep -rnE '\b(FIXME\|HACK\|XXX)\b' ... \| wc -l` |
 | **G-CQ05** | Echte TODO-Marker | 1 ✓ | ≤ 1 | `grep -rnE "\bTODO\b" --include=*.ts ... website/src scripts tests k3d brett/src \| wc -l` |
 | **G-CQ06** | `@deprecated`-Symbole | 1 ✓ | ≤ 1 | `grep -rnE '@deprecated' website/src \| wc -l` |
@@ -172,7 +172,7 @@ Auf Target, nur halten. `bash scripts/health-goals-check.sh` prüft die ✅-repr
 | **G-CQ09** | S3 hartkodierte Hostnames | 0 ✓ | ≤ 10 | `python3 -c "..S3-Gate.." < docs/code-quality/baseline.json` |
 | **G-CQ10** | S4 verwaiste Scripts | 0 ✓ | ≤ 4 | `python3 -c "..S4-Gate.." < docs/code-quality/baseline.json` |
 | **G-SIZE01** | Freeze-Frühwarn-Band (80–100 % S1) | 0 ✓ | ≤ 15 | `python3 -c "import json; d=json.load(open('docs/code-quality/loc-budget.json')); print(sum(1 for v in d.values() if isinstance(v,dict) and v.get('pct_used',0)>=80))"` |
-| **G-SIZE03** | God-File `website/src/lib/website-db.ts` | 2890 ✓ | ≤ 3000 | `wc -l < website/src/lib/website-db.ts` |
+| **G-SIZE03** | God-File `website/src/lib/website-db.ts` | 2106 ✓ | ≤ 3000 | `wc -l < website/src/lib/website-db.ts` |
 | **G-GIT01** | Offene PRs >7 Tage | 0 ✓ | 0 | `gh pr list --state open --json number,createdAt` |
 | **G-DEP01** | High/Critical npm-Vulnerabilities | 0 ✓ | 0 | `cd website && pnpm audit --json 2>/dev/null \| python3 -c "..."` |
 | **G-DEP03** | PM-Konsistenz (pnpm) | 0 ✓ | 1 PM | `grep -q "npm ci" website/Dockerfile && echo inkonsistent \|\| echo ok` |

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -3004,6 +3004,11 @@ tasks:
     cmds:
       - bash scripts/health-goals-check.sh {{.CLI_ARGS}}
 
+  health:goals:update:
+    desc: "Schreibt frisch gemessene Werte in die Aktuell-Spalte der Prio-C-Tabelle (Green Gates) in .claude/lib/goals.md. Freitextige Prio-A/B-Abschnitte bleiben unangetastet. Flags nach --, z.B. task health:goals:update -- --dry-run"
+    cmds:
+      - bash scripts/health-goals-update.sh {{.CLI_ARGS}}
+
   quality:baseline:freeze:
     desc: "One-time: freeze the current code-quality violations into docs/code-quality/baseline.json"
     cmds:

--- a/docs/code-quality/loc-budget.json
+++ b/docs/code-quality/loc-budget.json
@@ -1,8 +1,8 @@
 {
-  "total_lines": 522478,
+  "total_lines": 523143,
   "file_count": 3959,
-  "commit": "a718b45a",
-  "measured_at": "2026-07-01T07:14:11.981Z",
+  "commit": "672f32b0",
+  "measured_at": "2026-07-01T07:36:10.694Z",
   "thresholds": {
     "warn_pct": 5,
     "fail_pct": 15,

--- a/scripts/health-goals-check.sh
+++ b/scripts/health-goals-check.sh
@@ -15,6 +15,11 @@
 #   --fast     überspringt langsame Checks (task env:validate, kustomize-Parse)
 #   --quiet    nur die Zusammenfassung
 #   --only=…   nur die genannten Ziel-IDs prüfen (kommagetrennt, z.B. --only=G-RH01,G-CQ02)
+#
+# HG_VALUES_FILE=<path>  wenn gesetzt, hängt jede gemessene (nicht übersprungene) Zeile als
+#                        "<id> <actual> <cmp> <target>" an <path> an — Rohdaten für
+#                        scripts/health-goals-update.sh, ohne dieses Skripts Report-Verhalten
+#                        zu ändern.
 set -uo pipefail
 
 cd "$(git rev-parse --show-toplevel 2>/dev/null)" || { echo "kein git-Repo" >&2; exit 2; }
@@ -52,6 +57,7 @@ row() {
     eq) [ "$actual" -eq "$target" ] && ok=1 || ok=0 ;;
     *)  ok=0 ;;
   esac
+  [ -n "${HG_VALUES_FILE:-}" ] && printf '%s %s %s %s\n' "$id" "$actual" "$cmp" "$target" >> "$HG_VALUES_FILE"
   local cmpsym; case "$cmp" in le) cmpsym="≤" ;; ge) cmpsym="≥" ;; eq) cmpsym="=" ;; esac
   local valstr; valstr=$(printf "%s (Ziel %s%s)" "$actual" "$cmpsym" "$target")
   if [ "$ok" = 1 ]; then

--- a/scripts/health-goals-update.sh
+++ b/scripts/health-goals-update.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# health-goals-update.sh — schreibt frisch gemessene Werte in die "Aktuell"-Spalte der
+# Prio-C-Tabelle (Green Gates) in .claude/lib/goals.md.
+#
+# Bewusst eingeschränkter Scope: nur die maschinenlesbare Markdown-Tabelle wird angefasst.
+# Die freitextigen Prio-A/B-Abschnitte (Policy-Begründungen, "war X"-Historie, Ticket-Status)
+# bleiben menschlicher Redaktion vorbehalten — dort steckt Kontext, den kein Regex sicher
+# fortschreiben kann. Zellen, die kein einfaches Integer-Format haben (Brüche wie "0/30",
+# "Exit 0", Freitext wie "Elite"), werden übersprungen und zur manuellen Prüfung aufgelistet.
+#
+# Usage: bash scripts/health-goals-update.sh [--dry-run] [--full]
+#   --dry-run  zeigt die Diffs, schreibt aber nicht in goals.md
+#   --full     läuft ohne --fast (inkl. env:validate, Vitest-Coverage) — langsamer, mehr Abdeckung
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel 2>/dev/null)" || { echo "kein git-Repo" >&2; exit 2; }
+
+DRY_RUN=0
+CHECK_ARGS=(--fast --quiet)
+for a in "$@"; do case "$a" in
+  --dry-run) DRY_RUN=1 ;;
+  --full) CHECK_ARGS=(--quiet) ;;
+  -h|--help) sed -n '2,17p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+  *) echo "unbekanntes Flag: $a" >&2; exit 2 ;;
+esac; done
+
+GOALS_FILE=".claude/lib/goals.md"
+VALUES_FILE="$(mktemp)"
+trap 'rm -f "$VALUES_FILE"' EXIT
+
+HG_VALUES_FILE="$VALUES_FILE" bash scripts/health-goals-check.sh "${CHECK_ARGS[@]}" >/dev/null || true
+
+if [ ! -s "$VALUES_FILE" ]; then
+  echo "keine Messwerte erhalten — abgebrochen" >&2
+  exit 1
+fi
+
+python3 - "$GOALS_FILE" "$VALUES_FILE" "$DRY_RUN" <<'PY'
+import re
+import sys
+
+goals_file, values_file, dry_run = sys.argv[1], sys.argv[2], sys.argv[3] == "1"
+
+values = {}
+with open(values_file) as f:
+    for line in f:
+        parts = line.split()
+        if len(parts) != 4:
+            continue
+        gid, actual, cmp_op, target = parts
+        values[gid] = (actual, cmp_op, target)
+
+with open(goals_file) as f:
+    lines = f.readlines()
+
+# Prio-C-Tabellenzeile: "| **ID** | Ziel | Aktuell | Target | Basis-Messung |"
+row_re = re.compile(r'^\|\s*\*\*(G-[A-Z0-9]+)\*\*\s*\|([^|]*)\|([^|]*)\|([^|]*)\|(.*)\|\s*$')
+bare_int_re = re.compile(r'^\s*([+-]?\d+)\s*(?:✓|⚠)?\s*$')
+
+# Bekannte ID-Kollisionen: dieselbe ID misst in health-goals-check.sh (Skript) etwas anderes
+# als in der goals.md-Tabelle beschrieben. G-FE03: Skript zählt console.error/warn (passend
+# zum offenen OpenSpec-Change g-fe03-structured-logger), Tabelle dokumentiert console.log/
+# debug/info. Ein Auto-Write würde hier den falschen Messwert unter der falschen Beschreibung
+# ablegen — Auflösung braucht eine inhaltliche Entscheidung, kein Skript.
+EXCLUDE_IDS = {"G-FE03"}
+
+changed = []
+skipped_format = []
+excluded = []
+for i, line in enumerate(lines):
+    m = row_re.match(line.rstrip("\n"))
+    if not m:
+        continue
+    gid = m.group(1)
+    if gid not in values:
+        continue
+    if gid in EXCLUDE_IDS:
+        excluded.append(gid)
+        continue
+    actual, cmp_op, target = values[gid]
+    ziel_cell, aktuell_cell, target_cell, rest_cell = m.group(2), m.group(3), m.group(4), m.group(5)
+    cm = bare_int_re.match(aktuell_cell)
+    if not cm:
+        skipped_format.append(gid)
+        continue
+    old_val = cm.group(1)
+    if old_val == actual:
+        continue
+    ok = {
+        "le": int(actual) <= int(target),
+        "ge": int(actual) >= int(target),
+        "eq": int(actual) == int(target),
+    }.get(cmp_op, False)
+    marker = "✓" if ok else "⚠"
+    lines[i] = f"| **{gid}** |{ziel_cell}| {actual} {marker} |{target_cell}|{rest_cell}|\n"
+    changed.append((gid, old_val, actual, ok))
+
+if changed:
+    print("Aktualisiert:")
+    for gid, old, new, ok in changed:
+        note = "" if ok else "  ⚠ verletzt jetzt Target — Sektion ggf. manuell nach Prio B verschieben"
+        print(f"  {gid}: {old} -> {new}{note}")
+else:
+    print("Keine Änderungen — alle Werte bereits aktuell.")
+
+if skipped_format:
+    print("\nÜbersprungen (kein einfaches Integer-Format in der Aktuell-Spalte, manuell prüfen):")
+    for gid in skipped_format:
+        print(f"  {gid}")
+
+if excluded:
+    print("\nAusgeschlossen (bekannte ID-Kollision Skript vs. Tabelle, siehe EXCLUDE_IDS):")
+    for gid in excluded:
+        print(f"  {gid}")
+
+if changed and not dry_run:
+    with open(goals_file, "w") as f:
+        f.writelines(lines)
+    print(f"\n{goals_file} geschrieben — Narrative (Sprint-Highlights, Baseline-Update) bleibt manuell.")
+elif changed and dry_run:
+    print("\n--dry-run: Datei nicht geschrieben.")
+PY


### PR DESCRIPTION
## Summary
- Add `scripts/health-goals-update.sh` (`task health:goals:update`): reuses `health-goals-check.sh`'s measurements and writes fresh numbers into the "Aktuell" column of the machine-readable Prio-C table in `.claude/lib/goals.md`. Freeform Prio-A/B prose (policy decisions, "war X" history) is intentionally left to human editing.
- `health-goals-check.sh`: add opt-in `HG_VALUES_FILE` env var so `row()` can emit `<id> <actual> <cmp> <target>` for the updater to consume, without changing the existing report output.
- `.claude/lib/goals.md`: refreshed 3 stale Prio-C baselines (G-RH01 28→26, G-CQ02 8→11, G-SIZE03 2890→2106) as a first real run of the new script.
- `.claude/lib/README.md`, `Taskfile.yml`: document/register the new script and task.
- `docs/code-quality/loc-budget.json`: regenerated via `task freshness:regenerate` (required by the freshness guard).

**Found but deliberately not fixed here:** `G-FE03` is used for two different metrics — the script measures `console.error/warn`, the goals.md table describes `console.log/debug/info`. The updater excludes this ID (see `EXCLUDE_IDS` in `health-goals-update.sh`) rather than silently overwriting the table with the wrong metric. Resolving the ID collision is a content decision, not a mechanical one.

## Test plan
- [x] `bash scripts/health-goals-update.sh --dry-run` and non-dry-run — verified diff only touches the Prio-C table's numeric cells
- [x] `task test:changed` — 52/52 pass
- [x] `task workspace:validate` — manifests valid
- [x] `task freshness:regenerate && task freshness:check` — clean after regeneration
- [x] `bash -n` syntax check on both shell scripts

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_01KXaS6BKbbb7XuDxmDUDewF