### PR TITLE
fix(infra): scope rate-limit-auth to /api on auth.mentolder.de [T001430]

### DIFF
--- a/prod/ingress.yaml
+++ b/prod/ingress.yaml
@@ -26,13 +26,42 @@ spec:
                 port:
                   number: 443
 ---
-# ── Pocket ID (Auth / SSO) — Rate-Limiting ──────────────────────────
+# ── Pocket ID (Auth / SSO) — API: Rate-Limiting (Brute-Force-Schutz) ─
+# T001430: rate-limit-auth NUR auf /api scopen, nicht auf die gesamte
+# Route — sonst reisst der SvelteKit-SPA-Asset-Burst (_app/immutable/*)
+# beim Laden das Limit (average=20/burst=40 pro echter Client-IP seit
+# T001341 den klipper-lb-IP-Maskierungsbug entfernt hat).
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: workspace-ingress-auth-api
+  annotations:
+    traefik.ingress.kubernetes.io/router.middlewares: "${WORKSPACE_NAMESPACE}-redirect-https@kubernetescrd,${WORKSPACE_NAMESPACE}-hsts-headers@kubernetescrd,${WORKSPACE_NAMESPACE}-security-headers@kubernetescrd,${WORKSPACE_NAMESPACE}-rate-limit-auth@kubernetescrd"
+spec:
+  tls:
+    - hosts:
+        - auth.${PROD_DOMAIN}
+      secretName: ${TLS_SECRET_NAME}
+  rules:
+    - host: auth.${PROD_DOMAIN}
+      http:
+        paths:
+          - path: /api
+            pathType: Prefix
+            backend:
+              service:
+                name: pocket-id
+                port:
+                  number: 1411
+---
+# ── Pocket ID (Auth / SSO) — SPA/Static: ohne Rate-Limit ────────────
+# Brute-Force-Schutz greift ausschliesslich ueber /api (siehe oben).
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: workspace-ingress-auth
   annotations:
-    traefik.ingress.kubernetes.io/router.middlewares: "${WORKSPACE_NAMESPACE}-redirect-https@kubernetescrd,${WORKSPACE_NAMESPACE}-hsts-headers@kubernetescrd,${WORKSPACE_NAMESPACE}-security-headers@kubernetescrd,${WORKSPACE_NAMESPACE}-rate-limit-auth@kubernetescrd"
+    traefik.ingress.kubernetes.io/router.middlewares: "${WORKSPACE_NAMESPACE}-redirect-https@kubernetescrd,${WORKSPACE_NAMESPACE}-hsts-headers@kubernetescrd,${WORKSPACE_NAMESPACE}-security-headers@kubernetescrd"
 spec:
   tls:
     - hosts:


### PR DESCRIPTION
## Summary
- `workspace-ingress-auth` applied `rate-limit-auth` (avg=20/burst=40) to the whole `auth.${PROD_DOMAIN}` route, including pocket-id's SvelteKit SPA static assets (`_app/immutable/*`).
- Since T001341 removed klipper-lb's client-IP masking, the limit is now enforced per real client IP instead of being diluted across shared pseudo-IPs — a single browser loading the SPA bursts past 40 requests and gets 429s, breaking the OIDC authorize flow site-wide (blocks login for Nextcloud, Vaultwarden, Docs, Downloads, Brett, Tracking, Website, RustDesk-Web, Studio, Comfy — all oauth2-proxy-fronted services).
- Split into two Ingress resources: `workspace-ingress-auth-api` (path=`/api`, keeps `rate-limit-auth` for brute-force protection on the actual auth endpoints) and `workspace-ingress-auth` (path=`/`, no rate limit, serves the SPA shell and static assets).

## Test plan
- [x] `kubectl kustomize prod-fleet/mentolder` and `prod-fleet/korczewski` render both Ingress resources without error
- [x] `task workspace:validate` passes
- [x] `task test:all` passes (52/52, LOC budget within threshold)
- [ ] Post-merge: verify `auth.mentolder.de` authorize flow loads without 429s and login still works
- [ ] Post-merge: confirm brute-force protection still active on `/api/login` (rate-limit-auth still applied there)

Incident ticket: T001430

https://claude.ai/code/session_012gw2FmCNThnJ2tmU7VSG3b