### PR TITLE
fix(ci): repair commitlint scope-enum + mishap-bundle path drift [T001516]

### DIFF
--- a/scripts/register-scope.sh
+++ b/scripts/register-scope.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # register-scope.sh <scope> [--config <path>] — idempotently register a new
-# scope in commitlint.config.cjs's scope-enum (the SSOT, T001364).
+# scope in commitlint.config.cjs's namedScopes array (the SSOT, T001364).
 set -euo pipefail
 
 SCOPE="${1:?Usage: register-scope.sh <scope> [--config <path>]}"
@@ -32,7 +32,7 @@ fi
 
 if node -e "
   const cfg = require('$CONFIG');
-  const scopes = cfg.rules['scope-enum'][2];
+  const scopes = cfg.namedScopes;
   process.exit(scopes.includes('$SCOPE') ? 0 : 1);
 "; then
   echo "register-scope: scope '$SCOPE' is already registered — nothing to do" >&2
@@ -47,8 +47,8 @@ node -e "
   const path = '$CONFIG';
   const scope = '$SCOPE';
   const lines = fs.readFileSync(path, 'utf8').split('\n');
-  const closeIdx = lines.findIndex((l) => l.trim() === ']');
-  if (closeIdx === -1) { console.error('register-scope: could not find scope-enum array close'); process.exit(1); }
+  const closeIdx = lines.findIndex((l) => l.trim() === ']' || l.trim() === '];');
+  if (closeIdx === -1) { console.error('register-scope: could not find namedScopes array close'); process.exit(1); }
   const prevIdx = closeIdx - 1;
   const indent = lines[prevIdx].match(/^\s*/)[0];
   // Ensure the previous last-entry line ends with a trailing comma before

--- a/tests/spec/t001353-mishap-bundle-ci-tickets.bats
+++ b/tests/spec/t001353-mishap-bundle-ci-tickets.bats
@@ -24,7 +24,7 @@ setup() {
   REPO="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
   LINT="$REPO/scripts/plan-lint.sh"
   BASELINE="$REPO/docs/code-quality/baseline.json"
-  MISHAPS="$REPO/openspec/changes/t001353-mishap-bundle-ci-tickets/mishaps.md"
+  MISHAPS="$REPO/openspec/changes/archive/2026-07-01-t001353-mishap-bundle-ci-tickets/mishaps.md"
 }
 
 @test "Mishap 1: plan-lint effective_threshold for InboxApp.svelte matches current baseline.json (not a stale hardcoded snapshot)" {

--- a/tests/spec/t001356-git02-conventional-commit.bats
+++ b/tests/spec/t001356-git02-conventional-commit.bats
@@ -98,18 +98,22 @@ teardown() {
   echo "$output" | grep -qx "ci"
 }
 
-@test "scopes: output matches commitlint.config.cjs scope-enum exactly" {
+@test "scopes: output matches commitlint.config.cjs namedScopes exactly" {
   run "$SCRIPT" scopes
   [ "$status" -eq 0 ]
   node_scopes=$(node -e "
     const cfg = require('${BATS_TEST_DIRNAME}/../../commitlint.config.cjs');
-    console.log(cfg.rules['scope-enum'][2].join('\n'));
+    console.log(cfg.namedScopes.join('\n'));
   ")
   [ "$output" == "$node_scopes" ]
 }
 
 @test "ci.yml commit-lint job loads scopes dynamically instead of a hardcoded list" {
-  grep -q 'validate-commit-msg.sh scopes' "${BATS_TEST_DIRNAME}/../../.github/workflows/ci.yml"
+  # ci.yml enforces scopes via the shared 'range' subcommand (individual
+  # commit messages), which internally reads commitlint.config.cjs.namedScopes
+  # dynamically (see validate-commit-msg.sh load_allowed_scopes) — no
+  # hardcoded scope list lives in the workflow itself.
+  grep -q 'validate-commit-msg.sh range' "${BATS_TEST_DIRNAME}/../../.github/workflows/ci.yml"
 }
 
 @test "pr-auto-title.yml checks out the repo before deriving a scope" {


### PR DESCRIPTION
## Summary
- `commitlint.config.cjs` moved from a `scope-enum` rule to a plugin-based `scope-allowed` rule backed by a `namedScopes` array, but `register-scope.sh` and `tests/spec/t001356-git02-conventional-commit.bats` still read the old `cfg.rules['scope-enum'][2]` shape — fixed to `cfg.namedScopes`.
- `register-scope.sh`'s array-close detector only matched a bare `]` line, missing the `];`-terminated `namedScopes` array — now matches both.
- `tests/spec/t001353-mishap-bundle-ci-tickets.bats` hardcoded the pre-archive path to `mishaps.md`; updated to the actual archived location.
- Updated the ci.yml-scope-loading assertion to match the actual (intentional) `range`-subcommand design instead of a `scopes`-subcommand string that was never true.

Discovered while diagnosing failing "Offline Tests" CI checks on PR #2527 and #2529 — this breakage pre-dates both and lives on `main`.

Ticket: T001516

## Test plan
- [x] `./tests/unit/lib/bats-core/bin/bats tests/spec/t001353-mishap-bundle-ci-tickets.bats tests/spec/t001356-git02-conventional-commit.bats` — 24/24 green locally
- [ ] CI green on this PR