### PR TITLE
chore(infra): add resources.requests to 4 containers [T001437]

### DIFF
--- a/docs/code-quality/loc-budget.json
+++ b/docs/code-quality/loc-budget.json
@@ -1,8 +1,8 @@
 {
-  "total_lines": 527459,
+  "total_lines": 528177,
   "file_count": 4000,
-  "commit": "181bd66a",
-  "measured_at": "2026-07-02T11:07:16.974Z",
+  "commit": "f36624132",
+  "measured_at": "2026-07-02T11:24:07.117Z",
   "thresholds": {
     "warn_pct": 5,
     "fail_pct": 15,

--- a/docs/generated/blast-radius.md
+++ b/docs/generated/blast-radius.md
@@ -1,6 +1,6 @@
 # Blast-Radius-Report
-> Generated: 2026-07-01T13:41:44.985Z
-> Nodes: 88 | Edges: 1674 | Isolated: 4
+> Generated: 2026-07-02T11:24:05.995Z
+> Nodes: 86 | Edges: 1671 | Isolated: 5
 
 ## Ranking (transitive Abhängige)
 
@@ -73,16 +73,15 @@
 | 65 | keycloak | 1 | 50 | 1 |
 | 66 | tracking | 1 | 50 | 1 |
 | 67 | docuseal | 1 | 50 | 1 |
-| 68 | loki | 3 | 3 | 3 |
-| 69 | docs | 1 | 1 | 1 |
-| 70 | downloads | 1 | 1 | 1 |
-| 71 | einvoice-sidecar | 1 | 1 | 1 |
-| 72 | mediaviewer-widget | 1 | 1 | 1 |
-| 73 | monitoring-kube-state-metrics | 1 | 1 | 1 |
-| 74 | monitoring-operator | 1 | 1 | 1 |
-| 75 | nextcloud-redis | 1 | 1 | 1 |
-| 76 | sealed-secrets-controller | 1 | 1 | 1 |
-| 77 | whisper | 1 | 1 | 1 |
+| 68 | docs | 1 | 1 | 1 |
+| 69 | downloads | 1 | 1 | 1 |
+| 70 | einvoice-sidecar | 1 | 1 | 1 |
+| 71 | mediaviewer-widget | 1 | 1 | 1 |
+| 72 | monitoring-kube-state-metrics | 1 | 1 | 1 |
+| 73 | monitoring-operator | 1 | 1 | 1 |
+| 74 | nextcloud-redis | 1 | 1 | 1 |
+| 75 | sealed-secrets-controller | 1 | 1 | 1 |
+| 76 | whisper | 1 | 1 | 1 |
 
 ## Details
 
@@ -420,11 +419,6 @@
 **Direkte Abhängige:** 1 — shared-db
 **Transitive Abhängige:** 50 — admin-actions-cleanup, admin-actions-prune, billing-dunning-detection, brett, db-backup, ddns-updater, dev-db-refresh, knowledge-ingest-bugs, knowledge-ingest-markdown, knowledge-ingest-prs, knowledge-reindex-all, livekit-egress, livekit-ingress, livekit-server, monthly-billing, nextcloud, notify-unread, oauth2-proxy-brett, oauth2-proxy-comfy, oauth2-proxy-dev, oauth2-proxy-docs, oauth2-proxy-downloads, oauth2-proxy-mailpit, oauth2-proxy-mediaviewer, oauth2-proxy-recovery, oauth2-proxy-rustdesk-web, oauth2-proxy-studio, oauth2-proxy-traefik, oauth2-proxy-videovault, pocket-id, pvc-backup, scheduled-publish, sessions-purge, shared-db, shared-db-dev, shared-db-dev-lb, shared-db-staging, spreed-signaling, studio-server, systemtest-cleanup, systemtest-outbox, systemtest-purge-all, talk-recording, talk-transcriber, tests-results-retention, traefik, vaultwarden, videovault, website, whiteboard
 **Upstream (In-Degree):** 1
-
-### loki
-**Direkte Abhängige:** 3 — loki, loki-headless, loki-memberlist
-**Transitive Abhängige:** 3 — loki, loki-headless, loki-memberlist
-**Upstream (In-Degree):** 3
 
 ### docs
 **Direkte Abhängige:** 1 — docs

--- a/docs/generated/graph.json
+++ b/docs/generated/graph.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-01T13:41:44.872Z",
+  "generatedAt": "2026-07-02T11:24:05.888Z",
   "nodes": [
     {
       "id": "admin-actions-cleanup",
@@ -492,18 +492,6 @@
       "namespace": "mentolder",
       "type": "Service",
       "name": "shared-db-dev-lb"
-    },
-    {
-      "id": "loki-memberlist",
-      "namespace": "mentolder",
-      "type": "Service",
-      "name": "loki-memberlist"
-    },
-    {
-      "id": "loki-headless",
-      "namespace": "mentolder",
-      "type": "Service",
-      "name": "loki-headless"
     },
     {
       "id": "keycloak",
@@ -1410,24 +1398,6 @@
     {
       "from": "monitoring-operator",
       "to": "monitoring-operator",
-      "via": "selector",
-      "kind": "selector"
-    },
-    {
-      "from": "loki-memberlist",
-      "to": "loki",
-      "via": "selector",
-      "kind": "selector"
-    },
-    {
-      "from": "loki-headless",
-      "to": "loki",
-      "via": "selector",
-      "kind": "selector"
-    },
-    {
-      "from": "loki",
-      "to": "loki",
       "via": "selector",
       "kind": "selector"
     },

--- a/k3d/dev-cluster/kube-vip-ds.yaml
+++ b/k3d/dev-cluster/kube-vip-ds.yaml
@@ -54,6 +54,13 @@ spec:
         image: ghcr.io/kube-vip/kube-vip:v0.8.7@sha256:32829cc6f8630eba4e1b5e4df5bcbc34c767e70703d26e64a0f7317951c7b517
         imagePullPolicy: IfNotPresent
         name: kube-vip
+        resources:
+          requests:
+            cpu: 50m
+            memory: 64Mi
+          limits:
+            cpu: 100m
+            memory: 128Mi
         securityContext:
           capabilities:
             add:

--- a/k3d/dev-stack/shared-db-dev.yaml
+++ b/k3d/dev-stack/shared-db-dev.yaml
@@ -95,6 +95,13 @@ spec:
       containers:
         - name: init
           image: pgvector/pgvector:0.8.0-pg16@sha256:a132765ec351c65111b5b675928a3a0515a466a40f97277329db8b8209ad8bc9
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
           env:
             - name: PGHOST
               value: shared-db-dev

--- a/k3d/monitoring/kustomization.yaml
+++ b/k3d/monitoring/kustomization.yaml
@@ -21,3 +21,11 @@ resources:
   - promtail-rendered.yaml
   - loki-grafana-datasource.yaml
   - grafana-dashboards
+
+# Adds resources.requests/limits to the loki-sc-rules sidecar that the
+# pre-rendered Helm output (loki-rendered.yaml) does not set. Strategic-merge
+# patches the StatefulSet `loki` and merges the resources block into the
+# existing loki-sc-rules container without touching the rendered YAML (which
+# would be overwritten on the next `task loki:render`).
+patches:
+  - path: loki-sc-rules-resources-patch.yaml

--- a/k3d/monitoring/loki-sc-rules-resources-patch.yaml
+++ b/k3d/monitoring/loki-sc-rules-resources-patch.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: loki
+  namespace: monitoring
+spec:
+  template:
+    spec:
+      containers:
+        - name: loki-sc-rules
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi

--- a/k3d/staging-stack/shared-db-staging.yaml
+++ b/k3d/staging-stack/shared-db-staging.yaml
@@ -88,6 +88,13 @@ spec:
       containers:
         - name: init
           image: pgvector/pgvector:0.8.0-pg16@sha256:a132765ec351c65111b5b675928a3a0515a466a40f97277329db8b8209ad8bc9
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
           env:
             - name: PGHOST
               value: shared-db-staging


### PR DESCRIPTION
## Summary
Addresses the maintenance findings from the automated health check on 2026-07-02 (GitHub issue #2482, ticket T001437): 4 containers in the dev/staging/monitoring kustomize overlays were missing `resources.requests` (and `resources.limits`), preventing the scheduler from making informed placement decisions and excluding them from `LimitRange` enforcement.

- `k3d/dev-cluster/kube-vip-ds.yaml` — `kube-vip` container (DaemonSet)
- `k3d/dev-stack/shared-db-dev.yaml` — `init` container (Job)
- `k3d/staging-stack/shared-db-staging.yaml` — `init` container (Job)
- `k3d/monitoring/loki-sc-rules` sidecar (StatefulSet) — patched via a Kustomize strategic-merge patch instead of editing the pre-rendered Helm output (`loki-rendered.yaml`), so the values survive the next `task loki:render`

Values are conservative defaults based on each workload's profile. No behavior change at runtime — scheduler placement is the only observable effect.

## Test Plan
- [x] `task workspace:validate` — all overlays build cleanly
- [x] `task monitoring:validate` — `k3d/monitoring` + `prod-fleet/{mentolder,korczewski}` all build
- [x] `task test:code-quality` — 52/52 tests pass, no new violations
- [x] `task test:changed` — passes
- [x] `task freshness:regenerate` + freshness artifacts committed

## References
- GitHub issue #2482
- Ticket T001437

🤖 [T001437]