### PR TITLE
test(dev-flow): decouple plan-context.bats from live openspec/changes state [T001534]

### DIFF
--- a/tests/spec/plan-context.bats
+++ b/tests/spec/plan-context.bats
@@ -2,6 +2,10 @@
 # tests/spec/plan-context.bats
 # SSOT: openspec/changes/plan-context-role-filter/specs/dev-flow-plan.md
 # T001387 — plan-context.sh <role> wertet <role> nie aus; Filter ist wirkungslos.
+# T001534 — decoupled from live openspec/changes/ contents (PR #2480 archived
+#   60 stale changes incl. the two proposals this file used to hardcode by
+#   name, and dropped the active-changes count below the old >=30 floor —
+#   breaking these tests without any change to plan-context.sh itself).
 #
 # Failing-test contract: these cases MUST fail on the pre-fix
 # `fix/t001387-plan-context-role-filter` branch (the current script
@@ -11,9 +15,12 @@
 # Test strategy: we run the script against the *real* repo (the script
 # uses `git rev-parse --show-toplevel` to anchor `CHANGES_DIR`; an
 # OPENSPEC_ROOT override is intentionally NOT used so we test the
-# production code path). The cases assert inclusion / exclusion of
-# specific real proposals in the active change set, plus stderr WARN
-# markers emitted by the new filter logic.
+# production code path). To stay independent of the ever-changing set of
+# real active OpenSpec changes (proposals get archived over time), the
+# role-filter inclusion/exclusion cases use dedicated fixture proposals
+# created in setup() and removed in teardown(). Anchor cases that assert
+# "all non-archived proposals" compare against the real on-disk count
+# computed at test time, not a hardcoded floor.
 #
 # Cases 3, 5, 7 are anchor cases (PASS pre- and post-fix) that lock in
 # the existing semantics (archive exclusion, mandatory-arg error) so
@@ -23,44 +30,79 @@ setup() {
   REPO="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
   SCRIPT="$REPO/scripts/plan-context.sh"
   [[ -x "$SCRIPT" ]] || chmod +x "$SCRIPT"
+
+  CHANGES_DIR="$REPO/openspec/changes"
+  FIXTURE_OPS_SLUG="zz-test-pcf-fixture-ops"
+  FIXTURE_WEBSITE_SLUG="zz-test-pcf-fixture-website"
+  FIXTURE_CI_SLUG="zz-test-pcf-fixture-ci"
+
+  _make_fixture() {
+    local slug="$1" domains="$2"
+    mkdir -p "$CHANGES_DIR/$slug"
+    cat > "$CHANGES_DIR/$slug/proposal.md" <<EOF
+---
+title: "Proposal: $slug"
+EOF
+    printf -- '---\n' >> "$CHANGES_DIR/$slug/proposal.md"
+    printf '\n# Proposal: %s\n\ntest fixture, safe to ignore.\n' "$slug" >> "$CHANGES_DIR/$slug/proposal.md"
+    cat > "$CHANGES_DIR/$slug/tasks.md" <<EOF
+---
+title: "Tasks: $slug"
+domains: [$domains]
+status: active
+---
+
+# Tasks: $slug
+
+- [ ] test fixture task
+EOF
+  }
+
+  _make_fixture "$FIXTURE_OPS_SLUG" "ops"
+  _make_fixture "$FIXTURE_WEBSITE_SLUG" "website"
+  _make_fixture "$FIXTURE_CI_SLUG" "ci"
+}
+
+teardown() {
+  rm -rf "$CHANGES_DIR/$FIXTURE_OPS_SLUG" "$CHANGES_DIR/$FIXTURE_WEBSITE_SLUG" "$CHANGES_DIR/$FIXTURE_CI_SLUG"
 }
 
 # ── (1) role=ops must include ops-tagged proposals and exclude website-only ──
 
