### PR TITLE
chore(deps): update Context7 libraries 2026-07-07

### DIFF
--- a/docs/code-quality/baseline.json
+++ b/docs/code-quality/baseline.json
@@ -4,181 +4,188 @@
     "path": "art-library/_tooling/extract-from-handoff.mjs",
     "metric": 669,
     "detail": "669 lines > 500 limit (.mjs)",
-    "frozen_at": "8b581ebe"
+    "frozen_at": "90ff47d"
   },
   "S1:k3d/talk-transcriber/app.py": {
     "gate": "S1",
     "path": "k3d/talk-transcriber/app.py",
     "metric": 648,
     "detail": "648 lines > 600 limit (.py)",
-    "frozen_at": "8b581ebe"
+    "frozen_at": "90ff47d"
   },
   "S1:scripts/docs-gen/templates.mjs": {
     "gate": "S1",
     "path": "scripts/docs-gen/templates.mjs",
     "metric": 587,
     "detail": "587 lines > 500 limit (.mjs)",
-    "frozen_at": "8b581ebe"
+    "frozen_at": "90ff47d"
   },
   "S1:website/src/components/BookingForm.svelte": {
     "gate": "S1",
     "path": "website/src/components/BookingForm.svelte",
     "metric": 560,
     "detail": "560 lines > 500 limit (.svelte)",
-    "frozen_at": "8b581ebe"
+    "frozen_at": "90ff47d"
   },
   "S1:website/src/components/Navigation.svelte": {
     "gate": "S1",
     "path": "website/src/components/Navigation.svelte",
     "metric": 535,
     "detail": "535 lines > 500 limit (.svelte)",
-    "frozen_at": "8b581ebe"
+    "frozen_at": "90ff47d"
   },
   "S1:website/src/components/admin/NewsletterAdmin.svelte": {
     "gate": "S1",
     "path": "website/src/components/admin/NewsletterAdmin.svelte",
     "metric": 556,
     "detail": "556 lines > 500 limit (.svelte)",
-    "frozen_at": "8b581ebe"
+    "frozen_at": "90ff47d"
   },
   "S1:website/src/components/admin/coaching/CoachingSettings.svelte": {
     "gate": "S1",
     "path": "website/src/components/admin/coaching/CoachingSettings.svelte",
     "metric": 598,
     "detail": "598 lines > 500 limit (.svelte)",
-    "frozen_at": "8b581ebe"
+    "frozen_at": "90ff47d"
   },
   "S1:website/src/components/assistant/QuestionnaireView.svelte": {
     "gate": "S1",
     "path": "website/src/components/assistant/QuestionnaireView.svelte",
     "metric": 1001,
     "detail": "1001 lines > 500 limit (.svelte)",
-    "frozen_at": "8b581ebe"
+    "frozen_at": "90ff47d"
   },
   "S1:website/src/components/inbox/InboxApp.svelte": {
     "gate": "S1",
     "path": "website/src/components/inbox/InboxApp.svelte",
     "metric": 954,
     "detail": "954 lines > 500 limit (.svelte)",
-    "frozen_at": "8b581ebe"
+    "frozen_at": "90ff47d"
   },
   "S1:website/src/components/inbox/InboxDetail.svelte": {
     "gate": "S1",
     "path": "website/src/components/inbox/InboxDetail.svelte",
     "metric": 837,
     "detail": "837 lines > 500 limit (.svelte)",
-    "frozen_at": "8b581ebe"
+    "frozen_at": "90ff47d"
   },
   "S1:website/src/components/portal/QuestionnaireWizard.svelte": {
     "gate": "S1",
     "path": "website/src/components/portal/QuestionnaireWizard.svelte",
     "metric": 678,
     "detail": "678 lines > 500 limit (.svelte)",
-    "frozen_at": "8b581ebe"
+    "frozen_at": "90ff47d"
   },
   "S1:website/src/lib/coaching-db.ts": {
     "gate": "S1",
     "path": "website/src/lib/coaching-db.ts",
     "metric": 668,
     "detail": "668 lines > 600 limit (.ts)",
-    "frozen_at": "8b581ebe"
+    "frozen_at": "90ff47d"
   },
   "S1:website/src/lib/helpContent.ts": {
     "gate": "S1",
     "path": "website/src/lib/helpContent.ts",
     "metric": 923,
     "detail": "923 lines > 600 limit (.ts)",
-    "frozen_at": "8b581ebe"
+    "frozen_at": "90ff47d"
   },
   "S1:website/src/lib/tickets/admin.ts": {
     "gate": "S1",
     "path": "website/src/lib/tickets/admin.ts",
     "metric": 632,
     "detail": "632 lines > 600 limit (.ts)",
-    "frozen_at": "8b581ebe"
+    "frozen_at": "90ff47d"
   },
   "S1:website/src/pages/admin/[clientId].astro": {
     "gate": "S1",
     "path": "website/src/pages/admin/[clientId].astro",
     "metric": 745,
     "detail": "745 lines > 400 limit (.astro)",
-    "frozen_at": "8b581ebe"
+    "frozen_at": "90ff47d"
   },
   "S1:website/src/pages/admin/billing/[id]/drucken.astro": {
     "gate": "S1",
     "path": "website/src/pages/admin/billing/[id]/drucken.astro",
     "metric": 513,
     "detail": "513 lines > 400 limit (.astro)",
-    "frozen_at": "8b581ebe"
+    "frozen_at": "90ff47d"
   },
   "S1:website/src/pages/admin/clients.astro": {
     "gate": "S1",
     "path": "website/src/pages/admin/clients.astro",
     "metric": 470,
     "detail": "470 lines > 400 limit (.astro)",
-    "frozen_at": "8b581ebe"
+    "frozen_at": "90ff47d"
   },
   "S1:website/src/pages/admin/fragebogen/[assignmentId].astro": {
     "gate": "S1",
     "path": "website/src/pages/admin/fragebogen/[assignmentId].astro",
     "metric": 619,
     "detail": "619 lines > 400 limit (.astro)",
-    "frozen_at": "8b581ebe"
+    "frozen_at": "90ff47d"
   },
   "S1:website/src/pages/admin/kalender.astro": {
     "gate": "S1",
     "path": "website/src/pages/admin/kalender.astro",
     "metric": 412,
     "detail": "412 lines > 400 limit (.astro)",
-    "frozen_at": "8b581ebe"
+    "frozen_at": "90ff47d"
   },
   "S1:website/src/pages/admin/projekte.astro": {
     "gate": "S1",
     "path": "website/src/pages/admin/projekte.astro",
     "metric": 408,
     "detail": "408 lines > 400 limit (.astro)",
-    "frozen_at": "8b581ebe"
+    "frozen_at": "90ff47d"
   },
   "S1:website/src/pages/admin/projekte/[id].astro": {
     "gate": "S1",
     "path": "website/src/pages/admin/projekte/[id].astro",
     "metric": 923,
     "detail": "923 lines > 400 limit (.astro)",
-    "frozen_at": "8b581ebe"
+    "frozen_at": "90ff47d"
   },
   "S1:website/src/pages/admin/rechnungen.astro": {
     "gate": "S1",
     "path": "website/src/pages/admin/rechnungen.astro",
     "metric": 592,
     "detail": "592 lines > 400 limit (.astro)",
-    "frozen_at": "8b581ebe"
+    "frozen_at": "90ff47d"
   },
   "S1:website/src/pages/admin/systemtest/board.astro": {
     "gate": "S1",
     "path": "website/src/pages/admin/systemtest/board.astro",
     "metric": 419,
     "detail": "419 lines > 400 limit (.astro)",
-    "frozen_at": "8b581ebe"
+    "frozen_at": "90ff47d"
   },
   "S1:website/src/pages/admin/termine.astro": {
     "gate": "S1",
     "path": "website/src/pages/admin/termine.astro",
     "metric": 773,
     "detail": "773 lines > 400 limit (.astro)",
-    "frozen_at": "8b581ebe"
+    "frozen_at": "90ff47d"
   },
   "S1:website/src/pages/portal/billing/[id]/drucken.astro": {
     "gate": "S1",
     "path": "website/src/pages/portal/billing/[id]/drucken.astro",
     "metric": 515,
     "detail": "515 lines > 400 limit (.astro)",
-    "frozen_at": "8b581ebe"
+    "frozen_at": "90ff47d"
   },
   "S1:website/tests/api.test.mjs": {
     "gate": "S1",
     "path": "website/tests/api.test.mjs",
     "metric": 589,
     "detail": "589 lines > 500 limit (.mjs)",
-    "frozen_at": "8b581ebe"
+    "frozen_at": "90ff47d"
+  },
+  "S4:scripts/agent-orchestrator.sh": {
+    "gate": "S4",
+    "path": "scripts/agent-orchestrator.sh",
+    "metric": 1,
+    "detail": "no reference to 'agent-orchestrator.sh' in any configured source",
+    "frozen_at": "90ff47d"
   }
 }

