### PR TITLE
fix(infra): serve redirect index.html instead of static-web-server default page [T001431]

### DIFF
--- a/.github/workflows/build-rustdesk-installer.yml
+++ b/.github/workflows/build-rustdesk-installer.yml
@@ -169,6 +169,9 @@ jobs:
 
           New-Item -ItemType Directory -Force -Path layer-root/public | Out-Null
           Copy-Item rustdesk-workspace-installer.exe layer-root/public/rustdesk-workspace-installer.exe
+          # T001431: matches scripts/downloads.Dockerfile's COPY — without this,
+          # static-web-server serves its own built-in placeholder page at "/".
+          Copy-Item scripts/downloads-index.html layer-root/public/index.html
           tar -cf layer.tar -C layer-root public
           if ($LASTEXITCODE -ne 0) { Write-Error "tar failed ($LASTEXITCODE)"; exit $LASTEXITCODE }
 

--- a/scripts/downloads-index.html
+++ b/scripts/downloads-index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=/rustdesk-workspace-installer.exe">
+    <title>RustDesk Workspace Installer</title>
+</head>
+<body>
+    <p>Download startet automatisch. Falls nicht: <a href="/rustdesk-workspace-installer.exe">rustdesk-workspace-installer.exe</a></p>
+</body>
+</html>

--- a/scripts/downloads.Dockerfile
+++ b/scripts/downloads.Dockerfile
@@ -6,6 +6,10 @@ FROM joseluisq/static-web-server:2.36-alpine
 # is the "Verify downloads-content package is private" step in
 # .github/workflows/build-rustdesk-installer.yml (REQ-RUSTDESK-CLIENT-003).
 COPY rustdesk-workspace-installer.exe /public/rustdesk-workspace-installer.exe
+# T001431: without a custom index.html, static-web-server falls back to its
+# own built-in placeholder page ("Static Web Server ... View on GitHub") at
+# the root path instead of starting the download.
+COPY downloads-index.html /public/index.html
 ENV SERVER_ROOT=/public
 ENV SERVER_PORT=8787
 ENV SERVER_CACHE_CONTROL_HEADERS=false


### PR DESCRIPTION
## Summary
- `downloads.mentolder.de` root path showed static-web-server's built-in placeholder page instead of starting the installer download — `scripts/downloads.Dockerfile` only ever `COPY`s the `.exe`, never a custom `index.html`.
- Added `scripts/downloads-index.html` (meta-refresh redirect + manual fallback link to the `.exe`) and wired it into both the Dockerfile (for parity/documentation) and the actual CI build step in `build-rustdesk-installer.yml` (which assembles the image via `crane`/`tar`, not `docker build`).

## Test plan
- [x] `task workspace:validate` passes
- [x] `task test:all` — only pre-existing unrelated failure (`mcp-tooling.bats` local `Bash(gh *)` settings gap, reproduces identically on `main`)
- [ ] Post-merge: run the `Build RustDesk Installer` workflow, verify `https://downloads.mentolder.de/` redirects straight to the `.exe` after login

Ticket: T001431

https://claude.ai/code/session_012gw2FmCNThnJ2tmU7VSG3b