### PR TITLE
fix(website): restore Gerald's hero portrait photo on mentolder homepage [T001711]

### DIFF
--- a/website/content/mentolder/homepage.json
+++ b/website/content/mentolder/homepage.json
@@ -22,7 +22,7 @@
     { "title": "Wie ich arbeite", "text": "Analytische Präzision mit Beziehungsarbeit." }
   ],
   "avatarType": "image",
-  "avatarSrc": "/brand/mentolder/characters/leadership.portrait.svg",
+  "avatarSrc": "/gerald.jpg",
   "quote": "Ich stelle unbequeme Fragen – weil echte Lösungen manchmal unbequeme Wahrheiten brauchen.",
   "quoteName": "Gerald Korczewski",
   "processSteps": [

--- a/website/src/lib/__tests__/content-bundle.test.ts
+++ b/website/src/lib/__tests__/content-bundle.test.ts
@@ -24,4 +24,14 @@ describe('content-bundle', () => {
       expect(stammdaten.name.length).toBeGreaterThan(0);
     }
   });
+
+  it('mentolder hero avatar is Gerald\'s real photo, not the placeholder illustration [T001561]', () => {
+    // Regression guard: fb4826963 silently reverted this to the SVG
+    // placeholder by re-running the one-shot DB export against a DB
+    // that lacked the T001561 admin override. The content bundle is
+    // now the git-tracked SSOT for this field — pin the value so any
+    // future re-export (or manual edit) that loses it fails CI.
+    const hp = loadDomain('mentolder', 'homepage');
+    expect(hp.avatarSrc).toBe('/gerald.jpg');
+  });
 });


### PR DESCRIPTION
## Summary
- Root cause (systematic-debugging): the T001490 content-bundle seed (PR #2653) silently reverted `avatarSrc` in `website/content/mentolder/homepage.json` from `/gerald.jpg` to the SVG placeholder illustration (`/brand/mentolder/characters/leadership.portrait.svg`). The one-shot DB export (`scripts/export-site-content.mjs`) read from a DB missing the T001561 admin override — most likely a missing/wrong `SESSIONS_DATABASE_URL` connection — and wrote the stale value into the git-tracked bundle.
- Fix: restore `avatarSrc: "/gerald.jpg"` directly in the git-tracked content bundle, which is the SSOT since T001490 (zero runtime DB dependency for the homepage render path already — this closes the loop so the bundle itself carries the correct value).
- Guard against recurrence: added a regression test in `content-bundle.test.ts` pinning `avatarSrc` for the mentolder homepage bundle, so any future accidental re-export or edit that drops it fails CI immediately.

## Test plan
- [x] `pnpm vitest run src/lib/__tests__/content-bundle.test.ts` — new regression test green
- [x] `pnpm vitest run src/lib/content.test.ts src/components/Portrait.test.ts` — unaffected suites still green
- [ ] Visual check on mentolder.de homepage after deploy (hero portrait shows Gerald's real photo)

Ticket: T001711

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013YnmheGCoreTE6SMece519