### PR TITLE
feat(factory): deterministic devflow phase telemetry + merge gate + Versand lane [T001444]

### DIFF
--- a/.claude/skills/dev-flow-execute/SKILL.md
+++ b/.claude/skills/dev-flow-execute/SKILL.md
@@ -174,6 +174,8 @@ SLUG=$(basename "$PLAN_FILE" .md)
 ./scripts/ticket.sh phase "$TICKET_ID" plan entered --driver devflow --detail "Plan: $SLUG · $TICKET_ID" || true
 ```
 
+> `plan`/`implement`/`deploy`-Events entstehen jetzt automatisch aus den Statuswechseln (`update-status`/`stage-plan`); Doppel-Emission ist dank Dedup harmlos.
+
 Falls der Plan die berührten Dateien kennt, registriere sie für die Conflict-Gate (parallele Sessions sehen die Kollision via `agent-collision.sh`) — **MCP-first**:
 
 > `mcp__ticket-mcp__set_touched_files({ id: "$TICKET_ID", files: "<comma-separated-paths>" })`
@@ -277,7 +279,7 @@ bash scripts/devflow-build-loop.sh "$TICKET_ID"
 
 Rufe das Skill **`verification-before-completion`** auf, um die Verifikation strukturiert zu steuern.
 
-Phasen-Telemetrie (best-effort) — **MCP-first** (`ticket-mcp`):
+Phasen-Telemetrie (PFLICHT für verify — das Gate erzwingt sie) — **MCP-first** (`ticket-mcp`):
 
 > `mcp__ticket-mcp__record_phase_event({ id: "$TICKET_ID", phase: "implement", state: "done", driver: "devflow", detail: "Implementierung fertig" })`
 > `mcp__ticket-mcp__record_phase_event({ id: "$TICKET_ID", phase: "verify", state: "entered", driver: "devflow", detail: "task test:changed + freshness" })`
@@ -289,7 +291,9 @@ Nach grünen Tests — **MCP-first**:
 
 > `mcp__ticket-mcp__record_phase_event({ id: "$TICKET_ID", phase: "verify", state: "done", driver: "devflow", detail: "Tests grün · freshness OK" })`
 
-Fallback (ticket-mcp nicht erreichbar; Telemetrie ist best-effort und darf den Flow nie stoppen):
+> `plan`/`implement`/`deploy`-Events entstehen jetzt automatisch aus den Statuswechseln (`update-status`/`stage-plan`); Doppel-Emission ist dank Dedup harmlos.
+
+Fallback (ticket-mcp nicht erreichbar; die `verify`-Zeilen bleiben Pflicht — das Gate in Schritt 6 erzwingt `verify:done`):
 
 ```bash
 ./scripts/ticket.sh phase "$TICKET_ID" implement done --driver devflow --detail "Implementierung fertig" || true
