### PR TITLE
chore(scripts): skip loc-budget.json rewrite in post-merge hook when only timestamp/hash changed [T001450]

### DIFF
--- a/.githooks/post-merge
+++ b/.githooks/post-merge
@@ -5,6 +5,20 @@ repo_root="$(git rev-parse --show-toplevel)"
 if [ -d "$repo_root/node_modules" ]; then
   task -d "$repo_root" freshness:regenerate 2>/dev/null || true
 fi
+# loc-budget.json always gets a fresh `commit`/`measured_at` stamp from
+# freshness:regenerate — that alone is diff noise, not a real LOC change.
+# Restore it unless total_lines/file_count actually drifted from HEAD, so a
+# plain `git pull` doesn't leave the tree dirty. CI (freshness-regen.yml)
+# is the source of truth that actually commits this file. [T001450]
+_lb="$repo_root/docs/code-quality/loc-budget.json"
+if [ -f "$_lb" ] && command -v jq &>/dev/null; then
+  _head_counts=$(git -C "$repo_root" show HEAD:docs/code-quality/loc-budget.json 2>/dev/null \
+    | jq -c '{total_lines, file_count}' 2>/dev/null || true)
+  _cur_counts=$(jq -c '{total_lines, file_count}' "$_lb" 2>/dev/null || true)
+  if [ -n "$_head_counts" ] && [ "$_head_counts" = "$_cur_counts" ]; then
+    git -C "$repo_root" checkout -- docs/code-quality/loc-budget.json 2>/dev/null || true
+  fi
+fi
 # Keep codebase-memory graph in sync after merge (incremental, non-blocking).
 if command -v /home/patrick/.local/bin/codebase-memory-mcp &>/dev/null; then
   /home/patrick/.local/bin/codebase-memory-mcp cli index_repository \


### PR DESCRIPTION
## Summary
- `.githooks/post-merge` regenerated `docs/code-quality/loc-budget.json` after every `git pull`, always rewriting `commit`/`measured_at` — pure diff noise even when `total_lines`/`file_count` were unchanged, leaving `main` dirty after a clean pull.
- CI (`freshness-regen.yml`) is already the authoritative source that commits this file after every push to `main`; the local rewrite was redundant.
- Fix: the hook now restores the file to HEAD unless the actual LOC counts drifted, keeping real growth signals while suppressing timestamp-only noise.

## Test plan
- [x] Ran `bash .githooks/post-merge` locally with an unchanged codebase — file restored to HEAD, `git status` clean.
- [x] Verified the hook does NOT restore when counts genuinely differ (observed real drift, tracked separately as T001451).

Ticket: T001450 (chore, status=done — no plan, direct chore per dev-flow-chore).
