### PR TITLE
fix(infra): verify-deployment.sh and post-deploy-watch.sh check dead keycloak deployment [T001412]

### DIFF
--- a/scripts/post-deploy-watch.sh
+++ b/scripts/post-deploy-watch.sh
@@ -48,7 +48,7 @@ FAIL=0
 echo "═══ Post-deploy watch for ${ENV} ═══"
 
 DEPLOYMENTS=(
-  "keycloak:${WS_NS}"
+  "pocket-id:${WS_NS}"
   "nextcloud:${WS_NS}"
   "shared-db:${WS_NS}"
   "website:${WEB_NS}"

--- a/scripts/verify-deployment.sh
+++ b/scripts/verify-deployment.sh
@@ -138,11 +138,11 @@ echo -e "${BOLD}Deployment Verification${RESET}  ${DIM}ENV=${ENV}  ns=${NS}  web
 section "Cross-namespace network paths"
 
 if [[ "$ENV" != "dev" ]]; then
-  # website pod → keycloak (OIDC callback — the path that caused login failures)
+  # website pod → pocket-id (OIDC callback)
   _http_probe \
-    "${WEB_NS} → keycloak:8080 (OIDC)" \
+    "${WEB_NS} → pocket-id:1411 (OIDC)" \
     "$WEB_NS" "website" \
-    "http://keycloak.${NS}.svc.cluster.local:8080/realms/workspace/.well-known/openid-configuration"
+    "http://pocket-id.${NS}.svc.cluster.local:1411/.well-known/openid-configuration"
 
   # workspace cronjobs → website API (billing, notify-unread, monthly-billing)
   _http_probe \
@@ -180,7 +180,7 @@ fi
 # ── 3. Workloads running ──────────────────────────────────────────────
 section "Workloads running"
 
-_check_deploy "keycloak"   "$NS"     "keycloak"
+_check_deploy "pocket-id"  "$NS"     "pocket-id"
 _check_deploy "nextcloud"  "$NS"     "nextcloud"
 _check_deploy "website"    "$WEB_NS" "website"
 _check_deploy "shared-db"  "$NS"     "shared-db"


### PR DESCRIPTION
## Summary
- `scripts/post-deploy-watch.sh` and `scripts/verify-deployment.sh` still probed a `keycloak` deployment/OIDC endpoint, but Keycloak was fully replaced by Pocket-ID (no `k3d/keycloak.yaml` exists anymore) — post-deploy verification was silently checking a service that doesn't exist.
- Renamed the checks to `pocket-id` (port 1411, `/.well-known/openid-configuration`).
- Recovered from an orphaned local git stash discovered during repo hygiene.

## Test plan
- [ ] `bash scripts/verify-deployment.sh ENV=<brand>` succeeds against fleet
- [ ] `bash scripts/post-deploy-watch.sh ENV=<brand>` shows pocket-id, not keycloak

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_012gw2FmCNThnJ2tmU7VSG3b