### PR TITLE
fix(e2e): [T001472] make FA-10 service pages brand-aware for korczewski

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -42,11 +42,13 @@ jobs:
             prod_domain: mentolder.de
             contact_email: info@mentolder.de
             contact_phone: "+49 151 508 32 601"
+            service_pages: /coaching,/beratung
           - cluster: korczewski
             website_url: https://web.korczewski.de
             prod_domain: korczewski.de
             contact_email: info@korczewski.de
             contact_phone: ""
+            service_pages: /ki-beratung,/software-dev,/deployment
     env:
       SELECTED_CLUSTER: ${{ inputs.cluster }}
       EVENT_NAME: ${{ github.event_name }}
@@ -106,6 +108,7 @@ jobs:
           # Per-cluster brand assertions
           CONTACT_EMAIL: ${{ matrix.contact_email }}
           CONTACT_PHONE: ${{ matrix.contact_phone }}
+          WEBSITE_SERVICE_PAGES: ${{ matrix.service_pages }}
           # Auth
           MM_TEST_USER: ${{ secrets.MM_TEST_USER }}
           MM_TEST_PASS: ${{ secrets.MM_TEST_PASS }}

--- a/tests/e2e/specs/fa-10-website.spec.ts
+++ b/tests/e2e/specs/fa-10-website.spec.ts
@@ -27,7 +27,13 @@ test.describe('FA-10: Unternehmenswebsite (Astro) & Kontaktformular', { tag: ['@
 
   test('T2: Subpages are reachable', async ({ page }) => {
     test.setTimeout(120000);
-    const servicePages = (process.env.WEBSITE_SERVICE_PAGES || '/coaching,/beratung').split(',');
+    // Service pages differ per brand. The CI workflow (e2e.yml) sets
+    // WEBSITE_SERVICE_PAGES per-brand in the matrix.  The default here
+    // covers local dev against the mentolder brand.
+    const defaultPages = BASE.includes('korczewski')
+      ? '/ki-beratung,/software-dev,/deployment'
+      : '/coaching,/beratung';
+    const servicePages = (process.env.WEBSITE_SERVICE_PAGES || defaultPages).split(',').filter(Boolean);
     const pages = [
       ...servicePages,
       // '/ueber-mich' — temporarily disabled: consistently times out from GitHub Actions


### PR DESCRIPTION
## Summary

The nightly E2E run (ID 28606358793) failed on both brands. Root cause analysis identified three failure clusters:

### Root cause 1 (FIXED): FA-10 T2 hardcoded /coaching for all brands

`fa-10-website.spec.ts` used a hardcoded default `WEBSITE_SERVICE_PAGES=/coaching,/beratung`. Korczewski brand has no `/coaching` page (its services are `/ki-beratung`, `/software-dev`, `/deployment`), resulting in a non-200 response.

**Fix:** Two-part change:
1. `tests/e2e/specs/fa-10-website.spec.ts` — defaultPages is now brand-aware via `BASE.includes('korczewski')`
2. `.github/workflows/e2e.yml` — added `service_pages` per-brand matrix entry + `WEBSITE_SERVICE_PAGES` env var

### Root cause 2 (ops, not code-fixable): Keycloak/Pocket-ID SSO unreachable

`realms/workspace` timeout cascades to \~60+ auth-dependent tests across both brands.

### Root cause 3 (secondary cascade): systemtest-* + wissensquellen specs

Auth failure cascade from root cause 2.

Closes T001472