### PR TITLE
test(website): exclude .test.ts from G-FE03 bats console.error/warn count [T001527]

### DIFF
--- a/tests/spec/g-fe03-structured-logger.bats
+++ b/tests/spec/g-fe03-structured-logger.bats
@@ -6,7 +6,7 @@
 @test "G-FE03: keine rohen console.error/warn Aufrufe (exkl. browser-logger-Stub)" {
   count=$(grep -rEn 'console\.(error|warn)' website/src \
     --include='*.ts' --include='*.svelte' --include='*.astro' 2>/dev/null \
-    | grep -v 'browser-logger\.ts' | wc -l | tr -d ' ')
+    | grep -v 'browser-logger\.ts' | grep -v '\.test\.ts' | wc -l | tr -d ' ')
   [ "$count" -eq 0 ]
 }
 


### PR DESCRIPTION
## Summary
- tests/spec/g-fe03-structured-logger.bats never picked up the `.test.ts` exclusion that commit 00ee94ab4 already applied to `scripts/health-goals-check.sh` for the same G-FE03 metric — the two implementations of the same grep drifted apart.
- `website/src/lib/browser-logger.test.ts` and `website/src/lib/systemtest/recorder.test.ts` legitimately call `console.error`/`console.warn` directly (spying on the browser-logger stub's forwarding behavior, and testing the console-capture monkeypatch respectively) — this is expected per REQ-5 of the archived G-FE03 SSOT spec, not application-code drift.
- Fix: bats test's grep now also excludes `*.test.ts`, matching `health-goals-check.sh`.

Root cause: this is not new drift in production/test code — it's the bats assertion being stale relative to a fix already applied elsewhere in the repo for the identical metric.

## Test plan
- [x] `./tests/unit/lib/bats-core/bin/bats tests/spec/g-fe03-structured-logger.bats` — all 3 tests pass
- [x] No `@test` entries added/removed — test-inventory regeneration confirmed no diff (`task test:inventory`, `task freshness:regenerate`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)