### PR TITLE
chore(mcp): sync project-level MCP servers into opencode.jsonc [T001661]

### DIFF
--- a/.opencode/opencode.jsonc
+++ b/.opencode/opencode.jsonc
@@ -27,6 +27,31 @@
         "/home/patrick/.local/bin/codebase-memory-mcp"
       ],
       "enabled": true
+    },
+    "mcp-task-runner": {
+      "type": "local",
+      "command": [
+        "mcp-task-runner",
+        "--otel-endpoint", "localhost:4317",
+        "--taskfile", "/home/patrick/Bachelorprojekt/Taskfile.yml"
+      ],
+      "enabled": true
+    },
+    "ticket-mcp": {
+      "type": "local",
+      "command": [
+        "/home/patrick/Bachelorprojekt/scripts/ticket-mcp/ticket-mcp-go"
+      ],
+      "enabled": true
+    },
+    "task-master-ai": {
+      "type": "local",
+      "command": ["npx", "-y", "task-master-ai"],
+      "environment": {
+        "OLLAMA_BASE_URL": "http://localhost:11434/api",
+        "TASK_MASTER_TOOLS": "all"
+      },
+      "enabled": true
     }
   }
 }


### PR DESCRIPTION
## Summary
- Registriert die drei in `.mcp.json` (Claude Code) vorhandenen, aber in `.opencode/opencode.jsonc` fehlenden Projekt-Level-MCP-Server für opencode: `mcp-task-runner`, `ticket-mcp`, `task-master-ai`
- Bringt die opencode-Config in Deckung mit der in CLAUDE.md dokumentierten Server-Liste

## Verification
- `opencode mcp list` im Worktree: alle **7** Server `connected`
- `task test:all` grün (52 pass), `task freshness:check` grün

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011TjK7eZ3HW7exTx94SP9p9