### PR TITLE
chore(scripts): fix SCS auto-reindex pipeline end-to-end [T001692]

### DIFF
--- a/.codebase-memory/artifact.json
+++ b/.codebase-memory/artifact.json
@@ -1,11 +1,11 @@
 {
     "schema_version": 1,
-    "commit": "f0e4eb7f5fdd340fcbb58137cd7ec12ec388bf61",
-    "indexed_at": "2026-07-09T13:16:37Z",
-    "project": "home-runner-work-Bachelorprojekt-Bachelorprojekt",
-    "nodes": 51081,
-    "edges": 128557,
-    "original_size": 73007104,
-    "compressed_size": 12592187,
-    "compression_level": 9
+    "commit": "61a1e41f298dc58ef51c05611900660417d8a62f",
+    "indexed_at": "2026-07-09T14:15:52Z",
+    "project": "home-patrick-Bachelorprojekt",
+    "nodes": 52493,
+    "edges": 130177,
+    "original_size": 106823680,
+    "compressed_size": 18592568,
+    "compression_level": 3
 }

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1500,6 +1500,7 @@ tasks:
       - chmod +x .githooks/pre-commit
       - chmod +x .githooks/commit-msg
       - chmod +x .githooks/pre-push
+      - chmod +x .githooks/post-commit
       - chmod +x .githooks/post-commit-index
       - chmod +x .githooks/post-checkout
       - chmod +x .githooks/post-merge
@@ -4611,7 +4612,6 @@ tasks:
         fi
 
         PGHOST=localhost PGPORT=15434 PGDATABASE=website PGUSER=website \
-          LLM_EMBED_URL="${LLM_EMBED_URL:-http://llm-gateway-embed.${NS}.svc.cluster.local:8081}" \
           npx tsx scripts/index-repo.ts
 
   scs:index-incremental:
@@ -4636,7 +4636,6 @@ tasks:
         sleep 4
 
         PGHOST=localhost PGPORT=15434 PGDATABASE=website PGUSER=website \
-          LLM_EMBED_URL="${LLM_EMBED_URL:-http://llm-gateway-embed.${NS}.svc.cluster.local:8081}" \
           npx tsx -e "
             import { searchCode, searchCodeAugmented } from './website/src/lib/codesearch-db.ts';
             const args = process.argv.slice(1);

--- a/docs/code-quality/loc-budget.json
+++ b/docs/code-quality/loc-budget.json
@@ -1,8 +1,8 @@
 {
-  "total_lines": 542919,
+  "total_lines": 542926,
   "file_count": 4120,
-  "commit": "519321c1",
-  "measured_at": "2026-07-09T13:09:49.998Z",
+  "commit": "61a1e41f2",
+  "measured_at": "2026-07-09T14:15:58.262Z",
   "thresholds": {
     "warn_pct": 5,
     "fail_pct": 15,


### PR DESCRIPTION
## Summary

The SCS (semantic code search) auto-reindex pipeline never actually ran, for two independent reasons:

1. **`.githooks/post-commit-index` is not a git-recognized hook filename** — git only ever auto-invokes a file literally named `post-commit`. `core.hooksPath` being unset on this checkout was a secondary problem; even with it set, this hook could never fire. Added `.githooks/post-commit` as the real entrypoint, dispatching to the existing `post-commit-index` logic.
2. **`index-repo.ts` / `codesearch-db.ts` defaulted `LLM_EMBED_URL`/`PGHOST` to cluster-internal DNS names** that never resolve from a developer host (git hook, `task scs:index`, `task scs:index-incremental`) — every embed/DB call failed silently. Both now probe the cluster hostname and fall back to the local dev stack (LM Studio direct on `:1234`, local Postgres) when it doesn't resolve; explicit env vars still win. `Taskfile.yml` `scs:index`/`scs:search` no longer hardcode a cluster-only `LLM_EMBED_URL` override.

Also: `post-commit-index` now surfaces failures instead of swallowing to `/dev/null`, has a 30s per-file timeout, and an `SCS_HOOK_DISABLED` opt-out; `pg.Pool` gets `connectionTimeoutMillis` so a dead DB fails fast instead of hanging a commit.

## Verification

Enabled `core.hooksPath`, made a real commit against a disposable local Postgres+pgvector container with `LLM_EMBED_MODEL=bge` (matching the locally-loaded LM Studio model), and confirmed:
- the hook fired **automatically** (no manual reindex call) on a plain `git commit`
- real 1024-dim embeddings from the local LM Studio instance landed in `code_embeddings` for every changed file
- `scs:search` then found them via cosine similarity

## Test plan

- [x] `bats tests/unit/scs-search.bats` — 24/24 pass (2 new tests covering the `post-commit` dispatcher)
- [x] `task test:changed` — green
- [x] `task freshness:check` — green
- [x] Real end-to-end hook verification against ephemeral Postgres + local LM Studio (see above), ephemeral container removed afterward