@@ -360,6 +364,14 @@ Seit T001415 (Finding 2) beendet sich `devflow-ci-watch.sh` zusätzlich mit Exit
 
 > **Hinweis:** `E2E PR` ist kein required check (T000722) — blockiert den Merge NICHT.
 > Die Required-Check-Liste lebt in [ci-fix-loop](file:///home/patrick/Bachelorprojekt/.claude/skills/references/ci-fix-loop.md).
+
+**Fail-closed Phase-Chain-Gate (T001444) — PFLICHT vor dem Merge, KEIN `|| true`:**
+Prüft, dass `plan:done`, `implement:entered` und `verify:done` vorliegen. Bei FAIL
+zuerst backfillen (insb. `verify done` nach grünem `task test:changed`), dann mergen.
+
+```bash
+./scripts/ticket.sh assert-phase-chain --id "$TICKET_ID"
+```
 
 ```bash
 # Merge PR aus dem Haupt-Repo, um Konflikte zu vermeiden
@@ -432,7 +444,9 @@ Abschluss-Lifecycle — **MCP-first** (`ticket-mcp`). Merge = Abschluss (T001092
 > `mcp__ticket-mcp__record_phase_event({ id: "$TICKET_ID", phase: "deploy", state: "done", driver: "devflow", detail: "PR #$PR_NUM merged · done/shipped" })`
 > `mcp__ticket-mcp__add_comment({ id: "$TICKET_ID", body: "PR #$PR_NUM merged. Plan archived to tickets.ticket_plans." })`
 
-Fallback (ticket-mcp nicht erreichbar; die Phasen-Events sind best-effort und nie blockierend):
+> `plan`/`implement`/`deploy`-Events entstehen jetzt automatisch aus den Statuswechseln (`update-status`/`stage-plan`); Doppel-Emission ist dank Dedup harmlos. Das `verify:done`-Event bleibt Pflicht (Merge-Gate).
+
+Fallback (ticket-mcp nicht erreichbar; die `verify`-Zeile bleibt Pflicht, der Rest ist idempotent):
 
 ```bash
 ./scripts/ticket.sh add-pr-link --id "$TICKET_ID" --pr "$PR_NUM"

--- a/docs/code-quality/loc-budget.json
+++ b/docs/code-quality/loc-budget.json
@@ -1,8 +1,8 @@
 {
-  "total_lines": 527505,
-  "file_count": 4001,
-  "commit": "d9b2fda5",
-  "measured_at": "2026-07-02T11:30:25.425Z",
+  "total_lines": 528454,
+  "file_count": 4002,
+  "commit": "2ef06fbcd",
+  "measured_at": "2026-07-02T12:53:26.777Z",
   "thresholds": {
     "warn_pct": 5,
     "fail_pct": 15,

--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -2744,7 +2744,7 @@
       "id": "scripts-infra",
       "name": "Operational + build scripts",
       "owner_agent": "bachelorprojekt-infra",
-      "file_count": 471,
+      "file_count": 472,
       "files": [
         "scripts/README.md",
         "scripts/add-whiteboard-library.py",
@@ -3203,6 +3203,7 @@
         "scripts/vda/release-notes.sh",
         "scripts/vda/ticket.sh",
         "scripts/vda/ticket/_ticket-core.sh",
+        "scripts/vda/ticket/assert-phase-chain.sh",
         "scripts/vda/ticket/backfill-id.sh",
         "scripts/vda/ticket/create.sh",
         "scripts/vda/ticket/enqueue.sh",

--- a/docs/superpowers/specs/2026-07-02-devflow-phase-telemetry-design.md
+++ b/docs/superpowers/specs/2026-07-02-devflow-phase-telemetry-design.md
@@ -1,0 +1,158 @@
+---
+ticket_id: T001444
+plan_ref: openspec/changes/devflow-phase-telemetry/tasks.md
+status: active
+date: 2026-07-02
+---
+
+# Design: Deterministische Devflow-Phase-Telemetrie + Checkpoint-Gate + Versand-Lane-Klärung
+
+- Datum: 2026-07-02
+- Slug: `devflow-phase-telemetry`
+- Modus: autonomer Lauf (Goal-Hook) — Entscheidungen dokumentiert statt interaktiv erfragt
+
+## Problem
+
+dev-flow-execute-Läufe erscheinen nicht zuverlässig auf dem Factory Floor (`/admin/pipeline`)
+und hinterlassen keine vollständigen Analytics-Spuren. Befund (DB, 2026-07-02):
+
+- Die Mehrzahl der jüngst per devflow abgeschlossenen Tickets (`done`) hat **null**
+  Zeilen in `tickets.factory_phase_events` (u. a. T001437, T001441, T001394, T001390,
+  T001435, T001438).
+- Der Rest hat fragmentierte Ketten (nur `deploy`, nur `plan+deploy`); `deploy entered`
+  existiert 153×, `deploy done` nur 73×.
+- `getHall()` (`website/src/lib/factory-floor.ts:177-181`) zeigt slot-lose Tickets nur,
+  wenn ≥1 `driver='devflow'`-Event existiert → Tickets ohne Events sind auf dem Floor
+  **unsichtbar**, PhaseStepper/Heatmap/Timeline bleiben leer.
+
+**Root Cause:** Die Telemetrie ist in `.claude/skills/dev-flow-execute/SKILL.md` als
+„Live-Floor-Telemetrie (best-effort)" mit `|| true` formuliert. Instruktions-basierte
+Telemetrie wird von LLM-Agents unzuverlässig befolgt. Zusätzlich unklar: die
+„Versand"-Spalte (`ShippedColumn.svelte`) trägt ein hartkodiertes Heading, das vom
+SSOT-Label („Fertig", `pipeline-order.ts`) abweicht, und ihre Semantik (Merge =
+Abschluss, Deploy entkoppelt, ADR-005) ist im UI nicht erklärt.
+
+## Ziele
+
+1. Jeder dev-flow-execute-Lauf ist ohne Agent-Disziplin auf dem Floor sichtbar
+   (vollständige Phase-Kette scout→deploy).
+2. Fail-closed Checkpoint: vor PR-Merge wird die Phase-Kette maschinell geprüft.
+3. „Versand"-Lane: SSOT-Label und UI-Heading identisch, Semantik im UI erklärt.
+
+Nicht-Ziele: neue Phasen/States/Tabellen; Go-MCP-Server-Änderungen; CI-seitiges
+DB-Gate (Runner hat keinen Cluster-DB-Zugriff).
+
+## Entscheidung A — Auto-Emission als Seiteneffekt (statt Instruktion)
+
+Alle Status-Transitions laufen durch genau zwei sourced Module —
+`scripts/vda/ticket/update-status.sh` (CLI **und** MCP `transition_status`, das intern
+`ticket.sh update-status` aufruft) und `scripts/vda/ticket/stage-plan.sh`. Dort werden
+Phase-Events deterministisch mit-emittiert:
+
+| Auslöser | Auto-Event(s) | Begründung |
+|---|---|---|
+| `stage-plan` | `scout done`, `design done`, `plan done` | Ein gestagter Plan impliziert durchlaufene Exploration/Design/Plan-Phase (dev-flow-plan) |
+| Status → `in_progress` | `implement entered` | Implementierung beginnt |
+| Status → `in_review` | `implement done` | PR offen |
+| Status → `qa_review` | `verify entered` | historischer/manueller Pfad |
+| Status → `done` | `deploy done` | Merge = Abschluss (ADR-005) |
+| Status → `blocked` | `<letzte Phase> blocked` (SQL-Lookup, Fallback `implement`) | Attention-Strip-Telemetrie |
+
+Eigenschaften:
+
+- **Idempotent/Dedup:** kein Insert, wenn für das Ticket bereits ein Event mit gleichem
+  `(phase, state)` existiert. Factory-Läufe (pipeline.js emittiert weiterhin selbst,
+  vor dem Statuswechsel, mit reicheren Details) bekommen dadurch keine Duplikate.
+- **Driver-Attribution:** `TICKET_PHASE_DRIVER` env, Default `devflow`;
+  `scripts/factory/pipeline.js` exportiert `factory` (greift nur, falls Dedup je nicht
+  greift — Sicherheitsnetz).
+- **Best-effort gegenüber DB-Fehlern:** der Statuswechsel selbst darf nie an der
+  Telemetrie scheitern (Insert im selben `_exec_sql`-Fluss, aber Fehler nicht fatal).
+- **Detail-Konvention:** `detail = 'auto: <auslöser>'`, damit Auto-Events in Timeline
+  und Observability von hand-emittierten unterscheidbar sind.
+- Implementierung als SQL im selben psql-Roundtrip (CTE/zweites Statement), kein
+  zusätzlicher `kubectl exec`.
+
+Verworfen: DB-Trigger (keine Driver-Attribution, DDL-/Migrationsaufwand); nur
+Skill-Prosa verschärfen (nachweislich wirkungslos).
+
+## Entscheidung B — Fail-closed Checkpoint-Gate
+
+Neues sourced Modul `scripts/vda/ticket/assert-phase-chain.sh`, Dispatcher-Eintrag
+`ticket.sh assert-phase-chain --id T…` (Muster wie `update-status.sh`):
+
+- Prüft, dass für das Ticket Events `plan:done`, `implement:entered` und `verify:done`
+  existieren (beliebiger Driver).
+- Bei Lücken: Exit 1 + Ausgabe der exakten Backfill-Kommandos
+  (`./scripts/ticket.sh phase <id> <phase> <state> --driver devflow --detail …`).
+- `--json`-Flag für maschinelle Auswertung (`{"ok":bool,"missing":[…]}`).
+
+Skill-Änderungen `.claude/skills/dev-flow-execute/SKILL.md`:
+
+- Schritt 6.5 (vor `gh pr merge`): PFLICHT-Aufruf `assert-phase-chain` **ohne**
+  `|| true`; bei FAIL erst backfillen (insb. `verify done` nach grünem
+  `task test:changed`), dann mergen.
+- `verify entered`/`verify done`-Emission bleibt Aufgabe des Agenten (nicht aus Status
+  ableitbar), wird aber von „best-effort" auf Pflicht umformuliert; das Gate erzwingt
+  sie nachweislich.
+- Die übrigen Telemetrie-Blöcke verweisen darauf, dass plan/implement/deploy jetzt
+  automatisch aus Statuswechseln entstehen (Doppel-Emission ist dank Dedup harmlos).
+
+Verworfen: CI-Gate (kein DB-Zugriff vom Runner); neues Go-MCP-Tool
+(Rebuild/Redeploy-Aufwand, YAGNI — `record_phase_event` existiert bereits, das Gate
+ist shell-first; MCP-Pendant als mögliches Follow-up).
+
+## Entscheidung C — Versand-Lane klären
+
+- `website/src/lib/tickets/pipeline-order.ts`: Label der `shipped`-Lane von „Fertig" →
+  **„Versand"** (konsistent mit Fabrikhallen-Metapher: Planung → Kommissioniert →
+  Laderampe → In Arbeit → QS-Abnahme → Versand).
+- `website/src/components/factory/ShippedColumn.svelte`: Heading importiert das Label
+  aus dem SSOT (kein Hardcode mehr) und erhält einen Untertitel:
+  „Gemergt nach main · Prod-Deploy entkoppelt". Empty-State-Text bleibt
+  „Noch nichts versandt.".
+- Damit ist maschinenlesbar und im UI erklärt: **Versand = Ticket gemergt
+  (status `done`), nicht notwendigerweise prod-live** (ADR-005 Merge = Abschluss).
+
+## Datenfluss (Ziel)
+
+```
+stage-plan / update-status (CLI + MCP transition_status)
+        │  Auto-Emission (dedup, TICKET_PHASE_DRIVER)
+        ▼
+tickets.factory_phase_events ──► getHall()/getTicketDetail() ──► FactoryFloor (SSE-Refetch)
+        │                        v_timeline, Heatmap, Observability
+        ▲
+dev-flow-execute: verify entered/done (Pflicht) + assert-phase-chain-Gate vor Merge
+```
+
+## Fehlerbehandlung
+
+- Auto-Emission scheitert (DB weg): Statuswechsel bleibt erfolgreich, Warnung auf
+  stderr — Verfügbarkeit des Ticket-Flows > Telemetrie.
+- Gate nicht ausführbar (DB weg): Exit ≠ 0 → Merge blockiert; Agent eskaliert statt
+  still zu mergen (fail-closed per Definition).
+- Doppel-Emission (Factory + Auto): durch Dedup ausgeschlossen.
+
+## Tests
+
+- BATS in `tests/spec/software-factory.bats`: Auto-Emissions-Mapping (Status →
+  Event), Dedup-Verhalten, `assert-phase-chain` PASS/FAIL/`--json`, Backfill-Hinweise.
+  SQL-Aufrufe gemockt nach bestehendem Muster der ticket.sh-Tests.
+- Bestehende Svelte-/DAL-Tests: Label-Änderung `shipped` → „Versand" nachziehen
+  (`factory-floor.test.ts`, e2e-Selektoren nutzen `data-testid`, nicht das Label).
+- Manuelle Verifikation: ein Ticket per `stage-plan` + `update-status` durchschalten
+  und die Kette in `tickets.factory_phase_events` + `/admin/pipeline` prüfen.
+
+## Betroffene Dateien
+
+| Datei | Zeilen (Ist) | S1-Anmerkung |
+|---|---|---|
+| `scripts/vda/ticket/update-status.sh` | 44 | weit unter .sh-Limit 500 |
+| `scripts/vda/ticket/stage-plan.sh` | 36 | dito |
+| `scripts/vda/ticket/assert-phase-chain.sh` | neu | klein halten (<120) |
+| `scripts/ticket.sh` | 852 (>Limit 500, in s1.ignore laut gates.yaml) | nur ~4 Dispatcher-Zeilen; keine Netto-Vergrößerung darüber hinaus |
+| `.claude/skills/dev-flow-execute/SKILL.md` | 569 | Doku, kein Code-Ratchet |
+| `website/src/lib/tickets/pipeline-order.ts` | 45 | Label-Änderung, ±0 |
+| `website/src/components/factory/ShippedColumn.svelte` | 58 | Import + Untertitel, +~5 |
+| `tests/spec/software-factory.bats` | 2966 | neue @tests |

--- a/openspec/changes/devflow-phase-telemetry/intel.json
+++ b/openspec/changes/devflow-phase-telemetry/intel.json
@@ -1,0 +1,138 @@
+{
+  "meta": {
+    "slug": "devflow-phase-telemetry",
+    "ticket_id": "T001444",
+    "generated_from": "main@9df03a0d3",
+    "domains": ["software-factory", "dev-tooling", "website"],
+    "intel_sources": ["mcp-postgres", "grep", "Read", "baseline.json"]
+  },
+  "impact_files": [
+    {"path": "scripts/vda/ticket/update-status.sh", "language": "bash", "loc": 44, "s1_limit": 500, "s1_baseline": null, "s1_budget": 456},
+    {"path": "scripts/vda/ticket/stage-plan.sh", "language": "bash", "loc": 36, "s1_limit": 500, "s1_baseline": null, "s1_budget": 464},
+    {"path": "scripts/vda/ticket/assert-phase-chain.sh", "language": "bash", "loc": 0, "s1_limit": 500, "s1_baseline": null, "s1_budget": 500},
+    {"path": "scripts/ticket.sh", "language": "bash", "loc": 852, "s1_limit": 500, "s1_baseline": null, "s1_budget": -352},
+    {"path": "website/src/lib/tickets/pipeline-order.ts", "language": "typescript", "loc": 45, "s1_limit": 600, "s1_baseline": null, "s1_budget": 555},
+    {"path": "website/src/components/factory/ShippedColumn.svelte", "language": "svelte", "loc": 58, "s1_limit": 500, "s1_baseline": null, "s1_budget": 442},
+    {"path": ".claude/skills/dev-flow-execute/SKILL.md", "language": "markdown", "loc": 569, "s1_limit": 0, "s1_baseline": null, "s1_budget": 0},
+    {"path": "tests/spec/software-factory.bats", "language": "bash", "loc": 2966, "s1_limit": 0, "s1_baseline": null, "s1_budget": 0}
+  ],
+  "symbols": [
+    {
+      "qualified_name": "scripts/ticket.sh:cmd_phase",
+      "kind": "function",
+      "file": "scripts/ticket.sh",
+      "signature": "ticket.sh phase <ext_id> <phase> <state> [--detail \"...\"] [--driver factory|devflow]",
+      "type_text": "phase ∈ {scout,design,plan,implement,verify,deploy}; state ∈ {entered,done,blocked}; INSERT INTO tickets.factory_phase_events (ticket_id, phase, state, detail, driver) SELECT id,... FROM tickets.tickets WHERE external_id=:'ext_id'; validiert VOR _pgpod (FA-SF-48); offline-skip via _ticket_offline_skip",
+      "source": "grep"
+    },
+    {
+      "qualified_name": "scripts/vda/ticket/update-status.sh:main",
+      "kind": "function",
+      "file": "scripts/vda/ticket/update-status.sh",
+      "signature": "main --id <ext_id> --status <status> [--resolution <r>] [--notes <n>]",
+      "type_text": "UPDATE tickets.tickets SET status, resolution, done_at (bei done), pipeline_slot=NULL (bei done/archived), notes append; via _exec_sql \"$pod\" -v ...; pod aus _pgpod; sourced von cmd_update_status (ticket.sh:69-71) mit _ticket_offline_skip Guard davor",
+      "source": "Read"
+    },
+    {
+      "qualified_name": "scripts/vda/ticket/stage-plan.sh:main",
+      "kind": "function",
+      "file": "scripts/vda/ticket/stage-plan.sh",
+      "signature": "main --id <ext_id> --branch <branch> --plan <plan-path>",
+      "type_text": "UPDATE tickets.tickets SET status='plan_staged'; danach idempotenter INSERT eines FACTORY-PLAN-REF Kommentars in tickets.ticket_comments (author_label='dev-flow-plan', visibility='internal')",
+      "source": "Read"
+    },
+    {
+      "qualified_name": "scripts/ticket-mcp/go/internal/tools/lifecycle.go:transition_status",
+      "kind": "mcp-tool",
+      "file": "scripts/ticket-mcp/go/internal/tools/lifecycle.go",
+      "signature": "transition_status({id, brand?, status, resolution?, notes?}) → runner.RunTicket([\"update-status\", \"--id\", id, \"--status\", status, ...])",
+      "type_text": "MCP-Tool shellt zu ticket.sh update-status durch → Auto-Emission in update-status.sh deckt MCP-Pfad automatisch mit ab; KEINE Go-Änderung nötig",
+      "source": "Read"
+    },
+    {
+      "qualified_name": "website/src/lib/tickets/pipeline-order.ts:PIPELINE_LANES",
+      "kind": "const",
+      "file": "website/src/lib/tickets/pipeline-order.ts",
+      "signature": "export const PIPELINE_LANES: readonly { key: string; label: string; statuses: readonly string[]; side?: boolean }[]",
+      "type_text": "shipped-Lane: { key: 'shipped', label: 'Fertig', statuses: ['done'] }; SSOT laut openspec/specs/software-factory.md 'Pipeline-Order SSOT Lane Mapping' — STATUS_BUCKETS byte-identisch abgeleitet (key/status-basiert, Label-Änderung ungefährlich, Tests nachziehen)",
+      "source": "Read"
+    },
+    {
+      "qualified_name": "website/src/components/factory/ShippedColumn.svelte",
+      "kind": "component",
+      "file": "website/src/components/factory/ShippedColumn.svelte",
+      "signature": "<ShippedColumn shipped={ShippedTicket[]}>",
+      "type_text": "Zeile 20: hartkodiertes <h3>Versand</h3>, data-col=\"done\", data-testid=\"floor-shipped\", Empty-Text 'Noch nichts versandt.'; gespeist von getShipped() (factory-floor.ts:202-225, tickets WHERE status='done' + ticket_links kind='pr')",
+      "source": "Read"
+    },
+    {
+      "qualified_name": "website/src/lib/factory-floor.ts:getHall",
+      "kind": "function",
+      "file": "website/src/lib/factory-floor.ts",
+      "signature": "getHall(): DISTINCT ON (ticket_id) latest phase/state aus tickets.factory_phase_events",
+      "type_text": "Zeilen 172-181: slot-lose Tickets nur im Hall wenn ≥1 driver='devflow' Phase-Event existiert — deshalb sind devflow-Tickets ohne Events unsichtbar",
+      "source": "Read"
+    },
+    {
+      "qualified_name": "scripts/factory/pipeline.js:phaseEvent",
+      "kind": "function",
+      "file": "scripts/factory/pipeline.js",
+      "signature": "phaseEvent(ph, state, detail) → ticket.sh phase <id> <ph> <state> --driver factory",
+      "type_text": "Factory emittiert selbst scout/design/plan/implement/verify/deploy VOR den Statuswechseln — Auto-Emission muss dedupen (kein Insert wenn (ticket,phase,state) existiert), sonst Duplikate; pipeline.js soll TICKET_PHASE_DRIVER=factory exportieren",
+      "source": "Read"
+    }
+  ],
+  "call_graph": [
+    {"from": "mcp ticket-mcp transition_status", "to": "scripts/ticket.sh update-status", "mode": "cross_service", "note": "runner.RunTicket shell-out"},
+    {"from": "scripts/ticket.sh cmd_update_status (ticket.sh:69)", "to": "scripts/vda/ticket/update-status.sh:main", "mode": "calls", "note": "source + main; _ticket_offline_skip Guard in ticket.sh:70"},
+    {"from": "scripts/ticket.sh cmd_stage_plan (ticket.sh:263)", "to": "scripts/vda/ticket/stage-plan.sh:main", "mode": "calls"},
+    {"from": "scripts/vda/ticket/update-status.sh", "to": "tickets.factory_phase_events", "mode": "data_flow", "note": "NEU: Auto-Emission"},
+    {"from": "tickets.factory_phase_events", "to": "website/src/lib/factory-floor.ts:getHall/getTicketDetail", "mode": "data_flow"},
+    {"from": "website/src/lib/factory-floor.ts", "to": "website/src/components/FactoryFloor.svelte", "mode": "data_flow", "note": "GET /api/factory-floor + SSE stream 'phase' → refetch"}
+  ],
+  "db_tables": [
+    {
+      "table": "tickets.factory_phase_events",
+      "columns": [
+        {"name": "id", "type": "bigint", "nullable": false},
+        {"name": "ticket_id", "type": "uuid", "nullable": false},
+        {"name": "phase", "type": "text", "nullable": false},
+        {"name": "state", "type": "text", "nullable": false},
+        {"name": "detail", "type": "text", "nullable": true},
+        {"name": "driver", "type": "text", "nullable": false},
+        {"name": "at", "type": "timestamptz", "nullable": false}
+      ],
+      "note": "append-only; CHECK auf phase/state/driver; DDL in website/src/lib/tickets/tables/factory-control.ts"
+    },
+    {
+      "table": "tickets.tickets",
+      "columns": [
+        {"name": "id", "type": "uuid", "nullable": false},
+        {"name": "external_id", "type": "text", "nullable": true},
+        {"name": "status", "type": "text", "nullable": false},
+        {"name": "resolution", "type": "text", "nullable": true},
+        {"name": "done_at", "type": "timestamptz", "nullable": true},
+        {"name": "pipeline_slot", "type": "integer", "nullable": true}
+      ],
+      "note": "Teilmenge relevanter Spalten; Statuswechsel via update-status.sh"
+    }
+  ],
+  "api_contracts": [
+    {
+      "endpoint": "GET /api/factory-floor",
+      "handler": "website/src/pages/api/factory-floor.ts → getFloor() (factory-floor.ts)",
+      "note": "liest tickets, factory_phase_events, v_factory_metrics; keine Änderung nötig — Auto-Emission füllt nur die Quelle"
+    },
+    {
+      "endpoint": "GET /api/factory-floor/stream",
+      "handler": "website/src/pages/api/factory-floor/stream.ts",
+      "note": "SSE 'phase'-Events → UI-Refetch; profitiert automatisch"
+    }
+  ],
+  "external_types": [],
+  "risks": [
+    {"severity": "warn", "note": "codebase-memory/LSP nicht konsultiert (Shell-Skripte + kleine TS/Svelte-Dateien, direkt gelesen); Symbole stammen aus Read/grep mit Zeilenreferenzen"},
+    {"severity": "warn", "note": "scripts/ticket.sh ist mit 852 LOC über dem .sh-Limit 500 (laut gates.yaml in s1.ignore) — Dispatcher nur um die minimalen assert-phase-chain-Zeilen erweitern (sourced-Modul-Muster), keine sonstige Netto-Vergrößerung"},
+    {"severity": "info", "note": "BATS-Tests für ticket.sh mocken kubectl/_pgpod nach bestehendem Muster in tests/spec/software-factory.bats (FA-SF-48: Arg-Validierung vor _pgpod)"}
+  ]
+}

--- a/openspec/changes/devflow-phase-telemetry/proposal.md
+++ b/openspec/changes/devflow-phase-telemetry/proposal.md
@@ -1,0 +1,42 @@
+# Proposal: devflow-phase-telemetry
+
+## Why
+
+dev-flow-execute-Läufe erscheinen nicht zuverlässig auf dem Factory Floor
+(`/admin/pipeline`) und hinterlassen keine vollständigen Analytics-Spuren:
+Die Mehrzahl der jüngst per devflow abgeschlossenen Tickets hat **null** Zeilen
+in `tickets.factory_phase_events` (u. a. T001437, T001441, T001394, T001390),
+der Rest fragmentierte Ketten. Root Cause: Die Telemetrie ist im Skill nur als
+„best-effort `|| true`" formuliert — instruktions-basierte Telemetrie wird von
+LLM-Agents unzuverlässig befolgt. `getHall()` zeigt slot-lose Tickets aber nur
+mit ≥1 `driver='devflow'`-Event → ohne Events unsichtbar. Zusätzlich weicht das
+hartkodierte UI-Heading „Versand" (`ShippedColumn.svelte`) vom SSOT-Label
+(„Fertig", `pipeline-order.ts`) ab und die Lane-Semantik (Merge = Abschluss,
+ADR-005) ist im UI nicht erklärt.
+
+## What
+
+1. **Auto-Emission (deterministisch statt instruiert):**
+   `scripts/vda/ticket/update-status.sh` und `scripts/vda/ticket/stage-plan.sh`
+   emittieren Phase-Events als Seiteneffekt der Status-Transitions — dadurch
+   sind CLI **und** MCP (`transition_status`) abgedeckt. Mapping:
+   `stage-plan` → scout/design/plan `done`; `in_progress` → implement `entered`;
+   `in_review` → implement `done`; `qa_review` → verify `entered`;
+   `done` → deploy `done`; `blocked` → letzte Phase `blocked`.
+   Idempotent (Dedup auf ticket+phase+state), Driver via `TICKET_PHASE_DRIVER`
+   (Default `devflow`), `detail='auto: …'`, Telemetrie-Fehler nie fatal für den
+   Statuswechsel.
+2. **Fail-closed Checkpoint-Gate:** neues Subkommando
+   `ticket.sh assert-phase-chain --id T… [--json]` (sourced Modul
+   `scripts/vda/ticket/assert-phase-chain.sh`) prüft plan:done,
+   implement:entered, verify:done; Exit 1 mit exakten Backfill-Kommandos.
+   `dev-flow-execute` ruft es PFLICHT vor `gh pr merge` auf (kein `|| true`);
+   verify-Emission wird von best-effort auf Pflicht angehoben.
+3. **Versand-Lane geklärt:** SSOT-Label der `shipped`-Lane in
+   `pipeline-order.ts` → „Versand"; `ShippedColumn.svelte` importiert das Label
+   aus dem SSOT und erhält den Untertitel „Gemergt nach main · Prod-Deploy
+   entkoppelt" (Versand = gemergt, nicht prod-live).
+
+Spec: `docs/superpowers/specs/2026-07-02-devflow-phase-telemetry-design.md`
+
+_Ticket: T001444_

--- a/openspec/changes/devflow-phase-telemetry/specs/software-factory.md
+++ b/openspec/changes/devflow-phase-telemetry/specs/software-factory.md
@@ -1,0 +1,65 @@
+## ADDED Requirements
+
+### Requirement: Deterministische Phase-Event-Auto-Emission bei Status-Transitions
+
+The system SHALL emit `tickets.factory_phase_events` rows as a deterministic side effect of every ticket status transition and every plan-staging, so that dev-flow-execute runs become visible on the factory floor without relying on agent-issued telemetry instructions. Emission SHALL happen inside `scripts/vda/ticket/update-status.sh` and `scripts/vda/ticket/stage-plan.sh` (covering both the CLI and the MCP `transition_status` path, which shells out to `ticket.sh update-status`). The status→event mapping SHALL be: `plan_staged`-staging → `scout done` + `design done` + `plan done`; `in_progress` → `implement entered`; `in_review` → `implement done`; `qa_review` → `verify entered`; `done` → `deploy done`; `blocked` → the ticket's most recent phase (SQL lookup, fallback `implement`) in state `blocked`. Emission SHALL be idempotent via a `NOT EXISTS` dedup on `(ticket_id, phase, state)`, SHALL attribute the driver from the `TICKET_PHASE_DRIVER` environment variable (default `devflow`, only `factory`|`devflow` accepted), SHALL set `detail = 'auto: <trigger>'`, and SHALL NOT make the status transition fail when telemetry cannot be written.
+
+#### Scenario: Status-Transition emittiert das gemappte Phase-Event
+
+- **GIVEN** ein Ticket `T000001` existiert und ein `kubectl`/`psql`-Stub erfasst die abgesetzte SQL
+- **WHEN** `ticket.sh update-status --id T000001 --status done` läuft
+- **THEN** die erfasste SQL enthält einen `INSERT INTO tickets.factory_phase_events` mit `deploy` / `done`, einen `NOT EXISTS`-Dedup auf `(ticket_id, phase, state)` und `detail` mit dem Präfix `auto:`; `in_progress` mappt auf `implement`/`entered`, `in_review` auf `implement`/`done`, `qa_review` auf `verify`/`entered`
+
+#### Scenario: Driver aus TICKET_PHASE_DRIVER, Default devflow, offline-skip
+
+- **GIVEN** `TICKET_PHASE_DRIVER=factory` ist gesetzt und ein Stub erfasst die SQL
+- **WHEN** `ticket.sh update-status --id T000001 --status in_progress` läuft
+- **THEN** die erfasste SQL setzt `driver` auf `factory`; ohne die Variable wird `devflow` verwendet; unter `TICKET_OFFLINE=1` wird der Statuswechsel per Dispatcher-Guard übersprungen und keine `kubectl`-Emission ausgeführt
+
+#### Scenario: Plan-Staging emittiert scout/design/plan done idempotent
+
+- **GIVEN** ein Ticket `T000001` und ein SQL-erfassender Stub
+- **WHEN** `ticket.sh stage-plan --id T000001 --branch feature/x --plan openspec/changes/x/tasks.md` läuft
+- **THEN** die erfasste SQL emittiert `scout`, `design` und `plan` je in State `done` über einen `CROSS JOIN (VALUES …)` mit `NOT EXISTS`-Dedup und `detail` mit Präfix `auto:`
+
+---
+
+### Requirement: Fail-closed Phase-Chain Assertion Gate
+
+The system SHALL provide a `ticket.sh assert-phase-chain --id <ext_id> [--json]` subcommand (sourced module `scripts/vda/ticket/assert-phase-chain.sh`) that verifies the presence of the phase events `plan:done`, `implement:entered`, and `verify:done` for a ticket (any driver). Argument validation (missing `--id`) SHALL happen before any cluster call and exit 2 (FA-SF-48 convention). When one or more required events are missing, the command SHALL exit 1 and print the exact backfill commands (`./scripts/ticket.sh phase <ext_id> <phase> <state> --driver devflow --detail "…"`) for each gap; when all are present it SHALL exit 0. The `--json` flag SHALL emit `{"ok":<bool>,"missing":[…]}`. `dev-flow-execute` SHALL invoke this gate as a mandatory step before `gh pr merge` without an `|| true` suppression.
+
+#### Scenario: Fehlendes --id wird vor dem Cluster-Call abgewiesen
+
+- **GIVEN** kein Cluster ist erreichbar (offline)
+- **WHEN** `ticket.sh assert-phase-chain` ohne `--id` aufgerufen wird
+- **THEN** Exit 2 mit `--id is required`; die Validierung erfolgt vor `_pgpod`
+
+#### Scenario: Vollständige Kette besteht, Lücke schlägt fehl mit Backfill-Hinweisen
+
+- **GIVEN** ein `kubectl`-Stub liefert für `T000001` die Zeilen `plan:done`, `implement:entered`, `verify:done`
+- **WHEN** `ticket.sh assert-phase-chain --id T000001` läuft
+- **THEN** Exit 0; liefert der Stub nur `plan:done` und `implement:entered`, dann Exit 1 und die Ausgabe enthält `ticket.sh phase T000001 verify done`
+
+#### Scenario: --json liefert maschinenlesbaren Status
+
+- **GIVEN** ein `kubectl`-Stub liefert nur `plan:done` für `T000001`
+- **WHEN** `ticket.sh assert-phase-chain --id T000001 --json` läuft
+- **THEN** die Ausgabe ist `{"ok":false,"missing":["implement:entered","verify:done"]}` und der Exit-Code ist 1; bei vollständiger Kette lautet die Ausgabe `{"ok":true,"missing":[]}` mit Exit 0
+
+---
+
+### Requirement: Versand-Lane SSOT-Label und entkoppelte-Deploy-Semantik
+
+The system SHALL define the `shipped` lane display label once in `website/src/lib/tickets/pipeline-order.ts` as `Versand`, and `website/src/components/factory/ShippedColumn.svelte` SHALL import that label from the SSOT instead of hardcoding it. The Versand column SHALL render the subtitle `Gemergt nach main · Prod-Deploy entkoppelt` to communicate that shipped means merged (status `done`), not necessarily production-live (ADR-005 Merge = Abschluss). The empty-state text SHALL remain `Noch nichts versandt.`.
+
+#### Scenario: Label wird aus der SSOT bezogen
+
+- **GIVEN** `PIPELINE_LANES` aus `pipeline-order.ts` ist geladen
+- **WHEN** der `shipped`-Lane-Eintrag geprüft wird
+- **THEN** dessen `label` ist `Versand`; `ShippedColumn.svelte` rendert dieses Label ohne eigenes String-Literal und zeigt den Untertitel `Gemergt nach main · Prod-Deploy entkoppelt`
+
+#### Scenario: Bucket-Zuordnung bleibt stabil
+
+- **GIVEN** die abgeleitete `STATUS_BUCKETS`-Map
+- **WHEN** `STATUS_BUCKETS.done` ausgewertet wird
+- **THEN** der Wert ist `shipped` (Label-Änderung ändert die key-basierte Bucket-Ableitung nicht)

--- a/openspec/changes/devflow-phase-telemetry/tasks.md
+++ b/openspec/changes/devflow-phase-telemetry/tasks.md
@@ -13,12 +13,12 @@ depends_on_plans: []
 # Tasks: devflow-phase-telemetry (T001444)
 
 - [x] Task 1: Auto-Emission in `scripts/vda/ticket/update-status.sh` (Status → Phase-Event, Dedup, `TICKET_PHASE_DRIVER`)
-- [ ] Task 2: Auto-Emission in `scripts/vda/ticket/stage-plan.sh` (scout/design/plan done)
-- [ ] Task 3: `scripts/factory/pipeline.js` exportiert `TICKET_PHASE_DRIVER=factory`
-- [ ] Task 4: Neues Gate-Modul `scripts/vda/ticket/assert-phase-chain.sh` + Dispatcher in `scripts/ticket.sh`
-- [ ] Task 5: `.claude/skills/dev-flow-execute/SKILL.md` — Pflicht-Gate vor `gh pr merge`, verify von best-effort auf Pflicht
-- [ ] Task 6: Versand-Lane — Label-SSOT `pipeline-order.ts` + `ShippedColumn.svelte` Import & Untertitel
-- [ ] Task 7: Finale Verifikation (Gates + Inventar + OpenSpec-Validate)
+- [x] Task 2: Auto-Emission in `scripts/vda/ticket/stage-plan.sh` (scout/design/plan done)
+- [x] Task 3: `scripts/factory/pipeline.js` exportiert `TICKET_PHASE_DRIVER=factory`
+- [x] Task 4: Neues Gate-Modul `scripts/vda/ticket/assert-phase-chain.sh` + Dispatcher in `scripts/ticket.sh`
+- [x] Task 5: `.claude/skills/dev-flow-execute/SKILL.md` — Pflicht-Gate vor `gh pr merge`, verify von best-effort auf Pflicht
+- [x] Task 6: Versand-Lane — Label-SSOT `pipeline-order.ts` + `ShippedColumn.svelte` Import & Untertitel
+- [x] Task 7: Finale Verifikation (Gates + Inventar + OpenSpec-Validate)
 
 ---
 
@@ -247,7 +247,7 @@ git commit -m "feat(factory): auto-emit phase events from update-status transiti
 - Consumes: `_pgpod`, `_exec_sql`; `$TICKET_PHASE_DRIVER` env.
 - Produces: Ein `stage-plan`-Aufruf emittiert zusätzlich `scout done`, `design done`, `plan done` (`detail='auto: stage-plan'`), idempotent per `NOT EXISTS`.
 
-- [ ] **Step 1: Failing-Test-Step (RED).** Ergänze im T001444-Block in `tests/spec/software-factory.bats`:
+- [x] **Step 1: Failing-Test-Step (RED).** Ergänze im T001444-Block in `tests/spec/software-factory.bats`:
 
 ```bash
 @test "T001444: stage-plan auto-emits scout/design/plan done" {
@@ -261,12 +261,12 @@ git commit -m "feat(factory): auto-emit phase events from update-status transiti
 }
 ```
 
-- [ ] **Step 2: Run RED, verify it fails.**
+- [x] **Step 2: Run RED, verify it fails.**
 
 Run: `tests/unit/lib/bats-core/bin/bats tests/spec/software-factory.bats -f "T001444: stage-plan"`
 Expected: FAIL (kein `VALUES ('scout')...` in der Capture-Datei).
 
-- [ ] **Step 3: Implement.** Füge in `scripts/vda/ticket/stage-plan.sh` unmittelbar vor der Abschlusszeile `echo "Ticket $id staged in Kommissionierung (status=plan_staged)"` ein:
+- [x] **Step 3: Implement.** Füge in `scripts/vda/ticket/stage-plan.sh` unmittelbar vor der Abschlusszeile `echo "Ticket $id staged in Kommissionierung (status=plan_staged)"` ein:
 
 ```bash
   local driver="${TICKET_PHASE_DRIVER:-devflow}"
@@ -284,12 +284,12 @@ WHERE t.external_id = :'ext_id'
 EOF
 ```
 
-- [ ] **Step 4: Run GREEN, verify it passes.**
+- [x] **Step 4: Run GREEN, verify it passes.**
 
 Run: `tests/unit/lib/bats-core/bin/bats tests/spec/software-factory.bats -f "T001444: stage-plan"`
 Expected: PASS.
 
-- [ ] **Step 5: Commit.**
+- [x] **Step 5: Commit.**
 
 ```bash
 git add scripts/vda/ticket/stage-plan.sh tests/spec/software-factory.bats
@@ -308,7 +308,7 @@ git commit -m "feat(factory): auto-emit scout/design/plan done on stage-plan [T0
 - Consumes: nichts Neues.
 - Produces: `process.env.TICKET_PHASE_DRIVER === 'factory'` für alle vom Pipeline-Prozess aus geshellten `ticket.sh`-Aufrufe (Sicherheitsnetz für die Driver-Attribution, falls Dedup nicht greift).
 
-- [ ] **Step 1: Failing-Test-Step (RED).** Ergänze im T001444-Block:
+- [x] **Step 1: Failing-Test-Step (RED).** Ergänze im T001444-Block:
 
 ```bash
 @test "T001444: pipeline.js exports TICKET_PHASE_DRIVER=factory" {
@@ -317,12 +317,12 @@ git commit -m "feat(factory): auto-emit scout/design/plan done on stage-plan [T0
 }
 ```
 
-- [ ] **Step 2: Run RED, verify it fails.**
+- [x] **Step 2: Run RED, verify it fails.**
 
 Run: `tests/unit/lib/bats-core/bin/bats tests/spec/software-factory.bats -f "T001444: pipeline.js exports"`
 Expected: FAIL (`TICKET_PHASE_DRIVER` fehlt in `pipeline.js`).
 
-- [ ] **Step 3: Implement.** Füge in `scripts/factory/pipeline.js` direkt nach dem `require`-Block am Modulkopf (nach der `const path = require('path')`-Gruppe) ein:
+- [x] **Step 3: Implement.** Füge in `scripts/factory/pipeline.js` direkt nach dem `require`-Block am Modulkopf (nach der `const path = require('path')`-Gruppe) ein:
 
 ```javascript
 // Attribute all phase events emitted by shelled-out ticket.sh calls to the factory
@@ -331,12 +331,12 @@ Expected: FAIL (`TICKET_PHASE_DRIVER` fehlt in `pipeline.js`).
 process.env.TICKET_PHASE_DRIVER = process.env.TICKET_PHASE_DRIVER || 'factory'
 ```
 
-- [ ] **Step 4: Run GREEN + Offline-Syntaxcheck.**
+- [x] **Step 4: Run GREEN + Offline-Syntaxcheck.**
 
 Run: `tests/unit/lib/bats-core/bin/bats tests/spec/software-factory.bats -f "T001444: pipeline.js exports" && node --check scripts/factory/pipeline.js`
 Expected: PASS und keine Syntaxfehler.
 
-- [ ] **Step 5: Commit.**
+- [x] **Step 5: Commit.**
 
 ```bash
 git add scripts/factory/pipeline.js tests/spec/software-factory.bats
@@ -356,7 +356,7 @@ git commit -m "feat(factory): pipeline.js pins TICKET_PHASE_DRIVER=factory [T001
 - Consumes: `_pgpod`, `_exec_sql`.
 - Produces: `ticket.sh assert-phase-chain --id <ext_id> [--json]` — Exit 0 wenn `plan:done` + `implement:entered` + `verify:done` vorhanden, sonst Exit 1 mit Backfill-Kommandos; `--json` ⇒ `{"ok":<bool>,"missing":[…]}`; fehlendes `--id` ⇒ Exit 2 vor `_pgpod`.
 
-- [ ] **Step 1: Failing-Test-Step (RED).** Ergänze im T001444-Block einen Row-Stub (liefert kontrollierte Query-Zeilen) und die Gate-Tests:
+- [x] **Step 1: Failing-Test-Step (RED).** Ergänze im T001444-Block einen Row-Stub (liefert kontrollierte Query-Zeilen) und die Gate-Tests:
 
 ```bash
 _pt_rows_stub() {   # $1 = phase:state-Zeilen, die der exec-Call zurückgibt
@@ -404,12 +404,12 @@ STUB
 }
 ```
 
-- [ ] **Step 2: Run RED, verify it fails.**
+- [x] **Step 2: Run RED, verify it fails.**
 
 Run: `tests/unit/lib/bats-core/bin/bats tests/spec/software-factory.bats -f "T001444: assert-phase-chain"`
 Expected: FAIL (`Unknown command: assert-phase-chain`).
 
-- [ ] **Step 3a: Create the gate module.** Schreibe `scripts/vda/ticket/assert-phase-chain.sh`:
+- [x] **Step 3a: Create the gate module.** Schreibe `scripts/vda/ticket/assert-phase-chain.sh`:
 
 ```bash
 # scripts/vda/ticket/assert-phase-chain.sh — fail-closed phase-chain gate (T001444).
@@ -473,7 +473,7 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
 fi
 ```
 
-- [ ] **Step 3b: Wire the dispatcher.** Füge in `scripts/ticket.sh` neben den anderen `cmd_*`-Funktionen (z. B. direkt nach `cmd_stage_plan()`) ein:
+- [x] **Step 3b: Wire the dispatcher.** Füge in `scripts/ticket.sh` neben den anderen `cmd_*`-Funktionen (z. B. direkt nach `cmd_stage_plan()`) ein:
 
 ```bash
 cmd_assert_phase_chain() {
@@ -490,12 +490,12 @@ Ergänze im `case "$cmd"`-Block (neben `phase)`):
 
 Und hänge `assert-phase-chain` an die Usage-Kommandoliste im `if [[ $# -lt 1 ]]`-Zweig an (nach `phase,`).
 
-- [ ] **Step 4: Run GREEN, verify it passes.**
+- [x] **Step 4: Run GREEN, verify it passes.**
 
 Run: `tests/unit/lib/bats-core/bin/bats tests/spec/software-factory.bats -f "T001444: assert-phase-chain"`
 Expected: PASS (alle fünf Gate-Tests grün).
 
-- [ ] **Step 5: Commit.**
+- [x] **Step 5: Commit.**
 
 ```bash
 git add scripts/vda/ticket/assert-phase-chain.sh scripts/ticket.sh tests/spec/software-factory.bats
@@ -514,7 +514,7 @@ git commit -m "feat(factory): fail-closed assert-phase-chain gate [T001444]"
 - Consumes: `ticket.sh assert-phase-chain` (Task 4).
 - Produces: Doku-Kontrakt — Gate-Aufruf vor `gh pr merge` ohne `|| true`; verify-Emission als Pflicht.
 
-- [ ] **Step 1: Failing-Test-Step (RED).** Ergänze im T001444-Block (`$SKILL` ist in dieser Datei bereits definiert):
+- [x] **Step 1: Failing-Test-Step (RED).** Ergänze im T001444-Block (`$SKILL` ist in dieser Datei bereits definiert):
 
 ```bash
 @test "T001444: SKILL gates merge on assert-phase-chain without || true" {
@@ -526,12 +526,12 @@ git commit -m "feat(factory): fail-closed assert-phase-chain gate [T001444]"
 }
 ```
 
-- [ ] **Step 2: Run RED, verify it fails.**
+- [x] **Step 2: Run RED, verify it fails.**
 
 Run: `tests/unit/lib/bats-core/bin/bats tests/spec/software-factory.bats -f "T001444: SKILL gates"`
 Expected: FAIL (`assert-phase-chain` steht noch nicht im Skill).
 
-- [ ] **Step 3: Implement.** In `.claude/skills/dev-flow-execute/SKILL.md`, in „Schritt 6: Auto-Merge wenn CI grün", direkt VOR dem `(cd "$MAIN_REPO" && gh pr merge …)`-Codeblock einfügen:
+- [x] **Step 3: Implement.** In `.claude/skills/dev-flow-execute/SKILL.md`, in „Schritt 6: Auto-Merge wenn CI grün", direkt VOR dem `(cd "$MAIN_REPO" && gh pr merge …)`-Codeblock einfügen:
 
 ```markdown
 **Fail-closed Phase-Chain-Gate (T001444) — PFLICHT vor dem Merge, KEIN `|| true`:**
@@ -545,12 +545,12 @@ zuerst backfillen (insb. `verify done` nach grünem `task test:changed`), dann m
 
 Ändere zusätzlich die verify-Telemetrie in „Schritt 3: Lokale Verifikation" und „Schritt 6.5: Ticket abschließen": ersetze die einleitende Formulierung `Phasen-Telemetrie (best-effort)` / `best-effort und darf den Flow nie stoppen` für die `verify entered`/`verify done`-Events durch `Phasen-Telemetrie (PFLICHT für verify — das Gate erzwingt sie)`. Ergänze am Ende der Telemetrie-Blöcke von Schritt 1.5/2/6.5 den Hinweissatz: „`plan`/`implement`/`deploy`-Events entstehen jetzt automatisch aus den Statuswechseln (`update-status`/`stage-plan`); Doppel-Emission ist dank Dedup harmlos." Die `|| true`-Fallback-Zeilen für `verify` bleiben als Fallback erhalten, aber der Fließtext benennt verify als Pflicht.
 
-- [ ] **Step 4: Run GREEN, verify it passes.**
+- [x] **Step 4: Run GREEN, verify it passes.**
 
 Run: `tests/unit/lib/bats-core/bin/bats tests/spec/software-factory.bats -f "T001444: SKILL gates"`
 Expected: PASS.
 
-- [ ] **Step 5: Commit.**
+- [x] **Step 5: Commit.**
 
 ```bash
 git add .claude/skills/dev-flow-execute/SKILL.md tests/spec/software-factory.bats
@@ -570,7 +570,7 @@ git commit -m "docs(dev-flow): gate merge on assert-phase-chain, verify mandator
 - Consumes: `PIPELINE_LANES` (readonly Liste `{ key, label, statuses, side }`) aus `pipeline-order.ts`.
 - Produces: `shipped`-Lane-`label === 'Versand'`; `ShippedColumn.svelte` rendert dieses Label aus der SSOT plus den Untertitel „Gemergt nach main · Prod-Deploy entkoppelt".
 
-- [ ] **Step 1: Failing-Test-Step (RED).** Erweitere `website/src/lib/tickets/pipeline-order.test.ts` um die Import-Zeile `PIPELINE_LANES` (falls nicht vorhanden) und einen Test:
+- [x] **Step 1: Failing-Test-Step (RED).** Erweitere `website/src/lib/tickets/pipeline-order.test.ts` um die Import-Zeile `PIPELINE_LANES` (falls nicht vorhanden) und einen Test:
 
 ```typescript
 it('labels the shipped lane Versand (SSOT)', () => {
@@ -579,18 +579,18 @@ it('labels the shipped lane Versand (SSOT)', () => {
 });
 ```
 
-- [ ] **Step 2: Run RED, verify it fails.**
+- [x] **Step 2: Run RED, verify it fails.**
 
 Run: `npx --prefix website vitest run src/lib/tickets/pipeline-order.test.ts -t "Versand"`
 Expected: FAIL (Label ist noch `'Fertig'`).
 
-- [ ] **Step 3a: Change the SSOT label.** In `website/src/lib/tickets/pipeline-order.ts`, in `PIPELINE_LANES`, die `shipped`-Zeile:
+- [x] **Step 3a: Change the SSOT label.** In `website/src/lib/tickets/pipeline-order.ts`, in `PIPELINE_LANES`, die `shipped`-Zeile:
 
 ```typescript
   { key: 'shipped',        label: 'Versand',         statuses: ['done'],                    side: false },
 ```
 
-- [ ] **Step 3b: Consume the label in the component.** In `website/src/components/factory/ShippedColumn.svelte` im `<script lang="ts">`-Block (vor dem `$props()`-Aufruf) ergänzen:
+- [x] **Step 3b: Consume the label in the component.** In `website/src/components/factory/ShippedColumn.svelte` im `<script lang="ts">`-Block (vor dem `$props()`-Aufruf) ergänzen:
 
 ```svelte
   import { PIPELINE_LANES } from '../../lib/tickets/pipeline-order';
@@ -604,12 +604,12 @@ Ersetze im Markup `<h3 class="font-semibold mb-2">Versand</h3>` durch:
   <p class="text-muted text-[11px] mb-2">Gemergt nach main · Prod-Deploy entkoppelt</p>
 ```
 
-- [ ] **Step 4: Run GREEN + Typecheck.**
+- [x] **Step 4: Run GREEN + Typecheck.**
 
 Run: `npx --prefix website vitest run src/lib/tickets/pipeline-order.test.ts && npx --prefix website tsc --noEmit`
 Expected: PASS, keine Typfehler.
 
-- [ ] **Step 5: Commit.**
+- [x] **Step 5: Commit.**
 
 ```bash
 git add website/src/lib/tickets/pipeline-order.ts website/src/components/factory/ShippedColumn.svelte website/src/lib/tickets/pipeline-order.test.ts
@@ -622,14 +622,14 @@ git commit -m "feat(factory-floor): Versand lane SSOT label + decoupled-deploy s
 
 **Files:** keine Code-Änderung — nur Gates ausführen und generierte Artefakte committen.
 
-- [ ] **Step 1: Test-Inventar regenerieren.** Da neue `@test`-Blöcke hinzugefügt wurden:
+- [x] **Step 1: Test-Inventar regenerieren.** Da neue `@test`-Blöcke hinzugefügt wurden:
 
 ```bash
 task test:inventory
 git add website/src/data/test-inventory.json
 ```
 
-- [ ] **Step 2: OpenSpec validieren (muss grün sein).**
+- [x] **Step 2: OpenSpec validieren (muss grün sein).**
 
 ```bash
 task test:openspec
@@ -638,7 +638,7 @@ bash scripts/openspec.sh validate
 ```
 Expected: `devflow-phase-telemetry` validiert ohne Fehler.
 
-- [ ] **Step 3: Gezielte Tests + Freshness-Ratchet (die drei Pflicht-Gates).**
+- [x] **Step 3: Gezielte Tests + Freshness-Ratchet (die drei Pflicht-Gates).**
 
 ```bash
 task test:changed
@@ -647,7 +647,7 @@ task freshness:check
 ```
 Expected: alle grün; `freshness:check` meldet keine neuen/verschlechterten S1–S4-Violations (die berührten `ticket.sh`/`pipeline.js` stehen in `s1.ignore`).
 
-- [ ] **Step 4: Inventar-/Artefakt-Commit (falls `freshness:regenerate` etwas geändert hat).**
+- [x] **Step 4: Inventar-/Artefakt-Commit (falls `freshness:regenerate` etwas geändert hat).**
 
 ```bash
 git add -A

--- a/openspec/changes/devflow-phase-telemetry/tasks.md
+++ b/openspec/changes/devflow-phase-telemetry/tasks.md
@@ -12,7 +12,7 @@ depends_on_plans: []
 
 # Tasks: devflow-phase-telemetry (T001444)
 
-- [ ] Task 1: Auto-Emission in `scripts/vda/ticket/update-status.sh` (Status → Phase-Event, Dedup, `TICKET_PHASE_DRIVER`)
+- [x] Task 1: Auto-Emission in `scripts/vda/ticket/update-status.sh` (Status → Phase-Event, Dedup, `TICKET_PHASE_DRIVER`)
 - [ ] Task 2: Auto-Emission in `scripts/vda/ticket/stage-plan.sh` (scout/design/plan done)
 - [ ] Task 3: `scripts/factory/pipeline.js` exportiert `TICKET_PHASE_DRIVER=factory`
 - [ ] Task 4: Neues Gate-Modul `scripts/vda/ticket/assert-phase-chain.sh` + Dispatcher in `scripts/ticket.sh`
@@ -86,7 +86,7 @@ tests/spec/software-factory.bats       ← MODIFY: neue @test-Blöcke (Auto-Emis
 - Consumes: `_pgpod`, `_exec_sql` aus `scripts/vda/ticket/_ticket-core.sh`; DB-Tabelle `tickets.factory_phase_events (ticket_id uuid, phase text, state text, detail text, driver text, at timestamptz)`.
 - Produces: Als Seiteneffekt eines `update-status --id <ext_id> --status <status>`-Aufrufs wird für gemappte Status genau ein Phase-Event emittiert (`detail='auto: update-status <status>'`, `driver=$TICKET_PHASE_DRIVER`). Kein neues Bash-Symbol nach außen.
 
-- [ ] **Step 1: Failing-Test-Step (RED).** Füge oben in `tests/spec/software-factory.bats` (nach den vorhandenen Test-Blöcken, z. B. am Dateiende vor einer evtl. bestehenden Sektion) einen Kapselblock mit einem `kubectl`-Capture-Stub und den Mapping-Tests hinzu:
+- [x] **Step 1: Failing-Test-Step (RED).** Füge oben in `tests/spec/software-factory.bats` (nach den vorhandenen Test-Blöcken, z. B. am Dateiende vor einer evtl. bestehenden Sektion) einen Kapselblock mit einem `kubectl`-Capture-Stub und den Mapping-Tests hinzu:
 
 ```bash
 # ── T001444-phase-telemetry ─────────────────────────────────────#
@@ -150,12 +150,12 @@ STUB
 }
 ```
 
-- [ ] **Step 2: Run RED, verify it fails.**
+- [x] **Step 2: Run RED, verify it fails.**
 
 Run: `tests/unit/lib/bats-core/bin/bats tests/spec/software-factory.bats -f "T001444: update-status"`
 Expected: FAIL (die Capture-Datei enthält weder `auto_phase=` noch `NOT EXISTS`, weil die Emission fehlt).
 
-- [ ] **Step 3: Implement — Mapping + Dedup-INSERT.** Ersetze den Body von `main()` in `scripts/vda/ticket/update-status.sh` (ab der Pflichtprüfung) durch:
+- [x] **Step 3: Implement — Mapping + Dedup-INSERT.** Ersetze den Body von `main()` in `scripts/vda/ticket/update-status.sh` (ab der Pflichtprüfung) durch:
 
 ```bash
   if [[ -z "$id" || -z "$status" ]]; then
@@ -223,12 +223,12 @@ EOF
   echo "Ticket $id status updated to $status"
 ```
 
-- [ ] **Step 4: Run GREEN, verify it passes.**
+- [x] **Step 4: Run GREEN, verify it passes.**
 
 Run: `tests/unit/lib/bats-core/bin/bats tests/spec/software-factory.bats -f "T001444: update-status"`
 Expected: PASS (alle vier update-status-Tests grün).
 
-- [ ] **Step 5: Commit.**
+- [x] **Step 5: Commit.**
 
 ```bash
 git add scripts/vda/ticket/update-status.sh tests/spec/software-factory.bats

--- a/openspec/changes/devflow-phase-telemetry/tasks.md
+++ b/openspec/changes/devflow-phase-telemetry/tasks.md
@@ -1,0 +1,655 @@
+---
+title: "devflow-phase-telemetry — Implementation Plan"
+ticket_id: T001444
+domains: [software-factory, dev-tooling, website]
+status: active
+file_locks: []
+shared_changes: false
+batch_id: null
+parent_feature: null
+depends_on_plans: []
+---
+
+# Tasks: devflow-phase-telemetry (T001444)
+
+- [ ] Task 1: Auto-Emission in `scripts/vda/ticket/update-status.sh` (Status → Phase-Event, Dedup, `TICKET_PHASE_DRIVER`)
+- [ ] Task 2: Auto-Emission in `scripts/vda/ticket/stage-plan.sh` (scout/design/plan done)
+- [ ] Task 3: `scripts/factory/pipeline.js` exportiert `TICKET_PHASE_DRIVER=factory`
+- [ ] Task 4: Neues Gate-Modul `scripts/vda/ticket/assert-phase-chain.sh` + Dispatcher in `scripts/ticket.sh`
+- [ ] Task 5: `.claude/skills/dev-flow-execute/SKILL.md` — Pflicht-Gate vor `gh pr merge`, verify von best-effort auf Pflicht
+- [ ] Task 6: Versand-Lane — Label-SSOT `pipeline-order.ts` + `ShippedColumn.svelte` Import & Untertitel
+- [ ] Task 7: Finale Verifikation (Gates + Inventar + OpenSpec-Validate)
+
+---
+
+# devflow-phase-telemetry — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** dev-flow-execute-Läufe werden ohne Agent-Disziplin vollständig auf dem Factory Floor sichtbar, ein fail-closed Gate erzwingt die Phase-Kette vor dem Merge, und die Versand-Lane erklärt ihre entkoppelte-Deploy-Semantik.
+
+**Architecture:** Phase-Events entstehen deterministisch als SQL-Seiteneffekt der Status-Transitions in den zwei sourced Ticket-Modulen (deckt CLI und MCP `transition_status` ab), idempotent per `NOT EXISTS`-Dedup. Ein neues sourced Modul `assert-phase-chain.sh` prüft die Kette maschinell; das dev-flow-execute-Skill ruft es fail-closed vor `gh pr merge`. Das Versand-Lane-Label wird auf einen SSOT (`pipeline-order.ts`) reduziert.
+
+**Tech Stack:** Bash (`psql -qtA -v ON_ERROR_STOP=1` via `kubectl exec`), Postgres 16 (`tickets.factory_phase_events`), BATS (offline, PATH-Stub für `kubectl`), TypeScript/Svelte (Vitest).
+
+## Global Constraints
+
+- Phase-Werte ∈ `{scout,design,plan,implement,verify,deploy}`, State ∈ `{entered,done,blocked}`, Driver ∈ `{factory,devflow}` — die DB-`CHECK`-Constraints auf `tickets.factory_phase_events` (SSOT-DDL: `website/src/lib/tickets/tables/factory-control.ts`).
+- Telemetrie darf einen Statuswechsel NIE fatal machen: die UPDATE-Anweisung läuft im psql-Autocommit VOR dem Event-INSERT (die gemappten `(phase,state)`-Werte sind stets CHECK-gültig).
+- Auto-Events tragen `detail` mit dem Präfix `auto:` zur Unterscheidung von hand-emittierten Events.
+- Arg-Validierung IMMER vor `_pgpod` (FA-SF-48-Konvention), damit Fehlbedienung offline deterministisch Exit 2 gibt.
+- `scripts/ticket.sh` und `scripts/factory/pipeline.js` stehen in `docs/code-quality/gates.yaml → s1.ignore`; Zeilenwachstum dort ist S1-neutral. `ticket.sh` wird nur um Dispatcher-Zeilen erweitert, die Logik bleibt in das sourced Modul extrahiert (kein weiterer Extract der Datei nötig).
+- Keine Brand-Domain-Literale (`*.mentolder.de` / `*.korczewski.de`) in Code oder Snippets (S3).
+
+---
+
+## File Structure
+
+```
+scripts/vda/ticket/update-status.sh    ← MODIFY: Status→Phase-Event-Mapping + Dedup-INSERT
+scripts/vda/ticket/stage-plan.sh       ← MODIFY: scout/design/plan done Auto-Emission
+scripts/vda/ticket/assert-phase-chain.sh ← CREATE: fail-closed Phase-Chain-Gate (sourced Modul)
+scripts/ticket.sh                      ← MODIFY: Dispatcher-Zeilen für assert-phase-chain (s1.ignore)
+scripts/factory/pipeline.js            ← MODIFY: TICKET_PHASE_DRIVER=factory export (s1.ignore)
+.claude/skills/dev-flow-execute/SKILL.md ← MODIFY: Gate vor gh pr merge, verify Pflicht
+website/src/lib/tickets/pipeline-order.ts ← MODIFY: shipped-Label 'Fertig' → 'Versand'
+website/src/components/factory/ShippedColumn.svelte ← MODIFY: Label aus SSOT + Untertitel
+website/src/lib/tickets/pipeline-order.test.ts ← MODIFY: Label-Assertion (Vitest)
+tests/spec/software-factory.bats       ← MODIFY: neue @test-Blöcke (Auto-Emission, Gate)
+```
+
+### Pre-flight — S1-Schwellen (wirksame Grenze pro Datei)
+
+| Datei | Ext / Limit | Ist | Nach Änderung | Reserve |
+|---|---|---|---|---|
+| `scripts/vda/ticket/update-status.sh` | .sh / 500 | 44 | ~74 | ~426 |
+| `scripts/vda/ticket/stage-plan.sh` | .sh / 500 | 36 | ~50 | ~450 |
+| `scripts/vda/ticket/assert-phase-chain.sh` | .sh / 500 | 0 (neu) | ~58 | ~442 |
+| `scripts/ticket.sh` | s1.ignore | 852 | ~857 | n/a (ignored) |
+| `scripts/factory/pipeline.js` | s1.ignore | 709 | ~710 | n/a (ignored) |
+| `website/src/lib/tickets/pipeline-order.ts` | .ts / 600 | 45 | 45 | 555 |
+| `website/src/components/factory/ShippedColumn.svelte` | .svelte / 500 | 58 | ~63 | ~437 |
+| `.claude/skills/dev-flow-execute/SKILL.md` | ungated | 569 | ~575 | n/a |
+| `tests/spec/software-factory.bats` | ungated | 2966 | ~3080 | n/a |
+
+<!-- vitest: pipeline-order.test.ts wird um eine Label-Assertion erweitert; ShippedColumn.svelte hat keinen eigenen Unit-Test (e2e nutzt data-testid), die Label-Ableitung wird über die SSOT-Assertion abgedeckt. -->
+
+---
+
+## Task 1: Auto-Emission in `update-status.sh`
+
+**Files:**
+- Modify: `scripts/vda/ticket/update-status.sh`
+- Test: `tests/spec/software-factory.bats`
+
+**Interfaces:**
+- Consumes: `_pgpod`, `_exec_sql` aus `scripts/vda/ticket/_ticket-core.sh`; DB-Tabelle `tickets.factory_phase_events (ticket_id uuid, phase text, state text, detail text, driver text, at timestamptz)`.
+- Produces: Als Seiteneffekt eines `update-status --id <ext_id> --status <status>`-Aufrufs wird für gemappte Status genau ein Phase-Event emittiert (`detail='auto: update-status <status>'`, `driver=$TICKET_PHASE_DRIVER`). Kein neues Bash-Symbol nach außen.
+
+- [ ] **Step 1: Failing-Test-Step (RED).** Füge oben in `tests/spec/software-factory.bats` (nach den vorhandenen Test-Blöcken, z. B. am Dateiende vor einer evtl. bestehenden Sektion) einen Kapselblock mit einem `kubectl`-Capture-Stub und den Mapping-Tests hinzu:
+
+```bash
+# ── T001444-phase-telemetry ─────────────────────────────────────#
+# Auto-Emission + fail-closed Gate. Offline, CI-safe: ein PATH-Stub ersetzt
+# `kubectl` — `get` liefert einen Fake-Pod, `exec` schreibt -v-Args + SQL-Heredoc
+# in eine Capture-Datei. Reads/Writes erreichen so nie einen echten Cluster.
+_pt_capture_stub() {   # $CAP_FILE muss vor dem Aufruf exportiert sein
+  local dir; dir="$(mktemp -d)"
+  cat > "$dir/kubectl" <<'STUB'
+#!/usr/bin/env bash
+mode=""
+for a in "$@"; do case "$a" in get) mode=get;; exec) mode=exec;; esac; done
+if [[ "$mode" == get ]]; then echo "pod/shared-db-0"; exit 0; fi
+printf '%s\n' "$@" >> "$CAP_FILE"
+cat >> "$CAP_FILE"
+exit 0
+STUB
+  chmod +x "$dir/kubectl"
+  PATH="$dir:$PATH"
+}
+
+@test "T001444: update-status done auto-emits deploy/done" {
+  CAP_FILE="$(mktemp)"; export CAP_FILE
+  _pt_capture_stub
+  run env TICKET_PHASE_DRIVER=devflow bash scripts/ticket.sh update-status --id T000001 --status done
+  [ "$status" -eq 0 ]
+  grep -q "auto_phase=deploy"          "$CAP_FILE"
+  grep -q "auto_state=done"            "$CAP_FILE"
+  grep -q "driver=devflow"             "$CAP_FILE"
+  grep -q "NOT EXISTS"                 "$CAP_FILE"
+  grep -q "auto: update-status done"   "$CAP_FILE"
+}
+
+@test "T001444: update-status in_progress→implement/entered, in_review→implement/done, qa_review→verify/entered" {
+  for pair in "in_progress implement entered" "in_review implement done" "qa_review verify entered"; do
+    set -- $pair
+    CAP_FILE="$(mktemp)"; export CAP_FILE
+    _pt_capture_stub
+    run bash scripts/ticket.sh update-status --id T000001 --status "$1"
+    [ "$status" -eq 0 ]
+    grep -q "auto_phase=$2"  "$CAP_FILE"
+    grep -q "auto_state=$3"  "$CAP_FILE"
+  done
+}
+
+@test "T001444: update-status defaults driver to devflow, factory via env" {
+  CAP_FILE="$(mktemp)"; export CAP_FILE
+  _pt_capture_stub
+  run env TICKET_PHASE_DRIVER=factory bash scripts/ticket.sh update-status --id T000001 --status in_progress
+  [ "$status" -eq 0 ]
+  grep -q "driver=factory" "$CAP_FILE"
+}
+
+@test "T001444: update-status honors TICKET_OFFLINE (no emission)" {
+  CAP_FILE="$(mktemp)"; export CAP_FILE
+  _pt_capture_stub
+  run env TICKET_OFFLINE=1 bash scripts/ticket.sh update-status --id T000001 --status done
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "OFFLINE" ]]
+  [ ! -s "$CAP_FILE" ]
+}
+```
+
+- [ ] **Step 2: Run RED, verify it fails.**
+
+Run: `tests/unit/lib/bats-core/bin/bats tests/spec/software-factory.bats -f "T001444: update-status"`
+Expected: FAIL (die Capture-Datei enthält weder `auto_phase=` noch `NOT EXISTS`, weil die Emission fehlt).
+
+- [ ] **Step 3: Implement — Mapping + Dedup-INSERT.** Ersetze den Body von `main()` in `scripts/vda/ticket/update-status.sh` (ab der Pflichtprüfung) durch:
+
+```bash
+  if [[ -z "$id" || -z "$status" ]]; then
+    echo "ERROR: --id and --status are required." >&2
+    exit 2
+  fi
+
+  # Status → auto-emitted phase event (T001444). Leere auto_phase = keine Emission.
+  local auto_phase="" auto_state=""
+  case "$status" in
+    in_progress) auto_phase="implement"; auto_state="entered" ;;
+    in_review)   auto_phase="implement"; auto_state="done" ;;
+    qa_review)   auto_phase="verify";    auto_state="entered" ;;
+    done)        auto_phase="deploy";    auto_state="done" ;;
+    blocked)     auto_phase="__last__";  auto_state="blocked" ;;
+  esac
+  local driver="${TICKET_PHASE_DRIVER:-devflow}"
+  case "$driver" in factory|devflow) ;; *) driver="devflow" ;; esac
+
+  local pod
+  pod=$(_pgpod)
+
+  # UPDATE (autocommit) läuft VOR dem Event-INSERT — Telemetrie kann den
+  # Statuswechsel nicht zurückrollen. blocked löst die letzte Phase per Lookup auf
+  # (Fallback implement). Dedup: kein Insert bei vorhandenem (ticket,phase,state).
+  _exec_sql "$pod" \
+    -v ext_id="$id" \
+    -v status="$status" \
+    -v res="$resolution" \
+    -v notes="$notes" \
+    -v auto_phase="$auto_phase" \
+    -v auto_state="$auto_state" \
+    -v driver="$driver" \
+    -v detail="auto: update-status $status" <<'EOF' >/dev/null
+UPDATE tickets.tickets SET
+  status = :'status',
+  resolution = NULLIF(:'res', ''),
+  done_at = CASE WHEN :'status' = 'done' THEN now() ELSE done_at END,
+  -- Release the pipeline slot on a terminal transition so the ledger never leaks (T000525).
+  pipeline_slot = CASE WHEN :'status' IN ('done','archived') THEN NULL ELSE pipeline_slot END,
+  notes = CASE WHEN :'notes' <> '' THEN COALESCE(notes || E'\n\n', '') || :'notes' ELSE notes END
+WHERE external_id = :'ext_id';
+
+INSERT INTO tickets.factory_phase_events (ticket_id, phase, state, detail, driver)
+SELECT t.id, r.phase, :'auto_state', :'detail', :'driver'
+FROM tickets.tickets t
+CROSS JOIN LATERAL (
+  SELECT CASE
+    WHEN :'auto_phase' = '__last__'
+      THEN COALESCE(
+        (SELECT e.phase FROM tickets.factory_phase_events e
+          WHERE e.ticket_id = t.id ORDER BY e.at DESC LIMIT 1),
+        'implement')
+    ELSE :'auto_phase'
+  END AS phase
+) r
+WHERE t.external_id = :'ext_id'
+  AND :'auto_phase' <> ''
+  AND NOT EXISTS (
+    SELECT 1 FROM tickets.factory_phase_events e2
+     WHERE e2.ticket_id = t.id AND e2.phase = r.phase AND e2.state = :'auto_state'
+  );
+EOF
+
+  echo "Ticket $id status updated to $status"
+```
+
+- [ ] **Step 4: Run GREEN, verify it passes.**
+
+Run: `tests/unit/lib/bats-core/bin/bats tests/spec/software-factory.bats -f "T001444: update-status"`
+Expected: PASS (alle vier update-status-Tests grün).
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add scripts/vda/ticket/update-status.sh tests/spec/software-factory.bats
+git commit -m "feat(factory): auto-emit phase events from update-status transitions [T001444]"
+```
+
+---
+
+## Task 2: Auto-Emission in `stage-plan.sh`
+
+**Files:**
+- Modify: `scripts/vda/ticket/stage-plan.sh`
+- Test: `tests/spec/software-factory.bats`
+
+**Interfaces:**
+- Consumes: `_pgpod`, `_exec_sql`; `$TICKET_PHASE_DRIVER` env.
+- Produces: Ein `stage-plan`-Aufruf emittiert zusätzlich `scout done`, `design done`, `plan done` (`detail='auto: stage-plan'`), idempotent per `NOT EXISTS`.
+
+- [ ] **Step 1: Failing-Test-Step (RED).** Ergänze im T001444-Block in `tests/spec/software-factory.bats`:
+
+```bash
+@test "T001444: stage-plan auto-emits scout/design/plan done" {
+  CAP_FILE="$(mktemp)"; export CAP_FILE
+  _pt_capture_stub
+  run bash scripts/ticket.sh stage-plan --id T000001 --branch feature/x --plan openspec/changes/x/tasks.md
+  [ "$status" -eq 0 ]
+  grep -qF "VALUES ('scout'),('design'),('plan')" "$CAP_FILE"
+  grep -q  "auto: stage-plan"                     "$CAP_FILE"
+  grep -q  "NOT EXISTS"                           "$CAP_FILE"
+}
+```
+
+- [ ] **Step 2: Run RED, verify it fails.**
+
+Run: `tests/unit/lib/bats-core/bin/bats tests/spec/software-factory.bats -f "T001444: stage-plan"`
+Expected: FAIL (kein `VALUES ('scout')...` in der Capture-Datei).
+
+- [ ] **Step 3: Implement.** Füge in `scripts/vda/ticket/stage-plan.sh` unmittelbar vor der Abschlusszeile `echo "Ticket $id staged in Kommissionierung (status=plan_staged)"` ein:
+
+```bash
+  local driver="${TICKET_PHASE_DRIVER:-devflow}"
+  case "$driver" in factory|devflow) ;; *) driver="devflow" ;; esac
+  _exec_sql "$pod" -v ext_id="$id" -v driver="$driver" -v detail="auto: stage-plan" <<'EOF' >/dev/null
+INSERT INTO tickets.factory_phase_events (ticket_id, phase, state, detail, driver)
+SELECT t.id, p.phase, 'done', :'detail', :'driver'
+FROM tickets.tickets t
+CROSS JOIN (VALUES ('scout'),('design'),('plan')) AS p(phase)
+WHERE t.external_id = :'ext_id'
+  AND NOT EXISTS (
+    SELECT 1 FROM tickets.factory_phase_events e
+     WHERE e.ticket_id = t.id AND e.phase = p.phase AND e.state = 'done'
+  );
+EOF
+```
+
+- [ ] **Step 4: Run GREEN, verify it passes.**
+
+Run: `tests/unit/lib/bats-core/bin/bats tests/spec/software-factory.bats -f "T001444: stage-plan"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add scripts/vda/ticket/stage-plan.sh tests/spec/software-factory.bats
+git commit -m "feat(factory): auto-emit scout/design/plan done on stage-plan [T001444]"
+```
+
+---
+
+## Task 3: `pipeline.js` exportiert `TICKET_PHASE_DRIVER=factory`
+
+**Files:**
+- Modify: `scripts/factory/pipeline.js`
+- Test: `tests/spec/software-factory.bats`
+
+**Interfaces:**
+- Consumes: nichts Neues.
+- Produces: `process.env.TICKET_PHASE_DRIVER === 'factory'` für alle vom Pipeline-Prozess aus geshellten `ticket.sh`-Aufrufe (Sicherheitsnetz für die Driver-Attribution, falls Dedup nicht greift).
+
+- [ ] **Step 1: Failing-Test-Step (RED).** Ergänze im T001444-Block:
+
+```bash
+@test "T001444: pipeline.js exports TICKET_PHASE_DRIVER=factory" {
+  run grep -Eq "TICKET_PHASE_DRIVER['\"]?[[:space:]]*=[[:space:]]*['\"]factory['\"]" "$PIPELINE_SCRIPT"
+  [ "$status" -eq 0 ]
+}
+```
+
+- [ ] **Step 2: Run RED, verify it fails.**
+
+Run: `tests/unit/lib/bats-core/bin/bats tests/spec/software-factory.bats -f "T001444: pipeline.js exports"`
+Expected: FAIL (`TICKET_PHASE_DRIVER` fehlt in `pipeline.js`).
+
+- [ ] **Step 3: Implement.** Füge in `scripts/factory/pipeline.js` direkt nach dem `require`-Block am Modulkopf (nach der `const path = require('path')`-Gruppe) ein:
+
+```javascript
+// Attribute all phase events emitted by shelled-out ticket.sh calls to the factory
+// driver. The auto-emission dedup makes double-emission harmless; this is the
+// safety net for driver attribution when dedup does not apply (T001444).
+process.env.TICKET_PHASE_DRIVER = process.env.TICKET_PHASE_DRIVER || 'factory'
+```
+
+- [ ] **Step 4: Run GREEN + Offline-Syntaxcheck.**
+
+Run: `tests/unit/lib/bats-core/bin/bats tests/spec/software-factory.bats -f "T001444: pipeline.js exports" && node --check scripts/factory/pipeline.js`
+Expected: PASS und keine Syntaxfehler.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add scripts/factory/pipeline.js tests/spec/software-factory.bats
+git commit -m "feat(factory): pipeline.js pins TICKET_PHASE_DRIVER=factory [T001444]"
+```
+
+---
+
+## Task 4: Gate-Modul `assert-phase-chain.sh` + Dispatcher
+
+**Files:**
+- Create: `scripts/vda/ticket/assert-phase-chain.sh`
+- Modify: `scripts/ticket.sh` (Dispatcher-Zeilen; `s1.ignore`)
+- Test: `tests/spec/software-factory.bats`
+
+**Interfaces:**
+- Consumes: `_pgpod`, `_exec_sql`.
+- Produces: `ticket.sh assert-phase-chain --id <ext_id> [--json]` — Exit 0 wenn `plan:done` + `implement:entered` + `verify:done` vorhanden, sonst Exit 1 mit Backfill-Kommandos; `--json` ⇒ `{"ok":<bool>,"missing":[…]}`; fehlendes `--id` ⇒ Exit 2 vor `_pgpod`.
+
+- [ ] **Step 1: Failing-Test-Step (RED).** Ergänze im T001444-Block einen Row-Stub (liefert kontrollierte Query-Zeilen) und die Gate-Tests:
+
+```bash
+_pt_rows_stub() {   # $1 = phase:state-Zeilen, die der exec-Call zurückgibt
+  local rows="$1" dir; dir="$(mktemp -d)"
+  cat > "$dir/kubectl" <<STUB
+#!/usr/bin/env bash
+for a in "\$@"; do case "\$a" in get) echo "pod/shared-db-0"; exit 0;; esac; done
+printf '%s' "$rows"
+exit 0
+STUB
+  chmod +x "$dir/kubectl"
+  PATH="$dir:$PATH"
+}
+
+@test "T001444: assert-phase-chain requires --id before cluster" {
+  run bash scripts/ticket.sh assert-phase-chain
+  [ "$status" -eq 2 ]
+  [[ "$output" =~ "--id is required" ]]
+}
+
+@test "T001444: assert-phase-chain passes on complete chain" {
+  _pt_rows_stub $'plan:done\nimplement:entered\nverify:done\n'
+  run bash scripts/ticket.sh assert-phase-chain --id T000001
+  [ "$status" -eq 0 ]
+}
+
+@test "T001444: assert-phase-chain fails with backfill hint on gap" {
+  _pt_rows_stub $'plan:done\nimplement:entered\n'
+  run bash scripts/ticket.sh assert-phase-chain --id T000001
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "phase T000001 verify done" ]]
+}
+
+@test "T001444: assert-phase-chain --json emits ok/missing shape" {
+  _pt_rows_stub $'plan:done\n'
+  run bash scripts/ticket.sh assert-phase-chain --id T000001 --json
+  [ "$status" -eq 1 ]
+  [[ "$output" == *'{"ok":false,"missing":["implement:entered","verify:done"]}'* ]]
+}
+
+@test "T001444: assert-phase-chain listed in dispatch usage" {
+  run bash scripts/ticket.sh
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "assert-phase-chain" ]]
+}
+```
+
+- [ ] **Step 2: Run RED, verify it fails.**
+
+Run: `tests/unit/lib/bats-core/bin/bats tests/spec/software-factory.bats -f "T001444: assert-phase-chain"`
+Expected: FAIL (`Unknown command: assert-phase-chain`).
+
+- [ ] **Step 3a: Create the gate module.** Schreibe `scripts/vda/ticket/assert-phase-chain.sh`:
+
+```bash
+# scripts/vda/ticket/assert-phase-chain.sh — fail-closed phase-chain gate (T001444).
+# Sourced by ticket.sh. Verifies plan:done, implement:entered, verify:done exist
+# for a ticket (any driver). Exit 0 = complete, 1 = gap, 2 = bad args.
+source "$(dirname "${BASH_SOURCE[0]}")/_ticket-core.sh"
+
+main() {
+  local id="" json=false
+  while [[ $# -gt 0 ]]; do case "$1" in
+      --id)   id="$2"; shift 2 ;;
+      --json) json=true; shift ;;
+      *)      echo "Unknown assert-phase-chain option: $1" >&2; exit 2 ;;
+    esac; done
+  # Validate BEFORE _pgpod so bad-arg errors are deterministic w/o a cluster (FA-SF-48).
+  if [[ -z "$id" ]]; then echo "ERROR: --id is required." >&2; exit 2; fi
+
+  local pod; pod=$(_pgpod)
+  local present
+  present=$(_exec_sql "$pod" -v ext_id="$id" <<'EOF'
+SELECT DISTINCT e.phase || ':' || e.state
+FROM tickets.factory_phase_events e
+JOIN tickets.tickets t ON t.id = e.ticket_id
+WHERE t.external_id = :'ext_id'
+  AND (e.phase, e.state) IN (('plan','done'),('implement','entered'),('verify','done'));
+EOF
+)
+  local required=(plan:done implement:entered verify:done)
+  local missing=() r
+  for r in "${required[@]}"; do
+    grep -qxF "$r" <<<"$present" || missing+=("$r")
+  done
+
+  if [[ "$json" == true ]]; then
+    local ok="true" arr="" first=1 m
+    [[ ${#missing[@]} -gt 0 ]] && ok="false"
+    for m in "${missing[@]:-}"; do
+      [[ -z "$m" ]] && continue
+      [[ $first -eq 1 ]] || arr+=","
+      arr+="\"$m\""; first=0
+    done
+    echo "{\"ok\":$ok,\"missing\":[$arr]}"
+    [[ ${#missing[@]} -eq 0 ]]; exit $?
+  fi
+
+  if [[ ${#missing[@]} -eq 0 ]]; then
+    echo "OK: phase chain complete for $id (plan:done, implement:entered, verify:done)"
+    exit 0
+  fi
+
+  echo "FAIL: phase chain incomplete for $id — missing: ${missing[*]}" >&2
+  echo "Backfill with:" >&2
+  for m in "${missing[@]}"; do
+    echo "  ./scripts/ticket.sh phase $id ${m%%:*} ${m##*:} --driver devflow --detail \"backfill: assert-phase-chain\"" >&2
+  done
+  exit 1
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi
+```
+
+- [ ] **Step 3b: Wire the dispatcher.** Füge in `scripts/ticket.sh` neben den anderen `cmd_*`-Funktionen (z. B. direkt nach `cmd_stage_plan()`) ein:
+
+```bash
+cmd_assert_phase_chain() {
+  source "$(dirname "${BASH_SOURCE[0]}")/vda/ticket/assert-phase-chain.sh"
+  main "$@"
+}
+```
+
+Ergänze im `case "$cmd"`-Block (neben `phase)`):
+
+```bash
+  assert-phase-chain) cmd_assert_phase_chain "$@" ;;
+```
+
+Und hänge `assert-phase-chain` an die Usage-Kommandoliste im `if [[ $# -lt 1 ]]`-Zweig an (nach `phase,`).
+
+- [ ] **Step 4: Run GREEN, verify it passes.**
+
+Run: `tests/unit/lib/bats-core/bin/bats tests/spec/software-factory.bats -f "T001444: assert-phase-chain"`
+Expected: PASS (alle fünf Gate-Tests grün).
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add scripts/vda/ticket/assert-phase-chain.sh scripts/ticket.sh tests/spec/software-factory.bats
+git commit -m "feat(factory): fail-closed assert-phase-chain gate [T001444]"
+```
+
+---
+
+## Task 5: dev-flow-execute Skill — Pflicht-Gate + verify Pflicht
+
+**Files:**
+- Modify: `.claude/skills/dev-flow-execute/SKILL.md`
+- Test: `tests/spec/software-factory.bats`
+
+**Interfaces:**
+- Consumes: `ticket.sh assert-phase-chain` (Task 4).
+- Produces: Doku-Kontrakt — Gate-Aufruf vor `gh pr merge` ohne `|| true`; verify-Emission als Pflicht.
+
+- [ ] **Step 1: Failing-Test-Step (RED).** Ergänze im T001444-Block (`$SKILL` ist in dieser Datei bereits definiert):
+
+```bash
+@test "T001444: SKILL gates merge on assert-phase-chain without || true" {
+  run grep -q "assert-phase-chain" "$SKILL"
+  [ "$status" -eq 0 ]
+  # keine || true Suppression auf der Gate-Zeile
+  run bash -c "grep 'assert-phase-chain' '$SKILL' | grep -q '|| true'"
+  [ "$status" -ne 0 ]
+}
+```
+
+- [ ] **Step 2: Run RED, verify it fails.**
+
+Run: `tests/unit/lib/bats-core/bin/bats tests/spec/software-factory.bats -f "T001444: SKILL gates"`
+Expected: FAIL (`assert-phase-chain` steht noch nicht im Skill).
+
+- [ ] **Step 3: Implement.** In `.claude/skills/dev-flow-execute/SKILL.md`, in „Schritt 6: Auto-Merge wenn CI grün", direkt VOR dem `(cd "$MAIN_REPO" && gh pr merge …)`-Codeblock einfügen:
+
+```markdown
+**Fail-closed Phase-Chain-Gate (T001444) — PFLICHT vor dem Merge, KEIN `|| true`:**
+Prüft, dass `plan:done`, `implement:entered` und `verify:done` vorliegen. Bei FAIL
+zuerst backfillen (insb. `verify done` nach grünem `task test:changed`), dann mergen.
+
+​```bash
+./scripts/ticket.sh assert-phase-chain --id "$TICKET_ID"
+​```
+```
+
+Ändere zusätzlich die verify-Telemetrie in „Schritt 3: Lokale Verifikation" und „Schritt 6.5: Ticket abschließen": ersetze die einleitende Formulierung `Phasen-Telemetrie (best-effort)` / `best-effort und darf den Flow nie stoppen` für die `verify entered`/`verify done`-Events durch `Phasen-Telemetrie (PFLICHT für verify — das Gate erzwingt sie)`. Ergänze am Ende der Telemetrie-Blöcke von Schritt 1.5/2/6.5 den Hinweissatz: „`plan`/`implement`/`deploy`-Events entstehen jetzt automatisch aus den Statuswechseln (`update-status`/`stage-plan`); Doppel-Emission ist dank Dedup harmlos." Die `|| true`-Fallback-Zeilen für `verify` bleiben als Fallback erhalten, aber der Fließtext benennt verify als Pflicht.
+
+- [ ] **Step 4: Run GREEN, verify it passes.**
+
+Run: `tests/unit/lib/bats-core/bin/bats tests/spec/software-factory.bats -f "T001444: SKILL gates"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add .claude/skills/dev-flow-execute/SKILL.md tests/spec/software-factory.bats
+git commit -m "docs(dev-flow): gate merge on assert-phase-chain, verify mandatory [T001444]"
+```
+
+---
+
+## Task 6: Versand-Lane — SSOT-Label + Untertitel
+
+**Files:**
+- Modify: `website/src/lib/tickets/pipeline-order.ts`
+- Modify: `website/src/components/factory/ShippedColumn.svelte`
+- Test: `website/src/lib/tickets/pipeline-order.test.ts`
+
+**Interfaces:**
+- Consumes: `PIPELINE_LANES` (readonly Liste `{ key, label, statuses, side }`) aus `pipeline-order.ts`.
+- Produces: `shipped`-Lane-`label === 'Versand'`; `ShippedColumn.svelte` rendert dieses Label aus der SSOT plus den Untertitel „Gemergt nach main · Prod-Deploy entkoppelt".
+
+- [ ] **Step 1: Failing-Test-Step (RED).** Erweitere `website/src/lib/tickets/pipeline-order.test.ts` um die Import-Zeile `PIPELINE_LANES` (falls nicht vorhanden) und einen Test:
+
+```typescript
+it('labels the shipped lane Versand (SSOT)', () => {
+  const shipped = PIPELINE_LANES.find((l) => l.key === 'shipped');
+  expect(shipped?.label).toBe('Versand');
+});
+```
+
+- [ ] **Step 2: Run RED, verify it fails.**
+
+Run: `npx --prefix website vitest run src/lib/tickets/pipeline-order.test.ts -t "Versand"`
+Expected: FAIL (Label ist noch `'Fertig'`).
+
+- [ ] **Step 3a: Change the SSOT label.** In `website/src/lib/tickets/pipeline-order.ts`, in `PIPELINE_LANES`, die `shipped`-Zeile:
+
+```typescript
+  { key: 'shipped',        label: 'Versand',         statuses: ['done'],                    side: false },
+```
+
+- [ ] **Step 3b: Consume the label in the component.** In `website/src/components/factory/ShippedColumn.svelte` im `<script lang="ts">`-Block (vor dem `$props()`-Aufruf) ergänzen:
+
+```svelte
+  import { PIPELINE_LANES } from '../../lib/tickets/pipeline-order';
+  const shippedLabel = PIPELINE_LANES.find((l) => l.key === 'shipped')?.label ?? 'Versand';
+```
+
+Ersetze im Markup `<h3 class="font-semibold mb-2">Versand</h3>` durch:
+
+```svelte
+  <h3 class="font-semibold mb-1">{shippedLabel}</h3>
+  <p class="text-muted text-[11px] mb-2">Gemergt nach main · Prod-Deploy entkoppelt</p>
+```
+
+- [ ] **Step 4: Run GREEN + Typecheck.**
+
+Run: `npx --prefix website vitest run src/lib/tickets/pipeline-order.test.ts && npx --prefix website tsc --noEmit`
+Expected: PASS, keine Typfehler.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add website/src/lib/tickets/pipeline-order.ts website/src/components/factory/ShippedColumn.svelte website/src/lib/tickets/pipeline-order.test.ts
+git commit -m "feat(factory-floor): Versand lane SSOT label + decoupled-deploy subtitle [T001444]"
+```
+
+---
+
+## Task 7: Finale Verifikation
+
+**Files:** keine Code-Änderung — nur Gates ausführen und generierte Artefakte committen.
+
+- [ ] **Step 1: Test-Inventar regenerieren.** Da neue `@test`-Blöcke hinzugefügt wurden:
+
+```bash
+task test:inventory
+git add website/src/data/test-inventory.json
+```
+
+- [ ] **Step 2: OpenSpec validieren (muss grün sein).**
+
+```bash
+task test:openspec
+# Fallback ohne OpenSpec-CLI:
+bash scripts/openspec.sh validate
+```
+Expected: `devflow-phase-telemetry` validiert ohne Fehler.
+
+- [ ] **Step 3: Gezielte Tests + Freshness-Ratchet (die drei Pflicht-Gates).**
+
+```bash
+task test:changed
+task freshness:regenerate
+task freshness:check
+```
+Expected: alle grün; `freshness:check` meldet keine neuen/verschlechterten S1–S4-Violations (die berührten `ticket.sh`/`pipeline.js` stehen in `s1.ignore`).
+
+- [ ] **Step 4: Inventar-/Artefakt-Commit (falls `freshness:regenerate` etwas geändert hat).**
+
+```bash
+git add -A
+git commit -m "chore(factory): regenerate freshness artifacts + test inventory [T001444]"
+```

--- a/scripts/factory/pipeline.js
+++ b/scripts/factory/pipeline.js
@@ -23,6 +23,10 @@ try { _msgBridge = require('./agent-msg-bridge.cjs') } catch (_) {}
 const ACI = process.env.ACI_ENABLED === 'true' ? require('./aci.cjs') : null
 const { decideDeployTransition } = require('./deploy-transition.cjs')
 const { resolveTaskSource } = require('./task-source.cjs')
+// Attribute all phase events emitted by shelled-out ticket.sh calls to the factory
+// driver. The auto-emission dedup makes double-emission harmless; this is the
+// safety net for driver attribution when dedup does not apply (T001444).
+if (!process.env.TICKET_PHASE_DRIVER) process.env.TICKET_PHASE_DRIVER = 'factory'
 function routeProviderSync(source, tier) {
   if (tier === 'opus') return { provider: 'anthropic', modelId: 'claude-opus-4-6', baseUrl: null, slotId: null, emergency: false }
   if (process.env.ANTHROPIC_MODEL) {

--- a/scripts/factory/service-registry.sh
+++ b/scripts/factory/service-registry.sh
@@ -69,6 +69,7 @@ declare -A SERVICE_REGISTRY=(
   # Pocket ID migration (#2042/#2057) + new services — classified to match app: labels
   [k3d/pocket-id.yaml]="pocket-id"
   [k3d/pocket-id-client-seed.yaml]="pocket-id"
+  [k3d/pocket-id-client-seed-rbac.yaml]="pocket-id"
   [k3d/studio.yaml]="studio-server"
   [k3d/oauth2-proxy-studio.yaml]="studio-server"
   [k3d/mentolder-web.yaml]="mentolder-web"

--- a/scripts/ticket.sh
+++ b/scripts/ticket.sh
@@ -265,6 +265,11 @@ cmd_stage_plan() {
   main "$@"
 }
 
+cmd_assert_phase_chain() {
+  source "$(dirname "${BASH_SOURCE[0]}")/vda/ticket/assert-phase-chain.sh"
+  main "$@"
+}
+
 cmd_set_touched_files() {
   local id="" files=""
   while [[ $# -gt 0 ]]; do case "$1" in
@@ -811,7 +816,7 @@ cmd_triage() {
 
 if [[ $# -lt 1 ]]; then
   echo "Usage: $0 <command> [options]" >&2
-  echo "Commands: create, update-status, add-comment, add-pr-link, grill, archive-plan, get-attachments, get, set-touched-files, set-scout-drift, set-pipeline-slot, release-slot, touch, enqueue, stage-plan, retry-count, factory-control, dryrun-mark, dryrun-check, feature-flag, phase, inject, get-injections, plan-meta, lastenheft, list, backfill-id, triage, link-tickets, get-ticket-links, get-timeline" >&2
+  echo "Commands: create, update-status, add-comment, add-pr-link, grill, archive-plan, get-attachments, get, set-touched-files, set-scout-drift, set-pipeline-slot, release-slot, touch, enqueue, stage-plan, assert-phase-chain, retry-count, factory-control, dryrun-mark, dryrun-check, feature-flag, phase, inject, get-injections, plan-meta, lastenheft, list, backfill-id, triage, link-tickets, get-ticket-links, get-timeline" >&2
   exit 1
 fi
 cmd="$1"; shift
@@ -834,6 +839,7 @@ case "$cmd" in
   triage)            cmd_triage "$@" ;;
   enqueue)           cmd_enqueue "$@" ;;
   stage-plan)        cmd_stage_plan "$@" ;;
+  assert-phase-chain) cmd_assert_phase_chain "$@" ;;
   retry-count)       cmd_retry_count "$@" ;;
   factory-control)   cmd_factory_control "$@" ;;
   dryrun-mark)       cmd_dryrun_mark "$@" ;;

--- a/scripts/vda/ticket/assert-phase-chain.sh
+++ b/scripts/vda/ticket/assert-phase-chain.sh
@@ -1,0 +1,59 @@
+# scripts/vda/ticket/assert-phase-chain.sh — fail-closed phase-chain gate (T001444).
+# Sourced by ticket.sh. Verifies plan:done, implement:entered, verify:done exist
+# for a ticket (any driver). Exit 0 = complete, 1 = gap, 2 = bad args.
+source "$(dirname "${BASH_SOURCE[0]}")/_ticket-core.sh"
+
+main() {
+  local id="" json=false
+  while [[ $# -gt 0 ]]; do case "$1" in
+      --id)   id="$2"; shift 2 ;;
+      --json) json=true; shift ;;
+      *)      echo "Unknown assert-phase-chain option: $1" >&2; exit 2 ;;
+    esac; done
+  # Validate BEFORE _pgpod so bad-arg errors are deterministic w/o a cluster (FA-SF-48).
+  if [[ -z "$id" ]]; then echo "ERROR: --id is required." >&2; exit 2; fi
+
+  local pod; pod=$(_pgpod)
+  local present
+  present=$(_exec_sql "$pod" -v ext_id="$id" <<'EOF'
+SELECT DISTINCT e.phase || ':' || e.state
+FROM tickets.factory_phase_events e
+JOIN tickets.tickets t ON t.id = e.ticket_id
+WHERE t.external_id = :'ext_id'
+  AND (e.phase, e.state) IN (('plan','done'),('implement','entered'),('verify','done'));
+EOF
+)
+  local required=(plan:done implement:entered verify:done)
+  local missing=() r
+  for r in "${required[@]}"; do
+    grep -qxF "$r" <<<"$present" || missing+=("$r")
+  done
+
+  if [[ "$json" == true ]]; then
+    local ok="true" arr="" first=1 m
+    [[ ${#missing[@]} -gt 0 ]] && ok="false"
+    for m in "${missing[@]:-}"; do
+      [[ -z "$m" ]] && continue
+      [[ $first -eq 1 ]] || arr+=","
+      arr+="\"$m\""; first=0
+    done
+    echo "{\"ok\":$ok,\"missing\":[$arr]}"
+    [[ ${#missing[@]} -eq 0 ]]; exit $?
+  fi
+
+  if [[ ${#missing[@]} -eq 0 ]]; then
+    echo "OK: phase chain complete for $id (plan:done, implement:entered, verify:done)"
+    exit 0
+  fi
+
+  echo "FAIL: phase chain incomplete for $id — missing: ${missing[*]}" >&2
+  echo "Backfill with:" >&2
+  for m in "${missing[@]}"; do
+    echo "  ./scripts/ticket.sh phase $id ${m%%:*} ${m##*:} --driver devflow --detail \"backfill: assert-phase-chain\"" >&2
+  done
+  exit 1
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi

--- a/scripts/vda/ticket/stage-plan.sh
+++ b/scripts/vda/ticket/stage-plan.sh
@@ -28,6 +28,19 @@ SELECT t.id, 'dev-flow-plan', :'ref', 'internal'
       WHERE c.ticket_id = t.id AND c.body LIKE 'FACTORY-PLAN-REF %'
    );
 EOF
+  local driver="${TICKET_PHASE_DRIVER:-devflow}"
+  case "$driver" in factory|devflow) ;; *) driver="devflow" ;; esac
+  _exec_sql "$pod" -v ext_id="$id" -v driver="$driver" -v detail="auto: stage-plan" <<'EOF' >/dev/null
+INSERT INTO tickets.factory_phase_events (ticket_id, phase, state, detail, driver)
+SELECT t.id, p.phase, 'done', :'detail', :'driver'
+FROM tickets.tickets t
+CROSS JOIN (VALUES ('scout'),('design'),('plan')) AS p(phase)
+WHERE t.external_id = :'ext_id'
+  AND NOT EXISTS (
+    SELECT 1 FROM tickets.factory_phase_events e
+     WHERE e.ticket_id = t.id AND e.phase = p.phase AND e.state = 'done'
+  );
+EOF
   echo "Ticket $id staged in Kommissionierung (status=plan_staged)"
 }
 

--- a/scripts/vda/ticket/update-status.sh
+++ b/scripts/vda/ticket/update-status.sh
@@ -18,14 +18,33 @@ main() {
     exit 2
   fi
 
+  # Status → auto-emitted phase event (T001444). Leere auto_phase = keine Emission.
+  local auto_phase="" auto_state=""
+  case "$status" in
+    in_progress) auto_phase="implement"; auto_state="entered" ;;
+    in_review)   auto_phase="implement"; auto_state="done" ;;
+    qa_review)   auto_phase="verify";    auto_state="entered" ;;
+    done)        auto_phase="deploy";    auto_state="done" ;;
+    blocked)     auto_phase="__last__";  auto_state="blocked" ;;
+  esac
+  local driver="${TICKET_PHASE_DRIVER:-devflow}"
+  case "$driver" in factory|devflow) ;; *) driver="devflow" ;; esac
+
   local pod
   pod=$(_pgpod)
 
+  # UPDATE (autocommit) läuft VOR dem Event-INSERT — Telemetrie kann den
+  # Statuswechsel nicht zurückrollen. blocked löst die letzte Phase per Lookup auf
+  # (Fallback implement). Dedup: kein Insert bei vorhandenem (ticket,phase,state).
   _exec_sql "$pod" \
     -v ext_id="$id" \
     -v status="$status" \
     -v res="$resolution" \
-    -v notes="$notes" <<'EOF' >/dev/null
+    -v notes="$notes" \
+    -v auto_phase="$auto_phase" \
+    -v auto_state="$auto_state" \
+    -v driver="$driver" \
+    -v detail="auto: update-status $status" <<'EOF' >/dev/null
 UPDATE tickets.tickets SET
   status = :'status',
   resolution = NULLIF(:'res', ''),
@@ -34,6 +53,26 @@ UPDATE tickets.tickets SET
   pipeline_slot = CASE WHEN :'status' IN ('done','archived') THEN NULL ELSE pipeline_slot END,
   notes = CASE WHEN :'notes' <> '' THEN COALESCE(notes || E'\n\n', '') || :'notes' ELSE notes END
 WHERE external_id = :'ext_id';
+
+INSERT INTO tickets.factory_phase_events (ticket_id, phase, state, detail, driver)
+SELECT t.id, r.phase, :'auto_state', :'detail', :'driver'
+FROM tickets.tickets t
+CROSS JOIN LATERAL (
+  SELECT CASE
+    WHEN :'auto_phase' = '__last__'
+      THEN COALESCE(
+        (SELECT e.phase FROM tickets.factory_phase_events e
+          WHERE e.ticket_id = t.id ORDER BY e.at DESC LIMIT 1),
+        'implement')
+    ELSE :'auto_phase'
+  END AS phase
+) r
+WHERE t.external_id = :'ext_id'
+  AND :'auto_phase' <> ''
+  AND NOT EXISTS (
+    SELECT 1 FROM tickets.factory_phase_events e2
+     WHERE e2.ticket_id = t.id AND e2.phase = r.phase AND e2.state = :'auto_state'
+  );
 EOF
 
   echo "Ticket $id status updated to $status"

--- a/tests/spec/software-factory.bats
+++ b/tests/spec/software-factory.bats
@@ -3083,3 +3083,12 @@ STUB
   [ "$status" -eq 1 ]
   [[ "$output" =~ "assert-phase-chain" ]]
 }
+
+@test "T001444: SKILL gates merge on assert-phase-chain without || true" {
+  SKILL=".claude/skills/dev-flow-execute/SKILL.md"
+  run grep -q "assert-phase-chain" "$SKILL"
+  [ "$status" -eq 0 ]
+  # keine || true Suppression auf der Gate-Zeile
+  run bash -c "grep 'assert-phase-chain' '$SKILL' | grep -q '|| true'"
+  [ "$status" -ne 0 ]
+}

--- a/tests/spec/software-factory.bats
+++ b/tests/spec/software-factory.bats
@@ -3024,3 +3024,18 @@ STUB
   [[ "$output" =~ "OFFLINE" ]]
   [ ! -s "$CAP_FILE" ]
 }
+
+@test "T001444: stage-plan auto-emits scout/design/plan done" {
+  CAP_FILE="$(mktemp)"; export CAP_FILE
+  _pt_capture_stub
+  run bash scripts/ticket.sh stage-plan --id T000001 --branch feature/x --plan openspec/changes/x/tasks.md
+  [ "$status" -eq 0 ]
+  grep -qF "VALUES ('scout'),('design'),('plan')" "$CAP_FILE"
+  grep -q  "auto: stage-plan"                     "$CAP_FILE"
+  grep -q  "NOT EXISTS"                           "$CAP_FILE"
+}
+
+@test "T001444: pipeline.js exports TICKET_PHASE_DRIVER=factory" {
+  run grep -Eq "TICKET_PHASE_DRIVER['\"]?[[:space:]]*=[[:space:]]*['\"]factory['\"]" "$PIPELINE_SCRIPT"
+  [ "$status" -eq 0 ]
+}

--- a/tests/spec/software-factory.bats
+++ b/tests/spec/software-factory.bats
@@ -2964,3 +2964,63 @@ FACTORY_CHART_COLORS="$BATS_TEST_DIRNAME/../../website/src/components/factory/fa
   run grep -F "export const PHASE_COLOR_BY_NAME" "$FACTORY_CHART_COLORS"
   [ "$status" -eq 0 ]
 }
+
+# ── T001444-phase-telemetry ─────────────────────────────────────#
+# Auto-Emission + fail-closed Gate. Offline, CI-safe: ein PATH-Stub ersetzt
+# `kubectl` — `get` liefert einen Fake-Pod, `exec` schreibt -v-Args + SQL-Heredoc
+# in eine Capture-Datei. Reads/Writes erreichen so nie einen echten Cluster.
+_pt_capture_stub() {   # $CAP_FILE muss vor dem Aufruf exportiert sein
+  local dir; dir="$(mktemp -d)"
+  cat > "$dir/kubectl" <<'STUB'
+#!/usr/bin/env bash
+mode=""
+for a in "$@"; do case "$a" in get) mode=get;; exec) mode=exec;; esac; done
+if [[ "$mode" == get ]]; then echo "pod/shared-db-0"; exit 0; fi
+printf '%s\n' "$@" >> "$CAP_FILE"
+cat >> "$CAP_FILE"
+exit 0
+STUB
+  chmod +x "$dir/kubectl"
+  PATH="$dir:$PATH"
+}
+
+@test "T001444: update-status done auto-emits deploy/done" {
+  CAP_FILE="$(mktemp)"; export CAP_FILE
+  _pt_capture_stub
+  run env TICKET_PHASE_DRIVER=devflow bash scripts/ticket.sh update-status --id T000001 --status done
+  [ "$status" -eq 0 ]
+  grep -q "auto_phase=deploy"          "$CAP_FILE"
+  grep -q "auto_state=done"            "$CAP_FILE"
+  grep -q "driver=devflow"             "$CAP_FILE"
+  grep -q "NOT EXISTS"                 "$CAP_FILE"
+  grep -q "auto: update-status done"   "$CAP_FILE"
+}
+
+@test "T001444: update-status in_progress→implement/entered, in_review→implement/done, qa_review→verify/entered" {
+  for pair in "in_progress implement entered" "in_review implement done" "qa_review verify entered"; do
+    set -- $pair
+    CAP_FILE="$(mktemp)"; export CAP_FILE
+    _pt_capture_stub
+    run bash scripts/ticket.sh update-status --id T000001 --status "$1"
+    [ "$status" -eq 0 ]
+    grep -q "auto_phase=$2"  "$CAP_FILE"
+    grep -q "auto_state=$3"  "$CAP_FILE"
+  done
+}
+
+@test "T001444: update-status defaults driver to devflow, factory via env" {
+  CAP_FILE="$(mktemp)"; export CAP_FILE
+  _pt_capture_stub
+  run env TICKET_PHASE_DRIVER=factory bash scripts/ticket.sh update-status --id T000001 --status in_progress
+  [ "$status" -eq 0 ]
+  grep -q "driver=factory" "$CAP_FILE"
+}
+
+@test "T001444: update-status honors TICKET_OFFLINE (no emission)" {
+  CAP_FILE="$(mktemp)"; export CAP_FILE
+  _pt_capture_stub
+  run env TICKET_OFFLINE=1 bash scripts/ticket.sh update-status --id T000001 --status done
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "OFFLINE" ]]
+  [ ! -s "$CAP_FILE" ]
+}

