### PR TITLE
fix(infra): sync website-secrets on pocket-id-client-seed rotation [T001435]

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -2575,6 +2575,8 @@ tasks:
           # transformer would otherwise force them into workspace).
           envsubst "\$WORKSPACE_NAMESPACE \$WEBSITE_NAMESPACE" < k3d/tests-retention-cronjob.yaml | kubectl apply -f -
           envsubst "\$WORKSPACE_NAMESPACE \$WEBSITE_NAMESPACE" < k3d/cicd-deploy-sa.yaml | kubectl apply -f -
+          # Cross-namespace RBAC for pocket-id-client-seed to also patch website-secrets (T001435)
+          envsubst "\$WORKSPACE_NAMESPACE \$WEBSITE_NAMESPACE" < k3d/pocket-id-client-seed-website-rbac.yaml | kubectl apply -f -
           # System-test failure-loop cleanup CronJobs — applied separately so
           # they land in WEBSITE_NAMESPACE alongside the website pod (kustomize's
           # top-level `namespace: workspace` would otherwise force them into the
@@ -2752,6 +2754,9 @@ tasks:
           envsubst "\$WORKSPACE_NAMESPACE \$WEBSITE_NAMESPACE" < k3d/tests-retention-cronjob.yaml \
             | kubectl --context "$ENV_CONTEXT" apply -f -
           envsubst "\$WORKSPACE_NAMESPACE \$WEBSITE_NAMESPACE" < k3d/cicd-deploy-sa.yaml \
+            | kubectl --context "$ENV_CONTEXT" apply -f -
+          # Cross-namespace RBAC for pocket-id-client-seed to also patch website-secrets (T001435)
+          envsubst "\$WORKSPACE_NAMESPACE \$WEBSITE_NAMESPACE" < k3d/pocket-id-client-seed-website-rbac.yaml \
             | kubectl --context "$ENV_CONTEXT" apply -f -
           # System-test failure-loop cleanup CronJobs — applied separately so
           # they land in WEBSITE_NAMESPACE alongside the website pod.

