### PR TITLE
fix(quality): ignore .opencode/plugins symlinks in S1 gate [T001686]

### DIFF
--- a/docs/code-quality/gates.yaml
+++ b/docs/code-quality/gates.yaml
@@ -91,6 +91,12 @@ s1:
     # module for the OCX Worktree plugin. It exceeds the limit due to the full
     # mutex-protected tmux surface; further splitting yields circular imports.
     - ".opencode/skills/dev-flow/plugins/worktree/terminal.ts"
+    # .opencode/plugins/background-agents.ts and worktree.ts are symlinks to the two
+    # sanctioned exceptions above (opencode's plugin loader resolves plugins from
+    # .opencode/plugins/, so the symlink is required). The scanner checks the symlink
+    # path itself, not its target, so it needs its own ignore entry (T001686).
+    - ".opencode/plugins/background-agents.ts"
+    - ".opencode/plugins/worktree.ts"
 
 s2:
   graphs:


### PR DESCRIPTION
## Summary
- `.opencode/plugins/{background-agents,worktree}.ts` are symlinks to the two files already sanctioned as S1 exceptions under `.opencode/skills/dev-flow/`.
- The S1 scanner checks the symlink path itself, not the resolved target, so the existing exception didn't cover it.
- Result: `quality:check` on `main` had 2 blocking violations, failing `task freshness:check` (Offline Tests CI job) for every open PR rebased against main — discovered while triaging CI on PR #2676.

## Fix
Add the two symlink paths to `s1.ignore` in `docs/code-quality/gates.yaml`, mirroring the existing sanctioned entries for their targets.

## Test plan
- [x] `node scripts/code-quality/check.mjs` → `0 blocking` (was 2)
- [x] `task freshness:regenerate` — no other artifacts drifted

T001686