### PR TITLE
chore: exclude .test.ts from G-FE03 console.error/warn count, document goals.md baseline workflow [T001414]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -200,6 +200,25 @@ Registered as `codebase-memory-mcp` in both `.mcp.json` (Claude Code) and `.open
 - `CONTRIBUTING.md` — human-readable dev workflow
 - `.agents/skills/OVERVIEW.md` — skill layering contract (dev-flow → superpowers)
 
+## Updating the Health Baseline (`.claude/lib/goals.md`)
+
+~40 quantified health goals (G-* IDs) are tracked in the file. When a goal's measured value
+changes (via `bash scripts/health-goals-check.sh`), update the baseline:
+
+1. **Check:** `bash scripts/health-goals-check.sh --only=G-XXXX` — get the current value.
+2. **Edit `.claude/lib/goals.md`:**
+   - Inline description text (current value, what changed, why).
+   - **Baseline** meta-line: `**A · Baseline:** <alt> → <neu>`.
+   - Goal reached target → move from Prio A/B → Prio C table.
+   - Goal regressed → move from Prio C → Prio A + open a ticket.
+3. **Append `Baseline-Update` entry** at the bottom (section above Mess-Werkzeug):
+   `**Baseline-Update YYYY-MM-DD:** G-XXXX <alt>→<neu> (Begründung); ...`
+4. **Update Sprint-Highlights** with notable changes (target hits, priority changes).
+5. **Never renumber** G-RH01–G-RH07 (externally referenced anchors).
+6. **Verify:** `bash scripts/health-goals-check.sh` still works and shows correct status.
+
+**Convention:** redaktionell, kein Feature-Ticket/OpenSpec-Change nötig.
+
 ## OpenSpec conventions
 
 Proposal and task files (`openspec/changes/<slug>/proposal.md`, `tasks.md`, `specs/*.md`) may include YAML frontmatter parsed by `scripts/openspec-embed.mjs` (used to index changes in pgvector for `plan-context.sh --semantic`). Language convention: **Purpose sections in German; Requirements and Scenarios in English** (GIVEN/WHEN/THEN). Rule source: `openspec/config.yaml` (keys: `proposal`, `tasks`, `specs`, `design`).

--- a/scripts/health-goals-check.sh
+++ b/scripts/health-goals-check.sh
@@ -227,7 +227,7 @@ row target G-CQ07 "$(n_baseline_gate S2)" le 0  "S2 Import-Zyklen"
 row target G-CQ09 "$(n_baseline_gate S3)" le 10 "S3 hartkodierte Hostnames"
 row target G-CQ10 "$(n_baseline_gate S4)" le 4  "S4 verwaiste Scripts/Manifeste"
 row target G-CQ02 "$(grep -rn ': any\|<any>\|as any' website/src --include='*.ts' --include='*.svelte' --include='*.astro' 2>/dev/null | wc -l | tr -d ' ')" le 280 "explizite any-Verwendungen"
-row target G-FE03 "$(grep -rEn 'console\.(error|warn)' website/src --include='*.ts' --include='*.svelte' --include='*.astro' 2>/dev/null | grep -v 'browser-logger\.ts' | wc -l | tr -d ' ')" le 0 "rohe console.error/warn Aufrufe (exkl. browser-logger-Stub) — T001299"
+row target G-FE03 "$(grep -rEn 'console\.(error|warn)' website/src --include='*.ts' --include='*.svelte' --include='*.astro' 2>/dev/null | grep -v 'browser-logger\.ts' | grep -v '\.test\.ts' | wc -l | tr -d ' ')" le 0 "rohe console.error/warn Aufrufe (exkl. browser-logger-Stub, exkl. Tests) — T001299"
 row target G-FE04 "$(grep -rEn 'console\.(log|debug|info)' website/src --include='*.ts' --include='*.svelte' --include='*.astro' 2>/dev/null | grep -v 'browser-logger.ts' | grep -v '\.test\.ts' | wc -l | tr -d ' ')" eq 0 "Stray console.log/debug/info"
 row target G-SIZE03 "$( [ -f website/src/lib/website-db.ts ] && wc -l < website/src/lib/website-db.ts | tr -d ' ' || echo - )" le 3000 "God-File website-db.ts (Zeilen)"
 # .codebase-memory/ ist bewusst aus dem Scope ausgeschlossen (Policy-Entscheidung T001348):


### PR DESCRIPTION
## Summary
- `scripts/health-goals-check.sh`: G-FE03 (raw console.error/warn count) now excludes `*.test.ts`, mirroring the exclusion already applied to G-FE04. Test files legitimately log errors/warnings on purpose.
- `AGENTS.md`: documents the `.claude/lib/goals.md` baseline-update convention (how to record a measured G-* value change).
- Recovered from an orphaned local git stash discovered during repo hygiene.

## Test plan
- [x] `bash scripts/health-goals-check.sh --only=G-FE03` runs and reports 0 ✅

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_012gw2FmCNThnJ2tmU7VSG3b