### PR TITLE
feat(scripts): open-goals report with ticket suggestion in health-goals-update [T001406]

### DIFF
--- a/docs/code-quality/loc-budget.json
+++ b/docs/code-quality/loc-budget.json
@@ -1,8 +1,8 @@
 {
-  "total_lines": 524578,
-  "file_count": 3975,
-  "commit": "cbbb083e",
-  "measured_at": "2026-07-01T16:44:47.224Z",
+  "total_lines": 524715,
+  "file_count": 3976,
+  "commit": "9c700a0a",
+  "measured_at": "2026-07-01T16:52:57.795Z",
   "thresholds": {
     "warn_pct": 5,
     "fail_pct": 15,

--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 522,
+      "file_count": 523,
       "files": [
         "tests/.gitignore",
         "tests/README.md",
@@ -375,6 +375,7 @@
         "tests/spec/pocket-id-migration.bats",
         "tests/spec/pocket-id-proxy-ip.bats",
         "tests/spec/react-homepage-blocks.bats",
+        "tests/spec/repo-health-goals.bats",
         "tests/spec/rustdesk-server.bats",
         "tests/spec/s1-violations-batch2.bats",
         "tests/spec/s1-violations.bats",

--- a/docs/superpowers/specs/2026-07-01-health-goals-open-list-design.md
+++ b/docs/superpowers/specs/2026-07-01-health-goals-open-list-design.md
@@ -1,0 +1,101 @@
+---
+ticket_id: null
+plan_ref: null
+status: active
+date: 2026-07-01
+---
+
+# health-goals-update: Offene-Ziele-Report + Ticket-Vorschlag
+
+## Kontext
+
+`task health:goals:update` (`scripts/health-goals-update.sh`) schreibt frisch gemessene Werte in
+die "Aktuell"-Spalte der Prio-C-Tabelle (Green Gates) in `.claude/lib/goals.md`. Nach PR #2415
+kamen die neuen `G-AGENTIC03`–`G-AGENTIC17`-Ziele (Agent-/Skill-/MCP-/Command-Health) hinzu. Nach
+einem Refresh gibt es aktuell keinen Überblick, welche Ziele ihr Target verfehlen (⚠) — der User
+müsste die ganze Tabelle manuell durchscrollen, um zu entscheiden, welche Verletzungen ein Ticket
+verdienen.
+
+## Ziel
+
+Nach dem Tabellen-Update druckt das Skript zusätzlich eine Übersicht aller Prio-C-Ziele mit
+Marker `⚠` (Target verfehlt) — unabhängig davon, ob sich der Wert in diesem Lauf geändert hat —
+und pro Ziel einen fertigen, copy-paste-fähigen `scripts/ticket.sh create ...`-Befehl. Die
+Entscheidung, ob und wie ein Ticket angelegt wird, bleibt beim Menschen (kein automatisches
+Anlegen, keine interaktiven Prompts).
+
+## Nicht-Ziele
+
+- Kein neues CLI-Flag (`--list-open` o.ä.) — der Report läuft immer mit, auch bei `--dry-run`.
+- Keine automatische Ticket-Erstellung.
+- Keine Änderung am bestehenden Tabellen-Update-Verhalten (Parsing, Marker-Logik, Exit-Codes).
+
+## Design
+
+### Datenquelle
+
+Kein zusätzlicher Datei-Read. Der bestehende Python-Parse-Loop in `health-goals-update.sh`
+iteriert bereits über jede Prio-C-Tabellenzeile (`row_re`-Match) und berechnet pro Zeile `ok`
+(Vergleich `actual` vs. `target` über `cmp_op`) und `marker` (`"✓"` oder `"⚠"`). Diese Berechnung
+läuft aktuell nur für Zeilen, deren Wert sich geändert hat (`old_val != actual` als Gate vor der
+`ok`-Berechnung). Für den neuen Report wird die `ok`/`marker`-Berechnung auch für unveränderte
+Zeilen durchgeführt (der `old_val == actual`-Continue-Zweig bleibt für die Tabellen-Schreib-Logik
+bestehen, aber sammelt zusätzlich in eine neue Liste `open_goals`, falls `marker == "⚠"`).
+
+`open_goals`-Einträge: `(gid, ziel_text, actual, target)` — `ziel_text` aus der `Ziel`-Spalte
+(`m.group(2)`, getrimmt).
+
+### Report-Format
+
+Nach dem bestehenden Ausgabeblock (`Aktualisiert:` / `Keine Änderungen` / `Übersprungen` /
+`Ausgeschlossen`) wird angehängt:
+
+```
+Offene Ziele (Target verfehlt):
+  ⚠ G-AGENTIC17 — Command-Orphans via S4: 3 (Target: ≤ 0)
+    scripts/ticket.sh create --type task --brand mentolder \
+      --title "Health-Goal: G-AGENTIC17 — Command-Orphans via S4" \
+      --description "Aktuell: 3, Target: <= 0. Siehe .claude/lib/goals.md#G-AGENTIC17" \
+      --priority mittel
+```
+
+Sortierung: nach `gid` aufsteigend (deterministisch, konsistent mit der Tabellen-Sortierung in
+`goals.md`).
+
+Bei `open_goals == []`:
+```
+Offene Ziele (Target verfehlt): keine — alle Prio-C-Gates grün.
+```
+
+### Escaping
+
+`ziel_text` kann Anführungszeichen/Backticks enthalten (z. B. Ziel-Namen mit Pfaden). Vor dem
+Einsetzen in `--title`/`--description` werden `"` → `\"` und `` ` `` → `` \` `` ersetzt, damit der
+gedruckte Befehl direkt copy-paste-fähig in einer Bash-Shell ist. `cmp_op`-Symbole (`<=`, `>=`,
+`==`) werden für die Description in ASCII (`<=`/`>=`/`==`) statt Unicode geschrieben, um
+Encoding-Überraschungen beim Copy-Paste zu vermeiden.
+
+### Kein neues Flag
+
+Der Report läuft immer am Ende des Skripts, auch bei `--dry-run` (er liest nur, schreibt nichts,
+verändert also kein Verhalten bzgl. `goals.md`). Kein Interaktions-Modus, kein `read -p` — das
+Skript läuft non-interactive in Agent-/CI-Kontexten durch.
+
+### Tests
+
+Neue BATS-Datei `tests/spec/repo-health-goals.bats` (noch nicht vorhanden — anlegen nach dem
+`tests/spec/software-factory.bats`-Vorlage-Muster), Fälle:
+
+1. Fixture-`goals.md` mit einer ⚠-Zeile → Report enthält die Zeile + einen `ticket.sh create`-Befehl
+   mit korrektem `--title`/`--description`.
+2. Fixture-`goals.md` ohne ⚠-Zeile → Report zeigt die Leer-Meldung, kein `ticket.sh create`-Aufruf
+   im Output.
+3. Generierter Befehl ist syntaktisch valide (`bash -n <(echo "$cmd")` oder äquivalente
+   Flag-Zählung: `--type`, `--title`, `--description`, `--priority` je genau einmal vorhanden).
+4. Report erscheint identisch bei `--dry-run` (kein Unterschied zum Normal-Lauf bzgl. des
+   Report-Blocks).
+
+## Betroffene Datei
+
+- `scripts/health-goals-update.sh` (Python-Heredoc-Block erweitern)
+- `tests/spec/repo-health-goals.bats` (neu)

--- a/openspec/changes/health-goals-open-list/.openspec.yaml
+++ b/openspec/changes/health-goals-open-list/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-01

--- a/openspec/changes/health-goals-open-list/design.md
+++ b/openspec/changes/health-goals-open-list/design.md
@@ -1,0 +1,49 @@
+## Context
+
+`scripts/health-goals-update.sh` parst die Prio-C-Tabelle in `.claude/lib/goals.md` per Python-
+Heredoc (`row_re`) und schreibt frisch gemessene Werte zurück. Der Marker (`✓`/`⚠`) wird pro Zeile
+bereits berechnet, aber nur für Zeilen ausgewertet, deren Wert sich im aktuellen Lauf geändert hat
+(`if old_val == actual: continue`). Volle Spec: siehe
+`docs/superpowers/specs/2026-07-01-health-goals-open-list-design.md`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Nach jedem Refresh sichtbar machen, welche Prio-C-Ziele ihr Target verfehlen — auch wenn sie
+  in diesem Lauf unverändert ⚠ geblieben sind.
+- Pro offenem Ziel einen direkt copy-paste-fähigen `scripts/ticket.sh create ...`-Befehl liefern.
+
+**Non-Goals:**
+- Kein neues CLI-Flag, kein `--list-open`-Schalter — der Report läuft immer mit.
+- Keine automatische Ticket-Erstellung oder interaktive Prompts.
+- Keine Änderung an `health-goals-check.sh` (Mess-Logik) oder am Tabellen-Schreibformat.
+
+## Decisions
+
+- **Marker-Berechnung entkoppeln vom "geändert"-Gate:** Der bestehende `old_val == actual`-Continue
+  bleibt für die Tabellen-Schreib-Logik bestehen (verhindert unnötige Diffs), aber vor diesem
+  Continue wird jetzt zusätzlich `ok`/`marker` für JEDE Zeile berechnet und bei `marker == "⚠"` in
+  eine neue Liste `open_goals` gesammelt — unabhängig vom Änderungsstatus. Alternative verworfen:
+  zweiter Parse-Durchlauf nur für den Report — unnötige Redundanz, gleiche Regex zweimal pflegen.
+- **Sortierung nach `gid`:** deterministisch, konsistent mit der Zeilen-Reihenfolge in `goals.md`.
+- **Escaping von `"`/`` ` `` in Ziel-Text:** macht den gedruckten `ticket.sh create`-Befehl direkt
+  in einer Bash-Shell ausführbar, ohne dass Sonderzeichen im Ziel-Namen die Quotes brechen.
+- **`cmp_op`-Symbole in ASCII (`<=`/`>=`/`==`) für die Description:** vermeidet
+  Encoding-Überraschungen beim Copy-Paste aus dem Terminal in eine andere Shell/Editor.
+- **Immer aktiv, kein Flag:** Der Report ist ein reiner zusätzlicher stdout-Block; er ändert
+  weder Exit-Code noch Schreibverhalten, daher ist ein Opt-in-Flag unnötiger Overhead.
+
+## Risks / Trade-offs
+
+- [Risk] Ziel-Text (`Ziel`-Spalte) enthält unerwartete Zeichen, die das Escaping nicht abdeckt
+  (z. B. `$`-Interpolation in Bash) → Mitigation: Escaping-Test in `tests/spec/repo-health-goals.bats`
+  deckt `"` und `` ` `` ab; `$` kommt in bisherigen Ziel-Namen nicht vor (grep-verifiziert gegen
+  aktuelle `goals.md`), daher kein Blocker für diesen Change — bei künftigem Auftreten nachziehen.
+- [Trade-off] Der Report läuft immer mit (kein Flag) → bei sehr vielen offenen Zielen wird der
+  stdout-Output länger. Akzeptiert, da `task health:goals:update` ohnehin ein manuell getriggerter,
+  nicht CI-gebundener Befehl ist.
+
+## Migration Plan
+
+Kein Migrationsschritt nötig — reine Erweiterung eines bestehenden, manuell aufgerufenen Skripts.
+Kein Rollback-Bedarf über `git revert` hinaus.

--- a/openspec/changes/health-goals-open-list/proposal.md
+++ b/openspec/changes/health-goals-open-list/proposal.md
@@ -1,0 +1,35 @@
+## Why
+
+`task health:goals:update` aktualisiert die Prio-C-Tabelle in `.claude/lib/goals.md`, aber gibt
+dem User keinen Überblick, welche Ziele nach dem Refresh ihr Target verfehlen (⚠) — inkl. der
+neuen `G-AGENTIC03`–`G-AGENTIC17`-Ziele aus PR #2415. Ohne diese Übersicht muss die gesamte
+Tabelle manuell durchgescrollt werden, um zu entscheiden, welche Verletzungen ein Ticket
+verdienen.
+
+## What Changes
+
+- `scripts/health-goals-update.sh` druckt nach dem bestehenden Tabellen-Update-Report
+  zusätzlich eine Liste aller Prio-C-Ziele mit Marker `⚠` (Target verfehlt), unabhängig davon,
+  ob sich der Wert in diesem Lauf geändert hat.
+- Pro offenem Ziel wird ein copy-paste-fähiger `scripts/ticket.sh create ...`-Befehlsvorschlag
+  gedruckt (Titel, Beschreibung mit Aktuell/Target-Werten + Link auf `goals.md#<ID>`,
+  `--priority mittel`).
+- Kein automatisches Ticket-Anlegen, kein neues CLI-Flag — der Report läuft immer mit
+  (auch bei `--dry-run`).
+
+## Capabilities
+
+### New Capabilities
+
+(keine)
+
+### Modified Capabilities
+
+- `t001358-sec05-health-goals`: neue Requirement für den Offene-Ziele-Report von
+  `health-goals-update.sh` (Anzeige + Ticket-Befehlsvorschlag für ⚠-Ziele).
+
+## Impact
+
+- `scripts/health-goals-update.sh` (Python-Heredoc-Block erweitert)
+- `tests/spec/repo-health-goals.bats` (neu)
+- Keine Änderung an `health-goals-check.sh`, `.claude/lib/goals.md`-Schreiblogik oder CI.

--- a/openspec/changes/health-goals-open-list/specs/t001358-sec05-health-goals.md
+++ b/openspec/changes/health-goals-open-list/specs/t001358-sec05-health-goals.md
@@ -1,0 +1,39 @@
+## ADDED Requirements
+
+### Requirement: Open-Goals Report with Ticket Suggestion
+
+`scripts/health-goals-update.sh` SHALL print, after the Prio-C table refresh report, a list of
+every Prio-C goal whose marker is `⚠` (target not met) — regardless of whether that goal's value
+changed in the current run — together with a ready-to-run `scripts/ticket.sh create ...` command
+suggestion for each open goal. The script SHALL NOT create tickets automatically and SHALL NOT
+prompt interactively; the report SHALL be printed unconditionally, including when `--dry-run` is
+passed.
+
+#### Scenario: Open goal with unchanged value is listed
+
+- **GIVEN** a Prio-C table row `G-AGENTIC17` whose "Aktuell" value already carries the `⚠` marker
+  before this run, and whose measured value is identical to the stored value
+- **WHEN** `bash scripts/health-goals-update.sh` runs
+- **THEN** the open-goals report includes `G-AGENTIC17` with its current and target values
+
+#### Scenario: Ticket command suggestion is well-formed
+
+- **GIVEN** an open goal `G-AGENTIC17` with measured value `3` and target `≤ 0`
+- **WHEN** the open-goals report is printed
+- **THEN** it includes a `scripts/ticket.sh create` command containing exactly one each of
+  `--type`, `--title`, `--description`, and `--priority`, with the goal ID and its current/target
+  values embedded in `--title`/`--description`
+
+#### Scenario: No open goals
+
+- **GIVEN** every Prio-C table row carries the `✓` marker after the refresh
+- **WHEN** `bash scripts/health-goals-update.sh` runs
+- **THEN** the open-goals report prints a single line stating that no goals are open, and no
+  `scripts/ticket.sh create` command is printed
+
+#### Scenario: Report is identical under --dry-run
+
+- **GIVEN** the same measured values
+- **WHEN** `bash scripts/health-goals-update.sh --dry-run` runs instead of a normal run
+- **THEN** the open-goals report block is printed identically (dry-run only suppresses the write
+  to `.claude/lib/goals.md`, not the report)

--- a/openspec/changes/health-goals-open-list/tasks.md
+++ b/openspec/changes/health-goals-open-list/tasks.md
@@ -1,0 +1,317 @@
+---
+title: "health-goals-open-list — Offene-Ziele-Report + Ticket-Vorschlag"
+ticket_id: "T001406"
+domains: [scripts, testing]
+status: planning
+---
+
+# health-goals-open-list — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `scripts/health-goals-update.sh` prints, after the existing Prio-C table-refresh report, a list of every Prio-C goal whose marker is `⚠` (target not met) plus a ready-to-run `scripts/ticket.sh create …` suggestion per open goal.
+
+**Architecture:** Extend the existing Python heredoc inside `health-goals-update.sh`. The per-row `ok`/`marker` computation is decoupled from the existing "value changed" gate so it also runs for unchanged rows; matching `⚠` rows are collected into an `open_goals` list and rendered as an extra stdout block after the current report. A minimal env-var seam (`HG_GOALS_FILE`, pre-supplied `HG_VALUES_FILE`) makes the script testable against a fixture without invoking the live measurement script.
+
+**Tech Stack:** Bash + embedded Python 3 (`python3 - … <<'PY'`), BATS for tests.
+
+## Global Constraints
+
+- No new CLI flag; the open-goals report runs unconditionally, including under `--dry-run` (dry-run only suppresses the write to `.claude/lib/goals.md`).
+- No automatic ticket creation and no interactive prompts — the script stays non-interactive for agent/CI contexts.
+- No change to the existing table-write behaviour (parsing, marker logic, exit codes) or to `scripts/health-goals-check.sh`.
+- Generated `ticket.sh create` command omits `--brand` (defaults to `mentolder` in `create.sh`) — no brand-domain literal appears in code (S3).
+- `cmp_op` symbols are rendered in ASCII (`<=`/`>=`/`==`) in the ticket description to avoid copy-paste encoding surprises.
+
+## Delta / Requirement Reference
+
+The requirement and its four scenarios are the SSOT in
+`openspec/changes/health-goals-open-list/specs/t001358-sec05-health-goals.md`
+(operation: `## ADDED Requirements` → `### Requirement: Open-Goals Report with Ticket Suggestion`). This plan implements them; each scenario maps to a BATS case in Task 1:
+
+- Scenario "Open goal with unchanged value is listed" → Task 1 test `unchanged open goal is listed`.
+- Scenario "Ticket command suggestion is well-formed" → Task 1 test `ticket command is well-formed`.
+- Scenario "No open goals" → Task 1 test `no open goals prints the empty line`.
+- Scenario "Report is identical under --dry-run" → Task 1 test `report block is identical under dry-run`.
+
+## File Structure
+
+- Modify: `scripts/health-goals-update.sh` — add the `HG_GOALS_FILE` / pre-supplied `HG_VALUES_FILE` seam, decouple the `ok`/`marker` computation from the change gate, collect `open_goals`, and print the report block.
+- Create: `tests/spec/repo-health-goals.bats` — BATS suite driving the script against a fixture `goals.md` + fixture values file.
+
+## Pre-flight — Plan-Quality-Gates (S1–S4)
+
+- `scripts/health-goals-update.sh`: live `wc -l` = 120; not baselined (`jq -r '."S1:scripts/health-goals-update.sh".metric // "nicht-baselined"'` → `nicht-baselined`) → effective threshold = static `.sh` limit 500 → **Budget 380**. Ample room; the report block adds ~35 lines.
+- `tests/spec/repo-health-goals.bats`: new file. S1 is **not gated for `.bats`** (no `.bats` entry in `docs/code-quality/gates.yaml` `s1.limits`, and `_ext_limit` in `scripts/plan-lint.sh` returns 0 for it) → no line budget applies.
+- S2 (import cycles): not applicable — Bash + embedded Python, no TS/JS import graph.
+- S3 (hardcoded hostnames): none introduced; the generated command carries no brand-domain literal.
+- S4 (orphans): the new `.bats` file lives under `tests/**/*.bats`, already listed in `gates.yaml` `s4.reference_sources`, and references the existing script — no orphan risk for either file.
+
+---
+
+### Task 1: Failing BATS suite for the open-goals report
+
+**Files:**
+- Create: `tests/spec/repo-health-goals.bats`
+
+**Interfaces:**
+- Consumes: `scripts/health-goals-update.sh` invoked with env `HG_GOALS_FILE=<fixture goals.md>` and `HG_VALUES_FILE=<fixture values file>` (the seam added in Task 2). Values-file line format: `<gid> <actual> <cmp_op> <target>` with `cmp_op ∈ {le,ge,eq}`.
+- Produces: nothing consumed by later tasks; this is the red test that Task 2 turns green.
+
+- [ ] **Step 1: Write the failing test file**
+
+```bash
+cat > tests/spec/repo-health-goals.bats <<'BATS'
+#!/usr/bin/env bats
+# tests/spec/repo-health-goals.bats
+# SSOT: openspec/specs/t001358-sec05-health-goals.md
+# Covers: Open-Goals Report with Ticket Suggestion (health-goals-update.sh).
+
+SCRIPT="scripts/health-goals-update.sh"
+
+setup() {
+  REPO_ROOT="$(git rev-parse --show-toplevel)"
+  cd "$REPO_ROOT"
+  TMP="$(mktemp -d)"
+  GOALS="$TMP/goals.md"
+  VALUES="$TMP/values.txt"
+}
+
+teardown() {
+  rm -rf "$TMP"
+}
+
+# Fixture with one open (⚠) row and one green (✓) row.
+_write_mixed_fixture() {
+  cat > "$GOALS" <<'MD'
+| **ID** | Ziel | Aktuell | Target | Basis-Messung |
+|--------|------|---------|--------|---------------|
+| **G-AGENTIC17** | Command-Orphans via S4 | 3 ⚠ | ≤ 0 | `echo 3` |
+| **G-RH01** | Gate-Violations | 26 ✓ | ≤ 30 | `echo 26` |
+MD
+  cat > "$VALUES" <<'VAL'
+G-AGENTIC17 3 le 0
+G-RH01 26 le 30
+VAL
+}
+
+# Fixture with only green rows.
+_write_green_fixture() {
+  cat > "$GOALS" <<'MD'
+| **ID** | Ziel | Aktuell | Target | Basis-Messung |
+|--------|------|---------|--------|---------------|
+| **G-RH01** | Gate-Violations | 26 ✓ | ≤ 30 | `echo 26` |
+MD
+  cat > "$VALUES" <<'VAL'
+G-RH01 26 le 30
+VAL
+}
+
+@test "unchanged open goal is listed" {
+  _write_mixed_fixture
+  run env HG_GOALS_FILE="$GOALS" HG_VALUES_FILE="$VALUES" bash "$SCRIPT" --dry-run
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Offene Ziele (Target verfehlt):"* ]]
+  [[ "$output" == *"G-AGENTIC17"* ]]
+  [[ "$output" == *"Target: <= 0"* ]]
+}
+
+@test "ticket command is well-formed" {
+  _write_mixed_fixture
+  run env HG_GOALS_FILE="$GOALS" HG_VALUES_FILE="$VALUES" bash "$SCRIPT" --dry-run
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"scripts/ticket.sh create"* ]]
+  # exactly one of each required flag in the suggestion
+  [ "$(grep -c -- '--type' <<<"$output")" -eq 1 ]
+  [ "$(grep -c -- '--title' <<<"$output")" -eq 1 ]
+  [ "$(grep -c -- '--description' <<<"$output")" -eq 1 ]
+  [ "$(grep -c -- '--priority' <<<"$output")" -eq 1 ]
+  [[ "$output" == *'--title "Health-Goal: G-AGENTIC17'* ]]
+}
+
+@test "no open goals prints the empty line" {
+  _write_green_fixture
+  run env HG_GOALS_FILE="$GOALS" HG_VALUES_FILE="$VALUES" bash "$SCRIPT" --dry-run
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"keine — alle Prio-C-Gates grün."* ]]
+  [[ "$output" != *"scripts/ticket.sh create"* ]]
+}
+
+@test "report block is identical under dry-run" {
+  _write_mixed_fixture
+  run env HG_GOALS_FILE="$GOALS" HG_VALUES_FILE="$VALUES" bash "$SCRIPT" --dry-run
+  dry="$(sed -n '/Offene Ziele/,$p' <<<"$output")"
+  _write_mixed_fixture
+  run env HG_GOALS_FILE="$GOALS" HG_VALUES_FILE="$VALUES" bash "$SCRIPT"
+  normal="$(sed -n '/Offene Ziele/,$p' <<<"$output")"
+  [ "$dry" = "$normal" ]
+}
+BATS
+```
+
+- [ ] **Step 2: Run the suite to verify it fails**
+
+Run: `bats tests/spec/repo-health-goals.bats`
+Expected: FAIL — the script has no `HG_GOALS_FILE` seam yet and prints no "Offene Ziele" block, so the assertions do not match (the first assertion `expected: FAIL`).
+
+- [ ] **Step 3: Commit the red test**
+
+```bash
+git add tests/spec/repo-health-goals.bats
+git commit -m "test: add failing open-goals report spec for health-goals-update"
+```
+
+---
+
+### Task 2: Implement the open-goals report + testability seam
+
+**Files:**
+- Modify: `scripts/health-goals-update.sh`
+
+**Interfaces:**
+- Consumes: fixture env vars from Task 1 (`HG_GOALS_FILE`, `HG_VALUES_FILE`).
+- Produces: the "Offene Ziele (Target verfehlt):" stdout block and, per open goal, a `scripts/ticket.sh create --type task --title … --description … --priority mittel` suggestion.
+
+- [ ] **Step 1: Add the fixture seam (goals-file override + pre-supplied values)**
+
+Replace the current block (lines 27–36):
+
+```bash
+GOALS_FILE=".claude/lib/goals.md"
+VALUES_FILE="$(mktemp)"
+trap 'rm -f "$VALUES_FILE"' EXIT
+
+HG_VALUES_FILE="$VALUES_FILE" bash scripts/health-goals-check.sh "${CHECK_ARGS[@]}" >/dev/null || true
+
+if [ ! -s "$VALUES_FILE" ]; then
+  echo "keine Messwerte erhalten — abgebrochen" >&2
+  exit 1
+fi
+```
+
+with:
+
+```bash
+GOALS_FILE="${HG_GOALS_FILE:-.claude/lib/goals.md}"
+
+# Testability seam: if the caller pre-supplies a non-empty HG_VALUES_FILE we
+# reuse it verbatim (fixture/CI); otherwise mktemp + run the live check script.
+if [ -n "${HG_VALUES_FILE:-}" ] && [ -s "${HG_VALUES_FILE:-}" ]; then
+  VALUES_FILE="$HG_VALUES_FILE"
+else
+  VALUES_FILE="$(mktemp)"
+  trap 'rm -f "$VALUES_FILE"' EXIT
+  HG_VALUES_FILE="$VALUES_FILE" bash scripts/health-goals-check.sh "${CHECK_ARGS[@]}" >/dev/null || true
+fi
+
+if [ ! -s "$VALUES_FILE" ]; then
+  echo "keine Messwerte erhalten — abgebrochen" >&2
+  exit 1
+fi
+```
+
+- [ ] **Step 2: Collect open goals in the parse loop**
+
+Inside the Python heredoc, add an `open_goals` accumulator next to `changed`/`skipped_format`/`excluded`:
+
+```python
+changed = []
+skipped_format = []
+excluded = []
+open_goals = []
+```
+
+Then, in the row loop, move the `ok`/`marker` computation **before** the `old_val == actual` change-gate so it runs for every measured row, and collect `⚠` rows. Replace the block from `old_val = cm.group(1)` down to `changed.append(...)`:
+
+```python
+    old_val = cm.group(1)
+    ok = {
+        "le": int(actual) <= int(target),
+        "ge": int(actual) >= int(target),
+        "eq": int(actual) == int(target),
+    }.get(cmp_op, False)
+    marker = "✓" if ok else "⚠"
+    if not ok:
+        open_goals.append((gid, ziel_cell.strip(), actual, cmp_op, target))
+    if old_val == actual:
+        continue
+    lines[i] = f"| **{gid}** |{ziel_cell}| {actual} {marker} |{target_cell}|{rest_cell}|\n"
+    changed.append((gid, old_val, actual, ok))
+```
+
+- [ ] **Step 3: Print the report block**
+
+After the `excluded` block (before the `if changed and not dry_run:` write block), insert:
+
+```python
+CMP_SYMBOL = {"le": "<=", "ge": ">=", "eq": "=="}
+
+def _sh_escape(text):
+    return text.replace("\\", "\\\\").replace('"', '\\"').replace("`", "\\`")
+
+print("\nOffene Ziele (Target verfehlt):")
+if not open_goals:
+    print("  keine — alle Prio-C-Gates grün.")
+else:
+    for gid, ziel_text, actual, cmp_op, target in sorted(open_goals):
+        sym = CMP_SYMBOL.get(cmp_op, cmp_op)
+        title = _sh_escape(f"Health-Goal: {gid} — {ziel_text}")
+        desc = _sh_escape(
+            f"Aktuell: {actual}, Target: {sym} {target}. Siehe .claude/lib/goals.md#{gid}"
+        )
+        print(f"  ⚠ {gid} — {ziel_text}: {actual} (Target: {sym} {target})")
+        print("    scripts/ticket.sh create --type task \\")
+        print(f'      --title "{title}" \\')
+        print(f'      --description "{desc}" \\')
+        print("      --priority mittel")
+```
+
+- [ ] **Step 4: Run the suite to verify it passes**
+
+Run: `bats tests/spec/repo-health-goals.bats`
+Expected: PASS (all four cases green).
+
+- [ ] **Step 5: Commit the implementation**
+
+```bash
+git add scripts/health-goals-update.sh
+git commit -m "feat: print open-goals report with ticket suggestion in health-goals-update"
+```
+
+---
+
+### Task 3: Verify, regenerate freshness artifacts, and refresh test inventory
+
+**Files:**
+- Modify: `website/src/data/test-inventory.json` (regenerated by `task test:inventory` because a new BATS file was added).
+
+**Interfaces:**
+- Consumes: the committed changes from Tasks 1–2.
+- Produces: green CI-equivalent gates and an up-to-date test inventory.
+
+- [ ] **Step 1: Regenerate the test inventory (new BATS file was added)**
+
+Run: `task test:inventory`
+This updates `website/src/data/test-inventory.json`; CI fails if it drifts from the committed version.
+
+- [ ] **Step 2: Run the mandatory gate commands**
+
+```bash
+task test:changed          # targeted tests for changed domains (BATS selection + quality)
+task freshness:regenerate  # refresh generated artifacts (test-inventory, repo-index, …)
+task freshness:check       # CI equivalent: freshness + quality:check (S1–S4 ratchet) + baseline assertion
+```
+
+Expected: all three exit 0.
+
+- [ ] **Step 3: Confirm the plan-lint gate on this plan**
+
+Run: `bash scripts/plan-lint.sh openspec/changes/health-goals-open-list/tasks.md`
+Expected: `PLAN-LINT: PASS`.
+
+- [ ] **Step 4: Commit the regenerated inventory + any freshness artifacts**
+
+```bash
+git add website/src/data/test-inventory.json
+git commit -m "chore: regenerate test inventory for repo-health-goals spec"
+```

--- a/scripts/health-goals-update.sh
+++ b/scripts/health-goals-update.sh
@@ -24,11 +24,17 @@ for a in "$@"; do case "$a" in
   *) echo "unbekanntes Flag: $a" >&2; exit 2 ;;
 esac; done
 
-GOALS_FILE=".claude/lib/goals.md"
-VALUES_FILE="$(mktemp)"
-trap 'rm -f "$VALUES_FILE"' EXIT
+GOALS_FILE="${HG_GOALS_FILE:-.claude/lib/goals.md}"
 
-HG_VALUES_FILE="$VALUES_FILE" bash scripts/health-goals-check.sh "${CHECK_ARGS[@]}" >/dev/null || true
+# Testability seam: if the caller pre-supplies a non-empty HG_VALUES_FILE we
+# reuse it verbatim (fixture/CI); otherwise mktemp + run the live check script.
+if [ -n "${HG_VALUES_FILE:-}" ] && [ -s "${HG_VALUES_FILE:-}" ]; then
+  VALUES_FILE="$HG_VALUES_FILE"
+else
+  VALUES_FILE="$(mktemp)"
+  trap 'rm -f "$VALUES_FILE"' EXIT
+  HG_VALUES_FILE="$VALUES_FILE" bash scripts/health-goals-check.sh "${CHECK_ARGS[@]}" >/dev/null || true
+fi
 
 if [ ! -s "$VALUES_FILE" ]; then
   echo "keine Messwerte erhalten — abgebrochen" >&2
@@ -65,6 +71,7 @@ EXCLUDE_IDS = set()
 changed = []
 skipped_format = []
 excluded = []
+open_goals = []
 for i, line in enumerate(lines):
     m = row_re.match(line.rstrip("\n"))
     if not m:
@@ -82,14 +89,16 @@ for i, line in enumerate(lines):
         skipped_format.append(gid)
         continue
     old_val = cm.group(1)
-    if old_val == actual:
-        continue
     ok = {
         "le": int(actual) <= int(target),
         "ge": int(actual) >= int(target),
         "eq": int(actual) == int(target),
     }.get(cmp_op, False)
     marker = "✓" if ok else "⚠"
+    if not ok:
+        open_goals.append((gid, ziel_cell.strip(), actual, cmp_op, target))
+    if old_val == actual:
+        continue
     lines[i] = f"| **{gid}** |{ziel_cell}| {actual} {marker} |{target_cell}|{rest_cell}|\n"
     changed.append((gid, old_val, actual, ok))
 
@@ -110,6 +119,27 @@ if excluded:
     print("\nAusgeschlossen (bekannte ID-Kollision Skript vs. Tabelle, siehe EXCLUDE_IDS):")
     for gid in excluded:
         print(f"  {gid}")
+
+CMP_SYMBOL = {"le": "<=", "ge": ">=", "eq": "=="}
+
+def _sh_escape(text):
+    return text.replace("\\", "\\\\").replace('"', '\\"').replace("`", "\\`")
+
+print("\nOffene Ziele (Target verfehlt):")
+if not open_goals:
+    print("  keine — alle Prio-C-Gates grün.")
+else:
+    for gid, ziel_text, actual, cmp_op, target in sorted(open_goals):
+        sym = CMP_SYMBOL.get(cmp_op, cmp_op)
+        title = _sh_escape(f"Health-Goal: {gid} — {ziel_text}")
+        desc = _sh_escape(
+            f"Aktuell: {actual}, Target: {sym} {target}. Siehe .claude/lib/goals.md#{gid}"
+        )
+        print(f"  ⚠ {gid} — {ziel_text}: {actual} (Target: {sym} {target})")
+        print("    scripts/ticket.sh create --type task \\")
+        print(f'      --title "{title}" \\')
+        print(f'      --description "{desc}" \\')
+        print("      --priority mittel")
 
 if changed and not dry_run:
     with open(goals_file, "w") as f:

--- a/scripts/health-goals-update.sh
+++ b/scripts/health-goals-update.sh
@@ -123,7 +123,12 @@ if excluded:
 CMP_SYMBOL = {"le": "<=", "ge": ">=", "eq": "=="}
 
 def _sh_escape(text):
-    return text.replace("\\", "\\\\").replace('"', '\\"').replace("`", "\\`")
+    return (
+        text.replace("\\", "\\\\")
+        .replace('"', '\\"')
+        .replace("`", "\\`")
+        .replace("$", "\\$")
+    )
 
 print("\nOffene Ziele (Target verfehlt):")
 if not open_goals:

--- a/tests/spec/repo-health-goals.bats
+++ b/tests/spec/repo-health-goals.bats
@@ -1,0 +1,84 @@
+#!/usr/bin/env bats
+# tests/spec/repo-health-goals.bats
+# SSOT: openspec/specs/t001358-sec05-health-goals.md
+# Covers: Open-Goals Report with Ticket Suggestion (health-goals-update.sh).
+
+SCRIPT="scripts/health-goals-update.sh"
+
+setup() {
+  REPO_ROOT="$(git rev-parse --show-toplevel)"
+  cd "$REPO_ROOT"
+  TMP="$(mktemp -d)"
+  GOALS="$TMP/goals.md"
+  VALUES="$TMP/values.txt"
+}
+
+teardown() {
+  rm -rf "$TMP"
+}
+
+# Fixture with one open (⚠) row and one green (✓) row.
+_write_mixed_fixture() {
+  cat > "$GOALS" <<'MD'
+| **ID** | Ziel | Aktuell | Target | Basis-Messung |
+|--------|------|---------|--------|---------------|
+| **G-AGENTIC17** | Command-Orphans via S4 | 3 ⚠ | ≤ 0 | `echo 3` |
+| **G-RH01** | Gate-Violations | 26 ✓ | ≤ 30 | `echo 26` |
+MD
+  cat > "$VALUES" <<'VAL'
+G-AGENTIC17 3 le 0
+G-RH01 26 le 30
+VAL
+}
+
+# Fixture with only green rows.
+_write_green_fixture() {
+  cat > "$GOALS" <<'MD'
+| **ID** | Ziel | Aktuell | Target | Basis-Messung |
+|--------|------|---------|--------|---------------|
+| **G-RH01** | Gate-Violations | 26 ✓ | ≤ 30 | `echo 26` |
+MD
+  cat > "$VALUES" <<'VAL'
+G-RH01 26 le 30
+VAL
+}
+
+@test "unchanged open goal is listed" {
+  _write_mixed_fixture
+  run env HG_GOALS_FILE="$GOALS" HG_VALUES_FILE="$VALUES" bash "$SCRIPT" --dry-run
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Offene Ziele (Target verfehlt):"* ]]
+  [[ "$output" == *"G-AGENTIC17"* ]]
+  [[ "$output" == *"Target: <= 0"* ]]
+}
+
+@test "ticket command is well-formed" {
+  _write_mixed_fixture
+  run env HG_GOALS_FILE="$GOALS" HG_VALUES_FILE="$VALUES" bash "$SCRIPT" --dry-run
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"scripts/ticket.sh create"* ]]
+  # exactly one of each required flag in the suggestion
+  [ "$(grep -c -- '--type' <<<"$output")" -eq 1 ]
+  [ "$(grep -c -- '--title' <<<"$output")" -eq 1 ]
+  [ "$(grep -c -- '--description' <<<"$output")" -eq 1 ]
+  [ "$(grep -c -- '--priority' <<<"$output")" -eq 1 ]
+  [[ "$output" == *'--title "Health-Goal: G-AGENTIC17'* ]]
+}
+
+@test "no open goals prints the empty line" {
+  _write_green_fixture
+  run env HG_GOALS_FILE="$GOALS" HG_VALUES_FILE="$VALUES" bash "$SCRIPT" --dry-run
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"keine — alle Prio-C-Gates grün."* ]]
+  [[ "$output" != *"scripts/ticket.sh create"* ]]
+}
+
+@test "report block is identical under dry-run" {
+  _write_mixed_fixture
+  run env HG_GOALS_FILE="$GOALS" HG_VALUES_FILE="$VALUES" bash "$SCRIPT" --dry-run
+  dry="$(sed -n '/Offene Ziele/,$p' <<<"$output")"
+  _write_mixed_fixture
+  run env HG_GOALS_FILE="$GOALS" HG_VALUES_FILE="$VALUES" bash "$SCRIPT"
+  normal="$(sed -n '/Offene Ziele/,$p' <<<"$output")"
+  [ "$dry" = "$normal" ]
+}

