### PR TITLE
chore(goals): fix G-FE03/G-FE04 ID collision [T001369]

### DIFF
--- a/.claude/lib/goals.md
+++ b/.claude/lib/goals.md
@@ -146,6 +146,16 @@ pnpm --dir website build >/dev/null 2>&1 && find website/dist -name '*.js' -path
 
 > **B · Baseline:** unbekannt (Voll-Build nötig) · **Target:** kein Netto-Zuwachs/Release · **Aufwand:** gering + Policy · **Messzyklus:** pro Release · **Reproduzierbar:** eingeschränkt
 
+## G-FE03 — Strukturiertes Logging: console.error/warn 10 → 0
+
+Aktiver OpenSpec-Change [`g-fe03-structured-logger`](../../openspec/changes/g-fe03-structured-logger/) (Ticket T001299, Status `plan_staged`) migriert alle `console.error`/`console.warn`-Aufrufe auf den pino-basierten Logger (`website/src/lib/logger.ts`) bzw. den Browser-Logger-Stub. **Korrektur (T001369):** diese ID war bis dahin fälschlich in der Prio-C-Tabelle als bereits-grüner Gate für `console.log/debug/info` gelistet — zwei verschiedene Metriken teilten sich eine ID. `console.log/debug/info` läuft jetzt unter der neuen ID [`G-FE04`](#prio-c) (bereits grün, keine Migration nötig).
+
+```bash
+grep -rEn 'console\.(error|warn)' website/src --include='*.ts' --include='*.svelte' --include='*.astro' | grep -v 'browser-logger.ts' | wc -l
+```
+
+> **B · Baseline:** 10 (erstmals korrekt gemessen; vorher fälschlich als 0 ✓ unter G-FE03 in Prio C geführt) · **Target:** 0 · **Aufwand:** ~30 Dateien (siehe Change-Plan) · **Messzyklus:** wöchentlich · **Reproduzierbar:** ja · Ticket: T001299 (`plan_staged`)
+
 ---
 
 # Priorität C — Green Gates {#prio-c}
@@ -207,7 +217,7 @@ Auf Target, nur halten. `bash scripts/health-goals-check.sh` prüft die ✅-repr
 | **G-DORA02** | Lead Time (PR→merge) | Median 0.03h ✓ | ≤ 1h | `gh-axi api repos/{owner}/{repo}/pulls?...` |
 | **G-DORA03** | Change Failure Rate (Proxy) | 7.4 % ✓ | ≤ 15 % | `git log --since="8 weeks ago" --first-parent --oneline main \| ...fix()/revert-Rate` |
 | **G-DORA04** | MTTR | n/a ✓ | < 24h | `git log --since="8 weeks ago" --first-parent --format='%ct %s' main \| grep -iE 'revert\|hotfix'` |
-| **G-FE03** | Stray `console.log/debug/info` | 0 ✓ | 0 | `grep -rEn 'console\.(log\|debug\|info)' website/src --include='*.ts' --include='*.svelte' --include='*.astro' \| grep -v 'browser-logger.ts' \| grep -v '\.test\.ts' \| wc -l` |
+| **G-FE04** | Stray `console.log/debug/info` | 0 ✓ | 0 | `grep -rEn 'console\.(log\|debug\|info)' website/src --include='*.ts' --include='*.svelte' --include='*.astro' \| grep -v 'browser-logger.ts' \| grep -v '\.test\.ts' \| wc -l` |
 | **G-GIT02** | Non-conventional Commits | 0/30 ✓ | 0 | `git log --format=%s -30 origin/main \| grep -vcE '^(feat\|fix\|chore\|...)'` |
 | **G-GIT03** | Dateien >1MB im Tree | 6 ✓ | ≤ 6 | `git ls-files -z \| grep -zv '^\.codebase-memory/' \| xargs -0 -I{} sh -c 'test -f "{}" && wc -c "{}"' \| awk '$1>1048576{c++} END{print c+0}'` (`.codebase-memory/` per Policy-Entscheidung T001348 ausgeschlossen) |
 
@@ -225,7 +235,7 @@ bash scripts/health-goals-check.sh --only=G-RH01,G-CQ02
 **Messzyklus:**
 - **Pro Merge (CI-Gate):** G-RH02/07, G-TEST02/04, G-CQ04, G-SEC01/02, G-K8S04, G-CFG01, G-CI02, G-GIT02, G-SPEC01
 - **Täglich:** G-RH06, G-CI02, G-DATA01, G-GIT01
-- **Wöchentlich:** G-RH01/03, G-TEST01/03, G-SIZE01/03/04, G-CI01, G-CD01, G-CQ02/05, G-IMG01, G-K8S03, G-SPEC03, G-GIT03
+- **Wöchentlich:** G-RH01/03, G-TEST01/03, G-SIZE01/03/04, G-CI01, G-CD01, G-CQ02/05, G-IMG01, G-K8S03, G-SPEC03, G-GIT03, G-FE03/04
 - **Monatlich/Quartal:** G-DEP02, G-SEC03/04, G-DOC02, G-FE01/02
 
 **Aktuell A-Ziele (2026-07-01):** G-SIZE04 (G-GIT03 per T001348 auf ≤ 6 gebracht und von Prio A nach Prio C gewechselt; G-CD01 per T001349 auf 100 % (15/15) gebracht und von Prio A nach Prio C gewechselt)

--- a/docs/code-quality/loc-budget.json
+++ b/docs/code-quality/loc-budget.json
@@ -1,8 +1,8 @@
 {
-  "total_lines": 522606,
+  "total_lines": 523264,
   "file_count": 3960,
-  "commit": "04841579",
-  "measured_at": "2026-07-01T07:41:37.895Z",
+  "commit": "f479b852",
+  "measured_at": "2026-07-01T08:01:13.769Z",
   "thresholds": {
     "warn_pct": 5,
     "fail_pct": 15,

--- a/scripts/health-goals-check.sh
+++ b/scripts/health-goals-check.sh
@@ -106,7 +106,8 @@ row target G-CQ07 "$(n_baseline_gate S2)" le 0  "S2 Import-Zyklen"
 row target G-CQ09 "$(n_baseline_gate S3)" le 10 "S3 hartkodierte Hostnames"
 row target G-CQ10 "$(n_baseline_gate S4)" le 4  "S4 verwaiste Scripts/Manifeste"
 row target G-CQ02 "$(grep -rn ': any\|<any>\|as any' website/src --include='*.ts' --include='*.svelte' --include='*.astro' 2>/dev/null | wc -l | tr -d ' ')" le 280 "explizite any-Verwendungen"
-row target G-FE03 "$(grep -rEn 'console\.(error|warn)' website/src --include='*.ts' --include='*.svelte' --include='*.astro' 2>/dev/null | grep -v 'browser-logger\.ts' | wc -l | tr -d ' ')" le 0 "rohe console.error/warn Aufrufe (exkl. browser-logger-Stub)"
+row target G-FE03 "$(grep -rEn 'console\.(error|warn)' website/src --include='*.ts' --include='*.svelte' --include='*.astro' 2>/dev/null | grep -v 'browser-logger\.ts' | wc -l | tr -d ' ')" le 0 "rohe console.error/warn Aufrufe (exkl. browser-logger-Stub) — T001299"
+row target G-FE04 "$(grep -rEn 'console\.(log|debug|info)' website/src --include='*.ts' --include='*.svelte' --include='*.astro' 2>/dev/null | grep -v 'browser-logger.ts' | grep -v '\.test\.ts' | wc -l | tr -d ' ')" eq 0 "Stray console.log/debug/info"
 row target G-SIZE03 "$( [ -f website/src/lib/website-db.ts ] && wc -l < website/src/lib/website-db.ts | tr -d ' ' || echo - )" le 3000 "God-File website-db.ts (Zeilen)"
 # .codebase-memory/ ist bewusst aus dem Scope ausgeschlossen (Policy-Entscheidung T001348):
 # graph.db.zst ist ein generiertes, `merge=ours` Binärartefakt (PR #2281), das von

--- a/scripts/health-goals-update.sh
+++ b/scripts/health-goals-update.sh
@@ -58,11 +58,9 @@ row_re = re.compile(r'^\|\s*\*\*(G-[A-Z0-9]+)\*\*\s*\|([^|]*)\|([^|]*)\|([^|]*)\
 bare_int_re = re.compile(r'^\s*([+-]?\d+)\s*(?:✓|⚠)?\s*$')
 
 # Bekannte ID-Kollisionen: dieselbe ID misst in health-goals-check.sh (Skript) etwas anderes
-# als in der goals.md-Tabelle beschrieben. G-FE03: Skript zählt console.error/warn (passend
-# zum offenen OpenSpec-Change g-fe03-structured-logger), Tabelle dokumentiert console.log/
-# debug/info. Ein Auto-Write würde hier den falschen Messwert unter der falschen Beschreibung
-# ablegen — Auflösung braucht eine inhaltliche Entscheidung, kein Skript.
-EXCLUDE_IDS = {"G-FE03"}
+# als in der goals.md-Tabelle beschrieben. Aktuell keine offenen Fälle (T001369 hat die
+# G-FE03/G-FE04-Kollision aufgelöst) — Set bleibt als Sicherheitsnetz für künftige Drifts.
+EXCLUDE_IDS = set()
 
 changed = []
 skipped_format = []


### PR DESCRIPTION
## Summary
- `G-FE03` was used for two different metrics: `health-goals-check.sh` measured `console.error/warn` (matching the active OpenSpec change `g-fe03-structured-logger`, ticket T001299), while the `.claude/lib/goals.md` Prio-C table described `console.log/debug/info` under the same ID — a falsely-green `0 ✓` when the real error/warn count is 10.
- Fix: `G-FE03` keeps the `console.error/warn` meaning and moves out of the Prio-C ("Green Gates") table into a proper Prio-B ("Offene Ziele") section, with its real baseline (10) and a link to the open OpenSpec change/ticket.
- `console.log/debug/info` gets its own new ID `G-FE04` in the Prio-C table (already green, 0, no migration needed).
- `health-goals-check.sh` gains `row target G-FE04` for the split-off metric.
- `health-goals-update.sh`'s `EXCLUDE_IDS` is empty again (collision resolved) — kept as a documented safety net for future drifts.

Follow-up to #2395, where this collision was found and deliberately excluded from auto-write rather than silently papered over.

## Test plan
- [x] `bash scripts/health-goals-check.sh --only=G-FE03,G-FE04` — G-FE03 now correctly 🟡 (10, target ≤0), G-FE04 ✅ (0)
- [x] `bash scripts/health-goals-update.sh --dry-run` — no spurious changes, table already consistent
- [x] `bash -n` syntax check on both shell scripts
- [x] `task test:changed` — 327/337 Vitest + 52/52 unit tests pass (one unrelated pre-existing flake in `nextcloud-files.test.ts` on first run, green on rerun)
- [x] `task workspace:validate`, `task freshness:regenerate && task freshness:check` — clean

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_01KXaS6BKbbb7XuDxmDUDewF