--- a/tests/spec/software-factory.bats
+++ b/tests/spec/software-factory.bats
@@ -3039,3 +3039,47 @@ STUB
   run grep -Eq "TICKET_PHASE_DRIVER['\"]?[[:space:]]*=[[:space:]]*['\"]factory['\"]" "$PIPELINE_SCRIPT"
   [ "$status" -eq 0 ]
 }
+
+_pt_rows_stub() {   # $1 = phase:state-Zeilen, die der exec-Call zurückgibt
+  local rows="$1" dir; dir="$(mktemp -d)"
+  cat > "$dir/kubectl" <<STUB
+#!/usr/bin/env bash
+for a in "\$@"; do case "\$a" in get) echo "pod/shared-db-0"; exit 0;; esac; done
+printf '%s' "$rows"
+exit 0
+STUB
+  chmod +x "$dir/kubectl"
+  PATH="$dir:$PATH"
+}
+
+@test "T001444: assert-phase-chain requires --id before cluster" {
+  run bash scripts/ticket.sh assert-phase-chain
+  [ "$status" -eq 2 ]
+  [[ "$output" =~ "--id is required" ]]
+}
+
+@test "T001444: assert-phase-chain passes on complete chain" {
+  _pt_rows_stub $'plan:done\nimplement:entered\nverify:done\n'
+  run bash scripts/ticket.sh assert-phase-chain --id T000001
+  [ "$status" -eq 0 ]
+}
+
+@test "T001444: assert-phase-chain fails with backfill hint on gap" {
+  _pt_rows_stub $'plan:done\nimplement:entered\n'
+  run bash scripts/ticket.sh assert-phase-chain --id T000001
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "phase T000001 verify done" ]]
+}
+
+@test "T001444: assert-phase-chain --json emits ok/missing shape" {
+  _pt_rows_stub $'plan:done\n'
+  run bash scripts/ticket.sh assert-phase-chain --id T000001 --json
+  [ "$status" -eq 1 ]
+  [[ "$output" == *'{"ok":false,"missing":["implement:entered","verify:done"]}'* ]]
+}
+
+@test "T001444: assert-phase-chain listed in dispatch usage" {
+  run bash scripts/ticket.sh
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "assert-phase-chain" ]]
+}

