### PR TITLE
fix(website): coaching-studio Workspace crasht bei leerem CUSTOMERS-Array [T001656]

### DIFF
--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 557,
+      "file_count": 558,
       "files": [
         "tests/.gitignore",
         "tests/README.md",
@@ -52,6 +52,7 @@
         "tests/e2e/specs/brett-mobile.spec.ts",
         "tests/e2e/specs/brett-roles.spec.ts",
         "tests/e2e/specs/brett-share-link.spec.ts",
+        "tests/e2e/specs/coaching-studio-empty-customer.spec.ts",
         "tests/e2e/specs/dashboard-art.spec.ts",
         "tests/e2e/specs/dev-status-tabs.spec.ts",
         "tests/e2e/specs/fa-01-messaging.spec.ts",

--- a/openspec/changes/coaching-studio-empty-customer-fallback/.openspec.yaml
+++ b/openspec/changes/coaching-studio-empty-customer-fallback/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-08

--- a/openspec/changes/coaching-studio-empty-customer-fallback/specs/coaching-studio-empty-customer-fallback.md
+++ b/openspec/changes/coaching-studio-empty-customer-fallback/specs/coaching-studio-empty-customer-fallback.md
@@ -1,0 +1,18 @@
+## ADDED Requirements
+
+### Requirement: coaching-studio Workspace bleibt bei leerem CUSTOMERS-Array stabil
+
+Das statische coaching-studio-Prototyp (`website/public/coaching-studio/`) SHALL nicht
+abstürzen, wenn `CUSTOMERS` (in `data.jsx`) leer ist. Screens, die
+`customer || CUSTOMERS[0]` als Fallback nutzen, SHALL zusätzlich auf ein
+`EMPTY_CUSTOMER`-Platzhalterobjekt zurückfallen (`customer || CUSTOMERS[0] || EMPTY_CUSTOMER`),
+sodass `Workspace()`, `Kundenakte()`, `ProfileEditor()` und `CompareView()` immer ein
+definiertes Objekt mit allen von diesen Screens gelesenen Feldern erhalten
+(`name`, `initials`, `since`, `lang`, `category`, `aktiv`, `pausiert`, `fertig`, `sessions`).
+
+#### Scenario: Klick auf "Neue Session" bei leerer Kundenliste crasht nicht
+
+- **GIVEN** `CUSTOMERS` ist ein leeres Array (Standardzustand seit T001560)
+- **WHEN** im coaching-studio-Prototyp auf "Neue Session" (Dashboard oder TopBar) geklickt wird
+- **THEN** wird kein uncaught `pageerror` ausgelöst und die Workspace-Ansicht rendert
+  (`.ws`-Container / "Ebene 01"-Überschrift)

--- a/openspec/changes/coaching-studio-empty-customer-fallback/tasks.md
+++ b/openspec/changes/coaching-studio-empty-customer-fallback/tasks.md
@@ -1,0 +1,109 @@
+---
+title: "coaching-studio-empty-customer-fallback — fix Workspace crash when CUSTOMERS is empty"
+ticket_id: T001656
+domains: [website]
+status: plan_staged
+---
+
+# coaching-studio-empty-customer-fallback — Implementation Plan
+
+Fixes a crash in the static coaching-studio prototype (`website/public/coaching-studio/`):
+PR #2545 (T001560) emptied the hardcoded `CUSTOMERS` array in `data.jsx` but left several
+screens defaulting to `customer || CUSTOMERS[0]`, which now resolves to `undefined`. Clicking
+"Neue Session" (or loading the app fresh) then crashes with
+`Cannot read properties of undefined (reading 'name')` in `Workspace()`
+(`website/public/coaching-studio/workspace.jsx:174`).
+
+## File Structure
+
+Modified files (fix already applied to the working tree, verified against the earlier
+console error — this plan adds the missing test coverage and formalizes the change):
+- `website/public/coaching-studio/data.jsx` — adds `EMPTY_CUSTOMER` placeholder object,
+  exposed via `Object.assign(window, {...})`. `.jsx` extension: not covered by the S1
+  line-limit table (S1 applies to `.ts/.js/.jsx/.py/.svelte/.sh/.mjs/.mts/.astro/.tsx/.java/.php/.bash/.cjs`
+  — wait, `.jsx` IS listed); check baseline: `jq -r '."S1:website/public/coaching-studio/data.jsx".metric // "nicht-baselined"' docs/code-quality/baseline.json` →
+  `nicht-baselined` (file not in baseline, it's a static prototype asset outside the normal
+  `src/` tree). Net change: +7 lines. No S1 concern (small net add to an unbaselined file).
+- `website/public/coaching-studio/workspace.jsx` — `Workspace()`'s `cust` fallback:
+  `customer || CUSTOMERS[0]` → `customer || CUSTOMERS[0] || EMPTY_CUSTOMER`. Net: +1/-1 line.
+  `nicht-baselined` (same reasoning).
+- `website/public/coaching-studio/screens_core.jsx` — same fallback fix in `Kundenakte()` and
+  `ProfileEditor()`. Net: +2/-2 lines. `nicht-baselined`.
+- `website/public/coaching-studio/screens_more.jsx` — same fallback fix in `CompareView()`.
+  Net: +1/-1 line. `nicht-baselined`.
+
+New file:
+- `tests/e2e/specs/coaching-studio-empty-customer.spec.ts` — Playwright test that loads
+  `/coaching-studio/` and drives the crash path directly (no unit-test harness exists for
+  this directory: it's plain Babel-in-browser JSX with no bundler/module system, so Vitest
+  cannot import it — the only realistic verification is a real browser).
+
+## Reference patterns (read before implementing)
+
+- `website/public/coaching-studio/app.jsx` — the app shell; `TopBar`'s "Session" button and
+  `Dashboard`'s "Neue Session" button both call `onNav("workspace", CUSTOMERS[0])`, which is
+  how `customer=undefined` reaches `Workspace()` when `CUSTOMERS` is empty.
+- `website/public/coaching-studio/data.jsx` line ~107 — `const CUSTOMERS = [];` (the state
+  that triggers the bug; do not repopulate it — T001560 intentionally emptied it for privacy
+  reasons; the fix is a safe fallback, not reverting the emptying).
+- Existing Playwright specs under `tests/e2e/specs/` for the page-navigation + assertion
+  pattern this repo uses (e.g. any existing `*.spec.ts` that does `page.goto(...)` +
+  `page.click(...)` + asserts no console error) — follow the same structure/imports.
+
+## Task 1 — Failing E2E test reproducing the crash (RED)
+
+Create `tests/e2e/specs/coaching-studio-empty-customer.spec.ts`:
+- Navigate to the coaching-studio prototype page (check `website/src/pages/` or static
+  routing for how `/coaching-studio/` or `/public/coaching-studio/index.html` is served in
+  dev — confirm the actual served path before writing the test; it's under `website/public/`
+  so Astro serves it statically at `/coaching-studio/`).
+- Listen for `pageerror` / uncaught exceptions on the page (Playwright:
+  `page.on('pageerror', ...)`).
+- Click the "Neue Session" button (Dashboard) or the "Session" button (TopBar) — whichever is
+  reachable first on initial load.
+- Assert: no `pageerror` was emitted, and the workspace screen (`.ws` container or
+  `Ebene 01` heading) renders.
+
+Run this test against the CURRENT `main` state of `data.jsx`/`workspace.jsx` first (temporarily
+`git stash` the fix in this worktree, or check out the pre-fix blob) to confirm it fails —
+**expected: FAIL** (the crash reproduces: `pageerror` fires with
+"Cannot read properties of undefined"). Then restore the fix and re-run to confirm green.
+
+**Verify:** `npx playwright test tests/e2e/specs/coaching-studio-empty-customer.spec.ts` —
+FAILS against the pre-fix code, PASSES with the fix applied.
+
+## Task 2 — Confirm the fix (already applied) matches the plan
+
+The fix is already present in this worktree (`EMPTY_CUSTOMER` in `data.jsx` +
+`customer || CUSTOMERS[0] || EMPTY_CUSTOMER` in the four screen files listed above). Verify:
+- `EMPTY_CUSTOMER` has all fields the screens read: `name`, `initials`, `since`, `lang`,
+  `category`, `aktiv`, `pausiert`, `fertig`, `sessions` (array, since `Kundenakte` reads
+  `k.sessions.length` and `k.sessions.map(...)`).
+- All four fallback sites (`workspace.jsx`, `screens_core.jsx` ×2, `screens_more.jsx`) use the
+  identical `customer || CUSTOMERS[0] || EMPTY_CUSTOMER` expression.
+
+No code changes expected in this task if the existing diff already satisfies both — just
+confirm via `grep -n "EMPTY_CUSTOMER" website/public/coaching-studio/*.jsx`.
+
+**Verify:** `grep -c EMPTY_CUSTOMER website/public/coaching-studio/data.jsx` → `2` (definition +
+window export); `grep -c "CUSTOMERS\[0\] || EMPTY_CUSTOMER" website/public/coaching-studio/workspace.jsx website/public/coaching-studio/screens_core.jsx website/public/coaching-studio/screens_more.jsx` → `1`, `2`, `1` respectively.
+
+## Task 3 — Test inventory + final verification (mandatory gates)
+
+1. Regenerate the test inventory (a new E2E spec was added):
+   ```bash
+   task test:inventory
+   ```
+   Commit the updated `website/src/data/test-inventory.json`.
+2. Run the three mandatory verify commands:
+   ```bash
+   task test:changed
+   task freshness:regenerate
+   task freshness:check
+   ```
+3. Run the new E2E spec explicitly to confirm it's green against the fixed code:
+   ```bash
+   npx playwright test tests/e2e/specs/coaching-studio-empty-customer.spec.ts
+   ```
+
+**Verify:** all three `task` commands exit 0; the new Playwright spec passes.

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -93,6 +93,7 @@ export default defineConfig({
         '**/fa-50-*.spec.ts',                        // request correlation / X-Request-ID (T000964)
         '**/fa-51-*.spec.ts',                        // sidekick navigation + grilling/mediaviewer views (T000965)
         '**/a11y-axe.spec.ts',                       // axe-core a11y-Scan der Kern-Routen (G-FE01, T001206)
+        '**/coaching-studio-empty-customer.spec.ts', // coaching-studio Workspace-Crash bei leerem CUSTOMERS (T001656)
       ],
       use: {
         ...devices['Desktop Chrome'],

--- a/tests/e2e/specs/coaching-studio-empty-customer.spec.ts
+++ b/tests/e2e/specs/coaching-studio-empty-customer.spec.ts
@@ -1,0 +1,71 @@
+import { test, expect } from '@playwright/test';
+
+const BASE       = process.env.WEBSITE_URL    ?? 'https://web.mentolder.de';
+const ADMIN_USER = process.env.E2E_ADMIN_USER ?? 'paddione';
+const ADMIN_PASS = process.env.E2E_ADMIN_PASS;
+
+/**
+ * T001656: coaching-studio Workspace crashes on "Neue Session" when CUSTOMERS
+ * is empty.
+ *
+ * PR #2545 (T001560) emptied the hardcoded `CUSTOMERS` array in
+ * `website/public/coaching-studio/data.jsx` (privacy — no more seeded fake
+ * clients). Several screens still defaulted to `customer || CUSTOMERS[0]`,
+ * which now resolves to `undefined` and crashes `Workspace()` with
+ * "Cannot read properties of undefined (reading 'name')" as soon as
+ * "Neue Session" is clicked from an empty client list.
+ *
+ * The fix adds an `EMPTY_CUSTOMER` placeholder object in `data.jsx` and uses
+ * it as a final fallback (`customer || CUSTOMERS[0] || EMPTY_CUSTOMER`) in
+ * `workspace.jsx`, `screens_core.jsx` (×2) and `screens_more.jsx`.
+ *
+ * The prototype is a plain Babel-in-browser JSX bundle with no
+ * bundler/module system (loaded via `<script type="text/babel">` in
+ * `website/src/pages/admin/coaching/studio.astro`), so there is no unit-test
+ * harness that can import it — a real browser is the only realistic way to
+ * verify the fix.
+ */
+
+async function loginAsAdmin(page: import('@playwright/test').Page, returnTo = '/admin/coaching/studio'): Promise<void> {
+  if (!ADMIN_PASS) throw new Error('E2E_ADMIN_PASS is not set');
+  await page.goto(`${BASE}/api/auth/login?returnTo=${encodeURIComponent(returnTo)}`);
+  await page.waitForURL(/realms\/workspace/, { timeout: 30_000 });
+  await page.locator('#username, input[name="username"]').first().fill(ADMIN_USER);
+  await page.locator('#password, input[name="password"]').first().fill(ADMIN_PASS);
+  await page.locator('#kc-login, input[type="submit"]').first().click();
+  await page.waitForURL(url => url.toString().startsWith(BASE), { timeout: 60_000 });
+}
+
+test.describe('T001656: coaching-studio empty-customer fallback', () => {
+  test('T1: /admin/coaching/studio requires authentication', async ({ page }) => {
+    await page.goto(`${BASE}/admin/coaching/studio`);
+    await expect(page).not.toHaveURL(`${BASE}/admin/coaching/studio`);
+  });
+
+  test.describe('authenticated', () => {
+    test.skip(!ADMIN_PASS, 'E2E_ADMIN_PASS not set — skipping authenticated coaching-studio checks');
+
+    test('T2: "Neue Session" does not crash the Workspace when CUSTOMERS is empty', async ({ page }) => {
+      const pageErrors: Error[] = [];
+      page.on('pageerror', err => pageErrors.push(err));
+
+      await loginAsAdmin(page, '/admin/coaching/studio');
+      await page.waitForURL(/\/admin\/coaching\/studio$/, { timeout: 20_000 });
+
+      // TopBar "Session" button (always visible) and Dashboard "Neue Session"
+      // button both call onNav("workspace", CUSTOMERS[0]) — with CUSTOMERS
+      // empty, customer arrives as undefined and used to crash Workspace().
+      const neueSession = page.getByRole('button', { name: /Neue Session/i }).first();
+      await neueSession.waitFor({ state: 'visible', timeout: 15_000 });
+      await neueSession.click();
+
+      // Workspace screen renders — "Ebene 01" heading / .ws container.
+      await expect(page.locator('.ws, text=Ebene 01').first()).toBeVisible({ timeout: 10_000 });
+
+      expect(
+        pageErrors.map(e => e.message),
+        'no uncaught page error should fire when opening a session with an empty client list',
+      ).toEqual([]);
+    });
+  });
+});

--- a/website/public/coaching-studio/data.jsx
+++ b/website/public/coaching-studio/data.jsx
@@ -107,6 +107,13 @@ function mkSessions(){
 const CUSTOMERS = [];
 CUSTOMERS.forEach(k=> k.sessions = mkSessions());
 
+// Fallback, solange keine echten Klient:innen angelegt sind — verhindert
+// Abstürze in Screens, die `customer || CUSTOMERS[0]` als Default nutzen.
+const EMPTY_CUSTOMER = {
+  id: null, name: "—", initials: "–", since: "—", lang: "—", category: "—",
+  aktiv: 0, pausiert: 0, fertig: 0, sessions: [],
+};
+
 // ---------------------------------------------------------------------
 // ÜBERSETZUNGEN — DE-Original parallel zur Zielsprache (Platzhalter)
 // ---------------------------------------------------------------------
@@ -120,4 +127,4 @@ const TARGET_LANGS = [
 ];
 
 // expose
-Object.assign(window, { Icon, BrandMark, lorem, LOREM, LEVELS, PROFILE_FIELDS, CUSTOMERS, SOURCE_DE, TARGET_LANGS });
+Object.assign(window, { Icon, BrandMark, lorem, LOREM, LEVELS, PROFILE_FIELDS, CUSTOMERS, EMPTY_CUSTOMER, SOURCE_DE, TARGET_LANGS });

--- a/website/public/coaching-studio/screens_core.jsx
+++ b/website/public/coaching-studio/screens_core.jsx
@@ -66,7 +66,7 @@ function Dashboard({ onNav }){
 // =====================================================================
 const STATUS_LABEL = { aktiv:"Aktiv", pausiert:"Pausiert", fertig:"Abgeschlossen" };
 function Kundenakte({ customer, onNav }){
-  const k = customer || CUSTOMERS[0];
+  const k = customer || CUSTOMERS[0] || EMPTY_CUSTOMER;
   const activeProfile = PROFILE_FIELDS.filter(f=> f.active);
 
   return (
@@ -154,7 +154,7 @@ function Kundenakte({ customer, onNav }){
 // 3 · KI-PROFIL-EDITOR
 // =====================================================================
 function ProfileEditor({ customer, onNav }){
-  const k = customer || CUSTOMERS[0];
+  const k = customer || CUSTOMERS[0] || EMPTY_CUSTOMER;
   const [fields, setFields] = useState(()=> PROFILE_FIELDS.map(f=> ({...f})));
   const toggle = (i)=> setFields(fs=> fs.map((f,j)=> j===i ? {...f, active:!f.active} : f));
   const edit = (i,v)=> setFields(fs=> fs.map((f,j)=> j===i ? {...f, value:v} : f));

--- a/website/public/coaching-studio/screens_more.jsx
+++ b/website/public/coaching-studio/screens_more.jsx
@@ -5,7 +5,7 @@
 // 5 · VERGLEICHSANSICHT — Split (Vorlage links · neue Session rechts)
 // =====================================================================
 function CompareView({ customer, onNav }){
-  const k = customer || CUSTOMERS[0];
+  const k = customer || CUSTOMERS[0] || EMPTY_CUSTOMER;
   const diffs = { 2:true, 5:true, 8:true, 9:true };
   return (
     <div className="screen"><div className="wrap">

--- a/website/public/coaching-studio/workspace.jsx
+++ b/website/public/coaching-studio/workspace.jsx
@@ -91,7 +91,7 @@ function TranslationPanel(){
 }
 
 function Workspace({ customer, onNav }){
-  const cust = customer || CUSTOMERS[0];
+  const cust = customer || CUSTOMERS[0] || EMPTY_CUSTOMER;
   const [active, setActive] = useState(0);
   const [prompts, setPrompts] = useState(()=> LEVELS.map(l=> l.prompt));
   const [done, setDone] = useState(()=> LEVELS.map(()=> false));

--- a/website/src/data/test-inventory.json
+++ b/website/src/data/test-inventory.json
@@ -78,6 +78,12 @@
     "kind": "playwright"
   },
   {
+    "id": "E2E:coaching-studio-empty-customer",
+    "file": "tests/e2e/specs/coaching-studio-empty-customer.spec.ts",
+    "category": "E2E",
+    "kind": "playwright"
+  },
+  {
     "id": "E2E:dashboard-art",
     "file": "tests/e2e/specs/dashboard-art.spec.ts",
     "category": "E2E",


### PR DESCRIPTION
## Summary

Fixes a crash in the static coaching-studio prototype (`website/public/coaching-studio/`):
PR #2545 (T001560) emptied the hardcoded `CUSTOMERS` array in `data.jsx` (privacy — no more
seeded fake clients), but several screens still fell back to `customer || CUSTOMERS[0]`,
which then resolves to `undefined`. Clicking "Neue Session" crashes `Workspace()` with
`Cannot read properties of undefined (reading 'name')`.

- `data.jsx` — adds an `EMPTY_CUSTOMER` placeholder object (all fields the screens read:
  `name`, `initials`, `since`, `lang`, `category`, `aktiv`, `pausiert`, `fertig`, `sessions`).
- `workspace.jsx`, `screens_core.jsx` (`Kundenakte`, `ProfileEditor`), `screens_more.jsx`
  (`CompareView`) — fallback chain extended to `customer || CUSTOMERS[0] || EMPTY_CUSTOMER`.

Closes T001656

## Test plan

- [x] New Playwright spec `tests/e2e/specs/coaching-studio-empty-customer.spec.ts`, wired
      into the `website` project in `tests/e2e/playwright.config.ts`. T1 asserts
      `/admin/coaching/studio` requires authentication; T2 (behind `E2E_ADMIN_PASS`, follows
      the existing `fa-54-coaching-sessions.spec.ts` `loginAsAdmin` pattern) drives the
      "Neue Session" click and asserts no `pageerror` fires and the Workspace screen renders.
- [x] `task test:inventory` regenerated and committed.
- [x] `task test:changed`, `task freshness:regenerate`, `task freshness:check` all green.
- [x] Added an OpenSpec delta (`openspec/changes/coaching-studio-empty-customer-fallback/specs/`)
      — required by `test:openspec`; no existing SSOT spec covered the coaching-studio
      prototype, so this is a new standalone delta.

**Known gap:** the new Playwright spec was not executed live end-to-end in this sandbox.
`tests/e2e/playwright.config.ts`'s `globalSetup`/`globalTeardown` require `CRON_SECRET`
(prod DB purge bracketing) and T2 requires a real Keycloak login (`E2E_ADMIN_PASS`) — neither
is available in this isolated worktree (no reachable cluster, no local Postgres/Keycloak
stack, no docker). The spec does compile and is correctly discovered by
`playwright test --list --project=website`. Recommend a live run via `dev-flow-e2e` against
fleet post-merge. The manual fix itself was verified by re-deriving the exact crash path from
`app.jsx`'s `onNav("workspace", CUSTOMERS[0])` call and confirming `EMPTY_CUSTOMER` covers
every field the four fallback sites read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011TjK7eZ3HW7exTx94SP9p9