### PR TITLE
fix(infra): $$-Collapse auch fuer rohe shared-db.yaml-Applies [T001673]

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -2552,7 +2552,11 @@ tasks:
           kubectl apply -f k3d/secrets.yaml -n workspace
           kubectl apply -f k3d/configmap-domains.yaml -n workspace
           kubectl apply -f k3d/website-schema.yaml -n workspace
-          kubectl apply -f k3d/shared-db.yaml -n workspace
+          # $$ -> $ Collapse wie im kustomize-Hauptpfad: shared-db.yaml traegt $$-escapte
+          # Shell-Vars; roh applied setzt der postStart-Hook sonst alle DB-Passwoerter
+          # auf '<PID>{VAR}' (Incident T001673).
+          sed -E 's/\$\$([a-zA-Z0-9_]|\{)/$\1/g' k3d/shared-db.yaml \
+            | kubectl apply -n workspace -f -
           echo "Waiting for shared-db to be ready before deploying dependent services..."
           kubectl rollout status deployment/shared-db -n workspace --timeout=120s
           # Run website DB migrations before the website Deployment is rolled
@@ -2674,7 +2678,11 @@ tasks:
           # target ns. The base manifest intentionally omits namespace on the
           # Deployment so the prod/ strategic-merge patch matches it as [noNs];
           # PVC/ConfigMap/Services keep their explicit (sed-rewritten) namespace.
+          # $$ -> $ Collapse wie im kustomize-Hauptpfad (Zeile mit ENVSUBST_VARS unten):
+          # ohne ihn landet '$${VAR}' literal im postStart-Hook und die Shell expandiert
+          # $$ zur PID — alle DB-User-Passwoerter werden zu '<PID>{VAR}' (Incident T001673).
           sed "s/namespace: workspace$/namespace: ${_ws_ns}/g" k3d/shared-db.yaml \
+            | sed -E 's/\$\$([a-zA-Z0-9_]|\{)/$\1/g' \
             | kubectl --context "$ENV_CONTEXT" -n "${_ws_ns}" apply -f -
           echo "Waiting for shared-db to be ready before deploying dependent services..."
           kubectl --context "$ENV_CONTEXT" rollout status deployment/shared-db -n "${_ws_ns}" --timeout=120s

--- a/tests/unit/shared-db-initdb-selfheal.bats
+++ b/tests/unit/shared-db-initdb-selfheal.bats
@@ -30,3 +30,17 @@ setup() {
   run grep -qE "SELECT 1 FROM pg_database WHERE datname='\\\$\\\$db'" "$MANIFEST"
   [ "$status" -eq 0 ]
 }
+
+# T001673: shared-db.yaml traegt $$-escapte Shell-Vars. JEDER Apply-Pfad in der
+# Taskfile muss den $$->$-Collapse-sed anwenden — ein roher Apply setzt sonst via
+# postStart alle DB-User-Passwoerter auf '<PID>{VAR}' (Prod-Incident 2026-07-08).
+@test "T001673: every raw k3d/shared-db.yaml apply in Taskfile pipes through the collapse sed" {
+  TASKFILE="$REPO_ROOT/Taskfile.yml"
+  # Kein direktes 'kubectl apply -f k3d/shared-db.yaml' mehr (ohne Collapse-Pipe)
+  run grep -nE 'kubectl[^|]*apply -f k3d/shared-db\.yaml' "$TASKFILE"
+  [ "$status" -ne 0 ]
+  # Collapse-Regex muss fuer alle vier Pfade vorhanden sein:
+  # dev-Apply, dev-kustomize, prod-early-Apply, prod-kustomize
+  cnt=$(grep -cF 's/\$\$([a-zA-Z0-9_]|\{)/$\1/g' "$TASKFILE" || true)
+  [ "${cnt:-0}" -ge 4 ]
+}


### PR DESCRIPTION
## Summary
**Prod-Incident 2026-07-08 (~13:30–19:00):** Nach dem Rollout von PR #2622 setzte der shared-db-postStart-Hook alle DB-User-Passwörter (nextcloud, vaultwarden, website, videovault, pocket_id) auf `<PID>{VAR}`-Müll — `password authentication failed` für alle Consumer, Website-Kontaktformular/Live-E2E rot, Nextcloud-DB-Fehler.

**Root Cause:** `k3d/shared-db.yaml` trägt seit PR #2507 `$$`-escapte Shell-Variablen, die der kustomize-Hauptpfad in `workspace:deploy` per sed zu `$` kollabiert. Der **frühe Prod-Apply** von shared-db (und der Dev-Apply) pipen die Datei aber **roh** nach kubectl — `$${VAR}` landete literal im Pod, die Shell expandierte `$$` zur PID.

**Fix:**
- Collapse-sed (`s/\$\$([a-zA-Z0-9_]|\{)/$\1/g`) in beide rohe Apply-Pfade eingefügt (dev + prod-early)
- BATS-Guard: kein `kubectl apply -f k3d/shared-db.yaml` ohne Pipe mehr; Collapse-Regex muss ≥4× in der Taskfile stehen
- plpgsql-`DO $$`-Blöcke bleiben unberührt (Regex greift nur vor Alnum/`{`)

**Sofort-Remediation (bereits erledigt):** Passwörter aller 5 User im laufenden Pod per `ALTER USER … :'pw'` aus den korrekten Secret-Envs wiederhergestellt — seitdem 0 Auth-Fehler. korczewski war nicht betroffen (altes Manifest ohne `$$`).

## Test Plan
- [x] `npx bats tests/unit/shared-db-initdb-selfheal.bats` — 5/5 grün
- [x] `task --dry workspace:deploy ENV=dev` parst
- [x] Collapse-Ausgabe verifiziert: `ALTER USER … '${VAR}'`, nur plpgsql-`$$` verbleibt

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017L1RiPVKDnwhinMsm6L8CH