### PR TITLE
chore(db): add reproducible migration for ticket-triage local-qwen35 routing [T001680]

### DIFF
--- a/docs/db-audit/2026-07-09-index-and-nplus1-audit.md
+++ b/docs/db-audit/2026-07-09-index-and-nplus1-audit.md
@@ -46,8 +46,9 @@ Brand-DBs. `t` = vorhanden, `f` = fehlt.
 | 24 | `2026-06-17-triage-columns` | `tickets.tickets.component` | t | t | ok |
 | 25 | `2026-07-03-context-budget` | `tickets.provider_config.context_window + context_budget` | t | t | ok |
 | 26 | `2026-07-03-context-budget` | `tickets.provider_health.reserved_tokens` | t | t | ok |
-| 27 | `2026-07-03-local-qwen35-seed` | `provider_config` row `provider='local-qwen35'` | **f** | **f** | (beide) |
+| 27 | `2026-07-03-local-qwen35-seed` | `provider_config` rows für `factory-scout`/`factory-plan`/`lavish-artifact` (`provider='local-qwen35'`) | **f** | **f** | (beide) — weiterhin ausstehend, nur diese 3 Sources; nutzt zudem eine veraltete hartcodierte wg-gpu-IP statt Service-DNS (siehe Zeile 29). |
 | 28 | `2026-07-08-coaching-is-test-data` | `coaching.sessions.is_test_data` | t | t | ok |
+| 29 | `2026-07-09-ticket-triage-local-qwen35` | `provider_config` row `ticket-triage/haiku priority=1, provider='local-qwen35'` | t | t | ok — live via `kubectl exec`+`psql` angewendet, dann als Migrationsdatei nachgezogen (T001680-Folge). base_url ist zwingend brand-different (K8s-Service-DNS je Namespace), verwendet daher `-v base_url=...` statt hartcodierter IP. Zusätzlich: mentolder-`llm-gateway-lmstudio`-Endpoints-IP war auf `172.17.0.1` (Dev-Bridge) statt `192.168.100.10` (Prod-WireGuard) verdriftet — per `kubectl patch` korrigiert (reiner Live-Cluster-Zustand, kein Manifest-Fix nötig, `environments/mentolder.yaml` hatte den korrekten Wert bereits). |
 
 ### 1a. Lücken → Nachzieh-Empfehlung (NICHT durch dieses PR umgesetzt)
 
@@ -331,6 +332,7 @@ BRAND=korczewski bash -c 'source scripts/factory/lib.sh; factory_resolve; factor
 | **T001678** (Folge, done) | Verifikation `DATABASE_URL`/`SESSIONS_DATABASE_URL` (siehe §3a) + `ai-metrics.ts`/`ai-quality.ts` Pool-Konsolidierung. Ergab Bug T001679 (DATABASE_URL in Prod nie gesetzt). |
 | **T001679** (Bug, gefixt in T001678) | `ai-metrics.ts`/`ai-quality.ts` verbanden sich in Prod mit `connectionString: undefined` (pg-Default `localhost`) statt der echten DB — `ai_call_log`-Inserts scheiterten lautlos seit Feature-Einführung. |
 | **T001680** (Folge, done) | Operator-Nachzug für 3 Migrationslücken aus §1 (Zeilen 1-3, 11): `ai-question-human-answer` auf korczewski nachgezogen, `central-dashboard-view` als obsolet entfernt (kein Code-Konsument, abgelöst durch `v_cockpit_rollup`), `llm-availability-seed` auf mentolder nachgezogen (überschreibt dabei `ticket-triage priority=1` von `local-cluster` auf `deepseek` — Live-Routing-Änderung, siehe Zeile 33). `local-qwen35-seed` (Zeile 49, fehlt auf beiden Brands) bewusst nicht mit-nachgezogen. |
+| **T001680-Folge** (done) | `ticket-triage` explizit auf `local-qwen35`/`qwen3.5-9b@iq4_xs` umgestellt (Priorität 1, beide Brands) — siehe Zeile 29. Zusätzlich mentolder-`llm-gateway-lmstudio`-Endpoints-IP-Drift (`172.17.0.1` statt `192.168.100.10`) per `kubectl patch` behoben. |
 | **TBD** (Folge) | `knowledge-db.ts` `upsertChunks` + `mergeCollections` N+1 → `unnest`-Batch-INSERTs. |
 | **TBD** (Folge) | `unused-indexes`-Re-Audit nach ≥30d Postgres-Uptime, dann DROP-Entscheidung pro Index. |
 | **TBD** (Ops) | `VACUUM (ANALYZE) coaching.*` + `ANALYZE knowledge.chunks` + `ANALYZE tickets.ticket_embeddings` nach dem Merge. |

