### PR TITLE
test(test): fix stale WiX/provision file references in rustdesk-server.bats [T001535]

### DIFF
--- a/tests/spec/rustdesk-server.bats
+++ b/tests/spec/rustdesk-server.bats
@@ -191,11 +191,11 @@ setup() {
 
 @test "rustdesk-client: WiX wrapper source is well-formed XML" {
   command -v python3 >/dev/null || skip "python3 not installed"
-  python3 -c "import xml.dom.minidom as m; m.parse('${REPO_ROOT}/rustdesk-installer/Package.wxs')"
+  python3 -c "import xml.dom.minidom as m; m.parse('${REPO_ROOT}/rustdesk-installer/Bundle.wxs')"
   python3 -c "import xml.dom.minidom as m; m.parse('${REPO_ROOT}/rustdesk-installer/rustdesk-installer.wixproj')"
 }
 
-@test "rustdesk-client: provision.ps1 keeps secret placeholders (no committed secret)" {
-  grep -q '__RUSTDESK_CONFIG__' "${REPO_ROOT}/rustdesk-installer/provision.ps1"
-  grep -q '__RUSTDESK_PASSWORD__' "${REPO_ROOT}/rustdesk-installer/provision.ps1"
+@test "rustdesk-client: provision.cmd keeps secret placeholders (no committed secret)" {
+  grep -q '__RUSTDESK_CONFIG__' "${REPO_ROOT}/rustdesk-installer/provision.cmd"
+  grep -q '__RUSTDESK_PASSWORD__' "${REPO_ROOT}/rustdesk-installer/provision.cmd"
 }


### PR DESCRIPTION
## Summary
- Two assertions in `tests/spec/rustdesk-server.bats` referenced files deleted in T001425 (`rustdesk-installer/Package.wxs`, `rustdesk-installer/provision.ps1`), which were replaced by `Bundle.wxs`/`provision.cmd` when the installer was rewritten from a wrapper MSI to a WiX Burn bundle.
- This made both tests fail unconditionally on every run since that rewrite landed, blocking any PR that triggers `task test:changed`'s broader domain suite.

## Root cause
Commit `a46447c8f` (T001425) renamed `Package.wxs` → `Bundle.wxs` and `provision.ps1` → `provision.cmd`, but the bats test file was never updated to match.

## Fix
Point both assertions at the current filenames (`Bundle.wxs`, `provision.cmd`); no production code changed — the WiX bundle XML is well-formed and `provision.cmd` already keeps the `__RUSTDESK_CONFIG__` / `__RUSTDESK_PASSWORD__` placeholders.

## Test plan
- [x] `./tests/unit/lib/bats-core/bin/bats tests/spec/rustdesk-server.bats` — all 25 tests pass locally
- [x] `task test:inventory` run (no diff produced)

Ticket: T001535