--- a/website/src/components/factory/ShippedColumn.svelte
+++ b/website/src/components/factory/ShippedColumn.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+  import { PIPELINE_LANES } from '../../lib/tickets/pipeline-order';
+  const shippedLabel = PIPELINE_LANES.find((l) => l.key === 'shipped')?.label ?? 'Versand';
+
   let {
     shipped,
     mobileColIndex,
@@ -17,7 +20,8 @@
 </script>
 
 <div data-col="done" class:mobile-visible={mobileColIndex === 9} class="lg:w-1/5" data-testid="floor-shipped">
-  <h3 class="font-semibold mb-2">Versand</h3>
+  <h3 class="font-semibold mb-1">{shippedLabel}</h3>
+  <p class="text-muted text-[11px] mb-2">Gemergt nach main · Prod-Deploy entkoppelt</p>
   {#if shipped.length === 0}
     <p class="text-muted text-sm">Noch nichts versandt.</p>
   {:else}

--- a/website/src/lib/tickets/pipeline-order.test.ts
+++ b/website/src/lib/tickets/pipeline-order.test.ts
@@ -73,3 +73,10 @@ describe('STATUS_BUCKETS', () => {
     expect(STATUS_BUCKETS.done).toBe<LaneKey>('shipped');
   });
 });
