### PR TITLE
fix(factory): classify RustDesk k3d files in service-registry

### DIFF
--- a/scripts/factory/service-registry.sh
+++ b/scripts/factory/service-registry.sh
@@ -73,6 +73,11 @@ declare -A SERVICE_REGISTRY=(
   [k3d/oauth2-proxy-studio.yaml]="studio-server"
   [k3d/mentolder-web.yaml]="mentolder-web"
   [k3d/ntfy.yaml]="ntfy"
+  # RustDesk feature (#2403/#2407)
+  [k3d/downloads.yaml]="downloads"
+  [k3d/oauth2-proxy-downloads.yaml]="downloads"
+  [k3d/rustdesk-web-bridge.yaml]="rustdesk-web"
+  [k3d/oauth2-proxy-rustdesk-web.yaml]="rustdesk-web"
 )
 
 # Infra: namespace/network/secrets/controller — ALWAYS full-deploy, never partial.


### PR DESCRIPTION
## Summary
- 4 k3d/*.yaml files added by the RustDesk feature (PRs #2403/#2407) were never classified in `scripts/factory/service-registry.sh`, which fails FA-SF-60's "every k3d/*.yaml is classified" contract whenever a future PR touches k3d/*.yaml.
- Classified `k3d/downloads.yaml` + `k3d/oauth2-proxy-downloads.yaml` as slug `downloads`, and `k3d/rustdesk-web-bridge.yaml` + `k3d/oauth2-proxy-rustdesk-web.yaml` as slug `rustdesk-web`, matching each manifest's `app:` label — same pattern as existing entries (e.g. brett/oauth2-proxy-brett).

## Test plan
- [x] `./tests/unit/lib/bats-core/bin/bats tests/local/FA-SF-60-partial-deploy.bats` — confirmed red before the fix (4 UNCLASSIFIED files), green after (16/16 passing)
- [x] `task test:factory` — full factory BATS suite green, including all FA-SF-60 cases

Closes T001405.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016PZLJ3BvuAFujmJMVU8kjo