### PR TITLE
fix: CI-Freshness-Gate blocking machen (Hebel 1) [T001593]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,6 @@ jobs:
 
       - name: Ensure freshness artifacts are up to date
         if: github.event_name == 'pull_request'
-        continue-on-error: true
         run: |
           if ! task freshness:check; then
             echo ""


### PR DESCRIPTION
## Zusammenfassung
Hebel 1 aus dem Engineering-Audit 2026-07-03 (T001593): Entfernt `continue-on-error: true` vom CI-Step **"Ensure freshness artifacts are up to date"** (`task freshness:check`). Bisher war das Gate rein advisory — veraltete generierte Artefakte konnten unbemerkt gemergt werden.

## Verifikation
- Lokal: `task freshness:check` auf sauberem Tree → exit 0.
- Absichtlich veraltetes committetes `website/src/data/test-inventory.json` (Eintrag entfernt + committet) → `task freshness:check` exit 201 (≠0) mit klarer Stale-Meldung. Der CI-Step schlägt damit künftig hart fehl.
- `task test:all` grün.

## Scope-Begründung: warum nur dieser eine Step
Die anderen `continue-on-error`-Steps bleiben bewusst unangetastet:
- **Knip-Report (~Zeile 251)**: rein informatives Dead-Code-Reporting ohne Baseline-Ratchet — als Blocker würde er unabhängige PRs für Altlasten rot machen.
- Der Freshness-Step dagegen prüft deterministisch regenerierbare Artefakte, die der PR-Autor selbst mit `task freshness:regenerate` fixen kann — hier ist Blocking das korrekte Verhalten und schließt die Lücke zwischen lokalem Gate (`task freshness:check` vor Push) und CI.

Ticket: T001593 (Hebel 1 von 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SEcYiYScddN9tPXHsjNddg