### PR TITLE
chore(scripts): add hermes-delegate wrapper, switch to gemma [T001376]

### DIFF
--- a/.claude/skills/references/subagent-provisioning.md
+++ b/.claude/skills/references/subagent-provisioning.md
@@ -12,6 +12,7 @@ Klassifiziere die Aufgabe nach **Komplexität × Risiko × Rolle**:
 
 | Aufgaben-Charakter | Modell |
 |---|---|
+| Reine Textgenerierung ohne Urteilsvermögen: Boilerplate-Text, Klassifizierung, Umbenennungs-Vorschläge, Kurz-Zusammenfassung — kein Datei-/Shell-Zugriff nötig | `hermes-delegate` (lokal, kostenlos) |
 | Mechanisch: Config, Doku, Rename, Single-File-Edit, Lockfile-/Dependency-Bump | `haiku` |
 | Standard: normale Feature-/Fix-Implementierung, mehrere Dateien, klarer Plan | `sonnet` |
 | Komplex/riskant: systemübergreifend, Architektur, Security, DB-/Schema-Migration, Nebenläufigkeit, Auto-Deploy | `opus` |
@@ -19,6 +20,17 @@ Klassifiziere die Aufgabe nach **Komplexität × Risiko × Rolle**:
 
 Im Zweifel **eine Stufe höher**. Wenn unsicher, ob ein Spezial-Modell überhaupt passt: **`model` weglassen**
 → der Subagent erbt das Main-Loop-Modell (fast immer korrekt).
+
+> **Tier 0 — `hermes-delegate` (lokal, vor `haiku`):** Für Prompts, die reine Textgenerierung ohne
+> Dateizugriff, Werkzeugnutzung oder mehrschrittiges Reasoning sind, ruf statt eines `haiku`-Subagenten
+> `bash scripts/hermes-delegate.sh "<prompt>"` auf. Läuft lokal über den bereits konfigurierten
+> Hermes-Agent (`~/.hermes/config.yaml`, Modell `google/gemma-4-12b-qat` via LM Studio) — kostet keine
+> API-Tokens. **Keine Werkzeuge standardmäßig aktiv** (`-t ""`); nur bei explizitem Bedarf ein
+> Toolset als zweites Argument übergeben (`scripts/hermes-delegate.sh "<prompt>" file`), dann aber
+> wie jeden Tool-Zugriff mit Vorsicht behandeln — das Modell ist kleiner und weniger zuverlässig in
+> mehrschrittigem Tool-Calling als `haiku`. **Nicht** verwenden für: Aufgaben mit Urteilsvermögen,
+> Sicherheitsrelevanz, mehreren Dateien, oder wenn das Ergebnis ungeprüft weiterverwendet wird — dort
+> bleibt `haiku`/`sonnet` die Untergrenze.
 
 > **⚠ Haiku-Fußangel bei Spec-Reviews [T000551]:** Haiku liest ohne expliziten `limit`-Parameter nur
 > die ersten ~80 Zeilen einer Datei und liefert daher false negatives bei Spec-Compliance-Prüfungen

--- a/docs/code-quality/loc-budget.json
+++ b/docs/code-quality/loc-budget.json
@@ -1,8 +1,8 @@
 {
-  "total_lines": 522854,
+  "total_lines": 523527,
   "file_count": 3966,
-  "commit": "f3518fad",
-  "measured_at": "2026-07-01T10:02:17.487Z",
+  "commit": "8130069c",
+  "measured_at": "2026-07-01T11:35:10.181Z",
   "thresholds": {
     "warn_pct": 5,
     "fail_pct": 15,

--- a/scripts/hermes-delegate.sh
+++ b/scripts/hermes-delegate.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Delegates a single, cheap-inference prompt to the local Hermes Agent
+# (gemma-4-12b-qat via LM Studio) instead of spending an expensive model's
+# tokens on it. Intended for mechanical, low-risk subtasks (boilerplate,
+# classification, rename suggestions, summarization) — not for anything
+# needing judgment, architecture decisions, or untrusted tool execution.
+#
+# Usage: scripts/hermes-delegate.sh "<prompt>" [toolsets]
+#   toolsets: comma-separated Hermes toolsets to enable (default: none —
+#             pure text generation, no file/shell/exec access).
+set -euo pipefail
+
+HERMES="${HERMES:-$HOME/.local/bin/hermes}"
+PROMPT="${1:?usage: hermes-delegate.sh \"<prompt>\" [toolsets]}"
+TOOLSETS="${2:-}"
+
+if [[ ! -x "$HERMES" ]]; then
+  echo "FATAL: hermes binary not found at $HERMES" >&2
+  exit 1
+fi
+
+if [[ -n "$TOOLSETS" ]]; then
+  exec "$HERMES" -z "$PROMPT" -t "$TOOLSETS" --cli
+else
+  exec "$HERMES" -z "$PROMPT" -t "" --cli
+fi


### PR DESCRIPTION
## Summary
- Hermes Agent's default model (`hermes-3-llama-3.1-8b`) lacks tool-calling support per Hermes' own startup warning — switched to `google/gemma-4-12b-qat` (same LM Studio gateway).
- Added `scripts/hermes-delegate.sh`: a thin `hermes -z/--oneshot` wrapper for delegating pure-text-generation subtasks (no judgment, no tool access) to the local free Hermes/Gemma stack instead of a paid `haiku` subagent.
- Documented this as a new Tier 0 in `subagent-provisioning.md`, below `haiku`, for genuinely mechanical/cheap-inference work.

## Test plan
- [x] `hermes config set model.default google/gemma-4-12b-qat` verified live (`hermes -z "Say exactly: PONG"` → PONG)
- [x] `scripts/hermes-delegate.sh "Say exactly: DELEGATION-OK"` verified live
- [x] `task workspace:validate`
- [x] `task test:changed` (52/52 pass)
- [x] `task freshness:regenerate` + `task freshness:check` (clean)

T001376