### PR TITLE
chore(dev-flow): fix opencode lmstudio provider baseURL + gemma stop token [T001410]

### DIFF
--- a/.opencode/opencode.jsonc
+++ b/.opencode/opencode.jsonc
@@ -54,14 +54,17 @@
   "provider": {
     "lmstudio": {
       "options": {
-        "baseURL": "http://192.168.100.10:1234/v1",
+        "baseURL": "http://localhost:1234/v1",
         "apiKey": "lmstudio"
       },
       "models": {
         "google/gemma-4-12b-qat": {
           "id": "google/gemma-4-12b-qat",
           "name": "Gemma 4 12B QAT",
-          "limit": { "context": 131072, "output": 8192 }
+          "limit": { "context": 131072, "output": 8192 },
+          "options": {
+            "stop": ["<end_of_turn>"]
+          }
         },
         "text-embedding-bge-m3": {
           "id": "text-embedding-bge-m3",


### PR DESCRIPTION
## Summary
- `.opencode/opencode.jsonc`: `lmstudio` provider `baseURL` changed from the wg-gpu tunnel IP (`192.168.100.10:1234`, unreachable from the WSL host itself — connection refused) to `localhost:1234` (works via WSL mirrored networking directly to LM Studio on Windows)
- Added `stop: ["<end_of_turn>"]` override for `google/gemma-4-12b-qat` — works around a broken EOG/tokenizer bug in the Gemma-4 GGUF (confirmed in LM Studio server logs across both lmstudio-community and unsloth quantizations) where the real end-of-turn token is stripped from the model's end-of-generation list, causing generation to run to the token limit instead of stopping cleanly
- `docs/code-quality/loc-budget.json` regenerated (pre-existing staleness, unrelated to this change)

Local dev tooling config only — no platform behavior change.

## Test plan
- [x] `task workspace:validate`
- [x] `task test:changed`
- [x] `task freshness:regenerate` && `task freshness:check`
- [x] Verified `http://localhost:1234/v1/models` reachable from WSL, `192.168.100.10:1234` confirmed connection-refused

Ticket: T001410

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SEqUTfcJ6tw7qDuUbwAsFj