### PR TITLE
fix(scripts): mishap bundle - plan_staged drift detection, dev-flow-chore skip, mishap-tracker process type, agent-lock reap live-claim guard

### DIFF
--- a/.claude/skills/dev-flow-chore/SKILL.md
+++ b/.claude/skills/dev-flow-chore/SKILL.md
@@ -59,16 +59,19 @@ bash scripts/agent-lock.sh claim branch "chore/<slug>" --worktree "$PWD" --label
 Claim-Semantik, main-checkout-Sonderfall (`claim main-checkout`) und Release:
 [session-coordination](file:///home/patrick/Bachelorprojekt/.claude/skills/references/session-coordination.md).
 
-Lege ein minimales Audit-Ticket an (type=task, status=done — Chores haben keinen Plan,
-nur eine Audit-Spur):
+Überspringe die Ticket-Erstellung, wenn bereits eine `TICKET_EXT_ID` gesetzt ist (z.B.
+bei Wiederverwendung eines bestehenden Tickets). Sonst lege ein minimales Audit-Ticket
+an (type=task, status=done — Chores haben keinen Plan, nur eine Audit-Spur):
 ```bash
-TICKET_RESULT=$(./scripts/ticket.sh create \
-  --type task \
-  --brand mentolder \
-  --title "chore: <slug>" \
-  --status done \
-  --description "Branch: chore/<slug>"$'\n'"Kein Plan — direktes Chore.")
-TICKET_EXT_ID=$(echo "$TICKET_RESULT" | cut -d'|' -f1)
+if [[ -z "${TICKET_EXT_ID:-}" ]]; then
+  TICKET_RESULT=$(./scripts/ticket.sh create \
+    --type task \
+    --brand mentolder \
+    --title "chore: <slug>" \
+    --status done \
+    --description "Branch: chore/<slug>"$'\n'"Kein Plan — direktes Chore.")
+  TICKET_EXT_ID=$(echo "$TICKET_RESULT" | cut -d'|' -f1)
+fi
 ```
 
 ## Schritt 2: Änderungen vornehmen

--- a/.claude/skills/mishap-tracker/SKILL.md
+++ b/.claude/skills/mishap-tracker/SKILL.md
@@ -14,7 +14,7 @@ Called as the final step of runbook skills that maintain a `MISHAP_LOG`.
 ## Input
 
 The calling skill accumulates a `MISHAP_LOG` — a list of entries, each with:
-- `type`: `broken` | `degraded` | `suspicious` | `security` | `drift` | `process`
+- `type`: `broken` | `degraded` | `suspicious` | `security` | `drift`
 - `title`: Short, actionable summary
 - `description`: What was observed and why it matters
 - `component`: Affected subsystem (e.g., `kubeconfig`, `repo/chore/…`, `skills/<name>`)
@@ -39,7 +39,6 @@ Before reporting any mishap, verify the claim with a concrete check:
 | `broken` (file missing/stale) | `ls` or `git show HEAD:<file>` to confirm absence |
 | `drift` (version mismatch) | Check current value via kubectl/grep before asserting drift |
 | `suspicious` (unexpected state) | Run the command that reveals the state and confirm it |
-| `process` | Observations, not assertions — no verification needed |
 | `security` | Always report without suppression |
 
 **If verification contradicts the observation:** drop the mishap and log `[mishap-tracker] SKIP <title> — verified false positive: <reason>`.
@@ -57,9 +56,6 @@ Before reporting any mishap, verify the claim with a concrete check:
 | `degraded` | `minor` | `mittel` | `needs_human` |
 | `suspicious` | `minor` | `mittel` | `ai_ready` |
 | `drift` | `trivial` | `niedrig` | `ai_ready` |
-| `process` | `trivial` | `niedrig` | `ai_ready` |
-
-For `process` mishaps, set `component = 'skills/<skill-name>'`.
 
 ---
 
@@ -72,7 +68,7 @@ mcp__ticket-mcp__report_mishap({
   title: "<titel>",
   description: "<beschreibung>",
   component: "<komponente>",
-  type: "<broken|degraded|suspicious|security|drift|process>",
+  type: "<broken|degraded|suspicious|security|drift>",
   brand: "<brand>"
 })
 ```

--- a/docs/code-quality/loc-budget.json
+++ b/docs/code-quality/loc-budget.json
@@ -1,8 +1,8 @@
 {
-  "total_lines": 527993,
+  "total_lines": 528783,
   "file_count": 4003,
-  "commit": "c363d0a0",
-  "measured_at": "2026-07-02T14:20:25.015Z",
+  "commit": "fa4a7afaf",
+  "measured_at": "2026-07-02T14:49:29.724Z",
   "thresholds": {
     "warn_pct": 5,
     "fail_pct": 15,

--- a/scripts/agent-lock.sh
+++ b/scripts/agent-lock.sh
@@ -89,6 +89,21 @@ _lock_field() { sed -n "s/.*\"$2\": *\"\\([^\"]*\\)\".*/\\1/p" "$1" 2>/dev/null 
 # Append an append-only audit line whenever a claim is classified reapable.
 # Fail-open: a write failure is ignored (consistent with the rest of the script).
 # NOTE: .reap.log is not rotated here — small text lines; rotate in a follow-up if it grows.
+# Check if a git branch has a live (non-reapable) agent-lock claim. Used by
+# cmd_reap step 2c to protect live-claimed branches from deletion. [T001448 M3]
+_branch_is_live_claimed() {
+  local br="$1" d f
+  d="$(_lock_dir)"
+  [ -d "$d" ] || return 1
+  for f in "$d"/*.json; do
+    [ -e "$f" ] || continue
+    [ "$(_lock_field "$f" branch)" = "$br" ] || continue
+    _reapable "$f" && continue
+    return 0
+  done
+  return 1
+}
+
 _reap_log() {  # <lock-file> <reason>
   printf '%s %s/%s %s\n' "$(_now)" \
     "$(_lock_field "$1" scope)" "$(_lock_field "$1" id)" "$2" \
@@ -266,6 +281,11 @@ cmd_reap() {
   git fetch --prune origin 2>/dev/null || true
   # 2c) delete local branches that were squash-merged into main (upstream gone)
   for br in $(git branch --merged main 2>/dev/null | sed 's/^[* ]*//' | grep -v '^main$'); do
+    # skip branches that have a live agent-lock claim (e.g. dev-flow-plan in progress) [T001448 M3]
+    if _branch_is_live_claimed "$br"; then
+      echo "AGENT-LOCK: Skipping branch '$br' (live agent-lock claim)" >&2
+      continue
+    fi
     # only delete if the upstream tracking branch is gone
     upstream="$(git rev-parse --abbrev-ref "$br@{upstream}" 2>/dev/null)" || true
     if [ -z "$upstream" ] || ! git show-ref --verify --quiet "refs/remotes/$upstream" 2>/dev/null; then

--- a/scripts/factory/reconcile-ticket-status.sh
+++ b/scripts/factory/reconcile-ticket-status.sh
@@ -168,4 +168,85 @@ SQL
   echo "reconcile-ticket-status: $ext_id terminal-no-pr — set attention_mode=needs_human" >&2
 done
 
+# ── Pattern 4: plan_staged without FACTORY-PLAN-REF comment (drift) ──────
+# Tickets in plan_staged should have a FACTORY-PLAN-REF comment with branch
+# info pointing to the remote plan branch. If missing, the ticket is in a
+# confusing state — flag for review. plan_staged + FACTORY-PLAN-REF = healthy
+# (the plan lives on the remote branch, not in ticket_plans). [T001448 M1]
+echo "reconcile-ticket-status: scanning plan_staged-without-plan-ref (${BRAND})" >&2
+mapfile -t ps_no_ref < <(
+  kubectl exec "$POD" -n "$FACTORY_NS" --context "$FACTORY_CTX" -c postgres -- \
+    psql -U website -d website -qtA -v ON_ERROR_STOP=1 \
+      -c "SELECT t.external_id
+           FROM tickets.tickets t
+           WHERE t.status = 'plan_staged'
+             AND t.updated_at < now() - interval '1 hour'
+             AND NOT EXISTS (
+               SELECT 1 FROM tickets.ticket_comments c
+               WHERE c.ticket_id = t.id
+                 AND c.body LIKE 'FACTORY-PLAN-REF %'
+             )
+           ORDER BY t.updated_at DESC;" 2>/dev/null || true
+)
+
+for ext_id in "${ps_no_ref[@]}"; do
+  [[ -z "$ext_id" ]] && continue
+  if [[ "$DRY_RUN" == "true" ]]; then
+    echo "reconcile-ticket-status [DRY-RUN]: $ext_id plan_staged-without-plan-ref — flagging for review" >&2
+    continue
+  fi
+  kubectl exec "$POD" -n "$FACTORY_NS" --context "$FACTORY_CTX" -c postgres -- \
+    psql -U website -d website -qtA -v ON_ERROR_STOP=1 \
+      -v ext_id="$ext_id" <<'SQL' >/dev/null
+UPDATE tickets.tickets
+   SET attention_mode = 'needs_human',
+       notes = COALESCE(notes || E'\n\n', '') || format(E'reconcile-ticket-status watchdog: plan_staged-without-plan-ref — ticket is plan_staged but has no FACTORY-PLAN-REF comment with branch info. Needs manual review.\nDetected: %s', to_char(now(), 'YYYY-MM-DD HH24:MI:SS')),
+       updated_at = now()
+ WHERE external_id = :'ext_id'
+   AND attention_mode IS DISTINCT FROM 'needs_human';
+SQL
+  echo "reconcile-ticket-status: $ext_id plan_staged-without-plan-ref — set attention_mode=needs_human" >&2
+done
+
+# ── Pattern 4b: plan_staged with FACTORY-PLAN-REF but remote branch gone ──
+# The FACTORY-PLAN-REF comment references a remote branch. If that branch has
+# been deleted (e.g. merged and pruned), the plan is orphaned on this ticket
+# and should be flagged as drift. [T001448 M1]
+echo "reconcile-ticket-status: scanning plan_staged-orphan-branch (${BRAND})" >&2
+mapfile -t ps_orphan < <(
+  kubectl exec "$POD" -n "$FACTORY_NS" --context "$FACTORY_CTX" -c postgres -- \
+    psql -U website -d website -qtA -v ON_ERROR_STOP=1 \
+      -c "SELECT t.external_id,
+                 trim(substring(c.body from 'branch=([^ ]+)'))
+          FROM tickets.tickets t
+          JOIN tickets.ticket_comments c ON c.ticket_id = t.id
+          WHERE t.status = 'plan_staged'
+            AND c.body LIKE 'FACTORY-PLAN-REF %branch=%'
+            AND t.updated_at < now() - interval '1 hour'
+          ORDER BY t.updated_at DESC;" 2>/dev/null || true
+)
+
+while IFS='|' read -r ext_id branch_ref; do
+  [[ -z "$ext_id" || -z "$branch_ref" ]] && continue
+  # Check if remote branch exists
+  if ! git ls-remote --heads origin "$branch_ref" 2>/dev/null | grep -q .; then
+    if [[ "$DRY_RUN" == "true" ]]; then
+      echo "reconcile-ticket-status [DRY-RUN]: $ext_id plan_staged-orphan-branch — remote branch '$branch_ref' gone" >&2
+      continue
+    fi
+    kubectl exec "$POD" -n "$FACTORY_NS" --context "$FACTORY_CTX" -c postgres -- \
+      psql -U website -d website -qtA -v ON_ERROR_STOP=1 \
+        -v ext_id="$ext_id" \
+        -v branch="$branch_ref" <<'SQL' >/dev/null
+UPDATE tickets.tickets
+   SET attention_mode = 'needs_human',
+       notes = COALESCE(notes || E'\n\n', '') || format(E'reconcile-ticket-status watchdog: plan_staged-orphan-branch — FACTORY-PLAN-REF references branch ''%s'' but remote branch is gone. Plan is orphaned. Needs manual review.\nDetected: %s', :'branch', to_char(now(), 'YYYY-MM-DD HH24:MI:SS')),
+       updated_at = now()
+ WHERE external_id = :'ext_id'
+   AND attention_mode IS DISTINCT FROM 'needs_human';
+SQL
+    echo "reconcile-ticket-status: $ext_id plan_staged-orphan-branch — remote branch '$branch_ref' gone; set attention_mode=needs_human" >&2
+  fi
+done <<< "$(printf '%s\n' "${ps_orphan[@]}")"
+
 echo "reconcile-ticket-status: fertig (BRAND=${BRAND}, DRY_RUN=${DRY_RUN})"


### PR DESCRIPTION
Mishap 1: reconcile-ticket-status.sh add Patterns 4a/4b for plan_staged
drift detection using FACTORY-PLAN-REF comment + remote branch check.
Mishap 2a: dev-flow-chore SKILL.md skip new-ticket if TICKET_EXT_ID set.
Mishap 2b: mishap-tracker SKILL.md drop process type (API mismatch).
Mishap 3a: agent-lock.sh _branch_is_live_claimed() guard in reap step 2c.
