### PR TITLE
fix(infra): dead SQL path + port 15433 collision in context7 seed [T001375]

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -4159,7 +4159,7 @@ tasks:
           node scripts/knowledge/ingest-web.mjs {{.CLI_ARGS}}
 
   knowledge:seed-context7:
-    desc: "Create + ingest all 20 context7 library collections (ENV=mentolder|korczewski)"
+    desc: "Create + ingest all 35 context7 library collections (ENV=mentolder|korczewski)"
     vars:
       ENV: '{{.ENV | default "mentolder"}}'
     cmds:
@@ -4181,7 +4181,7 @@ tasks:
         # Apply SQL migration via kubectl exec as postgres (DDL requires table owner)
         echo "=== Applying context7_docs source migration ==="
         kubectl $ctx_flag exec -i -n "$NS" deploy/shared-db -- \
-          psql -U postgres -d website < scripts/one-shot/20260519-context7-source.sql
+          psql -U postgres -d website < scripts/one-shot/archive/20260519-context7-source.sql
 
         # Helper: run SQL as website user via kubectl exec (avoids port-forward TCP RST crashes)
         # -q suppresses command completion tags (INSERT 0 1) that pollute $() captures
@@ -4212,6 +4212,21 @@ tasks:
           ["Traefik"]="/websites/doc_traefik_io_traefik"
           ["Kustomize"]="/kubernetes-sigs/kustomize"
           ["Express 5"]="/websites/expressjs_en_5"
+          ["OpenAI SDK"]="/websites/developers_openai_api"
+          ["Mistral AI SDK"]="/mistralai/client-ts"
+          ["Stripe.js"]="/stripe/stripe-js"
+          ["PDFKit"]="/foliojs/pdfkit"
+          ["pdf-lib"]="/hopding/pdf-lib"
+          ["pdf-parse"]="/mehmet-kozan/pdf-parse"
+          ["D3"]="/d3/d3"
+          ["Chart.js"]="/chartjs/chart.js"
+          ["PixiJS"]="/pixijs/pixijs"
+          ["rrweb"]="/rrweb-io/rrweb"
+          ["Pino"]="/pinojs/pino"
+          ["Nodemailer"]="/nodemailer/nodemailer"
+          ["qrcode"]="/soldair/node-qrcode"
+          ["signature_pad"]="/szimek/signature_pad"
+          ["epub2"]="/julien-c/epub"
         )
 
         # Phase 1: create all collections via kubectl exec (no port-forward needed)
@@ -4228,22 +4243,22 @@ tasks:
         done
 
         # Phase 2: port-forward for Node.js ingestion
-        # Use 15433 (not 5432) to avoid conflicts with other open port-forwards
+        # Use 15499 (not 5432) to avoid conflicts with other open port-forwards
         echo ""
         echo "=== Phase 2: ingesting via context7 API ==="
-        fuser -k 15433/tcp 2>/dev/null || true
-        kubectl $ctx_flag -n "$NS" port-forward svc/shared-db 15433:5432 \
+        fuser -k 15499/tcp 2>/dev/null || true
+        kubectl $ctx_flag -n "$NS" port-forward svc/shared-db 15499:5432 \
           >/tmp/knowledge-context7-pf.log 2>&1 &
         PF=$!
         trap 'kill $PF 2>/dev/null' EXIT
         sleep 4
-        if ! nc -z 127.0.0.1 15433 2>/dev/null; then
-          echo "ERROR: port-forward not listening on 15433:" >&2
+        if ! nc -z 127.0.0.1 15499 2>/dev/null; then
+          echo "ERROR: port-forward not listening on 15499:" >&2
           cat /tmp/knowledge-context7-pf.log >&2
           exit 1
         fi
 
-        PGURL="postgres://website:${WEBSITE_DB_PASSWORD}@localhost:15433/website"
+        PGURL="postgres://website:${WEBSITE_DB_PASSWORD}@localhost:15499/website"
         SUMMARY=""
         for NAME in "${!LIBS[@]}"; do
           LIB_ID="${LIBS[$NAME]}"
@@ -4297,21 +4312,21 @@ tasks:
           -o jsonpath="{.data.VOYAGE_API_KEY}" 2>/dev/null | base64 -d)
         export VOYAGE_API_KEY
 
