### PR TITLE
fix(website): restore Gerald's real photo on the mentolder homepage hero [T001561]

### DIFF
--- a/website/content/mentolder/homepage.json
+++ b/website/content/mentolder/homepage.json
@@ -22,7 +22,7 @@
     { "title": "Wie ich arbeite", "text": "Analytische Präzision mit Beziehungsarbeit." }
   ],
   "avatarType": "image",
-  "avatarSrc": "/brand/mentolder/characters/leadership.portrait.svg",
+  "avatarSrc": "/gerald.jpg",
   "quote": "Ich stelle unbequeme Fragen – weil echte Lösungen manchmal unbequeme Wahrheiten brauchen.",
   "quoteName": "Gerald Korczewski",
   "processSteps": [

--- a/website/src/lib/__tests__/content-bundle.test.ts
+++ b/website/src/lib/__tests__/content-bundle.test.ts
@@ -24,4 +24,9 @@ describe('content-bundle', () => {
       expect(stammdaten.name.length).toBeGreaterThan(0);
     }
   });
+
+  it('mentolder homepage hero shows the real Gerald photo, not a placeholder illustration [T001561]', () => {
+    const hp = loadDomain('mentolder', 'homepage');
+    expect(hp.avatarSrc).toBe('/gerald.jpg');
+  });
 });


### PR DESCRIPTION
## Summary
- Homepage hero avatar on web.mentolder.de regressed to a generic placeholder illustration (`leadership.portrait.svg`) instead of Gerald's real photo (`/gerald.jpg`).
- Root cause: the T001490 content-bundle export froze an already-drifted DB value into `website/content/mentolder/homepage.json`; since public pages no longer read the DB, it could not self-correct.
- Fix: `avatarSrc` restored to `/gerald.jpg`, matching the canonical hero seed (`mentolder-web/src/blocks/seed.ts`) and existing test fixtures.

## Test plan
- [x] Added failing regression test (`content-bundle.test.ts`) asserting `avatarSrc === '/gerald.jpg'`, confirmed RED before the fix
- [x] Fix applied, test GREEN
- [x] `task test:changed` green
- [x] LOC budget check passed

Ticket: T001561

🤖 Generated with Claude Code