### PR TITLE
test(website): fix stale npm assertions in docker-build-speedup.bats

### DIFF
--- a/tests/spec/docker-build-speedup.bats
+++ b/tests/spec/docker-build-speedup.bats
@@ -6,7 +6,7 @@
 # ── Phase 1: Layer-Caching ──────────────────────────────────────────────────
 @test "P1: website Dockerfile hat # syntax + npm-Cache-Mount" {
   head -1 website/Dockerfile | grep -q 'syntax=docker/dockerfile:1'
-  grep -q 'mount=type=cache,target=/root/.npm npm ci' website/Dockerfile
+  grep -q 'mount=type=cache,target=/pnpm/store pnpm install --frozen-lockfile' website/Dockerfile
 }
 
 @test "P1: kein --no-cache in den umgestellten Build-Workflows" {
@@ -34,7 +34,7 @@
 
 # ── Phase 2: Website slim + Konsolidierung ─────────────────────────────────
 @test "P2: website Dockerfile pruned devDependencies" {
-  grep -q 'npm prune --omit=dev' website/Dockerfile
+  grep -q 'pnpm install --prod' website/Dockerfile
 }
 
 @test "P2: website-Build-Workflow pusht das geteilte Image" {


### PR DESCRIPTION
## Summary
- P1 and P2 tests in `tests/spec/docker-build-speedup.bats` still asserted npm-era Dockerfile commands (`mount=type=cache,target=/root/.npm npm ci`, `npm prune --omit=dev`).
- PR #2215 (T001224/T001276) migrated `website/Dockerfile` to pnpm but never updated these test assertions, leaving the bats file permanently red on main.
- Updated the two grep assertions to match the actual pnpm commands in the Dockerfile: `mount=type=cache,target=/pnpm/store pnpm install --frozen-lockfile` and `pnpm install --prod`.

Root cause: stale test, not stale production code — the Dockerfile itself is correct post-migration.

## Verification
```
./tests/unit/lib/bats-core/bin/bats tests/spec/docker-build-speedup.bats
# 1..14, all ok
```
No `@test` entries added/removed/renamed, so `test-inventory.json` is unchanged (`task test:inventory` produced no diff).

[T001523]