### PR TITLE
chore: default worktree dir to .worktrees/<slug> [T001684]

### DIFF
--- a/.claude/lib/behaviors/commit-conventions.md
+++ b/.claude/lib/behaviors/commit-conventions.md
@@ -31,9 +31,9 @@ Nach PR-Erstellung keine weiteren Commits hinzufügen — auto-merge erledigt da
 
 ## Worktrees bevorzugen
 ```bash
-bash scripts/worktree-create.sh <branch> tmp/wt-<slug>
+bash scripts/worktree-create.sh <branch> .worktrees/<slug>
 ```
 Worktrees laufen in `/tmp/` (kurzlebig). Nach Merge aufräumen:
 ```bash
-bash scripts/worktree-create.sh --cleanup tmp/wt-<slug>
+bash scripts/worktree-create.sh --cleanup .worktrees/<slug>
 ```

--- a/.claude/lib/behaviors/never-push-main.md
+++ b/.claude/lib/behaviors/never-push-main.md
@@ -10,7 +10,7 @@ Alle Änderungen laufen über Pull Requests:
 
 **In Worktrees arbeiten** (bevorzugt):
 ```bash
-bash scripts/worktree-create.sh <branch> tmp/wt-<slug>
+bash scripts/worktree-create.sh <branch> .worktrees/<slug>
 ```
 Die `dev-flow-plan`- und `using-git-worktrees`-Skills automatisieren das.
 

--- a/.claude/skills/dev-flow-chore/SKILL.md
+++ b/.claude/skills/dev-flow-chore/SKILL.md
@@ -51,8 +51,8 @@ einen Cron-Job ein. **STOPP hier.**
 
 > **Test-only-Kurzpfad (kein Worktree):** Berührt die Chore **ausschließlich** Testdateien
 > (`tests/**/*.bats`, `tests/spec/*.bats`, `website/**/*.test.ts`, Playwright-Specs) — z.B. "schreib
-> einen Test für X" — dann entfällt `tmp/wt-*` als Standardfall. Ein eigener Worktree pro Testdatei
-> erzeugt nur IDE-Clutter (jede offene `tmp/wt-*`-Kopie erscheint als eigener Ordner) ohne
+> einen Test für X" — dann entfällt `.worktrees/*` als Standardfall. Ein eigener Worktree pro Testdatei
+> erzeugt nur IDE-Clutter (jede offene `.worktrees/*`-Kopie erscheint als eigener Ordner) ohne
 > Isolationsgewinn, solange kein anderer Prozess konkurrierend im Haupt-Checkout schreibt. Prüfe das:
 > ```bash
 > bash scripts/agent-lock.sh list   # leer/keine fremde main-checkout- oder branch-Claim?
@@ -69,8 +69,8 @@ einen Cron-Job ein. **STOPP hier.**
 Regulärer Pfad (Default für alles außer dem Test-only-Kurzpfad oben):
 ```bash
 # git-crypt-safe: creates the worktree, handles git-crypt, inits submodules
