### PR TITLE
chore(dev-flow): subagent context-budget handoff rule [T001571]

### DIFF
--- a/.claude/skills/references/subagent-provisioning.md
+++ b/.claude/skills/references/subagent-provisioning.md
@@ -58,3 +58,26 @@ Der Subagent hat per Konstruktion **keinen** Kontext — gib alles explizit, abe
 - Die relevanten **Artefakt-Pfade** (Spec/Plan/Ticket), nicht deren Volltext, wenn er sie selbst lesen kann.
 - Bei mehreren Vorstufen-Ergebnissen: **zusammenfassen, nie Roh-JSON dumpen**. (Ein 162k-Zeichen-Prompt ließ
   einen Synthese-Agenten ohne brauchbare Antwort scheitern — die Provisioning-Lehre schlechthin.)
+
+### 4. Kontext-Budget & Handoff (PFLICHT-Direktive in jedem Subagenten-Prompt) [T001571]
+
+Subagenten degradieren still, wenn ihr Kontext gegen das Fenster (~200k Tokens) läuft: Scope-Drift,
+fachfremde Edits, vergessene Auftragsdetails („Dumbzone"). Es gibt keinen Harness-Mechanismus, der
+das hart begrenzt — deshalb ist die Selbstmeldung Teil des Auftrags.
+
+**In JEDEN Subagenten-Prompt gehört diese Standing-Direktive (sinngemäß):**
+
+> Überwache dein eigenes Kontext-Budget. Bei Anzeichen von Kontext-Überlauf — Heuristik:
+> >100 Tool-Calls, viele große File-Reads/CI-Logs, oder du bemerkst, dass frühere Details
+> fehlen/kompaktiert wurden — NICHT weiterarbeiten. Stattdessen sofort stoppen und als finale
+> Nachricht einen strukturierten **Handoff-Report** liefern: (1) erledigte Schritte,
+> (2) exakter Git-/Datei-Zustand (Branch, letzte Commits, dirty files), (3) offene Schritte in
+> Reihenfolge, (4) bekannte Fallen. Ein sauberer Handoff ist Erfolg, kein Versagen.
+
+**Orchestrator-Pflichten beim Ersatz eines Agenten:**
+1. Alten Agenten stoppen (`TaskStop`), NICHT parallel weiterlaufen lassen.
+2. Im Worktree `git status` prüfen: committete Arbeit bleibt; **fachfremde uncommittete
+   Änderungen verwerfen** (`git checkout -- <files>`) — Dumbzone-Edits an Dateien außerhalb
+   des Auftrags-Scopes sind das Leitsymptom.
+3. Frischen Agenten mit kompaktem Lagebild spawnen (Commits seit origin/main, offene Schritte),
+   nicht mit dem Volltranskript des Vorgängers.

--- a/docs/code-quality/loc-budget.json
+++ b/docs/code-quality/loc-budget.json
@@ -1,8 +1,8 @@
 {
-  "total_lines": 529966,
+  "total_lines": 529982,
   "file_count": 4022,
-  "commit": "97e93ed4",
-  "measured_at": "2026-07-03T05:05:31.344Z",
+  "commit": "e8aed4383",
+  "measured_at": "2026-07-03T06:53:16.571Z",
   "thresholds": {
     "warn_pct": 5,
     "fail_pct": 15,


### PR DESCRIPTION
Verankert die Kontext-Budget-Handoff-Regel für Subagenten als §4 in der SSOT-Referenz `.claude/skills/references/subagent-provisioning.md`:

- Standing-Direktive für jeden Subagenten-Prompt: bei Anzeichen von Kontext-Überlauf (~200k-Fenster) stoppen und strukturierten Handoff-Report liefern statt weiterzuwühlen (Dumbzone-Prävention).
- Orchestrator-Pflichten beim Agent-Ersatz: TaskStop, fachfremde uncommittete Änderungen verwerfen, frischen Agenten mit kompaktem Lagebild spawnen.

Anlass: Implementer-Subagent in der brain-foundation-Session driftete nach Kontext-Überlauf in fachfremde Dateien.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tg6pAHFbXU65CAD7a1kYyU