### PR TITLE
chore(ci): vitest + e2e pr run only changed files [T001651]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,10 +182,14 @@ jobs:
       - run: npm run build --prefix brett
 
   vitest-website:
-    # Always runs on every PR (no path filter) so the branch-protection
+    # Always runs on every PR (no job-level path filter) so the branch-protection
     # required-check "Vitest (website)" reports on chore / config-only PRs too.
     # See mishap: Vitest (website) was required by main but no workflow
     # produced it, blocking auto-merge of chore PRs (e.g. #2094 admin-merged).
+    # Smart selection happens INSIDE the vitest run via `--changed`
+    # (mirrors local `task test:changed`): a chore PR runs zero tests in
+    # ~1s, a website-feature PR runs only the affected ones. The
+    # coverage gate below treats the no-changes case as a pass.
     name: Vitest (website)
     if: github.event.action != 'edited'
     runs-on: ubuntu-latest
@@ -214,15 +218,21 @@ jobs:
           cd website
           pnpm lint
 
-      - name: Run website unit tests (with coverage)
+      - name: Run website unit tests (with coverage, --changed)
+        # Mirrors the local `task test:changed` smart selection: only run
+        # the tests affected by files changed in this PR (vitest --changed).
+        # On a chore / config-only PR (no website/ source touched) the run
+        # exits 0 with zero tests, producing a coverage report with
+        # pct: "Unknown" — the gate step below treats that as a pass
+        # because there is no source delta to regress.
         # Default 5s per-test timeout is too tight for DB-heavy tests
         # (e.g. tickets/cockpit-db.test.ts seeds 1005 rows) when vitest
         # runs ~243 files in parallel on shared CI runners.
         # --coverage is on by default here so the suite runs once, not twice —
-        # it also feeds the coverage gate step below. [T001336]
+        # it also feeds the coverage gate step below. [T001336, T001651]
         run: |
           cd website
-          pnpm exec vitest run --coverage --testTimeout=30000
+          pnpm exec vitest run --changed --coverage --testTimeout=30000
 
       - name: Upload Vitest JUnit report
         # Runs even if the tests above failed, so a red PR still gets a
@@ -241,9 +251,22 @@ jobs:
         # Belt-and-braces second check against the coverage-summary.json
         # produced by the run above, so a misconfigured reporter cannot
         # silently bypass the gate. Does NOT re-run vitest. [T001336]
+        # Skip when --changed produced zero tests (pct: "Unknown"): there
+        # is no website source delta to regress on a chore / config-only
+        # PR. We still run vitest above (so the required check reports
+        # green and junit.xml is produced), we just don't penalise the
+        # 0% "no tests ran" coverage artifact. [T001651]
         run: |
           cd website
+          if [ ! -f coverage/coverage-summary.json ]; then
+            echo "::notice::No coverage-summary.json (--changed produced no report) — skipping gate"
+            exit 0
+          fi
           COV=$(jq -r '.total.lines.pct' coverage/coverage-summary.json)
+          if [ "$COV" = "Unknown" ] || [ "$COV" = "null" ] || [ -z "$COV" ]; then
+            echo "::notice::Coverage pct: ${COV:-empty} (--changed found no website/ changes) — skipping gate"
+            exit 0
+          fi
           echo "Total line coverage: ${COV}%"
           awk -v cov="$COV" 'BEGIN { if (cov + 0 < 60) { print "::error::Coverage gate failed: " cov "% < 60%"; exit 1 } else { print "::notice::Coverage gate passed: " cov "% >= 60%" } }'
 

--- a/.github/workflows/e2e-pr.yml
+++ b/.github/workflows/e2e-pr.yml
@@ -128,14 +128,48 @@ jobs:
           echo "grep_pattern=$GREP_PATTERN" >> "$GITHUB_OUTPUT"
           echo "feature_tag=$TAG"          >> "$GITHUB_OUTPUT"
 
+      - name: Detect changed E2E spec files
+        # Mirrors the local `task test:changed` smart selection: if a
+        # spec file under tests/e2e/specs/ was touched in this PR, add
+        # it to the run as a positional arg (in addition to the
+        # tag-grep filter above). Working dir is the repo root, so
+        # strip the `tests/e2e/` prefix to match Playwright's --config
+        # testDir (./specs). [T001651]
+        if: steps.filter.outputs.run_e2e == 'true'
+        id: specs
+        run: |
+          CHANGED=$(git diff --name-only origin/main...HEAD 2>/dev/null || echo "")
+          CHANGED_SPECS=$(echo "$CHANGED" \
+            | grep -E '^tests/e2e/specs/.*\.spec\.ts$' \
+            | sed 's|^tests/e2e/||' \
+            | paste -sd' ' - \
+            || true)
+          if [ -n "$CHANGED_SPECS" ]; then
+            echo "Changed spec files (will be added to the run):"
+            echo "$CHANGED_SPECS" | tr ' ' '\n' | sed 's/^/  /'
+          else
+            echo "No changed spec files"
+          fi
+          echo "changed_specs=$CHANGED_SPECS" >> "$GITHUB_OUTPUT"
+
       - name: E2E — ${{ steps.tag.outputs.feature_tag || 'smoke' }} + @smoke gegen web.mentolder.de
         if: steps.filter.outputs.run_e2e == 'true'
         id: playwright
         working-directory: tests/e2e