-bash scripts/worktree-create.sh chore/<slug> /tmp/wt-<slug>
-cd /tmp/wt-<slug>
+bash scripts/worktree-create.sh chore/<slug> .worktrees/<slug>
+cd .worktrees/<slug>
 bash scripts/agent-lock.sh claim branch "chore/<slug>" --worktree "$PWD" --label dev-flow-chore
 ```
 
@@ -131,7 +131,7 @@ Rufe `commit-commands:commit-push-pr` auf (Claude Code slash-command) oder führ
 
 **`git-workflow` Schritt 7** (SSOT): Lock-Release
 ([session-coordination](file:///home/patrick/Bachelorprojekt/.claude/skills/references/session-coordination.md)),
-dann `git worktree remove /tmp/wt-<slug> --force && git branch -D chore/<slug>` im Haupt-Repo.
+dann `git worktree remove .worktrees/<slug> --force && git branch -D chore/<slug>` im Haupt-Repo.
 
 Beim Test-only-Kurzpfad (Schritt 1) gibt es keinen Worktree zu entfernen — nur
 `bash scripts/agent-lock.sh release main-checkout` und `git checkout main && git branch -D chore/<slug>`.
@@ -147,7 +147,7 @@ Nur wenn die Chore deploybare Pfade berührt — Mapping in
 
 **Zustand nach Schritt 6:**
 - `main` enthält die gemergten Änderungen (squash commit)
-- Worktree `/tmp/wt-<slug>` gelöscht, Branch `chore/<slug>` gelöscht
+- Worktree `.worktrees/<slug>` gelöscht, Branch `chore/<slug>` gelöscht
 - Ticket status = `done` (wurde beim Anlegen bereits gesetzt)
 - Branch-Lock freigegeben
 

--- a/.claude/skills/dev-flow-execute/SKILL.md
+++ b/.claude/skills/dev-flow-execute/SKILL.md
@@ -66,16 +66,16 @@ if [[ -z "$CURRENT_BRANCH" || "$CURRENT_BRANCH" == "HEAD" ]]; then
 fi
 ```
 `dev-flow-execute` erwartet normalerweise, dass `dev-flow-plan` bereits einen isolierten Worktree unter
-`tmp/wt-*` übergeben hat. Das wird hier nie explizit geprüft — läuft die Execute-Phase versehentlich im
+`.worktrees/*` übergeben hat. Das wird hier nie explizit geprüft — läuft die Execute-Phase versehentlich im
 Haupt-Checkout (z.B. nach einem Session-Neustart), schreibt der Implementer-Subagent direkt ins
 Haupt-Repo statt in eine isolierte Kopie [T001363]:
 ```bash
 # Worktree-Isolation-Check [T001363]
-# Wir sind entweder schon in einem tmp/wt-*-Worktree ODER müssen einen anlegen.
-if [[ "$PWD" != *"/tmp/wt-"* ]]; then
-  echo "⚠️  Kein isolierter Worktree unter tmp/wt-* erkannt (PWD=$PWD)."
+# Wir sind entweder schon in einem .worktrees/*-Worktree ODER müssen einen anlegen.
+if [[ "$PWD" != *".worktrees/"* ]]; then
+  echo "⚠️  Kein isolierter Worktree unter .worktrees/* erkannt (PWD=$PWD)."
   SLUG=$(echo "$CURRENT_BRANCH" | sed 's#^[a-z]*/##')
-  WORKTREE_PATH="tmp/wt-${SLUG}"
+  WORKTREE_PATH=".worktrees/${SLUG}"
   echo "→ Lege isolierten Worktree an: scripts/worktree-create.sh $CURRENT_BRANCH $WORKTREE_PATH"
   bash scripts/worktree-create.sh "$CURRENT_BRANCH" "$WORKTREE_PATH"
   if [[ -d "$WORKTREE_PATH" ]]; then
@@ -437,7 +437,7 @@ gh pr merge --auto --squash --delete-branch
 Lösche den lokalen Worktree und Branch (im Haupt-Repo ausführen):
 Claims freigeben VOR dem Worktree-Remove ([session-coordination](file:///home/patrick/Bachelorprojekt/.claude/skills/references/session-coordination.md)), dann:
 ```bash
-git worktree remove "$MAIN_REPO/tmp/wt-<slug>" --force
+git worktree remove "$MAIN_REPO/.worktrees/<slug>" --force
 git branch -D "<branch>"
 ```
 
@@ -456,7 +456,7 @@ Führe danach `dev-flow-e2e` aus, um E2E-Tests gegen die Live-Umgebung zu schrei
 
 **Zustand nach Schritt 8:**
 - `main` enthält die gemergten Änderungen (squash commit)
-- Worktree `/tmp/wt-<slug>` gelöscht, Branch `feature/<slug>` gelöscht
+- Worktree `.worktrees/<slug>` gelöscht, Branch `feature/<slug>` gelöscht
 - Ticket status = `done` (resolution=shipped)
 - Branch-Lock und Ticket-Lock freigegeben
 - Deployed (falls `devflow-post-merge-deploy.sh` Pfad-Treffer)

--- a/.claude/skills/dev-flow-plan/SKILL.md
+++ b/.claude/skills/dev-flow-plan/SKILL.md
@@ -188,10 +188,10 @@ Falls neue E2E-Tests geplant sind, weise das passende Playwright-Projekt zu (sie
 Erstelle den Worktree NACH dem Propose (niemals `.claude/worktrees/` verwenden!):
 ```bash
 # git-crypt-safe: creates the worktree, handles git-crypt, inits submodules
