### PR TITLE
fix(website): correct relative import path in coaching sessions API [T001685]

### DIFF
--- a/website/src/api/admin/coaching/sessions.ts
+++ b/website/src/api/admin/coaching/sessions.ts
@@ -1,23 +1,23 @@
-import { db } from '../../../../lib/db';
+import { pool } from '../../../lib/db-pool';
 
 export async function GET() {
   try {
     // Prüfen ob coaching_customers Tabelle existiert
-    const exists = await db.query(`
+    const exists = await pool.query(`
       SELECT EXISTS (
-        SELECT FROM information_schema.tables 
+        SELECT FROM information_schema.tables
         WHERE table_name = 'coaching_customers'
       ) as exists;
     `);
 
-    if (!exists[0].exists) {
+    if (!exists.rows[0]?.exists) {
       // Falls nicht, leere Daten zurückgeben
       return Response.json([]);
     }
 
     // Echte Daten aus DB
-    const result = await db.query(`
-      SELECT 
+    const result = await pool.query(`
+      SELECT
         cc.id,
         cc.name as customer_name,
         cc.profile_id,
@@ -27,7 +27,7 @@ export async function GET() {
       ORDER BY cc.created_at DESC
     `);
 
-    return Response.json(result);
+    return Response.json(result.rows);
   } catch (error) {
     console.error('Error fetching coaching sessions:', error);
     return Response.json([]);


### PR DESCRIPTION
## Summary
- `website/src/api/admin/coaching/sessions.ts` imported `'../../../../lib/db'` (one level too deep — module doesn't exist) instead of the real `'../../../lib/db-pool'` pool export. This currently breaks the Astro TypeScript Check gate on `origin/main`, blocking the typecheck for every open PR in the repo.
- Also fixes the query result shape: `pg` `pool.query()` returns `{ rows }`, not a bare array — `exists[0].exists` / `Response.json(result)` were wrong.
- Isolated, minimal fix (one file) so it can merge independently and unblock other PRs' CI without waiting on unrelated in-flight work.

## Test plan
- [x] `pnpm astro check` — 0 errors (previously 1 error on this file)
- [x] `task test:all` — 52/52 pass

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>