### PR TITLE
fix(website): set avatarSrc in static fallback config to prevent drift [T001687]

### DIFF
--- a/website/src/config/brands/mentolder.ts
+++ b/website/src/config/brands/mentolder.ts
@@ -78,7 +78,7 @@ export const mentolderConfig: BrandConfig = {
       },
     ],
     avatarType: 'image',
-    avatarSrc: '/brand/mentolder/characters/leadership.portrait.svg',
+    avatarSrc: '/gerald.jpg',
     quote: 'Ich stelle unbequeme Fragen – weil echte Lösungen manchmal unbequeme Wahrheiten brauchen.',
     quoteName: 'Gerald Korczewski',
     timeline: false,


### PR DESCRIPTION
This PR fixes the static fallback configuration for the homepage avatarSrc in `website/src/config/brands/mentolder.ts` to prevent future regressions where the content-bundle is regenerated from the fallback and reverts to the SVG placeholder. Closes T001687.