### PR TITLE
fix(scripts): add commit-vs-diff guard for T001434-mishap

### DIFF
--- a/.claude/skills/dev-flow-plan/SKILL.md
+++ b/.claude/skills/dev-flow-plan/SKILL.md
@@ -558,9 +558,28 @@ Damit ist das Fix-Ticket als `plan_staged` in der DB verankert und für `dev-flo
 Füge den failing Test und den Plan hinzu, committe und pushe auf den fix Branch:
 ```bash
 git add tests/ openspec/changes/<slug>/tasks.md
-git commit -m "fix(<scope>): add failing test + stage plan [$TICKET_EXT_ID]"
+git commit -m "chore(plans): add failing test + stage plan [$TICKET_EXT_ID]"
 git push -u origin $(git branch --show-current)
 ```
+
+> **Wichtig — Commit-Titel-Konvention für Plan-Stage-Commits:** Der Stage-Commit enthält
+> NUR den RED-Test und Plan-Artefakte, KEINE Production-Code-Änderung. Verwende deshalb
+> `chore(plans):` (analog zum Feature-Pfad oben) — **nicht** `fix(<scope>):` /
+> `feat(<scope>):` / `refactor(<scope>):` / `perf(<scope>):`. Diese Implementierungs-
+> Präfixe wären eine Lüge, weil der Diff keinen Production-Code enthält. Der nachfolgende
+> `dev-flow-execute`-Implementer würde dem Titel vertrauen und den eigentlichen Fix
+> überspringen — exakt das ist bei T001434 (2026-07-02) passiert.
+>
+> Falls der Plan zusätzlich Production-Code-Aufgaben enthält, die der Planer bereits
+> anwendet (z.B. Boilerplate, der vom Fix unabhängig ist): trotzdem `chore(plans):`
+> verwenden und die Production-Code-Änderung in einem **separaten Commit** mit
+> `fix(<scope>):` ablegen, damit die `commit-vs-diff`-Guard (`.githooks/commit-msg`)
+> den Stage-Commit passieren lässt.
+>
+> Guard: `scripts/check-commit-vs-diff.sh` + `.githooks/commit-msg` (siehe
+> `openspec/specs/ci-cd.md`) blockiert jeden Commit mit Implementation-Type, dessen
+> Staged-Diff nur Test-/Spec-/Plan-Dateien enthält — mit Verweis auf die richtigen
+> Präfixe. Bypass: `SKIP_COMMIT_VS_DIFF=1 git commit ...` (Notfall).
 
 **STOPP.** Failing Test, Spec und Plan sind committed und gepusht. Nächster Schritt: `dev-flow-execute` aufrufen.
 

--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# commit-msg: enforce subject-vs-diff consistency.
+#
+# Rejects commits whose subject uses an implementation type (fix/feat/
+# refactor/perf) but whose staged diff contains only test/spec/plan files.
+# Closes the T001434 mishap: a "fix(infra): chain loggingMiddleware..."
+# title with only a RED test + plan artifacts in the diff caused the
+# implementer to trust the title and skip the actual fix.
+#
+# Exit codes: 0 = subject and diff are consistent, 1 = inconsistent (block).
+# Bypass (emergency only): SKIP_COMMIT_VS_DIFF=1 git commit ...
+
+set -uo pipefail
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+if [[ -z "$repo_root" ]]; then
+  exit 0  # not a git repo (e.g. initialising) — nothing to do
+fi
+
+if [[ "${SKIP_COMMIT_VS_DIFF:-0}" == "1" ]]; then
+  echo "⚠  commit-msg: SKIP_COMMIT_VS_DIFF=1 — bypassing check-commit-vs-diff" >&2
+  exit 0
+fi
+
+if ! bash "$repo_root/scripts/check-commit-vs-diff.sh" "$1"; then
+  echo "" >&2
+  echo "💡 Hint: use 'test(red):' for RED-only test commits or" >&2
+  echo "         'chore(plan):' for plan-only commits." >&2
+  exit 1
+fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -361,3 +361,48 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           bash scripts/validate-commit-msg.sh range "${BASE_SHA}..${HEAD_SHA}"
+
+      # commit-vs-diff consistency guard (T001434-mishap). Catches any commit
+      # whose subject claims an implementation change but whose diff contains
+      # only test/spec/plan files. Mirrors the local .githooks/commit-msg hook
+      # so a bypassed hook (SKIP_COMMIT_VS_DIFF=1) is still caught in CI.
+      - name: commit-vs-diff consistency (T001434-mishap guard)
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          fail=0
+          while IFS= read -r sha; do
+            [[ -z "$sha" ]] && continue
+            subject=$(git log -1 --format='%s' "$sha")
+            # Get the list of files changed by this commit (relative to its
+            # first parent, falling back to the merge-base for merge commits).
+            parent=$(git rev-parse "$sha^1" 2>/dev/null || echo "$BASE_SHA")
+            files=$(git diff --name-only "$parent" "$sha" 2>/dev/null || true)
+            # Build a temp commit-msg file and synthesize a staged index so
+            # the guard script can validate without touching the working tree.
+            tmp_msg=$(mktemp)
+            trap 'rm -f "$tmp_msg"' EXIT
+            printf '%s\n' "$subject" > "$tmp_msg"
+            tmp_idx=$(mktemp -d)
+            export GIT_INDEX_FILE="$tmp_idx/index"
+            git read-tree "$sha"
+            git add -A "$sha" 2>/dev/null || true
+            git diff --cached --name-only > "$tmp_idx/staged.txt" || true
+            if ! GIT_INDEX_FILE="$tmp_idx/index" \
+                 bash scripts/check-commit-vs-diff.sh "$tmp_msg"; then
+              echo "✗ commit $sha fails commit-vs-diff guard: $subject" >&2
+              fail=1
+            fi
+            rm -rf "$tmp_idx"
+            rm -f "$tmp_msg"
+          done < <(git rev-list "${BASE_SHA}..${HEAD_SHA}" --no-merges)
+          if [[ "$fail" -ne 0 ]]; then
+            echo "" >&2
+            echo "✗ commit-vs-diff consistency guard failed" >&2
+            echo "  One or more commits in this PR have an implementation-type" >&2
+            echo "  subject (fix/feat/refactor/perf) but a diff that contains" >&2
+            echo "  only test/spec/plan files. See T001434-mishap." >&2
+            exit 1
+          fi

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -285,6 +285,7 @@ tasks:
       - task: test:unit:ticket-triage
       - task: test:unit:website-ci-deploy
       - task: test:unit:plan-frontmatter-hook
+      - task: test:unit:check-commit-vs-diff
       - task: test:unit:plan-lint
       - task: test:unit:mishap-tracker
       - task: test:unit:ticket-add-pr-link
@@ -513,6 +514,11 @@ tasks:
     internal: true
     cmds:
       - ./tests/unit/lib/bats-core/bin/bats tests/unit/plan-frontmatter-hook.bats
+
+  test:unit:check-commit-vs-diff:
+    internal: true
+    cmds:
+      - ./tests/unit/lib/bats-core/bin/bats tests/unit/check-commit-vs-diff.bats
 
   test:unit:plan-lint:
     internal: true
@@ -1470,12 +1476,15 @@ tasks:
         done
 
   secrets:install-hooks:
-    desc: "Point git at the repo's tracked hooks (.githooks) — installs the plaintext-secret pre-commit guard + merge drivers"
+    desc: "Point git at the repo's tracked hooks (.githooks) — installs the plaintext-secret pre-commit guard + commit-vs-diff guard + merge drivers"
     cmds:
       - git config core.hooksPath .githooks
       - chmod +x .githooks/pre-commit
+      - chmod +x .githooks/commit-msg
       - chmod +x .githooks/pre-push
       - chmod +x .githooks/post-commit-index
+      - chmod +x .githooks/post-checkout
+      - chmod +x .githooks/post-merge
       - git config merge.ours.driver true
       - echo "hooksPath set to .githooks; merge.ours driver registered"
 

--- a/docs/code-quality/loc-budget.json
+++ b/docs/code-quality/loc-budget.json
@@ -1,8 +1,8 @@
 {
-  "total_lines": 527013,
-  "file_count": 3998,
-  "commit": "b1f05874",
-  "measured_at": "2026-07-02T10:27:55.968Z",
+  "total_lines": 528148,
+  "file_count": 4000,
+  "commit": "147259b0e",
+  "measured_at": "2026-07-02T10:56:56.442Z",
   "thresholds": {
     "warn_pct": 5,
     "fail_pct": 15,

--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 535,
+      "file_count": 536,
       "files": [
         "tests/.gitignore",
         "tests/README.md",
@@ -423,6 +423,7 @@
         "tests/unit/brainstorm-extract-choice.bats",
         "tests/unit/build-graph.bats",
         "tests/unit/changed-manifests.bats",
+        "tests/unit/check-commit-vs-diff.bats",
         "tests/unit/coaching-json-ingest.bats",
         "tests/unit/collabora-wopi-discovery.bats",
         "tests/unit/collabora-wopi-single-brand-guard.bats",
@@ -2742,7 +2743,7 @@
       "id": "scripts-infra",
       "name": "Operational + build scripts",
       "owner_agent": "bachelorprojekt-infra",
-      "file_count": 470,
+      "file_count": 471,
       "files": [
         "scripts/README.md",
         "scripts/add-whiteboard-library.py",
@@ -2822,6 +2823,7 @@
         "scripts/build-test-inventory.sh",
         "scripts/changed-manifests.sh",
         "scripts/check-bundle-size.mjs",
+        "scripts/check-commit-vs-diff.sh",
         "scripts/check-connectivity.sh",
         "scripts/check-loc-budget.mjs",
         "scripts/check-updates.sh",

--- a/openspec/specs/ci-cd.md
+++ b/openspec/specs/ci-cd.md
@@ -629,6 +629,49 @@ The system SHALL validate all commit messages in a PR (range `origin/main..HEAD`
 - **WHEN** CI runs the `commit-lint` job
 - **THEN** the job fails and reports which commit messages are invalid
 
+### Requirement: commit-vs-diff-consistency-guard
+
+The system SHALL reject any commit whose subject uses an implementation type (`fix`, `feat`, `refactor`, `perf`, including the breaking-change marker `!`) but whose staged diff contains only test/spec/plan artifacts (no production-code change). The guard is implemented as `scripts/check-commit-vs-diff.sh` wired into the `.githooks/commit-msg` hook (blockierend) and mirrored into the CI `commit-lint` job (catches bypasses).
+
+**Background (T001434-mishap, 2026-07-02):** a dev-flow-plan stage commit used
+`fix(infra): chain loggingMiddleware in middleware.ts via sequence() [T001434]` as its
+title, but the diff only contained the RED integration test plus plan artifacts. The
+next implementer (dev-flow-execute) trusted the title and skipped the actual fix; the
+bug landed in a follow-up commit instead of the same PR. The dev-flow-plan SKILL.md
+now mandates `chore(plans):` for plan-stage commits; this guard is the belt-and-suspenders
+backstop for any future SKILL-deviation or human bypass.
+
+#### Scenario: Plan-stage commit with implementation-type subject is blocked
+
+- **GIVEN** a developer runs `git add openspec/changes/<slug>/ website/src/middleware.test.ts`
+- **AND** the commit message is `fix(infra): chain loggingMiddleware in middleware.ts via sequence() [T001434]`
+- **WHEN** `git commit` is invoked
+- **THEN** the `commit-msg` hook runs `scripts/check-commit-vs-diff.sh`
+- **AND** the hook rejects the commit with exit code 1
+- **AND** the error message references the T001434 mishap pattern
+- **AND** the error message suggests `test(red):` or `chore(plan):` as the correct prefixes
+
+#### Scenario: Implementation commit with real production code passes
+
+- **GIVEN** a developer runs `git add website/src/middleware.ts website/src/middleware.test.ts`
+- **AND** the commit message is `fix(infra): chain loggingMiddleware in middleware.ts via sequence() [T001434]`
+- **WHEN** `git commit` is invoked
+- **THEN** the `commit-msg` hook runs `scripts/check-commit-vs-diff.sh`
+- **AND** the hook accepts the commit with exit code 0
+
+#### Scenario: Plan-stage commit with chore(plans): prefix passes
+
+- **GIVEN** a developer runs `git add openspec/changes/<slug>/`
+- **AND** the commit message is `chore(plans): stage <slug> for execution [T-...]`
+- **WHEN** `git commit` is invoked
+- **THEN** the `commit-msg` hook accepts the commit (no implementation-type claim)
+
+#### Scenario: Bypass for emergency
+
+- **GIVEN** a developer runs `SKIP_COMMIT_VS_DIFF=1 git commit ...` with an otherwise-blocked subject/diff pair
+- **WHEN** the `commit-msg` hook runs
+- **THEN** the hook prints a `⚠  SKIP_COMMIT_VS_DIFF=1` warning but exits 0
+
 ## Testszenarien
 
 <!-- merged from BATS unit tests and Playwright e2e tests -->

--- a/scripts/check-commit-vs-diff.sh
+++ b/scripts/check-commit-vs-diff.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+# check-commit-vs-diff.sh — reject commits whose subject claims an
+# implementation change but whose staged diff contains only test/spec/plan
+# files. The guard closes the T001434 mishap: a dev-flow-plan stage commit
+# used "fix(infra): chain loggingMiddleware in middleware.ts via
+# sequence() [T001434]" as its title, but the diff only contained the RED
+# integration test plus plan artifacts. The next implementer
+# (dev-flow-execute) trusted the title and skipped the actual fix; the bug
+# landed in a follow-up commit instead of the same PR.
+#
+# This script enforces the rule at commit-msg time:
+#   - If the subject uses an implementation type (fix/feat/refactor/perf)
+#   - AND the staged diff contains ONLY test/spec/plan files
+#   - THEN reject with a clear error pointing the author to the right
+#     prefix (test(red): for RED-only test commits, chore(plan): for
+#     plan-only commits).
+#
+# Wired into:
+#   - .githooks/commit-msg  (local, blocking)
+#   - .github/workflows/ci.yml commit-lint job (CI, blocking, catches bypasses)
+#
+# Usage:
+#   check-commit-vs-diff.sh <commit-msg-file>
+#   check-commit-vs-diff.sh --self-test   # internal sanity test (no side effects)
+#
+# Exit codes: 0 = subject and diff are consistent, 1 = inconsistent (commit blocked).
+set -uo pipefail
+
+MSG_FILE="${1:-}"
+SELF_TEST=0
+if [[ "${1:-}" == "--self-test" ]]; then
+  SELF_TEST=1
+  MSG_FILE=""
+fi
+
+if [[ -z "$MSG_FILE" && $SELF_TEST -eq 0 ]]; then
+  echo "check-commit-vs-diff: usage: check-commit-vs-diff.sh <commit-msg-file>" >&2
+  exit 2
+fi
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo "")"
+if [[ -z "$REPO_ROOT" ]]; then
+  echo "check-commit-vs-diff: not inside a git repository" >&2
+  exit 2
+fi
+
+# ── Self-test mode ────────────────────────────────────────────────────────────
+if [[ $SELF_TEST -eq 1 ]]; then
+  TMP="$(mktemp -d)"
+  trap 'rm -rf "$TMP"' EXIT
+  fail=0
+  assert_allows() {
+    local name="$1" subject="$2" files="$3"
+    rm -rf "$TMP/repo" && mkdir -p "$TMP/repo" && cd "$TMP/repo" && git init -q >/dev/null
+    git config user.email test@test && git config user.name test >/dev/null
+    : > "$TMP/msg"
+    printf '%s\n' "$subject" >> "$TMP/msg"
+    for f in $files; do
+      mkdir -p "$(dirname "$f")"
+      printf 'content' > "$f"
+    done
+    [[ -n "$files" ]] && git add -A >/dev/null 2>&1
+    if "$REPO_ROOT/scripts/check-commit-vs-diff.sh" "$TMP/msg" >/dev/null 2>&1; then
+      echo "  ok    $name"
+    else
+      echo "  FAIL  $name (expected allow, got block)"
+      fail=1
+    fi
+    cd "$REPO_ROOT"
+  }
+  assert_blocks() {
+    local name="$1" subject="$2" files="$3"
+    rm -rf "$TMP/repo" && mkdir -p "$TMP/repo" && cd "$TMP/repo" && git init -q >/dev/null
+    git config user.email test@test && git config user.name test >/dev/null
+    : > "$TMP/msg"
+    printf '%s\n' "$subject" >> "$TMP/msg"
+    for f in $files; do
+      mkdir -p "$(dirname "$f")"
+      printf 'content' > "$f"
+    done
+    [[ -n "$files" ]] && git add -A >/dev/null 2>&1
+    if "$REPO_ROOT/scripts/check-commit-vs-diff.sh" "$TMP/msg" >/dev/null 2>&1; then
+      echo "  FAIL  $name (expected block, got allow)"
+      fail=1
+    else
+      echo "  ok    $name (blocked as expected)"
+    fi
+    cd "$REPO_ROOT"
+  }
+
+  # Allow cases
+  assert_allows "feat(real-code)"      "feat(website): add pricing widget"        "website/src/components/Pricing.tsx"
+  assert_allows "fix(real-code)"       "fix(infra): chain middleware sequence"    "website/src/middleware.ts"
+  assert_allows "fix(real+test)"       "fix(infra): chain middleware sequence"    "website/src/middleware.ts website/src/middleware.test.ts"
+  assert_allows "chore(plans)"         "chore(plans): stage t001434 for execution" "openspec/changes/t001434/tasks.md"
+  assert_allows "test(red-only)"       "test(red): verify locals.requestLogger"   "website/src/middleware.test.ts"
+  assert_allows "docs(readme)"         "docs: update README"                      "README.md"
+  assert_allows "ci(workflow)"         "ci: bump action versions"                ".github/workflows/ci.yml"
+  assert_allows "fix(scope-less)"      "fix: typo"                                "scripts/check.sh"
+
+  # Block cases — the T001434 pattern
+  assert_blocks "fix(red-only-test)"   "fix(infra): chain middleware sequence"    "website/src/middleware.test.ts"
+  assert_blocks "fix(plan-only)"       "fix(infra): chain middleware sequence"    "openspec/changes/t001434/tasks.md"
+  assert_blocks "fix(plan-and-test)"   "fix(infra): chain middleware sequence"    "website/src/middleware.test.ts openspec/changes/t001434/tasks.md"
+  assert_blocks "fix(spec-only)"       "fix(infra): chain middleware sequence"    "openspec/specs/centralized-logging.md"
+  assert_blocks "feat(plan-only)"      "feat(infra): add logging chain"           "openspec/changes/t001434/proposal.md openspec/changes/t001434/tasks.md"
+  assert_blocks "refactor(plan-only)"  "refactor(scripts): consolidate guards"    "openspec/changes/cleanup/tasks.md"
+  assert_blocks "perf(plan-only)"      "perf(db): index tickets table"            "openspec/changes/perf-index/tasks.md"
+
+  # Edge case: production code in a non-standard path still counts as impl
+  assert_allows "fix(kustomize)"       "fix(infra): tweak configmap"              "k3d/configmap-domains.yaml"
+  # Edge case: amend without staged changes (no-op commit) — should not block
+  assert_allows "fix(no-op)"           "fix: nothing"                             ""
+
+  if [[ $fail -ne 0 ]]; then
+    echo "check-commit-vs-diff: self-test FAILED" >&2
+    exit 1
+  fi
+  echo "check-commit-vs-diff: self-test passed (15 cases)"
+  exit 0
+fi
+
+# ── Normal mode ───────────────────────────────────────────────────────────────
+[[ -f "$MSG_FILE" ]] || { echo "check-commit-vs-diff: message file '$MSG_FILE' not found" >&2; exit 2; }
+
+# --- Parse subject (first non-comment, non-blank line) ---
+SUBJECT="$(grep -m1 -E '^[^#[:space:]]' "$MSG_FILE" | sed 's/^[[:space:]]*//')"
+[[ -n "$SUBJECT" ]] || exit 0  # empty subject — let other hooks (commitlint) handle it
+
+# --- Detect implementation types ---
+# Mirrors @commitlint/config-conventional `types:` plus the breaking-change
+# marker `!`. We deliberately do NOT block `test:`, `chore:`, `docs:`, `ci:`,
+# `build:`, `style:`, `revert:` — those are non-implementation.
+if ! echo "$SUBJECT" | grep -qE '^(fix|feat|refactor|perf)(!)?(\([^)]+\))?:\s'; then
+  exit 0
+fi
+
+# --- Inspect staged diff file list ---
+STAGED_FILES="$(git -C "$REPO_ROOT" diff --cached --name-only --diff-filter=ACMR 2>/dev/null || true)"
+[[ -n "$STAGED_FILES" ]] || exit 0  # empty commit (e.g. amend with --allow-empty) — nothing to check
+
+# Files that are NOT production-code-bearing: test/spec/plan artifacts.
+# Everything that survives this filter is "real" code that proves the
+# implementation claim in the subject line.
+NON_IMPL_FILES="$(echo "$STAGED_FILES" \
+  | grep -vE '\.(test|spec)\.[A-Za-z0-9]+$' \
+  | grep -vE '^(openspec/changes/|openspec/changes/archive/)' \
+  | grep -vE '^openspec/specs/' \
+  | grep -vE '^docs/superpowers/specs/' \
+  | grep -vE '^\.ticket$' \
+  | grep -vE '^openspec/changes/[^/]+/\.openspec\.yaml$')"
+
+if [[ -z "$NON_IMPL_FILES" ]]; then
+  cat >&2 <<EOF
+✗  check-commit-vs-diff: subject claims implementation but diff has no production code
+
+Subject:    $SUBJECT
+Staged:     $(echo "$STAGED_FILES" | tr '\n' ' ' | sed 's/ $//')
+
+This is the T001434 mishap pattern — a 'fix:' / 'feat:' / 'refactor:' /
+'perf:' title with only RED-tests or plan artifacts in the diff. The next
+implementer would trust the title and skip the actual implementation,
+and the bug lands in a follow-up commit instead of the same PR.
+
+Use one of these prefixes instead:
+  test(red): …   for a RED-only test commit (the test is supposed to fail)
+  chore(plan): … for a plan-only commit (openspec/changes/, openspec/specs/, docs/superpowers/specs/)
+  test: …        for a test commit that is intentionally part of the fix
+
+If this really IS an implementation commit, your diff is missing the
+production-code change — review the plan and add the missing files before
+committing again.
+
+To bypass (emergency only): SKIP_COMMIT_VS_DIFF=1 git commit ...
+EOF
+  exit 1
+fi
+
+exit 0

--- a/tests/spec/ci-cd.bats
+++ b/tests/spec/ci-cd.bats
@@ -201,3 +201,51 @@ PY
   run node "$REPO_ROOT/scripts/check-loc-budget.mjs" --baseline=/nonexistent/loc-budget.json
   [ "$status" -eq 1 ]
 }
+
+# ── G-COMMIT-VS-DIFF: commit-vs-diff consistency guard (T001434-mishap) ──────
+# SSOT: openspec/specs/ci-cd.md "Requirement: commit-vs-diff-consistency-guard"
+
+@test "G-COMMIT-VS-DIFF: scripts/check-commit-vs-diff.sh exists" {
+  [ -f "$REPO_ROOT/scripts/check-commit-vs-diff.sh" ]
+}
+
+@test "G-COMMIT-VS-DIFF: .githooks/commit-msg exists and is executable" {
+  [ -x "$REPO_ROOT/.githooks/commit-msg" ]
+}
+
+@test "G-COMMIT-VS-DIFF: .githooks/commit-msg delegates to check-commit-vs-diff.sh" {
+  grep -q 'check-commit-vs-diff.sh' "$REPO_ROOT/.githooks/commit-msg"
+}
+
+@test "G-COMMIT-VS-DIFF: secrets:install-hooks chmod's the commit-msg hook" {
+  # Grab the full secrets:install-hooks task block (until next blank line / new task)
+  awk '/^  secrets:install-hooks:/{flag=1; next} flag && /^  [a-z]/{flag=0} flag' \
+    "$REPO_ROOT/Taskfile.yml" | grep -q 'chmod +x .githooks/commit-msg'
+}
+
+@test "G-COMMIT-VS-DIFF: dev-flow-plan SKILL.md uses chore(plans): for stage commit (NOT fix(<scope>):)" {
+  # Regression for T001434-mishap: the dev-flow-plan SKILL.md used to
+  # recommend `fix(<scope>):` for the RED-test stage commit, which produced
+  # a misleading commit title whose diff contained no production code.
+  # The fix is to use `chore(plans):` for the plan-stage commit (matching
+  # the feature-path convention) so the commit-vs-diff guard passes.
+  local stage_line
+  stage_line=$(grep -E 'git commit -m "[^"]*add failing test' "$REPO_ROOT/.claude/skills/dev-flow-plan/SKILL.md" | head -1)
+  [ -n "$stage_line" ]
+  [[ "$stage_line" == *"chore(plans):"* ]]
+  [[ "$stage_line" != *"fix(<scope>):"* ]]
+}
+
+@test "G-COMMIT-VS-DIFF: openspec/specs/ci-cd.md documents the guard requirement" {
+  grep -q '^### Requirement: commit-vs-diff-consistency-guard' "$REPO_ROOT/openspec/specs/ci-cd.md"
+}
+
+@test "G-COMMIT-VS-DIFF: unit tests in tests/unit/check-commit-vs-diff.bats cover all branches" {
+  # Sanity: the unit suite must exercise both allow and block paths
+  local bats_file="$REPO_ROOT/tests/unit/check-commit-vs-diff.bats"
+  [ -f "$bats_file" ]
+  grep -qE 'allows:.*real-code' "$bats_file"
+  grep -qE 'blocks:.*T001434' "$bats_file"
+  grep -qE 'blocks:.*plan-only' "$bats_file"
+  grep -qE 'SKIP_COMMIT_VS_DIFF' "$bats_file"
+}

--- a/tests/unit/check-commit-vs-diff.bats
+++ b/tests/unit/check-commit-vs-diff.bats
@@ -1,0 +1,219 @@
+#!/usr/bin/env bats
+# tests/unit/check-commit-vs-diff.bats
+#
+# Unit tests for scripts/check-commit-vs-diff.sh — the commit-msg guard that
+# rejects commits whose subject uses an implementation type (fix/feat/
+# refactor/perf) but whose staged diff contains only test/spec/plan files.
+#
+# Closes the T001434 mishap: a dev-flow-plan stage commit used
+#   "fix(infra): chain loggingMiddleware in middleware.ts via sequence() [T001434]"
+# as its title, but the diff only contained the RED integration test plus
+# plan artifacts. The next implementer (dev-flow-execute) trusted the title
+# and skipped the actual fix; the bug landed in a follow-up commit instead
+# of the same PR.
+#
+# SSOT: this script + hook implements the policy declared in
+#   openspec/specs/ci-cd.md (commit-msg-guard requirement).
+# Convention: one .bats per script. BATS runs as part of `task test:unit`.
+
+setup() {
+  REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+  SCRIPT="$REPO_ROOT/scripts/check-commit-vs-diff.sh"
+  HOOK="$REPO_ROOT/.githooks/commit-msg"
+  TMP="$(mktemp -d)"
+  export TMP
+}
+
+teardown() {
+  [[ -n "$TMP" && -d "$TMP" ]] && rm -rf "$TMP"
+}
+
+# ── 1. Script exists and is executable ──────────────────────────────────────
+
+@test "check-commit-vs-diff.sh exists" {
+  [ -f "$SCRIPT" ]
+}
+
+@test "check-commit-vs-diff.sh is executable" {
+  [ -x "$SCRIPT" ]
+}
+
+# ── 2. Subject-line classification (allow cases) ─────────────────────────────
+
+@test "allows: fix(real-code) — production-code change" {
+  mkdir -p "$TMP/repo" && cd "$TMP/repo" && git init -q && git config user.email t@t && git config user.name t
+  printf 'src/middleware.ts' > "$TMP/msg-subject"
+  mkdir -p src && printf 'real code' > src/middleware.ts
+  git add src/middleware.ts
+  run bash "$SCRIPT" "$TMP/msg-subject"
+  [ "$status" -eq 0 ]
+}
+
+@test "allows: fix(real-code+test) — production + test in same commit" {
+  mkdir -p "$TMP/repo" && cd "$TMP/repo" && git init -q && git config user.email t@t && git config user.name t
+  printf 'fix(infra): chain middleware sequence\n' > "$TMP/msg-subject"
+  mkdir -p src && printf 'real' > src/middleware.ts && printf 'test' > src/middleware.test.ts
+  git add src/
+  run bash "$SCRIPT" "$TMP/msg-subject"
+  [ "$status" -eq 0 ]
+}
+
+@test "allows: test(red-only) — RED-test commit uses test: prefix" {
+  mkdir -p "$TMP/repo" && cd "$TMP/repo" && git init -q && git config user.email t@t && git config user.name t
+  printf 'test(red): verify locals.requestLogger is set\n' > "$TMP/msg-subject"
+  mkdir -p src && printf 'test' > src/middleware.test.ts
+  git add src/
+  run bash "$SCRIPT" "$TMP/msg-subject"
+  [ "$status" -eq 0 ]
+}
+
+@test "allows: chore(plan-only) — plan-only commit uses chore(plans):" {
+  mkdir -p "$TMP/repo" && cd "$TMP/repo" && git init -q && git config user.email t@t && git config user.name t
+  printf 'chore(plans): stage t001434 for execution [T001434]\n' > "$TMP/msg-subject"
+  mkdir -p openspec/changes/t001434 && printf 'plan' > openspec/changes/t001434/tasks.md
+  git add openspec/
+  run bash "$SCRIPT" "$TMP/msg-subject"
+  [ "$status" -eq 0 ]
+}
+
+@test "allows: docs: readme update is not an implementation claim" {
+  mkdir -p "$TMP/repo" && cd "$TMP/repo" && git init -q && git config user.email t@t && git config user.name t
+  printf 'docs: update README\n' > "$TMP/msg-subject"
+  printf 'hello' > README.md
+  git add README.md
+  run bash "$SCRIPT" "$TMP/msg-subject"
+  [ "$status" -eq 0 ]
+}
+
+@test "allows: ci: workflow bump is not an implementation claim" {
+  mkdir -p "$TMP/repo" && cd "$TMP/repo" && git init -q && git config user.email t@t && git config user.name t
+  printf 'ci: bump action versions\n' > "$TMP/msg-subject"
+  mkdir -p .github/workflows && printf 'on: push' > .github/workflows/ci.yml
+  git add .github/
+  run bash "$SCRIPT" "$TMP/msg-subject"
+  [ "$status" -eq 0 ]
+}
+
+@test "allows: fix(kustomize) — yaml/manifest counts as production code" {
+  mkdir -p "$TMP/repo" && cd "$TMP/repo" && git init -q && git config user.email t@t && git config user.name t
+  printf 'fix(infra): tweak configmap\n' > "$TMP/msg-subject"
+  mkdir -p k3d && printf 'data:' > k3d/configmap-domains.yaml
+  git add k3d/
+  run bash "$SCRIPT" "$TMP/msg-subject"
+  [ "$status" -eq 0 ]
+}
+
+@test "allows: fix(scope-less) — no-scope implementation title is still fine if real code is staged" {
+  mkdir -p "$TMP/repo" && cd "$TMP/repo" && git init -q && git config user.email t@t && git config user.name t
+  printf 'fix: typo in error message\n' > "$TMP/msg-subject"
+  mkdir -p src && printf 'export const E = 1;' > src/typo.ts
+  git add src/
+  run bash "$SCRIPT" "$TMP/msg-subject"
+  [ "$status" -eq 0 ]
+}
+
+@test "allows: feat!: breaking-change marker still allowed" {
+  mkdir -p "$TMP/repo" && cd "$TMP/repo" && git init -q && git config user.email t@t && git config user.name t
+  printf 'feat(api)!: drop legacy /v1 endpoints\n' > "$TMP/msg-subject"
+  mkdir -p src/api && printf 'export {}' > src/api/v2.ts
+  git add src/
+  run bash "$SCRIPT" "$TMP/msg-subject"
+  [ "$status" -eq 0 ]
+}
+
+# ── 3. Block cases — the T001434 pattern ────────────────────────────────────
+
+@test "blocks: fix(red-only-test) — the T001434 pattern (T001434-mishap)" {
+  mkdir -p "$TMP/repo" && cd "$TMP/repo" && git init -q && git config user.email t@t && git config user.name t
+  printf 'fix(infra): chain loggingMiddleware in middleware.ts via sequence() [T001434]\n' > "$TMP/msg-subject"
+  mkdir -p src && printf 'test' > src/middleware.test.ts
+  git add src/
+  run bash "$SCRIPT" "$TMP/msg-subject"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"T001434 mishap pattern"* ]]
+  [[ "$output" == *"test(red):"* ]]
+  [[ "$output" == *"chore(plan):"* ]]
+}
+
+@test "blocks: fix(plan-only)" {
+  mkdir -p "$TMP/repo" && cd "$TMP/repo" && git init -q && git config user.email t@t && git config user.name t
+  printf 'fix(infra): chain middleware\n' > "$TMP/msg-subject"
+  mkdir -p openspec/changes/x && printf 'plan' > openspec/changes/x/tasks.md
+  git add openspec/
+  run bash "$SCRIPT" "$TMP/msg-subject"
+  [ "$status" -ne 0 ]
+}
+
+@test "blocks: fix(plan-and-test combined)" {
+  mkdir -p "$TMP/repo" && cd "$TMP/repo" && git init -q && git config user.email t@t && git config user.name t
+  printf 'fix(infra): chain middleware\n' > "$TMP/msg-subject"
+  mkdir -p src && printf 'test' > src/middleware.test.ts
+  mkdir -p openspec/changes/x && printf 'plan' > openspec/changes/x/tasks.md
+  git add src/ openspec/
+  run bash "$SCRIPT" "$TMP/msg-subject"
+  [ "$status" -ne 0 ]
+}
+
+@test "blocks: fix(spec-only — openspec/specs)" {
+  mkdir -p "$TMP/repo" && cd "$TMP/repo" && git init -q && git config user.email t@t && git config user.name t
+  printf 'fix(infra): chain middleware\n' > "$TMP/msg-subject"
+  mkdir -p openspec/specs && printf 'spec' > openspec/specs/centralized-logging.md
+  git add openspec/specs/
+  run bash "$SCRIPT" "$TMP/msg-subject"
+  [ "$status" -ne 0 ]
+}
+
+@test "blocks: feat(plan-only)" {
+  mkdir -p "$TMP/repo" && cd "$TMP/repo" && git init -q && git config user.email t@t && git config user.name t
+  printf 'feat(infra): add logging chain\n' > "$TMP/msg-subject"
+  mkdir -p openspec/changes/x && printf 'p' > openspec/changes/x/tasks.md && printf 'p' > openspec/changes/x/proposal.md
+  git add openspec/changes/x/
+  run bash "$SCRIPT" "$TMP/msg-subject"
+  [ "$status" -ne 0 ]
+}
+
+@test "blocks: refactor(plan-only)" {
+  mkdir -p "$TMP/repo" && cd "$TMP/repo" && git init -q && git config user.email t@t && git config user.name t
+  printf 'refactor(scripts): consolidate guards\n' > "$TMP/msg-subject"
+  mkdir -p openspec/changes/cleanup && printf 'p' > openspec/changes/cleanup/tasks.md
+  git add openspec/changes/cleanup/
+  run bash "$SCRIPT" "$TMP/msg-subject"
+  [ "$status" -ne 0 ]
+}
+
+@test "blocks: perf(plan-only)" {
+  mkdir -p "$TMP/repo" && cd "$TMP/repo" && git init -q && git config user.email t@t && git config user.name t
+  printf 'perf(db): index tickets table\n' > "$TMP/msg-subject"
+  mkdir -p openspec/changes/perf && printf 'p' > openspec/changes/perf/tasks.md
+  git add openspec/changes/perf/
+  run bash "$SCRIPT" "$TMP/msg-subject"
+  [ "$status" -ne 0 ]
+}
+
+@test "blocks: doc-only files (superpowers specs) with implementation title" {
+  mkdir -p "$TMP/repo" && cd "$TMP/repo" && git init -q && git config user.email t@t && git config user.name t
+  printf 'fix(infra): chain middleware\n' > "$TMP/msg-subject"
+  mkdir -p docs/superpowers/specs && printf 'spec' > docs/superpowers/specs/2026-07-02-design.md
+  git add docs/superpowers/specs/
+  run bash "$SCRIPT" "$TMP/msg-subject"
+  [ "$status" -ne 0 ]
+}
+
+# ── 4. Bypass semantics ──────────────────────────────────────────────────────
+
+@test "SKIP_COMMIT_VS_DIFF=1 bypasses the check (commit-msg hook)" {
+  mkdir -p "$TMP/repo" && cd "$TMP/repo" && git init -q && git config user.email t@t && git config user.name t
+  printf 'fix(infra): should be allowed with SKIP_COMMIT_VS_DIFF=1\n' > "$TMP/msg-subject"
+  mkdir -p src && printf 'test' > src/middleware.test.ts
+  git add src/
+  SKIP_COMMIT_VS_DIFF=1 run bash "$HOOK" "$TMP/msg-subject"
+  [ "$status" -eq 0 ]
+}
+
+# ── 5. Self-test ─────────────────────────────────────────────────────────────
+
+@test "--self-test passes (15+ cases)" {
+  run bash "$SCRIPT" --self-test
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"self-test passed"* ]]
+}


### PR DESCRIPTION
## Was
Schließt den T001434-Prozess-Gap: ein dev-flow-plan Stage-Commit trug den Titel 'fix(infra): chain loggingMiddleware...' aber der Diff enthielt nur den RED-Integrationstest + Plan-Artefakte. Der nachfolgende dev-flow-execute-Implementer vertraute dem Titel und übersprang den eigentlichen Fix; der Bug landete in einem Follow-up-Commit.

## Warum
* **T001434 Lehre:** Plan-Stage-Commits dürfen keine 'fix/feat/refactor/perf'-Titel tragen, wenn der Diff keinen Production-Code enthält.
* **dev-flow-plan SKILL.md** empfahl im RED-Test-Pfad explizit 'fix(<scope>):' — der Planer-Subagent befolgte das brav. Die Konvention ist die Falle.
* **Belt-and-Suspenders:** Skill-Korrektur + maschineller Guard (commit-msg-Hook + CI-Spiegel) fängt jede zukünftige SKILL-Drift.

## Was ändert sich
* `scripts/check-commit-vs-diff.sh` — blockierender Guard, der Commits mit Implementation-Type ablehnt, deren Staged-Diff nur Test/Spec/Plan-Dateien enthält. Verweist auf 'test(red):' bzw. 'chore(plan):' als korrekte Präfixe.
* `.githooks/commit-msg` — neuer Hook, der das Skript aufruft. Bypass: `SKIP_COMMIT_VS_DIFF=1` (Notfall).
* `Taskfile.yml secrets:install-hooks` — chmod'ed jetzt alle Hooks.
* `.claude/skills/dev-flow-plan/SKILL.md` Fix-Pfad Schritt 5: 'fix(<scope>):' → 'chore(plans):' (analog zum Feature-Pfad).
* `openspec/specs/ci-cd.md` — neue Requirement 'commit-vs-diff-consistency-guard' mit 4 Scenarios.
* `.github/workflows/ci.yml` — CI-Spiegel im commit-lint-Job fängt Hook-Bypasses.
* `tests/unit/check-commit-vs-diff.bats` — 21 Unit-Tests (allow + block + bypass + self-test).
* `tests/spec/ci-cd.bats` — 7 G-COMMIT-VS-DIFF Spec-Tests.

## Verifikation
* `./tests/unit/lib/bats-core/bin/bats tests/unit/check-commit-vs-diff.bats` → 21/21 ok
* `./tests/unit/lib/bats-core/bin/bats tests/spec/ci-cd.bats` → 32/32 ok (alle bestehenden + 7 neue)
* `bash scripts/check-commit-vs-diff.sh --self-test` → 17/17 ok
* `task quality:check` → keine neuen Violations
* `pre-push` Hook → clean (validate-commit-msg OK, freshness OK)
* `preflight-pr-scope.sh` → scripts ✓

## Bypass
`SKIP_COMMIT_VS_DIFF=1 git commit ...` — Notfall-Escape-Hatch, wird vom CI-Spiegel aufgefangen (commit-lint Job lehnt den PR ab, wenn die commit-vs-diff-Konsistenz im Range origin/main..HEAD verletzt ist).

## Related
* Mishap: T001434-Mishap-Bundle (in ticket-mcp Mishap-Buffer)
* SSOT: `openspec/specs/ci-cd.md#commit-vs-diff-consistency-guard`