### PR TITLE
chore: add agy-awareness to skill files and skill-dispatch protocol [T001620]

### DIFF
--- a/.claude/skills/dev-flow-chore/SKILL.md
+++ b/.claude/skills/dev-flow-chore/SKILL.md
@@ -120,7 +120,7 @@ Chore-spezifisch: Titelformat `chore(<scope>): <subject> [$TICKET_EXT_ID]`. Die
 `[T000XXX]`-Referenz wird von `.github/workflows/post-merge.yml` gelesen — das Ticket ist
 bereits `done`, der Status-Update ist ein idempotenter No-op.
 
-Rufe `commit-commands:commit-push-pr` auf (oder `gh pr create` manuell).
+Rufe `commit-commands:commit-push-pr` auf (Claude Code slash-command) oder führe `gh pr create` manuell aus (beide Frameworks).
 
 ## Schritt 5: Merge wenn CI grün
 

--- a/.claude/skills/dev-flow-execute/SKILL.md
+++ b/.claude/skills/dev-flow-execute/SKILL.md
@@ -36,7 +36,7 @@ Fallback (mcp-postgres nicht erreichbar — Verfügbarkeits-Guard siehe [`mcp-to
 kubectl exec -n workspace deploy/shared-db -- psql -U postgres -d website -t -A -F '|' -c \
   "SELECT external_id, title FROM tickets.tickets WHERE status='plan_staged' ORDER BY planning_rank ASC NULLS LAST, created_at DESC LIMIT 10;"
 ```
-Bei mehreren staged plans den User via `AskUserQuestion`-Tool nach der gewünschten Ticket-ID fragen.
+Bei mehreren staged plans den User via `AskUserQuestion` (Claude Code) oder `question` (opencode/agy) nach der gewünschten Ticket-ID fragen.
 
 ## Schritt −1: Main-Branch im Haupt-Repo synchronisieren (Pull-First)
 
@@ -185,9 +185,10 @@ Fallback:
 ```
 Statt deinen eigenen Kontext/Modell zurückzusetzen (das ließe dich den Faden verlieren), delegiere die **gesamte Implementierung an EINEN frischen Subagenten** — sauberer Kontext per Konstruktion. Du behältst den vollen Plan-Kontext und verifizierst das Ergebnis anschließend unabhängig.
 > **Warum EIN Implementer statt `superpowers:subagent-driven-development`-Fan-out?** Dieser Skill läuft bereits *selbst* als delegierte Ebene (oft aus einem dev-flow-Orchestrator). Ein zusätzlicher Per-Task-Fan-out wäre **verschachtelte Delegation** $\rightarrow$ Kontext-Explosion und Synthese-Last (siehe [subagent-provisioning](file:///home/patrick/Bachelorprojekt/.claude/skills/references/subagent-provisioning.md), 162k-Prompt-Lehre). Der Implementer ruft `superpowers:executing-plans` daher **in-context** auf (kein weiterer Agenten-Fan-out). Nur wenn der Plan ausdrücklich viele **voneinander unabhängige** Tasks hat und der Einzel-Implementer am Kontext-Limit scheitert, lohnt der Wechsel auf `subagent-driven-development` bzw. einen `Workflow`-Fan-out — bewusste Eskalation, nicht Default.
-Spawne den Subagenten:
+Spawne den Subagenten, provisioniert gemäß [subagent-provisioning](file:///home/patrick/Bachelorprojekt/.claude/skills/references/subagent-provisioning.md):
 * **Gemini/Antigravity CLI:** call `invoke_subagent` with `TypeName: "self"` (inherits permissions and tools), `Role: "Implementer <TICKET_ID>"`, and `Workspace: "share"` (or `"inherit"`).
-* **Claude Code CLI:** Spawne über das `Agent`/`Task`-Tool einen Subagenten (`subagent_type: general-purpose`), **provisioniert gemäß** [subagent-provisioning](file:///home/patrick/Bachelorprojekt/.claude/skills/references/subagent-provisioning.md) — Modell nach Plan-Charakter (Implementer-Default: `sonnet`; mechanisch `haiku`, komplex/riskant `opus`), Effort per Prompt-Direktive und die Worktree-`cd`-Pflicht stehen dort (SSOT, nicht hier wiederholen).
+* **Claude Code CLI:** Spawne über das `Agent`/`Task`-Tool einen Subagenten (`subagent_type: general-purpose`) — Modell nach Plan-Charakter (Implementer-Default: `sonnet`; mechanisch `haiku`, komplex/riskant `opus`), Effort per Prompt-Direktive.
+* **opencode:** Nutze `delegate(prompt, agent="researcher")` für read-only Subagenten oder die native write-capable Delegation. Die Worktree-`cd`-Pflicht und Modell-Effort-Formulierungen stehen in der Reference (SSOT, nicht hier wiederholen).
 - **Kontext-Injektion** (er hat sonst KEINEN Kontext — gib ihm alles explizit; Kompaktheits-Regeln siehe subagent-provisioning §3):
   - Plan-Datei `$PLAN_FILE` (aus Schritt 1, via DB aufgelöst) + Ticket-ID.
   - Attachment-Verzeichnis `$ATTACHMENT_DIR` — bei UI-Arbeit ALLE Bilder/Texte mit dem `Read`-Tool einlesen.
@@ -211,7 +212,7 @@ Spawne den Subagenten:
   **Ziel:** Die Gesamtzahl der `.bats`-Dateien in `tests/local/` sinkt oder bleibt konstant. Ticket-nummerierte Dateien (`FA-SF-42.bats`) sind Legacy — nicht neu anlegen.
 - **Auftrag:**
   - **/goal: Finish dev-flow-execute and merge the PR cleanly.**
-  - *Feature:* Rufe `superpowers:executing-plans` (in-context, KEIN weiterer Agenten-Fan-out) + `test-driven-development` auf und arbeite den Plan vollständig ab. Aktualisiere nach jedem Meilenstein die Checkbox im Plan (`- [ ] M1` → `- [x] M1`), committe und pushe.
+  - *Feature:* Rufe `superpowers:executing-plans` (Claude Code — built-in; opencode: führe die Schritte direkt aus — `opencode-flow-execute` hat das Äquivalent inlined) + `test-driven-development` (Claude Code — built-in; opencode: siehe `vitest/SKILL.md`) auf und arbeite den Plan vollständig ab. Aktualisiere nach jedem Meilenstein die Checkbox im Plan (`- [ ] M1` → `- [x] M1`), committe und pushe.
   - *Fix:* Verifiziere zuerst, dass ein failing Test existiert, dann nach Rot-Grün-Prinzip bis grün.
    - Bei Kompilier-/Testfehlern: diagnostiziere und fixe systematisch (Logs lesen, Fehler eingrenzen, Hypothese testen, fixen, Re-Test).
   - **PFLICHT vor PR-Erstellung — Freshness-Artefakte regenerieren und committen** (sonst schlägt CI mit "stale artifact" fehl; `executing-plans` → `finishing-a-development-branch` überspringt diesen Schritt). Befehle + Artefakt-Pfadliste (SSOT): [verification-block](file:///home/patrick/Bachelorprojekt/.claude/skills/references/verification-block.md) — der Subagent MUSS die Datei lesen und den `git add`-Block daraus verwenden.
@@ -231,7 +232,8 @@ bash scripts/devflow-build-loop.sh "$TICKET_ID"
 
 ## Schritt 3: Lokale Verifikation
 
-Rufe das Skill **`verification-before-completion`** auf, um die Verifikation strukturiert zu steuern.
+Rufe das Skill **`verification-before-completion`** auf (Claude Code — built-in; opencode: siehe die
+inlined Steps in `opencode-flow-execute/SKILL.md` und den `references/verification-block.md`), um die Verifikation strukturiert zu steuern.
 Phasen-Telemetrie (PFLICHT für verify — das Gate erzwingt sie) — **MCP-first** (`ticket-mcp`):
 > `mcp__ticket-mcp__record_phase_event({ id: "$TICKET_ID", phase: "implement", state: "done", driver: "devflow", detail: "Implementierung fertig" })`
 > `mcp__ticket-mcp__record_phase_event({ id: "$TICKET_ID", phase: "verify", state: "entered", driver: "devflow", detail: "task test:changed + freshness" })`
@@ -259,7 +261,9 @@ bash scripts/admin-menu-gate.sh
 ## Schritt 3.8: Code Review Gate (Mandatory)
 
 Vor dem PR-Merge muss eine unabhängige Überprüfung stattfinden.
-1. Rufe das Skill **`requesting-code-review`** (oder `pr-review-toolkit:review-pr` bzw. einen Review-Subagenten) auf, um die Änderungen zu auditieren.
+1. Rufe das Skill **`requesting-code-review`** auf (Claude Code — built-in; opencode: nutze
+   `pr-review-toolkit:review-pr` oder delegiere an einen Review-Subagenten via `delegate()`),
+   um die Änderungen zu auditieren.
 2. Behebe alle gefundenen Probleme und stelle sicher, dass der Reviewer "Approved" gibt, bevor du fortfährst.
 
 ## Schritt 4: Dev-Iteration (optional)
@@ -274,7 +278,7 @@ Allowlist prüfen [T001395], explizite Pathspecs statt `git add -A` (git-crypt-G
 Commit-Verifikation `HEAD_SHA != BASE_SHA` [T000925], `preflight-pr-scope.sh` vor `gh pr create`,
 REST-Fallback für Titel-Edits.
 Execute-spezifisch: Ticket-ID `[$TICKET_ID]` in Header und `Closes T000XXX` im Body bei Fixes.
-Rufe `commit-commands:commit-push-pr` auf (oder führe `gh pr create` manuell aus).
+Rufe `commit-commands:commit-push-pr` auf (Claude Code slash-command) oder führe `gh pr create` manuell aus (beide Frameworks).
 
 ## Schritt 5.5: CI/CD-Fix-Schleife
 

--- a/.claude/skills/dev-flow-plan/SKILL.md
+++ b/.claude/skills/dev-flow-plan/SKILL.md
@@ -159,7 +159,10 @@ Repo-Datei (`git diff` / `Read` der Live-Datei) erst beim Verbauen, nicht als Pl
 #### Schritt A.3: Lavish-Board starten ⚡ PFLICHT — vor Brainstorming
 Erstelle `.lavish/<slug>-brainstorm.html` (Sections: Intent, Constraints, Trade-offs, Entscheidungen) und öffne es mit `npx -y lavish-axi .lavish/<slug>-brainstorm.html`. Dieses Board dient als visuelles Arbeitsblatt während des Brainstormings.
 #### Schritt A.4: Brainstorming ⚡ IMMER — kein Überspringen
-Rufe `superpowers:brainstorming` auf. Nutze das `lavish`-Board (aus Schritt A.3) für visuelle Dokumentation und strukturiertes Feedback.
+Rufe `superpowers:brainstorming` auf (Claude Code — built-in) oder führe die Brainstorming-Schritte
+direkt aus (opencode — das Äquivalent ist in `opencode-flow-plan` inlined; lies die Spec und
+arbeite die Schritte A.3→A.5 ohne Skill-Load durch).
+Nutze das `lavish`-Board (aus Schritt A.3) für visuelle Dokumentation und strukturiertes Feedback.
 Ergebnis: Spec-Datei in `docs/superpowers/specs/<date>-<slug>-design.md`.
 Nach dem Schreiben der Spec das Frontmatter setzen (siehe
 `docs/superpowers/specs/spec-frontmatter-standard.md`):
@@ -233,7 +236,9 @@ bash scripts/ticket-attach.sh "$TICKET_UUID" \
 ### Schritt 3.7: Plan-Erstellung an einen passend provisionierten Subagenten delegieren
 Statt deinen eigenen Kontext zurückzusetzen (das ließe dich den Faden verlieren), committe die Spec und delegiere das Plan-Schreiben an einen **frischen Subagenten** — der hat per Konstruktion einen sauberen Kontext und bekommt ein **zur Plan-Komplexität passendes Modell + Effort**. Du selbst behältst den vollen Brainstorming-Kontext.
 1. Committe und pushe die Spec-Datei auf den Feature-Branch.
-2. Spawne über das `Agent`/`Task`-Tool einen Subagenten (`subagent_type: general-purpose`), **provisioniert gemäß** [subagent-provisioning](file:///home/patrick/Bachelorprojekt/.claude/skills/references/subagent-provisioning.md) — Plan-Schreiben ist reasoning-lastige Meta-Arbeit: Modell-Default `opus` (triviale chore-artige Pläne: `sonnet`), Effort high; bei großen multi-subsystem-Specs die ultra-Stufe (`Workflow`-Fan-out) — Effort-Formulierungen, Worktree-`cd`-Pflicht und Eskalations-Rubrik stehen in der Reference (SSOT, nicht hier wiederholen).
+2. Spawne einen Subagenten, provisioniert gemäß [subagent-provisioning](file:///home/patrick/Bachelorprojekt/.claude/skills/references/subagent-provisioning.md):
+   - **Claude Code:** Über das `Agent`/`Task`-Tool (`subagent_type: general-purpose`) — Plan-Schreiben ist reasoning-lastige Meta-Arbeit: Modell-Default `opus` (triviale chore-artige Pläne: `sonnet`), Effort high; bei großen multi-subsystem-Specs die ultra-Stufe (`Workflow`-Fan-out).
+   - **opencode:** Über `delegate(prompt, agent="researcher")` für read-only oder native write-capable Delegation. Effort-Formulierungen, Worktree-`cd`-Pflicht und Eskalations-Rubrik stehen in der Reference (SSOT, nicht hier wiederholen).
    - **Kontext-Injektion** (er hat sonst KEINEN Kontext — gib ihm alles explizit; Kompaktheits-Regeln siehe subagent-provisioning §3):
      - Spec-Pfad: `docs/superpowers/specs/<date>-<slug>-design.md`
      - **Design-Bundle** (falls Schritt A.2 lief): `openspec/changes/<slug>/assets/` —
@@ -425,7 +430,10 @@ kein Test schreiben, bevor Root-Cause und Fix-Ansatz im Board geklärt sind.
 Schreibe einen automatisierten Test, der den Bug reproduziert und fehlschlägt (PASS/FAIL rot-grün Prinzip). Dies ist eine **harte Voraussetzung** für den Fix-Pfad.
 **Wo:** In `tests/spec/<spec-slug>.bats` (Spec zu diesem Fix aus `openspec/specs/`), nicht in eine neue `tests/local/FA-XY-*.bats` Ticket-Datei. Falls `tests/spec/<spec-slug>.bats` noch nicht existiert, anlegen (Vorlage: `tests/spec/software-factory.bats`).
 ### Schritt 4: Plan schreiben
-Rufe `superpowers:writing-plans` auf. Wende das Frontmatter an und trage die Ticket-ID ein. Committe und pushe den Plan.
+Rufe `superpowers:writing-plans` auf (Claude Code — built-in) oder führe die Plan-Schreib-Schritte
+direkt aus (opencode — das Äquivalent ist in `opencode-flow-plan` inlined; schreibe den Plan nach
+`openspec/changes/<slug>/tasks.md` gemäß den plan-lint Hard Rules in Schritt 3.7).
+Wende das Frontmatter an und trage die Ticket-ID ein. Committe und pushe den Plan.
 ### Schritt 4.5: Plan stagen (Fix 6)
 **MCP-first** (`ticket-mcp`):
 > `mcp__ticket-mcp__stage_plan({ id: "$TICKET_EXT_ID", branch: "fix/<slug>", plan: "openspec/changes/<slug>/tasks.md" })`
@@ -484,8 +492,8 @@ Der Skill liest den Plan automatisch aus der DB (`FACTORY-PLAN-REF` Kommentar) �
 | Skill | Beziehung |
 |-------|-----------|
 | `using-git-worktrees` | Hintergrund — ersetzt durch `scripts/worktree-create.sh` (git-crypt-safe) |
-| `superpowers:brainstorming` | **IMMER** aufgerufen — Feature-Pfad Schritt 3, Fix-Pfad Schritt 2.8 |
-| `superpowers:writing-plans` | Aufgerufen vom Plan-Subagenten (Schritt 3.7) |
+| `superpowers:brainstorming` | **IMMER** aufgerufen — Feature-Pfad Schritt 3, Fix-Pfad Schritt 2.8. Stub in `.claude/skills/superpowers-brainstorming/` für opencode-Kompatibilität |
+| `superpowers:writing-plans` | Aufgerufen vom Plan-Subagenten (Schritt 3.7). Stub in `.claude/skills/superpowers-writing-plans/` für opencode-Kompatibilität |
 | `dev-flow-execute` | **Nachfolger im Kreislauf** — implementiert den erstellten Plan |
 | `dev-flow-chore` | Geschwister — Chores statt Features/Fixes (direkter Kurzschluss) |
 | `mishap-tracker` | Abschluss — protokolliert Frictions |

--- a/.claude/skills/incident-response/SKILL.md
+++ b/.claude/skills/incident-response/SKILL.md
@@ -72,6 +72,7 @@ Capture the fix PR number (`PR_NUM=$(gh pr view <branch-or-num> --json number -q
 psql -c \
   "UPDATE tickets.tickets SET status = 'done', resolution = 'fixed', done_at = now(), notes = COALESCE(notes || E'\n\n', '') || '[incident-response $(date +%Y-%m-%d)] Root cause: <cause>. Fix: <fix>. Duration: <X> min.' WHERE external_id = '<TICKET_EXT_ID>';
 
+   -- AUTHOR_LABEL: Set platform-agnostic. Claude Code → 'claude-code', opencode → 'opencode'
    INSERT INTO tickets.ticket_comments (ticket_id, author_label, body, visibility)
    SELECT id, 'claude-code', 'Resolved by PR #<PR_NUM> (or rollback to <PREV_SHA>).', 'internal'
    FROM tickets.tickets WHERE external_id = '<TICKET_EXT_ID>';"

--- a/.claude/skills/lavish/SKILL.md
+++ b/.claude/skills/lavish/SKILL.md
@@ -33,7 +33,7 @@ Opening a Lavish session starts a real browser tab and a background server on th
 
 - **Already consent** (skip the gate, proceed straight to Workflow): the user typed `/lavish`, or their message explicitly names an artifact, HTML page, Lavish, an interactive/reviewable surface, or otherwise directly asks for this format.
 - **Not yet consent** (gate required): you decided on your own that a plan, comparison, diagram, table, or report from the current task "would be easier to grasp visually." A good idea for you is not the same as buy-in from the user.
-- When the gate applies, ask a single short, concrete question before doing any Lavish work — e.g. "Soll ich das als interaktives Lavish-Artefakt statt als Text aufbereiten?" Use `AskUserQuestion` if the harness has it, otherwise ask in plain text and wait for the reply.
+- When the gate applies, ask a single short, concrete question before doing any Lavish work — e.g. "Soll ich das als interaktives Lavish-Artefakt statt als Text aufbereiten?" Use the framework-appropriate tool (`AskUserQuestion` in Claude Code, `question` in opencode), otherwise ask in plain text and wait for the reply.
 - If the user declines, doesn't respond affirmatively, or the ask would be disruptive mid-task, fall back to a normal prose/markdown response instead — do not silently build the artifact anyway.
 - One confirmation covers the whole build → poll → feedback cycle for that artifact; don't re-ask on every poll iteration or layout fix.
 

--- a/.claude/skills/references/gh-axi.md
+++ b/.claude/skills/references/gh-axi.md
@@ -1,6 +1,6 @@
 # gh-axi — GitHub CLI Wrapper
 
-`gh-axi` ist ein Ergonomie-Wrapper um die `gh` CLI. **Alle Agents sollen `gh-axi` statt `gh` direkt verwenden**, sofern ein passendes Sub-Kommando existiert.
+`gh-axi` ist ein Ergonomie-Wrapper um die `gh` CLI. **Alle Agents sollen `gh-axi` statt `gh` direkt verwenden**, sofern ein passendes Sub-Kommando existiert. (Framework-agnostisch — funktioniert in Claude Code, opencode und agy gleichermaßen.)
 
 Binary: `~/.npm-global/bin/gh-axi`  
 Repo-Kontext: wird automatisch aus dem aktuellen Git-Checkout abgeleitet (kein `-R` nötig).

--- a/.claude/skills/references/subagent-provisioning.md
+++ b/.claude/skills/references/subagent-provisioning.md
@@ -47,7 +47,9 @@ Das `task`-Tool kennt **`subagent_type` und `description`**, keinen separaten Ef
 | low | „Arbeite zügig und fokussiert." | mechanisch, geringes Risiko |
 | medium | (neutral, kein Zusatz) | Standard |
 | high | „Ultrathink. Denke sehr gründlich nach." | komplex/riskant/Meta |
-| **ultra** | high **+ `Workflow`-Fan-out statt Einzel-Agent** | sehr groß/parallelisierbar (multi-subsystem Plan/Review): nutze das `Workflow`-Tool (mehrere Agenten + adversariale Verifikation gegen einen **geteilten Interface-Contract**), nicht einen einzelnen Agenten |
+| **ultra** | high **+ `Workflow`-Fan-out statt Einzel-Agent** | sehr groß/parallelisierbar (multi-subsystem Plan/Review): nutze das **Claude Code** `Workflow`-Tool (mehrere Agenten + adversariale Verifikation gegen einen **geteilten Interface-Contract**), nicht einen einzelnen Agenten. In **opencode/agy** kein `Workflow`-Pendant — führe die Plan-Schritte seriell oder delegiere an einen einzelnen Subagenten mit high-Effort-Prompt. |
+
+> **Framework-Routing für Subagenten:** Claude Code → `Agent`/`Task` tool mit `subagent_type`. opencode → `delegate(prompt, agent)` für read-only, native write-capable Delegation für Edit-Zugriff. agy → treat opencode path as authoritative; bash/MCP tool calls are framework-agnostic.
 
 ### 3. Kontext (passend & KOMPAKT)
 

--- a/.claude/skills/requesting-code-review/SKILL.md
+++ b/.claude/skills/requesting-code-review/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: requesting-code-review
+description: "[STUB] Built-in skill — redirects to inlined alternative. See skill body for details."
+---
+
+# requesting-code-review — STUB / Redirect
+
+This skill is a **built-in superpower** of Claude Code and is not shipped as a standalone file
+in this repository.
+
+## Framework mapping
+
+| Framework | Availability |
+|-----------|-------------|
+| **Claude Code** | Built-in — available as `requesting-code-review` via the Claude Code CLI |
+| **opencode** | Not available as a separate skill. The equivalent review steps are **inlined** in `dev-flow-execute/SKILL.md` (step 3.8), with an alternative path using `pr-review-toolkit:review-pr` or a review subagent |
+| **agy** | Treat the opencode path as authoritative. Code review is a manual/git-based process — framework-agnostic. |
+
+## What this stub is for
+
+This stub exists so that skill-loading calls to `requesting-code-review` do not fail
+with a "skill not found" error. It contains no executable workflow — the real logic lives
+in the skills listed above.
+
+If you are running in **Claude Code**, invoke the built-in superpower directly.
+If you are running in **opencode** or **agy**, use the inlined review steps in
+`dev-flow-execute/SKILL.md` instead.

--- a/.claude/skills/superpowers-brainstorming/SKILL.md
+++ b/.claude/skills/superpowers-brainstorming/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: superpowers:brainstorming
+description: "[STUB] Built-in skill — redirects to inlined alternative. See skill body for details."
+---
+
+# superpowers:brainstorming — STUB / Redirect
+
+This skill is a **built-in superpower** of Claude Code and is not shipped as a standalone file
+in this repository.
+
+## Framework mapping
+
+| Framework | Availability |
+|-----------|-------------|
+| **Claude Code** | Built-in — available as `superpowers:brainstorming` via the Claude Code CLI |
+| **opencode** | Not available as a separate skill. Equivalent functionality is **inlined** in `opencode-flow-plan/SKILL.md` (steps A.3–A.5) and in `dev-flow-plan/SKILL.md` (step A.4, which contains the brainstorming workflow directly) |
+| **agy** | Treat the opencode path as authoritative — all CLI tools (`gh`, `git`, `kubectl`, `task`, `bash scripts/`) and MCP tool calls work identically. The brainstorming workflow steps are bash/MCP-based and framework-agnostic. |
+
+## What this stub is for
+
+This stub exists so that skill-loading calls to `superpowers:brainstorming` do not fail
+with a "skill not found" error. It contains no executable workflow — the real logic lives
+in the skills listed above.
+
+If you are running in **Claude Code**, invoke the built-in superpower directly.
+If you are running in **opencode** or **agy**, use the inlined brainstorming steps in the
+dev-flow or opencode-flow skills instead.

--- a/.claude/skills/superpowers-executing-plans/SKILL.md
+++ b/.claude/skills/superpowers-executing-plans/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: superpowers:executing-plans
+description: "[STUB] Built-in skill — redirects to inlined alternative. See skill body for details."
+---
+
+# superpowers:executing-plans — STUB / Redirect
+
+This skill is a **built-in superpower** of Claude Code and is not shipped as a standalone file
+in this repository.
+
+## Framework mapping
+
+| Framework | Availability |
+|-----------|-------------|
+| **Claude Code** | Built-in — available as `superpowers:executing-plans` via the Claude Code CLI |
+| **opencode** | Not available as a separate skill. The plan-execution logic is **inlined** in `dev-flow-execute/SKILL.md` (steps 2–8) and in `opencode-flow-execute/SKILL.md` |
+| **agy** | Treat the opencode path as authoritative — all CLI tools (`gh`, `git`, `kubectl`, `task`, `bash scripts/`) and MCP tool calls work identically. Plan-execution is entirely bash/MCP-driven and framework-agnostic. |
+
+## What this stub is for
+
+This stub exists so that skill-loading calls to `superpowers:executing-plans` do not fail
+with a "skill not found" error. It contains no executable workflow — the real logic lives
+in the skills listed above.
+
+If you are running in **Claude Code**, invoke the built-in superpower directly.
+If you are running in **opencode** or **agy**, use the inlined execution steps in the dev-flow
+or opencode-flow skills instead.

--- a/.claude/skills/superpowers-writing-plans/SKILL.md
+++ b/.claude/skills/superpowers-writing-plans/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: superpowers:writing-plans
+description: "[STUB] Built-in skill — redirects to inlined alternative. See skill body for details."
+---
+
+# superpowers:writing-plans — STUB / Redirect
+
+This skill is a **built-in superpower** of Claude Code and is not shipped as a standalone file
+in this repository.
+
+## Framework mapping
+
+| Framework | Availability |
+|-----------|-------------|
+| **Claude Code** | Built-in — available as `superpowers:writing-plans` via the Claude Code CLI |
+| **opencode** | Not available as a separate skill. The plan-writing logic is **inlined** in `dev-flow-plan/SKILL.md` (step 3.7 for plan creation, step 3.8 for quality gates) and in `opencode-flow-plan/SKILL.md` |
+| **agy** | Treat the opencode path as authoritative — all CLI tools (`gh`, `git`, `kubectl`, `task`, `bash scripts/`) and MCP tool calls work identically. Plan-writing uses bash/MCP-based tooling that is framework-agnostic. |
+
+## What this stub is for
+
+This stub exists so that skill-loading calls to `superpowers:writing-plans` do not fail
+with a "skill not found" error. It contains no executable workflow — the real logic lives
+in the skills listed above.
+
+If you are running in **Claude Code**, invoke the built-in superpower directly.
+If you are running in **opencode** or **agy**, use the inlined plan-writing steps in the
+dev-flow or opencode-flow skills instead.

--- a/.claude/skills/test-driven-development/SKILL.md
+++ b/.claude/skills/test-driven-development/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: test-driven-development
+description: "[STUB] Built-in skill — redirects to inlined alternative. See skill body for details."
+---
+
+# test-driven-development — STUB / Redirect
+
+This skill is a **built-in superpower** of Claude Code and is not shipped as a standalone file
+in this repository.
+
+## Framework mapping
+
+| Framework | Availability |
+|-----------|-------------|
+| **Claude Code** | Built-in — available as `test-driven-development` via the Claude Code CLI |
+| **opencode** | Not available as a separate skill. The TDD workflow is **inlined** in `dev-flow-execute/SKILL.md` (step 2, red-green principle) and `vitest/SKILL.md` |
+| **agy** | Treat the opencode path as authoritative — TDD is entirely test-framework-driven (vitest, BATS, Playwright) and framework-agnostic. |
+
+## What this stub is for
+
+This stub exists so that skill-loading calls to `test-driven-development` do not fail
+with a "skill not found" error. It contains no executable workflow — the real logic lives
+in the skills listed above.
+
+If you are running in **Claude Code**, invoke the built-in superpower directly.
+If you are running in **opencode** or **agy**, use the inlined TDD steps in the dev-flow
+skills and the vitest skill instead.

--- a/.claude/skills/ticket-ops/SKILL.md
+++ b/.claude/skills/ticket-ops/SKILL.md
@@ -146,8 +146,11 @@ Mirror `website/src/lib/clarification-questions.ts` (`deriveSections`) — the s
 | `priority` / `severity` | Priorität (hoch/mittel/niedrig)? Severity (critical/major/minor/trivial)? |
 | `area/component` | Welcher Bereich/Component ist betroffen? |
 
-### Step 2.3: Ask via `AskUserQuestion`
-One `AskUserQuestion` round per ticket (≤4 questions per call — split into multiple calls if a ticket has more), in priority order. Use the radio/checkbox option sets from `clarification-questions.ts` where they exist; free-text otherwise. If you are running without the `AskUserQuestion` tool (e.g. dispatched as a subagent), fall back to one consolidated plain-text question per ticket.
+### Step 2.3: Ask via the interactive question tool
+Use the framework-appropriate question tool:
+- **Claude Code:** `AskUserQuestion` — one round per ticket (≤4 questions per call), in priority order. Use the radio/checkbox option sets from `clarification-questions.ts` where they exist; free-text otherwise.
+- **opencode:** `question` tool — same workflow, same constraints.
+If you are running without an interactive question tool (e.g. dispatched as a subagent without one), fall back to one consolidated plain-text question per ticket.
 
 ### Step 2.4: Write answers back to the DB
 
@@ -162,12 +165,13 @@ Fallback / bulk path (ticket-mcp nicht erreichbar, oder für Felder ohne Wrapper
 ```bash
 psql -c "
 UPDATE tickets.tickets
-   SET readiness   = COALESCE(readiness,'{}'::jsonb) || '{\"spec_skizziert\":true,\"aufwand_geschaetzt\":true}'::jsonb,
-       effort      = 'mittel',
-       depends_on  = ARRAY['T000YYY'],
-       priority    = 'hoch',
-       updated_at  = now()
+   SET readiness   = COALESCE(readiness,'{}'::jsonb) || '{"spec_skizziert":true,"aufwand_geschaetzt":true}'::jsonb,
+        effort      = 'mittel',
+        depends_on  = ARRAY['T000YYY'],
+        priority    = 'hoch',
+        updated_at  = now()
  WHERE external_id = 'T000XXX';
+-- AUTHOR_LABEL: Set platform-agnostic. Claude Code → 'claude-code', opencode → 'opencode'
 INSERT INTO tickets.ticket_comments (ticket_id, author_label, body, visibility)
 SELECT id, 'claude-code',
        E'## Klärungsrunde $(date +%F)\n| Frage | Antwort |\n|---|---|\n| Kern-Flow | … |\n| Aufwand | mittel |',

--- a/.claude/skills/verification-before-completion/SKILL.md
+++ b/.claude/skills/verification-before-completion/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: verification-before-completion
+description: "[STUB] Built-in skill — redirects to inlined alternative. See skill body for details."
+---
+
+# verification-before-completion — STUB / Redirect
+
+This skill is a **built-in superpower** of Claude Code and is not shipped as a standalone file
+in this repository.
+
+## Framework mapping
+
+| Framework | Availability |
+|-----------|-------------|
+| **Claude Code** | Built-in — available as `verification-before-completion` via the Claude Code CLI |
+| **opencode** | Not available as a separate skill. The equivalent verification steps are **inlined** in `dev-flow-execute/SKILL.md` (step 3) and documented in the shared reference `references/verification-block.md` |
+| **agy** | Treat the opencode path as authoritative — verification is entirely bash-driven (`task test:changed`, `task freshness:*`) and framework-agnostic. |
+
+## What this stub is for
+
+This stub exists so that skill-loading calls to `verification-before-completion` do not fail
+with a "skill not found" error. It contains no executable workflow — the real logic lives
+in the skills listed above.
+
+If you are running in **Claude Code**, invoke the built-in superpower directly.
+If you are running in **opencode** or **agy**, use the `verification-block.md` reference and
+the inlined steps in `dev-flow-execute/SKILL.md` instead.

--- a/.opencode/skills/opencode-flow-plan/SKILL.md
+++ b/.opencode/skills/opencode-flow-plan/SKILL.md
@@ -109,7 +109,7 @@ Delegiere das Plan-Schreiben an einen read-only Subagenten via `background-agent
 delegate(prompt: "<plan-writing task mit Spec + intel.json>", agent: "explore")
 ```
 
-Ergebnis mit `delegation_read(id)` abrufen. Falls `background-agents.ts` nicht verfügbar, schreibe den Plan inline.
+Ergebnis mit `delegation_read(id)` abrufen. Falls `background-agents.ts` nicht verfügbar (opencode oder agy ohne Plugin), schreibe den Plan inline.
 
 Der Subagent MUSS die Spec + `openspec/changes/<slug>/intel.json` als Kontext erhalten und die Plan-Qualitäts-Gates einhalten: S1-Budget pro Datei, `plan-lint.sh`-Konformität (F1/F2/STRUCT1-3/P1), drei verify-Commands im letzten Task.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,6 +157,10 @@ category: devflow                  # optional — existing field
    For a write-capable sub-agent: opencode's native write-capable delegation, selecting the
    agent by name. If `background-agents.ts` is unavailable, run the sub-step inline.
 
+### agy compatibility
+
+agy is **not explicitly covered** in most skill files. The rule of thumb: **treat the opencode path as authoritative**. All CLI tools (`gh`, `git`, `kubectl`, `task`, `bash scripts/`), MCP tool calls, and git workflows are framework-agnostic. The only gaps are framework-native subagent spawning (`delegate()`, `Agent`/`Task` tool) and Claude Code built-in superpowers — for those, execute the steps inline or manually. The 6 superpower stubs under `.claude/skills/superpowers-*/` and `.claude/skills/{test-driven-development,verification-before-completion,requesting-code-review}/` have framework mapping tables that include agy guidance.
+
 ### Current skill → agent map
 
 Only skills with an explicit `agent:` field in their SKILL.md frontmatter are dispatched as subagents. The rest are coordination skills loaded inline. As of 2026-06-22, exactly three skills declare an `agent:` field:


### PR DESCRIPTION
## Summary

Add **agy** (an agent-framework used by some team members) as a first-class citizen in the skill dispatch documentation, alongside existing Claude Code and opencode references.

## Changes

### New files (6 superpower stubs + TDD/code-review stubs)
- `.claude/skills/superpowers-brainstorming/SKILL.md`
- `.claude/skills/superpowers-writing-plans/SKILL.md`
- `.claude/skills/superpowers-executing-plans/SKILL.md`
- `.claude/skills/test-driven-development/SKILL.md`
- `.claude/skills/verification-before-completion/SKILL.md`
- `.claude/skills/requesting-code-review/SKILL.md`

### Existing files — agy awareness added
- `AGENTS.md` — added `### agy compatibility` section to Skill Dispatch Protocol
- `.claude/skills/references/subagent-provisioning.md` — added agy to framework-routing table
- `.claude/skills/references/gh-axi.md` — noted it is framework-agnostic
- `.opencode/skills/opencode-flow-plan/SKILL.md` — mentioned agy in delegate() fallback
- `.claude/skills/lavish/SKILL.md` — framework-agnostic note
- `.claude/skills/dev-flow-*/`, `incident-response`, `ticket-ops` — existing opencode compat fixes

### Excluded
- `website/src/data/openspec-status.json` — unrelated freshness noise

## Why

Recent work on opencode compat found that a third framework ("agy") was invisible in the skill docs. All three rely on the same bash/MCP tools, so agy can treat the opencode path as authoritative — the only gaps are framework-native subagent spawning and built-in superpowers, which are now documented with inline-fallback guidance.