### PR TITLE
fix(ci): install pnpm in offline-tests job for G-DEP01 audit gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,20 @@ jobs:
           node-version: '22'
           cache: 'npm'
 
+      - name: Set up pnpm
+        # Needed because tests/spec/*.bats (run via `task test:changed` ->
+        # `task test:factory`) shell out to `pnpm audit` / `pnpm why` for the
+        # G-DEP01 gate. Without this, pnpm is missing from PATH on the
+        # runner and that gate fails even when the lockfile is clean.
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda  # v4.1.0
+        with:
+          version: 10
+
+      - name: Install website dependencies
+        run: |
+          cd website
+          pnpm install --frozen-lockfile
+
       - uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611  # v2.0.0
         with:
           version: 3.x


### PR DESCRIPTION
## Summary
- `tests/spec/g-dep01-npm-vuln.bats` ("pnpm audit reports zero vulnerabilities") shells out to `pnpm audit --json`, run as part of `task test:changed` -> `task test:factory` inside the `offline-tests` CI job.
- That job never ran `pnpm/action-setup` or installed `website/` deps (only `vitest-website`/`astro-check` did), so `pnpm` was missing from `PATH` there, `pnpm audit --json` produced no valid JSON, and the test's fallback `total=-1` made the assertion fail — even though the lockfile itself has 0 vulnerabilities (verified locally: `pnpm audit --json` → `{info:0,low:0,moderate:0,high:0,critical:0}`).
- This blocked unrelated PRs touching `scripts/` or `tests/spec/` (which trigger the broader `test:factory` domain suite) from merging.
- Fix: add the same `pnpm/action-setup` (v10, matching the other jobs) + `pnpm install --frozen-lockfile` steps to the `offline-tests` job, before `task test:changed` runs.

Root cause ticket: T001530

## Verification
- `./tests/unit/lib/bats-core/bin/bats tests/spec/g-dep01-npm-vuln.bats` — all 3 tests pass
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` — YAML parses cleanly
- `git push` pre-push hooks (commit-msg lint, quality:check, freshness) all passed with no new violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)