-@test "PCF: role=bachelorprojekt-ops includes ops-tagged proposal (agent-push-notifications)" {
+@test "PCF: role=bachelorprojekt-ops includes ops-tagged proposal (fixture)" {
   out="$(bash "$SCRIPT" bachelorprojekt-ops 2>/dev/null || true)"
-  echo "$out" | grep -q '### Active proposal: agent-push-notifications' \
-    || { echo "MISSING: agent-push-notifications (domains: [infra, website, ops, security]) should be included for ops"; return 1; }
+  echo "$out" | grep -q "### Active proposal: $FIXTURE_OPS_SLUG" \
+    || { echo "MISSING: $FIXTURE_OPS_SLUG (domains: [ops]) should be included for ops"; return 1; }
 }
 
-@test "PCF: role=bachelorprojekt-ops excludes website-only proposal (cockpit-mobile-view)" {
+@test "PCF: role=bachelorprojekt-ops excludes website-only proposal (fixture)" {
   out="$(bash "$SCRIPT" bachelorprojekt-ops 2>/dev/null || true)"
-  if echo "$out" | grep -q '### Active proposal: cockpit-mobile-view'; then
-    echo "REGRESSION: cockpit-mobile-view (domains: [website]) leaked into ops output — filter not active"
+  if echo "$out" | grep -q "### Active proposal: $FIXTURE_WEBSITE_SLUG"; then
+    echo "REGRESSION: $FIXTURE_WEBSITE_SLUG (domains: [website]) leaked into ops output — filter not active"
     return 1
   fi
 }
 
-@test "PCF: role=bachelorprojekt-ops excludes non-ops/non-infra proposal (ci01-skip-ci-bot-commits)" {
+@test "PCF: role=bachelorprojekt-ops excludes non-ops/non-infra proposal (fixture)" {
   out="$(bash "$SCRIPT" bachelorprojekt-ops 2>/dev/null || true)"
-  if echo "$out" | grep -q '### Active proposal: ci01-skip-ci-bot-commits'; then
-    echo "REGRESSION: ci01-skip-ci-bot-commits (domains: [ci]) leaked into ops output — filter not active"
+  if echo "$out" | grep -q "### Active proposal: $FIXTURE_CI_SLUG"; then
+    echo "REGRESSION: $FIXTURE_CI_SLUG (domains: [ci]) leaked into ops output — filter not active"
     return 1
   fi
 }
 
 # ── (2) role=website must include website-tagged and exclude pure-test ──
 
-@test "PCF: role=bachelorprojekt-website includes website-tagged proposal (cockpit-mobile-view)" {
+@test "PCF: role=bachelorprojekt-website includes website-tagged proposal (fixture)" {
   out="$(bash "$SCRIPT" bachelorprojekt-website 2>/dev/null || true)"
-  echo "$out" | grep -q '### Active proposal: cockpit-mobile-view' \
-    || { echo "MISSING: cockpit-mobile-view (domains: [website]) should be included for website"; return 1; }
+  echo "$out" | grep -q "### Active proposal: $FIXTURE_WEBSITE_SLUG" \
+    || { echo "MISSING: $FIXTURE_WEBSITE_SLUG (domains: [website]) should be included for website"; return 1; }
 }
 
-@test "PCF: role=bachelorprojekt-website excludes non-website proposal (img02-image-drift)" {
+@test "PCF: role=bachelorprojekt-website excludes non-website proposal (fixture)" {
   out="$(bash "$SCRIPT" bachelorprojekt-website 2>/dev/null || true)"
-  if echo "$out" | grep -q '### Active proposal: img02-image-drift'; then
-    echo "REGRESSION: img02-image-drift (domains: [infra]) leaked into website output"
+  if echo "$out" | grep -q "### Active proposal: $FIXTURE_OPS_SLUG"; then
+    echo "REGRESSION: $FIXTURE_OPS_SLUG (domains: [ops]) leaked into website output"
     return 1
   fi
 }
@@ -68,12 +110,18 @@ setup() {
 # ── (3) role=orchestrator returns all non-archived proposals (anchor) ──
 
 @test "PCF: role=orchestrator returns all non-archived proposals (anchor)" {
+  expected=0
+  for f in "$CHANGES_DIR"/*/proposal.md; do
+    [[ -f "$f" ]] || continue
+    slug=$(basename "$(dirname "$f")")
+    [[ "$slug" == "archive" ]] && continue
+    expected=$((expected+1))
+  done
+
   out="$(bash "$SCRIPT" orchestrator 2>/dev/null || true)"
   count=$(echo "$out" | grep -c '^### Active proposal:' || true)
-  # Repo has ~60+ active changes; we expect the count to be ≥ 30 to be
-  # robust against archived changes but still catch a no-op filter.
-  [ "$count" -ge 30 ] \
-    || { echo "orchestrator should return all non-archived proposals (got $count)"; return 1; }
+  [ "$count" -eq "$expected" ] \
+    || { echo "orchestrator should return all $expected non-archived proposals (got $count)"; return 1; }
 }
 
 # ── (4) role=foobar (unknown) emits stderr WARN and returns all proposals ──
@@ -85,10 +133,18 @@ setup() {
 }
 
 @test "PCF: unknown role returns all non-archived proposals (fail-soft)" {
+  expected=0
+  for f in "$CHANGES_DIR"/*/proposal.md; do
+    [[ -f "$f" ]] || continue
+    slug=$(basename "$(dirname "$f")")
+    [[ "$slug" == "archive" ]] && continue
+    expected=$((expected+1))
+  done
+
   out="$(bash "$SCRIPT" foobar 2>/dev/null || true)"
   count=$(echo "$out" | grep -c '^### Active proposal:' || true)
-  [ "$count" -ge 30 ] \
-    || { echo "unknown role should return all proposals as fail-soft (got $count)"; return 1; }
+  [ "$count" -eq "$expected" ] \
+    || { echo "unknown role should return all $expected proposals as fail-soft (got $count)"; return 1; }
 }
 
 # ── (5) archive/ is always excluded (anchor) ──
@@ -112,8 +168,9 @@ setup() {
   website="$(bash "$SCRIPT" bachelorprojekt-website 2>/dev/null | grep -c '^### Active proposal:' || true)"
   # A correctly filtered ops/website output should be strictly less than
   # the unfiltered orchestrator count (the script today returns the same
-  # ~60 entries for all three — the bug). Allow a small floor to absorb
-  # multi-domain proposals but require a real reduction (≥ 25%).
+  # entries for all three — the bug). The three fixture proposals plus at
+  # least one non-matching real proposal (fixture-ci is domains:[ci],
+  # excluded from both) guarantee a real reduction.
   [ "$ops" -lt "$all" ] \
     || { echo "BUG STILL ACTIVE: ops count ($ops) >= orchestrator count ($all) — filter does nothing"; return 1; }
   [ "$website" -lt "$all" ] \


### PR DESCRIPTION
## Summary
- `tests/spec/plan-context.bats` hardcoded specific proposal slugs (`agent-push-notifications`, `cockpit-mobile-view`) and a `>=30` active-proposal count floor for role-filter and fail-soft/anchor cases.
- PR #2480 ("chore: archive 60 stale OpenSpec changes") archived both referenced proposals and dropped the real active-changes count to 6, breaking 4 test cases even though `scripts/plan-context.sh`'s role-filter logic is unchanged and correct.
- Fix: replace the hardcoded slugs with dedicated fixture proposals created in `setup()` / removed in `teardown()`, and compare the orchestrator/fail-soft anchor counts against the real on-disk proposal count computed at test time instead of a hardcoded floor — so future OpenSpec archival churn can't break this test file again.

## Root cause
Test fragility, not production drift: the test asserted against mutable real repo state (`openspec/changes/*`) instead of using isolated fixtures.

## Verification
```
./tests/unit/lib/bats-core/bin/bats tests/spec/plan-context.bats
# 1..11, all ok
```
`task test:inventory` run — no diff (test count unchanged, only titles renamed).

Ticket: T001534