--- a/scripts/migrations/2026-07-09-ticket-triage-local-qwen35.sql
+++ b/scripts/migrations/2026-07-09-ticket-triage-local-qwen35.sql
@@ -1,0 +1,63 @@
+-- 2026-07-09-ticket-triage-local-qwen35.sql
+-- Routes ticket-triage to the local LM-Studio qwen3.5 model at priority 1
+-- (context_window=60000, context_budget=180000), demoting the existing
+-- priority-1 row to the next free priority for (source, tier). Idempotent
+-- (ON CONFLICT DO UPDATE + provider<>'local-qwen35' demotion guard, mirrors
+-- 2026-07-03-local-qwen35-seed.sql).
+--
+-- Reproduces a change already applied live via kubectl exec + psql on
+-- 2026-07-09 (T001680 follow-up conversation) — this file exists so a
+-- cluster rebuild / disaster recovery reproduces the same state.
+--
+-- base_url is the K8s Service DNS for llm-gateway-lmstudio, which differs
+-- per brand (separate namespace per brand) — unlike prior migrations in
+-- this directory, this one is NOT brand-agnostic and requires the
+-- `-v base_url=...` psql variable (supported by factory_psql, see
+-- scripts/factory/lib.sh). Do NOT hardcode a wg-gpu IP here (a prior
+-- migration did this for other sources and drifted — see
+-- 2026-07-03-local-qwen35-seed.sql / docs/db-audit/2026-07-09-index-and-nplus1-audit.md §3a).
+--
+-- Apply to BOTH brands (separate per-brand DBs, different base_url each):
+--   BRAND=mentolder bash -c 'source scripts/factory/lib.sh; factory_resolve; factory_psql -v base_url="http://llm-gateway-lmstudio.workspace.svc.cluster.local:1234/v1" < scripts/migrations/2026-07-09-ticket-triage-local-qwen35.sql'
+--   BRAND=korczewski bash -c 'source scripts/factory/lib.sh; factory_resolve; factory_psql -v base_url="http://llm-gateway-lmstudio.workspace-korczewski.svc.cluster.local:1234/v1" < scripts/migrations/2026-07-09-ticket-triage-local-qwen35.sql'
+-- Dev (k3d): kubectl exec -n workspace <shared-db-pod> -- psql -U website website -v base_url='http://llm-gateway-lmstudio.workspace-dev.svc.cluster.local:1234/v1'
+BEGIN;
+
+-- Demote the current priority-1 row for ticket-triage/haiku to the next free
+-- priority. `provider <> 'local-qwen35'` keeps this idempotent: a second run
+-- must not re-demote the already-seeded local-qwen35 row.
+WITH targets AS (
+  SELECT id
+    FROM tickets.provider_config
+   WHERE source = 'ticket-triage' AND tier = 'haiku'
+     AND priority = 1
+     AND provider <> 'local-qwen35'
+),
+new_prio AS (
+  SELECT t.id,
+         (SELECT COALESCE(MAX(pc2.priority), 1) + 1
+            FROM tickets.provider_config pc2
+           WHERE pc2.source = 'ticket-triage' AND pc2.tier = 'haiku') AS priority
+    FROM targets t
+)
+UPDATE tickets.provider_config pc
+   SET priority = np.priority, updated_at = now()
+  FROM new_prio np
+ WHERE pc.id = np.id;
+
+-- Priority-1 local-qwen35 row for ticket-triage. base_url is passed in via
+-- the `base_url` psql variable (see invocation examples above).
+INSERT INTO tickets.provider_config
+  (source, tier, priority, provider, model_id, base_url, context_window, context_budget, enabled)
+VALUES
+  ('ticket-triage', 'haiku', 1, 'local-qwen35', 'qwen3.5-9b@iq4_xs', :'base_url', 60000, 180000, true)
+ON CONFLICT (source, tier, priority) DO UPDATE
+  SET provider       = EXCLUDED.provider,
+      model_id       = EXCLUDED.model_id,
+      base_url       = EXCLUDED.base_url,
+      context_window = EXCLUDED.context_window,
+      context_budget = EXCLUDED.context_budget,
+      enabled        = EXCLUDED.enabled,
+      updated_at     = now();
+
+COMMIT;


### PR DESCRIPTION
## Summary
Follow-up zu T001680 — schreibt eine bereits **live** angewendete Änderung als reproduzierbare Migration fest.

- **`ticket-triage`/`haiku`** routet jetzt auf beiden Brands zu `local-qwen35`/`qwen3.5-9b@iq4_xs` (LM Studio) mit Priorität 1. Bisherige Priorität-1-Row wird verdrängt, nicht gelöscht.
- `base_url` unterscheidet sich zwingend pro Brand (K8s-Service-DNS je Namespace, nicht brand-agnostisch wie alle bisherigen Migrationen in diesem Verzeichnis) — nutzt daher das bereits von `factory_psql` unterstützte `-v`-Pattern statt einer hartcodierten IP (die ältere `2026-07-03-local-qwen35-seed.sql` hat genau das getan und ist dadurch verdriftet).
- Nebenbefund + Fix (nicht Teil dieses Commits, reiner Live-Cluster-Zustand): mentolder-`llm-gateway-lmstudio`-Endpoints-IP war auf die Dev-Docker-Bridge-Adresse (`172.17.0.1`) verdriftet statt der in `environments/mentolder.yaml` bereits korrekt hinterlegten Prod-WireGuard-IP (`192.168.100.10`) — per `kubectl patch` korrigiert.
- Audit-Doku §1/§9 aktualisiert (neue Zeile 29, Klarstellung dass `2026-07-03-local-qwen35-seed` weiterhin nur für die anderen 3 Sources aussteht).

## Test plan
- [x] `task test:changed` — grün, LOC-Budget PASS
- [x] `task freshness:regenerate` + `task freshness:check` — grün
- [x] Live-Verifikation bereits vor diesem PR durchgeführt (Anthropic-`/v1/messages`-Kompatibilität von LM Studio getestet, Modell-ID `qwen3.5-9b@iq4_xs` bestätigt, `provider_config`-Rows auf beiden Brands verifiziert)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QhqsYm52ZjC3ViiQNdjkKD