### PR TITLE
fix: t001524 g sec05

### DIFF
--- a/tests/spec/commit-signing.bats
+++ b/tests/spec/commit-signing.bats
@@ -5,7 +5,11 @@
 
 load 'test_helper'
 
-BOT_EMAIL="41898282+github-actions[bot]@users.noreply.github.com"
+# Match both noreply email variants used by github-actions[bot] across workflows:
+# the canonical "<id>+github-actions[bot]@..." form and the bare form some
+# workflows configure via `git config user.email`. grep -F substring-matches,
+# so the bare suffix below matches both.
+BOT_EMAIL="github-actions[bot]@users.noreply.github.com"
 
 @test "G-SEC05: adjusted unsigned-Anteil auf main (ohne Bot) ist <= 5%" {
   unsigned=$(git -C "$PROJECT_DIR" log -50 --pretty="%G? %ae" origin/main 2>/dev/null \


### PR DESCRIPTION
## Summary
Fixes tests/spec/commit-signing.bats test case "G-SEC05: adjusted unsigned-Anteil auf main (ohne Bot) ist <= 5%", which fails on current origin/main.

## Root cause
`BOT_EMAIL` in the test only matched the canonical `<id>+github-actions[bot]@users.noreply.github.com` noreply address. `.github/workflows/codebase-memory-regen.yml` configures git with the bare `github-actions[bot]@users.noreply.github.com` form (no numeric id prefix) for its auto-commit step. Those bot commits are unsigned and leaked into the "non-bot unsigned" bucket, pushing the ratio above the 5% G-SEC05 threshold.

## Fix
Narrowed `BOT_EMAIL` to the common suffix shared by both noreply email variants (`github-actions[bot]@users.noreply.github.com`). `grep -F` substring-matches, so this now excludes bot commits under either email format, matching the SSOT intent (exclude all github-actions[bot] commits from the unsigned-signing metric) rather than one specific address string.

## Verification
```
cd tests/unit/lib/bats-core... # bundled bats
./tests/unit/lib/bats-core/bin/bats tests/spec/commit-signing.bats
# 1..2
# ok 1 G-SEC05: adjusted unsigned-Anteil auf main (ohne Bot) ist <= 5%
# ok 2 G-SEC05: health-goals-check.sh verwendet adjusted metric (kein raw grep -c N)
```

No `@test` entries added/removed/renamed, so no test-inventory.json regeneration needed.

Ticket: T001524