### PR TITLE
test(website): repair any-typed mocks + missing beforeEach import [T001517]

### DIFF
--- a/website/src/lib/auth/magic-link.test.ts
+++ b/website/src/lib/auth/magic-link.test.ts
@@ -12,14 +12,14 @@ async function loadModule() {
 describe('mintMagicLink', () => {
   it('generates token and stores in database with default TTL', async () => {
     let called = false;
-    const mockQuery = vi.fn(async (_sql: string, _params?: any[]) => {
+    const mockQuery = vi.fn(async (_sql: string, _params?: unknown[]) => {
       called = true;
       return { rows: [] };
     });
 
     globalThis.process.env.PUBLIC_URL = 'https://test.example.com';
     
-    (await import('../website-db')).pool.query = mockQuery;
+    (await import('../website-db')).pool.query = mockQuery as never;
 
     const m = await loadModule();
     await m.mintMagicLink({
@@ -32,15 +32,15 @@ describe('mintMagicLink', () => {
   });
 
   it('generates token and stores with custom TTL', async () => {
-    let paramsReceived: any[] = [];
-    const mockQuery = vi.fn(async (_sql: string, p?: any[]) => {
-      paramsReceived = p;
+    let paramsReceived: unknown[] = [];
+    const mockQuery = vi.fn(async (_sql: string, p?: unknown[]) => {
+      paramsReceived = p ?? [];
       return { rows: [] };
     });
 
     globalThis.process.env.PUBLIC_URL = 'https://test.example.com';
     
-    (await import('../website-db')).pool.query = mockQuery;
+    (await import('../website-db')).pool.query = mockQuery as never;
 
     const m = await loadModule();
     await m.mintMagicLink({
@@ -50,14 +50,14 @@ describe('mintMagicLink', () => {
       ttlMs: 10 * 60 * 1000, // Custom TTL
     });
 
-    expect(paramsReceived?.[4] > Date.now() + 9 * 60 * 1000).toBe(true);
+    expect(Number(paramsReceived[4])).toBeGreaterThan(Date.now() + 9 * 60 * 1000);
   });
 
   it('falls back to SITE_URL when PUBLIC_URL is not set', async () => {
     delete globalThis.process.env.PUBLIC_URL;
     
-    const mockQuery = vi.fn(async (_sql: string, _params?: any[]) => ({ rows: [] }));
-    (await import('../website-db')).pool.query = mockQuery;
+    const mockQuery = vi.fn(async (_sql: string, _params?: unknown[]) => ({ rows: [] }));
+    (await import('../website-db')).pool.query = mockQuery as never;
 
     globalThis.process.env.SITE_URL = 'https://alt.example.com';
 
@@ -74,32 +74,32 @@ describe('mintMagicLink', () => {
 
 describe('redeemMagicToken - missing token validation', () => {
   it('returns missing for empty string token', async () => {
-    const mockQuery = vi.fn(async (): Promise<{ rows: any[] }> => ({ rows: [] }));
-    (await import('../website-db')).pool.query = mockQuery;
+    const mockQuery = vi.fn(async (): Promise<{ rows: unknown[] }> => ({ rows: [] }));
+    (await import('../website-db')).pool.query = mockQuery as never;
 
     const m = await loadModule();
     expect(await m.redeemMagicToken('')).toEqual({ ok: false, reason: 'missing' });
   });
 
   it('returns missing for null token', async () => {
-    const mockQuery = vi.fn(async (): Promise<{ rows: any[] }> => ({ rows: [] }));
-    (await import('../website-db')).pool.query = mockQuery;
+    const mockQuery = vi.fn(async (): Promise<{ rows: unknown[] }> => ({ rows: [] }));
+    (await import('../website-db')).pool.query = mockQuery as never;
 
     const m = await loadModule();
     expect(await m.redeemMagicToken(null as unknown as string)).toEqual({ ok: false, reason: 'missing' });
   });
 
   it('returns missing for undefined token', async () => {
-    const mockQuery = vi.fn(async (): Promise<{ rows: any[] }> => ({ rows: [] }));
-    (await import('../website-db')).pool.query = mockQuery;
+    const mockQuery = vi.fn(async (): Promise<{ rows: unknown[] }> => ({ rows: [] }));
+    (await import('../website-db')).pool.query = mockQuery as never;
 
     const m = await loadModule();
     expect(await m.redeemMagicToken(undefined as unknown as string)).toEqual({ ok: false, reason: 'missing' });
   });
 
   it('returns missing for whitespace token', async () => {
-    const mockQuery = vi.fn(async (): Promise<{ rows: any[] }> => ({ rows: [] }));
-    (await import('../website-db')).pool.query = mockQuery;
+    const mockQuery = vi.fn(async (): Promise<{ rows: unknown[] }> => ({ rows: [] }));
+    (await import('../website-db')).pool.query = mockQuery as never;
 
     const m = await loadModule();
     expect(await m.redeemMagicToken('   ')).toEqual({ ok: false, reason: 'unknown' });
@@ -108,8 +108,8 @@ describe('redeemMagicToken - missing token validation', () => {
 
 describe('redeemMagicToken - database lookup scenarios', () => {
   it('returns unknown when token does not exist in database', async () => {
-    const mockQuery = vi.fn(async (): Promise<{ rows: any[] }> => ({ rows: [] }));
-    (await import('../website-db')).pool.query = mockQuery;
+    const mockQuery = vi.fn(async (): Promise<{ rows: unknown[] }> => ({ rows: [] }));
+    (await import('../website-db')).pool.query = mockQuery as never;
 
     const m = await loadModule();
     expect(await m.redeemMagicToken('nonexistent-token')).toEqual({ ok: false, reason: 'unknown' });
@@ -144,7 +144,7 @@ describe('redeemMagicToken - database lookup scenarios', () => {
   });
 
   it('returns success when token is valid', async () => {
-    let rowReturned: any;
+    let rowReturned: { keycloak_user_id: string; session_payload: string; redirect_uri: string } | undefined;
     vi.mocked((await import('../website-db')).pool.query).mockImplementation(async (sql: string) => {
       if (sql.includes('UPDATE')) {
         rowReturned = { keycloak_user_id: 'kc-user-123', session_payload: JSON.stringify({ sub: 'sub-456', email: 'success@example.com', name: 'Success User', preferred_username: 'successuser' }), redirect_uri: '/dashboard' };
@@ -157,6 +157,7 @@ describe('redeemMagicToken - database lookup scenarios', () => {
     const result = await m.redeemMagicToken('valid-token');
 
     expect(result.ok).toBe(true);
+    if (!rowReturned) throw new Error('expected UPDATE row');
     const payload = JSON.parse(rowReturned.session_payload);
     expect(payload.email).toBe('success@example.com');
   });
@@ -174,6 +175,7 @@ describe('redeemMagicToken - session properties', () => {
     const m = await loadModule();
     const result = await m.redeemMagicToken('redirect-token');
 
+    if (!result.ok) throw new Error('expected redeem success');
     expect(result.redirectUri).toBe('/custom-path?param=value');
   });
 
@@ -183,6 +185,7 @@ describe('redeemMagicToken - session properties', () => {
     const m = await loadModule();
     const result = await m.redeemMagicToken('exp-token');
 
+    if (!result.ok) throw new Error('expected redeem success');
     expect(result.user.expires_at - Date.now()).toBeGreaterThan(8 * 60 * 60 * 1000 - 5000);
   });
 
@@ -194,6 +197,7 @@ describe('redeemMagicToken - session properties', () => {
     const m = await loadModule();
     const result = await m.redeemMagicToken('brand-token');
 
+    if (!result.ok) throw new Error('expected redeem success');
     expect(result.user.brand).toBe('brand-uuid');
   });
 
@@ -206,6 +210,7 @@ describe('redeemMagicToken - session properties', () => {
     const m = await loadModule();
     const result = await m.redeemMagicToken('fallback-token');
 
+    if (!result.ok) throw new Error('expected redeem success');
     expect(result.user.brand).toBe('fallback-brand');
   });
 });

--- a/website/src/lib/browser-logger.test.ts
+++ b/website/src/lib/browser-logger.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { beforeEach, describe, it, expect, vi } from 'vitest';
 import { browserLogger } from './browser-logger';
 
 describe('browserLogger', () => {


### PR DESCRIPTION
## Summary
- `28595cce0` (feat(test): improve vitest coverage for auth module) left `any`-typed `vi.fn()` mocks in `magic-link.test.ts` and a missing `beforeEach` import in `browser-logger.test.ts`.
- This breaks two CI jobs on `main`: `@typescript-eslint/no-explicit-any` (Vitest/lint job, 10 errors) and the Astro TypeScript Check (14 tsc errors — mock type mismatches + unnarrowed `RedeemedToken | RedeemFailure` union access).
- Currently blocking PR #2528 (release-please).

Ticket: T001517

## Test plan
- [x] `pnpm exec eslint src/lib/auth/magic-link.test.ts src/lib/browser-logger.test.ts --max-warnings 0` — clean
- [x] `pnpm exec astro check` — 0 errors (was 14)
- [x] `pnpm exec vitest run src/lib/auth/magic-link.test.ts src/lib/browser-logger.test.ts` — 25/25 passed
- [ ] CI green on this PR