### PR TITLE
test(scripts): pass --suggest-tickets in repo-health-goals ticket-suggestion tests [T001531]

### DIFF
--- a/tests/spec/repo-health-goals.bats
+++ b/tests/spec/repo-health-goals.bats
@@ -54,7 +54,7 @@ VAL
 
 @test "ticket command is well-formed" {
   _write_mixed_fixture
-  run env HG_GOALS_FILE="$GOALS" HG_VALUES_FILE="$VALUES" bash "$SCRIPT" --dry-run
+  run env HG_GOALS_FILE="$GOALS" HG_VALUES_FILE="$VALUES" bash "$SCRIPT" --dry-run --suggest-tickets
   [ "$status" -eq 0 ]
   [[ "$output" == *"scripts/ticket.sh create"* ]]
   # exactly one of each required flag in the suggestion
@@ -82,7 +82,7 @@ MD
   cat > "$VALUES" <<'VAL'
 G-ESC01 3 le 0
 VAL
-  run env HG_GOALS_FILE="$GOALS" HG_VALUES_FILE="$VALUES" bash "$SCRIPT" --dry-run
+  run env HG_GOALS_FILE="$GOALS" HG_VALUES_FILE="$VALUES" bash "$SCRIPT" --dry-run --suggest-tickets
   [ "$status" -eq 0 ]
   # $, ", and ` must all be backslash-escaped so the suggestion is safe to
   # paste into a double-quoted shell string without triggering substitution.


### PR DESCRIPTION
## Summary
- Fixes two failing bats tests in `tests/spec/repo-health-goals.bats`: "ticket command is well-formed" and "special chars in goal text are shell-escaped in the suggestion".
- Root cause: PR #2480 made `scripts/health-goals-update.sh`'s ticket-create suggestion output opt-in via `--suggest-tickets` (to stop the auto-suggestion churn pattern), but never updated these two tests, which still invoked the script with only `--dry-run`. The suggestion block was therefore silently skipped, so the assertions checking for `scripts/ticket.sh create ...` output failed.
- Fix: add `--suggest-tickets` to both `run env ... bash "$SCRIPT" --dry-run` invocations, matching current script behavior. No production code changed — the script's opt-in behavior is intentional (see commit d5f47a6cd).

## Verification
```
./tests/unit/lib/bats-core/bin/bats tests/spec/repo-health-goals.bats
# 1..5
# ok 1 unchanged open goal is listed
# ok 2 ticket command is well-formed
# ok 3 no open goals prints the empty line
# ok 4 special chars in goal text are shell-escaped in the suggestion
# ok 5 report block is identical under dry-run
```
`task test:inventory` produces no diff (no `@test` entries added/removed, only assertion bodies changed).

[T001531]