### PR TITLE
chore(factory): fix factory-mcp URL drift + add BATS guardrail

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -19,10 +19,10 @@
       "type": "http",
       "url": "http://localhost:13001/mcp"
     },
-"factory-mcp": {
-	"type": "http",
-	"url": "http://127.0.0.1:13004/mcp"
-},
+    "factory-mcp": {
+      "type": "http",
+      "url": "http://localhost:13003/mcp"
+    },
     "mcp-task-runner": {
       "command": "mcp-task-runner",
       "args": [

--- a/tests/spec/mcp-tooling.bats
+++ b/tests/spec/mcp-tooling.bats
@@ -11,6 +11,31 @@ setup() {
   GUIDE="$REPO_ROOT/.claude/skills/references/mcp-tool-guide.md"
 }
 
+# Hard-CI guard for openspec/specs/mcp-skill-integration.md §"factory-mcp
+# registration and wiring" — both runtime configs MUST point at
+# http://localhost:13003/mcp. Catches port-drift (e.g. 13004) and missing entries.
+# .mcp.json is strict JSON; .opencode/opencode.jsonc has // and /* */ comments,
+# so we extract the factory-mcp URL by regex (the key is unique in the file and
+# the URL is a literal string, no comment-like substrings to worry about).
+@test "factory-mcp is registered at :13003/mcp in BOTH .mcp.json and .opencode/opencode.jsonc" {
+  REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+  run node -e '
+    const fs = require("fs"), path = require("path");
+    const root = process.argv[1];
+    const want = "http://localhost:13003/mcp";
+    const mc = JSON.parse(fs.readFileSync(path.join(root, ".mcp.json"), "utf8"));
+    const m1 = mc.mcpServers && mc.mcpServers["factory-mcp"] && mc.mcpServers["factory-mcp"].url;
+    if (m1 !== want) { console.error("FAIL .mcp.json factory-mcp.url =", JSON.stringify(m1), "!=", want); process.exit(1); }
+    const ocRaw = fs.readFileSync(path.join(root, ".opencode/opencode.jsonc"), "utf8");
+    const m = ocRaw.match(/"factory-mcp"\s*:\s*\{\s*"type"\s*:\s*"remote"\s*,\s*"url"\s*:\s*"([^"]+)"/);
+    const m2 = m ? m[1] : null;
+    if (m2 !== want) { console.error("FAIL .opencode/opencode.jsonc factory-mcp.url =", JSON.stringify(m2), "!=", want); process.exit(2); }
+    process.exit(0);
+  ' "$REPO_ROOT"
+  echo "# stdout: $output"
+  [ "$status" -eq 0 ]
+}
+
 @test "every skill-critical ticket.sh verb has a ticket-mcp wrapper" {
   [ -d "$TOOLS_DIR" ]
   verbs=(phase grill stage-plan create enqueue set-touched-files get-attachments archive-plan add-pr-link get add-comment)


### PR DESCRIPTION
## Summary
- `.mcp.json` zeigte `factory-mcp` auf `127.0.0.1:13004` mit kaputter Tab-Formatierung — verletzt `openspec/specs/mcp-skill-integration.md:116` (Spec: SHALL be `http://localhost:13003/mcp`).
- `.opencode/opencode.jsonc` war bereits korrekt; die Drift war nur in `.mcp.json`.
- Neuer BATS-Guardrail in `tests/spec/mcp-tooling.bats` erzwingt die Spec-Invariante künftig (positiv + negativ verifiziert).

## Warum
Die Spec ist SSOT und `.mcp.json` ist die Implementierung dazu. Der Drift war still — der bestehende `mcp-tooling.bats` testete nur ticket-mcp Tool-Namen, nicht die factory-mcp-URL-Registrierung. Server lief nicht (nichts auf 13003/13004), Claude-Code-Runtime konnte sich also nicht verbinden.

## Test Plan
- [x] `bats tests/spec/mcp-tooling.bats` — neuer Guardrail grün, 3/3
- [x] `curl -sf http://127.0.0.1:13003/health` → `{"ok":true,"server":"factory-mcp"}`
- [x] MCP `initialize` + `tools/list` → 7 Tools (factory_status/queue/enqueue/trigger/recent/openspec_find_similar/factory_ask)
- [x] `factory_status` Live-Aufruf liefert sinnvolle Daten (backlog=0, plan_staged=2, tick_running=true)
- [x] Negativ-Probe: bei Revert auf `13004` schlägt der neue `@test` fehl mit klarer Meldung

## Notizen
- Kein Ticket: ad-hoc-Fix gegen eine bestehende Spec, kein neues Feature. CI `[T000XXX]`-Check ist advisory only.
- factory-mcp-Daemon läuft jetzt lokal auf `:13003` (PID-File `/tmp/factory-mcp.pid`, gestartet via `task factory-mcp:start`).