### PR TITLE
chore(scripts): make ticket-mcp:build idempotent; add setup:local-bins umbrella [T001586]

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -4597,10 +4597,41 @@ tasks:
   # ─────────────────────────────────────────────
   # ticket-mcp Go Binary
   # ─────────────────────────────────────────────
+  # scripts/ticket-mcp/ticket-mcp-go is .gitignored and consumed by
+  # `.opencode/opencode.jsonc` → `mcp.ticket-mcp.command`. A fresh checkout
+  # MUST build it before `opencode` will start — otherwise the spawn fails
+  # silently and the TUI hangs on a blank screen. The targets below are
+  # idempotent: rebuilds only fire when a Go source file (or the go.mod /
+  # Makefile) is newer than the binary.
   ticket-mcp:build:
-    desc: "Build the ticket-mcp Go binary (scripts/ticket-mcp/ticket-mcp-go)"
+    desc: "Build the ticket-mcp Go binary (scripts/ticket-mcp/ticket-mcp-go). Idempotent — only rebuilds when Go source changes."
+    dir: scripts/ticket-mcp/go
+    sources:
+      - cmd/**/*.go
+      - internal/**/*.go
+      - Makefile
+      - go.mod
+      - go.sum
+    generates:
+      - ../ticket-mcp-go
     cmds:
-      - make -C scripts/ticket-mcp/go build
+      - go build -o ../ticket-mcp-go ./cmd/ticket-mcp
+      - 'echo "✓ ticket-mcp-go built: scripts/ticket-mcp/ticket-mcp-go"'
+      - 'echo "  Restart opencode to pick up the new binary (Ctrl+C, then re-run)."'
+
+  ticket-mcp:rebuild:
+    desc: "Force-rebuild ticket-mcp-go (bypass mtime cache; e.g. after pulling a new commit on an unchanged source tree)"
+    cmds:
+      - rm -f scripts/ticket-mcp/ticket-mcp-go
+      - task: ticket-mcp:build
+
+  setup:local-bins:
+    desc: "Build every local dev binary that opencode / agent tooling spawns (currently: ticket-mcp-go). Run once after a fresh checkout, then on demand."
+    cmds:
+      - task: ticket-mcp:build
+      - 'echo ""'
+      - 'echo "✓ All local dev binaries are up to date."'
+      - 'echo "  Next: run ''opencode'' in the project root."'
 
   # ─────────────────────────────────────────────
   # Maintenance — periodic cleanups


### PR DESCRIPTION
## Summary
- `task ticket-mcp:build` is now idempotent via `sources:`/`generates:` (only rebuilds when a Go source file, Makefile, go.mod, or go.sum is newer than the binary), replacing the always-invoke `make -C ... build` form.
- Adds `task ticket-mcp:rebuild` to force a clean rebuild (bypass mtime cache).
- Adds `task setup:local-bins` — an umbrella target that builds every project-local binary that opencode/agent tooling spawns, printing a "next: run opencode" hint.
- Inlines a comment above the targets documenting the `.gitignore` + TUI-hang failure mode: `scripts/ticket-mcp/ticket-mcp-go` is gitignored and consumed by `.opencode/opencode.jsonc` → `mcp.ticket-mcp.command`; a fresh checkout without the binary makes opencode hang on a blank TUI because the spawn failure never returns control to the event loop.

Ticket: T001586

## Test plan
- [x] `task ticket-mcp:build` — first run builds; second run reports "up to date" (idempotency verified)
- [x] `task ticket-mcp:rebuild` — force-rebuilds bypassing the mtime cache
- [x] `task setup:local-bins` — builds ticket-mcp-go and prints the opencode hint
- [x] `task test:all` — full offline suite green
- [x] `task test:mcp-tooling` — ticket-mcp BATS guardrail green
- [x] `task --list` — new/changed task descriptions render correctly

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TzhY1EhnruxLeE3D7MtjaM