--- a/docs/code-quality/loc-budget.json
+++ b/docs/code-quality/loc-budget.json
@@ -1,8 +1,8 @@
 {
-  "total_lines": 536192,
+  "total_lines": 536329,
   "file_count": 4084,
-  "commit": "9b1b808f",
-  "measured_at": "2026-07-08T10:33:17.645Z",
+  "commit": "a4b80db5a",
+  "measured_at": "2026-07-08T11:20:42.885Z",
   "thresholds": {
     "warn_pct": 5,
     "fail_pct": 15,

--- a/k3d/pocket-id-client-seed-website-rbac.yaml
+++ b/k3d/pocket-id-client-seed-website-rbac.yaml
@@ -1,0 +1,44 @@
+# ═══════════════════════════════════════════════════════════════════
+# Cross-namespace RBAC for pocket-id-client-seed to patch
+# website-secrets in the website namespace (T001435).
+#
+# The seed Job's ServiceAccount lives in ${WORKSPACE_NAMESPACE} but
+# also needs to write POCKET_ID_WEBSITE_SECRET into the
+# website-secrets k8s Secret (in ${WEBSITE_NAMESPACE}) when it
+# creates a NEW website OIDC client — otherwise the website pod
+# reads a stale value and Pocket ID rejects it (secret mismatch).
+#
+# Least privilege: get+patch, scoped via resourceNames to the single
+# Secret object "website-secrets".
+#
+# Applied via envsubst (outside kustomize) so kustomize's namespace
+# transformer doesn't force it into the workspace ns.
+# ═══════════════════════════════════════════════════════════════════
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: pocket-id-client-seed-website-role
+  namespace: ${WEBSITE_NAMESPACE}
+  labels:
+    app: pocket-id
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: ["website-secrets"]
+    verbs: ["get", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: pocket-id-client-seed-website-rolebinding
+  namespace: ${WEBSITE_NAMESPACE}
+  labels:
+    app: pocket-id
+subjects:
+  - kind: ServiceAccount
+    name: pocket-id-client-seed
+    namespace: ${WORKSPACE_NAMESPACE}
+roleRef:
+  kind: Role
+  name: pocket-id-client-seed-website-role
+  apiGroup: rbac.authorization.k8s.io

--- a/k3d/pocket-id-client-seed.yaml
+++ b/k3d/pocket-id-client-seed.yaml
@@ -40,6 +40,14 @@
 #     converge instead of drifting: once a client exists with a secret
 #     that matches workspace-secrets, subsequent runs never touch it
 #     again.
+#
+#   - CROSS-NAMESPACE DRIFT (website only, T001435): the website pod
+#     reads POCKET_ID_WEBSITE_SECRET from `website-secrets` (website
+#     namespace), NOT from workspace-secrets. On creating a NEW website
+#     client, patch_secret now also writes the generated secret into
+#     website-secrets/<secretKey> so both k8s Secrets stay in sync.
+#     The seed Job's SA needs get+patch RBAC on website-secrets too
+#     (see pocket-id-client-seed-website-rbac.yaml).
 # ═══════════════════════════════════════════════════════════════════
 apiVersion: batch/v1
 kind: Job
@@ -104,6 +112,8 @@ spec:
           env:
             - name: POCKET_ID_FRONTEND_URL
               value: "${POCKET_ID_FRONTEND_URL}"
+            - name: WEBSITE_NAMESPACE
+              value: "${WEBSITE_NAMESPACE}"
             - name: API
               value: "http://pocket-id:1411"
             - name: POCKET_ID_API_KEY
@@ -231,6 +241,10 @@ spec:
               # stringData lets the API server base64-encode server-side --
               # no client-side base64 needed. allow-apiserver-egress
               # (T000368) already permits this egress from workspace pods.
+              # For the website client, also sync to website-secrets in the
+              # website namespace — otherwise the website pod reads the stale
+              # value from its own namespace and Pocket ID rejects the secret
+              # ("invalid client secret" / secret mismatch, T001435).
               KSA_DIR=/var/run/secrets/kubernetes.io/serviceaccount
               patch_secret() {
                 key="$1"; val="$2"
@@ -242,6 +256,15 @@ spec:
                   -X PATCH \
                   "https://kubernetes.default.svc/api/v1/namespaces/${ns}/secrets/workspace-secrets" \
                   -d "$body" </dev/null >/dev/null
+                if [ "$key" = "POCKET_ID_WEBSITE_SECRET" ] && [ -n "${WEBSITE_NAMESPACE:-}" ]; then
+                  curl -fsS $CURL_RETRY --cacert "${KSA_DIR}/ca.crt" \
+                    -H "Authorization: Bearer $(cat ${KSA_DIR}/token)" \
+                    -H "Content-Type: application/merge-patch+json" \
+                    -X PATCH \
+                    "https://kubernetes.default.svc/api/v1/namespaces/${WEBSITE_NAMESPACE}/secrets/website-secrets" \
+                    -d "$body" </dev/null >/dev/null
+                  echo "  (also synced to ${WEBSITE_NAMESPACE}/website-secrets)"
+                fi
               }
 
               # Idempotent upsert: create if missing, otherwise update via PUT
@@ -282,7 +305,7 @@ spec:
                     exit 1
                   fi
                   patch_secret "$secret_key" "$plaintext"
-                  echo "created ${cid} (id=${new_id}), secret generated + written back to workspace-secrets/${secret_key}"
+                  echo "created ${cid} (id=${new_id}), secret generated + written back to workspace-secrets/${secret_key}${WEBSITE_NAMESPACE:+ + website-secrets/${secret_key}}"
                 fi
               }
 


### PR DESCRIPTION
## Summary
- **Problem:** `pocket-id-client-seed` Job rotates the `website` OIDC client secret on every deploy via Pocket ID API, but only wrote the new value back to `workspace-secrets` (workspace namespace). The website pod reads its secret from `website-secrets` (website namespace) — stale value → Pocket ID rejects the rotated secret → "invalid client secret" / "secretmismatch" on login
- **Fix:** Added cross-namespace sync in `patch_secret()`: when `key == "POCKET_ID_WEBSITE_SECRET"`, also PATCH `website-secrets` in `$WEBSITE_NAMESPACE`
- New RBAC Role+RoleBinding (`pocket-id-client-seed-website-rbac.yaml`) grants the seed Job's SA `get`+`patch` on `website-secrets` in the website namespace
- Applied via `envsubst` in both dev and prod deploy paths (same pattern as `tests-retention-cronjob.yaml`)

## Test Plan
- [x] `task test:manifests` — 52/52 pass
- [x] `task test:unit` — all seed-Job BATS pass (11/11)
- [x] `task workspace:validate` — kustomize dry-run ok
- [x] `task test:code-quality` — 52/52 (S1–S5, LOC budget)

🤖 [T001435]