-bash scripts/worktree-create.sh feature/<slug> /tmp/wt-<slug>
+bash scripts/worktree-create.sh feature/<slug> .worktrees/<slug>
 
 # Doppelarbeit verhindern: Branch claimen (Session-Koordination [T000510]).
-bash scripts/agent-lock.sh claim branch "feature/<slug>" --worktree "/tmp/wt-<slug>" --label dev-flow-plan \
+bash scripts/agent-lock.sh claim branch "feature/<slug>" --worktree ".worktrees/<slug>" --label dev-flow-plan \
   || { echo "🛑 Branch wird bereits von einer anderen Session bearbeitet — koordinieren oder anderen slug wählen."; exit 1; }
 
 # Ticket-Claim (Session-Koordination [T000510]) — nur falls die Ticket-ID schon bekannt
@@ -199,14 +199,14 @@ bash scripts/agent-lock.sh claim branch "feature/<slug>" --worktree "/tmp/wt-<sl
 # Schritt 4.5 den Claim nach, sobald das Ticket dort angelegt/wiederverwendet wird. [T001386]
 if [[ -n "${TICKET_EXT_ID:-}" ]]; then
   bash scripts/agent-lock.sh claim ticket "$TICKET_EXT_ID" \
-    --branch "feature/<slug>" --worktree "/tmp/wt-<slug>" --label dev-flow-plan \
+    --branch "feature/<slug>" --worktree ".worktrees/<slug>" --label dev-flow-plan \
     || { echo "🛑 Ticket wird bereits von einer anderen Session bearbeitet — koordinieren."; exit 1; }
 fi
 ```
 #### Schritt B.2: Proposal-Artefakte in den Worktree verschieben
 Die Artefakte aus Phase A befinden sich noch im main-Checkout — jetzt in den frischen Worktree verschieben:
 ```bash
-WT="/tmp/wt-<slug>"
+WT=".worktrees/<slug>"
 
 # OpenSpec-Change-Ordner (proposal.md, tasks.md, ggf. assets/)
 mkdir -p "${WT}/openspec/changes/"