+        env:
+          CHANGED_SPECS: ${{ steps.specs.outputs.changed_specs }}
         run: |
-          npx playwright test \
-            --config playwright.pr.config.ts \
-            --grep "${{ steps.tag.outputs.grep_pattern }}"
+          if [ -n "${CHANGED_SPECS:-}" ]; then
+            echo "→ Running tag-grep + changed specs: $CHANGED_SPECS"
+            npx playwright test \
+              --config playwright.pr.config.ts \
+              --grep "${{ steps.tag.outputs.grep_pattern }}" \
+              $CHANGED_SPECS
+          else
+            npx playwright test \
+              --config playwright.pr.config.ts \
+              --grep "${{ steps.tag.outputs.grep_pattern }}"
+          fi
 
       - name: Upload Ergebnisse (Traces + JSON)
         if: always() && steps.filter.outputs.run_e2e == 'true'

--- a/openspec/specs/ci-cd.md
+++ b/openspec/specs/ci-cd.md
@@ -38,6 +38,79 @@ against `main` and SHALL block merge until all checks pass.
 
 ---
 
+### Requirement: PR-Gate — Vitest (website) mit `--changed` Smart-Selection
+
+The system SHALL run Vitest unit tests on every non-draft PR against `main` using
+`pnpm vitest run --changed --coverage` (mirrors the local `task test:changed` smart
+selection) and SHALL keep the `Vitest line coverage gate (>= 60% on src/lib)` as a
+required check that reports green on chore / config-only PRs even when no `website/`
+files were touched.
+
+The `vitest-website` job SHALL stay present and required on every PR (no job-level
+path filter) so branch protection's `Vitest (website)` check always reports — the
+smart selection happens inside the `pnpm vitest run` command, not at the workflow
+level.
+
+#### Scenario: Chore-PR ohne website-Änderungen besteht Vitest-Gate
+
+- **GIVEN** ein PR ändert nur `openspec/` und `AGENTS.md` (keine Datei unter `website/`)
+- **WHEN** der `vitest-website`-Job `pnpm exec vitest run --changed --coverage` ausführt
+- **THEN** beendet Vitest mit Exit-Code 0 (keine Tests, da keine `website/`-Diffs seit `origin/main`)
+- **THEN** schreibt `coverage/coverage-summary.json` mit `pct: "Unknown"` (kein Source-Coverage-Sample)
+- **THEN** der Coverage-Gate-Schritt erkennt `pct: "Unknown"`, gibt `::notice::Coverage pct: Unknown (--changed found no website/ changes) — skipping gate` aus und beendet sich mit Exit-Code 0
+
+#### Scenario: Website-Feature-PR läuft nur betroffene Tests
+
+- **GIVEN** ein PR ändert `website/src/lib/auth/magic-link.ts` und `website/src/lib/auth/magic-link.test.ts`
+- **WHEN** der `vitest-website`-Job `pnpm exec vitest run --changed --coverage` ausführt
+- **THEN** läuft nur `magic-link.test.ts` (und ggf. transitiv abhängige Tests), nicht die vollen ~243 Vitest-Dateien
+- **THEN** schreibt `coverage/coverage-summary.json` einen realen `pct`-Wert für `src/lib/auth/magic-link.ts`
+- **THEN** der Coverage-Gate-Schritt wertet diesen Wert aus und blockt den Merge bei `< 60 %`
+
+#### Scenario: Vitest-Befehl bleibt required Check auf jedem PR
+
+- **GIVEN** der `Vitest (website)`-Check ist als required Check in der Branch-Protection konfiguriert
+- **WHEN** ein chore-PR geöffnet wird, der keine `website/`-Dateien berührt
+- **THEN** läuft der `vitest-website`-Job trotzdem und reported grün — der Check ist nicht "skipped" / "missing"
+
+---
+
+### Requirement: PR-Gate — E2E PR mit Changed-Spec-Selection
+
+The system SHALL run Playwright E2E on a PR only when E2E-relevant files (`website/`,
+`tests/e2e/`, `.github/workflows/e2e-pr.yml`) changed, and WHEN running, SHALL also
+include any spec files changed in `tests/e2e/specs/*.spec.ts` as positional arguments
+to `npx playwright test` in addition to the tag-based grep filter.
+
+#### Scenario: Chore-PR ohne E2E-relevante Änderungen überspringt E2E
+
+- **GIVEN** ein PR ändert nur `openspec/` und `scripts/` (keine Datei unter `website/`, `tests/e2e/`, oder `.github/workflows/e2e-pr.yml`)
+- **WHEN** der `e2e-pr`-Job den `Check if E2E-relevant files changed`-Schritt ausführt
+- **THEN** setzt er `run_e2e=false` und alle nachfolgenden Schritte (Install, Playwright, Upload, Kommentar) werden mit `if: steps.filter.outputs.run_e2e == 'true'` übersprungen
+
+#### Scenario: Website-Feature-PR läuft Tag-gefilterte E2E-Suite
+
+- **GIVEN** ein PR mit Branch `feature/content-hub-foo` ändert `website/src/pages/coaching.astro` (keine Spec-Datei)
+- **WHEN** der `e2e-pr`-Job den `Leite Feature-Tag aus Branch-Name ab`-Schritt ausführt
+- **THEN** leitet er `TAG=content-hub` und `GREP_PATTERN=@content-hub|@smoke` ab
+- **THEN** ruft `npx playwright test --grep "@content-hub|@smoke"` auf (keine zusätzlichen positional args, da `CHANGED_SPECS` leer ist)
+
+#### Scenario: PR mit geänderter Spec-Datei läuft Tag-Grep + die geänderte Spec
+
+- **GIVEN** ein PR ändert `tests/e2e/specs/fa-30-cockpit.spec.ts` und `website/src/pages/cockpit.astro`
+- **WHEN** der `e2e-pr`-Job den `Detect changed E2E spec files`-Schritt ausführt
+- **THEN** setzt er `changed_specs=specs/fa-30-cockpit.spec.ts` (Prefix `tests/e2e/` gestrippt, damit es zum `testDir: ./specs` der Config passt)
+- **THEN** ruft der Playwright-Schritt `npx playwright test --grep "<tag-pattern>" specs/fa-30-cockpit.spec.ts` auf — die geänderte Spec läuft zusätzlich zur Tag-gefilterten Suite
+
+#### Scenario: PR mit nur Spec-Änderungen läuft die Spec + Smoke
+
+- **GIVEN** ein PR ändert nur `tests/e2e/specs/fa-12-mcp.spec.ts` (kein `website/`-Code)
+- **WHEN** der `e2e-pr`-Job den `Check if E2E-relevant files changed`-Schritt ausführt
+- **THEN** triggert der Match auf `tests/e2e/` und setzt `run_e2e=true`
+- **THEN** läuft Playwright mit dem Smoke-Grep (kein Feature-Tag ableitbar) + die geänderte Spec
+
+---
+
 ### Requirement: PR-Gate — Security Scan
 
 The system SHALL scan every PR for hardcoded passwords in `k3d/*.yaml`, unencrypted tracked


