### PR TITLE
fix: Hartkodierten Dev-OIDC-Secret-Fallback entfernen (Hebel 3) [T001593]

### DIFF
--- a/docs/code-quality/loc-budget.json
+++ b/docs/code-quality/loc-budget.json
@@ -1,8 +1,8 @@
 {
-  "total_lines": 532579,
+  "total_lines": 532615,
   "file_count": 4039,
-  "commit": "28f185c3",
-  "measured_at": "2026-07-03T20:26:45.705Z",
+  "commit": "a00f6248b",
+  "measured_at": "2026-07-03T20:38:35.940Z",
   "thresholds": {
     "warn_pct": 5,
     "fail_pct": 15,

--- a/website/.env.example
+++ b/website/.env.example
@@ -13,8 +13,10 @@ SMTP_PASS=
 FROM_EMAIL=info@yourdomain.tld
 FROM_NAME=yourbrand.tld
 
-# ── OIDC (Keycloak client for login) ────────────────────
-WEBSITE_OIDC_SECRET=devwebsiteoidcsecret12345
+# ── OIDC (Pocket ID client for login) ───────────────────
+# Required — the server refuses to boot without it (T001593).
+# Dev value matches k3d/website-dev-secrets.yaml.
+POCKET_ID_WEBSITE_SECRET=devwebsitepocketidsecret123456
 
 # ── External services (portal Dienste section) ──────────
 NEXTCLOUD_EXTERNAL_URL=http://files.localhost

--- a/website/src/lib/auth.test.ts
+++ b/website/src/lib/auth.test.ts
@@ -140,3 +140,26 @@ describe('exchangeCode', () => {
     expect(await m.exchangeCode('code-123')).toBeNull();
   });
 });
+
+describe('client secret guard (T001593)', () => {
+  const ORIGINAL_LEGACY = process.env.WEBSITE_OIDC_SECRET;
+
+  afterEach(() => {
+    if (ORIGINAL_LEGACY === undefined) delete process.env.WEBSITE_OIDC_SECRET;
+    else process.env.WEBSITE_OIDC_SECRET = ORIGINAL_LEGACY;
+  });
+
+  it('throws at import when no OIDC client secret is set', async () => {
+    delete process.env.POCKET_ID_WEBSITE_SECRET;
+    delete process.env.WEBSITE_OIDC_SECRET;
+    vi.resetModules();
+    await expect(loadModule()).rejects.toThrow(/OIDC client secret/);
+  });
+
+  it('accepts the legacy WEBSITE_OIDC_SECRET variable', async () => {
+    delete process.env.POCKET_ID_WEBSITE_SECRET;
+    process.env.WEBSITE_OIDC_SECRET = 'legacy-secret';
+    vi.resetModules();
+    await expect(loadModule()).resolves.toBeDefined();
+  });
+});

--- a/website/src/lib/auth.ts
+++ b/website/src/lib/auth.ts
@@ -5,7 +5,16 @@ import { logger } from './logger';
 const PI_FRONTEND_URL = process.env.POCKET_ID_FRONTEND_URL || '';
 const PI_INTERNAL_URL = process.env.POCKET_ID_URL || 'http://pocket-id.workspace.svc.cluster.local:1411';
 const CLIENT_ID = 'website';
-const CLIENT_SECRET = process.env.POCKET_ID_WEBSITE_SECRET || process.env.WEBSITE_OIDC_SECRET || 'devwebsiteoidcsecret12345';
+const CLIENT_SECRET = process.env.POCKET_ID_WEBSITE_SECRET || process.env.WEBSITE_OIDC_SECRET || '';
+if (!CLIENT_SECRET) {
+  // Fail hard at boot instead of silently falling back to a well-known dev
+  // secret (removed 2026-07, T001593). Dev clusters get the secret from
+  // k3d/website-dev-secrets.yaml; prod via SealedSecret (environments/schema.yaml:
+  // POCKET_ID_WEBSITE_SECRET). For local `pnpm dev` see website/.env.example.
+  throw new Error(
+    'POCKET_ID_WEBSITE_SECRET (or legacy WEBSITE_OIDC_SECRET) is not set — refusing to start without an OIDC client secret',
+  );
+}
 const SITE_URL = process.env.SITE_URL || '';
 const CALLBACK_PATH = '/api/auth/callback';
 const COOKIE_NAME = 'workspace_session';

--- a/website/vitest.config.ts
+++ b/website/vitest.config.ts
@@ -30,6 +30,8 @@ export default defineConfig({
       : ['default'],
     env: {
       VOYAGE_API_KEY: 'test-key',
+      // auth.ts fails hard at import when no OIDC client secret is set (T001593)
+      POCKET_ID_WEBSITE_SECRET: 'test-oidc-secret',
     },
     coverage: {
       provider: 'v8',
@@ -59,7 +61,7 @@ export default defineConfig({
           ],
           exclude: ['node_modules/**', 'dist/**', ...COMPONENT_TESTS],
           globals: true,
-          env: { VOYAGE_API_KEY: 'test-key' },
+          env: { VOYAGE_API_KEY: 'test-key', POCKET_ID_WEBSITE_SECRET: 'test-oidc-secret' },
         },
       },
       {
@@ -73,7 +75,7 @@ export default defineConfig({
           include: COMPONENT_TESTS,
           exclude: ['node_modules/**', 'dist/**'],
           globals: true,
-          env: { VOYAGE_API_KEY: 'test-key' },
+          env: { VOYAGE_API_KEY: 'test-key', POCKET_ID_WEBSITE_SECRET: 'test-oidc-secret' },
           setupFiles: ['./src/lib/__tests__/setup.ts'],
         },
       },


### PR DESCRIPTION
## Zusammenfassung
Hebel 3 aus dem Engineering-Audit 2026-07-03 (T001593): `website/src/lib/auth.ts` fiel bei fehlendem `POCKET_ID_WEBSITE_SECRET` stillschweigend auf den öffentlich bekannten Dev-Wert `devwebsiteoidcsecret12345` zurück. Jetzt wirft das Modul beim Import (= Server-Boot) hart, analog zur Fail-Fast-Philosophie in `brett/src/server/auth.ts`.

## Umgebungs-Preflight (vor Merge geprüft)
- **Dev-Cluster**: `k3d/website-dev-secrets.yaml` setzt `POCKET_ID_WEBSITE_SECRET`; `k3d/website.yaml` mountet es non-optional per secretKeyRef.
- **Prod**: `environments/schema.yaml` führt `POCKET_ID_WEBSITE_SECRET` (SealedSecret-Pfad); `scripts/verify-deployment.sh` prüft Sync workspace ↔ website ns.
- **CI/Vitest**: Test-Secret in allen `env`-Blöcken von `vitest.config.ts` ergänzt (viele Suiten importieren auth.ts transitiv). Volle Suite: 331 files / 2642 Tests grün.
- **Image-Build**: `astro build` OHNE Secret verifiziert grün (build-website.yml setzt keins; kein prerendered Importer von lib/auth).
- **Lokales `pnpm dev`**: `.env.example` auf `POCKET_ID_WEBSITE_SECRET` aktualisiert (Wert = Dev-Cluster-Wert).

## Tests
- Neu: Import wirft ohne Secret; Legacy-Var `WEBSITE_OIDC_SECRET` wird weiter akzeptiert.
- `task test:all` + `task freshness:check` grün (loc-budget regeneriert und committet).

Ticket: T001593 (Hebel 3 von 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SEcYiYScddN9tPXHsjNddg