### PR TITLE
fix(coaching): sessions-audit rest — 404-Semantik, Fehler-Logging, Config-Hygiene [T001670]

### DIFF
--- a/docs/code-quality/loc-budget.json
+++ b/docs/code-quality/loc-budget.json
@@ -1,8 +1,8 @@
 {
-  "total_lines": 538301,
+  "total_lines": 538397,
   "file_count": 4110,
-  "commit": "be4808ee",
-  "measured_at": "2026-07-08T18:25:19.883Z",
+  "commit": "96148b956",
+  "measured_at": "2026-07-08T18:35:57.716Z",
   "thresholds": {
     "warn_pct": 5,
     "fail_pct": 15,

--- a/environments/schema.yaml
+++ b/environments/schema.yaml
@@ -38,6 +38,37 @@ env_vars:
     required: false
     default_dev: "true"
 
+  # Runtime-Env-Vars der Website rund um Coaching-Sessions (T001672). Alle optional
+  # mit Code-Fallbacks — hier dokumentiert, damit sie auffindbar/konfigurierbar sind.
+  # COACHING_SESSION_MODEL: Claude-Modell für den Abschlussbericht (complete.ts);
+  #   Fallback DEFAULT_CLAUDE_SESSION_MODEL in lib/claude-session-agent.ts.
+  - name: COACHING_SESSION_MODEL
+    required: false
+    default_dev: ""
+
+  # LLM_GATEWAY_URL: OpenAI-kompatibler Gateway-Endpoint für den Provider 'anthropic'
+  # in lib/openai-compatible-session-agent.ts; Fallback ist der Cluster-DNS
+  # llm-gateway-lmstudio.workspace.svc.cluster.local:1234/v1.
+  - name: LLM_GATEWAY_URL
+    required: false
+    default_dev: ""
+
+  # SESSION_HUB_REGISTRY: Pfad zur active-sessions.json des Session-Hubs
+  # (api/admin/sessions). SESSION_HUB_REGISTRY_WRITABLE: nur wenn "true", erlauben
+  # POST/DELETE das Registrieren/Deregistrieren (sonst 501 — bewusstes Gating).
+  # SESSIONS_ARCHIVE_DIR: Ablage archivierter Session-Formulare (history/[id]).
+  - name: SESSION_HUB_REGISTRY
+    required: false
+    default_dev: ""
+
+  - name: SESSION_HUB_REGISTRY_WRITABLE
+    required: false
+    default_dev: ""
+
+  - name: SESSIONS_ARCHIVE_DIR
+    required: false
+    default_dev: ""
+
   - name: CONTACT_CITY
     required: true
     default_dev: "DevCity"

--- a/tests/spec/coaching-sessions-polish-guide.bats
+++ b/tests/spec/coaching-sessions-polish-guide.bats
@@ -96,3 +96,21 @@ setup() {
   run grep -qF "Kein KI-Provider konfiguriert" "$WEB/pages/api/admin/coaching/sessions/[id]/steps/[n]/generate.ts"
   [ "$status" -eq 0 ]
 }
+
+@test "T001670 archive/unarchive endpoints return 404 for unknown session ids" {
+  run grep -qF "Session nicht gefunden" "$WEB/pages/api/admin/coaching/sessions/[id]/archive.ts"
+  [ "$status" -eq 0 ]
+  run grep -qF "Session nicht gefunden" "$WEB/pages/api/admin/coaching/sessions/[id]/unarchive.ts"
+  [ "$status" -eq 0 ]
+}
+
+@test "T001672 anthropic gateway endpoint is env-overridable and documented" {
+  run grep -qF "LLM_GATEWAY_URL" "$WEB/lib/openai-compatible-session-agent.ts"
+  [ "$status" -eq 0 ]
+  run grep -qF "LLM_GATEWAY_URL" "$REPO_ROOT/environments/schema.yaml"
+  [ "$status" -eq 0 ]
+  run grep -qF "COACHING_SESSION_MODEL" "$REPO_ROOT/environments/schema.yaml"
+  [ "$status" -eq 0 ]
+  run grep -qF "SESSION_HUB_REGISTRY_WRITABLE" "$REPO_ROOT/environments/schema.yaml"
+  [ "$status" -eq 0 ]
+}

--- a/website/src/lib/claude-session-agent.ts
+++ b/website/src/lib/claude-session-agent.ts
@@ -10,6 +10,10 @@ import {
 
 const MAX_TOOL_ROUNDS = 3;
 
+// Letzter Fallback, wenn weder kiConfig.modelName noch COACHING_SESSION_MODEL gesetzt sind.
+// Eine Stelle statt drei (T001672) — auch von complete.ts konsumiert.
+export const DEFAULT_CLAUDE_SESSION_MODEL = 'claude-haiku-4-5-20251001';
+
 export class ClaudeSessionAgent implements SessionAgent {
   private buildClient(kiConfig: GenerateOptions['kiConfig']): Anthropic {
     const apiKey = kiConfig.apiKey ?? process.env.ANTHROPIC_API_KEY;
@@ -42,7 +46,7 @@ export class ClaudeSessionAgent implements SessionAgent {
   async generate(options: GenerateOptions): Promise<GenerateResult> {
     const { kiConfig, history, effectiveSystemPrompt, assembledUserPrompt, sessionId } = options;
     const client = this.buildClient(kiConfig);
-    const model = kiConfig.modelName ?? 'claude-haiku-4-5-20251001';
+    const model = kiConfig.modelName ?? DEFAULT_CLAUDE_SESSION_MODEL;
     const startMs = Date.now();
 
     const messages: MessageParam[] = [
@@ -93,7 +97,7 @@ export class ClaudeSessionAgent implements SessionAgent {
   async *stream(options: GenerateOptions): AsyncIterable<string> {
     const { kiConfig, history, effectiveSystemPrompt, assembledUserPrompt } = options;
     const client = this.buildClient(kiConfig);
-    const model = kiConfig.modelName ?? 'claude-haiku-4-5-20251001';
+    const model = kiConfig.modelName ?? DEFAULT_CLAUDE_SESSION_MODEL;
 
     const messages: MessageParam[] = [
       ...history.map(t => ({ role: t.role, content: t.content } as MessageParam)),

--- a/website/src/lib/coaching-session-db.test.ts
+++ b/website/src/lib/coaching-session-db.test.ts
@@ -185,12 +185,21 @@ describe('archiveSession / unarchiveSession', () => {
     const s = await createSession(pool, {
       brand: 'mentolder', title: 'T', mode: 'live', createdBy: 'coach',
     });
-    await archiveSession(pool, s.id, 'coach');
+    expect(await archiveSession(pool, s.id, 'coach')).toBe(true);
     const fetched = await getSession(pool, s.id);
     expect(fetched?.archivedAt).not.toBeNull();
-    await unarchiveSession(pool, s.id, 'coach');
+    expect(await unarchiveSession(pool, s.id, 'coach')).toBe(true);
     const fetched2 = await getSession(pool, s.id);
     expect(fetched2?.archivedAt).toBeNull();
+  });
+
+  it('returns false for a non-existent session id (T001670)', async () => {
+    const ghost = '00000000-0000-4000-8000-000000000000';
+    expect(await archiveSession(pool, ghost, 'coach')).toBe(false);
+    expect(await unarchiveSession(pool, ghost, 'coach')).toBe(false);
+    // kein Audit-Log-Eintrag für die Geister-ID
+    const log = await getAuditLog(pool, ghost);
+    expect(log).toEqual([]);
   });
 });
 

--- a/website/src/lib/coaching-session-db.ts
+++ b/website/src/lib/coaching-session-db.ts
@@ -401,20 +401,25 @@ export async function updateSessionFields(
   }
 }
 
-export async function archiveSession(pool: Pool, id: string, actor: string): Promise<void> {
+export async function archiveSession(pool: Pool, id: string, actor: string): Promise<boolean> {
   const client = await pool.connect();
   try {
     await client.query('BEGIN');
-    await client.query(
+    const updated = await client.query(
       `UPDATE coaching.sessions SET archived_at = now() WHERE id = $1`,
       [id],
     );
+    if (updated.rowCount === 0) {
+      await client.query('ROLLBACK');
+      return false;
+    }
     await client.query(
       `INSERT INTO coaching.session_audit_log (session_id, event_type, actor, step_number, payload)
        VALUES ($1, $2, $3, $4, $5)`,
       [id, 'status_change', actor, null, JSON.stringify({ action: 'archived' })],
     );
     await client.query('COMMIT');
+    return true;
   } catch (e) {
     await client.query('ROLLBACK');
     throw e;
@@ -423,20 +428,25 @@ export async function archiveSession(pool: Pool, id: string, actor: string): Pro
   }
 }
 
-export async function unarchiveSession(pool: Pool, id: string, actor: string): Promise<void> {
+export async function unarchiveSession(pool: Pool, id: string, actor: string): Promise<boolean> {
   const client = await pool.connect();
   try {
     await client.query('BEGIN');
-    await client.query(
+    const updated = await client.query(
       `UPDATE coaching.sessions SET archived_at = null WHERE id = $1`,
       [id],
     );
+    if (updated.rowCount === 0) {
+      await client.query('ROLLBACK');
+      return false;
+    }
     await client.query(
       `INSERT INTO coaching.session_audit_log (session_id, event_type, actor, step_number, payload)
        VALUES ($1, $2, $3, $4, $5)`,
       [id, 'status_change', actor, null, JSON.stringify({ action: 'unarchived' })],
     );
     await client.query('COMMIT');
+    return true;
   } catch (e) {
     await client.query('ROLLBACK');
     throw e;

--- a/website/src/lib/openai-compatible-session-agent.ts
+++ b/website/src/lib/openai-compatible-session-agent.ts
@@ -7,7 +7,7 @@ export function resolveEndpoint(kiConfig: KiConfig): string {
   const gpuBase = process.env.LLM_HOST_IP?.trim() || 'localhost';
   const defaults: Record<string, string> = {
     'deepseek': 'https://api.deepseek.com/v1',
-    'anthropic': 'http://llm-gateway-lmstudio.workspace.svc.cluster.local:1234/v1',
+    'anthropic': process.env.LLM_GATEWAY_URL ?? 'http://llm-gateway-lmstudio.workspace.svc.cluster.local:1234/v1',
     'local-cluster': process.env.LLM_ROUTER_URL ?? `http://${gpuBase}:1234/v1`,
     'local-lmstudio': `http://${gpuBase}:1234/v1`,
     'local-ollama': `http://${gpuBase}:1234/v1`,

--- a/website/src/lib/sessions/templates.test.ts
+++ b/website/src/lib/sessions/templates.test.ts
@@ -3,7 +3,11 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 vi.mock('../website-db', () => ({
   pool: { query: vi.fn(), end: vi.fn() },
 }));
+vi.mock('../logger', () => ({
+  logger: { error: vi.fn() },
+}));
 import { pool } from '../website-db';
+import { logger } from '../logger';
 import { DEFAULT_TEMPLATES, listTemplates, cloneTemplate, deleteTemplate } from './templates';
 
 describe('DEFAULT_TEMPLATES', () => {
@@ -32,6 +36,12 @@ describe('listTemplates — DB fallback', () => {
     const result = await listTemplates('user-123');
     expect(result).toHaveLength(5);
     expect(result[0].is_default).toBe(true);
+  });
+
+  it('logs the DB error instead of swallowing it silently (T001671)', async () => {
+    vi.mocked(pool.query).mockRejectedValue(new Error('connection refused'));
+    await listTemplates('user-123');
+    expect(logger.error).toHaveBeenCalledOnce();
   });
 
   it('returns DB rows when query succeeds', async () => {

--- a/website/src/lib/sessions/templates.ts
+++ b/website/src/lib/sessions/templates.ts
@@ -2,6 +2,7 @@
 // CRUD logic for brainstorm session templates with hardcoded fallback.
 
 import { pool } from '../website-db';
+import { logger } from '../logger';
 
 export interface SessionTemplate {
   id: string;
@@ -47,7 +48,9 @@ export async function listTemplates(ownerId: string): Promise<SessionTemplate[]>
       [ownerId]
     );
     return rows as SessionTemplate[];
-  } catch {
+  } catch (err) {
+    // Fallback bleibt (Templates sind nicht kritisch), aber der DB-Ausfall muss sichtbar sein
+    logger.error({ err }, '[sessions/templates] listTemplates DB query failed — serving DEFAULT_TEMPLATES');
     return DEFAULT_TEMPLATES;
   }
 }

--- a/website/src/pages/api/admin/coaching/sessions/[id]/archive.ts
+++ b/website/src/pages/api/admin/coaching/sessions/[id]/archive.ts
@@ -8,6 +8,7 @@ export const prerender = false;
 export const POST: APIRoute = async ({ request, params }) => {
   const session = await getSession(request.headers.get('cookie'));
   if (!session || !isAdmin(session)) return new Response('Unauthorized', { status: 401 });
-  await archiveSession(pool, params.id as string, session.preferred_username);
+  const archived = await archiveSession(pool, params.id as string, session.preferred_username);
+  if (!archived) return new Response(JSON.stringify({ error: 'Session nicht gefunden' }), { status: 404, headers: { 'content-type': 'application/json' } });
   return new Response(JSON.stringify({ ok: true }), { headers: { 'content-type': 'application/json' } });
 };

--- a/website/src/pages/api/admin/coaching/sessions/[id]/complete.ts
+++ b/website/src/pages/api/admin/coaching/sessions/[id]/complete.ts
@@ -2,6 +2,7 @@ import type { APIRoute } from 'astro';
 import Anthropic from '@anthropic-ai/sdk';
 import { getSession, isAdmin } from '../../../../../../lib/auth';
 import { getSession as getCoachingSession, completeSession } from '../../../../../../lib/coaching-session-db';
+import { DEFAULT_CLAUDE_SESSION_MODEL } from '../../../../../../lib/claude-session-agent';
 import { pool } from '../../../../../../lib/website-db';
 
 export const prerender = false;
@@ -16,7 +17,8 @@ export const POST: APIRoute = async ({ request, params , locals }) => {
     return new Response(JSON.stringify({ error: 'Not found' }), { status: 404, headers: { 'content-type': 'application/json' } });
   }
 
-  // If the ClaudeSessionAgent already wrote the report via draft_session_report tool, reuse it
+  // Step 0 aiResponse wird nur von completeSession selbst geschrieben — dieser Branch greift
+  // also nur bei einem wiederholten Complete-Aufruf und macht ihn idempotent (kein zweiter LLM-Call).
   const existingReport = coachingSession.steps.find(s => s.stepNumber === 0 && s.aiResponse);
   if (existingReport?.aiResponse) {
     await completeSession(pool, sessionId, existingReport.aiResponse);
@@ -36,7 +38,7 @@ export const POST: APIRoute = async ({ request, params , locals }) => {
     try {
       const client = new Anthropic({ apiKey });
       const msg = await client.messages.create({
-        model: process.env.COACHING_SESSION_MODEL || 'claude-haiku-4-5-20251001',
+        model: process.env.COACHING_SESSION_MODEL || DEFAULT_CLAUDE_SESSION_MODEL,
         max_tokens: 1200,
         system: `Du bist ein Coaching-Protokollant. Erstelle aus den 10 Schritten einer Coaching-Session eine strukturierte Zusammenfassung auf Deutsch.
 Abschnitte: ## Ausgangslage, ## Analyse, ## Lösungsansatz, ## Vereinbarte Schritte, ## Bewertung.

--- a/website/src/pages/api/admin/coaching/sessions/[id]/unarchive.ts
+++ b/website/src/pages/api/admin/coaching/sessions/[id]/unarchive.ts
@@ -8,6 +8,7 @@ export const prerender = false;
 export const POST: APIRoute = async ({ request, params }) => {
   const session = await getSession(request.headers.get('cookie'));
   if (!session || !isAdmin(session)) return new Response('Unauthorized', { status: 401 });
-  await unarchiveSession(pool, params.id as string, session.preferred_username);
+  const unarchived = await unarchiveSession(pool, params.id as string, session.preferred_username);
+  if (!unarchived) return new Response(JSON.stringify({ error: 'Session nicht gefunden' }), { status: 404, headers: { 'content-type': 'application/json' } });
   return new Response(JSON.stringify({ ok: true }), { headers: { 'content-type': 'application/json' } });
 };


### PR DESCRIPTION
## Summary
Räumt die verbliebenen Low-Priority-Funde aus dem Sessions-Tool-Audit ab (T001670, T001671, T001672):

- **T001670 — korrekte 404-Semantik:** `archiveSession`/`unarchiveSession` prüfen jetzt `rowCount` und rollbacken ohne Audit-Log-Zeile, wenn die Session nicht existiert; die Endpoints `/archive` und `/unarchive` antworten mit 404 statt `200 {ok:true}` — konsistent zu `status.ts`/`index.ts`.
- **T001671 — kein stilles Schlucken mehr:** `lib/sessions/templates.ts` loggt DB-Fehler über den geteilten pino-Logger (Fallback auf `DEFAULT_TEMPLATES` bleibt, ist aber jetzt diagnostizierbar).
- **T001672 — Config-Hygiene:** `LLM_GATEWAY_URL` als Env-Override für den bisher hart gepinnten `anthropic`-Gateway-Endpoint; `COACHING_SESSION_MODEL`, `SESSION_HUB_REGISTRY`, `SESSION_HUB_REGISTRY_WRITABLE`, `SESSIONS_ARCHIVE_DIR` in `environments/schema.yaml` dokumentiert; das dreifach duplizierte `claude-haiku-4-5-20251001` als geteilte Konstante `DEFAULT_CLAUDE_SESSION_MODEL`; irreführender Idempotenz-Kommentar in `complete.ts` korrigiert.

## Test Plan
- [x] 2 neue Vitest-Fälle (pg-mem: false + kein Audit-Log für Geister-ID; Logger-Spy für templates)
- [x] 2 neue BATS-Assertions in `coaching-sessions-polish-guide.bats`
- [x] Volle Website-Suite 2702 Tests grün; `pnpm lint` + `astro check` 0 Fehler; `task env:validate` OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017L1RiPVKDnwhinMsm6L8CH