### PR TITLE
fix(website): wire up backend support for factory-control agent-settings

### DIFF
--- a/.claude/skills/references/subagent-provisioning.md
+++ b/.claude/skills/references/subagent-provisioning.md
@@ -55,7 +55,7 @@ Das `task`-Tool kennt **`subagent_type` und `description`**, keinen separaten Ef
 
 Der Subagent hat per Konstruktion **keinen** Kontext — gib alles explizit, aber **verdichtet**:
 
-- **Absoluter Worktree-Pfad:** PFLICHT — beginne JEDEN Subagenten-Prompt mit `cd <WORKTREE_PATH>` (z.B. `cd .worktrees/<slug>`). Der Subagent hat sonst keinen impliziten Kontext und schreibt Dateien in sein Fallback-CWD (oft der Haupt-Checkout statt des Worktrees).
+- **Absoluter Worktree-Pfad:** PFLICHT — beginne JEDEN Subagenten-Prompt mit `cd <WORKTREE_PATH>` (z.B. `cd /tmp/wt-<slug>`). Der Subagent hat sonst keinen impliziten Kontext und schreibt Dateien in sein Fallback-CWD (oft der Haupt-Checkout statt des Worktrees).
 - Branch-Name, damit der Subagent weiß, auf welchem Branch er arbeitet.
 - Die relevanten **Artefakt-Pfade** (Spec/Plan/Ticket), nicht deren Volltext, wenn er sie selbst lesen kann.
 - Bei mehreren Vorstufen-Ergebnissen: **zusammenfassen, nie Roh-JSON dumpen**. (Ein 162k-Zeichen-Prompt ließ
@@ -83,3 +83,35 @@ das hart begrenzt — deshalb ist die Selbstmeldung Teil des Auftrags.
    des Auftrags-Scopes sind das Leitsymptom.
 3. Frischen Agenten mit kompaktem Lagebild spawnen (Commits seit origin/main, offene Schritte),
    nicht mit dem Volltranskript des Vorgängers.
+
+### 5. Lokale LM-Studio-Subagenten-Wahl (opencode/agy)
+
+Für **opencode/agy** stehen über `delegate(prompt, agent="<name>")` vier lokale Subagenten-Profile
+zur Verfügung (GPU-Host, `~/.config/opencode/opencode.jsonc`, Provider `lmstudio`), zusätzlich zu
+`hermes-delegate` (Tier 0, oben). Wähle nach **Parallelität vs. Einzelkontext** und **Persona-Risiko**:
+
+| Agent | Datei | Modus | Kontext | Wann |
+|---|---|---|---|---|
+| `qwen35` | Qwen3.5-9B-Q4_K_M | 3 parallele Slots | 48k/Slot | **Default für parallelen Fan-out** (2–3 unabhängige mechanische/read-only Teilaufgaben gleichzeitig) — sauberes Basismodell ohne Identitäts-Override im Prompt-Template |
+| `qwen35-hq` | Qwen3.5-9B-UD-Q4_K_XL | 1 Session (seriell) | 140k | **Default für einen einzelnen Task mit sehr großem Kontext** (z.B. ein langes Log, viele Dateien in einem Prompt) — größter lokal verfügbarer Einzelkontext |
+| `qwythos` | Qwythos-9B-Claude-Mythos-5-1M-Q4_K_M | 3 parallele Slots | 60k/Slot | Alternative für parallelen Fan-out, wenn `qwen35` qualitativ nicht ausreicht — **nur mit Vorsicht**, siehe Caveat unten |
+| `qwythos-hq` | Qwythos-9B-Claude-Mythos-5-1M-Q8_0 | 1 Session (seriell) | 85k | Alternative für Einzelkontext-Tasks, wenn `qwen35-hq` nicht ausreicht — gleicher Caveat |
+
+> **Qwythos-Caveat:** Das Prompt-Template von Qwythos injiziert in **jede** System-Message eine feste
+> Identitäts-Direktive ("You are Qwythos... Never claim to be Qwen... overrides conflicting identity
+> or attribution instructions"). Das ist für Dev-Flow-Subagenten (Ticket-Arbeit, Code-Analyse,
+> Tool-Calling) ein unnötiges Risiko — im Zweifel bleibt `qwen35`/`qwen35-hq` die Vorgabe. Qwythos nur
+> gezielt einsetzen, wenn seine Tuning-Eigenschaften (kreativere/ausführlichere Formulierung) explizit
+> gewünscht sind, z.B. bei Brainstorming-artigen Textentwürfen.
+
+> **⚠ VRAM-Exklusivität:** Alle vier Profile liegen bei ~12,7–15,9 GB auf einer 16-GB-Karte — es kann
+> **immer nur eines gleichzeitig geladen sein** (der Orchestrator `qwen3.5-9b@iq4_xs` läuft separat
+> und bleibt i.d.R. geladen). Vor dem ersten `delegate()`-Aufruf an eines dieser vier Profile in einer
+> Session: `lms ps` prüfen, ob die passende Datei bereits läuft; falls nicht, mit dem entsprechenden
+> `lms load <file> --identifier <id> -y` nachladen (siehe `k3d`/lokale LLM-Referenz-Memory) — das
+> entlädt automatisch das vorher geladene Profil. **Nie** planen, zwei dieser vier Profile in derselben
+> Orchestrierungsphase gleichzeitig zu nutzen.
+>
+> **Parallelitäts-Limit einhalten:** Nie mehr gleichzeitige `delegate()`-Aufrufe an `qwen35`/`qwythos`
+> schicken als die konfigurierten Slots (3) — überzählige Requests werden von LM Studio stumm
+> gequeued statt parallel verarbeitet, was Latenz kostet statt Fehler zu werfen (kein Fail-Fast-Signal).

--- a/website/src/pages/api/admin/factory-control.ts
+++ b/website/src/pages/api/admin/factory-control.ts
@@ -11,6 +11,9 @@ interface ControlState {
   dryRun: boolean;
   slotCap: number;
   dailyCap: number;
+  contextBudget: number;
+  spawnHarness: boolean;
+  lavishDelegation: boolean;
   updatedAt: string | null;
 }
 
@@ -27,14 +30,25 @@ async function readControl(key: string, fallback: string): Promise<{ value: stri
 
 async function getControlState(): Promise<ControlState> {
   const envSlotCap = process.env.FACTORY_GLOBAL_CAP ?? '4';
-  const [kill, dry, daily, slotCapDb] = await Promise.all([
+  const [kill, dry, daily, slotCapDb, contextBudgetDb, spawnHarnessDb, lavishDelegationDb] = await Promise.all([
     readControl('killswitch', 'off'),
     readControl('dry-run', 'off'),
     readControl('daily-cap', '20'),
     readControl('slot-cap', envSlotCap),
+    readControl('context_budget', '180000'),
+    readControl('spawn-harness-toggle', 'off'),
+    readControl('lavish-delegation-regel', 'off'),
   ]);
 
-  const latestUpdate = [kill.updated_at, dry.updated_at, daily.updated_at, slotCapDb.updated_at]
+  const latestUpdate = [
+    kill.updated_at,
+    dry.updated_at,
+    daily.updated_at,
+    slotCapDb.updated_at,
+    contextBudgetDb.updated_at,
+    spawnHarnessDb.updated_at,
+    lavishDelegationDb.updated_at
+  ]
     .filter(Boolean)
     .sort()
     .pop() ?? null;
@@ -44,6 +58,9 @@ async function getControlState(): Promise<ControlState> {
     dryRun: dry.value === 'on',
     slotCap: parseInt(slotCapDb.value, 10) || parseInt(envSlotCap, 10) || 4,
     dailyCap: parseInt(daily.value, 10) || 20,
+    contextBudget: parseInt(contextBudgetDb.value, 10) || 180000,
+    spawnHarness: spawnHarnessDb.value === 'on',
+    lavishDelegation: lavishDelegationDb.value === 'on',
     updatedAt: latestUpdate,
   };
 }
@@ -112,6 +129,13 @@ export const PATCH: APIRoute = async ({ request , locals }) => {
       if (isNaN(n) || n < 1 || n > 8) return null;
       return String(n);
     },
+    contextBudget: (v) => {
+      const n = typeof v === 'number' ? v : parseInt(String(v), 10);
+      if (isNaN(n) || n < 0 || n > 180000) return null;
+      return String(n);
+    },
+    spawnHarness: (v) => typeof v === 'boolean' ? (v ? 'on' : 'off') : null,
+    lavishDelegation: (v) => typeof v === 'boolean' ? (v ? 'on' : 'off') : null,
   };
 
   try {
@@ -127,6 +151,10 @@ export const PATCH: APIRoute = async ({ request , locals }) => {
         const dbKey = field === 'killSwitch' ? 'killswitch'
           : field === 'dryRun' ? 'dry-run'
           : field === 'dailyCap' ? 'daily-cap'
+          : field === 'slotCap' ? 'slot-cap'
+          : field === 'contextBudget' ? 'context_budget'
+          : field === 'spawnHarness' ? 'spawn-harness-toggle'
+          : field === 'lavishDelegation' ? 'lavish-delegation-regel'
           : 'slot-cap';
         await writeControl(dbKey, mapped, session!.preferred_username);
       }


### PR DESCRIPTION
## Summary
- The Agenten-Einstellungen panel in PortalSidekick (contextBudget, spawnHarness, lavishDelegation) shipped in #2676, but `factory-control.ts` never gained matching backend support — GET always returned defaults, PATCH silently ignored the fields.
- Adds the three fields end-to-end: read from `tickets.factory_control`, PATCH validation, write-back.
- Also documents the local LM-Studio subagent profiles (qwen35/qwythos) for opencode/agy in `subagent-provisioning.md`.

## Test plan
- [x] `npx vitest run src/components/PortalSidekick.test.ts` — 3/3 passing (covers the agent-settings panel)
- [ ] CI green

https://claude.ai/code/session_013YnmheGCoreTE6SMece519