### PR TITLE
chore(website): add github-actions + junit reporters to vitest CI [T001407]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,6 +211,17 @@ jobs:
           cd website
           pnpm exec vitest run --coverage --testTimeout=30000
 
+      - name: Upload Vitest JUnit report
+        # Runs even if the tests above failed, so a red PR still gets a
+        # downloadable per-test breakdown (not just the raw log).
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: vitest-junit-report
+          path: website/test-results/junit.xml
+          retention-days: 14
+          if-no-files-found: ignore
+
       - name: Vitest line coverage gate (>= 60% on src/lib)
         # G-TEST05 — vitest's built-in thresholds block on regression below
         # 60% lines (see website/vitest.config.ts coverage.thresholds.lines).

--- a/docs/code-quality/loc-budget.json
+++ b/docs/code-quality/loc-budget.json
@@ -1,8 +1,8 @@
 {
-  "total_lines": 524057,
+  "total_lines": 524723,
   "file_count": 3976,
-  "commit": "513fc8ec",
-  "measured_at": "2026-07-01T16:57:00.629Z",
+  "commit": "41a4bab7",
+  "measured_at": "2026-07-01T17:01:57.121Z",
   "thresholds": {
     "warn_pct": 5,
     "fail_pct": 15,

--- a/website/.gitignore
+++ b/website/.gitignore
@@ -6,6 +6,7 @@
 
 # Vitest coverage output
 /coverage/
+/test-results/
 
 # Lockfiles
 /package-lock.json

--- a/website/vitest.config.ts
+++ b/website/vitest.config.ts
@@ -21,6 +21,13 @@ export default defineConfig({
     root: __dirname,
     globals: true,
     testTimeout: 10000,
+    // In CI, add the built-in github-actions reporter (inline PR annotations
+    // on failing tests, no extra tooling) and a JUnit report (uploaded as an
+    // artifact by the workflow) for failure-history/duration tracking.
+    // Local runs keep the plain default reporter.
+    reporters: process.env.GITHUB_ACTIONS
+      ? ['default', 'github-actions', ['junit', { outputFile: './test-results/junit.xml' }]]
+      : ['default'],
     env: {
       VOYAGE_API_KEY: 'test-key',
     },


### PR DESCRIPTION
## Summary
- vitest reporters are conditional on `process.env.GITHUB_ACTIONS`: local runs stay `default`, CI adds the built-in `github-actions` reporter (inline failure annotations directly on the PR diff) and a `junit` reporter writing `website/test-results/junit.xml`.
- CI uploads `test-results/junit.xml` as an artifact (`if: always()`), so a red run still leaves a downloadable per-test breakdown instead of forcing a scroll through raw logs.
- `website/.gitignore` ignores `/test-results/` (mirrors the existing `/coverage/` entry).

No change to which tests run, timeouts, or the coverage gate — reporting/DX only.

## Test plan
- [x] `pnpm exec tsc --noEmit` clean on `vitest.config.ts`
- [x] `GITHUB_ACTIONS=true pnpm exec vitest run --project node src/lib/content.test.ts` — confirms `junit.xml` is written and the github-actions reporter loads without error
- [x] `task freshness:check`, `task test:changed`, `task workspace:validate` all pass
- [ ] CI green on this PR (Vitest (website) job produces the `vitest-junit-report` artifact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0147KVwmuJk1kReeYW4obHbH