### PR TITLE
fix(ci): add -bindpath so wix build finds baked payload files [T001422]

### DIFF
--- a/.github/workflows/build-rustdesk-installer.yml
+++ b/.github/workflows/build-rustdesk-installer.yml
@@ -63,8 +63,13 @@ jobs:
       - name: Build wrapper MSI
         shell: pwsh
         run: |
+          # Package.wxs <File Source="..."> uses bare relative filenames
+          # (official-rustdesk.msi, provision.ps1); those live under
+          # rustdesk-installer/, not the repo root the build runs from —
+          # -bindpath adds that directory to wix's source search path (T001422).
           wix build rustdesk-installer/Package.wxs `
             -ext WixToolset.Util.wixext `
+            -bindpath rustdesk-installer `
             -arch x64 `
             -o rustdesk-workspace-installer.msi
 


### PR DESCRIPTION
## Summary
- Package.wxs references payload files with bare relative Source paths (official-rustdesk.msi, provision.ps1), which physically live under rustdesk-installer/.
- wix build runs from the repo root, so without -bindpath it can't resolve those Source paths → WIX0103.
- Adds `-bindpath rustdesk-installer` to the build-rustdesk-installer.yml invocation.

## Test plan
- [x] Fix reproduces the exact failing step from run 28547329660
- [ ] Re-trigger build-rustdesk-installer.yml after merge and confirm "Build wrapper MSI" passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012gw2FmCNThnJ2tmU7VSG3b