### PR TITLE
fix(ci): add OPENSPEC_TELEMETRY opt-out to 3 drifted workflows

### DIFF
--- a/.github/workflows/build-rustdesk-installer.yml
+++ b/.github/workflows/build-rustdesk-installer.yml
@@ -13,6 +13,9 @@ permissions:
   packages: write
 
 env:
+  # T001265: CI-wide OpenSpec telemetry opt-out (blanket convention, applied
+  # regardless of whether this workflow invokes the openspec CLI directly).
+  OPENSPEC_TELEMETRY: '0'
   # Non-sensitive public relay host; used ONLY to assert the client was configured.
   EXPECTED_ID_SERVER: rustdesk.mentolder.de
   # Supply-chain pin — official RustDesk Windows MSI (rustdesk/rustdesk 1.4.8).

--- a/.github/workflows/codebase-memory-regen.yml
+++ b/.github/workflows/codebase-memory-regen.yml
@@ -10,6 +10,11 @@ concurrency:
   group: codebase-memory-regen-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  # T001265: CI-wide OpenSpec telemetry opt-out (blanket convention, applied
+  # regardless of whether this workflow invokes the openspec CLI directly).
+  OPENSPEC_TELEMETRY: '0'
+
 jobs:
   reindex:
     name: Re-index codebase graph

--- a/.github/workflows/pr-auto-title.yml
+++ b/.github/workflows/pr-auto-title.yml
@@ -23,6 +23,11 @@ on:
 permissions:
   pull-requests: write
 
+env:
+  # T001265: CI-wide OpenSpec telemetry opt-out (blanket convention, applied
+  # regardless of whether this workflow invokes the openspec CLI directly).
+  OPENSPEC_TELEMETRY: '0'
+
 jobs:
   auto-title:
     name: Auto-title PR from branch name


### PR DESCRIPTION
## Summary
- Fixes T001532 (ticketed bug): `tests/spec/openspec-workflow.bats` T001265 asserts every workflow under `.github/workflows/` sets `OPENSPEC_TELEMETRY: '0'`.
- Three workflows had drifted from this blanket convention: `build-rustdesk-installer.yml`, `codebase-memory-regen.yml`, `pr-auto-title.yml`.
- This pre-existing failure was blocking unrelated PRs whenever `task test:changed` widened to the domain suite touching `scripts/` or `tests/spec/`.

## Root cause
The repo blanket-sets `OPENSPEC_TELEMETRY: '0'` in every CI workflow's `env:` block (regardless of whether that workflow invokes the openspec CLI/task), per T001265. These 3 workflows were added or edited afterward without it.

## Fix
Add `OPENSPEC_TELEMETRY: '0'` to each workflow's `env:` block, matching the established pattern used everywhere else.

## Test plan
- [x] `./tests/unit/lib/bats-core/bin/bats tests/spec/openspec-workflow.bats` — all 29 tests pass locally (target test 12 now green, no regressions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)