+
+describe('shipped lane label', () => {
+  it('labels the shipped lane Versand (SSOT)', () => {
+    const shipped = PIPELINE_LANES.find((l) => l.key === 'shipped');
+    expect(shipped?.label).toBe('Versand');
+  });
+});

--- a/website/src/lib/tickets/pipeline-order.ts
+++ b/website/src/lib/tickets/pipeline-order.ts
@@ -29,7 +29,7 @@ export const PIPELINE_LANES: readonly PipelineLane[] = [
   { key: 'hall',        label: 'In Arbeit',      statuses: ['in_progress', 'in_review'], side: false },
   { key: 'qa',             label: 'QS-Abnahme',     statuses: ['qa_review'],               side: false },
   { key: 'awaitingDeploy', label: 'Deploy-Wartung',  statuses: ['awaiting_deploy'],          side: false },
-  { key: 'shipped',        label: 'Fertig',          statuses: ['done'],                    side: false },
+  { key: 'shipped',        label: 'Versand',         statuses: ['done'],                    side: false },
   { key: 'attention',   label: 'Blockiert',      statuses: ['blocked'],            side: true },
   { key: 'archive',     label: 'Archiv',         statuses: ['archived'],           side: true },
 ] as const;


### PR DESCRIPTION
## Summary

Deterministic **phase telemetry** for the ticket lifecycle so dev-flow-execute runs become fully visible on the Factory Floor without agent discipline, a **fail-closed merge gate** that enforces the phase chain, and a **Versand lane** that explains its decoupled-deploy semantics. Ticket **T001444**.

