### PR TITLE
fix(ci): honor optional secretKeyRefs in build-website secret-check [T001446]

### DIFF
--- a/.github/workflows/build-website.yml
+++ b/.github/workflows/build-website.yml
@@ -177,7 +177,7 @@ jobs:
                   for c in (doc.get('spec',{}).get('template',{}).get('spec',{}).get('containers',[]) or []):
                       for e in (c.get('env',[]) or []):
                           v = (e.get('valueFrom') or {}).get('secretKeyRef') or {}
-                          if v.get('name') == 'website-secrets' and v.get('key'):
+                          if v.get('name') == 'website-secrets' and v.get('key') and not v.get('optional'):
                               print(v['key'])
           "); do
             if ! kubectl get secret website-secrets -n "$NAMESPACE" \
@@ -296,7 +296,7 @@ jobs:
                   for c in (doc.get('spec',{}).get('template',{}).get('spec',{}).get('containers',[]) or []):
                       for e in (c.get('env',[]) or []):
                           v = (e.get('valueFrom') or {}).get('secretKeyRef') or {}
-                          if v.get('name') == 'website-secrets' and v.get('key'):
+                          if v.get('name') == 'website-secrets' and v.get('key') and not v.get('optional'):
                               print(v['key'])
           "); do
             if ! kubectl get secret website-secrets -n "$NAMESPACE" \

--- a/docs/code-quality/loc-budget.json
+++ b/docs/code-quality/loc-budget.json
@@ -1,8 +1,8 @@
 {
-  "total_lines": 527773,
+  "total_lines": 528504,
   "file_count": 4002,
-  "commit": "72156ccd",
-  "measured_at": "2026-07-02T13:24:15.806Z",
+  "commit": "3ced6a28d",
+  "measured_at": "2026-07-02T13:32:09.468Z",
   "thresholds": {
     "warn_pct": 5,
     "fail_pct": 15,

--- a/tests/spec/ci-cd.bats
+++ b/tests/spec/ci-cd.bats
@@ -249,3 +249,45 @@ PY
   grep -qE 'blocks:.*plan-only' "$bats_file"
   grep -qE 'SKIP_COMMIT_VS_DIFF' "$bats_file"
 }
+
+@test "T001446: build-website Pre-Rollout Secret-Check skips optional secretKeyRefs (both deploy jobs)" {
+  # Regression for T001446: the check collected ALL website-secrets keys from
+  # k3d/website.yaml and hard-failed on cluster-missing ones — even when the
+  # manifest marks the ref `optional: true` (SEPA_CREDITOR_*, DEEPSEEK_API_KEY*,
+  # schema.yaml required:false). That blocked every korczewski website deploy.
+  local wf="$REPO_ROOT/.github/workflows/build-website.yml"
+  [ -f "$wf" ]
+  local count
+  count=$(grep -c "and not v.get('optional')" "$wf")
+  [ "$count" -eq 2 ]
+}
+
+@test "T001446: secret-check filter behaves correctly against a fixture manifest" {
+  # Functional check of the exact python filter line: optional refs excluded,
+  # required refs included.
+  local out
+  out=$(python3 - <<'PY'
+import yaml, io
+doc = """
+spec:
+  template:
+    spec:
+      containers:
+        - name: website
+          env:
+            - name: REQ
+              valueFrom: {secretKeyRef: {name: website-secrets, key: REQ}}
+            - name: OPT
+              valueFrom: {secretKeyRef: {name: website-secrets, key: OPT, optional: true}}
+"""
+for d in yaml.safe_load_all(io.StringIO(doc)):
+    if not d: continue
+    for c in (d.get('spec',{}).get('template',{}).get('spec',{}).get('containers',[]) or []):
+        for e in (c.get('env',[]) or []):
+            v = (e.get('valueFrom') or {}).get('secretKeyRef') or {}
+            if v.get('name') == 'website-secrets' and v.get('key') and not v.get('optional'):
+                print(v['key'])
+PY
+)
+  [ "$out" = "REQ" ]
+}


### PR DESCRIPTION
## Problem
Der Pre-Rollout Secret-Check in `.github/workflows/build-website.yml` (beide Deploy-Jobs) sammelt alle `website-secrets`-`secretKeyRef`-Keys aus `k3d/website.yaml` und failt hart, wenn sie im Cluster fehlen — auch wenn die Referenz `optional: true` ist (SEPA_CREDITOR_*, DEEPSEEK_API_KEY*; laut `environments/schema.yaml` `required: false`).

**Folge:** `Deploy Website (korczewski)` failt seit ≥2026-07-01 bei jedem Lauf — korczewski.de bekommt keine neuen Website-Builds (u. a. die Versand-Lane aus T001444/#2495 nicht live).

## Fix
Python-Filter um `and not v.get('optional')` ergänzt (2 Stellen: mentolder- und korczewski-Job).

## Tests
- `tests/spec/ci-cd.bats`: struktureller Guard (beide Stellen) + funktionaler Fixture-Test des Filters (RED→GREEN).
- `task freshness:check` grün; Test-Inventar regeneriert.

Closes T001446

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B5o6guzf5J3B7v2GMnjt7k