### PR TITLE
test(test): update stale busybox canonical pin from 1.37 to 1.38.0 [T001529]

### DIFF
--- a/tests/spec/image-drift.bats
+++ b/tests/spec/image-drift.bats
@@ -12,8 +12,8 @@
 #     loki-rendered.yaml, promtail-rendered.yaml) sind deterministisch aus
 #     dem Upstream-Chart → werden ausgeschlossen.
 #
-# Aktuelle kanonische Pins (2026-06-27):
-#   busybox:1.37
+# Aktuelle kanonische Pins (2026-07-03):
+#   busybox:1.38.0
 #   curlimages/curl:8.7.1   (zusätzlich: 8.7.1@sha256:… bleibt erlaubt)
 #   kiwigrid/k8s-sidecar:2.7.3   (nur in helm-rendered; derzeit ausgeschlossen)
 
@@ -21,10 +21,10 @@ setup() {
   REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
 }
 
-@test "G-IMG02: keine busybox Drift-Tags (außer 1.37) in hand-editierten Manifesten" {
+@test "G-IMG02: keine busybox Drift-Tags (außer 1.38.0) in hand-editierten Manifesten" {
   drift=$(grep -rhE 'image:[[:space:]]+["'"'"']?busybox:' \
     "$REPO_ROOT/k3d/" "$REPO_ROOT/prod/" "$REPO_ROOT/prod-korczewski/" 2>/dev/null \
-    | grep -vE 'busybox:1\.37(\s|$|")' \
+    | grep -vE 'busybox:1\.38\.0(@sha256|\s|$|")' \
     | grep -vE 'kube-prometheus-stack-rendered|loki-rendered|promtail-rendered' \
     | wc -l)
   [ "$drift" -eq 0 ]


### PR DESCRIPTION
## Summary
- G-IMG02's busybox drift test (`tests/spec/image-drift.bats`) hardcoded `busybox:1.37` as the canonical pin, but the whole repo (`k3d/`, `prod/`, `prod-korczewski/`) has been uniformly on `busybox:1.38.0@sha256:...` for a while — zero actual drift.
- The dynamic drift-family test in the same file (which derives the canonical tag instead of hardcoding it) already passed, confirming there is no real drift, only a stale hardcoded expectation.
- Updates the hardcoded regex and doc comment to the current canonical tag.

## Root cause
Test-side drift: the assertion hardcodes a canonical version string in a comment/regex instead of deriving it dynamically (like the companion "Drift-Familie" test does). When busybox was bumped repo-wide from 1.37 to 1.38.0, this test was not updated to match.

## Verification
```
./tests/unit/lib/bats-core/bin/bats tests/spec/image-drift.bats
# 1..4
# ok 1 G-IMG02: keine busybox Drift-Tags (außer 1.38.0) in hand-editierten Manifesten
# ok 2 G-IMG02: keine curlimages/curl Drift-Tags (außer 8.7.1 + sha256-Pin) in hand-editierten Manifesten
# ok 3 G-IMG02: busybox Drift-Familie: 0 (≤ 1 kanonischer Tag in hand-editierten Manifesten)
# ok 4 G-IMG02: curlimages/curl Drift-Familie: 0 (≤ 1 kanonischer Tag in hand-editierten Manifesten)
```

Ticket: T001529