### PR TITLE
chore(infra): upgrade Loki sidecar image version [T001703]

### DIFF
--- a/k3d/monitoring/loki-rendered.yaml
+++ b/k3d/monitoring/loki-rendered.yaml
@@ -345,7 +345,7 @@ spec:
               cpu: 100m
               memory: 256Mi
         - name: loki-sc-rules
-          image: docker.io/kiwigrid/k8s-sidecar:2.5.0
+          image: quay.io/kiwigrid/k8s-sidecar:2.7.3@sha256:694950d736c8b532eba4006527ccbdac98fefc9f30b3346ba2de50b6cad91c94
           imagePullPolicy: IfNotPresent
           env:
             - name: METHOD


### PR DESCRIPTION
This PR upgrades the Loki sidecar container image (`kiwigrid/k8s-sidecar`) from `2.5.0` to `2.7.3` (pinned with its sha256 digest) inside `k3d/monitoring/loki-rendered.yaml` to match the version used in the Prometheus stack. Closes T001703.