--- a/website/package.json
+++ b/website/package.json
@@ -74,7 +74,7 @@
     "tsx": "^4.22.3",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.62.0",
-    "vitest": "^4.1.9",
+    "vitest": "^4.1.10",
     "@vitest/coverage-v8": "^4.1.9"
   }
 }

--- a/website/package.json
+++ b/website/package.json
@@ -75,6 +75,6 @@
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.62.0",
     "vitest": "^4.1.10",
-    "@vitest/coverage-v8": "^4.1.9"
+    "@vitest/coverage-v8": "^4.1.10"
   }
 }

--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -141,8 +141,8 @@ importers:
         specifier: ^0.17.6
         version: 0.17.6
       '@vitest/coverage-v8':
-        specifier: ^4.1.9
-        version: 4.1.9(vitest@4.1.10)
+        specifier: ^4.1.10
+        version: 4.1.10(vitest@4.1.10)
       eslint:
         specifier: ^10.5.0
         version: 10.5.0(jiti@2.7.0)
@@ -178,7 +178,7 @@ importers:
         version: 8.62.0(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@types/node@25.9.1)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.1.0(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
+        version: 4.1.10(@types/node@25.9.1)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.1.0(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
 
 packages:
 
@@ -1753,11 +1753,11 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
 
-  '@vitest/coverage-v8@4.1.9':
-    resolution: {integrity: sha512-G9/lgqibheLVBDRuya45EbsEXTYcWoSG+TLg7i2axuzx0Eq62eXn+aWXyaVdV5vKvFSWd6ywcX8hA7la9Pvu8g==}
+  '@vitest/coverage-v8@4.1.10':
+    resolution: {integrity: sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==}
     peerDependencies:
-      '@vitest/browser': 4.1.9
-      vitest: 4.1.9
+      '@vitest/browser': 4.1.10
+      vitest: 4.1.10
     peerDependenciesMeta:
       '@vitest/browser':
         optional: true
@@ -1779,9 +1779,6 @@ packages:
   '@vitest/pretty-format@4.1.10':
     resolution: {integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==}
 
-  '@vitest/pretty-format@4.1.9':
-    resolution: {integrity: sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==}
-
   '@vitest/runner@4.1.10':
     resolution: {integrity: sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==}
 
@@ -1793,9 +1790,6 @@ packages:
 
   '@vitest/utils@4.1.10':
     resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
-
-  '@vitest/utils@4.1.9':
-    resolution: {integrity: sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==}
 
   '@volar/kit@2.4.28':
     resolution: {integrity: sha512-cKX4vK9dtZvDRaAzeoUdaAJEew6IdxHNCRrdp5Kvcl6zZOqb6jTOfk3kXkIkG3T7oTFXguEMt5+9ptyqYR84Pg==}
@@ -5443,7 +5437,7 @@ snapshots:
       svelte: 5.56.4(@typescript-eslint/types@8.62.0)
     optionalDependencies:
       vite: 8.1.0(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)
-      vitest: 4.1.10(@types/node@25.9.1)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.1.0(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
+      vitest: 4.1.10(@types/node@25.9.1)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.1.0(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
 
   '@tsconfig/svelte@1.0.13': {}
 
@@ -5764,10 +5758,10 @@ snapshots:
       react-refresh: 0.18.0
       vite: 8.1.0(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)
 
-  '@vitest/coverage-v8@4.1.9(vitest@4.1.10)':
+  '@vitest/coverage-v8@4.1.10(vitest@4.1.10)':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
-      '@vitest/utils': 4.1.9
+      '@vitest/utils': 4.1.10
       ast-v8-to-istanbul: 1.0.4
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-report: 3.0.1
@@ -5776,7 +5770,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@types/node@25.9.1)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.1.0(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
+      vitest: 4.1.10(@types/node@25.9.1)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.1.0(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
 
   '@vitest/expect@4.1.10':
     dependencies:
@@ -5799,10 +5793,6 @@ snapshots:
     dependencies:
       tinyrainbow: 3.1.0
 
-  '@vitest/pretty-format@4.1.9':
-    dependencies:
-      tinyrainbow: 3.1.0
-
   '@vitest/runner@4.1.10':
     dependencies:
       '@vitest/utils': 4.1.10
@@ -5820,12 +5810,6 @@ snapshots:
   '@vitest/utils@4.1.10':
     dependencies:
       '@vitest/pretty-format': 4.1.10
-      convert-source-map: 2.0.0
-      tinyrainbow: 3.1.0
-
-  '@vitest/utils@4.1.9':
-    dependencies:
-      '@vitest/pretty-format': 4.1.9
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
@@ -8144,7 +8128,7 @@ snapshots:
     optionalDependencies:
       vite: 8.1.0(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)
 
-  vitest@4.1.10(@types/node@25.9.1)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.1.0(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)):
+  vitest@4.1.10(@types/node@25.9.1)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.1.0(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.10
       '@vitest/mocker': 4.1.10(vite@8.1.0(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
@@ -8168,7 +8152,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.9.1
-      '@vitest/coverage-v8': 4.1.9(vitest@4.1.10)
+      '@vitest/coverage-v8': 4.1.10(vitest@4.1.10)
       jsdom: 29.1.1(@noble/hashes@1.8.0)
     transitivePeerDependencies:
       - msw

--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -133,7 +133,7 @@ importers:
         version: 6.9.1
       '@testing-library/svelte':
         specifier: ^5.3.1
-        version: 5.3.1(svelte@5.56.4(@typescript-eslint/types@8.62.0))(vite@8.1.0(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))(vitest@4.1.9)
+        version: 5.3.1(svelte@5.56.4(@typescript-eslint/types@8.62.0))(vite@8.1.0(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))(vitest@4.1.10)
       '@types/nodemailer':
         specifier: ^8.0.0
         version: 8.0.0
@@ -142,7 +142,7 @@ importers:
         version: 0.17.6
       '@vitest/coverage-v8':
         specifier: ^4.1.9
-        version: 4.1.9(vitest@4.1.9)
+        version: 4.1.9(vitest@4.1.10)
       eslint:
         specifier: ^10.5.0
         version: 10.5.0(jiti@2.7.0)
@@ -177,8 +177,8 @@ importers:
         specifier: ^8.62.0
         version: 8.62.0(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)
       vitest:
-        specifier: ^4.1.9
-        version: 4.1.9(@types/node@25.9.1)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.1.0(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@25.9.1)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.1.0(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
 
 packages:
 
@@ -1762,11 +1762,11 @@ packages:
       '@vitest/browser':
         optional: true
 
-  '@vitest/expect@4.1.9':
-    resolution: {integrity: sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==}
+  '@vitest/expect@4.1.10':
+    resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
 
-  '@vitest/mocker@4.1.9':
-    resolution: {integrity: sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==}
+  '@vitest/mocker@4.1.10':
+    resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
     peerDependencies:
       msw: ^2.4.9
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -1776,17 +1776,23 @@ packages:
       vite:
         optional: true
 
+  '@vitest/pretty-format@4.1.10':
+    resolution: {integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==}
+
   '@vitest/pretty-format@4.1.9':
     resolution: {integrity: sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==}
 
-  '@vitest/runner@4.1.9':
-    resolution: {integrity: sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==}
+  '@vitest/runner@4.1.10':
+    resolution: {integrity: sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==}
 
-  '@vitest/snapshot@4.1.9':
-    resolution: {integrity: sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==}
+  '@vitest/snapshot@4.1.10':
+    resolution: {integrity: sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==}
 
-  '@vitest/spy@4.1.9':
-    resolution: {integrity: sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==}
+  '@vitest/spy@4.1.10':
+    resolution: {integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==}
+
+  '@vitest/utils@4.1.10':
+    resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
 
   '@vitest/utils@4.1.9':
     resolution: {integrity: sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==}
@@ -4052,20 +4058,20 @@ packages:
       vite:
         optional: true
 
-  vitest@4.1.9:
-    resolution: {integrity: sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==}
+  vitest@4.1.10:
+    resolution: {integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
       '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-      '@vitest/browser-playwright': 4.1.9
-      '@vitest/browser-preview': 4.1.9
-      '@vitest/browser-webdriverio': 4.1.9
-      '@vitest/coverage-istanbul': 4.1.9
-      '@vitest/coverage-v8': 4.1.9
-      '@vitest/ui': 4.1.9
+      '@vitest/browser-playwright': 4.1.10
+      '@vitest/browser-preview': 4.1.10
+      '@vitest/browser-webdriverio': 4.1.10
+      '@vitest/coverage-istanbul': 4.1.10
+      '@vitest/coverage-v8': 4.1.10
+      '@vitest/ui': 4.1.10
       happy-dom: '*'
       jsdom: '*'
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -5430,14 +5436,14 @@ snapshots:
     dependencies:
       svelte: 5.56.4(@typescript-eslint/types@8.62.0)
 
-  '@testing-library/svelte@5.3.1(svelte@5.56.4(@typescript-eslint/types@8.62.0))(vite@8.1.0(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))(vitest@4.1.9)':
+  '@testing-library/svelte@5.3.1(svelte@5.56.4(@typescript-eslint/types@8.62.0))(vite@8.1.0(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))(vitest@4.1.10)':
     dependencies:
       '@testing-library/dom': 10.4.1
       '@testing-library/svelte-core': 1.0.0(svelte@5.56.4(@typescript-eslint/types@8.62.0))
       svelte: 5.56.4(@typescript-eslint/types@8.62.0)
     optionalDependencies:
       vite: 8.1.0(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)
-      vitest: 4.1.9(@types/node@25.9.1)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.1.0(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
+      vitest: 4.1.10(@types/node@25.9.1)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.1.0(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
 
   '@tsconfig/svelte@1.0.13': {}
 
@@ -5758,7 +5764,7 @@ snapshots:
       react-refresh: 0.18.0
       vite: 8.1.0(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)
 
-  '@vitest/coverage-v8@4.1.9(vitest@4.1.9)':
+  '@vitest/coverage-v8@4.1.9(vitest@4.1.10)':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.1.9
@@ -5770,42 +5776,52 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@types/node@25.9.1)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.1.0(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
+      vitest: 4.1.10(@types/node@25.9.1)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.1.0(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
 
-  '@vitest/expect@4.1.9':
+  '@vitest/expect@4.1.10':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@vitest/spy': 4.1.9
-      '@vitest/utils': 4.1.9
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.9(vite@8.1.0(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.10(vite@8.1.0(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))':
     dependencies:
-      '@vitest/spy': 4.1.9
+      '@vitest/spy': 4.1.10
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       vite: 8.1.0(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)
 
+  '@vitest/pretty-format@4.1.10':
+    dependencies:
+      tinyrainbow: 3.1.0
+
   '@vitest/pretty-format@4.1.9':
     dependencies:
       tinyrainbow: 3.1.0
 
-  '@vitest/runner@4.1.9':
+  '@vitest/runner@4.1.10':
     dependencies:
-      '@vitest/utils': 4.1.9
+      '@vitest/utils': 4.1.10
       pathe: 2.0.3
 
-  '@vitest/snapshot@4.1.9':
+  '@vitest/snapshot@4.1.10':
     dependencies:
-      '@vitest/pretty-format': 4.1.9
-      '@vitest/utils': 4.1.9
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/utils': 4.1.10
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/spy@4.1.9': {}
+  '@vitest/spy@4.1.10': {}
+
+  '@vitest/utils@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
 
   '@vitest/utils@4.1.9':
     dependencies:
@@ -8128,15 +8144,15 @@ snapshots:
     optionalDependencies:
       vite: 8.1.0(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)
 
-  vitest@4.1.9(@types/node@25.9.1)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.1.0(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)):
+  vitest@4.1.10(@types/node@25.9.1)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.1.0(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)):
     dependencies:
-      '@vitest/expect': 4.1.9
-      '@vitest/mocker': 4.1.9(vite@8.1.0(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
-      '@vitest/pretty-format': 4.1.9
-      '@vitest/runner': 4.1.9
-      '@vitest/snapshot': 4.1.9
-      '@vitest/spy': 4.1.9
-      '@vitest/utils': 4.1.9
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@8.1.0(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
       es-module-lexer: 2.1.0
       expect-type: 1.3.0
       magic-string: 0.30.21
@@ -8146,13 +8162,13 @@ snapshots:
       std-env: 4.1.0
       tinybench: 2.9.0
       tinyexec: 1.2.2
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
       vite: 8.1.0(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.9.1
-      '@vitest/coverage-v8': 4.1.9(vitest@4.1.9)
+      '@vitest/coverage-v8': 4.1.9(vitest@4.1.10)
       jsdom: 29.1.1(@noble/hashes@1.8.0)
     transitivePeerDependencies:
       - msw

--- a/website/pnpm-workspace.yaml
+++ b/website/pnpm-workspace.yaml
@@ -33,6 +33,7 @@ minimumReleaseAgeExclude:
   - astro@7.0.4 || 7.0.5 || 7.0.6
   - '@astrojs/internal-helpers@0.10.1'
   - '@astrojs/markdown-satteri@0.3.3'
+  - '@vitest/coverage-v8@4.1.10'
 
 overrides:
   yaml: "^2.9.0"

--- a/website/pnpm-workspace.yaml
+++ b/website/pnpm-workspace.yaml
@@ -2,16 +2,16 @@ allowBuilds:
   esbuild: true
   sharp: true
 minimumReleaseAgeExclude:
-  - '@vitest/expect@4.1.9'
-  - '@vitest/mocker@4.1.9'
-  - '@vitest/pretty-format@4.1.9'
-  - '@vitest/runner@4.1.9'
-  - '@vitest/snapshot@4.1.9'
-  - '@vitest/spy@4.1.9'
-  - '@vitest/utils@4.1.9'
+  - '@vitest/expect@4.1.9 || 4.1.10'
+  - '@vitest/mocker@4.1.9 || 4.1.10'
+  - '@vitest/pretty-format@4.1.9 || 4.1.10'
+  - '@vitest/runner@4.1.9 || 4.1.10'
+  - '@vitest/snapshot@4.1.9 || 4.1.10'
+  - '@vitest/spy@4.1.9 || 4.1.10'
+  - '@vitest/utils@4.1.9 || 4.1.10'
   - playwright-core@1.61.0 || 1.61.1
   - playwright@1.61.0 || 1.61.1
-  - vitest@4.1.9
+  - vitest@4.1.9 || 4.1.10
   - '@anthropic-ai/sdk@0.104.2 || 0.105.0 || 0.106.0 || 0.109.0 || 0.109.1 || 0.110.0'
   - livekit-server-sdk@2.15.5 || 2.16.0
   - pg-connection-string@2.14.0

--- a/website/src/lib/caldav.test.ts
+++ b/website/src/lib/caldav.test.ts
@@ -196,7 +196,7 @@ describe('getClientBookings', () => {
 describe('getAvailableSlots', () => {
   it('degrades gracefully and returns [] when fetchEventsRaw fails (admin view, no brand)', async () => {
     mockFetchEventsRaw.mockRejectedValue(new Error('down'));
-    const from = new Date('2026-07-06T00:00:00Z'); // Monday
+    const from = new Date('2030-07-08T00:00:00Z'); // Monday
     const slots = await getAvailableSlots(from);
     // No brand => windowsMap stays null => falls back to WORK_DAYS branch.
     // fetchEvents catches the error internally and returns [], so slots for
@@ -206,10 +206,10 @@ describe('getAvailableSlots', () => {
 
   it('produces slots for admin overview (no brand) on a working day, respecting MIN_ADVANCE_HOURS', async () => {
     mockFetchEventsRaw.mockResolvedValue([]);
-    const from = new Date('2026-07-06T00:00:00Z'); // Monday, well in the future
+    const from = new Date('2030-07-08T00:00:00Z'); // Monday, well in the future
     const days = await getAvailableSlots(from);
     expect(days.length).toBeGreaterThan(0);
-    const monday = days.find((d) => d.date === '2026-07-06');
+    const monday = days.find((d) => d.date === '2030-07-08');
     expect(monday).toBeDefined();
     expect(monday!.weekday).toBe('Montag');
     expect(monday!.slots.length).toBeGreaterThan(0);
@@ -219,13 +219,13 @@ describe('getAvailableSlots', () => {
   it('excludes slots overlapping an existing calendar event', async () => {
     const busy = vevent({
       UID: 'busy@x',
-      DTSTART: '20260706T090000Z',
-      DTEND: '20260706T170000Z',
+      DTSTART: '20300708T090000Z',
+      DTEND: '20300708T170000Z',
     });
     mockFetchEventsRaw.mockResolvedValue([ical(busy)]);
-    const from = new Date('2026-07-06T00:00:00Z');
+    const from = new Date('2030-07-08T00:00:00Z');
     const days = await getAvailableSlots(from);
-    const monday = days.find((d) => d.date === '2026-07-06');
+    const monday = days.find((d) => d.date === '2030-07-08');
     // Entire working day is busy -> no slots that day.
     expect(monday).toBeUndefined();
   });
@@ -233,17 +233,17 @@ describe('getAvailableSlots', () => {
   it('skips vacation days entirely', async () => {
     mockFetchEventsRaw.mockResolvedValue([]);
     mockGetVacationPeriods.mockResolvedValue([
-      { id: 'v1', start: '2026-07-06', end: '2026-07-06', label: 'Urlaub' },
+      { id: 'v1', start: '2030-07-08', end: '2030-07-08', label: 'Urlaub' },
     ]);
-    const from = new Date('2026-07-06T00:00:00Z');
+    const from = new Date('2030-07-08T00:00:00Z');
     const days = await getAvailableSlots(from);
-    expect(days.find((d) => d.date === '2026-07-06')).toBeUndefined();
+    expect(days.find((d) => d.date === '2030-07-08')).toBeUndefined();
   });
 
   it('falls back gracefully when getVacationPeriods throws', async () => {
     mockFetchEventsRaw.mockResolvedValue([]);
     mockGetVacationPeriods.mockRejectedValue(new Error('table missing'));
-    const from = new Date('2026-07-06T00:00:00Z');
+    const from = new Date('2030-07-08T00:00:00Z');
     const days = await getAvailableSlots(from);
     expect(Array.isArray(days)).toBe(true);
   });
@@ -251,11 +251,11 @@ describe('getAvailableSlots', () => {
   it('uses admin-defined free-time windows when a brand is given', async () => {
     mockFetchEventsRaw.mockResolvedValue([]);
     mockGetFreeTimeWindows.mockResolvedValue([
-      { id: 'w1', date: '2026-07-06', winStart: '09:00', winEnd: '10:00' },
+      { id: 'w1', date: '2030-07-08', winStart: '09:00', winEnd: '10:00' },
     ]);
-    const from = new Date('2026-07-06T00:00:00Z');
+    const from = new Date('2030-07-08T00:00:00Z');
     const days = await getAvailableSlots(from, 'mentolder');
-    const monday = days.find((d) => d.date === '2026-07-06');
+    const monday = days.find((d) => d.date === '2030-07-08');
     expect(monday).toBeDefined();
     expect(monday!.slots).toHaveLength(1);
     expect(monday!.slots[0].display).toBe('09:00 - 10:00');
@@ -264,26 +264,26 @@ describe('getAvailableSlots', () => {
   it('falls back to no windowsMap when getFreeTimeWindows throws (brand given)', async () => {
     mockFetchEventsRaw.mockResolvedValue([]);
     mockGetFreeTimeWindows.mockRejectedValue(new Error('no table'));
-    const from = new Date('2026-07-06T00:00:00Z');
+    const from = new Date('2030-07-08T00:00:00Z');
     const days = await getAvailableSlots(from, 'mentolder');
     // windowsMap stays null -> falls through to WORK_DAYS admin branch.
-    const monday = days.find((d) => d.date === '2026-07-06');
+    const monday = days.find((d) => d.date === '2030-07-08');
     expect(monday).toBeDefined();
     expect(monday!.slots.length).toBeGreaterThan(0);
   });
 
   it('produces no slots on a weekend day for the admin overview', async () => {
     mockFetchEventsRaw.mockResolvedValue([]);
-    const from = new Date('2026-07-04T00:00:00Z'); // Saturday
+    const from = new Date('2030-07-06T00:00:00Z'); // Saturday
     const days = await getAvailableSlots(from);
-    expect(days.find((d) => d.date === '2026-07-04')).toBeUndefined();
+    expect(days.find((d) => d.date === '2030-07-06')).toBeUndefined();
   });
 
   it('honours a custom slot duration', async () => {
     mockFetchEventsRaw.mockResolvedValue([]);
-    const from = new Date('2026-07-06T00:00:00Z');
+    const from = new Date('2030-07-08T00:00:00Z');
     const days = await getAvailableSlots(from, undefined, 30);
-    const monday = days.find((d) => d.date === '2026-07-06');
+    const monday = days.find((d) => d.date === '2030-07-08');
     expect(monday).toBeDefined();
     // 30-minute slots => "09:00 - 09:30"
     expect(monday!.slots[0].display).toBe('09:00 - 09:30');


### PR DESCRIPTION
## Context7 Library Updates

Automated daily patch/minor update for libraries tracked in **CLAUDE.md § Context7**.
Major version bumps are excluded and require manual review.

| File | Package | Current | Updated |
|---|---|---|---|
| website/package.json | vitest | ^4.1.9 | ^4.1.10 |
| website/package.json | @vitest/coverage-v8 | ^4.1.9 | ^4.1.10 |

### Baseline allowance

[baseline-allow:inherited-orphan] — `S4:scripts/agent-orchestrator.sh` was already present in main before this branch was cut; not introduced by this PR.

---
*Auto-generated by the Daily Context7 Library Updater (05:00 UTC daily).*