@@ -274,7 +274,7 @@ Statt deinen eigenen Kontext zurückzusetzen (das ließe dich den Faden verliere
       - **P1 Placeholder-Verbot:** In Prosa (außerhalb von ```-Fences und
         `inline code`) dürfen die Tokens `TBD`, `TODO`, `FIXME`, `???`,
         `<ausfüllen>` und `similar to Task <N>` NICHT vorkommen.
-      - **Auftrag:** „**PFLICHT — Worktree-Isolation:** Beginne deinen Prompt mit `cd /tmp/wt-<slug>` — der Subagent hat keinen impliziten CWD-Kontext und schreibt sonst ins Haupt-Checkout. Alle folgenden Dateipfade sind relativ zu diesem Worktree.
+      - **Auftrag:** „**PFLICHT — Worktree-Isolation:** Beginne deinen Prompt mit `cd .worktrees/<slug>` — der Subagent hat keinen impliziten CWD-Kontext und schreibt sonst ins Haupt-Checkout. Alle folgenden Dateipfade sind relativ zu diesem Worktree.
      Dann: Lies die Spec UND `.claude/skills/references/plan-quality-gates.md`. Rufe `superpowers:writing-plans` auf und schreibe den Implementierungsplan **ausschließlich** nach `openspec/changes/<slug>/tasks.md` (OpenSpec-Format: H2-Operationsheader im Delta, H3-Requirement, H4-Scenario im `specs/<capability>.md`). Der finale Verifikations-Task des Plans MUSS `task test:changed`, `task freshness:regenerate` und `task freshness:check` als Steps enthalten (CI-Äquivalent inkl. S1–S4-Ratchet); nach Test-Änderungen zusätzlich `task test:inventory` + Commit des Inventars. Vor dem Commit: `task test:openspec` (oder `bash scripts/openspec.sh validate`) — muss grün sein. **Test-Assertion-Konsistenz:** Verifiziere vor Finalisierung, dass jede im Plan-Task vorgegebene Test-Regex/Erwartung tatsächlich die im selben Task referenzierten Implementierungs-Snippets matchen kann — bei Diskrepanz wähle eine semantisch äquivalente Assertion-Form, die zum Snippet passt. Starte KEINE Implementierung (nur Plan schreiben, dann STOPP). Gib den Plan-Pfad (`openspec/changes/<slug>/tasks.md`) und eine 3-Zeilen-Zusammenfassung zurück."
 ### Schritt 3.8: Plan-Qualitäts-Gate (deterministischer Linter + advisory LLM-QA)
 Führe ZUERST den deterministischen, fail-closed Linter auf den Plan-Pfad aus, den der
@@ -408,8 +408,8 @@ TICKET_UUID=$(echo "$TICKET_RESULT"   | cut -d'|' -f2)
 ### Schritt 2: Worktree anlegen
 ```bash
 # git-crypt-safe: creates the worktree, handles git-crypt, inits submodules
-bash scripts/worktree-create.sh fix/<slug> /tmp/wt-<slug>
-cd /tmp/wt-<slug>
+bash scripts/worktree-create.sh fix/<slug> .worktrees/<slug>
+cd .worktrees/<slug>
 ```
 ### Schritt 2.5: Ticket & Branch claimen (Session-Koordination [T000510])
 ```bash

--- a/.claude/skills/git-workflow/SKILL.md
+++ b/.claude/skills/git-workflow/SKILL.md
@@ -202,7 +202,7 @@ MAIN_REPO=$(git worktree list --porcelain | awk '/^worktree/{print $2; exit}')
 
 ## Schritt 7 — Post-Merge Cleanup (Worktrees)
 
-Nur wenn in einem `/tmp/wt-*`-Worktree gearbeitet wurde:
+Nur wenn in einem `.worktrees/*`-Worktree gearbeitet wurde:
 
 ```bash
 WORKTREE_PATH="$(git rev-parse --show-toplevel)"

--- a/.claude/skills/references/dev-flow-gotchas.md
+++ b/.claude/skills/references/dev-flow-gotchas.md
@@ -11,7 +11,7 @@ This section aggregates known operational issues, gotchas, and workarounds for t
 **Rule**: Always derive the `$PORT` dynamically from the return value of `start-server.sh`. Hardcoding or guessing a port from a prior session will result in 502 Bad Gateway.
 
 ### [T000298] Git Auto-Merge in Worktrees
-**Context**: `gh pr merge --auto` inside `/tmp/wt-*` worktrees.
+**Context**: `gh pr merge --auto` inside `.worktrees/*` worktrees.
 **Rule**: Running `--auto` inside a worktree can silently fail or skip because Git thinks `main` is already in use by the primary worktree. Always run the merge command either with explicit `--repo` from the primary repository directory, or poll the checks sequentially (without `--auto`) before merging.
 
 ### [T000346] K8s Object verification before Planning

--- a/.claude/skills/references/subagent-provisioning.md
+++ b/.claude/skills/references/subagent-provisioning.md
@@ -55,7 +55,7 @@ Das `task`-Tool kennt **`subagent_type` und `description`**, keinen separaten Ef
 
 Der Subagent hat per Konstruktion **keinen** Kontext — gib alles explizit, aber **verdichtet**:
 
-- **Absoluter Worktree-Pfad:** PFLICHT — beginne JEDEN Subagenten-Prompt mit `cd <WORKTREE_PATH>` (z.B. `cd /tmp/wt-<slug>`). Der Subagent hat sonst keinen impliziten Kontext und schreibt Dateien in sein Fallback-CWD (oft der Haupt-Checkout statt des Worktrees).
+- **Absoluter Worktree-Pfad:** PFLICHT — beginne JEDEN Subagenten-Prompt mit `cd <WORKTREE_PATH>` (z.B. `cd .worktrees/<slug>`). Der Subagent hat sonst keinen impliziten Kontext und schreibt Dateien in sein Fallback-CWD (oft der Haupt-Checkout statt des Worktrees).
 - Branch-Name, damit der Subagent weiß, auf welchem Branch er arbeitet.
 - Die relevanten **Artefakt-Pfade** (Spec/Plan/Ticket), nicht deren Volltext, wenn er sie selbst lesen kann.
 - Bei mehreren Vorstufen-Ergebnissen: **zusammenfassen, nie Roh-JSON dumpen**. (Ein 162k-Zeichen-Prompt ließ

--- a/.claude/skills/superpowers/using-git-worktrees/SKILL.md
+++ b/.claude/skills/superpowers/using-git-worktrees/SKILL.md
@@ -111,7 +111,7 @@ cause PR/branch operations that omit `--head` to resolve against the wrong branc
 
 Rules:
 - Any subagent that mutates git state (checkout, rebase, stash) **must** operate
-  in an isolated `/tmp/wt-*` worktree, never the primary repo.
+  in an isolated `.worktrees/*` worktree, never the primary repo.
 - Always pass `--head <branch>` explicitly on `gh pr create` and `gh pr merge`
   — never rely on the ambient current branch.
 

--- a/.claude/skills/ticket-ops/SKILL.md
+++ b/.claude/skills/ticket-ops/SKILL.md
@@ -228,7 +228,7 @@ DEFERRED (needs_human, ungeklärt): T000738
 ### Step 3.5: Dispatch wave 1 (after the user approves)
 For each wave-1 ticket, in parallel (use `dispatching-parallel-agents`):
 1. `bash scripts/agent-lock.sh claim ticket <ext-id> --branch <b> --worktree <wt> --label ticket-ops` (skip/coordinate on exit 1 — a live session already owns it).
-2. Create the worktree: `bash scripts/worktree-create.sh <branch> tmp/wt-<slug>`.
+2. Create the worktree: `bash scripts/worktree-create.sh <branch> .worktrees/<slug>`.
 3. Hand to `dev-flow-execute` (plan_staged) or `dev-flow-plan` (unplanned) inside that worktree.
 
 Merge = Abschluss: each ticket closes on its own green auto-merge; the masterplan tracks dispatch, not prod-live.

--- a/.opencode/skills/dev-flow/plugins/worktree/WORKTREE.SKILL.md
+++ b/.opencode/skills/dev-flow/plugins/worktree/WORKTREE.SKILL.md
@@ -14,14 +14,14 @@ Worktree management for OpenCode git isolation and temporary workspace creation.
 # Create a new worktree
 worktree:create {
   branch: "feature/my-feature"
-  path: "tmp/wt-my-feature"
+  path: ".worktrees/my-feature"
 }
 
 # ... do work in the worktree ...
 
 # Cleanup when done  
 worktree:cleanup {
-  worktreePath: "tmp/wt-my-feature"
+  worktreePath: ".worktrees/my-feature"
 }
 ```
 

--- a/.opencode/skills/dev-flow/worktree.SKILL.md
+++ b/.opencode/skills/dev-flow/worktree.SKILL.md
@@ -14,14 +14,14 @@ Worktree management for OpenCode git isolation and temporary workspace creation.
 # Create a new worktree
 worktree:create {
   branch: "feature/my-feature"
-  path: "tmp/wt-my-feature"
+  path: ".worktrees/my-feature"
 }
 
 # ... do work in the worktree ...
 
 # Cleanup when done  
 worktree:cleanup {
-  worktreePath: "tmp/wt-my-feature"
+  worktreePath: ".worktrees/my-feature"
 }
 ```
 

--- a/.opencode/skills/dev-flow/worktree/worktree.SKILL.md
+++ b/.opencode/skills/dev-flow/worktree/worktree.SKILL.md
@@ -29,7 +29,7 @@ launch-context.ts     → Working directory injection
 # Create a new worktree
 worktree:create {
   branch: "feature/my-feature"  
-  path: "tmp/wt-my-feature"
+  path: ".worktrees/my-feature"
 }
 ```
 

--- a/.opencode/skills/opencode-flow-chore/SKILL.md
+++ b/.opencode/skills/opencode-flow-chore/SKILL.md
@@ -29,7 +29,7 @@ Frage den User, ob die Chore regelmäßig laufen soll. Falls ja, richte einen Cr
 `worktree.ts`'s `worktree_create` fehlt git-crypt-Filter-Neutralisierung (bekannte Limitation) — daher das Wrapper-Skript verwenden:
 
 ```bash
-bash scripts/worktree-create.sh chore/<slug> /tmp/wt-<slug>
+bash scripts/worktree-create.sh chore/<slug> .worktrees/<slug>
 bash scripts/agent-lock.sh claim branch "chore/<slug>" --worktree "$PWD" --label opencode-flow-chore
 ```
 
@@ -66,7 +66,7 @@ Delegate to **`opencode-git-workflow` Steps 2–6** (SSOT):
 
 Lock-Release, dann:
 ```bash
-git worktree remove /tmp/wt-<slug> --force && git branch -D chore/<slug>
+git worktree remove .worktrees/<slug> --force && git branch -D chore/<slug>
 ```
 
 ## Schritt 7: Deploy (falls nötig)

--- a/.opencode/skills/opencode-flow-execute/SKILL.md
+++ b/.opencode/skills/opencode-flow-execute/SKILL.md
@@ -30,11 +30,11 @@ git fetch origin main && git pull --rebase origin main
 
 ## Schritt 0: Worktree-Konsistenz
 
-Prüfe, ob du in einem `/tmp/wt-*` Worktree bist. Falls nicht:
+Prüfe, ob du in einem `.worktrees/*` Worktree bist. Falls nicht:
 
 ```bash
 SLUG=$(echo "$(git branch --show-current)" | sed 's#^[a-z]*/##')
-bash scripts/worktree-create.sh "$(git branch --show-current)" "tmp/wt-${SLUG}"
+bash scripts/worktree-create.sh "$(git branch --show-current)" ".worktrees/${SLUG}"
 ```
 
 (`scripts/worktree-create.sh` ist git-crypt-safe. `worktree.ts`'s `worktree_create` hat diese Neutralisierung nicht — bekanntes Limitation.)
@@ -59,7 +59,7 @@ PLAN_FILE=$(echo "$PLAN_REF" | sed -n 's/.*plan=\([^ ]*\).*/\1/p')
 ## Schritt 1.4: Doppelarbeit-Guard
 
 ```
-agent-lock.sh claim ticket T000XXX --branch feature/<slug> --worktree /tmp/wt-<slug> --label opencode-flow-execute
+agent-lock.sh claim ticket T000XXX --branch feature/<slug> --worktree .worktrees/<slug> --label opencode-flow-execute
 ```
 
 ## Schritt 1.5: Ticket auf in_progress setzen
@@ -132,7 +132,7 @@ git commit -m "chore(plans): archive $SLUG [$TICKET_ID]"
 
 ```
 agent-lock.sh release ticket $TICKET_ID
-git worktree remove /tmp/wt-<slug> --force
+git worktree remove .worktrees/<slug> --force
 git branch -D feature/<slug>
 ```
 

--- a/.opencode/skills/opencode-flow-plan/SKILL.md
+++ b/.opencode/skills/opencode-flow-plan/SKILL.md
@@ -87,14 +87,14 @@ Starte strukturiertes Brainstorming mit dem User. Stelle Fragen als Plain-Text-F
 Da `worktree.ts`'s `worktree_create` keine git-crypt-Filter-Neutralisierung hat (bekannte Limitation — siehe opencode-git-workflow), immer das Wrapper-Skript verwenden:
 
 ```bash
-bash scripts/worktree-create.sh feature/<slug> /tmp/wt-<slug>
-bash scripts/agent-lock.sh claim branch "feature/<slug>" --worktree "/tmp/wt-<slug>" --label opencode-flow-plan
+bash scripts/worktree-create.sh feature/<slug> .worktrees/<slug>
+bash scripts/agent-lock.sh claim branch "feature/<slug>" --worktree ".worktrees/<slug>" --label opencode-flow-plan
 ```
 
 #### Schritt B.2: Proposal-Artefakte in den Worktree verschieben
 
 ```bash
-WT="/tmp/wt-<slug>"
+WT=".worktrees/<slug>"
 mkdir -p "${WT}/openspec/changes/"
 mv "${REPO_ROOT}/openspec/changes/<slug>" "${WT}/openspec/changes/<slug>"
 cd "${WT}"

--- a/.opencode/skills/opencode-git-workflow/SKILL.md
+++ b/.opencode/skills/opencode-git-workflow/SKILL.md
@@ -169,7 +169,7 @@ In opencode sind zwei Wege verfügbar:
 
 ```bash
 # Empfohlen (git-crypt-safe):
-bash scripts/worktree-create.sh <branch> /tmp/wt-<slug>
+bash scripts/worktree-create.sh <branch> .worktrees/<slug>
 ```
 
 ---

--- a/scripts/batch-workflow-gen.sh
+++ b/scripts/batch-workflow-gen.sh
@@ -64,8 +64,8 @@ ${ctx ? `\nZUSATZ-KONTEXT:\n${ctx}` : ''}
 ABLAUF (führe jeden Schritt aus):
 1. cd ${repoRoot}
 2. Lege Worktree an:
-   bash scripts/worktree-create.sh ${branch} /tmp/wt-batch-${slug}
-3. cd /tmp/wt-batch-${slug}
+   bash scripts/worktree-create.sh ${branch} ${repoRoot}/.worktrees/batch-${slug}
+3. cd ${repoRoot}/.worktrees/batch-${slug}
 4. Schreibe Spec nach docs/superpowers/specs/${today}-${slug}-design.md
    - Vollständige Markdown-Spec basierend auf Ticket-Beschreibung
    - Kein Brainstorming nötig — Ticket-Beschreibung ist die Quelle

--- a/scripts/factory/cleanup.sh
+++ b/scripts/factory/cleanup.sh
@@ -6,7 +6,7 @@
 #
 # Usage: cleanup.sh --branch <name> --worktree <path>
 #   --branch    local branch to delete (e.g. feature/sf-t000469)
-#   --worktree  worktree path to remove (e.g. /tmp/wt-sf-t000469)
+#   --worktree  worktree path to remove (e.g. .worktrees/sf-t000469)
 set -euo pipefail
 
 BRANCH=""

--- a/scripts/factory/pipeline-pattern.md
+++ b/scripts/factory/pipeline-pattern.md
@@ -251,7 +251,7 @@ const results = await pipeline(
       FILES: ${task.files.join(', ')}
       ACCEPTANCE: ${task.acceptance_criteria}
 
-      1. Create worktree: bash scripts/worktree-create.sh feature/${args.slug}-${task.id} /tmp/wt-${task.id}
+      1. Create worktree: bash scripts/worktree-create.sh feature/${args.slug}-${task.id} .worktrees/${task.id}
       2. Implement the change
       3. Run local tests: task test:all
       4. Return the diff and test results

--- a/scripts/factory/pipeline.js
+++ b/scripts/factory/pipeline.js
@@ -66,7 +66,7 @@ const A = args ?? {}
 const slug = A.slug           // args.timestamp for resume-safe timestamps
 const brand = A.brand ?? 'mentolder'
 const REPO = '/home/patrick/Bachelorprojekt'
-const WT = `/tmp/wt-${slug}`
+const WT = `${REPO}/.worktrees/${slug}`
 
 function phaseEvent(ph, state, detail) {
   try {
@@ -99,7 +99,7 @@ const REUSE_BRANCH = A.branch || null
 const REUSE_PLAN   = A.plan_path || null
 const REUSE = !!(REUSE_BRANCH && REUSE_PLAN)
 const WORK_BRANCH = REUSE ? REUSE_BRANCH : `feature/${slug}`
-const WORK_WT = REUSE ? `/tmp/wt-${slug}-reuse` : WT
+const WORK_WT = REUSE ? `${REPO}/.worktrees/${slug}-reuse` : WT
 
 let specPath = null
 let tasks = []

--- a/scripts/factory/watchdog.sh
+++ b/scripts/factory/watchdog.sh
@@ -23,7 +23,7 @@ for ext_id in "${stale[@]}"; do
   BRAND="$BRAND" TICKET_CTX="$FACTORY_CTX" bash "$HERE/../ticket.sh" release-slot --id "$ext_id" >/dev/null
   BRAND="$BRAND" TICKET_CTX="$FACTORY_CTX" bash "$HERE/../ticket.sh" add-comment --id "$ext_id" \
     --body "Watchdog: pipeline stale > ${STALE_MIN}min (no phase progress write). Returned to queue (triage); slot released." >/dev/null
-  # Zombie-Worktree-Cleanup: a hung pipeline leaves /tmp/wt-sf-* behind. Remove the
+  # Zombie-Worktree-Cleanup: a hung pipeline leaves .worktrees/sf-* behind. Remove the
   # worktree whose branch matches this ticket (idempotent; never fails the loop).
   ext_lc="$(printf '%s' "$ext_id" | tr '[:upper:]' '[:lower:]')"
   stale_wt="$(git worktree list --porcelain 2>/dev/null \

--- a/scripts/weekly-dep-schema-audit.sh
+++ b/scripts/weekly-dep-schema-audit.sh
@@ -7,7 +7,7 @@ cd "$(git rev-parse --show-toplevel 2>/dev/null || echo "/home/patrick/Bachelorp
 
 SLUG="weekly-dep-schema-audit"
 BRANCH="chore/${SLUG}"
-WORKTREE="/tmp/wt-${SLUG}"
+WORKTREE=".worktrees/${SLUG}"
 TICKET_TITLE="chore: weekly dep + schema audit $(date +%Y-%m-%d)"
 
 # Sync main

--- a/scripts/worktree-create.sh
+++ b/scripts/worktree-create.sh
@@ -18,7 +18,7 @@
 #             origin) the worktree CHECKS IT OUT; otherwise a new branch is
 #             created from <base>. The existing-branch mode is what the Software
 #             Factory plan-reuse / dev-flow handoff path needs (T000473).
-#   <path>    worktree path, e.g. /tmp/wt-foo
+#   <path>    worktree path, e.g. .worktrees/foo (repo-relative default location)
 #   <base>    base ref for a NEW branch (default: origin/main); ignored when the
 #             branch already exists.
 set -euo pipefail


### PR DESCRIPTION
## Summary
- Switches the default worktree location repo-wide from `/tmp/wt-<slug>` (or bare `tmp/wt-<slug>`) to `.worktrees/<slug>`, which was already git-ignored.
- Updates `worktree-create.sh` usage docs, the factory pipeline (`pipeline.js`, `batch-workflow-gen.sh`, `weekly-dep-schema-audit.sh`, `cleanup.sh`, `watchdog.sh` comment), and all `dev-flow`/`git-workflow` skill docs for both Claude Code (`.claude/`) and opencode (`.opencode/`) so every agent creates and expects worktrees under `.worktrees/` going forward.
- No behavior change to worktree isolation logic itself (git-crypt handling, submodule init, node_modules symlinking) — only the default path.

## Test plan
- [x] `task test:all` — 52/52 pass, LOC budget unaffected
- [x] `task freshness:check` — green
- [x] `bash -n` on all modified shell scripts, `node --check` on `pipeline.js`
- [x] Manually created a worktree via `scripts/worktree-create.sh` to verify the wrapper still works

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>