--- a/tests/spec/repo-health-goals.bats
+++ b/tests/spec/repo-health-goals.bats
@@ -73,6 +73,24 @@ VAL
   [[ "$output" != *"scripts/ticket.sh create"* ]]
 }
 
+@test "special chars in goal text are shell-escaped in the suggestion" {
+  cat > "$GOALS" <<'MD'
+| **ID** | Ziel | Aktuell | Target | Basis-Messung |
+|--------|------|---------|--------|---------------|
+| **G-ESC01** | Budget $5 "quoted" backtick ` check | 3 ⚠ | ≤ 0 | `echo 3` |
+MD
+  cat > "$VALUES" <<'VAL'
+G-ESC01 3 le 0
+VAL
+  run env HG_GOALS_FILE="$GOALS" HG_VALUES_FILE="$VALUES" bash "$SCRIPT" --dry-run
+  [ "$status" -eq 0 ]
+  # $, ", and ` must all be backslash-escaped so the suggestion is safe to
+  # paste into a double-quoted shell string without triggering substitution.
+  [[ "$output" == *'\$5'* ]]
+  [[ "$output" == *'\"quoted\"'* ]]
+  [[ "$output" == *'\`'* ]]
+}
+
 @test "report block is identical under dry-run" {
   _write_mixed_fixture
   run env HG_GOALS_FILE="$GOALS" HG_VALUES_FILE="$VALUES" bash "$SCRIPT" --dry-run


### PR DESCRIPTION
## Summary
- `scripts/health-goals-update.sh` now prints an "Offene Ziele (Target verfehlt):" block after the existing Prio-C report, listing every open (⚠) goal plus a ready-to-run `scripts/ticket.sh create …` suggestion.
- Adds a testability seam (`HG_GOALS_FILE` / pre-supplied `HG_VALUES_FILE`) so the report is BATS-testable against a fixture without invoking the live measurement script.
- Escapes `\`, `"`, `` ` ``, and `$` in the generated suggestion text (hardening added after code review).

## Test plan
- [x] `tests/spec/repo-health-goals.bats` — 5 cases, all green (unchanged open goal listed, well-formed ticket command, no-open-goals empty line, special-char escaping, dry-run/normal parity)
- [x] `task test:changed` — no new failures (one pre-existing unrelated failure in `tests/spec/mcp-tooling.bats` confirmed present on `origin/main` too)
- [x] `task freshness:regenerate` + `task freshness:check` — green
- [x] `bash scripts/plan-lint.sh openspec/changes/health-goals-open-list/tasks.md` — PLAN-LINT: PASS
- [x] Code review via `superpowers:requesting-code-review` — Important finding ($-escaping) fixed and covered by a new test case

Plan: `openspec/changes/health-goals-open-list/tasks.md`
Ticket: T001406

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BWTYLagPPpKCj8togNzRdU