### PR TITLE
fix(ci): pin WixToolset.Util.wixext version to match wix core [T001421]

### DIFF
--- a/.github/workflows/build-rustdesk-installer.yml
+++ b/.github/workflows/build-rustdesk-installer.yml
@@ -32,8 +32,11 @@ jobs:
           # Pinned to the last pre-OSMF major: v7 requires accepting the Open
           # Source Maintenance Fee EULA interactively, which fails non-interactive
           # CI runs with WIX7015. See https://docs.firegiant.com/wix/osmf/.
+          # Extension version must match the wix core major/minor (T001421) —
+          # unpinned `extension add` resolves to the latest (v7) package, which
+          # is incompatible with the v5 core (WIX6101).
           dotnet tool install --global wix --version 5.0.2
-          wix extension add -g WixToolset.Util.wixext
+          wix extension add -g WixToolset.Util.wixext/5.0.2
 
       - name: Download + pin-verify official RustDesk MSI
         shell: pwsh


### PR DESCRIPTION
## Summary
- `wix extension add -g WixToolset.Util.wixext` (no version) resolves to the latest extension (v7), which is incompatible with the `wix` core pinned to 5.0.2 in T001416 (to dodge the WIX7015 OSMF EULA gate).
- Pins the extension to `5.0.2` to match, fixing WIX6101 ("Could not find expected package root folder wixext5") that blocked `build-rustdesk-installer.yml`.

## Test plan
- [x] Fix reproduces the exact failing step from run 28547040932
- [ ] Re-trigger `build-rustdesk-installer.yml` after merge and confirm the "Install WiX Toolset + util extension" step passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012gw2FmCNThnJ2tmU7VSG3b