### PR TITLE
fix(test): build+install mcp-task-runner binary in test:factory, fix stale tools/list assertion

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -717,6 +717,28 @@ tasks:
     desc: "Run the offline-safe Software Factory bats (tests/local/FA-SF-* + FA-AR-*) and spec bats (tests/spec/*). Live-DB cases skip without a reachable cluster, so this is CI-safe."
     cmds:
       - '[ -f ./tests/unit/lib/bats-core/bin/bats ] || git submodule update --init --recursive'
+      - |
+        # tests/spec/mcp-task-runner.bats invokes the compiled binary at
+        # /usr/local/bin/mcp-task-runner directly — nothing else in the repo
+        # builds/installs it, so rebuild it fresh here (best-effort: on hosts
+        # where /usr/local/bin isn't writable, e.g. a locked-down dev box, fall
+        # back to whatever is already installed there). [T001533]
+        if command -v go >/dev/null 2>&1; then
+          TMP_BIN="$(mktemp -d)/mcp-task-runner"
+          if (cd mcp-task-runner && go build -o "$TMP_BIN" .); then
+            if install -m 0755 "$TMP_BIN" /usr/local/bin/mcp-task-runner 2>/dev/null; then
+              echo "mcp-task-runner: installed fresh build to /usr/local/bin"
+            elif sudo -n install -m 0755 "$TMP_BIN" /usr/local/bin/mcp-task-runner 2>/dev/null; then
+              echo "mcp-task-runner: installed fresh build to /usr/local/bin (sudo)"
+            else
+              echo "mcp-task-runner: /usr/local/bin not writable — using pre-installed binary if present"
+            fi
+          else
+            echo "mcp-task-runner: go build failed — using pre-installed binary if present"
+          fi
+        else
+          echo "mcp-task-runner: go not found — using pre-installed binary if present"
+        fi
       - ./tests/unit/lib/bats-core/bin/bats tests/local/FA-SF-*.bats tests/local/FA-AR-*.bats tests/spec/*.bats
 
   test:mcp-tooling:

--- a/tests/spec/mcp-task-runner.bats
+++ b/tests/spec/mcp-task-runner.bats
@@ -59,12 +59,15 @@ _mcp() {
 
 # ── Tests ─────────────────────────────────────────────────────────────────────
 
-@test "MCP-TASK-RUNNER-001: tools/list returns exactly 3 tools (plan_tasks, run_task, execute_plan)" {
+@test "MCP-TASK-RUNNER-001: tools/list returns all 7 tools (plan_tasks, run_task, execute_plan, get_task_graph, run_task_async, cancel_task, get_task_result)" {
   run _mcp '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}'
   [ "$status" -eq 0 ]
-  # Validate JSON is well-formed and contains all 3 expected tool names
-  echo "$output" | jq -e '.result.tools | length == 3' > /dev/null
-  echo "$output" | jq -e '[.result.tools[].name] | contains(["plan_tasks","run_task","execute_plan"])' > /dev/null
+  # Validate JSON is well-formed and contains all 7 expected tool names.
+  # Tool count grew from 3 to 7 with the archived 2026-06-28
+  # mcp-server-capabilities change (async lifecycle + graph tools); this
+  # assertion tracks the current shipped surface, not the original 3. [T001533]
+  echo "$output" | jq -e '.result.tools | length == 7' > /dev/null
+  echo "$output" | jq -e '[.result.tools[].name] | contains(["plan_tasks","run_task","execute_plan","get_task_graph","run_task_async","cancel_task","get_task_result"])' > /dev/null
 }
 
 @test "MCP-TASK-RUNNER-002: plan_tasks with two same-named tasks (different env) groups them into one parallel group" {


### PR DESCRIPTION
## Summary
- `task test:factory` now does a best-effort `go build` of `mcp-task-runner/` and installs the fresh binary to `/usr/local/bin/mcp-task-runner` before running `tests/spec/*.bats` — nothing previously built/installed this binary anywhere (Taskfile or CI), so on a clean CI runner `tests/spec/mcp-task-runner.bats` failed outright because the binary didn't exist.
- Updated `MCP-TASK-RUNNER-001` to assert the current 7-tool `tools/list` surface (`plan_tasks`, `run_task`, `execute_plan`, `get_task_graph`, `run_task_async`, `cancel_task`, `get_task_result`) instead of a stale hardcoded count of 3 — `main.go` has shipped these 7 tools since the archived `2026-06-28-mcp-server-capabilities` change; the test never caught up.

## Root cause
Two independent drifts compounded into one failing bats file:
1. No build/install step for the `mcp-task-runner` Go binary exists anywhere in `Taskfile.yml` or `.github/workflows/ci.yml`. It only worked locally because someone had manually run `make install` once.
2. `MCP-TASK-RUNNER-001` asserted `tools/list | length == 3`, which was true when the test was authored but has been stale since a later change added 4 more tools (`get_task_graph`, `run_task_async`, `cancel_task`, `get_task_result`).

## Fix
- `Taskfile.yml` `test:factory`: best-effort `go build` + `install`/`sudo -n install` to `/usr/local/bin`, gracefully falling back (with a warning, not a hard failure) if `go` is missing or the path isn't writable, so this doesn't break locked-down dev boxes.
- `tests/spec/mcp-task-runner.bats`: `MCP-TASK-RUNNER-001` now checks for all 7 currently-registered tools.

## Verification
```
cd mcp-task-runner && go build -o /tmp/mtr-test . && echo BUILD_OK
./tests/unit/lib/bats-core/bin/bats tests/spec/mcp-task-runner.bats
# 1..4
# ok 1 MCP-TASK-RUNNER-001: tools/list returns all 7 tools (...)
# ok 2 MCP-TASK-RUNNER-002: plan_tasks with two same-named tasks (different env) groups them into one parallel group
# ok 3 MCP-TASK-RUNNER-003: run_task with a fake task that exits 0 returns exit_code 0 and a trace_id
# ok 4 MCP-TASK-RUNNER-004: binary is on PATH and --help exits 0
task test:inventory   # no diff — no @test entries added/removed
```

[T001533]

https://claude.ai/code/session_01RMizQeex7g3ZbYFP24cFwJ