### PR TITLE
chore(ci): pin wix dotnet tool to 5.0.2 to avoid OSMF EULA failure

### DIFF
--- a/.github/workflows/build-rustdesk-installer.yml
+++ b/.github/workflows/build-rustdesk-installer.yml
@@ -29,7 +29,10 @@ jobs:
       - name: Install WiX Toolset + util extension
         shell: pwsh
         run: |
-          dotnet tool install --global wix
+          # Pinned to the last pre-OSMF major: v7 requires accepting the Open
+          # Source Maintenance Fee EULA interactively, which fails non-interactive
+          # CI runs with WIX7015. See https://docs.firegiant.com/wix/osmf/.
+          dotnet tool install --global wix --version 5.0.2
           wix extension add -g WixToolset.Util.wixext
 
       - name: Download + pin-verify official RustDesk MSI

--- a/docs/code-quality/loc-budget.json
+++ b/docs/code-quality/loc-budget.json
@@ -1,8 +1,8 @@
 {
-  "total_lines": 524433,
+  "total_lines": 525091,
   "file_count": 3977,
-  "commit": "ddbc0a3d",
-  "measured_at": "2026-07-01T18:46:40.303Z",
+  "commit": "266a9d35",
+  "measured_at": "2026-07-01T19:04:36.801Z",
   "thresholds": {
     "warn_pct": 5,
     "fail_pct": 15,


### PR DESCRIPTION
## Summary
- `dotnet tool install --global wix` was pulling the latest major (v7), which now requires interactively accepting an Open Source Maintenance Fee EULA — fails non-interactive CI with `WIX7015`.
- Pins to `5.0.2` (last pre-OSMF major) so `build-rustdesk-installer.yml` can run unattended via `workflow_dispatch`.

## Test plan
- [x] `task workspace:validate`
- [x] `task freshness:check` (after `task freshness:regenerate`)
- [ ] Re-run `build-rustdesk-installer.yml` after merge to confirm the WiX install step succeeds

T001416

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012gw2FmCNThnJ2tmU7VSG3b