-        fuser -k 15433/tcp 2>/dev/null || true
-        kubectl $ctx_flag -n "$NS" port-forward svc/shared-db 15433:5432 \
+        fuser -k 15499/tcp 2>/dev/null || true
+        kubectl $ctx_flag -n "$NS" port-forward svc/shared-db 15499:5432 \
           >/tmp/knowledge-context7-pf.log 2>&1 &
         PF=$!
         trap 'kill $PF 2>/dev/null || true' EXIT
         sleep 4
-        if ! nc -z 127.0.0.1 15433 2>/dev/null; then
-          echo "ERROR: port-forward not listening on 15433:" >&2
+        if ! nc -z 127.0.0.1 15499 2>/dev/null; then
+          echo "ERROR: port-forward not listening on 15499:" >&2
           cat /tmp/knowledge-context7-pf.log >&2
           exit 1
         fi
 
         COLLECTION_ID="{{.COLLECTION_ID}}" \
         LIBRARY_ID="{{.LIBRARY_ID}}" \
-        PGURL="postgres://website:${WEBSITE_DB_PASSWORD}@localhost:15433/website" \
+        PGURL="postgres://website:${WEBSITE_DB_PASSWORD}@localhost:15499/website" \
           node scripts/knowledge/ingest-context7.mjs
 
   coaching:ingest:
@@ -4336,19 +4351,19 @@ tasks:
           -o jsonpath="{.data.VOYAGE_API_KEY}" 2>/dev/null | base64 -d)
         export VOYAGE_API_KEY
 
-        fuser -k 15433/tcp 2>/dev/null || true
-        kubectl $ctx_flag -n "$NS" port-forward svc/shared-db 15433:5432 \
+        fuser -k 15499/tcp 2>/dev/null || true
+        kubectl $ctx_flag -n "$NS" port-forward svc/shared-db 15499:5432 \
           >/tmp/coaching-ingest-json-pf.log 2>&1 &
         PF=$!
         trap 'kill $PF 2>/dev/null || true' EXIT
         sleep 4
-        if ! nc -z 127.0.0.1 15433 2>/dev/null; then
-          echo "ERROR: port-forward not listening on 15433:" >&2
+        if ! nc -z 127.0.0.1 15499 2>/dev/null; then
+          echo "ERROR: port-forward not listening on 15499:" >&2
           cat /tmp/coaching-ingest-json-pf.log >&2
           exit 1
         fi
 
-        cd website && PGHOST=localhost PGPORT=15433 PGDATABASE=website PGUSER=website \
+        cd website && PGHOST=localhost PGPORT=15499 PGDATABASE=website PGUSER=website \
           PGPASSWORD="$WEBSITE_DB_PASSWORD" \
           LLM_ENABLED=false \
           npx tsx ../scripts/coaching/ingest-json.mts {{.CLI_ARGS}}


### PR DESCRIPTION
## Summary
- `task knowledge:seed-context7` referenced `scripts/one-shot/20260519-context7-source.sql`, which moved to `scripts/one-shot/archive/` in PR #876 — task aborted immediately with "no such file".
- `kubectl port-forward` only binds `[::1]:15433` (IPv6); a foreign process on the WSL host held `127.0.0.1:15433` (IPv4), so `localhost:15433` could resolve to the wrong Postgres endpoint and every ingest failed with a spurious auth error even though the secret was correct. Moved to port `15499` across `knowledge:seed-context7`, `knowledge:ingest-context7`, and `knowledge:reindex`.
- Adds 15 new context7 library collections that were missing from the seed list (OpenAI SDK, Mistral AI SDK, Stripe.js, PDFKit, pdf-lib, pdf-parse, D3, Chart.js, PixiJS, rrweb, Pino, Nodemailer, qrcode, signature_pad, epub2).

## Test plan
- [x] `task knowledge:seed-context7 ENV=mentolder` run end-to-end after the fix — 34/35 collections ingested successfully (the one 404, Express 5, is a pre-existing entry unrelated to this fix)
- [x] Verified port-forward cleans up (no orphaned `kubectl port-forward` / `node ingest-context7.mjs` processes after run)
- [x] `task quality:check` clean (no new violations)

Ref: T001375

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_01Fnyaz2571LWEfTH54Le9c4