### PR DESCRIPTION
## Summary

Apply the `test:changed` smart-selection pattern (currently used for offline BATS tests via `task test:changed`) to the Vitest (website) and E2E PR CI jobs, mirroring the local development workflow.

## Changes

**ci.yml — `vitest-website` job**
- `pnpm vitest run --coverage` → `--changed --coverage`
- Coverage gate now skips with `::notice::` when `--changed` produced zero tests (`pct: "Unknown"` / missing summary): no source delta on a chore / config-only PR → no regression to measure.
- Job keeps no path filter so the required check `Vitest (website)` still reports on every PR (preserves the branch-protection contract from mishap #2094).

**e2e-pr.yml**
- New `Detect changed E2E spec files` step pulls any `tests/e2e/specs/*.spec.ts` touched in `origin/main...HEAD`, strips the `tests/e2e/` prefix to match the config's `testDir`, and passes the result as positional args to `npx playwright test` in addition to the existing tag-grep.
- Chore PR path is unchanged: the file-level filter at the top of the job still skips install/playwright when no `website/`/`tests/e2e/` files moved.

**openspec/specs/ci-cd.md**
- Two new Requirements + 7 Scenarios documenting the smart-selection contracts (chore-PR, website-PR, spec-only-PR paths).

## Verification

- `task test:changed` → 52/52 pass, 0 fail, LOC delta 0.00%
- `task freshness:check` → OK
- `bash scripts/openspec.sh validate` → OK
- `tests/spec/{openspec-workflow,openspec-embedding,ci-cd}.bats` → OK
- Manually tested both `vitest --changed` states (no-changes → `pct: "Unknown"`, gate skips; with-changes → real coverage, gate evaluates)

## Ticket

[T001651]