### PR TITLE
fix(website): consolidate ai-metrics/ai-quality onto shared db-pool [T001678]

### DIFF
--- a/docs/code-quality/loc-budget.json
+++ b/docs/code-quality/loc-budget.json
@@ -1,8 +1,8 @@
 {
-  "total_lines": 539090,
+  "total_lines": 539084,
   "file_count": 4115,
-  "commit": "b8ac0736",
-  "measured_at": "2026-07-08T23:25:22.372Z",
+  "commit": "60affdfc6",
+  "measured_at": "2026-07-08T23:44:24.314Z",
   "thresholds": {
     "warn_pct": 5,
     "fail_pct": 15,

--- a/docs/db-audit/2026-07-09-index-and-nplus1-audit.md
+++ b/docs/db-audit/2026-07-09-index-and-nplus1-audit.md
@@ -94,8 +94,8 @@ Nutzt `SESSIONS_DATABASE_URL` (Fallback auf die `website`-DB), `nodeLookup` DNS-
 | `website/src/lib/codesearch-db.ts` | `SESSIONS_DATABASE_URL` | eigener Pool + `nodeLookup` | **KONSOLIDIEREN** | identische DB/Config; gewinnt DNS-Workaround + fail-soft Timeouts. Embedding-Queries sind reine SELECTs auf indizierten Spalten → bleiben unter 2s. N+1 in `searchCodeAugmented` (s. §5) wird beim Refactor mit behoben (`= ANY($1)`). |
 | `website/src/lib/knowledge-db.ts` | `SESSIONS_DATABASE_URL` | eigener Pool + `nodeLookup` | **KONSOLIDIEREN** | identische DB/Config. Bulk-Pfad in `ingestJsonChunks` lebt in einem **separaten** Modul (`pages/api/admin/knowledge/import/json.ts`, s. nächste Zeile) und nutzt dort seinen eigenen Pool — das `knowledge-db.ts` selbst macht keine Bulk-Inserts, die das `statement_timeout` sprengen. |
 | `website/src/pages/api/cron/notify-unread.ts` | `SESSIONS_DATABASE_URL` | eigener Pool, **ohne** `nodeLookup`/Timeouts | **KONSOLIDIEREN** | identische DB; Cron-Query ist ein einzelnes Read + Mail-Versand → 2s ausreichend. Gewinnt DNS-Workaround + fail-soft Timeouts. |
-| `website/src/lib/ai-metrics.ts` | `DATABASE_URL` | eigener Pool, ohne `nodeLookup`/Timeouts | **KEEP als Sonder-Pool** (s. §6) | andere Env-Var → möglicherweise andere DB. **Verifikation steht aus**: für beide Brands prüfen, ob `DATABASE_URL` in Prod auf dieselbe `website`-DB auflöst wie `SESSIONS_DATABASE_URL`. Bis dahin: keine konsolidierende Änderung. |
-| `website/src/pages/api/admin/ai-quality.ts` | `DATABASE_URL` | eigener Pool, ohne `nodeLookup`/Timeouts | **KEEP als Sonder-Pool** (s. §6) | teilt den `AiWorkflow`-Typ mit `ai-metrics.ts`; Konsolidierung muss **beide** Module gemeinsam oder gar nicht umfassen, konsistent zur `ai-metrics`-Entscheidung. |
+| `website/src/lib/ai-metrics.ts` | `SESSIONS_DATABASE_URL` (nach T001678) | konsolidiert auf `db-pool.ts` | **KONSOLIDIERT** | Verifikation (T001678, s. §3a) ergab: `DATABASE_URL` ist in Prod (beide Brands, Namespaces `website`/`website-korczewski`) **überhaupt nicht gesetzt** (kein env-Eintrag, kein ConfigMap-Key, kein `PG*`-Fallback) — `new Pool({ connectionString: undefined })` fiel auf pg-Library-Defaults (`localhost:5432`) zurück, was im Pod nicht existiert. `ai_call_log`-Inserts scheiterten seit Einführung lautlos (Bug T001679). Fix: Modul auf den gehärteten `db-pool.ts` (`SESSIONS_DATABASE_URL`, nodeLookup + Timeouts) umgestellt. |
+| `website/src/pages/api/admin/ai-quality.ts` | `SESSIONS_DATABASE_URL` (nach T001678) | konsolidiert auf `db-pool.ts` | **KONSOLIDIERT** | Gleicher Root Cause wie `ai-metrics.ts` (teilt den `AiWorkflow`-Typ) — gemeinsam mit `ai-metrics.ts` in T001678/T001679 konsolidiert. |
 | `website/src/pages/api/admin/knowledge/import/json.ts` | `SESSIONS_DATABASE_URL` | eigener Pool, kein Timeout | **KEEP als Sonder-Pool** | Bulk-Import (`ingestJsonChunks`). Der 2s-`statement_timeout` des geteilten Pools würde große Importe abbrechen. Falls der Bulk-Pfad in den geteilten Pool soll: betroffene Aufrufe explizit mit `SET LOCAL statement_timeout` in einer Transaktion überschreiben — Aufwand > Nutzen für die einzige Bulk-Stelle. |
 
 > **DB-Pool-Sonderfall `platformPool`:** `db-pool.ts` exportiert `platformPool = pool`.
@@ -104,24 +104,27 @@ Nutzt `SESSIONS_DATABASE_URL` (Fallback auf die `website`-DB), `nodeLookup` DNS-
 > erreichen → ECONNREFUSED). Jede Brand nutzt ihr eigenes `shared-db`. Diese
 > Sonderheit ist in `db-pool.ts:49-53` dokumentiert.
 
-### 3a. Verifikation der `DATABASE_URL`/`SESSIONS_DATABASE_URL`-Gleichheit (ausstehend)
+### 3a. Verifikation der `DATABASE_URL`/`SESSIONS_DATABASE_URL`-Gleichheit (T001678 — abgeschlossen)
 
-Die Sonder-Pool-Entscheidung für `ai-metrics.ts` und `ai-quality.ts` hängt davon ab, ob
-beide Env-Vars in Prod (beide Brands) auf dieselbe DB zeigen. Verifikationsschritte
-(siehe §6 Follow-up-Ticket):
+Verifikationsschritte (Kontext `fleet`, Namespaces `website` + `website-korczewski` — **nicht**
+`workspace`/`workspace-korczewski`, die Website läuft in eigenen Namespaces):
 
 ```bash
-for BRAND in mentolder korczewski; do
-  for ENV_NS in workspace workspace-korczewski; do
-    kubectl get deploy website -n "$ENV_NS" --context fleet \
-      -o jsonpath='{.spec.template.spec.containers[0].env}' \
-      | jq '[.[] | select(.name|test("^(DATABASE|SESSIONS_DATABASE)_URL$")) | {name, value: (.value // ("fromSecret:" + .valueFrom.secretKeyRef.name + "/" + .valueFrom.secretKeyRef.key))}]'
-  done
+for NS in website website-korczewski; do
+  kubectl get deploy website -n "$NS" --context fleet \
+    -o jsonpath='{.spec.template.spec.containers[0].env}' \
+    | jq '[.[] | select(.name|test("^(DATABASE|SESSIONS_DATABASE)_URL$")) | {name, value: (.value // ("fromSecret:" + .valueFrom.secretKeyRef.name + "/" + .valueFrom.secretKeyRef.key))}]'
 done
 ```
 
-Erst wenn alle vier Slots auf denselben `host:port/database` auflösen, kann die
-Konsolidierung von `ai-metrics.ts`/`ai-quality.ts` in einem Folge-PR erfolgen.
+**Befund:** `DATABASE_URL` ist in **keinem** der beiden Deployments gesetzt — weder als
+direkter `env`-Eintrag noch im `envFrom`-ConfigMap `website-config` noch als `PG*`-Fallback
+(pg-Library-Default wäre sonst gegriffen). Nur `SESSIONS_DATABASE_URL` ist vorhanden
+(je Brand auf das jeweils eigene `shared-db.<namespace>.svc.cluster.local`). Damit war die
+angenommene Prämisse ("evtl. andere DB") falsch — es gab **gar keine** funktionierende DB für
+`ai-metrics.ts`/`ai-quality.ts` in Prod. Root-Cause- und Fix-Details: Bug T001679.
+`ai-metrics.ts` + `ai-quality.ts` wurden in T001678 auf `db-pool.ts`/`SESSIONS_DATABASE_URL`
+konsolidiert (s. Tabelle oben).
 
 ## 4. Index-Audit (Stufe C2 — EXPLAIN-driven)
 
@@ -325,7 +328,8 @@ BRAND=korczewski bash -c 'source scripts/factory/lib.sh; factory_resolve; factor
 |---|---|
 | **T001676** (dieser PR) | Phase-2-Drop, Orphan-Migration, Pool-Konsolidierung (Codesearch/Knowledge/Notify), Index-Audit-Doku, N+1 in `codesearch-db.ts` gefixt. |
 | **T001677** (Folge, in Triage) | Migrations-System-Konsolidierung: `scripts/migrations/*.sql` unter einen getrackten Runner analog `website/src/db/migrate.ts` (`public.schema_migrations`) bringen. |
-| **TBD** (Folge) | `ai-metrics.ts` + `ai-quality.ts` Pool-Konsolidierung, **nach** Verifikation `DATABASE_URL == SESSIONS_DATABASE_URL` (siehe §3a). |
+| **T001678** (Folge, done) | Verifikation `DATABASE_URL`/`SESSIONS_DATABASE_URL` (siehe §3a) + `ai-metrics.ts`/`ai-quality.ts` Pool-Konsolidierung. Ergab Bug T001679 (DATABASE_URL in Prod nie gesetzt). |
+| **T001679** (Bug, gefixt in T001678) | `ai-metrics.ts`/`ai-quality.ts` verbanden sich in Prod mit `connectionString: undefined` (pg-Default `localhost`) statt der echten DB — `ai_call_log`-Inserts scheiterten lautlos seit Feature-Einführung. |
 | **TBD** (Folge) | `knowledge-db.ts` `upsertChunks` + `mergeCollections` N+1 → `unnest`-Batch-INSERTs. |
 | **TBD** (Folge) | `unused-indexes`-Re-Audit nach ≥30d Postgres-Uptime, dann DROP-Entscheidung pro Index. |
 | **TBD** (Ops) | `VACUUM (ANALYZE) coaching.*` + `ANALYZE knowledge.chunks` + `ANALYZE tickets.ticket_embeddings` nach dem Merge. |

--- a/website/src/lib/ai-metrics.test.ts
+++ b/website/src/lib/ai-metrics.test.ts
@@ -1,15 +1,11 @@
 import { describe, test, expect, vi, beforeEach } from 'vitest';
+import * as mod from './ai-metrics';
 
 const queryMock = vi.fn().mockResolvedValue({ rows: [] });
-vi.mock('pg', () => ({
-  Pool: class { query = queryMock; },
-}));
 
-let mod: typeof import('./ai-metrics');
-beforeEach(async () => {
+beforeEach(() => {
   queryMock.mockClear();
-  vi.resetModules();
-  mod = await import('./ai-metrics');
+  mod.__setPoolForTests({ query: (...a: unknown[]) => queryMock(...a) } as never);
 });
 
 describe('withAiMetrics', () => {

--- a/website/src/lib/ai-metrics.ts
+++ b/website/src/lib/ai-metrics.ts
@@ -1,4 +1,5 @@
-import { Pool } from 'pg';
+import type { Pool } from 'pg';
+import { pool as defaultPool } from './db-pool';
 import { logger } from './logger';
 
 export type AiWorkflow =
@@ -22,11 +23,11 @@ export interface AiCallRecord extends AiCallMeta {
   error?: string;
 }
 
-let pool: Pool | null = null;
-function getPool(): Pool {
-  if (!pool) pool = new Pool({ connectionString: process.env.DATABASE_URL });
-  return pool;
-}
+// Test-only escape hatch: ai-metrics.test.ts mocks the pool directly.
+// In production this always resolves to `defaultPool` (from db-pool.ts).
+let _pool: Pool | undefined;
+export function __setPoolForTests(testPool: Pool): void { _pool = testPool; }
+function getPool(): Pool { return _pool ?? defaultPool; }
 
 export async function logAiCall(rec: AiCallRecord): Promise<void> {
   try {

--- a/website/src/pages/api/admin/ai-quality.test.ts
+++ b/website/src/pages/api/admin/ai-quality.test.ts
@@ -1,21 +1,17 @@
 import { describe, test, expect, vi, beforeEach } from 'vitest';
 
 const queryMock = vi.fn();
-vi.mock('pg', () => ({
-  Pool: class { query = queryMock; },
-}));
 vi.mock('../../../lib/auth', () => ({
   getSession: vi.fn(),
   isAdmin: vi.fn(),
 }));
 
 import { getSession, isAdmin } from '../../../lib/auth';
-let route: typeof import('./ai-quality');
+import * as route from './ai-quality';
 
-beforeEach(async () => {
+beforeEach(() => {
   queryMock.mockReset();
-  vi.resetModules();
-  route = await import('./ai-quality');
+  route.__setPoolForTests({ query: (...a: unknown[]) => queryMock(...a) } as never);
 });
 
 function req(): Request {

--- a/website/src/pages/api/admin/ai-quality.ts
+++ b/website/src/pages/api/admin/ai-quality.ts
@@ -1,5 +1,6 @@
 import type { APIRoute } from 'astro';
-import { Pool } from 'pg';
+import type { Pool } from 'pg';
+import { pool as defaultPool } from '../../../lib/db-pool';
 import { getSession, isAdmin } from '../../../lib/auth';
 import type { AiWorkflow } from '../../../lib/ai-metrics';
 
@@ -11,11 +12,11 @@ const PRICE_PER_1K_EUR: Record<string, { input: number; output: number }> = {
   'bge-m3':            { input: 0,       output: 0       },
 };
 
-let pool: Pool | null = null;
-function getPool(): Pool {
-  if (!pool) pool = new Pool({ connectionString: process.env.DATABASE_URL });
-  return pool;
-}
+// Test-only escape hatch: ai-quality.test.ts mocks the pool directly.
+// In production this always resolves to `defaultPool` (from db-pool.ts).
+let _pool: Pool | undefined;
+export function __setPoolForTests(testPool: Pool): void { _pool = testPool; }
+function getPool(): Pool { return _pool ?? defaultPool; }
 
 export type Health = 'green' | 'yellow' | 'red';
 


### PR DESCRIPTION
## Summary
- Follow-up zu T001676 (docs/db-audit/2026-07-09-index-and-nplus1-audit.md §3a/§6): Verifikation der `DATABASE_URL`/`SESSIONS_DATABASE_URL`-Gleichheit in Prod (beide Brands).
- **Befund:** `DATABASE_URL` ist in Prod (Namespaces `website`/`website-korczewski`, Kontext `fleet`) gar nicht gesetzt — weder als env-Eintrag noch im ConfigMap `website-config` noch als `PG*`-Fallback. `ai-metrics.ts`/`ai-quality.ts` verbanden sich seit Feature-Einführung mit pg-Library-Defaults (`localhost:5432`) statt der echten DB. `ai_call_log`-Inserts scheiterten dadurch lautlos (`catch` verschluckt den Fehler, nur `logger.error`). Dokumentiert als Bug T001679.
- Fix: beide Module gemeinsam auf den gehärteten `db-pool.ts` (`SESSIONS_DATABASE_URL`, nodeLookup DNS-Workaround + fail-soft Timeouts) konsolidiert — analog zur Pool-Konsolidierung in T001676 Stufe C (`codesearch-db.ts`/`knowledge-db.ts`).
- Audit-Doku §3a/§9 mit dem tatsächlichen Befund aktualisiert (statt "Verifikation steht aus").

Tickets: T001678 (Follow-up-Task, done), T001679 (Bug, gefixt in diesem PR).

## Test plan
- [x] `website/src/lib/ai-metrics.test.ts` (4/4) — Pool-Mock via `__setPoolForTests` statt `vi.mock('pg')`
- [x] `website/src/pages/api/admin/ai-quality.test.ts` (3/3) — dito
- [x] `task test:changed` — grün, LOC-Budget PASS (-6 Zeilen)
- [x] `task freshness:regenerate` + `task freshness:check` — grün

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QhqsYm52ZjC3ViiQNdjkKD