### What changed (7 tasks, TDD RED→GREEN)

1. **`update-status.sh`** — status transitions auto-emit a phase event as a SQL side-effect (`in_progress→implement/entered`, `in_review→implement/done`, `qa_review→verify/entered`, `done→deploy/done`, `blocked→<last>/blocked`). Idempotent via `NOT EXISTS` dedup; `detail` prefixed `auto:`; driver from `$TICKET_PHASE_DRIVER` (default `devflow`). Covers the MCP `transition_status` path too (it shells out to `ticket.sh`).
2. **`stage-plan.sh`** — auto-emits `scout/design/plan done` (idempotent).
3. **`pipeline.js`** — pins `TICKET_PHASE_DRIVER=factory` (safety net for driver attribution; dedup makes double-emission harmless).
4. **`assert-phase-chain.sh`** (new, sourced module) + `ticket.sh` dispatcher — `assert-phase-chain --id <ext_id> [--json]`: exit 0 if `plan:done` + `implement:entered` + `verify:done` present, else exit 1 with backfill hints; exit 2 on bad args (validated before `_pgpod`, FA-SF-48).
5. **`dev-flow-execute/SKILL.md`** — fail-closed gate call before `gh pr merge` (no `|| true`); verify telemetry reframed from best-effort to mandatory.
6. **Versand lane** — `pipeline-order.ts` shipped-lane label `Fertig → Versand` (SSOT); `ShippedColumn.svelte` consumes it + subtitle "Gemergt nach main · Prod-Deploy entkoppelt".
7. Freshness artifacts + test inventory regenerated.

### Incidental fix (surfaced, not introduced)

- **`service-registry.sh`** — classifies `k3d/pocket-id-client-seed-rbac.yaml` as `pocket-id`. This was a **latent FA-SF-60 failure**: PR #2487 added the manifest without a registry entry, but that PR did not touch `scripts/factory/`, so its CI skipped `test:factory`. Touching `pipeline.js` here re-triggers `test:factory`, surfacing the gap. One-line fix matching its siblings.

## Self-review (code-review gate — no agent spawned)

- **SQL-injection safety**: every parameter flows through psql `-v var=value` + `:'var'` auto-quoting — no string interpolation into SQL. Verified across `update-status.sh`, `stage-plan.sh`, `assert-phase-chain.sh`.
- **No status-change regression / silent failure**: the `UPDATE` runs in psql autocommit **before** the event `INSERT`, so telemetry can never roll back a status change. Mapped `(phase,state)` values are always CHECK-valid and `driver` is validated to `factory|devflow`, so the INSERT cannot violate a constraint; a nonexistent ticket touches 0 rows (no error).
- **Factory-path regression**: `pipeline.js` only sets an env default when unset; `test:factory` green (340 ok).
- **Gate correctness**: args validated before `_pgpod`; exit codes 0/1/2 as specified; `--json` handles the empty-missing array safely.

## Gates run

| Gate | Result |
|------|--------|
| `tests/spec/software-factory.bats` (T001444, 12 new @tests) | PASS |
| `task test:factory` | PASS (340 ok) after registry fix |
| `task test:unit` | PASS except one machine-local test (`antigravity-cli settings.json`, skips in CI where the file is absent) |
| website vitest (incl. `pipeline-order.test.ts`) | PASS (2646 passed, 0 failed) |
| `task test:openspec` / `openspec.sh validate` | PASS |
| `task freshness:regenerate` + `task freshness:check` | PASS (exit 0) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B5o6guzf5J3B7v2GMnjt7k
